### PR TITLE
SyntaxConformanceTest::testSqlOperators - Fix failure on MySQL 8

### DIFF
--- a/tests/phpunit/api/v3/SyntaxConformanceTest.php
+++ b/tests/phpunit/api/v3/SyntaxConformanceTest.php
@@ -575,6 +575,7 @@ class api_v3_SyntaxConformanceTest extends CiviUnitTestCase {
     ];
 
     // The testSqlOperators fails sporadically on MySQL 5.5, which is deprecated anyway.
+    // Re:^^^ => the failure was probably correct behavior, and test is now fixed, but yeah 5.5 is deprecated, and don't care enough to verify.
     // Test data providers should be able to run in pre-boot environment, so we connect directly to SQL server.
     require_once 'DB.php';
     $db = DB::connect(CIVICRM_DSN);
@@ -1104,7 +1105,7 @@ class api_v3_SyntaxConformanceTest extends CiviUnitTestCase {
       }
       $totalEntities = 3;
     }
-    $entities = $this->callAPISuccess($entityName, 'get', ['options' => ['limit' => 0]]);
+    $entities = $this->callAPISuccess($entityName, 'get', ['options' => ['limit' => 0, 'sort' => 'id']]);
     $entities = array_keys($entities['values']);
     $this->assertGreaterThan(2, $totalEntities);
     $this->callAPISuccess($entityName, 'getsingle', ['id' => ['IN' => [$entities[0]]]]);


### PR DESCRIPTION
Before
------

`SyntaxConformanceTest::testSqlOperators` frequently fails on the `Dedupe` entity when running on MySQL 8 (`bknix-edge`).

After
------

`SyntaxConformanceTest::testSqlOperators` repeatedly passes for all entities on my copy of MySQL 8 (`bknix-edge`).

Technical Details
-----------------

The `testSqlOperators` creates a small pool of example records (`$entities`), then it slices/dices that pool with a few SQL operators and asserts the number of matches.

In particular:

```php
$this->callAPISuccessGetCount($entityName,
  ['id' => ['>' => $entities[0]]], 
  $totalEntities - 1);
```

The problem is that `$entities[0]` does not necessarily have the lowest ID -- because `$entities` was not fetched in any particular order.  The default ordering is *often* the same as the `id`, but not always.

I suspect that this problem manifests most frequently with the `Dedupe` entity because the underlying table (`civicrm_prevnext_cache`) is highly volatile (many writes+deletes) -- thus it's more likely to reuse old storage slots for new rows.

IMHO, the problem *ought* to occur in many SQL environments, but the *frequency* of occurrence seems to vary by version.