### PR TITLE
[regression] Fix error on no MIME type

### DIFF
--- a/CRM/Utils/File.php
+++ b/CRM/Utils/File.php
@@ -1082,7 +1082,7 @@ HTACCESS;
    * @param string $mimeType the mime-type we want extensions for
    * @return array
    */
-  public static function getAcceptableExtensionsForMimeType($mimeType = NULL) {
+  public static function getAcceptableExtensionsForMimeType($mimeType = []) {
     $mimeRepostory = new \MimeTyper\Repository\ExtendedRepository();
     return $mimeRepostory->findExtensions($mimeType);
   }


### PR DESCRIPTION
I have a regression from [#16436](https://github.com/civicrm/civicrm-core/pull/16436).  It's in my logs, so I don't know how to replicate it, but it seems easy to fix.

Since upgrading to 5.25.0 I've been seeing this error:
```
TypeError: Argument 1 passed to MimeTyper\Repository\AbstractRepository::setFromMap() must be of the type array, null given, called in /var/local/mysite.org/sites/all/modules/civicrm/vendor/adrienrn/php-mimetyper/src/Repository/MimeDbRepository.php on line 52 in MimeTyper\Repository\AbstractRepository-&gt;setFromMap() (line 18 of /var/local/mysite.org/sites/all/modules/civicrm/vendor/adrienrn/php-mimetyper/src/Repository/AbstractRepository.php
```