### PR TITLE
Add propertyBag handling for getEmail when incoming uses email-5

### DIFF
--- a/Civi/Payment/PropertyBag.php
+++ b/Civi/Payment/PropertyBag.php
@@ -210,6 +210,13 @@ class PropertyBag implements \ArrayAccess {
       // Good, modern name.
       return $prop;
     }
+    // Handling for legacy addition of billing details.
+    if ($newName === NULL && substr($prop, -2) === '-' . \CRM_Core_BAO_LocationType::getBilling()
+      && isset(static::$propMap[substr($prop, 0, -2)])
+    ) {
+      $newName = substr($prop, 0, -2);
+    }
+
     if ($newName === NULL) {
       if ($silent) {
         // Only for use by offsetExists

--- a/tests/phpunit/Civi/Payment/PropertyBagTest.php
+++ b/tests/phpunit/Civi/Payment/PropertyBagTest.php
@@ -81,6 +81,15 @@ class PropertyBagTest extends \PHPUnit\Framework\TestCase implements HeadlessInt
   }
 
   /**
+   * Test that emails set by the legacy method of 'email-5' can be retrieved with getEmail.
+   */
+  public function testSetBillingEmailLegacy() {
+    $localPropertyBag = new PropertyBag();
+    $localPropertyBag->mergeLegacyInputParams(['email-' . \CRM_Core_BAO_LocationType::getBilling() => 'a@b.com']);
+    $this->assertEquals('a@b.com', $localPropertyBag->getEmail());
+  }
+
+  /**
    */
   public function testMergeInputs() {
     $propertyBag = new PropertyBag();
@@ -88,7 +97,7 @@ class PropertyBagTest extends \PHPUnit\Framework\TestCase implements HeadlessInt
       'contactID' => 123,
       'contributionRecurID' => 456,
     ]);
-    $this->assertEquals("We have merged input params into the property bag for now but please rewrite code to not use this.", $propertyBag->lastWarning);
+    $this->assertEquals('We have merged input params into the property bag for now but please rewrite code to not use this.', $propertyBag->lastWarning);
     $this->assertEquals(123, $propertyBag->getContactID());
     $this->assertEquals(456, $propertyBag->getContributionRecurID());
   }


### PR DESCRIPTION
Overview
----------------------------------------
Update to PropertyBag to enable it to handle the fact that calling functions use some legacy params for billing fields not yet handled - ie

$params['email-5'] for Billing email.

With this change we encourage the use of setEmail but if the param was email-5 it can still be retrieved with getEmail

Before
----------------------------------------
$params['email-5'] not returned when calling getEmail

After
----------------------------------------
$params['email-5'] returned when calling getEmail

Also any other fields which match the correct field with an appended '-5' (Where 5 is the billing location ID)

Technical Details
----------------------------------------
Calling code is often setting email-5. The property bag should iron out this inconsistency, and getEmail (and similar)
should handle the appended billing id. We can't do this in the static property map as it is a calculated variable

Comments
----------------------------------------
@artfulrobot @mattwire 
