### PR TITLE
CRM/Logging - Remove obsolete cache static clear in test

### DIFF
--- a/tests/phpunit/CRM/Logging/SchemaTest.php
+++ b/tests/phpunit/CRM/Logging/SchemaTest.php
@@ -279,10 +279,6 @@ class CRM_Logging_SchemaTest extends CiviUnitTestCase {
       CHANGE COLUMN test_integer test_integer int(6) NULL,
       CHANGE COLUMN test_decimal test_decimal decimal(22,2) NULL"
     );
-    \Civi::$statics['CRM_Logging_Schema']['columnSpecs'] = [];
-    $schema->fixSchemaDifferences();
-    // need to do it twice so the columnSpecs static is refreshed
-    \Civi::$statics['CRM_Logging_Schema']['columnSpecs'] = [];
     $schema->fixSchemaDifferences();
     $ci = \Civi::$statics['CRM_Logging_Schema']['columnSpecs'];
     // length should increase
@@ -293,9 +289,6 @@ class CRM_Logging_SchemaTest extends CiviUnitTestCase {
       CHANGE COLUMN test_integer test_integer int(4) NULL,
       CHANGE COLUMN test_decimal test_decimal decimal(20,2) NULL"
     );
-    \Civi::$statics['CRM_Logging_Schema']['columnSpecs'] = [];
-    $schema->fixSchemaDifferences();
-    \Civi::$statics['CRM_Logging_Schema']['columnSpecs'] = [];
     $schema->fixSchemaDifferences();
     $ci = \Civi::$statics['CRM_Logging_Schema']['columnSpecs'];
     // length should not decrease
@@ -312,9 +305,6 @@ class CRM_Logging_SchemaTest extends CiviUnitTestCase {
     $schema = new CRM_Logging_Schema();
     $schema->enableLogging();
     CRM_Core_DAO::executeQuery("ALTER TABLE civicrm_test_enum_change CHANGE COLUMN test_enum test_enum enum('A','B','C','D') NULL");
-    \Civi::$statics['CRM_Logging_Schema']['columnSpecs'] = [];
-    $schema->fixSchemaDifferences();
-    // need to do it twice so the columnSpecs static is refreshed
     \Civi::$statics['CRM_Logging_Schema']['columnSpecs'] = [];
     $schema->fixSchemaDifferences();
     $ci = \Civi::$statics['CRM_Logging_Schema']['columnSpecs'];


### PR DESCRIPTION
Overview
----------------------------------------
This simplifies `CRM_Logging_SchemaTest::testLengthChange()` and `CRM_Logging_SchemaTest::testEnumChange()` by removing a manual reset on a cache static and a second call to `CRM_Logging_Schema::fixSchemaDifferences()`

Before
----------------------------------------
Cache static is cleared by test and `CRM_Logging_Schema::fixSchemaDifferences()` is called twice for each schema change.

After
----------------------------------------
No cache manipulation in test code and `CRM_Logging_Schema::fixSchemaDifferences()` is called only once. 

Comments
----------------------------------------
This was made obsolete by a40a5a4875bf5caa03eaa8732c958f5c714c7b61, which has added a cache flush to `fixSchemaDifferences()` via `fixSchemaDifferencesForAll()`.

ping @totten
