### PR TITLE
(NFC) RegionTest - Small cleanups

### DIFF
--- a/tests/phpunit/CRM/Core/RegionTest.php
+++ b/tests/phpunit/CRM/Core/RegionTest.php
@@ -8,12 +8,12 @@ class CRM_Core_RegionTest extends CiviUnitTestCase {
 
   public function setUp() {
     parent::setUp();
-    require_once 'CRM/Core/Smarty.php';
-    require_once 'CRM/Core/Region.php';
 
     // Templates injected into regions should normally be file names, but for unit-testing it's handy to use "string:" notation
     require_once 'CRM/Core/Smarty/resources/String.php';
     civicrm_smarty_register_string_resource();
+
+    $this->useTransaction();
   }
 
   /**


### PR DESCRIPTION
Before
----------------------------------------

* Unnecessary / old-school `require_once` statements
* Non-transactional

After
----------------------------------------

* Uses autoloader. Welcome to 2005!
* Wrapped in transaction. If this test manipulated any DB data, this'd provide stronger isolation / faster cleanup.
