### PR TITLE
Fix PHP notice when is_override is not set

### DIFF
--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -925,7 +925,7 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
    * or FALSE otherwise.
    */
   private function convertIsOverrideValue() {
-    $this->_params['is_override'] = CRM_Member_StatusOverrideTypes::isOverridden($this->_params['is_override']);
+    $this->_params['is_override'] = CRM_Member_StatusOverrideTypes::isOverridden($this->_params['is_override'] ?? CRM_Member_StatusOverrideTypes::NO);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Found when adding membership via backend "Submit credit card membership" form. `is_override` param not set and php notice thrown.

Before
----------------------------------------
PHP notice.

After
----------------------------------------
No notice.

Technical Details
----------------------------------------


Comments
----------------------------------------
