### PR TITLE
Switch addActivity to use API4

### DIFF
--- a/CRM/Activity/Selector/Search.php
+++ b/CRM/Activity/Selector/Search.php
@@ -300,7 +300,7 @@ class CRM_Activity_Selector_Search extends CRM_Core_Selector_Base implements CRM
       );
       $accessMailingReport = FALSE;
       $activityTypeId = $row['activity_type_id'];
-      if ($row['activity_is_test']) {
+      if (!empty($row['activity_is_test'])) {
         $row['activity_type'] = CRM_Core_TestEntity::appendTestText($row['activity_type']);
       }
       $row['mailingId'] = '';

--- a/tests/phpunit/CRM/Activity/Form/SearchTest.php
+++ b/tests/phpunit/CRM/Activity/Form/SearchTest.php
@@ -49,6 +49,8 @@ class CRM_Activity_Form_SearchTest extends CiviUnitTestCase {
         'source_record_id' => '1',
         'activity_type_id' => '6',
         'activity_type' => 'Contribution',
+        // This line breaks tests with https://github.com/civicrm/civicrm-core/pull/17274
+        'activity_is_test' => '0',
         'target_contact_name' => [],
         'assignee_contact_name' => [],
         'source_contact_id' => '3',

--- a/tests/phpunit/CRM/Activity/Form/SearchTest.php
+++ b/tests/phpunit/CRM/Activity/Form/SearchTest.php
@@ -49,7 +49,6 @@ class CRM_Activity_Form_SearchTest extends CiviUnitTestCase {
         'source_record_id' => '1',
         'activity_type_id' => '6',
         'activity_type' => 'Contribution',
-        'activity_is_test' => '0',
         'target_contact_name' => [],
         'assignee_contact_name' => [],
         'source_contact_id' => '3',


### PR DESCRIPTION
Overview
----------------------------------------
Debugging various issues with payments keeps leading me back to this `addActivity` function. In a number of cases `source_contact_id` is not being set and this triggers the `fatal` in `addActivity` which triggers a rollback of the transaction.
What that usually means is that payment was taken but doesn't get recorded in CiviCRM because `fatal()` rolls back the transaction.

Before
----------------------------------------
Fatal error causes important information to be lost (such as contribution records) which upsets people because they've actually paid...

After
----------------------------------------
Switch to calling API4 which throws an exception which can be handled at the form layer, easily debugged and doesn't rollback the transaction.

Technical Details
----------------------------------------
_If the PR involves technical details/changes/considerations which would not be manifest to a casual developer skimming the above sections, please describe the details here._

Comments
----------------------------------------
Adding activities is important but not as important as the actual contribution/membership/participant data..

@eileenmcnaughton @artfulrobot I come across a lot of sites where for some users (normally anonymous - ie. creating a contact) the site crashes on the thankyou page and then information is not recorded properly in CiviCRM. This fatal is the cause of a lot of those problems.