### PR TITLE
Use the environment setting instead of checking for a git directory

### DIFF
--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -1817,12 +1817,10 @@ class CRM_Utils_System {
    * @return bool
    */
   public static function isDevelopment() {
-    static $cache = NULL;
-    if ($cache === NULL) {
-      global $civicrm_root;
-      $cache = file_exists("{$civicrm_root}/.svn") || file_exists("{$civicrm_root}/.git");
+    if (Civi::settings()->get('environment') === 'Development') {
+      return TRUE;
     }
-    return $cache;
+    return FALSE;
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Environment can be one of "Production", "Staging" or "Development". The `isDevelopment()` function currently controls whether to enable MYSQL strict mode and whether to log deprecation notices.

Before
----------------------------------------
Check for presence of .svn or .git directory in CiviCRM root.

After
----------------------------------------
Check if the value of environment is set to Development.

Technical Details
----------------------------------------
We don't need to cache because it's cached by `SettingsBag`.

Comments
----------------------------------------