### PR TITLE
Support order_reference param in API3 Payment.create

### DIFF
--- a/CRM/Financial/BAO/Payment.php
+++ b/CRM/Financial/BAO/Payment.php
@@ -42,7 +42,7 @@ class CRM_Financial_BAO_Payment {
     $isPaymentCompletesContribution = self::isPaymentCompletesContribution($params['contribution_id'], $params['total_amount'], $contributionStatus);
     $lineItems = self::getPayableLineItems($params);
 
-    $whiteList = ['check_number', 'payment_processor_id', 'fee_amount', 'total_amount', 'contribution_id', 'net_amount', 'card_type_id', 'pan_truncation', 'trxn_result_code', 'payment_instrument_id', 'trxn_id', 'trxn_date'];
+    $whiteList = ['check_number', 'payment_processor_id', 'fee_amount', 'total_amount', 'contribution_id', 'net_amount', 'card_type_id', 'pan_truncation', 'trxn_result_code', 'payment_instrument_id', 'trxn_id', 'trxn_date', 'order_reference'];
     $paymentTrxnParams = array_intersect_key($params, array_fill_keys($whiteList, 1));
     $paymentTrxnParams['is_payment'] = 1;
     // Really we should have a DB default.

--- a/api/v3/Payment.php
+++ b/api/v3/Payment.php
@@ -273,6 +273,22 @@ function _civicrm_api3_payment_create_spec(&$params) {
         'type' => 'Text',
       ],
     ],
+    'order_reference' => [
+      'name' => 'order_reference',
+      'type' => CRM_Utils_Type::T_STRING,
+      'title' => 'Order Reference',
+      'description' => 'Payment Processor external order reference',
+      'maxlength' => 255,
+      'size' => 25,
+      'where' => 'civicrm_financial_trxn.order_reference',
+      'table_name' => 'civicrm_financial_trxn',
+      'entity' => 'FinancialTrxn',
+      'bao' => 'CRM_Financial_DAO_FinancialTrxn',
+      'localizable' => 0,
+      'html' => [
+        'type' => 'Text',
+      ],
+    ],
     'check_number' => [
       'name' => 'check_number',
       'type' => CRM_Utils_Type::T_STRING,


### PR DESCRIPTION
Overview
----------------------------------------
order_reference was added to the `civicrm_financial_trxn` table in 2019. Payment.get has been updated to allow retrieving via that parameter but it's not currently possible to save the `order_reference` parameter using Payment.create

Before
----------------------------------------
Not possible to set `order_reference`

After
----------------------------------------
`order_reference` can be passed as param to Payment.create

Technical Details
----------------------------------------


Comments
----------------------------------------
@eileenmcnaughton @artfulrobot 