### PR TITLE
Remove most uses of check.gif

### DIFF
--- a/CRM/Campaign/Page/DashBoard.php
+++ b/CRM/Campaign/Page/DashBoard.php
@@ -312,11 +312,7 @@ class CRM_Campaign_Page_DashBoard extends CRM_Core_Page {
         }
         $surveysData[$sid]['isActive'] = $isActive;
 
-        $isDefault = NULL;
-        if ($surveysData[$sid]['is_default']) {
-          $isDefault = '<img src="' . $config->resourceBase . 'i/check.gif" alt="' . ts('Default') . '" />';
-        }
-        $surveysData[$sid]['is_default'] = $isDefault;
+        $surveysData[$sid]['is_default'] = self::crmIcon('fa-check', ts('Default'), $surveysData[$sid]['is_default']);
 
         if ($surveysData[$sid]['result_id']) {
           $resultSet = '<a href= "javascript:displayResultSet( ' . $sid . ',' . "'" . $surveysData[$sid]['title'] . "'" . ', ' . $surveysData[$sid]['result_id'] . ' )" title="' . ts('view result set') . '">' . ts('Result Set') . '</a>';
@@ -415,11 +411,7 @@ class CRM_Campaign_Page_DashBoard extends CRM_Core_Page {
           $isActive = ts('Yes');
         }
         $petitionsData[$pid]['isActive'] = $isActive;
-        $isDefault = NULL;
-        if ($petitionsData[$pid]['is_default']) {
-          $isDefault = '<img src="' . $config->resourceBase . 'i/check.gif" alt="' . ts('Default') . '" />';
-        }
-        $petitionsData[$pid]['is_default'] = $isDefault;
+        $petitionsData[$pid]['is_default'] = self::crmIcon('fa-check', ts('Default'), $petitionsData[$pid]['is_default']);
 
         $petitionsData[$pid]['action'] = CRM_Core_Action::formLink(self::petitionActionLinks(),
           $action,

--- a/CRM/Core/BAO/CustomOption.php
+++ b/CRM/Core/BAO/CustomOption.php
@@ -138,21 +138,12 @@ class CRM_Core_BAO_CustomOption {
       }
 
       if (in_array($field->html_type, ['CheckBox', 'Multi-Select'])) {
-        if (isset($defVal) && in_array($dao->value, $defVal)) {
-          $options[$dao->id]['is_default'] = '<img src="' . $config->resourceBase . 'i/check.gif" />';
-        }
-        else {
-          $options[$dao->id]['is_default'] = '';
-        }
+        $isDefault = (isset($defVal) && in_array($dao->value, $defVal));
       }
       else {
-        if ($field->default_value == $dao->value) {
-          $options[$dao->id]['is_default'] = '<img src="' . $config->resourceBase . 'i/check.gif" />';
-        }
-        else {
-          $options[$dao->id]['is_default'] = '';
-        }
+        $isDefault = ($field->default_value == $dao->value);
       }
+      $options[$dao->id]['is_default'] = CRM_Core_Page::crmIcon('fa-check', ts('Default'), $isDefault);
       $options[$dao->id]['description'] = $dao->description;
       $options[$dao->id]['class'] = $dao->id . ',' . $class;
       $options[$dao->id]['is_active'] = empty($dao->is_active) ? ts('No') : ts('Yes');

--- a/CRM/Core/Page.php
+++ b/CRM/Core/Page.php
@@ -418,4 +418,35 @@ class CRM_Core_Page {
     $this->assign('fields', $dateFields);
   }
 
+  /**
+   * Handy helper to produce the standard markup for an icon with alternative
+   * text for a title and screen readers.
+   *
+   * See also the smarty block function `icon`
+   *
+   * @param string $icon
+   *   The class name of the icon to display.
+   * @param string $text
+   *   The translated text to display.
+   * @param bool $condition
+   *   Whether to display anything at all. This helps simplify code when a
+   *   checkmark should appear if something is true.
+   *
+   * @return string
+   *   The whole bit to drop in.
+   */
+  public static function crmIcon($icon, $text = NULL, $condition = TRUE) {
+    if (!$condition) {
+      return '';
+    }
+    if ($text === NULL || $text === '') {
+      $title = $sr = '';
+    }
+    else {
+      $title = " title=\"$text\"";
+      $sr = "<span class=\"sr-only\">$text</span>";
+    }
+    return "<i class=\"crm-i $icon\"$title></i>$sr";
+  }
+
 }

--- a/CRM/Core/Smarty/plugins/block.icon.php
+++ b/CRM/Core/Smarty/plugins/block.icon.php
@@ -1,0 +1,40 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @author Andrew Hunt, AGH Strategies
+ * $Id$
+ *
+ */
+
+/**
+ * Display an icon with some alternative text.
+ *
+ * This is a wrapper around CRM_Core_Page::icon().
+ *
+ * @param $params
+ *   - condition: if present and falsey, return empty
+ *   - icon: the icon class to display instead of fa-check
+ *
+ * @param $text
+ *   The translated text to include in the icon's title and screen-reader text.
+ *
+ * @param $smarty
+ *
+ * @return string
+ */
+function smarty_block_icon($params, $text, &$smarty) {
+  $condition = array_key_exists('condition', $params) ? $params['condition'] : 1;
+  $icon = $params['icon'] ?? 'fa-check';
+  return CRM_Core_Page::crmIcon($icon, $text, $condition);
+}

--- a/CRM/Price/Page/Option.php
+++ b/CRM/Price/Page/Option.php
@@ -160,12 +160,7 @@ class CRM_Price_Page_Option extends CRM_Core_Page {
           $action -= CRM_Core_Action::DISABLE;
         }
       }
-      if (!empty($customOption[$id]['is_default'])) {
-        $customOption[$id]['is_default'] = '<img src="' . $config->resourceBase . 'i/check.gif" />';
-      }
-      else {
-        $customOption[$id]['is_default'] = '';
-      }
+      $customOption[$id]['is_default'] = CRM_Core_Page::crmIcon('fa-check', ts('Default'), !empty($customOption[$id]['is_default']));
       $customOption[$id]['order'] = $customOption[$id]['weight'];
       $customOption[$id]['action'] = CRM_Core_Action::formLink(self::actionLinks(), $action,
         [

--- a/ang/crmMailing.css
+++ b/ang/crmMailing.css
@@ -86,10 +86,6 @@ input[name=preview_test_email]:-ms-input-placeholder {
   font-size: 1.2em;
   float: none;
 }
-.crm-container a.crmMailing-submit-button div {
-  background: url(../i/check.gif) no-repeat left center;
-  padding-left: 20px;
-}
 .crm-container a.crmMailing-submit-button.disabled,
 .crm-container a.crmMailing-submit-button.blocking {
   opacity: .6;

--- a/ang/crmMailing/EditMailingCtrl/2step.html
+++ b/ang/crmMailing/EditMailingCtrl/2step.html
@@ -42,9 +42,7 @@
           <div crm-mailing-block-schedule crm-mailing="mailing"></div>
         </div>
         <center>
-          <a class="button crmMailing-submit-button crmMailing-btn-primary" ng-click="submit()" ng-class="{blocking: block.check(), disabled: crmMailingSubform.$invalid}">
-            <div>{{:: ts('Submit Mailing') }}</div>
-          </a>
+          <a class="button crmMailing-submit-button crmMailing-btn-primary" crm-icon="fa-paper-plane" ng-click="submit()" ng-class="{blocking: block.check(), disabled: crmMailingSubform.$invalid}">{{:: ts('Submit Mailing') }}</a>
         </center>
       </div>
 

--- a/ang/crmMailing/EditMailingCtrl/wizard.html
+++ b/ang/crmMailing/EditMailingCtrl/wizard.html
@@ -45,9 +45,7 @@
           <div crm-mailing-block-review crm-mailing="mailing" crm-mailing-attachments="attachments"></div>
         </div>
         <center>
-          <a class="button crmMailing-submit-button crmMailing-btn-primary" ng-click="submit()" ng-class="{blocking: block.check(), disabled: crmMailingSubform.$invalid}">
-            <div>{{:: ts('Submit Mailing') }}</div>
-          </a>
+          <a class="button crmMailing-submit-button crmMailing-btn-primary" crm-icon="fa-paper-plane" ng-click="submit()" ng-class="{blocking: block.check(), disabled: crmMailingSubform.$invalid}">{{:: ts('Submit Mailing') }}</a>
         </center>
       </div>
 

--- a/ang/crmMailing/EditMailingCtrl/workflow.html
+++ b/ang/crmMailing/EditMailingCtrl/workflow.html
@@ -47,14 +47,10 @@
           <div crm-mailing-block-approve crm-mailing="mailing"></div>
         </div>
         <center ng-if="!checkPerm('approve mailings') && !checkPerm('access CiviMail')">
-          <a class="button crmMailing-submit-button crmMailing-btn-primary" ng-click="submit()" ng-class="{blocking: block.check(), disabled: crmMailingSubform.$invalid}">
-            <div>{{:: ts('Submit Mailing') }}</div>
-          </a>
+          <a class="button crmMailing-submit-button crmMailing-btn-primary" crm-icon="fa-check" ng-click="submit()" ng-class="{blocking: block.check(), disabled: crmMailingSubform.$invalid}">{{:: ts('Submit Mailing') }}</a>
         </center>
         <center ng-if="checkPerm('approve mailings') || checkPerm('access CiviMail')">
-          <a class="button crmMailing-submit-button crmMailing-btn-primary" ng-click="approve('Approved')" ng-class="{blocking: block.check(), disabled: crmMailingSubform.$invalid}">
-            <div>{{:: ts('Submit and Approve Mailing') }}</div>
-          </a>
+          <a class="button crmMailing-submit-button crmMailing-btn-primary" crm-icon="fa-paper-plane" ng-click="approve('Approved')" ng-class="{blocking: block.check(), disabled: crmMailingSubform.$invalid}">{{:: ts('Submit and Approve Mailing') }}</a>
         </center>
       </div>
 

--- a/ang/crmMailingAB/EditCtrl/edit.html
+++ b/ang/crmMailingAB/EditCtrl/edit.html
@@ -158,9 +158,7 @@
           }"
           crm-abtest="abtest"></div>
         <center>
-          <a class="button crmMailing-submit-button" ng-click="submit()" ng-class="{blocking: block.check(), disabled: crmMailingAB.$invalid}">
-            <div>{{:: ts('Submit Mailing') }}</div>
-          </a>
+          <a class="button crmMailing-submit-button" crm-icon="fa-paper-plane" ng-click="submit()" ng-class="{blocking: block.check(), disabled: crmMailingAB.$invalid}">{{:: ts('Submit Mailing') }}</a>
         </center>
       </div>
       <span crm-ui-wizard-buttons style="float:right;">

--- a/templates/CRM/Admin/Page/LabelFormats.tpl
+++ b/templates/CRM/Admin/Page/LabelFormats.tpl
@@ -53,8 +53,7 @@
               <td class="crm-labelFormat-name">{$row.groupName}</td>
               <td class="crm-labelFormat-order nowrap">{$row.weight}</td>
               <td class="crm-labelFormat-description">{$row.grouping}</td>
-              <td class="crm-labelFormat-is_default">{if $row.is_default eq 1}
-              <img src="{$config->resourceBase}i/check.gif" alt="{ts}Default{/ts}"/>{/if}&nbsp;</td>
+              <td class="crm-labelFormat-is_default">{icon condition=$row.is_default}{ts}Default{/ts}{/icon}&nbsp;</td>
               <td class="crm-labelFormat-is_reserved">{if $row.is_reserved eq 1}{ts}Yes{/ts}{else}{ts}No{/ts}{/if}
                 &nbsp;</td>
               <td>{$row.action|replace:'xx':$row.id}</td>

--- a/templates/CRM/Admin/Page/LocationType.tpl
+++ b/templates/CRM/Admin/Page/LocationType.tpl
@@ -40,7 +40,7 @@
         <td class="crmf-vcard_name crm-editable">{$row.vcard_name}</td>
         <td class="crmf-description crm-editable">{$row.description}</td>
         <td id="row_{$row.id}_status" class="crmf-is_active">{if $row.is_active eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
-        <td class="crmf-is_default" >{if $row.is_default eq 1}<img src="{$config->resourceBase}i/check.gif" alt="{ts}Default{/ts}" />{/if}&nbsp;</td>
+        <td class="crmf-is_default">{icon condition=$row.is_default}{ts}Default{/ts}{/icon}&nbsp;</td>
         <td>{$row.action|replace:'xx':$row.id}</td>
     </tr>
     {/foreach}

--- a/templates/CRM/Admin/Page/Options.tpl
+++ b/templates/CRM/Admin/Page/Options.tpl
@@ -131,13 +131,13 @@
               <td>{$row.financial_account}</td>
             {/if}
             {if $showCounted}
-              <td class="center crm-admin-options-filter">{if $row.filter eq 1}<img src="{$config->resourceBase}i/check.gif" alt="{ts}Counted{/ts}" />{/if}</td>
+              <td class="center crm-admin-options-filter">{icon condition=$row.filter}{ts}Counted{/ts}{/icon}</td>
             {/if}
             {if $showVisibility}<td class="crm-admin-visibility_label">{$row.visibility_label}</td>{/if}
             <td class="crm-admin-options-description crm-editable" data-field="description" data-type="textarea">{$row.description}</td>
             <td class="nowrap crm-admin-options-order">{$row.weight}</td>
             {if $showIsDefault}
-              <td class="crm-admin-options-is_default" align="center">{if $row.is_default eq 1}<img src="{$config->resourceBase}i/check.gif" alt="{ts}Default{/ts}" />{/if}&nbsp;</td>
+              <td class="crm-admin-options-is_default" align="center">{icon condition=$row.is_default}{ts}Default{/ts}{/icon}&nbsp;</td>
             {/if}
             <td class="crm-admin-options-is_reserved">{if $row.is_reserved eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
             <td class="crm-admin-options-is_active" id="row_{$row.id}_status">{if $row.is_active eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>

--- a/templates/CRM/Admin/Page/ParticipantStatusType.tpl
+++ b/templates/CRM/Admin/Page/ParticipantStatusType.tpl
@@ -33,9 +33,9 @@
           <td class="crmf-label crm-editable" data-field="label">{$row.label}</td>
           <td class="crmf-name">{$row.name} ({$row.id})</td>
           <td class="crmf-class {if !$row.is_reserved} crm-editable {/if}" data-type="select">{$row.class}</td>
-          <td class="center crmf-is_reserved">{if $row.is_reserved}<img src="{$config->resourceBase}i/check.gif" alt="{ts}Reserved{/ts}" />{/if}</td>
+          <td class="center crmf-is_reserved">{icon condition=$row.is_reserved}{ts}Reserved{/ts}{/icon}</td>
         <td id="row_{$row.id}_status" class="crmf-is_active">{if $row.is_active eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
-          <td class="center crmf-is_counted">{if $row.is_counted} <img src="{$config->resourceBase}i/check.gif" alt="{ts}Counted{/ts}" />{/if}</td>
+          <td class="center crmf-is_counted">{icon condition=$row.is_counted}{ts}Counted{/ts}{/icon}</td>
           <td class="crmf-weight">{$row.weight}</td>
           <td class="crmf-visibility">{$row.visibility}</td>
           <td>{$row.action|replace:'xx':$row.id}</td>

--- a/templates/CRM/Admin/Page/PaymentProcessor.tpl
+++ b/templates/CRM/Admin/Page/PaymentProcessor.tpl
@@ -42,8 +42,7 @@
             <td class="crmf-description">{$row.description}</td>
             <td class="crmf-financial_account_id">{$row.financialAccount}</td>
             <td class="crmf-is_active center">{if $row.is_active eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
-            <td class="crmf-is_default center">
-              {if $row.is_default eq 1}<img src="{$config->resourceBase}i/check.gif" alt="{ts}Default{/ts}"/>{/if}&nbsp;
+            <td class="crmf-is_default center">{icon condition=$row.is_default}{ts}Default{/ts}{/icon}&nbsp;
             </td>
             <td>{$row.action|replace:'xx':$row.id}</td>
         </tr>

--- a/templates/CRM/Admin/Page/PaymentProcessorType.tpl
+++ b/templates/CRM/Admin/Page/PaymentProcessorType.tpl
@@ -36,7 +36,7 @@
           <td class="crm-paymentProcessorType-title crm-editable" data-field="title">{$row.title}</td>
             <td class="crm-paymentProcessorType-description">{$row.description}</td>
           <td id="row_{$row.id}_status" class="crm-paymentProcessorType-is_active">{if $row.is_active eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
-            <td class="crm-paymentProcessorType-is_default">{if $row.is_default eq 1}<img src="{$config->resourceBase}i/check.gif" alt="{ts}Default{/ts}" />{/if}&nbsp;</td>
+            <td class="crm-paymentProcessorType-is_default">{icon condition=$row.is_default}{ts}Default{/ts}{/icon}&nbsp;</td>
           <td>{$row.action}</td>
         </tr>
         {/foreach}

--- a/templates/CRM/Admin/Page/PdfFormats.tpl
+++ b/templates/CRM/Admin/Page/PdfFormats.tpl
@@ -50,7 +50,7 @@
         <tr id="row_{$row.id}" class="crm-pdfFormat {cycle values="odd-row,even-row"} {$row.class}">
             <td class="crm-pdfFormat-name">{$row.name}</td>
             <td class="crm-pdfFormat-description">{$row.description}</td>
-            <td class="crm-pdfFormat-is_default">{if $row.is_default eq 1}<img src="{$config->resourceBase}i/check.gif" alt="{ts}Default{/ts}" />{/if}&nbsp;</td>
+            <td class="crm-pdfFormat-is_default">{icon condition=$row.is_default}{ts}Default{/ts}{/icon}&nbsp;</td>
           <td class="crm-pdfFormat-order nowrap">{$row.weight}</td>
           <td>{$row.action|replace:'xx':$row.id}</td>
         </tr>

--- a/templates/CRM/Badge/Page/Layout.tpl
+++ b/templates/CRM/Badge/Page/Layout.tpl
@@ -38,10 +38,7 @@
               <td id="row_{$row.id}_status" class="crm-badge-layout-is_active">
                 {if $row.is_active eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}
               </td>
-              <td class="crm-badge-layout-is_default">
-                {if $row.is_default eq 1}
-                <img src="{$config->resourceBase}i/check.gif" alt="{ts}Default{/ts}"/>
-                {/if}&nbsp;
+              <td class="crm-badge-layout-is_default">{icon condition=$row.is_default}{ts}Default{/ts}{/icon}&nbsp;
               </td>
               <td>{$row.action|replace:'xx':$row.id}</td>
             </tr>

--- a/templates/CRM/Campaign/Page/Petition.tpl
+++ b/templates/CRM/Campaign/Page/Petition.tpl
@@ -40,7 +40,7 @@
           <td>{$survey.release_frequency}</td>
           <td>{$survey.max_number_of_contacts}</td>
           <td>{$survey.default_number_of_contacts}</td>
-          <td>{if $survey.is_default}<img src="{$config->resourceBase}i/check.gif" alt="{ts}Default{/ts}" /> {/if}</td>
+          <td>{icon condition=$survey.is_default}{ts}Default{/ts}{/icon}</td>
           <td id="row_{$survey.id}_status">{if $survey.is_active}{ts}Yes{/ts}{else}{ts}No{/ts}{/if}</td>
      <td class="crm-report-optionList-action">{$survey.action}</td>
         </tr>

--- a/templates/CRM/Financial/Page/FinancialAccount.tpl
+++ b/templates/CRM/Financial/Page/FinancialAccount.tpl
@@ -52,7 +52,7 @@
           <td>{$row.financial_account_type_id}{if $row.account_type_code} ({$row.account_type_code}){/if}</td>
           <td>{if $row.is_deductible eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
           <td>{if $row.is_reserved eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
-          <td>{if $row.is_default eq 1}<img src="{$config->resourceBase}i/check.gif" alt="{ts}Default{/ts}" /> {/if}</td>
+          <td>{icon condition=$row.is_default}{ts}Default{/ts}{/icon}</td>
           <td id="row_{$row.id}_status">{if $row.is_active eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
           <td>{$row.action|replace:'xx':$row.id}</td>
         </tr>

--- a/templates/CRM/Mailing/Page/Component.tpl
+++ b/templates/CRM/Mailing/Page/Component.tpl
@@ -35,7 +35,7 @@
            <td>{$row.subject}</td>
            <td>{$row.body_html|escape}</td>
            <td>{$row.body_text|escape}</td>
-           <td>{if $row.is_default eq 1}<img src="{$config->resourceBase}i/check.gif" alt="{ts}Default{/ts}" />{/if}&nbsp;</td>
+           <td>{icon condition=$row.is_default}{ts}Default{/ts}{/icon}&nbsp;</td>
      <td id="row_{$row.id}_status">{if $row.is_active eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
            <td>{$row.action|replace:'xx':$row.id}</td>
         </tr>

--- a/templates/CRM/Price/Page/Option.tpl
+++ b/templates/CRM/Price/Page/Option.tpl
@@ -68,7 +68,7 @@
                 <td class="crm-price-option-count">{$row.count}</td>
                 <td class="crm-price-option-max">{$row.max_value}</td>
               {/if}
-              <td class="crm-price-option-is_default">{if $row.is_default}<img src="{$config->resourceBase}i/check.gif" alt="{ts}Default{/ts}" />{/if}</td>
+              <td class="crm-price-option-is_default">{icon condition=$row.is_default}{ts}Default{/ts}{/icon}</td>
               <td class="nowrap crm-price-option-financial-type-id">{$row.financial_type_id}</td>
               <td class="nowrap crm-price-option-order">{$row.weight}</td>
               {if $getTaxDetails}


### PR DESCRIPTION
Overview
----------------------------------------
This slices off the two commits from #17259 for ease of review.

Aside from the admin console itself, this removes all instances of check.gif and replaces them with Font Awesome icons.  The checkmark to send a CiviMail mailing is replaced with `fa-paper-plane`, while the checkmarks indicating default items are replaced with `fa-check`.

This introduces a helper function, `CRM_Core_Page::crmIcon()`, that produces the markup for a specified icon, plus alternative text, optionally only when a condition is true.  There is also a corresponding Smarty block function to do this, `{icon}`.  This allows what would otherwise be repetitive and lengthy code (where it would be easy to mess up the screen reader text) to be replaced by `{icon condition=$row.is_default}{ts}Default{/ts}{/icon}`.

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/1682375/81506170-786de480-92c2-11ea-8c89-84b926506b22.png)


After
----------------------------------------
![image](https://user-images.githubusercontent.com/1682375/81506132-3b095700-92c2-11ea-8f26-f8486fc4fc4e.png)


Technical Details
----------------------------------------
This must be merged before #17284 and #17285.
