### PR TITLE
No rendered icons in data source

### DIFF
--- a/CRM/Campaign/Page/DashBoard.php
+++ b/CRM/Campaign/Page/DashBoard.php
@@ -312,7 +312,8 @@ class CRM_Campaign_Page_DashBoard extends CRM_Core_Page {
         }
         $surveysData[$sid]['isActive'] = $isActive;
 
-        $surveysData[$sid]['is_default'] = self::crmIcon('fa-check', ts('Default'), $surveysData[$sid]['is_default']);
+        // For some reason, 'is_default' is coming as a string.
+        $surveysData[$sid]['is_default'] = boolval($surveysData[$sid]['is_default']);
 
         if ($surveysData[$sid]['result_id']) {
           $resultSet = '<a href= "javascript:displayResultSet( ' . $sid . ',' . "'" . $surveysData[$sid]['title'] . "'" . ', ' . $surveysData[$sid]['result_id'] . ' )" title="' . ts('view result set') . '">' . ts('Result Set') . '</a>';
@@ -411,7 +412,9 @@ class CRM_Campaign_Page_DashBoard extends CRM_Core_Page {
           $isActive = ts('Yes');
         }
         $petitionsData[$pid]['isActive'] = $isActive;
-        $petitionsData[$pid]['is_default'] = self::crmIcon('fa-check', ts('Default'), $petitionsData[$pid]['is_default']);
+
+        // For some reason, 'is_default' is coming as a string.
+        $petitionsData[$pid]['is_default'] = boolval($petitionsData[$pid]['is_default']);
 
         $petitionsData[$pid]['action'] = CRM_Core_Action::formLink(self::petitionActionLinks(),
           $action,

--- a/CRM/Core/BAO/CustomOption.php
+++ b/CRM/Core/BAO/CustomOption.php
@@ -138,12 +138,11 @@ class CRM_Core_BAO_CustomOption {
       }
 
       if (in_array($field->html_type, ['CheckBox', 'Multi-Select'])) {
-        $isDefault = (isset($defVal) && in_array($dao->value, $defVal));
+        $options[$dao->id]['is_default'] = (isset($defVal) && in_array($dao->value, $defVal));
       }
       else {
-        $isDefault = ($field->default_value == $dao->value);
+        $options[$dao->id]['is_default'] = ($field->default_value == $dao->value);
       }
-      $options[$dao->id]['is_default'] = CRM_Core_Page::crmIcon('fa-check', ts('Default'), $isDefault);
       $options[$dao->id]['description'] = $dao->description;
       $options[$dao->id]['class'] = $dao->id . ',' . $class;
       $options[$dao->id]['is_active'] = empty($dao->is_active) ? ts('No') : ts('Yes');

--- a/CRM/Price/Page/Option.php
+++ b/CRM/Price/Page/Option.php
@@ -160,7 +160,6 @@ class CRM_Price_Page_Option extends CRM_Core_Page {
           $action -= CRM_Core_Action::DISABLE;
         }
       }
-      $customOption[$id]['is_default'] = CRM_Core_Page::crmIcon('fa-check', ts('Default'), !empty($customOption[$id]['is_default']));
       $customOption[$id]['order'] = $customOption[$id]['weight'];
       $customOption[$id]['action'] = CRM_Core_Action::formLink(self::actionLinks(), $action,
         [

--- a/js/Common.js
+++ b/js/Common.js
@@ -417,6 +417,7 @@ if (!CRM.vars) CRM.vars = {};
     var title = '';
     var sr = '';
     if (text) {
+      text = _.escape(text);
       title = ' title="' + text + '"';
       sr = '<span class="sr-only">' + text + '</span>';
     }

--- a/js/Common.js
+++ b/js/Common.js
@@ -396,6 +396,34 @@ if (!CRM.vars) CRM.vars = {};
   }
 
   /**
+   * Helper to generate an icon with alt text.
+   *
+   * See also smarty `{icon}` and CRM_Core_Page::crmIcon() functions
+   *
+   * @param string icon
+   *   The Font Awesome icon class to use.
+   * @param string text
+   *   Alt text to display.
+   * @param mixed condition
+   *   This will only display if this is truthy.
+   *
+   * @return string
+   *   The formatted icon markup.
+   */
+  CRM.utils.formatConditionalIcon = function (icon, text, condition) {
+    if (!condition) {
+      return '';
+    }
+    var title = '';
+    var sr = '';
+    if (text) {
+      title = ' title="' + text + '"';
+      sr = '<span class="sr-only">' + text + '</span>';
+    }
+    return '<i class="crm-i ' + icon + '"' + title + '></i>' + sr;
+  };
+
+  /**
    * Wrapper for select2 initialization function; supplies defaults
    * @param options object
    */

--- a/js/Common.js
+++ b/js/Common.js
@@ -410,8 +410,8 @@ if (!CRM.vars) CRM.vars = {};
    * @return string
    *   The formatted icon markup.
    */
-  CRM.utils.formatConditionalIcon = function (icon, text, condition) {
-    if (!condition) {
+  CRM.utils.formatIcon = function (icon, text, condition) {
+    if (typeof condition !== 'undefined' && !condition) {
       return '';
     }
     var title = '';

--- a/js/Common.js
+++ b/js/Common.js
@@ -387,7 +387,7 @@ if (!CRM.vars) CRM.vars = {};
       description = row.description || $(row.element).data('description'),
       ret = '';
     if (icon) {
-      ret += '<i class="crm-i ' + icon + '"></i> ';
+      ret += '<i class="crm-i ' + icon + '" aria-hidden="true"></i> ';
     }
     if (color) {
       ret += '<span class="crm-select-item-color" style="background-color: ' + color + '"></span> ';
@@ -421,7 +421,7 @@ if (!CRM.vars) CRM.vars = {};
       title = ' title="' + text + '"';
       sr = '<span class="sr-only">' + text + '</span>';
     }
-    return '<i class="crm-i ' + icon + '"' + title + '></i>' + sr;
+    return '<i class="crm-i ' + icon + '"' + title + ' aria-hidden="true"></i>' + sr;
   };
 
   /**
@@ -463,7 +463,7 @@ if (!CRM.vars) CRM.vars = {};
             placeholder = settings.placeholder || $el.data('placeholder') || $el.attr('placeholder') || $('option[value=""]', $el).text();
           if (m.length && placeholder === m) {
             iconClass = $el.attr('class').match(/(fa-\S*)/)[1];
-            out = '<i class="crm-i ' + iconClass + '"></i> ' + out;
+            out = '<i class="crm-i ' + iconClass + '" aria-hidden="true"></i> ' + out;
           }
           return out;
         };
@@ -733,7 +733,7 @@ if (!CRM.vars) CRM.vars = {};
     }
     _.each(createLinks, function(link) {
       markup += ' <a class="crm-add-entity crm-hover-button" href="' + link.url + '">' +
-        '<i class="crm-i ' + (link.icon || 'fa-plus-circle') + '"></i> ' +
+        '<i class="crm-i ' + (link.icon || 'fa-plus-circle') + '" aria-hidden="true"></i> ' +
         _.escape(link.label) + '</a>';
     });
     markup += '</div>';

--- a/templates/CRM/Campaign/Form/Search/Petition.tpl
+++ b/templates/CRM/Campaign/Form/Search/Petition.tpl
@@ -198,7 +198,7 @@ function loadPetitionList( )
 
          //add id for yes/no column.
          CRM.$(nRow).children().eq(8).attr( 'id', rowId + '_status' );
-         CRM.$(nRow).children().eq(6).html(CRM.utils.formatConditionalIcon('fa-check', ts('Default'), nRow.cells[6].innerText));
+         CRM.$(nRow).children().eq(6).html(CRM.utils.formatIcon('fa-check', ts('Default'), nRow.cells[6].innerText));
 
          return nRow;
     },

--- a/templates/CRM/Campaign/Form/Search/Petition.tpl
+++ b/templates/CRM/Campaign/Form/Search/Petition.tpl
@@ -198,6 +198,7 @@ function loadPetitionList( )
 
          //add id for yes/no column.
          CRM.$(nRow).children().eq(8).attr( 'id', rowId + '_status' );
+         CRM.$(nRow).children().eq(6).html(CRM.utils.formatConditionalIcon('fa-check', ts('Default'), nRow.cells[6].innerText));
 
          return nRow;
     },

--- a/templates/CRM/Campaign/Form/Search/Survey.tpl
+++ b/templates/CRM/Campaign/Form/Search/Survey.tpl
@@ -210,6 +210,7 @@ function loadSurveyList( )
 
          //add id for yes/no column.
          CRM.$(nRow).children().eq(11).attr( 'id', rowId + '_status' );
+         CRM.$(nRow).children().eq(9).html(CRM.utils.formatConditionalIcon('fa-check', ts('Default'), nRow.cells[9].innerText));
 
          return nRow;
     },

--- a/templates/CRM/Campaign/Form/Search/Survey.tpl
+++ b/templates/CRM/Campaign/Form/Search/Survey.tpl
@@ -210,7 +210,7 @@ function loadSurveyList( )
 
          //add id for yes/no column.
          CRM.$(nRow).children().eq(11).attr( 'id', rowId + '_status' );
-         CRM.$(nRow).children().eq(9).html(CRM.utils.formatConditionalIcon('fa-check', ts('Default'), nRow.cells[9].innerText));
+         CRM.$(nRow).children().eq(9).html(CRM.utils.formatIcon('fa-check', ts('Default'), nRow.cells[9].innerText));
 
          return nRow;
     },

--- a/templates/CRM/Custom/Page/Option.tpl
+++ b/templates/CRM/Custom/Page/Option.tpl
@@ -54,8 +54,8 @@
               "aoColumns"  : [
                               {sClass:'crm-custom_option-label'},
                               {sClass:'crm-custom_option-value'},
+                              {sClass:'crm-custom_option-description'},
                               {sClass:'crm-custom_option-default_value'},
-                              {sClass:'crm-custom_option-default_description'},
                               {sClass:'crm-custom_option-is_active'},
                               {sClass:'crm-custom_option-links'},
                               {sClass:'hiddenElement'}
@@ -87,7 +87,7 @@
                 $(nRow).addClass(cl).attr({id: 'OptionValue-' + id});
                 $('td:eq(0)', nRow).wrapInner('<span class="crm-editable crmf-label" />');
                 $('td:eq(0)', nRow).prepend('<span class="crm-i fa-arrows crm-grip" />');
-                $('td:eq(2)', nRow).addClass('crmf-default_value');
+                $('td:eq(3)', nRow).addClass('crmf-default_value').html(CRM.utils.formatConditionalIcon('fa-check', ts('Default'), nRow.cells[3].innerText));
                 return nRow;
               },
               "fnDrawCallback": function() {

--- a/templates/CRM/Custom/Page/Option.tpl
+++ b/templates/CRM/Custom/Page/Option.tpl
@@ -87,7 +87,7 @@
                 $(nRow).addClass(cl).attr({id: 'OptionValue-' + id});
                 $('td:eq(0)', nRow).wrapInner('<span class="crm-editable crmf-label" />');
                 $('td:eq(0)', nRow).prepend('<span class="crm-i fa-arrows crm-grip" />');
-                $('td:eq(3)', nRow).addClass('crmf-default_value').html(CRM.utils.formatConditionalIcon('fa-check', ts('Default'), nRow.cells[3].innerText));
+                $('td:eq(3)', nRow).addClass('crmf-default_value').html(CRM.utils.formatIcon('fa-check', ts('Default'), nRow.cells[3].innerText));
                 return nRow;
               },
               "fnDrawCallback": function() {


### PR DESCRIPTION
Overview
----------------------------------------
This slices off two commit from #17259 for ease of review.  It relies upon #17279 so it includes one commit that is more properly reviewed there, and then this describes the second commit.  #17279 should be reviewed and merged before merging this.

In some spots the BAO or page class was sending the full icon markup to the template rather than letting the template render the icon.  In other words, the data from the BAO, page class, or JSON callback would send a bunch of HTML with a checkmark icon for `is_default` instead of just true or false.

Three of these examples were in datatables, so I wrote a new `CRM.utils.formatConditionalIcon()` to provide this in Javascript.  This is parallel to the `CRM_Core_Page::crmIcon()` and `{icon}` PHP and Smarty functions.

Before
----------------------------------------
Custom field option and CiviCampaign datatable callbacks deliver markup rendering a checkmark if an option, survey, or petition is default.

After
----------------------------------------
The callbacks deliver `true` and the template renders that as a checkmark.

Technical Details
----------------------------------------
I don't think these callbacks are used for anything besides the listing pages, but this should be a bridge to getting generic API output and rendering it in the page.
