### PR TITLE
Icon helper: replace quotes in html title.

### DIFF
--- a/CRM/Core/Page.php
+++ b/CRM/Core/Page.php
@@ -443,6 +443,7 @@ class CRM_Core_Page {
       $title = $sr = '';
     }
     else {
+      $text = htmlspecialchars($text);
       $title = " title=\"$text\"";
       $sr = "<span class=\"sr-only\">$text</span>";
     }


### PR DESCRIPTION
Overview
----------------------------------------
@demeritcowboy raised [an observation](https://github.com/civicrm/civicrm-core/pull/17279#discussion_r422725941) in #17279 but it got merged so fast I couldn't address it: icon alt text might have quotes, and it wouldn't be escaped by `CRM_Core_Page::crmIcon()`.

Before
----------------------------------------
Text like `Click here to remove the "Golf" event type` will cause problems.

After
----------------------------------------
The quotes will be replaced with `&quot;` characters.