### PR TITLE
dev/core#1750: Replace Tokens In Activity Content for Sent Emails

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -1118,9 +1118,6 @@ class CRM_Activity_BAO_Activity extends CRM_Activity_DAO_Activity {
       $from = "$fromDisplayName <$fromEmail>";
     }
 
-    //create the meta level record first ( email activity )
-    $activityID = self::createEmailActivity($userID, $subject, $html, $text, $additionalDetails, $campaignId, $attachments, $caseId);
-
     $returnProperties = [];
     if (isset($messageToken['contact'])) {
       foreach ($messageToken['contact'] as $key => $value) {
@@ -1226,6 +1223,9 @@ class CRM_Activity_BAO_Activity extends CRM_Activity_DAO_Activity {
       }
 
       $sent = FALSE;
+      // Create the email activity.
+      $activityID = self::createEmailActivity($userID, $tokenSubject, $tokenHtml, $tokenText, $additionalDetails, $campaignId, $attachments, $caseId);
+
       if (self::sendMessage(
         $from,
         $userID,


### PR DESCRIPTION
Overview
----------------------------------------
When an email is sent via the email activity form, any used tokens aren’t replaced in the resultant stored body of the content in the activity.

See also: https://lab.civicrm.org/dev/core/-/issues/1750

Before
----------------------------------------
The issue described above exists.
- The email activity is created before the token replacements is done here: https://github.com/civicrm/civicrm-core/blob/master/CRM/Activity/BAO/Activity.php#L1122.
- Token replacements are done here: https://github.com/civicrm/civicrm-core/blob/master/CRM/Activity/BAO/Activity.php#L1193-L1216


After
----------------------------------------
Used tokens in the emails are now properly replaced and the actual content displayed in the email activity.
- The activity creation is moved to before the email is sent, after token replacements.



