### PR TITLE
sr-only text for relationship permissions

### DIFF
--- a/templates/CRM/Contact/Page/View/RelationshipPerm.tpl
+++ b/templates/CRM/Contact/Page/View/RelationshipPerm.tpl
@@ -27,6 +27,9 @@
   <i class="crm-i fa-square fa-stack-2x {if $permType eq 1}crm-i-blue{else}crm-i-green{/if}"></i>
   <i class="crm-i {if $permType eq 1}fa-pencil{else}fa-eye{/if} fa-inverse fa-stack-1x"></i>
 </span>
+{if !$displayText}
+<span class="sr-only">{$permText}</span>
+{/if}
 
 {* Used for viewing a relationship *}
 {if $displayText}


### PR DESCRIPTION
Overview
----------------------------------------
The icons for relationship permissions had `title` text but not screen reader text.

Split from #17271.

Before
----------------------------------------
A screen reader might not pick up that one contact can view or edit another.

After
----------------------------------------
The text in the `title` is also included in a `sr-only` span.
