### PR TITLE
Replaced more> icon with Font Awesome

### DIFF
--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -1549,18 +1549,12 @@ input.crm-form-entityref {
   cursor: pointer;
   position: relative;
   white-space: nowrap;
-  padding-right: 15px !important;
   display: inline;
 }
 .crm-container .btn-slide:after {
-  content: "";
-  display: block;
-  height: 15px;
-  position: absolute;
-  right: 2px;
-  top: 3px;
-  width: 15px;
-  background: url("../i/TreePlus.gif") no-repeat right 1px;
+  font-family: "FontAwesome";
+  content: "\f0da";
+  padding-left: .5ex;
 }
 
 .crm-container .btn-slide-active .panel {


### PR DESCRIPTION
Overview
----------------------------------------
The little triangle after "More" on row links is switched to the new icon system.

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/1682375/81623131-bbae7d00-93c0-11ea-835c-e109f15c4abf.png)

After
----------------------------------------
![image](https://user-images.githubusercontent.com/1682375/81623156-cb2dc600-93c0-11ea-9cdd-11869baab740.png)

Technical Details
----------------------------------------
Being a font, the triangle doesn't have to be a single color.  It picks up the color of the link now, but it could be anything.
