### PR TITLE
dev/core#1753 - Attachments aren't deleted when deleting activity

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -182,6 +182,8 @@ class CRM_Activity_BAO_Activity extends CRM_Activity_DAO_Activity {
         // CRM-13994 delete activity entity_tag
         $query = "DELETE FROM civicrm_entity_tag WHERE entity_table = 'civicrm_activity' AND entity_id = %1";
         $dao = CRM_Core_DAO::executeQuery($query, [1 => [$activity->id, 'Positive']]);
+
+        CRM_Core_BAO_File::deleteEntityFile('civicrm_activity', $activity->id);
       }
     }
     else {


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/1753

1. Create an activity, e.g. a meeting or one more likely to have an attachment like an email activity.
1. Add an attachment.
1. Delete the activity, e.g. from your contact's activity tab.
1. Look in sites/default/files/civicrm/custom. The attachment file is still there.
1. Also the entries are still there in civicrm_file and civicrm_entity_file even though the entry in civicrm_activity isn't there anymore.

Also in the added test the last three asserts all fail.

Before
----------------------------------------
Deleting an activity leaves the attachments orphaned in the filesystem and database.

After
----------------------------------------
Deleting an activity also deletes the attachments.

Technical Details
----------------------------------------
Oversight?

Possibly there's a reason it didn't delete attachments - anybody know of one? The function call I've added checks the reference count in case it's shared with another entity, so it's only deleted from the filesystem if this is the last reference.

Comments
----------------------------------------
I thought I had seen this before a long time ago but (a) in CiviCase you never delete, and (b) it doesn't really come up for me personally for regular activities either, and (c) it's not something users would notice and report.
