### PR TITLE
[REF] Prevent memory leak in Error logging on Drupal 8

### DIFF
--- a/CRM/Core/Error.php
+++ b/CRM/Core/Error.php
@@ -515,6 +515,16 @@ class CRM_Core_Error extends PEAR_ErrorStack {
         $out = "\$$variable_name = $out";
       }
       else {
+        // Block to avoid memory leak in drupal 8
+        if (array_key_exists('exception', $variable)) {
+          $exception = (array) $variable['exception'];
+          foreach ($exception as $k => & $v) {
+            if (gettype($v) == 'array') {
+              $v = self::formatBacktrace($v);
+            }
+          }
+          $variable['exception'] = $exception;
+        }
         // use var_dump
         ob_start();
         var_dump($variable);


### PR DESCRIPTION
Overview
----------------------------------------
This aims to prevent a memory leak during the var_dump in CRM_Core_Error that only seems to occur on Drupal 8 due to the usage of symphony etc

Before
----------------------------------------
Memory Error in the var_dump

After
----------------------------------------
No memory error

Technical Details
----------------------------------------
This is picked up and submitted code from the work @jackrabbithanna and his team has done as per https://chat.civicrm.org/civicrm/pl/1ww1h5hq8tgn5c4qcgo5e4wdsc to debug this problem

Comments
----------------------------------------
ping @mlutfy @KarinG @petednz fellow D8 users
