### PR TITLE
crmButton: support icon=0 for no icon

### DIFF
--- a/CRM/Core/Smarty/plugins/block.crmButton.php
+++ b/CRM/Core/Smarty/plugins/block.crmButton.php
@@ -38,9 +38,21 @@ function smarty_block_crmButton($params, $text, &$smarty) {
   // Always add class 'button' - fixme probably should be crm-button
   $params['class'] = empty($params['class']) ? 'button' : 'button ' . $params['class'];
   // Any FA icon works
-  $icon = CRM_Utils_Array::value('icon', $params, 'pencil');
+  if (array_key_exists('icon', $params) && !$params['icon']) {
+    // icon=0 should produce a button with no icon
+    $iconMarkup = '';
+  }
+  else {
+    $icon = $params['icon'] ?? 'fa-pencil';
+    // Assume for now that all icons are Font Awesome v4.x but handle if it's
+    // specified
+    if (strpos($icon, 'fa-') !== 0) {
+      $icon = "fa-$icon";
+    }
+    $iconMarkup = "<i class='crm-i $icon'></i>&nbsp; ";
+  }
   // All other params are treated as html attributes
   CRM_Utils_Array::remove($params, 'icon', 'p', 'q', 'a', 'f', 'h', 'fb', 'fe');
   $attributes = CRM_Utils_String::htmlAttributes($params);
-  return "<a $attributes><span><i class='crm-i fa-$icon'></i>&nbsp; $text</span></a>";
+  return "<a $attributes><span>$iconMarkup$text</span></a>";
 }


### PR DESCRIPTION
Overview
----------------------------------------
There is a handy `{crmButton}` Smarty function for creating buttons, but it requires all buttons to have icons.  This retains backwards compatibility that not specifying the icon produces a pencil, but you can do `icon=0` to specify no icon.

Before
----------------------------------------
All buttons produced with `{crmButton}` get an icon.  If none is specified, a pencil is displayed.

After
----------------------------------------
Buttons produced with `{crmButton}` that lack an `icon` param get a pencil, but you can set `icon=0` and get no icon.

Technical Details
----------------------------------------
We're a little inconsistent in general as to whether icons should be something generic like `heart` or specific Font Awesome classes like `fa-heart`.  This continues to support icons without the `fa-` prefix, but it now allows them with the prefix.  In my opinion the latter is preferable: we are providing a specific icon by name, not a general-purpose representation of a concept.

Comments
----------------------------------------
I noticed this in updating the UI framework documentation after my little icon blitz.
