### PR TITLE
dev/core#1755 Fix reCaptcha on Mailing Subscribe

### DIFF
--- a/CRM/Mailing/Form/Subscribe.php
+++ b/CRM/Mailing/Form/Subscribe.php
@@ -105,32 +105,11 @@ ORDER BY title";
       $this->addFormRule(['CRM_Mailing_Form_Subscribe', 'formRule']);
     }
 
-    $addCaptcha = TRUE;
-
-    // if recaptcha is not configured, then dont add it
-    // CRM-11316 Only enable ReCAPTCHA for anonymous visitors
-    $config = CRM_Core_Config::singleton();
+    // CRM-11316 Enable ReCAPTCHA for anonymous visitors
     $session = CRM_Core_Session::singleton();
     $contactID = $session->get('userID');
 
-    if (empty($config->recaptchaPublicKey) ||
-      empty($config->recaptchaPrivateKey) ||
-      $contactID
-    ) {
-      $addCaptcha = FALSE;
-    }
-    else {
-      // If this is POST request and came from a block,
-      // lets add recaptcha only if already present.
-      // Gross hack for now.
-      if (!empty($_POST) &&
-        !array_key_exists('recaptcha_challenge_field', $_POST)
-      ) {
-        $addCaptcha = FALSE;
-      }
-    }
-
-    if ($addCaptcha) {
+    if (!$contactID) {
       CRM_Utils_ReCAPTCHA::enableCaptchaOnForm($this);
     }
 


### PR DESCRIPTION
Overview
----------------------------------------

https://lab.civicrm.org/dev/core/-/issues/1755

* Enable reCaptcha on site
* Go to the mailing subscribe form (ex: https://civicrm.org/civicrm/mailing/subscribe?reset=1)
* Submit the form without answering the reCaptcha challenge.

The form submission will be accepted, without the challenge.

Before
---------------

![civicrm-broken-recaptcha](https://user-images.githubusercontent.com/254741/81716485-6ff2e680-9447-11ea-8e1e-138345b56a65.gif)

After
-----------

![civicrm-recaptcha-fixed](https://user-images.githubusercontent.com/254741/81716558-813bf300-9447-11ea-9ddf-84df81b3e8d7.gif)


Technical Details
----------------------------------------

* I cleaned up the code because the verification to see if the settings exist is already in the enableCaptchaOnForm function.
* The "gross hack for now" goes back to 2009 and is not clear. Maybe there was a Drupal block back then? [reference](https://github.com/civicrm/civicrm-svn/commit/e745abc5114e644ef58712a42e73af9be100588c#diff-7e49ca39c25024fb4dbba97bee79be03)
