### PR TITLE
Comm prefs: add condition param for {privacyFlag}

### DIFF
--- a/CRM/Core/Smarty/plugins/function.privacyFlag.php
+++ b/CRM/Core/Smarty/plugins/function.privacyFlag.php
@@ -13,7 +13,6 @@
  *
  * @package CRM
  * @author Andrew Hunt, AGH Strategies
- * $Id$
  *
  */
 
@@ -23,12 +22,16 @@
  * @param $params
  *   - field: the applicable privacy field
  *     (one of CRM_Core_SelectValues::privacy() or `on_hold`)
+ *   - condition: if present and falsey, return empty
  *
  * @param $smarty
  *
  * @return string
  */
 function smarty_function_privacyFlag($params, &$smarty) {
+  if (array_key_exists('condition', $params) && !$params['condition']) {
+    return '';
+  }
   $icons = [
     'do_not_phone' => 'fa-phone',
     'do_not_email' => 'fa-paper-plane',

--- a/templates/CRM/Contact/Form/Selector.tpl
+++ b/templates/CRM/Contact/Form/Selector.tpl
@@ -81,7 +81,7 @@
             <td><a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=`$row.contact_id`&key=`$qfKey`&context=`$context`"}">{if $row.is_deleted}<del>{/if}{$row.sort_name}{if $row.is_deleted}</del>{/if}</a></td>
             {if $action eq 512 or $action eq 256}
               {if !empty($columnHeaders.street_address)}
-          <td><span title="{$row.street_address|escape}">{$row.street_address|mb_truncate:22:"...":true}{if $row.do_not_mail} {privacyFlag field=do_not_mail}{/if}</span></td>
+          <td><span title="{$row.street_address|escape}">{$row.street_address|mb_truncate:22:"...":true}{privacyFlag field=do_not_mail condition=$row.do_not_mail}</span></td>
         {/if}
         {if !empty($columnHeaders.city)}
                 <td>{$row.city}</td>
@@ -99,23 +99,16 @@
                 {if $row.email}
                     <span title="{$row.email|escape}">
                         {$row.email|mb_truncate:17:"...":true}
-                        {if $row.on_hold}
-                          {privacyFlag field=on_hold}
-                        {elseif $row.do_not_email}
-                          {privacyFlag field=do_not_email}
-                        {/if}
+                        {privacyFlag field=do_not_email condition=$row.do_not_email}
+                        {privacyFlag field=on_hold condition=$row.on_hold}
                     </span>
                 {/if}
               </td>
               <td>
                 {if $row.phone}
                   {$row.phone}
-                  {if $row.do_not_phone}
-                    {privacyFlag field=do_not_phone}
-                  {/if}
-                  {if $row.do_not_sms}
-                    {privacyFlag field=do_not_sms}
-                  {/if}
+                  {privacyFlag field=do_not_phone condition=$row.do_not_phone}
+                  {privacyFlag field=do_not_sms condition=$row.do_not_sms}
                 {/if}
               </td>
            {else}

--- a/templates/CRM/Contact/Page/Inline/Address.tpl
+++ b/templates/CRM/Contact/Page/Inline/Address.tpl
@@ -24,7 +24,7 @@
       <div class="crm-summary-row {if $add.is_primary eq 1} primary{/if}">
         <div class="crm-label">
           {ts 1=$add.location_type}%1 Address{/ts}
-          {if $privacy.do_not_mail}{privacyFlag field=do_not_mail}{/if}
+          {privacyFlag field=do_not_mail condition=$privacy.do_not_mail}
           {if $config->mapProvider AND
               !empty($add.geo_code_1) AND
               is_numeric($add.geo_code_1) AND

--- a/templates/CRM/Contact/Page/Inline/Email.tpl
+++ b/templates/CRM/Contact/Page/Inline/Email.tpl
@@ -29,7 +29,7 @@
     <div class="crm-summary-row {if $item.is_primary eq 1}primary{/if}">
       <div class="crm-label">
         {$item.location_type} {ts}Email{/ts}
-        {if $privacy.do_not_email}{privacyFlag field=do_not_email}{elseif $item.on_hold}{privacyFlag field=on_hold}{/if}
+        {privacyFlag field=do_not_email condition=$privacy.do_not_email}{privacyFlag field=on_hold condition=$item.on_hold}
       </div>
       <div class="crm-content crm-contact_email">
         {if !$item.on_hold and !$privacy.do_not_email}

--- a/templates/CRM/Contact/Page/Inline/Phone.tpl
+++ b/templates/CRM/Contact/Page/Inline/Phone.tpl
@@ -19,8 +19,8 @@
       <div class="crm-summary-row">
         <div class="crm-label">
           {ts}Phone{/ts}
-          {if $privacy.do_not_sms}{privacyFlag field=do_not_sms}{/if}
-          {if $privacy.do_not_phone}{privacyFlag field=do_not_phone}{/if}
+          {privacyFlag field=do_not_sms condition=$privacy.do_not_sms}
+          {privacyFlag field=do_not_phone condition=$privacy.do_not_phone}
         </div>
         <div class="crm-content"></div>
       </div>
@@ -29,8 +29,8 @@
       {if $item.phone || $item.phone_ext}
         <div class="crm-summary-row {if $item.is_primary eq 1}primary{/if}">
           <div class="crm-label">
-            {if $privacy.do_not_sms}{privacyFlag field=do_not_sms}{/if}
-            {if $privacy.do_not_phone}{privacyFlag field=do_not_phone}{/if}
+            {privacyFlag field=do_not_sms condition=$privacy.do_not_sms}
+            {privacyFlag field=do_not_phone condition=$privacy.do_not_phone}
             {$item.location_type} {$item.phone_type}
           </div>
           <div class="crm-content crm-contact_phone">


### PR DESCRIPTION
Overview
----------------------------------------
This is a follow-up for #17283 that adds a `condition` parameter for `{privacyFlag}` to simplify the code a bit and make it work more similarly to `{icon}`.

In the process, this also displays on hold status alongside do not email status.  This was handled inconsistently before (the on hold would take precedence in search results, while the do not email would take precedence on the contact summary).  Both pieces of information are also independently useful.

Before
----------------------------------------
If you want to use `{privacyFlag}` to show "Do not mail", etc., you need to wrap it in an `{if}`.

After
----------------------------------------
You can supply a value as a condition to `{privacyFlag}`, and it will only display the icon if the value is true.