### PR TITLE
Member tab: auto-renew status was hidden from screen readers

### DIFF
--- a/templates/CRM/Member/Page/Tab.tpl
+++ b/templates/CRM/Member/Page/Tab.tpl
@@ -80,9 +80,9 @@
                 <td class="crm-membership-source">{$activeMember.source}</td>
                 <td class="crm-membership-auto_renew">
                   {if $activeMember.auto_renew eq 1}
-                      <i class="crm-i fa-check" aria-hidden="true" title="{ts}Auto-renew active{/ts}"></i>
+                      {icon icon="fa-check"}{ts}Auto-renew active{/ts}{/icon}
                   {elseif $activeMember.auto_renew eq 2}
-                      <i class="crm-i fa-ban" aria-hidden="true" title="{ts}Auto-renew error{/ts}"></i>
+                      {icon icon="fa-exclamation-triangle"}{ts}Auto-renew error{/ts}{/icon}
                   {/if}
                 </td>
                 <td class="crm-membership-related_count">{$activeMember.related_count}</td>
@@ -130,9 +130,9 @@
                 <td class="crm-membership-source">{$inActiveMember.source}</td>
                 <td class="crm-membership-auto_renew">
                   {if $inActiveMember.auto_renew eq 1}
-                    <i class="crm-i fa-check" aria-hidden="true" title="{ts}Auto-renew active{/ts}"></i>
+                    {icon icon="fa-check"}{ts}Auto-renew active{/ts}{/icon}
                   {elseif $inActiveMember.auto_renew eq 2}
-                    <i class="crm-i fa-ban" aria-hidden="true" title="{ts}Auto-renew error{/ts}"></i>
+                    {icon icon="fa-exclamation-triangle"}{ts}Auto-renew error{/ts}{/icon}
                   {/if}
                 </td>
     <td>{$inActiveMember.action|replace:'xx':$inActiveMember.id}


### PR DESCRIPTION
Overview
----------------------------------------
The icon for auto-renew status was hidden from screen readers.  Also, when there was an error it used `fa-ban`, which is ambiguous as to whether auto-renewal was broken, never started, or canceled.  This changes it to `fa-exclamation-triangle, which more clearly reflects that there was an error.

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/1682375/81738869-68900500-9468-11ea-83a0-246bfe05e1c4.png)
No screen reader text, and element is `aria-hidden`.

After
----------------------------------------
![image](https://user-images.githubusercontent.com/1682375/81738789-439b9200-9468-11ea-9d4a-dbbe1b5c60f8.png)
Screen reader text is provided.  The icon itself should be `aria-hidden` (per #17318), but that's what the screen reader text is for.
