### PR TITLE
Migrate CiviMail "extern" scripts to conventional routes

### DIFF
--- a/CRM/Admin/Form/Setting/Url.php
+++ b/CRM/Admin/Form/Setting/Url.php
@@ -21,6 +21,7 @@
 class CRM_Admin_Form_Setting_Url extends CRM_Admin_Form_Setting {
   protected $_settings = [
     'disable_core_css' => CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME,
+    'defaultExternUrl' => CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME,
     'userFrameworkResourceURL' => CRM_Core_BAO_Setting::URL_PREFERENCES_NAME,
     'imageUploadURL' => CRM_Core_BAO_Setting::URL_PREFERENCES_NAME,
     'customCSSURL' => CRM_Core_BAO_Setting::URL_PREFERENCES_NAME,

--- a/CRM/Mailing/BAO/TrackableURL.php
+++ b/CRM/Mailing/BAO/TrackableURL.php
@@ -76,7 +76,9 @@ class CRM_Mailing_BAO_TrackableURL extends CRM_Mailing_DAO_TrackableURL {
       $urlCache[$mailing_id . $url] = $redirect;
     }
 
-    $returnUrl = CRM_Utils_System::externUrl('extern/url', "u=$id&qid=$queue_id");
+    // This looks silly - calling the hook twice. This smells like an accident. Restoring old cache-based lookup.
+    // $returnUrl = CRM_Utils_System::externUrl('extern/url', "u=$id&qid=$queue_id");
+    $returnUrl = "{$urlCache[$mailing_id . $url]}&qid={$queue_id}";
 
     if ($hrefExists) {
       $returnUrl = "href='{$returnUrl}' rel='nofollow'";

--- a/CRM/Mailing/Page/Open.php
+++ b/CRM/Mailing/Page/Open.php
@@ -1,0 +1,58 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+/**
+ * Indicate that a CiviMail message has been opened
+ *
+ * General Usage: civicrm/mailing/open?qid={event_queue_id}
+ *
+ * NOTE: The parameter name has changed slightly from 'extern/open.php?q={event_queue_id}`.
+ */
+class CRM_Mailing_Page_Open extends CRM_Core_Page {
+
+  /**
+   * Mark the mailing as opened
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function run() {
+    $queue_id = CRM_Utils_Request::retrieveValue('qid', 'Positive', NULL, FALSE, 'GET');
+    if (!$queue_id) {
+      // Deprecated: "?q=" is problematic in Drupal integrations, but we'll accept if igiven
+      $queue_id = CRM_Utils_Request::retrieveValue('q', 'Positive', NULL, FALSE, 'GET');;
+    }
+    if (!$queue_id) {
+      echo "Missing input parameters\n";
+      exit();
+    }
+
+    CRM_Mailing_Event_BAO_Opened::open($queue_id);
+
+    $filename = Civi::paths()->getPath('[civicrm.root]/i/tracker.gif');
+
+    header('Cache-Control: must-revalidate, post-check=0, pre-check=0');
+    header('Content-Description: File Transfer');
+    header('Content-type: image/gif');
+    header('Content-Length: ' . filesize($filename));
+    header('Content-Disposition: inline; filename=tracker.gif');
+
+    readfile($filename);
+
+    CRM_Utils_System::civiExit();
+  }
+
+}

--- a/CRM/Mailing/Page/Url.php
+++ b/CRM/Mailing/Page/Url.php
@@ -58,7 +58,11 @@ class CRM_Mailing_Page_Url extends CRM_Core_Page {
         $url .= '#' . $pieces['fragment'];
       }
     }
-    CRM_Utils_System::redirect($url);
+    CRM_Utils_System::redirect($url, [
+      'for' => 'civicrm/mailing/url',
+      'queue_id' => $queue_id,
+      'url_id' => $url_id,
+    ]);
   }
 
   /**

--- a/CRM/Mailing/Page/Url.php
+++ b/CRM/Mailing/Page/Url.php
@@ -1,0 +1,65 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+/**
+ * Redirects a user to the full url from a mailing url.
+ */
+class CRM_Mailing_Page_Url extends CRM_Core_Page {
+
+  /**
+   * Redirect the user to the specified url.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function run() {
+    $queue_id = CRM_Utils_Request::retrieveValue('qid', 'Integer');
+    $url_id = CRM_Utils_Request::retrieveValue('u', 'Integer', NULL, TRUE);
+    $url = CRM_Mailing_Event_BAO_TrackableURLOpen::track($queue_id, $url_id);
+
+    // CRM-7103
+    // Looking for additional query variables and append them when redirecting.
+    $query_param = $_GET;
+    unset($query_param['qid'], $query_param['u']);
+    $query_string = http_build_query($query_param);
+
+    if (strlen($query_string) > 0) {
+      // Parse the url to preserve the fragment.
+      $pieces = parse_url($url);
+
+      if (isset($pieces['fragment'])) {
+        $url = str_replace('#' . $pieces['fragment'], '', $url);
+      }
+
+      // Handle additional query string params.
+      if ($query_string) {
+        if (stristr($url, '?')) {
+          $url .= '&' . $query_string;
+        }
+        else {
+          $url .= '?' . $query_string;
+        }
+      }
+
+      // slap the fragment onto the end per URL spec
+      if (isset($pieces['fragment'])) {
+        $url .= '#' . $pieces['fragment'];
+      }
+    }
+    CRM_Utils_System::redirect($url);
+  }
+
+}

--- a/CRM/Mailing/Page/Url.php
+++ b/CRM/Mailing/Page/Url.php
@@ -85,9 +85,18 @@ class CRM_Mailing_Page_Url extends CRM_Core_Page {
    * @link https://issues.civicrm.org/jira/browse/CRM-7103
    */
   protected function extractPassthroughParameters():string {
+    $config = CRM_Core_Config::singleton();
+
     $query_param = $_GET;
-    unset($query_param['qid'], $query_param['u']);
-    unset($query_param[CRM_Core_Config::singleton()->userFrameworkURLVar]);
+    unset($query_param['qid']);
+    unset($query_param['u']);
+    unset($query_param[$config->userFrameworkURLVar]);
+    if ($config->userFramework === 'WordPress') {
+      // Ugh
+      unset($query_param['page']);
+      unset($query_param['noheader']);
+    }
+
     $query_string = http_build_query($query_param);
     return $query_string;
   }

--- a/CRM/Mailing/xml/Menu/Mailing.xml
+++ b/CRM/Mailing/xml/Menu/Mailing.xml
@@ -202,4 +202,9 @@
     <page_callback>CRM_Mailing_Page_AJAX::getContactMailings</page_callback>
     <access_arguments>access CiviCRM</access_arguments>
   </item>
+  <item>
+    <path>civicrm/mailing/url</path>
+    <page_callback>CRM_Mailing_Page_Url</page_callback>
+    <access_arguments>*always allow*</access_arguments>
+  </item>
 </menu>

--- a/CRM/Mailing/xml/Menu/Mailing.xml
+++ b/CRM/Mailing/xml/Menu/Mailing.xml
@@ -207,4 +207,9 @@
     <page_callback>CRM_Mailing_Page_Url</page_callback>
     <access_arguments>*always allow*</access_arguments>
   </item>
+  <item>
+    <path>civicrm/mailing/open</path>
+    <page_callback>CRM_Mailing_Page_Open</page_callback>
+    <access_arguments>*always allow*</access_arguments>
+  </item>
 </menu>

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -354,6 +354,7 @@ class Container {
     $dispatcher->addListener('hook_civicrm_buildAsset', ['\CRM_Core_Resources', 'renderMenubarStylesheet']);
     $dispatcher->addListener('hook_civicrm_coreResourceList', ['\CRM_Utils_System', 'appendCoreResources']);
     $dispatcher->addListener('hook_civicrm_getAssetUrl', ['\CRM_Utils_System', 'alterAssetUrl']);
+    $dispatcher->addListener('hook_civicrm_alterExternUrl', ['\CRM_Utils_System', 'migrateExternUrl'], 1000);
     $dispatcher->addListener('civi.dao.postInsert', ['\CRM_Core_BAO_RecurringEntity', 'triggerInsert']);
     $dispatcher->addListener('civi.dao.postUpdate', ['\CRM_Core_BAO_RecurringEntity', 'triggerUpdate']);
     $dispatcher->addListener('civi.dao.postDelete', ['\CRM_Core_BAO_RecurringEntity', 'triggerDelete']);

--- a/settings/Core.setting.php
+++ b/settings/Core.setting.php
@@ -239,6 +239,27 @@ return [
     'description' => NULL,
     'help_text' => NULL,
   ],
+  'defaultExternUrl' => [
+    'group_name' => 'CiviCRM Preferences',
+    'group' => 'core',
+    'name' => 'defaultExternUrl',
+    'type' => 'String',
+    'quick_form_type' => 'Select',
+    'html_type' => 'Select',
+    'html_attributes' => [
+      'class' => 'crm-select2',
+    ],
+    'default' => 'router',
+    'add' => '5.27',
+    'title' => ts('Extern URL Style'),
+    'is_domain' => 1,
+    'is_contact' => 0,
+    'help_text' => NULL,
+    'options' => [
+      'standalone' => ts('Prefer standalone scripts'),
+      'router' => ts('Prefer normal router'),
+    ],
+  ],
   'activity_assignee_notification' => [
     'group_name' => 'CiviCRM Preferences',
     'group' => 'core',

--- a/settings/Core.setting.php
+++ b/settings/Core.setting.php
@@ -251,9 +251,10 @@ return [
     ],
     'default' => 'router',
     'add' => '5.27',
-    'title' => ts('Extern URL Style (Transition Support)'),
+    'title' => ts('Extern URL Style'),
     'is_domain' => 1,
     'is_contact' => 0,
+    'description' => ts('This setting provides transitional support. It should be set to "Prefer normal router." If your deployment requires "Prefer standalone script", then please ensure that the issue is tracked in <code>lab.civicrm.org</code>.'),
     'help_text' => NULL,
     'options' => [
       'standalone' => ts('Prefer standalone scripts'),

--- a/settings/Core.setting.php
+++ b/settings/Core.setting.php
@@ -251,7 +251,7 @@ return [
     ],
     'default' => 'router',
     'add' => '5.27',
-    'title' => ts('Extern URL Style'),
+    'title' => ts('Extern URL Style (Transition Support)'),
     'is_domain' => 1,
     'is_contact' => 0,
     'help_text' => NULL,

--- a/templates/CRM/Admin/Form/Setting/Url.hlp
+++ b/templates/CRM/Admin/Form/Setting/Url.hlp
@@ -70,6 +70,16 @@
 <p>{ts}You can modify the look and feel of CiviCRM by adding your own stylesheet. For small to medium sized modifications, use your css file to override some of the styles in civicrm.css. Or if you need to make drastic changes, you can choose to disable civicrm.css completely.{/ts}</p>
 {/htxt}
 
+{htxt id='id-defaultExternUrl'}
+<p>{ts}CiviCRM generates callback URLs for external services.{/ts}</p>
+<p>{ts}Some callback URLs are being migrated to a different style. During the transition, you may indicate a preferred style, such as:{/ts}</p>
+<ul>
+    <li>{ts}"Standalone Scripts" - In the traditional style, each callback URL is a standalone PHP script. You may wish to use this style if you need to maximize performance or if you need continuity.{/ts}</li>
+    <li>{ts}"Router" - In the newer style, each callback URL is defined like a normal CiviCRM page. You may wish to use this style for greater consistency or portability.{/ts}</li>
+</ul>
+<p>{ts}This setting only affects the default URL produced by "civicrm-core". Extensions and add-ons may override specific URLs.{/ts}</p>
+{/htxt}
+
 {htxt id='id-url_vars'}
 {ts}URL Variables{/ts}
   <table>

--- a/templates/CRM/Admin/Form/Setting/Url.tpl
+++ b/templates/CRM/Admin/Form/Setting/Url.tpl
@@ -77,6 +77,14 @@
             <p class="description font-red">{ts}{$verifySSL_description}{/ts}</p>
         </td>
     </tr>
+    <tr class="crm-url-form-block-defaultExternUrl">
+        <td class="label">
+            {$form.defaultExternUrl.label} {help id='id-defaultExternUrl'}
+        </td>
+        <td>
+            {$form.defaultExternUrl.html}
+        </td>
+    </tr>
 </table>
 <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
 </div>

--- a/templates/CRM/Admin/Form/Setting/Url.tpl
+++ b/templates/CRM/Admin/Form/Setting/Url.tpl
@@ -82,7 +82,8 @@
             {$form.defaultExternUrl.label} {help id='id-defaultExternUrl'}
         </td>
         <td>
-            {$form.defaultExternUrl.html}
+            {$form.defaultExternUrl.html}<br/>
+            <p class="description font-red">{ts}{$settings_fields.defaultExternUrl.description}{/ts}</p>
         </td>
     </tr>
 </table>

--- a/tests/phpunit/CRM/Mailing/BaseMailingSystemTest.php
+++ b/tests/phpunit/CRM/Mailing/BaseMailingSystemTest.php
@@ -200,7 +200,7 @@ abstract class CRM_Mailing_BaseMailingSystemTest extends CiviUnitTestCase {
       $this->assertRegExp(
         ";" .
         // body_html
-        "<p>You can go to <a href=['\"].*extern/url\.php\?u=\d+&amp\\;qid=\d+['\"] rel='nofollow'>Google</a>" .
+        "<p>You can go to <a href=['\"].*civicrm/mailing/url\.php\?u=\d+&amp\\;qid=\d+['\"] rel='nofollow'>Google</a>" .
         " or <a href=\"http.*civicrm/mailing/optout.*\">opt out</a>.</p>\n" .
         // Default footer
         "Sample Footer for HTML formatted content" .
@@ -219,7 +219,7 @@ abstract class CRM_Mailing_BaseMailingSystemTest extends CiviUnitTestCase {
         "\n" .
         "Links:\n" .
         "------\n" .
-        "\\[1\\] .*extern/url\.php\?u=\d+&qid=\d+\n" .
+        "\\[1\\] http.*civicrm/mailing/url\.php\?u=\d+&qid=\d+\n" .
         "\\[2\\] http.*civicrm/mailing/optout.*\n" .
         "\n" .
         // Default footer
@@ -280,8 +280,8 @@ abstract class CRM_Mailing_BaseMailingSystemTest extends CiviUnitTestCase {
     // Tracking enabled
     $cases[] = [
       '<p><a href="http://example.net/">Foo</a></p>',
-      ';<p><a href=[\'"].*extern/url\.php\?u=\d+.*[\'"]>Foo</a></p>;',
-      ';\\[1\\] .*extern/url\.php\?u=\d+.*;',
+      ';<p><a href=[\'"].*civicrm/mailing/url\.php\?u=\d+.*[\'"]>Foo</a></p>;',
+      ';\\[1\\] .*civicrm/mailing/url\.php\?u=\d+.*;',
       ['url_tracking' => 1],
     ];
     $cases[] = [
@@ -311,7 +311,7 @@ abstract class CRM_Mailing_BaseMailingSystemTest extends CiviUnitTestCase {
       // but not in HTML emails.
       "<p>Please go to: http://example.net/</p>",
       ";<p>Please go to: http://example\.net/</p>;",
-      ';Please go to: .*extern/url.php\?u=\d+&qid=\d+;',
+      ';Please go to: .*civicrm/mailing.php\?u=\d+&qid=\d+;',
       ['url_tracking' => 1],
     ];
 
@@ -322,6 +322,7 @@ abstract class CRM_Mailing_BaseMailingSystemTest extends CiviUnitTestCase {
    * Generate a fully-formatted mailing (with body_html content).
    *
    * @dataProvider urlTrackingExamples
+   * @throws \CRM_Core_Exception
    */
   public function testUrlTracking($inputHtml, $htmlUrlRegex, $textUrlRegex, $params) {
     $caseName = print_r(['inputHtml' => $inputHtml, 'params' => $params], 1);

--- a/tests/phpunit/CRM/Mailing/BaseMailingSystemTest.php
+++ b/tests/phpunit/CRM/Mailing/BaseMailingSystemTest.php
@@ -200,7 +200,7 @@ abstract class CRM_Mailing_BaseMailingSystemTest extends CiviUnitTestCase {
       $this->assertRegExp(
         ";" .
         // body_html
-        "<p>You can go to <a href=['\"].*civicrm/mailing/url\.php\?u=\d+&amp\\;qid=\d+['\"] rel='nofollow'>Google</a>" .
+        "<p>You can go to <a href=['\"].*(extern/url.php|civicrm/mailing/url)(\?|&amp\\;)u=\d+&amp\\;qid=\d+['\"] rel='nofollow'>Google</a>" .
         " or <a href=\"http.*civicrm/mailing/optout.*\">opt out</a>.</p>\n" .
         // Default footer
         "Sample Footer for HTML formatted content" .
@@ -219,7 +219,7 @@ abstract class CRM_Mailing_BaseMailingSystemTest extends CiviUnitTestCase {
         "\n" .
         "Links:\n" .
         "------\n" .
-        "\\[1\\] http.*civicrm/mailing/url\.php\?u=\d+&qid=\d+\n" .
+        "\\[1\\] http.*(extern/url.php|civicrm/mailing/url)(\?|&)u=\d+&qid=\d+\n" .
         "\\[2\\] http.*civicrm/mailing/optout.*\n" .
         "\n" .
         // Default footer
@@ -243,32 +243,32 @@ abstract class CRM_Mailing_BaseMailingSystemTest extends CiviUnitTestCase {
     $cases = [];
 
     // Tracking disabled
-    $cases[] = [
+    $cases[0] = [
       '<p><a href="http://example.net/">Foo</a></p>',
       ';<p><a href="http://example\.net/">Foo</a></p>;',
       ';\\[1\\] http://example\.net/;',
       ['url_tracking' => 0],
     ];
-    $cases[] = [
+    $cases[1] = [
       '<p><a href="http://example.net/?id={contact.contact_id}">Foo</a></p>',
       // FIXME: Legacy tracker adds extra quote after URL
       ';<p><a href="http://example\.net/\?id=\d+""?>Foo</a></p>;',
       ';\\[1\\] http://example\.net/\?id=\d+;',
       ['url_tracking' => 0],
     ];
-    $cases[] = [
+    $cases[2] = [
       '<p><a href="{action.optOutUrl}">Foo</a></p>',
       ';<p><a href="http.*civicrm/mailing/optout.*">Foo</a></p>;',
       ';\\[1\\] http.*civicrm/mailing/optout.*;',
       ['url_tracking' => 0],
     ];
-    $cases[] = [
+    $cases[3] = [
       '<p>Look at <img src="http://example.net/foo.png">.</p>',
       ';<p>Look at <img src="http://example\.net/foo\.png">\.</p>;',
       ';Look at \.;',
       ['url_tracking' => 0],
     ];
-    $cases[] = [
+    $cases[4] = [
       // Plain-text URL's are tracked in plain-text emails...
       // but not in HTML emails.
       "<p>Please go to: http://example.net/</p>",
@@ -278,13 +278,13 @@ abstract class CRM_Mailing_BaseMailingSystemTest extends CiviUnitTestCase {
     ];
 
     // Tracking enabled
-    $cases[] = [
+    $cases[5] = [
       '<p><a href="http://example.net/">Foo</a></p>',
-      ';<p><a href=[\'"].*civicrm/mailing/url\.php\?u=\d+.*[\'"]>Foo</a></p>;',
-      ';\\[1\\] .*civicrm/mailing/url\.php\?u=\d+.*;',
+      ';<p><a href=[\'"].*(extern/url.php|civicrm/mailing/url)(\?|&amp\\;)u=\d+.*[\'"]>Foo</a></p>;',
+      ';\\[1\\] .*(extern/url.php|civicrm/mailing/url)[\?&]u=\d+.*;',
       ['url_tracking' => 1],
     ];
-    $cases[] = [
+    $cases[6] = [
       // FIXME: CiviMail URL tracking doesn't track tokenized links.
       '<p><a href="http://example.net/?id={contact.contact_id}">Foo</a></p>',
       // FIXME: Legacy tracker adds extra quote after URL
@@ -292,26 +292,26 @@ abstract class CRM_Mailing_BaseMailingSystemTest extends CiviUnitTestCase {
       ';\\[1\\] http://example\.net/\?id=\d+;',
       ['url_tracking' => 1],
     ];
-    $cases[] = [
+    $cases[7] = [
       // It would be redundant/slow to track the action URLs?
       '<p><a href="{action.optOutUrl}">Foo</a></p>',
       ';<p><a href="http.*civicrm/mailing/optout.*">Foo</a></p>;',
       ';\\[1\\] http.*civicrm/mailing/optout.*;',
       ['url_tracking' => 1],
     ];
-    $cases[] = [
+    $cases[8] = [
       // It would be excessive/slow to track every embedded image.
       '<p>Look at <img src="http://example.net/foo.png">.</p>',
       ';<p>Look at <img src="http://example\.net/foo\.png">\.</p>;',
       ';Look at \.;',
       ['url_tracking' => 1],
     ];
-    $cases[] = [
+    $cases[8] = [
       // Plain-text URL's are tracked in plain-text emails...
       // but not in HTML emails.
       "<p>Please go to: http://example.net/</p>",
       ";<p>Please go to: http://example\.net/</p>;",
-      ';Please go to: .*civicrm/mailing.php\?u=\d+&qid=\d+;',
+      ';Please go to: .*(extern/url.php|civicrm/mailing/url)[\?&]u=\d+&qid=\d+;',
       ['url_tracking' => 1],
     ];
 

--- a/tests/phpunit/CRM/Mailing/BaseMailingSystemTest.php
+++ b/tests/phpunit/CRM/Mailing/BaseMailingSystemTest.php
@@ -151,7 +151,7 @@ abstract class CRM_Mailing_BaseMailingSystemTest extends CiviUnitTestCase {
         // Default footer
         "Sample Footer for HTML formatted content" .
         ".*\n" .
-        "<img src=\".*extern/open.php.*\"" .
+        "<img src=\".*(extern/open.php|civicrm/mailing/open).*\"" .
         ";",
         $htmlPart->text
       );
@@ -206,7 +206,7 @@ abstract class CRM_Mailing_BaseMailingSystemTest extends CiviUnitTestCase {
         "Sample Footer for HTML formatted content" .
         ".*\n" .
         // Open-tracking code
-        "<img src=\".*extern/open.php.*\"" .
+        "<img src=\".*(extern/open.php|civicrm/mailing/open).*\"" .
         ";",
         $htmlPart->text
       );

--- a/tests/phpunit/CRM/Mailing/BaseMailingSystemTest.php
+++ b/tests/phpunit/CRM/Mailing/BaseMailingSystemTest.php
@@ -306,7 +306,7 @@ abstract class CRM_Mailing_BaseMailingSystemTest extends CiviUnitTestCase {
       ';Look at \.;',
       ['url_tracking' => 1],
     ];
-    $cases[8] = [
+    $cases[9] = [
       // Plain-text URL's are tracked in plain-text emails...
       // but not in HTML emails.
       "<p>Please go to: http://example.net/</p>",


### PR DESCRIPTION
Overview
----------------------------------------

Update CiviMail's default behavior to replace `extern/open.php` and `extern/url.php` with `civicrm/mailing/open` and `civicrm/mailing/url`.

This is an update/replacement for #17084. It contributes towards multiple issues - e.g. https://lab.civicrm.org/dev/drupal/-/issues/9, https://lab.civicrm.org/dev/drupal/-/issues/77, https://lab.civicrm.org/dev/core/-/issues/1708, and possibly https://lab.civicrm.org/dev/mail/-/issues/17

Before
----------------------------------------

* CiviMail accepts callbacks at these URLs:
   * `http://example.com/...codepath.../civicrm/extern/url.php?u=NNN&qid=NNN`
   * `http://example.com/...codepath.../civicrm/extern/open.php?q=NNN`
* When composing CiviMail messages, the links always point to those two locations.

After
----------------------------------------

* CiviMail accepts callbacks at these URLs:
   * `http://example.com/...codepath.../civicrm/extern/url.php?u=NNN&qid=NNN` (same)
   * `http://example.com/...codepath.../civicrm/extern/open.php?q=NNN` (same)
   * `http://example.com/civicrm/mailing/url?u=NNN&qid=NNN` (new)
   * `http://example.com/civicrm/mailing/open?qid=NNN` (new; note: 'q` becomes `qid`)
* When composing CiviMail messages, the links obey a setting (`defaultExternUrl=router` or `defaultExternUrl=standalone`). The default is `router`.
* The setting is available in "System Settings => Resource URLs".
    <img width="1011" alt="Screen Shot 2020-05-13 at 12 28 01 AM" src="https://user-images.githubusercontent.com/1336047/81783774-b3ce0600-94b0-11ea-9ef7-12202889c86e.png">

Technical Details
----------------------------------------

This is an update/replacement for #17084. Some distinguishing characteristics are:

* It addresses `extern/open` in addition to `extern/url`.
* When preparing callback URLs, it still goes through the same API as before (`CRM_Utils_System::externUrl()`). This should mean that `wp-civi-rest` and `flexmailer` can get decent forward/backward compatibility by using that API.
* It allows for a gentler transition - if the new routes have some problematic edge-case, then you can switch back.

Why allow the option? It's a hedge against some of risks/edges invovled.

* Some sites may use `settings_location.php` and/or customized boot logic (for multisite/URL dynamism). While these ought to work better out-of-the-box, it's an open-space and hard to verify from my POV.
* Moving to the CMS/Civi router has two potential impacts on performance. 
     * When going through a framework, one is more prone to unexpected session-initialization - which is undesirable for webmail clicks.
     * There will be a full bootstrap, which can add latency to handling clickthroughs.
     * (*One would expect these to be acceptable/manageable, but that's not an empirical or objective judgment and may require some real-world usage to fully shake-out.*)

Of course, there are several upsides:

* The bootstrap is more typical (which is notably useful on WP - and should reduce the need for `setting_location.php`-style customizations).
* These PHP files don't need to be exposed to the web (which is notably useful on D8).
* The `extern/url.php` replacement supports `hook_civicrm_alterRedirect`. Compared to `hook_civicrm_alterMailParams` (which was reportedly used circa v3.3 to customize click-through tracker URLs), this is a simpler and safer way to programmatically supplement click-through URLs.

Going forward, when we tackle migrations for some other `extern` scripts, the setting `defaultExternUrl` and the function `migrateExternUrl()` may come in handy again.