### PR TITLE
dev/core#1760 - Fix quoting in js context for warning on SMTP settings page

### DIFF
--- a/templates/CRM/Admin/Form/Setting/Smtp.tpl
+++ b/templates/CRM/Admin/Form/Setting/Smtp.tpl
@@ -93,7 +93,7 @@
     CRM.$(function($) {
       var mailSetting = $("input[name='outBound_option']:checked").val( );
 
-      var archiveWarning = "{/literal}{ts escape='js'}WARNING: You are switching from a testing mode (Redirect to Database) to a live mode. Check Mailings > Archived Mailings, and delete any test mailings that are not in Completed status prior to running the mailing cron job for the first time. This will ensure that test mailings are not actually sent out.{/ts}{literal}"
+      var archiveWarning = '{/literal}{ts escape="js"}WARNING: You are switching from a testing mode (Redirect to Database) to a live mode. Check Mailings > Archived Mailings, and delete any test mailings that are not in Completed status prior to running the mailing cron job for the first time. This will ensure that test mailings are not actually sent out.{/ts}{literal}';
 
         showHideMailOptions( $("input[name='outBound_option']:checked").val( ) ) ;
 


### PR DESCRIPTION
Overview
----------------------------------------
Came up in chat https://chat.civicrm.org/civicrm/pl/zbgx8a3rjfgz9jfapdmpsn1nhe

https://lab.civicrm.org/dev/core/-/issues/1760

On the SMTP settings admin page, there's a warning when you switch from Redirect to database to a live mode. In French the translation has double-quotes, but js-escaping does single quotes and expects the terminator to be single quotes.

To reproduce, switch language to french and visit the admin smtp settings page. Look in the browser javascript console and you'll see the error.

Before
----------------------------------------
js error when translation contains double-quotes

After
----------------------------------------
no js error

Technical Details
----------------------------------------
Also it was missing a semicolon at the end, but the browser doesn't care.

Comments
----------------------------------------

