### PR TITLE
Extend icon helper support, including for formLink

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -1290,7 +1290,8 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution {
       if (empty($resultDAO->payment_processor_id) && CRM_Core_Permission::check('edit contributions')) {
         $links = [
           CRM_Core_Action::UPDATE => [
-            'name' => "<i class='crm-i fa-pencil'></i>",
+            'name' => ts('Edit Payment'),
+            'icon' => 'fa-pencil',
             'url' => 'civicrm/payment/edit',
             'class' => 'medium-popup',
             'qs' => "reset=1&id=%%id%%&contribution_id=%%contribution_id%%",

--- a/CRM/Core/Action.php
+++ b/CRM/Core/Action.php
@@ -247,7 +247,7 @@ class CRM_Core_Action {
           $urlPath,
           $classes,
           !empty($link['title']) ? "title='{$link['title']}' " : '',
-          $link['name']
+          empty($link['icon']) ? $link['name'] : CRM_Core_Page::crmIcon($link['icon'], $link['name'], TRUE, ['title' => ''])
         );
       }
     }

--- a/CRM/Core/Page.php
+++ b/CRM/Core/Page.php
@@ -431,23 +431,45 @@ class CRM_Core_Page {
    * @param bool $condition
    *   Whether to display anything at all. This helps simplify code when a
    *   checkmark should appear if something is true.
+   * @param array $attribs
+   *   Attributes to set or override on the icon element.  Any standard
+   *   attribute can be unset by setting the value to an empty string.
    *
    * @return string
    *   The whole bit to drop in.
    */
-  public static function crmIcon($icon, $text = NULL, $condition = TRUE) {
+  public static function crmIcon($icon, $text = NULL, $condition = TRUE, $attribs = []) {
     if (!$condition) {
       return '';
     }
+
+    // Add icon classes to any that might exist in $attribs
+    $classes = array_key_exists('class', $attribs) ? explode(' ', $attribs['class']) : [];
+    $classes[] = 'crm-i';
+    $classes[] = $icon;
+    $attribs['class'] = implode(' ', array_unique($classes));
+
+    $standardAttribs = ['aria-hidden' => 'true'];
     if ($text === NULL || $text === '') {
       $title = $sr = '';
     }
     else {
-      $text = htmlspecialchars($text);
-      $title = " title=\"$text\"";
+      $standardAttribs['title'] = $text;
       $sr = "<span class=\"sr-only\">$text</span>";
     }
-    return "<i class=\"crm-i $icon\"$title></i>$sr";
+
+    // Assemble attribs
+    $attribString = '';
+    // Strip out title if $attribs specifies a blank title
+    $attribs = array_merge($standardAttribs, $attribs);
+    foreach ($attribs as $attrib => $val) {
+      if (strlen($val)) {
+        $val = htmlspecialchars($val);
+        $attribString .= " $attrib=\"$val\"";
+      }
+    }
+
+    return "<i$attribString></i>$sr";
   }
 
 }

--- a/CRM/Core/Smarty/plugins/block.icon.php
+++ b/CRM/Core/Smarty/plugins/block.icon.php
@@ -25,6 +25,7 @@
  * @param $params
  *   - condition: if present and falsey, return empty
  *   - icon: the icon class to display instead of fa-check
+ *   - anything else is passed along as attributes for the icon
  *
  * @param $text
  *   The translated text to include in the icon's title and screen-reader text.
@@ -36,5 +37,9 @@
 function smarty_block_icon($params, $text, &$smarty) {
   $condition = array_key_exists('condition', $params) ? $params['condition'] : 1;
   $icon = $params['icon'] ?? 'fa-check';
-  return CRM_Core_Page::crmIcon($icon, $text, $condition);
+  $dontPass = [
+    'condition' => 1,
+    'icon' => 1,
+  ];
+  return CRM_Core_Page::crmIcon($icon, $text, $condition, array_diff_key($params, $dontPass));
 }

--- a/tests/phpunit/CRM/Core/PageTest.php
+++ b/tests/phpunit/CRM/Core/PageTest.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * Class CRM_Core_PageTest
+ * @group headless
+ */
+class CRM_Core_PageTest extends CiviUnitTestCase {
+
+  /**
+   * Test data for testMakeIcons
+   *
+   * @return array
+   */
+  public function iconTestData() {
+    // first item is icon, text, condition, and attribs, second is expected markup
+    return [
+      [
+        '<i aria-hidden="true" title="We have a winner" class="crm-i fa-trophy"></i><span class="sr-only">We have a winner</span>',
+        ['fa-trophy', 'We have a winner', TRUE, []],
+        '{icon icon="fa-trophy"}We have a winner{/icon}',
+      ],
+      [
+        '',
+        ['fa-trophy', 'We have a winner', 0, []],
+        '{icon icon="fa-trophy" condition=0}We have a winner{/icon}',
+      ],
+      [
+        '<i aria-hidden="true" title="Favorite" class="action-icon test-icon crm-i fa-heart"></i><span class="sr-only">Favorite</span>',
+        ['fa-heart', 'Favorite', TRUE, ['class' => 'action-icon test-icon']],
+        '{icon icon="fa-heart" class="action-icon test-icon"}Favorite{/icon}',
+      ],
+      [
+        '<i aria-hidden="true" title="I &quot;choo-choo&quot; choose you" class="crm-i fa-train"></i><span class="sr-only">I "choo-choo" choose you</span>',
+        ['fa-train', 'I "choo-choo" choose you', TRUE, []],
+        '{icon icon="fa-train"}I "choo-choo" choose you{/icon}',
+      ],
+      [
+        '<i aria-hidden="true" class="crm-i fa-trash"></i><span class="sr-only">Trash</span>',
+        ['fa-trash', 'Trash', TRUE, ['title' => '']],
+        '{icon icon="fa-trash" title=""}Trash{/icon}',
+      ],
+      [
+        '<i title="It\'s bedtime" class="crm-i fa-bed"></i><span class="sr-only">It\'s bedtime</span>',
+        ['fa-bed', "It's bedtime", TRUE, ['aria-hidden' => '']],
+        // Ye olde Smarty 2 doesn't support hyphenated function parameters
+      ],
+      [
+        '<i aria-hidden="true" class="crm-i fa-snowflake-o"></i>',
+        ['fa-snowflake-o', NULL, TRUE, []],
+        '{icon icon="fa-snowflake-o"}{/icon}',
+      ],
+    ];
+  }
+
+  /**
+   * Test that icons are formed properly
+   *
+   * @param string $expectedMarkup
+   * @param array $params
+   * @param string $smartyFunc
+   * @dataProvider iconTestData
+   */
+  public function testMakeIcons($expectedMarkup, $params, $smartyFunc = '') {
+    list($icon, $text, $condition, $attribs) = $params;
+    $this->assertEquals($expectedMarkup, CRM_Core_Page::crmIcon($icon, $text, $condition, $attribs));
+    if (!empty($smartyFunc)) {
+      $smarty = CRM_Core_Smarty::singleton();
+      $actual = $smarty->fetch('string:' . $smartyFunc);
+      $this->assertEquals($expectedMarkup, $actual, "Process input=[$smartyFunc]");
+    }
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
The `CRM_Core_Action::formLink()` function is what prepares the edit/disable/delete items at the ends of most rows.  It's what sends most things through to `hook_civicrm_links()`.

The "Edit Payment" link on (viewing a contribution) formed an icon-only link by sending the icon markup through as the `name` on one of these links.  It just seems wrong:
https://github.com/civicrm/civicrm-core/blob/a0a0da016a4b6162877fc9e4197e0cec77b1c67f/CRM/Contribute/BAO/Contribution.php#L1291-L1299

It also lacks any text for a screen reader, and adding that to the `name` would be even uglier.

However, the visual result isn't too bad--it makes a pencil icon for the edit link:
![image](https://user-images.githubusercontent.com/1682375/81874153-491dd880-954b-11ea-9a0b-161ee580c819.png)

I decided it would make sense to make `CRM_Core_Action::formLink()` (and thus `hook_civicrm_links()`) produce an icon-only link with screen reader text.  This PR makes it such that adding a value to the link array for `icon` will display the link as that icon only, with the `name` providing screen reader text and the `title` providing hover text as always.

To support this, I allowed `CRM_Core_Page::crmIcon()` to take an array of extra attributes for the icon, and `{icon}` now passes any extra function attributes to that array.

Since there's now a lot of functionality riding on these icon helpers, I added a unit test with a bunch of test cases.

Before
----------------------------------------
The Edit Payment link has a bunch of HTML as its `name`.

After
----------------------------------------
When an item is passed to `CRM_Core_Action::formLink()` with a value for `icon`, the link displays as that icon, with the `name` as the screen reader text and the `title` as the title.

`CRM_Core_Page::crmIcon()` and `{icon}` now can add extra HTML attributes.

Technical Details
----------------------------------------
Overall this belongs with #17285 in the theme of "don't send markup; let things be themed later".

Comments
----------------------------------------
This PR does *not* do this, but as a proof-of-concept, these changes could support turning all of the links in a selector into icons like this:
![image](https://user-images.githubusercontent.com/1682375/81874834-ca299f80-954c-11ea-818c-9210fa3d1757.png)

