### PR TITLE
(NFC) CRM_Utils_Url - Fix declared type

### DIFF
--- a/CRM/Utils/Url.php
+++ b/CRM/Utils/Url.php
@@ -19,7 +19,7 @@ class CRM_Utils_Url {
    *
    * @param string $url
    *
-   * @return \GuzzleHttp\Psr7\UriInterface
+   * @return \Psr\Http\Message\UriInterface
    */
   public static function parseUrl($url) {
     return new Uri($url);
@@ -28,7 +28,7 @@ class CRM_Utils_Url {
   /**
    * Unparse url back to a string.
    *
-   * @param \GuzzleHttp\Psr7\UriInterface $parsed
+   * @param \Psr\Http\Message\UriInterface $parsed
    *
    * @return string
    */


### PR DESCRIPTION
Before
------

References a non-existent type `\GuzzleHttp\Psr7\UriInterface`.

After
-----

References an existent type `\Psr\Http\Message\UriInterface`.
