### PR TITLE
Remove using the ambiguous $_REQUEST

### DIFF
--- a/CRM/Activity/Form/ActivityLinks.php
+++ b/CRM/Activity/Form/ActivityLinks.php
@@ -30,7 +30,7 @@ class CRM_Activity_Form_ActivityLinks extends CRM_Core_Form {
   public static function commonBuildQuickForm($self) {
     $contactId = CRM_Utils_Request::retrieve('cid', 'Positive', $self);
     if (!$contactId) {
-      $contactId = CRM_Utils_Request::retrieve('cid', 'Positive', CRM_Core_DAO::$_nullObject, FALSE, NULL, $_REQUEST);
+      $contactId = CRM_Utils_Request::retrieve('cid', 'Positive', CRM_Core_DAO::$_nullObject, FALSE, NULL);
     }
     $urlParams = "action=add&reset=1&cid={$contactId}&selectedChild=activity&atype=";
 

--- a/CRM/Admin/Form/Setting/UpdateConfigBackend.php
+++ b/CRM/Admin/Form/Setting/UpdateConfigBackend.php
@@ -44,7 +44,7 @@ class CRM_Admin_Form_Setting_UpdateConfigBackend extends CRM_Admin_Form_Setting 
   }
 
   public function postProcess() {
-    if (isset($_REQUEST['_qf_UpdateConfigBackend_next_cleanup'])) {
+    if (($_POST['_qf_UpdateConfigBackend_next_cleanup'] ?? $_GET['_qf_UpdateConfigBackend_next_cleanup'] ?? NULL) !== NULL) {
       $config = CRM_Core_Config::singleton();
 
       // cleanup templates_c directory
@@ -61,7 +61,7 @@ class CRM_Admin_Form_Setting_UpdateConfigBackend extends CRM_Admin_Form_Setting 
 
       CRM_Core_Session::setStatus(ts('Cache has been cleared and menu has been rebuilt successfully.'), ts("Success"), "success");
     }
-    elseif (isset($_REQUEST['_qf_UpdateConfigBackend_next_resetpaths'])) {
+    elseif (($_POST['_qf_UpdateConfigBackend_next_resetpaths'] ?? $_GET['_qf_UpdateConfigBackend_next_resetpaths'] ?? NULL) !== NULL) {
       $msg = CRM_Core_BAO_ConfigSetting::doSiteMove();
 
       CRM_Core_Session::setStatus($msg, ts("Success"), "success");

--- a/CRM/Admin/Page/AJAX.php
+++ b/CRM/Admin/Page/AJAX.php
@@ -418,7 +418,7 @@ class CRM_Admin_Page_AJAX {
       $result = array_values(array_unique($result));
     }
 
-    if (!empty($_REQUEST['is_unit_test'])) {
+    if (!empty($_POST['is_unit_test'] ?? $_GET['is_unit_test'] ?? NULL)) {
       return $result;
     }
 

--- a/CRM/Admin/Page/CKEditorConfig.php
+++ b/CRM/Admin/Page/CKEditorConfig.php
@@ -53,7 +53,7 @@ class CRM_Admin_Page_CKEditorConfig extends CRM_Core_Page {
    * @return string
    */
   public function run() {
-    $this->preset = CRM_Utils_Array::value('preset', $_REQUEST, 'default');
+    $this->preset = CRM_Utils_Request::retrieveValue('preset', 'String', 'default');
 
     // If the form was submitted, take appropriate action.
     if (!empty($_POST['revert'])) {

--- a/CRM/Batch/Page/AJAX.php
+++ b/CRM/Batch/Page/AJAX.php
@@ -59,13 +59,16 @@ class CRM_Batch_Page_AJAX {
         6 => 'created_id.sort_name',
       ];
     }
-    $sEcho = CRM_Utils_Type::escape($_REQUEST['sEcho'], 'Integer');
-    $offset = isset($_REQUEST['iDisplayStart']) ? CRM_Utils_Type::escape($_REQUEST['iDisplayStart'], 'Integer') : 0;
-    $rowCount = isset($_REQUEST['iDisplayLength']) ? CRM_Utils_Type::escape($_REQUEST['iDisplayLength'], 'Integer') : 25;
-    $sort = isset($_REQUEST['iSortCol_0']) ? CRM_Utils_Array::value(CRM_Utils_Type::escape($_REQUEST['iSortCol_0'], 'Integer'), $sortMapper) : NULL;
-    $sortOrder = isset($_REQUEST['sSortDir_0']) ? CRM_Utils_Type::escape($_REQUEST['sSortDir_0'], 'String') : 'asc';
 
-    $params = $_REQUEST;
+    // POST takes precedence over GET:
+    $params = array_merge($_GET, $_POST);
+
+    $sEcho = CRM_Utils_Type::escape($params['sEcho'], 'Integer');
+    $offset = isset($params['iDisplayStart']) ? CRM_Utils_Type::escape($params['iDisplayStart'], 'Integer') : 0;
+    $rowCount = isset($params['iDisplayLength']) ? CRM_Utils_Type::escape($params['iDisplayLength'], 'Integer') : 25;
+    $sort = isset($params['iSortCol_0']) ? CRM_Utils_Array::value(CRM_Utils_Type::escape($params['iSortCol_0'], 'Integer'), $sortMapper) : NULL;
+    $sortOrder = isset($params['sSortDir_0']) ? CRM_Utils_Type::escape($params['sSortDir_0'], 'String') : 'asc';
+
     if ($sort && $sortOrder) {
       $params['sortBy'] = $sort . ' ' . $sortOrder;
     }

--- a/CRM/Contact/Controller/Search.php
+++ b/CRM/Contact/Controller/Search.php
@@ -71,10 +71,10 @@ class CRM_Contact_Controller_Search extends CRM_Core_Controller {
     }
     elseif (
       strpos($qString, 'custom') !== FALSE &&
-      isset($_REQUEST['csid'])
+      ($_POST['csid'] ?? $_GET['csid'] ?? NULL) !== NULL
     ) {
       $path = 'civicrm/contact/search/custom';
-      $args = "reset=1&csid={$_REQUEST['csid']}";
+      $args = "reset=1&csid=" . rawurlencode($_POST['csid'] ?? $_GET['csid']);
     }
 
     $url = CRM_Utils_System::url($path, $args);

--- a/CRM/Contact/Form/Inline.php
+++ b/CRM/Contact/Form/Inline.php
@@ -56,7 +56,7 @@ abstract class CRM_Contact_Form_Inline extends CRM_Core_Form {
    * Common preprocess: fetch contact ID and contact type
    */
   public function preProcess() {
-    $this->_contactId = CRM_Utils_Request::retrieve('cid', 'Positive', $this, TRUE, NULL, $_REQUEST);
+    $this->_contactId = CRM_Utils_Request::retrieve('cid', 'Positive', $this, TRUE, NULL);
     $this->assign('contactId', $this->_contactId);
 
     // get contact type and subtype

--- a/CRM/Contact/Form/Inline/Address.php
+++ b/CRM/Contact/Form/Inline/Address.php
@@ -58,7 +58,7 @@ class CRM_Contact_Form_Inline_Address extends CRM_Contact_Form_Inline {
    * hence calling parent constructor
    */
   public function __construct() {
-    $locBlockNo = CRM_Utils_Request::retrieve('locno', 'Positive', CRM_Core_DAO::$_nullObject, TRUE, NULL, $_REQUEST);
+    $locBlockNo = CRM_Utils_Request::retrieve('locno', 'Positive', CRM_Core_DAO::$_nullObject, TRUE, NULL);
     $name = "Address_{$locBlockNo}";
 
     parent::__construct(NULL, CRM_Core_Action::NONE, 'post', $name);
@@ -70,14 +70,14 @@ class CRM_Contact_Form_Inline_Address extends CRM_Contact_Form_Inline {
   public function preProcess() {
     parent::preProcess();
 
-    $this->_locBlockNo = CRM_Utils_Request::retrieve('locno', 'Positive', $this, TRUE, NULL, $_REQUEST);
+    $this->_locBlockNo = CRM_Utils_Request::retrieve('locno', 'Positive', $this, TRUE, NULL);
     $this->assign('blockId', $this->_locBlockNo);
 
     $addressSequence = CRM_Core_BAO_Address::addressSequence();
     $this->assign('addressSequence', $addressSequence);
 
     $this->_values = [];
-    $this->_addressId = CRM_Utils_Request::retrieve('aid', 'Positive', $this, FALSE, NULL, $_REQUEST);
+    $this->_addressId = CRM_Utils_Request::retrieve('aid', 'Positive', $this, FALSE, NULL);
 
     $this->_action = CRM_Core_Action::ADD;
     if ($this->_addressId) {

--- a/CRM/Contact/Form/Inline/CustomData.php
+++ b/CRM/Contact/Form/Inline/CustomData.php
@@ -40,10 +40,10 @@ class CRM_Contact_Form_Inline_CustomData extends CRM_Contact_Form_Inline {
   public function preProcess() {
     parent::preProcess();
 
-    $this->_groupID = CRM_Utils_Request::retrieve('groupID', 'Positive', $this, TRUE, NULL, $_REQUEST);
+    $this->_groupID = CRM_Utils_Request::retrieve('groupID', 'Positive', $this, TRUE, NULL);
     $this->assign('customGroupId', $this->_groupID);
-    $customRecId = CRM_Utils_Request::retrieve('customRecId', 'Positive', $this, FALSE, 1, $_REQUEST);
-    $cgcount = CRM_Utils_Request::retrieve('cgcount', 'Positive', $this, FALSE, 1, $_REQUEST);
+    $customRecId = CRM_Utils_Request::retrieve('customRecId', 'Positive', $this, FALSE, 1);
+    $cgcount = CRM_Utils_Request::retrieve('cgcount', 'Positive', $this, FALSE, 1);
     $subType = CRM_Contact_BAO_Contact::getContactSubType($this->_contactId, ',');
     CRM_Custom_Form_CustomData::preProcess($this, NULL, $subType, $cgcount,
       $this->_contactType, $this->_contactId);

--- a/CRM/Contact/Form/Search.php
+++ b/CRM/Contact/Form/Search.php
@@ -526,8 +526,8 @@ class CRM_Contact_Form_Search extends CRM_Core_Form_Search {
     $this->_ssID = CRM_Utils_Request::retrieve('ssID', 'Positive', $this);
     $this->_sortByCharacter = CRM_Utils_Request::retrieve('sortByCharacter', 'String', $this);
     $this->_ufGroupID = CRM_Utils_Request::retrieve('id', 'Positive', $this);
-    $this->_componentMode = CRM_Utils_Request::retrieve('component_mode', 'Positive', $this, FALSE, CRM_Contact_BAO_Query::MODE_CONTACTS, $_REQUEST);
-    $this->_operator = CRM_Utils_Request::retrieve('operator', 'String', $this, FALSE, CRM_Contact_BAO_Query::SEARCH_OPERATOR_AND, 'REQUEST');
+    $this->_componentMode = CRM_Utils_Request::retrieve('component_mode', 'Positive', $this, FALSE, CRM_Contact_BAO_Query::MODE_CONTACTS);
+    $this->_operator = CRM_Utils_Request::retrieve('operator', 'String', $this, FALSE, CRM_Contact_BAO_Query::SEARCH_OPERATOR_AND);
 
     /**
      * set the button names

--- a/CRM/Contact/Form/Search/Custom/FullText.php
+++ b/CRM/Contact/Form/Search/Custom/FullText.php
@@ -105,8 +105,8 @@ class CRM_Contact_Form_Search_Custom_FullText extends CRM_Contact_Form_Search_Cu
       // 1. this custom search has slightly different structure ,
       // 2. we are in constructor right now,
       // we 'll use a small hack -
-      $rowCount = CRM_Utils_Array::value('crmRowCount', $_REQUEST, CRM_Utils_Pager::ROWCOUNT);
-      $pageId = CRM_Utils_Array::value('crmPID', $_REQUEST, 1);
+      $rowCount = CRM_Utils_Request::retrieveValue('crmRowCount', 'Positive', CRM_Utils_Pager::ROWCOUNT);
+      $pageId = CRM_Utils_Request::retrieveValue('crmPID', 'Positive', 1);
       $offset = ($pageId - 1) * $rowCount;
       $this->_limitClause = NULL;
       $this->_limitRowClause = [$rowCount, NULL];

--- a/CRM/Contact/Page/Inline/Actions.php
+++ b/CRM/Contact/Page/Inline/Actions.php
@@ -26,7 +26,7 @@ class CRM_Contact_Page_Inline_Actions extends CRM_Core_Page {
    * This method is called after the page is created.
    */
   public function run() {
-    $contactId = CRM_Utils_Request::retrieve('cid', 'Positive', CRM_Core_DAO::$_nullObject, TRUE, NULL, $_REQUEST);
+    $contactId = CRM_Utils_Request::retrieve('cid', 'Positive', CRM_Core_DAO::$_nullObject, TRUE, NULL);
 
     $this->assign('contactId', $contactId);
     $this->assign('actionsMenuList', CRM_Contact_BAO_Contact::contextMenu($contactId));

--- a/CRM/Contact/Page/Inline/Address.php
+++ b/CRM/Contact/Page/Inline/Address.php
@@ -27,9 +27,9 @@ class CRM_Contact_Page_Inline_Address extends CRM_Core_Page {
    */
   public function run() {
     // get the emails for this contact
-    $contactId = CRM_Utils_Request::retrieve('cid', 'Positive', CRM_Core_DAO::$_nullObject, TRUE, NULL, $_REQUEST);
-    $locBlockNo = CRM_Utils_Request::retrieve('locno', 'Positive', CRM_Core_DAO::$_nullObject, TRUE, NULL, $_REQUEST);
-    $addressId = CRM_Utils_Request::retrieve('aid', 'Positive', CRM_Core_DAO::$_nullObject, FALSE, NULL, $_REQUEST);
+    $contactId = CRM_Utils_Request::retrieve('cid', 'Positive', CRM_Core_DAO::$_nullObject, TRUE, NULL);
+    $locBlockNo = CRM_Utils_Request::retrieve('locno', 'Positive', CRM_Core_DAO::$_nullObject, TRUE, NULL);
+    $addressId = CRM_Utils_Request::retrieve('aid', 'Positive', CRM_Core_DAO::$_nullObject, FALSE, NULL);
 
     $address = [];
     if ($addressId > 0) {

--- a/CRM/Contact/Page/Inline/ContactInfo.php
+++ b/CRM/Contact/Page/Inline/ContactInfo.php
@@ -27,7 +27,7 @@ class CRM_Contact_Page_Inline_ContactInfo extends CRM_Core_Page {
    */
   public function run() {
     // get the emails for this contact
-    $contactId = CRM_Utils_Request::retrieve('cid', 'Positive', CRM_Core_DAO::$_nullObject, TRUE, NULL, $_REQUEST);
+    $contactId = CRM_Utils_Request::retrieve('cid', 'Positive', CRM_Core_DAO::$_nullObject, TRUE, NULL);
 
     $params = ['id' => $contactId];
 

--- a/CRM/Contact/Page/Inline/ContactName.php
+++ b/CRM/Contact/Page/Inline/ContactName.php
@@ -27,7 +27,7 @@ class CRM_Contact_Page_Inline_ContactName extends CRM_Core_Page {
    */
   public function run() {
     // get the emails for this contact
-    $contactId = CRM_Utils_Request::retrieve('cid', 'Positive', CRM_Core_DAO::$_nullObject, TRUE, NULL, $_REQUEST);
+    $contactId = CRM_Utils_Request::retrieve('cid', 'Positive', CRM_Core_DAO::$_nullObject, TRUE, NULL);
 
     $isDeleted = (bool) CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Contact', $contactId, 'is_deleted');
 

--- a/CRM/Contact/Page/Inline/CustomData.php
+++ b/CRM/Contact/Page/Inline/CustomData.php
@@ -27,10 +27,10 @@ class CRM_Contact_Page_Inline_CustomData extends CRM_Core_Page {
    */
   public function run() {
     // get the emails for this contact
-    $contactId = CRM_Utils_Request::retrieve('cid', 'Positive', CRM_Core_DAO::$_nullObject, TRUE, NULL, $_REQUEST);
-    $cgId = CRM_Utils_Request::retrieve('groupID', 'Positive', CRM_Core_DAO::$_nullObject, TRUE, NULL, $_REQUEST);
-    $customRecId = CRM_Utils_Request::retrieve('customRecId', 'Positive', CRM_Core_DAO::$_nullObject, FALSE, 1, $_REQUEST);
-    $cgcount = CRM_Utils_Request::retrieve('cgcount', 'Positive', CRM_Core_DAO::$_nullObject, FALSE, 1, $_REQUEST);
+    $contactId = CRM_Utils_Request::retrieve('cid', 'Positive', CRM_Core_DAO::$_nullObject, TRUE, NULL);
+    $cgId = CRM_Utils_Request::retrieve('groupID', 'Positive', CRM_Core_DAO::$_nullObject, TRUE, NULL);
+    $customRecId = CRM_Utils_Request::retrieve('customRecId', 'Positive', CRM_Core_DAO::$_nullObject, FALSE, 1);
+    $cgcount = CRM_Utils_Request::retrieve('cgcount', 'Positive', CRM_Core_DAO::$_nullObject, FALSE, 1);
 
     //custom groups Inline
     $entityType = CRM_Contact_BAO_Contact::getContactType($contactId);

--- a/CRM/Contact/Page/Inline/Demographics.php
+++ b/CRM/Contact/Page/Inline/Demographics.php
@@ -27,7 +27,7 @@ class CRM_Contact_Page_Inline_Demographics extends CRM_Core_Page {
    */
   public function run() {
     // get the emails for this contact
-    $contactId = CRM_Utils_Request::retrieve('cid', 'Positive', CRM_Core_DAO::$_nullObject, TRUE, NULL, $_REQUEST);
+    $contactId = CRM_Utils_Request::retrieve('cid', 'Positive', CRM_Core_DAO::$_nullObject, TRUE, NULL);
 
     $params = ['id' => $contactId];
 

--- a/CRM/Contact/Page/Inline/Email.php
+++ b/CRM/Contact/Page/Inline/Email.php
@@ -27,7 +27,7 @@ class CRM_Contact_Page_Inline_Email extends CRM_Core_Page {
    */
   public function run() {
     // get the emails for this contact
-    $contactId = CRM_Utils_Request::retrieve('cid', 'Positive', CRM_Core_DAO::$_nullObject, TRUE, NULL, $_REQUEST);
+    $contactId = CRM_Utils_Request::retrieve('cid', 'Positive', CRM_Core_DAO::$_nullObject, TRUE, NULL);
 
     $locationTypes = CRM_Core_PseudoConstant::get('CRM_Core_DAO_Address', 'location_type_id', ['labelColumn' => 'display_name']);
 

--- a/CRM/Contact/Page/Inline/IM.php
+++ b/CRM/Contact/Page/Inline/IM.php
@@ -27,7 +27,7 @@ class CRM_Contact_Page_Inline_IM extends CRM_Core_Page {
    */
   public function run() {
     // get the emails for this contact
-    $contactId = CRM_Utils_Request::retrieve('cid', 'Positive', CRM_Core_DAO::$_nullObject, TRUE, NULL, $_REQUEST);
+    $contactId = CRM_Utils_Request::retrieve('cid', 'Positive', CRM_Core_DAO::$_nullObject, TRUE, NULL);
 
     $locationTypes = CRM_Core_PseudoConstant::get('CRM_Core_DAO_Address', 'location_type_id', ['labelColumn' => 'display_name']);
     $IMProviders = CRM_Core_PseudoConstant::get('CRM_Core_DAO_IM', 'provider_id');

--- a/CRM/Core/Controller.php
+++ b/CRM/Core/Controller.php
@@ -208,7 +208,7 @@ class CRM_Core_Controller extends HTML_QuickForm_Controller {
 
     parent::__construct($name, $modal);
 
-    $snippet = $_REQUEST['snippet'] ?? NULL;
+    $snippet = $_POST['snippet'] ?? $_GET['snippet'] ?? NULL;
     if ($snippet) {
       if ($snippet == 3) {
         $this->_print = CRM_Core_Smarty::PRINT_PDF;
@@ -255,8 +255,7 @@ class CRM_Core_Controller extends HTML_QuickForm_Controller {
       'String',
       $this,
       FALSE,
-      NULL,
-      $_REQUEST
+      NULL
     );
   }
 
@@ -284,7 +283,7 @@ class CRM_Core_Controller extends HTML_QuickForm_Controller {
       return NULL;
     }
 
-    $key = $_REQUEST['qfKey'] ?? NULL;
+    $key = CRM_Utils_Request::retrieveValue('qfKey', 'String');
     if (!$key && $_SERVER['REQUEST_METHOD'] === 'GET') {
       $key = CRM_Core_Key::get($name, $addSequence);
     }

--- a/CRM/Core/Error.php
+++ b/CRM/Core/Error.php
@@ -341,7 +341,7 @@ class CRM_Core_Error extends PEAR_ErrorStack {
     CRM_Core_Error::backtrace('backTrace', TRUE);
 
     // If we are in an ajax callback, format output appropriately
-    if (CRM_Utils_Array::value('snippet', $_REQUEST) === CRM_Core_Smarty::PRINT_JSON) {
+    if (CRM_Utils_Request::retrieveValue('snippet', 'String') === CRM_Core_Smarty::PRINT_JSON) {
       $out = [
         'status' => 'fatal',
         'content' => '<div class="messages status no-popup"><div class="icon inform-icon"></div>' . ts('Sorry but we are not able to provide this at the moment.') . '</div>',
@@ -888,7 +888,7 @@ class CRM_Core_Error extends PEAR_ErrorStack {
       $title = ts('Error');
     }
     $session->setStatus($status, $title, 'alert', ['expires' => 0]);
-    if (CRM_Utils_Array::value('snippet', $_REQUEST) === CRM_Core_Smarty::PRINT_JSON) {
+    if (CRM_Utils_Request::retrieveValue('snippet', 'String') === CRM_Core_Smarty::PRINT_JSON) {
       CRM_Core_Page_AJAX::returnJsonResponse(['status' => 'error']);
     }
     CRM_Utils_System::redirect($redirect);

--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -485,10 +485,8 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
     $this->postProcessHook();
 
     // Respond with JSON if in AJAX context (also support legacy value '6')
-    if ($allowAjax && !empty($_REQUEST['snippet']) && in_array($_REQUEST['snippet'], [
-      CRM_Core_Smarty::PRINT_JSON,
-      6,
-    ])) {
+    $snippet = $_POST['snippet'] ?? $_GET['snippet'] ?? NULL;
+    if ($allowAjax && in_array($snippet, [CRM_Core_Smarty::PRINT_JSON, 6])) {
       $this->ajaxResponse['buttonName'] = str_replace('_qf_' . $this->getAttribute('id') . '_', '', $this->controller->getButtonName());
       $this->ajaxResponse['action'] = $this->_action;
       if (isset($this->_id) || isset($this->id)) {

--- a/CRM/Core/IDS.php
+++ b/CRM/Core/IDS.php
@@ -57,13 +57,14 @@ class CRM_Core_IDS {
     $init = self::create(self::createRouteConfig($route));
 
     // Add request url and user agent.
-    $_REQUEST['IDS_request_uri'] = $_SERVER['REQUEST_URI'];
+    $request = array_merge($_GET, $_POST);
+    $request['IDS_request_uri'] = $_SERVER['REQUEST_URI'];
     if (isset($_SERVER['HTTP_USER_AGENT'])) {
-      $_REQUEST['IDS_user_agent'] = $_SERVER['HTTP_USER_AGENT'];
+      $request['IDS_user_agent'] = $_SERVER['HTTP_USER_AGENT'];
     }
 
     require_once 'IDS/Monitor.php';
-    $ids = new \IDS_Monitor($_REQUEST, $init);
+    $ids = new \IDS_Monitor($request, $init);
 
     $result = $ids->run();
     if (!$result->isEmpty()) {

--- a/CRM/Core/Invoke.php
+++ b/CRM/Core/Invoke.php
@@ -55,7 +55,7 @@ class CRM_Core_Invoke {
       return NULL;
     }
     // CRM-15901: Turn off PHP errors display for all ajax calls
-    if (CRM_Utils_Array::value(1, $args) == 'ajax' || !empty($_REQUEST['snippet'])) {
+    if (CRM_Utils_Array::value(1, $args) == 'ajax' || !empty($_POST['snippet'] ?? $_GET['snippet'] ?? NULL)) {
       ini_set('display_errors', 0);
     }
 

--- a/CRM/Core/Page.php
+++ b/CRM/Core/Page.php
@@ -119,16 +119,17 @@ class CRM_Core_Page {
     }
 
     // FIXME - why are we messing with 'snippet'? Why not just pass it directly into $this->_print?
-    if (!empty($_REQUEST['snippet'])) {
-      if ($_REQUEST['snippet'] == CRM_Core_Smarty::PRINT_PDF) {
+    $snippet = $_POST['snippet'] ?? $_GET['snippet'] ?? NULL;
+    if (!empty($snippet)) {
+      if ($snippet == CRM_Core_Smarty::PRINT_PDF) {
         $this->_print = CRM_Core_Smarty::PRINT_PDF;
       }
       // FIXME - why does this number not match the constant?
-      elseif ($_REQUEST['snippet'] == 5) {
+      elseif ($snippet == 5) {
         $this->_print = CRM_Core_Smarty::PRINT_NOFORM;
       }
       // Support 'json' as well as legacy value '6'
-      elseif (in_array($_REQUEST['snippet'], [CRM_Core_Smarty::PRINT_JSON, 6])) {
+      elseif (in_array($snippet, [CRM_Core_Smarty::PRINT_JSON, 6])) {
         $this->_print = CRM_Core_Smarty::PRINT_JSON;
       }
       else {
@@ -137,7 +138,7 @@ class CRM_Core_Page {
     }
 
     // if the request has a reset value, initialize the controller session
-    if (!empty($_REQUEST['reset'])) {
+    if (!empty($_POST['reset'] ?? $_GET['reset'] ?? NULL)) {
       $this->reset();
     }
   }

--- a/CRM/Core/Page/AJAX.php
+++ b/CRM/Core/Page/AJAX.php
@@ -27,10 +27,11 @@ class CRM_Core_Page_AJAX {
    *
    */
   public static function run() {
-    $className = CRM_Utils_Type::escape($_REQUEST['class_name'], 'String');
+    $request = array_merge($_GET, $_POST);
+    $className = CRM_Utils_Type::escape($request['class_name'], 'String');
     $type = '';
-    if (!empty($_REQUEST['type'])) {
-      $type = CRM_Utils_Type::escape($_REQUEST['type'], 'String');
+    if (!empty($request['type'])) {
+      $type = CRM_Utils_Type::escape($request['type'], 'String');
     }
 
     if (!$className) {
@@ -38,8 +39,8 @@ class CRM_Core_Page_AJAX {
     }
 
     $fnName = NULL;
-    if (isset($_REQUEST['fn_name'])) {
-      $fnName = CRM_Utils_Type::escape($_REQUEST['fn_name'], 'String');
+    if (isset($request['fn_name'])) {
+      $fnName = CRM_Utils_Type::escape($request['fn_name'], 'String');
     }
 
     if (!self::checkAuthz($type, $className, $fnName)) {
@@ -77,9 +78,10 @@ class CRM_Core_Page_AJAX {
    *
    */
   public static function setIsQuickConfig() {
-    $id = $context = NULL;
-    if (!empty($_REQUEST['id'])) {
-      $id = CRM_Utils_Type::escape($_REQUEST['id'], 'Integer');
+    $context = NULL;
+    $id = CRM_Utils_Request::retrieveValue('id', 'Positive');
+    if (!empty($id)) {
+      $id = CRM_Utils_Type::escape($id, 'Integer');
     }
 
     $context = CRM_Utils_Request::retrieve('context', 'Alphanumeric');

--- a/CRM/Core/Page/AJAX/Location.php
+++ b/CRM/Core/Page/AJAX/Location.php
@@ -194,8 +194,9 @@ class CRM_Core_Page_AJAX_Location {
   public static function getLocBlock() {
     // i wish i could retrieve loc block info based on loc_block_id,
     // Anyway, lets retrieve an event which has loc_block_id set to 'lbid'.
-    if ($_REQUEST['lbid']) {
-      $params = ['1' => [$_REQUEST['lbid'], 'Integer']];
+    $lbid = CRM_Utils_Request::retrieveValue('lbid', 'Integer');
+    if ($lbid) {
+      $params = ['1' => [$lbid, 'Integer']];
       $eventId = CRM_Core_DAO::singleValueQuery('SELECT id FROM civicrm_event WHERE loc_block_id=%1 LIMIT 1', $params);
     }
     // now lets use the event-id obtained above, to retrieve loc block information.
@@ -255,7 +256,7 @@ class CRM_Core_Page_AJAX_Location {
     }
 
     // set the message if loc block is being used by more than one event.
-    $result['count_loc_used'] = CRM_Event_BAO_Event::countEventsUsingLocBlockId($_REQUEST['lbid']);
+    $result['count_loc_used'] = CRM_Event_BAO_Event::countEventsUsingLocBlockId($lbid);
 
     CRM_Utils_JSON::output($result);
   }

--- a/CRM/Core/Page/AJAX/RecurringEntity.php
+++ b/CRM/Core/Page/AJAX/RecurringEntity.php
@@ -14,11 +14,12 @@ class CRM_Core_Page_AJAX_RecurringEntity {
 
   public static function updateMode() {
     $finalResult = [];
-    if (!empty($_REQUEST['mode']) && !empty($_REQUEST['entityId']) && !empty($_REQUEST['entityTable'])) {
-      $mode = CRM_Utils_Type::escape($_REQUEST['mode'], 'Integer');
-      $entityId = CRM_Utils_Type::escape($_REQUEST['entityId'], 'Integer');
-      $entityTable = CRM_Utils_Type::escape($_REQUEST['entityTable'], 'String');
-      $priceSet = CRM_Utils_Type::escape($_REQUEST['priceSet'], 'String');
+    $request = array_merge($_GET, $_POST);
+    if (!empty($request['mode']) && !empty($request['entityId']) && !empty($request['entityTable'])) {
+      $mode = CRM_Utils_Type::escape($request['mode'], 'Integer');
+      $entityId = CRM_Utils_Type::escape($request['entityId'], 'Integer');
+      $entityTable = CRM_Utils_Type::escape($request['entityTable'], 'String');
+      $priceSet = CRM_Utils_Type::escape($request['priceSet'], 'String');
 
       // CRM-21764 fix
       // Retrieving existing priceset if price set id is not passed
@@ -29,7 +30,7 @@ class CRM_Core_Page_AJAX_RecurringEntity {
         $priceSetEntity->find(TRUE);
         $priceSet = $priceSetEntity->price_set_id;
       }
-      $linkedEntityTable = $_REQUEST['linkedEntityTable'];
+      $linkedEntityTable = $request['linkedEntityTable'];
       $finalResult = CRM_Core_BAO_RecurringEntity::updateModeAndPriceSet($entityId, $entityTable, $mode, $linkedEntityTable, $priceSet);
     }
     CRM_Utils_JSON::output($finalResult);

--- a/CRM/Core/Page/Inline/Help.php
+++ b/CRM/Core/Page/Inline/Help.php
@@ -22,7 +22,7 @@
 class CRM_Core_Page_Inline_Help {
 
   public function run() {
-    $args = $_REQUEST;
+    $args = array_merge($_GET, $_POST);
     if (!empty($args['file']) && strpos($args['file'], '..') === FALSE) {
       $file = $args['file'] . '.hlp';
       $additionalTPLFile = $args['file'] . '.extra.hlp';

--- a/CRM/Core/Page/RecurringEntityPreview.php
+++ b/CRM/Core/Page/RecurringEntityPreview.php
@@ -22,7 +22,8 @@ class CRM_Core_Page_RecurringEntityPreview extends CRM_Core_Page {
   public function run() {
     $parentEntityId = $startDate = $endDate = NULL;
     $dates = $original = [];
-    $formValues = $_REQUEST;
+    // Q: should this only use _POST?
+    $formValues = array_merge($_GET, $_POST);
     if (!empty($formValues['entity_table'])) {
       $startDateColumnName = CRM_Core_BAO_RecurringEntity::$_dateColumns[$formValues['entity_table']]['dateColumns'][0];
       $endDateColumnName = CRM_Core_BAO_RecurringEntity::$_dateColumns[$formValues['entity_table']]['intervalDateColumns'][0];

--- a/CRM/Core/Page/Redirect.php
+++ b/CRM/Core/Page/Redirect.php
@@ -20,7 +20,7 @@ class CRM_Core_Page_Redirect extends CRM_Core_Page {
    * @param array $pageArgs
    */
   public function run($path = NULL, $pageArgs = []) {
-    $url = self::createUrl($path, $_REQUEST, $pageArgs, TRUE);
+    $url = self::createUrl($path, array_merge($_GET, $_POST), $pageArgs, TRUE);
     CRM_Utils_System::redirect($url);
   }
 

--- a/CRM/Core/Payment.php
+++ b/CRM/Core/Payment.php
@@ -281,13 +281,15 @@ abstract class CRM_Core_Payment {
     }
 
     $log = new CRM_Utils_SystemLogger();
-    // $_REQUEST doesn't handle JSON, to support providers that POST JSON we need the raw POST data.
+    // $_POST doesn't handle JSON, to support providers that POST JSON we need the raw POST data.
     $rawRequestData = file_get_contents("php://input");
     if (CRM_Utils_JSON::isValidJSON($rawRequestData)) {
       $log->alert($message, json_decode($rawRequestData, TRUE));
     }
     else {
-      $log->alert($message, $_REQUEST);
+      // Note: the array_merge here is to preserve the existing behaviour, but
+      // it might make more sense for it to just be _POST.
+      $log->alert($message, array_merge($_GET, $_POST));
     }
   }
 
@@ -1580,7 +1582,7 @@ abstract class CRM_Core_Payment {
     }
 
     // Call IPN postIPNProcess hook to allow for custom processing of IPN data.
-    $IPNParams = array_merge($_GET, $_REQUEST);
+    $IPNParams = array_merge($_GET, $_POST);
     CRM_Utils_Hook::postIPNProcess($IPNParams);
     if (!$extension_instance_found) {
       $message = "No extension instances of the '%1' payment processor were found.<br />" .

--- a/CRM/Core/Payment/AuthorizeNet.php
+++ b/CRM/Core/Payment/AuthorizeNet.php
@@ -733,7 +733,7 @@ class CRM_Core_Payment_AuthorizeNet extends CRM_Core_Payment {
    * Process incoming notification.
    */
   public static function handlePaymentNotification() {
-    $ipnClass = new CRM_Core_Payment_AuthorizeNetIPN(array_merge($_GET, $_REQUEST));
+    $ipnClass = new CRM_Core_Payment_AuthorizeNetIPN(array_merge($_GET, $_POST));
     $ipnClass->main();
   }
 

--- a/CRM/Core/Payment/PayPalImpl.php
+++ b/CRM/Core/Payment/PayPalImpl.php
@@ -704,7 +704,7 @@ class CRM_Core_Payment_PayPalImpl extends CRM_Core_Payment {
    * @throws \CiviCRM_API3_Exception
    */
   public static function handlePaymentNotification() {
-    $params = array_merge($_GET, $_REQUEST);
+    $params = array_merge($_GET, $_POST);
     $q = explode('/', CRM_Utils_Array::value('q', $params, ''));
     $lastParam = array_pop($q);
     if (is_numeric($lastParam)) {

--- a/CRM/Core/Payment/PayPalProIPN.php
+++ b/CRM/Core/Payment/PayPalProIPN.php
@@ -432,8 +432,9 @@ class CRM_Core_Payment_PayPalProIPN extends CRM_Core_Payment_BaseIPN {
     }
     else {
       // get the optional ids
-      //@ how can this not be broken retrieving from GET as we are dealing with a POST request?
-      // copy & paste? Note the retrieve function now uses data from _REQUEST so this will be included
+      //@todo how can this not be broken retrieving from GET as we are dealing with a POST request?
+      // copy & paste? Note the retrieve function now basically uses array_merge(_GET, _POST) so this will be included
+      // ^ @todo clarify the comment above!
       $ids['membership'] = self::retrieve('membershipID', 'Integer', 'GET', FALSE);
       $ids['contributionRecur'] = self::getValue('r', FALSE);
       $ids['contributionPage'] = self::getValue('p', FALSE);

--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -537,7 +537,7 @@ class CRM_Core_Permission {
     // check whether the following Ajax requests submitted the right key
     // FIXME: this should be integrated into ACLs proper
     if (CRM_Utils_Array::value('page_type', $item) == 3) {
-      if (!CRM_Core_Key::validate($_REQUEST['key'], $item['path'])) {
+      if (!CRM_Core_Key::validate($_POST['key'] ?? $_GET['key'] ?? NULL, $item['path'])) {
         return FALSE;
       }
     }

--- a/CRM/Core/Resources.php
+++ b/CRM/Core/Resources.php
@@ -855,7 +855,7 @@ class CRM_Core_Resources {
    *   is this page request an ajax snippet?
    */
   public static function isAjaxMode() {
-    if (in_array(CRM_Utils_Array::value('snippet', $_REQUEST), [
+    if (in_array(CRM_Utils_Request::retrieveValue('snippet', 'String'), [
       CRM_Core_Smarty::PRINT_SNIPPET,
       CRM_Core_Smarty::PRINT_NOFORM,
       CRM_Core_Smarty::PRINT_JSON,

--- a/CRM/Custom/Page/AJAX.php
+++ b/CRM/Custom/Page/AJAX.php
@@ -26,11 +26,11 @@ class CRM_Custom_Page_AJAX {
    * @deprecated
    */
   public static function getOptionList() {
-    $params = $_REQUEST;
+    $params = array_merge($_GET, $_POST);
 
-    $sEcho = CRM_Utils_Type::escape($_REQUEST['sEcho'], 'Integer');
-    $offset = isset($_REQUEST['iDisplayStart']) ? CRM_Utils_Type::escape($_REQUEST['iDisplayStart'], 'Integer') : 0;
-    $rowCount = isset($_REQUEST['iDisplayLength']) ? CRM_Utils_Type::escape($_REQUEST['iDisplayLength'], 'Integer') : 25;
+    $sEcho = CRM_Utils_Type::escape($request['sEcho'], 'Integer');
+    $offset = isset($request['iDisplayStart']) ? CRM_Utils_Type::escape($request['iDisplayStart'], 'Integer') : 0;
+    $rowCount = isset($request['iDisplayLength']) ? CRM_Utils_Type::escape($request['iDisplayLength'], 'Integer') : 25;
 
     $params['page'] = ($offset / $rowCount) + 1;
     $params['rp'] = $rowCount;
@@ -58,7 +58,7 @@ class CRM_Custom_Page_AJAX {
    *
    */
   public static function fixOrdering() {
-    $params = $_REQUEST;
+    $params = array_merge($_GET, $_POST);
 
     $queryParams = [
       1 => [$params['start'], 'Integer'],

--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -1744,7 +1744,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
       }
       if (CRM_Financial_BAO_FinancialType::isACLFinancialTypeStatus()
         && empty($form->_values['fee'])
-        && CRM_Utils_Array::value('snippet', $_REQUEST) == CRM_Core_Smarty::PRINT_NOFORM
+        && ($_POST['snippet'] ?? $_GET['snippet'] ?? NULL) == CRM_Core_Smarty::PRINT_NOFORM
       ) {
         CRM_Core_Session::setStatus(ts('You do not have all the permissions needed for this page.'), 'Permission Denied', 'error');
         return FALSE;

--- a/CRM/Event/Form/Registration/Confirm.php
+++ b/CRM/Event/Form/Registration/Confirm.php
@@ -1253,7 +1253,8 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
     $form = new CRM_Event_Form_Registration_Confirm();
     // This way the mocked up controller ignores the session stuff.
     $_SERVER['REQUEST_METHOD'] = 'GET';
-    $_REQUEST['id'] = $form->_eventId = $params['id'];
+    // Unsure which var to set here, previously _REQUEST.
+    $_GET['id'] = $_POST['id'] = $form->_eventId = $params['id'];
     $form->controller = new CRM_Event_Controller_Registration();
     $form->_params = $params['params'];
     // This happens in buildQuickForm so emulate here.

--- a/CRM/Financial/Page/AJAX.php
+++ b/CRM/Financial/Page/AJAX.php
@@ -245,17 +245,18 @@ class CRM_Financial_Page_AJAX {
       9 => 'name',
     ];
 
-    $sEcho = CRM_Utils_Type::escape($_REQUEST['sEcho'], 'Integer');
-    $return = isset($_REQUEST['return']) ? CRM_Utils_Type::escape($_REQUEST['return'], 'Boolean') : FALSE;
-    $offset = isset($_REQUEST['iDisplayStart']) ? CRM_Utils_Type::escape($_REQUEST['iDisplayStart'], 'Integer') : 0;
-    $rowCount = isset($_REQUEST['iDisplayLength']) ? CRM_Utils_Type::escape($_REQUEST['iDisplayLength'], 'Integer') : 25;
-    $sort = isset($_REQUEST['iSortCol_0']) ? CRM_Utils_Array::value(CRM_Utils_Type::escape($_REQUEST['iSortCol_0'], 'Integer'), $sortMapper) : NULL;
-    $sortOrder = isset($_REQUEST['sSortDir_0']) ? CRM_Utils_Type::escape($_REQUEST['sSortDir_0'], 'String') : 'asc';
+    $request = array_merge($_GET, $_POST);
+    $sEcho = CRM_Utils_Type::escape($request['sEcho'], 'Integer');
+    $return = isset($request['return']) ? CRM_Utils_Type::escape($request['return'], 'Boolean') : FALSE;
+    $offset = isset($request['iDisplayStart']) ? CRM_Utils_Type::escape($request['iDisplayStart'], 'Integer') : 0;
+    $rowCount = isset($request['iDisplayLength']) ? CRM_Utils_Type::escape($request['iDisplayLength'], 'Integer') : 25;
+    $sort = isset($request['iSortCol_0']) ? CRM_Utils_Array::value(CRM_Utils_Type::escape($request['iSortCol_0'], 'Integer'), $sortMapper) : NULL;
+    $sortOrder = isset($request['sSortDir_0']) ? CRM_Utils_Type::escape($request['sSortDir_0'], 'String') : 'asc';
     $context = CRM_Utils_Request::retrieve('context', 'Alphanumeric');
-    $entityID = isset($_REQUEST['entityID']) ? CRM_Utils_Type::escape($_REQUEST['entityID'], 'String') : NULL;
-    $notPresent = isset($_REQUEST['notPresent']) ? CRM_Utils_Type::escape($_REQUEST['notPresent'], 'String') : NULL;
-    $statusID = isset($_REQUEST['statusID']) ? CRM_Utils_Type::escape($_REQUEST['statusID'], 'String') : NULL;
-    $search = isset($_REQUEST['search']);
+    $entityID = isset($request['entityID']) ? CRM_Utils_Type::escape($request['entityID'], 'String') : NULL;
+    $notPresent = isset($request['notPresent']) ? CRM_Utils_Type::escape($request['notPresent'], 'String') : NULL;
+    $statusID = isset($request['statusID']) ? CRM_Utils_Type::escape($request['statusID'], 'String') : NULL;
+    $search = isset($request['search']);
 
     $params = $_POST;
     if ($sort && $sortOrder) {
@@ -458,9 +459,10 @@ class CRM_Financial_Page_AJAX {
   }
 
   public static function bulkAssignRemove() {
-    $checkIDs = $_REQUEST['ID'];
-    $entityID = CRM_Utils_Type::escape($_REQUEST['entityID'], 'String');
-    $action = CRM_Utils_Type::escape($_REQUEST['action'], 'String');
+    $request = array_merge($_GET, $_POST);
+    $checkIDs = $request['ID'];
+    $entityID = CRM_Utils_Type::escape($request['entityID'], 'String');
+    $action = CRM_Utils_Type::escape($request['action'], 'String');
     foreach ($checkIDs as $key => $value) {
       if ((substr($value, 0, 7) == "mark_x_" && $action == 'Assign') || (substr($value, 0, 7) == "mark_y_" && $action == 'Remove')) {
         $contributions = explode("_", $value);
@@ -496,7 +498,7 @@ class CRM_Financial_Page_AJAX {
   }
 
   public static function getBatchSummary() {
-    $batchID = CRM_Utils_Type::escape($_REQUEST['batchID'], 'String');
+    $batchID = CRM_Utils_Type::escape(CRM_Utils_Request::retrieveValue('batchID', 'String'), 'String');
     $params = ['id' => $batchID];
 
     $batchSummary = self::makeBatchSummary($batchID, $params);

--- a/CRM/Mailing/Page/Common.php
+++ b/CRM/Mailing/Page/Common.php
@@ -44,16 +44,14 @@ class CRM_Mailing_Page_Common extends CRM_Core_Page {
     }
 
     $cancel = CRM_Utils_Request::retrieve("_qf_{$this->_type}_cancel", 'String', CRM_Core_DAO::$_nullObject,
-      FALSE, NULL, $_REQUEST
-    );
+      FALSE, NULL);
     if ($cancel) {
       $config = CRM_Core_Config::singleton();
       CRM_Utils_System::redirect($config->userFrameworkBaseURL);
     }
 
     $confirm = CRM_Utils_Request::retrieve('confirm', 'Boolean', CRM_Core_DAO::$_nullObject,
-      FALSE, NULL, $_REQUEST
-    );
+      FALSE, NULL);
 
     list($displayName, $email) = CRM_Mailing_Event_BAO_Queue::getContactInfo($queue_id);
     $this->assign('display_name', $displayName);

--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -649,7 +649,7 @@ class CRM_Report_Form extends CRM_Core_Form {
       // lets always do a force if reset is found in the url.
       // Hey why not? see CRM-17225 for more about this. The use of reset to be force is historical for reasons stated
       // in the comment line above these 2.
-      if (!empty($_REQUEST['reset'])
+      if (!empty($_POST['reset'] ?? $_GET['reset'] ?? NULL)
           && !in_array(CRM_Utils_Request::retrieve('output', 'String'), ['save', 'criteria'])) {
         $this->_force = 1;
       }

--- a/CRM/Report/Utils/Report.php
+++ b/CRM/Report/Utils/Report.php
@@ -385,13 +385,14 @@ WHERE  inst.report_id = %1";
   public static function processReport($params) {
     $instanceId = $params['instanceId'] ?? NULL;
 
+    $request = array_merge($_GET, $_POST);
     // hack for now, CRM-8358
-    $_REQUEST['instanceId'] = $instanceId;
-    $_REQUEST['sendmail'] = CRM_Utils_Array::value('sendmail', $params, 1);
+    $request['instanceId'] = $instanceId;
+    $request['sendmail'] = CRM_Utils_Array::value('sendmail', $params, 1);
 
     // if cron is run from terminal --output is reserved, and therefore we would provide another name 'format'
-    $_REQUEST['output'] = CRM_Utils_Array::value('format', $params, CRM_Utils_Array::value('output', $params, 'pdf'));
-    $_REQUEST['reset'] = CRM_Utils_Array::value('reset', $params, 1);
+    $request['output'] = CRM_Utils_Array::value('format', $params, CRM_Utils_Array::value('output', $params, 'pdf'));
+    $request['reset'] = CRM_Utils_Array::value('reset', $params, 1);
 
     $optionVal = self::getValueFromUrl($instanceId);
     $messages = ["Report Mail Triggered..."];

--- a/CRM/SMS/Page/Callback.php
+++ b/CRM/SMS/Page/Callback.php
@@ -17,9 +17,10 @@
 class CRM_SMS_Page_Callback {
 
   public function run() {
-    $provider = CRM_SMS_Provider::singleton($_REQUEST);
+    $request = array_merge($_GET, $_POST);
+    $provider = CRM_SMS_Provider::singleton($request);
 
-    if (array_key_exists('status', $_REQUEST)) {
+    if (array_key_exists('status', $request)) {
       $provider->callback();
     }
     else {

--- a/CRM/UF/Form/Inline/Preview.php
+++ b/CRM/UF/Form/Inline/Preview.php
@@ -42,7 +42,7 @@ class CRM_UF_Form_Inline_Preview extends CRM_UF_Form_AbstractPreview {
     if (!CRM_Core_Permission::check($checkPermission)) {
       CRM_Core_Error::statusBounce(ts('Permission Denied'));
     }
-    $content = json_decode($_REQUEST['ufData'], TRUE);
+    $content = json_decode(CRM_Utils_Request::retrieveValue('ufData', 'String'), TRUE);
     foreach (['ufGroup', 'ufFieldCollection'] as $key) {
       if (!is_array($content[$key])) {
         CRM_Core_Error::fatal("Missing JSON parameter, $key");

--- a/CRM/UF/Page/ProfileEditor.php
+++ b/CRM/UF/Page/ProfileEditor.php
@@ -100,7 +100,7 @@ class CRM_UF_Page_ProfileEditor extends CRM_Core_Page {
    * AJAX callback.
    */
   public static function getSchemaJSON() {
-    $entityTypes = explode(',', $_REQUEST['entityTypes']);
+    $entityTypes = explode(',', CRM_Utils_Request::retrieveValue('entityTypes', 'String', ''));
     CRM_Utils_JSON::output(self::getSchema($entityTypes));
   }
 

--- a/CRM/Upgrade/Page/Upgrade.php
+++ b/CRM/Upgrade/Page/Upgrade.php
@@ -51,7 +51,10 @@ class CRM_Upgrade_Page_Upgrade extends CRM_Core_Page {
       CRM_Utils_System::url('civicrm/dashboard', 'reset=1')
     );
 
-    $action = CRM_Utils_Array::value('action', $_REQUEST, 'intro');
+    // Note: this does not use CRM_Utils_Request::retrieveValue because
+    // that function includes a hack that changes the 'action' value and
+    // we need the raw value here.
+    $action = $_POST['action'] ?? $_GET['action'] ?? 'intro';
     switch ($action) {
       case 'intro':
         $this->runIntro();

--- a/CRM/Utils/PagerAToZ.php
+++ b/CRM/Utils/PagerAToZ.php
@@ -137,7 +137,7 @@ class CRM_Utils_PagerAToZ {
     if (empty($qfKey)) {
       // CRM-20943 Can only pass variables by reference and also cannot use $this so using $empty setting to NULL which is default.
       $emptyVariable = NULL;
-      $qfKey = CRM_Utils_Request::retrieve('qfKey', 'String', $emptyVariable, FALSE, NULL, $_REQUEST);
+      $qfKey = CRM_Utils_Request::retrieve('qfKey', 'String', $emptyVariable, FALSE, NULL);
     }
 
     $aToZBar = [];

--- a/CRM/Utils/REST.php
+++ b/CRM/Utils/REST.php
@@ -561,7 +561,7 @@ class CRM_Utils_REST {
    */
   public static function processMultiple() {
     $output = [];
-    foreach (json_decode($_REQUEST['json'], TRUE) as $key => $call) {
+    foreach (json_decode(CRM_Utils_Request::retrieveValue('json', 'String'), TRUE) as $key => $call) {
       $args = [
         'civicrm',
         $call[0],

--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -563,7 +563,7 @@ class CRM_Utils_System {
    */
   public static function authenticateKey($abort = TRUE) {
     // also make sure the key is sent and is valid
-    $key = trim(CRM_Utils_Array::value('key', $_REQUEST));
+    $key = trim(CRM_Utils_Request::retrieveValue('key', 'String'));
 
     $docAdd = "More info at:" . CRM_Utils_System::docURL2("Managing Scheduled Jobs", TRUE, NULL, NULL, NULL, "wiki");
 
@@ -616,8 +616,8 @@ class CRM_Utils_System {
     // auth to make sure the user has a login/password to do a shell operation
     // later on we'll link this to acl's
     if (!$name) {
-      $name = trim(CRM_Utils_Array::value('name', $_REQUEST));
-      $pass = trim(CRM_Utils_Array::value('pass', $_REQUEST));
+      $name = trim(CRM_Utils_Request::retrieveValue('name', 'String', ''));
+      $pass = trim(CRM_Utils_Request::retrieveValue('pass', 'String', ''));
     }
 
     // its ok to have an empty password

--- a/CRM/Utils/System/Backdrop.php
+++ b/CRM/Utils/System/Backdrop.php
@@ -567,8 +567,9 @@ AND    u.status = 1
     $uid = $params['uid'] ?? NULL;
     if (!$uid) {
       // Load the user we need to check Backdrop permissions.
-      $name = CRM_Utils_Array::value('name', $params, FALSE) ? $params['name'] : trim(CRM_Utils_Array::value('name', $_REQUEST));
-      $pass = CRM_Utils_Array::value('pass', $params, FALSE) ? $params['pass'] : trim(CRM_Utils_Array::value('pass', $_REQUEST));
+      $request = array_merge($_GET, $_POST);
+      $name = CRM_Utils_Array::value('name', $params, FALSE) ? $params['name'] : trim(CRM_Utils_Array::value('name', $request));
+      $pass = CRM_Utils_Array::value('pass', $params, FALSE) ? $params['pass'] : trim(CRM_Utils_Array::value('pass', $request));
 
       if ($name) {
         $uid = user_authenticate($name, $pass);

--- a/CRM/Utils/System/Drupal.php
+++ b/CRM/Utils/System/Drupal.php
@@ -514,8 +514,9 @@ AND    u.status = 1
     $uid = $params['uid'] ?? NULL;
     if (!$uid) {
       //load user, we need to check drupal permissions.
-      $name = CRM_Utils_Array::value('name', $params, FALSE) ? $params['name'] : trim(CRM_Utils_Array::value('name', $_REQUEST));
-      $pass = CRM_Utils_Array::value('pass', $params, FALSE) ? $params['pass'] : trim(CRM_Utils_Array::value('pass', $_REQUEST));
+      $request = array_merge($_GET, $_POST);
+      $name = CRM_Utils_Array::value('name', $params, FALSE) ? $params['name'] : trim(CRM_Utils_Array::value('name', $request));
+      $pass = CRM_Utils_Array::value('pass', $params, FALSE) ? $params['pass'] : trim(CRM_Utils_Array::value('pass', $request));
 
       if ($name) {
         $uid = user_authenticate($name, $pass);

--- a/CRM/Utils/System/Drupal6.php
+++ b/CRM/Utils/System/Drupal6.php
@@ -463,8 +463,9 @@ class CRM_Utils_System_Drupal6 extends CRM_Utils_System_DrupalBase {
     $uid = $params['uid'] ?? NULL;
     if (!$uid) {
       //load user, we need to check drupal permissions.
-      $name = CRM_Utils_Array::value('name', $params, FALSE) ? $params['name'] : trim(CRM_Utils_Array::value('name', $_REQUEST));
-      $pass = CRM_Utils_Array::value('pass', $params, FALSE) ? $params['pass'] : trim(CRM_Utils_Array::value('pass', $_REQUEST));
+      $request = array_merge($_GET, $_POST);
+      $name = CRM_Utils_Array::value('name', $params, FALSE) ? $params['name'] : trim(CRM_Utils_Array::value('name', $request));
+      $pass = CRM_Utils_Array::value('pass', $params, FALSE) ? $params['pass'] : trim(CRM_Utils_Array::value('pass', $request));
 
       if ($name) {
         $user = user_authenticate(['name' => $name, 'pass' => $pass]);

--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -526,8 +526,9 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
     require_once $cmsRootPath . DIRECTORY_SEPARATOR . 'wp-includes/pluggable.php';
     $uid = $params['uid'] ?? NULL;
     if (!$uid) {
-      $name = $name ? $name : trim(CRM_Utils_Array::value('name', $_REQUEST));
-      $pass = $pass ? $pass : trim(CRM_Utils_Array::value('pass', $_REQUEST));
+      $request = array_merge($_GET, $_POST);
+      $name = $name ? $name : trim(CRM_Utils_Array::value('name', $request));
+      $pass = $pass ? $pass : trim(CRM_Utils_Array::value('pass', $request));
       if ($name) {
         $uid = wp_authenticate($name, $pass);
         if (!$uid) {

--- a/CRM/Utils/Type.php
+++ b/CRM/Utils/Type.php
@@ -208,6 +208,9 @@ class CRM_Utils_Type {
   /**
    * Verify that a variable is of a given type, and apply a bit of processing.
    *
+   * @todo: clarify escape for *what purpose*? Shell argument? SQL? e.g. this
+   * function is NOT suitable for escaping a boolean for MySQL.
+   *
    * @param mixed $data
    *   The value to be verified/escaped.
    * @param string $type

--- a/api/v3/ContributionPage.php
+++ b/api/v3/ContributionPage.php
@@ -96,15 +96,17 @@ function civicrm_api3_contribution_page_submit($params) {
  *
  * @return array
  *   API result array
+ *
  */
 function civicrm_api3_contribution_page_validate($params) {
   // If we are calling this as a result of a POST action (e.g validating a form submission before first getting payment
   // authorization from a payment processor like Paypal checkout) the lack of a qfKey will not result in a valid
   // one being generated so we generate one first.
-  $originalRequest = $_REQUEST;
-  $qfKey = $_REQUEST['qfKey'] ?? NULL;
+  $originalPost = $_POST;
+  $qfKey = CRM_Utils_Request::retrieveValue('qfKey', 'String');
   if (!$qfKey) {
-    $_REQUEST['qfKey'] = CRM_Core_Key::get('CRM_Core_Controller', TRUE);
+    // Generate a key for the duration of this process.
+    $_POST['qfKey'] = CRM_Core_Key::get('CRM_Core_Controller', TRUE);
   }
   $form = new CRM_Contribute_Form_Contribution_Main();
   $form->controller = new CRM_Core_Controller();
@@ -114,7 +116,8 @@ function civicrm_api3_contribution_page_validate($params) {
   if ($errors === TRUE) {
     $errors = [];
   }
-  $_REQUEST = $originalRequest;
+  // Restore _POST var
+  $_POST = $originalPost;
   return civicrm_api3_create_success($errors, $params, 'ContributionPage', 'validate');
 }
 

--- a/bin/cron.php
+++ b/bin/cron.php
@@ -28,7 +28,7 @@ if ($job === NULL) {
 else {
   $ignored = array("name", "pass", "key", "job");
   $params = array();
-  foreach ($_REQUEST as $name => $value) {
+  foreach (array_merge($_GET, $_POST) as $name => $value) {
     if (!in_array($name, $ignored)) {
       $params[$name] = CRM_Utils_Request::retrieve($name, 'String', CRM_Core_DAO::$_nullArray, FALSE, NULL, 'REQUEST');
     }

--- a/extern/authorizeIPN.php
+++ b/extern/authorizeIPN.php
@@ -23,15 +23,17 @@ session_start();
 require_once '../civicrm.config.php';
 CRM_Core_Config::singleton();
 $log = new CRM_Utils_SystemLogger();
-$log->alert('payment_notification processor_name=AuthNet', $_REQUEST);
+$request = array_merge($_GET, $_POST);
+$log->alert('payment_notification processor_name=AuthNet', $request);
 
-$authorizeNetIPN = new CRM_Core_Payment_AuthorizeNetIPN($_REQUEST);
+$authorizeNetIPN = new CRM_Core_Payment_AuthorizeNetIPN($request);
 try {
   $authorizeNetIPN->main();
 }
 catch (CRM_Core_Exception $e) {
   CRM_Core_Error::debug_log_message($e->getMessage());
   CRM_Core_Error::debug_var('error data', $e->getErrorData(), TRUE, TRUE);
-  CRM_Core_Error::debug_var('REQUEST', $_REQUEST, TRUE, TRUE);
+  CRM_Core_Error::debug_var('GET', $_GET, TRUE, TRUE);
+  CRM_Core_Error::debug_var('POST', $_POST, TRUE, TRUE);
   echo "The transaction has failed. Please review the log for more detail";
 }

--- a/extern/ipn.php
+++ b/extern/ipn.php
@@ -49,13 +49,14 @@ require_once '../civicrm.config.php';
 
 CRM_Core_Config::singleton();
 $log = new CRM_Utils_SystemLogger();
+$request = array_merge($_GET, $_POST);
 if (empty($_GET)) {
-  $log->alert('payment_notification processor_name=PayPal', $_REQUEST);
-  $paypalIPN = new CRM_Core_Payment_PayPalProIPN($_REQUEST);
+  $log->alert('payment_notification processor_name=PayPal', $request);
+  $paypalIPN = new CRM_Core_Payment_PayPalProIPN($request);
 }
 else {
-  $log->alert('payment_notification PayPal_Standard', $_REQUEST);
-  $paypalIPN = new CRM_Core_Payment_PayPalIPN($_REQUEST);
+  $log->alert('payment_notification PayPal_Standard', $request);
+  $paypalIPN = new CRM_Core_Payment_PayPalIPN($request);
   // @todo upgrade standard per Pro
 }
 try {
@@ -76,7 +77,8 @@ try {
 catch (CRM_Core_Exception $e) {
   CRM_Core_Error::debug_log_message($e->getMessage());
   CRM_Core_Error::debug_var('error data', $e->getErrorData(), TRUE, TRUE);
-  CRM_Core_Error::debug_var('REQUEST', $_REQUEST, TRUE, TRUE);
+  CRM_Core_Error::debug_var('GET', $_GET, TRUE, TRUE);
+  CRM_Core_Error::debug_var('POST', $_POST, TRUE, TRUE);
   //@todo give better info to logged in user - ie dev
   echo "The transaction has failed. Please review the log for more detail";
 }

--- a/extern/pxIPN.php
+++ b/extern/pxIPN.php
@@ -20,7 +20,7 @@ require_once 'CRM/Core/Config.php';
 
 CRM_Core_Config::singleton();
 $log = new CRM_Utils_SystemLogger();
-$log->alert('payment_notification processor_name=Payment_Express', $_REQUEST);
+$log->alert('payment_notification processor_name=Payment_Express', array_merge($_GET, $_POST));
 /*
  * Get the password from the Payment Processor's table based on the DPS user id
  * being passed back from the server

--- a/install/index.php
+++ b/install/index.php
@@ -144,11 +144,10 @@ if (!defined('CIVICRM_L10N_BASEDIR') && file_exists($crmPath . DIRECTORY_SEPARAT
 }
 
 // CRM-16801 This validates that seedLanguage is valid by looking in $langs.
-// NB: the variable is initial a $_REQUEST for the initial page reload,
-// then becomes a $_POST when the installation form is submitted.
-// ^ I think that comment means that the parameter is first found in _GET then later in _POST
-$request = array_merge($_GET, $_POST);
-if (isset($request['seedLanguage']) && isset($langs[$request['seedLanguage']])) {
+// 'seedLanguage' is originally passed in on the query string so found in _GET,
+// but on the subsequent request(s) it will be in _POST.
+$inputSource = ($_SERVER['REQUEST_METHOD'] === 'POST') ? $_POST : $_GET;
+if (isset($inputSource['seedLanguage']) && isset($langs[$inputSource['seedLanguage']])) {
   $seedLanguage = $request['seedLanguage'];
   $tsLocale = $request['seedLanguage'];
 }

--- a/install/index.php
+++ b/install/index.php
@@ -146,9 +146,11 @@ if (!defined('CIVICRM_L10N_BASEDIR') && file_exists($crmPath . DIRECTORY_SEPARAT
 // CRM-16801 This validates that seedLanguage is valid by looking in $langs.
 // NB: the variable is initial a $_REQUEST for the initial page reload,
 // then becomes a $_POST when the installation form is submitted.
-if (isset($_REQUEST['seedLanguage']) and isset($langs[$_REQUEST['seedLanguage']])) {
-  $seedLanguage = $_REQUEST['seedLanguage'];
-  $tsLocale = $_REQUEST['seedLanguage'];
+// ^ I think that comment means that the parameter is first found in _GET then later in _POST
+$request = array_merge($_GET, $_POST);
+if (isset($request['seedLanguage']) && isset($langs[$request['seedLanguage']])) {
+  $seedLanguage = $request['seedLanguage'];
+  $tsLocale = $request['seedLanguage'];
 }
 
 CRM_Core_Config::singleton(FALSE);

--- a/tests/phpunit/CRM/Case/BAO/CaseTest.php
+++ b/tests/phpunit/CRM/Case/BAO/CaseTest.php
@@ -439,18 +439,18 @@ class CRM_Case_BAO_CaseTest extends CiviUnitTestCase {
     // HTTP vars needed because that's how the form determines stuff
     $oldMETHOD = empty($_SERVER['REQUEST_METHOD']) ? NULL : $_SERVER['REQUEST_METHOD'];
     $oldGET = empty($_GET) ? [] : $_GET;
-    $oldREQUEST = empty($_REQUEST) ? [] : $_REQUEST;
+    $oldPOST = empty($_POST) ? [] : $_POST;
     $_SERVER['REQUEST_METHOD'] = 'GET';
     $_GET['caseid'] = $case_id;
-    $_REQUEST['caseid'] = $case_id;
+    $_POST['caseid'] = $case_id;
     $_GET['cid'] = $client_id;
-    $_REQUEST['cid'] = $client_id;
+    $_POST['cid'] = $client_id;
     $_GET['action'] = 'add';
-    $_REQUEST['action'] = 'add';
+    $_POST['action'] = 'add';
     $_GET['reset'] = 1;
-    $_REQUEST['reset'] = 1;
+    $_POST['reset'] = 1;
     $_GET['atype'] = $atype;
-    $_REQUEST['atype'] = $atype;
+    $_POST['atype'] = $atype;
 
     $form = new CRM_Case_Form_Activity();
     $form->controller = new CRM_Core_Controller_Simple('CRM_Case_Form_Activity', 'Case Activity');
@@ -513,7 +513,7 @@ class CRM_Case_BAO_CaseTest extends CiviUnitTestCase {
       $_SERVER['REQUEST_METHOD'] = $oldMETHOD;
     }
     $_GET = $oldGET;
-    $_REQUEST = $oldREQUEST;
+    $_POST = $oldPOST;
   }
 
   /**

--- a/tests/phpunit/CRM/Contact/Page/AjaxTest.php
+++ b/tests/phpunit/CRM/Contact/Page/AjaxTest.php
@@ -6,22 +6,22 @@
 class CRM_Contact_Page_AjaxTest extends CiviUnitTestCase {
 
   /**
-   * Original $_REQUEST
+   * Original $_POST
    *
    * We are messing with globals so fix afterwards.
    *
    * @var array
    */
-  protected $originalRequest = [];
+  protected $originalPost = [];
 
   public function setUp() {
     $this->useTransaction(TRUE);
     parent::setUp();
-    $this->originalRequest = $_REQUEST;
+    $this->originalPost = $_POST;
   }
 
   public function tearDown() {
-    $_REQUEST = $this->originalRequest;
+    $_POST = $this->originalPost;
     parent::tearDown();
   }
 
@@ -29,9 +29,9 @@ class CRM_Contact_Page_AjaxTest extends CiviUnitTestCase {
    * Minimal test on the testGetDupes function to make sure it completes without error.
    */
   public function testGetDedupes() {
-    $_REQUEST['gid'] = 1;
-    $_REQUEST['rgid'] = 1;
-    $_REQUEST['columns'] = [
+    $_POST['gid'] = 1;
+    $_POST['rgid'] = 1;
+    $_POST['columns'] = [
       [
         'search' => [
           'value' => [
@@ -41,7 +41,7 @@ class CRM_Contact_Page_AjaxTest extends CiviUnitTestCase {
         'data' => 'src',
       ],
     ];
-    $_REQUEST['is_unit_test'] = TRUE;
+    $_POST['is_unit_test'] = TRUE;
     $result = CRM_Contact_Page_AJAX::getDedupes();
     $this->assertEquals(['data' => [], 'recordsTotal' => 0, 'recordsFiltered' => 0], $result);
   }
@@ -63,11 +63,11 @@ class CRM_Contact_Page_AjaxTest extends CiviUnitTestCase {
   }
 
   public function testGetDedupesPostCode() {
-    $_REQUEST['gid'] = 1;
-    $_REQUEST['rgid'] = 1;
-    $_REQUEST['snippet'] = 4;
-    $_REQUEST['draw'] = 3;
-    $_REQUEST['columns'] = [
+    $_POST['gid'] = 1;
+    $_POST['rgid'] = 1;
+    $_POST['snippet'] = 4;
+    $_POST['draw'] = 3;
+    $_POST['columns'] = [
       0 => [
         'data' => 'is_selected_input',
         'name' => '',
@@ -222,19 +222,19 @@ class CRM_Contact_Page_AjaxTest extends CiviUnitTestCase {
       ],
     ];
 
-    $_REQUEST['start'] = 0;
-    $_REQUEST['length'] = 10;
-    $_REQUEST['search'] = [
+    $_POST['start'] = 0;
+    $_POST['length'] = 10;
+    $_POST['search'] = [
       'value' => '',
       'regex' => FALSE,
     ];
 
-    $_REQUEST['_'] = 1466478641007;
-    $_REQUEST['Drupal_toolbar_collapsed'] = 0;
-    $_REQUEST['has_js'] = 1;
-    $_REQUEST['SESSa06550b3043ecca303761d968e3c846a'] = 'qxSxw0F_UmBITMM0JaVwTRcHV1bQqBSHNmBMY9AA8Wk';
+    $_POST['_'] = 1466478641007;
+    $_POST['Drupal_toolbar_collapsed'] = 0;
+    $_POST['has_js'] = 1;
+    $_POST['SESSa06550b3043ecca303761d968e3c846a'] = 'qxSxw0F_UmBITMM0JaVwTRcHV1bQqBSHNmBMY9AA8Wk';
 
-    $_REQUEST['is_unit_test'] = TRUE;
+    $_POST['is_unit_test'] = TRUE;
 
     $result = CRM_Contact_Page_AJAX::getDedupes();
     $this->assertEquals(['data' => [], 'recordsTotal' => 0, 'recordsFiltered' => 0], $result);
@@ -294,7 +294,7 @@ class CRM_Contact_Page_AjaxTest extends CiviUnitTestCase {
 
     // CASE I : check the usage count of parent tag which need to be 1
     //  as the one contact added
-    $_REQUEST['is_unit_test'] = TRUE;
+    $_POST['is_unit_test'] = TRUE;
     $parentTagTreeResult = CRM_Admin_Page_AJAX::getTagTree();
     foreach ($parentTagTreeResult as $result) {
       if ($result['id'] == $parentTag['id']) {

--- a/tests/phpunit/CRM/Contact/Page/View/UserDashBoardTest.php
+++ b/tests/phpunit/CRM/Contact/Page/View/UserDashBoardTest.php
@@ -160,11 +160,11 @@ class CRM_Contact_Page_View_UserDashBoardTest extends CiviUnitTestCase {
    * Run the user dashboard.
    */
   protected function runUserDashboard() {
-    $_REQUEST = ['reset' => 1, 'id' => $this->contactID];
+    $_POST = ['reset' => 1, 'id' => $this->contactID];
     $dashboard = new CRM_Contact_Page_View_UserDashBoard();
     $dashboard->_contactId = $this->contactID;
     $dashboard->run();
-    $_REQUEST = [];
+    $_POST = [];
   }
 
 }

--- a/tests/phpunit/CRM/Contact/Page/View/UserDashboard/GroupContactTest.php
+++ b/tests/phpunit/CRM/Contact/Page/View/UserDashboard/GroupContactTest.php
@@ -83,7 +83,7 @@ class CRM_Contact_Page_View_UserDashboard_GroupContactTest extends CiviUnitTestC
 
     // Get logged in user contact ID.
     $user_id = $this->createLoggedInUser();
-    $_REQUEST['id'] = $user_id;
+    $_POST['id'] = $user_id;
 
     // Add current user to the test groups.
     $publicSmartGroup = $this->callAPISuccess('Contact', 'create', [
@@ -169,7 +169,7 @@ class CRM_Contact_Page_View_UserDashboard_GroupContactTest extends CiviUnitTestC
 
     // Run the contact dashboard and assert that only the public groups appear
     // in select list of available groups.
-    $_REQUEST['id'] = $user_id;
+    $_POST['id'] = $user_id;
     $page = new CRM_Contact_Page_View_UserDashBoard_GroupContact();
     $page->run();
 
@@ -193,7 +193,7 @@ class CRM_Contact_Page_View_UserDashboard_GroupContactTest extends CiviUnitTestC
 
     // Run the contact dashboard and assert that none of the groups appear
     // in select list of available groups.
-    $_REQUEST['id'] = $user_id;
+    $_POST['id'] = $user_id;
     $page = new CRM_Contact_Page_View_UserDashBoard_GroupContact();
     $page->run();
 

--- a/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
@@ -1349,7 +1349,7 @@ Price Field - Price Field 1        1   $ 100.00      $ 100.00
     $form = new CRM_Contribute_Form_ContributionBase();
     $form->controller = new CRM_Core_Controller();
     $form->set('id', $page1['id']);
-    $_REQUEST['id'] = $page1['id'];
+    $_POST['id'] = $page1['id'];
 
     $form->preProcess();
     $this->assertEquals($form->_paymentProcessor['name'], 'pay_later');
@@ -1361,7 +1361,7 @@ Price Field - Price Field 1        1   $ 100.00      $ 100.00
     //Assert an exception is thrown on loading the contribution page.
     $form = new CRM_Contribute_Form_ContributionBase();
     $form->controller = new CRM_Core_Controller();
-    $_REQUEST['id'] = $page2['id'];
+    $_POST['id'] = $page2['id'];
     $form->set('id', $page2['id']);
     try {
       $form->preProcess();

--- a/tests/phpunit/CRM/Core/Page/HookTest.php
+++ b/tests/phpunit/CRM/Core/Page/HookTest.php
@@ -69,7 +69,7 @@ class CRM_Core_Page_HookTest extends CiviUnitTestCase {
   public function testFormsCallBuildFormOnce() {
     CRM_Utils_Hook_UnitTests::singleton()->setHook('civicrm_buildForm', [$this, 'onBuildForm']);
     CRM_Utils_Hook_UnitTests::singleton()->setHook('civicrm_preProcess', [$this, 'onPreProcess']);
-    $_REQUEST = ['action' => 'add'];
+    $_POST = ['action' => 'add'];
     foreach ($this->basicPages as $pageName) {
       // Reset the counters
       $this->hookCount = [
@@ -108,7 +108,7 @@ class CRM_Core_Page_HookTest extends CiviUnitTestCase {
    */
   public function testPagesCallPageRunOnce() {
     CRM_Utils_Hook_UnitTests::singleton()->setHook('civicrm_pageRun', [$this, 'onPageRun']);
-    $_REQUEST = ['action' => 'browse'];
+    $_POST = ['action' => 'browse'];
     foreach ($this->basicPages as $pageName) {
       // Reset the counters
       $this->hookCount = ['pageRun' => []];

--- a/tests/phpunit/CRM/Core/Payment/PayPalIPNTest.php
+++ b/tests/phpunit/CRM/Core/Payment/PayPalIPNTest.php
@@ -79,8 +79,8 @@ class CRM_Core_Payment_PayPalIPNTest extends CiviUnitTestCase {
     $this->assertEquals(NULL, $contribution['values'][0]['trxn_id']);
     $this->assertEquals($pendingStatusID, $contribution['values'][0]['contribution_status_id']);
 
-    global $_REQUEST;
-    $_REQUEST = ['q' => CRM_Utils_System::url('civicrm/payment/ipn/' . $this->_paymentProcessorID)] + $this->getPaypalTransaction();
+    global $_POST;
+    $_POST = ['q' => CRM_Utils_System::url('civicrm/payment/ipn/' . $this->_paymentProcessorID)] + $this->getPaypalTransaction();
 
     $mut = new CiviMailUtils($this, TRUE);
     $paymentProcesors = $this->callAPISuccessGetSingle('PaymentProcessor', ['id' => $this->_paymentProcessorID]);
@@ -97,7 +97,7 @@ class CRM_Core_Payment_PayPalIPNTest extends CiviUnitTestCase {
 
     $contribution = $this->callAPISuccess('contribution', 'get', ['id' => $this->_contributionID, 'sequential' => 1]);
     // assert that contribution is completed after getting response from paypal standard which has transaction id set and completed status
-    $this->assertEquals($_REQUEST['txn_id'], $contribution['values'][0]['trxn_id']);
+    $this->assertEquals($_POST['txn_id'], $contribution['values'][0]['trxn_id']);
     $this->assertEquals($completedStatusID, $contribution['values'][0]['contribution_status_id']);
   }
 
@@ -306,15 +306,15 @@ class CRM_Core_Payment_PayPalIPNTest extends CiviUnitTestCase {
     $this->assertEquals(NULL, $contribution['values'][0]['trxn_id']);
     $this->assertEquals($pendingStatusID, $contribution['values'][0]['contribution_status_id']);
     $this->hookClass->setHook('civicrm_postIPNProcess', [$this, 'hookCiviCRMAlterIPNData']);
-    global $_REQUEST;
-    $_REQUEST = ['q' => CRM_Utils_System::url('civicrm/payment/ipn/' . $this->_paymentProcessorID)] + $this->getPaypalTransaction();
+    global $_POST;
+    $_POST = ['q' => CRM_Utils_System::url('civicrm/payment/ipn/' . $this->_paymentProcessorID)] + $this->getPaypalTransaction();
 
     $mut = new CiviMailUtils($this, TRUE);
     $payment = CRM_Core_Payment::handlePaymentMethod('PaymentNotification', ['processor_id' => $this->_paymentProcessorID]);
 
     $contribution = $this->callAPISuccess('contribution', 'get', ['id' => $this->_contributionID, 'sequential' => 1]);
     // assert that contribution is completed after getting response from paypal standard which has transaction id set and completed status
-    $this->assertEquals($_REQUEST['txn_id'], $contribution['values'][0]['trxn_id']);
+    $this->assertEquals($_POST['txn_id'], $contribution['values'][0]['trxn_id']);
     $this->assertEquals($completedStatusID, $contribution['values'][0]['contribution_status_id']);
     $this->assertEquals('test12345', $contribution['values'][0]['custom_' . $this->_customFieldID]);
   }
@@ -342,14 +342,14 @@ class CRM_Core_Payment_PayPalIPNTest extends CiviUnitTestCase {
     $payPalIPNParams = $this->getPaypalTransaction();
     $payPalIPNParams['contactID'] = $contactTobeDeleted;
     $this->callAPISuccess('Contact', 'delete', ['id' => $contactTobeDeleted, 'skip_undelete' => 1]);
-    global $_REQUEST;
-    $_REQUEST = ['q' => CRM_Utils_System::url('civicrm/payment/ipn/' . $this->_paymentProcessorID)] + $payPalIPNParams;
+    global $_POST;
+    $_POST = ['q' => CRM_Utils_System::url('civicrm/payment/ipn/' . $this->_paymentProcessorID)] + $payPalIPNParams;
     // Now process the IPN noting that the contact id that was supplied with the IPN has been deleted but there is still a valid one on the contribution id
     $payment = CRM_Core_Payment::handlePaymentMethod('PaymentNotification', ['processor_id' => $this->_paymentProcessorID]);
 
     $contribution = $this->callAPISuccess('contribution', 'get', ['id' => $this->_contributionID, 'sequential' => 1]);
     // assert that contribution is completed after getting response from paypal standard which has transaction id set and completed status
-    $this->assertEquals($_REQUEST['txn_id'], $contribution['values'][0]['trxn_id']);
+    $this->assertEquals($_POST['txn_id'], $contribution['values'][0]['trxn_id']);
     $this->assertEquals($completedStatusID, $contribution['values'][0]['contribution_status_id']);
   }
 

--- a/tests/phpunit/CRM/Core/ResourcesTest.php
+++ b/tests/phpunit/CRM/Core/ResourcesTest.php
@@ -31,7 +31,7 @@ class CRM_Core_ResourcesTest extends CiviUnitTestCase {
    */
   protected $cacheBusterString = 'xBkdk3';
 
-  protected $originalRequest;
+  protected $originalPost;
   protected $originalGet;
 
   public function setUp() {
@@ -47,7 +47,7 @@ class CRM_Core_ResourcesTest extends CiviUnitTestCase {
     require_once 'CRM/Core/Smarty/resources/String.php';
     civicrm_smarty_register_string_resource();
 
-    $this->originalRequest = $_REQUEST;
+    $this->originalPost = $_POST;
     $this->originalGet = $_GET;
   }
 
@@ -55,7 +55,7 @@ class CRM_Core_ResourcesTest extends CiviUnitTestCase {
    * Restore globals so this test doesn't interfere with others.
    */
   public function tearDown() {
-    $_REQUEST = $this->originalRequest;
+    $_POST = $this->originalPost;
     $_GET = $this->originalGet;
   }
 
@@ -330,7 +330,7 @@ class CRM_Core_ResourcesTest extends CiviUnitTestCase {
    * @dataProvider ajaxModeData
    */
   public function testIsAjaxMode($query, $result) {
-    $_REQUEST = $_GET = $query;
+    $_POST = $_GET = $query;
     $this->assertEquals($result, CRM_Core_Resources::isAjaxMode());
   }
 

--- a/tests/phpunit/CRM/Financial/Page/AjaxTest.php
+++ b/tests/phpunit/CRM/Financial/Page/AjaxTest.php
@@ -28,9 +28,9 @@ class CRM_Financial_Page_AjaxTest extends CiviUnitTestCase {
      INSERT INTO civicrm_entity_batch (entity_table, entity_id, batch_id)
      values('civicrm_financial_trxn', 1, 1)
    ");
-    $_REQUEST['sEcho'] = 1;
-    $_REQUEST['entityID'] = $batch['id'];
-    $_REQUEST['return'] = TRUE;
+    $_POST['sEcho'] = 1;
+    $_POST['entityID'] = $batch['id'];
+    $_POST['return'] = TRUE;
     $json = CRM_Financial_Page_AJAX::getFinancialTransactionsList();
     $json = str_replace(rtrim(CIVICRM_UF_BASEURL, '/'), 'http://FIX ME', $json);
     $this->assertEquals($json, '{"sEcho": 1, "iTotalRecords": 1, "iTotalDisplayRecords": 1, "aaData": [ ["","<a href=\"/index.php?q=civicrm/profile/view&amp;reset=1&amp;gid=7&amp;id=3&amp;snippet=4\" class=\"crm-summary-link\"><div'

--- a/tests/phpunit/CRM/Group/Page/AjaxTest.php
+++ b/tests/phpunit/CRM/Group/Page/AjaxTest.php
@@ -65,8 +65,8 @@ class CRM_Group_Page_AjaxTest extends CiviUnitTestCase {
    */
   public function setPermissionAndRequest($permission) {
     $this->setPermissions((array) $permission);
-    global $_REQUEST;
-    $_REQUEST = $this->_params;
+    global $_POST;
+    $_POST = $this->_params;
   }
 
   /**
@@ -76,8 +76,8 @@ class CRM_Group_Page_AjaxTest extends CiviUnitTestCase {
   public function setHookAndRequest($permission, $hook) {
     CRM_Core_Config::singleton()->userPermissionClass->permissions = (array) $permission;
     $this->hookClass->setHook('civicrm_aclGroup', [$this, $hook]);
-    global $_REQUEST;
-    $_REQUEST = $this->_params;
+    global $_POST;
+    $_POST = $this->_params;
   }
 
   /**
@@ -664,8 +664,8 @@ class CRM_Group_Page_AjaxTest extends CiviUnitTestCase {
    *
    */
   public function setupEditAllGroupsACL() {
-    global $_REQUEST;
-    $_REQUEST = $this->_params;
+    global $_POST;
+    $_POST = $this->_params;
 
     CRM_Core_Config::singleton()->userPermissionClass->permissions = ['access CiviCRM'];
     $optionGroupID = $this->callAPISuccessGetValue('option_group', ['return' => 'id', 'name' => 'acl_role']);

--- a/tests/phpunit/CRM/Member/Form/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/Form/MembershipTest.php
@@ -1156,8 +1156,8 @@ Expires: ',
    * @throws \CRM_Core_Exception
    */
   protected function getForm() {
-    if (isset($_REQUEST['cid'])) {
-      unset($_REQUEST['cid']);
+    if (isset($_POST['cid'])) {
+      unset($_POST['cid']);
     }
     $form = new CRM_Member_Form_Membership();
     $_SERVER['REQUEST_METHOD'] = 'GET';

--- a/tests/phpunit/CRM/Utils/RestTest.php
+++ b/tests/phpunit/CRM/Utils/RestTest.php
@@ -30,7 +30,7 @@ class CRM_Utils_RestTest extends CiviUnitTestCase {
         ],
       ],
     ];
-    $_REQUEST['json'] = json_encode($input);
+    $_POST['json'] = json_encode($input);
     $output = CRM_Utils_REST::processMultiple();
     $this->assertGreaterThan(0, $output['cow']['id']);
     $this->assertGreaterThan($output['cow']['id'], $output['sheep']['id']);

--- a/tests/phpunit/CiviTest/CiviReportTestCase.php
+++ b/tests/phpunit/CiviTest/CiviReportTestCase.php
@@ -67,7 +67,7 @@ class CiviReportTestCase extends CiviUnitTestCase {
     $reportObj =& $controller->_pages[$reportName];
 
     $tmpGlobals = array();
-    $tmpGlobals['_REQUEST']['force'] = 1;
+    $tmpGlobals['_POST']['force'] = 1;
     $tmpGlobals['_GET'][$config->userFrameworkURLVar] = 'civicrm/placeholder';
     $tmpGlobals['_SERVER']['QUERY_STRING'] = '';
     if (!empty($inputParams['fields'])) {

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -364,7 +364,7 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
     //flush component settings
     CRM_Core_Component::getEnabledComponents(TRUE);
 
-    $_REQUEST = $_GET = $_POST = [];
+    $_GET = $_POST = [];
     error_reporting(E_ALL);
 
     $this->renameLabels();
@@ -2322,8 +2322,7 @@ VALUES
    * @param bool $isProfile
    */
   public function setupACL($isProfile = FALSE) {
-    global $_REQUEST;
-    $_REQUEST = $this->_params;
+    $_POST = $this->_params;
 
     CRM_Core_Config::singleton()->userPermissionClass->permissions = ['access CiviCRM'];
     $optionGroupID = $this->callAPISuccessGetValue('option_group', ['return' => 'id', 'name' => 'acl_role']);

--- a/tests/phpunit/api/v3/CaseTest.php
+++ b/tests/phpunit/api/v3/CaseTest.php
@@ -338,7 +338,7 @@ class api_v3_CaseTest extends CiviCaseTestCase {
     $relType = $this->relationshipTypeCreate(['name_a_b' => 'Test AB', 'name_b_a' => 'Test BA', 'contact_type_b' => 'Individual']);
     $relContact = $this->individualCreate(['first_name' => 'First', 'last_name' => 'Last']);
 
-    $_REQUEST = [
+    $_POST = [
       'rel_type' => "{$relType}_b_a",
       'rel_contact' => $relContact,
       'case_id' => $case['id'],
@@ -857,7 +857,7 @@ class api_v3_CaseTest extends CiviCaseTestCase {
 
     $relType = $this->relationshipTypeCreate(['name_a_b' => 'Test AB', 'name_b_a' => 'Test BA', 'contact_type_b' => 'Individual']);
     $relContact = $this->individualCreate(['first_name' => 'First', 'last_name' => 'Last']);
-    $_REQUEST = [
+    $_POST = [
       'rel_type' => "{$relType}_b_a",
       'rel_contact' => $relContact,
       'case_id' => $case['id'],

--- a/tests/phpunit/api/v3/ContributionPageTest.php
+++ b/tests/phpunit/api/v3/ContributionPageTest.php
@@ -2009,7 +2009,7 @@ class api_v3_ContributionPageTest extends CiviUnitTestCase {
    * to be done before processing but the validity of input needs to be checked first.
    *
    * For example Paypal Checkout will replace the confirm button with it's own but we are able to validate
-   * before paypal launches it's modal. In this case the $_REQUEST is post but we need validation to succeed.
+   * before paypal launches it's modal. In this case the request is sent using POST but we need validation to succeed.
    *
    * @throws \CRM_Core_Exception
    */
@@ -2059,7 +2059,7 @@ class api_v3_ContributionPageTest extends CiviUnitTestCase {
     ]);
     $message .= json_encode($log_params);
     $log = new CRM_Utils_SystemLogger();
-    $log->debug($message, $_REQUEST);
+    $log->debug($message, $_POST);
   }
 
   /**

--- a/tests/phpunit/api/v3/ReportTemplateTest.php
+++ b/tests/phpunit/api/v3/ReportTemplateTest.php
@@ -214,8 +214,7 @@ class api_v3_ReportTemplateTest extends CiviUnitTestCase {
     $this->loadXMLDataSet(__DIR__ . '/../../CRM/Mailing/BAO/queryDataset.xml');
 
     // Check total rows without distinct
-    global $_REQUEST;
-    $_REQUEST['distinct'] = 0;
+    $_POST['distinct'] = 0;
     $result = $this->callAPIAndDocument('report_template', 'getrows', [
       'report_id' => 'Mailing/opened',
       'options' => ['metadata' => ['labels', 'title']],
@@ -223,7 +222,7 @@ class api_v3_ReportTemplateTest extends CiviUnitTestCase {
     $this->assertEquals(14, $result['count']);
 
     // Check total rows with distinct
-    $_REQUEST['distinct'] = 1;
+    $_POST['distinct'] = 1;
     $result = $this->callAPIAndDocument('report_template', 'getrows', [
       'report_id' => 'Mailing/opened',
       'options' => ['metadata' => ['labels', 'title']],
@@ -231,7 +230,7 @@ class api_v3_ReportTemplateTest extends CiviUnitTestCase {
     $this->assertEquals(5, $result['count']);
 
     // Check total rows with distinct by passing NULL value to distinct parameter
-    $_REQUEST['distinct'] = NULL;
+    $_POST['distinct'] = NULL;
     $result = $this->callAPIAndDocument('report_template', 'getrows', [
       'report_id' => 'Mailing/opened',
       'options' => ['metadata' => ['labels', 'title']],


### PR DESCRIPTION
Overview
----------------------------------------

Until this PR, lots of code accessed `$_REQUEST`.

This is problematic for the following reasons:

1. The contents differs between hosting environments, meaning we don't really know where the data is coming from. The assumption (I believe) has been that it contains `array_merge($_GET, $_POST)`, in that order (i.e. a `$_POST` param overrides a `$_GET` one), and without any `$_COOKIE` or other data. However, this cannot be guaranteed as [request_order](https://www.php.net/manual/en/ini.core.php#ini.request-order) and [variables_order](https://www.php.net/manual/en/ini.core.php#ini.variables-order) are PHP settings that affect this. There's a note on php.net that distribution defaults don't include cookies for security reasons, which hints that it's a bad thing to be potentially allowing cookie data into our `$_REQUEST` data.

2. Much better to know where you're expecting your data to come from, and code with `$_GET` for query string data and `$_POST` for request body data (or of course `file_get_contents('php://input')` for the raw data). Just using `$_REQUEST` is a shortcut, but because of that it increases the attack surface (e.g. possible to inject data via GET that the code assumed to have come from a POSTed form); reduces code clarity and makes debugging harder.


Before
----------------------------------------

Lots of code accessed `$_REQUEST` directly and `CRM_Utils_Request::retrieve()` also used `$_REQUEST`.


After
----------------------------------------

No core uses `$_REQUEST`.


Technical Details
----------------------------------------

Generally speaking, I've kept the changes to a minimum, preferring the smallest number of changes to keep the exact same behaviour. But in combing though I found a few incorrect things that I couldn't ignore.

The main `CRM_Utils_Request::retrieve()` method now uses `array_merge($_GET, $_POST)` as its source of data for the default method (i.e. when the caller does not specify GET or POST explicitly). This should be identical to `$_REQUEST` on 99% of server environs and on those that are different, it is now what Civi needs it to be, instead of whatever they have!

General patterns:

A lot of code called `CRM_Utils_Request::retrieve` or `CRM_Utils_Request::retrieveValue` with the wrong value type for it's `$method` which is supposed to be a String, but in dozens of places code was passing the `$_REQUEST` Array. The retrieve method is and was coded with a `switch` that checks on strings `'POST'` and `'GET'`, and in all other cases (e.g. an array!), it defaulted to `$_REQUEST` - so serendipity has served us well! In these cases I have simply removed that param since it's the default behaviour anyway.

The retrieve functions require a validation type. As all* data in HTTP is string data, it's worth noting that `'String'` is a good default to use if you're unsure. \* *all data*: OK, so the exceptions are when PHP has itself coerced the data into something else (e.g. Arrays are created by parameters with `[]` at the end of their names) or cases where Civi has parsed decode a JSON body.

I tried to maintain the exact same logic as-is before this PR. This sometimes meant that I could not use the `CRM_Utils_Request::retrieve*` methods, since `isset()` is not the same as `empty()` etc. So when was the case I used a chain of Null coalesce operators `??`, like `$_POST['foo'] ?? $_GET['foo'] ?? NULL`. Sometimes this was clearer/less code too.

Where I found a dense nest of `$_REQUEST` references close together I have extracted the data into a separate variable to keep the look of the code the same - there's so many variations of logic that are probably not supposed to be different but are subtly different, it seemed simpler and safer to leave that alone. If it ain't broke, don't fix it, sort of thing.

I'll await Jenkins' tests.