### PR TITLE
WIP add preIPNProcess hook so extensions can edit incoming IPN data before processing

### DIFF
--- a/CRM/Core/Payment/AuthorizeNet.php
+++ b/CRM/Core/Payment/AuthorizeNet.php
@@ -733,7 +733,9 @@ class CRM_Core_Payment_AuthorizeNet extends CRM_Core_Payment {
    * Process incoming notification.
    */
   public static function handlePaymentNotification() {
-    $ipnClass = new CRM_Core_Payment_AuthorizeNetIPN(array_merge($_GET, $_REQUEST));
+    $ipnParams = array_merge($_GET, $_REQUEST);
+    CRM_Utils_Hook::preIPNProcess($ipnParams);
+    $ipnClass = new CRM_Core_Payment_AuthorizeNetIPN($ipnParams);
     $ipnClass->main();
   }
 

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -2636,6 +2636,19 @@ abstract class CRM_Utils_Hook {
   }
 
   /**
+   * Allow Extensions to modify IPNData before it gets processed
+   * @param array $IPNData - Array of IPN Data
+   * @return mixed
+   */
+  public static function preIPNProcess(&$IPNData) {
+    return self::singleton()->invoke(['IPNData'],
+      $IPNData, self::$_nullObject, self::$_nullObject,
+      self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      'civicrm_preIPNProcess'
+    );
+  }
+
+  /**
    * Allow extensions to modify the array of acceptable fields to be included on profiles
    * @param array $fields
    *   format is [Entity => array of DAO fields]


### PR DESCRIPTION
Overview
----------------------------------------
This adds a hook preIPNProcess which allows one to edit IPN data before it is processed in CiviCRM.

It is a complement to the postIPNProcess hook (which it looks like was originally designed to be "alterIPNData" https://github.com/civicrm/civicrm-core/pull/12928 and work like this one)

Before
----------------------------------------
No hook that allows one to alter incoming IPN data before it gets processed by CiviCRM

After
----------------------------------------
Hook that allows one to alter incoming IPN data before it gets processed by CiviCRM

Technical Details
----------------------------------------
Currently this only works for the authorize.net IPN if people are on board I can extend it to cover more Incoming IPNs