### PR TITLE
Remove unneeded parameters in {ts} on membership form

### DIFF
--- a/templates/CRM/Member/Form/Membership.tpl
+++ b/templates/CRM/Member/Form/Membership.tpl
@@ -532,7 +532,7 @@
 
           alert = CRM.alert(
             // Mixing client-side variables with a translated string in smarty is awkward!
-            ts({/literal}'{ts escape='js' 1='%1' 2='%2' 3='%3' 4='%4'}This contact has an existing %1 membership at %2 with %3 status%4.{/ts}'{literal}, {1:memberorgs[selectedorg].membership_type, 2: org, 3: memberorgs[selectedorg].membership_status, 4: andEndDate})
+            ts({/literal}'{ts escape='js'}This contact has an existing %1 membership at %2 with %3 status%4.{/ts}'{literal}, {1:memberorgs[selectedorg].membership_type, 2: org, 3: memberorgs[selectedorg].membership_status, 4: andEndDate})
               + '<ul><li><a href="' + memberorgs[selectedorg].renewUrl + '">'
               + {/literal}'{ts escape='js'}Renew the existing membership instead{/ts}'
               + '</a></li><li><a href="' + memberorgs[selectedorg].membershipTab + '">'


### PR DESCRIPTION
Overview
----------------------------------------
These numbers, they do nothing.

Before
----------------------------------------
Same as after.

After
----------------------------------------
Same as before.

Technical Details
----------------------------------------
This line took me a while to get my head around. It's a smarty `{ts}` inside a javascript `ts()` inside a javascript alert(). But for the inner smarty `{ts}`, all it's doing is replacing %1 with the literal %1, %2 with the literal %2, etc... The final output from the smarty template is the same either way.

Also I checked and it's not going to change the string that goes to transifex, e.g.: https://lab.civicrm.org/dev/translation/-/blob/master/po/fr_CA/member.po#L1710

Comments
----------------------------------------
Easiest way to see this is go to a contact with an existing membership, then click to add a membership, then view page source, then find the checkExistingMemOrg function.
