### PR TITLE
Make is_archived work as a url-search parameter

### DIFF
--- a/CRM/Mailing/BAO/Query.php
+++ b/CRM/Mailing/BAO/Query.php
@@ -122,7 +122,7 @@ class CRM_Mailing_BAO_Query {
    * rather than a static function.
    */
   public static function getSearchFieldMetadata() {
-    $fields = ['mailing_job_start_date'];
+    $fields = ['mailing_job_start_date', 'is_archived'];
     $metadata = civicrm_api3('Mailing', 'getfields', [])['values'];
     $metadata = array_merge($metadata, civicrm_api3('MailingJob', 'getfields', [])['values']);
     return array_intersect_key($metadata, array_flip($fields));

--- a/CRM/Mailing/Page/Browse.php
+++ b/CRM/Mailing/Page/Browse.php
@@ -64,7 +64,7 @@ class CRM_Mailing_Page_Browse extends CRM_Core_Page {
   public function preProcess() {
     Civi::resources()->addStyleFile('civicrm', 'css/searchForm.css', 1, 'html-header');
 
-    $this->_unscheduled = $this->_archived = $archiveLinks = FALSE;
+    $this->_unscheduled = $archiveLinks = FALSE;
     $this->_mailingId = CRM_Utils_Request::retrieve('mid', 'Positive', $this);
     $this->_sms = CRM_Utils_Request::retrieve('sms', 'Positive', $this);
 
@@ -119,6 +119,7 @@ class CRM_Mailing_Page_Browse extends CRM_Core_Page {
     $newArgs = func_get_args();
     // since we want only first function argument
     $newArgs = $newArgs[0];
+    $this->_isArchived = $this->isArchived($newArgs);
     if (isset($_GET['runJobs']) || CRM_Utils_Array::value('2', $newArgs) == 'queue') {
       $mailerJobSize = Civi::settings()->get('mailerJobSize');
       CRM_Mailing_BAO_MailingJob::runJobs_pre($mailerJobSize);
@@ -140,10 +141,7 @@ class CRM_Mailing_Page_Browse extends CRM_Core_Page {
     }
     $this->set('unscheduled', $this->_unscheduled);
 
-    if (CRM_Utils_Array::value(3, $newArgs) == 'archived') {
-      $this->_archived = TRUE;
-    }
-    $this->set('archived', $this->_archived);
+    $this->set('archived', $this->isArchived($newArgs));
 
     if (CRM_Utils_Array::value(3, $newArgs) == 'scheduled') {
       $this->_scheduled = TRUE;
@@ -260,7 +258,8 @@ class CRM_Mailing_Page_Browse extends CRM_Core_Page {
       $urlParams .= '&scheduled=false';
       $this->assign('unscheduled', TRUE);
     }
-    elseif (CRM_Utils_Array::value(3, $newArgs) == 'archived') {
+
+    if ($this->isArchived($newArgs)) {
       $urlString .= '/archived';
       $this->assign('archived', TRUE);
     }
@@ -351,6 +350,19 @@ class CRM_Mailing_Page_Browse extends CRM_Core_Page {
     }
 
     return implode(' AND ', $clauses);
+  }
+
+  /**
+   * Is the search limited to archived mailings.
+   *
+   * @param array $urlArguments
+   *
+   * @return bool
+   *
+   * @throws \CRM_Core_Exception
+   */
+  protected function isArchived($urlArguments): bool {
+    return in_array('archived', $urlArguments, TRUE) || CRM_Utils_Request::retrieveValue('is_archived', 'Boolean');
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Eg civicrm/mailing/browse/scheduled?reset=1&is_archived=1&force=1

Before
----------------------------------------
is_archived cannot be passed in the url using our normal url protocol

After
----------------------------------------
```civicrm/mailing/browse/scheduled?reset=1&is_archived=1&force=1``` works, other params would work if in metadata

<img width="522" alt="Screen Shot 2020-05-15 at 12 57 17 PM" src="https://user-images.githubusercontent.com/336308/82000208-ba749d00-96ab-11ea-887c-aa6f0e5de446.png">


Technical Details
----------------------------------------
Ref https://github.com/civicrm/civicrm-core/pull/16478

Comments
----------------------------------------
