### PR TITLE
dev/core#611 Allow individuals to download invoices for their organisation

### DIFF
--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -1644,6 +1644,10 @@ class CRM_Core_Permission {
     ) {
       return TRUE;
     }
+    // Allow downloading invoices for a related contact with view permission
+    if (CRM_Contact_BAO_Contact_Permission::allow($_GET['cid'], CRM_Core_Permission::VIEW)) {
+      return TRUE;
+    }
     return FALSE;
   }
 


### PR DESCRIPTION
Overview
----------------------------------------

My use-case is the following:

- Membership is invoiced to the organization;
- A related contact (with view/edit permission) should be able to login and access the dashboard of the organization, download invoices.

Viewing the related org's dashboard works, it displays the list of invoices and a download link, but clicking on the link results in an "Access Denied".

* https://lab.civicrm.org/dev/core/-/issues/611
* (duplicate) https://lab.civicrm.org/dev/financial/-/issues/125

Before
----------------------------------------

User cannot download invoices for related organization (ex: their employer).

After
----------------------------------------

User can download.

Technical Details
----------------------------------------

The permission check was copied from CRM/Contact/Page/View/UserDashBoard.php.

I would have liked to add a test, but since this is a change on the permission check for the URL route, I'm not sure how to do it.