### PR TITLE
[REF] Fix install on Drupal 8 using new setup code

### DIFF
--- a/Civi/Install/Requirements.php
+++ b/Civi/Install/Requirements.php
@@ -291,7 +291,7 @@ class Requirements {
    * @return array
    */
   public function checkMysqlVersion(array $db_config) {
-    $min = CRM_Upgrade_Incremental_General::MIN_INSTALL_MYSQL_VER;
+    $min = \CRM_Upgrade_Incremental_General::MIN_INSTALL_MYSQL_VER;
     $results = [
       'title' => 'CiviCRM MySQL Version',
       'severity' => $this::REQUIREMENT_OK,


### PR DESCRIPTION
Overview
----------------------------------------
This fixes a hard fail caused by #17261 which showed up when trying to build the Drupal 8 demo site

Before
----------------------------------------
PHP Error

```
  [Symfony\Component\Debug\Exception\FatalThrowableError]         
  Class 'Civi\Install\CRM_Upgrade_Incremental_General' not found  
                                                                  

Exception trace:
 () at /srv/buildkit/build/d8-master/web/vendor/civicrm/civicrm-core/Civi/Install/Requirements.php:294
 Civi\Install\Requirements->checkMysqlVersion() at /srv/buildkit/build/d8-master/web/vendor/civicrm/civicrm-core/Civi/Install/Requirements.php:103
 Civi\Install\Requirements->checkDatabase() at /srv/buildkit/build/d8-master/web/vendor/civicrm/civicrm-core/setup/plugins/checkRequirements/CoreRequirementsAdapter.civi-setup.php:31
```

After
----------------------------------------
No PHP Error

ping @eileenmcnaughton @totten 