### PR TITLE
[REF] Missing semicolon on smtp settings page, code cleanup in file-on-case, add test

### DIFF
--- a/CRM/Activity/Page/AJAX.php
+++ b/CRM/Activity/Page/AJAX.php
@@ -353,7 +353,7 @@ class CRM_Activity_Page_AJAX {
     if (!empty($params['assigneeContactIds'])) {
       $assigneeContacts = array_unique(explode(',', $params['assigneeContactIds']));
     }
-    foreach ($assigneeContacts as $key => $value) {
+    foreach ($assigneeContacts as $value) {
       $assigneeParams = [
         'activity_id' => $mainActivityId,
         'contact_id' => $value,

--- a/templates/CRM/Admin/Form/Setting/Smtp.tpl
+++ b/templates/CRM/Admin/Form/Setting/Smtp.tpl
@@ -93,7 +93,7 @@
     CRM.$(function($) {
       var mailSetting = $("input[name='outBound_option']:checked").val( );
 
-      var archiveWarning = "{/literal}{ts escape='js'}WARNING: You are switching from a testing mode (Redirect to Database) to a live mode. Check Mailings > Archived Mailings, and delete any test mailings that are not in Completed status prior to running the mailing cron job for the first time. This will ensure that test mailings are not actually sent out.{/ts}{literal}"
+      var archiveWarning = "{/literal}{ts escape='js'}WARNING: You are switching from a testing mode (Redirect to Database) to a live mode. Check Mailings > Archived Mailings, and delete any test mailings that are not in Completed status prior to running the mailing cron job for the first time. This will ensure that test mailings are not actually sent out.{/ts}{literal}";
 
         showHideMailOptions( $("input[name='outBound_option']:checked").val( ) ) ;
 

--- a/templates/CRM/Case/Form/ActivityToCase.tpl
+++ b/templates/CRM/Case/Form/ActivityToCase.tpl
@@ -73,7 +73,7 @@
             var caseUrl = destUrl + selectedCaseId + '&cid=' + contactId + context;
 
             var statusMsg = {/literal}'{ts escape='js' 1='%1'}Activity has been filed to %1 case.{/ts}'{literal};
-            CRM.alert(ts(statusMsg, {1: '<a href="' + caseUrl + '">' + caseTitle + '</a>'}), '{/literal}{ts escape="js"}Saved{/ts}{literal}', 'success');
+            CRM.alert(ts(statusMsg, {1: '<a href="' + caseUrl + '">' + CRM._.escape(caseTitle) + '</a>'}), '{/literal}{ts escape="js"}Saved{/ts}{literal}', 'success');
             CRM.refreshParent(a);
           }
         }

--- a/templates/CRM/Report/Form/Actions.tpl
+++ b/templates/CRM/Report/Form/Actions.tpl
@@ -42,7 +42,7 @@
                       (function($) {
                         $('#groups').val('').change(function() {
                           CRM.confirm({
-                            message: ts({/literal}'{ts escape='js' 1='<em>%1</em>'}Add all contacts to %1 group?{/ts}'{literal}, {1: $('option:selected', '#groups').text()})
+                            message: ts({/literal}'{ts escape='js' 1='<em>%1</em>'}Add all contacts to %1 group?{/ts}'{literal}, {1: CRM._.escape($('option:selected', '#groups').text())})
                           })
                             .on({
                               'crmConfirm:yes': function() {

--- a/tests/phpunit/CRM/Activity/Page/AJAXTest.php
+++ b/tests/phpunit/CRM/Activity/Page/AJAXTest.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * @group headless
+ */
+class CRM_Activity_Page_AJAXTest extends CiviUnitTestCase {
+
+  public function setUp() {
+    parent::setUp();
+
+    $this->loadAllFixtures();
+
+    CRM_Core_BAO_ConfigSetting::enableComponent('CiviCase');
+
+    $this->loggedInUser = $this->createLoggedInUser();
+    $this->target = $this->individualCreate();
+  }
+
+  /**
+   * Test the underlying function that implements file-on-case.
+   *
+   * The UI is a quickform but it's only realized as a popup ajax form that
+   * doesn't have its own postProcess. Instead the values are ultimately
+   * passed to the function this test is testing. So there's no form or ajax
+   * being tested here, just the final act of filing the activity.
+   */
+  public function testConvertToCaseActivity() {
+    $activity = $this->callAPISuccess('Activity', 'create', [
+      'source_contact_id' => $this->loggedInUser,
+      'activity_type_id' => 'Meeting',
+      'subject' => 'test file on case',
+      'status_id' => 'Completed',
+      'target_id' => $this->target,
+    ]);
+
+    $case = $this->callAPISuccess('Case', 'create', [
+      'contact_id' => $this->target,
+      'case_type_id' => 'housing_support',
+      'subject' => 'Needs housing',
+    ]);
+
+    $params = [
+      'activityID' => $activity['id'],
+      'caseID' => $case['id'],
+      'mode' => 'file',
+      'targetContactIds' => $this->target,
+    ];
+    $result = CRM_Activity_Page_AJAX::_convertToCaseActivity($params);
+
+    $this->assertEmpty($result['error_msg']);
+    $newActivityId = $result['newId'];
+
+    $caseActivities = $this->callAPISuccess('Activity', 'get', [
+      'case_id' => $case['id'],
+    ])['values'];
+    $this->assertEquals('test file on case', $caseActivities[$newActivityId]['subject']);
+    // This should be a different physical activity, not the same db record as the original.
+    $this->assertNotEquals($activity['id'], $caseActivities[$newActivityId]['id']);
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Missing semicolon on smtp settings page.
Misc code cleanup in file-on-case.
Add test for file-on-case since I didn't see any.

Comments
----------------------------------------
FYI @colemanw @mlutfy 