### PR TITLE
[TEST] dev/core#1766 - Remove flakiness from testGetFromTo tests

### DIFF
--- a/tests/phpunit/CRM/Utils/DateTest.php
+++ b/tests/phpunit/CRM/Utils/DateTest.php
@@ -36,39 +36,52 @@ class CRM_Utils_DateTest extends CiviUnitTestCase {
     return TRUE;
   }
 
-  public function fromToData() {
+  /**
+   * Used by testGetFromTo
+   */
+  private function fromToData() {
     $cases = [];
     // Absolute dates
-    $cases[] = ['20170901000000', '20170913235959', 0, '09/01/2017', '09/13/2017'];
+    $cases['absolute'] = [
+      'expectedFrom' => '20170901000000',
+      'expectedTo' => '20170913235959',
+      'relative' => 0,
+      'from' => '09/01/2017',
+      'to' => '09/13/2017',
+    ];
     // "Today" relative date filter
     $date = new DateTime();
-    $expectedFrom = $date->format('Ymd') . '000000';
-    $expectedTo = $date->format('Ymd') . '235959';
-    $cases[] = [$expectedFrom, $expectedTo, 'this.day', '', ''];
+    $cases['today'] = [
+      'expectedFrom' => $date->format('Ymd') . '000000',
+      'expectedTo' => $date->format('Ymd') . '235959',
+      'relative' => 'this.day',
+      'from' => '',
+      'to' => '',
+    ];
     // "yesterday" relative date filter
     $date = new DateTime();
     $date->sub(new DateInterval('P1D'));
-    $expectedFrom = $date->format('Ymd') . '000000';
-    $expectedTo = $date->format('Ymd') . '235959';
-    $cases[] = [$expectedFrom, $expectedTo, 'previous.day', '', ''];
+    $cases['yesterday'] = [
+      'expectedFrom' => $date->format('Ymd') . '000000',
+      'expectedTo' => $date->format('Ymd') . '235959',
+      'relative' => 'previous.day',
+      'from' => '',
+      'to' => '',
+    ];
     return $cases;
   }
 
   /**
    * Test that getFromTo returns the correct dates.
-   *
-   * @dataProvider fromToData
-   * @param $expectedFrom
-   * @param $expectedTo
-   * @param $relative
-   * @param $from
-   * @param $to
    */
-  public function testGetFromTo($expectedFrom, $expectedTo, $relative, $from, $to) {
-    $obj = new CRM_Utils_Date();
-    list($calculatedFrom, $calculatedTo) = $obj->getFromTo($relative, $from, $to);
-    $this->assertEquals($expectedFrom, $calculatedFrom);
-    $this->assertEquals($expectedTo, $calculatedTo);
+  public function testGetFromTo() {
+    $cases = $this->fromToData();
+    foreach ($cases as $caseDescription => $case) {
+      $obj = new CRM_Utils_Date();
+      list($calculatedFrom, $calculatedTo) = $obj->getFromTo($case['relative'], $case['from'], $case['to']);
+      $this->assertEquals($case['expectedFrom'], $calculatedFrom, "Expected From failed for case $caseDescription");
+      $this->assertEquals($case['expectedTo'], $calculatedTo, "Expected To failed for case $caseDescription");
+    }
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------

https://lab.civicrm.org/dev/core/-/issues/1766

Dataproviders can contain dynamic code but they run even before setupBeforeClass, so among other things they run at a different time than the tests that use them.

Before
----------------------------------------
test results are not consistent

After
----------------------------------------
more consistent test results

Technical Details
----------------------------------------
While it could be done with closures as array elements returned by the dataprovider that then get called from the actual test, for this one it seemed cleaner to just redo it without a dataprovider, and it would be just as easy to add more datasets later .

Comments
----------------------------------------
For the files tab in github, for this one I find this one a little easier to look at using split view.
