### PR TITLE
[NFC] Add comment that deprecated code is actually still reachable

### DIFF
--- a/CRM/Contact/Import/Parser.php
+++ b/CRM/Contact/Import/Parser.php
@@ -832,6 +832,7 @@ abstract class CRM_Contact_Import_Parser extends CRM_Import_Parser {
               $this->formatLocationBlock($value, $formatted);
             }
             else {
+              // @todo - this is still reachable - e.g. import with related contact info like firstname,lastname,spouse-first-name,spouse-last-name,spouse-home-phone
               CRM_Core_Error::deprecatedFunctionWarning('this is not expected to be reachable now');
               $this->formatContactParameters($value, $formatted);
             }


### PR DESCRIPTION
Overview
----------------------------------------
I'm not sure I want to take this on so just adding a comment that this deprecation warning is not true in case someone comes along and deletes it. You can reach it by doing a contact import with "related contact" info, e.g. a csv like

First Name,Last Name,spouse-first-name,spouse-last-name,spouse-home-phone
Amy,Jones,Doug,Jones,444-544-6666

