### PR TITLE
Remove "page=CiviCRM" query string from WordPress front-end

### DIFF
--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -253,7 +253,13 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
 
       // pre-existing logic
       if (isset($path)) {
-        $queryParts[] = 'page=CiviCRM';
+        // Admin URLs still need "page=CiviCRM", front-end URLs do not.
+        if ((is_admin() && !$frontend) || $forceBackend) {
+          $queryParts[] = 'page=CiviCRM';
+        }
+        else {
+          $queryParts[] = 'civiwp=CiviCRM';
+        }
         $queryParts[] = 'q=' . rawurlencode($path);
       }
       if ($wpPageParam) {


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [this issue on Lab](https://lab.civicrm.org/dev/wordpress/-/issues/49).

Before
----------------------------------------
Front end CiviCRM forms fail to load.

After
----------------------------------------
Front end CiviCRM forms load as expected.

Technical Details
----------------------------------------
WordPress has changed the way that `redirect_canonical()` handles the reserved `page` query variable. This PR removes CiviCRM's usage of `page` when rendering front-end forms.

Comments
----------------------------------------
Dependent on [this PR in CiviCRM WordPress](https://github.com/civicrm/civicrm-wordpress/pull/193).