### PR TITLE
Remove "page=CiviCRM" query string from WordPress front-end (5.26)

### DIFF
--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -253,7 +253,13 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
 
       // pre-existing logic
       if (isset($path)) {
-        $queryParts[] = 'page=CiviCRM';
+        // Admin URLs still need "page=CiviCRM", front-end URLs do not.
+        if ((is_admin() && !$frontend) || $forceBackend) {
+          $queryParts[] = 'page=CiviCRM';
+        }
+        else {
+          $queryParts[] = 'civiwp=CiviCRM';
+        }
         $queryParts[] = 'q=' . rawurlencode($path);
       }
       if ($wpPageParam) {


### PR DESCRIPTION
Overview
----------------------------------------
Duplicate of #17350 against 5.26 branch. Requires [this PR to CiviCRM-WordPress](https://github.com/civicrm/civicrm-wordpress/pull/194). Solves [this issue on Lab](https://lab.civicrm.org/dev/wordpress/-/issues/49).