### PR TITLE
Delegate Path and URL discovery to each CMS

### DIFF
--- a/CRM/Utils/System/Base.php
+++ b/CRM/Utils/System/Base.php
@@ -697,6 +697,181 @@ abstract class CRM_Utils_System_Base {
   }
 
   /**
+   * Determine the location of the CiviCRM packages directory.
+   *
+   * @return array
+   *   - url: string. ex: "http://example.com/sites/all/modules/civicrm/packages/"
+   *   - path: string. ex: "/var/www/sites/all/modules/civicrm/packages/"
+   */
+  public function getCiviPackagesStorage() {
+    return [
+      'path' => Civi::paths()->getPath('[civicrm.root]/packages/'),
+      'url' => Civi::paths()->getUrl('[civicrm.root]/packages/', 'absolute'),
+    ];
+  }
+
+  /**
+   * Determine the location of the CiviCRM vendor directory.
+   *
+   * @return array
+   *   - url: string. ex: "http://example.com/sites/all/modules/civicrm/vendor/"
+   *   - path: string. ex: "/var/www/sites/all/modules/civicrm/vendor/"
+   */
+  public function getCiviVendorStorage() {
+    return [
+      'path' => Civi::paths()->getPath('[civicrm.root]/vendor/'),
+      'url' => Civi::paths()->getUrl('[civicrm.root]/vendor/', 'absolute'),
+    ];
+  }
+
+  /**
+   * Determine the location of the CiviCRM bower components directory.
+   *
+   * @return array
+   *   - url: string. ex: "http://example.com/sites/all/modules/civicrm/bower_components/"
+   *   - path: string. ex: "/var/www/sites/all/modules/civicrm/bower_components/"
+   */
+  public function getCiviBowerStorage() {
+    return [
+      'path' => Civi::paths()->getPath('[civicrm.root]/bower_components/'),
+      'url' => Civi::paths()->getUrl('[civicrm.root]/bower_components/', 'absolute'),
+    ];
+  }
+
+  /**
+   * Determine the location of the CiviCRM private directory.
+   *
+   * @return array
+   *   - path: string. ex: "/var/www/sites/default/civicrm/"
+   */
+  public function getCiviPrivateStorage() {
+    return [
+      // For backward compatibility with existing deployments, this
+      // effectively returns `dirname(CIVICRM_TEMPLATE_COMPILEDIR)`.
+      // That's confusing. Future installers should probably set `civicrm.private`
+      // explicitly instead of setting `CIVICRM_TEMPLATE_COMPILEDIR`.
+      'path' => CRM_Utils_File::baseFilePath(),
+    ];
+  }
+
+  /**
+   * Determine the location of the CiviCRM Config and Log directory.
+   *
+   * @return array
+   *   - path: string. ex: "/var/www/sites/default/civicrm/ConfigAndLog"
+   */
+  public function getCiviConfigAndLogStorage() {
+    return [
+      'path' => Civi::paths()->getPath('[civicrm.private]/ConfigAndLog'),
+    ];
+  }
+
+  /**
+   * Determine the location of the CiviCRM template compile directory.
+   *
+   * @return array
+   *   - path: string. ex: "/var/www/sites/default/civicrm/templates_c"
+   */
+  public function getCiviCompileDirectory() {
+    return [
+      // These two formulations are equivalent in typical deployments; however,
+      // for existing systems which previously customized CIVICRM_TEMPLATE_COMPILEDIR,
+      // using the constant should be more backward-compatibility.
+      'path' => defined('CIVICRM_TEMPLATE_COMPILEDIR') ? CIVICRM_TEMPLATE_COMPILEDIR : Civi::paths()->getPath('[civicrm.private]/templates_c'),
+    ];
+  }
+
+  /**
+   * Determine the location of the CiviCRM localisation directory.
+   *
+   * @return array
+   *   - path: string. ex: "/var/www/sites/default/civicrm/l10n"
+   */
+  public function getCiviL10nDirectory() {
+    $dir = defined('CIVICRM_L10N_BASEDIR') ? CIVICRM_L10N_BASEDIR : Civi::paths()->getPath('[civicrm.private]/l10n');
+    return [
+      'path' => is_dir($dir) ? $dir : Civi::paths()->getPath('[civicrm.root]/l10n'),
+    ];
+  }
+
+  /**
+   * Determine the WordPress "front-end base" URL.
+   *
+   * @return array
+   *   - url: string. ex: "http://example.com/"
+   */
+  public function getWPFrontendBase() {
+    return ['url' => rtrim(CIVICRM_UF_BASEURL, '/') . '/'];
+  }
+
+  /**
+   * Determine the WordPress "front-end" URL.
+   *
+   * @return array
+   *   - url: string. ex: "http://example.com/civicrm"
+   */
+  public function getWPFrontend($paths) {
+    $config = CRM_Core_Config::singleton();
+    $suffix = defined('CIVICRM_UF_WP_BASEPAGE') ? CIVICRM_UF_WP_BASEPAGE : $config->wpBasePage;
+    return [
+      'url' => $paths->getVariable('wp.frontend.base', 'url') . $suffix,
+    ];
+  }
+
+  /**
+   * Determine the WordPress "back-end base" URL.
+   *
+   * @return array
+   *   - url: string. ex: "http://example.com/wp-admin/"
+   */
+  public function getWPBackendBase() {
+    return [
+      'url' => rtrim(CIVICRM_UF_BASEURL, '/') . '/wp-admin/',
+    ];
+  }
+
+  /**
+   * Determine the WordPress "back-end" URL.
+   *
+   * @return array
+   *   - url: string. ex: "http://example.com/wp-admin/admin.php"
+   */
+  public function getWPBackend($paths) {
+    return [
+      'url' => $paths->getVariable('wp.backend.base', 'url') . 'admin.php',
+    ];
+  }
+
+  /**
+   * Determine the CMS Path and URL.
+   *
+   * @return array
+   *   - url: string. ex: "http://example.com/wp-admin/admin.php"
+   */
+  public function getCMSPathAndURL() {
+    $config = CRM_Core_Config::singleton();
+    return [
+      'path' => $config->userSystem->cmsRootPath(),
+      'url' => CRM_Utils_System::baseCMSURL(),
+    ];
+  }
+
+  /**
+   * Determine the CMS Root Path and URL.
+   *
+   * @return array
+   *   - url: string. ex: "http://example.com/wp-admin/admin.php"
+   */
+  public function getCMSRootPathAndURL() {
+    $config = CRM_Core_Config::singleton();
+    return [
+      'path' => $config->userSystem->cmsRootPath(),
+      // Misleading: this *removes* the language part of the URL, producing a pristine base URL.
+      'url' => CRM_Utils_System::languageNegotiationURL(CRM_Utils_System::baseCMSURL(), FALSE, TRUE),
+    ];
+  }
+
+  /**
    * Perform any post login activities required by the CMS.
    *
    * e.g. for drupal: records a watchdog message about the new session, saves the login timestamp,


### PR DESCRIPTION
Overview
----------------------------------------
This PR seeks to address the problems identified in [this issue on Lab](https://lab.civicrm.org/dev/wordpress/issues/47) by delegating Path and URL discovery to each CMS. In this PR only WordPress paths are handled separately - but with this architecture, each CMS can handle paths in its own way.

For historical reasons, CiviCRM seeks to discover paths and URLs for all CMSes with a unified set of methods. This seems to work for Drupal 6/7 but is unreliable on WordPress (and Drupal 8 too, AFAIK). When multi-lingual plugins are used in WordPress they impose certain limitations which make it _impossible_ to discover the path to the "base page" for a particular language without bootstrapping WordPress itself.

The best way to do ensure that WordPress is bootstrapped is for all requests to be routed via WordPress itself - and now that the WordPress REST API wrapper is in place, there is no longer any need to call scripts in CiviCRM's `extern` directory. We are now in the "post-extern" world mentioned in the Lab issue and can make progress on previously intractable problems.

To give an example; with Polylang installed, an administrator may choose a different base page per language and then the Polylang plugin itself determines the path to the base page - with the result that the "standard" CiviCRM base page's path of `civicrm` (the default path) is *not* the desired base page. Only Polylang knows the correct page for the requested language - it cannot be externally determined.

This PR does *not* include the final code to satisfy this multi-lingual plugin requirement, but sets the stage for additional code to be added which would resolve the problem. The code to be added to `getBaseUrl()` which resolves this for Polylang looks like this:

```php
      // Get default Base Page object.
      $basepage_obj = get_page_by_path($config->wpBasePage);
      
      // Support Polylang by finding the translated Base Page.
      if (function_exists('pll_get_post')) {
        $post_id = pll_get_post($basepage_obj->ID, pll_current_language());
        $basepage_obj = get_page($post_id);
      }
 
      // Support other plugins, e.g. WPML here.
 
      return get_permalink($basepage_obj->ID);
```

I will open a fresh PR which addresses the precise needs of multi-lingual plugins in WordPress when it is possible to support them - i.e. once this PR (or one similar to this) has been merged.

Before
----------------------------------------
Paths and URLs are determined by code that does not always bootstrap the host CMS.

After
----------------------------------------
Paths and URLs are determined by code that rely on the host CMS being bootstrapped.

Technical Details
----------------------------------------
I have moved the existing logic from `Civi/Core/Paths.php` to `CRM/Utils/System/Base.php` so that only the methods which require special handling by a particular CMS need to be overloaded in their `CRM_Utils_System_CMSNAME` class. The overloaded methods in `CRM_Utils_System_WordPress` show this being done for WordPress, where CMS-specific logic is implemented.