### PR TITLE
[TEST] Update test to support for 8.0.19 change

### DIFF
--- a/tests/phpunit/CRM/Logging/SchemaTest.php
+++ b/tests/phpunit/CRM/Logging/SchemaTest.php
@@ -6,7 +6,10 @@
  */
 class CRM_Logging_SchemaTest extends CiviUnitTestCase {
 
+  protected $databaseVersion;
+
   public function setUp() {
+    $this->databaseVersion = CRM_Utils_SQL::getDatabaseVersion();
     parent::setUp();
   }
 
@@ -18,6 +21,7 @@ class CRM_Logging_SchemaTest extends CiviUnitTestCase {
   public function tearDown() {
     $schema = new CRM_Logging_Schema();
     $schema->disableLogging();
+    $this->databaseVersion = NULL;
     parent::tearDown();
     $this->quickCleanup(['civicrm_contact'], TRUE);
     $schema->dropAllLogTables();
@@ -235,13 +239,17 @@ class CRM_Logging_SchemaTest extends CiviUnitTestCase {
     $this->assertEquals('int', $ci['test_id']['DATA_TYPE']);
     $this->assertEquals('NO', $ci['test_id']['IS_NULLABLE']);
     $this->assertEquals('auto_increment', $ci['test_id']['EXTRA']);
-    $this->assertEquals('10', $ci['test_id']['LENGTH']);
+    if (!$this->isMySQL8()) {
+      $this->assertEquals('10', $ci['test_id']['LENGTH']);
+    }
 
     $this->assertEquals('varchar', $ci['test_varchar']['DATA_TYPE']);
     $this->assertEquals('42', $ci['test_varchar']['LENGTH']);
 
     $this->assertEquals('int', $ci['test_integer']['DATA_TYPE']);
-    $this->assertEquals('8', $ci['test_integer']['LENGTH']);
+    if (!$this->isMySQL8()) {
+      $this->assertEquals('8', $ci['test_integer']['LENGTH']);
+    }
     $this->assertEquals('YES', $ci['test_integer']['IS_NULLABLE']);
 
     $this->assertEquals('decimal', $ci['test_decimal']['DATA_TYPE']);
@@ -282,7 +290,9 @@ class CRM_Logging_SchemaTest extends CiviUnitTestCase {
     $schema->fixSchemaDifferences();
     $ci = \Civi::$statics['CRM_Logging_Schema']['columnSpecs'];
     // length should increase
-    $this->assertEquals(6, $ci['log_civicrm_test_length_change']['test_integer']['LENGTH']);
+    if (!$this->isMySQL8()) {
+      $this->assertEquals(6, $ci['log_civicrm_test_length_change']['test_integer']['LENGTH']);
+    }
     $this->assertEquals('22,2', $ci['log_civicrm_test_length_change']['test_decimal']['LENGTH']);
     CRM_Core_DAO::executeQuery(
       "ALTER TABLE civicrm_test_length_change
@@ -292,7 +302,9 @@ class CRM_Logging_SchemaTest extends CiviUnitTestCase {
     $schema->fixSchemaDifferences();
     $ci = \Civi::$statics['CRM_Logging_Schema']['columnSpecs'];
     // length should not decrease
-    $this->assertEquals(6, $ci['log_civicrm_test_length_change']['test_integer']['LENGTH']);
+    if (!$this->isMySQL8()) {
+      $this->assertEquals(6, $ci['log_civicrm_test_length_change']['test_integer']['LENGTH']);
+    }
     $this->assertEquals('22,2', $ci['log_civicrm_test_length_change']['test_decimal']['LENGTH']);
   }
 
@@ -310,6 +322,15 @@ class CRM_Logging_SchemaTest extends CiviUnitTestCase {
     $ci = \Civi::$statics['CRM_Logging_Schema']['columnSpecs'];
     // new enum value should be included
     $this->assertEquals("'A','B','C','D'", $ci['civicrm_test_enum_change']['test_enum']['ENUM_VALUES']);
+  }
+
+  /**
+   * Determine if we are running on MySQL 8 version 8.0.19 or later.
+   *
+   * @return bool
+   */
+  protected function isMySQL8() {
+    return (bool) (version_compare($this->databaseVersion, '8.0.19', '>=') && stripos($this->databaseVersion, 'mariadb') === FALSE);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
This updates the logging test for changes in MySQL version 8.0.19

Before
----------------------------------------
Tests could fail because the integer length is no longer reported

After
----------------------------------------
Tests pass on MySQL version 8.0.19

Technical Details
----------------------------------------
"Display width specification for integer data types was deprecated in MySQL 8.0.17, and now statements that include data type definitions in their output no longer show the display width for integer types, with these exceptions:

The type is TINYINT(1). MySQL Connectors make the assumption that TINYINT(1) columns originated as BOOLEAN columns; this exception enables them to continue to make that assumption.

The type includes the ZEROFILL attribute.

This change applies to tables, views, and stored routines, and affects the output from SHOW CREATE and DESCRIBE statements, and from INFORMATION_SCHEMA tables.

For DESCRIBE statements and INFORMATION_SCHEMA queries, output is unaffected for objects created in previous MySQL 8.0 versions because information already stored in the data dictionary remains unchanged. This exception does not apply for upgrades from MySQL 5.7 to 8.0, for which all data dictionary information is re-created such that data type definitions do not include display width. (Bug #30556657, Bug #97680)"

Source: https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-19.html

ping @eileenmcnaughton @totten @pfigel 
