### PR TITLE
Fix for dev/core#1608: correct date format for trxn_date.

### DIFF
--- a/CRM/Core/Payment/PayPalProIPN.php
+++ b/CRM/Core/Payment/PayPalProIPN.php
@@ -588,7 +588,7 @@ INNER JOIN civicrm_membership_payment mp ON m.id = mp.membership_id AND mp.contr
     // & suspec main function may be a victom of copy & paste
     // membership would be an easy add - but not relevant to my customer...
     $this->_component = $input['component'] = 'contribute';
-    $input['trxn_date'] = date('Y-m-d-H-i-s', strtotime(self::retrieve('time_created', 'String')));
+    $input['trxn_date'] = date('Y-m-d H:i:s', strtotime(self::retrieve('time_created', 'String')));
     $paymentProcessorID = $contributionRecur['payment_processor_id'];
 
     if (!$this->validateData($input, $ids, $objects, TRUE, $paymentProcessorID)) {


### PR DESCRIPTION
Overview
----------------------------------------
Aims to fix [Recurring contribution fails with "ipn_payment_callback_exception", for membership auto-renewal via PayPalPro](https://lab.civicrm.org/dev/core/-/issues/1608) by correcting date format for the `$input['trxn_date']` parameter.

Before
----------------------------------------
Automatic membership renewal payments, when received as IPN messages for PayPal Pro, fail with exception message "Oops, it looks like there is no valid membership status corresponding to the membership start and end dates for this membership. Contact the site administrator for assistance."

After
----------------------------------------
IPN notifications are processed successfully.

Technical Details
----------------------------------------
Please see long explanation in the [first comment of the referenced issue](https://lab.civicrm.org/dev/core/-/issues/1608#note_32174).

Comments
----------------------------------------
Currently WIP, looking to see test results.