### PR TITLE
[TEST] Fix test failure on Drupal 8 E2E PrevNextTest by only includin…

### DIFF
--- a/tests/phpunit/E2E/Core/PrevNextTest.php
+++ b/tests/phpunit/E2E/Core/PrevNextTest.php
@@ -48,7 +48,7 @@ class PrevNextTest extends \CiviEndToEndTestCase {
     $prefillLimit = 25;
     $sort = NULL;
 
-    $query = new \CRM_Contact_BAO_Query(array(), NULL, NULL, FALSE, FALSE, 1, FALSE, TRUE, FALSE, NULL, 'AND');
+    $query = new \CRM_Contact_BAO_Query([['sort_name', 'IS NOT NULL', 1, 0, 0]], NULL, NULL, FALSE, FALSE, 1, FALSE, TRUE, FALSE, NULL, 'AND');
     $sql = $query->searchQuery($start, $prefillLimit, $sort, FALSE, $query->_includeContactIds,
       FALSE, TRUE, TRUE);
     $selectSQL = "SELECT DISTINCT %1, contact_a.id, contact_a.sort_name";


### PR DESCRIPTION
…g contacts where there is a sort name

Overview
----------------------------------------
The issue here 2 fold 1) the order of the contacts as they are cached is different when running in different cmses and 2) the sort_name doesn't get populated for the admin user (i suspect because of the lack of the sync for users but maybe not) however this change I don't think alters the substance of the test at all

Before
----------------------------------------
Test fails on Drupal 8

After
----------------------------------------
Test passes on Drupal 8

ping @totten @eileenmcnaughton 