### PR TITLE
dev/core#1757 - CRM Menubar - hide toggle menu button for non admin users

### DIFF
--- a/CRM/Utils/System/Drupal.php
+++ b/CRM/Utils/System/Drupal.php
@@ -73,6 +73,23 @@ class CRM_Utils_System_Drupal extends CRM_Utils_System_DrupalBase {
   }
 
   /**
+   * Appends a Drupal 7 Javascript file when the CRM Menubar Javascript file has
+   * been included.
+   */
+  public function appendCoreResources(\Civi\Core\Event\GenericHookEvent $event) {
+    $crmDrupal7JsFilePath = 'js/crm.drupal7.js';
+    $smartMenuFilePath = 'js/crm.menubar.js';
+    $smartMenuFileIndex = array_search($smartMenuFilePath, $event->list);
+    $hasNotIncludedTheCrmMenu = $smartMenuFileIndex === FALSE;
+
+    if ($hasNotIncludedTheCrmMenu) {
+      return;
+    }
+
+    array_splice($event->list, $smartMenuFileIndex + 1, 0, [$crmDrupal7JsFilePath]);
+  }
+
+  /**
    * @inheritDoc
    */
   public function updateCMSName($ufID, $ufName) {

--- a/CRM/Utils/System/Drupal.php
+++ b/CRM/Utils/System/Drupal.php
@@ -74,19 +74,20 @@ class CRM_Utils_System_Drupal extends CRM_Utils_System_DrupalBase {
 
   /**
    * Appends a Drupal 7 Javascript file when the CRM Menubar Javascript file has
-   * been included.
+   * been included. The file is added before the menu bar so we can properly listen
+   * for the menu bar ready event.
    */
   public function appendCoreResources(\Civi\Core\Event\GenericHookEvent $event) {
     $crmDrupal7JsFilePath = 'js/crm.drupal7.js';
-    $smartMenuFilePath = 'js/crm.menubar.js';
-    $smartMenuFileIndex = array_search($smartMenuFilePath, $event->list);
-    $hasNotIncludedTheCrmMenu = $smartMenuFileIndex === FALSE;
+    $menuBarFilePath = 'js/crm.menubar.js';
+    $menuBarFileIndex = array_search($menuBarFilePath, $event->list);
+    $hasNotIncludedTheCrmMenu = $menuBarFileIndex === FALSE;
 
     if ($hasNotIncludedTheCrmMenu) {
       return;
     }
 
-    array_splice($event->list, $smartMenuFileIndex + 1, 0, [$crmDrupal7JsFilePath]);
+    array_splice($event->list, $menuBarFileIndex, 0, [$crmDrupal7JsFilePath]);
   }
 
   /**

--- a/js/crm.drupal7.js
+++ b/js/crm.drupal7.js
@@ -1,4 +1,4 @@
-(function($, crmMenubar) {
+(function($) {
   var menuReadyEvents = {
     adminMenu: $.Deferred(),
     crmMenu: $.Deferred()
@@ -16,10 +16,8 @@
    */
   function hideMenuToggleButtonForNonAdminUsers() {
     var $adminToolbar = $('#toolbar');
-    var $body = $('body');
     var $menuToggleButton = $('#crm-menubar-toggle-position');
     var hasAdminToolbar = $adminToolbar.length > 0;
-    var isCrmMenubarBelowAdminbar = $body.hasClass('crm-menubar-below-cms-menu');
 
     if (hasAdminToolbar) {
       return;
@@ -27,8 +25,8 @@
 
     $menuToggleButton.hide();
 
-    if (isCrmMenubarBelowAdminbar) {
-      crmMenubar.togglePosition();
+    if (CRM.menubar.position === 'below-cms-menu') {
+      CRM.menubar.togglePosition();
     }
   }
-})(CRM.$, CRM.menubar);
+})(CRM.$);

--- a/js/crm.drupal7.js
+++ b/js/crm.drupal7.js
@@ -1,0 +1,44 @@
+(function($, crmMenubar) {
+  var numberOfMenusReady = 0;
+  var numberOfMenusToWaitFor = 2;
+
+  $(document).ready(runWhenMenusAreReady);
+  $(document).on('crmLoad', '#civicrm-menu', runWhenMenusAreReady);
+
+  /**
+   * Runs the hide menu toggle button when both the Admin Menu and the
+   * CiviCRM menu are ready.
+   */
+  function runWhenMenusAreReady() {
+    numberOfMenusReady++;
+
+    if (numberOfMenusReady < numberOfMenusToWaitFor) {
+      return;
+    }
+
+    hideMenuToggleButtonForNonAdminUsers();
+  }
+
+  /**
+   * Hides the Menu Toggle Button when the Admin Menu is not available for the user.
+   * It also positions the CiviCRM Menu in the right position in case it was displayed
+   * under where the Admin Menu would have been. This avoids displaying an empty gap.
+   */
+  function hideMenuToggleButtonForNonAdminUsers() {
+    var $adminToolbar = $('#toolbar');
+    var $body = $('body');
+    var $menuToggleButton = $('#crm-menubar-toggle-position');
+    var hasAdminToolbar = $adminToolbar.length > 0;
+    var isCrmMenubarBelowAdminbar = $body.hasClass('crm-menubar-below-cms-menu');
+
+    if (hasAdminToolbar) {
+      return;
+    }
+
+    $menuToggleButton.hide();
+
+    if (isCrmMenubarBelowAdminbar) {
+      crmMenubar.togglePosition();
+    }
+  }
+})(CRM.$, CRM.menubar);

--- a/js/crm.drupal7.js
+++ b/js/crm.drupal7.js
@@ -1,23 +1,13 @@
 (function($, crmMenubar) {
-  var numberOfMenusReady = 0;
-  var numberOfMenusToWaitFor = 2;
+  var menuReadyEvents = {
+    adminMenu: $.Deferred(),
+    crmMenu: $.Deferred()
+  };
 
-  $(document).ready(runWhenMenusAreReady);
-  $(document).on('crmLoad', '#civicrm-menu', runWhenMenusAreReady);
-
-  /**
-   * Runs the hide menu toggle button when both the Admin Menu and the
-   * CiviCRM menu are ready.
-   */
-  function runWhenMenusAreReady() {
-    numberOfMenusReady++;
-
-    if (numberOfMenusReady < numberOfMenusToWaitFor) {
-      return;
-    }
-
-    hideMenuToggleButtonForNonAdminUsers();
-  }
+  $.when(menuReadyEvents.adminMenu, menuReadyEvents.crmMenu)
+    .done(hideMenuToggleButtonForNonAdminUsers);
+  $(document).ready(menuReadyEvents.adminMenu.resolve);
+  $(document).on('crmLoad', '#civicrm-menu', menuReadyEvents.crmMenu.resolve);
 
   /**
    * Hides the Menu Toggle Button when the Admin Menu is not available for the user.


### PR DESCRIPTION
Overview
----------------------------------------
This PR hides the "adjust menu position" for non admin users. The reason for this is that the user would see an empty gap if they can't normally see the admin menu.

Before
----------------------------------------
![gif](https://user-images.githubusercontent.com/1642119/82278922-5840c400-9959-11ea-9e4a-d06af75d0f80.gif)


After
----------------------------------------
![gif](https://user-images.githubusercontent.com/1642119/82278752-ecf6f200-9958-11ea-8743-add6dd972bbe.gif)


Technical Details
----------------------------------------

We have updated the `CRM/Utils/System/Drupal.php` file so it includes a `js/crm.drupal7.js` script only for Drupal 7 installations since this issue is related to the Drupal menu. We take into consideration if the `js/crm.menubar.js` has already been appended for two reasons: 1 - we only want to hide this button when the CRM menu is present, and 2 - we insert the script after the CRM Menubar script because we need to use the toggle function inside there.

for the `js/crm.drupal7.js` file we need to wait for both the CiviCRM Menu and Admin Menu to be available to determine if we need to hide the toggle button and to hide button itself since it's included inside of the CiviCRM Menu. We know the CiviCRM menu is ready after listening for `$(document).on('crmLoad', '#civicrm-menu')` and the Admin menu is ready when the document is loaded on `$(document).ready`. Something important to consider for this implementation is that the CiviCRM Menu might be ready before, or after the document is ready. This is because the CiviCRM Menu is cached after it first loads. This is the reason why we need to listen for both events.

After we wait for both menus to be ready we check if the Admin Menu has been appended to the DOM, and if not, we hide the toggle button since there's nothing to toggle. We also set the menu in the right position in case this button was already toggled so we avoid showing an empty gap to the user. This can happen after toggling the button or when switching from an admin account to a normal user account.


