### PR TITLE
WP - Change definitions of `cms.root`, `civicrm.root`

### DIFF
--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -44,25 +44,76 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
    * Specify the default computation for various paths/URLs.
    */
   protected function registerPathVars():void {
-    Civi::paths()
-      ->register('wp.frontend.base', function () {
-        return ['url' => rtrim(CIVICRM_UF_BASEURL, '/') . '/'];
-      })
-      ->register('wp.frontend', function () {
-        $config = \CRM_Core_Config::singleton();
-        $suffix = defined('CIVICRM_UF_WP_BASEPAGE') ? CIVICRM_UF_WP_BASEPAGE : $config->wpBasePage;
+    $isNormalBoot = function_exists('get_option');
+    if ($isNormalBoot) {
+      // Normal mode - CMS boots first, then calls Civi. "Normal" web pages and newer extern routes.
+      // To simplify the code-paths, some items are re-registered with WP-specific functions.
+      $cmsRoot = function() {
         return [
-          'url' => Civi::paths()->getVariable('wp.frontend.base', 'url') . $suffix,
+          'path' => untrailingslashit(ABSPATH),
+          'url' => home_url(),
         ];
-      })
-      ->register('wp.backend.base', function () {
-        return ['url' => rtrim(CIVICRM_UF_BASEURL, '/') . '/wp-admin/'];
-      })
-      ->register('wp.backend', function () {
+      };
+      Civi::paths()->register('cms', $cmsRoot);
+      Civi::paths()->register('cms.root', $cmsRoot);
+      Civi::paths()->register('civicrm.files', function () {
+        $upload_dir = wp_get_upload_dir();
         return [
-          'url' => Civi::paths()->getVariable('wp.backend.base', 'url') . 'admin.php',
+          'path' => $upload_dir['basedir'] . DIRECTORY_SEPARATOR . 'civicrm' . DIRECTORY_SEPARATOR,
+          'url' => $upload_dir['baseurl'] . '/civicrm/',
         ];
       });
+      Civi::paths()->register('civicrm.root', function () {
+        return [
+          'path' => CIVICRM_PLUGIN_DIR . 'civicrm' . DIRECTORY_SEPARATOR,
+          'url' => CIVICRM_PLUGIN_URL . 'civicrm/',
+        ];
+      });
+      Civi::paths()->register('wp.frontend.base', function () {
+        return [
+          'url' => home_url('/'),
+        ];
+      });
+      Civi::paths()->register('wp.frontend', function () {
+        $config = CRM_Core_Config::singleton();
+        $basepage = get_page_by_path($config->wpBasePage);
+        return [
+          'url' => get_permalink($basepage->ID),
+        ];
+      });
+      Civi::paths()->register('wp.backend.base', function () {
+        return [
+          'url' => admin_url(),
+        ];
+      });
+      Civi::paths()->register('wp.backend', function() {
+        return [
+          'url' => admin_url('admin.php'),
+        ];
+      });
+    }
+    else {
+      // Legacy support - only relevant for older extern routes.
+      Civi::paths()
+        ->register('wp.frontend.base', function () {
+          return ['url' => rtrim(CIVICRM_UF_BASEURL, '/') . '/'];
+        })
+        ->register('wp.frontend', function () {
+          $config = \CRM_Core_Config::singleton();
+          $suffix = defined('CIVICRM_UF_WP_BASEPAGE') ? CIVICRM_UF_WP_BASEPAGE : $config->wpBasePage;
+          return [
+            'url' => Civi::paths()->getVariable('wp.frontend.base', 'url') . $suffix,
+          ];
+        })
+        ->register('wp.backend.base', function () {
+          return ['url' => rtrim(CIVICRM_UF_BASEURL, '/') . '/wp-admin/'];
+        })
+        ->register('wp.backend', function () {
+          return [
+            'url' => Civi::paths()->getVariable('wp.backend.base', 'url') . 'admin.php',
+          ];
+        });
+    }
   }
 
   /**

--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -35,6 +35,36 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
     $this->is_wordpress = TRUE;
   }
 
+  public function initialize() {
+    parent::initialize();
+    $this->registerPathVars();
+  }
+
+  /**
+   * Specify the default computation for various paths/URLs.
+   */
+  protected function registerPathVars():void {
+    Civi::paths()
+      ->register('wp.frontend.base', function () {
+        return ['url' => rtrim(CIVICRM_UF_BASEURL, '/') . '/'];
+      })
+      ->register('wp.frontend', function () {
+        $config = \CRM_Core_Config::singleton();
+        $suffix = defined('CIVICRM_UF_WP_BASEPAGE') ? CIVICRM_UF_WP_BASEPAGE : $config->wpBasePage;
+        return [
+          'url' => Civi::paths()->getVariable('wp.frontend.base', 'url') . $suffix,
+        ];
+      })
+      ->register('wp.backend.base', function () {
+        return ['url' => rtrim(CIVICRM_UF_BASEURL, '/') . '/wp-admin/'];
+      })
+      ->register('wp.backend', function () {
+        return [
+          'url' => Civi::paths()->getVariable('wp.backend.base', 'url') . 'admin.php',
+        ];
+      });
+  }
+
   /**
    * @inheritDoc
    */

--- a/Civi/Core/Paths.php
+++ b/Civi/Core/Paths.php
@@ -30,7 +30,6 @@ class Paths {
    * Class constructor.
    */
   public function __construct() {
-    $paths = $this;
     $this
       ->register('civicrm.root', function () {
         return \CRM_Core_Config::singleton()->userSystem->getCiviSourceStorage();
@@ -82,24 +81,6 @@ class Paths {
         $dir = defined('CIVICRM_L10N_BASEDIR') ? CIVICRM_L10N_BASEDIR : \Civi::paths()->getPath('[civicrm.private]/l10n');
         return [
           'path' => is_dir($dir) ? $dir : \Civi::paths()->getPath('[civicrm.root]/l10n'),
-        ];
-      })
-      ->register('wp.frontend.base', function () {
-        return ['url' => rtrim(CIVICRM_UF_BASEURL, '/') . '/'];
-      })
-      ->register('wp.frontend', function () use ($paths) {
-        $config = \CRM_Core_Config::singleton();
-        $suffix = defined('CIVICRM_UF_WP_BASEPAGE') ? CIVICRM_UF_WP_BASEPAGE : $config->wpBasePage;
-        return [
-          'url' => $paths->getVariable('wp.frontend.base', 'url') . $suffix,
-        ];
-      })
-      ->register('wp.backend.base', function () {
-        return ['url' => rtrim(CIVICRM_UF_BASEURL, '/') . '/wp-admin/'];
-      })
-      ->register('wp.backend', function () use ($paths) {
-        return [
-          'url' => $paths->getVariable('wp.backend.base', 'url') . 'admin.php',
         ];
       })
       ->register('cms', function () {

--- a/Civi/Core/Paths.php
+++ b/Civi/Core/Paths.php
@@ -30,6 +30,10 @@ class Paths {
    * Class constructor.
    */
   public function __construct() {
+    // Below is a *default* set of functions to calculate paths/URLs.
+    // Some variables may be overridden as follow:
+    // - The global `$civicrm_paths` may be preset before Civi boots. (Ex: via `civicrm.settings.php`, `settings.php`, or `vendor/autoload.php`)
+    // - Variables may be re-registered. (Ex: via `CRM_Utils_System_WordPress`)
     $this
       ->register('civicrm.root', function () {
         return \CRM_Core_Config::singleton()->userSystem->getCiviSourceStorage();


### PR DESCRIPTION
Overview
----------------------------------------

This is an alternative to #17353.

Before
----------------------------------------

The logic for computing path/URL defaults is in `Civi/Core/Paths.php`.

On WP, normal Civi pages and standalone extern scripts use the same logic for computing paths/URLs.

After
----------------------------------------

The *base* logic for computing path/URL defaults is in `Civi/Core/Paths.php`.

For Civi-WP, certain variables (which are easier to compute via WP APIs) are overridden in `CRM/Utils/System/WordPress.php`.

On WP, the path/URL logic for has been split:

* One codepath for normal Civi pages - based on WP APIs
* Another codepath for older, standalone extern scripts - based on the same logic as before

Technical Details
----------------------------------------

Some key differentiators vs #17353:

* Uses the existing `Civi::paths()->register()` interface
* Doesn't add a long list of `getFooStorage()` functions
* If you use any normal page or any newer extern-like end-points, then it uses the prettier callpath.
* If you have external references to the standalone `extern/*` scripts, and if those scripts are currently working, then they should continue working in the same way as before.
* Moves the `wp.frontend`, `wp.backend`, etc variables (which are really WP-specific) out from `Civi/Core/Paths.php` to `CRM/Utils/System/WordPress.php`.