### PR TITLE
dev/core#1767 Fix phone key parsing in CRM_Dedupe_Finder

### DIFF
--- a/CRM/Dedupe/Finder.php
+++ b/CRM/Dedupe/Finder.php
@@ -252,7 +252,7 @@ class CRM_Dedupe_Finder {
     // the -digit to civicrm_address.location_type_id and -Primary to civicrm_address.is_primary
     foreach ($flat as $key => $value) {
       $matches = [];
-      if (preg_match('/(.*)-(Primary-[\d+])$|(.*)-(\d+|Primary)$/', $key, $matches)) {
+      if (preg_match('/(.\*)-(Primary-[\d+])$|(.\*)-(\d+-\d+)$|(.\*)-(\d+|Primary)$/', $key, $matches)) {
         $return = array_values(array_filter($matches));
         // make sure the first occurrence is kept, not the last
         $flat[$return[1]] = empty($flat[$return[1]]) ? $value : $flat[$return[1]];

--- a/CRM/Dedupe/Finder.php
+++ b/CRM/Dedupe/Finder.php
@@ -252,7 +252,7 @@ class CRM_Dedupe_Finder {
     // the -digit to civicrm_address.location_type_id and -Primary to civicrm_address.is_primary
     foreach ($flat as $key => $value) {
       $matches = [];
-      if (preg_match('/(.\*)-(Primary-[\d+])$|(.\*)-(\d+-\d+)$|(.\*)-(\d+|Primary)$/', $key, $matches)) {
+      if (preg_match('/(.*)-(Primary-[\d+])$|(.*)-(\d+-\d+)$|(.*)-(\d+|Primary)$/', $key, $matches)) {
         $return = array_values(array_filter($matches));
         // make sure the first occurrence is kept, not the last
         $flat[$return[1]] = empty($flat[$return[1]]) ? $value : $flat[$return[1]];


### PR DESCRIPTION
Overview
----------------------------------------
This is a PR for an issue reported on lab. That issue also contained a solution and I have created the PR. As SRQ_Civicrm was not able to do so. So I helped him by providing the PR. 

The issue is wel documented on lab.

Before
----------------------------------------

The reg ex for finding duplicate phone numbers was wrong.

1. Create individual unsupervised rule that matches on phone
1. Create input profile that creates contact with phone-main-mobile and set to "Update the matching contact" on duplicate match
1. Create multiple contacts with same phone

-> Creates duplicate contacts

After
----------------------------------------

The reg ex has been changed a duplicate phone numbers would be found. 

->Update pre-existing contact

Comments
----------------------------------------
See https://lab.civicrm.org/dev/core/-/issues/1767 for reproduction steps.
