### PR TITLE
dev/core#1757 hide menu toggle when D7 toolbar is absent

### DIFF
--- a/CRM/Utils/System/Drupal.php
+++ b/CRM/Utils/System/Drupal.php
@@ -78,16 +78,11 @@ class CRM_Utils_System_Drupal extends CRM_Utils_System_DrupalBase {
    * for the menu bar ready event.
    */
   public function appendCoreResources(\Civi\Core\Event\GenericHookEvent $event) {
-    $crmDrupal7JsFilePath = 'js/crm.drupal7.js';
-    $menuBarFilePath = 'js/crm.menubar.js';
-    $menuBarFileIndex = array_search($menuBarFilePath, $event->list);
-    $hasNotIncludedTheCrmMenu = $menuBarFileIndex === FALSE;
+    $menuBarFileIndex = array_search('js/crm.menubar.js', $event->list);
 
-    if ($hasNotIncludedTheCrmMenu) {
-      return;
+    if ($menuBarFileIndex !== FALSE) {
+      array_splice($event->list, $menuBarFileIndex, 0, ['js/crm.drupal7.js']);
     }
-
-    array_splice($event->list, $menuBarFileIndex, 0, [$crmDrupal7JsFilePath]);
   }
 
   /**

--- a/CRM/Utils/System/Drupal.php
+++ b/CRM/Utils/System/Drupal.php
@@ -73,6 +73,24 @@ class CRM_Utils_System_Drupal extends CRM_Utils_System_DrupalBase {
   }
 
   /**
+   * Appends a Drupal 7 Javascript file when the CRM Menubar Javascript file has
+   * been included. The file is added before the menu bar so we can properly listen
+   * for the menu bar ready event.
+   */
+  public function appendCoreResources(\Civi\Core\Event\GenericHookEvent $event) {
+    $crmDrupal7JsFilePath = 'js/crm.drupal7.js';
+    $menuBarFilePath = 'js/crm.menubar.js';
+    $menuBarFileIndex = array_search($menuBarFilePath, $event->list);
+    $hasNotIncludedTheCrmMenu = $menuBarFileIndex === FALSE;
+
+    if ($hasNotIncludedTheCrmMenu) {
+      return;
+    }
+
+    array_splice($event->list, $menuBarFileIndex, 0, [$crmDrupal7JsFilePath]);
+  }
+
+  /**
    * @inheritDoc
    */
   public function updateCMSName($ufID, $ufName) {

--- a/js/crm.drupal7.js
+++ b/js/crm.drupal7.js
@@ -1,32 +1,18 @@
+// https://civicrm.org/licensing
 (function($) {
-  var menuReadyEvents = {
-    adminMenu: $.Deferred(),
-    crmMenu: $.Deferred()
-  };
+  "use strict";
 
-  $.when(menuReadyEvents.adminMenu, menuReadyEvents.crmMenu)
-    .done(hideMenuToggleButtonForNonAdminUsers);
-  $(document).ready(menuReadyEvents.adminMenu.resolve);
-  $(document).on('crmLoad', '#civicrm-menu', menuReadyEvents.crmMenu.resolve);
+  $(document).on('crmLoad', '#civicrm-menu', hideMenuToggleButtonForNonAdminUsers);
 
   /**
    * Hides the Menu Toggle Button when the Admin Menu is not available for the user.
-   * It also positions the CiviCRM Menu in the right position in case it was displayed
-   * under where the Admin Menu would have been. This avoids displaying an empty gap.
    */
   function hideMenuToggleButtonForNonAdminUsers() {
-    var $adminToolbar = $('#toolbar');
-    var $menuToggleButton = $('#crm-menubar-toggle-position');
-    var hasAdminToolbar = $adminToolbar.length > 0;
-
-    if (hasAdminToolbar) {
-      return;
-    }
-
-    $menuToggleButton.hide();
-
-    if (CRM.menubar.position === 'below-cms-menu') {
-      CRM.menubar.togglePosition();
-    }
+    $(document).ready(function() {
+      if (!$('#toolbar').length) {
+        CRM.menubar.removeToggleButton();
+      }
+    });
   }
+
 })(CRM.$);

--- a/js/crm.drupal7.js
+++ b/js/crm.drupal7.js
@@ -1,0 +1,32 @@
+(function($) {
+  var menuReadyEvents = {
+    adminMenu: $.Deferred(),
+    crmMenu: $.Deferred()
+  };
+
+  $.when(menuReadyEvents.adminMenu, menuReadyEvents.crmMenu)
+    .done(hideMenuToggleButtonForNonAdminUsers);
+  $(document).ready(menuReadyEvents.adminMenu.resolve);
+  $(document).on('crmLoad', '#civicrm-menu', menuReadyEvents.crmMenu.resolve);
+
+  /**
+   * Hides the Menu Toggle Button when the Admin Menu is not available for the user.
+   * It also positions the CiviCRM Menu in the right position in case it was displayed
+   * under where the Admin Menu would have been. This avoids displaying an empty gap.
+   */
+  function hideMenuToggleButtonForNonAdminUsers() {
+    var $adminToolbar = $('#toolbar');
+    var $menuToggleButton = $('#crm-menubar-toggle-position');
+    var hasAdminToolbar = $adminToolbar.length > 0;
+
+    if (hasAdminToolbar) {
+      return;
+    }
+
+    $menuToggleButton.hide();
+
+    if (CRM.menubar.position === 'below-cms-menu') {
+      CRM.menubar.togglePosition();
+    }
+  }
+})(CRM.$);

--- a/js/crm.menubar.js
+++ b/js/crm.menubar.js
@@ -8,6 +8,7 @@
     data: null,
     settings: {collapsibleBehavior: 'accordion'},
     position: 'over-cms-menu',
+    toggleButton: true,
     attachTo: (CRM.menubar && CRM.menubar.position === 'above-crm-container') ? '#crm-container' : 'body',
     initialize: function() {
       var cache = CRM.cache.get('menubar');
@@ -231,7 +232,7 @@
       }
     },
     initializePosition: function() {
-      if (CRM.menubar.position === 'over-cms-menu' || CRM.menubar.position === 'below-cms-menu') {
+      if (CRM.menubar.toggleButton && (CRM.menubar.position === 'over-cms-menu' || CRM.menubar.position === 'below-cms-menu')) {
         $('#civicrm-menu')
           .on('click', 'a[href="#toggle-position"]', function(e) {
             e.preventDefault();
@@ -241,6 +242,13 @@
         CRM.menubar.position = CRM.cache.get('menubarPosition', CRM.menubar.position);
       }
       $('body').addClass('crm-menubar-visible crm-menubar-' + CRM.menubar.position);
+    },
+    removeToggleButton: function() {
+      $('#crm-menubar-toggle-position').remove();
+      CRM.menubar.toggleButton = false;
+      if (CRM.menubar.position === 'below-cms-menu') {
+        CRM.menubar.togglePosition();
+      }
     },
     initializeResponsive: function() {
       var $mainMenuState = $('#crm-menubar-state');


### PR DESCRIPTION
Overview
----------------------------------------
*This is a reviewer's cut of #17359:*

This PR hides the "adjust menu position" for non admin users. The reason for this is that the user would see an empty gap if they can't normally see the admin menu.

Before
----------------------------------------
![gif](https://user-images.githubusercontent.com/1642119/82278922-5840c400-9959-11ea-9e4a-d06af75d0f80.gif)


After
----------------------------------------
![gif](https://user-images.githubusercontent.com/1642119/82278752-ecf6f200-9958-11ea-8743-add6dd972bbe.gif)


Technical Details
----------------------------------------

We have updated the `CRM/Utils/System/Drupal.php` file so it includes a `js/crm.drupal7.js` script only for Drupal 7 installations since this issue is related to the Drupal menu. We take into consideration if the `js/crm.menubar.js` has already been appended for two reasons: 1 - we only want to hide this button when the CRM menu is present, and 2 - we insert the script after the CRM Menubar script because we need to use the toggle function inside there.

for the `js/crm.drupal7.js` file we need to wait for both the CiviCRM Menu and Admin Menu to be available to determine if we need to hide the toggle button and to hide button itself since it's included inside of the CiviCRM Menu. We know the CiviCRM menu is ready after listening for `$(document).on('crmLoad', '#civicrm-menu')` and the Admin menu is ready when the document is loaded on `$(document).ready`. Something important to consider for this implementation is that the CiviCRM Menu might be ready before, or after the document is ready. This is because the CiviCRM Menu is cached after it first loads. This is the reason why we need to listen for both events.

After we wait for both menus to be ready we check if the Admin Menu has been appended to the DOM, and if not, we hide the toggle button since there's nothing to toggle. We also set the menu in the right position in case this button was already toggled so we avoid showing an empty gap to the user. This can happen after toggling the button or when switching from an admin account to a normal user account.


