### PR TITLE
Api4: Add Price api entities

### DIFF
--- a/CRM/Core/I18n/SchemaStructure.php
+++ b/CRM/Core/I18n/SchemaStructure.php
@@ -154,7 +154,7 @@ class CRM_Core_I18n_SchemaStructure {
           'help_post' => "text COMMENT 'Description and/or help text to display after this field.'",
         ],
         'civicrm_price_field_value' => [
-          'label' => "varchar(255) COMMENT 'Price field option label'",
+          'label' => "varchar(255) NOT NULL COMMENT 'Price field option label'",
           'description' => "text DEFAULT NULL COMMENT 'Price field option description.'",
           'help_pre' => "text DEFAULT NULL COMMENT 'Price field option pre help text.'",
           'help_post' => "text DEFAULT NULL COMMENT 'Price field option post field help.'",

--- a/CRM/Price/BAO/PriceFieldValue.php
+++ b/CRM/Price/BAO/PriceFieldValue.php
@@ -61,7 +61,7 @@ class CRM_Price_BAO_PriceFieldValue extends CRM_Price_DAO_PriceFieldValue {
       return NULL;
     }
     if (!$id && empty($params['name'])) {
-      $params['name'] = strtolower(CRM_Utils_String::munge($params['label'], '_', 242));
+      $params['name'] = strtolower(CRM_Utils_String::munge(($params['label'] ?? '_'), '_', 242));
     }
 
     if ($id && !empty($params['weight'])) {
@@ -76,13 +76,8 @@ class CRM_Price_BAO_PriceFieldValue extends CRM_Price_DAO_PriceFieldValue {
       $fieldValues = ['price_field_id' => CRM_Utils_Array::value('price_field_id', $params, 0)];
       $params['weight'] = CRM_Utils_Weight::updateOtherWeights('CRM_Price_DAO_PriceFieldValue', $oldWeight, $params['weight'], $fieldValues);
     }
-    else {
-      if (!$id) {
-        CRM_Core_DAO::setCreateDefaults($params, self::getDefaults());
-        if (empty($params['name'])) {
-          $params['name'] = CRM_Utils_String::munge(CRM_Utils_Array::value('label', $params), '_', 64);
-        }
-      }
+    elseif (!$id) {
+      CRM_Core_DAO::setCreateDefaults($params, self::getDefaults());
     }
 
     $financialType = $params['financial_type_id'] ?? NULL;

--- a/Civi/Api4/PriceField.php
+++ b/Civi/Api4/PriceField.php
@@ -13,10 +13,10 @@
 namespace Civi\Api4;
 
 /**
- * LocationType entity.
+ * PriceField entity.
  *
  * @package Civi\Api4
  */
-class LocationType extends Generic\DAOEntity {
+class PriceField extends Generic\DAOEntity {
 
 }

--- a/Civi/Api4/PriceFieldValue.php
+++ b/Civi/Api4/PriceFieldValue.php
@@ -13,10 +13,10 @@
 namespace Civi\Api4;
 
 /**
- * LocationType entity.
+ * PriceFieldValue entity.
  *
  * @package Civi\Api4
  */
-class LocationType extends Generic\DAOEntity {
+class PriceFieldValue extends Generic\DAOEntity {
 
 }

--- a/Civi/Api4/PriceSet.php
+++ b/Civi/Api4/PriceSet.php
@@ -13,10 +13,10 @@
 namespace Civi\Api4;
 
 /**
- * LocationType entity.
+ * PriceSet entity.
  *
  * @package Civi\Api4
  */
-class LocationType extends Generic\DAOEntity {
+class PriceSet extends Generic\DAOEntity {
 
 }

--- a/Civi/Api4/Service/Spec/Provider/PriceFieldValueCreationSpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/PriceFieldValueCreationSpecProvider.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+
+namespace Civi\Api4\Service\Spec\Provider;
+
+use Civi\Api4\Service\Spec\RequestSpec;
+
+class PriceFieldValueCreationSpecProvider implements Generic\SpecProviderInterface {
+
+  /**
+   * @inheritDoc
+   */
+  public function modifySpec(RequestSpec $spec) {
+    // Name will be auto-generated from label if not supplied
+    $spec->getFieldByName('name')->setRequired(FALSE);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function applies($entity, $action) {
+    return $entity === 'PriceFieldValue' && $action === 'create';
+  }
+
+}

--- a/xml/schema/Price/PriceFieldValue.xml
+++ b/xml/schema/Price/PriceFieldValue.xml
@@ -37,6 +37,7 @@
     <title>Name</title>
     <length>255</length>
     <comment>Price field option name</comment>
+    <required>true</required>
     <html>
       <type>Text</type>
     </html>
@@ -49,6 +50,7 @@
     <length>255</length>
     <localizable>true</localizable>
     <comment>Price field option label</comment>
+    <required>true</required>
     <html>
       <type>Text</type>
     </html>


### PR DESCRIPTION
Overview
----------------------------------------
Api4 entities for Price, PriceField & PriceFieldValue.

All 3 entities are accessed in the PriceFieldTest

Before
----------------------------------------
No api4 for specified entities

After
----------------------------------------
Basic crud entities created

Technical Details
----------------------------------------


Comments
----------------------------------------

