### PR TITLE
Revert "[REF] Code readability changes on activity tokens."

### DIFF
--- a/CRM/Activity/Form/Task/PDFLetterCommon.php
+++ b/CRM/Activity/Form/Task/PDFLetterCommon.php
@@ -53,7 +53,7 @@ class CRM_Activity_Form_Task_PDFLetterCommon extends CRM_Core_Form_Task_PDFLette
     $tp->addMessage('body_html', $html_message, 'text/html');
 
     foreach ($activityIds as $activityId) {
-      $tp->addRow()->context('activity_id', $activityId);
+      $tp->addRow()->context('activityId', $activityId);
     }
     $tp->evaluate();
 
@@ -69,7 +69,7 @@ class CRM_Activity_Form_Task_PDFLetterCommon extends CRM_Core_Form_Task_PDFLette
     return new TokenProcessor(\Civi::dispatcher(), [
       'controller' => get_class(),
       'smarty' => FALSE,
-      'schema' => ['activity_id'],
+      'schema' => ['activityId'],
     ]);
   }
 

--- a/CRM/Activity/Tokens.php
+++ b/CRM/Activity/Tokens.php
@@ -48,12 +48,10 @@ class CRM_Activity_Tokens extends \Civi\Token\AbstractTokenSubscriber {
   }
 
   /**
-   * Get the name of the field which holds the ID of the given entity.
-   *
    * @return string
    */
-  private function getEntityIDFieldName(): string {
-    return 'activity_id';
+  private function getEntityContextSchema(): string {
+    return 'activityId';
   }
 
   /**
@@ -90,7 +88,7 @@ class CRM_Activity_Tokens extends \Civi\Token\AbstractTokenSubscriber {
     // Find all the entity IDs
     $entityIds
       = $e->getTokenProcessor()->getContextValues('actionSearchResult', 'entityID')
-      + $e->getTokenProcessor()->getContextValues($this->getEntityIDFieldName());
+      + $e->getTokenProcessor()->getContextValues($this->getEntityContextSchema());
 
     if (!$entityIds) {
       return NULL;
@@ -124,8 +122,6 @@ class CRM_Activity_Tokens extends \Civi\Token\AbstractTokenSubscriber {
 
   /**
    * @inheritDoc
-   *
-   * @throws \CRM_Core_Exception
    */
   public function evaluateToken(\Civi\Token\TokenRow $row, $entity, $field, $prefetch = NULL) {
     // maps token name to api field
@@ -134,7 +130,7 @@ class CRM_Activity_Tokens extends \Civi\Token\AbstractTokenSubscriber {
     ];
 
     // Get ActivityID either from actionSearchResult (for scheduled reminders) if exists
-    $activityId = $row->context['actionSearchResult']->entityID ?? $row->context[$this->getEntityIDFieldName()];
+    $activityId = $row->context['actionSearchResult']->entityID ?? $row->context[$this->getEntityContextSchema()];
 
     $activity = (object) $prefetch['activity'][$activityId];
 

--- a/CRM/Core/TokenTrait.php
+++ b/CRM/Core/TokenTrait.php
@@ -19,7 +19,7 @@ trait CRM_Core_TokenTrait {
    * @inheritDoc
    */
   public function checkActive(\Civi\Token\TokenProcessor $processor) {
-    return in_array($this->getEntityIDFieldName(), $processor->context['schema'], TRUE) ||
+    return in_array($this->getEntityContextSchema(), $processor->context['schema']) ||
       (!empty($processor->context['actionMapping'])
         && $processor->context['actionMapping']->getEntity() === $this->getEntityTableName());
   }
@@ -51,7 +51,6 @@ trait CRM_Core_TokenTrait {
 
   /**
    * Find the fields that we need to get to construct the tokens requested.
-   *
    * @param  array $tokens list of tokens
    * @return array         list of fields needed to generate those tokens
    */

--- a/Civi/Token/TokenProcessor.php
+++ b/Civi/Token/TokenProcessor.php
@@ -58,7 +58,7 @@ class TokenProcessor {
    *   - schema: array, a list of fields that will be provided for each row.
    *     This is automatically populated with any general context
    *     keys, but you may need to add extra keys for token-row data.
-   *     ex: ['contactId', 'activity_id']. (Note we are standardising on the latter).
+   *     ex: ['contactId', 'activityId'].
    */
   public $context;
 


### PR DESCRIPTION
Overview
----------------------------------------
Reverts an unreleased commit that is only in the rc

Before
----------------------------------------
Commit present

After
----------------------------------------
As if it had never been 

Technical Details
----------------------------------------
Per https://docs.civicrm.org/dev/en/latest/framework/token/#token-processor
The contactId is actually documented. While I've been removing those in various places in
favour of contactID or contact_id it seems Tim has been putting them in so
I think it's safer to revert this change at this stage

This reverts commit 2ebb452b239c28e7ed2c50da69d324a8d40a7e88.

Comments
----------------------------------------
@mattwire @totten 
