### PR TITLE
dev/core#1768 - Update mailing database after each mail is sent.

### DIFF
--- a/CRM/Mailing/BAO/MailingJob.php
+++ b/CRM/Mailing/BAO/MailingJob.php
@@ -706,15 +706,18 @@ VALUES (%1, %2, %3, %4, %5, %6, %7)
         // Register the delivery event.
         $deliveredParams[] = $field['id'];
         $targetParams[] = $field['contact_id'];
-
+        // #1768 Write to the database every time we send a mail.
+        // If we don't do this, and the job fails for some reason, the mailer
+        // will re-send the mails it has already sent when the job restarts.
+        $this->writeToDB(
+          $deliveredParams,
+          $targetParams,
+          $mailing,
+          $job_date
+        );
         $count++;
         if ($count % CRM_Mailing_Config::BULK_MAIL_INSERT_COUNT == 0) {
-          $this->writeToDB(
-            $deliveredParams,
-            $targetParams,
-            $mailing,
-            $job_date
-          );
+
           $count = 0;
 
           // hack to stop mailing job at run time, CRM-4246.


### PR DESCRIPTION
Overview
----------------------------------------
This relates to [CiviMail mail job fails to complete, even though mail is sent](https://lab.civicrm.org/dev/core/-/issues/1768) flagging up an issue where when a mail job fails to complete, it can re-send mails it has already sent because it didn't record each mail as it goes along.

Before
----------------------------------------
The mailer only recorded sent mails every CRM_Mailing_Config::BULK_MAIL_INSERT_COUNT, currently set to 10. 

After
----------------------------------------
the mailer records every sent mail.  This means that it will not repeat sending mails already sent if the mailer job fails to complete and then restarts.

Technical Details
----------------------------------------
This PR moves:
       $this->writeToDB(
          $deliveredParams,
          $targetParams,
          $mailing,
          $job_date
        );
to just before the if statement starting with:
if ($count % CRM_Mailing_Config::BULK_MAIL_INSERT_COUNT == 0) in CRM/Mailing/BAO/MailingJob.php

Comments
----------------------------------------
This may introduce a performance hit.

I tested it by sending emails to the database whilst running in debug mode, killing jobs by exiting the debugger and then running them again.  There was no apparent duplication of mail sent to the database.