### PR TITLE
[REF] Minor code simplification

### DIFF
--- a/CRM/Contact/Form/Task/EmailTrait.php
+++ b/CRM/Contact/Form/Task/EmailTrait.php
@@ -360,6 +360,7 @@ trait CRM_Contact_Form_Task_EmailTrait {
    * @throws \CRM_Core_Exception
    * @throws \CiviCRM_API3_Exception
    * @throws \Civi\API\Exception\UnauthorizedException
+   * @throws \API_Exception
    */
   public function postProcess() {
     $this->bounceIfSimpleMailLimitExceeded(count($this->_contactIds));
@@ -428,7 +429,6 @@ trait CRM_Contact_Form_Task_EmailTrait {
 
     // format contact details array to handle multiple emails from same contact
     $formattedContactDetails = [];
-    $tempEmails = [];
     foreach ($this->_contactIds as $key => $contactId) {
       // if we dont have details on this contactID, we should ignore
       // potentially this is due to the contact not wanting to receive email
@@ -438,14 +438,10 @@ trait CRM_Contact_Form_Task_EmailTrait {
       $email = $this->_toContactEmails[$key];
       // prevent duplicate emails if same email address is selected CRM-4067
       // we should allow same emails for different contacts
-      $emailKey = "{$contactId}::{$email}";
-      if (!in_array($emailKey, $tempEmails)) {
-        $tempEmails[] = $emailKey;
-        $details = $this->_contactDetails[$contactId];
-        $details['email'] = $email;
-        unset($details['email_id']);
-        $formattedContactDetails[] = $details;
-      }
+      $details = $this->_contactDetails[$contactId];
+      $details['email'] = $email;
+      unset($details['email_id']);
+      $formattedContactDetails["{$contactId}::{$email}"] = $details;
     }
 
     $contributionIds = [];


### PR DESCRIPTION

Overview
----------------------------------------
 Reduce brain hurt

Before
----------------------------------------
Temporary array used to prevent duplicate contact-email combos

After
----------------------------------------
Array index used

Technical Details
----------------------------------------
On digging the only reason for the  array is to prevent duplicates.
The function  is passed do doesn't care how it's indexed so just use php array to prevent duplicates.

Comments
----------------------------------------
