### PR TITLE
CRM_Core_I18n::setLocale() - Fix bug with repeated usage

### DIFF
--- a/CRM/Core/I18n.php
+++ b/CRM/Core/I18n.php
@@ -623,13 +623,14 @@ class CRM_Core_I18n {
     // Change the language of the CMS as well, for URLs.
     CRM_Utils_System::setUFLocale($locale);
 
-    // change the gettext ressources
     if ($this->_nativegettext) {
+      // Native gettext has its own global flag indicating the active locale.
       $this->setNativeGettextLocale($locale);
     }
     else {
-      // phpgettext
-      $this->setPhpGettextLocale($locale);
+      // With phpgettext, each locale is retained as a separate instance of CRM_Core_I18n.
+      // It is sufficient to update `$tsLocale` and switch to the designated instance.
+      // Changing the locale for a live instance will actually cause problems when alternating locales.
     }
 
     // For sql queries, if running in DB multi-lingual mode.

--- a/CRM/Core/I18n.php
+++ b/CRM/Core/I18n.php
@@ -612,6 +612,17 @@ class CRM_Core_I18n {
   }
 
   /**
+   * If you switch back/forth between locales/drivers, it may be necessary
+   * to reset some options.
+   */
+  protected function reactivate() {
+    if ($this->_nativegettext) {
+      $this->setNativeGettextLocale($this->locale);
+    }
+
+  }
+
+  /**
    * Change the processing language without changing the current user language
    *
    * @param $locale
@@ -623,16 +634,6 @@ class CRM_Core_I18n {
     // Change the language of the CMS as well, for URLs.
     CRM_Utils_System::setUFLocale($locale);
 
-    if ($this->_nativegettext) {
-      // Native gettext has its own global flag indicating the active locale.
-      $this->setNativeGettextLocale($locale);
-    }
-    else {
-      // With phpgettext, each locale is retained as a separate instance of CRM_Core_I18n.
-      // It is sufficient to update `$tsLocale` and switch to the designated instance.
-      // Changing the locale for a live instance will actually cause problems when alternating locales.
-    }
-
     // For sql queries, if running in DB multi-lingual mode.
     global $dbLocale;
 
@@ -643,6 +644,8 @@ class CRM_Core_I18n {
     // For self::getLocale()
     global $tsLocale;
     $tsLocale = $locale;
+
+    CRM_Core_I18n::singleton()->reactivate();
   }
 
   /**

--- a/tests/phpunit/CRM/Core/I18n/LocaleTest.php
+++ b/tests/phpunit/CRM/Core/I18n/LocaleTest.php
@@ -45,6 +45,11 @@ class CRM_Core_I18n_LocaleTest extends CiviUnitTestCase {
       'fr_CA' => 'French (Canada)',
       'de_DE' => 'German',
     ];
+    $examples = [
+      'en_US' => 'Yes',
+      'fr_CA' => 'Oui',
+      'de_DE' => 'Ja',
+    ];
     $codes = array_keys($languages);
     Civi::settings()->set('uiLanguages', $codes);
 
@@ -76,6 +81,14 @@ class CRM_Core_I18n_LocaleTest extends CiviUnitTestCase {
       'en_US' => 'English (United States)',
       'fr_CA' => 'French (Canada)',
     ], $result);
+
+    // If you switch back and forth among these languages, `ts()` should follow suit.
+    for ($trial = 0; $trial < 3; $trial++) {
+      foreach ($examples as $exLocale => $exString) {
+        CRM_Core_I18n::singleton()->setLocale($exLocale);
+        $this->assertEquals($exString, ts('Yes'), "Translate");
+      }
+    }
 
     CRM_Core_I18n::singleton()->setLocale('en_US');
     CRM_Core_I18n_Schema::makeSinglelingual('en_US');


### PR DESCRIPTION
Overview
--------

Suppose you use `setLocale()` to change back and forth between languages, e.g.

```php
/*1*/ $i18n->setLocale('en_US'); echo ts('Yes');
/*2*/ $i18n->setLocale('fr_FR'); echo ts('Yes');
/*3*/ $i18n->setLocale('de_DE'); echo ts('Yes');
/*4*/ $i18n->setLocale('en_US'); echo ts('Yes');
/*5*/ $i18n->setLocale('fr_FR'); echo ts('Yes');
/*6*/ $i18n->setLocale('de_DE'); echo ts('Yes');
```

This fixes a bug with that use-case.

For more detailed example/reproduction, see https://gist.github.com/totten/de0dc9add8dee3956ecad29ec0906cc3 - specifically variant 2.

Before
------

There is a leak which causes mistranslations, e.g.

```
/*4*/ $i18n->setLocale('en_US'); echo ts('Yes');
//          ==> Outputs "Oui"
/*5*/ $i18n->setLocale('fr_FR'); echo ts('Yes');
//          ==> Outputs "Ja"
```

After
-----

You can freely switch between instances of `CRM_Core_I18n`.

Technical Details
-----------------

(1) ~~I'm using a default configuration, wherein `CIVICRM_GETTEXT_NATIVE` is not set...  so it uses phpgettext.~~ UPDATE: I tested with both native/PECL and portable/PHP gettext. You can run the test either way by twiddling `CIVICRM_GETTEXT_NATIVE` in `civicrm.settings.php`. It turns out that `CIVICRM_GETTEXT_NATIVE` isn't *purely* native... it's actually a hybrid where `en_US` still looks like `phpgettext`. Fun fact.

(2) As you use multiple locales, `CRM_Core_I18n::singleton()` constructs multiple instances of `CRM_Core_I18n` (one for each locale; this despite the misnomer of `singleton`). `singleton()` always returns the instance indicated by the active locale (as directed by `global $tsLocale`).

The problem: if you call `$en_US->setPhpGettextLocale('fr_FR')` (*line 2 in "Overview")*, then future requests for American English will actually return French.  Similarly, if you call `$fr_FR->setPhpGettextLocale('de_DE')` (*line 3*), then future requests for French will actually return German.

(3) ~~I haven't tested native gettext, but my guess is that it was working there. Added comments to explain the difference.~~