### PR TITLE
dev/core#1774 - fix pay later value after completetransaction is exec…

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4438,6 +4438,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
 
     $contributionParams = array_merge([
       'contribution_status_id' => $completedContributionStatusID,
+      'is_pay_later' => FALSE,
       'source' => self::getRecurringContributionDescription($contribution, $event),
     ], array_intersect_key($input, array_fill_keys($inputContributionWhiteList, 1)
     ));

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -2859,7 +2859,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
     $this->swapMessageTemplateForTestTemplate();
     $mut = new CiviMailUtils($this, TRUE);
     $this->createLoggedInUser();
-    $params = array_merge($this->_params, ['contribution_status_id' => 2, 'receipt_date' => 'now']);
+    $params = array_merge($this->_params, ['contribution_status_id' => 2, 'receipt_date' => 'now', 'is_pay_later' => TRUE]);
     $contribution = $this->callAPISuccess('contribution', 'create', $params);
     $this->callAPISuccess('contribution', 'completetransaction', ['id' => $contribution['id'], 'trxn_date' => date('Y-m-d')]);
     $contribution = $this->callAPISuccess('contribution', 'get', ['id' => $contribution['id'], 'sequential' => 1]);


### PR DESCRIPTION
…uted

Overview
----------------------------------------
`$is_pay_later` is TRUE in contribution receipt even if payment is completed.

Before
----------------------------------------
To replicate -

- Create a pay later payment in civicrm using a front end contribution page.
- Note that the email received has `Invoice` in the subject. This text is set when you choose to pay via `pay later`.
- Complete the payment using `completetransaction` API (or use API explorer from UI). This is used by payment processors, xero, etc to complete the payment in civicrm on receiving the confirmation.

```
$result = civicrm_api3('Contribution', 'completetransaction', [
  'id' => <contribution_id>,
]);
```
- The email confirmation still has `Invoice` in the subject.


After
----------------------------------------
Contribution Pay later is reset to 0 in completetransaction API which sends an expected FALSE value of `$is_pay_later` variable in the message template. 


Comments
----------------------------------------
includes unit test.

Gitlab - https://lab.civicrm.org/dev/core/-/issues/1774