### PR TITLE
Public status messages should show correct class/icon like error

### DIFF
--- a/templates/CRM/common/status.tpl
+++ b/templates/CRM/common/status.tpl
@@ -13,7 +13,7 @@
   {assign var="status" value=$session->getStatus(true)}
   {foreach name=statLoop item=statItem from=$status}
     {if $urlIsPublic}
-      {assign var="infoType" value="no-popup"}
+      {assign var="infoType" value="no-popup `$statItem.type`"}
     {else}
       {assign var="infoType" value=$statItem.type}
     {/if}


### PR DESCRIPTION
Overview
----------------------------------------

For some reason or lack thereof, Civi's template for status messages means you end up with things like a big green box with a big green tick when the message is an error. This is bad UX and people think they've succeeded when they have failed.

Before
----------------------------------------

Example messages (note actual colours/icons depend on the CMS and theme):

✔ Good news
✔ We failed to unsubscribe you!
✔ Erm, jussayin'...

![image](https://user-images.githubusercontent.com/870343/82563445-ff4a7900-9b6e-11ea-9209-63135487d2e8.png)


After
----------------------------------------


✔ Good news
✖ We failed to unsubscribe you!
ⓘ Erm, jussayin'...

![image](https://user-images.githubusercontent.com/870343/82563526-26a14600-9b6f-11ea-86ba-a814d5184e31.png)


Technical Details
----------------------------------------

This is just a change in a class in a Smarty template. The class is already in use for non public forms (so I assume it's attribute-safe)


Comments
----------------------------------------

Was there a reason why we didn't want to give semantic class names to our messages when used on public forms? I can't think of one.
