### PR TITLE
[NFC] Remove some more of the old  cvs blocks

### DIFF
--- a/CRM/Core/Smarty/plugins/block.icon.php
+++ b/CRM/Core/Smarty/plugins/block.icon.php
@@ -13,8 +13,6 @@
  *
  * @package CRM
  * @author Andrew Hunt, AGH Strategies
- * $Id$
- *
  */
 
 /**

--- a/CRM/Core/Smarty/plugins/function.copyIcon.php
+++ b/CRM/Core/Smarty/plugins/function.copyIcon.php
@@ -13,8 +13,6 @@
  *
  * @package CRM
  * @author Andrew Hunt, AGH Strategies
- * $Id$
- *
  */
 
 /**

--- a/CRM/Event/Controller/Registration.php
+++ b/CRM/Event/Controller/Registration.php
@@ -10,11 +10,7 @@
  */
 
 /**
- *
- * @package CRM
- * @copyright CiviCRM LLC https://civicrm.org/licensing
- * $Id$
- *
+ * Class CRM_Event_Controller_Registration
  */
 class CRM_Event_Controller_Registration extends CRM_Core_Controller {
 

--- a/CRM/Event/Controller/Search.php
+++ b/CRM/Event/Controller/Search.php
@@ -10,14 +10,6 @@
  */
 
 /**
- *
- * @package CRM
- * @copyright CiviCRM LLC https://civicrm.org/licensing
- * $Id$
- *
- */
-
-/**
  * This class is used by the Search functionality.
  *
  *  - the search controller is used for building/processing multiform
@@ -36,6 +28,8 @@ class CRM_Event_Controller_Search extends CRM_Core_Controller {
    * @param string $title
    * @param bool|int $action
    * @param bool $modal
+   *
+   * @throws \CRM_Core_Exception
    */
   public function __construct($title = NULL, $action = CRM_Core_Action::NONE, $modal = TRUE) {
 

--- a/CRM/Event/StateMachine/Registration.php
+++ b/CRM/Event/StateMachine/Registration.php
@@ -10,16 +10,7 @@
  */
 
 /**
- *
- * @package CRM
- * @copyright CiviCRM LLC https://civicrm.org/licensing
- * $Id$
- *
- */
-
-/**
  * State machine for managing different states of the EventWizard process.
- *
  */
 class CRM_Event_StateMachine_Registration extends CRM_Core_StateMachine {
 
@@ -27,9 +18,9 @@ class CRM_Event_StateMachine_Registration extends CRM_Core_StateMachine {
    * Class constructor.
    *
    * @param object $controller
-   * @param \const|int $action
+   * @param int $action
    *
-   * @return \CRM_Event_StateMachine_Registration CRM_Event_StateMachine
+   * @throws \CRM_Core_Exception
    */
   public function __construct($controller, $action = CRM_Core_Action::NONE) {
     parent::__construct($controller, $action);

--- a/CRM/Event/StateMachine/Search.php
+++ b/CRM/Event/StateMachine/Search.php
@@ -10,11 +10,7 @@
  */
 
 /**
- *
- * @package CRM
- * @copyright CiviCRM LLC https://civicrm.org/licensing
- * $Id$
- *
+ * Class CRM_Event_StateMachine_Search
  */
 class CRM_Event_StateMachine_Search extends CRM_Core_StateMachine {
 
@@ -28,7 +24,7 @@ class CRM_Event_StateMachine_Search extends CRM_Core_StateMachine {
   /**
    * Class constructor.
    *
-   * @param object $controller
+   * @param CRM_Core_Controller $controller
    * @param int $action
    */
   public function __construct($controller, $action = CRM_Core_Action::NONE) {

--- a/CRM/Extension/ClassLoader.php
+++ b/CRM/Extension/ClassLoader.php
@@ -10,12 +10,7 @@
  */
 
 /**
- *
- *
- * @package CRM
- * @copyright CiviCRM LLC https://civicrm.org/licensing
- * $Id$
- *
+ * Class CRM_Extension_ClassLoader
  */
 class CRM_Extension_ClassLoader {
 

--- a/CRM/Grant/BAO/Grant.php
+++ b/CRM/Grant/BAO/Grant.php
@@ -10,11 +10,7 @@
  */
 
 /**
- *
- * @package CRM
- * @copyright CiviCRM LLC https://civicrm.org/licensing
- * $Id$
- *
+ * Class CRM_Grant_BAO_Grant
  */
 class CRM_Grant_BAO_Grant extends CRM_Grant_DAO_Grant {
 

--- a/CRM/Grant/BAO/Query.php
+++ b/CRM/Grant/BAO/Query.php
@@ -10,11 +10,7 @@
  */
 
 /**
- *
- * @package CRM
- * @copyright CiviCRM LLC https://civicrm.org/licensing
- * $Id$
- *
+ * Class CRM_Grant_BAO_Query
  */
 class CRM_Grant_BAO_Query extends CRM_Core_BAO_Query {
 

--- a/CRM/Grant/Form/Grant.php
+++ b/CRM/Grant/Form/Grant.php
@@ -10,14 +10,6 @@
  */
 
 /**
- *
- * @package CRM
- * @copyright CiviCRM LLC https://civicrm.org/licensing
- * $Id$
- *
- */
-
-/**
  * This class generates form components for processing a case
  *
  */

--- a/CRM/Grant/Form/Task.php
+++ b/CRM/Grant/Form/Task.php
@@ -10,14 +10,6 @@
  */
 
 /**
- *
- * @package CRM
- * @copyright CiviCRM LLC https://civicrm.org/licensing
- * $Id$
- *
- */
-
-/**
  * Class for grant form task actions.
  * FIXME: This needs refactoring to properly inherit from CRM_Core_Form_Task and share more functions.
  */

--- a/CRM/Upgrade/Form.php
+++ b/CRM/Upgrade/Form.php
@@ -10,11 +10,7 @@
  */
 
 /**
- *
- * @package CRM
- * @copyright CiviCRM LLC https://civicrm.org/licensing
- * $Id$
- *
+ * Class CRM_Upgrade_Form
  */
 class CRM_Upgrade_Form extends CRM_Core_Form {
   const QUEUE_NAME = 'CRM_Upgrade';

--- a/Civi/Api4/Action/Setting/Set.php
+++ b/Civi/Api4/Action/Setting/Set.php
@@ -10,14 +10,6 @@
  +--------------------------------------------------------------------+
  */
 
-/**
- *
- * @package CRM
- * @copyright CiviCRM LLC https://civicrm.org/licensing
- * $Id$
- *
- */
-
 namespace Civi\Api4\Action\Setting;
 
 use Civi\Api4\Generic\Result;

--- a/Civi/Api4/Action/System/Check.php
+++ b/Civi/Api4/Action/System/Check.php
@@ -10,14 +10,6 @@
  +--------------------------------------------------------------------+
  */
 
-/**
- *
- * @package CRM
- * @copyright CiviCRM LLC https://civicrm.org/licensing
- * $Id$
- *
- */
-
 namespace Civi\Api4\Action\System;
 
 /**

--- a/Civi/Api4/Action/System/Flush.php
+++ b/Civi/Api4/Action/System/Flush.php
@@ -10,14 +10,6 @@
  +--------------------------------------------------------------------+
  */
 
-/**
- *
- * @package CRM
- * @copyright CiviCRM LLC https://civicrm.org/licensing
- * $Id$
- *
- */
-
 namespace Civi\Api4\Action\System;
 
 /**

--- a/Civi/Api4/Result/ReplaceResult.php
+++ b/Civi/Api4/Result/ReplaceResult.php
@@ -10,16 +10,13 @@
  +--------------------------------------------------------------------+
  */
 
-/**
- *
- * @package CRM
- * @copyright CiviCRM LLC https://civicrm.org/licensing
- * $Id$
- *
- */
-
 namespace Civi\Api4\Result;
 
+/**
+ * Class ReplaceResult
+ *
+ * @package Civi\Api4\Result
+ */
 class ReplaceResult extends \Civi\Api4\Generic\Result {
   /**
    * @var array

--- a/Civi/Api4/Service/Spec/Provider/ContactTypeCreationSpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/ContactTypeCreationSpecProvider.php
@@ -10,19 +10,15 @@
  +--------------------------------------------------------------------+
  */
 
-/**
- *
- * @package CRM
- * @copyright CiviCRM LLC https://civicrm.org/licensing
- * $Id$
- *
- */
-
-
 namespace Civi\Api4\Service\Spec\Provider;
 
 use Civi\Api4\Service\Spec\RequestSpec;
 
+/**
+ * Class ContactTypeCreationSpecProvider
+ *
+ * @package Civi\Api4\Service\Spec\Provider
+ */
 class ContactTypeCreationSpecProvider implements Generic\SpecProviderInterface {
 
   /**

--- a/Civi/Api4/Utils/ArrayInsertionUtil.php
+++ b/Civi/Api4/Utils/ArrayInsertionUtil.php
@@ -10,17 +10,13 @@
  +--------------------------------------------------------------------+
  */
 
-/**
- *
- * @package CRM
- * @copyright CiviCRM LLC https://civicrm.org/licensing
- * $Id$
- *
- */
-
-
 namespace Civi\Api4\Utils;
 
+/**
+ * Class ArrayInsertionUtil
+ *
+ * @package Civi\Api4\Utils
+ */
 class ArrayInsertionUtil {
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Comment block cleanup

Before
----------------------------------------
``$id ``

After
----------------------------------------
poof

Technical Details
----------------------------------------
The id notation is cvs. We agreed we don't need the whole block - unless it adds extra info - ie I left the author in the ones @agh1  added

Comments
----------------------------------------
