### PR TITLE
Use apiv4, cache infra for basicTypes

### DIFF
--- a/CRM/Core/SelectValues.php
+++ b/CRM/Core/SelectValues.php
@@ -68,11 +68,7 @@ class CRM_Core_SelectValues {
    * @return array
    */
   public static function contactType() {
-    static $contactType = NULL;
-    if (!$contactType) {
-      $contactType = CRM_Contact_BAO_ContactType::basicTypePairs();
-    }
-    return $contactType;
+    return CRM_Contact_BAO_ContactType::basicTypePairs();
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Minor code cleanup

Before
----------------------------------------
Old DAO executeQuery pattern used which passes a DAO string to the function in order to use storeValues

Convoluted caching

After
----------------------------------------
Uses apiv4, simpler caching

Technical Details
----------------------------------------
I came across this as using an old weird pattern accessing the DAO. On looking it made most
sense just to switch to an apiv4 call. The caching was not convoluted but effectively
used an array cache, if loaded, and the array or Redis or sql cache if not. This
is the same as using the 'metadata' or 'contactTypes' cache so I switched to the latter.

I was inclined towards the former as I lean towards thinking this metadata all belongs in one - but there
is already another function in the same class going to the latter.

Comments
----------------------------------------
From https://github.com/civicrm/civicrm-core/pull/17385
