### PR TITLE
Add in domain tokens onto the Message Template admin interface

### DIFF
--- a/CRM/Admin/Form/MessageTemplates.php
+++ b/CRM/Admin/Form/MessageTemplates.php
@@ -167,6 +167,7 @@ class CRM_Admin_Form_MessageTemplates extends CRM_Core_Form {
 
     //get the tokens.
     $tokens = CRM_Core_SelectValues::contactTokens();
+    $tokens = array_merge($tokens, CRM_Core_SelectValues::domainTokens());
 
     $this->assign('tokens', CRM_Utils_Token::formatTokensForDisplay($tokens));
 


### PR DESCRIPTION
Overview
----------------------------------------
This exposes the domain tokens into the Message Template editing 

Before
----------------------------------------
Domain tokens not exposed
![before_pr](https://user-images.githubusercontent.com/6799125/82846977-cde6fa00-9f2e-11ea-87a8-cb7d7d59d74c.jpg)


After
----------------------------------------
Domains tokens exposed in the Message Template editing interface
![after_pr](https://user-images.githubusercontent.com/6799125/82846979-d17a8100-9f2e-11ea-8e03-c3022399616d.jpg)


ping @JoeMurray @eileenmcnaughton 