### PR TITLE
Set default using spec for activity_date_time

### DIFF
--- a/api/v3/Activity.php
+++ b/api/v3/Activity.php
@@ -202,6 +202,8 @@ function _civicrm_api3_activity_create_spec(&$params) {
     'FKApiName' => 'Case',
   ];
 
+  $params['activity_date_time']['api.default'] = date('YmdHis');
+
 }
 
 /**
@@ -737,13 +739,6 @@ function _civicrm_api3_activity_check_params(&$params) {
   // needs testing
   if (isset($params['duration_minutes']) && !is_numeric($params['duration_minutes'])) {
     throw new API_Exception('Invalid Activity Duration (in minutes)');
-  }
-
-  //if adding a new activity & date_time not set make it now
-  // this should be managed by the wrapper layer & setting ['api.default'] in speces
-  // needs testing
-  if (empty($params['id']) && empty($params['activity_date_time'])) {
-    $params['activity_date_time'] = CRM_Utils_Date::processDate(date('Y-m-d H:i:s'));
   }
 
   return NULL;


### PR DESCRIPTION
Overview
----------------------------------------
Replace a convoluted way of setting this with a standard way.

Before
----------------------------------------
`date` called more than once and formatted.

After
----------------------------------------
`activity_date_time` takes default via spec.

Technical Details
----------------------------------------
We were creating a date in one format, then reformatting it into the format we want!

Comments
----------------------------------------
@colemanw I know you love inconsistencies like this.. ;-)
