### PR TITLE
[REF] Code simplification & unit test on suppressed emails in task

### DIFF
--- a/tests/phpunit/CRM/Contact/Form/Task/EmailCommonTest.php
+++ b/tests/phpunit/CRM/Contact/Form/Task/EmailCommonTest.php
@@ -89,6 +89,10 @@ class CRM_Contact_Form_Task_EmailCommonTest extends CiviUnitTestCase {
       $form->_contactIds[$contactID] = $contactID;
       $form->_toContactEmails[$this->callAPISuccessGetValue('Email', ['return' => 'id', 'email' => $email])] = $email;
     }
+    $deceasedContactID = $this->individualCreate(['is_deceased' => 1, 'email' => 'dead@example.com']);
+    $form->_contactIds[$deceasedContactID] = $deceasedContactID;
+    $form->_toContactEmails[$this->callAPISuccessGetValue('Email', ['return' => 'id', 'email' => 'dead@example.com'])] = 'dead@example.com';
+
     $loggedInEmail = $this->callAPISuccess('Email', 'create', [
       'email' => 'mickey@mouse.com',
       'location_type_id' => 1,
@@ -119,6 +123,20 @@ class CRM_Contact_Form_Task_EmailCommonTest extends CiviUnitTestCase {
     $bccUrl1 = CRM_Utils_System::url('civicrm/contact/view', ['reset' => 1, 'force' => 1, 'cid' => $bcc1], TRUE);
     $bccUrl2 = CRM_Utils_System::url('civicrm/contact/view', ['reset' => 1, 'force' => 1, 'cid' => $bcc2], TRUE);
     $this->assertContains("bcc : <a href='" . $bccUrl1 . "'>Mr. Anthony Anderson II</a><a href='" . $bccUrl2 . "'>Mr. Anthony Anderson II</a>", $activity['details']);
+    $this->assertEquals([
+      [
+        'text' => '27 messages were sent successfully. ',
+        'title' => 'Messages Sent',
+        'type' => 'success',
+        'options' => NULL,
+      ],
+      [
+        'text' => '(because no email address on file or communication preferences specify DO NOT EMAIL or Contact is deceased or Primary email address is On Hold)<ul><li><a href="/index.php?q=civicrm/contact/view&amp;reset=1&amp;cid=' . $deceasedContactID . '" title="dead@example.com">Mr. Anthony Anderson II</a></li></ul>',
+        'title' => 'One Message Not Sent',
+        'type' => 'info',
+        'options' => NULL,
+      ],
+    ], CRM_Core_Session::singleton()->getStatus());
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Minor code simplification, add test

Before
----------------------------------------
Long winded code - 
in Build form
1) set ```$this->_contactDetails``` to what is effectively the result of a contact.get on the ids
filtered by $this->_allContactIds
2) iterate through $this->_allContactIds & look for values in the array returned by searching for those ids
3) if they are suppressed then increment a counter and unset them from the original array
4) if they DO exist then add them to another array (initially empty) ```$this->_contactDetails```

in submit
De-wrangle the contacts  by array-diffing the 2 arrays above to get the suppressed ones & then wrangling them for a message

After
----------------------------------------
Set the suppressed emails in the first place as their own array, using the final required style

Technical Details
----------------------------------------


Comments
----------------------------------------

