### PR TITLE
APIv4 - fix returning custom field values with API4

### DIFF
--- a/Civi/Api4/Service/Schema/Joiner.php
+++ b/Civi/Api4/Service/Schema/Joiner.php
@@ -61,10 +61,11 @@ class Joiner {
       $target = $link->getTargetTable();
       $alias = $link->getAlias();
       $bao = \CRM_Core_DAO_AllCoreTables::getBAOClassName(\CRM_Core_DAO_AllCoreTables::getClassForTable($target));
-      $conditions = array_merge(
-        $link->getConditionsForJoin($baseTable),
-        $query->getAclClause($alias, $bao, explode('.', $joinPath))
-      );
+      $conditions = $link->getConditionsForJoin($baseTable);
+      // Custom fields do not have a bao, and currently do not have field-specific ACLs
+      if ($bao) {
+        $conditions = array_merge($conditions, $query->getAclClause($alias, $bao, explode('.', $joinPath)));
+      }
 
       $query->join($side, $target, $alias, $conditions);
 

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -464,6 +464,17 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
       'return.custom_' . $ids['custom_field_id'] => 1,
       'id' => $result['id'],
     ]);
+    $group = $this->callAPISuccess('CustomGroup', 'getsingle', ['id' => $ids['custom_group_id']]);
+    $field = $this->callAPISuccess('CustomField', 'getsingle', ['id' => $ids['custom_field_id']]);
+    $contribution = \Civi\Api4\Contribution::get()
+      ->setSelect([
+        'id',
+        'total_amount',
+        $group['name'] . '.' . $field['name'],
+      ])
+      ->addWhere('id', '=', $result['id'])
+      ->execute()
+      ->first();
     $this->customFieldDelete($ids['custom_field_id']);
     $this->customGroupDelete($ids['custom_group_id']);
     $this->assertEquals('custom string', $check['values'][$check['id']]['custom_' . $ids['custom_field_id']]);


### PR DESCRIPTION
Overview
----------------------------------------
Fixes recent regression and adds in a unit test to confirm that custom field data for 1-1 custom fields can be returned in the get clause.

Before
----------------------------------------
No test

After
----------------------------------------
Test

This is currently failing due to recent changes @colemanw @pfigel @eileenmcnaughton 