### PR TITLE
Fix core#1773 unsubscribe form causes errors if submitted twice

### DIFF
--- a/CRM/Mailing/Form/Unsubscribe.php
+++ b/CRM/Mailing/Form/Unsubscribe.php
@@ -16,6 +16,14 @@
  */
 class CRM_Mailing_Form_Unsubscribe extends CRM_Core_Form {
 
+  /**
+   * Prevent people double-submitting the form (e.g. by double-clicking).
+   * https://lab.civicrm.org/dev/core/-/issues/1773
+   *
+   * @var bool
+   */
+  public $submitOnce = TRUE;
+
   public function preProcess() {
 
     $this->_type = 'unsubscribe';


### PR DESCRIPTION
Overview
----------------------------------------

Please see https://lab.civicrm.org/dev/core/-/issues/1773

Before
----------------------------------------

Unsubscribe form could cause errors (may or may not be visible to users) if the form's submit button was clicked twice.


After
----------------------------------------

Form is prevented from being submitted twice.


Technical Details
----------------------------------------

Minor change: uses core's `$submitOnce` property on the form class.

Comments
----------------------------------------

Credit to https://lab.civicrm.org/DaveD for elegant solution.
