### PR TITLE
[REF] Pass params not-by-reference

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -1079,10 +1079,10 @@ class CRM_Activity_BAO_Activity extends CRM_Activity_DAO_Activity {
    * @throws \CiviCRM_API3_Exception
    */
   public static function sendEmail(
-    &$contactDetails,
-    &$subject,
-    &$text,
-    &$html,
+    $contactDetails,
+    $subject,
+    $text,
+    $html,
     $emailAddress,
     $userID = NULL,
     $from = NULL,


### PR DESCRIPTION


Overview
----------------------------------------
Do not pass params by reference

Before
----------------------------------------
passed by reference

After
----------------------------------------
not

Technical Details
----------------------------------------
This function is only called by one place in core + a deprecated unused class. The details are not used again

Comments
----------------------------------------
The deprecated class was left in order to help callers outside core (despite it being unsupported) but changes to the tpl might mean that it should be removed fairly quickly...
