### PR TITLE
[REF] Allow extensions to alter sql generated for the Statistics quer…

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -520,6 +520,18 @@ class CRM_Report_Form extends CRM_Core_Form {
   public $optimisedForOnlyFullGroupBy = TRUE;
 
   /**
+   * Replacement Select query for Statistics
+   * @var string
+   */
+  protected $_statiscticsSelect;
+
+  /**
+   * Replacement group by for Statistics
+   * @var string
+   */
+  protected $_statiscticsGroupBy;
+
+  /**
    * Class constructor.
    */
   public function __construct() {

--- a/CRM/Report/Form/ActivitySummary.php
+++ b/CRM/Report/Form/ActivitySummary.php
@@ -600,7 +600,7 @@ class CRM_Report_Form_ActivitySummary extends CRM_Report_Form {
         {$this->_tempDurationSumTableName}.civicrm_activity_duration_total
     FROM {$this->_tempTableName} INNER JOIN {$this->_tempDurationSumTableName}
       ON ({$this->_tempTableName}.id = {$this->_tempDurationSumTableName}.id)";
-
+    $this->addToDeveloperTab($query);
     $actDAO = CRM_Core_DAO::executeQuery($query);
 
     $activityTypesCount = [];

--- a/CRM/Report/Form/Case/Detail.php
+++ b/CRM/Report/Form/Case/Detail.php
@@ -477,8 +477,10 @@ class CRM_Report_Form_Case_Detail extends CRM_Report_Form {
   public function statistics(&$rows) {
     $statistics = parent::statistics($rows);
 
-    $select = "select COUNT( DISTINCT( {$this->_aliases['civicrm_address']}.country_id))";
-    $sql = "{$select} {$this->_from} {$this->_where}";
+    $this->_statiscticsSelect = "select COUNT( DISTINCT( {$this->_aliases['civicrm_address']}.country_id))";
+    CRM_Utils_Hook::alterReportVar('statssql', $this, $this);
+    $sql = "{$this->_statiscticsSelect} {$this->_from} {$this->_where}";
+    $this->addToDeveloperTab($sql);
     $countryCount = CRM_Core_DAO::singleValueQuery($sql);
 
     $statistics['counts']['case'] = [

--- a/CRM/Report/Form/Contribute/Bookkeeping.php
+++ b/CRM/Report/Form/Contribute/Bookkeeping.php
@@ -597,16 +597,17 @@ class CRM_Report_Form_Contribute_Bookkeeping extends CRM_Report_Form {
       "{$this->_aliases['civicrm_contribution']}.currency",
       $financialSelect,
     ];
-    $select = "SELECT " . implode(', ', $this->_selectClauses);
+    $this->_statiscticsSelect = "SELECT " . implode(', ', $this->_selectClauses);
 
     $this->groupBy();
-
+    CRM_Utils_Hook::alterReportVar('statssql', $this, $this);
     $tempTableName = $this->createTemporaryTable('tempTable', "
-                  {$select} {$this->_from} {$this->_where} {$this->_groupBy} ");
+                  {$this->_statiscticsSelect} {$this->_from} {$this->_where} {$this->_groupBy} ");
 
     $sql = "SELECT COUNT(trxnID) as count, SUM(amount) as amount, currency
             FROM {$tempTableName}
             GROUP BY currency";
+    $this->addToDeveloperTab($sql);
     $dao = CRM_Core_DAO::executeQuery($sql);
     $amount = $avg = [];
     while ($dao->fetch()) {

--- a/CRM/Report/Form/Contribute/Detail.php
+++ b/CRM/Report/Form/Contribute/Detail.php
@@ -417,7 +417,7 @@ class CRM_Report_Form_Contribute_Detail extends CRM_Report_Form {
 
     $totalAmount = $average = $fees = $net = [];
     $count = 0;
-    $select = "
+    $this->_statiscticsSelect = "
         SELECT COUNT({$this->_aliases['civicrm_contribution']}.total_amount ) as count,
                SUM( {$this->_aliases['civicrm_contribution']}.total_amount ) as amount,
                ROUND(AVG({$this->_aliases['civicrm_contribution']}.total_amount), 2) as avg,
@@ -426,8 +426,9 @@ class CRM_Report_Form_Contribute_Detail extends CRM_Report_Form {
                SUM( {$this->_aliases['civicrm_contribution']}.net_amount ) as net
         ";
 
-    $group = "\nGROUP BY {$this->_aliases['civicrm_contribution']}.currency";
-    $sql = "{$select} {$this->_from} {$this->_where} {$group}";
+    $this->_statiscticsGroupBy = "\nGROUP BY {$this->_aliases['civicrm_contribution']}.currency";
+    CRM_Utils_Hook::alterReportVar('statssql', $this, $this);
+    $sql = "{$this->_statiscticsSelect} {$this->_from} {$this->_where} {$this->_statiscticsGroupBy}";
     $dao = CRM_Core_DAO::executeQuery($sql);
     $this->addToDeveloperTab($sql);
 

--- a/CRM/Report/Form/Contribute/PCP.php
+++ b/CRM/Report/Form/Contribute/PCP.php
@@ -306,11 +306,13 @@ LEFT JOIN civicrm_event {$this->_aliases['civicrm_event']}
     $statistics = parent::statistics($rows);
 
     // Calculate totals from the civicrm_contribution_soft table.
-    $select = "SELECT SUM({$this->_aliases['civicrm_contribution_soft']}.amount) "
+    $this->_statiscticsSelect = "SELECT SUM({$this->_aliases['civicrm_contribution_soft']}.amount) "
       . "as committed_total, COUNT({$this->_aliases['civicrm_contribution_soft']}.id) "
       . "as donors_total, SUM(IF( contribution_civireport.contribution_status_id > 1, 0, "
       . "contribution_soft_civireport.amount)) AS received_total ";
+    CRM_Utils_Hook:alterReportVar('statssql', $this, $this);
     $sql = "{$select} {$this->_from} {$this->_where}";
+    $this->addToDeveloperTab($sql);
     $dao = CRM_Core_DAO::executeQuery($sql);
     $dao->fetch();
     $committed_total = $dao->committed_total;

--- a/CRM/Report/Form/Contribute/Repeat.php
+++ b/CRM/Report/Form/Contribute/Repeat.php
@@ -667,8 +667,19 @@ LEFT JOIN $this->tempTableRepeat2 {$this->_aliases['civicrm_contribution']}2
    * @return array
    */
   public function statistics(&$rows) {
+    $this->_statiscticsSelect = "
+SELECT COUNT({$this->_aliases['civicrm_contribution']}1.total_amount_count )       as count,
+       SUM({$this->_aliases['civicrm_contribution']}1.total_amount_sum )           as amount,
+       ROUND(AVG({$this->_aliases['civicrm_contribution']}1.total_amount_sum), 2)  as avg,
+       COUNT({$this->_aliases['civicrm_contribution']}2.total_amount_count )       as count2,
+       SUM({$this->_aliases['civicrm_contribution']}2.total_amount_sum )           as amount2,
+       ROUND(AVG({$this->_aliases['civicrm_contribution']}2.total_amount_sum), 2)  as avg2,
+       currency";
+    $this->_statiscticsGroupBy = "GROUP BY    currency";
+    CRM_Utils_Hook::alterReportVar('statssql', $this, $this);
     $statistics = parent::statistics($rows);
     $sql = "{$this->_select} {$this->_from} {$this->_where}";
+    $this->addToDeveloperTab($sql);
     $dao = $this->executeReportQuery($sql);
     //store contributions in array 'contact_sums' for comparison
     $contact_sums = array();
@@ -740,17 +751,8 @@ LEFT JOIN $this->tempTableRepeat2 {$this->_aliases['civicrm_contribution']}2
       'title' => ts('% Maintained Donors'),
     );
 
-    $select = "
-SELECT COUNT({$this->_aliases['civicrm_contribution']}1.total_amount_count )       as count,
-       SUM({$this->_aliases['civicrm_contribution']}1.total_amount_sum )           as amount,
-       ROUND(AVG({$this->_aliases['civicrm_contribution']}1.total_amount_sum), 2)  as avg,
-       COUNT({$this->_aliases['civicrm_contribution']}2.total_amount_count )       as count2,
-       SUM({$this->_aliases['civicrm_contribution']}2.total_amount_sum )           as amount2,
-       ROUND(AVG({$this->_aliases['civicrm_contribution']}2.total_amount_sum), 2)  as avg2,
-       currency";
-    $sql = "{$select} {$this->_from} {$this->_where}
-GROUP BY    currency
-";
+    $sql = "{$this->_statiscticsSelect} {$this->_from} {$this->_where} {$this->_statiscticsGroupBy}";
+    $this->addtoDeveloperTab($sql);
     $dao = $this->executeReportQuery($sql);
 
     $amount = $average = $amount2 = $average2 = array();

--- a/CRM/Report/Form/Contribute/SoftCredit.php
+++ b/CRM/Report/Form/Contribute/SoftCredit.php
@@ -476,17 +476,16 @@ GROUP BY {$this->_aliases['civicrm_contribution_soft']}.contact_id, constituentn
   public function statistics(&$rows) {
     $statistics = parent::statistics($rows);
 
-    $select = "
+    $this->_statiscticsSelect = "
         SELECT COUNT({$this->_aliases['civicrm_contribution_soft']}.amount ) as count,
                SUM({$this->_aliases['civicrm_contribution_soft']}.amount ) as amount,
                ROUND(AVG({$this->_aliases['civicrm_contribution_soft']}.amount), 2) as avg,
                {$this->_aliases['civicrm_contribution']}.currency as currency
         ";
-
-    $sql = "{$select} {$this->_from} {$this->_where}
-GROUP BY   {$this->_aliases['civicrm_contribution']}.currency
-";
-
+    $this->_statiscticsGroupBy = "GROUP BY   {$this->_aliases['civicrm_contribution']}.currency";
+    CRM_Utils_Hook::alterReportVar('statssql', $this, $this);
+    $sql = "{$this->_statiscticsSelect} {$this->_from} {$this->_where} {$this->_statiscticsGroupBy}";
+    $this->addToDeveloperTab($sql);
     $dao = CRM_Core_DAO::executeQuery($sql);
     $count = 0;
     $totalAmount = $average = [];

--- a/CRM/Report/Form/Contribute/Sybunt.php
+++ b/CRM/Report/Form/Contribute/Sybunt.php
@@ -397,11 +397,11 @@ class CRM_Report_Form_Contribute_Sybunt extends CRM_Report_Form {
     $statistics = parent::statistics($rows);
 
     if (!empty($rows)) {
-      $select = "
+      $this->_statiscticsSelect = "
                    SELECT
                         SUM({$this->_aliases['civicrm_contribution']}.total_amount ) as amount ";
-
-      $sql = "{$select} {$this->_from} {$this->_where}";
+      CRM_Utils_Hook::alterReportVar('statssql', $this, $this);
+      $sql = "{$this->_statiscticsSelect} {$this->_from} {$this->_where}";
       $dao = CRM_Core_DAO::executeQuery($sql);
       if ($dao->fetch()) {
         $statistics['counts']['amount'] = [

--- a/CRM/Report/Form/Event/IncomeCountSummary.php
+++ b/CRM/Report/Form/Event/IncomeCountSummary.php
@@ -251,12 +251,12 @@ class CRM_Report_Form_Event_IncomeCountSummary extends CRM_Report_Form {
    */
   public function statistics(&$rows) {
     $statistics = parent::statistics($rows);
-    $select = "
+    $this->_statiscticsSelect = "
          SELECT SUM( {$this->_aliases['civicrm_line_item']}.participant_count ) as count,
                 SUM( {$this->_aliases['civicrm_line_item']}.line_total )  as amount";
-
-    $sql = "{$select} {$this->_from} {$this->_where}";
-
+    CRM_Utils_Hook::alterReportVar('statssql', $this, $this);
+    $sql = "{$this->_statiscticsSelect} {$this->_from} {$this->_where}";
+    $this->addToDeveloperTab($sql);
     $dao = CRM_Core_DAO::executeQuery($sql);
 
     if ($dao->fetch()) {

--- a/CRM/Report/Form/Event/ParticipantListCount.php
+++ b/CRM/Report/Form/Event/ParticipantListCount.php
@@ -345,10 +345,12 @@ class CRM_Report_Form_Event_ParticipantListCount extends CRM_Report_Form {
 
     $statistics = parent::statistics($rows);
     $avg = NULL;
-    $select = " SELECT SUM( {$this->_aliases['civicrm_line_item']}.participant_count ) as count,
+    $this->_statiscticsSelect = " SELECT SUM( {$this->_aliases['civicrm_line_item']}.participant_count ) as count,
                   SUM( {$this->_aliases['civicrm_line_item']}.line_total )   as amount
             ";
-    $sql = "{$select} {$this->_from} {$this->_where}";
+    CRM_Utils_Hook::alterReportVar('statssql', $this, $this);
+    $sql = "{$this->_statiscticsSelect} {$this->_from} {$this->_where}";
+    $this->addToDeveloperTab($sql);
     $dao = CRM_Core_DAO::executeQuery($sql);
     if ($dao->fetch()) {
 

--- a/CRM/Report/Form/Member/ContributionDetail.php
+++ b/CRM/Report/Form/Member/ContributionDetail.php
@@ -582,13 +582,15 @@ class CRM_Report_Form_Member_ContributionDetail extends CRM_Report_Form {
   public function statistics(&$rows) {
     $statistics = parent::statistics($rows);
 
-    $select = "SELECT DISTINCT {$this->_aliases['civicrm_contribution']}.id";
+    $this->_statiscticsSelect = "SELECT DISTINCT {$this->_aliases['civicrm_contribution']}.id";
+    CRM_Utils_Hook::alterReportVar('statssql', $this, $this);
 
     $sql = "SELECT COUNT(cc.id) as count, SUM(cc.total_amount) as amount, ROUND(AVG(cc.total_amount), 2) as avg, cc.currency as currency
             FROM civicrm_contribution cc
-            WHERE cc.id IN ({$select} {$this->_from} {$this->_where})
+            WHERE cc.id IN ({$this->_statiscticsSelect} {$this->_from} {$this->_where})
             GROUP BY cc.currency";
 
+    $this->addToDeveloperTab($sql);
     $dao = CRM_Core_DAO::executeQuery($sql);
     $totalAmount = $average = [];
     while ($dao->fetch()) {

--- a/CRM/Report/Form/Member/Summary.php
+++ b/CRM/Report/Form/Member/Summary.php
@@ -367,18 +367,17 @@ class CRM_Report_Form_Member_Summary extends CRM_Report_Form {
    */
   public function statistics(&$rows) {
     $statistics = parent::statistics($rows);
-    $select = "
+    $this->_statiscticsSelect = "
         SELECT COUNT({$this->_aliases['civicrm_contribution']}.total_amount ) as count,
                IFNULL(SUM({$this->_aliases['civicrm_contribution']}.total_amount ), 0) as amount,
                IFNULL(ROUND(AVG({$this->_aliases['civicrm_contribution']}.total_amount), 2),0) as avg,
                COUNT( DISTINCT {$this->_aliases['civicrm_membership']}.id ) as memberCount,
                {$this->_aliases['civicrm_contribution']}.currency as currency
         ";
-
-    $sql = "{$select} {$this->_from} {$this->_where}
-GROUP BY    {$this->_aliases['civicrm_contribution']}.currency
-";
-
+    $this->_statiscticsGroupBy = "GROUP BY    {$this->_aliases['civicrm_contribution']}.currency";
+    CRM_Utils_Hook::alterReportVar('statssql', $this, $this);
+    $sql = "{$this->_statiscticsSelect} {$this->_from} {$this->_where} {$this->_statiscticsGroupBy}";
+    $this->addToDeveloperTab($sql);
     $dao = CRM_Core_DAO::executeQuery($sql);
 
     $totalAmount = $average = [];

--- a/CRM/Report/Form/Pledge/Detail.php
+++ b/CRM/Report/Form/Pledge/Detail.php
@@ -270,15 +270,16 @@ class CRM_Report_Form_Pledge_Detail extends CRM_Report_Form {
     if (!$this->_having) {
       $totalAmount = $average = [];
       $count = 0;
-      $select = "
+      $this->_statiscticsSelect = "
         SELECT COUNT({$this->_aliases['civicrm_pledge']}.amount )       as count,
           SUM({$this->_aliases['civicrm_pledge']}.amount )         as amount,
           ROUND(AVG({$this->_aliases['civicrm_pledge']}.amount), 2) as avg,
           {$this->_aliases['civicrm_pledge']}.currency as currency
         ";
 
-      $group = "GROUP BY {$this->_aliases['civicrm_pledge']}.currency";
-      $sql = "{$select} {$this->_from} {$this->_where} {$group}";
+      $this->_statiscticsGroupBy = "GROUP BY {$this->_aliases['civicrm_pledge']}.currency";
+      CRM_Utils_Hook::alterReportVar('statssql', $this, $this);
+      $sql = "{$this->_statiscticsSelect} {$this->_from} {$this->_where} {$this->_statiscticsGroupBy}";
       $dao = CRM_Core_DAO::executeQuery($sql);
       $count = $index = $totalCount = 0;
       // this will run once per currency

--- a/CRM/Report/Form/Pledge/Summary.php
+++ b/CRM/Report/Form/Pledge/Summary.php
@@ -272,13 +272,13 @@ class CRM_Report_Form_Pledge_Summary extends CRM_Report_Form {
     $statistics = parent::statistics($rows);
 
     if (!$this->_having) {
-      $select = "
+      $this->_statiscticsSelect = "
             SELECT COUNT({$this->_aliases['civicrm_pledge']}.amount )       as count,
                    SUM({$this->_aliases['civicrm_pledge']}.amount )         as amount,
                    ROUND(AVG({$this->_aliases['civicrm_pledge']}.amount), 2) as avg
             ";
-
-      $sql = "{$select} {$this->_from} {$this->_where}";
+      CRM_Utils_Hook::alterReportVar('statssql', $this, $this);
+      $sql = "{$this->_statiscticsSelect} {$this->_from} {$this->_where}";
 
       $dao = CRM_Core_DAO::executeQuery($sql);
 


### PR DESCRIPTION
…y separately to general build clause and also ensure that statistics sql is added to the developer tab

Overview
----------------------------------------
This aims to allow extensions to modify the sql that is generated for statistics part of the report as well as the main query, Also ensures that statistics queries are added to the developer tab

Before
----------------------------------------
Not all stats queries not added to the developer tab and stats queries not able to be modified by extensions

After
----------------------------------------
Stats queries added to the developer tab and able to be modified by extensions

ping @eileenmcnaughton @mattwire 