### PR TITLE
Allow bidirectional assignment of relationships from search results

### DIFF
--- a/CRM/Case/Form/AddToCaseAsRole.php
+++ b/CRM/Case/Form/AddToCaseAsRole.php
@@ -51,7 +51,10 @@ class CRM_Case_Form_AddToCaseAsRole extends CRM_Contact_Form_Task {
     $roleTypes = [];
 
     foreach ($relType as $k => $v) {
-      $roleTypes[substr($k, 0, strpos($k, '_'))] = $v;
+      //Limit this to relationship types from contact A to B
+      if (substr($k, -4) == "_a_b") {
+        $roleTypes[substr($k, 0, strpos($k, '_'))] = $v;
+      }
     }
 
     return $roleTypes;

--- a/CRM/Contact/BAO/Relationship.php
+++ b/CRM/Contact/BAO/Relationship.php
@@ -1489,13 +1489,14 @@ LEFT JOIN  civicrm_country ON (civicrm_address.country_id = civicrm_country.id)
   }
 
   /**
-   * Get get list of relationship type based on the target contact type.
+   * Get list of relationship type based on the target contact type.
+   * Both directions of relationships are included if their labels are not the same.
    *
    * @param string $targetContactType
-   *   It's valid contact tpye(may be Individual , Organization , Household).
+   *   A valid contact type (may be Individual, Organization, Household).
    *
    * @return array
-   *   array reference of all relationship types with context to current contact type .
+   *   array reference of all relationship types with context to current contact type.
    */
   public static function getRelationType($targetContactType) {
     $relationshipType = [];
@@ -1504,6 +1505,11 @@ LEFT JOIN  civicrm_country ON (civicrm_address.country_id = civicrm_country.id)
     foreach ($allRelationshipType as $key => $type) {
       if ($type['contact_type_b'] == $targetContactType || empty($type['contact_type_b'])) {
         $relationshipType[$key . '_a_b'] = $type['label_a_b'];
+      }
+      if (($type['contact_type_a'] == $targetContactType || empty($type['contact_type_a']))
+        && $type['label_a_b'] != $type['label_b_a']
+      ) {
+        $relationshipType[$key . '_b_a'] = $type['label_b_a'];
       }
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
When assigning relationships from search results, look at contact types for both A and B.
![image](https://user-images.githubusercontent.com/7529633/66168454-4816e700-e60b-11e9-9d50-ea43516eb0d3.png)
![image](https://user-images.githubusercontent.com/7529633/66168465-4f3df500-e60b-11e9-873b-244e6fead683.png)


Before
----------------------------------------
Only target contact type (Contact B) is considered

After
----------------------------------------
All relationship options where either contacts A and/or B fit the criteria are considered.
![image](https://user-images.githubusercontent.com/7529633/66168524-785e8580-e60b-11e9-92ed-a6101a21af76.png)



Comments
----------------------------------------
Re-submission of #15386. With this version, the CiviCase task "Add to case as role" still only considers the target contact type. It was necessary to add a condition, as that form is hard-coded for contact assignments for Individuals only. 
