### PR TITLE
dev/core#1745 Fix caching bug when adding a contact to a group

### DIFF
--- a/CRM/Contact/BAO/GroupContact.php
+++ b/CRM/Contact/BAO/GroupContact.php
@@ -129,14 +129,13 @@ class CRM_Contact_BAO_GroupContact extends CRM_Contact_DAO_GroupContact {
 
     CRM_Utils_Hook::pre('create', 'GroupContact', $groupId, $contactIds);
 
-    list($numContactsAdded, $numContactsNotAdded)
-      = self::bulkAddContactsToGroup($contactIds, $groupId, $method, $status, $tracking);
-
+    $result = self::bulkAddContactsToGroup($contactIds, $groupId, $method, $status, $tracking);
+    CRM_Contact_BAO_GroupContactCache::invalidateGroupContactCache($groupId);
     CRM_Contact_BAO_Contact_Utils::clearContactCaches();
 
     CRM_Utils_Hook::post('create', 'GroupContact', $groupId, $contactIds);
 
-    return [count($contactIds), $numContactsAdded, $numContactsNotAdded];
+    return [count($contactIds), $result['count_added'], $result['count_not_added']];
   }
 
   /**
@@ -763,7 +762,7 @@ AND    contact_id IN ( $contactStr )
       }
     }
 
-    return [$numContactsAdded, $numContactsNotAdded];
+    return ['count_added' => $numContactsAdded, 'count_not_added' => $numContactsNotAdded];
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Per https://lab.civicrm.org/dev/core/-/issues/1745
When contacts have been statically added to a smart group, they are not found in a search of group members

Reproduction steps

Create a smart group (From advanced search. On test data, search for name=Lou)
Go to a contact not in the group, Groups tab, Add to Group, select smart group from previous step


Before
----------------------------------------
1. `Contact > Manage Groups > Contacts` (of smart group) does not list static members
1. `Search > Find Contacts` Group = smart group does not list static members
1. Go to the statically added Contact, groups tab - note that smart group name shows under `Regular groups`

After
----------------------------------------
What should happen: static members should show when searching for group members.

Technical Details
----------------------------------------
Just adds a row to invalidate the contact cache

Comments
----------------------------------------
This was identified as a possible regression but I am fairly sure it's just obscure

@aydun 

