### PR TITLE
Still generate hash for log file if it is under the webroot

### DIFF
--- a/CRM/Core/Error.php
+++ b/CRM/Core/Error.php
@@ -680,7 +680,13 @@ class CRM_Core_Error extends PEAR_ErrorStack {
         $hash = self::generateLogFileHash($config) . '.';
       }
       else {
-        $hash = '';
+        // If Config And Log Directory is under the webroot still generate the hash file.
+        if (stripos($config->configAndLogDir, $config->userSystem->getCiviSourceStorage()['path'])) {
+          $hash = self::generateLogFileHash($config) . '.';
+        }
+        else {
+          $hash = '';
+        }
       }
       $fileName = $config->configAndLogDir . 'CiviCRM.' . $prefixString . $hash . 'log';
 


### PR DESCRIPTION
Overview
----------------------------------------
This ensures that even if someone turns off the hash generation that if the ConfigAndLogDir is under the webroot we still generate the hash

Before
----------------------------------------
Hash could be turned off potentially making the log file more guessable if ConfigAndLogdir is not also moved

After
----------------------------------------
Hash is still gnerated if config and log dir is under the webroot

ping @totten 