### PR TITLE
Allow to set payment order_reference from Contribution.create/repeattransaction

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -3609,7 +3609,9 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
         'fee_amount' => $params['fee_amount'] ?? NULL,
         'net_amount' => CRM_Utils_Array::value('net_amount', $params, $totalAmount),
         'currency' => $params['contribution']->currency,
-        'trxn_id' => $params['contribution']->trxn_id,
+        'trxn_id' => $params['trxn_id'],
+        'order_reference' => $params['order_reference'],
+
         // @todo - this is getting the status id from the contribution - that is BAD - ie the contribution could be partially
         // paid but each payment is completed. The work around is to pass in the status_id in the trxn_params but
         // this should really default to completed (after discussion).

--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4417,6 +4417,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
       'fee_amount',
       'net_amount',
       'trxn_id',
+      'order_reference',
       'check_number',
       'payment_instrument_id',
       'is_test',

--- a/api/v3/Contribution.php
+++ b/api/v3/Contribution.php
@@ -609,6 +609,7 @@ function civicrm_api3_contribution_repeattransaction($params) {
 
     $passThroughParams = [
       'trxn_id',
+      'order_reference',
       'total_amount',
       'campaign_id',
       'fee_amount',


### PR DESCRIPTION
Overview
----------------------------------------
`Payment.get` and `Payment.create` now support getting/setting `order_reference` parameter in `civicrm_financial_trxn`. But it is not possible to set this value using the `Contribution.create` or `Contribution.repeattransaction` API.

This makes writing IPN callbacks for payment processors more difficult because to set the `order_reference` parameter you have to wait for `Contribution.repeattransaction` to finish, lookup the contribution ID and get the *latest* payment (making the assumption that is the one that was just created). Then you call `Payment.create` to update the order_reference.

Before
----------------------------------------
To set the `order_reference` parameter you have to wait for `Contribution.repeattransaction` to finish, lookup the contribution ID and get the *latest* payment (making the assumption that is the one that was just created). Then you call `Payment.create` to update the order_reference.

After
----------------------------------------
Add `order_reference` parameter when calling `Contribution.repeattransaction`.

Technical Details
----------------------------------------
This just adds the parameter to the whitelist of parameters.

Comments
----------------------------------------
@eileenmcnaughton @artfulrobot 