### PR TITLE
Fix parameters when calling Contribution.repeattransaction with a contribution that has no recurring contribution

### DIFF
--- a/api/v3/Contribution.php
+++ b/api/v3/Contribution.php
@@ -595,10 +595,13 @@ function civicrm_api3_contribution_repeattransaction($params) {
       'A valid original contribution ID is required', 'invalid_data');
   }
   $original_contribution = clone $contribution;
-  $input['payment_processor_id'] = civicrm_api3('contributionRecur', 'getvalue', [
-    'return' => 'payment_processor_id',
-    'id' => $contribution->contribution_recur_id,
-  ]);
+  if (!empty($contribution->contribution_recur_id)) {
+    // If $contribution->contribution_recur_id is empty this returns 1 as the result which is wrong!
+    $input['payment_processor_id'] = civicrm_api3('contributionRecur', 'getvalue', [
+      'return' => 'payment_processor_id',
+      'id' => $contribution->contribution_recur_id,
+    ]);
+  }
   try {
     if (!$contribution->loadRelatedObjects($input, $ids, TRUE)) {
       throw new API_Exception('failed to load related objects');


### PR DESCRIPTION
Overview
----------------------------------------
This fixes the situation when you call `Contribution.repeattransaction` when the contribution does not have a linked recurring contribution.

Before
----------------------------------------
1. If the `financial_type_id` and `contact_id` are not specified as parameters the API call will fail with missing mandatory parameters.
2. The financialTrxn record gets recorded with payment_processor_id = 1.

After
----------------------------------------
1. If the `financial_type_id` and `contact_id` are not specified as parameters the API call take those parameters from the original contribution.
2. The financialTrxn record gets recorded with payment_processor_id = NULL.

Technical Details
----------------------------------------
Explained above and in code comments.

Comments
----------------------------------------
@eileenmcnaughton @artfulrobot 

We should either fix these issues or explicitly *not* support calling `Contribution.repeattransaction` if there is no recurring contribution.
I think it probably makes sense to support it because it allows you to build renewal workflows that don't rely on the recurring contribution. @KarinG I feel you may have thoughts on this?