### PR TITLE
Make 'Pending' the default status for Contribution.repeattransaction

### DIFF
--- a/api/v3/Contribution.php
+++ b/api/v3/Contribution.php
@@ -709,6 +709,7 @@ function _civicrm_api3_contribution_repeattransaction_spec(&$params) {
       'optionGroupName' => 'contribution_status',
     ],
     'api.required' => TRUE,
+    'api.default' => 'Pending',
   ];
   $params['receive_date'] = [
     'title' => 'Contribution Receive Date',


### PR DESCRIPTION
Overview
----------------------------------------
As the preferred way to repeat a contribution is now to call `Contribution.repeattransaction` and then `Payment.create` it makes sense to set `contribution_status_id` to `Pending` by default as that is the preferred way to call this API

Before
----------------------------------------
Must specify `contribution_status_id` for repeattransaction.

After
----------------------------------------
Don't need to specify it. When implementing functionality using `Contribution.repeattransaction` it is obvious that the intended way to call it is with status=Pending.

Technical Details
----------------------------------------
Just sets default at API level. As this is a required parameter it won't affect any existing implementations as they will all specify the `contribution_status_id` as a parameter.

Comments
----------------------------------------
@eileenmcnaughton 