### PR TITLE
Improve inconsistent handling of `trxn_date` / `receive_date` in Contribution/Payment APIs

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4451,6 +4451,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
       'source' => self::getRecurringContributionDescription($contribution, $event),
     ], array_intersect_key($input, array_fill_keys($inputContributionWhiteList, 1)
     ));
+    $contributionParams['receive_date'] = $input['trxn_date'];
 
     // CRM-20678 Ensure that the currency is correct in subseqent transcations.
     if (empty($contributionParams['currency']) && isset($objects['first_contribution']->currency)) {
@@ -4467,11 +4468,6 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
 
     if ($recurringContributionID) {
       $contributionParams['contribution_recur_id'] = $recurringContributionID;
-    }
-    $changeDate = CRM_Utils_Array::value('trxn_date', $input, date('YmdHis'));
-
-    if (empty($contributionParams['receive_date']) && $changeDate) {
-      $contributionParams['receive_date'] = $changeDate;
     }
 
     self::repeatTransaction($contribution, $input, $contributionParams, $paymentProcessorId);
@@ -4512,7 +4508,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
         self::updateMembershipBasedOnCompletionOfContribution(
           $contribution,
           $primaryContributionID,
-          $changeDate
+          $input['trxn_date']
         );
       }
     }
@@ -4520,7 +4516,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
       if (empty($input['IAmAHorribleNastyBeyondExcusableHackInTheCRMEventFORMTaskClassThatNeedsToBERemoved'])) {
         if ($event->is_email_confirm) {
           // @todo this should be set by the function that sends the mail after sending.
-          $contributionParams['receipt_date'] = $changeDate;
+          $contributionParams['receipt_date'] = $input['trxn_date'];
         }
         $participantParams['id'] = $participant->id;
         $participantParams['status_id'] = 'Registered';

--- a/CRM/Core/Payment/BaseIPN.php
+++ b/CRM/Core/Payment/BaseIPN.php
@@ -477,6 +477,8 @@ class CRM_Core_Payment_BaseIPN {
    * @throws \CiviCRM_API3_Exception
    */
   public function completeTransaction(&$input, &$ids, &$objects, $transaction = NULL) {
+    // We need to pass $input['trxn_date'] to completeOrder. Previously we *may* have used receive_date
+    $input['trxn_date'] = $input['trxn_date'] ?? $input['receive_date'] ?? date('YmdHis');
     CRM_Contribute_BAO_Contribution::completeOrder($input, $ids, $objects, $transaction);
   }
 

--- a/CRM/Core/Payment/PaymentExpressIPN.php
+++ b/CRM/Core/Payment/PaymentExpressIPN.php
@@ -181,7 +181,7 @@ class CRM_Core_Payment_PaymentExpressIPN extends CRM_Core_Payment_BaseIPN {
         $contribution->trxn_id = $ids['membership'];
       }
     }
-    CRM_Contribute_BAO_Contribution::completeOrder($input, $ids, $objects);
+    $this->completeTransaction($input, $ids, $objects);
     return TRUE;
   }
 

--- a/CRM/Event/Form/Task/Batch.php
+++ b/CRM/Event/Form/Task/Batch.php
@@ -430,6 +430,8 @@ class CRM_Event_Form_Task_Batch extends CRM_Event_Form_Task {
     //complete the contribution.
     // @todo use the api - ie civicrm_api3('Contribution', 'completetransaction', $input);
     // as this method is not preferred / supported.
+    // We need to pass $input['trxn_date'] to completeOrder. Previously we *may* have used receive_date
+    $input['trxn_date'] = $input['trxn_date'] ?? $input['receive_date'] ?? date('YmdHis');
     CRM_Contribute_BAO_Contribution::completeOrder($input, $ids, $objects);
 
     // reset template values before processing next transactions

--- a/api/v3/Contribution.php
+++ b/api/v3/Contribution.php
@@ -605,10 +605,11 @@ function civicrm_api3_contribution_repeattransaction($params) {
     }
 
     unset($contribution->id, $contribution->receive_date, $contribution->invoice_id);
-    $contribution->receive_date = $params['receive_date'];
+    $contribution->receive_date = $params['trxn_date'];
 
     $passThroughParams = [
       'trxn_id',
+      'trxn_date',
       'total_amount',
       'campaign_id',
       'fee_amount',
@@ -657,12 +658,6 @@ function _ipn_process_transaction(&$params, $contribution, $input, $ids, $firstC
   if (isset($params['is_email_receipt'])) {
     $input['is_email_receipt'] = $params['is_email_receipt'];
   }
-  if (!empty($params['trxn_date'])) {
-    $input['trxn_date'] = $params['trxn_date'];
-  }
-  if (!empty($params['receive_date'])) {
-    $input['receive_date'] = $params['receive_date'];
-  }
   if (empty($contribution->contribution_page_id)) {
     static $domainFromName;
     static $domainFromEmail;
@@ -710,10 +705,11 @@ function _civicrm_api3_contribution_repeattransaction_spec(&$params) {
     ],
     'api.required' => TRUE,
   ];
-  $params['receive_date'] = [
-    'title' => 'Contribution Receive Date',
-    'name' => 'receive_date',
+  $params['trxn_date'] = [
+    'title' => 'Transaction Date',
+    'description' => 'Date this transaction occurred',
     'type' => CRM_Utils_Type::T_DATE + CRM_Utils_Type::T_TIME,
+    'api.aliases' => ['receive_date'],
     'api.default' => 'now',
   ];
   $params['trxn_id'] = [


### PR DESCRIPTION
Overview
----------------------------------------
Improve inconsistent handling of `trxn_date` / `receive_date` in Contribution/Payment APIs that currently makes it more difficult than it needs to be to create/repeat payments.

Before
----------------------------------------
`Contribution.repeattransaction` takes `receive_date`. `Contribution.create` takes `receive_date`
`Contribution.completetransaction` takes `trxn_date`. `Payment.create` takes `trxn_date`.

After
----------------------------------------
`Contribution.create` takes `receive_date`.
`Contribution.repeattransaction`, `Contribution.completetransaction`, `Payment.create` takes `trxn_date`.

Technical Details
----------------------------------------
`Contribution.repeattransaction` parameter is changed to `trxn_date` with `receive_date` as alias for compatibility.
At various levels of code there were checks to see if receive_date and/or trxn_date were set. This moves that check up to a higher level and simplifies the lower level `completeOrder` function.

Comments
----------------------------------------
@eileenmcnaughton @artfulrobot This provides some consistency for the date handling and simplifies these functions a little bit. It should be fully backwards compatible because I've checked that `trxn_date` is being passed in in all cases (and added default handling where it wasn't).

In particular this makes it much easier to call `Contribution.repeattransaction` followed by `Payment.create` because you can use the same date parameter!
