### PR TITLE
dev/core#1791 - E_WARNINGS when viewing list of pledge payments

### DIFF
--- a/templates/CRM/Pledge/Page/Payment.tpl
+++ b/templates/CRM/Pledge/Page/Payment.tpl
@@ -31,7 +31,7 @@
     <td>{$row.reminder_date|truncate:10:''|crmDate}</td>
     <td class="right">{if $row.reminder_count}{$row.reminder_count}{/if}</td>
     <td {if ! ($permission EQ 'edit' and ($row.status eq 'Pending' or $row.status eq 'Overdue' or $row.status eq 'Completed')) } colspan="2"{/if} >{$row.label}</td>
-{if $context neq user}
+{if $context neq 'user'}
     {if $permission EQ 'edit' and ($row.status eq 'Pending' or $row.status eq 'Overdue' or $row.status eq 'Completed') }
         <td class="nowrap">
         {if $row.status eq 'Completed'} {* Link to view contribution record for completed payment.*}


### PR DESCRIPTION
1. Add a pledge for a contact. The details don't matter much, e.g. put in an amount and leave all the rest as defaults.
2. On the contact's pledges tab, right-click on the triangle to the left of the table that expands the pledge payment sequence and choose Open in New Tab.
3. Screen fills with E_WARNINGS.
4. You can also see it if you click the triangle normally and then check drupal watchdog.

The cause is some missing quotes here: https://github.com/civicrm/civicrm-core/blob/5.25.0/templates/CRM/Pledge/Page/Payment.tpl#L34