### PR TITLE
Revert Matt's fix for dev/membership#24 as it is incomplete and add a…

### DIFF
--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -1579,6 +1579,11 @@ WHERE  civicrm_membership.contact_id = civicrm_contact.id
    * @return null|string
    */
   public static function getContactMembershipCount($contactID, $activeOnly = FALSE) {
+    CRM_Financial_BAO_FinancialType::getAvailableMembershipTypes($membershipTypes);
+    $addWhere = " AND membership_type_id IN (0)";
+    if (!empty($membershipTypes)) {
+      $addWhere = " AND membership_type_id IN (" . implode(',', array_keys($membershipTypes)) . ")";
+    }
     $select = "SELECT count(*) FROM civicrm_membership ";
     $where = "WHERE civicrm_membership.contact_id = {$contactID} AND civicrm_membership.is_test = 0 ";
 
@@ -1588,7 +1593,7 @@ WHERE  civicrm_membership.contact_id = civicrm_contact.id
       $where .= " and civicrm_membership_status.is_current_member = 1";
     }
 
-    $query = $select . $where;
+    $query = $select . $where . $addWhere;
     return CRM_Core_DAO::singleValueQuery($query);
   }
 

--- a/CRM/Member/Page/Tab.php
+++ b/CRM/Member/Page/Tab.php
@@ -33,9 +33,17 @@ class CRM_Member_Page_Tab extends CRM_Core_Page {
    * called when action is browse.
    */
   public function browse() {
+    $links = self::links('all', $this->_isPaymentProcessor, $this->_accessContribution);
+    CRM_Financial_BAO_FinancialType::getAvailableMembershipTypes($membershipTypes);
+    $addWhere = "membership_type_id IN (0)";
+    if (!empty($membershipTypes)) {
+      $addWhere = "membership_type_id IN (" . implode(',', array_keys($membershipTypes)) . ")";
+    }
+
     $membership = [];
     $dao = new CRM_Member_DAO_Membership();
     $dao->contact_id = $this->_contactId;
+    $dao->whereAdd($addWhere);
     $dao->find();
 
     //CRM--4418, check for view, edit, delete

--- a/tests/phpunit/api/v3/FinancialTypeACLTest.php
+++ b/tests/phpunit/api/v3/FinancialTypeACLTest.php
@@ -316,4 +316,20 @@ class api_v3_FinancialTypeACLTest extends CiviUnitTestCase {
     $this->assertEquals($contribution['count'], 1);
   }
 
+  public function testMembersipTypeACLFinancialTypeACL() {
+    $contactID = $this->individualCreate();
+    $this->contactMembershipCreate(['contact_id' => $contactID]);
+    $this->enableFinancialACLs();
+    $this->setPermissions([
+      'access CiviCRM',
+      'access CiviContribute',
+      'view all contacts',
+      'add contributions of type Donation',
+      'view contributions of type Donation',
+    ]);
+    $this->assertEquals(0, CRM_Member_BAO_Membership::getContactMembershipCount($contactID));
+    $this->addFinancialAclPermissions([['view', 'Member Dues']]);
+    $this->assertEquals(1, CRM_Member_BAO_Membership::getContactMembershipCount($contactID));
+  }
+
 }


### PR DESCRIPTION
… unit test in to cover the financial type acls side of the code

Overview
----------------------------------------
This reverts the change from https://github.com/civicrm/civicrm-core/pull/17143 which implemented a regression in regards to Memberships showing and financial Type ACLs and also adds in a unit test to lock in the current correct behaviour

Before
----------------------------------------
No unit test and intra release regression

After
----------------------------------------
Unit test and no regression

ping @monishdeb @eileenmcnaughton @mattwire @jaapjansma 