### PR TITLE
dev/core#1747 don't drop temp tables on class destruct.

### DIFF
--- a/CRM/Contact/Form/Search/Custom/DateAdded.php
+++ b/CRM/Contact/Form/Search/Custom/DateAdded.php
@@ -383,19 +383,6 @@ class CRM_Contact_Form_Search_Custom_DateAdded extends CRM_Contact_Form_Search_C
     return $dao->N;
   }
 
-  public function __destruct() {
-    //drop the temp. tables if they exist
-    if ($this->_igTable && !empty($this->_includeGroups)) {
-      $sql = "DROP TEMPORARY TABLE IF EXISTS {$this->_igTable}";
-      CRM_Core_DAO::executeQuery($sql);
-    }
-
-    if ($this->_xgTable && !empty($this->_excludeGroups)) {
-      $sql = "DROP TEMPORARY TABLE IF EXISTS {$this->_xgTable}";
-      CRM_Core_DAO::executeQuery($sql);
-    }
-  }
-
   /**
    * @param string $tableAlias
    */


### PR DESCRIPTION

Overview
----------------------------------------
Fixes a regression whereby saved searches off the Date Added search can't load as the temp table is cleaned up too aggressively - description etc copied from gitlab as it was well explained

Since upgrading to 5.24 creating smart group using 'Date Added to CiviCRM' fails with DB Error: no such table. Also when a smart group is based on 'Date Added to CiviCRM' and try to refresh the count it fails with same error message

Reproduction steps
----------------------------------------
1. Navigate to CiviCRM >> Search >> Custom Searches >> Date Added to CiviCRM
1. Do a search on date and include in group.
1. Select all contact and try adding to smart group.
1. Got an error "**Fatal error: DB error**".

![smartGroupError](https://lab.civicrm.org/dev/core/uploads/3ea50e38bccd47141831b4990f6f6b0a/smartGroupError.gif)

Current behaviour
----------------------------------------
Get DB error 'Database Error Code: Table 'dmastercivi_g5lis.civicrm_tmp_e_ig_6f1e2d3b300d50a856f5cb9140996451' doesn't exist, 1146' when trying to create smart group or refresh count

Expected behaviour
----------------------------------------
smart should be created with correct contacts in it and also when refreshing the group count, the group should show correct count

Technical Details
----------------------------------------
Recent code clean up means the search class is now dropped more quickly - meaning that dropping
these tables in the destructors is too aggressive. Since they are memory tables & temp tables they get
cleaned up anyway I think. Regardless the odd slow cleanup is better than the current situation

We should move this search to an extension that ships with core, not necessarily
enabled on initial install but that is up for discussion

Comments
----------------------------------------

