### PR TITLE
dev/core#1725 Remove groups, tags and notes from the returned data fo…

### DIFF
--- a/CRM/Export/Form/Map.php
+++ b/CRM/Export/Form/Map.php
@@ -146,6 +146,14 @@ class CRM_Export_Form_Map extends CRM_Core_Form {
       $exportParams['postal_mailing_export']['postal_mailing_export'] == 1
     );
     $processor = new CRM_Export_BAO_ExportProcessor($this->get('exportMode'), NULL, $this->get('queryOperator'), $this->get('mergeSameHousehold'), $isPostalOnly, $this->get('mergeSameAddress'));
+    // dev/core#1775 Remove notes,groups and tags from the preview data to speed up export
+    $defaultProperties = $processor->getDefaultReturnProperties();
+    foreach ($defaultProperties as $key => $var) {
+      if (in_array($key, ['groups', 'tags', 'notes'])) {
+        unset($defaultProperties[$key]);
+      }
+    }
+    $processor->setReturnProperties($defaultProperties);
     $processor->setComponentTable($this->get('componentTable'));
     $processor->setComponentClause($this->get('componentClause'));
     $data = $processor->getPreview(4);


### PR DESCRIPTION
…r the usage in preview data to speed up loading of the select fields screen

Overview
----------------------------------------
This aims to speed up the generation of the select fields for export screen after doing an advanced search by removing the groups, tags and notes return properties

Before
----------------------------------------
slow to load the select fields for export screen due to slow joins / select query

After
----------------------------------------
Faster to load the screen

ping @eileenmcnaughton @jitendrapurohit 