### PR TITLE
Fixed hide show of start date

### DIFF
--- a/templates/CRM/Contribute/Form/Contribution.tpl
+++ b/templates/CRM/Contribute/Form/Contribution.tpl
@@ -549,14 +549,14 @@ function adjustPayment( ) {
 }
 
 {/literal}{if $processorSupportsFutureStartDate}{literal}
-cj ('input:radio[name="is_recur"]').click( function( ) {
+cj ('#is_recur').click( function( ) {
   showStartDate( );
 });
 
 showStartDate( );
 
 function showStartDate( ) {
-  if (cj( 'input:radio[name="is_recur"]:checked').val( ) == 0 ) {
+  if (cj('#is_recur').is(':checked')) {
     cj('#start_date').hide( );
   }
   else {

--- a/templates/CRM/Contribute/Form/Contribution.tpl
+++ b/templates/CRM/Contribute/Form/Contribution.tpl
@@ -556,7 +556,7 @@ cj ('#is_recur').click( function( ) {
 showStartDate( );
 
 function showStartDate( ) {
-  if (cj('#is_recur').is(':checked')) {
+  if (!cj('#is_recur').is(':checked')) {
     cj('#start_date').hide( );
   }
   else {


### PR DESCRIPTION
Overview
----------------------------------------
Fix hide show of receive date for recurring contributions.

Before
----------------------------------------
Clicking on the is_recur checkbox does not hide the start date. Start date is also shown on page load.

After
----------------------------------------
Start date is hidden until the is_recur checkbox is clicked. 

Comments
----------------------------------------
The above can be replicated on a back office credit card contribution form.