### PR TITLE
Don't allow Contribution.repeattransaction to be used without a recurring contribution

### DIFF
--- a/api/v3/Contribution.php
+++ b/api/v3/Contribution.php
@@ -594,6 +594,14 @@ function civicrm_api3_contribution_repeattransaction($params) {
     throw new API_Exception(
       'A valid original contribution ID is required', 'invalid_data');
   }
+  // We don't support repeattransaction without a related recurring contribution.
+  if (empty($contribution->contribution_recur_id)) {
+    throw new API_Exception(
+      'Repeattransaction API can only be used in the context of contributions that have a contribution_recur_id.',
+      'invalid_data'
+    );
+  }
+
   $original_contribution = clone $contribution;
   $input['payment_processor_id'] = civicrm_api3('contributionRecur', 'getvalue', [
     'return' => 'payment_processor_id',


### PR DESCRIPTION
Overview
----------------------------------------
Per #17429 `Contribution.repeattransaction` is not supported for use without a recurring contribution. I accidentally used it in this way while doing some development testing and there is no known use of it in this way. So let's explicitly disallow it.

Before
----------------------------------------
Can trigger `Contribution.repeattransaction` without a recurring contribution available (found either via contribution or via recur ID passed directly.

After
----------------------------------------
Triggering `Contribution.repeattransaction` throws an exception if it can't find a recurring contribution.

Technical Details
----------------------------------------
Just add an exception.

Comments
----------------------------------------
@eileenmcnaughton @KarinG Per discussion on #17429 let's just prevent it from being used in this way.
