### PR TITLE
Navigation menu: fix translation of new-subtype entries

### DIFF
--- a/CRM/Contact/BAO/ContactType.php
+++ b/CRM/Contact/BAO/ContactType.php
@@ -603,7 +603,7 @@ WHERE name = %1';
 
     if (!empty($params['id'])) {
       $newParams = [
-        'label' => "New $contact",
+        'label' => ts("New %1", [1 => $contact]),
         'is_active' => $active,
       ];
       CRM_Core_BAO_Navigation::processUpdate(['name' => "New $contactName"], $newParams);
@@ -616,7 +616,7 @@ WHERE name = %1';
       $value = ['name' => "New $name"];
       CRM_Core_BAO_Navigation::retrieve($value, $navinfo);
       $navigation = [
-        'label' => "New $contact",
+        'label' => ts("New %1", [1 => $contact]),
         'name' => "New $contactName",
         'url' => "civicrm/contact/add?ct=$name&cst=$contactName&reset=1",
         'permission' => 'add contacts',


### PR DESCRIPTION
Overview
----------------------------------------

To reproduce:

* Set the language to another language than English (ex: French)
* Create a new Contact SubType (Admin > Customize > Contact Sub-Types)

Before
----------------------------------------

The menu entries for the contact sub-types always prefix with "New" instead of the site language. Ex: "New [...]".

![new-english](https://user-images.githubusercontent.com/254741/83409742-02512f00-a3e3-11ea-932d-7e08a4552b8e.jpg)

Reported by fxsan on mattermost [link](https://chat.civicrm.org/civicrm/pl/5j8zy3trrtydtna34aibdznkwh)

After
----------------------------------------

The menu items will be in the site language.

Comments
----------------------------------------

This does not fix multi-lingual installs, but that is not an easy fix.