### PR TITLE
[REF] Start to convert Dummy processor to use PropertyBag

### DIFF
--- a/CRM/Core/Payment/Dummy.php
+++ b/CRM/Core/Payment/Dummy.php
@@ -11,18 +11,16 @@
  *
  * @package CRM
  * @author Marshal Newrock <marshal@idealso.com>
- * $Id: Dummy.php 45429 2013-02-06 22:11:18Z lobo $
  */
 
 use Civi\Payment\Exception\PaymentProcessorException;
+use Civi\Payment\PropertyBag;
 
 /**
  * Dummy payment processor
  */
 class CRM_Core_Payment_Dummy extends CRM_Core_Payment {
-  const CHARSET = 'iso-8859-1';
-
-  protected $_mode = NULL;
+  protected $_mode;
 
   protected $_params = [];
   protected $_doDirectPaymentResult = [];
@@ -44,27 +42,16 @@ class CRM_Core_Payment_Dummy extends CRM_Core_Payment {
   }
 
   /**
-   * We only need one instance of this object. So we use the singleton
-   * pattern and cache the instance in this variable
-   *
-   * @var object
-   */
-  static private $_singleton = NULL;
-
-  /**
    * Constructor.
    *
    * @param string $mode
    *   The mode of operation: live or test.
    *
-   * @param $paymentProcessor
-   *
-   * @return \CRM_Core_Payment_Dummy
+   * @param array $paymentProcessor
    */
   public function __construct($mode, &$paymentProcessor) {
     $this->_mode = $mode;
     $this->_paymentProcessor = $paymentProcessor;
-    $this->_processorName = ts('Dummy Processor');
   }
 
   /**
@@ -78,19 +65,19 @@ class CRM_Core_Payment_Dummy extends CRM_Core_Payment {
    * @throws \Civi\Payment\Exception\PaymentProcessorException
    */
   public function doDirectPayment(&$params) {
+    $propertyBag = PropertyBag::cast($params);
     // Invoke hook_civicrm_paymentProcessor
     // In Dummy's case, there is no translation of parameters into
     // the back-end's canonical set of parameters.  But if a processor
     // does this, it needs to invoke this hook after it has done translation,
     // but before it actually starts talking to its proprietary back-end.
-    if (!empty($params['is_recur'])) {
-      $throwAnENoticeIfNotSetAsTheseAreRequired = $params['frequency_interval'] . $params['frequency_unit'];
+    if ($propertyBag->getIsRecur()) {
+      $throwAnENoticeIfNotSetAsTheseAreRequired = $propertyBag->getRecurFrequencyInterval() . $propertyBag->getRecurFrequencyUnit();
     }
     // no translation in Dummy processor
-    $cookedParams = $params;
     CRM_Utils_Hook::alterPaymentProcessorParams($this,
       $params,
-      $cookedParams
+      $propertyBag
     );
     // This means we can test failing transactions by setting a past year in expiry. A full expiry check would
     // be more complete.
@@ -107,26 +94,25 @@ class CRM_Core_Payment_Dummy extends CRM_Core_Payment {
       $result['trxn_id'] = array_shift($this->_doDirectPaymentResult['trxn_id']);
       return $result;
     }
-    if ($this->_mode == 'test') {
+    if ($this->_mode === 'test') {
       $query = "SELECT MAX(trxn_id) FROM civicrm_contribution WHERE trxn_id LIKE 'test\\_%'";
       $p = [];
-      $trxn_id = strval(CRM_Core_DAO::singleValueQuery($query, $p));
+      $trxn_id = (string) CRM_Core_DAO::singleValueQuery($query, $p);
       $trxn_id = str_replace('test_', '', $trxn_id);
-      $trxn_id = intval($trxn_id) + 1;
+      $trxn_id = (int) $trxn_id + 1;
       $params['trxn_id'] = 'test_' . $trxn_id . '_' . uniqid();
     }
     else {
       $query = "SELECT MAX(trxn_id) FROM civicrm_contribution WHERE trxn_id LIKE 'live_%'";
       $p = [];
-      $trxn_id = strval(CRM_Core_DAO::singleValueQuery($query, $p));
+      $trxn_id = (string) CRM_Core_DAO::singleValueQuery($query, $p);
       $trxn_id = str_replace('live_', '', $trxn_id);
-      $trxn_id = intval($trxn_id) + 1;
+      $trxn_id = (int) $trxn_id + 1;
       $params['trxn_id'] = 'live_' . $trxn_id . '_' . uniqid();
     }
-    $params['gross_amount'] = $params['amount'];
+    $params['gross_amount'] = $propertyBag->getAmount();
     // Add a fee_amount so we can make sure fees are handled properly in underlying classes.
     $params['fee_amount'] = 1.50;
-    $params['net_amount'] = $params['gross_amount'] - $params['fee_amount'];
     $params['description'] = $this->getPaymentDescription($params);
 
     return $params;
@@ -142,7 +128,8 @@ class CRM_Core_Payment_Dummy extends CRM_Core_Payment {
   }
 
   /**
-   * Supports altering future start dates
+   * Supports altering future start dates.
+   *
    * @return bool
    */
   public function supportsFutureRecurStartDate() {
@@ -158,28 +145,6 @@ class CRM_Core_Payment_Dummy extends CRM_Core_Payment {
    *   Assoc array of input parameters for this transaction.
    */
   public function doRefund(&$params) {}
-
-  /**
-   * Generate error object.
-   *
-   * Throwing exceptions is preferred over this.
-   *
-   * @param string $errorCode
-   * @param string $errorMessage
-   *
-   * @return CRM_Core_Error
-   *   Error object.
-   */
-  public function &error($errorCode = NULL, $errorMessage = NULL) {
-    $e = CRM_Core_Error::singleton();
-    if ($errorCode) {
-      $e->push($errorCode, 0, NULL, $errorMessage);
-    }
-    else {
-      $e->push(9001, 0, NULL, 'Unknown System Error.');
-    }
-    return $e;
-  }
 
   /**
    * This function checks to see if we have the right config values.
@@ -221,13 +186,37 @@ class CRM_Core_Payment_Dummy extends CRM_Core_Payment {
   }
 
   /**
-   * @param string $message
-   * @param array $params
+   * Does this processor support cancelling recurring contributions through code.
    *
-   * @return bool|object
+   * If the processor returns true it must be possible to take action from within CiviCRM
+   * that will result in no further payments being processed. In the case of token processors (e.g
+   * IATS, eWay) updating the contribution_recur table is probably sufficient.
+   *
+   * @return bool
    */
-  public function cancelSubscription(&$message = '', $params = []) {
+  protected function supportsCancelRecurring() {
     return TRUE;
+  }
+
+  /**
+   * Cancel a recurring subscription.
+   *
+   * Payment processor classes should override this rather than implementing cancelSubscription.
+   *
+   * A PaymentProcessorException should be thrown if the update of the contribution_recur
+   * record should not proceed (in many cases this function does nothing
+   * as the payment processor does not need to take any action & this should silently
+   * proceed. Note the form layer will only call this after calling
+   * $processor->supports('cancelRecurring');
+   *
+   * @param \Civi\Payment\PropertyBag $propertyBag
+   *
+   * @return array
+   *
+   * @throws \Civi\Payment\Exception\PaymentProcessorException
+   */
+  public function doCancelRecurring(PropertyBag $propertyBag) {
+    return ['message' => ts('Recurring contribution cancelled')];
   }
 
 }

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -1162,7 +1162,7 @@ abstract class CRM_Utils_Hook {
    *   See discussion in CRM-16224 as to whether $paymentObj should be passed by reference.
    * @param array &$rawParams
    *    array of params as passed to to the processor
-   * @param array &$cookedParams
+   * @param array|\Civi\Payment\PropertyBag &$cookedParams
    *     params after the processor code has translated them into its own key/value pairs
    *
    * @return mixed

--- a/Civi/Payment/PropertyBag.php
+++ b/Civi/Payment/PropertyBag.php
@@ -777,9 +777,12 @@ class PropertyBag implements \ArrayAccess {
    *
    * @param string $label
    *
-   * @return bool|null
+   * @return bool
    */
   public function getIsRecur($label = 'default'):bool {
+    if (!$this->has('isRecur')) {
+      return FALSE;
+    }
     return $this->get('isRecur', $label);
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
This starts the process of adopting the new property bag - but in the Dummy processor rather than a live processor

Before
----------------------------------------
Uses the array

After
----------------------------------------
Casts to the bag

Technical Details
----------------------------------------
@artfulrobot @mattwire I'm thinking this will throw an error on tests in setAmount per previous - but it occurred to me that the Dummy processor was a good one to convert first as it's more used by devs & less by live sites.

Also, I added preferred functions for doCancelRecurrring - really we should also rename doDirectPayment to doPayment as part of modelling preferred practice

Comments
----------------------------------------

Note $params IS still being accessed in this class - for credit card variables. We haven't got those handled as yet on the PropertyBag - if we merge this we should review those next

