### PR TITLE
WIP Save custom data when creating contribution during repeattransaction

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2623,9 +2623,10 @@ LEFT JOIN  civicrm_contribution contribution ON ( componentPayment.contribution_
         $contributionParams['tax_amount'] = $contribution->tax_amount;
       }
 
+      $customData = CRM_Contribute_BAO_ContributionRecur::getCustomDataForContribution($templateContribution['id']);
+      $contributionParams = array_merge($customData, $contributionParams);
       $createContribution = civicrm_api3('Contribution', 'create', $contributionParams);
       $contribution->id = $createContribution['id'];
-      CRM_Contribute_BAO_ContributionRecur::copyCustomValues($contributionParams['contribution_recur_id'], $contribution->id);
       self::handleMembershipIDOverride($contribution->id, $input);
       return TRUE;
     }


### PR DESCRIPTION
Overview
----------------------------------------
When using `Contribution.repeattransaction` any custom data (values) from the template/previous contribution is copied over. I didn't know this happened and only found out while working on the giftaid extension (where we do NOT want this to happen).
On investigation it turned out that custom data was being copied via a direct database `INSERT` after the contribution had been created using API3 Contribution.create. This means it bypassed hooks, there was no way of knowing it happened (without looking at the data afterwards) and no way of overriding/changing via hooks.

Before
----------------------------------------
Secret magic copy of custom data on contributions during repeattransaction.

After
----------------------------------------
Custom data copied as part of the `Contribution.create` API call. Data shows in pre/post hooks.

Technical Details
----------------------------------------
The existing `CRM_Contribute_BAO_ContributionRecur::copyCustomValues()` function builds a custom data tree and then inserts it directly into the database. I've taken that function and extracted the part to build a custom data tree into `CRM_Contribute_BAO_ContributionRecur::getCustomDataForContribution()` which returns an API3 style array of ['custom_x' = X] which can be passed directly into the API3 call. That could be further refactored into a generic function and perhaps would be better nearer to the API3 classes - I've captured that via a todo comment.

Comments
----------------------------------------
