### PR TITLE
Get the template contribution instead of the first contribution when using repeattransaction

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4424,6 +4424,8 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
       $contribution = new CRM_Contribute_BAO_Contribution();
       $contribution->copyValues(CRM_Contribute_BAO_ContributionRecur::getTemplateContribution($recurringContributionID));
       $primaryContributionID = $contribution->id;
+      unset($contribution->id, $contribution->invoice_id);
+      isset($input['receive_date']) ? $contribution->receive_date = $input['receive_date'] : NULL;
     }
     else {
       $primaryContributionID = $contribution->id ?? $objects['first_contribution']->id;

--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4417,7 +4417,18 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
       $transaction = new CRM_Core_Transaction();
     }
     $contribution = $objects['contribution'];
-    $primaryContributionID = $contribution->id ?? $objects['first_contribution']->id;
+
+    $recurContrib = $objects['contributionRecur'] ?? NULL;
+    $recurringContributionID = (empty($recurContrib->id)) ? NULL : $recurContrib->id;
+    if ($recurringContributionID) {
+      $contribution = new CRM_Contribute_BAO_Contribution();
+      $contribution->copyValues(CRM_Contribute_BAO_ContributionRecur::getTemplateContribution($recurringContributionID));
+      $primaryContributionID = $contribution->id;
+    }
+    else {
+      $primaryContributionID = $contribution->id ?? $objects['first_contribution']->id;
+    }
+
     // The previous details are used when calculating line items so keep it before any code that 'does something'
     if (!empty($contribution->id)) {
       $input['prevContribution'] = CRM_Contribute_BAO_Contribution::getValues(['id' => $contribution->id]);
@@ -4441,8 +4452,6 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
     }
 
     $participant = $objects['participant'] ?? NULL;
-    $recurContrib = $objects['contributionRecur'] ?? NULL;
-    $recurringContributionID = (empty($recurContrib->id)) ? NULL : $recurContrib->id;
     $event = $objects['event'] ?? NULL;
 
     $paymentProcessorId = '';

--- a/CRM/Contribute/BAO/ContributionRecur.php
+++ b/CRM/Contribute/BAO/ContributionRecur.php
@@ -409,7 +409,7 @@ INNER JOIN civicrm_contribution       con ON ( con.id = mp.contribution_id )
    *
    * @param int $id
    * @param array $overrides
-   *   Parameters that should be overriden. Add unit tests if using parameters other than total_amount & financial_type_id.
+   *   Parameters that should be overridden. Add unit tests if using parameters other than total_amount & financial_type_id.
    *
    * @return array
    *

--- a/tests/phpunit/CRM/Contribute/BAO/ContributionRecurTest.php
+++ b/tests/phpunit/CRM/Contribute/BAO/ContributionRecurTest.php
@@ -225,6 +225,7 @@ class CRM_Contribute_BAO_ContributionRecurTest extends CiviUnitTestCase {
       'contribution_recur_id' => $contributionRecur['id'],
       'total_amount' => '3.00',
       'financial_type_id' => 1,
+      'source' => 'Template Contribution',
       'payment_instrument_id' => 1,
       'currency' => 'USD',
       'contact_id' => $this->individualCreate(),
@@ -237,6 +238,7 @@ class CRM_Contribute_BAO_ContributionRecurTest extends CiviUnitTestCase {
       'contribution_recur_id' => $contributionRecur['id'],
       'total_amount' => '3.00',
       'financial_type_id' => 1,
+      'source' => 'Non-template Contribution',
       'payment_instrument_id' => 1,
       'currency' => 'USD',
       'contact_id' => $this->individualCreate(),
@@ -246,6 +248,12 @@ class CRM_Contribute_BAO_ContributionRecurTest extends CiviUnitTestCase {
     $fetchedTemplate = CRM_Contribute_BAO_ContributionRecur::getTemplateContribution($contributionRecur['id']);
     // Fetched template should be the is_template, not the latest contrib
     $this->assertEquals($fetchedTemplate['id'], $templateContrib['id']);
+
+    $repeatContribution = $this->callAPISuccess('Contribution', 'repeattransaction', [
+      'contribution_status_id' => "Completed",
+      'contribution_recur_id' => $contributionRecur['id'],
+    ]);
+    $this->assertEquals($repeatContribution['values'][$repeatContribution['id']]['source'], $templateContrib['values'][$templateContrib['id']]['source']);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
When calling repeattransaction we should be preferring the template contribution (and using the function in `CRM_Contribute_BAO_ContributionRecur` to get the correct template contribution).
Currently we're using the first contribution.

Logic should be: template contribution ?? latest contribution.

Before
----------------------------------------
`Contribution.repeattransaction` uses first contribution as template.

After
----------------------------------------
`Contribution.repeattransaction` uses standard method to get template contribution.

Technical Details
----------------------------------------
Switch to standard function.

Comments
----------------------------------------
@eileenmcnaughton @monishdeb @artfulrobot This came out of #17032 and causes issues such as contribution source text not being what you expect it to be, lineitems matching first contribution instead of latest etc.