### PR TITLE
Flag that doDirectPayment and doTransferCheckout are deprecated

### DIFF
--- a/CRM/Core/Error.php
+++ b/CRM/Core/Error.php
@@ -1035,12 +1035,17 @@ class CRM_Core_Error extends PEAR_ErrorStack {
    *
    * @param $newMethod
    *   description of new method (eg. "buildOptions() method in the appropriate BAO object").
+   * @param $oldMethod
+   *   optional description of old method (if not the calling method). eg. CRM_MyClass::myOldMethodToGetTheOptions()
    */
-  public static function deprecatedFunctionWarning($newMethod) {
-    $dbt = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2);
-    $callerFunction = $dbt[1]['function'] ?? NULL;
-    $callerClass = $dbt[1]['class'] ?? NULL;
-    Civi::log()->warning("Deprecated function $callerClass::$callerFunction, use $newMethod.", ['civi.tag' => 'deprecated']);
+  public static function deprecatedFunctionWarning($newMethod, $oldMethod = NULL) {
+    if (!$oldMethod) {
+      $dbt = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2);
+      $callerFunction = $dbt[1]['function'] ?? NULL;
+      $callerClass = $dbt[1]['class'] ?? NULL;
+      $oldMethod = "{$callerClass}::{$callerFunction}";
+    }
+    Civi::log()->warning("Deprecated function $oldMethod, use $newMethod.", ['civi.tag' => 'deprecated']);
   }
 
 }

--- a/CRM/Core/Payment.php
+++ b/CRM/Core/Payment.php
@@ -1357,12 +1357,14 @@ abstract class CRM_Core_Payment {
     }
 
     if ($this->_paymentProcessor['billing_mode'] == 4) {
+      CRM_Core_Error::deprecatedFunctionWarning('doPayment', 'CRM_Core_Payment::doTransferCheckout');
       $result = $this->doTransferCheckout($params, $component);
       if (is_array($result) && !isset($result['payment_status_id'])) {
         $result['payment_status_id'] = array_search('Pending', $statuses);
       }
     }
     else {
+      CRM_Core_Error::deprecatedFunctionWarning('doPayment', 'CRM_Core_Payment::doDirectPayment');
       $result = $this->doDirectPayment($params, $component);
       if (is_array($result) && !isset($result['payment_status_id'])) {
         if (!empty($params['is_recur'])) {


### PR DESCRIPTION
Overview
----------------------------------------
Add deprecation warning to `doDirectPayment` and `doTransferCheckout` methods on `CRM_Core_Payment`

Before
----------------------------------------
No notice

After
----------------------------------------
A notice.

Technical Details
----------------------------------------


Comments
----------------------------------------
`doPayment` was added in 2014. the other methods have been deprecated for a long time now.
