### PR TITLE
[REF] Retrieve the token if it is available from the Payment Token ta…

### DIFF
--- a/CRM/Contribute/BAO/ContributionRecur.php
+++ b/CRM/Contribute/BAO/ContributionRecur.php
@@ -330,6 +330,7 @@ class CRM_Contribute_BAO_ContributionRecur extends CRM_Contribute_DAO_Contributi
 SELECT rec.id                   as recur_id,
        rec.processor_id         as subscription_id,
        rec.frequency_interval,
+       rec.payment_token_id as token_id,
        rec.installments,
        rec.frequency_unit,
        rec.amount,

--- a/CRM/Contribute/Form/CancelSubscription.php
+++ b/CRM/Contribute/Form/CancelSubscription.php
@@ -218,7 +218,7 @@ class CRM_Contribute_Form_CancelSubscription extends CRM_Contribute_Form_Contrib
         $propertyBag->setIsNotifyProcessorOnCancelRecur(!empty($params['send_cancel_request']));
       }
       $propertyBag->setContributionRecurID($this->getSubscriptionDetails()->recur_id);
-      $propertyBag->setRecurProcessorID($this->getSubscriptionDetails()->subscription_id);
+      $propertyBag->setRecurProcessorID($this->getSubscriptionID());
       $message = $this->_paymentProcessorObj->doCancelRecurring($propertyBag)['message'];
     }
     catch (\Civi\Payment\Exception\PaymentProcessorException $e) {

--- a/CRM/Contribute/Form/ContributionRecur.php
+++ b/CRM/Contribute/Form/ContributionRecur.php
@@ -195,6 +195,17 @@ class CRM_Contribute_Form_ContributionRecur extends CRM_Core_Form {
     return $sub->contact_id ?? FALSE;
   }
 
+  protected function getSubscriptionID() {
+    $sub = $this->getSubscriptionDetails();
+    if (empty($sub->subscription_id) && !empty($sub->token_id)) {
+      $tokenDetails = civicrm_api3('PaymentToken', 'get', ['id' => $sub->token_id]);
+      if (!empty($tokenDetails['values'])) {
+        return $tokenDetails['values'][$tokenDetails['id']]['token'];
+      }
+    }
+    return $sub->subscription_id;
+  }
+
   /**
    * Is this being used by a front end user to update their own recurring.
    *

--- a/CRM/Contribute/Form/UpdateBilling.php
+++ b/CRM/Contribute/Form/UpdateBilling.php
@@ -202,7 +202,7 @@ class CRM_Contribute_Form_UpdateBilling extends CRM_Contribute_Form_Contribution
     $processorParams['country'] = CRM_Core_PseudoConstant::country($params["billing_country_id-{$this->_bltID}"], FALSE);
     $processorParams['month'] = $processorParams['credit_card_exp_date']['M'];
     $processorParams['year'] = $processorParams['credit_card_exp_date']['Y'];
-    $processorParams['subscriptionId'] = $this->_subscriptionDetails->subscription_id;
+    $processorParams['subscriptionId'] = $this->getSubscriptionID();
     $processorParams['amount'] = $this->_subscriptionDetails->amount;
     $updateSubscription = $this->_paymentProcessor['object']->updateSubscriptionBillingInfo($message, $processorParams);
     if (is_a($updateSubscription, 'CRM_Core_Error')) {

--- a/CRM/Contribute/Form/UpdateSubscription.php
+++ b/CRM/Contribute/Form/UpdateSubscription.php
@@ -206,7 +206,7 @@ class CRM_Contribute_Form_UpdateSubscription extends CRM_Contribute_Form_Contrib
     $params['id'] = $this->_subscriptionDetails->recur_id;
     $message = '';
 
-    $params['subscriptionId'] = $this->_subscriptionDetails->subscription_id;
+    $params['subscriptionId'] = $this->getSubscriptionID();
     $updateSubscription = TRUE;
     if ($this->_paymentProcessorObj->supports('changeSubscriptionAmount')) {
       try {


### PR DESCRIPTION
…ble if no processor_id is set

Overview
----------------------------------------
Some Payment Processors (notably IATS) do not store the customer token in the civicrm_contribution_recur.processor_id column but rather in the civicrm_payment_token.token column instead see https://github.com/iATSPayments/com.iatspayments.civicrm/blob/3f72337ca0430fc3aaad94c3aba2271c198b2273/CRM/Core/Payment/iATSServiceACHEFT.php#L266

However this causes the cancel form on contribution recur self service to break because the cancel form is assuming the payment token will always be in civicrm_contribution_recur.processor_id https://github.com/civicrm/civicrm-core/blob/master/CRM/Contribute/Form/CancelSubscription.php#L219 

Before
----------------------------------------
Self-Service Cancel form fails or IATS and possibly other payment processors that store the token in the civicrm_payment_token table rather than in the civicrm_contribution_recur table 

After
----------------------------------------
Cancel form works for IATS and similar

ping @mattwire @eileenmcnaughton @KarinG note that this is a partial alternate to @Edzelopez 's https://github.com/civicrm/civicrm-core/pull/17445 Note this aims to only fix item 1 from that PR