### PR TITLE
dev/core#1780 Fix bug where non-household merge contacts were being skipped

### DIFF
--- a/CRM/Export/BAO/ExportProcessor.php
+++ b/CRM/Export/BAO/ExportProcessor.php
@@ -498,7 +498,7 @@ class CRM_Export_BAO_ExportProcessor {
    */
   public function setRelationshipValue($relationshipType, $contactID, $field, $value) {
     $this->relatedContactValues[$relationshipType][$contactID][$field] = $value;
-    if ($field === 'id') {
+    if ($field === 'id' && $this->isHouseholdMergeRelationshipTypeKey($relationshipType)) {
       $this->householdsToSkip[] = $value;
     }
   }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a bug where exporting a child and their parent was only resulting in one row being exported, when the related contact id was selected

Before
----------------------------------------
Per https://lab.civicrm.org/dev/core/-/issues/1780

After
----------------------------------------
Per https://lab.civicrm.org/dev/core/-/issues/1780

Technical Details
----------------------------------------


Comments
----------------------------------------
@yashodha this should do it
