### PR TITLE
APIv4 - Improve custom field spec gathering

### DIFF
--- a/Civi/Api4/Service/Schema/Joinable/CustomGroupJoinable.php
+++ b/Civi/Api4/Service/Schema/Joinable/CustomGroupJoinable.php
@@ -61,7 +61,7 @@ class CustomGroupJoinable extends Joinable {
     if (!$this->entityFields) {
       $fields = CustomField::get()
         ->setCheckPermissions(FALSE)
-        ->setSelect(['custom_group.name', 'custom_group.extends', '*'])
+        ->setSelect(['custom_group.name', 'custom_group.extends', 'custom_group.table_name', '*'])
         ->addWhere('custom_group.table_name', '=', $this->getTargetTable())
         ->execute();
       foreach ($fields as $field) {

--- a/Civi/Api4/Service/Spec/SpecGatherer.php
+++ b/Civi/Api4/Service/Spec/SpecGatherer.php
@@ -109,15 +109,24 @@ class SpecGatherer {
   }
 
   /**
+   * Get custom fields that extend this entity
+   *
+   * @see \CRM_Core_SelectValues::customGroupExtends
+   *
    * @param string $entity
    * @param \Civi\Api4\Service\Spec\RequestSpec $specification
    * @param array $values
    * @throws \API_Exception
    */
   private function addCustomFields($entity, RequestSpec $specification, $values = []) {
+    // Custom_group.extends pretty much maps 1-1 with entity names, except for a couple oddballs (Contact, Participant).
     $extends = [$entity];
     if ($entity === 'Contact') {
-      $extends = !empty($values['contact_type']) ? [$values['contact_type'], 'Contact'] : ['Contact', 'Individual', 'Organization', 'Household'];
+      $contactType = !empty($values['contact_type']) ? [$values['contact_type']] : \CRM_Contact_BAO_ContactType::basicTypes();
+      $extends = array_merge(['Contact'], $contactType);
+    }
+    if ($entity === 'Participant') {
+      $extends = ['Participant', 'ParticipantRole', 'ParticipantEventName', 'ParticipantEventType'];
     }
     $customFields = CustomField::get()
       ->setCheckPermissions(FALSE)


### PR DESCRIPTION
Overview
----------------------------------------
Some minor fixes in APIv4 custom field spec handling.

Before
----------------------------------------
Inactive contact types included.
All variants of participant fields not included.

After
----------------------------------------
Uses the basicTypes() function instead of hard-coding contact types,
Includes all the weird variants of Participant.
