### PR TITLE
Convert remaining Authorize.net test to use guzzle

### DIFF
--- a/CRM/Core/Payment/AuthorizeNet.php
+++ b/CRM/Core/Payment/AuthorizeNet.php
@@ -245,7 +245,7 @@ class CRM_Core_Payment_AuthorizeNet extends CRM_Core_Payment {
       $intervalLength *= 12;
       $intervalUnit = 'months';
     }
-    elseif ($intervalUnit == 'day') {
+    elseif ($intervalUnit === 'day') {
       $intervalUnit = 'days';
     }
     elseif ($intervalUnit == 'month') {


### PR DESCRIPTION


Overview
----------------------------------------
This allows us to remove the handling for when a.net doesn't reply

Before
----------------------------------------
Test dependency on external services, flakey

After
----------------------------------------
Mocks requests

Technical Details
----------------------------------------


Comments
----------------------------------------
