### PR TITLE
APIv4 - Support "relative date ranges" with the "IS" operator

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -2734,7 +2734,7 @@ SELECT contact_id
             }
             return $escapedCriteria;
 
-          // Special purpose "IS" operator
+          // The "IS" operator is like an alias; it can be rewritten into other criteria.
           case 'IS':
             $newFilter = \Civi\Api4\Utils\CoreUtil::rewriteIsCriteria($fieldName, $criteria);
             if ($newFilter !== NULL) {

--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -2736,23 +2736,10 @@ SELECT contact_id
 
           // Special purpose "IS" operator
           case 'IS':
-            $recurse = function ($newFilter) use ($fieldName, $type, $alias, $returnSanitisedArray) {
+            $newFilter = \Civi\Api4\Utils\CoreUtil::rewriteIsCriteria($fieldName, $criteria);
+            if ($newFilter !== NULL) {
               return self::createSQLFilter($fieldName, $newFilter, $type, $alias, $returnSanitisedArray);
-            };
-
-            if ($criteria === 'null' || $criteria === 'NULL') {
-              return $recurse(['IS NULL' => '']);
             }
-            elseif ($criteria === 'not null' || $criteria === 'NOT NULL') {
-              return $recurse(['IS NOT NULL' => '']);
-            }
-
-            $relDateFilters = \CRM_Core_OptionGroup::values('relative_date_filters');
-            if (isset($relDateFilters[$criteria])) {
-              list ($dateFrom, $dateTo) = \CRM_Utils_Date::getFromTo($criteria, NULL, NULL);
-              return $recurse(['BETWEEN' => [$dateFrom, $dateTo]]);
-            }
-
             break;
 
           // binary operators

--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -2736,11 +2736,12 @@ SELECT contact_id
 
           // The "IS" operator is like an alias; it can be rewritten into other criteria.
           case 'IS':
-            $newFilter = \Civi\Api4\Utils\CoreUtil::rewriteIsCriteria($fieldName, $criteria);
+          case 'IS NOT':
+            $newFilter = \Civi\Api4\Utils\CoreUtil::rewriteIsCriteria($fieldName, $operator, $criteria);
             if ($newFilter !== NULL) {
               return self::createSQLFilter($fieldName, $newFilter, $type, $alias, $returnSanitisedArray);
             }
-            break;
+            return NULL;
 
           // binary operators
 
@@ -2778,6 +2779,7 @@ SELECT contact_id
       'BETWEEN',
       'NOT BETWEEN',
       'IS',
+      'IS NOT',
       'IS NOT NULL',
       'IS NULL',
     ];

--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -2734,6 +2734,27 @@ SELECT contact_id
             }
             return $escapedCriteria;
 
+          // Special purpose "IS" operator
+          case 'IS':
+            $recurse = function ($newFilter) use ($fieldName, $type, $alias, $returnSanitisedArray) {
+              return self::createSQLFilter($fieldName, $newFilter, $type, $alias, $returnSanitisedArray);
+            };
+
+            if ($criteria === 'null' || $criteria === 'NULL') {
+              return $recurse(['IS NULL' => '']);
+            }
+            elseif ($criteria === 'not null' || $criteria === 'NOT NULL') {
+              return $recurse(['IS NOT NULL' => '']);
+            }
+
+            $relDateFilters = \CRM_Core_OptionGroup::values('relative_date_filters');
+            if (isset($relDateFilters[$criteria])) {
+              list ($dateFrom, $dateTo) = \CRM_Utils_Date::getFromTo($criteria, NULL, NULL);
+              return $recurse(['BETWEEN' => [$dateFrom, $dateTo]]);
+            }
+
+            break;
+
           // binary operators
 
           default:
@@ -2769,6 +2790,7 @@ SELECT contact_id
       'NOT IN',
       'BETWEEN',
       'NOT BETWEEN',
+      'IS',
       'IS NOT NULL',
       'IS NULL',
     ];

--- a/Civi/Api4/Generic/Traits/ArrayQueryActionTrait.php
+++ b/Civi/Api4/Generic/Traits/ArrayQueryActionTrait.php
@@ -22,6 +22,7 @@
 namespace Civi\Api4\Generic\Traits;
 
 use Civi\API\Exception\NotImplementedException;
+use Civi\Api4\Utils\CoreUtil;
 
 /**
  * Helper functions for performing api queries on arrays of data.
@@ -141,6 +142,12 @@ trait ArrayQueryActionTrait {
 
       case '<=':
         return $value <= $expected;
+
+      case 'IS':
+        foreach ((array) CoreUtil::rewriteIsCriteria($condition[0], $expected) as $newOperator => $newCriteria) {
+          return $this->walkFilters($row, [$condition[0], $newOperator, $newCriteria]);
+        }
+        return FALSE;
 
       case 'BETWEEN':
       case 'NOT BETWEEN':

--- a/Civi/Api4/Generic/Traits/ArrayQueryActionTrait.php
+++ b/Civi/Api4/Generic/Traits/ArrayQueryActionTrait.php
@@ -144,7 +144,8 @@ trait ArrayQueryActionTrait {
         return $value <= $expected;
 
       case 'IS':
-        foreach ((array) CoreUtil::rewriteIsCriteria($condition[0], $expected) as $newOperator => $newCriteria) {
+      case 'IS NOT':
+        foreach ((array) CoreUtil::rewriteIsCriteria($condition[0], $operator, $expected) as $newOperator => $newCriteria) {
           return $this->walkFilters($row, [$condition[0], $newOperator, $newCriteria]);
         }
         return FALSE;

--- a/Civi/Api4/Query/Api4SelectQuery.php
+++ b/Civi/Api4/Query/Api4SelectQuery.php
@@ -304,7 +304,7 @@ class Api4SelectQuery extends SelectQuery {
     // For WHERE clause, expr must be the name of a field.
     if ($type === 'WHERE') {
       $field = $this->getField($expr, TRUE);
-      FormattingUtil::formatInputValue($value, $expr, $field);
+      FormattingUtil::formatInputValue($value, $expr, $field, 'get', $operator);
       $fieldAlias = $field['sql_name'];
     }
     // For HAVING, expr must be an item in the SELECT clause

--- a/Civi/Api4/Utils/CoreUtil.php
+++ b/Civi/Api4/Utils/CoreUtil.php
@@ -79,24 +79,25 @@ class CoreUtil {
    *
    * @param string $fieldName
    *   Ex: 'activity_date_time'
+   * @param string $operator
+   *   Ex: 'IS' or 'IS NOT'
    * @param string $criteria
    *   Ex: ['IS' => 'previous.month']
    * @return array|NULL
    *   Array(string $newOperator, mixed $newCriteria).
    *   Ex: ['BETWEEN' => ['2020-05-01', '2020-06-01']]
    */
-  public static function rewriteIsCriteria($fieldName, $criteria) {
+  public static function rewriteIsCriteria($fieldName, $operator, $criteria) {
+    $affirm = ($operator == 'IS');
     if ($criteria === 'null' || $criteria === 'NULL') {
-      return ['IS NULL' => ''];
-    }
-    elseif ($criteria === 'not null' || $criteria === 'NOT NULL') {
-      return ['IS NOT NULL' => ''];
+      return $affirm ? ['IS NULL' => ''] : ['IS NOT NULL' => ''];
     }
 
     $relDateFilters = \CRM_Core_OptionGroup::values('relative_date_filters');
     if (isset($relDateFilters[$criteria])) {
       list ($dateFrom, $dateTo) = \CRM_Utils_Date::getFromTo($criteria, NULL, NULL);
-      return ['BETWEEN' => [\CRM_Utils_Date::mysqlToIso($dateFrom), \CRM_Utils_Date::mysqlToIso($dateTo)]];
+      $newOp = $affirm ? 'BETWEEN' : 'NOT BETWEEN';
+      return [$newOp => [\CRM_Utils_Date::mysqlToIso($dateFrom), \CRM_Utils_Date::mysqlToIso($dateTo)]];
     }
 
     return NULL;

--- a/Civi/Api4/Utils/CoreUtil.php
+++ b/Civi/Api4/Utils/CoreUtil.php
@@ -73,4 +73,33 @@ class CoreUtil {
     return $entityName;
   }
 
+  /**
+   * Given an expression like "activity_date_time IS previous.month", rewrite to
+   * an equivalent expression "activity_date_time BETWEEN {start-of-previous-month} AND {end-of-previous-month}.
+   *
+   * @param string $fieldName
+   *   Ex: 'activity_date_time'
+   * @param string $criteria
+   *   Ex: ['IS' => 'previous.month']
+   * @return array|NULL
+   *   Array(string $newOperator, mixed $newCriteria).
+   *   Ex: ['BETWEEN' => ['2020-05-01', '2020-06-01']]
+   */
+  public static function rewriteIsCriteria($fieldName, $criteria) {
+    if ($criteria === 'null' || $criteria === 'NULL') {
+      return ['IS NULL' => ''];
+    }
+    elseif ($criteria === 'not null' || $criteria === 'NOT NULL') {
+      return ['IS NOT NULL' => ''];
+    }
+
+    $relDateFilters = \CRM_Core_OptionGroup::values('relative_date_filters');
+    if (isset($relDateFilters[$criteria])) {
+      list ($dateFrom, $dateTo) = \CRM_Utils_Date::getFromTo($criteria, NULL, NULL);
+      return ['BETWEEN' => [\CRM_Utils_Date::mysqlToIso($dateFrom), \CRM_Utils_Date::mysqlToIso($dateTo)]];
+    }
+
+    return NULL;
+  }
+
 }

--- a/Civi/Api4/Utils/FormattingUtil.php
+++ b/Civi/Api4/Utils/FormattingUtil.php
@@ -119,11 +119,11 @@ class FormattingUtil {
 
     switch ($fieldSpec['data_type'] ?? NULL) {
       case 'Timestamp':
-        $value = ($operator === 'IS') ? (string) $value : date('Y-m-d H:i:s', strtotime($value));
+        $value = in_array($operator, ['IS', 'IS NOT']) ? (string) $value : date('Y-m-d H:i:s', strtotime($value));
         break;
 
       case 'Date':
-        $value = ($operator === 'IS') ? (string) $value : date('Ymd', strtotime($value));
+        $value = in_array($operator, ['IS', 'IS NOT']) ? (string) $value : date('Ymd', strtotime($value));
         break;
     }
 

--- a/Civi/Api4/Utils/FormattingUtil.php
+++ b/Civi/Api4/Utils/FormattingUtil.php
@@ -83,10 +83,14 @@ class FormattingUtil {
    * @param string $fieldName
    * @param array $fieldSpec
    * @param string $action
+   * @param string|NULL $operator
+   *   For WHERE clauses, the formatting of an input value depends on the operator.
+   *   For other kinds of clauses, it does not.
+   *   Ex: '=', 'BETWEEN', 'IS'
    * @throws \API_Exception
    * @throws \CRM_Core_Exception
    */
-  public static function formatInputValue(&$value, $fieldName, $fieldSpec, $action = 'get') {
+  public static function formatInputValue(&$value, $fieldName, $fieldSpec, $action = 'get', $operator = NULL) {
     // Evaluate pseudoconstant suffix
     $suffix = strpos($fieldName, ':');
     if ($suffix) {
@@ -96,7 +100,7 @@ class FormattingUtil {
     }
     elseif (is_array($value)) {
       foreach ($value as &$val) {
-        self::formatInputValue($val, $fieldName, $fieldSpec, $action);
+        self::formatInputValue($val, $fieldName, $fieldSpec, $action, $operator);
       }
       return;
     }
@@ -115,11 +119,11 @@ class FormattingUtil {
 
     switch ($fieldSpec['data_type'] ?? NULL) {
       case 'Timestamp':
-        $value = date('Y-m-d H:i:s', strtotime($value));
+        $value = ($operator === 'IS') ? (string) $value : date('Y-m-d H:i:s', strtotime($value));
         break;
 
       case 'Date':
-        $value = date('Ymd', strtotime($value));
+        $value = ($operator === 'IS') ? (string) $value : date('Ymd', strtotime($value));
         break;
     }
 

--- a/tests/phpunit/api/v4/Action/GetFromArrayTest.php
+++ b/tests/phpunit/api/v4/Action/GetFromArrayTest.php
@@ -116,6 +116,11 @@ class GetFromArrayTest extends UnitTestCase {
     $this->assertEquals([1, 3], array_column((array) $result, 'field1'));
 
     $result = MockArrayEntity::get()
+      ->addWhere('field3', 'IS', 'null')
+      ->execute();
+    $this->assertEquals([1, 3], array_column((array) $result, 'field1'));
+
+    $result = MockArrayEntity::get()
       ->addWhere('field3', '=', '0')
       ->execute();
     $this->assertEquals([2], array_column((array) $result, 'field1'));
@@ -154,6 +159,15 @@ class GetFromArrayTest extends UnitTestCase {
       ->addWhere('field1', 'NOT BETWEEN', [3, 4])
       ->execute();
     $this->assertEquals([1, 2, 5], array_column((array) $result, 'field1'));
+  }
+
+  public function testArrayGetWithIsDateRange() {
+    $result = MockArrayEntity::get()
+      ->addWhere('field7', 'IS', 'previous.week')
+      ->execute();
+    $resultIds = array_column((array) $result, 'field1');
+    $this->assertTrue(in_array(3, $resultIds));
+    $this->assertFalse(in_array(1, $resultIds));
   }
 
   public function testArrayGetWithNestedWhereClauses() {

--- a/tests/phpunit/api/v4/Action/GetFromArrayTest.php
+++ b/tests/phpunit/api/v4/Action/GetFromArrayTest.php
@@ -168,6 +168,13 @@ class GetFromArrayTest extends UnitTestCase {
     $resultIds = array_column((array) $result, 'field1');
     $this->assertTrue(in_array(3, $resultIds));
     $this->assertFalse(in_array(1, $resultIds));
+
+    $result = MockArrayEntity::get()
+      ->addWhere('field7', 'IS NOT', 'previous.week')
+      ->execute();
+    $resultIds = array_column((array) $result, 'field1');
+    $this->assertTrue(in_array(1, $resultIds));
+    $this->assertFalse(in_array(3, $resultIds));
   }
 
   public function testArrayGetWithNestedWhereClauses() {

--- a/tests/phpunit/api/v4/Entity/ParticipantTest.php
+++ b/tests/phpunit/api/v4/Entity/ParticipantTest.php
@@ -188,6 +188,30 @@ class ParticipantTest extends UnitTestCase {
       $otherParticipantResult->offsetExists($firstParticipantId),
       'excluded wrong record');
 
+    // check syntax for IS date-range
+
+    $getParticipantsById = function ($wheres = []) {
+      return Participant::get()
+        ->setCheckPermissions(FALSE)
+        ->setWhere($wheres)
+        ->execute()
+        ->indexBy('id');
+    };
+
+    $thisYearParticipants = $getParticipantsById([['register_date', 'IS', 'this.year']]);
+    $this->assertFalse(isset($thisYearParticipants[$firstParticipantId]));
+
+    $otherYearParticipants = $getParticipantsById([['register_date', 'IS NOT', 'this.year']]);
+    $this->assertTrue(isset($otherYearParticipants[$firstParticipantId]));
+
+    Participant::update()->setCheckPermissions(FALSE)
+      ->addWhere('id', '=', $firstParticipantId)
+      ->addValue('register_date', \CRM_Utils_Time::getTime('Y-m-d H:i:s'))
+      ->execute();
+
+    $thisYearParticipants = $getParticipantsById([['register_date', 'IS', 'this.year']]);
+    $this->assertTrue(isset($thisYearParticipants[$firstParticipantId]));
+
     // retrieve a participant record and update some records
     $patchRecord = [
       'source' => "not " . $firstResult['source'],

--- a/tests/phpunit/api/v4/Mock/Api4/Action/MockArrayEntity/Get.php
+++ b/tests/phpunit/api/v4/Mock/Api4/Action/MockArrayEntity/Get.php
@@ -34,6 +34,7 @@ class Get extends \Civi\Api4\Generic\BasicGetAction {
         'field3' => NULL,
         'field4' => [1, 2, 3],
         'field5' => 'apple',
+        'field7' => date('Y-m-d H:i:s', strtotime('now')),
       ],
       [
         'field1' => 2,
@@ -42,6 +43,7 @@ class Get extends \Civi\Api4\Generic\BasicGetAction {
         'field4' => [2, 3, 4],
         'field5' => 'banana',
         'field6' => '',
+        'field7' => date('Y-m-d H:i:s', strtotime('now')),
       ],
       [
         'field1' => 3,
@@ -49,6 +51,7 @@ class Get extends \Civi\Api4\Generic\BasicGetAction {
         'field4' => [3, 4, 5],
         'field5' => 'banana',
         'field6' => 0,
+        'field7' => date('Y-m-d H:i:s', strtotime('-1 week')),
       ],
       [
         'field1' => 4,
@@ -57,6 +60,7 @@ class Get extends \Civi\Api4\Generic\BasicGetAction {
         'field4' => [4, 5, 6],
         'field5' => 'apple',
         'field6' => '0',
+        'field7' => date('Y-m-d H:i:s', strtotime('-2 week')),
       ],
       [
         'field1' => 5,
@@ -65,6 +69,7 @@ class Get extends \Civi\Api4\Generic\BasicGetAction {
         'field4' => [4, 5, 6],
         'field5' => 'apple',
         'field6' => 0,
+        'field7' => date('Y-m-d H:i:s', strtotime('+1 week')),
       ],
     ];
   }


### PR DESCRIPTION
Before
------

In APIv4, there's no good way to use the "relative date ranges" (e.g. `previous.month`, `previous.year`, `this.fiscal_year`, `next.week`).

After
-----

APIv4 supports two new query operators, `IS` and `IS NOT`. The `IS` operator is loosely similar to the SQL `IS` operator in that it accepts symbolic quasi-values (eg `myfield IS null`). This flavor of `IS` accepts `null` as well as the relative date ranges, e.g.

```php
civicrm_api4("Activity", "get", [
  "where" => [["activity_date_time", "IS", "previous.year"]],
  "select" => ["id","activity_date_time"],
  "limit" => 10,
]);
```
