### PR TITLE
[Ref] Remove old pattern from payment classes

### DIFF
--- a/CRM/Core/Payment/AuthorizeNet.php
+++ b/CRM/Core/Payment/AuthorizeNet.php
@@ -52,14 +52,6 @@ class CRM_Core_Payment_AuthorizeNet extends CRM_Core_Payment {
   }
 
   /**
-   * We only need one instance of this object. So we use the singleton
-   * pattern and cache the instance in this variable
-   *
-   * @var object
-   */
-  static private $_singleton = NULL;
-
-  /**
    * Constructor.
    *
    * @param string $mode

--- a/CRM/Core/Payment/Dummy.php
+++ b/CRM/Core/Payment/Dummy.php
@@ -44,14 +44,6 @@ class CRM_Core_Payment_Dummy extends CRM_Core_Payment {
   }
 
   /**
-   * We only need one instance of this object. So we use the singleton
-   * pattern and cache the instance in this variable
-   *
-   * @var object
-   */
-  static private $_singleton = NULL;
-
-  /**
    * Constructor.
    *
    * @param string $mode

--- a/CRM/Core/Payment/Elavon.php
+++ b/CRM/Core/Payment/Elavon.php
@@ -29,14 +29,6 @@ class CRM_Core_Payment_Elavon extends CRM_Core_Payment {
     CHARSET = 'UFT-8';
 
   /**
-   * We only need one instance of this object. So we use the singleton
-   * pattern and cache the instance in this variable
-   *
-   * @var CRM_Core_Payment_Elavon
-   */
-  static private $_singleton = NULL;
-
-  /**
    * Constructor.
    *
    * @param string $mode

--- a/CRM/Core/Payment/FirstData.php
+++ b/CRM/Core/Payment/FirstData.php
@@ -56,14 +56,6 @@ class CRM_Core_Payment_FirstData extends CRM_Core_Payment {
   const CHARSET = 'UFT-8';
 
   /**
-   * We only need one instance of this object. So we use the singleton
-   * pattern and cache the instance in this variable
-   *
-   * @var object
-   */
-  static private $_singleton = NULL;
-
-  /**
    * Constructor.
    *
    * @param string $mode

--- a/CRM/Core/Payment/PayJunction.php
+++ b/CRM/Core/Payment/PayJunction.php
@@ -23,14 +23,6 @@ class CRM_Core_Payment_PayJunction extends CRM_Core_Payment {
   const CHARSET = 'UFT-8';
 
   /**
-   * We only need one instance of this object. So we use the singleton
-   * pattern and cache the instance in this variable
-   *
-   * @var object
-   */
-  static private $_singleton = NULL;
-
-  /**
    * Constructor.
    *
    * @param string $mode

--- a/CRM/Core/Payment/PayflowPro.php
+++ b/CRM/Core/Payment/PayflowPro.php
@@ -18,14 +18,6 @@ class CRM_Core_Payment_PayflowPro extends CRM_Core_Payment {
     CHARSET = 'UFT-8';
 
   /**
-   * We only need one instance of this object. So we use the singleton
-   * pattern and cache the instance in this variable
-   *
-   * @var object
-   */
-  static private $_singleton = NULL;
-
-  /**
    * Constructor
    *
    * @param string $mode

--- a/CRM/Core/Payment/PaymentExpress.php
+++ b/CRM/Core/Payment/PaymentExpress.php
@@ -42,14 +42,6 @@ class CRM_Core_Payment_PaymentExpress extends CRM_Core_Payment {
   protected $_mode = NULL;
 
   /**
-   * We only need one instance of this object. So we use the singleton
-   * pattern and cache the instance in this variable
-   *
-   * @var object
-   */
-  static private $_singleton = NULL;
-
-  /**
    * Constructor.
    *
    * @param string $mode

--- a/CRM/Core/Payment/PaymentExpressIPN.php
+++ b/CRM/Core/Payment/PaymentExpressIPN.php
@@ -39,14 +39,6 @@
 class CRM_Core_Payment_PaymentExpressIPN extends CRM_Core_Payment_BaseIPN {
 
   /**
-   * We only need one instance of this object. So we use the singleton
-   * pattern and cache the instance in this variable
-   *
-   * @var object
-   */
-  static private $_singleton = NULL;
-
-  /**
    * Mode of operation: live or test
    *
    * @var object

--- a/CRM/Core/Payment/Realex.php
+++ b/CRM/Core/Payment/Realex.php
@@ -45,14 +45,6 @@ class CRM_Core_Payment_Realex extends CRM_Core_Payment {
   protected $_params = [];
 
   /**
-   * We only need one instance of this object. So we use the singleton
-   * pattern and cache the instance in this variable
-   *
-   * @var object
-   */
-  static private $_singleton = NULL;
-
-  /**
    * Constructor.
    *
    * @param string $mode

--- a/CRM/Core/Payment/eWAY.php
+++ b/CRM/Core/Payment/eWAY.php
@@ -103,14 +103,6 @@ class CRM_Core_Payment_eWAY extends CRM_Core_Payment {
   const CHARSET = 'UTF-8';
 
   /**
-   * We only need one instance of this object. So we use the singleton
-   * pattern and cache the instance in this variable
-   *
-   * @var object
-   */
-  static private $_singleton = NULL;
-
-  /**
    * *******************************************************
    * Constructor
    *


### PR DESCRIPTION


Overview
----------------------------------------
This is cleanup, since people copy these classes we should remove old cruft.

Note moving these to extensions that ship with core (& some that
eventually don't) is a goal here

Before
----------------------------------------
unsused ```static private $_singleton = NULL;```

After
----------------------------------------
Poof

Technical Details
----------------------------------------


Comments
----------------------------------------

