### PR TITLE
dev/core#1751: [Create Email] Only Show Update/Save Template when User has Permission to Edit Templates

### DIFF
--- a/templates/CRM/Contact/Form/Task/EmailCommon.tpl
+++ b/templates/CRM/Contact/Form/Task/EmailCommon.tpl
@@ -44,12 +44,14 @@
   </div><!-- /.crm-accordion-body -->
 </div><!-- /.crm-accordion-wrapper -->
 <div id="editMessageDetails" class="section">
-    <div id="updateDetails" class="section" >
-  {$form.updateTemplate.html}&nbsp;{$form.updateTemplate.label}
-    </div>
-    <div class="section">
-  {$form.saveTemplate.html}&nbsp;{$form.saveTemplate.label}
-    </div>
+  {if call_user_func(array('CRM_Core_Permission','check'), 'edit message templates') }
+      <div id="updateDetails" class="section" >
+    {$form.updateTemplate.html}&nbsp;{$form.updateTemplate.label}
+      </div>
+      <div class="section">
+    {$form.saveTemplate.html}&nbsp;{$form.saveTemplate.label}
+      </div>
+  {/if}
 </div>
 
 <div id="saveDetails" class="section">

--- a/templates/CRM/Mailing/Form/InsertTokens.tpl
+++ b/templates/CRM/Mailing/Form/InsertTokens.tpl
@@ -54,8 +54,26 @@ var isMailing    = false;
 {/if}
 {literal}
 
+/**
+ * Checks if both the Save Template and Update Template fields exist.
+ * These fields will not exist if user does not have the edit message
+ * templates permission.
+ *
+ * @param {String} prefix
+ */
+function manageTemplateFieldsExists(prefix) {
+  var saveTemplate = document.getElementsByName(prefix + "saveTemplate");
+  var updateTemplate = document.getElementsByName(prefix + "updateTemplate");
+
+  return saveTemplate.length > 0 && updateTemplate.length > 0;
+}
+
 function showSaveUpdateChkBox(prefix) {
   prefix = prefix || '';
+  if (!manageTemplateFieldsExists(prefix)) {
+    document.getElementById(prefix + "saveDetails").style.display = "none";
+    return;
+  }
   if (document.getElementById(prefix + "template") == null) {
     if (document.getElementsByName(prefix + "saveTemplate")[0].checked){
       document.getElementById(prefix + "saveDetails").style.display = "block";
@@ -89,9 +107,11 @@ function showSaveUpdateChkBox(prefix) {
 }
 
 function selectValue( val, prefix) {
-  document.getElementsByName(prefix + "saveTemplate")[0].checked = false;
-  document.getElementsByName(prefix + "updateTemplate")[0].checked = false;
-  showSaveUpdateChkBox(prefix);
+  if (manageTemplateFieldsExists(prefix)) {
+    document.getElementsByName(prefix + "saveTemplate")[0].checked = false;
+    document.getElementsByName(prefix + "updateTemplate")[0].checked = false;
+    showSaveUpdateChkBox(prefix);
+  }
   if ( !val ) {
     if (document.getElementById("subject").length) {
       document.getElementById("subject").value ="";
@@ -180,6 +200,9 @@ if ( isMailing ) {
 
   function verify(select, prefix) {
     prefix = prefix || '';
+    if (!manageTemplateFieldsExists(prefix)) {
+      return;
+    }
     if (document.getElementsByName(prefix + "saveTemplate")[0].checked  == false) {
       document.getElementById(prefix + "saveDetails").style.display = "none";
     }


### PR DESCRIPTION
Overview
----------------------------------------
In the email modal, CiviCRM users can write an email from scratch or use an existing message template. They are given the options to update existing templates or save a new template.

These options are currently available and can be completed by users with basic access to CiviCRM, even when they do not have the permission CiviCRM: edit message templates.

Organisations want to create standard message templates that cannot be altered by the hundreds of staff using the templates. They need to be able to set this up as a user permission.

Before
----------------------------------------
A Civicrm user without access to the CiviCRM: edit message templates permission can update existing templates or save a new template when sending an email via the email activity form.

After
----------------------------------------
The CiviCRM: edit message templates permission is needed to update existing templates or save a new template when sending an email via the email activity form.

User without edit message templates permission:
<img width="1280" alt="Casee User  CaseLatest 2020-06-03 18-33-32" src="https://user-images.githubusercontent.com/6951813/83669139-f8892080-a5c8-11ea-90e4-37920c394e47.png">

User with edit message templates permission:
<img width="1280" alt="Manage Cases  CaseLatest 2020-06-03 18-34-26" src="https://user-images.githubusercontent.com/6951813/83669195-13f42b80-a5c9-11ea-97e9-6428253aca39.png">



Technical Details
----------------------------------------
The permission check for `edit message templates` was added in the EmailCommon Template before displaying the `Update Template` and `Save as New Template` checkboxes. 
After making this change, there were some errors in the console regarding these two fields for the case where the user does not have the `edit message templates` permission, some checks were added in these functions for the existent of these fields before the logic were executed.