### PR TITLE
APIv4 - Support pseudoconstant suffixes in orderBy clause

### DIFF
--- a/ang/api4Explorer/Explorer.html
+++ b/ang/api4Explorer/Explorer.html
@@ -138,7 +138,7 @@
               </div>
             </div>
             <div class="api4-input form-inline">
-              <input class="collapsible-optgroups form-control huge" ng-model="controls.orderBy" crm-ui-select="{data: fieldsAndJoinsAndFunctions}" placeholder="Add orderBy" />
+              <input class="collapsible-optgroups form-control huge" ng-model="controls.orderBy" crm-ui-select="{data: fieldsAndJoinsAndFunctionsWithSuffixes}" placeholder="Add orderBy" />
             </div>
           </fieldset>
           <fieldset ng-if="::availableParams.limit && availableParams.offset">

--- a/ang/api4Explorer/Explorer.js
+++ b/ang/api4Explorer/Explorer.js
@@ -28,6 +28,7 @@
     $scope.havingOptions = [];
     $scope.fieldsAndJoins = [];
     $scope.fieldsAndJoinsAndFunctions = [];
+    $scope.fieldsAndJoinsAndFunctionsWithSuffixes = [];
     $scope.fieldsAndJoinsAndFunctionsAndWildcards = [];
     $scope.availableParams = {};
     $scope.params = {};
@@ -357,6 +358,7 @@
       $scope.action = $routeParams.api4action;
       $scope.fieldsAndJoins.length = 0;
       $scope.fieldsAndJoinsAndFunctions.length = 0;
+      $scope.fieldsAndJoinsAndFunctionsWithSuffixes.length = 0;
       $scope.fieldsAndJoinsAndFunctionsAndWildcards.length = 0;
       if (!actions.length) {
         formatForSelect2(getEntity().actions, actions, 'name', ['description', 'params']);
@@ -382,10 +384,12 @@
             });
           }
           $scope.fieldsAndJoinsAndFunctions = addJoins($scope.fields.concat(functions), true);
+          $scope.fieldsAndJoinsAndFunctionsWithSuffixes = addJoins(getFieldList($scope.action, ['name', 'label']).concat(functions), false, ['name', 'label']);
           $scope.fieldsAndJoinsAndFunctionsAndWildcards = addJoins(getFieldList($scope.action, ['name', 'label']).concat(functions), true, ['name', 'label']);
         } else {
           $scope.fieldsAndJoins = getFieldList($scope.action, ['name']);
           $scope.fieldsAndJoinsAndFunctions = $scope.fields;
+          $scope.fieldsAndJoinsAndFunctionsWithSuffixes = getFieldList($scope.action, ['name', 'label']);
           $scope.fieldsAndJoinsAndFunctionsAndWildcards = getFieldList($scope.action, ['name', 'label']);
         }
         $scope.fieldsAndJoinsAndFunctionsAndWildcards.unshift({id: '*', text: '*', 'description': 'All core ' + $scope.entity + ' fields'});

--- a/tests/phpunit/api/v4/Action/BasicActionsTest.php
+++ b/tests/phpunit/api/v4/Action/BasicActionsTest.php
@@ -266,6 +266,7 @@ class BasicActionsTest extends UnitTestCase {
 
     $results = MockBasicEntity::get()
       ->addSelect('*', 'group:label', 'group:name', 'fruit:name', 'fruit:color', 'fruit:label')
+      ->addOrderBy('fruit:color', "DESC")
       ->execute();
 
     $this->assertEquals('round', $results[0]['shape']);
@@ -276,6 +277,12 @@ class BasicActionsTest extends UnitTestCase {
     $this->assertEquals('Banana', $results[0]['fruit:label']);
     $this->assertEquals('banana', $results[0]['fruit:name']);
     $this->assertEquals('yellow', $results[0]['fruit:color']);
+
+    // Reverse order
+    $results = MockBasicEntity::get()
+      ->addOrderBy('fruit:color')
+      ->execute();
+    $this->assertEquals('two', $results[0]['group']);
 
     // Cannot match to a non-unique option property like :color on create
     try {

--- a/tests/phpunit/api/v4/Action/PseudoconstantTest.php
+++ b/tests/phpunit/api/v4/Action/PseudoconstantTest.php
@@ -196,6 +196,33 @@ class PseudoconstantTest extends BaseCustomValueTest {
     $this->assertEquals('blü', $result['myPseudoconstantTest.Color:label']);
     $this->assertEquals('bl_', $result['myPseudoconstantTest.Color:name']);
     $this->assertEquals('b', $result['myPseudoconstantTest.Color']);
+
+    $cid1 = Contact::create()
+      ->setCheckPermissions(FALSE)
+      ->addValue('first_name', 'two')
+      ->addValue('myPseudoconstantTest.Technicolor:label', 'RED')
+      ->execute()->first()['id'];
+    $cid2 = Contact::create()
+      ->setCheckPermissions(FALSE)
+      ->addValue('first_name', 'two')
+      ->addValue('myPseudoconstantTest.Technicolor:label', 'GREEN')
+      ->execute()->first()['id'];
+
+    // Test ordering by label
+    $result = Contact::get()
+      ->setCheckPermissions(FALSE)
+      ->addWhere('id', 'IN', [$cid1, $cid2])
+      ->addSelect('id')
+      ->addOrderBy('myPseudoconstantTest.Technicolor:label')
+      ->execute()->first()['id'];
+    $this->assertEquals($cid2, $result);
+    $result = Contact::get()
+      ->setCheckPermissions(FALSE)
+      ->addWhere('id', 'IN', [$cid1, $cid2])
+      ->addSelect('id')
+      ->addOrderBy('myPseudoconstantTest.Technicolor:label', 'DESC')
+      ->execute()->first()['id'];
+    $this->assertEquals($cid1, $result);
   }
 
   public function testJoinOptions() {


### PR DESCRIPTION
Overview
----------------------------------------
Allows results from API get to be ordered by a suffix e.g. `activity_type_id:label`. Works for DAO entities as well as basic entities. Exposed to the API explorer.

Before
----------------------------------------
Could only order by field value, which would appear out of order when viewing the label.

After
----------------------------------------
Can order by label, name, color, etc.

Technical Details
----------------------------------------
Pseudoconstant substitution happens through the magic of MySql `FIELD()` function.
