### PR TITLE
Test fixes to support apiv4 add of MembershipType

### DIFF
--- a/tests/phpunit/api/v3/RelationshipTest.php
+++ b/tests/phpunit/api/v3/RelationshipTest.php
@@ -128,7 +128,7 @@ class api_v3_RelationshipTest extends CiviUnitTestCase {
     $this->assertEquals($employer, $organisation);
 
     //Update relationship type
-    $update = $this->callAPISuccess('Relationship', 'create', [
+    $this->callAPISuccess('Relationship', 'create', [
       'id' => $employerRelationship['id'],
       'relationship_type_id' => $this->_relTypeID,
     ]);
@@ -929,9 +929,9 @@ class api_v3_RelationshipTest extends CiviUnitTestCase {
     ];
     $result = $this->callAPIAndDocument('relationship', 'get', $getParams, __FUNCTION__, __FILE__, $description, $subfile);
     $this->assertEquals($result['count'], 2);
-    $this->AssertEquals([$rel1['id'], $rel4['id']], array_keys($result['values']));
+    $this->assertEquals([$rel1['id'], $rel4['id']], array_keys($result['values']));
 
-    $description = "Demonstrates use of BETWEEN filter.";
+    $description = 'Demonstrates use of BETWEEN filter.';
     $subfile = 'BetweenRelationshipType';
     $getParams = [
       'relationship_type_id' => ['BETWEEN' => [$relationType2, $relationType4]],
@@ -940,14 +940,14 @@ class api_v3_RelationshipTest extends CiviUnitTestCase {
     $this->assertEquals($result['count'], 3);
     $this->AssertEquals([$rel2['id'], $rel3['id'], $rel4['id']], array_keys($result['values']));
 
-    $description = "Demonstrates use of Not BETWEEN filter.";
+    $description = 'Demonstrates use of Not BETWEEN filter.';
     $subfile = 'NotBetweenRelationshipType';
     $getParams = [
       'relationship_type_id' => ['NOT BETWEEN' => [$relationType2, $relationType4]],
     ];
     $result = $this->callAPIAndDocument('relationship', 'get', $getParams, __FUNCTION__, __FILE__, $description, $subfile);
     $this->assertEquals($result['count'], 1);
-    $this->AssertEquals([$rel1['id']], array_keys($result['values']));
+    $this->assertEquals([$rel1['id']], array_keys($result['values']));
 
     foreach ([$relationType2, $relationType3, $relationType4] as $id) {
       $this->callAPISuccess('RelationshipType', 'delete', ['id' => $id]);
@@ -1169,8 +1169,11 @@ class api_v3_RelationshipTest extends CiviUnitTestCase {
    *
    * We should get 1 result without or with correct relationship type id & 0 with
    * an incorrect one
+   *
    * @param int $version
+   *
    * @dataProvider versionThreeAndFour
+   * @throws \CRM_Core_Exception
    */
   public function testGetRelationshipByMembershipTypeDAO($version) {
     $this->_apiversion = $version;
@@ -1215,6 +1218,8 @@ class api_v3_RelationshipTest extends CiviUnitTestCase {
     $result = $this->callAPISuccess($this->entity, 'get', [
       'contact_id_a' => $this->_cId_a,
       'membership_type_id' => $memberType,
+      // Pass version here as there is no intention to replicate support for passing in membership_type_id
+      'version' => 3,
     ]);
     // although our contact has more than one relationship we have passed them in as contact_id_a & can't get reciprocal
     $this->assertEquals(1, $result['count']);
@@ -1229,8 +1234,11 @@ class api_v3_RelationshipTest extends CiviUnitTestCase {
    *
    * We should get 1 result without or with correct relationship type id & 0 with
    * an incorrect one
+   *
    * @param int $version
+   *
    * @dataProvider versionThreeAndFour
+   * @throws \CRM_Core_Exception
    */
   public function testGetRelationshipByMembershipTypeReciprocal($version) {
     $this->_apiversion = $version;
@@ -1274,6 +1282,9 @@ class api_v3_RelationshipTest extends CiviUnitTestCase {
     $result = $this->callAPISuccess($this->entity, 'get', [
       'contact_id' => $this->_cId_a,
       'membership_type_id' => $memberType,
+      // There is no intention to replicate support for passing in membership_type_id
+      // in apiv4 so pass version as 3
+      'version' => 3,
     ]);
     // Although our contact has more than one relationship we have passed them in as contact_id_a & can't get reciprocal
     $this->assertEquals(2, $result['count']);


### PR DESCRIPTION
Overview
----------------------------------------
Update test so that https://github.com/civicrm/civicrm-core/pull/17448 does not fail on something we don't plan to support in apiv4

Before
----------------------------------------
```
    $result = $this->callAPISuccess('Relationship', 'get', [
      'contact_id_a' => $this->_cId_a,
      'membership_type_id' => $memberType,
    ]);
```

After
----------------------------------------
```
    $result = $this->callAPISuccess('Relationship', 'get', [
      'contact_id_a' => $this->_cId_a,
      'membership_type_id' => $memberType,
      // Pass version here as there is no intention to replicate support for passing in membership_type_id
      'version' => 3,
    ]);
```

Technical Details
----------------------------------------
membership_type_id in Relationship.get is the sort of 'this & that' we are avoiding supporting in apiv4

Comments
----------------------------------------
@mattwire 
