### PR TITLE
dev/core#1681 Add in notice about 5.28 Dropping MySQL 5.5 Support

### DIFF
--- a/CRM/Upgrade/Incremental/General.php
+++ b/CRM/Upgrade/Incremental/General.php
@@ -59,6 +59,13 @@ class CRM_Upgrade_Incremental_General {
   const MIN_INSTALL_MYSQL_VER = '5.5';
 
   /**
+   * The minimum MySQL/MariaDB version required to install Civi.
+   *
+   * @see install/index.php
+   */
+  const NEW_MIN_INSTALL_MYSQL_VER = '5.6.5';
+
+  /**
    * Compute any messages which should be displayed before upgrade.
    *
    * @param string $preUpgradeMessage
@@ -74,6 +81,25 @@ class CRM_Upgrade_Incremental_General {
         1 => $latestVer,
         2 => self::MIN_RECOMMENDED_PHP_VER,
         3 => preg_replace(';^(\d+\.\d+(?:\.[1-9]\d*)?).*$;', '\1', self::RECOMMENDED_PHP_VER),
+      ]);
+      $preUpgradeMessage .= '</p>';
+    }
+    if (version_compare(CRM_Utils_SQL::getDatabaseVersion(), self::MIN_RECOMMENDED_MYSQL_VER) < 0 && version_compare(CRM_Utils_SQL::getDatabaseVersion(), self::NEW_MIN_INSTALL_MYSQL_VER) >= 0) {
+      $preUpgradeMessage .= '<p>';
+      $preUpgradeMessage .= ts('You may proceed with the upgrade and CiviCRM %1 will continue working normally, but future releases will require MySQL version %2 or above or MariaDB version %3 or above.', [
+        1 => $latestVer,
+        2 => self::MIN_RECOMMENDED_MYSQL_VER,
+        3 => '10.1',
+      ]);
+      $preUpgradeMessage .= '</p>';
+    }
+    if (version_compare(CRM_Utils_SQL::getDatabaseVersion(), self::NEW_MIN_INSTALL_MYSQL_VER) < 0) {
+      $preUpgradeMessage .= '<p>';
+      $preUpgradeMessage .= ts('You may proceed with the upgrade and CiviCRM %1 will continue working normally, but CiviCRM versions from 5.28 onwards will require at least MySQL version %1. It is recommended to use MySQL version %3 or above or MariaDB version %4 or above.', [
+        1 => $latestVer,
+        2 => self::NEW_MIN_INSTALL_MYSQL_VER,
+        3 => self::MIN_RECOMMENDED_MYSQL_VER,
+        4 => '10.1',
       ]);
       $preUpgradeMessage .= '</p>';
     }

--- a/CRM/Utils/Check/Component/Env.php
+++ b/CRM/Utils/Check/Component/Env.php
@@ -949,7 +949,34 @@ class CRM_Utils_Check_Component_Env extends CRM_Utils_Check_Component {
           3 => '10.1',
         ]),
         ts('MySQL Out of date'),
+        \Psr\Log\LogLevel::ERROR,
+        'fa-server'
+      );
+    }
+    elseif (version_compare(CRM_Utils_SQL::getDatabaseVersion(), CRM_Upgrade_Incremental_General::NEW_MIN_INSTALL_MYSQL_VER, '<')) {
+      $messages[] = new CRM_Utils_Check_Message(
+        __FUNCTION__,
+        ts('This system uses MySQL/MariaDB version %1. CiviCRM versions 5.28 and onwards will require MySQL version at least %2, however MySQL version %3 or MariaDB version %4 is recommended', [
+          1 => $version,
+          2 => CRM_Upgrade_Incremental_General::NEW_MIN_INSTALL_MYSQL_VER,
+          3 => $minRecommendedVersion,
+          4 => '10.1',
+        ]),
+        ts('MySQL Out of date'),
         \Psr\Log\LogLevel::WARNING,
+        'fa-server'
+      );
+    }
+    elseif (version_compare(CRM_Utils_SQL::getDatabaseVersion(), $minRecommendedVersion, '<')) {
+      $messages[] = new CRM_Utils_Check_Message(
+        __FUNCTION__,
+        ts('This system uses MySQL/MariaDB version %1. You can continue to use that version of MySQL however support for it is likely to be removed shortly, MySQL version %2 or MariaDB version %3 is recommended', [
+          1 => $version,
+          2 => $minRecommendedVersion,
+          3 => '10.1',
+        ]),
+        ts('MySQL Out of date'),
+        \Psr\Log\LogLevel::NOTICE,
         'fa-server'
       );
     }


### PR DESCRIPTION
Overview
----------------------------------------
This adds notices to sites advising of the fact that from CiviCRM 5.28 we will be dropping support for MySQL 5.5

Before
----------------------------------------
No notice on dropping Support for MySQL 5.5

After
----------------------------------------
Notice before upgrade and on the system check about the drop in support

ping @eileenmcnaughton @totten @colemanw 