### PR TITLE
Fix probably-unused core payment processors to throw extensions

### DIFF
--- a/CRM/Core/Payment/FirstData.php
+++ b/CRM/Core/Payment/FirstData.php
@@ -14,6 +14,8 @@
  +--------------------------------------------------------------------+
  */
 
+use Civi\Payment\Exception\PaymentProcessorException;
+
 /**
  * Note that in order to use FirstData / LinkPoint you need a certificate (.pem) file issued by them
  * and a store number. You can configure the path to the certificate and the store number
@@ -52,8 +54,6 @@
  * **************************
  */
 class CRM_Core_Payment_FirstData extends CRM_Core_Payment {
-  // (not used, implicit in the API, might need to convert?)
-  const CHARSET = 'UFT-8';
 
   /**
    * Constructor.
@@ -61,12 +61,9 @@ class CRM_Core_Payment_FirstData extends CRM_Core_Payment {
    * @param string $mode
    *   The mode of operation: live or test.
    *
-   * @param $paymentProcessor
-   *
-   * @return \CRM_Core_Payment_FirstData *******************************************************
+   * @param array $paymentProcessor
    */
   public function __construct($mode, &$paymentProcessor) {
-    // live or test
     $this->_mode = $mode;
     $this->_paymentProcessor = $paymentProcessor;
   }
@@ -87,9 +84,9 @@ class CRM_Core_Payment_FirstData extends CRM_Core_Payment {
     /*concatenate full customer name first  - code from EWAY gateway
      */
 
-    $credit_card_name = $params['first_name'] . " ";
+    $credit_card_name = $params['first_name'] . ' ';
     if (strlen($params['middle_name']) > 0) {
-      $credit_card_name .= $params['middle_name'] . " ";
+      $credit_card_name .= $params['middle_name'] . ' ';
     }
     $credit_card_name .= $params['last_name'];
 
@@ -182,7 +179,7 @@ class CRM_Core_Payment_FirstData extends CRM_Core_Payment {
     // Check to see if we have a duplicate before we send
     //----------------------------------------------------------------------------------------------------
     if ($this->checkDupe($params['invoiceID'], CRM_Utils_Array::value('contributionID', $params))) {
-      return self::errorExit(9003, 'It appears that this transaction is a duplicate.  Have you already submitted the form once?  If so there may have been a connection problem.  Check your email for a receipt from eWAY.  If you do not receive a receipt within 2 hours you can try your transaction again.  If you continue to have problems please contact the site administrator.');
+      throw new PaymentProcessorException('It appears that this transaction is a duplicate.  Have you already submitted the form once?  If so there may have been a connection problem.  Check your email for a receipt from eWAY.  If you do not receive a receipt within 2 hours you can try your transaction again.  If you continue to have problems please contact the site administrator.', 9003);
     }
     //----------------------------------------------------------------------------------------------------
     // Convert to XML using function provided by payment processor
@@ -196,7 +193,7 @@ class CRM_Core_Payment_FirstData extends CRM_Core_Payment {
 
     $ch = curl_init($host);
     if (!$ch) {
-      return self::errorExit(9004, 'Could not initiate connection to payment gateway');
+      throw new PaymentProcessorException('Could not initiate connection to payment gateway', 9004);
     }
 
     curl_setopt($ch, CURLOPT_POST, 1);
@@ -236,10 +233,10 @@ class CRM_Core_Payment_FirstData extends CRM_Core_Payment {
         $errorDesc = "Connection to payment gateway failed";
       }
       if ($errorNum == 60) {
-        return self::errorExit($errorNum, "Curl error - " . $errorDesc . " Try this link for more information http://curl.haxx.se/docs/sslcerts.html");
+        throw new PaymentProcessorException("Curl error - " . $errorDesc . ' Try this link for more information http://curl.haxx.se/docs/sslcerts.html', $errorNum);
       }
 
-      return self::errorExit($errorNum, "Curl error - " . $errorDesc . " your key is located at " . $key . " the url is " . $host . " xml is " . $requestxml . " processor response = " . $processorResponse);
+      throw new PaymentProcessorException('Curl error - ' . $errorDesc . ' your key is located at ' . $key . ' the url is ' . $host . ' xml is ' . $requestxml . ' processor response = ' . $processorResponse, $errorNum);
     }
 
     //----------------------------------------------------------------------------------------------------
@@ -249,14 +246,14 @@ class CRM_Core_Payment_FirstData extends CRM_Core_Payment {
     //       any reason, the return value will be the boolean false.
     //----------------------------------------------------------------------------------------------------
     if (($responseData === FALSE) || (strlen($responseData) == 0)) {
-      return self::errorExit(9006, "Error: Connection to payment gateway failed - no data returned.");
+      throw new PaymentProcessorException('Error: Connection to payment gateway failed - no data returned.', 9006);
     }
 
     //----------------------------------------------------------------------------------------------------
     // If gateway returned no data - tell 'em and bail out
     //----------------------------------------------------------------------------------------------------
     if (empty($responseData)) {
-      return self::errorExit(9007, "Error: No data returned from payment gateway.");
+      throw new PaymentProcessorException('Error: No data returned from payment gateway.', 9007);
     }
 
     //----------------------------------------------------------------------------------------------------
@@ -271,8 +268,8 @@ class CRM_Core_Payment_FirstData extends CRM_Core_Payment {
     $processorResponse = lphp::decodeXML($responseData);
 
     // transaction failed, print the reason
-    if ($processorResponse["r_approved"] != "APPROVED") {
-      return self::errorExit(9009, "Error: [" . $processorResponse['r_error'] . "] - from payment processor");
+    if ($processorResponse['r_approved'] !== "APPROVED") {
+      throw new PaymentProcessorException('Error: [' . $processorResponse['r_error'] . '] - from payment processor', 9009);
     }
     else {
 
@@ -300,28 +297,6 @@ class CRM_Core_Payment_FirstData extends CRM_Core_Payment {
       CRM_Core_Error::debug_log_message("r_time " . $processorResponse['r_time']);
       return $params;
     }
-  }
-
-  // end function doDirectPayment
-
-  /**
-   * Produces error message and returns from class.
-   *
-   * @param int $errorCode
-   * @param string $errorMessage
-   *
-   * @return object
-   */
-  public function &errorExit($errorCode = NULL, $errorMessage = NULL) {
-    $e = CRM_Core_Error::singleton();
-
-    if ($errorCode) {
-      $e->push($errorCode, 0, NULL, $errorMessage);
-    }
-    else {
-      $e->push(9000, 0, NULL, 'Unknown System Error.');
-    }
-    return $e;
   }
 
   /**
@@ -352,9 +327,7 @@ class CRM_Core_Payment_FirstData extends CRM_Core_Payment {
     if (!empty($errorMsg)) {
       return implode('<p>', $errorMsg);
     }
-    else {
-      return NULL;
-    }
+    return NULL;
   }
 
 }


### PR DESCRIPTION


Overview
----------------------------------------
Make FirstData and Payjunction comply with our error handling expectations

Before
----------------------------------------
```
return self::errorExit(9003, $message);
```

After
----------------------------------------
throw new PaymentProcessorException($message, 9003);

Technical Details
----------------------------------------
These 2 processors are probably entirely unused and are not enabled on new installs. However, as they are still in core,
and removing them will take a plan + time, we should have them model 'good behaviour' - ie throwing exceptions
rather than returning errors

Comments
----------------------------------------

