### PR TITLE
Payment PropertyBag - Fix setAmount

### DIFF
--- a/Civi/Payment/PropertyBag.php
+++ b/Civi/Payment/PropertyBag.php
@@ -388,7 +388,7 @@ class PropertyBag implements \ArrayAccess {
       throw new \InvalidArgumentException("setAmount requires a numeric amount value");
     }
 
-    return $this->set('amount', CRM_Utils_Money::format($value, NULL, NULL, TRUE), $label);
+    return $this->set('amount', $label, \CRM_Utils_Money::format($value, NULL, NULL, TRUE));
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
This is quite a serious issue as it causes the amount to be set incorrectly on propertybag because the params are the wrong way around.

Before
----------------------------------------
Params switched so setAmount doesn't set amount correctly.

After
----------------------------------------
Amount set correctly on propertybag.

Technical Details
----------------------------------------


Comments
----------------------------------------
@eileenmcnaughton @artfulrobot Can you check please - we really need to get this in asap (before the 5.27 RC is cut as it causes the amount to be set incorrectly on propertybag.