### PR TITLE
Payment Propertybag remove warning

### DIFF
--- a/Civi/Payment/PropertyBag.php
+++ b/Civi/Payment/PropertyBag.php
@@ -296,7 +296,6 @@ class PropertyBag implements \ArrayAccess {
    * @param array $data
    */
   public function mergeLegacyInputParams($data) {
-    $this->legacyWarning('We have merged input params into the property bag for now but please rewrite code to not use this.');
     foreach ($data as $key => $value) {
       if ($value !== NULL && $value !== '') {
         $this->offsetSet($key, $value);

--- a/tests/phpunit/Civi/Payment/PropertyBagTest.php
+++ b/tests/phpunit/Civi/Payment/PropertyBagTest.php
@@ -103,7 +103,6 @@ class PropertyBagTest extends \PHPUnit\Framework\TestCase implements HeadlessInt
       'contactID' => 123,
       'contributionRecurID' => 456,
     ]);
-    $this->assertEquals('We have merged input params into the property bag for now but please rewrite code to not use this.', $propertyBag->lastWarning);
     $this->assertEquals(123, $propertyBag->getContactID());
     $this->assertEquals(456, $propertyBag->getContributionRecurID());
   }


### PR DESCRIPTION
Overview
----------------------------------------
Remove the "We have merged input params..." warning from `mergeLegacyInputParams` because:
1) We get a separate message logged for every property that was merged.
2) We're going to be using this function for a long time and the message doesn't really give us anything useful - if the function is called and nothing is merged then we don't have any code that needs fixing.
3) The developer that sees this error probably can't do anything to resolve the issue.

Before
----------------------------------------
Warning triggered everytime function is called + Warning for each property that was actually merged.

After
----------------------------------------
Warning for each property that was actually merged.

Technical Details
----------------------------------------


Comments
----------------------------------------
@eileenmcnaughton @artfulrobot
