### PR TITLE
Payment Propertybag as array

### DIFF
--- a/Civi/Payment/PropertyBag.php
+++ b/Civi/Payment/PropertyBag.php
@@ -99,6 +99,22 @@ class PropertyBag implements \ArrayAccess {
   }
 
   /**
+   * Get the property bag as an array
+   *
+   * Transition function.
+   * This allows you to convert a processor to use property bag but handle existing code that doesn't (yet)
+   * support propertybag. This is particularly important because many widely used functions stop working
+   * with propertybag such as empty(), array_*.
+   *
+   * @param string $label
+   *
+   * @return array
+   */
+  public function getPropsAsArray($label = 'default') {
+    return $this->props[$label];
+  }
+
+  /**
    * Just for unit testing.
    *
    * @var string


### PR DESCRIPTION
Overview
----------------------------------------
With more complex payment processors converting to use propertybag is a big project that cannot reasonably be completed in one development cycle. There may also be dependencies on other code (core or extensions) that do not accept a payment propertybag and use `array_` functions or `empty()`. Passing a propertybag *will* cause this code to break.

Eventually we hope to be in a position where the payment propertybag can be passed and understood everywhere. But not yet.

Before
----------------------------------------
Cannot get payment propertybag as an array.

After
----------------------------------------
Can get payment propertybag as an array.

Technical Details
----------------------------------------


Comments
----------------------------------------
@eileenmcnaughton @artfulrobot Per discussions on mattermost, this allows for a smoother transition to propertybag.
