### PR TITLE
Set default payment processor at paymentform level

### DIFF
--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -79,7 +79,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
    * @var array
    *   An array of payment processor details with objects loaded in the 'object' field.
    */
-  protected $_paymentProcessors;
+  public $_paymentProcessors;
 
   /**
    * Available payment processors (IDS).
@@ -791,6 +791,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
         if (empty($this->_paymentProcessor) && $paymentProcessorDetail['is_default'] == 1 || (count($this->_paymentProcessors) == 1)
         ) {
           $this->_paymentProcessor = $paymentProcessorDetail;
+          $this->_paymentProcessorID = $paymentProcessorID;
           $this->assign('paymentProcessor', $this->_paymentProcessor);
           // Setting this is a bit of a legacy overhang.
           $this->_paymentObject = $paymentProcessorDetail['object'];

--- a/CRM/Core/Payment/Form.php
+++ b/CRM/Core/Payment/Form.php
@@ -290,6 +290,15 @@ class CRM_Core_Payment_Form {
       $form->_defaults["billing_state_province_id-{$form->_bltID}"] = CRM_Core_Config::singleton()
         ->defaultContactStateProvince;
     }
+
+    // Set default payment processor
+    if (!empty($form->_paymentProcessors)) {
+      foreach ($form->_paymentProcessors as $pid => $value) {
+        if (!empty($value['is_default'])) {
+          $form->_defaults['payment_processor_id'] = $pid;
+        }
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
This is currently set at a lower level on the registration/contribution forms. But it makes more sense to do it here and will mean that code can be removed at a lower level. This is required for #17508 and means we don't need to implement default handling there.

Before
----------------------------------------
Payment processor default defined at lower form level.

After
----------------------------------------
Payment processor default defined at core_form level so all forms implementing payment processor selectors benefit.


Technical Details
----------------------------------------


Comments
----------------------------------------
