### PR TITLE
Add isBackOffice, isPayLater, getPaymentMode helpers to frontendpaymentformtrait

### DIFF
--- a/CRM/Event/Form/Registration.php
+++ b/CRM/Event/Form/Registration.php
@@ -79,14 +79,6 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
   public $_additionalParticipantIds;
 
   /**
-   * The mode that we are in.
-   *
-   * @var string
-   * @protect
-   */
-  public $_mode;
-
-  /**
    * The values for the contribution db object.
    *
    * @var array
@@ -182,12 +174,9 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
   public function preProcess() {
     $this->_eventId = CRM_Utils_Request::retrieve('id', 'Positive', $this, TRUE);
     $this->_action = CRM_Utils_Request::retrieve('action', 'Alphanumeric', $this, FALSE, CRM_Core_Action::ADD);
-
     //CRM-4320
     $this->_participantId = CRM_Utils_Request::retrieve('participantId', 'Positive', $this);
-
-    // current mode
-    $this->_mode = ($this->_action == 1024) ? 'test' : 'live';
+    $this->setPaymentMode();
 
     $this->_values = $this->get('values');
     $this->_fields = $this->get('fields');

--- a/CRM/Event/Form/Registration/Register.php
+++ b/CRM/Event/Form/Registration/Register.php
@@ -1157,7 +1157,7 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
     // CRM-3907, skip check for preview registrations
     // CRM-4320 participant need to walk wizard
     if (
-      ($form->_mode == 'test' || $form->_allowConfirmation)
+      ($form->getPaymentMode() === 'test' || $form->_allowConfirmation)
     ) {
       return FALSE;
     }

--- a/CRM/Financial/Form/FrontEndPaymentFormTrait.php
+++ b/CRM/Financial/Form/FrontEndPaymentFormTrait.php
@@ -21,11 +21,70 @@
 trait CRM_Financial_Form_FrontEndPaymentFormTrait {
 
   /**
+   * Is pay later enabled on this form?
+   *
+   * @var bool
+   */
+  protected $isPayLater = FALSE;
+
+  /**
    * The label for the pay later pseudoprocessor option.
    *
    * @var string
    */
   protected $payLaterLabel;
+
+  /**
+   * Is this a back office form
+   *
+   * @var bool
+   */
+  public $isBackOffice = FALSE;
+
+  /**
+   * The payment mode that we are in ("live" or "test")
+   * This should be protected and retrieved via getPaymentMode() but it's accessed all over the place so we have to leave it public for now.
+   *
+   * @var string
+   */
+  public $_mode;
+
+  /**
+   * @return bool
+   */
+  public function isPayLater() {
+    return $this->isPayLater;
+  }
+
+  /**
+   * @param bool $isPayLater
+   */
+  public function setIsPayLater($isPayLater) {
+    $this->isPayLater = $isPayLater;
+  }
+
+  /**
+   * @return bool
+   */
+  public function getIsBackOffice() {
+    return $this->isBackOffice;
+  }
+
+  /**
+   * Get the payment mode ('live' or 'test')
+   *
+   * @return string
+   */
+  public function getPaymentMode() {
+    return $this->_mode;
+  }
+
+  /**
+   * Set the payment mode ('live' or 'test')
+   */
+  public function setPaymentMode() {
+    $this->_mode = ($this->_action === CRM_Core_Action::PREVIEW) ? 'test' : 'live';
+  }
 
   /**
    * @return string


### PR DESCRIPTION
Overview
----------------------------------------
This adds helper functions and properties to `frontendpaymentformtrait` for `isBackOffice()`, `isPayLater()` and `get/SetPaymentMode()` so we don't have to interact directly with the properties and do not have to specify them on each form.

Developed for #17508

Before
----------------------------------------
Direct access to properties, they must be specified on each form.

After
----------------------------------------
Just use `frontendpaymentformtrait` and the new methods.

Technical Details
----------------------------------------


Comments
----------------------------------------
