### PR TITLE
core#1795: Searchable Parent tags

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -3268,7 +3268,6 @@ WHERE  $smartGroupClause
   public function tag(&$values) {
     list($name, $op, $value, $grouping, $wildcard) = $values;
 
-    list($qillop, $qillVal) = self::buildQillForFieldValue('CRM_Core_DAO_EntityTag', "tag_id", $value, $op, ['onlyActive' => FALSE]);
     // API/Search Builder format array(operator => array(values))
     if (is_array($value)) {
       if (in_array(key($value), CRM_Core_DAO::acceptedSQLOperators(), TRUE)) {
@@ -3279,6 +3278,19 @@ WHERE  $smartGroupClause
         $this->_useDistinct = TRUE;
       }
     }
+
+    if (strpos($op, 'NULL') || strpos($op, 'EMPTY')) {
+      $value = NULL;
+    }
+
+    $tagTree = CRM_Core_BAO_Tag::getChildTags();
+    foreach ((array) $value as $tagID) {
+      if (!empty($tagTree[$tagID])) {
+        $value = array_unique(array_merge($value, $tagTree[$tagID]));
+      }
+    }
+
+    list($qillop, $qillVal) = self::buildQillForFieldValue('CRM_Core_DAO_EntityTag', "tag_id", $value, $op, ['onlyActive' => FALSE]);
 
     // implode array, then remove all spaces
     $value = str_replace(' ', '', implode(',', (array) $value));

--- a/tests/phpunit/CRM/Contact/BAO/QueryTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/QueryTest.php
@@ -58,7 +58,9 @@ class CRM_Contact_BAO_QueryTest extends CiviUnitTestCase {
 
     $tag7 = $this->ids['Tag'][7] = $this->tagCreate(['name' => 'Test Tag 7', 'description' => 'Test Tag 7'])['id'];
     $tag9 = $this->ids['Tag'][9] = $this->tagCreate(['name' => 'Test Tag 9', 'description' => 'Test Tag 9'])['id'];
-    $this->tagCreate(['name' => 'Test Tag 10']);
+    $tag10 = $this->ids['Tag'][10] = $this->tagCreate(['name' => 'Test Tag 10', 'description' => 'Test Tag 10', 'parent_id' => $tag9])['id'];
+    $tag11 = $this->ids['Tag'][11] = $this->tagCreate(['name' => 'Test Tag 11', 'description' => 'Test Tag 11', 'parent_id' => $tag10])['id'];
+
     $groups = [
       3 => ['name' => 'Test Group 3'],
       4 => ['name' => 'Test Smart Group 4', 'saved_search_id' => 1],
@@ -118,6 +120,8 @@ class CRM_Contact_BAO_QueryTest extends CiviUnitTestCase {
         'api.entity_tag.create' => ['tag_id' => $tag9],
         'api.entity_tag.create.2' => ['tag_id' => $tag7],
       ],
+      ['first_name' => 'Test', 'last_name' => 'Test Contact 25', 'api.entity_tag.create' => ['tag_id' => $tag10]],
+      ['first_name' => 'Test', 'last_name' => 'Test Contact 26', 'api.entity_tag.create' => ['tag_id' => $tag11]],
     ];
     foreach ($individuals as $individual) {
       $this->ids['Contact'][$individual['last_name']] = $this->individualCreate($individual);
@@ -189,6 +193,7 @@ class CRM_Contact_BAO_QueryTest extends CiviUnitTestCase {
     foreach ($ids as $id) {
       $expectedIDs[] = $this->ids['Contact']['Test Contact ' . $id];
     }
+
     $this->assertEquals($expectedIDs, $contacts);
   }
 

--- a/tests/phpunit/CRM/Contact/BAO/QueryTestDataProvider.php
+++ b/tests/phpunit/CRM/Contact/BAO/QueryTestDataProvider.php
@@ -141,6 +141,8 @@ class CRM_Contact_BAO_QueryTestDataProvider implements Iterator {
         '20',
         '22',
         '24',
+        '25',
+        '26',
       ],
     ],
     //  Include tags 7 and 9
@@ -159,6 +161,32 @@ class CRM_Contact_BAO_QueryTestDataProvider implements Iterator {
         '22',
         '23',
         '24',
+        '25',
+        '26',
+      ],
+    ],
+    //  Include tags 7 and 10
+    [
+      'fv' => ['tag' => ['7', '10']],
+      'id' => [
+        '11',
+        '12',
+        '15',
+        '16',
+        '19',
+        '20',
+        '23',
+        '24',
+        '25',
+        '26',
+      ],
+    ],
+    //  Include tags 10 and 11
+    [
+      'fv' => ['tag' => ['10', '11']],
+      'id' => [
+        '25',
+        '26',
       ],
     ],
     // gender_id 1 = 'Female'


### PR DESCRIPTION
Overview
----------------------------------------
Steps to replicate the issue:
1. Create a parent tag A and child tag A1
2. Create/update contact and tag with A1
3. Go to 'Find Contacts' or 'Find Contributions' and search by Tag - A

Before
----------------------------------------
1. In 'Find Contact' result, it doesn't show contact which is tagged with child tag A1
2. In 'Find Contributions' result, it doesn't pull contribution(s) of contact tagged with child tag A1 

After
----------------------------------------
Searching using a parent tag should automatically include the contacts which are in parent tag A and in its n child tag(s) - A(n). In this use-case, it should show contact tagged with child A1 tag

Technical Details
----------------------------------------
This improvement, in other words, the code fix, affects search forms only where Tag filter is used (doesn't affect API). This idea about making parent tag searchable is about making the tag hierarchy feature useful for searching purposes like we are already supporting searchable parent regular/smart group [here](https://github.com/civicrm/civicrm-core/blob/master/CRM/Contact/BAO/Query.php#L3008) 

Comments
----------------------------------------
ping @JoeMurray @eileenmcnaughton @lcdservices @seamuslee001 
