### PR TITLE
Price Field Form: save the fid for the postProcess hook

### DIFF
--- a/CRM/Price/Form/Field.php
+++ b/CRM/Price/Form/Field.php
@@ -667,7 +667,13 @@ class CRM_Price_Form_Field extends CRM_Core_Form {
 
     if (!is_a($priceField, 'CRM_Core_Error')) {
       CRM_Core_Session::setStatus(ts('Price Field \'%1\' has been saved.', [1 => $priceField->label]), ts('Saved'), 'success');
+
+      // Useful for postProcess hooks
+      if (!$this->_fid) {
+        $this->_fid = $priceField->id;
+      }
     }
+
     $buttonName = $this->controller->getButtonName();
     $session = CRM_Core_Session::singleton();
     if ($buttonName == $this->getButtonName('next', 'new')) {


### PR DESCRIPTION
Overview
----------------------------------------

When customizing the Price Field form (i.e. new Price set -> new price field), extensions implementing the postProcess hook cannot handle new fields, since the fid is not set in the form.

I wasn't sure how common this is, but some forms seem to do it, including the Register Participant form:  
https://github.com/civicrm/civicrm-core/blame/master/CRM/Event/Form/Participant.php#L1624

