### PR TITLE
[REF] Replace the deprecated system_rebuild_module_data function with…

### DIFF
--- a/CRM/Utils/System/Drupal8.php
+++ b/CRM/Utils/System/Drupal8.php
@@ -537,7 +537,7 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
   public function getModules() {
     $modules = [];
 
-    $module_data = system_rebuild_module_data();
+    $module_data = \Drupal::service('extension.list.module')->reset()->getList();
     foreach ($module_data as $module_name => $extension) {
       if (!isset($extension->info['hidden']) && $extension->origin != 'core') {
         $extension->schema_version = drupal_get_installed_schema_version($module_name);

--- a/setup/plugins/installDatabase/FlushDrupal8.civi-setup.php
+++ b/setup/plugins/installDatabase/FlushDrupal8.civi-setup.php
@@ -16,7 +16,7 @@ if (!defined('CIVI_SETUP')) {
     }
     \Civi\Setup::log()->info(sprintf('[%s] Flush CMS metadata', basename(__FILE__)));
 
-    system_rebuild_module_data();
+    \Drupal::service('extension.list.module')->reset();
     \Drupal::service('module_installer')->install(['civicrm', 'civicrmtheme']);
     drupal_flush_all_caches();
     civicrm_install_set_drupal8_perms();


### PR DESCRIPTION
… equivilant extension.list.module service function calls to be Drupal 9 compatiable

Overview
----------------------------------------
This function is deprecated in D8 and removed in D9 lets replace with more current methods of doing the same thing

Before
----------------------------------------
Deprecated function used

After
----------------------------------------
Non Deprecated function used

ping @MikeyMJCO @KarinG @totten @dsnopek 