### PR TITLE
dev/core#1790 - Contact Card - Email Links

### DIFF
--- a/CRM/Contact/Form/Task/Email.php
+++ b/CRM/Contact/Form/Task/Email.php
@@ -37,10 +37,14 @@ class CRM_Contact_Form_Task_Email extends CRM_Contact_Form_Task {
 
     $cid = CRM_Utils_Request::retrieve('cid', 'String', $this, FALSE);
 
-    // Allow request to specify email id rather than contact id
+    // Allow request to specify email id or address rather than contact id
     $toEmailId = CRM_Utils_Request::retrieve('email_id', 'String', $this);
-    if ($toEmailId) {
-      $toEmail = civicrm_api('email', 'getsingle', ['version' => 3, 'id' => $toEmailId]);
+    $toEmailAddress = CRM_Utils_Request::retrieve('email', 'String', $this);
+    if ($toEmailId || $toEmailAddress) {
+      $filter = $toEmailId
+        ? ['id' => $toEmailId]
+        : ['email' => $toEmailAddress];
+      $toEmail = civicrm_api('email', 'getsingle', array_merge(['version' => 3], $filter));
       if (!empty($toEmail['email']) && !empty($toEmail['contact_id'])) {
         $this->_toEmail = $toEmail;
       }

--- a/CRM/Profile/Page/Dynamic.php
+++ b/CRM/Profile/Page/Dynamic.php
@@ -316,9 +316,12 @@ class CRM_Profile_Page_Dynamic extends CRM_Core_Page {
       }
 
       foreach ($values as $title => $value) {
-        $profileFields[$labels[$title]] = [
+        $fieldName = $labels[$title];
+        $fieldValue = $this->getProfileFieldValue($fieldName, $value);
+
+        $profileFields[$fieldName] = [
           'label' => $title,
-          'value' => $value,
+          'value' => $fieldValue,
         ];
       }
 
@@ -414,6 +417,36 @@ class CRM_Profile_Page_Dynamic extends CRM_Core_Page {
   public function overrideExtraTemplateFileName() {
     $fileName = $this->checkTemplateFileExists('extra.');
     return $fileName ? $fileName : parent::overrideExtraTemplateFileName();
+  }
+
+  /**
+   * Returns the profile expected value according to their type:
+   *
+   * - For emails we return a link to the email composer form.
+   *
+   * For all other types we return the same same value passed to this function.
+   *
+   * @param string $fieldName
+   *   the name of the profile field.
+   * @param string $rawValue
+   *   the value for the profile field.
+   * @return string
+   */
+  private function getProfileFieldValue($fieldName, $rawValue) {
+    $fieldType = [];
+    preg_match('/email|address|phone/', $fieldName, $fieldType);
+
+    if ($fieldType[0] === 'email') {
+      $emailPopupUrl = CRM_Utils_System::url('civicrm/activity/email/add', [
+        'action' => 'add',
+        'reset' => '1',
+        'email' => $rawValue,
+      ], TRUE);
+
+      return '<a class="crm-popup" href="' . $emailPopupUrl . '">' . $rawValue . '</a>';
+    }
+
+    return $rawValue;
   }
 
 }

--- a/js/Common.js
+++ b/js/Common.js
@@ -1058,6 +1058,8 @@ if (!CRM.vars) CRM.vars = {};
   };
 
   $.fn.crmtooltip = function () {
+    var TOOLTIP_HIDE_DELAY = 300;
+
     $(document)
       .on('mouseover', 'a.crm-summary-link:not(.crm-processed)', function (e) {
         $(this).addClass('crm-processed crm-tooltip-active');
@@ -1072,8 +1074,13 @@ if (!CRM.vars) CRM.vars = {};
             .load(this.href);
         }
       })
-      .on('mouseout', 'a.crm-summary-link', function () {
-        $(this).removeClass('crm-processed crm-tooltip-active crm-tooltip-down');
+      .on('mouseleave', 'a.crm-summary-link', function () {
+        var tooltipLink = $(this);
+        setTimeout(function () {
+          if (tooltipLink.filter(':hover').length === 0) {
+            tooltipLink.removeClass('crm-processed crm-tooltip-active crm-tooltip-down');
+          }
+        }, TOOLTIP_HIDE_DELAY);
       })
       .on('click', 'a.crm-summary-link', false);
   };

--- a/templates/CRM/Contact/Form/Selector.tpl
+++ b/templates/CRM/Contact/Form/Selector.tpl
@@ -98,7 +98,9 @@
               <td>
                 {if $row.email}
                     <span title="{$row.email|escape}">
-                        {$row.email|mb_truncate:17:"...":true}
+                        <a class="crm-popup" href="{crmURL p='civicrm/activity/email/add' q="reset=1&action=add&email=`$row.email`"}">
+                          {$row.email|mb_truncate:17:"...":true}
+                        </a>
                         {privacyFlag field=do_not_email condition=$row.do_not_email}
                         {privacyFlag field=on_hold condition=$row.on_hold}
                     </span>
@@ -113,8 +115,14 @@
               </td>
            {else}
               {foreach from=$row item=value key=key}
-                {if ($key neq "checkbox") and ($key neq "action") and ($key neq "contact_type") and ($key neq "status") and ($key neq "sort_name") and ($key neq "contact_id") and ($key neq "contact_type_orig")}
+                {if !in_array($key, ['checkbox', 'action', 'contact_type', 'status', 'sort_name', 'contact_id', 'contact_type_orig', 'email'])}
                  <td>{$value}&nbsp;</td>
+                {elseif $key eq 'email'}
+                  <td>
+                    <a class="crm-popup" href="{crmURL p='civicrm/activity/email/add' q="reset=1&action=add&email=`$value`"}">
+                      {$value}
+                    </a>
+                  </td>
                 {/if}
               {/foreach}
             {/if}


### PR DESCRIPTION
Overview
----------------------------------------
This PR adds a feature where emails on the contact's card and contact's search results can be clicked. When clicked the email form popup is displayed.

Before
----------------------------------------
### Contact's Card
![gif](https://user-images.githubusercontent.com/1642119/83933526-5491a780-a777-11ea-919d-624ad33e6a23.gif)

* Emails are not links
* Can't place the mouse inside the tooltip panel before it closes.

### Contact's Search Results

![Screen Shot 2020-07-04 at 2 32 50 PM](https://user-images.githubusercontent.com/1642119/86518923-62345e80-be03-11ea-9af7-2864e0d03025.png)


After
----------------------------------------
### Contact's Card

![gif](https://user-images.githubusercontent.com/1642119/83933479-dfbe6d80-a776-11ea-8465-36f039606d0c.gif)

### Contact's Search Results

![gif](https://user-images.githubusercontent.com/1642119/86518977-061e0a00-be04-11ea-82c7-50c725aefbe5.gif)


Technical Details
----------------------------------------

We updated `CRM/Contact/Form/Task/Email.php` so we can pass an `email` parameter instead of the `email_id` parameter to prepopulate the email form. This is important since in some scenarios we do know the email address, but not the email id.

We also updated `CRM/Profile/Page/Dynamic.php` so we can display the email link on the contact's card. We added a `getProfileFieldValue` private method that checks the name of the profile field, if it contains the `email` keyword it will replace the raw email address value for a link to the email. In the future, this function can serve as a strategy handler to display different type of values depending on the field type.

We had to update the tooltip function in `js/Common.js` to add a small delay of 300ms when moving the mouse away from the triggering element. This allows the mouse to move to the contact's card in a reasonable time before it closes. As a note, we changed `mouseout` for `mouseleave` because the former is triggered multiple times while the mouse moves, and the later is only triggered once, which is enough to determine if the mouse is completely outside of the tooltip and its link.

Finally, we updated the `templates/CRM/Contact/Form/Selector.tpl` template so we include a link to the email form for both: normal contact search results, and advanced search results.

