### PR TITLE
dev/core#1681 - Copy-edits on MySQL version notices

### DIFF
--- a/CRM/Upgrade/Incremental/General.php
+++ b/CRM/Upgrade/Incremental/General.php
@@ -75,31 +75,36 @@ class CRM_Upgrade_Incremental_General {
    */
   public static function setPreUpgradeMessage(&$preUpgradeMessage, $currentVer, $latestVer) {
     $dateFormat = Civi::Settings()->get('dateformatshortdate');
-    if (version_compare(phpversion(), self::MIN_RECOMMENDED_PHP_VER) < 0) {
+    $phpversion = phpversion();
+    if (version_compare($phpversion, self::MIN_RECOMMENDED_PHP_VER) < 0) {
       $preUpgradeMessage .= '<p>';
-      $preUpgradeMessage .= ts('You may proceed with the upgrade and CiviCRM %1 will continue working normally, but future releases will require PHP %2 or above. We recommend PHP version %3.', [
+      $preUpgradeMessage .= ts('This system uses PHP v%4. You may proceed with the upgrade, and CiviCRM v%1 will continue working normally. However, future releases will require PHP v%2. We recommend PHP v%3.', [
         1 => $latestVer,
-        2 => self::MIN_RECOMMENDED_PHP_VER,
-        3 => preg_replace(';^(\d+\.\d+(?:\.[1-9]\d*)?).*$;', '\1', self::RECOMMENDED_PHP_VER),
+        2 => self::MIN_RECOMMENDED_PHP_VER . '+',
+        3 => preg_replace(';^(\d+\.\d+(?:\.[1-9]\d*)?).*$;', '\1', self::RECOMMENDED_PHP_VER) . '+',
+        4 => $phpversion,
       ]);
       $preUpgradeMessage .= '</p>';
     }
     if (version_compare(CRM_Utils_SQL::getDatabaseVersion(), self::MIN_RECOMMENDED_MYSQL_VER) < 0 && version_compare(CRM_Utils_SQL::getDatabaseVersion(), self::NEW_MIN_INSTALL_MYSQL_VER) >= 0) {
       $preUpgradeMessage .= '<p>';
-      $preUpgradeMessage .= ts('You may proceed with the upgrade and CiviCRM %1 will continue working normally, but future releases will require MySQL version %2 or above or MariaDB version %3 or above.', [
+      $preUpgradeMessage .= ts('This system uses MySQL/MariaDB v%4. You may proceed with the upgrade, and CiviCRM v%1 will continue working normally. However, future releases will require MySQL v%2 or MariaDB v%3.', [
         1 => $latestVer,
-        2 => self::MIN_RECOMMENDED_MYSQL_VER,
-        3 => '10.1',
+        2 => self::MIN_RECOMMENDED_MYSQL_VER . '+',
+        3 => '10.1' . '+',
+        4 => CRM_Utils_SQL::getDatabaseVersion(),
       ]);
       $preUpgradeMessage .= '</p>';
     }
     if (version_compare(CRM_Utils_SQL::getDatabaseVersion(), self::NEW_MIN_INSTALL_MYSQL_VER) < 0) {
       $preUpgradeMessage .= '<p>';
-      $preUpgradeMessage .= ts('You may proceed with the upgrade and CiviCRM %1 will continue working normally, but CiviCRM versions from 5.28 onwards will require at least MySQL version %1. It is recommended to use MySQL version %3 or above or MariaDB version %4 or above.', [
+      $preUpgradeMessage .= ts('This system uses MySQL/MariaDB v%6. You may proceed with the upgrade, and CiviCRM v%1 will continue working normally. However, CiviCRM v%5 will require MySQL v%2. We recommend MySQL v%3 or MariaDB v%4.', [
         1 => $latestVer,
-        2 => self::NEW_MIN_INSTALL_MYSQL_VER,
-        3 => self::MIN_RECOMMENDED_MYSQL_VER,
-        4 => '10.1',
+        2 => self::NEW_MIN_INSTALL_MYSQL_VER . '+',
+        3 => self::MIN_RECOMMENDED_MYSQL_VER . '+',
+        4 => '10.1' . '+',
+        5 => '5.28' . '+',
+        6 => CRM_Utils_SQL::getDatabaseVersion(),
       ]);
       $preUpgradeMessage .= '</p>';
     }

--- a/CRM/Utils/Check/Component/Env.php
+++ b/CRM/Utils/Check/Component/Env.php
@@ -940,15 +940,17 @@ class CRM_Utils_Check_Component_Env extends CRM_Utils_Check_Component {
     $version = CRM_Utils_SQL::getDatabaseVersion();
     $minInstallVersion = CRM_Upgrade_Incremental_General::MIN_INSTALL_MYSQL_VER;
     $minRecommendedVersion = CRM_Upgrade_Incremental_General::MIN_RECOMMENDED_MYSQL_VER;
+    $mariaDbRecommendedVersion = '10.1';
+    $upcomingCiviChangeVersion = '5.28';
     if (version_compare(CRM_Utils_SQL::getDatabaseVersion(), $minInstallVersion, '<')) {
       $messages[] = new CRM_Utils_Check_Message(
         __FUNCTION__,
-        ts('This system uses MySQL/MariaDB version %1. To ensure the continued operation of CiviCRM, upgrade your server now. At least MySQL version %2 or MariaDB version %3 is recommended', [
+        ts('This system uses MySQL/MariaDB v%1. To ensure the continued operation of CiviCRM, upgrade MySQL now. The recommended version is MySQL v%2 or MariaDB v%3.', [
           1 => $version,
-          2 => $minRecommendedVersion,
-          3 => '10.1',
+          2 => $minRecommendedVersion . '+',
+          3 => '10.1' . '+',
         ]),
-        ts('MySQL Out of date'),
+        ts('MySQL Out-of-Date'),
         \Psr\Log\LogLevel::ERROR,
         'fa-server'
       );
@@ -956,13 +958,14 @@ class CRM_Utils_Check_Component_Env extends CRM_Utils_Check_Component {
     elseif (version_compare(CRM_Utils_SQL::getDatabaseVersion(), CRM_Upgrade_Incremental_General::NEW_MIN_INSTALL_MYSQL_VER, '<')) {
       $messages[] = new CRM_Utils_Check_Message(
         __FUNCTION__,
-        ts('This system uses MySQL/MariaDB version %1. CiviCRM versions 5.28 and onwards will require MySQL version at least %2, however MySQL version %3 or MariaDB version %4 is recommended', [
+        ts('This system uses MySQL/MariaDB v%1. To prepare for CiviCRM v%5, please upgrade MySQL. The recommended version will be MySQL v%3 or MariaDB v%4. The minimum requirement will be MySQL v%2. ', [
           1 => $version,
-          2 => CRM_Upgrade_Incremental_General::NEW_MIN_INSTALL_MYSQL_VER,
-          3 => $minRecommendedVersion,
-          4 => '10.1',
+          2 => CRM_Upgrade_Incremental_General::NEW_MIN_INSTALL_MYSQL_VER . '+',
+          3 => $minRecommendedVersion . '+',
+          4 => $mariaDbRecommendedVersion . '+',
+          5 => $upcomingCiviChangeVersion . '+',
         ]),
-        ts('MySQL Out of date'),
+        ts('MySQL Out-of-Date'),
         \Psr\Log\LogLevel::WARNING,
         'fa-server'
       );
@@ -970,12 +973,12 @@ class CRM_Utils_Check_Component_Env extends CRM_Utils_Check_Component {
     elseif (version_compare(CRM_Utils_SQL::getDatabaseVersion(), $minRecommendedVersion, '<')) {
       $messages[] = new CRM_Utils_Check_Message(
         __FUNCTION__,
-        ts('This system uses MySQL/MariaDB version %1. You can continue to use that version of MySQL however support for it is likely to be removed shortly, MySQL version %2 or MariaDB version %3 is recommended', [
+        ts('This system uses MySQL/MariaDB v%1. You can continue to use this version of MySQL. However, support may be removed in a future release. The recommended version is MySQL v%2 or MariaDB v%3.', [
           1 => $version,
-          2 => $minRecommendedVersion,
-          3 => '10.1',
+          2 => $minRecommendedVersion . '+',
+          3 => $mariaDbRecommendedVersion . '+',
         ]),
-        ts('MySQL Out of date'),
+        ts('MySQL Out-of-Date'),
         \Psr\Log\LogLevel::NOTICE,
         'fa-server'
       );


### PR DESCRIPTION
Overview
----------------------------------------

* The titles for PHP+MySQL notices should use the same capitalization/hyphenation ("Out-of-Date" vs "Out of date").
* Extract some more "%N" variables. Fix one errant variable.
* Reference versions as "vN.N" or "vN.N+". (Given the complexity of MySQL-or-MariaDB versioning constraints, the verbose form gets a bit difficult to read.)
* Make it possible to add/remove the "+" notation without changing the ts() message.
* Fix a run-on
* Flip some word ordering ("X.Y is the recommended version" ==> "The recommended version is X.Y")

Comments
----------------------------------------

I made these edits while testing/backporting #17496.  To test, I used local overrides and coereced `CRM_Utils_SQL::getDatabaseVersion()` and `$phpversion` to present different values.