### PR TITLE
Zip code range search only supports numeric zip codes 

### DIFF
--- a/CRM/Contact/Form/Search/Custom/ZipCodeRange.php
+++ b/CRM/Contact/Form/Search/Custom/ZipCodeRange.php
@@ -146,16 +146,22 @@ LEFT JOIN civicrm_email   email   ON ( email.contact_id = contact_a.id AND
    * @return string
    */
   public function where($includeContactIDs = FALSE) {
-    $params = [];
-
     $low = CRM_Utils_Array::value('postal_code_low',
       $this->_formValues
     );
     $high = CRM_Utils_Array::value('postal_code_high',
       $this->_formValues
     );
+    $errorMessage = NULL;
     if ($low == NULL || $high == NULL) {
-      CRM_Core_Error::statusBounce(ts('Please provide start and end postal codes'),
+      $errorMessage = ts('Please provide start and end postal codes.');
+    }
+
+    if (!is_numeric($low) || !is_numeric($high)) {
+      $errorMessage = ts('This search only supports numeric postal codes.');
+    }
+    if ($errorMessage) {
+      CRM_Core_Error::statusBounce($errorMessage,
         CRM_Utils_System::url('civicrm/contact/search/custom',
           "reset=1&csid={$this->_formValues['customSearchID']}",
           FALSE, NULL, FALSE, TRUE


### PR DESCRIPTION
Overview
----------------------------------------
Zip code range search only supports numeric zip codes so don't try and search if values are not numeric.

Before
----------------------------------------
Report crashes with DB errors if you put non numeric values in the search criteria.

After
----------------------------------------
An error message pops up telling the user to use numeric values.

Technical Details
----------------------------------------

Comments
----------------------------------------
