### PR TITLE
Disable frequency/interval fields if not required. Mark required if they are so they are validated before submit

### DIFF
--- a/templates/CRM/Contribute/Form/Contribution/Main.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Main.tpl
@@ -333,15 +333,27 @@
       var isRecur = cj('input[id="is_recur"]:checked');
       var allowAutoRenew = {/literal}'{$allowAutoRenewMembership}'{literal};
       var quickConfig = {/literal}{$quickConfig}{literal};
-      if ( allowAutoRenew && cj("#auto_renew") && quickConfig) {
+      if (allowAutoRenew && cj("#auto_renew") && quickConfig) {
         showHideAutoRenew(null);
       }
+
+      var frequencyUnit = cj('#frequency_unit');
+      var frequencyInerval = cj('#frequency_interval');
+      var installments = cj('#installments');
+      isDisabled = false;
+
       if (isRecur.val() > 0) {
         cj('#recurHelp').show();
+        frequencyUnit.prop('disabled', false).addClass('required');
+        frequencyInerval.prop('disabled', false).addClass('required');
+        installments.prop('disabled', false);
         cj('#amount_sum_label').text('{/literal}{ts escape='js'}Regular amount{/ts}{literal}');
       }
       else {
         cj('#recurHelp').hide();
+        frequencyUnit.prop('disabled', true).removeClass('required');
+        frequencyInerval.prop('disabled', true).removeClass('required');
+        installments.prop('disabled', true);
         cj('#amount_sum_label').text('{/literal}{ts escape='js'}Total Amount{/ts}{literal}');
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------
Support js validation on frequency interval field on frontend contribution page

Before
----------------------------------------
No jquery validation on frequency interval on frontend contribution page.

After
----------------------------------------
jquery validation works. Fields are disabled when not required:
![ezgif com-crop](https://user-images.githubusercontent.com/2052161/83954174-c1bc4000-a83e-11ea-8db9-529157cced8c.gif)

Technical Details
----------------------------------------
If the "i want to contribute this amount every" checkbox is checked then the frequency interval is a required field. But it's not marked as required so only fails validation on the php side once the form is submitted.

Comments
----------------------------------------
Related issue https://github.com/civicrm/civicrm-core/pull/16495
