### PR TITLE
CommunityMessages - Define more consistent behavior in the face of slow execution

### DIFF
--- a/CRM/Core/CommunityMessages.php
+++ b/CRM/Core/CommunityMessages.php
@@ -95,15 +95,16 @@ class CRM_Core_CommunityMessages {
       $isChanged = TRUE;
     }
 
-    if ($document['expires'] <= CRM_Utils_Time::getTimeRaw()) {
+    $refTime = CRM_Utils_Time::getTimeRaw();
+    if ($document['expires'] <= $refTime) {
       $newDocument = $this->fetchDocument();
       if ($newDocument && $this->validateDocument($newDocument)) {
         $document = $newDocument;
-        $document['expires'] = CRM_Utils_Time::getTimeRaw() + $document['ttl'];
+        $document['expires'] = $refTime + $document['ttl'];
       }
       else {
         // keep the old messages for now, try again later
-        $document['expires'] = CRM_Utils_Time::getTimeRaw() + $document['retry'];
+        $document['expires'] = $refTime + $document['retry'];
       }
       $isChanged = TRUE;
     }

--- a/tests/phpunit/CRM/Core/CommunityMessagesTest.php
+++ b/tests/phpunit/CRM/Core/CommunityMessagesTest.php
@@ -19,7 +19,7 @@ class CRM_Core_CommunityMessagesTest extends CiviUnitTestCase {
    * The max difference between two times such that they should be
    * treated as equals (expressed in seconds).
    */
-  const APPROX_TIME_EQUALITY = 2;
+  const APPROX_TIME_EQUALITY = 4;
 
   /**
    * @var CRM_Utils_Cache_Interface
@@ -293,14 +293,14 @@ class CRM_Core_CommunityMessagesTest extends CiviUnitTestCase {
     $this->assertEquals($doc2['expires'], $doc3['expires']);
 
     // fourth try, $doc2 has expired yet; new request; replace data
-    CRM_Utils_Time::setTime('2013-03-01 12:10:02');
+    CRM_Utils_Time::setTime('2013-03-01 12:10:05');
     $communityMessages = new CRM_Core_CommunityMessages(
       $this->cache,
       $this->expectOneHttpRequest(self::$webResponses['second-valid-response'])
     );
     $doc4 = $communityMessages->getDocument();
     $this->assertEquals('<h1>Second valid response</h1>', $doc4['messages'][0]['markup']);
-    $this->assertApproxEquals(strtotime('2013-03-01 12:20:02'), $doc4['expires'], self::APPROX_TIME_EQUALITY);
+    $this->assertApproxEquals(strtotime('2013-03-01 12:20:05'), $doc4['expires'], self::APPROX_TIME_EQUALITY);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------

The `CommunityMessagesTest` is producing failures with [TIME_FUNC](https://github.com/civicrm/civicrm-core/pull/17414) option of `linear:500` (the value currently used in PR test runs) -- which is to say, it fails when the system runs very slowly (with some 500ms stalling during execution).

This gets it working under some brutally slow scenarios:

```
for TIME_FUNC in natural frozen linear:500 linear:1250 prng:500 prng:666 prng:1000 prng:1500 ; do
  export TIME_FUNC;
  echo;
  echo "TIME_FUNC=$TIME_FUNC" ;
  env CIVICRM_UF=UnitTests phpunit6 tests/phpunit/CRM/Core/CommunityMessagesTest.php ;
done
```
