### PR TITLE
QueueTest - Be more forgiving about slow execution

### DIFF
--- a/tests/phpunit/CRM/Queue/QueueTest.php
+++ b/tests/phpunit/CRM/Queue/QueueTest.php
@@ -155,7 +155,7 @@ class CRM_Queue_QueueTest extends CiviUnitTestCase {
     $this->assertEquals(FALSE, $item2);
 
     // pass expiration mark
-    CRM_Utils_Time::setTime('2012-04-01 2:00:01');
+    CRM_Utils_Time::setTime('2012-04-01 2:00:03');
     $item3 = $this->queue->claimItem();
     $this->assertEquals('a', $item3->data['test-key']);
     $this->assertEquals(1, $this->queue->numberOfItems());


### PR DESCRIPTION
The `CRM_Queue_QueueTest` is producing failures with the [TIME_FUNC](https://github.com/civicrm/civicrm-core/pull/17414) option of `linear:500` (the value currently used in PR test runs) -- which is to say, it fails when the system runs very slowly (with some 500ms stalling during execution).

This gets it working under some very slow scenarios:

```
for TIME_FUNC in natural frozen linear:500 linear:1250 prng:500 prng:666 prng:1000 prng:1500 ; do
  export TIME_FUNC;
  echo;
  echo "TIME_FUNC=$TIME_FUNC" ;
  env CIVICRM_UF=UnitTests phpunit6 tests/phpunit/CRM/Queue/QueueTest.php ;
done
```
