### PR TITLE
[REF] Replace some instances of fatal with thrown exceptions.

### DIFF
--- a/CRM/Bridge/OG/CiviCRM.php
+++ b/CRM/Bridge/OG/CiviCRM.php
@@ -35,7 +35,7 @@ class CRM_Bridge_OG_CiviCRM {
    * @param $group
    */
   public static function groupAdd($groupID, $group) {
-    $ogID = CRM_Bridge_OG_Utils::ogID($groupID, FALSE);
+    $ogID = CRM_Bridge_OG_Utils::ogID($groupID);
 
     $node = new StdClass();
     if ($ogID) {
@@ -69,7 +69,7 @@ class CRM_Bridge_OG_CiviCRM {
    * @param $group
    */
   public static function groupDelete($groupID, $group) {
-    $ogID = CRM_Bridge_OG_Utils::ogID($groupID, FALSE);
+    $ogID = CRM_Bridge_OG_Utils::ogID($groupID);
     if (!$ogID) {
       return;
     }
@@ -84,7 +84,7 @@ class CRM_Bridge_OG_CiviCRM {
    */
   public static function groupContact($groupID, $contactIDs, $op) {
     $config = CRM_Core_Config::singleton();
-    $ogID = CRM_Bridge_OG_Utils::ogID($groupID, FALSE);
+    $ogID = CRM_Bridge_OG_Utils::ogID($groupID);
 
     if (!$ogID) {
       return;

--- a/CRM/Bridge/OG/Drupal.php
+++ b/CRM/Bridge/OG/Drupal.php
@@ -204,7 +204,7 @@ SELECT v.id
 
     $contactID = CRM_Bridge_OG_Utils::contactID($params['uf_id']);
     if (!$contactID) {
-      CRM_Core_Error::fatal();
+      throw new CRM_Core_Exception(' no contact found');
     }
 
     // get the group id of this OG

--- a/CRM/Bridge/OG/Utils.php
+++ b/CRM/Bridge/OG/Utils.php
@@ -56,12 +56,11 @@ class CRM_Bridge_OG_Utils {
 
   /**
    * @param int $groupID
-   * @param bool $abort
    *
    * @return int|null|string
    * @throws Exception
    */
-  public static function ogID($groupID, $abort = TRUE) {
+  public static function ogID($groupID) {
     $source = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Group',
       $groupID,
       'source'
@@ -72,9 +71,6 @@ class CRM_Bridge_OG_Utils {
       if (is_numeric($matches[1])) {
         return $matches[1];
       }
-    }
-    if ($abort) {
-      CRM_Core_Error::fatal();
     }
     return NULL;
   }
@@ -97,7 +93,7 @@ class CRM_Bridge_OG_Utils {
     CRM_Core_BAO_UFMatch::synchronizeUFMatch($account, $ufID, $account->mail, 'Drupal');
     $contactID = CRM_Core_BAO_UFMatch::getContactId($ufID);
     if (!$contactID) {
-      CRM_Core_Error::fatal();
+      throw new CRM_Core_Exception('no contact found');
     }
     return $contactID;
   }
@@ -108,7 +104,7 @@ class CRM_Bridge_OG_Utils {
    * @param bool $abort
    *
    * @return null|string
-   * @throws Exception
+   * @throws \CRM_Core_Exception
    */
   public static function groupID($source, $title = NULL, $abort = FALSE) {
     $query = "
@@ -126,7 +122,7 @@ SELECT id
     if ($abort &&
       !$groupID
     ) {
-      CRM_Core_Error::fatal();
+      throw new CRM_Core_Exception('no group found');
     }
 
     return $groupID;

--- a/CRM/Extension/Manager/Payment.php
+++ b/CRM/Extension/Manager/Payment.php
@@ -109,7 +109,7 @@ class CRM_Extension_Manager_Payment extends CRM_Extension_Manager_Base {
   public function onPreUninstall(CRM_Extension_Info $info) {
     $paymentProcessorTypes = $this->_getAllPaymentProcessorTypes('class_name');
     if (!array_key_exists($info->key, $paymentProcessorTypes)) {
-      CRM_Core_Error::fatal(ts('This payment processor type is not registered.'));
+      throw new CRM_Core_Exception(ts('This payment processor type is not registered.'));
     }
 
     $dao = new CRM_Financial_DAO_PaymentProcessor();
@@ -229,7 +229,7 @@ class CRM_Extension_Manager_Payment extends CRM_Extension_Manager_Base {
     }
 
     if (empty($class_name)) {
-      CRM_Core_Error::fatal("Unable to find payment processor in " . __CLASS__ . '::' . __METHOD__);
+      throw new CRM_Core_Exception('Unable to find payment processor in ' . __CLASS__ . '::' . __METHOD__);
     }
 
     // In the case of uninstall, check for instances of PP first.

--- a/CRM/Extension/Manager/Search.php
+++ b/CRM/Extension/Manager/Search.php
@@ -69,12 +69,12 @@ class CRM_Extension_Manager_Search extends CRM_Extension_Manager_Base {
   public function onPreUninstall(CRM_Extension_Info $info) {
     $customSearchesByName = $this->getCustomSearchesByName();
     if (!array_key_exists($info->key, $customSearchesByName)) {
-      CRM_Core_Error::fatal('This custom search is not registered.');
+      throw new CRM_Core_Exception('This custom search is not registered.');
     }
 
     $cs = $this->getCustomSearchesById();
     $id = $cs[$customSearchesByName[$info->key]];
-    $optionValue = CRM_Core_BAO_OptionValue::del($id);
+    CRM_Core_BAO_OptionValue::del($id);
 
     return TRUE;
   }

--- a/CRM/Financial/BAO/FinancialType.php
+++ b/CRM/Financial/BAO/FinancialType.php
@@ -422,7 +422,7 @@ class CRM_Financial_BAO_FinancialType extends CRM_Financial_DAO_FinancialType {
     foreach ($lineItems as $items) {
       if (!CRM_Core_Permission::check($op . ' contributions of type ' . CRM_Contribute_PseudoConstant::financialType($items['financial_type_id']))) {
         if ($force) {
-          CRM_Core_Error::fatal(ts('You do not have permission to access this page.'));
+          throw new CRM_Core_Exception(ts('You do not have permission to access this page.'));
           break;
         }
         $flag = FALSE;

--- a/CRM/PCP/BAO/PCP.php
+++ b/CRM/PCP/BAO/PCP.php
@@ -936,7 +936,7 @@ INNER JOIN civicrm_uf_group ufgroup
          WHERE pb.entity_id = %1 AND pb.entity_table = %2";
     $params = [1 => [$component_id, 'Integer'], 2 => [$entity_table, 'String']];
     if (!$ownerNotificationId = CRM_Core_DAO::singleValueQuery($query, $params)) {
-      CRM_Core_Error::fatal(ts('Owner Notification is not set for this Personal Campaign Page. Please contact the site administrator if you need assistance.'));
+      throw new CRM_Core_Exception(ts('Owner Notification is not set for this Personal Campaign Page. Please contact the site administrator if you need assistance.'));
     }
     else {
       return $ownerNotificationId;

--- a/CRM/Pledge/BAO/Pledge.php
+++ b/CRM/Pledge/BAO/Pledge.php
@@ -692,7 +692,7 @@ GROUP BY  currency
       }
 
       if (is_a(CRM_Activity_BAO_Activity::create($activityParams), 'CRM_Core_Error')) {
-        CRM_Core_Error::fatal("Failed creating Activity for acknowledgment");
+        throw new CRM_Core_Exception('Failed creating Activity for acknowledgment');
       }
     }
   }

--- a/CRM/Pledge/BAO/PledgeBlock.php
+++ b/CRM/Pledge/BAO/PledgeBlock.php
@@ -206,7 +206,7 @@ class CRM_Pledge_BAO_PledgeBlock extends CRM_Pledge_DAO_PledgeBlock {
       }
       // give error if empty or build form for payment.
       if (empty($payments)) {
-        CRM_Core_Error::fatal(ts("Oops. It looks like there is no valid payment status for online payment."));
+        throw new CRM_Core_Exception(ts('Oops. It looks like there is no valid payment status for online payment.'));
       }
       else {
         $form->assign('is_pledge_payment', TRUE);

--- a/CRM/Price/BAO/PriceSet.php
+++ b/CRM/Price/BAO/PriceSet.php
@@ -1670,8 +1670,8 @@ WHERE     ct.id = cp.financial_type_id AND
           break;
 
         default:
-          CRM_Core_Error::fatal("$table is not supported in PriceSet::usedBy()");
-          break;
+          throw new CRM_Core_Exception("$table is not supported in PriceSet::usedBy()");
+
       }
     }
     return $usedBy;

--- a/tests/phpunit/CRM/Financial/BAO/FinancialTypeTest.php
+++ b/tests/phpunit/CRM/Financial/BAO/FinancialTypeTest.php
@@ -320,8 +320,8 @@ class CRM_Financial_BAO_FinancialTypeTest extends CiviUnitTestCase {
       CRM_Financial_BAO_FinancialType::checkPermissionedLineItems($contributions->id, 'view');
       $this->fail('Missed expected exception');
     }
-    catch (Exception $e) {
-      $this->assertEquals('A fatal error was triggered: You do not have permission to access this page.', $e->getMessage());
+    catch (CRM_Core_Exception $e) {
+      $this->assertEquals('You do not have permission to access this page.', $e->getMessage());
     }
 
     $this->setPermissions([


### PR DESCRIPTION
Overview
----------------------------------------
This is ongoing cleanup to consistently throw exceptions. 

Before
----------------------------------------
```
CRM_Core_Error::fatal();
```

After
----------------------------------------
```throw new CRM_Core_Exception(' no contact found');```

Technical Details
----------------------------------------
The only thing notable is in the OG class where
    it turned out the exception was thrown if a never-passed-in-parameter was passed in, so I removed the
    construct


Comments
----------------------------------------

