### PR TITLE
Replace calls to fatal with statusBounces

### DIFF
--- a/CRM/Activity/Page/Tab.php
+++ b/CRM/Activity/Page/Tab.php
@@ -154,7 +154,7 @@ class CRM_Activity_Page_Tab extends CRM_Core_Page {
       in_array($action, [CRM_Core_Action::UPDATE, CRM_Core_Action::VIEW])
     ) {
       if (!CRM_Activity_BAO_Activity::checkPermission($this->_id, $action)) {
-        CRM_Core_Error::fatal(ts('You are not authorized to access this page.'));
+        CRM_Core_Error::statusBounce(ts('You are not authorized to access this page.'));
       }
     }
 

--- a/CRM/Admin/Form/Extensions.php
+++ b/CRM/Admin/Form/Extensions.php
@@ -57,7 +57,7 @@ class CRM_Admin_Form_Extensions extends CRM_Admin_Form {
 
       case CRM_Core_Action::UPDATE:
         if (!CRM_Extension_System::singleton()->getBrowser()->isEnabled()) {
-          CRM_Core_Error::fatal(ts('The system administrator has disabled this feature.'));
+          CRM_Core_Error::statusBounce(ts('The system administrator has disabled this feature.'));
         }
         $info = CRM_Extension_System::singleton()->getBrowser()->getExtension($this->_key);
         $extInfo = CRM_Admin_Page_Extensions::createExtendedInfo($info);
@@ -65,7 +65,7 @@ class CRM_Admin_Form_Extensions extends CRM_Admin_Form {
         break;
 
       default:
-        CRM_Core_Error::fatal(ts('Unsupported action'));
+        CRM_Core_Error::statusBounce(ts('Unsupported action'));
     }
 
   }

--- a/CRM/Campaign/Form/Survey/Delete.php
+++ b/CRM/Campaign/Form/Survey/Delete.php
@@ -77,7 +77,7 @@ class CRM_Campaign_Form_Survey_Delete extends CRM_Core_Form {
       CRM_Utils_System::redirect(CRM_Utils_System::url('civicrm/campaign', 'reset=1&subPage=survey'));
     }
     else {
-      CRM_Core_Error::fatal(ts('Delete action is missing expected survey ID.'));
+      CRM_Core_Error::statusBounce(ts('Delete action is missing expected survey ID.'));
     }
   }
 

--- a/CRM/Campaign/Page/Petition/Confirm.php
+++ b/CRM/Campaign/Page/Petition/Confirm.php
@@ -36,7 +36,7 @@ class CRM_Campaign_Page_Petition_Confirm extends CRM_Core_Page {
       !$subscribe_id ||
       !$hash
     ) {
-      CRM_Core_Error::fatal(ts("Missing input parameters"));
+      CRM_Core_Error::statusBounce(ts("Missing input parameters"));
     }
 
     $result = $this->confirm($contact_id, $subscribe_id, $hash, $activity_id, $petition_id);

--- a/CRM/Custom/Form/Group.php
+++ b/CRM/Custom/Form/Group.php
@@ -54,7 +54,7 @@ class CRM_Custom_Form_Group extends CRM_Core_Form {
     $this->_id = $this->get('id');
 
     if ($this->_id && $isReserved = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_CustomGroup', $this->_id, 'is_reserved', 'id')) {
-      CRM_Core_Error::fatal("You cannot edit the settings of a reserved custom field-set.");
+      CRM_Core_Error::statusBounce("You cannot edit the settings of a reserved custom field-set.");
     }
     // setting title for html page
     if ($this->_action == CRM_Core_Action::UPDATE) {

--- a/CRM/UF/Form/Inline/Preview.php
+++ b/CRM/UF/Form/Inline/Preview.php
@@ -10,12 +10,6 @@
  */
 
 /**
- *
- * @package CRM
- * @copyright CiviCRM LLC https://civicrm.org/licensing
- */
-
-/**
  * This class generates form components
  * for previewing Civicrm Profile Group
  */
@@ -27,10 +21,10 @@ class CRM_UF_Form_Inline_Preview extends CRM_UF_Form_AbstractPreview {
    * gets session variables for group or field id
    */
   public function preProcess() {
-    if ($_SERVER['REQUEST_METHOD'] != 'POST') {
+    if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
       // CRM_Core_Controller validates qfKey for POST requests, but not necessarily
       // for GET requests. Allowing GET would therefore be CSRF vulnerability.
-      CRM_Core_Error::fatal(ts('Preview only supports HTTP POST'));
+      CRM_Core_Error::statusBounce(ts('Preview only supports HTTP POST'));
     }
     // Inline forms don't get menu-level permission checks
     $checkPermission = [
@@ -45,15 +39,12 @@ class CRM_UF_Form_Inline_Preview extends CRM_UF_Form_AbstractPreview {
     $content = json_decode($_REQUEST['ufData'], TRUE);
     foreach (['ufGroup', 'ufFieldCollection'] as $key) {
       if (!is_array($content[$key])) {
-        CRM_Core_Error::fatal("Missing JSON parameter, $key");
+        CRM_Core_Error::statusBounce("Missing JSON parameter, $key");
       }
     }
-    //echo '<pre>'.htmlentities(var_export($content, TRUE)) .'</pre>';
-    //CRM_Utils_System::civiExit();
+
     $fields = CRM_Core_BAO_UFGroup::formatUFFields($content['ufGroup'], $content['ufFieldCollection']);
-    //$fields = CRM_Core_BAO_UFGroup::getFields(1);
     $this->setProfile($fields);
-    //echo '<pre>'.htmlentities(var_export($fields, TRUE)) .'</pre>';CRM_Utils_System::civiExit();
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Replace calls to fatal with statusBounces

Before
----------------------------------------
```
 CRM_Core_Error::fatal(ts('You are not authorized to access this page.'));
```

After
----------------------------------------
```
    CRM_Core_Error::statusBounce(ts('You are not authorized to access this page.'));
```

Technical Details
----------------------------------------
@seamuslee001 we are just one last push away from being done with these

Comments
----------------------------------------

