### PR TITLE
APIv4 - filter getActions results based on user permissions

### DIFF
--- a/Civi/Api4/Action/GetActions.php
+++ b/Civi/Api4/Action/GetActions.php
@@ -75,7 +75,7 @@ class GetActions extends BasicGetAction {
     try {
       if (!isset($this->_actions[$actionName]) && (!$this->_actionsToGet || in_array($actionName, $this->_actionsToGet))) {
         $action = \Civi\API\Request::create($this->getEntityName(), $actionName, ['version' => 4]);
-        if (is_object($action)) {
+        if (is_object($action) && (!$this->checkPermissions || $action->isAuthorized())) {
           $this->_actions[$actionName] = ['name' => $actionName];
           if ($this->_isFieldSelected('description', 'comment', 'see')) {
             $vars = ['entity' => $this->getEntityName(), 'action' => $actionName];


### PR DESCRIPTION
Overview
----------------------------------------
Makes the api explorer and search builder more user-friendly by only showing actions the user has permissions to use.

Before
----------------------------------------
All actions returned by APIv4 getActions.

After
----------------------------------------
APIv4 getActions filtered by those the user has permission to execute, if checkPermissions is enabled.
