### PR TITLE
Fix validateAll to no longer support unused abort param

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -3696,7 +3696,7 @@ WHERE  $smartGroupClause
     }
     CRM_Utils_Type::validateAll($contactIds, 'Positive');
     if (!empty($contactIds)) {
-      $this->_where[0][] = " ( contact_a.id IN (" . implode(',', $contactIds) . " ) ) ";
+      $this->_where[0][] = ' ( contact_a.id IN (' . implode(',', $contactIds) . " ) ) ";
     }
   }
 

--- a/CRM/Utils/Type.php
+++ b/CRM/Utils/Type.php
@@ -196,11 +196,18 @@ class CRM_Utils_Type {
   /**
    * Helper function to call validate on arrays
    *
+   * @param mixed $data
+   * @param string $type
+   *
+   * @return mixed
+   *
+   * @throws \CRM_Core_Exception
+   *
    * @see validate
    */
-  public static function validateAll($data, $type, $abort = TRUE) {
+  public static function validateAll($data, $type) {
     foreach ($data as $key => $value) {
-      $data[$key] = CRM_Utils_Type::validate($value, $type, $abort);
+      $data[$key] = CRM_Utils_Type::validate($value, $type);
     }
     return $data;
   }


### PR DESCRIPTION

Overview
----------------------------------------
Fix validateAll to no longer support unused abort param

Before
----------------------------------------
Optional Param $abort is never passed

After
----------------------------------------
Param not in signature

Technical Details
----------------------------------------
Default of TRUE is good here

Comments
----------------------------------------

