### PR TITLE
Remove isThrowException from CRM_Utils_Type::validate() signature

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -3033,10 +3033,7 @@ class CRM_Contact_BAO_Query {
       if ($op === '!=') {
         $groupIds = '';
         if (!empty($regularGroupIDs)) {
-          $groupIds = CRM_Utils_Type::validate(
-            implode(',', (array) $regularGroupIDs),
-            'CommaSeparatedIntegers'
-          );
+          $groupIds = CRM_Utils_Type::validate(implode(',', (array) $regularGroupIDs), 'CommaSeparatedIntegers');
         }
         $clause = "{$gcTable}.contact_id NOT IN (SELECT contact_id FROM civicrm_group_contact cgc WHERE cgc.group_id = $groupIds )";
       }
@@ -3283,10 +3280,7 @@ WHERE  $smartGroupClause
     // implode array, then remove all spaces
     $value = str_replace(' ', '', implode(',', (array) $value));
     if (!empty($value)) {
-      $value = CRM_Utils_Type::validate(
-        $value,
-        'CommaSeparatedIntegers'
-      );
+      $value = CRM_Utils_Type::validate($value, 'CommaSeparatedIntegers');
     }
 
     $useAllTagTypes = $this->getWhereValues('all_tag_types', $grouping);

--- a/CRM/Utils/Check/Component/OptionGroups.php
+++ b/CRM/Utils/Check/Component/OptionGroups.php
@@ -33,9 +33,9 @@ class CRM_Utils_Check_Component_OptionGroups extends CRM_Utils_Check_Component {
         if (count($values) > 0) {
           foreach ($values as $value) {
             try {
-              CRM_Utils_Type::validate($value['value'], $optionGroup['data_type'], FALSE, '', TRUE);
+              CRM_Utils_Type::validate($value['value'], $optionGroup['data_type']);
             }
-            catch (Exception $e) {
+            catch (CRM_Core_Exception $e) {
               $problemValues[] = [
                 'group_name' => $optionGroup['title'],
                 'value_name' => $value['label'],

--- a/CRM/Utils/Type.php
+++ b/CRM/Utils/Type.php
@@ -351,15 +351,13 @@ class CRM_Utils_Type {
    *   If TRUE, the operation will CRM_Core_Error::fatal() on invalid data.
    * @param string $name
    *   The name of the attribute
-   * @param bool $isThrowException
-   *   Should an exception be thrown rather than a using a deprecated fatal error.
    *
    * @return mixed
    *   The data, escaped if necessary
    *
    * @throws \CRM_Core_Exception
    */
-  public static function validate($data, $type, $abort = TRUE, $name = 'One of parameters ', $isThrowException = TRUE) {
+  public static function validate($data, $type, $abort = TRUE, $name = 'One of parameters ') {
 
     $possibleTypes = [
       'Integer',
@@ -385,10 +383,7 @@ class CRM_Utils_Type {
       'Color',
     ];
     if (!in_array($type, $possibleTypes)) {
-      if ($isThrowException) {
-        throw new CRM_Core_Exception(ts('Invalid type, must be one of : ' . implode($possibleTypes)));
-      }
-      CRM_Core_Error::fatal(ts('Invalid type, must be one of : ' . implode($possibleTypes)));
+      throw new CRM_Core_Exception(ts('Invalid type, must be one of : ' . implode($possibleTypes)));
     }
     switch ($type) {
       case 'Integer':
@@ -465,10 +460,7 @@ class CRM_Utils_Type {
 
     if ($abort) {
       $data = htmlentities($data);
-      if ($isThrowException) {
-        throw new CRM_Core_Exception("$name (value: $data) is not of the type $type");
-      }
-      CRM_Core_Error::fatal("$name (value: $data) is not of the type $type");
+      throw new CRM_Core_Exception("$name (value: $data) is not of the type $type");
     }
 
     return NULL;


### PR DESCRIPTION

Overview
----------------------------------------
Remove isThrowException from CRM_Utils_Type::validate() signature

Before
----------------------------------------
```
public static function validate($data, $type, $abort = TRUE, $name = 'One of parameters ', $isThrowException = TRUE)
```

After
----------------------------------------
```
public static function validate($data, $type, $abort = TRUE, $name = 'One of parameters ')
```

Technical Details
----------------------------------------
There are no instances in core where FALSE is passed

Comments
----------------------------------------
@seamuslee001 you'll need to do your own grep & see if you reach the same conclusion
