### PR TITLE
Deprecate error handling bypasses

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -1481,6 +1481,7 @@ FROM   civicrm_domain
     }
 
     if ($trapException) {
+      CRM_Core_Error::deprecatedFunctionWarning('calling functions should handle exceptions');
       $errorScope = CRM_Core_TemporaryErrorScope::ignoreException();
     }
 
@@ -1584,6 +1585,9 @@ FROM   civicrm_domain
    * @throws CRM_Core_Exception
    */
   public static function composeQuery($query, $params = [], $abort = TRUE) {
+    if (!$abort) {
+      CRM_Core_Error::deprecatedFunctionWarning('calling functions should not bypass error handling');
+    }
     $tr = [];
     foreach ($params as $key => $item) {
       if (is_numeric($key)) {


### PR DESCRIPTION

Overview
----------------------------------------
I don't believe these are passed in anywhere but it's impossible to be sure so
deprecation makes sense


Before
----------------------------------------
ExecuteQuery quietly accepts $trapException and singleValueQuery quietly accepts $abort = FALSE

After
----------------------------------------
Above params accepted noisily

Technical Details
----------------------------------------
We don't expect these params to be passed in - the calling function should handle any errors

Comments
----------------------------------------

