### PR TITLE
Support passing old method name into deprecatedFunctionWarning

### DIFF
--- a/CRM/Core/Error.php
+++ b/CRM/Core/Error.php
@@ -1033,14 +1033,19 @@ class CRM_Core_Error extends PEAR_ErrorStack {
   /**
    * Output a deprecated function warning to log file.  Deprecated class:function is automatically generated from calling function.
    *
-   * @param $newMethod
+   * @param string $newMethod
    *   description of new method (eg. "buildOptions() method in the appropriate BAO object").
+   * @param string $oldMethod
+   *   optional description of old method (if not the calling method). eg. CRM_MyClass::myOldMethodToGetTheOptions()
    */
-  public static function deprecatedFunctionWarning($newMethod) {
-    $dbt = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2);
-    $callerFunction = $dbt[1]['function'] ?? NULL;
-    $callerClass = $dbt[1]['class'] ?? NULL;
-    Civi::log()->warning("Deprecated function $callerClass::$callerFunction, use $newMethod.", ['civi.tag' => 'deprecated']);
+  public static function deprecatedFunctionWarning($newMethod, $oldMethod = NULL) {
+    if (!$oldMethod) {
+      $dbt = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2);
+      $callerFunction = $dbt[1]['function'] ?? NULL;
+      $callerClass = $dbt[1]['class'] ?? NULL;
+      $oldMethod = "{$callerClass}::{$callerFunction}";
+    }
+    Civi::log()->warning("Deprecated function $oldMethod, use $newMethod.", ['civi.tag' => 'deprecated']);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
When I originally added this function it replaced a lot of adhoc, inconsistent log messages that were doing the same thing. We are now using this function extensively to indicate that things are deprecated but it does not always work because the calling method is not always the deprecated one. Eg. see https://github.com/civicrm/civicrm-core/pull/17456 for an example (there are already examples in core where we are doing similar but overriding the `$newMethod` text to include the name of the old method etc.

Before
----------------------------------------
Doesn't work well when caller is not the deprecated method.

After
----------------------------------------
Works well when caller is deprecated and when caller is not deprecated.

Technical Details
----------------------------------------
Add an optional second param `$oldMethod`

Comments
----------------------------------------
@eileenmcnaughton 
