### PR TITLE
dev/core#560 Add in deprecated function warning now that fatal is dep…

### DIFF
--- a/CRM/Core/Error.php
+++ b/CRM/Core/Error.php
@@ -301,6 +301,7 @@ class CRM_Core_Error extends PEAR_ErrorStack {
    * @throws Exception
    */
   public static function fatal($message = NULL, $code = NULL, $email = NULL) {
+    CRM_Core_Error::deprecatedFunctionWarning('throw new CRM_Core_Exception or use CRM_Core_Error::statusBounce', 'CRM_Core_Error::fatal');
     $vars = [
       'message' => $message,
       'code' => $code,


### PR DESCRIPTION
…recated

Overview
----------------------------------------
This adds a deprecated function warning onto CRM_Core_Error::fatal now that we have removed all core usages of it

Before
----------------------------------------
No deprecated warning

After
----------------------------------------
Deprecated warning

ping @eileenmcnaughton 