### PR TITLE
dev/core#1801 Fix hardcoded activity priority by label

### DIFF
--- a/CRM/Activity/Form/Activity.php
+++ b/CRM/Activity/Form/Activity.php
@@ -582,7 +582,7 @@ class CRM_Activity_Form_Activity extends CRM_Contact_Form_Task {
     }
     if (empty($defaults['priority_id'])) {
       $priority = CRM_Core_PseudoConstant::get('CRM_Activity_DAO_Activity', 'priority_id');
-      $defaults['priority_id'] = array_search('Normal', $priority);
+      $defaults['priority_id'] = CRM_Core_PseudoConstant::getKey('CRM_Activity_DAO_Activity', 'priority_id', 'Normal');
     }
     if (empty($defaults['status_id'])) {
       $defaults['status_id'] = CRM_Core_OptionGroup::getDefaultValue('activity_status');


### PR DESCRIPTION
Overview
----------------------------------------
Fix issue with set default priority in non-english installation. https://lab.civicrm.org/dev/core/-/issues/1801

Before
----------------------------------------
Default priority must have "Normal" in label. When change label of "Normal" priority - field as empty.

After
----------------------------------------
Default priority is set to "Normal" value, regardless of the label name.

Technical Details
----------------------------------------


Comments
----------------------------------------
Thanks for @eileenmcnaughton for this code. I am sending PR so that the change can occur in CiviCRM. Thanks a lot.