### PR TITLE
dev/core#1681 Block sites from upgrading if on a MySQL version less t…

### DIFF
--- a/CRM/Upgrade/Form.php
+++ b/CRM/Upgrade/Form.php
@@ -453,6 +453,16 @@ SET    version = '$version'
         ]);
     }
 
+    if (version_compare(CRM_Utils_SQL::getDatabaseVersion(), CRM_Upgrade_Incremental_General::MIN_INSTALL_MYSQL_VER) < 0) {
+      $error = ts('CiviCRM %4 requires MySQL version v%1 or MariaDB v%3 (or newer), but the current system uses %2 ',
+        [
+          1 => CRM_Upgrade_Incremental_General::MIN_INSTALL_MYSQL_VER,
+          2 => CRM_Utils_SQL::getDatabaseVersion(),
+          3 => '10.1',
+          4 => $latestVer,
+        ]);
+    }
+
     // check for mysql trigger privileges
     if (!\Civi::settings()->get('logging_no_trigger_permission') && !CRM_Core_DAO::checkTriggerViewPermission(FALSE, TRUE)) {
       $error = ts('CiviCRM %1 requires MySQL trigger privileges.',

--- a/CRM/Upgrade/Incremental/General.php
+++ b/CRM/Upgrade/Incremental/General.php
@@ -59,13 +59,6 @@ class CRM_Upgrade_Incremental_General {
   const MIN_INSTALL_MYSQL_VER = '5.6.5';
 
   /**
-   * The minimum MySQL/MariaDB version required to install Civi.
-   *
-   * @see install/index.php
-   */
-  const NEW_MIN_INSTALL_MYSQL_VER = '5.6.5';
-
-  /**
    * Compute any messages which should be displayed before upgrade.
    *
    * @param string $preUpgradeMessage
@@ -86,25 +79,14 @@ class CRM_Upgrade_Incremental_General {
       ]);
       $preUpgradeMessage .= '</p>';
     }
-    if (version_compare(CRM_Utils_SQL::getDatabaseVersion(), self::MIN_RECOMMENDED_MYSQL_VER) < 0 && version_compare(CRM_Utils_SQL::getDatabaseVersion(), self::NEW_MIN_INSTALL_MYSQL_VER) >= 0) {
+    if (version_compare(CRM_Utils_SQL::getDatabaseVersion(), self::MIN_RECOMMENDED_MYSQL_VER) < 0) {
       $preUpgradeMessage .= '<p>';
-      $preUpgradeMessage .= ts('This system uses MySQL/MariaDB v%4. You may proceed with the upgrade, and CiviCRM v%1 will continue working normally. However, future releases will require MySQL v%2 or MariaDB v%3.', [
+      $preUpgradeMessage .= ts('This system uses MySQL/MariaDB v%5. You may proceed with the upgrade, and CiviCRM v%1 will continue working normally. However, CiviCRM v%4 will require MySQL v%2 or MariaDB v%3.', [
         1 => $latestVer,
         2 => self::MIN_RECOMMENDED_MYSQL_VER . '+',
         3 => '10.1' . '+',
-        4 => CRM_Utils_SQL::getDatabaseVersion(),
-      ]);
-      $preUpgradeMessage .= '</p>';
-    }
-    if (version_compare(CRM_Utils_SQL::getDatabaseVersion(), self::NEW_MIN_INSTALL_MYSQL_VER) < 0) {
-      $preUpgradeMessage .= '<p>';
-      $preUpgradeMessage .= ts('This system uses MySQL/MariaDB v%6. You may proceed with the upgrade, and CiviCRM v%1 will continue working normally. However, CiviCRM v%5 will require MySQL v%2. We recommend MySQL v%3 or MariaDB v%4.', [
-        1 => $latestVer,
-        2 => self::NEW_MIN_INSTALL_MYSQL_VER . '+',
-        3 => self::MIN_RECOMMENDED_MYSQL_VER . '+',
-        4 => '10.1' . '+',
-        5 => '5.28' . '+',
-        6 => CRM_Utils_SQL::getDatabaseVersion(),
+        4 => '5.34' . '+',
+        5 => CRM_Utils_SQL::getDatabaseVersion(),
       ]);
       $preUpgradeMessage .= '</p>';
     }

--- a/CRM/Utils/Check/Component/Env.php
+++ b/CRM/Utils/Check/Component/Env.php
@@ -938,45 +938,17 @@ class CRM_Utils_Check_Component_Env extends CRM_Utils_Check_Component {
   public function checkMysqlVersion() {
     $messages = [];
     $version = CRM_Utils_SQL::getDatabaseVersion();
-    $minInstallVersion = CRM_Upgrade_Incremental_General::MIN_INSTALL_MYSQL_VER;
     $minRecommendedVersion = CRM_Upgrade_Incremental_General::MIN_RECOMMENDED_MYSQL_VER;
     $mariaDbRecommendedVersion = '10.1';
-    $upcomingCiviChangeVersion = '5.28';
-    if (version_compare(CRM_Utils_SQL::getDatabaseVersion(), $minInstallVersion, '<')) {
+    $upcomingCiviChangeVersion = '5.34';
+    if (version_compare(CRM_Utils_SQL::getDatabaseVersion(), $minRecommendedVersion, '<')) {
       $messages[] = new CRM_Utils_Check_Message(
         __FUNCTION__,
-        ts('This system uses MySQL/MariaDB v%1. To ensure the continued operation of CiviCRM, upgrade MySQL now. The recommended version is MySQL v%2 or MariaDB v%3.', [
-          1 => $version,
-          2 => $minRecommendedVersion . '+',
-          3 => '10.1' . '+',
-        ]),
-        ts('MySQL Out-of-Date'),
-        \Psr\Log\LogLevel::ERROR,
-        'fa-server'
-      );
-    }
-    elseif (version_compare(CRM_Utils_SQL::getDatabaseVersion(), CRM_Upgrade_Incremental_General::NEW_MIN_INSTALL_MYSQL_VER, '<')) {
-      $messages[] = new CRM_Utils_Check_Message(
-        __FUNCTION__,
-        ts('This system uses MySQL/MariaDB v%1. To prepare for CiviCRM v%5, please upgrade MySQL. The recommended version will be MySQL v%3 or MariaDB v%4. The minimum requirement will be MySQL v%2. ', [
-          1 => $version,
-          2 => CRM_Upgrade_Incremental_General::NEW_MIN_INSTALL_MYSQL_VER . '+',
-          3 => $minRecommendedVersion . '+',
-          4 => $mariaDbRecommendedVersion . '+',
-          5 => $upcomingCiviChangeVersion . '+',
-        ]),
-        ts('MySQL Out-of-Date'),
-        \Psr\Log\LogLevel::WARNING,
-        'fa-server'
-      );
-    }
-    elseif (version_compare(CRM_Utils_SQL::getDatabaseVersion(), $minRecommendedVersion, '<')) {
-      $messages[] = new CRM_Utils_Check_Message(
-        __FUNCTION__,
-        ts('This system uses MySQL/MariaDB v%1. You can continue to use this version of MySQL. However, support may be removed in a future release. The recommended version is MySQL v%2 or MariaDB v%3.', [
+        ts('To prepare for CiviCRM v%4, please upgrade MySQL. The recommended version will be MySQL v%2 or MariaDB v%3.', [
           1 => $version,
           2 => $minRecommendedVersion . '+',
           3 => $mariaDbRecommendedVersion . '+',
+          4 => $upcomingCiviChangeVersion . '+',
         ]),
         ts('MySQL Out-of-Date'),
         \Psr\Log\LogLevel::NOTICE,


### PR DESCRIPTION
…han 5.6.5

Overview
----------------------------------------
This blocks CiviCRM from trying to upgrade if not on the new Minimum MySQL version as of 5.28 which is 5.6.5

Before
----------------------------------------
 Upgrade could go ahead and may hard fail

After
----------------------------------------
Upgrade can't proceed

ping @totten @eileenmcnaughton @mattwire @colemanw 