### PR TITLE
Add recurring contribution ID to updateSubscriptionBillingInfo

### DIFF
--- a/CRM/Contribute/Form/UpdateBilling.php
+++ b/CRM/Contribute/Form/UpdateBilling.php
@@ -202,7 +202,8 @@ class CRM_Contribute_Form_UpdateBilling extends CRM_Contribute_Form_Contribution
     $processorParams['country'] = CRM_Core_PseudoConstant::country($params["billing_country_id-{$this->_bltID}"], FALSE);
     $processorParams['month'] = CRM_Core_Payment_Form::getCreditCardExpirationMonth($processorParams);
     $processorParams['year'] = CRM_Core_Payment_Form::getCreditCardExpirationYear($processorParams);
-    $processorParams['subscriptionId'] = $this->getSubscriptionDetails()->processor_id;
+    $processorParams['subscriptionId'] = $processorParams['recurProcessorID'] = $this->getSubscriptionDetails()->processor_id;
+    $processorParams['contributionRecurID'] = $this->getSubscriptionDetails()->recur_id;
     $processorParams['amount'] = $this->_subscriptionDetails->amount;
     $updateSubscription = $this->_paymentProcessor['object']->updateSubscriptionBillingInfo('', $processorParams);
     if (is_a($updateSubscription, 'CRM_Core_Error')) {

--- a/CRM/Utils/Hook/DrupalBase.php
+++ b/CRM/Utils/Hook/DrupalBase.php
@@ -84,7 +84,7 @@ class CRM_Utils_Hook_DrupalBase extends CRM_Utils_Hook {
         $this->drupalModules = $this->getDrupalModules();
       }
 
-      if ($this->civiModules === NULL) {
+      if (empty($this->civiModules)) {
         $this->civiModules = [];
         $this->requireCiviModules($this->civiModules);
       }


### PR DESCRIPTION
Overview
----------------------------------------
@KarinG @eileenmcnaughton Per #17461 it seems we're still not passing the recurring contribution ID into this function! Also per discussion we would like to replace this function and *possibly* merge it with `updateSubscriptionAmount` via a wrapper `doUpdate..` which is called with a payment PropertyBag as params.

I don't think we are ready to do that yet as we have lot's of other outstanding payment processor changes in progress and payment PropertyBag is still evolving - see https://lab.civicrm.org/dev/financial/-/issues/130

This PR moves us a little closer by passing "standardized" params for `contributionRecurID` and `recurProcessorID` which will allow payment processors to simplify the code in `updateSubscriptionBillingInfo` and align to the parameters that they will receive once we are passing in a propertyBag. Importantly it allows processors to remove various workarounds to get the recur ID.

Before
----------------------------------------
No recur ID available to function.

After
----------------------------------------
recur ID available to function.

Technical Details
----------------------------------------
For now we are just passing them in as parameters (the data is already available immediately before the function call).

Comments
----------------------------------------
@KarinG @eileenmcnaughton I think it is sensible to add like this for now, it will help smooth the transition once we know what we want this function to look like and it removes another pain point for payment processor developers!
