### PR TITLE
ensure custom field checkboxes are populated in profiles

### DIFF
--- a/CRM/Core/BAO/UFGroup.php
+++ b/CRM/Core/BAO/UFGroup.php
@@ -2339,7 +2339,7 @@ AND    ( entity_id IS NULL OR entity_id <= 0 )
             $defaults[$fldName] = $details['worldregion_id'];
           }
           elseif (CRM_Core_BAO_CustomField::getKeyID($name)) {
-            $defaults[$fldName] = self::formatCustomValue($field, $details[$name]);
+            self::formatCustomValue($field, $details[$name], $fldName, $defaults);
           }
           else {
             $defaults[$fldName] = $details[$name];
@@ -2419,12 +2419,12 @@ AND    ( entity_id IS NULL OR entity_id <= 0 )
                       }
                     }
                     elseif (strpos($fieldName, 'address_custom') === 0 && !empty($value[substr($fieldName, 8)])) {
-                      $defaults[$fldName] = self::formatCustomValue($field, $value[substr($fieldName, 8)]);
+                      self::formatCustomValue($field, $details[$name], $fldName, $defaults);
                     }
                   }
                 }
                 elseif (strpos($fieldName, 'address_custom') === 0 && !empty($value[substr($fieldName, 8)])) {
-                  $defaults[$fldName] = self::formatCustomValue($field, $value[substr($fieldName, 8)]);
+                  self::formatCustomValue($field, $details[$name], $fldName, $defaults);
                 }
               }
             }
@@ -3591,25 +3591,31 @@ SELECT  group_id
    *   Field metadata.
    * @param string $value
    *   Raw value
+   * @param string $fldName
+   *   Index to be used in $defaults array
+   * @param array $defaults
+   *   Array of default values passed by reference
    *
    * @return mixed
    *   String or array, depending on the html type
    */
-  private static function formatCustomValue($field, $value) {
+  private static function formatCustomValue($field, $value, $fldName, &$defaults) {
     if (CRM_Core_BAO_CustomField::isSerialized($field)) {
       $value = CRM_Utils_Array::explodePadded($value);
-
       if ($field['html_type'] === 'CheckBox') {
-        $checkboxes = [];
-        foreach (array_filter($value) as $item) {
-          $checkboxes[$item] = 1;
-          // CRM-2969 seems like we need this for QF style checkboxes in profile where its multiindexed
-          $checkboxes["[{$item}]"] = 1;
+        foreach ($value as $item) {
+          if ($item) {
+            $defaults[$fldName . "[$item]"] = 1;
+          }
         }
-        return $checkboxes;
+      }
+      else {
+        $defaults[$fldName] = $value;
       }
     }
-    return $value;
+    else {
+      $defaults[$fldName] = $value;
+    }
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Ensure that custom fields that use the checkbox html type are populated when viewing an existing record, i.e. when using the "Update multiple contacts" search action.

Replicate
-----------------------------------------

1. Create a custom field group that extends the individual
1. Create a field (Alphanumeric / Checkbox) with two options.
1. Create a profile called "Update contact" and add the field you just created.
1. Find a contact and populate the field you just created with one or more values.
1. Perform a search for all contacts with the field populated to the value you used
1. Select the one record
1. Choose "Update multiple contacts"
1. Choose the profile "Update contact" that you just created
1. View whether or not the field you created is displayed with populated data

Before
----------------------------------------
When you run "Update Multiple Contacts" on a profile with a custom checkbox field, the existing values are not shown. All contacts show no checkboxes checked even if their contact record shows that they have checkboxes checked.

After
----------------------------------------
Now, checkboxes are properly checked.

Technical Details
----------------------------------------
The checkbox field is an outlier when it comes to handling default data. Select, Multi-select, radio and other fields with one or more values will work fine with one entry in the $defaults array that is set to an array of values to populate.

But the checkbox needs each individual checkbox that should be checked to be an entry in the $defaults array.

Comments
----------------------------------------
Maybe it would be better to fix the form layer so that checkboxes could accept default values in the same format as all the other fields??

Also @colemanw - this code was very recently touched by you - so I hope I'm not clobbering some other functionality that you fixed in d4502c25240948ea0d5ea6973c7a8fe1212256b2.