### PR TITLE
Dedupe performance - hard-remove financial_item from list of dymnamic  refs to contact table

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -2401,7 +2401,6 @@ SELECT contact_id
     $refsFound = [];
     foreach (CRM_Core_DAO_AllCoreTables::getClasses() as $daoClassName) {
       $links = $daoClassName::getReferenceColumns();
-      $daoTableName = $daoClassName::getTableName();
 
       foreach ($links as $refSpec) {
         /** @var $refSpec CRM_Core_Reference_Interface */

--- a/CRM/Dedupe/MergeHandler.php
+++ b/CRM/Dedupe/MergeHandler.php
@@ -124,6 +124,13 @@ class CRM_Dedupe_MergeHandler {
     if (!isset(\Civi::$statics[__CLASS__]['dynamic'])) {
       \Civi::$statics[__CLASS__]['dynamic'] = [];
       foreach (CRM_Core_DAO::getDynamicReferencesToTable('civicrm_contact') as $tableName => $field) {
+        if ($tableName === 'civicrm_financial_item') {
+          // It turns out that civicrm_financial_item does not have an index on entity_table (only as the latter
+          // part of a entity_id/entity_table index which probably is not adding any value over & above entity_id
+          // only. This means this is a slow query. The correct fix is probably to add a whitelist to
+          // values for entity_table in the schema.
+          continue;
+        }
         $sql[] = "(SELECT '$tableName' as civicrm_table, '{$field[0]}' as field_name FROM $tableName WHERE entity_table = 'civicrm_contact' LIMIT 1)";
       }
       $sqlString = implode(' UNION ', $sql);


### PR DESCRIPTION
Overview
----------------------------------------
Rc fix for performance regression in deduping - note I want to see if we can do a better fix onn master

Before
----------------------------------------
SQL runs:

```select id FROM civicrm_financial_item WHERE entity_table = 'civicrm_contact'; ``` to see if the table is a dedupe candidate. 

However, the index on this table does not cover the where clause & as this is a large table it gets slow

After
----------------------------------------
Query hacked out of the list

Technical Details
----------------------------------------
For the 'real' fix on master I think we want a schema for this - ie something like

```
--- a/xml/schema/Financial/FinancialItem.xml
+++ b/xml/schema/Financial/FinancialItem.xml
@@ -130,9 +130,11 @@
     <name>entity_table</name>
     <type>varchar</type>
     <title>Entity Table</title>
+    <required>true</required>
     <length>64</length>
     <comment>The table providing the source of this item such as civicrm_line_item</comment>
     <add>4.3</add>
+    <validTables>civicrm_line_item, civicrm_financial_trxn</validTables>
   </field>
   <field>
     <name>entity_id</name>

```

Note there is a previous pointer to this approach
https://github.com/civicrm/civicrm-core/blob/449c4e6bf67c8a177b56e6a176bcad1ac028b95f/CRM/Core/DAO.php#L2407


Comments
----------------------------------------
@totten @seamuslee001 @colemanw a couple of questions

1) How do we want the xml to look for specifying valid tables for civicrm_entity
2) Does this need to be in regen / go into the DAO ?
3) Should it be hookabale?
