### PR TITLE
Contribution confirmation page should not display the name of payment processor type

### DIFF
--- a/CRM/Core/Payment.php
+++ b/CRM/Core/Payment.php
@@ -600,16 +600,7 @@ abstract class CRM_Core_Payment {
         return $gotText;
 
       case 'contributionPageContinueText':
-        if ($params['amount'] <= 0) {
-          return ts('To complete this transaction, click the <strong>Continue</strong> button below.');
-        }
-        if ($this->_paymentProcessor['billing_mode'] == 4) {
-          return ts('Click the <strong>Continue</strong> button to go to %1, where you will select your payment method and complete the contribution.', [$this->_paymentProcessor['payment_processor_type']]);
-        }
-        if ($params['is_payment_to_existing']) {
-          return ts('To complete this transaction, click the <strong>Make Payment</strong> button below.');
-        }
-        return ts('To complete your contribution, click the <strong>Continue</strong> button below.');
+        return ts('Click the <strong>Continue</strong> button to proceed with the payment.');
 
       case 'cancelRecurDetailText':
         if ($params['mode'] === 'auto_renew') {


### PR DESCRIPTION
Overview
----------------------------------------
The name of the payment processor type is displayed on the confirmation page. That is not needed.

Before
----------------------------------------
The text is **Click the Continue button to go to PayPal_Standard, where you will select your payment method and complete the contribution.**
![confirm-page](https://user-images.githubusercontent.com/49378827/84232103-ed874080-ab32-11ea-955b-07b4eb9cb7f8.png)


After
----------------------------------------
The text is **Click the Continue button to complete the contribution.**

Comments
----------------------------------------
A fixed text is good enough.
It can display the name/title of the payment processor instance, however, there is no description on the payment processor settings page says the field will be displayed publicly and the site admin has to update it.

Gitlab ref: https://lab.civicrm.org/dev/financial/-/issues/134

Agileware ref: CIVICRM-1496
