### PR TITLE
core#1805: Autocomplete-select custom field is not searchable

### DIFF
--- a/CRM/Activity/Form/Search.php
+++ b/CRM/Activity/Form/Search.php
@@ -182,8 +182,6 @@ class CRM_Activity_Form_Search extends CRM_Core_Form_Search {
       $this->_formValues["activity_test"] = 0;
     }
 
-    CRM_Core_BAO_CustomValue::fixCustomFieldValue($this->_formValues);
-
     $this->_queryParams = CRM_Contact_BAO_Query::convertFormValues($this->_formValues);
 
     $this->set('queryParams', $this->_queryParams);

--- a/CRM/Case/Form/Search.php
+++ b/CRM/Case/Form/Search.php
@@ -202,8 +202,6 @@ class CRM_Case_Form_Search extends CRM_Core_Form_Search {
     if (empty($this->_formValues['case_deleted'])) {
       $this->_formValues['case_deleted'] = 0;
     }
-    // @todo - stop changing formValues - respect submitted form values, change a working array.
-    CRM_Core_BAO_CustomValue::fixCustomFieldValue($this->_formValues);
 
     // @todo - stop changing formValues - respect submitted form values, change a working array.
     $this->_queryParams = CRM_Contact_BAO_Query::convertFormValues($this->_formValues);

--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -1587,6 +1587,7 @@ class CRM_Contact_BAO_Query {
     }
 
     self::filterCountryFromValuesIfStateExists($formValues);
+    CRM_Core_BAO_CustomValue::fixCustomFieldValue($formValues);
 
     foreach ($formValues as $id => $values) {
       if (self::isAlreadyProcessedForQueryFormat($values)) {

--- a/CRM/Contact/Form/Search/Advanced.php
+++ b/CRM/Contact/Form/Search/Advanced.php
@@ -297,8 +297,6 @@ class CRM_Contact_Form_Search_Advanced extends CRM_Contact_Form_Search {
       $this->_sortByCharacter = NULL;
     }
 
-    CRM_Core_BAO_CustomValue::fixCustomFieldValue($this->_formValues);
-
     $this->_params = CRM_Contact_BAO_Query::convertFormValues($this->_formValues, 0, FALSE, NULL, $this->entityReferenceFields);
     $this->_returnProperties = &$this->returnProperties();
     parent::postProcess();

--- a/CRM/Contribute/Form/Search.php
+++ b/CRM/Contribute/Form/Search.php
@@ -308,9 +308,6 @@ class CRM_Contribute_Form_Search extends CRM_Core_Form_Search {
     }
 
     // @todo - stop changing formValues - respect submitted form values, change a working array.
-    CRM_Core_BAO_CustomValue::fixCustomFieldValue($this->_formValues);
-
-    // @todo - stop changing formValues - respect submitted form values, change a working array.
     $this->_queryParams = CRM_Contact_BAO_Query::convertFormValues($this->_formValues);
 
     $this->set('queryParams', $this->_queryParams);

--- a/CRM/Core/BAO/CustomValue.php
+++ b/CRM/Core/BAO/CustomValue.php
@@ -175,6 +175,9 @@ class CRM_Core_BAO_CustomValue extends CRM_Core_DAO {
       ) {
         $formValues[$key] = ['LIKE' => $formValues[$key]];
       }
+      elseif ($htmlType == 'Autocomplete-Select' && !empty($formValues[$key]) && is_string($formValues[$key]) && (strpos($formValues[$key], ',') != FALSE)) {
+        $formValues[$key] = ['IN' => explode(',', $formValues[$key])];
+      }
     }
   }
 

--- a/CRM/Custom/Form/Field.php
+++ b/CRM/Custom/Form/Field.php
@@ -748,10 +748,6 @@ SELECT count(*)
                 $errors['option_value[' . $nextIndex . ']'] = ts('Duplicate Option values');
                 $_flagOption = 1;
               }
-              if (strpos($fields['option_value'][$start], ',') != FALSE) {
-                $errors['option_value[' . $start . ']'] = ts('You cannot use comma in Option value');
-                $_flagOption = 1;
-              }
               $nextIndex++;
             }
             $start++;

--- a/CRM/Custom/Form/Field.php
+++ b/CRM/Custom/Form/Field.php
@@ -748,6 +748,10 @@ SELECT count(*)
                 $errors['option_value[' . $nextIndex . ']'] = ts('Duplicate Option values');
                 $_flagOption = 1;
               }
+              if (strpos($fields['option_value'][$start], ',') != FALSE) {
+                $errors['option_value[' . $start . ']'] = ts('You cannot use comma in Option value');
+                $_flagOption = 1;
+              }
               $nextIndex++;
             }
             $start++;

--- a/CRM/Event/Form/Search.php
+++ b/CRM/Event/Form/Search.php
@@ -285,8 +285,6 @@ class CRM_Event_Form_Search extends CRM_Core_Form_Search {
       $this->_formValues["participant_test"] = 0;
     }
 
-    CRM_Core_BAO_CustomValue::fixCustomFieldValue($this->_formValues);
-
     $this->_queryParams = CRM_Contact_BAO_Query::convertFormValues($this->_formValues, 0, FALSE, NULL, ['event_id']);
 
     $this->set('queryParams', $this->_queryParams);

--- a/CRM/Grant/Form/Search.php
+++ b/CRM/Grant/Form/Search.php
@@ -162,8 +162,6 @@ class CRM_Grant_Form_Search extends CRM_Core_Form_Search {
       $this->_formValues = CRM_Contact_BAO_SavedSearch::getFormValues($this->_ssID);
     }
 
-    CRM_Core_BAO_CustomValue::fixCustomFieldValue($this->_formValues);
-
     $this->_queryParams = CRM_Contact_BAO_Query::convertFormValues($this->_formValues);
 
     $this->set('queryParams', $this->_queryParams);

--- a/CRM/Member/Form/Search.php
+++ b/CRM/Member/Form/Search.php
@@ -222,8 +222,6 @@ class CRM_Member_Form_Search extends CRM_Core_Form_Search {
       $this->_formValues["member_test"] = 0;
     }
 
-    CRM_Core_BAO_CustomValue::fixCustomFieldValue($this->_formValues);
-
     $this->_queryParams = CRM_Contact_BAO_Query::convertFormValues($this->_formValues, 0, FALSE, NULL, $this->entityReferenceFields);
 
     $this->set('queryParams', $this->_queryParams);

--- a/tests/phpunit/CRM/Core/BAO/CustomValueTest.php
+++ b/tests/phpunit/CRM/Core/BAO/CustomValueTest.php
@@ -100,7 +100,7 @@ class CRM_Core_BAO_CustomValueTest extends CiviUnitTestCase {
   public function testFixCustomFieldValue() {
     $customGroup = $this->customGroupCreate(['extends' => 'Individual']);
     $params = [
-      'email' => 'abc@webaccess.co.in',
+      'email' => 'abc@example.com',
     ];
 
     foreach ([

--- a/tests/phpunit/CRM/Core/BAO/CustomValueTest.php
+++ b/tests/phpunit/CRM/Core/BAO/CustomValueTest.php
@@ -97,28 +97,60 @@ class CRM_Core_BAO_CustomValueTest extends CiviUnitTestCase {
     }
   }
 
-  public function fixCustomFieldValue() {
+  public function testFixCustomFieldValue() {
     $customGroup = $this->customGroupCreate(['extends' => 'Individual']);
-
-    $fields = [
-      'custom_group_id' => $customGroup['id'],
-      'data_type' => 'Memo',
-      'html_type' => 'TextArea',
-      'default_value' => '',
-    ];
-
-    $customField = $this->customFieldCreate($fields);
-
-    $custom = 'custom_' . $customField['id'];
     $params = [
       'email' => 'abc@webaccess.co.in',
-      $custom => 'note',
     ];
 
-    CRM_Core_BAO_CustomValue::fixCustomFieldValue($params);
-    $this->assertEquals($params[$custom], '%note%', 'Checking the returned value of type Memo.');
+    foreach ([
+      [
+        'custom_group_id' => $customGroup['id'],
+        'data_type' => 'Memo',
+        'html_type' => 'TextArea',
+        'default_value' => '',
+        'search_value' => '%note%',
+        'expected_value' => ['LIKE' => '%note%'],
+      ],
+      [
+        'custom_group_id' => $customGroup['id'],
+        'data_type' => 'String',
+        'html_type' => 'Autocomplete-Select',
+        'default_value' => '',
+        'search_value' => 'R,Y',
+        'expected_value' => ['IN' => ['R', 'Y']],
+        'option_values' => [
+          [
+            'label' => 'Red',
+            'value' => 'R',
+            'weight' => 1,
+            'is_active' => 1,
+          ],
+          [
+            'label' => 'Yellow',
+            'value' => 'Y',
+            'weight' => 2,
+            'is_active' => 1,
+          ],
+          [
+            'label' => 'Green',
+            'value' => 'G',
+            'weight' => 3,
+            'is_active' => 1,
+          ],
+        ],
+      ],
+    ] as $field) {
+      $id = $this->customFieldCreate($field)['id'];
+      $customKey = 'custom_' . $id;
+      $params[$customKey] = $field['search_value'];
+      CRM_Core_BAO_CustomValue::fixCustomFieldValue($params);
+      $this->assertEquals($params[$customKey], $field['expected_value'], 'Checking the returned value of type ' . $field['data_type']);
 
-    $this->customFieldDelete($customField['id']);
+      // delete created custom field
+      $this->customFieldDelete($id);
+    }
+
     $this->customGroupDelete($customGroup['id']);
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
 Steps to replicate:
1. Create an 'Autocomplete Select' custom field for any component, say Contribution here
2. Update/add two or more records with these custom field options
3. Go to the desired search form, here 'Find Contribution'
4. Select two or more option and submit the criteria

Before
----------------------------------------
![before](https://user-images.githubusercontent.com/3735621/84233836-c1f35e80-ab10-11ea-8f07-0a06dbbbf003.gif)

After
----------------------------------------
![after](https://user-images.githubusercontent.com/3735621/84234601-2c58ce80-ab12-11ea-91d3-d9a156cf41fc.gif)


Technical Details
----------------------------------------
This patch introduces two improvement and the fix for the current issue, depends on it:

1. I have moved the ```CRM_Core_BAO_CustomValue::fixCustomFieldValue``` inside ```CRM_Contact_BAO_Query::convertFormValues(...)``` and its safe for two reason: 

-  This latter fn is been accessed by both API and Search Forms to format the parameters in query format. For customfields, when it is used in API parameter, its already in OK (Operator in Key) format thus the CRM_Core_BAO_CustomValue::fixCustomFieldValue fn bypass for value for formatting in [here](https://github.com/civicrm/civicrm-core/blob/master/CRM/Core/BAO/CustomValue.php#L168) 
- As you can see in the patch, fixCustomFieldValue fn is executed separately on all Search forms in order to format the customfield's value. The reason, why I have moved the fn and won't cause any unintended regression. In addition it gives more authority to CRM_Contact_BAO_Query::convertFormValues to now format the customfield filters too. 

2. Added form validation to prevent entering comma value in custom field form.


Comments
----------------------------------------
ping @eileenmcnaughton @seamuslee001 @JoeMurray @lcdservices 