### PR TITLE
[REF] Add in upgrade step to populate missing contact_type.name field

### DIFF
--- a/CRM/Upgrade/Incremental/php/FiveTwentyEight.php
+++ b/CRM/Upgrade/Incremental/php/FiveTwentyEight.php
@@ -69,4 +69,30 @@ class CRM_Upgrade_Incremental_php_FiveTwentyEight extends CRM_Upgrade_Incrementa
   //   return TRUE;
   // }
 
+  /**
+   * Upgrade function.
+   *
+   * @param string $rev
+   */
+  public function upgrade_5_28_alpha1($rev) {
+    $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
+    $this->addTask('Populate missing Contact Type name fields', 'populateMissingContactTypeName');
+  }
+
+  public static function populateMissingContactTypeName() {
+    $contactTypes = \Civi\Api4\ContactType::get()
+      ->setCheckPermissions(FALSE)
+      ->execute();
+    foreach ($contactTypes as $contactType) {
+      if (empty($contactType['name'])) {
+        \Civi\Api4\ContactType::update()
+          ->addWhere('id', '=', $contactType['id'])
+          ->addValue('name', ucfirst(CRM_Utils_String::munge($contactType['label'])))
+          ->setCheckPermissions(FALSE)
+          ->execute();
+      }
+    }
+    return TRUE;
+  }
+
 }

--- a/CRM/Upgrade/Incremental/sql/5.28.alpha1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.28.alpha1.mysql.tpl
@@ -5,4 +5,8 @@ ALTER TABLE `civicrm_activity` CHANGE `activity_date_time` `activity_date_time` 
 ALTER TABLE `civicrm_activity` CHANGE `created_date` `created_date` timestamp NULL  DEFAULT CURRENT_TIMESTAMP COMMENT 'When was the activity was created.';
 
 -- https://github.com/civicrm/civicrm-core/pull/17548
-ALTER table civicrm_contact_type modify name varchar(64) not null comment 'Internal name of Contact Type (or Subtype).';
+ALTER TABLE civicrm_contact_type CHANGE name  name varchar(64) not null comment 'Internal name of Contact Type (or Subtype).';
+ALTER TABLE civicrm_contact_type CHANGE is_active is_active tinyint DEFAULT 1  COMMENT 'Is this entry active?';
+ALTER TABLE civicrm_contact_type CHANGE is_reserved is_reserved tinyint DEFAULT 0  COMMENT 'Is this contact type a predefined system type';
+UPDATE civicrm_contact_type SET is_active = 1 WHERE is_active IS NULL;
+UPDATE civicrm_contact_type SET is_reserved = 0 WHERE is_reserved IS NULL;

--- a/tests/phpunit/CRM/Upgrade/Incremental/BaseTest.php
+++ b/tests/phpunit/CRM/Upgrade/Incremental/BaseTest.php
@@ -673,4 +673,12 @@ class CRM_Upgrade_Incremental_BaseTest extends CiviUnitTestCase {
     $this->assertEquals('1991-11-01 00:00:00', $formValues['receive_date_from']);
   }
 
+  public function testUpdateContactTypeNameField() {
+    CRM_Core_DAO::executeQuery("INSERT INTO civicrm_contact_type (name,label,parent_id, is_active) VALUES ('', 'Test Contact Type', 1, 1)");
+    CRM_Upgrade_Incremental_php_FiveTwentyEight::populateMissingContactTypeName();
+    $contactType = $this->callAPISuccess('ContactType', 'getsingle', ['label' => 'Test Contact Type']);
+    $this->assertNotEmpty($contactType['name']);
+    $this->callAPISuccess('ContactType', 'delete', ['id' => $contactType['id']]);
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
As picked up by @aydun there was no fixing up of hte current name column data when it was missing as requested by @totten in https://github.com/civicrm/civicrm-core/pull/17548/files

Before
----------------------------------------
No populating of the name column if empty

After
----------------------------------------
Upgrade script with test

ping @eileenmcnaughton 