### PR TITLE
dev/core#1809 - Add start/end adjustment columns to membership status…

### DIFF
--- a/CRM/Member/Page/MembershipStatus.php
+++ b/CRM/Member/Page/MembershipStatus.php
@@ -114,11 +114,24 @@ class CRM_Member_Page_MembershipStatus extends CRM_Core_Page_Basic {
           $dao->id
         );
       }
-      if ($startEvent = CRM_Utils_Array::value('start_event', $membershipStatus[$dao->id])) {
+      $startEvent = $membershipStatus[$dao->id]['start_event'] ?? NULL;
+      $endEvent = $membershipStatus[$dao->id]['end_event'] ?? NULL;
+      $startEventUnit = $membershipStatus[$dao->id]['start_event_adjust_unit'] ?? NULL;
+      $endEventUnit = $membershipStatus[$dao->id]['end_event_adjust_unit'] ?? NULL;
+      $startEventInterval = $membershipStatus[$dao->id]['start_event_adjust_interval'] ?? NULL;
+      $endEventInterval = $membershipStatus[$dao->id]['end_event_adjust_interval'] ?? NULL;
+
+      if ($startEvent) {
         $membershipStatus[$dao->id]['start_event'] = ($startEvent == 'join_date') ? 'member since' : str_replace("_", " ", $startEvent);
       }
-      if ($endEvent = CRM_Utils_Array::value('end_event', $membershipStatus[$dao->id])) {
+      if ($endEvent) {
         $membershipStatus[$dao->id]['end_event'] = ($endEvent == 'join_date') ? 'member since' : str_replace("_", " ", $endEvent);
+      }
+      if ($startEventUnit && $startEventInterval) {
+        $membershipStatus[$dao->id]['start_event_adjust_unit_interval'] = "{$startEventInterval} {$startEventUnit}";
+      }
+      if ($endEventUnit && $endEventInterval) {
+        $membershipStatus[$dao->id]['end_event_adjust_interval'] = "{$endEventInterval} {$endEventUnit}";
       }
     }
     // Add order changing widget to selector

--- a/templates/CRM/Member/Page/MembershipStatus.tpl
+++ b/templates/CRM/Member/Page/MembershipStatus.tpl
@@ -28,7 +28,9 @@
         <thead class="sticky">
             <th>{ts}Status{/ts}</th>
             <th>{ts}Start Event{/ts}</th>
+            <th>{ts}Start Adjustment{/ts}</th>
             <th>{ts}End Event{/ts}</th>
+            <th>{ts}End Adjustment{/ts}</th>
             <th>{ts}Member{/ts}</th>
             <th>{ts}Admin{/ts}</th>
             <th>{ts}Order{/ts}</th>
@@ -38,8 +40,10 @@
         {foreach from=$rows item=row}
         <tr id="membership_status-{$row.id}" class="crm-entity {cycle values="odd-row,even-row"} {$row.class} {if NOT $row.is_active} disabled{/if} crmf">
           <td class="crmf-label crm-editable" >{$row.label}</td>
-          <td class="crmf-start_event crm-editable" data-type="select" data-empty-option="{ts}- none -{/ts}">{$row.start_event}</td>
-          <td class="crmf-end_event crm-editable" data-type="select" data-empty-option="{ts}- none -{/ts}">{$row.end_event}</td>
+          <td class="nowrap crmf-start_event crm-editable" data-type="select" data-empty-option="{ts}- none -{/ts}">{$row.start_event}</td>
+          <td class="nowrap crmf-start_event_adjust_unit_interval">{$row.start_event_adjust_unit_interval}</td>
+          <td class="nowrap crmf-end_event crm-editable" data-type="select" data-empty-option="{ts}- none -{/ts}">{$row.end_event}</td>
+          <td class="nowrap crmf-end_event_adjust_interval">{$row.end_event_adjust_interval}</td>
           <td class="crmf-is_current_member crm-editable" data-type="boolean">{if $row.is_current_member eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
           <td class="crmf-is_admin crm-editable" data-type="boolean">{if $row.is_admin eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
           <td class="nowrap crmf-weight">{$row.weight}</td>


### PR DESCRIPTION
… page

Overview
----------------------------------------
Display start/end adjustment on membership status page

Before
----------------------------------------
No start and end adjustment displayed on the table. Hard to identify at a glance whether or not the start/end of these periods is continuous.

![image](https://user-images.githubusercontent.com/5929648/84265910-4362e500-ab41-11ea-9128-b63e20d0fe06.png)

After
----------------------------------------
Start and End Adjustment column added to the page.

![image](https://user-images.githubusercontent.com/5929648/84265923-4b228980-ab41-11ea-8945-c495b6c5b59d.png)


Comments
----------------------------------------
Gitlab - https://lab.civicrm.org/dev/core/-/issues/1809