### PR TITLE
[REF] Replace incorrect usages of array_key_exists when the variable …

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -175,7 +175,7 @@ class CRM_Contact_BAO_Contact extends CRM_Contact_DAO_Contact {
     // Since hash was required, make sure we have a 0 value for it (CRM-1063).
     // @todo - does this mean we can remove this block?
     // Fixed in 1.5 by making hash optional, only do this in create mode, not update.
-    if ((!array_key_exists('hash', $contact) || !$contact->hash) && !$contact->id) {
+    if ((!isset($contact->hash) || !$contact->hash) && !$contact->id) {
       $allNull = FALSE;
       $contact->hash = md5(uniqid(rand(), TRUE));
     }

--- a/CRM/Core/PseudoConstant.php
+++ b/CRM/Core/PseudoConstant.php
@@ -1551,7 +1551,7 @@ WHERE  id = %1
     $output = [];
     $query = "$select $from";
     if ($wheres) {
-      $query .= " WHERE " . implode($wheres, ' AND ');
+      $query .= " WHERE " . implode(' AND ', $wheres);
     }
     $query .= ' ' . $order;
     $dao = CRM_Core_DAO::executeQuery($query, $queryParams);

--- a/api/v3/Membership.php
+++ b/api/v3/Membership.php
@@ -135,7 +135,7 @@ function civicrm_api3_membership_create($params) {
   // @todo stop passing $ids (membership and userId may be set above)
   $membershipBAO = CRM_Member_BAO_Membership::create($params, $ids);
 
-  if (array_key_exists('is_error', $membershipBAO)) {
+  if (property_exists($membershipBAO, 'is_error')) {
     // In case of no valid status for given dates, $membershipBAO
     // is going to contain 'is_error' => "Error Message"
     return civicrm_api3_create_error(ts('The membership can not be saved, no valid membership status for given dates'));

--- a/api/v3/utils.php
+++ b/api/v3/utils.php
@@ -990,7 +990,7 @@ function _civicrm_api3_dao_to_array($dao, $params = NULL, $uniqueFields = TRUE, 
   while ($dao->fetch()) {
     $tmp = [];
     foreach ($fields as $key) {
-      if (array_key_exists($key, $dao)) {
+      if (property_exists($dao, $key)) {
         // not sure on that one
         if ($dao->$key !== NULL) {
           $tmp[$key] = $dao->$key;
@@ -1047,8 +1047,8 @@ function _civicrm_api3_object_to_array(&$dao, &$values, $uniqueFields = FALSE) {
 
   $fields = _civicrm_api3_build_fields_array($dao, $uniqueFields);
   foreach ($fields as $key => $value) {
-    if (array_key_exists($key, $dao)) {
-      $values[$key] = $dao->$key;
+    if (property_exists($dao, $key)) {
+      $values[$key] = $dao->$key ?? NULL;
     }
   }
 }


### PR DESCRIPTION
…is not an array with property_exists and also fix the parameter order for an implode statement

Overview
----------------------------------------
In PHP7.4 there has been a crackdown on where using array_key_exists is actually on an object not an array so I have swapped these out for property_exists and also fixed the paraemeter order on an implode which now if you don't pass the parameters in the correct order it puts out a deprecation notice

ping @eileenmcnaughton @colemanw 