### PR TITLE
[REF] Using {} to access string or array offsets has been deprecated …

### DIFF
--- a/CRM/Mailing/BAO/MailingJob.php
+++ b/CRM/Mailing/BAO/MailingJob.php
@@ -781,7 +781,7 @@ VALUES (%1, %2, %3, %4, %5, %6, %7)
     }
 
     // Register 5xx SMTP response code (permanent failure) as bounce.
-    if (isset($code{0}) && $code{0} === '5') {
+    if (isset($code[0]) && $code[0] === '5') {
       return FALSE;
     }
 

--- a/CRM/Utils/SQL/Insert.php
+++ b/CRM/Utils/SQL/Insert.php
@@ -67,7 +67,7 @@ class CRM_Utils_SQL_Insert {
         $value = NULL;
       }
       // Skip '_foobar' and '{\u00}*_options' and 'N'.
-      if (preg_match('/[a-zA-Z]/', $key{0}) && $key !== 'N') {
+      if (preg_match('/[a-zA-Z]/', $key[0]) && $key !== 'N') {
         $row[$key] = $value;
       }
     }

--- a/Civi/Core/Resolver.php
+++ b/Civi/Core/Resolver.php
@@ -95,7 +95,7 @@ class Resolver {
       // Callback: Constant value.
       return new ResolverConstantCallback((int) $id);
     }
-    elseif ($id{0} >= 'A' && $id{0} <= 'Z') {
+    elseif ($id[0] >= 'A' && $id[0] <= 'Z') {
       // Object: New/default instance.
       return new $id();
     }

--- a/ext/sequentialcreditnotes/sequentialcreditnotes.civix.php
+++ b/ext/sequentialcreditnotes/sequentialcreditnotes.civix.php
@@ -244,7 +244,7 @@ function _sequentialcreditnotes_civix_find_files($dir, $pattern) {
     if ($dh = opendir($subdir)) {
       while (FALSE !== ($entry = readdir($dh))) {
         $path = $subdir . DIRECTORY_SEPARATOR . $entry;
-        if ($entry{0} == '.') {
+        if ($entry[0] == '.') {
         }
         elseif (is_dir($path)) {
           $todos[] = $path;


### PR DESCRIPTION
…in PHP7.4

Overview
----------------------------------------
As per https://www.php.net/manual/en/migration74.deprecated.php using {} on array or string offesets has been deprecated in PHP7.4 I have opened a PR https://github.com/totten/civix/pull/177 to address the civix template matter

ping @eileenmcnaughton 