### PR TITLE
[REF] Using ternary operation without nesting is deprecated and also …

### DIFF
--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -1469,7 +1469,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
       $options = $info['values'];
     }
     if (!array_key_exists('placeholder', $props)) {
-      $props['placeholder'] = $required ? ts('- select -') : CRM_Utils_Array::value('context', $props) == 'search' ? ts('- any -') : ts('- none -');
+      $props['placeholder'] = $required ? ts('- select -') : (CRM_Utils_Array::value('context', $props) == 'search' ? ts('- any -') : ts('- none -'));
     }
     // Handle custom field
     if (strpos($name, 'custom_') === 0 && is_numeric($name[7])) {

--- a/tests/phpunit/CRM/Activity/BAO/ActivityTest.php
+++ b/tests/phpunit/CRM/Activity/BAO/ActivityTest.php
@@ -1613,6 +1613,7 @@ $text
   protected function setShowCaseActivitiesInCore(bool $val) {
     Civi::settings()->set('civicaseShowCaseActivities', $val ? 1 : 0);
     CRM_Core_Component::getEnabledComponents();
+    Civi::$statics['CRM_Core_Component']['info']['CiviCase'] = new CRM_Case_Info('CiviCase', 'CRM_Case', 7);
     Civi::$statics['CRM_Core_Component']['info']['CiviCase']->info['showActivitiesInCore'] = $val;
   }
 


### PR DESCRIPTION
…using methods and properly instanciate the CiviCase Info object in test

Overview
----------------------------------------
Using nested ternary operators without explicit parenthesies has been deprecated in PHP 7.4 https://www.php.net/manual/en/migration74.deprecated.php

ping @eileenmcnaughton 