### PR TITLE
APIv4 - Skip empty leaves in WHERE clause

### DIFF
--- a/Civi/Api4/Query/Api4SelectQuery.php
+++ b/Civi/Api4/Query/Api4SelectQuery.php
@@ -199,7 +199,10 @@ class Api4SelectQuery extends SelectQuery {
    */
   protected function buildWhereClause() {
     foreach ($this->where as $clause) {
-      $this->query->where($this->treeWalkClauses($clause, 'WHERE'));
+      $sql = $this->treeWalkClauses($clause, 'WHERE');
+      if ($sql) {
+        $this->query->where($sql);
+      }
     }
   }
 
@@ -270,6 +273,10 @@ class Api4SelectQuery extends SelectQuery {
    * @uses composeClause() to generate the SQL etc.
    */
   protected function treeWalkClauses($clause, $type) {
+    // Skip empty leaf.
+    if (in_array($clause[0], ['AND', 'OR', 'NOT']) && empty($clause[1])) {
+      return '';
+    }
     switch ($clause[0]) {
       case 'OR':
       case 'AND':


### PR DESCRIPTION
Overview
----------------------------------------
Fixes an annoying problem with search builder where the api gives a sql error while building your where clause.

Before
----------------------------------------
Empty AND/OR/NOT branches in the WHERE clause generate a sql syntax error: `WHERE (AND ())`

After
----------------------------------------
The solution is to skip empty leaves, treating them as WIP.
