### PR TITLE
dev/core#1670 copy custom fields from master to shared address

### DIFF
--- a/CRM/Core/BAO/Address.php
+++ b/CRM/Core/BAO/Address.php
@@ -157,25 +157,15 @@ class CRM_Core_BAO_Address extends CRM_Core_DAO_Address {
       self::fixSharedAddress($params);
     }
 
-    if (empty($params['id']) && isset($params['master_id']) && !CRM_Utils_System::isNull($params['master_id'])) {
-      // copy from master to ensure we have custom fields
-      // but keep all params data that might have been updated above
-      $fieldsFix = [
-        'replace' => $params,
-      ];
-      $address = CRM_Core_DAO::copyGeneric(
-        'CRM_Core_DAO_Address',
-        ['id' => $params['master_id']],
-        NULL,
-        $fieldsFix
-      );
-    }
-    else {
-      $address->copyValues($params);
-      $address->save();
-    }
+    $address->copyValues($params);
+    $address->save();
 
     if ($address->id) {
+      // first get custom field from master address if any
+      if (isset($params['master_id']) && !CRM_Utils_System::isNull($params['master_id'])) {
+        $address->copyCustomFields($params['master_id'], $address->id);
+      }
+
       if (isset($params['custom'])) {
         $addressCustom = $params['custom'];
       }

--- a/CRM/Core/BAO/Address.php
+++ b/CRM/Core/BAO/Address.php
@@ -163,8 +163,9 @@ class CRM_Core_BAO_Address extends CRM_Core_DAO_Address {
       $fieldsFix = [
         'replace' => $params,
       ];
-      $address = CRM_Core_DAO::copyGeneric('CRM_Core_DAO_Address', [
-        'id' => $params['master_id']],
+      $address = CRM_Core_DAO::copyGeneric(
+        'CRM_Core_DAO_Address',
+        ['id' => $params['master_id']],
         NULL,
         $fieldsFix
       );

--- a/tests/phpunit/CRM/Core/BAO/AddressTest.php
+++ b/tests/phpunit/CRM/Core/BAO/AddressTest.php
@@ -653,5 +653,4 @@ class CRM_Core_BAO_AddressTest extends CiviUnitTestCase {
 
   }
 
-
 }

--- a/tests/phpunit/CRM/Core/BAO/AddressTest.php
+++ b/tests/phpunit/CRM/Core/BAO/AddressTest.php
@@ -31,6 +31,8 @@
  */
 class CRM_Core_BAO_AddressTest extends CiviUnitTestCase {
 
+  use CRMTraits_Custom_CustomDataTrait;
+
   public function setUp() {
     parent::setUp();
 
@@ -602,5 +604,54 @@ class CRM_Core_BAO_AddressTest extends CiviUnitTestCase {
     // CRM-21214 - AdressA shouldn't be master of itself.
     $this->assertEmpty($updatedAddressA->master_id);
   }
+
+  /**
+   * dev/core#1670 - Ensure that the custom fields on adresses are copied
+   * to inherited address
+   * 1. test the creation of the shared address with custom field
+   * 2. test the update of the custom field in the master
+   */
+  public function testSharedAddressCustomField() {
+
+    $this->createCustomGroupWithFieldOfType(['extends' => 'Address'], 'text');
+    $customField = $this->getCustomFieldName('text');
+
+    $contactIdA = $this->individualCreate([], 0);
+    $contactIdB = $this->individualCreate([], 1);
+
+    $addressParamsA = [
+      'street_address' => '123 Fake St.',
+      'location_type_id' => '1',
+      'is_primary' => '1',
+      'contact_id' => $contactIdA,
+      $customField => 'this is a custom text field',
+    ];
+
+    $addAddressA = CRM_Core_BAO_Address::add($addressParamsA, FALSE);
+
+    // without having the custom field, we should still copy the values from master
+    $addressParamsB = [
+      'street_address' => '123 Fake St.',
+      'location_type_id' => '1',
+      'is_primary' => '1',
+      'master_id' => $addAddressA->id,
+      'contact_id' => $contactIdB,
+    ];
+    $addAddressB = CRM_Core_BAO_Address::add($addressParamsB, FALSE);
+
+    // 1. check if the custom fields values have been copied from master to shared address
+    $address = $this->callAPISuccessGetSingle('Address', ['id' => $addAddressB->id, 'return' => $this->getCustomFieldName('text')]);
+    $this->assertEquals($addressParamsA[$customField], $address[$customField]);
+
+    // 2. now, we update addressA custom field to see if it goes into addressB
+    $addressParamsA['id'] = $addAddressA->id;
+    $addressParamsA[$customField] = 'updated custom text field';
+    $addAddressA = CRM_Core_BAO_Address::add($addressParamsA, FALSE);
+
+    $address = $this->callAPISuccessGetSingle('Address', ['id' => $addAddressB->id, 'return' => $this->getCustomFieldName('text')]);
+    $this->assertEquals($addressParamsA[$customField], $address[$customField]);
+
+  }
+
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Shared address custom fields are not copied from master. The contact summary is correct because it is taking the values from the master. However, custom fields values are empty for shared address on reports and exports.

https://lab.civicrm.org/dev/core/-/issues/1670

Before
----------------------------------------
The custom fields on address are not copied from master to shared addresses in the database.

After
----------------------------------------
The custom fields on address are copied from master to shared addresses.

Technical Details
----------------------------------------
Eileen has suggested using DAO CopyGeneric which I did as much as possible.
However, it is only applicable for creation, not for update.
It might be cleaner to simply use dao copyCustomFields in both create and update instead.

I've added some unit testing which are failing without the patch and pass correctly after that.