### PR TITLE
Fix fatal error regression in master

### DIFF
--- a/CRM/Contribute/Form/UpdateBilling.php
+++ b/CRM/Contribute/Form/UpdateBilling.php
@@ -204,7 +204,8 @@ class CRM_Contribute_Form_UpdateBilling extends CRM_Contribute_Form_Contribution
     $processorParams['year'] = CRM_Core_Payment_Form::getCreditCardExpirationYear($processorParams);
     $processorParams['subscriptionId'] = $this->getSubscriptionDetails()->processor_id;
     $processorParams['amount'] = $this->_subscriptionDetails->amount;
-    $updateSubscription = $this->_paymentProcessor['object']->updateSubscriptionBillingInfo('', $processorParams);
+    $message = '';
+    $updateSubscription = $this->_paymentProcessor['object']->updateSubscriptionBillingInfo($message, $processorParams);
     if (is_a($updateSubscription, 'CRM_Core_Error')) {
       CRM_Core_Error::displaySessionError($updateSubscription);
     }


### PR DESCRIPTION


Overview
----------------------------------------
Fatal from this line due to pass by reference

https://github.com/civicrm/civicrm-core/pull/16514/files#diff-a8611c9a226a40b585001082b38467b0R207

Before
----------------------------------------
Non-var passed as reference

After
----------------------------------------
var declared

Technical Details
----------------------------------------


Comments
----------------------------------------
@mattwire 