### PR TITLE
[REF] Fix unit test failures on MySQL 5.6 due to Custom Field table being created without Dynamic Row Format

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -1631,6 +1631,12 @@ SELECT $columnName
       ],
     ];
 
+    // If on MySQL 5.6 include ROW_FORMAT=DYNAMIC to fix unit tests
+    $databaseVersion = CRM_Utils_SQL::getDatabaseVersion();
+    if (version_compare($databaseVersion, '5.7', '<') && version_compare($databaseVersion, '5.6', '>=')) {
+      $table['attributes'] = $table['attributes'] . ' ROW_FORMAT=DYNAMIC';
+    }
+
     if (!$params['is_multiple']) {
       $table['indexes'] = [
         [


### PR DESCRIPTION
Overview
----------------------------------------
This fixes some test failures when running on MySQL 5.6 when combined with https://github.com/amp-cli/amp/pull/64 

Before
----------------------------------------
Tests fail because custom data table can't be altered due to key length error

After
----------------------------------------
Tests pass

ping @eileenmcnaughton @totten 