### PR TITLE
Improve PropertyBag handling of offsetGet and custom properties; add …

### DIFF
--- a/Civi/Payment/PropertyBag.php
+++ b/Civi/Payment/PropertyBag.php
@@ -130,6 +130,10 @@ class PropertyBag implements \ArrayAccess {
         return $this->getCustomProperty($offset, 'default');
       }
       catch (BadMethodCallException $e) {
+        \CRM_Core_Error::deprecatedFunctionWarning(
+          "Use \$propertyBag->setCustomProperty('$offset', \$value) and then \$propertyBag->getCustomProperty('$offset') instead.",
+          "Accessing a not-set custom property via array access is deprecated. We're returning NULL for now but you should update your code."
+        );
         $this->legacyWarning($e->getMessage() . " calling getCustomProperty on a non-set property will result in a BadMethodCallException exception, but for your legacy use we have returned NULL. Please update your code.");
         return NULL;
       }

--- a/Civi/Payment/PropertyBag.php
+++ b/Civi/Payment/PropertyBag.php
@@ -109,7 +109,9 @@ class PropertyBag implements \ArrayAccess {
    */
   public function offsetExists ($offset): bool {
     $prop = $this->handleLegacyPropNames($offset, TRUE);
-    return $prop && isset($this->props['default'][$prop]);
+    // If there's no prop, assume it's a custom property.
+    $prop = $prop ?? $offset;
+    return array_key_exists($prop, $this->props['default']);
   }
 
   /**
@@ -118,8 +120,11 @@ class PropertyBag implements \ArrayAccess {
    * @param mixed $offset
    * @return mixed
    */
-  public function offsetGet ($offset) {
-    $prop = $this->handleLegacyPropNames($offset);
+  public function offsetGet($offset) {
+    $prop = $this->handleLegacyPropNames($offset, TRUE);
+    // Allow transparent access to custom properties.
+    // We could issue a deprecation notice here, but we've probably got enough in this code already!
+    $prop = $prop ?? $offset;
     return $this->get($prop, 'default');
   }
 


### PR DESCRIPTION
…more tests

Overview
----------------------------------------

See discussion at https://github.com/civicrm/civicrm-dev-docs/pull/817


Before
----------------------------------------

Use of `empty($propBag['something'])` was iffy if something was a custom property. Also, array access did not work for custom properties.


After
----------------------------------------

Works as expected. See tests.

- `empty()` should now be reliable.
- `$propBag['customFieldThatDoesNotExist']` still throws exception, which is what we want
- `$propBag['customFieldThatWasSet']` now works.

