### PR TITLE
Remove unused paymentInstrumentID from forms and fix regression

### DIFF
--- a/CRM/Contribute/Form/AbstractEditPayment.php
+++ b/CRM/Contribute/Form/AbstractEditPayment.php
@@ -182,13 +182,6 @@ class CRM_Contribute_Form_AbstractEditPayment extends CRM_Contact_Form_Task {
   protected $_formType;
 
   /**
-   * Payment instrument id for the transaction.
-   *
-   * @var int
-   */
-  public $paymentInstrumentID;
-
-  /**
    * Component - event, membership or contribution.
    *
    * @var string

--- a/CRM/Contribute/Form/AdditionalPayment.php
+++ b/CRM/Contribute/Form/AdditionalPayment.php
@@ -184,7 +184,7 @@ class CRM_Contribute_Form_AdditionalPayment extends CRM_Contribute_Form_Abstract
       return;
     }
 
-    CRM_Core_Payment_Form::buildPaymentForm($this, $this->_paymentProcessor, FALSE, TRUE, CRM_Utils_Request::retrieve('payment_instrument_id', 'Integer'));
+    CRM_Core_Payment_Form::buildPaymentForm($this, $this->_paymentProcessor, FALSE, TRUE);
     $this->add('select', 'payment_processor_id', ts('Payment Processor'), $this->_processors, NULL);
 
     $attributes = CRM_Core_DAO::getAttribute('CRM_Financial_DAO_FinancialTrxn');

--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -559,8 +559,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
       $paneNames[ts('Premium Information')] = 'Premium';
     }
 
-    $this->payment_instrument_id = CRM_Utils_Array::value('payment_instrument_id', $defaults, $this->getDefaultPaymentInstrumentId());
-    if (CRM_Core_Payment_Form::buildPaymentForm($this, $this->_paymentProcessor, FALSE, TRUE, $this->payment_instrument_id) == TRUE) {
+    if (CRM_Core_Payment_Form::buildPaymentForm($this, $this->_paymentProcessor, FALSE, TRUE) == TRUE) {
       if (!empty($this->_recurPaymentProcessors)) {
         $buildRecurBlock = TRUE;
         if ($this->_ppID) {

--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -186,16 +186,6 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
   public $isBackOffice = FALSE;
 
   /**
-   * Payment instrument if for the transaction.
-   *
-   * This will generally be drawn from the payment processor and is ignored for
-   * front end forms.
-   *
-   * @var int
-   */
-  public $paymentInstrumentID;
-
-  /**
    * Is the price set quick config.
    * @return bool
    */

--- a/CRM/Core/Payment/ProcessorForm.php
+++ b/CRM/Core/Payment/ProcessorForm.php
@@ -49,9 +49,6 @@ class CRM_Core_Payment_ProcessorForm {
     }
     $form->set('paymentProcessor', $form->_paymentProcessor);
     $form->_paymentObject = System::singleton()->getByProcessor($form->_paymentProcessor);
-    if ($form->paymentInstrumentID) {
-      $form->_paymentObject->setPaymentInstrumentID($form->paymentInstrumentID);
-    }
     $form->_paymentObject->setBackOffice($form->isBackOffice);
     $form->assign('isBackOffice', $form->isBackOffice);
 
@@ -87,8 +84,7 @@ class CRM_Core_Payment_ProcessorForm {
       $form,
       $form->_paymentProcessor,
       CRM_Utils_Request::retrieve('billing_profile_id', 'String'),
-      $form->isBackOffice,
-      $form->paymentInstrumentID
+      $form->isBackOffice
     );
 
     $form->assign_by_ref('paymentProcessor', $form->_paymentProcessor);
@@ -139,7 +135,7 @@ class CRM_Core_Payment_ProcessorForm {
     if (!empty($processorId)) {
       $form->addElement('hidden', 'hidden_processor', 1);
     }
-    CRM_Core_Payment_Form::buildPaymentForm($form, $form->_paymentProcessor, $billing_profile_id, $form->isBackOffice, $form->paymentInstrumentID ?? NULL);
+    CRM_Core_Payment_Form::buildPaymentForm($form, $form->_paymentProcessor, $billing_profile_id, $form->isBackOffice);
   }
 
 }

--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -1746,7 +1746,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
         return FALSE;
       }
 
-      CRM_Core_Payment_Form::buildPaymentForm($form, $form->_paymentProcessor, FALSE, TRUE, self::getDefaultPaymentInstrumentId());
+      CRM_Core_Payment_Form::buildPaymentForm($form, $form->_paymentProcessor, FALSE, TRUE);
       if (!$form->_mode) {
         $form->addElement('checkbox', 'record_contribution', ts('Record Payment?'), NULL,
           ['onclick' => "return showHideByValue('record_contribution','','payment_information','table-row','radio',false);"]
@@ -1766,11 +1766,6 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
 
         $form->add('datepicker', 'receive_date', ts('Received'), [], FALSE, ['time' => TRUE]);
 
-        $form->add('select', 'payment_instrument_id',
-          ts('Payment Method'),
-          ['' => ts('- select -')] + CRM_Contribute_PseudoConstant::paymentInstrument(),
-          FALSE, ['onChange' => "return showHideByValue('payment_instrument_id','4','checkNumber','table-row','select',false);"]
-        );
         // don't show transaction id in batch update mode
         $path = CRM_Utils_System::currentPath();
         $form->assign('showTransactionId', FALSE);

--- a/CRM/Event/Form/Registration.php
+++ b/CRM/Event/Form/Registration.php
@@ -159,16 +159,6 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
   public $isBackOffice = FALSE;
 
   /**
-   * Payment instrument iD for the transaction.
-   *
-   * This will generally be drawn from the payment processor and is ignored for
-   * front end forms.
-   *
-   * @var int
-   */
-  public $paymentInstrumentID;
-
-  /**
    * Set variables up before form is built.
    */
   public function preProcess() {

--- a/CRM/Member/Form.php
+++ b/CRM/Member/Form.php
@@ -212,7 +212,7 @@ class CRM_Member_Form extends CRM_Contribute_Form_AbstractEditPayment {
     $this->assignSalesTaxMetadataToTemplate();
 
     $this->addPaymentProcessorSelect(TRUE, FALSE, TRUE);
-    CRM_Core_Payment_Form::buildPaymentForm($this, $this->_paymentProcessor, FALSE, TRUE, $this->getDefaultPaymentInstrumentId());
+    CRM_Core_Payment_Form::buildPaymentForm($this, $this->_paymentProcessor, FALSE, TRUE);
     $this->assign('recurProcessor', json_encode($this->_recurPaymentProcessors));
     // Build the form for auto renew. This is displayed when in credit card mode or update mode.
     // The reason for showing it in update mode is not that clear.


### PR DESCRIPTION
Overview
----------------------------------------
As identified by https://lab.civicrm.org/extensions/smartdebit/-/issues/2 there is a core regression around the paymentInstrumentID using the default instead of the payment processor.

As pointed out by @eileenmcnaughton (https://github.com/civicrm/civicrm-core/pull/17510) we should be using the payment processor `paymentInstrumentID`. Prior to 5.21 (when propertyBag was introduced) we were because of a bug in `setPaymentInstrumentID()` which ignored the incoming parameter. That was fixed with propertyBag which meant that we started using the default paymentInstrumentID (incorrectly in most cases).
Going through the code I identified that in most cases we were getting a default and assigning it to the form (even supporting `payment_processor_id` as a URL parameter) but then ignoring it when submitting the form. The only time we *do* want it to work is when recording a payment without a payment processor - and that is the only time the instrument select element actually appears on the form and the value is available during postProcess.

Before
----------------------------------------
Default paymentInstrumentID used when it shouldn't be.

After
----------------------------------------
Cleaned up setting of `paymentInstrumentID` and not overriding the payment processor anymore.

Technical Details
----------------------------------------
- `buildPaymentForm()` is only relevant if we have a payment processor. So we should never pass a paymentInstrumentID.
- `$form->paymentInstrumentID` is read but never set. So we can remove it throughout.

Comments
----------------------------------------
