### PR TITLE
Fix broken entities in civicrm/export/standalone

### DIFF
--- a/CRM/Export/Controller/Standalone.php
+++ b/CRM/Export/Controller/Standalone.php
@@ -15,6 +15,25 @@
 class CRM_Export_Controller_Standalone extends CRM_Core_Controller {
 
   /**
+   * Yet another hardcoded list :(
+   *
+   * Very similar to the switch statement in CRM_Export_Form_Select::preProcess
+   * TODO: Make this extensible for extension export pages.
+   *
+   * @var string[]
+   */
+  public static $components = [
+    'Contact' => 'Contact',
+    'Contribution' => 'Contribute',
+    'Membership' => 'Member',
+    'Participant' => 'Event',
+    'Pledge' => 'Pledge',
+    'Case' => 'Case',
+    'Grant' => 'Grant',
+    'Activity' => 'Activity',
+  ];
+
+  /**
    * Class constructor.
    *
    * @param string $title
@@ -42,6 +61,10 @@ class CRM_Export_Controller_Standalone extends CRM_Core_Controller {
       $this->set('cids', implode(',', array_keys($perm['values'])));
     }
 
+    // For the benefit of CRM_Export_Form_Select::getQueryMode()
+    $queryComponent = $entity === 'Contact' ? 'CONTACTS' : strtoupper(self::$components[$entity]);
+    $this->set('component_mode', constant('CRM_Contact_BAO_Query::MODE_' . $queryComponent));
+
     $this->_stateMachine = new CRM_Export_StateMachine_Standalone($this, $action);
 
     // create and instantiate the pages
@@ -49,6 +72,9 @@ class CRM_Export_Controller_Standalone extends CRM_Core_Controller {
 
     // add all the actions
     $this->addActions();
+
+    $dao = CRM_Core_DAO_AllCoreTables::getFullName($entity);
+    CRM_Utils_System::setTitle(ts('Export %1', [1 => $dao::getEntityTitle()]));
   }
 
   /**
@@ -67,7 +93,7 @@ class CRM_Export_Controller_Standalone extends CRM_Core_Controller {
       }
     }
     // Set the "task" selector value to Export
-    $className = 'CRM_' . $this->get('entity') . '_Task';
+    $className = 'CRM_' . self::$components[$this->get('entity')] . '_Task';
     foreach ($className::tasks() as $taskId => $task) {
       $taskForm = (array) $task['class'];
       if ($taskForm[0] == 'CRM_Export_Form_Select') {

--- a/CRM/Export/Form/Select.php
+++ b/CRM/Export/Form/Select.php
@@ -78,6 +78,8 @@ class CRM_Export_Form_Select extends CRM_Core_Form_Task {
     $this->_componentIds = [];
     $this->_componentClause = NULL;
 
+    $formName = NULL;
+
     // we need to determine component export
     $components = ['Contact', 'Contribute', 'Member', 'Event', 'Pledge', 'Case', 'Grant', 'Activity'];
 
@@ -193,7 +195,7 @@ class CRM_Export_Form_Select extends CRM_Core_Form_Task {
     $taskName = $componentTasks[$this->_task];
     $this->assign('taskName', $taskName);
 
-    if ($this->_componentTable) {
+    if ($this->_componentTable && $formName !== 'CRM_Export_StateMachine_Standalone') {
       $query = "
 SELECT count(*)
 FROM   {$this->_componentTable}


### PR DESCRIPTION
Overview
----------------------------------------
Standalone export was broken for several entities, and reporting the count of contacts as zero even though the rest was working.
This fixes the broken entities, missing page titles and broken count.

Before
----------------------------------------
Visiting http://example.com/civicrm/export/standalone?entity=Contact&id=1,2,3,4,5,6 would incorrectly say "0 records selected for export."
Other entities such as "Contribution" were completely broken.

After
----------------------------------------
Visiting http://example.com/civicrm/export/standalone?entity=Contact&id=1,2,3,4,5,6 now correctly says "6 records selected for export."
Entities all seem to be working now.

Notes
-------------------------------------
I really hate the inflexibility of this hardcoded list (need a way for extensions export screens to work with this standalone controller) but the hardcodedness in our export classes is kind of a pre-existing condition.