### PR TITLE
Fix retrieving MySQL version for checking as part of install requirem…

### DIFF
--- a/Civi/Install/Requirements.php
+++ b/Civi/Install/Requirements.php
@@ -307,7 +307,8 @@ class Requirements {
       return $results;
     }
 
-    if (version_compare($info, $min) == -1) {
+    $versionDetails = mysqli_query($conn, 'SELECT version() as version')->fetch_assoc();
+    if (version_compare($versionDetails['version'], $min) == -1) {
       $results['severity'] = $this::REQUIREMENT_ERROR;
       $results['details'] = "MySQL version is {$info}; minimum required is {$min}";
       return $results;


### PR DESCRIPTION
…ents

Overview
----------------------------------------
This fixes a bug that comes on some MariaDB instances where by the version maybe 10.2 but it gets reported via the mysqli_info as 5.5.5-10.2. This is presently happening on our demo sites 
"ERROR: (database) CiviCRM MySQL Version: MySQL version is 5.5.5-10.2.32-MariaDB-10.2.32+maria~stretch; minimum required is 5.6.5" 

Before
----------------------------------------
MySQL DB information doesn't always work correctly for us

After
----------------------------------------
Correct version returned

ping @eileenmcnaughton @mlutfy 