### PR TITLE
Add Unit tests for Authorize.net support for PropertyBags

### DIFF
--- a/tests/phpunit/CRM/Core/Payment/AuthorizeNetTest.php
+++ b/tests/phpunit/CRM/Core/Payment/AuthorizeNetTest.php
@@ -43,14 +43,21 @@ class CRM_Core_Payment_AuthorizeNetTest extends CiviUnitTestCase {
   /**
    * Test doing a one-off payment.
    *
+   * @dataProvider getBooleanDataProvider
+   *
+   * @param bool $usePaymentBag
+   *
    * @throws \Civi\Payment\Exception\PaymentProcessorException
    */
-  public function testSinglePayment() {
+  public function testSinglePayment($usePaymentBag) {
     $this->createMockHandler([$this->getExpectedSinglePaymentResponse()]);
     $this->setUpClientWithHistoryContainer();
     $this->processor->setGuzzleClient($this->getGuzzleClient());
     $params = $this->getBillingParams();
     $params['amount'] = 5.24;
+    if ($usePaymentBag) {
+      $params = PropertyBag::cast($params);
+    }
     $this->processor->doPayment($params);
     $this->assertEquals($this->getExpectedSinglePaymentRequest(), $this->getRequestBodies()[0]);
   }
@@ -77,8 +84,15 @@ class CRM_Core_Payment_AuthorizeNetTest extends CiviUnitTestCase {
    * Create a single post dated payment as a recurring transaction.
    *
    * Test works but not both due to some form of caching going on in the SmartySingleton
+   *
+   * @dataProvider getBooleanDataProvider
+   *
+   * @param bool $usePaymentBag
+   *
+   * @throws \CRM_Core_Exception
+   * @throws \Civi\Payment\Exception\PaymentProcessorException
    */
-  public function testCreateSingleNowDated() {
+  public function testCreateSingleNowDated($usePaymentBag) {
     $this->createMockHandler([$this->getExpectedResponse()]);
     $this->setUpClientWithHistoryContainer();
     $this->processor->setGuzzleClient($this->getGuzzleClient());
@@ -175,7 +189,9 @@ class CRM_Core_Payment_AuthorizeNetTest extends CiviUnitTestCase {
       'contributionTypeID' => $this->_financialTypeId,
       'contributionRecurID' => $recur['id'],
     ]);
-
+    if ($usePaymentBag) {
+      $params = PropertyBag::cast($params);
+    }
     // turn verifySSL off
     Civi::settings()->set('verifySSL', '0');
     $this->processor->doPayment($params);
@@ -201,8 +217,15 @@ class CRM_Core_Payment_AuthorizeNetTest extends CiviUnitTestCase {
 
   /**
    * Create a single post dated payment as a recurring transaction.
+   *
+   * @dataProvider getBooleanDataProvider
+   *
+   * @param $usePaymentBag
+   *
+   * @throws \CRM_Core_Exception
+   * @throws \Civi\Payment\Exception\PaymentProcessorException
    */
-  public function testCreateSinglePostDated() {
+  public function testCreateSinglePostDated($usePaymentBag) {
     $this->createMockHandler([$this->getExpectedResponse()]);
     $this->setUpClientWithHistoryContainer();
     $this->processor->setGuzzleClient($this->getGuzzleClient());
@@ -320,7 +343,9 @@ class CRM_Core_Payment_AuthorizeNetTest extends CiviUnitTestCase {
     // to make a successful call for another trxn, we need to set it to something else.
     $smarty = CRM_Core_Smarty::singleton();
     $smarty->assign('subscriptionType', 'create');
-
+    if ($usePaymentBag) {
+      $params = PropertyBag::cast($params);
+    }
     $this->processor->doPayment($params);
 
     // if subscription was successful, processor_id / subscription-id must not be null
@@ -430,8 +455,14 @@ class CRM_Core_Payment_AuthorizeNetTest extends CiviUnitTestCase {
 
   /**
    * Test the update billing function.
+   *
+   * @dataProvider getBooleanDataProvider
+   *
+   * @param bool $usePaymentBag
+   *
+   * @throws \Civi\Payment\Exception\PaymentProcessorException
    */
-  public function testUpdateBilling() {
+  public function testUpdateBilling($usePaymentBag) {
     $this->setUpClient($this->getExpectedUpdateResponse());
     $params = [
       'qfKey' => '52e3078a34158a80b18d0e3c690c5b9f_2369',
@@ -456,6 +487,9 @@ class CRM_Core_Payment_AuthorizeNetTest extends CiviUnitTestCase {
       'amount' => '6.00',
     ];
     $message = '';
+    if ($usePaymentBag) {
+      $params = PropertyBag::cast($params);
+    }
     $result = $this->processor->updateSubscriptionBillingInfo($message, $params);
     $requests = $this->getRequestBodies();
     $this->assertEquals('I00001: Successful.', $message);
@@ -466,9 +500,13 @@ class CRM_Core_Payment_AuthorizeNetTest extends CiviUnitTestCase {
   /**
    * Test change subscription function.
    *
+   * @dataProvider getBooleanDataProvider
+   *
+   * @param bool $usePaymentBag
+   *
    * @throws \Civi\Payment\Exception\PaymentProcessorException
    */
-  public function testChangeSubscription() {
+  public function testChangeSubscription($usePaymentBag) {
     $this->setUpClient($this->getExpectedUpdateResponse());
     $params = [
       'hidden_custom' => '1',
@@ -486,6 +524,9 @@ class CRM_Core_Payment_AuthorizeNetTest extends CiviUnitTestCase {
       'subscriptionId' => 1234,
     ];
     $message = '';
+    if ($usePaymentBag) {
+      $params = PropertyBag::cast($params);
+    }
     $result = $this->processor->changeSubscriptionAmount($message, $params);
     $requests = $this->getRequestBodies();
     $this->assertEquals('I00001: Successful.', $message);


### PR DESCRIPTION
Overview
----------------------------------------
The PropertyBag is a new Object we introduced to CiviCRM late last year. The goal was that we would be able to pass this object to processors and their existing code would not break, but that they could choose to take advantage of the property bag to access properties in a more predictable way.

At this stage we have not started to pass propertyBag out except to the cancel function - because we are not confident that it will not break existing code. As this test demonstrates the cancel function was the only one that the core Authorize.net implementation could support without changing the code in Authorize.net, as of now.

While we want to model preferred coding practices in core I think before we change the processors we need to make it so that that we did't have to - ie use this test suite to fix up all the places that Authorize.net is not getting what it needs, since we can reasonably assume it is not alone

Before
----------------------------------------
No test cover for an unconverted payment processor coping with the property bag

After
----------------------------------------
Test cover - note this will not pass yet as it highlights that the propertyBag does not support Authorize.net.



Technical Details
----------------------------------------
Note there is a philosophical question blocking this ie

"The Property Bag should support all payment processors"

versus

"The Property Bag is a backdoor way of deprecating processors we don't like"

Authorize.net is a 'we don't like' processor - so this can only work if we agree to support 'processors we don't like' - as a project the Property bag is blocked on this question, and if we decide not to support processors we don't like, then on us figuring out a plan for them.


Comments
----------------------------------------

