### PR TITLE
PropertyBag - add cardNumber to getters

### DIFF
--- a/Civi/Payment/PropertyBag.php
+++ b/Civi/Payment/PropertyBag.php
@@ -38,12 +38,14 @@ class PropertyBag implements \ArrayAccess {
     'billingPostalCode'           => TRUE,
     'billingCounty'               => TRUE,
     'billingCountry'              => TRUE,
+    'cardNumber'                  => TRUE,
     'contactID'                   => TRUE,
     'contact_id'                  => 'contactID',
     'contributionID'              => TRUE,
     'contribution_id'             => 'contributionID',
     'contributionRecurID'         => TRUE,
     'contribution_recur_id'       => 'contributionRecurID',
+    'credit_card_number'          => 'cardNumber',
     'currency'                    => TRUE,
     'currencyID'                  => 'currency',
     'description'                 => TRUE,
@@ -555,6 +557,29 @@ class PropertyBag implements \ArrayAccess {
   }
 
   /**
+   * Get the (generally credit) card number.
+   *
+   * @param string $label
+   *
+   * @return string
+   */
+  public function getCardNumber($label = 'default'): string {
+    return $this->get('cardNumber', $label);
+  }
+
+  /**
+   * @param string $cardNumber
+   * @param string $label
+   *
+   * @return \Civi\Payment\PropertyBag
+   */
+  public function setCardNumber($cardNumber, $label = 'default'): PropertyBag {
+    return $this->set('cardNumber', $label, (string) $cardNumber);
+  }
+
+  /**
+   * @param string $label
+   *
    * @return int
    */
   public function getContactID($label = 'default'): int {
@@ -564,6 +589,8 @@ class PropertyBag implements \ArrayAccess {
   /**
    * @param int $contactID
    * @param string $label
+   *
+   * @return \Civi\Payment\PropertyBag
    */
   public function setContactID($contactID, $label = 'default') {
     // We don't use this because it counts zero as positive: CRM_Utils_Type::validate($contactID, 'Positive');


### PR DESCRIPTION

Overview
----------------------------------------
Adds cardNumber to getters & setters

Before
----------------------------------------
As https://github.com/civicrm/civicrm-core/pull/17594 demonstrates, existing processors crash if passed a settings bag because it doesn't not handle 'credit_card_number'

After
----------------------------------------
Test gets down to the next missing parameter :-)

Technical Details
----------------------------------------
@mattwire @KarinG @artfulrobot my only real question on this one is the data type - ie it could be an integer rather than a string - would that always be true? I think perhaps there is a chance a  js script could swap it out to a token-string  which would be invisible at the form layer so int feels a bit risky.

Also - Omnipay has separate private properties for fields that require security - perhaps if we did that it could be a follow up. I know there was some hope we could just go with the 'bad processor' - don't use card numbers directly approach - but I think it's hard to make the case that that overrules the expectation existing processors should work

Comments
----------------------------------------

