### PR TITLE
dev/financial#131 Give deprecation notice if the payment processor returns an error

### DIFF
--- a/CRM/Core/Payment.php
+++ b/CRM/Core/Payment.php
@@ -1375,6 +1375,7 @@ abstract class CRM_Core_Payment {
       }
     }
     if (is_a($result, 'CRM_Core_Error')) {
+      CRM_Core_Error::deprecatedFunctionWarning('payment processors should throw exceptions rather than return errors');
       throw new PaymentProcessorException(CRM_Core_Error::getMessages($result));
     }
     return $result;


### PR DESCRIPTION
Overview
----------------------------------------
Payment Processors are expected to throw PaymentProcessorExceptions rather than return CRM_Core_Error objects - we have fixed all the core ones & some community ones (IATS) are fixed whereas others have not returned error objects for some time - this should flush out the others

 Deprecation notices will be visible on sites that are in developer mode (which translates to the presence of .git or .svn) and have e-notice settings that surface Deprecated level bugs.

Also note that this will not affect process who implement doPayment (recommended)

Before
----------------------------------------
CRM_Core_Payment silently handles returned errors, 

After
----------------------------------------
CRM_Core_Payment noisily handles returned errors.

Technical Details
----------------------------------------

Comments
----------------------------------------

