### PR TITLE
[REF] Update packages to work with PHP7.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,7 @@
     "symfony/process": "~3.0 || ~4.4",
     "psr/log": "~1.0",
     "symfony/finder": "~3.0 || ~4.4",
-    "tecnickcom/tcpdf" : "6.2.*",
+    "tecnickcom/tcpdf" : "6.3.*",
     "totten/ca-config": "~17.05",
     "zetacomponents/base": "1.9.*",
     "zetacomponents/mail": "1.9.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f547e4d1ac65fa8044d302f46a7e7267",
+    "content-hash": "3c6d377d0dfd5ce11b0a96af56344181",
     "packages": [
         {
             "name": "adrienrn/php-mimetyper",
@@ -2587,16 +2587,16 @@
         },
         {
             "name": "tecnickcom/tcpdf",
-            "version": "6.2.26",
+            "version": "6.3.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/tecnickcom/TCPDF.git",
-                "reference": "367241059ca166e3a76490f4448c284e0a161f15"
+                "reference": "19a535eaa7fb1c1cac499109deeb1a7a201b4549"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/tecnickcom/TCPDF/zipball/367241059ca166e3a76490f4448c284e0a161f15",
-                "reference": "367241059ca166e3a76490f4448c284e0a161f15",
+                "url": "https://api.github.com/repos/tecnickcom/TCPDF/zipball/19a535eaa7fb1c1cac499109deeb1a7a201b4549",
+                "reference": "19a535eaa7fb1c1cac499109deeb1a7a201b4549",
                 "shasum": ""
             },
             "require": {
@@ -2625,7 +2625,7 @@
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "LGPL-3.0"
+                "LGPL-3.0-only"
             ],
             "authors": [
                 {
@@ -2645,7 +2645,7 @@
                 "pdf417",
                 "qrcode"
             ],
-            "time": "2018-10-16T17:24:05+00:00"
+            "time": "2020-02-14T14:20:12+00:00"
         },
         {
             "name": "togos/gitignore",
@@ -2967,22 +2967,23 @@
         },
         {
             "name": "zetacomponents/mail",
-            "version": "1.9.1",
+            "version": "1.9.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zetacomponents/Mail.git",
-                "reference": "4dc71ccbcc8b67951a2efe47d3fcc2aeaa7f530d"
+                "reference": "c55267564d78724d4c25188fc653fef0da4c920a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zetacomponents/Mail/zipball/4dc71ccbcc8b67951a2efe47d3fcc2aeaa7f530d",
-                "reference": "4dc71ccbcc8b67951a2efe47d3fcc2aeaa7f530d",
+                "url": "https://api.github.com/repos/zetacomponents/Mail/zipball/c55267564d78724d4c25188fc653fef0da4c920a",
+                "reference": "c55267564d78724d4c25188fc653fef0da4c920a",
                 "shasum": ""
             },
             "require": {
                 "zetacomponents/base": "~1.8"
             },
             "require-dev": {
+                "phpunit/phpunit": "~7.5",
                 "zetacomponents/unit-test": "*"
             },
             "type": "library",
@@ -3043,7 +3044,7 @@
             ],
             "description": "The component allows you construct and/or parse Mail messages conforming to  the mail standard. It has support for attachments, multipart messages and HTML  mail. It also interfaces with SMTP to send mail or IMAP, POP3 or mbox to  retrieve e-mail.",
             "homepage": "https://github.com/zetacomponents",
-            "time": "2020-01-17T11:18:01+00:00"
+            "time": "2020-06-13T12:38:26+00:00"
         }
     ],
     "packages-dev": [],


### PR DESCRIPTION
Overview
----------------------------------------
This updates 2 packages found via unit tests to have issues with PHP7.4 to versions or adds patches to make them work on PHP7.4

Before
----------------------------------------
Packages have issues in PHP7.4

After
----------------------------------------
Packages work on PHP7.4

ping @eileenmcnaughton 

Tests affected are https://test.civicrm.org/job/CiviCRM-Core-Edge/CIVIVER=master,label=test-3/515/testReport/junit/(root)/CRM_Utils_Mail_EmailProcessorTest/testBounceProcessingInvalidCharacter/ and also the `CRM_Core_Page_HookTest`