### PR TITLE
[REF] Fix some additional issues where curly braces were being used t…

### DIFF
--- a/CRM/Custom/Form/Field.php
+++ b/CRM/Custom/Form/Field.php
@@ -618,7 +618,7 @@ class CRM_Custom_Form_Field extends CRM_Core_Form {
     //checks the given custom field name doesnot start with digit
     if (!empty($title)) {
       // gives the ascii value
-      $asciiValue = ord($title{0});
+      $asciiValue = ord($title[0]);
       if ($asciiValue >= 48 && $asciiValue <= 57) {
         $errors['label'] = ts("Name cannot not start with a digit");
       }

--- a/CRM/Utils/Number.php
+++ b/CRM/Utils/Number.php
@@ -75,7 +75,7 @@ class CRM_Utils_Number {
    */
   public static function formatUnitSize($size, $checkForPostMax = FALSE) {
     if ($size) {
-      $last = strtolower($size{strlen($size) - 1});
+      $last = strtolower($size[strlen($size) - 1]);
       $size = (int) $size;
       switch ($last) {
         // The 'G' modifier is available since PHP 5.1.0

--- a/Civi/Core/Themes.php
+++ b/Civi/Core/Themes.php
@@ -135,7 +135,7 @@ class Themes {
   public function getAvailable() {
     $result = [];
     foreach ($this->getAll() as $key => $theme) {
-      if ($key{0} !== '_') {
+      if ($key[0] !== '_') {
         $result[$key] = $theme['title'];
       }
     }


### PR DESCRIPTION
…o access string or array offsets

Overview
----------------------------------------
This fixes another couple of issues with {} being used to access array/string offsets

Before
----------------------------------------
Code having issues on PHP7.4

After
----------------------------------------
Code works on PHP7.4 

ping @eileenmcnaughton 

Tests that demonstrate the issues https://test.civicrm.org/job/CiviCRM-Core-Edge/513/CIVIVER=master,label=test-3/testReport/(root)/api_v3_ACLPermissionTest/testContactGetNoResultsHook_with_data_set__0/  https://test.civicrm.org/job/CiviCRM-Core-Edge/513/CIVIVER=master,label=test-3/testReport/(root)/api_v3_CustomFieldTest/testCustomFieldCreateAllAvailableFormInputs/ and `CRM_Core_Page_HookTest`