### PR TITLE
[REF] Fix issue with using array access tools on NULL values

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -3288,7 +3288,7 @@ WHERE  $smartGroupClause
 
     $etTable = "`civicrm_entity_tag-" . uniqid() . "`";
 
-    if ($useAllTagTypes[2]) {
+    if (!empty($useAllTagTypes[2])) {
       $this->_tables[$etTable] = $this->_whereTables[$etTable]
         = " LEFT JOIN civicrm_entity_tag {$etTable} ON ( {$etTable}.entity_id = contact_a.id  AND {$etTable}.entity_table = 'civicrm_contact') ";
 
@@ -4237,7 +4237,7 @@ WHERE  $smartGroupClause
     // Note we do not currently set mySql to handle timezones, so doing this the old-fashioned way
     $today = date('Ymd');
     //check for active, inactive and all relation status
-    if ($relStatus[2] == 0) {
+    if (empty($relStatus[2])) {
       $where[$grouping][] = "(
 civicrm_relationship.is_active = 1 AND
 ( civicrm_relationship.end_date IS NULL OR civicrm_relationship.end_date >= {$today} ) AND

--- a/CRM/Contact/Page/AJAX.php
+++ b/CRM/Contact/Page/AJAX.php
@@ -770,7 +770,7 @@ LIMIT {$offset}, {$rowCount}
   public static function getSearchOptionsFromRequest() {
     $searchParams = [];
     $searchData = $_REQUEST['search'] ?? NULL;
-    $searchData['value'] = CRM_Utils_Type::escape($searchData['value'], 'String');
+    $searchData['value'] = CRM_Utils_Type::escape($searchData['value'] ?? NULL, 'String');
     $selectorElements = [
       'is_selected',
       'is_selected_input',

--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -1886,7 +1886,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
       // contribution amount to be null, so that it will not show
       // contribution amount same as membership amount.
       //@todo - merge with section above
-      if ($this->_membershipBlock['is_separate_payment']
+      if (!empty($this->_membershipBlock['is_separate_payment'])
         && !empty($this->_values['fee'][$priceField->id])
         && CRM_Utils_Array::value('name', $this->_values['fee'][$priceField->id]) == 'contribution_amount'
         && CRM_Utils_Array::value("price_{$priceField->id}", $this->_params) == '-1'

--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -703,7 +703,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
       }
 
       // CRM-12233
-      if ($membershipIsActive && !$self->_membershipBlock['is_required']
+      if ($membershipIsActive && empty($self->_membershipBlock['is_required'])
         && $self->_values['amount_block_is_active']
       ) {
         $membershipFieldId = $contributionFieldId = $errorKey = $otherFieldId = NULL;

--- a/CRM/Group/Form/Edit.php
+++ b/CRM/Group/Form/Edit.php
@@ -127,7 +127,7 @@ class CRM_Group_Form_Edit extends CRM_Core_Form {
       }
     }
     else {
-      if ($this->_groupValues['is_reserved'] == 1 && !CRM_Core_Permission::check('administer reserved groups')) {
+      if ($this->_id && $this->_groupValues['is_reserved'] == 1 && !CRM_Core_Permission::check('administer reserved groups')) {
         CRM_Core_Error::statusBounce(ts("You do not have sufficient permission to change settings for this reserved group."));
       }
       if (isset($this->_id)) {

--- a/CRM/Mailing/ActionTokens.php
+++ b/CRM/Mailing/ActionTokens.php
@@ -82,10 +82,10 @@ class CRM_Mailing_ActionTokens extends \Civi\Token\AbstractTokenSubscriber {
 
     list($verp, $urls) = CRM_Mailing_BAO_Mailing::getVerpAndUrls(
       $row->context['mailingJobId'],
-      $row->context['mailingActionTarget']['id'],
-      $row->context['mailingActionTarget']['hash'],
+      $row->context['mailingActionTarget']['id'] ?? 0,
+      $row->context['mailingActionTarget']['hash'] ?? '',
       // Note: Behavior is already undefined for SMS/'phone' mailings...
-      $row->context['mailingActionTarget']['email']
+      $row->context['mailingActionTarget']['email'] ?? ''
     );
 
     $row->format('text/plain')->tokens($entity, $field,

--- a/CRM/Profile/Page/MultipleRecordFieldsListing.php
+++ b/CRM/Profile/Page/MultipleRecordFieldsListing.php
@@ -53,7 +53,7 @@ class CRM_Profile_Page_MultipleRecordFieldsListing extends CRM_Core_Page_Basic {
    *   (reference) of action links
    */
   public function &links() {
-    if (!(self::$_links[$this->_pageViewType])) {
+    if (!isset(self::$_links[$this->_pageViewType])) {
       // helper variable for nicer formatting
       $links = [];
 

--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -681,7 +681,7 @@ class CRM_Report_Form extends CRM_Core_Form {
     // Do not display Report Settings section if administer Reports permission is absent OR
     // if report instance is reserved and administer reserved reports absent
     if (!CRM_Core_Permission::check('administer Reports') ||
-      ($this->_instanceValues['is_reserved'] &&
+      (!empty($this->_instanceValues['is_reserved']) &&
         !CRM_Core_Permission::check('administer reserved reports'))
     ) {
       $this->_instanceForm = FALSE;
@@ -692,7 +692,7 @@ class CRM_Report_Form extends CRM_Core_Form {
     if (CRM_Core_Permission::check('administer Reports') ||
       CRM_Core_Permission::check('access Report Criteria')
     ) {
-      if (!$this->_instanceValues['is_reserved'] ||
+      if (empty($this->_instanceValues['is_reserved']) ||
         CRM_Core_Permission::check('administer reserved reports')
       ) {
         $this->assign('criteriaForm', TRUE);

--- a/tests/phpunit/api/v4/Entity/ParticipantTest.php
+++ b/tests/phpunit/api/v4/Entity/ParticipantTest.php
@@ -129,7 +129,7 @@ class ParticipantTest extends UnitTestCase {
       ->addWhere('event_id', 'IN', [$firstEventId, $secondEventId])
       ->execute();
 
-    $firstResult = $result->first();
+    $firstResult = $firstTwo->first();
 
     // verify counts
     // count should either twice the first event count or one less


### PR DESCRIPTION
Overview
----------------------------------------
This fixes some issues found by unit tests where by we are trying to use array access on NULL values

Before
----------------------------------------
Tests fail on PHP7.4

After
----------------------------------------
Tests pass on PHP7.4

tests affected

https://test.civicrm.org/job/CiviCRM-Core-Edge/513/CIVIVER=master,label=test-3/testReport/(root)/CRM_Contact_Page_AjaxTest/testGetDedupes/ https://test.civicrm.org/job/CiviCRM-Core-Edge/513/CIVIVER=master,label=test-3/testReport/api.v4.Entity/ParticipantTest/testGet/ https://test.civicrm.org/job/CiviCRM-Core-Edge/513/CIVIVER=master,label=test-3/testReport/(root)/CRM_Report_Form_TestCaseTest/testBadReportOutput_with_data_set__1/ https://test.civicrm.org/job/CiviCRM-Core-Edge/513/CIVIVER=master,label=test-3/testReport/(root)/CRM_Mailing_TokensTest/testTokensWithoutMailingJob_with_data_set__1/