### PR TITLE
[REF] Fix another couple of uses of array_key_exists when the variabl…

### DIFF
--- a/CRM/Core/Page/Basic.php
+++ b/CRM/Core/Page/Basic.php
@@ -306,7 +306,7 @@ abstract class CRM_Core_Page_Basic extends CRM_Core_Page {
     $object_type = get_class($object);
 
     if (!$forceAction) {
-      if (array_key_exists('is_reserved', $object) && $object->is_reserved) {
+      if (property_exists($object, 'is_reserved') && $object->is_reserved) {
         $values['class'] = 'reserved';
         // check if object is relationship type
 
@@ -326,7 +326,7 @@ abstract class CRM_Core_Page_Basic extends CRM_Core_Page {
         }
       }
       else {
-        if (array_key_exists('is_active', $object)) {
+        if (property_exists($object, 'is_active')) {
           if ($object->is_active) {
             if ($hasDisable) {
               $newAction += CRM_Core_Action::DISABLE;


### PR DESCRIPTION
…e being checked is an object

Overview
----------------------------------------
This fixes another couple of places where we were using array_key_exists on objects that tests found

Before
----------------------------------------
array_key_exists on objects

After
----------------------------------------
use proper object functions

ping @eileenmcnaughton Test affected https://test.civicrm.org/job/CiviCRM-Core-Edge/513/CIVIVER=master,label=test-3/testReport/(root)/CRM_Core_Page_HookTest/testPagesCallPageRunOnce/