### PR TITLE
REF Access the method not the property directly to check if a payment processor supports recurring

### DIFF
--- a/CRM/Contribute/Form/AbstractEditPayment.php
+++ b/CRM/Contribute/Form/AbstractEditPayment.php
@@ -361,7 +361,7 @@ WHERE  contribution_id = {$id}
       if (!empty($processor['description'])) {
         $this->_processors[$id] .= ' : ' . $processor['description'];
       }
-      if ($processor['is_recur']) {
+      if ($this->_paymentProcessors[$id]['object']->supportsRecurring()) {
         $this->_recurPaymentProcessors[$id] = $this->_processors[$id];
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------
We have access to the payment processor object and should check the method rather than the metadata directly to see if the processor supports recurring.  A processor can override the `supportsRecurring()` and could choose to return different values based on context.

Before
----------------------------------------
Property accessed directly.

After
----------------------------------------
Method accessed (which by default reads the property).

Technical Details
----------------------------------------


Comments
----------------------------------------

