### PR TITLE
[NFC] Update mocking to use getMockBuilder instead instead of createMock

### DIFF
--- a/tests/phpunit/CRM/Core/CommunityMessagesTest.php
+++ b/tests/phpunit/CRM/Core/CommunityMessagesTest.php
@@ -369,8 +369,7 @@ class CRM_Core_CommunityMessagesTest extends CiviUnitTestCase {
    * @return CRM_Utils_HttpClient|PHPUnit\Framework\MockObject\MockObject
    */
   protected function expectNoHttpRequest() {
-    $mockFunction = $this->mockMethod;
-    $client = $this->$mockFunction('CRM_Utils_HttpClient');
+    $client = $this->getMockBuilder('CRM_Utils_HttpClient')->getMock();
     $client->expects($this->never())
       ->method('get');
     return $client;
@@ -384,8 +383,7 @@ class CRM_Core_CommunityMessagesTest extends CiviUnitTestCase {
    * @return CRM_Utils_HttpClient|PHPUnit\Framework\MockObject\MockObject
    */
   protected function expectOneHttpRequest($response) {
-    $mockFunction = $this->mockMethod;
-    $client = $this->$mockFunction('CRM_Utils_HttpClient');
+    $client = $this->getMockBuilder('CRM_Utils_HttpClient')->getMock();
     $client->expects($this->once())
       ->method('get')
       ->will($this->returnValue($response));

--- a/tests/phpunit/CRM/Core/JobManagerTest.php
+++ b/tests/phpunit/CRM/Core/JobManagerTest.php
@@ -20,7 +20,6 @@ class CRM_Core_JobManagerTest extends CiviUnitTestCase {
   }
 
   public function testHookCron() {
-    $mockFunction = $this->mockMethod;
     $hook = $this->getMockBuilder(stdClass::class)
       ->setMethods(['civicrm_cron'])
       ->getMock();

--- a/tests/phpunit/CRM/Extension/ManagerTest.php
+++ b/tests/phpunit/CRM/Extension/ManagerTest.php
@@ -33,8 +33,7 @@ class CRM_Extension_ManagerTest extends CiviUnitTestCase {
    * @expectedException CRM_Extension_Exception
    */
   public function testInstallInvalidType() {
-    $mockFunction = $this->mockMethod;
-    $testingTypeManager = $this->$mockFunction('CRM_Extension_Manager_Interface');
+    $testingTypeManager = $this->getMockBuilder('CRM_Extension_Manager_Interface')->getMock();
     $testingTypeManager->expects($this->never())
       ->method('onPreInstall');
     $manager = $this->_createManager([
@@ -51,8 +50,7 @@ class CRM_Extension_ManagerTest extends CiviUnitTestCase {
    * "the first row" or "all rows".
    */
   public function testInstall_Disable_Uninstall() {
-    $mockFunction = $this->mockMethod;
-    $testingTypeManager = $this->$mockFunction('CRM_Extension_Manager_Interface');
+    $testingTypeManager = $this->getMockBuilder('CRM_Extension_Manager_Interface')->getMock();
     $manager = $this->_createManager([
       self::TESTING_TYPE => $testingTypeManager,
     ]);
@@ -98,8 +96,7 @@ class CRM_Extension_ManagerTest extends CiviUnitTestCase {
    * @throws \CRM_Extension_Exception
    */
   public function test_InstallAuto_DisableDownstream_UninstallDownstream() {
-    $mockFunction = $this->mockMethod;
-    $testingTypeManager = $this->$mockFunction('CRM_Extension_Manager_Interface');
+    $testingTypeManager = $this->getMockBuilder('CRM_Extension_Manager_Interface')->getMock();
     $manager = $this->_createManager([
       self::TESTING_TYPE => $testingTypeManager,
     ]);
@@ -140,8 +137,7 @@ class CRM_Extension_ManagerTest extends CiviUnitTestCase {
    * @throws \CRM_Extension_Exception
    */
   public function testInstallAuto_Twice() {
-    $mockFunction = $this->mockMethod;
-    $testingTypeManager = $this->$mockFunction('CRM_Extension_Manager_Interface');
+    $testingTypeManager = $this->getMockBuilder('CRM_Extension_Manager_Interface')->getMock();
     $manager = $this->_createManager([
       self::TESTING_TYPE => $testingTypeManager,
     ]);
@@ -170,8 +166,7 @@ class CRM_Extension_ManagerTest extends CiviUnitTestCase {
   }
 
   public function test_InstallAuto_DisableUpstream() {
-    $mockFunction = $this->mockMethod;
-    $testingTypeManager = $this->$mockFunction('CRM_Extension_Manager_Interface');
+    $testingTypeManager = $this->getMockBuilder('CRM_Extension_Manager_Interface')->getMock();
     $manager = $this->_createManager([
       self::TESTING_TYPE => $testingTypeManager,
     ]);
@@ -213,8 +208,7 @@ class CRM_Extension_ManagerTest extends CiviUnitTestCase {
    * Subseuently disable and uninstall.
    */
   public function testInstall_DirtyRemove_Disable_Uninstall() {
-    $mockFunction = $this->mockMethod;
-    $testingTypeManager = $this->$mockFunction('CRM_Extension_Manager_Interface');
+    $testingTypeManager = $this->getMockBuilder('CRM_Extension_Manager_Interface')->getMock();
     $manager = $this->_createManager([
       self::TESTING_TYPE => $testingTypeManager,
     ]);
@@ -252,8 +246,7 @@ class CRM_Extension_ManagerTest extends CiviUnitTestCase {
    * Install an extension with a valid type name.
    */
   public function testInstall_Disable_Enable() {
-    $mockFunction = $this->mockMethod;
-    $testingTypeManager = $this->$mockFunction('CRM_Extension_Manager_Interface');
+    $testingTypeManager = $this->getMockBuilder('CRM_Extension_Manager_Interface')->getMock();
     $manager = $this->_createManager([
       self::TESTING_TYPE => $testingTypeManager,
     ]);
@@ -295,8 +288,7 @@ class CRM_Extension_ManagerTest extends CiviUnitTestCase {
    * Performing 'install' on a 'disabled' extension performs an 'enable'
    */
   public function testInstall_Disable_Install() {
-    $mockFunction = $this->mockMethod;
-    $testingTypeManager = $this->$mockFunction('CRM_Extension_Manager_Interface');
+    $testingTypeManager = $this->getMockBuilder('CRM_Extension_Manager_Interface')->getMock();
     $manager = $this->_createManager([
       self::TESTING_TYPE => $testingTypeManager,
     ]);
@@ -335,8 +327,7 @@ class CRM_Extension_ManagerTest extends CiviUnitTestCase {
    * Install an extension with a valid type name.
    */
   public function testEnableBare() {
-    $mockFunction = $this->mockMethod;
-    $testingTypeManager = $this->$mockFunction('CRM_Extension_Manager_Interface');
+    $testingTypeManager = $this->getMockBuilder('CRM_Extension_Manager_Interface')->getMock();
     $manager = $this->_createManager([
       self::TESTING_TYPE => $testingTypeManager,
     ]);
@@ -363,8 +354,7 @@ class CRM_Extension_ManagerTest extends CiviUnitTestCase {
    * Get the status of an unknown extension.
    */
   public function testStatusUnknownKey() {
-    $mockFunction = $this->mockMethod;
-    $testingTypeManager = $this->$mockFunction('CRM_Extension_Manager_Interface');
+    $testingTypeManager = $this->getMockBuilder('CRM_Extension_Manager_Interface')->getMock();
     $testingTypeManager->expects($this->never())
       ->method('onPreInstall');
     $manager = $this->_createManager([
@@ -377,8 +367,7 @@ class CRM_Extension_ManagerTest extends CiviUnitTestCase {
    * Replace code for an extension that doesn't exist in the container
    */
   public function testReplace_Unknown() {
-    $mockFunction = $this->mockMethod;
-    $testingTypeManager = $this->$mockFunction('CRM_Extension_Manager_Interface');
+    $testingTypeManager = $this->getMockBuilder('CRM_Extension_Manager_Interface')->getMock();
     $manager = $this->_createManager([
       self::TESTING_TYPE => $testingTypeManager,
     ]);
@@ -406,8 +395,7 @@ class CRM_Extension_ManagerTest extends CiviUnitTestCase {
    * Replace code for an extension that doesn't exist in the container
    */
   public function testReplace_Uninstalled() {
-    $mockFunction = $this->mockMethod;
-    $testingTypeManager = $this->$mockFunction('CRM_Extension_Manager_Interface');
+    $testingTypeManager = $this->getMockBuilder('CRM_Extension_Manager_Interface')->getMock();
     $manager = $this->_createManager([
       self::TESTING_TYPE => $testingTypeManager,
     ]);
@@ -440,8 +428,7 @@ class CRM_Extension_ManagerTest extends CiviUnitTestCase {
    * file="oddball", and the upgrade has file="newextension".
    */
   public function testReplace_Installed() {
-    $mockFunction = $this->mockMethod;
-    $testingTypeManager = $this->$mockFunction('CRM_Extension_Manager_Interface');
+    $testingTypeManager = $this->getMockBuilder('CRM_Extension_Manager_Interface')->getMock();
     $manager = $this->_createManager([
       self::TESTING_TYPE => $testingTypeManager,
     ]);
@@ -478,8 +465,7 @@ class CRM_Extension_ManagerTest extends CiviUnitTestCase {
    * file="oddball", and the upgrade has file="newextension".
    */
   public function testReplace_InstalledMissing() {
-    $mockFunction = $this->mockMethod;
-    $testingTypeManager = $this->$mockFunction('CRM_Extension_Manager_Interface');
+    $testingTypeManager = $this->getMockBuilder('CRM_Extension_Manager_Interface')->getMock();
     $manager = $this->_createManager([
       self::TESTING_TYPE => $testingTypeManager,
     ]);

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -166,13 +166,6 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
   public $setupIDs = [];
 
   /**
-   * PHPUnit Mock Method to use.
-   *
-   * @var string
-   */
-  public $mockMethod = 'getMock';
-
-  /**
    *  Constructor.
    *
    *  Because we are overriding the parent class constructor, we
@@ -200,12 +193,6 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
     if (function_exists('_civix_phpunit_setUp')) {
       // FIXME: loosen coupling
       _civix_phpunit_setUp();
-    }
-    if (class_exists('PHPUnit_Runner_Version') && version_compare(\PHPUnit_Runner_Version::id(), '5', '>=')) {
-      $this->mockMethod = 'createMock';
-    }
-    elseif (class_exists('PHPUnit\Runner\Version') && version_compare(PHPUnit\Runner\Version::id(), '6', '>=')) {
-      $this->mockMethod = 'createMock';
     }
   }
 

--- a/tests/phpunit/api/v3/ContactTest.php
+++ b/tests/phpunit/api/v3/ContactTest.php
@@ -2370,8 +2370,7 @@ class api_v3_ContactTest extends CiviUnitTestCase {
     $this->assertTrue(is_numeric($ufMatch->id));
 
     // setup - mock the calls to CRM_Utils_System_*::getUfId
-    $mockFunction = $this->mockMethod;
-    $userSystem = $this->$mockFunction('CRM_Utils_System_UnitTests', ['getUfId']);
+    $userSystem = $this->getMockBuilder('CRM_Utils_System_UnitTests')->setMethods(['getUfId'])->getMock();
     $userSystem->expects($this->once())
       ->method('getUfId')
       ->with($this->equalTo('exampleUser'))
@@ -2457,8 +2456,7 @@ class api_v3_ContactTest extends CiviUnitTestCase {
    */
   public function testContactGetByUnknownUsername() {
     // setup - mock the calls to CRM_Utils_System_*::getUfId
-    $mockFunction = $this->mockMethod;
-    $userSystem = $this->$mockFunction('CRM_Utils_System_UnitTests', ['getUfId']);
+    $userSystem = $this->getMockBuilder('CRM_Utils_System_UnitTests')->setMethods(['getUfId'])->getMock();
     $userSystem->expects($this->once())
       ->method('getUfId')
       ->with($this->equalTo('exampleUser'))


### PR DESCRIPTION
Overview
----------------------------------------
Uses standard getMockBuilder instead of CreateMock in unit tests

Before
----------------------------------------
Tests fail on PHP7.4

After
----------------------------------------
Tests pass on PHP7.4

ping @eileenmcnaughton