### PR TITLE
Fix payment instrument bug by using correct payment instrument

### DIFF
--- a/CRM/Contribute/Form/AbstractEditPayment.php
+++ b/CRM/Contribute/Form/AbstractEditPayment.php
@@ -653,14 +653,15 @@ WHERE  contribution_id = {$id}
   /**
    * Get the default payment instrument id.
    *
+   * This priortises the submitted value, if any and falls back on the processor.
+   *
    * @return int
+   *
+   * @throws \CRM_Core_Exception
    */
   protected function getDefaultPaymentInstrumentId() {
     $paymentInstrumentID = CRM_Utils_Request::retrieve('payment_instrument_id', 'Integer');
-    if ($paymentInstrumentID) {
-      return $paymentInstrumentID;
-    }
-    return key(CRM_Core_OptionGroup::values('payment_instrument', FALSE, FALSE, FALSE, 'AND is_default = 1'));
+    return (int) ($paymentInstrumentID ?? $this->_paymentProcessor['payment_instrument_id']);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Per https://github.com/civicrm/civicrm-core/pull/17589 it is necessary that we do NOT pass the wrong payment_instrument_id
to the payment processor. BUT we have to provide accurate defaults for manual payments. 
This fixes the function that gets the default to get it from the relevant processor.

This is a narrower fix than Per https://github.com/civicrm/civicrm-core/pull/17589

- back office membership form
- back office participant form
- back office contribution form

and in all cases the Manual processor still loaded correctly.

 I don't feel I can say this is the last fix in this
area but it stands alone as a sensible fix to do and also one that should address the immediate issue and can reasonably go in the rc / potentially backported.

Note there is some weirdness in a second function in EventFees - that function should GO IMHO - but I have not yet reached it in
UI testing to confirm if other changes need to be made.

Before
----------------------------------------
If the payment_processor_id is not set by the user the default is the main site default

After
----------------------------------------
If the payment_processor_id is not set by the user the default is the default appropriate to the processor

Technical Details
----------------------------------------


Comments
----------------------------------------
