### PR TITLE
dev/translation#48 Implement Brick/Money to better handle money values

### DIFF
--- a/CRM/Utils/Money.php
+++ b/CRM/Utils/Money.php
@@ -15,6 +15,10 @@
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
 
+use Brick\Money\Money;
+use Brick\Money\Context\DefaultContext;
+use Brick\Math\RoundingMode;
+
 /**
  * Money utilties
  */
@@ -135,8 +139,8 @@ class CRM_Utils_Money {
    */
   public static function subtractCurrencies($leftOp, $rightOp, $currency) {
     if (is_numeric($leftOp) && is_numeric($rightOp)) {
-      $precision = pow(10, self::getCurrencyPrecision($currency));
-      return (($leftOp * $precision) - ($rightOp * $precision)) / $precision;
+      $money = Money::of($leftOp, $currency, new DefaultContext(), RoundingMode::CEILING);
+      return $money->minus($rightOp)->getAmount()->toFloat();
     }
   }
 

--- a/composer.json
+++ b/composer.json
@@ -75,7 +75,9 @@
     "league/csv": "^9.2",
     "tplaner/when": "~3.0.0",
     "xkerman/restricted-unserialize": "~1.1",
-    "typo3/phar-stream-wrapper": "^2 || ^3.0"
+    "typo3/phar-stream-wrapper": "^2 || ^3.0",
+    "brick/money": "~0.4",
+    "ext-intl": "*"
   },
   "scripts": {
     "post-install-cmd": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "96209031150a0c16ca42aeb4422abe56",
+    "content-hash": "0e6f527fa9032d1f8445c8ec2963c3c9",
     "packages": [
         {
             "name": "adrienrn/php-mimetyper",
@@ -41,6 +41,98 @@
             ],
             "description": "PHP mime type and extension mapping library: compatible with Symfony, powered by jshttp/mime-db",
             "time": "2018-09-27T09:45:05+00:00"
+        },
+        {
+            "name": "brick/math",
+            "version": "0.8.15",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/brick/math.git",
+                "reference": "9b08d412b9da9455b210459ff71414de7e6241cd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/brick/math/zipball/9b08d412b9da9455b210459ff71414de7e6241cd",
+                "reference": "9b08d412b9da9455b210459ff71414de7e6241cd",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": "^7.1|^8.0"
+            },
+            "require-dev": {
+                "php-coveralls/php-coveralls": "^2.2",
+                "phpunit/phpunit": "^7.5.15|^8.5",
+                "vimeo/psalm": "^3.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Brick\\Math\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Arbitrary-precision arithmetic library",
+            "keywords": [
+                "Arbitrary-precision",
+                "BigInteger",
+                "BigRational",
+                "arithmetic",
+                "bigdecimal",
+                "bignum",
+                "brick",
+                "math"
+            ],
+            "time": "2020-04-15T15:59:35+00:00"
+        },
+        {
+            "name": "brick/money",
+            "version": "0.4.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/brick/money.git",
+                "reference": "91f2b5bc35646f172b038e46bb496ad18db59c3c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/brick/money/zipball/91f2b5bc35646f172b038e46bb496ad18db59c3c",
+                "reference": "91f2b5bc35646f172b038e46bb496ad18db59c3c",
+                "shasum": ""
+            },
+            "require": {
+                "brick/math": "~0.7.3 || ~0.8.0",
+                "php": "^7.1|^8.0"
+            },
+            "require-dev": {
+                "brick/varexporter": "~0.2.1",
+                "ext-dom": "*",
+                "ext-pdo": "*",
+                "php-coveralls/php-coveralls": "^2.2",
+                "phpunit/phpunit": "^7.5.15"
+            },
+            "suggest": {
+                "ext-intl": "Required to format Money objects"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Brick\\Money\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Money and currency library",
+            "keywords": [
+                "brick",
+                "currency",
+                "money"
+            ],
+            "time": "2020-05-31T14:17:02+00:00"
         },
         {
             "name": "cache/integration-tests",
@@ -3061,11 +3153,11 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "~7.1"
+        "php": "~7.1",
+        "ext-intl": "*"
     },
     "platform-dev": [],
     "platform-overrides": {
         "php": "7.1"
-    },
-    "plugin-api-version": "1.1.0"
+    }
 }

--- a/tests/phpunit/CRM/Utils/MoneyTest.php
+++ b/tests/phpunit/CRM/Utils/MoneyTest.php
@@ -41,6 +41,7 @@ class CRM_Utils_MoneyTest extends CiviUnitTestCase {
       [2, 1, 'USD', 1],
       [0, 0, 'USD', 0],
       [1, 2, 'USD', -1],
+      [269.565217391, 1, 'USD', 268.57],
       [number_format(19.99, 2), number_format(20.00, 2), 'USD', number_format(-0.01, 2)],
       ['notanumber', 5.00, 'USD', NULL],
     ];


### PR DESCRIPTION
Overview
----------------------------------------
This implements the PHP library brick/money https://github.com/brick/money to better handle currency amounts

Before
----------------------------------------
Non standard library used

After
----------------------------------------
Library used to make calculations

https://lab.civicrm.org/dev/translation/-/issues/48

ping @eileenmcnaughton 