### PR TITLE
[not for merge] - let's worry about formatting fn for now dev/core#1603 Add tpl level formatting for tax_amount

### DIFF
--- a/CRM/Core/Smarty/plugins/modifier.crmMoney.php
+++ b/CRM/Core/Smarty/plugins/modifier.crmMoney.php
@@ -9,13 +9,9 @@
  +--------------------------------------------------------------------+
  */
 
-/**
- *
- * @package CRM
- * @copyright CiviCRM LLC https://civicrm.org/licensing
- * $Id$
- *
- */
+use Brick\Money\Money;
+use Brick\Money\Context\DefaultContext;
+use Brick\Math\RoundingMode;
 
 /**
  * Format the given monetary amount (and currency) for display
@@ -25,12 +21,15 @@
  * @param string $currency
  *   The (optional) currency.
  *
- * @param null $format
- * @param bool $onlyNumber
- *
  * @return string
  *   formatted monetary amount
  */
-function smarty_modifier_crmMoney($amount, $currency = NULL, $format = NULL, $onlyNumber = FALSE) {
-  return CRM_Utils_Money::format($amount, $currency, $format, $onlyNumber);
+function smarty_modifier_crmMoney($amount, $currency = NULL) {
+  if (!$amount) {
+    return $amount;
+  }
+  $currency = $currency ?? CRM_Core_Config::singleton()->defaultCurrency;
+  $money = Money::of($amount, $currency, new DefaultContext(), RoundingMode::CEILING);
+  $formatter = new \NumberFormatter(CRM_Core_I18n::singleton()->getLocale(), \NumberFormatter::CURRENCY);
+  return $money->formatWith($formatter);
 }

--- a/templates/CRM/Price/Page/LineItem.tpl
+++ b/templates/CRM/Price/Page/LineItem.tpl
@@ -67,7 +67,10 @@
       <td class="right">{$line.line_total|crmMoney:$currency}</td>
       {if $line.tax_rate != "" || $line.tax_amount != ""}
         <td class="right">{$taxTerm} ({$line.tax_rate}%)</td>
-        <td class="right">{$line.tax_amount|crmMoney:$currency}</td>
+        <td class="right">
+          {math equation="(x * y) / 100" x=$line.line_total y=$line.tax_rate assign=tax_value}
+          {$tax_value|crmMoney:$currency}
+        </td>
       {else}
         <td></td>
         <td></td>


### PR DESCRIPTION
Overview
----------------------------------------
This is a partial fix for https://lab.civicrm.org/dev/core/-/issues/1603 where the presented values are the result of rounding before multiplying rather than after. 

To summarise - the 2 values have been carefully selected with many decimal places to round to being round numbers after tax is applied. However, the rounding is being done on each line item early on - so when they are added together & rounded the total falls short.

The right fix is to NOT round in the BAO / database and only round on the  presentation layer rather than the BAO layer. This adds handling on the presentation layer - offering us the ability to change the BAO layer next without breaking it. 

Fixing the presentation layer needs to be done first to allow hacks to come out of the BAO layer and since this change has significant implications I believe it should stand alone.

The change relies the brickMoney library per https://github.com/civicrm/civicrm-core/pull/17608
as part of the fix. Note that the rounding I chose was RoundingMode::CEILING
- this is not set in stone but the sum of the individual amounts come closer
to the total than with rounding down. However, I would note it works perfectly here as 

$eventTotal = 409.99173913

Without  this patch that is rounded down $409.99 - with this patch we get $410

Note there were 2 params passed to the function that I removed - I think they are unnused but
I am digging further. Also note that this uses the default locale but we might prefer to
pass the user's locale when we know it as the locale can alter formatting e.g for Euro


Before
----------------------------------------
<img width="846" alt="Screen Shot 2020-06-14 at 5 11 42 PM" src="https://user-images.githubusercontent.com/336308/84585271-27718300-ae62-11ea-86e0-ce8e01e322e4.png">


After
----------------------------------------
<img width="836" alt="Screen Shot 2020-06-14 at 5 10 38 PM" src="https://user-images.githubusercontent.com/336308/84585253-fd1fc580-ae61-11ea-920e-d6243e521d97.png">


Technical Details
----------------------------------------


Comments
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/1603
https://lab.civicrm.org/dev/translation/-/issues/48 