### PR TITLE
dev/core#1603 remove places where taxAmount is rounded

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4204,7 +4204,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
     ) {
       $taxRateParams = $taxRates[$params['financial_type_id']];
       $taxAmount = CRM_Contribute_BAO_Contribution_Utils::calculateTaxAmount(CRM_Utils_Array::value('total_amount', $params), $taxRateParams);
-      $params['tax_amount'] = round($taxAmount['tax_amount'], 2);
+      $params['tax_amount'] = $taxAmount['tax_amount'];
 
       // Get Line Item on update of contribution
       if (isset($params['id'])) {
@@ -4227,7 +4227,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
         if (isset($value['financial_type_id']) && array_key_exists($value['financial_type_id'], $taxRates)) {
           $taxRate = $taxRates[$value['financial_type_id']];
           $taxAmount = CRM_Contribute_BAO_Contribution_Utils::calculateTaxAmount($value['line_total'], $taxRate);
-          $taxAmountArray[] = round($taxAmount['tax_amount'], 2);
+          $taxAmountArray[] = $taxAmount['tax_amount'];
         }
       }
       $params['tax_amount'] = array_sum($taxAmountArray);
@@ -4238,7 +4238,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
       if (isset($params['financial_type_id']) && array_key_exists($params['financial_type_id'], $taxRates) && $isLineItem) {
         $taxRate = $taxRates[$params['financial_type_id']];
         $taxAmount = CRM_Contribute_BAO_Contribution_Utils::calculateTaxAmount($params['line_total'], $taxRate);
-        $params['tax_amount'] = round($taxAmount['tax_amount'], 2);
+        $params['tax_amount'] = $taxAmount['tax_amount'];
       }
     }
     return $params;

--- a/CRM/Price/BAO/PriceSet.php
+++ b/CRM/Price/BAO/PriceSet.php
@@ -1485,10 +1485,10 @@ WHERE       ps.id = %1
   public static function setLineItem($field, $lineItem, $optionValueId, &$totalTax) {
     // Here we round - i.e. after multiplying by quantity
     if ($field['html_type'] == 'Text') {
-      $taxAmount = round($field['options'][$optionValueId]['tax_amount'] * $lineItem[$optionValueId]['qty'], 2);
+      $taxAmount = $field['options'][$optionValueId]['tax_amount'] * $lineItem[$optionValueId]['qty'];
     }
     else {
-      $taxAmount = round($field['options'][$optionValueId]['tax_amount'], 2);
+      $taxAmount = $field['options'][$optionValueId]['tax_amount'];
     }
     $taxRate = $field['options'][$optionValueId]['tax_rate'];
     $lineItem[$optionValueId]['tax_amount'] = $taxAmount;
@@ -1705,7 +1705,7 @@ WHERE     ct.id = cp.financial_type_id AND
           if (array_key_exists($params['financial_type_id'], $taxRates)) {
             $field['options'][key($field['options'])]['tax_rate'] = $taxRates[$params['financial_type_id']];
             $taxAmount = CRM_Contribute_BAO_Contribution_Utils::calculateTaxAmount($field['options'][$optionValueId]['amount'], $field['options'][$optionValueId]['tax_rate']);
-            $field['options'][$optionValueId]['tax_amount'] = round($taxAmount['tax_amount'], 2);
+            $field['options'][$optionValueId]['tax_amount'] = $taxAmount['tax_amount'];
           }
         }
         if (!empty($field['options'][$optionValueId]['tax_rate'])) {


### PR DESCRIPTION
Overview
----------------------------------------
Let's just run the tests first... From https://github.com/civicrm/civicrm-core/pull/16590 but without the other changes I was less comfortable with

Before
----------------------------------------
It's generally agreed that rounding in the BAO is a bad thing & that unrounded variables should be saved to the DB - however, our code does not reflect that

After
----------------------------------------
No BAO rounding

Technical Details
----------------------------------------
While I originally thought this mattered for display I've been testing for quite a bit & not found anything to back that up. At this stage I can't find any case where rounding in the BAO is a good thing

Comments
----------------------------------------
There were some other minor changes in https://github.com/civicrm/civicrm-core/pull/16590 that I have left out - one seemed a bit wrong & then by the time I'd decided to do ONLY round in this PR the other was best left out too.

Let's see what tests throw up!