### PR TITLE
[NFC] Remove instances where html is passed to crmMoney

### DIFF
--- a/CRM/Core/Smarty/plugins/modifier.crmMoney.php
+++ b/CRM/Core/Smarty/plugins/modifier.crmMoney.php
@@ -25,12 +25,11 @@
  * @param string $currency
  *   The (optional) currency.
  *
- * @param null $format
- * @param bool $onlyNumber
- *
  * @return string
  *   formatted monetary amount
+ *
+ * @throws \CRM_Core_Exception
  */
-function smarty_modifier_crmMoney($amount, $currency = NULL, $format = NULL, $onlyNumber = FALSE) {
-  return CRM_Utils_Money::format($amount, $currency, $format, $onlyNumber);
+function smarty_modifier_crmMoney($amount, $currency = NULL) {
+  return CRM_Utils_Money::format($amount, $currency);
 }

--- a/templates/CRM/Contribute/Form/AdditionalInfo/AdditionalDetail.tpl
+++ b/templates/CRM/Contribute/Form/AdditionalInfo/AdditionalDetail.tpl
@@ -13,9 +13,9 @@
     <table class="form-layout-compressed">
         <tr  class="crm-contribution-form-block-contribution_page"><td class="label">{$form.contribution_page_id.label}</td><td{$valueStyle}>{$form.contribution_page_id.html|crmAddClass:twenty}</td></tr>
         <tr class="crm-contribution-form-block-note"><td class="label" style="vertical-align:top;">{$form.note.label}</td><td>{$form.note.html}</td></tr>
-        <tr class="crm-contribution-form-block-non_deductible_amount"><td class="label">{$form.non_deductible_amount.label}</td><td{$valueStyle}>{$form.non_deductible_amount.html|crmMoney:$currency:'':1}<br />
+        <tr class="crm-contribution-form-block-non_deductible_amount"><td class="label">{$form.non_deductible_amount.label}</td><td{$valueStyle}>{$form.non_deductible_amount.html}<br />
             <span class="description">{ts}Non-deductible portion of this contribution.{/ts}</span></td></tr>
-        <tr class="crm-contribution-form-block-fee_amount"><td class="label">{$form.fee_amount.label}</td><td{$valueStyle}>{$form.fee_amount.html|crmMoney:$currency:'XXX':'YYY'}<br />
+        <tr class="crm-contribution-form-block-fee_amount"><td class="label">{$form.fee_amount.label}</td><td{$valueStyle}>{$form.fee_amount.html}<br />
             <span class="description">{ts}Processing fee for this transaction (if applicable).{/ts}</span></td></tr>
         <tr class="crm-contribution-form-block-invoice_id"><td class="label">{$form.invoice_id.label}</td><td{$valueStyle}>{$form.invoice_id.html}<br />
             <span class="description">{ts}Unique internal reference ID for this contribution.{/ts}</span></td></tr>

--- a/templates/CRM/Contribute/Form/AdditionalPayment.tpl
+++ b/templates/CRM/Contribute/Form/AdditionalPayment.tpl
@@ -92,7 +92,7 @@
             <td class="label">{$form.trxn_id.label}</td>
             <td>{$form.trxn_id.html} {help id="id-trans_id"}</td>
           </tr>
-          <tr class="crm-payment-form-block-fee_amount"><td class="label">{$form.fee_amount.label}</td><td{$valueStyle}>{$form.fee_amount.html|crmMoney:$currency:'XXX':'YYY'}<br />
+          <tr class="crm-payment-form-block-fee_amount"><td class="label">{$form.fee_amount.label}</td><td{$valueStyle}>{$form.fee_amount.html}<br />
             <span class="description">{ts}Processing fee for this transaction (if applicable).{/ts}</span></td></tr>
         </table>
       </div>


### PR DESCRIPTION

Overview
----------------------------------------
After grepping I'm pretty confident the other params are never passed so removed

Before
----------------------------------------
Invalid calls to crmSmarty on input html

The HTML is passed to the money-formatter, but the value isn't changed (because it's malformed input).

After
----------------------------------------
Calls removed, also unused params removed

The HTML is not passed to the money-formatter.
