### PR TITLE
dev/core#1433 - Replace call to CRM_Case_XMLProcessor::allActivityTypes() that doesn't cache properly

### DIFF
--- a/CRM/Case/XMLProcessor/Process.php
+++ b/CRM/Case/XMLProcessor/Process.php
@@ -253,7 +253,7 @@ class CRM_Case_XMLProcessor_Process extends CRM_Case_XMLProcessor {
    * @return array
    */
   public function activityTypes($activityTypesXML, $maxInst = FALSE, $isLabel = FALSE, $maskAction = FALSE) {
-    $activityTypes = &$this->allActivityTypes(TRUE, TRUE);
+    $activityTypes = CRM_Case_PseudoConstant::caseActivityType(TRUE, TRUE);
     $result = [];
     foreach ($activityTypesXML as $activityTypeXML) {
       foreach ($activityTypeXML as $recordXML) {


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/1433

There are very few uses of this function, and one spot has already been replaced earlier. Basically the function will always return whatever it did on the first call in a page run, even if you change the parameters in subsequent calls.

Before
----------------------------------------
Function doesn't do caching properly

After
----------------------------------------
Function does caching properly

Technical Details
----------------------------------------
Function doesn't take parameters into account when deciding if it's already calculated the result, but since it's just a wrapper to a function that does, and there aren't many uses of this wrapper, just replace the call with the other function.

Note there's both `CRM_Case_XMLProcessor::allActivityTypes()` and `CRM_Case_XMLProcessor_Process::activityTypes()`. The first is the bad one, it's just we're touching the second one to eliminate the call and they happen to have similar names.

Also the `&` isn't needed since the variable is never updated.

Comments
----------------------------------------
Has test.
