### PR TITLE
dev/core#1433 - Replace last instances of calls to CRM_Case_XMLProcessor::allActivityTypes()

### DIFF
--- a/CRM/Case/XMLProcessor/Process.php
+++ b/CRM/Case/XMLProcessor/Process.php
@@ -404,7 +404,7 @@ AND        a.is_deleted = 0
    */
   public function createActivity($activityTypeXML, &$params) {
     $activityTypeName = (string) $activityTypeXML->name;
-    $activityTypes = &$this->allActivityTypes(TRUE, TRUE);
+    $activityTypes = CRM_Case_PseudoConstant::caseActivityType(TRUE, TRUE);
     $activityTypeInfo = $activityTypes[$activityTypeName] ?? NULL;
 
     if (!$activityTypeInfo) {

--- a/CRM/Case/XMLProcessor/Report.php
+++ b/CRM/Case/XMLProcessor/Report.php
@@ -771,7 +771,7 @@ LIMIT  1
       $activityTypes = $form->getActivityTypes($xml, $activitySetName);
     }
     else {
-      $activityTypes = CRM_Case_XMLProcessor::allActivityTypes(FALSE, TRUE);
+      $activityTypes = CRM_Case_PseudoConstant::caseActivityType(FALSE, TRUE);
     }
 
     if (!$activityTypes) {

--- a/tests/phpunit/CRM/Case/Form/SearchTest.php
+++ b/tests/phpunit/CRM/Case/Form/SearchTest.php
@@ -1,0 +1,42 @@
+<?php
+require_once 'CiviTest/CiviCaseTestCase.php';
+
+/**
+ * Class CRM_Case_Form_SearchTest
+ * @group headless
+ */
+class CRM_Case_Form_SearchTest extends CiviCaseTestCase {
+
+  public function setUp() {
+    parent::setUp();
+    $this->quickCleanup(['civicrm_case_contact', 'civicrm_case', 'civicrm_contact']);
+  }
+
+  /**
+   * Similar to tests in CRM_Core_FormTest where it's just testing there's no
+   * red boxes when you open the form, but it requires CiviCase to be
+   * enabled so putting in a separate place.
+   *
+   * This doesn't test much expected output just that the page opens without
+   * notices or errors. For example to make it fail change the spelling of a
+   * variable so it has a typo in CRM_Case_Form_Search::preProcess(), and then
+   * this test will throw an exception.
+   */
+  public function testOpeningFindCaseForm() {
+    $form = new CRM_Case_Form_Search();
+    $form->controller = new CRM_Case_Controller_Search('Find Cases');
+
+    ob_start();
+    $form->controller->_actions['display']->perform($form, 'display');
+    $contents = ob_get_contents();
+    ob_end_clean();
+
+    // There's a bunch of other stuff we could check for in $contents, but then
+    // it's tied to the html output and has the same maintenance problems
+    // as webtests. Mostly what we're doing in this test is checking that it
+    // doesn't generate any E_NOTICES/WARNINGS or other errors. But let's do
+    // one check.
+    $this->assertContains('<label for="case_id">', $contents);
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/1433

Follow on from https://github.com/civicrm/civicrm-core/pull/17614. **These are the last instances.**

Technical Details
----------------------------------------
Function doesn't do caching right, but it's just a wrapper around a function that does, so call that function instead.

Also the `&` isn't needed in createActivity() since the variable is never updated.

Comments
----------------------------------------
The added test is for something unrelated because there's already good test coverage for createActivity(), and that gets called every time you create a case with a timeline. And there's some coverage already for populateCaseReportTemplate in CRM_Case_XMLProcessor_ReportTest.
