### PR TITLE
dev/core#1823 Fix issue where Contribution Choices do not appear

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -2591,7 +2591,7 @@ SELECT contact_id
   public static function buildOptions($fieldName, $context = NULL, $props = []) {
     // If a given bao does not override this function
     $baoName = get_called_class();
-    return CRM_Core_PseudoConstant::get($baoName, $fieldName, [], $context);
+    return CRM_Core_PseudoConstant::get($baoName, $fieldName, $props, $context);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
This aims to resolve an issue where the column visibility_id is getting set to 0 wrongly when saving amounts on the Manage Contribution Page screen

https://lab.civicrm.org/dev/core/-/issues/1823

Before
----------------------------------------
visibility_id set to the wrong value

After
----------------------------------------
visibility_id set to the correct value

ping @MegaphoneJon @MikeyMJCO 