### PR TITLE
dev/core#1823 Fix building the Price Field visibility options

### DIFF
--- a/CRM/Price/BAO/PriceField.php
+++ b/CRM/Price/BAO/PriceField.php
@@ -865,14 +865,10 @@ WHERE  id IN (" . implode(',', array_keys($priceFields)) . ')';
   public static function getVisibilityOptionID($visibilityName) {
 
     if (!isset(self::$visibilityOptionsKeys)) {
-      self::$visibilityOptionsKeys = CRM_Price_BAO_PriceField::buildOptions(
-        'visibility_id',
-        NULL,
-        [
-          'labelColumn' => 'name',
-          'flip' => TRUE,
-        ]
-      );
+      self::$visibilityOptionsKeys = CRM_Core_PseudoConstant::get('CRM_Price_BAO_PriceField', 'visibility_id', [
+        'labelColumn' => 'name',
+        'flip' => TRUE,
+      ]);
     }
 
     if (isset(self::$visibilityOptionsKeys[$visibilityName])) {


### PR DESCRIPTION
Overview
----------------------------------------
This aims to fix the issue where by re-saving the amounts tab on a contribution page using user entered price amounts causes them to dissappear 

See: https://lab.civicrm.org/dev/core/-/issues/1823

Before
----------------------------------------

When anonymous user views certain contribution pages, the price options are not visible.

After
----------------------------------------

When anonymous user views certain contribution pages, the price options are visible.
