### PR TITLE
Sort options without relying on unavailable buildOptions param

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -6409,9 +6409,8 @@ AND   displayRelType.is_active = 1
           if (empty($fieldSpec['bao'])) {
             continue;
           }
-          $sortedOptions = $fieldSpec['bao']::buildOptions($fieldSpec['name'], NULL, [
-            'orderColumn' => CRM_Utils_Array::value('labelColumn', $pseudoConstantMetadata, 'label'),
-          ]);
+          $sortedOptions = $fieldSpec['bao']::buildOptions($fieldSpec['name']);
+          natcasesort($sortedOptions);
           $fieldIDsInOrder = implode(',', array_keys($sortedOptions));
           // Pretty sure this validation ALSO happens in the order clause & this can't be reached but...
           // this might give some early warning.


### PR DESCRIPTION
Overview
----------------------------------------
Followup to #17122 - fixes reliance on unavailable `BAO::buildOptions` param.

Before
----------------------------------------
Passes in `$params` to buildOptions, which will be ignored per cleanup in #17122.

After
----------------------------------------
Just does the sorting manually.

Comments
----------------------------------------
This was broken as of #17122, but it's also noteworthy that it would have been broken for non-sql-based option lists anyway, as they come from a callback or something that doesn't care about `orderColumn`.