### PR TITLE
Fix issue with building smart groups when  is empty

### DIFF
--- a/CRM/Contact/BAO/GroupContactCache.php
+++ b/CRM/Contact/BAO/GroupContactCache.php
@@ -489,7 +489,9 @@ WHERE  id IN ( $groupIDs )
     $tempTable = $groupContactsTempTable->getName();
     $groupContactsTempTable->createWithColumns('contact_id int, group_id int, UNIQUE UI_contact_group (contact_id,group_id)');
 
-    $contactQueries[] = $sql;
+    if (!empty($sql)) {
+      $contactQueries[] = $sql;
+    }
     // lets also store the records that are explicitly added to the group
     // this allows us to skip the group contact LEFT JOIN
     $contactQueries[] =


### PR DESCRIPTION
Overview
----------------------------------------
_A brief description of the pull request. Keep technical jargon to a minimum. Hyperlink relevant discussions._

Before
----------------------------------------
Fixes an issue which was reported in stack exchange https://civicrm.stackexchange.com/questions/35868/smart-group-db-error and due to a $contctQueries array like 

```
nothing... $contactQueries is
Array
(
    [0] => 
    [1] => SELECT 27 as group_id, contact_id as contact_id
       FROM   civicrm_group_contact
       WHERE  civicrm_group_contact.status = 'Added' AND civicrm_group_contact.group_id = 27 
)
```

After
----------------------------------------
Smart Groups build correctly
