### PR TITLE
dev/core#1816 - Legacy support for matching custom field options by label

### DIFF
--- a/api/v3/utils.php
+++ b/api/v3/utils.php
@@ -2342,6 +2342,16 @@ function _civicrm_api3_api_match_pseudoconstant_value(&$value, $options, $fieldN
       // CiviMagic syntax for Nulling out the field - let it through.
       return;
     }
+    // Legacy support for custom fields: If matching failed by name, fallback to label
+    // @see https://lab.civicrm.org/dev/core/-/issues/1816
+    if ($customFieldId = CRM_Core_BAO_CustomField::getKeyID($fieldName)) {
+      $field = new CRM_Core_BAO_CustomField();
+      $field->id = $customFieldId;
+      $options = array_map("strtolower", $field->getOptions());
+      $newValue = array_search(strtolower($value), $options);
+    }
+  }
+  if ($newValue === FALSE) {
     throw new API_Exception("'$value' is not a valid option for field $fieldName", 2001, ['error_field' => $fieldName]);
   }
   $value = $newValue;

--- a/tests/phpunit/CRMTraits/Custom/CustomDataTrait.php
+++ b/tests/phpunit/CRMTraits/Custom/CustomDataTrait.php
@@ -91,7 +91,7 @@ trait CRMTraits_Custom_CustomDataTrait {
    * @throws \Civi\API\Exception\UnauthorizedException
    */
   public function createCustomGroupWithFieldOfType($groupParams = [], $customFieldType = 'text', $identifier = NULL) {
-    $supported = ['text', 'select', 'date', 'int', 'contact_reference'];
+    $supported = ['text', 'select', 'date', 'int', 'contact_reference', 'radio'];
     if (!in_array($customFieldType, $supported, TRUE)) {
       throw new CRM_Core_Exception('we have not yet extracted other custom field types from createCustomFieldsOfAllTypes, Use consistent syntax when you do');
     }
@@ -120,6 +120,11 @@ trait CRMTraits_Custom_CustomDataTrait {
       case 'contact_reference':
         $reference = $this->createContactReferenceCustomField($fieldParams)['id'];
         return;
+
+      case 'radio':
+        $reference = $this->createIntegerRadioCustomField($fieldParams)['id'];
+        return;
+
     }
   }
 
@@ -330,6 +335,18 @@ trait CRMTraits_Custom_CustomDataTrait {
   }
 
   /**
+   * Create a custom field of  type radio with integer values.
+   *
+   * @param array $params
+   *
+   * @return array
+   */
+  protected function createIntegerRadioCustomField($params): array {
+    $params = array_merge($this->getFieldsValuesByType('Int', 'Radio'), $params);
+    return $this->callAPISuccess('custom_field', 'create', $params)['values'][0];
+  }
+
+  /**
    * Get default field values for the type of field.
    *
    * @param $dataType
@@ -424,7 +441,7 @@ trait CRMTraits_Custom_CustomDataTrait {
         ],
         'CheckBox' => [
           'label' => 'Pick Color',
-          'html_type' => 'Checkbox',
+          'html_type' => 'CheckBox',
           'data_type' => 'String',
           'text_length' => '',
           'default_value' => '',
@@ -544,6 +561,12 @@ trait CRMTraits_Custom_CustomDataTrait {
               'label' => '100',
               'value' => 4,
               'weight' => 2,
+              'is_active' => 1,
+            ],
+            [
+              'label' => 'Red Testing',
+              'value' => 5,
+              'weight' => 3,
               'is_active' => 1,
             ],
           ],

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -4515,6 +4515,9 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
     ]);
     $this->assertEquals(5, $getContribution['values'][$contribution['id']][$this->getCustomFieldName('int')]);
     $this->assertEquals('Some Text', $getContribution['values'][$contribution['id']]['custom_' . $this->ids['CustomField']['text']]);
+    $this->callAPISuccess('CustomField', 'delete', ['id' => $this->ids['CustomField']['text']]);
+    $this->callAPISuccess('CustomField', 'delete', ['id' => $this->ids['CustomField']['int']]);
+    $this->callAPISuccess('CustomGroup', 'delete', ['id' => $this->ids['CustomGroup']['Custom Group']]);
   }
 
   /**
@@ -4534,6 +4537,17 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
         'custom_' . $this->ids['CustomField']['int'] => 5,
       ]);
     }
+  }
+
+  /**
+   * Test that passing in label for an option value linked to a custom field works
+   * @see dev/core#1816
+   */
+  public function testCustomValueOptionLabelTest() {
+    $this->createCustomGroupWithFieldOfType([], 'radio');
+    $params = $this->_params;
+    $params['custom_' . $this->ids['CustomField']['radio']] = 'Red Testing';
+    $contribution = $this->callAPISuccess('Contribution', 'Create', $params);
   }
 
 }


### PR DESCRIPTION
Backport #17628. Tested with the same `r-run` procedure as #17628.