### PR TITLE
dev/core#1806 - Fix import of "Radio"-style custom fields using option "label"

### DIFF
--- a/CRM/Contribute/Import/Parser/Contribution.php
+++ b/CRM/Contribute/Import/Parser/Contribution.php
@@ -671,6 +671,7 @@ class CRM_Contribute_Import_Parser_Contribution extends CRM_Contribute_Import_Pa
             }
           }
         }
+        continue;
       }
 
       switch ($key) {


### PR DESCRIPTION
Overview
----------------------------------------

This fixes a regression when using the contribution importer with certain custom-data.

Custom fields of type "Radio" or "Select" have a list of acceptable options, and every acceptable option has a "value" (`OptionValue.value`) and "label" (`OptionValue.label`). During import, each input must be checked against the list of acceptable options. 

See: https://lab.civicrm.org/dev/core/-/issues/1806

Before
----------------------------------------

When matching the imported datum to the list of acceptable options, it matches only by "value" (`OptionValue.value`).

After
----------------------------------------

When matching an imported datum to the list of acceptable options, it matches on either "value" or "label" (`OptionValue.value` or `OptionValue.label`). This reproduces the older behavior.

ping @eileenmcnaughton @totten 