### PR TITLE
[dev/core#750] Don't check server variables if we're running in CLI

### DIFF
--- a/Civi/Install/Requirements.php
+++ b/Civi/Install/Requirements.php
@@ -28,10 +28,13 @@ class Requirements {
    */
   protected $system_checks = [
     'checkMemory',
-    'checkServerVariables',
     'checkMysqlConnectExists',
     'checkJsonEncodeExists',
     'checkMultibyteExists',
+  ];
+
+  protected $system_checks_web = [
+    'checkServerVariables',
   ];
 
   protected $database_checks = [
@@ -81,6 +84,12 @@ class Requirements {
     $errors[] = $this->checkFilepathIsWritable($file_paths);
     foreach ($this->system_checks as $check) {
       $errors[] = $this->$check();
+    }
+
+    if (PHP_SAPI !== 'cli') {
+      foreach ($this->system_checks_web as $check) {
+        $errors[] = $this->$check();
+      }
     }
 
     return $errors;


### PR DESCRIPTION
Overview
----------------------------------------
_This PR introduces skipping the server variable checks if we're running in a CLI environment, removing an error when running Drush commands against Drupal 8 and Drupal 9 based sites._

Before
----------------------------------------
_What is the old user-interface or technical-contract (as appropriate)?_
_Drush commands error due to missing server variables, however we shouldn't actually check these variables when running from CLI environments as it's not reasonable to expect them to be set._

After
----------------------------------------
_What changed? What is new old user-interface or technical-contract?_
_The server variables check is now only run for non-cli environments. The error no longer appears!_
