### PR TITLE
Add CRM_Core_Form::isFormInViewMode and CRM_Core_Form::isFormInEditMode

### DIFF
--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -2575,16 +2575,39 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
    *
    * @return bool
    */
-  public function isFormInViewOrEditMode() {
+  protected function isFormInViewOrEditMode() {
+    return $this->isFormInViewMode() || $this->isFormInEditMode();
+  }
+
+  /**
+   * Is the form in edit mode.
+   *
+   * Helper function, notably for extensions implementing the buildForm hook,
+   * so that they can return early.
+   *
+   * @return bool
+   */
+  public function isFormInEditMode() {
     return in_array($this->_action, [
       CRM_Core_Action::UPDATE,
       CRM_Core_Action::ADD,
-      CRM_Core_Action::VIEW,
       CRM_Core_Action::BROWSE,
       CRM_Core_Action::BASIC,
       CRM_Core_Action::ADVANCED,
       CRM_Core_Action::PREVIEW,
     ]);
+  }
+
+  /**
+   * Is the form in view mode.
+   *
+   * Helper function, notably for extensions implementing the buildForm hook,
+   * so that they can return early.
+   *
+   * @return bool
+   */
+  public function isFormInViewMode() {
+    return $this->_action == CRM_Core_Action::VIEW;
   }
 
   /**

--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -2575,7 +2575,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
    *
    * @return bool
    */
-  protected function isFormInViewOrEditMode() {
+  public function isFormInViewOrEditMode() {
     return in_array($this->_action, [
       CRM_Core_Action::UPDATE,
       CRM_Core_Action::ADD,


### PR DESCRIPTION
Overview
----------------------------------------

Extensions implementing the buildForm hook often have to make sure that `$form->elementExists()` before applying a certain logic, otherwise QuickForm will throw a fatal error if the field is missing.

Sometimes we use it as a lazy way of checking the mode of the form, which we can get through `$form->getMode()` and then try to remember which of the `CRM_Core_Action` constants we have to check against.

I stumbled on `CRM_Core_Form::isFormInViewOrEditMode` and found it rather practical, but it is set as protected, so we cannot call it from a buildForm hook, which has `$form`, not `$this`.

Comments
----------------------------------------

The function was added in 2018-01 as part of 240b0e652adbcfc01ea0f97989ba5cc74d3c7b79, which is fitting. I stumbled on a similar bug in an extension just now, while trying to delete a profile field.