### PR TITLE
handle less common dynamic reference cases

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -2471,7 +2471,7 @@ SELECT contact_id
       $coreReferences = CRM_Core_DAO::getReferencesToTable($tableName);
       foreach ($coreReferences as $coreReference) {
         if ($coreReference instanceof \CRM_Core_Reference_Dynamic) {
-          \Civi::$statics[__CLASS__]['contact_references_dynamic'][$tableName][$coreReference->getReferenceTable()][] = $coreReference->getReferenceKey();
+          \Civi::$statics[__CLASS__]['contact_references_dynamic'][$tableName][$coreReference->getReferenceTable()][] = [$coreReference->getReferenceKey(), $coreReference->getTypeColumn()];
         }
       }
     }

--- a/CRM/Dedupe/MergeHandler.php
+++ b/CRM/Dedupe/MergeHandler.php
@@ -123,7 +123,7 @@ class CRM_Dedupe_MergeHandler {
   public function getTablesDynamicallyRelatedToContactTable() {
     if (!isset(\Civi::$statics[__CLASS__]['dynamic'])) {
       \Civi::$statics[__CLASS__]['dynamic'] = [];
-      foreach (CRM_Core_DAO::getDynamicReferencesToTable('civicrm_contact') as $tableName => $field) {
+      foreach (CRM_Core_DAO::getDynamicReferencesToTable('civicrm_contact') as $tableName => $fields) {
         if ($tableName === 'civicrm_financial_item') {
           // It turns out that civicrm_financial_item does not have an index on entity_table (only as the latter
           // part of a entity_id/entity_table index which probably is not adding any value over & above entity_id
@@ -131,7 +131,9 @@ class CRM_Dedupe_MergeHandler {
           // values for entity_table in the schema.
           continue;
         }
-        $sql[] = "(SELECT '$tableName' as civicrm_table, '{$field[0]}' as field_name FROM $tableName WHERE entity_table = 'civicrm_contact' LIMIT 1)";
+        foreach ($fields as $field) {
+          $sql[] = "(SELECT '$tableName' as civicrm_table, '{$field[0]}' as field_name FROM $tableName WHERE {$field[1]} = 'civicrm_contact' LIMIT 1)";
+        }
       }
       $sqlString = implode(' UNION ', $sql);
       if ($sqlString) {

--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -495,6 +495,7 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
     $otherId = $mergeHandler->getToRemoveID();
     $cidRefs = self::cidRefs();
     $eidRefs = $mergeHandler->getTablesDynamicallyRelatedToContactTable();
+    $dynamicRefs = CRM_Core_DAO::getDynamicReferencesToTable('civicrm_contact');
     $cpTables = self::cpTables();
     $paymentTables = self::paymentTables();
     self::filterRowBasedCustomDataFromCustomTables($cidRefs);
@@ -551,8 +552,10 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
       }
 
       if (isset($eidRefs[$table])) {
-        $sqls[] = "UPDATE IGNORE $table SET {$eidRefs[$table]}= $mainId WHERE {$eidRefs[$table]} = $otherId AND entity_table = 'civicrm_contact'";
-        $sqls[] = "DELETE FROM $table WHERE {$eidRefs[$table]} = $otherId AND entity_table = 'civicrm_contact'";
+        foreach ($dynamicRefs[$table] as $dynamicRef) {
+          $sqls[] = "UPDATE IGNORE $table SET {$dynamicRef[0]}= $mainId WHERE {$dynamicRef[0]} = $otherId AND {$dynamicRef[1]} = 'civicrm_contact'";
+          $sqls[] = "DELETE FROM $table WHERE {$dynamicRef[0]} = $otherId AND {$dynamicRef[1]} = 'civicrm_contact'";
+        }
       }
     }
 


### PR DESCRIPTION
Civi 5.26 included #17125, "Fix Dedupe entity_tag mangling bug".  This introduced the new method `CRM_Core_DAO::getDynamicReferencesToTable()` and `CRM_Dedupe_MergeHandler::getTablesRelatedToTheMergePair()`.  However, there are two bugs in the implementation:

* It assumes that only one dynamic reference can exist between two tables.  In addition to extensions that may introduce dynamic references, this is also untrue in core: `civicrm_pcp_block` has two dynamic references to `civicrm_contact`: Both `entity_id` and `target_entity_id`.
* It assumes that the column specifying the entity is always called `entity_table`, and this is hard-coded into the SQL in `getTablesRelatedToTheMergePair()`.  However, this column isn't always `entity_table`.  We should pull the correct column name from the metadata.

I don't think there's a Gitlab ticket for PR #17125, so I'm referencing the PR here instead.