### PR TITLE
Price Field Form: save the fid for the postProcess hook

### DIFF
--- a/CRM/Price/Form/Field.php
+++ b/CRM/Price/Form/Field.php
@@ -690,6 +690,8 @@ class CRM_Price_Form_Field extends CRM_Core_Form {
     $priceField = CRM_Price_BAO_PriceField::create($params);
 
     if (!is_a($priceField, 'CRM_Core_Error')) {
+      // Required by extensions implementing the postProcess hook (to get the ID of new entities)
+      $this->setEntityId($priceField->id);
       CRM_Core_Session::setStatus(ts('Price Field \'%1\' has been saved.', [1 => $priceField->label]), ts('Saved'), 'success');
     }
     $buttonName = $this->controller->getButtonName();


### PR DESCRIPTION
Overview
----------------------------------------

When customizing the Price Field form (i.e. new Price set -> new price field), extensions implementing the postProcess hook cannot handle new fields, since the fid is not set in the form.

This is only visible when adding a new price field, not when editing an existing field.

Before/After
----------------------------------------

With this PR, extensions can do extra processing in a postProcess (ex: handle a field that was added to the interface).

Comments
----------------------------------------

Related PRs: #17516 , #17514