### PR TITLE
Bug in Grant statistics report

### DIFF
--- a/CRM/Report/Form/Grant/Statistics.php
+++ b/CRM/Report/Form/Grant/Statistics.php
@@ -533,7 +533,7 @@ SELECT COUNT({$this->_aliases['civicrm_grant']}.id) as count ,
       return;
     }
 
-    $currencies = CRM_Core_PseudoConstant::get('CRM_Grant_DAO_Grant', 'currency', ['labelColumn' => 'symbol']);
+    $currencies = CRM_Core_PseudoConstant::get('CRM_Grant_DAO_Grant', 'currency', ['labelColumn' => 'name']);
     $currency = $currencies[$values['civicrm_grant_currency']];
 
     if (!$customData) {


### PR DESCRIPTION
Overview
----------------------------------------
The Statistics report in the Grant component is broken, displaying an error while trying to run it.

Before
----------------------------------------
![Screenshot_2020-06-16](https://user-images.githubusercontent.com/372004/84822744-36377180-afeb-11ea-9606-d5dbc60739b0.png)

After
----------------------------------------
![Screenshot_2020-06-16 Grant Statistics](https://user-images.githubusercontent.com/372004/84822757-3afc2580-afeb-11ea-989b-6de0418f97a9.png)

Technical Details
----------------------------------------
CRM_Utils_Money::format expect the name of the currency, not the symbol

