### PR TITLE
dev/core#1590: Don't send reminders on deleted events

### DIFF
--- a/CRM/Activity/ActionMapping.php
+++ b/CRM/Activity/ActionMapping.php
@@ -118,4 +118,12 @@ class CRM_Activity_ActionMapping extends \Civi\ActionSchedule\Mapping {
     return $query;
   }
 
+  /**
+   * Determine whether a schedule based on this mapping should
+   * send to additional contacts.
+   */
+  public function sendToAdditional($entityId): bool {
+    return TRUE;
+  }
+
 }

--- a/CRM/Contact/ActionMapping.php
+++ b/CRM/Contact/ActionMapping.php
@@ -139,4 +139,12 @@ class CRM_Contact_ActionMapping extends \Civi\ActionSchedule\Mapping {
     return $query;
   }
 
+  /**
+   * Determine whether a schedule based on this mapping should
+   * send to additional contacts.
+   */
+  public function sendToAdditional($entityId): bool {
+    return TRUE;
+  }
+
 }

--- a/CRM/Contribute/ActionMapping/ByPage.php
+++ b/CRM/Contribute/ActionMapping/ByPage.php
@@ -216,4 +216,12 @@ class CRM_Contribute_ActionMapping_ByPage implements \Civi\ActionSchedule\Mappin
     return FALSE;
   }
 
+  /**
+   * Determine whether a schedule based on this mapping should
+   * send to additional contacts.
+   */
+  public function sendToAdditional($entityId): bool {
+    return TRUE;
+  }
+
 }

--- a/CRM/Contribute/ActionMapping/ByType.php
+++ b/CRM/Contribute/ActionMapping/ByType.php
@@ -235,4 +235,12 @@ class CRM_Contribute_ActionMapping_ByType implements \Civi\ActionSchedule\Mappin
     return FALSE;
   }
 
+  /**
+   * Determine whether a schedule based on this mapping should
+   * send to additional contacts.
+   */
+  public function sendToAdditional($entityId): bool {
+    return TRUE;
+  }
+
 }

--- a/CRM/Event/ActionMapping.php
+++ b/CRM/Event/ActionMapping.php
@@ -159,6 +159,7 @@ class CRM_Event_ActionMapping extends \Civi\ActionSchedule\Mapping {
     }
 
     // build where clause
+    // FIXME: This handles scheduled reminder of type "Event Name" and "Event Type", gives incorrect result on "Event Template".
     if (!empty($selectedValues)) {
       $valueField = ($this->id == \CRM_Event_ActionMapping::EVENT_TYPE_MAPPING_ID) ? 'event_type_id' : 'id';
       $query->where("r.{$valueField} IN (@selectedValues)")
@@ -184,6 +185,51 @@ class CRM_Event_ActionMapping extends \Civi\ActionSchedule\Mapping {
       }
     }
     return $query;
+  }
+
+  /**
+   * Determine whether a schedule based on this mapping should
+   * send to additional contacts.
+   *
+   * @param string $entityId Either an event ID/event type ID, or a set of event IDs/types separated
+   *  by the separation character.
+   */
+  public function sendToAdditional($entityId): bool {
+    $selectedValues = (array) \CRM_Utils_Array::explodePadded($entityId);
+    switch ($this->id) {
+      case self::EVENT_TYPE_MAPPING_ID:
+        $valueTable = 'e';
+        $valueField = 'event_type_id';
+        $templateReminder = FALSE;
+        break;
+
+      case self::EVENT_NAME_MAPPING_ID:
+        $valueTable = 'e';
+        $valueField = 'id';
+        $templateReminder = FALSE;
+        break;
+
+      case self::EVENT_TPL_MAPPING_ID:
+        $valueTable = 't';
+        $valueField = 'id';
+        $templateReminder = TRUE;
+        break;
+    }
+    // Don't send to additional recipients if this event is deleted or a template.
+    $query = new \CRM_Utils_SQL_Select('civicrm_event e');
+    $query
+      ->select('e.id')
+      ->where("e.is_template = 0")
+      ->where("e.is_active = 1");
+    if ($templateReminder) {
+      $query->join('r', 'INNER JOIN civicrm_event t ON e.template_title = t.template_title AND t.is_template = 1');
+    }
+    $sql = $query
+      ->where("{$valueTable}.{$valueField} IN (@selectedValues)")
+      ->param('selectedValues', $selectedValues)
+      ->toSQL();
+    $dao = \CRM_Core_DAO::executeQuery($sql);
+    return (bool) $dao->N;
   }
 
 }

--- a/CRM/Member/ActionMapping.php
+++ b/CRM/Member/ActionMapping.php
@@ -168,4 +168,12 @@ class CRM_Member_ActionMapping extends \Civi\ActionSchedule\Mapping {
     }
   }
 
+  /**
+   * Determine whether a schedule based on this mapping should
+   * send to additional contacts.
+   */
+  public function sendToAdditional($entityId): bool {
+    return TRUE;
+  }
+
 }

--- a/Civi/ActionSchedule/Mapping.php
+++ b/Civi/ActionSchedule/Mapping.php
@@ -337,4 +337,10 @@ abstract class Mapping implements MappingInterface {
     return FALSE;
   }
 
+  /**
+   * Determine whether a schedule based on this mapping should
+   * send to additional contacts.
+   */
+  abstract public function sendToAdditional($entityId): bool;
+
 }

--- a/Civi/ActionSchedule/MappingInterface.php
+++ b/Civi/ActionSchedule/MappingInterface.php
@@ -139,4 +139,10 @@ interface MappingInterface {
    */
   public function resetOnTriggerDateChange($schedule);
 
+  /**
+   * Determine whether a schedule based on this mapping should
+   * send to additional contacts.
+   */
+  public function sendToAdditional($entityId): bool;
+
 }

--- a/Civi/ActionSchedule/RecipientBuilder.php
+++ b/Civi/ActionSchedule/RecipientBuilder.php
@@ -138,7 +138,7 @@ class RecipientBuilder {
   public function build() {
     $this->buildRelFirstPass();
 
-    if ($this->prepareAddlFilter('c.id') && $this->notTemplate()) {
+    if ($this->prepareAddlFilter('c.id') && $this->mapping->sendToAdditional($this->actionSchedule->entity_value)) {
       $this->buildAddlFirstPass();
     }
 
@@ -146,7 +146,7 @@ class RecipientBuilder {
       $this->buildRelRepeatPass();
     }
 
-    if ($this->actionSchedule->is_repeat && $this->prepareAddlFilter('c.id')) {
+    if ($this->actionSchedule->is_repeat && $this->prepareAddlFilter('c.id') && $this->mapping->sendToAdditional($this->actionSchedule->entity_value)) {
       $this->buildAddlRepeatPass();
     }
   }
@@ -601,27 +601,6 @@ reminder.action_schedule_id = {$this->actionSchedule->id}";
    */
   protected function resetOnTriggerDateChange() {
     return $this->mapping->resetOnTriggerDateChange($this->actionSchedule);
-  }
-
-  /**
-   * Confirm this object isn't attached to a template.
-   * Returns TRUE if this action schedule isn't attached to a template.
-   * Templates are (currently) unique to events, so we only evaluate those.
-   *
-   * @return bool;
-   */
-  private function notTemplate() {
-    if ($this->mapping->getEntity() === 'civicrm_participant') {
-      $entityId = $this->actionSchedule->entity_value;
-      $query = new \CRM_Utils_SQL_Select('civicrm_event e');
-      $sql = $query
-        ->select('is_template')
-        ->where("e.id = {$entityId}")
-        ->toSQL();
-      $dao = \CRM_Core_DAO::executeQuery($sql);
-      return !(bool) $dao->fetchValue();
-    }
-    return TRUE;
   }
 
 }

--- a/tests/phpunit/api/v3/JobTest.php
+++ b/tests/phpunit/api/v3/JobTest.php
@@ -331,6 +331,41 @@ class api_v3_JobTest extends CiviUnitTestCase {
   }
 
   /**
+   * Deleted events should not send reminders to additional contacts.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testDeletedEventRemindAddlContacts() {
+    $contactId = $this->individualCreate();
+    $groupId = $this->groupCreate(['name' => 'Additional Contacts', 'title' => 'Additional Contacts']);
+    $this->callAPISuccess('GroupContact', 'create', [
+      'contact_id' => $contactId,
+      'group_id' => $groupId,
+    ]);
+    $event = $this->eventCreate(['title' => 'delete this event']);
+    $eventId = $event['id'];
+
+    $this->callAPISuccess('action_schedule', 'create', [
+      'title' => 'Do not send me',
+      'subject' => 'I am a reminder attached to a (soon to be) deleted event.',
+      'entity_value' => $eventId,
+      'mapping_id' => CRM_Event_ActionMapping::EVENT_NAME_MAPPING_ID,
+      'start_action_date' => 'start_date',
+      'start_action_offset' => 1,
+      'start_action_condition' => 'before',
+      'start_action_unit' => 'day',
+      'group_id' => $groupId,
+      'limit_to' => FALSE,
+      'mode' => 'Email',
+    ]);
+    $this->callAPISuccess('event', 'delete', ['id' => $eventId]);
+
+    $this->callAPISuccess('job', 'send_reminder', []);
+    $successfulCronCount = CRM_Core_DAO::singleValueQuery('SELECT count(*) FROM civicrm_action_log');
+    $this->assertEquals(0, $successfulCronCount);
+  }
+
+  /**
    * Test scheduled reminders respect limit to (since above identified addition_to handling issue).
    *
    * We create 3 contacts - 1 is in our group, 1 has our membership & the chosen one has both


### PR DESCRIPTION
Overview
----------------------------------------
If you have a scheduled reminder for an event that's deleted, it will still send (repeatedly!) reminders to anyone listed under "Additional Recipients".

Details for replication and a technical discussion are in [core#1590](https://lab.civicrm.org/dev/core/-/issues/1590).

Technical Details
----------------------------------------
This is an improvement on the approach used in #16311.  When I wrote that patch, I thought the only exception to "send to additional recipients" was if the event was a template.  I can now see that each ActionMapping class needs its own criteria to determine if additional recipients should be reminded. E.g. contacts need to check for `is_deleted`, contributions/memberships need to actually check if the record was deleted, events must do the latter AND ensure it's not a template.

So instead of simply modifying the logic of the `notTemplate()` method, I've created a new method `Civi/ActionSchedule/MappingInterface::sendToAdditional()`, and moved the `notTemplate()` logic into `CRM_Event_ActionMapping `.

Comments
----------------------------------------
This passes the test in #16311, and adds another test for deleted events.

I've set all the other `sendToAdditional()` methods to return `TRUE` to preserve current behavior on all other scheduled reminder types.  I don't doubt there are some undesired behaviors in there, but that's beyond the scope of this PR (though this PR should make those fixes trivial).
