### PR TITLE
[not-for-merge][Test] We are hitting these legacywarnings in our tests - lets' flush them out

### DIFF
--- a/Civi/Payment/PropertyBag.php
+++ b/Civi/Payment/PropertyBag.php
@@ -175,6 +175,12 @@ class PropertyBag implements \ArrayAccess {
    */
   protected function legacyWarning($message) {
     if (empty(static::$legacyWarnings)) {
+      if (CIVICRM_UF === 'UnitTests') {
+        // This idea of logging lots of warnings to the log file is an ad hoc pattern.
+        // Our standard pattern is to use CRM_Core_Error::deprecatedFunctionWarning
+        // This is just to flush out why we are hitting these in our unit tests.
+        \CRM_Core_Error::deprecatedFunctionWarning($message);
+      }
       // First time we have been called.
       register_shutdown_function([PropertyBag::class, 'writeLegacyWarnings']);
     }


### PR DESCRIPTION
Overview
----------------------------------------
This is an attempt to flush out the warnings in our test suite that are causing confusion.

Our 'normal' practice is to throw deprecation errors when deprecated code is hit. These cause tests to fail (as they should if we have decided something is deprecated to the point of having an opinion about people using it) and provide a lot of noise on dev sites but are silent on not live sites.

Currently PropertyBag is not doing this   - however there is a separate PR that relates  & should supercede this - https://github.com/civicrm/civicrm-core/pull/17588 so the primary goal here is to figure out why we are already seeing errors in the test output relating to the property bag


Before
----------------------------------------
_What is the old user-interface or technical-contract (as appropriate)?_
_For optimal clarity, include a concrete example such as a screenshot, GIF ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)), or code-snippet._

After
----------------------------------------
_What changed? What is new old user-interface or technical-contract?_
_For optimal clarity, include a concrete example such as a screenshot, GIF ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)), or code-snippet._

Technical Details
----------------------------------------
_If the PR involves technical details/changes/considerations which would not be manifest to a casual developer skimming the above sections, please describe the details here._

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
