### PR TITLE
core#1826: Ignore location_type_id when deduping postal address

### DIFF
--- a/CRM/Dedupe/BAO/Rule.php
+++ b/CRM/Dedupe/BAO/Rule.php
@@ -93,8 +93,6 @@ class CRM_Dedupe_BAO_Rule extends CRM_Dedupe_DAO_Rule {
 
       case 'civicrm_address':
         $id = 'contact_id';
-        $on[] = 't1.location_type_id = t2.location_type_id';
-        $innerJoinClauses[] = 't1.location_type_id = t2.location_type_id';
         if (!empty($this->params['civicrm_address']['location_type_id'])) {
           $locTypeId = CRM_Utils_Type::escape($this->params['civicrm_address']['location_type_id'], 'Integer', FALSE);
           if ($locTypeId) {

--- a/CRM/Dedupe/BAO/Rule.php
+++ b/CRM/Dedupe/BAO/Rule.php
@@ -92,15 +92,6 @@ class CRM_Dedupe_BAO_Rule extends CRM_Dedupe_DAO_Rule {
         break;
 
       case 'civicrm_address':
-        $id = 'contact_id';
-        if (!empty($this->params['civicrm_address']['location_type_id'])) {
-          $locTypeId = CRM_Utils_Type::escape($this->params['civicrm_address']['location_type_id'], 'Integer', FALSE);
-          if ($locTypeId) {
-            $where[] = "t1.location_type_id = $locTypeId";
-          }
-        }
-        break;
-
       case 'civicrm_email':
       case 'civicrm_im':
       case 'civicrm_openid':

--- a/tests/phpunit/CRM/Dedupe/DedupeFinderTest.php
+++ b/tests/phpunit/CRM/Dedupe/DedupeFinderTest.php
@@ -448,20 +448,4 @@ class CRM_Dedupe_DedupeFinderTest extends CiviUnitTestCase {
     $this->assertEquals(count($this->contactIDs), 7, 'Check for number of contacts.');
   }
 
-  /**
-   * @return array|int
-   * @throws \CRM_Core_Exception
-   */
-  protected function createRuleGroup() {
-    $ruleGroup = $this->callAPISuccess('RuleGroup', 'create', [
-      'contact_type' => 'Individual',
-      'threshold' => 8,
-      'used' => 'General',
-      'name' => 'TestRule',
-      'title' => 'TestRule',
-      'is_reserved' => 0,
-    ]);
-    return $ruleGroup;
-  }
-
 }

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -3550,6 +3550,22 @@ VALUES
   }
 
   /**
+   * @return array|int
+   * @throws \CRM_Core_Exception
+   */
+  protected function createRuleGroup() {
+    $ruleGroup = $this->callAPISuccess('RuleGroup', 'create', [
+      'contact_type' => 'Individual',
+      'threshold' => 8,
+      'used' => 'General',
+      'name' => 'TestRule',
+      'title' => 'TestRule',
+      'is_reserved' => 0,
+    ]);
+    return $ruleGroup;
+  }
+
+  /**
    * Generic create test.
    *
    * @param int $version


### PR DESCRIPTION
Overview
----------------------------------------
[Core#1826](https://lab.civicrm.org/dev/core/-/issues/1826) builds on [this Stack Exchange question](https://civicrm.stackexchange.com/questions/34671/dedupe-rule-ignores-the-location-type-for-email-phone-but-does-not-ignore-for-ad), which discusses the inconsistency of location types when deduping.  Location type is ignored for emails and phones, but considered for postal address.  Per Stack Exchange, the consensus is to ignore location_type_id for postal addresses.

Before
----------------------------------------
When deduping, we don't count identical address fields (e.g. postal code) if the addresses have different location types.

After
----------------------------------------
When deduping, we **do** count identical address fields (e.g. postal code) if the addresses have different location types.

Comments
----------------------------------------
The only functional change is removing the two lines in `CRM_Dedupe_BAO_Rule`.  In the tests, I moved the `createRuleGroup()` helper method to a parent class so I could make use of it in `CRM_Dedupe_MergerTest`.
