### PR TITLE
Fix isMultilingual to use static caching and respect current domain

### DIFF
--- a/CRM/Core/I18n.php
+++ b/CRM/Core/I18n.php
@@ -584,15 +584,14 @@ class CRM_Core_I18n {
   }
 
   /**
-   * Is the CiviCRM in multilingual mode.
+   * Is the current CiviCRM domain in multilingual mode.
    *
    * @return Bool
    *   True if CiviCRM is in multilingual mode.
    */
   public static function isMultilingual() {
-    $domain = new CRM_Core_DAO_Domain();
-    $domain->find(TRUE);
-    return (bool) $domain->locales;
+    $domainId = CRM_Core_Config::domainID();
+    return (bool) CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Domain', $domainId, 'locales');
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
This improves the efficiency and accuracy of the `CRM_Core_I18n::isMultilingual` function, preventing a large number of duplicate queries on every request.

Before
----------------------------------------
The function `CRM_Core_I18n::isMultilingual` apparently had two problems:

1. The results were not cached, and since this function is called frequently, that resulted in repetitive hits on the database.
2. The function did not seem to respect multi-domain setups, as it always used domain 1 instead of the current domain.

After
----------------------------------------
Fixed.

Comments
----------------------------------------
This is going to especially help the efficiency of medatata-heavy operations like APIv4, as `AllCoreTables` calls this function repeatedly.