### PR TITLE
[REF] Fix parts of code where curly brackets were being used for array or string access which is deprecated in PHP7.4

### DIFF
--- a/CRM/Report/Form/Contribute/Summary.php
+++ b/CRM/Report/Form/Contribute/Summary.php
@@ -354,7 +354,7 @@ class CRM_Report_Form_Contribute_Summary extends CRM_Report_Form {
                 $fy = $config->fiscalYearStart;
                 $fiscal = self::fiscalYearOffset($field['dbAlias']);
 
-                $select[] = "DATE_ADD(MAKEDATE({$fiscal}, 1), INTERVAL ({$fy{'M'}})-1 MONTH) AS {$tableName}_{$fieldName}_start";
+                $select[] = "DATE_ADD(MAKEDATE({$fiscal}, 1), INTERVAL ({$fy['M']})-1 MONTH) AS {$tableName}_{$fieldName}_start";
                 $select[] = "{$fiscal} AS {$tableName}_{$fieldName}_subtotal";
                 $select[] = "{$fiscal} AS {$tableName}_{$fieldName}_interval";
                 $field['title'] = ts('Fiscal Year Beginning');

--- a/Civi/Angular/ChangeSet.php
+++ b/Civi/Angular/ChangeSet.php
@@ -150,7 +150,7 @@ class ChangeSet implements ChangeSetInterface {
    */
   public function alterHtml($file, $callback) {
     $this->htmlFilters[] = [
-      'regex' => ($file{0} === ';') ? $file : $this->createRegex($file),
+      'regex' => ($file[0] === ';') ? $file : $this->createRegex($file),
       'callback' => $callback,
     ];
     return $this;

--- a/composer.json
+++ b/composer.json
@@ -242,6 +242,9 @@
         "Support PHPUnit 6+": "https://github.com/php-cache/integration-tests/commit/1ec7362962185df91d3d749bc3fa7e7b99cb9fc7.patch",
         "Add tests for binary data round trip": "https://github.com/php-cache/integration-tests/commit/89cd7068e83aa776774bfc44f6bcba858c085616.patch"
       },
+      "electrolinux/phpquery": {
+        "PHP7.4 Fix for array access using {} instead of []": "https://raw.githubusercontent.com/civicrm/civicrm-core/fe45bdfc4f3e3d3deb27e3d853cdbc7f616620a9/tools/scripts/composer/patches/php74_array_access_fix_phpquery.patch"
+      },
       "pear/mail": {
         "Apply CiviCRM Customisations for CRM-1367 and CRM-5946": "https://raw.githubusercontent.com/civicrm/civicrm-core/36319938a5bf26c1e7e2110a26a65db6a5979268/tools/scripts/composer/patches/pear-mail.patch"
       },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3c6d377d0dfd5ce11b0a96af56344181",
+    "content-hash": "96209031150a0c16ca42aeb4422abe56",
     "packages": [
         {
             "name": "adrienrn/php-mimetyper",
@@ -431,6 +431,11 @@
                 "shasum": ""
             },
             "type": "library",
+            "extra": {
+                "patches_applied": {
+                    "PHP7.4 Fix for array access using {} instead of []": "https://raw.githubusercontent.com/civicrm/civicrm-core/fe45bdfc4f3e3d3deb27e3d853cdbc7f616620a9/tools/scripts/composer/patches/php74_array_access_fix_phpquery.patch"
+                }
+            },
             "autoload": {
                 "classmap": [
                     "phpQuery/"
@@ -3061,5 +3066,6 @@
     "platform-dev": [],
     "platform-overrides": {
         "php": "7.1"
-    }
+    },
+    "plugin-api-version": "1.1.0"
 }


### PR DESCRIPTION
Overview
----------------------------------------
PHP 7.4 deprecates using {} for array or string access

Before
----------------------------------------
Tests fail due to {} being used

After
----------------------------------------
Tests pass

Tests affected are 

* api_v3_ReportTemplateTest.testReportTemplateSelectWhere with data set #5 (from api_v3_ReportTemplateTest__testReportTemplateSelectWhere)
* Civi\Angular\ChangeSetTest::testInsertAfter
* Civi\Angular\ManagerTest::testGetPartials
* Civi\Angular\PartialSyntaxTest::testConsistencyExamples

ping @mattwire @eileenmcnaughton 
