### PR TITLE
[REF] Ensure that the Manual Payment Processor sets the _paymentProc…

### DIFF
--- a/CRM/Core/Payment/Manual.php
+++ b/CRM/Core/Payment/Manual.php
@@ -24,6 +24,19 @@ class CRM_Core_Payment_Manual extends CRM_Core_Payment {
   public function checkConfig() {}
 
   /**
+   * Constructor.
+   */
+  public function __construct() {
+    $this->_paymentProcessor = [
+      'payment_type' => 0,
+      'billing_mode' => 0,
+      'id' => 0,
+      'url_recur' => '',
+      'is_recur' => 0,
+    ];
+  }
+
+  /**
    * Get billing fields required for this processor.
    *
    * We apply the existing default of returning fields only for payment processor type 1. Processors can override to


### PR DESCRIPTION
…essor variable like other Processors to fix issues in PHP7.4 and UnitTests

Overview
----------------------------------------
This aims to fix some failing unit tests on PHP7.4 by ensuring that the Manual Processor sets the _paymentProcessor variable like other processors

Before
----------------------------------------
Tests fail on PHP7.4

After
----------------------------------------
Tests pass on PHP7.4

example test fail on PHP7.4 https://test.civicrm.org/job/CiviCRM-Core-Edge/CIVIVER=master,label=test-3/lastCompletedBuild/testReport/(root)/api_v3_ContributionPageTest/testValidate/