### PR TITLE
[REF] Fix PHP7.4 Test fails when we are accessing array keys when the…

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -2049,7 +2049,7 @@ class CRM_Contact_BAO_Query {
             $this->_params[$id][1]
           );
           $this->_qill[0][] = ts("%1 %2 %3", [
-            1 => $field['title'],
+            1 => $field['title'] ?? '',
             2 => $qillop,
             3 => $qillVal,
           ]);

--- a/tests/phpunit/CRM/Core/BAO/CustomFieldTest.php
+++ b/tests/phpunit/CRM/Core/BAO/CustomFieldTest.php
@@ -216,13 +216,13 @@ class CRM_Core_BAO_CustomFieldTest extends CiviUnitTestCase {
     ];
     $createdField = $this->callAPISuccess('customField', 'create', $params);
     $contact1 = $this->individualCreate();
-    $contact2 = $this->individualCreate(['custom_' . $createdField['id'] => $contact1['id']]);
-
-    $this->assertEquals($contact1['display_name'], CRM_Core_BAO_CustomField::displayValue($contact2['id'], $createdField['id']));
+    $contact2 = $this->individualCreate(['custom_' . $createdField['id'] => $contact1]);
+    $contact1Details = $this->callAPISuccess('Contact', 'getsingle', ['id' => $contact1]);
+    $this->assertEquals($contact1Details['display_name'], CRM_Core_BAO_CustomField::displayValue($contact2, $createdField['id']));
     $this->assertEquals("Bob", CRM_Core_BAO_CustomField::displayValue("Bob", $createdField['id']));
 
-    $this->contactDelete($contact2['id']);
-    $this->contactDelete($contact1['id']);
+    $this->contactDelete($contact2);
+    $this->contactDelete($contact1);
     $this->customGroupDelete($customGroup['id']);
   }
 


### PR DESCRIPTION
… value is not an array

Overview
----------------------------------------
This aims to fix a couple of unit tests that fail on PHP 7.4 because we are using array access on values that are either NULL or an Integer

Before
----------------------------------------
Tests fail on PHP7.4

After
----------------------------------------
Tests pass on PHP7.4

tests affected are:

* CRM_Core_BAO_CustomFieldTest::testAlterCustomFieldDisplayValueHook
* CRM_Core_BAO_CustomFieldTest::testGetDisplayedValuesContactRef