### PR TITLE
[REF] - Add helper function for the repetitive task of fetching multilingual

### DIFF
--- a/CRM/Admin/Form/Setting/Localization.php
+++ b/CRM/Admin/Form/Setting/Localization.php
@@ -181,9 +181,8 @@ class CRM_Admin_Form_Setting_Localization extends CRM_Admin_Form_Setting {
 
     // add a new db locale if the requested language is not yet supported by the db
     if (empty($values['makeSinglelingual']) && !empty($values['addLanguage'])) {
-      $domain = new CRM_Core_DAO_Domain();
-      $domain->find(TRUE);
-      if (!substr_count($domain->locales, $values['addLanguage'])) {
+      $locales = CRM_Core_I18n::getMultilingual();
+      if (!in_array($values['addLanguage'], $locales)) {
         CRM_Core_I18n_Schema::addLocale($values['addLanguage'], $values['lcMessages']);
       }
       $values['languageLimit'][$values['addLanguage']] = 1;
@@ -276,22 +275,15 @@ class CRM_Admin_Form_Setting_Localization extends CRM_Admin_Form_Setting {
    * @return array
    */
   public static function getDefaultLocaleOptions() {
-    $domain = new CRM_Core_DAO_Domain();
-    $domain->find(TRUE);
-    $locales = CRM_Core_I18n::languages();
-    if ($domain->locales) {
+    $locales = CRM_Core_I18n::getMultilingual();
+    $languages = CRM_Core_I18n::languages();
+    if ($locales) {
       // for multi-lingual sites, populate default language drop-down with available languages
-      $defaultLocaleOptions = [];
-      foreach ($locales as $loc => $lang) {
-        if (substr_count($domain->locales, $loc)) {
-          $defaultLocaleOptions[$loc] = $lang;
-        }
-      }
+      return array_intersect_key($languages, array_flip($locales));
     }
     else {
-      $defaultLocaleOptions = $locales;
+      return $languages;
     }
-    return $defaultLocaleOptions;
   }
 
   /**

--- a/CRM/Case/Info.php
+++ b/CRM/Case/Info.php
@@ -255,12 +255,10 @@ class CRM_Case_Info extends CRM_Core_Component_Info {
     $dao = new CRM_Core_DAO();
     $db = $dao->getDatabaseConnection();
 
-    $domain = new CRM_Core_DAO_Domain();
-    $domain->find(TRUE);
-    $multiLingual = (bool) $domain->locales;
+    $locales = CRM_Core_I18n::getMultilingual();
     $smarty = CRM_Core_Smarty::singleton();
-    $smarty->assign('multilingual', $multiLingual);
-    $smarty->assign('locales', explode(CRM_Core_DAO::VALUE_SEPARATOR, $domain->locales));
+    $smarty->assign('multilingual', (bool) $locales);
+    $smarty->assign('locales', $locales);
 
     if (!$lineMode) {
 

--- a/CRM/Contribute/BAO/ContributionPage.php
+++ b/CRM/Contribute/BAO/ContributionPage.php
@@ -842,8 +842,7 @@ LEFT JOIN  civicrm_premiums            ON ( civicrm_premiums.entity_id = civicrm
     $tsLocale = CRM_Core_I18n::getLocale();
     $config = CRM_Core_Config::singleton();
     $json = $jsonDecode = NULL;
-    $domain = new CRM_Core_DAO_Domain();
-    $domain->find(TRUE);
+    $multilingual = CRM_Core_I18n::isMultilingual();
 
     $moduleDataFormat = [
       'soft_credit' => [
@@ -866,7 +865,7 @@ LEFT JOIN  civicrm_premiums            ON ( civicrm_premiums.entity_id = civicrm
     if ($setDefault) {
       $jsonDecode = json_decode($params);
       $jsonDecode = (array) $jsonDecode->$module;
-      if (!$domain->locales && !empty($jsonDecode['default'])) {
+      if (!$multilingual && !empty($jsonDecode['default'])) {
         //monolingual state
         $jsonDecode += (array) $jsonDecode['default'];
         unset($jsonDecode['default']);
@@ -882,7 +881,7 @@ LEFT JOIN  civicrm_premiums            ON ( civicrm_premiums.entity_id = civicrm
     }
 
     //check and handle multilingual honoree params
-    if (!$domain->locales) {
+    if (!$multilingual) {
       //if in singlelingual state simply return the array format
       $json = [$module => NULL];
       foreach ($moduleDataFormat[$module] as $key => $attribute) {

--- a/CRM/Core/BAO/SchemaHandler.php
+++ b/CRM/Core/BAO/SchemaHandler.php
@@ -335,10 +335,8 @@ ALTER TABLE {$tableName}
       else {
         CRM_Core_DAO::executeQuery($sql, [], TRUE, NULL, FALSE, FALSE);
       }
-      $domain = new CRM_Core_DAO_Domain();
-      $domain->find(TRUE);
-      if ($domain->locales) {
-        $locales = explode(CRM_Core_DAO::VALUE_SEPARATOR, $domain->locales);
+      $locales = CRM_Core_I18n::getMultilingual();
+      if ($locales) {
         CRM_Core_I18n_Schema::rebuildMultilingualSchema($locales, NULL, $isUpgradeMode);
       }
     }
@@ -385,9 +383,7 @@ ADD UNIQUE INDEX `unique_entity_id` ( `entity_id` )";
    */
   public static function createIndexes($tables, $createIndexPrefix = 'index', $substrLengths = []) {
     $queries = [];
-    $domain = new CRM_Core_DAO_Domain();
-    $domain->find(TRUE);
-    $locales = explode(CRM_Core_DAO::VALUE_SEPARATOR, $domain->locales);
+    $locales = CRM_Core_I18n::getMultilingual();
 
     // if we're multilingual, cache the information on internationalised fields
     static $columns = NULL;

--- a/CRM/Core/BAO/WordReplacement.php
+++ b/CRM/Core/BAO/WordReplacement.php
@@ -152,8 +152,6 @@ WHERE  domain_id = %1
       }
     }
     $config = CRM_Core_Config::singleton();
-    $domain = new CRM_Core_DAO_Domain();
-    $domain->find(TRUE);
 
     // So. Weird. Some bizarre/probably-broken multi-lingual thing where
     // data isn't really stored in civicrm_word_replacements. Probably

--- a/CRM/Core/DAO/AllCoreTables.php
+++ b/CRM/Core/DAO/AllCoreTables.php
@@ -117,10 +117,8 @@ class CRM_Core_DAO_AllCoreTables {
    *   index definitions after localization
    */
   public static function multilingualize($class, $originalIndices) {
-    $domain = new CRM_Core_DAO_Domain();
-    $domain->find(TRUE);
-    $locales = explode(CRM_Core_DAO::VALUE_SEPARATOR, $domain->locales);
-    if (CRM_Utils_System::isNull($locales)) {
+    $locales = CRM_Core_I18n::getMultilingual();
+    if (!$locales) {
       return $originalIndices;
     }
     $classFields = $class::fields();

--- a/CRM/Core/I18n.php
+++ b/CRM/Core/I18n.php
@@ -586,12 +586,27 @@ class CRM_Core_I18n {
   /**
    * Is the current CiviCRM domain in multilingual mode.
    *
-   * @return Bool
+   * @return bool
    *   True if CiviCRM is in multilingual mode.
    */
   public static function isMultilingual() {
-    $domainId = CRM_Core_Config::domainID();
-    return (bool) CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Domain', $domainId, 'locales');
+    return (bool) CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Domain',
+      CRM_Core_Config::domainID(),
+      'locales'
+    );
+  }
+
+  /**
+   * Returns languages if domain is in multilingual mode.
+   *
+   * @return array|bool
+   */
+  public static function getMultilingual() {
+    $locales = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Domain',
+      CRM_Core_Config::domainID(),
+      'locales'
+    );
+    return $locales ? CRM_Core_DAO::unSerializeField($locales, CRM_Core_DAO::SERIALIZE_SEPARATOR_TRIMMED) : FALSE;
   }
 
   /**
@@ -600,7 +615,7 @@ class CRM_Core_I18n {
    * @param $language
    *   Language (for example 'en_US', or 'fr_CA').
    *
-   * @return Bool
+   * @return bool
    *   True if it is an RTL language.
    */
   public static function isLanguageRTL($language) {

--- a/CRM/Core/I18n/Schema.php
+++ b/CRM/Core/I18n/Schema.php
@@ -20,13 +20,11 @@ class CRM_Core_I18n_Schema {
    * Drop all views (for use by CRM_Core_DAO::dropAllTables() mostly).
    */
   public static function dropAllViews() {
-    $domain = new CRM_Core_DAO_Domain();
-    $domain->find(TRUE);
-    if (!$domain->locales) {
+    $locales = CRM_Core_I18n::getMultilingual();
+    if (!$locales) {
       return;
     }
 
-    $locales = explode(CRM_Core_DAO::VALUE_SEPARATOR, $domain->locales);
     $tables = CRM_Core_I18n_SchemaStructure::tables();
 
     foreach ($locales as $locale) {
@@ -81,6 +79,7 @@ class CRM_Core_I18n_Schema {
    */
   public static function makeSinglelingual($retain) {
     $domain = new CRM_Core_DAO_Domain();
+    $domain->id = CRM_Core_Config::domainID();
     $domain->find(TRUE);
     $locales = explode(CRM_Core_DAO::VALUE_SEPARATOR, $domain->locales);
 
@@ -130,6 +129,7 @@ class CRM_Core_I18n_Schema {
     $triggers = []
   ) {
     $domain = new CRM_Core_DAO_Domain();
+    $domain->id = CRM_Core_Config::domainID();
     $domain->find(TRUE);
     $locales = explode(CRM_Core_DAO::VALUE_SEPARATOR, $domain->locales);
 
@@ -207,6 +207,7 @@ class CRM_Core_I18n_Schema {
   public static function addLocale($locale, $source) {
     // get the current supported locales
     $domain = new CRM_Core_DAO_Domain();
+    $domain->id = CRM_Core_Config::domainID();
     $domain->find(TRUE);
     $locales = explode(CRM_Core_DAO::VALUE_SEPARATOR, $domain->locales);
 
@@ -485,13 +486,11 @@ class CRM_Core_I18n_Schema {
    */
   public static function triggerInfo(&$info, $tableName = NULL) {
     // get the current supported locales
-    $domain = new CRM_Core_DAO_Domain();
-    $domain->find(TRUE);
-    if (empty($domain->locales)) {
+    $locales = CRM_Core_I18n::getMultilingual();
+    if (!$locales) {
       return;
     }
 
-    $locales = explode(CRM_Core_DAO::VALUE_SEPARATOR, $domain->locales);
     $locale = array_pop($locales);
 
     // CRM-10027

--- a/CRM/Logging/Schema.php
+++ b/CRM/Logging/Schema.php
@@ -72,8 +72,6 @@ class CRM_Logging_Schema {
    * @throws API_Exception
    */
   public static function checkLoggingSupport(&$value, $fieldSpec) {
-    $domain = new CRM_Core_DAO_Domain();
-    $domain->find(TRUE);
     if (!(CRM_Core_DAO::checkTriggerViewPermission(FALSE)) && $value) {
       throw new API_Exception(ts("In order to use this functionality, the installation's database user must have privileges to create triggers and views (if binary logging is enabled – this means the SUPER privilege). This install does not have the required privilege(s) enabled."));
     }

--- a/CRM/Upgrade/Form.php
+++ b/CRM/Upgrade/Form.php
@@ -68,11 +68,10 @@ class CRM_Upgrade_Form extends CRM_Core_Form {
   ) {
     $this->_config = CRM_Core_Config::singleton();
 
-    $domain = new CRM_Core_DAO_Domain();
-    $domain->find(TRUE);
+    $locales = CRM_Core_I18n::getMultilingual();
 
-    $this->multilingual = (bool) $domain->locales;
-    $this->locales = explode(CRM_Core_DAO::VALUE_SEPARATOR, $domain->locales);
+    $this->multilingual = (bool) $locales;
+    $this->locales = $locales;
 
     $smarty = CRM_Core_Smarty::singleton();
     //$smarty->compile_dir = $this->_config->templateCompileDir;

--- a/CRM/Upgrade/Incremental/Base.php
+++ b/CRM/Upgrade/Incremental/Base.php
@@ -140,13 +140,11 @@ class CRM_Upgrade_Incremental_Base {
    * @return bool
    */
   public static function addColumn($ctx, $table, $column, $properties, $localizable = FALSE, $version = NULL) {
-    $domain = new CRM_Core_DAO_Domain();
-    $domain->find(TRUE);
+    $locales = CRM_Core_I18n::getMultilingual();
     $queries = [];
     if (!CRM_Core_BAO_SchemaHandler::checkIfFieldExists($table, $column, FALSE)) {
-      if ($domain->locales) {
+      if ($locales) {
         if ($localizable) {
-          $locales = explode(CRM_Core_DAO::VALUE_SEPARATOR, $domain->locales);
           foreach ($locales as $locale) {
             if (!CRM_Core_BAO_SchemaHandler::checkIfFieldExists($table, "{$column}_{$locale}", FALSE)) {
               $queries[] = "ALTER TABLE `$table` ADD COLUMN `{$column}_{$locale}` $properties";
@@ -164,8 +162,7 @@ class CRM_Upgrade_Incremental_Base {
         CRM_Core_DAO::executeQuery($query, [], TRUE, NULL, FALSE, FALSE);
       }
     }
-    if ($domain->locales) {
-      $locales = explode(CRM_Core_DAO::VALUE_SEPARATOR, $domain->locales);
+    if ($locales) {
       CRM_Core_I18n_Schema::rebuildMultilingualSchema($locales, $version, TRUE);
     }
     return TRUE;
@@ -298,10 +295,8 @@ class CRM_Upgrade_Incremental_Base {
    * @return bool
    */
   public static function rebuildMultilingalSchema($ctx, $version = NULL) {
-    $domain = new CRM_Core_DAO_Domain();
-    $domain->find(TRUE);
-    if ($domain->locales) {
-      $locales = explode(CRM_Core_DAO::VALUE_SEPARATOR, $domain->locales);
+    $locales = CRM_Core_I18n::getMultilingual();
+    if ($locales) {
       CRM_Core_I18n_Schema::rebuildMultilingualSchema($locales, $version);
     }
     return TRUE;

--- a/CRM/Upgrade/Incremental/php/FiveTwentySeven.php
+++ b/CRM/Upgrade/Incremental/php/FiveTwentySeven.php
@@ -75,10 +75,8 @@ class CRM_Upgrade_Incremental_php_FiveTwentySeven extends CRM_Upgrade_Incrementa
   }
 
   public function priceFieldValueLabelRequired($ctx) {
-    $domain = new CRM_Core_DAO_Domain();
-    $domain->find(TRUE);
-    if ($domain->locales) {
-      $locales = explode(CRM_Core_DAO::VALUE_SEPARATOR, $domain->locales);
+    $locales = CRM_Core_I18n::getMultilingual();
+    if ($locales) {
       foreach ($locales as $locale) {
         CRM_Core_DAO::executeQuery("UPDATE civicrm_price_field_value SET label_{$locale} = '' WHERE label_{$locale} IS NULL", [], TRUE, NULL, FALSE, FALSE);
         CRM_Core_DAO::executeQuery("ALTER TABLE civicrm_price_field_value CHANGE `label_{$locale}` `label_{$locale}` varchar(255) NOT NULL   COMMENT 'Price field option label'", [], TRUE, NULL, FALSE, FALSE);
@@ -92,10 +90,8 @@ class CRM_Upgrade_Incremental_php_FiveTwentySeven extends CRM_Upgrade_Incrementa
   }
 
   public function nameMembershipTypeRequired($ctx) {
-    $domain = new CRM_Core_DAO_Domain();
-    $domain->find(TRUE);
-    if ($domain->locales) {
-      $locales = explode(CRM_Core_DAO::VALUE_SEPARATOR, $domain->locales);
+    $locales = CRM_Core_I18n::getMultilingual();
+    if ($locales) {
       foreach ($locales as $locale) {
         CRM_Core_DAO::executeQuery("UPDATE civicrm_membership_type SET name_{$locale} = '' WHERE name_{$locale} IS NULL", [], TRUE, NULL, FALSE, FALSE);
         CRM_Core_DAO::executeQuery("ALTER TABLE civicrm_membership_type CHANGE `name_{$locale}` `name_{$locale}` varchar(128) NOT NULL   COMMENT 'Name of Membership Type'", [], TRUE, NULL, FALSE, FALSE);

--- a/api/v3/System.php
+++ b/api/v3/System.php
@@ -514,11 +514,8 @@ function civicrm_api3_system_createmissinglogtables() {
  *
  */
 function civicrm_api3_system_rebuildmultilingualschema() {
-  $domain = new CRM_Core_DAO_Domain();
-  $domain->find(TRUE);
-
-  if ($domain->locales) {
-    $locales = explode(CRM_Core_DAO::VALUE_SEPARATOR, $domain->locales);
+  $locales = CRM_Core_I18n::getMultilingual();
+  if ($locales) {
     CRM_Core_I18n_Schema::rebuildMultilingualSchema($locales);
     return civicrm_api3_create_success(1);
   }


### PR DESCRIPTION
Overview
----------

Adds the function CRM_Core_I18n::getMultilingual() and replaces a bunch of places where the work was being done manually.

Before
----------------------------------------
Repetitive, inefficient code that did not respect multiple domains.

After
----------------------------------------
Smaller, more efficient, respects current domain and uses caching to avoid unnecessary hits on the db.

Comments
----------

This also fixes what I suspect is a bug - multiple domains may not have been compatible with multiple languages, as this code pattern seems to ignore the current domain and always return domain 1:

```php
  $domain = new CRM_Core_DAO_Domain();
  $domain->find(TRUE);
```

**Update:** Per https://lab.civicrm.org/dev/core/-/issues/1852 we have pushed a PR that ensures all domains reflect multilingual settings, so this PR should work consistently now that #17733 is merged.