### PR TITLE
Use BrickMoney for Smarty modifier 

### DIFF
--- a/CRM/Core/Smarty/plugins/modifier.crmMoney.php
+++ b/CRM/Core/Smarty/plugins/modifier.crmMoney.php
@@ -9,13 +9,9 @@
  +--------------------------------------------------------------------+
  */
 
-/**
- *
- * @package CRM
- * @copyright CiviCRM LLC https://civicrm.org/licensing
- * $Id$
- *
- */
+use Brick\Money\Money;
+use Brick\Money\Context\DefaultContext;
+use Brick\Math\RoundingMode;
 
 /**
  * Format the given monetary amount (and currency) for display
@@ -31,5 +27,11 @@
  * @throws \CRM_Core_Exception
  */
 function smarty_modifier_crmMoney($amount, $currency = NULL) {
-  return CRM_Utils_Money::format($amount, $currency);
+  if (!$amount) {
+    return $amount;
+  }
+  $currency = $currency ?? CRM_Core_Config::singleton()->defaultCurrency;
+  $money = Money::of($amount, $currency, new DefaultContext(), RoundingMode::CEILING);
+  $formatter = new \NumberFormatter(CRM_Core_I18n::singleton()->getLocale(), \NumberFormatter::CURRENCY);
+  return $money->formatWith($formatter);
 }


### PR DESCRIPTION

Overview
----------------------------------------
Switchings crmMoney to use BrickMoney

Before
----------------------------------------
Custom handling

After
----------------------------------------
Relevant package

Technical Details
----------------------------------------
Note that this will need testing in various currency & locale configs

Note that using ```CRM_Core_I18n::singleton()->getLocale()``` for the locale might have some
edge cases.

If I'm in NZ paying in Euros should I see the decimal in the NZ place or the Euro
place. Backoffice users should not be confused by commas etc.  I haven't tested these
variations yet so flagging them as things to consider during review stage

Comments
----------------------------------------
Needs a good tyre-kicking 