### PR TITLE
dev/core#1828 Geo code Job, filter on contact type

### DIFF
--- a/CRM/Utils/Address/BatchUpdate.php
+++ b/CRM/Utils/Address/BatchUpdate.php
@@ -28,6 +28,7 @@ class CRM_Utils_Address_BatchUpdate {
   public $geocoding = 1;
   public $parse = 1;
   public $throttle = 0;
+  public $ct = NULL;
 
   public $returnMessages = [];
   public $returnError = 0;
@@ -126,6 +127,11 @@ class CRM_Utils_Address_BatchUpdate {
     if ($this->end) {
       $clause[] = "( c.id <= %2 )";
       $params[2] = [$this->end, 'Integer'];
+    }
+    // contact type filter
+    if ($this->ct && in_array($this->ct, ['Individual', 'Household', 'Organization'])) {
+      $clause[] = "( c.contact_type = %3 )";
+      $params[3] = [$this->ct, 'String'];
     }
 
     if ($processGeocode) {

--- a/api/v3/Job.php
+++ b/api/v3/Job.php
@@ -179,6 +179,10 @@ function _civicrm_api3_job_geocode_spec(&$params) {
     'description' => 'If enabled, geo-codes at a slow rate',
     'type' => CRM_Utils_Type::T_BOOLEAN,
   ];
+  $params['ct'] = [
+    'title' => 'Contact Type',
+    'type' => CRM_Utils_Type::T_STRING,
+  ];
 }
 
 /**

--- a/xml/templates/civicrm_data.tpl
+++ b/xml/templates/civicrm_data.tpl
@@ -1662,6 +1662,7 @@ VALUES
 parse=[1 or 0] required
 start=[contact ID] optional-begin with this contact ID
 end=[contact ID] optional-process contacts with IDs less than this
+ct=[Individual or Household or Organization] optional-process contacts with these type
 throttle=[1 or 0] optional-1 adds five second sleep{/ts}', 0),
     ( @domainID, 'Daily' ,  NULL, '{ts escape="sql" skip="true"}Update Greetings and Addressees{/ts}','{ts escape="sql" skip="true"}Goes through contact records and updates email and postal greetings, or addressee value{/ts}', 'job', 'update_greeting','{ts escape="sql" skip="true"}ct=[Individual or Household or Organization] required
 gt=[email_greeting or postal_greeting or addressee] required


### PR DESCRIPTION
Overview
----------------------------------------
Add option to batch_update job to permit specifying the contact type.

When civicrm address have millions of address record without geo codes, We don't want geo code for all contacts because of free api quota per day/month, for that we want to restrict geo code for certain contact type, e.g Organization.

Currently We don't have control on choosing specific type of Contact Type of Geo code.


Current available options
----------------------------------------
geocoding=[1 or 0] required

parse=[1 or 0] required

start=[contact ID] optional-begin with this contact ID

end=[contact ID] optional-process contacts with IDs less than this

throttle=[1 or 0] optional-1 adds five second sleep

Proposed New option along with existing options
----------------------------------------
ct=[Individual or Household or Organization] optional-process contacts with these type

----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/1828