### PR TITLE
[REF] Fix Compatability issue with flexmailer caused by the PHP7.4 fix

### DIFF
--- a/CRM/Mailing/ActionTokens.php
+++ b/CRM/Mailing/ActionTokens.php
@@ -82,10 +82,10 @@ class CRM_Mailing_ActionTokens extends \Civi\Token\AbstractTokenSubscriber {
 
     list($verp, $urls) = CRM_Mailing_BAO_Mailing::getVerpAndUrls(
       $row->context['mailingJobId'],
-      $row->context['mailingActionTarget']['id'] ?? 0,
-      $row->context['mailingActionTarget']['hash'] ?? '',
+      $row->context['mailingActionTarget']['id'] ?? NULL,
+      $row->context['mailingActionTarget']['hash'] ?? NULL,
       // Note: Behavior is already undefined for SMS/'phone' mailings...
-      $row->context['mailingActionTarget']['email'] ?? ''
+      $row->context['mailingActionTarget']['email'] ?? NULL
     );
 
     $row->format('text/plain')->tokens($entity, $field,


### PR DESCRIPTION
Overview
----------------------------------------
This commit https://github.com/civicrm/civicrm-core/pull/17600/commits/32c3b33f2460e1aef692964c1cfbcf06097d7d20 to fix some null value access issues for PHP7.4 reasons broke a couple of flexmailer tests

Before
----------------------------------------
Flexmailer tests broken https://test.civicrm.org/job/CiviCRM-Ext-Matrix/BKPROF=min,BUILDTYPE=git,CIVIVER=master,EXTKEY=org.civicrm.flexmailer,label=bknix-tmp/1986/ 

After
----------------------------------------
Flexmailer tests fixed

ping @eileenmcnaughton @totten @mattwire 