### PR TITLE
[NFC] Fix tests in prepartion for phpunit7

### DIFF
--- a/CRM/Core/BAO/Country.php
+++ b/CRM/Core/BAO/Country.php
@@ -57,7 +57,7 @@ class CRM_Core_BAO_Country extends CRM_Core_DAO_Country {
     if (!isset(Civi::$statics[__CLASS__]['countryLimit'])) {
       $countryIsoCodes = CRM_Core_PseudoConstant::countryIsoCode();
       $country = [];
-      $countryLimit = Civi::settings()->get('countryLimit');
+      $countryLimit = Civi::settings()->get('countryLimit') ?? [];
       if (is_array($countryLimit)) {
         foreach ($countryLimit as $val) {
           // CRM-12007

--- a/Civi/Test/DbTestTrait.php
+++ b/Civi/Test/DbTestTrait.php
@@ -143,7 +143,7 @@ trait DbTestTrait {
     $expectedValue, $message
   ) {
     $value = \CRM_Core_DAO::getFieldValue($daoName, $searchValue, $returnColumn, $searchColumn, TRUE);
-    $this->assertEquals($expectedValue, $value, $message);
+    $this->assertEquals(trim($expectedValue), trim($value), $message);
   }
 
   /**

--- a/tests/phpunit/CRM/Campaign/Form/CampaignTest.php
+++ b/tests/phpunit/CRM/Campaign/Form/CampaignTest.php
@@ -40,7 +40,7 @@ class CRM_Campaign_Form_CampaignTest extends CiviUnitTestCase {
       'campaign_type_id' => 1,
     ], $form);
     $campaign = $this->callAPISuccess('campaign', 'get', ['id' => $result['id']]);
-    $this->assertEquals('10000', $campaign['values'][$campaign['id']]['goal_revenue']);
+    $this->assertEquals('10000.00', $campaign['values'][$campaign['id']]['goal_revenue']);
   }
 
 }

--- a/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
@@ -413,7 +413,7 @@ class CRM_Contribute_Form_ContributionTest extends CiviUnitTestCase {
       'contact_id' => $this->_individualId,
       'contribution_status_id' => 'Completed',
     ]);
-    $this->assertEquals('50', $contribution['total_amount']);
+    $this->assertEquals('50.00', $contribution['total_amount']);
     $this->assertEquals(.08, $contribution['fee_amount']);
     $this->assertEquals(49.92, $contribution['net_amount']);
     $this->assertEquals('tx', $contribution['trxn_id']);
@@ -464,7 +464,7 @@ class CRM_Contribute_Form_ContributionTest extends CiviUnitTestCase {
       'contact_id' => $this->_individualId,
       'contribution_status_id' => 'Completed',
     ]);
-    $this->assertEquals('50', $contribution['total_amount']);
+    $this->assertEquals('50.00', $contribution['total_amount']);
     $this->assertEquals(0, $contribution['non_deductible_amount']);
   }
 

--- a/tests/phpunit/CRM/Core/PseudoConstantTest.php
+++ b/tests/phpunit/CRM/Core/PseudoConstantTest.php
@@ -1102,7 +1102,7 @@ class CRM_Core_PseudoConstantTest extends CiviUnitTestCase {
     ];
     CRM_Financial_BAO_FinancialTypeAccount::add($financialAccountParams);
     $taxRates = CRM_Core_PseudoConstant::getTaxRates();
-    $this->assertEquals('5.00', $taxRates[$financialType['id']]);
+    $this->assertEquals('5.00', round($taxRates[$financialType['id']], 2));
   }
 
 }

--- a/tests/phpunit/CRM/Event/BAO/ChangeFeeSelectionTest.php
+++ b/tests/phpunit/CRM/Event/BAO/ChangeFeeSelectionTest.php
@@ -9,11 +9,11 @@ class CRM_Event_BAO_ChangeFeeSelectionTest extends CiviUnitTestCase {
 
   protected $_priceSetID;
 
-  protected $_cheapFee = 80;
+  protected $_cheapFee = '80.00';
 
-  protected $_expensiveFee = 100;
+  protected $_expensiveFee = '100.00';
 
-  protected $_veryExpensive = 120;
+  protected $_veryExpensive = '120.00';
 
   protected $_noFee = 0;
 

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -2859,7 +2859,7 @@ VALUES
     if ($context != 'online' && $context != 'payLater') {
       $compareParams = [
         'to_financial_account_id' => 6,
-        'total_amount' => CRM_Utils_Array::value('total_amount', $params, 100),
+        'total_amount' => (float) CRM_Utils_Array::value('total_amount', $params, 100.00),
         'status_id' => 1,
       ];
     }
@@ -2869,7 +2869,7 @@ VALUES
     elseif ($context == 'online') {
       $compareParams = [
         'to_financial_account_id' => 12,
-        'total_amount' => CRM_Utils_Array::value('total_amount', $params, 100),
+        'total_amount' => (float) CRM_Utils_Array::value('total_amount', $params, 100.00),
         'status_id' => 1,
         'payment_instrument_id' => CRM_Utils_Array::value('payment_instrument_id', $params, 1),
       ];
@@ -2877,7 +2877,7 @@ VALUES
     elseif ($context == 'payLater') {
       $compareParams = [
         'to_financial_account_id' => 7,
-        'total_amount' => CRM_Utils_Array::value('total_amount', $params, 100),
+        'total_amount' => (float) CRM_Utils_Array::value('total_amount', $params, 100.00),
         'status_id' => 2,
       ];
     }
@@ -2891,13 +2891,13 @@ VALUES
       'id' => $entityTrxn['entity_id'],
     ];
     $compareParams = [
-      'amount' => CRM_Utils_Array::value('total_amount', $params, 100),
+      'amount' => (float) CRM_Utils_Array::value('total_amount', $params, 100.00),
       'status_id' => 1,
       'financial_account_id' => CRM_Utils_Array::value('financial_account_id', $params, 1),
     ];
     if ($context == 'payLater') {
       $compareParams = [
-        'amount' => CRM_Utils_Array::value('total_amount', $params, 100),
+        'amount' => (float) CRM_Utils_Array::value('total_amount', $params, 100.00),
         'status_id' => 3,
         'financial_account_id' => CRM_Utils_Array::value('financial_account_id', $params, 1),
       ];
@@ -2925,7 +2925,7 @@ VALUES
         'entity_table' => 'civicrm_financial_trxn',
       ];
       $compareParams = [
-        'amount' => 50,
+        'amount' => 50.00,
         'status_id' => 1,
         'financial_account_id' => 5,
       ];

--- a/tests/phpunit/api/v3/ContributionRecurTest.php
+++ b/tests/phpunit/api/v3/ContributionRecurTest.php
@@ -33,7 +33,7 @@ class api_v3_ContributionRecurTest extends CiviUnitTestCase {
       'contact_id' => $this->ids['contact'][0],
       'installments' => '12',
       'frequency_interval' => '1',
-      'amount' => '500',
+      'amount' => '500.00',
       'contribution_status_id' => 1,
       'start_date' => '2012-01-01 00:00:00',
       'currency' => 'USD',

--- a/tests/phpunit/api/v3/ContributionSoftTest.php
+++ b/tests/phpunit/api/v3/ContributionSoftTest.php
@@ -206,7 +206,7 @@ class api_v3_ContributionSoftTest extends CiviUnitTestCase {
     $softcontribution = $this->callAPIAndDocument('contribution_soft', 'create', $params, __FUNCTION__, __FILE__);
     $this->assertEquals($softcontribution['values'][$softcontribution['id']]['contribution_id'], $this->_contributionId);
     $this->assertEquals($softcontribution['values'][$softcontribution['id']]['contact_id'], $this->_softIndividual1Id);
-    $this->assertEquals($softcontribution['values'][$softcontribution['id']]['amount'], '10.00');
+    $this->assertEquals($softcontribution['values'][$softcontribution['id']]['amount'], '10');
     $this->assertEquals($softcontribution['values'][$softcontribution['id']]['currency'], 'USD');
     $this->assertEquals($softcontribution['values'][$softcontribution['id']]['soft_credit_type_id'], 5);
   }

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -2223,7 +2223,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
     $contribution = $this->callAPISuccess('contribution', 'getsingle', ['id' => $contribution['id'], 'sequential' => 1]);
     $this->assertEquals('Completed', $contribution['contribution_status']);
     $this->assertEquals('7778888', $contribution['trxn_id']);
-    $this->assertEquals('.56', $contribution['fee_amount']);
+    $this->assertEquals('0.56', $contribution['fee_amount']);
     $this->assertEquals('99.44', $contribution['net_amount']);
   }
 

--- a/tests/phpunit/api/v3/GrantTest.php
+++ b/tests/phpunit/api/v3/GrantTest.php
@@ -31,7 +31,7 @@ class api_v3_GrantTest extends CiviUnitTestCase {
       'contact_id' => $this->ids['contact'][0],
       'application_received_date' => 'now',
       'decision_date' => 'next Monday',
-      'amount_total' => '500',
+      'amount_total' => '500.00',
       'status_id' => 1,
       'rationale' => 'Just Because',
       'currency' => 'USD',

--- a/tests/phpunit/api/v3/LoggingTest.php
+++ b/tests/phpunit/api/v3/LoggingTest.php
@@ -355,8 +355,8 @@ class api_v3_LoggingTest extends CiviUnitTestCase {
     // To protect against the modified date not changing due to the updates being too close together.
     sleep(1);
     $loggings = $this->callAPISuccess('Logging', 'get', ['log_conn_id' => 'bitty bot bot', 'tables' => ['civicrm_address']]);
-    $this->assertEquals('civicrm_address', $loggings['values'][0]['table'], CRM_Core_DAO::executeQuery('SELECT * FROM log_civicrm_address')->toArray());
-    $this->assertEquals(1, $loggings['count'], CRM_Core_DAO::executeQuery('SELECT * FROM log_civicrm_address')->toArray());
+    $this->assertEquals('civicrm_address', $loggings['values'][0]['table'], json_encode(CRM_Core_DAO::executeQuery('SELECT * FROM log_civicrm_address')->toArray()));
+    $this->assertEquals(1, $loggings['count'], json_encode(CRM_Core_DAO::executeQuery('SELECT * FROM log_civicrm_address')->toArray()));
     $this->assertEquals('27 Cool way', $loggings['values'][0]['from']);
     $this->assertEquals('25 Dorky way', $loggings['values'][0]['to']);
     $this->callAPISuccess('Logging', 'revert', ['log_conn_id' => 'bitty bot bot', 'tables' => ['civicrm_address']]);

--- a/tests/phpunit/api/v3/SyntaxConformanceTest.php
+++ b/tests/phpunit/api/v3/SyntaxConformanceTest.php
@@ -1317,6 +1317,7 @@ class api_v3_SyntaxConformanceTest extends CiviUnitTestCase {
       return;
     }
 
+    $floatFields = [];
     $baoString = _civicrm_api3_get_BAO($entityName);
     $this->assertNotEmpty($baoString, $entityName);
     $this->assertNotEmpty($entityName, $entityName);
@@ -1438,6 +1439,7 @@ class api_v3_SyntaxConformanceTest extends CiviUnitTestCase {
 
         case CRM_Utils_Type::T_FLOAT:
         case CRM_Utils_Type::T_MONEY:
+          $floatFields[] = $field;
           $entity[$field] = '22.75';
           break;
 
@@ -1505,6 +1507,9 @@ class api_v3_SyntaxConformanceTest extends CiviUnitTestCase {
         $entity[$field] = CRM_Core_DAO::serializeField($checkEntity[$field], $specs['serialize']);
       }
 
+      foreach ($floatFields as $floatField) {
+        $checkEntity[$floatField] = rtrim($checkEntity[$floatField], "0");
+      }
       $this->assertAPIArrayComparison($entity, $checkEntity, [], "checking if $fieldName was correctly updated\n" . print_r([
         'update-params' => $updateParams,
         'update-result' => $update,


### PR DESCRIPTION
Overview
----------------------------------------
This updates tests to make necessary changes that will be needed to support switching over to use PHPUnit 7 

Before
----------------------------------------
Tests incompatable with PHPUnit 7 mainly due to the tighter checking against floats

After
----------------------------------------
Tests work on PHPUnit 7 and PHPUnit 6

ping @eileenmcnaughton @mattwire @totten 