### PR TITLE
dev/core#1829 - Custom Date field with format=yy displays calendar ic…

### DIFF
--- a/js/crm.datepicker.js
+++ b/js/crm.datepicker.js
@@ -75,6 +75,7 @@
         } else {
           $dateField.attr('min', settings.minDate ? CRM.utils.formatDate(settings.minDate, 'yy') : '1000');
           $dateField.attr('max', settings.maxDate ? CRM.utils.formatDate(settings.maxDate, 'yy') : '4000');
+          placeholder = null;
         }
         // Set placeholder as calendar icon (`fa-calendar` is Unicode f073)
         $dateField.attr({placeholder: placeholder === undefined ? '\uF073' : placeholder}).change(updateDataField);


### PR DESCRIPTION
…on that doesn't work

Overview
----------------------------------------
Do not display placeholder for non datepicker fields. Eg custom field with format = yy.

Before
----------------------------------------
Custom date fields with format = yy display an unnecessary calendar icon.

![image](https://user-images.githubusercontent.com/5929648/85125093-ac84df80-b248-11ea-8e32-e45147536911.png)

After
----------------------------------------
No calendar icon shown -

![image](https://user-images.githubusercontent.com/5929648/85124915-52841a00-b248-11ea-866d-be0a0d712b23.png)


Technical Details
----------------------------------------
yy is rendered as `number` input field and does not have datepicker. The placeholder was incorrectly shown which is avoided in this PR.

Comments
----------------------------------------
Gitlab - https://lab.civicrm.org/dev/core/-/issues/1829