### PR TITLE
Throw exception if id not passed into discard

### DIFF
--- a/CRM/Contact/BAO/Group.php
+++ b/CRM/Contact/BAO/Group.php
@@ -52,6 +52,9 @@ class CRM_Contact_BAO_Group extends CRM_Contact_DAO_Group {
    * @param int $id Group id.
    */
   public static function discard($id) {
+    if (!$id || !is_numeric($id)) {
+      throw new CRM_Core_Exception('Invalid group request attempted');
+    }
     CRM_Utils_Hook::pre('delete', 'Group', $id, CRM_Core_DAO::$_nullArray);
 
     $transaction = new CRM_Core_Transaction();


### PR DESCRIPTION


Overview
----------------------------------------
https://lab.civicrm.org/dev/drupal/-/issues/123 - may not be related but this seems a good precaution

Before
----------------------------------------
Calling BAO_Group::discard with NULL looks like it might over-delete.

After
----------------------------------------
Calling BAO_Group::discard with NULL would throw an exception

Technical Details
----------------------------------------
I can't find any evidence this is happening but it seems like a sensible precaution

Comments
----------------------------------------
