### PR TITLE
dev/translation#48 Add check for PHP-Intl Extension

### DIFF
--- a/CRM/Utils/Check/Component/Env.php
+++ b/CRM/Utils/Check/Component/Env.php
@@ -986,4 +986,18 @@ class CRM_Utils_Check_Component_Env extends CRM_Utils_Check_Component {
     return $messages;
   }
 
+  public function checkPHPIntlExists() {
+    $messages = [];
+    if (!extension_loaded('intl')) {
+      $messages[] = new CRM_Utils_Check_Message(
+        __FUNCTION__,
+        ts('This system currently does not have the PHP-INTL extension enabled please contact your system administrator about getting the extension enabled'),
+        ts('Missing PHP Extension: INTL'),
+        \Psr\Log\LogLevel::WARNING,
+        'fa-server'
+      );
+    }
+    return $messages;
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
This adds in a system check for the PHP-Intl extension that will be needed from 5.28 onwards

Before
----------------------------------------
No System check

After
----------------------------------------
System Check

ping @eileenmcnaughton @kcristiano 