### PR TITLE
[REF] Fix allowing users to clear values for raido custom fields when…

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -796,6 +796,9 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
         else {
           parse_str($field->attributes, $radioAttributes);
           $radioAttributes = array_merge($radioAttributes, $customFieldAttributes);
+          if ($search || empty($useRequired)) {
+            $radioAttributes['allowClear'] = TRUE;
+          }
           $qf->addRadio($elementName, $label, $options, $radioAttributes, NULL, $useRequired);
         }
         break;


### PR DESCRIPTION
… not required

Overview
----------------------------------------
This fixes a minor regression from https://github.com/civicrm/civicrm-core/pull/16488/files which is for a radio custom field that is not required the x to clear values after being set on the edit page doesn't show up

Before
----------------------------------------
No ability to clear values on radio custom fields
![non-required-radio-custom-field-pre](https://user-images.githubusercontent.com/6799125/85200354-0c0ee800-b33a-11ea-89fe-a8625a1973c2.jpg)


After
----------------------------------------
ability to clear them
![non-required-radio-custom-field-post](https://user-images.githubusercontent.com/6799125/85200356-0fa26f00-b33a-11ea-9bb2-459237bebae9.jpg)


ping @mattwire 

This is the equivalent of the code here https://github.com/civicrm/civicrm-core/pull/16488/files#diff-bdea9a3ec62827e6c90a70202ea9f7ccL800