### PR TITLE
[REF] Fix jquery error message display on select2 field validation

### DIFF
--- a/templates/CRM/common/l10n.js.tpl
+++ b/templates/CRM/common/l10n.js.tpl
@@ -95,7 +95,8 @@
   var params = {
     errorClass: 'crm-inline-error alert-danger',
     messages: {},
-    ignore: ".select2-offscreen, [readonly], :hidden:not(.crm-select2)"
+    ignore: ".select2-offscreen, [readonly], :hidden:not(.crm-select2)",
+    ignoreTitle: true
   };
 
   // use civicrm notifications when there are errors


### PR DESCRIPTION
Overview
----------------------------------------
This fixes a change that was caused by https://github.com/civicrm/civicrm-core/pull/16488 where by for select2 fields an incorrect and problematic message shows

Before
----------------------------------------
Problematic message shows
![select2-error](https://user-images.githubusercontent.com/6799125/85200207-bf76dd00-b338-11ea-838d-dd291ff44a37.jpg)


After
----------------------------------------
Correct error message shows
![select2-error-post](https://user-images.githubusercontent.com/6799125/85200228-edf4b800-b338-11ea-8573-85d78207477b.jpg)


ping @mattwire 