### PR TITLE
Fix validation of select2 fields in "On behalf of Organisation" block

### DIFF
--- a/templates/CRM/Contribute/Form/Contribution/OnBehalfOf.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/OnBehalfOf.tpl
@@ -25,8 +25,8 @@
 
 <div class="crm-public-form-item" id="on-behalf-block">
   {crmRegion name="onbehalf-block"}
-    {if $onBehalfOfFields && $onBehalfOfFields|@count}
-      <fieldset>
+  {if $onBehalfOfFields && $onBehalfOfFields|@count}
+    <fieldset>
       <legend>{$fieldSetTitle}</legend>
       {if $form.org_option}
         <div id='orgOptions' class="section crm-public-form-item crm-section">
@@ -36,8 +36,8 @@
         </div>
       {/if}
       {include file="CRM/UF/Form/Block.tpl" fields=$onBehalfOfFields mode=8 prefix='onbehalf'}
-      </fieldset>
-    {/if}
+    </fieldset>
+  {/if}
   {/crmRegion}
 </div>
 
@@ -61,131 +61,131 @@
       $('#on-behalf-block').toggle($(this).is(':checked'));
     });
 
-   $("input:radio[name='org_option']").click( function( ) {
-     var orgOption = $(this).attr('id');
-     selectCreateOrg(orgOption, true);
-   });
+    $("input:radio[name='org_option']").click( function( ) {
+      var orgOption = $(this).attr('id');
+      selectCreateOrg(orgOption, true);
+    });
 
-   onbehalfof_id.change(function() {
-    setLocationDetails($(this).val());
-   }).change();
+    onbehalfof_id.change(function() {
+      setLocationDetails($(this).val());
+    }).change();
 
-   if (onbehalfof_id.length) {
-     setLocationDetails(onbehalfof_id.val());
-   }
+    if (onbehalfof_id.length) {
+      setLocationDetails(onbehalfof_id.val());
+    }
 
     function resetValues() {
-     // Don't trip chain-select when clearing values
-     $('.crm-chain-select-control', "#select_org div").select2('val', '');
-     $('input[type=text], select, textarea', "#select_org div").not('.crm-chain-select-control, #onbehalfof_id').val('').change();
-     $('input[type=radio], input[type=checkbox]', "#select_org div").prop('checked', false).change();
+      // Don't trip chain-select when clearing values
+      $('.crm-chain-select-control', "#select_org div").select2('val', '');
+      $('input[type=text], select, textarea', "#select_org div").not('.crm-chain-select-control, #onbehalfof_id').val('').change();
+      $('input[type=radio], input[type=checkbox]', "#select_org div").prop('checked', false).change();
 
-     $('#on-behalf-block input').not('input[type=checkbox], input[type=radio], #onbehalfof_id').val('');
-     // clear checkboxes and radio
-     $('#on-behalf-block')
-      .find('input[type=checkbox], input[type=radio]')
-      .not('input[name=org_option]')
-      .attr('checked', false);
+      $('#on-behalf-block input').not('input[type=checkbox], input[type=radio], #onbehalfof_id').val('');
+      // clear checkboxes and radio
+      $('#on-behalf-block')
+              .find('input[type=checkbox], input[type=radio]')
+              .not('input[name=org_option]')
+              .attr('checked', false);
     }
 
-   function selectCreateOrg( orgOption, reset ) {
-    if (orgOption == 'CIVICRM_QFID_0_org_option') {
-      $("#onbehalfof_id").show().change();
-      $("input#onbehalf_organization_name").hide();
-    }
-    else if (orgOption == 'CIVICRM_QFID_1_org_option') {
-      $("input#onbehalf_organization_name").show();
-      $("#onbehalfof_id").hide();
-      reset = true;
+    function selectCreateOrg( orgOption, reset ) {
+      if (orgOption == 'CIVICRM_QFID_0_org_option') {
+        $("#onbehalfof_id").show().change();
+        $("input#onbehalf_organization_name").hide();
+      }
+      else if (orgOption == 'CIVICRM_QFID_1_org_option') {
+        $("input#onbehalf_organization_name").show();
+        $("#onbehalfof_id").hide();
+        reset = true;
+      }
+
+      if ( reset ) {
+        resetValues();
+      }
     }
 
-    if ( reset ) {
+    function setLocationDetails(contactID , reset) {
       resetValues();
-    }
-  }
+      var locationUrl = {/literal}'{$locDataURL}'{literal} + contactID;
+      var submittedOnBehalfInfo = {/literal}'{$submittedOnBehalfInfo}'{literal};
+      var submittedCID = {/literal}"{$submittedOnBehalf}"{literal};
 
- function setLocationDetails(contactID , reset) {
-   resetValues();
-   var locationUrl = {/literal}'{$locDataURL}'{literal} + contactID;
-   var submittedOnBehalfInfo = {/literal}'{$submittedOnBehalfInfo}'{literal};
-   var submittedCID = {/literal}"{$submittedOnBehalf}"{literal};
+      if (submittedOnBehalfInfo) {
+        submittedOnBehalfInfo = $.parseJSON(submittedOnBehalfInfo);
 
-   if (submittedOnBehalfInfo) {
-     submittedOnBehalfInfo = $.parseJSON(submittedOnBehalfInfo);
-
-     if (submittedCID == contactID) {
-       $.each(submittedOnBehalfInfo, function(key, value) {
-         //handle checkboxes
-         if (typeof value === 'object') {
-           $.each(value, function(k, v) {
-             $('#onbehalf_' + key + '_' + k).prop('checked', v);
-           });
-         }
-         else if ($('#onbehalf_' + key).length) {
-           $('#onbehalf_' + key ).val(value);
-         }
-         //radio buttons
-         else if ($("input[name='onbehalf[" + key + "]']").length) {
-           $("input[name='onbehalf[" + key + "]']").val([value]);
-         }
-       });
-       return;
-     }
-   }
-
-   $.ajax({
-    url         : locationUrl,
-    dataType    : "json",
-    timeout     : 5000, //Time in milliseconds
-    success     : function(data, status) {
-      for (var ele in data) {
-        if ($("#"+ ele).hasClass('crm-chain-select-target')) {
-          $("#"+ ele).data('newVal', data[ele].value).off('.autofill').on('crmOptionsUpdated.autofill', function() {
-            $(this).off('.autofill').val($(this).data('newVal')).change();
+        if (submittedCID == contactID) {
+          $.each(submittedOnBehalfInfo, function(key, value) {
+            //handle checkboxes
+            if (typeof value === 'object') {
+              $.each(value, function(k, v) {
+                $('#onbehalf_' + key + '_' + k).prop('checked', v);
+              });
+            }
+            else if ($('#onbehalf_' + key).length) {
+              $('#onbehalf_' + key ).val(value);
+            }
+            //radio buttons
+            else if ($("input[name='onbehalf[" + key + "]']").length) {
+                $("input[name='onbehalf[" + key + "]']").val([value]);
+              }
           });
-        }
-        else if ($('#' + ele).data('select2')) {
-          $('#' + ele).select2('val', data[ele].value);
-        }
-        if (data[ele].type == 'Radio') {
-          if (data[ele].value) {
-            var fldName = ele.replace('onbehalf_', '');
-            $("input[name='onbehalf["+ fldName +"]']").filter("[value='" + data[ele].value + "']").prop('checked', true);
-          }
-        }
-        else if (data[ele].type == 'CheckBox') {
-          for (var selectedOption in data[ele].value) {
-            var fldName = ele.replace('onbehalf_', '');
-            $("input[name='onbehalf["+ fldName+"]["+ selectedOption +"]']").prop('checked','checked');
-          }
-        }
-        else if (data[ele].type == 'AdvMulti-Select') {
-          var customFld = ele.replace('onbehalf_', '');
-          // remove empty value if any
-          $('#onbehalf\\['+ customFld +'\\]-f option[value=""]').remove();
-          $('#onbehalf\\['+ customFld +'\\]-t option[value=""]').remove();
-
-          for (var selectedOption in data[ele].value) {
-            // remove selected values from left and selected values to right
-            $('#onbehalf\\['+ customFld +'\\]-f option[value="' + selectedOption + '"]').remove()
-              .appendTo('#onbehalf\\['+ customFld +'\\]-t');
-            $('#onbehalf_'+ customFld).val(selectedOption);
-          }
-        }
-        else {
-          // do not set defaults to file type fields
-          if ($('#' + ele).attr('type') != 'file') {
-            $('#' + ele ).val(data[ele].value).change();
-          }
+          return;
         }
       }
-    },
-    error       : function(XMLHttpRequest, textStatus, errorThrown) {
-      CRM.console('error', "HTTP error status: ", textStatus);
+
+      $.ajax({
+        url         : locationUrl,
+        dataType    : "json",
+        timeout     : 5000, //Time in milliseconds
+        success     : function(data, status) {
+          for (var ele in data) {
+            if ($("#"+ ele).hasClass('crm-chain-select-target')) {
+              $("#"+ ele).data('newVal', data[ele].value).off('.autofill').on('crmOptionsUpdated.autofill', function() {
+                $(this).off('.autofill').val($(this).data('newVal')).change();
+              });
+            }
+            else if ($('#' + ele).data('select2')) {
+              $('#' + ele).select2('val', data[ele].value);
+            }
+            if (data[ele].type == 'Radio') {
+              if (data[ele].value) {
+                var fldName = ele.replace('onbehalf_', '');
+                $("input[name='onbehalf["+ fldName +"]']").filter("[value='" + data[ele].value + "']").prop('checked', true);
+              }
+            }
+            else if (data[ele].type == 'CheckBox') {
+              for (var selectedOption in data[ele].value) {
+                var fldName = ele.replace('onbehalf_', '');
+                $("input[name='onbehalf["+ fldName+"]["+ selectedOption +"]']").prop('checked','checked');
+              }
+            }
+            else if (data[ele].type == 'AdvMulti-Select') {
+                var customFld = ele.replace('onbehalf_', '');
+                // remove empty value if any
+                $('#onbehalf\\['+ customFld +'\\]-f option[value=""]').remove();
+                $('#onbehalf\\['+ customFld +'\\]-t option[value=""]').remove();
+
+                for (var selectedOption in data[ele].value) {
+                  // remove selected values from left and selected values to right
+                  $('#onbehalf\\['+ customFld +'\\]-f option[value="' + selectedOption + '"]').remove()
+                          .appendTo('#onbehalf\\['+ customFld +'\\]-t');
+                  $('#onbehalf_'+ customFld).val(selectedOption);
+                }
+              }
+              else {
+                // do not set defaults to file type fields
+                if ($('#' + ele).attr('type') != 'file') {
+                  $('#' + ele ).val(data[ele].value).change();
+                }
+              }
+          }
+        },
+        error       : function(XMLHttpRequest, textStatus, errorThrown) {
+          CRM.console('error', "HTTP error status: ", textStatus);
+        }
+      });
     }
   });
-}
-});
 
 </script>
 {/literal}

--- a/templates/CRM/Contribute/Form/Contribution/OnBehalfOf.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/OnBehalfOf.tpl
@@ -54,12 +54,23 @@
     selectCreateOrg(orgOption, false);
 
     if (is_for_organization.length) {
-      $('#on-behalf-block').toggle(is_for_organization.is(':checked'));
+      showHideOnBehalfOfBlock();
+
+      is_for_organization.on('change', function() {
+        showHideOnBehalfOfBlock();
+      });
     }
 
-    is_for_organization.on('change', function(){
-      $('#on-behalf-block').toggle($(this).is(':checked'));
-    });
+    function showHideOnBehalfOfBlock() {
+      $('#on-behalf-block').toggle(is_for_organization.is(':checked'));
+
+      if (is_for_organization.is(':checked')) {
+        $('#onBehalfOfOrg select.crm-select2').removeClass('crm-no-validate');
+      }
+      else {
+        $('#onBehalfOfOrg select.crm-select2').addClass('crm-no-validate');
+      }
+    }
 
     $("input:radio[name='org_option']").click( function( ) {
       var orgOption = $(this).attr('id');

--- a/templates/CRM/common/l10n.js.tpl
+++ b/templates/CRM/common/l10n.js.tpl
@@ -95,7 +95,7 @@
   var params = {
     errorClass: 'crm-inline-error alert-danger',
     messages: {},
-    ignore: ".select2-offscreen, [readonly], :hidden:not(.crm-select2)",
+    ignore: '.select2-offscreen, [readonly], :hidden:not(.crm-select2), .crm-no-validate'
     ignoreTitle: true
   };
 


### PR DESCRIPTION
Overview
----------------------------------------
Found by @jmcclelland via https://lab.civicrm.org/extensions/stripe/-/issues/147#note_38994

Normally a select2 is a hidden select field with another visible "text" field. But it is the hidden select2 field that actually needs validating so we ignore (following #16488) using jquery validate and the pattern `hidden:not(.select2)`. This fails for the "I want to contribution on behalf of organisation" block because the select2 fields get hidden by the parent div and are not required when the block is hidden - but they *are* required when the block is visible.

Before
----------------------------------------
Form validation fails if you have "on behalf of organisation" option on the form and one of those fields is a select2.

After
----------------------------------------
Form validation fails if you have "on behalf of organisation" option **checked** on the form and one of those fields is a select2 but passes if you don't have the option **checked**

Technical Details
----------------------------------------
We introduce a new "crm-no-validate" class for jquery validate to ignore. Then we apply that to the select2 fields when hiding the "On behalf of" block.

Comments
----------------------------------------
The first commit is just whitespace cleanup. Please review the second commit to see the changes made.