### PR TITLE
[REF] Ensure that our custom error handler is called when jquery vali…

### DIFF
--- a/js/Common.js
+++ b/js/Common.js
@@ -882,6 +882,8 @@ if (!CRM.vars) CRM.vars = {};
       var validator = $(this).validate();
       var that = this;
       validator.settings = $.extend({}, validator.settings, CRM.validate._defaults, CRM.validate.params);
+      // Call our custom validation handler.
+      $(validator.currentForm).on("invalid-form.validate", validator.settings.invalidHandler );
       // Call any post-initialization callbacks
       if (CRM.validate.functions && CRM.validate.functions.length) {
         $.each(CRM.validate.functions, function(i, func) {

--- a/templates/CRM/common/l10n.js.tpl
+++ b/templates/CRM/common/l10n.js.tpl
@@ -104,6 +104,7 @@
     // but there will be no overall message. Currently the container is only available on backoffice pages.
     if ($('#crm-notification-container').length) {
       $.each(validator.errorList, function(k, error) {
+        $(error.element).parents('.crm-custom-accordion.collapsed').crmAccordionToggle();
         $(error.element).crmError(error.message);
       });
     }


### PR DESCRIPTION
…dates and expand any collapsed accordions that are hiding required fields that haven't been filled in

Overview
----------------------------------------
This does 2 things 

1. ensures that our custom validation handler which puts messages into the crm alert area in the backoffice is run and 
2. If a required field is hidden by a collapsed accordion it expands that accordion so the field error message is shown

Before
----------------------------------------
Field is validated but accordion stays shut

After
----------------------------------------
Accordion opens when field is validated

To reproduce on a a buildkit demo

1. Edit the Marital Status field within the Constituent Information custom group to be a required field
2. Navigate to any contact and click edit so you go to the full edit mode e.g. `/civicrm/contact/add?reset=1&action=update&cid=202` 
3. Press save and note nothing happens. This is because the Maritial status field is within a hidden accordion