### PR TITLE
[NFC] Fix Unit test failure on MySQL 8 due to mysql ordering issue

### DIFF
--- a/tests/phpunit/CRM/Contact/BAO/ContactType/ContactTypeTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/ContactType/ContactTypeTest.php
@@ -77,7 +77,8 @@ class CRM_Contact_BAO_ContactType_ContactTypeTest extends CiviUnitTestCase {
 
     // check for all contact types
     $result = CRM_Contact_BAO_ContactType::subTypes();
-    $this->assertEquals(array_keys($this->getExpectedAllSubtypes()), $result);
+    $subtypes = array_keys($this->getExpectedAllSubtypes());
+    $this->assertEquals(sort($subtypes), sort($result));
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
This aims to fix a test failure that occurred on MySQL8 which is due to the ordering within the array by sorting the array first https://test.civicrm.org/job/CiviCRM-Core-Edge/CIVIVER=master,label=test-3/lastCompletedBuild/testReport/(root)/CRM_Contact_BAO_ContactType_ContactTypeTest/testGetMethods/

Before
----------------------------------------
Test fails on MySQL8 

After
----------------------------------------
Test passes on MySQL8

ping @eileenmcnaughton 