### PR TITLE
dev/core#1817 - Editing a custom field option value from the custom field admin screen changes the name field

### DIFF
--- a/CRM/Custom/Form/Option.php
+++ b/CRM/Custom/Form/Option.php
@@ -387,17 +387,19 @@ SELECT count(*)
     // set values for custom field properties and save
     $customOption = new CRM_Core_DAO_OptionValue();
     $customOption->label = $params['label'];
-    $customOption->name = CRM_Utils_String::titleToVar($params['label']);
     $customOption->weight = $params['weight'];
     $customOption->description = $params['description'];
     $customOption->value = $params['value'];
-    $customOption->is_active = CRM_Utils_Array::value('is_active', $params, FALSE);
+    $customOption->is_active = $params['is_active'] ?? FALSE;
 
     $oldWeight = NULL;
     if ($this->_id) {
       $customOption->id = $this->_id;
       CRM_Core_BAO_CustomOption::updateCustomValues($params);
       $oldWeight = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_OptionValue', $this->_id, 'weight', 'id');
+    }
+    else {
+      $customOption->name = CRM_Utils_String::titleToVar($params['label']);
     }
 
     $fieldValues = ['option_group_id' => $this->_optionGroupID];

--- a/tests/phpunit/CRM/Custom/Form/OptionTest.php
+++ b/tests/phpunit/CRM/Custom/Form/OptionTest.php
@@ -1,0 +1,69 @@
+<?php
+
+/**
+ * Class CRM_Custom_Form_OptionTest
+ * @group headless
+ */
+class CRM_Custom_Form_OptionTest extends CiviUnitTestCase {
+
+  public function setUp() {
+    parent::setUp();
+  }
+
+  /**
+   * Test the `name` field doesn't get changed when editing an existing option.
+   */
+  public function testEditCustomFieldOptionValue() {
+    // Create a custom field for contacts with some option choices
+    $customGroup = $this->customGroupCreate(['extends' => 'Contact', 'title' => 'contact stuff']);
+    $customField = $this->customFieldOptionValueCreate($customGroup, 'myCustomField');
+    $fid = $customField['id'];
+    $option_group_id = $customField['values'][$fid]['option_group_id'];
+    $optionValue = $this->callAPISuccess('OptionValue', 'get', [
+      'option_group_id' => $option_group_id,
+      'sequential' => 1,
+    ])['values'][0];
+
+    // Run the form
+    $form = new CRM_Custom_Form_Option();
+    $form->controller = new CRM_Core_Controller_Simple('CRM_Custom_Form_Option', 'Custom Option');
+
+    $form->set('id', $optionValue['id']);
+    $form->set('fid', $customField['id']);
+    $form->set('gid', $customGroup['id']);
+
+    ob_start();
+    $form->controller->_actions['display']->perform($form, 'display');
+    $contents = ob_get_contents();
+    ob_end_clean();
+    // We could check for something in $contents, but we don't really care
+    // what the form looks like here.
+
+    // Submit the form
+    //
+    // This might not work if postProcess does something like access certain
+    // properties that here won't have been rebuilt from the full http post
+    // etc process. But at the moment it doesn't.
+    $container = &$form->controller->container();
+    $container['values']['Option'] = [
+      'label' => 'Label changed',
+      'value' => $optionValue['value'],
+      'description' => '',
+      'weight' => $optionValue['value'],
+      'is_active' => '1',
+      // unchecked checkboxes don't submit any actual value
+      // 'default_value' => $optionValue['is_default'],
+      'optionId' => $optionValue['id'],
+      'fieldId' => $fid,
+    ];
+    $form->mainProcess();
+
+    $newOptionValue = $this->callAPISuccess('OptionValue', 'get', [
+      'id' => $optionValue['id'],
+    ])['values'][$optionValue['id']];
+    $this->assertEquals($optionValue['name'], $newOptionValue['name']);
+    $this->assertEquals($optionValue['value'], $newOptionValue['value']);
+    $this->assertEquals('Label changed', $newOptionValue['label']);
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/1817

1. Create a custom field that has a choice list, like a select field.
2. Add some options. Save the field.
3. Go to the custom field admin screen where you can edit one of the option values. The screen I'm talking about has a url like `/civicrm/admin/custom/group/field/option?reset=1&action=browse&fid=18&gid=7`. Administer - Customize Data and Screens - Custom Fields - View and Edit Custom fields - Edit Multiple Choice Options.
4. Edit one of the option choices and change the label. Save it.
5. If you look in the database or use api explorer to do optionvalue get for the option value, you'll see the name field has changed.

Note that if you edit the option from Administer - System Settings - Option Groups, it's a different form and it works ok.

Before
----------------------------------------
name field gets changed so you need to edit your code whereever you use name to access it whenever the label is changed.

After
----------------------------------------
name only gets set for new option values

Technical Details
----------------------------------------
I think there are two separate forms to do the same thing because of history. A future todo might be to consolidate and figure out what else one might be doing that the other isn't doing.

Comments
----------------------------------------
Has test.
