### PR TITLE
Add auto-renew status to membership detail report

### DIFF
--- a/CRM/Report/Form/Member/Detail.php
+++ b/CRM/Report/Form/Member/Detail.php
@@ -223,6 +223,26 @@ class CRM_Report_Form_Member_Detail extends CRM_Report_Form {
         ],
         'grouping' => 'contri-fields',
       ],
+      'civicrm_contribution_recur' => [
+        'dao' => 'CRM_Contribute_DAO_ContributionRecur',
+        'fields' => [
+          'autorenew_status_id' => [
+            'name' => 'contribution_status_id',
+            'title' => ts('Auto-Renew Subscription Status'),
+          ],
+        ],
+        'filters' => [
+          'autorenew_status_id' => [
+            'name' => 'contribution_status_id',
+            'title' => ts('Auto-Renew Subscription Status?'),
+            'operatorType' => CRM_Report_Form::OP_MULTISELECT,
+            'options' => [0 => ts('None'), -1 => ts('Ended')] + CRM_Contribute_BAO_ContributionRecur::buildOptions('contribution_status_id', 'search'),
+            'type' => CRM_Utils_Type::T_INT,
+            'pseudofield' => TRUE,
+          ],
+        ],
+        'grouping' => 'member-fields',
+      ],
     ] + $this->getAddressColumns([
       // These options are only excluded because they were not previously present.
       'order_by' => FALSE,
@@ -241,6 +261,23 @@ class CRM_Report_Form_Member_Detail extends CRM_Report_Form {
   public function preProcess() {
     $this->assign('reportTitle', ts('Membership Detail Report'));
     parent::preProcess();
+  }
+
+  public function select() {
+    parent::select();
+    if (in_array('civicrm_contribution_recur_autorenew_status_id', $this->_selectAliases)) {
+      // If we're getting auto-renew status we'll want to know if auto-renew has
+      // ended.
+      $this->_selectClauses[] = "{$this->_aliases['civicrm_contribution_recur']}.end_date as civicrm_contribution_recur_end_date";
+      $this->_selectAliases[] = 'civicrm_contribution_recur_end_date';
+      // Regenerate SELECT part of query
+      $this->_select = "SELECT " . implode(', ', $this->_selectClauses) . " ";
+      $this->_columnHeaders["civicrm_contribution_recur_end_date"] = [
+        'title' => NULL,
+        'type' => NULL,
+        'no_display' => TRUE,
+      ];
+    }
   }
 
   public function from() {
@@ -265,6 +302,80 @@ class CRM_Report_Form_Member_Detail extends CRM_Report_Form {
                  ON {$this->_aliases['civicrm_membership']}.id = cmp.membership_id
              LEFT JOIN civicrm_contribution {$this->_aliases['civicrm_contribution']}
                  ON cmp.contribution_id={$this->_aliases['civicrm_contribution']}.id\n";
+    }
+    if ($this->isTableSelected('civicrm_contribution_recur')) {
+      $this->_from .= <<<HERESQL
+            LEFT JOIN civicrm_contribution_recur {$this->_aliases['civicrm_contribution_recur']}
+                ON {$this->_aliases['civicrm_membership']}.contribution_recur_id = {$this->_aliases['civicrm_contribution_recur']}.id
+HERESQL;
+    }
+  }
+
+  /**
+   * Override to add handling for autorenew status.
+   */
+  public function storeWhereHavingClauseArray() {
+    parent::storeWhereHavingClauseArray();
+
+    // Handle autorenew status
+    $op = $this->_params['autorenew_status_id_op'] ?? NULL;
+    $value = $this->_params['autorenew_status_id_value'] ?? NULL;
+    $clauseParts = [];
+    switch ($op) {
+      case 'in':
+        if ($value !== NULL && is_array($value) && count($value) > 0) {
+          $regularOptions = implode(', ', array_diff($value, [0, -1]));
+          // None: is null
+          if (in_array(0, $value)) {
+            $clauseParts[] = "{$this->_aliases['civicrm_membership']}.contribution_recur_id IS NULL";
+          }
+          // Ended: not null, end_date in past
+          if (in_array(-1, $value)) {
+            $clauseParts[] = <<<HERESQL
+              {$this->_aliases['civicrm_membership']}.contribution_recur_id IS NOT NULL
+                AND {$this->_aliases['civicrm_contribution_recur']}.end_date < NOW()
+HERESQL;
+          }
+          // Normal statuses: IN()
+          if (!empty($regularOptions)) {
+            $clauseParts[] = "{$this->_aliases['civicrm_contribution_recur']}.contribution_status_id IN ($regularOptions)";
+          }
+          $this->_whereClauses[] = '(' . implode(') OR (', $clauseParts) . ')';
+        }
+        break;
+
+      case 'notin':
+        if ($value !== NULL && is_array($value) && count($value) > 0) {
+          $regularOptions = implode(', ', array_diff($value, [0, -1]));
+          // None: is not null
+          if (in_array(0, $value)) {
+            $clauseParts[] = "{$this->_aliases['civicrm_membership']}.contribution_recur_id IS NOT NULL";
+          }
+          // Ended: null or end_date in future
+          if (in_array(-1, $value)) {
+            $clauseParts[] = <<<HERESQL
+              {$this->_aliases['civicrm_membership']}.contribution_recur_id IS NULL
+                OR {$this->_aliases['civicrm_contribution_recur']}.end_date >= NOW()
+                OR {$this->_aliases['civicrm_contribution_recur']}.end_date IS NULL
+HERESQL;
+          }
+          // Normal statuses: null or NOT IN()
+          if (!empty($regularOptions)) {
+            $clauseParts[] = <<<HERESQL
+              {$this->_aliases['civicrm_membership']}.contribution_recur_id IS NULL
+                OR {$this->_aliases['civicrm_contribution_recur']}.contribution_status_id NOT IN ($regularOptions)
+HERESQL;
+          }
+          $this->_whereClauses[] = '(' . implode(') AND (', $clauseParts) . ')';
+        }
+        break;
+
+      case 'nll':
+        $this->_whereClauses[] = "{$this->_aliases['civicrm_membership']}.contribution_recur_id IS NULL";
+        break;
+
+      case 'nnll':
+        $this->_whereClauses[] = "{$this->_aliases['civicrm_membership']}.contribution_recur_id IS NOT NULL";
     }
   }
 
@@ -367,6 +478,15 @@ class CRM_Report_Form_Member_Detail extends CRM_Report_Form {
       }
       if ($value = CRM_Utils_Array::value('civicrm_contribution_payment_instrument_id', $row)) {
         $rows[$rowNum]['civicrm_contribution_payment_instrument_id'] = $paymentInstruments[$value];
+        $entryFound = TRUE;
+      }
+      if ($value = $row['civicrm_contribution_recur_autorenew_status_id'] ?? NULL) {
+        $rows[$rowNum]['civicrm_contribution_recur_autorenew_status_id'] = $contributionStatus[$value];
+        if (!empty($row['civicrm_contribution_recur_end_date'])
+          && strtotime($row['civicrm_contribution_recur_end_date']) < time()) {
+          $ended = ts('ended');
+          $rows[$rowNum]['civicrm_contribution_recur_autorenew_status_id'] .= " ($ended)";
+        }
         $entryFound = TRUE;
       }
 

--- a/tests/phpunit/CRM/Report/Form/Member/DetailTest.php
+++ b/tests/phpunit/CRM/Report/Form/Member/DetailTest.php
@@ -1,0 +1,110 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *  Test Activity report outcome
+ *
+ * @package CiviCRM
+ */
+class CRM_Report_Form_Member_DetailTest extends CiviReportTestCase {
+
+  public function setUp() {
+    parent::setUp();
+
+    $this->_orgContactID = $this->organizationCreate();
+    $this->_financialTypeId = 1;
+    $this->_membershipStatusID = $this->membershipStatusCreate('test status');
+    $this->_membershipTypeID = $this->membershipTypeCreate(['name' => 'Test Member']);
+  }
+
+  public function testAutoRenewDisplay() {
+
+    $indContactID1 = $this->individualCreate();
+    $indContactID2 = $this->individualCreate();
+    $recurStatus = array_search(
+      'In Progress',
+      CRM_Contribute_PseudoConstant::contributionStatus(NULL, 'name')
+    );
+    $recurParams = [
+      'contact_id' => $indContactID1,
+      'amount' => '5.00',
+      'currency' => 'USD',
+      'frequency_unit' => 'day',
+      'frequency_interval' => 30,
+      'create_date' => '2019-06-22',
+      'start_date' => '2019-06-22',
+      'contribution_status_id' => $recurStatus,
+    ];
+    $recur1 = civicrm_api3('ContributionRecur', 'create', $recurParams);
+    $memParams = [
+      'membership_type_id' => $this->_membershipTypeID,
+      'contact_id' => $indContactID1,
+      'status_id' => $this->_membershipStatusID,
+      'contribution_recur_id' => $recur1['id'],
+      'join_date' => '2019-06-22',
+      'start_date' => '2019-06-22',
+      'end_date' => '2019-07-22',
+      'source' => 'Payment',
+    ];
+    $mem1 = civicrm_api3('Membership', 'create', $memParams);
+    $recurParams['end_date'] = '2019-06-23';
+    $recurParams['contact_id'] = $indContactID1;
+    $recur2 = civicrm_api3('ContributionRecur', 'create', $recurParams);
+    $memParams['contact_id'] = $indContactID2;
+    $memParams['contribution_recur_id'] = $recur2['id'];
+    $mem2 = civicrm_api3('Membership', 'create', $memParams);
+
+    $input = [
+      'fields' => ['autorenew_status_id'],
+      'filters' => [
+        'tid_op' => 'in',
+        'tid_value' => $this->_membershipTypeID,
+        'autorenew_status_id_op' => 'in',
+        'autorenew_status_id_value' => $recurStatus,
+      ],
+    ];
+    $obj = $this->getReportObject('CRM_Report_Form_Member_Detail', $input);
+    $results = $obj->getResultSet();
+    $this->assertCount(2, $results);
+    foreach ($results as $result) {
+      if ($result['civicrm_contact_id'] == $indContactID1) {
+        $this->assertNotContains('(ended)', $result['civicrm_contribution_recur_autorenew_status_id']);
+      }
+      if ($result['civicrm_contact_id'] == $indContactID2) {
+        $this->assertContains('(ended)', $result['civicrm_contribution_recur_autorenew_status_id']);
+      }
+    }
+
+    $input['filters']['autorenew_status_id_op'] = 'nll';
+    $obj = $this->getReportObject('CRM_Report_Form_Member_Detail', $input);
+    $results = $obj->getResultSet();
+    $this->assertCount(0, $results);
+
+    $input['filters']['autorenew_status_id_op'] = 'in';
+    $input['filters']['autorenew_status_id_value'] = 0;
+    $obj = $this->getReportObject('CRM_Report_Form_Member_Detail', $input);
+    $results = $obj->getResultSet();
+    $this->assertCount(0, $results);
+
+    $input['filters']['autorenew_status_id_op'] = 'in';
+    $input['filters']['autorenew_status_id_value'] = 1000;
+    $obj = $this->getReportObject('CRM_Report_Form_Member_Detail', $input);
+    $results = $obj->getResultSet();
+    $this->assertCount(0, $results);
+
+    $input['filters']['autorenew_status_id_op'] = 'notin';
+    $input['filters']['autorenew_status_id_value'] = 1000;
+    $obj = $this->getReportObject('CRM_Report_Form_Member_Detail', $input);
+    $results = $obj->getResultSet();
+    $this->assertCount(2, $results);
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
This adds a column and a filter for autorenew status to the membership detail report.

Before
----------------------------------------
No way to see or filter by memberships that are autorenewing.

After
----------------------------------------
You can add the status as a column in the report:
![image](https://user-images.githubusercontent.com/1682375/85466160-9ee89600-b577-11ea-8080-131c5f9200cf.png)

You can also filter by the autorenew statuses, plus "None" (for memberships that don't autorenew) and "Ended" (for those of any statuses that have an end date in the past).:
![image](https://user-images.githubusercontent.com/1682375/85465762-2bdf1f80-b577-11ea-8f77-c27a2e0609ce.png)

Auto-renewals with the end date in the past display "(ended)" following the status:
![image](https://user-images.githubusercontent.com/1682375/85465576-f20e1900-b576-11ea-8ed1-5426239f3ab2.png)


Technical Details
----------------------------------------
These statuses are different from those in Find Memberships because they're pulled from the DAO.  "Ended" works similarly, though.

I've added test coverage for this, too.