### PR TITLE
Add selfService flag to cancelSubscription getText so we can display different text for each case

### DIFF
--- a/CRM/Contribute/Form/CancelSubscription.php
+++ b/CRM/Contribute/Form/CancelSubscription.php
@@ -55,6 +55,7 @@ class CRM_Contribute_Form_CancelSubscription extends CRM_Contribute_Form_Contrib
       'frequency_interval' => $this->getSubscriptionDetails()->frequency_interval,
       'frequency_unit' => $this->getSubscriptionDetails()->frequency_unit,
       'installments' => $this->getSubscriptionDetails()->installments,
+      'selfService' => $this->isSelfService(),
     ];
 
     if ($this->_crid) {

--- a/CRM/Core/Payment.php
+++ b/CRM/Core/Payment.php
@@ -565,7 +565,12 @@ abstract class CRM_Core_Payment {
    *   Currently supported:
    *   - contributionPageRecurringHelp (params: is_recur_installments, is_email_receipt)
    *   - contributionPageContinueText (params: amount, is_payment_to_existing)
-   *   - cancelRecurDetailText (params: mode, amount, currency, frequency_interval, frequency_unit, installments, {membershipType|only if mode=auto_renew})
+   *   - cancelRecurDetailText:
+   *     params:
+   *       mode, amount, currency, frequency_interval, frequency_unit,
+   *       installments, {membershipType|only if mode=auto_renew},
+   *       selfService (bool) - TRUE if user doesn't have "edit contributions" permission.
+   *         ie. they are accessing via a "self-service" link from an email receipt or similar.
    *   - cancelRecurNotSupportedText
    *
    * @param array $params


### PR DESCRIPTION
Overview
----------------------------------------
A self-service cancellation does not display the "Send cancellation request to payment processor" yes/no radio but the backend cancellation does.
In the self-service case the payment processor code makes a choice, in the backend case the user gets the choice.

So you might want to display to self-service:
"GoCardless will be notified and your subscription will be cancelled."

But for backend you might say:
"If you select 'Send cancellation request' then GoCardless will be notified and your subscription will be cancelled."

Before
----------------------------------------
Not possible to identify contexts.

After
----------------------------------------
Possible to identify context and display more appropriate messaging.

Technical Details
----------------------------------------
This is a change that allows payment processor developers to identify the different contexts and display appropriate messaging.

Comments
----------------------------------------
@artfulrobot @eileenmcnaughton See https://github.com/artfulrobot/uk.artfulrobot.civicrm.gocardless/pull/83 for context.