### PR TITLE
Payment.create should not set contribution date to today

### DIFF
--- a/CRM/Financial/BAO/Payment.php
+++ b/CRM/Financial/BAO/Payment.php
@@ -141,6 +141,7 @@ class CRM_Financial_BAO_Payment {
           'id' => $contribution['id'],
           'is_post_payment_create' => TRUE,
           'is_email_receipt' => $params['is_send_contribution_notification'],
+          'trxn_date' => $params['trxn_date'],
         ]);
         // Get the trxn
         $trxnId = CRM_Core_BAO_FinancialTrxn::getFinancialTrxnId($contribution['id'], 'DESC');


### PR DESCRIPTION
Overview
----------------------------------------

I noticed that calling the payment.create API resets the contribution date.

Before
----------------------------------------

1. create a pending contribution with a historical date.
2. create a payment on it also with a historical date
3. contribution `receive_date` gets reset to today's date.


After
----------------------------------------

1. create a pending contribution with a historical date.
2. create a payment on it also with a historical date
3. contribution `receive_date` gets update to the payment's date.

Technical Details
----------------------------------------

Has test.

@eileenmcnaughton @JoeMurray @mattwire @adixon may be interested