### PR TITLE
Use psr-4 instead of psr-0 in Civi directory

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
       "Civi\\": ["tests/phpunit/"]
     },
     "psr-4": {
-      "Civi\\": [".", "setup/src/"]
+      "Civi\\": [".", "Civi/", "setup/src/"]
     }
   },
   "include-path": ["vendor/tecnickcom"],


### PR DESCRIPTION
Overview
----------------------------------------
This is a followup to #17105 which attempted the same thing but without success.
This finally gets classnames with underscores to work correctly in the Civi directory.

Before
----------------------------------------
PSR-4 was not working in Civi directory.

After
----------------------------------------
Now it works.
