### PR TITLE
core#1840 - Can't add/change recipient on non-bulk SMS

### DIFF
--- a/templates/CRM/Contact/Form/Task/SMS.tpl
+++ b/templates/CRM/Contact/Form/Task/SMS.tpl
@@ -86,7 +86,7 @@ CRM.$(function($){
       ajax: {
         url: sourceDataUrl,
         data: function(term) {
-          return { name: term,};
+          return { name: term, id: 1};
         },
         results: function(response) {
           return { results: response };


### PR DESCRIPTION
https://lab.civicrm.org/dev/core/-/issues/1840

Overview
----------------------------------------
When sending a non-bulk SMS, you can't add recipients or change the recipient; only the default recipient works.

Before
----------------------------------------
Crash with an exception:
```
CRM_Core_Exception: One of parameters  (value: &amp;amp;quot;Lastname) is not of the type Positive
```
After
----------------------------------------
Works.

Technical Details
----------------------------------------
The JS is making an AJAX request to `CRM_Contact_Page_AJAX::getContactPhone()`.  In [line 451](https://github.com/civicrm/civicrm-core/blob/master/CRM/Contact/Page/AJAX.php#L451), you can see that the results can be returned in one of two formats, depending on whether it was called with a true `id` parameter.  This JS wasn't passing `id`, so it was getting back the results in an incorrect format.