### PR TITLE
[REF] Add in Report output handler factory and interface so extensions can more easily customise output handling

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -5077,11 +5077,9 @@ LEFT JOIN civicrm_contact {$field['alias']} ON {$field['alias']}.id = {$this->_a
       unset($this->_params['task']);
     }
 
-    if (!empty($this->_outputMode) && empty($this->_outputHandler)) {
-      $className = 'CRM_Report_Output_' . ucfirst($this->_outputMode);
-      if (class_exists($className)) {
-        $this->_outputHandler = new $className($this);
-      }
+    if (!empty($this->_outputMode) && empty($this->_outputHandler) && !in_array($this->_outputMode, ['save', 'copy', 'group'])) {
+      $outputHandlerFactory = new \Civi\Report\OutputHandlerFactory();
+      $this->_outputHandler = $outputHandlerFactory->getOutputHandler($this->_outputMode, $this);
     }
   }
 

--- a/CRM/Report/Output/Csv.php
+++ b/CRM/Report/Output/Csv.php
@@ -9,10 +9,14 @@
  +--------------------------------------------------------------------+
  */
 
+/**
+ * CSV Report Output handler
+ */
 class CRM_Report_Output_Csv implements CRM_Report_Output_Interface {
 
   /**
    * Reference of the report instance.
+   * @var \CRM_Report_Form
    */
   protected $report;
 

--- a/CRM/Report/Output/Csv.php
+++ b/CRM/Report/Output/Csv.php
@@ -1,0 +1,44 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+class CRM_Report_Output_Csv implements CRM_Report_Output_Interface {
+
+  /**
+   * Reference of the report instance.
+   */
+  protected $report;
+
+  /**
+   * @inheritDoc
+   */
+  public function __construct(&$report) {
+    $report->printOnly = TRUE;
+    $report->absoluteUrl = TRUE;
+    $report->setAddPaging(FALSE);
+
+    $this->report = $report;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function supportsSqlDeveloperTab() {
+    return FALSE;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function generateOutput(&$rows = NULL) {
+    CRM_Report_Utils_Report::export2csv($this->report, $rows);
+  }
+
+}

--- a/CRM/Report/Output/Interface.php
+++ b/CRM/Report/Output/Interface.php
@@ -1,0 +1,45 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ *
+ * CRM_Report_Output_Interface implements helper functions to determine what to
+ * do with the report data, such as displaying on the screen, printing, pdf,
+ * csv, etc. Extensions can also provide their own implementations, such as the
+ * civiexportexcel extension.
+ */
+interface CRM_Report_Output_Interface {
+
+  /**
+   * Class constructor.
+   *
+   * @param CRM_Report_Form
+   */
+  public function __construct(&$report);
+
+  /**
+   * Checks if the output method supports the SQL developer tab.
+   *
+   * @return bool
+   */
+  public function supportsSqlDeveloperTab();
+
+  /**
+   * Generate the output.
+   *
+   * @param array
+   */
+  public function generateOutput(&$rows = NULL);
+
+}

--- a/CRM/Report/Output/Interface.php
+++ b/CRM/Report/Output/Interface.php
@@ -24,7 +24,7 @@ interface CRM_Report_Output_Interface {
   /**
    * Class constructor.
    *
-   * @param CRM_Report_Form
+   * @param CRM_Report_Form $report
    */
   public function __construct(&$report);
 
@@ -38,7 +38,7 @@ interface CRM_Report_Output_Interface {
   /**
    * Generate the output.
    *
-   * @param array
+   * @param array $rows
    */
   public function generateOutput(&$rows = NULL);
 

--- a/CRM/Report/Output/Pdf.php
+++ b/CRM/Report/Output/Pdf.php
@@ -1,0 +1,62 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+class CRM_Report_Output_Pdf implements CRM_Report_Output_Interface {
+
+  /**
+   * Reference of the report instance.
+   */
+  protected $report;
+
+  /**
+   * @inheritDoc
+   */
+  public function __construct(&$report) {
+    $report->printOnly = TRUE;
+    $report->absoluteUrl = TRUE;
+    $report->setAddPaging(FALSE);
+
+    $this->report = $report;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function supportsSqlDeveloperTab() {
+    return FALSE;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function generateOutput(&$rows = NULL) {
+    $content = $this->report->compileContent();
+    $id = $this->report->getID();
+    $url = CRM_Utils_System::url("civicrm/report/instance/{$id}", "reset=1", TRUE);
+
+    // Nb. Once upon a time we used a package called Open Flash Charts to
+    // draw charts, and we had a feature whereby a browser could send the
+    // server a PNG version of the chart, which could then be included in a
+    // PDF by including <img> tags in the HTML for the conversion below.
+    //
+    // This feature stopped working when browsers stopped supporting Flash,
+    // and although we have a different client-side charting library in
+    // place, we decided not to reimplement the (rather convoluted)
+    // browser-sending-rendered-chart-to-server process.
+    //
+    // If this feature is required in future we should find a better way to
+    // render charts on the server side, e.g. server-created SVG.
+    CRM_Utils_PDF_Utils::html2pdf($content, "CiviReport.pdf", FALSE, ['orientation' => 'landscape']);
+
+    CRM_Utils_System::civiExit();
+  }
+
+}

--- a/CRM/Report/Output/Print.php
+++ b/CRM/Report/Output/Print.php
@@ -10,9 +10,9 @@
  */
 
 /**
- * PDF Report Output Handler
+ * Print Report Output Handler
  */
-class CRM_Report_Output_Pdf implements CRM_Report_Output_Interface {
+class CRM_Report_Output_Print implements CRM_Report_Output_Interface {
 
   /**
    * Reference of the report instance.
@@ -45,22 +45,6 @@ class CRM_Report_Output_Pdf implements CRM_Report_Output_Interface {
     $content = $this->report->compileContent();
     $id = $this->report->getID();
     $url = CRM_Utils_System::url("civicrm/report/instance/{$id}", "reset=1", TRUE);
-
-    // Nb. Once upon a time we used a package called Open Flash Charts to
-    // draw charts, and we had a feature whereby a browser could send the
-    // server a PNG version of the chart, which could then be included in a
-    // PDF by including <img> tags in the HTML for the conversion below.
-    //
-    // This feature stopped working when browsers stopped supporting Flash,
-    // and although we have a different client-side charting library in
-    // place, we decided not to reimplement the (rather convoluted)
-    // browser-sending-rendered-chart-to-server process.
-    //
-    // If this feature is required in future we should find a better way to
-    // render charts on the server side, e.g. server-created SVG.
-    CRM_Utils_PDF_Utils::html2pdf($content, "CiviReport.pdf", FALSE, ['orientation' => 'landscape']);
-
-    CRM_Utils_System::civiExit();
   }
 
 }

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -2666,4 +2666,17 @@ abstract class CRM_Utils_Hook {
     );
   }
 
+  /**
+   * This hook allows for extensions to add to the list of report output handlers
+   * @param array $outputHandlers
+   *
+   * @return mixed
+   */
+  public static function outputHandlers(&$outputHandlers) {
+    return self::singleton()->invoke(['outputHandlers'], $outputHandlers,
+      self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      'civicrm_outputHandlers'
+    );
+  }
+
 }

--- a/Civi/Report/OutputHandlerFactory.php
+++ b/Civi/Report/OutputHandlerFactory.php
@@ -1,0 +1,50 @@
+<?php
+
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Report;
+
+/**
+ *
+ * @package CiviCRM_Hook
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+class OutputHandlerFactory {
+
+  /**
+   * Array of output modes to the respective class
+   * @var array
+   */
+  public $outputHandlers;
+
+  /**
+   * Set the relevant OutputHandler to use in Export Forms.
+   * @param string $outputMode
+   * @param \CRM_Report_Form $reportForm
+   * @return \CRM_Report_Output_Interface
+   */
+  public function getOutputHandler(&$outputMode, $reportForm) {
+    $this->buildOutputHandlers();
+    return new $this->outputHandlers[$outputMode]($reportForm);
+  }
+
+  public function buildOutputHandlers() {
+    $outputHandlers = [
+      'csv' => 'CRM_Report_Output_Csv',
+      'pdf' => 'CRM_Report_Output_Pdf',
+      'print' => 'CRM_Report_Output_Print',
+    ];
+    \CRM_Utils_Hook::outputHandlers($outputHandlers);
+    $this->outputHandlers = $outputHandlers;
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
This picks up the work from https://github.com/civicrm/civicrm-core/pull/17145 and adds in the OutputHandlerFactory as suggested by @demeritcowboy @eileenmcnaughton to allow extensions to add and or remove OutputHandlers

Before
----------------------------------------
No easy ability for extensions to alter report Output Handlers

After
----------------------------------------
Easier for extension authors to add in report output handlers

ping @mlutfy @totten @eileenmcnaughton @demeritcowboy 