### PR TITLE
dev/core#1137 Implement ability to connect to MySQL database over SSL

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -430,6 +430,9 @@ class CRM_Core_DAO extends DB_DataObject {
 
     $conn = &$_DB_DATAOBJECT['CONNECTIONS'][$this->_database_dsn_md5];
     $orig_options = $conn->options;
+    if (defined('CIVICRM_DB_USE_SSL')) {
+      $this->setOptions(array_merge($this->_options, ['ssl' => TRUE]));
+    }
     $this->_setDBOptions($this->_options);
 
     if ($i18nRewrite and $dbLocale) {
@@ -472,6 +475,11 @@ class CRM_Core_DAO extends DB_DataObject {
    */
   public function initialize() {
     $this->_connect();
+    if (defined('CIVICRM_DB_USE_SSL')) {
+      $conn = $this->getConnection();
+      $orig_options = $conn->options;
+      $this->_setDBOptions(array_merge($orig_options, ['ssl' => TRUE]));
+    }
     if (empty(Civi::$statics[__CLASS__]['init'])) {
       // CRM_Core_DAO::init() must be called before CRM_Core_DAO->initialize().
       // This occurs very early in bootstrap - error handlers may not be wired up.

--- a/CRM/Utils/File.php
+++ b/CRM/Utils/File.php
@@ -325,7 +325,11 @@ class CRM_Utils_File {
     }
     else {
       require_once 'DB.php';
-      $db = DB::connect($dsn);
+      $options = [];
+      if (defined('CIVICRM_DB_USE_SSL')) {
+        $options['ssl'] = TRUE;
+      }
+      $db = DB::connect($dsn, $options);
     }
 
     if (PEAR::isError($db)) {

--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -724,7 +724,11 @@ class CRM_Utils_System {
     $session->set('civicrmInitSession', TRUE);
 
     if ($config->userFrameworkDSN) {
-      $dbDrupal = DB::connect($config->userFrameworkDSN);
+      $options = [];
+      if (defined('CIVICRM_DB_USE_SSL')) {
+        $options['ssl'] = TRUE;
+      }
+      $dbDrupal = DB::connect($config->userFrameworkDSN, $options);
     }
     return $config->userSystem->authenticate($name, $password, $loadCMSBootstrap, $realPath);
   }

--- a/CRM/Utils/System/Backdrop.php
+++ b/CRM/Utils/System/Backdrop.php
@@ -291,7 +291,11 @@ class CRM_Utils_System_Backdrop extends CRM_Utils_System_DrupalBase {
   public function authenticate($name, $password, $loadCMSBootstrap = FALSE, $realPath = NULL) {
     $config = CRM_Core_Config::singleton();
 
-    $dbBackdrop = DB::connect($config->userFrameworkDSN);
+    $options = [];
+    if (defined('CIVICRM_DB_USE_SSL')) {
+      $options['ssl'] = TRUE;
+    }
+    $dbBackdrop = DB::connect($config->userFrameworkDSN, $options);
     if (DB::isError($dbBackdrop)) {
       throw new CRM_Core_Exception("Cannot connect to Backdrop database via $config->userFrameworkDSN, " . $dbBackdrop->getMessage());
     }

--- a/CRM/Utils/System/Drupal.php
+++ b/CRM/Utils/System/Drupal.php
@@ -317,7 +317,11 @@ class CRM_Utils_System_Drupal extends CRM_Utils_System_DrupalBase {
 
     $config = CRM_Core_Config::singleton();
 
-    $dbDrupal = DB::connect($config->userFrameworkDSN);
+    $options = [];
+    if (defined('CIVICRM_DB_USE_SSL')) {
+      $options['ssl'] = TRUE;
+    }
+    $dbDrupal = DB::connect($config->userFrameworkDSN, $options);
     if (DB::isError($dbDrupal)) {
       throw new CRM_Core_Exception("Cannot connect to drupal db via $config->userFrameworkDSN, " . $dbDrupal->getMessage());
     }

--- a/CRM/Utils/System/Drupal6.php
+++ b/CRM/Utils/System/Drupal6.php
@@ -300,7 +300,11 @@ class CRM_Utils_System_Drupal6 extends CRM_Utils_System_DrupalBase {
 
     $config = CRM_Core_Config::singleton();
 
-    $dbDrupal = DB::connect($config->userFrameworkDSN);
+    $options = [];
+    if (defined('CIVICRM_DB_USE_SSL')) {
+      $options['ssl'] = TRUE;
+    }
+    $dbDrupal = DB::connect($config->userFrameworkDSN, $options);
     if (DB::isError($dbDrupal)) {
       throw new CRM_Core_Exception("Cannot connect to drupal db via $config->userFrameworkDSN, " . $dbDrupal->getMessage());
     }

--- a/install/civicrm.php
+++ b/install/civicrm.php
@@ -141,7 +141,11 @@ function civicrm_source($dsn, $fileName, $lineMode = FALSE) {
     define('DB_DSN_MODE', 'auto');
   }
 
-  $db = DB::connect($dsn);
+  $options = [];
+  if (defined('CIVICRM_DB_USE_SSL')) {
+    $options['ssl'] = TRUE;
+  }
+  $db = DB::connect($dsn, $options);
   if (PEAR::isError($db)) {
     die("Cannot open $dsn: " . $db->getMessage());
   }

--- a/templates/CRM/common/civicrm.settings.php.template
+++ b/templates/CRM/common/civicrm.settings.php.template
@@ -503,6 +503,13 @@ if (CIVICRM_UF === 'UnitTests') {
 // }
 
 /**
+ * Determine if we should connect to the database over SSL
+ */
+// if (!defined('CIVICRM_DB_USE_SSL')) {
+//   define('CIVICRM_DB_USE_SSL', FALSE);
+// }
+
+/**
  *
  * Do not change anything below this line. Keep as is
  *


### PR DESCRIPTION
Overview
----------------------------------------
This implements the ability to connect to the MySQL databaes using SSL if appropriately defined as part of the DSN

Before
----------------------------------------
CiviCRM cannot connect to MySQL over SSL

After
----------------------------------------
Allow CiviCRM to connect to MySQL over SSL

ping @totten @demeritcowboy 