### PR TITLE
event#38 fix wording on event reg page

### DIFF
--- a/templates/CRM/Event/Form/Registration/Register.tpl
+++ b/templates/CRM/Event/Form/Registration/Register.tpl
@@ -55,7 +55,7 @@
           {$form.additional_participants.html}{if $contact_id || $contact_id == NULL}{ts}(including yourself){/ts}{/if}
           <br/>
           <span
-            class="description">{ts}Fill in your registration information on this page. If you are registering additional people, you will be able to enter their registration information after you complete this page and click &quot;Continue&quot;.{/ts}</span>
+            class="description">{ts}Fill in your registration information on this page. If you are registering additional people, you will be able to enter their registration information after you complete this page and click &quot;Review your registration&quot;.{/ts}</span>
         </div>
         <div class="clear"></div>
       </div>


### PR DESCRIPTION
https://lab.civicrm.org/dev/event/-/issues/38

Overview
----------------------------------------
The on-page instructions state "If you are registering additional people, you will be able to enter their registration information after you complete this page and click Continue", the only button available says 'Review you registration'.

https://civicrm.stackexchange.com/questions/35964/misleading-instructions-in-civievent-registration-template-for-multiple-particip

Before
----------------------------------------
Text says "Continue"

After
----------------------------------------
Text says "Review your registration".

Technical Details
----------------------------------------
lol