### PR TITLE
Add define to allow CiviCRM to connect using utf8mb4 charset

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -178,7 +178,10 @@ class CRM_Core_DAO extends DB_DataObject {
       }
       CRM_Core_DAO::executeQuery("SET SESSION sql_mode = %1", [1 => [implode(',', $currentModes), 'String']]);
     }
-    CRM_Core_DAO::executeQuery('SET NAMES utf8');
+    if (!defined('CIVICRM_CHARSET')) {
+      define('CIVICRM_CHARSET', 'utf8');
+    }
+    CRM_Core_DAO::executeQuery('SET NAMES ' . CIVICRM_CHARSET);
     CRM_Core_DAO::executeQuery('SET @uniqueID = %1', [1 => [CRM_Utils_Request::id(), 'String']]);
   }
 

--- a/templates/CRM/common/civicrm.settings.php.template
+++ b/templates/CRM/common/civicrm.settings.php.template
@@ -129,6 +129,15 @@ if (!defined('CIVICRM_LOGGING_DSN')) {
 }
 
 /**
+ * utf8mb4 support - see https://lab.civicrm.org/dev/core/-/wikis/utf8mb4
+ * If your database is uses charset utf8mb4 and collation utf8mb4_unicode_ci you can enable this and CiviCRM will
+ * connect to the database in utf8mb4 mode and you can save emojis!
+ */
+// if (!defined('CIVICRM_CHARSET')) {
+//   define('CIVICRM_CHARSET', 'utf8mb4');
+// }
+
+/**
  * File System Paths:
  *
  * $civicrm_root is the file system path on your server where the civicrm


### PR DESCRIPTION
Overview
----------------------------------------
See https://lab.civicrm.org/dev/core/-/wikis/utf8mb4 and https://github.com/civicrm/civicrm-core/pull/13633

This allows you to specify utf8mb4 as the charset using `civicrm.settings.php` which via this PR means that all calls to `CRM_Core_DAO::init()` will run `SET NAMES utf8mb4` instead of `SET NAMES utf8` and will successfully save utf8mb4 characters (eg. 😊) to the database.

Before
----------------------------------------
CiviCRM will fail to save utf8mb4 characters to a utf8mb4 database.

After
----------------------------------------
CiviCRM will save utf8mb4 characters to a utf8mb4 database.

Technical Details
----------------------------------------
Explained above and in links

Comments
----------------------------------------
@mfb @eileenmcnaughton @demeritcowboy This is another small step towards supporting utf8mb4. There are probably other places in the codebase that should use the constant but this is the most important and most obvious - as it actually controls whether CiviCRM connects to the database in utf8 or utf8mb4 and allows us to save utf8mb4 characters or die.
