### PR TITLE
Multi record import screen fix

### DIFF
--- a/CRM/Core/BAO/Mapping.php
+++ b/CRM/Core/BAO/Mapping.php
@@ -151,6 +151,7 @@ class CRM_Core_BAO_Mapping extends CRM_Core_DAO_Mapping {
         civicrm_api3('OptionValue', 'create', [
           'option_group_id' => 'mapping_type',
           'label' => $mappingType,
+          'name' => $mappingType,
           'value' => max(array_keys($mappingValues['values'])) + 1,
           'is_reserved' => 1,
         ]);

--- a/tests/phpunit/CRM/Core/BAO/MappingTest.php
+++ b/tests/phpunit/CRM/Core/BAO/MappingTest.php
@@ -219,4 +219,11 @@ class CRM_Core_BAO_MappingTest extends CiviUnitTestCase {
     ];
   }
 
+  /**
+   * Ensure getCreateMappingValues() doesn't return an error when there are spaces in the name.
+   */
+  public function testGetCreateMappingValues() {
+    CRM_Core_BAO_Mapping::getCreateMappingValues("Import Multi value custom data");
+  }
+
 }


### PR DESCRIPTION
https://lab.civicrm.org/dev/core/-/issues/1841

Overview
----------------------------------------
Accessing the "Import Multi-Record Custom Fields" screen crashes unless you've previously accessed it.

Before
----------------------------------------
Exception: 'Import Multi value custom data' is not a valid option for field mapping_type_id.`

After
----------------------------------------
Page loads.

Technical Details
----------------------------------------
See the ticket!