### PR TITLE
Add system check to ensure WP base page exists

### DIFF
--- a/CRM/Utils/Check/Component/Cms.php
+++ b/CRM/Utils/Check/Component/Cms.php
@@ -27,6 +27,12 @@ class CRM_Utils_Check_Component_Cms extends CRM_Utils_Check_Component {
     if ($config->userFramework != 'WordPress') {
       return [];
     }
+    if (is_multisite()) {
+      // There are a lot potential configurations in a multisite context where
+      // this could show a false positive.  This completely skips multisite for
+      // now.
+      return [];
+    }
     $messages = [];
 
     $slug = $config->wpBasePage;

--- a/CRM/Utils/Check/Component/Cms.php
+++ b/CRM/Utils/Check/Component/Cms.php
@@ -1,0 +1,100 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+class CRM_Utils_Check_Component_Cms extends CRM_Utils_Check_Component {
+
+  /**
+   * For sites running in WordPress, make sure the configured base page exists.
+   *
+   * @return array
+   *   Instances of CRM_Utils_Check_Message
+   */
+  public static function checkWpBasePage() {
+    $config = CRM_Core_Config::singleton();
+    if ($config->userFramework != 'WordPress') {
+      return [];
+    }
+    $messages = [];
+
+    $slug = $config->wpBasePage;
+    $pageArgs = [
+      'name' => $slug,
+      'post_type' => 'page',
+      'post_status' => 'publish',
+      'numberposts' => 1,
+    ];
+    $basePage = get_posts($pageArgs);
+    if (!$basePage) {
+      $cmsSettings = CRM_Utils_System::url(
+        'civicrm/admin/setting',
+        $query = ['reset' => 1],
+        FALSE,
+        NULL,
+        TRUE,
+        FALSE,
+        TRUE
+      );
+      $messageText = [
+        ts(
+          'CiviCRM relies upon a base page in WordPress at %1%2, but it is missing.',
+          [
+            1 => $config->userFrameworkBaseURL,
+            2 => $slug,
+          ]
+        ),
+      ];
+      if ($slug == 'civicrm') {
+        $messageText[] = ts(
+          'If you have an alternative base page, it can be set in the <a href="%2">WordPress integration settings</a>.',
+          [
+            1 => $config->userFrameworkBaseURL,
+            2 => $cmsSettings,
+          ]
+        );
+      }
+      else {
+        $pageArgs['name'] = 'civicrm';
+        $defaultBasePage = get_posts($pageArgs);
+        if ($defaultBasePage) {
+          $messageText[] = ts(
+            'The default is %1civicrm, which <a href="%1civicrm">does exist on this site</a>.',
+            [1 => $config->userFrameworkBaseURL]
+          );
+        }
+        else {
+          $messageText[] = ts(
+            'The default is %1civicrm, but that does not exist on this site either.',
+            [1 => $config->userFrameworkBaseURL]
+          );
+        }
+        $messageText[] = ts(
+          'You can set the correct base page in the <a href="%1">WordPress integration settings</a>.',
+          [1 => $cmsSettings]
+        );
+      }
+      $messages[] = new CRM_Utils_Check_Message(
+        __FUNCTION__,
+        implode(' ', $messageText),
+        ts('WordPress Base Page Missing'),
+        \Psr\Log\LogLevel::ERROR,
+        'fa-wordpress'
+      );
+    }
+
+    return $messages;
+  }
+
+}

--- a/CRM/Utils/Check/Component/Cms.php
+++ b/CRM/Utils/Check/Component/Cms.php
@@ -33,42 +33,53 @@ class CRM_Utils_Check_Component_Cms extends CRM_Utils_Check_Component {
       // now.
       return [];
     }
-    $messages = [];
 
-    $slug = $config->wpBasePage;
-    $basePage = get_page_by_path($slug);
-    if (!$basePage || $basePage->post_status != 'publish') {
-      $cmsSettings = CRM_Utils_System::url(
-        'civicrm/admin/setting',
-        $query = ['reset' => 1],
-        FALSE,
-        NULL,
-        TRUE,
-        FALSE,
-        TRUE
-      );
-      if ($basePage) {
+    switch (self::pageExists($config->wpBasePage)) {
+      case 1:
+        // Page is here and published
+        return [];
+
+      case 0:
         $messageText = [
           ts(
             'CiviCRM relies upon a <a href="%1%2">base page in WordPress</a>, but it is not published.',
             [
               1 => $config->userFrameworkBaseURL,
-              2 => $slug,
+              2 => $config->wpBasePage,
             ]
           ),
         ];
-      }
-      else {
+        break;
+
+      case -1:
+        // Page is missing, but let's look around to see if the default is there
+        // --either the default as modified by civicrm_basepage_slug or the
+        // default default, `civicrm`.
+        $cmsSettings = CRM_Utils_System::url(
+          'civicrm/admin/setting',
+          $query = ['reset' => 1],
+          FALSE,
+          NULL,
+          TRUE,
+          FALSE,
+          TRUE
+        );
         $messageText = [
           ts(
             'CiviCRM relies upon a base page in WordPress at %1%2, but it is missing.',
             [
               1 => $config->userFrameworkBaseURL,
-              2 => $slug,
+              2 => $config->wpBasePage,
             ]
           ),
         ];
-        if ($slug == 'civicrm') {
+
+        $altSlugs = array_unique([
+          apply_filters('civicrm_basepage_slug', 'civicrm'),
+          'civicrm',
+        ]);
+
+        if (in_array($config->wpBasePage, $altSlugs)) {
           $messageText[] = ts(
             'If you have an alternative base page, it can be set in the <a href="%2">WordPress integration settings</a>.',
             [
@@ -78,36 +89,72 @@ class CRM_Utils_Check_Component_Cms extends CRM_Utils_Check_Component {
           );
         }
         else {
-          $pageArgs['name'] = 'civicrm';
-          $defaultBasePage = get_posts($pageArgs);
-          if ($defaultBasePage) {
+          foreach ($altSlugs as $slug) {
+            $exists = self::pageExists($slug);
+            if ($exists >= 0) {
+              // One of the possible defaults is here, published or not.
+              $messageText[] = ts(
+                'The default is %1%2, which <a href="%1%2">does exist on this site</a>.',
+                [
+                  1 => $config->userFrameworkBaseURL,
+                  2 => $slug,
+                ]
+              );
+              if ($exists == 0) {
+                $messageText[] = ts('However, it is not published.');
+              }
+              // We've found one, and if the `civicrm_basepage_slug` filter has
+              // modified the default, we should go with it.
+              break;
+            }
+          }
+          if ($exists == -1) {
+            // We went through the default(s) and couldn't find one.  Defer to
+            // the one modified by the filter.
             $messageText[] = ts(
-              'The default is %1civicrm, which <a href="%1civicrm">does exist on this site</a>.',
-              [1 => $config->userFrameworkBaseURL]
+              'The default is %1%2, but that does not exist on this site either.',
+              [
+                1 => $config->userFrameworkBaseURL,
+                2 => $altSlugs[0],
+              ]
             );
           }
-          else {
-            $messageText[] = ts(
-              'The default is %1civicrm, but that does not exist on this site either.',
-              [1 => $config->userFrameworkBaseURL]
-            );
-          }
+
           $messageText[] = ts(
             'You can set the correct base page in the <a href="%1">WordPress integration settings</a>.',
             [1 => $cmsSettings]
           );
         }
-      }
-      $messages[] = new CRM_Utils_Check_Message(
+    }
+
+    return [
+      new CRM_Utils_Check_Message(
         __FUNCTION__,
         implode(' ', $messageText),
         ts('WordPress Base Page Missing'),
         \Psr\Log\LogLevel::ERROR,
         'fa-wordpress'
-      );
+      ),
+    ];
+  }
+
+  /**
+   * See if a page exists and is published.
+   *
+   * @param string $slug
+   *   The page path.
+   * @return int
+   *   -1 if it's missing
+   *   0 if it's present but not published
+   *   1 if it's present and published
+   */
+  private static function pageExists($slug) {
+    $basePage = get_page_by_path($slug);
+    if (!$basePage) {
+      return -1;
     }
 
-    return $messages;
+    return (int) ($basePage->post_status == 'publish');
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
The WordPress base page is important for rendering content in WordPress, but someone might delete the page, or the configured path might be changed so that it doesn't match the page.

This adds a system check to make sure that the page configured on the WordPress Integration settings page exists.

Before
----------------------------------------
If you delete the page at `/civicrm`, or if you accidentally change the setting to something different without having a page there, you'll have problems and won't know why.

After
----------------------------------------
If there is no page with the slug specified by the WordPress Base Page setting, you get one of the following `ERROR`-level messages:

- Base page is the default, but no page has that slug:
  ![image](https://user-images.githubusercontent.com/1682375/85782024-4d194a80-b6f4-11ea-8f94-4b6087194fa1.png)

- Non-standard base page, but the default `/civicrm` exists:
  ![image](https://user-images.githubusercontent.com/1682375/85781709-f9a6fc80-b6f3-11ea-8503-29462e7ba46b.png)

- Non-standard base page, and the default `/civicrm` doesn't exist either:
  ![image](https://user-images.githubusercontent.com/1682375/85781874-2824d780-b6f4-11ea-93e9-1c5719823eaa.png)

If `is_multisite()` it will skip the whole check per comments below.

Technical Details
----------------------------------------
I added a new `CRM_Utils_Check_Component_Cms` that could potentially include other CMS-specific checks.
