### PR TITLE
Remove email field

### DIFF
--- a/templates/CRM/Event/Cart/Form/Checkout/Participant.tpl
+++ b/templates/CRM/Event/Cart/Form/Checkout/Participant.tpl
@@ -10,16 +10,7 @@
           <div class="profile-group">
           {include file="CRM/UF/Form/Block.tpl" fields=$custom.$pre form=$form.field.$participant_id}
           </div>
-
-    <div class="participant-info crm-section form-item">
-      <div class="label">
-              {$form.event.$event_id.participant.$participant_id.email.label}
-      </div>
-      <div class="edit-value content">
-              {$form.event.$event_id.participant.$participant_id.email.html}
-      </div>
-    </div>
-
+          
           {assign var=post value="event[`$event_id`][participant][`$participant_id`][customPost]"}
           <div style="clear:left"></div>
           <div class="profile-group">


### PR DESCRIPTION
This Event Cart template should allow Civi Profiles to handle the fields that are added, not inject an email field of its own.

https://lab.civicrm.org/dev/event/-/issues/2

Overview
----------------------------------------
Event Cart includes an extra field

Before
----------------------------------------
If you add a profile with an email field, two email addresses would appear on the registration page.
![image](https://user-images.githubusercontent.com/72763/85828503-bfa72a80-b7c7-11ea-990d-7d2c275e153b.png)

After
----------------------------------------
No duplicate field.
![image](https://user-images.githubusercontent.com/72763/85828471-aaca9700-b7c7-11ea-928a-d7124d87455d.png)


Technical Details
----------------------------------------
The email in registration seems to be handled by Profiles. Event Cart is quite an old part of CiviCRM, but I'm not clear why the extra email field was injected outside the profiles capability.

