### PR TITLE
Remove url-tracking in mass sms. dev/core#1843

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -1528,6 +1528,12 @@ ORDER BY   civicrm_email.is_bulkmail DESC
       \Civi::log('Parameter $ids is no longer used by Mailing::create. Use the api or just pass $params', ['civi.tag' => 'deprecated']);
     }
 
+    // CRM-#1843
+    // If it is a mass sms, set url_tracking to false
+    if (!empty($params['sms_provider_id'])) {
+      $params['url_tracking'] = 0;
+    }
+
     // CRM-12430
     // Do the below only for an insert
     // for an update, we should not set the defaults


### PR DESCRIPTION
Overview
----------------------------------------
If a mass sms is sent with a url in the message, when sending the sms a url-tracking is added. This affects the length of the sms and also, there are no sms tracking reports.

Issue: dev/core#1843