### PR TITLE
dev/wordpress#61 - Financial Account by Relationship lookup is incorrectly using label not name

### DIFF
--- a/CRM/Core/PseudoConstant.php
+++ b/CRM/Core/PseudoConstant.php
@@ -1376,19 +1376,21 @@ WHERE  id = %1
    * The static array option values is returned
    *
    *
-   * @param bool $optionGroupName
-   *   Get All Option Group values- default is to get only active ones.
+   * @param string $optionGroupName
+   *   Name of option group
    *
    * @param int $id
-   * @param null $condition
+   * @param string $condition
+   * @param string $column
+   *   Whether to return 'name' or 'label'
    *
    * @return array
-   *   array reference of all Option Group Name
+   *   array reference of all Option Values
    */
-  public static function accountOptionValues($optionGroupName, $id = NULL, $condition = NULL) {
-    $cacheKey = $optionGroupName . '_' . $condition;
+  public static function accountOptionValues($optionGroupName, $id = NULL, $condition = NULL, $column = 'label') {
+    $cacheKey = $optionGroupName . '_' . $condition . '_' . $column;
     if (empty(self::$accountOptionValues[$cacheKey])) {
-      self::$accountOptionValues[$cacheKey] = CRM_Core_OptionGroup::values($optionGroupName, FALSE, FALSE, FALSE, $condition);
+      self::$accountOptionValues[$cacheKey] = CRM_Core_OptionGroup::values($optionGroupName, FALSE, FALSE, FALSE, $condition, $column);
     }
     if ($id) {
       return self::$accountOptionValues[$cacheKey][$id] ?? NULL;

--- a/CRM/Financial/BAO/FinancialAccount.php
+++ b/CRM/Financial/BAO/FinancialAccount.php
@@ -216,6 +216,8 @@ WHERE cft.id = %1
    *
    * Note that we avoid the CRM_Core_PseudoConstant function as it stores one
    * account per financial type and is unreliable.
+   * @todo Not sure what the above comment means, and the function uses the
+   * PseudoConstant twice. Three times if you count the for loop.
    *
    * @param int $financialTypeID
    *
@@ -224,7 +226,12 @@ WHERE cft.id = %1
    * @return int
    */
   public static function getFinancialAccountForFinancialTypeByRelationship($financialTypeID, $relationshipType) {
-    $relationTypeId = key(CRM_Core_PseudoConstant::accountOptionValues('account_relationship', NULL, " AND v.name LIKE '{$relationshipType}' "));
+    // This is keyed on the `value` column from civicrm_option_value
+    $accountRelationshipsByValue = CRM_Core_PseudoConstant::accountOptionValues('account_relationship', NULL, NULL, 'name');
+    // We look up by the name a couple times below, so flip it.
+    $accountRelationships = array_flip($accountRelationshipsByValue);
+
+    $relationTypeId = $accountRelationships[$relationshipType] ?? NULL;
 
     if (!isset(Civi::$statics[__CLASS__]['entity_financial_account'][$financialTypeID][$relationTypeId])) {
       $accounts = civicrm_api3('EntityFinancialAccount', 'get', [
@@ -236,14 +243,12 @@ WHERE cft.id = %1
         Civi::$statics[__CLASS__]['entity_financial_account'][$financialTypeID][$account['account_relationship']] = $account['financial_account_id'];
       }
 
-      $accountRelationships = CRM_Core_PseudoConstant::accountOptionValues('account_relationship', NULL);
-
-      $incomeAccountRelationshipID = array_search('Income Account is', $accountRelationships);
+      $incomeAccountRelationshipID = $accountRelationships['Income Account is'] ?? FALSE;
       $incomeAccountFinancialAccountID = Civi::$statics[__CLASS__]['entity_financial_account'][$financialTypeID][$incomeAccountRelationshipID];
 
       foreach (['Chargeback Account is', 'Credit/Contra Revenue Account is'] as $optionalAccountRelationship) {
 
-        $accountRelationshipID = array_search($optionalAccountRelationship, $accountRelationships);
+        $accountRelationshipID = $accountRelationships[$optionalAccountRelationship] ?? FALSE;
         if (empty(Civi::$statics[__CLASS__]['entity_financial_account'][$financialTypeID][$accountRelationshipID])) {
           Civi::$statics[__CLASS__]['entity_financial_account'][$financialTypeID][$accountRelationshipID] = $incomeAccountFinancialAccountID;
         }

--- a/tests/phpunit/CRM/Financial/BAO/FinancialAccountTest.php
+++ b/tests/phpunit/CRM/Financial/BAO/FinancialAccountTest.php
@@ -163,6 +163,28 @@ class CRM_Financial_BAO_FinancialAccountTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test getting financial account for a given financial Type with a particular relationship with label changed.
+   */
+  public function testGetFinancialAccountByFinancialTypeAndRelationshipBuiltInLabel() {
+    // change the label
+    $optionValue = $this->callAPISuccess('OptionValue', 'get', [
+      'option_group_id' => 'account_relationship',
+      'name' => 'Income Account is',
+    ]);
+    $this->callAPISuccess('OptionValue', 'create', [
+      'id' => $optionValue['id'],
+      'label' => 'Changed label',
+    ]);
+    // run test
+    $this->assertEquals(2, CRM_Financial_BAO_FinancialAccount::getFinancialAccountForFinancialTypeByRelationship(2, 'Income Account is'));
+    // restore label
+    $this->callAPISuccess('OptionValue', 'create', [
+      'id' => $optionValue['id'],
+      'label' => 'Income Account is',
+    ]);
+  }
+
+  /**
    * Test getting financial account for a given financial Type with a particular relationship.
    */
   public function testGetFinancialAccountByFinancialTypeAndRelationshipBuiltInRefunded() {
@@ -170,10 +192,54 @@ class CRM_Financial_BAO_FinancialAccountTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test getting financial account for a given financial Type with a particular relationship with label changed.
+   */
+  public function testGetFinancialAccountByFinancialTypeAndRelationshipBuiltInRefundedLabel() {
+    // change the label
+    $optionValue = $this->callAPISuccess('OptionValue', 'get', [
+      'option_group_id' => 'account_relationship',
+      'name' => 'Credit/Contra Revenue Account is',
+    ]);
+    $this->callAPISuccess('OptionValue', 'create', [
+      'id' => $optionValue['id'],
+      'label' => 'Changed label',
+    ]);
+    // run test
+    $this->assertEquals(2, CRM_Financial_BAO_FinancialAccount::getFinancialAccountForFinancialTypeByRelationship(2, 'Credit/Contra Revenue Account is'));
+    // restore label
+    $this->callAPISuccess('OptionValue', 'create', [
+      'id' => $optionValue['id'],
+      'label' => 'Credit/Contra Revenue Account is',
+    ]);
+  }
+
+  /**
    * Test getting financial account for a given financial Type with a particular relationship.
    */
   public function testGetFinancialAccountByFinancialTypeAndRelationshipBuiltInChargeBack() {
     $this->assertEquals(2, CRM_Financial_BAO_FinancialAccount::getFinancialAccountForFinancialTypeByRelationship(2, 'Chargeback Account is'));
+  }
+
+  /**
+   * Test getting financial account for a given financial Type with a particular relationship with label changed.
+   */
+  public function testGetFinancialAccountByFinancialTypeAndRelationshipBuiltInChargeBackLabel() {
+    // change the label
+    $optionValue = $this->callAPISuccess('OptionValue', 'get', [
+      'option_group_id' => 'account_relationship',
+      'name' => 'Chargeback Account is',
+    ]);
+    $this->callAPISuccess('OptionValue', 'create', [
+      'id' => $optionValue['id'],
+      'label' => 'Changed label',
+    ]);
+    // run test
+    $this->assertEquals(2, CRM_Financial_BAO_FinancialAccount::getFinancialAccountForFinancialTypeByRelationship(2, 'Chargeback Account is'));
+    // restore label
+    $this->callAPISuccess('OptionValue', 'create', [
+      'id' => $optionValue['id'],
+      'label' => 'Chargeback Account is',
+    ]);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/wordpress/-/issues/61

It's not specific to wordpress - it's another example of name vs label. The easiest way to see the error is:

1. Turn off popups at Administer - Customize - Display Preferences (this isn't part of this problem it's just so that you can see notices/warnings since they get hidden by popups).
2. Go to Administer - System Settings - Option Groups.
3. Beside Account Relationship click Edit Options.
4. Change the label for Income Account is.
5. Go create a simple contribution of type donation.
6. `Notice: Undefined offset: 0 in CRM_Financial_BAO_FinancialAccount::getFinancialAccountForFinancialTypeByRelationship() (line 242 of /path/to/civicrm/CRM/Financial/BAO/FinancialAccount.php).`

So this also affects non-english installs since the labels are different.

And it's not just a notice, it can end up assigning the wrong account relationships.

Before
----------------------------------------
Notice. Incorrect account relationships assigned.

After
----------------------------------------
No notice. Correct accounts assigned.

Technical Details
----------------------------------------
I debated over what and how much to change. An alternate would be to remove any calls to the PseudoConstant from getFinancialAccountForFinancialTypeByRelationship and just call CRM_Core_OptionGroup::values. I'm willing to do that if people feel that's better.

Also there's some spots where maybe it should throw an exception instead of silent fail? If it can't find the `Income Account is` relationship for example, instead of assigning it as `FALSE` which ends up being treated as id 0. It's a builtin account and if somebody removes it that seems like it would cause problems elsewhere.

Comments
----------------------------------------
Has test.
