### PR TITLE
Fix currency symbol for Total Amount on contribution page

### DIFF
--- a/templates/CRM/Price/Form/Calculate.tpl
+++ b/templates/CRM/Price/Form/Calculate.tpl
@@ -157,7 +157,7 @@ function display(totalfee) {
   // totalfee is monetary, round it to 2 decimal points so it can
   // go as a float - CRM-13491
   totalfee = Math.round(totalfee*100)/100;
-  var totalFormattedFee = CRM.formatMoney(totalfee);
+  var totalFormattedFee = symbol + ' ' + CRM.formatMoney(totalfee, true);
   cj('#pricevalue').html(totalFormattedFee);
 
   cj('#total_amount').val( totalfee );


### PR DESCRIPTION
Overview
----------------------------------------
"Total Amount" shows default system currency symbol if contribution page is configured to use a different currency.

Setup a simple contribution page with a price set and a text amount/quantity field. Set the currency on the contribution page to something other than the CiviCRM default.

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/2052161/85927327-4b3ebb00-b89d-11ea-847b-976cbfe94ce9.png)


After
----------------------------------------
![image](https://user-images.githubusercontent.com/2052161/85927317-382beb00-b89d-11ea-878a-3f43e562e41b.png)


Technical Details
----------------------------------------
The correct currency symbol is assigned to the form but not used because the currency is formatted by `CRM.formatMoney`.
We change that to only return a number and append the currency symbol we already have. Note there is currently no way to pass the currency into CRM.formatMoney via javascript.

Comments
----------------------------------------
@eileenmcnaughton As you've started working on brick money as a formatter in CiviCRM this could probably be resolved in a better way. This fixes the immediate problem and indicates where a better formatter could be introduced. But that's probably something to work on after this is fixed.
@jitendrapurohit Can you review?
