### PR TITLE
APIv4 - Improve row_count to work with HAVING, GROUP BY, and SELECT

### DIFF
--- a/CRM/Api4/Page/AJAX.php
+++ b/CRM/Api4/Page/AJAX.php
@@ -129,6 +129,7 @@ class CRM_Api4_Page_AJAX extends CRM_Core_Page {
     foreach (get_class_vars(get_class($result)) as $key => $val) {
       $vals[$key] = $result->$key;
     }
+    unset($vals['rowCount']);
     $vals['count'] = $result->count();
     return $vals;
   }

--- a/Civi/Api4/Action/Domain/Get.php
+++ b/Civi/Api4/Action/Domain/Get.php
@@ -19,6 +19,8 @@
 
 namespace Civi\Api4\Action\Domain;
 
+use Civi\Api4\Generic\Result;
+
 /**
  * @inheritDoc
  */
@@ -34,11 +36,11 @@ class Get extends \Civi\Api4\Generic\DAOGetAction {
   /**
    * @inheritDoc
    */
-  protected function getObjects() {
+  protected function getObjects(Result $result) {
     if ($this->currentDomain) {
       $this->addWhere('id', '=', \CRM_Core_Config::domainID());
     }
-    return parent::getObjects();
+    parent::getObjects($result);
   }
 
 }

--- a/Civi/Api4/Generic/BasicGetAction.php
+++ b/Civi/Api4/Generic/BasicGetAction.php
@@ -59,7 +59,7 @@ class BasicGetAction extends AbstractGetAction {
     $this->expandSelectClauseWildcards();
     $values = $this->getRecords();
     $this->formatRawValues($values);
-    $result->exchangeArray($this->queryArray($values));
+    $this->queryArray($values, $result);
   }
 
   /**

--- a/Civi/Api4/Generic/BasicGetFieldsAction.php
+++ b/Civi/Api4/Generic/BasicGetFieldsAction.php
@@ -97,7 +97,7 @@ class BasicGetFieldsAction extends BasicGetAction {
       $values = $this->getRecords();
     }
     $this->formatResults($values);
-    $result->exchangeArray($this->queryArray($values));
+    $this->queryArray($values, $result);
   }
 
   /**

--- a/Civi/Api4/Generic/Result.php
+++ b/Civi/Api4/Generic/Result.php
@@ -40,6 +40,10 @@ class Result extends \ArrayObject implements \JsonSerializable {
    * @var int
    */
   public $version = 4;
+  /**
+   * @var int
+   */
+  public $rowCount;
 
   private $indexedBy;
 
@@ -107,11 +111,7 @@ class Result extends \ArrayObject implements \JsonSerializable {
    * @return int
    */
   public function count() {
-    $count = parent::count();
-    if ($count == 1 && is_array($this->first()) && array_keys($this->first()) == ['row_count']) {
-      return $this->first()['row_count'];
-    }
-    return $count;
+    return $this->rowCount ?? parent::count();
   }
 
   /**

--- a/Civi/Api4/Generic/Traits/ArrayQueryActionTrait.php
+++ b/Civi/Api4/Generic/Traits/ArrayQueryActionTrait.php
@@ -32,16 +32,18 @@ trait ArrayQueryActionTrait {
 
   /**
    * @param array $values
-   *   List of all rows
-   * @return array
-   *   Filtered list of rows
+   *   List of all rows to be filtered
+   * @param \Civi\Api4\Generic\Result $result
+   *   Object to store result
    */
-  protected function queryArray($values) {
+  protected function queryArray($values, $result) {
     $values = $this->filterArray($values);
     $values = $this->sortArray($values);
+    // Set total count before applying limit
+    $result->rowCount = count($values);
     $values = $this->limitArray($values);
     $values = $this->selectArray($values);
-    return $values;
+    $result->exchangeArray($values);
   }
 
   /**

--- a/Civi/Api4/Query/Api4SelectQuery.php
+++ b/Civi/Api4/Query/Api4SelectQuery.php
@@ -11,7 +11,6 @@
 
 namespace Civi\Api4\Query;
 
-use Civi\API\SelectQuery;
 use Civi\Api4\Service\Schema\Joinable\CustomGroupJoinable;
 use Civi\Api4\Utils\FormattingUtil;
 use Civi\Api4\Utils\CoreUtil;
@@ -30,12 +29,40 @@ use Civi\Api4\Utils\SelectUtil;
  * * "NOT LIKE", 'IN', 'NOT IN', 'BETWEEN', 'NOT BETWEEN',
  * * 'IS NOT NULL', or 'IS NULL'.
  */
-class Api4SelectQuery extends SelectQuery {
+class Api4SelectQuery {
+
+  const
+    MAIN_TABLE_ALIAS = 'a';
 
   /**
-   * @var int
+   * @var \CRM_Utils_SQL_Select
    */
-  protected $apiVersion = 4;
+  protected $query;
+
+  /**
+   * @var array
+   */
+  protected $joins = [];
+
+  /**
+   * @var array[]
+   */
+  protected $apiFieldSpec;
+
+  /**
+   * @var array
+   */
+  protected $entityFieldNames = [];
+
+  /**
+   * @var array
+   */
+  protected $aclFields = [];
+
+  /**
+   * @var \Civi\Api4\Generic\DAOGetAction
+   */
+  private $api;
 
   /**
    * @var array
@@ -44,56 +71,28 @@ class Api4SelectQuery extends SelectQuery {
   protected $selectAliases = [];
 
   /**
-   * If set to an array, this will start collecting debug info.
-   *
-   * @var null|array
+   * @var bool
    */
-  public $debugOutput = NULL;
-
-  /**
-   * @var array
-   */
-  public $groupBy = [];
-
   public $forceSelectId = TRUE;
-
-  /**
-   * @var array
-   */
-  public $having = [];
 
   /**
    * @param \Civi\Api4\Generic\DAOGetAction $apiGet
    */
   public function __construct($apiGet) {
-    $this->entity = $apiGet->getEntityName();
-    $this->checkPermissions = $apiGet->getCheckPermissions();
-    $this->select = $apiGet->getSelect();
-    $this->where = $apiGet->getWhere();
-    $this->groupBy = $apiGet->getGroupBy();
-    $this->orderBy = $apiGet->getOrderBy();
-    $this->limit = $apiGet->getLimit();
-    $this->offset = $apiGet->getOffset();
-    $this->having = $apiGet->getHaving();
-    // Always select ID of main table unless grouping is used
-    $this->forceSelectId = !$this->groupBy;
-    if ($apiGet->getDebug()) {
-      $this->debugOutput =& $apiGet->_debugOutput;
-    }
+    $this->api = $apiGet;
+    // Always select ID of main table unless grouping by something else
+    $this->forceSelectId = !$apiGet->getGroupBy() || $apiGet->getGroupBy() === ['id'];
     foreach ($apiGet->entityFields() as $field) {
       $this->entityFieldNames[] = $field['name'];
       $field['sql_name'] = '`' . self::MAIN_TABLE_ALIAS . '`.`' . $field['column_name'] . '`';
       $this->addSpecField($field['name'], $field);
     }
 
-    $baoName = CoreUtil::getBAOFromApiName($this->entity);
+    $baoName = CoreUtil::getBAOFromApiName($this->getEntity());
     $this->constructQueryObject();
 
     // Add ACLs first to avoid redundant subclauses
     $this->query->where($this->getAclClause(self::MAIN_TABLE_ALIAS, $baoName));
-
-    // Add explicit joins. Other joins implied by dot notation may be added later
-    $this->addExplicitJoins($apiGet->getJoin());
   }
 
   /**
@@ -105,6 +104,8 @@ class Api4SelectQuery extends SelectQuery {
    * @throws \Civi\API\Exception\UnauthorizedException
    */
   public function getSql() {
+    // Add explicit joins. Other joins implied by dot notation may be added later
+    $this->addExplicitJoins();
     $this->buildSelectClause();
     $this->buildWhereClause();
     $this->buildOrderBy();
@@ -122,12 +123,10 @@ class Api4SelectQuery extends SelectQuery {
   public function run() {
     $results = [];
     $sql = $this->getSql();
-    if (is_array($this->debugOutput)) {
-      $this->debugOutput['sql'][] = $sql;
-    }
+    $this->debug('sql', $sql);
     $query = \CRM_Core_DAO::executeQuery($sql);
     while ($query->fetch()) {
-      if (in_array('row_count', $this->select)) {
+      if (in_array('row_count', $this->getSelect())) {
         $results[]['row_count'] = (int) $query->c;
         break;
       }
@@ -139,47 +138,49 @@ class Api4SelectQuery extends SelectQuery {
       }
       $results[] = $result;
     }
-    FormattingUtil::formatOutputValues($results, $this->getApiFieldSpec(), $this->getEntity());
+    FormattingUtil::formatOutputValues($results, $this->apiFieldSpec, $this->getEntity());
     return $results;
   }
 
+  /**
+   * @throws \API_Exception
+   */
   protected function buildSelectClause() {
+    $select = $this->getSelect();
     // An empty select is the same as *
-    if (empty($this->select)) {
-      $this->select = $this->entityFieldNames;
+    if (empty($select)) {
+      $select = $this->entityFieldNames;
     }
-    elseif (in_array('row_count', $this->select)) {
+    elseif (in_array('row_count', $select)) {
       $this->query->select("COUNT(*) AS `c`");
       return;
     }
     else {
       if ($this->forceSelectId) {
-        $this->select = array_merge(['id'], $this->select);
+        $select = array_merge(['id'], $select);
       }
 
       // Expand wildcards in joins (the api wrapper already expanded non-joined wildcards)
-      $wildFields = array_filter($this->select, function($item) {
+      $wildFields = array_filter($select, function($item) {
         return strpos($item, '*') !== FALSE && strpos($item, '.') !== FALSE && strpos($item, '(') === FALSE && strpos($item, ' ') === FALSE;
       });
       foreach ($wildFields as $item) {
-        $pos = array_search($item, array_values($this->select));
+        $pos = array_search($item, array_values($select));
         $this->autoJoinFK($item);
         $matches = SelectUtil::getMatchingFields($item, array_keys($this->apiFieldSpec));
-        array_splice($this->select, $pos, 1, $matches);
+        array_splice($select, $pos, 1, $matches);
       }
-      $this->select = array_unique($this->select);
+      $select = array_unique($select);
     }
-    foreach ($this->select as $item) {
+    foreach ($select as $item) {
       $expr = SqlExpression::convert($item, TRUE);
       $valid = TRUE;
       foreach ($expr->getFields() as $fieldName) {
         $field = $this->getField($fieldName);
         // Remove expressions with unknown fields without raising an error
         if (!$field) {
-          $this->select = array_diff($this->select, [$item]);
-          if (is_array($this->debugOutput)) {
-            $this->debugOutput['undefined_fields'][] = $fieldName;
-          }
+          $select = array_diff($select, [$item]);
+          $this->debug('undefined_fields', $fieldName);
           $valid = FALSE;
         }
       }
@@ -195,10 +196,10 @@ class Api4SelectQuery extends SelectQuery {
   }
 
   /**
-   * @inheritDoc
+   * Add WHERE clause to query
    */
   protected function buildWhereClause() {
-    foreach ($this->where as $clause) {
+    foreach ($this->getWhere() as $clause) {
       $sql = $this->treeWalkClauses($clause, 'WHERE');
       if ($sql) {
         $this->query->where($sql);
@@ -207,21 +208,21 @@ class Api4SelectQuery extends SelectQuery {
   }
 
   /**
-   * Build HAVING clause.
+   * Add HAVING clause to query
    *
    * Every expression referenced must also be in the SELECT clause.
    */
   protected function buildHavingClause() {
-    foreach ($this->having as $clause) {
+    foreach ($this->getHaving() as $clause) {
       $this->query->having($this->treeWalkClauses($clause, 'HAVING'));
     }
   }
 
   /**
-   * @inheritDoc
+   * Add ORDER BY to query
    */
   protected function buildOrderBy() {
-    foreach ($this->orderBy as $item => $dir) {
+    foreach ($this->getOrderBy() as $item => $dir) {
       if ($dir !== 'ASC' && $dir !== 'DESC') {
         throw new \API_Exception("Invalid sort direction. Cannot order by $item $dir");
       }
@@ -243,20 +244,22 @@ class Api4SelectQuery extends SelectQuery {
   }
 
   /**
+   * Add LIMIT to query
+   *
    * @throws \CRM_Core_Exception
    */
   protected function buildLimit() {
-    if (!empty($this->limit) || !empty($this->offset)) {
+    if ($this->getLimit() || $this->getOffset()) {
       // If limit is 0, mysql will actually return 0 results. Instead set to maximum possible.
-      $this->query->limit($this->limit ?: '18446744073709551615', $this->offset);
+      $this->query->limit($this->getLimit() ?: '18446744073709551615', $this->getOffset());
     }
   }
 
   /**
-   * Adds GROUP BY clause to query
+   * Add GROUP BY clause to query
    */
   protected function buildGroupBy() {
-    foreach ($this->groupBy as $item) {
+    foreach ($this->getGroupBy() as $item) {
       $this->query->groupBy($this->getExpression($item)->render($this->apiFieldSpec));
     }
   }
@@ -395,10 +398,29 @@ class Api4SelectQuery extends SelectQuery {
   }
 
   /**
-   * @inheritDoc
+   * Get acl clause for an entity
+   *
+   * @param string $tableAlias
+   * @param \CRM_Core_DAO|string $baoName
+   * @param array $stack
+   * @return array
    */
-  protected function getFields() {
-    return $this->apiFieldSpec;
+  public function getAclClause($tableAlias, $baoName, $stack = []) {
+    if (!$this->getCheckPermissions()) {
+      return [];
+    }
+    // Prevent (most) redundant acl sub clauses if they have already been applied to the main entity.
+    // FIXME: Currently this only works 1 level deep, but tracking through multiple joins would increase complexity
+    // and just doing it for the first join takes care of most acl clause deduping.
+    if (count($stack) === 1 && in_array($stack[0], $this->aclFields)) {
+      return [];
+    }
+    $clauses = $baoName::getSelectWhereClause($tableAlias);
+    if (!$stack) {
+      // Track field clauses added to the main entity
+      $this->aclFields = array_keys($clauses);
+    }
+    return array_filter($clauses);
   }
 
   /**
@@ -408,7 +430,7 @@ class Api4SelectQuery extends SelectQuery {
    * @param bool $strict
    *   In strict mode, this will throw an exception if the field doesn't exist
    *
-   * @return string|null
+   * @return array|null
    * @throws \API_Exception
    */
   public function getField($expr, $strict = FALSE) {
@@ -431,12 +453,11 @@ class Api4SelectQuery extends SelectQuery {
   /**
    * Join onto other entities as specified by the api call.
    *
-   * @param $joins
    * @throws \API_Exception
    * @throws \Civi\API\Exception\NotImplementedException
    */
-  private function addExplicitJoins($joins) {
-    foreach ($joins as $join) {
+  private function addExplicitJoins() {
+    foreach ($this->getJoin() as $join) {
       // First item in the array is the entity name
       $entity = array_shift($join);
       // Which might contain an alias. Split on the keyword "AS"
@@ -446,10 +467,9 @@ class Api4SelectQuery extends SelectQuery {
       // First item in the array is a boolean indicating if the join is required (aka INNER or LEFT).
       // The rest are join conditions.
       $side = array_shift($join) ? 'INNER' : 'LEFT';
-      $joinEntityGet = \Civi\API\Request::create($entity, 'get', ['version' => 4, 'checkPermissions' => $this->checkPermissions]);
+      $joinEntityGet = \Civi\API\Request::create($entity, 'get', ['version' => 4, 'checkPermissions' => $this->getCheckPermissions()]);
       foreach ($joinEntityGet->entityFields() as $field) {
         $field['sql_name'] = '`' . $alias . '`.`' . $field['column_name'] . '`';
-        $field['is_join'] = TRUE;
         $this->addSpecField($alias . '.' . $field['name'], $field);
       }
       $conditions = $this->getJoinConditions($entity, $alias);
@@ -478,7 +498,7 @@ class Api4SelectQuery extends SelectQuery {
       if ($field['entity'] !== $entity && $field['fk_entity'] === $entity) {
         $conditions[] = $this->treeWalkClauses([$name, '=', "$alias.id"], 'ON');
       }
-      elseif (strpos($name, "$alias.") === 0 && substr_count($name, '.') === 1 &&  $field['fk_entity'] === $this->entity) {
+      elseif (strpos($name, "$alias.") === 0 && substr_count($name, '.') === 1 &&  $field['fk_entity'] === $this->getEntity()) {
         $conditions[] = $this->treeWalkClauses([$name, '=', 'id'], 'ON');
         $stack = ['id'];
       }
@@ -531,9 +551,21 @@ class Api4SelectQuery extends SelectQuery {
     foreach ($lastLink->getEntityFields() as $fieldObject) {
       $fieldArray = $fieldObject->toArray();
       $fieldArray['sql_name'] = '`' . $lastLink->getAlias() . '`.`' . $fieldArray['column_name'] . '`';
-      $fieldArray['is_custom'] = $isCustom;
-      $fieldArray['is_join'] = TRUE;
       $this->addSpecField($prefix . $fieldArray['name'], $fieldArray);
+    }
+  }
+
+  /**
+   * @param string $side
+   * @param string $tableName
+   * @param string $tableAlias
+   * @param array $conditions
+   */
+  public function join($side, $tableName, $tableAlias, $conditions) {
+    // INNER JOINs take precedence over LEFT JOINs
+    if ($side != 'LEFT' || !isset($this->joins[$tableAlias])) {
+      $this->joins[$tableAlias] = $side;
+      $this->query->join($tableAlias, "$side JOIN `$tableName` `$tableAlias` ON " . implode(' AND ', $conditions));
     }
   }
 
@@ -541,56 +573,70 @@ class Api4SelectQuery extends SelectQuery {
    * @return FALSE|string
    */
   public function getFrom() {
-    return CoreUtil::getTableName($this->entity);
+    return CoreUtil::getTableName($this->getEntity());
   }
 
   /**
    * @return string
    */
   public function getEntity() {
-    return $this->entity;
+    return $this->api->getEntityName();
   }
 
   /**
    * @return array
    */
   public function getSelect() {
-    return $this->select;
+    return $this->api->getSelect();
   }
 
   /**
    * @return array
    */
   public function getWhere() {
-    return $this->where;
+    return $this->api->getWhere();
+  }
+
+  /**
+   * @return array
+   */
+  public function getHaving() {
+    return $this->api->getHaving();
+  }
+
+  /**
+   * @return array
+   */
+  public function getJoin() {
+    return $this->api->getJoin();
+  }
+
+  /**
+   * @return array
+   */
+  public function getGroupBy() {
+    return $this->api->getGroupBy();
   }
 
   /**
    * @return array
    */
   public function getOrderBy() {
-    return $this->orderBy;
+    return $this->api->getOrderBy();
   }
 
   /**
    * @return mixed
    */
   public function getLimit() {
-    return $this->limit;
+    return $this->api->getLimit();
   }
 
   /**
    * @return mixed
    */
   public function getOffset() {
-    return $this->offset;
-  }
-
-  /**
-   * @return array
-   */
-  public function getSelectFields() {
-    return $this->selectFields;
+    return $this->api->getOffset();
   }
 
   /**
@@ -601,45 +647,10 @@ class Api4SelectQuery extends SelectQuery {
   }
 
   /**
-   * @return array
-   */
-  public function getJoins() {
-    return $this->joins;
-  }
-
-  /**
-   * @return array
-   */
-  public function getApiFieldSpec() {
-    return $this->apiFieldSpec;
-  }
-
-  /**
-   * @return array
-   */
-  public function getEntityFieldNames() {
-    return $this->entityFieldNames;
-  }
-
-  /**
-   * @return array
-   */
-  public function getAclFields() {
-    return $this->aclFields;
-  }
-
-  /**
    * @return bool|string
    */
   public function getCheckPermissions() {
-    return $this->checkPermissions;
-  }
-
-  /**
-   * @return int
-   */
-  public function getApiVersion() {
-    return $this->apiVersion;
+    return $this->api->getCheckPermissions();
   }
 
   /**
@@ -648,24 +659,33 @@ class Api4SelectQuery extends SelectQuery {
    * @return void
    */
   public function constructQueryObject() {
-    $tableName = CoreUtil::getTableName($this->entity);
+    $tableName = CoreUtil::getTableName($this->getEntity());
     $this->query = \CRM_Utils_SQL_Select::from($tableName . ' ' . self::MAIN_TABLE_ALIAS);
   }
 
   /**
-   * @param $path
-   * @param $field
+   * @param string $path
+   * @param array $field
    */
   private function addSpecField($path, $field) {
     // Only add field to spec if we have permission
-    if ($this->checkPermissions && !empty($field['permission']) && !\CRM_Core_Permission::check($field['permission'])) {
+    if ($this->getCheckPermissions() && !empty($field['permission']) && !\CRM_Core_Permission::check($field['permission'])) {
       $this->apiFieldSpec[$path] = FALSE;
       return;
     }
-    $defaults = [];
-    $defaults['is_custom'] = $defaults['is_join'] = FALSE;
-    $field += $defaults;
     $this->apiFieldSpec[$path] = $field;
+  }
+
+  /**
+   * Add something to the api's debug output if debugging is enabled
+   *
+   * @param $key
+   * @param $item
+   */
+  public function debug($key, $item) {
+    if ($this->api->getDebug()) {
+      $this->api->_debugOutput[$key][] = $item;
+    }
   }
 
 }

--- a/ang/api4Explorer/Explorer.html
+++ b/ang/api4Explorer/Explorer.html
@@ -50,10 +50,10 @@
             </label>
             <a href class="crm-hover-button" title="Clear" ng-click="clearParam(name)" ng-show="params[name] !== null"><i class="crm-i fa-times" aria-hidden="true"></i></a>
           </div>
-          <fieldset class="api4-input form-inline" ng-mouseenter="help('select', availableParams.select)" ng-mouseleave="help()" ng-if="availableParams.select && !isSelectRowCount()">
+          <fieldset class="api4-input form-inline" ng-mouseenter="help('select', availableParams.select)" ng-mouseleave="help()" ng-if="availableParams.select">
             <legend>select<span class="crm-marker" ng-if="::availableParams.select.required"> *</span></legend>
             <div ng-model="params.select" ui-sortable="{axis: 'y'}">
-              <div class="api4-input form-inline" ng-repeat="item in params.select track by $index">
+              <div class="api4-input form-inline" ng-repeat="item in params.select track by $index" ng-show="item !== 'row_count'">
                 <i class="crm-i fa-arrows" aria-hidden="true"></i>
                 <input class="form-control huge" type="text" ng-model="params.select[$index]" />
                 <a href class="crm-hover-button" title="Clear" ng-click="clearParam('select', $index)"><i class="crm-i fa-times" aria-hidden="true"></i></a>

--- a/tests/phpunit/api/v4/Action/BasicActionsTest.php
+++ b/tests/phpunit/api/v4/Action/BasicActionsTest.php
@@ -45,7 +45,9 @@ class BasicActionsTest extends UnitTestCase {
     MockBasicEntity::update()->addWhere('id', '=', $id2)->addValue('foo', 'new')->execute();
 
     $result = MockBasicEntity::get()->addOrderBy('id', 'DESC')->setLimit(1)->execute();
-    $this->assertCount(1, $result);
+    // The object's count() method will account for all results, ignoring limit, while the array results are limited
+    $this->assertCount(2, $result);
+    $this->assertCount(1, (array) $result);
     $this->assertEquals('new', $result->first()['foo']);
 
     $result = MockBasicEntity::save()

--- a/tests/phpunit/api/v4/Action/ComplexQueryTest.php
+++ b/tests/phpunit/api/v4/Action/ComplexQueryTest.php
@@ -23,6 +23,7 @@ namespace api\v4\Action;
 
 use api\v4\UnitTestCase;
 use Civi\Api4\Activity;
+use Civi\Api4\Contact;
 
 /**
  * @group headless
@@ -57,9 +58,27 @@ class ComplexQueryTest extends UnitTestCase {
   }
 
   /**
-   * Fetch all activities with a blue tag; and return all tags on the activities
+   *
    */
-  public function testGetAllTagsForBlueTaggedActivities() {
+  public function testGetWithCount() {
+    $myName = uniqid('count');
+    for ($i = 1; $i <= 20; ++$i) {
+      Contact::create()
+        ->addValue('first_name', "Contact $i")
+        ->addValue('last_name', $myName)
+        ->setCheckPermissions(FALSE)->execute();
+    }
+
+    $get1 = Contact::get()
+      ->addWhere('last_name', '=', $myName)
+      ->selectRowCount()
+      ->addSelect('first_name')
+      ->setLimit(10)
+      ->setDebug(TRUE)
+      ->setCheckPermissions(FALSE)->execute();
+
+    $this->assertEquals(20, $get1->count());
+    $this->assertCount(10, (array) $get1);
 
   }
 

--- a/tests/phpunit/api/v4/Action/ContactGetTest.php
+++ b/tests/phpunit/api/v4/Action/ContactGetTest.php
@@ -74,9 +74,22 @@ class ContactGetTest extends \api\v4\UnitTestCase {
       ->execute()->first();
 
     $num = Contact::get()->setCheckPermissions(FALSE)->selectRowCount()->execute()->count();
-    $this->assertCount($num - 1, Contact::get()->setCheckPermissions(FALSE)->setLimit(0)->setOffset(1)->execute());
-    $this->assertCount($num - 2, Contact::get()->setCheckPermissions(FALSE)->setLimit(0)->setOffset(2)->execute());
-    $this->assertCount(2, Contact::get()->setCheckPermissions(FALSE)->setLimit(2)->setOffset(0)->execute());
+
+    // The object's count() method will account for all results, ignoring limit & offset, while the array results are limited
+    $offset1 = Contact::get()->setCheckPermissions(FALSE)->setOffset(1)->execute();
+    $this->assertCount($num, $offset1);
+    $this->assertCount($num - 1, (array) $offset1);
+    $offset2 = Contact::get()->setCheckPermissions(FALSE)->setOffset(2)->execute();
+    $this->assertCount($num - 2, (array) $offset2);
+    $this->assertCount($num, $offset2);
+    // With limit, it doesn't fetch total count by default
+    $limit2 = Contact::get()->setCheckPermissions(FALSE)->setLimit(2)->execute();
+    $this->assertCount(2, (array) $limit2);
+    $this->assertCount(2, $limit2);
+    // With limit, you have to trigger the full row count manually
+    $limit2 = Contact::get()->setCheckPermissions(FALSE)->setLimit(2)->addSelect('sort_name', 'row_count')->execute();
+    $this->assertCount(2, (array) $limit2);
+    $this->assertCount($num, $limit2);
   }
 
 }

--- a/tests/phpunit/api/v4/Action/GetFromArrayTest.php
+++ b/tests/phpunit/api/v4/Action/GetFromArrayTest.php
@@ -36,7 +36,10 @@ class GetFromArrayTest extends UnitTestCase {
       ->execute();
     $this->assertEquals(3, $result[0]['field1']);
     $this->assertEquals(4, $result[1]['field1']);
-    $this->assertEquals(2, count($result));
+
+    // The object's count() method will account for all results, ignoring limit, while the array results are limited
+    $this->assertCount(2, (array) $result);
+    $this->assertCount(5, $result);
   }
 
   public function testArrayGetWithSort() {

--- a/tests/phpunit/api/v4/Query/Api4SelectQueryTest.php
+++ b/tests/phpunit/api/v4/Query/Api4SelectQueryTest.php
@@ -52,13 +52,13 @@ class Api4SelectQueryTest extends UnitTestCase {
     $phoneNum = $this->getReference('test_phone_1')['phone'];
     $contact = $this->getReference('test_contact_1');
 
-    $api = \Civi\API\Request::create('Phone', 'get', ['version' => 4, 'checkPermissions' => FALSE]);
+    $api = \Civi\API\Request::create('Phone', 'get', [
+      'version' => 4,
+      'checkPermissions' => FALSE,
+      'select' => ['id', 'phone', 'contact.display_name', 'contact.first_name'],
+      'where' => [['phone', '=', $phoneNum]],
+    ]);
     $query = new Api4SelectQuery($api);
-    $query->select[] = 'id';
-    $query->select[] = 'phone';
-    $query->select[] = 'contact.display_name';
-    $query->select[] = 'contact.first_name';
-    $query->where[] = ['phone', '=', $phoneNum];
     $results = $query->run();
 
     $this->assertCount(1, $results);
@@ -67,20 +67,28 @@ class Api4SelectQueryTest extends UnitTestCase {
   }
 
   public function testInvaidSort() {
-    $api = \Civi\API\Request::create('Contact', 'get', ['version' => 4, 'checkPermissions' => FALSE]);
+    $api = \Civi\API\Request::create('Contact', 'get', [
+      'version' => 4,
+      'checkPermissions' => FALSE,
+      'select' => ['id', 'display_name'],
+      'where' => [['first_name', '=', 'phoney']],
+      'orderBy' => ['first_name' => 'sleep(1)'],
+    ]);
     $query = new Api4SelectQuery($api);
-    $query->select[] = 'id';
-    $query->select[] = 'first_name';
-    $query->select[] = 'phones.phone';
-    $query->where[] = ['first_name', '=', 'Phoney'];
-    $query->orderBy = ['first_name' => 'sleep(1)'];
     try {
       $results = $query->run();
       $this->fail('An Exception Should have been raised');
     }
     catch (\API_Exception $e) {
     }
-    $query->orderBy = ['sleep(1)', 'ASC'];
+    $api = \Civi\API\Request::create('Contact', 'get', [
+      'version' => 4,
+      'checkPermissions' => FALSE,
+      'select' => ['id', 'display_name'],
+      'where' => [['first_name', '=', 'phoney']],
+      'orderBy' => ['sleep(1)' => 'ASC'],
+    ]);
+    $query = new Api4SelectQuery($api);
     try {
       $results = $query->run();
       $this->fail('An Exception Should have been raised');

--- a/tests/phpunit/api/v4/Query/OptionValueJoinTest.php
+++ b/tests/phpunit/api/v4/Query/OptionValueJoinTest.php
@@ -48,11 +48,13 @@ class OptionValueJoinTest extends UnitTestCase {
   }
 
   public function testCommunicationMethodJoin() {
-    $api = \Civi\API\Request::create('Contact', 'get', ['version' => 4, 'checkPermissions' => FALSE]);
+    $api = \Civi\API\Request::create('Contact', 'get', [
+      'version' => 4,
+      'checkPermissions' => FALSE,
+      'select' => ['first_name', 'preferred_communication_method:label'],
+      'where' => [['preferred_communication_method', 'IS NOT NULL']],
+    ]);
     $query = new Api4SelectQuery($api);
-    $query->select[] = 'first_name';
-    $query->select[] = 'preferred_communication_method:label';
-    $query->where[] = ['preferred_communication_method', 'IS NOT NULL'];
     $results = $query->run();
     $first = array_shift($results);
     $keys = array_keys($first);


### PR DESCRIPTION
Overview
----------------------------------------
This changes the meaning of $result->count(), to give a total count of filtered items, ignoring limit and offset.
This allows APIv4 `get` to fetch both a single page of results (using limit) **and** the total number for the pager to display.
The new Search Builder UI can take advantage of this.
Also fixes APIv4 count() to work with GROUP BY and HAVING clauses, using a subquery.

Before
----------------------------------------
`$result->count()` would always be a simple count of the results array.

After
----------------------------------------
`$result->count()` gives a total number of filtered results **before** OFFSET or LIMIT are applied.
For DAO queries, you must select 'row_count' to trigger this behavior, as it requires a separate query.
