### PR TITLE
dev/core#1137 - Allow ssl connection to mysql by specifying in DSN

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -163,6 +163,11 @@ class CRM_Core_DAO extends DB_DataObject {
     $options = &PEAR::getStaticProperty('DB_DataObject', 'options');
     $options['database'] = $dsn;
     $options['quote_identifiers'] = TRUE;
+    if (self::isSSLDSN($dsn)) {
+      // There are two different options arrays.
+      $other_options = &PEAR::getStaticProperty('DB', 'options');
+      $other_options['ssl'] = TRUE;
+    }
     if (defined('CIVICRM_DAO_DEBUG')) {
       self::DebugLevel(CIVICRM_DAO_DEBUG);
     }
@@ -3066,6 +3071,23 @@ SELECT contact_id
     if (isset($this->name)) {
       unset(self::$_dbColumnValueCache[$daoName]['name'][$this->name]);
     }
+  }
+
+  /**
+   * Does the DSN indicate the connection should use ssl.
+   *
+   * @param string $dsn
+   *
+   * @return bool
+   */
+  public static function isSSLDSN(string $dsn):bool {
+    // Note that ssl= below is not an official PEAR::DB option. It doesn't know
+    // what to do with it. We made it up because it's not required
+    // to have client-side certificates to use ssl, so here you can specify
+    // you want that by putting ssl=1 in the DSN string.
+    //
+    // Cast to bool in case of error which we interpret as no ssl.
+    return (bool) preg_match('/[\?&](key|cert|ca|capath|cipher|ssl)=/', $dsn);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Alternate to https://github.com/civicrm/civicrm-core/pull/17694.

**** **This requires https://github.com/civicrm/civicrm-packages/pull/298 to fully work.** ****

 There may also be another spot or two as noted in the other PR like CRM_Utils_File, but this is the minimum to get you into the civi dashboard and up and running.

https://lab.civicrm.org/dev/core/-/issues/1137

How to use/test is at https://lab.civicrm.org/dev/core/-/issues/1137#note_39424

Before
----------------------------------------
Can't use ssl to connect to mysql

After
----------------------------------------
Can use ssl to connect to mysql

Technical Details
----------------------------------------
You don't want to know.

Comments
----------------------------------------
I don't think it would be possible to write a test for this unless the database server was started with SSL enabled and configured.
