### PR TITLE
dev/core#1768 - Add CiviMail synchronisation frequency setting.

### DIFF
--- a/CRM/Admin/Form/Setting/Mail.php
+++ b/CRM/Admin/Form/Setting/Mail.php
@@ -57,8 +57,9 @@ class CRM_Admin_Form_Setting_Mail extends CRM_Admin_Form_Setting {
         $errors['mailerJobSize'] = ts('A job size smaller than the batch limit will negate the effect of the batch limit.');
       }
     }
+    // dev/core#1768 Check the civimail_sync_interval setting.
     if (CRM_Utils_Array::value('civimail_sync_interval', $fields) < 1) {
-       $errors['civimail_sync_interval'] = ts('Error - the synchronization interval must be at least 1');
+      $errors['civimail_sync_interval'] = ts('Error - the synchronization interval must be at least 1');
     }
     return empty($errors) ? TRUE : $errors;
   }

--- a/CRM/Admin/Form/Setting/Mail.php
+++ b/CRM/Admin/Form/Setting/Mail.php
@@ -26,6 +26,8 @@ class CRM_Admin_Form_Setting_Mail extends CRM_Admin_Form_Setting {
     'mailerJobSize' => CRM_Core_BAO_Setting::MAILING_PREFERENCES_NAME,
     'mailerJobsMax' => CRM_Core_BAO_Setting::MAILING_PREFERENCES_NAME,
     'verpSeparator' => CRM_Core_BAO_Setting::MAILING_PREFERENCES_NAME,
+    // dev/core#1768 Make this interval configurable.
+    'civimail_sync_interval' => CRM_Core_BAO_Setting::MAILING_PREFERENCES_NAME,
     'replyTo' => CRM_Core_BAO_Setting::MAILING_PREFERENCES_NAME,
   ];
 
@@ -35,7 +37,6 @@ class CRM_Admin_Form_Setting_Mail extends CRM_Admin_Form_Setting {
   public function buildQuickForm() {
     CRM_Utils_System::setTitle(ts('Settings - CiviMail'));
     $this->addFormRule(['CRM_Admin_Form_Setting_Mail', 'formRule']);
-
     parent::buildQuickForm();
   }
 
@@ -46,7 +47,6 @@ class CRM_Admin_Form_Setting_Mail extends CRM_Admin_Form_Setting {
    */
   public static function formRule($fields) {
     $errors = [];
-
     if (CRM_Utils_Array::value('mailerJobSize', $fields) > 0) {
       if (CRM_Utils_Array::value('mailerJobSize', $fields) < 1000) {
         $errors['mailerJobSize'] = ts('The job size must be at least 1000 or set to 0 (unlimited).');
@@ -57,7 +57,9 @@ class CRM_Admin_Form_Setting_Mail extends CRM_Admin_Form_Setting {
         $errors['mailerJobSize'] = ts('A job size smaller than the batch limit will negate the effect of the batch limit.');
       }
     }
-
+    if (CRM_Utils_Array::value('civimail_sync_interval', $fields) < 1) {
+       $errors['civimail_sync_interval'] = ts('Error - the synchronization interval must be at least 1');
+    }
     return empty($errors) ? TRUE : $errors;
   }
 

--- a/CRM/Mailing/BAO/MailingJob.php
+++ b/CRM/Mailing/BAO/MailingJob.php
@@ -432,6 +432,8 @@ VALUES (%1, %2, %3, %4, %5, %6, %7)
       $now = time();
       $params = [];
       $count = 0;
+      // dev/core#1768 Get the mail sync interval.
+      $mail_sync_interval = Civi::settings()->get('civimail_sync_interval');
       while ($recipients->fetch()) {
         // CRM-18543: there are situations when both the email and phone are null.
         // Skip the recipient in this case.
@@ -453,7 +455,8 @@ VALUES (%1, %2, %3, %4, %5, %6, %7)
           $recipients->phone_id,
         ];
         $count++;
-        if ($count % CRM_Mailing_Config::BULK_MAIL_INSERT_COUNT == 0) {
+        // dev/core#1768 Mail sync interval is now configurable.
+        if ($count % $mail_sync_interval == 0) {
           CRM_Mailing_Event_BAO_Queue::bulkCreate($params, $now);
           $count = 0;
           $params = [];
@@ -576,6 +579,8 @@ VALUES (%1, %2, %3, %4, %5, %6, %7)
     $returnProperties = $mailing->getReturnProperties();
     $params = $targetParams = $deliveredParams = [];
     $count = 0;
+    // dev/core#1768 Get the mail sync interval.
+    $mail_sync_interval = Civi::settings()->get('civimail_sync_interval');
     $retryGroup = FALSE;
 
     // CRM-15702: Sending bulk sms to contacts without e-mail address fails.
@@ -708,7 +713,8 @@ VALUES (%1, %2, %3, %4, %5, %6, %7)
         $targetParams[] = $field['contact_id'];
 
         $count++;
-        if ($count % CRM_Mailing_Config::BULK_MAIL_INSERT_COUNT == 0) {
+        // dev/core#1768 Mail sync interval is now configurable.
+        if ($count % $mail_sync_interval == 0) {
           $this->writeToDB(
             $deliveredParams,
             $targetParams,

--- a/CRM/Mailing/Config.php
+++ b/CRM/Mailing/Config.php
@@ -27,6 +27,8 @@ class CRM_Mailing_Config {
   // special value for mail bulk inserts to avoid
   // potential duplication, assuming a smaller number reduces number of queries
   // by some factor, so some tradeoff. CRM-8678
+  // dev/core#1768 Remove this after Dec 2020.
+  // Replaced with civimail_sync_interval.
   const BULK_MAIL_INSERT_COUNT = 10;
 
 }

--- a/settings/Mailing.setting.php
+++ b/settings/Mailing.setting.php
@@ -369,4 +369,25 @@ return [
     'description' => ts('If checked, mailings will have open tracking enabled by default.'),
     'help_text' => NULL,
   ],
+  // dev/cor#1768 Allow mailer sync interval to be configured by the
+  // adminstrator.
+  'civimail_sync_interval' => [
+    'group_name' => 'Mailing Preferences',
+    'group' => 'mailing',
+    'name' => 'civimail_sync_interval',
+    'type' => 'Integer',
+    'quick_form_type' => 'Element',
+    'html_type' => 'text',
+    'html_attributes' => [
+      'size' => 4,
+      'maxlength' => 8,
+    ],
+    'default' => 10,
+    'title' => ts('Database Update Frequency'),
+    'add' => '5.28',
+    'is_domain' => 1,
+    'is_contact' => 0,
+    'description' => ts('The frequency that CiviMail updates its sent mail database.'),
+    'help_text' => 'CiviMail records email sent at the frequency you specify.  If you set it to 1, it will update the database every time it sends an email.  This ensures that emails are not resent if the batch job fails, but this may cause a performance hit, particularly for large jobs.',
+  ],
 ];

--- a/templates/CRM/Mailing/Form/Settings.hlp
+++ b/templates/CRM/Mailing/Form/Settings.hlp
@@ -21,4 +21,8 @@
 </p><p>
 {ts}"user and user admin" only means that only users that received the mailing or administrators can view the content of this email as a web page; the recipients will have to log in to be able to view the message{/ts}
 <p></p>
+{htxt id="mailing-sync-interval-title"}
+  {ts}Sync Interval{/ts}
+{ts}"civimail_sync_interval" specifies how frequently CiviMail records which emails it has sent.  A value of 1 means that it updates the database with every email sent, but this may have a performance hit.{/ts}:
+<p></p>
 {/htxt}


### PR DESCRIPTION
Overview
----------------------------------------
Add a CiviMail Mailer setting specifying how often batch jobs record which emails they have sent. 
Issue  [(CiviMail mail job fails to complete, even though mail is sent)](https://lab.civicrm.org/dev/core/-/issues/1768)  raised the problem that under some circumstances, a CiviMail batch job can be caught in an infinite loop.  A previous  PR (#17367) was closed, as it hard-coded how often CiviMail recorded which emails it had sent and it was suggested that it should be a configurable setting instead.

Before
----------------------------------------
```
Screen shot file of CiviMail-> Mailer Settings refused to upload.
```

Mailer Batch Limit | Throttle email delivery by setting the maximum number of emails sent during each CiviMail run (0 = unlimited).
Mailer Throttle Time | The time to sleep in between each e-mail in micro seconds. Setting this above 0 allows you to control the rate at which e-mail messages are sent to the mail server, avoiding filling up the mail queue very quickly. Set to 0 to disable.
Mailer Job Size | If you want to utilise multi-threading enter the size you want your sub jobs to be split into. Recommended values are between 1,000 and 10,000. Use a lower value if your server has multiple cron jobs running simultaneously, but do not use values smaller than 1,000. Enter "0" to disable multi-threading and process mail as one single job - batch limits still apply.
Mailer Cron Job Limit | The maximum number of mailer delivery jobs executing simultaneously (0 = allow as many processes to execute as started by cron).
VERP Separator | Separator character used when CiviMail generates VERP (variable envelope return path) Mail-From addresses.
Enable Custom Reply-To | Yes  NoAllow CiviMail users to send mailings with a custom Reply-To header.

After
----------------------------------------
```
Screen shot file refused to upload.
```

Mailer Batch Limit | Throttle email delivery by setting the maximum number of emails sent during each CiviMail run (0 = unlimited).
Mailer Throttle Time | The time to sleep in between each e-mail in micro seconds. Setting this above 0 allows you to control the rate at which e-mail messages are sent to the mail server, avoiding filling up the mail queue very quickly. Set to 0 to disable.
Mailer Job Size | If you want to utilise multi-threading enter the size you want your sub jobs to be split into. Recommended values are between 1,000 and 10,000. Use a lower value if your server has multiple cron jobs running simultaneously, but do not use values smaller than 1,000. Enter "0" to disable multi-threading and process mail as one single job - batch limits still apply.
Mailer Cron Job Limit | The maximum number of mailer delivery jobs executing simultaneously (0 = allow as many processes to execute as started by cron).
VERP Separator | Separator character used when CiviMail generates VERP (variable envelope return path) Mail-From addresses.
**Database Update Frequency | The frequency that CiviMail updates its sent mail database.
Enable Custom Reply-To | Yes  NoAllow CiviMail users to send mailings with a custom Reply-To header.**

Technical Details
----------------------------------------

- Add `civicrm_sync_interval` to `.../civicrm/settings/Mailing.setting.php`
- Add that field to `.../civicrm/CRM/Admin/Form/Setting/Mail.php` and specified that it must have a value of at least 1.
- Change `.../civicrm/CRM/Mailing/BAO/MailingJob.php` so it uses `civicrm_sync_interval` instead of `CRM_Mailing_Config::BULK_MAIL_INSERT_COUNT`.
- Deprecate that constant in `.../civicrm/CRM/Mailing/Config.php`
- Update '.../civicrm/templates/CRM/Mailing/Form/Settings.hlp ' accordingly

Comments
----------------------------------------
See comment from @totten : [https://github.com/civicrm/civicrm-core/pull/17367#issuecomment-648488654](https://github.com/civicrm/civicrm-core/pull/17367#issuecomment-648488654) where he suggests just this PR.
