### PR TITLE
dev/joomla/#28 5.27 Upgrade fails

### DIFF
--- a/Civi/Api4/Event/Events.php
+++ b/Civi/Api4/Event/Events.php
@@ -28,4 +28,10 @@ class Events {
    */
   const SCHEMA_MAP_BUILD = 'api.schema_map.build';
 
+  /**
+   * Add back POST_SELECT_QUERY const due to Joomla upgrade failure
+   * https://lab.civicrm.org/dev/joomla/-/issues/28#note_39487
+   */
+  const POST_SELECT_QUERY = 'api.select_query.post';
+
 }


### PR DESCRIPTION
Failure is due to 'Undefined class constant 'POST_SELECT_QUERY'  see https://lab.civicrm.org/dev/joomla/-/issues/28

Overview
----------------------------------------
Unable to upgrade Joomla to 5.27

Before
----------------------------------------
Unable to upgrade Joomla to 5.27.  This appears to be the fault of all files not being removed during upgrade process in Joomla
After

----------------------------------------
Upgrade succeeds

Technical Details
----------------------------------------
Temporarily add back const until the cause of the issue can be fixed

