### PR TITLE
Connect to database using SET NAMES utf8mb4

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -178,7 +178,7 @@ class CRM_Core_DAO extends DB_DataObject {
       }
       CRM_Core_DAO::executeQuery("SET SESSION sql_mode = %1", [1 => [implode(',', $currentModes), 'String']]);
     }
-    CRM_Core_DAO::executeQuery('SET NAMES utf8');
+    CRM_Core_DAO::executeQuery('SET NAMES utf8mb4');
     CRM_Core_DAO::executeQuery('SET @uniqueID = %1', [1 => [CRM_Utils_Request::id(), 'String']]);
   }
 

--- a/CRM/Utils/File.php
+++ b/CRM/Utils/File.php
@@ -334,7 +334,7 @@ class CRM_Utils_File {
     if (CRM_Utils_Constant::value('CIVICRM_MYSQL_STRICT', CRM_Utils_System::isDevelopment())) {
       $db->query('SET SESSION sql_mode = STRICT_TRANS_TABLES');
     }
-    $db->query('SET NAMES utf8');
+    $db->query('SET NAMES utf8mb4');
     $transactionId = CRM_Utils_Type::escape(CRM_Utils_Request::id(), 'String');
     $db->query('SET @uniqueID = ' . "'$transactionId'");
 

--- a/Civi/Test/Data.php
+++ b/Civi/Test/Data.php
@@ -18,7 +18,7 @@ class Data {
       \Civi\Test::schema()->setStrict(FALSE);
 
       // Ensure that when we populate the database it is done in utf8 mode
-      \Civi\Test::execute('SET NAMES utf8');
+      \Civi\Test::execute('SET NAMES utf8mb4');
       $sqlDir = dirname(dirname(__DIR__)) . "/sql";
 
       if (!isset(\Civi\Test::$statics['locale_data'])) {

--- a/install/civicrm.php
+++ b/install/civicrm.php
@@ -145,9 +145,7 @@ function civicrm_source($dsn, $fileName, $lineMode = FALSE) {
   if (PEAR::isError($db)) {
     die("Cannot open $dsn: " . $db->getMessage());
   }
-  $db->query("SET NAMES utf8");
-
-  $db->query("SET NAMES utf8");
+  $db->query('SET NAMES utf8mb4');
 
   if (!$lineMode) {
     $string = file_get_contents($fileName);


### PR DESCRIPTION
Overview
----------------------------------------
Alternative to https://github.com/civicrm/civicrm-core/pull/17696 as discussed by @pfigel @mfb @demeritcowboy @eileenmcnaughton @seamuslee001 . The use of `SET NAMES utf8mb4` has no impact on supported mysql versions for CiviCRM even if the site is not using utf8mb4.

I've switched all uses of SET NAMES (that I could find) to utf8mb4

Before
----------------------------------------
Database connection with `SET NAMES utf8` - can't use utf8mb4 characters.

After
----------------------------------------
Database connection with `SET NAMES utf8mb4` - can use utf8mb4 characters.

Technical Details
----------------------------------------


Comments
----------------------------------------
