### PR TITLE
Fix CRM_Utils_JS::dedupeClosures to ignore comments

### DIFF
--- a/CRM/Utils/JS.php
+++ b/CRM/Utils/JS.php
@@ -109,7 +109,7 @@ class CRM_Utils_JS {
    * @return string
    */
   public static function stripComments($script) {
-    return preg_replace(":^\\s*//[^\n]+$:m", "", $script);
+    return preg_replace("#^\\s*//[^\n]*$(?:\r\n|\n)?#m", "", $script);
   }
 
   /**

--- a/Civi/Angular/Page/Modules.php
+++ b/Civi/Angular/Page/Modules.php
@@ -106,15 +106,14 @@ class Modules extends \CRM_Core_Page {
   public function digestJs($files) {
     $scripts = [];
     foreach ($files as $file) {
-      $scripts[] = file_get_contents($file);
+      $scripts[] = \CRM_Utils_JS::stripComments(file_get_contents($file));
     }
     $scripts = \CRM_Utils_JS::dedupeClosures(
       $scripts,
       ['angular', '$', '_'],
       ['angular', 'CRM.$', 'CRM._']
     );
-    // This impl of stripComments currently adds 10-20ms and cuts ~7%
-    return \CRM_Utils_JS::stripComments(implode("\n", $scripts));
+    return implode("\n", $scripts);
   }
 
   /**

--- a/ang/crmUi.js
+++ b/ang/crmUi.js
@@ -484,7 +484,6 @@
     //         $scope.myOrder.setDir('field2', '');
     //   HTML: <tr ng-repeat="... | order:myOrder.get()">...</tr>
     .service('CrmUiOrderCtrl', function(){
-      //
       function CrmUiOrderCtrl(defaults){
         this.values = defaults;
       }

--- a/tests/phpunit/CRM/Utils/JSTest.php
+++ b/tests/phpunit/CRM/Utils/JSTest.php
@@ -155,11 +155,15 @@ class CRM_Utils_JSTest extends CiviUnitTestCase {
     $cases = [];
     $cases[] = [
       "a();\n//# sourceMappingURL=../foo/bar/baz.js\nb();",
-      "a();\n\nb();",
+      "a();\nb();",
     ];
     $cases[] = [
       "// foo\na();",
-      "\na();",
+      "a();",
+    ];
+    $cases[] = [
+      "// foo\n //\na();",
+      "a();",
     ];
     $cases[] = [
       "b();\n  // foo",
@@ -167,11 +171,11 @@ class CRM_Utils_JSTest extends CiviUnitTestCase {
     ];
     $cases[] = [
       "/// foo\na();\n\t \t//bar\nb();\n// whiz",
-      "\na();\n\nb();\n",
+      "a();\nb();\n",
     ];
     $cases[] = [
       "alert('//# sourceMappingURL=../foo/bar/baz.js');\n//zoop\na();",
-      "alert('//# sourceMappingURL=../foo/bar/baz.js');\n\na();",
+      "alert('//# sourceMappingURL=../foo/bar/baz.js');\na();",
     ];
     return $cases;
   }


### PR DESCRIPTION
Overview
----------------------------------------
This runs stripComments BEFORE dedupeClosures so that comments don't interfere with the deduping.
Also fixes stripComments to remove the line break as well as the comment line.

Before
----------------------------------------
Duplicate closures and stray line breaks in rendered angular js module file.

After
----------------------------------------
Cleaner.
