### PR TITLE
dev/core#1846 Regression (sorta) Hacks to avoid failure on upgrade due to new field not yet being in the DB

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -396,7 +396,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
         // Temporary hack - in 5.27 a new field is added to civicrm_custom_field. There is a high
         // risk this function is called before the upgrade page can be reached and if
         // so it will potentially result in fatal error.
-        $serializeField = CRM_Core_BAO_Domain::isDBUpdateRequired() ? '' : "$cfTable.serialize,";
+        $serializeField = CRM_Core_BAO_Domain::isDBVersionAtLeast('5.27.alpha1') ? '' : "$cfTable.serialize,";
 
         $query = "SELECT $cfTable.id, $cfTable.label,
                             $cgTable.title,
@@ -498,7 +498,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
           $fields[$dao->id]['is_required'] = $dao->is_required;
           $fields[$dao->id]['table_name'] = $dao->table_name;
           $fields[$dao->id]['column_name'] = $dao->column_name;
-          $fields[$dao->id]['serialize'] = $dao->serialize;
+          $fields[$dao->id]['serialize'] = $serializeField ? $dao->serialize : (int) self::isSerialized($dao);
           $fields[$dao->id]['where'] = $dao->table_name . '.' . $dao->column_name;
           // Probably we should use a different fn to get the extends tables but this is a refactor so not changing that now.
           $fields[$dao->id]['extends_table'] = array_key_exists($dao->extends, CRM_Core_BAO_CustomQuery::$extendsMap) ? CRM_Core_BAO_CustomQuery::$extendsMap[$dao->extends] : '';
@@ -2548,7 +2548,7 @@ WHERE cf.id = %1 AND cg.is_multiple = 1";
     if ($html_type === 'CheckBox' || strpos($html_type, 'Multi') !== FALSE) {
       return TRUE;
     }
-    // Otherwise this is the new standard as of 5.26
+    // Otherwise this is the new standard as of 5.27
     return is_object($field) ? !empty($field->serialize) : !empty($field['serialize']);
   }
 

--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -278,6 +278,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
    *
    * @return array
    *   an array of active custom fields.
+   * @throws \CRM_Core_Exception
    */
   public static function &getFields(
     $customDataType = 'Individual',
@@ -392,6 +393,10 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
         if ($onlyParent) {
           $extends .= " AND $cgTable.extends_entity_column_value IS NULL AND $cgTable.extends_entity_column_id IS NULL ";
         }
+        // Temporary hack - in 5.27 a new field is added to civicrm_custom_field. There is a high
+        // risk this function is called before the upgrade page can be reached and if
+        // so it will potentially result in fatal error.
+        $serializeField = CRM_Core_BAO_Domain::isDBUpdateRequired() ? '' : "$cfTable.serialize,";
 
         $query = "SELECT $cfTable.id, $cfTable.label,
                             $cgTable.title,
@@ -410,7 +415,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
                             $cfTable.date_format,
                             $cfTable.time_format,
                             $cgTable.is_multiple,
-                            $cfTable.serialize,
+                            $serializeField
                             $cgTable.table_name,
                             og.name as option_group_name
                      FROM $cfTable

--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -396,7 +396,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
         // Temporary hack - in 5.27 a new field is added to civicrm_custom_field. There is a high
         // risk this function is called before the upgrade page can be reached and if
         // so it will potentially result in fatal error.
-        $serializeField = CRM_Core_BAO_Domain::isDBVersionAtLeast('5.27.alpha1') ? '' : "$cfTable.serialize,";
+        $serializeField = CRM_Core_BAO_Domain::isDBVersionAtLeast('5.27.alpha1') ? "$cfTable.serialize," : '';
 
         $query = "SELECT $cfTable.id, $cfTable.label,
                             $cgTable.title,

--- a/CRM/Core/BAO/Domain.php
+++ b/CRM/Core/BAO/Domain.php
@@ -83,6 +83,19 @@ class CRM_Core_BAO_Domain extends CRM_Core_DAO_Domain {
   }
 
   /**
+   * Is a database update required to apply latest schema changes.
+   *
+   * @return bool
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public static function isDBUpdateRequired() {
+    $dbVersion = CRM_Core_BAO_Domain::version();
+    $codeVersion = CRM_Utils_System::version();
+    return version_compare($dbVersion, $codeVersion) < 0;
+  }
+
+  /**
    * Get the location values of a domain.
    *
    * @return array

--- a/CRM/Core/BAO/Domain.php
+++ b/CRM/Core/BAO/Domain.php
@@ -96,6 +96,16 @@ class CRM_Core_BAO_Domain extends CRM_Core_DAO_Domain {
   }
 
   /**
+   * Checks that the current DB schema is at least $min version
+   *
+   * @param string|number $min
+   * @return bool
+   */
+  public static function isDBVersionAtLeast($min) {
+    return version_compare(self::version(), $min, '>=');
+  }
+
+  /**
    * Get the location values of a domain.
    *
    * @return array

--- a/CRM/Utils/Check/Component/Env.php
+++ b/CRM/Utils/Check/Component/Env.php
@@ -751,7 +751,7 @@ class CRM_Utils_Check_Component_Env extends CRM_Utils_Check_Component {
       }
 
       // if db.ver > code.ver, sth really wrong
-      if (version_compare($dbVersion, $codeVersion) > 0) {
+      if (!CRM_Core_BAO_Domain::isDBUpdateRequired()) {
         $messages[] = new CRM_Utils_Check_Message(
           __FUNCTION__,
           ts('Your database is marked with an unexpected version number: %1. The v%2 codebase may not be compatible with your database state.

--- a/CRM/Utils/Check/Component/Env.php
+++ b/CRM/Utils/Check/Component/Env.php
@@ -739,10 +739,8 @@ class CRM_Utils_Check_Component_Env extends CRM_Utils_Check_Component {
       );
     }
     else {
-      $codeVersion = CRM_Utils_System::version();
-
       // if db.ver < code.ver, time to upgrade
-      if (version_compare($dbVersion, $codeVersion) < 0) {
+      if (CRM_Core_BAO_Domain::isDBUpdateRequired()) {
         $messages[] = new CRM_Utils_Check_Message(
           __FUNCTION__,
           ts('New codebase version detected. You must visit <a href=\'%1\'>upgrade screen</a> to upgrade the database.', [1 => $upgradeUrl]),

--- a/CRM/Utils/Check/Component/Env.php
+++ b/CRM/Utils/Check/Component/Env.php
@@ -751,7 +751,7 @@ class CRM_Utils_Check_Component_Env extends CRM_Utils_Check_Component {
       }
 
       // if db.ver > code.ver, sth really wrong
-      if (!CRM_Core_BAO_Domain::isDBUpdateRequired()) {
+      if (version_compare($dbVersion, CRM_Utils_System::version()) > 0) {
         $messages[] = new CRM_Utils_Check_Message(
           __FUNCTION__,
           ts('Your database is marked with an unexpected version number: %1. The v%2 codebase may not be compatible with your database state.

--- a/CRM/Utils/Check/Component/Schema.php
+++ b/CRM/Utils/Check/Component/Schema.php
@@ -94,6 +94,10 @@ class CRM_Utils_Check_Component_Schema extends CRM_Utils_Check_Component {
    * @return array
    */
   public function checkSmartGroupCustomFieldCriteria() {
+    if (CRM_Core_BAO_Domain::isDBUpdateRequired()) {
+      // Do not run this check when the db has not been updated as it might fail on non-updated schema issues.
+      return [];
+    }
     $messages = $problematicSG = [];
     $customFieldIds = array_keys(CRM_Core_BAO_CustomField::getFields('ANY', FALSE, FALSE, NULL, NULL, FALSE, FALSE, FALSE));
     try {

--- a/api/v3/CustomField.php
+++ b/api/v3/CustomField.php
@@ -122,7 +122,7 @@ function civicrm_api3_custom_field_delete($params) {
  * @return array
  */
 function civicrm_api3_custom_field_get($params) {
-  if (($params['legacy_html_type'] ?? TRUE) && !empty($params['return'])) {
+  if (!CRM_Core_BAO_Domain::isDBUpdateRequired() && ($params['legacy_html_type'] ?? TRUE) && !empty($params['return'])) {
     if (is_array($params['return'])) {
       $params['return'][] = 'serialize';
     }

--- a/api/v3/CustomField.php
+++ b/api/v3/CustomField.php
@@ -122,7 +122,7 @@ function civicrm_api3_custom_field_delete($params) {
  * @return array
  */
 function civicrm_api3_custom_field_get($params) {
-  if (!CRM_Core_BAO_Domain::isDBVersionAtLeast('5.27.alpha1') && ($params['legacy_html_type'] ?? TRUE) && !empty($params['return'])) {
+  if (CRM_Core_BAO_Domain::isDBVersionAtLeast('5.27.alpha1') && ($params['legacy_html_type'] ?? TRUE) && !empty($params['return'])) {
     if (is_array($params['return'])) {
       $params['return'][] = 'serialize';
     }

--- a/api/v3/CustomField.php
+++ b/api/v3/CustomField.php
@@ -122,7 +122,7 @@ function civicrm_api3_custom_field_delete($params) {
  * @return array
  */
 function civicrm_api3_custom_field_get($params) {
-  if (!CRM_Core_BAO_Domain::isDBUpdateRequired() && ($params['legacy_html_type'] ?? TRUE) && !empty($params['return'])) {
+  if (!CRM_Core_BAO_Domain::isDBVersionAtLeast('5.27.alpha1') && ($params['legacy_html_type'] ?? TRUE) && !empty($params['return'])) {
     if (is_array($params['return'])) {
       $params['return'][] = 'serialize';
     }

--- a/sql/test_data_second_domain.mysql
+++ b/sql/test_data_second_domain.mysql
@@ -963,4 +963,4 @@ INSERT INTO civicrm_navigation
 VALUES
     ( @domainID, CONCAT('civicrm/report/instance/', @instanceID,'&reset=1'), 'Mailing Detail Report', 'Mailing Detail Report', 'administer CiviMail', 'OR', @reportlastID, '1', NULL, @instanceID+2 );
 UPDATE civicrm_report_instance SET navigation_id = LAST_INSERT_ID() WHERE id = @instanceID;
-UPDATE civicrm_domain SET version = '4.6.alpha1';
+UPDATE civicrm_domain SET version = '5.27.alpha1';

--- a/xml/schema/Core/CustomField.xml
+++ b/xml/schema/Core/CustomField.xml
@@ -290,7 +290,7 @@
     <pseudoconstant>
       <callback>CRM_Core_SelectValues::fieldSerialization</callback>
     </pseudoconstant>
-    <add>5.26</add>
+    <add>5.27</add>
   </field>
   <field>
     <name>filter</name>


### PR DESCRIPTION

Overview
----------------------------------------
On attempting to upgrade I found I couldn't get to the upgrade screen add the new serialize field as
I got fatal errors in these 2 places (maybe more to come).

The new field is civicrm_custom_field.serialize

Before
----------------------------------------
Can't reach upgrade page due to fatal errors due to db not being upgraded

After
----------------------------------------
short circuit hacks

Technical Details
----------------------------------------


Comments
----------------------------------------

https://lab.civicrm.org/dev/core/-/issues/1846