### PR TITLE
[REF] Remove ACL join on temp table creation in Member ContributionDe…

### DIFF
--- a/CRM/Report/Form/Member/ContributionDetail.php
+++ b/CRM/Report/Form/Member/ContributionDetail.php
@@ -517,7 +517,6 @@ class CRM_Report_Form_Member_ContributionDetail extends CRM_Report_Form {
           FROM civicrm_contribution contribution
           INNER JOIN civicrm_contact {$this->_aliases['civicrm_contact']}
                 ON {$this->_aliases['civicrm_contact']}.id = contribution.contact_id AND contribution.is_test = 0
-          {$this->_aclFrom}
           LEFT JOIN civicrm_membership_payment mp
                 ON contribution.id = mp.contribution_id
           LEFT JOIN civicrm_membership m


### PR DESCRIPTION
…tail report

Overview
----------------------------------------
This removes an unnecessary join onto the civicrm_acl_contact_cache table when populating the temporary table. The ACL join and where clause is correctly applied in the main report query

Before
----------------------------------------
Unnecessary Join to acl_contact_cache

After
----------------------------------------
No unnecessary join to acl_contact_cache table

ping @eileenmcnaughton 