### PR TITLE
Remove obsolete function formatWikiURL

### DIFF
--- a/CRM/Case/XMLProcessor/Report.php
+++ b/CRM/Case/XMLProcessor/Report.php
@@ -538,9 +538,6 @@ WHERE      a.id = %1
             ) {
               $value = $this->redact($value);
             }
-            elseif (CRM_Utils_Array::value('type', $typeValue) == 'Link') {
-              $value = CRM_Utils_System::formatWikiURL($value);
-            }
           }
           //$typeValue
           $customGroup[] = array(

--- a/CRM/Utils/Check/Component/Env.php
+++ b/CRM/Utils/Check/Component/Env.php
@@ -118,7 +118,7 @@ class CRM_Utils_Check_Component_Env extends CRM_Utils_Check_Component {
       $messages[] = new CRM_Utils_Check_Message(
         __FUNCTION__,
         ts('Timestamps reported by MySQL (eg "%2") and PHP (eg "%3" ) are mismatched.<br /><a href="%1">Read more about this warning</a>', [
-          1 => CRM_Utils_System::getWikiBaseURL() . 'checkMysqlTime',
+          1 => CRM_Utils_System::docURL2('sysadmin/requirements/#mysql-time', TRUE),
           2 => $sqlNow,
           3 => $phpNow,
         ]),

--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -1066,28 +1066,6 @@ class CRM_Utils_System {
   }
 
   /**
-   * Format wiki url.
-   *
-   * @param string $string
-   * @param bool $encode
-   *
-   * @return string
-   */
-  public static function formatWikiURL($string, $encode = FALSE) {
-    $items = explode(' ', trim($string), 2);
-    if (count($items) == 2) {
-      $title = $items[1];
-    }
-    else {
-      $title = $items[0];
-    }
-
-    // fix for CRM-4044
-    $url = $encode ? self::urlEncode($items[0]) : $items[0];
-    return "<a href=\"$url\">$title</a>";
-  }
-
-  /**
    * Encode url.
    *
    * @param string $url

--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -1073,6 +1073,7 @@ class CRM_Utils_System {
    * @return null|string
    */
   public static function urlEncode($url) {
+    CRM_Core_Error::deprecatedFunctionWarning('urlEncode');
     $items = parse_url($url);
     if ($items === FALSE) {
       return NULL;
@@ -1578,6 +1579,7 @@ class CRM_Utils_System {
    * @return string
    */
   public static function relativeURL($url) {
+    CRM_Core_Error::deprecatedFunctionWarning('url');
     // check if url is relative, if so return immediately
     if (substr($url, 0, 4) != 'http') {
       return $url;
@@ -1605,6 +1607,7 @@ class CRM_Utils_System {
    * @return string
    */
   public static function absoluteURL($url, $removeLanguagePart = FALSE) {
+    CRM_Core_Error::deprecatedFunctionWarning('url');
     // check if url is already absolute, if so return immediately
     if (substr($url, 0, 4) == 'http') {
       return $url;


### PR DESCRIPTION
Overview
----------------------------------------
Remove obsolete, unused function to create links to our long-dead wiki.

Before
----------------------------------------
Function exists

After
----------------------------------------
Gone

Technical Details
----------------------------------------
It was actually used in 1 place, but the usage made no sense to me, and I'm not sure if the code was even reachable.

Comments
----------------------------------------
@demeritcowboy would you mind taking a look at the case report to see if the function was as misapplied as I think it was?