### PR TITLE
dev/translation#48: fix up system check grammar and add pre-upgrade message.

### DIFF
--- a/CRM/Upgrade/Incremental/php/FiveTwentySeven.php
+++ b/CRM/Upgrade/Incremental/php/FiveTwentySeven.php
@@ -29,6 +29,10 @@ class CRM_Upgrade_Incremental_php_FiveTwentySeven extends CRM_Upgrade_Incrementa
     // if ($rev == '5.12.34') {
     //   $preUpgradeMessage .= '<p>' . ts('A new permission, "%1", has been added. This permission is now used to control access to the Manage Tags screen.', array(1 => ts('manage tags'))) . '</p>';
     // }
+    $preUpgradeMessage .= '<p>' . ts('Starting with version 5.28.0, CiviCRM will
+      require the PHP Internationalization extension (PHP-Intl).  In preparation
+      for this, the system check will show a warning beginning in 5.27.0 if your
+      site lacks this extension.') . '</p>';
   }
 
   /**

--- a/CRM/Utils/Check/Component/Env.php
+++ b/CRM/Utils/Check/Component/Env.php
@@ -991,7 +991,7 @@ class CRM_Utils_Check_Component_Env extends CRM_Utils_Check_Component {
     if (!extension_loaded('intl')) {
       $messages[] = new CRM_Utils_Check_Message(
         __FUNCTION__,
-        ts('This system currently does not have the PHP-INTL extension enabled please contact your system administrator about getting the extension enabled'),
+        ts('This system currently does not have the PHP-Intl extension enabled.  Please contact your system administrator about getting the extension enabled.'),
         ts('Missing PHP Extension: INTL'),
         \Psr\Log\LogLevel::WARNING,
         'fa-server'


### PR DESCRIPTION
Overview
----------------------------------------
This follows on #17668 to add a pre-upgrade message about requiring PHP-Intl.

Before
----------------------------------------
A user with a site that lacks PHP-Intl will run an upgrade, think it went well, and then have a warning pop up for all admins.

After
----------------------------------------
Anyone lacking PHP-Intl will still get a warning after upgrade, but they'll see a message about it before running the upgrade script.

Technical Details
----------------------------------------
I fixed a run-on sentence in the system check, too.

Comments
----------------------------------------
I feel strongly that a system check that declares something to be a problem when it wasn't an actual problem before should be accompanied by an upgrade message.  Many system checks unearth problems that have always been actual problems (and that's fine).  Many look for real problems but get false positives (and they just need to be tuned better).  However, some of the most annoying ones are along the lines of, "You don't have this thing that you don't need yet but might soon!"  The least we can do is warn people about the warning.
