### PR TITLE
dev/core#1494 System check for moneyvalueformat: grammar & clarity

### DIFF
--- a/CRM/Utils/Check/Component/Schema.php
+++ b/CRM/Utils/Check/Component/Schema.php
@@ -183,8 +183,11 @@ class CRM_Utils_Check_Component_Schema extends CRM_Utils_Check_Component {
     if (CRM_Core_Config::singleton()->moneyvalueformat !== '%!i') {
       $msg = new CRM_Utils_Check_Message(
         __FUNCTION__,
-        ts('<p>The Money Value format stored is deprecated please report your configuration on <a href="https://lab.civicrm.org/dev/core/-/issues/1494">Gitlab Issue</a>'),
-        ts('Deprectad money value format configuration'),
+        ts(
+          '<p>The Monetary Value Display format is a deprecated setting, and this site has a non-standard format. Please report your configuration on <a href="%1">this Gitlab issue</a>.',
+          [1 => 'https://lab.civicrm.org/dev/core/-/issues/1494']
+        ),
+        ts('Deprecated monetary value display format configuration'),
         \Psr\Log\LogLevel::WARNING,
         'fa-server'
       );


### PR DESCRIPTION
Overview
----------------------------------------
This follows on #17577 to fix a run-on sentence, a typo, and the display name of the moneyvalueformat setting.

Before
----------------------------------------
> ### Deprectad money value format configuration
>
> The Money Value format stored is deprecated please report your configuration on [Gitlab Issue](#)

After
----------------------------------------
> ### Deprecated monetary value display format configuration
>
> The Monetary Value Display format is a deprecated setting, and this site has a non-standard format. Please report your configuration on [this Gitlab issue](#).
