### PR TITLE
5.27.0 release notes: final edits

### DIFF
--- a/release-notes/5.27.0.md
+++ b/release-notes/5.27.0.md
@@ -403,7 +403,7 @@ Released July 1, 2020
   avoid markup problems.
 
 - **Add serialize column to civicrm_custom_field, remove "Multi-Select" html
-  type ([16992](https://github.com/civicrm/civicrm-core/pull/16992))**
+  type ([16992](https://github.com/civicrm/civicrm-core/pull/16992), [17722](https://github.com/civicrm/civicrm-core/pull/17722))**
 
   Work towards making custom select and multi-select fields more similar to
   core select/multi-select fields.
@@ -742,7 +742,7 @@ Released July 1, 2020
   ([17436](https://github.com/civicrm/civicrm-core/pull/17436))**
 
 - **[REF] Implement required fields database changes that have occured du…
-  ([17465](https://github.com/civicrm/civicrm-core/pull/17465))**
+  ([17465](https://github.com/civicrm/civicrm-core/pull/17465), [17725](https://github.com/civicrm/civicrm-core/pull/17725))**
 
 - **[REF] Bump Pear Log version to fix compatability with Drupal 8 / Drup…
   ([17460](https://github.com/civicrm/civicrm-core/pull/17460))**

--- a/release-notes/5.27.0.md
+++ b/release-notes/5.27.0.md
@@ -27,13 +27,13 @@ Released July 1, 2020
 
 - **Warn users who lack PHP-Intl extension (Work Towards
   [dev/translation#48](https://lab.civicrm.org/dev/translation/-/issues/48):
-  [17668](https://github.com/civicrm/civicrm-core/pull/17668))**
+  [17668](https://github.com/civicrm/civicrm-core/pull/17668), [17728](https://github.com/civicrm/civicrm-core/pull/17728))**
 
   A system check warning will now appear on sites that lack the PHP
   Internationalization extension.  This is in preparation for changes that will
   appear in CiviCRM 5.28 and require the extension.
 
-- **advanced search: allow searching by first/last name; pass values from
+- **Advanced Search - Allow searching by first/last name; pass values from
   quicksearch ([dev/core#1722](https://lab.civicrm.org/dev/core/-/issues/1722):
   [17118](https://github.com/civicrm/civicrm-core/pull/17118))**
 
@@ -63,7 +63,7 @@ Released July 1, 2020
   name followed by a suffix, such as `activity_type_id:label`.  This now works
   for retrieval and sort.
 
-- **APIv4 - support custom entity joins
+- **APIv4 - Support custom entity joins
   ([17394](https://github.com/civicrm/civicrm-core/pull/17394))**
 
   Improves APIv4 so that it supports implicit and explicit joins onto custom
@@ -74,13 +74,6 @@ Released July 1, 2020
 
   The help text for reCAPTCHA settings now specifies the type of reCAPTCHA
   supported.
-
-- **Wrap separators in price field in spans with classes
-  ([dev/user-interface#18](https://lab.civicrm.org/dev/user-interface/-/issues/18):
-  [17078](https://github.com/civicrm/civicrm-core/pull/17078))**
-
-  Colons separating pre- and post-field help text from price fields are now
-  wrapped in `<span>` elements.
 
 - **Configurable logfile size and hashing
   ([17192](https://github.com/civicrm/civicrm-core/pull/17192))**
@@ -94,7 +87,7 @@ Released July 1, 2020
 
   Makes it so CiviCRM plays nicely with Symfony 4.4.
 
-- **Add in domain tokens onto the Message Template admin interface
+- **Add domain tokens to the Message Template admin interface
   ([17388](https://github.com/civicrm/civicrm-core/pull/17388))**
 
   This adds the domain tokens (the domain organization name, address, email, and
@@ -139,7 +132,7 @@ Released July 1, 2020
   It also adds a helper function in Javascript similar to those in PHP and
   Smarty to render icons.
 
-- **crmButton: support icon=0 for no icon
+- **crmButton: Support icon=0 for no icon
   ([17303](https://github.com/civicrm/civicrm-core/pull/17303))**
 
   Makes it possible to create a button without an icon using {crmButton}.
@@ -184,19 +177,26 @@ Released July 1, 2020
 
 ### CiviContribute
 
-- **Allow to search on contribution id
+- **Wrap separators in price field in spans with classes
+  ([dev/user-interface#18](https://lab.civicrm.org/dev/user-interface/-/issues/18):
+  [17078](https://github.com/civicrm/civicrm-core/pull/17078))**
+
+  Colons separating pre- and post-field help text from price fields are now
+  wrapped in `<span>` elements.
+
+- **Allow to search on contribution ID
   ([dev/core#1580](https://lab.civicrm.org/dev/core/-/issues/1580):
   [16484](https://github.com/civicrm/civicrm-core/pull/16484))**
 
   This improves the "Find Contributions" search form by adding a field to search
   by Contribution ID.
 
-- **Api4: Add Price api entities
+- **APIv4 - Add "Price"-related entities
   ([17363](https://github.com/civicrm/civicrm-core/pull/17363))**
 
   Priceset, PriceField, and PriceOption entities are added to APIv4.
 
-- **Add ContributionRecur crud api
+- **APIv4 - Add ContributionRecur entity
   ([17299](https://github.com/civicrm/civicrm-core/pull/17299))**
 
   Adds Contribution Recur to APIv4.
@@ -221,7 +221,7 @@ Released July 1, 2020
   Updates CiviMail's default behavior to replace `extern/open.php` and
   `extern/url.php` with `civicrm/mailing/open` and `civicrm/mailing/url`.
 
-- **Make is_archived work as a url-search parameter
+- **Make `is_archived` work as a url-search parameter
   ([17328](https://github.com/civicrm/civicrm-core/pull/17328))**
 
   The Find Mailings URL can now have `is_archived` as a parameter to only find
@@ -244,7 +244,7 @@ Released July 1, 2020
   users to avoid confusion for users who do not have access to the Drupal admin
   menu.
 
-- **provide Calendar module with end_date when duration is provided
+- **Provide "Calendar" module with an end-date when a duration is provided
   ([601](https://github.com/civicrm/civicrm-drupal/pull/601))**
 
   Improves display of activities in calendar views.
@@ -299,7 +299,7 @@ Released July 1, 2020
   ([dev/core#1743](https://lab.civicrm.org/dev/core/-/issues/1743):
   [17260](https://github.com/civicrm/civicrm-core/pull/17260))**
 
-- **Statically added members of a smart group not found
+- **Statically added members of a smart group are not found
   ([dev/core#1745](https://lab.civicrm.org/dev/core/-/issues/1745):
   [17419](https://github.com/civicrm/civicrm-core/pull/17419))**
 
@@ -347,9 +347,9 @@ Released July 1, 2020
   If a clause of a contact query used to build a smart group is empty, it would
   result in a database error.
 
-- **replace deprecated money_format() fn to support PHP 7.4
+- **Replace deprecated `money_format()` fn to support PHP 7.4
   (Work Towards [dev/core#1494](https://lab.civicrm.org/dev/core/-/issues/1494):
-  [17577](https://github.com/civicrm/civicrm-core/pull/17577))**
+  [17577](https://github.com/civicrm/civicrm-core/pull/17577), [17730](https://github.com/civicrm/civicrm-core/pull/17730))**
 
   Adds a deprecation notice and a status check for a money value format
   configuration other than the default.
@@ -363,7 +363,7 @@ Released July 1, 2020
   This helps avoid test failures on broadcast messages when the system is
   running slowly.
 
-- **Scheduled Reminders -set boolean fields to false if not set.
+- **Scheduled Reminders - Set boolean fields to false if not set.
   ([17494](https://github.com/civicrm/civicrm-core/pull/17494))**
 
 - **Allow bidirectional assignment of relationships from search results
@@ -372,7 +372,7 @@ Released July 1, 2020
   Previously relationships could only be created from search results where the
   contacts would be valid in the "A" side of the relationship type.
 
-- **Navigation menu: fix translation of new-subtype entries
+- **Navigation menu - Fix translation of new-subtype entries
   ([17451](https://github.com/civicrm/civicrm-core/pull/17451))**
 
   The "New" in menu items for creating a new contact of a subtype was not
@@ -381,7 +381,7 @@ Released July 1, 2020
 - **utf8mb4 - If strict mode enabled query will fail if KEY_BLOCK_SIZE is not 0
   ([17253](https://github.com/civicrm/civicrm-core/pull/17253))**
 
-- **Update DAO and L10n Schema file
+- **Update DAO and l10n schema file
   ([17395](https://github.com/civicrm/civicrm-core/pull/17395))**
 
   Price option name and value are now required in the database.
@@ -408,10 +408,10 @@ Released July 1, 2020
   Work towards making custom select and multi-select fields more similar to
   core select/multi-select fields.
 
-- **respect file fields that have been configured as view only in profiles
+- **Respect file fields that have been configured as view only in profiles
   ([17079](https://github.com/civicrm/civicrm-core/pull/17079))**
 
-- **Tag create: respect created_date and created_id params
+- **Tag create - Respect created_date and created_id params
   ([17257](https://github.com/civicrm/civicrm-core/pull/17257))**
 
 - **Public status messages should show correct class/icon like error
@@ -420,7 +420,7 @@ Released July 1, 2020
 - **Decorative chevrons should be icons not angle quotes
   ([17245](https://github.com/civicrm/civicrm-core/pull/17245))**
 
-- **A/B test: icon should be Erlenmeyer flask, not bar chart
+- **A/B Test - Icon should be Erlenmeyer flask, not bar chart
   ([17316](https://github.com/civicrm/civicrm-core/pull/17316))**
 
 - **Proceeding to confirmation page should be a "next" button not a check
@@ -428,7 +428,7 @@ Released July 1, 2020
 
 ### CiviCase
 
-- **case activity: follow-up activity assignee does not receive email
+- **Case Activity: Follow-up activity assignee does not receive email
   ([dev/core#1721](https://lab.civicrm.org/dev/core/-/issues/1721):
   [17116](https://github.com/civicrm/civicrm-core/pull/17116))**
 
@@ -590,7 +590,7 @@ Released July 1, 2020
   another for older, standalone scripts in the `extern` folder which is based on
   the same logic as before.
 
-- **Declare Minimum WP and PHP versions required for installation
+- **Declare minimum WP and PHP versions required for installation
   ([201](https://github.com/civicrm/civicrm-wordpress/pull/201))**
 
 - **wp-rest - Adjust extern URL. Be more defensive about 'query' part.
@@ -601,7 +601,7 @@ Released July 1, 2020
 
 ## <a name="misc"></a>Miscellany
 
-- **handle less common dynamic reference cases
+- **Handle less common dynamic reference cases
   ([17653](https://github.com/civicrm/civicrm-core/pull/17653))**
 
 - **Use apiv4, cache infra for basicTypes

--- a/release-notes/5.27.0.md
+++ b/release-notes/5.27.0.md
@@ -16,7 +16,7 @@ Released July 1, 2020
 | Fix security vulnerabilities?                                   |   no    |
 | **Change the database schema?**                                 | **yes** |
 | **Alter the API?**                                              | **yes** |
-| Require attention to configuration options?                     |   no    |
+| **Require attention to configuration options?**                 | **yes** |
 | **Fix problems installing or upgrading to a previous version?** | **yes** |
 | **Introduce features?**                                         | **yes** |
 | **Fix bugs?**                                                   | **yes** |
@@ -25,48 +25,43 @@ Released July 1, 2020
 
 ### Core CiviCRM
 
+- **Warn users who lack PHP-Intl extension (Work Towards
+  [dev/translation#48](https://lab.civicrm.org/dev/translation/-/issues/48):
+  [17668](https://github.com/civicrm/civicrm-core/pull/17668))**
+
+  A system check warning will now appear on sites that lack the PHP
+  Internationalization extension.  This is in preparation for changes that will
+  appear in CiviCRM 5.28 and require the extension.
+
 - **advanced search: allow searching by first/last name; pass values from
   quicksearch ([dev/core#1722](https://lab.civicrm.org/dev/core/-/issues/1722):
   [17118](https://github.com/civicrm/civicrm-core/pull/17118))**
 
-  Makes First and last name available on the advanced search form, and ensures
-  quick search filters are passed to the appropriate field.
+  This makes separate First Name and Last Name fields available on the Advanced
+  Search form, and it ensures quick search filters are passed to the appropriate
+  field.
 
 - **Add more search options
   ([17372](https://github.com/civicrm/civicrm-core/pull/17372))**
 
-  Improves the Individual search form by adding fields for" `organization_name`,
-  `first_name`, `nick_name` and `last_name`.
-
-- **Investigate php currency library (Work Towards
-  [dev/translation#48](https://lab.civicrm.org/dev/translation/-/issues/48):
-  [17668](https://github.com/civicrm/civicrm-core/pull/17668))**
-
-  Adds a system check for a php extension (INTL) that will be required for
-  CiviCRM 5.28 and up.
+  Improves the search form for individuals in contact reference fields by adding
+  fields for Employer Name, First Name, Last Name, and Nick Name.
 
 - **End of life planning for MySQL server 5.0 - 5.6
   ([dev/core#1681](https://lab.civicrm.org/dev/core/-/issues/1681):
   [17518](https://github.com/civicrm/civicrm-core/pull/17518) and
   [17496](https://github.com/civicrm/civicrm-core/pull/17496))**
 
-  Adds a notice about 5.28 Dropping MySQL 5.5 Support.
-
-- **Add MembershipType to Api4
-  ([17448](https://github.com/civicrm/civicrm-core/pull/17448))**
-
-  Adds a Membership Type entity to APIv4.
-
-- **Api4: Add Price api entities
-  ([17363](https://github.com/civicrm/civicrm-core/pull/17363))**
-
-  Adds Price entities to APIv4.
+  Sites running MySQL 5.5 and below will have a pre-upgrade message and a system
+  check warning to say that CiviCRM 5.28 will require MySQL 5.6 or MariaDB 10.1.
 
 - **APIv4 - Improve pseudoconstant suffix support
   ([17368](https://github.com/civicrm/civicrm-core/pull/17368) and
   [17482](https://github.com/civicrm/civicrm-core/pull/17482))**
 
-  Improves suffix support in APIv4.
+  APIv4 allows pseudoconstant fields to be specified with the pseudoconstant
+  name followed by a suffix, such as `activity_type_id:label`.  This now works
+  for retrieval and sort.
 
 - **APIv4 - support custom entity joins
   ([17394](https://github.com/civicrm/civicrm-core/pull/17394))**
@@ -74,26 +69,18 @@ Released July 1, 2020
   Improves APIv4 so that it supports implicit and explicit joins onto custom
   entities.
 
-- **Add ContributionRecur crud api
-  ([17299](https://github.com/civicrm/civicrm-core/pull/17299))**
-
-  Adds Contribution Recur to APIv4.
-
 - **Make reCAPTCHA settings clearer
   ([17426](https://github.com/civicrm/civicrm-core/pull/17426))**
 
-  Improves help text for reCAPTCHA settings.
+  The help text for reCAPTCHA settings now specifies the type of reCAPTCHA
+  supported.
 
 - **Wrap separators in price field in spans with classes
   ([dev/user-interface#18](https://lab.civicrm.org/dev/user-interface/-/issues/18):
   [17078](https://github.com/civicrm/civicrm-core/pull/17078))**
 
-  Improve user interface by wrapping separators in price fields in spans.
-
-- **Make is_archived work as a url-search parameter
-  ([17328](https://github.com/civicrm/civicrm-core/pull/17328))**
-
-  Makes it possible to send `is_archived` as a url search parameter.
+  Colons separating pre- and post-field help text from price fields are now
+  wrapped in `<span>` elements.
 
 - **Configurable logfile size and hashing
   ([17192](https://github.com/civicrm/civicrm-core/pull/17192))**
@@ -110,41 +97,90 @@ Released July 1, 2020
 - **Add in domain tokens onto the Message Template admin interface
   ([17388](https://github.com/civicrm/civicrm-core/pull/17388))**
 
-  Adds the domain tokens to the Message Template admin interface "Tokens"
-  dropdown.
+  This adds the domain tokens (the domain organization name, address, email, and
+  phone) to the available listed tokens for editing message templates.
 
-- **Make all icons aria-hidden
-  ([17318](https://github.com/civicrm/civicrm-core/pull/17318))**
+- **Hide icon elements from screen readers and add handling for
+  screen-reader-only text
+  ([17318](https://github.com/civicrm/civicrm-core/pull/17318),
+  [17293](https://github.com/civicrm/civicrm-core/pull/17293),
+  [17294](https://github.com/civicrm/civicrm-core/pull/17294), and
+  [17310](https://github.com/civicrm/civicrm-core/pull/17310))**
 
-  Improves user experience when using a screen reader by hiding icons.
+  CiviCRM uses empty `<i>` elements to provide most icons.  Screen readers,
+  which won't render the visual icon anyway, will either skip over an empty
+  element or announce it in a way that would be confusing.  This makes it
+  explicit that screen readers and other ARIA devices should skip them.
 
-- **Extend icon helper support, including for formLink
-  ([17319](https://github.com/civicrm/civicrm-core/pull/17319))**
+  Meanwhile, if the icon is the only way a piece of information is displayed, a
+  screen reader user won't get that information.  This adds a `sr-only` class
+  that makes the element invisible on screen without being ignored by a screen
+  reader.
 
-  Improves `CRM_Core_Action::formLink()` so that it produces more accessible
-  icon HTML.
+  Screen reader text is added for the field option wrench icons, relationship
+  permissions, and membership auto-renew status.
 
-- **Screen reader text for wrenches
-  ([17293](https://github.com/civicrm/civicrm-core/pull/17293))**
+- **Add icon helper functions and remove most uses of check.gif
+  ([17279](https://github.com/civicrm/civicrm-core/pull/17279) and
+  [17289](https://github.com/civicrm/civicrm-core/pull/17289))**
 
-  Improves usability for screen reader users by explaining wrench icons.
+  This adds helper functions in PHP and Smarty to render consistent icons with a
+  minimum of code.  It also replaces most instances of the green checkmark image
+  with a checkmark icon.
 
-- **sr-only text for relationship permissions
-  ([17294](https://github.com/civicrm/civicrm-core/pull/17294))**
+- **Separate icon markup from labels and add JS icon helper
+  ([17319](https://github.com/civicrm/civicrm-core/pull/17319) and
+  [17285](https://github.com/civicrm/civicrm-core/pull/17285))**
 
-  Improves usability for screen reader users by descriptions for icons for
-  relationships permissions.
+  These changes improve `CRM_Core_Action::formLink()`, `hook_civicrm_links`, and
+  certain listing pages so that HTML icon markup is added at the point of
+  display rather than during the processing of values.
+
+  It also adds a helper function in Javascript similar to those in PHP and
+  Smarty to render icons.
 
 - **crmButton: support icon=0 for no icon
   ([17303](https://github.com/civicrm/civicrm-core/pull/17303))**
 
-  Makes it possible to create a button without and icon using {crmButton}.
+  Makes it possible to create a button without an icon using {crmButton}.
+
+- **Replace stop-icon.png with fa-ban over a relevant icon for privacy
+  ([17283](https://github.com/civicrm/civicrm-core/pull/17283) and
+  [17307](https://github.com/civicrm/civicrm-core/pull/17307))**
+
+  The communication preference icons are standardized and more specific than the
+  old stop sign.
+
+- **Replace image icons with Font Awesome icons
+  ([17296]([17280](https://github.com/civicrm/civicrm-core/pull/17280),
+  [17281](https://github.com/civicrm/civicrm-core/pull/17281),
+  [17282](https://github.com/civicrm/civicrm-core/pull/17282),
+  [17295](https://github.com/civicrm/civicrm-core/pull/17295),
+  https://github.com/civicrm/civicrm-core/pull/17296),
+  [17297](https://github.com/civicrm/civicrm-core/pull/17297))**
+
+  Nearly all image icons have been replaced with the corresponding icons from
+  the Font Awesome library.
+
+- **Simplify admin console and remove superfluous icons
+  ([17284](https://github.com/civicrm/civicrm-core/pull/17284))**
+
+  The Administration console has been redesigned to have a simpler layout,
+  display more information, dynamically include all enabled components, display
+  responsively on small screens, and remove a slew of 15-year-old image icons.
 
 - **Dedupe performance - hard-remove financial_item from list of dymnamic  refs
   to contact table
   ([17567](https://github.com/civicrm/civicrm-core/pull/17567))**
 
-  Improves performance when dedupping.
+  This improves performance when deduping by no longer querying the financial
+  item table.
+
+- **Trigger fatalErrorHandler for PEAR errors and for logs with severity ERROR
+  or higher ([17277](https://github.com/civicrm/civicrm-core/pull/17277))**
+
+  This allows extensions that implement `$config->fatalErrorHandler` to react to
+  a wider variety of errors that CiviCRM may generate.
 
 ### CiviContribute
 
@@ -152,18 +188,26 @@ Released July 1, 2020
   ([dev/core#1580](https://lab.civicrm.org/dev/core/-/issues/1580):
   [16484](https://github.com/civicrm/civicrm-core/pull/16484))**
 
-  Improves the "Find Contributions" search form by adding a field to search by
-  "Contribution ID".
+  This improves the "Find Contributions" search form by adding a field to search
+  by Contribution ID.
 
-### CiviEvent
+- **Api4: Add Price api entities
+  ([17363](https://github.com/civicrm/civicrm-core/pull/17363))**
 
-- **Replace ical and office calendar image icons
-  ([17282](https://github.com/civicrm/civicrm-core/pull/17282))**
+  Priceset, PriceField, and PriceOption entities are added to APIv4.
 
-  Changes the icons on the bottom of event info pages to use Font
-  Awesome icons instead of images.
+- **Add ContributionRecur crud api
+  ([17299](https://github.com/civicrm/civicrm-core/pull/17299))**
+
+  Adds Contribution Recur to APIv4.
 
 ### CiviMail
+
+- **Allow click-through and open tracking to be enabled/disabled by default
+  ([17291](https://github.com/civicrm/civicrm-core/pull/17291))**
+
+  Adds a setting to CiviMail which allows for setting the click-through and open
+  tracking defaults.
 
 - **Extend content array of hook_civicrm_alterMailContent
   ([dev/core#1620](https://lab.civicrm.org/dev/core/-/issues/1620):
@@ -177,11 +221,18 @@ Released July 1, 2020
   Updates CiviMail's default behavior to replace `extern/open.php` and
   `extern/url.php` with `civicrm/mailing/open` and `civicrm/mailing/url`.
 
-- **Allow click-through and open tracking to be enabled/disabled by default
-  ([17291](https://github.com/civicrm/civicrm-core/pull/17291))**
+- **Make is_archived work as a url-search parameter
+  ([17328](https://github.com/civicrm/civicrm-core/pull/17328))**
 
-  Adds a setting to CiviMail which allows for setting the click-through and open
-  tracking defaults.
+  The Find Mailings URL can now have `is_archived` as a parameter to only find
+  archived mailings.
+
+### CiviMember
+
+- **Add MembershipType to Api4
+  ([17448](https://github.com/civicrm/civicrm-core/pull/17448))**
+
+  Adds a Membership Type entity to APIv4.
 
 ### Drupal Integration
 
@@ -189,8 +240,9 @@ Released July 1, 2020
   ([dev/core#1757](https://lab.civicrm.org/dev/core/-/issues/1757):
   [17362](https://github.com/civicrm/civicrm-core/pull/17362))**
 
-  Hides the "adjust menu position" icon in the CiviCRM Menu for non admin users
-  to avoid confusion for users who do not have access to the Drupal admin menu.
+  This hides the "adjust menu position" icon in the CiviCRM Menu for non admin
+  users to avoid confusion for users who do not have access to the Drupal admin
+  menu.
 
 - **provide Calendar module with end_date when duration is provided
   ([601](https://github.com/civicrm/civicrm-drupal/pull/601))**
@@ -205,13 +257,14 @@ Released July 1, 2020
   ([dev/core#1781](https://lab.civicrm.org/dev/core/-/issues/1781):
   [17414](https://github.com/civicrm/civicrm-core/pull/17414))**
 
-  CRM_Utils_Time - Allow TIME_FUNC to better isolate timing bugs.
+  This allows the CRM_Utils_Time functions used in unit tests to use TIME_FUNC
+  to better isolate timing bugs.
 
 - **Confusing popups when importing activities
   ([dev/user-interface#17](https://lab.civicrm.org/dev/user-interface/-/issues/17):
   [17067](https://github.com/civicrm/civicrm-core/pull/17067))**
 
-  Fixes a bug where the confirmation popup would appear when hitting the
+  This fixes a bug where the confirmation popup would appear when hitting the
   back/cancel buttons, not just the import button, on most import forms.
 
 - **Installing CiviCRM in another language, with civicrm-setup
@@ -239,7 +292,8 @@ Released July 1, 2020
   ([dev/core#1731](https://lab.civicrm.org/dev/core/-/issues/1731):
   [17163](https://github.com/civicrm/civicrm-core/pull/17163))**
 
-  Ensures that importing relationships works as expected.
+  Ensures that importing relationships works as expected when the same field is
+  to be imported for the main imported contact and a related contact.
 
 - **Apostrophes in richtext fields don't get exported properly in CiviReport
   ([dev/core#1743](https://lab.civicrm.org/dev/core/-/issues/1743):
@@ -254,22 +308,18 @@ Released July 1, 2020
   ([dev/core#1753](https://lab.civicrm.org/dev/core/-/issues/1753):
   [17298](https://github.com/civicrm/civicrm-core/pull/17298))**
 
-- **E_WARNINGS when viewing list of pledge payments
-  ([dev/core#1791](https://lab.civicrm.org/dev/core/-/issues/1791):
-  [17434](https://github.com/civicrm/civicrm-core/pull/17434))**
-
 - **Deselected checkbox settings are not saved
   ([dev/core#1794](https://lab.civicrm.org/dev/core/-/issues/1794):
   [17493](https://github.com/civicrm/civicrm-core/pull/17493))**
 
-  Ensures deselected values are saved on custom fields settings forms.
+  Ensures deselected values are saved on custom field settings forms.
 
 - **Added activity types don't appear in the type dropdown on New Activity
   ([dev/core#1822](https://lab.civicrm.org/dev/core/-/issues/1822):
   [17625](https://github.com/civicrm/civicrm-core/pull/17625))**
 
-- **[regression](for real this time) API doesn't allow passing option values by
-  label ([dev/core#1816](https://lab.civicrm.org/dev/core/-/issues/1816):
+- **API doesn't allow passing option values by label
+  ([dev/core#1816](https://lab.civicrm.org/dev/core/-/issues/1816):
   [17628](https://github.com/civicrm/civicrm-core/pull/17628))**
 
   Updates APIv4 so that it matches based on label if name is not found.
@@ -286,13 +336,16 @@ Released July 1, 2020
 - **APIv4 - fix returning custom field values with API4
   ([17399](https://github.com/civicrm/civicrm-core/pull/17399))**
 
-- **[regression] Attempting to access Multi-Record Custom Field import results
+- **Attempting to access Multi-Record Custom Field import results
   in crash
   ([dev/core#1841](https://lab.civicrm.org/dev/core/-/issues/1841):
   [17713](https://github.com/civicrm/civicrm-core/pull/17713))**
 
 - **Fix issue with building smart groups when $contactQueries is empty
   ([17622](https://github.com/civicrm/civicrm-core/pull/17622))**
+
+  If a clause of a contact query used to build a smart group is empty, it would
+  result in a database error.
 
 - **replace deprecated money_format() fn to support PHP 7.4
   (Work Towards [dev/core#1494](https://lab.civicrm.org/dev/core/-/issues/1494):
@@ -307,14 +360,23 @@ Released July 1, 2020
 - **CommunityMessages - Define more consistent behavior in the face of slow
   execution ([17529](https://github.com/civicrm/civicrm-core/pull/17529))**
 
-- **set boolean fields to false if not set.
+  This helps avoid test failures on broadcast messages when the system is
+  running slowly.
+
+- **Scheduled Reminders -set boolean fields to false if not set.
   ([17494](https://github.com/civicrm/civicrm-core/pull/17494))**
 
 - **Allow bidirectional assignment of relationships from search results
   ([17413](https://github.com/civicrm/civicrm-core/pull/17413))**
 
+  Previously relationships could only be created from search results where the
+  contacts would be valid in the "A" side of the relationship type.
+
 - **Navigation menu: fix translation of new-subtype entries
   ([17451](https://github.com/civicrm/civicrm-core/pull/17451))**
+
+  The "New" in menu items for creating a new contact of a subtype was not
+  translated.
 
 - **utf8mb4 - If strict mode enabled query will fail if KEY_BLOCK_SIZE is not 0
   ([17253](https://github.com/civicrm/civicrm-core/pull/17253))**
@@ -322,8 +384,13 @@ Released July 1, 2020
 - **Update DAO and L10n Schema file
   ([17395](https://github.com/civicrm/civicrm-core/pull/17395))**
 
+  Price option name and value are now required in the database.
+
 - **Fix adding languages in multilingual
   ([17228](https://github.com/civicrm/civicrm-core/pull/17228))**
+
+  This resolves a database error when adding or removing a language on a
+  multilingual site.
 
 - **Don't exclude deleted contacts from ACL cache when user has permission
   ([17379](https://github.com/civicrm/civicrm-core/pull/17379))**
@@ -332,8 +399,8 @@ Released July 1, 2020
   ([dev/core#1760](https://lab.civicrm.org/dev/core/-/issues/1760):
   [17317](https://github.com/civicrm/civicrm-core/pull/17317))**
 
-- **Trigger fatalErrorHandler for PEAR errors and for logs with severity ERROR
-  or higher ([17277](https://github.com/civicrm/civicrm-core/pull/17277))**
+  Javascript strings that appear in Smarty are now escaped more thoroughly to
+  avoid markup problems.
 
 - **Add serialize column to civicrm_custom_field, remove "Multi-Select" html
   type ([16992](https://github.com/civicrm/civicrm-core/pull/16992))**
@@ -341,52 +408,14 @@ Released July 1, 2020
   Work towards making custom select and multi-select fields more similar to
   core select/multi-select fields.
 
-- **Fix PHP notice when is_override is not set
-  ([17273](https://github.com/civicrm/civicrm-core/pull/17273))**
-
 - **respect file fields that have been configured as view only in profiles
   ([17079](https://github.com/civicrm/civicrm-core/pull/17079))**
 
 - **Tag create: respect created_date and created_id params
   ([17257](https://github.com/civicrm/civicrm-core/pull/17257))**
 
-- **Add propertyBag handling for getEmail when incoming uses email-5
-  ([17267](https://github.com/civicrm/civicrm-core/pull/17267))**
-
 - **Public status messages should show correct class/icon like error
   ([17376](https://github.com/civicrm/civicrm-core/pull/17376))**
-
-- **Accordion open-close with Font Awesome icons
-  ([17296](https://github.com/civicrm/civicrm-core/pull/17296))**
-
-  Use Font Awesome icons instead of triangle gifs to indicate Accordion
-  open-close.
-
-- **Comm prefs: add condition param for {privacyFlag}
-  ([17307](https://github.com/civicrm/civicrm-core/pull/17307))**
-
-  Makes the {privacyFlag} icon usage more consistent.
-
-- **Member tab: auto-renew status was hidden from screen readers
-  ([17310](https://github.com/civicrm/civicrm-core/pull/17310))**
-
-- **No rendered icons in data source
-  ([17285](https://github.com/civicrm/civicrm-core/pull/17285))**
-
-- **Simplify admin console and remove superfluous icons
-  ([17284](https://github.com/civicrm/civicrm-core/pull/17284))**
-
-- **Replace stop-icon.png with fa-ban over a relevant icon for privacy
-  ([17283](https://github.com/civicrm/civicrm-core/pull/17283))**
-
-- **Replace all instances of copy.png with font awesome
-  ([17280](https://github.com/civicrm/civicrm-core/pull/17280))**
-
-- **Remove most uses of check.gif
-  ([17279](https://github.com/civicrm/civicrm-core/pull/17279))**
-
-- **Replace geotag_16.png with fa-map-marker
-  ([17281](https://github.com/civicrm/civicrm-core/pull/17281))**
 
 - **Decorative chevrons should be icons not angle quotes
   ([17245](https://github.com/civicrm/civicrm-core/pull/17245))**
@@ -396,17 +425,6 @@ Released July 1, 2020
 
 - **Proceeding to confirmation page should be a "next" button not a check
   ([17246](https://github.com/civicrm/civicrm-core/pull/17246))**
-
-- **Replaced more> icon with Font Awesome
-  ([17295](https://github.com/civicrm/civicrm-core/pull/17295))**
-
-- **Icon helper: replace quotes in html title.
-  ([17289](https://github.com/civicrm/civicrm-core/pull/17289))**
-
-- **Removed last TreePlus.gif and TreeMinus.gif spots
-  ([17297](https://github.com/civicrm/civicrm-core/pull/17297))**
-
-  Improves the UI by using icons instead of the black triangle gifs.
 
 ### CiviCase
 
@@ -423,8 +441,8 @@ Released July 1, 2020
   ([dev/core#1728](https://lab.civicrm.org/dev/core/-/issues/1728):
   [17301](https://github.com/civicrm/civicrm-core/pull/17301))**
 
-  Ensures that financial type specific custom fields are displayed on the
-  backend contribution form on refresh.
+  This ensures that financial type specific custom fields are displayed on the
+  backend contribution form when it is refreshed.
 
 - **Fix pricefield pseudoconstant.
   ([17364](https://github.com/civicrm/civicrm-core/pull/17364))**
@@ -434,6 +452,9 @@ Released July 1, 2020
 
 - **Nuance cancel options for processors
   ([17430](https://github.com/civicrm/civicrm-core/pull/17430))**
+
+  This allows payment processors to specify the way they allow cancellation of
+  recurring contributions.
 
 - **[regression] Contribution amount choices don't appear for anonymous users
   ([dev/core#1823](https://lab.civicrm.org/dev/core/-/issues/1823):
@@ -465,6 +486,10 @@ Released July 1, 2020
 - **Fix payment instrument bug by using correct payment instrument
   ([17607](https://github.com/civicrm/civicrm-core/pull/17607))**
 
+  When a backend payment form records a payment it now will use a
+  processor-specific default payment instrument rather than the site-wide
+  default if it is set.
+
 - **Payment PropertyBag - Fix setAmount
   ([17505](https://github.com/civicrm/civicrm-core/pull/17505))**
 
@@ -490,11 +515,26 @@ Released July 1, 2020
 - **Support order_reference param in API3 Payment.create
   ([17278](https://github.com/civicrm/civicrm-core/pull/17278))**
 
+- **E_WARNINGS when viewing list of pledge payments
+  ([dev/core#1791](https://lab.civicrm.org/dev/core/-/issues/1791):
+  [17434](https://github.com/civicrm/civicrm-core/pull/17434))**
+
+- **Add propertyBag handling for getEmail when incoming uses email-5
+  ([17267](https://github.com/civicrm/civicrm-core/pull/17267))**
+
+  Payment processors can now retrieve billing email using the `propertyBag`
+  class methods.
+
 ### CiviMail
 
 - **Don't log subscription_history
   ([dev/core#1762](https://lab.civicrm.org/dev/core/-/issues/1762):
   [17323](https://github.com/civicrm/civicrm-core/pull/17323))**
+
+  The `civicrm_subscription_history` table is effectively a log of contacts
+  being added to and removed from groups.  Rows do not change value; each change
+  in group subscription results in a new row.  Consequently, there is no reason
+  to attach detailed logging to this table.
 
 - **Unsubscribe generates 500 server error responses, logs say "missing
   parameters" ([dev/core#1773](https://lab.civicrm.org/dev/core/-/issues/1773):
@@ -509,16 +549,21 @@ Released July 1, 2020
   ([dev/core#1608](https://lab.civicrm.org/dev/core/-/issues/1608):
   [17355](https://github.com/civicrm/civicrm-core/pull/17355))**
 
-- **Memberships of disabled membership types do not appear on the membership tab
-  BUT do throw duplicate Membership Warning
+- **Don't hide disabled memberships from the contact membership tab
   ([dev/membership#24](https://lab.civicrm.org/dev/membership/-/issues/24):
   [17143](https://github.com/civicrm/civicrm-core/pull/17143) and
   [17435](https://github.com/civicrm/civicrm-core/pull/17435))**
 
-  Adds a unit test to lock in the correct behavior.
+  This resolves a problem where memberships of disabled membership types would
+  not appear on the membership tab but would throw a duplicate membership
+  warning when creating a new membership with the same membership organization.
+  This also adds a unit test to lock in the correct behavior.
 
 - **Update MembershipType.name to be a required field
   ([17463](https://github.com/civicrm/civicrm-core/pull/17463))**
+
+- **Fix PHP notice when is_override is not set
+  ([17273](https://github.com/civicrm/civicrm-core/pull/17273))**
 
 ### Joomla Integration
 
@@ -537,18 +582,22 @@ Released July 1, 2020
 
   The base logic for computing path/URL defaults is in Civi/Core/Paths.php.
 
-  For Civi-WP, certain variables (which are easier to compute via WP APIs) are
-  overridden in CRM/Utils/System/WordPress.php.
+  For CiviCRM on WordPress, certain variables (which are easier to compute via
+  WordPress APIs) are overridden in `CRM_Utils_System_WordPress`.
 
-  On WP, the path/URL logic for has been split: One codepath for normal Civi
-  pages - based on WP APIs and another codepath for older, standalone extern
-  scripts - based on the same logic as before
+  On WordPress, the path/URL logic for has been split: there is one code path
+  for normal CiviCRM pages which is based on WordPress APIs, and there is
+  another for older, standalone scripts in the `extern` folder which is based on
+  the same logic as before.
 
 - **Declare Minimum WP and PHP versions required for installation
   ([201](https://github.com/civicrm/civicrm-wordpress/pull/201))**
 
 - **wp-rest - Adjust extern URL. Be more defensive about 'query' part.
   ([192](https://github.com/civicrm/civicrm-wordpress/pull/192))**
+
+  This resolves issues with tracking URLs via the `wp-rest` endpoint that are
+  then modified with `hook_civicrm_alterExternUrl`.
 
 ## <a name="misc"></a>Miscellany
 
@@ -827,7 +876,7 @@ reviewers contributed their comments:
 Agileware - Justin Freeman; Artful Robot - Rich Lott; Betty Dolfing; CiviCoop -
 Jaap Jansma; iXiam - Luciano Spiegel; JMA Consulting - Monish Deb; Kartik
 Kathuria; Korlon - Stuart Gaston; Megaphone Technology Consulting - Dennis P.
-Osorio; Squiffle Consulting - Aidan Saunders;
+Osorio; Squiffle Consulting - Aidan Saunders
 
 ## <a name="feedback"></a>Feedback
 


### PR DESCRIPTION
It's ready to go.  There are a couple of late PRs I opened that clarify system check wording.  See #17728 and #17730 .  If they're merged, lines 30 and 352 will need to be updated, respectively, to add the additional PRs. @seamuslee001 you might want to see if they're acceptable edits since they relate to changes you made.