### PR TITLE
sql/test_data_second_domain.mysql - Always use matching version

### DIFF
--- a/Civi/Test/Data.php
+++ b/Civi/Test/Data.php
@@ -32,6 +32,7 @@ class Data {
       if (\Civi\Test::execute($query2) === FALSE) {
         throw new RuntimeException("Cannot load civicrm_data.mysql. Aborting.");
       }
+      print_r(\Civi\Test::pdo()->query("SELECT id, version FROM civicrm_domain")->fetchAll());
       if (\Civi\Test::execute($query3) === FALSE) {
         throw new RuntimeException("Cannot load test_data.mysql. Aborting.");
       }

--- a/sql/test_data_second_domain.mysql
+++ b/sql/test_data_second_domain.mysql
@@ -1,3 +1,4 @@
+  SELECT @domainVersion := version FROM civicrm_domain LIMIT 1;
   SET @domainName := 'Second Domain';
   INSERT INTO civicrm_contact(sort_name, display_name, contact_type, organization_name)
   VALUES (@domainName, @domainName, 'Organization', @domainName);
@@ -27,7 +28,7 @@ INSERT INTO civicrm_loc_block ( address_id, email_id, phone_id, address_2_id, em
 SELECT @locBlockId := id from civicrm_loc_block where phone_id = @phoneId AND email_id = @emailId AND address_id = @addId;
 
   INSERT INTO civicrm_domain
-  (name, version,contact_id) VALUES (@domainName, '4.2', @contactID);
+  (name, version,contact_id) VALUES (@domainName, @domainVersion, @contactID);
   SELECT @domainID := id FROM civicrm_domain where name = 'Second Domain';
   INSERT INTO
    `civicrm_option_value` (`option_group_id`, `label`, `value`, `name`, `grouping`, `filter`, `is_default`, `weight`, `description`, `is_optgroup`, `is_reserved`, `is_active`, `component_id`, `domain_id`, `visibility_id`)
@@ -963,4 +964,3 @@ INSERT INTO civicrm_navigation
 VALUES
     ( @domainID, CONCAT('civicrm/report/instance/', @instanceID,'&reset=1'), 'Mailing Detail Report', 'Mailing Detail Report', 'administer CiviMail', 'OR', @reportlastID, '1', NULL, @instanceID+2 );
 UPDATE civicrm_report_instance SET navigation_id = LAST_INSERT_ID() WHERE id = @instanceID;
-UPDATE civicrm_domain SET version = '5.28.alpha1';


### PR DESCRIPTION
Overview
----------------------------------------
The file `test_data_second_domain.mysql` is used by some test scripts to create extra sample data (i.e. in addition to the default domain, this creates a secondary domain). It has a stale element which caused some confusion in #17729.

Before
----------------------------------------
`test_data_second_domain.mysql` has a hard-coded `version` number. It is very stale. This creates a nonsensical configuration where there are two domains but they are flagged with different versions.

After
----------------------------------------
When creating the secondary domain, it uses the same `version` as the main domain.