### PR TITLE
Fix saving of State/Province Multi-select values

### DIFF
--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -1361,6 +1361,7 @@ ORDER BY civicrm_custom_group.weight,
                 }
               }
               else {
+                // Values may be "array strings" or actual arrays. Handle both.
                 if (is_array($value) && count($value)) {
                   CRM_Utils_Array::formatArrayKeys($value);
                   $checkedValue = $value;
@@ -1383,7 +1384,14 @@ ORDER BY civicrm_custom_group.weight,
           }
           else {
             if (isset($value)) {
-              $checkedValue = explode(CRM_Core_DAO::VALUE_SEPARATOR, $value);
+              // Values may be "array strings" or actual arrays. Handle both.
+              if (is_array($value) && count($value)) {
+                CRM_Utils_Array::formatArrayKeys($value);
+                $checkedValue = $value;
+              }
+              else {
+                $checkedValue = explode(CRM_Core_DAO::VALUE_SEPARATOR, substr($value, 1, -1));
+              }
               foreach ($checkedValue as $val) {
                 if ($val) {
                   $defaults[$elementName][$val] = $val;


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [this issue on Lab](https://lab.civicrm.org/dev/core/-/issues/1851).

A Custom Field of type State/Province Multi-select fails to save values when attached to an Event and "Is this Field Searchable?" is set to `false`. Reproduced on WPMaster and DMaster demo sites for a CiviEvent. I haven't checked if this is exclusive to Events, but can see the solution and will open a PR in due course.

Reproduction steps
----------------------------------------
1. Create a set of Custom Fields and attach to to "Event"
1. Add a field of data type "State/Province" and field type "Select State/Province"
1. Enable "Multi-Select" and disable "Is this Field Searchable?"
1. Visit a "Configure Event" page and select some "State/Province" values
1. Submit the form to save the event - State/Province" values are saved
1. Submit the form again to save the event - State/Province" values are lost

Current behaviour
----------------------------------------
Following the above procedure (line refs are for 5.26.2) throws the following warnings:

```
[02-Jul-2020 12:59:29 Europe/London] PHP Warning:  explode() expects parameter 2 to be string, array given in /path/to/CRM/Core/BAO/CustomGroup.php on line 1383
[02-Jul-2020 12:59:29 Europe/London] PHP Warning:  Invalid argument supplied for foreach() in /path/to/CRM/Core/BAO/CustomGroup.php on line 1384
```

The WPMaster and DMaster logs will show similar entries.

Expected behaviour
----------------------------------------
The incoming data should be parsed in the same way that [this commit](https://github.com/civicrm/civicrm-core/commit/fb56e9640b4380f2f76b72da2031d37e67165045#diff-d9f1be3fcfd7cea0a4864a21997c258aR1384-R1390) implements. Doing so fixes the problem.