### PR TITLE
(dev/core#1846) Ensure that the `Container` is always fresh when upgrading

### DIFF
--- a/CRM/Core/Config/Runtime.php
+++ b/CRM/Core/Config/Runtime.php
@@ -141,6 +141,14 @@ class CRM_Core_Config_Runtime extends CRM_Core_Config_MagicMerge {
         defined('CIVICRM_DOMAIN_ID') ? CIVICRM_DOMAIN_ID : 1,
         // e.g. one codebase, multi database
         parse_url(CIVICRM_DSN, PHP_URL_PATH),
+
+        // e.g. when you load a new version of the codebase, use different caches
+        // Note: in principle, the version number is just a proxy for a dozen other signals (new versions of file A, B, C).
+        // Proper caches should reset whenever the underlying signal (file A, B, or C) changes. However, bugs in this
+        // behavior often go un-detected during dev/test. Including the software-version basically mitigates the problem
+        // for sysadmin-workflows - so that such bugs should only impact developer-workflows.
+        \CRM_Utils_System::version(),
+
         // e.g. CMS vs extern vs installer
         \CRM_Utils_Array::value('SCRIPT_FILENAME', $_SERVER, ''),
         // e.g. name-based vhosts


### PR DESCRIPTION
Overview
---------

CiviCRM has a "container cache" (`CachedCiviContainer.XXX.php`) to organize the loading of various resources.

Generally, the "container cache" should auto-update whenever the corresponding CiviCRM code changes. However, there still appear to be some scenarios where it doesn't - which can lead to failures. For example, [this comment](https://lab.civicrm.org/dev/core/-/issues/1846#note_39634) reported an upgrade failure involving the resource `ContactSchemaMapSubscriber` -- that was removed in 5.27. The failure message implies that a stale copy of `CachedCiviContainer.XXX.php` retained a reference to `ContactSchemaMapSubscriber`.

```
Error: Class 'Civi\Api4\Event\Subscriber\ContactSchemaMapSubscriber' not found in
CachedCiviContainer->getCiviApi4EventSubscriberContactschemamapsubscriberService()
(line 426 of /home/webadmin/public_html/XXX/sites/default/files/civicrm/templates_/
CachedCiviContainer.XXX3a1bd2c1b046653ce2f7b8bfb2a5.php).
```

Before
------

When upgrading, the `CachedCiviContainer.XXX.php` performs its regular freshness check. This ordinarily causes it to refresh `CachedCiviContainer.XXX.php`. However, if (for any reason), the freshness check doesn't work - then it may complain.

After
-----

When upgrading, the cache filename `CachedCiviContainer.XXX.php`  changes (ie by choosing a different value of `XXX`). It will not read the old file - and it will only create a new/fresh file that matches the current version.

Comments
-----------

I could not reproduce the reported error organically with an upgrade from 5.26 to 5.27. To reproduce it, I had to use this procedure:

- Install v5.26
- Edit `civicrm.settings.php` to set `define('CIVICRM_CONTAINER_CACHE', 'always');`
- Switch to v5.27

In theory, the error might also happen if you upgrade from an older/buggier version - for example, in v5.24, it had a bug which put incomplete metadata into `CachedCiviContainer.XXX.php`. The bug in v5.24 could prevent it from rebuilding the file automatically on v5.27.

With the change in this patch, someone performing an upgrade should get a clean `CachedCiviContainer` *even if* the settings are weird (`CIVICRM_CONTAINER_CACHE`) and *even if* the previously-installed version had a bug.