### PR TITLE
Improve efficiency of findFiles

### DIFF
--- a/CRM/Utils/File.php
+++ b/CRM/Utils/File.php
@@ -753,9 +753,16 @@ HTACCESS;
    * @return array(string)
    */
   public static function findFiles($dir, $pattern, $relative = FALSE) {
-    if (!is_dir($dir)) {
+    if (!is_dir($dir) || !is_readable($dir)) {
       return [];
     }
+    // Which dirs should we exclude from our searches?
+    // If not defined, we default to excluding any dirname that begins
+    // with a . which is the old behaviour and therefore excludes .git/
+    $excludeDirsPattern = defined('CIVICRM_EXCLUDE_DIRS_PATTERN')
+      ? constant('CIVICRM_EXCLUDE_DIRS_PATTERN')
+      : '@' . preg_quote(DIRECTORY_SEPARATOR) . '\.@';
+
     $dir = rtrim($dir, '/');
     $todos = [$dir];
     $result = [];
@@ -769,13 +776,21 @@ HTACCESS;
           }
         }
       }
+      // Find subdirs to recurse into.
       if ($dh = opendir($subdir)) {
         while (FALSE !== ($entry = readdir($dh))) {
           $path = $subdir . DIRECTORY_SEPARATOR . $entry;
-          if ($entry{0} == '.') {
-            // ignore
-          }
-          elseif (is_dir($path)) {
+          // Exclude . (self) and .. (parent) to avoid infinite loop.
+          // Exclude configured exclude dirs.
+          // Exclude dirs we can't read.
+          // Exclude anything that's not a dir.
+          if (
+            $entry !== '.'
+            && $entry !== '..'
+            && (empty($excludeDirsPattern) || !preg_match($excludeDirsPattern, $path))
+            && is_dir($path)
+            && is_readable($path)
+          ) {
             $todos[] = $path;
           }
         }

--- a/templates/CRM/common/civicrm.settings.php.template
+++ b/templates/CRM/common/civicrm.settings.php.template
@@ -503,6 +503,27 @@ if (CIVICRM_UF === 'UnitTests') {
 // }
 
 /**
+ * Which directories should we exclude when scanning the codebase for things
+ * like extension .info files, or .html partials or .xml files etc. This needs
+ * to be a valid preg_match() pattern.
+ *
+ * If you do not define it, a pattern that excludes dirs starting with a dot is
+ * used, e.g. to exclude .git/). Adding suitable patterns here can vastly speed
+ * up your container rebuilds and cache flushes. The pattern is matched against
+ * the absolute path. Remember to use your system's DIRECTORY_SEPARATOR the
+ * examples below assume /
+ *
+ * Example: This excludes node_modules (can be huge), various CiviCRM dirs that
+ * are unlikely to have anything we need to scan inside, and (what could be
+ * your) Drupal's private file storage area.
+ *
+ * '@/(\.|node_modules|js/|css/|bower_components|packages/|vendor/|sites/default/files/private)@'
+ */
+// if (!defined('CIVICRM_EXCLUDE_DIRS_PATTERN')) {
+//   define('CIVICRM_EXCLUDE_DIRS_PATTERN', '@/\.@');
+// }
+
+/**
  *
  * Do not change anything below this line. Keep as is
  *


### PR DESCRIPTION
Overview
----------------------------------------

findFiles is slow because it:

- scans loads of dirs it shouldn't need to
- tries and fails to scan dirs it does not have access to, leading to log writes


Before
----------------------------------------

- findFiles did not check if a dir was readable before opening it.
- findFiles only excluded dirs beginning with a .
- cold scan on one site took 4.3s, warm scan (i.e. repeat straight away) took 1.7s

After
----------------------------------------

- findFiles does check if a dir is readable before opening it.
- optional constant can be defined locally to help findFiles exclude irrelevant dirs
- default exclude pattern keeps original behaviour
- (with locally-suitable configured regex) cold scan took 0.5s, warm scan took 0.45s

