### PR TITLE
Fix typo in templates/CRM/Report/Form/Tabs/GroupBy.tpl

### DIFF
--- a/templates/CRM/Report/Form/Tabs/GroupBy.tpl
+++ b/templates/CRM/Report/Form/Tabs/GroupBy.tpl
@@ -13,11 +13,11 @@
       <tr class="crm-report crm-report-criteria-groupby">
         {foreach from=$groupByElements item=gbElem key=dnc}
         {assign var="count" value=`$count+1`}
-        <td width="25%" {if $form.fields.$gbElem}"{/if}>
-        {$form.group_bys[$gbElem].html}
-        {if $form.group_bys_freq[$gbElem].html}:<br>
-          &nbsp;&nbsp;{$form.group_bys_freq[$gbElem].label}&nbsp;{$form.group_bys_freq[$gbElem].html}
-        {/if}
+        <td width="25%">
+          {$form.group_bys[$gbElem].html}
+          {if $form.group_bys_freq[$gbElem].html}:<br>
+            &nbsp;&nbsp;{$form.group_bys_freq[$gbElem].label}&nbsp;{$form.group_bys_freq[$gbElem].html}
+          {/if}
         </td>
         {if $count is div by 4}
       </tr><tr class="crm-report crm-report-criteria-groupby">


### PR DESCRIPTION
Overview
----------------------------------------

In Reports, under the Group By section, there is a typo in the HTML, without a visual impact, but rather odd.

I'm not too sure how to trigger the behaviour on a default report. I was fiddling with a custom report (https://lab.civicrm.org/extensions/membershipreport) when I noticed it, but it wasn't happening on dmaster with the Contribution Detail report, because for some reason gbElem is not true.