### PR TITLE
dev/drupal#114 and dev/core#1647 - Remove resource url status check

### DIFF
--- a/CRM/Utils/Check/Component/Env.php
+++ b/CRM/Utils/Check/Component/Env.php
@@ -847,36 +847,6 @@ class CRM_Utils_Check_Component_Env extends CRM_Utils_Check_Component {
   }
 
   /**
-   * Check that the resource URL points to the correct location.
-   * @return array
-   */
-  public function checkResourceUrl() {
-    $messages = [];
-    // Skip when run during unit tests, you can't check without a CMS.
-    if (CRM_Core_Config::singleton()->userFramework == 'UnitTests') {
-      return $messages;
-    }
-    // CRM-21629 Set User Agent to avoid being blocked by filters
-    stream_context_set_default([
-      'http' => ['user_agent' => 'CiviCRM'],
-    ]);
-
-    // Does arrow.png exist where we expect it?
-    $arrowUrl = CRM_Core_Config::singleton()->userFrameworkResourceURL . 'packages/jquery/css/images/arrow.png';
-    if ($this->fileExists($arrowUrl) === FALSE) {
-      $messages[] = new CRM_Utils_Check_Message(
-        __FUNCTION__,
-        ts('The Resource URL is not set correctly. Please set the <a href="%1">CiviCRM Resource URL</a>.',
-          [1 => CRM_Utils_System::url('civicrm/admin/setting/url', 'reset=1')]),
-        ts('Incorrect Resource URL'),
-        \Psr\Log\LogLevel::ERROR,
-        'fa-server'
-      );
-    }
-    return $messages;
-  }
-
-  /**
    * Check for utf8mb4 support by MySQL.
    *
    * @return array<CRM_Utils_Check_Message> an empty array, or a list of warnings


### PR DESCRIPTION
Overview
----------------------------------------
This check is driving several people nuts.

It made sense at the time it was introduced - my understanding is it mimicked the small missing arrow in the menus, which was subtle and so it wasn't obvious there was a problem or what it was. But:

* The arrow it checks for is no longer used in the menus,
* The check is ALWAYS a false negative in drupal 8 (and I understand maybe wordpress too),
* It's a false negative if using a self-signed certificate,
* And the symptoms are no longer subtle so it doesn't require a check. Now if resources can't be loaded then typically your menus are completely messed up.

It could maybe be replaced with something else, but want to wait to see what happens with https://lab.civicrm.org/dev/core/-/issues/1647.

Before
----------------------------------------
False negatives.

After
----------------------------------------
Better

Technical Details
----------------------------------------
It assumes packages is under userFrameworkResourceUrl, but it no longer always is.

Comments
----------------------------------------

