### PR TITLE
Fix PHP notice on wordpress permissions form

### DIFF
--- a/CRM/ACL/Form/WordPress/Permissions.php
+++ b/CRM/ACL/Form/WordPress/Permissions.php
@@ -135,7 +135,7 @@ class CRM_ACL_Form_WordPress_Permissions extends CRM_Core_Form {
       }
 
       //Add the selected wordpress capabilities for the role
-      $rolePermissions = $params[$role];
+      $rolePermissions = $params[$role] ?? [];
       if (!empty($rolePermissions)) {
         foreach ($rolePermissions as $key => $capability) {
           $roleObj->add_cap($key);


### PR DESCRIPTION
Overview
----------------------------------------
Sometimes $params[$role] is not set and you get a PHP notice.

Before
----------------------------------------
PHP notice if `$params[$role]` is not set.

After
----------------------------------------
No PHP notice.

Technical Details
----------------------------------------
Happened when updating a wordpress role to add additional permissions. Undefined index was "administrator".

Comments
----------------------------------------

