### PR TITLE
Ensure that when normal routing trackable urls and opens in Joomla go…

### DIFF
--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -333,7 +333,7 @@ class CRM_Utils_System {
      * @return \Psr\Http\Message\UriInterface
      */
     $mkRouteUri = function ($path, $query) use ($e) {
-      $urlTxt = CRM_Utils_System::url($path, $query, $e->absolute, $e->fragment, FALSE);
+      $urlTxt = CRM_Utils_System::url($path, $query, $e->absolute, $e->fragment, FALSE, TRUE);
       if ($e->isSSL || ($e->isSSL === NULL && \CRM_Utils_System::isSSL())) {
         $urlTxt = str_replace('http://', 'https://', $urlTxt);
       }

--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -272,7 +272,7 @@ class CRM_Utils_System {
     }
 
     $config = CRM_Core_Config::singleton();
-    $url = $config->userSystem->url($path, $query, $absolute, $fragment, $frontend, $forceBackend);
+    $url = $config->userSystem->url($path, $query, $absolute, $fragment, $frontend, $forceBackend, $htmlize);
 
     if ($htmlize) {
       $url = htmlentities($url);

--- a/CRM/Utils/System/Base.php
+++ b/CRM/Utils/System/Base.php
@@ -124,6 +124,8 @@ abstract class CRM_Utils_System_Base {
    *   This link should be to the CMS front end (applies to WP & Joomla).
    * @param bool $forceBackend
    *   This link should be to the CMS back end (applies to WP & Joomla).
+   * @param bool $htmlize
+   *   Whether to encode special html characters such as &.
    *
    * @return string
    */
@@ -133,7 +135,8 @@ abstract class CRM_Utils_System_Base {
     $absolute = FALSE,
     $fragment = NULL,
     $frontend = FALSE,
-    $forceBackend = FALSE
+    $forceBackend = FALSE,
+    $htmlize = TRUE
   ) {
     return NULL;
   }

--- a/CRM/Utils/System/Drupal8.php
+++ b/CRM/Utils/System/Drupal8.php
@@ -280,7 +280,8 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
     $absolute = FALSE,
     $fragment = NULL,
     $frontend = FALSE,
-    $forceBackend = FALSE
+    $forceBackend = FALSE,
+    $htmlize = TRUE
   ) {
     $query = html_entity_decode($query);
 

--- a/CRM/Utils/System/DrupalBase.php
+++ b/CRM/Utils/System/DrupalBase.php
@@ -153,7 +153,8 @@ abstract class CRM_Utils_System_DrupalBase extends CRM_Utils_System_Base {
     $absolute = FALSE,
     $fragment = NULL,
     $frontend = FALSE,
-    $forceBackend = FALSE
+    $forceBackend = FALSE,
+    $htmlize = TRUE
   ) {
     $config = CRM_Core_Config::singleton();
     $script = 'index.php';

--- a/CRM/Utils/System/Joomla.php
+++ b/CRM/Utils/System/Joomla.php
@@ -239,7 +239,8 @@ class CRM_Utils_System_Joomla extends CRM_Utils_System_Base {
     $absolute = FALSE,
     $fragment = NULL,
     $frontend = FALSE,
-    $forceBackend = FALSE
+    $forceBackend = FALSE,
+    $htmlize = TRUE
   ) {
     $config = CRM_Core_Config::singleton();
     $separator = '&';

--- a/CRM/Utils/System/Soap.php
+++ b/CRM/Utils/System/Soap.php
@@ -43,7 +43,7 @@ class CRM_Utils_System_Soap extends CRM_Utils_System_Base {
   /**
    * @inheritDoc
    */
-  public function url($path = NULL, $query = NULL, $absolute = TRUE, $fragment = NULL) {
+  public function url($path = NULL, $query = NULL, $absolute = TRUE, $fragment = NULL, $frontend = FALSE, $forceBackend = FALSE, $htmlize = TRUE) {
     if (isset(self::$ufClass)) {
       $className = self::$ufClass;
       $url = $className::url($path, $query, $absolute, $fragment);

--- a/CRM/Utils/System/UnitTests.php
+++ b/CRM/Utils/System/UnitTests.php
@@ -75,9 +75,9 @@ class CRM_Utils_System_UnitTests extends CRM_Utils_System_Base {
     $query = NULL,
     $absolute = FALSE,
     $fragment = NULL,
-    $htmlize = TRUE,
     $frontend = FALSE,
-    $forceBackend = FALSE
+    $forceBackend = FALSE,
+    $htmlize = TRUE
   ) {
     $config = CRM_Core_Config::singleton();
     static $script = 'index.php';

--- a/CRM/Utils/System/UnitTests.php
+++ b/CRM/Utils/System/UnitTests.php
@@ -92,7 +92,7 @@ class CRM_Utils_System_UnitTests extends CRM_Utils_System_Base {
     }
     $base = $absolute ? $config->userFrameworkBaseURL : $config->useFrameworkRelativeBase;
 
-    $separator = $htmlize ? '&amp;' : '&';
+    $separator = ($htmlize && $frontend) ? '&amp;' : '&';
 
     if (!$config->cleanURL) {
       if (isset($path)) {

--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -265,7 +265,8 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
     $absolute = FALSE,
     $fragment = NULL,
     $frontend = FALSE,
-    $forceBackend = FALSE
+    $forceBackend = FALSE,
+    $htmlize = TRUE
   ) {
     $config = CRM_Core_Config::singleton();
     $script = '';


### PR DESCRIPTION
… to the frontend not administrator site

Overview
----------------------------------------
When sending out a bulk email in Joomla using the normal routing, The urls are currently after https://github.com/civicrm/civicrm-core/commit/a5949c8f3d98f16d8739e82a7aaa1742b724dba9 are generated to access via the backend rather than the front end as reported by @andrewpthompson 

Before
----------------------------------------
Backend urls generated

After
----------------------------------------
Front end urls are generated

ping @eileenmcnaughton @totten @kcristiano 