### PR TITLE
dev/core#1847 Fix datepicker to respect the searchDate offsets

### DIFF
--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -359,6 +359,8 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
    *
    * @return HTML_QuickForm_Element
    *   Could be an error object
+   *
+   * @throws \CRM_Core_Exception
    */
   public function &add(
     $type, $name, $label = '',
@@ -385,8 +387,19 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
       unset($attributes['multiple']);
       $extra = NULL;
     }
+
     // @see https://docs.civicrm.org/dev/en/latest/framework/ui/#date-picker
-    if ($type == 'datepicker') {
+    if ($type === 'datepicker') {
+      $attributes = $attributes ?: [];
+      if (!empty($attributes['format'])) {
+        $dateAttributes = CRM_Core_SelectValues::date($attributes['format'], NULL, NULL, NULL, 'Input');
+        if (empty($extra['minDate']) && !empty($dateAttributes['minYear'])) {
+          $extra['minDate'] = $dateAttributes['minYear'] . '-01-01';
+        }
+        if (empty($extra['maxDate']) && !empty($dateAttributes['minYear'])) {
+          $extra['maxDate'] = $dateAttributes['maxYear'] . '-12-31';
+        }
+      }
       // Support minDate/maxDate properties
       if (isset($extra['minDate'])) {
         $extra['minDate'] = date('Y-m-d', strtotime($extra['minDate']));
@@ -395,14 +408,13 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
         $extra['maxDate'] = date('Y-m-d', strtotime($extra['maxDate']));
       }
 
-      $attributes = ($attributes ? $attributes : []);
       $attributes['data-crm-datepicker'] = json_encode((array) $extra);
       if (!empty($attributes['aria-label']) || $label) {
         $attributes['aria-label'] = CRM_Utils_Array::value('aria-label', $attributes, $label);
       }
       $type = "text";
     }
-    if ($type == 'select' && is_array($extra)) {
+    if ($type === 'select' && is_array($extra)) {
       // Normalize this property
       if (!empty($extra['multiple'])) {
         $extra['multiple'] = 'multiple';


### PR DESCRIPTION
Overview
----------------------------------------
This restores previous behaviour where search datepicker fields had date ranges bounded by the values configured on the date preferences screenn
<img alt="config screen" src="https://lab.civicrm.org/dev/core/uploads/96847ace7528adc16ad37a7ad42692ed/pref.png">

Before
----------------------------------------
(with default range of 20 years offset in either direction)
<img width="419" alt="before screen shot" src="https://lab.civicrm.org/dev/core/uploads/1d56258d69093584213d945beb1bad0f/daterange.gif">

After
----------------------------------------
(with default range of 20 years offset in either direction)
<img width="419" alt="Screen Shot 2020-07-06 at 1 48 51 PM" src="https://user-images.githubusercontent.com/336308/86548291-f6cbc780-bf8f-11ea-8dd4-7bb3e85556e4.png">


Technical Details
----------------------------------------
The min and max year are from civicrm_preferences_date table

Comments
----------------------------------------
I have some misgivings about this since I suspect the rationale behind the search offsets was primarily about the clunky UI.

Having said that I think the datepicker UI is a bit clunky on this front too as it's not obvious you can choose earlier
dates. This does at least restore established behaviour.

https://lab.civicrm.org/dev/core/-/issues/1847

ping @colemanw @seamuslee001 @mattwire @yashodha 