### PR TITLE
dev/core#1853 - Fix validation errors when removing contact subtype

### DIFF
--- a/CRM/Contact/Form/Contact.php
+++ b/CRM/Contact/Form/Contact.php
@@ -367,8 +367,8 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
       else {
         $contactSubType = $this->_contactSubType;
         // need contact sub type to build related grouptree array during post process
-        if (!empty($_POST['contact_sub_type'])) {
-          $contactSubType = $_POST['contact_sub_type'];
+        if (!empty($_POST['qfKey'])) {
+          $contactSubType = $_POST['contact_sub_type'] ?? NULL;
         }
         //only custom data has preprocess hence directly call it
         CRM_Custom_Form_CustomData::preProcess($this, NULL, $contactSubType,


### PR DESCRIPTION
Overview
----------------------------------------
Fixes the bug documented in https://lab.civicrm.org/dev/core/-/issues/1853

Before
----------------------------------------
Removing contact sub-type could cause validation errors if there were required custom fields specific to that sub-type.

After
----------------------------------------
Works normally.
