### PR TITLE
dev/core#1858 Prevent Duplicate contact records being created and har…

### DIFF
--- a/CRM/Core/BAO/UFMatch.php
+++ b/CRM/Core/BAO/UFMatch.php
@@ -191,6 +191,12 @@ class CRM_Core_BAO_UFMatch extends CRM_Core_DAO_UFMatch {
       if (!empty($_POST) && !$isLogin) {
         $params = $_POST;
         $params['email'] = $uniqId;
+        // dev/core#1858 Ensure that if we have a contactID parameter which is set in the Create user Record contact task form
+        // That this contacID value is passed through as the contact_id to the get duplicate contacts function. This is necessary because for Drupal 8 this function gets invoked
+        // Before the civicrm_uf_match record is added where as in D7 it isn't called until the user tries to actually login.
+        if (!empty($params['contactID'])) {
+          $params['contact_id'] = $params['contactID'];
+        }
 
         $ids = CRM_Contact_BAO_Contact::getDuplicateContacts($params, 'Individual', 'Unsupervised', [], FALSE);
 


### PR DESCRIPTION
…d fatal errors when creating a CMS user account from the contact action by ensuring that the contact_id field is correctly passed through for dedupe matching

Overview
----------------------------------------
Reproduction steps are on the lab ticket https://lab.civicrm.org/dev/core/-/issues/1858 but the key aspect of the reproduction steps is having an unsupervised dedupe rule for individuals that requires not just a match on email address to work

Before
----------------------------------------
DB error / duplicate contact created

After
----------------------------------------
No DB Error / no duplicate contact record created

ping @demeritcowboy @eileenmcnaughton @mlutfy @KarinG @kcristiano 