### PR TITLE
Remove check for valid email in synchronizeUFMatch

### DIFF
--- a/CRM/Core/BAO/UFMatch.php
+++ b/CRM/Core/BAO/UFMatch.php
@@ -171,12 +171,6 @@ class CRM_Core_BAO_UFMatch extends CRM_Core_DAO_UFMatch {
    */
   public static function &synchronizeUFMatch(&$user, $userKey, $uniqId, $uf, $status = NULL, $ctype = NULL, $isLogin = FALSE) {
     $config = CRM_Core_Config::singleton();
-
-    if (!CRM_Utils_Rule::email($uniqId)) {
-      $retVal = $status ? NULL : FALSE;
-      return $retVal;
-    }
-
     $newContact = FALSE;
 
     // make sure that a contact id exists for this user id


### PR DESCRIPTION
Overview
----------------------------------------
Recently I was asked to look at a Wordpress + CiviCRM site which was triggering all sorts of errors and not working properly. I traced it to `userID` not being set on the session when logged in and `CRM_Core_Session::getLoggedInContactID()` returning NULL. Hardcoding or clearing the userID field in the session here "fixed" the issue until the next login.

It turns out that this was all triggered because `CRM_Core_BAO_UFMatch::synchronizeUFMatch()` is checking that `$uniqId` is a valid email address. On this staging site it was not (according to PHP `filter_var`) because the email was suffixed with `_test`. So instead of syncing the user login and setting the session variables properly it silently returned FALSE in this function.

The alternative is just to emit a log message in this case which might be a safer change but I don't know why we would need to check for email validity here as the CMS will already do that and there is no issue storing an "invalid" email like this in the database.

Before
----------------------------------------
Silent session failure.

After
----------------------------------------
An invalid email (according to PHP filter_var) won't cause a logged in session to fail silently and horribly (things like the Civi user dashboard goes into an infinite loop and tries to load an infinite number of dashlets).

Technical Details
----------------------------------------
Described above.

Comments
----------------------------------------

