### PR TITLE
dev/core#1860 Fix installing on PHP7.3 Ubuntu 20.04 and MariaDB 10.3

### DIFF
--- a/install/index.php
+++ b/install/index.php
@@ -1069,8 +1069,14 @@ class InstallRequirements {
         return TRUE;
       }
       else {
-        $testDetails[2] .= "{$majorHas}.{$minorHas}.";
-        $this->error($testDetails);
+        $versionDetails = mysqli_query($this->conn, 'SELECT version() as version')->fetch_assoc();
+        if (version_compare($versionDetails['version'], $min) == -1) {
+          $testDetails[2] .= "{$majorHas}.{$minorHas}.";
+          $this->error($testDetails);
+        }
+        else {
+          return TRUE;
+        }
       }
     }
   }


### PR DESCRIPTION
Overview
----------------------------------------
This fixes an issue where by the mysqli_server_info may prepend something like 5.5.5  to the front of the MySQL server version depending on the exact MySQL version your running

Before
----------------------------------------
Installation fails on the above configuration

After
----------------------------------------
Installation works on the above configuration

ping @kcristiano @demeritcowboy 