### PR TITLE
Status Checks - Use more specific label regarding "Domain"/"Organization" check

### DIFF
--- a/CRM/Utils/Check/Component/Env.php
+++ b/CRM/Utils/Check/Component/Env.php
@@ -218,7 +218,7 @@ class CRM_Utils_Check_Component_Env extends CRM_Utils_Check_Component {
       $messages[] = new CRM_Utils_Check_Message(
         __FUNCTION__,
         $msg,
-        ts('Complete Setup'),
+        ts('Organization Setup'),
         \Psr\Log\LogLevel::WARNING,
         'fa-check-square-o'
       );


### PR DESCRIPTION
Before
------

Suppose you install CiviCRM anew.  The installer shows a bulleted list of things to do.  One of those takes you to another, much longer list of things to do.  And *then* there's a popup on the sidebar which says you need to "Complete Setup".

You say to yourself, "I thought that's what I was doing!" But you click it anyway.

That takes you to a page with another list of things to do, one of which is to "Complete Setup".  The text and link clarify that "Complete Setup" actually means *set the name and address of the organization*.

![Screen Shot 2020-07-08 at 3 15 40 PM](https://user-images.githubusercontent.com/1336047/86975797-f49f6f80-c12d-11ea-89bb-c1893b4915db.png)

After
-----

There are still several different pages telling you what to do after setup.

But at least the label is more precise. :)

![Screen Shot 2020-07-08 at 3 15 05 PM](https://user-images.githubusercontent.com/1336047/86975795-f406d900-c12d-11ea-8a20-687868678ffa.png)
