### PR TITLE
dev/financial#139 contribution receive_date shouldn't change when payments come in

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4481,10 +4481,6 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
     }
     $changeDate = CRM_Utils_Array::value('trxn_date', $input, date('YmdHis'));
 
-    if (empty($contributionParams['receive_date']) && $changeDate) {
-      $contributionParams['receive_date'] = $changeDate;
-    }
-
     self::repeatTransaction($contribution, $input, $contributionParams, $paymentProcessorId);
     $contributionParams['financial_type_id'] = $contribution->financial_type_id;
 

--- a/CRM/Contribute/Form/Task/PDF.php
+++ b/CRM/Contribute/Form/Task/PDF.php
@@ -253,7 +253,7 @@ AND    {$this->_componentClause}";
 
     $pdfElements['contribIDs'] = implode(',', $contribIds);
 
-    $pdfElements['details'] = CRM_Contribute_Form_Task_Status::getDetails($pdfElements['contribIDs']);
+    $pdfElements['details'] = self::getDetails($pdfElements['contribIDs']);
 
     $pdfElements['baseIPN'] = new CRM_Core_Payment_BaseIPN();
 
@@ -293,6 +293,49 @@ AND    {$this->_componentClause}";
     $pdfElements['excludeContactIds'] = $excludeContactIds;
 
     return $pdfElements;
+  }
+
+  /**
+   * @param string $contributionIDs
+   *
+   * @return array
+   */
+  private static function getDetails($contributionIDs) {
+    if (empty($contributionIDs)) {
+      return [];
+    }
+    $query = "
+SELECT    c.id              as contribution_id,
+          c.contact_id      as contact_id     ,
+          mp.membership_id  as membership_id  ,
+          pp.participant_id as participant_id ,
+          p.event_id        as event_id
+FROM      civicrm_contribution c
+LEFT JOIN civicrm_membership_payment  mp ON mp.contribution_id = c.id
+LEFT JOIN civicrm_participant_payment pp ON pp.contribution_id = c.id
+LEFT JOIN civicrm_participant         p  ON pp.participant_id  = p.id
+WHERE     c.id IN ( $contributionIDs )";
+
+    $rows = [];
+    $dao = CRM_Core_DAO::executeQuery($query);
+
+    while ($dao->fetch()) {
+      $rows[$dao->contribution_id]['component'] = $dao->participant_id ? 'event' : 'contribute';
+      $rows[$dao->contribution_id]['contact'] = $dao->contact_id;
+      if ($dao->membership_id) {
+        if (!array_key_exists('membership', $rows[$dao->contribution_id])) {
+          $rows[$dao->contribution_id]['membership'] = [];
+        }
+        $rows[$dao->contribution_id]['membership'][] = $dao->membership_id;
+      }
+      if ($dao->participant_id) {
+        $rows[$dao->contribution_id]['participant'] = $dao->participant_id;
+      }
+      if ($dao->event_id) {
+        $rows[$dao->contribution_id]['event'] = $dao->event_id;
+      }
+    }
+    return $rows;
   }
 
 }

--- a/CRM/Contribute/Form/Task/Status.php
+++ b/CRM/Contribute/Form/Task/Status.php
@@ -68,21 +68,6 @@ AND    {$this->_componentClause}";
    * Build the form object.
    */
   public function buildQuickForm() {
-    $status = CRM_Contribute_BAO_Contribution_Utils::getContributionStatuses(
-      'contribution', $this->_contributionIds[0]
-    );
-    $byName = CRM_Contribute_PseudoConstant::contributionStatus(NULL, 'name');
-    // FIXME: if it's invalid to transition from Pending to
-    // In Progress or Overdue, we should move that logic to
-    // CRM_Contribute_BAO_Contribution_Utils::getContributionStatuses.
-    foreach (['Pending', 'In Progress', 'Overdue'] as $suppress) {
-      unset($status[CRM_Utils_Array::key($suppress, $byName)]);
-    }
-    $this->add('select', 'contribution_status_id',
-      ts('Contribution Status'),
-      $status,
-      TRUE
-    );
     $this->add('checkbox', 'is_email_receipt', ts('Send e-mail receipt'));
     $this->setDefaults(['is_email_receipt' => 1]);
 
@@ -198,7 +183,7 @@ AND    co.id IN ( $contribIDs )";
     // submit the form with values.
     self::processForm($this, $params);
 
-    CRM_Core_Session::setStatus(ts('Contribution status has been updated for selected record(s).'), ts('Status Updated'), 'success');
+    CRM_Core_Session::setStatus(ts('Payments have been recorded for selected record(s).'), ts('Payments recorded'), 'success');
   }
 
   /**
@@ -212,124 +197,26 @@ AND    co.id IN ( $contribIDs )";
    * @throws \Exception
    */
   public static function processForm($form, $params) {
-    $statusID = $params['contribution_status_id'] ?? NULL;
-    $baseIPN = new CRM_Core_Payment_BaseIPN();
-
-    // get the missing pieces for each contribution
-    $contribIDs = implode(',', $form->_contributionIds);
-    $details = self::getDetails($contribIDs);
-    $template = CRM_Core_Smarty::singleton();
-
-    // for each contribution id, we just call the baseIPN stuff
     foreach ($form->_rows as $row) {
-      $input = $ids = $objects = [];
-      $input['component'] = $details[$row['contribution_id']]['component'];
-
-      $ids['contact'] = $row['contact_id'];
-      $ids['contribution'] = $row['contribution_id'];
-      $ids['contributionRecur'] = NULL;
-      $ids['contributionPage'] = NULL;
-      $ids['membership'] = $details[$row['contribution_id']]['membership'] ?? NULL;
-      $ids['participant'] = $details[$row['contribution_id']]['participant'] ?? NULL;
-      $ids['event'] = $details[$row['contribution_id']]['event'] ?? NULL;
-
-      if (!$baseIPN->validateData($input, $ids, $objects, FALSE)) {
-        CRM_Core_Error::statusBounce('Supplied data was not able to be validated');
-      }
-
-      $contribution = &$objects['contribution'];
-
-      $contributionStatuses = CRM_Contribute_PseudoConstant::contributionStatus(NULL,
-        'name'
-      );
-
-      if ($statusID == array_search('Cancelled', $contributionStatuses)) {
-        $transaction = new CRM_Core_Transaction();
-        $baseIPN->cancelled($objects, $transaction);
-        $transaction->commit();
-        continue;
-      }
-      elseif ($statusID == array_search('Failed', $contributionStatuses)) {
-        $transaction = new CRM_Core_Transaction();
-        $baseIPN->failed($objects, $transaction);
-        $transaction->commit();
-        continue;
-      }
-
-      // status is not pending
-      if ($contribution->contribution_status_id != array_search('Pending',
-          $contributionStatuses
-        )
-      ) {
-        continue;
-      }
-
-      // set some fake input values so we can reuse IPN code
-      $input['amount'] = $contribution->total_amount;
-      $input['is_test'] = $contribution->is_test;
-      $input['fee_amount'] = $params["fee_amount_{$row['contribution_id']}"];
-      $input['check_number'] = $params["check_number_{$row['contribution_id']}"];
-      $input['payment_instrument_id'] = $params["payment_instrument_id_{$row['contribution_id']}"];
-      $input['net_amount'] = $contribution->total_amount - $input['fee_amount'];
-
-      if (!empty($params["trxn_id_{$row['contribution_id']}"])) {
-        $input['trxn_id'] = trim($params["trxn_id_{$row['contribution_id']}"]);
-      }
-      else {
-        $input['trxn_id'] = $contribution->invoice_id;
-      }
-      $input['trxn_date'] = $params["trxn_date_{$row['contribution_id']}"] . ' ' . date('H:i:s');
-      $input['is_email_receipt'] = !empty($params['is_email_receipt']);
-
-      // @todo calling CRM_Contribute_BAO_Contribution::completeOrder like this is a pattern in it's last gasps. Call contribute.completetransaction api.
-      CRM_Contribute_BAO_Contribution::completeOrder($input, $ids, $objects);
-
-      // reset template values before processing next transactions
-      $template->clearTemplateVars();
+      $contribData = civicrm_api3('Contribution', 'getSingle', ['id' => $row['contribution_id']]);
+      $trxnParams = [
+        'contribution_id' => $row['contribution_id'],
+        // We are safe assuming that payments will be for the total amount of
+        // the contribution because the contributions must be in "Pending"
+        // status.
+        'total_amount' => $contribData['total_amount'],
+        'fee_amount' => $params["fee_amount_{$row['contribution_id']}"],
+        'check_number' => $params["check_number_{$row['contribution_id']}"],
+        'payment_instrument_id' => $params["payment_instrument_id_{$row['contribution_id']}"],
+        'net_amount' => $contribData['total_amount'] - $params["fee_amount_{$row['contribution_id']}"],
+        // Not sure why to default to invoice_id, but that's what the form has
+        // been doing historically
+        'trxn_id' => $params["trxn_id_{$row['contribution_id']}"] ?? $contribData['invoice_id'],
+        'trxn_date' => $params["trxn_date_{$row['contribution_id']}"] ?? 'now',
+        'is_send_contribution_notification' => !empty($params['is_email_receipt']),
+      ];
+      $result = civicrm_api3('Payment', 'create', $trxnParams);
     }
-  }
-
-  /**
-   * @param string $contributionIDs
-   *
-   * @return array
-   */
-  public static function &getDetails($contributionIDs) {
-    if (empty($contributionIDs)) {
-      return [];
-    }
-    $query = "
-SELECT    c.id              as contribution_id,
-          c.contact_id      as contact_id     ,
-          mp.membership_id  as membership_id  ,
-          pp.participant_id as participant_id ,
-          p.event_id        as event_id
-FROM      civicrm_contribution c
-LEFT JOIN civicrm_membership_payment  mp ON mp.contribution_id = c.id
-LEFT JOIN civicrm_participant_payment pp ON pp.contribution_id = c.id
-LEFT JOIN civicrm_participant         p  ON pp.participant_id  = p.id
-WHERE     c.id IN ( $contributionIDs )";
-
-    $rows = [];
-    $dao = CRM_Core_DAO::executeQuery($query);
-
-    while ($dao->fetch()) {
-      $rows[$dao->contribution_id]['component'] = $dao->participant_id ? 'event' : 'contribute';
-      $rows[$dao->contribution_id]['contact'] = $dao->contact_id;
-      if ($dao->membership_id) {
-        if (!array_key_exists('membership', $rows[$dao->contribution_id])) {
-          $rows[$dao->contribution_id]['membership'] = [];
-        }
-        $rows[$dao->contribution_id]['membership'][] = $dao->membership_id;
-      }
-      if ($dao->participant_id) {
-        $rows[$dao->contribution_id]['participant'] = $dao->participant_id;
-      }
-      if ($dao->event_id) {
-        $rows[$dao->contribution_id]['event'] = $dao->event_id;
-      }
-    }
-    return $rows;
   }
 
 }

--- a/CRM/Contribute/Task.php
+++ b/CRM/Contribute/Task.php
@@ -81,7 +81,7 @@ class CRM_Contribute_Task extends CRM_Core_Task {
           'result' => TRUE,
         ],
         self::UPDATE_STATUS => [
-          'title' => ts('Update pending contribution status'),
+          'title' => ts('Record payments for contributions'),
           'class' => 'CRM_Contribute_Form_Task_Status',
           'result' => TRUE,
         ],

--- a/api/v3/Contribution.php
+++ b/api/v3/Contribution.php
@@ -488,7 +488,8 @@ function civicrm_api3_contribution_completetransaction($params) {
   elseif ($contribution->contribution_status_id == CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Completed')) {
     throw new API_Exception(ts('Contribution already completed'), 'contribution_completed');
   }
-  $input['trxn_id'] = !empty($params['trxn_id']) ? $params['trxn_id'] : $contribution->trxn_id;
+  $input['trxn_id'] = $params['trxn_id'] ?? $contribution->trxn_id;
+
   if (!empty($params['fee_amount'])) {
     $input['fee_amount'] = $params['fee_amount'];
   }

--- a/templates/CRM/Contribute/Form/Task/Status.tpl
+++ b/templates/CRM/Contribute/Form/Task/Status.tpl
@@ -8,18 +8,13 @@
  +--------------------------------------------------------------------+
 *}
 <div class="form-item crm-block crm-form-block crm-contribution-form-block">
-  <h3>{ts}Update Contribution Status{/ts}</h3>
+  <h3>{ts}Record payments for contributions{/ts}</h3>
   <div class="help">
-    {ts}Use this form to record received payments for 'pay later' online contributions, membership signups and event registrations. You can use the Transaction ID field to record account+check number, bank transfer identifier, or other unique payment identifier.{/ts}
+    <p>{ts}Use this form to record received payments for "pay later" online contributions, membership signups and event registrations. You can use the Transaction ID field to record account+check number, bank transfer identifier, or other unique payment identifier.{/ts}</p>
+    <p>{ts}The contribution status will be updated as appropriate.  To update contribution statuses directly, return to the search results and select "Update multiple contributions".{/ts}</p>
   </div>
 
   <table class="form-layout-compressed">
-    <tr class="crm-contribution-form-block-contribution_status_id">
-      <td class="label">{$form.contribution_status_id.label}</td>
-      <td class="html-adjust">{$form.contribution_status_id.html}<br />
-        <span class="description">{ts}Assign the selected status to all contributions listed below.{/ts}</span>
-      </td>
-    </tr>
     <tr class="crm-contribution-form-block-is_email_receipt">
       <td class="label">{$form.is_email_receipt.label}</td>
       <td class="html-adjust">{$form.is_email_receipt.html}<br />

--- a/templates/CRM/Contribute/Form/Task/Status.tpl
+++ b/templates/CRM/Contribute/Form/Task/Status.tpl
@@ -8,50 +8,54 @@
  +--------------------------------------------------------------------+
 *}
 <div class="form-item crm-block crm-form-block crm-contribution-form-block">
-<div class="help">
+  <h3>{ts}Update Contribution Status{/ts}</h3>
+  <div class="help">
     {ts}Use this form to record received payments for 'pay later' online contributions, membership signups and event registrations. You can use the Transaction ID field to record account+check number, bank transfer identifier, or other unique payment identifier.{/ts}
-</div>
-<fieldset>
-    <legend>{ts}Update Contribution Status{/ts}</legend>
-     <table class="form-layout-compressed">
-     <tr class="crm-contribution-form-block-contribution_status_id"><td class="label">{$form.contribution_status_id.label}</td><td class="html-adjust">{$form.contribution_status_id.html}<br />
-            <span class="description">{ts}Assign the selected status to all contributions listed below.{/ts}</td></tr>
-       <tr class="crm-contribution-form-block-is_email_receipt"><td class="label">{$form.is_email_receipt.label}</td>
-         <td class="html-adjust">{$form.is_email_receipt.html}<br />
-           <span class="description">{ts}When checked CiviCRM will send an e-mail receipt to the donor. Leave unchecked when you don't want to send an e-mail.{/ts}
-         </td>
-       </tr>
-     </table>
-<table>
-<tr class="columnheader">
-    <th>{ts}Name{/ts}</th>
-    <th class="right">{ts}Amount{/ts}&nbsp;&nbsp;</th>
-    <th>{ts}Source{/ts}</th>
-    <th>{ts}Fee Amount{/ts}</th>
-    <th>{ts}Payment Method{/ts}</th>
-    <th>{ts}Check{/ts} #</th>
-    <th>{ts}Transaction ID{/ts}</th>
-    <th>{ts}Transaction Date{/ts}</th>
-</tr>
+  </div>
 
-{foreach from=$rows item=row}
-<tr class="{cycle values="odd-row,even-row"}">
-    <td>{$row.display_name}</td>
-    <td class="right nowrap">{$row.amount|crmMoney}&nbsp;&nbsp;</td>
-    <td>{$row.source}</td>
-    {assign var="element_name" value="fee_amount_"|cat:$row.contribution_id}
-    <td>{$form.$element_name.html}</td>
-    {assign var="element_name" value="payment_instrument_id_"|cat:$row.contribution_id}
-    <td class="form-text four">{$form.$element_name.html}</td>
-    {assign var="element_name" value="check_number_"|cat:$row.contribution_id}
-    <td class="form-text four">{$form.$element_name.html|crmAddClass:four}</td>
-    {assign var="element_name" value="trxn_id_"|cat:$row.contribution_id}
-    <td>{$form.$element_name.html|crmAddClass:eight}</td>
-    {assign var="element_name" value="trxn_date_"|cat:$row.contribution_id}
-    <td>{$form.$element_name.html}</td>
-</tr>
-{/foreach}
-</table>
+  <table class="form-layout-compressed">
+    <tr class="crm-contribution-form-block-contribution_status_id">
+      <td class="label">{$form.contribution_status_id.label}</td>
+      <td class="html-adjust">{$form.contribution_status_id.html}<br />
+        <span class="description">{ts}Assign the selected status to all contributions listed below.{/ts}</span>
+      </td>
+    </tr>
+    <tr class="crm-contribution-form-block-is_email_receipt">
+      <td class="label">{$form.is_email_receipt.label}</td>
+      <td class="html-adjust">{$form.is_email_receipt.html}<br />
+        <span class="description">{ts}When checked CiviCRM will send an e-mail receipt to the donor. Leave unchecked when you don't want to send an e-mail.{/ts}</span>
+      </td>
+    </tr>
+  </table>
+  <table>
+    <tr class="columnheader">
+      <th>{ts}Name{/ts}</th>
+      <th class="right">{ts}Amount{/ts}&nbsp;&nbsp;</th>
+      <th>{ts}Source{/ts}</th>
+      <th>{ts}Fee Amount{/ts}</th>
+      <th>{ts}Payment Method{/ts}</th>
+      <th>{ts}Check{/ts} #</th>
+      <th>{ts}Transaction ID{/ts}</th>
+      <th>{ts}Transaction Date{/ts}</th>
+    </tr>
+
+    {foreach from=$rows item=row}
+    <tr class="{cycle values="odd-row,even-row"}">
+      <td>{$row.display_name}</td>
+      <td class="right nowrap">{$row.amount|crmMoney}&nbsp;&nbsp;</td>
+      <td>{$row.source}</td>
+      {assign var="element_name" value="fee_amount_"|cat:$row.contribution_id}
+      <td>{$form.$element_name.html}</td>
+      {assign var="element_name" value="payment_instrument_id_"|cat:$row.contribution_id}
+      <td class="form-text four">{$form.$element_name.html}</td>
+      {assign var="element_name" value="check_number_"|cat:$row.contribution_id}
+      <td class="form-text four">{$form.$element_name.html|crmAddClass:four}</td>
+      {assign var="element_name" value="trxn_id_"|cat:$row.contribution_id}
+      <td>{$form.$element_name.html|crmAddClass:eight}</td>
+      {assign var="element_name" value="trxn_date_"|cat:$row.contribution_id}
+      <td>{$form.$element_name.html}</td>
+    </tr>
+    {/foreach}
+  </table>
   <div class="crm-submit-buttons">{$form.buttons.html}</div>
-</fieldset>
 </div>

--- a/tests/phpunit/api/v3/PaymentTest.php
+++ b/tests/phpunit/api/v3/PaymentTest.php
@@ -1124,9 +1124,7 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
     $this->assertEquals($trxnID, $contribution['trxn_id'],
       "Contribution trxn_id should have been set to that of the payment.");
 
-    // change $trxnDate for $receiveDate if we agree that transactions should NOT
-    // update contributions.
-    $this->assertEquals($trxnDate, $contribution['receive_date'],
+    $this->assertEquals($originalReceiveDate, $contribution['receive_date'],
       "Contribution receive date was changed, but should not have been.");
 
     $this->validateAllPayments();


### PR DESCRIPTION
Overview
----------------------------------------
The contribution `receive_date` would change when payments arrive on a pending contribution.  This can cause reporting mayhem (your June totals may go down if you run the report after some payments arrive in July), and it generally goes against fundraisers' accrual perspective of donations.

This is a regression appearing in 5.18, but addressing it ran into issues dating to users' expectations from the "Update pending contribution status" search action (expressed in [CRM-17146](https://issues.civicrm.org/jira/browse/CRM-17146)).  Because it was using the IPN code, users assumed that the date specified on the payment should actually update the contribution's date because that code treated the two identically.

The solution was to rework that form so it strictly records a bunch of payments.  The dates will become `trxn_date` on the payment, and the contribution `receive_date` is left intact.  The contribution statuses will get updated according to the normal rules (which should always result in "Completed" because at least as of now the form will only let you record payments in full).  If you want to edit contribution statuses, you can always batch update with a profile.

That meant I could remove the contribution status field, and in the process I renamed the action "Record payments for contributions" to better reflect this.  The main use case is when someone checks the mail and has a stack of checks.

See [dev/financial#139](https://lab.civicrm.org/dev/financial/-/issues/139) for extensive discussion.

Before
----------------------------------------
1.  Recording a payment that completes a contribution updates the contribution `receive_date` to the payment's `trxn_date`.

2.  There's a search action called "Update pending contribution status".

    ![image](https://user-images.githubusercontent.com/1682375/88579838-b1436d00-d018-11ea-8037-854097fed159.png)

3.  Someone using "Update pending contribution status" is invited to manually set the contribution status, which could lead to unexpected results.

    ![image](https://user-images.githubusercontent.com/1682375/88579770-9670f880-d018-11ea-981b-4465993c4e2b.png)

After
----------------------------------------
1.  The contribution `receive_date` does not change unless you manually change it, even if it becomes completed.

2. The search action is renamed "Record payments for contributions".
 
    ![image](https://user-images.githubusercontent.com/1682375/88579556-367a5200-d018-11ea-80bd-5c744abc662a.png)

3. There is no field to set the contribution status on that search action.  The help text suggests using batch edit with profiles.
 
    ![image](https://user-images.githubusercontent.com/1682375/88579704-7e997480-d018-11ea-8b87-5e88611d1b7d.png)

Technical Details
----------------------------------------
I added and updated a bunch of tests, including several instances where they are testing the opposite result of what they used to test.

Comments
----------------------------------------
It might be a nice improvement to that multiple payment form to allow for payments with different amounts, and it should work fine setting the contribution status to Partially Paid as appropriate.  Similarly, it might be nice to allow payments on partially paid contributions.  Both were out of scope here.
