### PR TITLE
Setup UI - Validate that at least one "Component" is enabled

### DIFF
--- a/setup/plugins/blocks/components.tpl.php
+++ b/setup/plugins/blocks/components.tpl.php
@@ -2,6 +2,8 @@
 endif; ?>
 <h2 id="components"><?php echo ts('Components'); ?></h2>
 
+<p class="comp-error-required"><?php echo ts('At least one component must be enabled.'); ?></p>
+
 <div>
   <?php foreach ($model->getField('components', 'options') as $comp => $label): ?>
     <input class="comp-cb sr-only" style="display: none;" type="checkbox" name="civisetup[components][<?php echo $comp; ?>]" id="civisetup[components][<?php echo $comp; ?>]" <?php echo in_array($comp, $model->components) ? 'checked' : '' ?>>
@@ -16,3 +18,11 @@ endif; ?>
   <strong><?php echo ts('Tip'); ?></strong>:
   <?php echo ts('Not sure? That\'s OK. After installing, you can enable and disable components at any time.'); ?>
 </p>
+
+<script type="text/javascript">
+  csj$(function($){
+    $('.comp-cb').useValidator(function(){
+      $('.comp-error-required').toggleError($('.comp-cb:checked').length == 0);
+    });
+  });
+</script>

--- a/setup/plugins/installDatabase/InstallComponents.civi-setup.php
+++ b/setup/plugins/installDatabase/InstallComponents.civi-setup.php
@@ -9,6 +9,17 @@ if (!defined('CIVI_SETUP')) {
   exit("Installation plugins must only be loaded by the installer.\n");
 }
 
+Civi\Setup::dispatcher()
+  ->addListener('civi.setup.checkRequirements', function (\Civi\Setup\Event\CheckRequirementsEvent $e) {
+    \Civi\Setup::log()->info(sprintf('[%s] Handle %s', basename(__FILE__), 'checkRequirements'));
+    $model = $e->getModel();
+
+    if (empty($model->components)) {
+      $e->addError('system', 'components', "System must have at least one active component.");
+      return;
+    }
+  });
+
 \Civi\Setup::dispatcher()
   ->addListener('civi.setup.installDatabase', function (\Civi\Setup\Event\InstallDatabaseEvent $e) {
     \Civi\Setup::log()->info('[InstallComponents.civi-setup.php] Activate components: ' . implode(" ", $e->getModel()->components));

--- a/setup/res/installer.js
+++ b/setup/res/installer.js
@@ -1,0 +1,31 @@
+(function($){
+  /**
+   * Enable or disable an error message.
+   *
+   * <p id="my-error-message">The world is one fire.</p>
+   * Ex: $('#my-error-message').toggleError(false)
+   *
+   * @param bool isError
+   */
+  $.fn.toggleError = function (isError) {
+    this.toggleClass('install-validate-ok', !isError)
+      .toggleClass('install-validate-bad', isError)
+      .toggleClass('error', isError);
+
+    var errors = $('.install-validate-bad');
+    $('#install_button').prop('disabled', errors.length > 0);
+    return this;
+  };
+
+  /**
+   * Ex: $('.watch-these').useValidator(function(){
+   *   $('#some-error-message').toggleError(booleanExpression);
+   * })
+   * @param cb
+   */
+  $.fn.useValidator = function(cb) {
+    cb();
+    this.on('change', cb);
+    return this;
+  };
+})($);

--- a/setup/res/jquery.setupui.js
+++ b/setup/res/jquery.setupui.js
@@ -1,3 +1,6 @@
+/**
+ * This is a jQuery plugin which adds some helpers for the setup UI.
+ */
 (function($){
   /**
    * Enable or disable an error message.
@@ -28,4 +31,4 @@
     this.on('change', cb);
     return this;
   };
-})($);
+})(jQuery);

--- a/setup/res/template.css
+++ b/setup/res/template.css
@@ -130,6 +130,13 @@ body {
   font-size: 80%;
 }
 
+.civicrm-setup-body .install-validate-ok {
+  display: none;
+}
+
+.civicrm-setup-body .install-validate-bad {
+}
+
 .civicrm-setup-body .reqTable {
   border-collapse: collapse;
   width: 100%;
@@ -222,6 +229,10 @@ body {
 }
 .civicrm-setup-body input[type=submit]:hover {
   background: #60A237;
+}
+.civicrm-setup-body input[type=submit]:disabled {
+  background: #888;
+  cursor: not-allowed;
 }
 
 .civicrm-setup-body .settingsTable input[type=text] { width: 80%; }

--- a/setup/src/Setup/UI/SetupController.php
+++ b/setup/src/Setup/UI/SetupController.php
@@ -191,6 +191,7 @@ class SetupController implements SetupControllerInterface {
     $r->body = $body;
     $r->assets = [
       ['type' => 'script-url', 'url' => $this->getUrl('jquery.js')],
+      ['type' => 'script-url', 'url' => $this->urls['res'] . "installer.js"],
       ['type' => 'script-code', 'code' => 'window.csj$ = jQuery.noConflict();'],
       ['type' => 'style-url', 'url' => $this->urls['res'] . "template.css"],
       ['type' => 'style-url', 'url' => $this->getUrl('font-awesome.css')],

--- a/setup/src/Setup/UI/SetupController.php
+++ b/setup/src/Setup/UI/SetupController.php
@@ -191,7 +191,7 @@ class SetupController implements SetupControllerInterface {
     $r->body = $body;
     $r->assets = [
       ['type' => 'script-url', 'url' => $this->getUrl('jquery.js')],
-      ['type' => 'script-url', 'url' => $this->urls['res'] . "installer.js"],
+      ['type' => 'script-url', 'url' => $this->urls['res'] . "jquery.setupui.js"],
       ['type' => 'script-code', 'code' => 'window.csj$ = jQuery.noConflict();'],
       ['type' => 'style-url', 'url' => $this->urls['res'] . "template.css"],
       ['type' => 'style-url', 'url' => $this->getUrl('font-awesome.css')],


### PR DESCRIPTION
Overview
----------------------------------------

Suppose an admin uses the "Setup UI" to perform installation - and disables all components. The behavior should be less crashy.


Before
----------------------------------------

The user is allowed to start the installation. It aborts mid-way through, leaving the system in an inconsistent state.

After
----------------------------------------

There are now two more guards:

* __Server side__: If one submits a request to install without any `components`, it will complain during the `checkRequirements` phase -- before installation begins.
* __Client side__: If one uses the "Setup UI" and disables components, the form will display an error and prevent submission.

![Screen Shot 2020-07-08 at 6 27 31 PM](https://user-images.githubusercontent.com/1336047/86987451-ead83500-c14a-11ea-9be7-45865aa80a1d.png)

Comments
----------------------------------------

This PR builds on #17749. It is not logically dependent, but it is technically dependent - because they both touch the list of `<script>` tags used on the "Setup" screen. Consequently, the list of commits is a bit long right now - this PR is really just the last three commits.