### PR TITLE
CRM_Utils_SQL - Add "onDuplicate()" and "syncInto()" helpers

### DIFF
--- a/CRM/Utils/SQL/Select.php
+++ b/CRM/Utils/SQL/Select.php
@@ -375,6 +375,45 @@ class CRM_Utils_SQL_Select extends CRM_Utils_SQL_BaseParamQuery {
   }
 
   /**
+   * Take the results of the SELECT query and copy them into another
+   * table.
+   *
+   * If the same record already exists in the other table (based on
+   * primary-key or unique-key), then update the corresponding record.
+   *
+   * @param string $table
+   *   The table to write data into.
+   * @param array|string $keys
+   *   List of PK/unique fields
+   *   NOTE: This must match the unique-key that was declared in the schema.
+   * @param array $mapping
+   *   List of values to select and where to send them.
+   *
+   *   For example, consider:
+   *     ['relationship_id' => 'rel.id']
+   *
+   *   This would select the value of 'rel.id' and write to 'relationship_id'.
+   *
+   * @param null|array $args
+   *   Use NULL to skip interpolation; use an array of variables to enable.
+   * @return $this
+   */
+  public function syncInto($table, $keys, $mapping, $args = NULL) {
+    $keys = (array) $keys;
+
+    $this->select(array_values($mapping), $args);
+    $this->insertInto($table, array_keys($mapping));
+
+    foreach ($mapping as $intoColumn => $fromValue) {
+      if (!in_array($intoColumn, $keys)) {
+        $this->onDuplicate("$intoColumn = $fromValue", $args);
+      }
+    }
+
+    return $this;
+  }
+
+  /**
    * @param array $fields
    *   The fields to fill in the other table (in order).
    * @return CRM_Utils_SQL_Select

--- a/tests/phpunit/CRM/Utils/SQL/SelectTest.php
+++ b/tests/phpunit/CRM/Utils/SQL/SelectTest.php
@@ -325,6 +325,15 @@ class CRM_Utils_SQL_SelectTest extends CiviUnitTestCase {
     $this->assertLike('INSERT INTO bar (first, second, third, fourth) SELECT fid, 1, fid, 1 FROM foo WHERE (zoo = 3) AND (aviary = 3) GROUP BY noodle, sauce', $select->toSQL());
   }
 
+  public function testInsertInto_OnDuplicateUpdate() {
+    $select = CRM_Utils_SQL_Select::from('foo')
+      ->insertInto('bar', ['first', 'second', 'third'])
+      ->select(['foo.one', 'foo.two', 'foo.three'])
+      ->onDuplicate('second = twiddle(foo.two)')
+      ->onDuplicate('third = twiddle(foo.three)');
+    $this->assertLike('INSERT INTO bar (first, second, third) SELECT foo.one, foo.two, foo.three FROM foo ON DUPLICATE KEY UPDATE second = twiddle(foo.two), third = twiddle(foo.three)', $select->toSQL());
+  }
+
   /**
    * @param $expected
    * @param $actual


### PR DESCRIPTION
Overview
---------

This adds helper functions, `onDuplicate(...)` and `syncInto(...)`, for reading data from one table and writing to another.

This is an offshoot of #17724 which only adds the helper function and the unit-test.

Before
------

It is possible to construct a `SELECT` query and insert the results to another table:

```php
CRM_Utils_SQL_Select::from('foo_table')
  ->select(['foo_name', 'foo_value1', 'foo_value2'])
  ->insertInto('bar_table', ['bar_name', 'bar_output1', 'bar_output2']);
```

However, this will always insert new records. It cannot be used to `UPDATE` existing records (i.e. `INSERT INTO ... SELECT ... ON DUPLICATE UPDATE...`).

The operation `REPLACE INTO` (`replaceInto()`) is somewhat similar to `ON DUPLICATE UPDATE`. Both operations will insert a new record. But if there's a conflict/pre-existing record, the `REPLACE INTO` will *remove and replace* the record, whereas `ON DUPLICATE UPDATE` only modifies fields. One benchmark reported [a ~35x performance difference](https://stackoverflow.com/a/27966919/4195300) between `REPLACE INTO` and `ON DUPLICATE UPDATE`.

After
------

This first commit makes it possible to construct an `ON DUPLICATE UPDATE` query, eg.

```php
CRM_Utils_SQL_Select::from('foo_table')
  ->select(['foo_name', 'foo_value1', 'foo_value2'])
  ->insertInto('bar_table', ['bar_name', 'bar_output1', 'bar_output2'])
  ->onDuplicate(['bar_output1 = foo_value1', 'bar_output2 = foo_value2']);
```

This parallels the underlying SQL structure. However, it is a bit verbose -- observe that every field on every side of the data-transfer (`foo_value1`, `bar_value1`, `foo_value2`, etc) has to be mentioned multiple times.

The second commit provides a convenience function which does the same thing - but with cleaner notation:

```php
CRM_Utils_SQL_Select::from('foo_table')
  ->syncInto('bar_table', 'bar_name', [
    'bar_name' => 'foo_name',
    'bar_output1' => 'foo_value1',
    'bar_output2' => 'foo_value1',
  ])
```
