### PR TITLE
dev/core#1868 - Regression - Description field is always blank on profiles admin page and slew of E_NOTICES

### DIFF
--- a/CRM/Core/BAO/UFGroup.php
+++ b/CRM/Core/BAO/UFGroup.php
@@ -1663,7 +1663,7 @@ AND    ( entity_id IS NULL OR entity_id <= 0 )
    *   array of ufgroups for a module
    */
   public static function getModuleUFGroup($moduleName = NULL, $count = 0, $skipPermission = TRUE, $op = CRM_Core_Permission::VIEW, $returnFields = NULL) {
-    $selectFields = ['id', 'title', 'created_id', 'is_active', 'is_reserved', 'group_type'];
+    $selectFields = ['id', 'title', 'created_id', 'is_active', 'is_reserved', 'group_type', 'description'];
 
     if (CRM_Core_BAO_SchemaHandler::checkIfFieldExists('civicrm_uf_group', 'frontend_title')) {
       $selectFields[] = 'frontend_title';


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/1868

Before
----------------------------------------
Blank description field at Administer - Customize - Profiles.
Lots of E_NOTICES.

After
----------------------------------------
Good.

Technical Details
----------------------------------------
Recent cleanup to remove pre 4.4.7 upgrade code accidentally removed the description lookup. This puts it back.

Comments
----------------------------------------
Seems to only be in master.