### PR TITLE
[REF] Follow up cleanup

### DIFF
--- a/CRM/Contribute/Form/ContributionRecur.php
+++ b/CRM/Contribute/Form/ContributionRecur.php
@@ -87,7 +87,7 @@ class CRM_Contribute_Form_ContributionRecur extends CRM_Core_Form {
   /**
    * Details of the subscription (recurring contribution) to be altered.
    *
-   * @var array
+   * @var \CRM_Core_DAO
    */
   protected $subscriptionDetails = [];
 
@@ -179,7 +179,7 @@ class CRM_Contribute_Form_ContributionRecur extends CRM_Core_Form {
   /**
    * Get details for the recurring contribution being altered.
    *
-   * @return array
+   * @return \CRM_Core_DAO
    */
   public function getSubscriptionDetails() {
     return $this->subscriptionDetails;


### PR DESCRIPTION
Overview
----------------------------------------
This removes an IF block that relies on the always-true parameter

I'm pretty sure it just wasn't done last round as all the white space created a lot of noise

Before
----------------------------------------
If -> else exists but the condition for the IF is always true because this is the only place $cancelSubscription is referred to

https://github.com/civicrm/civicrm-core/pull/17788/files#diff-30a8e5b11544ab10573dea3f36cb9db2L202

After
----------------------------------------
Block removed

Technical Details
----------------------------------------
This is best viewed with the w=1 parameter - https://github.com/civicrm/civicrm-core/pull/17788/files?w=1 as it is otherwise hard to read. There are small additional cleanups:
- comments
- use statement along with shorter declaration later on
- preferred functions on session (CRM_Core_Session::singleton()) 

Comments
----------------------------------------

