### PR TITLE
Add hidden tag to search extension

### DIFF
--- a/ext/search/info.xml
+++ b/ext/search/info.xml
@@ -13,6 +13,9 @@
   </urls>
   <releaseDate>2020-07-08</releaseDate>
   <version>1.0</version>
+  <tags>
+    <tag>mgmt:hidden</tag>
+  </tags>
   <develStage>stable</develStage>
   <compatibility>
     <ver>5.28</ver>


### PR DESCRIPTION


Overview
----------------------------------------
This was a suggestion from @mattwire that we hide the extension from the UI until the styling dependency is resovled.

It seems reasonable to me as this is primarily in the civicrm-core repo for code management purposes and
making it too easy to enable before the styling is resolved could lead to confusion.

I would quite like to enable on buildkit builds just for dev visibility - but that is something to think
about

Before
----------------------------------------
New search extension is visible to be enabled in extension ui - however, it dieplays poorly for non-shoreditch users

After
----------------------------------------
Not visible in the UI - this is proposed to be the case until the above is resolved

Technical Details
----------------------------------------


Comments
