### PR TITLE
dev/core#1864 Correct problem with returning all records when not specifying Search in Trash

### DIFF
--- a/CRM/ACL/API.php
+++ b/CRM/ACL/API.php
@@ -88,13 +88,14 @@ class CRM_ACL_API {
     // the default value which is valid for the final AND
     $deleteClause = ' ( 1 ) ';
     if (!$skipDeleteClause) {
-      if (CRM_Core_Permission::check('access deleted contacts')) {
-        if ($onlyDeleted) {
-          $deleteClause = '(contact_a.is_deleted)';
-        }
+      // dev/core#1864 We get only deleted if $only deleted is set and you have
+      // permission to see deleted contacts.
+      if (CRM_Core_Permission::check('access deleted contacts') && $onlyDeleted) {
+        $deleteClause = '(contact_a.is_deleted)';
       }
       else {
-        // Exclude deleted contacts due to permissions
+        // Exclude deleted contacts due to permissions or because we do not
+        // want to search in trash.
         $deleteClause = '(contact_a.is_deleted = 0)';
       }
     }


### PR DESCRIPTION


Overview
----------------------------------------
_A brief description of the pull request. Keep technical jargon to a minimum. Hyperlink relevant discussions._
Advanced Search was returning _all_ records when Search in Trash was not ticked.  This is unexpected behaviour.
See [Advanced Search returns contacts in Trash even if 'Search in Trash' not ticked.](https://lab.civicrm.org/dev/core/-/issues/1864)

Before
----------------------------------------
When Search in Trash was not ticked in Advanced Search, _all_ records, including deleted ones are returned.

After
----------------------------------------
Only non-deleted ones are returned.  When Search in Trash is ticked _and_ you have permission to search in trash, only the deleted records are returned.

Technical Details
----------------------------------------
_If the PR involves technical details/changes/considerations which would not be manifest to a casual developer skimming the above sections, please describe the details here._

![image](https://user-images.githubusercontent.com/10037367/87228853-e3f43100-c39b-11ea-9b33-95f94afb87ad.png)


Comments
----------------------------------------
_Anything else you would like the reviewer to note_

This corrects an issue introduced with 5.27.0