### PR TITLE
APIv4 - Fix saving custom fields with same name

### DIFF
--- a/Civi/Api4/Generic/Traits/DAOActionTrait.php
+++ b/Civi/Api4/Generic/Traits/DAOActionTrait.php
@@ -12,6 +12,7 @@
 
 namespace Civi\Api4\Generic\Traits;
 
+use Civi\Api4\CustomField;
 use Civi\Api4\Utils\FormattingUtil;
 
 /**
@@ -168,50 +169,29 @@ trait DAOActionTrait {
     // $customValueID is the ID of the custom value in the custom table for this
     // entity (i guess this assumes it's not a multi value entity)
     foreach ($params as $name => $value) {
-      if (strpos($name, '.') === FALSE) {
+      $field = $this->getCustomFieldInfo($name);
+      if (!$field) {
         continue;
       }
 
-      list($customGroup, $customField) = explode('.', $name);
-      list($customField, $option) = array_pad(explode(':', $customField), 2, NULL);
-
-      $customFieldId = \CRM_Core_BAO_CustomField::getFieldValue(
-        \CRM_Core_DAO_CustomField::class,
-        $customField,
-        'id',
-        'name'
-      );
-      $customFieldType = \CRM_Core_BAO_CustomField::getFieldValue(
-        \CRM_Core_DAO_CustomField::class,
-        $customField,
-        'html_type',
-        'name'
-      );
-      $customFieldExtends = \CRM_Core_BAO_CustomGroup::getFieldValue(
-        \CRM_Core_DAO_CustomGroup::class,
-        $customGroup,
-        'extends',
-        'name'
-      );
-
       // todo are we sure we don't want to allow setting to NULL? need to test
-      if ($customFieldId && NULL !== $value) {
+      if (NULL !== $value) {
 
-        if ($option) {
-          $options = FormattingUtil::getPseudoconstantList($this->getEntityName(), 'custom_' . $customFieldId, $option, $params, $this->getActionName());
+        if ($field['suffix']) {
+          $options = FormattingUtil::getPseudoconstantList($this->getEntityName(), 'custom_' . $field['id'], $field['suffix'], $params, $this->getActionName());
           $value = FormattingUtil::replacePseudoconstant($options, $value, TRUE);
         }
 
-        if ($customFieldType === 'CheckBox') {
+        if ($field['html_type'] === 'CheckBox') {
           // this function should be part of a class
-          formatCheckBoxField($value, 'custom_' . $customFieldId, $this->getEntityName());
+          formatCheckBoxField($value, 'custom_' . $field['id'], $this->getEntityName());
         }
 
         \CRM_Core_BAO_CustomField::formatCustomField(
-          $customFieldId,
+          $field['id'],
           $customParams,
           $value,
-          $customFieldExtends,
+          $field['custom_group.extends'],
           // todo check when this is needed
           NULL,
           $entityId,
@@ -225,6 +205,30 @@ trait DAOActionTrait {
     if ($customParams) {
       $params['custom'] = $customParams;
     }
+  }
+
+  /**
+   * Gets field info needed to save custom data
+   *
+   * @param string $name
+   *   Field identifier with possible suffix, e.g. MyCustomGroup.MyField1:label
+   * @return array|NULL
+   */
+  protected function getCustomFieldInfo($name) {
+    if (strpos($name, '.') === FALSE) {
+      return NULL;
+    }
+    list($groupName, $fieldName) = explode('.', $name);
+    list($fieldName, $suffix) = array_pad(explode(':', $fieldName), 2, NULL);
+    if (empty(\Civi::$statics['APIv4_Custom_Fields'][$groupName])) {
+      \Civi::$statics['APIv4_Custom_Fields'][$groupName] = (array) CustomField::get()
+        ->setCheckPermissions(FALSE)
+        ->addSelect('id', 'name', 'html_type', 'custom_group.extends')
+        ->addWhere('custom_group.name', '=', $groupName)
+        ->execute()->indexBy('name');
+    }
+    $info = \Civi::$statics['APIv4_Custom_Fields'][$groupName][$fieldName] ?? NULL;
+    return $info ? ['suffix' => $suffix] + $info : NULL;
   }
 
   /**

--- a/tests/phpunit/api/v4/Action/BasicCustomFieldTest.php
+++ b/tests/phpunit/api/v4/Action/BasicCustomFieldTest.php
@@ -90,27 +90,38 @@ class BasicCustomFieldTest extends BaseCustomValueTest {
 
   public function testWithTwoFields() {
 
-    $customGroup = CustomGroup::create()
+    // First custom set
+    CustomGroup::create()
       ->setCheckPermissions(FALSE)
       ->addValue('name', 'MyContactFields')
       ->addValue('extends', 'Contact')
-      ->execute()
-      ->first();
-
-    CustomField::create()
-      ->setCheckPermissions(FALSE)
-      ->addValue('label', 'FavColor')
-      ->addValue('custom_group_id', $customGroup['id'])
-      ->addValue('html_type', 'Text')
-      ->addValue('data_type', 'String')
+      ->addChain('field1', CustomField::create()
+        ->addValue('label', 'FavColor')
+        ->addValue('custom_group_id', '$id')
+        ->addValue('html_type', 'Text')
+        ->addValue('data_type', 'String'))
+      ->addChain('field2', CustomField::create()
+        ->addValue('label', 'FavFood')
+        ->addValue('custom_group_id', '$id')
+        ->addValue('html_type', 'Text')
+        ->addValue('data_type', 'String'))
       ->execute();
 
-    CustomField::create()
+    // Second custom set
+    CustomGroup::create()
       ->setCheckPermissions(FALSE)
-      ->addValue('label', 'FavFood')
-      ->addValue('custom_group_id', $customGroup['id'])
-      ->addValue('html_type', 'Text')
-      ->addValue('data_type', 'String')
+      ->addValue('name', 'MyContactFields2')
+      ->addValue('extends', 'Contact')
+      ->addChain('field1', CustomField::create()
+        ->addValue('label', 'FavColor')
+        ->addValue('custom_group_id', '$id')
+        ->addValue('html_type', 'Text')
+        ->addValue('data_type', 'String'))
+      ->addChain('field2', CustomField::create()
+        ->addValue('label', 'FavFood')
+        ->addValue('custom_group_id', '$id')
+        ->addValue('html_type', 'Text')
+        ->addValue('data_type', 'String'))
       ->execute();
 
     $contactId1 = Contact::create()
@@ -145,19 +156,38 @@ class BasicCustomFieldTest extends BaseCustomValueTest {
     $this->assertArrayHasKey('MyContactFields.FavColor', $contact);
     $this->assertEquals('Red', $contact['MyContactFields.FavColor']);
 
+    // Update 2nd set and ensure 1st hasn't changed
+    Contact::update()
+      ->addWhere('id', '=', $contactId1)
+      ->addValue('MyContactFields2.FavColor', 'Orange')
+      ->addValue('MyContactFields2.FavFood', 'Tangerine')
+      ->execute();
+    $contact = Contact::get()
+      ->setCheckPermissions(FALSE)
+      ->addSelect('MyContactFields.FavColor', 'MyContactFields2.FavColor', 'MyContactFields.FavFood', 'MyContactFields2.FavFood')
+      ->addWhere('id', '=', $contactId1)
+      ->execute()
+      ->first();
+    $this->assertEquals('Red', $contact['MyContactFields.FavColor']);
+    $this->assertEquals('Orange', $contact['MyContactFields2.FavColor']);
+    $this->assertEquals('Cherry', $contact['MyContactFields.FavFood']);
+    $this->assertEquals('Tangerine', $contact['MyContactFields2.FavFood']);
+
+    // Update 1st set and ensure 2st hasn't changed
     Contact::update()
       ->addWhere('id', '=', $contactId1)
       ->addValue('MyContactFields.FavColor', 'Blue')
       ->execute();
-
     $contact = Contact::get()
       ->setCheckPermissions(FALSE)
-      ->addSelect('MyContactFields.FavColor')
+      ->addSelect('MyContactFields.FavColor', 'MyContactFields2.FavColor', 'MyContactFields.FavFood', 'MyContactFields2.FavFood')
       ->addWhere('id', '=', $contactId1)
       ->execute()
       ->first();
-
     $this->assertEquals('Blue', $contact['MyContactFields.FavColor']);
+    $this->assertEquals('Orange', $contact['MyContactFields2.FavColor']);
+    $this->assertEquals('Cherry', $contact['MyContactFields.FavFood']);
+    $this->assertEquals('Tangerine', $contact['MyContactFields2.FavFood']);
 
     $search = Contact::get()
       ->setCheckPermissions(FALSE)


### PR DESCRIPTION
Overview
----------------------------------------
This fixes the bug documented in https://lab.civicrm.org/dev/core/-/issues/1866

In API4 custom fields are referred to as eg 'Custom_Group1.Custom_Field1'.

If the same custom field name is used in two custom field groups, API4 gets confused and updates to the field in the second group are either wrongly applied to the field in the first group, or have no effect.

Reproduction steps
----------------------------------------
1. Create a custom field group 'CustomGroup1' used for Individuals and custom field 'myfield' (alpha text)
1. Create a custom field group 'CustomGroup2' used for Individuals and custom field 'myfield' (alpha text)

1. Use [API4](https://dmaster.demo.civicrm.org/civicrm/api4#/explorer/Contact/update?where=%5B%5B%22id%22,%22%3D%22,%22203%22%5D%5D&values=%5B%5B%22CustomGroup1.MyField%22,%22hello%22%5D%5D) to set 'CustomGroup1.myfield' to 'hello' -  works as expected

1. Use [API4](https://dmaster.demo.civicrm.org/civicrm/api4#/explorer/Contact/update?where=%5B%5B%22id%22,%22%3D%22,%22203%22%5D%5D&values=%5B%5B%22CustomGroup2.MyField%22,%22world%22%5D%5D) to set 'CustomGroup2.myfield' to 'world' - Observe that the wrong field is updated: 'CustomGroup**1**.myfield' is changed to 'world', no change to CustomGroup2.myfield

Note that if the CustomGroups are used for different purposes and only the second group is applicable, attempts to update its field have no effect.
