### PR TITLE
Sort permittedActivityTypes

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -2455,6 +2455,7 @@ INNER JOIN  civicrm_option_group grp ON (grp.id = option_group_id AND grp.name =
       foreach ($types as $type) {
         $permittedActivityTypes[$type['activity_type_id']] = (int) $type['activity_type_id'];
       }
+      asort($permittedActivityTypes);
       Civi::$statics[__CLASS__]['permitted_activity_types'][$userID] = $permittedActivityTypes;
     }
     return Civi::$statics[__CLASS__]['permitted_activity_types'][$userID];


### PR DESCRIPTION
Overview
----------------------------------------
When determining whether to add a clause filtering activity types the permitted types
are compared to all types. If all are permitted no clause is needed.



Before
----------------------------------------
activity_type_id IN (1,3,,4) added, even when all activity type ids are in the IN

After
----------------------------------------
Clause not added if it includes all types

Technical Details
----------------------------------------
Without this sort it is incorrectly comparing the keys of the 2 arrays in addSelectWhere and concluding that they differ

Comments
----------------------------------------

