### PR TITLE
CheckEnv - Give new installs a grace period before 'Cron Not Running' msg

### DIFF
--- a/CRM/Core/JobManager.php
+++ b/CRM/Core/JobManager.php
@@ -73,6 +73,7 @@ class CRM_Core_JobManager {
     $statusPref = [
       'name' => 'checkLastCron',
       'check_info' => gmdate('U'),
+      'prefs' => '',
     ];
     CRM_Core_BAO_StatusPreference::create($statusPref);
   }


### PR DESCRIPTION
Overview
----------------------------------------
Don't bug site admins with "Cron Not Running" error messages right after install. Instead, give them a day's grace period in which to set it up.

Inspired by discussion at https://lab.civicrm.org/dev/core/-/issues/1863#note_39918

Before
----------------------------------------
"Cron Not Running" error pops up immediately after installing CiviCRM.

After
----------------------------------------
The error is suppressed for 24 hrs.

Technical Details
----------------------------------------
The last cron run is recorded as a status preference. That's a little odd, but I'll go with it. 
Now if a cron run isn't recorded, we create one with `prefs = 'new'` to distinguish it from normal cron runs.
I'm honestly not sure what the 'prefs' column is *supposed* to be used for; grepping turns up nothing. But it seems to work for this purpose.