### PR TITLE
APIv4 - Specify BridgeEntities to assist with joins

### DIFF
--- a/Civi/Api4/ActivityContact.php
+++ b/Civi/Api4/ActivityContact.php
@@ -29,6 +29,6 @@ namespace Civi\Api4;
  * @see \Civi\Api4\Activity
  * @package Civi\Api4
  */
-class ActivityContact extends Generic\DAOEntity {
+class ActivityContact extends Generic\BridgeEntity {
 
 }

--- a/Civi/Api4/Entity.php
+++ b/Civi/Api4/Entity.php
@@ -52,6 +52,11 @@ class Entity extends Generic\AbstractEntity {
           'description' => 'Localized title',
         ],
         [
+          'name' => 'type',
+          'description' => 'Base class for this entity',
+          'options' => ['DAOEntity' => 'DAOEntity', 'BasicEntity' => 'BasicEntity', 'BridgeEntity' => 'BridgeEntity', 'AbstractEntity' => 'AbstractEntity'],
+        ],
+        [
           'name' => 'description',
           'description' => 'Description from docblock',
         ],

--- a/Civi/Api4/EntityTag.php
+++ b/Civi/Api4/EntityTag.php
@@ -25,6 +25,6 @@ namespace Civi\Api4;
  *
  * @package Civi\Api4
  */
-class EntityTag extends Generic\DAOEntity {
+class EntityTag extends Generic\BridgeEntity {
 
 }

--- a/Civi/Api4/Generic/AbstractEntity.php
+++ b/Civi/Api4/Generic/AbstractEntity.php
@@ -78,7 +78,7 @@ abstract class AbstractEntity {
    * @return string
    */
   protected static function getEntityName() {
-    return substr(static::class, strrpos(static::class, '\\') + 1);
+    return self::stripNamespace(static::class);
   }
 
   /**
@@ -121,11 +121,22 @@ abstract class AbstractEntity {
     $info = [
       'name' => static::getEntityName(),
       'title' => static::getEntityTitle(),
+      'type' => self::stripNamespace(get_parent_class(static::class)),
     ];
     $reflection = new \ReflectionClass(static::class);
     $info += ReflectionUtils::getCodeDocs($reflection, NULL, ['entity' => $info['name']]);
     unset($info['package'], $info['method']);
     return $info;
+  }
+
+  /**
+   * Remove namespace prefix from a class name
+   *
+   * @param string $className
+   * @return string
+   */
+  private static function stripNamespace($className) {
+    return substr($className, strrpos($className, '\\') + 1);
   }
 
 }

--- a/Civi/Api4/Generic/BridgeEntity.php
+++ b/Civi/Api4/Generic/BridgeEntity.php
@@ -1,5 +1,4 @@
 <?php
-
 /*
  +--------------------------------------------------------------------+
  | Copyright CiviCRM LLC. All rights reserved.                        |
@@ -10,22 +9,13 @@
  +--------------------------------------------------------------------+
  */
 
-/**
- *
- * @package CRM
- * @copyright CiviCRM LLC https://civicrm.org/licensing
- */
-
-namespace Civi\Api4;
+namespace Civi\Api4\Generic;
 
 /**
- * DashboardContact entity.
+ * A bridge is a small table that provides an intermediary link between two other tables.
  *
- * This places a dashboard item on a user's home screen.
- *
- * @see \Civi\Api4\Dashboard
- * @package Civi\Api4
+ * The API can automatically incorporate a bridgeEntity into a join expression.
  */
-class DashboardContact extends Generic\BridgeEntity {
+class BridgeEntity extends DAOEntity {
 
 }

--- a/Civi/Api4/Generic/DAOGetAction.php
+++ b/Civi/Api4/Generic/DAOGetAction.php
@@ -48,7 +48,21 @@ class DAOGetAction extends AbstractGetAction {
   /**
    * Joins to other entities.
    *
+   * Each join is an array of properties:
+   *
+   * ```
+   * [Entity, Required, Bridge, [field, op, value]...]
+   * ```
+   *
+   * - `Entity`: the name of the api entity to join onto.
+   * - `Required`: `TRUE` for an `INNER JOIN`, `FALSE` for a `LEFT JOIN`.
+   * - `Bridge` (optional): Name of a BridgeEntity to incorporate into the join.
+   * - `[field, op, value]...`: zero or more conditions for the ON clause, using the same nested format as WHERE and HAVING
+   *     but with the difference that "value" is interpreted as an expression (e.g. can be the name of a field).
+   *     Enclose literal values with quotes.
+   *
    * @var array
+   * @see \Civi\Api4\Generic\BridgeEntity
    */
   protected $join = [];
 
@@ -141,10 +155,14 @@ class DAOGetAction extends AbstractGetAction {
   /**
    * @param string $entity
    * @param bool $required
+   * @param string $bridge
    * @param array ...$conditions
    * @return DAOGetAction
    */
-  public function addJoin(string $entity, bool $required = FALSE, ...$conditions): DAOGetAction {
+  public function addJoin(string $entity, bool $required = FALSE, $bridge = NULL, ...$conditions): DAOGetAction {
+    if ($bridge) {
+      array_unshift($conditions, $bridge);
+    }
     array_unshift($conditions, $entity, $required);
     $this->join[] = $conditions;
     return $this;

--- a/Civi/Api4/GroupContact.php
+++ b/Civi/Api4/GroupContact.php
@@ -30,7 +30,7 @@ namespace Civi\Api4;
  *
  * @package Civi\Api4
  */
-class GroupContact extends Generic\DAOEntity {
+class GroupContact extends Generic\BridgeEntity {
 
   /**
    * @return Action\GroupContact\Create

--- a/Civi/Api4/Query/Api4SelectQuery.php
+++ b/Civi/Api4/Query/Api4SelectQuery.php
@@ -439,7 +439,7 @@ class Api4SelectQuery {
     // Prevent (most) redundant acl sub clauses if they have already been applied to the main entity.
     // FIXME: Currently this only works 1 level deep, but tracking through multiple joins would increase complexity
     // and just doing it for the first join takes care of most acl clause deduping.
-    if (count($stack) === 1 && in_array($stack[0], $this->aclFields)) {
+    if (count($stack) === 1 && in_array($stack[0], $this->aclFields, TRUE)) {
       return [];
     }
     $clauses = $baoName::getSelectWhereClause($tableAlias);
@@ -494,12 +494,18 @@ class Api4SelectQuery {
       // First item in the array is a boolean indicating if the join is required (aka INNER or LEFT).
       // The rest are join conditions.
       $side = array_shift($join) ? 'INNER' : 'LEFT';
+      // Add all fields from joined entity to spec
       $joinEntityGet = \Civi\API\Request::create($entity, 'get', ['version' => 4, 'checkPermissions' => $this->getCheckPermissions()]);
       foreach ($joinEntityGet->entityFields() as $field) {
         $field['sql_name'] = '`' . $alias . '`.`' . $field['column_name'] . '`';
         $this->addSpecField($alias . '.' . $field['name'], $field);
       }
-      $conditions = $this->getJoinConditions($entity, $alias);
+      if (!empty($join[0]) && is_string($join[0]) && \CRM_Utils_Rule::alphanumeric($join[0])) {
+        $conditions = $this->getBridgeJoin($join, $entity, $alias);
+      }
+      else {
+        $conditions = $this->getJoinConditions($join, $entity, $alias);
+      }
       foreach (array_filter($join) as $clause) {
         $conditions[] = $this->treeWalkClauses($clause, 'ON');
       }
@@ -511,33 +517,131 @@ class Api4SelectQuery {
   /**
    * Supply conditions for an explicit join.
    *
-   * @param $entity
-   * @param $alias
+   * @param array $joinTree
+   * @param string $joinEntity
+   * @param string $alias
    * @return array
    */
-  private function getJoinConditions($entity, $alias) {
+  private function getJoinConditions($joinTree, $joinEntity, $alias) {
     $conditions = [];
     // getAclClause() expects a stack of 1-to-1 join fields to help it dedupe, but this is more flexible,
     // so unless this is a direct 1-to-1 join with the main entity, we'll just hack it
     // with a padded empty stack to bypass its deduping.
     $stack = [NULL, NULL];
-    foreach ($this->apiFieldSpec as $name => $field) {
-      if ($field['entity'] !== $entity && $field['fk_entity'] === $entity) {
-        $conditions[] = $this->treeWalkClauses([$name, '=', "$alias.id"], 'ON');
+    // If we're not explicitly referencing the joinEntity ID in the ON clause, search for a default
+    $explicitId = array_filter($joinTree, function($clause) use ($alias) {
+      list($sideA, $op, $sideB) = array_pad((array) $clause, 3, NULL);
+      return $op === '=' && ($sideA === "$alias.id" || $sideB === "$alias.id");
+    });
+    if (!$explicitId) {
+      foreach ($this->apiFieldSpec as $name => $field) {
+        if ($field['entity'] !== $joinEntity && $field['fk_entity'] === $joinEntity) {
+          $conditions[] = $this->treeWalkClauses([$name, '=', "$alias.id"], 'ON');
+        }
+        elseif (strpos($name, "$alias.") === 0 && substr_count($name, '.') === 1 && $field['fk_entity'] === $this->getEntity()) {
+          $conditions[] = $this->treeWalkClauses([$name, '=', 'id'], 'ON');
+          $stack = ['id'];
+        }
       }
-      elseif (strpos($name, "$alias.") === 0 && substr_count($name, '.') === 1 &&  $field['fk_entity'] === $this->getEntity()) {
-        $conditions[] = $this->treeWalkClauses([$name, '=', 'id'], 'ON');
-        $stack = ['id'];
+      // Hmm, if we came up with > 1 condition, then it's ambiguous how it should be joined so we won't return anything but the generic ACLs
+      if (count($conditions) > 1) {
+        $stack = [NULL, NULL];
+        $conditions = [];
       }
     }
-    // Hmm, if we came up with > 1 condition, then it's ambiguous how it should be joined so we won't return anything but the generic ACLs
-    if (count($conditions) > 1) {
-      $stack = [NULL, NULL];
-      $conditions = [];
-    }
-    $baoName = CoreUtil::getBAOFromApiName($entity);
+    $baoName = CoreUtil::getBAOFromApiName($joinEntity);
     $acls = array_values($this->getAclClause($alias, $baoName, $stack));
     return array_merge($acls, $conditions);
+  }
+
+  /**
+   * Join onto a BridgeEntity table
+   *
+   * @param array $joinTree
+   * @param string $joinEntity
+   * @param string $alias
+   * @return array
+   * @throws \API_Exception
+   */
+  protected function getBridgeJoin(&$joinTree, $joinEntity, $alias) {
+    $bridgeEntity = array_shift($joinTree);
+    if (!is_a('\Civi\Api4\\' . $bridgeEntity, '\Civi\Api4\Generic\BridgeEntity', TRUE)) {
+      throw new \API_Exception("Illegal bridge entity specified: " . $bridgeEntity);
+    }
+    $bridgeAlias = $alias . '_via_' . strtolower($bridgeEntity);
+    $bridgeTable = CoreUtil::getTableName($bridgeEntity);
+    $joinTable = CoreUtil::getTableName($joinEntity);
+    $bridgeEntityGet = \Civi\API\Request::create($bridgeEntity, 'get', ['version' => 4, 'checkPermissions' => $this->getCheckPermissions()]);
+    $fkToJoinField = $fkToBaseField = NULL;
+    // Find the bridge field that links to the joinEntity (either an explicit FK or an entity_id/entity_table combo)
+    foreach ($bridgeEntityGet->entityFields() as $name => $field) {
+      if ($field['fk_entity'] === $joinEntity || (!$fkToJoinField && $name === 'entity_id')) {
+        $fkToJoinField = $name;
+      }
+    }
+    // Get list of entities allowed for entity_table
+    if (array_key_exists('entity_id', $bridgeEntityGet->entityFields())) {
+      $entityTables = (array) civicrm_api4($bridgeEntity, 'getFields', [
+        'checkPermissions' => FALSE,
+        'where' => [['name', '=', 'entity_table']],
+        'loadOptions' => TRUE,
+      ], ['options'])->first();
+    }
+    // If bridge field to joinEntity is entity_id, validate entity_table is allowed
+    if (!$fkToJoinField || ($fkToJoinField === 'entity_id' && !array_key_exists($joinTable, $entityTables))) {
+      throw new \API_Exception("Unable to join $bridgeEntity to $joinEntity");
+    }
+    // Create link between bridge entity and join entity
+    $joinConditions = [
+      "`$bridgeAlias`.`$fkToJoinField` = `$alias`.`id`",
+    ];
+    if ($fkToJoinField === 'entity_id') {
+      $joinConditions[] = "`$bridgeAlias`.`entity_table` = '$joinTable'";
+    }
+    // Register fields from the bridge entity as if they belong to the join entity
+    foreach ($bridgeEntityGet->entityFields() as $name => $field) {
+      if ($name == 'id' || $name == $fkToJoinField || ($name == 'entity_table' && $fkToJoinField == 'entity_id')) {
+        continue;
+      }
+      if ($field['fk_entity'] || (!$fkToBaseField && $name == 'entity_id')) {
+        $fkToBaseField = $name;
+      }
+      // Note these fields get a sql alias pointing to the bridge entity, but an api alias pretending they belong to the join entity
+      $field['sql_name'] = '`' . $bridgeAlias . '`.`' . $field['column_name'] . '`';
+      $this->addSpecField($alias . '.' . $field['name'], $field);
+    }
+    // Move conditions for the bridge join out of the joinTree
+    $bridgeConditions = [];
+    $joinTree = array_filter($joinTree, function($clause) use ($fkToBaseField, $alias, $bridgeAlias, &$bridgeConditions) {
+      list($sideA, $op, $sideB) = array_pad((array) $clause, 3, NULL);
+      if ($op === '=' && $sideB && ($sideA === "$alias.$fkToBaseField" || $sideB === "$alias.$fkToBaseField")) {
+        $expr = $sideA === "$alias.$fkToBaseField" ? $sideB : $sideA;
+        $bridgeConditions[] = "`$bridgeAlias`.`$fkToBaseField` = " . $this->getExpression($expr)->render($this->apiFieldSpec);
+        return FALSE;
+      }
+      elseif ($op === '=' && $fkToBaseField == 'entity_id' && ($sideA === "$alias.entity_table" || $sideB === "$alias.entity_table")) {
+        $expr = $sideA === "$alias.entity_table" ? $sideB : $sideA;
+        $bridgeConditions[] = "`$bridgeAlias`.`entity_table` = " . $this->getExpression($expr)->render($this->apiFieldSpec);
+        return FALSE;
+      }
+      return TRUE;
+    });
+    // If no bridge conditions were specified, link it to the base entity
+    if (!$bridgeConditions) {
+      $bridgeConditions[] = "`$bridgeAlias`.`$fkToBaseField` = a.id";
+      if ($fkToBaseField == 'entity_id') {
+        if (!array_key_exists($this->getFrom(), $entityTables)) {
+          throw new \API_Exception("Unable to join $bridgeEntity to " . $this->getEntity());
+        }
+        $bridgeConditions[] = "`$bridgeAlias`.`entity_table` = '" . $this->getFrom() . "'";
+      }
+    }
+
+    $this->join('LEFT', $bridgeTable, $bridgeAlias, $bridgeConditions);
+
+    $baoName = CoreUtil::getBAOFromApiName($joinEntity);
+    $acls = array_values($this->getAclClause($alias, $baoName, [NULL, NULL]));
+    return array_merge($acls, $joinConditions);
   }
 
   /**

--- a/Civi/Api4/UFMatch.php
+++ b/Civi/Api4/UFMatch.php
@@ -26,6 +26,6 @@ namespace Civi\Api4;
  *
  * @package Civi\Api4
  */
-class UFMatch extends Generic\DAOEntity {
+class UFMatch extends Generic\BridgeEntity {
 
 }

--- a/ang/api4Explorer/Explorer.html
+++ b/ang/api4Explorer/Explorer.html
@@ -70,10 +70,15 @@
                 <div class="api4-input form-inline">
                   <i class="crm-i fa-arrows"></i>
                   <input class="form-control twenty" type="text" ng-model="params.join[$index][0]" ng-model-options="{updateOn: 'blur'}" ng-change="$ctrl.buildFieldList()"/>
+                  <label>{{:: ts('Required:') }}</label>
                   <select class="form-control" ng-model="params.join[$index][1]" ng-options="o.k as o.v for o in ::joinTypes" ></select>
+                  <label>{{:: ts('Using:') }}</label>
+                  <select class="form-control" ng-model="params.join[$index][2]" ng-options="e.name as e.name for e in ::bridgeEntities" ng-change="$ctrl.buildFieldList()">
+                    <option value="">{{:: ts('- none -') }}</option>
+                  </select>
                   <a href class="crm-hover-button" title="Clear" ng-click="clearParam('join', $index)"><i class="crm-i fa-times"></i></a>
                 </div>
-                <fieldset class="api4-clause-fieldset" crm-api4-clause="{skip: 2, clauses: params.join[$index], op: 'AND', label: 'On', fields: fieldsAndJoins, format: 'plain'}">
+                <fieldset class="api4-clause-fieldset" crm-api4-clause="{skip: 3, clauses: params.join[$index], op: 'AND', label: 'On', fields: fieldsAndJoins, format: 'plain'}">
                 </fieldset>
               </fieldset>
             </div>

--- a/ang/api4Explorer/Explorer.js
+++ b/ang/api4Explorer/Explorer.js
@@ -56,7 +56,8 @@
     $scope.loading = false;
     $scope.controls = {};
     $scope.langs = ['php', 'js', 'ang', 'cli'];
-    $scope.joinTypes = [{k: false, v: ts('Optional')}, {k: true, v: ts('Required')}];
+    $scope.joinTypes = [{k: false, v: 'FALSE (LEFT JOIN)'}, {k: true, v: 'TRUE (INNER JOIN)'}];
+    $scope.bridgeEntities = _.filter(schema, {type: 'BridgeEntity'});
     $scope.code = {
       php: [
         {name: 'oop', label: ts('OOP Style'), code: ''},

--- a/css/api4-explorer.css
+++ b/css/api4-explorer.css
@@ -54,10 +54,6 @@
   margin-bottom: 10px;
 }
 
-#bootstrap-theme.api4-explorer-page .api4-input.form-inline > label {
-  margin-right: 12px;
-}
-
 #bootstrap-theme.api4-explorer-page .explorer-help-panel .panel-body {
   word-break: break-word;
 }


### PR DESCRIPTION
Overview
----------------------------------------
In our schema we have these tiny tables like `civicrm_entity_tag` which serve no purpose other than to "bridge" 2 other tables together. Arguably they don't deserve to be their own API entities, but what I've done here is to at least distinguish them as "bridge" entities so they can receive separate treatment in search screens.
I've also taught the API to create joins through these bridge entities with a fairly simple syntax that, to the API consumer, only feels like 1 join, when behind the scenes the api constructs both joins and figures out which FKs link the 3 tables together.

Comments
----------------------------------------
This gets us closer to having things like Activities and Tags in the new SearchCreator. It still doesn't solve the problem of groups, which use 2 tables + caching to deal with smart groups. It also doesn't yet solve the problem of getting these things easily discoverable in the SearchCreator UI, but it's a step in the right direction.