### PR TITLE
dev/core#1867 CiviReport filters: Fix incorrect defaulting to the beginning rather than end the to-range day

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -2185,6 +2185,10 @@ class CRM_Report_Form extends CRM_Core_Form {
       $sqlOP = $this->getSQLOperator($relative);
       return "( {$fieldName} {$sqlOP} )";
     }
+    if (strlen($to) === 10) {
+      // If we just have the date we assume the end of that day.
+      $to .= ' 23:59:59';
+    }
 
     if ($relative) {
       list($from, $to) = $this->getFromTo($relative, $from, $to, $fromTime, $toTime);


### PR DESCRIPTION
Overview
----------------------------------------
Per https://lab.civicrm.org/dev/core/-/issues/1867 the to date is being treated as having time 00:00:00 - @karing did some checks for us and confirmed this was not the case inn 5.21 and I believe it regressed inn 5.25 
https://github.com/civicrm/civicrm-core/commit/6d6630cf6d9a5057e8d620644ccf5abbbe7ae461#diff-d355cdb00cea3915a3cf306c6c08f6a6L2206

Before
----------------------------------------

<img width="583" alt="Screen Shot 2020-07-13 at 5 51 49 PM" src="https://user-images.githubusercontent.com/336308/87275268-d96ba000-c531-11ea-903e-a4f2fc177cdc.png">

interpreted as from 1 July 2020 at 0 am to 13 July 2020 at 0 am


After
----------------------------------------
interpreted as from 1 July 2020 at 0 am to 13 July 2020 at 23:59:59 pm

Technical Details
----------------------------------------


Comments
----------------------------------------

