### PR TITLE
dev/core#1861 fix failure to unset location_type_id when saving uffield

### DIFF
--- a/CRM/UF/Form/Field.php
+++ b/CRM/UF/Form/Field.php
@@ -532,7 +532,7 @@ class CRM_UF_Form_Field extends CRM_Core_Form {
     }
     elseif ($params['field_name'][2] == 0) {
       // 0 is Primary location type
-      $apiFormattedParams['location_type_id'] = NULL;
+      $apiFormattedParams['location_type_id'] = '';
     }
     if (!empty($params['field_name'][3])) {
       $apiFormattedParams['phone_type_id'] = $params['field_name'][3];


### PR DESCRIPTION


Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/1861

If this is a regression it probably from 2017
https://github.com/civicrm/civicrm-core/commit/2e74ff5574027b2ce84177b82884ebd7c9b87fd1#diff-1911d0c1a896701ba9aa044181f5972bR556

Before
----------------------------------------
When updating a field within a profile 'Primary' does not save NULL to the DB and the prior location type is retained

After
----------------------------------------
Saves

Technical Details
----------------------------------------


Comments
----------------------------------------

