### PR TITLE
Make new email open and url routes 'public'

### DIFF
--- a/CRM/Mailing/xml/Menu/Mailing.xml
+++ b/CRM/Mailing/xml/Menu/Mailing.xml
@@ -206,10 +206,12 @@
     <path>civicrm/mailing/url</path>
     <page_callback>CRM_Mailing_Page_Url</page_callback>
     <access_arguments>*always allow*</access_arguments>
+    <is_public>true</is_public>
   </item>
   <item>
     <path>civicrm/mailing/open</path>
     <page_callback>CRM_Mailing_Page_Open</page_callback>
     <access_arguments>*always allow*</access_arguments>
+    <is_public>true</is_public>
   </item>
 </menu>


### PR DESCRIPTION
Overview
----------------------------------------
The new email url click-tracking and open-tracking routes are not marked as 'public' paths, even though they are. Let's add the is_public flag, to keep it consistent with other routes.

This is useful for sites that rely on this flag for implementing additional security for 'non-public' paths, for example. (Although this is custom functionality).

Ping @totten 