### PR TITLE
Fix dedupe on same-activity-connection

### DIFF
--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -535,6 +535,12 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
         continue;
       }
 
+      if ($table === 'civicrm_activity_contact') {
+        $sqls[] = "UPDATE IGNORE civicrm_activity_contact SET contact_id = $mainId WHERE contact_id = $otherId";
+        $sqls[] = "DELETE FROM civicrm_activity_contact WHERE contact_id = $otherId";
+        continue;
+      }
+
       // use UPDATE IGNORE + DELETE query pair to skip on situations when
       // there's a UNIQUE restriction on ($field, some_other_field) pair
       if (isset($cidRefs[$table])) {

--- a/tests/phpunit/api/v3/JobTest.php
+++ b/tests/phpunit/api/v3/JobTest.php
@@ -595,6 +595,16 @@ class api_v3_JobTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test that we handle cache entries without clashes.
+   */
+  public function testMergeSharedActivity() {
+    $contactID = $this->individualCreate();
+    $contact2ID = $this->individualCreate();
+    $activityID = $this->activityCreate(['target_contact_id' => [$contactID, $contact2ID]]);
+    $this->callAPISuccess('Job', 'process_batch_merge', ['mode' => 'safe']);
+  }
+
+  /**
    * Test the decisions made for addresses when merging.
    *
    * @dataProvider getMergeLocationData


### PR DESCRIPTION
Overview
----------------------------------------
Fix further variant of https://lab.civicrm.org/dev/core/-/issues/1862

Before
----------------------------------------
Error per https://lab.civicrm.org/dev/core/-/issues/1862#note_40073

After
----------------------------------------
no error

Technical Details
----------------------------------------
This is a hacky fix + test. I think the way forwards is to identify which tables are relevant to the 2 contacts in question but I think we need to keep building test cover a bit longer before that change

Comments
----------------------------------------

