### PR TITLE
dev/core#1812 Do not allow enabling database logging when using multilingual

### DIFF
--- a/CRM/Admin/Form/Setting/Miscellaneous.php
+++ b/CRM/Admin/Form/Setting/Miscellaneous.php
@@ -75,6 +75,8 @@ class CRM_Admin_Form_Setting_Miscellaneous extends CRM_Admin_Form_Setting {
     CRM_Utils_System::setTitle(ts('Misc (Undelete, PDFs, Limits, Logging, Captcha, etc.)'));
 
     $this->assign('validTriggerPermission', CRM_Core_DAO::checkTriggerViewPermission(FALSE));
+    // dev/core#1812 Assign multilingual status.
+    $this->assign('isMultilingual', CRM_Core_I18n::isMultilingual());
 
     $this->addFormRule(['CRM_Admin_Form_Setting_Miscellaneous', 'formRule'], $this);
 

--- a/CRM/Logging/Schema.php
+++ b/CRM/Logging/Schema.php
@@ -77,6 +77,10 @@ class CRM_Logging_Schema {
     if (!(CRM_Core_DAO::checkTriggerViewPermission(FALSE)) && $value) {
       throw new API_Exception(ts("In order to use this functionality, the installation's database user must have privileges to create triggers and views (if binary logging is enabled – this means the SUPER privilege). This install does not have the required privilege(s) enabled."));
     }
+    // dev/core#1812 Disable logging in a multilingual environment.
+    if (CRM_Core_I18n::isMultilingual() && $value) {
+      throw new API_Exception(ts("Logging is not supported in a multilingual environment!"));
+    }
     return TRUE;
   }
 

--- a/templates/CRM/Admin/Form/Setting/Miscellaneous.tpl
+++ b/templates/CRM/Admin/Form/Setting/Miscellaneous.tpl
@@ -31,10 +31,14 @@
         <td>
           {$form.logging.html}<br />
         {if $validTriggerPermission}
-          <p class="description">{ts}If enabled, all actions will be logged with a complete record of changes.{/ts}</p>
+          {if $isMultilingual}
+            <p class="description">{ts}Logging is not supported in multilingual environments.{/ts}</p>
+          {else}
+            <p class="description">{ts}If enabled, all actions will be logged with a complete record of changes.{/ts}</p>
+          {/if}
         {else}
           <p class="description">{ts}In order to use this functionality, the installation's database user must have privileges to create triggers (in MySQL 5.0 – and in MySQL 5.1 if binary logging is enabled – this means the SUPER privilege). This install either does not seem to have the required privilege enabled.{/ts}&nbsp;{ts}This functionality cannot be enabled on multilingual installations.{/ts}</p>
-         {/if}
+        {/if}
         </td>
       </tr>
       <tr class="crm-miscellaneous-form-block-doNotAttachPDFReceipt">


### PR DESCRIPTION
Overview
----------------------------------------

Logging is not supported in a multilingual environment, but that is not made clear on the page that enables logging. This deals with issue [Missing view when logging set in a non-US English instance.](https://lab.civicrm.org/dev/core/-/issues/1812) by making it impossible in the future to enable logging in a multilingual environment.

Before
----------------------------------------

![image](https://user-images.githubusercontent.com/10037367/87299007-24ba8a00-c503-11ea-8450-d54a8906096e.png)


After
----------------------------------------

![image](https://user-images.githubusercontent.com/10037367/87299168-706d3380-c503-11ea-8be7-234b15689457.png)

Technical Details
----------------------------------------

We test for if the environment is multilingual, and if it is, change the template message.  Also, if someone attempts to enable logging, we throw an error.

Comments
----------------------------------------

I spent quite some time investigating the possibility of supporting a multilingual environment, but realised it is quite complicated and need lots of testing.  This PR clarifies the current position.