### PR TITLE
Fix 'Undefined variable: jsSet in CRM_Core_BAO_Mapping::loadSavedMapping()'

### DIFF
--- a/CRM/Core/BAO/Mapping.php
+++ b/CRM/Core/BAO/Mapping.php
@@ -871,6 +871,7 @@ class CRM_Core_BAO_Mapping extends CRM_Core_DAO_Mapping {
    * @return array
    */
   protected static function loadSavedMapping($mappingLocation, int $x, int $i, $mappingName, $mapperFields, $mappingContactType, $mappingRelation, array $specialFields, $mappingPhoneType, array $defaults, array $noneArray, $mappingImProvider, $mappingOperator, $mappingValue) {
+    $jsSet = FALSE;
     $locationId = $mappingLocation[$x][$i] ?? 0;
     if (isset($mappingName[$x][$i])) {
       if (is_array($mapperFields[$mappingContactType[$x][$i]])) {


### PR DESCRIPTION
Overview
----------------------------------------
When editing smart group criteria built with 'Search builder':

`Notice: Undefined variable: jsSet in CRM_Core_BAO_Mapping::loadSavedMapping() (line 952 of /var/aegir/platforms/alumni-staging/sites/alumni.staging.drupal.uis.cam.ac.uk/modules/contrib/civicrm/CRM/Core/BAO/Mapping.php).`

Source: https://github.com/civicrm/civicrm-core/commit/5c322e13b7de0c2b0db4416680d5f8cba50a5c99 (Ping @eileenmcnaughton 

The variable forms part of the array that is returned, but it is not declared in some instances: 
https://github.com/civicrm/civicrm-core/blob/64aa560db1b9afecf26162220cf0eb8153ff5a11/CRM/Core/BAO/Mapping.php#L952

Before
----------------------------------------
jsSet might not be defined.

After
----------------------------------------
jsSet is always defined.