### PR TITLE
Simplify caching of status checks

### DIFF
--- a/CRM/Utils/Check/Component.php
+++ b/CRM/Utils/Check/Component.php
@@ -19,11 +19,6 @@ use Civi\Api4\StatusPreference;
 abstract class CRM_Utils_Check_Component {
 
   /**
-   * @var array
-   */
-  public $checksConfig = [];
-
-  /**
    * Get the configured status checks.
    *
    * @return array
@@ -32,20 +27,12 @@ abstract class CRM_Utils_Check_Component {
    * @throws \Civi\API\Exception\UnauthorizedException
    */
   public function getChecksConfig() {
-    if (empty($this->checksConfig)) {
-      $this->checksConfig = Civi::cache('checks')->get('checksConfig', []);
-      if (empty($this->checksConfig)) {
-        $this->checksConfig = StatusPreference::get(FALSE)->execute()->indexBy('name');
-      }
+    if (empty(Civi::$statics[__FUNCTION__])) {
+      Civi::$statics[__FUNCTION__] = (array) StatusPreference::get(FALSE)
+        ->addWhere('domain_id', '=', 'current_domain')
+        ->execute()->indexBy('name');
     }
-    return $this->checksConfig;
-  }
-
-  /**
-   * @param array $checksConfig
-   */
-  public function setChecksConfig(array $checksConfig) {
-    $this->checksConfig = $checksConfig;
+    return Civi::$statics[__FUNCTION__];
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Simplifies code and improves performance during system status checks.

Before
----------------------------------------
- `'domain_id'` was missing from the api params, which would have caused unexpected results and possibly crashes in multi-site setups.
- `Civi::cache` was being read but never written to.
- Non-static object caching did not persist in memory across different check classes and since there was no data in Civi::cache this caused multiple redundant queries (one per `CRM_Utils_Check_Component_*` class).
- If we did write to `Civi::cache` there is no mechanism for clearing that cache when data changes.

After
----------------------------------------
Solution: use simple array cache a-la Civi::$statics
