### PR TITLE
dev/core#1867 Ensure that the qill matches the filter when no time is…

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -3310,7 +3310,10 @@ WHERE cg.extends IN ('" . implode("','", $this->_customGroupExtends) . "') AND
             if (!empty($this->_params["{$fieldName}_relative"])) {
               list($from, $to) = CRM_Utils_Date::getFromTo($this->_params["{$fieldName}_relative"], NULL, NULL);
             }
-
+            if (strlen($to) === 10) {
+              // If we just have the date we assume the end of that day.
+              $to .= ' 23:59:59';
+            }
             if ($from || $to) {
               if ($from) {
                 $from = date('l j F Y, g:iA', strtotime($from));


### PR DESCRIPTION
… supplied

Overview
----------------------------------------
This follows on from https://github.com/civicrm/civicrm-core/pull/17811 and fixes the text of the filter to match the actual filter when no time is specified

Before
----------------------------------------
![qill_fix_pre](https://user-images.githubusercontent.com/6799125/87359396-09a35500-c5ab-11ea-8221-6524c09ce25c.jpg)


After
----------------------------------------
![qill_fix_post](https://user-images.githubusercontent.com/6799125/87359400-0d36dc00-c5ab-11ea-80a5-01ef274b0147.jpg)


ping @eileenmcnaughton 