### PR TITLE
dev/core#1867 Ensure that the qill matches the filter when no time is…

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -3310,7 +3310,10 @@ WHERE cg.extends IN ('" . implode("','", $this->_customGroupExtends) . "') AND
             if (!empty($this->_params["{$fieldName}_relative"])) {
               list($from, $to) = CRM_Utils_Date::getFromTo($this->_params["{$fieldName}_relative"], NULL, NULL);
             }
-
+            if (strlen($to) === 10) {
+              // If we just have the date we assume the end of that day.
+              $to .= ' 23:59:59';
+            }
             if ($from || $to) {
               if ($from) {
                 $from = date('l j F Y, g:iA', strtotime($from));


### PR DESCRIPTION
… supplied

Overview
----------------------------------------
5.27 backport of https://github.com/civicrm/civicrm-core/pull/17820

Before
----------------------------------------
![qill_fix_pre](https://user-images.githubusercontent.com/6799125/87359572-6868ce80-c5ab-11ea-9c3f-6c8c8cc1ad31.jpg)


After
----------------------------------------
![qill_fix_post](https://user-images.githubusercontent.com/6799125/87359576-6b63bf00-c5ab-11ea-8d41-5c3100eaa722.jpg)


ping @eileenmcnaughton 