### PR TITLE
dev/core#1871 - require_once's that include "packages/" in the path don't work on drupal 8

### DIFF
--- a/CRM/Utils/PDF/Utils.php
+++ b/CRM/Utils/PDF/Utils.php
@@ -207,7 +207,7 @@ class CRM_Utils_PDF_Utils {
    * @param string $fileName
    */
   public static function _html2pdf_wkhtmltopdf($paper_size, $orientation, $margins, $html, $output, $fileName) {
-    require_once 'packages/snappy/src/autoload.php';
+    require_once 'snappy/src/autoload.php';
     $config = CRM_Core_Config::singleton();
     $snappy = new Knp\Snappy\Pdf($config->wkhtmltopdfPath);
     $snappy->setOption("page-width", $paper_size[2] . "pt");

--- a/CRM/Utils/ReCAPTCHA.php
+++ b/CRM/Utils/ReCAPTCHA.php
@@ -78,7 +78,7 @@ class CRM_Utils_ReCAPTCHA {
     $config = CRM_Core_Config::singleton();
     $useSSL = FALSE;
     if (!function_exists('recaptcha_get_html')) {
-      require_once 'packages/recaptcha/recaptchalib.php';
+      require_once 'recaptcha/recaptchalib.php';
     }
 
     // Load the Recaptcha api.js over HTTPS


### PR DESCRIPTION
Overview
----------------------------------------
Recaptcha and wkhtmltopdf don't work.

https://lab.civicrm.org/dev/core/-/issues/1871

Before
----------------------------------------
A quick way to demonstrate is:

```sh
> cv ev "CRM_Utils_ReCAPTCHA::add(new CRM_Core_Form());"
Fatal error: require_once(): Failed opening required 'packages/recaptcha/recaptchalib.php'...
```

After
----------------------------------------
```sh
> cv ev "CRM_Utils_ReCAPTCHA::add(new CRM_Core_Form());"
To use reCAPTCHA you must get an API key from <a href='https://www.google.com/recaptcha/admin/create'>https://www.google.com/recaptcha/admin/create</a>
```
(On a stock unconfigured system you still get an error but it's coming from recaptcha, so it loaded.)

Technical Details
----------------------------------------
packages is already in the include path and in drupal 8 if you include the word `packages` then it won't be able to find it since packages is no longer under anything in the include path. In drupal 7 the main tree is in the include path AND it has packages right below it so including the word `packages` would find it.

Comments
----------------------------------------

