### PR TITLE
Remove unnecessary try/catch per #17729

### DIFF
--- a/CRM/Utils/Check/Component.php
+++ b/CRM/Utils/Check/Component.php
@@ -88,19 +88,10 @@ abstract class CRM_Utils_Check_Component {
    * @throws \Civi\API\Exception\UnauthorizedException
    */
   public function isDisabled($method) {
-    try {
-      $checks = $this->getChecksConfig();
-      if (!empty($checks[$method])) {
-        return (bool) empty($checks[$method]['is_active']);
-      }
+    $checks = $this->getChecksConfig();
+    if (isset($checks[$method]['is_active'])) {
+      return !$checks[$method]['is_active'];
     }
-    catch (PEAR_Exception $e) {
-      // if we're hitting this, DB migration to 5.19 probably hasn't run yet, so
-      // is_active doesn't exist. Ignore this error so the status check (which
-      // might warn about missing migrations!) still renders.
-      // TODO: remove at some point after 5.19
-    }
-
     return FALSE;
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Now that #17729 is merged the API will automatically guard against querying unknown fields, we can remove this precaution.

Before
----------------------------------------
Try/catch block.

After
----------------------------------------
There is no try.
![There is no try](https://media.giphy.com/media/26FmQ6EOvLxp6cWyY/giphy.gif)

Comments
-----------
Thanks to @demeritcowboy I can't get this meme out of my head.