### PR TITLE
Remove hard coded charset.

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -27,12 +27,12 @@ class CRM_Contact_BAO_Contact extends CRM_Contact_DAO_Contact {
   const DROP_STRIP_FUNCTION_43 = "DROP FUNCTION IF EXISTS civicrm_strip_non_numeric";
 
   const CREATE_STRIP_FUNCTION_43 = "
-    CREATE FUNCTION civicrm_strip_non_numeric(input VARCHAR(255) CHARACTER SET utf8)
-      RETURNS VARCHAR(255) CHARACTER SET utf8
+    CREATE FUNCTION civicrm_strip_non_numeric(input VARCHAR(255))
+      RETURNS VARCHAR(255)
       DETERMINISTIC
       NO SQL
     BEGIN
-      DECLARE output   VARCHAR(255) CHARACTER SET utf8 DEFAULT '';
+      DECLARE output   VARCHAR(255) DEFAULT '';
       DECLARE iterator INT          DEFAULT 1;
       WHILE iterator < (LENGTH(input) + 1) DO
         IF SUBSTRING(input, iterator, 1) IN ('0', '1', '2', '3', '4', '5', '6', '7', '8', '9') THEN


### PR DESCRIPTION
Overview
----------------------------------------
Removes charset information from the strip_phone_numeric function

Before
----------------------------------------
CHARSET hard-coded to utf8 - which opens the 'utf8mb4 question

After
----------------------------------------
No hard-coding. I believe it's not required

Technical Details
----------------------------------------
In thinking about the proposal here
https://github.com/civicrm/civicrm-core/pull/13633/files#diff-c5e39924ad99ac88b48763a0d8fa246eR30
to switch to utf8mb4 I found that none of the places on the web that suggest functions like ours
specifiy charset - eg. https://stackoverflow.com/questions/287105/mysql-strip-non-numeric-characters-to-compare

When I look at the code it is iterating through the characters to find integers - which should
be the same regardless of charset. So, I think we can simply remove it.

Comments
----------------------------------------
