### PR TITLE
Hooks/Dispatcher - Close loopholes that occur around "preboot" hooks

### DIFF
--- a/CRM/Extension/Manager/Report.php
+++ b/CRM/Extension/Manager/Report.php
@@ -24,7 +24,10 @@ class CRM_Extension_Manager_Report extends CRM_Extension_Manager_Base {
    */
   public function __construct() {
     parent::__construct(TRUE);
-    $this->groupId = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_OptionGroup',
+  }
+
+  public function getGroupId() {
+    return CRM_Core_DAO::getFieldValue('CRM_Core_DAO_OptionGroup',
       self::REPORT_GROUP_NAME, 'id', 'name'
     );
   }
@@ -51,7 +54,7 @@ class CRM_Extension_Manager_Report extends CRM_Extension_Manager_Base {
       throw new CRM_Core_Exception(ts('Component for which you are trying to install the extension (%1) is currently disabled.', [1 => $info->typeInfo['component']]));
     }
     $weight = CRM_Utils_Weight::getDefaultWeight('CRM_Core_DAO_OptionValue',
-      ['option_group_id' => $this->groupId]
+      ['option_group_id' => $this->getGroupId()]
     );
     $params = [
       'label' => $info->label . ' (' . $info->key . ')',
@@ -60,7 +63,7 @@ class CRM_Extension_Manager_Report extends CRM_Extension_Manager_Base {
       'weight' => $weight,
       'description' => $info->label . ' (' . $info->key . ')',
       'component_id' => $compId,
-      'option_group_id' => $this->groupId,
+      'option_group_id' => $this->getGroupId(),
       'is_active' => 1,
     ];
 

--- a/CRM/Extension/Manager/Search.php
+++ b/CRM/Extension/Manager/Search.php
@@ -24,7 +24,10 @@ class CRM_Extension_Manager_Search extends CRM_Extension_Manager_Base {
    */
   public function __construct() {
     parent::__construct(TRUE);
-    $this->groupId = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_OptionGroup',
+  }
+
+  public function getGroupId() {
+    return CRM_Core_DAO::getFieldValue('CRM_Core_DAO_OptionGroup',
       self::CUSTOM_SEARCH_GROUP_NAME, 'id', 'name'
     );
   }
@@ -42,11 +45,11 @@ class CRM_Extension_Manager_Search extends CRM_Extension_Manager_Base {
     }
 
     $weight = CRM_Utils_Weight::getDefaultWeight('CRM_Core_DAO_OptionValue',
-      ['option_group_id' => $this->groupId]
+      ['option_group_id' => $this->getGroupId()]
     );
 
     $params = [
-      'option_group_id' => $this->groupId,
+      'option_group_id' => $this->getGroupId(),
       'weight' => $weight,
       'description' => $info->label . ' (' . $info->key . ')',
       'name' => $info->key,

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -152,20 +152,6 @@ abstract class CRM_Utils_Hook {
     &$arg1, &$arg2, &$arg3, &$arg4, &$arg5, &$arg6,
     $fnSuffix
   ) {
-    if (!\Civi\Core\Container::isContainerBooted()) {
-      $prebootHooks = ['civicrm_container', 'civicrm_entityTypes'];
-      // 'civicrm_config' ?
-      if (in_array($fnSuffix, $prebootHooks)) {
-        $count = is_array($names) ? count($names) : $names;
-        return $this->invokeViaUF($count, $arg1, $arg2, $arg3, $arg4, $arg5, $arg6, $fnSuffix);
-      }
-      else {
-        // TODO: Emit a warning, eg
-        // error_log("Warning: hook_$fnSuffix fired prematurely. Dropped.");
-        return;
-      }
-    }
-
     if (!is_array($names)) {
       // We were called with the old contract wherein $names is actually an int.
       // Symfony dispatcher requires some kind of name.

--- a/Civi.php
+++ b/Civi.php
@@ -64,7 +64,14 @@ class Civi {
    * @return \Symfony\Component\EventDispatcher\EventDispatcherInterface
    */
   public static function dispatcher() {
-    return Civi\Core\Container::singleton()->get('dispatcher');
+    // NOTE: The dispatcher object is initially created as a boot service
+    // (ie `dispatcher.boot`). For compatibility with the container (eg
+    // `RegisterListenersPass` and `createEventDispatcher` addons),
+    // it is also available as the `dispatcher` service.
+    //
+    // The 'dispatcher.boot' and 'dispatcher' services are the same object,
+    // but 'dispatcher.boot' is resolvable earlier during bootstrap.
+    return Civi\Core\Container::getBootService('dispatcher.boot');
   }
 
   /**

--- a/Civi/Core/CiviEventDispatcher.php
+++ b/Civi/Core/CiviEventDispatcher.php
@@ -117,6 +117,9 @@ class CiviEventDispatcher extends EventDispatcher {
         case 'fail':
           throw new \RuntimeException("The dispatch policy prohibits event \"$eventName\".");
 
+        case 'not-ready':
+          throw new \RuntimeException("CiviCRM has not bootstrapped sufficiently to fire event \"$eventName\".");
+
         default:
           throw new \RuntimeException("The dispatch policy for \"$eventName\" is unrecognized ($mode).");
 


### PR DESCRIPTION
Overview
---------

In `CRM_Utils_Hook` and `Civi::dispatcher()`, there is a subtle distinction between normal hooks and "preboot" hooks. This eliminates the distinction, making it easier to reason about and modify the hook mechanism.

Before
------

* To listen to almost any hook, you may use  `function PREFIX_civicrm_HOOK($param...)` or `Civi::dispatcher()`.
* **Except...** if you wish to listen to the preboot hooks (`hook_civicrm_container` and `hook_civicrm_entityTypes`), then `Civi::dispatcher()` does not work.
* One cannot register any listeners via `Civi::dispatcher()` until fairly late during bootstrap.

After
-----

* All hooks - including `hook_civicrm_container` and `hook_civicrm_entityTypes` should work with `Civi::dispatcher()`.
* There is a built-in guard-rail - if some future change causes a hook to fire too early (eg in a way that breaks `Civi::dispatcher()`), then it will raise an exception. This is not specifically a unit-test - but it would raised by the unit-tests for any use-cases involving a premature hook.
* One can register listeners via `Civi::dispatcher()` fairly early during bootstrap.

Comments
-----------

In "Before/After", the third item speaks about "early" and "late" during bootstrap, and this is probably a bit abstract. My long-term aim is to [move some of the civix boilerplate](https://github.com/totten/civix/issues/175) which will require other PR(s). For something immediate+concrete, this may be a better demonstration of the principle:

* Before, an extension which uses `Civi::dispatcher()` must call it from within some other hook:
    ```php
    // FILE: mymod.php
    function mymod_civicrm_config() {
      ...
      Civi::dispatcher()->addListener('hook_civicrm_pre', ...);
      ..
    }
    ```
* After, an extension may directly use `Civi::dispatcher()` at the top-level of the PHP file:
    ```php
    // FILE: mymod.php
    Civi::dispatcher()->addListener('hook_civicrm_pre', ...);
    ```

I haven't fully tested the lifecycle of an extension using this code-style (because it's a bit incidental/by-the-by), but it hopefully demonstrates the principle of the change.