### PR TITLE
civix#175 - Add support for shim scripts

### DIFF
--- a/CRM/Extension/ShimApi.php
+++ b/CRM/Extension/ShimApi.php
@@ -1,0 +1,104 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * Class CRM_Extension_ShimApi
+ *
+ * For every extension which loads a shim, there should be one instance of the
+ * ShimApi. This is the record offered to shim functions.
+ */
+class CRM_Extension_ShimApi {
+
+  // EX: How to veto a shim-file
+  // private static $vetoList = ['legacy-example'];
+
+  /**
+   * Load the shims listed in the map.
+   *
+   * @param array $shimMap
+   *   Ex: [0 =>['key' => 'org.civicrm.flexmailer', 'file' => 'flexmailer', 'shimFiles' => ['foo' => 'shims/foo.shim.php']]]
+   * @return array
+   *   A copy of the $shimMap, possibly with some changes applied.
+   */
+  public static function loadMap($shimMap) {
+    foreach ($shimMap as &$shimMapItem) {
+      $shimApi = new static();
+      $shimApi->raw = $shimMapItem;
+      $shimApi->longName = $shimMapItem['longName'];
+      $shimApi->shortName = $shimMapItem['shortName'];
+      $shimApi->bootCache = $shimMapItem['bootCache'];
+      $shimApi->path = CRM_Extension_System::singleton()->getFullContainer()->getPath($shimApi->longName);
+
+      foreach ($shimMapItem['shimFiles'] as $shimName => $shimFile) {
+        // TODO: If $shimName has been assimilated into core, then skip or substitute it. At the moment, none have been assimilated.
+        // if (in_array($shimName, static::$vetoList)) continue;
+
+        $shim = include $shimApi->path . '/' . $shimFile;
+        if ($shim) {
+          $shim($shimApi);
+        }
+      }
+
+      $shimMapItem['bootCache'] = $shimApi->bootCache;
+    }
+
+    return $shimMap;
+  }
+
+  /**
+   * @var string
+   *
+   * Ex: 'org.civicrm.flexmailer'
+   */
+  public $longName;
+
+  /**
+   * @var string
+   *
+   * Ex: 'flexmailer'
+   */
+  public $shortName;
+
+  /**
+   * @var string|null
+   *
+   * Ex: '/var/www/modules/civicrm/ext/flexmailer'.
+   */
+  public $path;
+
+  /**
+   * @var array
+   */
+  private $bootCache;
+
+  /**
+   * Define a persistent value in the extension's boot-cache.
+   *
+   * This value is retained as part of the boot-cache. It will be loaded
+   * very quickly (eg via php op-code caching). However, as a trade-off,
+   * you will not be able to change/reset at runtime - it will only
+   * reset in response to a system-wide flush or redeployment.
+   *
+   * Ex: $shimApi->define('initTime', function() { return time(); });
+   *
+   * @param string $key
+   * @param mixed $callback
+   * @return mixed
+   *   The value of $callback (either cached or fresh)
+   */
+  public function define($key, $callback) {
+    if (!isset($this->bootCache[$key])) {
+      $this->bootCache[$key] = $callback($this);
+    }
+    return $this->bootCache[$key];
+  }
+
+}

--- a/CRM/Extension/ShimMapper.php
+++ b/CRM/Extension/ShimMapper.php
@@ -1,0 +1,113 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * Class CRM_Extension_ShimMap
+ *
+ * The ShimmerMap scans the list of extensions and creates a list of
+ * active shims.
+ */
+class CRM_Extension_ShimMapper {
+
+  /**
+   * @var CRM_Extension_Mapper
+   */
+  protected $mapper;
+
+  /**
+   * @var CRM_Extension_Manager
+   */
+  protected $manager;
+
+  /**
+   * CRM_Extension_ClassLoader constructor.
+   * @param \CRM_Extension_Mapper $mapper
+   * @param \CRM_Extension_Manager $manager
+   */
+  public function __construct(\CRM_Extension_Mapper $mapper, \CRM_Extension_Manager $manager) {
+    $this->mapper = $mapper;
+    $this->manager = $manager;
+  }
+
+  /**
+   * @return array
+   *   Ex: ['org.civicrm.flexmailer' => ['longName' => 'org.civicrm.flexmailer', 'shortName' => 'flexmailer', 'shimFiles' => ['foo' => 'shims/foo.shim.php']]]
+   */
+  public function build() {
+    $shimMap = [];
+
+    foreach ($this->getInstalledKeys() as $key) {
+      $path = $this->mapper->keyToBasePath($key);
+      $info = $this->mapper->keyToInfo($key);
+
+      $shimFiles = $this->findShimFiles($path);
+      if (!empty($shimFiles)) {
+        $shimMap[$key] = [
+          'longName' => $key,
+          'shortName' => $info->file,
+          'shimFiles' => $shimFiles,
+          'bootCache' => [],
+        ];
+      }
+    }
+    return $shimMap;
+  }
+
+  /**
+   * Convert a shimMap to PHP source-code.
+   *
+   * @param array $shimMap
+   * @return string
+   *   The serialized PHP source-code representation of the shim map.
+   *   This should be loaded on future page-views.
+   */
+  public function dump($shimMap) {
+    $src = sprintf('%s::loadMap(unserialize(%s));',
+      CRM_Extension_ShimApi::CLASS,
+      var_export(serialize($shimMap), 1));
+    return $src;
+  }
+
+  /**
+   * @return array
+   */
+  private function getInstalledKeys() {
+    $keys = [];
+
+    $statuses = $this->manager->getStatuses();
+    ksort($statuses);
+    foreach ($statuses as $key => $status) {
+      if ($status === CRM_Extension_Manager::STATUS_INSTALLED) {
+        $keys[] = $key;
+      }
+    }
+
+    return $keys;
+  }
+
+  /**
+   * @param string $path
+   * @return array
+   *   Ex: ['xml-menu-autoload' => 'shims/xml-menu-autoload.shim.php']
+   */
+  private function findShimFiles($path) {
+    $result = [];
+    $shimFiles = (array) glob("$path/shims/*.shim.php");
+    sort($shimFiles);
+    foreach ($shimFiles as $shimFile) {
+      $shimName = preg_replace(';\.shim\.php$;', '', basename($shimFile));
+      $shimFileRel = ltrim(CRM_Utils_File::relativize($shimFile, $path), '/' . DIRECTORY_SEPARATOR);
+      $result[$shimName] = $shimFileRel;
+    }
+    return $result;
+  }
+
+}


### PR DESCRIPTION
Overview
--------

The `civix` code-generator provides a large set of boilerplate code (eg `mymod.civix.php` and `mymod.php`). Its purpose is to make `civix` code-conventions (e.g. `*.mgd.php`, `xml/Menu/*.xml`) work with `civicrm-core` APIs (e.g. `hook_managed`, `hook_xmlMenu`). In this way, it serves as a *bridge*, *polyfill*, or *shim* between a civix extension and core.

However, the boilerplate technique has various challenges. (See comments.)

This PR enables an alternative technique using "shim-files". A shim-file is a PHP file. As input, it receives some information about the extension (e.g. the extension-name and directory-path). It can analyze the extension. As output, it can register for hooks and call other APIs.

Compared to the boilerplate, shim-files aim to be gentler to work with at each stage of the lifecycle -- e.g.

* Prototyping - Instead of editing meta-PHP within `civix.git`, you can edit a regular PHP file in a regular extension.
* Distribution - Instead of re-generating a large boilerplate file from meta-PHP, and instead of manually updating random bits in a large boilerplate file... you can facilely copy small-grained files (without editing).
* Assimilation - If a shim-file is useful enough, then you can put the functionality in `civicrm-core`. This will automatically deactivate any obsolete shim-files bundled into extensions (without needing to republish the extensions).

See: totten/civix#175
Depends: #17831

Before
------

The civix templates generate two files, such as `mymod.php` (src:[module.php.php](https://github.com/totten/civix/blob/v20.07.1/src/CRM/CivixBundle/Resources/views/Code/module.php.php)) and `mymod.civix.php` (src:[module.civix.php.php](https://github.com/totten/civix/blob/v20.07.1/src/CRM/CivixBundle/Resources/views/Code/module.civix.php.php)).

A typical example looks like this:

```php
// mymod.php - Implement hook_civicrm_xmlMenu
require_once 'mymod.civix.php';
function mymod_civicrm_xmlMenu(&$files, $all, $the, $params) {
  _mymod_civix_civicrm_xmlMenu($files, $all, $the, $params);
}
```

and

```php
// mymod.civix.php - Implement hook_civicrm_xmlMenu
function _mymod_civix_civicrm_xmlMenu(&$files, $all, $the, $params) {
  foreach (_mosaico_civix_glob(__DIR__ . '/xml/Menu/*.xml') as $file) {
    $files[] = $file;
  }
}
```

The actual files (`mymod.php` and `mymod.civix.php`) are much longer than the example - because they contain about a dozen shims.

These two files are managed differently:

* `mymod.php` is owned by the downstream developer, and they may add/remove/manage the hooks in this file. If any changes are required in this boilerplate, then the developer must make them manually. (See: https://github.com/totten/civix/blob/master/UPGRADE.md  - "Special Tasks")
* `mymod.civix.php` is owned by `civix` and must be autogenerated. If any changes are required in this boilerplate, then the developer must regenerate. (See: https://github.com/totten/civix/blob/master/UPGRADE.md - "General Tasks")

After
-----

When loading an extension, Civi will look for files named `shims/*.shim.php`. These are basic PHP files and do not require meta-PHP templating. Each file has an init function like:

```php
return function(\CRM_Extension_ShimApi $shimApi) {
  // echo "This is " . $shimApi->longName . "!\n";
  \Civi::dispatcher()->addListener("hook_civicrm_xmlMenu", function($e) use ($shimApi) {
    foreach ((array) glob($shimApi->path . '/xml/Menu/*.xml') as $file) {
      $e->files[] = $file;
    }
  });
}
```

The shim-file has a few distinctive properties:

* It is loaded very early (at the same time as the extension's class-loader). This allows it to register for hooks.
* It receives some metadata about the extension (`$shimApi`). This allows it to examine the extension and register its artifacts.
* When/if `civicrm-core` provides the same functionality, then `civicrm-core` can disable/ignore/override the shim-file.
* It is a plain PHP file (not meta-PHP).
* It can be run multiple times and composed in different ways -- because it returns a callback and does not define any conflict-prone elements (`class`, `interface`, etc). (*Analogy: The shim-file closure is similar to the Javascript closure used in a jQuery plugin.*)

Depending on circumstance/taste, the shim-files may be written in a highly-coupled or loosely-coupled style:

* In highly-coupled style, you might have `civix-convention-v1.shim.php` with 10 different event listeners.
* In loosely-coupled style, you might have `civix-menu-loader.shim.php`, `civix-mgd-loader.shim.php`, and so on. Each file has only 1 or 2 listeners. These files are only created if they're needed.

Comments
---------------------

Both approaches -- boilerplate/meta-PHP-template and shim-files -- can serve the role of bridge/polyfill/shim. You can write an extension using new code-conventions immediately (before they've been approved in core).

However, the boilerplate comes with a few pain-points:

* If you want to write a patch for `_mymod_civix_civicrm_xmlMenu`, the dev-test-loop requires several steps.
* If civix needs to add a new `hook_civicrm_foo`, then the author must manually create the stub  function in `mymod.php`. `civix` has documentation (`UPGRADE.md`) which keeps a long list of stubs that must be manually added.
* If civix adds `hook_civicrm_foo`, then it must add it to the boilerplate of *all* extensions... even for the many extensions which never use `hook_civicrm_foo`.
* If civix needs an update to its `hook_civicrm_foo`, then the author must regenerate `mymod.civix.php`.
* If civix's spin on `hook_civicrm_xmlMenu` becomes widespread, then the `xmlMenu` boilerplate is duplicated across many extensions.
* If you wish to canonize civix's  xmlMenu scanner, then you might reproduce the scanner in `civicrm-core`. But this will cause a problem because *all the previously published extensions still have their own copy of the scanner*. Each `*.xml` file will be picked up twice, and there is no way to conditionally disable the old boilerplate.

With shim-files, one can still take advantage of new coding-conventions immediately. However, several of those pain-points are improved because shims are plain PHP files that can be debugged/copied/edited verbatim, and they can register their own hooks (without dynamic code generation). The code is no longer a "template", and it doesn't need to be interwoven between `mymod.php` and `mymod.civix.php`.

There is a presumption that all shims will be loaded.  However, if the equivalent functionality has been migrated into `civicrm-core`, then `civicrm-core` may veto the shim-file.

Here's a slightly longer example of shim code: https://gist.github.com/totten/5fcd4835194981a6d667202d9e720cd5

Bike-shedding: The word "shim" mostly captures the intent, though other names could also describe this functionality - e.g. "mini module", "micro extension", "meta module"? 