### PR TITLE
APIv4 - Add shorthand for setCheckPermissions()

### DIFF
--- a/Civi/Api4/Address.php
+++ b/Civi/Api4/Address.php
@@ -33,24 +33,30 @@ namespace Civi\Api4;
 class Address extends Generic\DAOEntity {
 
   /**
-   * @return \Civi\Api4\Action\Address\Create
+   * @param bool $checkPermissions
+   * @return Action\Address\Create
    */
-  public static function create() {
-    return new \Civi\Api4\Action\Address\Create(__CLASS__, __FUNCTION__);
+  public static function create($checkPermissions = TRUE) {
+    return (new Action\Address\Create(__CLASS__, __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
   }
 
   /**
-   * @return \Civi\Api4\Action\Address\Save
+   * @param bool $checkPermissions
+   * @return Action\Address\Save
    */
-  public static function save() {
-    return new \Civi\Api4\Action\Address\Save(__CLASS__, __FUNCTION__);
+  public static function save($checkPermissions = TRUE) {
+    return (new Action\Address\Save(__CLASS__, __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
   }
 
   /**
-   * @return \Civi\Api4\Action\Address\Update
+   * @param bool $checkPermissions
+   * @return Action\Address\Update
    */
-  public static function update() {
-    return new \Civi\Api4\Action\Address\Update(__CLASS__, __FUNCTION__);
+  public static function update($checkPermissions = TRUE) {
+    return (new Action\Address\Update(__CLASS__, __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
   }
 
 }

--- a/Civi/Api4/Campaign.php
+++ b/Civi/Api4/Campaign.php
@@ -28,10 +28,12 @@ namespace Civi\Api4;
 class Campaign extends Generic\DAOEntity {
 
   /**
-   * @return \Civi\Api4\Action\Campaign\Get
+   * @param bool $checkPermissions
+   * @return Action\Campaign\Get
    */
-  public static function get() {
-    return new \Civi\Api4\Action\Campaign\Get(__CLASS__, __FUNCTION__);
+  public static function get($checkPermissions = TRUE) {
+    return (new Action\Campaign\Get(__CLASS__, __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
   }
 
 }

--- a/Civi/Api4/Contact.php
+++ b/Civi/Api4/Contact.php
@@ -33,17 +33,21 @@ namespace Civi\Api4;
 class Contact extends Generic\DAOEntity {
 
   /**
-   * @return \Civi\Api4\Action\Contact\GetChecksum
+   * @param bool $checkPermissions
+   * @return Action\Contact\GetChecksum
    */
-  public static function getChecksum() {
-    return new Action\Contact\GetChecksum(__CLASS__, __FUNCTION__);
+  public static function getChecksum($checkPermissions = TRUE) {
+    return (new Action\Contact\GetChecksum(__CLASS__, __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
   }
 
   /**
-   * @return \Civi\Api4\Action\Contact\ValidateChecksum
+   * @param bool $checkPermissions
+   * @return Action\Contact\ValidateChecksum
    */
-  public static function validateChecksum() {
-    return new Action\Contact\ValidateChecksum(__CLASS__, __FUNCTION__);
+  public static function validateChecksum($checkPermissions = TRUE) {
+    return (new Action\Contact\ValidateChecksum(__CLASS__, __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
   }
 
 }

--- a/Civi/Api4/CustomValue.php
+++ b/Civi/Api4/CustomValue.php
@@ -37,74 +37,90 @@ class CustomValue {
 
   /**
    * @param string $customGroup
+   * @param bool $checkPermissions
    * @return Action\CustomValue\Get
    * @throws \API_Exception
    */
-  public static function get($customGroup) {
-    return new Action\CustomValue\Get($customGroup, __FUNCTION__);
+  public static function get($customGroup, $checkPermissions = TRUE) {
+    return (new Action\CustomValue\Get($customGroup, __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
   }
 
   /**
    * @param string $customGroup
+   * @param bool $checkPermissions
    * @return Action\CustomValue\GetFields
    * @throws \API_Exception
    */
-  public static function getFields($customGroup = NULL) {
-    return new Action\CustomValue\GetFields($customGroup, __FUNCTION__);
+  public static function getFields($customGroup = NULL, $checkPermissions = TRUE) {
+    return (new Action\CustomValue\GetFields($customGroup, __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
   }
 
   /**
    * @param string $customGroup
+   * @param bool $checkPermissions
    * @return Action\CustomValue\Save
    * @throws \API_Exception
    */
-  public static function save($customGroup) {
-    return new Action\CustomValue\Save($customGroup, __FUNCTION__);
+  public static function save($customGroup, $checkPermissions = TRUE) {
+    return (new Action\CustomValue\Save($customGroup, __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
   }
 
   /**
    * @param string $customGroup
+   * @param bool $checkPermissions
    * @return Action\CustomValue\Create
    * @throws \API_Exception
    */
-  public static function create($customGroup) {
-    return new Action\CustomValue\Create($customGroup, __FUNCTION__);
+  public static function create($customGroup, $checkPermissions = TRUE) {
+    return (new Action\CustomValue\Create($customGroup, __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
   }
 
   /**
    * @param string $customGroup
+   * @param bool $checkPermissions
    * @return Action\CustomValue\Update
    * @throws \API_Exception
    */
-  public static function update($customGroup) {
-    return new Action\CustomValue\Update($customGroup, __FUNCTION__);
+  public static function update($customGroup, $checkPermissions = TRUE) {
+    return (new Action\CustomValue\Update($customGroup, __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
   }
 
   /**
    * @param string $customGroup
+   * @param bool $checkPermissions
    * @return Action\CustomValue\Delete
    * @throws \API_Exception
    */
-  public static function delete($customGroup) {
-    return new Action\CustomValue\Delete($customGroup, __FUNCTION__);
+  public static function delete($customGroup, $checkPermissions = TRUE) {
+    return (new Action\CustomValue\Delete($customGroup, __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
   }
 
   /**
    * @param string $customGroup
+   * @param bool $checkPermissions
    * @return Action\CustomValue\Replace
    * @throws \API_Exception
    */
-  public static function replace($customGroup) {
-    return new Action\CustomValue\Replace($customGroup, __FUNCTION__);
+  public static function replace($customGroup, $checkPermissions = TRUE) {
+    return (new Action\CustomValue\Replace($customGroup, __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
   }
 
   /**
    * @param string $customGroup
+   * @param bool $checkPermissions
    * @return Action\CustomValue\GetActions
    * @throws \API_Exception
    */
-  public static function getActions($customGroup = NULL) {
-    return new Action\CustomValue\GetActions($customGroup, __FUNCTION__);
+  public static function getActions($customGroup = NULL, $checkPermissions = TRUE) {
+    return (new Action\CustomValue\GetActions($customGroup, __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
   }
 
   /**

--- a/Civi/Api4/Domain.php
+++ b/Civi/Api4/Domain.php
@@ -30,8 +30,13 @@ namespace Civi\Api4;
  */
 class Domain extends Generic\DAOEntity {
 
-  public static function get() {
-    return new \Civi\Api4\Action\Domain\Get(__CLASS__, __FUNCTION__);
+  /**
+   * @param bool $checkPermissions
+   * @return Action\Domain\Get
+   */
+  public static function get($checkPermissions = TRUE) {
+    return (new Action\Domain\Get(__CLASS__, __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
   }
 
 }

--- a/Civi/Api4/Entity.php
+++ b/Civi/Api4/Entity.php
@@ -31,17 +31,20 @@ namespace Civi\Api4;
 class Entity extends Generic\AbstractEntity {
 
   /**
+   * @param bool $checkPermissions
    * @return Action\Entity\Get
    */
-  public static function get() {
-    return new Action\Entity\Get('Entity', __FUNCTION__);
+  public static function get($checkPermissions = TRUE) {
+    return (new Action\Entity\Get('Entity', __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
   }
 
   /**
-   * @return \Civi\Api4\Generic\BasicGetFieldsAction
+   * @param bool $checkPermissions
+   * @return Generic\BasicGetFieldsAction
    */
-  public static function getFields() {
-    return new \Civi\Api4\Generic\BasicGetFieldsAction('Entity', __FUNCTION__, function() {
+  public static function getFields($checkPermissions = TRUE) {
+    return (new Generic\BasicGetFieldsAction('Entity', __FUNCTION__, function() {
       return [
         [
           'name' => 'name',
@@ -73,14 +76,16 @@ class Entity extends Generic\AbstractEntity {
           'description' => 'Any @see annotations from docblock',
         ],
       ];
-    });
+    }))->setCheckPermissions($checkPermissions);
   }
 
   /**
+   * @param bool $checkPermissions
    * @return Action\Entity\GetLinks
    */
-  public static function getLinks() {
-    return new Action\Entity\GetLinks('Entity', __FUNCTION__);
+  public static function getLinks($checkPermissions = TRUE) {
+    return (new Action\Entity\GetLinks('Entity', __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
   }
 
   /**

--- a/Civi/Api4/Event.php
+++ b/Civi/Api4/Event.php
@@ -31,10 +31,12 @@ namespace Civi\Api4;
 class Event extends Generic\DAOEntity {
 
   /**
-   * @return \Civi\Api4\Action\Event\Get
+   * @param bool $checkPermissions
+   * @return Action\Event\Get
    */
-  public static function get() {
-    return new \Civi\Api4\Action\Event\Get(__CLASS__, __FUNCTION__);
+  public static function get($checkPermissions = TRUE) {
+    return (new Action\Event\Get(__CLASS__, __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
   }
 
 }

--- a/Civi/Api4/Generic/AbstractAction.php
+++ b/Civi/Api4/Generic/AbstractAction.php
@@ -33,7 +33,6 @@ use Civi\Api4\Utils\ReflectionUtils;
  *  - Expose the param in the Api Explorer (be sure to add a doc-block as it displays in the help panel).
  *  - Require a value for the param if you add the "@required" annotation.
  *
- * @method $this setCheckPermissions(bool $value) Enable/disable permission checks
  * @method bool getCheckPermissions()
  * @method $this setDebug(bool $value) Enable/disable debug output
  * @method bool getDebug()
@@ -171,6 +170,15 @@ abstract class AbstractAction implements \ArrayAccess {
     if ($val !== 4 && $val !== '4') {
       throw new \API_Exception('Cannot modify api version');
     }
+    return $this;
+  }
+
+  /**
+   * @param bool $checkPermissions
+   * @return $this
+   */
+  public function setCheckPermissions(bool $checkPermissions) {
+    $this->checkPermissions = $checkPermissions;
     return $this;
   }
 

--- a/Civi/Api4/Generic/AbstractEntity.php
+++ b/Civi/Api4/Generic/AbstractEntity.php
@@ -47,10 +47,12 @@ use Civi\Api4\Utils\ReflectionUtils;
 abstract class AbstractEntity {
 
   /**
+   * @param bool $checkPermissions
    * @return \Civi\Api4\Action\GetActions
    */
-  public static function getActions() {
-    return new \Civi\Api4\Action\GetActions(self::getEntityName(), __FUNCTION__);
+  public static function getActions($checkPermissions = TRUE) {
+    return (new \Civi\Api4\Action\GetActions(self::getEntityName(), __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
   }
 
   /**
@@ -94,7 +96,7 @@ abstract class AbstractEntity {
    * Magic method to return the action object for an api.
    *
    * @param string $action
-   * @param null $args
+   * @param array $args
    * @return AbstractAction
    * @throws NotImplementedException
    */
@@ -104,6 +106,9 @@ abstract class AbstractEntity {
     $entityAction = "\\Civi\\Api4\\Action\\$entity\\" . ucfirst($action);
     if (class_exists($entityAction)) {
       $actionObject = new $entityAction($entity, $action);
+      if (isset($args[0]) && $args[0] === FALSE) {
+        $actionObject->setCheckPermissions(FALSE);
+      }
     }
     else {
       throw new NotImplementedException("Api $entity $action version 4 does not exist.");

--- a/Civi/Api4/Generic/DAOEntity.php
+++ b/Civi/Api4/Generic/DAOEntity.php
@@ -18,56 +18,66 @@ namespace Civi\Api4\Generic;
 abstract class DAOEntity extends AbstractEntity {
 
   /**
+   * @param bool $checkPermissions
    * @return DAOGetAction
-   *
-   * @throws \API_Exception
    */
-  public static function get() {
-    return new DAOGetAction(static::class, __FUNCTION__);
+  public static function get($checkPermissions = TRUE) {
+    return (new DAOGetAction(static::class, __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
   }
 
   /**
+   * @param bool $checkPermissions
    * @return DAOSaveAction
    */
-  public static function save() {
-    return new DAOSaveAction(static::class, __FUNCTION__);
+  public static function save($checkPermissions = TRUE) {
+    return (new DAOSaveAction(static::class, __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
   }
 
   /**
+   * @param bool $checkPermissions
    * @return DAOGetFieldsAction
    */
-  public static function getFields() {
-    return new DAOGetFieldsAction(static::class, __FUNCTION__);
+  public static function getFields($checkPermissions = TRUE) {
+    return (new DAOGetFieldsAction(static::class, __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
   }
 
   /**
+   * @param bool $checkPermissions
    * @return DAOCreateAction
-   *
-   * @throws \API_Exception
    */
-  public static function create() {
-    return new DAOCreateAction(static::class, __FUNCTION__);
+  public static function create($checkPermissions = TRUE) {
+    return (new DAOCreateAction(static::class, __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
   }
 
   /**
+   * @param bool $checkPermissions
    * @return DAOUpdateAction
    */
-  public static function update() {
-    return new DAOUpdateAction(static::class, __FUNCTION__);
+  public static function update($checkPermissions = TRUE) {
+    return (new DAOUpdateAction(static::class, __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
   }
 
   /**
+   * @param bool $checkPermissions
    * @return DAODeleteAction
    */
-  public static function delete() {
-    return new DAODeleteAction(static::class, __FUNCTION__);
+  public static function delete($checkPermissions = TRUE) {
+    return (new DAODeleteAction(static::class, __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
   }
 
   /**
+   * @param bool $checkPermissions
    * @return BasicReplaceAction
    */
-  public static function replace() {
-    return new BasicReplaceAction(static::class, __FUNCTION__);
+  public static function replace($checkPermissions = TRUE) {
+    return (new BasicReplaceAction(static::class, __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
   }
 
   /**

--- a/Civi/Api4/GroupContact.php
+++ b/Civi/Api4/GroupContact.php
@@ -33,24 +33,30 @@ namespace Civi\Api4;
 class GroupContact extends Generic\DAOEntity {
 
   /**
+   * @param bool $checkPermissions
    * @return Action\GroupContact\Create
    */
-  public static function create() {
-    return new Action\GroupContact\Create(__CLASS__, __FUNCTION__);
+  public static function create($checkPermissions = TRUE) {
+    return (new Action\GroupContact\Create(__CLASS__, __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
   }
 
   /**
+   * @param bool $checkPermissions
    * @return Action\GroupContact\Save
    */
-  public static function save() {
-    return new Action\GroupContact\Save(__CLASS__, __FUNCTION__);
+  public static function save($checkPermissions = TRUE) {
+    return (new Action\GroupContact\Save(__CLASS__, __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
   }
 
   /**
+   * @param bool $checkPermissions
    * @return Action\GroupContact\Update
    */
-  public static function update() {
-    return new Action\GroupContact\Update(__CLASS__, __FUNCTION__);
+  public static function update($checkPermissions = TRUE) {
+    return (new Action\GroupContact\Update(__CLASS__, __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
   }
 
 }

--- a/Civi/Api4/Relationship.php
+++ b/Civi/Api4/Relationship.php
@@ -31,10 +31,12 @@ namespace Civi\Api4;
 class Relationship extends Generic\DAOEntity {
 
   /**
-   * @return \Civi\Api4\Action\Relationship\Get
+   * @param bool $checkPermissions
+   * @return Action\Relationship\Get
    */
-  public static function get() {
-    return new \Civi\Api4\Action\Relationship\Get(static::class, __FUNCTION__);
+  public static function get($checkPermissions = TRUE) {
+    return (new Action\Relationship\Get(static::class, __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
   }
 
 }

--- a/Civi/Api4/Route.php
+++ b/Civi/Api4/Route.php
@@ -14,13 +14,9 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
- * $Id$
- *
  */
 
 namespace Civi\Api4;
-
-use Civi\Api4\Generic\BasicGetFieldsAction;
 
 /**
  * CiviCRM menu route.
@@ -36,10 +32,11 @@ use Civi\Api4\Generic\BasicGetFieldsAction;
 class Route extends \Civi\Api4\Generic\AbstractEntity {
 
   /**
+   * @param bool $checkPermissions
    * @return \Civi\Api4\Generic\BasicGetAction
    */
-  public static function get() {
-    return new \Civi\Api4\Generic\BasicGetAction(__CLASS__, __FUNCTION__, function ($get) {
+  public static function get($checkPermissions = TRUE) {
+    return (new \Civi\Api4\Generic\BasicGetAction(__CLASS__, __FUNCTION__, function ($get) {
       // Pulling from ::items() rather than DB -- because it provides the final/live/altered data.
       $items = \CRM_Core_Menu::items();
       $result = [];
@@ -47,11 +44,15 @@ class Route extends \Civi\Api4\Generic\AbstractEntity {
         $result[] = ['path' => $path] + $item;
       }
       return $result;
-    });
+    }))->setCheckPermissions($checkPermissions);
   }
 
-  public static function getFields() {
-    return new BasicGetFieldsAction(__CLASS__, __FUNCTION__, function() {
+  /**
+   * @param bool $checkPermissions
+   * @return Generic\BasicGetFieldsAction
+   */
+  public static function getFields($checkPermissions = TRUE) {
+    return (new Generic\BasicGetFieldsAction(__CLASS__, __FUNCTION__, function() {
       return [
         [
           'name' => 'path',
@@ -90,7 +91,7 @@ class Route extends \Civi\Api4\Generic\AbstractEntity {
           'data_type' => 'Array',
         ],
       ];
-    });
+    }))->setCheckPermissions($checkPermissions);
   }
 
   /**

--- a/Civi/Api4/Setting.php
+++ b/Civi/Api4/Setting.php
@@ -31,20 +31,40 @@ namespace Civi\Api4;
  */
 class Setting extends Generic\AbstractEntity {
 
-  public static function get() {
-    return new Action\Setting\Get(__CLASS__, __FUNCTION__);
+  /**
+   * @param bool $checkPermissions
+   * @return Action\Setting\Get
+   */
+  public static function get($checkPermissions = TRUE) {
+    return (new Action\Setting\Get(__CLASS__, __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
   }
 
-  public static function set() {
-    return new Action\Setting\Set(__CLASS__, __FUNCTION__);
+  /**
+   * @param bool $checkPermissions
+   * @return Action\Setting\Set
+   */
+  public static function set($checkPermissions = TRUE) {
+    return (new Action\Setting\Set(__CLASS__, __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
   }
 
-  public static function revert() {
-    return new Action\Setting\Revert(__CLASS__, __FUNCTION__);
+  /**
+   * @param bool $checkPermissions
+   * @return Action\Setting\Revert
+   */
+  public static function revert($checkPermissions = TRUE) {
+    return (new Action\Setting\Revert(__CLASS__, __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
   }
 
-  public static function getFields() {
-    return new Action\Setting\GetFields(__CLASS__, __FUNCTION__);
+  /**
+   * @param bool $checkPermissions
+   * @return Action\Setting\GetFields
+   */
+  public static function getFields($checkPermissions = TRUE) {
+    return (new Action\Setting\GetFields(__CLASS__, __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
   }
 
 }

--- a/Civi/Api4/System.php
+++ b/Civi/Api4/System.php
@@ -16,10 +16,7 @@
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
 
-
 namespace Civi\Api4;
-
-use Civi\Api4\Generic\BasicGetFieldsAction;
 
 /**
  * A collection of system maintenance/diagnostic utilities.
@@ -28,18 +25,32 @@ use Civi\Api4\Generic\BasicGetFieldsAction;
  */
 class System extends Generic\AbstractEntity {
 
-  public static function flush() {
-    return new Action\System\Flush(__CLASS__, __FUNCTION__);
+  /**
+   * @param bool $checkPermissions
+   * @return Action\System\Flush
+   */
+  public static function flush($checkPermissions = TRUE) {
+    return (new Action\System\Flush(__CLASS__, __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
   }
 
-  public static function check() {
-    return new Action\System\Check(__CLASS__, __FUNCTION__);
+  /**
+   * @param bool $checkPermissions
+   * @return Action\System\Check
+   */
+  public static function check($checkPermissions = TRUE) {
+    return (new Action\System\Check(__CLASS__, __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
   }
 
-  public static function getFields() {
-    return new BasicGetFieldsAction(__CLASS__, __FUNCTION__, function() {
+  /**
+   * @param bool $checkPermissions
+   * @return Generic\BasicGetFieldsAction
+   */
+  public static function getFields($checkPermissions = TRUE) {
+    return (new Generic\BasicGetFieldsAction(__CLASS__, __FUNCTION__, function() {
       return [];
-    });
+    }))->setCheckPermissions($checkPermissions);
   }
 
 }

--- a/ang/api4Explorer/Explorer.js
+++ b/ang/api4Explorer/Explorer.js
@@ -663,11 +663,12 @@
     // Format oop params
     function formatOOP(entity, action, params, indent) {
       var code = '',
-        newLine = "\n" + _.repeat(' ', indent);
+        newLine = "\n" + _.repeat(' ', indent),
+        perm = params.checkPermissions === false ? 'FALSE' : '';
       if (entity.substr(0, 7) !== 'Custom_') {
-        code = "\\Civi\\Api4\\" + entity + '::' + action + '()';
+        code = "\\Civi\\Api4\\" + entity + '::' + action + '(' + perm + ')';
       } else {
-        code = "\\Civi\\Api4\\CustomValue::" + action + "('" + entity.substr(7) + "')";
+        code = "\\Civi\\Api4\\CustomValue::" + action + "('" + entity.substr(7) + "'" + (perm ? ', ' : '') + perm + ")";
       }
       _.each(params, function(param, key) {
         var val = '';
@@ -700,7 +701,7 @@
             code += (chain.length > 3 ? ',' : '') + (!_.isEmpty(chain[2]) ? newLine : ' ') + (chain.length > 3 ? phpFormat(chain[3]) : '') + ')';
           });
         }
-        else {
+        else if (key !== 'checkPermissions') {
           code += newLine + "->set" + ucfirst(key) + '(' + phpFormat(param, 2 + indent) + ')';
         }
       });

--- a/tests/phpunit/api/v4/Action/ContactApiKeyTest.php
+++ b/tests/phpunit/api/v4/Action/ContactApiKeyTest.php
@@ -123,8 +123,7 @@ class ContactApiKeyTest extends \api\v4\UnitTestCase {
       return strpos(json_encode($mixed), $key) === FALSE;
     };
 
-    $contact = Contact::create()
-      ->setCheckPermissions(FALSE)
+    $contact = Contact::create(FALSE)
       ->addValue('first_name', 'Api')
       ->addValue('last_name', 'Key0')
       ->addValue('api_key', $key)
@@ -132,14 +131,12 @@ class ContactApiKeyTest extends \api\v4\UnitTestCase {
       ->first();
     $this->assertFalse($isSafe($contact), "Should reveal secret details ($key): " . var_export($contact, 1));
 
-    Email::create()
-      ->setCheckPermissions(FALSE)
+    Email::create(FALSE)
       ->addValue('email', 'foo@example.org')
       ->addValue('contact_id', $contact['id'])
       ->execute();
 
-    $result = Email::get()
-      ->setCheckPermissions(FALSE)
+    $result = Email::get(FALSE)
       ->addWhere('contact_id', '=', $contact['id'])
       ->addSelect('email')
       ->addSelect('contact.api_key')
@@ -147,8 +144,7 @@ class ContactApiKeyTest extends \api\v4\UnitTestCase {
       ->first();
     $this->assertFalse($isSafe($result), "Should reveal secret details ($key): " . var_export($result, 1));
 
-    $result = Email::get()
-      ->setCheckPermissions(TRUE)
+    $result = Email::get(TRUE)
       ->addWhere('contact_id', '=', $contact['id'])
       ->addSelect('contact.api_key')
       ->execute()
@@ -160,8 +156,7 @@ class ContactApiKeyTest extends \api\v4\UnitTestCase {
     \CRM_Core_Config::singleton()->userPermissionClass->permissions = ['access CiviCRM', 'edit all contacts'];
     $key = uniqid();
 
-    $contact = Contact::create()
-      ->setCheckPermissions(FALSE)
+    $contact = Contact::create(FALSE)
       ->addValue('first_name', 'Api')
       ->addValue('last_name', 'Key2')
       ->addValue('api_key', $key)
@@ -180,8 +175,7 @@ class ContactApiKeyTest extends \api\v4\UnitTestCase {
       $error = $e->getMessage();
     }
 
-    $result = Contact::get()
-      ->setCheckPermissions(FALSE)
+    $result = Contact::get(FALSE)
       ->addWhere('id', '=', $contact['id'])
       ->addSelect('api_key')
       ->execute()
@@ -214,8 +208,7 @@ class ContactApiKeyTest extends \api\v4\UnitTestCase {
     \CRM_Core_Config::singleton()->userPermissionClass->permissions = ['access CiviCRM', 'edit own api keys', 'edit all contacts'];
     $key = uniqid();
 
-    $contact = Contact::create()
-      ->setCheckPermissions(FALSE)
+    $contact = Contact::create(FALSE)
       ->addValue('first_name', 'Api')
       ->addValue('last_name', 'Key3')
       ->addValue('api_key', $key)
@@ -236,8 +229,7 @@ class ContactApiKeyTest extends \api\v4\UnitTestCase {
 
     $this->assertContains('key', $error);
 
-    $result = Contact::get()
-      ->setCheckPermissions(FALSE)
+    $result = Contact::get(FALSE)
       ->addWhere('id', '=', $contact['id'])
       ->addSelect('api_key')
       ->execute()
@@ -254,8 +246,7 @@ class ContactApiKeyTest extends \api\v4\UnitTestCase {
       ->addValue('api_key', "MyId!")
       ->execute();
 
-    $result = Contact::get()
-      ->setCheckPermissions(FALSE)
+    $result = Contact::get(FALSE)
       ->addWhere('id', '=', $contact['id'])
       ->addSelect('api_key')
       ->execute()

--- a/tests/phpunit/api/v4/Entity/ConformanceTest.php
+++ b/tests/phpunit/api/v4/Entity/ConformanceTest.php
@@ -231,13 +231,13 @@ class ConformanceTest extends UnitTestCase {
     $exceptionThrown = '';
     try {
       $entityClass::get()
-        ->setCheckPermissions('nada')
+        ->setDebug('not a bool')
         ->execute();
     }
     catch (\API_Exception $e) {
       $exceptionThrown = $e->getMessage();
     }
-    $this->assertContains('checkPermissions', $exceptionThrown);
+    $this->assertContains('debug', $exceptionThrown);
     $this->assertContains('type', $exceptionThrown);
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
This adds a much-requested shorthand for setting `$checkPermissions` in APIv4.

- For api consumers, the change is backward compatible and does not require any updates to your code.
- As with any API changes, any extensions taking advantage of the shorter syntax will need to update their core version dependency (in this case to 5.29).
- For api authors, you will need to update the factory functions in any api classes that extend `AbstractAction`, `BasicAction` or `DAOAction`. Until you do so, a php warning will be generated about function signatures not matching.

Before
----------------------------------------
    \Civi\Api4\Contact::get()
      ->setCheckPermissions(FALSE)
      ->execute();

After
----------------------------------------
    \Civi\Api4\Contact::get(FALSE)
      ->execute();

Technical Details
----------------------------------------
This required updating every API factory method, so it's a big PR.

It's also going to generate on-screen PHP warnings for any extensions with built-from-scratch APIs (of which there are very few in existence and most if not all of them were written by me) until those function signatures get updated. I can take care of that shortly after this PR gets accepted. Extensions with regular DAO-based APIv4 entities are not affected if they just inherit all their factory functions from the base class.

Comments
--------
Also updated the API Explorer:
![image](https://user-images.githubusercontent.com/2874912/87467336-cc0fed80-c5e5-11ea-8cd5-f723adbe08db.png)
