### PR TITLE
Revert "dev/core#1847 Fix datepicker to respect the searchDate offsets"

### DIFF
--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -359,8 +359,6 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
    *
    * @return HTML_QuickForm_Element
    *   Could be an error object
-   *
-   * @throws \CRM_Core_Exception
    */
   public function &add(
     $type, $name, $label = '',
@@ -387,34 +385,16 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
       unset($attributes['multiple']);
       $extra = NULL;
     }
-
-    // @see https://docs.civicrm.org/dev/en/latest/framework/ui/#date-picker
-    if ($type === 'datepicker') {
-      $attributes = $attributes ?: [];
-      if (!empty($attributes['format'])) {
-        $dateAttributes = CRM_Core_SelectValues::date($attributes['format'], NULL, NULL, NULL, 'Input');
-        if (empty($extra['minDate']) && !empty($dateAttributes['minYear'])) {
-          $extra['minDate'] = $dateAttributes['minYear'] . '-01-01';
-        }
-        if (empty($extra['maxDate']) && !empty($dateAttributes['minYear'])) {
-          $extra['maxDate'] = $dateAttributes['maxYear'] . '-12-31';
-        }
-      }
-      // Support minDate/maxDate properties
-      if (isset($extra['minDate'])) {
-        $extra['minDate'] = date('Y-m-d', strtotime($extra['minDate']));
-      }
-      if (isset($extra['maxDate'])) {
-        $extra['maxDate'] = date('Y-m-d', strtotime($extra['maxDate']));
-      }
-
+    // @see http://wiki.civicrm.org/confluence/display/CRMDOC/crmDatepicker
+    if ($type == 'datepicker') {
+      $attributes = ($attributes ? $attributes : []);
       $attributes['data-crm-datepicker'] = json_encode((array) $extra);
       if (!empty($attributes['aria-label']) || $label) {
         $attributes['aria-label'] = CRM_Utils_Array::value('aria-label', $attributes, $label);
       }
       $type = "text";
     }
-    if ($type === 'select' && is_array($extra)) {
+    if ($type == 'select' && is_array($extra)) {
       // Normalize this property
       if (!empty($extra['multiple'])) {
         $extra['multiple'] = 'multiple';


### PR DESCRIPTION
The intent is to refix-better in the rc

This reverts commit 4c69df351115c19bf0ea7d62d53a016d86e66847.

Overview
----------------------------------------
Our rc backport caused a regression - we have a proposed fix here 

https://github.com/civicrm/civicrm-core/pull/17836

However, I think for the 5.27 we should back-out the original backport & avoid dropping the proposed fix same-day

Before
----------------------------------------
_What is the old user-interface or technical-contract (as appropriate)?_
_For optimal clarity, include a concrete example such as a screenshot, GIF ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)), or code-snippet._

After
----------------------------------------
_What changed? What is new old user-interface or technical-contract?_
_For optimal clarity, include a concrete example such as a screenshot, GIF ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)), or code-snippet._

Technical Details
----------------------------------------
_If the PR involves technical details/changes/considerations which would not be manifest to a casual developer skimming the above sections, please describe the details here._

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
