### PR TITLE
Update regen.sh with new & upcoming core extensions

### DIFF
--- a/bin/regen.sh
+++ b/bin/regen.sh
@@ -49,7 +49,7 @@ php GenerateData.php
 
 ## Prune local data
 $MYSQLCMD -e "DROP TABLE zipcodes; DROP TABLE IF EXISTS civicrm_install_canary; DELETE FROM civicrm_cache; DELETE FROM civicrm_setting;"
-$MYSQLCMD -e "DELETE FROM civicrm_extension WHERE full_name NOT IN ('sequentialcreditnotes');"
+$MYSQLCMD -e "DELETE FROM civicrm_extension WHERE full_name NOT IN ('sequentialcreditnotes', 'eventcart', 'search', 'flexmailer');"
 TABLENAMES=$( echo "show tables like 'civicrm_%'" | $MYSQLCMD | grep ^civicrm_ | xargs )
 
 cd $CIVISOURCEDIR/sql


### PR DESCRIPTION


Overview
----------------------------------------
regen.sh fix for core extensions

Before
----------------------------------------
Eventcart & other not-yet enabled extensions not listed in handy hard-coded list...

After
----------------------------------------
They are....

Technical Details
----------------------------------------
Putting this out there in case some goes 'oh I could just write the bash to do that off the folder names
in the directory....

Comments
----------------------------------------

