### PR TITLE
API tests - label versions in dataprovider versionThreeAndFour

### DIFF
--- a/Civi/Test/Api3TestTrait.php
+++ b/Civi/Test/Api3TestTrait.php
@@ -23,7 +23,10 @@ trait Api3TestTrait {
    * @return array
    */
   public function versionThreeAndFour() {
-    return [[3], [4]];
+    return [
+      'APIv3' => [3],
+      'APIv4' => [4],
+    ];
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
In unit tests, make it more clear which api version is being tested.

Before
----------------------------------------
Numeric keys gave ambiguous messages like "Test xyz failed with dataset 0"

After
----------------------------------------
String keys should give more specific messages like "Test xyz failed with dataset 'APIv3'"