### PR TITLE
dev/core#1880 add backticks to custom field insertions

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -1814,9 +1814,9 @@ WHERE  id IN ( %1, %2 )
     $add->custom_group_id = $newGroup->id;
     self::createField($add, 'add');
 
-    $sql = "INSERT INTO {$newGroup->table_name} (entity_id, {$field->column_name})
-            SELECT entity_id, {$field->column_name} FROM {$oldGroup->table_name}
-            ON DUPLICATE KEY UPDATE {$field->column_name} = {$oldGroup->table_name}.{$field->column_name}
+    $sql = "INSERT INTO {$newGroup->table_name} (entity_id, `{$field->column_name}`)
+            SELECT entity_id, `{$field->column_name}` FROM {$oldGroup->table_name}
+            ON DUPLICATE KEY UPDATE `{$field->column_name}` = {$oldGroup->table_name}.`{$field->column_name}`
             ";
     CRM_Core_DAO::executeQuery($sql);
 
@@ -2066,10 +2066,10 @@ WHERE  id IN ( %1, %2 )
       }
       if (in_array($field['data_type'], $fieldTypesNotHandledInMergeAttempt) && !$isMultiple) {
         CRM_Core_DAO::executeQuery(
-          "INSERT INTO {$field['custom_group_id.table_name']} (entity_id, {$field['column_name']})
+          "INSERT INTO {$field['custom_group_id.table_name']} (entity_id, `{$field['column_name']}`)
           VALUES ($newContactID, {$oldContact['custom_' . $field['id']]})
           ON DUPLICATE KEY UPDATE
-          {$field['column_name']} = {$oldContact['custom_' . $field['id']]}
+          `{$field['column_name']}` = {$oldContact['custom_' . $field['id']]}
         ");
       }
     }

--- a/CRM/Core/BAO/CustomValueTable.php
+++ b/CRM/Core/BAO/CustomValueTable.php
@@ -238,7 +238,7 @@ class CRM_Core_BAO_CustomValueTable {
         if (!empty($set)) {
           $setClause = [];
           foreach ($set as $n => $v) {
-            $setClause[] = "$n = $v";
+            $setClause[] = "`$n` = $v";
           }
           $setClause = implode(',', $setClause);
           if (!$where) {


### PR DESCRIPTION
Overview
----------------------------------------
If a custom field is created with a MySQL reserved term, such as "use," it may result in a column in the corresponding value table with that name. Because it is a reserved word, it triggered errors during insert/update. This is easily remedied with the use of backticks (which we're starting to use more consistently anyway).

One could argue we should address this upstream and prevent the creation of fields with reserved names. But that won't address previously created fields, and adding backticks to our SQL is a good policy anyway.

Before
----------------------------------------
Use of reserved terms in custom value table columns results in errors during insert/update.

After
----------------------------------------
No errors during insert/update.