### PR TITLE
handlePaymentNotification() should not be declared as a static method

### DIFF
--- a/CRM/Core/Payment/AuthorizeNet.php
+++ b/CRM/Core/Payment/AuthorizeNet.php
@@ -673,7 +673,7 @@ class CRM_Core_Payment_AuthorizeNet extends CRM_Core_Payment {
   /**
    * Process incoming notification.
    */
-  public static function handlePaymentNotification() {
+  public function handlePaymentNotification() {
     $ipnClass = new CRM_Core_Payment_AuthorizeNetIPN(array_merge($_GET, $_REQUEST));
     $ipnClass->main();
   }

--- a/CRM/Core/Payment/PayPalImpl.php
+++ b/CRM/Core/Payment/PayPalImpl.php
@@ -690,7 +690,7 @@ class CRM_Core_Payment_PayPalImpl extends CRM_Core_Payment {
    * @throws \CRM_Core_Exception
    * @throws \CiviCRM_API3_Exception
    */
-  public static function handlePaymentNotification() {
+  public function handlePaymentNotification() {
     $params = array_merge($_GET, $_REQUEST);
     $q = explode('/', CRM_Utils_Array::value('q', $params, ''));
     $lastParam = array_pop($q);


### PR DESCRIPTION
Overview
----------------------------------------
Per https://github.com/civicrm/civicrm-core/blob/master/CRM/Core/Payment.php#L1606 `handlePaymentNotification()` is a member function and should not be declared as static.

Before
----------------------------------------
Some payment processors declare as static.

After
----------------------------------------
No core payment processors declare as static.

Technical Details
----------------------------------------

Comments
----------------------------------------
This is a change to make it technically correct. Spotted while debugging some IPN stuff and did not actually have an impact on the site if it was static or not. But this may become an issue in PHP7.4 and higher where the spec becomes tighter? @eileenmcnaughton @seamuslee001 
