### PR TITLE
[REF] Only printOnly once

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -2839,8 +2839,6 @@ WHERE cg.extends IN ('" . implode("','", $this->_customGroupExtends) . "') AND
         CRM_Core_DAO::$_nullObject
       );
 
-    $this->assign('printOnly', $this->printOnly);
-
     if ($this->_outputMode == 'print' ||
       ($this->_sendmail && !$this->_outputMode)
     ) {


### PR DESCRIPTION
Overview
----------------------------------------
It assigns printOnly twice.

Before
----------------------------------------
printOnly is assigned to the template first before being set to its proper value and then assigns it again later after.

After
----------------------------------------
Only printOnly once

Technical Details
----------------------------------------
Look down at line 2867. Also note the intervening lines might change its value, so it doesn't make sense to assign it before that.

Comments
----------------------------------------
This is part of a larger PR, so if you're thinking that `if else` block could be cleaned up it's coming later.
