### PR TITLE
dev/core#1882 - Missing version number in status check message about db version vs code version

### DIFF
--- a/CRM/Utils/Check/Component/Env.php
+++ b/CRM/Utils/Check/Component/Env.php
@@ -751,7 +751,8 @@ class CRM_Utils_Check_Component_Env extends CRM_Utils_Check_Component {
       }
 
       // if db.ver > code.ver, sth really wrong
-      if (version_compare($dbVersion, CRM_Utils_System::version()) > 0) {
+      $codeVersion = CRM_Utils_System::version();
+      if (version_compare($dbVersion, $codeVersion) > 0) {
         $messages[] = new CRM_Utils_Check_Message(
           __FUNCTION__,
           ts('Your database is marked with an unexpected version number: %1. The v%2 codebase may not be compatible with your database state.


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/1882

It says `...The v codebase may not be compatible with your database state...`

Before
----------------------------------------
version missing

After
----------------------------------------
version shown

Technical Details
----------------------------------------
In https://github.com/civicrm/civicrm-core/pull/17722/files#diff-50f6e167c4bfdcf605b5e0617d06b82d some of the code got moved around and the variable that holds the version got moved with it.

Comments
----------------------------------------
It affects 5.27 too.
