### PR TITLE
dev/core#1090 Update extendedSerializeData to use the Backbone namesp…

### DIFF
--- a/js/view/crm.designer.js
+++ b/js/view/crm.designer.js
@@ -2,7 +2,7 @@
   if (!CRM.Designer) CRM.Designer = {};
 
   /**
-   * When rendering a template with Marionette.ItemView, the list of variables is determined by
+   * When rendering a template with Backbone.Marionette.ItemView, the list of variables is determined by
    * serializeData(). The normal behavior is to map each property of this.model to a template
    * variable.
    *
@@ -14,7 +14,7 @@
    * @return {*}
    */
   var extendedSerializeData = function() {
-    var result = Marionette.ItemView.prototype.serializeData.apply(this);
+    var result = Backbone.Marionette.ItemView.prototype.serializeData.apply(this);
     result._view = this;
     result._model = this.model;
     result._collection = this.collection;


### PR DESCRIPTION
…ace to fix an issue with recent versions of elementor wordpress plugin

Overview
----------------------------------------
This doesn't aim to solve everything in the dec/core#1090 however i found a similar variant of that issue in that a client of ours uses the [elementor](https://wordpress.org/plugins/elementor/) plugin and after installing the latest version of the edit profile option on an Event or contribution on line registration section broke

Before
----------------------------------------
Cannot edit a profile from the online registration section of Event Registration config

After
----------------------------------------
Can edit a profile from the online registration section of event Regsitration configuration

ping @kcristiano 