### PR TITLE
EventCart - Resolve BAO identity and uncommitted DAO changes

### DIFF
--- a/CRM/Core/CodeGen/Specification.php
+++ b/CRM/Core/CodeGen/Specification.php
@@ -192,6 +192,7 @@ class CRM_Core_CodeGen_Specification {
     $sourceFile = "xml/schema/{$base}/{$klass}.xml";
     $daoPath = "{$base}/DAO/";
     $baoPath = __DIR__ . '/../../../' . str_replace(' ', '', "{$base}/BAO/");
+    $useBao = $this->value('useBao', $tableXML, file_exists($baoPath . $klass . '.php'));
     $pre = str_replace('/', '_', $daoPath);
     $this->classNames[$name] = $pre . $klass;
 
@@ -213,7 +214,7 @@ class CRM_Core_CodeGen_Specification {
       'icon' => $tableXML->icon ?? NULL,
       'labelName' => substr($name, 8),
       'className' => $this->classNames[$name],
-      'bao' => (file_exists($baoPath . $klass . '.php') ? str_replace('DAO', 'BAO', $this->classNames[$name]) : $this->classNames[$name]),
+      'bao' => ($useBao ? str_replace('DAO', 'BAO', $this->classNames[$name]) : $this->classNames[$name]),
       'entity' => $klass,
       'attributes_simple' => trim($database['tableAttributes_simple']),
       'attributes_modern' => trim($database['tableAttributes_modern']),

--- a/xml/schema/Event/Cart/Cart.xml
+++ b/xml/schema/Event/Cart/Cart.xml
@@ -3,6 +3,7 @@
 <table>
   <base>CRM/Event/Cart</base>
   <class>Cart</class>
+  <useBao>1</useBao>
   <name>civicrm_event_carts</name>
   <field>
     <name>id</name>

--- a/xml/schema/Event/Cart/EventInCart.xml
+++ b/xml/schema/Event/Cart/EventInCart.xml
@@ -3,6 +3,7 @@
 <table>
   <base>CRM/Event/Cart</base>
   <class>EventInCart</class>
+  <useBao>1</useBao>
   <name>civicrm_events_in_carts</name>
   <field>
     <name>id</name>


### PR DESCRIPTION
Overview
--------

This fixes a recent issue in which `setup.sh` is producing local-only changes to the `Cart` and `EventInCart` DAO files.

To reduce ambiguity, I'm rephrasing the normal "Before/After" and giving a 3-step evolution/history.

ping @eileenmcnaughton @seamuslee001

Evolution
---------

(1) Traditionally, the `Cart`/`EventInCart` entities have both BAO+DAO in main source-tree.

(2) With #17743 (685bf3d218a9dad7e90d24aec165c63df12c1f67), the BAO moved away. But then we get some detritus in the code-tree whenever you run `setup.sh`.

(3) With this patch, we don't get the detritus anymore.

Technical Details
-----------------

When I ran `setup.sh -g`, it produced local modifications like this:

```
diff --git a/CRM/Event/Cart/DAO/Cart.php b/CRM/Event/Cart/DAO/Cart.php
index 4683add13d..3a7f721dc1 100644
--- a/CRM/Event/Cart/DAO/Cart.php
+++ b/CRM/Event/Cart/DAO/Cart.php
@@ -94,7 +94,7 @@ class CRM_Event_Cart_DAO_Cart extends CRM_Core_DAO {
           'where' => 'civicrm_event_carts.id',
           'table_name' => 'civicrm_event_carts',
           'entity' => 'Cart',
-          'bao' => 'CRM_Event_Cart_BAO_Cart',
+          'bao' => 'CRM_Event_Cart_DAO_Cart',
           'localizable' => 0,
           'add' => '4.1',
         ],
```

(Let's ignore the cyclic dependency in this design - that's a messier/broader/pre-existing issue.)

That metadata is inaccurate.  The `bao` should point to the BAO.

It's inaccurate because there's a file-existence check, and it fails when the BAO has a different location.

This patch allows you override the file-existence check -- saying, "this entity will use BAO's even though they're not in the file-location you might normally expect."
