### PR TITLE
Fix potential js error on summary screen when reloading blocks

### DIFF
--- a/templates/CRM/Contact/Page/View/Summary.js
+++ b/templates/CRM/Contact/Page/View/Summary.js
@@ -61,10 +61,14 @@
   function reloadBlock(el) {
     return $(el).each(function() {
       var data = $(this).data('edit-params');
-      data.snippet = data.reset = 1;
-      data.class_name = data.class_name.replace('Form', 'Page');
-      data.type = 'page';
-      $(this).closest('.crm-summary-block').load(CRM.url('civicrm/ajax/inline', data), function() {$(this).trigger('crmLoad');});
+      if (data) {
+        data.snippet = data.reset = 1;
+        data.class_name = data.class_name.replace('Form', 'Page');
+        data.type = 'page';
+        $(this).closest('.crm-summary-block').load(CRM.url('civicrm/ajax/inline', data), function() {
+          $(this).trigger('crmLoad');
+        });
+      }
     });
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a possible edge-case js error on the summary screen when saving and reloading blocks.

Before
----------------------------------------
Possible error in rare cases where a dependent block has been altered by the layout editor to not support reloading.

After
----------------------------------------
If clause guards against errors.