### PR TITLE
dev/core#1578 - Fix APIv4 chaining with custom fields

### DIFF
--- a/Civi/Api4/Provider/ActionObjectProvider.php
+++ b/Civi/Api4/Provider/ActionObjectProvider.php
@@ -116,7 +116,8 @@ class ActionObjectProvider implements EventSubscriberInterface, ProviderInterfac
       }
     }
     elseif (is_string($val) && strlen($val) > 1 && substr($val, 0, 1) === '$') {
-      $val = \CRM_Utils_Array::pathGet($result, explode('.', substr($val, 1)));
+      $key = substr($val, 1);
+      $val = $result[$key] ?? \CRM_Utils_Array::pathGet($result, explode('.', $key));
     }
   }
 

--- a/tests/phpunit/api/v4/Action/ChainTest.php
+++ b/tests/phpunit/api/v4/Action/ChainTest.php
@@ -22,11 +22,24 @@
 namespace api\v4\Action;
 
 use api\v4\UnitTestCase;
+use Civi\Api4\Activity;
+use Civi\Api4\Contact;
+use Civi\Api4\CustomField;
+use Civi\Api4\CustomGroup;
 
 /**
  * @group headless
  */
 class ChainTest extends UnitTestCase {
+
+  public function tearDown() {
+    $result = CustomField::delete()
+      ->setCheckPermissions(FALSE)
+      ->addWhere('name', '=', 'FavPerson')
+      ->addChain('group', CustomGroup::delete()->addWhere('name', '=', 'TestActCus'))
+      ->execute();
+    parent::tearDown();
+  }
 
   public function testGetActionsWithFields() {
     $actions = \Civi\Api4\Activity::getActions()
@@ -55,7 +68,7 @@ class ChainTest extends UnitTestCase {
     $firstName = uniqid('cwtf');
     $lastName = uniqid('cwtl');
 
-    $contact = \Civi\Api4\Contact::create()
+    $contact = Contact::create()
       ->addValue('first_name', $firstName)
       ->addValue('last_name', $lastName)
       ->addChain('group', \Civi\Api4\Group::create()->addValue('title', '$display_name'), 0)
@@ -67,6 +80,48 @@ class ChainTest extends UnitTestCase {
     $this->assertCount(1, $contact['check_group']);
     $this->assertEquals($contact['id'], $contact['check_group'][0]['contact_id']);
     $this->assertEquals($contact['group']['id'], $contact['check_group'][0]['group_id']);
+  }
+
+  public function testWithContactRef() {
+    CustomGroup::create()
+      ->setCheckPermissions(FALSE)
+      ->addValue('name', 'TestActCus')
+      ->addValue('extends', 'Activity')
+      ->addChain('field1', CustomField::create()
+        ->addValue('label', 'FavPerson')
+        ->addValue('custom_group_id', '$id')
+        ->addValue('html_type', 'Autocomplete-Select')
+        ->addValue('data_type', 'ContactReference')
+      )
+      ->execute();
+
+    $sourceId = Contact::create()->addValue('first_name', 'Source')->execute()->first()['id'];
+
+    $created = Contact::create()
+      ->setCheckPermissions(FALSE)
+      ->addValue('first_name', 'Fav')
+      ->addChain('activity', Activity::create()
+        ->addValue('activity_type_id:name', 'Meeting')
+        ->addValue('source_contact_id', $sourceId)
+        ->addValue('TestActCus.FavPerson', '$id'),
+      0)
+      ->execute()->first();
+
+    $found = Activity::get()
+      ->addSelect('TestActCus.*')
+      ->addWhere('id', '=', $created['activity']['id'])
+      ->addChain('contact', Contact::get()
+        // Test that we can access an array key with a dot in it (and it won't be confused with dot notation)
+        ->addWhere('id', '=', '$TestActCus.FavPerson'),
+      0)
+      ->addChain('contact2', Contact::get()
+        // Test that we can access a value within an array using dot notation
+        ->addWhere('id', '=', '$contact.id'),
+      0)
+      ->execute()->first();
+
+    $this->assertEquals('Fav', $found['contact']['first_name']);
+    $this->assertEquals('Fav', $found['contact2']['first_name']);
   }
 
 }

--- a/tests/phpunit/api/v4/Action/EventTest.php
+++ b/tests/phpunit/api/v4/Action/EventTest.php
@@ -29,9 +29,11 @@ class EventTest extends \api\v4\UnitTestCase {
    * @throws \Civi\API\Exception\UnauthorizedException
    */
   public function testTemplateFilterByDefault() {
-    Event::create()->setValues(['template_title' => 'Big Event', 'is_template' => 1, 'start_date' => 'now', 'event_type_id' => 'Meeting'])->execute();
-    Event::create()->setValues(['title' => 'Bigger Event', 'start_date' => 'now', 'event_type_id' => 'Meeting'])->execute();
-    $this->assertEquals(1, Event::get()->selectRowCount()->execute()->count());
+    $t = Event::create()->setValues(['template_title' => 'Big Event', 'is_template' => 1, 'start_date' => 'now', 'event_type_id:name' => 'Meeting'])->execute()->first();
+    $e = Event::create()->setValues(['title' => 'Bigger Event', 'start_date' => 'now', 'event_type_id:name' => 'Meeting'])->execute()->first();
+    $result = (array) Event::get()->execute()->column('id');
+    $this->assertContains($e['id'], $result);
+    $this->assertNotContains($t['id'], $result);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Fix bug in APIv4 related to chaining and custom fields.

Before
----------------------------------------
See https://lab.civicrm.org/dev/core/-/issues/1578

After
----------------------------------------
Fixed.
