### PR TITLE
dev/mailing#70 - Don't create users for test mail if user doesn't have permission

### DIFF
--- a/ang/crmMailing/services.js
+++ b/ang/crmMailing/services.js
@@ -470,7 +470,7 @@
             .then(function (deliveryInfos) {
               var count = Object.keys(deliveryInfos).length;
               if (count === 0) {
-                CRM.alert(ts('Could not identify any recipients. Perhaps the group is empty?'));
+                CRM.alert(ts('Could not identify any recipients. Perhaps your test group is empty, or you tried sending to contacts that do not exist and you have no permission to add contacts.'));
               }
             })
           ;

--- a/api/v3/Mailing.php
+++ b/api/v3/Mailing.php
@@ -657,7 +657,7 @@ function civicrm_api3_mailing_send_test($params) {
         $emailId = $emailDetail[$email]['email_id'];
         $contactId = $emailDetail[$email]['contact_id'];
       }
-      if (!$contactId) {
+      if (!$contactId && CRM_Core_Permission::check('add contacts')) {
         //create new contact.
         $contact   = civicrm_api3('Contact', 'create',
           [
@@ -669,13 +669,15 @@ function civicrm_api3_mailing_send_test($params) {
         $contactId = $contact['id'];
         $emailId   = $contact['values'][$contactId]['api.Email.get']['id'];
       }
-      civicrm_api3('MailingEventQueue', 'create',
-        [
-          'job_id' => $job['id'],
-          'email_id' => $emailId,
-          'contact_id' => $contactId,
-        ]
-      );
+      if ($emailId && $contactId) {
+        civicrm_api3('MailingEventQueue', 'create',
+          [
+            'job_id' => $job['id'],
+            'email_id' => $emailId,
+            'contact_id' => $contactId,
+          ]
+        );
+      }
     }
   }
 


### PR DESCRIPTION
https://lab.civicrm.org/dev/mail/-/issues/70

### Overview

When sending a test mail, CiviCRM will check if the email matches an existing contact in the database.  If it does, it uses that contact ID; if not, it creates a contact.  However, it creates a contact without regard for whether a user has permission to add contacts.

### Steps to replicate

* Create a user that does not have the "Add Contacts" permission.
* With that user, create a new mailing (traditional or Mosaico, doesn't matter).
* Send a test ("draft") mail to an email address that doesn't exist in the database.

### Before

A new contact is created.

### After

No new contact is created.

An error is displayed:

![Screen Shot 2020-07-20 at 4 26 23 PM](https://user-images.githubusercontent.com/1336047/87995976-d169ae00-caa5-11ea-80e1-c1bf007e3ed2.png)

### Comments

This looks bigger than it is because I wrapped some lines in an `if` clause.