### PR TITLE
[REF] Remove civicrm.files override for WordPress to fix issues with…

### DIFF
--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -56,13 +56,6 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
       };
       Civi::paths()->register('cms', $cmsRoot);
       Civi::paths()->register('cms.root', $cmsRoot);
-      Civi::paths()->register('civicrm.files', function () {
-        $upload_dir = wp_get_upload_dir();
-        return [
-          'path' => $upload_dir['basedir'] . DIRECTORY_SEPARATOR . 'civicrm' . DIRECTORY_SEPARATOR,
-          'url' => $upload_dir['baseurl'] . '/civicrm/',
-        ];
-      });
       Civi::paths()->register('civicrm.root', function () {
         return [
           'path' => CIVICRM_PLUGIN_DIR . 'civicrm' . DIRECTORY_SEPARATOR,


### PR DESCRIPTION
… users struggling to find extensions

Overview
----------------------------------------
This removes the `civicrm.files` token override which seems to have caused some issues for users on upgrade to 5.27 see this thread https://chat.civicrm.org/civicrm/pl/mmqxdjnap3b4ubbeqwnn7kdxgc 

Before
----------------------------------------
civicrm.files gives off potentially the wrong file path

After
----------------------------------------
civicrm.files gives off the correct civicrm files file path

ping @jusfreeman @kcristiano @christianwach 