### PR TITLE
Use PrematureExit exception instead of weird hack in tests

### DIFF
--- a/CRM/Activity/Page/AJAX.php
+++ b/CRM/Activity/Page/AJAX.php
@@ -379,7 +379,7 @@ class CRM_Activity_Page_AJAX {
   /**
    * Get activities for the contact.
    *
-   * @return array
+   * @throws \CRM_Core_Exception
    */
   public static function getContactActivity() {
     $requiredParameters = [
@@ -420,10 +420,10 @@ class CRM_Activity_Page_AJAX {
       unset($optionalParameters['context']);
       foreach ($optionalParameters as $searchField => $dataType) {
         $formSearchField = $searchField;
-        if ($searchField == 'activity_type_id') {
+        if ($searchField === 'activity_type_id') {
           $formSearchField = 'activity_type_filter_id';
         }
-        elseif ($searchField == 'activity_type_exclude_id') {
+        elseif ($searchField === 'activity_type_exclude_id') {
           $formSearchField = 'activity_type_exclude_filter_id';
         }
         if (!empty($params[$searchField])) {
@@ -431,16 +431,13 @@ class CRM_Activity_Page_AJAX {
           if (in_array($searchField, ['activity_date_time_low', 'activity_date_time_high'])) {
             $activityFilter['activity_date_time_relative'] = 0;
           }
-          elseif ($searchField == 'activity_status_id') {
+          elseif ($searchField === 'activity_status_id') {
             $activityFilter['status_id'] = explode(',', $activityFilter[$searchField]);
           }
         }
       }
 
       Civi::contactSettings()->set('activity_tab_filter', $activityFilter);
-    }
-    if (!empty($_GET['is_unit_test'])) {
-      return [$activities, $activityFilter];
     }
 
     CRM_Utils_JSON::output($activities);

--- a/CRM/Custom/Page/AJAX.php
+++ b/CRM/Custom/Page/AJAX.php
@@ -93,7 +93,6 @@ class CRM_Custom_Page_AJAX {
 
   /**
    * Get list of Multi Record Fields.
-   *
    */
   public static function getMultiRecordFieldList() {
 
@@ -138,10 +137,6 @@ class CRM_Custom_Page_AJAX {
     $multiRecordFields['data'] = $fieldList;
     $multiRecordFields['recordsTotal'] = $totalRecords;
     $multiRecordFields['recordsFiltered'] = $totalRecords;
-
-    if (!empty($_GET['is_unit_test'])) {
-      return $multiRecordFields;
-    }
 
     CRM_Utils_JSON::output($multiRecordFields);
   }

--- a/CRM/Group/Page/AJAX.php
+++ b/CRM/Group/Page/AJAX.php
@@ -13,7 +13,6 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
- *
  */
 
 /**
@@ -62,10 +61,6 @@ class CRM_Group_Page_AJAX {
           $groups = CRM_Contact_BAO_Group::getGroupListSelector($params);
         }
       }
-    }
-
-    if (!empty($_GET['is_unit_test'])) {
-      return $groups;
     }
 
     CRM_Utils_JSON::output($groups);

--- a/tests/phpunit/CRM/Custom/Page/AJAXTest.php
+++ b/tests/phpunit/CRM/Custom/Page/AJAXTest.php
@@ -54,9 +54,13 @@ class CRM_Custom_Page_AJAXTest extends CiviUnitTestCase {
     $_GET = [
       'cid' => $contactId,
       'cgid' => $ids['custom_group_id'],
-      'is_unit_test' => TRUE,
     ];
-    $multiRecordFields = CRM_Custom_Page_AJAX::getMultiRecordFieldList();
+    try {
+      CRM_Custom_Page_AJAX::getMultiRecordFieldList();
+    }
+    catch (CRM_Core_Exception_PrematureExitException $e) {
+      $multiRecordFields = $e->errorData;
+    }
 
     //check sorting
     foreach ($customFields as $fieldId) {
@@ -72,7 +76,12 @@ class CRM_Custom_Page_AJAXTest extends CiviUnitTestCase {
         'dir' => 'desc',
       ],
     ];
-    $sortedRecords = CRM_Custom_Page_AJAX::getMultiRecordFieldList();
+    try {
+      CRM_Custom_Page_AJAX::getMultiRecordFieldList();
+    }
+    catch (CRM_Core_Exception_PrematureExitException $e) {
+      $sortedRecords = $e->errorData;
+    }
 
     $this->assertEquals(3, $sortedRecords['recordsTotal']);
     $this->assertEquals(3, $multiRecordFields['recordsTotal']);

--- a/tests/phpunit/CRM/Group/Page/AjaxTest.php
+++ b/tests/phpunit/CRM/Group/Page/AjaxTest.php
@@ -34,7 +34,6 @@ class CRM_Group_Page_AjaxTest extends CiviUnitTestCase {
       'rowCount' => 50,
       'sort' => NULL,
       'parentsOnly' => FALSE,
-      'is_unit_test' => TRUE,
     ];
     $this->hookClass = CRM_Utils_Hook::singleton();
     $this->createLoggedInUser();
@@ -90,15 +89,25 @@ class CRM_Group_Page_AjaxTest extends CiviUnitTestCase {
     $obj = new CRM_Group_Page_AJAX();
 
     //filter with title
-    $_GET['title'] = "not-me-active";
-    $groups = $obj->getGroupList();
+    $_GET['title'] = 'not-me-active';
+    try {
+      CRM_Group_Page_AJAX::getGroupList();
+    }
+    catch (CRM_Core_Exception_PrematureExitException $e) {
+      $groups = $e->errorData;
+    }
     $this->assertEquals(1, $groups['recordsTotal']);
     $this->assertEquals('not-me-active', $groups['data'][0]['title']);
     unset($_GET['title']);
 
     // check on status
     $_GET['status'] = 2;
-    $groups = $obj->getGroupList();
+    try {
+      CRM_Group_Page_AJAX::getGroupList();
+    }
+    catch (CRM_Core_Exception_PrematureExitException $e) {
+      $groups = $e->errorData;
+    }
     foreach ($groups['data'] as $key => $val) {
       $this->assertEquals('crm-entity disabled', $val['DT_RowClass']);
     }
@@ -544,8 +553,12 @@ class CRM_Group_Page_AjaxTest extends CiviUnitTestCase {
     // Load the Manage Group page code and we should get a count from our
     // group because the cache is fresh.
     $_GET = $this->_params;
-    $obj = new CRM_Group_Page_AJAX();
-    $groups = $obj->getGroupList();
+    try {
+      CRM_Group_Page_AJAX::getGroupList();
+    }
+    catch (CRM_Core_Exception_PrematureExitException $e) {
+      $groups = $e->errorData;
+    }
 
     // Make sure we returned our smart group and ensure the count is accurate.
     $found = FALSE;
@@ -566,8 +579,12 @@ class CRM_Group_Page_AjaxTest extends CiviUnitTestCase {
 
     // Load the Manage Group page code.
     $_GET = $this->_params;
-    $obj = new CRM_Group_Page_AJAX();
-    $groups = $obj->getGroupList();
+    try {
+      CRM_Group_Page_AJAX::getGroupList();
+    }
+    catch (CRM_Core_Exception_PrematureExitException $e) {
+      $groups = $e->errorData;
+    }
 
     // Make sure the smart group reports unknown count.
     $count_is_unknown = FALSE;
@@ -607,8 +624,12 @@ class CRM_Group_Page_AjaxTest extends CiviUnitTestCase {
 
     // Load the Manage Group page code.
     $_GET = $this->_params;
-    $obj = new CRM_Group_Page_AJAX();
-    $groups = $obj->getGroupList();
+    try {
+      CRM_Group_Page_AJAX::getGroupList();
+    }
+    catch (CRM_Core_Exception_PrematureExitException $e) {
+      // Perhaps this was just testing valid sql...
+    }
 
     // Ensure we did not regenerate the cache.
     $sql = 'SELECT DATE_FORMAT(cache_date, "%Y%m%d%H%i%s") AS cache_date ' .


### PR DESCRIPTION


Overview
----------------------------------------
Passing is_unit_test to a function to avoid the civiExit routine has been superceded by catching
PrematureExitExceptions

Before
----------------------------------------
'is_unit_test' passed as a $_POST or $_GET

After
----------------------------------------
Catch the exception

Technical Details
----------------------------------------


Comments
----------------------------------------

