### PR TITLE
Use new checkPermissions shorthand in api calls

### DIFF
--- a/CRM/Contact/BAO/ContactType.php
+++ b/CRM/Contact/BAO/ContactType.php
@@ -67,7 +67,7 @@ class CRM_Contact_BAO_ContactType extends CRM_Contact_DAO_ContactType {
   public static function basicTypeInfo($includeInactive = FALSE) {
     $cacheKey = 'CRM_CT_BTI_' . (int) $includeInactive;
     if (!Civi::cache('contactTypes')->has($cacheKey)) {
-      $contactType = ContactType::get()->setCheckPermissions(FALSE)->setSelect(['*'])->addWhere('parent_id', 'IS NULL');
+      $contactType = ContactType::get(FALSE)->setSelect(['*'])->addWhere('parent_id', 'IS NULL');
       if ($includeInactive === FALSE) {
         $contactType->addWhere('is_active', '=', 1);
       }
@@ -887,7 +887,7 @@ WHERE ($subtypeClause)";
    */
   protected static function getAllContactTypes() {
     if (!Civi::cache('contactTypes')->has('all')) {
-      $contactTypes = (array) ContactType::get()->setCheckPermissions(FALSE)
+      $contactTypes = (array) ContactType::get(FALSE)
         ->setSelect(['id', 'name', 'label', 'description', 'is_active', 'is_reserved', 'image_URL', 'parent_id', 'parent_id:name', 'parent_id:label'])
         ->execute()->indexBy('name');
 

--- a/CRM/Contact/BAO/SavedSearch.php
+++ b/CRM/Contact/BAO/SavedSearch.php
@@ -208,8 +208,7 @@ class CRM_Contact_BAO_SavedSearch extends CRM_Contact_DAO_SavedSearch {
    * @throws \CiviCRM_API3_Exception
    */
   public static function getSearchParams($id) {
-    $savedSearch = \Civi\Api4\SavedSearch::get()
-      ->setCheckPermissions(FALSE)
+    $savedSearch = \Civi\Api4\SavedSearch::get(FALSE)
       ->addWhere('id', '=', $id)
       ->execute()
       ->first();

--- a/CRM/Contribute/BAO/ContributionRecur.php
+++ b/CRM/Contribute/BAO/ContributionRecur.php
@@ -424,8 +424,7 @@ INNER JOIN civicrm_contribution       con ON ( con.id = mp.contribution_id )
       'id' => $id,
     ]);
     // First look for new-style template contribution with is_template=1
-    $templateContributions = \Civi\Api4\Contribution::get()
-      ->setCheckPermissions(FALSE)
+    $templateContributions = \Civi\Api4\Contribution::get(FALSE)
       ->addWhere('contribution_recur_id', '=', $id)
       ->addWhere('is_template', '=', 1)
       ->addWhere('is_test', '=', $is_test)
@@ -434,8 +433,7 @@ INNER JOIN civicrm_contribution       con ON ( con.id = mp.contribution_id )
       ->execute();
     if (!$templateContributions->count()) {
       // Fall back to old style template contributions
-      $templateContributions = \Civi\Api4\Contribution::get()
-        ->setCheckPermissions(FALSE)
+      $templateContributions = \Civi\Api4\Contribution::get(FALSE)
         ->addWhere('contribution_recur_id', '=', $id)
         ->addWhere('is_test', '=', $is_test)
         ->addOrderBy('id', 'DESC')

--- a/CRM/Core/BAO/MessageTemplate.php
+++ b/CRM/Core/BAO/MessageTemplate.php
@@ -416,8 +416,7 @@ class CRM_Core_BAO_MessageTemplate extends CRM_Core_DAO_MessageTemplate {
       throw new CRM_Core_Exception(ts("Message template's option value or ID missing."));
     }
 
-    $apiCall = MessageTemplate::get()
-      ->setCheckPermissions(FALSE)
+    $apiCall = MessageTemplate::get(FALSE)
       ->addSelect('msg_subject', 'msg_text', 'msg_html', 'pdf_format_id', 'id')
       ->addWhere('is_default', '=', 1);
 

--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -598,8 +598,7 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
    * @throws \Civi\API\Exception\UnauthorizedException
    */
   protected static function filterRowBasedCustomDataFromCustomTables(array &$cidRefs) {
-    $customTables = (array) CustomGroup::get()
-      ->setCheckPermissions(FALSE)
+    $customTables = (array) CustomGroup::get(FALSE)
       ->setSelect(['table_name'])
       ->addWhere('is_multiple', '=', 0)
       ->addWhere('extends', 'IN', array_merge(['Contact'], CRM_Contact_BAO_ContactType::contactTypes()))

--- a/CRM/Upgrade/Incremental/php/FiveTwentyEight.php
+++ b/CRM/Upgrade/Incremental/php/FiveTwentyEight.php
@@ -66,8 +66,7 @@ class CRM_Upgrade_Incremental_php_FiveTwentyEight extends CRM_Upgrade_Incrementa
   }
 
   public static function populateMissingContactTypeName() {
-    $contactTypes = \Civi\Api4\ContactType::get()
-      ->setCheckPermissions(FALSE)
+    $contactTypes = \Civi\Api4\ContactType::get(FALSE)
       ->execute();
     foreach ($contactTypes as $contactType) {
       if (empty($contactType['name'])) {

--- a/CRM/Upgrade/Incremental/php/FiveTwentyOne.php
+++ b/CRM/Upgrade/Incremental/php/FiveTwentyOne.php
@@ -43,7 +43,7 @@ class CRM_Upgrade_Incremental_php_FiveTwentyOne extends CRM_Upgrade_Incremental_
     if ($rev == '5.21.alpha1') {
       // Find any option groups that were not converted during the upgrade.
       $notConverted = [];
-      $optionGroups = \Civi\Api4\OptionGroup::get()->setCheckPermissions(FALSE)->execute();
+      $optionGroups = \Civi\Api4\OptionGroup::get(FALSE)->execute();
       foreach ($optionGroups as $optionGroup) {
         $trimmedName = trim($optionGroup['name']);
         if (strpos($trimmedName, ' ') !== FALSE) {
@@ -86,8 +86,7 @@ class CRM_Upgrade_Incremental_php_FiveTwentyOne extends CRM_Upgrade_Incremental_
   }
 
   public static function fixOptionGroupName() {
-    $optionGroups = \Civi\Api4\OptionGroup::get()
-      ->setCheckPermissions(FALSE)
+    $optionGroups = \Civi\Api4\OptionGroup::get(FALSE)
       ->execute();
     foreach ($optionGroups as $optionGroup) {
       $name = trim($optionGroup['name']);

--- a/CRM/Utils/Check/Component.php
+++ b/CRM/Utils/Check/Component.php
@@ -35,7 +35,7 @@ abstract class CRM_Utils_Check_Component {
     if (empty($this->checksConfig)) {
       $this->checksConfig = Civi::cache('checks')->get('checksConfig', []);
       if (empty($this->checksConfig)) {
-        $this->checksConfig = StatusPreference::get()->setCheckPermissions(FALSE)->execute()->indexBy('name');
+        $this->checksConfig = StatusPreference::get(FALSE)->execute()->indexBy('name');
       }
     }
     return $this->checksConfig;

--- a/CRM/Utils/Migrate/Import.php
+++ b/CRM/Utils/Migrate/Import.php
@@ -349,8 +349,7 @@ AND        v.name = %1
     }
 
     foreach ($fields_indexed_by_group_id as $group_id => $fields) {
-      \Civi\Api4\CustomField::save()
-        ->setCheckPermissions(FALSE)
+      \Civi\Api4\CustomField::save(FALSE)
         ->setDefaults(['custom_group_id' => $group_id])
         ->setRecords(json_decode(json_encode($fields), TRUE))
         ->execute();

--- a/Civi/Api4/Action/Setting/AbstractSettingAction.php
+++ b/Civi/Api4/Action/Setting/AbstractSettingAction.php
@@ -73,11 +73,11 @@ abstract class AbstractSettingAction extends \Civi\Api4\Generic\AbstractAction {
 
   protected function findDomains() {
     if ($this->domainId == 'all') {
-      $this->domainId = Domain::get()->setCheckPermissions(FALSE)->addSelect('id')->execute()->column('id');
+      $this->domainId = Domain::get(FALSE)->addSelect('id')->execute()->column('id');
     }
     elseif ($this->domainId) {
       $this->domainId = (array) $this->domainId;
-      $domains = Domain::get()->setCheckPermissions(FALSE)->addSelect('id')->execute()->column('id');
+      $domains = Domain::get(FALSE)->addSelect('id')->execute()->column('id');
       $invalid = array_diff($this->domainId, $domains);
       if ($invalid) {
         throw new \API_Exception('Invalid domain id: ' . implode(', ', $invalid));

--- a/Civi/Api4/Event/Subscriber/ActivityPreCreationSubscriber.php
+++ b/Civi/Api4/Event/Subscriber/ActivityPreCreationSubscriber.php
@@ -35,8 +35,7 @@ class ActivityPreCreationSubscriber extends Generic\PreCreationSubscriber {
     $activityType = $request->getValue('activity_type');
     if ($activityType) {
       \CRM_Core_Error::deprecatedFunctionWarning('Use activity_type_id:name instead of activity_type in APIv4');
-      $result = OptionValue::get()
-        ->setCheckPermissions(FALSE)
+      $result = OptionValue::get(FALSE)
         ->addWhere('name', '=', $activityType)
         ->addWhere('option_group.name', '=', 'activity_type')
         ->execute();

--- a/Civi/Api4/Event/Subscriber/OptionValuePreCreationSubscriber.php
+++ b/Civi/Api4/Event/Subscriber/OptionValuePreCreationSubscriber.php
@@ -53,8 +53,7 @@ class OptionValuePreCreationSubscriber extends Generic\PreCreationSubscriber {
       return;
     }
     \CRM_Core_Error::deprecatedFunctionWarning('Use option_group_id:name instead of option_group in APIv4');
-    $optionGroup = OptionGroup::get()
-      ->setCheckPermissions(FALSE)
+    $optionGroup = OptionGroup::get(FALSE)
       ->addSelect('id')
       ->addWhere('name', '=', $optionGroupName)
       ->execute();

--- a/Civi/Api4/Generic/Traits/DAOActionTrait.php
+++ b/Civi/Api4/Generic/Traits/DAOActionTrait.php
@@ -221,8 +221,7 @@ trait DAOActionTrait {
     list($groupName, $fieldName) = explode('.', $name);
     list($fieldName, $suffix) = array_pad(explode(':', $fieldName), 2, NULL);
     if (empty(\Civi::$statics['APIv4_Custom_Fields'][$groupName])) {
-      \Civi::$statics['APIv4_Custom_Fields'][$groupName] = (array) CustomField::get()
-        ->setCheckPermissions(FALSE)
+      \Civi::$statics['APIv4_Custom_Fields'][$groupName] = (array) CustomField::get(FALSE)
         ->addSelect('id', 'name', 'html_type', 'custom_group.extends')
         ->addWhere('custom_group.name', '=', $groupName)
         ->execute()->indexBy('name');

--- a/Civi/Api4/Service/Schema/Joinable/CustomGroupJoinable.php
+++ b/Civi/Api4/Service/Schema/Joinable/CustomGroupJoinable.php
@@ -59,8 +59,7 @@ class CustomGroupJoinable extends Joinable {
    */
   public function getEntityFields() {
     if (!$this->entityFields) {
-      $fields = CustomField::get()
-        ->setCheckPermissions(FALSE)
+      $fields = CustomField::get(FALSE)
         ->setSelect(['custom_group.name', 'custom_group.extends', 'custom_group.table_name', '*'])
         ->addWhere('custom_group.table_name', '=', $this->getTargetTable())
         ->execute();

--- a/Civi/Api4/Service/Schema/SchemaMapBuilder.php
+++ b/Civi/Api4/Service/Schema/SchemaMapBuilder.php
@@ -44,7 +44,7 @@ class SchemaMapBuilder {
    */
   public function __construct(EventDispatcherInterface $dispatcher) {
     $this->dispatcher = $dispatcher;
-    $this->apiEntities = array_keys((array) Entity::get()->setCheckPermissions(FALSE)->addSelect('name')->execute()->indexBy('name'));
+    $this->apiEntities = array_keys((array) Entity::get(FALSE)->addSelect('name')->execute()->indexBy('name'));
   }
 
   /**

--- a/Civi/Api4/Service/Spec/SpecGatherer.php
+++ b/Civi/Api4/Service/Spec/SpecGatherer.php
@@ -128,8 +128,7 @@ class SpecGatherer {
     if ($entity === 'Participant') {
       $extends = ['Participant', 'ParticipantRole', 'ParticipantEventName', 'ParticipantEventType'];
     }
-    $customFields = CustomField::get()
-      ->setCheckPermissions(FALSE)
+    $customFields = CustomField::get(FALSE)
       ->addWhere('custom_group.extends', 'IN', $extends)
       ->addWhere('custom_group.is_multiple', '=', '0')
       ->setSelect(['custom_group.name', '*'])
@@ -146,8 +145,7 @@ class SpecGatherer {
    * @param \Civi\Api4\Service\Spec\RequestSpec $specification
    */
   private function getCustomGroupFields($customGroup, RequestSpec $specification) {
-    $customFields = CustomField::get()
-      ->setCheckPermissions(FALSE)
+    $customFields = CustomField::get(FALSE)
       ->addWhere('custom_group.name', '=', $customGroup)
       ->setSelect(['custom_group.name', 'custom_group.table_name', '*'])
       ->execute();

--- a/ext/search/CRM/Search/Upgrader.php
+++ b/ext/search/CRM/Search/Upgrader.php
@@ -10,8 +10,7 @@ class CRM_Search_Upgrader extends CRM_Search_Upgrader_Base {
    * Add menu item when enabled.
    */
   public function enable() {
-    \Civi\Api4\Navigation::create()
-      ->setCheckPermissions(FALSE)
+    \Civi\Api4\Navigation::create(FALSE)
       ->addValue('parent_id:name', 'Search')
       ->addValue('label', E::ts('Create Search...'))
       ->addValue('name', 'create_search')
@@ -26,8 +25,7 @@ class CRM_Search_Upgrader extends CRM_Search_Upgrader_Base {
    * Delete menu item when disabled.
    */
   public function disable() {
-    \Civi\Api4\Navigation::delete()
-      ->setCheckPermissions(FALSE)
+    \Civi\Api4\Navigation::delete(FALSE)
       ->addWhere('name', '=', 'create_search')
       ->addWhere('domain_id', '=', 'current_domain')
       ->execute();

--- a/ext/sequentialcreditnotes/sequentialcreditnotes.php
+++ b/ext/sequentialcreditnotes/sequentialcreditnotes.php
@@ -32,7 +32,7 @@ function sequentialcreditnotes_civicrm_pre($op, $objectName, $id, &$params) {
     $reversalStatuses = ['Cancelled', 'Chargeback', 'Refunded'];
     if (empty($params['creditnote_id']) && in_array(CRM_Core_PseudoConstant::getName('CRM_Contribute_BAO_Contribution', 'contribution_status_id', $params['contribution_status_id']), $reversalStatuses, TRUE)) {
       if ($id) {
-        $existing = Contribution::get()->setCheckPermissions(FALSE)->addWhere('id', '=', (int) $id)->setSelect(['creditnote_id'])->execute()->first();
+        $existing = Contribution::get(FALSE)->addWhere('id', '=', (int) $id)->setSelect(['creditnote_id'])->execute()->first();
         if ($existing['creditnote_id']) {
           // Since we have it adding it makes is clearer.
           $params['creditnote_id'] = $existing['creditnote_id'];

--- a/tests/phpunit/CRM/Contact/Form/Task/EmailCommonTest.php
+++ b/tests/phpunit/CRM/Contact/Form/Task/EmailCommonTest.php
@@ -119,7 +119,7 @@ class CRM_Contact_Form_Task_EmailCommonTest extends CiviUnitTestCase {
       'This is a test Signature',
     ]);
     $mut->stop();
-    $activity = Activity::get()->setCheckPermissions(FALSE)->setSelect(['details'])->execute()->first();
+    $activity = Activity::get(FALSE)->setSelect(['details'])->execute()->first();
     $bccUrl1 = CRM_Utils_System::url('civicrm/contact/view', ['reset' => 1, 'force' => 1, 'cid' => $bcc1], TRUE);
     $bccUrl2 = CRM_Utils_System::url('civicrm/contact/view', ['reset' => 1, 'force' => 1, 'cid' => $bcc2], TRUE);
     $this->assertContains("bcc : <a href='" . $bccUrl1 . "'>Mr. Anthony Anderson II</a><a href='" . $bccUrl2 . "'>Mr. Anthony Anderson II</a>", $activity['details']);

--- a/tests/phpunit/CRM/Core/BAO/ActionScheduleTest.php
+++ b/tests/phpunit/CRM/Core/BAO/ActionScheduleTest.php
@@ -920,7 +920,7 @@ class CRM_Core_BAO_ActionScheduleTest extends CiviUnitTestCase {
     ));
     $activity->save();
 
-    ActivityContact::create()->setCheckPermissions(FALSE)->setValues([
+    ActivityContact::create(FALSE)->setValues([
       'contact_id' => $contact['id'],
       'activity_id' => $activity->id,
       'record_type_id:name' => 'Activity Source',
@@ -2583,7 +2583,7 @@ class CRM_Core_BAO_ActionScheduleTest extends CiviUnitTestCase {
     );
     $this->assertInternalType('numeric', $membership->id);
     if ($emailParams) {
-      Civi\Api4\Email::create()->setCheckPermissions(FALSE)->setValues(array_merge([
+      Civi\Api4\Email::create(FALSE)->setValues(array_merge([
         'contact_id' => $membership->contact_id,
         'location_type_id' => 1,
       ], $emailParams))->execute();

--- a/tests/phpunit/CRMTraits/Custom/CustomDataTrait.php
+++ b/tests/phpunit/CRMTraits/Custom/CustomDataTrait.php
@@ -50,7 +50,7 @@ trait CRMTraits_Custom_CustomDataTrait {
       'max_multiple' => 0,
     ], $params);
     $identifier = $params['name'] ?? $params['title'];
-    $this->ids['CustomGroup'][$identifier] = CustomGroup::create()->setCheckPermissions(FALSE)->setValues($params)->execute()->first()['id'];
+    $this->ids['CustomGroup'][$identifier] = CustomGroup::create(FALSE)->setValues($params)->execute()->first()['id'];
     return $this->ids['CustomGroup'][$identifier];
   }
 

--- a/tests/phpunit/api/v3/ACLPermissionTest.php
+++ b/tests/phpunit/api/v3/ACLPermissionTest.php
@@ -1010,8 +1010,7 @@ class api_v3_ACLPermissionTest extends CiviUnitTestCase {
     $group = uniqid('mg');
     $textField = uniqid('tx');
 
-    CustomGroup::create()
-      ->setCheckPermissions(FALSE)
+    CustomGroup::create(FALSE)
       ->addValue('name', $group)
       ->addValue('extends', 'Contact')
       ->addValue('is_multiple', TRUE)

--- a/tests/phpunit/api/v4/Action/BasicCustomFieldTest.php
+++ b/tests/phpunit/api/v4/Action/BasicCustomFieldTest.php
@@ -32,15 +32,13 @@ class BasicCustomFieldTest extends BaseCustomValueTest {
 
   public function testWithSingleField() {
 
-    $customGroup = CustomGroup::create()
-      ->setCheckPermissions(FALSE)
+    $customGroup = CustomGroup::create(FALSE)
       ->addValue('name', 'MyIndividualFields')
       ->addValue('extends', 'Individual')
       ->execute()
       ->first();
 
-    CustomField::create()
-      ->setCheckPermissions(FALSE)
+    CustomField::create(FALSE)
       ->addValue('label', 'FavColor')
       ->addValue('custom_group_id', $customGroup['id'])
       ->addValue('html_type', 'Text')
@@ -48,13 +46,12 @@ class BasicCustomFieldTest extends BaseCustomValueTest {
       ->execute();
 
     // Individual fields should show up when contact_type = null|Individual but not other contact types
-    $getFields = Contact::getFields()->setCheckPermissions(FALSE);
+    $getFields = Contact::getFields(FALSE);
     $this->assertContains('MyIndividualFields.FavColor', $getFields->execute()->column('name'));
     $this->assertContains('MyIndividualFields.FavColor', $getFields->setValues(['contact_type' => 'Individual'])->execute()->column('name'));
     $this->assertNotContains('MyIndividualFields.FavColor', $getFields->setValues(['contact_type' => 'Household'])->execute()->column('name'));
 
-    $contactId = Contact::create()
-      ->setCheckPermissions(FALSE)
+    $contactId = Contact::create(FALSE)
       ->addValue('first_name', 'Johann')
       ->addValue('last_name', 'Tester')
       ->addValue('contact_type', 'Individual')
@@ -62,8 +59,7 @@ class BasicCustomFieldTest extends BaseCustomValueTest {
       ->execute()
       ->first()['id'];
 
-    $contact = Contact::get()
-      ->setCheckPermissions(FALSE)
+    $contact = Contact::get(FALSE)
       ->addSelect('first_name')
       ->addSelect('MyIndividualFields.FavColor')
       ->addWhere('id', '=', $contactId)
@@ -78,8 +74,7 @@ class BasicCustomFieldTest extends BaseCustomValueTest {
       ->addValue('MyIndividualFields.FavColor', 'Blue')
       ->execute();
 
-    $contact = Contact::get()
-      ->setCheckPermissions(FALSE)
+    $contact = Contact::get(FALSE)
       ->addSelect('MyIndividualFields.FavColor')
       ->addWhere('id', '=', $contactId)
       ->execute()
@@ -91,8 +86,7 @@ class BasicCustomFieldTest extends BaseCustomValueTest {
   public function testWithTwoFields() {
 
     // First custom set
-    CustomGroup::create()
-      ->setCheckPermissions(FALSE)
+    CustomGroup::create(FALSE)
       ->addValue('name', 'MyContactFields')
       ->addValue('extends', 'Contact')
       ->addChain('field1', CustomField::create()
@@ -108,8 +102,7 @@ class BasicCustomFieldTest extends BaseCustomValueTest {
       ->execute();
 
     // Second custom set
-    CustomGroup::create()
-      ->setCheckPermissions(FALSE)
+    CustomGroup::create(FALSE)
       ->addValue('name', 'MyContactFields2')
       ->addValue('extends', 'Contact')
       ->addChain('field1', CustomField::create()
@@ -124,8 +117,7 @@ class BasicCustomFieldTest extends BaseCustomValueTest {
         ->addValue('data_type', 'String'))
       ->execute();
 
-    $contactId1 = Contact::create()
-      ->setCheckPermissions(FALSE)
+    $contactId1 = Contact::create(FALSE)
       ->addValue('first_name', 'Johann')
       ->addValue('last_name', 'Tester')
       ->addValue('MyContactFields.FavColor', 'Red')
@@ -133,8 +125,7 @@ class BasicCustomFieldTest extends BaseCustomValueTest {
       ->execute()
       ->first()['id'];
 
-    $contactId2 = Contact::create()
-      ->setCheckPermissions(FALSE)
+    $contactId2 = Contact::create(FALSE)
       ->addValue('first_name', 'MaryLou')
       ->addValue('last_name', 'Tester')
       ->addValue('MyContactFields.FavColor', 'Purple')
@@ -142,8 +133,7 @@ class BasicCustomFieldTest extends BaseCustomValueTest {
       ->execute()
       ->first()['id'];
 
-    $contact = Contact::get()
-      ->setCheckPermissions(FALSE)
+    $contact = Contact::get(FALSE)
       ->addSelect('first_name')
       ->addSelect('MyContactFields.FavColor')
       ->addSelect('MyContactFields.FavFood')
@@ -162,8 +152,7 @@ class BasicCustomFieldTest extends BaseCustomValueTest {
       ->addValue('MyContactFields2.FavColor', 'Orange')
       ->addValue('MyContactFields2.FavFood', 'Tangerine')
       ->execute();
-    $contact = Contact::get()
-      ->setCheckPermissions(FALSE)
+    $contact = Contact::get(FALSE)
       ->addSelect('MyContactFields.FavColor', 'MyContactFields2.FavColor', 'MyContactFields.FavFood', 'MyContactFields2.FavFood')
       ->addWhere('id', '=', $contactId1)
       ->execute()
@@ -178,8 +167,7 @@ class BasicCustomFieldTest extends BaseCustomValueTest {
       ->addWhere('id', '=', $contactId1)
       ->addValue('MyContactFields.FavColor', 'Blue')
       ->execute();
-    $contact = Contact::get()
-      ->setCheckPermissions(FALSE)
+    $contact = Contact::get(FALSE)
       ->addSelect('MyContactFields.FavColor', 'MyContactFields2.FavColor', 'MyContactFields.FavFood', 'MyContactFields2.FavFood')
       ->addWhere('id', '=', $contactId1)
       ->execute()
@@ -189,8 +177,7 @@ class BasicCustomFieldTest extends BaseCustomValueTest {
     $this->assertEquals('Cherry', $contact['MyContactFields.FavFood']);
     $this->assertEquals('Tangerine', $contact['MyContactFields2.FavFood']);
 
-    $search = Contact::get()
-      ->setCheckPermissions(FALSE)
+    $search = Contact::get(FALSE)
       ->addClause('OR', ['MyContactFields.FavColor', '=', 'Blue'], ['MyContactFields.FavFood', '=', 'Grapes'])
       ->addSelect('id')
       ->addOrderBy('id')
@@ -199,8 +186,7 @@ class BasicCustomFieldTest extends BaseCustomValueTest {
 
     $this->assertEquals([$contactId1, $contactId2], array_keys((array) $search));
 
-    $search = Contact::get()
-      ->setCheckPermissions(FALSE)
+    $search = Contact::get(FALSE)
       ->addClause('NOT', ['MyContactFields.FavColor', '=', 'Purple'], ['MyContactFields.FavFood', '=', 'Grapes'])
       ->addSelect('id')
       ->addOrderBy('id')
@@ -209,8 +195,7 @@ class BasicCustomFieldTest extends BaseCustomValueTest {
 
     $this->assertNotContains($contactId2, array_keys((array) $search));
 
-    $search = Contact::get()
-      ->setCheckPermissions(FALSE)
+    $search = Contact::get(FALSE)
       ->addClause('NOT', ['MyContactFields.FavColor', '=', 'Purple'], ['MyContactFields.FavFood', '=', 'Grapes'])
       ->addSelect('id')
       ->addOrderBy('id')
@@ -220,8 +205,7 @@ class BasicCustomFieldTest extends BaseCustomValueTest {
     $this->assertContains($contactId1, array_keys((array) $search));
     $this->assertNotContains($contactId2, array_keys((array) $search));
 
-    $search = Contact::get()
-      ->setCheckPermissions(FALSE)
+    $search = Contact::get(FALSE)
       ->setWhere([['NOT', ['OR', [['MyContactFields.FavColor', '=', 'Blue'], ['MyContactFields.FavFood', '=', 'Grapes']]]]])
       ->addSelect('id')
       ->addOrderBy('id')

--- a/tests/phpunit/api/v4/Action/ComplexQueryTest.php
+++ b/tests/phpunit/api/v4/Action/ComplexQueryTest.php
@@ -49,8 +49,7 @@ class ComplexQueryTest extends UnitTestCase {
    * Expects at least one activity loaded from the data set.
    */
   public function testGetAllHousingSupportActivities() {
-    $results = Activity::get()
-      ->setCheckPermissions(FALSE)
+    $results = Activity::get(FALSE)
       ->addWhere('activity_type_id:name', '=', 'Phone Call')
       ->execute();
 

--- a/tests/phpunit/api/v4/Action/ContactChecksumTest.php
+++ b/tests/phpunit/api/v4/Action/ContactChecksumTest.php
@@ -29,8 +29,7 @@ use Civi\Api4\Contact;
 class ContactChecksumTest extends \api\v4\UnitTestCase {
 
   public function testGetChecksum() {
-    $contact = Contact::create()
-      ->setCheckPermissions(FALSE)
+    $contact = Contact::create(FALSE)
       ->addValue('first_name', 'Check')
       ->addValue('last_name', 'Sum')
       ->addChain('cs', Contact::getChecksum()->setContactId('$id')->setTtl(500), 0)
@@ -47,8 +46,7 @@ class ContactChecksumTest extends \api\v4\UnitTestCase {
   }
 
   public function testValidateChecksum() {
-    $cid = Contact::create()
-      ->setCheckPermissions(FALSE)
+    $cid = Contact::create(FALSE)
       ->addValue('first_name', 'Checker')
       ->addValue('last_name', 'Sum')
       ->execute()

--- a/tests/phpunit/api/v4/Action/ContactGetTest.php
+++ b/tests/phpunit/api/v4/Action/ContactGetTest.php
@@ -73,21 +73,21 @@ class ContactGetTest extends \api\v4\UnitTestCase {
       ->setValues(['first_name' => 'Dan', 'last_name' => $last_name])
       ->execute()->first();
 
-    $num = Contact::get()->setCheckPermissions(FALSE)->selectRowCount()->execute()->count();
+    $num = Contact::get(FALSE)->selectRowCount()->execute()->count();
 
     // The object's count() method will account for all results, ignoring limit & offset, while the array results are limited
-    $offset1 = Contact::get()->setCheckPermissions(FALSE)->setOffset(1)->execute();
+    $offset1 = Contact::get(FALSE)->setOffset(1)->execute();
     $this->assertCount($num, $offset1);
     $this->assertCount($num - 1, (array) $offset1);
-    $offset2 = Contact::get()->setCheckPermissions(FALSE)->setOffset(2)->execute();
+    $offset2 = Contact::get(FALSE)->setOffset(2)->execute();
     $this->assertCount($num - 2, (array) $offset2);
     $this->assertCount($num, $offset2);
     // With limit, it doesn't fetch total count by default
-    $limit2 = Contact::get()->setCheckPermissions(FALSE)->setLimit(2)->execute();
+    $limit2 = Contact::get(FALSE)->setLimit(2)->execute();
     $this->assertCount(2, (array) $limit2);
     $this->assertCount(2, $limit2);
     // With limit, you have to trigger the full row count manually
-    $limit2 = Contact::get()->setCheckPermissions(FALSE)->setLimit(2)->addSelect('sort_name', 'row_count')->execute();
+    $limit2 = Contact::get(FALSE)->setLimit(2)->addSelect('sort_name', 'row_count')->execute();
     $this->assertCount(2, (array) $limit2);
     $this->assertCount($num, $limit2);
   }

--- a/tests/phpunit/api/v4/Action/CreateCustomValueTest.php
+++ b/tests/phpunit/api/v4/Action/CreateCustomValueTest.php
@@ -34,15 +34,13 @@ class CreateCustomValueTest extends BaseCustomValueTest {
   public function testGetWithCustomData() {
     $optionValues = ['r' => 'Red', 'g' => 'Green', 'b' => 'Blue'];
 
-    $customGroup = CustomGroup::create()
-      ->setCheckPermissions(FALSE)
+    $customGroup = CustomGroup::create(FALSE)
       ->addValue('name', 'MyContactFields')
       ->addValue('extends', 'Contact')
       ->execute()
       ->first();
 
-    CustomField::create()
-      ->setCheckPermissions(FALSE)
+    CustomField::create(FALSE)
       ->addValue('label', 'Color')
       ->addValue('option_values', $optionValues)
       ->addValue('custom_group_id', $customGroup['id'])
@@ -50,8 +48,7 @@ class CreateCustomValueTest extends BaseCustomValueTest {
       ->addValue('data_type', 'String')
       ->execute();
 
-    $customField = CustomField::get()
-      ->setCheckPermissions(FALSE)
+    $customField = CustomField::get(FALSE)
       ->addWhere('label', '=', 'Color')
       ->execute()
       ->first();
@@ -59,16 +56,14 @@ class CreateCustomValueTest extends BaseCustomValueTest {
     $this->assertNotNull($customField['option_group_id']);
     $optionGroupId = $customField['option_group_id'];
 
-    $optionGroup = OptionGroup::get()
-      ->setCheckPermissions(FALSE)
+    $optionGroup = OptionGroup::get(FALSE)
       ->addWhere('id', '=', $optionGroupId)
       ->execute()
       ->first();
 
     $this->assertEquals('Color', $optionGroup['title']);
 
-    $createdOptionValues = OptionValue::get()
-      ->setCheckPermissions(FALSE)
+    $createdOptionValues = OptionValue::get(FALSE)
       ->addWhere('option_group_id', '=', $optionGroupId)
       ->execute()
       ->getArrayCopy();

--- a/tests/phpunit/api/v4/Action/CreateWithOptionGroupTest.php
+++ b/tests/phpunit/api/v4/Action/CreateWithOptionGroupTest.php
@@ -44,15 +44,13 @@ class CreateWithOptionGroupTest extends BaseCustomValueTest {
     $colorField = uniqid('colora');
     $foodField = uniqid('fooda');
 
-    $customGroupId = CustomGroup::create()
-      ->setCheckPermissions(FALSE)
+    $customGroupId = CustomGroup::create(FALSE)
       ->addValue('name', $group)
       ->addValue('extends', 'Contact')
       ->execute()
       ->first()['id'];
 
-    CustomField::create()
-      ->setCheckPermissions(FALSE)
+    CustomField::create(FALSE)
       ->addValue('label', $colorField)
       ->addValue('name', $colorField)
       ->addValue('option_values', ['r' => 'Red', 'g' => 'Green', 'b' => 'Blue'])
@@ -61,8 +59,7 @@ class CreateWithOptionGroupTest extends BaseCustomValueTest {
       ->addValue('data_type', 'String')
       ->execute();
 
-    CustomField::create()
-      ->setCheckPermissions(FALSE)
+    CustomField::create(FALSE)
       ->addValue('label', $foodField)
       ->addValue('name', $foodField)
       ->addValue('option_values', ['1' => 'Corn', '2' => 'Potatoes', '3' => 'Cheese'])
@@ -71,23 +68,20 @@ class CreateWithOptionGroupTest extends BaseCustomValueTest {
       ->addValue('data_type', 'String')
       ->execute();
 
-    $customGroupId = CustomGroup::create()
-      ->setCheckPermissions(FALSE)
+    $customGroupId = CustomGroup::create(FALSE)
       ->addValue('name', 'FinancialStuff')
       ->addValue('extends', 'Contact')
       ->execute()
       ->first()['id'];
 
-    CustomField::create()
-      ->setCheckPermissions(FALSE)
+    CustomField::create(FALSE)
       ->addValue('label', 'Salary')
       ->addValue('custom_group_id', $customGroupId)
       ->addValue('html_type', 'Number')
       ->addValue('data_type', 'Money')
       ->execute();
 
-    Contact::create()
-      ->setCheckPermissions(FALSE)
+    Contact::create(FALSE)
       ->addValue('first_name', 'Jerome')
       ->addValue('last_name', 'Tester')
       ->addValue('contact_type', 'Individual')
@@ -96,8 +90,7 @@ class CreateWithOptionGroupTest extends BaseCustomValueTest {
       ->addValue('FinancialStuff.Salary', 50000)
       ->execute();
 
-    $result = Contact::get()
-      ->setCheckPermissions(FALSE)
+    $result = Contact::get(FALSE)
       ->addSelect('first_name')
       ->addSelect("$group.$colorField:label")
       ->addSelect("$group.$foodField:label")
@@ -117,15 +110,13 @@ class CreateWithOptionGroupTest extends BaseCustomValueTest {
     $colorField = uniqid('colorb');
     $foodField = uniqid('foodb');
 
-    $customGroupId = CustomGroup::create()
-      ->setCheckPermissions(FALSE)
+    $customGroupId = CustomGroup::create(FALSE)
       ->addValue('name', $group)
       ->addValue('extends', 'Contact')
       ->execute()
       ->first()['id'];
 
-    CustomField::create()
-      ->setCheckPermissions(FALSE)
+    CustomField::create(FALSE)
       ->addValue('label', $colorField)
       ->addValue('name', $colorField)
       ->addValue('option_values', ['r' => 'Red', 'g' => 'Green', 'b' => 'Blue'])
@@ -134,8 +125,7 @@ class CreateWithOptionGroupTest extends BaseCustomValueTest {
       ->addValue('data_type', 'String')
       ->execute();
 
-    CustomField::create()
-      ->setCheckPermissions(FALSE)
+    CustomField::create(FALSE)
       ->addValue('label', $foodField)
       ->addValue('name', $foodField)
       ->addValue('option_values', ['1' => 'Corn', '2' => 'Potatoes', '3' => 'Cheese'])
@@ -144,23 +134,20 @@ class CreateWithOptionGroupTest extends BaseCustomValueTest {
       ->addValue('data_type', 'String')
       ->execute();
 
-    $customGroupId = CustomGroup::create()
-      ->setCheckPermissions(FALSE)
+    $customGroupId = CustomGroup::create(FALSE)
       ->addValue('name', 'FinancialStuff')
       ->addValue('extends', 'Contact')
       ->execute()
       ->first()['id'];
 
-    CustomField::create()
-      ->setCheckPermissions(FALSE)
+    CustomField::create(FALSE)
       ->addValue('label', 'Salary')
       ->addValue('custom_group_id', $customGroupId)
       ->addValue('html_type', 'Number')
       ->addValue('data_type', 'Money')
       ->execute();
 
-    Contact::create()
-      ->setCheckPermissions(FALSE)
+    Contact::create(FALSE)
       ->addValue('first_name', 'Red')
       ->addValue('last_name', 'Corn')
       ->addValue('contact_type', 'Individual')
@@ -169,8 +156,7 @@ class CreateWithOptionGroupTest extends BaseCustomValueTest {
       ->addValue('FinancialStuff.Salary', 10000)
       ->execute();
 
-    Contact::create()
-      ->setCheckPermissions(FALSE)
+    Contact::create(FALSE)
       ->addValue('first_name', 'Blue')
       ->addValue('last_name', 'Cheese')
       ->addValue('contact_type', 'Individual')
@@ -179,8 +165,7 @@ class CreateWithOptionGroupTest extends BaseCustomValueTest {
       ->addValue('FinancialStuff.Salary', 500000)
       ->execute();
 
-    $result = Contact::get()
-      ->setCheckPermissions(FALSE)
+    $result = Contact::get(FALSE)
       ->addSelect('first_name')
       ->addSelect('last_name')
       ->addSelect("$group.$colorField:label")

--- a/tests/phpunit/api/v4/Action/CustomValuePerformanceTest.php
+++ b/tests/phpunit/api/v4/Action/CustomValuePerformanceTest.php
@@ -37,16 +37,14 @@ class CustomValuePerformanceTest extends BaseCustomValueTest {
 
     $this->markTestIncomplete();
 
-    $customGroupId = CustomGroup::create()
-      ->setCheckPermissions(FALSE)
+    $customGroupId = CustomGroup::create(FALSE)
       ->addValue('name', 'MyContactFields')
       ->addValue('title', 'MyContactFields')
       ->addValue('extends', 'Contact')
       ->execute()
       ->first()['id'];
 
-    CustomField::create()
-      ->setCheckPermissions(FALSE)
+    CustomField::create(FALSE)
       ->addValue('label', 'FavColor')
       ->addValue('custom_group_id', $customGroupId)
       ->addValue('options', ['r' => 'Red', 'g' => 'Green', 'b' => 'Blue'])
@@ -54,24 +52,21 @@ class CustomValuePerformanceTest extends BaseCustomValueTest {
       ->addValue('data_type', 'String')
       ->execute();
 
-    CustomField::create()
-      ->setCheckPermissions(FALSE)
+    CustomField::create(FALSE)
       ->addValue('label', 'FavAnimal')
       ->addValue('custom_group_id', $customGroupId)
       ->addValue('html_type', 'Text')
       ->addValue('data_type', 'String')
       ->execute();
 
-    CustomField::create()
-      ->setCheckPermissions(FALSE)
+    CustomField::create(FALSE)
       ->addValue('label', 'FavLetter')
       ->addValue('custom_group_id', $customGroupId)
       ->addValue('html_type', 'Text')
       ->addValue('data_type', 'String')
       ->execute();
 
-    CustomField::create()
-      ->setCheckPermissions(FALSE)
+    CustomField::create(FALSE)
       ->addValue('label', 'FavFood')
       ->addValue('custom_group_id', $customGroupId)
       ->addValue('html_type', 'Text')
@@ -80,8 +75,7 @@ class CustomValuePerformanceTest extends BaseCustomValueTest {
 
     $this->beginQueryCount();
 
-    Contact::create()
-      ->setCheckPermissions(FALSE)
+    Contact::create(FALSE)
       ->addValue('first_name', 'Red')
       ->addValue('last_name', 'Tester')
       ->addValue('contact_type', 'Individual')
@@ -91,8 +85,7 @@ class CustomValuePerformanceTest extends BaseCustomValueTest {
       ->addValue('MyContactFields.FavFood', 'Coconuts')
       ->execute();
 
-    Contact::get()
-      ->setCheckPermissions(FALSE)
+    Contact::get(FALSE)
       ->addSelect('display_name')
       ->addSelect('MyContactFields.FavColor.label')
       ->addSelect('MyContactFields.FavColor.weight')

--- a/tests/phpunit/api/v4/Action/CustomValueTest.php
+++ b/tests/phpunit/api/v4/Action/CustomValueTest.php
@@ -44,16 +44,14 @@ class CustomValueTest extends BaseCustomValueTest {
     $multiField = uniqid('chkbx');
     $textField = uniqid('txt');
 
-    $customGroup = CustomGroup::create()
-      ->setCheckPermissions(FALSE)
+    $customGroup = CustomGroup::create(FALSE)
       ->addValue('name', $group)
       ->addValue('extends', 'Contact')
       ->addValue('is_multiple', TRUE)
       ->execute()
       ->first();
 
-    CustomField::create()
-      ->setCheckPermissions(FALSE)
+    CustomField::create(FALSE)
       ->addValue('label', $colorField)
       ->addValue('option_values', $optionValues)
       ->addValue('custom_group_id', $customGroup['id'])
@@ -61,8 +59,7 @@ class CustomValueTest extends BaseCustomValueTest {
       ->addValue('data_type', 'String')
       ->execute();
 
-    CustomField::create()
-      ->setCheckPermissions(FALSE)
+    CustomField::create(FALSE)
       ->addValue('label', $multiField)
       ->addValue('option_values', $optionValues)
       ->addValue('custom_group_id', $customGroup['id'])
@@ -70,16 +67,14 @@ class CustomValueTest extends BaseCustomValueTest {
       ->addValue('data_type', 'String')
       ->execute();
 
-    CustomField::create()
-      ->setCheckPermissions(FALSE)
+    CustomField::create(FALSE)
       ->addValue('label', $textField)
       ->addValue('custom_group_id', $customGroup['id'])
       ->addValue('html_type', 'Text')
       ->addValue('data_type', 'String')
       ->execute();
 
-    $this->contactID = Contact::create()
-      ->setCheckPermissions(FALSE)
+    $this->contactID = Contact::create(FALSE)
       ->addValue('first_name', 'Johann')
       ->addValue('last_name', 'Tester')
       ->addValue('contact_type', 'Individual')
@@ -195,8 +190,7 @@ class CustomValueTest extends BaseCustomValueTest {
 
     // CASE 3: Test CustomValue::replace
     // create a second contact which will be used to replace the custom values, created earlier
-    $secondContactID = Contact::create()
-      ->setCheckPermissions(FALSE)
+    $secondContactID = Contact::create(FALSE)
       ->addValue('first_name', 'Adam')
       ->addValue('last_name', 'Tester')
       ->addValue('contact_type', 'Individual')

--- a/tests/phpunit/api/v4/Action/ExtendFromIndividualTest.php
+++ b/tests/phpunit/api/v4/Action/ExtendFromIndividualTest.php
@@ -32,24 +32,21 @@ class ExtendFromIndividualTest extends BaseCustomValueTest {
 
   public function testGetWithNonStandardExtends() {
 
-    $customGroup = CustomGroup::create()
-      ->setCheckPermissions(FALSE)
+    $customGroup = CustomGroup::create(FALSE)
       ->addValue('name', 'MyContactFields')
       // not Contact
       ->addValue('extends', 'Individual')
       ->execute()
       ->first();
 
-    CustomField::create()
-      ->setCheckPermissions(FALSE)
+    CustomField::create(FALSE)
       ->addValue('label', 'FavColor')
       ->addValue('custom_group_id', $customGroup['id'])
       ->addValue('html_type', 'Text')
       ->addValue('data_type', 'String')
       ->execute();
 
-    $contactId = Contact::create()
-      ->setCheckPermissions(FALSE)
+    $contactId = Contact::create(FALSE)
       ->addValue('first_name', 'Johann')
       ->addValue('last_name', 'Tester')
       ->addValue('contact_type', 'Individual')
@@ -57,8 +54,7 @@ class ExtendFromIndividualTest extends BaseCustomValueTest {
       ->execute()
       ->first()['id'];
 
-    $contact = Contact::get()
-      ->setCheckPermissions(FALSE)
+    $contact = Contact::get(FALSE)
       ->addSelect('display_name')
       ->addSelect('MyContactFields.FavColor')
       ->addWhere('id', '=', $contactId)

--- a/tests/phpunit/api/v4/Action/FkJoinTest.php
+++ b/tests/phpunit/api/v4/Action/FkJoinTest.php
@@ -49,8 +49,7 @@ class FkJoinTest extends UnitTestCase {
    * loaded from the data set.
    */
   public function testThreeLevelJoin() {
-    $results = Activity::get()
-      ->setCheckPermissions(FALSE)
+    $results = Activity::get(FALSE)
       ->addWhere('activity_type_id:name', '=', 'Phone Call')
       ->execute();
 
@@ -60,11 +59,10 @@ class FkJoinTest extends UnitTestCase {
   public function testOptionalJoin() {
     // DefaultDataSet includes 2 phones for contact 1, 0 for contact 2.
     // We'll add one for contact 2 as a red herring to make sure we only get back the correct ones.
-    Phone::create()->setCheckPermissions(FALSE)
+    Phone::create(FALSE)
       ->setValues(['contact_id' => $this->getReference('test_contact_2')['id'], 'phone' => '123456'])
       ->execute();
-    $contacts = Contact::get()
-      ->setCheckPermissions(FALSE)
+    $contacts = Contact::get(FALSE)
       ->addJoin('Phone', FALSE)
       ->addSelect('id', 'phone.phone')
       ->addWhere('id', 'IN', [$this->getReference('test_contact_1')['id']])
@@ -77,8 +75,7 @@ class FkJoinTest extends UnitTestCase {
 
   public function testRequiredJoin() {
     // Joining with no condition
-    $contacts = Contact::get()
-      ->setCheckPermissions(FALSE)
+    $contacts = Contact::get(FALSE)
       ->addSelect('id', 'phone.phone')
       ->addJoin('Phone', TRUE)
       ->addWhere('id', 'IN', [$this->getReference('test_contact_1')['id'], $this->getReference('test_contact_2')['id']])
@@ -89,8 +86,7 @@ class FkJoinTest extends UnitTestCase {
     $this->assertEquals($this->getReference('test_contact_1')['id'], $contacts[1]['id']);
 
     // Add is_primary condition, should result in only one record
-    $contacts = Contact::get()
-      ->setCheckPermissions(FALSE)
+    $contacts = Contact::get(FALSE)
       ->addSelect('id', 'phone.phone', 'phone.location_type_id')
       ->addJoin('Phone', TRUE, ['phone.is_primary', '=', TRUE])
       ->addWhere('id', 'IN', [$this->getReference('test_contact_1')['id'], $this->getReference('test_contact_2')['id']])
@@ -103,14 +99,14 @@ class FkJoinTest extends UnitTestCase {
   }
 
   public function testJoinToTheSameTableTwice() {
-    $cid1 = Contact::create()->setCheckPermissions(FALSE)
+    $cid1 = Contact::create(FALSE)
       ->addValue('first_name', 'Aaa')
       ->addChain('email1', Email::create()->setValues(['email' => 'yoohoo@yahoo.test', 'contact_id' => '$id', 'location_type_id:name' => 'Home']))
       ->addChain('email2', Email::create()->setValues(['email' => 'yahoo@yoohoo.test', 'contact_id' => '$id', 'location_type_id:name' => 'Work']))
       ->execute()
       ->first()['id'];
 
-    $cid2 = Contact::create()->setCheckPermissions(FALSE)
+    $cid2 = Contact::create(FALSE)
       ->addValue('first_name', 'Bbb')
       ->addChain('email1', Email::create()->setValues(['email' => '1@test.test', 'contact_id' => '$id', 'location_type_id:name' => 'Home']))
       ->addChain('email2', Email::create()->setValues(['email' => '2@test.test', 'contact_id' => '$id', 'location_type_id:name' => 'Work']))
@@ -118,13 +114,12 @@ class FkJoinTest extends UnitTestCase {
       ->execute()
       ->first()['id'];
 
-    $cid3 = Contact::create()->setCheckPermissions(FALSE)
+    $cid3 = Contact::create(FALSE)
       ->addValue('first_name', 'Ccc')
       ->execute()
       ->first()['id'];
 
-    $contacts = Contact::get()
-      ->setCheckPermissions(FALSE)
+    $contacts = Contact::get(FALSE)
       ->addSelect('id', 'first_name', 'any_email.email', 'any_email.location_type_id:name', 'any_email.is_primary', 'primary_email.email')
       ->addJoin('Email AS any_email', TRUE)
       ->addJoin('Email AS primary_email', FALSE, ['primary_email.is_primary', '=', TRUE])

--- a/tests/phpunit/api/v4/Action/GetExtraFieldsTest.php
+++ b/tests/phpunit/api/v4/Action/GetExtraFieldsTest.php
@@ -31,7 +31,7 @@ use Civi\Api4\Contact;
 class GetExtraFieldsTest extends UnitTestCase {
 
   public function testGetFieldsByContactType() {
-    $getFields = Contact::getFields()->setCheckPermissions(FALSE)->addSelect('name')->setIncludeCustom(FALSE);
+    $getFields = Contact::getFields(FALSE)->addSelect('name')->setIncludeCustom(FALSE);
 
     $baseFields = array_column(\CRM_Contact_BAO_Contact::fields(), 'name');
     $returnedFields = $getFields->execute()->column('name');
@@ -53,7 +53,7 @@ class GetExtraFieldsTest extends UnitTestCase {
   }
 
   public function testGetOptionsAddress() {
-    $getFields = Address::getFields()->setCheckPermissions(FALSE)->addWhere('name', '=', 'state_province_id')->setLoadOptions(TRUE);
+    $getFields = Address::getFields(FALSE)->addWhere('name', '=', 'state_province_id')->setLoadOptions(TRUE);
 
     $usOptions = $getFields->setValues(['country_id' => 1228])->execute()->first();
 

--- a/tests/phpunit/api/v4/Action/NullValueTest.php
+++ b/tests/phpunit/api/v4/Action/NullValueTest.php
@@ -35,8 +35,7 @@ class NullValueTest extends UnitTestCase {
   }
 
   public function testStringNull() {
-    $contact = Contact::create()
-      ->setCheckPermissions(FALSE)
+    $contact = Contact::create(FALSE)
       ->addValue('first_name', 'Joseph')
       ->addValue('last_name', 'null')
       ->addValue('contact_type', 'Individual')
@@ -48,8 +47,7 @@ class NullValueTest extends UnitTestCase {
   }
 
   public function testSettingToNull() {
-    $contact = Contact::create()
-      ->setCheckPermissions(FALSE)
+    $contact = Contact::create(FALSE)
       ->addValue('first_name', 'ILoveMy')
       ->addValue('last_name', 'LastName')
       ->addValue('contact_type', 'Individual')
@@ -59,8 +57,7 @@ class NullValueTest extends UnitTestCase {
     $this->assertSame('ILoveMy LastName', $contact['display_name']);
     $contactId = $contact['id'];
 
-    $contact = Contact::update()
-      ->setCheckPermissions(FALSE)
+    $contact = Contact::update(FALSE)
       ->addWhere('id', '=', $contactId)
       ->addValue('last_name', NULL)
       ->execute()
@@ -71,15 +68,13 @@ class NullValueTest extends UnitTestCase {
   }
 
   public function testSaveWithReload() {
-    $contact = Contact::create()
-      ->setCheckPermissions(FALSE)
+    $contact = Contact::create(FALSE)
       ->addValue('first_name', 'Firsty')
       ->addValue('last_name', 'Lasty')
       ->execute()
       ->first();
 
-    $activity = Activity::create()
-      ->setCheckPermissions(FALSE)
+    $activity = Activity::create(FALSE)
       ->addValue('source_contact_id', $contact['id'])
       ->addValue('activity_type_id', 1)
       ->addValue('subject', 'hello')
@@ -88,8 +83,7 @@ class NullValueTest extends UnitTestCase {
 
     $this->assertEquals('hello', $activity['subject']);
 
-    $saved = Activity::save()
-      ->setCheckPermissions(FALSE)
+    $saved = Activity::save(FALSE)
       ->addRecord(['id' => $activity['id'], 'subject' => NULL])
       ->execute()
       ->first();
@@ -97,8 +91,7 @@ class NullValueTest extends UnitTestCase {
     $this->assertNull($saved['subject']);
     $this->assertArrayNotHasKey('activity_date_time', $saved);
 
-    $saved = Activity::save()
-      ->setCheckPermissions(FALSE)
+    $saved = Activity::save(FALSE)
       ->addRecord(['id' => $activity['id'], 'subject' => NULL])
       ->setReload(TRUE)
       ->execute()

--- a/tests/phpunit/api/v4/Action/PseudoconstantTest.php
+++ b/tests/phpunit/api/v4/Action/PseudoconstantTest.php
@@ -36,7 +36,7 @@ use Civi\Api4\Tag;
 class PseudoconstantTest extends BaseCustomValueTest {
 
   public function testOptionValue() {
-    $cid = Contact::create()->setCheckPermissions(FALSE)->addValue('first_name', 'bill')->execute()->first()['id'];
+    $cid = Contact::create(FALSE)->addValue('first_name', 'bill')->execute()->first()['id'];
     $subject = uniqid('subject');
     OptionValue::create()
       ->addValue('option_group_id:name', 'activity_type')
@@ -99,7 +99,7 @@ class PseudoconstantTest extends BaseCustomValueTest {
   }
 
   public function testAddressOptions() {
-    $cid = Contact::create()->setCheckPermissions(FALSE)->addValue('first_name', 'addr')->execute()->first()['id'];
+    $cid = Contact::create(FALSE)->addValue('first_name', 'addr')->execute()->first()['id'];
     Address::save()
       ->addRecord([
         'contact_id' => $cid,
@@ -153,8 +153,7 @@ class PseudoconstantTest extends BaseCustomValueTest {
       ['id' => 'b', 'name' => 'blue', 'label' => 'BLUE', 'color' => '#0000ff', 'description' => 'Blue color', 'icon' => 'fa-blue'],
     ];
 
-    CustomGroup::create()
-      ->setCheckPermissions(FALSE)
+    CustomGroup::create(FALSE)
       ->addValue('name', 'myPseudoconstantTest')
       ->addValue('extends', 'Individual')
       ->addChain('field1', CustomField::create()
@@ -181,14 +180,12 @@ class PseudoconstantTest extends BaseCustomValueTest {
       }
     }
 
-    $cid = Contact::create()
-      ->setCheckPermissions(FALSE)
+    $cid = Contact::create(FALSE)
       ->addValue('first_name', 'col')
       ->addValue('myPseudoconstantTest.Color:label', 'blü')
       ->execute()->first()['id'];
 
-    $result = Contact::get()
-      ->setCheckPermissions(FALSE)
+    $result = Contact::get(FALSE)
       ->addWhere('id', '=', $cid)
       ->addSelect('myPseudoconstantTest.Color:name', 'myPseudoconstantTest.Color:label', 'myPseudoconstantTest.Color')
       ->execute()->first();
@@ -197,27 +194,23 @@ class PseudoconstantTest extends BaseCustomValueTest {
     $this->assertEquals('bl_', $result['myPseudoconstantTest.Color:name']);
     $this->assertEquals('b', $result['myPseudoconstantTest.Color']);
 
-    $cid1 = Contact::create()
-      ->setCheckPermissions(FALSE)
+    $cid1 = Contact::create(FALSE)
       ->addValue('first_name', 'two')
       ->addValue('myPseudoconstantTest.Technicolor:label', 'RED')
       ->execute()->first()['id'];
-    $cid2 = Contact::create()
-      ->setCheckPermissions(FALSE)
+    $cid2 = Contact::create(FALSE)
       ->addValue('first_name', 'two')
       ->addValue('myPseudoconstantTest.Technicolor:label', 'GREEN')
       ->execute()->first()['id'];
 
     // Test ordering by label
-    $result = Contact::get()
-      ->setCheckPermissions(FALSE)
+    $result = Contact::get(FALSE)
       ->addWhere('id', 'IN', [$cid1, $cid2])
       ->addSelect('id')
       ->addOrderBy('myPseudoconstantTest.Technicolor:label')
       ->execute()->first()['id'];
     $this->assertEquals($cid2, $result);
-    $result = Contact::get()
-      ->setCheckPermissions(FALSE)
+    $result = Contact::get(FALSE)
       ->addWhere('id', 'IN', [$cid1, $cid2])
       ->addSelect('id')
       ->addOrderBy('myPseudoconstantTest.Technicolor:label', 'DESC')
@@ -226,17 +219,17 @@ class PseudoconstantTest extends BaseCustomValueTest {
   }
 
   public function testJoinOptions() {
-    $cid1 = Contact::create()->setCheckPermissions(FALSE)
+    $cid1 = Contact::create(FALSE)
       ->addValue('first_name', 'Tom')
       ->addValue('gender_id:label', 'Male')
       ->addChain('email', Email::create()->setValues(['contact_id' => '$id', 'email' => 'tom@example.com', 'location_type_id:name' => 'Work']))
       ->execute()->first()['id'];
-    $cid2 = Contact::create()->setCheckPermissions(FALSE)
+    $cid2 = Contact::create(FALSE)
       ->addValue('first_name', 'Sue')
       ->addValue('gender_id:name', 'Female')
       ->addChain('email', Email::create()->setValues(['contact_id' => '$id', 'email' => 'sue@example.com', 'location_type_id:name' => 'Home']))
       ->execute()->first()['id'];
-    $cid3 = Contact::create()->setCheckPermissions(FALSE)
+    $cid3 = Contact::create(FALSE)
       ->addValue('first_name', 'Pat')
       ->addChain('email', Email::create()->setValues(['contact_id' => '$id', 'email' => 'pat@example.com', 'location_type_id:name' => 'Home']))
       ->execute()->first()['id'];
@@ -266,7 +259,7 @@ class PseudoconstantTest extends BaseCustomValueTest {
 
   public function testTagOptions() {
     $tag = uniqid('tag');
-    Tag::create()->setCheckPermissions(FALSE)
+    Tag::create(FALSE)
       ->addValue('name', $tag)
       ->addValue('description', 'colorful')
       ->addValue('color', '#aabbcc')

--- a/tests/phpunit/api/v4/Action/ReplaceTest.php
+++ b/tests/phpunit/api/v4/Action/ReplaceTest.php
@@ -106,8 +106,7 @@ class ReplaceTest extends UnitTestCase {
   }
 
   public function testCustomValueReplace() {
-    $customGroup = CustomGroup::create()
-      ->setCheckPermissions(FALSE)
+    $customGroup = CustomGroup::create(FALSE)
       ->addValue('name', 'replaceTest')
       ->addValue('extends', 'Contact')
       ->addValue('is_multiple', TRUE)
@@ -121,8 +120,7 @@ class ReplaceTest extends UnitTestCase {
       ->addValue('data_type', 'String')
       ->execute();
 
-    CustomField::create()
-      ->setCheckPermissions(FALSE)
+    CustomField::create(FALSE)
       ->addValue('label', 'Custom2')
       ->addValue('custom_group_id', $customGroup['id'])
       ->addValue('html_type', 'String')

--- a/tests/phpunit/api/v4/Action/ResultTest.php
+++ b/tests/phpunit/api/v4/Action/ResultTest.php
@@ -30,7 +30,7 @@ use api\v4\UnitTestCase;
 class ResultTest extends UnitTestCase {
 
   public function testJsonSerialize() {
-    $result = Contact::getFields()->setCheckPermissions(FALSE)->setIncludeCustom(FALSE)->execute();
+    $result = Contact::getFields(FALSE)->setIncludeCustom(FALSE)->execute();
     $json = json_encode($result);
     $this->assertStringStartsWith('[{"', $json);
     $this->assertTrue(is_array(json_decode($json)));

--- a/tests/phpunit/api/v4/Action/SqlFunctionTest.php
+++ b/tests/phpunit/api/v4/Action/SqlFunctionTest.php
@@ -38,9 +38,8 @@ class SqlFunctionTest extends UnitTestCase {
   }
 
   public function testGroupAggregates() {
-    $cid = Contact::create()->setCheckPermissions(FALSE)->addValue('first_name', 'bill')->execute()->first()['id'];
-    Contribution::save()
-      ->setCheckPermissions(FALSE)
+    $cid = Contact::create(FALSE)->addValue('first_name', 'bill')->execute()->first()['id'];
+    Contribution::save(FALSE)
       ->setDefaults(['contact_id' => $cid, 'financial_type_id' => 1])
       ->setRecords([
         ['total_amount' => 100, 'receive_date' => '2020-01-01'],
@@ -49,8 +48,7 @@ class SqlFunctionTest extends UnitTestCase {
         ['total_amount' => 400, 'receive_date' => '2020-01-01'],
       ])
       ->execute();
-    $agg = Contribution::get()
-      ->setCheckPermissions(FALSE)
+    $agg = Contribution::get(FALSE)
       ->addGroupBy('contact_id')
       ->addWhere('contact_id', '=', $cid)
       ->addSelect('AVG(total_amount) AS average')
@@ -68,9 +66,8 @@ class SqlFunctionTest extends UnitTestCase {
   }
 
   public function testGroupHaving() {
-    $cid = Contact::create()->setCheckPermissions(FALSE)->addValue('first_name', 'donor')->execute()->first()['id'];
-    Contribution::save()
-      ->setCheckPermissions(FALSE)
+    $cid = Contact::create(FALSE)->addValue('first_name', 'donor')->execute()->first()['id'];
+    Contribution::save(FALSE)
       ->setDefaults(['contact_id' => $cid, 'financial_type_id' => 1])
       ->setRecords([
         ['total_amount' => 100, 'receive_date' => '2020-02-02'],
@@ -79,8 +76,7 @@ class SqlFunctionTest extends UnitTestCase {
         ['total_amount' => 400, 'receive_date' => '2020-04-04'],
       ])
       ->execute();
-    $result = Contribution::get()
-      ->setCheckPermissions(FALSE)
+    $result = Contribution::get(FALSE)
       ->addGroupBy('contact_id')
       ->addGroupBy('receive_date')
       ->addSelect('contact_id')

--- a/tests/phpunit/api/v4/Action/UpdateContactTest.php
+++ b/tests/phpunit/api/v4/Action/UpdateContactTest.php
@@ -32,16 +32,14 @@ use api\v4\UnitTestCase;
 class UpdateContactTest extends UnitTestCase {
 
   public function testUpdateWithIdInWhere() {
-    $contactId = Contact::create()
-      ->setCheckPermissions(FALSE)
+    $contactId = Contact::create(FALSE)
       ->addValue('first_name', 'Johann')
       ->addValue('last_name', 'Tester')
       ->addValue('contact_type', 'Individual')
       ->execute()
       ->first()['id'];
 
-    $contact = Contact::update()
-      ->setCheckPermissions(FALSE)
+    $contact = Contact::update(FALSE)
       ->addWhere('id', '=', $contactId)
       ->addValue('first_name', 'Testy')
       ->execute()
@@ -51,16 +49,14 @@ class UpdateContactTest extends UnitTestCase {
   }
 
   public function testUpdateWithIdInValues() {
-    $contactId = Contact::create()
-      ->setCheckPermissions(FALSE)
+    $contactId = Contact::create(FALSE)
       ->addValue('first_name', 'Bobby')
       ->addValue('last_name', 'Tester')
       ->addValue('contact_type', 'Individual')
       ->execute()
       ->first()['id'];
 
-    $contact = Contact::update()
-      ->setCheckPermissions(FALSE)
+    $contact = Contact::update(FALSE)
       ->addValue('id', $contactId)
       ->addValue('first_name', 'Billy')
       ->execute();

--- a/tests/phpunit/api/v4/Action/UpdateCustomValueTest.php
+++ b/tests/phpunit/api/v4/Action/UpdateCustomValueTest.php
@@ -33,23 +33,20 @@ class UpdateCustomValueTest extends BaseCustomValueTest {
 
   public function testGetWithCustomData() {
 
-    $customGroup = CustomGroup::create()
-      ->setCheckPermissions(FALSE)
+    $customGroup = CustomGroup::create(FALSE)
       ->addValue('name', 'MyContactFields')
       ->addValue('extends', 'Contact')
       ->execute()
       ->first();
 
-    CustomField::create()
-      ->setCheckPermissions(FALSE)
+    CustomField::create(FALSE)
       ->addValue('label', 'FavColor')
       ->addValue('custom_group_id', $customGroup['id'])
       ->addValue('html_type', 'Text')
       ->addValue('data_type', 'String')
       ->execute();
 
-    $contactId = Contact::create()
-      ->setCheckPermissions(FALSE)
+    $contactId = Contact::create(FALSE)
       ->addValue('first_name', 'Red')
       ->addValue('last_name', 'Tester')
       ->addValue('contact_type', 'Individual')
@@ -57,8 +54,7 @@ class UpdateCustomValueTest extends BaseCustomValueTest {
       ->execute()
       ->first()['id'];
 
-    Contact::update()
-      ->setCheckPermissions(FALSE)
+    Contact::update(FALSE)
       ->addWhere('id', '=', $contactId)
       ->addValue('first_name', 'Red')
       ->addValue('last_name', 'Tester')

--- a/tests/phpunit/api/v4/Entity/ConformanceTest.php
+++ b/tests/phpunit/api/v4/Entity/ConformanceTest.php
@@ -70,7 +70,7 @@ class ConformanceTest extends UnitTestCase {
    * @throws \Civi\API\Exception\UnauthorizedException
    */
   public function getEntitiesHitech() {
-    return $this->toDataProviderArray(Entity::get()->setCheckPermissions(FALSE)->execute()->column('name'));
+    return $this->toDataProviderArray(Entity::get(FALSE)->execute()->column('name'));
   }
 
   /**
@@ -140,8 +140,7 @@ class ConformanceTest extends UnitTestCase {
    * @param string $entity
    */
   protected function checkFields($entityClass, $entity) {
-    $fields = $entityClass::getFields()
-      ->setCheckPermissions(FALSE)
+    $fields = $entityClass::getFields(FALSE)
       ->setIncludeCustom(FALSE)
       ->execute()
       ->indexBy('name');
@@ -158,8 +157,7 @@ class ConformanceTest extends UnitTestCase {
    * @return array
    */
   protected function checkActions($entityClass) {
-    $actions = $entityClass::getActions()
-      ->setCheckPermissions(FALSE)
+    $actions = $entityClass::getActions(FALSE)
       ->execute()
       ->indexBy('name');
 
@@ -196,8 +194,7 @@ class ConformanceTest extends UnitTestCase {
   protected function checkUpdateFailsFromCreate($entityClass, $id) {
     $exceptionThrown = '';
     try {
-      $entityClass::create()
-        ->setCheckPermissions(FALSE)
+      $entityClass::create(FALSE)
         ->addValue('id', $id)
         ->execute();
     }
@@ -213,8 +210,7 @@ class ConformanceTest extends UnitTestCase {
    * @param string $entity
    */
   protected function checkGet($entityClass, $id, $entity) {
-    $getResult = $entityClass::get()
-      ->setCheckPermissions(FALSE)
+    $getResult = $entityClass::get(FALSE)
       ->addWhere('id', '=', $id)
       ->execute();
 
@@ -229,16 +225,14 @@ class ConformanceTest extends UnitTestCase {
    * @param string $entity
    */
   protected function checkGetCount($entityClass, $id, $entity) {
-    $getResult = $entityClass::get()
-      ->setCheckPermissions(FALSE)
+    $getResult = $entityClass::get(FALSE)
       ->addWhere('id', '=', $id)
       ->selectRowCount()
       ->execute();
     $errMsg = sprintf('%s getCount failed', $entity);
     $this->assertEquals(1, $getResult->count(), $errMsg);
 
-    $getResult = $entityClass::get()
-      ->setCheckPermissions(FALSE)
+    $getResult = $entityClass::get(FALSE)
       ->selectRowCount()
       ->execute();
     $errMsg = sprintf('%s getCount failed', $entity);
@@ -282,8 +276,7 @@ class ConformanceTest extends UnitTestCase {
    * @param int $id
    */
   protected function checkDeletion($entityClass, $id) {
-    $deleteResult = $entityClass::delete()
-      ->setCheckPermissions(FALSE)
+    $deleteResult = $entityClass::delete(FALSE)
       ->addWhere('id', '=', $id)
       ->execute();
 
@@ -297,8 +290,7 @@ class ConformanceTest extends UnitTestCase {
    * @param string $entity
    */
   protected function checkPostDelete($entityClass, $id, $entity) {
-    $getDeletedResult = $entityClass::get()
-      ->setCheckPermissions(FALSE)
+    $getDeletedResult = $entityClass::get(FALSE)
       ->addWhere('id', '=', $id)
       ->execute();
 

--- a/tests/phpunit/api/v4/Entity/ContactTypeTest.php
+++ b/tests/phpunit/api/v4/Entity/ContactTypeTest.php
@@ -49,8 +49,7 @@ class ContactTypeTest extends UnitTestCase {
       ->setCheckPermissions(FALSE)
       ->execute()->first()['id'];
 
-    $result = Contact::get()
-      ->setCheckPermissions(FALSE)
+    $result = Contact::get(FALSE)
       ->addSelect('*', 'prefix_id:label')
       ->addWhere('id', 'IN', [$indiv, $org, $hh])
       ->execute()
@@ -76,8 +75,7 @@ class ContactTypeTest extends UnitTestCase {
     $this->assertArrayNotHasKey('household_name', $result[$org]);
     $this->assertArrayNotHasKey('household_name', $result[$indiv]);
 
-    $emails = Email::get()
-      ->setCheckPermissions(FALSE)
+    $emails = Email::get(FALSE)
       ->addWhere('contact_id', 'IN', [$indiv, $org, $hh])
       ->addSelect('id', 'contact_id', 'contact.*', 'contact.prefix_id:label')
       ->execute()

--- a/tests/phpunit/api/v4/Entity/EntityTest.php
+++ b/tests/phpunit/api/v4/Entity/EntityTest.php
@@ -30,8 +30,7 @@ use api\v4\UnitTestCase;
 class EntityTest extends UnitTestCase {
 
   public function testEntityGet() {
-    $result = Entity::get()
-      ->setCheckPermissions(FALSE)
+    $result = Entity::get(FALSE)
       ->execute()
       ->indexBy('name');
     $this->assertArrayHasKey('Entity', $result,
@@ -41,8 +40,7 @@ class EntityTest extends UnitTestCase {
   }
 
   public function testEntity() {
-    $result = Entity::getActions()
-      ->setCheckPermissions(FALSE)
+    $result = Entity::getActions(FALSE)
       ->execute()
       ->indexBy('name');
     $this->assertNotContains(

--- a/tests/phpunit/api/v4/Entity/ParticipantTest.php
+++ b/tests/phpunit/api/v4/Entity/ParticipantTest.php
@@ -41,8 +41,7 @@ class ParticipantTest extends UnitTestCase {
   }
 
   public function testGetActions() {
-    $result = Participant::getActions()
-      ->setCheckPermissions(FALSE)
+    $result = Participant::getActions(FALSE)
       ->execute()
       ->indexBy('name');
 
@@ -60,7 +59,7 @@ class ParticipantTest extends UnitTestCase {
     }
 
     // With no records:
-    $result = Participant::get()->setCheckPermissions(FALSE)->execute();
+    $result = Participant::get(FALSE)->execute();
     $this->assertEquals(0, $result->count(), "count of empty get is not 0");
 
     // Check that the $result knows what the inputs were
@@ -115,8 +114,7 @@ class ParticipantTest extends UnitTestCase {
     $secondEventId = $dummy['events'][1]['id'];
     $firstContactId = $dummy['contacts'][0]['id'];
 
-    $firstOnlyResult = Participant::get()
-      ->setCheckPermissions(FALSE)
+    $firstOnlyResult = Participant::get(FALSE)
       ->addClause('AND', ['event_id', '=', $firstEventId])
       ->execute();
 
@@ -124,8 +122,7 @@ class ParticipantTest extends UnitTestCase {
       "count of first event is not $expectedFirstEventCount");
 
     // get first two events using different methods
-    $firstTwo = Participant::get()
-      ->setCheckPermissions(FALSE)
+    $firstTwo = Participant::get(FALSE)
       ->addWhere('event_id', 'IN', [$firstEventId, $secondEventId])
       ->execute();
 
@@ -145,8 +142,7 @@ class ParticipantTest extends UnitTestCase {
       "count is too low"
     );
 
-    $firstParticipantResult = Participant::get()
-      ->setCheckPermissions(FALSE)
+    $firstParticipantResult = Participant::get(FALSE)
       ->addWhere('event_id', '=', $firstEventId)
       ->addWhere('contact_id', '=', $firstContactId)
       ->execute();
@@ -156,8 +152,7 @@ class ParticipantTest extends UnitTestCase {
     $firstParticipantId = $firstParticipantResult->first()['id'];
 
     // get a result which excludes $first_participant
-    $otherParticipantResult = Participant::get()
-      ->setCheckPermissions(FALSE)
+    $otherParticipantResult = Participant::get(FALSE)
       ->setSelect(['id'])
       ->addClause('NOT', [
         ['event_id', '=', $firstEventId],
@@ -167,8 +162,7 @@ class ParticipantTest extends UnitTestCase {
       ->indexBy('id');
 
     // check alternate syntax for NOT
-    $otherParticipantResult2 = Participant::get()
-      ->setCheckPermissions(FALSE)
+    $otherParticipantResult2 = Participant::get(FALSE)
       ->setSelect(['id'])
       ->addClause('NOT', 'AND', [
         ['event_id', '=', $firstEventId],

--- a/tests/phpunit/api/v4/Entity/SavedSearchTest.php
+++ b/tests/phpunit/api/v4/Entity/SavedSearchTest.php
@@ -31,8 +31,8 @@ use Civi\Api4\Email;
 class SavedSearchTest extends UnitTestCase {
 
   public function testContactSmartGroup() {
-    $in = Contact::create()->setCheckPermissions(FALSE)->addValue('first_name', 'yes')->addValue('do_not_phone', TRUE)->execute()->first();
-    $out = Contact::create()->setCheckPermissions(FALSE)->addValue('first_name', 'no')->addValue('do_not_phone', FALSE)->execute()->first();
+    $in = Contact::create(FALSE)->addValue('first_name', 'yes')->addValue('do_not_phone', TRUE)->execute()->first();
+    $out = Contact::create(FALSE)->addValue('first_name', 'no')->addValue('do_not_phone', FALSE)->execute()->first();
 
     $savedSearch = civicrm_api4('SavedSearch', 'create', [
       'values' => [
@@ -57,10 +57,10 @@ class SavedSearchTest extends UnitTestCase {
   }
 
   public function testEmailSmartGroup() {
-    $in = Contact::create()->setCheckPermissions(FALSE)->addValue('first_name', 'yep')->execute()->first();
-    $out = Contact::create()->setCheckPermissions(FALSE)->addValue('first_name', 'nope')->execute()->first();
+    $in = Contact::create(FALSE)->addValue('first_name', 'yep')->execute()->first();
+    $out = Contact::create(FALSE)->addValue('first_name', 'nope')->execute()->first();
     $email = uniqid() . '@' . uniqid();
-    Email::create()->setCheckPermissions(FALSE)->addValue('email', $email)->addValue('contact_id', $in['id'])->execute();
+    Email::create(FALSE)->addValue('email', $email)->addValue('contact_id', $in['id'])->execute();
 
     $savedSearch = civicrm_api4('SavedSearch', 'create', [
       'values' => [

--- a/tests/phpunit/api/v4/Spec/SpecGathererTest.php
+++ b/tests/phpunit/api/v4/Spec/SpecGathererTest.php
@@ -78,8 +78,7 @@ class SpecGathererTest extends UnitTestCase {
   }
 
   public function testPseudoConstantOptionsWillBeAdded() {
-    $customGroupId = CustomGroup::create()
-      ->setCheckPermissions(FALSE)
+    $customGroupId = CustomGroup::create(FALSE)
       ->addValue('name', 'FavoriteThings')
       ->addValue('extends', 'Contact')
       ->execute()
@@ -87,8 +86,7 @@ class SpecGathererTest extends UnitTestCase {
 
     $options = ['r' => 'Red', 'g' => 'Green', 'p' => 'Pink'];
 
-    CustomField::create()
-      ->setCheckPermissions(FALSE)
+    CustomField::create(FALSE)
       ->addValue('label', 'FavColor')
       ->addValue('custom_group_id', $customGroupId)
       ->addValue('option_values', $options)


### PR DESCRIPTION
Overview
----------------------------------------
This does a simple find/replace to update internal api calls to use the new shorthand from #17834.

Before
----------------------------------------
`Foo::get()->setCheckPermissions(FALSE)...`

After
----------------------------------------
`Foo::get(FALSE)...`

Comments
-----------
This doesn't update every single instance but I wanted to keep the regex simple & safe.