### PR TITLE
Ensure serialize field exists before adding to query

### DIFF
--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -108,8 +108,8 @@ class CRM_Core_BAO_CustomGroup extends CRM_Core_DAO_CustomGroup {
       'is_multiple',
       'icon',
     ];
-    $current_db_version = CRM_Core_DAO::singleValueQuery("SELECT version FROM civicrm_domain WHERE id = " . CRM_Core_Config::domainID());
-    $is_public_version = $current_db_version >= '4.7.19' ? 1 : 0;
+    $current_db_version = CRM_Core_BAO_Domain::version();
+    $is_public_version = version_compare($current_db_version, '4.7.19', '>=');
     if ($is_public_version) {
       $fields[] = 'is_public';
     }
@@ -400,7 +400,6 @@ class CRM_Core_BAO_CustomGroup extends CRM_Core_DAO_CustomGroup {
         'time_format',
         'option_group_id',
         'in_selector',
-        'serialize',
       ],
       'custom_group' => [
         'id',
@@ -418,10 +417,14 @@ class CRM_Core_BAO_CustomGroup extends CRM_Core_DAO_CustomGroup {
         'max_multiple',
       ],
     ];
-    $current_db_version = CRM_Core_DAO::singleValueQuery("SELECT version FROM civicrm_domain WHERE id = " . CRM_Core_Config::domainID());
-    $is_public_version = $current_db_version >= '4.7.19' ? 1 : 0;
+    $current_db_version = CRM_Core_BAO_Domain::version();
+    $is_public_version = version_compare($current_db_version, '4.7.19', '>=');
+    $serialize_version = version_compare($current_db_version, '5.27.alpha1', '>=');
     if ($is_public_version) {
       $tableData['custom_group'][] = 'is_public';
+    }
+    if ($serialize_version) {
+      $tableData['custom_field'][] = 'serialize';
     }
     if (!$toReturn || !is_array($toReturn)) {
       $toReturn = $tableData;


### PR DESCRIPTION
Overview
----------------------------------------
This fixes an additional bug noted on #17722 where a query can crash during upgrades due to a nonexistent field getting added to the query.

Before
----------------------------------------
No version check

After
----------------------------------------
Version check.
