### PR TITLE
Ensure serialize field exists before adding to query

### DIFF
--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -399,7 +399,6 @@ class CRM_Core_BAO_CustomGroup extends CRM_Core_DAO_CustomGroup {
         'time_format',
         'option_group_id',
         'in_selector',
-        'serialize',
       ],
       'custom_group' => [
         'id',
@@ -419,8 +418,12 @@ class CRM_Core_BAO_CustomGroup extends CRM_Core_DAO_CustomGroup {
     ];
     $current_db_version = CRM_Core_DAO::singleValueQuery("SELECT version FROM civicrm_domain WHERE id = " . CRM_Core_Config::domainID());
     $is_public_version = $current_db_version >= '4.7.19' ? 1 : 0;
+    $serialize_version = version_compare($current_db_version, '5.27.alpha1', '>=');
     if ($is_public_version) {
       $tableData['custom_group'][] = 'is_public';
+    }
+    if ($serialize_version) {
+      $tableData['custom_field'][] = 'serialize';
     }
     if (!$toReturn || !is_array($toReturn)) {
       $toReturn = $tableData;


### PR DESCRIPTION
Overview
----------------------------------------
Backport of #17875 to solve upgrade woes.

Before
----------------------------------------
Upgrade crashes for sites with civicrm_views enabled & possibly other situations.

After
----------------------------------------
Problem reported to be solved by this patch.

Technical Details
----------------------------------------
This is a more minimal patch than #17875 - just enough to get the job done for 5.27.