### PR TITLE
EventCart ext: Fix autogenerated code, remove unused hooks, update readme

### DIFF
--- a/ext/eventcart/README.md
+++ b/ext/eventcart/README.md
@@ -1,44 +1,11 @@
 # eventcart
 
-![Screenshot](/images/screenshot.png)
-
-(*FIXME: In one or two paragraphs, describe what the extension does and why one would download it. *)
+This extracts most of the event cart functionality into an extension.
 
 The extension is licensed under [AGPL-3.0](LICENSE.txt).
 
-## Requirements
+## Remaining work
 
-* PHP v7.0+
-* CiviCRM (*FIXME: Version number*)
-
-## Installation (Web UI)
-
-This extension has not yet been published for installation via the web UI.
-
-## Installation (CLI, Zip)
-
-Sysadmins and developers may download the `.zip` file for this extension and
-install it with the command-line tool [cv](https://github.com/civicrm/cv).
-
-```bash
-cd <extension-dir>
-cv dl eventcart@https://github.com/FIXME/eventcart/archive/master.zip
-```
-
-## Installation (CLI, Git)
-
-Sysadmins and developers may clone the [Git](https://en.wikipedia.org/wiki/Git) repo for this extension and
-install it with the command-line tool [cv](https://github.com/civicrm/cv).
-
-```bash
-git clone https://github.com/FIXME/eventcart.git
-cv en eventcart
-```
-
-## Usage
-
-(* FIXME: Where would a new user navigate to get started? What changes would they see? *)
-
-## Known Issues
-
-(* FIXME *)
+1. Move CRM_Event_Cart_DAO_Cart and CRM_Event_Cart_DAO_EventInCart from CiviCRM core (see https://github.com/civicrm/civicrm-core/pull/17339 for details).
+1. There are various places in CiviCRM which still check the setting `enable_cart`. These should be moved to this extension.
+1. The "Conference Slots" functionality is only enabled if Event Cart is enabled so that should be moved into this extension too.

--- a/ext/eventcart/eventcart.civix.php
+++ b/ext/eventcart/eventcart.civix.php
@@ -6,10 +6,10 @@
  * The ExtensionUtil class provides small stubs for accessing resources of this
  * extension.
  */
-class CRM_Eventcart_ExtensionUtil {
+class CRM_Event_Cart_ExtensionUtil {
   const SHORT_NAME = "eventcart";
   const LONG_NAME = "eventcart";
-  const CLASS_PREFIX = "CRM_Eventcart";
+  const CLASS_PREFIX = "CRM_Event_Cart";
 
   /**
    * Translate a string using the extension's domain.
@@ -77,7 +77,7 @@ class CRM_Eventcart_ExtensionUtil {
 
 }
 
-use CRM_Eventcart_ExtensionUtil as E;
+use CRM_Event_Cart_ExtensionUtil as E;
 
 /**
  * (Delegated) Implements hook_civicrm_config().
@@ -206,14 +206,14 @@ function _eventcart_civix_civicrm_upgrade($op, CRM_Queue_Queue $queue = NULL) {
 }
 
 /**
- * @return CRM_Eventcart_Upgrader
+ * @return CRM_Event_Cart_Upgrader
  */
 function _eventcart_civix_upgrader() {
-  if (!file_exists(__DIR__ . '/CRM/Eventcart/Upgrader.php')) {
+  if (!file_exists(__DIR__ . '/CRM/Event/Cart/Upgrader.php')) {
     return NULL;
   }
   else {
-    return CRM_Eventcart_Upgrader_Base::instance();
+    return CRM_Event_Cart_Upgrader_Base::instance();
   }
 }
 

--- a/ext/eventcart/eventcart.php
+++ b/ext/eventcart/eventcart.php
@@ -90,19 +90,6 @@ function eventcart_civicrm_managed(&$entities) {
 }
 
 /**
- * Implements hook_civicrm_caseTypes().
- *
- * Generate a list of case-types.
- *
- * Note: This hook only runs in CiviCRM 4.4+.
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_caseTypes
- */
-function eventcart_civicrm_caseTypes(&$caseTypes) {
-  _eventcart_civix_civicrm_caseTypes($caseTypes);
-}
-
-/**
  * Implements hook_civicrm_angularModules().
  *
  * Generate a list of Angular modules.
@@ -135,38 +122,3 @@ function eventcart_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
 function eventcart_civicrm_entityTypes(&$entityTypes) {
   _eventcart_civix_civicrm_entityTypes($entityTypes);
 }
-
-/**
- * Implements hook_civicrm_thems().
- */
-function eventcart_civicrm_themes(&$themes) {
-  _eventcart_civix_civicrm_themes($themes);
-}
-
-// --- Functions below this ship commented out. Uncomment as required. ---
-
-/**
- * Implements hook_civicrm_preProcess().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_preProcess
- */
-//function eventcart_civicrm_preProcess($formName, &$form) {
-//
-//}
-
-/**
- * Implements hook_civicrm_navigationMenu().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_navigationMenu
- */
-//function eventcart_civicrm_navigationMenu(&$menu) {
-//  _eventcart_civix_insert_navigation_menu($menu, 'Mailings', array(
-//    'label' => E::ts('New subliminal message'),
-//    'name' => 'mailing_subliminal_message',
-//    'url' => 'civicrm/mailing/subliminal',
-//    'permission' => 'access CiviMail',
-//    'operator' => 'OR',
-//    'separator' => 0,
-//  ));
-//  _eventcart_civix_navigationMenu($menu);
-//}


### PR DESCRIPTION
Overview
----------------------------------------
Eventcart.civix.php was generated with wrong classes. Also cleanup eventcart.php and update README to be more useful.

Partial from #17339 and fix to work done via separate PRs

Before
----------------------------------------
Wrong classes on eventcart.civix.php

After
----------------------------------------
Correct classes on eventcart.civix.php

More useful README.

Technical Details
----------------------------------------

Comments
----------------------------------------
@seamuslee001 @eileenmcnaughton 
