### PR TITLE
EventCart ext: Cleanup and move form components to ext

### DIFF
--- a/CRM/Event/Form/ManageEvent/TabHeader.php
+++ b/CRM/Event/Form/ManageEvent/TabHeader.php
@@ -83,6 +83,7 @@ class CRM_Event_Form_ManageEvent_TabHeader {
       unset($tabs['repeat']['class']);
     }
 
+    // @todo Move to eventcart extension
     // check if we're in shopping cart mode for events
     if (!(bool) Civi::settings()->get('enable_cart')) {
       unset($tabs['conference']);

--- a/CRM/Event/Page/EventInfo.php
+++ b/CRM/Event/Page/EventInfo.php
@@ -272,21 +272,11 @@ class CRM_Event_Page_EventInfo extends CRM_Core_Page {
             $registerText = $values['event']['registration_link_text'];
           }
 
-          // check if we're in shopping cart mode for events
-          $enable_cart = Civi::settings()->get('enable_cart');
-          if ($enable_cart) {
-            $link = CRM_Event_Cart_BAO_EventInCart::get_registration_link($this->_id);
-            $registerText = $link['label'];
-
-            $url = CRM_Utils_System::url($link['path'], $link['query'] . $action_query, FALSE, NULL, TRUE, TRUE);
-          }
-
           //Fixed for CRM-4855
           $allowRegistration = CRM_Event_BAO_Event::showHideRegistrationLink($values);
 
           $this->assign('registerText', $registerText);
           $this->assign('registerURL', $url);
-          $this->assign('eventCartEnabled', $enable_cart);
         }
       }
       elseif (CRM_Core_Permission::check('register for events')) {

--- a/CRM/Event/Page/List.php
+++ b/CRM/Event/Page/List.php
@@ -23,13 +23,12 @@ class CRM_Event_Page_List extends CRM_Core_Page {
     $info = CRM_Event_BAO_Event::getCompleteInfo($start, $type, $id, $end);
     $this->assign('events', $info);
 
+    // @todo Move this to eventcart extension
     // check if we're in shopping cart mode for events
-    $enable_cart = (bool) Civi::settings()->get('enable_cart');
-    $this->assign('eventCartEnabled', $enable_cart);
-
-    if ($enable_cart) {
+    if ((bool) Civi::settings()->get('enable_cart')) {
       $this->assign('registration_links', TRUE);
     }
+
     return parent::run();
   }
 

--- a/CRM/Event/Page/ManageEvent.php
+++ b/CRM/Event/Page/ManageEvent.php
@@ -123,13 +123,15 @@ class CRM_Event_Page_ManageEvent extends CRM_Core_Page {
   /**
    * Get tab  Links for events.
    *
-   * @param $enableCart
-   *
    * @return array
    *   (reference) of tab links
+   * @throws \CiviCRM_API3_Exception
    */
   public static function &tabs() {
-    $enableCart = Civi::settings()->get('enable_cart');
+    // @todo Move to eventcart extension
+    // check if we're in shopping cart mode for events
+    $enableCart = (bool) Civi::settings()->get('enable_cart');
+
     $cacheKey = $enableCart ? 1 : 0;
     if (!(self::$_tabLinks)) {
       self::$_tabLinks = [];
@@ -340,9 +342,6 @@ ORDER BY start_date desc
     while ($pcpDao->fetch()) {
       $eventPCPS[$pcpDao->entity_id] = $pcpDao->entity_id;
     }
-    // check if we're in shopping cart mode for events
-    $enableCart = Civi::settings()->get('enable_cart');
-    $this->assign('eventCartEnabled', $enableCart);
     $mapping = CRM_Utils_Array::first(CRM_Core_BAO_ActionSchedule::getMappings([
       'id' => CRM_Event_ActionMapping::EVENT_NAME_MAPPING_ID,
     ]));
@@ -426,7 +425,7 @@ ORDER BY start_date desc
       }
     }
 
-    $manageEvent['tab'] = self::tabs($enableCart);
+    $manageEvent['tab'] = self::tabs();
     $this->assign('rows', $manageEvent);
 
     $statusTypes = CRM_Event_PseudoConstant::participantStatus(NULL, 'is_counted = 1', 'label');

--- a/ext/eventcart/CRM/Event/Cart/PageCallback.php
+++ b/ext/eventcart/CRM/Event/Cart/PageCallback.php
@@ -1,0 +1,41 @@
+<?php
+
+class CRM_Event_Cart_PageCallback {
+
+  /**
+   * @param \Civi\Core\Event\GenericHookEvent $event
+   */
+  public static function run($event) {
+    switch ($event->page->getVar('_name')) {
+      case 'CRM_Event_Page_EventInfo':
+        self::alterEventInfo($event);
+        break;
+
+      case 'CRM_Event_Page_List':
+        self::alterEventList($event);
+    }
+  }
+
+  public static function alterEventInfo($event) {
+    $eventID = $event->page->getVar('_id');
+    $link = CRM_Event_Cart_BAO_EventInCart::get_registration_link($eventID);
+    $registerText = $link['label'];
+
+    $action = CRM_Utils_Request::retrieve('action', 'String', $event->page, FALSE);
+    $action_query = ($action === CRM_Core_Action::PREVIEW) ? "&action=$action" : '';
+
+    $url = CRM_Utils_System::url($link['path'], $link['query'] . $action_query, FALSE, NULL, TRUE, TRUE);
+
+    $event->page->assign('registerText', $registerText);
+    $event->page->assign('registerURL', $url);
+    $event->page->assign('eventCartEnabled', TRUE);
+  }
+
+  public static function alterEventList($event) {
+    if ((bool) Civi::settings()->get('enable_cart')) {
+      CRM_Core_Region::instance('crm-event-list-pre')
+        ->add(['template' => 'CRM/Event/Cart/eventlistpre.tpl']);
+    }
+  }
+
+}

--- a/ext/eventcart/eventcart.php
+++ b/ext/eventcart/eventcart.php
@@ -11,6 +11,12 @@ use CRM_Eventcart_ExtensionUtil as E;
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_config/
  */
 function eventcart_civicrm_config(&$config) {
+  if (isset(Civi::$statics[__FUNCTION__])) {
+    return;
+  }
+  Civi::$statics[__FUNCTION__] = 1;
+  Civi::dispatcher()->addListener('hook_civicrm_pageRun', 'CRM_Event_Cart_PageCallback::run');
+
   _eventcart_civix_civicrm_config($config);
 }
 

--- a/ext/eventcart/templates/CRM/Event/Cart/eventlistpre.tpl
+++ b/ext/eventcart/templates/CRM/Event/Cart/eventlistpre.tpl
@@ -1,0 +1,2 @@
+<a href="{crmURL p='civicrm/event/view_cart'}" class="button crm-shoppingcart-button"><i class="crm-i fa-shopping-cart" aria-hidden="true"></i> {ts}View Cart{/ts}</a>
+<a href="{crmURL p='civicrm/event/cart_checkout'}" class="button crm-check-out-button"><i class="crm-i fa-credit-card" aria-hidden="true"></i> {ts}Checkout{/ts}</a>

--- a/templates/CRM/Event/Page/List.tpl
+++ b/templates/CRM/Event/Page/List.tpl
@@ -10,10 +10,8 @@
 {* Displays current and upcoming public Events Listing as an HTML page. *}
 {include file="CRM/common/jsortable.tpl"}
 <div class="crm-section crm-event-list">
-  {if $eventCartEnabled}
-    <a href="{crmURL p='civicrm/event/view_cart' }" class="button crm-shoppingcart-button"><i class="crm-i fa-shopping-cart" aria-hidden="true"></i> {ts}View Cart{/ts}</a>
-    <a href="{crmURL p='civicrm/event/cart_checkout'}" class="button crm-check-out-button"><i class="crm-i fa-credit-card" aria-hidden="true"></i> {ts}Checkout{/ts}</a>
-  {/if}
+  {crmRegion name="crm-event-list-pre"}
+  {/crmRegion}
 
   <table id="options" class="display">
     <thead>
@@ -48,4 +46,7 @@
       </tr>
     {/foreach}
   </table>
+
+  {crmRegion name="crm-event-list-post"}
+  {/crmRegion}
 </div>


### PR DESCRIPTION
Overview
----------------------------------------
This cleans up the use of `enable_cart` setting in core and moves eventcart form elements out of EventInfo and EventList forms into the eventcart extension.

Partial from #17339

Before
----------------------------------------
More bits in core

After
----------------------------------------
Less bits in core

Technical Details
----------------------------------------
Use `hook_civicrm_pageRun` to add eventcart form elements instead of hardcoding in core forms.

Comments
----------------------------------------

