### PR TITLE
Disable frequency/interval fields if not required on backend contribution forms

### DIFF
--- a/templates/CRM/Contribute/Form/AdditionalInfo/Payment.tpl
+++ b/templates/CRM/Contribute/Form/AdditionalInfo/Payment.tpl
@@ -12,21 +12,23 @@
 {literal}
   <script type="text/javascript" >
 
-    function enablePeriod() {
-      var frUnit = cj('#frequency_unit');
-      var frInerval = cj('#frequency_interval');
+    function toggleRecur() {
+      var isRecur = cj('input[id="is_recur"]:checked');
+      var frequencyUnit = cj('#frequency_unit');
+      var frequencyInterval = cj('#frequency_interval');
       var installments = cj('#installments');
-      isDisabled = false;
-
-      if (cj('input:radio[name="is_recur"]:checked').val() == 0)  {
-        isDisabled = true;
-        frInerval.val('');
-        installments.val('');
+      if (isRecur.val() > 0) {
+        frequencyUnit.prop('disabled', false).addClass('required');
+        frequencyInterval.prop('disabled', false).addClass('required');
+        installments.prop('disabled', false);
       }
-
-      frUnit.prop('disabled', isDisabled);
-      frInerval.prop('disabled', isDisabled);
-      installments.prop('disabled', isDisabled);
+      else {
+        frequencyInterval.val('');
+        installments.val('');
+        frequencyUnit.prop('disabled', true).removeClass('required');
+        frequencyInterval.prop('disabled', true).removeClass('required');
+        installments.prop('disabled', true);
+      }
     }
 
     function buildRecurBlock(processorId) {
@@ -44,14 +46,17 @@
           cj('input:radio[name="is_recur"]')[0].checked = true;
         }
       }
-
-      enablePeriod();
+      toggleRecur();
       eval('cj("#recurringPaymentBlock").' + funName + "()");
     }
 
     CRM.$(function($) {
       buildRecurBlock(null);
-      enablePeriod();
+      toggleRecur();
+
+      cj('input[id="is_recur"]').on('change', function() {
+        toggleRecur();
+      });
     });
 
   </script>

--- a/templates/CRM/Contribute/Form/Contribution.tpl
+++ b/templates/CRM/Contribute/Form/Contribution.tpl
@@ -33,7 +33,6 @@
   {/if}
 
   <div class="crm-block crm-form-block crm-contribution-form-block">
-
     {if !$email and $action neq 8 and $context neq 'standalone'}
       <div class="messages status no-popup">
         {icon icon="fa-info-circle"}{/icon}{ts}You will not be able to send an automatic email receipt for this contribution because there is no email address recorded for this contact. If you want a receipt to be sent when this contribution is recorded, click Cancel and then click Edit from the Summary tab to add an email address before recording the contribution.{/ts}
@@ -102,7 +101,7 @@
           </tr>
 
           {if $buildRecurBlock && !$payNow}
-            <tr id='recurringPaymentBlock' class='hiddenElement'>
+            <tr id='recurringPaymentBlock'>
               <td></td>
               <td>
                 <strong>{$form.is_recur.html} {ts}every{/ts}
@@ -343,6 +342,7 @@
             loadPanes(cj(this).attr('id'));
           });
         });
+
         // load panes function calls for snippet based on id of crm-accordion-header
         function loadPanes(id) {
           var url = "{/literal}{crmURL p='civicrm/contact/view/contribution' q="snippet=4&id=`$entityID`&formType=" h=0}{literal}" + id;
@@ -398,9 +398,7 @@
         {* Additional Detail / Honoree Information / Premium Information *}
         {foreach from=$allPanes key=paneName item=paneValue}
           <div class="crm-accordion-wrapper crm-ajax-accordion crm-{$paneValue.id}-accordion {if $paneValue.open neq 'true'}collapsed{/if}">
-            <div class="crm-accordion-header" id="{$paneValue.id}">
-              {$paneName}
-            </div><!-- /.crm-accordion-header -->
+            <div class="crm-accordion-header" id="{$paneValue.id}">{$paneName}</div>
             <div class="crm-accordion-body">
               <div class="{$paneValue.id}"></div>
             </div><!-- /.crm-accordion-body -->
@@ -469,17 +467,13 @@
       });
     </script>
   {/if} {* not delete mode if*}
-
 {/if} {* closing of main custom data if *}
 
 {literal}
 <script type="text/javascript">
-
   {/literal}
-
   // load form during form rule.
   {if $buildPriceSet}{literal}buildAmount();{/literal}{/if}
-
   {literal}
 
   // CRM-16451: set financial type of 'Price Set' in back office contribution


### PR DESCRIPTION
Overview
----------------------------------------
Follow up to https://github.com/civicrm/civicrm-core/pull/17526

Freeze the recur frequency interval/unit fields if recur is not selected. This does the same thing that #17526 did for the contribution frontend form.

Support js validation on frequency interval field on backend contribution page.

Before
----------------------------------------
Fields not disabled when recurring is not selected. Recur fields sometimes do not load for the default processor when there are multiple processors on the form and the default supports recurring.

After
----------------------------------------
Disabled:
![image](https://user-images.githubusercontent.com/2052161/87856619-28417d00-c918-11ea-9113-ffeee683a180.png)

Enabled:
![image](https://user-images.githubusercontent.com/2052161/87856626-368f9900-c918-11ea-9bb9-dca79f66dc44.png)

Fields appear for the default processor if it supports recur.

Technical Details
----------------------------------------


Comments
----------------------------------------
Seems that the fields only appear if your default payment processor has some paymentfields defined (eg. creditcard or bank details). Stripe, gocardless etc. do not... But the authorizenet extension does (as would the core version). Then just open the standard "submit credit card" form on the contribution tab and you should see options to enter "every x month/year"
