### PR TITLE
Event Cart ext: Move menu entries to extension

### DIFF
--- a/CRM/Event/xml/Menu/Event.xml
+++ b/CRM/Event/xml/Menu/Event.xml
@@ -128,13 +128,13 @@
      <weight>399</weight>
   </item>
   <item>
-     <path>civicrm/admin/options/conference_slot</path>
-     <title>Conference Slot Labels</title>
-     <page_callback>CRM_Admin_Page_Options</page_callback>
-     <desc>Define conference slots and labels.</desc>
-     <access_arguments>administer CiviCRM,access CiviEvent</access_arguments>
-     <adminGroup>CiviEvent</adminGroup>
-     <weight>415</weight>
+    <path>civicrm/admin/options/conference_slot</path>
+    <title>Conference Slot Labels</title>
+    <page_callback>CRM_Admin_Page_Options</page_callback>
+    <desc>Define conference slots and labels.</desc>
+    <access_arguments>administer CiviCRM,access CiviEvent</access_arguments>
+    <adminGroup>CiviEvent</adminGroup>
+    <weight>415</weight>
   </item>
   <item>
      <path>civicrm/admin/setting/preferences/event</path>
@@ -225,12 +225,12 @@
      <weight>960</weight>
   </item>
   <item>
-     <path>civicrm/event/manage/conference</path>
-     <title>Conference Slots</title>
-     <page_callback>CRM_Event_Form_ManageEvent_Conference</page_callback>
-     <access_arguments>access CiviEvent</access_arguments>
-     <is_ssl>true</is_ssl>
-     <weight>950</weight>
+    <path>civicrm/event/manage/conference</path>
+    <title>Conference Slots</title>
+    <page_callback>CRM_Event_Form_ManageEvent_Conference</page_callback>
+    <access_arguments>access CiviEvent</access_arguments>
+    <is_ssl>true</is_ssl>
+    <weight>950</weight>
   </item>
   <item>
      <path>civicrm/event/add</path>
@@ -296,50 +296,6 @@
      <path>civicrm/ajax/locBlock</path>
      <page_callback>CRM_Core_Page_AJAX_Location::getLocBlock</page_callback>
      <access_arguments>access CiviEvent</access_arguments>
-  </item>
-  <item>
-    <path>civicrm/ajax/event/add_participant_to_cart</path>
-    <page_callback>CRM_Event_Cart_Page_CheckoutAJAX::add_participant_to_cart</page_callback>
-    <access_callback>1</access_callback>
-    <is_public>true</is_public>
-  </item>
-  <item>
-    <path>civicrm/ajax/event/remove_participant_from_cart</path>
-    <page_callback>CRM_Event_Cart_Page_CheckoutAJAX::remove_participant_from_cart</page_callback>
-    <access_callback>1</access_callback>
-    <is_public>true</is_public>
-  </item>
-  <item>
-    <path>civicrm/event/add_to_cart</path>
-    <title>Add Event To Cart</title>
-    <page_callback>CRM_Event_Cart_Page_AddToCart</page_callback>
-    <access_callback>1</access_callback>
-    <is_public>true</is_public>
-    <is_ssl>false</is_ssl>
-  </item>
-  <item>
-    <path>civicrm/event/cart_checkout</path>
-    <title>Cart Checkout</title>
-    <page_callback>CRM_Event_Cart_Controller_Checkout</page_callback>
-    <access_callback>1</access_callback>
-    <is_public>true</is_public>
-    <is_ssl>true</is_ssl>
-  </item>
-  <item>
-    <path>civicrm/event/remove_from_cart</path>
-    <title>Remove From Cart</title>
-    <page_callback>CRM_Event_Cart_Page_RemoveFromCart</page_callback>
-    <access_callback>1</access_callback>
-    <is_public>true</is_public>
-    <is_ssl>false</is_ssl>
-  </item>
-  <item>
-    <path>civicrm/event/view_cart</path>
-    <title>View Cart</title>
-    <page_callback>CRM_Event_Cart_Page_ViewCart</page_callback>
-    <access_callback>1</access_callback>
-    <is_public>true</is_public>
-    <is_ssl>false</is_ssl>
   </item>
   <item>
     <path>civicrm/event/participant/feeselection</path>

--- a/ext/eventcart/xml/Menu/Eventcart.xml
+++ b/ext/eventcart/xml/Menu/Eventcart.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="iso-8859-1" ?>
+
+<menu>
+  <item>
+    <path>civicrm/ajax/event/add_participant_to_cart</path>
+    <page_callback>CRM_Event_Cart_Page_CheckoutAJAX::add_participant_to_cart</page_callback>
+    <access_callback>1</access_callback>
+    <is_public>true</is_public>
+  </item>
+  <item>
+    <path>civicrm/ajax/event/remove_participant_from_cart</path>
+    <page_callback>CRM_Event_Cart_Page_CheckoutAJAX::remove_participant_from_cart</page_callback>
+    <access_callback>1</access_callback>
+    <is_public>true</is_public>
+  </item>
+  <item>
+    <path>civicrm/event/add_to_cart</path>
+    <title>Add Event To Cart</title>
+    <page_callback>CRM_Event_Cart_Page_AddToCart</page_callback>
+    <access_callback>1</access_callback>
+    <is_public>true</is_public>
+    <is_ssl>false</is_ssl>
+  </item>
+  <item>
+    <path>civicrm/event/cart_checkout</path>
+    <title>Cart Checkout</title>
+    <page_callback>CRM_Event_Cart_Controller_Checkout</page_callback>
+    <access_callback>1</access_callback>
+    <is_public>true</is_public>
+    <is_ssl>true</is_ssl>
+  </item>
+  <item>
+    <path>civicrm/event/remove_from_cart</path>
+    <title>Remove From Cart</title>
+    <page_callback>CRM_Event_Cart_Page_RemoveFromCart</page_callback>
+    <access_callback>1</access_callback>
+    <is_public>true</is_public>
+    <is_ssl>false</is_ssl>
+  </item>
+  <item>
+    <path>civicrm/event/view_cart</path>
+    <title>View Cart</title>
+    <page_callback>CRM_Event_Cart_Page_ViewCart</page_callback>
+    <access_callback>1</access_callback>
+    <is_public>true</is_public>
+    <is_ssl>false</is_ssl>
+  </item>
+</menu>


### PR DESCRIPTION
Overview
----------------------------------------
The BAO / Form / Pages have already moved. Move the xml menu definitions as well. We don't move the conference ones now because conference forms/pages are still in core.

Before
----------------------------------------
Menu definitions in core.

After
----------------------------------------
Menu definitions in ext.

Technical Details
----------------------------------------

Comments
----------------------------------------

