### PR TITLE
Update version in the test_data_second_domain file and also update th…

### DIFF
--- a/Civi/Test/Data.php
+++ b/Civi/Test/Data.php
@@ -44,6 +44,8 @@ class Data {
       \Civi\Test::schema()->setStrict(TRUE);
     });
 
+    civicrm_api('setting', 'create', ['installed' => 1, 'domain_id' => 'all', 'version' => 3]);
+
     // Rebuild triggers
     civicrm_api('system', 'flush', ['version' => 3, 'triggers' => 1]);
 

--- a/sql/test_data_second_domain.mysql
+++ b/sql/test_data_second_domain.mysql
@@ -963,4 +963,4 @@ INSERT INTO civicrm_navigation
 VALUES
     ( @domainID, CONCAT('civicrm/report/instance/', @instanceID,'&reset=1'), 'Mailing Detail Report', 'Mailing Detail Report', 'administer CiviMail', 'OR', @reportlastID, '1', NULL, @instanceID+2 );
 UPDATE civicrm_report_instance SET navigation_id = LAST_INSERT_ID() WHERE id = @instanceID;
-UPDATE civicrm_domain SET version = '5.28.alpha1';
+UPDATE civicrm_domain SET version = '5.29.alpha1';

--- a/tools/bin/scripts/set-version.php
+++ b/tools/bin/scripts/set-version.php
@@ -71,8 +71,12 @@ updateFile("sql/civicrm_generated.mysql", function ($content) use ($newVersion, 
   return str_replace($oldVersion, $newVersion, $content);
 });
 
+updateFile("sql/test_data_second_domain.mysql", function ($content) use ($newVersion, $oldVersion) {
+  return str_replace($oldVersion, $newVersion, $content);
+});
+
 if ($doCommit) {
-  $files = "xml/version.xml sql/civicrm_generated.mysql " . escapeshellarg($phpFile) . ' ' . escapeshellarg($sqlFile);
+  $files = "xml/version.xml sql/civicrm_generated.mysql sql/test_data_second_domain.mysql " . escapeshellarg($phpFile) . ' ' . escapeshellarg($sqlFile);
   passthru("git add $files");
   passthru("git commit $files -m " . escapeshellarg("Set version to $newVersion"));
 }


### PR DESCRIPTION
…e setVersion script to update the file version as necessary

Overview
----------------------------------------
This updates the version in the second domain file to match that of the current master version but also updates the setversion script to set the version whenever the other version parts are changed

Before
----------------------------------------
old version used in the second domain file

After
----------------------------------------
Current version always used in the second domain file

Technical Details
----------------------------------------
For some reason this line https://github.com/civicrm/civicrm-core/pull/17894/files#diff-72130c654283a432eb75d288a8ea9b20R44 kept causing problems for me locally in @colemanw 's alternate version this aims for more of a minimalist approach

ping @totten @eileenmcnaughton @colemanw 