### PR TITLE
dev/core#1855 - Allow different output formats for CiviReport results and untangle code

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -1114,6 +1114,37 @@ class CRM_Report_Form extends CRM_Core_Form {
   }
 
   /**
+   * Getter for _outputMode
+   *
+   * Note you can implement hook_civicrm_alterReportVar('actions', ...)
+   * which indirectly allows setting _outputMode if the user chooses
+   * your action.
+   *
+   * @return string
+   */
+  public function getOutputMode():string {
+    return $this->_outputMode;
+  }
+
+  /**
+   * Getter for report header form field value
+   *
+   * @return string
+   */
+  public function getReportHeader():string {
+    return $this->_formValues['report_header'] ?? '';
+  }
+
+  /**
+   * Getter for report footer form field value
+   *
+   * @return string
+   */
+  public function getReportFooter():string {
+    return $this->_formValues['report_footer'] ?? '';
+  }
+
+  /**
    * Setter for $_force.
    *
    * @param bool $isForce
@@ -1680,6 +1711,8 @@ class CRM_Report_Form extends CRM_Core_Form {
     if (!$this->_csvSupported) {
       unset($actions['report_instance.csv']);
     }
+
+    CRM_Utils_Hook::alterReportVar('actions', $actions, $this);
 
     return $actions;
   }
@@ -2839,25 +2872,35 @@ WHERE cg.extends IN ('" . implode("','", $this->_customGroupExtends) . "') AND
         CRM_Core_DAO::$_nullObject
       );
 
-    if ($this->_outputMode == 'print' ||
-      ($this->_sendmail && !$this->_outputMode)
-    ) {
-      $this->printOnly = TRUE;
-      $this->addPaging = FALSE;
+    if ($this->_sendmail && !$this->_outputMode) {
+      // If we're here from the mail_report job, then the default there gets
+      // set to pdf before we get here, but if we're somehow here and sending
+      // by email and don't have a format set, then use print.
+      // @todo Is this on purpose - why would they be different defaults?
       $this->_outputMode = 'print';
+    }
+
+    // _outputMode means multiple things and can cover export to file formats,
+    // like csv, or actions with no output, like save. So this will only set
+    // a handler if it's one of the former. But it's also possible we have a
+    // really interesting handler out there. But the point is we don't need to
+    // know, just to know that a handler doesn't always get set by this call.
+    $this->setOutputHandler();
+
+    if (!empty($this->outputHandler)) {
       if ($this->_sendmail) {
+        // If we're sending by email these are the only options that make
+        // sense.
+        $this->printOnly = TRUE;
+        $this->addPaging = FALSE;
         $this->_absoluteUrl = TRUE;
       }
-    }
-    elseif ($this->_outputMode == 'pdf') {
-      $this->printOnly = TRUE;
-      $this->addPaging = FALSE;
-      $this->_absoluteUrl = TRUE;
-    }
-    elseif ($this->_outputMode == 'csv') {
-      $this->printOnly = TRUE;
-      $this->_absoluteUrl = TRUE;
-      $this->addPaging = FALSE;
+      else {
+        // otherwise ask the handler
+        $this->printOnly = $this->outputHandler->isPrintOnly();
+        $this->addPaging = $this->outputHandler->isAddPaging();
+        $this->_absoluteUrl = $this->outputHandler->isAbsoluteUrl();
+      }
     }
     elseif ($this->_outputMode == 'copy' && $this->_criteriaForm) {
       $this->_createNew = TRUE;
@@ -3413,98 +3456,21 @@ WHERE cg.extends IN ('" . implode("','", $this->_customGroupExtends) . "') AND
       $this->_resultSet = $rows;
     }
 
-    if ($this->_outputMode == 'print' ||
-      $this->_outputMode == 'pdf' ||
-      $this->_sendmail
-    ) {
-
-      $content = $this->compileContent();
-      $url = CRM_Utils_System::url("civicrm/report/instance/{$this->_id}",
-        "reset=1", TRUE
-      );
-
-      if ($this->_sendmail) {
-        $config = CRM_Core_Config::singleton();
-        $attachments = [];
-
-        if ($this->_outputMode == 'csv') {
-          $content
-            = $this->_formValues['report_header'] . '<p>' . ts('Report URL') .
-            ": {$url}</p>" . '<p>' .
-            ts('The report is attached as a CSV file.') . '</p>' .
-            $this->_formValues['report_footer'];
-
-          $csvFullFilename = $config->templateCompileDir .
-            CRM_Utils_File::makeFileName('CiviReport.csv');
-          $csvContent = CRM_Report_Utils_Report::makeCsv($this, $rows);
-          file_put_contents($csvFullFilename, $csvContent);
-          $attachments[] = [
-            'fullPath' => $csvFullFilename,
-            'mime_type' => 'text/csv',
-            'cleanName' => 'CiviReport.csv',
-            'charset' => 'utf-8',
-          ];
-        }
-        if ($this->_outputMode == 'pdf') {
-          // generate PDF content
-          $pdfFullFilename = $config->templateCompileDir .
-            CRM_Utils_File::makeFileName('CiviReport.pdf');
-          file_put_contents($pdfFullFilename,
-            CRM_Utils_PDF_Utils::html2pdf($content, "CiviReport.pdf",
-              TRUE, ['orientation' => 'landscape']
-            )
-          );
-          // generate Email Content
-          $content
-            = $this->_formValues['report_header'] . '<p>' . ts('Report URL') .
-            ": {$url}</p>" . '<p>' .
-            ts('The report is attached as a PDF file.') . '</p>' .
-            $this->_formValues['report_footer'];
-
-          $attachments[] = [
-            'fullPath' => $pdfFullFilename,
-            'mime_type' => 'application/pdf',
-            'cleanName' => 'CiviReport.pdf',
-          ];
-        }
-
-        if (CRM_Report_Utils_Report::mailReport($content, $this->_id,
-          $this->_outputMode, $attachments
-        )
-        ) {
-          CRM_Core_Session::setStatus(ts("Report mail has been sent."), ts('Sent'), 'success');
-        }
-        else {
-          CRM_Core_Session::setStatus(ts("Report mail could not be sent."), ts('Mail Error'), 'error');
-        }
-        return;
-      }
-      elseif ($this->_outputMode == 'print') {
-        echo $content;
-      }
-      else {
-        // Nb. Once upon a time we used a package called Open Flash Charts to
-        // draw charts, and we had a feature whereby a browser could send the
-        // server a PNG version of the chart, which could then be included in a
-        // PDF by including <img> tags in the HTML for the conversion below.
-        //
-        // This feature stopped working when browsers stopped supporting Flash,
-        // and although we have a different client-side charting library in
-        // place, we decided not to reimplement the (rather convoluted)
-        // browser-sending-rendered-chart-to-server process.
-        //
-        // If this feature is required in future we should find a better way to
-        // render charts on the server side, e.g. server-created SVG.
-        CRM_Utils_PDF_Utils::html2pdf($content, "CiviReport.pdf", FALSE, ['orientation' => 'landscape']);
-      }
-      CRM_Utils_System::civiExit();
-    }
-    elseif ($this->_outputMode == 'csv') {
-      CRM_Report_Utils_Report::export2csv($this, $rows);
-    }
-    elseif ($this->_outputMode == 'group') {
+    // Add contacts to group
+    if ($this->_outputMode == 'group') {
       $group = $this->_params['groups'];
       $this->add2group($group);
+    }
+    else {
+      if ($this->_sendmail) {
+        $this->sendEmail();
+      }
+      elseif (!empty($this->outputHandler)) {
+        $this->outputHandler->download();
+        CRM_Utils_System::civiExit();
+      }
+      // else we don't need to do anything here since it must have been
+      // outputMode=save or something like that
     }
   }
 
@@ -5987,6 +5953,60 @@ LEFT JOIN civicrm_contact {$field['alias']} ON {$field['alias']}.id = {$this->_a
       }
     }
     return '';
+  }
+
+  /**
+   * Retrieve a suitable object from the factory depending on the report
+   * parameters, which typically might just be dependent on outputMode.
+   *
+   * If there is no suitable output handler, e.g. if outputMode is "copy",
+   * then this sets it to NULL.
+   */
+  public function setOutputHandler() {
+    $this->outputHandler = \Civi\Report\OutputHandlerFactory::singleton()->create($this);
+  }
+
+  /**
+   * Send report by email
+   */
+  public function sendEmail() {
+    if (empty($this->outputHandler)) {
+      // It's possible to end up here with outputMode unset, so we use
+      // the "print" handler which was the default before, i.e. include
+      // it as html in the body.
+      $oldOutputMode = $this->_outputMode ?? NULL;
+      $this->_outputMode = 'print';
+      $this->setOutputHandler();
+      $this->_outputMode = $oldOutputMode;
+    }
+
+    $mailBody = $this->outputHandler->getMailBody();
+
+    $attachments = [];
+    $attachmentFileName = $this->outputHandler->getFileName();
+    // It's not always in the form of an attachment, e.g. for 'print' the
+    // output ends up in $mailBody above.
+    if ($attachmentFileName) {
+      $fullFilename = CRM_Core_Config::singleton()->templateCompileDir . CRM_Utils_File::makeFileName($attachmentFileName);
+      file_put_contents($fullFilename, $this->outputHandler->getOutputString());
+      $attachments[] = [
+        'fullPath' => $fullFilename,
+        'mime_type' => $this->outputHandler->getMimeType(),
+        'cleanName' => $attachmentFileName,
+        'charset' => $this->outputHandler->getCharset(),
+      ];
+    }
+
+    // Send the email
+    // @todo outputMode doesn't seem to get used by mailReport, which is good
+    // since it shouldn't have any outputMode-related `if` statements in it.
+    // Someday could remove the param from the function call.
+    if (CRM_Report_Utils_Report::mailReport($mailBody, $this->_id, $this->_outputMode, $attachments)) {
+      CRM_Core_Session::setStatus(ts("Report mail has been sent."), ts('Sent'), 'success');
+    }
+    else {
+      CRM_Core_Session::setStatus(ts("Report mail could not be sent."), ts('Mail Error'), 'error');
+    }
   }
 
 }

--- a/CRM/Report/OutputHandler/Csv.php
+++ b/CRM/Report/OutputHandler/Csv.php
@@ -1,0 +1,105 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+use Civi\Report\OutputHandlerInterface;
+use Civi\Report\OutputHandlerBase;
+
+/**
+ * CSV Report Output Handler
+ */
+class CRM_Report_OutputHandler_Csv extends OutputHandlerBase implements OutputHandlerInterface {
+
+  /**
+   * Are we a suitable output handler based on the given form?
+   *
+   * The class member $form isn't set yet at this point since we don't
+   * even know if we're in play yet, so the form is a parameter.
+   *
+   * @param CRM_Report_Form $form
+   *
+   * @return bool
+   */
+  public function isOutputHandlerFor(CRM_Report_Form $form):bool {
+    return ($form->getOutputMode() === 'csv');
+  }
+
+  /**
+   * Return the download filename. This should be the "clean" name, not
+   * a munged temporary filename.
+   *
+   * @return string
+   */
+  public function getFileName():string {
+    return 'CiviReport.csv';
+  }
+
+  /**
+   * Return the html body of the email.
+   *
+   * @return string
+   */
+  public function getMailBody():string {
+    // @todo It would be nice if this was more end-user configurable, but
+    // keeping it the same as it was before for now.
+    $url = CRM_Utils_System::url('civicrm/report/instance/' . $this->getForm()->getID(), 'reset=1', TRUE);
+    return $this->getForm()->getReportHeader() . '<p>' . ts('Report URL') .
+      ": {$url}</p>" . '<p>' .
+      ts('The report is attached as a CSV file.') . '</p>' .
+      $this->getForm()->getReportFooter();
+  }
+
+  /**
+   * Return the report contents as a string, in this case the csv output.
+   *
+   * @return string
+   */
+  public function getOutputString():string {
+    //@todo Hmm. See note in CRM_Report_Form::endPostProcess about $rows.
+    $rows = $this->getForm()->getTemplate()->get_template_vars('rows');
+
+    // avoid pass-by-ref warning
+    $form = $this->getForm();
+
+    return CRM_Report_Utils_Report::makeCsv($form, $rows);
+  }
+
+  /**
+   * Set headers as appropriate and send the output to the browser.
+   */
+  public function download() {
+    //@todo Hmm. See note in CRM_Report_Form::endPostProcess about $rows.
+    $rows = $this->getForm()->getTemplate()->get_template_vars('rows');
+
+    // avoid pass-by-ref warning
+    $form = $this->getForm();
+
+    CRM_Report_Utils_Report::export2csv($form, $rows);
+  }
+
+  /**
+   * Mime type of the attachment.
+   *
+   * @return string
+   */
+  public function getMimeType():string {
+    return 'text/csv';
+  }
+
+  /**
+   * Charset of the attachment.
+   *
+   * @return string
+   */
+  public function getCharset():string {
+    return 'utf-8';
+  }
+
+}

--- a/CRM/Report/OutputHandler/Pdf.php
+++ b/CRM/Report/OutputHandler/Pdf.php
@@ -1,0 +1,107 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+use Civi\Report\OutputHandlerInterface;
+use Civi\Report\OutputHandlerBase;
+
+/**
+ * PDF Report Output Handler
+ */
+class CRM_Report_OutputHandler_Pdf extends OutputHandlerBase implements OutputHandlerInterface {
+
+  /**
+   * Are we a suitable output handler based on the given form?
+   *
+   * The class member $form isn't set yet at this point since we don't
+   * even know if we're in play yet, so the form is a parameter.
+   *
+   * @param CRM_Report_Form $form
+   *
+   * @return bool
+   */
+  public function isOutputHandlerFor(CRM_Report_Form $form):bool {
+    return ($form->getOutputMode() === 'pdf');
+  }
+
+  /**
+   * Return the download filename. This should be the "clean" name, not
+   * a munged temporary filename.
+   *
+   * @return string
+   */
+  public function getFileName():string {
+    return 'CiviReport.pdf';
+  }
+
+  /**
+   * Return the html body of the email.
+   *
+   * @return string
+   */
+  public function getMailBody():string {
+    // @todo It would be nice if this was more end-user configurable, but
+    // keeping it the same as it was before for now.
+    $url = CRM_Utils_System::url('civicrm/report/instance/' . $this->getForm()->getID(), 'reset=1', TRUE);
+    return $this->getForm()->getReportHeader() . '<p>' . ts('Report URL') .
+      ": {$url}</p>" . '<p>' .
+      ts('The report is attached as a PDF file.') . '</p>' .
+      $this->getForm()->getReportFooter();
+  }
+
+  /**
+   * Return the report contents as a string, in this case the pdf file.
+   *
+   * @return string
+   */
+  public function getOutputString():string {
+    return CRM_Utils_PDF_Utils::html2pdf(
+      $this->getForm()->compileContent(),
+      $this->getFileName(),
+      TRUE,
+      ['orientation' => 'landscape']
+    );
+  }
+
+  /**
+   * Set headers as appropriate and send the output to the browser.
+   */
+  public function download() {
+    // Nb. Once upon a time we used a package called Open Flash Charts to
+    // draw charts, and we had a feature whereby a browser could send the
+    // server a PNG version of the chart, which could then be included in a
+    // PDF by including <img> tags in the HTML for the conversion below.
+    //
+    // This feature stopped working when browsers stopped supporting Flash,
+    // and although we have a different client-side charting library in
+    // place, we decided not to reimplement the (rather convoluted)
+    // browser-sending-rendered-chart-to-server process.
+    //
+    // If this feature is required in future we should find a better way to
+    // render charts on the server side, e.g. server-created SVG.
+
+    CRM_Utils_PDF_Utils::html2pdf(
+      $this->getForm()->compileContent(),
+      $this->getFileName(),
+      FALSE,
+      ['orientation' => 'landscape']
+    );
+  }
+
+  /**
+   * Mime type of the attachment.
+   *
+   * @return string
+   */
+  public function getMimeType():string {
+    return 'application/pdf';
+  }
+
+}

--- a/CRM/Report/OutputHandler/Print.php
+++ b/CRM/Report/OutputHandler/Print.php
@@ -1,0 +1,81 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+use Civi\Report\OutputHandlerInterface;
+use Civi\Report\OutputHandlerBase;
+
+/**
+ * CSV Report Output Handler
+ */
+class CRM_Report_OutputHandler_Print extends OutputHandlerBase implements OutputHandlerInterface {
+
+  /**
+   * Are we a suitable output handler based on the given form?
+   *
+   * The class member $form isn't set yet at this point since we don't
+   * even know if we're in play yet, so the form is a parameter.
+   *
+   * @param CRM_Report_Form $form
+   *
+   * @return bool
+   */
+  public function isOutputHandlerFor(CRM_Report_Form $form):bool {
+    return ($form->getOutputMode() === 'print');
+  }
+
+  /**
+   * Return the download filename. This should be the "clean" name, not
+   * a munged temporary filename.
+   *
+   * For 'print' there is no attachment.
+   *
+   * @return string
+   */
+  public function getFileName():string {
+    return '';
+  }
+
+  /**
+   * Return the html body of the email.
+   *
+   * @return string
+   */
+  public function getMailBody():string {
+    return $this->getOutputString();
+  }
+
+  /**
+   * Return the report contents as a string.
+   *
+   * @return string
+   */
+  public function getOutputString():string {
+    return $this->getForm()->compileContent();
+  }
+
+  /**
+   * Set headers as appropriate and send the output to the browser.
+   * Here the headers are already text/html.
+   */
+  public function download() {
+    echo $this->getOutputString();
+  }
+
+  /**
+   * Override so links displayed in the browser are relative.
+   *
+   * @return bool
+   */
+  public function isAbsoluteUrl():bool {
+    return FALSE;
+  }
+
+}

--- a/Civi/Report/OutputHandlerBase.php
+++ b/Civi/Report/OutputHandlerBase.php
@@ -1,0 +1,146 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+namespace Civi\Report;
+
+/**
+ * Base Report Output Handler
+ */
+class OutputHandlerBase implements OutputHandlerInterface {
+
+  /**
+   * This is for convenience since otherwise several functions
+   * would take it as a parameter.
+   *
+   * @var \CRM_Report_Form
+   */
+  protected $form;
+
+  /**
+   * Getter for $form
+   *
+   * @return \CRM_Report_Form
+   */
+  public function getForm():\CRM_Report_Form {
+    return $this->form;
+  }
+
+  /**
+   * Setter for $form
+   *
+   * @param \CRM_Report_Form $form
+   */
+  public function setForm(\CRM_Report_Form $form) {
+    $this->form = $form;
+  }
+
+  /**
+   * Are we a suitable output handler based on the given form?
+   *
+   * The class member $form isn't set yet at this point since we don't
+   * even know if we're in play yet, so the form is a parameter.
+   *
+   * @param \CRM_Report_Form $form
+   *
+   * @return bool
+   */
+  public function isOutputHandlerFor(\CRM_Report_Form $form):bool {
+    return FALSE;
+  }
+
+  /**
+   * Return the download filename. This should be the "clean" name, not
+   * a munged temporary filename.
+   *
+   * @return string
+   */
+  public function getFileName():string {
+    return '';
+  }
+
+  /**
+   * Return the html body of the email.
+   *
+   * @return string
+   */
+  public function getMailBody():string {
+    return '';
+  }
+
+  /**
+   * Return the report contents as a string.
+   *
+   * @return string
+   */
+  public function getOutputString():string {
+    return '';
+  }
+
+  /**
+   * Set headers as appropriate and send the output to the browser.
+   */
+  public function download() {
+  }
+
+  /**
+   * Mime type of the attachment.
+   *
+   * @return string
+   */
+  public function getMimeType():string {
+    return 'text/html';
+  }
+
+  /**
+   * Charset of the attachment.
+   *
+   * The default of '' means charset is not specified in the mimepart,
+   * which is normal for binary attachments, but for text attachments you
+   * should specify something like 'utf-8'.
+   *
+   * @return string
+   */
+  public function getCharset():string {
+    return '';
+  }
+
+  /**
+   * Hide/show various elements in the output, but generally for a handler
+   * this is always set to TRUE.
+   *
+   * @return bool
+   */
+  public function isPrintOnly():bool {
+    return TRUE;
+  }
+
+  /**
+   * Use a pager, but for a handler this would be FALSE since paging
+   * is a UI element.
+   *
+   * @return bool
+   */
+  public function isAddPaging():bool {
+    return FALSE;
+  }
+
+  /**
+   * Create absolute urls for links. Generally for a handler
+   * this is always set to TRUE, but for example for 'print' it's displayed
+   * on the site so it can be relative.
+   * @todo Couldn't it just always be absolute?
+   *
+   * @return bool
+   */
+  public function isAbsoluteUrl():bool {
+    return TRUE;
+  }
+
+}

--- a/Civi/Report/OutputHandlerFactory.php
+++ b/Civi/Report/OutputHandlerFactory.php
@@ -1,0 +1,101 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+namespace Civi\Report;
+
+/**
+ * OutputHandlers can either be the standard core ones: print/pdf/csv, or
+ * extensions can add their own.
+ *
+ * @package Civi\Report
+ */
+class OutputHandlerFactory {
+
+  protected static $singleton;
+
+  /**
+   * @var array
+   *   Array of registered possible OutputHandlers.
+   */
+  protected static $registered = [];
+
+  /**
+   * Singleton function.
+   *
+   * @return OutputHandlerFactory
+   */
+  public static function singleton() {
+    if (self::$singleton === NULL) {
+      self::$singleton = new OutputHandlerFactory();
+      self::registerBuiltins();
+    }
+    return self::$singleton;
+  }
+
+  /**
+   * Return an OutputHandler based on the parameters.
+   *
+   * @param \CRM_Report_Form $form
+   *   A CiviReport that extends CRM_Report_Form.
+   *
+   * @return \Civi\Report\OutputHandlerInterface|NULL
+   *   An object that implements the OutputHandlerInterface, or NULL if
+   *   nothing suitable for the given parameters.
+   */
+  public function create(\CRM_Report_Form $form) {
+    /**
+     * The first draft of this had extensions register their classes,
+     * but it needed to be early on because there's also the dropdown on the
+     * report form that lists the output formats available which happens
+     * earlier than the output run and that worked better as a simple hook.
+     * So it just felt out of place then to have two different types of things,
+     * and people are used to hooks, and there's already alterReportVar which
+     * seemed a natural place.
+     */
+    \CRM_Utils_Hook::alterReportVar('outputhandlers', self::$registered, $form);
+    foreach (self::$registered as $candidate) {
+      try {
+        $outputHandler = new $candidate();
+        if ($outputHandler->isOutputHandlerFor($form)) {
+          $outputHandler->setForm($form);
+          return $outputHandler;
+        }
+      }
+      catch (\Exception $e) {
+        // no ts() since this is a sysadmin-y message
+        \Civi::log()->warn("Unable to use $candidate as an output handler. " . $e->getMessage());
+      }
+    }
+    return NULL;
+  }
+
+  /**
+   * Register an outputHandler to handle an output format.
+   *
+   * @param string $outputHandler
+   *   The classname of a class that implements OutputHandlerInterface.
+   */
+  public function register(string $outputHandler) {
+    // Use classname as index to (a) avoid duplicates and (b) make it easier
+    // to unset/overwrite one via hook.
+    self::$registered[$outputHandler] = $outputHandler;
+  }
+
+  /**
+   * There are some handlers that were hard-coded in to the form before which
+   * have now been moved to outputhandlers.
+   */
+  private static function registerBuiltins() {
+    self::$singleton->register('\CRM_Report_OutputHandler_Print');
+    self::$singleton->register('\CRM_Report_OutputHandler_Csv');
+    self::$singleton->register('\CRM_Report_OutputHandler_Pdf');
+  }
+
+}

--- a/Civi/Report/OutputHandlerInterface.php
+++ b/Civi/Report/OutputHandlerInterface.php
@@ -1,0 +1,121 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+namespace Civi\Report;
+
+/**
+ * @package Civi\Report
+ */
+interface OutputHandlerInterface {
+
+  /**
+   * Getter for $form.
+   *
+   * It's suggested to extend \Civi\Report\OutputHandlerBase and then this will
+   * be handled for you.
+   *
+   * @return \CRM_Report_Form
+   */
+  public function getForm():\CRM_Report_Form;
+
+  /**
+   * Setter for $form.
+   *
+   * It's suggested to extend \Civi\Report\OutputHandlerBase and then this will
+   * be handled for you.
+   *
+   * @param \CRM_Report_Form $form
+   */
+  public function setForm(\CRM_Report_Form $form);
+
+  /**
+   * Are we a suitable output handler based on the given form?
+   *
+   * The class member $form isn't set yet at this point since we don't
+   * even know if we're in play yet, so the form is a parameter.
+   *
+   * @param \CRM_Report_Form $form
+   *
+   * @return bool
+   */
+  public function isOutputHandlerFor(\CRM_Report_Form $form):bool;
+
+  /**
+   * Return the download filename. This should be the "clean" name, not
+   * a munged temporary filename.
+   *
+   * @return string
+   */
+  public function getFileName():string;
+
+  /**
+   * Return the html body of the email.
+   *
+   * @return string
+   */
+  public function getMailBody():string;
+
+  /**
+   * Return the report contents as a string.
+   *
+   * @return string
+   */
+  public function getOutputString():string;
+
+  /**
+   * Set headers as appropriate and send the output to the browser.
+   */
+  public function download();
+
+  /**
+   * Mime type of the attachment.
+   *
+   * @return string
+   */
+  public function getMimeType():string;
+
+  /**
+   * Charset of the attachment.
+   *
+   * The default of '' means charset is not specified in the mimepart,
+   * which is normal for binary attachments, but for text attachments you
+   * should specify something like 'utf-8'.
+   *
+   * @return string
+   */
+  public function getCharset():string;
+
+  /**
+   * Hide/show various elements in the output, but generally for a handler
+   * this is always set to TRUE.
+   *
+   * @return bool
+   */
+  public function isPrintOnly():bool;
+
+  /**
+   * Use a pager, but for a handler this would be FALSE since paging
+   * is a UI element.
+   *
+   * @return bool
+   */
+  public function isAddPaging():bool;
+
+  /**
+   * Create absolute urls for links. Generally for a handler
+   * this is always set to TRUE, but for example for 'print' it's displayed
+   * on the site so it can be relative.
+   * @todo Couldn't it just always be absolute?
+   *
+   * @return bool
+   */
+  public function isAbsoluteUrl():bool;
+
+}

--- a/tests/phpunit/CRM/Report/Form/SampleForm.php
+++ b/tests/phpunit/CRM/Report/Form/SampleForm.php
@@ -4,7 +4,7 @@
  * Helper class to simulate a report form but allow us access to some protected
  * fields for tests.
  * There's an argument that you shouldn't be testing against internal fields
- * and that the getters in here should either be part of the real class or
+ * and that the functions in here should either be part of the real class or
  * there should be some other public output to test against, but for the
  * purposes of refactoring something like a big if/else block this is helpful
  * to ensure the same before and after, and it's easier to remove this test
@@ -12,12 +12,32 @@
  */
 class CRM_Report_Form_SampleForm extends CRM_Report_Form_Contribute_Summary {
 
-  public function getOutputMode():string {
-    return $this->_outputMode;
-  }
-
+  /**
+   * Getter for addPaging.
+   *
+   * @return bool
+   */
   public function getAddPaging():bool {
     return $this->addPaging;
+  }
+
+  /**
+   * Thin wrapper around protected function for testing.
+   * Just calls getActions.
+   *
+   * @param int $instanceId
+   * @return array
+   */
+  public function getActionsForTesting($instanceId) {
+    return $this->getActions($instanceId);
+  }
+
+  /**
+   * This just allows setting outputMode directly for testing.
+   * @param string $outputMode
+   */
+  public function setOutputModeForTesting(string $outputMode) {
+    $this->_outputMode = $outputMode;
   }
 
 }

--- a/tests/phpunit/Civi/Report/OutputHandlerFactoryTest.php
+++ b/tests/phpunit/Civi/Report/OutputHandlerFactoryTest.php
@@ -1,0 +1,80 @@
+<?php
+namespace Civi\Report;
+
+/**
+ * Class OutputHandlerFactoryTest
+ * @package Civi\Report
+ * @group headless
+ */
+class OutputHandlerFactoryTest extends \CiviUnitTestCase {
+
+  /**
+   * Test builtin outputhandler creation
+   */
+  public function testCreateBuiltin() {
+    $form = new \CRM_Report_Form_SampleForm();
+    $form->setOutputModeForTesting('csv');
+    $outputHandler = OutputHandlerFactory::singleton()->create($form);
+    $this->assertEquals('CRM_Report_OutputHandler_Csv', get_class($outputHandler));
+
+    $form->setOutputModeForTesting('pdf');
+    $outputHandler = OutputHandlerFactory::singleton()->create($form);
+    $this->assertEquals('CRM_Report_OutputHandler_Pdf', get_class($outputHandler));
+
+    $form->setOutputModeForTesting('print');
+    $outputHandler = OutputHandlerFactory::singleton()->create($form);
+    $this->assertEquals('CRM_Report_OutputHandler_Print', get_class($outputHandler));
+  }
+
+  /**
+   * Test when no suitable handler available for given report parameters.
+   */
+  public function testCreateNoMatch() {
+    $form = new \CRM_Report_Form_SampleForm();
+    $form->setOutputModeForTesting('something_nonexistent');
+    $outputHandler = OutputHandlerFactory::singleton()->create($form);
+    $this->assertNull($outputHandler);
+  }
+
+  /**
+   * Test handler made available via hook.
+   */
+  public function testCreateWithHook() {
+    \Civi::dispatcher()->addListener('hook_civicrm_alterReportVar', [$this, 'hookForAlterReportVar']);
+    $form = new \CRM_Report_Form_SampleForm();
+    $form->setOutputModeForTesting('sample');
+    $outputHandler = OutputHandlerFactory::singleton()->create($form);
+    $this->assertEquals('Civi\Report\SampleOutputHandler', get_class($outputHandler));
+  }
+
+  /**
+   * Test actions modified by hook.
+   */
+  public function testAlterReportVarHookWithActions() {
+    \Civi::dispatcher()->addListener('hook_civicrm_alterReportVar', [$this, 'hookForAlterReportVar']);
+    $form = new \CRM_Report_Form_SampleForm();
+    // NULL means no particular instance - running new report from template
+    $actions = $form->getActionsForTesting(NULL);
+    $this->assertEquals(['title' => 'Export Sample'], $actions['report_instance.sample']);
+  }
+
+  /**
+   * This is the listener for hook_civicrm_alterReportVar
+   *
+   * @param \Civi\Core\Event\GenericHookEvent $e
+   *   Should contain 'varType', 'var', and 'object' members corresponding
+   *   to the hook parameters.
+   */
+  public function hookForAlterReportVar(\Civi\Core\Event\GenericHookEvent $e) {
+    switch ($e->varType) {
+      case 'outputhandlers':
+        $e->var['\Civi\Report\SampleOutputHandler'] = '\Civi\Report\SampleOutputHandler';
+        break;
+
+      case 'actions':
+        $e->var['report_instance.sample'] = ['title' => 'Export Sample'];
+        break;
+    }
+  }
+
+}

--- a/tests/phpunit/Civi/Report/SampleOutputHandler.php
+++ b/tests/phpunit/Civi/Report/SampleOutputHandler.php
@@ -1,0 +1,20 @@
+<?php
+namespace Civi\Report;
+
+/**
+ * Helper class to simulate an OutputHandler that an extension might provide.
+ */
+class SampleOutputHandler extends OutputHandlerBase {
+
+  /**
+   * Are we a suitable output handler for the given parameters.
+   *
+   * @param \CRM_Report_Form $form
+   *
+   * @return bool
+   */
+  public function isOutputHandlerFor(\CRM_Report_Form $form):bool {
+    return $form->getOutputMode() === 'sample';
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/1855

The code to output csv/pdf/etc is hardcoded and hard to follow - I've previously struggled looking through the code a few times - but there's also several uses for being able to allow extensions to provide their own output formats or alter the core ones. I've expanded on this a bit in the lab ticket.

Inspired by and borrows from https://github.com/civicrm/civicrm-core/pull/17145 and https://github.com/civicrm/civicrm-core/pull/17693.

There's no change to existing report functions proposed here. A stock install should function the same as before.

There's a docs PR coming. It adds two `varTypes` to hook_civicrm_alterReportVar.

Before
----------------------------------------
CiviReports

After
----------------------------------------
Still CiviReports, but you can add your own formats. They also automatically become available as formats for the mail_report scheduled job.

If you want to get fancy, it's flexible enough to let you provide different output handlers for different report instances, or different report classes.

Technical Details
----------------------------------------
Since it looks big, here's a walkthrough:

1. Three of the files are for tests. I also recently added several tests [here](https://github.com/civicrm/civicrm-core/commit/9c4a5d7c25ffb23208b9351d8859e5e61297b5d3), [here](https://github.com/civicrm/civicrm-core/commit/d0d1c38b95f7daac9183d97ec012c9949c1a1feb#diff-a95d6214aaf5b8f4e1cdb78f8b95d676), and [here](https://github.com/civicrm/civicrm-core/commit/d45fdad695cc41c17a3844d1f1a3b34357cbdfdb) to cover existing functionality.

2. There's three files in the Civi/Report folder:
  * One is an interface, so by definition is boilerplate.
  * One is a base class, which is identical to the interface but implements some defaults.
  * The other is the factory, which is mostly just a hook for you to advertise your extension's outputhandler(s), with some fluff around it. On its own without the hook it just helps replace the big "if/else/if/then" that was hardcoded in the form by instead registering builtin types for 'pdf', 'csv', 'print'.

3. There's three files in the CRM/Report/OutputHandler folder, which are all copy/paste from the base class except for the parts that are different for the specific type, which are copy/paste from the `if` blocks. A key simplification here was that emailing a report and downloading a report start with the same thing: getting the output string.

4. That just leaves CRM_Report_Form itself.
  * There's some getters added.
  * It's hard to see from the github UI but if you look at the function endPostProcess before, you'll see it's this big nested `if` statement. By using the simplification above and moving the code into the outputhandler files, the `if` reduces mostly to:
  ```
  if ($this->_sendmail) {
    $this->sendEmail();
  }
  elseif (!empty($this->outputHandler)) {
    $this->outputHandler->download();
    CRM_Utils_System::civiExit();
  }
  ```
  * There's a hook for the dropdown actions on the civireport page. Technically, this could be done already with hook_buildForm, but when you do that you have to do something like this: https://lab.civicrm.org/extensions/civiexportexcel/-/blob/ad7e59a587b5e7d6fe334fe03773e8173e2b64f1/civiexportexcel.php#L87-118, and that's without the extra code or core patch to make it actually do something when you choose it. With the new addition to alterReportVar it looks like this, and will automatically call out to your outputhandler when chosen:
  ```
  function examplereportoutputhandler_civicrm_alterReportVar($type, &$vars, $form) {
  switch ($type) {
  case 'actions':
    $vars['report_instance.excel2007'] = ['title' => ts('Export to Excel')];
    break;
  }
  ```

Comments
----------------------------------------
There's an example outputhandler extension which implements an "emoji" format at https://lab.civicrm.org/DaveD/examplereportoutputhandler

On the civireports instance listing pages, there are some links on the righthand side. This PR doesn't automatically alter those links, but there is already a hook for those that you could implement in your extension (hook_links with $op = 'view.report.links').

This PR does not fully address the hardcoding of the email body text when using the mail_report job - it's the same as before - but this might make it easier to make that more configurable via UI later since it's now out of the big `if` block. Even without a UI, you can now override it by extending one of the core outputhandlers and changing just the related function(s). You could do it before with hook_alterMailParams, but it wasn't very robust since you had to guess if the email was a civireport.