### PR TITLE
dev/core#1894 - Make CRM_Activity_Form_SearchTest::testQill less time-sensitive

### DIFF
--- a/tests/phpunit/CRM/Activity/Form/SearchTest.php
+++ b/tests/phpunit/CRM/Activity/Form/SearchTest.php
@@ -66,55 +66,49 @@ class CRM_Activity_Form_SearchTest extends CiviUnitTestCase {
 
   /**
    * Test the Qill for activity Date time.
-   *
-   * @dataProvider getSearchCriteria
-   *
-   * @param array $searchCriteria
-   * @param array $expectedQill
    */
-  public function testQill($searchCriteria, $expectedQill) {
-    $selector = new CRM_Activity_Selector_Search($searchCriteria);
-    $this->assertEquals($expectedQill, $selector->getQILL());
+  public function testQill() {
+    foreach ($this->getSearchCriteria() as $test_name => $data) {
+      $selector = new CRM_Activity_Selector_Search($data['search_criteria']);
+      $this->assertEquals($data['expected_qill'], $selector->getQILL(), "Failed for data set: $test_name");
+    }
   }
 
   /**
    * Get criteria for activity testing.
    */
   public function getSearchCriteria() {
-
-    // We have to define format because tests crash trying to access the config param from the dataProvider
-    // perhaps because there is no property on config?
-    $format = '%B %E%f, %Y %l:%M %P';
+    $format = \Civi::settings()->get('dateformatDatetime');
     $dates['ending_60.day'] = CRM_Utils_Date::getFromTo('ending_60.day', NULL, NULL);
     $dates['earlier.year'] = CRM_Utils_Date::getFromTo('earlier.year', NULL, NULL);
     $dates['greater.year'] = CRM_Utils_Date::getFromTo('greater.year', NULL, NULL);
     return [
-      [
+      'last 60' => [
         'search_criteria' => [
           ['activity_date_time_relative', '=', 'ending_60.day', 0, 0],
         ],
         'expected_qill' => [['Activity Date is Last 60 days including today (between ' . CRM_Utils_Date::customFormat($dates['ending_60.day'][0], $format) . ' and ' . CRM_Utils_Date::customFormat($dates['ending_60.day'][1], $format) . ')']],
       ],
-      [
+      'end of previous year' => [
         'search_criteria' => [
           ['activity_date_time_relative', '=', 'earlier.year', 0, 0],
         ],
         'expected_qill' => [['Activity Date is To end of previous calendar year (to ' . CRM_Utils_Date::customFormat($dates['earlier.year'][1], $format) . ')']],
       ],
-      [
+      'start of current year' => [
         'search_criteria' => [
           ['activity_date_time_relative', '=', 'greater.year', 0, 0],
         ],
         'expected_qill' => [['Activity Date is From start of current calendar year (from ' . CRM_Utils_Date::customFormat($dates['greater.year'][0], $format) . ')']],
       ],
-      [
+      'between' => [
         'search_criteria' => [
           ['activity_date_time_low', '=', '2019-03-05', 0, 0],
           ['activity_date_time_high', '=', '2019-03-27', 0, 0],
         ],
         'expected_qill' => [['Activity Date - greater than or equal to "March 5th, 2019 12:00 AM" AND less than or equal to "March 27th, 2019 11:59 PM"']],
       ],
-      [
+      'status is one of' => [
         'search_criteria' => [
           ['activity_status_id', '=', ['IN' => ['1', '2']], 0, 0],
         ],


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/1894

This test has failed twice recently near GMT 00:00 on different PRs. It maybe doesn't come up that often but it can be made less time sensitive.

Technical Details
----------------------------------------
Dataproviders run at a different time and in a potentially different context than the actual test that uses them. If the provider runs and calculates something based on current time/day, and then the clock ticks past midnight before the actual test runs, the test might calculate a different time/day so it won't match.

Comments
----------------------------------------
Is test
