### PR TITLE
[REF] remove unnecessary variable variables

### DIFF
--- a/CRM/Contact/BAO/Individual.php
+++ b/CRM/Contact/BAO/Individual.php
@@ -50,9 +50,9 @@ class CRM_Contact_BAO_Individual extends CRM_Contact_DAO_Contact {
     }
 
     $sortName = $displayName = '';
-    $firstName = CRM_Utils_Array::value('first_name', $params, '');
-    $middleName = CRM_Utils_Array::value('middle_name', $params, '');
-    $lastName = CRM_Utils_Array::value('last_name', $params, '');
+    $firstName = trim($params['first_name'] ?? '');
+    $middleName = trim($params['middle_name'] ?? '');
+    $lastName = trim($params['last_name'] ?? '');
     $nickName = CRM_Utils_Array::value('nick_name', $params, '');
     $prefix_id = CRM_Utils_Array::value('prefix_id', $params, '');
     $suffix_id = CRM_Utils_Array::value('suffix_id', $params, '');
@@ -160,11 +160,6 @@ class CRM_Contact_BAO_Individual extends CRM_Contact_DAO_Contact {
           $formalTitle = $individual->formal_title;
         }
       }
-    }
-
-    //first trim before further processing.
-    foreach (['lastName', 'firstName', 'middleName'] as $fld) {
-      $$fld = trim($$fld);
     }
 
     if ($lastName || $firstName || $middleName) {


### PR DESCRIPTION
Overview
----------------------------------------
For a brief but terrifying spell this arvo I delved into this function to try to understand
the purpose of 'preserveDBName'. Obviously I ran screaming from the room but I thought I could disarm these
few lines to slighly file down the fangs of the beast.

Code is heavily covered by tests

Before
----------------------------------------
```
$firstName = CRM_Utils_Array::value('first_name', $params, '');
```
...

```
$$fld = trim($$fld);
```

After
----------------------------------------
```$firstName = trim($params['first_name'] ?? '');```

Technical Details
----------------------------------------
Obviously this scope could creep in many directions but I'm aiming to keep trauma levels low

Comments
----------------------------------------

