### PR TITLE
Remove unused "ufUniqID" session variable

### DIFF
--- a/CRM/Core/BAO/UFMatch.php
+++ b/CRM/Core/BAO/UFMatch.php
@@ -93,7 +93,6 @@ class CRM_Core_BAO_UFMatch extends CRM_Core_DAO_UFMatch {
         $userIds = self::getUFValues();
         $session->set('ufID', CRM_Utils_Array::value('uf_id', $userIds, ''));
         $session->set('userID', CRM_Utils_Array::value('contact_id', $userIds, ''));
-        $session->set('ufUniqID', CRM_Utils_Array::value('uf_name', $userIds, ''));
       }
     }
 
@@ -110,7 +109,6 @@ class CRM_Core_BAO_UFMatch extends CRM_Core_DAO_UFMatch {
     //make sure we have session w/ consistent ids.
     $ufID = $ufmatch->uf_id;
     $userID = $ufmatch->contact_id;
-    $ufUniqID = '';
     if ($isUserLoggedIn) {
       $loggedInUserUfID = CRM_Utils_System::getLoggedInUfID();
       //are we processing logged in user.
@@ -118,14 +116,12 @@ class CRM_Core_BAO_UFMatch extends CRM_Core_DAO_UFMatch {
         $userIds = self::getUFValues($loggedInUserUfID);
         $ufID = CRM_Utils_Array::value('uf_id', $userIds, '');
         $userID = CRM_Utils_Array::value('contact_id', $userIds, '');
-        $ufUniqID = CRM_Utils_Array::value('uf_name', $userIds, '');
       }
     }
 
     //set user ids to session.
     $session->set('ufID', $ufID);
     $session->set('userID', $userID);
-    $session->set('ufUniqID', $ufUniqID);
 
     // add current contact to recently viewed
     if ($ufmatch->contact_id) {


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [this issue on Lab](https://lab.civicrm.org/dev/core/-/issues/1890).

Before
----------------------------------------
CiviCRM populates the unused `ufUniqID` session variable.

After
----------------------------------------
The `ufUniqID` session variable is removed.