### PR TITLE
Member detail report: nest "in" options in parentheses

### DIFF
--- a/CRM/Report/Form/Member/Detail.php
+++ b/CRM/Report/Form/Member/Detail.php
@@ -335,7 +335,8 @@ HERESQL;
             if (!empty($regularOptions)) {
               $clauseParts[] = "{$this->_aliases['civicrm_contribution_recur']}.contribution_status_id IN ($regularOptions)";
             }
-            return '(' . implode(') OR (', $clauseParts) . ')';
+            // Double parentheses b/c ORs should be treated as a group
+            return '((' . implode(') OR (', $clauseParts) . '))';
           }
           return;
 

--- a/tests/phpunit/CRM/Report/Form/Member/DetailTest.php
+++ b/tests/phpunit/CRM/Report/Form/Member/DetailTest.php
@@ -29,6 +29,7 @@ class CRM_Report_Form_Member_DetailTest extends CiviReportTestCase {
 
     $indContactID1 = $this->individualCreate();
     $indContactID2 = $this->individualCreate();
+    $indContactID3 = $this->individualCreate();
     $recurStatus = array_search(
       'In Progress',
       CRM_Contribute_PseudoConstant::contributionStatus(NULL, 'name')
@@ -61,6 +62,9 @@ class CRM_Report_Form_Member_DetailTest extends CiviReportTestCase {
     $memParams['contact_id'] = $indContactID2;
     $memParams['contribution_recur_id'] = $recur2['id'];
     $mem2 = civicrm_api3('Membership', 'create', $memParams);
+    $memParams['contact_id'] = $indContactID3;
+    unset($memParams['contribution_recur_id']);
+    $mem3 = civicrm_api3('Membership', 'create', $memParams);
 
     $input = [
       'fields' => ['autorenew_status_id'],
@@ -83,16 +87,21 @@ class CRM_Report_Form_Member_DetailTest extends CiviReportTestCase {
       }
     }
 
+    $input['filters']['autorenew_status_id_value'] = "0,$recurStatus";
+    $obj = $this->getReportObject('CRM_Report_Form_Member_Detail', $input);
+    $results = $obj->getResultSet();
+    $this->assertCount(3, $results);
+
     $input['filters']['autorenew_status_id_op'] = 'nll';
     $obj = $this->getReportObject('CRM_Report_Form_Member_Detail', $input);
     $results = $obj->getResultSet();
-    $this->assertCount(0, $results);
+    $this->assertCount(1, $results);
 
     $input['filters']['autorenew_status_id_op'] = 'in';
     $input['filters']['autorenew_status_id_value'] = 0;
     $obj = $this->getReportObject('CRM_Report_Form_Member_Detail', $input);
     $results = $obj->getResultSet();
-    $this->assertCount(0, $results);
+    $this->assertCount(1, $results);
 
     $input['filters']['autorenew_status_id_op'] = 'in';
     $input['filters']['autorenew_status_id_value'] = 1000;
@@ -102,6 +111,11 @@ class CRM_Report_Form_Member_DetailTest extends CiviReportTestCase {
 
     $input['filters']['autorenew_status_id_op'] = 'notin';
     $input['filters']['autorenew_status_id_value'] = 1000;
+    $obj = $this->getReportObject('CRM_Report_Form_Member_Detail', $input);
+    $results = $obj->getResultSet();
+    $this->assertCount(3, $results);
+
+    $input['filters']['autorenew_status_id_value'] = '0,1000';
     $obj = $this->getReportObject('CRM_Report_Form_Member_Detail', $input);
     $results = $obj->getResultSet();
     $this->assertCount(2, $results);


### PR DESCRIPTION
Overview
----------------------------------------
@Stoob found this issue in #17683 where multiple autorenew statuses would screw up the filters.

Before
----------------------------------------
If there are multiple autorenew statuses, the query would be `WHERE` a bunch of things `AND` the first autorenew status `OR` another autorenew status `AND` any subsequent things.  The result is that memberships matching the second or subsequent autorenew status(es) would display even if they didn't match other applied filters.

After
----------------------------------------
All of the `OR` bits for the autorenew statuses are enclosed in parentheses.  Any membership listed in the report must meet all other filter criteria.

Technical Details
----------------------------------------
I added a test case for this.
