### PR TITLE
Update flexmailer release information

### DIFF
--- a/ext/flexmailer/info.xml
+++ b/ext/flexmailer/info.xml
@@ -14,16 +14,16 @@
     <url desc="Support">http://civicrm.stackexchange.com/</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2019-11-26</releaseDate>
-  <version>1.1.1</version>
-  <develStage>alpha</develStage>
+  <releaseDate>2020-08-05</releaseDate>
+  <version>1.1.2</version>
+  <develStage>stable</develStage>
   <comments>
     FlexMailer is an email delivery engine which replaces the internal guts
     of CiviMail.  It is a drop-in replacement which enables *other* extensions
     to provide richer email features.
   </comments>
   <compatibility>
-    <ver>5.13</ver>
+    <ver>5.29</ver>
   </compatibility>
   <classloader>
     <psr4 prefix="Civi\FlexMailer\" path="src"/>


### PR DESCRIPTION
Overview
----------------------------------------
I went to look at https://docs.civicrm.org/dev/en/latest/extensions/info-xml/ and found the example to
be out of date. I thought we could replace with flexmailer -but we are still calling it 'alpha' so
I updated the basic values for when it goes first ships with core (well I guess it will ship in 5.28 but
this will hit 5.29).

Before
----------------------------------------
flexmailer still states alpha

After
----------------------------------------
New release with 'stable', sets release dates to the date when 5.29 goes into rc & targets 5.29

Technical Details
----------------------------------------
 Open question as to whether we keep incrementing the version
but I don't think it's urgent. I feel like ideally we would align the version with the civi version like we do with drupal modules - but not necessarily this month

Comments
----------------------------------------
