### PR TITLE
dev/drupal#127 - CRM_Core_Session::setStatus() gets ignored sometimes

### DIFF
--- a/templates/CRM/common/info.tpl
+++ b/templates/CRM/common/info.tpl
@@ -8,7 +8,7 @@
  +--------------------------------------------------------------------+
 *}
 {* Handles display of passed $infoMessage. *}
-{if $infoMessage}
+{if $infoMessage or $infoTitle}
   <div class="messages status {$infoType}"{if $infoOptions} data-options='{$infoOptions}'{/if}>
     <div class="icon inform-icon"></div>
     <span class="msg-title">{$infoTitle}</span>

--- a/tests/phpunit/CRM/Core/SessionTest.php
+++ b/tests/phpunit/CRM/Core/SessionTest.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * Class CRM_Core_SessionTest
+ * @group headless
+ */
+class CRM_Core_SessionTest extends CiviUnitTestCase {
+
+  public function setUp() {
+    CRM_Core_Smarty::singleton()->clearTemplateVars();
+  }
+
+  /**
+   * Test that the template setStatus uses gives reasonable output.
+   * Test with text only.
+   */
+  public function testSetStatusWithTextOnly() {
+    $smarty = CRM_Core_Smarty::singleton();
+    $smarty->assign('infoMessage', 'Your refridgerator door is open.');
+    $output = $smarty->fetch('CRM/common/info.tpl');
+    $this->assertStringContainsString('Your refridgerator door is open.', $output);
+  }
+
+  /**
+   * Test that the template setStatus uses gives reasonable output.
+   * Test with title only.
+   */
+  public function testSetStatusWithTitleOnly() {
+    $smarty = CRM_Core_Smarty::singleton();
+    $smarty->assign('infoTitle', 'Error Error Error.');
+    $output = $smarty->fetch('CRM/common/info.tpl');
+    $this->assertStringContainsString('Error Error Error.', $output);
+  }
+
+  /**
+   * Test that the template setStatus uses gives reasonable output.
+   * Test with both text and title.
+   */
+  public function testSetStatusWithBoth() {
+    $smarty = CRM_Core_Smarty::singleton();
+    $smarty->assign('infoTitle', 'Spoiler alert!');
+    $smarty->assign('infoMessage', 'Your refridgerator door is open.');
+    $output = $smarty->fetch('CRM/common/info.tpl');
+    $this->assertStringContainsString('Spoiler alert!', $output);
+    $this->assertStringContainsString('Your refridgerator door is open.', $output);
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/drupal/-/issues/127

This part isn't specific to drupal.

It looks like there are two paths to get a status message popup. One follows a javascript-only path, the other goes through templates/CRM/common/info.tpl. For the second one, if you only set a title and leave the message blank when calling CRM_Core_Session::setStatus(), then it gets ignored.

There's a couple places where this happens:
* On the Create User Record action you can choose when viewing a contact
  * This is what the drupal ticket was originally about, but there's also a second bug in case of error so this alone doesn't fix the if-error part, but fixes the success message. On drupal 7 though you wouldn't think about it because you see the CMS's message anyway, but it's more obvious on drupal 8 (well, if the absence of something could be considered "obvious").
* After doing batch update for contact records.
* After deleting a campaign survey.

Probably the easiest way to reproduce is:
1. Do a contact search.
2. Select a couple and from the actions dropdown choose Update Multiple.
3. Choose a profile. New Individual is simple.
4. Make your changes and click Update.
5. Did it succeed? It's a mystery.

Before
----------------------------------------
No popup status message.

After
----------------------------------------
Popup status message as intended.

Technical Details
----------------------------------------
All the code along the way seems to support having a title but no message *except* the last stage when it runs thru the template, where it only does anything if there's a message component.

Comments
----------------------------------------

