### PR TITLE
dev/drupal#127 - require email for the Useradd task and errors not showing

### DIFF
--- a/CRM/Contact/Form/Task/Useradd.php
+++ b/CRM/Contact/Form/Task/Useradd.php
@@ -73,6 +73,7 @@ class CRM_Contact_Form_Task_Useradd extends CRM_Core_Form {
     $this->addRule('cms_pass', 'Password is required', 'required');
     $this->addRule(['cms_pass', 'cms_confirm_pass'], 'ERROR: Password mismatch', 'compare');
     $this->add('text', 'email', ts('Email:'), ['class' => 'huge'])->freeze();
+    $this->addRule('email', 'Email is required', 'required');
     $this->add('hidden', 'contactID');
 
     //add a rule to check username uniqueness
@@ -101,8 +102,12 @@ class CRM_Contact_Form_Task_Useradd extends CRM_Core_Form {
     // store the submitted values in an array
     $params = $this->exportValues();
 
-    CRM_Core_BAO_CMSUser::create($params, 'email');
-    CRM_Core_Session::setStatus('', ts('User Added'), 'success');
+    if (CRM_Core_BAO_CMSUser::create($params, 'email') === FALSE) {
+      CRM_Core_Error::statusBounce(ts('Error creating CMS user account.'));
+    }
+    else {
+      CRM_Core_Session::setStatus(ts('User Added'), '', 'success');
+    }
   }
 
   /**

--- a/CRM/Utils/System/Drupal8.php
+++ b/CRM/Utils/System/Drupal8.php
@@ -56,6 +56,9 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
     // Validate the user object
     $violations = $account->validate();
     if (count($violations)) {
+      foreach ($violations as $violation) {
+        CRM_Core_Session::setStatus($violation->getPropertyPath() . ': ' . $violation->getMessage(), '', 'alert');
+      }
       return FALSE;
     }
 

--- a/tests/phpunit/CRM/Contact/Form/Task/UseraddTest.php
+++ b/tests/phpunit/CRM/Contact/Form/Task/UseraddTest.php
@@ -1,0 +1,38 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+ /**
+  * @group headless
+  */
+class CRM_Contact_Form_Task_UseraddTest extends CiviUnitTestCase {
+
+  /**
+   * Test postProcess failure.
+   *
+   * In unit tests, the CMS user creation will always fail, but that's
+   * ok because that's what we're testing here.
+   */
+  public function testUserCreateFail() {
+    $form = new CRM_Contact_Form_Task_Useradd();
+    // We don't need to set params or anything because we're testing fail,
+    // which the user creation will do in unit tests no matter what we set.
+    // But before the patch, the status messages were always success no
+    // matter what.
+    try {
+      $form->postProcess();
+    }
+    catch (CRM_Core_Exception_PrematureExitException $e) {
+    }
+    $statuses = CRM_Core_Session::singleton()->getStatus(TRUE);
+    $this->assertEquals('alert', $statuses[0]['type']);
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/drupal/-/issues/127

This is more noticeable on drupal 8 because in drupal 7 the CMS prevents it and outputs its own error message, but either way the "Create User Record" action when viewing a contact doesn't properly display or check for errors when creating the CMS user.

1. Find a contact without an email.
2. Choose Create User Record from the actions dropdown.
3. Fill out the form.
4. When you submit, what happens on drupal 8 is it goes back to contact view with ~~no message~~ a success message but the CMS user is not created.
  * Additionally, if you look at the original code even in drupal 7 it's written to display a success message even when the CMS user creation fails. ~~That doesn't happen because of a separate bug~~ (#17914), but you can see there's no check on the return value from the create call.


Before
----------------------------------------
Missing or incorrect message. Also the actual cause of the error is not recorded or displayed anywhere.

After
----------------------------------------
Proper message and cause displayed.

Technical Details
----------------------------------------
Also to be in line with https://lab.civicrm.org/dev/drupal/-/issues/91 I made email required on the form to head off errors from that.

Comments
----------------------------------------
Has test.
