### PR TITLE
Improve caching of current domain

### DIFF
--- a/CRM/Core/BAO/Domain.php
+++ b/CRM/Core/BAO/Domain.php
@@ -21,16 +21,20 @@
 class CRM_Core_BAO_Domain extends CRM_Core_DAO_Domain {
 
   /**
-   * Cache for the current domain object.
-   * @var object
-   */
-  public static $_domain = NULL;
-
-  /**
    * Cache for a domain's location array
    * @var array
    */
   private $_location = NULL;
+
+  /**
+   * Flushes the cache set by getDomain.
+   *
+   * @see CRM_Core_BAO_Domain::getDomain()
+   * @param CRM_Core_DAO_Domain $domain
+   */
+  public static function onPostSave($domain) {
+    Civi::$statics[__CLASS__]['current'] = NULL;
+  }
 
   /**
    * Fetch object based on array of properties.
@@ -47,21 +51,20 @@ class CRM_Core_BAO_Domain extends CRM_Core_DAO_Domain {
   }
 
   /**
-   * Get the domain BAO.
-   *
-   * @param bool $reset
+   * Get the current domain.
    *
    * @return \CRM_Core_BAO_Domain
    * @throws \CRM_Core_Exception
    */
-  public static function getDomain($reset = NULL) {
-    static $domain = NULL;
-    if (!$domain || $reset) {
+  public static function getDomain() {
+    $domain = Civi::$statics[__CLASS__]['current'] ?? NULL;
+    if (!$domain) {
       $domain = new CRM_Core_BAO_Domain();
       $domain->id = CRM_Core_Config::domainID();
       if (!$domain->find(TRUE)) {
         throw new CRM_Core_Exception('No domain in DB');
       }
+      Civi::$statics[__CLASS__]['current'] = $domain;
     }
     return $domain;
   }
@@ -69,17 +72,16 @@ class CRM_Core_BAO_Domain extends CRM_Core_DAO_Domain {
   /**
    * @param bool $skipUsingCache
    *
-   * @return null|string
+   * @return string
    *
    * @throws \CRM_Core_Exception
    */
   public static function version($skipUsingCache = FALSE) {
-    return CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Domain',
-      CRM_Core_Config::domainID(),
-      'version',
-      'id',
-      $skipUsingCache
-    );
+    if ($skipUsingCache) {
+      Civi::$statics[__CLASS__]['current'] = NULL;
+    }
+
+    return self::getDomain()->version;
   }
 
   /**
@@ -90,7 +92,7 @@ class CRM_Core_BAO_Domain extends CRM_Core_DAO_Domain {
    * @throws \CRM_Core_Exception
    */
   public static function isDBUpdateRequired() {
-    $dbVersion = CRM_Core_BAO_Domain::version();
+    $dbVersion = self::version();
     $codeVersion = CRM_Utils_System::version();
     return version_compare($dbVersion, $codeVersion) < 0;
   }
@@ -108,16 +110,12 @@ class CRM_Core_BAO_Domain extends CRM_Core_DAO_Domain {
   /**
    * Get the location values of a domain.
    *
-   * @return array
-   *   Location::getValues
-   *
-   * @throws \CRM_Core_Exception
+   * @return CRM_Core_BAO_Location[]|NULL
    */
-  public function &getLocationValues() {
+  public function getLocationValues() {
     if ($this->_location == NULL) {
-      $domain = self::getDomain(NULL);
       $params = [
-        'contact_id' => $domain->contact_id,
+        'contact_id' => $this->contact_id,
       ];
       $this->_location = CRM_Core_BAO_Location::getValues($params, TRUE);
 
@@ -242,9 +240,7 @@ class CRM_Core_BAO_Domain extends CRM_Core_DAO_Domain {
     }
     elseif ($multisite) {
       // create a group with that of domain name
-      $title = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Domain',
-        CRM_Core_Config::domainID(), 'name'
-      );
+      $title = self::getDomain()->name;
       $groupID = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Group',
         $title, 'id', 'title', TRUE
       );

--- a/CRM/Core/BAO/FinancialTrxn.php
+++ b/CRM/Core/BAO/FinancialTrxn.php
@@ -415,7 +415,7 @@ WHERE ceft.entity_id = %1";
     $fItemParams
       = [
         'financial_account_id' => $financialAccount,
-        'contact_id' => CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Domain', CRM_Core_Config::domainID(), 'contact_id'),
+        'contact_id' => CRM_Core_BAO_Domain::getDomain()->contact_id,
         'created_date' => date('YmdHis'),
         'transaction_date' => $params['trxnParams']['trxn_date'],
         'amount' => $amount,

--- a/CRM/Core/BAO/Location.php
+++ b/CRM/Core/BAO/Location.php
@@ -226,10 +226,9 @@ WHERE e.id = %1";
    * @param array $entityBlock
    * @param bool $microformat
    *
-   * @return array
-   *   array of objects(CRM_Core_BAO_Location)
+   * @return CRM_Core_BAO_Location[]|NULL
    */
-  public static function &getValues($entityBlock, $microformat = FALSE) {
+  public static function getValues($entityBlock, $microformat = FALSE) {
     if (empty($entityBlock)) {
       return NULL;
     }

--- a/CRM/Core/I18n.php
+++ b/CRM/Core/I18n.php
@@ -590,10 +590,8 @@ class CRM_Core_I18n {
    *   True if CiviCRM is in multilingual mode.
    */
   public static function isMultilingual() {
-    return (bool) CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Domain',
-      CRM_Core_Config::domainID(),
-      'locales'
-    );
+    $domain = CRM_Core_BAO_Domain::getDomain();
+    return (bool) $domain->locales;
   }
 
   /**
@@ -602,11 +600,8 @@ class CRM_Core_I18n {
    * @return array|bool
    */
   public static function getMultilingual() {
-    $locales = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Domain',
-      CRM_Core_Config::domainID(),
-      'locales'
-    );
-    return $locales ? CRM_Core_DAO::unSerializeField($locales, CRM_Core_DAO::SERIALIZE_SEPARATOR_TRIMMED) : FALSE;
+    $domain = CRM_Core_BAO_Domain::getDomain();
+    return $domain->locales ? CRM_Core_DAO::unSerializeField($domain->locales, CRM_Core_DAO::SERIALIZE_SEPARATOR_TRIMMED) : FALSE;
   }
 
   /**

--- a/CRM/Financial/BAO/FinancialTypeAccount.php
+++ b/CRM/Financial/BAO/FinancialTypeAccount.php
@@ -190,7 +190,7 @@ class CRM_Financial_BAO_FinancialTypeAccount extends CRM_Financial_DAO_EntityFin
     if (!$dao->N) {
       $params = [
         'name' => $financialType->name,
-        'contact_id' => CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Domain', CRM_Core_Config::domainID(), 'contact_id'),
+        'contact_id' => CRM_Core_BAO_Domain::getDomain()->contact_id,
         'financial_account_type_id' => array_search('Revenue', $financialAccountTypeID),
         'description' => $financialType->description,
         'account_type_code' => 'INC',

--- a/CRM/Financial/Form/FinancialAccount.php
+++ b/CRM/Financial/Form/FinancialAccount.php
@@ -160,7 +160,7 @@ class CRM_Financial_Form_FinancialAccount extends CRM_Contribute_Form {
   public function setDefaultValues() {
     $defaults = parent::setDefaultValues();
     if ($this->_action & CRM_Core_Action::ADD) {
-      $defaults['contact_id'] = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Domain', CRM_Core_Config::domainID(), 'contact_id');
+      $defaults['contact_id'] = CRM_Core_BAO_Domain::getDomain()->contact_id;
     }
     return $defaults;
   }

--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -250,7 +250,7 @@ class CRM_Utils_Token {
 
   /**
    * @param $token
-   * @param $domain
+   * @param CRM_Core_BAO_Domain $domain
    * @param bool $html
    * @param bool $escapeSmarty
    *
@@ -261,7 +261,7 @@ class CRM_Utils_Token {
     // we have to do this because this function is
     // called only when we find a token in the string
 
-    $loc = &$domain->getLocationValues();
+    $loc = $domain->getLocationValues();
 
     if (!in_array($token, self::$_tokens['domain'])) {
       $value = "{domain.$token}";

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -356,6 +356,7 @@ class Container {
     $dispatcher->addListener('civi.dao.postInsert', ['\CRM_Core_BAO_RecurringEntity', 'triggerInsert']);
     $dispatcher->addListener('civi.dao.postUpdate', ['\CRM_Core_BAO_RecurringEntity', 'triggerUpdate']);
     $dispatcher->addListener('civi.dao.postDelete', ['\CRM_Core_BAO_RecurringEntity', 'triggerDelete']);
+    $dispatcher->addListener('hook_civicrm_postSave_civicrm_domain', ['\CRM_Core_BAO_Domain', 'onPostSave']);
     $dispatcher->addListener('hook_civicrm_unhandled_exception', [
       'CRM_Core_LegacyErrorHandler',
       'handleException',

--- a/api/v3/Domain.php
+++ b/api/v3/Domain.php
@@ -28,17 +28,23 @@ function civicrm_api3_domain_get($params) {
   $params['version'] = $params['domain_version'] ?? NULL;
   unset($params['version']);
 
-  $bao = new CRM_Core_BAO_Domain();
   if (!empty($params['current_domain'])) {
-    $domainBAO = CRM_Core_Config::domainID();
-    $params['id'] = $domainBAO;
+    $params['id'] = CRM_Core_Config::domainID();
   }
   if (!empty($params['options']) && !empty($params['options']['is_count'])) {
     return _civicrm_api3_basic_get(_civicrm_api3_get_BAO(__FUNCTION__), $params);
   }
 
-  _civicrm_api3_dao_set_filter($bao, $params, TRUE);
-  $domains = _civicrm_api3_dao_to_array($bao, $params, TRUE, 'Domain');
+  // If requesting current domain, read from cache
+  if (!empty($params['id']) && $params['id'] == CRM_Core_Config::domainID()) {
+    $bao = CRM_Core_BAO_Domain::getDomain();
+    $domains = [$params['id'] => $bao->toArray()];
+  }
+  else {
+    $bao = new CRM_Core_BAO_Domain();
+    _civicrm_api3_dao_set_filter($bao, $params, TRUE);
+    $domains = _civicrm_api3_dao_to_array($bao, $params, TRUE, 'Domain');
+  }
 
   foreach ($domains as $domain) {
     if (!empty($domain['contact_id'])) {

--- a/tests/phpunit/CRM/Core/DAOTest.php
+++ b/tests/phpunit/CRM/Core/DAOTest.php
@@ -518,14 +518,14 @@ class CRM_Core_DAOTest extends CiviUnitTestCase {
 
   public function testSupportedFields() {
     // Hack a different db version which will trigger getSupportedFields to filter out newer fields
-    \CRM_Core_DAO::$_dbColumnValueCache['CRM_Core_DAO_Domain']['id'][1]['version'] = '5.26.0';
+    CRM_Core_BAO_Domain::getDomain()->version = '5.26.0';
 
     $customGroupFields = CRM_Core_DAO_CustomGroup::getSupportedFields();
     // 'icon' was added in 5.28
     $this->assertArrayNotHasKey('icon', $customGroupFields);
 
     // Remove domain version override:
-    \CRM_Core_DAO::$_dbColumnValueCache = NULL;
+    CRM_Core_BAO_Domain::version(TRUE);
 
     $activityFields = CRM_Activity_DAO_Activity::getSupportedFields();
     // Fields should be indexed by name not unique_name (which is "activity_id")


### PR DESCRIPTION
Overview
----------------------------------------
The current domain is read dozens, sometimes hundreds of times per request, so it needs to have solid caching. This consolidates 4 different ways it was being cached (or in the case of api3, not cached) into one central spot.

Before
----------------------------------------
Current domain cached during bootstrap but never flushed in the event of changes.
Several other methods of reading the domain were used that bypassed that cache or used some other cache.

After
----------------------------------------
All centralized to one cache, which is automatically flushed by hook whenever updates are made (which is rare but important to respond to, and essential for unit tests)
