### PR TITLE
Fix sticky table header on "Find Activities" page

### DIFF
--- a/templates/CRM/Activity/Form/Selector.tpl
+++ b/templates/CRM/Activity/Form/Selector.tpl
@@ -14,8 +14,8 @@
 
 {strip}
 <table class="selector row-highlight">
-   <thead>
-     <tr class="sticky">
+   <thead class="sticky">
+     <tr>
        {if !$single and $context eq 'Search' }
           <th scope="col" title="Select Rows">{$form.toggleSelect.html}</th>
        {/if}


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [this issue on Lab](https://lab.civicrm.org/dev/core/-/issues/1901). 

The `templates/CRM/Activity/Form/Selector.tpl` template assigns the `sticky` class to the wrong element and therefore its sticky header is never initialised.

Before
----------------------------------------
No sticky table header on "Find Activities" page

After
----------------------------------------
Sticky table header on "Find Activities" page works as expected.