### PR TITLE
[REF] Reduce interaction between dedupe code and createProfileContact

### DIFF
--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -615,6 +615,30 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
   }
 
   /**
+   * Update the contact with the new parameters.
+   *
+   * This function is intended as an interim function, with the intent being
+   * an apiv4 call.
+   *
+   * The function was calling the rather-terrifying createProfileContact. I copied all
+   * that code into this function and then removed all the parts that have no effect in this scenario.
+   *
+   * @param int $contactID
+   * @param array $params
+   *
+   * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
+   * @throws \Civi\API\Exception\UnauthorizedException
+   */
+  protected static function createContact($contactID, $params) {
+    // This parameter causes blank fields to be be emptied out.
+    // We can probably remove.
+    $params['updateBlankLocInfo'] = TRUE;
+    list($data) = CRM_Contact_BAO_Contact::formatProfileContactParams($params, [], $contactID);
+    CRM_Contact_BAO_Contact::create($data);
+  }
+
+  /**
    * Given a contact ID, will check if a record exists in given table.
    *
    * @param int $contactID
@@ -1450,8 +1474,7 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
       if (!isset($submitted['suffix_id']) && !empty($migrationInfo['main_details']['suffix_id'])) {
         $submitted['suffix_id'] = $migrationInfo['main_details']['suffix_id'];
       }
-      $null = [];
-      CRM_Contact_BAO_Contact::createProfileContact($submitted, $null, $mainId);
+      self::createContact($mainId, $submitted);
     }
     $transaction->commit();
     CRM_Utils_Hook::post('merge', 'Contact', $mainId);


### PR DESCRIPTION
Overview
----------------------------------------
Code cleanup in Dedupe function

Before
----------------------------------------
Problematic ```createProfileContact``` function called

After
----------------------------------------
A cut down version of the function called - with the goal to reduce further

Technical Details
----------------------------------------
Ideally we want to simply call apiv4 from the deduper. However, it seems to take a bit of analysis to determine
if anything is done in there that might have some impact. This takes one step in that direction.  I copied the full function over
and then remove all the parts that are unreachable due to the passed in params or meaningless due to us not having Billing
fields. I think the Profile hooks are overkill - the merge hooks and contact hooks are being run and no profile is being submitted

Comments
----------------------------------------
@pfigel  @JKingsnorth @demeritcowboy perhaps one of you can check this

Test cover should be pretty good
