### PR TITLE
[REF] Do not pass variable by reference

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -1958,10 +1958,14 @@ ORDER BY civicrm_email.is_primary DESC";
    *
    * @return int
    *   contact id created/edited
+   *
+   * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
+   * @throws \Civi\API\Exception\UnauthorizedException
    */
   public static function createProfileContact(
     &$params,
-    &$fields = [],
+    $fields = [],
     $contactID = NULL,
     $addToGroupID = NULL,
     $ufGroupId = NULL,


### PR DESCRIPTION


Overview
----------------------------------------
Minor code cleanup - do not pass variables by reference where it is unnecessary

Before
----------------------------------------
&$fields

After
----------------------------------------
$fields

Technical Details
----------------------------------------
This variable is not altered in the function so does not need to be passed by reference

Comments
----------------------------------------

