### PR TITLE
dev/core#785 Differentiate smart group from regular group using icon in select2 field

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -304,7 +304,7 @@ class CRM_Contact_BAO_Contact extends CRM_Contact_DAO_Contact {
       }
     }
 
-    if (array_key_exists('group', $params)) {
+    if (!empty($params['group'])) {
       $contactIds = [$params['contact_id']];
       foreach ($params['group'] as $groupId => $flag) {
         if ($flag == 1) {

--- a/CRM/Contact/BAO/Group.php
+++ b/CRM/Contact/BAO/Group.php
@@ -1055,7 +1055,7 @@ class CRM_Contact_BAO_Group extends CRM_Contact_DAO_Group {
     $groups = [];
     $args = [1 => [$groupIdString, 'String']];
     $query = "
-SELECT id, title, description, visibility, parents
+SELECT id, title, description, visibility, parents, saved_search_id
 FROM   civicrm_group
 WHERE  id IN $groupIdString
 ";
@@ -1081,7 +1081,7 @@ WHERE  id IN $groupIdString
         $parent = self::filterActiveGroups($parentArray);
         $tree[$parent][] = [
           'id' => $dao->id,
-          'title' => $dao->title,
+          'title' => empty($dao->saved_search_id) ? $dao->title : '* ' . $dao->title,
           'visibility' => $dao->visibility,
           'description' => $dao->description,
         ];
@@ -1089,7 +1089,7 @@ WHERE  id IN $groupIdString
       else {
         $roots[] = [
           'id' => $dao->id,
-          'title' => $dao->title,
+          'title' => empty($dao->saved_search_id) ? $dao->title : '* ' . $dao->title,
           'visibility' => $dao->visibility,
           'description' => $dao->description,
         ];
@@ -1123,8 +1123,9 @@ WHERE  id IN $groupIdString
       $hierarchy[$group['id']] = $spaces . $group['title'];
     }
     else {
-      $hierarchy[$group['id']] = [
-        'title' => $spaces . $group['title'],
+      $hierarchy[] = [
+        'id' => $group['id'],
+        'text' => $spaces . $group['title'],
         'description' => $group['description'],
         'visibility' => $group['visibility'],
       ];

--- a/CRM/Contact/Form/Contact.php
+++ b/CRM/Contact/Form/Contact.php
@@ -870,8 +870,10 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
     }
 
     $group = $params['group'] ?? NULL;
-    if (!empty($group) && is_array($group)) {
-      unset($params['group']);
+    $params['group'] = ($params['group'] == '') ? [] : $params['group'];
+    if (!empty($group)) {
+      $group = is_array($group) ? $group : explode(',', $group);
+      $params['group'] = [];
       foreach ($group as $key => $value) {
         $params['group'][$value] = 1;
       }

--- a/CRM/Contact/Form/Edit/TagsAndGroups.php
+++ b/CRM/Contact/Form/Edit/TagsAndGroups.php
@@ -102,17 +102,17 @@ class CRM_Contact_Form_Edit_TagsAndGroups {
           }
 
           if ($groupElementType == 'select') {
-            $groupsOptions[$id] = $group['title'];
+            $groupsOptions[$id] = $group;
           }
           else {
             $form->_tagGroup[$fName][$id]['description'] = $group['description'];
-            $elements[] = &$form->addElement('advcheckbox', $id, NULL, $group['title'], $attributes);
+            $elements[] = &$form->addElement('advcheckbox', $id, NULL, $group['text'], $attributes);
           }
         }
 
         if ($groupElementType == 'select' && !empty($groupsOptions)) {
-          $form->add('select', $fName, $groupName, $groupsOptions, FALSE,
-            ['id' => $fName, 'multiple' => 'multiple', 'class' => 'crm-select2 twenty']
+          $form->add('select2', $fName, $groupName, $groupsOptions, FALSE,
+            ['placeholder' => '- select -', 'multiple' => TRUE, 'class' => 'twenty']
           );
           $form->assign('groupCount', count($groupsOptions));
         }
@@ -166,11 +166,11 @@ class CRM_Contact_Form_Edit_TagsAndGroups {
 
       $contactGroup = CRM_Contact_BAO_GroupContact::getContactGroup($id, 'Added', NULL, FALSE, TRUE);
       if ($contactGroup) {
-        foreach ($contactGroup as $group) {
-          if ($groupElementType == 'select') {
-            $defaults[$fName][] = $group['group_id'];
-          }
-          else {
+        if ($groupElementType == 'select') {
+          $defaults[$fName] = implode(',', CRM_Utils_Array::collect('group_id', $contactGroup));
+        }
+        else {
+          foreach ($contactGroup as $group) {
             $defaults[$fName . '[' . $group['group_id'] . ']'] = 1;
           }
         }

--- a/CRM/Contact/Form/GroupContact.php
+++ b/CRM/Contact/Form/GroupContact.php
@@ -73,7 +73,7 @@ class CRM_Contact_Form_GroupContact extends CRM_Core_Form {
         if ($onlyPublicGroups && $group['visibility'] == 'User and User Admin Only') {
           continue;
         }
-        $allGroups[$id] = $group;
+        $allGroups[$group['id']] = $group;
       }
     }
     else {

--- a/CRM/Contact/Form/Search/Basic.php
+++ b/CRM/Contact/Form/Search/Basic.php
@@ -49,13 +49,14 @@ class CRM_Contact_Form_Search_Basic extends CRM_Contact_Form_Search {
 
     // add select for groups
     // Get hierarchical listing of groups, respecting ACLs for CRM-16836.
-    $groupHierarchy = CRM_Contact_BAO_Group::getGroupsHierarchy($this->_group, NULL, '&nbsp;&nbsp;', TRUE);
+    $groupHierarchy = CRM_Contact_BAO_Group::getGroupsHierarchy($this->_group, NULL, '&nbsp;&nbsp;');
     if (!empty($searchOptions['groups'])) {
       $this->addField('group', [
         'entity' => 'group_contact',
         'label' => ts('in'),
         'placeholder' => ts('- any group -'),
         'options' => $groupHierarchy,
+        'type' => 'Select2',
       ]);
     }
 

--- a/CRM/Contact/Form/Search/Criteria.php
+++ b/CRM/Contact/Form/Search/Criteria.php
@@ -45,7 +45,7 @@ class CRM_Contact_Form_Search_Criteria {
         $groupHierarchy = CRM_Contact_BAO_Group::getGroupsHierarchy($form->_group, NULL, '&nbsp;&nbsp;', TRUE);
 
         $form->add('select', 'group', ts('Groups'), $groupHierarchy, FALSE,
-          ['id' => 'group', 'multiple' => 'multiple', 'class' => 'crm-select2']
+         ['id' => 'group', 'multiple' => 'multiple', 'class' => 'crm-select2']
         );
         $groupOptions = CRM_Core_BAO_OptionValue::getOptionValuesAssocArrayFromName('group_type');
         $form->add('select', 'group_type', ts('Group Types'), $groupOptions, FALSE,

--- a/ang/crmMailing/Recipients.js
+++ b/ang/crmMailing/Recipients.js
@@ -95,11 +95,12 @@
           }
           var option = convertValueToObj(item.id);
           var icon = (option.entity_type === 'civicrm_mailing') ? 'fa-envelope' : 'fa-users';
+          var smartGroupMarker = item.is_smart ? '* ' : '';
           var spanClass = (option.mode == 'exclude') ? 'crmMailing-exclude' : 'crmMailing-include';
           if (option.entity_type != 'civicrm_mailing' && isMandatory(option.entity_id)) {
             spanClass = 'crmMailing-mandatory';
           }
-          return '<i class="crm-i '+icon+'" aria-hidden="true"></i> <span class="' + spanClass + '">' + item.text + '</span>';
+          return '<i class="crm-i '+icon+'"></i> <span class="' + spanClass + '">' + smartGroupMarker + item.text + '</span>';
         }
 
         function validate() {
@@ -154,7 +155,7 @@
               mids.push(0);
             }
 
-            CRM.api3('Group', 'getlist', { params: { id: { IN: gids }, options: { limit: 0 } }, extra: ["is_hidden"] } ).then(
+            CRM.api3('Group', 'getlist', { params: { id: { IN: gids }, options: { limit: 0 } }, extra: ["is_hidden"] }).then(
               function(glist) {
                 CRM.api3('Mailing', 'getlist', { params: { id: { IN: mids }, options: { limit: 0 } } }).then(
                   function(mlist) {
@@ -165,6 +166,7 @@
 
                     $(glist.values).each(function (idx, group) {
                       var key = group.id + ' civicrm_group include';
+
                       groupNames.push({id: parseInt(group.id), title: group.label, is_hidden: group.extra.is_hidden});
                       if (values.indexOf(key) >= 0) {
                         datamap.push({id: key, text: group.label});
@@ -232,6 +234,9 @@
               if('civicrm_mailing' === rcpAjaxState.entity) {
                 params["api.MailingRecipients.getcount"] = {};
               }
+              else if ('civicrm_group' === rcpAjaxState.entity) {
+                params.extra = ["saved_search_id"];
+              }
 
               return params;
             },
@@ -255,8 +260,8 @@
                                text: obj.label } : '';
                   }
                   else {
-                    return {   id: obj.id + ' ' + rcpAjaxState.entity + ' ' + rcpAjaxState.type,
-                               text: obj.label };
+                    return {   id: obj.id + ' ' + rcpAjaxState.entity + ' ' + rcpAjaxState.type, text: obj.label,
+                              is_smart: (!_.isEmpty(obj.extra.saved_search_id)) };
                   }
                 })
               };

--- a/tests/phpunit/CRM/Contact/Page/View/UserDashboard/GroupContactTest.php
+++ b/tests/phpunit/CRM/Contact/Page/View/UserDashboard/GroupContactTest.php
@@ -177,7 +177,7 @@ class CRM_Contact_Page_View_UserDashboard_GroupContactTest extends CiviUnitTestC
     $group_id_field_html = $form['group_id']['html'];
     $this->assertContains($publicSmartGroupTitle, $group_id_field_html, "Group '$publicSmartGroupTitle' should be in listed available groups, but is not.");
     $this->assertContains($publicStdGroupTitle, $group_id_field_html, "Group '$publicStdGroupTitle' should be in listed available groups, but is not.");
-    $this->assertNotContains($adminSmartGroupTitle, $group_id_field_html, "Group '$adminSmartGroupTitle' should not be in listed available groups, but is.");
+    $this->assertNotContains('* ' . $adminSmartGroupTitle, $group_id_field_html, "Group '$adminSmartGroupTitle' should not be in listed available groups, but is.");
     $this->assertNotContains($adminStdGroupTitle, $group_id_field_html, "Group '$adminStdGroupTitle' should not be in listed available groups, but is.");
 
     // Add current user to the test groups.
@@ -199,9 +199,9 @@ class CRM_Contact_Page_View_UserDashboard_GroupContactTest extends CiviUnitTestC
 
     $form = CRM_Core_Smarty::singleton()->get_template_vars('form');
     $group_id_field_html = $form['group_id']['html'];
-    $this->assertNotContains($publicSmartGroupTitle, $group_id_field_html, "Group '$publicSmartGroupTitle' should not be in listed available groups, but is.");
+    $this->assertNotContains('* ' . $publicSmartGroupTitle, $group_id_field_html, "Group '$publicSmartGroupTitle' should not be in listed available groups, but is.");
     $this->assertNotContains($publicStdGroupTitle, $group_id_field_html, "Group '$publicStdGroupTitle' should not be in listed available groups, but is.");
-    $this->assertNotContains($adminSmartGroupTitle, $group_id_field_html, "Group '$adminSmartGroupTitle' should not be in listed available groups, but is.");
+    $this->assertNotContains('* ' . $adminSmartGroupTitle, $group_id_field_html, "Group '$adminSmartGroupTitle' should not be in listed available groups, but is.");
     $this->assertNotContains($adminStdGroupTitle, $group_id_field_html, "Group '$adminStdGroupTitle' should not be in listed available groups, but is.");
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Currently, there is no way to tell which group is smart or regular group from UI. It would be ideal to use icon against such smart group options to differentiate them from regular ones. This patch appends an icon against smart group option of the select2 widget 

https://lab.civicrm.org/dev/core/-/issues/785

Before
----------------------------------------
<img width="250" alt="Screen Shot 2019-04-04 at 5 54 08 PM" src="https://user-images.githubusercontent.com/3735621/55555351-b6352c80-5702-11e9-83ba-fbb7ced8cd58.png">

<img width="268" alt="Screen Shot 2019-04-04 at 5 46 34 PM" src="https://user-images.githubusercontent.com/3735621/55555423-e250ad80-5702-11e9-9290-15f387db713c.png">



After
----------------------------------------
<img width="219" alt="Screen Shot 2019-04-04 at 5 42 38 PM" src="https://user-images.githubusercontent.com/3735621/55554749-3064b180-5701-11e9-8325-61099940f39e.png">
<img width="239" alt="Screen Shot 2019-04-04 at 5 43 13 PM" src="https://user-images.githubusercontent.com/3735621/55555774-a79b4500-5703-11e9-9944-41137c5f7032.png">




Comments
----------------------------------------
resubmitted PR after fixing the regression encountered in https://lab.civicrm.org/dev/core/-/issues/1888 

ping @eileenmcnaughton @demeritcowboy @lcdservices 