### PR TITLE
dev/core#1903 - Avoid E_WARNING and remove code

### DIFF
--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -439,7 +439,6 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
       unset($extra['option_context']);
     }
 
-    $this->addRequiredAttribute($required, $extra);
     $element = $this->addElement($type, $name, CRM_Utils_String::purifyHTML($label), $attributes, $extra);
     if (HTML_QuickForm::isError($element)) {
       CRM_Core_Error::statusBounce(HTML_QuickForm::errorMessage($element));
@@ -1175,20 +1174,6 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
   }
 
   /**
-   * jQuery validate prefers to see a validation rule as a class (eg. "required").
-   * We can't add a class at the quickform level but jQuery validate also works with HTML5:
-   * HTML5 validation requires a separate attribute "required".
-   *
-   * @param $required
-   * @param $attributes
-   */
-  private function addRequiredAttribute($required, $attributes) {
-    // Ideally we do this by adding "required" as a class on the radio but we can't
-    // But adding the attribute "required" directly to the element also works.
-    $required ? $attributes['required'] = 1 : NULL;
-  }
-
-  /**
    * @param string $name
    * @param $title
    * @param $values
@@ -1205,8 +1190,6 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
     $allowClear = !empty($attributes['allowClear']);
     unset($attributes['allowClear']);
     $attributes['id_suffix'] = $name;
-    // For jquery validate we need to flag the actual radio as required.
-    $this->addRequiredAttribute($required, $attributes);
     foreach ($values as $key => $var) {
       $optAttributes = $attributes;
       if (!empty($optionAttributes[$key])) {

--- a/tests/phpunit/CRM/Core/FormTest.php
+++ b/tests/phpunit/CRM/Core/FormTest.php
@@ -65,6 +65,13 @@ class CRM_Core_FormTest extends CiviUnitTestCase {
           $form->_action = CRM_Core_Action::BASIC;
         },
       ],
+      'New Price Field' => [
+        'CRM_Price_Form_Field',
+        function(CRM_Core_Form $form) {
+          $form->set('sid', 1);
+          $form->_action = CRM_Core_Action::ADD;
+        },
+      ],
     ];
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/1903

1. Create or edit a price field.
2. `Warning: Illegal string offset 'required' in CRM_Core_Form->addRequiredAttribute() (line 1188 of .../CRM/Core/Form.php).`

Before
----------------------------------------
Warning on screen. Test fails.

After
----------------------------------------
No warning. Test passes.

Technical Details
----------------------------------------
I can't see how the removed code can possibly work. It modifies a local copy of the variable which is passed by value. Further, $attributes can be a string, such as in [Price_Field](https://github.com/civicrm/civicrm-core/blob/a48fe430b9e67a9a1a292e802da48d73412457cd/CRM/Price/Form/Field.php#L235-L237). Further further, $attributes is actually $extra from the add() function.

The reference to radios and the description in the [original commit](https://github.com/civicrm/civicrm-core/pull/16488) don't seem to make any difference to how radios or other elements function with or without the code. Either way they don't get an html `required` attribute.

Comments
----------------------------------------
Has test. Started in 5.28.
