### PR TITLE
dev/core#1902: "Contribution Source" profile field has no effect

### DIFF
--- a/CRM/Contribute/BAO/Contribution/Utils.php
+++ b/CRM/Contribute/BAO/Contribution/Utils.php
@@ -83,6 +83,9 @@ class CRM_Contribute_BAO_Contribution_Utils {
       $form->_values['amount'] = $form->_params['amount'];
     }
 
+    if (isset($paymentParams['contribution_source'])) {
+      $paymentParams['source'] = $paymentParams['contribution_source'];
+    }
     if ($isPaymentTransaction) {
       $contributionParams = [
         'id' => $paymentParams['contribution_id'] ?? NULL,
@@ -142,9 +145,6 @@ class CRM_Contribute_BAO_Contribution_Utils {
 
       $paymentParams['contributionID'] = $contribution->id;
       $paymentParams['contributionPageID'] = $contribution->contribution_page_id;
-      if (isset($paymentParams['contribution_source'])) {
-        $paymentParams['source'] = $paymentParams['contribution_source'];
-      }
 
       if (!empty($form->_params['is_recur']) && $contribution->contribution_recur_id) {
         $paymentParams['contributionRecurID'] = $contribution->contribution_recur_id;


### PR DESCRIPTION
This profile field has on the new contribution.

From the linked issue ([dev/core#1902](https://lab.civicrm.org/dev/core/-/issues/1902)):

> Overview
> ----------------------------------------
> Profiles allow inclusion of the "Contributions :: Contribution Source" on contribution pages, but any value entered therein is disregarded when saving a new contribution.
> 
> Steps to reproduce (on dmaster.demo.civicrm.org)
> 
> Reproduction steps
> ----------------------------------------
> 1. Start with the Name and Address profile, and add to this profile the field "Contributions :: Contribution Source"
> 2. Add this profile to a Contribution Page, e.g., "Help Support CiviCRM!"
> 3. Open the Contribution Page, and fill in the form to submit an online contribution; for the Contribution Source field, enter a testable value such as "test source".
> 4. Submit the contribution
> 5. Find the contribution in CiviCRM, and open it; examine the value of the "Source" field.
> 
> Current behaviour
> ----------------------------------------
> * The "Source" field reads "Online Contribution: Help Support CiviCRM!"
> 
> Expected behaviour
> ----------------------------------------
> * The "Source" field should read "test source"
> 
> Environment information
> ----------------------------------------
> The above repro steps were performed today on dmaster.demo.civicrm.org.
> 