### PR TITLE
[REF] Refactor to use the standard CRM_Core_Form::addRadio function f…

### DIFF
--- a/CRM/Activity/Import/Form/DataSource.php
+++ b/CRM/Activity/Import/Form/DataSource.php
@@ -31,20 +31,11 @@ class CRM_Activity_Import_Form_DataSource extends CRM_Import_Form_DataSource {
     parent::buildQuickForm();
 
     // FIXME: This 'onDuplicate' form element is never used -- copy/paste error?
-    $duplicateOptions = [];
-    $duplicateOptions[] = $this->createElement('radio',
-      NULL, NULL, ts('Skip'), CRM_Import_Parser::DUPLICATE_SKIP
-    );
-    $duplicateOptions[] = $this->createElement('radio',
-      NULL, NULL, ts('Update'), CRM_Import_Parser::DUPLICATE_UPDATE
-    );
-    $duplicateOptions[] = $this->createElement('radio',
-      NULL, NULL, ts('Fill'), CRM_Import_Parser::DUPLICATE_FILL
-    );
-
-    $this->addGroup($duplicateOptions, 'onDuplicate',
-      ts('On duplicate entries')
-    );
+    $this->addRadio('onDuplicate', ts('On duplicate entries'), [
+      CRM_Import_Parser::DUPLICATE_SKIP => ts('Skip'),
+      CRM_Import_Parser::DUPLICATE_UPDATE => ts('Update'),
+      CRM_Import_Parser::DUPLICATE_FILL => ts('Fill'),
+    ]);
   }
 
   /**

--- a/CRM/Contact/Form/Search/Criteria.php
+++ b/CRM/Contact/Form/Search/Criteria.php
@@ -556,15 +556,12 @@ class CRM_Contact_Form_Search_Criteria {
     $form->addSearchFieldMetadata(['Contact' => self::getFilteredSearchFieldMetadata('demographic')]);
     $form->addFormFieldsFromMetadata();
     // radio button for gender
-    $genderOptions = [];
+    $genderOptionsAttributes = [];
     $gender = CRM_Core_PseudoConstant::get('CRM_Contact_DAO_Contact', 'gender_id');
     foreach ($gender as $key => $var) {
-      $genderOptions[$key] = $form->createElement('radio', NULL,
-        ts('Gender'), $var, $key,
-        ['id' => "civicrm_gender_{$var}_{$key}"]
-      );
+      $genderOptionsAttributes[$key] = ['id' => "civicrm_gender_{$var}_{$key}"];
     }
-    $form->addGroup($genderOptions, 'gender_id', ts('Gender'))->setAttribute('allowClear', TRUE);
+    $form->addRadio('gender_id', ts('Gender'), $gender, ['allowClear' => TRUE], NULL, FALSE, $genderOptionsAttributes);
 
     $form->add('number', 'age_low', ts('Min Age'), ['class' => 'four', 'min' => 0]);
     $form->addRule('age_low', ts('Please enter a positive integer'), 'positiveInteger');

--- a/CRM/Contact/Import/Form/DataSource.php
+++ b/CRM/Contact/Import/Form/DataSource.php
@@ -137,23 +137,12 @@ class CRM_Contact_Import_Form_DataSource extends CRM_Core_Form {
     );
 
     // duplicate handling options
-    $duplicateOptions = [];
-    $duplicateOptions[] = $this->createElement('radio',
-      NULL, NULL, ts('Skip'), CRM_Import_Parser::DUPLICATE_SKIP
-    );
-    $duplicateOptions[] = $this->createElement('radio',
-      NULL, NULL, ts('Update'), CRM_Import_Parser::DUPLICATE_UPDATE
-    );
-    $duplicateOptions[] = $this->createElement('radio',
-      NULL, NULL, ts('Fill'), CRM_Import_Parser::DUPLICATE_FILL
-    );
-    $duplicateOptions[] = $this->createElement('radio',
-      NULL, NULL, ts('No Duplicate Checking'), CRM_Import_Parser::DUPLICATE_NOCHECK
-    );
-
-    $this->addGroup($duplicateOptions, 'onDuplicate',
-      ts('For Duplicate Contacts')
-    );
+    $this->addRadio('onDuplicate', ts('For Duplicate Contacts'), [
+      CRM_Import_Parser::DUPLICATE_SKIP => ts('Skip'),
+      CRM_Import_Parser::DUPLICATE_UPDATE => ts('Update'),
+      CRM_Import_Parser::DUPLICATE_FILL => ts('Fill'),
+      CRM_Import_Parser::DUPLICATE_NOCHECK => ts('No Duplicate Checking'),
+    ]);
 
     $mappingArray = CRM_Core_BAO_Mapping::getMappings('Import Contact');
 
@@ -162,26 +151,20 @@ class CRM_Contact_Import_Form_DataSource extends CRM_Core_Form {
 
     $js = ['onClick' => "buildSubTypes();buildDedupeRules();"];
     // contact types option
-    $contactOptions = [];
+    $contactTypeOptions = $contactTypeAttributes = [];
     if (CRM_Contact_BAO_ContactType::isActive('Individual')) {
-      $contactOptions[] = $this->createElement('radio',
-        NULL, NULL, ts('Individual'), CRM_Import_Parser::CONTACT_INDIVIDUAL, $js
-      );
+      $contactTypeOptions[CRM_Import_Parser::CONTACT_INDIVIDUAL] = ts('Individual');
+      $contactTypeAttributes[CRM_Import_Parser::CONTACT_INDIVIDUAL] = $js;
     }
     if (CRM_Contact_BAO_ContactType::isActive('Household')) {
-      $contactOptions[] = $this->createElement('radio',
-        NULL, NULL, ts('Household'), CRM_Import_Parser::CONTACT_HOUSEHOLD, $js
-      );
+      $contactTypeOptions[CRM_Import_Parser::CONTACT_HOUSEHOLD] = ts('Household');
+      $contactTypeAttributes[CRM_Import_Parser::CONTACT_HOUSEHOLD] = $js;
     }
     if (CRM_Contact_BAO_ContactType::isActive('Organization')) {
-      $contactOptions[] = $this->createElement('radio',
-        NULL, NULL, ts('Organization'), CRM_Import_Parser::CONTACT_ORGANIZATION, $js
-      );
+      $contactTypeOptions[CRM_Import_Parser::CONTACT_ORGANIZATION] = ts('Organization');
+      $contactTypeAttributes[CRM_Import_Parser::CONTACT_ORGANIZATION] = $js;
     }
-
-    $this->addGroup($contactOptions, 'contactType',
-      ts('Contact Type')
-    );
+    $this->addRadio('contactType', ts('Contact Type'), $contactTypeOptions, [], NULL, FALSE, $contactTypeAttributes);
 
     $this->addElement('select', 'subType', ts('Subtype'));
     $this->addElement('select', 'dedupe', ts('Dedupe Rule'));

--- a/CRM/Contribute/Form/CancelSubscription.php
+++ b/CRM/Contribute/Form/CancelSubscription.php
@@ -136,16 +136,7 @@ class CRM_Contribute_Form_CancelSubscription extends CRM_Contribute_Form_Contrib
     $this->buildQuickEntityForm();
     // Determine if we can cancel recurring contribution via API with this processor
     if ($this->_paymentProcessorObj->supports('CancelRecurringNotifyOptional')) {
-      $searchRange = [];
-      $searchRange[] = $this->createElement('radio', NULL, NULL, ts('Yes'), '1');
-      $searchRange[] = $this->createElement('radio', NULL, NULL, ts('No'), '0');
-
-      $this->addGroup(
-        $searchRange,
-        'send_cancel_request',
-        ts('Send cancellation request to %1 ?',
-          [1 => $this->_paymentProcessorObj->getTitle()])
-      );
+      $this->addRadio('send_cancel_request', ts('Send cancellation request to %1 ?', [1 => $this->_paymentProcessorObj->getTitle()]), [ts('No'), ts('Yes')]);
     }
     else {
       $this->assign('cancelRecurNotSupportedText', $this->_paymentProcessorObj->getText('cancelRecurNotSupportedText', []));

--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -444,10 +444,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
           ['onclick' => "showHideByValue('pcp_display_in_roll','','nameID|nickID|personalNoteID','block','radio',false); pcpAnonymous( );"]
         );
         $extraOption = ['onclick' => "return pcpAnonymous( );"];
-        $elements = [];
-        $elements[] = &$this->createElement('radio', NULL, '', ts('Include my name and message'), 0, $extraOption);
-        $elements[] = &$this->createElement('radio', NULL, '', ts('List my contribution anonymously'), 1, $extraOption);
-        $this->addGroup($elements, 'pcp_is_anonymous', NULL, '&nbsp;&nbsp;&nbsp;');
+        $this->addRadio('pcp_is_anonymous', NULL, [ts('Include my name and message'), ts('List my contribution anonymously')], [], '&nbsp;&nbsp;&nbsp;', FALSE, [$extraOption, $extraOption]);
 
         $this->add('text', 'pcp_roll_nickname', ts('Name'), ['maxlength' => 30]);
         $this->addField('pcp_personal_note', ['entity' => 'ContributionSoft', 'context' => 'create', 'style' => 'height: 3em; width: 40em;']);

--- a/CRM/Contribute/Form/ContributionPage/Settings.php
+++ b/CRM/Contribute/Form/ContributionPage/Settings.php
@@ -157,10 +157,7 @@ class CRM_Contribute_Form_ContributionPage_Settings extends CRM_Contribute_Form_
 
     $this->addProfileSelector('onbehalf_profile_id', ts('Organization Profile'), $allowCoreTypes, $allowSubTypes, $entities);
 
-    $options = [];
-    $options[] = $this->createElement('radio', NULL, NULL, ts('Optional'), 1);
-    $options[] = $this->createElement('radio', NULL, NULL, ts('Required'), 2);
-    $this->addGroup($options, 'is_for_organization', '');
+    $this->addRadio('is_for_organization', '', [1 => ts('Optional'), 2 => ts('Required')]);
     $this->add('textarea', 'for_organization', ts('On behalf of Label'), ['rows' => 2, 'cols' => 50]);
 
     // collect goal amount

--- a/CRM/Contribute/Import/Form/DataSource.php
+++ b/CRM/Contribute/Import/Form/DataSource.php
@@ -31,15 +31,10 @@ class CRM_Contribute_Import_Form_DataSource extends CRM_Import_Form_DataSource {
     parent::buildQuickForm();
 
     $duplicateOptions = [];
-    $duplicateOptions[] = $this->createElement('radio',
-      NULL, NULL, ts('Insert new contributions'), CRM_Import_Parser::DUPLICATE_SKIP
-    );
-    $duplicateOptions[] = $this->createElement('radio',
-      NULL, NULL, ts('Update existing contributions'), CRM_Import_Parser::DUPLICATE_UPDATE
-    );
-    $this->addGroup($duplicateOptions, 'onDuplicate',
-      ts('Import mode')
-    );
+    $this->addRadio('onDuplicate', ts('Import mode'), [
+      CRM_Import_Parser::DUPLICATE_SKIP => ts('Insert new contributions'),
+      CRM_Import_Parser::DUPLICATE_UPDATE => ts('Update existing contributions'),
+    ]);
 
     $this->setDefaults(['onDuplicate' => CRM_Import_Parser::DUPLICATE_SKIP]);
 

--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -822,12 +822,13 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
 
           // Add and/or option for fields that store multiple values
           if ($search && self::isSerialized($field)) {
-
-            $operators = [
-              $qf->createElement('radio', NULL, '', ts('Any'), 'or', ['title' => ts('Results may contain any of the selected options')]),
-              $qf->createElement('radio', NULL, '', ts('All'), 'and', ['title' => ts('Results must have all of the selected options')]),
-            ];
-            $qf->addGroup($operators, $elementName . '_operator');
+            $qf->addRadio($elementName . '_operator', '', [
+              'or' => ts('Any'),
+              'and' => ts('All'),
+            ], [], NULL, FALSE, [
+              'or' => ['title' => ts('Results may contain any of the selected options')],
+              'and' => ['title' => ts('Results must have all of the selected options')],
+            ]);
             $qf->setDefaults([$elementName . '_operator' => 'or']);
           }
         }

--- a/CRM/Core/BAO/UFGroup.php
+++ b/CRM/Core/BAO/UFGroup.php
@@ -1940,16 +1940,7 @@ AND    ( entity_id IS NULL OR entity_id <= 0 )
     elseif (in_array($fieldName, ['gender_id', 'communication_style_id'])) {
       $options = [];
       $pseudoValues = CRM_Core_PseudoConstant::get('CRM_Contact_DAO_Contact', $fieldName);
-      foreach ($pseudoValues as $key => $var) {
-        $options[$key] = $form->createElement('radio', NULL, ts($title), $var, $key);
-      }
-      $group = $form->addGroup($options, $name, $title);
-      if ($required) {
-        $form->addRule($name, ts('%1 is a required field.', [1 => $title]), 'required');
-      }
-      else {
-        $group->setAttribute('allowClear', TRUE);
-      }
+      $form->addRadio($name, ts('%1', [1 => $title]), $pseudoValues, ['allowClear' => !$required], NULL, $required);
     }
     elseif ($fieldName === 'prefix_id' || $fieldName === 'suffix_id') {
       $form->addSelect($name, [

--- a/CRM/Core/Form/Date.php
+++ b/CRM/Core/Form/Date.php
@@ -38,14 +38,14 @@ class CRM_Core_Form_Date {
       $dateText = ts('yyyy-mm-dd OR yyyymmdd (1998-12-25 OR 19981225) OR (2008-9-1 OR 20080901)');
     }
 
-    $dateOptions[] = $form->createElement('radio', NULL, NULL, $dateText, self::DATE_yyyy_mm_dd);
-
-    $dateOptions[] = $form->createElement('radio', NULL, NULL, ts('mm/dd/yy OR mm-dd-yy (12/25/98 OR 12-25-98) OR (9/1/08 OR 9-1-08)'), self::DATE_mm_dd_yy);
-    $dateOptions[] = $form->createElement('radio', NULL, NULL, ts('mm/dd/yyyy OR mm-dd-yyyy (12/25/1998 OR 12-25-1998) OR (9/1/2008 OR 9-1-2008)'), self::DATE_mm_dd_yyyy);
-    $dateOptions[] = $form->createElement('radio', NULL, NULL, ts('Month dd, yyyy (December 12, 1998)'), self::DATE_Month_dd_yyyy);
-    $dateOptions[] = $form->createElement('radio', NULL, NULL, ts('dd-mon-yy OR dd/mm/yy (25-Dec-98 OR 25/12/98)'), self::DATE_dd_mon_yy);
-    $dateOptions[] = $form->createElement('radio', NULL, NULL, ts('dd/mm/yyyy (25/12/1998) OR (1/9/2008)'), self::DATE_dd_mm_yyyy);
-    $form->addGroup($dateOptions, 'dateFormats', ts('Date Format'), '<br/>');
+    $form->addRadio('dateFormats', ts('Date Format'), [
+      self::DATE_yyyy_mm_dd => $dateText,
+      self::DATE_mm_dd_yy => ts('mm/dd/yy OR mm-dd-yy (12/25/98 OR 12-25-98) OR (9/1/08 OR 9-1-08)'),
+      self::DATE_mm_dd_yyyy => ts('mm/dd/yyyy OR mm-dd-yyyy (12/25/1998 OR 12-25-1998) OR (9/1/2008 OR 9-1-2008)'),
+      self::DATE_Month_dd_yyyy => ts('Month dd, yyyy (December 12, 1998)'),
+      self::DATE_dd_mon_yy => ts('dd-mon-yy OR dd/mm/yy (25-Dec-98 OR 25/12/98)'),
+      self::DATE_dd_mm_yyyy => ts('dd/mm/yyyy (25/12/1998) OR (1/9/2008)'),
+    ], [], '<br/>');
     $form->setDefaults(['dateFormats' => self::DATE_yyyy_mm_dd]);
   }
 

--- a/CRM/Custom/Form/Field.php
+++ b/CRM/Custom/Form/Field.php
@@ -538,11 +538,7 @@ class CRM_Custom_Form_Field extends CRM_Core_Form {
     );
 
     // is searchable by range?
-    $searchRange = [];
-    $searchRange[] = $this->createElement('radio', NULL, NULL, ts('Yes'), '1');
-    $searchRange[] = $this->createElement('radio', NULL, NULL, ts('No'), '0');
-
-    $this->addGroup($searchRange, 'is_search_range', ts('Search by Range?'));
+    $this->addRadio('is_search_range', ts('Search by Range?'), [ts('No'), ts('Yes')]);
 
     // add buttons
     $this->addButtons([

--- a/CRM/Event/Import/Form/DataSource.php
+++ b/CRM/Event/Import/Form/DataSource.php
@@ -33,19 +33,11 @@ class CRM_Event_Import_Form_DataSource extends CRM_Import_Form_DataSource {
     parent::buildQuickForm();
 
     $duplicateOptions = [];
-    $duplicateOptions[] = $this->createElement('radio',
-      NULL, NULL, ts('Skip'), CRM_Import_Parser::DUPLICATE_SKIP
-    );
-    $duplicateOptions[] = $this->createElement('radio',
-      NULL, NULL, ts('Update'), CRM_Import_Parser::DUPLICATE_UPDATE
-    );
-    $duplicateOptions[] = $this->createElement('radio',
-      NULL, NULL, ts('No Duplicate Checking'), CRM_Import_Parser::DUPLICATE_NOCHECK
-    );
-    $this->addGroup($duplicateOptions, 'onDuplicate',
-      ts('On Duplicate Entries')
-    );
-
+    $this->addRadio('onDuplicate', ts('On Duplicate Entries'), [
+      CRM_Import_Parser::DUPLICATE_SKIP => ts('Skip'),
+      CRM_Import_Parser::DUPLICATE_UPDATE => ts('Update'),
+      CRM_Import_Parser::DUPLICATE_NOCHECK => ts('No Duplicate Checking'),
+    ]);
     $this->setDefaults(['onDuplicate' => CRM_Import_Parser::DUPLICATE_SKIP]);
 
     $this->addContactTypeSelector();

--- a/CRM/Import/Form/DataSource.php
+++ b/CRM/Import/Form/DataSource.php
@@ -95,26 +95,17 @@ abstract class CRM_Import_Form_DataSource extends CRM_Core_Form {
    */
   protected function addContactTypeSelector() {
     //contact types option
-    $contactOptions = [];
+    $contactTypeOptions = [];
     if (CRM_Contact_BAO_ContactType::isActive('Individual')) {
-      $contactOptions[] = $this->createElement('radio',
-        NULL, NULL, ts('Individual'), CRM_Import_Parser::CONTACT_INDIVIDUAL
-      );
+      $contactTypeOptions[CRM_Import_Parser::CONTACT_INDIVIDUAL] = ts('Individual');
     }
     if (CRM_Contact_BAO_ContactType::isActive('Household')) {
-      $contactOptions[] = $this->createElement('radio',
-        NULL, NULL, ts('Household'), CRM_Import_Parser::CONTACT_HOUSEHOLD
-      );
+      $contactTypeOptions[CRM_Import_Parser::CONTACT_HOUSEHOLD] = ts('Household');
     }
     if (CRM_Contact_BAO_ContactType::isActive('Organization')) {
-      $contactOptions[] = $this->createElement('radio',
-        NULL, NULL, ts('Organization'), CRM_Import_Parser::CONTACT_ORGANIZATION
-      );
+      $contactTypeOptions[CRM_Import_Parser::CONTACT_ORGANIZATION] = ts('Organization');
     }
-
-    $this->addGroup($contactOptions, 'contactType',
-      ts('Contact Type')
-    );
+    $this->addRadio('contactType', ts('Contact Type'), $contactTypeOptions);
 
     $this->setDefaults([
       'contactType' => CRM_Import_Parser::CONTACT_INDIVIDUAL,

--- a/CRM/Member/Import/Form/DataSource.php
+++ b/CRM/Member/Import/Form/DataSource.php
@@ -32,17 +32,10 @@ class CRM_Member_Import_Form_DataSource extends CRM_Import_Form_DataSource {
   public function buildQuickForm() {
     parent::buildQuickForm();
 
-    $duplicateOptions = [];
-    $duplicateOptions[] = $this->createElement('radio',
-      NULL, NULL, ts('Insert new Membership'), CRM_Import_Parser::DUPLICATE_SKIP
-    );
-    $duplicateOptions[] = $this->createElement('radio',
-      NULL, NULL, ts('Update existing Membership'), CRM_Import_Parser::DUPLICATE_UPDATE
-    );
-
-    $this->addGroup($duplicateOptions, 'onDuplicate',
-      ts('Import mode')
-    );
+    $this->addRadio('onDuplicate', ts('Import mode'), [
+      CRM_Import_Parser::DUPLICATE_SKIP => ts('Insert new Membership'),
+      CRM_Import_Parser::DUPLICATE_UPDATE => ts('Update existing Membership'),
+    ]);
     $this->setDefaults([
       'onDuplicate' => CRM_Import_Parser::DUPLICATE_SKIP,
     ]);

--- a/CRM/PCP/BAO/PCP.php
+++ b/CRM/PCP/BAO/PCP.php
@@ -464,10 +464,7 @@ WHERE pcp.id = %1 AND cc.contribution_status_id = %2 AND cc.is_test = 0";
         ['onclick' => "showHideByValue('pcp_display_in_roll','','nameID|nickID|personalNoteID','block','radio',false); pcpAnonymous( );"]
       );
       $extraOption = ['onclick' => "return pcpAnonymous( );"];
-      $elements = [];
-      $elements[] = &$page->createElement('radio', NULL, '', ts('Include my name and message'), 0, $extraOption);
-      $elements[] = &$page->createElement('radio', NULL, '', ts('List my support anonymously'), 1, $extraOption);
-      $page->addGroup($elements, 'pcp_is_anonymous', NULL, '&nbsp;&nbsp;&nbsp;');
+      $page->addRadio('pcp_is_anonymous', '', [ts('Include my name and message'), ts('List my support anonymously')], [], '&nbsp;&nbsp;&nbsp;', FALSE, [$extraOption, $extraOption]);
       $page->_defaults['pcp_is_anonymous'] = 0;
 
       $page->add('text', 'pcp_roll_nickname', ts('Name'), ['maxlength' => 30]);

--- a/CRM/SMS/Form/Schedule.php
+++ b/CRM/SMS/Form/Schedule.php
@@ -52,11 +52,13 @@ class CRM_SMS_Form_Schedule extends CRM_Core_Form {
     // on page refresh.
     $this->setAttribute('autocomplete', 'off');
 
-    $sendOptions = [
-      $this->createElement('radio', NULL, NULL, ts('Send immediately'), 'send_immediate', ['id' => 'send_immediate', 'style' => 'margin-bottom: 10px;']),
-      $this->createElement('radio', NULL, NULL, ts('Send at:'), 'send_later', ['id' => 'send_later']),
-    ];
-    $this->addGroup($sendOptions, 'send_option', '', '<br>');
+    $this->addRadio('send_option', '', [
+      'send_immediate' => ts('Send immediately'),
+      'send_later' => ts('Send at:'),
+    ], [], '<br>', FALSE, [
+      'send_immediate' => ['id' => 'send_immediate', 'style' => 'margin-bottom: 10px;'],
+      'send_later' => ['id' => 'send_later'],
+    ]);
 
     $this->add('datepicker', 'start_date', '', NULL, FALSE, ['minDate' => time()]);
 

--- a/CRM/UF/Form/AdvanceSetting.php
+++ b/CRM/UF/Form/AdvanceSetting.php
@@ -32,12 +32,7 @@ class CRM_UF_Form_AdvanceSetting extends CRM_UF_Form_Group {
     $form->addElement('checkbox', 'is_map', ts('Enable mapping for this profile?'));
 
     // should we allow updates on a exisitng contact
-    $options = [];
-    $options[] = $form->createElement('radio', NULL, NULL, ts('Issue warning and do not save'), 0);
-    $options[] = $form->createElement('radio', NULL, NULL, ts('Update the matching contact'), 1);
-    $options[] = $form->createElement('radio', NULL, NULL, ts('Allow duplicate contact to be created'), 2);
-
-    $form->addGroup($options, 'is_update_dupe', ts('What to do upon duplicate match'));
+    $form->addRadio('is_update_dupe', ts('What to do upon duplicate match'), [ts('Issue warning and do not save'), ts('Update the matching contact'), ts('Allow duplicate contact to be created')]);
     // we do not have any url checks to allow relative urls
     $form->addElement('text', 'post_URL', ts('Redirect URL'), CRM_Core_DAO::getAttribute('CRM_Core_DAO_UFGroup', 'post_URL'));
 
@@ -71,20 +66,10 @@ class CRM_UF_Form_AdvanceSetting extends CRM_UF_Form_Group {
       $form->_cmsId = TRUE;
     }
 
-    $options = [];
-    $options[] = $form->createElement('radio', NULL, NULL, ts('No account create option'), 0);
-    $options[] = $form->createElement('radio', NULL, NULL, ts('Give option, but not required'), 1);
-    $options[] = $form->createElement('radio', NULL, NULL, ts('Account creation required'), 2);
-
-    $form->addGroup($options, 'is_cms_user', ts('%1 user account registration option?', [1 => $config->userFramework]));
+    $form->addRadio('is_cms_user', ts('%1 user account registration option?', [1 => $config->userFramework]), [ts('No account create option'), ts('Give option, but not required'), ts('Account creation required')]);
 
     // options for including Proximity Search in the profile search form
-    $proxOptions = [];
-    $proxOptions[] = $form->createElement('radio', NULL, NULL, ts('None'), 0);
-    $proxOptions[] = $form->createElement('radio', NULL, NULL, ts('Optional'), 1);
-    $proxOptions[] = $form->createElement('radio', NULL, NULL, ts('Required'), 2);
-
-    $form->addGroup($proxOptions, 'is_proximity_search', ts('Proximity Search'));
+    $form->addRadio('is_proximity_search', ts('Proximity Search'), [ts('None'), ts('Optional'), ts('Required')]);
   }
 
 }


### PR DESCRIPTION
…or a number of radio elements

Overview
----------------------------------------
This refactors a number of calls to createElement for adding radio elements on forms to use the CiviCRM Core method CRM_Core_Form::addRadio

Before
----------------------------------------
Multiple instances of going straight to quickform by-passing the CRM_Core_Form::addRadio

After
----------------------------------------
CRM_Core_Form::addRadio used

ping @demeritcowboy @eileenmcnaughton 