### PR TITLE
dev/core#1899 specify display mode for action links with icons

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -1321,7 +1321,8 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution {
           FALSE,
           'Payment.edit.action',
           'Payment',
-          $resultDAO->id
+          $resultDAO->id,
+          'icon'
         );
       }
 

--- a/CRM/Core/Action.php
+++ b/CRM/Core/Action.php
@@ -178,6 +178,12 @@ class CRM_Core_Action {
    * @param null $op
    * @param null $objectName
    * @param int $objectId
+   * @param string $iconMode
+   *   - `text`: even if `icon` is set for a link, display the `name`
+   *   - `icon`: display only the `icon` for each link if it's available, and
+   *     don't tuck anything under "more >"
+   *   - `both`: if `icon` is available, display it next to the `name` for each
+   *     link
    *
    * @return string
    *   the html string
@@ -190,7 +196,8 @@ class CRM_Core_Action {
     $enclosedAllInSingleUL = FALSE,
     $op = NULL,
     $objectName = NULL,
-    $objectId = NULL
+    $objectId = NULL,
+    $iconMode = 'text'
   ) {
     if (empty($links)) {
       return NULL;
@@ -243,11 +250,22 @@ class CRM_Core_Action {
         if (strpos($urlPath, '/delete') || strpos($urlPath, 'action=delete')) {
           $classes .= " small-popup";
         }
+
+        $linkContent = $link['name'];
+        if (!empty($link['icon'])) {
+          if ($iconMode == 'icon') {
+            $linkContent = CRM_Core_Page::crmIcon($link['icon'], $link['name'], TRUE, ['title' => '']);
+          }
+          elseif ($iconMode == 'both') {
+            $linkContent = CRM_Core_Page::crmIcon($link['icon']) . ' ' . $linkContent;
+          }
+        }
+
         $url[] = sprintf('<a href="%s" class="%s" %s' . $extra . '>%s</a>',
           $urlPath,
           $classes,
           !empty($link['title']) ? "title='{$link['title']}' " : '',
-          empty($link['icon']) ? $link['name'] : CRM_Core_Page::crmIcon($link['icon'], $link['name'], TRUE, ['title' => ''])
+          $linkContent
         );
       }
     }
@@ -261,11 +279,13 @@ class CRM_Core_Action {
     }
     else {
       $extra = '';
-      $extraLinks = array_splice($url, 2);
-      if (count($extraLinks) > 1) {
-        $mainLinks = array_slice($url, 0, 2);
-        CRM_Utils_String::append($extra, '</li><li>', $extraLinks);
-        $extra = "{$extraULName}<ul class='panel'><li>{$extra}</li></ul>";
+      if ($iconMode != 'icon') {
+        $extraLinks = array_splice($url, 2);
+        if (count($extraLinks) > 1) {
+          $mainLinks = array_slice($url, 0, 2);
+          CRM_Utils_String::append($extra, '</li><li>', $extraLinks);
+          $extra = "{$extraULName}<ul class='panel'><li>{$extra}</li></ul>";
+        }
       }
       $resultLinks = '';
       CRM_Utils_String::append($resultLinks, '', $mainLinks);


### PR DESCRIPTION
Overview
----------------------------------------
Changes in #17319 allow action links to be specified with `icon` to display the icon only instead of the link text.  However, case activity action links have icons specified dating back to #14349 because they serve double-duty as specifying the buttons when viewing a single activity.  This is a nice pattern to follow elsewhere in the future, but the result is that it forced the action links to render as icons only.

This allows the `$iconMode` to be set in `CRM_Core_Action::formLink()` in order to decide whether to display each action link as an icon (if specified), text, or both.

Before
----------------------------------------
Activity listing when viewing a case:
![image](https://user-images.githubusercontent.com/1682375/88352099-99bd6900-cd26-11ea-84ef-b2a3de1e9bf9.png)


After
----------------------------------------
![image](https://user-images.githubusercontent.com/1682375/88352157-d4bf9c80-cd26-11ea-8b27-0a36d3cb90fe.png)

Technical Details
----------------------------------------
I set it so `icon` mode doesn't stash extra items under the "more >" both since there's more real estate and it just looks stupid.  The screenshot below is what the same activity listing would appear as if it were in `icon` mode now (though *it is not set this way as submitted*):

![image](https://user-images.githubusercontent.com/1682375/88352083-89a58980-cd26-11ea-87cd-e10f76eaae77.png)

Note that `icon` mode displays the text if there is no icon specified.

Comments
----------------------------------------
The only place where the links are displayed as icons is the edit payment link (a pencil) when viewing a contribution.
