### PR TITLE
Deprecate error handling bypasses, $daoName from executeQuery

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -1515,10 +1515,12 @@ FROM   civicrm_domain
       $dao = new CRM_Core_DAO();
     }
     else {
+      CRM_Core_Error::deprecatedFunctionWarning('passing in DAOName is deprecated');
       $dao = new $daoName();
     }
 
     if ($trapException) {
+      CRM_Core_Error::deprecatedFunctionWarning('calling functions should handle exceptions');
       $errorScope = CRM_Core_TemporaryErrorScope::ignoreException();
     }
 
@@ -1622,6 +1624,9 @@ FROM   civicrm_domain
    * @throws CRM_Core_Exception
    */
   public static function composeQuery($query, $params = [], $abort = TRUE) {
+    if (!$abort) {
+      CRM_Core_Error::deprecatedFunctionWarning('calling functions should not bypass error handling');
+    }
     $tr = [];
     foreach ($params as $key => $item) {
       if (is_numeric($key)) {

--- a/tests/phpunit/CRM/Contact/BAO/ContactType/ContactTypeTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/ContactType/ContactTypeTest.php
@@ -66,19 +66,24 @@ class CRM_Contact_BAO_ContactType_ContactTypeTest extends CiviUnitTestCase {
     // check for type:Individual
     $result = CRM_Contact_BAO_ContactType::subTypes('Individual');
     $this->assertEquals(array_keys($this->getExpectedContactSubTypes('Individual')), $result);
+    $this->assertEquals($this->getExpectedContactSubTypes('Individual'), CRM_Contact_BAO_ContactType::subTypeInfo('Individual'));
 
     // check for type:Organization
     $result = CRM_Contact_BAO_ContactType::subTypes('Organization');
     $this->assertEquals(array_keys($this->getExpectedContactSubTypes('Organization')), $result);
+    $this->assertEquals($this->getExpectedContactSubTypes('Organization'), CRM_Contact_BAO_ContactType::subTypeInfo('Organization'));
 
     // check for type:Household
     $result = CRM_Contact_BAO_ContactType::subTypes('Household');
     $this->assertEquals(array_keys($this->getExpectedContactSubTypes('Household')), $result);
+    $this->assertEquals($this->getExpectedContactSubTypes('Household'), CRM_Contact_BAO_ContactType::subTypeInfo('Household'));
 
     // check for all contact types
     $result = CRM_Contact_BAO_ContactType::subTypes();
     $subtypes = array_keys($this->getExpectedAllSubtypes());
     $this->assertEquals(sort($subtypes), sort($result));
+    $this->assertEquals($this->getExpectedAllSubtypes(), CRM_Contact_BAO_ContactType::subTypeInfo());
+
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
This adds deprecation notices for some legacy & hopefully now unused parameters in DAO::executeQuery

Before
----------------------------------------
Params $abort, $daoName, $trapException are silently silly

After
----------------------------------------
Params $abort, $daoName, $trapException are noisily silly

Technical Details
----------------------------------------
I think once https://github.com/civicrm/civicrm-core/pull/17934 is merged there should be no remaining places that are tested & hit these

Comments
----------------------------------------
