### PR TITLE
Remove extraneous opportunistic cache flush.

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -2053,8 +2053,6 @@ ORDER BY civicrm_email.is_primary DESC";
       CRM_Contact_BAO_GroupContact::addContactsToGroup($contactIds, $addToGroupID);
     }
 
-    CRM_Contact_BAO_GroupContactCache::opportunisticCacheFlush();
-
     if ($editHook) {
       CRM_Utils_Hook::post('edit', 'Profile', $contactID, $params);
     }


### PR DESCRIPTION


Overview
----------------------------------------
Removes a cache flush line that is not required as it has only just been flushed a few lines earlierr

Before
----------------------------------------
``` CRM_Contact_BAO_GroupContactCache::opportunisticCacheFlush();```

After
----------------------------------------
poof

Technical Details
----------------------------------------
The opportunistic cache flush is already called by contact create and then again by each of the places
where the contact might be added to a group so this is just extraneous

Comments
----------------------------------------
@demeritcowboy this is what I mentioned on the dedupe one
