### PR TITLE
Fix JQuery Validation for radios

### DIFF
--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -366,6 +366,9 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
     $type, $name, $label = '',
     $attributes = '', $required = FALSE, $extra = NULL
   ) {
+    if ($type === 'radio') {
+      CRM_Core_Error::deprecatedFunctionWarning('CRM_Core_Form::addRadio');
+    }
     // Fudge some extra types that quickform doesn't support
     $inputType = $type;
     if ($type == 'wysiwyg' || in_array($type, self::$html5Types)) {
@@ -1202,7 +1205,11 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
           }
         }
       }
-      $options[] = $this->createElement('radio', NULL, NULL, $var, $key, $optAttributes);
+      $element = $this->createElement('radio', NULL, NULL, $var, $key, $optAttributes);
+      if ($required) {
+        $element->setAttribute('required', TRUE);
+      }
+      $options[] = $element;
     }
     $group = $this->addGroup($options, $name, $title, $separator);
 

--- a/js/Common.js
+++ b/js/Common.js
@@ -883,7 +883,7 @@ if (!CRM.vars) CRM.vars = {};
       var that = this;
       validator.settings = $.extend({}, validator.settings, CRM.validate._defaults, CRM.validate.params);
       // Call our custom validation handler.
-      $(validator.currentForm).on("invalid-form.validate", validator.settings.invalidHandler );
+      $(validator.currentForm).on("invalid-form.validate", validator.settings.invalidHandler);
       // Call any post-initialization callbacks
       if (CRM.validate.functions && CRM.validate.functions.length) {
         $.each(CRM.validate.functions, function(i, func) {

--- a/templates/CRM/common/l10n.js.tpl
+++ b/templates/CRM/common/l10n.js.tpl
@@ -96,7 +96,15 @@
     errorClass: 'crm-inline-error alert-danger',
     messages: {},
     ignore: '.select2-offscreen, [readonly], :hidden:not(.crm-select2), .crm-no-validate',
-    ignoreTitle: true
+    ignoreTitle: true,
+    errorPlacement: function(error, element) {
+      if (element.prop('type') === 'radio') {
+        error.appendTo(element.parent('div.content'));
+      }
+      else {
+        error.insertAfter(element);
+      }
+    }
   };
 
   // use civicrm notifications when there are errors


### PR DESCRIPTION
Overview
----------------------------------------
This fixes the jQuery validation for radio html objects by ensuring that the required attribute is properly set on radio html objects and that the error message is correctly placed

Before
----------------------------------------
1. Create a profile that includes the gender field as a required field
2. Set that profile to be used on a contribution page
3. Navigate to the live contribution page
4. Open up the console and enter in `CRM.$('#Main').valid();`
5. Note that in the console you get a message about it being invalid but note there is no visual display that the gender is a required field

After
----------------------------------------
Repeat Steps 1-4 as above but in step 5 you should find that for the radio field there is a new message that it is a required field sitting next to the radios

ping @demeritcowboy @mattwire @colemanw 