### PR TITLE
Remove error checking by-pass in tests

### DIFF
--- a/Civi/Test/DbTestTrait.php
+++ b/Civi/Test/DbTestTrait.php
@@ -184,7 +184,7 @@ trait DbTestTrait {
     $actual = \CRM_Core_DAO::singleValueQuery($query, $params);
     $this->assertEquals($expected, $actual,
       sprintf('%sexpected=[%s] actual=[%s] query=[%s]',
-        $message, $expected, $actual, \CRM_Core_DAO::composeQuery($query, $params, FALSE)
+        $message, $expected, $actual, \CRM_Core_DAO::composeQuery($query, $params)
       )
     );
   }


### PR DESCRIPTION
Overview
----------------------------------------
Stop passing $abort to executeQuery within test - this parameter allows validation to be bypassed

Before
----------------------------------------
$abort = FALSE

After
----------------------------------------
$abort =TRUE

Technical Details
----------------------------------------
I think the param just exists because it's old code

Comments
----------------------------------------

