### PR TITLE
[Ref] Simplify field reference

### DIFF
--- a/CRM/Export/BAO/ExportProcessor.php
+++ b/CRM/Export/BAO/ExportProcessor.php
@@ -1146,32 +1146,31 @@ class CRM_Export_BAO_ExportProcessor {
             return $i18n->crm_translate($fieldValue);
 
           default:
-            if (isset($metadata[$field])) {
-              // No I don't know why we do it this way & whether we could
-              // make better use of pseudoConstants.
-              if (!empty($metadata[$field]['context'])) {
-                return $i18n->crm_translate($fieldValue, $metadata[$field]);
-              }
-              if (!empty($metadata[$field]['pseudoconstant'])) {
-                if (!empty($metadata[$field]['bao'])) {
-                  return CRM_Core_PseudoConstant::getLabel($metadata[$field]['bao'], $metadata[$field]['name'], $fieldValue);
-                }
-                // This is not our normal syntax for pseudoconstants but I am a bit loath to
-                // call an external function until sure it is not increasing php processing given this
-                // may be iterated 100,000 times & we already have the $imProvider var loaded.
-                // That can be next refactor...
-                // Yes - definitely feeling hatred for this bit of code - I know you will beat me up over it's awfulness
-                // but I have to reach a stable point....
-                $varName = $metadata[$field]['pseudoconstant']['var'];
-                if ($varName === 'imProviders') {
-                  return CRM_Core_PseudoConstant::getLabel('CRM_Core_DAO_IM', 'provider_id', $fieldValue);
-                }
-                if ($varName === 'phoneTypes') {
-                  return CRM_Core_PseudoConstant::getLabel('CRM_Core_DAO_Phone', 'phone_type_id', $fieldValue);
-                }
-              }
-
+            $fieldSpec = $metadata[$field] ?? [];
+            // No I don't know why we do it this way & whether we could
+            // make better use of pseudoConstants.
+            if (!empty($fieldSpec['context'])) {
+              return $i18n->crm_translate($fieldValue, $fieldSpec);
             }
+            if (!empty($fieldSpec['pseudoconstant'])) {
+              if (!empty($fieldSpec['bao'])) {
+                return CRM_Core_PseudoConstant::getLabel($fieldSpec['bao'], $fieldSpec['name'], $fieldValue);
+              }
+              // This is not our normal syntax for pseudoconstants but I am a bit loath to
+              // call an external function until sure it is not increasing php processing given this
+              // may be iterated 100,000 times & we already have the $imProvider var loaded.
+              // That can be next refactor...
+              // Yes - definitely feeling hatred for this bit of code - I know you will beat me up over it's awfulness
+              // but I have to reach a stable point....
+              $varName = $fieldSpec['pseudoconstant']['var'];
+              if ($varName === 'imProviders') {
+                return CRM_Core_PseudoConstant::getLabel('CRM_Core_DAO_IM', 'provider_id', $fieldValue);
+              }
+              if ($varName === 'phoneTypes') {
+                return CRM_Core_PseudoConstant::getLabel('CRM_Core_DAO_Phone', 'phone_type_id', $fieldValue);
+              }
+            }
+
             return $fieldValue;
         }
       }


### PR DESCRIPTION
Overview
----------------------------------------
Minor code simplification - This removes an IF block - hence the code noise - 

Before
----------------------------------------
```if (isset($metadata[$field])) {````

After
----------------------------------------
If gone - metadata[$field] set per ``` $fieldSpec = $metadata[$field] ?? [];```

Technical Details
----------------------------------------
Better to read with w=1 since it's mostly just indentationn

Comments
----------------------------------------

