### PR TITLE
dev/core#1905 Add configure icons on public pages

### DIFF
--- a/CRM/Event/Form/Registration/Register.php
+++ b/CRM/Event/Form/Registration/Register.php
@@ -629,6 +629,7 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
           }
         }
       }
+      $form->_priceSet['id'] = $form->_priceSet['id'] ?? $form->_priceSetId;
       $form->assign('priceSet', $form->_priceSet);
     }
     else {

--- a/CRM/Price/BAO/PriceSet.php
+++ b/CRM/Price/BAO/PriceSet.php
@@ -860,6 +860,7 @@ WHERE  id = %1";
         }
       }
     }
+    $form->_priceSet['id'] = $form->_priceSet['id'] ?? $priceSetId;
     $form->assign('priceSet', $form->_priceSet);
 
     $component = 'contribution';

--- a/templates/CRM/Contribute/Form/Contribution/Main.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Main.tpl
@@ -56,6 +56,11 @@
     </div>
   {/if}
 
+  {if call_user_func(array('CRM_Core_Permission','check'), 'administer CiviCRM') }
+    {capture assign="configureURL"}{crmURL p="civicrm/admin/contribute/settings" q="reset=1&action=update&id=`$contributionPageID`"}{/capture}
+    {ts 1=$configureURL}<a class="button " target="_blank" href=%1><i aria-hidden="true" title="Configure Contribution Page" class="crm-i fa-wrench"></i> Configure</a>{/ts}
+    <div class='clear'></div>
+  {/if}
   {include file="CRM/common/TrackingFields.tpl"}
 
   <div class="crm-contribution-page-id-{$contributionPageID} crm-block crm-contribution-main-form-block">

--- a/templates/CRM/Event/Form/Registration/Register.tpl
+++ b/templates/CRM/Event/Form/Registration/Register.tpl
@@ -7,6 +7,11 @@
  | and copyright information, see https://civicrm.org/licensing       |
  +--------------------------------------------------------------------+
 *}
+{if call_user_func(array('CRM_Core_Permission','check'), 'administer CiviCRM') }
+  {capture assign="configureURL"}{crmURL p="civicrm/event/manage/settings" q="reset=1&action=update&id=`$event.id`"}{/capture}
+  {ts 1=$configureURL}<a class="button " target="_blank" href=%1><i aria-hidden="true" title="Configure Event" class="crm-i fa-wrench"></i> Configure</a>{/ts}
+  <div class='clear'></div>
+{/if}
 {* Callback snippet: Load payment processor *}
   {if $action & 1024}
     {include file="CRM/Event/Form/Registration/PreviewHeader.tpl"}

--- a/templates/CRM/Price/Form/PriceSet.tpl
+++ b/templates/CRM/Price/Form/PriceSet.tpl
@@ -16,6 +16,14 @@
     {assign var='adminFld' value=false}
     {if call_user_func(array('CRM_Core_Permission','check'), 'administer CiviCRM') }
       {assign var='adminFld' value=true}
+      {if $priceSet.id && !$priceSet.is_quick_config}
+        {capture assign="priceSetURL"}{crmURL p="civicrm/admin/price/field" q="reset=1&action=browse&sid=`$priceSet.id`"}{/capture}
+        <div class='float-right'>
+          {ts 1=$priceSetURL}<a class="crm-hover-button" target="_blank" href=%1>
+            <i aria-hidden="true" title="Edit Priceset" class="crm-i fa-wrench"></i>
+          </a>{/ts}
+        </div>
+      {/if}
     {/if}
 
     {foreach from=$priceSet.fields item=element key=field_id}


### PR DESCRIPTION
Overview
----------------------------------------
Add configure and priceset url icons on public contribution & event pages

Before
----------------------------------------
No Option to directly navigate to the configuration page or the priceset page used on the event or contribution

After
----------------------------------------
Configure and priceset icon is displayed on contribution and event pages.

<img width="818" alt="Screenshot 2020-07-24 at 7 02 26 PM" src="https://user-images.githubusercontent.com/5929648/88396545-4f002780-cde0-11ea-8b78-effdf39577ed.png">

Similarly for events.

![image](https://user-images.githubusercontent.com/5929648/88396064-a4880480-cddf-11ea-9f09-857a7ca54978.png)

<img width="787" alt="Screenshot 2020-07-24 at 6 58 36 PM" src="https://user-images.githubusercontent.com/5929648/88396214-d7ca9380-cddf-11ea-8d52-7431a7c27e77.png">


Comments
----------------------------------------
Gitlab - https://lab.civicrm.org/dev/core/-/issues/1905