### PR TITLE
dev/core#1906 - Allow payment create api to record payment on Failed …

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -3924,6 +3924,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
       'Refunded' => ['Cancelled', 'Completed'],
       'Partially paid' => ['Completed'],
       'Pending refund' => ['Completed', 'Refunded'],
+      'Failed' => ['Pending'],
     ];
 
     if (!in_array($contributionStatuses[$fields['contribution_status_id']],


### PR DESCRIPTION
…Contributions

Overview
----------------------------------------
Allow payment create api to record payment on Failed Contribution.

Before
----------------------------------------

from https://chat.civicrm.org/civicrm/pl/iqwg9chm4pgq9gd57sb3q5h49y
Example workflow / use-case:

1. Contribution is created in pending (eg. Recurring contribution using Stripe via contribution page and card number: 4000000000000341 - see https://stripe.com/docs/testing#cards-responses).
2. IPN returns "Failed" and API3 Contribution.create is called with status=Failed.
3. Later an IPN returns "Success" and API3 Payment.create is called with status=Completed.

Currently, step 3 fails because Failed->Completed is not allowed for contributions.

After
----------------------------------------
Payment create api can be called on Failed contribution.  

Technical Details
----------------------------------------
The payment create on Failed contribution is done as Failed -> Pending -> Completed. This inserts 2 rows in financial transaction table. 

1. From=NULL to=account_receivable with is_payment=0.

The next insertion is handled in the same way as a normal Pending -> Completed transaction is done. This also includes if the `payment` create is done in partial payments.

Thoughts/Discussion? @eileenmcnaughton @mattwire @seamuslee001 

Comments
----------------------------------------
Gitlab - https://lab.civicrm.org/dev/core/-/issues/1906