### PR TITLE
CRM_Utils_Check_Component_Case - Guard against post-upgrade crash

### DIFF
--- a/CRM/Utils/Check/Component/Case.php
+++ b/CRM/Utils/Check/Component/Case.php
@@ -342,7 +342,7 @@ class CRM_Utils_Check_Component_Case extends CRM_Utils_Check_Component {
       + array_column($relationshipTypes, 'id', 'label_b_a');
     $missing = [];
     foreach ($caseTypes as $caseType) {
-      foreach ($caseType['definition']['caseRoles'] as $role) {
+      foreach ($caseType['definition']['caseRoles'] ?? [] as $role) {
         if (!isset($allConfigured[$role['name']])) {
           $missing[$role['name']] = $role['name'];
         }


### PR DESCRIPTION
Overview
----------------------------------------
This fixes a crash I noticed immediately after an upgrade from 4.6 => 5.27.

Before
----------------------------------------
Cannot view site post-upgrade, crashes with fatal error.

After
----------------------------------------
Works normally.
