### PR TITLE
Upgrade PEAR/mail_mime package to be compliant with PHP7.4 and deploy it using composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -77,7 +77,8 @@
     "xkerman/restricted-unserialize": "~1.1",
     "typo3/phar-stream-wrapper": "^2 || ^3.0",
     "brick/money": "~0.4",
-    "ext-intl": "*"
+    "ext-intl": "*",
+    "pear/mail_mime": "~1.10"
   },
   "scripts": {
     "post-install-cmd": [
@@ -252,6 +253,9 @@
       },
       "pear/mail": {
         "Apply CiviCRM Customisations for CRM-1367 and CRM-5946": "https://raw.githubusercontent.com/civicrm/civicrm-core/36319938a5bf26c1e7e2110a26a65db6a5979268/tools/scripts/composer/patches/pear-mail.patch"
+      },
+      "pear/mail_mime": {
+        "Apply patch for CRM-3133 wordwrap body to be 750 characters to apply with RFC 2821": "https://raw.githubusercontent.com/civicrm/civicrm-core/74e25f27bb3be32519657539afe8a285c6c99a08/tools/scripts/composer/patches/mail_mime_crm_3133.patch"
       },
       "pear/net_smtp": {
         "Add in CiviCRM custom error message for CRM-8744": "https://raw.githubusercontent.com/civicrm/civicrm-core/a6a0ff13d2a155ad962529595dceaef728116f96/tools/scripts/composer/patches/net-smtp-patch.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e0a0679ca623418ab9273d71dee6f5cd",
+    "content-hash": "1ff9c045fb03756148c0c66562aa61fd",
     "packages": [
         {
             "name": "adrienrn/php-mimetyper",
@@ -1113,6 +1113,57 @@
             "description": "Class that provides multiple interfaces for sending emails.",
             "homepage": "http://pear.php.net/package/Mail",
             "time": "2017-04-11T17:27:29+00:00"
+        },
+        {
+            "name": "pear/mail_mime",
+            "version": "1.10.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pear/Mail_Mime.git",
+                "reference": "1e7ae4e5258b6c0d385a8e76add567934245d38d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pear/Mail_Mime/zipball/1e7ae4e5258b6c0d385a8e76add567934245d38d",
+                "reference": "1e7ae4e5258b6c0d385a8e76add567934245d38d",
+                "shasum": ""
+            },
+            "require": {
+                "pear/pear-core-minimal": "*"
+            },
+            "type": "library",
+            "extra": {
+                "patches_applied": {
+                    "Apply patch for CRM-3133 wordwrap body to be 750 characters to apply with RFC 2821": "https://raw.githubusercontent.com/civicrm/civicrm-core/74e25f27bb3be32519657539afe8a285c6c99a08/tools/scripts/composer/patches/mail_mime_crm_3133.patch"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Mail": "./"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "include-path": [
+                "./"
+            ],
+            "license": [
+                "BSD-3-clause"
+            ],
+            "authors": [
+                {
+                    "name": "Cipriano Groenendal",
+                    "email": "cipri@php.net",
+                    "role": "Lead"
+                },
+                {
+                    "name": "Aleksander Machniak",
+                    "email": "alec@php.net",
+                    "role": "Lead"
+                }
+            ],
+            "description": "Mail_Mime provides classes to create MIME messages",
+            "homepage": "http://pear.php.net/package/Mail_Mime",
+            "time": "2020-06-27T08:35:27+00:00"
         },
         {
             "name": "pear/net_smtp",


### PR DESCRIPTION
Overview
----------------------------------------
This upgrades the Pear/mail_mime version from 1.10.2 to 1.10.9 the change logs are [1.10.9](https://pear.php.net/package/Mail_Mime/download/), [1.10.8](https://pear.php.net/package/Mail_Mime/download/1.10.8), [1.10.7](https://pear.php.net/package/Mail_Mime/download/1.10.7), [1.10.6](https://pear.php.net/package/Mail_Mime/download/1.10.6), [1.10.5](https://pear.php.net/package/Mail_Mime/download/1.10.5), [1.10.4](https://pear.php.net/package/Mail_Mime/download/1.10.4), [1.10.3](https://pear.php.net/package/Mail_Mime/download/1.10.3)

Nothing jumps out at me as being problematic and also there is a unit test that failed on PHP7.4 https://test.civicrm.org/job/CiviCRM-Core-Edge/CIVIVER=master,label=test-3/lastCompletedBuild/testReport/(root)/api_v3_JobTest/testMailReportForCsv/

Before
----------------------------------------
Test fails on PHP7.4 

After
----------------------------------------
Test passes on PHP7.4 