### PR TITLE
dev/core#1895 fix first/last name adv search

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -1742,7 +1742,7 @@ class CRM_Contact_BAO_Query {
     }
 
     if (!$likeNames) {
-      $likeNames = ['sort_name', 'email', 'note', 'display_name'];
+      $likeNames = ['sort_name', 'first_name', 'last_name', 'email', 'note', 'display_name'];
     }
 
     // email comes in via advanced search

--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -1742,7 +1742,7 @@ class CRM_Contact_BAO_Query {
     }
 
     if (!$likeNames) {
-      $likeNames = ['sort_name', 'first_name', 'last_name', 'email', 'note', 'display_name'];
+      $likeNames = ['sort_name', 'email', 'note', 'display_name'];
     }
 
     // email comes in via advanced search

--- a/CRM/Contact/Form/Search/Criteria.php
+++ b/CRM/Contact/Form/Search/Criteria.php
@@ -28,6 +28,9 @@ class CRM_Contact_Form_Search_Criteria {
     self::setBasicSearchFields($form);
     $form->addElement('hidden', 'hidden_basic', 1);
 
+    $form->add('text', 'first_name', ts('First Name'), CRM_Core_DAO::getAttribute('CRM_Contact_DAO_Contact', 'first_name'));
+    $form->add('text', 'last_name', ts('Last Name'), CRM_Core_DAO::getAttribute('CRM_Contact_DAO_Contact', 'last_name'));
+
     if ($form->_searchOptions['contactType']) {
       $contactTypes = CRM_Contact_BAO_ContactType::getSelectElements();
 
@@ -249,8 +252,6 @@ class CRM_Contact_Form_Search_Criteria {
         'template_grouping' => 'basic',
         'template' => 'CRM/Contact/Form/Search/Criteria/Fields/sort_name.tpl',
       ],
-      'first_name' => ['template_grouping' => 'basic'],
-      'last_name' => ['template_grouping' => 'basic'],
       'email' => ['title' => ts('Complete OR Partial Email'), 'entity' => 'Email', 'template_grouping' => 'basic'],
       'contact_tags' => ['name' => 'contact_tags', 'type' => CRM_Utils_Type::T_INT, 'is_pseudofield' => TRUE, 'template_grouping' => 'basic'],
       'created_date' => ['name' => 'created_date', 'template_grouping' => 'changeLog'],

--- a/CRM/Contact/Form/Search/Criteria.php
+++ b/CRM/Contact/Form/Search/Criteria.php
@@ -28,9 +28,6 @@ class CRM_Contact_Form_Search_Criteria {
     self::setBasicSearchFields($form);
     $form->addElement('hidden', 'hidden_basic', 1);
 
-    $form->add('text', 'first_name', ts('First Name'), CRM_Core_DAO::getAttribute('CRM_Contact_DAO_Contact', 'first_name'));
-    $form->add('text', 'last_name', ts('Last Name'), CRM_Core_DAO::getAttribute('CRM_Contact_DAO_Contact', 'last_name'));
-
     if ($form->_searchOptions['contactType']) {
       $contactTypes = CRM_Contact_BAO_ContactType::getSelectElements();
 
@@ -252,6 +249,8 @@ class CRM_Contact_Form_Search_Criteria {
         'template_grouping' => 'basic',
         'template' => 'CRM/Contact/Form/Search/Criteria/Fields/sort_name.tpl',
       ],
+      'first_name' => ['template_grouping' => 'basic'],
+      'last_name' => ['template_grouping' => 'basic'],
       'email' => ['title' => ts('Complete OR Partial Email'), 'entity' => 'Email', 'template_grouping' => 'basic'],
       'contact_tags' => ['name' => 'contact_tags', 'type' => CRM_Utils_Type::T_INT, 'is_pseudofield' => TRUE, 'template_grouping' => 'basic'],
       'created_date' => ['name' => 'created_date', 'template_grouping' => 'changeLog'],
@@ -324,6 +323,8 @@ class CRM_Contact_Form_Search_Criteria {
     return [
       // For now an empty array is still left in place for ordering.
       'sort_name' => [],
+      'first_name' => [],
+      'last_name' => [],
       'email' => ['name' => 'email'],
       'contact_type' => ['name' => 'contact_type'],
       'group' => [

--- a/templates/CRM/Contact/Form/Search/Criteria/Basic.tpl
+++ b/templates/CRM/Contact/Form/Search/Criteria/Basic.tpl
@@ -10,7 +10,7 @@
 <div class="advanced-search-fields basic-fields form-layout">
   {foreach from=$basicSearchFields item=fieldSpec}
     {assign var=field value=$form[$fieldSpec.name]}
-    {if $field}
+    {if $field && !in_array($fieldSpec.name, array('first_name', 'last_name'))}
       <div class="search-field {$fieldSpec.class|escape}">
         {if $fieldSpec.template}
           {include file=$fieldSpec.template}

--- a/templates/CRM/Contact/Form/Search/Criteria/Fields/sort_name.tpl
+++ b/templates/CRM/Contact/Form/Search/Criteria/Fields/sort_name.tpl
@@ -11,16 +11,16 @@
   <script type="text/javascript">
     CRM.$(function($) {
       function showIndivFldsSearch() {
-        $('#sortnameselect').hide();
-        $('#indivfldselect').show();
+        $('#sortnameselect').css('visibility', 'hidden').css('position','absolute');
+        $('#indivfldselect').css('visibility', 'visible').css('position','static');
         $('#sort_name').val('');
         $('#first_name').removeClass('big').addClass('eight');
         $('#last_name').removeClass('big').addClass('eight');
         return false;
       }
       function showSortNameSearch() {
-        $('#indivfldselect').hide();
-        $('#sortnameselect').show();
+        $('#indivfldselect').css('visibility', 'hidden').css('position','absolute');
+        $('#sortnameselect').css('visibility', 'visible').css('position','static');
         $('#first_name').val('');
         $('#last_name').val('');
         return false;


### PR DESCRIPTION
Overview
----------------------------------------
The ability to search first/last name was recently added to core. The primary intent was to properly handle advanced searches that originate from quicksearch first/last name filters. While that was working, a first/last name search that originated directly from an advanced search was not working. This fixes the issue.

Before
----------------------------------------
Go to advanced search, expose the first/last name fields, enter criteria and initiate the search. Result = all records returned and the filter value was not preserved.

After
----------------------------------------
Conduct search and it returns results as expected.

Technical Details
----------------------------------------
There were a couple issues with the original patch that needed to be addressed. The first/last name fields needed to be constructed in the form explicitly, rather than through the metadata function, as they were not handled properly by the form via the previous method. And the js that toggles between the sort_name and first_name/last_name fields needed to use a method other than show()/hide() as the resulting display:none meant that the form values were lost on reload. 