### PR TITLE
[REF] Simplify location metadata handling in Export class

### DIFF
--- a/CRM/Export/BAO/Export.php
+++ b/CRM/Export/BAO/Export.php
@@ -132,7 +132,7 @@ INSERT INTO {$componentTable} SELECT distinct gc.contact_id FROM civicrm_group_c
 
     $addPaymentHeader = FALSE;
 
-    list($outputColumns, $metadata) = $processor->getExportStructureArrays();
+    list($outputColumns) = $processor->getExportStructureArrays();
 
     if ($processor->isMergeSameAddress()) {
       foreach (array_keys($processor->getAdditionalFieldsForSameAddressMerge()) as $field) {
@@ -185,7 +185,7 @@ INSERT INTO {$componentTable} SELECT distinct gc.contact_id FROM civicrm_group_c
       while ($iterationDAO->fetch()) {
         $count++;
         $rowsThisIteration++;
-        $row = $processor->buildRow($query, $iterationDAO, $outputColumns, $metadata, $paymentDetails, $addPaymentHeader);
+        $row = $processor->buildRow($query, $iterationDAO, $outputColumns, $paymentDetails, $addPaymentHeader);
         if ($row === FALSE) {
           continue;
         }

--- a/tests/phpunit/CRM/Export/BAO/ExportTest.php
+++ b/tests/phpunit/CRM/Export/BAO/ExportTest.php
@@ -279,7 +279,7 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
       'Phone Extension' => '',
       'Phone Type' => '',
       'Email' => 'home@example.com',
-      'On Hold' => '',
+      'On Hold' => 'No',
       'Use for Bulk Mail' => '',
       'Signature Text' => '',
       'Signature Html' => '',
@@ -1089,7 +1089,7 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
       'Phone Extension' => '',
       'Phone Type' => '',
       'Email' => 'home@example.com',
-      'On Hold' => '',
+      'On Hold' => 'No',
       'Use for Bulk Mail' => '',
       'Signature Text' => '',
       'Signature Html' => '',
@@ -2896,7 +2896,7 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
         $this->assertContains($row[$key], $alternatives[$key]);
       }
       else {
-        $this->assertEquals($value, $row[$key]);
+        $this->assertEquals($value, $row[$key], 'mismatch on ' . $key);
       }
     }
   }


### PR DESCRIPTION
Overview
----------------------------------------
[REF] Simplify location metadata handling in Export class

Before
----------------------------------------
$metadata is a subset of ExportProcessor metadata including only location fields & is passed around

After
----------------------------------------
ExportProcessor metadata accessed instead. Filtering based on whether the field is a location field

Technical Details
----------------------------------------
 The metadata array that is passed into getTransformedFieldValue is just a subset of the class metadata. It is
    - keyed slightly differently
    - only location fields
    
    Obviously passing this around when we can access it directly is silly and it was as a consquence as this code having
    started off incredibly toxic and a slow incremental cleanup process that it was done this way. The cleanup had
    not reached that array.
    
    This has excellent test cover with multiple variations of phones & Ims tested along with all entities. These exposed
    a tangental improvement (not replacing the word 'No' with '' ) Email On Hold.


Comments
----------------------------------------
Note the first commit is separately in https://github.com/civicrm/civicrm-core/pull/17941

Extensive tests were written on this code during the last round of refactoring.
