### PR TITLE
APIv4 - Add keyword to select all custom fields

### DIFF
--- a/Civi/Api4/Generic/DAOGetAction.php
+++ b/Civi/Api4/Generic/DAOGetAction.php
@@ -35,7 +35,9 @@ class DAOGetAction extends AbstractGetAction {
   use Traits\DAOActionTrait;
 
   /**
-   * Fields to return. Defaults to all non-custom fields `[*]`.
+   * Fields to return. Defaults to all non-custom fields `['*']`.
+   *
+   * The keyword `"custom.*"` selects all custom fields. So to select all core + custom fields, select `['*', 'custom.*']`.
    *
    * Use the dot notation to perform joins in the select clause, e.g. selecting `['*', 'contact.*']` from `Email::get()`
    * will select all fields for the email + all fields for the related contact.

--- a/ang/api4Explorer/Explorer.js
+++ b/ang/api4Explorer/Explorer.js
@@ -416,6 +416,10 @@
         addJoins($scope.fieldsAndJoinsAndFunctionsWithSuffixes, false, ['name', 'label']);
         addJoins($scope.fieldsAndJoinsAndFunctionsAndWildcards, true, ['name', 'label']);
       }
+      // Custom fields are supported if HAVING is
+      if (actionInfo.params.having) {
+        $scope.fieldsAndJoinsAndFunctionsAndWildcards.unshift({id: 'custom.*', text: 'custom.*', 'description': 'All custom fields'});
+      }
       $scope.fieldsAndJoinsAndFunctionsAndWildcards.unshift({id: '*', text: '*', 'description': 'All core ' + $scope.entity + ' fields'});
     };
 

--- a/tests/phpunit/api/v4/Action/BasicCustomFieldTest.php
+++ b/tests/phpunit/api/v4/Action/BasicCustomFieldTest.php
@@ -140,9 +140,17 @@ class BasicCustomFieldTest extends BaseCustomValueTest {
       ->addWhere('MyContactFields.FavFood', '=', 'Cherry')
       ->execute()
       ->first();
-
     $this->assertArrayHasKey('MyContactFields.FavColor', $contact);
     $this->assertEquals('Red', $contact['MyContactFields.FavColor']);
+
+    // By default custom fields are not returned
+    $contact = Contact::get(FALSE)
+      ->addWhere('id', '=', $contactId1)
+      ->addWhere('MyContactFields.FavColor', '=', 'Red')
+      ->addWhere('MyContactFields.FavFood', '=', 'Cherry')
+      ->execute()
+      ->first();
+    $this->assertArrayNotHasKey('MyContactFields.FavColor', $contact);
 
     // Update 2nd set and ensure 1st hasn't changed
     Contact::update()
@@ -166,7 +174,7 @@ class BasicCustomFieldTest extends BaseCustomValueTest {
       ->addValue('MyContactFields.FavColor', 'Blue')
       ->execute();
     $contact = Contact::get(FALSE)
-      ->addSelect('MyContactFields.FavColor', 'MyContactFields2.FavColor', 'MyContactFields.FavFood', 'MyContactFields2.FavFood')
+      ->addSelect('custom.*')
       ->addWhere('id', '=', $contactId1)
       ->execute()
       ->first();


### PR DESCRIPTION
Overview
----------------------------------------
Adds a convenience feature to APIv4, making it easy to select all custom fields.

Before
----------------------------------------
APIv4 `Get` only selects core fields by default; custom fields must be added one-at-a-time or on a per-group basis.

After
----------------------------------------
APIv4 `Get` only selects core fields by default, but all custom fields can be added with a simple keyword.

Technical Details
----------------------------------------
To select all core + custom fields, select `['*', 'custom.*']`.

Comments
----------------------------------------
Updated tests, docs, and the API Explorer :)