### PR TITLE
Add APIv4 copy action

### DIFF
--- a/Civi/Api4/Generic/BasicCopyAction.php
+++ b/Civi/Api4/Generic/BasicCopyAction.php
@@ -1,0 +1,115 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+
+namespace Civi\Api4\Generic;
+
+/**
+ * Copies one or more $ENTITIES based on the WHERE criterla.
+ *
+ * @method $this setValues(array $values) Set all field values from an array of key => value pairs.
+ * @method array getValues() Get field values.
+ *
+ * @package Civi\Api4\Generic
+ */
+class BasicCopyAction extends AbstractGetAction {
+
+  /**
+   * Unique fields that should be excluded from the copy.
+   * @var array
+   */
+  private $idFields;
+
+  /**
+   * Criteria for selecting $ENTITIES to copy.
+   *
+   * @var array
+   * @required
+   */
+  protected $where = [];
+
+  /**
+   * Fields to copy over. Defaults to all core + custom fields, select `['*', 'custom.*']`.
+   *
+   * @var array
+   */
+  protected $select = [];
+
+  /**
+   * Field values to set in each copy.
+   *
+   * @var array
+   * @required
+   */
+  protected $values = [];
+
+  /**
+   * BasicCopyAction constructor.
+   * @param string $entityName
+   * @param string $actionName
+   * @param string|string[] $idFields
+   * @throws \API_Exception
+   */
+  public function __construct($entityName, $actionName, $idFields = ['id']) {
+    parent::__construct($entityName, $actionName);
+    $this->idFields = (array) $idFields;
+  }
+
+  /**
+   * @param Result $result
+   */
+  public function _run(Result $result) {
+    $records = $this->getBatchRecords();
+    foreach ($records as $record) {
+      \CRM_Utils_Array::remove($record, $this->idFields);
+      $record = $this->values + $record;
+      $result[] = $copy = civicrm_api4($this->getEntityName(), 'create', ['values' => $record])->first();
+      // Call hook_civicrm_copy, which expects an object rather than an array
+      $copy = (object) ($copy + $record);
+      \CRM_Utils_Hook::copy($this->getEntityName(), $copy);
+    }
+  }
+
+  /**
+   * @return Result
+   */
+  protected function getBatchRecords() {
+    $params = [
+      'checkPermissions' => $this->checkPermissions,
+      'select' => $this->select ?: ['*', 'custom.*'],
+      'where' => $this->where,
+      'orderBy' => $this->orderBy,
+      'limit' => $this->limit,
+      'offset' => $this->offset,
+    ];
+    return civicrm_api4($this->getEntityName(), 'get', $params);
+  }
+
+  /**
+   * Add an item to the values array.
+   *
+   * @param string $fieldName
+   * @param mixed $value
+   * @return $this
+   */
+  public function addValue(string $fieldName, $value) {
+    $this->values[$fieldName] = $value;
+    return $this;
+  }
+
+}

--- a/Civi/Api4/Generic/BasicEntity.php
+++ b/Civi/Api4/Generic/BasicEntity.php
@@ -129,6 +129,15 @@ abstract class BasicEntity extends AbstractEntity {
 
   /**
    * @param bool $checkPermissions
+   * @return BasicCopyAction
+   */
+  public static function copy($checkPermissions = TRUE) {
+    return (new BasicCopyAction(static::class, __FUNCTION__, static::$idField))
+      ->setCheckPermissions($checkPermissions);
+  }
+
+  /**
+   * @param bool $checkPermissions
    * @return BasicReplaceAction
    */
   public static function replace($checkPermissions = TRUE) {

--- a/Civi/Api4/Generic/DAOEntity.php
+++ b/Civi/Api4/Generic/DAOEntity.php
@@ -83,6 +83,15 @@ abstract class DAOEntity extends AbstractEntity {
 
   /**
    * @param bool $checkPermissions
+   * @return BasicCopyAction
+   */
+  public static function copy($checkPermissions = TRUE) {
+    return (new BasicCopyAction(static::class, __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
+  }
+
+  /**
+   * @param bool $checkPermissions
    * @return BasicReplaceAction
    */
   public static function replace($checkPermissions = TRUE) {

--- a/tests/phpunit/api/v4/Action/CopyTest.php
+++ b/tests/phpunit/api/v4/Action/CopyTest.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+namespace api\v4\Action;
+
+use Civi\Api4\Email;
+use api\v4\UnitTestCase;
+use Civi\Api4\Contact;
+
+/**
+ * @group headless
+ */
+class CopyTest extends UnitTestCase {
+
+  public function testEmailCopy() {
+    $cid1 = Contact::create()
+      ->addValue('first_name', 'Lotsa')
+      ->addValue('last_name', 'Emails')
+      ->execute()
+      ->first()['id'];
+    $e1 = Email::create()
+      ->setValues(['contact_id' => $cid1, 'email' => 'first@example.com', 'location_type_id' => 1])
+      ->execute()
+      ->first()['id'];
+    $e2 = Email::create()
+      ->setValues(['contact_id' => $cid1, 'email' => 'second@example.com', 'location_type_id' => 1])
+      ->execute()
+      ->first()['id'];
+
+    $copyResult = Email::copy()
+      ->addValue('location_type_id', 2)
+      ->addWhere('contact_id', '=', $cid1)
+      ->execute()
+      ->indexBy('id');
+    // Should have saved 2 records
+    $this->assertCount(2, $copyResult);
+    $this->assertArrayNotHasKey($e1, (array) $copyResult);
+    $this->assertArrayNotHasKey($e2, (array) $copyResult);
+
+    // Verify contact now has the new email records
+    $results = Email::get()
+      ->addWhere('contact_id', '=', $cid1)
+      ->addOrderBy('id')
+      ->execute()
+      ->indexBy('id');
+    $this->assertCount(4, $results);
+    $this->assertEquals(1, $results->first()['location_type_id']);
+    $this->assertEquals(2, $results->last()['location_type_id']);
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
This adds a generic "copy" action to APIv4. It works similarly to other bulk actions (like update) - it can copy more than one record at once, and gives you control over which fields should be copied (defaults to every core+custom field) and what new values should be set.

Technical Details
----------------------------------------
This is a "pure" api implementation and doesn't call any of the BAO copy functions.

It does call `hook_civicrm_copy()` but that hook expects a DAO object to be passed in. I guess it's good enough to cast our results array to a `stdObject` and pass that in.