### PR TITLE
dev/core#1909 - E_NOTICE opening file-on-case

### DIFF
--- a/CRM/Case/Form/ActivityToCase.php
+++ b/CRM/Case/Form/ActivityToCase.php
@@ -60,7 +60,7 @@ class CRM_Case_Form_ActivityToCase extends CRM_Core_Form {
     $params = ['id' => $this->_activityId];
 
     CRM_Activity_BAO_Activity::retrieve($params, $defaults);
-    $defaults['file_on_case_activity_subject'] = $defaults['subject'];
+    $defaults['file_on_case_activity_subject'] = $defaults['subject'] ?? '';
     $defaults['file_on_case_target_contact_id'] = $defaults['target_contact'];
 
     // If this contact has an open case, supply it as a default

--- a/tests/phpunit/CRM/Case/Form/TaskTest.php
+++ b/tests/phpunit/CRM/Case/Form/TaskTest.php
@@ -7,11 +7,6 @@ require_once 'CiviTest/CiviCaseTestCase.php';
  */
 class CRM_Case_Form_TaskTest extends CiviCaseTestCase {
 
-  public function setUp() {
-    parent::setUp();
-    $this->quickCleanup(['civicrm_case_contact', 'civicrm_case', 'civicrm_contact']);
-  }
-
   /**
    * Test the order of the corresponding ids in the output matches the order
    * of the ids in the input, i.e. case_contacts matches cases.
@@ -59,73 +54,166 @@ class CRM_Case_Form_TaskTest extends CiviCaseTestCase {
       // one input
       [
         [
-          ['contact_id' => 1, 'case_id' => 2],
+          ['contact_id' => 7, 'case_id' => 8],
         ],
         // the case id's in the order they were passed in from search results
-        [2],
+        [8],
         // the retrieved contacts listed in the expected order
-        [1],
+        [7],
       ],
       // some input
       [
         [
-          ['contact_id' => 1, 'case_id' => 2],
-          ['contact_id' => 3, 'case_id' => 4],
+          ['contact_id' => 7, 'case_id' => 8],
+          ['contact_id' => 9, 'case_id' => 4],
           ['contact_id' => 5, 'case_id' => 6],
         ],
-        [2, 4, 6],
-        [1, 3, 5],
+        [8, 4, 6],
+        [7, 9, 5],
       ],
       [
         [
-          ['contact_id' => 1, 'case_id' => 2],
-          ['contact_id' => 3, 'case_id' => 4],
+          ['contact_id' => 7, 'case_id' => 8],
+          ['contact_id' => 9, 'case_id' => 4],
           ['contact_id' => 5, 'case_id' => 6],
         ],
-        [4, 2, 6],
-        [3, 1, 5],
+        [4, 8, 6],
+        [9, 7, 5],
       ],
 
       // some more input
       [
         [
-          ['contact_id' => 17, 'case_id' => 12],
-          ['contact_id' => 3, 'case_id' => 8],
+          ['contact_id' => 19, 'case_id' => 12],
+          ['contact_id' => 9, 'case_id' => 8],
           ['contact_id' => 25, 'case_id' => 45],
-          ['contact_id' => 18, 'case_id' => 33],
+          ['contact_id' => 20, 'case_id' => 33],
         ],
         [12, 8, 45, 33],
-        [17, 3, 25, 18],
+        [19, 9, 25, 20],
       ],
       [
         [
-          ['contact_id' => 17, 'case_id' => 12],
-          ['contact_id' => 3, 'case_id' => 8],
+          ['contact_id' => 19, 'case_id' => 12],
+          ['contact_id' => 9, 'case_id' => 8],
           ['contact_id' => 25, 'case_id' => 45],
-          ['contact_id' => 18, 'case_id' => 33],
+          ['contact_id' => 20, 'case_id' => 33],
         ],
         [45, 8, 33, 12],
-        [25, 3, 18, 17],
+        [25, 9, 20, 19],
       ],
       [
         [
-          ['contact_id' => 17, 'case_id' => 12],
-          ['contact_id' => 3, 'case_id' => 8],
+          ['contact_id' => 19, 'case_id' => 12],
+          ['contact_id' => 9, 'case_id' => 8],
           ['contact_id' => 25, 'case_id' => 45],
-          ['contact_id' => 18, 'case_id' => 33],
+          ['contact_id' => 20, 'case_id' => 33],
         ],
         [12, 33, 45, 8],
-        [17, 18, 25, 3],
+        [19, 20, 25, 9],
       ],
       [
         [
-          ['contact_id' => 17, 'case_id' => 12],
-          ['contact_id' => 3, 'case_id' => 8],
+          ['contact_id' => 19, 'case_id' => 12],
+          ['contact_id' => 9, 'case_id' => 8],
           ['contact_id' => 25, 'case_id' => 45],
-          ['contact_id' => 18, 'case_id' => 33],
+          ['contact_id' => 20, 'case_id' => 33],
         ],
         [8, 33, 12, 45],
-        [3, 18, 17, 25],
+        [9, 20, 19, 25],
+      ],
+    ];
+  }
+
+  /**
+   * Test that File On Case and its friends open the form without errors.
+   *
+   * @dataProvider fileOnCaseVariationProvider
+   *
+   * @param array $input
+   */
+  public function testOpenFileOnCaseForm($input) {
+    // Create a case and an activity to use
+    $client_id = $this->individualCreate([], 0, TRUE);
+    $case = $this->createCase($client_id, $this->_loggedInUser);
+    // create 2 cases since "move"/"copy" aren't available actions otherwise
+    $case = $this->createCase($this->individualCreate([], 1, TRUE), $this->_loggedInUser);
+    $activity_params = [
+      'activity_type_id' => 'Inbound Email',
+      'source_contact_id' => $client_id,
+      'target_id' => $this->_loggedInUser,
+      'subject' => $input['subject'] ?? NULL,
+      'details' => 'test test test',
+      'activity_date_time' => date('Ymdhis'),
+    ];
+    if ($input['variation_type'] !== 'file') {
+      // For copy and move it doesn't make sense if the activity isn't a case
+      // activity.
+      $activity_params['case_id'] = $case->id;
+    }
+    $activity = $this->callAPISuccess('Activity', 'create', $activity_params);
+
+    $form = new CRM_Case_Form_ActivityToCase();
+    $form->controller = new CRM_Core_Controller_Simple('CRM_Case_Form_ActivityToCase', 'Case Thing');
+    $_REQUEST['activityId'] = $activity['id'];
+    $_REQUEST['fileOnCaseAction'] = $input['variation_type'];
+
+    ob_start();
+    $form->controller->_actions['display']->perform($form, 'display');
+    $contents = ob_get_contents();
+    ob_end_clean();
+
+    // We're really just checking for form opening errors, but let's check
+    // something while we're here.
+    $this->assertStringContainsString('<tr class="crm-case-activitytocase-form-block-file_on_case_unclosed_case_id">', $contents);
+
+    unset($_REQUEST['activityId']);
+    unset($_REQUEST['fileOnCaseAction']);
+  }
+
+  /**
+   * data provider for testFileOnCaseForm
+   *
+   * File On Case, copy to case, and move to case are all variations of the
+   * same thing.
+   */
+  public function fileOnCaseVariationProvider() {
+    return [
+      'File On Case with subject' => [
+        [
+          'variation_type' => 'file',
+          'subject' => 'test test test',
+        ],
+      ],
+      'Copy To Case with subject' => [
+        [
+          'variation_type' => 'copy',
+          'subject' => 'test test test',
+        ],
+      ],
+      'Move To Case with subject' => [
+        [
+          'variation_type' => 'move',
+          'subject' => 'test test test',
+        ],
+      ],
+      'File On Case no subject' => [
+        [
+          'variation_type' => 'file',
+          'subject' => NULL,
+        ],
+      ],
+      'Copy To Case no subject' => [
+        [
+          'variation_type' => 'copy',
+          'subject' => NULL,
+        ],
+      ],
+      'Move To Case no subject' => [
+        [
+          'variation_type' => 'move',
+          'subject' => NULL,
+        ],
       ],
     ];
   }


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/1909

E_NOTICE when opening file-on-case or its variations when the activity has no subject: `Notice: Undefined index: subject in CRM_Case_Form_ActivityToCase->setDefaultValues() (line 63 of .../CRM/Case/Form/ActivityToCase.php).`

This form is only reachable by popup, so you can't see the notice on the page since it gets snippet'd out. You need to look in drupal watchdog.

1. Create a case.
2. Create a non-case activity with no subject.
3. Choose file on case for that activity.
4. Look in drupal /admin/reports/dblog.

Ditto for copy-to-case and move-to-case but you need to create 2 cases and then in step 2 you'd create a case activity.

Technical Details
----------------------------------------
Subject can be legitimately blank for an activity

Comments
----------------------------------------
Has test

The changes to the other test are because the case-y stuff in this test needs the setup in the parent CiviCaseTestCase, but when I removed the quickcleanup the other test then failed because it uses ids that conflict with the parent setup and the fixtures that get loaded. So I changed 1,2,3 => 7,8,9 and 17,18 => 19,20. The original use of quickcleanup wasn't on purpose it was just copy/paste from somewhere, but inadvertently masked this conflict. And the ids in that test are arbitrary what matters is the order.
