### PR TITLE
dev/core#1911 - Default not being set for fixed contribution amounts or any price field that is not type text

### DIFF
--- a/CRM/Price/BAO/PriceFieldValue.php
+++ b/CRM/Price/BAO/PriceFieldValue.php
@@ -29,14 +29,14 @@ class CRM_Price_BAO_PriceFieldValue extends CRM_Price_DAO_PriceFieldValue {
    * @return CRM_Price_DAO_PriceFieldValue
    */
   public static function add($params) {
-    $fieldValueBAO = self::writeRecord($params);
-
     if (!empty($params['is_default'])) {
       $priceFieldID = $params['price_field_id'] ?? CRM_Core_DAO::getFieldValue('CRM_Price_BAO_PriceFieldValue', $fieldValueBAO->id, 'price_field_id');
       $query = 'UPDATE civicrm_price_field_value SET is_default = 0 WHERE  price_field_id = %1';
       $p = [1 => [$priceFieldID, 'Integer']];
       CRM_Core_DAO::executeQuery($query, $p);
     }
+
+    $fieldValueBAO = self::writeRecord($params);
 
     // Reset the cached values in this function.
     CRM_Price_BAO_PriceField::getOptions(CRM_Utils_Array::value('price_field_id', $params), FALSE, TRUE);

--- a/tests/phpunit/api/v3/PriceFieldValueTest.php
+++ b/tests/phpunit/api/v3/PriceFieldValueTest.php
@@ -217,4 +217,17 @@ class api_v3_PriceFieldValueTest extends CiviUnitTestCase {
     $this->callAPIFailure($this->_entity, 'create', $params);
   }
 
+  /**
+   * This is the same as testCreatePriceFieldValue but where is_default = 1.
+   */
+  public function testCreatePriceFieldValueAsDefault() {
+    $params = $this->_params;
+    $params['is_default'] = 1;
+    $result = $this->callAPISuccess($this->_entity, 'create', $params);
+    $this->assertAPISuccess($result);
+    $this->assertEquals(1, $result['count']);
+    $this->assertNotNull($result['values'][$result['id']]['id']);
+    $this->getAndCheck($params, $result['id'], $this->_entity);
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/1911

The default setting for price field options no longer works as of 5.27.

Easiest way to see is:
1. On a stock demo site go to the amounts tab for the "Help Support CiviCRM" contribution page.
2. Observe that "Booster $10" is the default amount.
3. Just click save.
4. Go back to the amounts tab. Nothing is set as default.
5. Also if you visit the live page no default is selected.

You can also see it if you:
1. Create a price set.
2. Add a price field that is not type text, like type select.
3. Create a few options and set one as a default.
4. Go back and look at it and it's not the default.

5.27 Backport of https://github.com/civicrm/civicrm-core/pull/17960

