### PR TITLE
dev/core#1909 Fix E-notice when adding a field on a profile

### DIFF
--- a/CRM/UF/Form/Field.php
+++ b/CRM/UF/Form/Field.php
@@ -530,7 +530,7 @@ class CRM_UF_Form_Field extends CRM_Core_Form {
         $apiFormattedParams['location_type_id'] = $params['field_name'][2];
       }
     }
-    elseif ($params['field_name'][2] == 0) {
+    elseif (isset($params['field_name'][2]) && $params['field_name'][2] == 0) {
       // 0 is Primary location type
       $apiFormattedParams['location_type_id'] = '';
     }


### PR DESCRIPTION
Overview
----------------------------------------
This fixes an e-notice which is found when adding a field that doesn't contain a location type.

To Reproduce

1. Navigate to one of the current profiles say Name and Address
2. when viewing the profile fields open up the Add field link in a new tab
3. Add a field e.g. Gender to the profile that doesn't use a location type
4. See e-notice as reported in the lab ticket https://lab.civicrm.org/dev/core/-/issues/1909

Before
----------------------------------------
E-notice shows when adding a field that doesn't use location type

After
----------------------------------------
No-enotice

ping @demeritcowboy @eileenmcnaughton 