### PR TITLE
dev/core#1909 Fix e-notice when adding a payment processor

### DIFF
--- a/CRM/Admin/Form/PaymentProcessor.php
+++ b/CRM/Admin/Form/PaymentProcessor.php
@@ -21,6 +21,16 @@
 class CRM_Admin_Form_PaymentProcessor extends CRM_Admin_Form {
   use CRM_Core_Form_EntityFormTrait;
 
+  /**
+   * @var int
+   * Test Payment Processor ID
+   */
+  protected $_testID;
+
+  /**
+   * @var \CRM_Core_DAO_PaymentProcessor
+   * Payment Processor DAO Object
+   */
   protected $_paymentProcessorDAO;
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
This fixes an e-notice about an undefined property _testID when adding a new payment processor as per the [lab issue](https://lab.civicrm.org/dev/core/-/issues/1909). It loosks like it was caused by this change here https://github.com/civicrm/civicrm-core/commit/833764691ef21020d2c25176cea7dbb9c98cfec1#diff-24dc91b43a3b998ad84ffe78397b2a06L40 

Before
----------------------------------------
E-notice shows

After
----------------------------------------
No E-notice

ping @eileenmcnaughton @demeritcowboy 
