### PR TITLE
[REF] Grant cleanup

### DIFF
--- a/CRM/Grant/BAO/Grant.php
+++ b/CRM/Grant/BAO/Grant.php
@@ -15,13 +15,6 @@
 class CRM_Grant_BAO_Grant extends CRM_Grant_DAO_Grant {
 
   /**
-   * Class constructor.
-   */
-  public function __construct() {
-    parent::__construct();
-  }
-
-  /**
    * Get events Summary.
    *
    *
@@ -93,7 +86,7 @@ class CRM_Grant_BAO_Grant extends CRM_Grant_DAO_Grant {
    * @param array $defaults
    *   (reference ) an assoc array to hold the flattened values.
    *
-   * @return CRM_Grant_BAO_ManageGrant
+   * @return CRM_Grant_DAO_Grant
    */
   public static function retrieve(&$params, &$defaults) {
     $grant = new CRM_Grant_DAO_Grant();
@@ -118,30 +111,6 @@ class CRM_Grant_BAO_Grant extends CRM_Grant_DAO_Grant {
     $hook = $id ? 'edit' : 'create';
     CRM_Utils_Hook::pre($hook, 'Grant', $id, $params);
 
-    // first clean up all the money fields
-    $moneyFields = [
-      'amount_total',
-      'amount_granted',
-      'amount_requested',
-    ];
-    foreach ($moneyFields as $field) {
-      if (isset($params[$field])) {
-        $params[$field] = CRM_Utils_Rule::cleanMoney($params[$field]);
-      }
-    }
-    // convert dates to mysql format
-    $dates = [
-      'application_received_date',
-      'decision_date',
-      'money_transfer_date',
-      'grant_due_date',
-    ];
-
-    foreach ($dates as $d) {
-      if (isset($params[$d])) {
-        $params[$d] = CRM_Utils_Date::processDate($params[$d], NULL, TRUE);
-      }
-    }
     $grant = new CRM_Grant_DAO_Grant();
     $grant->id = $id;
 

--- a/CRM/Grant/Form/Grant.php
+++ b/CRM/Grant/Form/Grant.php
@@ -40,8 +40,6 @@ class CRM_Grant_Form_Grant extends CRM_Core_Form {
 
   /**
    * Set variables up before form is built.
-   *
-   * @return void
    */
   public function preProcess() {
 
@@ -263,6 +261,16 @@ class CRM_Grant_Form_Grant extends CRM_Core_Form {
       'civicrm_grant',
       $this->_id
     );
+    $moneyFields = [
+      'amount_total',
+      'amount_granted',
+      'amount_requested',
+    ];
+    foreach ($moneyFields as $field) {
+      if (isset($params[$field])) {
+        $params[$field] = CRM_Utils_Rule::cleanMoney($params[$field]);
+      }
+    }
 
     $grant = CRM_Grant_BAO_Grant::create($params, $ids);
 

--- a/CRM/Grant/Form/Task/Update.php
+++ b/CRM/Grant/Form/Task/Update.php
@@ -80,9 +80,9 @@ class CRM_Grant_Form_Task_Update extends CRM_Grant_Form_Task {
         $values[$key] = $value;
       }
       foreach ($this->_grantIds as $grantId) {
-        $ids['grant_id'] = $grantId;
+        $values['id'] = $grantId;
 
-        CRM_Grant_BAO_Grant::add($values, $ids);
+        CRM_Grant_BAO_Grant::add($values);
         $updatedGrants++;
       }
     }


### PR DESCRIPTION


Overview
----------------------------------------
Minor code cleanup

Before
----------------------------------------
Handling for 'cleaning' money fields in the BAO

After
----------------------------------------
Handling moved to the form layer, legacy date handling removed

Technical Details
----------------------------------------
This does a couple of things to cleanup the Grant BAO -
1) moves money handling back to the form layer
2) removes unnecessary date handling - the format that comes from the form layer
is now supported by the BAO.

I was looking to work on another but but then figured I needed a v4 api before
writing the tests and then realised we shouldn't do a v4 api before getting
rid of the legacy money handling.

It does occur to me it might make more sense to start moving to an
extension before doing any of the other steps

Comments
----------------------------------------

