### PR TITLE
[Feature] dev/core#1913 Add in hook to allow extensions to modify the…

### DIFF
--- a/CRM/UF/Page/ProfileEditor.php
+++ b/CRM/UF/Page/ProfileEditor.php
@@ -192,7 +192,10 @@ class CRM_UF_Page_ProfileEditor extends CRM_Core_Page {
           break;
 
         default:
-          throw new CRM_Core_Exception("Unrecognized entity type: $entityType");
+          CRM_Utils_Hook::profileSchemas($civiSchema, $entityType, $availableFields);
+          if (!isset($civiSchema[$entityType])) {
+            throw new CRM_Core_Exception("Unrecognized entity type: $entityType");
+          }
       }
     }
 

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -2652,4 +2652,20 @@ abstract class CRM_Utils_Hook {
     );
   }
 
+  /**
+   * This hook is called to alter the profile schemas sent to the backbone marionette editor.
+   *
+   * @param array $civiSchema
+   * @param string $entityType
+   * @param array $availableFields
+   *
+   * @return mixed
+   */
+  public static function profileSchemas(&$civiSchema, $entityType, $availableFields) {
+    return self::singleton()->invoke(
+      ['civiSchema', 'entityType', 'availableFields'], $civiSchema, $entityType, $availableFields,
+      self::$_nullObject, self::$_nullObject, self::$_nullObject, 'civicrm_profileSchemas'
+    );
+  }
+
 }

--- a/tests/phpunit/CRM/UF/Page/ProfileEditorTest.php
+++ b/tests/phpunit/CRM/UF/Page/ProfileEditorTest.php
@@ -45,4 +45,36 @@ class CRM_UF_Page_ProfileEditorTest extends CiviUnitTestCase {
 
   }
 
+  public function testGetSchemaWithHooks() {
+    CRM_Utils_Hook::singleton()->setHook('civicrm_alterUFFields', [$this, 'hook_civicrm_alterUFFIelds']);
+    CRM_Utils_Hook::singleton()->setHook('civicrm_profileSchemas', [$this, 'hook_civicrm_profileSchemas']);
+    $schema = CRM_UF_Page_ProfileEditor::getSchema(['IndividualModel', 'GrantModel']);
+    $this->assertEquals('Grant', $schema['GrantModel']['schema']['grant_decision_date']['civiFieldType']);
+  }
+
+  /**
+   * Tries to load up the profile schema with a modal that is unknown
+   *
+   * @expectedException \CRM_Core_Exception
+   */
+  public function testGetSchemaWithHooksWithInvalidModel() {
+    CRM_Utils_Hook::singleton()->setHook('civicrm_alterUFFields', [$this, 'hook_civicrm_alterUFFIelds']);
+    CRM_Utils_Hook::singleton()->setHook('civicrm_profileSchemas', [$this, 'hook_civicrm_profileSchemas']);
+    $schema = CRM_UF_Page_ProfileEditor::getSchema(['IndividualModel', 'GrantModel', 'PledgeModel']);
+  }
+
+  public function hook_civicrm_alterUFFIelds(&$fields) {
+    $fields['Grant'] = CRM_Grant_BAO_Grant::exportableFields();
+  }
+
+  public function hook_civicrm_profileSchemas(&$civiSchema, $entityType, $availableFields) {
+    if ($entityType === 'GrantModel') {
+      $civiSchema[$entityType] = CRM_UF_Page_ProfileEditor::convertCiviModelToBackboneModel(
+        'Grant',
+        ts('Grant'),
+        $availableFields
+      );
+    }
+  }
+
 }


### PR DESCRIPTION
… profile schemas passed to the backbone.marionette modal

Overview
----------------------------------------
This is a bit of a follow on from https://github.com/civicrm/civicrm-core/pull/16655 This adds in a new hook to allow for the modification of profile schema by extensions that then gets passed onto backbone.marionette

Before
----------------------------------------
No Hook to allow for modification of the profile schemas

After
----------------------------------------
Hook

Technical Details
----------------------------------------
This is aiming to help me to remove an override within an extension, I have an extension that builds an equivilant form to a contribution page that uses profiles but for grants. We specify that we want to include Grants and GrantModel here https://github.com/JMAConsulting/biz.jmaconsulting.grantapplications/blob/master/CRM/Grant/Form/GrantPage/Custom.php#L59 however we have to have an overwrite of the core file to allow us to define the schema here https://github.com/JMAConsulting/biz.jmaconsulting.grantapplications/blob/master/CRM/UF/Page/ProfileEditor.php#L194 This hook would allow us to get rid of that core overwrite completely

ping @eileenmcnaughton @monishdeb @JoeMurray 
