### PR TITLE
Do not overwrite values saved from the repeatContribution routine

### DIFF
--- a/tests/phpunit/CRM/Contribute/BAO/ContributionRecurTest.php
+++ b/tests/phpunit/CRM/Contribute/BAO/ContributionRecurTest.php
@@ -225,6 +225,7 @@ class CRM_Contribute_BAO_ContributionRecurTest extends CiviUnitTestCase {
       'contribution_recur_id' => $contributionRecur['id'],
       'total_amount' => '3.00',
       'financial_type_id' => 1,
+      'source' => 'Template Contribution',
       'payment_instrument_id' => 1,
       'currency' => 'USD',
       'contact_id' => $this->individualCreate(),
@@ -237,6 +238,7 @@ class CRM_Contribute_BAO_ContributionRecurTest extends CiviUnitTestCase {
       'contribution_recur_id' => $contributionRecur['id'],
       'total_amount' => '3.00',
       'financial_type_id' => 1,
+      'source' => 'Non-template Contribution',
       'payment_instrument_id' => 1,
       'currency' => 'USD',
       'contact_id' => $this->individualCreate(),
@@ -246,6 +248,12 @@ class CRM_Contribute_BAO_ContributionRecurTest extends CiviUnitTestCase {
     $fetchedTemplate = CRM_Contribute_BAO_ContributionRecur::getTemplateContribution($contributionRecur['id']);
     // Fetched template should be the is_template, not the latest contrib
     $this->assertEquals($fetchedTemplate['id'], $templateContrib['id']);
+
+    $repeatContribution = $this->callAPISuccess('Contribution', 'repeattransaction', [
+      'contribution_status_id' => 'Completed',
+      'contribution_recur_id' => $contributionRecur['id'],
+    ]);
+    $this->assertEquals('Template Contribution', $repeatContribution['values'][$repeatContribution['id']]['source']);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a bug whereby the values being retrieved from the templateContribution routine and saved in repeattransaction were subsequently overwritten by values retrieved outside that routine

Before
----------------------------------------
'source' from the existing or first contribution is used

After
----------------------------------------
'source' from the template contribution is used

Technical Details
----------------------------------------
Ideally the v3 api would simply call repeattransaction and bypass completeorder but we are not sure whether we have disentangled everything we need to. In the meantime we should only save once, in repeattransaction

Comments
----------------------------------------
This is intended to replace https://github.com/civicrm/civicrm-core/pull/17455/files which has a test (which I brought across) but is also causing significant test failures
