### PR TITLE
[REF] Fix regression where adding any date based field onto a profile…

### DIFF
--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -391,8 +391,8 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
     // @see https://docs.civicrm.org/dev/en/latest/framework/ui/#date-picker
     if ($type === 'datepicker') {
       $attributes = $attributes ?: [];
-      if (!empty($attributes['format'])) {
-        $dateAttributes = CRM_Core_SelectValues::date($attributes['format'], NULL, NULL, NULL, 'Input');
+      if (!empty($attributes['formatType'])) {
+        $dateAttributes = CRM_Core_SelectValues::date($attributes['formatType'], NULL, NULL, NULL, 'Input');
         if (empty($extra['minDate']) && !empty($dateAttributes['minYear'])) {
           $extra['minDate'] = $dateAttributes['minYear'] . '-01-01';
         }
@@ -1394,7 +1394,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
       $required,
       ['class' => 'crm-select2']
     );
-    $attributes = ['format' => 'searchDate'];
+    $attributes = ['formatType' => 'searchDate'];
     $extra = ['time' => $isDateTime];
     $this->add('datepicker', $fieldName . $from, ts($fromLabel), $attributes, $required, $extra);
     $this->add('datepicker', $fieldName . $to, ts($toLabel), $attributes, $required, $extra);
@@ -1649,7 +1649,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
         }
         else {
           $fieldSpec = CRM_Utils_Date::addDateMetadataToField($fieldSpec, $fieldSpec);
-          $attributes = ['format' => $fieldSpec['html']['formatType']];
+          $attributes = ['format' => $fieldSpec['date_format']];
           return $this->add('datepicker', $name, $label, $attributes, $required, $fieldSpec['datepicker']['extra']);
         }
 


### PR DESCRIPTION
… triggers an error date preferences not configured when previewing the profile

Overview
----------------------------------------
This fixes recent regression where adding any date field onto a profile causes a fatal error when previewing that profile

Reproduction steps

1. Navigate to the Profiles
2. Click Fields next to the Name and Address profile
3. Add in a datepicker field onto the profile e.g. Revenue Recognition date 
4. Try and preview the profile

Before
----------------------------------------
Fatal Error

After
----------------------------------------
No Fatal error

Technical Details
----------------------------------------
This is happening because the dateMetadata has already been added here https://github.com/civicrm/civicrm-core/blob/master/CRM/Core/BAO/UFGroup.php#L510 which includes setting the min year and max year appropriately

ping @demeritcowboy @eileenmcnaughton 