### PR TITLE
Fix repeattransaction api to use custom data from the template contribution

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2636,7 +2636,7 @@ LEFT JOIN  civicrm_contribution contribution ON ( componentPayment.contribution_
 
       $createContribution = civicrm_api3('Contribution', 'create', $contributionParams);
       $contribution->id = $createContribution['id'];
-      CRM_Contribute_BAO_ContributionRecur::copyCustomValues($contributionParams['contribution_recur_id'], $contribution->id);
+      $contribution->copyCustomFields($templateContribution['id'], $contribution->id);
       self::handleMembershipIDOverride($contribution->id, $input);
       return TRUE;
     }

--- a/CRM/Contribute/BAO/ContributionRecur.php
+++ b/CRM/Contribute/BAO/ContributionRecur.php
@@ -545,6 +545,8 @@ INNER JOIN civicrm_contribution       con ON ( con.id = mp.contribution_id )
   /**
    * Copy custom data of the initial contribution into its recurring contributions.
    *
+   * @deprecated
+   *
    * @param int $recurId
    * @param int $targetContributionId
    */

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -9,6 +9,8 @@
  +--------------------------------------------------------------------+
  */
 
+use Civi\Api4\Contribution;
+
 /**
  *  Test APIv3 civicrm_contribute_* functions
  *
@@ -107,7 +109,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
    */
   public function tearDown() {
     $this->quickCleanUpFinancialEntities();
-    $this->quickCleanup(['civicrm_uf_match']);
+    $this->quickCleanup(['civicrm_uf_match'], TRUE);
     $financialAccounts = $this->callAPISuccess('FinancialAccount', 'get', []);
     foreach ($financialAccounts['values'] as $financialAccount) {
       if ($financialAccount['name'] === 'Test Tax financial account ' || $financialAccount['name'] === 'Test taxable financial Type') {
@@ -2327,6 +2329,46 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test custom data is copied over from the template transaction.
+   *
+   * (Over time various discussions have deemed this to be the most recent one, allowing
+   * users to alter custom data going forwards. This is implemented for line items already.
+   *
+   * @throws \API_Exception
+   * @throws \CRM_Core_Exception
+   */
+  public function testRepeatTransactionWithCustomData() {
+    $this->createCustomGroupWithFieldOfType(['extends' => 'Contribution', 'name' => 'Repeat'], 'text');
+    $originalContribution = $this->setUpRepeatTransaction([], 'single', [$this->getCustomFieldName('text') => 'first']);
+    $this->callAPISuccess('contribution', 'repeattransaction', [
+      'contribution_recur_id' => $originalContribution['contribution_recur_id'],
+      'contribution_status_id' => 'Completed',
+      'trxn_id' => 'my_trxn',
+    ]);
+
+    $contribution = Contribution::get()
+      ->addWhere('trxn_id', '=', 'my_trxn')
+      ->addSelect('Custom_Group.Enter_text_here')
+      ->addSelect('id')
+      ->execute()->first();
+    $this->assertEquals('first', $contribution['Custom_Group.Enter_text_here']);
+
+    Contribution::update()->setValues(['Custom_Group.Enter_text_here' => 'second'])->addWhere('id', '=', $contribution['id'])->execute();
+
+    $this->callAPISuccess('contribution', 'repeattransaction', [
+      'original_contribution_id' => $originalContribution['id'],
+      'contribution_status_id' => 'Completed',
+      'trxn_id' => 'number_3',
+    ]);
+
+    $contribution = Contribution::get()
+      ->addWhere('trxn_id', '=', 'number_3')
+      ->setSelect(['id', 'Custom_Group.Enter_text_here'])
+      ->execute()->first();
+    $this->assertEquals('second', $contribution['Custom_Group.Enter_text_here']);
+  }
+
+  /**
    * Test repeat contribution successfully creates line items (plural).
    *
    * @throws \CRM_Core_Exception
@@ -4170,6 +4212,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
       $params = array_merge($params, $contributionParams);
       $originalContribution = $this->callAPISuccess('contribution', 'create', $params);
     }
+    $originalContribution['contribution_recur_id'] = $contributionRecur['id'];
     $originalContribution['payment_processor_id'] = $paymentProcessorID;
     return $originalContribution;
   }


### PR DESCRIPTION
Overview
----------------------------------------
This ensures (& tests) that custom data is copied from the template transaction - generally the most recent transaction

Before
----------------------------------------
Custom data taken from earliest contribution when copying for repeattransaction

After
----------------------------------------
Custom data taken from template contribution

Technical Details
----------------------------------------
The template contribution is generally the most recent one in the series but we have also a concept not-really-implemented that it could be a particular status.

Comments
----------------------------------------
This replaces #17454 which was stuck on failing tests. 


Note there was talk trying to use the api in that approach. @colemanw has been working on a v4 copy api but I don't think we would want to change it without switching to v4 api. We would also want to test more field types if switching methodology