### PR TITLE
Fixed filling default values for tagssets in the advanced search form

### DIFF
--- a/CRM/Contact/Form/Search/Advanced.php
+++ b/CRM/Contact/Form/Search/Advanced.php
@@ -189,7 +189,7 @@ class CRM_Contact_Form_Search_Advanced extends CRM_Contact_Form_Search {
       'privacy_toggle' => 1,
       'operator' => 'AND',
     ], $defaults);
-    $this->normalizeDefaultValues($defaults);
+    $defaults = $this->normalizeDefaultValues($defaults);
 
     //991/Subtypes not respected when editing smart group criteria
     if (!empty($defaults['contact_type']) && !empty($this->_formValues['contact_sub_type'])) {


### PR DESCRIPTION
Overview
----------------------------------------
The edit smart group form does not fill the default values for tag sets.

Reproduction steps
----------------------------------------
1. Create a tag set. This can be done in the civicrm/tag?reset=1 form. Example:
![tagset](https://user-images.githubusercontent.com/14834891/88551760-8579b480-d023-11ea-83ce-239f90146857.png)


1. Now the tagset shows up in the advanced search:
![Selection_025](https://user-images.githubusercontent.com/14834891/88551833-9e826580-d023-11ea-9e1f-e9c9703bacc3.png)


1. Create smart group from this advanced search. This smart group works fine

1. Go to the smart group settings screen (1 - Manage Smart Groups, 2 - Go to the settings form of the smart group , 3 Click _Edit Smart Group Criteria_)

1. Now you cannot see what values of the tagset are chosen.

Current behavior
----------------------------------------
![current_behavior](https://user-images.githubusercontent.com/14834891/88551910-b528bc80-d023-11ea-9458-628c145a56b0.png)


Expected behavior
----------------------------------------
![Selection_025](https://user-images.githubusercontent.com/14834891/88551833-9e826580-d023-11ea-9e1f-e9c9703bacc3.png)

This is needed to know what the _original_ selection was

Environment information
----------------------------------------
Reproduced on the master 5.29.alpha1.

Comments
----------------------------------------
Related to https://lab.civicrm.org/dev/core/-/issues/1542