### PR TITLE
[REF] Move handling of form elements back to the Form

### DIFF
--- a/CRM/Contact/Form/Merge.php
+++ b/CRM/Contact/Form/Merge.php
@@ -229,8 +229,8 @@ class CRM_Contact_Form_Merge extends CRM_Core_Form {
       }
 
       // add related table elements
-      foreach ($rowsElementsAndInfo['rel_table_elements'] as $relTableElement) {
-        $element = $this->addElement($relTableElement[0], $relTableElement[1]);
+      foreach (array_keys($rowsElementsAndInfo['rel_tables']) as $relTableElement) {
+        $element = $this->addElement('checkbox', $relTableElement);
         $element->setChecked(TRUE);
       }
 

--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -1097,9 +1097,6 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
    *
    *   elements => An array of form elements for the merge UI
    *
-   *   rel_table_elements => An array of form elements for the merge UI for
-   *     entities related to the contact (eg: checkbox to move 'mailings')
-   *
    *   rel_tables => Stores the tables that have related entities for the contact
    *     for example mailings, groups
    *
@@ -1129,7 +1126,7 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
 
     $compareFields = self::retrieveFields($main, $other);
 
-    $rows = $elements = $relTableElements = $migrationInfo = [];
+    $rows = $elements = $migrationInfo = [];
 
     foreach ($compareFields['contact'] as $field) {
       if ($field === 'contact_sub_type') {
@@ -1186,7 +1183,6 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
     $mergeHandler = new CRM_Dedupe_MergeHandler((int) $mainId, (int) $otherId);
     $relTables = $mergeHandler->getTablesRelatedToTheMergePair();
     foreach ($relTables as $name => $null) {
-      $relTableElements[] = ['checkbox', "move_$name"];
       $migrationInfo["move_$name"] = 1;
 
       $relTables[$name]['main_url'] = str_replace('$cid', $mainId, $relTables[$name]['url']);
@@ -1274,7 +1270,6 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
     $result = [
       'rows' => $rows,
       'elements' => $elements,
-      'rel_table_elements' => $relTableElements,
       'rel_tables' => $relTables,
       'main_details' => $main,
       'other_details' => $other,


### PR DESCRIPTION
Overview
----------------------------------------
Minor code cleanup  - move generation of an array required to add the checkboxes for 'Move related contributions' etc for the form back to the form


Before
----------------------------------------
<img width="834" alt="Screen Shot 2020-07-28 at 2 36 11 PM" src="https://user-images.githubusercontent.com/336308/88613192-0cd92d80-d0e1-11ea-9f0f-93c377ec5d39.png">


After
----------------------------------------
No change - ie 
<img width="834" alt="Screen Shot 2020-07-28 at 2 36 11 PM" src="https://user-images.githubusercontent.com/336308/88613179-05b21f80-d0e1-11ea-92a0-e0727b052797.png">


Technical Details
----------------------------------------
This toxic function getRowsElementsAndInfo does things for the form layer but it's data also heavily used
in the BAO dedupeProcess. These are the only 2 places that call it


Ideally we want the things that are only being done to support (one specific) form
to sit on that form. This does that just for one of the 2 arrays it creates of form elements.

The rel_table_elements array is just an array that looks like
```
[
  ['checkbox',  'move_rel_contributions'],
  ['checkbox, 'move_rel_activities'],
]
```
The rel_tables array is an array of metadata keyed by eg. move_rel_contributions.

<img width="382" alt="Screen Shot 2020-07-28 at 2 47 45 PM" src="https://user-images.githubusercontent.com/336308/88613346-59bd0400-d0e1-11ea-8d63-4d714d1c762d.png">

Ergo this can be done easily on the form layer with the data it already has



Comments
----------------------------------------

