### PR TITLE
[Ref] Move noisily deprecate  BaseIPN->sendMail, call api from it rather than BAO function

### DIFF
--- a/CRM/Core/Payment/BaseIPN.php
+++ b/CRM/Core/Payment/BaseIPN.php
@@ -518,21 +518,14 @@ class CRM_Core_Payment_BaseIPN {
    * @param array $ids
    *   Related object IDs.
    * @param array $objects
-   * @param array $values
-   *   Values related to objects that have already been loaded.
-   * @param bool $recur
-   *   Is it part of a recurring contribution.
-   * @param bool $returnMessageText
-   *   Should text be returned instead of sent. This.
-   *   is because the function is also used to generate pdfs
    *
-   * @return array
-   * @throws \CRM_Core_Exception
    * @throws \CiviCRM_API3_Exception
    */
-  public function sendMail(&$input, &$ids, &$objects, &$values, $recur = FALSE, $returnMessageText = FALSE) {
-    return CRM_Contribute_BAO_Contribution::sendMail($input, $ids, $objects['contribution']->id, $values,
-      $returnMessageText);
+  public function sendMail($input, $ids, $objects) {
+    CRM_Core_Error::deprecatedFunctionWarning('this should be done via completetransaction api');
+    civicrm_api3('Contribution', 'sendconfirmation', [
+      'id' => $objects['contribution']->id,
+    ]);
   }
 
 }

--- a/tests/phpunit/CRM/Core/Payment/BaseIPNTest.php
+++ b/tests/phpunit/CRM/Core/Payment/BaseIPNTest.php
@@ -104,12 +104,12 @@ class CRM_Core_Payment_BaseIPNTest extends CiviUnitTestCase {
     $this->_setUpMembershipObjects();
     $this->_setUpRecurringContribution();
     $this->IPN->loadObjects($this->input, $this->ids, $this->objects, FALSE, $this->_processorId);
-    $this->assertFalse(empty($this->objects['membership']));
+    $this->assertNotEmpty($this->objects['membership']);
     $this->assertArrayHasKey($this->_membershipTypeID, $this->objects['membership']);
     $this->assertTrue(is_a($this->objects['membership'][$this->_membershipTypeID], 'CRM_Member_BAO_Membership'));
     $this->assertTrue(is_a($this->objects['financialType'], 'CRM_Financial_BAO_FinancialType'));
-    $this->assertFalse(empty($this->objects['contributionRecur']));
-    $this->assertFalse(empty($this->objects['paymentProcessor']));
+    $this->assertNotEmpty($this->objects['contributionRecur']);
+    $this->assertNotEmpty($this->objects['paymentProcessor']);
   }
 
   /**
@@ -145,7 +145,7 @@ class CRM_Core_Payment_BaseIPNTest extends CiviUnitTestCase {
     $contribution->id = $this->_contributionId;
     $contribution->find(TRUE);
     $contribution->loadRelatedObjects($this->input, $this->ids, TRUE);
-    $this->assertFalse(empty($contribution->_relatedObjects['membership']));
+    $this->assertNotEmpty($contribution->_relatedObjects['membership']);
     $this->assertArrayHasKey($this->_membershipTypeID, $contribution->_relatedObjects['membership']);
     $this->assertTrue(is_a($contribution->_relatedObjects['membership'][$this->_membershipTypeID], 'CRM_Member_BAO_Membership'));
     $this->assertTrue(is_a($contribution->_relatedObjects['financialType'], 'CRM_Financial_BAO_FinancialType'));
@@ -156,12 +156,13 @@ class CRM_Core_Payment_BaseIPNTest extends CiviUnitTestCase {
   /**
    * Test the LoadObjects function with recurring membership data.
    */
-  public function testsendMailMembershipObjects() {
+  public function testSendMailMembershipObjects() {
     $this->_setUpMembershipObjects();
+    $contribution = new CRM_Contribute_BAO_Contribution();
+    $contribution->id = $this->_contributionId;
     $values = [];
-    $this->IPN->loadObjects($this->input, $this->ids, $this->objects, FALSE, $this->_processorId);
-    $msg = $this->IPN->sendMail($this->input, $this->ids, $this->objects, $values, FALSE, TRUE);
-    $this->assertTrue(is_array($msg), "Message returned as an array in line");
+    $msg = $contribution->composeMessageArray($this->input, $this->ids, $values);
+    $this->assertInternalType('array', $msg, 'Message returned as an array in line');
     $this->assertEquals('Mr. Anthony Anderson II', $msg['to']);
     $this->assertContains('Membership Type: General', $msg['body']);
   }
@@ -173,9 +174,10 @@ class CRM_Core_Payment_BaseIPNTest extends CiviUnitTestCase {
    */
   public function testSendMailMembershipObjectsNoLeakage() {
     $this->_setUpMembershipObjects();
+    $contribution = new CRM_Contribute_BAO_Contribution();
     $values = [];
-    $this->IPN->loadObjects($this->input, $this->ids, $this->objects, FALSE, $this->_processorId);
-    $msg = $this->IPN->sendMail($this->input, $this->ids, $this->objects, $values, FALSE, TRUE);
+    $contribution->id = $this->_contributionId;
+    $msg = $contribution->composeMessageArray($this->input, $this->ids, $values);
     $this->assertEquals('Mr. Anthony Anderson II', $msg['to']);
     $this->assertContains('Membership Type: General', $msg['body']);
 
@@ -188,7 +190,9 @@ class CRM_Core_Payment_BaseIPNTest extends CiviUnitTestCase {
     $this->input['invoiceID'] = 'abc';
     $this->IPN->loadObjects($this->input, $this->ids, $this->objects, FALSE, $this->_processorId);
     $this->assertEquals('Donald', $this->objects['contact']->first_name);
-    $msg = $this->IPN->sendMail($this->input, $this->ids, $this->objects, $values, FALSE, TRUE);
+    $contribution = new CRM_Contribute_BAO_Contribution();
+    $contribution->id = $this->_contributionId;
+    $msg = $contribution->composeMessageArray($this->input, $this->ids, $values);
     $this->assertEquals('Dr. Donald Duck II', $msg['to']);
     $this->assertContains('Membership Type: Fowl', $msg['body']);
   }
@@ -196,11 +200,12 @@ class CRM_Core_Payment_BaseIPNTest extends CiviUnitTestCase {
   /**
    * Test the LoadObjects function with recurring membership data.
    */
-  public function testsendMailMembershipWithoutLoadObjects() {
+  public function testSendMailMembershipWithoutLoadObjects() {
     $this->_setUpMembershipObjects();
-    $values = [];
-    $msg = $this->IPN->sendMail($this->input, $this->ids, $this->objects, $values, FALSE, TRUE);
-    $this->assertTrue(is_array($msg), "Message returned as an array in line" . __LINE__);
+    $contribution = new CRM_Contribute_BAO_Contribution();
+    $contribution->id = $this->_contributionId;
+    $msg = $contribution->composeMessageArray($this->input, $this->ids, $values);
+    $this->assertInternalType('array', $msg, 'Message not returned as an array');
     $this->assertEquals('Mr. Anthony Anderson II', $msg['to']);
     $this->assertContains('Membership Type: General', $msg['body']);
   }
@@ -217,7 +222,7 @@ class CRM_Core_Payment_BaseIPNTest extends CiviUnitTestCase {
     $this->assertFalse(empty($this->objects['event']));
     $this->assertTrue(is_a($this->objects['event'], 'CRM_Event_BAO_Event'));
     $this->assertTrue(is_a($this->objects['contribution'], 'CRM_Contribute_BAO_Contribution'));
-    $this->assertFalse(empty($this->objects['event']->id));
+    $this->assertNotEmpty($this->objects['event']->id);
   }
 
   /**
@@ -227,8 +232,10 @@ class CRM_Core_Payment_BaseIPNTest extends CiviUnitTestCase {
     $this->_setUpParticipantObjects();
     $this->IPN->loadObjects($this->input, $this->ids, $this->objects, FALSE, $this->_processorId);
     $values = [];
-    $this->assertFalse(empty($this->objects['event']));
-    $msg = $this->IPN->sendMail($this->input, $this->ids, $this->objects, $values, FALSE, TRUE);
+    $this->assertNotEmpty($this->objects['event']);
+    $contribution = new CRM_Contribute_BAO_Contribution();
+    $contribution->id = $this->_contributionId;
+    $msg = $contribution->composeMessageArray($this->input, $this->ids, $values);
     $this->assertContains('registration has been received and your status has been updated to Attended.', $msg['body']);
     $this->assertContains('Annual CiviCRM meet', $msg['html']);
   }
@@ -237,9 +244,9 @@ class CRM_Core_Payment_BaseIPNTest extends CiviUnitTestCase {
    */
   public function testComposeMailParticipantObjects() {
     $this->_setUpParticipantObjects();
-    $values = [];
-    $msg = $this->IPN->sendMail($this->input, $this->ids, $this->objects, $values, FALSE, TRUE);
-    $this->assertTrue(is_array($msg), "Message returned as an array in line" . __LINE__);
+    $contribution = new CRM_Contribute_BAO_Contribution();
+    $contribution->id = $this->_contributionId;
+    $msg = $contribution->composeMessageArray($this->input, $this->ids, $values);
     $this->assertEquals('Mr. Anthony Anderson II', $msg['to']);
     $this->assertContains('Thank you for your registration', $msg['body']);
   }
@@ -247,12 +254,12 @@ class CRM_Core_Payment_BaseIPNTest extends CiviUnitTestCase {
   /**
    * Test the LoadObjects function with recurring membership data.
    */
-  public function testsendMailParticipantObjectsCheckLog() {
+  public function testSendMailParticipantObjectsCheckLog() {
     $this->_setUpParticipantObjects();
-    $values = [];
     $mut = new CiviMailUtils($this, TRUE);
-    $this->IPN->loadObjects($this->input, $this->ids, $this->objects, FALSE, $this->_processorId);
-    $this->IPN->sendMail($this->input, $this->ids, $this->objects, $values, FALSE, FALSE);
+    $this->callAPISuccess('Contribution', 'sendconfirmation', [
+      'id' => $this->_contributionId,
+    ]);
     $mut->checkMailLog([
       'Thank you for your registration',
       'Annual CiviCRM meet',
@@ -276,8 +283,9 @@ class CRM_Core_Payment_BaseIPNTest extends CiviUnitTestCase {
     ];
     $this->quickCleanup($tablesToTruncate, FALSE);
     $mut = new CiviMailUtils($this, TRUE);
-    $this->IPN->loadObjects($this->input, $this->ids, $this->objects, FALSE, $this->_processorId);
-    $this->IPN->sendMail($this->input, $this->ids, $this->objects, $values, FALSE, FALSE);
+    $contribution = new CRM_Contribute_BAO_Contribution();
+    $contribution->id = $this->_contributionId;
+    $msg = $contribution->composeMessageArray($this->input, $this->ids, $values);
     $mut->assertMailLogEmpty('no mail should have been send as event set to no confirm');
     $mut->stop();
   }
@@ -330,11 +338,11 @@ class CRM_Core_Payment_BaseIPNTest extends CiviUnitTestCase {
   /**
    * Test the LoadObjects function with a pledge.
    */
-  public function testsendMailPledge() {
+  public function testSendMailPledge() {
     $this->_setUpPledgeObjects();
-    $values = [];
-    $this->IPN->loadObjects($this->input, $this->ids, $this->objects, FALSE, NULL);
-    $msg = $this->IPN->sendMail($this->input, $this->ids, $this->objects, $values, FALSE, TRUE);
+    $contribution = new CRM_Contribute_BAO_Contribution();
+    $contribution->id = $this->_contributionId;
+    $msg = $contribution->composeMessageArray($this->input, $this->ids, $values);
     $this->assertContains('Contribution Information', $msg['html']);
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
This function has been deprecated since 2015 and it's tempting just to remove it but at this stage
I'm just upping the noise, bypassing it in tests, and making it call the api so we have more of a free hand with the BAO function - notably it makes it clearer we don't need to have params by reference in the BAO function.

Before
----------------------------------------
Deprecated (& probably unused - certainly unused by core) BaseIPN function calls a BAO function 

After
----------------------------------------
Deprecated (& probably unused - certainly unused by core) BaseIPN function calls the recommended api function. 
Unused parameters removed from the signature

Only 2 places still call this BAO function the api and one other. 

Technical Details
----------------------------------------
Baby cleanup step - facilitates https://github.com/civicrm/civicrm-core/pull/17984

Comments
----------------------------------------

Fun fact - these tests being altered are probably from our first ever test-driven refactor. They were written before moving the guts of the function out of the BaseIPN class & adding an api