### PR TITLE
[REF] Remove pass-by-reference & always empty param

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4598,8 +4598,6 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
    * @param array $ids
    *   Related object IDs.
    * @param int $contributionID
-   * @param array $values
-   *   Values related to objects that have already been loaded.
    * @param bool $returnMessageText
    *   Should text be returned instead of sent. This.
    *   is because the function is also used to generate pdfs
@@ -4609,9 +4607,8 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
    * @throws \CiviCRM_API3_Exception
    * @throws \Exception
    */
-  public static function sendMail(&$input, &$ids, $contributionID, &$values,
-                                  $returnMessageText = FALSE) {
-
+  public static function sendMail($input, $ids, $contributionID, $returnMessageText = FALSE) {
+    $values = [];
     $contribution = new CRM_Contribute_BAO_Contribution();
     $contribution->id = $contributionID;
     if (!$contribution->find(TRUE)) {

--- a/CRM/Contribute/Form/Task/PDF.php
+++ b/CRM/Contribute/Form/Task/PDF.php
@@ -184,7 +184,6 @@ AND    {$this->_componentClause}";
       // CRM_Contribute_BAO_Contribution::composeMessageArray expects mysql formatted date
       $objects['contribution']->receive_date = CRM_Utils_Date::isoToMysql($objects['contribution']->receive_date);
 
-      $values = [];
       if (isset($params['from_email_address']) && !$elements['createPdf']) {
         // If a logged in user from email is used rather than a domain wide from email address
         // the from_email_address params key will be numerical and we need to convert it to be
@@ -196,8 +195,7 @@ AND    {$this->_componentClause}";
         $input['receipt_from_name'] = str_replace('"', '', $fromDetails[0]);
       }
 
-      $mail = CRM_Contribute_BAO_Contribution::sendMail($input, $ids, $objects['contribution']->id, $values,
-        $elements['createPdf']);
+      $mail = CRM_Contribute_BAO_Contribution::sendMail($input, $ids, $objects['contribution']->id, $elements['createPdf']);
 
       if ($mail['html']) {
         $message[] = $mail['html'];

--- a/api/v3/Contribution.php
+++ b/api/v3/Contribution.php
@@ -393,7 +393,7 @@ function _civicrm_api3_contribute_format_params($params, &$values) {
  * @throws Exception
  */
 function civicrm_api3_contribution_sendconfirmation($params) {
-  $ids = $values = [];
+  $ids = [];
   $allowedParams = [
     'receipt_from_email',
     'receipt_from_name',
@@ -405,7 +405,7 @@ function civicrm_api3_contribution_sendconfirmation($params) {
   ];
   $input = array_intersect_key($params, array_flip($allowedParams));
   $input['is_email_receipt'] = TRUE;
-  CRM_Contribute_BAO_Contribution::sendMail($input, $ids, $params['id'], $values);
+  CRM_Contribute_BAO_Contribution::sendMail($input, $ids, $params['id']);
 }
 
 /**


### PR DESCRIPTION
Overview
----------------------------------------
Removes unused param, unnecessary pass by reference from function parameter

Before
----------------------------------------
```
public static function sendMail(&$input, &$ids, $contributionID, &$values,
                                  $returnMessageText = FALSE) {
```

After
----------------------------------------
```
public static function sendMail($input, $ids, $contributionID, $returnMessageText = FALSE) {
```

Technical Details
----------------------------------------

Once https://github.com/civicrm/civicrm-core/pull/17982 is merged there are only 2 places that call this function. In both
places
1) they instantiate an empty values array just to pass in
2) we can see they don't use input or ids afterwards, so they don't need to be passed by reference



Comments
----------------------------------------
Will not pass until https://github.com/civicrm/civicrm-core/pull/17982 is merged
