### PR TITLE
dev/core#1909 - Avoid E_Notice on SMS provider form when no default url

### DIFF
--- a/CRM/SMS/Form/Provider.php
+++ b/CRM/SMS/Form/Provider.php
@@ -114,7 +114,7 @@ class CRM_SMS_Form_Provider extends CRM_Core_Form {
     if ($name) {
       $defaults['name'] = $name;
       $provider = CRM_SMS_Provider::singleton(['provider' => $name]);
-      $defaults['api_url'] = $provider->_apiURL;
+      $defaults['api_url'] = $provider->_apiURL ?? '';
     }
 
     if (!$this->_id) {

--- a/tests/phpunit/CRM/SMS/ProviderTest.php
+++ b/tests/phpunit/CRM/SMS/ProviderTest.php
@@ -85,4 +85,26 @@ class CRM_SMS_ProviderTest extends CiviUnitTestCase {
     $message->toContactID = $testSourceContact;
   }
 
+  /**
+   * Some providers, like the mock one for these tests at the time of writing,
+   * or the dummy SMS provider extension, might not provide a default url,
+   * but the form shouldn't fail because of that.
+   */
+  public function testMissingUrl() {
+    $form = $this->getFormObject('CRM_SMS_Form_Provider');
+    $_REQUEST['key'] = 'CiviTestSMSProvider';
+
+    // This shouldn't give a notice
+    $defaults = $form->setDefaultValues();
+
+    $this->assertEquals([
+      'name' => 'CiviTestSMSProvider',
+      'api_url' => '',
+      'is_default' => 1,
+      'is_active' => 1,
+    ], $defaults);
+
+    unset($_REQUEST['key']);
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/1909

Some providers, like the dummy SMS provider extension, don't provide a default url. The form gives an E_NOTICE when adding it as a provider.

Before
----------------------------------------
Before the patch, test gives: `Undefined property: CiviTestSMSProvider::$_apiURL`

After
----------------------------------------
No notice

Technical Details
----------------------------------------
Just needs check against missing parameter.

Comments
----------------------------------------
Has test
