### PR TITLE
dev/core#1913 Allow for schemas to be added by extensions if they are…

### DIFF
--- a/CRM/UF/Page/ProfileEditor.php
+++ b/CRM/UF/Page/ProfileEditor.php
@@ -192,7 +192,20 @@ class CRM_UF_Page_ProfileEditor extends CRM_Core_Page {
           break;
 
         default:
-          throw new CRM_Core_Exception("Unrecognized entity type: $entityType");
+          if (strpos($entityType, 'Model') !== FALSE) {
+            $entity = str_replace('Model', '', $entityType);
+            $backboneModel = self::convertCiviModelToBackboneModel(
+              $entity,
+              ts('%1', [1 => $entity]),
+              $availableFields
+            );
+            if (!empty($backboneModel['schema'])) {
+              $civiSchema[$entityType] = $backboneModel;
+            }
+          }
+          if (!isset($civiSchema[$entityType])) {
+            throw new CRM_Core_Exception("Unrecognized entity type: $entityType");
+          }
       }
     }
 

--- a/tests/phpunit/CRM/UF/Page/ProfileEditorTest.php
+++ b/tests/phpunit/CRM/UF/Page/ProfileEditorTest.php
@@ -45,4 +45,28 @@ class CRM_UF_Page_ProfileEditorTest extends CiviUnitTestCase {
 
   }
 
+  /**
+   * Test that with an extension adding in UF Fields for an enttiy that isn't supplied by Core e.g. Grant
+   * That an appropriate entitytype can be specfied in the backbone.marionette profile editor e.g. GrantModel
+   */
+  public function testGetSchemaWithHooks() {
+    CRM_Utils_Hook::singleton()->setHook('civicrm_alterUFFields', [$this, 'hook_civicrm_alterUFFIelds']);
+    $schema = CRM_UF_Page_ProfileEditor::getSchema(['IndividualModel', 'GrantModel']);
+    $this->assertEquals('Grant', $schema['GrantModel']['schema']['grant_decision_date']['civiFieldType']);
+  }
+
+  /**
+   * Tries to load up the profile schema for a model where there is no corresponding set of fields avaliable.
+   *
+   * @expectedException \CRM_Core_Exception
+   */
+  public function testGetSchemaWithHooksWithInvalidModel() {
+    CRM_Utils_Hook::singleton()->setHook('civicrm_alterUFFields', [$this, 'hook_civicrm_alterUFFIelds']);
+    $schema = CRM_UF_Page_ProfileEditor::getSchema(['IndividualModel', 'GrantModel', 'PledgeModel']);
+  }
+
+  public function hook_civicrm_alterUFFIelds(&$fields) {
+    $fields['Grant'] = CRM_Grant_BAO_Grant::exportableFields();
+  }
+
 }


### PR DESCRIPTION
… in the format of <entityname>Model

Overview
----------------------------------------
This is an alternate PR to https://github.com/civicrm/civicrm-core/pull/17971 which aims to achieve the same effect without the new hook

Before
----------------------------------------
Adding in an entity GrandModel for UF ProfileSchema doesn't work without a core override

After
----------------------------------------
Does work without a core override as long as there are availabe fields added

ping @colemanw @eileenmcnaughton @monishdeb 