### PR TITLE
Remove duplicate cache flush

### DIFF
--- a/CRM/Core/BAO/Cache.php
+++ b/CRM/Core/BAO/Cache.php
@@ -247,11 +247,6 @@ class CRM_Core_BAO_Cache extends CRM_Core_DAO_Cache {
    * Cleanup ACL and System Level caches
    */
   public static function resetCaches() {
-    // also reset ACL Cache
-    // @todo why is this called when CRM_Utils_System::flushCache() does it as well.
-    CRM_ACL_BAO_Cache::resetCache();
-
-    // also reset memory cache if any
     CRM_Utils_System::flushCache();
   }
 


### PR DESCRIPTION


Overview
----------------------------------------
Removes duplicate, potentially expensive, query

Before
----------------------------------------

```
CRM_ACL_BAO_Cache::resetCache();
```

Called before

```
CRM_Utils_System::flushCache();
```

And also from within it

After
----------------------------------------
Only called within flushCache

Technical Details
----------------------------------------
As the comment points out CRM_ACL_BAO_Cache::resetCache is also called in CRM_Utils_System::flushCache
so we are running a query that is inclined to lock tables an extra time for no reason

Comments
----------------------------------------
@seamuslee001 