### PR TITLE
[REF] Extract function to get locations to merge, rename 'operation' …

### DIFF
--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -1388,7 +1388,9 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
         $removeTables = array_merge($moveTables, $relTables[substr($key, 5)]['tables']);
       }
     }
-    self::mergeLocations($mainId, $otherId, $migrationInfo);
+    $mergeHandler = new CRM_Dedupe_MergeHandler((int) $mainId, (int) $otherId);
+    $mergeHandler->setMigrationInfo($migrationInfo);
+    self::mergeLocations($mergeHandler);
 
     // **** Do contact related migrations
     // @todo - move all custom field processing to the move class & eventually have an
@@ -1396,7 +1398,7 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
     $customFieldBAO = new CRM_Core_BAO_CustomField();
     $customFieldBAO->move($otherId, $mainId, $submittedCustomFields);
     // add the related tables and unset the ones that don't sport any of the duplicate contact's info
-    $mergeHandler = new CRM_Dedupe_MergeHandler((int) $mainId, (int) $otherId);
+
     CRM_Dedupe_Merger::moveContactBelongings($mergeHandler, $moveTables, $tableOperations);
     unset($moveTables, $tableOperations);
 
@@ -1775,43 +1777,19 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
    * The use of the new hook is tested, including the fact it is called before contributions are merged, as this
    * is likely to be significant data in merge hooks.
    *
-   * @param int $mainId
-   * @param int $otherId
-   *
-   * @param array $migrationInfo
-   *   Migration info for the merge. This is passed to the hook as informational only.
+   * @param \CRM_Dedupe_MergeHandler $mergeHandler
    */
-  public static function mergeLocations($mainId, $otherId, $migrationInfo) {
-    foreach ($migrationInfo as $key => $value) {
-      $isLocationField = (substr($key, 0, 14) === 'move_location_' and $value != NULL);
-      if (!$isLocationField) {
-        continue;
-      }
-      $locField = explode('_', $key);
-      $fieldName = $locField[2];
-      $fieldCount = $locField[3];
-
-      // Set up the operation type (add/overwrite)
-      // Ignore operation for websites
-      // @todo Tidy this up
-      $operation = 0;
-      if ($fieldName !== 'website') {
-        $operation = $migrationInfo['location_blocks'][$fieldName][$fieldCount]['operation'] ?? NULL;
-      }
-      // default operation is overwrite.
-      if (!$operation) {
-        $operation = 2;
-      }
-      $locBlocks[$fieldName][$fieldCount]['operation'] = $operation;
-    }
+  public static function mergeLocations($mergeHandler) {
+    $locBlocks = $mergeHandler->getLocationBlocksToMerge();
     $blocksDAO = [];
+    $migrationInfo = $mergeHandler->getMigrationInfo();
 
     // @todo Handle OpenID (not currently in API).
     if (!empty($locBlocks)) {
       $locationBlocks = self::getLocationBlockInfo();
 
-      $primaryBlockIds = CRM_Contact_BAO_Contact::getLocBlockIds($mainId, ['is_primary' => 1]);
-      $billingBlockIds = CRM_Contact_BAO_Contact::getLocBlockIds($mainId, ['is_billing' => 1]);
+      $primaryBlockIds = CRM_Contact_BAO_Contact::getLocBlockIds($mergeHandler->getToKeepID(), ['is_primary' => 1]);
+      $billingBlockIds = CRM_Contact_BAO_Contact::getLocBlockIds($mergeHandler->getToKeepID(), ['is_billing' => 1]);
 
       foreach ($locBlocks as $name => $block) {
         $blocksDAO[$name] = ['delete' => [], 'update' => []];
@@ -1832,7 +1810,7 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
 
           // For the block which belongs to other-contact, link the location block to main-contact
           $otherBlockDAO = new $daoName();
-          $otherBlockDAO->contact_id = $mainId;
+          $otherBlockDAO->contact_id = $mergeHandler->getToKeepID();
 
           // Get the ID of this block on the 'other' contact, otherwise skip
           $otherBlockDAO->id = $otherBlockId;
@@ -1871,9 +1849,8 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
             $otherBlockDAO->is_billing = 0;
           }
 
-          $operation = CRM_Utils_Array::value('operation', $values, 2);
           // overwrite - need to delete block which belongs to main-contact.
-          if (!empty($mainBlockId) && ($operation == 2)) {
+          if (!empty($mainBlockId) && $values['is_replace']) {
             $deleteDAO = new $daoName();
             $deleteDAO->id = $mainBlockId;
             $deleteDAO->find(TRUE);
@@ -1893,7 +1870,7 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
       }
     }
 
-    CRM_Utils_Hook::alterLocationMergeData($blocksDAO, $mainId, $otherId, $migrationInfo);
+    CRM_Utils_Hook::alterLocationMergeData($blocksDAO, $mergeHandler->getToKeepID(), $mergeHandler->getToRemoveID(), $migrationInfo);
     foreach ($blocksDAO as $blockDAOs) {
       if (!empty($blockDAOs['update'])) {
         foreach ($blockDAOs['update'] as $blockDAO) {

--- a/tests/phpunit/api/v3/ContactTest.php
+++ b/tests/phpunit/api/v3/ContactTest.php
@@ -3968,23 +3968,17 @@ class api_v3_ContactTest extends CiviUnitTestCase {
    */
   public function testMerge() {
     $this->createLoggedInUser();
-    $otherContact = $this->callAPISuccess('contact', 'create', $this->_params);
-    $retainedContact = $this->callAPISuccess('contact', 'create', $this->_params);
-    $this->callAPISuccess('contact', 'merge', [
-      'to_keep_id' => $retainedContact['id'],
-      'to_remove_id' => $otherContact['id'],
-      'auto_flip' => FALSE,
-    ]);
+    $this->ids['contact'][0] = $this->callAPISuccess('Contact', 'create', $this->_params)['id'];
+    $this->ids['contact'][1] = $this->callAPISuccess('Contact', 'create', $this->_params)['id'];
+    $retainedContact = $this->doMerge();
 
-    $contacts = $this->callAPISuccess('contact', 'get', $this->_params);
-    $this->assertEquals($retainedContact['id'], $contacts['id']);
     $activity = $this->callAPISuccess('Activity', 'getsingle', [
       'target_contact_id' => $retainedContact['id'],
       'activity_type_id' => 'Contact Merged',
     ]);
     $this->assertEquals(date('Y-m-d'), date('Y-m-d', strtotime($activity['activity_date_time'])));
     $activity2 = $this->callAPISuccess('Activity', 'getsingle', [
-      'target_contact_id' => $otherContact['id'],
+      'target_contact_id' => $this->ids['contact'][1],
       'activity_type_id' => 'Contact Deleted by Merge',
     ]);
     $this->assertEquals($activity['id'], $activity2['parent_id']);


### PR DESCRIPTION
Overview
----------------------------------------
This is a preliminary refactor. I have a bug to fix in this code but cannot yet make sense of it. 

Before
----------------------------------------
One long function. Hard to interpret the meaning of 'operation' 

After
----------------------------------------
First part of the function is extracted, 'operation' is now cast to a boolean 'is_replace'

Technical Details
----------------------------------------
The mergeHandler class is simply an object to refactor the functions onto. Much of this code is hard to work with as the use of static functions
necessitates a lot of compilation and passing so the process of cleaning it up involves extracting functions to this
new class (which may one day replace the Merger class). As it is a refactoring process the functions reflect the old code
more than the ideal code. However, it provides the change to give some documentation regarding the locBlock array
and also to rename the confusing field 'operation' to 'is_replace'


Comments
----------------------------------------
There is extensive test cover on these lines in class touched & in api_v3_JobTest
