### PR TITLE
Remove first contribution

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4455,7 +4455,8 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
   public static function completeOrder($input, &$ids, $objects, $isPostPaymentCreate = FALSE) {
     $transaction = new CRM_Core_Transaction();
     $contribution = $objects['contribution'];
-    $primaryContributionID = $contribution->id ?? $objects['first_contribution']->id;
+
+    $primaryContributionID = $contribution->id ?? $input['original_contribution_id'];
     // The previous details are used when calculating line items so keep it before any code that 'does something'
     if (!empty($contribution->id)) {
       $input['prevContribution'] = CRM_Contribute_BAO_Contribution::getValues(['id' => $contribution->id]);

--- a/CRM/Event/Form/Task/Batch.php
+++ b/CRM/Event/Form/Task/Batch.php
@@ -379,6 +379,10 @@ class CRM_Event_Form_Task_Batch extends CRM_Event_Form_Task {
     if (!$baseIPN->validateData($input, $ids, $objects, FALSE)) {
       throw new CRM_Core_Exception('validation error');
     }
+    // @todo This replaces usage of $objects['first_contribution']->id - is it required here?
+    if (isset($objects['contributionRecur'])) {
+      $input['original_contribution_id'] = $objects['contribution']->id ?? NULL;
+    }
 
     $contribution = &$objects['contribution'];
 


### PR DESCRIPTION
Overview
----------------------------------------
This is a step towards simplifying completetransaction/repeattransaction calls. `$objects['first_contribution']` is only used in the case of repeattransaction and is only used to pass the contribution ID and currency.

The currency was added via a relatively recent PR and could have just used the existing contribution object - but given the number of different objects/array being passed around it would have been difficult to choose which one to use! 

Before
----------------------------------------
Additional object is passed around containing the "first_contribution" if called via Contribution.repeattransaction API.

After
----------------------------------------
Necessary parameters (contribution ID) are passed via input parameters. Currency is retrieved from `$contribution` object.

Technical Details
----------------------------------------
This is a further step towards simplifying this area of code.

Comments
----------------------------------------
@eileenmcnaughton You're probably the only one who can make sense of this :-) It sort of comes out of #17455 and should act as another step towards cleaning up the multiple template contribution lookups / calculation of original_contribution_id
