### PR TITLE
Cache loader - remove legacy handling, handle null result from setting

### DIFF
--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -210,7 +210,7 @@ class Container {
       ->setFactory('CRM_Utils_Mail::createMailer');
 
     if (empty(\Civi::$statics[__CLASS__]['boot'])) {
-      throw new \RuntimeException("Cannot initialize container. Boot services are undefined.");
+      throw new \RuntimeException('Cannot initialize container. Boot services are undefined.');
     }
     foreach (\Civi::$statics[__CLASS__]['boot'] as $bootService => $def) {
       $container->setDefinition($bootService, new Definition())->setSynthetic(TRUE)->setPublic(TRUE);
@@ -461,20 +461,19 @@ class Container {
    */
   public static function createPrevNextCache($container) {
     $setting = \Civi::settings()->get('prevNextBackend');
-    if ($setting === 'default') {
-      // For initial release (5.8.x), continue defaulting to SQL.
-      $isTransitional = version_compare(\CRM_Utils_System::version(), '5.9.alpha1', '<');
+    if (!$setting || $setting === 'default') {
       $cacheDriver = \CRM_Utils_Cache::getCacheDriver();
       $service = 'prevnext.driver.' . strtolower($cacheDriver);
-      return $container->has($service) && !$isTransitional
+      return $container->has($service)
         ? $container->get($service)
         : $container->get('prevnext.driver.sql');
     }
-    else {
-      return $container->get('prevnext.driver.' . $setting);
-    }
+    return $container->get('prevnext.driver.' . $setting);
   }
 
+  /**
+   * @return \ArrayObject
+   */
   public static function createCacheConfig() {
     $driver = \CRM_Utils_Cache::getCacheDriver();
     $settings = \CRM_Utils_Cache::getCacheSettings($driver);
@@ -548,6 +547,11 @@ class Container {
     }
   }
 
+  /**
+   * @param string $name
+   *
+   * @return mixed
+   */
   public static function getBootService($name) {
     return \Civi::$statics[__CLASS__]['boot'][$name];
   }


### PR DESCRIPTION


Overview
----------------------------------------
Provides backup handling for an edge case bug.

We are seeing this symptom in our tests in some cases
https://civicrm.stackexchange.com/questions/28897/error-when-merging-accounts

I'm not quite sure why the setting would be empty - but treating empty the same as 'default'
seems better than a hard fail and we know that settings have a track history of not all being
loaded at the right times.



Before
----------------------------------------
Fatal error when \Civi::settings()->get('prevNextBackend') returns nothing

After
----------------------------------------
Fallback handling

Technical Details
----------------------------------------
This also removes some legacy handling which seems intended to be temporary based on code comments

Comments
----------------------------------------

