### PR TITLE
Change inform-icon to fa-info-circle

### DIFF
--- a/CRM/Core/Error.php
+++ b/CRM/Core/Error.php
@@ -358,7 +358,7 @@ class CRM_Core_Error extends PEAR_ErrorStack {
     if (CRM_Utils_Array::value('snippet', $_REQUEST) === CRM_Core_Smarty::PRINT_JSON) {
       $out = [
         'status' => 'fatal',
-        'content' => '<div class="messages status no-popup"><div class="icon inform-icon"></div>' . ts('Sorry but we are not able to provide this at the moment.') . '</div>',
+        'content' => '<div class="messages status no-popup">' . CRM_Core_Page::crmIcon('fa-info-circle') . ' ' . ts('Sorry but we are not able to provide this at the moment.') . '</div>',
       ];
       if ($config->backtrace && CRM_Core_Permission::check('view debug output')) {
         $out['backtrace'] = self::parseBacktrace(debug_backtrace());

--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -2137,11 +2137,6 @@ a.crm-i:hover {
   padding-left: 1.6em;
 }
 
-.crm-container .inform-icon {
-  background-position: -16px -144px;
-  margin-right: 5px;
-}
-
 .crm-container a.helpicon {
   opacity: .8;
 }

--- a/templates/CRM/ACL/Form/ACL.tpl
+++ b/templates/CRM/ACL/Form/ACL.tpl
@@ -11,7 +11,7 @@
 <div class="crm-block crm-form-block crm-acl-form-block">
 {if $action eq 8}
   <div class="messages status no-popup">
-    <div class="icon inform-icon"></div>&nbsp;
+    {icon icon="fa-info-circle"}{/icon}
         {ts}WARNING: Delete will remove this permission from the specified ACL Role.{/ts} {ts}Do you want to continue?{/ts}
   </div>
 {else}

--- a/templates/CRM/ACL/Form/ACLBasic.tpl
+++ b/templates/CRM/ACL/Form/ACLBasic.tpl
@@ -14,7 +14,7 @@
 {if $action eq 8}
   <div class="messages status no-popup">
     <dl>
-      <dt><div class="icon inform-icon"></div></dt>
+      <dt>{icon icon="fa-info-circle"}{/icon}</dt>
       <dd>
         {ts}WARNING: Delete will remove this permission from the specified ACL Role.{/ts} {ts}Do you want to continue?{/ts}
       </dd>

--- a/templates/CRM/ACL/Form/EntityRole.tpl
+++ b/templates/CRM/ACL/Form/EntityRole.tpl
@@ -13,7 +13,7 @@
  <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
 {if $action eq 8}
   <div class="messages status no-popup">
-  <div class="icon inform-icon"></div>
+  {icon icon="fa-info-circle"}{/icon}
        {ts}WARNING: Deleting this option will remove this ACL Role Assignment.{/ts} {ts}Do you want to continue?{/ts}
   </div>
 {else}

--- a/templates/CRM/Activity/Form/Search/EmptyResults.tpl
+++ b/templates/CRM/Activity/Form/Search/EmptyResults.tpl
@@ -9,7 +9,7 @@
 *}
 {* No matches for submitted search request. *}
 <div class="messages status no-popup">
-  <div class="icon inform-icon"></div>  &nbsp;
+  {icon icon="fa-info-circle"}{/icon}
     {if $qill}{ts}No matches found for:{/ts}
         {include file="CRM/common/displaySearchCriteria.tpl"}
     {else}

--- a/templates/CRM/Activity/Form/Task/Delete.tpl
+++ b/templates/CRM/Activity/Form/Task/Delete.tpl
@@ -11,7 +11,7 @@
 <div class="crm-block crm-form-block crm-activity_delete-form-block">
 <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
 <div class="messages status no-popup">
-     <div class="icon inform-icon"></div>
+     {icon icon="fa-info-circle"}{/icon}
           <p>{ts}Are you sure you want to delete the selected Activities?{/ts}</p>
         <p>{include file="CRM/Activity/Form/Task.tpl"}</p>
     </div>

--- a/templates/CRM/Activity/Form/Task/Print.tpl
+++ b/templates/CRM/Activity/Form/Task/Print.tpl
@@ -67,7 +67,7 @@
   {include file="CRM/common/formButtons.tpl" location="bottom"}
 {else}
    <div class="messages status no-popup">
-       <div class="icon inform-icon"></div>
+       {icon icon="fa-info-circle"}{/icon}
          {ts}There are no records selected for Print.{/ts}
     </div>
 {/if}

--- a/templates/CRM/Activity/Form/Task/SearchTaskHookSample.tpl
+++ b/templates/CRM/Activity/Form/Task/SearchTaskHookSample.tpl
@@ -37,7 +37,7 @@
 
 {else}
    <div class="messages status no-popup">
-          <div class="icon inform-icon"></div>
+          {icon icon="fa-info-circle"}{/icon}
             {ts}There are no records selected.{/ts}
    </div>
 {/if}

--- a/templates/CRM/Activity/Page/UserDashboard.tpl
+++ b/templates/CRM/Activity/Page/UserDashboard.tpl
@@ -47,7 +47,7 @@ q="action=view&reset=1&id=`$row.activity_id`&cid=`$row.contact_id`&context=dashb
         {/strip}
     {else}
         <div class="messages status no-popup">
-           <div class="icon inform-icon"></div>&nbsp;
+           {icon icon="fa-info-circle"}{/icon}
                  {ts}There are no scheduled activities assigned to you.{/ts}
 
         </div>

--- a/templates/CRM/Admin/Form/ContactType.tpl
+++ b/templates/CRM/Admin/Form/ContactType.tpl
@@ -12,7 +12,7 @@
 <div class="crm-block crm-form-block crm-contact-type-form-block">
 {if $action eq 8}
   <div class="messages status no-popup">
-    <div class="icon inform-icon"></div>
+    {icon icon="fa-info-circle"}{/icon}
         {ts}WARNING: {ts}This action cannot be undone.{/ts} {ts}Do you want to continue?{/ts}{/ts}
     </div>
 {else}

--- a/templates/CRM/Admin/Form/Extensions.tpl
+++ b/templates/CRM/Admin/Form/Extensions.tpl
@@ -12,20 +12,20 @@
 <div class="crm-block crm-form-block crm-admin-optionvalue-form-block">
    {if $action eq 8}
       <div class="messages status no-popup">
-          <div class="icon inform-icon"></div>
-          {ts}WARNING: Uninstalling this extension might result in the loss of all records which use the extension.{/ts} {ts}This may mean the loss of a substantial amount of data, and the action cannot be undone. Please review the extension information below before you make final decision.{/ts} {ts}Do you want to continue?{/ts}
+        {icon icon="fa-info-circle"}{/icon}
+        {ts}WARNING: Uninstalling this extension might result in the loss of all records which use the extension.{/ts} {ts}This may mean the loss of a substantial amount of data, and the action cannot be undone. Please review the extension information below before you make final decision.{/ts} {ts}Do you want to continue?{/ts}
       </div>
    {/if}
    {if $action eq 1}
-      <div class="messages status no-popup">
-          <div class="icon inform-icon"></div>
-          {ts}Installing this extension will provide you with new functionality. Please make sure that the extension you're installing comes from a trusted source.{/ts} {ts}Do you want to continue?{/ts}
+     <div class="messages status no-popup">
+        {icon icon="fa-info-circle"}{/icon}
+        {ts}Installing this extension will provide you with new functionality. Please make sure that the extension you're installing comes from a trusted source.{/ts} {ts}Do you want to continue?{/ts}
       </div>
    {/if}
    {if $action eq 2}
-      <div class="messages status no-popup">
-          <div class="icon inform-icon"></div>
-          {ts}Downloading this extension will provide you with new functionality. Please make sure that the extension you're installing or upgrading comes from a trusted source.{/ts} {ts}Do you want to continue?{/ts}
+     <div class="messages status no-popup">
+        {icon icon="fa-info-circle"}{/icon}
+        {ts}Downloading this extension will provide you with new functionality. Please make sure that the extension you're installing or upgrading comes from a trusted source.{/ts} {ts}Do you want to continue?{/ts}
       </div>
    {/if}
    {if $action eq 8 or $action eq 1 or $action eq 2}

--- a/templates/CRM/Admin/Form/Job.tpl
+++ b/templates/CRM/Admin/Form/Job.tpl
@@ -14,12 +14,12 @@
 
 {if $action eq 8}
   <div class="messages status no-popup">
-      <div class="icon inform-icon"></div>
+      {icon icon="fa-info-circle"}{/icon}
         {ts}WARNING: Deleting this Scheduled Job will cause some important site functionality to stop working.{/ts} {ts}Do you want to continue?{/ts}
   </div>
 {elseif $action eq 4}
   <div class="messages status no-popup">
-      <div class="icon inform-icon"></div>
+      {icon icon="fa-info-circle"}{/icon}
         {ts 1=$jobName}Are you sure you would like to execute %1 job?{/ts}
   </div>
 {else}

--- a/templates/CRM/Admin/Form/LabelFormats.tpl
+++ b/templates/CRM/Admin/Form/LabelFormats.tpl
@@ -28,12 +28,12 @@
 <div class="crm-block crm-form-block crm-labelFormat-form-block">
   {if $action eq 8}
     <div class="messages status no-popup">
-      <div class="icon inform-icon"></div>
+      {icon icon="fa-info-circle"}{/icon}
       {ts 1=$formatName}WARNING: You are about to delete the Label Format titled <strong>%1</strong>.{/ts} {ts}Do you want to continue?{/ts}
     </div>
   {elseif $action eq 16384}
     <div class="messages status no-popup">
-      <div class="icon inform-icon"></div>
+      {icon icon="fa-info-circle"}{/icon}
       {ts 1=$formatName}Are you sure you would like to make a copy of the Label Format titled <strong>%1</strong>?{/ts}
     </div>
   {else}

--- a/templates/CRM/Admin/Form/LocationType.tpl
+++ b/templates/CRM/Admin/Form/LocationType.tpl
@@ -12,7 +12,7 @@
 <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
 {if $action eq 8}
   <div class="messages status no-popup">
-     <div class="icon inform-icon"></div>
+     {icon icon="fa-info-circle"}{/icon}
         {ts}WARNING: Deleting this option will result in the loss of all location type records which use the option.{/ts} {ts}This may mean the loss of a substantial amount of data, and the action cannot be undone.{/ts} {ts}Do you want to continue?{/ts}
       </div>
 {else}

--- a/templates/CRM/Admin/Form/MailSettings.tpl
+++ b/templates/CRM/Admin/Form/MailSettings.tpl
@@ -12,7 +12,7 @@
 <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
 {if $action eq 8}
   <div class="messages status no-popup">
-      <div class="icon inform-icon"></div>
+      {icon icon="fa-info-circle"}{/icon}
   {ts}WARNING: Deleting this option will result in the loss of mail settings data.{/ts} {ts}Do you want to continue?{/ts}
   </div>
     <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>

--- a/templates/CRM/Admin/Form/Mapping.tpl
+++ b/templates/CRM/Admin/Form/Mapping.tpl
@@ -27,7 +27,7 @@
       </table>
     {else}
         <div class="messages status no-popup">
-            <div class="icon inform-icon"></div> &nbsp;
+            {icon icon="fa-info-circle"}{/icon}
             {ts 1=$mappingName}WARNING: Are you sure you want to delete mapping '<b>%1</b>'?{/ts} {ts}This action cannot be undone.{/ts}
         </div>
         <br />

--- a/templates/CRM/Admin/Form/MessageTemplates.tpl
+++ b/templates/CRM/Admin/Form/MessageTemplates.tpl
@@ -22,7 +22,7 @@
 <div class="form-item" id="message_templates">
 {if $action eq 8}
    <div class="messages status no-popup">
-       <div class="icon inform-icon"></div>
+       {icon icon="fa-info-circle"}{/icon}
        {ts 1=$msg_title|escape}Do you want to delete the message template '%1'?{/ts}
    </div>
 {else}

--- a/templates/CRM/Admin/Form/OptionGroup.tpl
+++ b/templates/CRM/Admin/Form/OptionGroup.tpl
@@ -12,7 +12,7 @@
   <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
    {if $action eq 8}
       <div class="messages status no-popup">
-          <div class="icon inform-icon"></div>
+          {icon icon="fa-info-circle"}{/icon}
           {ts}WARNING: Deleting this option gruop will result in the loss of all records which use the option.{/ts} {ts}This may mean the loss of a substantial amount of data, and the action cannot be undone.{/ts} {ts}Do you want to continue?{/ts}
       </div>
      {else}

--- a/templates/CRM/Admin/Form/Options.tpl
+++ b/templates/CRM/Admin/Form/Options.tpl
@@ -12,7 +12,7 @@
 <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
   {if $action eq 8}
       <div class="messages status no-popup">
-        <div class="icon inform-icon"></div>
+        {icon icon="fa-info-circle"}{/icon}
              {ts 1=$gLabel}WARNING: Deleting this option will result in the loss of all %1 related records which use the option.{/ts} {ts}This may mean the loss of a substantial amount of data, and the action cannot be undone.{/ts} {ts}Do you want to continue?{/ts}
       </div>
     {else}

--- a/templates/CRM/Admin/Form/ParticipantStatusType.tpl
+++ b/templates/CRM/Admin/Form/ParticipantStatusType.tpl
@@ -15,7 +15,7 @@
    <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
     {if $action eq 8}
       <div class="messages status no-popup">
-       <div class="icon inform-icon"></div>
+       {icon icon="fa-info-circle"}{/icon}
              {ts}WARNING: Deleting this Participant Status will remove all of its settings.{/ts} {ts}Do you want to continue?{/ts}
        </div>
       <div>{include file="CRM/common/formButtons.tpl"}

--- a/templates/CRM/Admin/Form/PaymentProcessor.tpl
+++ b/templates/CRM/Admin/Form/PaymentProcessor.tpl
@@ -14,7 +14,7 @@
 
 {if $action eq 8}
   <div class="messages status no-popup">
-    <div class="icon inform-icon"></div>
+    {icon icon="fa-info-circle"}{/icon}
     {$deleteMessage|escape}
   </div>
 {else}

--- a/templates/CRM/Admin/Form/PaymentProcessorType.tpl
+++ b/templates/CRM/Admin/Form/PaymentProcessorType.tpl
@@ -13,7 +13,7 @@
  <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
 {if $action eq 8}
   <div class="messages status no-popup">
-      <div class="icon inform-icon"></div>
+      {icon icon="fa-info-circle"}{/icon}
       {ts}Do you want to continue?{/ts}
   </div>
 {else}

--- a/templates/CRM/Admin/Form/PdfFormats.tpl
+++ b/templates/CRM/Admin/Form/PdfFormats.tpl
@@ -30,7 +30,7 @@
 
 {if $action eq 8}
   <div class="messages status no-popup">
-      <div class="icon inform-icon"></div>
+      {icon icon="fa-info-circle"}{/icon}
         {ts 1=$formatName}WARNING: You are about to delete the PDF Page Format titled <strong>%1</strong>.{/ts}<p>{ts}This will remove the format from all Message Templates that use it. Do you want to continue?{/ts}</p>
   </div>
 {else}

--- a/templates/CRM/Admin/Form/ScheduleReminders.tpl
+++ b/templates/CRM/Admin/Form/ScheduleReminders.tpl
@@ -13,7 +13,7 @@
 
 {if $action eq 8}
   <div class="messages status no-popup">
-      <div class="icon inform-icon"></div>
+      {icon icon="fa-info-circle"}{/icon}
         {ts 1=$reminderName}WARNING: You are about to delete the Reminder titled <strong>%1</strong>.{/ts} {ts}Do you want to continue?{/ts}
   </div>
 {else}

--- a/templates/CRM/Admin/Page/EventTemplate.tpl
+++ b/templates/CRM/Admin/Page/EventTemplate.tpl
@@ -56,7 +56,7 @@
 
 {else}
     <div class="messages status no-popup">
-    <div class="icon inform-icon"></div>
+    {icon icon="fa-info-circle"}{/icon}
     {capture assign=crmURL}{crmURL p='civicrm/event/add' q="action=add&is_template=1&reset=1"}{/capture}
         {ts 1=$crmURL}There are no Event Templates present. You can <a href='%1'>add one</a>.{/ts}
     </div>

--- a/templates/CRM/Admin/Page/Extensions/AddNew.tpl
+++ b/templates/CRM/Admin/Page/Extensions/AddNew.tpl
@@ -41,7 +41,7 @@ Depends: CRM/common/enableDisableApi.tpl and CRM/common/jsortable.tpl
   </div>
 {else}
   <div class="messages status no-popup">
-       <div class="icon inform-icon"></div>
+       {icon icon="fa-info-circle"}{/icon}
       {ts}There are no extensions to display. Please click "Refresh" to update information about available extensions.{/ts}
   </div>
 {/if}

--- a/templates/CRM/Admin/Page/Extensions/AddNewReq.tpl
+++ b/templates/CRM/Admin/Page/Extensions/AddNewReq.tpl
@@ -1,7 +1,7 @@
 <div class="crm-content-block crm-block">
   {foreach from=$extAddNewReqs item=req}
   <div class="messages status no-popup">
-       <div class="icon inform-icon"></div>
+       {icon icon="fa-info-circle"}{/icon}
        {$req.title}<br/>
        {$req.message}
   </div>

--- a/templates/CRM/Admin/Page/Extensions/Main.tpl
+++ b/templates/CRM/Admin/Page/Extensions/Main.tpl
@@ -45,7 +45,7 @@ Depends: CRM/common/enableDisableApi.tpl and CRM/common/jsortable.tpl
   </div>
 {else}
   <div class="messages status no-popup">
-       <div class="icon inform-icon"></div>
+       {icon icon="fa-info-circle"}{/icon}
       {ts 1="https://civicrm.org/extensions"}There are no extensions to display. Click the "Add New" tab to browse and install extensions posted on the <a href="%1">public CiviCRM Extensions Directory</a>. If you have downloaded extensions manually and don't see them here, try clicking the "Refresh" button.{/ts}
   </div>
 {/if}

--- a/templates/CRM/Admin/Page/Job.tpl
+++ b/templates/CRM/Admin/Page/Job.tpl
@@ -63,7 +63,7 @@
 </div>
 {elseif $action ne 1}
     <div class="messages status no-popup">
-      <div class="icon inform-icon"></div>
+      {icon icon="fa-info-circle"}{/icon}
         {ts}There are no jobs configured.{/ts}
      </div>
      <div class="action-link">

--- a/templates/CRM/Admin/Page/JobLog.tpl
+++ b/templates/CRM/Admin/Page/JobLog.tpl
@@ -49,7 +49,7 @@
   </div>
 {elseif $action ne 1}
     <div class="messages status no-popup">
-      <div class="icon inform-icon"></div>&nbsp;
+      {icon icon="fa-info-circle"}{/icon}
       {if $jobId}
         {ts}This scheduled job does not have any log entries.{/ts}
       {else}

--- a/templates/CRM/Admin/Page/LabelFormats.tpl
+++ b/templates/CRM/Admin/Page/LabelFormats.tpl
@@ -68,7 +68,7 @@
     </div>
   {else}
     <div class="messages status no-popup">
-      <div class="icon inform-icon"></div>
+      {icon icon="fa-info-circle"}{/icon}
       {capture assign=crmURL}{crmURL p='civicrm/admin/labelFormats' q="action=add&reset=1"}{/capture}
       {ts 1=$crmURL}There are no Label Formats configured. You can<a href='%1'>add one</a>.{/ts}
     </div>

--- a/templates/CRM/Admin/Page/MessageTemplates.tpl
+++ b/templates/CRM/Admin/Page/MessageTemplates.tpl
@@ -147,7 +147,7 @@
 
             {if empty( $template_row) }
                 <div class="messages status no-popup">
-                    <div class="icon inform-icon"></div>&nbsp;
+                    {icon icon="fa-info-circle"}{/icon}
                     {ts 1=$crmURL}There are no User-driven Message Templates entered. You can <a href='%1'>add one</a>.{/ts}
                 </div>
             {/if}

--- a/templates/CRM/Admin/Page/PaymentProcessor.tpl
+++ b/templates/CRM/Admin/Page/PaymentProcessor.tpl
@@ -58,7 +58,7 @@
 </div>
 {elseif $action ne 1}
     <div class="messages status no-popup">
-      <div class="icon inform-icon"></div>
+      {icon icon="fa-info-circle"}{/icon}
         {ts}There are no Payment Processors entered.{/ts}
      </div>
      <div class="action-link">

--- a/templates/CRM/Admin/Page/PdfFormats.tpl
+++ b/templates/CRM/Admin/Page/PdfFormats.tpl
@@ -60,7 +60,7 @@
     </div>
 {else}
     <div class="messages status no-popup">
-      <div class="icon inform-icon"></div>
+      {icon icon="fa-info-circle"}{/icon}
       {ts}None found.{/ts}
     </div>
 {/if}

--- a/templates/CRM/Admin/Page/ScheduleReminders.tpl
+++ b/templates/CRM/Admin/Page/ScheduleReminders.tpl
@@ -29,7 +29,7 @@
     </div>
   {else}
     <div class="messages status no-popup">
-      <div class="icon inform-icon"></div>
+      {icon icon="fa-info-circle"}{/icon}
       {ts}None found.{/ts}
     </div>
   {/if}

--- a/templates/CRM/Badge/Form/Layout.tpl
+++ b/templates/CRM/Badge/Form/Layout.tpl
@@ -13,7 +13,7 @@
   <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
   {if $action eq 8}
     <div class="messages status no-popup">
-      <div class="icon inform-icon"></div>
+      {icon icon="fa-info-circle"}{/icon}
       {ts}This may mean the loss of a substantial amount of data, and the action cannot be undone.{/ts} {ts}Do you want to continue?{/ts}
     </div>
   {else}

--- a/templates/CRM/Batch/Form/Batch.tpl
+++ b/templates/CRM/Batch/Form/Batch.tpl
@@ -19,7 +19,7 @@
 <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
 {if $action eq 8}
   <div class="messages status no-popup">
-     <div class="icon inform-icon"></div>
+     {icon icon="fa-info-circle"}{/icon}
         {ts}WARNING: Deleting this batch will result in the loss of all data entered for the batch.{/ts} {ts}This may mean the loss of a substantial amount of data, and the action cannot be undone.{/ts} {ts}Do you want to continue?{/ts}
       </div>
 {else}

--- a/templates/CRM/Campaign/Form/Campaign.tpl
+++ b/templates/CRM/Campaign/Form/Campaign.tpl
@@ -14,7 +14,7 @@
   <table class="form-layout">
     <tr>
       <td colspan="2">
-        <div class="status"><div class="icon inform-icon"></div>&nbsp;{ts}Are you sure you want to delete this Campaign?{/ts}</div>
+        <div class="status">{icon icon="fa-info-circle"}{/icon}{ts}Are you sure you want to delete this Campaign?{/ts}</div>
       </td>
     </tr>
   </table>

--- a/templates/CRM/Campaign/Form/Gotv.tpl
+++ b/templates/CRM/Campaign/Form/Gotv.tpl
@@ -10,7 +10,7 @@
 
 {if $errorMessages}
   <div class="messages status crm-error no-popup">
-     <div class="icon inform-icon"></div>
+     {icon icon="fa-info-circle"}{/icon}
         <ul>
           {foreach from=$errorMessages item=errorMsg}
             <li>{ts}{$errorMsg}{/ts}</li>

--- a/templates/CRM/Campaign/Form/Petition.tpl
+++ b/templates/CRM/Campaign/Form/Petition.tpl
@@ -15,7 +15,7 @@
       <tr>
         <td colspan="2">
           <div class="status">
-            <div class="icon inform-icon"></div>
+            {icon icon="fa-info-circle"}{/icon}
             &nbsp;{ts}Are you sure you want to delete this Petition?{/ts}</div>
         </td>
       </tr>

--- a/templates/CRM/Campaign/Form/Search/Campaign.tpl
+++ b/templates/CRM/Campaign/Form/Search/Campaign.tpl
@@ -10,7 +10,7 @@
 
 {if !$hasCampaigns}
   <div class="messages status no-popup">
-    <div class="icon inform-icon"></div>
+    {icon icon="fa-info-circle"}{/icon}
     &nbsp;
     {ts}None found.{/ts}
   </div>

--- a/templates/CRM/Campaign/Form/Search/EmptyResults.tpl
+++ b/templates/CRM/Campaign/Form/Search/EmptyResults.tpl
@@ -9,7 +9,7 @@
 *}
 {* No matches for submitted search request. *}
 <div class="messages status no-popup">
-    <div class="icon inform-icon"></div>
+    {icon icon="fa-info-circle"}{/icon}
         {if $qill}{ts}No matches found for:{/ts}
             {include file="CRM/common/displaySearchCriteria.tpl"}
         {else}

--- a/templates/CRM/Campaign/Form/Search/Petition.tpl
+++ b/templates/CRM/Campaign/Form/Search/Petition.tpl
@@ -10,7 +10,7 @@
 
 {if !$hasPetitions}
     <div class="messages status no-popup">
-        <div class="icon inform-icon"></div> &nbsp;
+        {icon icon="fa-info-circle"}{/icon}
         {ts}None found.{/ts}
     </div>
 

--- a/templates/CRM/Campaign/Form/Search/Survey.tpl
+++ b/templates/CRM/Campaign/Form/Search/Survey.tpl
@@ -10,7 +10,7 @@
 
 {if !$hasSurveys}
     <div class="messages status no-popup">
-        <div class="icon inform-icon"></div> &nbsp;
+        {icon icon="fa-info-circle"}{/icon}
         {ts}None found.{/ts}
     </div>
 

--- a/templates/CRM/Campaign/Form/Survey/Delete.tpl
+++ b/templates/CRM/Campaign/Form/Survey/Delete.tpl
@@ -11,7 +11,7 @@
   <table class="form-layout">
     <tr>
       <td colspan="2">
-        <div class="status"><div class="icon inform-icon"></div>&nbsp;{ts 1=$surveyTitle}Are you sure you want to delete the %1 survey?{/ts}</div>
+        <div class="status">{icon icon="fa-info-circle"}{/icon}{ts 1=$surveyTitle}Are you sure you want to delete the %1 survey?{/ts}</div>
       </td>
     </tr>
   </table>

--- a/templates/CRM/Campaign/Form/Task/Interview.tpl
+++ b/templates/CRM/Campaign/Form/Task/Interview.tpl
@@ -9,7 +9,7 @@
 *}
 {if $votingTab and $errorMessages}
   <div class='messages status'>
-    <div class="icon inform-icon"></div>
+    {icon icon="fa-info-circle"}{/icon}
     <ul>
       {foreach from=$errorMessages item=errorMsg}
         <li>{ts}{$errorMsg}{/ts}</li>

--- a/templates/CRM/Campaign/Form/Task/Print.tpl
+++ b/templates/CRM/Campaign/Form/Task/Print.tpl
@@ -21,7 +21,7 @@
 
 {else}
    <div class="messages status no-popup">
-     <div class="icon inform-icon"/>
+     {icon icon="fa-info-circle"}{/icon}
         {ts}There are no records selected for Print.{/ts}
    </div>
 {/if}

--- a/templates/CRM/Campaign/Form/Task/Release.tpl
+++ b/templates/CRM/Campaign/Form/Task/Release.tpl
@@ -16,7 +16,7 @@
   <tr class="crm-campaign-task-release-form-block-surveytitle">
     <td colspan=2>
       <div class="status">
-        <div class="icon inform-icon"></div>&nbsp;{ts 1=$surveyTitle}Do you want to release respondents for '%1' ?{/ts}
+        {icon icon="fa-info-circle"}{/icon}{ts 1=$surveyTitle}Do you want to release respondents for '%1' ?{/ts}
       </div>
     </td>
   </tr>

--- a/templates/CRM/Campaign/Form/Task/Reserve.tpl
+++ b/templates/CRM/Campaign/Form/Task/Reserve.tpl
@@ -16,7 +16,7 @@
   <tr class="crm-campaign-task-reserve-form-block-surveytitle">
     <td colspan=2>
       <div class="status">
-        <div class="icon inform-icon"></div>&nbsp;{ts 1=$surveyTitle}Do you want to reserve respondents for '%1' ?{/ts}
+        {icon icon="fa-info-circle"}{/icon}{ts 1=$surveyTitle}Do you want to reserve respondents for '%1' ?{/ts}
       </div>
     </td>
   </tr>

--- a/templates/CRM/Campaign/Page/Petition.tpl
+++ b/templates/CRM/Campaign/Page/Petition.tpl
@@ -50,7 +50,7 @@
 
 {else}
   <div class="status">
-    <div class="icon inform-icon"></div>&nbsp;{ts}None found.{/ts}
+    {icon icon="fa-info-circle"}{/icon}{ts}None found.{/ts}
   </div>
 {/if}
 <div class="action-link">

--- a/templates/CRM/Campaign/Page/Petition/Confirm.tpl
+++ b/templates/CRM/Campaign/Page/Petition/Confirm.tpl
@@ -8,7 +8,7 @@
  +--------------------------------------------------------------------+
 *}
 <div class="messages status no-popup">
-    <div class="icon inform-icon"></div>&nbsp;
+    {icon icon="fa-info-circle"}{/icon}
     {if $success}
         {ts 1=$display_name 2=$email}<strong>%1 - your email address '%2' has been successfully verified.</strong>{/ts}
     {else}

--- a/templates/CRM/Campaign/Page/SurveyType.tpl
+++ b/templates/CRM/Campaign/Page/SurveyType.tpl
@@ -47,8 +47,8 @@
 </div>
 {else}
     <div class="messages status no-popup">
-         <div class="icon inform-icon"> &nbsp;
-         {ts p=$addSurveyType.0 q=$addSurveyType.1}There are no survey types entered. You can <a href='%1'>add one</a>.{/ts}</div>
+      {icon icon="fa-info-circle"}{/icon}
+      {ts p=$addSurveyType.0 q=$addSurveyType.1}There are no survey types entered. You can <a href='%1'>add one</a>.{/ts}
     </div>
 {/if}
 {/if}

--- a/templates/CRM/Campaign/Page/Vote.tpl
+++ b/templates/CRM/Campaign/Page/Vote.tpl
@@ -33,7 +33,7 @@
 
 {else}
  <div class="messages status no-popup">
-     <div class="icon inform-icon"></div>
+     {icon icon="fa-info-circle"}{/icon}
      {ts}You are not authorized to access this page.{/ts}
  </div>
 {/if}

--- a/templates/CRM/Case/Form/Case.tpl
+++ b/templates/CRM/Case/Form/Case.tpl
@@ -20,7 +20,7 @@
 <h3>{if $action eq 8}{ts}Delete Case{/ts}{elseif $action eq 32768}{ts}Restore Case{/ts}{/if}</h3>
 {if $action eq 8 or $action eq 32768 }
       <div class="messages status no-popup">
-        <div class="icon inform-icon"></div>
+        {icon icon="fa-info-circle"}{/icon}
           {if $action eq 8}
             {ts}Click Delete to move this case and all associated activities to the Trash.{/ts}
           {else}

--- a/templates/CRM/Case/Form/EditClient.tpl
+++ b/templates/CRM/Case/Form/EditClient.tpl
@@ -10,7 +10,7 @@
 {* template for assigning the current case to another client*}
 <div class="crm-block crm-form-block crm-case-editclient-form-block">
   <div class="messages status no-popup">
-    <div class="icon inform-icon"></div> {ts 1=$currentClientName}This is case is currently assigned to %1.{/ts}
+    {icon icon="fa-info-circle"}{/icon} {ts 1=$currentClientName}This is case is currently assigned to %1.{/ts}
   </div>
   <div class="crm-form-block">
     <table class="form-layout-compressed">

--- a/templates/CRM/Case/Form/Search/EmptyResults.tpl
+++ b/templates/CRM/Case/Form/Search/EmptyResults.tpl
@@ -9,7 +9,7 @@
 *}
 {* No matches for submitted search request. *}
 <div class="messages status no-popup">
-  <div class="icon inform-icon"></div>  &nbsp;
+  {icon icon="fa-info-circle"}{/icon}  &nbsp;
         {if $qill}{ts}No matches found for:{/ts}
             {include file="CRM/common/displaySearchCriteria.tpl"}
         {else}

--- a/templates/CRM/Case/Form/Task/Delete.tpl
+++ b/templates/CRM/Case/Form/Task/Delete.tpl
@@ -9,7 +9,7 @@
 *}
 {* Confirmation of contribution deletes  *}
 <div class="messages status no-popup">
-  <div class="icon inform-icon"></div>
+  {icon icon="fa-info-circle"}{/icon}
         &nbsp;{ts}Are you sure you want to delete the selected cases? This will move the case(s) and all associated activities to the Trash.{/ts}<br/>
         <p>{include file="CRM/Case/Form/Task.tpl"}</p>
 

--- a/templates/CRM/Case/Form/Task/Print.tpl
+++ b/templates/CRM/Case/Form/Task/Print.tpl
@@ -46,7 +46,7 @@
 
 {else}
    <div class="messages status no-popup">
-    <div class="icon inform-icon"></div>
+    {icon icon="fa-info-circle"}{/icon}
         {ts}There are no records selected for Print.{/ts}
     </div>
 {/if}

--- a/templates/CRM/Case/Form/Task/Restore.tpl
+++ b/templates/CRM/Case/Form/Task/Restore.tpl
@@ -9,7 +9,7 @@
 *}
 {* Confirmation of contribution deletes  *}
 <div class="messages status no-popup">
-  <div class="icon inform-icon"></div>
+  {icon icon="fa-info-circle"}{/icon}
         &nbsp;{ts}Are you sure you want to restore the selected cases? This operation will retrieve the case(s) and all associated activities from Trash.{/ts}</p>
         <p>{include file="CRM/Case/Form/Task.tpl"}</p>
   </div>

--- a/templates/CRM/Case/Form/Task/SearchTaskHookSample.tpl
+++ b/templates/CRM/Case/Form/Task/SearchTaskHookSample.tpl
@@ -30,7 +30,7 @@
 
 {else}
    <div class="messages status no-popup">
-      <div class="icon inform-icon"></div>
+      {icon icon="fa-info-circle"}{/icon}
           {ts}There are no records selected.{/ts}
       </div>
 {/if}

--- a/templates/CRM/Case/Page/ConfigureError.tpl
+++ b/templates/CRM/Case/Page/ConfigureError.tpl
@@ -12,7 +12,7 @@
 {capture assign=docLink}{docURL page="user/case-management/set-up" text="CiviCase Setup documentation"}{/capture}
 
 <div class="messages status no-popup">
-      <div class="icon inform-icon"></div>&nbsp;
+      {icon icon="fa-info-circle"}{/icon}
       <strong>{ts}You need to setup and load Case and Activity configuration files before you can begin using the CiviCase component.{/ts}</strong>
       {ts 1=$docLink}Refer to the %1 to learn about this process.{/ts}
 </div>

--- a/templates/CRM/Case/Page/Tab.tpl
+++ b/templates/CRM/Case/Page/Tab.tpl
@@ -12,7 +12,7 @@
 
 {elseif $redirectToCaseAdmin}
     <div class="messages status no-popup">
-      <div class="icon inform-icon"></div>&nbsp;
+      {icon icon="fa-info-circle"}{/icon}
          <strong>{ts}Oops, It looks like there are no active case types.{/ts}</strong>
            {if call_user_func(array('CRM_Core_Permission','check'), ' administer CiviCase')}
              {capture assign=adminCaseTypeURL}{crmURL p='civicrm/a/#/caseType'}
@@ -52,7 +52,7 @@
           {include file="CRM/Case/Form/Selector.tpl"}
     {else}
        <div class="messages status no-popup">
-          <div class="icon inform-icon"></div>
+          {icon icon="fa-info-circle"}{/icon}
             {ts}There are no case records for this contact.{/ts}
           </div>
     {/if}

--- a/templates/CRM/Contact/Form/Edit/Address.tpl
+++ b/templates/CRM/Contact/Form/Edit/Address.tpl
@@ -23,7 +23,7 @@
   {if $blockId gt 1}<fieldset><legend>{ts}Supplemental Address{/ts}</legend>{/if}
   <table class="form-layout-compressed crm-edit-address-form">
      {if $masterAddress.$blockId gt 0 }
-        <tr><td><div class="message status"><div class="icon inform-icon"></div>&nbsp; {ts 1=$masterAddress.$blockId}This address is shared with %1 contact record(s). Modifying this address will automatically update the shared address for these contacts.{/ts}</div></td></tr>
+        <tr><td><div class="message status">{icon icon="fa-info-circle"}{/icon} {ts 1=$masterAddress.$blockId}This address is shared with %1 contact record(s). Modifying this address will automatically update the shared address for these contacts.{/ts}</div></td></tr>
      {/if}
 
    {if $className eq 'CRM_Contact_Form_Contact'}

--- a/templates/CRM/Contact/Form/Merge.tpl
+++ b/templates/CRM/Contact/Form/Merge.tpl
@@ -13,13 +13,13 @@
   </div>
 
   <div class="message status">
-    <div class="icon inform-icon"></div>
+    {icon icon="fa-info-circle"}{/icon}
     <strong>{ts}WARNING: The duplicate contact record WILL BE DELETED after the merge is complete.{/ts}</strong>
   </div>
 
   {if $user}
     <div class="message status">
-      <div class="icon inform-icon"></div>
+      {icon icon="fa-info-circle"}{/icon}
       <strong>{ts 1=$config->userFramework}WARNING: There are %1 user accounts associated with both the original and duplicate contacts. Ensure that the %1 user you want to retain is on the right - if necessary use the 'Flip between original and duplicate contacts.' option at top to swap the positions of the two records before doing the merge.
   The user record associated with the duplicate contact will not be deleted, but will be unlinked from the associated contact record (which will be deleted).
   You will need to manually delete that user (click on the link to open the %1 user account in new screen). You may need to give thought to how you handle any content or contents associated with that user.{/ts}</strong>

--- a/templates/CRM/Contact/Form/Search/Custom/EmptyResults.tpl
+++ b/templates/CRM/Contact/Form/Search/Custom/EmptyResults.tpl
@@ -9,7 +9,7 @@
 *}
 {* Custom searches. Default template for NO MATCHES on submitted search request. *}
 <div class="messages status no-popup">
-  <div class="icon inform-icon"></div>&nbsp;
+  {icon icon="fa-info-circle"}{/icon}
   {if $qill}
     {ts}No matches found for:{/ts}
     {include file="CRM/common/displaySearchCriteria.tpl"}

--- a/templates/CRM/Contact/Form/Search/EmptyResults.tpl
+++ b/templates/CRM/Contact/Form/Search/EmptyResults.tpl
@@ -9,7 +9,7 @@
 *}
 {* No matches for submitted search request or viewing an empty group. *}
 <div class="messages status no-popup">
-  <div class="icon inform-icon"></div>&nbsp;
+  {icon icon="fa-info-circle"}{/icon}
         {if $context EQ 'smog'}
             {capture assign=crmURL}{crmURL q="context=amtg&amtgID=`$group.id`&reset=1"}{/capture}{ts 1=$group.title 2=$crmURL}%1 has no contacts which match your search criteria. You can <a href='%2'>add contacts here.</a>{/ts}
         {else}

--- a/templates/CRM/Contact/Form/Task/Delete.tpl
+++ b/templates/CRM/Contact/Form/Task/Delete.tpl
@@ -10,7 +10,7 @@
 {* Confirmation of contact deletes  *}
 <div class="crm-block crm-form-block crm-contact-task-delete-form-block">
 <div class="messages status no-popup">
-  <div class="icon inform-icon"></div>&nbsp;
+  {icon icon="fa-info-circle"}{/icon}
       {if $restore}
     {ts}Are you sure you want to restore the selected contact(s)? The contact(s) and all related data will be fully restored.{/ts}
       {elseif $trash}

--- a/templates/CRM/Contact/Form/Task/HookSample.tpl
+++ b/templates/CRM/Contact/Form/Task/HookSample.tpl
@@ -38,7 +38,7 @@
 </div>
 {else}
    <div class="messages status no-popup">
-  <div class="icon inform-icon"></div>
+  {icon icon="fa-info-circle"}{/icon}
        {ts}There are no records selected for Print.{/ts}
      </div>
 {/if}

--- a/templates/CRM/Contact/Form/Task/Print.tpl
+++ b/templates/CRM/Contact/Form/Task/Print.tpl
@@ -103,7 +103,7 @@
 
 {else}
    <div class="messages status no-popup">
-  <div class="icon inform-icon"></div>
+  {icon icon="fa-info-circle"}{/icon}
        {ts}There are no records selected for Print.{/ts}
   </div>
 {/if}

--- a/templates/CRM/Contact/Form/Task/Unhold.tpl
+++ b/templates/CRM/Contact/Form/Task/Unhold.tpl
@@ -10,7 +10,7 @@
 <div class="crm-block crm-form-block crm-unhold-form-block">
 <div class="spacer"></div>
 <div class="messages status no-popup">
-    <div class="icon inform-icon"></div>
+    {icon icon="fa-info-circle"}{/icon}
           <p>{ts}Are you sure you want to unhold email of selected contact(s)?.{/ts} {ts}This action cannot be undone.{/ts}</p>
       <p>{include file="CRM/Contact/Form/Task.tpl"}</p>
     </div>

--- a/templates/CRM/Contact/Page/View/ContactSmartGroup.tpl
+++ b/templates/CRM/Contact/Page/View/ContactSmartGroup.tpl
@@ -10,7 +10,7 @@
 <div class="section-shown">
   {if !$groupSmart AND !$groupParent}
     <div class="messages status no-popup">
-      <div class="icon inform-icon"></div>
+      {icon icon="fa-info-circle"}{/icon}
       &nbsp;{ts}This contact does not currently belong to any smart groups.{/ts}
     </div>
   {/if}

--- a/templates/CRM/Contact/Page/View/Delete.tpl
+++ b/templates/CRM/Contact/Page/View/Delete.tpl
@@ -9,7 +9,7 @@
 *}
 {* Confirmation of contact deletes  *}
 <div class="messages status no-popup">
-<div class="icon inform-icon"></div>
+{icon icon="fa-info-circle"}{/icon}
         <p>{ts  1=$displayName}Are you sure you want to delete the contact record and all related information for <strong>%1</strong>?{/ts}</p>
         <p>{ts}This action cannot be undone.{/ts}</p>
 </div>

--- a/templates/CRM/Contact/Page/View/Group.tpl
+++ b/templates/CRM/Contact/Page/View/Group.tpl
@@ -30,7 +30,7 @@
        </table>
      {else}
      <div class="messages status no-popup">
-     <div class="icon inform-icon"></div> &nbsp;
+     {icon icon="fa-info-circle"}{/icon}
       {ts}This contact does not belong to any groups.{/ts}
      </div>
      {/if}

--- a/templates/CRM/Contact/Page/View/GroupContact.tpl
+++ b/templates/CRM/Contact/Page/View/GroupContact.tpl
@@ -10,7 +10,7 @@
 <div class="view-content view-contact-groups">
   {if $groupCount eq 0}
     <div class="messages status no-popup">
-      <div class="icon inform-icon"></div>
+      {icon icon="fa-info-circle"}{/icon}
       &nbsp;{ts}This contact does not currently belong to any groups.{/ts}
     </div>
   {else}

--- a/templates/CRM/Contact/Page/View/Log.tpl
+++ b/templates/CRM/Contact/Page/View/Log.tpl
@@ -27,7 +27,7 @@
        </table>
      {else}
      <div class="messages status no-popup">
-      <div class="icon inform-icon"></div> &nbsp;
+      {icon icon="fa-info-circle"}{/icon}
       {ts}None found.{/ts}
      </div>
      {/if}

--- a/templates/CRM/Contact/Page/View/Note.tpl
+++ b/templates/CRM/Contact/Page/View/Note.tpl
@@ -240,7 +240,7 @@
 </div>
 {elseif ($action eq 16)}
    <div class="messages status no-popup">
-      <div class="icon inform-icon"></div>
+      {icon icon="fa-info-circle"}{/icon}
       {ts}There are no Notes for this contact.{/ts}
    </div>
 {/if}

--- a/templates/CRM/Contact/Page/View/UserDashBoard/GroupContact.tpl
+++ b/templates/CRM/Contact/Page/View/UserDashBoard/GroupContact.tpl
@@ -16,7 +16,7 @@
     <div class="view-content">
         {if $groupCount eq 0 }
             <div class="messages status no-popup">
-                    <div class="icon inform-icon"></div>
+                    {icon icon="fa-info-circle"}{/icon}
                     {ts}You are not currently subscribed to any Groups.{/ts}
             </div>
         {/if}

--- a/templates/CRM/Contribute/Form/AcceptCreditCard.tpl
+++ b/templates/CRM/Contribute/Form/AcceptCreditCard.tpl
@@ -13,7 +13,7 @@
 
    {if $action eq 8}
       <div class="messages status no-popup">
-        <div class="icon inform-icon"></div>
+        {icon icon="fa-info-circle"}{/icon}
           {ts}WARNING: If you delete this option, contributors will not be able to use this credit card type on your Online Contribution pages.{/ts} {ts}Do you want to continue?{/ts}
       </div>
      {else}

--- a/templates/CRM/Contribute/Form/AdditionalPayment.tpl
+++ b/templates/CRM/Contribute/Form/AdditionalPayment.tpl
@@ -20,7 +20,7 @@
 
   {if !$email}
     <div class="messages status no-popup">
-      <div class="icon inform-icon"></div>&nbsp;{ts}You will not be able to send an automatic email receipt for this payment because there is no email address recorded for this contact. If you want a receipt to be sent when this payment is recorded, click Cancel and then click Edit from the Summary tab to add an email address before recording the payment.{/ts}
+      {icon icon="fa-info-circle"}{/icon}{ts}You will not be able to send an automatic email receipt for this payment because there is no email address recorded for this contact. If you want a receipt to be sent when this payment is recorded, click Cancel and then click Edit from the Summary tab to add an email address before recording the payment.{/ts}
     </div>
   {/if}
   {if $newCredit AND $contributionMode EQ null}

--- a/templates/CRM/Contribute/Form/CancelSubscription.tpl
+++ b/templates/CRM/Contribute/Form/CancelSubscription.tpl
@@ -10,7 +10,7 @@
 
 <div class="crm-block crm-form-block crm-auto-renew-membership-cancellation">
 <div class="help">
-  <div class="icon inform-icon"></div>&nbsp;
+  {icon icon="fa-info-circle"}{/icon}
   {$cancelRecurDetailText}
   {if $cancelRecurNotSupportedText}
     <div class="status-warning">{$cancelRecurNotSupportedText}</div>

--- a/templates/CRM/Contribute/Form/Contribution.tpl
+++ b/templates/CRM/Contribute/Form/Contribution.tpl
@@ -33,13 +33,13 @@
 
     {if !$email and $action neq 8 and $context neq 'standalone'}
       <div class="messages status no-popup">
-        <div class="icon inform-icon"></div>&nbsp;{ts}You will not be able to send an automatic email receipt for this contribution because there is no email address recorded for this contact. If you want a receipt to be sent when this contribution is recorded, click Cancel and then click Edit from the Summary tab to add an email address before recording the contribution.{/ts}
+        {icon icon="fa-info-circle"}{/icon}{ts}You will not be able to send an automatic email receipt for this contribution because there is no email address recorded for this contact. If you want a receipt to be sent when this contribution is recorded, click Cancel and then click Edit from the Summary tab to add an email address before recording the contribution.{/ts}
       </div>
     {/if}
 
     {if $action eq 8}
       <div class="messages status no-popup">
-        <div class="icon inform-icon"></div>
+        {icon icon="fa-info-circle"}{/icon}
         {ts}WARNING: Deleting this contribution will result in the loss of the associated financial transactions (if any).{/ts} {ts}Do you want to continue?{/ts}
       </div>
     {else}

--- a/templates/CRM/Contribute/Form/ContributionPage/AddProduct.tpl
+++ b/templates/CRM/Contribute/Form/ContributionPage/AddProduct.tpl
@@ -21,7 +21,7 @@
 
   {if $action eq 8}
     <div class="messages status no-popup">
-      <div class="icon inform-icon"></div>
+      {icon icon="fa-info-circle"}{/icon}
       {ts}Are you sure you want to remove this premium product from this Contribution page?{/ts}
     </div>
   {elseif $action eq 1024}

--- a/templates/CRM/Contribute/Form/ContributionPage/Delete.tpl
+++ b/templates/CRM/Contribute/Form/ContributionPage/Delete.tpl
@@ -9,7 +9,7 @@
 *}
 {* this template is used for confirmation of delete for a group  *}
     <div class="messages status no-popup">
-      <div class="icon inform-icon"></div>
+      {icon icon="fa-info-circle"}{/icon}
           {if $relatedContributions}
            {ts 1=$title}You cannot delete this Contribution Page because it has already been used to submit a contribution or membership payment. It is recommended that your disable the page instead of deleting it, to preserve the integrity of your contribution records. If you do want to completely delete this contribution page, you first need to search for and delete all of the contribution transactions associated with this page in CiviContribute.{/ts}
           {else}

--- a/templates/CRM/Contribute/Form/ContributionPage/Widget.tpl
+++ b/templates/CRM/Contribute/Form/ContributionPage/Widget.tpl
@@ -11,7 +11,7 @@
 <h3>{ts}Configure Widget{/ts}</h3>
 {if $showStatus}
 <div class="messages status no-popup">
-    <div class="icon inform-icon"></div>
+    {icon icon="fa-info-circle"}{/icon}
     {ts}It looks like you may have posted and / or distributed the flash version of the Contribution widget. We won't be supporting the flash version in next release. You should try and get all sites using the flash widget to update to the improved HTML widget code below as soon as possible.{/ts}
 </div>
 {/if}

--- a/templates/CRM/Contribute/Form/ManagePremiums.tpl
+++ b/templates/CRM/Contribute/Form/ManagePremiums.tpl
@@ -11,7 +11,7 @@
 <div class="crm-block crm-form-block crm-contribution-manage_premiums-form-block">
    {if $action eq 8}
       <div class="messages status no-popup">
-          <div class="icon inform-icon"></div>
+          {icon icon="fa-info-circle"}{/icon}
           {ts}Are you sure you want to delete this premium?{/ts} {ts}This action cannot be undone.{/ts} {ts}This will also remove the premium from any contribution pages that currently include it.{/ts}
       </div>
   {elseif $action eq 1024}

--- a/templates/CRM/Contribute/Form/PCP/Delete.tpl
+++ b/templates/CRM/Contribute/Form/PCP/Delete.tpl
@@ -10,7 +10,7 @@
 {* this template is used for confirmation of delete for a group *}
 <fieldset><legend>{ts}Delete Campaign Page {/ts}</legend>
 <div class="messages status no-popup">
-   <div class="icon inform-icon"></div>
+   {icon icon="fa-info-circle"}{/icon}
   {ts 1=$title}Are you sure you want to delete Campaign Page '%1'?{/ts}<br />
   {ts}This action cannot be undone.{/ts}
 </div>

--- a/templates/CRM/Contribute/Form/PaymentInstrument.tpl
+++ b/templates/CRM/Contribute/Form/PaymentInstrument.tpl
@@ -13,7 +13,7 @@
   <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
    {if $action eq 8}
       <div class="messages status no-popup">
-           <div class="icon inform-icon"></div>
+           {icon icon="fa-info-circle"}{/icon}
           {ts}WARNING: Deleting this option will result in the loss of all contribution records which use this option.{/ts} {ts}This may mean the loss of a substantial amount of data, and the action cannot be undone.{/ts} {ts}Do you want to continue?{/ts}
       </div>
      {else}

--- a/templates/CRM/Contribute/Form/Search/EmptyResults.tpl
+++ b/templates/CRM/Contribute/Form/Search/EmptyResults.tpl
@@ -9,7 +9,7 @@
 *}
 {* No matches for submitted search request. *}
 <div class="messages status no-popup">
-    <div class="icon inform-icon"></div>  &nbsp;
+    {icon icon="fa-info-circle"}{/icon}  &nbsp;
         {if $qill}{ts}No matches found for:{/ts}
             {include file="CRM/common/displaySearchCriteria.tpl"}
         {else}

--- a/templates/CRM/Contribute/Form/Task/Delete.tpl
+++ b/templates/CRM/Contribute/Form/Task/Delete.tpl
@@ -9,7 +9,7 @@
 *}
 {* Confirmation of contribution deletes  *}
 <div class="messages status no-popup">
-    <div class="icon inform-icon"></div>
+    {icon icon="fa-info-circle"}{/icon}
         <p>{ts}Are you sure you want to delete the selected contributions? This delete operation cannot be undone and will delete all transactions and activity associated with these contributions.{/ts}</p>
         <p>{include file="CRM/Contribute/Form/Task.tpl"}</p>
 </div>

--- a/templates/CRM/Contribute/Form/Task/Invoice.tpl
+++ b/templates/CRM/Contribute/Form/Task/Invoice.tpl
@@ -8,7 +8,7 @@
  +--------------------------------------------------------------------+
 *}
 <div class="messages status no-popup">
-  <div class="icon inform-icon"></div>
+  {icon icon="fa-info-circle"}{/icon}
   {include file="CRM/Contribute/Form/Task.tpl"}
 </div>
 {if $selectedOutput ne 'email'}

--- a/templates/CRM/Contribute/Form/Task/PDF.tpl
+++ b/templates/CRM/Contribute/Form/Task/PDF.tpl
@@ -8,7 +8,7 @@
  +--------------------------------------------------------------------+
 *}
 <div class="messages status no-popup">
-  <div class="icon inform-icon"></div>
+  {icon icon="fa-info-circle"}{/icon}
       {include file="CRM/Contribute/Form/Task.tpl"}
 </div>
 <div class="help">

--- a/templates/CRM/Contribute/Form/Task/Print.tpl
+++ b/templates/CRM/Contribute/Form/Task/Print.tpl
@@ -52,7 +52,7 @@
 
 {else}
    <div class="messages status no-popup">
-     <div class="icon inform-icon"/>
+     {icon icon="fa-info-circle"}{/icon}
         {ts}There are no records selected for Print.{/ts}
    </div>
 {/if}

--- a/templates/CRM/Contribute/Form/Task/SearchTaskHookSample.tpl
+++ b/templates/CRM/Contribute/Form/Task/SearchTaskHookSample.tpl
@@ -32,7 +32,7 @@
 
 {else}
    <div class="messages status no-popup">
-    <div class="icon inform-icon"></div>
+    {icon icon="fa-info-circle"}{/icon}
     {ts}There are no records selected.{/ts}
    </div>
 {/if}

--- a/templates/CRM/Contribute/Form/UpdateBilling.tpl
+++ b/templates/CRM/Contribute/Form/UpdateBilling.tpl
@@ -8,7 +8,7 @@
  +--------------------------------------------------------------------+
 *}
 <div class="help">
-  <div class="icon inform-icon"></div>&nbsp;
+  {icon icon="fa-info-circle"}{/icon}
   {if $mode eq 'auto_renew'}
       {ts}Use this form to update the credit card and billing name and address used with the auto-renewal option for your {$membershipType} membership.{/ts}
   {else}

--- a/templates/CRM/Contribute/Page/ContributionPage.tpl
+++ b/templates/CRM/Contribute/Page/ContributionPage.tpl
@@ -99,7 +99,7 @@
       </div>
       {else}
       <div class="messages status no-popup">
-             <div class="icon inform-icon"></div> &nbsp;
+             {icon icon="fa-info-circle"}{/icon}
              {ts 1=$newPageURL}No contribution pages have been created yet. Click <a accesskey="N" href='%1'>here</a> to create a new contribution page.{/ts}
       </div>
         {/if}

--- a/templates/CRM/Contribute/Page/ContributionRecurPayments.tpl
+++ b/templates/CRM/Contribute/Page/ContributionRecurPayments.tpl
@@ -36,7 +36,7 @@
   </div>
 {else}
   <div class="messages status no-popup">
-    <div class="icon inform-icon"></div>
+    {icon icon="fa-info-circle"}{/icon}
     {ts}No contributions have been recorded for this recurring contribution.{/ts}
   </div>
 {/if}

--- a/templates/CRM/Contribute/Page/ContributionType.tpl
+++ b/templates/CRM/Contribute/Page/ContributionType.tpl
@@ -49,7 +49,7 @@
 </div>
 {else}
     <div class="messages status no-popup">
-        <div class="icon inform-icon"></div>
+        {icon icon="fa-info-circle"}{/icon}
       {ts}None found.{/ts}
     </div>
 {/if}

--- a/templates/CRM/Contribute/Page/PcpUserDashboard.tpl
+++ b/templates/CRM/Contribute/Page/PcpUserDashboard.tpl
@@ -40,7 +40,7 @@
 </div>
 {else}
 <div class="messages status no-popup">
-  <div class="icon inform-icon"></div>
+  {icon icon="fa-info-circle"}{/icon}
   {ts}You do not have any active Personal Campaign pages.{/ts}
 </div>
 {/if}

--- a/templates/CRM/Contribute/Page/Premium.tpl
+++ b/templates/CRM/Contribute/Page/Premium.tpl
@@ -51,11 +51,11 @@
   {if $showForm eq false}
     <div class="messages status no-popup">
       {if $products ne null }
-        <div class="icon inform-icon"></div>
+        {icon icon="fa-info-circle"}{/icon}
         {capture assign=crmURL}{crmURL p='civicrm/admin/contribute/addProductToPage' q="reset=1&action=update&id=$id"}{/capture}
         {ts 1=$crmURL}There are no premiums offered on this contribution page yet. You can <a href='%1'>add one</a>.{/ts}
       {else}
-        <div class="icon inform-icon"></div>
+        {icon icon="fa-info-circle"}{/icon}
         {ts 1=$managePremiumsURL}There are no active premiums for your site. You can <a href='%1'>create and/or enable premiums here</a>.{/ts}
       {/if}
     </div>

--- a/templates/CRM/Contribute/Page/Tab.tpl
+++ b/templates/CRM/Contribute/Page/Tab.tpl
@@ -63,7 +63,7 @@
             {include file="CRM/Contribute/Form/Selector.tpl"}
           {else}
             <div class="messages status no-popup">
-              <div class="icon inform-icon"></div>
+              {icon icon="fa-info-circle"}{/icon}
               {ts}No contributions have been recorded from this contact.{/ts}
             </div>
           {/if}

--- a/templates/CRM/Contribute/Page/UserDashboard.tpl
+++ b/templates/CRM/Contribute/Page/UserDashboard.tpl
@@ -71,7 +71,7 @@
         {/if}
     {else}
         <div class="messages status no-popup">
-            <div class="icon inform-icon"></div>
+            {icon icon="fa-info-circle"}{/icon}
             {ts}There are no contributions on record for you.{/ts}
         </div>
     {/if}

--- a/templates/CRM/Core/Form/EntityForm.tpl
+++ b/templates/CRM/Core/Form/EntityForm.tpl
@@ -12,7 +12,7 @@
   <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
   {if $action eq 8}
     <div class="messages status no-popup">
-      <div class="icon inform-icon"></div>
+      {icon icon="fa-info-circle"}{/icon}
       {$deleteMessage|escape}
     </div>
   {else}

--- a/templates/CRM/Custom/Form/ChangeFieldType.tpl
+++ b/templates/CRM/Custom/Form/ChangeFieldType.tpl
@@ -9,7 +9,7 @@
 *}
 <div class="crm-block crm-form-block crm-custom-field-form-block">
 <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
-    <div class='status'><div class="icon inform-icon"></div>
+    <div class='status'>{icon icon="fa-info-circle"}{/icon}
         &nbsp;{ts}Warning: This functionality is currently in beta stage. Consider backing up your database before using it. Click "Cancel" to return to the "edit custom field" form without making changes.{/ts}
     </div>
     <table class="form-layout">

--- a/templates/CRM/Custom/Form/DeleteField.tpl
+++ b/templates/CRM/Custom/Form/DeleteField.tpl
@@ -10,7 +10,7 @@
 {* this template is used for confirmation of delete for a Fields  *}
 <div class="crm-block crm-form-block crm-custom-deletefield-form-block">
     <div class="messages status no-popup">
-         <div class="icon inform-icon"></div>
+         {icon icon="fa-info-circle"}{/icon}
             {ts 1=$title}WARNING: Deleting this custom field will result in the loss of all '%1' data. Any Profile form and listings field(s) linked with '%1' will also be deleted.{/ts} {ts}This action cannot be undone.{/ts} {ts}Do you want to continue?{/ts}
          </div>
  <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>

--- a/templates/CRM/Custom/Form/DeleteFile.tpl
+++ b/templates/CRM/Custom/Form/DeleteFile.tpl
@@ -11,7 +11,7 @@
 <fieldset><legend>{ts}Delete Attached File{/ts}</legend>
     <div class="status">
       <dl>
-        <dt><div class="icon inform-icon"></div></dt>
+        <dt>{icon icon="fa-info-circle"}{/icon}</dt>
         <dd>
           {ts}WARNING: Are you sure you want to delete the attached file?{/ts}
         </dd>

--- a/templates/CRM/Custom/Form/DeleteGroup.tpl
+++ b/templates/CRM/Custom/Form/DeleteGroup.tpl
@@ -14,7 +14,7 @@
    {include file="CRM/common/formButtons.tpl" location="top"}
 </div>
     <div class="messages status no-popup">
-           <div class="icon inform-icon"></div>
+           {icon icon="fa-info-circle"}{/icon}
           {ts 1=$title}WARNING: Deleting this custom field set will result in the loss of all '%1' data.{/ts} {ts}This action cannot be undone.{/ts} {ts}Do you want to continue?{/ts}
     </div>
 <div class="crm-submit-buttons">

--- a/templates/CRM/Custom/Form/Option.tpl
+++ b/templates/CRM/Custom/Form/Option.tpl
@@ -14,7 +14,7 @@
     {/if} {* $action ne view *}
     {if $action eq 8}
       <div class="messages status no-popup">
-          <div class="icon inform-icon"></div>
+          {icon icon="fa-info-circle"}{/icon}
           {ts}WARNING: Deleting this custom field option will result in the loss of all related data.{/ts} {ts}This action cannot be undone.{/ts} {ts}Do you want to continue?{/ts}
       </div>
     {else}

--- a/templates/CRM/Custom/Page/Option.tpl
+++ b/templates/CRM/Custom/Page/Option.tpl
@@ -12,7 +12,7 @@
 {else}
   {if $reusedNames}
       <div class="message status">
-        <div class="icon inform-icon"></div> &nbsp; {ts 1=$reusedNames}These Multiple Choice Options are shared by the following custom fields: %1{/ts}
+        {icon icon="fa-info-circle"}{/icon} {ts 1=$reusedNames}These Multiple Choice Options are shared by the following custom fields: %1{/ts}
       </div>
   {/if}
 

--- a/templates/CRM/Dashlet/Page/Blog.tpl
+++ b/templates/CRM/Dashlet/Page/Blog.tpl
@@ -60,7 +60,7 @@
   {/foreach}
   {if !$feeds}
     <div class="messages status no-popup">
-      <div class="icon inform-icon"></div>
+      {icon icon="fa-info-circle"}{/icon}
       {ts}Sorry but we are not able to provide this at the moment.{/ts}
     </div>
   {/if}

--- a/templates/CRM/Event/Form/ManageEvent/Delete.tpl
+++ b/templates/CRM/Event/Form/ManageEvent/Delete.tpl
@@ -13,7 +13,7 @@
     {include file="CRM/common/formButtons.tpl" location="top"}
 </div>
 <div class="messages status no-popup">
-   <div class="icon inform-icon"></div>
+   {icon icon="fa-info-circle"}{/icon}
    <div>
        {if $isTemplate}
          {ts}Warning: Deleting this event template will also delete associated Event Registration Page and Event Fee configurations.{/ts} {ts}This action cannot be undone.{/ts} {ts}Do you want to continue?{/ts}

--- a/templates/CRM/Event/Form/Participant.tpl
+++ b/templates/CRM/Event/Form/Participant.tpl
@@ -196,7 +196,7 @@
       {if $action eq 8} {* If action is Delete *}
         <div class="crm-participant-form-block-delete messages status no-popup">
           <div class="crm-content">
-            <div class="icon inform-icon"></div> &nbsp;
+            {icon icon="fa-info-circle"}{/icon}
             {ts}WARNING: Deleting this registration will result in the loss of related payment records (if any).{/ts} {ts}Do you want to continue?{/ts}
           </div>
           {if $additionalParticipant}

--- a/templates/CRM/Event/Form/Search/EmptyResults.tpl
+++ b/templates/CRM/Event/Form/Search/EmptyResults.tpl
@@ -9,7 +9,7 @@
 *}
 {* No matches for submitted search request. *}
 <div class="messages status no-popup">
-  <div class="icon inform-icon"></div> &nbsp;
+  {icon icon="fa-info-circle"}{/icon}
     {if $qill}{ts}No matches found for:{/ts}
         {include file="CRM/common/displaySearchCriteria.tpl"}
     {else}

--- a/templates/CRM/Event/Form/Task/Cancel.tpl
+++ b/templates/CRM/Event/Form/Task/Cancel.tpl
@@ -10,7 +10,7 @@
 {* Confirmation of Cancel Registration *}
 <div class="crm-block crm-form-block crm-event-cancel-form-block">
 <div class="messages status no-popup">
-  <div class="icon inform-icon"></div>
+  {icon icon="fa-info-circle"}{/icon}
   <div>
       <p>{ts}Are you sure you want to set status to Cancelled for the selected participants?{/ts}</p>
       <p>{include file="CRM/Event/Form/Task.tpl"}</p>

--- a/templates/CRM/Event/Form/Task/Delete.tpl
+++ b/templates/CRM/Event/Form/Task/Delete.tpl
@@ -10,7 +10,7 @@
 {* Confirmation of participation deletes  *}
 <div class="crm-block crm-form-block crm-event-delete-form-block">
 <div class="messages status no-popup">
-  <div class="icon inform-icon"></div>
+  {icon icon="fa-info-circle"}{/icon}
   <div>
     <p>{ts}Are you sure you want to delete the selected participations? This delete operation cannot be undone and will delete all transactions and activity associated with these participations.{/ts}</p>
         <p>{include file="CRM/Event/Form/Task.tpl"}</p>

--- a/templates/CRM/Event/Form/Task/Print.tpl
+++ b/templates/CRM/Event/Form/Task/Print.tpl
@@ -59,6 +59,6 @@
 
 {else}
 <div class="messages status no-popup">
-    <div class="icon inform-icon"></div>&nbsp;{ts}There are no records selected for Print.{/ts}
+    {icon icon="fa-info-circle"}{/icon}{ts}There are no records selected for Print.{/ts}
 </div>
 {/if}

--- a/templates/CRM/Event/Form/Task/SearchTaskHookSample.tpl
+++ b/templates/CRM/Event/Form/Task/SearchTaskHookSample.tpl
@@ -31,6 +31,6 @@
 
 {else}
    <div class="messages status no-popup">
-      <div class="icon inform-icon"></div>&nbsp;{ts}There are no records selected.{/ts}
+      {icon icon="fa-info-circle"}{/icon}{ts}There are no records selected.{/ts}
    </div>
 {/if}

--- a/templates/CRM/Event/Page/DashBoard.tpl
+++ b/templates/CRM/Event/Page/DashBoard.tpl
@@ -124,7 +124,7 @@
     <br />
     <div class="messages status no-popup">
         <table>
-            <tr><div class="icon inform-icon"></div></tr>
+            <tr>{icon icon="fa-info-circle"}{/icon}</tr>
             <tr>
                 {ts}There are no active Events to display.{/ts}
                 {ts 1=$newEventURL}You can <a href="%1">Create a New Event</a> now.{/ts}

--- a/templates/CRM/Event/Page/ManageEvent.tpl
+++ b/templates/CRM/Event/Page/ManageEvent.tpl
@@ -137,7 +137,7 @@
 {else}
   {if $isSearch eq 1}
   <div class="status messages">
-    <div class="icon inform-icon"></div>
+    {icon icon="fa-info-circle"}{/icon}
     {capture assign=browseURL}{crmURL p='civicrm/event/manage' q="reset=1"}{/capture}
     {ts}No available Events match your search criteria. Suggestions:{/ts}
     <div class="spacer"></div>
@@ -151,7 +151,7 @@
   </div>
     {else}
   <div class="messages status no-popup">
-    <div class="icon inform-icon"></div>
+    {icon icon="fa-info-circle"}{/icon}
     {ts 1=$newEventURL}There are no events scheduled for the date range. You can <a href='%1'>add one</a>.{/ts}
   </div>
   {/if}

--- a/templates/CRM/Event/Page/ParticipantListing/Name.tpl
+++ b/templates/CRM/Event/Page/ParticipantListing/Name.tpl
@@ -33,7 +33,7 @@
 {else}
     <div class='spacer'></div>
     <div class="messages status no-popup">
-    <div class="icon inform-icon"></div>
+    {icon icon="fa-info-circle"}{/icon}
         {ts}There are currently no participants registered for this event.{/ts}
     </div>
 {/if}

--- a/templates/CRM/Event/Page/ParticipantListing/NameAndEmail.tpl
+++ b/templates/CRM/Event/Page/ParticipantListing/NameAndEmail.tpl
@@ -34,7 +34,7 @@
 {else}
     <div class='spacer'></div>
     <div class="messages status no-popup">
-      <div class="icon inform-icon"></div>
+      {icon icon="fa-info-circle"}{/icon}
         {ts}There are currently no participants registered for this event.{/ts}
     </div>
 {/if}

--- a/templates/CRM/Event/Page/ParticipantListing/NameStatusAndDate.tpl
+++ b/templates/CRM/Event/Page/ParticipantListing/NameStatusAndDate.tpl
@@ -35,7 +35,7 @@
 {else}
     <div class='spacer'></div>
     <div class="messages status no-popup">
-      <div class="icon inform-icon"></div>
+      {icon icon="fa-info-circle"}{/icon}
         {ts}There are currently no participants registered for this event.{/ts}
       </div>
 {/if}

--- a/templates/CRM/Event/Page/Tab.tpl
+++ b/templates/CRM/Event/Page/Tab.tpl
@@ -43,7 +43,7 @@
     {else}
        <div class="messages status no-popup">
            <table class="form-layout">
-             <tr><div class="icon inform-icon"></div>
+             <tr>{icon icon="fa-info-circle"}{/icon}
                    {ts}No event registrations have been recorded for this contact.{/ts}
              </tr>
            </table>

--- a/templates/CRM/Event/Page/UserDashboard.tpl
+++ b/templates/CRM/Event/Page/UserDashboard.tpl
@@ -50,7 +50,7 @@
         {/strip}
     {else}
         <div class="messages status no-popup">
-           <div class="icon inform-icon"></div>
+           {icon icon="fa-info-circle"}{/icon}
            {ts}You are not registered for any current or upcoming Events.{/ts}
         </div>
     {/if}

--- a/templates/CRM/Financial/Form/Export.tpl
+++ b/templates/CRM/Financial/Form/Export.tpl
@@ -10,7 +10,7 @@
 {* Confirmation of Export Batch(s)  *}
 <h3>{ts}Export Batch{/ts}</h3>
 <div class="messages status">
-  <div class="icon inform-icon"></div>
+  {icon icon="fa-info-circle"}{/icon}
   {ts}Warning: You will not be able to reopen or change the batch after it is exported. Are you sure you want to export?{/ts}
 </div>
 <div class="crm-block crm-form-block crm-export_batch-form-block">

--- a/templates/CRM/Financial/Form/FinancialAccount.tpl
+++ b/templates/CRM/Financial/Form/FinancialAccount.tpl
@@ -11,7 +11,7 @@
 <div class="crm-block crm-form-block crm-contribution_type-form-block crm-financial_type-form-block">
 {if $action eq 8}
   <div class="messages status no-popup">
-    <div class="icon inform-icon"></div>
+    {icon icon="fa-info-circle"}{/icon}
     {ts}WARNING: You cannot delete a {$delName} Financial Account if it is currently used by any Financial Types. Consider disabling this option instead.{/ts} {ts}Deleting a financial type cannot be undone.{/ts} {ts}Do you want to continue?{/ts}
   </div>
 {else}

--- a/templates/CRM/Financial/Form/FinancialBatch.tpl
+++ b/templates/CRM/Financial/Form/FinancialBatch.tpl
@@ -11,7 +11,7 @@
 <div class="crm-block crm-form-block crm-financial_type-form-block">
 {if $action eq 8}
   <div class="messages status">
-    <div class="icon inform-icon"></div>
+    {icon icon="fa-info-circle"}{/icon}
     {ts}WARNING: You cannot delete a financial type if it is currently used by any Contributions, Contribution Pages or Membership Types. Consider disabling this option instead.{/ts} {ts}Deleting a financial type cannot be undone.{/ts} {ts}Do you want to continue?{/ts}
   </div>
 {else}

--- a/templates/CRM/Financial/Form/FinancialTypeAccount.tpl
+++ b/templates/CRM/Financial/Form/FinancialTypeAccount.tpl
@@ -11,7 +11,7 @@
 <div class="crm-block crm-form-block crm-financial_type-form-block">
   {if $action eq 8}
     <div class="messages status">
-      <div class="icon inform-icon"></div>
+      {icon icon="fa-info-circle"}{/icon}
       {ts}WARNING: You cannot delete a financial type if it is currently used by any Contributions, Contribution Pages or Membership Types. Consider disabling this option instead.{/ts} {ts}Deleting a financial type cannot be undone. Unbalanced transactions may be created if you delete this account.{/ts} {ts}Do you want to continue?{/ts}
       </div>
   {else}

--- a/templates/CRM/Financial/Page/FinancialAccount.tpl
+++ b/templates/CRM/Financial/Page/FinancialAccount.tpl
@@ -69,7 +69,7 @@
     </div>
   {else}
     <div class="messages status">
-      <div class="icon inform-icon"></div>
+      {icon icon="fa-info-circle"}{/icon}
       {capture assign=crmURL}{crmURL q="action=add&reset=1"}{/capture}
       {ts 1=$crmURL}There are no Financial Account entered. You can <a href='%1'>add one</a>.{/ts}
     </div>

--- a/templates/CRM/Financial/Page/FinancialType.tpl
+++ b/templates/CRM/Financial/Page/FinancialType.tpl
@@ -53,7 +53,7 @@
 </div>
 {else}
     <div class="messages status no-popup">
-        <div class="icon inform-icon"></div>
+        {icon icon="fa-info-circle"}{/icon}
       {ts}None found.{/ts}
     </div>
 {/if}

--- a/templates/CRM/Financial/Page/FinancialTypeAccount.tpl
+++ b/templates/CRM/Financial/Page/FinancialTypeAccount.tpl
@@ -56,7 +56,7 @@
   </div>
   {else}
       <div class="messages status no-popup">
-          <div class="icon inform-icon"></div>
+          {icon icon="fa-info-circle"}{/icon}
           {capture assign=crmURL}{crmURL q="action=add&reset=1&aid=$aid"}{/capture}
           {ts 1=$crmURL}There are no financial accounts assigned to this financial type. You can <a href='%1'>assign one</a>.{/ts}
       </div>

--- a/templates/CRM/Grant/Form/Grant.tpl
+++ b/templates/CRM/Grant/Form/Grant.tpl
@@ -12,7 +12,7 @@
 <div class="crm-block crm-form-block crm-grant-form-block">
   {if $action eq 8}
      <div class="messages status">
-         <p><div class="icon inform-icon"></div>&nbsp;
+         <p>{icon icon="fa-info-circle"}{/icon}
          {ts}Are you sure you want to delete this Grant?{/ts} {ts}This action cannot be undone.{/ts}</p>
          <p>{include file="CRM/Grant/Form/Task.tpl"}</p>
      </div>

--- a/templates/CRM/Grant/Form/Search/EmptyResults.tpl
+++ b/templates/CRM/Grant/Form/Search/EmptyResults.tpl
@@ -9,7 +9,7 @@
 *}
 {* No matches for submitted search request. *}
 <div class="messages status">
-    <div class="icon inform-icon"></div>&nbsp;
+    {icon icon="fa-info-circle"}{/icon}
         {if $qill}{ts}No matches found for:{/ts}
             {include file="CRM/common/displaySearchCriteria.tpl"}
         {else}

--- a/templates/CRM/Grant/Form/Task/Delete.tpl
+++ b/templates/CRM/Grant/Form/Task/Delete.tpl
@@ -10,7 +10,7 @@
 {* Confirmation of Grant delete  *}
 <div class="crm-block crm-form-block crm-grant-task-delete-form-block">
   <div class="messages status no-popup">
-          <div class="icon inform-icon"></div>&nbsp;
+          {icon icon="fa-info-circle"}{/icon}
           {ts}Are you sure you want to delete the selected Grants? This delete operation cannot be undone and will delete all transactions associated with these grants.{/ts}
           <p>{include file="CRM/Grant/Form/Task.tpl"}</p>
   </div>

--- a/templates/CRM/Grant/Form/Task/Print.tpl
+++ b/templates/CRM/Grant/Form/Task/Print.tpl
@@ -43,7 +43,7 @@
 
 {else}
    <div class="messages status no-popup">
-    <div class="icon inform-icon"></div>&nbsp;
+    {icon icon="fa-info-circle"}{/icon}
         {ts}There are no records selected for Print.{/ts}
    </div>
 {/if}

--- a/templates/CRM/Grant/Form/Task/SearchTaskHookSample.tpl
+++ b/templates/CRM/Grant/Form/Task/SearchTaskHookSample.tpl
@@ -28,7 +28,7 @@
 
 {else}
    <div class="messages status no-popup">
-          <div class="icon inform-icon"></div>
+          {icon icon="fa-info-circle"}{/icon}
             {ts}There are no records selected.{/ts}
    </div>
 {/if}

--- a/templates/CRM/Grant/Page/Tab.tpl
+++ b/templates/CRM/Grant/Page/Tab.tpl
@@ -35,7 +35,7 @@
         {include file="CRM/Grant/Form/Selector.tpl"}
     {else}
         <div class="messages status">
-             <div class="icon inform-icon"></div>&nbsp;
+             {icon icon="fa-info-circle"}{/icon}
              {ts}No grants have been recorded for this contact.{/ts}
        </div>
     {/if}

--- a/templates/CRM/Logging/ReportDetail.tpl
+++ b/templates/CRM/Logging/ReportDetail.tpl
@@ -12,7 +12,7 @@
     {if $raw}
       <div class="status">
         <dl>
-          <dt><div class="icon inform-icon"></div></dt>
+          <dt>{icon icon="fa-info-circle"}{/icon}</dt>
           <dd>
             {ts}WARNING: Are you sure you want to revert the below changes?{/ts}
           </dd>
@@ -27,7 +27,7 @@
     {/if}
   {else}
     <div class='messages status'>
-        <div class='icon inform-icon'></div>&nbsp; {ts}This report can not be displayed because there are no relevant entries in the logging tables.{/ts}
+      {icon icon="fa-info-circle"}{/icon}{ts}This report can not be displayed because there are no relevant entries in the logging tables.{/ts}
     </div>
   {/if}
   {if $layout neq 'overlay'}

--- a/templates/CRM/Mailing/Form/Task/Print.tpl
+++ b/templates/CRM/Mailing/Form/Task/Print.tpl
@@ -43,7 +43,7 @@
 
 {else}
    <div class="messages status no-popup">
-     <div class="icon inform-icon"/>
+     {icon icon="fa-info-circle"}{/icon}
         {ts}There are no records selected for Print.{/ts}
    </div>
 {/if}

--- a/templates/CRM/Mailing/Page/Browse.tpl
+++ b/templates/CRM/Mailing/Page/Browse.tpl
@@ -97,7 +97,7 @@
     {/if}
     <div class="status messages">
         <table class="form-layout">
-            <tr><div class="icon inform-icon"></div>
+            <tr>{icon icon="fa-info-circle"}{/icon}
                {ts 1=$componentName}No %1 match your search criteria. Suggestions:{/ts}
       </tr>
                 <div class="spacer"></div>
@@ -111,7 +111,7 @@
 {elseif $unscheduled}
 
     <div class="messages status no-popup">
-            <div class="icon inform-icon"></div>&nbsp;
+            {icon icon="fa-info-circle"}{/icon}
             {capture assign=crmURL}{crmURL p=$newMassUrl q='reset=1'}{/capture}
             {ts 1=$componentName}There are no Unscheduled %1.{/ts}
       {if $showLinks}{ts 1=$crmURL}You can <a href='%1'>create and send one</a>.{/ts}{/if}
@@ -119,13 +119,13 @@
 
 {elseif $archived}
     <div class="messages status no-popup">
-            <div class="icon inform-icon"></div>&nbsp
+            {icon icon="fa-info-circle"}{/icon}&nbsp
             {capture assign=crmURL}{crmURL p='civicrm/mailing/browse/scheduled' q='scheduled=true&reset=1'}{$qVal}{/capture}
             {ts 1=$crmURL 2=$componentName}There are no Archived %2. You can archive %2 from <a href='%1'>Scheduled or Sent %2</a>.{/ts}
    </div>
 {else}
     <div class="messages status no-popup">
-            <div class="icon inform-icon"></div>&nbsp;
+            {icon icon="fa-info-circle"}{/icon}
             {capture assign=crmURL}{crmURL p=$newMassUrl q='reset=1'}{/capture}
             {capture assign=archiveURL}{crmURL p='civicrm/mailing/browse/archived' q='reset=1'}{$qVal}{/capture}
             {ts 1=$componentName}There are no Scheduled or Sent %1.{/ts}

--- a/templates/CRM/Mailing/Page/Confirm.tpl
+++ b/templates/CRM/Mailing/Page/Confirm.tpl
@@ -8,7 +8,7 @@
  +--------------------------------------------------------------------+
 *}
 <div class="messages status no-popup">
-      <div class="icon inform-icon"></div>&nbsp;
+      {icon icon="fa-info-circle"}{/icon}
 {if $success}
       {ts 1=$display_name 2=$email 3=$group}<strong>%1 (%2)</strong> has been successfully subscribed to the <strong>%3</strong> mailing list.{/ts}
 {else}

--- a/templates/CRM/Mailing/Page/Event.tpl
+++ b/templates/CRM/Mailing/Page/Event.tpl
@@ -39,7 +39,7 @@
   {/strip}
 {else}
   <div class="messages status no-popup">
-    <div class="icon inform-icon"></div>
+    {icon icon="fa-info-circle"}{/icon}
     &nbsp;
     {ts 1=$title}There are currently no %1.{/ts}
   </div>

--- a/templates/CRM/Mailing/Page/Resubscribe.tpl
+++ b/templates/CRM/Mailing/Page/Resubscribe.tpl
@@ -9,7 +9,7 @@
 *}
 {if $confirm}
 <div class="messages status no-popup">
-      <div class="icon inform-icon"></div>&nbsp;
+      {icon icon="fa-info-circle"}{/icon}
       <label>{$display_name} ({$email})</label> {ts}has been successfully resubscribed.{/ts}
 </div>
 {else}

--- a/templates/CRM/Member/Form/Membership.tpl
+++ b/templates/CRM/Member/Form/Membership.tpl
@@ -10,7 +10,7 @@
 {* this template is used for adding/editing/deleting memberships for a contact  *}
 {if $isRecur}
   <div class="messages status no-popup">
-    <div class="icon inform-icon"></div>
+    {icon icon="fa-info-circle"}{/icon}
     <p>{ts}This membership is set to renew automatically {if $endDate}on {$endDate|crmDate}{/if}. Please be aware that any changes that you make here may not be reflected in the payment processor. Please ensure that you alter the related subscription at the payment processor.{/ts}</p>
     {if $cancelAutoRenew}<p>{ts 1=$cancelAutoRenew}To stop the automatic renewal:
       <a href="%1">Cancel auto-renew</a>
@@ -42,7 +42,7 @@
   {/if}
   {if !$emailExists and $action neq 8 and $context neq 'standalone'}
   <div class="messages status no-popup">
-    <div class="icon inform-icon"></div>
+    {icon icon="fa-info-circle"}{/icon}
     <p>{ts}You will not be able to send an automatic email receipt for this Membership because there is no email address recorded for this contact. If you want a receipt to be sent when this Membership is recorded, click Cancel and then click Edit from the Summary tab to add an email address before recording the Membership.{/ts}</p>
   </div>
   {/if}
@@ -65,7 +65,7 @@
     <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
     {if $action eq 8}
     <div class="messages status no-popup">
-      <div class="icon inform-icon"></div>&nbsp;
+      {icon icon="fa-info-circle"}{/icon}
       {$deleteMessage}
     </div>
     {else}

--- a/templates/CRM/Member/Form/MembershipRenewal.tpl
+++ b/templates/CRM/Member/Form/MembershipRenewal.tpl
@@ -15,7 +15,7 @@
   {/if}
   {if !$email}
     <div class="messages status no-popup">
-      <div class="icon inform-icon"></div>
+      {icon icon="fa-info-circle"}{/icon}
       <p>{ts}You will not be able to send an automatic email receipt for this Renew Membership because there is no email address recorded for this contact. If you want a receipt to be sent when this Membership is recorded, click Cancel and then click Edit from the Summary tab to add an email address before Renewal the Membership.{/ts}</p>
     </div>
   {/if}
@@ -29,7 +29,7 @@
   {if $action eq 32768}
     {if $cancelAutoRenew}
       <div class="messages status no-popup">
-        <div class="icon inform-icon"></div>
+        {icon icon="fa-info-circle"}{/icon}
         <p>{ts 1=$cancelAutoRenew}This membership is set to renew automatically {if $renewalDate}on {$renewalDate|crmDate}{/if}. You will need to cancel the auto-renew option if you want to modify the Membership Type, End Date or Membership Status.
             <a href="%1">Click here</a>
             if you want to cancel the automatic renewal option.{/ts}</p>

--- a/templates/CRM/Member/Form/MembershipStatus.tpl
+++ b/templates/CRM/Member/Form/MembershipStatus.tpl
@@ -13,7 +13,7 @@
  <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
   {if $action eq 8}
     <div class="messages status no-popup">
-      <div class="icon inform-icon"></div>
+      {icon icon="fa-info-circle"}{/icon}
       {$deleteMessage|escape}
     </div>
   {else}

--- a/templates/CRM/Member/Form/MembershipType.tpl
+++ b/templates/CRM/Member/Form/MembershipType.tpl
@@ -104,7 +104,7 @@
     <fieldset><legend>{ts}Renewal Reminders{/ts}</legend>
       <div class="help">
         {capture assign=reminderLink}{crmURL p='civicrm/admin/scheduleReminders' q='reset=1'}{/capture}
-        <div class="icon inform-icon"></div>&nbsp;
+        {icon icon="fa-info-circle"}{/icon}
         {ts 1=$reminderLink}Configure membership renewal reminders using <a href="%1">Schedule Reminders</a>. If you have previously configured renewal reminder templates, you can re-use them with your new scheduled reminders.{/ts} {docURL page="user/email/scheduled-reminders"}
       </div>
     </fieldset>

--- a/templates/CRM/Member/Form/Search/EmptyResults.tpl
+++ b/templates/CRM/Member/Form/Search/EmptyResults.tpl
@@ -9,7 +9,7 @@
 *}
 {* No matches for submitted search request. *}
 <div class="messages status no-popup"> &nbsp;
-    <div class="icon inform-icon"></div>
+    {icon icon="fa-info-circle"}{/icon}
         {if $qill}{ts}No matches found for:{/ts}
             {include file="CRM/common/displaySearchCriteria.tpl"}
         {else}

--- a/templates/CRM/Member/Form/Task/Delete.tpl
+++ b/templates/CRM/Member/Form/Task/Delete.tpl
@@ -10,7 +10,7 @@
 {* Confirmation of membership deletes  *}
 <div class="crm-block crm-form-block crm-member-task-delete-form-block">
   <div class="messages status no-popup">
-     <div class="icon inform-icon"></div>
+     {icon icon="fa-info-circle"}{/icon}
         <span>{ts}Are you sure you want to delete the selected memberships? This delete operation cannot be undone and will delete all transactions and activity associated with these memberships.{/ts}</span>
         <p>{include file="CRM/Member/Form/Task.tpl"}</p>
   </div>

--- a/templates/CRM/Member/Form/Task/SearchTaskHookSample.tpl
+++ b/templates/CRM/Member/Form/Task/SearchTaskHookSample.tpl
@@ -30,7 +30,7 @@
 </div>
 {else}
    <div class="messages status no-popup">
-            <div class="icon inform-icon"></div>
+            {icon icon="fa-info-circle"}{/icon}
                {ts}There are no records selected.{/ts}
    </div>
 {/if}

--- a/templates/CRM/Member/Page/MembershipType.tpl
+++ b/templates/CRM/Member/Page/MembershipType.tpl
@@ -10,7 +10,7 @@
 
 {capture assign=reminderLink}{crmURL p='civicrm/admin/scheduleReminders' q='reset=1'}{/capture}
 <div class="help">
-  <p><div class="icon inform-icon"></div>&nbsp;{ts}Membership types are used to categorize memberships. You can define an unlimited number of types. Each type incorporates a 'name' (Gold Member, Honor Society Member...), a description, a minimum fee (can be $0), and a duration (can be 'lifetime'). Each member type is specifically linked to the membership entity (organization) - e.g. Bay Area Chapter.{/ts} {docURL page="user/membership/defining-memberships/"}</p>
+  <p>{icon icon="fa-info-circle"}{/icon}{ts}Membership types are used to categorize memberships. You can define an unlimited number of types. Each type incorporates a 'name' (Gold Member, Honor Society Member...), a description, a minimum fee (can be $0), and a duration (can be 'lifetime'). Each member type is specifically linked to the membership entity (organization) - e.g. Bay Area Chapter.{/ts} {docURL page="user/membership/defining-memberships/"}</p>
   <p>{ts 1=$reminderLink}Configure membership renewal reminders using <a href="%1">Schedule Reminders</a>.{/ts} {docURL page="user/email/scheduled-reminders"}</p>
 </div>
 

--- a/templates/CRM/Member/Page/Tab.tpl
+++ b/templates/CRM/Member/Page/Tab.tpl
@@ -44,7 +44,7 @@
     {/if}
     {if NOT ($activeMembers or $inActiveMembers) and $action ne 2 and $action ne 1 and $action ne 8 and $action ne 4 and $action ne 32768}
          <div class="messages status no-popup">
-          <div class="icon inform-icon"></div>
+          {icon icon="fa-info-circle"}{/icon}
               {ts}No memberships have been recorded for this contact.{/ts}
          </div>
     {/if}

--- a/templates/CRM/Member/Page/UserDashboard.tpl
+++ b/templates/CRM/Member/Page/UserDashboard.tpl
@@ -73,7 +73,7 @@
 
 {if NOT ($activeMembers or $inActiveMembers)}
    <div class="messages status no-popup">
-       <div class="icon inform-icon"></div></dt>
+       {icon icon="fa-info-circle"}{/icon}</dt>
            {ts}There are no memberships on record for you.{/ts}
    </div>
 {/if}

--- a/templates/CRM/PCP/Form/PCP/Delete.tpl
+++ b/templates/CRM/PCP/Form/PCP/Delete.tpl
@@ -10,7 +10,7 @@
 {* this template is used for confirmation of delete for a group *}
 <fieldset><legend>{ts}Delete Campaign Page {/ts}</legend>
 <div class="messages status no-popup">
-   <div class="icon inform-icon"></div>
+   {icon icon="fa-info-circle"}{/icon}
   {ts 1=$title}Are you sure you want to delete Campaign Page '%1'?{/ts}<br />
   {ts}This action cannot be undone.{/ts}
 </div>

--- a/templates/CRM/PCP/Page/PCP.tpl
+++ b/templates/CRM/PCP/Page/PCP.tpl
@@ -53,7 +53,7 @@
 </div>
 {else}
 <div class="messages status no-popup">
-<div class="icon inform-icon"></div>
+{icon icon="fa-info-circle"}{/icon}
     {if $isSearch}
         {ts}There are no Personal Campaign Pages which match your search criteria.{/ts}
     {else}

--- a/templates/CRM/PCP/Page/PCPInfo.tpl
+++ b/templates/CRM/PCP/Page/PCPInfo.tpl
@@ -10,7 +10,7 @@
 {* this template is used for displaying PCP information *}
 {if $owner}
 <div class="messages status no-popup">
-  <div class="icon inform-icon"></div>
+  {icon icon="fa-info-circle"}{/icon}
   <p><strong>{ts}Personal Campaign Preview{/ts}</strong> - {ts}This is a preview of your Personal Campaign Page in support of{/ts} <a href="{$parentURL}"><strong>{$pageName}</strong></a>.</p>
         {ts}The current status of your page is{/ts}: <strong {if $pcp.status_id NEQ 2}class=disabled {/if}>{$owner.status}</strong>.
         {if $pcp.status_id NEQ 2}<br /><span class="description">{ts}You will receive an email notification when your page is Approved and you can begin promoting your campaign.{/ts}</span>{/if}

--- a/templates/CRM/Pledge/Form/Pledge.tpl
+++ b/templates/CRM/Pledge/Form/Pledge.tpl
@@ -13,7 +13,7 @@
 {else}
 {if !$email and $action neq 8 and $context neq 'standalone'}
 <div class="messages status no-popup">
-  <div class="icon inform-icon"></div>
+  {icon icon="fa-info-circle"}{/icon}
   <p>{ts}You will not be able to send an acknowledgment for this pledge because there is no email address recorded for this contact. If you want a acknowledgment to be sent when this pledge is recorded, click Cancel and then click Edit from the Summary tab to add an email address before recording the pledge.{/ts}</p>
 </div>
 {/if}
@@ -29,7 +29,7 @@
  <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
    {if $action eq 8}
     <div class="messages status no-popup">
-    <div class="icon inform-icon"></div>&nbsp;
+    {icon icon="fa-info-circle"}{/icon}
     <span class="font-red bold">{ts}WARNING: Deleting this pledge will also delete any related pledge payments.{/ts} {ts}This action cannot be undone.{/ts}</span>
     <p>{ts}Consider cancelling the pledge instead if you want to maintain an audit trail and avoid losing payment data. To set the pledge status to Cancelled and cancel any not-yet-paid pledge payments, first click Cancel on this form. Then click the more &gt; link from the pledge listing, and select the Cancel action.{/ts}</p>
     </div>
@@ -43,7 +43,7 @@
             <td class="label">{$form.amount.label}</td>
             <td>
               <span>{$form.currency.html|crmAddClass:eight}&nbsp;{$form.amount.html|crmAddClass:eight}</span>
-              {if $originalPledgeAmount}<div class="messages status no-popup"><div class="icon inform-icon"></div>&nbsp;{ts 1=$originalPledgeAmount|crmMoney:$currency} Pledge total has changed due to payment adjustments. Original pledge amount was %1.{/ts}</div>{/if}
+              {if $originalPledgeAmount}<div class="messages status no-popup">{icon icon="fa-info-circle"}{/icon}{ts 1=$originalPledgeAmount|crmMoney:$currency} Pledge total has changed due to payment adjustments. Original pledge amount was %1.{/ts}</div>{/if}
             </td>
           </tr>
           <tr class="crm-pledge-form-block-installments">

--- a/templates/CRM/Pledge/Form/PledgeView.tpl
+++ b/templates/CRM/Pledge/Form/PledgeView.tpl
@@ -20,7 +20,7 @@
      <tr class="crm-pledge-form-block-amount">
         <td class="label">{ts}Total Pledge Amount{/ts}</td>
         <td><span class="bold">{$amount|crmMoney:$currency}</span>
-            {if $originalPledgeAmount}<div class="messages status no-popup"><div class="icon inform-icon"></div>{ts 1=$originalPledgeAmount|crmMoney:$currency} Pledge total has changed due to payment adjustments. Original pledge amount was %1.{/ts}</div>{/if}
+            {if $originalPledgeAmount}<div class="messages status no-popup">{icon icon="fa-info-circle"}{/icon}{ts 1=$originalPledgeAmount|crmMoney:$currency} Pledge total has changed due to payment adjustments. Original pledge amount was %1.{/ts}</div>{/if}
         </td>
      </tr>
      <tr class="crm-pledge-form-block-installments"><td class="label">{ts}To be paid in{/ts}</td><td>{$installments} {ts}installments of{/ts} {$original_installment_amount|crmMoney:$currency} {ts}every{/ts} {$frequency_interval} {$frequencyUnit}</td></tr>

--- a/templates/CRM/Pledge/Form/Search/EmptyResults.tpl
+++ b/templates/CRM/Pledge/Form/Search/EmptyResults.tpl
@@ -9,7 +9,7 @@
 *}
 {* No matches for submitted search request. *}
 <div class="messages status no-popup">
-    <div class="icon inform-icon"></div>
+    {icon icon="fa-info-circle"}{/icon}
         {if $qill}{ts}No matches found for:{/ts}
             {include file="CRM/common/displaySearchCriteria.tpl"}
         {else}

--- a/templates/CRM/Pledge/Form/Task/Delete.tpl
+++ b/templates/CRM/Pledge/Form/Task/Delete.tpl
@@ -9,7 +9,7 @@
 *}
 {* Confirmation of participation deletes  *}
 <div class="messages status no-popup">
-    <div class="icon inform-icon"></div>
+    {icon icon="fa-info-circle"}{/icon}
         <p>{ts}Are you sure you want to delete the selected pledges? This delete operation cannot be undone and will delete all transactions associated with these pledges.{/ts}</p>
         <p>{include file="CRM/Pledge/Form/Task.tpl"}</p>
 </div>

--- a/templates/CRM/Pledge/Form/Task/Print.tpl
+++ b/templates/CRM/Pledge/Form/Task/Print.tpl
@@ -43,7 +43,7 @@
 
 {else}
    <div class="messages status no-popup">
-    <div class="icon inform-icon"></div>
+    {icon icon="fa-info-circle"}{/icon}
         {ts}There are no records selected for Print.{/ts}
    </div>
 {/if}

--- a/templates/CRM/Pledge/Form/Task/SearchTaskHookSample.tpl
+++ b/templates/CRM/Pledge/Form/Task/SearchTaskHookSample.tpl
@@ -30,7 +30,7 @@
 
 {else}
    <div class="messages status no-popup">
-          <dt><div class="icon inform-icon"></div>
+          <dt>{icon icon="fa-info-circle"}{/icon}
             {ts}There are no records selected.{/ts}
       </dl>
    </div>

--- a/templates/CRM/Pledge/Page/Tab.tpl
+++ b/templates/CRM/Pledge/Page/Tab.tpl
@@ -36,7 +36,7 @@
 
 {else}
    <div class="messages status no-popup">
-       <div class="icon inform-icon"></div>
+       {icon icon="fa-info-circle"}{/icon}
             {ts}No pledges have been recorded from this contact.{/ts}
        </div>
 {/if}

--- a/templates/CRM/Pledge/Page/UserDashboard.tpl
+++ b/templates/CRM/Pledge/Page/UserDashboard.tpl
@@ -45,7 +45,7 @@
 {crmScript file='js/crm.expandRow.js'}
 {else}
 <div class="messages status no-popup">
-         <div class="icon inform-icon"></div>
+         {icon icon="fa-info-circle"}{/icon}
              {ts}There are no Pledges for your record.{/ts}
          </div>
 {/if}

--- a/templates/CRM/Price/Form/DeleteField.tpl
+++ b/templates/CRM/Price/Form/DeleteField.tpl
@@ -10,7 +10,7 @@
 {* this template is used for confirmation of delete for a Fields  *}
 <div class="crm-block crm-form-block crm-price_field_delete-form-block">
     <div class="messages status no-popup">
-        <div class="icon inform-icon"></div>
+        {icon icon="fa-info-circle"}{/icon}
           {ts 1=$title}WARNING: Deleting this price field will result in the loss of all '%1' data.{/ts} {ts}This action cannot be undone.{/ts} {ts}Do you want to continue?{/ts}
     </div>
     <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>

--- a/templates/CRM/Price/Form/Option.tpl
+++ b/templates/CRM/Price/Form/Option.tpl
@@ -10,7 +10,7 @@
 <div class="crm-form-block">
   {if $action eq 8}
     <div class="messages status no-popup">
-      <div class="icon inform-icon"></div>
+      {icon icon="fa-info-circle"}{/icon}
       {ts}WARNING: Deleting this option will result in the loss of all data.{/ts} {ts}This action cannot be undone.{/ts} {ts}Do you want to continue?{/ts}
     </div>
   {else}

--- a/templates/CRM/Price/Page/Field.tpl
+++ b/templates/CRM/Price/Page/Field.tpl
@@ -15,7 +15,7 @@
   {include file="CRM/Price/Form/Preview.tpl"}
 {elseif ($usedBy and $action eq 8) or $usedBy.civicrm_event or $usedBy.civicrm_contribution_page}
   <div id="price_set_used_by" class="messages status no-popup">
-    <div class="icon inform-icon"></div>
+    {icon icon="fa-info-circle"}{/icon}
     {if $action eq 8}
       {ts 1=$usedPriceSetTitle}Unable to delete the '%1' Price Field - it is currently in use by one or more active events or contribution pages or contributions  or event templates.{/ts}
     {/if}
@@ -89,7 +89,7 @@
 {else}
   {if $action eq 16}
     <div class="messages status no-popup crm-empty-table">
-      <div class="icon inform-icon"></div>
+      {icon icon="fa-info-circle"}{/icon}
       {ts}None found.{/ts}
     </div>
     <div class="action-link">

--- a/templates/CRM/Price/Page/Option.tpl
+++ b/templates/CRM/Price/Page/Option.tpl
@@ -13,7 +13,7 @@
 {elseif $usedBy}
   <div class='spacer'></div>
   <div id="price_set_used_by" class="messages status no-popup">
-    <div class="icon inform-icon"></div>
+    {icon icon="fa-info-circle"}{/icon}
     {if $action eq 8}
       {ts 1=$usedPriceSetTitle}Unable to delete the '%1' Price Field Option - it is currently in use by one or more active events  or contribution pages or contributions.{/ts}
     {/if}

--- a/templates/CRM/Price/Page/Set.tpl
+++ b/templates/CRM/Price/Page/Set.tpl
@@ -21,7 +21,7 @@
     {if $usedBy}
     <div class='spacer'></div>
     <div id="price_set_used_by" class="messages status no-popup">
-       <div class="icon inform-icon"></div>
+       {icon icon="fa-info-circle"}{/icon}
         {if $action eq 8}
             {ts 1=$usedPriceSetTitle}Unable to delete the '%1' price set - it is currently in use by one or more active events or contribution pages or contributions or event templates.{/ts}
         {/if}

--- a/templates/CRM/Profile/Form/Dynamic.tpl
+++ b/templates/CRM/Profile/Form/Dynamic.tpl
@@ -14,7 +14,7 @@
     cms account edit (mode=8) or civicrm/profile (mode=4) pages *}
 {if $deleteRecord}
 <div class="messages status no-popup">
-  <div class="icon inform-icon"></div>&nbsp;
+  {icon icon="fa-info-circle"}{/icon}
         {ts}Are you sure you want to delete this record?{/ts}
   </div>
 
@@ -250,7 +250,7 @@ invert              = 0
 }
 {elseif $statusMessage}
 <div class="messages status no-popup">
-  <div class="icon inform-icon"></div>
+  {icon icon="fa-info-circle"}{/icon}
   {$statusMessage}
 </div>
 {/if}

--- a/templates/CRM/Profile/Form/Search.tpl
+++ b/templates/CRM/Profile/Form/Search.tpl
@@ -85,12 +85,12 @@
 
 {elseif $statusMessage}
   <div class="messages status no-popup">
-    <div class="icon inform-icon"></div>
+    {icon icon="fa-info-circle"}{/icon}
     {$statusMessage}
   </div>
 {else} {* empty fields *}
   <div class="messages status no-popup">
-    <div class="icon inform-icon"></div>
+    {icon icon="fa-info-circle"}{/icon}
     {ts}No fields in this Profile have been configured as searchable. Ask the site administrator to check the Profile setup.{/ts}
   </div>
 {/if}

--- a/templates/CRM/Profile/Page/Listings.tpl
+++ b/templates/CRM/Profile/Page/Listings.tpl
@@ -77,7 +77,7 @@
 
 {else}
     <div class="messages status no-popup">
-        <div class="icon inform-icon"></div>
+        {icon icon="fa-info-circle"}{/icon}
         {ts}No fields in this Profile have been configured to display as a result column in the search results table. Ask the site administrator to check the Profile setup.{/ts}
     </div>
 {/if}

--- a/templates/CRM/Profile/Page/MultipleRecordFieldsListing.tpl
+++ b/templates/CRM/Profile/Page/MultipleRecordFieldsListing.tpl
@@ -91,7 +91,7 @@
     <div id='{$dialogId}' class="hiddenElement"></div>
   {elseif !$records}
     <div class="messages status no-popup">
-      <div class="icon inform-icon"></div>
+      {icon icon="fa-info-circle"}{/icon}
       &nbsp;
       {ts 1=$customGroupTitle}No records of type '%1' found.{/ts}
     </div>

--- a/templates/CRM/Report/Form/ErrorMessage.tpl
+++ b/templates/CRM/Report/Form/ErrorMessage.tpl
@@ -9,6 +9,6 @@
 *}
 {if $outputMode eq 'html' && !$rows}
   <div class="messages status no-popup">
-    <div class="icon inform-icon"></div>&nbsp; {ts}None found.{/ts}
+    {icon icon="fa-info-circle"}{/icon} {ts}None found.{/ts}
   </div>
 {/if}

--- a/templates/CRM/Report/Form/Register.tpl
+++ b/templates/CRM/Report/Form/Register.tpl
@@ -25,7 +25,7 @@
     <tr>
       <td colspan=2>
         <div class="messages status no-popup">
-          <div class="icon inform-icon"></div> &nbsp;
+          {icon icon="fa-info-circle"}{/icon}
           {ts}WARNING: Deleting this option will result in the loss of all Report related records which use the option. This may mean the loss of a substantial amount of data, and the action cannot be undone. Do you want to continue?{/ts}
         </div>
       </td>

--- a/templates/CRM/Report/Page/InstanceList.tpl
+++ b/templates/CRM/Report/Page/InstanceList.tpl
@@ -64,7 +64,7 @@
   {else}
     <div class="crm-content-block">
       <div class="messages status no-popup">
-        <div class="icon inform-icon"></div>&nbsp;
+        {icon icon="fa-info-circle"}{/icon}
         {if $myReports}
           {ts}You do not have any private reports. To add a report to this section, edit the Report Settings for a report and set 'Add to My Reports' to Yes.{/ts} &nbsp;
         {else}

--- a/templates/CRM/Report/Page/TemplateList.tpl
+++ b/templates/CRM/Report/Page/TemplateList.tpl
@@ -46,7 +46,7 @@
       {/foreach}
     {else}
       <div class="messages status no-popup">
-        <div class="icon inform-icon"></div>&nbsp; {ts}There are currently no Report Templates.{/ts}
+        {icon icon="fa-info-circle"}{/icon} {ts}There are currently no Report Templates.{/ts}
       </div>
     {/if}
   {/strip}

--- a/templates/CRM/SMS/Form/Group.tpl
+++ b/templates/CRM/SMS/Form/Group.tpl
@@ -9,7 +9,7 @@
 *}
 {if $groupCount == 0 and $mailingCount == 0}
   <div class="status">
-  <div class="icon inform-icon"></div>
+  {icon icon="fa-info-circle"}{/icon}
         {ts}To send a Mass SMS, you must have a valid group of recipients - either at least one group that's a Mailing List{/ts}
   </div>
 {else}

--- a/templates/CRM/SMS/Form/Provider.tpl
+++ b/templates/CRM/SMS/Form/Provider.tpl
@@ -13,12 +13,12 @@
 
 {if $action eq 8}
   <div class="messages status no-popup">
-      <div class="icon inform-icon"></div>
+      {icon icon="fa-info-circle"}{/icon}
         {ts}Do you want to continue?{/ts}
   </div>
 {elseif $action eq 128}
   <div class="messages status no-popup">
-      <div class="icon inform-icon"></div>
+      {icon icon="fa-info-circle"}{/icon}
         {ts}Are you sure you would like to execute this job?{/ts}
   </div>
 {else}

--- a/templates/CRM/SMS/Page/Provider.tpl
+++ b/templates/CRM/SMS/Page/Provider.tpl
@@ -46,7 +46,7 @@
   </div>
   {else}
     <div class="messages status no-popup">
-      <div class="icon inform-icon"></div>
+      {icon icon="fa-info-circle"}{/icon}
         {ts}None found.{/ts}
      </div>
 

--- a/templates/CRM/UF/Form/Field.tpl
+++ b/templates/CRM/UF/Form/Field.tpl
@@ -10,7 +10,7 @@
 <div class="crm-block crm-form-block crm-uf-field-form-block">
 {if $action eq 8}
   <div class="messages status no-popup">
-    <div class="icon inform-icon"></div>
+    {icon icon="fa-info-circle"}{/icon}
     {ts}WARNING: Deleting this profile field will remove it from Profile forms and listings. If this field is used in any 'stand-alone' Profile forms, you will need to update those forms to remove this field.{/ts} {ts}Do you want to continue?{/ts}
   </div>
 {else}

--- a/templates/CRM/UF/Form/Group.tpl
+++ b/templates/CRM/UF/Form/Group.tpl
@@ -25,7 +25,7 @@
 
 {if $action eq 8 or $action eq 64}
     <div class="messages status no-popup">
-           <div class="icon inform-icon"></div>
+           {icon icon="fa-info-circle"}{/icon}
            {$message}
     </div>
 {else}

--- a/templates/CRM/UF/Page/Field.tpl
+++ b/templates/CRM/UF/Page/Field.tpl
@@ -70,7 +70,7 @@
         {if $action eq 16}
         {capture assign=crmURL}{crmURL p="civicrm/admin/uf/group/field/add" q="reset=1&action=add&gid=$gid"}{/capture}
         <div class="messages status no-popup crm-empty-table">
-          <div class="icon inform-icon"></div>
+          {icon icon="fa-info-circle"}{/icon}
           {ts}None found.{/ts}
         </div>
         <div class="action-link">

--- a/templates/CRM/UF/Page/Group.tpl
+++ b/templates/CRM/UF/Page/Group.tpl
@@ -147,7 +147,7 @@
     {else}
     {if $action ne 1} {* When we are adding an item, we should not display this message *}
        <div class="messages status no-popup">
-         <div class="icon inform-icon"></div> &nbsp;
+         {icon icon="fa-info-circle"}{/icon}
          {capture assign=crmURL}{crmURL p='civicrm/admin/uf/group/add' q='action=add&reset=1'}{/capture}{ts 1=$crmURL}No CiviCRM Profiles have been created yet. You can <a href='%1'>add one now</a>.{/ts}
        </div>
     {/if}

--- a/templates/CRM/common/info.tpl
+++ b/templates/CRM/common/info.tpl
@@ -10,7 +10,7 @@
 {* Handles display of passed $infoMessage. *}
 {if $infoMessage or $infoTitle}
   <div class="messages status {$infoType}"{if $infoOptions} data-options='{$infoOptions}'{/if}>
-    <div class="icon inform-icon"></div>
+    {icon icon="fa-info-circle"}{/icon}
     <span class="msg-title">{$infoTitle}</span>
     <span class="msg-text">{$infoMessage}</span>
   </div>


### PR DESCRIPTION
Overview
----------------------------------------
Replace `<div class=icon inform-icon>` with fontawesome fa-icon-circle using icon helper.  If we're ok with this I'll add a mapping to the docs here: https://docs.civicrm.org/dev/en/latest/framework/ui/#older-icon-system

Before
----------------------------------------
Using legacy icon
eg.
![image](https://user-images.githubusercontent.com/2052161/88916561-310e4900-d25e-11ea-8836-d8dd70839a45.png)


After
----------------------------------------
Using standard function and current icon.
eg. 
![image](https://user-images.githubusercontent.com/2052161/88916725-7df21f80-d25e-11ea-9b04-595eddea3e8c.png)


Technical Details
----------------------------------------
Per UI discussions and call. This is changed in all templates using find/replace.

Comments
----------------------------------------
@colemanw @demeritcowboy @agh @vingle @totten This is an example of a find/replace (similar to and built on the work that @agh1 did) to update some of our UI in one go.