### PR TITLE
dev/core#1915 - E_NOTICE when making pcp contribution

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -3109,7 +3109,11 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
       //get soft contributions
       $softContributions = CRM_Contribute_BAO_ContributionSoft::getSoftContribution($this->id, TRUE);
       if (!empty($softContributions)) {
-        $values['softContributions'] = $softContributions['soft_credit'];
+        // For pcp soft credit, there is no 'soft_credit' member it comes
+        // back in different array members, but shortly after returning from
+        // this function it calls _assignMessageVariablesToTemplate which does
+        // its own lookup of any pcp soft credit, so we can skip it here.
+        $values['softContributions'] = $softContributions['soft_credit'] ?? NULL;
       }
       if (isset($this->contribution_page_id)) {
         // This is a call we want to use less, in favour of loading related objects.

--- a/tests/phpunit/CRM/PCP/BAO/PCPTest.php
+++ b/tests/phpunit/CRM/PCP/BAO/PCPTest.php
@@ -123,4 +123,133 @@ class CRM_PCP_BAO_PCPTest extends CiviUnitTestCase {
     ], CRM_PCP_BAO_PCP::getPcpDashboardInfo($contactID));
   }
 
+  /**
+   * Test that CRM_Contribute_BAO_Contribution::_gatherMessageValues() works
+   * with PCP.
+   */
+  public function testGatherMessageValuesForPCP() {
+    // set up a pcp page
+    $block = CRM_PCP_BAO_PCPBlock::create($this->pcpBlockParams());
+    // The owner of the pcp, who gets the soft credit
+    $contact_owner = $this->individualCreate([], 0, TRUE);
+    $contributionPage = $this->callAPISuccessGetSingle('ContributionPage', []);
+    $pcp = $this->callAPISuccess('Pcp', 'create', [
+      'contact_id' => $contact_owner,
+      'title' => 'pcp',
+      'page_id' => $contributionPage['id'],
+      'pcp_block_id' => $block->id,
+      'is_active' => TRUE,
+      'status_id' => 'Approved',
+    ]);
+
+    // set up a payment processor
+    $payment_processor_type = $this->callAPISuccess('PaymentProcessorType', 'get', ['name' => 'Dummy']);
+    $payment_processor = $this->callAPISuccess('PaymentProcessor', 'create', [
+      'name' => 'Dummy PP',
+      'payment_processor_type_id' => $payment_processor_type['id'],
+      'class_name' => $payment_processor_type['values'][$payment_processor_type['id']]['class_name'],
+    ]);
+
+    // create a contribution with the pcp soft credit
+    $contact_contributor = $this->individualCreate([], 1, TRUE);
+    $address = $this->callAPISuccess('address', 'create', [
+      'address_name' => "Giver {$contact_contributor}",
+      'street_address' => '123 Main St.',
+      'location_type_id' => 'Billing',
+      'is_billing' => 1,
+      'contact_id' => $contact_contributor,
+    ]);
+    $contribution = $this->callAPISuccess('Contribution', 'create', [
+      'contact_id' => $contact_contributor,
+      'address_id' => $address['id'],
+      'total_amount' => 10,
+      'receive_date' => date('YmdHis'),
+      'financial_type_id' => 'Donation',
+      'payment_processor' => $payment_processor['id'],
+      'payment_instrument_id' => 'Credit Card',
+    ]);
+    $contribution_soft = $this->callAPISuccess('ContributionSoft', 'create', [
+      'contribution_id' => $contribution['id'],
+      'amount' => 10,
+      'contact_id' => $contact_owner,
+      'pcp_id' => $pcp['id'],
+      'pcp_display_in_roll' => 1,
+      'pcp_roll_nickname' => "Giver {$contact_contributor}",
+      'soft_credit_type_id' => 'pcp',
+    ]);
+
+    // Retrieve it using BAO so we can call gatherMessageValues
+    $contribution_bao = new CRM_Contribute_BAO_Contribution();
+    $contribution_bao->id = $contribution['id'];
+    $contribution_bao->find(TRUE);
+
+    $contribution_bao->_component = 'contribute';
+
+    // call and check result. $values has to be defined since it's pass-by-ref.
+    $values = [
+      'receipt_from_name' => 'CiviCRM Fundraising Dept.',
+      'receipt_from_email' => 'donationFake@civicrm.org',
+      'contribution_status' => 'Completed',
+    ];
+    $gathered_values = $contribution_bao->_gatherMessageValues(
+      [
+        'payment_processor_id' => $payment_processor['id'],
+        'is_email_receipt' => TRUE,
+      ],
+      $values,
+      [
+        'component' => 'contribute',
+        'contact_id' => $contact_contributor,
+        'contact' => $contact_contributor,
+        'financialType' => $contribution['values'][$contribution['id']]['financial_type_id'],
+        'contributionType' => $contribution['values'][$contribution['id']]['contribution_type_id'],
+        'contributionPage' => $contributionPage['id'],
+        'membership' => [],
+        'paymentProcessor' => $payment_processor['id'],
+        'contribution' => $contribution['id'],
+      ]
+    );
+
+    $this->assertEquals([
+      'receipt_from_name' => 'CiviCRM Fundraising Dept.',
+      'receipt_from_email' => 'donationFake@civicrm.org',
+      'contribution_status' => 'Completed',
+      'billingName' => "Giver {$contact_contributor}",
+      'address' => "Giver {$contact_contributor}\n123 Main St.\n",
+      'softContributions' => NULL,
+      'title' => 'Contribution',
+      'priceSetID' => '1',
+      'useForMember' => FALSE,
+      'lineItem' => [
+        0 => [
+          1 => [
+            'qty' => 1.0,
+            'label' => 'Contribution Amount',
+            'unit_price' => '10.00',
+            'line_total' => '10.00',
+            'price_field_id' => '1',
+            'participant_count' => NULL,
+            'price_field_value_id' => '1',
+            'field_title' => 'Contribution Amount',
+            'html_type' => 'Text',
+            'description' => NULL,
+            'entity_id' => '1',
+            'entity_table' => 'civicrm_contribution',
+            'contribution_id' => '1',
+            'financial_type_id' => '1',
+            'financial_type' => 'Donation',
+            'membership_type_id' => NULL,
+            'membership_num_terms' => NULL,
+            'tax_amount' => 0.0,
+            'price_set_id' => '1',
+            'tax_rate' => FALSE,
+            'subTotal' => 10.0,
+          ],
+        ],
+      ],
+      'customGroup' => [],
+      'is_pay_later' => '0',
+    ], $gathered_values);
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/1915

1. Visit something like `/civicrm/contribute/transact?id=1&pcpId=1&reset=1` where the id's are for a contribution/pcp page that has PCP. That link works on the PR demo installs.
1. Fill it out and check the box for "Show my contribution in the public honor roll" and fill out that section.
1. Confirm the contibution on the second page.
1. `Notice: Undefined index: soft_credit in CRM_Contribute_BAO_Contribution->_gatherMessageValues() (line 3112 of .../CRM/Contribute/BAO/Contribution.php).`


Technical Details
----------------------------------------
At first I wasn't sure if this was something bigger, since the pcp details are in a different set of array elements than the 'soft_credit' one and so I thought it might be unknowingly skipping them. But it ends up looking them up separately later. See details in lab ticket.

Comments
----------------------------------------
Has test
