### PR TITLE
dev/core#1909 - E_NOTICE on contribution edit

### DIFF
--- a/CRM/Contribute/Form/AbstractEditPayment.php
+++ b/CRM/Contribute/Form/AbstractEditPayment.php
@@ -718,7 +718,7 @@ WHERE  contribution_id = {$id}
       $title .= " - {$info['title']}";
     }
     $this->assign('transaction', TRUE);
-    $this->assign('payments', $paymentInfo['transaction']);
+    $this->assign('payments', $paymentInfo['transaction'] ?? NULL);
     $this->assign('paymentLinks', $paymentInfo['payment_links']);
     return $title;
   }

--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -954,7 +954,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
         }
         $smarty = CRM_Core_Smarty::singleton();
         $smarty->assign('dataArray', $dataArray);
-        $smarty->assign('totalTaxAmount', $params['tax_amount']);
+        $smarty->assign('totalTaxAmount', $params['tax_amount'] ?? NULL);
       }
 
       // lets store it in the form variable so postProcess hook can get to this and use it

--- a/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
@@ -1696,4 +1696,29 @@ Price Field - Price Field 1        1   $ 100.00      $ 100.00
     $this->membershipDelete($membership['id']);
   }
 
+  /**
+   * Test no warnings or errors during preProcess when editing.
+   */
+  public function testPreProcessContributionEdit() {
+    // Simulate a contribution in pending status
+    $contribution = $this->callAPISuccess(
+      'Contribution',
+      'create',
+      array_merge($this->_params, ['contribution_status_id' => 'Pending'])
+    );
+
+    // set up the form to edit the contribution and call preProcess
+    $form = $this->getFormObject('CRM_Contribute_Form_Contribution');
+    $_REQUEST['cid'] = $this->_individualId;
+    $_REQUEST['id'] = $contribution['id'];
+    $form->_action = CRM_Core_Action::UPDATE;
+    $form->preProcess();
+
+    // Check something while we're here
+    $this->assertEquals($contribution['id'], $form->_values['contribution_id']);
+
+    unset($_REQUEST['cid']);
+    unset($_REQUEST['id']);
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/1909

1. Go to the add new contribution form.
1. At the top right choose submit credit card.
1. Fill it out checking the box to make a recurring payment for some period of months.
1. Save it.
1. Back on the contact's contribution tab it will show status Pending. Click on Edit.
1. `Notice: Undefined index: transaction in CRM_Contribute_Form_AbstractEditPayment->assignPaymentInfoBlock() (line 721 of .../CRM/Contribute/Form/AbstractEditPayment.php)`

Comments
----------------------------------------
Has test

Also included a similar notice for tax_amount when you saved the contribution but it only comes up if you have a weird setup where you've enabled tax and invoicing in the contribution settings but then haven't actually set it up, i.e. didn't go and create a liability account and assign it to the financial type.