### PR TITLE
dev/core#1918 - Remove dubious qfkey checking code that never runs

### DIFF
--- a/CRM/Core/Key.php
+++ b/CRM/Core/Key.php
@@ -110,30 +110,19 @@ class CRM_Core_Key {
   }
 
   /**
-   * @param $key
+   * The original version of this function, added circa 2010 and untouched
+   * since then, seemed intended to check for a 32-digit hex string followed
+   * optionally by an underscore and 4-digit number. But it had a bug where
+   * the optional part was never checked ever. So have decided to remove that
+   * second check to keep it simple since it seems like pseudo-security.
+   *
+   * @param string $key
    *
    * @return bool
    */
   public static function valid($key) {
-    // a valid key is a 32 digit hex number
-    // followed by an optional _ and a number between 1 and 10000
-    if (strpos('_', $key) !== FALSE) {
-      list($hash, $seq) = explode('_', $key);
-
-      // ensure seq is between 1 and 10000
-      if (!is_numeric($seq) ||
-        $seq < 1 ||
-        $seq > 10000
-      ) {
-        return FALSE;
-      }
-    }
-    else {
-      $hash = $key;
-    }
-
-    // ensure that hash is a 32 digit hex number
-    return (bool) preg_match('#[0-9a-f]{32}#i', $hash);
+    // ensure that key contains a 32 digit hex string
+    return (bool) preg_match('#[0-9a-f]{32}#i', $key);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/1918

This function has had a typo that caused the whole block except the last line to never get executed ever in the 10 years since it was added. If it was meant as security it's not secure, so have decided to remove it in the interest of simplicity. It would be just as easy to fix, but seems to have limited value to me if it hasn't run in 10 years and has no security purpose.

Technical Details
----------------------------------------
It generates an E_NOTICE because the strpos params are backwards, but it gets hidden.
