### PR TITLE
Re-fix test

### DIFF
--- a/tests/phpunit/CRM/Contribute/BAO/ContributionRecurTest.php
+++ b/tests/phpunit/CRM/Contribute/BAO/ContributionRecurTest.php
@@ -372,13 +372,14 @@ class CRM_Contribute_BAO_ContributionRecurTest extends CiviUnitTestCase {
     $this->validateAllCounts($membershipId1, 4);
     $this->validateAllCounts($membershipId2, 4);
 
+    $expectedMonth = date('m') + 4;
     // check membership end date.
     foreach ([$membershipId1, $membershipId2] as $mId) {
       $endDate = $this->callAPISuccessGetValue('Membership', [
         'id' => $mId,
         'return' => 'end_date',
       ]);
-      $this->assertEquals(date('Y-m', strtotime('+4 months')) . '-27', $endDate, ts('End date incorrect.'));
+      $this->assertEquals(date('Y-' . $expectedMonth . '-27'), $endDate, ts('End date incorrect.'));
     }
 
     // At this moment Contact 2 is deceased, but we wait until payment is recorded in civi before marking the contact deceased.


### PR DESCRIPTION


Overview
----------------------------------------
Fix for flakey test

Before
----------------------------------------
Test fails at the end of some months, notably this one

After
----------------------------------------
Less flakey

Technical Details
----------------------------------------
The strtotime calculation adds 4 months before setting the day of month. However

July 31 + 4 months is 1 Dec - ie the month is 12 not 11 due to there being only 30 days. So to
get 27 Nov we need to get the July month (7) and add 4 and voila 11, not 12

Comments
----------------------------------------

