### PR TITLE
FiveTwentyEight - Provide concrete details about civicrm.files

### DIFF
--- a/CRM/Upgrade/Incremental/php/FiveTwentyEight.php
+++ b/CRM/Upgrade/Incremental/php/FiveTwentyEight.php
@@ -56,16 +56,23 @@ class CRM_Upgrade_Incremental_php_FiveTwentyEight extends CRM_Upgrade_Incrementa
       return '';
     }
 
-    return '<p>' . ts('Starting with version 5.29.0, CiviCRM on WP will
-         automate the determination of the civicrm files directory. Please
-         <a href=\'%1\' target=\'_blank\'>read the upgrade documentation related to this change before starting the upgrade process </a>
-         If you have a legacy (wp-content/plugins/files/civicrm) or non-standard directory
-         structure you will need to either override the settings in civicrm.settings.php
-         or by specifying the locations in System Settings Directories and System
-         Settings Resource URLs. . Starting with version 4.7.0, wp-content/uploads/civicrm/
-         is the standard WordPress CiviCRM Files directory.', [
+    $table = '<table><tbody>'
+      . sprintf('<tr><th colspan="2">%s</th></tr>', ts('<b>[civicrm.files]</b> Path'))
+      . sprintf('<tr><td>%s</td><td><code>%s</code></td></tr>', ts('5.29 Default:'), wp_upload_dir()['basedir'] . DIRECTORY_SEPARATOR . 'civicrm' . DIRECTORY_SEPARATOR)
+      . sprintf('<tr><td>%s</td><td><code>%s</code></td></tr>', ts('5.28 Default:'), CRM_Core_Config::singleton()->userSystem->getDefaultFileStorage()['path'])
+      . sprintf('<tr><td>%s</td><td><code>%s</code></td></tr>', ts('Active Value:'), Civi::paths()->getVariable('civicrm.files', 'path'))
+      . sprintf('<tr><th colspan="2">%s</th></tr>', ts('<b>[civicrm.files]</b> URL'))
+      . sprintf('<tr><td>%s</td><td><code>%s</code></td></tr>', ts('5.29 Default:'), wp_upload_dir()['baseurl'] . '/civicrm/')
+      . sprintf('<tr><td>%s</td><td><code>%s</code></td></tr>', ts('5.28 Default:'), CRM_Core_Config::singleton()->userSystem->getDefaultFileStorage()['url'])
+      . sprintf('<tr><td>%s</td><td><code>%s</code></td></tr>', ts('Active Value:'), Civi::paths()->getVariable('civicrm.files', 'url'))
+      . '</tbody></table>';
+
+    return '<p>' . ts('Starting with version 5.29.0, CiviCRM on WordPress may make a subtle change in the calculation of <code>[civicrm.files]</code>.
+         To ensure a smooth upgrade, please review the following table. All paths and URLs should appear the same. If there is <strong><em>any</em></strong> discrepancy,
+         then consult <a href=\'%1\' target=\'_blank\'>the upgrade documentation</a>.', [
            1 => 'https://docs.civicrm.org/sysadmin/en/latest/upgrade/version-specific/#civicrm-5.29',
-         ]) . '</p>';
+           2 => '...wp-content/uploads/civicrm',
+         ]) . '</p>' . $table;
   }
 
   /*

--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -135,6 +135,9 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
    * Moved from CRM_Utils_System_Base
    */
   public function getDefaultFileStorage() {
+    // NOTE: On WordPress, this will be circumvented in the future. However,
+    // should retain it to allow transitional/upgrade code determine the old value.
+
     $config = CRM_Core_Config::singleton();
     $cmsUrl = CRM_Utils_System::languageNegotiationURL($config->userFrameworkBaseURL, FALSE, TRUE);
     $cmsPath = $this->cmsRootPath();


### PR DESCRIPTION
Overview
----------------------------------------

@kcristiano I was taking another look at the upgrade messaging and wondering about an inexperienced admin would interpret phrases like "a legacy (wp-content/plugins/files/civicrm) or non-standard directory structure". I agree with these, of course - it just helps to have the longer context.

But I think it may be easier to interpret (on the first impression) if we show the values more concretely.

Before
----------------------------------------

Message describes the paths in general terms.

After
----------------------------------------

Message provides the concrete values that are detected by the old/new functions. This serves two aims:

1. Give enough info to make a quick decision on whether they need to read the longer document
2. If they do need the longer document, give a reference to make the details clearer.

I've run this on two local builds - one which used the recent-style `uploads/civicrm`:

<img width="910" alt="Screen Shot 2020-07-31 at 3 20 38 AM" src="https://user-images.githubusercontent.com/1336047/89026092-e67fe180-d2dc-11ea-82a3-1217589ba038.png">

The other uses the older-style `plugins/files/civicrm`:

<img width="910" alt="Screen Shot 2020-07-31 at 3 20 52 AM" src="https://user-images.githubusercontent.com/1336047/89026094-e7187800-d2dc-11ea-857f-6511a94a4a54.png">

The upcoming content of the doc link is at https://github.com/civicrm/civicrm-sysadmin-guide/pull/260/files. I've updated the draft a bit to provide more linking words. I also tried to follow @gah242s's point that `[civicrm.files]` seems more googleable/research-able.
