### PR TITLE
SQL temp table not using utf8mb4 if server default already set to utf8mb4

### DIFF
--- a/CRM/Utils/SQL/TempTable.php
+++ b/CRM/Utils/SQL/TempTable.php
@@ -148,8 +148,7 @@ class CRM_Utils_SQL_TempTable {
       return '';
     }
     $dbUTF = CRM_Core_BAO_SchemaHandler::getDBCollation();
-    if (in_array($dbUTF, ['utf8_unicode_ci', 'utf8mb4_unicode_ci'])
-      && in_array($dbUTF, ['utf8', 'utf8mb4'])) {
+    if (strpos($dbUTF, 'utf8') !== FALSE) {
       return '';
     }
     return self::UTF8;
@@ -168,7 +167,7 @@ class CRM_Utils_SQL_TempTable {
       $this->toSQL('CREATE'),
       $columns,
       $this->memory ? self::MEMORY : self::INNODB,
-      $this->utf8 ? self::UTF8 : ''
+      $this->getUtf8String()
     );
     CRM_Core_DAO::executeQuery($sql, [], TRUE, NULL, TRUE, FALSE);
     $this->createSql = $sql;


### PR DESCRIPTION
Overview
----------------------------------------
A unit test was failing locally with row size too large but the db settings should have supported it. (CRM/Export/BAO/ExportTest.php)

Technical Details
----------------------------------------
One thing was createWithColumns was not using the getUtf8String() helper, so it was overriding the server default and putting utf8.

Another thing is that it wasn't clear what the intent of the `if` statement in that function was. If it was meant to be a boolean AND, then it would always fail. If it was meant to be a boolean OR, as I suspect, then why two clauses.

Comments
----------------------------------------
I don't know the exact server settings on the PR test sites but I'm a little confused as to why the test was working there before and not also getting row size too large. Maybe a different page_size or something?
