### PR TITLE
[REF] Stop passing transaction to completeTransaction

### DIFF
--- a/CRM/Core/Payment/AuthorizeNetIPN.php
+++ b/CRM/Core/Payment/AuthorizeNetIPN.php
@@ -186,7 +186,7 @@ class CRM_Core_Payment_AuthorizeNetIPN extends CRM_Core_Payment_BaseIPN {
       return TRUE;
     }
 
-    $this->completeTransaction($input, $ids, $objects, $transaction, $recur);
+    $this->completeTransaction($input, $ids, $objects);
 
     // Only Authorize.net does this so it is on the a.net class. If there is a need for other processors
     // to do this we should make it available via the api, e.g as a parameter, changing the nuance

--- a/CRM/Core/Payment/BaseIPN.php
+++ b/CRM/Core/Payment/BaseIPN.php
@@ -477,13 +477,12 @@ class CRM_Core_Payment_BaseIPN {
    * @param array $input
    * @param array $ids
    * @param array $objects
-   * @param CRM_Core_Transaction $transaction
    *
    * @throws \CRM_Core_Exception
    * @throws \CiviCRM_API3_Exception
    */
-  public function completeTransaction(&$input, &$ids, &$objects, $transaction = NULL) {
-    CRM_Contribute_BAO_Contribution::completeOrder($input, $ids, $objects, $transaction);
+  public function completeTransaction(&$input, &$ids, &$objects) {
+    CRM_Contribute_BAO_Contribution::completeOrder($input, $ids, $objects);
   }
 
   /**

--- a/CRM/Core/Payment/PayPalIPN.php
+++ b/CRM/Core/Payment/PayPalIPN.php
@@ -283,7 +283,7 @@ class CRM_Core_Payment_PayPalIPN extends CRM_Core_Payment_BaseIPN {
       return;
     }
 
-    $this->completeTransaction($input, $ids, $objects, $transaction, $recur);
+    $this->completeTransaction($input, $ids, $objects);
   }
 
   /**

--- a/CRM/Core/Payment/PayPalProIPN.php
+++ b/CRM/Core/Payment/PayPalProIPN.php
@@ -373,7 +373,7 @@ class CRM_Core_Payment_PayPalProIPN extends CRM_Core_Payment_BaseIPN {
       return;
     }
 
-    $this->completeTransaction($input, $ids, $objects, $transaction, $recur);
+    $this->completeTransaction($input, $ids, $objects);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Minor simplification - don't pass useless parameters

Before
----------------------------------------

```
  $transaction = new CRM_Core_Transaction();
....
 $this->completeTransaction($input, $ids, $objects, $transaction, $recur);
```

After
----------------------------------------
```
 $this->completeTransaction($input, $ids, $objects);
```
transaction is an optional param & will be instantiated per above if not passed in


Technical Details
----------------------------------------
Transaction is an optional parameter for completeOrder and it would only make sense to pass it in
it the transaction were carrying some information - 

However, in each of these cases no action has been taken since it was initiated to passing in NULL
is equally good.

(note this means a next step is to remove it from completeOrder signature too)

Comments
----------------------------------------
