### PR TITLE
dev/mail#72 Remove call to custom fatal error handler from CRM_Core_E…

### DIFF
--- a/CRM/Core/Error.php
+++ b/CRM/Core/Error.php
@@ -573,18 +573,6 @@ class CRM_Core_Error extends PEAR_ErrorStack {
     }
     $file_log->close();
 
-    // Use the custom fatalErrorHandler if defined
-    if (in_array($priority, [PEAR_LOG_EMERG, PEAR_LOG_ALERT, PEAR_LOG_CRIT, PEAR_LOG_ERR])) {
-      if ($config->fatalErrorHandler && function_exists($config->fatalErrorHandler)) {
-        $name = $config->fatalErrorHandler;
-        $vars = [
-          'debugLogMessage' => $message,
-          'priority' => $priority,
-        ];
-        $name($vars);
-      }
-    }
-
     if (!isset(\Civi::$statics[__CLASS__]['userFrameworkLogging'])) {
       // Set it to FALSE first & then try to set it. This is to prevent a loop as calling
       // $config->userFrameworkLogging can trigger DB queries & under log mode this


### PR DESCRIPTION
…rror::debug_log_message

Overview
----------------------------------------
This removes the call to the custom fatal error that is proving to be problematic as per the report in the lab ticket https://lab.civicrm.org/dev/mail/-/issues/72

Before
----------------------------------------
Custom fatal error handler called from debug_log_message causing an exception to be thrown which blocks email sending

After
----------------------------------------
Email not blocked in sending

ping @MegaphoneJon @totten @eileenmcnaughton 