### PR TITLE
Remove requirement to pass 'contribution_status_id' => Pending from order.create

### DIFF
--- a/api/v3/Order.php
+++ b/api/v3/Order.php
@@ -74,9 +74,9 @@ function civicrm_api3_order_create($params) {
   civicrm_api3_verify_one_mandatory($params, NULL, ['line_items', 'total_amount']);
   $entity = NULL;
   $entityIds = [];
-  $contributionStatus = $params['contribution_status_id'] ?? NULL;
-  if ($contributionStatus !== 'Pending' && 'Pending' !== CRM_Core_PseudoConstant::getName('CRM_Contribute_BAO_Contribution', 'contribution_status_id', $contributionStatus)) {
-    CRM_Core_Error::deprecatedFunctionWarning("Creating a Order with a status other than pending is deprecated. Currently empty defaults to 'Completed' so as a transition not passing in 'Pending' is deprecated. You can chain payment creation e.g civicrm_api3('Order', 'create', ['blah' => 'blah', 'contribution_status_id' => 'Pending', 'api.Payment.create => ['total_amount' => 5]]");
+  $params['contribution_status_id'] = $params['contribution_status_id'] ?? 'Pending';
+  if ($params['contribution_status_id'] !== 'Pending' && 'Pending' !== CRM_Core_PseudoConstant::getName('CRM_Contribute_BAO_Contribution', 'contribution_status_id', $params['contribution_status_id'])) {
+    CRM_Core_Error::deprecatedFunctionWarning("Creating a Order with a status other than pending is deprecated. Please do not set contribution_status_id, it will default to Pending. You can chain payment creation e.g civicrm_api3('Order', 'create', ['blah' => 'blah', 'contribution_status_id' => 'Pending', 'api.Payment.create => ['total_amount' => 5]]");
   }
 
   if (!empty($params['line_items']) && is_array($params['line_items'])) {
@@ -91,9 +91,7 @@ function civicrm_api3_order_create($params) {
       if ($entityParams) {
         if (in_array($entity, ['participant', 'membership'])) {
           $entityParams['skipLineItem'] = TRUE;
-          if ($contributionStatus === 'Pending') {
-            $entityParams['status_id'] = ($entity === 'participant' ? 'Pending from incomplete transaction' : 'Pending');
-          }
+          $entityParams['status_id'] = ($entity === 'participant' ? 'Pending from incomplete transaction' : 'Pending');
           $entityResult = civicrm_api3($entity, 'create', $entityParams);
           $params['contribution_mode'] = $entity;
           $entityIds[] = $params[$entity . '_id'] = $entityResult['id'];

--- a/tests/phpunit/CRM/Contribute/BAO/ContributionRecurTest.php
+++ b/tests/phpunit/CRM/Contribute/BAO/ContributionRecurTest.php
@@ -304,7 +304,6 @@ class CRM_Contribute_BAO_ContributionRecurTest extends CiviUnitTestCase {
       'contact_id' => $contactId1,
       'receive_date' => '2010-01-20',
       'financial_type_id' => 'Member Dues',
-      'contribution_status_id' => 'Pending',
       'contribution_recur_id' => $contributionRecurId,
       'total_amount' => 150,
       'api.Payment.create' => ['total_amount' => 150],

--- a/tests/phpunit/CRM/Contribute/Form/Task/InvoiceTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/Task/InvoiceTest.php
@@ -136,7 +136,6 @@ class CRM_Contribute_Form_Task_InvoiceTest extends CiviUnitTestCase {
         return $total;
       }),
       'financial_type_id' => $priceFieldValues['values'][0]['financial_type_id'],
-      'contribution_status_id' => 'Pending',
       'currency' => 'USD',
       'line_items' => $lineItemParams,
     ];


### PR DESCRIPTION

Overview
----------------------------------------
Alters Order.create api such that contribution_status_id defaults to pending if not passed in

Before
----------------------------------------
Order.create issues aa deprecation notice unless the following exists
```
'contribution_status_id' => 'Pending'
```

After
----------------------------------------
We switch from recommending passing in a specific value to passing in no value at all and providing a default of Pending.

Any other value will still result in a notice (for now, but later we can just ignore input on this field altogheter)

Technical Details
----------------------------------------

contribution_status_id is a required param, but the only acceptable value is Pending. Let's make it optional.....

Comments
----------------------------------------

