### PR TITLE
[REF] Stop instantiating transaction in PaypalIPN

### DIFF
--- a/CRM/Core/Payment/BaseIPN.php
+++ b/CRM/Core/Payment/BaseIPN.php
@@ -214,7 +214,7 @@ class CRM_Core_Payment_BaseIPN {
    * @return bool
    * @throws \CiviCRM_API3_Exception
    */
-  public function failed(&$objects, &$transaction, $input = []) {
+  public function failed(&$objects, $transaction = NULL, $input = []) {
     $contribution = &$objects['contribution'];
     $memberships = [];
     if (!empty($objects['membership'])) {
@@ -266,7 +266,9 @@ class CRM_Core_Payment_BaseIPN {
       }
     }
 
-    $transaction->commit();
+    if ($transaction) {
+      $transaction->commit();
+    }
     Civi::log()->debug("Setting contribution status to Failed");
     return TRUE;
   }
@@ -299,7 +301,7 @@ class CRM_Core_Payment_BaseIPN {
    * @return bool
    * @throws \CiviCRM_API3_Exception
    */
-  public function cancelled(&$objects, &$transaction, $input = []) {
+  public function cancelled(&$objects, $transaction = NULL, $input = []) {
     $contribution = &$objects['contribution'];
     $memberships = [];
     if (!empty($objects['membership'])) {
@@ -353,7 +355,9 @@ class CRM_Core_Payment_BaseIPN {
         $this->cancelParticipant($participant->id);
       }
     }
-    $transaction->commit();
+    if ($transaction) {
+      $transaction->commit();
+    }
     Civi::log()->debug("Setting contribution status to Cancelled");
     return TRUE;
   }

--- a/CRM/Core/Payment/PayPalIPN.php
+++ b/CRM/Core/Payment/PayPalIPN.php
@@ -256,18 +256,18 @@ class CRM_Core_Payment_PayPalIPN extends CRM_Core_Payment_BaseIPN {
       $contribution->total_amount = $input['amount'];
     }
 
-    $transaction = new CRM_Core_Transaction();
-
     $status = $input['paymentStatus'];
     if ($status == 'Denied' || $status == 'Failed' || $status == 'Voided') {
-      return $this->failed($objects, $transaction);
+      $this->failed($objects);
+      return;
     }
     if ($status === 'Pending') {
       Civi::log()->debug('Returning since contribution status is Pending');
       return;
     }
     elseif ($status == 'Refunded' || $status == 'Reversed') {
-      return $this->cancelled($objects, $transaction);
+      $this->cancelled($objects);
+      return;
     }
     elseif ($status !== 'Completed') {
       Civi::log()->debug('Returning since contribution status is not handled');
@@ -277,13 +277,12 @@ class CRM_Core_Payment_PayPalIPN extends CRM_Core_Payment_BaseIPN {
     // check if contribution is already completed, if so we ignore this ipn
     $completedStatusId = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Completed');
     if ($contribution->contribution_status_id == $completedStatusId) {
-      $transaction->commit();
       Civi::log()->debug('PayPalIPN: Returning since contribution has already been handled. (ID: ' . $contribution->id . ').');
       echo 'Success: Contribution has already been handled<p>';
       return;
     }
 
-    $this->completeTransaction($input, $ids, $objects, $transaction, $recur);
+    $this->completeTransaction($input, $ids, $objects);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Don't istantiate pointless transactionn

Before
----------------------------------------
Transaction instantiated & passed around - but adds no real value

After
----------------------------------------
Not instantiated, except in completeOrder where it is done in the right place (in the BAO function)

Technical Details
----------------------------------------
I can do similar for PaypalProIPN & Anet IPN

Comments
----------------------------------------
