### PR TITLE
Remove unused parameter ids['billing']

### DIFF
--- a/CRM/Core/Payment/AuthorizeNetIPN.php
+++ b/CRM/Core/Payment/AuthorizeNetIPN.php
@@ -203,11 +203,10 @@ class CRM_Core_Payment_AuthorizeNetIPN extends CRM_Core_Payment_BaseIPN {
    * Get the input from passed in fields.
    *
    * @param array $input
-   * @param array $ids
    *
    * @throws \CRM_Core_Exception
    */
-  public function getInput(&$input, &$ids) {
+  public function getInput(&$input) {
     $input['amount'] = $this->retrieve('x_amount', 'String');
     $input['subscription_id'] = $this->retrieve('x_subscription_id', 'Integer');
     $input['response_code'] = $this->retrieve('x_response_code', 'Integer');
@@ -215,7 +214,6 @@ class CRM_Core_Payment_AuthorizeNetIPN extends CRM_Core_Payment_BaseIPN {
     $input['response_reason_code'] = $this->retrieve('x_response_reason_code', 'String', FALSE);
     $input['response_reason_text'] = $this->retrieve('x_response_reason_text', 'String', FALSE);
     $input['subscription_paynum'] = $this->retrieve('x_subscription_paynum', 'Integer', FALSE, 0);
-    $input['trxn_id'] = $this->retrieve('x_trans_id', 'String', FALSE);
     $input['trxn_id'] = $this->retrieve('x_trans_id', 'String', FALSE);
     $input['receive_date'] = $this->retrieve('receive_date', 'String', FALSE, date('YmdHis', strtotime('now')));
 
@@ -229,7 +227,7 @@ class CRM_Core_Payment_AuthorizeNetIPN extends CRM_Core_Payment_BaseIPN {
       $input['trxn_id'] = md5(uniqid(rand(), TRUE));
     }
 
-    $billingID = $ids['billing'] = CRM_Core_BAO_LocationType::getBilling();
+    $billingID = CRM_Core_BAO_LocationType::getBilling();
     $params = [
       'first_name' => 'x_first_name',
       'last_name' => 'x_last_name',

--- a/CRM/Core/Payment/PayPalIPN.php
+++ b/CRM/Core/Payment/PayPalIPN.php
@@ -302,7 +302,7 @@ class CRM_Core_Payment_PayPalIPN extends CRM_Core_Payment_BaseIPN {
     $membershipID = $this->retrieve('membershipID', 'Integer', FALSE);
     $contributionRecurID = $this->retrieve('contributionRecurID', 'Integer', FALSE);
 
-    $this->getInput($input, $ids);
+    $this->getInput($input);
 
     if ($component == 'event') {
       $ids['event'] = $this->retrieve('eventID', 'Integer', TRUE);
@@ -375,12 +375,11 @@ class CRM_Core_Payment_PayPalIPN extends CRM_Core_Payment_BaseIPN {
 
   /**
    * @param array $input
-   * @param array $ids
    *
    * @throws \CRM_Core_Exception
    */
-  public function getInput(&$input, &$ids) {
-    $billingID = $ids['billing'] = CRM_Core_BAO_LocationType::getBilling();
+  public function getInput(&$input) {
+    $billingID = CRM_Core_BAO_LocationType::getBilling();
     $input['txnType'] = $this->retrieve('txn_type', 'String', FALSE);
     $input['paymentStatus'] = $this->retrieve('payment_status', 'String', FALSE);
     $input['invoice'] = $this->retrieve('invoice', 'String', TRUE);

--- a/CRM/Core/Payment/PayPalProIPN.php
+++ b/CRM/Core/Payment/PayPalProIPN.php
@@ -423,7 +423,7 @@ class CRM_Core_Payment_PayPalProIPN extends CRM_Core_Payment_BaseIPN {
     $ids['contact'] = self::getValue('c', TRUE);
     $ids['contribution'] = self::getValue('b', TRUE);
 
-    $this->getInput($input, $ids);
+    $this->getInput($input);
 
     if ($this->_component == 'event') {
       $ids['event'] = self::getValue('e', TRUE);
@@ -487,13 +487,12 @@ INNER JOIN civicrm_membership_payment mp ON m.id = mp.membership_id AND mp.contr
 
   /**
    * @param array $input
-   * @param array $ids
    *
    * @return void
    * @throws CRM_Core_Exception
    */
-  public function getInput(&$input, &$ids) {
-    $billingID = $ids['billing'] = CRM_Core_BAO_LocationType::getBilling();
+  public function getInput(&$input) {
+    $billingID = CRM_Core_BAO_LocationType::getBilling();
 
     $input['txnType'] = self::retrieve('txn_type', 'String', 'POST', FALSE);
     $input['paymentStatus'] = self::retrieve('payment_status', 'String', 'POST', FALSE);


### PR DESCRIPTION


Overview
----------------------------------------
$ids['billing'] calculated, but unused

Before
----------------------------------------
```
$billingID = $ids['billing'] = CRM_Core_BAO_LocationType::getBilling();
```

After
----------------------------------------
```
$billingID = CRM_Core_BAO_LocationType::getBilling();
```

Technical Details
----------------------------------------
This has been around a long time but most places in the code just call ``CRM_Core_BAO_LocationType::getBilling();`` as required now so it does nothing

Grepping for $ids['billing']  finds only one deprecated function

Comments
----------------------------------------

