### PR TITLE
Alternate cleanup on failed -  do not pass transaction, but use it

### DIFF
--- a/CRM/Core/Payment/BaseIPN.php
+++ b/CRM/Core/Payment/BaseIPN.php
@@ -214,7 +214,8 @@ class CRM_Core_Payment_BaseIPN {
    * @return bool
    * @throws \CiviCRM_API3_Exception
    */
-  public function failed(&$objects, &$transaction, $input = []) {
+  public function failed(&$objects, $input = []) {
+    $transaction = new CRM_Core_Transaction();
     $contribution = &$objects['contribution'];
     $memberships = [];
     if (!empty($objects['membership'])) {

--- a/CRM/Core/Payment/PayPalIPN.php
+++ b/CRM/Core/Payment/PayPalIPN.php
@@ -260,7 +260,7 @@ class CRM_Core_Payment_PayPalIPN extends CRM_Core_Payment_BaseIPN {
 
     $status = $input['paymentStatus'];
     if ($status == 'Denied' || $status == 'Failed' || $status == 'Voided') {
-      return $this->failed($objects, $transaction);
+      return $this->failed($objects);
     }
     if ($status === 'Pending') {
       Civi::log()->debug('Returning since contribution status is Pending');

--- a/CRM/Core/Payment/PayPalProIPN.php
+++ b/CRM/Core/Payment/PayPalProIPN.php
@@ -348,7 +348,7 @@ class CRM_Core_Payment_PayPalProIPN extends CRM_Core_Payment_BaseIPN {
 
     $status = $input['paymentStatus'];
     if ($status == 'Denied' || $status == 'Failed' || $status == 'Voided') {
-      $this->failed($objects, $transaction);
+      $this->failed($objects);
       return;
     }
     if ($status === 'Pending') {

--- a/CRM/Event/Form/Task/Batch.php
+++ b/CRM/Event/Form/Task/Batch.php
@@ -394,8 +394,7 @@ class CRM_Event_Form_Task_Batch extends CRM_Event_Form_Task {
       return $statusId;
     }
     elseif ($statusId == $contributionStatuses['Failed']) {
-      $transaction = new CRM_Core_Transaction();
-      $baseIPN->failed($objects, $transaction, $input);
+      $baseIPN->failed($objects, $input);
       $transaction->commit();
       return $statusId;
     }

--- a/tests/phpunit/CRM/Core/Payment/BaseIPNTest.php
+++ b/tests/phpunit/CRM/Core/Payment/BaseIPNTest.php
@@ -428,8 +428,7 @@ class CRM_Core_Payment_BaseIPNTest extends CiviUnitTestCase {
       'status_id' => 'Pending from incomplete transaction',
     ]);
 
-    $transaction = new CRM_Core_Transaction();
-    $this->IPN->failed($this->objects, $transaction);
+    $this->IPN->failed($this->objects);
 
     $cancelledParticipantsCount = civicrm_api3('Participant', 'get', [
       'sequential' => 1,


### PR DESCRIPTION
Overview
----------------------------------------
Alternative to https://github.com/civicrm/civicrm-core/pull/18020 focussing on failed - handles transaction fully within the failed function

Before
----------------------------------------
Transaction passed in (after no actions using it have been taken)

After
----------------------------------------
Transaction instantiated within failed function

Technical Details
----------------------------------------


Comments
----------------------------------------
