### PR TITLE
[Ref] Remove transaction instantiation in PaypalPro

### DIFF
--- a/CRM/Core/Payment/PayPalProIPN.php
+++ b/CRM/Core/Payment/PayPalProIPN.php
@@ -344,11 +344,9 @@ class CRM_Core_Payment_PayPalProIPN extends CRM_Core_Payment_BaseIPN {
       $contribution->total_amount = $input['amount'];
     }
 
-    $transaction = new CRM_Core_Transaction();
-
     $status = $input['paymentStatus'];
     if ($status == 'Denied' || $status == 'Failed' || $status == 'Voided') {
-      $this->failed($objects, $transaction);
+      $this->failed($objects);
       return;
     }
     if ($status === 'Pending') {
@@ -356,7 +354,7 @@ class CRM_Core_Payment_PayPalProIPN extends CRM_Core_Payment_BaseIPN {
       return;
     }
     elseif ($status == 'Refunded' || $status == 'Reversed') {
-      $this->cancelled($objects, $transaction);
+      $this->cancelled($objects);
       return;
     }
     elseif ($status !== 'Completed') {
@@ -367,13 +365,12 @@ class CRM_Core_Payment_PayPalProIPN extends CRM_Core_Payment_BaseIPN {
     // check if contribution is already completed, if so we ignore this ipn
     $completedStatusId = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Completed');
     if ($contribution->contribution_status_id == $completedStatusId) {
-      $transaction->commit();
       Civi::log()->debug('PayPalProIPN: Returning since contribution has already been handled.');
       echo 'Success: Contribution has already been handled<p>';
       return;
     }
 
-    $this->completeTransaction($input, $ids, $objects, $transaction, $recur);
+    $this->completeTransaction($input, $ids, $objects);
   }
 
   /**


### PR DESCRIPTION


Overview
----------------------------------------
The transaction is an optional param & we are not doing any saves so let's take the option to not pass it in...

Before
----------------------------------------
$transaction is now optional but still passed in, to no gain

After
----------------------------------------
completeOrder internally adds a transaction

Technical Details
----------------------------------------


Comments
----------------------------------------
Same as https://github.com/civicrm/civicrm-core/pull/18020 - different class
