### PR TITLE
[REF] Deploy Pear DB package using composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -78,7 +78,8 @@
     "typo3/phar-stream-wrapper": "^2 || ^3.0",
     "brick/money": "~0.4",
     "ext-intl": "*",
-    "pear/mail_mime": "~1.10"
+    "pear/mail_mime": "~1.10",
+    "pear/db": "1.10"
   },
   "scripts": {
     "post-install-cmd": [
@@ -250,6 +251,9 @@
       },
       "electrolinux/phpquery": {
         "PHP7.4 Fix for array access using {} instead of []": "https://raw.githubusercontent.com/civicrm/civicrm-core/fe45bdfc4f3e3d3deb27e3d853cdbc7f616620a9/tools/scripts/composer/patches/php74_array_access_fix_phpquery.patch"
+      },
+      "pear/db": {
+        "Apply CiviCRM Customisations for the pear:db package": "https://raw.githubusercontent.com/civicrm/civicrm-core/a48a43c2b5f6d694fff1cfb99d522c5d9e2459a0/tools/scripts/composer/pear_db_civicrm_changes.patch"
       },
       "pear/mail": {
         "Apply CiviCRM Customisations for CRM-1367 and CRM-5946": "https://raw.githubusercontent.com/civicrm/civicrm-core/36319938a5bf26c1e7e2110a26a65db6a5979268/tools/scripts/composer/patches/pear-mail.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1ff9c045fb03756148c0c66562aa61fd",
+    "content-hash": "46e891da51f0683373d9a6e62fb6f868",
     "packages": [
         {
             "name": "adrienrn/php-mimetyper",
@@ -997,6 +997,66 @@
             ],
             "description": "More info available on: http://pear.php.net/package/Console_Getopt",
             "time": "2015-07-20T20:28:12+00:00"
+        },
+        {
+            "name": "pear/db",
+            "version": "v1.10.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pear/DB.git",
+                "reference": "e158c3a48246b67cd8c95856ffbb93de4ef380fe"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pear/DB/zipball/e158c3a48246b67cd8c95856ffbb93de4ef380fe",
+                "reference": "e158c3a48246b67cd8c95856ffbb93de4ef380fe",
+                "shasum": ""
+            },
+            "require": {
+                "pear/pear-core-minimal": "*"
+            },
+            "type": "library",
+            "extra": {
+                "patches_applied": {
+                    "Apply CiviCRM Customisations for the pear:db package": "https://raw.githubusercontent.com/civicrm/civicrm-core/a48a43c2b5f6d694fff1cfb99d522c5d9e2459a0/tools/scripts/composer/pear_db_civicrm_changes.patch"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "DB": "./"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "include-path": [
+                "./"
+            ],
+            "license": [
+                "PHP License v3.01"
+            ],
+            "authors": [
+                {
+                    "name": "Daniel Convissor",
+                    "email": "danielc@php.net",
+                    "role": "Lead"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net",
+                    "role": "Lead"
+                },
+                {
+                    "name": "Stig Bakken",
+                    "email": "stig@php.net",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Tomas V.V.Cox",
+                    "email": "cox@idecnet.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "More info available on: http://pear.php.net/package/DB",
+            "time": "2020-04-19T19:45:59+00:00"
         },
         {
             "name": "pear/log",


### PR DESCRIPTION
Overview
----------------------------------------
This migrates how we deploy Pear DB to using the composer variant rather than from within civicrm-packages.

Before
----------------------------------------
civicrm-packages repo used
CiviCRM Patches compared to 1.9.3 which is the current version of the package we have https://gist.github.com/seamuslee001/f74756e7b0c16ac4931a9c59d7f17778

After
----------------------------------------
composer used
patches that will be applied as part of composer are here
https://raw.githubusercontent.com/civicrm/civicrm-core/a48a43c2b5f6d694fff1cfb99d522c5d9e2459a0/tools/scripts/composer/pear_db_civicrm_changes.patch

Technical Details
----------------------------------------
CiviCRM Has a few patches ontop of Pear DB. Most of these should be as far as I can tell covered within our unit tests

ping @eileenmcnaughton @totten @demeritcowboy 

I would suggest if we are happy with this that we merge this in after the next RC is cut