### PR TITLE
[Ref] Simplify is_email_receipt in sendMail

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2927,7 +2927,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
 
     //not really sure what params might be passed in but lets merge em into values
     $values = array_merge($this->_gatherMessageValues($input, $values, $ids), $values);
-    $values['is_email_receipt'] = $this->isEmailReceipt($input, $values);
+    $values['is_email_receipt'] = !$returnMessageText;
     if (!empty($input['receipt_date'])) {
       $values['receipt_date'] = $input['receipt_date'];
     }
@@ -5704,23 +5704,6 @@ LIMIT 1;";
         }
       }
     }
-  }
-
-  /**
-   * Should an email receipt be sent for this contribution when complete.
-   *
-   * @param array $input
-   *
-   * @return mixed
-   */
-  protected function isEmailReceipt($input) {
-    if (isset($input['is_email_receipt'])) {
-      return $input['is_email_receipt'];
-    }
-    if (!empty($this->_relatedObjects['contribution_page_id'])) {
-      return $this->_relatedObjects['contribution_page_id']->is_email_receipt;
-    }
-    return TRUE;
   }
 
   /**

--- a/api/v3/Contribution.php
+++ b/api/v3/Contribution.php
@@ -404,7 +404,6 @@ function civicrm_api3_contribution_sendconfirmation($params) {
     'payment_processor_id',
   ];
   $input = array_intersect_key($params, array_flip($allowedParams));
-  $input['is_email_receipt'] = TRUE;
   CRM_Contribute_BAO_Contribution::sendMail($input, $ids, $params['id']);
 }
 


### PR DESCRIPTION


Overview
----------------------------------------
Removes legacy handling from BAO_Contribution::sendMail

Before
----------------------------------------
The function attempts to calculate whether it actually should send mail

After
----------------------------------------
The function trusts it's caller. 

Technical Details
----------------------------------------
This function has evolved through refactoring so there was a time when this code needed to decide whether to
send emails out or not. However, the function is now called more deliberately -ie
1) from completeTransaction - where it is only called if the decision to send an email is made
2) from the search action send Email receipts - where a user has made the decision to send (or pdf)
receipts and unless it's being called with returnMessageText = TRUE (to construct a pdf) then
send makes sense

Ergo we should send unless returnMessageText = TRUE

Comments
----------------------------------------

