### PR TITLE
Remove invalid use of crmMoney formatter

### DIFF
--- a/templates/CRM/Contribute/Form/ContributionPage/Amount.tpl
+++ b/templates/CRM/Contribute/Form/ContributionPage/Amount.tpl
@@ -177,9 +177,9 @@
             <tr id="minMaxFields" class="crm-contribution-form-block-minMaxFields"><td>&nbsp;</td><td>
                <table class="form-layout-compressed">
                 <tr class="crm-contribution-form-block-min_amount"><th scope="row" class="label">{$form.min_amount.label}</th>
-                <td>{$form.min_amount.html|crmMoney}</td></tr>
+                <td>{$form.min_amount.html}</td></tr>
                 <tr class="crm-contribution-form-block-max_amount"><th scope="row" class="label">{$form.max_amount.label}</th>
-                <td>{$form.max_amount.html|crmMoney}<br />
+                <td>{$form.max_amount.html}<br />
                 <span class="description">{ts 1=5|crmMoney}If you have chosen to <strong>Allow Other Amounts</strong>, you can use the fields above to control minimum and/or maximum acceptable values (e.g. don't allow contribution amounts less than %1).{/ts}</span></td></tr>
                </table>
             </td></tr>
@@ -194,7 +194,7 @@
                         <tr class="columnheader" ><th scope="column">{ts}Contribution Label{/ts}</th><th scope="column">{ts}Amount{/ts}</th><th scope="column">{ts}Default?{/ts}<br />{$form.default.0.html}</th></tr>
                         {section name=loop start=1 loop=11}
                             {assign var=idx value=$smarty.section.loop.index}
-                            <tr><td class="even-row">{$form.label.$idx.html}</td><td>{$form.value.$idx.html|crmMoney}</td><td class="even-row">{$form.default.$idx.html}</td></tr>
+                            <tr><td class="even-row">{$form.label.$idx.html}</td><td>{$form.value.$idx.html}</td><td class="even-row">{$form.default.$idx.html}</td></tr>
                         {/section}
                     </table>
               </fieldset>


### PR DESCRIPTION
Overview
----------------------------------------
`crmMoney` smarty function is being used to "format" an html element instead of a monetary value.

Before
----------------------------------------
HTML element passed to `crmMoney`.

After
----------------------------------------
Not passed to `crmMoney`.

Technical Details
----------------------------------------


Comments
----------------------------------------
Identified while working on brick/money where this invalid use causes CRM_Utils_Money::format to throw an exception.
