### PR TITLE
Fix for failing test

### DIFF
--- a/tests/phpunit/CRM/Contribute/BAO/ContributionRecurTest.php
+++ b/tests/phpunit/CRM/Contribute/BAO/ContributionRecurTest.php
@@ -331,7 +331,7 @@ class CRM_Contribute_BAO_ContributionRecurTest extends CiviUnitTestCase {
           'contact_id' => $contactId,
           'membership_type_id' => $priceField['membership_type_id'],
           'source' => 'Payment',
-          'join_date' => date('Y-m') . '-28',
+          'join_date' => date('Y-m', strtotime('1 month ago')) . '-28',
           'start_date' => date('Y-m') . '-28',
           'contribution_recur_id' => $contributionRecurId,
           'status_id' => 'Pending',


### PR DESCRIPTION

Overview
----------------------------------------
Fix for failing test

Before
----------------------------------------
Test fails for much of the month as the join_date is in the past

After
cross fingers

Technical Details
----------------------------------------
BY ensuring join_date is in the past we get away from situations where there is no valid status

Comments
----------------------------------------
While it turns out https://github.com/civicrm/civicrm-core/pull/18034 passes I found it gets us into the rabbit hole of what should happen when an expired membership is renewed

What I found writing a test made my head hurt - so I figured I should fix it this way

