### PR TITLE
Add test on status calculation

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -5272,6 +5272,8 @@ LIMIT 1;";
          * In BAO/Membership.php(renewMembership function), we skip the extend membership date and status
          * when Contribution mode is notify and membership is for renewal )
          */
+        // Test cover for this is in testRepeattransactionRenewMembershipOldMembership
+        // Be afraid.
         CRM_Member_BAO_Membership::fixMembershipStatusBeforeRenew($currentMembership, $changeDate);
 
         // @todo - we should pass membership_type_id instead of null here but not


### PR DESCRIPTION
Overview
----------------------------------------
Adds test for code that is untested

Before
----------------------------------------
No test

After
----------------------------------------
Test

Technical Details
----------------------------------------
This test shows why https://github.com/civicrm/civicrm-core/pull/18034 seems tempting but is actually the wrong thing to do as it does actually change behaviour (which I had my doubts about until developing a test to hit those lines of code).

Comments
----------------------------------------
Thinking too deeply about this is for the faint hearted