### PR TITLE
Fix qill typo

### DIFF
--- a/CRM/Case/BAO/Query.php
+++ b/CRM/Case/BAO/Query.php
@@ -376,7 +376,7 @@ class CRM_Case_BAO_Query extends CRM_Core_BAO_Query {
         }
 
         $query->_where[$grouping][] = CRM_Contact_BAO_Query::buildClause("case_activity.status_id", $op, $value, 'Int');
-        $query->_qill[$grouping][] = ts("Activity Type %1 %2", [1 => $op, 2 => $names]);
+        $query->_qill[$grouping][] = ts("Activity Status %1 %2", [1 => $op, 2 => $names]);
         $query->_tables['case_activity'] = $query->_whereTables['case_activity'] = 1;
         $query->_tables['civicrm_case'] = $query->_whereTables['civicrm_case'] = 1;
         $query->_tables['case_activity_status'] = 1;

--- a/tests/phpunit/CRM/Case/BAO/QueryTest.php
+++ b/tests/phpunit/CRM/Case/BAO/QueryTest.php
@@ -22,9 +22,6 @@ class CRM_Case_BAO_QueryTest extends CiviUnitTestCase {
    * CRM-17120 check the qill is still calculated after changing function used
    * to retrieve function.
    *
-   * Note that the Qill doesn't actually appear to have the correct labels to
-   * start with. I didn't attempt to fix that. I just prevented regression.
-   *
    * I could not find anyway to actually do this search with the relevant fields
    * as parameters & don't know if they exist as legitimate code or code cruft so
    * this test was the only way I could verify the change.
@@ -61,7 +58,7 @@ class CRM_Case_BAO_QueryTest extends CiviUnitTestCase {
     $this->assertEquals(
       [
         0 => 'Activity Type = Contribution',
-        1 => 'Activity Type = Scheduled',
+        1 => 'Activity Status = Scheduled',
         2 => 'Activity Medium = In Person',
       ],
       $queryObj->_qill[1]


### PR DESCRIPTION
Overview
----------------------------------------
Fix typo in qill

Before
----------------------------------------
Status confused with Type

After
----------------------------------------
Status is status. Type is type.

Technical Details
----------------------------------------
As noted in the comments already there, this is a weird test since you can't see it in the UI anywhere. Any related searches in the UI show the qill correctly already. So 🤷 

Comments
----------------------------------------

