### PR TITLE
dev/core#1916 - Fix naming of case export fields / remove ones that aren't true

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -2175,15 +2175,11 @@ AND cl.modified_id  = c.id
           'title' => ts('Activity Reporter'),
           'type' => CRM_Utils_Type::T_STRING,
         ],
-        'case_recent_activity_date' => [
-          'title' => ts('Activity Actual Date'),
+        'case_activity_date_time' => [
+          'title' => ts('Activity Date'),
           'type' => CRM_Utils_Type::T_DATE,
         ],
-        'case_scheduled_activity_date' => [
-          'title' => ts('Activity Scheduled Date'),
-          'type' => CRM_Utils_Type::T_DATE,
-        ],
-        'case_recent_activity_type' => [
+        'case_activity_type' => [
           'title' => ts('Activity Type'),
           'type' => CRM_Utils_Type::T_STRING,
         ],

--- a/CRM/Case/BAO/Query.php
+++ b/CRM/Case/BAO/Query.php
@@ -100,9 +100,9 @@ class CRM_Case_BAO_Query extends CRM_Core_BAO_Query {
       $query->_tables['case_relation_type'] = $query->_whereTables['case_relation_type'] = 1;
     }
 
-    if (!empty($query->_returnProperties['case_recent_activity_date'])) {
-      $query->_select['case_recent_activity_date'] = "case_activity.activity_date_time as case_recent_activity_date";
-      $query->_element['case_recent_activity_date'] = 1;
+    if (!empty($query->_returnProperties['case_activity_date_time'])) {
+      $query->_select['case_activity_date_time'] = "case_activity.activity_date_time as case_activity_date_time";
+      $query->_element['case_activity_date_time'] = 1;
       $query->_tables['case_activity'] = $query->_whereTables['case_activity'] = 1;
     }
 
@@ -135,7 +135,7 @@ class CRM_Case_BAO_Query extends CRM_Core_BAO_Query {
       $query->_select['case_activity_status_id'] = "rec_activity_status.id as case_activity_status_id";
       $query->_element['case_activity_status_id'] = 1;
       $query->_tables['case_activity'] = 1;
-      $query->_tables['recent_activity_status'] = 1;
+      $query->_tables['case_activity_status'] = 1;
       $query->_tables['civicrm_case_contact'] = 1;
       $query->_tables['civicrm_case'] = 1;
     }
@@ -144,7 +144,7 @@ class CRM_Case_BAO_Query extends CRM_Core_BAO_Query {
       $query->_select['case_activity_status'] = "rec_activity_status.label as case_activity_status";
       $query->_element['case_activity_status'] = 1;
       $query->_tables['case_activity'] = 1;
-      $query->_tables['recent_activity_status'] = 1;
+      $query->_tables['case_activity_status'] = 1;
       $query->_tables['civicrm_case_contact'] = 1;
       $query->_tables['civicrm_case'] = 1;
     }
@@ -158,7 +158,7 @@ class CRM_Case_BAO_Query extends CRM_Core_BAO_Query {
     }
 
     if (!empty($query->_returnProperties['case_activity_medium_id'])) {
-      $query->_select['case_activity_medium_id'] = "recent_activity_medium.label as case_activity_medium_id";
+      $query->_select['case_activity_medium_id'] = "case_activity_medium.label as case_activity_medium_id";
       $query->_element['case_activity_medium_id'] = 1;
       $query->_tables['case_activity'] = 1;
       $query->_tables['case_activity_medium'] = 1;
@@ -182,16 +182,16 @@ class CRM_Case_BAO_Query extends CRM_Core_BAO_Query {
       $query->_tables['civicrm_case'] = 1;
     }
 
-    if (!empty($query->_returnProperties['case_scheduled_activity_date'])) {
-      $query->_select['case_scheduled_activity_date'] = "case_activity.activity_date_time as case_scheduled_activity_date";
-      $query->_element['case_scheduled_activity_date'] = 1;
+    if (!empty($query->_returnProperties['case_activity_date_time'])) {
+      $query->_select['case_activity_date_time'] = "case_activity.activity_date_time as case_activity_date_time";
+      $query->_element['case_activity_date_time'] = 1;
       $query->_tables['case_activity'] = 1;
       $query->_tables['civicrm_case_contact'] = 1;
       $query->_tables['civicrm_case'] = 1;
     }
-    if (!empty($query->_returnProperties['case_recent_activity_type'])) {
-      $query->_select['case_recent_activity_type'] = "rec_activity_type.label as case_recent_activity_type";
-      $query->_element['case_recent_activity_type'] = 1;
+    if (!empty($query->_returnProperties['case_activity_type'])) {
+      $query->_select['case_activity_type'] = "rec_activity_type.label as case_activity_type";
+      $query->_element['case_activity_type'] = 1;
       $query->_tables['case_activity'] = 1;
       $query->_tables['case_activity_type'] = 1;
       $query->_tables['civicrm_case_contact'] = 1;
@@ -331,31 +331,19 @@ class CRM_Case_BAO_Query extends CRM_Core_BAO_Query {
         $query->_tables['civicrm_case_contact'] = $query->_whereTables['civicrm_case_contact'] = 1;
         return;
 
-      case 'case_recent_activity_date':
+      case 'case_activity_date_time':
         $date = CRM_Utils_Date::format($value);
         $query->_where[$grouping][] = CRM_Contact_BAO_Query::buildClause("case_activity.activity_date_time", $op, $date, 'Date');
         if ($date) {
           $date = CRM_Utils_Date::customFormat($date);
-          $query->_qill[$grouping][] = ts("Activity Actual Date %1 %2", [1 => $op, 2 => $date]);
+          $query->_qill[$grouping][] = ts("Activity Date %1 %2", [1 => $op, 2 => $date]);
         }
         $query->_tables['case_activity'] = $query->_whereTables['case_activity'] = 1;
         $query->_tables['civicrm_case'] = $query->_whereTables['civicrm_case'] = 1;
         $query->_tables['civicrm_case_contact'] = $query->_whereTables['civicrm_case_contact'] = 1;
         return;
 
-      case 'case_scheduled_activity_date':
-        $date = CRM_Utils_Date::format($value);
-        $query->_where[$grouping][] = CRM_Contact_BAO_Query::buildClause("case_activity.activity_date_time", $op, $date, 'Date');
-        if ($date) {
-          $date = CRM_Utils_Date::customFormat($date);
-          $query->_qill[$grouping][] = ts("Activity Schedule Date %1 %2", [1 => $op, 2 => $date]);
-        }
-        $query->_tables['case_activity'] = $query->_whereTables['case_activity'] = 1;
-        $query->_tables['civicrm_case'] = $query->_whereTables['civicrm_case'] = 1;
-        $query->_tables['civicrm_case_contact'] = $query->_whereTables['civicrm_case_contact'] = 1;
-        return;
-
-      case 'case_recent_activity_type':
+      case 'case_activity_type':
         $names = $value;
         if (($activityType = CRM_Core_PseudoConstant::getLabel('CRM_Activity_BAO_Activity', 'activity_type_id', $value)) != FALSE) {
           $names = $activityType;
@@ -539,7 +527,7 @@ class CRM_Case_BAO_Query extends CRM_Core_BAO_Query {
         $from .= " $side JOIN civicrm_option_value rec_activity_type ON (case_activity.activity_type_id = rec_activity_type.value AND option_group_activity_type.id = rec_activity_type.option_group_id ) ";
         break;
 
-      case 'recent_activity_status':
+      case 'case_activity_status':
         $from .= " $side JOIN civicrm_option_group option_group_activity_status ON (option_group_activity_status.name = 'activity_status')";
         $from .= " $side JOIN civicrm_option_value rec_activity_status ON (case_activity.status_id = rec_activity_status.value AND option_group_activity_status.id = rec_activity_status.option_group_id ) ";
         break;
@@ -557,7 +545,7 @@ case_relation_type.id = case_relationship.relationship_type_id )";
 
       case 'case_activity_medium':
         $from .= " $side JOIN civicrm_option_group option_group_activity_medium ON (option_group_activity_medium.name = 'encounter_medium')";
-        $from .= " $side JOIN civicrm_option_value recent_activity_medium ON (case_activity.medium_id = recent_activity_medium.value AND option_group_activity_medium.id = recent_activity_medium.option_group_id ) ";
+        $from .= " $side JOIN civicrm_option_value case_activity_medium ON (case_activity.medium_id = case_activity_medium.value AND option_group_activity_medium.id = case_activity_medium.option_group_id ) ";
         break;
 
       case 'case_activity':
@@ -609,11 +597,9 @@ case_relation_type.id = case_relationship.relationship_type_id )";
         'case_type' => 1,
         'case_role' => 1,
         'case_deleted' => 1,
-        'case_recent_activity_date' => 1,
-        'case_recent_activity_type' => 1,
-        'case_scheduled_activity_date' => 1,
+        'case_activity_date_time' => 1,
+        'case_activity_type' => 1,
         'phone' => 1,
-        // 'case_scheduled_activity_type'=>      1
       ];
 
       if ($includeCustomFields) {

--- a/tests/phpunit/CRM/Case/BAO/QueryTest.php
+++ b/tests/phpunit/CRM/Case/BAO/QueryTest.php
@@ -4,17 +4,7 @@
  *  Include dataProvider for tests
  * @group headless
  */
-class CRM_Case_BAO_QueryTest extends CiviUnitTestCase {
-
-  /**
-   * Set up function.
-   *
-   * Ensure CiviCase is enabled.
-   */
-  public function setUp() {
-    parent::setUp();
-    CRM_Core_BAO_ConfigSetting::enableComponent('CiviCase');
-  }
+class CRM_Case_BAO_QueryTest extends CiviCaseTestCase {
 
   /**
    * Check that Qill is calculated correctly.
@@ -25,14 +15,14 @@ class CRM_Case_BAO_QueryTest extends CiviUnitTestCase {
    * I could not find anyway to actually do this search with the relevant fields
    * as parameters & don't know if they exist as legitimate code or code cruft so
    * this test was the only way I could verify the change.
-   *  - case_recent_activity_type
+   *  - case_activity_type
    *  - case_activity_status_id
    *  - case_activity_medium_id
    */
   public function testWhereClauseSingle() {
     $params = [
       0 => [
-        0 => 'case_recent_activity_type',
+        0 => 'case_activity_type',
         1 => '=',
         2 => 6,
         3 => 1,
@@ -62,6 +52,67 @@ class CRM_Case_BAO_QueryTest extends CiviUnitTestCase {
         2 => 'Activity Medium = In Person',
       ],
       $queryObj->_qill[1]
+    );
+  }
+
+  /**
+   * Test the qill for a find cases search.
+   */
+  public function testFindCasesQuery() {
+    $params = [
+      [
+        0 => 'case_type_id',
+        1 => 'IN',
+        2 => [1],
+        3 => 0,
+        4 => 0,
+      ],
+      [
+        0 => 'case_status_id',
+        1 => 'IN',
+        2 => [1],
+        3 => 0,
+        4 => 0,
+      ],
+      [
+        0 => 'case_deleted',
+        1 => '=',
+        2 => 0,
+        3 => 0,
+        4 => 0,
+      ],
+      [
+        0 => 'case_owner',
+        1 => '=',
+        2 => 1,
+        3 => 0,
+        4 => 0,
+      ],
+    ];
+
+    $query = new CRM_Contact_BAO_Query($params, NULL, NULL, FALSE, FALSE, CRM_Contact_BAO_Query::MODE_CASE);
+
+    $this->assertEquals(
+      [
+        0 => [
+          0 => 'Case Type(s) In Housing Support',
+          1 => 'Case Status(s) In Ongoing',
+          2 => 'Case = All Cases',
+        ],
+      ],
+      $query->_qill
+    );
+
+    $this->assertEquals(
+      [
+        0 => [
+          0 => 'civicrm_case.case_type_id IN ("1")',
+          1 => 'civicrm_case.status_id IN ("1")',
+          2 => 'civicrm_case.is_deleted = 0',
+          3 => 'civicrm_case_contact.contact_id = contact_a.id',
+        ],
+      ],
+      $query->_where
     );
   }
 

--- a/tests/phpunit/CRM/Export/BAO/ExportTest.php
+++ b/tests/phpunit/CRM/Export/BAO/ExportTest.php
@@ -1725,9 +1725,8 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
       'case_type' => 1,
       'case_role' => 1,
       'case_deleted' => 1,
-      'case_recent_activity_date' => 1,
-      'case_recent_activity_type' => 1,
-      'case_scheduled_activity_date' => 1,
+      'case_activity_date_time' => 1,
+      'case_activity_type' => 1,
     ];
   }
 
@@ -2294,9 +2293,8 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
       87 => 'Case Type',
       88 => 'Role in Case',
       89 => 'Case is in the Trash',
-      90 => 'Activity Actual Date',
+      90 => 'Activity Date',
       91 => 'Activity Type',
-      92 => 'Activity Scheduled Date',
       93 => 'Case Start Date',
       94 => 'Case End Date',
       95 => 'Activity Reporter',
@@ -2566,9 +2564,8 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
       'case_type' => '`case_type` text',
       'case_role' => '`case_role` text',
       'case_deleted' => '`case_deleted` varchar(16)',
-      'case_recent_activity_date' => '`case_recent_activity_date` varchar(32)',
-      'case_recent_activity_type' => '`case_recent_activity_type` varchar(255)',
-      'case_scheduled_activity_date' => '`case_scheduled_activity_date` varchar(32)',
+      'case_activity_date_time' => '`case_activity_date_time` varchar(32)',
+      'case_activity_type' => '`case_activity_type` varchar(255)',
     ];
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/1916

This is a follow on from https://github.com/civicrm/civicrm-core/pull/17970#discussion_r462429687. If you go to Find Cases and then choose to export and pick selected fields (ignore the e_notices), there's some fields in the list that don't make sense:

* Activity Actual Date - refers to a backend field called case_recent_activity_date, but which is really activity_date_time
* Activity Scheduled Date - refers to a backend field called case_scheduled_activity_date, but which is also really activity_date_time

Whenever this was set up I think there was some confusion about recent/scheduled which is what you see on the case dashboard, not actual fields on an activity. And then it's extra confusing that what both of them return in the export is the same value activity_date_time.

I choose to remove them and just have normal activity_date_time, given that they've never been anything else anyway. If the recent/scheduled were to be added they'd need to be (a) at the "case" level not activity level, (b) be added _in addition_ to the regular activity_date_time, and (c) represent what you see on the dashboard, i.e. the most recent activity on the case and the next scheduled activity on the case.

Before
----------------------------------------
Fields in dropdown that are called confusing things and both return the same thing.

After
----------------------------------------
More normal.

Technical Details
----------------------------------------
Also the backend reference to activity type had "recent" in it which also isn't what it is, it's just activity type.

Comments
----------------------------------------
The added test is only partly related but I didn't see anything for it. The updated export test already checks the labels.
