### PR TITLE
[Test fix] We might need this to ensure really quick test runs don't fail

### DIFF
--- a/tests/phpunit/CRM/Core/Payment/AuthorizeNetIPNTest.php
+++ b/tests/phpunit/CRM/Core/Payment/AuthorizeNetIPNTest.php
@@ -113,7 +113,8 @@ class CRM_Core_Payment_AuthorizeNetIPNTest extends CiviUnitTestCase {
     $contributionRecur  = $this->callAPISuccessGetSingle('ContributionRecur', ['id' => $this->_contributionRecurID]);
     $processor_id = $contributionRecur['processor_id'];
     $this->assertEquals('Pending', CRM_Core_PseudoConstant::getName('CRM_Contribute_BAO_Contribution', 'contribution_status_id', $contributionRecur['contribution_status_id']));
-    // Process the initial one.
+    // Process the initial one after a second's break to ensure modified date really is later.
+    sleep(1);
     $IPN = new CRM_Core_Payment_AuthorizeNetIPN(
       $this->getRecurTransaction(['x_subscription_id' => $processor_id])
     );


### PR DESCRIPTION
Overview
----------------------------------------
This is a new test & I just saw it fail because modified_date did not increase - I think a quick snooze will make it more robust

Before
----------------------------------------
likely new intermittent bug

After
----------------------------------------
Should be more reliable

Technical Details
----------------------------------------

Comments
----------------------------------------
I should note that a quick snooze generally makes me more robust

