### PR TITLE
[REF] Remove transaction from completeOrder signature

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4405,8 +4405,6 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
    * @param array $input
    * @param array $ids
    * @param array $objects
-   * @param CRM_Core_Transaction $transaction
-   *   It is not recommended to pass this in. The calling function handle it's own roll back if it wants it.
    * @param bool $isPostPaymentCreate
    *   Is this being called from the payment.create api. If so the api has taken care of financial entities.
    *   Note that our goal is that this would only ever be called from payment.create and never handle financials (only
@@ -4416,10 +4414,8 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
    * @throws \CRM_Core_Exception
    * @throws \CiviCRM_API3_Exception
    */
-  public static function completeOrder($input, &$ids, $objects, $transaction = NULL, $isPostPaymentCreate = FALSE) {
-    if (!$transaction) {
-      $transaction = new CRM_Core_Transaction();
-    }
+  public static function completeOrder($input, &$ids, $objects, $isPostPaymentCreate = FALSE) {
+    $transaction = new CRM_Core_Transaction();
     $contribution = $objects['contribution'];
     $primaryContributionID = $contribution->id ?? $objects['first_contribution']->id;
     // The previous details are used when calculating line items so keep it before any code that 'does something'

--- a/api/v3/Contribution.php
+++ b/api/v3/Contribution.php
@@ -682,7 +682,7 @@ function _ipn_process_transaction(&$params, $contribution, $input, $ids, $firstC
   }
   $input['card_type_id'] = $params['card_type_id'] ?? NULL;
   $input['pan_truncation'] = $params['pan_truncation'] ?? NULL;
-  return CRM_Contribute_BAO_Contribution::completeOrder($input, $ids, $objects, NULL,
+  return CRM_Contribute_BAO_Contribution::completeOrder($input, $ids, $objects,
     $params['is_post_payment_create'] ?? NULL);
 }
 


### PR DESCRIPTION

Overview
----------------------------------------
[REF] Remove transaction from completeOrder signature

Before
----------------------------------------
```
public static function completeOrder($input, &$ids, $objects, $transaction = NULL, $isPostPaymentCreate = FALSE) {
```

After
----------------------------------------
```
public static function completeOrder($input, &$ids, $objects, $isPostPaymentCreate = FALSE) {
```

Technical Details
----------------------------------------
It is no longer passed in

<img width="1277" alt="Screen Shot 2020-08-03 at 1 09 08 PM" src="https://user-images.githubusercontent.com/336308/89137096-e3118200-d58a-11ea-96df-30386ad0ec54.png">


Comments
----------------------------------------
We cleaned up the places that passed it prior
