### PR TITLE
dev/core#1665 Remove the having clause as well as having needs a group by

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -4989,8 +4989,7 @@ civicrm_relationship.start_date > {$today}
     $sqlParts = $this->getSearchSQLParts(NULL, NULL, NULL, FALSE, FALSE, TRUE);
     $query = "SELECT DISTINCT LEFT(contact_a.sort_name, 1) as sort_name
       {$sqlParts['from']}
-      {$sqlParts['where']}
-      {$sqlParts['having']}";
+      {$sqlParts['where']}";
     $dao = CRM_Core_DAO::executeQuery($query);
     return $dao;
   }


### PR DESCRIPTION
Overview
----------------------------------------
This removes a now redundant and problematic having clause as part of this query

Before
----------------------------------------
Having part of the query

After
----------------------------------------
Having not part

this is a follow on from https://github.com/civicrm/civicrm-core/pull/16877