### PR TITLE
[REF] remove first attempt to set currency in repeattransaction flow

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2620,8 +2620,11 @@ LEFT JOIN  civicrm_contribution contribution ON ( componentPayment.contribution_
       else {
         $contributionParams['financial_type_id'] = $templateContribution['financial_type_id'];
       }
-      $contributionParams['contact_id'] = $templateContribution['contact_id'];
-      $contributionParams['source'] = empty($templateContribution['source']) ? ts('Recurring contribution') : $templateContribution['source'];
+      foreach (['contact_id', 'currency', 'source'] as $fieldName) {
+        $contributionParams[$fieldName] = $templateContribution[$fieldName];
+      }
+
+      $contributionParams['source'] = $contributionParams['source'] ?: ts('Recurring contribution');
 
       //CRM-18805 -- Contribution page not recorded on recurring transactions, Recurring contribution payments
       //do not create CC or BCC emails or profile notifications.
@@ -4461,11 +4464,6 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
       'source' => self::getRecurringContributionDescription($contribution, $event),
     ], array_intersect_key($input, array_fill_keys($inputContributionWhiteList, 1)
     ));
-
-    // CRM-20678 Ensure that the currency is correct in subseqent transcations.
-    if (empty($contributionParams['currency']) && isset($objects['first_contribution']->currency)) {
-      $contributionParams['currency'] = $objects['first_contribution']->currency;
-    }
 
     $contributionParams['payment_processor'] = $input['payment_processor'] = $paymentProcessorId;
 

--- a/tests/phpunit/CRM/Contribute/BAO/ContributionRecurTest.php
+++ b/tests/phpunit/CRM/Contribute/BAO/ContributionRecurTest.php
@@ -227,7 +227,7 @@ class CRM_Contribute_BAO_ContributionRecurTest extends CiviUnitTestCase {
       'financial_type_id' => 1,
       'source' => 'Template Contribution',
       'payment_instrument_id' => 1,
-      'currency' => 'USD',
+      'currency' => 'AUD',
       'contact_id' => $this->individualCreate(),
       'contribution_status_id' => 1,
       'receive_date' => 'yesterday',
@@ -254,6 +254,7 @@ class CRM_Contribute_BAO_ContributionRecurTest extends CiviUnitTestCase {
       'contribution_recur_id' => $contributionRecur['id'],
     ]);
     $this->assertEquals('Template Contribution', $repeatContribution['values'][$repeatContribution['id']]['source']);
+    $this->assertEquals('AUD', $repeatContribution['values'][$repeatContribution['id']]['currency']);
   }
 
   /**


### PR DESCRIPTION

Overview
----------------------------------------
Removes code that no longer does anything

Before
----------------------------------------
contributionParams['currency'] set from a convoluted variable, but then overwritten in repeattransaction. For completetransaction is is not required as the contribution already has a saved currency

After
----------------------------------------
Test added, lines removed

Technical Details
----------------------------------------
The currency is retrieved from the template transaction, these lines are no longer needed, as demonstrated
in the test

Comments
----------------------------------------

Test cover in edited test  & also in  testRepeatTransactionWithDifferenceCurrency