### PR TITLE
Improve error handling on IPN

### DIFF
--- a/CRM/Core/Payment.php
+++ b/CRM/Core/Payment.php
@@ -1504,7 +1504,8 @@ abstract class CRM_Core_Payment {
     catch (CRM_Core_Exception $e) {
       Civi::log()->error('ipn_payment_callback_exception', [
         'context' => [
-          'backtrace' => CRM_Core_Error::formatBacktrace(debug_backtrace()),
+          'backtrace' => $e->getTraceAsString(),
+          'message' => $e->getMessage(),
         ],
       ]);
     }


### PR DESCRIPTION


Overview
----------------------------------------
Improve error output on IPN fails

Before
----------------------------------------
Actual error message not in out put
Trace is not the exception trace

After
----------------------------------------
Access message & trace from the exception

Technical Details
----------------------------------------
https://civicrm.stackexchange.com/questions/37277/paypal-standard-payments-are-being-accepted-but-marked-as-incomplete-transaction/37279#37279

shows how unhelpful this error is - getting data from the exception should help.

Targetting 5.28 in case the gitlab relates to a regression & we need to solicit more debug info

Comments
----------------------------------------

