### PR TITLE
dev/core#1905 rework #17942 with simpler ts strings

### DIFF
--- a/templates/CRM/Contribute/Form/Contribution/Main.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Main.tpl
@@ -57,8 +57,8 @@
   {/if}
 
   {if call_user_func(array('CRM_Core_Permission','check'), 'administer CiviCRM') }
-    {capture assign="configureURL"}{crmURL p="civicrm/admin/contribute/settings" q="reset=1&action=update&id=`$contributionPageID`"}{/capture}
-    {ts 1=$configureURL}<a class="button " target="_blank" href=%1><i aria-hidden="true" title="Configure Contribution Page" class="crm-i fa-wrench"></i> Configure</a>{/ts}
+    {capture assign="buttonTitle"}{ts}Configure Contribution Page{/ts}{/capture}
+    {crmButton target="_blank" p="civicrm/admin/contribute/settings" q="reset=1&action=update&id=`$contributionPageID`" title="$buttonTitle" icon="fa-wrench"}{ts}Configure{/ts}{/crmButton}
     <div class='clear'></div>
   {/if}
   {include file="CRM/common/TrackingFields.tpl"}

--- a/templates/CRM/Event/Form/Registration/Register.tpl
+++ b/templates/CRM/Event/Form/Registration/Register.tpl
@@ -8,8 +8,8 @@
  +--------------------------------------------------------------------+
 *}
 {if call_user_func(array('CRM_Core_Permission','check'), 'administer CiviCRM') }
-  {capture assign="configureURL"}{crmURL p="civicrm/event/manage/settings" q="reset=1&action=update&id=`$event.id`"}{/capture}
-  {ts 1=$configureURL}<a class="button " target="_blank" href=%1><i aria-hidden="true" title="Configure Event" class="crm-i fa-wrench"></i> Configure</a>{/ts}
+  {capture assign="buttonTitle"}{ts}Configure Event{/ts}{/capture}
+  {crmButton target="_blank" p="civicrm/event/manage/settings" q="reset=1&action=update&id=`$event.id`" title="$buttonTitle" icon="fa-wrench"}{ts}Configure{/ts}{/crmButton}
   <div class='clear'></div>
 {/if}
 {* Callback snippet: Load payment processor *}

--- a/templates/CRM/Price/Form/PriceSet.tpl
+++ b/templates/CRM/Price/Form/PriceSet.tpl
@@ -17,11 +17,10 @@
     {if call_user_func(array('CRM_Core_Permission','check'), 'administer CiviCRM') }
       {assign var='adminFld' value=true}
       {if $priceSet.id && !$priceSet.is_quick_config}
-        {capture assign="priceSetURL"}{crmURL p="civicrm/admin/price/field" q="reset=1&action=browse&sid=`$priceSet.id`"}{/capture}
         <div class='float-right'>
-          {ts 1=$priceSetURL}<a class="crm-hover-button" target="_blank" href=%1>
-            <i aria-hidden="true" title="Edit Priceset" class="crm-i fa-wrench"></i>
-          </a>{/ts}
+          <a class="crm-hover-button" target="_blank" href="{crmURL p="civicrm/admin/price/field" q="reset=1&action=browse&sid=`$priceSet.id`"}">
+            {icon icon="fa-wrench"}{ts}Edit Price Set{/ts}{/icon}
+          </a>
         </div>
       {/if}
     {/if}


### PR DESCRIPTION
Overview
----------------------------------------
This reworks the template markup for the buttons added in #17942 to get all the markup out of the string to translate with `{ts}`.

I also set the `title` for the whole buttons, not just the icons.

Before
----------------------------------------
Translator has to translate something like

```html
<a class="button " target="_blank" href=%1><i aria-hidden="true" title="Configure Contribution Page" class="crm-i fa-wrench"></i> Configure</a>
```

You have to hover over the wrench to see "Configure Contribution Page".

After
----------------------------------------
Translator has to translate "Configure Contribution Page" and "Configure".

You see "Configure Contribution Page" when hovering anywhere over the button.

Technical Details
----------------------------------------
I used the `{crmButton}` and `{icon}` Smarty helpers to cut down on a lot of boilerplate.