### PR TITLE
Show cron warning on Scheduled Jobs admin page

### DIFF
--- a/CRM/Admin/Page/Job.php
+++ b/CRM/Admin/Page/Job.php
@@ -142,6 +142,17 @@ class CRM_Admin_Page_Job extends CRM_Core_Page_Basic {
     if (CRM_Core_Config::environment() != 'Production') {
       CRM_Core_Session::setStatus(ts('Execution of scheduled jobs has been turned off by default since this is a non-production environment. You can override this for particular jobs by adding runInNonProductionEnvironment=TRUE as a parameter.'), ts("Non-production Environment"), "warning", array('expires' => 0));
     }
+    else {
+      $cronError = Civi\Api4\System::check(FALSE)
+        ->addWhere('name', '=', 'checkLastCron')
+        ->addWhere('severity_id', '>', 1)
+        ->setIncludeDisabled(TRUE)
+        ->execute()
+        ->first();
+      if ($cronError) {
+        CRM_Core_Session::setStatus($cronError['message'], $cronError['title'], 'alert', ['expires' => 0]);
+      }
+    }
 
     $sj = new CRM_Core_JobManager();
     $rows = $temp = [];

--- a/CRM/Utils/Check/Component/Env.php
+++ b/CRM/Utils/Check/Component/Env.php
@@ -325,7 +325,7 @@ class CRM_Utils_Check_Component_Env extends CRM_Utils_Check_Component {
         // After 1 day (86400 seconds) increase the error level
         $level = ($lastCron > $now - 86400) ? \Psr\Log\LogLevel::WARNING : \Psr\Log\LogLevel::ERROR;
       }
-      $msg .= '<p>' . ts('To enable scheduling support, please set up the cron job.') .
+      $msg .= '<p>' . ts('A cron job is required to execute scheduled jobs automatically.') .
        '<br />' . CRM_Utils_System::docURL2('sysadmin/setup/jobs/') . '</p>';
     }
 

--- a/CRM/Utils/REST.php
+++ b/CRM/Utils/REST.php
@@ -212,7 +212,7 @@ class CRM_Utils_REST {
     // interface can be disabled in more change to the configuration file.
     // first check for civicrm site key
     if (!CRM_Utils_System::authenticateKey(FALSE)) {
-      $docLink = CRM_Utils_System::docURL2("Managing Scheduled Jobs", TRUE, NULL, NULL, NULL, "wiki");
+      $docLink = CRM_Utils_System::docURL2('sysadmin/setup/jobs', TRUE);
       $key = $requestParams['key'] ?? NULL;
       if (empty($key)) {
         return self::error("FATAL: mandatory param 'key' missing. More info at: " . $docLink);

--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -600,7 +600,7 @@ class CRM_Utils_System {
     // also make sure the key is sent and is valid
     $key = trim(CRM_Utils_Array::value('key', $_REQUEST));
 
-    $docAdd = "More info at:" . CRM_Utils_System::docURL2("Managing Scheduled Jobs", TRUE, NULL, NULL, NULL, "wiki");
+    $docAdd = "More info at: " . CRM_Utils_System::docURL2('sysadmin/setup/jobs', TRUE);
 
     if (!$key) {
       return self::authenticateAbort(

--- a/Civi/Api4/Generic/Traits/ArrayQueryActionTrait.php
+++ b/Civi/Api4/Generic/Traits/ArrayQueryActionTrait.php
@@ -60,7 +60,7 @@ trait ArrayQueryActionTrait {
    * @return bool
    */
   private function evaluateFilters($row) {
-    $where = $this->getWhere();
+    $where = array_values($this->getWhere());
     $allConditions = in_array($where[0], ['AND', 'OR', 'NOT']) ? $where : ['AND', $where];
     return $this->walkFilters($row, $allConditions);
   }


### PR DESCRIPTION
Overview
----------------------------------------
This is a reviewer's cut of #17819 which adds a pop-up on the Scheduled Jobs page if cron does not appear to be running.

Before
----------------------------------------
Cron warning is only displayed in the System Status page along with all the other system status messages.

After
----------------------------------------
![image](https://user-images.githubusercontent.com/2874912/89340842-5dff9900-d66e-11ea-9b3c-9705a5b75e28.png)

Technical Details
----------------------------------------
This changes the wording of the messages based on the improvements made by @agh1 in #17819 
Also updates a couple doc links.