### PR TITLE
dev/drupal#131 Ensure that the General class exists

### DIFF
--- a/Civi/Install/Requirements.php
+++ b/Civi/Install/Requirements.php
@@ -294,6 +294,9 @@ class Requirements {
    * @return array
    */
   public function checkMysqlVersion(array $db_config) {
+    if (!class_exists('\CRM_Upgrade_Incremental_General')) {
+      require_once dirname(__FILE__) . '/../../CRM/Upgrade/Incremental/General.php';
+    }
     $min = \CRM_Upgrade_Incremental_General::MIN_INSTALL_MYSQL_VER;
     $results = [
       'title' => 'CiviCRM MySQL Version',


### PR DESCRIPTION
Overview
----------------------------------------
In some circumstances the General class hasn't been loaded (in the user's case running update.php) this mitigates by putting in a require once if the class doesn't exist

Before
----------------------------------------
Class may or may not exist

After
----------------------------------------
Class consistently exists

ping @eileenmcnaughton @demeritcowboy 