### PR TITLE
event#34: allow negative self-service/transfer time

### DIFF
--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -1158,6 +1158,8 @@ WHERE civicrm_event.is_active = 1
           'conference_sessions' => $sessions,
           'credit_card_number' => CRM_Utils_System::mungeCreditCard(CRM_Utils_Array::value('credit_card_number', $participantParams)),
           'credit_card_exp_date' => CRM_Utils_Date::mysqlToIso(CRM_Utils_Date::format(CRM_Utils_Array::value('credit_card_exp_date', $participantParams))),
+          'selfcancelxfer_time' => abs($values['event']['selfcancelxfer_time']),
+          'selfservice_preposition' => $values['event']['selfcancelxfer_time'] < 0 ? 'after' : 'before',
         ]);
 
         // CRM-13890 : NOTE wait list condition need to be given so that

--- a/CRM/Event/BAO/Participant.php
+++ b/CRM/Event/BAO/Participant.php
@@ -1877,7 +1877,6 @@ WHERE    civicrm_participant.contact_id = {$contactID} AND
    * Evaluate whether a participant record is eligible for self-service transfer/cancellation.  If so,
    * return additional participant/event details.
    *
-   * TODO: This function fails when the "hours until self-service" is less than zero.
    * @param int $participantId
    * @param string $url
    * @param bool $isBackOffice
@@ -1930,7 +1929,12 @@ WHERE    civicrm_participant.contact_id = {$contactID} AND
       $cancelDeadline = (new Datetime($start_date))->sub($cancelInterval);
       if ($timenow > $cancelDeadline) {
         $details['eligible'] = FALSE;
-        $details['ineligible_message'] = ts("Registration for this event cannot be cancelled or transferred less than %1 hours prior to the event's start time. Contact the event organizer if you have questions.", [1 => $time_limit]);
+        // Change the language of the status message based on whether the waitlist time limit is positive or negative.
+        $afterOrPrior = $time_limit < 0 ? 'after' : 'prior';
+        $moreOrLess = $time_limit < 0 ? 'more' : 'less';
+        $details['ineligible_message'] = ts("Registration for this event cannot be cancelled or transferred %1 than %2 hours %3 to the event's start time. Contact the event organizer if you have questions.",
+        [1 => $moreOrLess, 2 => $cancelHours, 3 => $afterOrPrior]);
+
       }
     }
     return $details;

--- a/CRM/Upgrade/Incremental/MessageTemplates.php
+++ b/CRM/Upgrade/Incremental/MessageTemplates.php
@@ -215,6 +215,16 @@ class CRM_Upgrade_Incremental_MessageTemplates {
           ['name' => 'contribution_invoice_receipt', 'type' => 'html'],
         ],
       ],
+      [
+        'version' => '5.30.alpha1',
+        'upgrade_descriptor' => ts('Support negative hours for cancellation/transfer'),
+        'templates' => [
+          ['name' => 'participant_confirm', 'type' => 'html'],
+          ['name' => 'participant_confirm', 'type' => 'text'],
+          ['name' => 'event_online_receipt', 'type' => 'html'],
+          ['name' => 'event_online_receipt', 'type' => 'text'],
+        ],
+      ],
 
     ];
   }

--- a/CRM/Upgrade/Incremental/sql/5.30.alpha1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.30.alpha1.mysql.tpl
@@ -1,1 +1,4 @@
 {* file to handle db changes in 5.30.alpha1 during upgrade *}
+-- Allow self-service/transfer to have a negative time.
+ALTER TABLE civicrm_event MODIFY COLUMN selfcancelxfer_time INT;
+

--- a/templates/CRM/Event/Form/ManageEvent/Registration.hlp
+++ b/templates/CRM/Event/Form/ManageEvent/Registration.hlp
@@ -89,5 +89,5 @@
   {ts}Cancellation or Transfer Time Limit{/ts}
 {/htxt}
 {htxt id="id-selfcancelxfer_time"}
-  {ts}Number of hours prior to event start date to allow self-service cancellation or transfer. Enter 0 (or leave empty) to allow cancellation or transfer up until the event has started.{/ts}
+  {ts}Number of hours prior to event start date to allow self-service cancellation or transfer. Enter a negative number of hours to allow cancellation after the event starts. Enter 0 (or leave empty) to allow cancellation or transfer up until the event has started.{/ts}
 {/htxt}

--- a/tests/phpunit/CRM/Event/BAO/ParticipantTest.php
+++ b/tests/phpunit/CRM/Event/BAO/ParticipantTest.php
@@ -493,6 +493,15 @@ class CRM_Event_BAO_ParticipantTest extends CiviUnitTestCase {
       'isBackOffice' => FALSE,
       'successExpected' => FALSE,
     ];
+    // Cancellation deadline is < 0 hours
+    $scenarios[] = [
+      'selfSvcEnabled' => 1,
+      'selfSvcHours' => -12,
+      'hoursToEvent' => 4,
+      'participantStatusId' => 1,
+      'isBackOffice' => FALSE,
+      'successExpected' => TRUE,
+    ];
     return $scenarios;
   }
 

--- a/xml/schema/Event/Event.xml
+++ b/xml/schema/Event/Event.xml
@@ -659,7 +659,7 @@
   </field>
   <field>
     <name>selfcancelxfer_time</name>
-    <type>int unsigned</type>
+    <type>int</type>
     <default>0</default>
     <title>Self-service Cancellation or Transfer Time</title>
     <comment>Number of hours prior to event start date to allow self-service cancellation or transfer.</comment>

--- a/xml/templates/message_templates/event_online_receipt_html.tpl
+++ b/xml/templates/message_templates/event_online_receipt_html.tpl
@@ -497,7 +497,7 @@
     {if $event.allow_selfcancelxfer }
      <tr>
       <td colspan="2" {$valueStyle}>
-        {ts 1=$event.selfcancelxfer_time}You may transfer your registration to another participant or cancel your registration up to %1 hours before the event.{/ts} {if $totalAmount}{ts}Cancellations are not refundable.{/ts}{/if}<br />
+        {ts 1=$selfcancelxfer_time 2=$selfservice_preposition}You may transfer your registration to another participant or cancel your registration up to %1 hours %2 the event.{/ts} {if $totalAmount}{ts}Cancellations are not refundable.{/ts}{/if}<br />
         {capture assign=selfService}{crmURL p='civicrm/event/selfsvcupdate' q="reset=1&pid=`$participant.id`&{contact.checksum}"  h=0 a=1 fe=1}{/capture}
         <a href="{$selfService}">{ts}Click here to transfer or cancel your registration.{/ts}</a>
       </td>

--- a/xml/templates/message_templates/event_online_receipt_text.tpl
+++ b/xml/templates/message_templates/event_online_receipt_text.tpl
@@ -291,7 +291,7 @@ You were registered by: {$payer.name}
 {/if}
 
 {if $event.allow_selfcancelxfer }
-{ts 1=$event.selfcancelxfer_time}You may transfer your registration to another participant or cancel your registration up to %1 hours before the event.{/ts} {if $totalAmount}{ts}Cancellations are not refundable.{/ts}{/if}
+{ts 1=$selfcancelxfer_time 2=$selfservice_preposition}You may transfer your registration to another participant or cancel your registration up to %1 hours %2 the event.{/ts} {if $totalAmount}{ts}Cancellations are not refundable.{/ts}{/if}
    {capture assign=selfService}{crmURL p='civicrm/event/selfsvcupdate' q="reset=1&pid=`$participant.id`&{contact.checksum}"  h=0 a=1 fe=1}{/capture}
 {ts}Transfer or cancel your registration:{/ts} {$selfService}
 {/if}

--- a/xml/templates/message_templates/participant_confirm_html.tpl
+++ b/xml/templates/message_templates/participant_confirm_html.tpl
@@ -165,7 +165,7 @@
   {if $event.allow_selfcancelxfer }
    <tr>
      <td colspan="2" {$valueStyle}>
-       {ts 1=$event.selfcancelxfer_time}You may transfer your registration to another participant or cancel your registration up to %1 hours before the event.{/ts} {if $totalAmount}{ts}Cancellations are not refundable.{/ts}{/if}<br />
+       {ts 1=$selfcancelxfer_time 2=$selfservice_preposition}You may transfer your registration to another participant or cancel your registration up to %1 hours %2 the event.{/ts} {if $totalAmount}{ts}Cancellations are not refundable.{/ts}{/if}<br />
          {capture assign=selfService}{crmURL p='civicrm/event/selfsvcupdate' q="reset=1&pid=`$participant.id`&{contact.checksum}"  h=0 a=1 fe=1}{/capture}
        <a href="{$selfService}">{ts}Click here to transfer or cancel your registration.{/ts}</a>
      </td>

--- a/xml/templates/message_templates/participant_confirm_text.tpl
+++ b/xml/templates/message_templates/participant_confirm_text.tpl
@@ -13,7 +13,7 @@ Click this link to go to a web page where you can confirm your registration onli
 {$confirmUrl}
 {/if}
 {if $event.allow_selfcancelxfer }
-{ts 1=$event.selfcancelxfer_time}You may transfer your registration to another participant or cancel your registration up to %1 hours before the event.{/ts} {if $totalAmount}{ts}Cancellations are not refundable.{/ts}{/if}
+{ts 1=$selfcancelxfer_time 2=$selfservice_preposition}You may transfer your registration to another participant or cancel your registration up to %1 hours %2 the event.{/ts} {if $totalAmount}{ts}Cancellations are not refundable.{/ts}{/if}
    {capture assign=selfService}{crmURL p='civicrm/event/selfsvcupdate' q="reset=1&pid=`$participant.id`&{contact.checksum}"  h=0 a=1 fe=1}{/capture}
 {ts}Transfer or cancel your registration:{/ts} {$selfService}
 {/if}


### PR DESCRIPTION
https://lab.civicrm.org/dev/event/-/issues/34

Overview
----------------------------------------
Events are often multi-day events; e.g. if events represent university courses, and there is a period wherein students may freely cancel their registration in the first week of classes, it's desirable to have the cancel time be negative.

![Selection_999(002)](https://user-images.githubusercontent.com/1796012/89343613-87222880-d672-11ea-98d6-73aafd1872a1.png)

Before
----------------------------------------
Entering a negative value into "Cancellation or transfer time limit (hours)" results in a DB Error.

After
----------------------------------------
Entering a negative value into "Cancellation or transfer time limit (hours)" saves correctly and works as expected.

Technical Notes
----------------------------------------
`civicrm_event.selfservicexfer_time` is now an `int` and not an `unsigned int`.

Comments
----------------------------------------
I regenerated the DAO, but I'm not sure if that's necessary here, because the DAO doesn't differentiate between the unsigned and signed int?
