### PR TITLE
dev/financial#135 Remove unreachable doDirectPayment from manual processor

### DIFF
--- a/CRM/Core/Payment/Manual.php
+++ b/CRM/Core/Payment/Manual.php
@@ -239,25 +239,6 @@ class CRM_Core_Payment_Manual extends CRM_Core_Payment {
   }
 
   /**
-   * Submit a manual payment.
-   *
-   * @param array $params
-   *   Assoc array of input parameters for this transaction.
-   *
-   * @return array
-   */
-  public function doDirectPayment(&$params) {
-    $statuses = CRM_Contribute_BAO_Contribution::buildOptions('contribution_status_id');
-    if ($params['is_pay_later']) {
-      $result['payment_status_id'] = array_search('Pending', $statuses);
-    }
-    else {
-      $result['payment_status_id'] = array_search('Completed', $statuses);
-    }
-    return $result;
-  }
-
-  /**
    * Should a receipt be sent out for a pending payment.
    *
    * e.g for traditional pay later & ones with a delayed settlement a pending receipt makes sense.


### PR DESCRIPTION




Overview
----------------------------------------
dev/financial#135 Remove unreachable doDirectPayment from manual processor

Before
----------------------------------------
Unreachable doDirectPayment function present

After
----------------------------------------
poof

Technical Details
----------------------------------------
doDirectPayment is only ever called (deprecated) when doPayment is not overriden (for quite some time now). This is
unreachable & can be removed

Comments
----------------------------------------

