### PR TITLE
[NFC] Fix provider unit test on PHP7.4

### DIFF
--- a/tests/phpunit/CiviTest/CiviTestSMSProvider.php
+++ b/tests/phpunit/CiviTest/CiviTestSMSProvider.php
@@ -25,7 +25,7 @@ class CiviTestSMSProvider extends CRM_SMS_Provider {
     if (isset($providerParams['provider'])) {
       $providers = CRM_SMS_BAO_Provider::getProviders(NULL, array('name' => $providerParams['provider']));
       $provider = current($providers);
-      $providerID = $provider['id'];
+      $providerID = $provider['id'] ?? NULL;
     }
     else {
       $providerID = $providerParams['provider_id'] ?? NULL;


### PR DESCRIPTION
Overview
----------------------------------------
This fixes a test failure on PHP7.4 "trying to access array offset on value of type bool"

Before
----------------------------------------
Test fails on PHP7.4

After
----------------------------------------
Test passes on PHP7.4

ping @demeritcowboy @eileenmcnaughton @mattwire 