### PR TITLE
dev/core#1930 fix for move-related checkbox being overridden to true …

### DIFF
--- a/CRM/Contact/Form/Merge.php
+++ b/CRM/Contact/Form/Merge.php
@@ -230,8 +230,8 @@ class CRM_Contact_Form_Merge extends CRM_Core_Form {
 
       // add related table elements
       foreach ($rowsElementsAndInfo['rel_table_elements'] as $relTableElement) {
-        $element = $this->addElement($relTableElement[0], $relTableElement[1]);
-        $element->setChecked(TRUE);
+        $this->addElement($relTableElement[0], $relTableElement[1]);
+        $this->_defaults[$relTableElement[1]] = 1;
       }
 
       $this->assign('rel_tables', $rowsElementsAndInfo['rel_tables']);
@@ -412,6 +412,16 @@ class CRM_Contact_Form_Merge extends CRM_Core_Form {
         'other_contact_value' => CRM_Utils_Date::customFormat($contacts[$this->_oid]['modified_date']) . ($mostRecent == $this->_oid ? ' (' . ts('Most Recent') . ')' : ''),
       ],
     ]);
+  }
+
+  /**
+   * Set the defaults for the form.
+   *
+   * @return array
+   *   Array of default values
+   */
+  public function setDefaultValues() {
+    return $this->_defaults;
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a  probable regression where deselecting 'move related contributions' etc does not block them being moved

ie activities are still transferred in this view
<img width="854" alt="Screen Shot 2020-08-06 at 12 57 55 PM" src="https://user-images.githubusercontent.com/336308/89478575-7e516400-d7e4-11ea-9688-af37f07afb46.png">

See: https://lab.civicrm.org/dev/core/-/issues/1930

Before
----------------------------------------
Deselection ignored

After
----------------------------------------
Deselection works

Technical Details
----------------------------------------
I haven't managed to determine when this changed but the method of 
```
$element->setChecked(TRUE);
```
is happening in preProcess and overwriting the submission - moving to setDefaults works

Comments
----------------------------------------

