### PR TITLE
dev/core#1928 Fix HTML5 error due to required attribute being set swi…

### DIFF
--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -1205,10 +1205,12 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
           }
         }
       }
-      $element = $this->createElement('radio', NULL, NULL, $var, $key, $optAttributes);
+      // We use a class here to avoid html5 issues with collapsed cutsomfield sets.
+      $optAttributes['class'] = $optAttributes['class'] ?? '';
       if ($required) {
-        $element->setAttribute('required', TRUE);
+        $optAttributes['class'] .= ' required';
       }
+      $element = $this->createElement('radio', NULL, NULL, $var, $key, $optAttributes);
       $options[] = $element;
     }
     $group = $this->addGroup($options, $name, $title, $separator);


### PR DESCRIPTION
…tch to using a class as jquery.validation picks up the class as well

See: https://lab.civicrm.org/dev/core/-/issues/1928

Overview
----------------------------------------
To reproduce the error create a custom field set that applies to any activity and that is collapsed by default and have a radio varchar field added that is required. Go to create a custom field and find you cannot submit form due to an console error. 

Before
----------------------------------------
Cannot create new cases with a hidden required radio field

After
----------------------------------------
Radio field still properly validated and also still picked up by jquery validation

ping @demeritcowboy @eileenmcnaughton @totten 