### PR TITLE
dev/core#1932 - Make status-checks more polite during upgrade

### DIFF
--- a/CRM/Utils/Check/Component.php
+++ b/CRM/Utils/Check/Component.php
@@ -27,10 +27,16 @@ abstract class CRM_Utils_Check_Component {
    * @throws \Civi\API\Exception\UnauthorizedException
    */
   public function getChecksConfig() {
-    if (empty(Civi::$statics[__FUNCTION__])) {
-      Civi::$statics[__FUNCTION__] = (array) StatusPreference::get(FALSE)
-        ->addWhere('domain_id', '=', 'current_domain')
-        ->execute()->indexBy('name');
+    if (!isset(Civi::$statics[__FUNCTION__])) {
+      // TODO: Remove this check when MINIMUM_UPGRADABLE_VERSION goes to 4.7.
+      if (CRM_Utils_System::version() !== CRM_Core_BAO_Domain::version() && !CRM_Core_DAO::checkTableExists('civicrm_status_pref')) {
+        Civi::$statics[__FUNCTION__] = [];
+      }
+      else {
+        Civi::$statics[__FUNCTION__] = (array) StatusPreference::get(FALSE)
+          ->addWhere('domain_id', '=', 'current_domain')
+          ->execute()->indexBy('name');
+      }
     }
     return Civi::$statics[__FUNCTION__];
   }

--- a/CRM/Utils/Check/Component/Env.php
+++ b/CRM/Utils/Check/Component/Env.php
@@ -281,6 +281,11 @@ class CRM_Utils_Check_Component_Env extends CRM_Utils_Check_Component {
    * @throws CRM_Core_Exception
    */
   public function checkLastCron($force = FALSE) {
+    // TODO: Remove this check when MINIMUM_UPGRADABLE_VERSION goes to 4.7.
+    if (CRM_Utils_System::version() !== CRM_Core_BAO_Domain::version()) {
+      return [];
+    }
+
     $messages = [];
 
     // Cron doesn't work in non-production environments; skip.

--- a/CRM/Utils/Check/Component/OptionGroups.php
+++ b/CRM/Utils/Check/Component/OptionGroups.php
@@ -20,6 +20,10 @@ class CRM_Utils_Check_Component_OptionGroups extends CRM_Utils_Check_Component {
    * @return CRM_Utils_Check_Message[]
    */
   public function checkOptionGroupValues() {
+    if (CRM_Utils_System::version() !== CRM_Core_BAO_Domain::version()) {
+      return [];
+    }
+
     $messages = [];
     $problemValues = [];
     $optionGroups  = civicrm_api3('OptionGroup', 'get', [

--- a/CRM/Utils/Check/Message.php
+++ b/CRM/Utils/Check/Message.php
@@ -246,6 +246,11 @@ class CRM_Utils_Check_Message {
    * @throws \CiviCRM_API3_Exception
    */
   private function checkStatusPreference() {
+    // TODO: Remove this check when MINIMUM_UPGRADABLE_VERSION goes to 4.7.
+    if (CRM_Utils_System::version() !== CRM_Core_BAO_Domain::version() && !CRM_Core_DAO::checkTableExists('civicrm_status_pref')) {
+      return FALSE;
+    }
+
     $this->hiddenUntil = FALSE;
     // Debug & info can't be hidden
     if ($this->level < 2) {


### PR DESCRIPTION
Before
------

If you happen to run a status-check (eg `showPeriodicAlerts()`) in the interim between
downloading code and running DB upgrades, then you'll get weird failures.

After
-----

The status-checks are able to complete.

Technical Details
-----------------

(1) I figure that this conditional is lightweight because it relies on data
that's read-once and then cached in memory:

```
CRM_Utils_System::version() !== CRM_Core_BAO_Domain::version()
```

(2) The easiest way to reproduce is to get a DB from before 4.7 and coerce
`CRM_Utils_Check::CHECK_TIMER`.
