### PR TITLE
Add the hook alterReportVar('sql') in some reports - https://lab.civi…

### DIFF
--- a/CRM/Logging/ReportSummary.php
+++ b/CRM/Logging/ReportSummary.php
@@ -428,6 +428,7 @@ WHERE  log_date <= %1 AND id = %2 ORDER BY log_date DESC LIMIT 1";
     // note the group by columns are same as that used in alterDisplay as $newRows - $key
     $this->limit();
     $this->orderBy();
+    CRM_Utils_Hook::alterReportVar('sql', $this, $this);
     $sql = "{$this->_select}
 FROM {$this->temporaryTableName} entity_log_civireport
 WHERE {$this->logTypeTableClause}

--- a/CRM/Report/Form/Activity.php
+++ b/CRM/Report/Form/Activity.php
@@ -811,7 +811,7 @@ GROUP BY civicrm_activity_id $having {$this->_orderBy}";
     if (!empty($this->_params['include_case_activities_value'])) {
       $caseJoin = "LEFT JOIN civicrm_case_activity {$this->_aliases['civicrm_case_activity']} ON {$this->_aliases['civicrm_activity']}.id = {$this->_aliases['civicrm_case_activity']}.activity_id";
     }
-
+    CRM_Utils_Hook::alterReportVar('sql', $this, $this);
     $sql = "{$this->_select}
       FROM $tempTableName tar
       INNER JOIN civicrm_activity {$this->_aliases['civicrm_activity']} ON {$this->_aliases['civicrm_activity']}.id = tar.civicrm_activity_id
@@ -821,7 +821,6 @@ GROUP BY civicrm_activity_id $having {$this->_orderBy}";
       {$caseJoin}
       {$this->_where} {$groupByFromSelect} {$this->_having} {$this->_orderBy} {$this->_limit}";
 
-    CRM_Utils_Hook::alterReportVar('sql', $this, $this);
     $this->addToDeveloperTab($sql);
 
     return $sql;

--- a/CRM/Report/Form/Contribute/Detail.php
+++ b/CRM/Report/Form/Contribute/Detail.php
@@ -520,6 +520,7 @@ GROUP BY {$this->_aliases['civicrm_contribution']}.currency";
   public function buildQuery($applyLimit = FALSE) {
     if ($this->isTempTableBuilt) {
       $this->limit();
+      CRM_Utils_Hook::alterReportVar('sql', $this, $this);
       return "SELECT SQL_CALC_FOUND_ROWS * FROM {$this->temporaryTables['civireport_contribution_detail_temp3']['name']} $this->_orderBy $this->_limit";
     }
     return parent::buildQuery($applyLimit);

--- a/CRM/Report/Form/Contribute/Lybunt.php
+++ b/CRM/Report/Form/Contribute/Lybunt.php
@@ -580,6 +580,8 @@ class CRM_Report_Form_Contribute_Lybunt extends CRM_Report_Form {
       $this->limit();
     }
 
+    CRM_Utils_Hook::alterReportVar('sql', $this, $this);
+
     $sql = "{$this->_select} {$this->_from} {$this->_where} {$limitFilter} {$this->_groupBy} {$this->_having} {$this->_rollup}";
 
     if (!empty($this->_orderByArray)) {
@@ -592,7 +594,6 @@ class CRM_Report_Form_Contribute_Lybunt extends CRM_Report_Form {
       $sql = "SELECT SQL_CALC_FOUND_ROWS  * FROM ( $sql ) as inner_query {$this->_orderBy} $this->_limit";
     }
 
-    CRM_Utils_Hook::alterReportVar('sql', $this, $this);
     $this->addToDeveloperTab($sql);
 
     return $sql;

--- a/CRM/Report/Form/Event/Income.php
+++ b/CRM/Report/Form/Event/Income.php
@@ -342,6 +342,9 @@ class CRM_Report_Form_Event_Income extends CRM_Report_Form {
    * @return string
    */
   public function buildQuery($applyLimit = FALSE) {
+
+    CRM_Utils_Hook::alterReportVar('sql', $this, $this);
+
     $eventID = implode(',', $this->eventIDs);
 
     $optionGroupDAO = new CRM_Core_DAO_OptionGroup();
@@ -363,6 +366,7 @@ class CRM_Report_Form_Event_Income extends CRM_Report_Form {
     ];
 
     $groupBy = CRM_Contact_BAO_Query::getGroupByFromSelectColumns($select, 'civicrm_event.id');
+
     $sql = "
             SELECT  " . implode(', ', $select) . ",
                     SUM(civicrm_participant.fee_amount) as total,

--- a/CRM/Report/Form/Member/ContributionDetail.php
+++ b/CRM/Report/Form/Member/ContributionDetail.php
@@ -550,6 +550,8 @@ class CRM_Report_Form_Member_ContributionDetail extends CRM_Report_Form {
       $this->limit();
     }
 
+    CRM_Utils_Hook::alterReportVar('sql', $this, $this);
+
     $sql = "{$this->_select} {$this->_from} {$this->_where} {$this->_groupBy} {$this->_having} {$this->_orderBy} {$this->_limit}";
     $this->addToDeveloperTab($sql);
     return $sql;


### PR DESCRIPTION
https://lab.civicrm.org/dev/report/-/issues/44

Overview
----------------------------------------
Add the possibility to use the hook_civicrm_alterReportVar('sql') in more reports

Before
----------------------------------------
We can't use the hook_civicrm_alterReportVar('sql',...) to manipulate the query.

After
----------------------------------------
Can be used in more reports the hook.

Technical Details
----------------------------------------
- In report CRM/Report/Form/Activity.php is moved before generate the sql, to give the possibility to alter the params.
- CRM/Report/Form/Event/Income.php don't give the possibility to manipulate the query.

Comments
----------------------------------------

