### PR TITLE
Swap out button/submit inputs for button elements

### DIFF
--- a/CRM/Admin/Form/Preferences/Display.php
+++ b/CRM/Admin/Form/Preferences/Display.php
@@ -54,7 +54,10 @@ class CRM_Admin_Form_Preferences_Display extends CRM_Admin_Form_Preferences {
       'xbutton',
       'ckeditor_config',
       CRM_Core_Page::crmIcon('fa-wrench') . ' ' . ts('Configure CKEditor'),
-      ['type' => 'submit']
+      [
+        'type' => 'submit',
+        'value' => 1,
+      ]
     );
 
     $editOptions = CRM_Core_OptionGroup::values('contact_edit_options', FALSE, FALSE, FALSE, 'AND v.filter = 0');

--- a/CRM/Admin/Form/Preferences/Display.php
+++ b/CRM/Admin/Form/Preferences/Display.php
@@ -50,7 +50,12 @@ class CRM_Admin_Form_Preferences_Display extends CRM_Admin_Form_Preferences {
     $invoiceSettings = Civi::settings()->get('contribution_invoice_settings');
     $this->assign('invoicing', CRM_Invoicing_Utils::isInvoicingEnabled());
 
-    $this->addElement('xbutton', 'ckeditor_config', ts('Configure CKEditor'), ['type' => 'submit']);
+    $this->addElement(
+      'xbutton',
+      'ckeditor_config',
+      CRM_Core_Page::crmIcon('fa-wrench') . ' ' . ts('Configure CKEditor'),
+      ['type' => 'submit']
+    );
 
     $editOptions = CRM_Core_OptionGroup::values('contact_edit_options', FALSE, FALSE, FALSE, 'AND v.filter = 0');
     $this->assign('editOptions', $editOptions);

--- a/CRM/Admin/Form/Preferences/Display.php
+++ b/CRM/Admin/Form/Preferences/Display.php
@@ -50,7 +50,7 @@ class CRM_Admin_Form_Preferences_Display extends CRM_Admin_Form_Preferences {
     $invoiceSettings = Civi::settings()->get('contribution_invoice_settings');
     $this->assign('invoicing', CRM_Invoicing_Utils::isInvoicingEnabled());
 
-    $this->addElement('submit', 'ckeditor_config', ts('Configure CKEditor'));
+    $this->addElement('xbutton', 'ckeditor_config', ts('Configure CKEditor'), ['type' => 'submit']);
 
     $editOptions = CRM_Core_OptionGroup::values('contact_edit_options', FALSE, FALSE, FALSE, 'AND v.filter = 0');
     $this->assign('editOptions', $editOptions);

--- a/CRM/Admin/Form/Preferences/Display.php
+++ b/CRM/Admin/Form/Preferences/Display.php
@@ -56,6 +56,8 @@ class CRM_Admin_Form_Preferences_Display extends CRM_Admin_Form_Preferences {
       CRM_Core_Page::crmIcon('fa-wrench') . ' ' . ts('Configure CKEditor'),
       [
         'type' => 'submit',
+        'class' => 'crm-button',
+        'style' => 'display:inline-block;vertical-align:middle;float:none!important;',
         'value' => 1,
       ]
     );

--- a/CRM/Admin/Form/Setting/Smtp.php
+++ b/CRM/Admin/Form/Setting/Smtp.php
@@ -61,11 +61,12 @@ class CRM_Admin_Form_Setting_Smtp extends CRM_Admin_Form_Setting {
     $this->addFormRule(['CRM_Admin_Form_Setting_Smtp', 'formRule']);
     parent::buildQuickForm();
     $buttons = $this->getElement('buttons')->getElements();
-    $attrs = [
-      'type' => 'submit',
-      'crm-icon' => 'fa-envelope-o',
-    ];
-    $buttons[] = $this->createElement('xbutton', $this->_testButtonName, ts('Save & Send Test Email'), $attrs);
+    $buttons[] = $this->createElement(
+      'xbutton',
+      $this->_testButtonName,
+      CRM_Core_Page::crmIcon('fa-envelope-o') . ' ' . ts('Save & Send Test Email'),
+      ['type' => 'submit']
+    );
     $this->getElement('buttons')->setElements($buttons);
 
     if (!empty($setStatus)) {

--- a/CRM/Admin/Form/Setting/Smtp.php
+++ b/CRM/Admin/Form/Setting/Smtp.php
@@ -61,7 +61,11 @@ class CRM_Admin_Form_Setting_Smtp extends CRM_Admin_Form_Setting {
     $this->addFormRule(['CRM_Admin_Form_Setting_Smtp', 'formRule']);
     parent::buildQuickForm();
     $buttons = $this->getElement('buttons')->getElements();
-    $buttons[] = $this->createElement('submit', $this->_testButtonName, ts('Save & Send Test Email'), ['crm-icon' => 'fa-envelope-o']);
+    $attrs = [
+      'type' => 'submit',
+      'crm-icon' => 'fa-envelope-o',
+    ];
+    $buttons[] = $this->createElement('xbutton', $this->_testButtonName, ts('Save & Send Test Email'), $attrs);
     $this->getElement('buttons')->setElements($buttons);
 
     if (!empty($setStatus)) {

--- a/CRM/Batch/Form/Entry.php
+++ b/CRM/Batch/Form/Entry.php
@@ -179,6 +179,7 @@ class CRM_Batch_Form_Entry extends CRM_Core_Form {
       [
         'type' => 'submit',
         'value' => 1,
+        'class' => 'crm-button crm-button_qf_Entry_upload_force-save',
       ]
     );
 

--- a/CRM/Batch/Form/Entry.php
+++ b/CRM/Batch/Form/Entry.php
@@ -176,7 +176,10 @@ class CRM_Batch_Form_Entry extends CRM_Core_Form {
     $this->addElement('xbutton',
       $forceSave,
       ts('Ignore Mismatch & Process the Batch?'),
-      ['type' => 'submit']
+      [
+        'type' => 'submit',
+        'value' => 1,
+      ]
     );
 
     $this->addButtons([

--- a/CRM/Batch/Form/Entry.php
+++ b/CRM/Batch/Form/Entry.php
@@ -173,9 +173,10 @@ class CRM_Batch_Form_Entry extends CRM_Core_Form {
     // add the force save button
     $forceSave = $this->getButtonName('upload', 'force');
 
-    $this->addElement('submit',
+    $this->addElement('xbutton',
       $forceSave,
-      ts('Ignore Mismatch & Process the Batch?')
+      ts('Ignore Mismatch & Process the Batch?'),
+      ['type' => 'submit']
     );
 
     $this->addButtons([

--- a/CRM/Case/Form/CaseView.php
+++ b/CRM/Case/Form/CaseView.php
@@ -275,7 +275,10 @@ class CRM_Case_Form_CaseView extends CRM_Core_Form {
     // This button is hidden but gets clicked by javascript at
     // https://github.com/civicrm/civicrm-core/blob/bd28ecf8121a85bc069cad3ab912a0c3dff8fdc5/templates/CRM/Case/Form/CaseView.js#L194
     // by the onChange handler for the above timeline_id select.
-    $this->addElement('submit', $this->getButtonName('next'), ' ', ['class' => 'hiddenElement']);
+    $this->addElement('xbutton', $this->getButtonName('next'), ' ', [
+      'class' => 'hiddenElement',
+      'type' => 'submit',
+    ]);
 
     $this->buildMergeCaseForm();
 
@@ -523,11 +526,12 @@ class CRM_Case_Form_CaseView extends CRM_Core_Form {
       // This button is hidden but gets clicked by javascript at
       // https://github.com/civicrm/civicrm-core/blob/bd28ecf8121a85bc069cad3ab912a0c3dff8fdc5/templates/CRM/Case/Form/CaseView.js#L55
       // when the mergeCasesDialog is saved.
-      $this->addElement('submit',
+      $this->addElement('xbutton',
         $this->getButtonName('next', 'merge_case'),
         ts('Merge'),
         [
           'class' => 'hiddenElement',
+          'type' => 'submit',
         ]
       );
     }

--- a/CRM/Contact/Form/Contact.php
+++ b/CRM/Contact/Form/Contact.php
@@ -808,17 +808,20 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
     $this->addField('image_URL', ['maxlength' => '255', 'label' => ts('Browse/Upload Image')]);
 
     // add the dedupe button
-    $this->addElement('submit',
+    $this->addElement('xbutton',
       $this->_dedupeButtonName,
-      ts('Check for Matching Contact(s)')
+      ts('Check for Matching Contact(s)'),
+      ['type' => 'submit']
     );
-    $this->addElement('submit',
+    $this->addElement('xbutton',
       $this->_duplicateButtonName,
-      ts('Save Matching Contact')
+      ts('Save Matching Contact'),
+      ['type' => 'submit']
     );
-    $this->addElement('submit',
+    $this->addElement('xbutton',
       $this->getButtonName('next', 'sharedHouseholdDuplicate'),
-      ts('Save With Duplicate Household')
+      ts('Save With Duplicate Household'),
+      ['type' => 'submit']
     );
 
     $buttons = [

--- a/CRM/Contact/Form/Contact.php
+++ b/CRM/Contact/Form/Contact.php
@@ -811,17 +811,28 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
     $this->addElement('xbutton',
       $this->_dedupeButtonName,
       ts('Check for Matching Contact(s)'),
-      ['type' => 'submit']
+      [
+        'type' => 'submit',
+        'value' => 1,
+        'class' => "crm-button crm-button{$this->_dedupeButtonName}",
+      ]
     );
     $this->addElement('xbutton',
       $this->_duplicateButtonName,
       ts('Save Matching Contact'),
-      ['type' => 'submit']
+      [
+        'type' => 'submit',
+        'value' => 1,
+        'class' => "crm-button crm-button{$this->_duplicateButtonName}",
+      ]
     );
     $this->addElement('xbutton',
       $this->getButtonName('next', 'sharedHouseholdDuplicate'),
       ts('Save With Duplicate Household'),
-      ['type' => 'submit']
+      [
+        'type' => 'submit',
+        'value' => 1,
+      ]
     );
 
     $buttons = [

--- a/CRM/Contact/Form/Search.php
+++ b/CRM/Contact/Form/Search.php
@@ -469,8 +469,9 @@ class CRM_Contact_Form_Search extends CRM_Core_Form_Search {
       // also set the group title and freeze the action task with Add Members to Group
       $groupValues = ['id' => $this->_amtgID, 'title' => $this->_group[$this->_amtgID]];
       $this->assign_by_ref('group', $groupValues);
-      $this->add('submit', $this->_actionButtonName, ts('Add Contacts to %1', [1 => $this->_group[$this->_amtgID]]),
+      $this->add('xbutton', $this->_actionButtonName, ts('Add Contacts to %1', [1 => $this->_group[$this->_amtgID]]),
         [
+          'type' => 'submit',
           'class' => 'crm-form-submit',
         ]
       );

--- a/CRM/Contact/Form/Task/AddToParentClass.php
+++ b/CRM/Contact/Form/Task/AddToParentClass.php
@@ -65,8 +65,12 @@ class CRM_Contact_Form_Task_AddToParentClass extends CRM_Contact_Form_Task {
     $this->assign('searchCount', $searchCount);
     $this->assign('searchDone', $this->get('searchDone'));
     $this->assign('contact_type_display', $contactType);
-    $this->addElement('submit', $this->getButtonName('refresh'), ts('Search'), ['class' => 'crm-form-submit']);
-    $this->addElement('submit', $this->getButtonName('cancel'), ts('Cancel'), ['class' => 'crm-form-submit']);
+    $buttonAttrs = [
+      'type' => 'submit',
+      'class' => 'crm-form-submit',
+    ];
+    $this->addElement('xbutton', $this->getButtonName('refresh'), ts('Search'), $buttonAttrs);
+    $this->addElement('xbutton', $this->getButtonName('cancel'), ts('Cancel'), $buttonAttrs);
     $this->addButtons([
       [
         'type' => 'next',

--- a/CRM/Contact/Form/Task/AddToParentClass.php
+++ b/CRM/Contact/Form/Task/AddToParentClass.php
@@ -68,6 +68,7 @@ class CRM_Contact_Form_Task_AddToParentClass extends CRM_Contact_Form_Task {
     $buttonAttrs = [
       'type' => 'submit',
       'class' => 'crm-form-submit',
+      'value' => 1,
     ];
     $this->addElement('xbutton', $this->getButtonName('refresh'), ts('Search'), $buttonAttrs);
     $this->addElement('xbutton', $this->getButtonName('cancel'), ts('Cancel'), $buttonAttrs);

--- a/CRM/Contribute/Form/ContributionPage.php
+++ b/CRM/Contribute/Form/ContributionPage.php
@@ -222,7 +222,10 @@ class CRM_Contribute_Form_ContributionPage extends CRM_Core_Form {
     // views are implemented as frozen form
     if ($this->_action & CRM_Core_Action::VIEW) {
       $this->freeze();
-      $this->addElement('button', 'done', ts('Done'), ['onclick' => "location.href='civicrm/admin/custom/group?reset=1&action=browse'"]);
+      $this->addElement('xbutton', 'done', ts('Done'), [
+        'type' => 'button',
+        'onclick' => "location.href='civicrm/admin/custom/group?reset=1&action=browse'",
+      ]);
     }
 
     // don't show option for contribution amounts section if membership price set

--- a/CRM/Contribute/Form/ContributionPage/Widget.php
+++ b/CRM/Contribute/Form/ContributionPage/Widget.php
@@ -188,9 +188,10 @@ class CRM_Contribute_Form_ContributionPage_Widget extends CRM_Contribute_Form_Co
     $this->assign_by_ref('colorFields', $this->_colorFields);
 
     $this->_refreshButtonName = $this->getButtonName('refresh');
-    $this->addElement('submit',
+    $this->addElement('xbutton',
       $this->_refreshButtonName,
-      ts('Save and Preview')
+      ts('Save and Preview'),
+      ['type' => 'submit']
     );
     parent::buildQuickForm();
     $this->addFormRule(['CRM_Contribute_Form_ContributionPage_Widget', 'formRule'], $this);

--- a/CRM/Contribute/Import/Form/DataSource.php
+++ b/CRM/Contribute/Import/Form/DataSource.php
@@ -38,7 +38,10 @@ class CRM_Contribute_Import_Form_DataSource extends CRM_Import_Form_DataSource {
 
     $this->setDefaults(['onDuplicate' => CRM_Import_Parser::DUPLICATE_SKIP]);
 
-    $this->addElement('submit', 'loadMapping', ts('Load Mapping'), NULL, ['onclick' => 'checkSelect()']);
+    $this->addElement('xbutton', 'loadMapping', ts('Load Mapping'), [
+      'type' => 'submit',
+      'onclick' => 'checkSelect()',
+    ]);
 
     $this->addContactTypeSelector();
   }

--- a/CRM/Core/BAO/Mapping.php
+++ b/CRM/Core/BAO/Mapping.php
@@ -318,8 +318,11 @@ class CRM_Core_BAO_Mapping extends CRM_Core_DAO_Mapping {
     $hasRelationTypes = [];
 
     $columnCount = $columnNo;
-    $form->addElement('submit', 'addBlock', ts('Also include contacts where'),
-      ['class' => 'submit-link']
+    $form->addElement('xbutton', 'addBlock', ts('Also include contacts where'),
+      [
+        'type' => 'submit',
+        'class' => 'submit-link',
+      ]
     );
 
     $contactTypes = CRM_Contact_BAO_ContactType::basicTypes();
@@ -553,7 +556,10 @@ class CRM_Core_BAO_Mapping extends CRM_Core_DAO_Mapping {
         $form->add('text', "value[$x][$i]", '');
       }
 
-      $form->addElement('submit', "addMore[$x]", ts('Another search field'), ['class' => 'submit-link']);
+      $form->addElement('xbutton', "addMore[$x]", ts('Another search field'), [
+        'type' => 'submit',
+        'class' => 'submit-link',
+      ]);
     }
     //end of block for
 

--- a/CRM/Core/BAO/Mapping.php
+++ b/CRM/Core/BAO/Mapping.php
@@ -322,6 +322,7 @@ class CRM_Core_BAO_Mapping extends CRM_Core_DAO_Mapping {
       [
         'type' => 'submit',
         'class' => 'submit-link',
+        'value' => 1,
       ]
     );
 
@@ -559,6 +560,7 @@ class CRM_Core_BAO_Mapping extends CRM_Core_DAO_Mapping {
       $form->addElement('xbutton', "addMore[$x]", ts('Another search field'), [
         'type' => 'submit',
         'class' => 'submit-link',
+        'value' => 1,
       ]);
     }
     //end of block for

--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -714,6 +714,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
         }
         $buttonContents = CRM_Core_Page::crmIcon($button['icon'] ?? $defaultIcon) . ' ' . $button['name'];
         $buttonName = $this->getButtonName($button['type'], CRM_Utils_Array::value('subName', $button));
+        $attrs['class'] .= " crm-button crm-button-type-{$button['type']} crm-button{$buttonName}";
         $attrs['type'] = 'submit';
         $prevnext[] = $this->createElement('xbutton', $buttonName, $buttonContents, $attrs);
       }

--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -668,6 +668,13 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
 
       $attrs = ['class' => 'crm-form-submit'] + (array) CRM_Utils_Array::value('js', $button);
 
+      // A lot of forms use the hacky method of looking at
+      // `$params['button name']` (dating back to them being inputs with a
+      // "value" of the button label) rather than looking at
+      // `$this->controller->getButtonName()`. It makes sense to give buttons a
+      // value by default as a precaution.
+      $attrs['value'] = 1;
+
       if (!empty($button['class'])) {
         $attrs['class'] .= ' ' . $button['class'];
       }

--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -705,13 +705,10 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
         if (in_array($button['type'], ['next', 'upload', 'done']) && $button['name'] === ts('Save')) {
           $attrs['accesskey'] = 'S';
         }
-        $icon = CRM_Utils_Array::value('icon', $button, $defaultIcon);
-        if ($icon) {
-          $attrs['crm-icon'] = $icon;
-        }
+        $buttonContents = CRM_Core_Page::crmIcon($button['icon'] ?? $defaultIcon) . ' ' . $button['name'];
         $buttonName = $this->getButtonName($button['type'], CRM_Utils_Array::value('subName', $button));
         $attrs['type'] = 'submit';
-        $prevnext[] = $this->createElement('xbutton', $buttonName, $button['name'], $attrs);
+        $prevnext[] = $this->createElement('xbutton', $buttonName, $buttonContents, $attrs);
       }
       if (!empty($button['isDefault'])) {
         $this->setDefaultAction($button['type']);

--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -686,7 +686,8 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
       }
 
       if ($button['type'] === 'reset') {
-        $prevnext[] = $this->createElement($button['type'], 'reset', $button['name'], $attrs);
+        $attrs['type'] = 'reset';
+        $prevnext[] = $this->createElement('xbutton', 'reset', $button['name'], $attrs);
       }
       else {
         if (!empty($button['subName'])) {
@@ -709,7 +710,8 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
           $attrs['crm-icon'] = $icon;
         }
         $buttonName = $this->getButtonName($button['type'], CRM_Utils_Array::value('subName', $button));
-        $prevnext[] = $this->createElement('submit', $buttonName, $button['name'], $attrs);
+        $attrs['type'] = 'submit';
+        $prevnext[] = $this->createElement('xbutton', $buttonName, $button['name'], $attrs);
       }
       if (!empty($button['isDefault'])) {
         $this->setDefaultAction($button['type']);
@@ -2448,7 +2450,10 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
         $this->_actionButtonName = $this->getButtonName('next', 'action');
       }
       $this->assign('actionButtonName', $this->_actionButtonName);
-      $this->add('submit', $this->_actionButtonName, ts('Go'), ['class' => 'hiddenElement crm-search-go-button']);
+      $this->add('xbutton', $this->_actionButtonName, ts('Go'), [
+        'type' => 'submit',
+        'class' => 'hiddenElement crm-search-go-button',
+      ]);
 
       // Radio to choose "All items" or "Selected items only"
       $selectedRowsRadio = $this->addElement('radio', 'radio_ts', NULL, '', 'ts_sel', ['checked' => 'checked']);

--- a/CRM/Custom/Form/Field.php
+++ b/CRM/Custom/Form/Field.php
@@ -565,10 +565,13 @@ class CRM_Custom_Form_Field extends CRM_Core_Form {
     if ($this->_action & CRM_Core_Action::VIEW) {
       $this->freeze();
       $url = CRM_Utils_System::url('civicrm/admin/custom/group/field', 'reset=1&action=browse&gid=' . $this->_gid);
-      $this->addElement('button',
+      $this->addElement('xbutton',
         'done',
         ts('Done'),
-        ['onclick' => "location.href='$url'"]
+        [
+          'type' => 'button',
+          'onclick' => "location.href='$url'",
+        ]
       );
     }
   }

--- a/CRM/Custom/Form/Group.php
+++ b/CRM/Custom/Form/Group.php
@@ -351,7 +351,10 @@ class CRM_Custom_Form_Group extends CRM_Core_Form {
     // TODO: Is this condition ever true? Can this code be removed?
     if ($this->_action & CRM_Core_Action::VIEW) {
       $this->freeze();
-      $this->addElement('button', 'done', ts('Done'), ['onclick' => "location.href='civicrm/admin/custom/group?reset=1&action=browse'"]);
+      $this->addElement('xbutton', 'done', ts('Done'), [
+        'type' => 'button',
+        'onclick' => "location.href='civicrm/admin/custom/group?reset=1&action=browse'",
+      ]);
     }
   }
 

--- a/CRM/Custom/Form/Option.php
+++ b/CRM/Custom/Form/Option.php
@@ -201,10 +201,15 @@ class CRM_Custom_Form_Option extends CRM_Core_Form {
           'reset=1&action=browse&fid=' . $this->_fid . '&gid=' . $this->_gid,
           TRUE, NULL, FALSE
         );
-        $this->addElement('button',
+        $this->addElement('xbutton',
           'done',
           ts('Done'),
-          ['onclick' => "location.href='$url'", 'class' => 'crm-form-submit cancel', 'crm-icon' => 'fa-times']
+          [
+            'type' => 'button',
+            'onclick' => "location.href='$url'",
+            'class' => 'crm-form-submit cancel',
+            'crm-icon' => 'fa-times',
+          ]
         );
       }
     }

--- a/CRM/Custom/Form/Option.php
+++ b/CRM/Custom/Form/Option.php
@@ -203,12 +203,11 @@ class CRM_Custom_Form_Option extends CRM_Core_Form {
         );
         $this->addElement('xbutton',
           'done',
-          ts('Done'),
+          CRM_Core_Page::crmIcon('fa-times') . ' ' . ts('Done'),
           [
             'type' => 'button',
             'onclick' => "location.href='$url'",
             'class' => 'crm-form-submit cancel',
-            'crm-icon' => 'fa-times',
           ]
         );
       }

--- a/CRM/Event/Form/ManageEvent/Fee.php
+++ b/CRM/Event/Form/ManageEvent/Fee.php
@@ -359,6 +359,7 @@ class CRM_Event_Form_ManageEvent_Fee extends CRM_Event_Form_ManageEvent {
       [
         'type' => 'submit',
         'class' => 'crm-form-submit cancel',
+        'value' => 1,
       ]
     );
     if (Civi::settings()->get('deferred_revenue_enabled')) {

--- a/CRM/Event/Form/ManageEvent/Fee.php
+++ b/CRM/Event/Form/ManageEvent/Fee.php
@@ -355,8 +355,11 @@ class CRM_Event_Form_ManageEvent_Fee extends CRM_Event_Form_ManageEvent {
       $this->add('datepicker', 'discount_end_date[' . $i . ']', ts('Discount End Date'), [], FALSE, ['time' => FALSE]);
     }
     $_showHide->addToTemplate();
-    $this->addElement('submit', $this->getButtonName('submit'), ts('Add Discount Set to Fee Table'),
-      ['class' => 'crm-form-submit cancel']
+    $this->addElement('xbutton', $this->getButtonName('submit'), ts('Add Discount Set to Fee Table'),
+      [
+        'type' => 'submit',
+        'class' => 'crm-form-submit cancel',
+      ]
     );
     if (Civi::settings()->get('deferred_revenue_enabled')) {
       $deferredFinancialType = CRM_Financial_BAO_FinancialAccount::getDeferredFinancialType();

--- a/CRM/Financial/Form/BatchTransaction.php
+++ b/CRM/Financial/Form/BatchTransaction.php
@@ -75,7 +75,7 @@ class CRM_Financial_Form_BatchTransaction extends CRM_Contribute_Form_Search {
    */
   public function buildQuickForm() {
     if ($this->_batchStatus == 'Closed') {
-      $this->add('submit', 'export_batch', ts('Export Batch'));
+      $this->add('xbutton', 'export_batch', ts('Export Batch'), ['type' => 'submit']);
     }
 
     // do not build rest of form unless it is open/reopened batch
@@ -85,9 +85,9 @@ class CRM_Financial_Form_BatchTransaction extends CRM_Contribute_Form_Search {
 
     parent::buildQuickForm();
     if (CRM_Batch_BAO_Batch::checkBatchPermission('close', $this->_values['created_id'])) {
-      $this->add('submit', 'close_batch', ts('Close Batch'));
+      $this->add('xbutton', 'close_batch', ts('Close Batch'), ['type' => 'submit']);
       if (CRM_Batch_BAO_Batch::checkBatchPermission('export', $this->_values['created_id'])) {
-        $this->add('submit', 'export_batch', ts('Close & Export Batch'));
+        $this->add('xbutton', 'export_batch', ts('Close & Export Batch'), ['type' => 'submit']);
       }
     }
 
@@ -99,8 +99,9 @@ class CRM_Financial_Form_BatchTransaction extends CRM_Contribute_Form_Search {
       ts('Task'),
       ['' => ts('- actions -')] + ['Remove' => ts('Remove from Batch')]);
 
-    $this->add('submit', 'rSubmit', ts('Go'),
+    $this->add('xbutton', 'rSubmit', ts('Go'),
       [
+        'type' => 'submit',
         'class' => 'crm-form-submit',
         'id' => 'GoRemove',
       ]);
@@ -123,8 +124,9 @@ class CRM_Financial_Form_BatchTransaction extends CRM_Contribute_Form_Search {
       ts('Task'),
       ['' => ts('- actions -')] + ['Assign' => ts('Assign to Batch')]);
 
-    $this->add('submit', 'submit', ts('Go'),
+    $this->add('xbutton', 'submit', ts('Go'),
       [
+        'type' => 'submit',
         'class' => 'crm-form-submit',
         'id' => 'Go',
       ]);

--- a/CRM/Financial/Form/Search.php
+++ b/CRM/Financial/Form/Search.php
@@ -93,8 +93,9 @@ class CRM_Financial_Form_Search extends CRM_Core_Form {
       ts('Task'),
       ['' => ts('- actions -')] + $batchAction);
 
-    $this->add('submit', 'submit', ts('Go'),
+    $this->add('xbutton', 'submit', ts('Go'),
       [
+        'type' => 'submit',
         'class' => 'crm-form-submit',
         'id' => 'Go',
       ]);

--- a/CRM/Price/Form/Field.php
+++ b/CRM/Price/Form/Field.php
@@ -376,10 +376,13 @@ class CRM_Price_Form_Field extends CRM_Core_Form {
     if ($this->_action & CRM_Core_Action::VIEW) {
       $this->freeze();
       $url = CRM_Utils_System::url('civicrm/admin/price/field', 'reset=1&action=browse&sid=' . $this->_sid);
-      $this->addElement('button',
+      $this->addElement('xbutton',
         'done',
         ts('Done'),
-        ['onclick' => "location.href='$url'"]
+        [
+          'type' => 'button',
+          'onclick' => "location.href='$url'",
+        ]
       );
     }
   }

--- a/CRM/Profile/Form.php
+++ b/CRM/Profile/Form.php
@@ -904,9 +904,10 @@ class CRM_Profile_Form extends CRM_Core_Form {
 
     if ($this->_context == 'dialog') {
       $this->addElement(
-        'submit',
+        'xbutton',
         $this->_duplicateButtonName,
-        ts('Save Matching Contact')
+        ts('Save Matching Contact'),
+        ['type' => 'submit']
       );
     }
   }

--- a/CRM/Profile/Form.php
+++ b/CRM/Profile/Form.php
@@ -907,7 +907,10 @@ class CRM_Profile_Form extends CRM_Core_Form {
         'xbutton',
         $this->_duplicateButtonName,
         ts('Save Matching Contact'),
-        ['type' => 'submit']
+        [
+          'type' => 'submit',
+          'class' => 'crm-button',
+        ]
       );
     }
   }

--- a/CRM/Profile/Form/Edit.php
+++ b/CRM/Profile/Form/Edit.php
@@ -209,7 +209,10 @@ SELECT module,is_reserved
 
     if (($this->_multiRecord & CRM_Core_Action::DELETE) && $this->_recordExists) {
       $this->_deleteButtonName = $this->getButtonName('upload', 'delete');
-      $this->addElement('xbutton', $this->_deleteButtonName, ts('Delete'), ['type' => 'submit']);
+      $this->addElement('xbutton', $this->_deleteButtonName, ts('Delete'), [
+        'type' => 'submit',
+        'value' => 1,
+      ]);
 
       return;
     }

--- a/CRM/Profile/Form/Edit.php
+++ b/CRM/Profile/Form/Edit.php
@@ -209,7 +209,7 @@ SELECT module,is_reserved
 
     if (($this->_multiRecord & CRM_Core_Action::DELETE) && $this->_recordExists) {
       $this->_deleteButtonName = $this->getButtonName('upload', 'delete');
-      $this->addElement('submit', $this->_deleteButtonName, ts('Delete'));
+      $this->addElement('xbutton', $this->_deleteButtonName, ts('Delete'), ['type' => 'submit']);
 
       return;
     }

--- a/CRM/Profile/Form/Edit.php
+++ b/CRM/Profile/Form/Edit.php
@@ -212,6 +212,7 @@ SELECT module,is_reserved
       $this->addElement('xbutton', $this->_deleteButtonName, ts('Delete'), [
         'type' => 'submit',
         'value' => 1,
+        'class' => 'crm-button',
       ]);
 
       return;

--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -1535,7 +1535,7 @@ class CRM_Report_Form extends CRM_Core_Form {
     if (!empty($this->_charts)) {
       $this->addElement('select', "charts", ts('Chart'), $this->_charts);
       $this->assign('charts', $this->_charts);
-      $this->addElement('submit', $this->_chartButtonName, ts('View'));
+      $this->addElement('xbutton', $this->_chartButtonName, ts('View'), ['type' => 'submit']);
     }
   }
 
@@ -1660,7 +1660,10 @@ class CRM_Report_Form extends CRM_Core_Form {
       $this->assign('group', TRUE);
     }
 
-    $this->addElement('submit', $this->_groupButtonName, '', ['style' => 'display: none;']);
+    $this->addElement('xbutton', $this->_groupButtonName, '', [
+      'type' => 'submit',
+      'style' => 'display: none;',
+    ]);
 
     $this->addChartOptions();
     $showResultsLabel = $this->getResultsLabel();

--- a/CRM/UF/Form/Field.php
+++ b/CRM/UF/Form/Field.php
@@ -467,8 +467,11 @@ class CRM_UF_Form_Field extends CRM_Core_Form {
     // if view mode pls freeze it with the done button.
     if ($this->_action & CRM_Core_Action::VIEW) {
       $this->freeze();
-      $this->addElement('button', 'done', ts('Done'),
-        ['onclick' => "location.href='civicrm/admin/uf/group/field?reset=1&action=browse&gid=" . $this->_gid . "'"]
+      $this->addElement('xbutton', 'done', ts('Done'),
+        [
+          'type' => 'button',
+          'onclick' => "location.href='civicrm/admin/uf/group/field?reset=1&action=browse&gid=" . $this->_gid . "'",
+        ]
       );
     }
 

--- a/CRM/UF/Form/Group.php
+++ b/CRM/UF/Form/Group.php
@@ -231,7 +231,10 @@ class CRM_UF_Form_Group extends CRM_Core_Form {
     // views are implemented as frozen form
     if ($this->_action & CRM_Core_Action::VIEW) {
       $this->freeze();
-      $this->addElement('button', 'done', ts('Done'), ['onclick' => "location.href='civicrm/admin/uf/group?reset=1&action=browse'"]);
+      $this->addElement('xbutton', 'done', ts('Done'), [
+        'type' => 'button',
+        'onclick' => "location.href='civicrm/admin/uf/group?reset=1&action=browse'",
+      ]);
     }
 
     $this->addFormRule(['CRM_UF_Form_Group', 'formRule'], $this);

--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -1844,14 +1844,10 @@ input.crm-form-entityref {
   min-height: 0;
 }
 
-/* A few of these are redundant: pretty much all buttons have the crm-button
-class.  It can't hurt, though. */
 .crm-container a.button,
 .crm-container a.button:link,
 .crm-container a.button:visited,
-.crm-container button.crm-form-submit,
 .crm-container .ui-dialog-buttonset .ui-button,
-.crm-container button[type=button],
 .crm-container .crm-button {
   text-shadow: 0 1px 0 black;
   background: #696969;
@@ -1863,36 +1859,15 @@ class.  It can't hurt, though. */
   text-decoration: none;
   cursor: pointer;
   border: 1px solid #3e3e3e;
-}
-
-.crm-container a.button,
-.crm-container a.button:link,
-.crm-container a.button:visited,
-.crm-container .crm-button {
   display: block;
   float: left;
   overflow: hidden;
   line-height: 135%;
+  border-radius: 3px;
 }
 
-/* Preserving the important but not sure why */
-.crm-container span.crm-button {
-  float: left !important;
-}
-
-.crm-container button.crm-button {
-  padding: 3px 6px;
-}
-
-.crm-container button.crm-button .icon {
-  margin-bottom: -4px;
-}
-
-/* Also redundant, see above */
 .crm-container .crm-button:hover,
 .crm-container .crm-button:focus,
-.crm-container button[type=submit]:hover,
-.crm-container button[type=button]:hover,
 .crm-container .ui-dialog-buttonset .ui-button:hover,
 .crm-container .ui-dialog-buttonset .ui-button:focus,
 .crm-container a.button:hover,
@@ -1900,35 +1875,25 @@ class.  It can't hurt, though. */
   background: #3e3e3e;
 }
 
-/* Also redundant, see above */
 .crm-container .crm-button-disabled,
 .crm-container .crm-button.crm-button-disabled,
 .crm-container .ui-dialog-buttonset .ui-button[disabled],
-.crm-container button.crm-form-submit[disabled],
-.crm-container button[type=button][disabled],
 .crm-container .crm-button[disabled] {
   opacity: .6;
   cursor: default;
-}
-
-/* Also redundant, see above */
-.crm-container .crm-button,
-.crm-container a.button,
-.crm-container a.button:link,
-.crm-container button.crm-form-submit,
-.crm-container button[type=button] {
-  border-radius: 3px;
 }
 
 .crm-container .ui-dialog-buttonpane {
   background: linear-gradient(to bottom, #f2f2f2 0%,#ffffff 35%);
 }
 
-.crm-container .ui-dialog-buttonset .ui-button {
-  padding: 0;
-}
 .crm-container .ui-dialog-buttonset .ui-button .ui-icon {
   background-image: url("../i/icons/jquery-ui-FFFFFF.png");
+}
+
+/* Override of a line in crm-i.css that may not be important anymore */
+.crm-container .ui-dialog-buttonset .ui-button .ui-icon[class*=" fa-"] {
+  margin-top: 0;
 }
 
 /* No crm-button styling for PayPal Express buttons */

--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -1173,7 +1173,7 @@ input.crm-form-entityref {
   cursor: pointer;
 }
 
-#crm-container input.submit-link {
+#crm-container button.submit-link {
   color: #285286;
   background: none transparent;
   border: none;
@@ -1833,17 +1833,6 @@ input.crm-form-entityref {
   margin-left: .5em;
 }
 
-.crm-container .crm-button input {
-  background: none;
-  border: medium none;
-  color: #FFF;
-  cursor: pointer;
-  font-size: 13px;
-  font-weight: normal;
-  margin: 0;
-  padding: 1px 8px 2px 4px;
-}
-
 .crm-container .crm-button-type-cancel,
 .crm-container .crm-button-type-back {
   margin-left: 20px;
@@ -1855,12 +1844,14 @@ input.crm-form-entityref {
   min-height: 0;
 }
 
+/* A few of these are redundant: pretty much all buttons have the crm-button
+class.  It can't hurt, though. */
 .crm-container a.button,
 .crm-container a.button:link,
 .crm-container a.button:visited,
-.crm-container input.crm-form-submit,
+.crm-container button.crm-form-submit,
 .crm-container .ui-dialog-buttonset .ui-button,
-.crm-container input[type=button],
+.crm-container button[type=button],
 .crm-container .crm-button {
   text-shadow: 0 1px 0 black;
   background: #696969;
@@ -1877,7 +1868,7 @@ input.crm-form-entityref {
 .crm-container a.button,
 .crm-container a.button:link,
 .crm-container a.button:visited,
-.crm-container span.crm-button {
+.crm-container .crm-button {
   display: block;
   float: left;
   overflow: hidden;
@@ -1897,23 +1888,11 @@ input.crm-form-entityref {
   margin-bottom: -4px;
 }
 
-.crm-container input.crm-form-submit,
-.crm-container input[type=button] {
-  padding: 2px 6px;
-}
-
-.crm-container .crm-button input[type=button],
-.crm-container .crm-button input.crm-form-submit {
-  padding: 0;
-  margin: 0;
-  background: none;
-  border: none;
-}
-
+/* Also redundant, see above */
 .crm-container .crm-button:hover,
 .crm-container .crm-button:focus,
-.crm-container input[type=submit]:hover,
-.crm-container input[type=button]:hover,
+.crm-container button[type=submit]:hover,
+.crm-container button[type=button]:hover,
 .crm-container .ui-dialog-buttonset .ui-button:hover,
 .crm-container .ui-dialog-buttonset .ui-button:focus,
 .crm-container a.button:hover,
@@ -1921,18 +1900,24 @@ input.crm-form-entityref {
   background: #3e3e3e;
 }
 
+/* Also redundant, see above */
 .crm-container .crm-button-disabled,
 .crm-container .crm-button.crm-button-disabled,
 .crm-container .ui-dialog-buttonset .ui-button[disabled],
-.crm-container input.crm-form-submit[disabled],
-.crm-container input[type=button][disabled],
+.crm-container button.crm-form-submit[disabled],
+.crm-container button[type=button][disabled],
 .crm-container .crm-button[disabled] {
   opacity: .6;
   cursor: default;
 }
 
-.crm-container .crm-button-disabled input[disabled] {
-  opacity: 1;
+/* Also redundant, see above */
+.crm-container .crm-button,
+.crm-container a.button,
+.crm-container a.button:link,
+.crm-container button.crm-form-submit,
+.crm-container button[type=button] {
+  border-radius: 3px;
 }
 
 .crm-container .ui-dialog-buttonpane {
@@ -2889,15 +2874,6 @@ tbody.scrollContent tr.alternateRow {
 }
 
 /* rounded corners */
-.crm-container .crm-button,
-.crm-container a.button,
-.crm-container a.button:link,
-.crm-container input.crm-form-submit,
-.crm-container input[type=button] {
-  border-radius: 3px;
-}
-
-
 .crm-container div.status,
 .crm-container #help,
 .crm-container .help,

--- a/css/joomla.css
+++ b/css/joomla.css
@@ -352,7 +352,7 @@ div#toolbar-box, div#toolbar-box div.m{
 .crm-container input {
   height: auto;
 }
-.crm-container input[type=submit] {
+.crm-container button[type=submit] {
   height: auto;
 }
 
@@ -377,7 +377,7 @@ div#toolbar-box, div#toolbar-box div.m{
 }
 
 /* Remove Joomla subhead toolbar & whitespace border */
-	
+
 body.admin.com_civicrm .subhead-collapse {
 	display:none;
 }

--- a/install/template.html
+++ b/install/template.html
@@ -34,7 +34,7 @@ if ($text_direction == 'rtl') {
   <?php } ?>
 
   <p>
-  <input id="install_button" type="submit" name="go" value="<?php echo ts('Check Requirements and Install CiviCRM', array('escape' => 'js')); ?>" onclick="document.getElementById('saving_top').style.display = ''; this.value = '<?php echo ts('Installing CiviCRM...', array('escape' => 'js')); ?>'" />
+  <button id="install_button" type="submit" name="go" onclick="document.getElementById('saving_top').style.display = ''; this.innerHTML = '<?php echo ts('Installing CiviCRM...', ['escape' => 'js']); ?>'"><?php echo ts('Check Requirements and Install CiviCRM', ['escape' => 'js']); ?></button>
 
   <span id="saving_top" style="display: none">
   &nbsp;
@@ -73,7 +73,7 @@ if ($text_direction == 'rtl') {
   ?>
 </select>
 <noscript>
-  <input type="submit" name="setlanguage" value="<?php echo ts('Change language', array('escape' => 'js')); ?>" />
+  <button type="submit" name="setlanguage"><?php echo ts('Change language', ['escape' => 'js']); ?></button>
 </noscript>
 <span class="testResults">
   <?php
@@ -135,7 +135,7 @@ if ($text_direction == 'rtl') {
     <span class="testResults">Check this box to pre-populate CiviCRM with sample English contact records, online contribution pages, profile forms, etc. These examples can help you learn about CiviCRM features.</span><br />
 </p>
 
-<p style="margin-left: 2em"><input type="submit" value="<?php echo ts('Re-check requirements', array('escape' => 'js')); ?>" /></p>
+<p style="margin-left: 2em"><button type="submit"><?php echo ts('Re-check requirements', ['escape' => 'js']); ?></button></p>
 
 <a name="dbDetails">
 

--- a/js/Common.js
+++ b/js/Common.js
@@ -145,32 +145,6 @@ function showHideByValue(trigger_field_id, trigger_value, target_element_id, tar
 }
 
 var submitcount = 0;
-/**
- * Old submit-once function. Will be removed soon.
- * @deprecated
- */
-function submitOnce(obj, formId, procText) {
-  // if named button clicked, change text
-  if (obj.value != null) {
-    cj('input[name=' + obj.name + ']').val(procText + " ...");
-  }
-  cj(obj).closest('form').attr('data-warn-changes', 'false');
-  if (document.getElementById) { // disable submit button for newer browsers
-    cj('input[name=' + obj.name + ']').attr("disabled", true);
-    document.getElementById(formId).submit();
-    return true;
-  }
-  else { // for older browsers
-    if (submitcount == 0) {
-      submitcount++;
-      return true;
-    }
-    else {
-      alert("Your request is currently being processed ... Please wait.");
-      return false;
-    }
-  }
-}
 
 /**
  * Function to show / hide the row in optionFields

--- a/js/Common.js
+++ b/js/Common.js
@@ -192,7 +192,7 @@ if (!CRM.vars) CRM.vars = {};
   $.propHooks.disabled = {
     set: function (el, value, name) {
       // Sync button enabled status with wrapper css
-      if ($(el).is('span.crm-button > input.crm-form-submit')) {
+      if ($(el).is('.crm-button.crm-form-submit')) {
         $(el).parent().toggleClass('crm-button-disabled', !!value);
       }
       // Sync button enabled status with dialog button
@@ -971,7 +971,7 @@ if (!CRM.vars) CRM.vars = {};
       $('form[data-submit-once]', e.target)
         .submit(submitOnceForm)
         .on('invalid-form', submitFormInvalid);
-      $('form[data-submit-once] input[type=submit]', e.target).click(function(e) {
+      $('form[data-submit-once] button[type=submit]', e.target).click(function(e) {
         submitButton = e.target;
       });
     })

--- a/js/crm.ajax.js
+++ b/js/crm.ajax.js
@@ -498,7 +498,7 @@
         var buttonContainers = '.crm-submit-buttons, .action-link',
           buttons = [],
           added = [];
-        $(buttonContainers, $el).find('input.crm-form-submit, a.button, button').each(function() {
+        $(buttonContainers, $el).find('.crm-form-submit, .crm-form-xbutton, a.button, button').each(function() {
           var $el = $(this),
             label = $el.is('input') ? $el.attr('value') : $el.text(),
             identifier = $el.attr('name') || $el.attr('href');
@@ -522,7 +522,7 @@
         $el.dialog('option', 'buttons', buttons);
       }
       // Allow a button to prevent ajax submit
-      $('input[data-no-ajax-submit=true]').click(function() {
+      $('input[data-no-ajax-submit=true], button[data-no-ajax-submit=true]').click(function() {
         $(this).closest('form').ajaxFormUnbind();
       });
       // For convenience, focus the first field

--- a/js/crm.searchForm.js
+++ b/js/crm.searchForm.js
@@ -134,7 +134,7 @@
       // When selecting a task
       .on('change', 'select#task', function(e) {
         var $form = $(this).closest('form'),
-        $go = $('input.crm-search-go-button', $form);
+        $go = $('button.crm-search-go-button', $form);
         var $selectedOption = $(this).find(':selected');
         if (!$selectedOption.val()) {
           // do not blank refresh the empty option.

--- a/js/jquery/jquery.dashboard.js
+++ b/js/jquery/jquery.dashboard.js
@@ -526,8 +526,8 @@
         html += '<form class="widget-settings">';
         html += '  <div class="widget-settings-inner"></div>';
         html += '  <div class="widget-settings-buttons">';
-        html += '    <input id="' + widget.id + '-settings-save" class="widget-settings-save" value="Save" type="submit" />';
-        html += '    <input id="' + widget.id + '-settings-cancel" class="widget-settings-cancel" value="Cancel" type="submit" />';
+        html += '    <button id="' + widget.id + '-settings-save" class="widget-settings-save" type="submit">Save</button>';
+        html += '    <button id="' + widget.id + '-settings-cancel" class="widget-settings-cancel" type="submit">Cancel</button>';
         html += '  </div>';
         html += '</form>';
         return html;

--- a/setup/plugins/blocks/advanced.tpl.php
+++ b/setup/plugins/blocks/advanced.tpl.php
@@ -26,7 +26,7 @@ endif; ?>
           <div>
 
           <input type="text" name="civisetup[advanced][db]" value="<?php echo htmlentities($model->extras['advanced']['db']); ?>" data-original="<?php echo htmlentities($model->extras['advanced']['db']); ?>">
-          <input id="db_apply_button" type="submit" name="civisetup[action][Start]" value="<?php echo htmlentities(ts('Apply')); ?>" />
+          <button id="db_apply_button" type="submit" name="civisetup[action][Start]"><?php echo htmlentities(ts('Apply')); ?></button>
           <a href="" onclick="civisetupAdvancedDbCancel(); return false;" title="<?php echo htmlentities(ts('Cancel')) ?>"><i class="fa fa-close"></i></a>
           <script type="text/javascript">
             function civisetupAdvancedDbCancel() {

--- a/setup/plugins/blocks/install.tpl.php
+++ b/setup/plugins/blocks/install.tpl.php
@@ -1,9 +1,8 @@
 <?php if (!defined('CIVI_SETUP')): exit("Installation plugins must only be loaded by the installer.\n");
 endif; ?>
 <div class="action-box">
-  <input id="install_button" type="submit" name="civisetup[action][Install]"
-         value="<?php echo htmlentities(ts('Install CiviCRM')); ?>"
-         onclick="document.getElementById('saving_top').style.display = ''; this.value = '<?php echo ts('Installing CiviCRM...', array('escape' => 'js')); ?>'"/>
+  <button id="install_button" type="submit" name="civisetup[action][Install]"
+         onclick="document.getElementById('saving_top').style.display = ''; this.innerHTML = '<?php echo ts('Installing CiviCRM...', array('escape' => 'js')); ?>'"><?php echo htmlentities(ts('Install CiviCRM')); ?></button>
   <div id="saving_top" style="display: none;">
 &nbsp;   <img src="<?php echo htmlentities($installURLPath . "network-save.gif") ?>"/>
     <?php echo ts('(this will take a few minutes)'); ?>

--- a/setup/plugins/blocks/requirements.tpl.php
+++ b/setup/plugins/blocks/requirements.tpl.php
@@ -46,7 +46,7 @@ uasort($msgs, function($a, $b) {
 </table>
 
 <div class="action-box">
-  <input id="recheck_button" type="submit" name="civisetup[action][Start]" value="<?php echo htmlentities(ts('Refresh')); ?>" />
+  <button id="recheck_button" type="submit" name="civisetup[action][Start]"><?php echo htmlentities(ts('Refresh')); ?></button>
   <div class="advancedTip">
     <?php echo ts('After updating your system, refresh to test the requirements again.'); ?>
   </div>

--- a/setup/res/template.css
+++ b/setup/res/template.css
@@ -15,7 +15,7 @@ body {
   float: left;
   margin-left: 10%;
   margin-top: 50px;
-  margin-right: 20%; 
+  margin-right: 20%;
   display: inline-flex;
 }
 
@@ -39,7 +39,7 @@ body {
     100% { left: 0; color: #555;}
 }
 
-  
+
 .civicrm-setup-header hr{
   border-bottom: 2px solid #fff;
   border-top: 2px solid #ddd;
@@ -217,7 +217,7 @@ body {
   text-align: center;
   margin: 2em 0.5em;
 }
-.civicrm-setup-body input[type=submit] {
+.civicrm-setup-body button[type=submit] {
   padding:15px 25px;
   background:#82C459;
   color: white;
@@ -227,10 +227,10 @@ body {
   border-radius: 5px;
   font-size: 20px;
 }
-.civicrm-setup-body input[type=submit]:hover {
+.civicrm-setup-body button[type=submit]:hover {
   background: #60A237;
 }
-.civicrm-setup-body input[type=submit]:disabled {
+.civicrm-setup-body button[type=submit]:disabled {
   background: #888;
   cursor: not-allowed;
 }
@@ -267,4 +267,3 @@ body {
     width: 95%;
   }
 }
-

--- a/setup/src/Setup/UI/SetupController.php
+++ b/setup/src/Setup/UI/SetupController.php
@@ -247,7 +247,7 @@ class SetupController implements SetupControllerInterface {
    *
    * @param array $fields
    *   HTTP inputs -- e.g. with a form element like this:
-   *   `<input type="submit" name="civisetup[action][Foo]" value="Do the foo">`
+   *   `<button type="submit" name="civisetup[action][Foo]">Do the foo</button>`
    * @param string $default
    *   The action-name to return if no other action is identified.
    * @return string

--- a/templates/CRM/Admin/Form/CKEditorConfig.tpl
+++ b/templates/CRM/Admin/Form/CKEditorConfig.tpl
@@ -97,16 +97,12 @@
     <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
 =======
     <div class="crm-submit-buttons">
-      <span class="crm-button">
-        <button type="submit" name="save" class="crm-form-submit" accesskey="S">
-          <i class="crm-i fa-wrench" aria-hidden="true"></i> {ts}Save{/ts}
-        </button>
-      </span>
-      <span class="crm-button">
-        <button type="submit" name="revert" class="crm-form-submit" onclick="return confirm('{$revertConfirm}');">
-          <i class="crm-i fa-times" aria-hidden="true"></i> {ts}Revert to Default{/ts}
-        </button>
-      </span>
+      <button type="submit" name="save" class="crm-form-submit crm-button" accesskey="S">
+        <i class="crm-i fa-wrench" aria-hidden="true"></i> {ts}Save{/ts}
+      </button>
+      <button type="submit" name="revert" class="crm-form-submit crm-button" onclick="return confirm('{$revertConfirm}');">
+        <i class="crm-i fa-times" aria-hidden="true"></i> {ts}Revert to Default{/ts}
+      </button>
     </div>
     <input type="hidden" value="{$preset}" name="preset" />
 >>>>>>> 4a004942c6... Put icons inside of button elements:templates/CRM/Admin/Page/CKEditorConfig.tpl

--- a/templates/CRM/Admin/Form/CKEditorConfig.tpl
+++ b/templates/CRM/Admin/Form/CKEditorConfig.tpl
@@ -93,7 +93,23 @@
       </fieldset>
     </div>
 
+<<<<<<< HEAD:templates/CRM/Admin/Form/CKEditorConfig.tpl
     <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
+=======
+    <div class="crm-submit-buttons">
+      <span class="crm-button">
+        <button type="submit" name="save" class="crm-form-submit" accesskey="S">
+          <i class="crm-i fa-wrench" aria-hidden="true"></i> {ts}Save{/ts}
+        </button>
+      </span>
+      <span class="crm-button">
+        <button type="submit" name="revert" class="crm-form-submit" onclick="return confirm('{$revertConfirm}');">
+          <i class="crm-i fa-times" aria-hidden="true"></i> {ts}Revert to Default{/ts}
+        </button>
+      </span>
+    </div>
+    <input type="hidden" value="{$preset}" name="preset" />
+>>>>>>> 4a004942c6... Put icons inside of button elements:templates/CRM/Admin/Page/CKEditorConfig.tpl
   </fieldset>
 </div>
 <script type="text/template" id="config-row-tpl">

--- a/templates/CRM/Admin/Form/Preferences/Display.tpl
+++ b/templates/CRM/Admin/Form/Preferences/Display.tpl
@@ -162,7 +162,6 @@
         {$form.editor_id.html}
         &nbsp;
         <span class="crm-button" style="display:inline-block;vertical-align:middle;float:none!important;">
-          <i class="crm-i fa-wrench" aria-hidden="true"></i>
           {$form.ckeditor_config.html}
         </span>
       </td>

--- a/templates/CRM/Admin/Form/Preferences/Display.tpl
+++ b/templates/CRM/Admin/Form/Preferences/Display.tpl
@@ -161,9 +161,7 @@
       <td>
         {$form.editor_id.html}
         &nbsp;
-        <span class="crm-button" style="display:inline-block;vertical-align:middle;float:none!important;">
-          {$form.ckeditor_config.html}
-        </span>
+        {$form.ckeditor_config.html}
       </td>
     </tr>
     <tr class="crm-preferences-display-form-block-ajaxPopupsEnabled">

--- a/templates/CRM/Admin/Page/APIExplorer.tpl
+++ b/templates/CRM/Admin/Page/APIExplorer.tpl
@@ -285,11 +285,9 @@
         </table>
       </div>
       <div class="crm-submit-buttons">
-        <span class="crm-button">
-          <button type="submit" class="crm-form-submit" accesskey="S" title="{ts}Execute API call and display results{/ts}">
-            <i class="crm-i fa-bolt" aria-hidden="true"></i> {ts}Execute{/ts}
-          </button>
-        </span>
+        <button type="submit" class="crm-button crm-form-submit" accesskey="S" title="{ts}Execute API call and display results{/ts}">
+          <i class="crm-i fa-bolt" aria-hidden="true"></i> {ts}Execute{/ts}
+        </button>
       </div>
 
 <pre id="api-result" class="linenums">

--- a/templates/CRM/Admin/Page/APIExplorer.tpl
+++ b/templates/CRM/Admin/Page/APIExplorer.tpl
@@ -286,7 +286,9 @@
       </div>
       <div class="crm-submit-buttons">
         <span class="crm-button">
-          <i class="crm-i fa-bolt" aria-hidden="true"></i> <input type="submit" value="{ts}Execute{/ts}" class="crm-form-submit" accesskey="S" title="{ts}Execute API call and display results{/ts}"/>
+          <button type="submit" class="crm-form-submit" accesskey="S" title="{ts}Execute API call and display results{/ts}">
+            <i class="crm-i fa-bolt" aria-hidden="true"></i> {ts}Execute{/ts}
+          </button>
         </span>
       </div>
 

--- a/templates/CRM/Batch/Form/Entry.tpl
+++ b/templates/CRM/Batch/Form/Entry.tpl
@@ -22,9 +22,7 @@
     <div class="status message status-warning">
       <i class="crm-i fa-exclamation-triangle" aria-hidden="true"></i> {ts}Total for amounts entered below does not match the expected batch total.{/ts}
     </div>
-    <span class="crm-button crm-button_qf_Entry_upload_force-save">
-      {$form._qf_Entry_upload_force.html}
-    </span>
+    {$form._qf_Entry_upload_force.html}
     <div class="clear"></div>
   {/if}
   <table class="form-layout-compressed batch-totals">

--- a/templates/CRM/Block/Add.tpl
+++ b/templates/CRM/Block/Add.tpl
@@ -45,7 +45,7 @@
     <input type="hidden" name="qfKey" value="{crmKey name='CRM_Contact_Form_Contact' addSequence=1}" />
 </div>
 
-<div class="form-item"><input type="submit" name="_qf_Contact_next" value="{ts}Save{/ts}" class="crm-form-submit" /></div>
+<div class="form-item"><button type="submit" name="_qf_Contact_next" class="crm-button crm-form-submit">{ts}Save{/ts}</button></div>
 
 </form>
 </div>

--- a/templates/CRM/Block/FullTextSearch.tpl
+++ b/templates/CRM/Block/FullTextSearch.tpl
@@ -24,7 +24,7 @@
 <div class="block-crm crm-container">
     <form method="post" id="id_fulltext_search">
     <div style="margin-bottom: 8px;">
-    <input type="text" name="text" id='text' value="" class="crm-form-text" style="width: 10em;" />&nbsp;<input type="submit" name="submit" id="fulltext_submit" value="{ts}Go{/ts}" class="crm-form-submit"/ onclick='submitForm();'>
+    <input type="text" name="text" id='text' value="" class="crm-form-text" style="width: 10em;" />&nbsp;<button type="submit" name="submit" id="fulltext_submit" class="crm-button crm-form-submit" onclick='submitForm();'>{ts}Go{/ts}</button>
     <input type="hidden" name="qfKey" value="{crmKey name='CRM_Contact_Controller_Search' addSequence=1}" />
   </div>
   <select class="form-select" id="fulltext_table" name="fulltext_table">

--- a/templates/CRM/Contact/Form/Contact.tpl
+++ b/templates/CRM/Contact/Form/Contact.tpl
@@ -66,14 +66,10 @@
           </table>
 
           {*add dupe buttons *}
-          <span class="crm-button crm-button_qf_Contact_refresh_dedupe">
-            {$form._qf_Contact_refresh_dedupe.html}
-          </span>
+          {$form._qf_Contact_refresh_dedupe.html}
           {if $isDuplicate}
             &nbsp;&nbsp;
-              <span class="crm-button crm-button_qf_Contact_upload_duplicate">
-                {$form._qf_Contact_upload_duplicate.html}
-              </span>
+            {$form._qf_Contact_upload_duplicate.html}
           {/if}
           <div class="spacer"></div>
         </div>
@@ -212,7 +208,7 @@
     loadMultiRecordFields();
 
     {/literal}{if $oldSubtypes}{literal}
-    $('input[name=_qf_Contact_upload_view], input[name=_qf_Contact_upload_new]').click(function() {
+    $('button[name=_qf_Contact_upload_view], button[name=_qf_Contact_upload_new]').click(function() {
       var submittedSubtypes = $('#contact_sub_type').val();
       var oldSubtypes = {/literal}{$oldSubtypes}{literal};
 

--- a/templates/CRM/Contact/Form/Search/Builder.js
+++ b/templates/CRM/Contact/Form/Search/Builder.js
@@ -293,7 +293,7 @@
       })
       // Add new field - if there's a hidden one, show it
       // Otherwise allow form to submit and fetch more from the server
-      .on('click', 'input[name^=addMore]', function() {
+      .on('click', 'button[name^=addMore]', function() {
         var table = $(this).closest('table');
         if ($('tr:hidden', table).length) {
           $('tr:hidden', table).first().show();

--- a/templates/CRM/Contact/Page/View/Print.tpl
+++ b/templates/CRM/Contact/Page/View/Print.tpl
@@ -19,7 +19,7 @@
 {/literal}
 <form action="{crmURL p='civicrm/contact/view' q="cid=`$contactId`&reset=1"}" method="post" id="Print1" >
   <div class="form-item">
-       <span class="element-right"><input onclick="window.print(); return false" class="crm-form-submit default" name="_qf_Print_next" value="{ts}Print{/ts}" type="submit" />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<input class="crm-form-submit" name="_qf_Print_back" value="{ts}Done{/ts}" type="submit" /></span>
+       <span class="element-right"><button onclick="window.print(); return false" class="crm-button crm-form-submit default" name="_qf_Print_next" type="submit">{ts}Print{/ts}</button>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<button class="crm-button crm-form-submit" name="_qf_Print_back" type="submit">{ts}Done{/ts}</button></span>
   </div>
 </form>
 <br />

--- a/templates/CRM/Contribute/Form/Contribution/PremiumBlock.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/PremiumBlock.tpl
@@ -62,7 +62,7 @@
               <div class="premium-full-title">{$row.name}</div>
               <div class="premium-full-disabled">
                 {ts 1=$row.min_contribution|crmMoney}You must contribute at least %1 to get this item{/ts}<br/>
-                <input type="button" value="{ts 1=$row.min_contribution|crmMoney}Contribute %1 Instead{/ts}" amount="{$row.min_contribution}" />
+                <button type="button" value="{ts 1=$row.min_contribution|crmMoney}Contribute %1 Instead{/ts}" amount="{$row.min_contribution}" />
               </div>
               <div class="premium-full-description">
                 {$row.description}
@@ -235,7 +235,7 @@
         amounts.sort(function(a,b){return a - b});
 
         // make contribution instead buttons work
-        $('.premium-full-disabled input').click(function(){
+        $('.premium-full-disabled button').click(function(){
           var amount = Number($(this).attr('amount'));
           if (price_sets[amount]) {
             if (!$(price_sets[amount]).length) {
@@ -347,4 +347,3 @@
     {/literal}
   {/if}
 {/if}
-

--- a/templates/CRM/Event/Form/ManageEvent/Registration.tpl
+++ b/templates/CRM/Event/Form/ManageEvent/Registration.tpl
@@ -396,7 +396,7 @@ invert              = 0
 <script type="text/javascript">
 {literal}    (function($, _) { // Generic Closure
 
-    $(".crm-submit-buttons input").click( function() {
+    $(".crm-submit-buttons button").click( function() {
       $(".dedupenotify .ui-notify-close").click();
     });
 

--- a/templates/CRM/Mailing/Page/Event.tpl
+++ b/templates/CRM/Mailing/Page/Event.tpl
@@ -56,7 +56,7 @@
   <script type="text/javascript">
     var totalPages = {/literal}{$pager->_totalPages}{literal};
     CRM.$(function($) {
-      $("#crm-container .crm-pager input.crm-form-submit").click(function () {
+      $("#crm-container .crm-pager button.crm-form-submit").click(function () {
         submitPagerData(this);
       });
     });

--- a/templates/CRM/Mailing/Page/Resubscribe.tpl
+++ b/templates/CRM/Mailing/Page/Resubscribe.tpl
@@ -18,9 +18,9 @@
 {ts 1=$display_name 2=$email}Are you sure you want to resubscribe: %1 (%2){/ts}
 <br/>
 <center>
-<input type="submit" name="_qf_resubscribe_next" value="{ts}Resubscribe{/ts}" class="crm-form-submit" />
+<button type="submit" name="_qf_resubscribe_next" class="crm-button crm-form-submit">{ts}Resubscribe{/ts}</button>
 &nbsp;&nbsp;&nbsp;
-<input type="submit" name="_qf_resubscribe_cancel" value="{ts}Cancel{/ts}" class="crm-form-submit" />
+<button type="submit" name="_qf_resubscribe_cancel" class="crm-button crm-form-submit">{ts}Cancel{/ts}</button>
 </center>
 </form>
 </div>

--- a/templates/CRM/Profile/Form/Dynamic.tpl
+++ b/templates/CRM/Profile/Form/Dynamic.tpl
@@ -19,7 +19,7 @@
   </div>
 
   <div class="crm-submit-buttons">
-    <span class="crm-button">{$form._qf_Edit_upload_delete.html}</span>
+    {$form._qf_Edit_upload_delete.html}
     {if $includeCancelButton}
       <a class="button cancel" href="{$cancelURL}">{$cancelButtonText}</a>
     {/if}
@@ -37,7 +37,7 @@
 
   {if $isDuplicate and ( ($action eq 1 and $mode eq 4 ) or ($action eq 2) or ($action eq 8192) ) }
     <div class="crm-submit-buttons">
-      <span class="crm-button">{$form._qf_Edit_upload_duplicate.html}</span>
+      {$form._qf_Edit_upload_duplicate.html}
     </div>
   {/if}
   {if $mode eq 1 || $activeComponent neq "CiviCRM"}
@@ -53,7 +53,7 @@
     {if $action eq 2 and $multiRecordFieldListing}
       <h1>{ts}Edit Details{/ts}</h1>
       <div class="crm-submit-buttons" style='float:right'>
-      {include file="CRM/common/formButtons.tpl"}{if $isDuplicate}<span class="crm-button">{$form._qf_Edit_upload_duplicate.html}</span>{/if}
+      {include file="CRM/common/formButtons.tpl"}{if $isDuplicate}{$form._qf_Edit_upload_duplicate.html}{/if}
       </div>
     {/if}
 
@@ -209,7 +209,7 @@
         </div>
       {/if}
       <div class="crm-submit-buttons" style='{$floatStyle}'>
-        {include file="CRM/common/formButtons.tpl"}{if $isDuplicate}<span class="crm-button">{$form._qf_Edit_upload_duplicate.html}</span>{/if}
+        {include file="CRM/common/formButtons.tpl"}{if $isDuplicate}{$form._qf_Edit_upload_duplicate.html}{/if}
         {if $includeCancelButton}
           <a class="button cancel" href="{$cancelURL}">
             <span>

--- a/templates/CRM/Report/Form/Layout/Graph.tpl
+++ b/templates/CRM/Report/Form/Layout/Graph.tpl
@@ -35,6 +35,7 @@
            createChart( chartID, divName, chartValues.size.xSize, chartValues.size.ySize, allData[chartID].object );
          });
 
+         // FIXME
          $("input[id$='submit_print'],input[id$='submit_pdf']").bind('click', function(e){
            // image creator php file path and append image name
            var url = CRM.url('civicrm/report/chart', 'name=' + '{/literal}{$chartId}{literal}' + '.png');

--- a/templates/CRM/common/TabHeader.js
+++ b/templates/CRM/common/TabHeader.js
@@ -23,7 +23,7 @@ CRM.$(function($) {
           params.autoClose = params.openInline = params.cancelButton = params.refreshAction = false;
           ui.panel.on('crmFormLoad', function() {
             // Hack: "Save and done" and "Cancel" buttons submit without ajax
-            $('.cancel.crm-form-submit, input[name$=upload_done]', this).on('click', function(e) {
+            $('.cancel.crm-form-submit, button[name$=upload_done]', this).on('click', function(e) {
               $(this).closest('form').ajaxFormUnbind();
             });
           });

--- a/templates/CRM/common/deferredFinancialType.tpl
+++ b/templates/CRM/common/deferredFinancialType.tpl
@@ -12,7 +12,7 @@
 {literal}
 <script type="text/javascript">
 CRM.$(function($) {
-  var more = $('.crm-button input.validate').click(function(e) {
+  var more = $('.crm-button.validate').click(function(e) {
     var message = "{/literal} {if $context eq 'Event'}
         {ts escape='js'}Note: Revenue for this event registration will not be deferred as the financial type does not have a deferred revenue account setup for it. If you want the revenue to be deferred, please select a different Financial Type with a Deferred Revenue account setup for it, or setup a Deferred Revenue account for this Financial Type.{/ts}
       {else if $context eq 'MembershipType'}

--- a/templates/CRM/common/formButtons.tpl
+++ b/templates/CRM/common/formButtons.tpl
@@ -28,20 +28,13 @@
   {/foreach}
 {/if}
 
-{* Loops through $form.buttons.html array and assigns separate spans with classes to allow theming by button and name.
- * crmBtnType grabs type keyword from button name (e.g. 'upload', 'next', 'back', 'cancel') so types of buttons can be styled differently via css.
- *}
 {foreach from=$form.buttons item=button key=key name=btns}
   {if $key|substring:0:4 EQ '_qf_'}
     {if $location}
-      {assign var='html' value=$form.buttons.$key.html|crmReplace:id:"$key-$location"}
+      {$form.buttons.$key.html|crmReplace:id:"$key-$location"}
     {else}
-      {assign var='html' value=$form.buttons.$key.html}
+      {$form.buttons.$key.html}
     {/if}
-    {crmGetAttribute html=$html attr='disabled' assign='disabled'}
-    <span class="crm-button crm-button-type-{$key|crmBtnType} crm-button{$key}{if $disabled} crm-button-disabled{/if}"{if $buttonStyle} style="{$buttonStyle}"{/if}>
-      {$html}
-    </span>
   {/if}
 {/foreach}
 {/crmRegion}

--- a/templates/CRM/common/formButtons.tpl
+++ b/templates/CRM/common/formButtons.tpl
@@ -38,14 +38,8 @@
     {else}
       {assign var='html' value=$form.buttons.$key.html}
     {/if}
-    {crmGetAttribute html=$html attr='crm-icon' assign='icon'}
-    {capture assign=iconPrefix}{$icon|truncate:3:"":true}{/capture}
-    {if $icon && $iconPrefix eq 'fa-'}
-      {capture assign=iconDisp}<i class="crm-i {$icon}" aria-hidden="true"></i>{/capture}
-    {/if}
     {crmGetAttribute html=$html attr='disabled' assign='disabled'}
     <span class="crm-button crm-button-type-{$key|crmBtnType} crm-button{$key}{if $disabled} crm-button-disabled{/if}"{if $buttonStyle} style="{$buttonStyle}"{/if}>
-      {$iconDisp}
       {$html}
     </span>
   {/if}

--- a/templates/CRM/common/navigation.js.tpl
+++ b/templates/CRM/common/navigation.js.tpl
@@ -17,7 +17,7 @@
             <input type="hidden" name="hidden_location" value="1" />
             <input type="hidden" name="hidden_custom" value="1" />
             <input type="hidden" name="qfKey" value="" />
-            <div style="height:1px; overflow:hidden;"><input type="submit" value="{ts}Go{/ts}" name="_qf_Advanced_refresh" class="crm-form-submit default" /></div>
+            <div style="height:1px; overflow:hidden;"><button type="submit" name="_qf_Advanced_refresh" class="crm-button crm-form-submit default">{ts}Go{/ts}</button></div>
           </div>
         </form>
         <ul>


### PR DESCRIPTION
Overview
----------------------------------------
In #18005 I caused problems in trying to make `<input type="submit">` elements look like `<a class="button">` elements as part of displaying icons inline.  Ultimately, the issue is that `<input type="submit">` elements can't contain any markup: the `value` is just text.  CiviCRM works around this by wrapping the input and icon in a `crm-button` class.  However, unless you adopt a hacky approach, the only clickable part of it is the input itself (as reported by @demeritcowboy [here](https://github.com/civicrm/civicrm-core/pull/18005#issuecomment-669936497)).

This PR replaces all of these `<input type="submit">` elements with `<button type="submit">` (and `<input type="button">` elements with `<button type="button">`). I also straightens out a bunch of consequences of this in terms of CSS and jQuery selectors.

Before
----------------------------------------
`<input type="submit">` everywhere

After
----------------------------------------
`<button type="submit">` everywhere

Technical Details
----------------------------------------
Just to make things fun, Quickform calls `<button>` elements "xbutton" because they turn "button" types into `<input type="button">`.

Comments
----------------------------------------
This probably should go as a PR to 5.29 eventually.
