### PR TITLE
dev/core#1905 force backend links for new "configure" buttons

### DIFF
--- a/templates/CRM/Contribute/Form/Contribution/Main.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Main.tpl
@@ -58,7 +58,7 @@
 
   {if call_user_func(array('CRM_Core_Permission','check'), 'administer CiviCRM') }
     {capture assign="buttonTitle"}{ts}Configure Contribution Page{/ts}{/capture}
-    {crmButton target="_blank" p="civicrm/admin/contribute/settings" q="reset=1&action=update&id=`$contributionPageID`" title="$buttonTitle" icon="fa-wrench"}{ts}Configure{/ts}{/crmButton}
+    {crmButton target="_blank" p="civicrm/admin/contribute/settings" q="reset=1&action=update&id=`$contributionPageID`" fb=1 title="$buttonTitle" icon="fa-wrench"}{ts}Configure{/ts}{/crmButton}
     <div class='clear'></div>
   {/if}
   {include file="CRM/common/TrackingFields.tpl"}

--- a/templates/CRM/Event/Form/Registration/Register.tpl
+++ b/templates/CRM/Event/Form/Registration/Register.tpl
@@ -9,7 +9,7 @@
 *}
 {if call_user_func(array('CRM_Core_Permission','check'), 'administer CiviCRM') }
   {capture assign="buttonTitle"}{ts}Configure Event{/ts}{/capture}
-  {crmButton target="_blank" p="civicrm/event/manage/settings" q="reset=1&action=update&id=`$event.id`" title="$buttonTitle" icon="fa-wrench"}{ts}Configure{/ts}{/crmButton}
+  {crmButton target="_blank" p="civicrm/event/manage/settings" q="reset=1&action=update&id=`$event.id`" fb=1 title="$buttonTitle" icon="fa-wrench"}{ts}Configure{/ts}{/crmButton}
   <div class='clear'></div>
 {/if}
 {* Callback snippet: Load payment processor *}

--- a/templates/CRM/Price/Form/PriceSet.tpl
+++ b/templates/CRM/Price/Form/PriceSet.tpl
@@ -18,7 +18,7 @@
       {assign var='adminFld' value=true}
       {if $priceSet.id && !$priceSet.is_quick_config}
         <div class='float-right'>
-          <a class="crm-hover-button" target="_blank" href="{crmURL p="civicrm/admin/price/field" q="reset=1&action=browse&sid=`$priceSet.id`"}">
+          <a class="crm-hover-button" target="_blank" href="{crmURL p="civicrm/admin/price/field" q="reset=1&action=browse&sid=`$priceSet.id`" fb=1}">
             {icon icon="fa-wrench"}{ts}Edit Price Set{/ts}{/icon}
           </a>
         </div>


### PR DESCRIPTION
Overview
----------------------------------------
The "Configure" buttons added in #17942 and edited in #18064 generate frontend links in WordPress and Joomla.  This modifies them to force backend links.

Before
----------------------------------------
Link attempts to load admin form on frontend in CMSes with distinct front and back ends.

After
----------------------------------------
Backend link formed where appropriate.
