### PR TITLE
[REF] Fix jquery validation for on behalf of fields when combined wit…

### DIFF
--- a/templates/CRM/Contribute/Form/Contribution/PremiumBlock.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/PremiumBlock.tpl
@@ -332,8 +332,6 @@
           $('#selectProduct').rules('add', 'premiums');
         });
 
-        // need to use jquery validate's ignore option, so that it will not ignore hidden fields
-        CRM.validate.params['ignore'] = '.ignore';
       });
     </script>
     {/literal}


### PR DESCRIPTION
…h a preimum

Overview
----------------------------------------
This fixes a bug in our jquery validation code, in that If you have a contribution page that offers premiums and you also have the option to contribute on behalf of others, if you don't elect to contribute on behalf of the org the page fails to validate because these links incorrectly blow away the configuration needed to ignore the hidden on behalf of fields

Before
----------------------------------------
Contribution Page fails to validate correctly when having on behalf of fields and premiums on the same page

After
----------------------------------------
Contribution Page validation works correctly

Technical Details
----------------------------------------
The issue is that this overrides the ignore key of the params which then causes it to override the _defaults as per https://github.com/civicrm/civicrm-core/blob/master/js/Common.js#L884 so this fixes it by removing that override

ping @eileenmcnaughton @mattwire @demeritcowboy 