### PR TITLE
CodeGen - Add use statement to extensions DAO files

### DIFF
--- a/CRM/Core/CodeGen/DAO.php
+++ b/CRM/Core/CodeGen/DAO.php
@@ -75,17 +75,8 @@ class CRM_Core_CodeGen_DAO extends CRM_Core_CodeGen_BaseTask {
       return;
     }
 
-    $template = new CRM_Core_CodeGen_Util_Template('php');
-    $template->assign('table', $this->tables[$this->name]);
-    if (empty($this->tables[$this->name]['index'])) {
-      $template->assign('indicesPhp', var_export([], 1));
-    }
-    else {
-      $template->assign('indicesPhp', var_export($this->tables[$this->name]['index'], 1));
-    }
+    $template = $this->getTemplate();
     $template->assign('genCodeChecksum', $this->getTableChecksum());
-    $template->assign('tsFunctionName', $this->tsFunctionName);
-    $template->assign('useHelper', $this->useHelper);
     $template->run('dao.tpl', $this->getAbsFileName());
   }
 
@@ -96,20 +87,28 @@ class CRM_Core_CodeGen_DAO extends CRM_Core_CodeGen_BaseTask {
    */
   public function getRaw() {
     if (!$this->raw) {
-      $template = new CRM_Core_CodeGen_Util_Template('php');
-      $template->assign('table', $this->tables[$this->name]);
-      if (empty($this->tables[$this->name]['index'])) {
-        $template->assign('indicesPhp', var_export([], 1));
-      }
-      else {
-        $template->assign('indicesPhp', var_export($this->tables[$this->name]['index'], 1));
-      }
+      $template = $this->getTemplate();
       $template->assign('genCodeChecksum', 'NEW');
-      $template->assign('tsFunctionName', $this->tsFunctionName);
-      $template->assign('useHelper', $this->useHelper);
       $this->raw = $template->fetch('dao.tpl');
     }
     return $this->raw;
+  }
+
+  /**
+   * @return CRM_Core_CodeGen_Util_Template
+   */
+  private function getTemplate() {
+    $template = new CRM_Core_CodeGen_Util_Template('php');
+    $template->assign('table', $this->tables[$this->name]);
+    if (empty($this->tables[$this->name]['index'])) {
+      $template->assign('indicesPhp', var_export([], 1));
+    }
+    else {
+      $template->assign('indicesPhp', var_export($this->tables[$this->name]['index'], 1));
+    }
+    $template->assign('tsFunctionName', $this->tsFunctionName);
+    $template->assign('useHelper', $this->useHelper);
+    return $template;
   }
 
   /**

--- a/CRM/Core/CodeGen/DAO.php
+++ b/CRM/Core/CodeGen/DAO.php
@@ -26,6 +26,8 @@ class CRM_Core_CodeGen_DAO extends CRM_Core_CodeGen_BaseTask {
    */
   private $tsFunctionName;
 
+  private $useHelper = '';
+
   /**
    * CRM_Core_CodeGen_DAO constructor.
    *
@@ -37,6 +39,11 @@ class CRM_Core_CodeGen_DAO extends CRM_Core_CodeGen_BaseTask {
     parent::__construct($config);
     $this->name = $name;
     $this->tsFunctionName = $tsFunctionName;
+    // Cleanup helper class with a use statement
+    if (strpos($tsFunctionName, '::ts')) {
+      $this->tsFunctionName = 'E::ts';
+      $this->useHelper = 'use \\' . explode('::', $tsFunctionName)[0] . ' as E;';
+    }
   }
 
   /**
@@ -78,6 +85,7 @@ class CRM_Core_CodeGen_DAO extends CRM_Core_CodeGen_BaseTask {
     }
     $template->assign('genCodeChecksum', $this->getTableChecksum());
     $template->assign('tsFunctionName', $this->tsFunctionName);
+    $template->assign('useHelper', $this->useHelper);
     $template->run('dao.tpl', $this->getAbsFileName());
   }
 
@@ -98,6 +106,7 @@ class CRM_Core_CodeGen_DAO extends CRM_Core_CodeGen_BaseTask {
       }
       $template->assign('genCodeChecksum', 'NEW');
       $template->assign('tsFunctionName', $this->tsFunctionName);
+      $template->assign('useHelper', $this->useHelper);
       $this->raw = $template->fetch('dao.tpl');
     }
     return $this->raw;

--- a/CRM/Core/CodeGen/Util/Template.php
+++ b/CRM/Core/CodeGen/Util/Template.php
@@ -78,6 +78,7 @@ class CRM_Core_CodeGen_Util_Template {
         '=> true,' => '=> TRUE,',
         '=> false,' => '=> FALSE,',
         'static ::' => 'static::',
+        'use\\' => 'use \\',
       ];
       $contents = str_replace(array_keys($replacements), array_values($replacements), $contents);
       $contents = preg_replace('#(\s*)\\/\\*\\*#', "\n\$1/**", $contents);

--- a/xml/templates/dao.tpl
+++ b/xml/templates/dao.tpl
@@ -7,7 +7,7 @@
  * {$generated}
  * (GenCodeChecksum:{$genCodeChecksum})
  */
-
+{$useHelper}
 /**
  * Database access object for the {$table.entity} entity.
  */

--- a/xml/templates/dao.tpl
+++ b/xml/templates/dao.tpl
@@ -60,7 +60,7 @@ class {$table.className} extends CRM_Core_DAO {ldelim}
      * Returns localized title of this entity.
      */
     public static function getEntityTitle() {ldelim}
-        return ts('{$table.title}');
+        return {$tsFunctionName}('{$table.title}');
     {rdelim}
 
 


### PR DESCRIPTION
Overview
----------------------------------------
Cleans up extensions' DAO files with a `use` statement instead of repetitive references to the helper class.

Before
----------------------------------------
DAO file littered with `CRM_Contactlayout_ExtensionUtil::ts()`

After
----------------------------------------
Single `use CRM_Contactlayout_ExtensionUtil as E;` at the top, then `E::ts()` throughout.
