### PR TITLE
dev/core#1926 - Towards supporting SSL for mysql connections - remove DB::connect that doesn't add anything

### DIFF
--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -717,15 +717,12 @@ class CRM_Utils_System {
      * process typically done in CLI and cron scripts. See: CRM-12648
      *
      * Q: Can we move this to the userSystem class so that it can be tuned
-     * per-CMS? For example, when dealing with UnitTests UF, there's no
-     * userFrameworkDSN.
+     * per-CMS? For example, when dealing with UnitTests UF, does it need to
+     * do this session write since the original issue was for Drupal.
      */
     $session = CRM_Core_Session::singleton();
     $session->set('civicrmInitSession', TRUE);
 
-    if ($config->userFrameworkDSN) {
-      $dbDrupal = DB::connect($config->userFrameworkDSN);
-    }
     return $config->userSystem->authenticate($name, $password, $loadCMSBootstrap, $realPath);
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/1926

The context is I'm updating all the places that need updating to allow for SSL.

I've been trying to see why this line is here. Even when [it was added](https://github.com/civicrm/civicrm-core/commit/c1e1e8b8280c7bf8b6cbf284c6bd54a781402b4c) for [CRM-12648](https://issues.civicrm.org/jira/browse/CRM-12648) it seems like it was misplaced, since even in that same tree as the commit the call to the drupal UF class does the [exact same connect  call](https://github.com/civicrm/civicrm-core/blob/bd28ecf8121a85bc069cad3ab912a0c3dff8fdc5/CRM/Utils/System/Drupal.php#L320) a few milliseconds later, and it doesn't have anything to do with the session as discussed in the issue.

Technical Details
----------------------------------------
Note that wordpress, joomla, and even drupal 8 don't do anything like this, they use CMS functions. So it's just drupal 7 (and I suspect even that's not necessary anymore but is a separate question).

Also note that cv and REST don't go thru here. You can trigger it as in the jira via http cron, or via bin/cli.php, e.g.

`curl http://your-site/sites/all/modules/civicrm/bin/cron.php?name=admin\&pass=password\&key=the_site_key`

or

`php bin/cli.php -u [cms username] -p [password] -e Job -a execute`

Both seem to run fine without the DB::connect line, because it doesn't add anything.

I can't see how to even test this on drupal 8 since none of those methods work anyway.


Comments
----------------------------------------