### PR TITLE
Allow overriding participant_status_id in Order API

### DIFF
--- a/CRM/Event/BAO/ParticipantStatusType.php
+++ b/CRM/Event/BAO/ParticipantStatusType.php
@@ -100,6 +100,29 @@ class CRM_Event_BAO_ParticipantStatusType extends CRM_Event_DAO_ParticipantStatu
   }
 
   /**
+   * Checks if status_id (id or string (eg. 5 or "Pending from pay later") is allowed for class
+   *
+   * @param int|string $status_id
+   * @param string $class
+   *
+   * @return bool
+   */
+  public static function getIsValidStatusForClass($status_id, $class = 'Pending') {
+    $classParticipantStatuses = civicrm_api3('ParticipantStatusType', 'get', [
+      'class' => $class,
+      'is_active' => 1,
+    ])['values'];
+    $allowedParticipantStatuses = [];
+    foreach ($classParticipantStatuses as $id => $detail) {
+      $allowedParticipantStatuses[$id] = $detail['name'];
+    }
+    if (in_array($status_id, $allowedParticipantStatuses) || array_key_exists($status_id, $allowedParticipantStatuses)) {
+      return TRUE;
+    }
+    return FALSE;
+  }
+
+  /**
    * @param array $params
    *
    * @return array

--- a/api/v3/Order.php
+++ b/api/v3/Order.php
@@ -93,7 +93,12 @@ function civicrm_api3_order_create($params) {
         $supportedEntity = TRUE;
         switch ($entity) {
           case 'participant':
-            $entityParams['status_id'] = 'Pending from incomplete transaction';
+            if (isset($entityParams['participant_status_id'])
+              && (!CRM_Event_BAO_ParticipantStatusType::getIsValidStatusForClass($entityParams['participant_status_id'], 'Pending'))) {
+              throw new CiviCRM_API3_Exception('Creating a participant via the Order API with a non "pending" status is not supported');
+            }
+            $entityParams['participant_status_id'] = $entityParams['participant_status_id'] ?? 'Pending from incomplete transaction';
+            $entityParams['status_id'] = $entityParams['participant_status_id'];
             break;
 
           case 'membership':


### PR DESCRIPTION
Overview
----------------------------------------
Allow overriding/specifying `participant_status_id` in Order API.

Before
----------------------------------------
`participant_status_id` is hardcoded.

After
----------------------------------------
`participant_status_id` can be specified in params to order API. Otherwise it will follow existing logic.

Technical Details
----------------------------------------
Currently used by #17886 to specify "Pending in cart" as initial participant status.

Comments
----------------------------------------
