### PR TITLE
There is no "I" in mysqli - oh wait there is

### DIFF
--- a/templates/CRM/common/civicrm.settings.php.template
+++ b/templates/CRM/common/civicrm.settings.php.template
@@ -70,10 +70,10 @@ if (!defined('CIVICRM_UF')) {
  * If any of these contain a single quote or backslash, escape those characters with a backslash: \' and \\, respectively.
  *
  * Datasource (DSN) format:
- *      define( 'CIVICRM_UF_DSN', 'mysql://cms_db_username:cms_db_password@db_server/cms_database?new_link=true');
+ *      define( 'CIVICRM_UF_DSN', 'mysqli://cms_db_username:cms_db_password@db_server/cms_database?new_link=true');
  */
 if (!defined('CIVICRM_UF_DSN') && CIVICRM_UF !== 'UnitTests') {
-  define( 'CIVICRM_UF_DSN'           , 'mysql://%%CMSdbUser%%:%%CMSdbPass%%@%%CMSdbHost%%/%%CMSdbName%%?new_link=true');
+  define( 'CIVICRM_UF_DSN'           , 'mysqli://%%CMSdbUser%%:%%CMSdbPass%%@%%CMSdbHost%%/%%CMSdbName%%?new_link=true');
 }
 
 // %%extraSettings%%
@@ -83,19 +83,19 @@ if (!defined('CIVICRM_UF_DSN') && CIVICRM_UF !== 'UnitTests') {
  *
  * Database URL (CIVICRM_DSN) for CiviCRM Data:
  * Database URL format:
- *      define( 'CIVICRM_DSN', 'mysql://crm_db_username:crm_db_password@db_server/crm_database?new_link=true');
+ *      define( 'CIVICRM_DSN', 'mysqli://crm_db_username:crm_db_password@db_server/crm_database?new_link=true');
  *
  * Drupal and CiviCRM can share the same database, or can be installed into separate databases.
  * Backdrop CMS and CiviCRM can also share the same database, or can be installed into separate databases.
  *
  * EXAMPLE: Drupal/Backdrop and CiviCRM running in the same database...
  *      DB Name = cms, DB User = cms
- *      define( 'CIVICRM_DSN'         , 'mysql://cms:YOUR_PASSWORD@localhost/cms?new_link=true');
+ *      define( 'CIVICRM_DSN'         , 'mysqli://cms:YOUR_PASSWORD@localhost/cms?new_link=true');
  *
  * EXAMPLE: Drupal/Backdrop and CiviCRM running in separate databases...
  *      CMS DB Name = cms, DB User = cms
  *      CiviCRM DB Name = civicrm, CiviCRM DB User = civicrm
- *      define( 'CIVICRM_DSN'         , 'mysql://civicrm:YOUR_PASSWORD@localhost/civicrm?new_link=true');
+ *      define( 'CIVICRM_DSN'         , 'mysqli://civicrm:YOUR_PASSWORD@localhost/civicrm?new_link=true');
  *
  * If your username, password, server or DB name contain a single quote or backslash, escape those characters
  * with a backslash: \' and \\, respectively.
@@ -106,7 +106,7 @@ if (!defined('CIVICRM_DSN')) {
     define('CIVICRM_DSN', $GLOBALS['_CV']['TEST_DB_DSN']);
   }
   else {
-    define('CIVICRM_DSN', 'mysql://%%dbUser%%:%%dbPass%%@%%dbHost%%/%%dbName%%?new_link=true');
+    define('CIVICRM_DSN', 'mysqli://%%dbUser%%:%%dbPass%%@%%dbHost%%/%%dbName%%?new_link=true');
   }
 }
 


### PR DESCRIPTION
Overview
----------------------------------------
Update civicrm.settings.php template to use `mysqli` going forward instead of `mysql`.

php-mysql was removed in php 7.0. Civi has a patch to silently convert on the fly if you still have mysql in your settings file, but for new installs it should say mysqli.