### PR TITLE
dev/event#40 - EventCart - Check legacy setting until extension is public

### DIFF
--- a/ext/eventcart/eventcart.php
+++ b/ext/eventcart/eventcart.php
@@ -15,7 +15,10 @@ function eventcart_civicrm_config(&$config) {
     return;
   }
   Civi::$statics[__FUNCTION__] = 1;
-  Civi::dispatcher()->addListener('hook_civicrm_pageRun', 'CRM_Event_Cart_PageCallback::run');
+  // Since as a hidden extension it's always enabled, until this is a "real" extension you can turn off we need to check the legacy setting.
+  if ((bool) Civi::settings()->get('enable_cart')) {
+    Civi::dispatcher()->addListener('hook_civicrm_pageRun', 'CRM_Event_Cart_PageCallback::run');
+  }
 
   _eventcart_civix_civicrm_config($config);
 }


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/event/-/issues/40

As a hidden extension it's always enabled. Until this is a "real" extension that you can turn off we need to check the legacy setting before it starts doing stuff.

Before
----------------------------------------
On 5.29+, AddToCart is always enabled on event info pages, regardless of the CiviEvent component setting.

After
----------------------------------------
Only enabled if the setting is checked.

Technical Details
----------------------------------------


Comments
----------------------------------------

