### PR TITLE
Update civicrm_value_price_field.name definition in database not updated in 5.27

### DIFF
--- a/CRM/Upgrade/Incremental/sql/5.29.beta1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.29.beta1.mysql.tpl
@@ -1,1 +1,4 @@
 {* file to handle db changes in 5.29.beta1 during upgrade *}
+-- It's really unlikely to be null, but if so just make it something unique.
+UPDATE civicrm_price_field_value SET `name` = CONCAT('name', LEFT(SHA1(id), 12)) WHERE `name` IS NULL;
+ALTER TABLE civicrm_price_field_value CHANGE `name` `name` varchar(255) NOT NULL COMMENT 'Price field option name';


### PR DESCRIPTION
Overview
----------------------------------------
As part of [this change](https://github.com/civicrm/civicrm-core/pull/17363/files#diff-fd197913929fa922fddbfda72798e280) in 5.27, the `name` field was made not null along with `label`. But the [upgrade script](https://github.com/civicrm/civicrm-core/commit/9d810a94abeeb6afc710b1d8ec0d88ed76fbd4ea#diff-3cda2805b20e244cccecf2bc0fd99198) only updated `label`.

It's unlikely to cause problems because name is probably enforced in other places, but it should be consistent with the xml schema definition.

Before
----------------------------------------
Probably fine.

After
----------------------------------------
Probably fine.

Technical Details
----------------------------------------

Comments
----------------------------------------
I don't know if there's a standard way of making a unique arbitrary `name`, so I just made one up that should work here, in the edge case where somehow they have name=NULL.