### PR TITLE
dev/core#1926 - Allow SSL mysql connections for civicrm-setup

### DIFF
--- a/Civi/Install/Requirements.php
+++ b/Civi/Install/Requirements.php
@@ -132,7 +132,24 @@ class Requirements {
     elseif (!empty($db_config['server'])) {
       $host = $db_config['server'];
     }
-    $conn = @mysqli_connect($host, $db_config['username'], $db_config['password'], $db_config['database'], !empty($db_config['port']) ? $db_config['port'] : NULL);
+    if (empty($db_config['ssl_params'])) {
+      $conn = @mysqli_connect($host, $db_config['username'], $db_config['password'], $db_config['database'], !empty($db_config['port']) ? $db_config['port'] : NULL);
+    }
+    else {
+      $conn = NULL;
+      $init = mysqli_init();
+      mysqli_ssl_set(
+        $init,
+        $db_config['ssl_params']['key'] ?? NULL,
+        $db_config['ssl_params']['cert'] ?? NULL,
+        $db_config['ssl_params']['ca'] ?? NULL,
+        $db_config['ssl_params']['capath'] ?? NULL,
+        $db_config['ssl_params']['cipher'] ?? NULL
+      );
+      if (@mysqli_real_connect($init, $host, $db_config['username'], $db_config['password'], $db_config['database'], (!empty($db_config['port']) ? $db_config['port'] : NULL), NULL, MYSQLI_CLIENT_SSL)) {
+        $conn = $init;
+      }
+    }
     return $conn;
   }
 

--- a/setup/plugins/checkRequirements/CheckDbWellFormed.civi-setup.php
+++ b/setup/plugins/checkRequirements/CheckDbWellFormed.civi-setup.php
@@ -23,19 +23,24 @@ if (!defined('CIVI_SETUP')) {
       $expectedKeys = array('server', 'username', 'password', 'database');
       sort($expectedKeys);
       if ($keys !== $expectedKeys) {
-        $e->addError('database', $dbField, sprintf("The database credentials for \"%s\" should be specified as (%s) not (%s)",
-          $dbField,
-          implode(',', $expectedKeys),
-          implode(',', $keys)
-        ));
-        $errors++;
+        // if it failed it might be because of the optional ssl parameters
+        $expectedKeys[] = 'ssl_params';
+        sort($expectedKeys);
+        if ($keys !== $expectedKeys) {
+          $e->addError('database', $dbField, sprintf("The database credentials for \"%s\" should be specified as (%s) not (%s)",
+            $dbField,
+            implode(',', $expectedKeys),
+            implode(',', $keys)
+          ));
+          $errors++;
+        }
       }
 
       foreach ($db as $k => $v) {
         if ($k === 'password' && empty($v)) {
           $e->addWarning('database', "$dbField.$k", "The property \"$dbField.$k\" is blank. This may be correct in some controlled environments; it could also be a mistake or a symptom of an insecure configuration.");
         }
-        elseif (!is_scalar($v)) {
+        elseif ($k !== 'ssl_params' && !is_scalar($v)) {
           $e->addError('database', "$dbField.$k", "The property \"$dbField.$k\" is not well-formed.");
           $errors++;
         }

--- a/setup/plugins/checkRequirements/CoreRequirementsAdapter.civi-setup.php
+++ b/setup/plugins/checkRequirements/CoreRequirementsAdapter.civi-setup.php
@@ -29,6 +29,7 @@ if (!defined('CIVI_SETUP')) {
       'username' => $model->db['username'],
       'password' => $model->db['password'],
       'database' => $model->db['database'],
+      'ssl_params' => $model->db['ssl_params'] ?? NULL,
     ));
     _corereqadapter_addMessages($e, 'database', $dbMsgs);
   });

--- a/setup/plugins/installFiles/InstallSettingsFile.civi-setup.php
+++ b/setup/plugins/installFiles/InstallSettingsFile.civi-setup.php
@@ -59,6 +59,13 @@ if (!defined('CIVI_SETUP')) {
     $params['dbPass'] = addslashes($m->db['password']);
     $params['dbHost'] = addslashes($m->db['server']);
     $params['dbName'] = addslashes($m->db['database']);
+    // The '&' prefix is awkward, but we don't know what's already in the file.
+    // At the time of writing, it has ?new_link=true. If that is removed,
+    // then need to update this.
+    // The PHP_QUERY_RFC3986 is important because PEAR::DB will interpret plus
+    // signs as a reference to its old DSN format and mangle the DSN, so we
+    // need to use %20 for spaces.
+    $params['dbSSL'] = empty($m->db['ssl_params']) ? '' : addslashes('&' . http_build_query($m->db['ssl_params'], '', '&', PHP_QUERY_RFC3986));
     $params['cms'] = addslashes($m->cms);
     $params['CMSdbUser'] = addslashes($m->cmsDb['username']);
     $params['CMSdbPass'] = addslashes($m->cmsDb['password']);

--- a/templates/CRM/common/civicrm.settings.php.template
+++ b/templates/CRM/common/civicrm.settings.php.template
@@ -106,7 +106,7 @@ if (!defined('CIVICRM_DSN')) {
     define('CIVICRM_DSN', $GLOBALS['_CV']['TEST_DB_DSN']);
   }
   else {
-    define('CIVICRM_DSN', 'mysql://%%dbUser%%:%%dbPass%%@%%dbHost%%/%%dbName%%?new_link=true');
+    define('CIVICRM_DSN', 'mysql://%%dbUser%%:%%dbPass%%@%%dbHost%%/%%dbName%%?new_link=true%%dbSSL%%');
   }
 }
 

--- a/tests/phpunit/Civi/Setup/DbUtilTest.php
+++ b/tests/phpunit/Civi/Setup/DbUtilTest.php
@@ -1,0 +1,59 @@
+<?php
+namespace Civi\Setup;
+
+/**
+ * Class DbUtilTest
+ * @package Civi\Setup
+ * @group headless
+ */
+class DbUtilTest extends \CiviUnitTestCase {
+
+  /**
+   * Test parseSSL
+   * @dataProvider queryStringProvider
+   * @param string $input
+   * @param array $expected
+   */
+  public function testParseSSL(string $input, array $expected) {
+    $this->assertSame($expected, \Civi\Setup\DbUtil::parseSSL($input));
+  }
+
+  /**
+   * Data provider for testParseSSL
+   * @return array
+   */
+  public function queryStringProvider():array {
+    return [
+      ['', []],
+      ['new_link=true', []],
+      ['ssl=1', ['ssl' => '1']],
+      ['new_link=true&ssl=1', ['ssl' => '1']],
+      ['ca=%2Ftmp%2Fcacert.crt', ['ca' => '/tmp/cacert.crt']],
+      [
+        'ca=%2Ftmp%2Fcacert.crt&cert=%2Ftmp%2Fcert.crt&key=%2Ftmp%2Fmy.key',
+        [
+          'ca' => '/tmp/cacert.crt',
+          'cert' => '/tmp/cert.crt',
+          'key' => '/tmp/my.key',
+        ],
+      ],
+      [
+        'ca=%2Fpath%20with%20spaces%2Fcacert.crt',
+        [
+          'ca' => '/path with spaces/cacert.crt',
+        ],
+      ],
+      ['cipher=aes', ['cipher' => 'aes']],
+      ['capath=%2Ftmp', ['capath' => '/tmp']],
+      [
+        'cipher=aes&capath=%2Ftmp&food=banana',
+        [
+          'cipher' => 'aes',
+          'capath' => '/tmp',
+        ],
+      ],
+      ['food=banana&cipher=aes', ['cipher' => 'aes']],
+    ];
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/1926

If mysql requires an encrypted connection, then currently you can't install civi directly into that instance.

Before
----------------------------------------
Can't use SSL

After
----------------------------------------
Can use SSL if you know the secret handshake.

Technical Details
----------------------------------------
https://www.php.net/manual/en/mysqli.ssl-set.php

https://github.com/civicrm/civicrm-packages/blob/60bdcbc11702717a57e6eb4d5e85861e1edc4c94/DB/mysqli.php#L303-L324

Comments
----------------------------------------
* Docs PR: https://lab.civicrm.org/documentation/docs/installation/-/merge_requests/7
* There is also install/index.php that could be updated, but I'm ignoring it unless it's desired to keep supporting it.
* Also to take the CMS database connection into account I think `cv` itself would need updating, so at the end you need to manually update civicrm.settings.php for CIVICRM_UF_DSN, but it's not needed during the civi install.

For testing, the simplest is without client certificates, but you still need to set up mysql itself with a server certificate, but it can be self-signed.

```
# For drupalish sites, add to settings.php in the $databases array as per docs PR:

'pdo' => array(
  PDO::MYSQL_ATTR_SSL_CA => TRUE,
  PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT => FALSE,
),

# mysql command, otherwise it will fall back to non-encrypted and you're not really testing anything
ALTER USER username@localhost REQUIRE SSL;

# cli command
cv core:install -vvv --cms-base-url=http://site/ --db="mysqli://user:pass@hostname/dbname?ssl=1"

# manually update civicrm.settings.php for the drupal CIVICRM_UF_DSN to add `&ssl=1`  on the end.

# click around inside civi

# restore
ALTER USER username@localhost REQUIRE NONE;
```
