### PR TITLE
Metadata fix - phone_type_id, location_type_id, gender_id

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -2189,7 +2189,7 @@ class CRM_Contact_BAO_Query {
         $name, $op, $value, $grouping,
         'CRM_Contact_DAO_Contact',
         $field,
-        $field['title'],
+        $field['html']['label'] ?? $field['title'],
         CRM_Utils_Type::typeToString($dataType)
       );
       if ($name === 'gender_id') {

--- a/CRM/Contact/DAO/Contact.php
+++ b/CRM/Contact/DAO/Contact.php
@@ -1216,7 +1216,7 @@ class CRM_Contact_DAO_Contact extends CRM_Core_DAO {
         'gender_id' => [
           'name' => 'gender_id',
           'type' => CRM_Utils_Type::T_INT,
-          'title' => ts('Gender'),
+          'title' => ts('Gender ID'),
           'description' => ts('FK to gender ID'),
           'import' => TRUE,
           'where' => 'civicrm_contact.gender_id',
@@ -1229,6 +1229,7 @@ class CRM_Contact_DAO_Contact extends CRM_Core_DAO {
           'localizable' => 0,
           'html' => [
             'type' => 'Select',
+            'label' => ts("Gender"),
           ],
           'pseudoconstant' => [
             'optionGroupName' => 'gender',

--- a/CRM/Core/DAO/Phone.php
+++ b/CRM/Core/DAO/Phone.php
@@ -174,7 +174,7 @@ class CRM_Core_DAO_Phone extends CRM_Core_DAO {
         'location_type_id' => [
           'name' => 'location_type_id',
           'type' => CRM_Utils_Type::T_INT,
-          'title' => ts('Phone Location Type'),
+          'title' => ts('Phone Location Type ID'),
           'description' => ts('Which Location does this phone belong to.'),
           'where' => 'civicrm_phone.location_type_id',
           'table_name' => 'civicrm_phone',
@@ -183,6 +183,7 @@ class CRM_Core_DAO_Phone extends CRM_Core_DAO {
           'localizable' => 0,
           'html' => [
             'type' => 'Select',
+            'label' => ts("Phone Location Type"),
           ],
           'pseudoconstant' => [
             'table' => 'civicrm_location_type',
@@ -301,6 +302,7 @@ class CRM_Core_DAO_Phone extends CRM_Core_DAO {
           'localizable' => 0,
           'html' => [
             'type' => 'Select',
+            'label' => ts("Phone Type"),
           ],
           'pseudoconstant' => [
             'optionGroupName' => 'phone_type',

--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -1185,7 +1185,7 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
       $rows["move_$field"] = [
         'main' => self::getFieldValueAndLabel($field, $main)['label'],
         'other' => self::getFieldValueAndLabel($field, $other)['label'],
-        'title' => $fields[$field]['title'],
+        'title' => $fields[$field]['html']['label'] ?? $fields[$field]['title'],
       ];
 
       $value = self::getFieldValueAndLabel($field, $other)['value'];

--- a/CRM/Export/BAO/ExportProcessor.php
+++ b/CRM/Export/BAO/ExportProcessor.php
@@ -639,6 +639,9 @@ class CRM_Export_BAO_ExportProcessor {
     $queryFields['world_region']['context'] = 'country';
     $queryFields['state_province']['context'] = 'province';
     $queryFields['contact_id'] = ['title' => ts('Contact ID'), 'type' => CRM_Utils_Type::T_INT];
+    // Set the label to gender for gender_id as we it's ... magic (not in a good way).
+    // In other places the query object offers e.g contribution_status & contribution_status_id
+    $queryFields['gender_id']['title'] = ts('Gender');
     $this->queryFields = $queryFields;
   }
 

--- a/xml/schema/Contact/Contact.xml
+++ b/xml/schema/Contact/Contact.xml
@@ -654,13 +654,14 @@
   </field>
   <field>
     <name>gender_id</name>
-    <title>Gender</title>
+    <title>Gender ID</title>
     <type>int unsigned</type>
     <pseudoconstant>
       <optionGroupName>gender</optionGroupName>
     </pseudoconstant>
     <html>
       <type>Select</type>
+      <label>Gender</label>
     </html>
     <headerPattern>/^gender$/i</headerPattern>
     <comment>FK to gender ID</comment>

--- a/xml/schema/Core/Phone.xml
+++ b/xml/schema/Core/Phone.xml
@@ -36,7 +36,7 @@
   </foreignKey>
   <field>
     <name>location_type_id</name>
-    <title>Phone Location Type</title>
+    <title>Phone Location Type ID</title>
     <type>int unsigned</type>
     <comment>Which Location does this phone belong to.</comment>
     <pseudoconstant>
@@ -46,6 +46,7 @@
     </pseudoconstant>
     <html>
       <type>Select</type>
+      <label>Phone Location Type</label>
     </html>
     <add>2.0</add>
   </field>
@@ -157,6 +158,7 @@
     </pseudoconstant>
     <html>
       <type>Select</type>
+      <label>Phone Type</label>
     </html>
     <add>2.2</add>
   </field>


### PR DESCRIPTION
Overview
----------------------------------------
Alter metadata label on phone_type_id from 'Phone Type' to 'Phone Type ID', also for gender_id & phone.location_type_id

Before
----------------------------------------
Title for phone_type_id is Phone Type

After
----------------------------------------
Title for phone_type_id is Phone Type ID
but html label is Phone Type

Technical Details
----------------------------------------
@colemanw & I have been trying to use 'title' for 2 different purposes resulting in a conflict over the labels. I thought this might break a label somewhere - but couldn't see any so I tried gender_id - but that is also set to work via
https://github.com/civicrm/civicrm-core/blob/996b358b2f124c8f8d5a20bb5e7a5b472c96d57b/CRM/Core/Form.php#L1581 in the places I looked at.

I would note that in the export we actually grab the html->label from the Option Group Title, where appropriate. With proper caching it might be worth doing that more places where option groups are involved. (it would also offer some tangental UI flexibility)

Comments
----------------------------------------
@colemanw I though putting this is a separate PR might unblock https://github.com/civicrm/civicrm-core/pull/17956 now we have an agreed approach

Specific tests that hit this:

testGetRowsElementsAndInfoSpecialInfo
testGenericWhereHandling
