### PR TITLE
dev/core#1943 add functionality to add civicrm log into Drupal access log

### DIFF
--- a/CRM/Core/Error.php
+++ b/CRM/Core/Error.php
@@ -586,6 +586,9 @@ class CRM_Core_Error extends PEAR_ErrorStack {
       if ($config->userSystem->is_drupal and function_exists('watchdog')) {
         watchdog('civicrm', '%message', ['%message' => $message], $priority ?? WATCHDOG_DEBUG);
       }
+      else if ($config->userSystem->is_drupal and CIVICRM_UF == 'Drupal8') {
+        \Drupal::logger('civicrm')->debug($message);
+      }
     }
 
     return $str;

--- a/CRM/Core/Error.php
+++ b/CRM/Core/Error.php
@@ -587,7 +587,7 @@ class CRM_Core_Error extends PEAR_ErrorStack {
         watchdog('civicrm', '%message', ['%message' => $message], $priority ?? WATCHDOG_DEBUG);
       }
       elseif ($config->userSystem->is_drupal and CIVICRM_UF == 'Drupal8') {
-        \Drupal::logger('civicrm')->debug($message);
+        \Drupal::logger('civicrm')->log($priority ?? \Drupal\Core\Logger\RfcLogLevel::DEBUG, '%message', ['%message' => $message]);
       }
     }
 

--- a/CRM/Core/Error.php
+++ b/CRM/Core/Error.php
@@ -586,7 +586,7 @@ class CRM_Core_Error extends PEAR_ErrorStack {
       if ($config->userSystem->is_drupal and function_exists('watchdog')) {
         watchdog('civicrm', '%message', ['%message' => $message], $priority ?? WATCHDOG_DEBUG);
       }
-      else if ($config->userSystem->is_drupal and CIVICRM_UF == 'Drupal8') {
+      elseif ($config->userSystem->is_drupal and CIVICRM_UF == 'Drupal8') {
         \Drupal::logger('civicrm')->debug($message);
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------
Currently We have Setting to log CiviCRM Error Log to Drupal Access Log, but functionality in code is not present.

Current behaviour
----------------------------------------
Code not present of Functionality present at /civicrm/admin/setting/debug?reset=1, `Enable Drupal Watchdog Logging`

Proposed behaviour
----------------------------------------
After changes, it will start logging into Drupal log if `Enable Drupal Watchdog Logging` is enabled

https://lab.civicrm.org/dev/core/-/issues/1943