### PR TITLE
Fix PHP notice on contribution page

### DIFF
--- a/CRM/Contribute/Form/ContributionPage/Amount.php
+++ b/CRM/Contribute/Form/ContributionPage/Amount.php
@@ -366,7 +366,7 @@ class CRM_Contribute_Form_ContributionPage_Amount extends CRM_Contribute_Form_Co
       }
     }
     else {
-      if ($fields['amount_block_is_active'] && empty($fields['payment_processor'])) {
+      if (!empty($fields['amount_block_is_active']) && empty($fields['payment_processor'])) {
         $errors['payment_processor'] = ts('You have listed fixed contribution options or selected a price set, but no payment option has been selected. Please select at least one payment processor and/or enable the pay later option.');
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------
When you have membership enabled and you want to switch to contributions you will get a PHP notice if you click "Save" because you can't enable the contributions block without disabling the membership block first and `amount_block_is_active` is not set.

Before
----------------------------------------
PHP notice

After
----------------------------------------
PHP notice gone

Technical Details
----------------------------------------


Comments
----------------------------------------

