### PR TITLE
Add disable_smarty option to MessageTemplate.send API

### DIFF
--- a/api/v3/MessageTemplate.php
+++ b/api/v3/MessageTemplate.php
@@ -181,4 +181,9 @@ function _civicrm_api3_message_template_send_spec(&$params) {
   $params['pdf_filename']['title'] = 'PDF Filename';
   $params['pdf_filename']['api.aliases'] = ['PDFFilename'];
   $params['pdf_filename']['type'] = CRM_Utils_Type::T_STRING;
+
+  $params['disable_smarty']['description'] = 'Disable Smarty. Normal CiviMail tokens are still supported. By default Smarty is enabled.';
+  $params['disable_smarty']['title'] = 'Disable Smarty';
+  $params['disable_smarty']['api.aliases'] = ['disableSmarty'];
+  $params['disable_smarty']['type'] = CRM_Utils_Type::T_BOOLEAN;
 }


### PR DESCRIPTION
Overview
----------------------------------------

New feature: Adds an optional parameter to disable smarty interpretation when sending a MessageTemplate.


Before
----------------------------------------

Smarty was always applied to the contents of MessageTemplate.send sent emails.


After
----------------------------------------

Smarty is not applied to the contents of MessageTemplate.send sent emails if the `disable_smarty => 1` was passed to the API (or `disableSmarty => 1` was passed to `CRM_Core_BAO_MessageTemplate::sendTemplate()`.

Technical Details
----------------------------------------

The implementation of this is very simple. The reasons it's helpful are a little more detailed.

The APIv3 `MessageTemplate.Send` method always uses Smarty. Doesn't care about `CIVICRM_MAIL_SMARTY` being defined at all, as I found and recorded at https://github.com/civicrm/org.civicrm.mosaicomsgtpl/issues/12#issue-499450997

There's good (reasonable at least!) reason for that: message templates are used for loads of system workflow stuff that relies heaviliy on Smarty.

However, when providing clients with automated functionality like sending an email from a Message Template in response to certain actions, you don't always want this. And, when used in conjunction with the Mosaico Message Template extension, you really don't want this, since those emails will definitely have content in that gets Smarty confused - e.g. CSS definitions inside `{}`.


Comments
----------------------------------------

This adds a new feature for developers. It does not affect normal use: Smarty being enabled is still the default.