### PR TITLE
[NFC] Add code comments about hidden but still used buttons

### DIFF
--- a/CRM/Case/Form/CaseView.php
+++ b/CRM/Case/Form/CaseView.php
@@ -272,6 +272,9 @@ class CRM_Case_Form_CaseView extends CRM_Core_Form {
         ['class' => 'crm-select2 crm-action-menu fa-list-ol']
       );
     }
+    // This button is hidden but gets clicked by javascript at
+    // https://github.com/civicrm/civicrm-core/blob/bd28ecf8121a85bc069cad3ab912a0c3dff8fdc5/templates/CRM/Case/Form/CaseView.js#L194
+    // by the onChange handler for the above timeline_id select.
     $this->addElement('xbutton', $this->getButtonName('next'), ' ', [
       'class' => 'hiddenElement',
       'type' => 'submit',
@@ -520,6 +523,9 @@ class CRM_Case_Form_CaseView extends CRM_Core_Form {
         FALSE,
         ['class' => 'crm-select2 huge']
       );
+      // This button is hidden but gets clicked by javascript at
+      // https://github.com/civicrm/civicrm-core/blob/bd28ecf8121a85bc069cad3ab912a0c3dff8fdc5/templates/CRM/Case/Form/CaseView.js#L55
+      // when the mergeCasesDialog is saved.
       $this->addElement('xbutton',
         $this->getButtonName('next', 'merge_case'),
         ts('Merge'),

--- a/templates/CRM/Case/Form/CaseView.tpl
+++ b/templates/CRM/Case/Form/CaseView.tpl
@@ -95,7 +95,7 @@
       <p>
         {$form.add_activity_type_id.html}
         {if $hasAccessToAllCases} &nbsp;
-          {$form.timeline_id.html}{$form._qf_CaseView_next.html} &nbsp;
+          {$form.timeline_id.html}{*This CaseView_next button is hidden, but gets clicked by the onChange handler for timeline_id in CaseView.js*}{$form._qf_CaseView_next.html} &nbsp;
           {$form.report_id.html}
         {/if}
       </p>
@@ -112,7 +112,7 @@
 
         {if $mergeCases}
           <a href="#mergeCasesDialog" class="action-item no-popup crm-hover-button case-miniform"><i class="crm-i fa-compress" aria-hidden="true"></i> {ts}Merge Case{/ts}</a>
-          {$form._qf_CaseView_next_merge_case.html}
+          {*This CaseView_next_merge_case button is hidden, but gets clicked by javascript in CaseView.js when the mergeCasesDialog popup is saved.*}{$form._qf_CaseView_next_merge_case.html}
           <span id="mergeCasesDialog" class="hiddenElement">
             {$form.merge_case_id.html}
           </span>


### PR DESCRIPTION
Overview
----------------------------------------
I was confused by these buttons since they're hidden and appeared to be from an older version of the form, but it turns out they're still used since they get clicked by javascript. So adding comments to avoid accidental removal of the buttons.
