### PR TITLE
dev/core#1936 Ensure that string nulls aren't saved for price field v…

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -736,6 +736,10 @@ class CRM_Core_DAO extends DB_DataObject {
       if ($exists) {
         if ($value === '') {
           $this->$dbName = 'null';
+          // If a field is of type string and is required i.e. can't be null rather than setting to the string 'null' lets set it to a blank string instead.
+          if (!empty($field['required']) && $field['type'] === CRM_Utils_Type::T_STRING) {
+            $this->$dbName = '';
+          }
         }
         elseif (is_array($value) && !empty($field['serialize'])) {
           $this->$dbName = CRM_Core_DAO::serializeField($value, $field['serialize']);

--- a/tests/phpunit/CRM/Price/BAO/PriceFieldValueTest.php
+++ b/tests/phpunit/CRM/Price/BAO/PriceFieldValueTest.php
@@ -39,4 +39,42 @@ class CRM_Price_BAO_PriceFieldValueTest extends CiviUnitTestCase {
     $this->assertEquals('visibility', $fields['visibility_id']['pseudoconstant']['optionGroupName']);
   }
 
+  public function testEmptyStringLabel() {
+    // Put stuff here that should happen before all tests in this unit.
+    $priceSetParams = [
+      'name' => 'default_goat_priceset',
+      'title' => 'Goat accommodation',
+      'is_active' => 1,
+      'help_pre' => "Where does your goat sleep",
+      'help_post' => "thank you for your time",
+      'extends' => 2,
+      'financial_type_id' => 1,
+      'is_quick_config' => 1,
+      'is_reserved' => 1,
+    ];
+
+    $price_set = $this->callAPISuccess('price_set', 'create', $priceSetParams);
+    $this->priceSetID = $price_set['id'];
+
+    $priceFieldParams = [
+      'price_set_id' => $this->priceSetID,
+      'name' => 'grassvariety',
+      'label' => 'Grass Variety',
+      'html_type' => 'Text',
+      'is_enter_qty' => 1,
+      'is_active' => 1,
+    ];
+    $priceField = $this->callAPISuccess('price_field', 'create', $priceFieldParams);
+    $this->priceFieldID = $priceField['id'];
+    $this->_params = [
+      'price_field_id' => $this->priceFieldID,
+      'name' => 'rye_grass',
+      'label' => '',
+      'amount' => 1,
+      'financial_type_id' => 1,
+    ];
+    $priceFieldValue = CRM_Price_BAO_PriceFieldValue::create($this->_params);
+    $this->assertEquals('', $priceFieldValue->label);
+  }
+
 }


### PR DESCRIPTION
…alue labels

Overview
----------------------------------------
This allows for strings to be set to blank strings rather than the string null if its a required text field

Before
----------------------------------------
String null saved into the database

After
----------------------------------------
Blank string saved into the database

ping @KarinG @eileenmcnaughton @demeritcowboy I'm expecting this may break some unit tests but lets see what happens