### PR TITLE
[WIP] dev/core#1926 - Allow ssl connection to mysql for scripts

### DIFF
--- a/CRM/Utils/System/Backdrop.php
+++ b/CRM/Utils/System/Backdrop.php
@@ -291,7 +291,8 @@ class CRM_Utils_System_Backdrop extends CRM_Utils_System_DrupalBase {
   public function authenticate($name, $password, $loadCMSBootstrap = FALSE, $realPath = NULL) {
     $config = CRM_Core_Config::singleton();
 
-    $dbBackdrop = DB::connect($config->userFrameworkDSN);
+    $db_options = CRM_Utils_SQL::isSSLDSN($config->userFrameworkDSN) ? ['ssl' => TRUE] : [];
+    $dbBackdrop = DB::connect($config->userFrameworkDSN, $db_options);
     if (DB::isError($dbBackdrop)) {
       throw new CRM_Core_Exception("Cannot connect to Backdrop database via $config->userFrameworkDSN, " . $dbBackdrop->getMessage());
     }

--- a/CRM/Utils/System/Drupal.php
+++ b/CRM/Utils/System/Drupal.php
@@ -317,7 +317,14 @@ class CRM_Utils_System_Drupal extends CRM_Utils_System_DrupalBase {
 
     $config = CRM_Core_Config::singleton();
 
-    $dbDrupal = DB::connect($config->userFrameworkDSN);
+    // DON'T use PEAR::getStatic, because civi is already initialized, and
+    // so the static namespace contains options from civi's side, not the ones
+    // we want for UF.
+    //
+    // @todo Do we need any of this anymore? Down below it says it's for SOAP
+    // because it can't bootstrap - is that still true?
+    $db_options = CRM_Utils_SQL::isSSLDSN($config->userFrameworkDSN) ? ['ssl' => TRUE] : [];
+    $dbDrupal = DB::connect($config->userFrameworkDSN, $db_options);
     if (DB::isError($dbDrupal)) {
       throw new CRM_Core_Exception("Cannot connect to drupal db via $config->userFrameworkDSN, " . $dbDrupal->getMessage());
     }


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/1926

This allows using ssl connections to mysql for scripts, e.g. bin\cli.php.

Before
----------------------------------------
_What is the old user-interface or technical-contract (as appropriate)?_
_For optimal clarity, include a concrete example such as a screenshot, GIF ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)), or code-snippet._

After
----------------------------------------
_What changed? What is new old user-interface or technical-contract?_
_For optimal clarity, include a concrete example such as a screenshot, GIF ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)), or code-snippet._

Technical Details
----------------------------------------
_If the PR involves technical details/changes/considerations which would not be manifest to a casual developer skimming the above sections, please describe the details here._

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
