### PR TITLE
dev/core#1934 fix regression on merging contacts with settings using contact_id

### DIFF
--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -541,6 +541,17 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
         continue;
       }
 
+      if ($table === 'civicrm_setting') {
+        // Per https://lab.civicrm.org/dev/core/-/issues/1934
+        // Note this line is not unit tested as yet as a quick-fix for a regression
+        // but it would be better to do a SELECT request & only update if needed (as a general rule
+        // more selects & less UPDATES will result in less deadlocks while de-duping.
+        // Note the delete is not important here - it can stay with the deleted contact on the
+        // off chance they get restored.
+        $sqls[] = "UPDATE IGNORE civicrm_setting SET contact_id = $mainId WHERE contact_id = $otherId";
+        continue;
+      }
+
       // use UPDATE IGNORE + DELETE query pair to skip on situations when
       // there's a UNIQUE restriction on ($field, some_other_field) pair
       if (isset($cidRefs[$table])) {


### PR DESCRIPTION


Overview
----------------------------------------
This is an interim fix to a reported regression. I'll look at more carefully in master when time permits

Before
----------------------------------------
Attempting to dedupe 2 contacts with settings with contact IDs will cause a fatal. My understanding is this would only be the case if an extension implemented it

After
----------------------------------------
Dedupe works

Technical Details
----------------------------------------


Comments
----------------------------------------
