### PR TITLE
[REF] Move isSSLDSN() function to avoid potential problems

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -163,7 +163,7 @@ class CRM_Core_DAO extends DB_DataObject {
     $options = &PEAR::getStaticProperty('DB_DataObject', 'options');
     $options['database'] = $dsn;
     $options['quote_identifiers'] = TRUE;
-    if (self::isSSLDSN($dsn)) {
+    if (CRM_Utils_SQL::isSSLDSN($dsn)) {
       // There are two different options arrays.
       $other_options = &PEAR::getStaticProperty('DB', 'options');
       $other_options['ssl'] = TRUE;
@@ -3109,23 +3109,6 @@ SELECT contact_id
     if (isset($this->name)) {
       unset(self::$_dbColumnValueCache[$daoName]['name'][$this->name]);
     }
-  }
-
-  /**
-   * Does the DSN indicate the connection should use ssl.
-   *
-   * @param string $dsn
-   *
-   * @return bool
-   */
-  public static function isSSLDSN(string $dsn):bool {
-    // Note that ssl= below is not an official PEAR::DB option. It doesn't know
-    // what to do with it. We made it up because it's not required
-    // to have client-side certificates to use ssl, so here you can specify
-    // you want that by putting ssl=1 in the DSN string.
-    //
-    // Cast to bool in case of error which we interpret as no ssl.
-    return (bool) preg_match('/[\?&](key|cert|ca|capath|cipher|ssl)=/', $dsn);
   }
 
 }

--- a/CRM/Utils/SQL.php
+++ b/CRM/Utils/SQL.php
@@ -168,4 +168,21 @@ class CRM_Utils_SQL {
     return CRM_Core_DAO::singleValueQuery('SELECT VERSION()');
   }
 
+  /**
+   * Does the DSN indicate the connection should use ssl.
+   *
+   * @param string $dsn
+   *
+   * @return bool
+   */
+  public static function isSSLDSN(string $dsn):bool {
+    // Note that ssl= below is not an official PEAR::DB option. It doesn't know
+    // what to do with it. We made it up because it's not required
+    // to have client-side certificates to use ssl, so here you can specify
+    // you want that by putting ssl=1 in the DSN string.
+    //
+    // Cast to bool in case of error which we interpret as no ssl.
+    return (bool) preg_match('/[\?&](key|cert|ca|capath|cipher|ssl)=/', $dsn);
+  }
+
 }

--- a/tests/phpunit/CRM/Utils/SQLTest.php
+++ b/tests/phpunit/CRM/Utils/SQLTest.php
@@ -32,4 +32,40 @@ class CRM_Utils_SQLTest extends CiviUnitTestCase {
     }
   }
 
+  /**
+   * Test isSSLDSN
+   * @dataProvider dsnProvider
+   * @param string $input
+   * @param bool $expected
+   */
+  public function testIsSSLDSN(string $input, bool $expected) {
+    $this->assertSame($expected, CRM_Utils_SQL::isSSLDSN($input));
+  }
+
+  /**
+   * Data provider for testIsSSLDSN
+   * @return array
+   */
+  public function dsnProvider():array {
+    return [
+      ['', FALSE],
+      ['mysqli://user:pass@localhost/drupal', FALSE],
+      ['mysqli://user:pass@localhost:3306/drupal', FALSE],
+      ['mysql://user:pass@localhost:3306/drupal', FALSE],
+      ['mysql://user:pass@localhost:3306/drupal', FALSE],
+      ['mysql://user:pass@localhost:3306/drupal?new_link=true', FALSE],
+      ['mysqli://user:pass@localhost:3306/drupal?ssl', FALSE],
+      ['mysqli://user:pass@localhost:3306/drupal?ssl=1', TRUE],
+      ['mysqli://user:pass@localhost:3306/drupal?new_link=true&ssl=1', TRUE],
+      ['mysql://user:pass@localhost:3306/drupal?ssl=1', TRUE],
+      ['mysqli://user:pass@localhost:3306/drupal?ca=%2Ftmp%2Fcacert.crt', TRUE],
+      ['mysqli://user:pass@localhost/drupal?ca=%2Ftmp%2Fcacert.crt&cert=%2Ftmp%2Fcert.crt&key=%2Ftmp%2F', TRUE],
+      ['mysqli://user:pass@localhost/drupal?ca=%2Fpath%20with%20spaces%2Fcacert.crt', TRUE],
+      ['mysqli://user:pass@localhost:3306/drupal?cipher=aes', TRUE],
+      ['mysqli://user:pass@localhost:3306/drupal?capath=%2Ftmp', TRUE],
+      ['mysqli://user:pass@localhost:3306/drupal?cipher=aes&capath=%2Ftmp&food=banana', TRUE],
+      ['mysqli://user:pass@localhost:3306/drupal?food=banana&cipher=aes', TRUE],
+    ];
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
This recently added function was put in CRM_Core_DAO just because of physical proximity to where it was being used. But this is less than 6 ft apart in violation of physical distancing precautions.

Before
----------------------------------------
Danger! Danger!

After
----------------------------------------
Normal civi levels of danger.

Technical Details
----------------------------------------
Even though all it does is parse a string, calling CRM_Core_DAO::anything triggers the constructor which triggers a database connection, which might not be what you want if you're still at the point of parsing the DSN string.

Function currently only used one place, inside CRM_Core_DAO. Straight up move to CRM_Utils_System which seems safe.

Comments
----------------------------------------
Added test.
