### PR TITLE
Deprecate/remove unused checkVersion() functions

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -1181,15 +1181,12 @@ LIKE %1
 
   /**
    * @param $version
-   *
+   * @deprecated
    * @return bool
    */
   public function checkVersion($version) {
-    $query = "
-SELECT version
-FROM   civicrm_domain
-";
-    $dbVersion = CRM_Core_DAO::singleValueQuery($query);
+    CRM_Core_Error::deprecatedFunctionWarning('CRM_Core_BAO_Domain::version');
+    $dbVersion = CRM_Core_BAO_Domain::version();
     return trim($version) == trim($dbVersion);
   }
 

--- a/CRM/Upgrade/Form.php
+++ b/CRM/Upgrade/Form.php
@@ -287,19 +287,6 @@ SET    version = '$version'
   }
 
   /**
-   * @param $version
-   *
-   * @return bool
-   */
-  public function checkVersion($version) {
-    $domainID = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Domain',
-      $version, 'id',
-      'version'
-    );
-    return (bool) $domainID;
-  }
-
-  /**
    * @return array
    * @throws Exception
    */


### PR DESCRIPTION
Overview
----------------------------------------
Deprecate 1 unused function and remove another unused function.

Before
----------------------------------------
2 unused functions.

After
----------------------------------------
CRM_Core_DAO::checkVersion() marked as deprecated.
CRM_Upgrade_Form::checkVersion() removed.

Comments
----------------------------------------
Both functions are unused according to my grepping. The one in `CRM_Core_DAO` could theoretically be used somewhere in the extension universe (though I doubt it), so I marked it as deprecated to provide a transition period.

The other function in `CRM_Upgrade_Form` is very "internal" and IMO very unlikely to be in use anywhere, so I deleted it.
