### PR TITLE
[Test framework] - Remove test for deprecated way of calling hook invoke

### DIFF
--- a/tests/phpunit/E2E/Core/HookTest.php
+++ b/tests/phpunit/E2E/Core/HookTest.php
@@ -39,35 +39,6 @@ class HookTest extends \CiviEndToEndTestCase {
   }
 
   /**
-   * This test ensures that CRM_Utils_Hook::invoke() dispatches via Symfony.
-   *
-   * This should be *in*addition* to dispatching through the UF event system,
-   * although the mechanics depend on the UF, so that part has to be tested per-UF.
-   *
-   * This uses the deprecated form, `CRM_Utils_Hook::invoke(int $count...)`
-   */
-  public function testSymfonyListener_int() {
-    $calls = 0;
-    $hookExample = function ($e) use (&$calls) {
-      $calls++;
-      $e->arg1['foo'] = 'a.num';
-      $e->arg2->bar = 'b.num';
-    };
-    \Civi::dispatcher()->addListener('hook_civicrm_e2eHookExample', $hookExample);
-    try {
-      $a = [];
-      $b = new \stdClass();
-      $this->hookStub(2, $a, $b);
-      $this->assertEquals(1, $calls);
-      $this->assertEquals('a.num', $a['foo']);
-      $this->assertEquals('b.num', $b->bar);
-    }
-    finally {
-      \Civi::dispatcher()->removeListener('hook_civicrm_e2eHookExample', $hookExample);
-    }
-  }
-
-  /**
    * @param mixed $names
    * @param array $a
    * @param \stdClass $b


### PR DESCRIPTION
Overview
----------------------------------------
In https://github.com/civicrm/civicrm-core/pull/17995 this method of calling the hook was deprecated.

I don't know why this doesn't show up on the PR test sites, but on my local when running with the [loud notices](https://lab.civicrm.org/extensions/loudnotices) extension this comes up via [E_USER_DEPRECATED](https://github.com/civicrm/civicrm-core/blob/cbc3948fcaab5ad6b3087ff8c3fc87261bf8aec2/CRM/Core/Error/Log.php#L58) that gets thrown.

Is this a jenkins/phpunit config setting that should maybe be turned on?

Before
----------------------------------------
Invisible error.

After
----------------------------------------
Invisible, because it's gone.

Technical Details
----------------------------------------


Comments
----------------------------------------
