### PR TITLE
Deprecate error handling bypasses

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -1517,10 +1517,12 @@ LIKE %1
       $dao = new CRM_Core_DAO();
     }
     else {
+      CRM_Core_Error::deprecatedFunctionWarning('passing in DAOName is deprecated');
       $dao = new $daoName();
     }
 
     if ($trapException) {
+      CRM_Core_Error::deprecatedFunctionWarning('calling functions should handle exceptions');
       $errorScope = CRM_Core_TemporaryErrorScope::ignoreException();
     }
 
@@ -1624,6 +1626,9 @@ LIKE %1
    * @throws CRM_Core_Exception
    */
   public static function composeQuery($query, $params = [], $abort = TRUE) {
+    if (!$abort) {
+      CRM_Core_Error::deprecatedFunctionWarning('calling functions should not bypass error handling');
+    }
     $tr = [];
     foreach ($params as $key => $item) {
       if (is_numeric($key)) {


### PR DESCRIPTION


Overview
----------------------------------------
I don't believe these are passed in anywhere but it's impossible to be sure so
deprecation makes sense

Before
----------------------------------------
Silly params for CRM_Core_DAO::executeQuery
- $daoName (used to be used in ContactType BAO)
- $trapException
- $abort

After
----------------------------------------
Above now give deprecation notices

Technical Details
----------------------------------------

Comments
----------------------------------------

