### PR TITLE
Deprecate 'trapException' in DAO::executeQuery

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -1521,6 +1521,7 @@ LIKE %1
     }
 
     if ($trapException) {
+      CRM_Core_Error::deprecatedFunctionWarning('calling functions should handle exceptions');
       $errorScope = CRM_Core_TemporaryErrorScope::ignoreException();
     }
 
@@ -1536,6 +1537,7 @@ LIKE %1
     }
 
     if (is_a($result, 'DB_Error')) {
+      CRM_Core_Error::deprecatedFunctionWarning('calling functions should handle exceptions');
       return $result;
     }
 

--- a/CRM/Core/PrevNextCache/Sql.php
+++ b/CRM/Core/PrevNextCache/Sql.php
@@ -40,8 +40,9 @@ class CRM_Core_PrevNextCache_Sql implements CRM_Core_PrevNextCache_Interface {
     $insertSQL = "
 INSERT INTO civicrm_prevnext_cache (cachekey, entity_id1, data)
 ";
-    $result = CRM_Core_DAO::executeQuery($insertSQL . $sql, $sqlParams, FALSE, NULL, FALSE, TRUE, TRUE);
+    $result = CRM_Core_DAO::executeQuery($insertSQL . $sql, $sqlParams, FALSE);
     if (is_a($result, 'DB_Error')) {
+      CRM_Core_Error::deprecatedFunctionWarning('errors are not expected to be returned');
       throw new CRM_Core_Exception($result->message);
     }
     return TRUE;


### PR DESCRIPTION
    
Overview
----------------------------------------
Deprecate 'trapException' inn DAO::executeQuery

Before
----------------------------------------
Silly parameter $trapException in use

After
----------------------------------------
Silly parameter $trapException deprecated




Technical Details
----------------------------------------
We are pretty heavily moving towards using exceptions so we should deprecate this. It seems the
 fillWithSql is just converting the error to an exception so it doesn't want the exception to be trapped

Comments
----------------------------------------
