### PR TITLE
(REF) CRM_Core_Region - Remove unused bits

### DIFF
--- a/CRM/Core/Region.php
+++ b/CRM/Core/Region.php
@@ -48,10 +48,6 @@ class CRM_Core_Region {
    * @param string $name
    */
   public function __construct($name) {
-    // Templates injected into regions should normally be file names, but sometimes inline notation is handy.
-    require_once 'CRM/Core/Smarty/resources/String.php';
-    civicrm_smarty_register_string_resource();
-
     $this->_name = $name;
     $this->_snippets = [];
 
@@ -223,7 +219,6 @@ class CRM_Core_Region {
           break;
 
         default:
-          require_once 'CRM/Core/Exception.php';
           throw new CRM_Core_Exception(ts('Snippet type %1 is unrecognized',
             [1 => $snippet['type']]));
       }

--- a/CRM/Core/Region.php
+++ b/CRM/Core/Region.php
@@ -254,48 +254,4 @@ class CRM_Core_Region {
     return 0;
   }
 
-  /**
-   * Add block of static HTML to a region.
-   *
-   * @param string $markup
-   *   HTML.
-   *
-   * public function addMarkup($markup) {
-   * return $this->add(array(
-   * 'type' => 'markup',
-   * 'markup' => $markup,
-   * ));
-   * }
-   *
-   * /**
-   * Add a Smarty template file to a region.
-   *
-   * Note: File is not evaluated until the page is rendered
-   *
-   * @param string $template
-   *   Path to the Smarty template file.
-   *
-   * public function addTemplate($template) {
-   * return $this->add(array(
-   * 'type' => 'template',
-   * 'template' => $template,
-   * ));
-   * }
-   *
-   * /**
-   * Use a callback function to extend a region.
-   *
-   * @param mixed $callback
-   * @param array $arguments
-   *   Optional, array of parameters for callback; if omitted, the default arguments are ($snippetSpec, $html).
-   *
-   * public function addCallback($callback, $arguments = FALSE) {
-   * return $this->add(array(
-   * 'type' => 'callback',
-   * 'callback' => $callback,
-   * 'arguments' => $arguments,
-   * ));
-   * }
-   */
-
 }


### PR DESCRIPTION
Overview
----------------------------------------
This removes a couple of of unnecessary bits from `CRM_Core_Region`.

Technical Details
----------------------------------------

1. We have class-loaders now-a-days...

2. When Smarty initializes (`CRM_Core_Smarty::singleton`), it loads support for "string" resources automatically. We don't need to re-load for every region...
    
3. Extra comments/drafts - not used.