### PR TITLE
Remove ajax timeout from contribution page on behalf of

### DIFF
--- a/templates/CRM/Contribute/Form/Contribution/OnBehalfOf.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/OnBehalfOf.tpl
@@ -147,7 +147,6 @@
       $.ajax({
         url         : locationUrl,
         dataType    : "json",
-        timeout     : 5000, //Time in milliseconds
         success     : function(data, status) {
           for (var ele in data) {
             if ($("#"+ ele).hasClass('crm-chain-select-target')) {


### PR DESCRIPTION
Overview
----------------------------------------
You'll probably only hit this timeout when debugging / slow connection. But it's the only place (I could find) that specifies an AJAX timeout in CiviCRM templates/js and it doesn't seem needed.

Before
----------------------------------------
AJAX call `civicrm/ajax/permlocation` times out after 5 seconds and you see "Common.js HTTP timeout" in browser console if debugging / site is slow to load / changing payment processors is slow.

After
----------------------------------------
Timeout gone. `civicrm/ajax/permlocation` loads in it's own time without timeout. If there was a real problem you'd see a 500 error or similar.

Technical Details
----------------------------------------
It is possible to specify timeouts on AJAX calls but we generally don't in CiviCRM.

Comments
----------------------------------------
