### PR TITLE
Move membership tab add/submit membership buttons to PHP layer

### DIFF
--- a/CRM/Member/Page/Tab.php
+++ b/CRM/Member/Page/Tab.php
@@ -48,6 +48,23 @@ class CRM_Member_Page_Tab extends CRM_Core_Page {
     $permissions = [CRM_Core_Permission::VIEW];
     if (CRM_Core_Permission::check('edit memberships')) {
       $permissions[] = CRM_Core_Permission::EDIT;
+      $linkButtons['add_membership'] = [
+        'title' => ts('Add Membership'),
+        'url' => 'civicrm/contact/view/membership',
+        'qs' => "reset=1&action=add&cid={$this->_contactId}&context=membership",
+        'icon' => 'fa-plus-circle',
+        'accessKey' => 'N',
+      ];
+      if ($this->_accessContribution && CRM_Core_Config::isEnabledBackOfficeCreditCardPayments()) {
+        $linkButtons['creditcard_membership'] = [
+          'title' => ts('Submit Credit Card Membership'),
+          'url' => 'civicrm/contact/view/membership',
+          'qs' => "reset=1&action=add&cid={$this->_contactId}&context=membership&mode=live",
+          'icon' => 'fa-credit-card',
+          'accessKey' => 'C',
+        ];
+      }
+      $this->assign('linkButtons', $linkButtons ?? []);
     }
     if (CRM_Core_Permission::check('delete in CiviMember')) {
       $permissions[] = CRM_Core_Permission::DELETE;
@@ -317,10 +334,7 @@ class CRM_Member_Page_Tab extends CRM_Core_Page {
     $this->preProcess();
 
     // check if we can process credit card membership
-    $newCredit = CRM_Core_Config::isEnabledBackOfficeCreditCardPayments();
-    $this->assign('newCredit', $newCredit);
-
-    if ($newCredit) {
+    if (CRM_Core_Config::isEnabledBackOfficeCreditCardPayments()) {
       $this->_isPaymentProcessor = TRUE;
     }
     else {

--- a/templates/CRM/Member/Page/Tab.tpl
+++ b/templates/CRM/Member/Page/Tab.tpl
@@ -15,31 +15,20 @@
 {elseif $action eq 32768}  {* renew *}
     {include file="CRM/Member/Form/MembershipRenewal.tpl"}
 {elseif $action eq 16} {* Browse memberships for a contact *}
-    {if $permission EQ 'edit'}
-      {capture assign=newURL}{crmURL p="civicrm/contact/view/membership" q="reset=1&action=add&cid=`$contactId`&context=membership"}{/capture}{/if}
-
     {if $action ne 1 and $action ne 2 and $permission EQ 'edit'}
         <div class="help">
-            {if $permission EQ 'edit'}
-              {capture assign="link"}class="action-item" href="{$newURL}"{/capture}
-              {ts 1=$link}Click <a %1>Add Membership</a> to record a new membership.{/ts}
-              {if $newCredit}
-                {capture assign=newCreditURL}{crmURL p="civicrm/contact/view/membership" q="reset=1&action=add&cid=`$contactId`&context=membership&mode=live"}{/capture}
-                {capture assign="link"}class="action-item" href="{$newCreditURL}"{/capture}
-                {ts 1=$link}Click <a %1>Submit Credit Card Membership</a> to process a Membership on behalf of the member using their credit card.{/ts}
-                {/if}
+            {if $linkButtons.add_membership}
+              {ts}Click <em>Add Membership</em> to record a new membership.{/ts}
             {else}
-                {ts 1=$displayName}Current and inactive memberships for %1 are listed below.{/ts}
+              {ts 1=$displayName}Current and inactive memberships for %1 are listed below.{/ts}
+            {/if}
+            {if $linkButtons.creditcard_membership}
+              {ts}Click <em>Submit Credit Card Membership</em> to process a Membership on behalf of the member using their credit card.{/ts}
             {/if}
         </div>
 
         <div class="action-link">
-            <a accesskey="N" href="{$newURL}" class="button"><span><i class="crm-i fa-plus-circle" aria-hidden="true"></i> {ts}Add Membership{/ts}</span></a>
-            {if $accessContribution and $newCredit}
-                <a accesskey="N" href="{$newCreditURL}" class="button"><span><i class="crm-i fa-credit-card" aria-hidden="true"></i> {ts}Submit Credit Card Membership{/ts}</span></a><br /><br />
-            {else}
-                <br/ ><br/ >
-            {/if}
+          {include file="CRM/common/formButtons.tpl" location="top"}
         </div>
     {/if}
     {if NOT ($activeMembers or $inActiveMembers) and $action ne 2 and $action ne 1 and $action ne 8 and $action ne 4 and $action ne 32768}


### PR DESCRIPTION
Overview
----------------------------------------
This moves the Add Membership / Submit Credit Card membership buttons from the smarty layer to the php layer so that:
- we don't need to assign as many vars to the tpl.
- we can use the generic button rendering template.
- it will be easier (in the future) to manipulate what buttons appear there.

My goal here is to allow the "submit" button to open in test mode (also for contributions/events). This is just a preliminary step (steps to follow for other "tab" buttons - ie. contribution,event buttons). I intend to follow up with PRs for other buttons and eventually a PR to allow manipulation of those buttons (not sure yet whether via hooks / settings etc. - TBD).

Before
----------------------------------------
Buttons rendered on smarty tpl layer using custom tpl markup.

After
----------------------------------------
Buttons generated at php form level and rendered using standard tpl markup.

![image](https://user-images.githubusercontent.com/2052161/90267023-d4f61800-de4c-11ea-9f16-6233a0ad58a6.png)


Technical Details
----------------------------------------


Comments
----------------------------------------
There is *one* change to the UI - the links in the description are no longer rendered as links. It seems a bit redundant to have links + buttons so I think this is ok.
