### PR TITLE
dev/core#1953 Ensure that Contribution pages do not fail validation o…

### DIFF
--- a/CRM/Core/Payment.php
+++ b/CRM/Core/Payment.php
@@ -831,7 +831,7 @@ abstract class CRM_Core_Payment {
           'size' => 20,
           'maxlength' => 20,
           'autocomplete' => 'off',
-          'class' => 'creditcard',
+          'class' => 'creditcard, required',
         ],
         'is_required' => TRUE,
         // 'description' => '16 digit card number', // If you enable a description field it will be shown below the field on the form
@@ -844,6 +844,7 @@ abstract class CRM_Core_Payment {
           'size' => 5,
           'maxlength' => 10,
           'autocomplete' => 'off',
+          'class' => 'required',
         ],
         'is_required' => $isCVVRequired,
         'rules' => [
@@ -867,7 +868,7 @@ abstract class CRM_Core_Payment {
             'rule_parameters' => TRUE,
           ],
         ],
-        'extra' => ['class' => 'crm-form-select'],
+        'extra' => ['class' => 'crm-form-select required'],
       ],
       'credit_card_type' => [
         'htmlType' => 'select',
@@ -884,6 +885,7 @@ abstract class CRM_Core_Payment {
           'size' => 20,
           'maxlength' => 34,
           'autocomplete' => 'on',
+          'class' => 'required',
         ],
         'is_required' => TRUE,
       ],
@@ -896,6 +898,7 @@ abstract class CRM_Core_Payment {
           'size' => 20,
           'maxlength' => 34,
           'autocomplete' => 'off',
+          'class' => 'required',
         ],
         'rules' => [
           [
@@ -915,6 +918,7 @@ abstract class CRM_Core_Payment {
           'size' => 20,
           'maxlength' => 11,
           'autocomplete' => 'off',
+          'class' => 'required',
         ],
         'is_required' => TRUE,
         'rules' => [
@@ -933,6 +937,7 @@ abstract class CRM_Core_Payment {
           'size' => 20,
           'maxlength' => 64,
           'autocomplete' => 'off',
+          'class' => 'required',
         ],
         'is_required' => TRUE,
 
@@ -1034,6 +1039,7 @@ abstract class CRM_Core_Payment {
         'size' => 30,
         'maxlength' => 60,
         'autocomplete' => 'off',
+        'class' => 'required',
       ],
       'is_required' => TRUE,
     ];
@@ -1060,6 +1066,7 @@ abstract class CRM_Core_Payment {
         'size' => 30,
         'maxlength' => 60,
         'autocomplete' => 'off',
+        'class' => 'required',
       ],
       'is_required' => TRUE,
     ];
@@ -1073,6 +1080,7 @@ abstract class CRM_Core_Payment {
         'size' => 30,
         'maxlength' => 60,
         'autocomplete' => 'off',
+        'class' => 'required',
       ],
       'is_required' => TRUE,
     ];
@@ -1086,6 +1094,7 @@ abstract class CRM_Core_Payment {
         'size' => 30,
         'maxlength' => 60,
         'autocomplete' => 'off',
+        'class' => 'required',
       ],
       'is_required' => TRUE,
     ];
@@ -1096,6 +1105,7 @@ abstract class CRM_Core_Payment {
       'name' => "billing_state_province_id-{$billingLocationID}",
       'cc_field' => TRUE,
       'is_required' => TRUE,
+      'extra' => ['class' => 'required'],
     ];
 
     $metadata["billing_postal_code-{$billingLocationID}"] = [
@@ -1107,6 +1117,7 @@ abstract class CRM_Core_Payment {
         'size' => 30,
         'maxlength' => 60,
         'autocomplete' => 'off',
+        'class' => 'required',
       ],
       'is_required' => TRUE,
     ];
@@ -1120,6 +1131,7 @@ abstract class CRM_Core_Payment {
         '' => ts('- select -'),
       ] + CRM_Core_PseudoConstant::country(),
       'is_required' => TRUE,
+      'extra' => ['class' => 'required'],
     ];
     return $metadata;
   }

--- a/CRM/Core/Payment/Form.php
+++ b/CRM/Core/Payment/Form.php
@@ -109,7 +109,7 @@ class CRM_Core_Payment_Form {
           $field['name'],
           $field['title'],
           $field['attributes'],
-          $field['is_required'],
+          FALSE,
           $field['extra']
         );
       }

--- a/templates/CRM/Core/BillingBlock.tpl
+++ b/templates/CRM/Core/BillingBlock.tpl
@@ -20,7 +20,9 @@
         {foreach from=$paymentFields item=paymentField}
           {assign var='name' value=$form.$paymentField.name}
           <div class="crm-section {$form.$paymentField.name}-section">
-            <div class="label">{$form.$paymentField.label}</div>
+            <div class="label">{$form.$paymentField.label}
+              {if $requiredPaymentFields.$name}<span class="crm-marker" title="{ts}This field is required.{/ts}">*</span>{/if}
+            </div>
             <div class="content">
                 {$form.$paymentField.html}
               {if $paymentFieldsMetadata.$name.description}
@@ -49,7 +51,9 @@
         {foreach from=$billingDetailsFields item=billingField}
           {assign var='name' value=$form.$billingField.name}
           <div class="crm-section {$form.$billingField.name}-section">
-            <div class="label">{$form.$billingField.label}</div>
+            <div class="label">{$form.$billingField.label}
+              {if $requiredPaymentFields.$name}<span class="crm-marker" title="{ts}This field is required.{/ts}">*</span>{/if}
+            </div>
             {if $form.$billingField.type == 'text'}
               <div class="content">{$form.$billingField.html}</div>
             {else}


### PR DESCRIPTION
…n credit cards when a zero dollar price is offered

Overview
----------------------------------------
This fixes a regression caused by https://github.com/civicrm/civicrm-core/pull/16488 which was causing the required form rule to be applied to the credit card field no matter the price amount

Before
----------------------------------------
Zero dollar contribution on a public contribution form cannot be submitted

After
----------------------------------------
Can be submitted

Technical Details
----------------------------------------
I have added a required class on various of the credit card fields so that JQuery validation can still do the validation whilst removing the adding of the quickform rule on these fields

ping @eileenmcnaughton @mattwire @KarinG 