### PR TITLE
Export fix on long custom fields

### DIFF
--- a/CRM/Export/BAO/ExportProcessor.php
+++ b/CRM/Export/BAO/ExportProcessor.php
@@ -1456,11 +1456,22 @@ class CRM_Export_BAO_ExportProcessor {
           return "`$fieldName` varchar(16)";
 
         case CRM_Utils_Type::T_STRING:
-          if (isset($queryFields[$columnName]['maxlength'])) {
-            return "`$fieldName` varchar({$queryFields[$columnName]['maxlength']})";
+          if (isset($fieldSpec['maxlength'])) {
+            return "`$fieldName` varchar({$fieldSpec['maxlength']})";
           }
-          else {
-            return "`$fieldName` varchar(255)";
+          $dataType = $fieldSpec['data_type'] ?? '';
+          // set the sql columns for custom data
+          switch ($dataType) {
+            case 'String':
+              // May be option labels, which could be up to 512 characters
+              $length = max(512, CRM_Utils_Array::value('text_length', $fieldSpec));
+              return "`$fieldName` varchar($length)";
+
+            case 'Memo':
+              return "`$fieldName` text";
+
+            default:
+              return "`$fieldName` varchar(255)";
           }
 
         case CRM_Utils_Type::T_TEXT:
@@ -1483,36 +1494,10 @@ class CRM_Export_BAO_ExportProcessor {
       }
     }
     else {
-      if (substr($fieldName, -3, 3) == '_id') {
+      if (substr($fieldName, -3, 3) === '_id') {
         return "`$fieldName` varchar(255)";
       }
-      elseif (substr($fieldName, -5, 5) == '_note') {
-        return "`$fieldName` text";
-      }
-      else {
-        // set the sql columns for custom data
-        if (isset($queryFields[$columnName]['data_type'])) {
-
-          switch ($queryFields[$columnName]['data_type']) {
-            case 'String':
-              // May be option labels, which could be up to 512 characters
-              $length = max(512, CRM_Utils_Array::value('text_length', $queryFields[$columnName]));
-              return "`$fieldName` varchar($length)";
-
-            case 'Link':
-              return "`$fieldName` varchar(255)";
-
-            case 'Memo':
-              return "`$fieldName` text";
-
-            default:
-              return "`$fieldName` varchar(255)";
-          }
-        }
-        else {
-          return "`$fieldName` text";
-        }
-      }
+      return "`$fieldName` text";
     }
   }
 

--- a/tests/phpunit/CRM/Export/BAO/ExportTest.php
+++ b/tests/phpunit/CRM/Export/BAO/ExportTest.php
@@ -679,7 +679,9 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
   /**
    * Test custom data exporting.
    *
+   * @throws \API_Exception
    * @throws \CRM_Core_Exception
+   * @throws \Civi\API\Exception\UnauthorizedException
    * @throws \League\Csv\Exception
    */
   public function testExportCustomData() {
@@ -690,17 +692,20 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
     for ($i = 0; $i < 70; $i++) {
       $longString .= 'Blah';
     }
+    $this->addOptionToCustomField('select_string', ['label' => $longString, 'name' => 'blah']);
 
     $this->callAPISuccess('Contact', 'create', [
       'id' => $this->contactIDs[1],
       $this->getCustomFieldName('text') => $longString,
       $this->getCustomFieldName('country') => 'LA',
+      $this->getCustomFieldName('select_string') => 'blah',
       'api.Address.create' => ['location_type_id' => 'Billing', 'city' => 'Waipu'],
     ]);
     $selectedFields = [
       ['name' => 'city', 'location_type_id' => CRM_Core_PseudoConstant::getKey('CRM_Core_BAO_Address', 'location_type_id', 'Billing')],
       ['name' => $this->getCustomFieldName('text')],
       ['name' => $this->getCustomFieldName('country')],
+      ['name' => $this->getCustomFieldName('select_string')],
     ];
 
     $this->doExportTest([
@@ -711,6 +716,7 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
     $this->assertEquals($longString, $row['Enter text here']);
     $this->assertEquals('Waipu', $row['Billing-City']);
     $this->assertEquals("Lao People's Democratic Republic", $row['Country']);
+    $this->assertEquals($longString, $row['Pick Color']);
   }
 
   /**

--- a/tests/phpunit/CRMTraits/Custom/CustomDataTrait.php
+++ b/tests/phpunit/CRMTraits/Custom/CustomDataTrait.php
@@ -10,6 +10,8 @@
  */
 
 use Civi\Api4\CustomGroup;
+use Civi\Api4\CustomField;
+use Civi\Api4\OptionValue;
 
 /**
  * Trait Custom Data trait.
@@ -162,6 +164,25 @@ trait CRMTraits_Custom_CustomDataTrait {
    */
   protected function getCustomFieldName($key) {
     return 'custom_' . $this->getCustomFieldID($key);
+  }
+
+  /**
+   * Add another option to the custom field.
+   *
+   * @param string $key
+   * @param array $values
+   *
+   * @return int
+   * @throws \API_Exception
+   */
+  protected function addOptionToCustomField($key, $values) {
+    $optionGroupID = CustomField::get(FALSE)
+      ->addWhere('id', '=', $this->getCustomFieldID($key))
+      ->addSelect('option_group_id')
+      ->execute()->first()['option_group_id'];
+    return (int) OptionValue::create(FALSE)
+      ->setValues(array_merge(['option_group_id' => $optionGroupID], $values))
+      ->execute()->first()['value'];
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a code miss whereby improved metadata meant the code intended to handle custom
fields was not being hit, adds tests for fixed variant of a long option value

Before
----------------------------------------
Handling for 'data_type' parameter in the export class is also missed because it was based on the assumption that 'type' was not set. However, quite some time back we standardised custom fields to load the correct type in their metadata.

After
----------------------------------------
Metadata fixed, resulting in custom fields with longer option values exporting - per test

Technical Details
----------------------------------------
Needs a rebase once https://github.com/civicrm/civicrm-core/pull/18114 and #18147  are merged

Comments
----------------------------------------
@mlutfy 
