### PR TITLE
dev/core#1952 Remove uncessary component checking when exporting all …

### DIFF
--- a/CRM/Activity/Form/Task.php
+++ b/CRM/Activity/Form/Task.php
@@ -70,16 +70,6 @@ class CRM_Activity_Form_Task extends CRM_Core_Form_Task {
       // CRM-12675
       $activityClause = NULL;
 
-      $components = CRM_Core_Component::getNames();
-      $componentClause = [];
-      foreach ($components as $componentID => $componentName) {
-        if ($componentName != 'CiviCase' && !CRM_Core_Permission::check("access $componentName")) {
-          $componentClause[] = " (activity_type.component_id IS NULL OR activity_type.component_id <> {$componentID}) ";
-        }
-      }
-      if (!empty($componentClause)) {
-        $activityClause = implode(' AND ', $componentClause);
-      }
       $result = $query->searchQuery(0, 0, NULL, FALSE, FALSE, FALSE, FALSE, FALSE, $activityClause);
 
       while ($result->fetch()) {


### PR DESCRIPTION
…activities

Overview
----------------------------------------
This removes unnecessary component checking an an unnecessary join on activity_type table. THe component checking and permissions checking for activities is now part of the selectWhereClause as per https://github.com/civicrm/civicrm-core/commit/d1d108ee227039e6eee69dd037c626cd9b301c20#diff-e54381bfdf51e31cab376c71ca0d66ffR5050

Before
----------------------------------------
Legacy component checking permission checking based on join to activity_type

After
----------------------------------------
Export works and checking only done once

ping @eileenmcnaughton @demeritcowboy @pradpnayak 