### PR TITLE
Convert Manual processor to use the propertyBag

### DIFF
--- a/CRM/Contribute/BAO/Contribution/Utils.php
+++ b/CRM/Contribute/BAO/Contribution/Utils.php
@@ -172,6 +172,17 @@ class CRM_Contribute_BAO_Contribution_Utils {
           }
           $processorParams = $paymentParams;
           $result = $payment->doPayment($processorParams);
+          if (empty($result['fee_amount']) && is_array($processorParams) && !empty($processorParams['fee_amount'])) {
+            // It's possible a processor might be setting fee_amount in the processorParams
+            // & expecting it to be parsed as this may have happened historically (the array used to be
+            // passed on to weird & wonderful places.)
+            // We don't have to worry about the other return params we support as we can see
+            // below that trxn_id was always taking from what was returned, ditto payment_status_id.
+            // Note we add the is_array check as most processors are not using property bags & we can reasonably
+            // communicate the need to add this to return properties to the very few that are.
+            CRM_Core_Error::deprecatedFunctionWarning('fee amount should be returned from doPayment if it needs to be set');
+            $result['fee_amount'] = $processorParams['fee_amount'];
+          }
           $form->_params = array_merge($form->_params, $result);
           $form->assign('trxn_id', CRM_Utils_Array::value('trxn_id', $result));
           if (!empty($result['trxn_id'])) {

--- a/CRM/Contribute/BAO/Contribution/Utils.php
+++ b/CRM/Contribute/BAO/Contribution/Utils.php
@@ -170,7 +170,8 @@ class CRM_Contribute_BAO_Contribution_Utils {
             // and always calling it first.
             $form->postProcessHook();
           }
-          $result = $payment->doPayment($paymentParams);
+          $processorParams = $paymentParams;
+          $result = $payment->doPayment($processorParams);
           $form->_params = array_merge($form->_params, $result);
           $form->assign('trxn_id', CRM_Utils_Array::value('trxn_id', $result));
           if (!empty($result['trxn_id'])) {

--- a/CRM/Core/Payment/Manual.php
+++ b/CRM/Core/Payment/Manual.php
@@ -9,6 +9,8 @@
  +--------------------------------------------------------------------+
  */
 
+use Civi\Payment\PropertyBag;
+
 /**
  *
  * @package CRM
@@ -101,7 +103,7 @@ class CRM_Core_Payment_Manual extends CRM_Core_Payment {
    * The function ensures an exception is thrown & moves some of this logic out of the form layer and makes the forms
    * more agnostic.
    *
-   * @param array $params
+   * @param array|PropertyBag $params
    *
    * @param string $component
    *
@@ -111,8 +113,8 @@ class CRM_Core_Payment_Manual extends CRM_Core_Payment {
    * @throws \Civi\Payment\Exception\PaymentProcessorException
    */
   public function doPayment(&$params, $component = 'contribute') {
-    $params['payment_status_id'] = $this->getResult();
-    return $params;
+    $params = PropertyBag::cast($params);
+    return ['payment_status_id' => $this->getResult()];
   }
 
   /**


### PR DESCRIPTION


Overview
----------------------------------------
This separates the usage of the array that is passed to the payment processor from that which continues to be used by 

BAO_Contribution_Utils::processConfirm

This function is called from
postProcessMembership & processFormSubmission which are used from front end contribution pages and back office membership pages - who call it passing ```$paymentParams``` by reference. However ```$paymentParams``` is all things to all people and gets accessed for various purposed later on - which do not expect it to have been cast to a propertyBag or altered beyond as relates to the payment

Before
----------------------------------------
```
$result = $payment->doPayment($paymentParams);
```

After
----------------------------------------
```
$processorParams = $paymentParams;
 $result = $payment->doPayment($processorParams);
```

Technical Details
----------------------------------------
We encourage processors to cast to the propertyBag where it can meet their needs.

However the forms need to be altered to cope with the possibility this has happened. We can do this
by having them not attempt to re-use the params they pass to doPayment for other purposes. As
https://github.com/civicrm/civicrm-core/pull/17507 highlights this function continues to
use $membershipParams in the outer functionn - unaware that within it's depths a processor has
converted it to a propetyBag - in that PR it is then cast back but one functions
standardisation is another functions 'tampering' - any code calling this function should
not expect $params['is_recur'] to be replaced with $params['isRecur'].

In fact the only reason everything is being passed from pillar to post is that is how the code worked going back to
2.x & we are too scared to undo all those pass-by-references.

Comments
----------------------------------------
The alternative, of course, is to tell processors not to alter $params but instead to create a copy. However, I think breaking unpredictable interactions is a good idea regardless
