### PR TITLE
Use more appropriate money format function

### DIFF
--- a/CRM/Campaign/Form/Campaign.php
+++ b/CRM/Campaign/Form/Campaign.php
@@ -222,7 +222,7 @@ class CRM_Campaign_Form_Campaign extends CRM_Core_Form {
     $this->add('wysiwyg', 'goal_general', ts('Campaign Goals'), ['rows' => 2, 'cols' => 40]);
     $this->add('text', 'goal_revenue', ts('Revenue Goal'), ['size' => 8, 'maxlength' => 12]);
     $this->addRule('goal_revenue', ts('Please enter a valid money value (e.g. %1).',
-      [1 => CRM_Utils_Money::format('99.99', ' ')]
+      [1 => CRM_Utils_Money::formatLocaleNumericRoundedForDefaultCurrency(99.99)]
     ), 'money');
 
     // is this Campaign active


### PR DESCRIPTION
Overview
----------------------------------------
Use a preferred function to format currency only without currency symbols

<img width="545" alt="Screen Shot 2020-08-15 at 11 50 26 AM" src="https://user-images.githubusercontent.com/336308/90300282-d0ce0700-deed-11ea-8edd-ac128595cd94.png">
<img width="458" alt="Screen Shot 2020-08-15 at 11 54 26 AM" src="https://user-images.githubusercontent.com/336308/90300329-1b4f8380-deee-11ea-9282-2589e73673d6.png">




Before
----------------------------------------
Abuses CRM_Utils_Money::format by passing in a blank locale


After
----------------------------------------
Uses the appropriate function formatLocaleNumericRoundedForDefaultCurrency

Technical Details
----------------------------------------
@seamuslee001 I think this one works

Comments
----------------------------------------

