### PR TITLE
dev/core#1950 Update help text and description for the profile add to groups setting

### DIFF
--- a/CRM/UF/Form/AdvanceSetting.php
+++ b/CRM/UF/Form/AdvanceSetting.php
@@ -47,7 +47,7 @@ class CRM_UF_Form_AdvanceSetting extends CRM_UF_Form_Group {
     $form->addElement('text', 'notify', ts('Notify when profile form is submitted?'));
 
     //group where new contacts are directed.
-    $form->addElement('select', 'add_contact_to_group', ts('Add new contacts to a Group?'), $group);
+    $form->addElement('select', 'add_contact_to_group', ts('Add contacts to a group?'), $group);
 
     // add CAPTCHA To this group ?
     $form->addElement('checkbox', 'add_captcha', ts('Include reCAPTCHA?'));

--- a/js/model/crm.uf.js
+++ b/js/model/crm.uf.js
@@ -510,8 +510,8 @@
         options: YESNO
       },
       'add_to_group_id': {
-        title: ts('Add new contacts to a Group?'),
-        help: ts('Select a group if you are using this profile for adding new contacts, AND you want the new contacts to be automatically assigned to a group.'),
+        title: ts('Add contacts to a group?'),
+        help: ts('Select a group if you want contacts to be automatically added to that group when the profile is submitted.'),
         type: 'Number'
       },
       'cancel_URL': {

--- a/templates/CRM/UF/Form/Group.hlp
+++ b/templates/CRM/UF/Form/Group.hlp
@@ -63,7 +63,7 @@
   {ts}Add to Group{/ts}
 {/htxt}
 {htxt id='id-add_group'}
-{ts}Select a group if you are using this profile for adding new contacts, AND you want the new contacts to be automatically assigned to a group.{/ts}
+{ts}Select a group if you want contacts to be automatically added to that group when the profile is submitted.{/ts}
 {/htxt}
 
 {htxt id='id-notify_email-title'}


### PR DESCRIPTION
Overview
----------------------------------------
Edited help text and description for add to group in profile settings, per https://lab.civicrm.org/dev/core/-/issues/1950

Before
----------------------------------------
Option labelled  "Add new contacts to a Group?" with a help text "Select a group if you are using this profile for adding new contacts, AND you want the new contacts to be automatically assigned to a group."

After
----------------------------------------
Option labelled  "Add contacts to a group?" with a help text "
Select a group if you want contacts to be automatically added to that group when the profile is submitted."

