### PR TITLE
Mass SMS: Limit group selection to mailing groups

### DIFF
--- a/CRM/SMS/Form/Group.php
+++ b/CRM/SMS/Form/Group.php
@@ -102,7 +102,7 @@ class CRM_SMS_Form_Group extends CRM_Contact_Form_Task {
     );
 
     // Get the mailing groups.
-    $groups = CRM_Core_PseudoConstant::nestedGroup('Mailing');
+    $groups = CRM_Core_PseudoConstant::nestedGroup(TRUE, 'Mailing');
 
     // Get the sms mailing list.
     $mailings = CRM_Mailing_PseudoConstant::completed('sms');


### PR DESCRIPTION
Overview
----------------------------------------
To populate the selector for mass SMS recipients, the form calls CRM_Core_PseudoConstant::nestedGroup(). However the function call was missing an argument, so all groups were being returned, not just mailing groups as intended. This PR corrects the mistake.

Before
----------------------------------------
On Mailings > New SMS (civicrm/sms/send), "Include Groups" and "Exclude Groups" both list all groups, regardless of group type.

After
----------------------------------------
On Mailings > New SMS (civicrm/sms/send), "Include Groups" and "Exclude Groups" list only "Mailing list" groups.

Comments
----------------------------------------
It is clear from the code that this was the original intention, but one of the parameters was left out.