### PR TITLE
Remove legacy handling for 'fixing' line_item.entity_id

### DIFF
--- a/CRM/Price/BAO/LineItem.php
+++ b/CRM/Price/BAO/LineItem.php
@@ -426,17 +426,8 @@ WHERE li.contribution_id = %1";
         }
         if (!empty($contributionDetails->id)) {
           $line['contribution_id'] = $contributionDetails->id;
-          if ($line['entity_table'] == 'civicrm_contribution') {
+          if ($line['entity_table'] === 'civicrm_contribution') {
             $line['entity_id'] = $contributionDetails->id;
-          }
-          // CRM-19094: entity_table is set to civicrm_membership then ensure
-          // the entityId is set to membership ID not contribution by default
-          elseif ($line['entity_table'] == 'civicrm_membership' && !empty($line['entity_id']) && $line['entity_id'] == $contributionDetails->id) {
-            $membershipId = CRM_Core_DAO::getFieldValue('CRM_Member_DAO_MembershipPayment', $contributionDetails->id, 'membership_id', 'contribution_id');
-            if ($membershipId && (int) $membershipId !== (int) $line['entity_id']) {
-              $line['entity_id'] = $membershipId;
-              Civi::log()->warning('Per https://lab.civicrm.org/dev/core/issues/15 this data fix should not be required. Please log a ticket at https://lab.civicrm.org/dev/core with steps to get this.', ['civi.tag' => 'deprecated']);
-            }
           }
         }
 


### PR DESCRIPTION

Overview
----------------------------------------
Removes code deprecated in 2018 that causes the entity_id on a line item attached to a membership to be incorrect in edge circumstances, in an attempt to fix it in other edge cases. The deprecation notice has never been 'noticed' so is probably not hit

Before
----------------------------------------
When an Order is created with 2 line items, each linked to a membership (in this case linked to different contact ids) the second line item is altered to have the same membership id as the first. A deprecation notice is hit

After
----------------------------------------
Line items unchanged in processPriceSet

Technical Details
----------------------------------------
I tried to see what was happening with the test in https://github.com/civicrm/civicrm-core/pull/18113
and spotted that it wasn't using Order.api so the line items were likely wrong. However, once I set
it up to use the Order api I found the code we added back in 2018 to attempt to cope with other code
setting entity_id incorrectly was actually itself setting entity_id incorrectly. The issue
happens when there are 2 Memberships linked to one contribution & the removed code 'decides'
one is wrong and alters it. https://github.com/civicrm/civicrm-core/pull/11816

This line of code throws a deprecation notice - which has not been reported / apparently seen in the last
couple of years so I'm assuming it's not actually doing any good and without removing it this test actually
fails

Comments
----------------------------------------

