### PR TITLE
Remove deprecated code ids['userId']

### DIFF
--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -295,12 +295,7 @@ class CRM_Member_BAO_Membership extends CRM_Member_DAO_Membership {
 
     $transaction = new CRM_Core_Transaction();
 
-    // @todo remove $ids from here $ids['userId'] is still used
     $params['id'] = CRM_Utils_Array::value('id', $params, CRM_Utils_Array::value('membership', $ids));
-    if (empty($params['modified_id']) && !empty($ids['userID'])) {
-      CRM_Core_Error::deprecatedFunctionWarning('$ids["userID"] no longer supported - use $params["modified_id"]');
-      $params['modified_id'] = $ids['userID'];
-    }
     $membership = self::add($params);
 
     if (is_a($membership, 'CRM_Core_Error')) {


### PR DESCRIPTION


Overview
----------------------------------------
Remove a few deprecated lines of code

Before
----------------------------------------
```
$params['modified_id'] = $ids['userID'];
```

After
----------------------------------------
$ids['userID'] now ignored rather than just deprecated

Technical Details
----------------------------------------
<img width="894" alt="Screen Shot 2020-08-15 at 5 31 53 PM" src="https://user-images.githubusercontent.com/336308/90306066-91b7aa00-df1d-11ea-939d-70df075cfe90.png">


Comments
----------------------------------------
It just sets the modified_id on the membership log - pretty unlikely it was ever called outside of core
