### PR TITLE
Initial refactor of createProfileContact groups

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -2029,6 +2029,8 @@ ORDER BY civicrm_email.is_primary DESC";
     }
 
     // Process group and tag
+    // @todo Contact::create also calls addContactsToGroup/removeContactsToGroup
+    //   Remove from here and use the existing functionality in Contact::create
     if (isset($params['group'])) {
       $method = 'Admin';
       // this for sure means we are coming in via profile since i added it to fix
@@ -2036,7 +2038,35 @@ ORDER BY civicrm_email.is_primary DESC";
       if ($visibility) {
         $method = 'Web';
       }
-      CRM_Contact_BAO_GroupContact::create($params['group'], $contactID, $visibility, $method);
+      $groupParams = $params['group'] ?? [];
+      $contactIds = [$contactID];
+      $contactGroup = [];
+
+      if ($contactID) {
+        $contactGroupList = CRM_Contact_BAO_GroupContact::getContactGroup($contactID, 'Added',
+          NULL, FALSE, $visibility
+        );
+        if (is_array($contactGroupList)) {
+          foreach ($contactGroupList as $key) {
+            $groupId = $key['group_id'];
+            $contactGroup[$groupId] = $groupId;
+          }
+        }
+      }
+      // get the list of all the groups
+      $allGroup = CRM_Contact_BAO_GroupContact::getGroupList(0, $visibility);
+
+      // check which values has to be add/remove contact from group
+      foreach ($allGroup as $key => $varValue) {
+        if (!empty($groupParams[$key]) && !array_key_exists($key, $contactGroup)) {
+          // add contact to group
+          CRM_Contact_BAO_GroupContact::addContactsToGroup($contactIds, $key, $method);
+        }
+        elseif (empty($groupParams[$key]) && array_key_exists($key, $contactGroup)) {
+          // remove contact from group
+          CRM_Contact_BAO_GroupContact::removeContactsFromGroup($contactIds, $key, $method);
+        }
+      }
     }
 
     if (!empty($fields['tag']) && array_key_exists('tag', $params)) {
@@ -2045,7 +2075,8 @@ ORDER BY civicrm_email.is_primary DESC";
       CRM_Core_BAO_EntityTag::create($tags, 'civicrm_contact', $contactID);
     }
 
-    //to add profile in default group
+    // to add profile in default group
+    // @todo merge this with code above which also calls addContactsToGroup
     if (is_array($addToGroupID)) {
       $contactIds = [$contactID];
       foreach ($addToGroupID as $groupId) {

--- a/CRM/Contact/BAO/GroupContact.php
+++ b/CRM/Contact/BAO/GroupContact.php
@@ -33,7 +33,7 @@ class CRM_Contact_BAO_GroupContact extends CRM_Contact_DAO_GroupContact {
    * @param array $params
    *   (reference ) an assoc array of name/value pairs.
    *
-   * @return CRM_Contact_BAO_Group
+   * @return CRM_Contact_BAO_GroupContact
    */
   public static function add($params) {
     $hook = empty($params['id']) ? 'create' : 'edit';
@@ -473,7 +473,7 @@ SELECT    *
    *   Id of a particular group.
    *
    *
-   * @return groupID
+   * @return int groupID
    */
   public static function getGroupId($groupContactID) {
     $dao = new CRM_Contact_DAO_GroupContact();
@@ -485,19 +485,25 @@ SELECT    *
   /**
    * Creates / removes contacts from the groups
    *
-   * FIXME: Nonstandard create function; only called from CRM_Contact_BAO_Contact::createProfileContact
-   *
    * @param array $params
    *   Name/value pairs.
    * @param int $contactId
    *   Contact id.
-   *
    * @param bool $ignorePermission
    *   if ignorePermission is true we are coming in via profile mean $method = 'Web'
-   *
    * @param string $method
+   *
+   * @return CRM_Contact_BAO_GroupContact|void
    */
   public static function create($params, $contactId, $ignorePermission = FALSE, $method = 'Admin') {
+    if (empty($contactId)) {
+      return self::add($params);
+    }
+
+    // @fixme create was only called from CRM_Contact_BAO_Contact::createProfileContact
+    //   Now it's not called from anywhere so we can remove the below code after some time
+    CRM_Core_Error::deprecatedFunctionWarning('Use the GroupContact API');
+
     $contactIds = [$contactId];
     $contactGroup = [];
 

--- a/api/v3/GroupContact.php
+++ b/api/v3/GroupContact.php
@@ -116,7 +116,7 @@ function civicrm_api3_group_contact_create($params) {
       $params['contact_id'] = $info['values'][$params['id']]['contact_id'];
     }
   }
-  $action = CRM_Utils_Array::value('status', $params, 'Added');
+  $action = $params['status'] ?? 'Added';
   return _civicrm_api3_group_contact_common($params, $action);
 }
 

--- a/tests/phpunit/CRM/Contact/BAO/ContactTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/ContactTest.php
@@ -721,6 +721,14 @@ class CRM_Contact_BAO_ContactTest extends CiviUnitTestCase {
    * Test case for createProfileContact.
    */
   public function testCreateProfileContact() {
+    //Create 3 groups.
+    foreach (['group1', 'group2', 'group3'] as $key => $title) {
+      $this->groups["id{$key}"] = $this->callAPISuccess('Group', 'create', [
+        'title' => $title,
+        'visibility' => "Public Pages",
+      ])['id'];
+    }
+
     $fields = CRM_Contact_BAO_Contact::exportableFields('Individual');
 
     //current employer field for individual
@@ -773,11 +781,17 @@ class CRM_Contact_BAO_ContactTest extends CiviUnitTestCase {
         '4' => '1',
         '1' => '1',
       ],
+      'group' => [
+        $this->groups["id0"] => '1',
+      ],
     ];
     $createParams = array_merge($contactParams, $profileParams);
 
     //create the contact using create profile contact.
     $contactId = CRM_Contact_BAO_Contact::createProfileContact($createParams, $fields, NULL, NULL, NULL, NULL, TRUE);
+
+    //Make sure contact is added to the group.
+    $this->assertTrue(CRM_Contact_BAO_GroupContact::isContactInGroup($contactId, $this->groups["id0"]));
 
     //get the parameters to compare.
     $params = $this->contactParams();
@@ -976,6 +990,12 @@ class CRM_Contact_BAO_ContactTest extends CiviUnitTestCase {
         '2' => '1',
         '5' => '1',
       ],
+      //Remove the contact from group1 and add to other 2 groups.
+      'group' => [
+        $this->groups["id0"] => '',
+        $this->groups["id1"] => '1',
+        $this->groups["id2"] => '1',
+      ],
     ];
 
     $createParams = array_merge($updateCParams, $updatePfParams);
@@ -984,6 +1004,16 @@ class CRM_Contact_BAO_ContactTest extends CiviUnitTestCase {
     $contactID = CRM_Contact_BAO_Contact::createProfileContact($createParams, $fields, $contactId,
       NULL, NULL, NULL, TRUE
     );
+
+    //Verify if contact is correctly removed from group1
+    $groups = array_keys(CRM_Contact_BAO_GroupContact::getContactGroup($contactID, 'Removed'));
+    $expectedGroups = [$this->groups["id0"]];
+    $this->checkArrayEquals($expectedGroups, $groups);
+
+    //Verify if contact is correctly added to group1 and group2
+    $groups = array_keys(CRM_Contact_BAO_GroupContact::getContactGroup($contactID, 'Added'));
+    $expectedGroups = [$this->groups["id1"], $this->groups["id2"]];
+    $this->checkArrayEquals($expectedGroups, $groups);
 
     //check the contact ids
     $this->assertEquals($contactId, $contactID, 'check for Contact ids');


### PR DESCRIPTION
Overview
----------------------------------------
There is a lot of duplication in the "groupcontact" code for `createProfileContact`. That function is called in a *lot* of places, particularly when submitting contribution pages, profiles, etc. and groupcontacts are added/removed twice in `createProfileContact` and once in `Contact::create` so 3 times in total. That's a lot of duplication of effort and a lot of cache flushes triggered.

Before
----------------------------------------
`createProfileContact` is the only caller of `CRM_Contact_BAO_GroupContact::create`.

After
----------------------------------------
`createProfileContact` has some extra comments and implements it's own copy of `CRM_Contact_BAO_GroupContact::create` which allows us to deprecate the non-standard BAO create function and consolidate all the groupcontact code into one place for `createProfileContact`.

Technical Details
----------------------------------------
There should be no functional change at this point. It is just consolidating code so that it will be easier to start simplifying / optimising.

Comments
----------------------------------------
It would be nice to get rid of `createProfileContact` altogether one day but it's currently called in at least 28 places and it's going to take quite some untangling to work out what it is doing and what can be replaced by a simple Contact.create API call. Simplifying it should allow us to see that a bit better. For example, I *think* that we will be able to remove all the groupcontact code from this function and rely on handling in `Contact::create` but we need to get the data passed through in the right format and the `$visibility`/`$method` parameters are not currently available there. I'm also not sure if they will eventually be required or not.