### PR TITLE
dev/core#1954 Ensure that submitting a zero dolloar option when there…

### DIFF
--- a/templates/CRM/common/paymentBlock.tpl
+++ b/templates/CRM/common/paymentBlock.tpl
@@ -24,6 +24,7 @@
     // to be hidden (or removed) in which case it can go from this function.
     var billing_block = cj("div#billing-payment-block");
     if (isHide) {
+      cj('div#billing-payment-block select.crm-select2').addClass('crm-no-validate')
       payment_options.hide();
       payment_processor.hide();
       payment_information.hide();
@@ -32,6 +33,7 @@
       cj('input[name="payment_processor_id"]').removeProp('checked');
     }
     else {
+      cj('div#billing-payment-block select.crm-select2').removeClass('crm-no-validate')
       payment_options.show();
       payment_processor.show();
       payment_information.show();


### PR DESCRIPTION
… is no default country set works on a public contribution page

Overview
----------------------------------------
This fixes a bug where by if you have a zero dollar option on a contribution page and you have no default country you cannot proceed to the next step when contributing if you don't fill in the country field within the billing block

Before
----------------------------------------
jQuery incorrectly tries to validate the country field within the billing block

After
----------------------------------------
JQuery only validates the country field within the billing block section if it shows 

ping @KarinG @eileenmcnaughton @mattwire 