### PR TITLE
cvv required html attribute should depend on backoffice setting

### DIFF
--- a/CRM/Core/Payment.php
+++ b/CRM/Core/Payment.php
@@ -844,7 +844,7 @@ abstract class CRM_Core_Payment {
           'size' => 5,
           'maxlength' => 10,
           'autocomplete' => 'off',
-          'class' => 'required',
+          'class' => ($isCVVRequired ? 'required' : ''),
         ],
         'is_required' => $isCVVRequired,
         'rules' => [


### PR DESCRIPTION
Overview
----------------------------------------
This class was recently added in https://github.com/civicrm/civicrm-core/pull/18144 but should depend on the backoffice setting. It doesn't make any functional difference at the moment, but shouldn't be there when you submit a credit card via backoffice if the setting is off.

