### PR TITLE
cvv required html attribute should depend on backoffice setting

### DIFF
--- a/CRM/Core/Payment.php
+++ b/CRM/Core/Payment.php
@@ -844,7 +844,7 @@ abstract class CRM_Core_Payment {
           'size' => 5,
           'maxlength' => 10,
           'autocomplete' => 'off',
-          'class' => 'required',
+          'class' => ($isCVVRequired ? 'required' : ''),
         ],
         'is_required' => $isCVVRequired,
         'rules' => [


### PR DESCRIPTION
5.28 port of https://github.com/civicrm/civicrm-core/pull/18166