### PR TITLE
Check if $post defined before trying to use its field values.

### DIFF
--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -319,9 +319,9 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
     if ($config->userFrameworkFrontend) {
       global $post;
       if (get_option('permalink_structure') != '') {
-        $script = get_permalink($post->ID);
+        $script = $post ? get_permalink($post->ID) : "";
       }
-      if ($config->wpBasePage == $post->post_name) {
+      if ($post && $config->wpBasePage == $post->post_name) {
         $basepage = TRUE;
       }
       // when shortcode is included in page


### PR DESCRIPTION

Overview
----------------------------------------
Admin pages (e.g. in a custom plugin) may see $post as undefined. The existing usage to get permalinks for these pages can fill debug logs with PHP Notices.

Before
----------------------------------------
```
[16-Aug-2020 02:09:11 UTC] PHP Notice:  Trying to get property 'ID' of non-object in <webroot path>\wp-content\plugins\civicrm\civicrm\CRM\Utils\System\WordPress.php on line 286
[16-Aug-2020 02:09:11 UTC] PHP Notice:  Trying to get property 'post_name' of non-object in <webroot path>\wp-content\plugins\civicrm\civicrm\CRM\Utils\System\WordPress.php on line 288

```

After
----------------------------------------
Don't see the notice

Technical Details
----------------------------------------
The permalinks are not necessary if the $post variable is not set. It must be a page without a permalink if $post is not set.
