### PR TITLE
E_WARNING when saving event fees admin page if there's no discounts set

### DIFF
--- a/CRM/Event/Form/ManageEvent/Fee.php
+++ b/CRM/Event/Form/ManageEvent/Fee.php
@@ -814,7 +814,7 @@ class CRM_Event_Form_ManageEvent_Fee extends CRM_Event_Form_ManageEvent {
         $params['value'][$index] = CRM_Utils_Rule::cleanMoney(trim($value));
       }
     }
-    foreach ($params['discounted_value'] as $index => $discountedValueSet) {
+    foreach ($params['discounted_value'] ?? [] as $index => $discountedValueSet) {
       foreach ($discountedValueSet as $innerIndex => $value) {
         if (CRM_Utils_System::isNull($value)) {
           unset($params['discounted_value'][$index][$innerIndex]);


### PR DESCRIPTION
Overview
----------------------------------------
1. Go to administer an event page and go to the fees tab.
2. Don't have any discounts.
3. You need to click "Save and Done" to see this not "Save" otherwise it gets swallowed by ajax.

`Notice: Undefined index: discounted_value in CRM_Event_Form_ManageEvent_Fee->cleanMoneyFields() (line 817 of .../CRM/Event/Form/ManageEvent/Fee.php).`

`Warning: Invalid argument supplied for foreach() in CRM_Event_Form_ManageEvent_Fee->cleanMoneyFields() (line 817 of .../CRM/Event/Form/ManageEvent/Fee.php).`