### PR TITLE
dev/core#1937 - Upgrade message about needing composer patching turned on and updating mysql in DSN strings

### DIFF
--- a/CRM/Upgrade/Incremental/php/FiveTwentyNine.php
+++ b/CRM/Upgrade/Incremental/php/FiveTwentyNine.php
@@ -25,10 +25,11 @@ class CRM_Upgrade_Incremental_php_FiveTwentyNine extends CRM_Upgrade_Incremental
    * @param null $currentVer
    */
   public function setPreUpgradeMessage(&$preUpgradeMessage, $rev, $currentVer = NULL) {
-    // Example: Generate a pre-upgrade message.
-    // if ($rev == '5.12.34') {
-    //   $preUpgradeMessage .= '<p>' . ts('A new permission, "%1", has been added. This permission is now used to control access to the Manage Tags screen.', array(1 => ts('manage tags'))) . '</p>';
-    // }
+    if ($rev == '5.29.beta1') {
+      if (CIVICRM_UF === 'Drupal8') {
+        $preUpgradeMessage .= '<p>' . ts('<em>Pre-announcement for upcoming version 5.30</em>: If your composer configuration or composer.json does not enable patching, you MUST do that BEFORE running composer to update your files to version 5.30. Either by using `composer config \'extra.enable-patching\' true`, or updating the top level composer.json\'s extra section with `"enable-patching": true`. See %1 for details.', [1 => '<a href="' . CRM_Utils_System::docURL2('installation/drupal8', TRUE) . '">Drupal 8 installation guide</a>']) . '</p>';
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/1937

In drupal 8 you need composer's enable-patching to be turned on for civi patches to get applied.

Technical Details
----------------------------------------
In particular for 5.30 because pear::DB has moved, the patch that would get applied to handle automatically using mysqli instead of mysql in the dsn string won't get applied, so it crashes. Most sites likely still have mysql in their civicrm.settings.php dsn strings.

But there's other patches for civi needed too even **pre-5.30**, you just don't get a crash without them.

Comments
----------------------------------------
There's still more needed because you won't even be able to get to this upgrade message if you go straight from your current version to 5.30 and don't try to install a pre-5.30 version first.
