### PR TITLE
Installation doclinks not getting url-rewritten

### DIFF
--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -1419,7 +1419,7 @@ class CRM_Utils_System {
    * @return mixed
    */
   public static function formatDocUrl($url) {
-    return preg_replace('#^(user|sysadmin|dev)/#', '\1/en/latest/', $url);
+    return preg_replace('#^(installation|user|sysadmin|dev)/#', '\1/en/latest/', $url);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Installation is now its own docbook. The links to installation/XX need to redirect the same as the others or it gives a 404.

Comments
----------------------------------------
