### PR TITLE
Processors - remove gross_amount param from processors

### DIFF
--- a/CRM/Core/Payment/AuthorizeNet.php
+++ b/CRM/Core/Payment/AuthorizeNet.php
@@ -193,7 +193,6 @@ class CRM_Core_Payment_AuthorizeNet extends CRM_Core_Payment {
       default:
         // Success
         $params['trxn_id'] = !empty($response_fields[6]) ? $response_fields[6] : $this->getTestTrxnID();
-        $params['gross_amount'] = $response_fields[9];
         break;
     }
 

--- a/CRM/Core/Payment/Dummy.php
+++ b/CRM/Core/Payment/Dummy.php
@@ -97,7 +97,6 @@ class CRM_Core_Payment_Dummy extends CRM_Core_Payment {
 
     $params['trxn_id'] = $this->getTrxnID();;
 
-    $params['gross_amount'] = $propertyBag->getAmount();
     // Add a fee_amount so we can make sure fees are handled properly in underlying classes.
     $params['fee_amount'] = 1.50;
     $params['description'] = $this->getPaymentDescription($params);

--- a/CRM/Core/Payment/PayJunction.php
+++ b/CRM/Core/Payment/PayJunction.php
@@ -151,7 +151,6 @@ class CRM_Core_Payment_PayJunction extends CRM_Core_Payment {
     // Success
     $params['trxn_result_code'] = $pjpgResponse['dc_response_code'];
     $params['trxn_id'] = $pjpgResponse['dc_transaction_id'];
-    $params['gross_amount'] = $params['amount'];
 
     return $params;
   }

--- a/CRM/Core/Payment/PayPalImpl.php
+++ b/CRM/Core/Payment/PayPalImpl.php
@@ -339,7 +339,6 @@ class CRM_Core_Payment_PayPalImpl extends CRM_Core_Payment {
 
     /* Success */
     $params['trxn_id'] = $result['transactionid'];
-    $params['gross_amount'] = $result['amt'];
     $params['fee_amount'] = $result['feeamt'];
     $params['net_amount'] = $result['settleamt'] ?? NULL;
     if ($params['net_amount'] == 0 && $params['fee_amount'] != 0) {

--- a/CRM/Core/Payment/Realex.php
+++ b/CRM/Core/Payment/Realex.php
@@ -175,7 +175,6 @@ class CRM_Core_Payment_Realex extends CRM_Core_Payment {
     $params['trxn_id'] = $response['PASREF'];
     $params['trxn_result_code'] = serialize($extras);
     $params['currencyID'] = $this->_getParam('currency');
-    $params['gross_amount'] = $this->_getParam('amount');
     $params['fee_amount'] = 0;
 
     return $params;

--- a/CRM/Core/Payment/eWAY.php
+++ b/CRM/Core/Payment/eWAY.php
@@ -340,7 +340,6 @@ class CRM_Core_Payment_eWAY extends CRM_Core_Payment {
       $beaglestatus = ': ' . $beaglestatus;
     }
     $params['trxn_result_code'] = $eWAYResponse->Status() . $beaglestatus;
-    $params['gross_amount'] = $eWAYResponse->Amount();
     $params['trxn_id'] = $eWAYResponse->TransactionNumber();
 
     return $params;


### PR DESCRIPTION


Overview
----------------------------------------
The gross_amount param is returned by a bunch of processors but is not used so this removes it.

The core processors are often used as a starting point for extensions - we can see for example
this parameter is present in IATS so removing it helps clarify it as unnecessary & unused

Before
----------------------------------------
Searching finds gross_amount (and variants) only used in processor classes

<img width="1272" alt="Screen Shot 2020-08-17 at 12 28 21 PM" src="https://user-images.githubusercontent.com/336308/90347725-2b01d000-e086-11ea-92fa-a3a85c452d3b.png">
_

After
----------------------------------------
<img width="1279" alt="Screen Shot 2020-08-17 at 12 35 58 PM" src="https://user-images.githubusercontent.com/336308/90347740-381ebf00-e086-11ea-8611-15b05dfd7b65.png">


Technical Details
----------------------------------------
Paypal uses it internally so I have not removed it from there 

Comments
----------------------------------------
Towards https://lab.civicrm.org/dev/financial/-/issues/135
