### PR TITLE
dev/financial#135 Fix Authorize.net to implement doPayment not doDirectPayment

### DIFF
--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -1124,7 +1124,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
       $payment = Civi\Payment\System::singleton()->getByProcessor($this->_paymentProcessor);
       try {
         $completeStatusId = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Completed');
-        $result = $payment->doPayment($paymentParams, 'contribute');
+        $result = $payment->doPayment($paymentParams);
         $this->assign('trxn_id', $result['trxn_id']);
         $contribution->trxn_id = $result['trxn_id'];
         /* Our scenarios here are

--- a/CRM/Core/Payment.php
+++ b/CRM/Core/Payment.php
@@ -1368,9 +1368,8 @@ abstract class CRM_Core_Payment {
     // If we have a $0 amount, skip call to processor and set payment_status to Completed.
     // Conceivably a processor might override this - perhaps for setting up a token - but we don't
     // have an example of that at the mome.
-    if ($params['amount'] == 0) {
-      $result['payment_status_id'] = array_search('Completed', $statuses);
-      return $result;
+    if ((float) $params['amount'] === 0.0) {
+      return $this->getSuccessResult();
     }
 
     if ($this->_paymentProcessor['billing_mode'] == 4) {
@@ -1846,6 +1845,15 @@ INNER JOIN civicrm_contribution con ON ( con.contribution_recur_id = rec.id )
    */
   public function isSendReceiptForPending() {
     return FALSE;
+  }
+
+  /**
+   * Get the result array to return from doPayment on success.
+   *
+   * @return array
+   */
+  protected function getSuccessResult(): array {
+    return ['payment_status_id' => CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Completed')];
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
We have recommended processors implement doPayment and NOT doDirectPayment or doTransferPayment for a long
time but have not modelled this in core, leading to the wrong code being copied & propagaged into
extensions.  Note Authorize.net is the most tested of the core extensions - we should be able to do the same to the others based on this one without individually testing them

Before
----------------------------------------
Authorize.net implements doDirectPayment

After
----------------------------------------
Authorize.net implements doPayment

Technical Details
----------------------------------------
As Karing outlined here https://lab.civicrm.org/dev/financial/-/issues/135
we need to ensure exceptions are thrown - that is already done. We also need to

1) ensure this->component is set for the return urls
2) handle zero amounts
3) ensure payment_status_id is set
4) rename the function

Comments
----------------------------------------

Recurring is covered in testIPNPaymentRecurNoReceipt