### PR TITLE
dev/core#1941 Revert "Fix issues with select2 validation when it is part of hidden 'On behalf of organisation' block"

### DIFF
--- a/templates/CRM/Contribute/Form/Contribution/OnBehalfOf.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/OnBehalfOf.tpl
@@ -54,23 +54,12 @@
     selectCreateOrg(orgOption, false);
 
     if (is_for_organization.length) {
-      showHideOnBehalfOfBlock();
-
-      is_for_organization.on('change', function() {
-        showHideOnBehalfOfBlock();
-      });
-    }
-
-    function showHideOnBehalfOfBlock() {
       $('#on-behalf-block').toggle(is_for_organization.is(':checked'));
-
-      if (is_for_organization.is(':checked')) {
-        $('#onBehalfOfOrg select.crm-select2').removeClass('crm-no-validate');
-      }
-      else {
-        $('#onBehalfOfOrg select.crm-select2').addClass('crm-no-validate');
-      }
     }
+
+    is_for_organization.on('change', function(){
+      $('#on-behalf-block').toggle($(this).is(':checked'));
+    });
 
     $("input:radio[name='org_option']").click( function( ) {
       var orgOption = $(this).attr('id');


### PR DESCRIPTION
Overview
----------------------------------------

This partially reverts commit 2ee6dbf5b8ee194e0d495d4ea8fc21575151973f which appears to have caused a minor regression


Before
----------------------------------------
Description per https://lab.civicrm.org/dev/core/-/issues/1941

After
----------------------------------------
@KarinG Can you confirm if the bug goes away with this

Technical Details
----------------------------------------


Comments
----------------------------------------
I haven't attempted to figure out a fix at this stage - I've just been trying to replicate & track it down- I suspect @mattwire would prefer to propose a fix than to have this reverted & we still have another day or so before we need to finalise this.
