### PR TITLE
Upgrade screen - show success instead of error if already upgraded

### DIFF
--- a/CRM/Upgrade/Page/Upgrade.php
+++ b/CRM/Upgrade/Page/Upgrade.php
@@ -78,34 +78,48 @@ class CRM_Upgrade_Page_Upgrade extends CRM_Core_Page {
     $template = CRM_Core_Smarty::singleton();
     list($currentVer, $latestVer) = $upgrade->getUpgradeVersions();
 
-    if ($error = $upgrade->checkUpgradeableVersion($currentVer, $latestVer)) {
+    // Show success msg if db already upgraded
+    if (version_compare($currentVer, $latestVer) == 0) {
+      $template->assign('upgraded', TRUE);
+      $template->assign('newVersion', $latestVer);
+      CRM_Utils_System::setTitle(ts('Your database has already been upgraded to CiviCRM %1',
+        [1 => $latestVer]
+      ));
+      $template->assign('pageTitle', ts('Your database has already been upgraded to CiviCRM %1',
+        [1 => $latestVer]
+      ));
+    }
+
+    // Throw error if db in unexpected condition
+    elseif ($error = $upgrade->checkUpgradeableVersion($currentVer, $latestVer)) {
       throw new CRM_Core_Exception($error);
     }
 
-    $config = CRM_Core_Config::singleton();
+    else {
+      $config = CRM_Core_Config::singleton();
 
-    // All cached content needs to be cleared because the civi codebase was just replaced
-    CRM_Core_Resources::singleton()->flushStrings()->resetCacheCode();
+      // All cached content needs to be cleared because the civi codebase was just replaced
+      CRM_Core_Resources::singleton()->flushStrings()->resetCacheCode();
 
-    // cleanup only the templates_c directory
-    $config->cleanup(1, FALSE);
+      // cleanup only the templates_c directory
+      $config->cleanup(1, FALSE);
 
-    $preUpgradeMessage = NULL;
-    $upgrade->setPreUpgradeMessage($preUpgradeMessage, $currentVer, $latestVer);
+      $preUpgradeMessage = NULL;
+      $upgrade->setPreUpgradeMessage($preUpgradeMessage, $currentVer, $latestVer);
 
-    $template->assign('currentVersion', $currentVer);
-    $template->assign('newVersion', $latestVer);
-    $template->assign('upgradeTitle', ts('Upgrade CiviCRM from v %1 To v %2',
-      [1 => $currentVer, 2 => $latestVer]
-    ));
-    $template->assign('upgraded', FALSE);
+      $template->assign('preUpgradeMessage', $preUpgradeMessage);
+      $template->assign('currentVersion', $currentVer);
+      $template->assign('newVersion', $latestVer);
+      $template->assign('upgradeTitle', ts('Upgrade CiviCRM from v %1 To v %2',
+        [1 => $currentVer, 2 => $latestVer]
+      ));
+      $template->assign('upgraded', FALSE);
+    }
 
     // Render page header
     if (!defined('CIVICRM_UF_HEAD') && $region = CRM_Core_Region::instance('html-header', FALSE)) {
       CRM_Utils_System::addHTMLHead($region->render(''));
     }
-
-    $template->assign('preUpgradeMessage', $preUpgradeMessage);
 
     $content = $template->fetch('CRM/common/success.tpl');
     echo CRM_Utils_System::theme($content, $this->_print, TRUE);


### PR DESCRIPTION
Overview
----------------------------------------
Fixes an annoying UI issue where the visiting `/civicrm/upgrade` will show a red error message if there are no pending upgrades to be done. People have commented over the years that it shouldn't look like an error, because it isn't.

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/2874912/90415430-13731900-e07f-11ea-8a5a-2f48b7536934.png)


After
----------------------------------------
![image](https://user-images.githubusercontent.com/2874912/90415357-f8a0a480-e07e-11ea-8a60-3c2833b0e9cc.png)

