### PR TITLE
Remove unnecessary transformation of upgrade msg severity

### DIFF
--- a/CRM/Utils/Check/Component/Env.php
+++ b/CRM/Utils/Check/Component/Env.php
@@ -504,15 +504,9 @@ class CRM_Utils_Check_Component_Env extends CRM_Utils_Check_Component {
     }
 
     if ($vc->isInfoAvailable) {
-      $severities = [
-        'info' => CRM_Utils_Check::severityMap(\Psr\Log\LogLevel::INFO),
-        'notice' => CRM_Utils_Check::severityMap(\Psr\Log\LogLevel::NOTICE) ,
-        'warning' => CRM_Utils_Check::severityMap(\Psr\Log\LogLevel::WARNING) ,
-        'critical' => CRM_Utils_Check::severityMap(\Psr\Log\LogLevel::CRITICAL),
-      ];
       foreach ($vc->getVersionMessages() ?? [] as $msg) {
         $messages[] = new CRM_Utils_Check_Message(__FUNCTION__ . '_' . $msg['name'],
-          $msg['message'], $msg['title'], $severities[$msg['severity']], 'fa-cloud-upload');
+          $msg['message'], $msg['title'], $msg['severity'], 'fa-cloud-upload');
       }
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
Removes unnecessary code that ultimately does nothing.

Before
----------------------------------------
Severity string coming back from the server would be put through some complex transformation that didn't ultimately do anything.

After
----------------------------------------
The original string was fine.

Technical Details
----------------------------------------
The constructor it's being passed to works just fine with with string input, and the strings are already correct.