### PR TITLE
CRM_Utils_VersionCheck - respect force param

### DIFF
--- a/CRM/Utils/Check/Component/Env.php
+++ b/CRM/Utils/Check/Component/Env.php
@@ -471,13 +471,15 @@ class CRM_Utils_Check_Component_Env extends CRM_Utils_Check_Component {
 
   /**
    * Checks if new versions are available
+   * @param bool $force
    * @return CRM_Utils_Check_Message[]
+   * @throws CRM_Core_Exception
    */
-  public function checkVersion() {
+  public function checkVersion($force = FALSE) {
     $messages = [];
     try {
       $vc = new CRM_Utils_VersionCheck();
-      $vc->initialize();
+      $vc->initialize($force);
     }
     catch (Exception $e) {
       $messages[] = new CRM_Utils_Check_Message(
@@ -492,7 +494,7 @@ class CRM_Utils_Check_Component_Env extends CRM_Utils_Check_Component {
     }
 
     // Show a notice if the version_check job is disabled
-    if (empty($vc->cronJob['is_active'])) {
+    if (!$force && empty($vc->cronJob['is_active'])) {
       $args = empty($vc->cronJob['id']) ? ['reset' => 1] : ['reset' => 1, 'action' => 'update', 'id' => $vc->cronJob['id']];
       $messages[] = new CRM_Utils_Check_Message(
         'checkVersionDisabled',

--- a/CRM/Utils/VersionCheck.php
+++ b/CRM/Utils/VersionCheck.php
@@ -74,9 +74,10 @@ class CRM_Utils_VersionCheck {
   /**
    * Self-populates version info
    *
-   * @throws \Exception
+   * @param bool $force
+   * @throws Exception
    */
-  public function initialize() {
+  public function initialize($force = FALSE) {
     $this->getJob();
 
     // Populate remote $versionInfo from cache file
@@ -84,9 +85,9 @@ class CRM_Utils_VersionCheck {
 
     // Fallback if scheduled job is enabled but has failed to run.
     $expiryTime = time() - self::CACHEFILE_EXPIRE;
-    if (!empty($this->cronJob['is_active']) &&
+    if ($force || (!empty($this->cronJob['is_active']) &&
       (!$this->isInfoAvailable || filemtime($this->cacheFile) < $expiryTime)
-    ) {
+    )) {
       // First try updating the files modification time, for 2 reasons:
       //  - if the file is not writeable, this saves the trouble of pinging back
       //  - if the remote server is down, this will prevent an immediate retry


### PR DESCRIPTION
Overview
----------------------------------------
Makes the versionCheck job more consistent with other checks by respecting the apiv4's setting to run even if disabled.

Before
----------------------------------------
Reads data from cache if not stale.

After
----------------------------------------
In force mode, will always skip cache.
