### PR TITLE
E_NOTICE on contribution page widget tab

### DIFF
--- a/CRM/Contribute/Form/ContributionPage/Widget.php
+++ b/CRM/Contribute/Form/ContributionPage/Widget.php
@@ -40,7 +40,7 @@ class CRM_Contribute_Form_ContributionPage_Widget extends CRM_Contribute_Form_Co
 
     $this->assign('cpageId', $this->_id);
 
-    $this->assign('widgetExternUrl', CRM_Utils_System::externUrl('extern/widget', "cpageId={$this->_id}&widgetId={$this->_widget->id}&format=3"));
+    $this->assign('widgetExternUrl', CRM_Utils_System::externUrl('extern/widget', "cpageId={$this->_id}&widgetId=" . ($this->_widget->id ?? '') . "&format=3"));
 
     $config = CRM_Core_Config::singleton();
     $title = CRM_Core_DAO::getFieldValue('CRM_Contribute_DAO_ContributionPage',

--- a/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
@@ -1721,4 +1721,32 @@ Price Field - Price Field 1        1   $ 100.00      $ 100.00
     unset($_REQUEST['id']);
   }
 
+  /**
+   * Mostly just check there's no errors opening the Widget tab on contribution
+   * pages.
+   */
+  public function testOpeningWidgetAdminPage() {
+    $page_id = $this->callAPISuccess('ContributionPage', 'create', [
+      'title' => 'my page',
+      'financial_type_id' => $this->_financialTypeId,
+      'payment_processor' => $this->paymentProcessorID,
+    ])['id'];
+
+    $form = new CRM_Contribute_Form_ContributionPage_Widget();
+    $form->controller = new CRM_Core_Controller_Simple('CRM_Contribute_Form_ContributionPage_Widget', 'Widget');
+
+    $form->set('reset', '1');
+    $form->set('action', 'update');
+    $form->set('id', $page_id);
+
+    ob_start();
+    $form->controller->_actions['display']->perform($form, 'display');
+    $contents = ob_get_contents();
+    ob_end_clean();
+
+    // The page contents load later by ajax, so there's just the surrounding
+    // html available now, but we can check at least one thing while we're here.
+    $this->assertStringContainsString("selectedTab = 'widget';", $contents);
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Create a new contribution page and go to the widget tab.

`Trying to get property 'id' of non-object in CRM_Contribute_Form_ContributionPage_Widget->preProcess() (line 43 of .../CRM/Contribute/Form/ContributionPage/Widget.php)`

You don't see it though because it's hidden by ajax. You can see it in drupal watchdog.


Technical Details
----------------------------------------
It's because `$this->_widget` is null if it's a new contribution page or you've never configured the widget, but then it tries to set the widgetExternUrl using `$this->_widget->id`.

Comments
----------------------------------------
Has test
