### PR TITLE
dev/core#1961 Fix regression - cancel button not working on recurring contributions

### DIFF
--- a/templates/CRM/Contribute/Page/ContributionRecurSelector.tpl
+++ b/templates/CRM/Contribute/Page/ContributionRecurSelector.tpl
@@ -7,6 +7,7 @@
  | and copyright information, see https://civicrm.org/licensing       |
  +--------------------------------------------------------------------+
 *}
+{include file="CRM/common/enableDisableApi.tpl"}
 {strip}
   <table class="selector row-highlight">
     <tr class="columnheader">


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a regression introduced in 5.29 where the cancel button does not work, with some processors, for recurring contributions

Before
----------------------------------------
Button does nothing when clicked

After
----------------------------------------
<img width="333" alt="Screen Shot 2020-08-20 at 11 17 14 PM" src="https://user-images.githubusercontent.com/336308/90763728-506b3400-e33b-11ea-8718-49970172b350.png">

Technical Details
----------------------------------------
Note this form only shows for some processors. To test an easy way is to edit
CRM_Core_Payment::supportsCancelRecurring to always return FALSE

Then attempt to cancel a recurring contribution - the cancel button does not launch a form
without this.

Regression from
https://github.com/civicrm/civicrm-core/pull/17178/files#diff-63d76bd172c85725aaf2e76247b86354L11

https://lab.civicrm.org/dev/core/-/issues/1961

Comments
----------------------------------------
Regression affects 5.27, 5.28, 5.29

This behaviour may change again in https://github.com/civicrm/civicrm-core/pull/18196
