### PR TITLE
dev/core#1963 - Expanded icon on manage groups appears as unknown icon

### DIFF
--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -2281,6 +2281,7 @@ div.crm-master-accordion-header a.helpicon {
 .crm-container span.expanded:before,
 .crm-container a.expanded:before,
 .crm-container .crm-expand-row.expanded:before {
+  font-family: "FontAwesome";
   content: "\f0d7";
 }
 


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/1963

Create a subgroup.
Go to Contacts - Manage Groups.
Click the triangle next to the parent group.
Icon becomes an unknown icon.

Before
----------------------------------------
See lab ticket

After
----------------------------------------
Downwards pointy triangle.

Technical Details
----------------------------------------
It's missing the font-family.

Comments
----------------------------------------

