### PR TITLE
dev/core#1959 Brick\Math\Exception\RoundingNecessaryException

### DIFF
--- a/CRM/Utils/Money.php
+++ b/CRM/Utils/Money.php
@@ -139,8 +139,9 @@ class CRM_Utils_Money {
    */
   public static function subtractCurrencies($leftOp, $rightOp, $currency) {
     if (is_numeric($leftOp) && is_numeric($rightOp)) {
-      $money = Money::of($leftOp, $currency, new DefaultContext(), RoundingMode::CEILING);
-      return $money->minus($rightOp)->getAmount()->toFloat();
+      $leftMoney = Money::of($leftOp, $currency, new DefaultContext(), RoundingMode::CEILING);
+      $rightMoney = Money::of($rightOp, $currency, new DefaultContext(), RoundingMode::CEILING);
+      return $leftMoney->minus($rightMoney)->getAmount()->toFloat();
     }
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
When viewing/editing a contribution, throws  Brick\Math\Exception\RoundingNecessaryException: "Rounding is necessary to represent the result of the operation at this scale." 

Happens in 5.28.0 as a regression of #17608 

Before
----------------------------------------
Steps to reproduce
1. Install Civi with sample data
1. Go to any contact
1. Create a new General membership with default values (Completed status etc) **Amount should be $100.00**
1. Go to contributions tab and view the new contribution
1. Throws the following error
![error](https://user-images.githubusercontent.com/33434409/90791752-825fa480-e301-11ea-8b25-f652120619c4.PNG)


After
----------------------------------------
Contribution can be viewed/edited correctly

Technical Details
----------------------------------------
The issue happens due to BCMath PHP extension. If GMP is installed, it works as intended. The following code in BrickMath chooses the class accordingly https://github.com/brick/math/blob/63dc40f6a2bbebf670b4d4b5f16bef2458a61402/src/Internal/Calculator.php#L76-L94 

    /**
     * Returns the fastest available Calculator implementation.
     *
     * @codeCoverageIgnore
     *
     * @return Calculator
     */
    private static function detect() : Calculator
    {
        if (\extension_loaded('gmp')) {
            return new Calculator\GmpCalculator();
        }


        if (\extension_loaded('bcmath')) {
            return new Calculator\BcMathCalculator();
        }


        return new Calculator\NativeCalculator();
    }

Upon further investigation showed  that while `$leftOp` amount is taken as `BigNumber` while `$rightOp` is taken as `BigRational` as that amount is not converted in the following code https://github.com/civicrm/civicrm-core/blob/c3852f1c14a206e0218b9502f4d35110fb47e745/CRM/Utils/Money.php#L141-L144

Therefore added code to get `Money::of` to `$rightOP` as well.

Comments
----------------------------------------
Not sure how rounding might affect this
