### PR TITLE
(NFC) Add some tests to the `resources` group

### DIFF
--- a/tests/phpunit/CRM/Core/RegionTest.php
+++ b/tests/phpunit/CRM/Core/RegionTest.php
@@ -3,6 +3,7 @@
 /**
  * Class CRM_Core_RegionTest
  * @group headless
+ * @group resources
  */
 class CRM_Core_RegionTest extends CiviUnitTestCase {
 

--- a/tests/phpunit/CRM/Core/Resources/StringsTest.php
+++ b/tests/phpunit/CRM/Core/Resources/StringsTest.php
@@ -12,6 +12,7 @@
 /**
  * Tests for parsing translatable strings in HTML content.
  * @group headless
+ * @group resources
  */
 class CRM_Core_Resources_StringsTest extends CiviUnitTestCase {
 

--- a/tests/phpunit/CRM/Core/ResourcesTest.php
+++ b/tests/phpunit/CRM/Core/ResourcesTest.php
@@ -12,6 +12,7 @@
 /**
  * Tests for linking to resource files
  * @group headless
+ * @group resources
  */
 class CRM_Core_ResourcesTest extends CiviUnitTestCase {
 


### PR DESCRIPTION
Overview
----------------------------------------
This is a small nicety for doing development in the realm of resources/regions/assets. There are a handful of distinct test classes in this area, and (when running locally to identify regressions) it's easier to run them as a group.

This helped me get my head around some flip-floppy stuff where different variations in a patch would raise different red-flags in different tests.

Before
----------------------------------------

```
env CIVICRM_UF=UnitTests phpunit6 --stop-on-failure --debug tests/phpunit/CRM/Core/RegionTest.php
env CIVICRM_UF=UnitTests phpunit6 --stop-on-failure --debug tests/phpunit/CRM/Core/Resources/StringsTest.php
env CIVICRM_UF=UnitTests phpunit6 --stop-on-failure --debug tests/phpunit/CRM/Core/ResourcesTest.php
```

After
----------------------------------------

```
env CIVICRM_UF=UnitTests phpunit6 --group resources --stop-on-failure --debug
```