### PR TITLE
Fix regression whereby deleted contacts are in quicksearch results

### DIFF
--- a/api/v3/Contact.php
+++ b/api/v3/Contact.php
@@ -818,7 +818,7 @@ function civicrm_api3_contact_getquick($params) {
   }
 
   $select = $actualSelectElements = ['sort_name'];
-  $where = '';
+
   foreach ($list as $value) {
     $suffix = substr($value, 0, 2) . substr($value, -1);
     switch ($value) {
@@ -875,14 +875,14 @@ function civicrm_api3_contact_getquick($params) {
 
   // add acl clause here
   list($aclFrom, $aclWhere) = CRM_Contact_BAO_Contact_Permission::cacheClause('cc');
-
+  $whereClauses = ['cc.is_deleted = 0'];
   if ($aclWhere) {
-    $where .= " AND $aclWhere ";
+    $whereClauses[] = $aclWhere;
   }
   $isPrependWildcard = \Civi::settings()->get('includeWildCardInName');
 
   if (!empty($params['org'])) {
-    $where .= " AND contact_type = \"Organization\"";
+    $whereClauses[] = 'contact_type = "Organization"';
 
     // CRM-7157, hack: get current employer details when
     // employee_id is present.
@@ -914,21 +914,21 @@ function civicrm_api3_contact_getquick($params) {
 
   if (!empty($params['contact_sub_type'])) {
     $contactSubType = CRM_Utils_Type::escape($params['contact_sub_type'], 'String');
-    $where .= " AND cc.contact_sub_type = '{$contactSubType}'";
+    $whereClauses[] = "cc.contact_sub_type = '{$contactSubType}'";
   }
 
   if (!empty($params['contact_type'])) {
     $contactType = CRM_Utils_Type::escape($params['contact_type'], 'String');
-    $where .= " AND cc.contact_type LIKE '{$contactType}'";
+    $whereClauses[] = "cc.contact_type LIKE '{$contactType}'";
   }
 
   // Set default for current_employer or return contact with particular id
   if (!empty($params['id'])) {
-    $where .= " AND cc.id = " . (int) $params['id'];
+    $whereClauses[] = 'cc.id = ' . (int) $params['id'];
   }
 
   if (!empty($params['cid'])) {
-    $where .= " AND cc.id <> " . (int) $params['cid'];
+    $whereClauses[] = 'cc.id <> ' . (int) $params['cid'];
   }
 
   // Contact's based of relationhip type
@@ -949,10 +949,10 @@ function civicrm_api3_contact_getquick($params) {
   if ($config->includeNickNameInName) {
     $includeNickName = " OR nick_name LIKE '$strSearch'";
   }
-
+  $where = ' AND ' . implode(' AND ', $whereClauses);
   if (isset($customOptionsWhere)) {
     $customOptionsWhere = $customOptionsWhere ?: [0];
-    $whereClause = " WHERE (" . implode(' OR ', $customOptionsWhere) . ") $where";
+    $whereClause = ' WHERE (' . implode(' OR ', $customOptionsWhere) . ") $where";
   }
   elseif (!empty($params['field_name']) && !empty($params['table_name']) && $params['field_name'] != 'sort_name') {
     $whereClause = " WHERE ( $table_name.$field_name LIKE '$strSearch') {$where}";

--- a/tests/phpunit/api/v3/ContactTest.php
+++ b/tests/phpunit/api/v3/ContactTest.php
@@ -3306,7 +3306,7 @@ class api_v3_ContactTest extends CiviUnitTestCase {
    * Test that getquick returns contacts with an exact first name match first.
    */
   public function testGetQuickID() {
-    $max = CRM_Core_DAO::singleValueQuery("SELECT max(id) FROM civicrm_contact");
+    $max = CRM_Core_DAO::singleValueQuery('SELECT max(id) FROM civicrm_contact');
     $this->getQuickSearchSampleData();
     $result = $this->callAPISuccess('contact', 'getquick', [
       'name' => $max + 2,
@@ -3479,6 +3479,28 @@ class api_v3_ContactTest extends CiviUnitTestCase {
     $this->callAPISuccess('Setting', 'create', ['includeOrderByClause' => FALSE]);
     $result = $this->callAPISuccess('contact', 'getquick', ['name' => 'bob']);
     $this->assertEquals('Bob, Bob :: bob@bob.com', $result['values'][0]['data']);
+  }
+
+  /**
+   * Test deleted contacts are excluded from getquick results.
+   *
+   * @throws \CiviCRM_API3_Exception
+   */
+  public function testGetQuickNotDeleted() {
+    $this->getQuickSearchSampleData();
+    $result = $this->callAPISuccess('contact', 'getquick', [
+      'name' => 'abc',
+      'field_name' => 'external_identifier',
+      'table_name' => 'cc',
+    ])['values'];
+    $this->assertCount(1, $result);
+    $this->callAPISuccess('Contact', 'delete', ['id' => $result['0']['id']]);
+    $result = $this->callAPISuccess('contact', 'getquick', [
+      'name' => 'abc',
+      'field_name' => 'external_identifier',
+      'table_name' => 'cc',
+    ])['values'];
+    $this->assertCount(0, $result);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a recent regression (5.27?) where deleted contacts returned in quicksearch results

As with https://github.com/civicrm/civicrm-core/pull/17798 it regressed in 5.27 but was not picked up until today

Before
----------------------------------------
Quicksearch results include deleted contacts

After
----------------------------------------
Contacts excluded

Technical Details
----------------------------------------
Note that there are several other tests on this function around the added test. I slightly cleaned up the building of $where 

Comments
----------------------------------------

