### PR TITLE
Metadata fix in activity search

### DIFF
--- a/CRM/Activity/BAO/Query.php
+++ b/CRM/Activity/BAO/Query.php
@@ -189,7 +189,7 @@ class CRM_Activity_BAO_Query {
         // We no longer expect "subject" as a specific criteria (as of CRM-19447),
         // but we still use activity_subject in Activity.Get API
       case 'activity_subject':
-        $query->_where[$grouping][] = CRM_Contact_BAO_Query::buildClause($fieldSpec['where'], $op, $value, CRM_Utils_Type::typeToString($fieldSpec['type']));
+        $query->_where[$grouping][] = CRM_Contact_BAO_Query::buildClause($fieldSpec['where'], $op, $value, $query->getDataTypeForRealField($name));
         $query->_qill[$grouping][]  = $query->getQillForField($fieldSpec['is_pseudofield_for'] ?? $fieldSpec['name'], $value, $op, $fieldSpec);
         break;
 

--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -6942,6 +6942,17 @@ AND   displayRelType.is_active = 1
   }
 
   /**
+   * Get the field datatype, using the type in the database rather than the pseudofield, if a pseudofield.
+   *
+   * @param string $fieldName
+   *
+   * @return string
+   */
+  public function getDataTypeForRealField($fieldName) {
+    return CRM_Utils_Type::typeToString($this->getMetadataForRealField($fieldName)['type']);
+  }
+
+  /**
    * If we have a field that is better rendered via the pseudoconstant handled them here.
    *
    * Rather than joining in the additional table we render the option value on output.


### PR DESCRIPTION


Overview
----------------------------------------
This fixes it such that even if the pseudofield (activity_type) has a 'type' the 'type'
from the 'real field' is used in the WHERE query. This mostly prevents a test fail per

https://github.com/civicrm/civicrm-core/pull/18147

if we improve the metadata. It's a bit of a non-fail fail - ie we are checking the where
clause has activity_type_id = 3 vs '3' and my testing has not shown a performance difference
but we don't want the test to be changed to the less good version

Before
----------------------------------------
Metadate 'type' for activity_type is 'wrong' if it is set correctly

After
----------------------------------------
Type always taken from the 'real field' in this code chunk

Technical Details
----------------------------------------
This is pretty obscure  - not functional change

Comments
----------------------------------------

