### PR TITLE
Fix setAmount should not return localized amount

### DIFF
--- a/Civi/Payment/PropertyBag.php
+++ b/Civi/Payment/PropertyBag.php
@@ -423,8 +423,7 @@ class PropertyBag implements \ArrayAccess {
     if (!is_numeric($value)) {
       throw new \InvalidArgumentException("setAmount requires a numeric amount value");
     }
-
-    return $this->set('amount', $label, \CRM_Utils_Money::format($value, NULL, NULL, TRUE));
+    return $this->set('amount', $label, filter_var($value, FILTER_SANITIZE_NUMBER_FLOAT, FILTER_FLAG_ALLOW_FRACTION));
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Currently payment processing using propertyBag is not possible when using not using '.' as decimal separator because setAmount() converts it to a localized format.

Before
----------------------------------------
\Civi\Payment\PropertyBag::setAmount() converts to localized format.

After
----------------------------------------
\Civi\Payment\PropertyBag::setAmount() does not convert and filters to ensure it's a valid float.

Technical Details
----------------------------------------
I've used the filter_var construct in Stripe/Smartdebit etc. for a long time now. It's a simple way of ensuring we get a properly formatted float from a whatever. At the point setAmount is called we should already be in non-localised format.

Comments
----------------------------------------
We should improve this further in the future. Perhaps to set/retrieve a money object using \Brick\Money. However that is a more complex change for what is currently a pretty serious bug! @eileenmcnaughton If you are interested in tackling that I don't mind reviewing but it has a few issues that need working through, such as `Money::of` requiring a currency. (so do you require that currency is set before calling setAmount, or use the default?).
You also need to return it numerically formatted which I did in https://github.com/civicrm/civicrm-core/pull/17893 but again you'll see it's not entirely straightforward with Brick\Money.
