### PR TITLE
Order API PriceSet ID

### DIFF
--- a/api/v3/Order.php
+++ b/api/v3/Order.php
@@ -103,13 +103,16 @@ function civicrm_api3_order_create($params) {
           // pledge payment
         }
       }
-      if (empty($priceSetID)) {
+      // Each set of lineitems maps to an event or a membership but each entity can (will) be linked to a different priceset.
+      if (!empty($lineItems['line_item'])) {
         $item = reset($lineItems['line_item']);
         $priceSetID = (int) civicrm_api3('PriceField', 'getvalue', [
           'return' => 'price_set_id',
           'id' => $item['price_field_id'],
         ]);
-        $params['line_item'][$priceSetID] = [];
+      }
+      else {
+        $priceSetID = 0;
       }
       $params['line_item'][$priceSetID] = array_merge($params['line_item'][$priceSetID], $lineItems['line_item']);
     }


### PR DESCRIPTION
Overview
----------------------------------------
Order API doesn't work with free events. Order API puts all lineitems in the ID of the first price set. But do we actually use the PriceSetID anywhere?

Before
----------------------------------------
_What is the old user-interface or technical-contract (as appropriate)?_
_For optimal clarity, include a concrete example such as a screenshot, GIF ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)), or code-snippet._

After
----------------------------------------
_What changed? What is new old user-interface or technical-contract?_
_For optimal clarity, include a concrete example such as a screenshot, GIF ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)), or code-snippet._

Technical Details
----------------------------------------
_If the PR involves technical details/changes/considerations which would not be manifest to a casual developer skimming the above sections, please describe the details here._

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
