### PR TITLE
Remove ref to logging time

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -17,4 +17,4 @@ Topics of particular importance while submitting pull requests include:
 * [Release Process](https://docs.civicrm.org/dev/en/latest/core/release-process/)
 * [Developer Community](https://docs.civicrm.org/dev/en/latest/basics/community/)
 
-CiviCRM thanks you for your contributions and invites you to [log your time spent](https://civicrm.org/contributor-log) so that you (or your organization) may receive public recognition and promotion for your efforts.
+CiviCRM thanks you for your contributions.


### PR DESCRIPTION


Overview
----------------------------------------
Update contributor.yml to remove reference to time logging

The page is not anon accessible & I think we don't do this now - @joshgowans ?

Before
----------------------------------------
CiviCRM thanks you for your contributions and invites you to [log your time spent](https://civicrm.org/contributor-log) so that you (or your organization) may receive public recognition and promotion for your efforts.

After
----------------------------------------
CiviCRM thanks you for your contributions.

Technical Details
----------------------------------------


Comments
----------------------------------------

