### PR TITLE
distmaker - Autogenerate civicrm-*-patchset.tar.gz

### DIFF
--- a/distmaker/distmaker.sh
+++ b/distmaker/distmaker.sh
@@ -41,6 +41,7 @@ D56PACK=0
 D7DIR=0
 J5PACK=0
 WP5PACK=0
+PATCHPACK=0
 SK5PACK=0
 L10NPACK=0
 REPOREPORT=0
@@ -61,6 +62,7 @@ display_usage()
   echo "  d7_dir         - generate Drupal7 PHP5 module, but output to a directory, no tarball"
   echo "  Joomla|j5      - generate Joomla PHP5 module"
   echo "  WordPress|wp5  - generate Wordpress PHP5 module"
+  echo "  patchset       - generate a tarball with patch files"
   echo "  sk             - generate Drupal StarterKit module"
   echo
   echo "You also need to have distmaker.conf file in place."
@@ -193,6 +195,12 @@ case $1 in
   WP5PACK=1
   ;;
 
+  ## PATCHSET export
+  patchset)
+  echo; echo "Generating patchset"; echo;
+  PATCHPACK=1
+  ;;
+
   # REPO REPORT PHP5
   report)
   echo; echo "Generating repo report module"; echo;
@@ -207,6 +215,7 @@ case $1 in
   D56PACK=1
   J5PACK=1
   WP5PACK=1
+  PATCHPACK=1
   SKPACK=1
   L10NPACK=1
   REPOREPORT=1
@@ -295,6 +304,11 @@ if [ "$WP5PACK" = 1 ]; then
   echo; echo "Packaging for Wordpress, PHP5 version"; echo;
   dm_git_checkout "$DM_SOURCEDIR/WordPress" "$DM_REF_WORDPRESS"
   bash $P/dists/wordpress_php5.sh
+fi
+
+if [ "$PATCHPACK" = 1 ]; then
+  echo; echo "Packaging for patchset tarball"; echo;
+  bash $P/dists/patchset.sh
 fi
 
 if [ "$REPOREPORT" = 1 ]; then

--- a/distmaker/dists/common.sh
+++ b/distmaker/dists/common.sh
@@ -257,7 +257,9 @@ function dm_install_cvext() {
   cv dl -b "@https://civicrm.org/extdir/ver=$DM_VERSION|cms=Drupal/$1.xml" --to="$2"
 }
 
+## Export a list of patch files from a git repo
 ## usage: dm_export_patches <src-repo> <out-dir> <range>
+## ex: dm_export_patches "$HOME/src/somerepo" "/tmp/export" 5.1.2..5.1.6
 function dm_export_patches() {
   if [ ! -d "$1" ]; then
     echo "ignore: $1"

--- a/distmaker/dists/common.sh
+++ b/distmaker/dists/common.sh
@@ -257,6 +257,19 @@ function dm_install_cvext() {
   cv dl -b "@https://civicrm.org/extdir/ver=$DM_VERSION|cms=Drupal/$1.xml" --to="$2"
 }
 
+## usage: dm_export_patches <src-repo> <out-dir> <range>
+function dm_export_patches() {
+  if [ ! -d "$1" ]; then
+    echo "ignore: $1"
+    return
+  fi
+  echo "Export \"$1\" ($3) to \"$2\""
+  pushd "$1" >> /dev/null
+    git format-patch "$3" -o "$2"
+  popd >> /dev/null
+}
+
+
 ## Edit a file by applying a regular expression.
 ## Note: We'd rather just call "sed", but it differs on GNU+BSD.
 ## usage: dm_preg_edit <search-pattern> <replacement-pattern> <file>

--- a/distmaker/dists/patchset.sh
+++ b/distmaker/dists/patchset.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+set -ex
+
+P=`dirname $0`
+CFFILE=$P/../distmaker.conf
+if [ ! -f $CFFILE ] ; then
+  echo "NO DISTMAKER.CONF FILE!"
+  exit 1
+else
+  . $CFFILE
+fi
+. "$P/common.sh"
+
+DM_MAJMIN=$(echo "$DM_VERSION" | cut -f1,2 -d\. )
+REFTAG=$(grep -h "^${DM_MAJMIN}:" "$P/../patchset-baselines.txt" | cut -f2 -d: )
+if [ -z "$REFTAG" ]; then
+  echo "The branch ${DM_MAJMIN} does not have a reference version. No patchset to generate."
+  exit 0
+fi
+
+SRC="$DM_SOURCEDIR"
+TRG="$DM_TMPDIR/civicrm-$DM_VERSION"
+
+# export patch files for each repo
+dm_reset_dirs "$TRG"
+mkdir -p "$TRG"/civicrm-{core,drupal-6,drupal-7,drupal-8,backdrop,packages,joomla,wordpress}
+dm_export_patches "$SRC"            "$TRG/civicrm-core"       $REFTAG..$DM_REF_CORE
+# dm_export_patches "$SRC/drupal"     "$TRG/civicrm-drupal-6"   6.x-$REFTAG..$DM_REF_DRUPAL6
+dm_export_patches "$SRC/drupal"     "$TRG/civicrm-drupal-7"   7.x-$REFTAG..$DM_REF_DRUPAL
+dm_export_patches "$SRC/drupal-8"   "$TRG/civicrm-drupal-8"   $REFTAG..$DM_REF_DRUPAL8
+dm_export_patches "$SRC/backdrop"   "$TRG/civicrm-backdrop"   1.x-$REFTAG..$DM_REF_BACKDROP
+dm_export_patches "$SRC/packages"   "$TRG/civicrm-packages"   $REFTAG..$DM_REF_PACKAGES
+dm_export_patches "$SRC/joomla"     "$TRG/civicrm-joomla"     $REFTAG..$DM_REF_JOOMLA
+dm_export_patches "$SRC/wordpress"  "$TRG/civicrm-wordpress"  $REFTAG..$DM_REF_WORDPRESS
+
+
+# gen tarball
+cd "$DM_TMPDIR"
+tar czf $DM_TARGETDIR/civicrm-$DM_VERSION-patchset.tar.gz civicrm-$DM_VERSION
+
+# clean up
+rm -rf $TRG

--- a/distmaker/patchset-baselines.txt
+++ b/distmaker/patchset-baselines.txt
@@ -1,0 +1,2 @@
+## Branch : Tag-name
+5.27:5.27.4

--- a/distmaker/patchset-baselines.txt
+++ b/distmaker/patchset-baselines.txt
@@ -1,2 +1,5 @@
-## Branch : Tag-name
+## When exporting patches for a given major-series (e.g. 5.27),
+## we use a fixed reference-point (e.g. `git log $REFPOINT..`).
+##
+## Major Series : Reference-Point (Tag/Commit)
 5.27:5.27.4


### PR DESCRIPTION
Overview
----------------------------------------

`civicrm-*-patchset.tar.gz` is an artifact included with ESR builds. It provides a list of recent patches. This updates `distmaker` to generate the file in the same way.

Before
----------------------------------------

Generating the file requires a special workflow.

After
----------------------------------------

The file is created automatically.

