### PR TITLE
dev/core#1942 handle multiple membership of same membership type to u…

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -3185,10 +3185,10 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
           foreach ($lineItems as &$eachItem) {
             if (isset($this->_relatedObjects['membership'])
               && is_array($this->_relatedObjects['membership'])
-              && array_key_exists($eachItem['membership_type_id'], $this->_relatedObjects['membership'])) {
-              $eachItem['join_date'] = CRM_Utils_Date::customFormat($this->_relatedObjects['membership'][$eachItem['membership_type_id']]->join_date);
-              $eachItem['start_date'] = CRM_Utils_Date::customFormat($this->_relatedObjects['membership'][$eachItem['membership_type_id']]->start_date);
-              $eachItem['end_date'] = CRM_Utils_Date::customFormat($this->_relatedObjects['membership'][$eachItem['membership_type_id']]->end_date);
+              && array_key_exists($eachItem['entity_id'] . '_' . $eachItem['membership_type_id'], $this->_relatedObjects['membership'])) {
+              $eachItem['join_date'] = CRM_Utils_Date::customFormat($this->_relatedObjects['membership'][$eachItem['entity_id'] . '_' . $eachItem['membership_type_id']]->join_date);
+              $eachItem['start_date'] = CRM_Utils_Date::customFormat($this->_relatedObjects['membership'][$eachItem['entity_id'] . '_' . $eachItem['membership_type_id']]->start_date);
+              $eachItem['end_date'] = CRM_Utils_Date::customFormat($this->_relatedObjects['membership'][$eachItem['entity_id'] . '_' . $eachItem['membership_type_id']]->end_date);
             }
             // This is actually used in conjunction with is_quick_config in the template & we should deprecate it.
             // However, that does create upgrade pain so would be better to be phased in.
@@ -4706,7 +4706,8 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
           $membership->join_date = CRM_Utils_Date::isoToMysql($membership->join_date);
           $membership->start_date = CRM_Utils_Date::isoToMysql($membership->start_date);
           $membership->end_date = CRM_Utils_Date::isoToMysql($membership->end_date);
-          $this->_relatedObjects['membership'][$membership->membership_type_id] = $membership;
+          $this->_relatedObjects['membership'][$membership->id . '_' . $membership->membership_type_id] = $membership;
+
         }
       }
     }

--- a/tests/phpunit/CRM/Core/Payment/BaseIPNTest.php
+++ b/tests/phpunit/CRM/Core/Payment/BaseIPNTest.php
@@ -104,8 +104,8 @@ class CRM_Core_Payment_BaseIPNTest extends CiviUnitTestCase {
     $this->_setUpRecurringContribution();
     $this->IPN->loadObjects($this->input, $this->ids, $this->objects, FALSE, $this->_processorId);
     $this->assertNotEmpty($this->objects['membership']);
-    $this->assertArrayHasKey($this->_membershipTypeID, $this->objects['membership']);
-    $this->assertTrue(is_a($this->objects['membership'][$this->_membershipTypeID], 'CRM_Member_BAO_Membership'));
+    $this->assertArrayHasKey($this->_membershipId . '_' . $this->_membershipTypeID, $this->objects['membership']);
+    $this->assertTrue(is_a($this->objects['membership'][$this->_membershipId . '_' . $this->_membershipTypeID], 'CRM_Member_BAO_Membership'));
     $this->assertTrue(is_a($this->objects['financialType'], 'CRM_Financial_BAO_FinancialType'));
     $this->assertNotEmpty($this->objects['contributionRecur']);
     $this->assertNotEmpty($this->objects['paymentProcessor']);
@@ -145,8 +145,8 @@ class CRM_Core_Payment_BaseIPNTest extends CiviUnitTestCase {
     $contribution->find(TRUE);
     $contribution->loadRelatedObjects($this->input, $this->ids, TRUE);
     $this->assertNotEmpty($contribution->_relatedObjects['membership']);
-    $this->assertArrayHasKey($this->_membershipTypeID, $contribution->_relatedObjects['membership']);
-    $this->assertTrue(is_a($contribution->_relatedObjects['membership'][$this->_membershipTypeID], 'CRM_Member_BAO_Membership'));
+    $this->assertArrayHasKey($this->_membershipId . '_' . $this->_membershipTypeID, $contribution->_relatedObjects['membership']);
+    $this->assertTrue(is_a($contribution->_relatedObjects['membership'][$this->_membershipId . '_' . $this->_membershipTypeID], 'CRM_Member_BAO_Membership'));
     $this->assertTrue(is_a($contribution->_relatedObjects['financialType'], 'CRM_Financial_BAO_FinancialType'));
     $this->assertFalse(empty($contribution->_relatedObjects['contributionRecur']));
     $this->assertFalse(empty($contribution->_relatedObjects['paymentProcessor']));

--- a/tests/phpunit/api/v3/MembershipTest.php
+++ b/tests/phpunit/api/v3/MembershipTest.php
@@ -174,6 +174,104 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test Multiple Membership Status for same contribution id.
+   */
+  public function testMultipleMembershipsContribution() {
+    // Main contact
+    $memStatus = CRM_Member_PseudoConstant::membershipStatus();
+    // Pending Membership Status
+    $pendingMembershipId = array_search('Pending', $memStatus);
+    // New Membership Status
+    $newMembershipId = array_search('test status', $memStatus);
+
+    $membershipParam = [
+      'membership_type_id' => $this->_membershipTypeID,
+      'source' => 'Webform Payment',
+      'status_id' => $pendingMembershipId,
+      'is_pay_later' => 1,
+      'skipStatusCal' => 1,
+    ];
+
+    // Contact 1
+    $contactId1 = $this->individualCreate();
+    $membershipParam['contact_id'] = $contactId1;
+    $membershipID1 = $this->contactMembershipCreate($membershipParam);
+
+    // Pending Payment Status
+    $ContributionCreate = $this->callAPISuccess('Contribution', 'create', [
+      'financial_type_id' => '1',
+      'total_amount' => 100,
+      'contact_id' => $contactId1,
+      'payment_instrument_id' => CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'payment_instrument_id', 'Check'),
+      'contribution_status_id' => 2,
+      'is_pay_later' => 1,
+      'receive_date' => date('Ymd'),
+    ]);
+    $this->callAPISuccess('MembershipPayment', 'create', [
+      'sequential' => 1,
+      'contribution_id' => $ContributionCreate['id'],
+      'membership_id' => $membershipID1,
+    ]);
+
+    // Contact 2
+    $contactId2 = $this->individualCreate();
+    $membershipParam['contact_id'] = $contactId2;
+    $membershipID2 = $this->contactMembershipCreate($membershipParam);
+    $this->callAPISuccess('MembershipPayment', 'create', [
+      'sequential' => 1,
+      'contribution_id' => $ContributionCreate['id'],
+      'membership_id' => $membershipID2,
+    ]);
+
+    // Contact 3
+    $contactId3 = $this->individualCreate();
+    $membershipParam['contact_id'] = $contactId3;
+    $membershipID3 = $this->contactMembershipCreate($membershipParam);
+    $this->callAPISuccess('MembershipPayment', 'create', [
+      'sequential' => 1,
+      'contribution_id' => $ContributionCreate['id'],
+      'membership_id' => $membershipID3,
+    ]);
+
+    // Change Payment Status to Completed
+    $form = new CRM_Contribute_Form_Contribution();
+    $form->_id = $ContributionCreate['id'];
+    $params = ['id' => $ContributionCreate['id']];
+    $values = $ids = [];
+    CRM_Contribute_BAO_Contribution::getValues($params, $values, $ids);
+    $form->_values = $values;
+    $form->testSubmit([
+      'total_amount' => 100,
+      'financial_type_id' => '1',
+      'contact_id' => $contactId1,
+      'payment_instrument_id' => CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'payment_instrument_id', 'Check'),
+      'contribution_status_id' => 1,
+    ],
+      CRM_Core_Action::UPDATE);
+
+    // check for Membership 1
+    $params = ['id' => $membershipID1];
+    $membership1 = $this->callAPISuccess('membership', 'get', $params);
+    $result1 = $membership1['values'][$membershipID1];
+    $this->assertEquals($result1['contact_id'], $contactId1);
+    $this->assertEquals($result1['status_id'], $newMembershipId);
+
+    // check for Membership 2
+    $params = ['id' => $membershipID2];
+    $membership2 = $this->callAPISuccess('membership', 'get', $params);
+    $result2 = $membership2['values'][$membershipID2];
+    $this->assertEquals($result2['contact_id'], $contactId2);
+    $this->assertEquals($result2['status_id'], $newMembershipId);
+
+    // check for Membership 3
+    $params = ['id' => $membershipID3];
+    $membership3 = $this->callAPISuccess('membership', 'get', $params);
+    $result3 = $membership3['values'][$membershipID3];
+    $this->assertEquals($result3['contact_id'], $contactId3);
+    $this->assertEquals($result3['status_id'], $newMembershipId);
+  }
+
+  /**
    * Test membership get.
    */
   public function testContactMembershipsGet() {


### PR DESCRIPTION
Re submitting https://github.com/civicrm/civicrm-core/pull/18113, small change : changed test function name (it already exist)

Overview
----------------------------------------
Pending Membership (multiple) created through Webform not updated in CiviCRM when Payment Status changed from Pending (paylater) to Completed.

Reproduction steps
----------------------------------------
1. Create Webform in Drupal 7/8, Enable multiple contacts for Membership Signup/renew.
2. Each contact can choose different/same membership type (-- User Select -- option for Membership Type)
3. When form is submitted. Contribution Record created and Multiple membership created and these memberships linked to same contribution record in **civicrm_membership_payment** table
4. In this scenario, All contact have chosen Same Membership Types

Current behaviour
----------------------------------------
at backend, when Contribution/payment record status changed from Pending (Pay_later) to Completed, only last membership record from `civicrm_membership_payment` against contribution record get updated to New/Current, other membership status remain Pending.

Note : This is no Inherited Membership, Each contact get Direct Membership for Same Contribution Record. 
e.g. IF 3 person signup for General Membership. then in `civicrm_membership_payment` table we have 3 entries of membership record with common contribution id.



Expected behaviour
----------------------------------------
All Pending Membership Status should change to New/Current.


https://lab.civicrm.org/dev/core/-/issues/1942