### PR TITLE
trim white space when checking dedupe

### DIFF
--- a/CRM/Dedupe/BAO/Rule.php
+++ b/CRM/Dedupe/BAO/Rule.php
@@ -136,7 +136,7 @@ class CRM_Dedupe_BAO_Rule extends CRM_Dedupe_DAO_Rule {
       $from = "{$this->rule_table} t1";
       $str = 'NULL';
       if (isset($this->params[$this->rule_table][$this->rule_field])) {
-        $str = CRM_Utils_Type::escape($this->params[$this->rule_table][$this->rule_field], 'String');
+        $str = trim(CRM_Utils_Type::escape($this->params[$this->rule_table][$this->rule_field], 'String'));
       }
       if ($this->rule_length) {
         $where[] = "SUBSTR(t1.{$this->rule_field}, 1, {$this->rule_length}) = SUBSTR('$str', 1, {$this->rule_length})";


### PR DESCRIPTION
Overview
----------------------------------------
https://civicrm.stackexchange.com/questions/37459/modify-unsupervised-dedupe-rule-to-ignore-whitespace

Before
----------------------------------------
If firstname or last name or any field had white space the dedupe failed to find a match

After
----------------------------------------
dedupes contact if there is white space

Technical Details
----------------------------------------
When a contact is saved first name, last name and most of the fields are trimmed before saving into database, But the dedupe finder don't trim white space before finding contacts in database. This PR trims the string in where clause to find contact.