### PR TITLE
Wrap "not you" message in crmRegion

### DIFF
--- a/templates/CRM/Contribute/Form/Contribution/Main.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Main.tpl
@@ -65,16 +65,19 @@
 
   <div class="crm-contribution-page-id-{$contributionPageID} crm-block crm-contribution-main-form-block">
 
+    {crmRegion name='contribution-main-not-you-block'}
     {if $contact_id && !$ccid}
       <div class="messages status no-popup crm-not-you-message">
         {ts 1=$display_name}Welcome %1{/ts}. (<a href="{crmURL p='civicrm/contribute/transact' q="cid=0&reset=1&id=`$contributionPageID`"}" title="{ts}Click here to do this for a different person.{/ts}">{ts 1=$display_name}Not %1, or want to do this for a different person{/ts}</a>?)
       </div>
     {/if}
+    {/crmRegion}
 
     <div id="intro_text" class="crm-public-form-item crm-section intro_text-section">
       {$intro_text}
     </div>
     {include file="CRM/common/cidzero.tpl"}
+
     {if $islifetime or $ispricelifetime}
       <div class="help">{ts}You have a current Lifetime Membership which does not need to be renewed.{/ts}</div>
     {/if}

--- a/templates/CRM/Event/Form/Registration/Register.tpl
+++ b/templates/CRM/Event/Form/Registration/Register.tpl
@@ -33,6 +33,7 @@
       </div>
     {/if}
 
+    {crmRegion name='event-register-not-you-block'}
     {if $contact_id}
       <div class="messages status no-popup crm-not-you-message" id="crm-event-register-different">
         {ts 1=$display_name}Welcome %1{/ts}. (<a
@@ -40,6 +41,8 @@
           title="{ts}Click here to register a different person for this event.{/ts}">{ts 1=$display_name}Not %1, or want to register a different person{/ts}</a>?)
       </div>
     {/if}
+    {/crmRegion}
+
     {if $event.intro_text}
       <div id="intro_text" class="crm-public-form-item crm-section intro_text-section">
         <p>{$event.intro_text}</p>


### PR DESCRIPTION
Overview
----------------------------------------
On both contribution pages and registration pages there is a "Not you, do you want to register for someone else" message. I've had requests from various clients to hide this and you can generally do it with javascript. But it's not ideal, it often "flashes" on screen before disappearing, if there is a javascript error it doesn't disappear, if you don''t load the javascript (eg. when a contribution is inserted via shortcode on wordpress).

This wraps the message in a `crmRegion` so that it can be removed/replaced via the buildForm hook before it reaches the browser. Example:
```
/**
 * Intercept form functions
 * @param string $formName
 * @param \CRM_Core_Form $form
 */
function bafamembers_civicrm_buildForm($formName, &$form) {
  switch ($formName) {
    case 'CRM_Contribute_Form_Contribution_Main':
      CRM_Core_Region::instance('contribution-main-not-you-block')
        ->update('default', ['disabled' => TRUE]);
      break;

    case 'CRM_Event_Form_Registration_Register':
      CRM_Core_Region::instance('event-register-not-you-block')
        ->update('default', ['disabled' => TRUE]);
      break;
  }
}
```

Before
----------------------------------------
Described above.

After
----------------------------------------
No change. By implementing code you can modify/remove the message div from the form.

Technical Details
----------------------------------------

Comments
----------------------------------------
