### PR TITLE
Remove 'hack' that overwrites result of searchColumns hook in mailings list

### DIFF
--- a/CRM/Mailing/Page/Browse.php
+++ b/CRM/Mailing/Page/Browse.php
@@ -243,11 +243,6 @@ class CRM_Mailing_Page_Browse extends CRM_Core_Page {
     $controller->setEmbedded(TRUE);
     $controller->run();
 
-    // hack to display results as per search
-    $rows = $controller->getRows($controller);
-
-    $this->assign('rows', $rows);
-
     $urlParams = 'reset=1';
     $urlString = 'civicrm/mailing/browse';
     if ($this->get('sms')) {


### PR DESCRIPTION
Overview
----------------------------------------
There is a strange "hack" in the Mailing browse page that runs the controller to build the page, generate rows (of mailings) and call the searchColumns hook. But then it calls getRows() again just before rendering the page meaning the searchColumns hook does not work. I cannot see any need to do this and the code has not been changed since import from SVN in 2013.

Removing the line allows the results of the searchColumns hook to be used and without the hook the page works as before (ie. loads all rows).

To test, browse to one of the "scheduled, unscheduled etc." mailing screens and check that you see a full list of mailings.

Before
----------------------------------------
Cannot use searchColumns hook on Mailings browse page.

After
----------------------------------------
Can use searchColumns hook on Mailings browse page.

Technical Details
----------------------------------------
Explained above.

Comments
----------------------------------------
This extension implements mailing permissions via the searchColumns hook and can be used to test if desired: https://lab.civicrm.org/extensions/mailingpermissions

You would need to setup a user without the new "View all mailings" permission, create a mailing as that user and then check that you can only see those mailings and not ones created by others.
