### PR TITLE
Spelling mistake "separator" not "seperator"

### DIFF
--- a/CRM/Activity/Import/Form/MapField.php
+++ b/CRM/Activity/Import/Form/MapField.php
@@ -350,7 +350,7 @@ class CRM_Activity_Import_Form_MapField extends CRM_Import_Form_MapField {
     }
 
     $fileName = $this->controller->exportValue('DataSource', 'uploadFile');
-    $seperator = $this->controller->exportValue('DataSource', 'fieldSeparator');
+    $separator = $this->controller->exportValue('DataSource', 'fieldSeparator');
     $skipColumnHeader = $this->controller->exportValue('DataSource', 'skipColumnHeader');
 
     $mapperKeys = [];
@@ -431,7 +431,7 @@ class CRM_Activity_Import_Form_MapField extends CRM_Import_Form_MapField {
     }
 
     $parser = new CRM_Activity_Import_Parser_Activity($mapperKeysMain, $mapperLocType, $mapperPhoneType);
-    $parser->run($fileName, $seperator, $mapper, $skipColumnHeader,
+    $parser->run($fileName, $separator, $mapper, $skipColumnHeader,
       CRM_Import_Parser::MODE_PREVIEW
     );
 

--- a/CRM/Activity/Import/Form/Preview.php
+++ b/CRM/Activity/Import/Form/Preview.php
@@ -92,7 +92,7 @@ class CRM_Activity_Import_Form_Preview extends CRM_Import_Form_Preview {
    */
   public function postProcess() {
     $fileName = $this->controller->exportValue('DataSource', 'uploadFile');
-    $seperator = $this->controller->exportValue('DataSource', 'fieldSeparator');
+    $separator = $this->controller->exportValue('DataSource', 'fieldSeparator');
     $skipColumnHeader = $this->controller->exportValue('DataSource', 'skipColumnHeader');
     $invalidRowCount = $this->get('invalidRowCount');
     $conflictRowCount = $this->get('conflictRowCount');
@@ -132,7 +132,7 @@ class CRM_Activity_Import_Form_Preview extends CRM_Import_Form_Preview {
       }
       $mapperFields[] = implode(' - ', $header);
     }
-    $parser->run($fileName, $seperator,
+    $parser->run($fileName, $separator,
       $mapperFields,
       $skipColumnHeader,
       CRM_Import_Parser::MODE_IMPORT,

--- a/CRM/Activity/Import/Parser.php
+++ b/CRM/Activity/Import/Parser.php
@@ -28,7 +28,7 @@ abstract class CRM_Activity_Import_Parser extends CRM_Import_Parser {
    * Separator being used.
    * @var string
    */
-  protected $_seperator;
+  protected $_separator;
 
   /**
    * Total number of lines in file.
@@ -45,7 +45,7 @@ abstract class CRM_Activity_Import_Parser extends CRM_Import_Parser {
 
   /**
    * @param string $fileName
-   * @param string $seperator
+   * @param string $separator
    * @param $mapper
    * @param bool $skipColumnHeader
    * @param int $mode
@@ -58,7 +58,7 @@ abstract class CRM_Activity_Import_Parser extends CRM_Import_Parser {
    */
   public function run(
     $fileName,
-    $seperator = ',',
+    $separator = ',',
     &$mapper,
     $skipColumnHeader = FALSE,
     $mode = self::MODE_PREVIEW,
@@ -75,7 +75,7 @@ abstract class CRM_Activity_Import_Parser extends CRM_Import_Parser {
 
     $this->_haveColumnHeader = $skipColumnHeader;
 
-    $this->_seperator = $seperator;
+    $this->_separator = $separator;
 
     $fd = fopen($fileName, "r");
     if (!$fd) {
@@ -106,7 +106,7 @@ abstract class CRM_Activity_Import_Parser extends CRM_Import_Parser {
     while (!feof($fd)) {
       $this->_lineCount++;
 
-      $values = fgetcsv($fd, 8192, $seperator);
+      $values = fgetcsv($fd, 8192, $separator);
       if (!$values) {
         continue;
       }
@@ -327,7 +327,7 @@ abstract class CRM_Activity_Import_Parser extends CRM_Import_Parser {
   public function set($store, $mode = self::MODE_SUMMARY) {
     $store->set('fileSize', $this->_fileSize);
     $store->set('lineCount', $this->_lineCount);
-    $store->set('seperator', $this->_seperator);
+    $store->set('separator', $this->_separator);
     $store->set('fields', $this->getSelectValues());
     $store->set('fieldTypes', $this->getSelectTypes());
 

--- a/CRM/Contribute/Import/Form/MapField.php
+++ b/CRM/Contribute/Import/Form/MapField.php
@@ -424,7 +424,7 @@ class CRM_Contribute_Import_Form_MapField extends CRM_Import_Form_MapField {
     }
 
     $fileName = $this->controller->exportValue('DataSource', 'uploadFile');
-    $seperator = $this->controller->exportValue('DataSource', 'fieldSeparator');
+    $separator = $this->controller->exportValue('DataSource', 'fieldSeparator');
     $skipColumnHeader = $this->controller->exportValue('DataSource', 'skipColumnHeader');
 
     $mapper = $mapperKeys = $mapperKeysMain = $mapperSoftCredit = $softCreditFields = $mapperPhoneType = $mapperSoftCreditType = [];
@@ -511,7 +511,7 @@ class CRM_Contribute_Import_Form_MapField extends CRM_Import_Form_MapField {
     }
 
     $parser = new CRM_Contribute_Import_Parser_Contribution($mapperKeysMain, $mapperSoftCredit, $mapperPhoneType);
-    $parser->run($fileName, $seperator, $mapper, $skipColumnHeader,
+    $parser->run($fileName, $separator, $mapper, $skipColumnHeader,
       CRM_Import_Parser::MODE_PREVIEW, $this->get('contactType')
     );
 

--- a/CRM/Contribute/Import/Form/Preview.php
+++ b/CRM/Contribute/Import/Form/Preview.php
@@ -94,7 +94,7 @@ class CRM_Contribute_Import_Form_Preview extends CRM_Import_Form_Preview {
    */
   public function postProcess() {
     $fileName = $this->controller->exportValue('DataSource', 'uploadFile');
-    $seperator = $this->controller->exportValue('DataSource', 'fieldSeparator');
+    $separator = $this->controller->exportValue('DataSource', 'fieldSeparator');
     $skipColumnHeader = $this->controller->exportValue('DataSource', 'skipColumnHeader');
     $invalidRowCount = $this->get('invalidRowCount');
     $conflictRowCount = $this->get('conflictRowCount');
@@ -128,7 +128,7 @@ class CRM_Contribute_Import_Form_Preview extends CRM_Import_Form_Preview {
       }
       $mapperFields[] = implode(' - ', $header);
     }
-    $parser->run($fileName, $seperator,
+    $parser->run($fileName, $separator,
       $mapperFields,
       $skipColumnHeader,
       CRM_Import_Parser::MODE_IMPORT,

--- a/CRM/Contribute/Import/Parser.php
+++ b/CRM/Contribute/Import/Parser.php
@@ -34,10 +34,10 @@ abstract class CRM_Contribute_Import_Parser extends CRM_Import_Parser {
   protected $_fileSize;
 
   /**
-   * Seperator being used
+   * Separator being used
    * @var string
    */
-  protected $_seperator;
+  protected $_separator;
 
   /**
    * Total number of lines in file
@@ -104,7 +104,7 @@ abstract class CRM_Contribute_Import_Parser extends CRM_Import_Parser {
 
   /**
    * @param string $fileName
-   * @param string $seperator
+   * @param string $separator
    * @param $mapper
    * @param bool $skipColumnHeader
    * @param int $mode
@@ -118,7 +118,7 @@ abstract class CRM_Contribute_Import_Parser extends CRM_Import_Parser {
    */
   public function run(
     $fileName,
-    $seperator = ',',
+    $separator = ',',
     &$mapper,
     $skipColumnHeader = FALSE,
     $mode = self::MODE_PREVIEW,
@@ -149,7 +149,7 @@ abstract class CRM_Contribute_Import_Parser extends CRM_Import_Parser {
 
     $this->_haveColumnHeader = $skipColumnHeader;
 
-    $this->_seperator = $seperator;
+    $this->_separator = $separator;
 
     $fd = fopen($fileName, "r");
     if (!$fd) {
@@ -182,7 +182,7 @@ abstract class CRM_Contribute_Import_Parser extends CRM_Import_Parser {
     while (!feof($fd)) {
       $this->_lineCount++;
 
-      $values = fgetcsv($fd, 8192, $seperator);
+      $values = fgetcsv($fd, 8192, $separator);
       if (!$values) {
         continue;
       }
@@ -506,7 +506,7 @@ abstract class CRM_Contribute_Import_Parser extends CRM_Import_Parser {
   public function set($store, $mode = self::MODE_SUMMARY) {
     $store->set('fileSize', $this->_fileSize);
     $store->set('lineCount', $this->_lineCount);
-    $store->set('seperator', $this->_seperator);
+    $store->set('separator', $this->_separator);
     $store->set('fields', $this->getSelectValues());
     $store->set('fieldTypes', $this->getSelectTypes());
 

--- a/CRM/Core/BAO/UFGroup.php
+++ b/CRM/Core/BAO/UFGroup.php
@@ -1316,8 +1316,8 @@ class CRM_Core_BAO_UFGroup extends CRM_Core_DAO_UFGroup {
             'Multi-Select State/Province',
             'Multi-Select Country',
           ])) {
-            $valSeperator = CRM_Core_DAO::VALUE_SEPARATOR;
-            $selectedOptions = explode($valSeperator, $params[$index]);
+            $valSeparator = CRM_Core_DAO::VALUE_SEPARATOR;
+            $selectedOptions = explode($valSeparator, $params[$index]);
 
             foreach ($selectedOptions as $key => $multiOption) {
               if ($multiOption) {
@@ -2982,7 +2982,7 @@ AND    ( entity_id IS NULL OR entity_id <= 0 )
 
   /**
    * Update the profile type 'group_type' as per profile fields including group types and group subtype values.
-   * Build and store string like: group_type1,group_type2[VALUE_SEPERATOR]group_type1Type:1:2:3,group_type2Type:1:2
+   * Build and store string like: group_type1,group_type2[VALUE_SEPARATOR]group_type1Type:1:2:3,group_type2Type:1:2
    *
    * FIELDS                                                   GROUP_TYPE
    * BirthDate + Email                                        Individual,Contact

--- a/CRM/Core/Report/Excel.php
+++ b/CRM/Core/Report/Excel.php
@@ -35,7 +35,7 @@ class CRM_Core_Report_Excel {
   public static function makeCSVTable($header, $rows, $outputHeader = TRUE) {
 
     $config = CRM_Core_Config::singleton();
-    $seperator = $config->fieldSeparator;
+    $separator = $config->fieldSeparator;
     $add_character = "\015\012";
 
     if ($outputHeader) {
@@ -68,7 +68,7 @@ class CRM_Core_Report_Excel {
               }
             }
 
-            $str = implode($seperator, $strArray);
+            $str = implode($separator, $strArray);
             $value = &$str;
           }
 
@@ -76,7 +76,7 @@ class CRM_Core_Report_Excel {
         }
 
         if ($colNo < $fields_cnt - 1) {
-          $schema_insert .= $seperator;
+          $schema_insert .= $separator;
         }
         $colNo++;
       }

--- a/CRM/Custom/Import/Parser.php
+++ b/CRM/Custom/Import/Parser.php
@@ -312,7 +312,7 @@ abstract class CRM_Custom_Import_Parser extends CRM_Contact_Import_Parser {
   public function set($store, $mode = self::MODE_SUMMARY) {
     $store->set('fileSize', $this->_fileSize);
     $store->set('lineCount', $this->_lineCount);
-    $store->set('seperator', $this->_separator);
+    $store->set('separator', $this->_separator);
     $store->set('fields', $this->getSelectValues());
     $store->set('fieldTypes', $this->getSelectTypes());
 

--- a/CRM/Event/Import/Form/MapField.php
+++ b/CRM/Event/Import/Form/MapField.php
@@ -387,7 +387,7 @@ class CRM_Event_Import_Form_MapField extends CRM_Import_Form_MapField {
     }
 
     $fileName = $this->controller->exportValue('DataSource', 'uploadFile');
-    $seperator = $this->controller->exportValue('DataSource', 'fieldSeparator');
+    $separator = $this->controller->exportValue('DataSource', 'fieldSeparator');
     $skipColumnHeader = $this->controller->exportValue('DataSource', 'skipColumnHeader');
 
     $mapperKeys = [];
@@ -461,7 +461,7 @@ class CRM_Event_Import_Form_MapField extends CRM_Import_Form_MapField {
     }
 
     $parser = new CRM_Event_Import_Parser_Participant($mapperKeysMain);
-    $parser->run($fileName, $seperator, $mapper, $skipColumnHeader,
+    $parser->run($fileName, $separator, $mapper, $skipColumnHeader,
       CRM_Import_Parser::MODE_PREVIEW, $this->get('contactType')
     );
     // add all the necessary variables to the form

--- a/CRM/Event/Import/Form/Preview.php
+++ b/CRM/Event/Import/Form/Preview.php
@@ -95,7 +95,7 @@ class CRM_Event_Import_Form_Preview extends CRM_Import_Form_Preview {
    */
   public function postProcess() {
     $fileName = $this->controller->exportValue('DataSource', 'uploadFile');
-    $seperator = $this->controller->exportValue('DataSource', 'fieldSeparator');
+    $separator = $this->controller->exportValue('DataSource', 'fieldSeparator');
     $skipColumnHeader = $this->controller->exportValue('DataSource', 'skipColumnHeader');
     $invalidRowCount = $this->get('invalidRowCount');
     $conflictRowCount = $this->get('conflictRowCount');
@@ -119,7 +119,7 @@ class CRM_Event_Import_Form_Preview extends CRM_Import_Form_Preview {
       }
       $mapperFields[] = implode(' - ', $header);
     }
-    $parser->run($fileName, $seperator,
+    $parser->run($fileName, $separator,
       $mapperFields,
       $skipColumnHeader,
       CRM_Import_Parser::MODE_IMPORT,

--- a/CRM/Event/Import/Parser.php
+++ b/CRM/Event/Import/Parser.php
@@ -30,7 +30,7 @@ abstract class CRM_Event_Import_Parser extends CRM_Import_Parser {
    *
    * @var string
    */
-  protected $_seperator;
+  protected $_separator;
 
   /**
    * Total number of lines in file.
@@ -48,7 +48,7 @@ abstract class CRM_Event_Import_Parser extends CRM_Import_Parser {
 
   /**
    * @param string $fileName
-   * @param string $seperator
+   * @param string $separator
    * @param $mapper
    * @param bool $skipColumnHeader
    * @param int $mode
@@ -60,7 +60,7 @@ abstract class CRM_Event_Import_Parser extends CRM_Import_Parser {
    */
   public function run(
     $fileName,
-    $seperator = ',',
+    $separator = ',',
     &$mapper,
     $skipColumnHeader = FALSE,
     $mode = self::MODE_PREVIEW,
@@ -89,7 +89,7 @@ abstract class CRM_Event_Import_Parser extends CRM_Import_Parser {
 
     $this->_haveColumnHeader = $skipColumnHeader;
 
-    $this->_seperator = $seperator;
+    $this->_separator = $separator;
 
     $fd = fopen($fileName, "r");
     if (!$fd) {
@@ -116,7 +116,7 @@ abstract class CRM_Event_Import_Parser extends CRM_Import_Parser {
     while (!feof($fd)) {
       $this->_lineCount++;
 
-      $values = fgetcsv($fd, 8192, $seperator);
+      $values = fgetcsv($fd, 8192, $separator);
       if (!$values) {
         continue;
       }
@@ -343,7 +343,7 @@ abstract class CRM_Event_Import_Parser extends CRM_Import_Parser {
   public function set($store, $mode = self::MODE_SUMMARY) {
     $store->set('fileSize', $this->_fileSize);
     $store->set('lineCount', $this->_lineCount);
-    $store->set('seperator', $this->_seperator);
+    $store->set('separator', $this->_separator);
     $store->set('fields', $this->getSelectValues());
     $store->set('fieldTypes', $this->getSelectTypes());
 

--- a/CRM/Member/Import/Form/MapField.php
+++ b/CRM/Member/Import/Form/MapField.php
@@ -398,7 +398,7 @@ class CRM_Member_Import_Form_MapField extends CRM_Import_Form_MapField {
     }
 
     $fileName = $this->controller->exportValue('DataSource', 'uploadFile');
-    $seperator = $this->controller->exportValue('DataSource', 'fieldSeparator');
+    $separator = $this->controller->exportValue('DataSource', 'fieldSeparator');
     $skipColumnHeader = $this->controller->exportValue('DataSource', 'skipColumnHeader');
 
     $mapperKeys = [];
@@ -487,7 +487,7 @@ class CRM_Member_Import_Form_MapField extends CRM_Import_Form_MapField {
     }
 
     $parser = new CRM_Member_Import_Parser_Membership($mapperKeysMain, $mapperLocType, $mapperPhoneType);
-    $parser->run($fileName, $seperator, $mapper, $skipColumnHeader,
+    $parser->run($fileName, $separator, $mapper, $skipColumnHeader,
       CRM_Import_Parser::MODE_PREVIEW, $this->get('contactType')
     );
     // add all the necessary variables to the form

--- a/CRM/Member/Import/Form/Preview.php
+++ b/CRM/Member/Import/Form/Preview.php
@@ -96,7 +96,7 @@ class CRM_Member_Import_Form_Preview extends CRM_Import_Form_Preview {
    */
   public function postProcess() {
     $fileName = $this->controller->exportValue('DataSource', 'uploadFile');
-    $seperator = $this->controller->exportValue('DataSource', 'fieldSeparator');
+    $separator = $this->controller->exportValue('DataSource', 'fieldSeparator');
     $skipColumnHeader = $this->controller->exportValue('DataSource', 'skipColumnHeader');
     $invalidRowCount = $this->get('invalidRowCount');
     $conflictRowCount = $this->get('conflictRowCount');
@@ -139,7 +139,7 @@ class CRM_Member_Import_Form_Preview extends CRM_Import_Form_Preview {
       }
       $mapperFields[] = implode(' - ', $header);
     }
-    $parser->run($fileName, $seperator,
+    $parser->run($fileName, $separator,
       $mapperFields,
       $skipColumnHeader,
       CRM_Import_Parser::MODE_IMPORT,

--- a/CRM/Member/Import/Parser.php
+++ b/CRM/Member/Import/Parser.php
@@ -27,10 +27,10 @@ abstract class CRM_Member_Import_Parser extends CRM_Import_Parser {
   protected $_fileSize;
 
   /**
-   * Seperator being used
+   * Separator being used
    * @var string
    */
-  protected $_seperator;
+  protected $_separator;
 
   /**
    * Total number of lines in file
@@ -47,7 +47,7 @@ abstract class CRM_Member_Import_Parser extends CRM_Import_Parser {
 
   /**
    * @param string $fileName
-   * @param string $seperator
+   * @param string $separator
    * @param $mapper
    * @param bool $skipColumnHeader
    * @param int $mode
@@ -61,7 +61,7 @@ abstract class CRM_Member_Import_Parser extends CRM_Import_Parser {
    */
   public function run(
     $fileName,
-    $seperator = ',',
+    $separator = ',',
     &$mapper,
     $skipColumnHeader = FALSE,
     $mode = self::MODE_PREVIEW,
@@ -92,7 +92,7 @@ abstract class CRM_Member_Import_Parser extends CRM_Import_Parser {
 
     $this->_haveColumnHeader = $skipColumnHeader;
 
-    $this->_seperator = $seperator;
+    $this->_separator = $separator;
 
     $fd = fopen($fileName, "r");
     if (!$fd) {
@@ -123,7 +123,7 @@ abstract class CRM_Member_Import_Parser extends CRM_Import_Parser {
     while (!feof($fd)) {
       $this->_lineCount++;
 
-      $values = fgetcsv($fd, 8192, $seperator);
+      $values = fgetcsv($fd, 8192, $separator);
       if (!$values) {
         continue;
       }
@@ -342,7 +342,7 @@ abstract class CRM_Member_Import_Parser extends CRM_Import_Parser {
   public function set($store, $mode = self::MODE_SUMMARY) {
     $store->set('fileSize', $this->_fileSize);
     $store->set('lineCount', $this->_lineCount);
-    $store->set('seperator', $this->_seperator);
+    $store->set('separator', $this->_separator);
     $store->set('fields', $this->getSelectValues());
     $store->set('fieldTypes', $this->getSelectTypes());
 

--- a/CRM/Price/BAO/PriceField.php
+++ b/CRM/Price/BAO/PriceField.php
@@ -296,7 +296,7 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
 
     //use value field.
     $valueFieldName = 'amount';
-    $seperator = '|';
+    $separator = '|';
     $invoiceSettings = Civi::settings()->get('contribution_invoice_settings');
     $taxTerm = Civi::settings()->get('tax_term');
     $displayOpt = $invoiceSettings['tax_display_settings'] ?? NULL;
@@ -312,7 +312,7 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
           $qf->assign('taxTerm', $taxTerm);
           $qf->assign('invoicing', $invoicing);
         }
-        $priceVal = implode($seperator, [
+        $priceVal = implode($separator, [
           $customOption[$optionKey][$valueFieldName] + $taxAmount,
           $count,
           $max_value,
@@ -403,7 +403,7 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
           }
           $count = CRM_Utils_Array::value('count', $opt, '');
           $max_value = CRM_Utils_Array::value('max_value', $opt, '');
-          $priceVal = implode($seperator, [$opt[$valueFieldName] + $taxAmount, $count, $max_value]);
+          $priceVal = implode($separator, [$opt[$valueFieldName] + $taxAmount, $count, $max_value]);
           if (isset($opt['visibility_id'])) {
             $visibility_id = $opt['visibility_id'];
           }
@@ -499,7 +499,7 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
             }
           }
 
-          $priceVal[$opt['id']] = implode($seperator, [$opt[$valueFieldName] + $taxAmount, $count, $max_value]);
+          $priceVal[$opt['id']] = implode($separator, [$opt[$valueFieldName] + $taxAmount, $count, $max_value]);
 
           if (!in_array($opt['id'], $freezeOptions)) {
             $allowedOptions[] = $opt['id'];
@@ -562,7 +562,7 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
             }
             $opt['label'] = $preHelpText . $opt['label'] . $postHelpText;
           }
-          $priceVal = implode($seperator, [$opt[$valueFieldName] + $taxAmount, $count, $max_value]);
+          $priceVal = implode($separator, [$opt[$valueFieldName] + $taxAmount, $count, $max_value]);
           $check[$opId] = &$qf->createElement('checkbox', $opt['id'], NULL, $opt['label'],
             [
               'price' => json_encode([$opt['id'], $priceVal]),

--- a/CRM/Report/Form/Event/ParticipantListing.php
+++ b/CRM/Report/Form/Event/ParticipantListing.php
@@ -693,7 +693,7 @@ ORDER BY  cv.label
         }
       }
 
-      // Handle value seperator in Fee Level
+      // Handle value separator in Fee Level
       if (array_key_exists('civicrm_participant_participant_fee_level', $row)) {
         $feeLevel = $row['civicrm_participant_participant_fee_level'];
         if ($feeLevel) {

--- a/CRM/Utils/Array.php
+++ b/CRM/Utils/Array.php
@@ -119,26 +119,26 @@ class CRM_Utils_Array {
    *   The array to be serialized.
    * @param int $depth
    *   (optional) Indentation depth counter.
-   * @param string $seperator
+   * @param string $separator
    *   (optional) String to be appended after open/close tags.
    *
    * @return string
    *   XML fragment representing $list.
    */
-  public static function &xml(&$list, $depth = 1, $seperator = "\n") {
+  public static function &xml(&$list, $depth = 1, $separator = "\n") {
     $xml = '';
     foreach ($list as $name => $value) {
       $xml .= str_repeat(' ', $depth * 4);
       if (is_array($value)) {
-        $xml .= "<{$name}>{$seperator}";
-        $xml .= self::xml($value, $depth + 1, $seperator);
+        $xml .= "<{$name}>{$separator}";
+        $xml .= self::xml($value, $depth + 1, $separator);
         $xml .= str_repeat(' ', $depth * 4);
-        $xml .= "</{$name}>{$seperator}";
+        $xml .= "</{$name}>{$separator}";
       }
       else {
         // make sure we escape value
         $value = self::escapeXML($value);
-        $xml .= "<{$name}>$value</{$name}>{$seperator}";
+        $xml .= "<{$name}>$value</{$name}>{$separator}";
       }
     }
     return $xml;
@@ -218,14 +218,14 @@ class CRM_Utils_Array {
    *   Destination array.
    * @param string $prefix
    *   (optional) String to prepend to keys.
-   * @param string $seperator
+   * @param string $separator
    *   (optional) String that separates the concatenated keys.
    */
-  public static function flatten(&$list, &$flat, $prefix = '', $seperator = ".") {
+  public static function flatten(&$list, &$flat, $prefix = '', $separator = ".") {
     foreach ($list as $name => $value) {
-      $newPrefix = ($prefix) ? $prefix . $seperator . $name : $name;
+      $newPrefix = ($prefix) ? $prefix . $separator . $name : $name;
       if (is_array($value)) {
-        self::flatten($value, $flat, $newPrefix, $seperator);
+        self::flatten($value, $flat, $newPrefix, $separator);
       }
       else {
         $flat[$newPrefix] = $value;

--- a/CRM/Utils/Date.php
+++ b/CRM/Utils/Date.php
@@ -26,7 +26,7 @@ class CRM_Utils_Date {
    * @param array $date
    *   ('Y', 'M', 'd').
    * @param string $separator
-   *   The seperator to use when formatting the date.
+   *   The separator to use when formatting the date.
    * @param int|string $invalidDate what to return if the date is invalid
    *
    * @return string

--- a/CRM/Utils/Mail/EmailProcessor.php
+++ b/CRM/Utils/Mail/EmailProcessor.php
@@ -134,10 +134,10 @@ class CRM_Utils_Mail_EmailProcessor {
     }
 
     $config = CRM_Core_Config::singleton();
-    $verpSeperator = preg_quote($config->verpSeparator);
-    $twoDigitStringMin = $verpSeperator . '(\d+)' . $verpSeperator . '(\d+)';
-    $twoDigitString = $twoDigitStringMin . $verpSeperator;
-    $threeDigitString = $twoDigitString . '(\d+)' . $verpSeperator;
+    $verpSeparator = preg_quote($config->verpSeparator);
+    $twoDigitStringMin = $verpSeparator . '(\d+)' . $verpSeparator . '(\d+)';
+    $twoDigitString = $twoDigitStringMin . $verpSeparator;
+    $threeDigitString = $twoDigitString . '(\d+)' . $verpSeparator;
 
     // FIXME: legacy regexen to handle CiviCRM 2.1 address patterns, with domain id and possible VERP part
     $commonRegex = '/^' . preg_quote($dao->localpart) . '(b|bounce|c|confirm|o|optOut|r|reply|re|e|resubscribe|u|unsubscribe)' . $threeDigitString . '([0-9a-f]{16})(-.*)?@' . preg_quote($dao->domain) . '$/';

--- a/templates/CRM/Event/Form/ParticipantFeeSelection.tpl
+++ b/templates/CRM/Event/Form/ParticipantFeeSelection.tpl
@@ -18,7 +18,7 @@ function display(totalfee) {
   // go as a float - CRM-13491
   totalfee = Math.round(totalfee*100)/100;
   // note : some variables used used here are global variables defined inside Calculate.tpl
-  var totalEventFee  = formatMoney( totalfee, 2, seperator, thousandMarker);
+  var totalEventFee  = formatMoney( totalfee, 2, separator, thousandMarker);
   cj('#pricevalue').html("<b>"+symbol+"</b> "+totalEventFee);
   scriptfee   = totalfee;
   scriptarray = price;
@@ -67,7 +67,7 @@ function populatebalanceFee(updatedAmt, onlyStatusUpdate) {
   }
 
   if (!onlyStatusUpdate) {
-    balanceAmt = formatMoney(balanceAmt, 2, seperator, thousandMarker);
+    balanceAmt = formatMoney(balanceAmt, 2, separator, thousandMarker);
     cj('#balance-fee').text(symbol+" "+balanceAmt);
   }
 }

--- a/templates/CRM/Pledge/Form/Pledge.tpl
+++ b/templates/CRM/Pledge/Form/Pledge.tpl
@@ -217,14 +217,14 @@
 
      function calculatedPaymentAmount( ) {
        var thousandMarker = {/literal}{crmSetting name="monetaryThousandSeparator" group="CiviCRM Localization"}{literal};
-       var seperator      = '{/literal}{$config->monetaryDecimalPoint}{literal}';
+       var separator      = '{/literal}{$config->monetaryDecimalPoint}{literal}';
        var amount = document.getElementById("amount").value;
-       // replace all thousandMarker and change the seperator to a dot
-       amount = amount.replace(thousandMarker,'').replace(seperator,'.');
+       // replace all thousandMarker and change the separator to a dot
+       amount = amount.replace(thousandMarker,'').replace(separator,'.');
        var installments = document.getElementById("installments").value;
        if ( installments != '' && installments != NaN) {
             amount =  amount/installments;
-            var installmentAmount = formatMoney( amount, 2, seperator, thousandMarker );
+            var installmentAmount = formatMoney( amount, 2, separator, thousandMarker );
             document.getElementById("eachPaymentAmount").value = installmentAmount;
        }
      }


### PR DESCRIPTION
Overview
----------------------------------------
This PR fixes a spelling mistake "separator" not "seperator" which inconsistent throughout the code.

Before
----------------------------------------
Sometimes variables, comments etc. use "seperator" and sometimes "separator" which could cause future bugs due to the incorrect spelling.

After
----------------------------------------
Fixed spelling and "separator" is now used consistently.

Technical Details
----------------------------------------
Have reviewed the changes and does not look like it should break anything. 

Looks like the change to **templates/CRM/Event/Form/ParticipantFeeSelection.tpl** may actually fix a bug due to the incorrect variable name.
Where "seperator" is referenced here, https://github.com/civicrm/civicrm-core/blob/master/templates/CRM/Event/Form/ParticipantFeeSelection.tpl#L21
With the "separator" defined here, https://github.com/civicrm/civicrm-core/blob/master/templates/CRM/Price/Form/Calculate.tpl#L28

Comments
----------------------------------------
Fingers crossed unit tests catch any problems with this change.
