### PR TITLE
Replace deprecated Drupal 8 constants

### DIFF
--- a/setup/plugins/installDatabase/FlushDrupal8.civi-setup.php
+++ b/setup/plugins/installDatabase/FlushDrupal8.civi-setup.php
@@ -51,6 +51,6 @@ function civicrm_install_set_drupal8_perms() {
     ]);
   }
   $perms = array_intersect($perms, $allPerms);
-  user_role_grant_permissions(DRUPAL_AUTHENTICATED_RID, $perms);
-  user_role_grant_permissions(DRUPAL_ANONYMOUS_RID, $perms);
+  user_role_grant_permissions(\Drupal\user\RoleInterface::AUTHENTICATED_ID, $perms);
+  user_role_grant_permissions(\Drupal\user\RoleInterface::ANONYMOUS_ID, $perms);
 }


### PR DESCRIPTION
Overview
----------------------------------------
These drupal role constants are deprecated in Drupal 8.

One way to see it is from a fresh drupal 8 install with drupal installed but not civi installed yet, go to the Extend menu choice and try to enable the civicrm module. If you haven't turned on on-screen logging at admin/config/development/logging, then you'll need to look in drupal watchdog.

Before
----------------------------------------
`Warning: Use of undefined constant DRUPAL_ANONYMOUS_RID - assumed 'DRUPAL_ANONYMOUS_RID' (this will throw an Error in a future version of PHP) in civicrm_install_set_drupal8_perms() (line 55 of ...\setup\plugins\installDatabase\FlushDrupal8.civi-setup.php)`

After
----------------------------------------


Technical Details
----------------------------------------
Deprecated

Comments
----------------------------------------

