### PR TITLE
Do not pass by reference for createRelatedMemberships

### DIFF
--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -1324,7 +1324,7 @@ WHERE  civicrm_membership.contact_id = civicrm_contact.id
    * @throws \CRM_Core_Exception
    * @throws \CiviCRM_API3_Exception
    */
-  public static function createRelatedMemberships(&$params, &$dao, $reset = FALSE) {
+  public static function createRelatedMemberships($params, $dao, $reset = FALSE) {
     // CRM-4213 check for loops, using static variable to record contacts already processed.
     if (!isset(\Civi::$statics[__CLASS__]['related_contacts'])) {
       \Civi::$statics[__CLASS__]['related_contacts'] = [];


### PR DESCRIPTION
Overview
----------------------------------------
Removes 2 pass by references that appear to increase the risk of unpredictable bugs & do not appear to have a logical reason to be passed by reference

Before
----------------------------------------
```public static function createRelatedMemberships(&$params, &$dao, $reset = FALSE) {```

Only really called from membership create: 

<img width="1276" alt="Screen Shot 2020-08-24 at 1 08 08 PM" src="https://user-images.githubusercontent.com/336308/90994058-7f1f2e00-e60b-11ea-9bd3-288e3c20e712.png">

The one other function that calls it is throwing away the params

After
----------------------------------------
```public static function createRelatedMemberships($params, $dao, $reset = FALSE) {```

Technical Details
----------------------------------------
There are 2 parameters passed by reference to this function
1) dao - this is not altered
2) params - this IS altered but the calling function (create) does not use it again. While it's
possible a function that calls create uses it again the idea that they would want the params
to have been altered to refer to a different related relationship does not seem probable.

Tests on this are in JobTest & apiv3_MembershipTest

Comments
----------------------------------------

