### PR TITLE
Remove old dropped items from the schema xml

### DIFF
--- a/xml/schema/Activity/Activity.xml
+++ b/xml/schema/Activity/Activity.xml
@@ -22,30 +22,6 @@
     <autoincrement>true</autoincrement>
   </primaryKey>
   <field>
-    <name>source_contact_id</name>
-    <type>int unsigned</type>
-    <title>Source Contact</title>
-    <import>true</import>
-    <headerPattern>/(activity.)?source(.contact(.id)?)?/i</headerPattern>
-    <comment>Contact ID of the person scheduling or logging this Activity. Usually the authenticated user.</comment>
-    <add>1.1</add>
-    <drop>4.4</drop>
-  </field>
-  <foreignKey>
-    <name>source_contact_id</name>
-    <table>civicrm_contact</table>
-    <key>id</key>
-    <add>1.1</add>
-    <drop>4.4</drop>
-    <onDelete>SET NULL</onDelete>
-  </foreignKey>
-  <index>
-    <name>UI_source_contact_id</name>
-    <fieldName>source_contact_id</fieldName>
-    <add>2.0</add>
-    <drop>3.2</drop>
-  </index>
-  <field>
     <name>source_record_id</name>
     <type>int unsigned</type>
     <title>Source Record</title>
@@ -81,23 +57,6 @@
     <add>1.6</add>
   </index>
   <field>
-    <name>target_entity_table</name>
-    <type>varchar</type>
-    <length>64</length>
-    <required>true</required>
-    <comment>Name of table where item being referenced is stored.</comment>
-    <add>1.1</add>
-    <drop>2.0</drop>
-  </field>
-  <field>
-    <name>target_entity_id</name>
-    <type>int unsigned</type>
-    <required>true</required>
-    <comment>Foreign key to the referenced item.</comment>
-    <add>1.1</add>
-    <drop>2.0</drop>
-  </field>
-  <field>
     <name>subject</name>
     <uniqueName>activity_subject</uniqueName>
     <type>varchar</type>
@@ -111,13 +70,6 @@
     </html>
     <add>1.1</add>
     <change>2.0</change>
-  </field>
-  <field>
-    <name>scheduled_date</name>
-    <type>datetime</type>
-    <comment>Date and time meeting is scheduled to occur.</comment>
-    <add>1.1</add>
-    <drop>2.0</drop>
   </field>
   <field>
     <name>activity_date_time</name>
@@ -140,27 +92,6 @@
     <fieldName>activity_date_time</fieldName>
     <add>4.7</add>
   </index>
-  <field>
-    <name>due_date_time</name>
-    <type>datetime</type>
-    <comment>Date and time this activity is due.</comment>
-    <add>2.0</add>
-    <drop>3.0</drop>
-  </field>
-  <field>
-    <name>duration_hours</name>
-    <type>int unsigned</type>
-    <comment>Planned or actual duration of meeting - hours.</comment>
-    <add>1.1</add>
-    <drop>2.0</drop>
-  </field>
-  <field>
-    <name>duration_minutes</name>
-    <type>int unsigned</type>
-    <comment>Planned or actual duration of meeting - minutes.</comment>
-    <add>1.1</add>
-    <drop>2.0</drop>
-  </field>
   <field>
     <name>duration</name>
     <uniqueName>activity_duration</uniqueName>
@@ -230,15 +161,6 @@
       <cols>60</cols>
     </html>
     <add>1.1</add>
-  </field>
-  <field>
-    <name>status</name>
-    <type>enum</type>
-    <title>Status</title>
-    <values>Scheduled, Completed</values>
-    <comment>What is the status of this meeting? Completed meeting status results in activity history entry.</comment>
-    <add>1.1</add>
-    <drop>2.0</drop>
   </field>
   <field>
     <name>status_id</name>
@@ -374,12 +296,6 @@
     <add>2.2</add>
     <onDelete>CASCADE</onDelete>
   </foreignKey>
-  <index>
-    <name>UI_original_id</name>
-    <fieldName>original_id</fieldName>
-    <add>2.2</add>
-    <drop>3.2</drop>
-  </index>
   <field>
     <name>result</name>
     <uniqueName>activity_result</uniqueName>

--- a/xml/schema/Activity/ActivityAssignment.xml
+++ b/xml/schema/Activity/ActivityAssignment.xml
@@ -18,59 +18,6 @@
     <name>id</name>
     <autoincrement>true</autoincrement>
   </primaryKey>
-
-  <field>
-    <name>activity_entity_table</name>
-    <type>varchar</type>
-    <length>64</length>
-    <required>true</required>
-    <comment>Name of table where item being referenced is stored (activity, phonecall or meeting).</comment>
-    <add>1.8</add>
-    <drop>2.0</drop>
-  </field>
-
-  <field>
-    <name>activity_entity_id</name>
-    <type>int unsigned</type>
-    <required>true</required>
-    <comment>Entity (activity, phonecall or meeting) id for which the assigment is created</comment>
-    <add>1.8</add>
-    <drop>2.0</drop>
-  </field>
-
-  <dynamicForeignKey>
-    <idColumn>activity_entity_id</idColumn>
-    <typeColumn>activity_entity_table</typeColumn>
-    <add>1.8</add>
-    <drop>2.0</drop>
-  </dynamicForeignKey>
-
-  <field>
-    <name>target_entity_table</name>
-    <type>varchar</type>
-    <length>64</length>
-    <required>true</required>
-    <comment>Name of table where item being referenced is stored (contact assigned to given activity).</comment>
-    <add>1.8</add>
-    <drop>2.0</drop>
-  </field>
-
-  <field>
-    <name>target_entity_id</name>
-    <type>int unsigned</type>
-    <required>true</required>
-    <comment>Foreign key to the referenced item.</comment>
-    <add>1.1</add>
-    <drop>2.0</drop>
-  </field>
-
-  <dynamicForeignKey>
-    <idColumn>target_entity_id</idColumn>
-    <typeColumn>target_entity_table</typeColumn>
-    <add>1.8</add>
-    <drop>2.0</drop>
-  </dynamicForeignKey>
-
   <field>
     <name>activity_id</name>
     <type>int unsigned</type>

--- a/xml/schema/Batch/Batch.xml
+++ b/xml/schema/Batch/Batch.xml
@@ -36,15 +36,6 @@
     <add>4.2</add>
   </index>
   <field>
-    <name>label</name>
-    <type>varchar</type>
-    <length>64</length>
-    <localizable>true</localizable>
-    <comment>Friendly Name.</comment>
-    <add>3.3</add>
-    <drop>4.2</drop>
-  </field>
-  <field>
     <name>title</name>
     <title>Batch Title</title>
     <type>varchar</type>

--- a/xml/schema/Case/Case.xml
+++ b/xml/schema/Case/Case.xml
@@ -25,23 +25,6 @@
     <autoincrement>true</autoincrement>
   </primaryKey>
   <field>
-    <name>contact_id</name>
-    <type>int unsigned</type>
-    <uniqueName>case_contact_id</uniqueName>
-    <required>true</required>
-    <comment>Contact ID of contact record given case belongs to.</comment>
-    <add>1.8</add>
-    <drop>2.1</drop>
-  </field>
-  <foreignKey>
-    <name>contact_id</name>
-    <table>civicrm_contact</table>
-    <key>id</key>
-    <add>1.8</add>
-    <drop>2.1</drop>
-    <onDelete>CASCADE</onDelete>
-  </foreignKey>
-  <field>
     <name>case_type_id</name>
     <type>int unsigned</type>
     <import>true</import>
@@ -70,51 +53,6 @@
     <key>id</key>
     <add>4.5</add>
   </foreignKey>
-  <field>
-    <name>casetag1_id</name>
-    <type>varchar</type>
-    <length>128</length>
-    <required>true</required>
-    <comment>Id of first case category.</comment>
-    <add>1.8</add>
-    <drop>2.0</drop>
-  </field>
-  <index>
-    <name>index_casetag1_id</name>
-    <fieldName>casetag1_id</fieldName>
-    <add>1.8</add>
-    <drop>2.0</drop>
-  </index>
-  <field>
-    <name>casetag2_id</name>
-    <type>varchar</type>
-    <length>128</length>
-    <required>true</required>
-    <comment>Id of second case category.</comment>
-    <add>1.8</add>
-    <drop>2.0</drop>
-  </field>
-  <index>
-    <name>index_casetag2_id</name>
-    <fieldName>casetag2_id</fieldName>
-    <add>1.8</add>
-    <drop>2.0</drop>
-  </index>
-  <field>
-    <name>casetag3_id</name>
-    <type>varchar</type>
-    <length>128</length>
-    <required>true</required>
-    <comment>Id of third case category.</comment>
-    <add>1.8</add>
-    <drop>2.0</drop>
-  </field>
-  <index>
-    <name>index_casetag3_id</name>
-    <fieldName>casetag3_id</fieldName>
-    <add>1.8</add>
-    <drop>2.0</drop>
-  </index>
   <field>
     <name>subject</name>
     <type>varchar</type>

--- a/xml/schema/Case/CaseActivity.xml
+++ b/xml/schema/Case/CaseActivity.xml
@@ -54,31 +54,4 @@
     <fieldName>activity_id</fieldName>
     <add>2.0</add>
   </index>
-
-  <field>
-   <name>activity_entity_table</name>
-   <type>varchar</type>
-   <length>64</length>
-   <required>true</required>
-   <comment>Name of table where item being referenced is stored (activity, phonecall or meeting).</comment>
-   <add>1.8</add>
-   <drop>2.0</drop>
-  </field>
-
-  <field>
-   <name>activity_entity_id</name>
-   <type>int unsigned</type>
-   <required>true</required>
-   <comment>Entity (activity, phonecall or meeting) id for which the assigment is created</comment>
-   <add>1.8</add>
-   <drop>2.0</drop>
-  </field>
-
-  <dynamicForeignKey>
-   <idColumn>activity_entity_id</idColumn>
-   <typeColumn>activity_entity_table</typeColumn>
-   <add>1.8</add>
-   <drop>2.0</drop>
-  </dynamicForeignKey>
-
 </table>

--- a/xml/schema/Contact/Contact.xml
+++ b/xml/schema/Contact/Contact.xml
@@ -247,19 +247,6 @@
     <add>1.1</add>
   </field>
   <field>
-    <name>home_URL</name>
-    <rule>url</rule>
-    <title>Website</title>
-    <type>varchar</type>
-    <length>128</length>
-    <import>true</import>
-    <headerPattern>/^(home\sURL)|URL|web|site/i</headerPattern>
-    <dataPattern>/^[\w\/\:\.]+$/</dataPattern>
-    <comment>optional "home page" URL for this contact.</comment>
-    <add>1.1</add>
-    <drop>3.2</drop>
-  </field>
-  <field>
     <name>image_URL</name>
     <type>text</type>
     <import>true</import>
@@ -510,32 +497,6 @@
     <add>4.4</add>
   </index>
   <field>
-    <name>greeting_type</name>
-    <type>varchar</type>
-    <length>128</length>
-    <import>true</import>
-    <comment>Preferred greeting format.</comment>
-    <add>1.1</add>
-    <drop>2.2</drop>
-  </field>
-  <field>
-    <name>greeting_type_id</name>
-    <title>Greeting Type</title>
-    <type>int unsigned</type>
-    <comment>FK to civicrm_option_value.id, that has to be valid, registered Greeting type.</comment>
-    <add>2.2</add>
-    <drop>3.0</drop>
-  </field>
-  <field>
-    <name>custom_greeting</name>
-    <type>varchar</type>
-    <length>128</length>
-    <import>true</import>
-    <comment>Custom greeting message.</comment>
-    <add>1.1</add>
-    <drop>3.0</drop>
-  </field>
-  <field>
     <name>email_greeting_id</name>
     <type>int unsigned</type>
     <title>Email Greeting ID</title>
@@ -723,23 +684,6 @@
     <contactType>Individual</contactType>
   </field>
   <field>
-    <name>mail_to_household_id</name>
-    <title>Mail to Household ID</title>
-    <type>int unsigned</type>
-    <comment>OPTIONAL FK to civicrm_contact_household record. If NOT NULL, direct mail communications to household rather than individual location. </comment>
-    <export>true</export>
-    <add>1.1</add>
-    <drop>3.3</drop>
-  </field>
-  <foreignKey>
-    <name>mail_to_household_id</name>
-    <table>civicrm_contact</table>
-    <key>id</key>
-    <add>2.1</add>
-    <onDelete>SET NULL</onDelete>
-    <drop>3.3</drop>
-  </foreignKey>
-  <field>
     <name>household_name</name>
     <type>varchar</type>
     <length>128</length>
@@ -858,12 +802,6 @@
     </html>
     <permission>access deleted contacts</permission>
   </field>
-  <index>
-    <name>index_is_deleted</name>
-    <fieldName>is_deleted</fieldName>
-    <add>3.2</add>
-    <drop>4.4</drop>
-  </index>
   <index>
     <name>index_is_deleted_sort_name</name>
     <fieldName>is_deleted</fieldName>

--- a/xml/schema/Contact/Individual.xml
+++ b/xml/schema/Contact/Individual.xml
@@ -75,14 +75,6 @@
     <add>1.8</add>
   </index>
   <field>
-    <name>gender</name>
-    <type>enum</type>
-    <import>true</import>
-    <values>Female, Male, Other</values>
-    <add>1.1</add>
-    <drop>1.2</drop>
-  </field>
-  <field>
     <name>prefix_id</name>
     <type>int unsigned</type>
     <comment>Prefix or Title for name (Ms, Mr...). FK to prefix ID</comment>
@@ -108,32 +100,6 @@
     <fieldName>suffix_id</fieldName>
     <add>1.6</add>
   </index>
-  <field>
-    <name>prefix</name>
-    <type>varchar</type>
-    <length>64</length>
-    <import>true</import>
-    <comment>Prefix to Name.</comment>
-    <add>1.1</add>
-    <drop>1.2</drop>
-  </field>
-  <field>
-    <name>suffix</name>
-    <type>varchar</type>
-    <length>64</length>
-    <import>true</import>
-    <comment>Suffix to Name.</comment>
-    <add>1.1</add>
-    <drop>1.2</drop>
-  </field>
-  <field>
-    <name>greeting_type</name>
-    <type>varchar</type>
-    <length>128</length>
-    <comment>Preferred greeting format.</comment>
-    <add>1.1</add>
-    <drop>2.2</drop>
-  </field>
   <field>
     <name>greeting_type_id</name>
     <title>Greeting Type</title>

--- a/xml/schema/Contact/SavedSearch.xml
+++ b/xml/schema/Contact/SavedSearch.xml
@@ -19,15 +19,6 @@
     <autoincrement>false</autoincrement>
   </primaryKey>
   <field>
-    <name>query</name>
-    <title>SQL Query</title>
-    <type>text</type>
-    <import>true</import>
-    <comment>SQL query for this search</comment>
-    <add>1.1</add>
-    <drop>1.5</drop>
-  </field>
-  <field>
     <name>form_values</name>
     <title>Submitted Form Values</title>
     <type>text</type>
@@ -35,14 +26,6 @@
     <comment>Submitted form values for this search</comment>
     <serialize>PHP</serialize>
     <add>1.1</add>
-  </field>
-  <field>
-    <name>is_active</name>
-    <type>boolean</type>
-    <title>Saved Search Enabled</title>
-    <comment>Is this entry active?</comment>
-    <add>1.1</add>
-    <drop>1.5</drop>
   </field>
   <field>
     <name>mapping_id</name>

--- a/xml/schema/Contribute/Contribution.xml
+++ b/xml/schema/Contribute/Contribution.xml
@@ -47,39 +47,6 @@
     <onDelete>CASCADE</onDelete>
   </foreignKey>
   <field>
-    <name>solicitor_id</name>
-    <title>Solicitor ID</title>
-    <type>int unsigned</type>
-    <comment>FK to Solicitor ID</comment>
-    <add>1.4</add>
-    <drop>2.2</drop>
-  </field>
-  <foreignKey>
-    <name>solicitor_id</name>
-    <table>civicrm_contact</table>
-    <key>id</key>
-    <add>1.4</add>
-    <drop>2.2</drop>
-    <onDelete>SET NULL</onDelete>
-  </foreignKey>
-  <field>
-    <name>contribution_type_id</name>
-    <title>Contribution Type</title>
-    <export>false</export>
-    <type>int unsigned</type>
-    <comment>FK to Contribution Type</comment>
-    <add>1.3</add>
-    <drop>4.3</drop>
-  </field>
-  <foreignKey>
-    <name>contribution_type_id</name>
-    <table>civicrm_contribution_type</table>
-    <key>id</key>
-    <add>1.3</add>
-    <drop>4.3</drop>
-    <onDelete>SET NULL</onDelete>
-  </foreignKey>
-  <field>
     <name>financial_type_id</name>
     <title>Financial Type</title>
     <type>int unsigned</type>
@@ -359,16 +326,6 @@
     <html>
       <type>Text</type>
     </html>
-  </field>
-  <field>
-    <name>note</name>
-    <type>text</type>
-    <comment>Note and/or Comment.</comment>
-    <import>true</import>
-    <headerPattern>/Note|Comment/i</headerPattern>
-    <dataPattern>//</dataPattern>
-    <add>1.4</add>
-    <drop>1.7</drop>
   </field>
   <index>
     <name>UI_contrib_trxn_id</name>

--- a/xml/schema/Contribute/ContributionPage.xml
+++ b/xml/schema/Contribute/ContributionPage.xml
@@ -42,20 +42,6 @@
     <add>1.3</add>
   </field>
   <field>
-    <name>contribution_type_id</name>
-    <type>int unsigned</type>
-    <required>true</required>
-    <comment>default Contribution type assigned to contributions submitted via this page, e.g. Contribution, Campaign Contribution</comment>
-    <add>1.3</add>
-    <drop>4.3</drop>
-  </field>
-  <foreignKey>
-    <name>contribution_type_id</name>
-    <table>civicrm_contribution_type</table>
-    <key>id</key>
-    <drop>4.3</drop>
-  </foreignKey>
-  <field>
     <name>financial_type_id</name>
     <title>Financial Type</title>
     <type>int unsigned</type>

--- a/xml/schema/Contribute/ContributionProduct.xml
+++ b/xml/schema/Contribute/ContributionProduct.xml
@@ -56,17 +56,6 @@
     <add>1.4</add>
   </field>
   <field>
-    <name>total_cost</name>
-    <type>decimal</type>
-    <required>true</required>
-    <import>true</import>
-    <headerPattern>/^total|(.?^am(ou)?nt)/i</headerPattern>
-    <dataPattern>/^\d+(\.\d{2})?$/</dataPattern>
-    <comment>quantity X civicrm_product.cost.</comment>
-    <add>1.3</add>
-    <drop>4.1</drop>
-  </field>
-  <field>
     <name>fulfilled_date</name>
     <type>date</type>
     <title>Fulfilled Date</title>

--- a/xml/schema/Contribute/ContributionRecur.xml
+++ b/xml/schema/Contribute/ContributionRecur.xml
@@ -287,13 +287,6 @@
       <type>Text</type>
     </html>
   </field>
-  <field>
-    <name>next_sched_contribution</name>
-    <type>datetime</type>
-    <comment>At Groundspring this was used by the cron job which triggered payments. If we''re not doing that but we know about payments, it might still be useful to store for display to org andor contributors.</comment>
-    <add>1.6</add>
-    <drop>4.4</drop>
-  </field>
     <field>
     <name>next_sched_contribution_date</name>
     <title>Next Scheduled Contribution Date</title>
@@ -364,23 +357,6 @@
     <table>civicrm_payment_processor</table>
     <key>id</key>
     <add>3.3</add>
-    <onDelete>SET NULL</onDelete>
-  </foreignKey>
-  <field>
-    <name>contribution_type_id</name>
-    <title>Contribution Type</title>
-    <export>false</export>
-    <type>int unsigned</type>
-    <comment>FK to Contribution Type</comment>
-    <add>4.1</add>
-    <drop>4.3</drop>
-  </field>
-  <foreignKey>
-    <name>contribution_type_id</name>
-    <table>civicrm_contribution_type</table>
-    <key>id</key>
-    <add>4.1</add>
-    <drop>4.3</drop>
     <onDelete>SET NULL</onDelete>
   </foreignKey>
   <field>

--- a/xml/schema/Contribute/PremiumsProduct.xml
+++ b/xml/schema/Contribute/PremiumsProduct.xml
@@ -48,14 +48,6 @@
     <add>1.4</add>
   </foreignKey>
   <field>
-    <name>sort_position</name>
-    <title>Sort Position</title>
-    <type>int unsigned</type>
-    <required>true</required>
-    <add>1.4</add>
-    <drop>2.0</drop>
-  </field>
-  <field>
     <name>weight</name>
     <title>Order</title>
     <type>int unsigned</type>

--- a/xml/schema/Core/Cache.xml
+++ b/xml/schema/Core/Cache.xml
@@ -36,14 +36,6 @@
     <add>2.1</add>
   </field>
   <index>
-    <name>UI_group_path</name>
-    <fieldName>group_name</fieldName>
-    <fieldName>path</fieldName>
-    <unique>true</unique>
-    <add>2.1</add>
-    <drop>4.2</drop>
-  </index>
-  <index>
     <name>UI_group_path_date</name>
     <fieldName>group_name</fieldName>
     <fieldName>path</fieldName>

--- a/xml/schema/Core/CustomField.xml
+++ b/xml/schema/Core/CustomField.xml
@@ -212,14 +212,6 @@
     <add>1.4</add>
   </field>
   <field>
-    <name>date_parts</name>
-    <type>varchar</type>
-    <length>255</length>
-    <comment>which date part included in display </comment>
-    <add>1.4</add>
-    <drop>3.1</drop>
-  </field>
-  <field>
     <name>date_format</name>
     <type>varchar</type>
     <title>Field Data Format</title>

--- a/xml/schema/Core/CustomGroup.xml
+++ b/xml/schema/Core/CustomGroup.xml
@@ -48,14 +48,6 @@
     <add>1.1</add>
   </field>
   <field>
-    <name>extends_entity_column_name</name>
-    <type>varchar</type>
-    <length>64</length>
-    <comment>linking custom group for dynamic object</comment>
-    <add>1.6</add>
-    <drop>2.2</drop>
-  </field>
-  <field>
     <name>extends_entity_column_id</name>
     <type>int unsigned</type>
     <title>Custom Group Subtype List</title>

--- a/xml/schema/Core/Dashboard.xml
+++ b/xml/schema/Core/Dashboard.xml
@@ -63,13 +63,6 @@
     <add>3.1</add>
   </field>
   <field>
-    <name>content</name>
-    <type>text</type>
-    <comment>dashlet content</comment>
-    <add>3.1</add>
-    <drop>3.3</drop>
-  </field>
-  <field>
     <name>permission</name>
     <type>varchar</type>
     <title>Dashlet Permission</title>
@@ -154,13 +147,5 @@
     <default>60</default>
     <required>true</required>
     <add>4.7</add>
-  </field>
-  <field>
-    <name>created_date</name>
-    <type>datetime</type>
-    <title>Dashlet Created Date</title>
-    <comment>When was content populated</comment>
-    <add>3.1</add>
-    <drop>3.3</drop>
   </field>
 </table>

--- a/xml/schema/Core/Discount.xml
+++ b/xml/schema/Core/Discount.xml
@@ -47,25 +47,6 @@
     <add>2.1</add>
   </index>
   <field>
-    <name>option_group_id</name>
-    <uniqueName>participant_discount_name</uniqueName>
-    <title>Discount Name</title>
-    <type>int unsigned</type>
-    <required>true</required>
-    <export>true</export>
-    <comment>FK to civicrm_price_set</comment>
-    <add>2.1</add>
-    <drop>4.3</drop>
-  </field>
-  <foreignKey>
-    <name>option_group_id</name>
-    <table>civicrm_price_set</table>
-    <key>id</key>
-    <add>2.1</add>
-    <onDelete>CASCADE</onDelete>
-    <drop>4.3</drop>
-  </foreignKey>
-  <field>
     <name>price_set_id</name>
     <uniqueName>participant_discount_name</uniqueName>
     <title>Discount Name</title>

--- a/xml/schema/Core/Domain.xml
+++ b/xml/schema/Core/Domain.xml
@@ -47,46 +47,6 @@
     <add>1.1</add>
   </index>
   <field>
-    <name>contact_name</name>
-    <type>varchar</type>
-    <length>64</length>
-    <comment>Name of the person responsible for this domain</comment>
-    <add>1.1</add>
-    <drop>1.9</drop>
-  </field>
-  <field>
-    <name>email_name</name>
-    <type>varchar</type>
-    <length>255</length>
-    <comment>The default email name that is used in the from address for all outgoing emails</comment>
-    <add>1.9</add>
-    <drop>2.2</drop>
-  </field>
-  <field>
-    <name>email_address</name>
-    <type>varchar</type>
-    <length>255</length>
-    <comment>The default email address that is used as the from address for all outgoing emails</comment>
-    <add>1.9</add>
-    <drop>2.2</drop>
-  </field>
-  <field>
-    <name>email_domain</name>
-    <type>varchar</type>
-    <length>64</length>
-    <comment>The domain from which outgoing email for this domain will appear to originate</comment>
-    <add>1.1</add>
-    <drop>2.2</drop>
-  </field>
-  <field>
-    <name>email_return_path</name>
-    <type>varchar</type>
-    <length>64</length>
-    <comment>The domain from which outgoing email for this domain will appear to originate</comment>
-    <add>1.1</add>
-    <drop>2.2</drop>
-  </field>
-  <field>
     <name>config_backend</name>
     <type>text</type>
     <title>Domain Configuration</title>
@@ -102,13 +62,6 @@
     <length>32</length>
     <comment>The civicrm version this instance is running</comment>
     <add>2.0</add>
-  </field>
-  <field>
-    <name>loc_block_id</name>
-    <type>int unsigned</type>
-    <comment>FK to Location Block ID. This is specifically not an FK to avoid circular constraints</comment>
-    <add>2.0</add>
-    <drop>4.3</drop>
   </field>
   <field>
     <name>contact_id</name>

--- a/xml/schema/Core/EntityTag.xml
+++ b/xml/schema/Core/EntityTag.xml
@@ -20,22 +20,6 @@
     <autoincrement>true</autoincrement>
   </primaryKey>
   <field>
-    <name>contact_id</name>
-    <type>int unsigned</type>
-    <required>true</required>
-    <comment>FK to contact table.</comment>
-    <add>2.0</add>
-    <drop>3.2</drop>
-  </field>
-  <foreignKey>
-    <name>contact_id</name>
-    <table>civicrm_contact</table>
-    <key>id</key>
-    <add>2.0</add>
-    <drop>3.2</drop>
-    <onDelete>CASCADE</onDelete>
-  </foreignKey>
-  <field>
     <name>entity_table</name>
     <type>varchar</type>
     <title>Entity Table</title>
@@ -59,13 +43,6 @@
     <typeColumn>entity_table</typeColumn>
     <add>3.2</add>
   </dynamicForeignKey>
-  <index>
-    <name>index_entity</name>
-    <fieldName>entity_table</fieldName>
-    <fieldName>entity_id</fieldName>
-    <add>3.2</add>
-    <drop>3.4</drop>
-  </index>
   <field>
     <name>tag_id</name>
     <type>int unsigned</type>

--- a/xml/schema/Core/Job.xml
+++ b/xml/schema/Core/Job.xml
@@ -86,15 +86,6 @@
     <add>4.1</add>
   </field>
   <field>
-    <name>api_prefix</name>
-    <type>varchar</type>
-    <length>255</length>
-    <default>"civicrm_api3"</default>
-    <comment>Prefix of the job api call</comment>
-    <add>4.1</add>
-    <drop>4.3</drop>
-  </field>
-  <field>
     <name>api_entity</name>
     <title>API Entity</title>
     <type>varchar</type>

--- a/xml/schema/Core/Mapping.xml
+++ b/xml/schema/Core/Mapping.xml
@@ -36,16 +36,6 @@
     <add>1.2</add>
   </field>
   <field>
-    <name>mapping_type</name>
-    <type>enum</type>
-    <values>Export, Import, Export Contributions, Import Contributions, Import Activity, Search Builder, Import
-      Memberships, Import Participants
-    </values>
-    <comment>Type of Mapping.</comment>
-    <add>1.2</add>
-    <drop>2.1</drop>
-  </field>
-  <field>
     <name>mapping_type_id</name>
     <type>int unsigned</type>
     <title>Mapping Type</title>

--- a/xml/schema/Core/MappingField.xml
+++ b/xml/schema/Core/MappingField.xml
@@ -79,14 +79,6 @@
     <add>1.2</add>
   </foreignKey>
   <field>
-    <name>phone_type</name>
-    <type>varchar</type>
-    <length>64</length>
-    <comment>Phone type, if required</comment>
-    <add>1.2</add>
-    <drop>2.2</drop>
-  </field>
-  <field>
     <name>phone_type_id</name>
     <title>Phone Type</title>
     <type>int unsigned</type>

--- a/xml/schema/Core/Phone.xml
+++ b/xml/schema/Core/Phone.xml
@@ -138,16 +138,6 @@
     <add>4.3</add>
   </index>
   <field>
-    <name>phone_type</name>
-    <type>enum</type>
-    <values>Phone, Mobile, Fax, Pager</values>
-    <headerPattern>/phone\s+type/i</headerPattern>
-    <dataPattern>/phone|mobile|fax|pager/i</dataPattern>
-    <comment>What type of telecom device is this.</comment>
-    <add>1.1</add>
-    <drop>2.2</drop>
-  </field>
-  <field>
     <name>phone_type_id</name>
     <title>Phone Type ID</title>
     <type>int unsigned</type>

--- a/xml/schema/Core/UFField.xml
+++ b/xml/schema/Core/UFField.xml
@@ -104,22 +104,6 @@
     <add>3.2</add>
   </field>
   <field>
-    <name>is_registration</name>
-    <type>boolean</type>
-    <default>0</default>
-    <comment>Is this field included in new user registration forms?</comment>
-    <add>1.1</add>
-    <drop>1.3</drop>
-  </field>
-  <field>
-    <name>is_match</name>
-    <type>boolean</type>
-    <default>0</default>
-    <comment>Is this field part of the key for matching users to contacts?</comment>
-    <add>1.1</add>
-    <drop>1.3</drop>
-  </field>
-  <field>
     <name>visibility</name>
     <title>Profile Field Visibility</title>
     <type>varchar</type>
@@ -133,14 +117,6 @@
     <html>
       <type>Select</type>
     </html>
-  </field>
-  <field>
-    <name>listings_title</name>
-    <type>varchar</type>
-    <length>64</length>
-    <comment>Page title for listings page (users who share a common value for this property).</comment>
-    <add>1.1</add>
-    <drop>1.2</drop>
   </field>
   <field>
     <name>in_selector</name>
@@ -172,14 +148,6 @@
     <add>1.3</add>
     <onDelete>SET NULL</onDelete>
   </foreignKey>
-  <field>
-    <name>phone_type</name>
-    <type>varchar</type>
-    <length>64</length>
-    <comment>Phone type, if required</comment>
-    <add>1.3</add>
-    <drop>2.2</drop>
-  </field>
   <field>
     <name>phone_type_id</name>
     <title>Profile Field Phone Type</title>

--- a/xml/schema/Core/UFGroup.xml
+++ b/xml/schema/Core/UFGroup.xml
@@ -38,13 +38,6 @@
     <add>2.1</add>
   </field>
   <field>
-    <name>form_type</name>
-    <type>enum</type>
-    <values>CiviCRM Profile</values>
-    <comment>Type of form.</comment>
-    <drop>2.1</drop>
-  </field>
-  <field>
     <name>title</name>
     <title>Profile Name</title>
     <type>varchar</type>
@@ -82,14 +75,6 @@
     <add>4.4</add>
   </field>
   <field>
-    <name>collapse_display</name>
-    <type>int unsigned</type>
-    <default>0</default>
-    <comment>Will this group be in collapsed or expanded mode on initial display ?</comment>
-    <add>1.1</add>
-    <drop>2.2</drop>
-  </field>
-  <field>
     <name>help_pre</name>
     <type>text</type>
     <localizable>true</localizable>
@@ -113,19 +98,6 @@
       <cols>80</cols>
     </html>
     <add>1.2</add>
-  </field>
-  <field>
-    <name>weight</name>
-    <title>Profile Weight</title>
-    <type>int</type>
-    <required>true</required>
-    <default>1</default>
-    <html>
-      <type>Text</type>
-    </html>
-    <comment>Controls display order when multiple user framework groups are setup for concurrent display.</comment>
-    <add>1.2</add>
-    <drop>1.3</drop>
   </field>
   <field>
     <name>limit_listings_group_id</name>

--- a/xml/schema/Core/UFMatch.xml
+++ b/xml/schema/Core/UFMatch.xml
@@ -74,15 +74,6 @@
     <onDelete>CASCADE</onDelete>
   </foreignKey>
   <field>
-    <name>email</name>
-    <type>varchar</type>
-    <length>64</length>
-    <rule>email</rule>
-    <comment>Email address</comment>
-    <add>1.1</add>
-    <drop>2.0</drop>
-  </field>
-  <field>
     <name>language</name>
     <title>Preferred Language</title>
     <type>varchar</type>
@@ -90,14 +81,6 @@
     <comment>UI language preferred by the given user/contact</comment>
     <add>2.1</add>
   </field>
-  <index>
-    <name>UI_uf_id_domain_id</name>
-    <fieldName>uf_id</fieldName>
-    <fieldName>domain_id</fieldName>
-    <unique>true</unique>
-    <add>1.5</add>
-    <drop>1.7</drop>
-  </index>
   <index>
     <name>UI_uf_name_domain_id</name>
     <fieldName>uf_name</fieldName>

--- a/xml/schema/Dedupe/RuleGroup.xml
+++ b/xml/schema/Dedupe/RuleGroup.xml
@@ -46,15 +46,6 @@
     </html>
   </field>
   <field>
-    <name>level</name>
-    <title>Level</title>
-    <type>enum</type>
-    <values>Strict, Fuzzy</values>
-    <comment>Whether the rule should be used for cases where strict matching of the given contact type is required or a fuzzy one</comment>
-    <add>2.1</add>
-    <drop>4.3</drop>
-  </field>
-  <field>
     <name>used</name>
     <type>varchar</type>
     <title>Length</title>
@@ -68,14 +59,6 @@
     <html>
       <type>Radio</type>
     </html>
-  </field>
-  <field>
-    <name>is_default</name>
-    <title>Default></title>
-    <type>boolean</type>
-    <comment>Is this a default rule (one rule for every contact type + level combination should be default)</comment>
-    <add>2.1</add>
-    <drop>4.3</drop>
   </field>
   <field>
     <name>name</name>

--- a/xml/schema/Event/Event.xml
+++ b/xml/schema/Event/Event.xml
@@ -219,14 +219,6 @@
     </html>
   </field>
   <field>
-    <name>contribution_type_id</name>
-    <type>int unsigned</type>
-    <default>0</default>
-    <comment>Contribution type assigned to paid event registrations for this event. Required if is_monetary is true.</comment>
-    <add>1.7</add>
-    <drop>4.3</drop>
-  </field>
-  <field>
     <name>financial_type_id</name>
     <type>int unsigned</type>
     <title>Financial Type</title>
@@ -318,19 +310,6 @@
     <onDelete>SET NULL</onDelete>
     <add>2.0</add>
   </foreignKey>
-  <field>
-    <name>receipt_text</name>
-    <type>varchar</type>
-    <html>
-      <type>TextArea</type>
-      <rows>6</rows>
-      <cols>50</cols>
-    </html>
-    <length>255</length>
-    <comment>Receipt Text for off-line event participation</comment>
-    <add>2.0</add>
-    <drop>2.1</drop>
-  </field>
   <field>
     <name>default_role_id</name>
     <uniqueName>default_role_id</uniqueName>

--- a/xml/schema/Financial/EntityFinancialTrxn.xml
+++ b/xml/schema/Financial/EntityFinancialTrxn.xml
@@ -63,15 +63,6 @@
     <comment>allocated amount of transaction to this entity</comment>
     <add>3.2</add>
   </field>
-  <field>
-    <name>currency</name>
-    <type>varchar</type>
-    <length>3</length>
-    <default>NULL</default>
-    <comment>3 character string, value from config setting or input via user.</comment>
-    <add>3.2</add>
-    <drop>4.3</drop>
-  </field>
   <index>
     <name>UI_entity_financial_trxn_entity_table</name>
     <fieldName>entity_table</fieldName>

--- a/xml/schema/Financial/FinancialAccount.xml
+++ b/xml/schema/Financial/FinancialAccount.xml
@@ -43,13 +43,6 @@
     <onDelete>SET NULL</onDelete>
   </foreignKey>
   <field>
-    <name>account_type_id</name>
-    <type>int unsigned</type>
-    <required>true</required>
-    <add>3.2</add>
-    <drop>4.3</drop>
-  </field>
-  <field>
     <name>financial_account_type_id</name>
     <type>int unsigned</type>
     <title>Financial Account Type</title>

--- a/xml/schema/Financial/FinancialTrxn.xml
+++ b/xml/schema/Financial/FinancialTrxn.xml
@@ -18,34 +18,6 @@
     <autoincrement>true</autoincrement>
   </primaryKey>
   <field>
-    <name>from_account_id</name>
-    <type>int unsigned</type>
-    <comment>FK to financial_account table.</comment>
-    <add>3.2</add>
-    <drop>4.3</drop>
-  </field>
-  <foreignKey>
-    <name>from_account_id</name>
-    <table>civicrm_financial_account</table>
-    <key>id</key>
-    <add>3.2</add>
-    <drop>4.3</drop>
-  </foreignKey>
-  <field>
-    <name>to_account_id</name>
-    <type>int unsigned</type>
-    <comment>FK to financial_account table.</comment>
-    <add>3.2</add>
-    <drop>4.3</drop>
-  </field>
-  <foreignKey>
-    <name>to_account_id</name>
-    <table>civicrm_financial_account</table>
-    <key>id</key>
-    <add>3.2</add>
-    <drop>4.3</drop>
-  </foreignKey>
-  <field>
     <name>from_financial_account_id</name>
     <type>int unsigned</type>
     <title>Financial Transaction From Account</title>
@@ -100,15 +72,6 @@
     </html>
   </field>
   <field>
-    <name>trxn_type</name>
-    <title>Financial Transaction Type</title>
-    <type>enum</type>
-    <values>Debit,Credit</values>
-    <required>true</required>
-    <add>1.3</add>
-    <drop>4.3</drop>
-  </field>
-  <field>
     <name>total_amount</name>
     <title>Financial Total Amount</title>
     <type>decimal</type>
@@ -160,15 +123,6 @@
     <import>true</import>
     <comment>Is this entry either a payment or a reversal of a payment?</comment>
     <add>4.7</add>
-  </field>
-  <field>
-    <name>payment_processor</name>
-    <type>varchar</type>
-    <length>64</length>
-    <required>true</required>
-    <comment>derived from Processor setting in civicrm.settings.php.</comment>
-    <add>1.3</add>
-    <drop>4.3</drop>
   </field>
   <field>
     <name>trxn_id</name>

--- a/xml/schema/Financial/FinancialType.xml
+++ b/xml/schema/Financial/FinancialType.xml
@@ -38,16 +38,6 @@
     <add>1.3</add>
   </field>
   <field>
-    <name>accounting_code</name>
-    <title>Accounting Code</title>
-    <type>varchar</type>
-    <length>64</length>
-    <export>true</export>
-    <comment>Optional value for mapping contributions to accounting system codes for each type/category of contribution.</comment>
-    <add>1.3</add>
-    <drop>4.3</drop>
-  </field>
-  <field>
     <name>description</name>
     <type>varchar</type>
     <html>

--- a/xml/schema/Financial/PaymentProcessor.xml
+++ b/xml/schema/Financial/PaymentProcessor.xml
@@ -71,14 +71,6 @@
     <add>1.8</add>
   </field>
   <field>
-    <name>payment_processor_type</name>
-    <type>varchar</type>
-    <length>255</length>
-    <comment>Payment Processor Type.</comment>
-    <add>1.8</add>
-    <drop>4.3</drop>
-  </field>
-  <field>
     <name>payment_processor_type_id</name>
     <title>Payment Processor Type ID</title>
     <type>int unsigned</type>

--- a/xml/schema/Grant/Grant.xml
+++ b/xml/schema/Grant/Grant.xml
@@ -180,15 +180,6 @@
     </html>
   </field>
   <field>
-    <name>currency</name>
-    <type>varchar</type>
-    <length>8</length>
-    <default>NULL</default>
-    <comment>3 character string, value from config setting or input via user.</comment>
-    <add>3.2</add>
-    <drop>4.3</drop>
-  </field>
-  <field>
     <name>rationale</name>
     <type>text</type>
     <title>Grant Rationale</title>

--- a/xml/schema/Member/MembershipType.xml
+++ b/xml/schema/Member/MembershipType.xml
@@ -85,21 +85,6 @@
     <onDelete>RESTRICT</onDelete>
   </foreignKey>
   <field>
-    <name>contribution_type_id</name>
-    <type>int unsigned</type>
-    <required>true</required>
-    <comment>If membership is paid by a contribution - what contribution type should be used. FK to Contribution Type ID</comment>
-    <add>1.5</add>
-    <drop>4.3</drop>
-  </field>
-  <foreignKey>
-    <name>contribution_type_id</name>
-    <table>civicrm_contribution_type</table>
-    <key>id</key>
-    <add>1.5</add>
-    <drop>4.3</drop>
-  </foreignKey>
-  <field>
     <name>financial_type_id</name>
     <title>Membership Financial Type</title>
     <type>int unsigned</type>
@@ -192,13 +177,6 @@
     <add>1.5</add>
     <serialize>SEPARATOR_TRIMMED</serialize>
   </field>
-  <foreignKey>
-    <name>relationship_type_id</name>
-    <table>civicrm_relationship_type</table>
-    <key>id</key>
-    <add>1.5</add>
-    <drop>3.3</drop>
-  </foreignKey>
   <index>
     <name>index_relationship_type_id</name>
     <fieldName>relationship_type_id</fieldName>

--- a/xml/schema/PCP/PCP.xml
+++ b/xml/schema/PCP/PCP.xml
@@ -92,20 +92,6 @@
     </html>
   </field>
   <field>
-    <name>contribution_page_id</name>
-    <type>int unsigned</type>
-    <required>true</required>
-    <comment>The Contribution Page which triggered this pcp</comment>
-    <add>2.2</add>
-    <drop>4.1</drop>
-  </field>
-  <foreignKey>
-    <name>contribution_page_id</name>
-    <table>civicrm_contribution_page</table>
-    <key>id</key>
-    <drop>4.1</drop>
-  </foreignKey>
-  <field>
     <name>page_id</name>
     <title>Contribution Page</title>
     <type>int unsigned</type>
@@ -181,15 +167,6 @@
     <html>
       <type>Select</type>
     </html>
-  </field>
-  <field>
-    <name>referer</name>
-    <title>Referer</title>
-    <type>varchar</type>
-    <length>255</length>
-    <default>NULL</default>
-    <add>2.2</add>
-    <drop>4.1</drop>
   </field>
   <field>
     <name>is_active</name>

--- a/xml/schema/PCP/PCPBlock.xml
+++ b/xml/schema/PCP/PCPBlock.xml
@@ -39,13 +39,6 @@
     <typeColumn>entity_table</typeColumn>
     <add>2.2</add>
   </dynamicForeignKey>
-  <foreignKey>
-    <name>entity_id</name>
-    <table>civicrm_contribution_page</table>
-    <key>id</key>
-    <add>2.2</add>
-    <drop>4.1</drop>
-  </foreignKey>
   <field>
     <name>target_entity_type</name>
     <title>Target Entity</title>

--- a/xml/schema/Pledge/Pledge.xml
+++ b/xml/schema/Pledge/Pledge.xml
@@ -41,23 +41,6 @@
     <onDelete>CASCADE</onDelete>
   </foreignKey>
   <field>
-    <name>contribution_type_id</name>
-    <uniqueName>pledge_contribution_type_id</uniqueName>
-    <export>false</export>
-    <type>int unsigned</type>
-    <comment>FK to Contribution Type. This is propagated to contribution record when pledge payments are made.</comment>
-    <add>2.1</add>
-    <drop>4.3</drop>
-  </field>
-  <foreignKey>
-    <name>contribution_type_id</name>
-    <table>civicrm_contribution_type</table>
-    <key>id</key>
-    <add>2.1</add>
-    <drop>4.3</drop>
-    <onDelete>SET NULL</onDelete>
-  </foreignKey>
-  <field>
     <name>financial_type_id</name>
     <title>Type</title>
     <uniqueName>pledge_financial_type_id</uniqueName>

--- a/xml/schema/Price/LineItem.xml
+++ b/xml/schema/Price/LineItem.xml
@@ -68,15 +68,6 @@
     <onDelete>SET NULL</onDelete>
   </foreignKey>
   <field>
-    <name>option_group_id</name>
-    <title>Line Item Option Group</title>
-    <type>int unsigned</type>
-    <required>true</required>
-    <comment>FK to option group</comment>
-    <add>1.7</add>
-    <drop>3.3</drop>
-  </field>
-  <field>
     <name>label</name>
     <title>Line Item Label</title>
     <type>varchar</type>

--- a/xml/schema/Price/PriceField.xml
+++ b/xml/schema/Price/PriceField.xml
@@ -221,12 +221,4 @@
       <type>Select</type>
     </html>
   </field>
-  <field>
-    <name>count</name>
-    <type>int unsigned</type>
-    <default>NULL</default>
-    <comment>Number of Participants Per field</comment>
-    <add>3.2</add>
-    <drop>3.3</drop>
-  </field>
 </table>

--- a/xml/schema/Price/PriceSet.xml
+++ b/xml/schema/Price/PriceSet.xml
@@ -138,23 +138,6 @@
     </html>
   </field>
   <field>
-    <name>contribution_type_id</name>
-    <title>Price Set Contribution Type</title>
-    <type>int unsigned</type>
-    <default>NULL</default>
-    <comment>FK to Contribution Type(for membership price sets only).</comment>
-    <add>3.4</add>
-    <drop>4.3</drop>
-  </field>
-  <foreignKey>
-    <name>contribution_type_id</name>
-    <table>civicrm_contribution_type</table>
-    <key>id</key>
-    <add>3.4</add>
-    <drop>4.3</drop>
-    <onDelete>SET NULL</onDelete>
-  </foreignKey>
-  <field>
     <name>financial_type_id</name>
     <title>Financial Type</title>
     <type>int unsigned</type>


### PR DESCRIPTION
Overview
----------------------------------------
Removes unused fields and indexes which were dropped prior to 4.4.7 which is currently the min upgradable version.
No reason to keep them around any longer.

Before
----------------------------------------
Unused cruft in the xml.

After
----------------------------------------
Gone.

Technical Details
----------------------------------------
Items in the schema xml with a `<drop>` tag are ignored. You can confirm that this PR has no effect on the generated DAO files by running GenCode.

Comments
----------------------------------------
Out of caution, I only removed the ones that were completely obsolete (older than the min upgradable version).
But honestly, I don't think any of them serve a purpose.
Maybe originally there was some sort of plan to give the `<drop>` tag additional functionality like auto-removing items during upgrade, but that never happened. So from what I can tell, we should just delete all the dropped stuff from the xml as there's no good reason to keep it around.