### PR TITLE
Fix for ongoing issues with static upsetting the apple cart

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -5261,11 +5261,6 @@ LIMIT 1;";
       //so make status override false.
       $membershipParams['is_override'] = FALSE;
       $membershipParams['status_override_end_date'] = 'null';
-
-      //CRM-17723 - reset static $relatedContactIds array()
-      // @todo move it to Civi Statics.
-      $var = TRUE;
-      CRM_Member_BAO_Membership::createRelatedMemberships($var, $var, TRUE);
       civicrm_api3('Membership', 'create', $membershipParams);
     }
   }

--- a/tests/phpunit/CRM/Member/Form/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/Form/MembershipTest.php
@@ -1023,6 +1023,7 @@ Expires: ',
    * Uses some data from tests/phpunit/CRM/Member/Form/dataset/data.xml .
    *
    * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
    */
   public function testTwoInheritedMembershipsViaPriceSetInBackend() {
     // Create an organization and give it a "Member of" relationship to $this->_individualId.
@@ -1045,7 +1046,7 @@ Expires: ',
     $primaryMembershipIds = [];
     foreach ($orgMembershipResult['values'] as $membership) {
       $primaryMembershipIds[] = $membership['id'];
-      $this->assertTrue(empty($membership['owner_membership_id']), "Membership on the organization has owner_membership_id so is inherited.");
+      $this->assertTrue(empty($membership['owner_membership_id']), 'Membership on the organization has owner_membership_id so is inherited.');
     }
 
     // CRM-20955: check that correct inherited memberships were created for the individual,
@@ -1100,6 +1101,7 @@ Expires: ',
    * checking that the line items have correct amounts.
    *
    * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
    */
   public function testTwoMembershipsViaPriceSetInBackendWithDiscount() {
     // Register buildAmount hook to apply discount.

--- a/tests/phpunit/api/v3/JobTest.php
+++ b/tests/phpunit/api/v3/JobTest.php
@@ -1990,7 +1990,6 @@ class api_v3_JobTest extends CiviUnitTestCase {
    * and left alone when it shouldn't.
    *
    * @throws \CRM_Core_Exception
-   * @throws \CiviCRM_API3_Exception
    */
   public function testProcessMembershipUpdateStatus() {
     $this->ids['MembershipType'] = $this->membershipTypeCreate();
@@ -2107,10 +2106,6 @@ class api_v3_JobTest extends CiviUnitTestCase {
     $this->assertEquals($organizationMembershipID, $expiredInheritedRelationship['owner_membership_id']);
     $this->assertMembershipStatus('Grace', (int) $expiredInheritedRelationship['status_id']);
 
-    // Reset static $relatedContactIds array in createRelatedMemberships(),
-    // to avoid bug where inherited membership gets deleted.
-    $var = TRUE;
-    CRM_Member_BAO_Membership::createRelatedMemberships($var, $var, TRUE);
     // Check that after running process_membership job, statuses are correct.
     $this->callAPISuccess('Job', 'process_membership', []);
 


### PR DESCRIPTION

Overview
----------------------------------------
This is an alternate to https://github.com/civicrm/civicrm-core/pull/18218



Before
----------------------------------------
Under various edge cases - including the one in the test & in https://github.com/civicrm/civicrm-core/pull/18218 inherited memberships are not created 

After
----------------------------------------
Memberships created more reliably

Technical Details
----------------------------------------
This removes a static variable which was intended to prevent a loop in https://issues.civicrm.org/jira/browse/CRM-4213

The static has caused  various ongoing bugs - including https://issues.civicrm.org/jira/browse/CRM-19735  which got past it by flushing the static. Fundamentally the static is not reliable enough so I've switched to looking up & checking existing memberships. 

I think it might mean more queries but they shouldn't be expensive queries & the
code is just too hard-going to skip straight from hacked but still intermittently buggy to 'good' (I won't pretend perfect was the enemy of good here- good was the enemy of 'not truly awful')

Comments
----------------------------------------

CRM-17723 was also a bug this static was interacting with