### PR TITLE
report#45 Ability to Search Smart or Normal Group using additional filter on Manage Group page

### DIFF
--- a/CRM/Contact/BAO/Group.php
+++ b/CRM/Contact/BAO/Group.php
@@ -1223,6 +1223,14 @@ WHERE {$whereClause}";
       $clauses[] = '`groups`.parents IS NULL';
     }
 
+    $savedSearch = CRM_Utils_Array::value('savedSearch', $params);
+    if ($savedSearch == 1) {
+      $clauses[] = 'groups.saved_search_id IS NOT NULL';
+    }
+    else if ($savedSearch == 2) {
+      $clauses[] = 'groups.saved_search_id IS NULL';
+    }
+
     // only show child groups of a specific parent group
     $parent_id = $params['parent_id'] ?? NULL;
     if ($parent_id) {

--- a/CRM/Contact/BAO/Group.php
+++ b/CRM/Contact/BAO/Group.php
@@ -1227,7 +1227,7 @@ WHERE {$whereClause}";
     if ($savedSearch == 1) {
       $clauses[] = 'groups.saved_search_id IS NOT NULL';
     }
-    else if ($savedSearch == 2) {
+    elseif ($savedSearch == 2) {
       $clauses[] = 'groups.saved_search_id IS NULL';
     }
 

--- a/CRM/Group/Form/Search.php
+++ b/CRM/Group/Form/Search.php
@@ -40,6 +40,14 @@ class CRM_Group_Form_Search extends CRM_Core_Form {
       CRM_Core_DAO::getAttribute('CRM_Contact_DAO_Group', 'title')
     );
 
+    $optionTypes = [
+      '1' => ts('Smart Group'),
+      '2' => ts('Normal Group'),
+    ];
+    $this->add('select', 'saved_search', ts('Group Type'),
+      ['' => ts('- any -')] + $optionTypes
+    );
+
     $groupTypes = CRM_Core_OptionGroup::values('group_type', TRUE);
     $config = CRM_Core_Config::singleton();
     if ($config->userFramework == 'Joomla') {

--- a/CRM/Group/Page/AJAX.php
+++ b/CRM/Group/Page/AJAX.php
@@ -42,6 +42,7 @@ class CRM_Group_Page_AJAX {
         'status' => 'Integer',
         'parentsOnly' => 'Integer',
         'showOrgInfo' => 'Boolean',
+        'savedSearch' => 'Integer',
         // Ignore 'parent_id' as that case is handled above
       ];
       $params = CRM_Core_Page_AJAX::defaultSortAndPagerParams();

--- a/templates/CRM/Group/Form/Search.tpl
+++ b/templates/CRM/Group/Form/Search.tpl
@@ -55,6 +55,13 @@
               {$form.component_mode.html}
             </td>
           </tr>
+          <tr>
+            <td>
+              {$form.saved_search.label} <br/>{$form.saved_search.html}
+            </td>
+            <td colspan="2">
+            </td>
+          </tr>
         </table>
       </div>
     </div>
@@ -116,6 +123,7 @@
           d.group_type = groupTypes,
           d.visibility = $(".crm-group-search-form-block select#visibility").val(),
           d.status = groupStatus,
+          d.savedSearch = $('.crm-group-search-form-block select#saved_search').val(),
           d.component_mode = $(".crm-group-search-form-block select#component_mode").val(),
           d.showOrgInfo = {/literal}"{$showOrgInfo}"{literal},
           d.parentsOnly = parentsOnly

--- a/tests/phpunit/CRM/Group/Page/AjaxTest.php
+++ b/tests/phpunit/CRM/Group/Page/AjaxTest.php
@@ -553,6 +553,8 @@ class CRM_Group_Page_AjaxTest extends CiviUnitTestCase {
     // Load the Manage Group page code and we should get a count from our
     // group because the cache is fresh.
     $_GET = $this->_params;
+    // look for Smart Group only
+    $_GET['savedSearch'] = 1;
     try {
       CRM_Group_Page_AJAX::getGroupList();
     }


### PR DESCRIPTION
Ability to Search Smart or Normal Group using additional filter on Manage Group page

Overview
----------------------------------------
Ability Search Smart or Normal Group using additional filter on Manage Group page

Before
----------------------------------------
There was not filter to show only Smart Group or Normal Group

After
----------------------------------------
There is Filter with Select Option : Normal Group, Smart Group

https://lab.civicrm.org/dev/report/-/issues/45