### PR TITLE
Optimise proximity custom search, by reducing addGeocodingData fn call

### DIFF
--- a/CRM/Contact/Form/Search/Custom/Proximity.php
+++ b/CRM/Contact/Form/Search/Custom/Proximity.php
@@ -19,9 +19,6 @@
  */
 class CRM_Contact_Form_Search_Custom_Proximity extends CRM_Contact_Form_Search_Custom_Base implements CRM_Contact_Form_Search_Interface {
 
-  protected $_latitude = NULL;
-  protected $_longitude = NULL;
-  protected $_distance = NULL;
   protected $_aclFrom = NULL;
   protected $_aclWhere = NULL;
 
@@ -39,21 +36,6 @@ class CRM_Contact_Form_Search_Custom_Proximity extends CRM_Contact_Form_Search_C
     unset($this->_formValues['uf_group_id']);
     unset($this->_formValues['component_mode']);
     unset($this->_formValues['operator']);
-
-    if (!empty($this->_formValues)) {
-      // add the country and state
-      self::addGeocodingData($this->_formValues);
-      $this->_latitude = $this->_formValues['geo_code_1'];
-      $this->_longitude = $this->_formValues['geo_code_2'];
-
-      if ($this->_formValues['prox_distance_unit'] == "miles") {
-        $conversionFactor = 1609.344;
-      }
-      else {
-        $conversionFactor = 1000;
-      }
-      $this->_distance = $this->_formValues['distance'] * $conversionFactor;
-    }
     $this->_group = $this->_formValues['group'] ?? NULL;
 
     $this->_tag = $this->_formValues['tag'] ?? NULL;
@@ -190,6 +172,10 @@ class CRM_Contact_Form_Search_Custom_Proximity extends CRM_Contact_Form_Search_C
     $isCountOnly = FALSE;
     if ($selectClause === 'count(distinct contact_a.id) as total') {
       $isCountOnly = TRUE;
+    }
+
+    if (empty($this->_formValues['geo_code_1']) ||  empty($this->_formValues['geo_code_2'])) {
+      self::addGeocodingData($this->_formValues);
     }
 
     $searchParams = [


### PR DESCRIPTION
Overview
----------------------------------------
Reduce the addGeocodingData() function call which is executed seven times on form submission and it affects the performance. 

Before
----------------------------------------
addGeocodingData fn is executed seven times which is responsible to fetch the geocoordinates

After
----------------------------------------
- addGeocodingData fn is executed seven times which is responsible to fetch the geocoordinates
- deleted unwanted variables


Comments
----------------------------------------
ping @lcdservices @eileenmcnaughton 