### PR TITLE
[REF] Ensure that the form param _id is set when adding a new group w…

### DIFF
--- a/CRM/Group/Form/Edit.php
+++ b/CRM/Group/Form/Edit.php
@@ -371,7 +371,8 @@ WHERE  title = %1
       );
 
       $group = CRM_Contact_BAO_Group::create($params);
-
+      // Set the entity id so it is available to postProcess hook consumers
+      $this->setEntityId($group->id);
       //Remove any parent groups requested to be removed
       if (!empty($this->_groupValues['parents'])) {
         $parentGroupIds = explode(',', $this->_groupValues['parents']);


### PR DESCRIPTION
…ith the newly created group id so that consumers of the hook_civicrm_postProcess can access the id

Overview
----------------------------------------
This ensures that the form parameter $this->_id is set to the newly created id / the id of the current group so that hook_civicrm_postProcess consumers can use it in their code

Before
----------------------------------------
_id parameter not always set 

After
----------------------------------------
_id parameter always set when we get to postProcess

ping @eileenmcnaughton @Edzelopez @mattwire 