### PR TITLE
Expose field label to APIv4 and Search creaor

### DIFF
--- a/Civi/Api4/Generic/BasicGetFieldsAction.php
+++ b/Civi/Api4/Generic/BasicGetFieldsAction.php
@@ -129,6 +129,7 @@ class BasicGetFieldsAction extends BasicGetAction {
         'data_type' => \CRM_Utils_Array::value('type', $field, 'String'),
       ], array_flip($fields));
       $field += $defaults;
+      $field['label'] = $field['label'] ?? $field['title'];
       if (isset($defaults['options'])) {
         $field['options'] = $this->formatOptionList($field['options']);
       }
@@ -217,14 +218,22 @@ class BasicGetFieldsAction extends BasicGetAction {
       [
         'name' => 'name',
         'data_type' => 'String',
+        'description' => ts('Unique field identifier'),
       ],
       [
         'name' => 'title',
         'data_type' => 'String',
+        'description' => ts('Technical name of field, shown in API and exports'),
+      ],
+      [
+        'name' => 'label',
+        'data_type' => 'String',
+        'description' => ts('User-facing label, shown on most forms and displays'),
       ],
       [
         'name' => 'description',
         'data_type' => 'String',
+        'description' => ts('Explanation of the purpose of the field'),
       ],
       [
         'name' => 'default_value',

--- a/Civi/Api4/Service/Spec/FieldSpec.php
+++ b/Civi/Api4/Service/Spec/FieldSpec.php
@@ -35,6 +35,11 @@ class FieldSpec {
   /**
    * @var string
    */
+  protected $label;
+
+  /**
+   * @var string
+   */
   protected $title;
 
   /**
@@ -161,6 +166,24 @@ class FieldSpec {
    */
   public function setName($name) {
     $this->name = $name;
+
+    return $this;
+  }
+
+  /**
+   * @return string
+   */
+  public function getLabel() {
+    return $this->label;
+  }
+
+  /**
+   * @param string $label
+   *
+   * @return $this
+   */
+  public function setLabel($label) {
+    $this->label = $label;
 
     return $this;
   }

--- a/Civi/Api4/Service/Spec/SpecFormatter.php
+++ b/Civi/Api4/Service/Spec/SpecFormatter.php
@@ -73,6 +73,7 @@ class SpecFormatter {
       $field = new FieldSpec($name, $entity, $dataTypeName);
       $field->setRequired(!empty($data['required']));
       $field->setTitle($data['title'] ?? NULL);
+      $field->setLabel($data['html']['label'] ?? NULL);
       $field->setOptions(!empty($data['pseudoconstant']));
     }
     $field->setSerialize($data['serialize'] ?? NULL);

--- a/ext/search/CRM/Search/Page/Ang.php
+++ b/ext/search/CRM/Search/Page/Ang.php
@@ -66,7 +66,7 @@ class CRM_Search_Page_Ang extends CRM_Core_Page {
       ->setChain([
         'get' => ['$name', 'getActions', ['where' => [['name', '=', 'get']]], ['params']],
       ])->execute();
-    $getFields = ['name', 'title', 'description', 'options', 'input_type', 'input_attrs', 'data_type', 'serialize'];
+    $getFields = ['name', 'label', 'description', 'options', 'input_type', 'input_attrs', 'data_type', 'serialize'];
     foreach ($schema as $entity) {
       // Skip if entity doesn't have a 'get' action or the user doesn't have permission to use get
       if ($entity['get']) {
@@ -78,7 +78,7 @@ class CRM_Search_Page_Ang extends CRM_Core_Page {
         $entity['fields'] = civicrm_api4($entity['name'], 'getFields', [
           'select' => $getFields,
           'where' => [['permission', 'IS NULL']],
-          'orderBy' => ['title'],
+          'orderBy' => ['label'],
           'loadOptions' => $loadOptions,
         ]);
         // Get the names of params this entity supports (minus some obvious ones)

--- a/ext/search/ang/search/crmSearch.component.js
+++ b/ext/search/ang/search/crmSearch.component.js
@@ -297,7 +297,7 @@
 
       this.getFieldLabel = function(col) {
         var info = searchMeta.parseExpr(col),
-          label = info.field.title;
+          label = info.field.label;
         if (info.fn) {
           label = '(' + info.fn.title + ') ' + label;
         }
@@ -393,7 +393,7 @@
           return _.transform(searchMeta.getEntity(entityName).fields, function(result, field) {
             var item = {
               id: prefix + field.name + (field.options ? suffix : ''),
-              text: field.title,
+              text: field.label,
               description: field.description
             };
             if (disabledIf(item.id)) {


### PR DESCRIPTION
Overview
----------------------------------------
This is another step to codify the difference between a field's *title* and *label* in the schema.
It exposes labels to APIv4 and switches over to using labels in the new Search extension.

It also attempts to clarify the difference between titles and labels in the getfields description:
- **title:** "Technical name of field, shown in API and exports"
- **label:** "User-facing label, shown on most forms and displays"

Comments
----------------------------------------
This continues in the same direction as #18114 but after merging this there's still more cleanup to do in the schema, fixing titles to be more technical and less "label-ey" and adding labels where they are missing (which is nearly everywhere).