### PR TITLE
Replace ids in CompleteOrder function signature wit the one relevant value in that array

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4439,7 +4439,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
    * Moving it out of the BaseIPN class is just the first step.
    *
    * @param array $input
-   * @param array $ids
+   * @param int|null $contributionContactID
    * @param array $objects
    * @param bool $isPostPaymentCreate
    *   Is this being called from the payment.create api. If so the api has taken care of financial entities.
@@ -4447,18 +4447,15 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
    *   transitioning related elements).
    *
    * @return array
+   * @throws \API_Exception
    * @throws \CRM_Core_Exception
    * @throws \CiviCRM_API3_Exception
+   * @throws \Civi\API\Exception\UnauthorizedException
    */
-  public static function completeOrder($input, $ids, $objects, $isPostPaymentCreate = FALSE) {
+  public static function completeOrder($input, $contributionContactID, $objects, $isPostPaymentCreate = FALSE) {
     $transaction = new CRM_Core_Transaction();
     $contribution = $objects['contribution'];
-    // @todo see if we even need this - it's used further down to create an activity
-    // but the BAO layer should create that - we just need to add a test to cover it & can
-    // maybe remove $ids altogether.
-    $contributionContactID = $ids['related_contact'] ?? NULL;
-    // Unset ids just to make it clear it's not used again.
-    unset($ids);
+
     // The previous details are used when calculating line items so keep it before any code that 'does something'
     if (!empty($contribution->id)) {
       $input['prevContribution'] = CRM_Contribute_BAO_Contribution::getValues(['id' => $contribution->id]);

--- a/CRM/Core/Payment/BaseIPN.php
+++ b/CRM/Core/Payment/BaseIPN.php
@@ -468,7 +468,7 @@ class CRM_Core_Payment_BaseIPN {
    * @throws \CiviCRM_API3_Exception
    */
   public function completeTransaction($input, $ids, $objects) {
-    CRM_Contribute_BAO_Contribution::completeOrder($input, $ids, $objects);
+    CRM_Contribute_BAO_Contribution::completeOrder($input, $ids['related_contact'] ?? NULL, $objects);
   }
 
   /**

--- a/CRM/Event/Form/Task/Batch.php
+++ b/CRM/Event/Form/Task/Batch.php
@@ -428,7 +428,7 @@ class CRM_Event_Form_Task_Batch extends CRM_Event_Form_Task {
     //complete the contribution.
     // @todo use the api - ie civicrm_api3('Contribution', 'completetransaction', $input);
     // as this method is not preferred / supported.
-    CRM_Contribute_BAO_Contribution::completeOrder($input, $ids, $objects);
+    CRM_Contribute_BAO_Contribution::completeOrder($input, $ids['related_contact'] ?? NULL, $objects);
 
     // reset template values before processing next transactions
     $template->clearTemplateVars();

--- a/api/v3/Contribution.php
+++ b/api/v3/Contribution.php
@@ -678,7 +678,7 @@ function _ipn_process_transaction(&$params, $contribution, $input, $ids, $firstC
   }
   $input['card_type_id'] = $params['card_type_id'] ?? NULL;
   $input['pan_truncation'] = $params['pan_truncation'] ?? NULL;
-  return CRM_Contribute_BAO_Contribution::completeOrder($input, $ids, $objects,
+  return CRM_Contribute_BAO_Contribution::completeOrder($input, $ids['related_contact'] ?? NULL, $objects,
     $params['is_post_payment_create'] ?? NULL);
 }
 


### PR DESCRIPTION


Overview
----------------------------------------
$ids is passed as an array but only one value in the array is ever used - just pass that value. Only called from 3 places

Before
----------------------------------------
```
public static function completeOrder($input, $ids, $objects, $isPostPaymentCreate = FALSE) {
```

After
----------------------------------------
```
public static function completeOrder($input, $contributionContactID, $objects, $isPostPaymentCreate = FALSE) {
```

<img width="1271" alt="Screen Shot 2020-08-27 at 8 44 57 AM" src="https://user-images.githubusercontent.com/336308/91355362-27b6d300-e842-11ea-88f5-3fbb2ee986b9.png">


Technical Details
----------------------------------------
This should make it easy to eliminate ids separately in the 3 functions that call this
since it is now clear all the other stuff they put in ids is not needed

Ideally we don't even need that value but more tests need to be written to elinimate it

Comments
----------------------------------------

