### PR TITLE
Use already determined value for contributionRecurID

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4545,8 +4545,8 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
     }
 
     // Add new soft credit against current $contribution.
-    if (!empty($objects['contributionRecur']) && $objects['contributionRecur']->id) {
-      CRM_Contribute_BAO_ContributionRecur::addrecurSoftCredit($objects['contributionRecur']->id, $contribution->id);
+    if ($recurringContributionID) {
+      CRM_Contribute_BAO_ContributionRecur::addrecurSoftCredit($recurringContributionID, $contribution->id);
     }
 
     $contribution->contribution_status_id = $contributionParams['contribution_status_id'];


### PR DESCRIPTION
Overview
----------------------------------------
Just eliminates a place where $objects is referred to as we have already determined the value from $objects

Before
----------------------------------------
$contributionRecurID not used

After
----------------------------------------
$contributionRecurID used


Technical Details
----------------------------------------
I think we should move to passing in more $ids and less $objects. - Event & contribution are the only 2 objects currently where we are looking for more than just an id

Ie we would call it like

```
    CRM_Contribute_BAO_Contribution::completeOrder($input, [
      'related_contact' => $ids['related_contact'] ?? NULL,
      'participant' => isset($objects['participant']) ? $objects['participant']->id : NULL,
      'contributionRecur' => isset($objects['contributionRecur']) ? $objects['contributionRecur']->id : NULL,
    ], $objects);
```

The 2 remaining objects (event & contribution) we would probably load within completeOrder & not pass in $objects at all - but a little more work to confirm that. I think fixing batchUpdate to not call completeOrder (with tests) would simplify)

Comments
----------------------------------------

