### PR TITLE
dev/core#1978 Ability Add/update Custom Field through Record Payment …

### DIFF
--- a/templates/CRM/Contribute/Form/AdditionalPayment.tpl
+++ b/templates/CRM/Contribute/Form/AdditionalPayment.tpl
@@ -99,6 +99,7 @@
       {/if}
       {include file='CRM/Core/BillingBlockWrapper.tpl'}
     </div>
+    {include file="CRM/common/customDataBlock.tpl"}
 
     {literal}
     <script type="text/javascript">


### PR DESCRIPTION
Overview
----------------------------------------
Ability to Submit/provide custom data through Record Payment Form.

Example use-case
----------------------------------------
Through online page user added contribution record using pay-later mode with pending status.
Now, customer send check, admin wanted to Record payment and upload scanned copy of check and other custom details through same form. 
Currently admin has to edit contribution record and upload scanned copy in custom field and other custom details.


Current behavior
----------------------------------------
Record Payment does not show Custom Field section

Proposed behavior
----------------------------------------
Record Payment will start showing Custom Field.
In case Multiple Record payment for same contribution record, existing custom field data on contribution record get pre-populated on Record Contribution form.
<img width="564" alt="Screenshot 2020-08-27 at 9 38 54 PM" src="https://user-images.githubusercontent.com/377735/91467209-ea882a80-e8ad-11ea-8191-dd66563286fd.png">


---
https://lab.civicrm.org/dev/core/-/issues/1978