### PR TITLE
dev/core#1972 Fix tax_amount calclation on renewal form

### DIFF
--- a/CRM/Financial/BAO/Order.php
+++ b/CRM/Financial/BAO/Order.php
@@ -236,18 +236,17 @@ class CRM_Financial_BAO_Order {
       $lineItems[$valueID] = CRM_Price_BAO_PriceSet::getLine($params, $throwAwayArray, $this->getPriceSetID(), $this->getPriceFieldSpec($fieldID), $fieldID, 0)[1][$valueID];
     }
 
-    $taxRates = CRM_Core_PseudoConstant::getTaxRates();
     foreach ($lineItems as &$lineItem) {
       // Set any pre-calculation to zero as we will calculate.
       $lineItem['tax_amount'] = 0;
       if ($this->getOverrideFinancialTypeID() !== FALSE) {
         $lineItem['financial_type_id'] = $this->getOverrideFinancialTypeID();
       }
-      $taxRate = $taxRates[$lineItem['financial_type_id']] ?? 0;
+      $taxRate = $this->getTaxRate((int) $lineItem['financial_type_id']);
       if ($this->getOverrideTotalAmount() !== FALSE) {
         if ($taxRate) {
           // Total is tax inclusive.
-          $lineItem['tax_amount'] = ($taxRate / 100) * $this->getOverrideTotalAmount();
+          $lineItem['tax_amount'] = ($taxRate / 100) * $this->getOverrideTotalAmount() / (1 + ($taxRate / 100));
           $lineItem['line_total'] = $lineItem['unit_price'] = $this->getOverrideTotalAmount() - $lineItem['tax_amount'];
         }
         else {
@@ -274,6 +273,21 @@ class CRM_Financial_BAO_Order {
       $amount += $lineItem['tax_amount'] ?? 0.0;
     }
     return $amount;
+  }
+
+  /**
+   * Get the tax rate for the given financial type.
+   *
+   * @param int $financialTypeID
+   *
+   * @return float
+   */
+  public function getTaxRate(int $financialTypeID) {
+    $taxRates = CRM_Core_PseudoConstant::getTaxRates();
+    if (!isset($taxRates[$financialTypeID])) {
+      return 0;
+    }
+    return $taxRates[$financialTypeID];
   }
 
 }

--- a/tests/phpunit/CRM/Member/Form/MembershipRenewalTest.php
+++ b/tests/phpunit/CRM/Member/Form/MembershipRenewalTest.php
@@ -241,7 +241,7 @@ class CRM_Member_Form_MembershipRenewalTest extends CiviUnitTestCase {
       ],
       'credit_card_type' => 'Visa',
       'billing_first_name' => 'Test',
-      'billing_middlename' => 'Last',
+      'billing_middle_name' => 'Last',
       'billing_street_address-5' => '10 Test St',
       'billing_city-5' => 'Test',
       'billing_state_province_id-5' => '1003',
@@ -250,7 +250,7 @@ class CRM_Member_Form_MembershipRenewalTest extends CiviUnitTestCase {
     ]);
     $contribution = $this->callAPISuccessGetSingle('Contribution', ['contact_id' => $this->_individualId, 'is_test' => TRUE, 'return' => ['total_amount', 'tax_amount']]);
     $this->assertEquals(50, $contribution['total_amount']);
-    $this->assertEquals(5, $contribution['tax_amount']);
+    $this->assertEquals(4.55, $contribution['tax_amount']);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a regression whereby the tax_amount was incorrectly calculated on the membership renewal form

Before
----------------------------------------
Tax (for a 10% rate) was calculated as

tax = totalAmount * .10

After
----------------------------------------
tax = totalAmount - (totalAmount / 1.1)

Technical Details
----------------------------------------
_If the PR involves technical details/changes/considerations which would not be manifest to a casual developer skimming the above sections, please describe the details here._

Comments
----------------------------------------
@KarinG has detailed this well in https://lab.civicrm.org/dev/core/-/issues/1972

We should backport this once merged
