### PR TITLE
dev/core#1974 Fix incorrect handling of serialize key when changing custom field type

### DIFF
--- a/CRM/Custom/Form/ChangeFieldType.php
+++ b/CRM/Custom/Form/ChangeFieldType.php
@@ -54,6 +54,9 @@ class CRM_Custom_Form_ChangeFieldType extends CRM_Core_Form {
     $params = ['id' => $this->_id];
     CRM_Core_BAO_CustomField::retrieve($params, $this->_values);
 
+    if ($this->_values['html_type'] == 'Select' && $this->_values['serialize']) {
+      $this->_values['html_type'] = 'Multi-Select';
+    }
     $this->_htmlTypeTransitions = self::fieldTypeTransitions(CRM_Utils_Array::value('data_type', $this->_values),
       CRM_Utils_Array::value('html_type', $this->_values)
     );

--- a/CRM/Custom/Form/ChangeFieldType.php
+++ b/CRM/Custom/Form/ChangeFieldType.php
@@ -146,13 +146,14 @@ class CRM_Custom_Form_ChangeFieldType extends CRM_Core_Form {
     $customField = new CRM_Core_DAO_CustomField();
     $customField->id = $this->_id;
     $customField->find(TRUE);
+    $customField->serialize = in_array($dstHtmlType, $mutliValueOps, TRUE);
 
     if ($dstHtmlType == 'Text' && in_array($srcHtmlType, [
       'Select',
       'Radio',
       'Autocomplete-Select',
     ])) {
-      $customField->option_group_id = "NULL";
+      $customField->option_group_id = 'NULL';
       CRM_Core_BAO_CustomField::checkOptionGroup($this->_values['option_group_id']);
     }
 
@@ -165,7 +166,7 @@ class CRM_Custom_Form_ChangeFieldType extends CRM_Core_Form {
       $this->firstValueToFlatten($tableName, $this->_values['column_name']);
     }
 
-    $customField->html_type = $dstHtmlType;
+    $customField->html_type = ($dstHtmlType === 'Multi-Select') ? 'Select' : $dstHtmlType;
     $customField->save();
 
     // Reset cache for custom fields


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a regression "Changing field from Multi-Select to Select seems to still be allowed -- but is broken"

See https://lab.civicrm.org/dev/core/-/issues/1974 as there is an excellent report of the issue there

Before
----------------------------------------
Not possible to use data after converting to MultiSelect

After
----------------------------------------
Works

Technical Details
----------------------------------------
It's a bit hacky but it's an oddball use case on an oddball form so I think it's enough for now

Comments
----------------------------------------
