### PR TITLE
dev/core#1980 Move (now tested) delete acl check from v3 api to pre delete hook

### DIFF
--- a/api/v3/LineItem.php
+++ b/api/v3/LineItem.php
@@ -75,18 +75,11 @@ function civicrm_api3_line_item_get($params) {
  *
  * @param array $params
  *   Array containing id of the group to be deleted.
+ *
  * @return array API result array
  * @throws API_Exception
+ * @throws \CiviCRM_API3_Exception
  */
 function civicrm_api3_line_item_delete($params) {
-  if (CRM_Financial_BAO_FinancialType::isACLFinancialTypeStatus() && !empty($params['check_permissions'])) {
-    CRM_Financial_BAO_FinancialType::getAvailableFinancialTypes($types, CRM_Core_Action::DELETE);
-    if (empty($params['financial_type_id'])) {
-      $params['financial_type_id'] = CRM_Core_DAO::getFieldValue('CRM_Price_DAO_LineItem', $params['id'], 'financial_type_id');
-    }
-    if (!in_array($params['financial_type_id'], array_keys($types))) {
-      throw new API_Exception('You do not have permission to delete this line item');
-    }
-  }
   return _civicrm_api3_basic_delete(_civicrm_api3_get_BAO(__FUNCTION__), $params);
 }


### PR DESCRIPTION
Overview
----------------------------------------
Move permission handling on LineItem delete from v3 api to financialacls extension, meaning it will also apply to v4 api

Before
----------------------------------------
In the api

After
----------------------------------------
In the new core extension

Technical Details
----------------------------------------
Will rebase once tests-only PR is merged. Given the exisiting code throws an exception I think it really is this simple - at least for parity

Comments
----------------------------------------

