### PR TITLE
report#48 View Payment owned by Different contact on Membership and Participant View

### DIFF
--- a/CRM/Contribute/Form/Search.php
+++ b/CRM/Contribute/Form/Search.php
@@ -386,12 +386,14 @@ class CRM_Contribute_Form_Search extends CRM_Core_Form_Search {
 
     $cid = CRM_Utils_Request::retrieve('cid', 'Positive', $this);
 
-    if ($cid) {
+    // skip cid (contact id of membership/participant record) to get associated payments for membership/participant record,
+    // contribution record may be on different contact id.
+    $skip_cid = CRM_Utils_Request::retrieve('skip_cid', 'Boolean', $this, FALSE, FALSE);
+
+    if ($cid && !$skip_cid) {
       $cid = CRM_Utils_Type::escape($cid, 'Integer');
       if ($cid > 0) {
         $this->_formValues['contact_id'] = $cid;
-        // @todo - why do we retrieve these when they are not used?
-        list($display, $image) = CRM_Contact_BAO_Contact::getDisplayAndImage($cid);
         $this->_defaults['sort_name'] = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Contact', $cid,
           'sort_name'
         );

--- a/CRM/Event/Page/Tab.php
+++ b/CRM/Event/Page/Tab.php
@@ -287,7 +287,7 @@ class CRM_Event_Page_Tab extends CRM_Core_Page {
       );
       $controller->setEmbedded(TRUE);
       $controller->set('force', 1);
-      $controller->set('cid', $this->_contactId);
+      $controller->set('skip_cid', TRUE);
       $controller->set('participantId', $this->_id);
       $controller->set('context', 'contribution');
       $controller->process();

--- a/CRM/Member/Page/Tab.php
+++ b/CRM/Member/Page/Tab.php
@@ -590,7 +590,7 @@ class CRM_Member_Page_Tab extends CRM_Core_Page {
     $controller->setEmbedded(TRUE);
     $controller->reset();
     $controller->set('force', 1);
-    $controller->set('cid', $contactId);
+    $controller->set('skip_cid', TRUE);
     $controller->set('memberId', $membershipId);
     $controller->set('context', 'contribution');
     $controller->process();

--- a/tests/phpunit/CRM/Member/Form/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/Form/MembershipTest.php
@@ -1512,4 +1512,77 @@ Expires: ',
     $this->assertCount(1, $contribution['values'], 'Completed contribution should be fetched.');
   }
 
+  /**
+   * Test Membership Payment owned by other contact, membership view should show all contribution records in listing.
+   * is other contact.
+   *
+   * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
+   * @throws \Exception
+   */
+  public function testMembershipViewContributionOwnerDifferent() {
+    // Membership Owner
+    $contactId1 = $this->individualCreate();
+
+    // Contribution Onwer
+    $contactId2 = $this->individualCreate();
+
+    // create new membership type
+    $membershipTypeAnnualFixed = $this->callAPISuccess('membership_type', 'create', [
+      'domain_id' => 1,
+      'name' => 'AnnualFixed 2',
+      'member_of_contact_id' => 23,
+      'duration_unit' => 'year',
+      'minimum_fee' => 50,
+      'duration_interval' => 1,
+      'period_type' => 'fixed',
+      'fixed_period_start_day' => '101',
+      'fixed_period_rollover_day' => '1231',
+      'financial_type_id' => 2,
+    ]);
+
+    // create Membership
+    $membershipId = $this->contactMembershipCreate([
+      'contact_id' => $contactId1,
+      'membership_type_id' => $membershipTypeAnnualFixed['id'],
+      'status_id' => 'New',
+    ]);
+
+    // 1st Payment
+    $contriParams = [
+      'membership_id' => $membershipId,
+      'total_amount' => 25,
+      'financial_type_id' => 2,
+      'contact_id' => $contactId2,
+    ];
+    $contribution1 = CRM_Member_BAO_Membership::recordMembershipContribution($contriParams);
+
+    // 2nd Payment
+    $contriParams = [
+      'membership_id' => $membershipId,
+      'total_amount' => 25,
+      'financial_type_id' => 2,
+      'contact_id' => $contactId2,
+    ];
+    $contribution2 = CRM_Member_BAO_Membership::recordMembershipContribution($contriParams);
+
+    // View Membership record
+    $membershipViewForm = new CRM_Member_Form_MembershipView();
+    $membershipViewForm->controller = new CRM_Core_Controller_Simple('CRM_Member_Form_MembershipView', 'View Membership');
+    $membershipViewForm->set('id', $membershipId);
+    $membershipViewForm->set('context', 'membership');
+    $membershipViewForm->controller->setEmbedded(TRUE);
+    $membershipViewForm->preProcess();
+
+    // get contribution rows related to membership payments
+    $templateVar = $membershipViewForm->getTemplate()->get_template_vars('rows');
+
+    $this->assertEquals($templateVar[0]['contribution_id'], $contribution1->id);
+    $this->assertEquals($templateVar[0]['contact_id'], $contactId2);
+
+    $this->assertEquals($templateVar[1]['contribution_id'], $contribution2->id);
+    $this->assertEquals($templateVar[1]['contact_id'], $contactId2);
+    $this->assertEquals(count($templateVar), 2);
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Using Webform, we can set that, contribution assigned to contact A and Membership record will be assigned to Contact B and C (based on number Contact selected in webform). IF we visit the Membership Record of B and C, we can not see the linked Payment, because its owned by another contact. and there is NO way to check who own the payment record.

Current behaviour
----------------------------------------
Currently it does not show linked payment record if payment is not present on same contact.

Expected behaviour
----------------------------------------
Linked Payment record should show, irrespective of who own  the payment record as long as payment is belong the respective Membership.

In this case, webform create membership payment link between each contact membership and contribution id in `civicrm_membership_payment` table.
As long as we have linking between membership and contribution id, then it shows linked payment on Membership View. Same apply to participant.

----------------------------------------
https://lab.civicrm.org/dev/report/-/issues/48