### PR TITLE
dev/core#1982 fix creator param handling

### DIFF
--- a/CRM/Case/XMLProcessor/Process.php
+++ b/CRM/Case/XMLProcessor/Process.php
@@ -85,7 +85,7 @@ class CRM_Case_XMLProcessor_Process extends CRM_Case_XMLProcessor {
       // create relationships for the ones that are required
       foreach ($xml->CaseRoles as $caseRoleXML) {
         foreach ($caseRoleXML->RelationshipType as $relationshipTypeXML) {
-          if ($relationshipTypeXML->creator) {
+          if (!empty($relationshipTypeXML->creator)) {
             if (!$this->createRelationships($relationshipTypeXML,
               $params
             )


### PR DESCRIPTION
Overview
----------------------------------------
Case open: doesn't respect case roles "creator" param if unset

to replicate:

1. create a new casetype
2. in the list of case roles, uncheck the "assign to creator" checkbox for the default case coordinator role
3. create a new case on a contact record

Before
----------------------------------------
case coordinator role is created and assigned to the logged in user

After
----------------------------------------
no case coordinator role created

Technical Details
----------------------------------------
simple fix to the condition that determines if the relationship should be created. 