### PR TITLE
Improve robustness of api/class.api.php

### DIFF
--- a/api/class.api.php
+++ b/api/class.api.php
@@ -14,15 +14,15 @@
  * ```
  *   require_once('/your/civi/folder/api/class.api.php');
  *   // the path to civicrm.settings.php
- *   $api = new civicrm_api3 (array('conf_path'=> '/your/path/to/your/civicrm/or/joomla/site));
+ *   $api = new civicrm_api3 (['conf_path'=> '/your/path/to/your/civicrm/or/joomla/site']);
  * ```
  *
  * or to query a remote server via the rest api
  *
  * ```
- *   $api = new civicrm_api3 (array ('server' => 'http://example.org',
- *                                   'api_key'=>'theusersecretkey',
- *                                   'key'=>'thesitesecretkey'));
+ *   $api = new civicrm_api3 (['server' => 'http://example.org',
+ *                             'api_key'=>'theusersecretkey',
+ *                             'key'=>'thesitesecretkey']);
  * ```
  *
  * No matter how initialised and if civicrm is local or remote, you use the class the same way.
@@ -34,7 +34,7 @@
  * So, to get the individual contacts:
  *
  * ```
- *   if ($api->Contact->Get(array('contact_type'=>'Individual','return'=>'sort_name,current_employer')) {
+ *   if ($api->Contact->Get(['contact_type'=>'Individual','return'=>'sort_name,current_employer']) {
  *     // each key of the result array is an attribute of the api
  *     echo "\n contacts found " . $api->count;
  *     foreach ($api->values as $c) {
@@ -49,7 +49,7 @@
  * Or, to create an event:
  *
  * ```
- *   if ($api->Event->Create(array('title'=>'Test','event_type_id' => 1,'is_public' => 1,'start_date' => 19430429))) {
+ *   if ($api->Event->Create(['title'=>'Test','event_type_id' => 1,'is_public' => 1,'start_date' => 19430429])) {
  *     echo "created event id:". $api->id;
  *   } else {
  *     echo $api->errorMsg();
@@ -62,7 +62,7 @@
  *
  * ```
  *   $api->Activity->Get (42);
- *   $api->Activity->Get (array('id'=>42));
+ *   $api->Activity->Get (['id'=>42]);
  * ```
  *
  *
@@ -87,23 +87,23 @@ class civicrm_api3 {
     $this->local      = TRUE;
     $this->input      = [];
     $this->lastResult = [];
-    if (isset($config) && isset($config['server'])) {
+    if (!empty($config) && !empty($config['server'])) {
       // we are calling a remote server via REST
       $this->local = FALSE;
       $this->uri = $config['server'];
-      if (isset($config['path'])) {
+      if (!empty($config['path'])) {
         $this->uri .= "/" . $config['path'];
       }
       else {
         $this->uri .= '/sites/all/modules/civicrm/extern/rest.php';
       }
-      if (isset($config['key'])) {
+      if (!empty($config['key'])) {
         $this->key = $config['key'];
       }
       else {
         die("\nFATAL:param['key] missing\n");
       }
-      if (isset($config['api_key'])) {
+      if (!empty($config['api_key'])) {
         $this->api_key = $config['api_key'];
       }
       else {
@@ -111,7 +111,7 @@ class civicrm_api3 {
       }
       return;
     }
-    if (isset($config) && isset($config['conf_path'])) {
+    if (!empty($config) && !empty($config['conf_path'])) {
       if (!defined('CIVICRM_SETTINGS_PATH')) {
         define('CIVICRM_SETTINGS_PATH', $config['conf_path'] . '/civicrm.settings.php');
       }

--- a/tests/phpunit/api/v3/ClassAPITest.php
+++ b/tests/phpunit/api/v3/ClassAPITest.php
@@ -1,0 +1,48 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * Test class for class.api.php
+ *
+ * @package CiviCRM_APIv3
+ * @group headless
+ */
+class class_api_test extends CiviUnitTestCase {
+
+  /**
+   * Test that error doesn't occur for non-existent file.
+   */
+  public function testConstructor() {
+    require_once 'api/class.api.php';
+
+    // Check no params is local
+    $api = new civicrm_api3();
+    $this->assertEquals(TRUE, $api->local);
+
+    // Be sure to include keys otherwise these calls die()
+    $keys = ['key' => 'my_site_key', 'api_key' => 'my_api_key'];
+
+    // Check empty server string is local
+    $api = new civicrm_api3(['server' => ''] + $keys);
+    $this->assertEquals(TRUE, $api->local);
+
+    // Check non-empty server string is remote, check default uri
+    $api = new civicrm_api3(['server' => 'http://my_server'] + $keys);
+    $this->assertEquals(FALSE, $api->local);
+    $this->assertEquals('http://my_server/sites/all/modules/civicrm/extern/rest.php', $api->uri);
+
+    // Check path in uri
+    $api = new civicrm_api3(['server' => 'http://my_server', 'path' => 'wibble'] + $keys);
+    $this->assertEquals('http://my_server/wibble', $api->uri);
+
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
When using class.api.php, passing an empty string as the 'server' causes it to be treated as remote not local

Before
----------------------------------------
```
require_once 'api/class.api.php';
$api = new civicrm_api3(['server' => '', ...])
```
`$api` is set to remote mode and future calls fail

After
----------------------------------------
```
require_once 'api/class.api.php';
$api = new civicrm_api3(['server' => '', ...])
```
`$api` is set to local mode

Technical Details
----------------------------------------
So far as I know, this file is not used anywhere by core Civi but the file is copied by various WordPress plugins (and maybe others) to enable local or remote use of the API.  The changes therefore should have no effect unless an plugin author updates to the latest version.

Note this adds a test for this file and the change.