### PR TITLE
dev/event#37 Add CONTAINS operator for APIv4 & Search

### DIFF
--- a/CRM/Api4/Page/Api4Explorer.php
+++ b/CRM/Api4/Page/Api4Explorer.php
@@ -11,6 +11,7 @@
  */
 
 use Civi\Api4\Service\Schema\Joinable\Joinable;
+use Civi\Api4\Utils\CoreUtil;
 
 /**
  *
@@ -30,7 +31,7 @@ class CRM_Api4_Page_Api4Explorer extends CRM_Core_Page {
       });
     }
     $vars = [
-      'operators' => \CRM_Core_DAO::acceptedSQLOperators(),
+      'operators' => CoreUtil::getOperators(),
       'basePath' => Civi::resources()->getUrl('civicrm'),
       'schema' => (array) \Civi\Api4\Entity::get()->setChain(['fields' => ['$name', 'getFields']])->execute(),
       'links' => $entityLinks,

--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -2830,7 +2830,7 @@ SELECT contact_id
   /**
    * @see http://issues.civicrm.org/jira/browse/CRM-9150
    * support for other syntaxes is discussed in ticket but being put off for now
-   * @return array
+   * @return string[]
    */
   public static function acceptedSQLOperators() {
     return [

--- a/Civi/Api4/Generic/AbstractQueryAction.php
+++ b/Civi/Api4/Generic/AbstractQueryAction.php
@@ -19,6 +19,8 @@
 
 namespace Civi\Api4\Generic;
 
+use Civi\Api4\Utils\CoreUtil;
+
 /**
  * Base class for all actions that need to fetch records (`Get`, `Update`, `Delete`, etc.).
  *
@@ -86,7 +88,7 @@ abstract class AbstractQueryAction extends AbstractAction {
    * @throws \API_Exception
    */
   public function addWhere(string $fieldName, string $op, $value = NULL) {
-    if (!in_array($op, \CRM_Core_DAO::acceptedSQLOperators())) {
+    if (!in_array($op, CoreUtil::getOperators())) {
       throw new \API_Exception('Unsupported operator');
     }
     $this->where[] = [$fieldName, $op, $value];
@@ -145,7 +147,7 @@ abstract class AbstractQueryAction extends AbstractAction {
       }
       return $output . '(' . $this->whereClauseToString($whereClause, $op) . ')';
     }
-    elseif (isset($whereClause[1]) && in_array($whereClause[1], \CRM_Core_DAO::acceptedSQLOperators())) {
+    elseif (isset($whereClause[1]) && in_array($whereClause[1], CoreUtil::getOperators())) {
       $output = $whereClause[0] . ' ' . $whereClause[1] . ' ';
       if (isset($whereClause[2])) {
         $output .= is_array($whereClause[2]) ? '[' . implode(', ', $whereClause[2]) . ']' : $whereClause[2];

--- a/Civi/Api4/Generic/DAOGetAction.php
+++ b/Civi/Api4/Generic/DAOGetAction.php
@@ -20,6 +20,7 @@
 namespace Civi\Api4\Generic;
 
 use Civi\Api4\Query\Api4SelectQuery;
+use Civi\Api4\Utils\CoreUtil;
 
 /**
  * Retrieve $ENTITIES based on criteria specified in the `where` parameter.
@@ -154,7 +155,7 @@ class DAOGetAction extends AbstractGetAction {
    * @throws \API_Exception
    */
   public function addHaving(string $expr, string $op, $value = NULL) {
-    if (!in_array($op, \CRM_Core_DAO::acceptedSQLOperators())) {
+    if (!in_array($op, CoreUtil::getOperators())) {
       throw new \API_Exception('Unsupported operator');
     }
     $this->having[] = [$expr, $op, $value];

--- a/Civi/Api4/Generic/Traits/ArrayQueryActionTrait.php
+++ b/Civi/Api4/Generic/Traits/ArrayQueryActionTrait.php
@@ -158,6 +158,15 @@ trait ArrayQueryActionTrait {
       case 'NOT IN':
         return !in_array($value, $expected);
 
+      case 'CONTAINS':
+        if (is_array($value)) {
+          return in_array($expected, $value);
+        }
+        elseif (is_string($value) || is_numeric($value)) {
+          return strpos((string) $value, (string) $expected) !== FALSE;
+        }
+        return $value == $expected;
+
       default:
         throw new NotImplementedException("Unsupported operator: '$operator' cannot be used with array data");
     }

--- a/Civi/Api4/Query/Api4SelectQuery.php
+++ b/Civi/Api4/Query/Api4SelectQuery.php
@@ -362,7 +362,7 @@ class Api4SelectQuery {
   protected function composeClause(array $clause, string $type) {
     // Pad array for unary operators
     list($expr, $operator, $value) = array_pad($clause, 3, NULL);
-    if (!in_array($operator, \CRM_Core_DAO::acceptedSQLOperators(), TRUE)) {
+    if (!in_array($operator, CoreUtil::getOperators(), TRUE)) {
       throw new \API_Exception('Illegal operator');
     }
 

--- a/Civi/Api4/Query/Api4SelectQuery.php
+++ b/Civi/Api4/Query/Api4SelectQuery.php
@@ -26,8 +26,8 @@ use Civi\Api4\Utils\SelectUtil;
  * Leaf operators are one of:
  *
  * * '=', '<=', '>=', '>', '<', 'LIKE', "<>", "!=",
- * * "NOT LIKE", 'IN', 'NOT IN', 'BETWEEN', 'NOT BETWEEN',
- * * 'IS NOT NULL', or 'IS NULL'.
+ * * 'NOT LIKE', 'IN', 'NOT IN', 'BETWEEN', 'NOT BETWEEN',
+ * * 'IS NOT NULL', or 'IS NULL', 'CONTAINS'.
  */
 class Api4SelectQuery {
 
@@ -379,7 +379,8 @@ class Api4SelectQuery {
         $fieldAlias = $expr;
         // Attempt to format if this is a real field
         if (isset($this->apiFieldSpec[$expr])) {
-          FormattingUtil::formatInputValue($value, $expr, $this->apiFieldSpec[$expr]);
+          $field = $this->getField($expr);
+          FormattingUtil::formatInputValue($value, $expr, $field);
         }
       }
       // Expr references a non-field expression like a function; convert to alias
@@ -392,7 +393,8 @@ class Api4SelectQuery {
         foreach ($this->selectAliases as $selectAlias => $selectExpr) {
           list($selectField) = explode(':', $selectAlias);
           if ($selectAlias === $selectExpr && $fieldName === $selectField && isset($this->apiFieldSpec[$fieldName])) {
-            FormattingUtil::formatInputValue($value, $expr, $this->apiFieldSpec[$fieldName]);
+            $field = $this->getField($fieldName);
+            FormattingUtil::formatInputValue($value, $expr, $field);
             $fieldAlias = $selectAlias;
             break;
           }
@@ -415,7 +417,29 @@ class Api4SelectQuery {
         return sprintf('%s %s %s', $fieldAlias, $operator, $valExpr->render($this->apiFieldSpec));
       }
       elseif ($fieldName) {
-        FormattingUtil::formatInputValue($value, $fieldName, $this->apiFieldSpec[$fieldName]);
+        $field = $this->getField($fieldName);
+        FormattingUtil::formatInputValue($value, $fieldName, $field);
+      }
+    }
+
+    if ($operator === 'CONTAINS') {
+      switch ($field['serialize'] ?? NULL) {
+        case \CRM_Core_DAO::SERIALIZE_JSON:
+          $operator = 'LIKE';
+          $value = '%"' . $value . '"%';
+          // FIXME: Use this instead of the above hack once MIN_INSTALL_MYSQL_VER is bumped to 5.7.
+          // return sprintf('JSON_SEARCH(%s, "one", "%s") IS NOT NULL', $fieldAlias, \CRM_Core_DAO::escapeString($value));
+          break;
+
+        case \CRM_Core_DAO::SERIALIZE_SEPARATOR_BOOKEND:
+          $operator = 'LIKE';
+          $value = '%' . \CRM_Core_DAO::VALUE_SEPARATOR . $value . \CRM_Core_DAO::VALUE_SEPARATOR . '%';
+          break;
+
+        default:
+          $operator = 'LIKE';
+          $value = '%' . $value . '%';
+          break;
       }
     }
 

--- a/Civi/Api4/Utils/CoreUtil.php
+++ b/Civi/Api4/Utils/CoreUtil.php
@@ -71,4 +71,11 @@ class CoreUtil {
     return $entityName;
   }
 
+  /**
+   * @return string[]
+   */
+  public static function getOperators() {
+    return \CRM_Core_DAO::acceptedSQLOperators();
+  }
+
 }

--- a/Civi/Api4/Utils/CoreUtil.php
+++ b/Civi/Api4/Utils/CoreUtil.php
@@ -75,7 +75,9 @@ class CoreUtil {
    * @return string[]
    */
   public static function getOperators() {
-    return \CRM_Core_DAO::acceptedSQLOperators();
+    $operators = \CRM_Core_DAO::acceptedSQLOperators();
+    $operators[] = 'CONTAINS';
+    return $operators;
   }
 
 }

--- a/ext/search/CRM/Search/Page/Ang.php
+++ b/ext/search/CRM/Search/Page/Ang.php
@@ -32,7 +32,7 @@ class CRM_Search_Page_Ang extends CRM_Core_Page {
 
     // Add client-side vars for the search UI
     $vars = [
-      'operators' => \Civi\Api4\Utils\CoreUtil::getOperators(),
+      'operators' => CRM_Utils_Array::makeNonAssociative($this->getOperators()),
       'schema' => $this->schema,
       'links' => $this->getLinks(),
       'loadOptions' => $this->loadOptions,
@@ -53,6 +53,29 @@ class CRM_Search_Page_Ang extends CRM_Core_Page {
     ]);
     $loader->load();
     parent::run();
+  }
+
+  /**
+   * @return string[]
+   */
+  private function getOperators() {
+    return [
+      '=' => '=',
+      '!=' => '≠',
+      '>' => '>',
+      '<' => '<',
+      '>=' => '≥',
+      '<=' => '≤',
+      'CONTAINS' => ts('Contains'),
+      'IN' => ts('Is In'),
+      'NOT IN' => ts('Not In'),
+      'LIKE' => ts('Is Like'),
+      'NOT LIKE' => ts('Not Like'),
+      'BETWEEN' => ts('Is Between'),
+      'NOT BETWEEN' => ts('Not Between'),
+      'IS NULL' => ts('Is Null'),
+      'IS NOT NULL' => ts('Not Null'),
+    ];
   }
 
   /**

--- a/ext/search/CRM/Search/Page/Ang.php
+++ b/ext/search/CRM/Search/Page/Ang.php
@@ -32,7 +32,7 @@ class CRM_Search_Page_Ang extends CRM_Core_Page {
 
     // Add client-side vars for the search UI
     $vars = [
-      'operators' => \CRM_Core_DAO::acceptedSQLOperators(),
+      'operators' => \Civi\Api4\Utils\CoreUtil::getOperators(),
       'schema' => $this->schema,
       'links' => $this->getLinks(),
       'loadOptions' => $this->loadOptions,

--- a/ext/search/ang/search/crmSearch.component.js
+++ b/ext/search/ang/search/crmSearch.component.js
@@ -340,6 +340,9 @@
         else if (type === 'Money') {
           return CRM.formatMoney(value);
         }
+        if (_.isArray(value)) {
+          return value.join(', ');
+        }
         return value;
       }
 

--- a/ext/search/ang/search/crmSearchClause.html
+++ b/ext/search/ang/search/crmSearchClause.html
@@ -16,7 +16,7 @@
       </div>
       <div ng-if="!$ctrl.conjunctions[clause[0]]" class="api4-input-group">
         <input class="form-control" ng-model="clause[0]" crm-ui-select="{data: data.fields, allowClear: true, placeholder: 'Field'}" />
-        <select class="form-control api4-operator" ng-model="clause[1]" ng-options="o for o in $ctrl.operators" ></select>
+        <select class="form-control api4-operator" ng-model="clause[1]" ng-options="o.key as o.value for o in $ctrl.operators" ></select>
         <input class="form-control" ng-model="clause[2]" crm-search-value="{field: clause[0], op: clause[1], format: data.format}" />
       </div>
       <fieldset class="clearfix" ng-if="$ctrl.conjunctions[clause[0]]" crm-search-clause="{format: data.format, clauses: clause[1], op: clause[0], fields: data.fields, groupParent: data.clauses, groupIndex: index}">

--- a/ext/search/ang/search/crmSearchValue.directive.js
+++ b/ext/search/ang/search/crmSearchValue.directive.js
@@ -36,10 +36,10 @@
             return;
           }
           if (inputType === 'Date') {
-            if (_.includes(['=', '!=', '<>', '>', '>=', '<', '<='], op)) {
+            if (_.includes(['=', '!=', '>', '>=', '<', '<='], op)) {
               $el.crmDatepicker({time: (field.input_attrs && field.input_attrs.time) || false});
             }
-          } else if (_.includes(['=', '!=', '<>', 'IN', 'NOT IN', 'CONTAINS'], op) && (field.fk_entity || field.options || dataType === 'Boolean')) {
+          } else if (_.includes(['=', '!=', 'IN', 'NOT IN', 'CONTAINS'], op) && (field.fk_entity || field.options || dataType === 'Boolean')) {
             if (field.options) {
               if (field.options === true) {
                 $el.addClass('loading');

--- a/ext/search/ang/search/crmSearchValue.directive.js
+++ b/ext/search/ang/search/crmSearchValue.directive.js
@@ -39,7 +39,7 @@
             if (_.includes(['=', '!=', '<>', '>', '>=', '<', '<='], op)) {
               $el.crmDatepicker({time: (field.input_attrs && field.input_attrs.time) || false});
             }
-          } else if (_.includes(['=', '!=', '<>', 'IN', 'NOT IN'], op) && (field.fk_entity || field.options || dataType === 'Boolean')) {
+          } else if (_.includes(['=', '!=', '<>', 'IN', 'NOT IN', 'CONTAINS'], op) && (field.fk_entity || field.options || dataType === 'Boolean')) {
             if (field.options) {
               if (field.options === true) {
                 $el.addClass('loading');

--- a/ext/search/css/search.css
+++ b/ext/search/css/search.css
@@ -133,7 +133,7 @@
 }
 
 #bootstrap-theme.crm-search .api4-operator {
-  width: 90px;
+  width: 110px;
 }
 
 #bootstrap-theme.crm-search .api4-add-where-group-menu {

--- a/tests/phpunit/api/v4/Action/BasicActionsTest.php
+++ b/tests/phpunit/api/v4/Action/BasicActionsTest.php
@@ -255,6 +255,49 @@ class BasicActionsTest extends UnitTestCase {
     $this->assertEquals(['shape', 'size', 'weight'], array_keys($result));
   }
 
+  public function testContainsOperator() {
+    MockBasicEntity::delete()->addWhere('id', '>', 0)->execute();
+
+    $records = [
+      ['group' => 'one', 'fruit:name' => ['apple', 'pear'], 'weight' => 11],
+      ['group' => 'two', 'fruit:name' => ['pear', 'banana'], 'weight' => 12],
+    ];
+    MockBasicEntity::save()->setRecords($records)->execute();
+
+    $result = MockBasicEntity::get()
+      ->addWhere('fruit:name', 'CONTAINS', 'apple')
+      ->execute();
+    $this->assertCount(1, $result);
+    $this->assertEquals('one', $result->first()['group']);
+
+    $result = MockBasicEntity::get()
+      ->addWhere('fruit:name', 'CONTAINS', 'pear')
+      ->execute();
+    $this->assertCount(2, $result);
+
+    $result = MockBasicEntity::get()
+      ->addWhere('group', 'CONTAINS', 'o')
+      ->execute();
+    $this->assertCount(2, $result);
+
+    $result = MockBasicEntity::get()
+      ->addWhere('weight', 'CONTAINS', 1)
+      ->execute();
+    $this->assertCount(2, $result);
+
+    $result = MockBasicEntity::get()
+      ->addWhere('fruit:label', 'CONTAINS', 'Banana')
+      ->execute();
+    $this->assertCount(1, $result);
+    $this->assertEquals('two', $result->first()['group']);
+
+    $result = MockBasicEntity::get()
+      ->addWhere('weight', 'CONTAINS', 2)
+      ->execute();
+    $this->assertCount(1, $result);
+    $this->assertEquals('two', $result->first()['group']);
+  }
+
   public function testPseudoconstantMatch() {
     MockBasicEntity::delete()->addWhere('id', '>', 0)->execute();
 

--- a/tests/phpunit/api/v4/Action/PseudoconstantTest.php
+++ b/tests/phpunit/api/v4/Action/PseudoconstantTest.php
@@ -27,6 +27,7 @@ use Civi\Api4\CustomGroup;
 use Civi\Api4\Email;
 use Civi\Api4\EntityTag;
 use Civi\Api4\OptionValue;
+use Civi\Api4\Participant;
 use Civi\Api4\Tag;
 
 /**
@@ -271,6 +272,31 @@ class PseudoconstantTest extends BaseCustomValueTest {
     $this->assertEquals('colorful', $options[$tag]['description']);
     $this->assertEquals('#aabbcc', $options[$tag]['color']);
     $this->assertEquals($tag, $options[$tag]['label']);
+  }
+
+  public function testParticipantRole() {
+    $event = $this->createEntity(['type' => 'Event']);
+    $contact = $this->createEntity(['type' => 'Individual']);
+    $participant = Participant::create()
+      ->addValue('contact_id', $contact['id'])
+      ->addValue('event_id', $event['id'])
+      ->addValue('role_id:label', ['Attendee', 'Volunteer'])
+      ->execute()->first();
+
+    $search1 = Participant::get()
+      ->addSelect('role_id', 'role_id:label')
+      ->addWhere('role_id:label', 'CONTAINS', 'Volunteer')
+      ->addOrderBy('id')
+      ->execute()->last();
+
+    $this->assertEquals(['Attendee', 'Volunteer'], $search1['role_id:label']);
+    $this->assertEquals(['1', '2'], $search1['role_id']);
+
+    $search2 = Participant::get()
+      ->addWhere('role_id:label', 'CONTAINS', 'Host')
+      ->execute()->indexBy('id');
+
+    $this->assertArrayNotHasKey($participant['id'], (array) $search2);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes https://lab.civicrm.org/dev/event/-/issues/37
Allows searching within arrays or serialized strings via API & new Search extension.

Before
----------------------------------------
Could not search within multivalued fields.

After
----------------------------------------
CONTAINS operator searches within arrays and serialized fields.

Technical Details
----------------------------------------
I left the json handling off for now, until we bump the minimum mysql version.