### PR TITLE
user-interface#30 Ability to Send Invoice with modified subject and CC

### DIFF
--- a/CRM/Contribute/Form/Task/Invoice.php
+++ b/CRM/Contribute/Form/Task/Invoice.php
@@ -143,6 +143,9 @@ class CRM_Contribute_Form_Task_Invoice extends CRM_Contribute_Form_Task {
       $this->addRule('from_email_address', ts('From Email Address is required'), 'required');
     }
 
+    $attributes = ['class' => 'huge'];
+    $this->add('text', 'cc_id', ts('CC'), $attributes);
+    $this->add('text', 'subject', ts('Subject'), $attributes + ['placeholder' => ts('Optional')]);
     $this->add('wysiwyg', 'email_comment', ts('If you would like to add personal message to email please add it here. (If sending to more then one receipient the same message will be sent to each contact.)'), [
       'rows' => 2,
       'cols' => 40,
@@ -413,6 +416,14 @@ class CRM_Contribute_Form_Task_Invoice extends CRM_Contribute_Form_Task {
 
       // from email address
       $fromEmailAddress = $params['from_email_address'] ?? NULL;
+      if (!empty($params['cc_id'])) {
+        $values['cc_receipt'] = $params['cc_id'];
+      }
+
+      // get subject from UI
+      if (!empty($params['subject'])) {
+        $sendTemplateParams['subject'] = $values['subject'] = $params['subject'];
+      }
 
       // condition to check for download PDF Invoice or email Invoice
       if ($invoiceElements['createPdf']) {

--- a/CRM/Contribute/Form/Task/Invoice.php
+++ b/CRM/Contribute/Form/Task/Invoice.php
@@ -16,6 +16,7 @@
  */
 
 use Civi\Api4\Email;
+
 /**
  * This class provides the functionality to email a group of
  * contacts.

--- a/CRM/Core/BAO/MessageTemplate.php
+++ b/CRM/Core/BAO/MessageTemplate.php
@@ -464,6 +464,11 @@ class CRM_Core_BAO_MessageTemplate extends CRM_Core_DAO_MessageTemplate {
       $mailContent['html'] = preg_replace('/<body(.*)$/im', "<body\\1\n{$testDao->html}", $mailContent['html']);
     }
 
+    // Overwrite subject from form field
+    if (!empty($params['subject'])) {
+      $mailContent['subject'] = $params['subject'];
+    }
+
     // replace tokens in the three elements (in subject as if it was the text body)
     $domain = CRM_Core_BAO_Domain::getDomain();
     $hookTokens = [];

--- a/templates/CRM/Contribute/Form/Task/Invoice.tpl
+++ b/templates/CRM/Contribute/Form/Task/Invoice.tpl
@@ -28,6 +28,18 @@
     <td class="label">{$form.from_email_address.label}</td>
     <td>{$form.from_email_address.html} {help id="id-from_email" file="CRM/Contact/Form/Task/Email.hlp" isAdmin=$isAdmin}</td>
   </tr>
+  <tr class="crm-email-element crm-contactEmail-form-block-cc_id">
+    <td class="label">{$form.cc_id.label}</td>
+    <td>
+        {$form.cc_id.html}
+    </td>
+  </tr>
+  <tr class="crm-email-element crm-contactEmail-form-block-subject">
+    <td class="label">{$form.subject.label}</td>
+    <td>
+        {$form.subject.html}
+    </td>
+  </tr>
   <tr class="crm-email-element">
     <td class="label">{$form.email_comment.label}</td>
     <td>{$form.email_comment.html}</td>


### PR DESCRIPTION
Overview
----------------------------------------
Ability to Send Invoice with CC email and with option to alter subject line.

Current behaviour
----------------------------------------
When Invoice Setting is Enabled at `CiviContribute Component Settings`, We get option to `Print Invoice` Or `Email Invoice`.

When we click on `Email Invoice`, we can choose From Address and Add additional Comment.

When Email Send: 

For online payment form:
- Subject:`Contribution Invoice: Help Support CiviCRM!- Test User`
- BCC and CC emailed copied from Online page and used to send email.

For Offline Submission:
-    Subject:`Invoice- Test User`
-    BCC and CC : No possible

You can modify the subject, for that we need to alter the subject line in invoice template.

New behaviour
----------------------------------------
You can override Email Subject from UI, its optional, if you don't provide subject, default subject form invoice template get used.

CC Field is available. that will override online page CC email, and for offline payment its new option to send CC email. 

<img width="1060" alt="Screenshot 2020-08-29 at 7 54 52 AM" src="https://user-images.githubusercontent.com/377735/91626929-e0128180-e9d0-11ea-87cc-d3d0713e6ab4.png">

----------------------------------------
https://lab.civicrm.org/dev/user-interface/-/issues/30