### PR TITLE
extend_testSubmitContributionPageWithPriceSetQuantity

### DIFF
--- a/tests/phpunit/api/v3/ContributionPageTest.php
+++ b/tests/phpunit/api/v3/ContributionPageTest.php
@@ -1957,6 +1957,7 @@ class api_v3_ContributionPageTest extends CiviUnitTestCase {
       'label' => 'Printing Rights',
       'html_type' => 'Text',
     ]);
+
     $this->callAPISuccess('price_field_value', 'create', [
       'price_set_id' => $priceSetID,
       'price_field_id' => $priceField['id'],
@@ -1969,10 +1970,28 @@ class api_v3_ContributionPageTest extends CiviUnitTestCase {
     // Set quantity for our test
     $submitParams['price_' . $priceFieldId] = 180;
 
+    $priceField = $this->callAPISuccess('price_field', 'create', [
+      'price_set_id' => $priceSetID,
+      'label' => 'Another Line Item',
+      'html_type' => 'Text',
+    ]);
+
+    $this->callAPISuccess('price_field_value', 'create', [
+      'price_set_id' => $priceSetID,
+      'price_field_id' => $priceField['id'],
+      'label' => 'Another Line Item',
+      'financial_type_id' => $financialTypeId,
+      'amount' => '2.95',
+    ]);
+    $priceFieldId = $priceField['id'];
+
+    // Set quantity for our test
+    $submitParams['price_' . $priceFieldId] = 110;
+
     // contribution_page submit requires amount and tax_amount - and that's ok we're not testing that - we're testing at the LineItem level
-    $submitParams['amount'] = $this->formatMoneyInput(180 * 16.95);
+    $submitParams['amount'] = $this->formatMoneyInput(180 * 16.95 + 110 * 2.95);
     // This is the correct Tax Amount - use it later to compare to what the CiviCRM Core came up with at the LineItem level
-    $submitParams['tax_amount'] = $this->formatMoneyInput(180 * 16.95 * 0.10);
+    $submitParams['tax_amount'] = (180 * 16.95 * 0.10 + 110 * 2.95 * 0.10);
 
     $this->callAPISuccess('contribution_page', 'submit', $submitParams);
     $contribution = $this->callAPISuccessGetSingle('contribution', [
@@ -1980,15 +1999,25 @@ class api_v3_ContributionPageTest extends CiviUnitTestCase {
     ]);
 
     // Retrieve the lineItem that belongs to the Printing Rights and check the tax_amount CiviCRM Core calculated for it
-    $lineItem = $this->callAPISuccessGetSingle('LineItem', [
+    $lineItem1 = $this->callAPISuccessGetSingle('LineItem', [
       'contribution_id' => $contribution['id'],
       'label' => 'Printing Rights',
     ]);
 
-    $lineItem_TaxAmount = round($lineItem['tax_amount'], 2);
+    // Retrieve the lineItem that belongs to the Another Line Item and check the tax_amount CiviCRM Core calculated for it
+    $lineItem2 = $this->callAPISuccessGetSingle('LineItem', [
+      'contribution_id' => $contribution['id'],
+      'label' => 'Another Line Item',
+    ]);
 
-    $this->assertEquals($lineItem['line_total'], $contribution['total_amount'], 'Contribution total should match line total');
-    $this->assertEquals($lineItem_TaxAmount, round(180 * 16.95 * 0.10, 2), 'Wrong Sales Tax Amount is calculated and stored.');
+    $finalContribution = $this->callAPISuccess('Contribution', 'getsingle', ['id' => $contribution['id'], 'return' => ['tax_amount', 'total_amount']]);
+
+    $this->assertEquals($lineItem1['line_total'] + $lineItem2['line_total'], round(180 * 16.95 + 110 * 2.95, 2), 'Line Item Total is incorrect.');
+    $this->assertEquals($lineItem1['line_total'] + $lineItem2['line_total'], $finalContribution['total_amount'], 'Contribution total should match line item totals');
+
+    $this->assertEquals(round($lineItem1['tax_amount'] + $lineItem2['tax_amount'], 2), round(180 * 16.95 * 0.10 + 110 * 2.95 * 0.10, 2), 'Wrong Sales Tax Amount is calculated and stored.');
+    $this->assertEquals(round($lineItem1['tax_amount'] + $lineItem2['tax_amount'], 2), $finalContribution['tax_amount'], 'Sales Tax Amount on Contribution does not match sum of Sales Tax Amount across the Line Items.');
+
   }
 
   /**


### PR DESCRIPTION
**Overview**
----------------------------------------
Gitlab: https://lab.civicrm.org/dev/core/-/issues/1983
"Total Tax Amount on the Contribution (generated in backoffice/offline) no longer adds up to sum of the Tax Amount for the individual line items (#1983)"

The same issue has also been reported on Public Contribution page -> https://civicrm.stackexchange.com/questions/37533/wrong-tax-calculation-on-donation-pages

So I'm looking to expand a test I put in a few years back -> `testSubmitContributionPageWithPriceSetQuantity`

**Before**
----------------------------------------
`testSubmitContributionPageWithPriceSetQuantity` is only checking 1 Line Items so can not reproduce the issue outlined in 1983

**After**
----------------------------------------
`testSubmitContributionPageWithPriceSetQuantity` now has two Line Items

**But can't reproduce...**
----------------------------------------
On my local these new assertions are passing! So I'm not able to reproduce 1983 in this test. It looks like 
So submitting it there to see what Jenkins thinks of it. 