### PR TITLE
Add test to check, remove unnecessary lines

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4527,10 +4527,6 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
     }
     else {
       if (empty($input['IAmAHorribleNastyBeyondExcusableHackInTheCRMEventFORMTaskClassThatNeedsToBERemoved'])) {
-        if ($event->is_email_confirm) {
-          // @todo this should be set by the function that sends the mail after sending.
-          $contributionParams['receipt_date'] = $changeDate;
-        }
         $participantParams['id'] = $participant->id;
         $participantParams['status_id'] = 'Registered';
         civicrm_api3('Participant', 'create', $participantParams);

--- a/tests/phpunit/CRM/Event/Form/Registration/ConfirmTest.php
+++ b/tests/phpunit/CRM/Event/Form/Registration/ConfirmTest.php
@@ -92,9 +92,10 @@ class CRM_Event_Form_Registration_ConfirmTest extends CiviUnitTestCase {
    *
    * @param string $thousandSeparator
    *
-   * @dataProvider getThousandSeparators
+   * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
    *
-   * @throws \Exception
+   * @dataProvider getThousandSeparators
    */
   public function testPaidSubmit($thousandSeparator) {
     $this->setCurrencySeparators($thousandSeparator);
@@ -165,6 +166,7 @@ class CRM_Event_Form_Registration_ConfirmTest extends CiviUnitTestCase {
     $this->assertEquals(8000.67, $contribution['total_amount']);
     $this->assertEquals(1.67, $contribution['fee_amount']);
     $this->assertEquals(7999, $contribution['net_amount']);
+    $this->assertNotEmpty($contribution['receipt_date']);
     $this->assertNotContains(' (multiple participants)', $contribution['amount_level']);
     $lastFinancialTrxnId = CRM_Core_BAO_FinancialTrxn::getFinancialTrxnId($contribution['id'], 'DESC');
     $financialTrxn = $this->callAPISuccessGetSingle(

--- a/tests/phpunit/CiviTest/CiviMailUtils.php
+++ b/tests/phpunit/CiviTest/CiviMailUtils.php
@@ -63,6 +63,16 @@ class CiviMailUtils extends PHPUnit\Framework\TestCase {
   }
 
   /**
+   * Clean up after test.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function __destruct() {
+    $this->stop();
+    $this->clearMessages();
+  }
+
+  /**
    * Start writing emails to db instead of current option.
    */
   public function start() {

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -729,6 +729,7 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
    * @param array $params
    *
    * @return mixed
+   * @throws \CRM_Core_Exception
    */
   public function paymentProcessorAuthorizeNetCreate($params = []) {
     $params = array_merge([


### PR DESCRIPTION


Overview
----------------------------------------
Per the code comment it was likely the removed lines were not needed but tests were required to confirm.

This does that

Before
----------------------------------------
```
  if ($event->is_email_confirm) {
          // @todo this should be set by the function that sends the mail after sending.
          $contributionParams['receipt_date'] = $changeDate;
        }
```

After
----------------------------------------
@todo done

Technical Details
----------------------------------------


Comments
----------------------------------------

