### PR TITLE
Move LineItem acl handling from v3 api to financialacls core extension

### DIFF
--- a/CRM/Price/BAO/LineItem.php
+++ b/CRM/Price/BAO/LineItem.php
@@ -117,34 +117,6 @@ class CRM_Price_BAO_LineItem extends CRM_Price_DAO_LineItem {
   }
 
   /**
-   * Modifies $params array for filtering financial types.
-   *
-   * @param array $params
-   *   (reference ) an assoc array of name/value pairs.
-   *
-   */
-  public static function getAPILineItemParams(&$params) {
-    CRM_Financial_BAO_FinancialType::getAvailableFinancialTypes($types);
-    if ($types && empty($params['financial_type_id'])) {
-      $params['financial_type_id'] = ['IN' => array_keys($types)];
-    }
-    elseif ($types) {
-      if (is_array($params['financial_type_id'])) {
-        $invalidFts = array_diff($params['financial_type_id'], array_keys($types));
-      }
-      elseif (!in_array($params['financial_type_id'], array_keys($types))) {
-        $invalidFts = $params['financial_type_id'];
-      }
-      if ($invalidFts) {
-        $params['financial_type_id'] = ['NOT IN' => $invalidFts];
-      }
-    }
-    else {
-      $params['financial_type_id'] = 0;
-    }
-  }
-
-  /**
    * @param int $contributionId
    *
    * @return null|string

--- a/api/v3/LineItem.php
+++ b/api/v3/LineItem.php
@@ -62,9 +62,6 @@ function _civicrm_api3_line_item_create_spec(&$params) {
  *   Array of matching line_items
  */
 function civicrm_api3_line_item_get($params) {
-  if (CRM_Financial_BAO_FinancialType::isACLFinancialTypeStatus() && !empty($params['check_permissions'])) {
-    CRM_Price_BAO_LineItem::getAPILineItemParams($params);
-  }
   return _civicrm_api3_basic_get(_civicrm_api3_get_BAO(__FUNCTION__), $params);
 }
 

--- a/ext/financialacls/financialacls.php
+++ b/ext/financialacls/financialacls.php
@@ -168,6 +168,27 @@ function financialacls_civicrm_pre($op, $objectName, $id, &$params) {
   }
 }
 
+/**
+ * Implements hook_civicrm_selectWhereClause().
+ *
+ * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_selectWhereClause
+ */
+function financialacls_civicrm_selectWhereClause($entity, &$clauses) {
+  if ($entity === 'LineItem') {
+    if (CRM_Financial_BAO_FinancialType::isACLFinancialTypeStatus()) {
+      $types = [];
+      CRM_Financial_BAO_FinancialType::getAvailableFinancialTypes($types);
+      if ($types) {
+        $clauses['financial_type_id'] = 'IN (' . implode(',', array_keys($types)) . ')';
+      }
+      else {
+        $clauses['financial_type_id'] = '= 0';
+      }
+    }
+  }
+
+}
+
 // --- Functions below this ship commented out. Uncomment as required. ---
 
 /**


### PR DESCRIPTION

Overview
----------------------------------------
Financial acl handling is in core but within core we are starting to restructure into a core-extension
This PR moves over the portion that relates to LineItem.get

Before
----------------------------------------
Acl directly in v3 api

After
----------------------------------------
Acl applied using best-practice hook, also available for v4 api

Technical Details
----------------------------------------
The code is a bit simpler as we didn't need to integrate it with a possibly existing key as the acl is constructed separately

Comments
----------------------------------------
@seamuslee001 