### PR TITLE
[REF] Separate and move line-item specific portion of checkTaxAmount to LineItem api

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4284,14 +4284,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
       $params['tax_amount'] = array_sum($taxAmountArray);
       $params['total_amount'] = $params['total_amount'] + $params['tax_amount'];
     }
-    else {
-      // update line item of contrbution
-      if (isset($params['financial_type_id']) && array_key_exists($params['financial_type_id'], $taxRates) && $isLineItem) {
-        $taxRate = $taxRates[$params['financial_type_id']];
-        $taxAmount = CRM_Contribute_BAO_Contribution_Utils::calculateTaxAmount($params['line_total'], $taxRate);
-        $params['tax_amount'] = round($taxAmount['tax_amount'], 2);
-      }
-    }
+
     return $params;
   }
 

--- a/api/v3/LineItem.php
+++ b/api/v3/LineItem.php
@@ -29,9 +29,13 @@
  */
 function civicrm_api3_line_item_create($params) {
   // @todo the following line is not really appropriate for the api. The BAO should
-  // do the work, and it should be in a tighter function. The below function is  not really
-  // readable because it is handling contribution and line item together.
-  $params = CRM_Contribute_BAO_Contribution::checkTaxAmount($params, TRUE);
+  // do the work.
+  $taxRates = CRM_Core_PseudoConstant::getTaxRates();
+  if (isset($params['financial_type_id']) && array_key_exists($params['financial_type_id'], $taxRates)) {
+    $taxRate = $taxRates[$params['financial_type_id']];
+    $taxAmount = CRM_Contribute_BAO_Contribution_Utils::calculateTaxAmount($params['line_total'], $taxRate);
+    $params['tax_amount'] = round($taxAmount['tax_amount'], 2);
+  }
   return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params, 'LineItem');
 }
 


### PR DESCRIPTION
Overview
----------------------------------------
Interim refactor as part of moving any handling out of apiv3 LineItem so we can create a v4 LineItem aaapi

Before
----------------------------------------
api calls
```
$params = CRM_Contribute_BAO_Contribution::checkTaxAmount($params, TRUE);
```

but it's hard to see what it's achieved

After
----------------------------------------
The lines that actually related to the LineItem.create action are moved there, making the path forwards to getting it out of the api & into the BAO simpler

Technical Details
----------------------------------------
This is not intended to be the final place or version, but making sense of checkTaxAmount is hard so I wanted to keep this simple and
iterate.

checkTaxAmount is called from 2 places - once from v3 LineItem.create with isLineItem = TRUE
and once from Contribution.create with isLineItem = FALSE

Most of the function is accessible dependent on isLineItem - meaning it's 2 separate functions.
However, the first chuck is called 'whenever id is set'. BUT it makes no sense for line items. It
uses the 'id' - regardless of whether it is a line item id or a contribution id - to get the previous
contribution. It then sets tax amount based on a comparison - but
that really makes zero sense. I'm pretty sure it was never intended to be used for LineItems

Comments
----------------------------------------

@seamuslee001 @monishdeb @pradpnayak  - can one of you look please. It's nasty code but I think I am right on this now