### PR TITLE
Test & remove handling for max_related in renewal form

### DIFF
--- a/CRM/Member/Form/MembershipRenewal.php
+++ b/CRM/Member/Form/MembershipRenewal.php
@@ -748,7 +748,6 @@ class CRM_Member_Form_MembershipRenewal extends CRM_Member_Form {
    */
   public function processMembership($contactID, $membershipTypeID, $is_test, $changeToday, $customFieldsFormatted, $numRenewTerms, $membershipID, $pending, $contributionRecurID, $isPayLater) {
     $allStatus = CRM_Member_PseudoConstant::membershipStatus();
-    $membershipTypeDetails = CRM_Member_BAO_MembershipType::getMembershipTypeDetails($membershipTypeID);
     $ids = [];
 
     // CRM-7297 - allow membership type to be be changed during renewal so long as the parent org of new membershipType
@@ -773,7 +772,6 @@ class CRM_Member_Form_MembershipRenewal extends CRM_Member_Form {
         'end_date' => $currentMembership['end_date'],
         'join_date' => $currentMembership['join_date'],
         'membership_type_id' => $membershipTypeID,
-        'max_related' => !empty($membershipTypeDetails['max_related']) ? $membershipTypeDetails['max_related'] : NULL,
         'membership_activity_status' => ($pending || $isPayLater) ? 'Scheduled' : 'Completed',
       ];
       if ($contributionRecurID) {

--- a/tests/phpunit/CRM/Member/Form/MembershipRenewalTest.php
+++ b/tests/phpunit/CRM/Member/Form/MembershipRenewalTest.php
@@ -91,6 +91,7 @@ class CRM_Member_Form_MembershipRenewalTest extends CiviUnitTestCase {
       'relationship_type_id' => 20,
       'min_fee' => 100,
       'financial_type_id' => $this->financialTypeID,
+      'max_related' => 10,
     ])['id'];
 
     $this->_membershipID = $this->callAPISuccess('Membership', 'create', [
@@ -144,7 +145,6 @@ class CRM_Member_Form_MembershipRenewalTest extends CiviUnitTestCase {
       // This format reflects the 23 being the organisation & the 25 being the type.
       'membership_type_id' => [23, $this->membershipTypeAnnualFixedID],
       'auto_renew' => '0',
-      'max_related' => '',
       'num_terms' => '1',
       'source' => '',
       'total_amount' => '50.00',
@@ -225,7 +225,6 @@ class CRM_Member_Form_MembershipRenewalTest extends CiviUnitTestCase {
       // This format reflects the 23 being the organisation & the 25 being the type.
       'membership_type_id' => [23, $this->membershipTypeAnnualFixedID],
       'auto_renew' => '0',
-      'max_related' => '',
       'num_terms' => '1',
       'source' => '',
       'total_amount' => '50.00',
@@ -281,7 +280,6 @@ class CRM_Member_Form_MembershipRenewalTest extends CiviUnitTestCase {
       'membership_type_id' => [23, $this->membershipTypeAnnualFixedID],
       'auto_renew' => '1',
       'is_recur' => 1,
-      'max_related' => 0,
       'num_terms' => '1',
       'source' => '',
       'total_amount' => '77.00',
@@ -493,7 +491,6 @@ class CRM_Member_Form_MembershipRenewalTest extends CiviUnitTestCase {
       // This format reflects the 23 being the organisation & the 25 being the type.
       'membership_type_id' => [23, $this->membershipTypeAnnualFixedID],
       'auto_renew' => '0',
-      'max_related' => '',
       'num_terms' => '2',
       'total_amount' => '50.00',
       //Member dues, see data.xml
@@ -546,7 +543,6 @@ class CRM_Member_Form_MembershipRenewalTest extends CiviUnitTestCase {
       // This format reflects the 23 being the organisation & the 25 being the type.
       'membership_type_id' => [23, $this->membershipTypeAnnualFixedID],
       'auto_renew' => '0',
-      'max_related' => '',
       'num_terms' => '2',
       'total_amount' => '50.00',
       //Member dues, see data.xml
@@ -561,7 +557,7 @@ class CRM_Member_Form_MembershipRenewalTest extends CiviUnitTestCase {
       'trxn_id' => 777,
       'contribution_status_id' => 2,
       'billing_first_name' => 'Test',
-      'billing_middlename' => 'Last',
+      'billing_middle_name' => 'Last',
       'billing_street_address-5' => '10 Test St',
       'billing_city-5' => 'Test',
       'billing_state_province_id-5' => '1003',
@@ -573,6 +569,8 @@ class CRM_Member_Form_MembershipRenewalTest extends CiviUnitTestCase {
     $form->testSubmit($params);
     $membership = $this->callAPISuccessGetSingle('Membership', ['contact_id' => $this->_individualId]);
     $this->assertEquals(strtotime($membership['end_date']), strtotime($originalMembership['end_date']));
+    $this->assertEquals(10, $membership['max_related']);
+
     $contribution = $this->callAPISuccessGetSingle('Contribution', [
       'contact_id' => $this->_individualId,
       'contribution_status_id' => 2,
@@ -609,7 +607,6 @@ class CRM_Member_Form_MembershipRenewalTest extends CiviUnitTestCase {
       // This format reflects the 23 being the organisation & the 25 being the type.
       'membership_type_id' => [23, $this->membershipTypeAnnualFixedID],
       'auto_renew' => '0',
-      'max_related' => '',
       'num_terms' => '2',
       'total_amount' => '50.00',
       //Member dues, see data.xml
@@ -685,7 +682,6 @@ class CRM_Member_Form_MembershipRenewalTest extends CiviUnitTestCase {
       'membership_type_id' => [23, $this->membershipTypeAnnualFixedID],
       'auto_renew' => '1',
       'is_recur' => 1,
-      'max_related' => 0,
       'num_terms' => '1',
       'total_amount' => $this->formatMoneyInput('7800.90'),
       //Member dues, see data.xml


### PR DESCRIPTION


Overview
----------------------------------------
Minor code cleanup - test to ensure code is not needed & remove a couple of lines

Before
----------------------------------------
$membershipType loaded in order to get max_related
```
'max_related' => !empty($membershipTypeDetails['max_related']) ? $membershipTypeDetails['max_related'] : NULL,
```

After
----------------------------------------
Similar snippet in Membership.create BAO does the same thing

Technical Details
----------------------------------------
 max_related is not a field on the renewal form - the handling appears to exist purely because
    at some stage the BAO was not able to calculate it - however, as the test demonstrates that is
    no longer the case

Comments
----------------------------------------

