### PR TITLE
dev/core#2003 Civicrm_price_field_value.amount truncation when localisation in play

### DIFF
--- a/CRM/Price/Form/Field.php
+++ b/CRM/Price/Form/Field.php
@@ -642,6 +642,9 @@ class CRM_Price_Form_Field extends CRM_Core_Form {
     // store the submitted values in an array
     $params = $this->controller->exportValues('Field');
     $params['price'] = CRM_Utils_Rule::cleanMoney($params['price']);
+    foreach ($params['option_amount'] as $key => $amount) {
+      $params['option_amount'][$key] = CRM_Utils_Rule::cleanMoney($amount);
+    }
 
     $params['is_display_amounts'] = CRM_Utils_Array::value('is_display_amounts', $params, FALSE);
     $params['is_required'] = CRM_Utils_Array::value('is_required', $params, FALSE);

--- a/CRM/Price/Form/Option.php
+++ b/CRM/Price/Form/Option.php
@@ -75,6 +75,9 @@ class CRM_Price_Form_Option extends CRM_Core_Form {
 
       // fix the display of the monetary value, CRM-4038
       foreach ($this->_moneyFields as $field) {
+        // @todo use formatLocaleNumericRoundedByOptionalPrecision - but note that there is an issue where php doesn't handle
+        // money strings beyond a certain total length - per https://github.com/civicrm/civicrm-core/pull/18409
+        // & https://github.com/civicrm/civicrm-core/pull/18409
         $defaults[$field] = CRM_Utils_Money::format(CRM_Utils_Array::value($field, $defaults), NULL, '%a');
       }
     }
@@ -326,7 +329,6 @@ class CRM_Price_Form_Option extends CRM_Core_Form {
       return NULL;
     }
     else {
-      $params = $ids = [];
       $params = $this->controller->exportValues('Option');
       $fieldLabel = CRM_Core_DAO::getFieldValue('CRM_Price_DAO_PriceField', $this->_fid, 'label');
 


### PR DESCRIPTION
Overview
----------------------------------------
This fixes the bug that derailed the fix for https://lab.civicrm.org/dev/core/-/issues/1603

On further testing I agree with Jitendra that the price field form was mis-saving the longer values (I only
tested with Euro style decimal separators but maybe on both) and it was bad data caused by this
that made the merged fix look like a regression.

I also observed that the Money functions intended to round only appeared to since it was rounding
just fine to 2 places, as tested, but it was still rounding to 2 places when we wanted more.

This fixes both the New Price field screen (when options are entered) and the edit options screen

Before
----------------------------------------
This amount string is truncated on save - ie the decimals below don't hit the civicrm_price_field_option_value table
<img width="906" alt="Screen Shot 2020-08-31 at 5 20 47 PM" src="https://user-images.githubusercontent.com/336308/91689308-ef075880-ebb7-11ea-912b-cf4998291034.png">




After
----------------------------------------
Amount is saved correctly into the db - displays rounded to 2 digits (unchanged)


Technical Details
----------------------------------------
@jaapjansma 

Comments
----------------------------------------

