### PR TITLE
core#365: Unwanted mail blast sent by Scheduled Reminders

### DIFF
--- a/CRM/Admin/Form/ScheduleReminders.php
+++ b/CRM/Admin/Form/ScheduleReminders.php
@@ -158,7 +158,7 @@ class CRM_Admin_Form_ScheduleReminders extends CRM_Admin_Form {
     $this->add('number', 'start_action_offset', ts('When'), ['class' => 'six', 'min' => 0]);
     $this->addRule('start_action_offset', ts('Value should be a positive number'), 'positiveInteger');
 
-    $date = $this->add('datepicker', 'created_date', ts('Created on'), [], FALSE);
+    $date = $this->add('datepicker', 'created_date', ts('Created Date'), [], FALSE);
     if ($this->_action & CRM_Core_Action::UPDATE) {
       $date->freeze();
     }

--- a/CRM/Admin/Form/ScheduleReminders.php
+++ b/CRM/Admin/Form/ScheduleReminders.php
@@ -158,6 +158,11 @@ class CRM_Admin_Form_ScheduleReminders extends CRM_Admin_Form {
     $this->add('number', 'start_action_offset', ts('When'), ['class' => 'six', 'min' => 0]);
     $this->addRule('start_action_offset', ts('Value should be a positive number'), 'positiveInteger');
 
+    $date = $this->add('datepicker', 'created_date', ts('Created on'), [], FALSE);
+    if ($this->_action & CRM_Core_Action::UPDATE) {
+      $date->freeze();
+    }
+
     $isActive = ts('Scheduled Reminder Active');
     $recordActivity = ts('Record activity for automated email');
     if ($providersCount) {
@@ -381,6 +386,7 @@ class CRM_Admin_Form_ScheduleReminders extends CRM_Admin_Form {
       $defaults['is_active'] = 1;
       $defaults['mode'] = 'Email';
       $defaults['record_activity'] = 1;
+      $defaults['created_date'] = date('Y-m-d H:i:s');
     }
     else {
       $defaults = $this->_values;

--- a/CRM/Upgrade/Incremental/php/FiveThirty.php
+++ b/CRM/Upgrade/Incremental/php/FiveThirty.php
@@ -73,6 +73,8 @@ class CRM_Upgrade_Incremental_php_FiveThirty extends CRM_Upgrade_Incremental_Bas
   public function upgrade_5_30_alpha1($rev) {
     $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
     $this->addTask('Add core (required) extension Financial ACLs', 'installFinancialAcls');
+    $this->addTask('core-issue#365 - Add created_date to civicrm_action_schedule', 'addColumn',
+      'civicrm_action_schedule', 'created_date', "timestamp NULL  DEFAULT CURRENT_TIMESTAMP COMMENT 'When was the schedule reminder created.'");
   }
 
   // public static function taskFoo(CRM_Queue_TaskContext $ctx, ...) {

--- a/Civi/ActionSchedule/RecipientBuilder.php
+++ b/Civi/ActionSchedule/RecipientBuilder.php
@@ -409,14 +409,14 @@ class RecipientBuilder {
       else {
         $startDateClauses[] = "DATE_SUB(!casNow, INTERVAL 1 DAY ) <= {$date}";
       }
-      if (!empty($actionSchedule->created_date) && !$actionSchedule->is_repeat) {
-        $startDateClauses[] = $actionSchedule->start_action_condition == 'before' ? "'{$actionSchedule->created_date}' >= {$date}" : "'{$actionSchedule->created_date}' <= {$date}";
+      if (!empty($actionSchedule->created_date)) {
+        $startDateClauses[] = "'{$actionSchedule->created_date}' <= {$date}";
       }
     }
     elseif ($actionSchedule->absolute_date) {
       $startDateClauses[] = "DATEDIFF(DATE('!casNow'),'{$actionSchedule->absolute_date}') = 0";
-      if (!empty($actionSchedule->created_date) && !$actionSchedule->is_repeat) {
-        $startDateClauses[] = "DATEDIFF(DATE('{$actionSchedule->created_date}'),'{$actionSchedule->absolute_date}') > 0";
+      if (!empty($actionSchedule->created_date)) {
+        $startDateClauses[] = "DATEDIFF(DATE('{$actionSchedule->created_date}'),'{$actionSchedule->absolute_date}') >= 0";
       }
     }
     return $startDateClauses;

--- a/Civi/ActionSchedule/RecipientBuilder.php
+++ b/Civi/ActionSchedule/RecipientBuilder.php
@@ -409,9 +409,15 @@ class RecipientBuilder {
       else {
         $startDateClauses[] = "DATE_SUB(!casNow, INTERVAL 1 DAY ) <= {$date}";
       }
+      if (!empty($actionSchedule->created_date) && !$actionSchedule->is_repeat) {
+        $startDateClauses[] = $actionSchedule->start_action_condition == 'before' ? "'{$actionSchedule->created_date}' >= {$date}" : "'{$actionSchedule->created_date}' <= {$date}";
+      }
     }
     elseif ($actionSchedule->absolute_date) {
       $startDateClauses[] = "DATEDIFF(DATE('!casNow'),'{$actionSchedule->absolute_date}') = 0";
+      if (!empty($actionSchedule->created_date) && !$actionSchedule->is_repeat) {
+        $startDateClauses[] = "DATEDIFF(DATE('{$actionSchedule->created_date}'),'{$actionSchedule->absolute_date}') > 0";
+      }
     }
     return $startDateClauses;
   }

--- a/templates/CRM/Admin/Form/ScheduleReminders.tpl
+++ b/templates/CRM/Admin/Form/ScheduleReminders.tpl
@@ -25,6 +25,10 @@
         <td class="label">{$form.entity.label}</td>
         <td>{$form.entity.html}</td>
     </tr>
+    <tr>
+       <td class="label">{$form.created_date.label}&nbsp;&nbsp;{help id="id-created_date"}</td>
+       <td>{$form.created_date.html}</td>
+   </tr>
 
     <tr class="crm-scheduleReminder-form-block-when">
         <td class="right">{$form.start_action_offset.label}</td>

--- a/templates/CRM/Admin/Page/ScheduleReminders.hlp
+++ b/templates/CRM/Admin/Page/ScheduleReminders.hlp
@@ -19,7 +19,7 @@
 {/htxt}
 
 {htxt id="id-created_date-title"}
-  {ts}Created on{/ts}
+  {ts}Created date{/ts}
 {/htxt}
 
 {htxt id="id-created_date"}

--- a/templates/CRM/Admin/Page/ScheduleReminders.hlp
+++ b/templates/CRM/Admin/Page/ScheduleReminders.hlp
@@ -18,6 +18,14 @@
   <p>{ts}For Membership and Contact reminders, you can limit or additionally include recipients by choosing specific contacts, or choosing a group.{/ts}</p>
 {/htxt}
 
+{htxt id="id-created_date-title"}
+  {ts}Created on{/ts}
+{/htxt}
+
+{htxt id="id-created_date"}
+  {ts}Reminder messages will not be sent for messages that should have already gone out before the Schedule Reminder was created.{/ts}
+{/htxt}
+
 {htxt id="id-from_name_email-title"}
   {ts}Specify FROM Name and Email{/ts}
 {/htxt}
@@ -33,4 +41,3 @@
 {htxt id="communication_language"}
   {ts}This is the communication language. If there are template translation or tokens, they will be localized accordingly. By default, the system default language will be used.{/ts}
 {/htxt}
-

--- a/tests/phpunit/CRM/Core/BAO/ActionScheduleTest.php
+++ b/tests/phpunit/CRM/Core/BAO/ActionScheduleTest.php
@@ -1162,6 +1162,7 @@ class CRM_Core_BAO_ActionScheduleTest extends CiviUnitTestCase {
     $this->callAPISuccess('contact', 'create', array_merge($this->fixtures['contact'], ['contact_id' => $membership->contact_id]));
     $actionSchedule = $this->fixtures['sched_membership_join_2week'];
     $actionSchedule['entity_value'] = $membership->membership_type_id;
+    $actionSchedule['created_date'] = '2012-03-21 01:00:00';
     $actionScheduleDao = CRM_Core_BAO_ActionSchedule::add($actionSchedule);
     $this->assertInternalType('numeric', $actionScheduleDao->id);
 
@@ -1183,6 +1184,7 @@ class CRM_Core_BAO_ActionScheduleTest extends CiviUnitTestCase {
 
     $actionSchedule = $this->fixtures['sched_membership_start_1week'];
     $actionSchedule['entity_value'] = $membership->membership_type_id;
+    $actionSchedule['created_date'] = '2012-03-21 01:00:00';
     $actionScheduleDao = CRM_Core_BAO_ActionSchedule::add($actionSchedule);
     $this->assertInternalType('numeric', $actionScheduleDao->id);
 
@@ -1263,6 +1265,7 @@ class CRM_Core_BAO_ActionScheduleTest extends CiviUnitTestCase {
       'start_action_offset' => '1',
       'start_action_unit' => 'day',
       'subject' => 'subject sched_contact_bday_yesterday',
+      'created_date' => '2005-06-08 20:00:00',
     ];
 
     // Create schedule reminder where parent group ($groupID) is selectd to limit recipients,
@@ -1658,6 +1661,7 @@ class CRM_Core_BAO_ActionScheduleTest extends CiviUnitTestCase {
     $contact = $this->callAPISuccess('Contact', 'create', $this->fixtures['contact_birthdate']);
     $this->_testObjects['CRM_Contact_DAO_Contact'][] = $contact['id'];
     $actionSchedule = $this->fixtures['sched_contact_bday_yesterday'];
+    $actionSchedule['created_date'] = '2005-07-07 01:00:00';
     $actionScheduleDao = CRM_Core_BAO_ActionSchedule::add($actionSchedule);
     $this->assertInternalType('numeric', $actionScheduleDao->id);
     $this->assertCronRuns([
@@ -1771,6 +1775,7 @@ class CRM_Core_BAO_ActionScheduleTest extends CiviUnitTestCase {
     $this->_testObjects['CRM_Contact_DAO_Contact'][] = $contact['id'];
     $modifiedDate = $this->callAPISuccess('Contact', 'getvalue', ['id' => $contact['id'], 'return' => 'modified_date']);
     $actionSchedule = $this->fixtures['sched_contact_mod_anniv'];
+    $actionSchedule['created_date'] = date('Y-m-d H:i:s', strtotime($contact['values'][$contact['id']]['modified_date'] . '+3 years +1 day'));
     $actionScheduleDao = CRM_Core_BAO_ActionSchedule::add($actionSchedule);
     $this->assertInternalType('numeric', $actionScheduleDao->id);
     $this->assertCronRuns([
@@ -1835,6 +1840,7 @@ class CRM_Core_BAO_ActionScheduleTest extends CiviUnitTestCase {
 
     $actionSchedule = $this->fixtures['sched_membership_join_2week'];
     $actionSchedule['entity_value'] = $membership->membership_type_id;
+    $actionSchedule['created_date'] = '2012-03-28 01:00:00';
     $actionScheduleDao = CRM_Core_BAO_ActionSchedule::add($actionSchedule);
     $this->assertInternalType('numeric', $actionScheduleDao->id);
 
@@ -1898,6 +1904,8 @@ class CRM_Core_BAO_ActionScheduleTest extends CiviUnitTestCase {
     $actionScheduleBefore = $this->fixtures['sched_membership_end_2week'];
     // Send email on end_date/expiry date
     $actionScheduleOn = $this->fixtures['sched_on_membership_end_date'];
+    $actionScheduleOn['created_date'] = '2012-06-14 00:00:00';
+
     // Send email 1 day after end_date/grace period
     $actionScheduleAfter = $this->fixtures['sched_after_1day_membership_end_date'];
     $actionScheduleAfter['created_date'] = '2012-06-15 01:00:00';

--- a/tests/phpunit/Civi/ActionSchedule/AbstractMappingTest.php
+++ b/tests/phpunit/Civi/ActionSchedule/AbstractMappingTest.php
@@ -283,6 +283,8 @@ abstract class AbstractMappingTest extends \CiviUnitTestCase {
 
     $actualMessages = [];
     foreach ($this->cronTimes() as $time) {
+      $this->schedule->created_date = $time;
+      $this->schedule->save();
       \CRM_Utils_Time::setTime($time);
       $this->callAPISuccess('job', 'send_reminder', []);
       foreach ($this->mut->getAllMessages('ezc') as $message) {

--- a/tests/phpunit/api/v3/JobTest.php
+++ b/tests/phpunit/api/v3/JobTest.php
@@ -270,6 +270,7 @@ class api_v3_JobTest extends CiviUnitTestCase {
       'limit_to' => TRUE,
       'sms_provider_id' => $provider['id'],
       'mode' => 'User_Preference',
+      'created_date' => date('YmdHis', strtotime('-2 days')),
     ]);
     $this->callAPISuccess('job', 'send_reminder', []);
     $successfulCronCount = CRM_Core_DAO::singleValueQuery("SELECT count(*) FROM civicrm_action_log");
@@ -405,6 +406,7 @@ class api_v3_JobTest extends CiviUnitTestCase {
       'limit_to' => TRUE,
       'sms_provider_id' => $provider['id'],
       'mode' => 'SMS',
+      'created_date' => date('YmdHis', strtotime('-2 days')),
     ]);
     $this->callAPISuccess('SmsProvider', 'delete', ['id' => $provider['id']]);
     $this->callAPISuccess('job', 'send_reminder', []);


### PR DESCRIPTION
Technical Details
----------------------------------------
See https://lab.civicrm.org/dev/core/-/issues/365 for details on the Before situation.

After the PR is applied, "Reminder messages will not be sent for messages that should have already gone out before the Schedule Reminder was created." 

Here's the details how the new condition will act upon schedule reminders configured for supported entities:


1. Introduced civicrm_action_schedule.created_date timestamp column, set default to current datetime.
![aosl](https://user-images.githubusercontent.com/3735621/92146976-1a987600-ee38-11ea-834e-92fbe1a60677.gif)


2. Added upgrade code. I am not sure how to populate the created_date values for old reminders, on the upgrade as I am not sure when the reminders were configured in the system. But as per now, since created_date has a default set to current time, so after upgrade it will populate the created_date to the current time for existing reminders.


3. Use-cases:

Here's the details how the new condition will act upon schedule reminders configured for supported entities: 

1. Introduced ```civicrm_action_schedule.created_date``` timestamp column, set default to current datetime. 
2. Added upgrade code. I am not sure how to populate the created_date values for old reminders, on the upgrade as I am not sure when the reminders were configured in the system. 
3. Use-cases:
- Reminder for entity (say event) configured with a relative date send using "after": 
``` 
1.1 If a reminder is configured to send emails to participants 1 week after the event end_date (= 25th Aug) and the
 reminder was configured today (created_date = 2nd September) which would be 1 week 1day after the event
 end_date - reminders won't be sent out to the participants. 
```
```
1.2 If a reminder is configured to send emails to its participants  1 week after the event end_date (= 25th Aug) and 
the reminder was configured yesterday (created_date = 1st September) which would be exactly 1 week after the 
event end_date - reminders will be sent out to the participants. 
```
- A reminder for entity (say event) configured with a relative date send using "before": 
```
1.1 If a reminder is configured to send emails to participants 1 week before the event start_date (= 25th Aug) and 
the reminder was configured on more then a week from start_date, say created_date = 15th Aug which would be
 10days before the event start_date - reminders won't be sent out to the participants.
```
``` 
1.2 If a reminder is configured to send emails to its participants 1 week before the event start_date (= 25th Aug) and the reminder was configured more then a week ago from start_date, i.e. created_date = 12th Aug which 13days before the event start_date - reminders will be sent out to the participants.` - reminders will be sent out to the participants. 
```
- Reminder for entity (say event) configured with an absolute date: 
```
1.1 If a reminder is configured to send emails to its participants yesterday (created_date = 1st Sept), then it won't send out emails to participants. 
```
```
1.2. If a reminder is configured to send emails to its participants today or any future date (created_date >= 2nd Sept), then it will deliver reminders to participants.
```

These use-cases hold true not only for the event but also for other supported entities, and for evidence, I have made necessary changes in the existing unit-tests with respective configurations, written for other entities 

I have added unit-test to capture the 1st use-case [here](https://github.com/civicrm/civicrm-core/pull/18298/files#diff-92b4f21751272bb336a5899bb77fa672R2172-R2221) 


Comments
----------------------------------------
ping @Stoob @JoeMurray @MegaphoneJon @eileenmcnaughton 
