### PR TITLE
dev/core#1750: Replace Tokens In Activity Content for Sent Emails

### DIFF
--- a/templates/CRM/Contact/Form/Task/Email.hlp
+++ b/templates/CRM/Contact/Form/Task/Email.hlp
@@ -26,6 +26,15 @@
 {/if}
 {/htxt}
 
+{htxt id="id-to_email-title"}
+  {ts}To Address{/ts}
+{/htxt}
+{htxt id="id-to_email"}
+<p>{ts}Contacts in the "To" field will each receive one copy of this email, with any tokens respectively filled for their contact record.{/ts}</p>
+<p>{ts}"To" recipients will not see which other "To" recipients received an email, but they will see the list of "Cc" recipients.{/ts}</p>
+<p>{ts}Any contacts in the "Cc" or "Bcc" fields will receive a copy, one for each "To" email, but with the tokens filled for the "To" contact.{/ts}</p>
+{/htxt}
+
 {htxt id="id-token-subject-title"}
   {ts}Subject Tokens{/ts}
 {/htxt}

--- a/templates/CRM/Contact/Form/Task/Email.tpl
+++ b/templates/CRM/Contact/Form/Task/Email.tpl
@@ -23,7 +23,7 @@
     <tr class="crm-contactEmail-form-block-recipient">
        <td class="label">{if $single eq false}{ts}Recipient(s){/ts}{else}{$form.to.label}{/if}</td>
        <td>
-         {$form.to.html}
+         {$form.to.html} {help id="id-to_email" file="CRM/Contact/Form/Task/Email.hlp"}
        </td>
     </tr>
     <tr class="crm-contactEmail-form-block-cc_id" {if !$form.cc_id.value}style="display:none;"{/if}>

--- a/tests/phpunit/CRM/Activity/BAO/ActivityTest.php
+++ b/tests/phpunit/CRM/Activity/BAO/ActivityTest.php
@@ -1567,6 +1567,137 @@ $text
   }
 
   /**
+   * Checks that tokens are uniquely replaced for contacts.
+   */
+  public function testSendEmailWillReplaceTokensUniquelyForEachContact() {
+    $contactId1 = $this->individualCreate(['last_name' => 'Red']);
+    $contactId2 = $this->individualCreate(['last_name' => 'Pink']);
+
+    // create a logged in USER since the code references it for sendEmail user.
+    $this->createLoggedInUser();
+    $session = CRM_Core_Session::singleton();
+    $loggedInUser = $session->get('userID');
+    $contact = $this->callAPISuccess('Contact', 'get', ['sequential' => 1, 'id' => ['IN' => [$contactId1, $contactId2]]]);
+
+    // Create a campaign.
+    $result = $this->callAPISuccess('Campaign', 'create', [
+      'version' => $this->_apiversion,
+      'title' => __FUNCTION__ . ' campaign',
+    ]);
+    $campaign_id = $result['id'];
+
+    // Add contact tokens in subject, html , text.
+    $subject = __FUNCTION__ . ' subject' . '{contact.display_name}';
+    $html = __FUNCTION__ . ' html' . '{contact.display_name}';
+    $text = __FUNCTION__ . ' text' . '{contact.display_name}';
+    $userID = $loggedInUser;
+
+    CRM_Activity_BAO_Activity::sendEmail(
+      $contact['values'],
+      $subject,
+      $text,
+      $html,
+      $contact['values'][0]['email'],
+      $userID,
+      $from = __FUNCTION__ . '@example.com',
+      $attachments = NULL,
+      $cc = NULL,
+      $bcc = NULL,
+      $contactIds = array_column($contact['values'], 'id'),
+      $additionalDetails = NULL,
+      NULL,
+      $campaign_id
+    );
+    $result = $this->callAPISuccess('activity', 'get', ['campaign_id' => $campaign_id]);
+    // An activity created for each of the two contacts
+    $this->assertEquals(2, $result['count']);
+    $id = 0;
+    foreach ($result['values'] as $activity) {
+      $htmlValue = str_replace('{contact.display_name}', $contact['values'][$id]['display_name'], $html);
+      $textValue = str_replace('{contact.display_name}', $contact['values'][$id]['display_name'], $text);
+      $subjectValue = str_replace('{contact.display_name}', $contact['values'][$id]['display_name'], $subject);
+      $details = "-ALTERNATIVE ITEM 0-
+$htmlValue
+-ALTERNATIVE ITEM 1-
+$textValue
+-ALTERNATIVE END-
+";
+      $this->assertEquals($activity['details'], $details, 'Activity details does not match.');
+      $this->assertEquals($activity['subject'], $subjectValue, 'Activity subject does not match.');
+      $id++;
+    }
+  }
+
+  /**
+   * Checks that attachments are not duplicated for activities.
+   */
+  public function testSendEmailDoesNotDuplicateAttachmentFileIdsForActivitiesCreated() {
+    $contactId1 = $this->individualCreate(['last_name' => 'Red']);
+    $contactId2 = $this->individualCreate(['last_name' => 'Pink']);
+
+    // create a logged in USER since the code references it for sendEmail user.
+    $this->createLoggedInUser();
+    $session = CRM_Core_Session::singleton();
+    $loggedInUser = $session->get('userID');
+    $contact = $this->callAPISuccess('Contact', 'get', ['sequential' => 1, 'id' => ['IN' => [$contactId1, $contactId2]]]);
+
+    // Create a campaign.
+    $result = $this->callAPISuccess('Campaign', 'create', [
+      'version' => $this->_apiversion,
+      'title' => __FUNCTION__ . ' campaign',
+    ]);
+    $campaign_id = $result['id'];
+
+    $subject = __FUNCTION__ . ' subject';
+    $html = __FUNCTION__ . ' html';
+    $text = __FUNCTION__ . ' text';
+    $userID = $loggedInUser;
+
+    $filepath = Civi::paths()->getPath('[civicrm.files]/custom');
+    $fileName = "test_email_create.txt";
+    $fileUri = "{$filepath}/{$fileName}";
+    // Create a file.
+    CRM_Utils_File::createFakeFile($filepath, 'Bananas do not bend themselves without a little help.', $fileName);
+    $attachments = [
+      'attachFile_1' =>
+        [
+          'uri' => $fileUri,
+          'type' => 'text/plain',
+          'location' => $fileUri,
+        ],
+    ];
+
+    CRM_Activity_BAO_Activity::sendEmail(
+      $contact['values'],
+      $subject,
+      $text,
+      $html,
+      $contact['values'][0]['email'],
+      $userID,
+      $from = __FUNCTION__ . '@example.com',
+      $attachments,
+      $cc = NULL,
+      $bcc = NULL,
+      $contactIds = array_column($contact['values'], 'id'),
+      $additionalDetails = NULL,
+      NULL,
+      $campaign_id
+    );
+    $result = $this->callAPISuccess('activity', 'get', ['campaign_id' => $campaign_id]);
+    // An activity created for each of the two contacts, i.e two activities.
+    $this->assertEquals(2, $result['count']);
+    $activityIds = array_column($result['values'], 'id');
+    $result = $this->callAPISuccess('Activity', 'get', [
+      'return' => ['file_id'],
+      'id' => ['IN' => $activityIds],
+      'sequential' => 1,
+    ]);
+
+    // Verify that the that both activities are linked to the same File Id.
+    $this->assertEquals($result['values'][0]['file_id'], $result['values'][1]['file_id']);
+  }
+
+  /**
    * Adds a case with one activity.
    *
    */


### PR DESCRIPTION
Overview
----------------------------------------
When an email is sent via the email activity form, any used tokens aren’t replaced in the resultant stored body of the content in the activity.

See also: https://lab.civicrm.org/dev/core/-/issues/1750

Before
----------------------------------------
The issue described above exists.
- The email activity is created before the token replacements is done here: https://github.com/civicrm/civicrm-core/blob/master/CRM/Activity/BAO/Activity.php#L1128
- Token replacements are done here: https://github.com/civicrm/civicrm-core/blob/master/CRM/Activity/BAO/Activity.php#L1193-L1216


After
----------------------------------------
Used tokens in the emails are now properly replaced and the actual content displayed in the email activity.
- The activity creation is moved to before the email is sent, after token replacements.
- The changes in the PR makes a switch from combined to multiple policy when creating Email activities. i.e now a separate activity is created for each email sent to a contact.  
- To minimise storage requirements, only one copy of any file attachments uploaded to CiviCRM is kept, even when multiple contacts will receive separate emails from CiviCRM.
- Any contacts in the "CC" or "BCC" fields will receive a copy of each original email, but with the tokens filled for the "To" contact.
- A help text message is added in the `To` contact selection box with message : `
Contacts in the "To" field will all receive a separate copy of this communication, with any tokens respectively filled for their contact record. To minimise storage requirements, only one copy of any file attachments uploaded to CiviCRM is kept, even when multiple contacts will receive separate emails from CiviCRM. Any contacts in the "CC" or "BCC" fields will receive a copy of each original email, but with the tokens filled for the "To" contact.`

<img width="1274" alt="New Email  civicase-core 2020-08-31 13-52-47" src="https://user-images.githubusercontent.com/6951813/91721869-5a89ff80-eb91-11ea-8113-e846917ebca7.png">


Technical Details
----------------------------------------
- When the email to be sent has attachments, after the first activity is created, the file Ids for the attachments is stored in an array so that these file Id's can be passed in when creating other activities for other contacts/recipients, passing the file Id's will prevent new file entries from being created and the file entries created will for the first activity will be re-used for all the activities. 
A new `getAttachmentFileIds` function was created in the Activity BAO to get the file Id's for attachments created for the first activity.
