### PR TITLE
Clean money for non-deductible amount

### DIFF
--- a/api/v3/Contribution.php
+++ b/api/v3/Contribution.php
@@ -32,7 +32,7 @@ function civicrm_api3_contribution_create($params) {
   // The BAO should not clean money - it should be done in the form layer & api wrapper
   // (although arguably the api should expect pre-cleaned it seems to do some cleaning.)
   if (empty($params['skipCleanMoney'])) {
-    foreach (['total_amount', 'net_amount', 'fee_amount'] as $field) {
+    foreach (['total_amount', 'net_amount', 'fee_amount', 'non_deductible_amount'] as $field) {
       if (isset($params[$field])) {
         $params[$field] = CRM_Utils_Rule::cleanMoney($params[$field]);
       }

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -4948,4 +4948,26 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
     $this->assertEquals('Completed', $contribution['contribution_status']);
   }
 
+  /**
+   * Test the "clean money" functionality.
+   */
+  public function testCleanMoney() {
+    $params = [
+      'contact_id' => $this->_individualId,
+      'financial_type_id' => 1,
+      'total_amount' => '$100',
+      'fee_amount' => '$20',
+      'net_amount' => '$80',
+      'non_deductible_amount' => '$80',
+      'sequential' => 1,
+    ];
+    $id = $this->callAPISuccess('Contribution', 'create', $params)['id'];
+    // Reading the return values of the API isn't reliable here; get the data from the db.
+    $contribution = $this->callAPISuccess('Contribution', 'getsingle', ['id' => $id]);
+    $this->assertEquals('100.00', $contribution['total_amount']);
+    $this->assertEquals('20.00', $contribution['fee_amount']);
+    $this->assertEquals('80.00', $contribution['net_amount']);
+    $this->assertEquals('80.00', $contribution['non_deductible_amount']);
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
The Contribution API cleans money inputs for 3 of the 4 money fields.  This corrects the inconsistency and adds tests for all four.

Before
----------------------------------------
"Non-deductible amount" treated differently than "fee amount", "net amount", and "total amount".

After
----------------------------------------
Consistent treatment.

Comments
----------------------------------------
The easiest way to replicate this is with the command line:

```shell
cv api Contribution.create total_amount=\$10 fee_amount=\$5 non_deductible_amount=\$4 financial_type_id=1 contact_id=1
```
Be sure to read the data back out again rather than relying on the output of the command above, which isn't definitive!