### PR TITLE
dev/core#1982 - 5.29 version of PR 18282

### DIFF
--- a/CRM/Case/XMLProcessor/Process.php
+++ b/CRM/Case/XMLProcessor/Process.php
@@ -85,7 +85,13 @@ class CRM_Case_XMLProcessor_Process extends CRM_Case_XMLProcessor {
       // create relationships for the ones that are required
       foreach ($xml->CaseRoles as $caseRoleXML) {
         foreach ($caseRoleXML->RelationshipType as $relationshipTypeXML) {
-          if ($relationshipTypeXML->creator) {
+          // simplexml treats node values differently than you'd expect,
+          // e.g. as an array
+          // Just using `if ($relationshipTypeXML->creator)` ends up always
+          // being true, so you have to cast to int or somehow force evaluation
+          // of the actual value. And casting to (bool) seems to behave
+          // differently on these objects than casting to (int).
+          if (!empty($relationshipTypeXML->creator)) {
             if (!$this->createRelationships($relationshipTypeXML,
               $params
             )
@@ -105,7 +111,7 @@ class CRM_Case_XMLProcessor_Process extends CRM_Case_XMLProcessor {
     foreach ($xml->ActivitySets as $activitySetsXML) {
       foreach ($activitySetsXML->ActivitySet as $activitySetXML) {
         if ($standardTimeline) {
-          if ($activitySetXML->timeline) {
+          if (!empty($activitySetXML->timeline)) {
             return $this->processStandardTimeline($activitySetXML, $params);
           }
         }

--- a/tests/phpunit/api/v3/CaseTest.php
+++ b/tests/phpunit/api/v3/CaseTest.php
@@ -666,6 +666,48 @@ class api_v3_CaseTest extends CiviCaseTestCase {
     $this->assertTrue($foundManager);
   }
 
+  /**
+   * Test that case role is not assigned to logged in user if you've unchecked
+   * the assign to creator in the case type definition.
+   */
+  public function testCaseGetWithRolesNoCreator() {
+    // Copy and adjust stock case type so that assign role to creator is not checked
+    $caseType = $this->callAPISuccess('CaseType', 'get', ['id' => $this->caseTypeId]);
+    $newCaseType = $caseType['values'][$this->caseTypeId];
+    // Sanity check that we're changing what we think we're changing.
+    $this->assertEquals('Homeless Services Coordinator', $newCaseType['definition']['caseRoles'][0]['name']);
+    // string '0' to match what actually happens when you do it in UI
+    $newCaseType['definition']['caseRoles'][0]['creator'] = '0';
+    unset($newCaseType['id']);
+    $newCaseType['name'] = 'tree_climbing';
+    $newCaseType['title'] = 'Tree Climbing';
+    $newCaseType = $this->callAPISuccess('CaseType', 'create', $newCaseType);
+
+    $case1 = $this->callAPISuccess('Case', 'create', [
+      'contact_id' => 17,
+      'subject' => "Test case with roles no creator",
+      'case_type_id' => $newCaseType['id'],
+      'status_id' => "Open",
+    ]);
+    $result = $this->callAPISuccessGetSingle('Case', [
+      'id' => $case1['id'],
+      'status_id' => "Open",
+      'return' => ['contacts'],
+    ]);
+
+    // There should only be the client role.
+    $this->assertCount(1, $result['contacts']);
+    $contact = $result['contacts'][0];
+    $this->assertEquals('Client', $contact['role']);
+    // For good measure
+    $this->assertNotEquals(1, $contact['creator'] ?? NULL);
+    $this->assertNotEquals(1, $contact['manager'] ?? NULL);
+
+    // clean up
+    $this->callAPISuccess('Case', 'create', ['id' => $case1['id'], 'case_type_id' => $this->caseTypeId]);
+    $this->callAPISuccess('CaseType', 'delete', ['id' => $newCaseType['id']]);
+  }
+
   public function testCaseGetWithDefinition() {
     $case1 = $this->callAPISuccess('Case', 'create', [
       'contact_id' => 17,


### PR DESCRIPTION
Overview
----------------------------------------
5.29 version of https://github.com/civicrm/civicrm-core/pull/18282 from @lcdservices 

Case role shouldn't assign to creator if uncheck creator in the config.

Technical Details
----------------------------------------
SimpleXML node values don't behave the same as regular variables.

Comments
----------------------------------------
Also updated the other line that had the same flaw from https://github.com/civicrm/civicrm-core/pull/17012. To trigger that you'd have to have an unusual xml configuration via files or api, and in fact the original cast to bool would also have been wrong so it was probably always wrong.

Has test (5.29 version of https://github.com/civicrm/civicrm-core/pull/18287)
