### PR TITLE
dev/core#1974: correct UI regression on custom field edit

### DIFF
--- a/templates/CRM/Custom/Form/Field.tpl
+++ b/templates/CRM/Custom/Form/Field.tpl
@@ -21,6 +21,9 @@
     <tr class="crm-custom-field-form-block-data_type">
       <td class="label">{$form.data_type.label}</td>
       <td class="html-adjust">{$form.data_type.html}
+        {if $action neq 1 && $form.data_type.value[1][0] eq "Select" && $form.serialize.value}
+          <span>({ts}Multi-Select{/ts})</span>
+        {/if}
         {if $action neq 4 and $action neq 2}
           <br /><span class="description">{ts}Select the type of data you want to collect and store for this contact. Then select from the available HTML input field types (choices are based on the type of data being collected).{/ts}</span>
         {/if}
@@ -34,10 +37,12 @@
         {/if}
       </td>
     </tr>
-    <tr class="crm-custom-field-form-block-serialize">
-      <td class="label">{$form.serialize.label}</td>
-      <td class="html-adjust">{$form.serialize.html}</td>
-    </tr>
+    {if $action eq 1}
+      <tr class="crm-custom-field-form-block-serialize">
+        <td class="label">{$form.serialize.label}</td>
+        <td class="html-adjust">{$form.serialize.html}</td>
+      </tr>
+    {/if}
     {if $form.in_selector}
       <tr class='crm-custom-field-form-block-in_selector'>
         <td class='label'>{$form.in_selector.label}</td>


### PR DESCRIPTION
Overview
----------------------------------------
Corrects the UI issue on the Custom Field edit form mentioned in https://lab.civicrm.org/dev/core/-/issues/1974

Before
----------------------------------------
When editing an existing Multi-Select field, the form showed the type as "Select" in a frozen element and, lower down on the form, offered a "Multi-Select" checkbox which could be unchecked, but doing so had no effect. The user might think they had changed the field from multi-select to select, but the change was not saved.

After
----------------------------------------
The form shows the type as "Select (Multi-Select)" in a static element. The user can still change the field type by using the "Change Input Field Type" link.

That's in Edit mode. In Create mode, the "Multi-Select" checkbox makes sense, so we keep it appearing (and working) as before.

Notes
----------------------------------------
"Select (Multi-Select)" is a bit awkward. I'd prefer just "Multi-Select" but this solution keeps the code changes to a minimum.