### PR TITLE
dev/core#1979 - Incorrect comparison of status_id when changing status of linked cases

### DIFF
--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -1890,6 +1890,7 @@ HERESQL;
         'case_id' => $dao->id,
         'case_type' => $dao->case_type,
         'client_name' => $clientView,
+        'status_id' => $dao->status_id,
         'case_status' => $statuses[$dao->status_id],
         'links' => $caseView,
       ];


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/1979

1. Create a case.
2. Create another case.
3. Create a link cases activity and link them.
4. Create a change case status activity and check the box to update related cases.
5. Click save.

It ends up working anyway and updating the other case but it's not comparing 'status_id' properly because the field available is actually a label called 'case_status', and you get an E_NOTICE telling you that: `Undefined index: status_id in CRM_Case_Form_Activity_ChangeCaseStatus::beginPostProcess() (line 137 of .../CRM/Case/Form/Activity/ChangeCaseStatus.php)`.

Technical Details
----------------------------------------
It works because it ends up updating cases it doesn't need to update by changing them to the same as they already are. The other option was to just remove the `if` and let it continue to update those.
https://github.com/civicrm/civicrm-core/blob/a841215a2ec1d98dcafd5844358c2692e2516750/CRM/Case/Form/Activity/ChangeCaseStatus.php#L137

Comments
----------------------------------------
Has test
