### PR TITLE
dev/core#1974 - ChangeFieldType - "Select (w/serialize)" field should be treated like older "Multi-Select" fields

### DIFF
--- a/CRM/Custom/Form/ChangeFieldType.php
+++ b/CRM/Custom/Form/ChangeFieldType.php
@@ -56,6 +56,9 @@ class CRM_Custom_Form_ChangeFieldType extends CRM_Core_Form {
     $params = ['id' => $this->_id];
     CRM_Core_BAO_CustomField::retrieve($params, $this->_values);
 
+    if ($this->_values['html_type'] == 'Select' && $this->_values['serialize']) {
+      $this->_values['html_type'] = 'Multi-Select';
+    }
     $this->_htmlTypeTransitions = self::fieldTypeTransitions(CRM_Utils_Array::value('data_type', $this->_values),
       CRM_Utils_Array::value('html_type', $this->_values)
     );


### PR DESCRIPTION
Overview
----------------------------------------
Backport of #18272 from 5.29-rc to 5.28-stable.

Note that the first commit was already included in a bulk-backport. This is the just second commit which didn't make it to the larger backport list.