### PR TITLE
completeOrder cleanup

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2833,10 +2833,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
       $this->find(TRUE);
     }
 
-    $paymentProcessorID = CRM_Utils_Array::value('payment_processor_id', $input, CRM_Utils_Array::value(
-      'paymentProcessor',
-      $ids
-    ));
+    $paymentProcessorID = $input['payment_processor_id'] ?? $ids['paymentProcessor'] ?? NULL;
 
     if (!isset($input['payment_processor_id']) && !$paymentProcessorID && $this->contribution_page_id) {
       $paymentProcessorID = CRM_Core_DAO::getFieldValue('CRM_Contribute_DAO_ContributionPage',

--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4380,6 +4380,8 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
    */
   public static function completeOrder($input, $ids, $objects, $isPostPaymentCreate = FALSE) {
     $transaction = new CRM_Core_Transaction();
+    // @todo $objects in use in this function are contribution,contributionRecur,participant,event
+    //   We should look them up directly here if needed so we can remove use of upstream loadObjects/loadRelatedObjects functions
     $contribution = $objects['contribution'];
     // @todo see if we even need this - it's used further down to create an activity
     // but the BAO layer should create that - we just need to add a test to cover it & can
@@ -4431,7 +4433,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
     ], array_intersect_key($input, array_fill_keys($inputContributionWhiteList, 1)
     ));
 
-    $contributionParams['payment_processor'] = $paymentProcessorId;
+    $contributionParams['payment_processor'] = $input['payment_processor_id'] ?? NULL;
 
     if (empty($contributionParams['payment_instrument_id']) && isset($contribution->_relatedObjects['paymentProcessor']['payment_instrument_id'])) {
       $contributionParams['payment_instrument_id'] = PaymentProcessor::get(FALSE)->addWhere('id', '=', $paymentProcessorId)->addSelect('payment_instrument_id')->execute()->first()['payment_instrument_id'];

--- a/CRM/Core/Payment/BaseIPN.php
+++ b/CRM/Core/Payment/BaseIPN.php
@@ -423,6 +423,7 @@ class CRM_Core_Payment_BaseIPN {
    */
   public function completeTransaction($input, $ids, $objects) {
     CRM_Core_Error::deprecatedFunctionWarning('Use Payment.create api');
+
     CRM_Contribute_BAO_Contribution::completeOrder($input, [
       'related_contact' => $ids['related_contact'] ?? NULL,
       'participant' => !empty($objects['participant']) ? $objects['participant']->id : NULL,

--- a/CRM/Event/Form/Task/Batch.php
+++ b/CRM/Event/Form/Task/Batch.php
@@ -383,6 +383,19 @@ class CRM_Event_Form_Task_Batch extends CRM_Event_Form_Task {
       $input['net_amount'] = $input['amount'] - $input['fee_amount'];
     }
 
+    // @fixme This allows us to stop using $objects['paymentProcessor'] in completeOrder by passing in $input['payment_processor_id'] instead.
+    // Further checking is needed to see if validateData ever sets $objects['paymentProcessor'] in this case.
+    if (!isset($input['payment_processor_id'])) {
+      if (isset($objects['paymentProcessor'])) {
+        if (is_array($objects['paymentProcessor'])) {
+          $input['payment_processor_id'] = $objects['paymentProcessor']['id'];
+        }
+        else {
+          $input['payment_processor_id'] = $objects['paymentProcessor']->id;
+        }
+      }
+    }
+
     //complete the contribution.
     // @todo use the api - ie civicrm_api3('Contribution', 'completetransaction', $input);
     // as this method is not preferred / supported.

--- a/api/v3/Contribution.php
+++ b/api/v3/Contribution.php
@@ -604,27 +604,23 @@ function civicrm_api3_contribution_repeattransaction($params) {
     'return' => 'payment_processor_id',
     'id' => $contribution->contribution_recur_id,
   ]);
-  try {
-    unset($contribution->id, $contribution->receive_date, $contribution->invoice_id);
-    $contribution->receive_date = $params['receive_date'];
 
-    $passThroughParams = [
-      'trxn_id',
-      'total_amount',
-      'campaign_id',
-      'fee_amount',
-      'financial_type_id',
-      'contribution_status_id',
-      'membership_id',
-      'payment_processor_id',
-    ];
-    $input = array_intersect_key($params, array_fill_keys($passThroughParams, NULL));
+  unset($contribution->id, $contribution->receive_date, $contribution->invoice_id);
+  $contribution->receive_date = $params['receive_date'];
 
-    return _ipn_process_transaction($params, $contribution, $input);
-  }
-  catch (Exception $e) {
-    throw new API_Exception($e->getMessage() . "\n" . $e->getTraceAsString());
-  }
+  $passThroughParams = [
+    'trxn_id',
+    'total_amount',
+    'campaign_id',
+    'fee_amount',
+    'financial_type_id',
+    'contribution_status_id',
+    'membership_id',
+    'payment_processor_id',
+  ];
+  $input = array_intersect_key($params, array_fill_keys($passThroughParams, NULL));
+
+  return _ipn_process_transaction($params, $contribution, $input);
 }
 
 /**

--- a/api/v3/Contribution.php
+++ b/api/v3/Contribution.php
@@ -643,7 +643,7 @@ function civicrm_api3_contribution_repeattransaction($params) {
  */
 function _ipn_process_transaction($params, $contribution, $input) {
   $ids = [];
-  if (!$contribution->loadRelatedObjects($input, $ids, TRUE)) {
+  if (!$contribution->loadRelatedObjects(['payment_processor_id' => $input['payment_processor_id']], $ids, TRUE)) {
     throw new API_Exception('failed to load related objects');
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Further cleanup to completeOrder and ipn_process_transaction. Includes #18311 and additional commits to be split into separate PRs. Each commit is an additional cleanup step aimed at simplifying the code and eventually removing `loadRelatedObjects()` and `_ipn_process_transaction()` altogether.

Before
----------------------------------------

After
----------------------------------------

Technical Details
----------------------------------------

Comments
----------------------------------------
@eileenmcnaughton I find it easier to do a few steps at once :-) Will see if tests pass and add them as separate PRs - they are designed to be sequentially applied.
