### PR TITLE
[REF] Remove most interaction with $objects in completeOrder

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4449,7 +4449,10 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
     // @todo see if we even need this - it's used further down to create an activity
     // but the BAO layer should create that - we just need to add a test to cover it & can
     // maybe remove $ids altogether.
-    $contributionContactID = $ids['related_contact'] ?? NULL;
+    $contributionContactID = $ids['related_contact'];
+    $participantID = $ids['participant'];
+    $recurringContributionID = $ids['contributionRecur'];
+
     // Unset ids just to make it clear it's not used again.
     unset($ids);
     // The previous details are used when calculating line items so keep it before any code that 'does something'
@@ -4472,9 +4475,6 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
       'financial_type_id',
     ];
 
-    $participant = $objects['participant'] ?? NULL;
-    $recurContrib = $objects['contributionRecur'] ?? NULL;
-    $recurringContributionID = (empty($recurContrib->id)) ? NULL : $recurContrib->id;
     $event = $objects['event'] ?? NULL;
 
     $paymentProcessorId = '';
@@ -4520,7 +4520,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
     }
     else {
       if (empty($input['IAmAHorribleNastyBeyondExcusableHackInTheCRMEventFORMTaskClassThatNeedsToBERemoved'])) {
-        $participantParams['id'] = $participant->id;
+        $participantParams['id'] = $participantID;
         $participantParams['status_id'] = 'Registered';
         civicrm_api3('Participant', 'create', $participantParams);
       }

--- a/CRM/Core/Payment/BaseIPN.php
+++ b/CRM/Core/Payment/BaseIPN.php
@@ -468,7 +468,11 @@ class CRM_Core_Payment_BaseIPN {
    * @throws \CiviCRM_API3_Exception
    */
   public function completeTransaction($input, $ids, $objects) {
-    CRM_Contribute_BAO_Contribution::completeOrder($input, $ids, $objects);
+    CRM_Contribute_BAO_Contribution::completeOrder($input, [
+      'related_contact' => $ids['related_contact'] ?? NULL,
+      'participant' => !empty($objects['participant']) ? $objects['participant']->id : NULL,
+      'contributionRecur' => !empty($objects['contributionRecur']) ? $objects['contributionRecur']->id : NULL,
+    ], $objects);
   }
 
   /**

--- a/CRM/Event/Form/Task/Batch.php
+++ b/CRM/Event/Form/Task/Batch.php
@@ -417,7 +417,11 @@ class CRM_Event_Form_Task_Batch extends CRM_Event_Form_Task {
     //complete the contribution.
     // @todo use the api - ie civicrm_api3('Contribution', 'completetransaction', $input);
     // as this method is not preferred / supported.
-    CRM_Contribute_BAO_Contribution::completeOrder($input, $ids, $objects);
+    CRM_Contribute_BAO_Contribution::completeOrder($input, [
+      'related_contact' => $ids['related_contact'] ?? NULL,
+      'participant' => !empty($objects['participant']) ? $objects['participant']->id : NULL,
+      'contributionRecur' => NULL,
+    ], $objects);
 
     // reset template values before processing next transactions
     $template->clearTemplateVars();

--- a/api/v3/Contribution.php
+++ b/api/v3/Contribution.php
@@ -681,7 +681,11 @@ function _ipn_process_transaction(&$params, $contribution, $input, $ids, $firstC
   if (!empty($params['payment_instrument_id'])) {
     $input['payment_instrument_id'] = $params['payment_instrument_id'];
   }
-  return CRM_Contribute_BAO_Contribution::completeOrder($input, $ids, $objects,
+  return CRM_Contribute_BAO_Contribution::completeOrder($input, [
+    'related_contact' => $ids['related_contact'] ?? NULL,
+    'participant' => !empty($objects['participant']) ? $objects['participant']->id : NULL,
+    'contributionRecur' => !empty($objects['contributionRecur']) ? $objects['contributionRecur']->id : NULL,
+  ], $objects,
     $params['is_post_payment_create'] ?? NULL);
 }
 


### PR DESCRIPTION

Overview
----------------------------------------
Towards removing $objects as a parameter for completeOrder

Before
----------------------------------------
Objects needs to be populated with objects, just to get the ids

After
----------------------------------------
We pass in the ids

Technical Details
----------------------------------------
With this change we are only looking up
1) objects['paymentProcessor'] - we should probably just pass in the id
2) objects['contribution'] - we could make this a param in it's own right & remove objects
3) objects['event'] - just used to get event title - we could do a query off participant

Comments
----------------------------------------

