### PR TITLE
Add postAssert to check payments and contributions are valid on all tests.

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -1993,7 +1993,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
       if (!empty($params['payment_processor_id'])) {
         $params['is_pay_later'] = 0;
       }
-      elseif ($params['amount'] !== 0) {
+      elseif (($params['amount'] ?? 0) !== 0) {
         $params['is_pay_later'] = civicrm_api3('contribution_page', 'getvalue', [
           'id' => $id,
           'return' => 'is_pay_later',

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -135,6 +135,16 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
   protected $ids = [];
 
   /**
+   * Should financials be checked after the test but before tear down.
+   *
+   * Ideally all tests (or at least all that call any financial api calls ) should do this but there
+   * are some test data issues and some real bugs currently blockinng.
+   *
+   * @var bool
+   */
+  protected $isValidateFinancialsOnPostAssert = FALSE;
+
+  /**
    * Class used for hooks during tests.
    *
    * This can be used to test hooks within tests. For example in the ACL_PermissionTrait:
@@ -477,6 +487,19 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
     $this->unsetExtensionSystem();
     $this->assertEquals([], CRM_Core_DAO::$_nullArray);
     $this->assertEquals(NULL, CRM_Core_DAO::$_nullObject);
+  }
+
+  /**
+   * CHeck that all tests that have created payments have created them with the right financial entities.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  protected function assertPostConditions() {
+    if (!$this->isValidateFinancialsOnPostAssert) {
+      return;
+    }
+    $this->validateAllPayments();
+    $this->validateAllContributions();
   }
 
   /**

--- a/tests/phpunit/api/v3/ACLPermissionTest.php
+++ b/tests/phpunit/api/v3/ACLPermissionTest.php
@@ -51,6 +51,7 @@ class api_v3_ACLPermissionTest extends CiviUnitTestCase {
       'civicrm_acl_entity_role',
       'civicrm_acl_contact_cache',
       'civicrm_contribution',
+      'civicrm_line_item',
       'civicrm_participant',
       'civicrm_uf_match',
       'civicrm_activity',


### PR DESCRIPTION
Overview
----------------------------------------
Add postAssert to validate the payments, line items and tax created by tests. Use opt in class property to allow us to turn on selectively as there are lots of tests that won't yet pass with this.


Before
----------------------------------------
No systematic way to check we are not creating invalid financial entities

After
----------------------------------------
use postAssert to check before tearDown

Technical Details
----------------------------------------
Eventually we might like to put something in the tests such that if a contribution is created the property is set? Or maybe it's quick enough to do on all tests when it passes for all

Comments
----------------------------------------
The first commit is in https://github.com/civicrm/civicrm-core/pull/18348 so I will rebase once that is merged