### PR TITLE
[REF] Add test for existing Participant batch update cancel and fix to not call BaseIPN->cancelled

### DIFF
--- a/CRM/Core/Payment/BaseIPN.php
+++ b/CRM/Core/Payment/BaseIPN.php
@@ -324,19 +324,18 @@ class CRM_Core_Payment_BaseIPN {
       CRM_Contribute_BAO_ContributionRecur::copyCustomValues($objects['contributionRecur']->id, $contribution->id);
     }
 
-    if (empty($input['IAmAHorribleNastyBeyondExcusableHackInTheCRMEventFORMTaskClassThatNeedsToBERemoved'])) {
-      if (!empty($memberships)) {
-        foreach ($memberships as $membership) {
-          if ($membership) {
-            $this->cancelMembership($membership, $membership->status_id);
-          }
+    if (!empty($memberships)) {
+      foreach ($memberships as $membership) {
+        if ($membership) {
+          $this->cancelMembership($membership, $membership->status_id);
         }
       }
-
-      if ($participant) {
-        $this->cancelParticipant($participant->id);
-      }
     }
+
+    if ($participant) {
+      $this->cancelParticipant($participant->id);
+    }
+
     if ($transaction) {
       $transaction->commit();
     }

--- a/CRM/Event/Form/Task/Batch.php
+++ b/CRM/Event/Form/Task/Batch.php
@@ -285,7 +285,8 @@ class CRM_Event_Form_Task_Batch extends CRM_Event_Form_Task {
       $contributionStatusId = array_search('Completed', $contributionStatuses);
     }
     if (array_key_exists($statusId, $negativeStatuses)) {
-      $contributionStatusId = array_search('Cancelled', $contributionStatuses);
+      civicrm_api3('Contribution', 'create', ['id' => $contributionId, 'contribution_status_id' => 'Cancelled']);
+      return;
     }
 
     if (!$contributionStatusId || !$participantId || !$contributionId) {
@@ -374,12 +375,6 @@ class CRM_Event_Form_Task_Batch extends CRM_Event_Form_Task {
       'flip' => 1,
     ]);
     $input['IAmAHorribleNastyBeyondExcusableHackInTheCRMEventFORMTaskClassThatNeedsToBERemoved'] = $params['IAmAHorribleNastyBeyondExcusableHackInTheCRMEventFORMTaskClassThatNeedsToBERemoved'] ?? NULL;
-    if ($statusId == $contributionStatuses['Cancelled']) {
-      $transaction = new CRM_Core_Transaction();
-      $baseIPN->cancelled($objects, $transaction, $input);
-      $transaction->commit();
-      return;
-    }
     if ($statusId == $contributionStatuses['Failed']) {
       $transaction = new CRM_Core_Transaction();
       $baseIPN->failed($objects, $transaction, $input);

--- a/tests/phpunit/CRM/Event/Form/Task/BatchTest.php
+++ b/tests/phpunit/CRM/Event/Form/Task/BatchTest.php
@@ -7,24 +7,44 @@
  * @group headless
  */
 class CRM_Event_Form_Task_BatchTest extends CiviUnitTestCase {
+  use CRMTraits_Financial_OrderTrait;
 
   /**
    * Test the the submit function on the event participant submit function.
-   *
-   * @todo extract submit functions on other Batch update classes, use dataprovider to test on all.
    */
   public function testSubmit() {
-    $group = $this->CustomGroupCreate(['extends' => 'Participant', 'title' => 'Participant']);
+    $group = $this->customGroupCreate(['extends' => 'Participant', 'title' => 'Participant']);
     $field = $this->customFieldCreate(['custom_group_id' => $group['id'], 'html_type' => 'CheckBox', 'option_values' => ['two' => 'A couple', 'three' => 'A few', 'four' => 'Too Many']]);
     $participantID = $this->participantCreate();
     $participant = $this->callAPISuccessGetSingle('Participant', ['id' => $participantID]);
     $this->assertEquals(2, $participant['participant_status_id']);
 
+    /* @var CRM_Event_Form_Task_Batch $form */
     $form = $this->getFormObject('CRM_Event_Form_Task_Batch');
     $form->submit(['field' => [$participantID => ['participant_status_id' => 1, 'custom_' . $field['id'] => ['two' => 1, 'four' => 1]]]]);
 
     $participant = $this->callAPISuccessGetSingle('Participant', ['id' => $participantID]);
     $this->assertEquals(1, $participant['participant_status_id']);
+  }
+
+  /**
+   * Test the the submit function on the event participant submit function.
+   *
+   * Test is to establish existing behaviour prior to code cleanup. It turns out the existing
+   * code ONLY cancels the contribution as well as the participant record if is_pay_later is true
+   * AND the source is 'Online Event Registration'.
+   */
+  public function testSubmitCancel() {
+    $this->createEventOrder(['source' => 'Online Event Registration', 'is_pay_later' => 1]);
+    $participantCancelledStatusID = CRM_Core_PseudoConstant::getKey('CRM_Event_BAO_Participant', 'status_id', 'Cancelled');
+
+    /* @var CRM_Event_Form_Task_Batch $form */
+    $form = $this->getFormObject('CRM_Event_Form_Task_Batch');
+    $form->submit(['field' => [$this->ids['Participant'][0] => ['participant_status' => $participantCancelledStatusID]]]);
+
+    $participant = $this->callAPISuccessGetSingle('Participant', ['id' => $this->ids['Participant'][0]]);
+    $this->assertEquals($participantCancelledStatusID, $participant['participant_status_id']);
+    $this->callAPISuccessGetSingle('Contribution', ['id' => $this->ids['Contribution'][0], 'contribution_status_id' => 'Cancelled']);
   }
 
 }

--- a/tests/phpunit/CRMTraits/Financial/OrderTrait.php
+++ b/tests/phpunit/CRMTraits/Financial/OrderTrait.php
@@ -163,6 +163,18 @@ trait CRMTraits_Financial_OrderTrait {
   }
 
   /**
+   * Create an order for an event.
+   *
+   * @param array $orderParams
+   *
+   * @throws \CRM_Core_Exception
+   */
+  protected function createEventOrder($orderParams = []) {
+    $this->ids['Contribution'][0] = $this->callAPISuccess('Order', 'create', array_merge($this->getParticipantOrderParams(), $orderParams))['id'];
+    $this->ids['Participant'][0] = $this->callAPISuccessGetValue('ParticipantPayment', ['return' => 'participant_id', 'contribution_id' => $this->ids['Contribution'][0]]);
+  }
+
+  /**
    * Create an extraneous contribution to throw off any 'number one bugs'.
    *
    * Ie this means our real data starts from 2 & we won't hit 'pretend passes'


### PR DESCRIPTION
Overview
----------------------------------------
Minor cleanup to avoid complicated calling a complicated function when a simple one will do

Before
----------------------------------------
```
$baseIPN->cancelled($objects, $transaction, $input);
```

After
----------------------------------------
```
civicrm_api3('Contribution', 'create', ['id' => $contributionId, 'contribution_status_id' => 'Cancelled']);
```

Technical Details
----------------------------------------
I dug into what is 'achieved' by calling BaseIPN->cancelled here and everything except the bit where the contribution
is updated to cancelled is actually bypassed so a simple api call suffices.

I also discovered the cancellation of the contribution is highly conditional and arguably illogical. I will separately
log a gitlab to discuss whether it still makes sense, but I wouldn't want that discussion to derail this
no-change cleanup

Comments
----------------------------------------
This cleans up one of the 'outer edges' of the BaseIPN flow. Cleaning the actual functions has been a bit blocked by them being called from more places than really makes sense.

Note there is quite a bit more follow up could be done