### PR TITLE
dev/core#1956 - Typo in call to nestedGroup on scheduled reminders admin form

### DIFF
--- a/CRM/Admin/Form/ScheduleReminders.php
+++ b/CRM/Admin/Form/ScheduleReminders.php
@@ -250,7 +250,7 @@ class CRM_Admin_Form_ScheduleReminders extends CRM_Admin_Form {
     $this->addEntityRef('recipient_manual_id', ts('Manual Recipients'), ['multiple' => TRUE, 'create' => TRUE]);
 
     $this->add('select', 'group_id', ts('Group'),
-      CRM_Core_PseudoConstant::nestedGroup('Mailing'), FALSE, ['class' => 'crm-select2 huge']
+      CRM_Core_PseudoConstant::nestedGroup(), FALSE, ['class' => 'crm-select2 huge']
     );
 
     // multilingual only options

--- a/CRM/Core/PseudoConstant.php
+++ b/CRM/Core/PseudoConstant.php
@@ -857,7 +857,7 @@ WHERE  id = %1";
    * @param bool $excludeHidden
    * @return array
    */
-  public static function nestedGroup($checkPermissions = TRUE, $groupType = NULL, $excludeHidden = TRUE) {
+  public static function nestedGroup(bool $checkPermissions = TRUE, $groupType = NULL, bool $excludeHidden = TRUE) {
     $groups = $checkPermissions ? self::group($groupType, $excludeHidden) : self::allGroup($groupType, $excludeHidden);
     return CRM_Contact_BAO_Group::getGroupsHierarchy($groups, NULL, '&nbsp;&nbsp;', TRUE);
   }

--- a/tests/phpunit/CRM/Contact/BAO/GroupTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/GroupTest.php
@@ -110,6 +110,55 @@ class CRM_Contact_BAO_GroupTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test nestedGroup pseudoconstant
+   */
+  public function testNestedGroup() {
+    $params = [
+      'name' => 'groupa',
+      'title' => 'Parent Group A',
+      'description' => 'Parent Group One',
+      'visibility' => 'User and User Admin Only',
+      'is_active' => 1,
+      // mailing group
+      'group_type' => ['2' => 1],
+    ];
+    $group1 = CRM_Contact_BAO_Group::create($params);
+
+    $params = [
+      'name' => 'groupb',
+      'title' => 'Parent Group B',
+      'description' => 'Parent Group Two',
+      'visibility' => 'User and User Admin Only',
+      'is_active' => 1,
+    ];
+    $group2 = CRM_Contact_BAO_Group::create($params);
+
+    $params = [
+      'name' => 'groupc',
+      'title' => 'Child Group C',
+      'description' => 'Child Group C',
+      'visibility' => 'User and User Admin Only',
+      'is_active' => 1,
+      'parents' => [
+        $group2->id => 1,
+      ],
+    ];
+    $group3 = CRM_Contact_BAO_Group::create($params);
+
+    // Check with no group type restriction
+    $nestedGroup = CRM_Core_PseudoConstant::nestedGroup();
+    $this->assertEquals([
+      $group1->id => 'Parent Group A',
+      $group2->id => 'Parent Group B',
+      $group3->id => '&nbsp;&nbsp;Child Group C',
+    ], $nestedGroup);
+
+    // Check restrict to mailing groups
+    $nestedGroup = CRM_Core_PseudoConstant::nestedGroup(TRUE, 'Mailing');
+    $this->assertSame([$group1->id => 'Parent Group A'], $nestedGroup);
+  }
+
+  /**
    * Test adding a smart group.
    */
   public function testAddSmart() {


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/1956

Similar to https://github.com/civicrm/civicrm-core/pull/18154 but as per discussion in lab ticket it's better to leave it displaying all groups as it has been doing and just remove the typo parameter.

To confirm it's still working after:

1. Go to Admin - Communications  - Schedule Reminders.
2. Click Add.
3. Where it says "Limit or Add Recipients", choose "Limit To".
4. For Choose Recipients pick "Select Group".
5. The group dropdown appears.

Before
----------------------------------------
Parameter passed as first argument when it should have been second.

After
----------------------------------------
As per discussion just remove all params.

Technical Details
----------------------------------------
The first parameter is supposed to be a boolean about permissions, and the second parameter is a string to restrict the group type. Instead it's being called with the first parameter as that string which converts to TRUE so it always shows all groups. After some discussion it was agreed that showing all groups made more sense here than restricting to mailing groups, so have just removed all parameters.

I also updated the function signature with a typehint but php doesn't seem to strictly enforce it which is kind of interesting.

Comments
----------------------------------------
I couldn't figure out a way to test this exactly so just added a generic minimal test for nestedGroup() since I didn't see any.

Note this does not fix any other issues where the reminder isn't working with groups.
