### PR TITLE
Display url_site and url_recur based on if the form elements exist

### DIFF
--- a/templates/CRM/Admin/Form/PaymentProcessor.tpl
+++ b/templates/CRM/Admin/Form/PaymentProcessor.tpl
@@ -73,15 +73,17 @@
             <td class="label">{$form.subject.label}</td><td>{$form.subject.html} {help id=$ppTypeName|cat:'-live-subject' title=$form.subject.label}</td>
         </tr>
 {/if}
+{if $form.url_site}
         <tr class="crm-paymentProcessor-form-block-url_site">
             <td class="label">{$form.url_site.label}</td><td>{$form.url_site.html|crmAddClass:huge} {help id=$ppTypeName|cat:'-live-url-site' title=$form.url_site.label}</td>
         </tr>
+{/if}
 {if $form.url_api}
         <tr class="crm-paymentProcessor-form-block-url_api">
             <td class="label">{$form.url_api.label}</td><td>{$form.url_api.html|crmAddClass:huge} {help id=$ppTypeName|cat:'-live-url-api' title=$form.url_api.label}</td>
         </tr>
 {/if}
-{if $is_recur}
+{if $form.url_recur}
         <tr class="crm-paymentProcessor-form-block-url_recur">
             <td class="label">{$form.url_recur.label}</td><td>{$form.url_recur.html|crmAddClass:huge} {help id=$ppTypeName|cat:'-live-url-recur' title=$form.url_recur.label}</td>
         </tr>
@@ -114,15 +116,17 @@
             <td class="label">{$form.test_subject.label}</td><td>{$form.test_subject.html} {help id=$ppTypeName|cat:'-test-subject' title=$form.test_subject.label}</td>
         </tr>
 {/if}
+{if $form.test_url_site}
         <tr class="crm-paymentProcessor-form-block-test_url_site">
             <td class="label">{$form.test_url_site.label}</td><td>{$form.test_url_site.html|crmAddClass:huge} {help id=$ppTypeName|cat:'-test-url-site' title=$form.test_url_site.label}</td>
         </tr>
+{/if}
 {if $form.test_url_api}
         <tr class="crm-paymentProcessor-form-block-test_url_api">
             <td class="label">{$form.test_url_api.label}</td><td>{$form.test_url_api.html|crmAddClass:huge} {help id=$ppTypeName|cat:'-test-url-api' title=$form.test_url_api.label}</td>
         </tr>
 {/if}
-{if $is_recur}
+{if $form.test_url_recur}
         <tr class="crm-paymentProcessor-form-block-test_url_recur">
             <td class="label">{$form.test_url_recur.label}</td><td>{$form.test_url_recur.html|crmAddClass:huge} {help id=$ppTypeName|cat:'-test-url-recur' title=$form.test_url_recur.label}</td>
         </tr>


### PR DESCRIPTION
Overview
----------------------------------------
The payment processor configuration form has a number of elements that are not used for quite a few processors (eg. Stripe).

For Stripe those elements are:
- Credit card types (not used)
- Site URL (hardcoded via sdk)
- Recur URL (not used)

Other processors work in a similar way and might want to hide these elements.

Before
----------------------------------------
Form elements can be removed via buildForm hook but remnants remain (help icon).

After
----------------------------------------
Form elements can be removed via buildForm and disappear properly. No impact on saving.
![image](https://user-images.githubusercontent.com/2052161/92014953-f78e9900-ed47-11ea-9676-dcd9b97b1c02.png)


Technical Details
----------------------------------------
For testing add the following to your buildForm hook:
```
    case 'CRM_Admin_Form_PaymentProcessor':
      foreach (['accept_credit_cards', 'url_site', 'url_recur', 'test_url_site', 'test_url_recur'] as $element)
      if ($form->elementExists($element)) {
        $form->removeElement($element);
      }
      break;
```

Comments
----------------------------------------
