### PR TITLE
dev/mail#24, item 1 - Fix spec labels MailingEventSubscribe.create

### DIFF
--- a/api/v3/MailingEventSubscribe.php
+++ b/api/v3/MailingEventSubscribe.php
@@ -66,12 +66,12 @@ function civicrm_api3_mailing_event_subscribe_create($params) {
 function _civicrm_api3_mailing_event_subscribe_create_spec(&$params) {
   $params['email'] = [
     'api.required' => 1,
-    'title' => 'Unsubscribe Email',
+    'title' => 'Subscribe Email',
     'type' => CRM_Utils_Type::T_STRING,
   ];
   $params['group_id'] = [
     'api.required' => 1,
-    'title' => 'Unsubscribe From Group',
+    'title' => 'Subscribe To Group',
     'type' => CRM_Utils_Type::T_INT,
   ];
 }


### PR DESCRIPTION
Overview
----------------------------------------
Correct the labels in the _spec function for API v3 for MailingEventSubscribe.create    This is a 'subscribe' action but the parameters are labelled as 'unsubscribe'

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/2730045/92025222-1d6f6a00-ed57-11ea-9a7f-6638639975a9.png)


After
----------------------------------------
![image](https://user-images.githubusercontent.com/2730045/92025053-e5682700-ed56-11ea-957c-7baf96fc55fc.png)



