### PR TITLE
Do not block user incase 'Require approval' is checked

### DIFF
--- a/CRM/Utils/System/Drupal8.php
+++ b/CRM/Utils/System/Drupal8.php
@@ -49,7 +49,7 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
     if ($user_register_conf != 'visitors' && !$user->hasPermission('administer users')) {
       $account->block();
     }
-    elseif (!$verify_mail_conf) {
+    elseif ($verify_mail_conf) {
       $account->activate();
     }
 
@@ -98,7 +98,7 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
     }
 
     // If this is a user creating their own account, login them in!
-    if ($account->isActive() && $user->isAnonymous()) {
+    if (!$verify_mail_conf && $account->isActive() && $user->isAnonymous()) {
       \user_login_finalize($account);
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
User set to blocked when created from profile even though 'Require email verification when a visitor creates an account' is set.

Before
----------------------------------------
User set blocked when created via profile

After
----------------------------------------
User set active when created via profile

Technical Details
----------------------------------------
When 'Require email verification when a visitor creates an account' is set, user created from /user/register page is set to active but its negate incase when user created via profile submit. If the user is set to blocked than they wont be able to verify their account using one time link from email they receive after registration. 