### PR TITLE
dev/wordpress#73 - Be more forgiving about slash in wpBasePage

### DIFF
--- a/CRM/Core/Config/MagicMerge.php
+++ b/CRM/Core/Config/MagicMerge.php
@@ -170,7 +170,6 @@ class CRM_Core_Config_MagicMerge {
       'userFrameworkUsersTableName' => ['setting'],
       'verpSeparator' => ['setting'],
       'wkhtmltopdfPath' => ['setting'],
-      'wpBasePage' => ['setting'],
       'wpLoadPhp' => ['setting'],
 
       // "path" properties are managed via Civi::paths and $civicrm_paths
@@ -204,6 +203,7 @@ class CRM_Core_Config_MagicMerge {
       // @todo remove geocodeMethod. As of Feb 2018, $config->geocodeMethod works but gives a deprecation warning.
       'geocodeMethod' => ['callback', 'CRM_Utils_Geocode', 'getProviderClass'],
       'defaultCurrencySymbol' => ['callback', 'CRM_Core_BAO_Country', 'getDefaultCurrencySymbol'],
+      'wpBasePage' => ['callback', 'CRM_Utils_System_WordPress', 'getBasePage'],
     ];
   }
 

--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -21,6 +21,13 @@
 class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
 
   /**
+   * Get a normalized version of the wpBasePage.
+   */
+  public static function getBasePage() {
+    return rtrim(Civi::settings()->get('wpBasePage'), '/');
+  }
+
+  /**
    */
   public function __construct() {
     /**


### PR DESCRIPTION
Overview
--------

The correct functioning of `wpBasePage` depends on whether the administrator omitted or added a trailing slash.  This is apparent on URLs with a trailing slash, eg

```
http://wpmaster.bknix:8001/civicrm/contribute/transact/?reset=1&id=1
```

Make it less sensitive.

Before
------

Example URL works OK with default setting `wpBasePage=civicrm`

Example URL fails with setting `wpBasePage=civicrm/`

After
-----

Example URL is OK with either setting `wpBasePage=civicrm` or `wpBasePage=civicrm/`

Technical Details
-----------------

I suspect the old symptom arose in the formula which produces the WP rewrite rules - ie the formula expects that there is no trailing slash. You could theoretically patch there, but this seems like it'll provide more thorough normalization.

When testing, the results affect the WP rewrite rules, so you may need to be particularly aggressive about clearing caches whenever you make a change in code or settings, eg

```
wp cache flush ; cv flush;  wp rewrite flush
```
