### PR TITLE
Add ability to enable query logging per process

### DIFF
--- a/CRM/Core/Error.php
+++ b/CRM/Core/Error.php
@@ -600,13 +600,15 @@ class CRM_Core_Error extends PEAR_ErrorStack {
    * @param string $string
    */
   public static function debug_query($string) {
-    if (defined('CIVICRM_DEBUG_LOG_QUERY')) {
-      if (CIVICRM_DEBUG_LOG_QUERY === 'backtrace') {
-        CRM_Core_Error::backtrace($string, TRUE);
-      }
-      elseif (CIVICRM_DEBUG_LOG_QUERY) {
-        CRM_Core_Error::debug_var('Query', $string, TRUE, TRUE, 'sql_log', PEAR_LOG_DEBUG);
-      }
+    if (!defined('CIVICRM_DEBUG_LOG_QUERY')) {
+      // TODO: When its updated to support getenv(), call CRM_Utils_Constant::value('CIVICRM_DEBUG_LOG_QUERY', FALSE)
+      define('CIVICRM_DEBUG_LOG_QUERY', getenv('CIVICRM_DEBUG_LOG_QUERY'));
+    }
+    if (CIVICRM_DEBUG_LOG_QUERY === 'backtrace') {
+      CRM_Core_Error::backtrace($string, TRUE);
+    }
+    elseif (CIVICRM_DEBUG_LOG_QUERY) {
+      CRM_Core_Error::debug_var('Query', $string, TRUE, TRUE, 'sql_log', PEAR_LOG_DEBUG);
     }
   }
 


### PR DESCRIPTION

Overview
----------------------------------------
This allows us to run a command such as
```
env CIVICRM_DEBUG_LOG_QUERY=1 drush cvapi Contact.get
```

and the queries for that process (but not others) are logged.

This facilitates a cleaner record of queries as it is just one process and more flexibility
(and less risk of leaving it on by mistake)

Before
----------------------------------------
Only possible to enable query logging for no processes or all processes

After
----------------------------------------
Ability to enable by-process

Technical Details
----------------------------------------

Output is in (eg)  more sites/default/files/civicrm/ConfigAndLog/CiviCRM.sql_log.18c370ca5e4f02fd7f0aa6c0.log 

Comments
----------------------------------------

