### PR TITLE
Remove pass-by-ref in PaypalProIPN::single

### DIFF
--- a/CRM/Core/Payment/PayPalProIPN.php
+++ b/CRM/Core/Payment/PayPalProIPN.php
@@ -321,7 +321,7 @@ class CRM_Core_Payment_PayPalProIPN extends CRM_Core_Payment_BaseIPN {
    *
    * @return void
    */
-  public function single(&$input, &$ids, &$objects, $recur = FALSE, $first = FALSE) {
+  public function single($input, $ids, $objects, $recur = FALSE, $first = FALSE) {
     $contribution = &$objects['contribution'];
 
     // make sure the invoice is valid and matches what we have in the contribution record


### PR DESCRIPTION


Overview
----------------------------------------
Continues the process of not passing by reference where not necessary

Before
----------------------------------------
```
public function single(&$input, &$ids, &$objects, $recur = FALSE, $first = FALSE) {
```

After
----------------------------------------
```
public function single($input, $ids, $objects, $recur = FALSE, $first = FALSE) {
```

Technical Details
----------------------------------------
This is called from 2 places. Neither use the values again & neither receive any pass-by-reference values
themselves

Comments
----------------------------------------

