### PR TITLE
Change wording on the Opt Out and Unsubscribe pages

### DIFF
--- a/CRM/Mailing/Form/Optout.php
+++ b/CRM/Mailing/Form/Optout.php
@@ -47,7 +47,7 @@ class CRM_Mailing_Form_Optout extends CRM_Core_Form {
 
   public function buildQuickForm() {
     CRM_Utils_System::addHTMLHead('<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">');
-    CRM_Utils_System::setTitle(ts('Please Confirm Your Opt Out'));
+    CRM_Utils_System::setTitle(ts('Opt Out Confirmation'));
 
     $this->add('text', 'email_confirm', ts('Verify email address to opt out:'));
     $this->addRule('email_confirm', ts('Email address is required to opt out.'), 'required');
@@ -89,7 +89,7 @@ class CRM_Mailing_Form_Optout extends CRM_Core_Form {
         CRM_Mailing_Event_BAO_Unsubscribe::send_unsub_response($queue_id, NULL, TRUE, $job_id);
       }
 
-      $statusMsg = ts('Email: %1 has been successfully opted out',
+      $statusMsg = ts('%1 opt out confirmed.',
         [1 => $values['email_confirm']]
       );
 
@@ -97,7 +97,7 @@ class CRM_Mailing_Form_Optout extends CRM_Core_Form {
     }
     elseif ($result == FALSE) {
       // Email address not verified
-      $statusMsg = ts('The email address: %1 you have entered does not match the email associated with this opt out request.',
+      $statusMsg = ts('%1 is not associated with this opt out request.',
         [1 => $values['email_confirm']]
       );
 

--- a/CRM/Mailing/Form/Unsubscribe.php
+++ b/CRM/Mailing/Form/Unsubscribe.php
@@ -61,7 +61,7 @@ class CRM_Mailing_Form_Unsubscribe extends CRM_Core_Form {
       }
     }
     if (!$groupExist) {
-      $statusMsg = ts('Email: %1 has been successfully unsubscribed from this Mailing List/Group.',
+      $statusMsg = ts('%1 has been unsubscribed.',
         [1 => $email]
       );
       CRM_Core_Session::setStatus($statusMsg, '', 'error');
@@ -72,7 +72,7 @@ class CRM_Mailing_Form_Unsubscribe extends CRM_Core_Form {
 
   public function buildQuickForm() {
     CRM_Utils_System::addHTMLHead('<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">');
-    CRM_Utils_System::setTitle(ts('Please Confirm Your Unsubscribe from this Mailing/Group'));
+    CRM_Utils_System::setTitle(ts('Unsubscribe Confirmation'));
 
     $this->add('text', 'email_confirm', ts('Verify email address to unsubscribe:'));
     $this->addRule('email_confirm', ts('Email address is required to unsubscribe.'), 'required');
@@ -114,7 +114,7 @@ class CRM_Mailing_Form_Unsubscribe extends CRM_Core_Form {
         CRM_Mailing_Event_BAO_Unsubscribe::send_unsub_response($queue_id, $groups, FALSE, $job_id);
       }
 
-      $statusMsg = ts('Email: %1 has been successfully unsubscribed from this Mailing List/Group.',
+      $statusMsg = ts('%1 is unsubscribed.',
         [1 => $values['email_confirm']]
       );
 
@@ -122,7 +122,7 @@ class CRM_Mailing_Form_Unsubscribe extends CRM_Core_Form {
     }
     elseif ($result == FALSE) {
       // Email address not verified
-      $statusMsg = ts('The email address: %1 you have entered does not match the email associated with this unsubscribe request.',
+      $statusMsg = ts('%1 is not associated with this unsubscribe request.',
         [1 => $values['email_confirm']]
       );
 


### PR DESCRIPTION
Overview
----------------------------------------
The language used on the Opt Out and Unsubscribe pages which are shown to end users can be improved.

Before
----------------------------------------
"Please Confirm Your Unsubscribe from this Mailing/Group" does not roll off the tongue. And "Please Confirm Your Opt Out" is also a bit clunky.

After
----------------------------------------
Words changed with the aim of both shortening and providing a clearer message to the end user.

Technical Details
----------------------------------------

Comments
----------------------------------------
Would like to change other words in CiviCRM too!


Agileware Ref: CIVICRM-1555