### PR TITLE
Move ACls on LineItem create to financialacls core extension

### DIFF
--- a/CRM/Price/BAO/LineItem.php
+++ b/CRM/Price/BAO/LineItem.php
@@ -35,11 +35,9 @@ class CRM_Price_BAO_LineItem extends CRM_Price_DAO_LineItem {
     $id = $params['id'] ?? NULL;
     if ($id) {
       CRM_Utils_Hook::pre('edit', 'LineItem', $id, $params);
-      $op = CRM_Core_Action::UPDATE;
     }
     else {
       CRM_Utils_Hook::pre('create', 'LineItem', $params['entity_id'], $params);
-      $op = CRM_Core_Action::ADD;
     }
 
     // unset entity table and entity id in $params
@@ -54,21 +52,12 @@ class CRM_Price_BAO_LineItem extends CRM_Price_DAO_LineItem {
         $params['unit_price'] = 0;
       }
     }
-    if (CRM_Financial_BAO_FinancialType::isACLFinancialTypeStatus() && !empty($params['check_permissions'])) {
-      if (empty($params['financial_type_id'])) {
-        throw new Exception('Mandatory key(s) missing from params array: financial_type_id');
-      }
-      CRM_Financial_BAO_FinancialType::getAvailableFinancialTypes($types, $op);
-      if (!in_array($params['financial_type_id'], array_keys($types))) {
-        throw new Exception('You do not have permission to create this line item');
-      }
-    }
 
     $lineItemBAO = new CRM_Price_BAO_LineItem();
     $lineItemBAO->copyValues($params);
 
     $return = $lineItemBAO->save();
-    if ($lineItemBAO->entity_table == 'civicrm_membership' && $lineItemBAO->contribution_id && $lineItemBAO->entity_id) {
+    if ($lineItemBAO->entity_table === 'civicrm_membership' && $lineItemBAO->contribution_id && $lineItemBAO->entity_id) {
       $membershipPaymentParams = [
         'membership_id' => $lineItemBAO->entity_id,
         'contribution_id' => $lineItemBAO->contribution_id,

--- a/ext/financialacls/financialacls.php
+++ b/ext/financialacls/financialacls.php
@@ -146,7 +146,7 @@ function financialacls_civicrm_themes(&$themes) {
 /**
  * Intervene to prevent deletion, where permissions block it.
  *
- * @param \CRM_Core_DAO $op
+ * @param string $op
  * @param string $objectName
  * @param int|null $id
  * @param array $params
@@ -155,14 +155,15 @@ function financialacls_civicrm_themes(&$themes) {
  * @throws \CRM_Core_Exception
  */
 function financialacls_civicrm_pre($op, $objectName, $id, &$params) {
-  if ($objectName === 'LineItem' && $op === 'delete' && !empty($params['check_permissions'])) {
+  if ($objectName === 'LineItem' && !empty($params['check_permissions'])) {
     if (CRM_Financial_BAO_FinancialType::isACLFinancialTypeStatus()) {
-      CRM_Financial_BAO_FinancialType::getAvailableFinancialTypes($types, CRM_Core_Action::DELETE);
+      $operationMap = ['delete' => CRM_Core_Action::DELETE, 'edit' => CRM_Core_Action::UPDATE, 'create' => CRM_Core_Action::ADD];
+      CRM_Financial_BAO_FinancialType::getAvailableFinancialTypes($types, $operationMap[$op]);
       if (empty($params['financial_type_id'])) {
         $params['financial_type_id'] = CRM_Core_DAO::getFieldValue('CRM_Price_DAO_LineItem', $params['id'], 'financial_type_id');
       }
       if (!in_array($params['financial_type_id'], array_keys($types))) {
-        throw new API_Exception('You do not have permission to delete this line item');
+        throw new API_Exception('You do not have permission to ' . $op . ' this line item');
       }
     }
   }

--- a/tests/phpunit/api/v3/FinancialTypeACLTest.php
+++ b/tests/phpunit/api/v3/FinancialTypeACLTest.php
@@ -230,7 +230,7 @@ class api_v3_FinancialTypeACLTest extends CiviUnitTestCase {
       'add contributions of type Donation',
       'delete contributions of type Donation',
     ]);
-    $this->callAPIFailure('contribution', 'create', $params, 'Error in call to LineItem_create : You do not have permission to create this line item');
+    $this->callAPIFailure('Contribution', 'create', $params, 'Error in call to LineItem_create : You do not have permission to create this line item');
 
     // Check that the entire contribution has rolled back.
     $contribution = $this->callAPISuccess('contribution', 'get', []);


### PR DESCRIPTION
Overview
----------------------------------------
Moves the financial ACL handling from LineItem BAO to the financialacls core extension.

Before
----------------------------------------
Code in LineItem BAO

After
----------------------------------------
Code in financialacls core extension.

Technical Details
----------------------------------------
This actually covers the originally missed situation where financial_type_id is not present on an update

Comments
----------------------------------------
@seamuslee001 
