### PR TITLE
Fix test to use validateAllContributions

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -1903,9 +1903,19 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     $params['invoiceID'] = md5(uniqid(rand(), TRUE));
 
     // We want to move away from passing in amount as it is calculated by the actually-submitted params.
-    $params['amount'] = $params['amount'] ?? $form->getMainContributionAmount($params);
+    if ($form->getMainContributionAmount($params)) {
+      $params['amount'] = $form->getMainContributionAmount($params);
+    }
     $paramsProcessedForForm = $form->_params = self::getFormParams($params['id'], $params);
-    $form->_amount = $params['amount'];
+
+    $order = new CRM_Financial_BAO_Order();
+    $order->setPriceSelectionFromUnfilteredInput($params);
+    if (isset($params['amount'])) {
+      // @todo deprecate receiving amount, calculate on the form.
+      $order->setOverrideTotalAmount($params['amount']);
+    }
+    $amount = $order->getTotalAmount();
+    $form->_amount = $params['amount'] = $form->_params['amount'] = $params['amount'] ?? $amount;
     // hack these in for test support.
     $form->_fields['billing_first_name'] = 1;
     $form->_fields['billing_last_name'] = 1;

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -3551,13 +3551,16 @@ VALUES
    * @throws \CRM_Core_Exception
    */
   protected function validateAllContributions() {
-    $contributions = $this->callAPISuccess('Contribution', 'get', [])['values'];
+    $contributions = $this->callAPISuccess('Contribution', 'get', ['return' => ['tax_amount', 'total_amount']])['values'];
     foreach ($contributions as $contribution) {
       $lineItems = $this->callAPISuccess('LineItem', 'get', ['contribution_id' => $contribution['id']])['values'];
       $total = 0;
+      $taxTotal = 0;
       foreach ($lineItems as $lineItem) {
         $total += $lineItem['line_total'];
+        $taxTotal += (float) ($lineItem['tax_amount'] ?? 0);
       }
+      $this->assertEquals($taxTotal, (float) ($contribution['tax_amount'] ?? 0));
       $this->assertEquals($total, $contribution['total_amount']);
     }
   }

--- a/tests/phpunit/api/v3/ContributionPageTest.php
+++ b/tests/phpunit/api/v3/ContributionPageTest.php
@@ -1862,7 +1862,6 @@ class api_v3_ContributionPageTest extends CiviUnitTestCase {
     $submitParams = [
       'price_' . $this->_ids['price_field'][0] => reset($this->_ids['price_field_value']),
       'id' => (int) $this->_ids['contribution_page'],
-      'amount' => 80,
       'first_name' => 'Billy',
       'last_name' => 'Gruff',
       'email' => 'billy@goat.gruff',
@@ -1870,7 +1869,7 @@ class api_v3_ContributionPageTest extends CiviUnitTestCase {
     ];
     $this->addPriceFields($submitParams);
 
-    $this->callAPISuccess('contribution_page', 'submit', $submitParams);
+    $this->callAPISuccess('ContributionPage', 'submit', $submitParams);
     $contribution = $this->callAPISuccessGetSingle('contribution', [
       'contribution_page_id' => $this->_ids['contribution_page'],
       'contribution_status_id' => 'Pending',
@@ -1988,12 +1987,12 @@ class api_v3_ContributionPageTest extends CiviUnitTestCase {
     // Set quantity for our test
     $submitParams['price_' . $priceFieldId] = 110;
 
-    // contribution_page submit requires amount and tax_amount - and that's ok we're not testing that - we're testing at the LineItem level
-    $submitParams['amount'] = $this->formatMoneyInput(180 * 16.95 + 110 * 2.95);
     // This is the correct Tax Amount - use it later to compare to what the CiviCRM Core came up with at the LineItem level
     $submitParams['tax_amount'] = (180 * 16.95 * 0.10 + 110 * 2.95 * 0.10);
 
-    $this->callAPISuccess('contribution_page', 'submit', $submitParams);
+    $this->callAPISuccess('ContributionPage', 'submit', $submitParams);
+    $this->validateAllContributions();
+
     $contribution = $this->callAPISuccessGetSingle('contribution', [
       'contribution_page_id' => $this->_ids['contribution_page'],
     ]);
@@ -2011,13 +2010,8 @@ class api_v3_ContributionPageTest extends CiviUnitTestCase {
     ]);
 
     $finalContribution = $this->callAPISuccess('Contribution', 'getsingle', ['id' => $contribution['id'], 'return' => ['tax_amount', 'total_amount']]);
-
     $this->assertEquals($lineItem1['line_total'] + $lineItem2['line_total'], round(180 * 16.95 + 110 * 2.95, 2), 'Line Item Total is incorrect.');
-    $this->assertEquals($lineItem1['line_total'] + $lineItem2['line_total'], $finalContribution['total_amount'], 'Contribution total should match line item totals');
-
     $this->assertEquals(round($lineItem1['tax_amount'] + $lineItem2['tax_amount'], 2), round(180 * 16.95 * 0.10 + 110 * 2.95 * 0.10, 2), 'Wrong Sales Tax Amount is calculated and stored.');
-    $this->assertEquals(round($lineItem1['tax_amount'] + $lineItem2['tax_amount'], 2), $finalContribution['tax_amount'], 'Sales Tax Amount on Contribution does not match sum of Sales Tax Amount across the Line Items.');
-
   }
 
   /**

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -2098,7 +2098,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
   /**
    * Test to ensure mail is sent on chosing pay later
    */
-  public function testpayLater() {
+  public function testPayLater() {
     $mut = new CiviMailUtils($this, TRUE);
     $this->swapMessageTemplateForTestTemplate();
     $this->createLoggedInUser();
@@ -2140,7 +2140,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
       'description' => 'Online Contribution: Help Support CiviCRM!',
       'price_set_id' => $priceSet['id'],
     ];
-    $this->callAPISuccess('contribution_page', 'submit', $params);
+    $this->callAPISuccess('ContributionPage', 'submit', $params);
 
     $mut->checkMailLog([
       'is_pay_later:::1',


### PR DESCRIPTION
Overview
----------------------------------------
Fixes the test testSubmitContributionPageWithPriceSetQuantity to call validateAllContributions to ensure the sum of the line items is equal to the contribution total amount & the sum of line item taxes is equal to the contribution tax amount

In order to do this we need to fix the ContributionPage.submit api handling to accurately calculate amount from the price set parameters & not require the test to pass in amount (which it is doing incorrectly)

Before
----------------------------------------
'amount' passed into ContributionPage.submit only has the value for 2/3 of the line items

After
----------------------------------------
amount is calculated based on actual submitted lineitems.  vallidateAllContributions validates the final amount

Technical Details
----------------------------------------


Comments
----------------------------------------

