### PR TITLE
dev/financial#143 Convert Paypal Pro to use Guzzle 

### DIFF
--- a/tests/phpunit/CRM/Core/Payment/PaypalProTest.php
+++ b/tests/phpunit/CRM/Core/Payment/PaypalProTest.php
@@ -1,0 +1,89 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * Class CRM_Core_Payment_PaypalPro
+ * @group headless
+ */
+class CRM_Core_Payment_PaypalProTest extends CiviUnitTestCase {
+
+  use CRM_Core_Payment_PaypalProTrait;
+
+  /**
+   * @throws \CiviCRM_API3_Exception
+   */
+  public function setUp() {
+    parent::setUp();
+    $this->createPaypalProProcessor();
+
+    $this->processor = Civi\Payment\System::singleton()->getById($this->ids['PaymentProcessor']['paypal_pro']);
+  }
+
+  public function tearDown() {
+    $this->quickCleanUpFinancialEntities();
+    parent::tearDown();
+  }
+
+  /**
+   * Test doing a one-off payment.
+   *
+   * @throws \Civi\Payment\Exception\PaymentProcessorException
+   * @throws \CiviCRM_API3_Exception
+   */
+  public function testSinglePayment() {
+    $this->setupMockHandler();
+    $params = $this->getBillingParams();
+    $params['amount'] = 5.24;
+    $params['currency'] = 'USD';
+    $params['invoiceID'] = 'xyz';
+    $params['ip_address'] = '127.0.0.1';
+    foreach ($params as $key => $value) {
+      // Paypal is super special and requires this. Leaving out of the more generic
+      // get billing params for now to make it more obvious.
+      // When/if PropertyBag supports all the params paypal needs we can convert & simplify this.
+      $params[str_replace('-5', '', str_replace('billing_', '', $key))] = $value;
+    }
+    $params['state_province'] = 'IL';
+    $params['country'] = 'US';
+    $this->processor->doPayment($params);
+    $this->assertEquals($this->getExpectedSinglePaymentRequests(), $this->getRequestBodies());
+  }
+
+  /**
+   * Get some basic billing parameters.
+   *
+   * These are what are entered by the form-filler.
+   *
+   * @return array
+   */
+  protected function getBillingParams(): array {
+    return [
+      'billing_first_name' => 'John',
+      'billing_middle_name' => '',
+      'billing_last_name' => "O'Connor",
+      'billing_street_address-5' => '8 Hobbitton Road',
+      'billing_city-5' => 'The Shire',
+      'billing_state_province_id-5' => 1012,
+      'billing_postal_code-5' => 5010,
+      'billing_country_id-5' => 1228,
+      'credit_card_number' => '4444333322221111',
+      'cvv2' => 123,
+      'credit_card_exp_date' => [
+        'M' => 9,
+        'Y' => 2025,
+      ],
+      'credit_card_type' => 'Visa',
+      'year' => 2022,
+      'month' => 10,
+    ];
+  }
+
+}

--- a/tests/phpunit/CRM/Core/Payment/PaypalProTrait.php
+++ b/tests/phpunit/CRM/Core/Payment/PaypalProTrait.php
@@ -1,0 +1,94 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * Class CRM_Core_Payment_AuthorizeNetTest
+ * @group headless
+ */
+trait CRM_Core_Payment_PaypalProTrait {
+  use \Civi\Test\GuzzleTestTrait;
+
+  /**
+   * @var \CRM_Core_Payment_PayPalImpl
+   */
+  protected $processor;
+
+  /**
+   * Is this a recurring transaction.
+   *
+   * @var bool
+   */
+  protected $isRecur = FALSE;
+
+  /**
+   * Get the expected response from Paypal Pro for a single payment.
+   *
+   * @return array
+   */
+  public function getExpectedSinglePaymentResponses() {
+    return [
+      'placeholder',
+    ];
+  }
+
+  /**
+   *  Get the expected request from Authorize.net.
+   *
+   * @return array
+   */
+  public function getExpectedSinglePaymentRequests() {
+    return [
+      'placeholder',
+    ];
+  }
+
+  /**
+   *  Get the expected request from Authorize.net.
+   *
+   * @return array
+   */
+  public function getExpectedRecurResponses() {
+    return [
+      'placeholder',
+    ];
+  }
+
+  /**
+   * Add a mock handler to the paypal Pro processor for testing.
+   *
+   * @param int|null $id
+   *
+   * @throws \CiviCRM_API3_Exception
+   */
+  protected function setupMockHandler($id = NULL) {
+    if ($id) {
+      $this->processor = Civi\Payment\System::singleton()->getById($id);
+    }
+    $responses = $this->isRecur ? $this->getExpectedRecurResponses() : $this->getExpectedSinglePaymentResponses();
+    // Comment the next line out when trying to capture the response.
+    // see https://github.com/civicrm/civicrm-core/pull/18350
+    //$this->createMockHandler($responses);
+    $this->setUpClientWithHistoryContainer();
+    $this->processor->setGuzzleClient($this->getGuzzleClient());
+  }
+
+  /**
+   * Create an AuthorizeNet processors with a configured mock handler.
+   *
+   * @throws \CiviCRM_API3_Exception
+   */
+  protected function createPaypalProProcessor() {
+    $processorID = $this->paymentProcessorCreate(['is_test' => 0]);
+    $this->setupMockHandler($processorID);
+    $this->ids['PaymentProcessor']['paypal_pro'] = $processorID;
+  }
+
+}

--- a/tests/phpunit/CRM/Core/Payment/PaypalProTrait.php
+++ b/tests/phpunit/CRM/Core/Payment/PaypalProTrait.php
@@ -9,12 +9,14 @@
  +--------------------------------------------------------------------+
  */
 
+use Civi\Test\GuzzleTestTrait;
+
 /**
  * Class CRM_Core_Payment_AuthorizeNetTest
  * @group headless
  */
 trait CRM_Core_Payment_PaypalProTrait {
-  use \Civi\Test\GuzzleTestTrait;
+  use GuzzleTestTrait;
 
   /**
    * @var \CRM_Core_Payment_PayPalImpl
@@ -35,7 +37,8 @@ trait CRM_Core_Payment_PaypalProTrait {
    */
   public function getExpectedSinglePaymentResponses() {
     return [
-      'placeholder',
+      'TIMESTAMP=2020%2d09%2d04T04%3a05%3a11Z&CORRELATIONID=246132f75a6f3&ACK=Success&VERSION=3&BUILD=54790461&AMT=5%2e24&CURRENCYCODE=USD&AVSCODE=A&CVV2MATCH=M&TRANSACTIONID=9TU23130NB247535M',
+      'RECEIVERBUSINESS=sunil%2e_1183377782_biz%40webaccess%2eco%2ein&RECEIVEREMAIL=sunil%2e_1183377782_biz%40webaccess%2eco%2ein&RECEIVERID=BNCETES6EECQQ&EMAIL=86Y37281N5671683A%40dcc2%2epaypal%2ecom&PAYERID=RYUKTRK2TRA4J&PAYERSTATUS=verified&COUNTRYCODE=US&ADDRESSOWNER=PayPal&ADDRESSSTATUS=None&INVNUM=68023&SALESTAX=0%2e00&TIMESTAMP=2020%2d09%2d04T05%3a18%3a33Z&CORRELATIONID=b74cfc6e440ea&ACK=Success&VERSION=3&BUILD=54686869&FIRSTNAME=John&LASTNAME=O%27Connor&TRANSACTIONID=58E89379MT3066727&RECEIPTID=3065%2d9946%2d9883%2d0395&TRANSACTIONTYPE=webaccept&PAYMENTTYPE=instant&ORDERTIME=2020%2d09%2d04T05%3a18%3a28Z&AMT=5%2e24&FEEAMT=0%2e45&TAXAMT=0%2e00&CURRENCYCODE=USD&PAYMENTSTATUS=Completed&PENDINGREASON=None&REASONCODE=None&SHIPPINGMETHOD=Default&L_QTY0=1&L_TAXAMT0=0%2e00&L_CURRENCYCODE0=USD&L_AMT0=5%2e24',
     ];
   }
 
@@ -46,7 +49,8 @@ trait CRM_Core_Payment_PaypalProTrait {
    */
   public function getExpectedSinglePaymentRequests() {
     return [
-      'placeholder',
+      'user=sunil._1183377782_biz_api1.webaccess.co.in&pwd=1183377788&version=3&signature=APixCoQ-Zsaj-u3IH7mD5Do-7HUqA9loGnLSzsZga9Zr-aNmaJa3WGPH&subject=&method=DoDirectPayment&paymentAction=Sale&amt=5.24&currencyCode=USD&invnum=xyz&ipaddress=127.0.0.1&creditCardType=Visa&acct=4444333322221111&expDate=102022&cvv2=123&firstName=John&lastName=O%27Connor&email=&street=8+Hobbitton+Road&city=The+Shire&state=IL&countryCode=US&zip=5010&desc=&custom=&BUTTONSOURCE=CiviCRM_SP',
+      'TRANSACTIONID=9TU23130NB247535M&user=sunil._1183377782_biz_api1.webaccess.co.in&pwd=1183377788&version=3&signature=APixCoQ-Zsaj-u3IH7mD5Do-7HUqA9loGnLSzsZga9Zr-aNmaJa3WGPH&subject=&method=GetTransactionDetails',
     ];
   }
 
@@ -75,7 +79,7 @@ trait CRM_Core_Payment_PaypalProTrait {
     $responses = $this->isRecur ? $this->getExpectedRecurResponses() : $this->getExpectedSinglePaymentResponses();
     // Comment the next line out when trying to capture the response.
     // see https://github.com/civicrm/civicrm-core/pull/18350
-    //$this->createMockHandler($responses);
+    $this->createMockHandler($responses);
     $this->setUpClientWithHistoryContainer();
     $this->processor->setGuzzleClient($this->getGuzzleClient());
   }


### PR DESCRIPTION
Overview
----------------------------------------
Convert PaypalPro to use Guzzle in order to bring it in under unit testing.

https://lab.civicrm.org/dev/financial/-/issues/143

Before
----------------------------------------
No testing on Paypal Pro payment processing


After
----------------------------------------
Testing added

Technical Details
----------------------------------------

Note the following explanation is intended to help document the process. 

As with most refactors most of the work and most of the change is in the test

The way we bring payment processors under CI is by converting them to use guzzle for http requests (this also makes CURL preferred but optional a the the server level). Guzzle has support for using mockHandlers to simulate http requests and responses without actually making them - so once we have set up guzzle testing we can supply an expected response and not rely on an outside service. We can also test the contents of the outgoing test - this gives us quick additional cover (for example the tests where we pass PropertyBag to Authorize.net fail in our guzzle tests because we are checking the http request and the credit card number is missing).

The steps to convert and set up a test are basically:

1) create the test shell 
2) switch the code from curl to guzzle
3) switch to live credentials and comment out the mock handler. Use a breakpoint to capture the response from the provider
4) re-enable the handler, run again - it should fail because we are comparing 'placeholder' with the actual request now
-  use the failure from the actual request to put into the getExpectedSinglePaymentRequest() function


**1 create the test shell**
The initial test shell is pretty boilerplate. The guzzle helper class is available to extensions. The key when trying to capture the response is   [to comment out the line](https://github.com/civicrm/civicrm-core/pull/18350/files#diff-910a89da0e15185925b9cfd92cbba1d0R78)
```
$this->createMockHandler([$response]);
```


**2. switch the code from curl to guzzle**
[Actually pretty straight forward](https://github.com/civicrm/civicrm-core/pull/18350/files#diff-96a0ea19e8ac102ef100c35b3b3d1c31R1018-R1024). Some variable for different expectations by the processor - e.g content type of xml used in Authorize.net


At this stage out code looks pretty much like [the first](https://github.com/civicrm/civicrm-core/pull/18350/commits/15912a4decf275132d36ac7c8483805a49227e0e) of the 2 commits in this PR

**3 Capture the response**
Basically key processor credentials into the test so the request works in a test context, and then grab that string and plug it into the tests - these screenshots are from stepping through the PaypalImpl class in phpstorm



<img width="758" alt="Screen Shot 2020-09-04 at 4 14 53 PM" src="https://user-images.githubusercontent.com/336308/92198984-f71e0b80-eec9-11ea-901d-7f0de5569105.png">



<img width="720" alt="Screen Shot 2020-09-04 at 4 16 53 PM" src="https://user-images.githubusercontent.com/336308/92199017-1157e980-eeca-11ea-8dec-744fd0ca731d.png">

Alternatively you can call 
```
$this->getResponseBodies();
``` 
from your test once it has run through

<img width="661" alt="Screen Shot 2020-09-04 at 5 18 46 PM" src="https://user-images.githubusercontent.com/336308/92202278-c0002800-eed2-11ea-8beb-e6b9d9e42230.png">


**Run the test & capture the requests that went out**
These will be in the test fail or $this->container in your test class. To view them from $this->container you should cast to a string or use the helper ``` $this->getRequestBodies()[0]```



