### PR TITLE
Add test to cover existing v3 api setting of tax_amount on line items

### DIFF
--- a/CRM/Financial/BAO/FinancialTypeAccount.php
+++ b/CRM/Financial/BAO/FinancialTypeAccount.php
@@ -52,14 +52,17 @@ class CRM_Financial_BAO_FinancialTypeAccount extends CRM_Financial_DAO_EntityFin
    * @param array $params
    *   Reference array contains the values submitted by the form.
    * @param array $ids
-   *   Reference array contains the id.
+   *   Reference array contains one possible value
+   *   - entityFinancialAccount.
    *
-   * @return object
+   * @return CRM_Financial_DAO_EntityFinancialAccount
+   *
+   * @throws \CRM_Core_Exception
    */
-  public static function add(&$params, &$ids = NULL) {
+  public static function add(&$params, $ids = NULL) {
     // action is taken depending upon the mode
     $financialTypeAccount = new CRM_Financial_DAO_EntityFinancialAccount();
-    if ($params['entity_table'] != 'civicrm_financial_type') {
+    if ($params['entity_table'] !== 'civicrm_financial_type') {
       $financialTypeAccount->entity_id = $params['entity_id'];
       $financialTypeAccount->entity_table = $params['entity_table'];
       $financialTypeAccount->find(TRUE);
@@ -71,6 +74,7 @@ class CRM_Financial_BAO_FinancialTypeAccount extends CRM_Financial_DAO_EntityFin
     $financialTypeAccount->copyValues($params);
     self::validateRelationship($financialTypeAccount);
     $financialTypeAccount->save();
+    unset(Civi::$statics['CRM_Core_PseudoConstant']['taxRates']);
     return $financialTypeAccount;
   }
 
@@ -80,6 +84,7 @@ class CRM_Financial_BAO_FinancialTypeAccount extends CRM_Financial_DAO_EntityFin
    * @param int $financialTypeAccountId
    * @param int $accountId
    *
+   * @throws \CRM_Core_Exception
    */
   public static function del($financialTypeAccountId, $accountId = NULL) {
     // check if financial type is present
@@ -102,6 +107,7 @@ class CRM_Financial_BAO_FinancialTypeAccount extends CRM_Financial_DAO_EntityFin
 
     foreach ($dependency as $name) {
       $daoString = 'CRM_' . $name[0] . '_DAO_' . $name[1];
+      /* @var \CRM_Core_DAO $dao */
       $dao = new $daoString();
       $dao->financial_type_id = $financialTypeId;
       if ($dao->find(TRUE)) {
@@ -111,7 +117,7 @@ class CRM_Financial_BAO_FinancialTypeAccount extends CRM_Financial_DAO_EntityFin
     }
 
     if ($check) {
-      if ($name[1] == 'PremiumsProduct' || $name[1] == 'Product') {
+      if ($name[1] === 'PremiumsProduct' || $name[1] === 'Product') {
         CRM_Core_Session::setStatus(ts('You cannot remove an account with a %1 relationship while the Financial Type is used for a Premium.', [1 => $relationValues[$financialTypeAccountId]]));
       }
       else {
@@ -136,6 +142,7 @@ class CRM_Financial_BAO_FinancialTypeAccount extends CRM_Financial_DAO_EntityFin
    *   Payment instrument value.
    *
    * @return null|int
+   * @throws \CiviCRM_API3_Exception
    */
   public static function getInstrumentFinancialAccount($paymentInstrumentValue) {
     if (!isset(\Civi::$statics[__CLASS__]['instrument_financial_accounts'][$paymentInstrumentValue])) {
@@ -249,7 +256,7 @@ class CRM_Financial_BAO_FinancialTypeAccount extends CRM_Financial_DAO_EntityFin
   /**
    * Validate account relationship with financial account type
    *
-   * @param obj $financialTypeAccount of CRM_Financial_DAO_EntityFinancialAccount
+   * @param CRM_Financial_DAO_EntityFinancialAccount $financialTypeAccount of CRM_Financial_DAO_EntityFinancialAccount
    *
    * @throws CRM_Core_Exception
    */

--- a/tests/phpunit/api/v3/LineItemTest.php
+++ b/tests/phpunit/api/v3/LineItemTest.php
@@ -14,6 +14,8 @@
  * @group headless
  */
 class api_v3_LineItemTest extends CiviUnitTestCase {
+  use CRM_Financial_Form_SalesTaxTrait;
+
   protected $params;
   protected $_entity = 'line_item';
 
@@ -46,6 +48,30 @@ class api_v3_LineItemTest extends CiviUnitTestCase {
       'unit_price' => 50,
       'line_total' => 50,
     ];
+  }
+
+  /**
+   * Test tax is calculated correctly on the line item.
+   */
+  public function testCreateLineItemWithTax() {
+    $this->enableSalesTaxOnFinancialType('Donation');
+    $this->params['financial_type_id'] = 'Donation';
+    $result = $this->callAPISuccess('LineItem', 'create', $this->params);
+    $lineItem = $this->callAPISuccessGetSingle('LineItem', ['id' => $result['id']]);
+    $this->assertEquals(5, $lineItem['tax_amount']);
+    $this->assertEquals(50, $lineItem['line_total']);
+  }
+
+  /**
+   * Enable tax for the given financial type.
+   *
+   * @todo move to a trait, share.
+   *
+   * @param string $type
+   */
+  public function enableSalesTaxOnFinancialType($type) {
+    $this->enableTaxAndInvoicing();
+    $this->relationForFinancialTypeWithFinancialAccount(CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'financial_type_id', $type));
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Additional unit tests to support moving tax calc from api to BAO for line items

Before
----------------------------------------
Less tests, caching issue blocking tests

After
----------------------------------------
Test added, now clearing static when altering FinancialAccount, minor cleanup including comments & do not pass by ref

Technical Details
----------------------------------------

Comments
----------------------------------------

This is the test to ensure https://github.com/civicrm/civicrm-core/pull/18352 doesn't break stuff