### PR TITLE
dev/core#1980 Move tax handling from line item api to BAO to make it available from apiv4

### DIFF
--- a/CRM/Price/BAO/LineItem.php
+++ b/CRM/Price/BAO/LineItem.php
@@ -26,7 +26,7 @@ class CRM_Price_BAO_LineItem extends CRM_Price_DAO_LineItem {
    * @param array $params
    *   (reference) an assoc array of name/value pairs.
    *
-   * @return \CRM_Price_DAO_LineItem
+   * @return CRM_Price_BAO_LineItem
    *
    * @throws \CiviCRM_API3_Exception
    * @throws \Exception
@@ -51,6 +51,12 @@ class CRM_Price_BAO_LineItem extends CRM_Price_DAO_LineItem {
       if (!isset($params['unit_price'])) {
         $params['unit_price'] = 0;
       }
+    }
+
+    $taxRates = CRM_Core_PseudoConstant::getTaxRates();
+    if (isset($params['financial_type_id'], $params['line_total'], $taxRates[$params['financial_type_id']])) {
+      $taxRate = $taxRates[$params['financial_type_id']];
+      $params['tax_amount'] = ($taxRate / 100) * $params['line_total'];
     }
 
     $lineItemBAO = new CRM_Price_BAO_LineItem();

--- a/api/v3/LineItem.php
+++ b/api/v3/LineItem.php
@@ -26,16 +26,11 @@
  *
  * @return array
  *   api result array
+ *
+ * @throws \API_Exception
+ * @throws \Civi\API\Exception\UnauthorizedException
  */
 function civicrm_api3_line_item_create($params) {
-  // @todo the following line is not really appropriate for the api. The BAO should
-  // do the work.
-  $taxRates = CRM_Core_PseudoConstant::getTaxRates();
-  if (isset($params['financial_type_id']) && array_key_exists($params['financial_type_id'], $taxRates)) {
-    $taxRate = $taxRates[$params['financial_type_id']];
-    $taxAmount = CRM_Contribute_BAO_Contribution_Utils::calculateTaxAmount($params['line_total'], $taxRate);
-    $params['tax_amount'] = round($taxAmount['tax_amount'], 2);
-  }
   return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params, 'LineItem');
 }
 


### PR DESCRIPTION
Overview
----------------------------------------
Move tax handling from line item api to BAO to make it available from apiv4

Before
----------------------------------------
Calculation of tax_amount for line items at the api layer

After
----------------------------------------
Moved to the BAO

Technical Details
----------------------------------------
This implementation has some limitations. I only address one in this PR - removing the rounding - as
the focus of the PR is the move.

The rounding from all save layers was previously removed but it was reverted when it was eroneously believed
to have caused a bug. The bug turned out to be https://github.com/civicrm/civicrm-core/pull/18297

Comments
----------------------------------------
Test is in https://github.com/civicrm/civicrm-core/pull/18351 - which can be merged first as it is a refactor-support-test to ensure no change