### PR TITLE
dev/core#1998 Address dedupe clash on dashboard contact

### DIFF
--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -541,6 +541,12 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
         continue;
       }
 
+      if ($table === 'civicrm_dashboard_contact') {
+        $sqls[] = "UPDATE IGNORE civicrm_dashboard_contact SET contact_id = $mainId WHERE contact_id = $otherId";
+        $sqls[] = "DELETE FROM civicrm_dashboard_contact WHERE contact_id = $otherId";
+        continue;
+      }
+
       if ($table === 'civicrm_dedupe_exception') {
         $sqls[] = "UPDATE IGNORE civicrm_dedupe_exception SET contact_id1 = $mainId WHERE contact_id1 = $otherId";
         $sqls[] = "UPDATE IGNORE civicrm_dedupe_exception SET contact_id2 = $mainId WHERE contact_id2 = $otherId";


### PR DESCRIPTION
Overview
----------------------------------------
Quick fix for dedupe fatal error on dashboard contacts - I will look at a better fix in master

Before
----------------------------------------
Error in specific circumstances per https://lab.civicrm.org/dev/core/-/issues/1998

After
----------------------------------------
Resolved

Technical Details
----------------------------------------
I have some thoughts about a fix in master that will follow the principle of checking before doing the update - more selects & less updates is less blocking than higher levels of updates / deletes.

Comments
----------------------------------------
