### PR TITLE
dev/user-interface#27 - Define a "bootstrap3" bundle (skeleton)

### DIFF
--- a/CRM/Api4/Page/Api4Explorer.php
+++ b/CRM/Api4/Page/Api4Explorer.php
@@ -40,6 +40,7 @@ class CRM_Api4_Page_Api4Explorer extends CRM_Core_Page {
       'groupOptions' => array_column((array) $groupOptions, 'options', 'name'),
     ];
     Civi::resources()
+      ->addBundle('bootstrap3')
       ->addVars('api4', $vars)
       ->addPermissions(['access debug output', 'edit groups', 'administer reserved groups'])
       ->addScriptFile('civicrm', 'js/load-bootstrap.js')

--- a/CRM/Core/Resources/Common.php
+++ b/CRM/Core/Resources/Common.php
@@ -25,11 +25,27 @@ class CRM_Core_Resources_Common {
    * @return \CRM_Core_Resources_Bundle
    */
   public static function createBootstrap3Bundle($name) {
-    $bundle = new CRM_Core_Resources_Bundle($name);
-    $bundle->addStyleFile('civicrm', 'css/bootstrap3.css');
-    $bundle->addScriptFile('civicrm', 'js/bootstrap3.js', [
-      'translate' => FALSE,
-    ]);
+    $bundle = new CRM_Core_Resources_Bundle($name, ['script', 'scriptFile', 'scriptUrl', 'settings', 'style', 'styleFile', 'styleUrl', 'markup']);
+    // Leave it to the theme/provider to register specific resources.
+    // $bundle->addStyleFile('civicrm', 'css/bootstrap3.css');
+    // $bundle->addScriptFile('civicrm', 'js/bootstrap3.js', [
+    //  'translate' => FALSE,
+    //]);
+
+    //  This warning will show if bootstrap is unavailable. Normally it will be hidden by the bootstrap .collapse class.
+    $bundle->addMarkup('
+      <div id="bootstrap-theme">
+        <div class="messages warning no-popup collapse">
+          <p>
+            <i class="crm-i fa-exclamation-triangle" aria-hidden="true"></i>
+            <strong>' . ts('Bootstrap theme not found.') . '</strong>
+          </p>
+          <p>' . ts('This screen may not work correctly without a bootstrap-based theme such as Shoreditch installed.') . '</p>
+        </div>
+      </div>',
+      ['region' => 'page-header']
+    );
+
     CRM_Utils_Hook::alterBundle($bundle);
     self::useRegion($bundle, self::REGION);
     return $bundle;

--- a/CRM/Core/Resources/Common.php
+++ b/CRM/Core/Resources/Common.php
@@ -17,6 +17,25 @@ class CRM_Core_Resources_Common {
   const REGION = 'html-header';
 
   /**
+   * The 'bundle.bootstrap3' service is a collection of resources which are
+   * loaded when a page needs to support Boostrap CSS v3.
+   *
+   * @param string $name
+   *   i.e. 'bootstrap3'
+   * @return \CRM_Core_Resources_Bundle
+   */
+  public static function createBootstrap3Bundle($name) {
+    $bundle = new CRM_Core_Resources_Bundle($name);
+    $bundle->addStyleFile('civicrm', 'css/bootstrap3.css');
+    $bundle->addScriptFile('civicrm', 'js/bootstrap3.js', [
+      'translate' => FALSE,
+    ]);
+    CRM_Utils_Hook::alterBundle($bundle);
+    self::useRegion($bundle, self::REGION);
+    return $bundle;
+  }
+
+  /**
    * The 'bundle.coreStyles' service is a collection of resources used on some
    * non-Civi pages (wherein Civi may be mixed-in).
    *

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -206,6 +206,9 @@ class Container {
       []
     ))->setPublic(TRUE);
 
+    $container->setDefinition('bundle.bootstrap3', new Definition('CRM_Core_Resources_Bundle', ['bootstrap3']))
+      ->setFactory('CRM_Core_Resources_Common::createBootstrap3Bundle');
+
     $container->setDefinition('bundle.coreStyles', new Definition('CRM_Core_Resources_Bundle', ['coreStyles']))
       ->setFactory('CRM_Core_Resources_Common::createStyleBundle');
 

--- a/ang/api4Explorer/Explorer.html
+++ b/ang/api4Explorer/Explorer.html
@@ -5,15 +5,6 @@
     {{:: ts('CiviCRM APIv4') }}{{ entity ? (' (' + entity + '::' + action + ')') : '' }}
   </h1>
 
-  <!--This warning will show if bootstrap is unavailable. Normally it will be hidden by the bootstrap .collapse class.-->
-  <div class="messages warning no-popup collapse">
-    <p>
-      <i class="crm-i fa-exclamation-triangle" aria-hidden="true"></i>
-      <strong>{{:: ts('Bootstrap theme not found.') }}</strong>
-    </p>
-    <p>{{:: ts('This screen may not work correctly without a bootstrap-based theme such as Shoreditch installed.') }}</p>
-  </div>
-
   <div class="api4-explorer-row">
       <form name="api4-explorer" class="panel panel-default explorer-params-panel">
         <div class="panel-heading">


### PR DESCRIPTION
Overview
----------------------------------------

If a page is written for the Bootstrap3 CSS vocabulary, then it should activate the corresponding bundle:

```php
Civi::resources()->addBundle('bootstrap3');
```

The bundle is a mix of different kinds of assets (e.g. CSS and JS).

Observe that different stakeholders interact with this bundle in different ways by :

* Application-pages (in `civicrm-core` or extensions) activate the bundle (but the implementation is opaque to them).
* Themes (in extensions) supply content for the bundle (but they are not responsible for deciding when to load it).
* CMS integrations/addons may veto the bundle in whole or in part (without knowing the specific pages that use the bundle -- and without knowing whether the files are called `bootstrap.css`, `bootstrap3.css`, `greenwich.css`, `greenwich-bootstrap.css`, or `asset-builder?asdf1234`).

This is a step toward https://lab.civicrm.org/dev/user-interface/-/issues/27. It extracts/polishes some parts of the exploratory branch https://github.com/civicrm/civicrm-core/pull/18190.

Before
----------------------------------------

There is no official contract between (a) extensions which provide Bootstrap CSS implementation and (b) extensions (or core pages) which consume the Bootstrap CSS implementation.

In the case of, say, Shoreditch, their work-around is to activate the file on every pageload, which creates other problems. Some implementers create targeted overrides just for Shoreditch's `bootstrap.css`, but this creates problems with mixing/matching. (Ex: If a CMS integrator writes an override to exclude Shoreditch's `bootstrap.css`, then that exclusion is unlikely to apply to Greenwich's `bootstrap.css`.)

After
----------------------------------------

The bundle name `bootstrap3` represents a contract between different parties.

* For application-pages, they may request it via `Civi::resources()->addBundle('bootstrap3');`
* For theme-extensions, they may provide it via `hook_civicrm_alterBundle`.
* If a site-build provides `bootstrap3` by some means that we're unaware of, then the entire bundle can be disabled. (Currently, this could be done with a late-priority listener for `hook_civicrm_alterBundle` which calls `$bundle->clear()` . We should probably expose this as a UI option as well.)  

Technical Details
----------------------------------------

This particular bundle is not really provided by `civicrm-core` -- core is just the middle-man who gives the name `bootstrap3`. The default content is to be provided by an extension (e.g. #18190 shows this being used with a core extension "Greenwich").

NOTE: Why is bundle called `bootstrap3` instead of just `bootstrap`? The bundle name represents a contract between app-dev and theme-dev, but there's been confusion/debate about whether to interpret "bootstrap" as "v3" or "v4" or "v5" or "pick your own version" . This approach means:

* The contract is unambiguous.
* Someday, we might leap-frog to (say) `bootstrap6` or `bootstrap7`. It will be possible for there to be a period where (say) `bootstrap3` and `bootstrap7` coexist (identified and activated separately).
