### PR TITLE
CustomField - Reformat data when modifying field serialize property.

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -1697,6 +1697,25 @@ SELECT $columnName
   }
 
   /**
+   * Reformat existing values for a field when changing its serialize attribute
+   *
+   * @param CRM_Core_DAO_CustomField $field
+   * @throws CRM_Core_Exception
+   */
+  private static function alterSerialize($field) {
+    $table = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_CustomGroup', $field->custom_group_id, 'table_name');
+    $col = $field->column_name;
+    $sp = CRM_Core_DAO::VALUE_SEPARATOR;
+    if ($field->serialize) {
+      $sql = "UPDATE `$table` SET `$col` = CONCAT('$sp', `$col`, '$sp') WHERE `$col` IS NOT NULL AND `$col` NOT LIKE '$sp%' AND `$col` != ''";
+    }
+    else {
+      $sql = "UPDATE `$table` SET `$col` = SUBSTRING_INDEX(SUBSTRING(`$col`, 2), '$sp', 1) WHERE `$col` LIKE '$sp%'";
+    }
+    CRM_Core_DAO::executeQuery($sql);
+  }
+
+  /**
    * Determine whether it would be safe to move a field.
    *
    * @param int $fieldID
@@ -1989,6 +2008,9 @@ WHERE  id IN ( %1, %2 )
     $transaction = new CRM_Core_Transaction();
     $params = self::prepareCreate($params);
 
+    $alterSerialize = isset($params['serialize']) && !empty($params['id'])
+      && ($params['serialize'] != CRM_Core_DAO::getFieldValue('CRM_Core_DAO_CustomField', $params['id'], 'serialize'));
+
     $customField = new CRM_Core_DAO_CustomField();
     $customField->copyValues($params);
     $customField->save();
@@ -2008,6 +2030,11 @@ WHERE  id IN ( %1, %2 )
 
     // make sure all values are present in the object for further processing
     $customField->find(TRUE);
+
+    if ($alterSerialize) {
+      self::alterSerialize($customField);
+    }
+
     return $customField;
   }
 

--- a/CRM/Core/DAO/AllCoreTables.php
+++ b/CRM/Core/DAO/AllCoreTables.php
@@ -280,7 +280,7 @@ class CRM_Core_DAO_AllCoreTables {
    * Get the classname for the table.
    *
    * @param string $tableName
-   * @return string
+   * @return CRM_Core_DAO|NULL
    */
   public static function getClassForTable($tableName) {
     //CRM-19677: on multilingual setup, trim locale from $tableName to fetch class name

--- a/Civi/Api4/Generic/AbstractAction.php
+++ b/Civi/Api4/Generic/AbstractAction.php
@@ -494,7 +494,7 @@ abstract class AbstractAction implements \ArrayAccess {
         if ($field) {
           $optionFields[$fieldName] = [
             'val' => $record[$expr],
-            'name' => empty($field['custom_field_id']) ? $field['name'] : 'custom_' . $field['custom_field_id'],
+            'field' => $field,
             'suffix' => substr($expr, $suffix + 1),
             'depends' => $field['input_attrs']['controlField'] ?? NULL,
           ];
@@ -504,11 +504,11 @@ abstract class AbstractAction implements \ArrayAccess {
     }
     // Sort option lookups by dependency, so e.g. country_id is processed first, then state_province_id, then county_id
     uasort($optionFields, function ($a, $b) {
-      return $a['name'] === $b['depends'] ? -1 : 1;
+      return $a['field']['name'] === $b['depends'] ? -1 : 1;
     });
     // Replace pseudoconstants. Note this is a reverse lookup as we are evaluating input not output.
     foreach ($optionFields as $fieldName => $info) {
-      $options = FormattingUtil::getPseudoconstantList($this->_entityName, $info['name'], $info['suffix'], $record, 'create');
+      $options = FormattingUtil::getPseudoconstantList($info['field'], $info['suffix'], $record, 'create');
       $record[$fieldName] = FormattingUtil::replacePseudoconstant($options, $info['val'], TRUE);
     }
   }

--- a/Civi/Api4/Query/Api4SelectQuery.php
+++ b/Civi/Api4/Query/Api4SelectQuery.php
@@ -275,7 +275,7 @@ class Api4SelectQuery {
       $suffix = strstr($item, ':');
       if ($suffix && $expr->getType() === 'SqlField') {
         $field = $this->getField($item);
-        $options = FormattingUtil::getPseudoconstantList($field['entity'], $field['name'], substr($suffix, 1));
+        $options = FormattingUtil::getPseudoconstantList($field, substr($suffix, 1));
         if ($options) {
           asort($options);
           $column = "FIELD($column,'" . implode("','", array_keys($options)) . "')";

--- a/Civi/Api4/Service/Schema/Joinable/CustomGroupJoinable.php
+++ b/Civi/Api4/Service/Schema/Joinable/CustomGroupJoinable.php
@@ -56,16 +56,19 @@ class CustomGroupJoinable extends Joinable {
    * @inheritDoc
    */
   public function getEntityFields() {
-    if (!$this->entityFields) {
+    $cacheKey = 'APIv4_CustomGroupJoinable-' . $this->getTargetTable();
+    $entityFields = (array) \Civi::cache('metadata')->get($cacheKey);
+    if (!$entityFields) {
       $fields = CustomField::get(FALSE)
         ->setSelect(['custom_group.name', 'custom_group.extends', 'custom_group.table_name', '*'])
         ->addWhere('custom_group.table_name', '=', $this->getTargetTable())
         ->execute();
       foreach ($fields as $field) {
-        $this->entityFields[] = \Civi\Api4\Service\Spec\SpecFormatter::arrayToField($field, $this->getEntityFromExtends($field['custom_group.extends']));
+        $entityFields[] = \Civi\Api4\Service\Spec\SpecFormatter::arrayToField($field, self::getEntityFromExtends($field['custom_group.extends']));
       }
+      \Civi::cache('metadata')->set($cacheKey, $entityFields);
     }
-    return $this->entityFields;
+    return $entityFields;
   }
 
   /**
@@ -102,7 +105,7 @@ class CustomGroupJoinable extends Joinable {
    * @throws \API_Exception
    * @throws \Civi\API\Exception\UnauthorizedException
    */
-  private function getEntityFromExtends($extends) {
+  public static function getEntityFromExtends($extends) {
     if (strpos($extends, 'Participant') === 0) {
       return 'Participant';
     }

--- a/Civi/Api4/Service/Schema/Joinable/Joinable.php
+++ b/Civi/Api4/Service/Schema/Joinable/Joinable.php
@@ -79,11 +79,6 @@ class Joinable {
   protected $entity;
 
   /**
-   * @var array
-   */
-  protected $entityFields;
-
-  /**
    * @param $targetTable
    * @param $targetColumn
    * @param string|null $alias
@@ -268,15 +263,14 @@ class Joinable {
    * @return \Civi\Api4\Service\Spec\FieldSpec[]
    */
   public function getEntityFields() {
-    if (!$this->entityFields) {
-      $bao = AllCoreTables::getClassForTable($this->getTargetTable());
-      if ($bao) {
-        foreach ($bao::fields() as $field) {
-          $this->entityFields[] = \Civi\Api4\Service\Spec\SpecFormatter::arrayToField($field, $this->getEntity());
-        }
+    $entityFields = [];
+    $bao = AllCoreTables::getClassForTable($this->getTargetTable());
+    if ($bao) {
+      foreach ($bao::getSupportedFields() as $field) {
+        $entityFields[] = \Civi\Api4\Service\Spec\SpecFormatter::arrayToField($field, $this->getEntity());
       }
     }
-    return $this->entityFields;
+    return $entityFields;
   }
 
   /**

--- a/tests/phpunit/api/v4/Action/CustomFieldAlterTest.php
+++ b/tests/phpunit/api/v4/Action/CustomFieldAlterTest.php
@@ -1,0 +1,114 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+
+namespace api\v4\Action;
+
+use Civi\Api4\Activity;
+use Civi\Api4\CustomField;
+use Civi\Api4\CustomGroup;
+
+/**
+ * @group headless
+ */
+class CustomFieldAlterTest extends BaseCustomValueTest {
+
+  public function testChangeSerialize() {
+    $contact = $this->createEntity(['type' => 'Individual']);
+
+    $customGroup = CustomGroup::create(FALSE)
+      ->addValue('title', 'MyFieldsToAlter')
+      ->addValue('extends', 'Activity')
+      ->addChain('field1', CustomField::create()
+        ->addValue('custom_group_id', '$id')
+        ->addValue('label', 'TestOptions')
+        ->addValue('html_type', 'Select')
+        ->addValue('option_values', [
+          1 => 'One',
+          2 => 'Two',
+          3 => 'Three',
+          4 => 'Four',
+        ]), 0
+      )
+      ->addChain('field2', CustomField::create()
+        ->addValue('custom_group_id', '$id')
+        ->addValue('label', 'TestText')
+        ->addValue('html_type', 'Text'), 0
+      )
+      ->execute()
+      ->first();
+
+    Activity::save(FALSE)
+      ->setDefaults(['activity_type_id' => 1, 'source_contact_id' => $contact['id']])
+      ->addRecord(['subject' => 'A1', 'MyFieldsToAlter.TestText' => 'A1', 'MyFieldsToAlter.TestOptions' => '1'])
+      ->addRecord(['subject' => 'A2', 'MyFieldsToAlter.TestText' => 'A2', 'MyFieldsToAlter.TestOptions' => '2'])
+      ->addRecord(['subject' => 'A3', 'MyFieldsToAlter.TestText' => 'A3', 'MyFieldsToAlter.TestOptions' => ''])
+      ->addRecord(['subject' => 'A4', 'MyFieldsToAlter.TestText' => 'A4'])
+      ->execute();
+
+    $result = Activity::get(FALSE)
+      ->addWhere('MyFieldsToAlter.TestText', 'IS NOT NULL')
+      ->addSelect('custom.*', 'subject', 'MyFieldsToAlter.TestOptions:label')
+      ->execute()->indexBy('subject');
+
+    $this->assertCount(4, $result);
+    $this->assertEquals(1, $result['A1']['MyFieldsToAlter.TestOptions']);
+    $this->assertEquals(2, $result['A2']['MyFieldsToAlter.TestOptions']);
+    $this->assertEquals('One', $result['A1']['MyFieldsToAlter.TestOptions:label']);
+    $this->assertEquals('Two', $result['A2']['MyFieldsToAlter.TestOptions:label']);
+    $this->assertTrue(empty($result['A3']['MyFieldsToAlter.TestOptions']));
+    $this->assertTrue(empty($result['A4']['MyFieldsToAlter.TestOptions']));
+
+    // Change field to multiselect
+    CustomField::update(FALSE)
+      ->addWhere('id', '=', $customGroup['field1']['id'])
+      ->addValue('serialize', TRUE)
+      ->execute();
+
+    $result = Activity::get(FALSE)
+      ->addWhere('MyFieldsToAlter.TestText', 'IS NOT NULL')
+      ->addSelect('custom.*', 'subject', 'MyFieldsToAlter.TestOptions:label')
+      ->execute()->indexBy('subject');
+
+    $this->assertEquals([1], $result['A1']['MyFieldsToAlter.TestOptions']);
+    $this->assertEquals([2], $result['A2']['MyFieldsToAlter.TestOptions']);
+    $this->assertEquals(['One'], $result['A1']['MyFieldsToAlter.TestOptions:label']);
+    $this->assertTrue(empty($result['A3']['MyFieldsToAlter.TestOptions']));
+    $this->assertTrue(empty($result['A4']['MyFieldsToAlter.TestOptions']));
+
+    // Change back to single-select
+    CustomField::update(FALSE)
+      ->addWhere('id', '=', $customGroup['field1']['id'])
+      ->addValue('serialize', FALSE)
+      ->execute();
+
+    $result = Activity::get(FALSE)
+      ->addWhere('MyFieldsToAlter.TestText', 'IS NOT NULL')
+      ->addSelect('custom.*', 'subject', 'MyFieldsToAlter.TestOptions:label')
+      ->execute()->indexBy('subject');
+
+    $this->assertCount(4, $result);
+    $this->assertEquals(1, $result['A1']['MyFieldsToAlter.TestOptions']);
+    $this->assertEquals(2, $result['A2']['MyFieldsToAlter.TestOptions']);
+    $this->assertEquals('One', $result['A1']['MyFieldsToAlter.TestOptions:label']);
+    $this->assertEquals('Two', $result['A2']['MyFieldsToAlter.TestOptions:label']);
+    $this->assertTrue(empty($result['A3']['MyFieldsToAlter.TestOptions']));
+    $this->assertTrue(empty($result['A4']['MyFieldsToAlter.TestOptions']));
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
This ensures that serialization of custom values stays in-sync with the a custom field's `serialize` property. Existing data is updated to be serialized or not when changing a custom field between e.g. Single Select or CheckBoxes or Multi-Select.

Before
----------------------------------------
The only way to "safely" update a custom field from single to multi-valued or vice-versa is via a quickform which says:
> Warning: This functionality is currently in beta stage. Consider backing up your database before using it. Click "Cancel" to return to the "edit custom field" form without making changes.

Updating via the api "works" but existing data would not be updated, leading to data corruption.

After
----------------------------------------
Updating `serialize` property of a field via API now ensures existing data is correctly serialized or unserialized as appropriate.

Comments
----------------------------------------
My plan is to switch that old untested quickform over to this new tested api method; then we can take the "beta" warning away, and replace it with a more useful message about whether or not the operation will cause data-loss (if converting mutivalued fields to single) and if so how many rows will be affected.