### PR TITLE
Use eventID rather than the object in completeTransaction

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4406,7 +4406,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
       'financial_type_id',
     ];
 
-    $event = $objects['event'] ?? NULL;
+    $eventID = $objects['event']->id ?? NULL;
 
     $paymentProcessorId = '';
     if (isset($objects['paymentProcessor'])) {
@@ -4422,7 +4422,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
 
     $contributionParams = array_merge([
       'contribution_status_id' => $completedContributionStatusID,
-      'source' => self::getRecurringContributionDescription($contribution, $event),
+      'source' => self::getRecurringContributionDescription($contribution, $eventID),
     ], array_intersect_key($input, array_fill_keys($inputContributionWhiteList, 1)
     ));
 
@@ -4636,12 +4636,12 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
    * Get the description (source field) for the recurring contribution.
    *
    * @param CRM_Contribute_BAO_Contribution $contribution
-   * @param CRM_Event_DAO_Event|null $event
+   * @param int|null $eventID
    *
    * @return string
    * @throws \CiviCRM_API3_Exception
    */
-  protected static function getRecurringContributionDescription($contribution, $event) {
+  protected static function getRecurringContributionDescription($contribution, $eventID) {
     if (!empty($contribution->source)) {
       return $contribution->source;
     }
@@ -4652,8 +4652,8 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
       ]);
       return ts('Online Contribution') . ': ' . $contributionPageTitle;
     }
-    elseif ($event) {
-      return ts('Online Event Registration') . ': ' . $event->title;
+    elseif ($eventID) {
+      return ts('Online Event Registration') . ': ' . CRM_Event_PseudoConstant::event($eventID);
     }
     elseif (!empty($contribution->contribution_recur_id)) {
       return 'recurring contribution';

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -3316,16 +3316,17 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
     $mut = new CiviMailUtils($this, TRUE);
     $mut->clearMessages();
     $this->_individualId = $this->createLoggedInUser();
+    // Unset source to test whether one is generated if not set already on the contribution.
+    unset($this->_params['source']);
     $contributionID = $this->createPendingParticipantContribution();
     $this->createJoinedProfile(['entity_id' => $this->_ids['event']['test'], 'entity_table' => 'civicrm_event']);
     $this->createJoinedProfile(['entity_id' => $this->_ids['event']['test'], 'entity_table' => 'civicrm_event', 'weight' => 2], ['name' => 'post_1', 'title' => 'title_post_2', 'frontend_title' => 'public 2']);
     $this->createJoinedProfile(['entity_id' => $this->_ids['event']['test'], 'entity_table' => 'civicrm_event', 'weight' => 3], ['name' => 'post_2', 'title' => 'title_post_3', 'frontend_title' => 'public 3']);
     $this->eliminateUFGroupOne();
 
-    $this->callAPISuccess('contribution', 'completetransaction', [
-      'id' => $contributionID,
-    ]
-    );
+    $this->callAPISuccess('contribution', 'completetransaction', ['id' => $contributionID]);
+    $contribution = $this->callAPISuccessGetSingle('Contribution', ['id' => $contributionID, 'return' => ['contribution_source']]);
+    $this->assertEquals('Online Event Registration: Annual CiviCRM meet', $contribution['contribution_source']);
     $participantStatus = $this->callAPISuccessGetValue('participant', [
       'id' => $this->_ids['participant'],
       'return' => 'participant_status_id',


### PR DESCRIPTION
Overview
----------------------------------------
This allows us to stop passing it in as an object as a follow up. It potentially does an extra query but this is
mitigated by
1) it only does a look up if the contribution does not already have a source (rare)
2) it uses a pseudoconstant so would only look up a given event once

- we can later remove the whole loading of event and just get the id from the participant record


Before
----------------------------------------
```
$objects['event']
```
passed around

After
----------------------------------------
just the id passed around


Technical Details
----------------------------------------


Comments
----------------------------------------

