### PR TITLE
dev/core#1921 Remove some places where the ghost of 2014 is getting special love

### DIFF
--- a/CRM/Contribute/BAO/ContributionRecur.php
+++ b/CRM/Contribute/BAO/ContributionRecur.php
@@ -261,9 +261,6 @@ class CRM_Contribute_BAO_ContributionRecur extends CRM_Contribute_DAO_Contributi
     if ($recur->find(TRUE)) {
       $transaction = new CRM_Core_Transaction();
       $recur->contribution_status_id = $cancelledId;
-      $recur->start_date = CRM_Utils_Date::isoToMysql($recur->start_date);
-      $recur->create_date = CRM_Utils_Date::isoToMysql($recur->create_date);
-      $recur->modified_date = CRM_Utils_Date::isoToMysql($recur->modified_date);
       $recur->cancel_reason = $params['cancel_reason'] ?? NULL;
       $recur->cancel_date = date('YmdHis');
       $recur->save();

--- a/CRM/Core/Payment/BaseIPN.php
+++ b/CRM/Core/Payment/BaseIPN.php
@@ -119,9 +119,6 @@ class CRM_Core_Payment_BaseIPN {
       }
     }
 
-    $contribution->receive_date = CRM_Utils_Date::isoToMysql($contribution->receive_date);
-    $contribution->receipt_date = CRM_Utils_Date::isoToMysql($contribution->receipt_date);
-
     $objects['contact'] = &$contact;
     $objects['contribution'] = &$contribution;
 
@@ -305,9 +302,6 @@ class CRM_Core_Payment_BaseIPN {
       'flip' => 1,
     ]);
     $contribution->contribution_status_id = $contributionStatuses['Cancelled'];
-    $contribution->receive_date = CRM_Utils_Date::isoToMysql($contribution->receive_date);
-    $contribution->receipt_date = CRM_Utils_Date::isoToMysql($contribution->receipt_date);
-    $contribution->thankyou_date = CRM_Utils_Date::isoToMysql($contribution->thankyou_date);
     $contribution->cancel_date = self::$_now;
     $contribution->cancel_reason = $input['reasonCode'] ?? NULL;
     $contribution->save();


### PR DESCRIPTION


Overview
----------------------------------------
Minor code cleanup on dates

Before
----------------------------------------
```
$recur->start_date = CRM_Utils_Date::isoToMysql($recur->start_date);
```
to handle the fact that 6 years ago we needed to do this before using $dao->save()

After
----------------------------------------
It's a whole new world

Technical Details
----------------------------------------
per https://lab.civicrm.org/dev/core/-/issues/1921 we fixed the root cause of this 6 years ago....

Comments
----------------------------------------

