### PR TITLE
Fix way of identityfing custom serialized fields

### DIFF
--- a/CRM/Core/BAO/UFGroup.php
+++ b/CRM/Core/BAO/UFGroup.php
@@ -1310,12 +1310,7 @@ class CRM_Core_BAO_UFGroup extends CRM_Core_DAO_UFGroup {
           if ($htmlType == 'Link') {
             $url = $params[$index];
           }
-          elseif (in_array($htmlType, [
-            'CheckBox',
-            'Multi-Select',
-            'Multi-Select State/Province',
-            'Multi-Select Country',
-          ])) {
+          elseif (!empty($field['serialize'])) {
             $valSeparator = CRM_Core_DAO::VALUE_SEPARATOR;
             $selectedOptions = explode($valSeparator, $params[$index]);
 


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a reference to field types that no longer exist.

Before
----------------------------------------
References 'Multi-Select', 'Multi-Select State/Province', 'Multi-Select Country', custom field types, which were all removed in 5.27.

After
----------------------------------------
I believe this is the right fix but haven't tested it.
