### PR TITLE
[NFC] Enable APIv4 Testing on the statusPrefence API Tests

### DIFF
--- a/tests/phpunit/api/v3/StatusPreferenceTest.php
+++ b/tests/phpunit/api/v3/StatusPreferenceTest.php
@@ -16,13 +16,11 @@
  * @group headless
  */
 class api_v3_StatusPreferenceTest extends CiviUnitTestCase {
-  protected $_apiversion;
   protected $_contactID;
   protected $_locationType;
   protected $_params;
 
   public function setUp() {
-    $this->_apiversion = 3;
     parent::setUp();
     $this->useTransaction(TRUE);
     $this->_params = [
@@ -34,7 +32,11 @@ class api_v3_StatusPreferenceTest extends CiviUnitTestCase {
     ];
   }
 
-  public function testCreateStatusPreference() {
+  /**
+   * @dataProvider versionThreeAndFour
+   */
+  public function testCreateStatusPreference($version) {
+    $this->_apiversion = $version;
     $result = $this->callAPIAndDocument('StatusPreference', 'create', $this->_params, __FUNCTION__, __FILE__);
     $this->assertNotNull($result['id'], 'In line ' . __LINE__);
     $id = $result['id'];
@@ -44,7 +46,11 @@ class api_v3_StatusPreferenceTest extends CiviUnitTestCase {
     $this->callAPISuccess('StatusPreference', 'delete', ['id' => $result['id']]);
   }
 
-  public function testDeleteStatusPreference() {
+  /**
+   * @dataProvider versionThreeAndFour
+   */
+  public function testDeleteStatusPreference($version) {
+    $this->_apiversion = $version;
     // create one
     $create = $this->callAPISuccess('StatusPreference', 'create', $this->_params);
 
@@ -59,15 +65,19 @@ class api_v3_StatusPreferenceTest extends CiviUnitTestCase {
 
   /**
    * Test a get with empty params.
+   * @dataProvider versionThreeAndFour
    */
-  public function testStatusPreferenceGetEmptyParams() {
+  public function testStatusPreferenceGetEmptyParams($version) {
+    $this->_apiversion = $version;
     $result = $this->callAPISuccess('StatusPreference', 'Get', []);
   }
 
   /**
    * Test a StatusPreference get.
+   * @dataProvider versionThreeAndFour
    */
-  public function testStatusPreferenceGet() {
+  public function testStatusPreferenceGet($version) {
+    $this->_apiversion = $version;
     $statusPreference = $this->callAPISuccess('StatusPreference', 'create', $this->_params);
     $id = $statusPreference['id'];
     $params = [
@@ -82,16 +92,20 @@ class api_v3_StatusPreferenceTest extends CiviUnitTestCase {
 
   /**
    * Ensure you can't create a StatusPref with ignore_severity > 7.
+   * @dataProvider versionThreeAndFour
    */
-  public function testCreateInvalidMinimumReportSeverity() {
+  public function testCreateInvalidMinimumReportSeverity($version) {
+    $this->_apiversion = $version;
     $this->_params['ignore_severity'] = 45;
     $result = $this->callAPIFailure('StatusPreference', 'create', $this->_params);
   }
 
   /**
    * Test creating a severity by name, not integer.
+   * @dataProvider versionThreeAndFour
    */
-  public function testCreateSeverityByName() {
+  public function testCreateSeverityByName($version) {
+    $this->_apiversion = $version;
     // Any permutation of uppercase/lowercase should work.
     $this->_params['ignore_severity'] = 'cRItical';
     $result = $this->callAPIAndDocument('StatusPreference', 'create', $this->_params, __FUNCTION__, __FILE__);
@@ -101,8 +115,10 @@ class api_v3_StatusPreferenceTest extends CiviUnitTestCase {
 
   /**
    * Test creating an invalid severity by name.
+   * @dataProvider versionThreeAndFour
    */
-  public function testCreateSeverityWithInvalidName() {
+  public function testCreateSeverityWithInvalidName($version) {
+    $this->_apiversion = $version;
     $this->_params['ignore_severity'] = 'wdsadasdarning';
     $result = $this->callAPIFailure('StatusPreference', 'create', $this->_params);
   }


### PR DESCRIPTION
Overview
----------------------------------------
Title says it all

Before
----------------------------------------
Only testing v3

After
----------------------------------------
Testing v3 & v4

ping @eileenmcnaughton 