### PR TITLE
Remove inaccessible call to baseIPN failed

### DIFF
--- a/CRM/Core/Payment/BaseIPN.php
+++ b/CRM/Core/Payment/BaseIPN.php
@@ -232,17 +232,15 @@ class CRM_Core_Payment_BaseIPN {
       CRM_Contribute_BAO_ContributionRecur::copyCustomValues($objects['contributionRecur']->id, $contribution->id);
     }
 
-    if (empty($input['IAmAHorribleNastyBeyondExcusableHackInTheCRMEventFORMTaskClassThatNeedsToBERemoved'])) {
-      if (!empty($memberships)) {
-        foreach ($memberships as $membership) {
-          // @fixme Should we cancel only Pending memberships? per cancelled()
-          $this->cancelMembership($membership, $membership->status_id, FALSE);
-        }
+    if (!empty($memberships)) {
+      foreach ($memberships as $membership) {
+        // @fixme Should we cancel only Pending memberships? per cancelled()
+        $this->cancelMembership($membership, $membership->status_id, FALSE);
       }
+    }
 
-      if ($participant) {
-        $this->cancelParticipant($participant->id);
-      }
+    if ($participant) {
+      $this->cancelParticipant($participant->id);
     }
 
     if ($transaction) {

--- a/CRM/Event/Form/Task/Batch.php
+++ b/CRM/Event/Form/Task/Batch.php
@@ -284,7 +284,6 @@ class CRM_Event_Form_Task_Batch extends CRM_Event_Form_Task {
       $params = [
         'component_id' => $participantId,
         'contribution_id' => $contributionId,
-        'contribution_status_id' => array_search('Completed', $contributionStatuses),
         'IAmAHorribleNastyBeyondExcusableHackInTheCRMEventFORMTaskClassThatNeedsToBERemoved' => 1,
       ];
 
@@ -314,7 +313,6 @@ class CRM_Event_Form_Task_Batch extends CRM_Event_Form_Task {
    */
   public static function updateContributionStatus($params) {
     // get minimum required values.
-    $statusId = $params['contribution_status_id'] ?? NULL;
     $componentId = $params['component_id'] ?? NULL;
     $contributionId = $params['contribution_id'] ?? NULL;
 
@@ -357,12 +355,6 @@ class CRM_Event_Form_Task_Batch extends CRM_Event_Form_Task {
       'flip' => 1,
     ]);
     $input['IAmAHorribleNastyBeyondExcusableHackInTheCRMEventFORMTaskClassThatNeedsToBERemoved'] = $params['IAmAHorribleNastyBeyondExcusableHackInTheCRMEventFORMTaskClassThatNeedsToBERemoved'] ?? NULL;
-    if ($statusId == $contributionStatuses['Failed']) {
-      $transaction = new CRM_Core_Transaction();
-      $baseIPN->failed($objects, $transaction, $input);
-      $transaction->commit();
-      return;
-    }
 
     // status is not pending
     if ($contribution->contribution_status_id != $contributionStatuses['Pending']) {


### PR DESCRIPTION

Overview
----------------------------------------
Remove unreachable code

Before
----------------------------------------
```
$baseIPN->failed($objects, $transaction, $input);
```
called if statusId = FailedStatus - which it never does


After
----------------------------------------
poof

Technical Details
----------------------------------------
As is now clear the updateContributionStatus function is only accessible to complete
a contribution. This removes the call to baseIPN->failed() as it is unreachable,
along with the hacky handling to support it

Comments
----------------------------------------
With this merged I think it becomes clear that a payment.create call can replace the remaining part of the code in this function