### PR TITLE
[REF] Simplify loading of related objects in transition components

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2129,11 +2129,7 @@ LEFT JOIN  civicrm_contribution contribution ON ( componentPayment.contribution_
       return $updateResult;
     }
 
-    //now we are ready w/ required ids, start processing.
-
-    $baseIPN = new CRM_Core_Payment_BaseIPN();
-
-    $input = $ids = $objects = [];
+    $input = $ids = [];
 
     $input['component'] = $componentDetails['component'] ?? NULL;
     $ids['contribution'] = $contributionId;
@@ -2145,14 +2141,16 @@ LEFT JOIN  civicrm_contribution contribution ON ( componentPayment.contribution_
     $ids['contributionRecur'] = NULL;
     $ids['contributionPage'] = NULL;
 
-    if (!$baseIPN->validateData($input, $ids, $objects, FALSE)) {
-      throw new CRM_Core_Exception('Unable to validate supplied data');
-    }
+    $contribution = new CRM_Contribute_BAO_Contribution();
+    $contribution->id = $ids['contribution'];
+    $contribution->find();
 
-    $memberships = &$objects['membership'];
-    $participant = &$objects['participant'];
-    $pledgePayment = &$objects['pledge_payment'];
-    $contribution = &$objects['contribution'];
+    $contribution->loadRelatedObjects($input, $ids);
+
+    $memberships = $contribution->_relatedObjects['membership'] ?? [];
+    $participant = $contribution->_relatedObjects['participant'] ?? [];
+    $pledgePayment = $contribution->_relatedObjects['pledge_payment'] ?? [];
+
     $pledgeID = $oldStatus = NULL;
     $pledgePaymentIDs = [];
     if ($pledgePayment) {


### PR DESCRIPTION


Overview
----------------------------------------
Simplify loading of related objects in transition components

Before
----------------------------------------
uses 
```
if (!$baseIPN->validateData($input, $ids, $objects, FALSE)) {
```

to call 
```
$contribution->loadRelatedObjects($input, $ids);
```

After
----------------------------------------
Calls
```
$contribution->loadRelatedObjects($input, $ids);
```
directly


Technical Details
----------------------------------------
This alters transitionComponents to  bypass validateData to load the related objects

Stepping through validateData it's clear that validate data
1) loads the contribution - this is now in transitionComponents
2) loads the contact - that is not specifically necessary as it is not used in transitionComponents
3) does some validation that relates to the IPNyness of BaseIPN but not to an internally called function
4) calls 'loadObjects'

LoadObjects does some error handling, sets the processorID if passed in, which it isn't  and then calls
contribution->loadRelatedObjects( )

- we now do that last call directly in-function


Comments
----------------------------------------

OrderTest::testCancelWithParticipant passes directly through this code