### PR TITLE
dev/core#1921 Further removal of iso date handling

### DIFF
--- a/CRM/Core/Payment/PayPalIPN.php
+++ b/CRM/Core/Payment/PayPalIPN.php
@@ -98,14 +98,6 @@ class CRM_Core_Payment_PayPalIPN extends CRM_Core_Payment_BaseIPN {
 
     $now = date('YmdHis');
 
-    // fix dates that already exist
-    $dates = ['create', 'start', 'end', 'cancel', 'modified'];
-    foreach ($dates as $date) {
-      $name = "{$date}_date";
-      if ($recur->$name) {
-        $recur->$name = CRM_Utils_Date::isoToMysql($recur->$name);
-      }
-    }
     $sendNotification = FALSE;
     $subscriptionPaymentStatus = NULL;
     // set transaction type


### PR DESCRIPTION


Overview
----------------------------------------
Same deal as https://github.com/civicrm/civicrm-core/pull/18359

Before
----------------------------------------
Casting to ISO date to avoid 2014 bug

After
----------------------------------------
We are stuck in 2020

Technical Details
----------------------------------------


Comments
----------------------------------------

