### PR TITLE
Remove deprecated ids param

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -84,22 +84,17 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution {
    *
    * @param array $params
    *   (reference ) an assoc array of name/value pairs.
-   * @param array $ids
-   *   The array that holds all the db ids.
    *
    * @return \CRM_Contribute_BAO_Contribution
    * @throws \CRM_Core_Exception
    * @throws \CiviCRM_API3_Exception
    */
-  public static function add(&$params, $ids = []) {
+  public static function add(&$params) {
     if (empty($params)) {
       return NULL;
     }
-    if (!empty($ids)) {
-      CRM_Core_Error::deprecatedFunctionWarning('ids should not be passed into Contribution.add');
-    }
-    //per http://wiki.civicrm.org/confluence/display/CRM/Database+layer we are moving away from $ids array
-    $contributionID = CRM_Utils_Array::value('contribution', $ids, CRM_Utils_Array::value('id', $params));
+
+    $contributionID = $params['id'] ?? NULL;
     $action = $contributionID ? 'edit' : 'create';
     $duplicates = [];
     if (self::checkDuplicate($params, $duplicates, $contributionID)) {


### PR DESCRIPTION
Overview
----------------------------------------
Remove param that has been noisily deprecated for 8 months & discouraged for much longer

Before
----------------------------------------
<img width="727" alt="Screen Shot 2020-09-05 at 4 02 10 PM" src="https://user-images.githubusercontent.com/336308/92297248-6ad71b80-ef91-11ea-85ec-883dc3826151.png">


<img width="1271" alt="Screen Shot 2020-09-05 at 4 05 21 PM" src="https://user-images.githubusercontent.com/336308/92297264-a07c0480-ef91-11ea-9577-ac9c08b056d7.png">


After
----------------------------------------
poof

Technical Details
----------------------------------------
We've been really clear for a long time that the way to do this from outside core is via the api so we don't need to worry too much about extensions that missed the warning 

Comments
----------------------------------------

