### PR TITLE
report#45 Switch out function call CRM_Utils_Array::value and extend …

### DIFF
--- a/CRM/Contact/BAO/Group.php
+++ b/CRM/Contact/BAO/Group.php
@@ -1223,12 +1223,12 @@ WHERE {$whereClause}";
       $clauses[] = '`groups`.parents IS NULL';
     }
 
-    $savedSearch = CRM_Utils_Array::value('savedSearch', $params);
+    $savedSearch = $params['savedSearch'] ?? NULL;
     if ($savedSearch == 1) {
-      $clauses[] = 'groups.saved_search_id IS NOT NULL';
+      $clauses[] = '`groups`.saved_search_id IS NOT NULL';
     }
     elseif ($savedSearch == 2) {
-      $clauses[] = 'groups.saved_search_id IS NULL';
+      $clauses[] = '`groups`.saved_search_id IS NULL';
     }
 
     // only show child groups of a specific parent group

--- a/tests/phpunit/CRM/Group/Page/AjaxTest.php
+++ b/tests/phpunit/CRM/Group/Page/AjaxTest.php
@@ -98,7 +98,27 @@ class CRM_Group_Page_AjaxTest extends CiviUnitTestCase {
     }
     $this->assertEquals(1, $groups['recordsTotal']);
     $this->assertEquals('not-me-active', $groups['data'][0]['title']);
+    // Search on just smart groups keeping the title filter
+    $_GET['savedSearch'] = 1;
+    try {
+      CRM_Group_Page_AJAX::getGroupList();
+    }
+    catch (CRM_Core_Exception_PrematureExitException $e) {
+      $groups = $e->errorData;
+    }
+    $this->assertEquals(0, $groups['recordsTotal']);
+    // Now search on just normal groups keeping the title filter
+    $_GET['savedSearch'] = 2;
+    try {
+      CRM_Group_Page_AJAX::getGroupList();
+    }
+    catch (CRM_Core_Exception_PrematureExitException $e) {
+      $groups = $e->errorData;
+    }
+    $this->assertEquals(1, $groups['recordsTotal']);
+    $this->assertEquals('not-me-active', $groups['data'][0]['title']);
     unset($_GET['title']);
+    unset($_GET['savedSearch']);
 
     // check on status
     $_GET['status'] = 2;


### PR DESCRIPTION
…test coverage

Overview
----------------------------------------
Followup to #18246 as per @MegaphoneJon 's comments https://github.com/civicrm/civicrm-core/pull/18246#issuecomment-687632816

Before
----------------------------------------
Test coverage only covered searching smart groups as the filter type

After
----------------------------------------
Test coverage covers all 3 states 

ping @MegaphoneJon @eileenmcnaughton 