### PR TITLE
[REF] simplify interaction with objects in complete order

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -13,6 +13,7 @@ use Civi\Api4\Activity;
 use Civi\Api4\ContributionPage;
 use Civi\Api4\ContributionRecur;
 use Civi\Api4\Participant;
+use Civi\Api4\PaymentProcessor;
 
 /**
  *
@@ -4425,10 +4426,8 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
 
     $contributionParams['payment_processor'] = $paymentProcessorId;
 
-    // If paymentProcessor is not set then the payment_instrument_id would not be correct.
-    // not clear when or if this would occur if you encounter this please fix here & add a unit test.
     if (empty($contributionParams['payment_instrument_id']) && isset($contribution->_relatedObjects['paymentProcessor']['payment_instrument_id'])) {
-      $contributionParams['payment_instrument_id'] = $contribution->_relatedObjects['paymentProcessor']['payment_instrument_id'];
+      $contributionParams['payment_instrument_id'] = PaymentProcessor::get()->addWhere('id', '=', $paymentProcessorId)->addSelect('payment_instrument_id')->execute()->first()['payment_instrument_id'];
     }
 
     if ($recurringContributionID) {

--- a/tests/phpunit/CRM/Member/BAO/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/BAO/MembershipTest.php
@@ -757,7 +757,9 @@ class CRM_Member_BAO_MembershipTest extends CiviUnitTestCase {
       'original_contribution_id' => $contribution['id'],
       'contribution_status_id' => 'Completed',
     ]);
-    $this->callAPISuccessGetCount('Contribution', [], 2);
+    $contributions = $this->callAPISuccess('Contribution', 'get', ['sequential' => 1])['values'];
+    $this->assertCount(2, $contributions);
+    $this->assertEquals('Debit Card', CRM_Core_PseudoConstant::getName('CRM_Contribute_BAO_Contribution', 'payment_instrument_id', $contributions[1]['payment_instrument_id']));
     // @todo this fails depending on what tests it is run with due some bad stuff in Membership.create
     // It needs to be addressed but might involve the switch to ORDER. Membership BAO does bad line item stuff.
     // $this->callAPISuccessGetCount('LineItem', [], 6);


### PR DESCRIPTION


Overview
----------------------------------------
Minor code simplification

Before
----------------------------------------
$paymentProcessorID needs to be in $objects AND $contribution->_relatedObjects

After
----------------------------------------
Only objects accessed

Technical Details
----------------------------------------
Per https://github.com/civicrm/civicrm-core/pull/18382 this line seems to be heavily tested so
& per the test we can use the 'already calculated value' for payment_processor_id rather than look
it up in yet another place.

This adds a query but in most cases queries can be removed before calling this function as
the various objects are not really accessed anymore (apart from the few lines just above this)

Comments
----------------------------------------
@seamuslee001 
