### PR TITLE
dev/core#1989 - E_WARNING when editing custom field with logging turned on

### DIFF
--- a/CRM/Logging/Schema.php
+++ b/CRM/Logging/Schema.php
@@ -441,10 +441,12 @@ AND    (TABLE_NAME LIKE 'log_civicrm_%' $nonStandardTableNameString )
     // should treat it as a modification.
     $this->resetSchemaCacheForTable("log_$table");
     $logTableSchema = $this->columnSpecsOf("log_$table");
-    foreach ($cols['ADD'] as $colKey => $col) {
-      if (array_key_exists($col, $logTableSchema)) {
-        $cols['MODIFY'][] = $col;
-        unset($cols['ADD'][$colKey]);
+    if (!empty($cols['ADD'])) {
+      foreach ($cols['ADD'] as $colKey => $col) {
+        if (array_key_exists($col, $logTableSchema)) {
+          $cols['MODIFY'][] = $col;
+          unset($cols['ADD'][$colKey]);
+        }
       }
     }
 

--- a/tests/phpunit/CRM/Logging/SchemaTest.php
+++ b/tests/phpunit/CRM/Logging/SchemaTest.php
@@ -325,6 +325,44 @@ class CRM_Logging_SchemaTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test editing a custom field
+   */
+  public function testCustomFieldEdit() {
+    $schema = new CRM_Logging_Schema();
+    $schema->enableLogging();
+    $customGroup = $this->entityCustomGroupWithSingleFieldCreate('Contact', 'ContactTest.php');
+
+    // get the custom group table name
+    $params = ['id' => $customGroup['custom_group_id']];
+    $custom_group = $this->callAPISuccess('custom_group', 'getsingle', $params);
+
+    // get the field db column name
+    $params = ['id' => $customGroup['custom_field_id']];
+    $custom_field = $this->callAPISuccess('custom_field', 'getsingle', $params);
+
+    // check it
+    $dao = CRM_Core_DAO::executeQuery("SHOW CREATE TABLE `log_{$custom_group['table_name']}`");
+    $dao->fetch();
+    $this->assertStringContainsString("`{$custom_field['column_name']}` varchar(255)", $dao->Create_Table);
+
+    // Edit the field
+    $params = [
+      'id' => $customGroup['custom_field_id'],
+      'label' => 'Label changed',
+      'text_length' => 768,
+    ];
+    $this->callAPISuccess('custom_field', 'create', $params);
+
+    // update logging schema
+    $schema->fixSchemaDifferences();
+
+    // verify
+    $dao = CRM_Core_DAO::executeQuery("SHOW CREATE TABLE `log_{$custom_group['table_name']}`");
+    $dao->fetch();
+    $this->assertStringContainsString("`{$custom_field['column_name']}` varchar(768)", $dao->Create_Table);
+  }
+
+  /**
    * Determine if we are running on MySQL 8 version 8.0.19 or later.
    *
    * @return bool


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/1989

1. Turn on logging (admin - system settings - misc).
2. Turn off popups so you can see the warning (admin - customize - display prefs) (or install the loudnotices extension).
3. Edit an existing custom field, e.g. just change the label, or don't even do anything and just click save.
4. ==> `Notice: Undefined index: ADD`
5. ==> `Warning: Invalid argument supplied for foreach()`

Technical Details
----------------------------------------
When there isn't anything to add to the table the array is empty.

Comments
----------------------------------------
Has test.
With whitespace ignored it's a one-line change.
