### PR TITLE
[REF] Remove unused lines from loadObjects

### DIFF
--- a/CRM/Core/Payment/BaseIPN.php
+++ b/CRM/Core/Payment/BaseIPN.php
@@ -92,9 +92,7 @@ class CRM_Core_Payment_BaseIPN {
     $contribution = new CRM_Contribute_BAO_Contribution();
     $contribution->id = $ids['contribution'];
     if (!$contribution->find(TRUE)) {
-      CRM_Core_Error::debug_log_message("Could not find contribution record: {$contribution->id} in IPN request: " . print_r($input, TRUE));
-      echo "Failure: Could not find contribution record for {$contribution->id}<p>";
-      return FALSE;
+      throw new CRM_Core_Exception('Failure: Could not find contribution record for ' . (int) $contribution->id, NULL, ['context' => "Could not find contribution record: {$contribution->id} in IPN request: " . print_r($input, TRUE)]);
     }
 
     // make sure contact exists and is valid
@@ -159,17 +157,8 @@ class CRM_Core_Payment_BaseIPN {
         'echo_error' => 1,
       ];
     }
+    $contribution = &$objects['contribution'];
     $ids['paymentProcessor'] = $paymentProcessorID;
-    if (is_a($objects['contribution'], 'CRM_Contribute_BAO_Contribution')) {
-      $contribution = &$objects['contribution'];
-    }
-    else {
-      //legacy support - functions are 'used' to be able to pass in a DAO
-      $contribution = new CRM_Contribute_BAO_Contribution();
-      $contribution->id = $ids['contribution'] ?? NULL;
-      $contribution->find(TRUE);
-      $objects['contribution'] = &$contribution;
-    }
     try {
       $success = $contribution->loadRelatedObjects($input, $ids);
       if ($required && empty($contribution->_relatedObjects['paymentProcessor'])) {


### PR DESCRIPTION

Overview
----------------------------------------
Minor code cleanup

Before
----------------------------------------
Unreachable code muddying the waters

After
----------------------------------------
poof

Technical Details
----------------------------------------
loadObjects is only called from one place. As we can see the contribution object is
always passed in so we don't need to handle the possibility of it being anything other than a
BAO (I tweaked the error handling around that line too to make it clearer where it was
coming from)

<img width="1276" alt="Screen Shot 2020-09-07 at 9 05 57 AM" src="https://user-images.githubusercontent.com/336308/92335698-91aa6480-f0ed-11ea-8cc4-0df1c8bbd844.png">


Comments
----------------------------------------

