### PR TITLE
[NFC/Test framework] Make class name match file name

### DIFF
--- a/tests/phpunit/CRM/Contact/AllTests.php
+++ b/tests/phpunit/CRM/Contact/AllTests.php
@@ -1,8 +1,6 @@
 <?php
-// vim: set si ai expandtab tabstop=4 shiftwidth=4 softtabstop=4:
-
 /**
- *  File for the CRM_Contacts_AllTests class
+ *  File for the CRM_Contact_AllTests class
  *
  *  (PHP 5)
  *
@@ -34,7 +32,7 @@
  *
  * @package   CiviCRM
  */
-class CRM_Contacts_AllTests extends CiviTestSuite {
+class CRM_Contact_AllTests extends CiviTestSuite {
   private static $instance = NULL;
 
   /**
@@ -55,13 +53,3 @@ class CRM_Contacts_AllTests extends CiviTestSuite {
   }
 
 }
-// class CRM_Contacts_AllTests
-
-// -- set Emacs parameters --
-// Local variables:
-// mode: php;
-// tab-width: 4
-// c-basic-offset: 4
-// c-hanging-comment-ender-p: nil
-// indent-tabs-mode: nil
-// End:

--- a/tests/phpunit/CRM/Contact/BAO/RelationshipCacheTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/RelationshipCacheTest.php
@@ -15,7 +15,7 @@
  * @package CiviCRM
  * @group headless
  */
-class RelationshipCacheTest extends CiviUnitTestCase {
+class CRM_Contact_BAO_RelationshipCacheTest extends CiviUnitTestCase {
 
   protected function setUp() {
     $this->useTransaction(TRUE);


### PR DESCRIPTION
Overview
----------------------------------------
There's only these 2 that don't match the pattern.

Also vi/emacs (*emacs!*) settings don't need to be in the file.