### PR TITLE
[NFC] Aim to reduce memory usage in create single value alter test by…

### DIFF
--- a/tests/phpunit/api/v3/SyntaxConformanceTest.php
+++ b/tests/phpunit/api/v3/SyntaxConformanceTest.php
@@ -1511,6 +1511,8 @@ class api_v3_SyntaxConformanceTest extends CiviUnitTestCase {
       foreach ($floatFields as $floatField) {
         $checkEntity[$floatField] = rtrim($checkEntity[$floatField], "0");
       }
+      unset($entity['xdebug']);
+      unset($checkEntity['xdebug']);
       $this->assertAPIArrayComparison($entity, $checkEntity, [], "checking if $fieldName was correctly updated\n" . print_r([
         'update-params' => $updateParams,
         'update-result' => $update,


### PR DESCRIPTION
… removing xdebug items from comparaison

Before
----------------------------------------
Every element of the returned array is compared

After
----------------------------------------
Only meaningful elements of the arrays are compared

Comments
----------------------------------------
@eileenmcnaughton 