### PR TITLE
dev/core#1987: Enable frontend and backend theme configuration in display preference page for Drupal CMS

### DIFF
--- a/templates/CRM/Admin/Form/Preferences/Display.tpl
+++ b/templates/CRM/Admin/Form/Preferences/Display.tpl
@@ -206,22 +206,14 @@
         {$form.menubar_color.html}
       </td>
     </tr>
-
-    {if $config->userSystem->is_drupal EQ '1'}
-      <tr class="crm-preferences-display-form-block-theme">
-        <td class="label">{ts}Theme{/ts} {help id="theme"}</td>
-        <td>{$form.theme_backend.html}</td>
-      </tr>
-    {else}
-      <tr class="crm-preferences-display-form-block-theme_backend">
-        <td class="label">{$form.theme_backend.label} {help id="theme_backend"}</td>
-        <td>{$form.theme_backend.html}</td>
-      </tr>
-      <tr class="crm-preferences-display-form-block-theme_frontend">
-        <td class="label">{$form.theme_frontend.label} {help id="theme_frontend"}</td>
-        <td>{$form.theme_frontend.html}</td>
-      </tr>
-      {/if}
+    <tr class="crm-preferences-display-form-block-theme_backend">
+      <td class="label">{$form.theme_backend.label} {help id="theme_backend"}</td>
+      <td>{$form.theme_backend.html}</td>
+    </tr>
+    <tr class="crm-preferences-display-form-block-theme_frontend">
+      <td class="label">{$form.theme_frontend.label} {help id="theme_frontend"}</td>
+      <td>{$form.theme_frontend.html}</td>
+    </tr>
   </table>
   <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
 </div>


### PR DESCRIPTION
Overview
----------------------------------------
CiviCRM, to handle front end pages theme (public pages) and backend pages theme (CiviCRM pages) separately, Ir contains a configuration under `civicrm/admin/setting/preferences/display?reset=1`. Where it provides a configuration field for the backend and the front end theme separately. 
  This works for all CMS except Drupal. For Drupal, it only had the `Theme` option which configures only the backend theme. This PR enables both the options for Drupal CMS too and also makes sure the correct theme (front end theme) is loaded on Drupal webform pages which loads CiviCRM components.

Before
----------------------------------------
![3ffa703e-9774-4224-abb0-c967b809dbef](https://user-images.githubusercontent.com/3340537/91982982-a7fc9d00-ed48-11ea-8813-d14926436a43.png)

After
----------------------------------------
![3403e6d0-6a80-4e20-ac50-bd24190cc858](https://user-images.githubusercontent.com/3340537/91983003-af23ab00-ed48-11ea-8fad-35bac2bb0087.png)

Technical Details
----------------------------------------
* `Display.tpl` was fixed so that both front end and backend theme configuration was provided to the end-user. The contextual logic for hiding the FE and BE configuration for Drupal CMS is removed.

