### PR TITLE
dev/core#1987: Fix Drupal Base 'isFrontEndPage' function to consider Drupal public page for FE theme

### DIFF
--- a/CRM/Utils/System/DrupalBase.php
+++ b/CRM/Utils/System/DrupalBase.php
@@ -660,7 +660,8 @@ abstract class CRM_Utils_System_DrupalBase extends CRM_Utils_System_Base {
 
     // Get the menu for above URL.
     $item = CRM_Core_Menu::get($path);
-    return !empty($item['is_public']);
+    // In case the URL is not a civicrm page (a drupal page) we set the FE theme to TRUE - covering the corner case
+    return (empty($item) || !empty($item['is_public']));
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Drupal webform pages may have CiviCRM fields which internally initialize CiviCRM assets and was loading CiviCRM current theme assets. This is because CiviCRM doesn't have the logic for checking Drupal webform pages, whether they are FE pages or backend and since the logic is incomplete it loads the backend theme which because of [this logic](https://github.com/civicrm/civicrm-core/blob/master/Civi/Core/Themes.php#L72.).

Extract
----------------------------------------
The whole idea is to tell Civicrm to treat non civicrm pages (Drupal public pages) which loads civicrm code to treat them as the front end page and apply front end theme. Currently it doesn't it treats these pages as backend pages and apply the civicrm backend theme on them.

Before
----------------------------------------
The CiviCRM was loading backend theme for the Drupal public web form pages which loads CiviCRM components.
Webform page which has civicrm enabled
<img width="1648" alt="Screenshot 2020-09-24 at 3 45 53 PM" src="https://user-images.githubusercontent.com/3340537/94133137-e6840400-fe7d-11ea-8418-3aa4d75f5b2d.png">

After
----------------------------------------
The CiviCRM was loading the front theme for the Drupal public web form pages which loads CiviCRM components.
Webform page which has civicrm enabled
<img width="1679" alt="Screenshot 2020-09-24 at 3 48 03 PM" src="https://user-images.githubusercontent.com/3340537/94133149-ea178b00-fe7d-11ea-9261-b4853ba1e4d4.png">

Technical Details
----------------------------------------
* `isFrontEndPage` is updated so that it treats Drupal public web form pages as CiviCRM public pages and load front end theme there.


### Note
The before and after screenshots are added after adding a `var_dump` in `getActiveThemeKey` function in `Themes.php`.
<img width="930" alt="Screenshot 2020-09-24 at 3 50 01 PM" src="https://user-images.githubusercontent.com/3340537/94133091-d2d89d80-fe7d-11ea-833f-9167591049e4.png">


