### PR TITLE
Fix formatLocaleNumericRoundedByCurrency

### DIFF
--- a/CRM/Utils/Money.php
+++ b/CRM/Utils/Money.php
@@ -201,7 +201,7 @@ class CRM_Utils_Money {
    * @return string
    */
   protected static function formatLocaleNumericRounded($amount, $numberOfPlaces) {
-    return self::formatLocaleNumeric(round($amount, $numberOfPlaces));
+    return self::formatNumericByFormat($amount, '%!.' . $numberOfPlaces . 'i');
   }
 
   /**
@@ -216,7 +216,42 @@ class CRM_Utils_Money {
    *   Formatted amount.
    */
   public static function formatLocaleNumericRoundedByCurrency($amount, $currency) {
-    $amount = self::formatLocaleNumericRounded($amount, self::getCurrencyPrecision($currency));
+    return self::formatLocaleNumericRoundedByPrecision($amount, self::getCurrencyPrecision($currency));
+  }
+
+  /**
+   * Format money for display (just numeric part) according to the current locale with rounding to the supplied precision.
+   *
+   * This handles both rounding & replacement of the currency separators for the locale.
+   *
+   * @param string $amount
+   * @param int $precision
+   *
+   * @return string
+   *   Formatted amount.
+   */
+  public static function formatLocaleNumericRoundedByPrecision($amount, $precision) {
+    $amount = self::formatLocaleNumericRounded($amount, $precision);
+    return self::replaceCurrencySeparators($amount);
+  }
+
+  /**
+   * Format money for display with rounding to the supplied precision but without padding.
+   *
+   * If the string is shorter than the precision trailing zeros are not added to reach the precision
+   * beyond the 2 required for normally currency formatting.
+   *
+   * This handles both rounding & replacement of the currency separators for the locale.
+   *
+   * @param string $amount
+   * @param int $precision
+   *
+   * @return string
+   *   Formatted amount.
+   */
+  public static function formatLocaleNumericRoundedByOptionalPrecision($amount, $precision) {
+    $decimalPlaces = strlen(substr($amount, strpos($amount, '.') + 1));
+    $amount = self::formatLocaleNumericRounded($amount, $precision > $decimalPlaces ? $decimalPlaces : $precision);
     return self::replaceCurrencySeparators($amount);
   }
 

--- a/tests/phpunit/CRM/Utils/MoneyTest.php
+++ b/tests/phpunit/CRM/Utils/MoneyTest.php
@@ -73,6 +73,38 @@ class CRM_Utils_MoneyTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test rounded by currency function with specified precision.
+   *
+   * @param string $thousandSeparator
+   *
+   * @dataProvider getThousandSeparators
+   */
+  public function testFormatLocaleNumericRoundedByPrecision($thousandSeparator) {
+    $this->setCurrencySeparators($thousandSeparator);
+    $result = CRM_Utils_Money::formatLocaleNumericRoundedByPrecision(8950.3678, 3);
+    $expected = ($thousandSeparator === ',') ? '8,950.368' : '8.950,368';
+    $this->assertEquals($expected, $result);
+  }
+
+  /**
+   * Test rounded by currency function with specified precision but without padding to reach it.
+   *
+   * @param string $thousandSeparator
+   *
+   * @dataProvider getThousandSeparators
+   */
+  public function testFormatLocaleNumericRoundedByOptionalPrecision($thousandSeparator) {
+    $this->setCurrencySeparators($thousandSeparator);
+    $result = CRM_Utils_Money::formatLocaleNumericRoundedByOptionalPrecision(8950.3678, 8);
+    $expected = ($thousandSeparator === ',') ? '8,950.3678' : '8.950,3678';
+    $this->assertEquals($expected, $result);
+
+    $result = CRM_Utils_Money::formatLocaleNumericRoundedByOptionalPrecision(123456789.987654321, 9);
+    $expected = ($thousandSeparator === ',') ? '123,456,789.98765' : '123.456.789,98765';
+    $this->assertEquals($result, $expected);
+  }
+
+  /**
    * Test that using the space character as a currency works
    */
   public function testSpaceCurrency() {


### PR DESCRIPTION


Overview
----------------------------------------
The function was rounding by a max of 2 regardless of the number of places passed - it
was only tested for 2 so seemed to work

Before
----------------------------------------
Regardless of the value of $numberOfPlaces it is always rounded to 2
```
 protected static function formatLocaleNumericRounded($amount, $numberOfPlaces) {
```

After
----------------------------------------
Rounds to actual number of places

Technical Details
----------------------------------------
This is the function fix pulled out of https://github.com/civicrm/civicrm-core/pull/18297

In ^^ there was an example which didn't work - the issue is at the php layer - the value is truncated by php & we won't resolve that without implementing brickmoney but it seems reasonable to leave out of scope

See how hard coded amount is passed directly to a function

<img width="840" alt="Screen Shot 2020-09-09 at 7 47 37 AM" src="https://user-images.githubusercontent.com/336308/92521468-605aa180-f271-11ea-94a1-d54f3469d1a7.png">

But it's received differently in the functionn

<img width="817" alt="Screen Shot 2020-09-09 at 7 47 45 AM" src="https://user-images.githubusercontent.com/336308/92521483-66508280-f271-11ea-868d-a534968e2cdf.png">

The total string length seems to matter - one less character at the beginning is one less at the end
<img width="660" alt="Screen Shot 2020-09-09 at 7 53 39 AM" src="https://user-images.githubusercontent.com/336308/92521657-b62f4980-f271-11ea-90e0-2d23c5e6ea5d.png">



Comments
----------------------------------------
