### PR TITLE
CRM-9362: PCP 'Your Message' should use WYSIWYG

### DIFF
--- a/CRM/PCP/Form/Campaign.php
+++ b/CRM/PCP/Form/Campaign.php
@@ -109,7 +109,7 @@ class CRM_PCP_Form_Campaign extends CRM_Core_Form {
     }
 
     $attrib = ['rows' => 8, 'cols' => 60];
-    $this->add('textarea', 'page_text', ts('Your Message'), NULL, FALSE);
+    $this->add('wysiwyg', 'page_text', ts('Your Message'), NULL, FALSE);
 
     $maxAttachments = 1;
     CRM_Core_BAO_File::buildAttachment($this, 'civicrm_pcp', $this->_pageId, $maxAttachments);


### PR DESCRIPTION
Overview
----------------------------------------
The page where you edit your PCP settings has a `textarea` field where a `wysiwyg` field should be.

Before
----------------------------------------
![Selection_911](https://user-images.githubusercontent.com/1796012/92526085-e71c6980-f1f2-11ea-903a-344ec9401506.png)

After
----------------------------------------
![Selection_910](https://user-images.githubusercontent.com/1796012/92526096-eb488700-f1f2-11ea-8e0f-61c44be38b28.png)


Technical Details
----------------------------------------
It's literally a one-word change.

Comments
----------------------------------------
I don't know when this regressed - but it must have been in SVN times.
