### PR TITLE
[REF] Minor readability fix

### DIFF
--- a/CRM/ACL/BAO/ACL.php
+++ b/CRM/ACL/BAO/ACL.php
@@ -206,30 +206,25 @@ SELECT      acl.*
 
     $rule = new CRM_ACL_BAO_ACL();
 
-    $aclRole = 'civicrm_acl_role';
-
-    $aclER = CRM_ACL_DAO_EntityRole::getTableName();
-    $c2g = CRM_Contact_BAO_GroupContact::getTableName();
-
     $query = "   SELECT          acl.*
                         FROM            civicrm_acl acl
                         INNER JOIN      civicrm_option_group og
                                 ON      og.name = 'acl_role'
                         INNER JOIN      civicrm_option_value ov
-                                ON      acl.entity_table   = '$aclRole'
+                                ON      acl.entity_table   = 'civicrm_acl_role'
                                 AND     ov.option_group_id  = og.id
                                 AND     acl.entity_id      = ov.value
                                 AND     ov.is_active        = 1
-                        INNER JOIN      $aclER
-                                ON      $aclER.acl_role_id = acl.entity_id
-                                AND     $aclER.is_active    = 1
-                        INNER JOIN  $c2g
-                                ON      $aclER.entity_id      = $c2g.group_id
-                                AND     $aclER.entity_table   = 'civicrm_group'
-                        WHERE       acl.entity_table       = '$aclRole'
+                        INNER JOIN      civicrm_acl_entity_role acl_entity_role
+                                ON      acl_entity_role.acl_role_id = acl.entity_id
+                                AND     acl_entity_role.is_active    = 1
+                        INNER JOIN  civicrm_group_contact group_contact
+                                ON      acl_entity_role.entity_id      = group_contact.group_id
+                                AND     acl_entity_role.entity_table   = 'civicrm_group'
+                        WHERE       acl.entity_table       = 'civicrm_acl_role'
                             AND     acl.is_active          = 1
-                            AND     $c2g.contact_id         = $contact_id
-                            AND     $c2g.status             = 'Added'";
+                            AND     group_contact.contact_id         = $contact_id
+                            AND     group_contact.status             = 'Added'";
 
     $results = [];
 


### PR DESCRIPTION


Overview
----------------------------------------
Removes some unnecessary variables for readability

Before
----------------------------------------
Hard to see what tables are in the sql

After
----------------------------------------
Just call em by their names

Technical Details
----------------------------------------
None of the table names in this query are localisable so we don't need to use variables
to refer to them.

Note the legacy dao->query() would require it if they were localisable whereas CRM_Core_DAO::executeQuery()
does not

Comments
----------------------------------------

