### PR TITLE
dev/core#2003 Use Brick/Money to ensure that we display all possible …

### DIFF
--- a/CRM/Price/Form/Option.php
+++ b/CRM/Price/Form/Option.php
@@ -75,10 +75,7 @@ class CRM_Price_Form_Option extends CRM_Core_Form {
 
       // fix the display of the monetary value, CRM-4038
       foreach ($this->_moneyFields as $field) {
-        // @todo use formatLocaleNumericRoundedByOptionalPrecision - but note that there is an issue where php doesn't handle
-        // money strings beyond a certain total length - per https://github.com/civicrm/civicrm-core/pull/18409
-        // & https://github.com/civicrm/civicrm-core/pull/18409
-        $defaults[$field] = CRM_Utils_Money::format(CRM_Utils_Array::value($field, $defaults), NULL, '%a');
+        $defaults[$field] = isset($defaults[$field]) ? CRM_Utils_Money::formatLocaleNumericRoundedByOptionalPrecision($defaults[$field], 9) : '';
       }
     }
 


### PR DESCRIPTION
…digits stored in the database for the option amount

Overview
----------------------------------------
This aims to fix the value shown when editing a price option to show all the possible decimal places

Before
----------------------------------------
Only 2 decimal places would get shown on the price field option value edit page. 

Attempting to show more with the existing functionality works to a point but php truncates very long floats (e.g if there are significant numbers before the decimal point as well as after)

After
----------------------------------------
All 9 decimal places are possible

Technical Details
----------------------------------------
This embeds us into needing the PHP INTL extension by using the `NumberFormatter` class to do the formatting of the number but it has been 3 months now and we have ~3,000 sites (~26% of all sites) on 5.27 or higher which would trigger the notices about needing PHP-INTL Extension and so far no one has reported in that they haven't been able to add it in.

ping @jaapjansma @eileenmcnaughton 
