### PR TITLE
dev/financial#86 Make 'Record Payment' & 'Record Refund' visible regardless of whether the balance 'requires' one

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -5201,35 +5201,27 @@ LIMIT 1;";
       'title' => ts('Record Payment'),
     ];
 
-    if ((int) $balance > 0) {
-      // @todo - this should be possible even if not > 0 - test & remove this if.
-      // it is possible to 'overpay' in the real world & we honor that.
-      if (CRM_Core_Config::isEnabledBackOfficeCreditCardPayments()) {
-        $actionLinks[] = [
-          'url' => CRM_Utils_System::url('civicrm/payment', [
-            'action' => 'add',
-            'reset' => 1,
-            'is_refund' => 0,
-            'id' => $id,
-            'mode' => 'live',
-          ]),
-          'title' => ts('Submit Credit Card payment'),
-        ];
-      }
-    }
-    elseif ((int) $balance < 0) {
-      // @todo - in the future remove this IF - OK to refund money even when not due since
-      // ... life.
+    if (CRM_Core_Config::isEnabledBackOfficeCreditCardPayments()) {
       $actionLinks[] = [
         'url' => CRM_Utils_System::url('civicrm/payment', [
           'action' => 'add',
           'reset' => 1,
+          'is_refund' => 0,
           'id' => $id,
-          'is_refund' => 1,
+          'mode' => 'live',
         ]),
-        'title' => ts('Record Refund'),
+        'title' => ts('Submit Credit Card payment'),
       ];
     }
+    $actionLinks[] = [
+      'url' => CRM_Utils_System::url('civicrm/payment', [
+        'action' => 'add',
+        'reset' => 1,
+        'id' => $id,
+        'is_refund' => 1,
+      ]),
+      'title' => ts('Record Refund'),
+    ];
     return $actionLinks;
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
This was agreed about a year ago - might as well do it

Before
----------------------------------------
No way to record an overpayment or unintended refund in the UI

After
----------------------------------------
<img width="776" alt="Screen Shot 2020-09-09 at 6 25 13 PM" src="https://user-images.githubusercontent.com/336308/92563326-8876ee80-f2cb-11ea-8ae8-d91e6c5c7296.png">

Note the Contribution status is not altered if a contribution is overpaid - adding a payment <> changing the amount that we expected to be paid, it just means you can enter it. I am not sure if adding a refund (e.g bounced check) changes to 'Partially refunded'  or even if it should - but those things are not specific to this change but rather to how Payment.create action works


Technical Details
----------------------------------------
I've kept this to the one place for now - if it gets complicated I'lll punt it again but it looked easy when I saw the gitlab (looking for something else)

Comments
----------------------------------------

Let's merge this based on an emoji poll - I'm sure there are other things we could do but I'm not that motivated so I'd like to either merge or close this (& if closed return to gitlab). I don't mind looking at follow up changes on how Payment.create should act (there may already be existing gitlabs)