### PR TITLE
report#49: add contact type custom fields to contribution details

### DIFF
--- a/CRM/Report/Form/Member/ContributionDetail.php
+++ b/CRM/Report/Form/Member/ContributionDetail.php
@@ -22,6 +22,9 @@ class CRM_Report_Form_Member_ContributionDetail extends CRM_Report_Form {
     'Contribution',
     'Membership',
     'Contact',
+    'Individual',
+    'Household',
+    'Organization',
   ];
 
   /**


### PR DESCRIPTION
https://lab.civicrm.org/dev/report/-/issues/49

Overview
----------------------------------------
Every other report template that has Contact in the $_customGroupExtends array also includes individual contact types - "Individual" almost always, "Organization" and "Household" where relevant.

This PR adds the contact types to the $_customGroupExtends array.


Before
----------------------------------------
Custom fields assigned to "Individual", "Household", and "Organization" are not available for selection on this report.

After
----------------------------------------
They are.