### PR TITLE
Minor code simplification on date handling in getMembershipStatusByDate

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2328,7 +2328,7 @@ LEFT JOIN  civicrm_contribution contribution ON ( componentPayment.contribution_
             $calcStatus = CRM_Member_BAO_MembershipStatus::getMembershipStatusByDate($dates['start_date'],
               $dates['end_date'],
               $dates['join_date'],
-              'today',
+              'now',
               TRUE,
               $membership->membership_type_id,
               (array) $membership
@@ -5180,7 +5180,7 @@ LIMIT 1;";
       $calcStatus = CRM_Member_BAO_MembershipStatus::getMembershipStatusByDate($dates['start_date'],
         $dates['end_date'],
         $dates['join_date'],
-        'today',
+        'now',
         TRUE,
         $membershipParams['membership_type_id'],
         $membershipParams

--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -265,7 +265,7 @@ class CRM_Member_BAO_Membership extends CRM_Member_DAO_Membership {
       }
 
       $calcStatus = CRM_Member_BAO_MembershipStatus::getMembershipStatusByDate($params['start_date'], $params['end_date'], $params['join_date'],
-        'today', $excludeIsAdmin, $params['membership_type_id'] ?? NULL, $params
+        'now', $excludeIsAdmin, $params['membership_type_id'] ?? NULL, $params
       );
       if (empty($calcStatus)) {
         throw new CRM_Core_Exception(ts("The membership cannot be saved because the status cannot be calculated for start_date: {$params['start_date']} end_date {$params['end_date']} join_date {$params['join_date']} as at " . date('Y-m-d H:i:s')));
@@ -1133,7 +1133,7 @@ AND civicrm_membership.is_test = %2";
    * @throws \CRM_Core_Exception
    */
   public static function fixMembershipStatusBeforeRenew(&$currentMembership, $changeToday) {
-    $today = NULL;
+    $today = 'now';
     if ($changeToday) {
       $today = CRM_Utils_Date::processDate($changeToday, NULL, FALSE, 'Y-m-d');
     }
@@ -1915,7 +1915,7 @@ INNER JOIN  civicrm_contact contact ON ( contact.id = membership.contact_id AND 
           CRM_Utils_Date::customFormat($dates['join_date'],
             $statusFormat
           ),
-          'today',
+          'now',
           TRUE,
           $membershipTypeID,
           $memParams
@@ -2675,7 +2675,7 @@ WHERE {$whereClause}";
             $updates["start_date"] ?? $newMembership->start_date,
             $updates["end_date"] ?? $newMembership->end_date,
             $updates["join_date"] ?? $newMembership->join_date,
-            'today',
+            'now',
             FALSE,
             $newMembershipId,
             $newMembership

--- a/CRM/Member/BAO/MembershipStatus.php
+++ b/CRM/Member/BAO/MembershipStatus.php
@@ -225,16 +225,16 @@ class CRM_Member_BAO_MembershipStatus extends CRM_Member_DAO_MembershipStatus {
    */
   public static function getMembershipStatusByDate(
     $startDate, $endDate, $joinDate,
-    $statusDate = 'today', $excludeIsAdmin = FALSE, $membershipTypeID = NULL, $membership = []
+    $statusDate = 'now', $excludeIsAdmin = FALSE, $membershipTypeID = NULL, $membership = []
   ) {
     $membershipDetails = [];
 
-    if (!$statusDate || $statusDate == 'today') {
-      $statusDate = date('Ymd');
+    if (!$statusDate || $statusDate === 'today') {
+      $statusDate = 'now';
+      CRM_Core_Error::deprecatedFunctionWarning('pass now rather than today in');
     }
-    else {
-      $statusDate = CRM_Utils_Date::customFormat($statusDate, '%Y%m%d');
-    }
+
+    $statusDate = date('Ymd', strtotime($statusDate));
 
     //fix for CRM-3570, if we have statuses with is_admin=1,
     //exclude these statuses from calculatation during import.

--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -822,7 +822,7 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
           $calcStatus = CRM_Member_BAO_MembershipStatus::getMembershipStatusByDate($startDate,
             $endDate,
             $joinDate,
-            'today',
+            'now',
             TRUE,
             $memType,
             $params

--- a/CRM/Member/Import/Parser/Membership.php
+++ b/CRM/Member/Import/Parser/Membership.php
@@ -428,7 +428,7 @@ class CRM_Member_Import_Parser_Membership extends CRM_Member_Import_Parser {
             $calcStatus = CRM_Member_BAO_MembershipStatus::getMembershipStatusByDate($startDate,
               $endDate,
               $joinDate,
-              'today',
+              'now',
               $excludeIsAdmin,
               $formatted['membership_type_id'],
               $formatted
@@ -518,7 +518,7 @@ class CRM_Member_Import_Parser_Membership extends CRM_Member_Import_Parser {
         $calcStatus = CRM_Member_BAO_MembershipStatus::getMembershipStatusByDate($startDate,
           $endDate,
           $joinDate,
-          'today',
+          'now',
           $excludeIsAdmin,
           $formatted['membership_type_id'],
           $formatted

--- a/api/v3/MembershipStatus.php
+++ b/api/v3/MembershipStatus.php
@@ -150,7 +150,7 @@ SELECT start_date, end_date, join_date, membership_type_id
   $dao = CRM_Core_DAO::executeQuery($query, $params);
   if ($dao->fetch()) {
     $membershipTypeID = empty($membershipParams['membership_type_id']) ? $dao->membership_type_id : $membershipParams['membership_type_id'];
-    $result = CRM_Member_BAO_MembershipStatus::getMembershipStatusByDate($dao->start_date, $dao->end_date, $dao->join_date, 'today', CRM_Utils_Array::value('ignore_admin_only', $membershipParams), $membershipTypeID, $membershipParams);
+    $result = CRM_Member_BAO_MembershipStatus::getMembershipStatusByDate($dao->start_date, $dao->end_date, $dao->join_date, 'now', CRM_Utils_Array::value('ignore_admin_only', $membershipParams), $membershipTypeID, $membershipParams);
     //make is error zero only when valid status found.
     if (!empty($result['id'])) {
       $result['is_error'] = 0;

--- a/tests/phpunit/CRM/Member/BAO/MembershipStatusTest.php
+++ b/tests/phpunit/CRM/Member/BAO/MembershipStatusTest.php
@@ -178,7 +178,7 @@ class CRM_Member_BAO_MembershipStatusTest extends CiviUnitTestCase {
     $membershipStatus = CRM_Member_BAO_MembershipStatus::add($params);
     $toDate = date('Ymd');
 
-    $result = CRM_Member_BAO_MembershipStatus::getMembershipStatusByDate($toDate, $toDate, $toDate, 'today', TRUE, NULL, $params);
+    $result = CRM_Member_BAO_MembershipStatus::getMembershipStatusByDate($toDate, $toDate, $toDate, 'now', TRUE, NULL, $params);
     $this->assertEquals($result['name'], 'Current', 'Verify membership status record.');
 
     $this->callAPISuccess('MembershipStatus', 'Delete', ['id' => $membershipStatus->id]);

--- a/tests/phpunit/CRM/Member/Form/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/Form/MembershipTest.php
@@ -477,6 +477,7 @@ class CRM_Member_Form_MembershipTest extends CiviUnitTestCase {
    *
    * @dataProvider getThousandSeparators
    * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
    */
   public function testSubmit($thousandSeparator) {
     CRM_Core_Session::singleton()->getStatus(TRUE);


### PR DESCRIPTION


Overview
----------------------------------------
This deprecates 'today' as a synonym for 'now' as the latter is more standard and slightly simplifies the date handling

Before
----------------------------------------
Uses weird function to do normal php date formatting
```
$statusDate = CRM_Utils_Date::customFormat($statusDate, '%Y%m%d');
```

After
----------------------------------------
uses strtotime, uses normal strtotime param

Technical Details
----------------------------------------

Comments
----------------------------------------
