### PR TITLE
NFC Clarify what CRM_Price_BAO_Priceset::getMembershipCount does

### DIFF
--- a/CRM/Price/BAO/PriceSet.php
+++ b/CRM/Price/BAO/PriceSet.php
@@ -1234,16 +1234,20 @@ INNER JOIN  civicrm_price_set pset    ON ( pset.id = field.price_set_id )
   }
 
   /**
-   * @param $ids
+   * Return a count of priceFieldValueIDs that are memberships by organisation and membership type
+   *
+   * @param string $priceFieldValueIDs
+   *   Comma separated string of priceFieldValue IDs
    *
    * @return array
+   *   Returns an array of counts by membership organisation
    */
-  public static function getMembershipCount($ids) {
+  public static function getMembershipCount($priceFieldValueIDs) {
     $queryString = "
 SELECT       count( pfv.id ) AS count, mt.member_of_contact_id AS id
 FROM         civicrm_price_field_value pfv
 INNER JOIN    civicrm_membership_type mt ON mt.id = pfv.membership_type_id
-WHERE        pfv.id IN ( $ids )
+WHERE        pfv.id IN ( $priceFieldValueIDs )
 GROUP BY     mt.member_of_contact_id ";
 
     $crmDAO = CRM_Core_DAO::executeQuery($queryString);

--- a/tests/phpunit/CRM/Price/BAO/PriceSetTest.php
+++ b/tests/phpunit/CRM/Price/BAO/PriceSetTest.php
@@ -82,7 +82,7 @@ class CRM_Price_BAO_PriceSetTest extends CiviUnitTestCase {
 
   /**
    * Test CRM_Price_BAO_PriceSet::getMembershipCount() that return correct number of
-   *   membership type occurances against it's corresponding member orgaisation
+   *   membership type occurrences against it's corresponding member organisation
    *
    * @throws \CRM_Core_Exception
    */


### PR DESCRIPTION
Overview
----------------------------------------
Partial from #18398 

This updates the docblock and variable name to clarify what the `CRM_Price_BAO_Priceset::getMembershipCount()` function actually does. It is called from a few places in the membership/contribution code and could probably be replaced. But first step is to make it clear what it actually does.

For example, reading the code you might easily make the assumption that the param `$ids` is an array of IDs.. But it's not.. It's actually a comma separated string of IDs.

Before
----------------------------------------
Difficult to understand what function is doing and expected params.

After
----------------------------------------
Easier to understand what function is doing and expected params.

Technical Details
----------------------------------------


Comments
----------------------------------------

