### PR TITLE
Switch backend membership form to use non-deprecated/cached functions to get membership types

### DIFF
--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -225,7 +225,9 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
           $cMemTypes[] = $mem['membership_type_id'];
         }
         if (count($cMemTypes) > 0) {
-          $memberorgs = CRM_Member_BAO_MembershipType::getMemberOfContactByMemTypes($cMemTypes);
+          foreach ($cMemTypes as $memTypeID) {
+            $memberorgs[$memTypeID] = CRM_Member_BAO_MembershipType::getMembershipType($memTypeID)['member_of_contact_id'];
+          }
           $mems_by_org = [];
           foreach ($contactMemberships as $mem) {
             $mem['member_of_contact_id'] = $memberorgs[$mem['membership_type_id']] ?? NULL;
@@ -759,8 +761,7 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
           $endDate = CRM_Utils_Date::processDate($params['end_date']);
         }
 
-        $membershipDetails = CRM_Member_BAO_MembershipType::getMembershipTypeDetails($memType);
-
+        $membershipDetails = CRM_Member_BAO_MembershipType::getMembershipType($memType);
         if ($startDate && CRM_Utils_Array::value('period_type', $membershipDetails) === 'rolling') {
           if ($startDate < $joinDate) {
             $errors['start_date'] = ts('Start date must be the same or later than Member since.');


### PR DESCRIPTION
Overview
----------------------------------------

Both `CRM_Member_BAO_MembershipType::``getMemberOfContactByMemTypes()` `getMembershipTypeDetails()` functions are non-cached functions to get information about the membershipType.

Switch to `CRM_Member_BAO_MembershipType::getMembershipType()` which is a cached function to get information about the same thing.

Partial from #18398 which is attempting to rationalise and cleanup the use of multiple functions to get the same information.

Before
----------------------------------------
Using non-cached function to get membershipType detail.

After
----------------------------------------
Using "standard" cached function to get membershipType detail.

Technical Details
----------------------------------------
The "cost" of retrieving all membershiptype details instead of just the membershiptype organisation is minimal because it still requires a "SELECT" from the database. But by using the cached function any other code that wants information can get it without triggering another lookup.

In this case we reduce the number of database queries by at least one when submitting the membership form (when both preProcess and formRule will be called).

Comments
----------------------------------------

