### PR TITLE
dev/core#2009 filter grant dashboard to exclude trashed contacts

### DIFF
--- a/CRM/Grant/BAO/Grant.php
+++ b/CRM/Grant/BAO/Grant.php
@@ -25,8 +25,13 @@ class CRM_Grant_BAO_Grant extends CRM_Grant_DAO_Grant {
    */
   public static function getGrantSummary($admin = FALSE) {
     $query = "
-            SELECT status_id, count(id) as status_total
-            FROM civicrm_grant  GROUP BY status_id";
+      SELECT status_id, count(g.id) as status_total
+      FROM civicrm_grant g
+      JOIN civicrm_contact c
+        ON g.contact_id = c.id
+      WHERE c.is_deleted = 0
+      GROUP BY status_id
+    ";
 
     $dao = CRM_Core_DAO::executeQuery($query);
 


### PR DESCRIPTION
Overview
----------------------------------------
The grant dashboard tallies include contacts that are trashed and shouldn't. To reproduce:

observe current dashboard stats for a specific status
create a contact and create a grant with that same status
trash the contact
observe the dashboard stats. it will have incremented by 1, including the trashed record

If you click the hyperlink to search for grants the trashed record is properly excluded. It's just the dashboard stats that are off.

Before
----------------------------------------
Grant dashboard counts grants attached to trashed contacts.

After
----------------------------------------
Grant dashboard does not count grants attached to trashed contacts.
