### PR TITLE
property bag's setAmount should ensure dot decimal point

### DIFF
--- a/Civi/Payment/PropertyBag.php
+++ b/Civi/Payment/PropertyBag.php
@@ -417,7 +417,20 @@ class PropertyBag implements \ArrayAccess {
   }
 
   /**
-   * Get the monetary amount.
+   * Set the monetary amount.
+   *
+   * - We expect to be called with a string amount with optional decimals using
+   *   a '.' as the decimal point (not a ',').
+   *
+   * - We're ok with floats/ints being passed in, too, but we'll cast them to a
+   *   string.
+   *
+   * - Negatives are fine.
+   *
+   * @see https://github.com/civicrm/civicrm-core/pull/18219
+   *
+   * @param string|float|int $value
+   * @param string $label
    */
   public function setAmount($value, $label = 'default') {
     if (!is_numeric($value)) {

--- a/Civi/Payment/PropertyBag.php
+++ b/Civi/Payment/PropertyBag.php
@@ -423,8 +423,7 @@ class PropertyBag implements \ArrayAccess {
     if (!is_numeric($value)) {
       throw new \InvalidArgumentException("setAmount requires a numeric amount value");
     }
-
-    return $this->set('amount', $label, \CRM_Utils_Money::format($value, NULL, NULL, TRUE));
+    return $this->set('amount', $label, filter_var($value, FILTER_SANITIZE_NUMBER_FLOAT, FILTER_FLAG_ALLOW_FRACTION));
   }
 
   /**

--- a/tests/phpunit/Civi/Payment/PropertyBagTest.php
+++ b/tests/phpunit/Civi/Payment/PropertyBagTest.php
@@ -45,6 +45,56 @@ class PropertyBagTest extends \PHPUnit\Framework\TestCase implements HeadlessInt
   }
 
   /**
+   * Test we can set an amount.
+   *
+   * @see https://github.com/civicrm/civicrm-core/pull/18219
+   *
+   * @dataProvider setAmountDataProvider
+   *
+   * @param mixed $value input
+   * @param mixed $expect output expected. Typically a string like '1.23' or NULL
+   * @param string $expectedExceptionMessage if there is one expected.
+   */
+  public function testSetAmount($value, $expect, $expectedExceptionMessage = '') {
+    $propertyBag = new PropertyBag();
+    try {
+      $propertyBag->setAmount($value);
+    }
+    catch (\Exception $e) {
+      if ($expectedExceptionMessage) {
+        $this->assertEquals($expectedExceptionMessage, $e->getMessage(), 'Expected a different exception.');
+        // OK.
+        return;
+      }
+      // not expecting an exception, re-throw it.
+      throw $e;
+    }
+    $got = $propertyBag->getAmount();
+    $this->assertInternalType('string', $got);
+    $this->assertEquals($expect, $got);
+  }
+
+  /**
+   *
+   */
+  public function setAmountDataProvider() {
+    return [
+      [1, '1'],
+      [1.23, '1.23'],
+      [1.234, '1.234'],
+      [-1.23, '-1.23'],
+      ['1', '1'],
+      ['1.23', '1.23'],
+      ['1.234', '1.234'],
+      ['-1.23', '-1.23'],
+      ['1,000.23', NULL, 'setAmount requires a numeric amount value'],
+      ['1,000', NULL, 'setAmount requires a numeric amount value'],
+      ['1,23', NULL, 'setAmount requires a numeric amount value'],
+      ['1.230,12', NULL, 'setAmount requires a numeric amount value'],
+    ];
+  }
+
+  /**
    * Test we cannot set an invalid contact ID.
    *
    * @expectedException \InvalidArgumentException


### PR DESCRIPTION
This is a follow up PR adding tests to https://github.com/civicrm/civicrm-core/pull/18219

Please see that PR for discussion and details.