### PR TITLE
dev/core#2017 Remove unused function OpenID::isAllowedToLogin

### DIFF
--- a/CRM/Core/BAO/OpenID.php
+++ b/CRM/Core/BAO/OpenID.php
@@ -44,23 +44,6 @@ class CRM_Core_BAO_OpenID extends CRM_Core_DAO_OpenID {
   }
 
   /**
-   * Returns whether or not this OpenID is allowed to login.
-   *
-   * @param string $identity_url
-   *   The OpenID to check.
-   *
-   * @return bool
-   */
-  public static function isAllowedToLogin($identity_url) {
-    $openId = new CRM_Core_DAO_OpenID();
-    $openId->openid = $identity_url;
-    if ($openId->find(TRUE)) {
-      return $openId->allowed_to_login == 1;
-    }
-    return FALSE;
-  }
-
-  /**
    * Get all the openids for a specified contact_id, with the primary openid being first
    *
    * @param int $id

--- a/tests/phpunit/CRM/Core/BAO/OpenIDTest.php
+++ b/tests/phpunit/CRM/Core/BAO/OpenIDTest.php
@@ -63,51 +63,6 @@ class CRM_Core_BAO_OpenIDTest extends CiviUnitTestCase {
   }
 
   /**
-   * IfAllowedToLogin() method (set and reset allowed_to_login)
-   */
-  public function testIfAllowedToLogin() {
-    $contactId = $this->individualCreate();
-    $this->assertDBRowExist('CRM_Contact_DAO_Contact', $contactId);
-    $openIdURL = "http://test-username.civicrm.org/";
-
-    $params = [
-      'contact_id' => $contactId,
-      'location_type_id' => 1,
-      'openid' => $openIdURL,
-      'is_primary' => 1,
-    ];
-
-    $openObject = CRM_Core_BAO_OpenID::add($params);
-
-    $openId = $openObject->id;
-    $this->assertDBNotNull('CRM_Core_DAO_OpenID', $openIdURL, 'id', 'openid',
-      'Database check for created OpenID.'
-    );
-
-    $allowedToLogin = CRM_Core_BAO_OpenID::isAllowedToLogin($openIdURL);
-    $this->assertEquals($allowedToLogin, FALSE, 'Verify allowed_to_login value is 0.');
-
-    // Now call add() to modify an existing open-id record
-
-    $params = [
-      'id' => $openId,
-      'contact_id' => $contactId,
-      'openid' => $openIdURL,
-      'is_bulkmail' => 1,
-      'allowed_to_login' => 1,
-    ];
-
-    CRM_Core_BAO_OpenID::add($params);
-
-    $allowedToLogin = CRM_Core_BAO_OpenID::isAllowedToLogin($openIdURL);
-
-    $this->assertEquals($allowedToLogin, TRUE, 'Verify allowed_to_login value is 1.');
-    $this->contactDelete($contactId);
-    //domain contact doesn't really get deleted //
-    $this->assertDBRowNotExist('CRM_Contact_DAO_Contact', $contactId);
-  }
-
-  /**
    * AllOpenIDs() method - get all OpenIDs for the given contact
    */
   public function testAllOpenIDs() {


### PR DESCRIPTION
Overview
----------------------------------------
Remove unused function OpenID::isAllowedToLogin

Before
----------------------------------------
<img width="1270" alt="Screen Shot 2020-09-11 at 8 00 13 PM" src="https://user-images.githubusercontent.com/336308/92898060-cd3c8a00-f471-11ea-962a-147ed926eeac.png">


After
----------------------------------------
poof

Technical Details
----------------------------------------


Comments
https://lab.civicrm.org/dev/core/-/issues/2017
