### PR TITLE
Search extension: edit smart groups

### DIFF
--- a/CRM/Contact/BAO/SavedSearch.php
+++ b/CRM/Contact/BAO/SavedSearch.php
@@ -54,9 +54,9 @@ class CRM_Contact_BAO_SavedSearch extends CRM_Contact_DAO_SavedSearch {
    * @param array $defaults
    *   (reference ) an assoc array to hold the flattened values.
    *
-   * @return CRM_Contact_BAO_SavedSearch
+   * @return CRM_Contact_DAO_SavedSearch
    */
-  public static function retrieve(&$params, &$defaults) {
+  public static function retrieve($params, &$defaults = []) {
     $savedSearch = new CRM_Contact_DAO_SavedSearch();
     $savedSearch->copyValues($params);
     if ($savedSearch->find(TRUE)) {
@@ -420,6 +420,35 @@ LEFT JOIN civicrm_email ON (contact_a.id = civicrm_email.contact_id AND civicrm_
         $formValues[$fieldName . '_to'] = $value;
         break;
     }
+  }
+
+  /**
+   * Generate a url to the appropriate search form for a given savedSearch
+   *
+   * @param int $id
+   *   Saved search id
+   * @return string
+   */
+  public static function getEditSearchUrl($id) {
+    $savedSearch = self::retrieve(['id' => $id]);
+    // APIv4 search
+    if (!empty($savedSearch->api_entity)) {
+      $groupName = self::getName($id);
+      return CRM_Utils_System::url('civicrm/search', NULL, FALSE, "/load/Group/$groupName");
+    }
+    // Classic search builder
+    if (!empty($savedSearch->mapping_id)) {
+      $path = 'civicrm/contact/search/builder';
+    }
+    // Classic custom search
+    elseif (!empty($savedSearch->search_custom_id)) {
+      $path = 'civicrm/contact/search/custom';
+    }
+    // Classic advanced search
+    else {
+      $path = 'civicrm/contact/search/advanced';
+    }
+    return CRM_Utils_System::url($path, ['reset' => 1, 'ssID' => $id]);
   }
 
 }

--- a/CRM/Contact/Form/Search.php
+++ b/CRM/Contact/Form/Search.php
@@ -429,11 +429,10 @@ class CRM_Contact_Form_Search extends CRM_Core_Form_Search {
         $ssID = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Group', $this->_groupID, 'saved_search_id');
         $this->assign('ssID', $ssID);
 
-        //get the saved search mapping id
+        //get the saved search edit link
         if ($ssID) {
           $this->_ssID = $ssID;
-          $ssMappingId = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_SavedSearch', $ssID, 'mapping_id');
-          $this->assign('ssMappingID', $ssMappingId);
+          $this->assign('editSmartGroupURL', CRM_Contact_BAO_SavedSearch::getEditSearchUrl($ssID));
         }
 
         // Set dynamic page title for 'Show Members of Group'

--- a/CRM/Group/Form/Edit.php
+++ b/CRM/Group/Form/Edit.php
@@ -137,14 +137,7 @@ class CRM_Group_Form_Edit extends CRM_Core_Form {
           'saved_search_id' => $this->_groupValues['saved_search_id'] ?? '',
         );
         if (isset($this->_groupValues['saved_search_id'])) {
-          $groupValues['mapping_id'] = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_SavedSearch',
-            $this->_groupValues['saved_search_id'],
-            'mapping_id'
-          );
-          $groupValues['search_custom_id'] = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_SavedSearch',
-            $this->_groupValues['saved_search_id'],
-            'search_custom_id'
-          );
+          $this->assign('editSmartGroupURL', CRM_Contact_BAO_SavedSearch::getEditSearchUrl($this->_groupValues['saved_search_id']));
         }
         if (!empty($this->_groupValues['created_id'])) {
           $groupValues['created_by'] = CRM_Core_DAO::getFieldValue("CRM_Contact_DAO_Contact", $this->_groupValues['created_id'], 'sort_name', 'id');

--- a/ang/api4Explorer/Explorer.js
+++ b/ang/api4Explorer/Explorer.js
@@ -791,7 +791,7 @@
           $scope.debug = debugFormat(resp.data);
           $scope.result = [
             formatMeta(resp.data),
-            prettyPrintOne('(' + resp.data.values.length + ') ' + _.escape(JSON.stringify(resp.data.values, null, 2)), 'js', 1)
+            prettyPrintOne((_.isArray(resp.data.values) ? '(' + resp.data.values.length + ') ' : '') + _.escape(JSON.stringify(resp.data.values, null, 2)), 'js', 1)
           ];
         }, function(resp) {
           $scope.loading = false;

--- a/ext/search/CRM/Search/Page/Ang.php
+++ b/ext/search/CRM/Search/Page/Ang.php
@@ -49,7 +49,7 @@ class CRM_Search_Page_Ang extends CRM_Core_Page {
     $loader->setModules(['search']);
     $loader->setPageName('civicrm/search');
     $loader->useApp([
-      'defaultRoute' => '/Contact',
+      'defaultRoute' => '/create/Contact',
     ]);
     $loader->load();
     parent::run();

--- a/ext/search/ang/search/SaveSmartGroup.ctrl.js
+++ b/ext/search/ang/search/SaveSmartGroup.ctrl.js
@@ -1,7 +1,7 @@
 (function(angular, $, _) {
   "use strict";
 
-  angular.module('search').controller('SaveSmartGroup', function ($scope, crmApi4, dialogService) {
+  angular.module('search').controller('SaveSmartGroup', function ($scope, $element, crmApi4, dialogService) {
     var ts = $scope.ts = CRM.ts(),
       model = $scope.model;
     $scope.groupEntityRefParams = {
@@ -23,9 +23,15 @@
       administerReservedGroups: CRM.checkPerm('administer reserved groups')
     };
     $scope.groupFields = _.indexBy(_.find(CRM.vars.search.schema, {name: 'Group'}).fields, 'name');
-    $scope.$watch('model.id', function (id) {
-      if (id) {
-        _.assign(model, $('#api-save-search-select-group').select2('data').extra);
+    $element.on('change', '#api-save-search-select-group', function() {
+      if ($(this).val()) {
+        $scope.$apply(function() {
+          var group = $('#api-save-search-select-group').select2('data').extra;
+          model.saved_search_id = group.saved_search_id;
+          model.description = group.description || '';
+          model.group_type = group.group_type || [];
+          model.visibility = group.visibility;
+        });
       }
     });
     $scope.cancel = function () {

--- a/ext/search/ang/search/crmSearch.component.js
+++ b/ext/search/ang/search/crmSearch.component.js
@@ -169,7 +169,10 @@
         })
           .finally(function() {
             if (ctrl.debug) {
-              ctrl.debug.params = JSON.stringify(ctrl.params, null, 2);
+              ctrl.debug.params = JSON.stringify(_.extend({version: 4}, ctrl.params), null, 2);
+              if (ctrl.debug.timeIndex) {
+                ctrl.debug.timeIndex = Number.parseFloat(ctrl.debug.timeIndex).toPrecision(2);
+              }
             }
           });
       }

--- a/ext/search/ang/search/crmSearch.component.js
+++ b/ext/search/ang/search/crmSearch.component.js
@@ -3,7 +3,8 @@
 
   angular.module('search').component('crmSearch', {
     bindings: {
-      entity: '='
+      entity: '=',
+      load: '<'
     },
     templateUrl: '~/search/crmSearch.html',
     controller: function($scope, $element, $timeout, crmApi4, dialogService, searchMeta, formatForSelect2) {
@@ -244,6 +245,9 @@
             ctrl.stale = true;
           }
         }
+        if (ctrl.load) {
+          ctrl.load.saved = false;
+        }
       }
 
       function onChangeOrderBy() {
@@ -255,6 +259,9 @@
       function onChangeFilters() {
         ctrl.stale = true;
         ctrl.selectedRows.length = 0;
+        if (ctrl.load) {
+          ctrl.load.saved = false;
+        }
         if (ctrl.autoSearch) {
           ctrl.refreshAll();
         }
@@ -526,6 +533,13 @@
         }
         $scope.$watch('$ctrl.params.having', onChangeFilters, true);
 
+        if (this.load) {
+          this.params = this.load.api_params;
+          $timeout(function() {
+            ctrl.load.saved = true;
+          });
+        }
+
         loadFieldOptions();
       };
 
@@ -540,16 +554,21 @@
           description: '',
           visibility: 'User and User Admin Only',
           group_type: [],
-          id: null,
+          id: ctrl.load ? ctrl.load.id : null,
           entity: ctrl.entity,
-          params: angular.extend({}, ctrl.params, {version: 4, select: [selectField]})
+          params: angular.extend({}, ctrl.params, {version: 4})
         };
         delete model.params.orderBy;
         var options = CRM.utils.adjustDialogDefaults({
           autoOpen: false,
           title: ts('Save smart group')
         });
-        dialogService.open('saveSearchDialog', '~/search/saveSmartGroup.html', model, options);
+        dialogService.open('saveSearchDialog', '~/search/saveSmartGroup.html', model, options)
+          .then(function() {
+            if (ctrl.load) {
+              ctrl.load.saved = true;
+            }
+          });
       };
     }
   });

--- a/ext/search/ang/search/crmSearch/criteria.html
+++ b/ext/search/ang/search/crmSearch/criteria.html
@@ -2,7 +2,7 @@
   <div>
     <div class="form-inline">
       <label for="crm-search-main-entity">{{:: ts('Search for') }}</label>
-      <input id="crm-search-main-entity" class="form-control" ng-model="$ctrl.entity" crm-ui-select="::{allowClear: false, data: entities}" ng-change="changeEntity()" />
+      <input id="crm-search-main-entity" class="form-control" ng-model="$ctrl.entity" crm-ui-select="::{allowClear: false, data: entities}" />
     </div>
     <div ng-if=":: $ctrl.paramExists('join')">
       <fieldset ng-repeat="join in $ctrl.params.join">
@@ -40,6 +40,12 @@
     </fieldset>
   </div>
   <div>
+    <div class="navbar-form clearfix" ng-if="$ctrl.load">
+      <div class="form-group pull-right">
+        <label>{{ $ctrl.load.title }}</label>
+        <button class="btn btn-default" ng-disabled="$ctrl.load.saved" ng-click="saveGroup()">{{ $ctrl.load.saved ? ts('Saved') : ts('Save') }}</button>
+      </div>
+    </div>
     <fieldset class="api4-clause-fieldset" crm-search-clause="{format: 'string', clauses: $ctrl.params.where, op: 'AND', label: ts('Where'), fields: fieldsForWhere}">
     </fieldset>
     <fieldset ng-if="$ctrl.paramExists('having') && $ctrl.params.groupBy.length" class="api4-clause-fieldset" crm-search-clause="{format: 'string', clauses: $ctrl.params.having, op: 'AND', label: ts('Filter'), fields: fieldsForHaving}">

--- a/templates/CRM/Contact/Form/Search/Basic.hlp
+++ b/templates/CRM/Contact/Form/Search/Basic.hlp
@@ -26,19 +26,6 @@
         <li>{ts}Use the 'Group Status...' checkboxes to view contacts with 'Pending' status and/or contacts who have been 'Removed' from this group.{/ts}</li>
       </ul>
     </p>
-    {if $params.permissionedForGroup}
-        {capture assign=addMembersURL}{crmURL q="context=amtg&amtgID=`$params.group_id`&reset=1"}{/capture}
-        <p>{ts 1=$addMembersURL 2=$params.group_title}Click <a href='%1'>Add Contacts to %2</a> if you want to add contacts to this group.{/ts}
-        {if !empty($params.ssID)}
-            {if $params.ssMappingID}
-                {capture assign=editSmartGroupURL}{crmURL p="civicrm/contact/search/builder" q="reset=1&force=1&ssID=`$params.ssID`"}{/capture}
-            {else}
-                {capture assign=editSmartGroupURL}{crmURL p="civicrm/contact/search/advanced" q="reset=1&force=1&ssID=`$params.ssID`"}{/capture}
-            {/if} 
-            {ts 1=$editSmartGroupURL}Click <a href='%1'>Edit Smart Group Search Criteria...</a> to change the search query used for this 'smart' group.{/ts}
-        {/if}
-        </p>
-    {/if}
 {/htxt}
 
 {htxt id="id-amtg-criteria-title"}

--- a/templates/CRM/Contact/Form/Search/Intro.tpl
+++ b/templates/CRM/Contact/Form/Search/Intro.tpl
@@ -11,20 +11,11 @@
 {* smog = 'show members of group'; amtg = 'add members to group' *}
 {if $context EQ 'smog'}
   {* Provide link to modify smart group search criteria if we are viewing a smart group (ssID = saved search ID) *}
-  {if $permissionEditSmartGroup}
-    {if !empty($ssID)}
-      {if $ssMappingID}
-        {capture assign=editSmartGroupURL}{crmURL p="civicrm/contact/search/builder" q="reset=1&ssID=`$ssID`"}{/capture}
-      {elseif $savedSearch.search_custom_id}
-        {capture assign=editSmartGroupURL}{crmURL p="civicrm/contact/search/custom" q="reset=1&ssID=`$ssID`"}{/capture}
-      {else}
-        {capture assign=editSmartGroupURL}{crmURL p="civicrm/contact/search/advanced" q="reset=1&ssID=`$ssID`"}{/capture}
-      {/if}
+  {if $permissionEditSmartGroup && !empty($editSmartGroupURL)}
       <div class="crm-submit-buttons">
         <a href="{$editSmartGroupURL}" class="button no-popup"><span><i class="crm-i fa-pencil" aria-hidden="true"></i> {ts 1=$group.title}Edit Smart Group Search Criteria for %1{/ts}</span></a>
         {help id="id-edit-smartGroup"}
       </div>
-    {/if}
   {/if}
 
   {if $permissionedForGroup}

--- a/templates/CRM/Contact/Form/Search/ResultTasks.tpl
+++ b/templates/CRM/Contact/Form/Search/ResultTasks.tpl
@@ -23,7 +23,7 @@
             <a href="{$searchBuilderURL}"><i class="crm-i fa-chevron-right" aria-hidden="true"></i> {ts}Search Builder{/ts}</a><br />
         {/if}
         {if $context eq 'smog'}
-            {help id="id-smog-criteria" group_id=$group.id group_title=$group.title ssID=$ssID ssMappingID=$ssMappingID permissionedForGroup=$permissionedForGroup}
+            {help id="id-smog-criteria" group_title=$group.title}
         {elseif $context eq 'amtg'}
             {help id="id-amtg-criteria" group_title=$group.title}
         {else}

--- a/templates/CRM/Group/Form/Edit.tpl
+++ b/templates/CRM/Group/Form/Edit.tpl
@@ -83,16 +83,9 @@
   {if $action neq 1}
     <div class="action-link">
       <a {$crmURL}><i class="crm-i fa-users" aria-hidden="true"></i> {ts}Contacts in this Group{/ts}</a>
-      {if $group.saved_search_id}
+      {if $editSmartGroupURL}
         <br />
-        {if $group.mapping_id}
-          <a class="no-popup" href="{crmURL p="civicrm/contact/search/builder" q="reset=1&ssID=`$group.saved_search_id`"}"><i class="crm-i fa-pencil" aria-hidden="true"></i> {ts}Edit Smart Group Criteria{/ts}</a>
-        {elseif $group.search_custom_id}
-          <a class="no-popup" href="{crmURL p="civicrm/contact/search/custom" q="reset=1&ssID=`$group.saved_search_id`"}"><i class="crm-i fa-pencil" aria-hidden="true"></i> {ts}Edit Smart Group Criteria{/ts}</a>
-        {else}
-          <a class="no-popup" href="{crmURL p="civicrm/contact/search/advanced" q="reset=1&ssID=`$group.saved_search_id`"}"><i class="crm-i fa-pencil" aria-hidden="true"></i> {ts}Edit Smart Group Criteria{/ts}</a>
-        {/if}
-
+        <a class="no-popup" href="{$editSmartGroupURL}"><i class="crm-i fa-pencil" aria-hidden="true"></i> {ts}Edit Smart Group Criteria{/ts}</a>
       {/if}
     </div>
   {/if}


### PR DESCRIPTION
Overview
----------------------------------------
Allows the search extension to edit smart groups.
Tweaks the "Edit smart group criteria" links to point to either classic search forms or the new search extension, as appropriate.

Before
----------------------------------------
Could create smart groups from search extension but not easily edit them.

After
----------------------------------------
Edit button links from group to search extension, which displays the name of the group being edited and a button to update the criteria.