### PR TITLE
dev/core#2017 Remove unused property,  override function that just calls parent

### DIFF
--- a/CRM/Member/BAO/MembershipStatus.php
+++ b/CRM/Member/BAO/MembershipStatus.php
@@ -17,19 +17,6 @@
 class CRM_Member_BAO_MembershipStatus extends CRM_Member_DAO_MembershipStatus {
 
   /**
-   * Static holder for the default LT.
-   * @var int
-   */
-  public static $_defaultMembershipStatus = NULL;
-
-  /**
-   * Class constructor.
-   */
-  public function __construct() {
-    parent::__construct();
-  }
-
-  /**
    * Fetch object based on array of properties.
    *
    * @param array $params


### PR DESCRIPTION
Overview
----------------------------------------
Remove unused property,  override function that just calls parent

Before
----------------------------------------
<img width="1275" alt="Screen Shot 2020-09-12 at 8 40 45 AM" src="https://user-images.githubusercontent.com/336308/92971225-2a692780-f4d4-11ea-8f89-6334616104d1.png">


After
----------------------------------------
poof

Technical Details
----------------------------------------

Comments
----------------------------------------

