### PR TITLE
[REF] minor tidy up on membershipStatus::create & add

### DIFF
--- a/CRM/Member/BAO/MembershipStatus.php
+++ b/CRM/Member/BAO/MembershipStatus.php
@@ -68,26 +68,21 @@ class CRM_Member_BAO_MembershipStatus extends CRM_Member_DAO_MembershipStatus {
    * Takes an associative array and creates a membership Status object.
    *
    * @param array $params
-   *   (reference ) an assoc array of name/value pairs.
+   *   Array of name/value pairs.
    *
-   * @throws Exception
-   * @return CRM_Member_BAO_MembershipStatus
+   * @throws CRM_Core_Exception
+   * @return CRM_Member_DAO_MembershipStatus
    */
   public static function create($params) {
-    $ids = [];
-    if (!empty($params['id'])) {
-      $ids['membershipStatus'] = $params['id'];
-    }
-    else {
+    if (empty($params['id'])) {
       //don't allow duplicate names - if id not set
       $status = new CRM_Member_DAO_MembershipStatus();
       $status->name = $params['name'];
       if ($status->find(TRUE)) {
-        throw new Exception('A membership status with this name already exists.');
+        throw new CRM_Core_Exception('A membership status with this name already exists.');
       }
     }
-    $membershipStatusBAO = CRM_Member_BAO_MembershipStatus::add($params, $ids);
-    return $membershipStatusBAO;
+    return self::add($params);
   }
 
   /**
@@ -98,10 +93,12 @@ class CRM_Member_BAO_MembershipStatus extends CRM_Member_DAO_MembershipStatus {
    * @param array $ids
    *   Array contains the id - this param is deprecated.
    *
-   *
-   * @return object
+   * @return CRM_Member_DAO_MembershipStatus
    */
   public static function add(&$params, $ids = []) {
+    if (!empty($ids)) {
+      CRM_Core_Error::deprecatedFunctionWarning('ids is a deprecated parameter');
+    }
     $id = $params['id'] ?? $ids['membershipStatus'] ?? NULL;
     if (!$id) {
       CRM_Core_DAO::setCreateDefaults($params, self::getDefaults());


### PR DESCRIPTION


Overview
----------------------------------------
We have been deprecating & removing the  array from BAO create & add actions - this continues that
(long slow) process'

Before
----------------------------------------
MembershipStatus::add already prefers not to receive ids - but create still conjures them up

After
----------------------------------------
ids no longer passed to add

Technical Details
----------------------------------------
I managed to eliminate most of the places add is called - I think ideally add would just be a (deprecated) pseudonym for create

Comments
----------------------------------------

