### PR TITLE
dev/core#2008 Fix apiv4 to use create permissions for save

### DIFF
--- a/Civi/Api4/Generic/AbstractAction.php
+++ b/Civi/Api4/Generic/AbstractAction.php
@@ -407,6 +407,9 @@ abstract class AbstractAction implements \ArrayAccess {
       'default' => ['administer CiviCRM'],
     ];
     $action = $this->getActionName();
+    if ($action === 'save') {
+      $action = 'create';
+    }
     if (isset($permissions[$action])) {
       return $permissions[$action];
     }


### PR DESCRIPTION


Overview
----------------------------------------
dev/core#2008 Fix apiv4 to use create permissions for save

Before
----------------------------------------
Entity specific params ignored on save action - eg MessageTemplate::save

After
----------------------------------------
create permissions used for save

Technical Details
----------------------------------------
@colemanw you might have a more elegant fix...

Comments
----------------------------------------

