### PR TITLE
dev/core#2008 APIv4 - Map specific action names to more generic versions

### DIFF
--- a/Civi/Api4/Generic/AbstractAction.php
+++ b/Civi/Api4/Generic/AbstractAction.php
@@ -407,13 +407,15 @@ abstract class AbstractAction implements \ArrayAccess {
       'default' => ['administer CiviCRM'],
     ];
     $action = $this->getActionName();
-    if (isset($permissions[$action])) {
-      return $permissions[$action];
-    }
-    elseif (in_array($action, ['getActions', 'getFields'])) {
-      return $permissions['meta'];
-    }
-    return $permissions['default'];
+    // Map specific action names to more generic versions
+    $map = [
+      'getActions' => 'meta',
+      'getFields' => 'meta',
+      'replace' => 'delete',
+      'save' => 'create',
+    ];
+    $generic = $map[$action] ?? 'default';
+    return $permissions[$action] ?? $permissions[$generic] ?? $permissions['default'];
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Ensures permissions are checked correctly for new actions like Save & Replace.
See https://lab.civicrm.org/dev/core/-/issues/2008

Before
----------------------------------------
Permissions too strict causing access denied for Save action, per https://github.com/civicrm/civicrm-core/pull/18436

After
----------------------------------------
Permissions checked correctly.

Technical Details
----------------------------------------
This adds mapping for non-crud actions similar to APIv3 in https://github.com/civicrm/civicrm-core/blob/5.19/CRM/Core/DAO/permissions.php#L61
