### PR TITLE
Way to alter schedule reminder email body

### DIFF
--- a/Civi/Token/TokenRow.php
+++ b/Civi/Token/TokenRow.php
@@ -404,6 +404,20 @@ class TokenRowContext implements \ArrayAccess, \IteratorAggregate, \Countable {
   }
 
   /**
+   * Register a string for which we'll need to merge in tokens.
+   *
+   * @param string $name
+   *   Ex: 'subject', 'body_html'.
+   * @param string $value
+   *   Ex: '<p>Hello {contact.name}</p>'.
+   * @param string $format
+   *   Ex: 'text/html'.
+   */
+  public function addMessage($name, $value, $format) {
+    $this->tokenProcessor->addMessage($name, $value, $format);
+  }
+
+  /**
    * Create merged array.
    *
    * @return array


### PR DESCRIPTION
Overview
----------------------------------------
There isn't a way you can alter the email body or subject before the message is render, unless you over-ride by re-rendering in altermailparams hook. 

This PR allows to change the body by using civicrm_container() hook see eg below

```
function abc_civicrm_container($container) {
  $container->addResource(new \Symfony\Component\Config\Resource\FileResource(__FILE__));
  $container->findDefinition('dispatcher')->addMethodCall('addListener',
    array(\Civi\Token\Events::TOKEN_EVALUATE, '_abc_evaluate_tokens')
  );
}

function _abc_evaluate_tokens(\Civi\Token\Event\TokenValueEvent $e) {
  foreach ($e->getRows() as $row) {
    CRM_MembershipApproval_Utils::$_tokenActId= NULL;
    if ($row->context['actionSearchResult']->entityTable == 'civicrm_activity') {
      $actTypeId = $row->context['actionSearchResult']->activity_type_id;
      if ($actTypeId = 13) {
        $row->context->addMessage('subject', 'update subject', 'text/plain');
        $row->context->addMessage('body_text', 'text message', 'text/plain');
        $row->context->addMessage('body_html', 'html message', 'text/html');
      }
      catch (Exception $e) {
        // ignore
      }
    }
  }
}
```