### PR TITLE
Make symfony aliased services public

### DIFF
--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -239,7 +239,7 @@ class Container {
       ))
         ->setFactory([$class, 'singleton'])->setPublic(TRUE);
     }
-    $container->setAlias('cache.short', 'cache.default');
+    $container->setAlias('cache.short', 'cache.default')->setPublic(TRUE);
 
     $container->setDefinition('resources', new Definition(
       'CRM_Core_Resources',


### PR DESCRIPTION
Overview
----------------------------------------
Similar to https://github.com/civicrm/civicrm-core/pull/18368

This came up in drupal 8 on the extensions list page after installing an extension.

Before
----------------------------------------
`The "cache.short" service is private, getting it from the container is deprecated since Symfony 3.2 and will fail in 4.0. You should either make the service public, or stop using the container directly and use dependency injection instead. - File: ...\vendor\symfony\dependency-injection\Container.php - Line: 282`

After
----------------------------------------
ok

Technical Details
----------------------------------------
The solution elsewhere when this has come up is to make it public which was the default before.

Comments
----------------------------------------

