### PR TITLE
Remove unnecessary debug from tests which messes up array output

### DIFF
--- a/Civi/Test/Api3TestTrait.php
+++ b/Civi/Test/Api3TestTrait.php
@@ -260,7 +260,6 @@ trait Api3TestTrait {
   public function callAPISuccessGetValue($entity, $params, $type = NULL) {
     $params += [
       'version' => $this->_apiversion,
-      'debug' => 1,
     ];
     $result = $this->civicrm_api($entity, 'getvalue', $params);
     if (is_array($result) && (!empty($result['is_error']) || isset($result['values']))) {


### PR DESCRIPTION
Overview
----------------------------------------
Test cleanup - fixes problem caused by needlessly passing debug into api during test.

Technical Details
----------------------------------------
GetValue and debug can't really be used together. If the output is scalar,
then there's no place for the debug info to go. If the output is an array of values,
the debug info will be injected into the values, messing up the test.

Comments
----------------------------------------
Test-only change, should be merged on pass.
