### PR TITLE
dev/translation#51 Fix inheritLocale regression

### DIFF
--- a/CRM/Core/BAO/ConfigSetting.php
+++ b/CRM/Core/BAO/ConfigSetting.php
@@ -178,7 +178,7 @@ class CRM_Core_BAO_ConfigSetting {
        * If the language is specified via "lcMessages" we skip this, since the
        * intention of the URL query var is to override all other sources.
        */
-      if ($settings->get('inheritLocale') && empty($chosenLocale)) {
+      if ($settings->get('inheritLocale')) {
 
         /*
          * FIXME: On multi-language installs, CRM_Utils_System::getUFLocale() in


### PR DESCRIPTION
To reproduce:

* Tested on Drupal7
* Enable locale/i18n and two languages (ex: English and French)
* Enable language-prefix language detection
* In CiviCRM, enable multilingual, and two languages

Then use the Drupal language switcher to change the language.

Result: the language only changes if we flush the CiviCRM cache. This is because the cache-flush removes data from `civicrm_cache`, including some session data.

Bug happens since 5.29, also in 5.30 and master.

https://lab.civicrm.org/dev/translation/-/issues/51