### PR TITLE
Pass in activity type rather than calculate it

### DIFF
--- a/CRM/Event/BAO/Participant.php
+++ b/CRM/Event/BAO/Participant.php
@@ -191,7 +191,7 @@ class CRM_Event_BAO_Participant extends CRM_Event_DAO_Participant {
     ) {
       // Default status if not specified
       $participant->status_id = $participant->status_id ?: self::fields()['participant_status_id']['default'];
-      CRM_Activity_BAO_Activity::addActivity($participant);
+      CRM_Activity_BAO_Activity::addActivity($participant, 'Event Registration');
     }
 
     //CRM-5403


### PR DESCRIPTION


Overview
----------------------------------------
Tiny code cleanup

Before
----------------------------------------
weird calculation for activity type

After
----------------------------------------
activity type passed in

Technical Details
----------------------------------------
This line is hit in CRM_Event_BAO_ParticipantTest.testCreate
api_v3_ContributionTest.testCompleteTransactionWithParticipantRecord

I think we should be moving the logic back to the calling functions in general - to the point of them
just calllng the v4 api directly, but this just clarifies on tiny bit

Comments
----------------------------------------

