### PR TITLE
Move definition of userName to where it is used and remove an unused parameter

### DIFF
--- a/CRM/Member/Form/MembershipRenewal.php
+++ b/CRM/Member/Form/MembershipRenewal.php
@@ -495,7 +495,7 @@ class CRM_Member_Form_MembershipRenewal extends CRM_Member_Form {
     $now = CRM_Utils_Date::getToday(NULL, 'YmdHis');
     $this->assign('receive_date', CRM_Utils_Array::value('receive_date', $this->_params, date('Y-m-d H:i:s')));
     $this->processBillingAddress();
-    list($userName) = CRM_Contact_BAO_Contact_Location::getEmailDetails(CRM_Core_Session::singleton()->get('userID'));
+
     $this->_params['total_amount'] = CRM_Utils_Array::value('total_amount', $this->_params,
       CRM_Core_DAO::getFieldValue('CRM_Member_DAO_MembershipType', $this->_memType, 'minimum_fee')
     );
@@ -602,10 +602,10 @@ class CRM_Member_Form_MembershipRenewal extends CRM_Member_Form {
 
     if (!empty($this->_params['record_contribution']) || $this->_mode) {
       // set the source
+      list($userName) = CRM_Contact_BAO_Contact_Location::getEmailDetails(CRM_Core_Session::singleton()->get('userID'));
       $this->_params['contribution_source'] = "{$this->membershipTypeName} Membership: Offline membership renewal (by {$userName})";
 
       //create line items
-      $lineItem = [];
       $this->_params = $this->setPriceSetParameters($this->_params);
 
       $order = new CRM_Financial_BAO_Order();


### PR DESCRIPTION
Overview
----------------------------------------
Trivial cleanup

Before
----------------------------------------
$userName calculated but hard to see easily where it is used

After
----------------------------------------
calculation moved to where it is used. An unused parameter is removed

Technical Details
----------------------------------------


Comments
----------------------------------------

