### PR TITLE
dev/financial#149 Add permission = false to apiv4 call to address unreleased regression

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4437,7 +4437,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
     $contributionParams['payment_processor'] = $paymentProcessorId;
 
     if (empty($contributionParams['payment_instrument_id']) && isset($contribution->_relatedObjects['paymentProcessor']['payment_instrument_id'])) {
-      $contributionParams['payment_instrument_id'] = PaymentProcessor::get()->addWhere('id', '=', $paymentProcessorId)->addSelect('payment_instrument_id')->execute()->first()['payment_instrument_id'];
+      $contributionParams['payment_instrument_id'] = PaymentProcessor::get(FALSE)->addWhere('id', '=', $paymentProcessorId)->addSelect('payment_instrument_id')->execute()->first()['payment_instrument_id'];
     }
 
     if ($recurringContributionID) {

--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -1020,7 +1020,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
 
     // create an activity record
     if ($contribution) {
-      CRM_Activity_BAO_Activity::addActivity($contribution, NULL, $targetContactID, $actParams);
+      CRM_Activity_BAO_Activity::addActivity($contribution, 'Contribution', $targetContactID, $actParams);
     }
 
     $transaction->commit();

--- a/tests/phpunit/CRM/Contribute/Form/Contribution/ConfirmTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/Contribution/ConfirmTest.php
@@ -28,9 +28,10 @@ class CRM_Contribute_Form_Contribution_ConfirmTest extends CiviUnitTestCase {
   /**
    * CRM-21200: Test that making online payment for pending contribution doesn't overwite the contribution details
    */
-  public function testPaynowPayment() {
+  public function testPayNowPayment() {
     $contactID = $this->individualCreate();
     $paymentProcessorID = $this->paymentProcessorCreate(['payment_processor_type_id' => 'Dummy']);
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = [];
 
     // create a contribution page which is later used to make pay-later contribution
     $result = $this->callAPISuccess('ContributionPage', 'create', [
@@ -80,7 +81,7 @@ class CRM_Contribute_Form_Contribution_ConfirmTest extends CiviUnitTestCase {
       'payment_instrument_id' => CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'payment_instrument_id', 'Credit card'),
     ];
     $form->_params = [
-      'qfKey' => 'donotcare',
+      'qfKey' => 'do not care',
       'contribution_id' => $contribution['id'],
       'credit_card_number' => 4111111111111111,
       'cvv2' => 234,
@@ -154,7 +155,7 @@ class CRM_Contribute_Form_Contribution_ConfirmTest extends CiviUnitTestCase {
       'relationship_type_id' => 5,
       'is_current_employer' => 1,
     ]);
-    $processConfirmResult = CRM_Contribute_BAO_Contribution_Utils::processConfirm($form,
+    CRM_Contribute_BAO_Contribution_Utils::processConfirm($form,
       $form->_params,
       $form->_params['onbehalf_contact_id'],
       $form->_values['financial_type_id'],
@@ -169,7 +170,7 @@ class CRM_Contribute_Form_Contribution_ConfirmTest extends CiviUnitTestCase {
       'sequential' => 1,
       'source_record_id' => $contribution['id'],
       'contact_id' => $form->_params['onbehalf_contact_id'],
-      'activity_type_id' => "Contribution",
+      'activity_type_id' => 'Contribution',
     ]);
     $this->assertEquals(1, $activity['count']);
   }

--- a/tests/phpunit/CRM/Event/Form/Registration/ConfirmTest.php
+++ b/tests/phpunit/CRM/Event/Form/Registration/ConfirmTest.php
@@ -76,6 +76,7 @@ class CRM_Event_Form_Registration_ConfirmTest extends CiviUnitTestCase {
         ],
       ],
     ]);
+
     $participant = $this->callAPISuccessGetSingle('Participant', []);
     $mut->checkMailLog([
       'Dear Logged In,  Thank you for your registration.  This is a confirmation that your registration has been received and your status has been updated to Registered.',
@@ -415,9 +416,10 @@ class CRM_Event_Form_Registration_ConfirmTest extends CiviUnitTestCase {
   /**
    * Submit event registration with a note field
    *
-   * @param  array $event
+   * @param array $event
    * @param int $contact_id
    *
+   * @return array
    * @throws \Exception
    */
   private function submitWithNote($event, $contact_id) {
@@ -532,8 +534,10 @@ class CRM_Event_Form_Registration_ConfirmTest extends CiviUnitTestCase {
    * @param string $field_name
    * @param string $field_type
    * @param string $field_label
+   *
    * @return array
    *   API result array
+   * @throws \CRM_Core_Exception
    */
   private function uf_field_add($uf_group_id, $field_name, $field_type, $field_label) {
     $params = [
@@ -546,8 +550,7 @@ class CRM_Event_Form_Registration_ConfirmTest extends CiviUnitTestCase {
       'is_active' => 1,
       'uf_group_id' => $uf_group_id,
     ];
-    $result = civicrm_api3('UFField', 'create', $params);
-    return $result;
+    return $this->callAPISuccess('UFField', 'create', $params);
   }
 
   /**
@@ -559,7 +562,7 @@ class CRM_Event_Form_Registration_ConfirmTest extends CiviUnitTestCase {
     //create an event with an attached profile containing a note
     $event = $this->creatEventWithProfile(NULL);
     $event['custom_pre_id'] = $this->ids["UFGroup"]["our profile"];
-    $event['note'] = "This is note 1";
+    $event['note'] = 'This is note 1';
     list($contact_id, $participant_id) = $this->submitWithNote($event, NULL);
     civicrm_api3('Participant', 'delete', ['id' => $participant_id]);
 
@@ -567,15 +570,15 @@ class CRM_Event_Form_Registration_ConfirmTest extends CiviUnitTestCase {
     //and confirm that the note shown in the email is the current one
     $event = $this->creatEventWithProfile($event);
     $event['custom_pre_id'] = $this->ids["UFGroup"]["our profile"];
-    $event['note'] = "This is note 2";
+    $event['note'] = 'This is note 2';
     list($contact_id, $participant_id) = $this->submitWithNote($event, $contact_id);
     civicrm_api3('Participant', 'delete', ['id' => $participant_id]);
 
     //finally, submit a blank note and confirm that the note shown in the email is blank
     $event = $this->creatEventWithProfile($event);
     $event['custom_pre_id'] = $this->ids["UFGroup"]["our profile"];
-    $event['note'] = "";
-    list($contact_id, $participant_id) = $this->submitWithNote($event, $contact_id);
+    $event['note'] = '';
+    $this->submitWithNote($event, $contact_id);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes an unreleased regression which affects contribution page processing by incorrectly checking permissions

Before
----------------------------------------
Exception on submitting contribution page for many users paying by card

After
----------------------------------------
Issue resolved

Technical Details
----------------------------------------
This retrieves payment processors using FALSE for get permissions. I was able to replicate the bug in the test.

I also updated one line that I passed through when stepping through the test that related to the addActivity.
It just passes in activityType rather than leaving addActivity to figure that out

Comments
----------------------------------------
Affects master - from https://github.com/civicrm/civicrm-core/pull/18385
