### PR TITLE
dev/core#1921 remove isoToMysql

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -1732,7 +1732,7 @@ WHERE      activity.id IN ($activityIds)";
         $params['campaign_id'] = $activity->campaign_id;
       }
 
-      $date = CRM_Utils_Date::isoToMysql($activity->receive_date);
+      $date = $activity->receive_date;
     }
 
     $activityParams = [

--- a/CRM/Financial/BAO/FinancialItem.php
+++ b/CRM/Financial/BAO/FinancialItem.php
@@ -74,7 +74,7 @@ class CRM_Financial_BAO_FinancialItem extends CRM_Financial_DAO_FinancialItem {
       $itemStatus = array_search('Partially paid', $financialItemStatus);
     }
     $params = [
-      'transaction_date' => CRM_Utils_Date::isoToMysql($contribution->receive_date),
+      'transaction_date' => $contribution->receive_date,
       'contact_id' => $contribution->contact_id,
       'amount' => $lineItem->line_total,
       'currency' => $contribution->currency,


### PR DESCRIPTION


Overview
----------------------------------------
Remove unnecessary isoToDate function

Before
----------------------------------------
Code compatible with packages code of 6 years ago

After
----------------------------------------
will break if you revert 6 year old fix....

Technical Details
----------------------------------------
The test testPaymentDontChangeReceiveDate passes through these 2 lines of code - which
I think is probably about the most we can confirm testing wise as we expect there
to be no reason to cast to mysql anymore

Comments
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/1921
