### PR TITLE
dev/financial#147 Ensure that jQuery Validation doesn't execute when …

### DIFF
--- a/CRM/Core/Payment/PayPalImpl.php
+++ b/CRM/Core/Payment/PayPalImpl.php
@@ -160,12 +160,22 @@ class CRM_Core_Payment_PayPalImpl extends CRM_Core_Payment {
         $form->_expressButtonName = $form->getButtonName('upload', 'express');
       }
       $form->assign('expressButtonName', $form->_expressButtonName);
-      $form->add(
-        'image',
-        $form->_expressButtonName,
-        $this->_paymentProcessor['url_button'],
-        ['class' => 'crm-form-submit']
-      );
+      $form->add('xbutton', $form->_expressButtonName, ts('Pay using PayPal'), [
+        'type' => 'submit',
+        'formnovalidate' => 'formnovalidate',
+        'class' => 'crm-form-submit',
+      ]);
+      CRM_Core_Resources::singleton()->addStyle('
+        button#' . $form->_expressButtonName . '{
+         background-image: url(' . $this->_paymentProcessor['url_button'] . ');
+         color: transparent;
+         background-repeat: no-repeat;
+         background-color: transparent;
+         background-position: center;
+         min-width: 150px;
+         min-height: 50px;
+         border: none;
+       ');
     }
   }
 
@@ -1108,7 +1118,6 @@ class CRM_Core_Payment_PayPalImpl extends CRM_Core_Payment {
     if ($this->isPayPalType($this::PAYPAL_EXPRESS)) {
       return TRUE;
     }
-
     // This would occur postProcess.
     if (!empty($params['token'])) {
       return TRUE;
@@ -1122,6 +1131,7 @@ class CRM_Core_Payment_PayPalImpl extends CRM_Core_Payment {
     $possibleExpressFields = [
       '_qf_Register_upload_express_x',
       '_qf_Payment_upload_express_x',
+      '_qf_Main_upload_express',
     ];
     if (array_intersect_key($params, array_fill_keys($possibleExpressFields, 1))) {
       return TRUE;


### PR DESCRIPTION
…we click the paypal express button and ensure the style of the button doesn't change

Overview
----------------------------------------
The aim of this is to fix a regression where by jquery validation was checking for credit card fields to be validated before allowing the form to be submitted which isn't the correct case when selecting the express button for PayPal Pro payment processor.

Before
----------------------------------------
Form doesn't submit when submitting using PayPal Pro payment processor and clicking on the Express button

After
----------------------------------------
Form submits and we rely on the PHP / Quickform validation layer to ensure that enough fields are filled in.

Technical Details
----------------------------------------
This changes the button from an image imput into a <button> class which may have some style issues down the track. However this does mean that we can pass in the attribute formnovalidate which stops jQuery validation from firing when the user clicks on the button

ping @agh1 @eileenmcnaughton @Stoob @mattwire 
