### PR TITLE
dev/drupal#138 - Drupal 9 deprecations

### DIFF
--- a/CRM/Utils/System/Drupal8.php
+++ b/CRM/Utils/System/Drupal8.php
@@ -34,7 +34,7 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
     }
 
     /** @var \Drupal\user\Entity\User $account */
-    $account = entity_create('user');
+    $account = \Drupal::entityTypeManager()->getStorage('user')->create();
     $account->setUsername($params['cms_name'])->setEmail($params[$mail]);
 
     // Allow user to set password only if they are an admin or if
@@ -109,7 +109,7 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
    * @inheritDoc
    */
   public function updateCMSName($ufID, $email) {
-    $user = entity_load('user', $ufID);
+    $user = \Drupal::entityTypeManager()->getStorage('user')->load($ufID);
     if ($user && $user->getEmail() != $email) {
       $user->setEmail($email);
 
@@ -134,7 +134,7 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
     if (!empty($params['name'])) {
       $name = $params['name'];
 
-      $user = entity_create('user');
+      $user = \Drupal::entityTypeManager()->getStorage('user')->create();
       $user->setUsername($name);
 
       // This checks for both username uniqueness and validity.
@@ -152,7 +152,7 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
     if (!empty($params['mail'])) {
       $mail = $params['mail'];
 
-      $user = entity_create('user');
+      $user = \Drupal::entityTypeManager()->getStorage('user')->create();
       $user->setEmail($mail);
 
       // This checks for both email uniqueness.
@@ -172,7 +172,7 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
    */
   public function getLoginURL($destination = '') {
     $query = $destination ? ['destination' => $destination] : [];
-    return \Drupal::url('user.login', [], ['query' => $query]);
+    return \Drupal\Core\Url::fromRoute('user.login', [], ['query' => $query])->toString();
   }
 
   /**
@@ -430,7 +430,7 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
     CRM_Utils_Hook::config($config);
 
     if ($loadUser) {
-      if (!empty($params['uid']) && $username = \Drupal\user\Entity\User::load($params['uid'])->getUsername()) {
+      if (!empty($params['uid']) && $username = \Drupal\user\Entity\User::load($params['uid'])->getAccountName()) {
         $this->loadUser($username);
       }
       elseif (!empty($params['name']) && !empty($params['pass']) && \Drupal::service('user.auth')->authenticate($params['name'], $params['pass'])) {


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/drupal/-/issues/138

The easiest way that will test most of these in one go is:

1. Install drupal 8, or 9, with civi.
1. Create a profile with an email field and that has the advanced setting to allow CMS user creation.
1. Create a simple contribution page where you use that profile.
1. As an anonymous user fill out the page checking the box for user creation.
1. Click the check-availability link (in drupal 9 for example this will hang).
1. Go thru to the end and complete the transaction.

Also using the Create User Record action on a contact view page will go thru most of them too.

Before
----------------------------------------
Works in drupal 8 but crashes in drupal 9, several times along the way. For reasons I won't go into here you never see the deprecation notices in drupal 8 no matter what you set for php error_reporting, so you won't be able to physically see the notices in drupal 8 (without some hacking or e.g. the loudnotices extension).

After
----------------------------------------
Works in drupal 8.5+ and drupal 9.

Technical Details
----------------------------------------
https://api.drupal.org/api/drupal/core!includes!entity.inc/function/entity_load/8.9.x

https://api.drupal.org/api/drupal/core!includes!entity.inc/function/entity_create/8.9.x

https://api.drupal.org/api/drupal/core!lib!Drupal!Core!Session!AccountInterface.php/function/AccountInterface%3A%3AgetUsername/8.9.x

https://api.drupal.org/api/drupal/core%21lib%21Drupal.php/function/Drupal%3A%3Aurl/8.9.x

Comments
----------------------------------------
It's not a pre-req but there's a related PR at https://github.com/civicrm/civicrm-drupal-8/pull/47 since you get a similar deprecation if you view the created user in edit mode and click on the Name and Address tab.
