### PR TITLE
dev/event#42 [REF] Start the process of separating the search action from the participant form

### DIFF
--- a/CRM/Contact/Task.php
+++ b/CRM/Contact/Task.php
@@ -234,7 +234,7 @@ class CRM_Contact_Task extends CRM_Core_Task {
       if (CRM_Core_Permission::access('CiviEvent')) {
         self::$_tasks[self::ADD_EVENT] = array(
           'title' => ts('Register participants for event'),
-          'class' => 'CRM_Event_Form_Participant',
+          'class' => 'CRM_Event_Form_Task_Register',
         );
       }
 

--- a/CRM/Event/Form/EventFees.php
+++ b/CRM/Event/Form/EventFees.php
@@ -159,6 +159,7 @@ class CRM_Event_Form_EventFees {
       if (in_array(get_class($form),
         [
           'CRM_Event_Form_Participant',
+          'CRM_Event_Form_Task_Register',
           'CRM_Event_Form_Registration_Register',
           'CRM_Event_Form_Registration_AdditionalParticipant',
         ]
@@ -173,7 +174,7 @@ class CRM_Event_Form_EventFees {
         foreach ($form->_priceSet['fields'] as $key => $val) {
           foreach ($val['options'] as $keys => $values) {
             if ($values['is_default']) {
-              if (get_class($form) != 'CRM_Event_Form_Participant' && !empty($values['is_full'])) {
+              if (!in_array(get_class($form), ['CRM_Event_Form_Participant', 'CRM_Event_Form_Task_Register']) && !empty($values['is_full'])) {
                 continue;
               }
 

--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -99,11 +99,14 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
 
   /**
    * Are we operating in "single mode", i.e. adding / editing only
-   * one participant record, or is this a batch add operation
+   * one participant record, or is this a batch add operation.
+   *
+   * Note the goal is to disentangle all the non-single stuff
+   * to CRM_Event_Form_Task_Register and discontinue this param.
    *
    * @var bool
    */
-  public $_single = FALSE;
+  public $_single = TRUE;
 
   /**
    * If event is paid or unpaid.
@@ -337,8 +340,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
 
     //check the mode when this form is called either single or as
     //search task action
-    if ($this->_id || $this->_contactId || $this->_context == 'standalone') {
-      $this->_single = TRUE;
+    if ($this->_single) {
       $this->assign('urlPath', 'civicrm/contact/view/participant');
       if (!$this->_id && !$this->_contactId) {
         $breadCrumbs = [
@@ -379,7 +381,6 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
       }
       CRM_Contact_Form_Task::preProcessCommon($this);
 
-      $this->_single = FALSE;
       $this->_contactId = NULL;
 
       //set ajax path, this used for custom data building

--- a/CRM/Event/Form/Registration.php
+++ b/CRM/Event/Form/Registration.php
@@ -657,7 +657,7 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
       }
     }
     if ($isPaidEvent && empty($form->_values['fee'])) {
-      if (CRM_Utils_System::getClassName($form) != 'CRM_Event_Form_Participant') {
+      if (!in_array(CRM_Utils_System::getClassName($form), ['CRM_Event_Form_Participant', 'CRM_Event_Form_Task_Register'])) {
         CRM_Core_Error::statusBounce(ts('No Fee Level(s) or Price Set is configured for this event.<br />Click <a href=\'%1\'>CiviEvent >> Manage Event >> Configure >> Event Fees</a> to configure the Fee Level(s) or Price Set for this event.', [1 => CRM_Utils_System::url('civicrm/event/manage/fee', 'reset=1&action=update&id=' . $form->_eventId)]));
       }
     }

--- a/CRM/Event/Form/Registration/Register.php
+++ b/CRM/Event/Form/Registration/Register.php
@@ -577,6 +577,7 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
         if (CRM_Utils_Array::value('visibility', $field) == 'public' ||
           (CRM_Utils_Array::value('visibility', $field) == 'admin' && $adminFieldVisible == TRUE) ||
           $className == 'CRM_Event_Form_Participant' ||
+          $className === 'CRM_Event_Form_Task_Register' ||
           $className == 'CRM_Event_Form_ParticipantFeeSelection'
         ) {
           $fieldId = $field['id'];
@@ -589,7 +590,7 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
 
           //user might modified w/ hook.
           $options = $field['options'] ?? NULL;
-          $formClasses = ['CRM_Event_Form_Participant', 'CRM_Event_Form_ParticipantFeeSelection'];
+          $formClasses = ['CRM_Event_Form_Participant', 'CRM_Event_Form_Task_Register', 'CRM_Event_Form_ParticipantFeeSelection'];
 
           if (!is_array($options)) {
             continue;
@@ -636,7 +637,7 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
 
           //CRM-7632, CRM-6201
           $totalAmountJs = NULL;
-          if ($className == 'CRM_Event_Form_Participant') {
+          if ($className == 'CRM_Event_Form_Participant' || $className === 'CRM_Event_Form_Task_Register') {
             $totalAmountJs = ['onClick' => "fillTotalAmount(" . $fee['value'] . ")"];
           }
 
@@ -755,7 +756,7 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
       }
 
       //ignore option full for offline registration.
-      if ($className == 'CRM_Event_Form_Participant') {
+      if ($className == 'CRM_Event_Form_Participant' || $className === 'CRM_Event_Form_Task_Register') {
         $optionFullIds = [];
       }
 

--- a/CRM/Event/Form/Task/Register.php
+++ b/CRM/Event/Form/Task/Register.php
@@ -1,0 +1,40 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+/**
+ * This class provides the register functionality from a search context.
+ *
+ * Originally the functionality was all munged into the main Participant form.
+ *
+ * Ideally it would be entirely separated but for now this overrides the main form,
+ * just providing a better separation of the functionality for the search vs main form.
+ */
+class CRM_Event_Form_Task_Register extends CRM_Event_Form_Participant {
+
+
+  /**
+   * Are we operating in "single mode", i.e. adding / editing only
+   * one participant record, or is this a batch add operation
+   *
+   * ote the goal is to disentangle all the non-single stuff
+   * into this form and discontinue this param.
+   *
+   * @var bool
+   */
+  public $_single = FALSE;
+
+}

--- a/CRM/Price/BAO/PriceSet.php
+++ b/CRM/Price/BAO/PriceSet.php
@@ -574,7 +574,7 @@ WHERE  id = %1";
         switch ($entityTable) {
           case 'civicrm_event':
             $entity = 'participant';
-            if (CRM_Utils_System::getClassName($form) == 'CRM_Event_Form_Participant') {
+            if (in_array(CRM_Utils_System::getClassName($form), ['CRM_Event_Form_Participant', 'CRM_Event_Form_Task_Register'])) {
               $entityId = $form->_id;
             }
             else {

--- a/tests/phpunit/CRM/Event/Form/Task/RegisterTest.php
+++ b/tests/phpunit/CRM/Event/Form/Task/RegisterTest.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ *  Test CRM_Event_Form_Registration functions.
+ *
+ * @package   CiviCRM
+ * @group headless
+ */
+class CRM_Event_Form_Task_RegisterTest extends CiviUnitTestCase {
+
+  /**
+   * Initial test of form class.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testGet() {
+    /* @var CRM_Event_Form_Task_Register $form */
+    $form = $this->getFormObject('CRM_Event_Form_Task_Register');
+    $this->assertEquals(FALSE, $form->_single);
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
[REF] Start the process of separating the search action from the participant form.

The affects the action when you do a contact search and then choose the action Register Participant

Before
----------------------------------------
The search action participant register is munged into the participant form

After
----------------------------------------
The search action is it's own form, extending the participant form, ready & waiting for more functionality to be moved across.

Technical Details
----------------------------------------
A lot code nastiness stems from the overloading of the participant registration form with the search task to register
multiples. A more logical structure would be some shared functionality but separate classes. This starts that
process, but with only the one property now separated to be a class property rather than a derived one. Later efforts
can disentangle which functionality belongs to which class

Comments
----------------------------------------

I added a very rudimentary test - I will build on it when I start to move functionality across