### PR TITLE
Remove fatalErrorHandler from scheduled jobs manager

### DIFF
--- a/CRM/Core/JobManager.php
+++ b/CRM/Core/JobManager.php
@@ -40,9 +40,6 @@ class CRM_Core_JobManager {
    * Class constructor.
    */
   public function __construct() {
-    $config = CRM_Core_Config::singleton();
-    $config->fatalErrorHandler = 'CRM_Core_JobManager_scheduledJobFatalErrorHandler';
-
     $this->jobs = $this->_getJobs();
   }
 
@@ -275,13 +272,4 @@ class CRM_Core_JobManager {
     return $status . $message;
   }
 
-}
-
-/**
- * @param $message
- *
- * @throws Exception
- */
-function CRM_Core_JobManager_scheduledJobFatalErrorHandler($message) {
-  throw new Exception("{$message['message']}: {$message['code']}");
 }


### PR DESCRIPTION
Overview
----------------------------------------
We are defining a fatalErrorHandler in the JobManager that throws an exception.  It does the same thing without the fatal error handler defined and still logs the same fatal error/backtrace in the logs and the actual error message in the scheduled job log.

Much more detail and testing info here: https://lab.civicrm.org/dev/mail/-/issues/72

We should not be overriding the fatalErrorHandler within core as this causes unexpected results when overriding via an extension (eg. reporterror).

Before
----------------------------------------
Scheduled Jobs manager overrides fatalErrorHandler

After
----------------------------------------
Scheduled Jobs manager does not override fatalErrorHandler

Technical Details
----------------------------------------
This is not the same as adding a call to fatalErrorHandler that we tried to do in #17277 but removes up the only known use of fatalErrorHandler in core. This will make an alternative to #17277 simpler to implement. This PR should not cause the regression descibed in https://lab.civicrm.org/dev/mail/-/issues/72 because we are not introducing a "PHP exit".

We are just replacing the internal fatalErrorHandler with the built-in civicrm exception handler. Both throw exceptions which will be handled in the same way by the mailing code.

Comments
----------------------------------------
