### PR TITLE
Fix parameters for MembershipTest

### DIFF
--- a/tests/phpunit/CRM/Member/Form/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/Form/MembershipTest.php
@@ -288,7 +288,7 @@ class CRM_Member_Form_MembershipTest extends CiviUnitTestCase {
   public function testFormRulePermanentOverrideWithNoStatus() {
     $params = [
       'join_date' => date('Y-m-d'),
-      'membership_type_id' => [$this->ids['contact']['organization'], '$this->membershipTypeAnnualFixedID'],
+      'membership_type_id' => [$this->ids['contact']['organization'], $this->membershipTypeAnnualFixedID],
       'is_override' => TRUE,
     ];
     $files = [];
@@ -301,7 +301,7 @@ class CRM_Member_Form_MembershipTest extends CiviUnitTestCase {
   public function testFormRuleUntilDateOverrideWithValidOverrideEndDate() {
     $params = [
       'join_date' => date('Y-m-d'),
-      'membership_type_id' => [$this->ids['contact']['organization'], '$this->membershipTypeAnnualFixedID'],
+      'membership_type_id' => [$this->ids['contact']['organization'], $this->membershipTypeAnnualFixedID],
       'is_override' => TRUE,
       'status_id' => 1,
       'status_override_end_date' => date('Y-m-d'),


### PR DESCRIPTION
Overview
----------------------------------------
These tests were recently updated by @eileenmcnaughton. They are causing test failures for https://github.com/civicrm/civicrm-core/pull/18427 but I can't understand why the parameters have been put in quotes.

@eileenmcnaughton I'm assuming the quotes were a typo and this PR is the correct fix for the tests?

