### PR TITLE
dev/core#1921 Further removal of iso date handling

### DIFF
--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -2070,7 +2070,7 @@ SELECT  id
         CRM_Core_DAO::storeValues($otherActivity, $mainActVals);
         $mainActivity->copyValues($mainActVals);
         $mainActivity->id = NULL;
-        $mainActivity->activity_date_time = CRM_Utils_Date::isoToMysql($otherActivity->activity_date_time);
+        $mainActivity->activity_date_time = $otherActivity->activity_date_time;
         $mainActivity->source_record_id = CRM_Utils_Array::value($mainActivity->source_record_id,
           $activityMappingIds
         );

--- a/tests/phpunit/api/v3/CaseTest.php
+++ b/tests/phpunit/api/v3/CaseTest.php
@@ -1003,19 +1003,17 @@ class api_v3_CaseTest extends CiviCaseTestCase {
    * Test the case merge function.
    *
    * 2 cases should be mergeable into 1
-   *
-   * @throws \Exception
    */
   public function testCaseMerge() {
     $contact1 = $this->individualCreate([], 1);
     $case1 = $this->callAPISuccess('Case', 'create', [
       'contact_id' => $contact1,
-      'subject' => "Test case 1",
+      'subject' => 'Test case 1',
       'case_type_id' => $this->caseTypeId,
     ]);
     $case2 = $this->callAPISuccess('Case', 'create', [
       'contact_id' => $contact1,
-      'subject' => "Test case 2",
+      'subject' => 'Test case 2',
       'case_type_id' => $this->caseTypeId,
     ]);
     $result = $this->callAPISuccess('Case', 'getcount', ['contact_id' => $contact1]);


### PR DESCRIPTION
Overview
----------------------------------------
Same deal as https://github.com/civicrm/civicrm-core/pull/18359

Before
----------------------------------------
Casting to ISO date to avoid 2014 bug

After
----------------------------------------
We are stuck in 2020

Technical Details
----------------------------------------

Comments
----------------------------------------
relevant tests
api_v3_CaseTest::testCaseMerge

