### PR TITLE
dev/core#2032 Add potential to vary query log files per process

### DIFF
--- a/CRM/Core/Error.php
+++ b/CRM/Core/Error.php
@@ -608,7 +608,7 @@ class CRM_Core_Error extends PEAR_ErrorStack {
       CRM_Core_Error::backtrace($string, TRUE);
     }
     elseif (CIVICRM_DEBUG_LOG_QUERY) {
-      CRM_Core_Error::debug_var('Query', $string, TRUE, TRUE, 'sql_log', PEAR_LOG_DEBUG);
+      CRM_Core_Error::debug_var('Query', $string, TRUE, TRUE, 'sql_log' . CIVICRM_DEBUG_LOG_QUERY, PEAR_LOG_DEBUG);
     }
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Creates option to redirect sql logging output to a new file

Before
----------------------------------------
All logging of sql queries goes to the same file, subject to log rotation

After
----------------------------------------
If a truthy value other than the reserved string 'backtrace' is used it will impact the eventual file name of the log.
e.g

``
env CIVICRM_DEBUG_LOG_QUERY=test_2 drush mycommand
``

Which would result in the created log file having a name like
```
CiviCRM.sql_log_test_2.7a880382d2e1d80611365ce1.log
```

Technical Details
----------------------------------------
This might be  a bit too hacky but I thought I'd put it up for consideration. Basically we have 3 existing
options for CIVICRM_DEBUG_LOG_QUERY

1) FALSE = do nothing (5.30 + or same as TRUE for earlier versions)
2) backtrace = log a full backtrace
3) anything else - log the sql query

This takes a bit of leeway with the 'everything else' and includes the value a part of the
prefix for writing to the query log - allowing something like



Comments
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/2032

@totten what is your opinion on this approach? We could add another define & I feel like I could make a case either way
