### PR TITLE
dev/core#1393 - distmaker - Fix URL-based installation on D7/BD

### DIFF
--- a/distmaker/dists/backdrop_php5.sh
+++ b/distmaker/dists/backdrop_php5.sh
@@ -28,6 +28,7 @@ dm_install_cvext com.iatspayments.civicrm "$TRG/ext/iatspayments"
 
 # gen tarball
 cd $TRG/..
+dm_assert_no_symlinks civicrm
 tar czf $DM_TARGETDIR/civicrm-$DM_VERSION-backdrop.tar.gz civicrm
 
 # clean up

--- a/distmaker/dists/common.sh
+++ b/distmaker/dists/common.sh
@@ -200,7 +200,7 @@ function dm_install_vendor() {
 
   local excludes_rsync=""
   ## CRM-21729 - .idea test-cases unit-test come from phpquery package.
-  for exclude in .git .svn {T,t}est{,s} {D,d}oc{,s} {E,e}xample{,s} .idea test-cases unit-test; do
+  for exclude in .git .svn {T,t}est{,s} {D,d}oc{,s} {E,e}xample{,s} .idea test-cases unit-test README.rst; do
     excludes_rsync="--exclude=${exclude} ${excludes_rsync}"
   done
 

--- a/distmaker/dists/common.sh
+++ b/distmaker/dists/common.sh
@@ -10,6 +10,18 @@ function dm_reset_dirs() {
   mkdir -p "$@"
 }
 
+## Assert that a folder contains no symlinks
+##
+## ex: dev/core#1393, dev/core#1990
+## usage: dm_assert_no_symlinks <basedir>
+function dm_assert_no_symlinks() {
+  local SYMLINKS=$( find "$1" -type l )
+  if [ -n "$SYMLINKS" ]; then
+    echo "ERROR: Folder $1 contains unexpected symlink(s): $SYMLINKS"
+    exit 10
+  fi
+}
+
 ## Copy files from one dir into another dir
 ## usage: dm_install_dir <from-dir> <to-dir>
 function dm_install_dir() {

--- a/distmaker/dists/drupal6_php5.sh
+++ b/distmaker/dists/drupal6_php5.sh
@@ -28,6 +28,7 @@ dm_install_cvext com.iatspayments.civicrm "$TRG/ext/iatspayments"
 
 # gen tarball
 cd $TRG/..
+dm_assert_no_symlinks civicrm
 tar czf $DM_TARGETDIR/civicrm-$DM_VERSION-drupal6.tar.gz civicrm
 
 # clean up

--- a/distmaker/dists/drupal_php5.sh
+++ b/distmaker/dists/drupal_php5.sh
@@ -28,6 +28,7 @@ dm_install_cvext com.iatspayments.civicrm "$TRG/ext/iatspayments"
 
 # gen tarball
 cd $TRG/..
+dm_assert_no_symlinks civicrm
 tar czf $DM_TARGETDIR/civicrm-$DM_VERSION-drupal.tar.gz civicrm
 
 # clean up

--- a/distmaker/dists/drupal_sk_php5.sh
+++ b/distmaker/dists/drupal_sk_php5.sh
@@ -36,6 +36,7 @@ rm -rf $TRG/packages/tinymce
 
 # gen tarball
 cd $TRG/..
+dm_assert_no_symlinks civicrm
 tar czf $DM_TARGETDIR/civicrm-$DM_VERSION-starterkit.tgz civicrm
 
 # clean up


### PR DESCRIPTION
Overview
----------------------------------------

Drupal 7 and Backdrop have an administrative option to install modules from a URL. This is documented in the Sysadmin/Installation Guide (e.g. [here](https://docs.civicrm.org/installation/en/latest/drupal7/#directory)), but it doesn't work with current tarballs.

See also:

* https://lab.civicrm.org/dev/core/-/issues/1393
* https://lab.civicrm.org/dev/core/-/issues/1990

Ping @demeritcowboy 

Steps to Reproduce
----------------------------------------

* Create an empty D7 site
* Login as admin
* Navigate to "Modules => Install New Module"
* Give a URL like `https://download.civicrm.org/latest/civicrm-STABLE-drupal.tar.gz`

Before
----------------------------------------

On Drupal 7:

![Screenshot](https://lab.civicrm.org/dev/core/uploads/6ce32abfa465983f3e9cb880cf4eef56/Screenshot_from_2020-09-02_20-23-59.png)

On Backdrop:

![Screenshot from 2020-09-14 21-10-07](https://user-images.githubusercontent.com/1336047/93164583-b777d080-f6ce-11ea-8806-3aebe471ba0b.png)

After
----------------------------------------

On Drupal 7:

![Screenshot from 2020-09-14 20-46-01](https://user-images.githubusercontent.com/1336047/93163197-5ac6e680-f6cb-11ea-9505-e8a0489a102f.png)

On Backdrop:

![Screenshot from 2020-09-14 21-07-08](https://user-images.githubusercontent.com/1336047/93164460-6071fb80-f6ce-11ea-973f-54c03203a11f.png)


Technical Details
----------------------------------------

I ran `distmaker` locally and performed successful installations on both D7+BD from tarballs. Note that it may be hard for a reviewer to `r-run` this -- but it would be fairly easy to r`run` post-merge. (You just make an empty D7/BD site and use the nightly autobuild tarball.)

I made an attempt based on `tar`'s `--dereference` option -- ie when building the tarball, replace symlinks with concrete files. It seemed like a twofer: fix this problem, and fix any future incidents where symlinks sneak into the tree. The problem is that the symlink here (`README.rst`) is invalid at that point, so it cannot be turned into a concrete file. That didn't work.

The approach in this branch is better - it addresses the broken `README.rst` and *also* raises a redflag if there's ever a regression which would leak symlinks into the tarball.