### PR TITLE
dev/core#2036 - PEAR::DB is no longer in packages, now autoloaded from vendor

### DIFF
--- a/install/civicrm.php
+++ b/install/civicrm.php
@@ -131,8 +131,6 @@ function civicrm_main(&$config) {
 function civicrm_source($dsn, $fileName, $lineMode = FALSE) {
   global $crmPath;
 
-  require_once "$crmPath/packages/DB.php";
-
   // CRM-19699 See also CRM_Core_DAO for PHP7 mysqli compatiblity.
   // Duplicated here because this is not using CRM_Core_DAO directly
   // and this function may be called directly from Drush.


### PR DESCRIPTION
Overview
----------------------------------------
Trying to install 5.30+ on drupal 7 with the regular UI installer crashes. (sites/all/modules/civicrm/install/index.php)

Before
----------------------------------------
Still looking for it in packages

After
----------------------------------------
Autoloaded from vendor

Technical Details
----------------------------------------
It moved in 5.30.

Comments
----------------------------------------
Just removing the require seems to work.
