### PR TITLE
[wip] dev/core#2039 Add check to ensure all location entities have a primary address

### DIFF
--- a/CRM/Core/BAO/Location.php
+++ b/CRM/Core/BAO/Location.php
@@ -53,14 +53,6 @@ class CRM_Core_BAO_Location extends CRM_Core_DAO {
       }
     }
 
-    // when we come from a form which displays all the location elements (like the edit form or the inline block
-    // elements, we can skip the below check. The below check adds quite a feq queries to an already overloaded
-    // form
-    if (empty($params['updateBlankLocInfo'])) {
-      // make sure contact should have only one primary block, CRM-5051
-      self::checkPrimaryBlocks(CRM_Utils_Array::value('contact_id', $params));
-    }
-
     return $location;
   }
 

--- a/CRM/Dedupe/MergeHandler.php
+++ b/CRM/Dedupe/MergeHandler.php
@@ -198,15 +198,15 @@ class CRM_Dedupe_MergeHandler {
    *
    * @param int $otherBlockId
    * @param string $name
-   * @param int $blkCount
+   * @param int $blockIndex
    *
    * @return CRM_Core_DAO_Address|CRM_Core_DAO_Email|CRM_Core_DAO_IM|CRM_Core_DAO_Phone|CRM_Core_DAO_Website
    *
    * @throws \CRM_Core_Exception
    */
-  public function copyDataToNewBlockDAO($otherBlockId, $name, $blkCount) {
+  public function copyDataToNewBlockDAO($otherBlockId, $name, $blockIndex) {
     // For the block which belongs to other-contact, link the location block to main-contact
-    $otherBlockDAO = $this->getDAOForLocationEntity($name, $this->getSelectedLocationType($name, $blkCount), $this->getSelectedType($name, $blkCount));
+    $otherBlockDAO = $this->getDAOForLocationEntity($name, $this->getSelectedLocationType($name, $blockIndex), $this->getSelectedType($name, $blockIndex));
     $otherBlockDAO->contact_id = $this->getToKeepID();
     // Get the ID of this block on the 'other' contact, otherwise skip
     $otherBlockDAO->id = $otherBlockId;

--- a/CRM/Dedupe/MergeHandler.php
+++ b/CRM/Dedupe/MergeHandler.php
@@ -214,6 +214,79 @@ class CRM_Dedupe_MergeHandler {
   }
 
   /**
+   * Get blocks, if any, to update for the deleted contact.
+   *
+   * If the deleted contact no longer has a primary address but still has
+   * one or more blocks we want to ensure the remaining block is updated
+   * to have is_primary = 1 in case the contact is ever undeleted.
+   *
+   * @param string $entity
+   *
+   * @return array
+   * @throws \CRM_Core_Exception
+   */
+  public function getBlocksToUpdateForDeletedContact($entity) {
+    $movedBlocks = $this->getLocationBlocksToMerge()[$entity];
+    $deletedContactsBlocks = $this->getLocationBlocksForContactToRemove()[$entity];
+    $unMovedBlocks = array_diff_key($deletedContactsBlocks, $movedBlocks);
+    if (empty($unMovedBlocks) || empty($movedBlocks)) {
+      return [];
+    }
+    foreach (array_keys($movedBlocks) as $index) {
+      if ($deletedContactsBlocks[$index]['is_primary']) {
+        // We have moved the primary - change any other block to be primary.
+        $newPrimaryBlock = $this->getDAOForLocationEntity($entity);
+        $newPrimaryBlock->id = $unMovedBlocks[0]['id'];
+        $newPrimaryBlock->is_primary = 1;
+        return [$newPrimaryBlock->id => $newPrimaryBlock];
+      }
+    }
+    return [];
+  }
+
+  /**
+   * Get the details of the blocks to be transferred over for the given entity.
+   *
+   * @param string $entity
+   *
+   * @return array
+   */
+  protected function getLocationBlocksToMoveForEntity($entity) {
+    $movedBlocks = $this->getLocationBlocksToMerge()[$entity];
+    $blockDetails = $this->getLocationBlocksForContactToRemove()[$entity];
+    return array_intersect_key($blockDetails, $movedBlocks);
+  }
+
+  /**
+   * Does the contact to keep have location blocks for the given entity.
+   *
+   * @param string $entity
+   *
+   * @return bool
+   */
+  public function contactToKeepHasLocationBlocksForEntity($entity) {
+    return !empty($this->getLocationBlocksForContactToKeep()[$entity]);
+  }
+
+  /**
+   * Get the location blocks for the contact to be kept.
+   *
+   * @return array
+   */
+  public function getLocationBlocksForContactToKeep() {
+    return $this->getMigrationInfo()['main_details']['location_blocks'];
+  }
+
+  /**
+   * Get the location blocks for the contact to be deleted.
+   *
+   * @return array
+   */
+  public function getLocationBlocksForContactToRemove() {
+    return $this->getMigrationInfo()['other_details']['location_blocks'];
+  }
+
+  /**
    * Get the DAO object appropriate to the location entity.
    *
    * @param string $entity

--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -1864,6 +1864,7 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
           }
           $blocksDAO[$name]['update'][$otherBlockDAO->id] = $otherBlockDAO;
         }
+        $blocksDAO[$name]['update'] += $mergeHandler->getBlocksToUpdateForDeletedContact($name);
       }
     }
 

--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -1806,9 +1806,6 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
 
       foreach ($locBlocks as $name => $block) {
         $blocksDAO[$name] = ['delete' => [], 'update' => []];
-        if (!is_array($block) || CRM_Utils_System::isNull($block)) {
-          continue;
-        }
         $daoName = 'CRM_Core_DAO_' . $locationBlocks[$name]['label'];
         $changePrimary = FALSE;
         $primaryDAOId = (array_key_exists($name, $primaryBlockIds)) ? array_pop($primaryBlockIds[$name]) : NULL;

--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -1799,14 +1799,12 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
 
     // @todo Handle OpenID (not currently in API).
     if (!empty($locBlocks)) {
-      $locationBlocks = self::getLocationBlockInfo();
 
       $primaryBlockIds = CRM_Contact_BAO_Contact::getLocBlockIds($mergeHandler->getToKeepID(), ['is_primary' => 1]);
       $billingBlockIds = CRM_Contact_BAO_Contact::getLocBlockIds($mergeHandler->getToKeepID(), ['is_billing' => 1]);
 
       foreach ($locBlocks as $name => $block) {
         $blocksDAO[$name] = ['delete' => [], 'update' => []];
-        $daoName = 'CRM_Core_DAO_' . $locationBlocks[$name]['label'];
         $changePrimary = FALSE;
         $primaryDAOId = (array_key_exists($name, $primaryBlockIds)) ? array_pop($primaryBlockIds[$name]) : NULL;
         $billingDAOId = (array_key_exists($name, $billingBlockIds)) ? array_pop($billingBlockIds[$name]) : NULL;

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -149,7 +149,7 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
    *
    * @var bool
    */
-  protected $isLocationTypesOnPostAssert = FALSE;
+  protected $isLocationTypesOnPostAssert = TRUE;
 
   /**
    * Class used for hooks during tests.

--- a/tests/phpunit/api/v3/JobTest.php
+++ b/tests/phpunit/api/v3/JobTest.php
@@ -45,6 +45,13 @@ class api_v3_JobTest extends CiviUnitTestCase {
   private $report_instance;
 
   /**
+   * Should location types be checked to ensure primary addresses are correctly assigned after each test.
+   *
+   * @var bool
+   */
+  protected $isLocationTypesOnPostAssert = TRUE;
+
+  /**
    * Set up for tests.
    */
   public function setUp() {

--- a/tests/phpunit/api/v3/SyntaxConformanceTest.php
+++ b/tests/phpunit/api/v3/SyntaxConformanceTest.php
@@ -39,6 +39,16 @@ class api_v3_SyntaxConformanceTest extends CiviUnitTestCase {
   protected $_entity;
 
   /**
+   * Should location types be checked to ensure primary addresses are correctly assigned after each test.
+   *
+   * Turn off for this class as we use DAO methods that bypass business logic. Also, this test class
+   * takes a long time so might be good not to add another check.
+   *
+   * @var bool
+   */
+  protected $isLocationTypesOnPostAssert = FALSE;
+
+  /**
    * Map custom group entities to civicrm components.
    * @var array
    */

--- a/tests/phpunit/api/v3/SyntaxConformanceTest.php
+++ b/tests/phpunit/api/v3/SyntaxConformanceTest.php
@@ -39,16 +39,6 @@ class api_v3_SyntaxConformanceTest extends CiviUnitTestCase {
   protected $_entity;
 
   /**
-   * Should location types be checked to ensure primary addresses are correctly assigned after each test.
-   *
-   * Turn off for this class as we use DAO methods that bypass business logic. Also, this test class
-   * takes a long time so might be good not to add another check.
-   *
-   * @var bool
-   */
-  protected $isLocationTypesOnPostAssert = FALSE;
-
-  /**
    * Map custom group entities to civicrm components.
    * @var array
    */


### PR DESCRIPTION
Overview
----------------------------------------
I'lll firm this up when I see how tests go - the goal is to ensure we consistently have valid primaries & then remove the line with the extra queries & make sure it has no impact

UPDATE - this found real live  bugs - https://github.com/civicrm/civicrm-core/pull/18489 and https://github.com/civicrm/civicrm-core/pull/18498 - will look again tomorrow at the fails but seeing...

1) Email::add is only called from tests & does not wrangle is_primary - propose deprecating add formally - moving functionality into create & calling thaat
2) sql based test set up
3) createTestObject based test set up

Before
----------------------------------------
_What is the old user-interface or technical-contract (as appropriate)?_
_For optimal clarity, include a concrete example such as a screenshot, GIF ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)), or code-snippet._

After
----------------------------------------
_What changed? What is new old user-interface or technical-contract?_
_For optimal clarity, include a concrete example such as a screenshot, GIF ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)), or code-snippet._

Technical Details
----------------------------------------
_If the PR involves technical details/changes/considerations which would not be manifest to a casual developer skimming the above sections, please describe the details here._

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
