### PR TITLE
dev/core#2043 remove pass-by-reference

### DIFF
--- a/CRM/Core/BAO/Block.php
+++ b/CRM/Core/BAO/Block.php
@@ -197,14 +197,14 @@ class CRM_Core_BAO_Block {
    * @param string $blockName
    *   Block name.
    * @param array $params
-   *   (reference ) an assoc array of name/value pairs.
-   * @param null $entity
+   *   Array of name/value pairs.
+   * @param string $entity
    * @param int $contactId
    *
-   * @return object
-   *   CRM_Core_BAO_Block object on success, null otherwise
+   * @return array|null
+   *   Array of created location entities or NULL if none to create.
    */
-  public static function create($blockName, &$params, $entity = NULL, $contactId = NULL) {
+  public static function create($blockName, $params, $entity = NULL, $contactId = NULL) {
     if (!self::blockExists($blockName, $params)) {
       return NULL;
     }


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#2043 remove pass-by-reference

Rationale in https://lab.civicrm.org/dev/core/-/issues/2043



Before
----------------------------------------
```
public static function create($blockName, &$params, $entity = NULL, $contactId = NULL) {
```

After
----------------------------------------
```
public static function create($blockName, $params, $entity = NULL, $contactId = NULL) {
```

Technical Details
----------------------------------------
With https://github.com/civicrm/civicrm-core/pull/18484 committed it's fairly easy to see $params is not altered in this function

Comments
----------------------------------------
