### PR TITLE
dev/event#42 [Ref] Separate url path calculation into the relevant classes

### DIFF
--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -338,55 +338,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
       return CRM_Event_Form_EventFees::preProcess($this);
     }
 
-    //check the mode when this form is called either single or as
-    //search task action
-    if ($this->_single) {
-      $this->assign('urlPath', 'civicrm/contact/view/participant');
-      if (!$this->_id && !$this->_contactId) {
-        $breadCrumbs = [
-          [
-            'title' => ts('CiviEvent Dashboard'),
-            'url' => CRM_Utils_System::url('civicrm/event', 'reset=1'),
-          ],
-        ];
-
-        CRM_Utils_System::appendBreadCrumb($breadCrumbs);
-      }
-    }
-    else {
-      //set the appropriate action
-      $context = $this->get('context');
-      $urlString = 'civicrm/contact/search';
-      $this->_action = CRM_Core_Action::BASIC;
-      switch ($context) {
-        case 'advanced':
-          $urlString = 'civicrm/contact/search/advanced';
-          $this->_action = CRM_Core_Action::ADVANCED;
-          break;
-
-        case 'builder':
-          $urlString = 'civicrm/contact/search/builder';
-          $this->_action = CRM_Core_Action::PROFILE;
-          break;
-
-        case 'basic':
-          $urlString = 'civicrm/contact/search/basic';
-          $this->_action = CRM_Core_Action::BASIC;
-          break;
-
-        case 'custom':
-          $urlString = 'civicrm/contact/search/custom';
-          $this->_action = CRM_Core_Action::COPY;
-          break;
-      }
-      CRM_Contact_Form_Task::preProcessCommon($this);
-
-      $this->_contactId = NULL;
-
-      //set ajax path, this used for custom data building
-      $this->assign('urlPath', $urlString);
-      $this->assign('urlPathVar', "_qf_Participant_display=true&qfKey={$this->controller->_key}");
-    }
+    $this->assignUrlPath();
 
     $this->assign('single', $this->_single);
 
@@ -2327,6 +2279,23 @@ INNER JOIN civicrm_price_field_value value ON ( value.id = lineItem.price_field_
     }
 
     return $feeDetails;
+  }
+
+  /**
+   * Assign the url path to the template.
+   */
+  protected function assignUrlPath() {
+    $this->assign('urlPath', 'civicrm/contact/view/participant');
+    if (!$this->_id && !$this->_contactId) {
+      $breadCrumbs = [
+        [
+          'title' => ts('CiviEvent Dashboard'),
+          'url' => CRM_Utils_System::url('civicrm/event', 'reset=1'),
+        ],
+      ];
+
+      CRM_Utils_System::appendBreadCrumb($breadCrumbs);
+    }
   }
 
 }

--- a/CRM/Event/Form/Task/Register.php
+++ b/CRM/Event/Form/Task/Register.php
@@ -37,4 +37,42 @@ class CRM_Event_Form_Task_Register extends CRM_Event_Form_Participant {
    */
   public $_single = FALSE;
 
+  /**
+   * Assign the url path to the template.
+   */
+  protected function assignUrlPath() {
+    //set the appropriate action
+    $context = $this->get('context');
+    $urlString = 'civicrm/contact/search';
+    $this->_action = CRM_Core_Action::BASIC;
+    switch ($context) {
+      case 'advanced':
+        $urlString = 'civicrm/contact/search/advanced';
+        $this->_action = CRM_Core_Action::ADVANCED;
+        break;
+
+      case 'builder':
+        $urlString = 'civicrm/contact/search/builder';
+        $this->_action = CRM_Core_Action::PROFILE;
+        break;
+
+      case 'basic':
+        $urlString = 'civicrm/contact/search/basic';
+        $this->_action = CRM_Core_Action::BASIC;
+        break;
+
+      case 'custom':
+        $urlString = 'civicrm/contact/search/custom';
+        $this->_action = CRM_Core_Action::COPY;
+        break;
+    }
+    CRM_Contact_Form_Task::preProcessCommon($this);
+
+    $this->_contactId = NULL;
+
+    //set ajax path, this used for custom data building
+    $this->assign('urlPath', $urlString);
+    $this->assign('urlPathVar', "_qf_Participant_display=true&qfKey={$this->controller->_key}");
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Separates functionality into the relevant classes between the participant search action & the main participant edit

Before
----------------------------------------
https://github.com/civicrm/civicrm-core/pull/18464 started the work of separating the 2 forms into 2 classes but only did if for one variable

After
----------------------------------------
This extends the above to cover the function assignUrlPath which was previously an if-else

Technical Details
----------------------------------------
https://lab.civicrm.org/dev/event/-/issues/42

Comments
----------------------------------------
@monishdeb  - since the other is sorted...
