### PR TITLE
dev/core#1973 Fix Email & Phone storage issues in event location

### DIFF
--- a/tests/phpunit/CRM/Contact/Import/Form/DataSourceTest.php
+++ b/tests/phpunit/CRM/Contact/Import/Form/DataSourceTest.php
@@ -40,7 +40,7 @@ class CRM_Contact_Import_Form_DataSourceTest extends CiviUnitTestCase {
   public function testSQLSource() {
     $this->callAPISuccess('Mapping', 'create', ['name' => 'Well dressed ducks', 'mapping_type_id' => 'Import Contact']);
     /** @var CRM_Import_DataSource_SQL $form */
-    $form = $this->getFormObject('CRM_Import_DataSource_SQL');
+    $form = $this->getFormObject('CRM_Import_DataSource_SQL', [], 'SQL');
     $coreForm = $this->getFormObject('CRM_Core_Form');
     $db = NULL;
     $params = ['sqlQuery' => 'SELECT 1 as id'];

--- a/tests/phpunit/CRM/Event/Form/ManageEvent/LocationTest.php
+++ b/tests/phpunit/CRM/Event/Form/ManageEvent/LocationTest.php
@@ -1,0 +1,123 @@
+<?php
+
+use Civi\Api4\Event;
+use Civi\Api4\Email;
+
+/**
+ *  Test CRM_Event_Form_Registration functions.
+ *
+ * @package   CiviCRM
+ * @group headless
+ */
+class CRM_Event_Form_ManageEvent_LocationTest extends CiviUnitTestCase {
+
+  /**
+   * Test the right emails exist after submitting the location form twice.
+   *
+   * @throws \API_Exception
+   * @throws \CRM_Core_Exception
+   * @throws \Civi\API\Exception\UnauthorizedException
+   */
+  public function testSubmit() {
+    $eventID = (int) $this->eventCreate()['id'];
+    $form = $this->getFormObject('CRM_Event_Form_ManageEvent_Location', $this->getFormValues());
+    $form->set('id', $eventID);
+    $form->preProcess();
+    $form->buildQuickForm();
+    $form->postProcess();
+    $this->assertCorrectEmails($eventID);
+
+    // Now do it again to see if it gets messed with.
+    $form = $this->getFormObject('CRM_Event_Form_ManageEvent_Location', array_merge($this->getFormValues(), ['loc_event_id' => $this->ids['LocBlock'][0]]));
+    $form->set('id', $eventID);
+    $form->preProcess();
+    $form->buildQuickForm();
+    $form->postProcess();
+    $this->assertCorrectEmails($eventID);
+  }
+
+  /**
+   * Get the values to submit for the form.
+   *
+   * @return array
+   */
+  protected function getFormValues() {
+    return [
+      'address' =>
+        [
+          1 =>
+            [
+              'master_id' => '',
+              'street_address' => '581O Lincoln Dr SW',
+              'supplemental_address_1' => '',
+              'supplemental_address_2' => '',
+              'supplemental_address_3' => '',
+              'city' => 'Santa Fe',
+              'postal_code' => '87594',
+              'country_id' => '1228',
+              'state_province_id' => '1030',
+              'county_id' => '',
+              'geo_code_1' => '35.5212',
+              'geo_code_2' => '-105.982',
+            ],
+        ],
+      'email' =>
+        [
+          1 =>
+            [
+              'email' => 'celebration@example.org',
+            ],
+          2 =>
+            [
+              'email' => 'bigger_party@example.org',
+            ],
+        ],
+      'phone' =>
+        [
+          1 =>
+            [
+              'phone_type_id' => '1',
+              'phone' => '303 323-1000',
+              'phone_ext' => '',
+            ],
+          2 =>
+            [
+              'phone_type_id' => '1',
+              'phone' => '44',
+              'phone_ext' => '',
+            ],
+        ],
+      'location_option' => '2',
+      'loc_event_id' => '3',
+      'is_show_location' => '1',
+      'is_template' => '0',
+    ];
+  }
+
+  /**
+   * @param int $eventID
+   *
+   * @return \Civi\Api4\Generic\Result
+   * @throws \API_Exception
+   * @throws \Civi\API\Exception\UnauthorizedException
+   */
+  protected function assertCorrectEmails($eventID) {
+    $emails = Email::get()
+      ->addWhere('email', 'IN', ['bigger_party@example.org', 'celebration@example.org'])
+      ->addOrderBy('email', 'DESC')
+      ->execute();
+
+    $this->assertCount(2, $emails);
+    $firstEmail = $emails->first();
+    $locationBlock = Event::get()
+      ->addWhere('id', '=', $eventID)
+      ->setSelect(['loc_block.*', 'loc_block_id'])
+      ->execute()->first();
+    $this->ids['LocBlock'][0] = $locationBlock['loc_block_id'];
+    $this->assertEquals($firstEmail['id'], $locationBlock['loc_block.email_id']);
+    $secondEmail = $emails->last();
+    $this->assertEquals($secondEmail['id'], $locationBlock['loc_block.email_2_id']);
+    return $emails;
+  }
+
+}

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -3268,6 +3268,7 @@ VALUES
    */
   public function getFormObject($class, $formValues = [], $pageName = '') {
     $_POST = $formValues;
+    /* @var CRM_Core_Form $form */
     $form = new $class();
     $_SERVER['REQUEST_METHOD'] = 'GET';
     switch ($class) {
@@ -3280,8 +3281,7 @@ VALUES
         $form->controller = new CRM_Core_Controller();
     }
     if (!$pageName) {
-      $formParts = explode('_', $class);
-      $pageName = array_pop($formParts);
+      $pageName = $form->getName();
     }
     $form->controller->setStateMachine(new CRM_Core_StateMachine($form->controller));
     $_SESSION['_' . $form->controller->_name . '_container']['values'][$pageName] = $formValues;


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a fairly old regression whereby updating event location fields doesn't work properly

Before
----------------------------------------
Email - Second field value cannot be saved on form submit.
To replicate -

Navigate to Event -> Location tab - https://dmaster.demo.civicrm.org/civicrm/event/manage/location?reset=1&action=update&id=3

Enter a value for the second email field and save. The second field is empty after the form is submitted. And Email2 value is displayed on the first email field

Phone: Every time the Location form is submitted, a new row is inserted in phone table even if it already exist.
To replicate -

Navigate to Event -> Location tab - https://dmaster.demo.civicrm.org/civicrm/event/manage/location?reset=1&action=update&id=3

Fill both the phone numbers and save.
Re-save the form without changing any value. 2 new duplicate rows have been inserted in civicrm_phone table.
This happens on every submission of the Location form.

After
----------------------------------------
Should update ok - hopefully without breaking @yashodha's use case from 
https://github.com/civicrm/civicrm-core/pull/13534

Technical Details
----------------------------------------
I wanted to go further on the cleanup but the approach to do that depends on https://lab.civicrm.org/dev/core/-/issues/2044

Comments
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/1973
