### PR TITLE
Remove deprecated code lines

### DIFF
--- a/CRM/Core/BAO/Email.php
+++ b/CRM/Core/BAO/Email.php
@@ -54,10 +54,6 @@ class CRM_Core_BAO_Email extends CRM_Core_DAO_Email {
     $hook = empty($params['id']) ? 'create' : 'edit';
     CRM_Utils_Hook::pre($hook, 'Email', CRM_Utils_Array::value('id', $params), $params);
 
-    if (isset($params['is_bulkmail']) && $params['is_bulkmail'] === 'null') {
-      CRM_Core_Error::deprecatedFunctionWarning('It is not valid to set bulkmail to null, it is boolean');
-      $params['bulkmail'] = 0;
-    }
     $email = new CRM_Core_DAO_Email();
     $email->copyValues($params);
     if (!empty($email->email)) {


### PR DESCRIPTION
Overview
----------------------------------------
Removes some deprecated handling

Before
----------------------------------------
<img width="910" alt="Screen Shot 2020-09-16 at 10 29 56 PM" src="https://user-images.githubusercontent.com/336308/93326094-6b629280-f86c-11ea-91b0-6c2555ffe369.png">


After
----------------------------------------
poof

Technical Details
----------------------------------------

Comments
----------------------------------------
As a required field this will now hard -fail if an extension tries to set it to null (which they shouldn't really have done even before the deprecation)

<img width="403" alt="Screen Shot 2020-09-17 at 4 59 11 PM" src="https://user-images.githubusercontent.com/336308/93422109-2b042280-f907-11ea-86a0-11c187e7aa3e.png">

