### PR TITLE
Ensure DAO base class contains functions to be removed from generated files

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -147,10 +147,21 @@ class CRM_Core_DAO extends DB_DataObject {
   }
 
   /**
-   * Empty definition for virtual function.
+   * Returns the name of this table
+   *
+   * @return string
    */
   public static function getTableName() {
-    return NULL;
+    return self::getLocaleTableName(static::$_tableName ?? NULL);
+  }
+
+  /**
+   * Returns if this table needs to be logged
+   *
+   * @return bool
+   */
+  public function getLog() {
+    return static::$_log ?? FALSE;
   }
 
   /**
@@ -2727,11 +2738,11 @@ SELECT contact_id
    */
   public function getFieldSpec($fieldName) {
     $fields = $this->fields();
-    $fieldKeys = $this->fieldKeys();
 
     // Support "unique names" as well as sql names
     $fieldKey = $fieldName;
     if (empty($fields[$fieldKey])) {
+      $fieldKeys = $this->fieldKeys();
       $fieldKey = $fieldKeys[$fieldName] ?? NULL;
     }
     // If neither worked then this field doesn't exist. Return false.
@@ -3128,6 +3139,16 @@ SELECT contact_id
     if (isset($this->name)) {
       unset(self::$_dbColumnValueCache[$daoName]['name'][$this->name]);
     }
+  }
+
+  /**
+   * Return a mapping from field-name to the corresponding key (as used in fields()).
+   *
+   * @return array
+   *   Array(string $name => string $uniqueName).
+   */
+  public static function fieldKeys() {
+    return array_flip(CRM_Utils_Array::collect('name', static::fields()));
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Ensures some functions are in the DAO baseclass so we can eventually remove them from the generated child classes.

Technical Details
----------------------------------------
The functions `fieldKeys()`, `getLog()`, and `getTableName() `are redundant in the generated DAO files; we don't need 50 copies of each function.

This preliminary commit ensures they are present in the parent class, and in the future we can regenerate the DAOs without them.

Comments
----------------------------------------
Although I'd like to remove the functions from `dao.tpl` and regenerate the files now, I think we should give a few month's lead time on doing so because extensions' daos are generated in the same way. As soon as we take the functions out of `dao.tpl` in master, then any extension regenerating its DAOs based on civicrm master will immediately lose backward-compatibility with all versions of CiviCRM prior to 5.31.