### PR TITLE
Fix default report permissions when creating reports from CiviCampaign

### DIFF
--- a/CRM/Campaign/Form/Survey/Results.php
+++ b/CRM/Campaign/Form/Survey/Results.php
@@ -461,6 +461,8 @@ class CRM_Campaign_Form_Survey_Results extends CRM_Campaign_Form_Survey {
       }
       $this->_createNew = TRUE;
       $this->_id = CRM_Report_Utils_Report::getInstanceIDForValue('survey/detail');
+      CRM_Report_Form_Instance::setDefaultValues($this, $this->_defaults);
+      $this->_params = array_merge($this->_params, $this->_defaults);
       CRM_Report_Form_Instance::postProcess($this, FALSE);
 
       $query = "SELECT MAX(id) FROM civicrm_report_instance WHERE name = %1";


### PR DESCRIPTION
Overview
----------------------------------------

When reports are created as part of CiviCampaign Surveys, the report title that is created is visible to everyone. The actual report is not accessible, but the title is. This can be sensitive in certain situations.

To reproduce:

* Enable CiviCampaign
* Create new Survey : Campaign > New Survey
* Follow the steps, fill in required fields, including the "Results" tab, where we can create a report

![Capture d’écran de 2020-09-16 13-27-20](https://user-images.githubusercontent.com/254741/93371444-60821080-f820-11ea-9746-495ae7d518a7.png)

Then, using a private browser tab, view the /civicrm/report/list?reset=1 page as an anonymous user. The report will be listed as an available report (but clicking on the link will result in an error, because the survey report itself has a permission check).

Before
----------------------------------------

Visible report in /civicrm/report/list

After
----------------------------------------

Not visible  report in /civicrm/report/list

Technical Details
----------------------------------------

I'm not 100% sure about this change:

```
+      $this->_params = array_merge($this->_params, $this->_defaults);
```

I didn't find a proper pattern for this in CiviCRM core. However, without it, the defaults are not applied to params.

Self promo: the [symbiotic](https://civicrm.org/extensions/symbiotic) extension monitors for "public" reports.