### PR TITLE
dev/core#2046 Rationalise add vs create on email BAO

### DIFF
--- a/CRM/Core/BAO/Email.php
+++ b/CRM/Core/BAO/Email.php
@@ -36,21 +36,6 @@ class CRM_Core_BAO_Email extends CRM_Core_DAO_Email {
       CRM_Core_BAO_Block::handlePrimary($params, get_class());
     }
 
-    $email = CRM_Core_BAO_Email::add($params);
-
-    return $email;
-  }
-
-  /**
-   * Takes an associative array and adds email.
-   *
-   * @param array $params
-   *   (reference ) an assoc array of name/value pairs.
-   *
-   * @return object
-   *   CRM_Core_BAO_Email object on success, null otherwise
-   */
-  public static function add(&$params) {
     $hook = empty($params['id']) ? 'create' : 'edit';
     CRM_Utils_Hook::pre($hook, 'Email', CRM_Utils_Array::value('id', $params), $params);
 
@@ -96,6 +81,20 @@ WHERE  contact_id = {$params['contact_id']}
 
     CRM_Utils_Hook::post($hook, 'Email', $email->id, $email);
     return $email;
+  }
+
+  /**
+   * Takes an associative array and adds email.
+   *
+   * @param array $params
+   *   (reference ) an assoc array of name/value pairs.
+   *
+   * @return object
+   *   CRM_Core_BAO_Email object on success, null otherwise
+   */
+  public static function add(&$params) {
+    CRM_Core_Error::deprecatedFunctionWarning('apiv4 create');
+    return self::create($params);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
This folds the email::add function into the email:create functions into one, deprecating add

- note test fail expected until #18494 is merged

Before
----------------------------------------
create calls add, add not deprecated

After
----------------------------------------
add deprecated wrapper for create

Technical Details
----------------------------------------
Discussion would be better over https://lab.civicrm.org/dev/core/-/issues/2046

Comments
----------------------------------------
Per comments on gitlab- I will close this & continue the discussion in gitlab unless this seems straight forward - once 
https://github.com/civicrm/civicrm-core/pull/18494 is merged I do not believe ::add is called except from create - except for here https://github.com/giant-rabbit/com.giantrabbit.civimailchimp/blob/9fed1abd9680b1ae0e352c97b6370a6378d0313d/CRM/CiviMailchimp/Page/Webhook.php#L88 - I added an issue there on it https://github.com/giant-rabbit/com.giantrabbit.civimailchimp/issues/4