### PR TITLE
dev/core#2039 Fix OpenID::add to ensure is_primary is set

### DIFF
--- a/CRM/Core/BAO/OpenID.php
+++ b/CRM/Core/BAO/OpenID.php
@@ -24,9 +24,16 @@ class CRM_Core_BAO_OpenID extends CRM_Core_DAO_OpenID {
    * Create or update OpenID record.
    *
    * @param array $params
+   *
    * @return CRM_Core_DAO_OpenID
+   *
+   * @throws \API_Exception
+   * @throws \CRM_Core_Exception
    */
   public static function add($params) {
+    if (empty($params['id']) || is_numeric($params['is_primary'] ?? NULL)) {
+      CRM_Core_BAO_Block::handlePrimary($params, __CLASS__);
+    }
     return self::writeRecord($params);
   }
 
@@ -38,6 +45,7 @@ class CRM_Core_BAO_OpenID extends CRM_Core_DAO_OpenID {
    *   Input parameters to find object.
    *
    * @return mixed
+   * @throws \CRM_Core_Exception
    */
   public static function &getValues($entityBlock) {
     return CRM_Core_BAO_Block::getValues('openid', $entityBlock);

--- a/tests/phpunit/api/v3/OpenIDTest.php
+++ b/tests/phpunit/api/v3/OpenIDTest.php
@@ -18,6 +18,13 @@
  */
 class api_v3_OpenIDTest extends CiviUnitTestCase {
 
+  /**
+   * Should location types be checked to ensure primary addresses are correctly assigned after each test.
+   *
+   * @var bool
+   */
+  protected $isLocationTypesOnPostAssert = TRUE;
+
   protected $_params;
   protected $id;
   protected $_entity;


### PR DESCRIPTION
Overview
----------------------------------------
In my efforts to determine the the non-performant line of code that makes sure IM is set is
not required I edited tests to track down when is_primary is not correct & determined it
is missing from the add function - same as #18489 for IM

Before
----------------------------------------
Calling OpenID::add does not ensure contact has one primary 

After
----------------------------------------
Calling OpenID::add does ensure contact has one primary - further establishing https://github.com/civicrm/civicrm-core/blob/d357f225f281a0862b67a60d027c703ed2292f8b/CRM/Core/BAO/Location.php#L73 as redundant

Technical Details
----------------------------------------
When creating 7 contacts with 7 contributions 18% of the total 393 queries were from that 1 line of code, 12% were for entities that were not created. My goal is to 'prove' the line of code can go - it turns out we needed to fix im & open_id before that is true (whether anyone uses them is an open question.....) 

Comments
----------------------------------------
The 2 other commits are open as separate PRs - this can merge once they are merged
https://lab.civicrm.org/dev/core/-/issues/2039
