### PR TITLE
dev/core#2047 [REF] Minor code extraction

### DIFF
--- a/CRM/Dedupe/MergeHandler.php
+++ b/CRM/Dedupe/MergeHandler.php
@@ -190,4 +190,39 @@ class CRM_Dedupe_MergeHandler {
     return $locBlocks;
   }
 
+  /**
+   * Copy the data to be moved to a new DAO object.
+   *
+   * This is intended as a refactoring step - not the long term function. Do not
+   * call from any function other than the one it is taken from (Merger::mergeLocations).
+   *
+   * @param string $daoName
+   * @param int $otherBlockId
+   * @param string $name
+   * @param int $blkCount
+   *
+   * @return mixed
+   */
+  public function copyDataToNewBlockDAO(string $daoName, $otherBlockId, $name, $blkCount) {
+    $locationBlocks = CRM_Dedupe_Merger::getLocationBlockInfo();
+    $migrationInfo = $this->getMigrationInfo();
+    // For the block which belongs to other-contact, link the location block to main-contact
+    $otherBlockDAO = new $daoName();
+    $otherBlockDAO->contact_id = $this->getToKeepID();
+
+    // Get the ID of this block on the 'other' contact, otherwise skip
+    $otherBlockDAO->id = $otherBlockId;
+
+    // Add/update location and type information from the form, if applicable
+    if ($locationBlocks[$name]['hasLocation']) {
+      $locTypeId = $migrationInfo['location_blocks'][$name][$blkCount]['locTypeId'] ?? NULL;
+      $otherBlockDAO->location_type_id = $locTypeId;
+    }
+    if ($locationBlocks[$name]['hasType']) {
+      $typeTypeId = $migrationInfo['location_blocks'][$name][$blkCount]['typeTypeId'] ?? NULL;
+      $otherBlockDAO->{$locationBlocks[$name]['hasType']} = $typeTypeId;
+    }
+    return $otherBlockDAO;
+  }
+
 }

--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -1820,23 +1820,7 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
           if (!$otherBlockId) {
             continue;
           }
-
-          // For the block which belongs to other-contact, link the location block to main-contact
-          $otherBlockDAO = new $daoName();
-          $otherBlockDAO->contact_id = $mergeHandler->getToKeepID();
-
-          // Get the ID of this block on the 'other' contact, otherwise skip
-          $otherBlockDAO->id = $otherBlockId;
-
-          // Add/update location and type information from the form, if applicable
-          if ($locationBlocks[$name]['hasLocation']) {
-            $locTypeId = $migrationInfo['location_blocks'][$name][$blkCount]['locTypeId'] ?? NULL;
-            $otherBlockDAO->location_type_id = $locTypeId;
-          }
-          if ($locationBlocks[$name]['hasType']) {
-            $typeTypeId = $migrationInfo['location_blocks'][$name][$blkCount]['typeTypeId'] ?? NULL;
-            $otherBlockDAO->{$locationBlocks[$name]['hasType']} = $typeTypeId;
-          }
+          $otherBlockDAO = $mergeHandler->copyDataToNewBlockDAO($daoName, $otherBlockId, $name, $blkCount);
 
           // If we're deliberately setting this as primary then add the flag
           // and remove it from the current primary location (if there is one).


### PR DESCRIPTION


Overview
----------------------------------------
Code extraction in (heavily tested) moveLocations action

Before
----------------------------------------
Long chunk of code

After
----------------------------------------
Partially extracted to the MergeHandler class

Technical Details
----------------------------------------
This extracts code to the MergeHandler class for deduping locations. We have a LOT of
test cover here with all the scenarios in jobTest::testBatchMergesAddresses & other functions
using that same data provider.

The goal is to refactor the code onto the MergeHandler class, with a view to
doing less variable passing & more property-using to help clean it up -
in this case it's already visible that 2 variables can be derived in the mergeHandler:

Comments
----------------------------------------

