### PR TITLE
dev/core#2047 [Ref] Remove obsolete check

### DIFF
--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -1806,9 +1806,6 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
 
       foreach ($locBlocks as $name => $block) {
         $blocksDAO[$name] = ['delete' => [], 'update' => []];
-        if (!is_array($block) || CRM_Utils_System::isNull($block)) {
-          continue;
-        }
         $daoName = 'CRM_Core_DAO_' . $locationBlocks[$name]['label'];
         $changePrimary = FALSE;
         $primaryDAOId = (array_key_exists($name, $primaryBlockIds)) ? array_pop($primaryBlockIds[$name]) : NULL;


### PR DESCRIPTION
Overview
----------------------------------------
Removes a couple of lines of code that are obsolete & invoke brain pain

Before
----------------------------------------
```
 if (!is_array($block) || CRM_Utils_System::isNull($block)) {
          continue;
  }
```

block is part of the the $locBlocks array

<img width="425" alt="Screen Shot 2020-09-27 at 10 12 38 AM" src="https://user-images.githubusercontent.com/336308/94350354-00099380-00aa-11eb-9ee9-8fa9280005c3.png">

and to be added to that $block would need to be an array because it is only ever set as an array

<img width="763" alt="Screen Shot 2020-09-27 at 11 01 24 PM" src="https://user-images.githubusercontent.com/336308/94362092-72638d80-0115-11eb-923d-e9dd8a5e39f5.png">




After
----------------------------------------
poof

Technical Details
----------------------------------------
When looking into ->getLocationBlocksToMerge(); it's not really possible
anymore for locBlocks to contain a block that is not an array
- we can remove this check for less brain pain - the code has changed & likely this made more sense once

Comments
----------------------------------------

