### PR TITLE
dev/core#2039 Fix test to use set up method with more data integrity

### DIFF
--- a/tests/phpunit/api/v3/ACLPermissionTest.php
+++ b/tests/phpunit/api/v3/ACLPermissionTest.php
@@ -31,7 +31,7 @@ class api_v3_ACLPermissionTest extends CiviUnitTestCase {
   public function setUp() {
     parent::setUp();
     CRM_Core_DAO::createTestObject('CRM_Pledge_BAO_Pledge', [], 1, 0);
-    CRM_Core_DAO::createTestObject('CRM_Core_BAO_Phone', [], 1, 0);
+    $this->callAPISuccess('Phone', 'create', ['id' => $this->individualCreate(['email' => '']), 'phone' => '911', 'location_type_id' => 'Home']);
     $this->prepareForACLs();
   }
 


### PR DESCRIPTION


Overview
----------------------------------------
Using the api rather than CRM_Core_DAO::createTestObject to create the phone ensures it is created with is_primary.

We might need to fix CRM_Core_DAO::createTestObject but for this case simply using the api suffices

Before
----------------------------------------
```
CRM_Core_DAO::createTestObject('CRM_Core_BAO_Phone', [], 1, 0);
```

After
----------------------------------------
```
  $this->callAPISuccess('Phone', 'create', ['id' => $this->individualCreate(['email' => '']), 'phone' => '911', 'location_type_id' => 'Home']);
```

Technical Details
----------------------------------------


Comments
----------------------------------------

