### PR TITLE
Remove long-deprecated hook_civicrm_tabs

### DIFF
--- a/CRM/Contact/Page/View/Summary.php
+++ b/CRM/Contact/Page/View/Summary.php
@@ -425,9 +425,8 @@ class CRM_Contact_Page_View_Summary extends CRM_Contact_Page_View {
       $weight += 10;
     }
 
+    // Allow other modules to add or remove tabs
     $context = ['contact_id' => $this->_contactId];
-    // see if any other modules want to add any tabs
-    CRM_Utils_Hook::tabs($allTabs, $this->_contactId);
     CRM_Utils_Hook::tabset('civicrm/contact/view', $allTabs, $context);
 
     // now sort the tabs based on weight

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -826,23 +826,6 @@ abstract class CRM_Utils_Hook {
   }
 
   /**
-   * This hook is called when rendering the tabs for a contact (q=civicrm/contact/view)c
-   *
-   * @param array $tabs
-   *   The array of tabs that will be displayed.
-   * @param int $contactID
-   *   The contactID for whom the dashboard is being rendered.
-   *
-   * @return null
-   * @deprecated Use tabset() instead.
-   */
-  public static function tabs(&$tabs, $contactID) {
-    return self::singleton()->invoke(['tabs', 'contactID'], $tabs, $contactID,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, 'civicrm_tabs'
-    );
-  }
-
-  /**
    * This hook is called when rendering the tabs used for events and potentially
    * contribution pages, etc.
    *


### PR DESCRIPTION
Overview
----------------------------------------
This hook has been deprecated for 5 years. Time to remove it.

Before
----------------------------------------
Long-deprecated hook exists.

After
----------------------------------------
So long, farewell...

Comments
----------------------------------------
I searched through [CiviCRM Universe](https://docs.civicrm.org/dev/en/latest/tools/universe/) and found that most extensions have already made the transition. Some older, less-maintained extensions have not. I submitted PRs to update them, in case they are still being maintained...

- https://github.com/sgladstone/com.fountaintribe.financialsummaries/pull/4
- https://github.com/systopia/de.systopia.donrec/pull/112
- https://lab.civicrm.org/extensions/multisite/-/merge_requests/1
- https://github.com/CiviCooP/no.maf.oppgavexml/pull/1
- https://github.com/CiviCooP/org.civicoop.contactsegment/pull/12
- https://github.com/compucorp/civibooking/pull/192
- https://github.com/futurefirst/uk.org.futurefirst.networks.civipoints/pull/19
- https://github.com/cividesk/com.cividesk.apikey/pull/2