### PR TITLE
dev/core#2040 - Multiple email activity cc recipients get scrunched together in recorded activity details field 

### DIFF
--- a/CRM/Contact/Form/Task/EmailTrait.php
+++ b/CRM/Contact/Form/Task/EmailTrait.php
@@ -558,12 +558,12 @@ trait CRM_Contact_Form_Task_EmailTrait {
    *   e.g. <a href='{$contactURL}'>Bob Smith</a>'
    */
   protected function getEmailUrlString(array $emailIDs): string {
-    $urlString = '';
+    $urls = [];
     foreach ($emailIDs as $email) {
-      $contactURL = CRM_Utils_System::url('civicrm/contact/view', ['reset' => 1, 'force' => 1, 'cid' => $this->contactEmails[$email]['contact_id']], TRUE);
-      $urlString .= "<a href='{$contactURL}'>" . $this->contactEmails[$email]['contact.display_name'] . '</a>';
+      $contactURL = CRM_Utils_System::url('civicrm/contact/view', ['reset' => 1, 'cid' => $this->contactEmails[$email]['contact_id']], TRUE);
+      $urls[] = "<a href='{$contactURL}'>" . $this->contactEmails[$email]['contact.display_name'] . '</a>';
     }
-    return $urlString;
+    return implode(', ', $urls);
   }
 
   /**

--- a/templates/CRM/Activity/Form/ActivityView.tpl
+++ b/templates/CRM/Activity/Form/ActivityView.tpl
@@ -119,7 +119,7 @@
             </tr>
         {else}
              <tr>
-                 <td class="label">{ts}Details{/ts}</td><td class="view-value report">{$values.details|crmStripAlternatives|nl2br}</td>
+                 <td class="label">{ts}Details{/ts}</td><td class="view-value report">{$values.details|crmStripAlternatives|purify|nl2br}</td>
              </tr>
         {/if}
 {if $values.attachment}

--- a/tests/phpunit/CRM/Contact/Form/Task/EmailCommonTest.php
+++ b/tests/phpunit/CRM/Contact/Form/Task/EmailCommonTest.php
@@ -120,9 +120,9 @@ class CRM_Contact_Form_Task_EmailCommonTest extends CiviUnitTestCase {
     ]);
     $mut->stop();
     $activity = Activity::get(FALSE)->setSelect(['details'])->execute()->first();
-    $bccUrl1 = CRM_Utils_System::url('civicrm/contact/view', ['reset' => 1, 'force' => 1, 'cid' => $bcc1], TRUE);
-    $bccUrl2 = CRM_Utils_System::url('civicrm/contact/view', ['reset' => 1, 'force' => 1, 'cid' => $bcc2], TRUE);
-    $this->assertContains("bcc : <a href='" . $bccUrl1 . "'>Mr. Anthony Anderson II</a><a href='" . $bccUrl2 . "'>Mr. Anthony Anderson II</a>", $activity['details']);
+    $bccUrl1 = CRM_Utils_System::url('civicrm/contact/view', ['reset' => 1, 'cid' => $bcc1], TRUE);
+    $bccUrl2 = CRM_Utils_System::url('civicrm/contact/view', ['reset' => 1, 'cid' => $bcc2], TRUE);
+    $this->assertContains("bcc : <a href='" . $bccUrl1 . "'>Mr. Anthony Anderson II</a>, <a href='" . $bccUrl2 . "'>Mr. Anthony Anderson II</a>", $activity['details']);
     $this->assertEquals([
       [
         'text' => '27 messages were sent successfully. ',


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/2040

1. Send an outbound email in civi to multiple cc recipients.
2. Look at the details field on the recorded activity. The cc's are scrunched together.

Before
----------------------------------------
Cc: Bob SmithJane Doe

After
----------------------------------------
Cc: Bob Smith, Jane Doe

Technical Details
----------------------------------------
Recently refactored and the comma separator went missing: https://github.com/civicrm/civicrm-core/commit/a01fb99f56574eae7b6ade7cbb4f3292c505fe7d#diff-e604b19bd1979412f2455096459e761bR411-L439

https://github.com/civicrm/civicrm-core/blob/b3925388349a3d356b8852ead72361123e3ed196/CRM/Contact/Form/Task/EmailTrait.php#L564

Also the contact link url contains force=1 which seems unnecessary.

Comments
----------------------------------------

