### PR TITLE
[REF] Fix visibility of afform_scanner container service for Symfony …

### DIFF
--- a/ext/afform/core/afform.php
+++ b/ext/afform/core/afform.php
@@ -33,7 +33,7 @@ function afform_civicrm_container($container) {
   $container->setDefinition('afform_scanner', new \Symfony\Component\DependencyInjection\Definition(
     'CRM_Afform_AfformScanner',
     []
-  ));
+  ))->setPublic(TRUE);
 }
 
 /**


### PR DESCRIPTION
…3 and 4

Overview
----------------------------------------
This is the same fix as many other recent fixes as per https://github.com/civicrm/civicrm-core/pull/18443

Before
----------------------------------------
Symfony service is private in 3 & 4

After
----------------------------------------
Symfony service is public in 3 & 4
