### PR TITLE
CRM_Core_Resources::addBundle() - Fix handling of array inputs

### DIFF
--- a/CRM/Core/Resources.php
+++ b/CRM/Core/Resources.php
@@ -206,8 +206,8 @@ class CRM_Core_Resources implements CRM_Core_Resources_CollectionAdderInterface 
     if (is_iterable($bundle)) {
       foreach ($bundle as $b) {
         $this->addBundle($b);
-        return $this;
       }
+      return $this;
     }
 
     if (is_string($bundle)) {

--- a/CRM/Core/Resources/CollectionTrait.php
+++ b/CRM/Core/Resources/CollectionTrait.php
@@ -327,8 +327,8 @@ trait CRM_Core_Resources_CollectionTrait {
     if (is_iterable($bundle)) {
       foreach ($bundle as $b) {
         $this->addBundle($b);
-        return $this;
       }
+      return $this;
     }
     if (is_string($bundle)) {
       $bundle = Civi::service('bundle.' . $bundle);


### PR DESCRIPTION
Overview
----------------------------------------

This fixes a small bug in a new function added during this version-cycle -- part of #18247.

The signature of `addBundle()` optionally accepts an array/iterable -- if given, then it should add all the items from the array. For example:

```php
Civi::resources()->addBundle(['foo', 'bar', 'whiz']);
```

Before
------

It adds `foo` but ignores `bar` and `whiz`.

After
-----

It adds `foo`, `bar`, and `whiz`.