### PR TITLE
Afform Tests - Fix extension tests when run via `civi-test-run`

### DIFF
--- a/Civi/Angular/Manager.php
+++ b/Civi/Angular/Manager.php
@@ -54,6 +54,20 @@ class Manager {
   }
 
   /**
+   * Clear out any runtime-cached metadata.
+   *
+   * This is useful if, eg, you have recently added or destroyed Angular modules.
+   *
+   * @return static
+   */
+  public function clear() {
+    $this->cache->clear();
+    $this->modules = NULL;
+    $this->changeSets = NULL;
+    return $this;
+  }
+
+  /**
    * Get a list of AngularJS modules which should be autoloaded.
    *
    * @return array

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -56,7 +56,7 @@ class Container {
     $cacheMode = defined('CIVICRM_CONTAINER_CACHE') ? CIVICRM_CONTAINER_CACHE : 'auto';
 
     // In pre-installation environments, don't bother with caching.
-    if (!defined('CIVICRM_DSN') || $cacheMode === 'never' || \CRM_Utils_System::isInUpgradeMode()) {
+    if (!defined('CIVICRM_DSN') || defined('CIVICRM_TEST') || CIVICRM_UF === 'UnitTests' || $cacheMode === 'never' || \CRM_Utils_System::isInUpgradeMode()) {
       $containerBuilder = $this->createContainer();
       $containerBuilder->compile();
       return $containerBuilder;

--- a/ext/afform/core/afform.php
+++ b/ext/afform/core/afform.php
@@ -514,10 +514,7 @@ function afform_civicrm_permission_check($permission, &$granted, $contactId) {
 function _afform_clear() {
   $container = \Civi::container();
   $container->get('afform_scanner')->clear();
-
-  // Civi\Angular\Manager doesn't currently have a way to clear its in-memory
-  // data, so we just reset the whole object.
-  $container->set('angular', NULL);
+  $container->get('angular')->clear();
 }
 
 /**


### PR DESCRIPTION
Overview
----------------------------------------
The afform tests were previously run locally with a script `bin/test-all.sh`. They were recently [added to the`civi-test-run`](https://github.com/civicrm/civicrm-buildkit/pull/562) sequence for core test jobs, but the environment is slightly different.

This involves two distinct changes.

Technical Details
----------------------------------------

* __Change 1__: Most of the tests include an installation step (eg `Civi\Test::headless()->installMe()...`). This had a problem that wasn't apparent when running locally on a heady dev-build, but it does appear in a clean-environment -- i.e. it wasn't sufficiently aggressive in clearing the `Container`. In other extensions (e.g. `flexmailer` and `mosaico`), the test-suite specifically disables the `Container` cache to avoid this problem. But it's kind of annoying to remember to do this on all test-suites.
    * __Before__: Tests fail unless (a) you pre-install the extension or (b) specifically set the container-cache policy to `never`.
    * __After__: Tests pass. When running any tests, the container-cache policy is effectively `never`.
* __Change 2__: When adding/editing/deleting afforms, it has the effect of updating the list of Angular modules. This requires clearing some metadata/caches.
    * __Before__: It clears the `angular` service-object. The Symfony Container allows this sometimes; but other times it doesn't.
    * __After__: It keeps the `angular` service-object, but asks it do it its own (more fine-tuned) cache-clear.
