### PR TITLE
Separate export into separate classes to allow unravelling of component handling (Member)

### DIFF
--- a/CRM/Export/Controller/Standalone.php
+++ b/CRM/Export/Controller/Standalone.php
@@ -72,7 +72,7 @@ class CRM_Export_Controller_Standalone extends CRM_Core_Controller {
     $className = 'CRM_' . $this->getComponent($this->get('entity')) . '_Task';
     foreach ($className::tasks() as $taskId => $task) {
       $taskForm = (array) $task['class'];
-      if ($taskForm[0] == 'CRM_Export_Form_Select') {
+      if (strpos($taskForm[0], 'CRM_Export_Form_Select') === 0) {
         $values['task'] = $taskId;
       }
     }

--- a/CRM/Export/Form/Map.php
+++ b/CRM/Export/Form/Map.php
@@ -28,6 +28,15 @@ class CRM_Export_Form_Map extends CRM_Core_Form {
   protected $_mappingId;
 
   /**
+   * Use the form name to create the tpl file name.
+   *
+   * @return string
+   */
+  public function getTemplateFileName() {
+    return 'CRM/Export/Form/Map.tpl';
+  }
+
+  /**
    * Build the form object.
    */
   public function preProcess() {

--- a/CRM/Export/Form/Select.php
+++ b/CRM/Export/Form/Select.php
@@ -53,6 +53,15 @@ class CRM_Export_Form_Select extends CRM_Core_Form_Task {
   public $_componentTable;
 
   /**
+   * Use the form name to create the tpl file name.
+   *
+   * @return string
+   */
+  public function getTemplateFileName() {
+    return 'CRM/Export/Form/Select.tpl';
+  }
+
+  /**
    * Build all the data structures needed to build the form.
    *
    * @param

--- a/CRM/Member/Export/Form/Map.php
+++ b/CRM/Member/Export/Form/Map.php
@@ -18,11 +18,6 @@
 /**
  * This class gets the name of the file to upload
  */
-class CRM_Export_Form_Select_Case extends CRM_Export_Form_Select {
-
-  /**
-   * @var int
-   */
-  protected $queryMode = CRM_Contact_BAO_Query::MODE_CASE;
+class CRM_Member_Export_Form_Map extends CRM_Export_Form_Map {
 
 }

--- a/CRM/Member/Export/Form/Select.php
+++ b/CRM/Member/Export/Form/Select.php
@@ -18,11 +18,6 @@
 /**
  * This class gets the name of the file to upload
  */
-class CRM_Export_Form_Select_Case extends CRM_Export_Form_Select {
-
-  /**
-   * @var int
-   */
-  protected $queryMode = CRM_Contact_BAO_Query::MODE_CASE;
+class CRM_Member_Export_Form_Select extends CRM_Export_Form_Select {
 
 }

--- a/CRM/Member/Task.php
+++ b/CRM/Member/Task.php
@@ -55,8 +55,8 @@ class CRM_Member_Task extends CRM_Core_Task {
         self::TASK_EXPORT => [
           'title' => ts('Export members'),
           'class' => [
-            'CRM_Export_Form_Select',
-            'CRM_Export_Form_Map',
+            'CRM_Member_Export_Form_Select',
+            'CRM_Member_Export_Form_Map',
           ],
           'result' => FALSE,
         ],


### PR DESCRIPTION
Overview
----------------------------------------
This sets the scene for separating the export function into component specific classes & removing the tough handling & interaction with $form::preProcessCommon - only member in this for easy review but I intend to do the same for the others

Before
----------------------------------------
All export actions use the same class

After
----------------------------------------
Export actions start to use different classes that extend the same class for shared functionality

Technical Details
----------------------------------------
This stuff is ugly & hard to read & this provides a way out....

<img width="516" alt="Screen Shot 2020-09-18 at 3 59 34 PM" src="https://user-images.githubusercontent.com/336308/93553756-f86e2e80-f9c7-11ea-9375-cd0050d08c87.png">


Comments
----------------------------------------

This demonstrates the sort of extraction where the switch could give way to class overrides https://github.com/civicrm/civicrm-core/pull/18513

Also this gives an indicator of where I'm going with it https://github.com/civicrm/civicrm-core/pull/18514