### PR TITLE
dev/financial#150: civicrm/payment/form url got empty currency argument in backoffice live CC form

### DIFF
--- a/CRM/Contribute/Form/AbstractEditPayment.php
+++ b/CRM/Contribute/Form/AbstractEditPayment.php
@@ -385,19 +385,7 @@ WHERE  contribution_id = {$id}
    * @return string
    */
   public function getCurrency($submittedValues = []) {
-    $config = CRM_Core_Config::singleton();
-
-    $currentCurrency = CRM_Utils_Array::value('currency',
-      $this->_values,
-      $config->defaultCurrency
-    );
-
-    // use submitted currency if present else use current currency
-    $result = CRM_Utils_Array::value('currency',
-      $submittedValues,
-      $currentCurrency
-    );
-    return $result;
+    return $submittedValues['currency'] ?? $this->_values['currency'] ?? CRM_Core_Config::singleton()->defaultCurrency;
   }
 
   public function preProcessPledge() {

--- a/templates/CRM/common/paymentBlock.tpl
+++ b/templates/CRM/common/paymentBlock.tpl
@@ -122,7 +122,8 @@
     }
 
     $('[name=payment_processor_id], #currency').on('change.paymentBlock', function() {
-      buildPaymentBlock($('[name=payment_processor_id]').val());
+      var payment_processor_id = $('[name=payment_processor_id]:checked').val() == undefined ? $('[name=payment_processor_id]').val() : $('[name=payment_processor_id]:checked').val();
+      buildPaymentBlock(payment_processor_id);
     });
 
     $('#payment_instrument_id').on('change.paymentBlock', function() {

--- a/templates/CRM/common/paymentBlock.tpl
+++ b/templates/CRM/common/paymentBlock.tpl
@@ -123,7 +123,9 @@
 
     $('[name=payment_processor_id], #currency').on('change.paymentBlock', function() {
       var payment_processor_id = $('[name=payment_processor_id]:checked').val() == undefined ? $('[name=payment_processor_id]').val() : $('[name=payment_processor_id]:checked').val();
-      buildPaymentBlock(payment_processor_id);
+      if (payment_processor_id != undefined) {
+        buildPaymentBlock(payment_processor_id);
+      }
     });
 
     $('#payment_instrument_id').on('change.paymentBlock', function() {

--- a/templates/CRM/common/paymentBlock.tpl
+++ b/templates/CRM/common/paymentBlock.tpl
@@ -98,7 +98,10 @@
 
       var payment_instrument_id = $('#payment_instrument_id').val();
 
-      var dataUrl = "{crmURL p='civicrm/payment/form' h=0 q="formName=`$form.formName`&currency=`$currency`&`$urlPathVar``$isBackOfficePathVar``$profilePathVar``$contributionPageID``$preProfileID`processor_id="}" + type;
+      var currency = '{$currency}';
+      currency = currency == '' ? $('#currency').val() : currency;
+
+      var dataUrl = "{crmURL p='civicrm/payment/form' h=0 q="formName=`$form.formName``$urlPathVar``$isBackOfficePathVar``$profilePathVar``$contributionPageID``$preProfileID`processor_id="}" + type;
       {literal}
       if (typeof(CRM.vars) != "undefined") {
         if (typeof(CRM.vars.coreForm) != "undefined") {
@@ -111,15 +114,15 @@
           }
         }
       }
-      dataUrl =  dataUrl + "&payment_instrument_id=" + payment_instrument_id;
+      dataUrl =  dataUrl + "&payment_instrument_id=" + payment_instrument_id + "&currency=" + currency;
 
       // Processors like pp-express will hide the form submit buttons, so re-show them when switching
       $('.crm-submit-buttons', $form).show().find('input').prop('disabled', true);
       CRM.loadPage(dataUrl, {target: '#billing-payment-block'});
     }
 
-    $('[name=payment_processor_id]').on('change.paymentBlock', function() {
-        buildPaymentBlock($(this).val());
+    $('[name=payment_processor_id], #currency').on('change.paymentBlock', function() {
+      buildPaymentBlock($('[name=payment_processor_id]').val());
     });
 
     $('#payment_instrument_id').on('change.paymentBlock', function() {


### PR DESCRIPTION
Overview
----------------------------------------
This affects iATS Payments ACH/EFT payment processor which renders the payment block based on currency chosen. 
Here are the steps to replicate:

1. Install and enable iATS paymentextension
2. Add and configure an iATS Payments ACH/EFT payment type payment processor.
3. Enable USD and CAD currencies
4. Go to 'Submit Credit Card Contribution' backoffice form
5. Choose payment processor created at step 2

Issue:
1. Payment block renders payment block without check template
2. Switching currency doesn't update the payment block.


Before
----------------------------------------
![crm-598-before](https://user-images.githubusercontent.com/3735621/93595871-22c6e880-f9d6-11ea-893a-884f70be05e8.gif)


After
----------------------------------------
![crm-598-after](https://user-images.githubusercontent.com/3735621/93595901-2bb7ba00-f9d6-11ea-8de7-93f12e4de516.gif)


Technical Details
----------------------------------------
For more detail discussion on MM - https://chat.civicrm.org/civicrm/pl/ixxrxhxs43r4mfyjpnf6tnwnnc

https://lab.civicrm.org/dev/financial/-/issues/150

ping @KarinG @Edzelopez @eileenmcnaughton @JoeMurray  
