### PR TITLE
Make it obvious that we are only passing payment_processor_id to loadRelatedObjects

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2833,10 +2833,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
       $this->find(TRUE);
     }
 
-    $paymentProcessorID = CRM_Utils_Array::value('payment_processor_id', $input, CRM_Utils_Array::value(
-      'paymentProcessor',
-      $ids
-    ));
+    $paymentProcessorID = $input['payment_processor_id'] ?? $ids['paymentProcessor'] ?? NULL;
 
     if (!isset($input['payment_processor_id']) && !$paymentProcessorID && $this->contribution_page_id) {
       $paymentProcessorID = CRM_Core_DAO::getFieldValue('CRM_Contribute_DAO_ContributionPage',

--- a/api/v3/Contribution.php
+++ b/api/v3/Contribution.php
@@ -479,10 +479,7 @@ function civicrm_api3_contribution_completetransaction($params) {
     throw new API_Exception('A valid contribution ID is required', 'invalid_data');
   }
 
-  if (isset($params['payment_processor_id'])) {
-    $input['payment_processor_id'] = $params['payment_processor_id'];
-  }
-  if (!$contribution->loadRelatedObjects($input, $ids, TRUE)) {
+  if (!$contribution->loadRelatedObjects(['payment_processor_id' => $params['payment_processor_id'] ?? NULL], $ids, TRUE)) {
     throw new API_Exception('failed to load related objects');
   }
   elseif ($contribution->contribution_status_id == CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Completed')) {
@@ -606,12 +603,12 @@ function civicrm_api3_contribution_repeattransaction($params) {
     );
   }
 
-  $input['payment_processor_id'] = civicrm_api3('contributionRecur', 'getvalue', [
+  $paymentProcessorID = civicrm_api3('contributionRecur', 'getvalue', [
     'return' => 'payment_processor_id',
     'id' => $contribution->contribution_recur_id,
   ]);
   try {
-    if (!$contribution->loadRelatedObjects($input, $ids, TRUE)) {
+    if (!$contribution->loadRelatedObjects(['payment_processor_id' => $paymentProcessorID], $ids, TRUE)) {
       throw new API_Exception('failed to load related objects');
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
Partial from #18313. Pass only the required params to loadRelatedObjects for complete/repeattransaction

Before
----------------------------------------
Passing `$input` array.

After
----------------------------------------
Passing specific parameters

Technical Details
----------------------------------------

Comments
----------------------------------------
@eileenmcnaughton I tried moving loadRelatedObjects to _ipn_process_transaction but that causes problems because we mess with (unset some bits) the contribution object before passing and that breaks it. This is a simple cleanup that will probably help us remove the call entirely.
