### PR TITLE
dev/core#2051 jQuery validation: use attributes not classes

### DIFF
--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -452,6 +452,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
     }
 
     if ($required) {
+      $element->setAttribute('required');
       if ($type == 'file') {
         $error = $this->addRule($name, ts('%1 is a required field.', [1 => $label]), 'uploadedfile');
       }
@@ -684,11 +685,10 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
       }
 
       if (in_array($button['type'], ['upload', 'next', 'submit', 'done', 'process', 'refresh'])) {
-        $attrs['class'] .= ' validate';
         $defaultIcon = 'fa-check';
       }
       else {
-        $attrs['class'] .= ' cancel';
+        $attrs['formnovalidate'] = 'formnovalidate';
         $defaultIcon = $button['type'] == 'back' ? 'fa-chevron-left' : 'fa-times';
       }
 
@@ -1215,7 +1215,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
       // We use a class here to avoid html5 issues with collapsed cutsomfield sets.
       $optAttributes['class'] = $optAttributes['class'] ?? '';
       if ($required) {
-        $optAttributes['class'] .= ' required';
+        $optAttributes['required'] = TRUE;
       }
       $element = $this->createElement('radio', NULL, NULL, $var, $key, $optAttributes);
       $options[] = $element;


### PR DESCRIPTION
Overview
----------------------------------------
jQuery validation does not appear to respond to the `required` class on elements.  It does look for the `required` attribute.  This sets it on elements.  In addition, jQuery validation does not appear to respond to the `validate` or `cancel` class on buttons.  Instead, if jQuery validation is active, all buttons with the type `submit` trigger validation unless the `formnovalidate` attribute is set.  This adds that to cancel buttons.

Please see [dev/core#2051](https://lab.civicrm.org/dev/core/-/issues/2051) for discussion on this.  There are still some potential problems with this.  The biggest thing is that we haven't been using jQuery validation consistently.

Before
----------------------------------------
New Contribution - neglect to set required fields and click Save:

Form submits, fails Quickform validation, and displays the errors:
![image](https://user-images.githubusercontent.com/1682375/93615083-f3e24f80-f9a0-11ea-87e9-eb2ba6a239f9.png)

After
----------------------------------------
New Contribution - neglect to set required fields and click Save:

Form does not submit, and a little tooltip thing pops up with the error:
![image](https://user-images.githubusercontent.com/1682375/93615164-0b213d00-f9a1-11ea-8041-4aaee0367469.png)

Technical Details
----------------------------------------
I think jQuery validation might have responded to class names once upon a time, just not anymore.

This will need to be checked in three distinct contexts:

- backend standalone form (e.g. in top menu Contributions > New Contribution)
- backend modal form (e.g. on contact record Actions > Add Contribution)
- frontend form (e.g. a contribution page)

