### PR TITLE
Search ext: Aggregate field fixes

### DIFF
--- a/ext/search/ang/search/crmSearch.component.js
+++ b/ext/search/ang/search/crmSearch.component.js
@@ -87,6 +87,9 @@
           ctrl.params.orderBy = {};
         }
         ctrl.params.orderBy[col] = dir;
+        if (ctrl.results) {
+          ctrl.refreshPage();
+        }
       };
 
       /**
@@ -233,6 +236,10 @@
       };
 
       function onChangeSelect(newSelect, oldSelect) {
+        // When removing a column from SELECT, also remove from ORDER BY
+        _.each(_.difference(_.keys(ctrl.params.orderBy), newSelect), function(col) {
+          delete ctrl.params.orderBy[col];
+        });
         // Re-arranging or removing columns doesn't merit a refresh, only adding columns does
         if (!oldSelect || _.difference(newSelect, oldSelect).length) {
           if (ctrl.autoSearch) {
@@ -240,12 +247,6 @@
           } else {
             ctrl.stale = true;
           }
-        }
-      }
-
-      function onChangeOrderBy() {
-        if (ctrl.results) {
-          ctrl.refreshPage();
         }
       }
 
@@ -480,7 +481,6 @@
           format: 'json',
           default: {}
         });
-        $scope.$watchCollection('$ctrl.params.orderBy', onChangeOrderBy);
 
         $scope.$bindToRoute({
           expr: '$ctrl.params.where',

--- a/ext/search/ang/search/crmSearchFunction.html
+++ b/ext/search/ang/search/crmSearchFunction.html
@@ -1,4 +1,4 @@
 <div class="form-inline">
-  <label>{{ $ctrl.field.title }}:</label>
+  <label>{{ $ctrl.field.label }}:</label>
   <input class="form-control" style="width: 15em;" ng-model="$ctrl.fn" crm-ui-select="{data: $ctrl.functions, placeholder: ts('Select')}" ng-change="$ctrl.selectFunction()">
 </div>


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a search extension regression in 5.30 where field labels failed to display in the "Aggregate Fields" section.
Also fixes common crashes caused by MYSQL's only-full-group-by mode, by assigning a default aggregator to non-grouped fields.
Also fixes a bug where aggregating a field would fail to update the ORDER BY clause.

Before
----------------------------------------
<img width="360" alt="Screen Shot 2020-09-19 at 7 48 39 AM" src="https://user-images.githubusercontent.com/336308/93639126-9f94a980-fa4c-11ea-9383-03376a310798.png">

After
----------------------------------------
<img width="355" alt="Screen Shot 2020-09-19 at 7 53 33 AM" src="https://user-images.githubusercontent.com/336308/93639530-40836480-fa4d-11ea-9afe-dc420737b4bf.png">



Comments
----------------------------------------
Targets 5.30 branch since it addresses a regression in 5.30, and this is still a very new extension.
