### PR TITLE
fix datepickers to show correct minDate

### DIFF
--- a/CRM/Admin/Form/Job.php
+++ b/CRM/Admin/Form/Job.php
@@ -97,7 +97,7 @@ class CRM_Admin_Form_Job extends CRM_Admin_Form {
     $this->add('select', 'run_frequency', ts('Run frequency'), CRM_Core_SelectValues::getJobFrequency());
 
     // CRM-17686
-    $this->add('datepicker', 'scheduled_run_date', ts('Scheduled Run Date'), NULL, FALSE, ['minDate' => time()]);
+    $this->add('datepicker', 'scheduled_run_date', ts('Scheduled Run Date'), NULL, FALSE, ['minDate' => date('Y-m-d')]);
 
     $this->add('textarea', 'parameters', ts('Command parameters'),
       "cols=50 rows=6"

--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -570,7 +570,7 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
         CRM_Member_StatusOverrideTypes::getSelectOptions()
       );
 
-      $this->add('datepicker', 'status_override_end_date', ts('Status Override End Date'), '', FALSE, ['minDate' => time(), 'time' => FALSE]);
+      $this->add('datepicker', 'status_override_end_date', ts('Status Override End Date'), '', FALSE, ['minDate' => date('Y-m-d'), 'time' => FALSE]);
 
       $this->addElement('checkbox', 'record_contribution', ts('Record Membership Payment?'));
 

--- a/CRM/SMS/Form/Schedule.php
+++ b/CRM/SMS/Form/Schedule.php
@@ -60,7 +60,7 @@ class CRM_SMS_Form_Schedule extends CRM_Core_Form {
       'send_later' => ['id' => 'send_later'],
     ]);
 
-    $this->add('datepicker', 'start_date', '', NULL, FALSE, ['minDate' => time()]);
+    $this->add('datepicker', 'start_date', '', NULL, FALSE, ['minDate' => date('Y-m-d')]);
 
     $this->addFormRule(['CRM_SMS_Form_Schedule', 'formRule'], $this);
 


### PR DESCRIPTION
https://lab.civicrm.org/dev/core/-/issues/2052

(This is against the RC, otherwise identical to #18522)

Overview
----------------------------------------
https://github.com/civicrm/civicrm-core/pull/16610 enforces a requirement that datepickers pass dates in `Y-m-d` format.  Some datepickers currently pass a Unix timestamp.

Before
----------------------------------------
At certain times of day, these datepickers show a minimum year thousands of years in the future.

After
----------------------------------------
Minimum year is 2020 (and counting).

Comments
----------------------------------------
Depending on the time of day, this bug won't manifest in the UI.  If the code in #16610 results in a date like "0255-09-18" then it's ignored.  To test if the bug is present, check the value of `$extra['minDate']` after it passes through [this line from #16610](https://github.com/mattwire/civicrm-core/blob/12c738662105b64cbb1a0e4008184a7b3d85ae9f/CRM/Core/Form.php#L392).  If the date isn't today's date, the bug is present.