### PR TITLE
Rename var to make it clear that we skip participant update from event batch

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4448,7 +4448,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
     $contributionResult = self::repeatTransaction($contribution, $input, $contributionParams);
     $contributionID = (int) $contribution->id;
 
-    if ($input['component'] == 'contribute') {
+    if ($input['component'] === 'contribute') {
       if ($contributionParams['contribution_status_id'] === $completedContributionStatusID) {
         self::updateMembershipBasedOnCompletionOfContribution(
           $contributionID,
@@ -4457,7 +4457,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
       }
     }
     else {
-      if (empty($input['IAmAHorribleNastyBeyondExcusableHackInTheCRMEventFORMTaskClassThatNeedsToBERemoved'])) {
+      if (empty($input['skipParticipantUpdate'])) {
         $participantParams['id'] = $participantID;
         $participantParams['status_id'] = 'Registered';
         civicrm_api3('Participant', 'create', $participantParams);

--- a/CRM/Event/Form/Task/Batch.php
+++ b/CRM/Event/Form/Task/Batch.php
@@ -278,13 +278,11 @@ class CRM_Event_Form_Task_Batch extends CRM_Event_Form_Task {
 
     $positiveStatuses = CRM_Event_PseudoConstant::participantStatus(NULL, "class = 'Positive'");
     $negativeStatuses = CRM_Event_PseudoConstant::participantStatus(NULL, "class = 'Negative'");
-    $contributionStatuses = CRM_Contribute_PseudoConstant::contributionStatus(NULL, 'name');
 
     if (array_key_exists($statusId, $positiveStatuses)) {
       $params = [
         'component_id' => $participantId,
         'contribution_id' => $contributionId,
-        'IAmAHorribleNastyBeyondExcusableHackInTheCRMEventFORMTaskClassThatNeedsToBERemoved' => 1,
       ];
 
       //change related contribution status.
@@ -326,7 +324,8 @@ class CRM_Event_Form_Task_Batch extends CRM_Event_Form_Task {
       'labelColumn' => 'name',
       'flip' => 1,
     ]);
-    $input['IAmAHorribleNastyBeyondExcusableHackInTheCRMEventFORMTaskClassThatNeedsToBERemoved'] = $params['IAmAHorribleNastyBeyondExcusableHackInTheCRMEventFORMTaskClassThatNeedsToBERemoved'] ?? NULL;
+
+    $input['skipParticipantUpdate'] = TRUE;
 
     // status is not pending
     if ($contribution->contribution_status_id != $contributionStatuses['Pending']) {


### PR DESCRIPTION
Overview
----------------------------------------
It wasn't clear what this variable was doing - renaming it and moving where it is set makes it clear.

Before
----------------------------------------
Unclear

After
----------------------------------------
More clear

Technical Details
----------------------------------------


Comments
----------------------------------------
@eileenmcnaughton More work on repeattransaction
