### PR TITLE
Switch to passing payment_processor_id as input param to completeOrder

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4406,18 +4406,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
       'financial_type_id',
     ];
 
-    // @todo - accept payment_processor_id as an input parameter as it is part of the
-    // incoming payment information (at least when coming from a payment processor).
-    // this is the last 'object' to get rid of....
-    $paymentProcessorId = '';
-    if (isset($objects['paymentProcessor'])) {
-      if (is_array($objects['paymentProcessor'])) {
-        $paymentProcessorId = $objects['paymentProcessor']['id'];
-      }
-      else {
-        $paymentProcessorId = $objects['paymentProcessor']->id;
-      }
-    }
+    $paymentProcessorId = $input['payment_processor_id'] ?? NULL;
 
     $completedContributionStatusID = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Completed');
 

--- a/CRM/Core/Payment/AuthorizeNetIPN.php
+++ b/CRM/Core/Payment/AuthorizeNetIPN.php
@@ -86,6 +86,7 @@ class CRM_Core_Payment_AuthorizeNetIPN extends CRM_Core_Payment_BaseIPN {
           if ($objects['contribution']->contribution_status_id == 1) {
             $first = FALSE;
           }
+          $input['payment_processor_id'] = $paymentProcessorID;
           return $this->recur($input, $ids, $objects, $first);
         }
       }

--- a/CRM/Core/Payment/PayPalIPN.php
+++ b/CRM/Core/Payment/PayPalIPN.php
@@ -345,6 +345,8 @@ class CRM_Core_Payment_PayPalIPN extends CRM_Core_Payment_BaseIPN {
         return;
       }
 
+      $input['payment_processor_id'] = $paymentProcessorID;
+
       self::$_paymentProcessor = &$objects['paymentProcessor'];
       if ($component == 'contribute') {
         if ($ids['contributionRecur']) {

--- a/CRM/Core/Payment/PayPalProIPN.php
+++ b/CRM/Core/Payment/PayPalProIPN.php
@@ -471,6 +471,8 @@ INNER JOIN civicrm_membership_payment mp ON m.id = mp.membership_id AND mp.contr
         return;
       }
 
+      $input['payment_processor_id'] = $paymentProcessorID;
+
       self::$_paymentProcessor = &$objects['paymentProcessor'];
       //?? how on earth would we not have component be one of these?
       // they are the only valid settings & this IPN file can't even be called without one of them

--- a/api/v3/Contribution.php
+++ b/api/v3/Contribution.php
@@ -606,7 +606,7 @@ function civicrm_api3_contribution_repeattransaction($params) {
     );
   }
 
-  $input['payment_processor_id'] = civicrm_api3('contributionRecur', 'getvalue', [
+  $input['payment_processor_id'] = $params['payment_processor_id'] = civicrm_api3('contributionRecur', 'getvalue', [
     'return' => 'payment_processor_id',
     'id' => $contribution->contribution_recur_id,
   ]);
@@ -626,6 +626,7 @@ function civicrm_api3_contribution_repeattransaction($params) {
       'financial_type_id',
       'contribution_status_id',
       'membership_id',
+      'payment_processor_id',
     ];
     $input = array_intersect_key($params, array_fill_keys($passThroughParams, NULL));
 


### PR DESCRIPTION
Overview
----------------------------------------
This stops using $objects['paymentProcessor'] and passes the payment_processor_id via `$input` instead. Further cleanup is required to remove the call to loadRelatedObjects altogether.

Before
----------------------------------------
loadRelatedObjects required to set `$objects['paymentProcessor']`

After
----------------------------------------
loadRelatedObjects not required to set `$objects['paymentProcessor']`. `$input['payment_processor_id']` contains the payment processor ID that is required.

Technical Details
----------------------------------------

Comments
----------------------------------------
@eileenmcnaughton replacement for #18518
