### PR TITLE
dev/core#2030 ensure that the Country selector is a Select 2 and ensu…

### DIFF
--- a/CRM/Core/Payment.php
+++ b/CRM/Core/Payment.php
@@ -1131,7 +1131,7 @@ abstract class CRM_Core_Payment {
         '' => ts('- select -'),
       ] + CRM_Core_PseudoConstant::country(),
       'is_required' => TRUE,
-      'extra' => ['class' => 'required'],
+      'extra' => ['class' => 'required crm-form-select2 crm-select2'],
     ];
     return $metadata;
   }

--- a/templates/CRM/common/paymentBlock.tpl
+++ b/templates/CRM/common/paymentBlock.tpl
@@ -28,6 +28,8 @@
       payment_processor.hide();
       payment_information.hide();
       billing_block.hide();
+      // Ensure that jquery validation doesn't block submission when we don't need to fill in the billing details section
+      cj('#billing-payment-block select.crm-select2').addClass('crm-no-validate');
       // also unset selected payment methods
       cj('input[name="payment_processor_id"]').removeProp('checked');
     }
@@ -36,6 +38,7 @@
       payment_processor.show();
       payment_information.show();
       billing_block.show();
+      cj('#billing-payment-block select.crm-select2').removeClass('crm-no-validate');
       // also set selected payment methods
       cj('input[name="payment_processor_id"][checked=checked]').prop('checked', true);
     }


### PR DESCRIPTION
…re that if it is not shown on the contribution form that it doesn't prevent form submissions

Overview
----------------------------------------
This ensures that as per https://lab.civicrm.org/dev/core/-/issues/2030 the Country selector in the billing section is a select 2 field but ensures that the field doesn't block jquery validation if it is hidden (e.g. in a 0 dollar price option)

Before
----------------------------------------
Country field is a select not select2

After
----------------------------------------
Country field is a select2

Technical Details
----------------------------------------
I would probably prefer to use CRM.$ but that isn't the standard in this template file and also adding the class is consistent with how Matt solved it for the on behalf of fields https://github.com/civicrm/civicrm-core/commit/2ee6dbf5b8ee194e0d495d4ea8fc21575151973f#diff-bf5d242d71afaa6b906db60a79a6822e

ping @mattwire @demeritcowboy @eileenmcnaughton @agh1 