### PR TITLE
Follow up fix on paypal redirect

### DIFF
--- a/CRM/Core/Exception/PrematureExitException.php
+++ b/CRM/Core/Exception/PrematureExitException.php
@@ -26,6 +26,13 @@
 class CRM_Core_Exception_PrematureExitException extends RuntimeException {
 
   /**
+   * Contextual data.
+   *
+   * @var array
+   */
+  public $errorData;
+
+  /**
    * Construct the exception. Note: The message is NOT binary safe.
    *
    * @link https://php.net/manual/en/exception.construct.php

--- a/CRM/Core/Payment/PayPalImpl.php
+++ b/CRM/Core/Payment/PayPalImpl.php
@@ -972,7 +972,7 @@ class CRM_Core_Payment_PayPalImpl extends CRM_Core_Payment {
     $paypalURL = "{$url}{$sub}?$uri";
 
     // Allow each CMS to do a pre-flight check before redirecting to PayPal.
-    CRM_Utils_System::prePostRedirect();
+    CRM_Core_Config::singleton()->userSystem->prePostRedirect();
 
     CRM_Utils_System::redirect($paypalURL);
   }

--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -511,7 +511,7 @@ class CRM_Utils_System {
     }
 
     self::setHttpHeader('Location', $url);
-    self::civiExit();
+    self::civiExit(0, ['url' => $url, 'context' => 'redirect']);
   }
 
   /**
@@ -1919,8 +1919,7 @@ class CRM_Utils_System {
    * Perform any necessary actions prior to redirecting via POST.
    */
   public static function prePostRedirect() {
-    $config = CRM_Core_Config::singleton();
-    $config->userSystem->paypalBeforeRedirect();
+    CRM_Core_Config::singleton()->userSystem->prePostRedirect();
   }
 
 }

--- a/tests/phpunit/CRM/Core/Payment/PaypalStdTest.php
+++ b/tests/phpunit/CRM/Core/Payment/PaypalStdTest.php
@@ -1,0 +1,76 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * Class CRM_Core_Payment_PaypalPro
+ * @group headless
+ */
+class CRM_Core_Payment_PaypalStdTest extends CiviUnitTestCase {
+
+  /**
+   * @var \CRM_Core_Payment_PayPalImpl
+   */
+  protected $processor;
+
+  /**
+   * @throws \CiviCRM_API3_Exception
+   */
+  public function setUp() {
+    parent::setUp();
+    $processorID = $this->processorCreate([
+      'payment_processor_type_id' => 'PayPal_Standard',
+      'is_recur' => TRUE,
+      'billing_mode' => 4,
+      'url_site' => 'https://www.paypal.com/',
+      'url_recur' => 'https://www.paypal.com/',
+      'class_name' => 'Payment_PayPalImpl',
+    ]);
+
+    $this->processor = Civi\Payment\System::singleton()->getById($processorID);
+  }
+
+  /**
+   * @throws \CRM_Core_Exception
+   */
+  public function tearDown() {
+    $this->quickCleanUpFinancialEntities();
+    parent::tearDown();
+  }
+
+  /**
+   * Test doing a one-off payment.
+   *
+   * @throws \Civi\Payment\Exception\PaymentProcessorException
+   */
+  public function testSinglePayment() {
+    $params = [];
+    $params['amount'] = 5.24;
+    $params['currency'] = 'USD';
+    $params['invoiceID'] = 'xyz';
+    $params['ip_address'] = '127.0.0.1';
+    $params['qfKey'] = 'w';
+    $params['currencyID'] = 'USD';
+    try {
+      $this->processor->doPayment($params);
+    }
+    catch (CRM_Core_Exception_PrematureExitException $e) {
+      $redirectValues = parse_url($e->errorData['url']);
+      $this->assertEquals('https', $redirectValues['scheme']);
+      $this->assertEquals('www.paypal.com', $redirectValues['host']);
+      $this->assertEquals('/cgi-bin/webscr', $redirectValues['path']);
+      $query = [];
+      parse_str($redirectValues['query'], $query);
+      $this->assertEquals(5.24, $query['amount']);
+      $this->assertEquals('CiviCRM_SP', $query['bn']);
+    }
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Turns out we did some function renaming & missed a spot before merging https://github.com/civicrm/civicrm-core/pull/18525 - this fixes

Before
----------------------------------------
Paypal std broken

After
----------------------------------------
works & has a a test that would have picked it up

Technical Details
----------------------------------------

As an aside I fixed Paypal to call CRM_Core_Config::singleton()->userSystem->prePostRedirect()
directly rather than via system. I'm tempted to take the System function back out
again - I don't think it offers a better one-liner

Comments
----------------------------------------

