### PR TITLE
[REF] Paypal std ipn Move not-actually shared-code out of shared code function

### DIFF
--- a/CRM/Core/Payment/PayPalIPN.php
+++ b/CRM/Core/Payment/PayPalIPN.php
@@ -248,24 +248,6 @@ class CRM_Core_Payment_PayPalIPN extends CRM_Core_Payment_BaseIPN {
       $contribution->total_amount = $input['amount'];
     }
 
-    $status = $input['paymentStatus'];
-    if ($status === 'Denied' || $status === 'Failed' || $status === 'Voided') {
-      $this->failed($objects);
-      return;
-    }
-    if ($status === 'Pending') {
-      Civi::log()->debug('Returning since contribution status is Pending');
-      return;
-    }
-    elseif ($status === 'Refunded' || $status === 'Reversed') {
-      $this->cancelled($objects);
-      return;
-    }
-    elseif ($status !== 'Completed') {
-      Civi::log()->debug('Returning since contribution status is not handled');
-      return;
-    }
-
     // check if contribution is already completed, if so we ignore this ipn
     $completedStatusId = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Completed');
     if ($contribution->contribution_status_id == $completedStatusId) {
@@ -365,6 +347,23 @@ class CRM_Core_Payment_PayPalIPN extends CRM_Core_Payment_BaseIPN {
           $this->recur($input, $ids, $objects, $first);
           return;
         }
+      }
+      $status = $input['paymentStatus'];
+      if ($status === 'Denied' || $status === 'Failed' || $status === 'Voided') {
+        $this->failed($objects);
+        return;
+      }
+      if ($status === 'Pending') {
+        Civi::log()->debug('Returning since contribution status is Pending');
+        return;
+      }
+      if ($status === 'Refunded' || $status === 'Reversed') {
+        $this->cancelled($objects);
+        return;
+      }
+      if ($status !== 'Completed') {
+        Civi::log()->debug('Returning since contribution status is not handled');
+        return;
       }
       $this->single($input, $ids, $objects);
     }


### PR DESCRIPTION

Overview
----------------------------------------
[REF] Move not-actually shared-code out of shared code function

Before
----------------------------------------
```single``` function appears to hold a lot of code that is shared between the ```main``` function and the ```recur``` function but on looking at the ```recur``` function it turns out to be entirely unreachable from there.

After
----------------------------------------
non-shared code returned to the function that uses it.

Technical Details
----------------------------------------
On looking at the recur function it turns out it never calls  without a
paymentStatus of 'Completed' ie it only proceeds to call ``` single ``` if ```$txnType == 'subscr_payment'```

https://github.com/civicrm/civicrm-core/blob/26ec07d78801d622c1a5d3432559ee25bce9d376/CRM/Core/Payment/PayPalIPN.php#L180

And if ``$txnType == 'subscr_payment'``` then paymentStatus must be Completed
https://github.com/civicrm/civicrm-core/blob/26ec07d78801d622c1a5d3432559ee25bce9d376/CRM/Core/Payment/PayPalIPN.php#L79

- so the lines handling other payment statuses are not actually shared
between the 2 code paths but specifically belong to the 'main' (non-recur) code path.

Moving it out of this function we start to see there is very little shared code & probably no case for
the function to exist when we get down to it

Comments
----------------------------------------

