### PR TITLE
dev/core#1986 Alter default for  send notification to contributor checkbox on cancel or edit recurring to off

### DIFF
--- a/CRM/Contribute/Form/CancelSubscription.php
+++ b/CRM/Contribute/Form/CancelSubscription.php
@@ -179,7 +179,6 @@ class CRM_Contribute_Form_CancelSubscription extends CRM_Contribute_Form_Contrib
    */
   public function setDefaultValues() {
     return [
-      'is_notify' => 1,
       'send_cancel_request' => 1,
     ];
   }

--- a/CRM/Contribute/Form/UpdateSubscription.php
+++ b/CRM/Contribute/Form/UpdateSubscription.php
@@ -131,7 +131,6 @@ class CRM_Contribute_Form_UpdateSubscription extends CRM_Contribute_Form_Contrib
     $this->_defaults['installments'] = $this->_subscriptionDetails->installments;
     $this->_defaults['campaign_id'] = $this->_subscriptionDetails->campaign_id;
     $this->_defaults['financial_type_id'] = $this->_subscriptionDetails->financial_type_id;
-    $this->_defaults['is_notify'] = 1;
     foreach ($this->editableScheduleFields as $field) {
       $this->_defaults[$field] = $this->_subscriptionDetails->$field ?? NULL;
     }


### PR DESCRIPTION


Overview
----------------------------------------
dev/core#1986 Alter default for  send notification to contributor checkbox on cancel or edit recurring to off

Before
----------------------------------------
<img width="692" alt="Screen Shot 2020-09-21 at 12 26 21 PM" src="https://user-images.githubusercontent.com/336308/93725803-1032f600-fc06-11ea-881d-83525e95e614.png">


After
----------------------------------------
<img width="662" alt="Screen Shot 2020-09-21 at 12 30 41 PM" src="https://user-images.githubusercontent.com/336308/93725831-496b6600-fc06-11ea-86f6-a20ec6151d34.png">


Technical Details
----------------------------------------


Comments
----------------------------------------
Per https://lab.civicrm.org/dev/core/-/issues/1986 this got strong support