### PR TITLE
[REF] Remove checks as to whether entityShortName is in the component  array

### DIFF
--- a/CRM/Export/Form/Select.php
+++ b/CRM/Export/Form/Select.php
@@ -76,27 +76,27 @@ class CRM_Export_Form_Select extends CRM_Core_Form_Task {
     $this->_componentIds = [];
     $this->_componentClause = NULL;
 
-    // we need to determine component export
-    $components = CRM_Export_BAO_Export::getComponents();
-
     // FIXME: This should use a modified version of CRM_Contact_Form_Search::getModeValue but it doesn't have all the contexts
     // FIXME: Or better still, use CRM_Core_DAO_AllCoreTables::getBriefName($daoName) to get the $entityShortName
     $entityShortname = $this->getEntityShortName();
 
-    if (in_array($entityShortname, $components)) {
-      $this->_exportMode = constant('CRM_Export_Form_Select::' . strtoupper($entityShortname) . '_EXPORT');
-      $formTaskClassName = "CRM_{$entityShortname}_Form_Task";
-      $taskClassName = "CRM_{$entityShortname}_Task";
-      if (isset($formTaskClassName::$entityShortname)) {
-        $this::$entityShortname = $formTaskClassName::$entityShortname;
-        if (isset($formTaskClassName::$tableName)) {
-          $this::$tableName = $formTaskClassName::$tableName;
-        }
+    if (!in_array($entityShortname, ['Contact', 'Contribute', 'Member', 'Event', 'Pledge', 'Case', 'Grant', 'Activity'], TRUE)) {
+      // This is never reached - the exception here is just to clarify that entityShortName MUST be one of the above
+      // to save future refactorers & reviewers from asking that question.
+      throw new CRM_Core_Exception('Unreachable code');
+    }
+    $this->_exportMode = constant('CRM_Export_Form_Select::' . strtoupper($entityShortname) . '_EXPORT');
+    $formTaskClassName = "CRM_{$entityShortname}_Form_Task";
+    $taskClassName = "CRM_{$entityShortname}_Task";
+    if (isset($formTaskClassName::$entityShortname)) {
+      $this::$entityShortname = $formTaskClassName::$entityShortname;
+      if (isset($formTaskClassName::$tableName)) {
+        $this::$tableName = $formTaskClassName::$tableName;
       }
-      else {
-        $this::$entityShortname = $entityShortname;
-        $this::$tableName = CRM_Core_DAO_AllCoreTables::getTableForClass(CRM_Core_DAO_AllCoreTables::getFullName($this->getDAOName()));
-      }
+    }
+    else {
+      $this::$entityShortname = $entityShortname;
+      $this::$tableName = CRM_Core_DAO_AllCoreTables::getTableForClass(CRM_Core_DAO_AllCoreTables::getFullName($this->getDAOName()));
     }
 
     // get the submitted values based on search
@@ -110,7 +110,7 @@ class CRM_Export_Form_Select extends CRM_Core_Form_Task {
       $values = $this->controller->exportValues('Custom');
     }
     else {
-      if (in_array($entityShortname, $components) && $entityShortname !== 'Contact') {
+      if ($entityShortname !== 'Contact') {
         $values = $this->controller->exportValues('Search');
       }
       else {


### PR DESCRIPTION
Overview
----------------------------------------
Removes some unreachable code

Before
----------------------------------------
```if (in_array($entityShortname, $components)) {```

we set ```$formTaskClassName ```

and there is an else for it if is not set. However per https://github.com/civicrm/civicrm-core/blob/6ec388a8153c42225bc111ce78dcbfcaddb43154/CRM/Export/Form/Select.php#L135 failure to set ```$formTaskClassName ``` would result in a fatal error
 
so the IF must always be TRUE

After
----------------------------------------
Poof

To make it really explicit I added the exception & hard-coded list as I think it would be easy to revisit this
later without that

Technical Details
----------------------------------------

If entityShortName is not in components then formTaskClassName will never be set & later down the attempt to use
that variable in formTaskClassName::preProcessCommon MUST fail - ergo it is always in components.



Comments
----------------------------------------

