### PR TITLE
dev/core#2034 Fix paypal standard cancel url

### DIFF
--- a/CRM/Core/Payment.php
+++ b/CRM/Core/Payment.php
@@ -1688,7 +1688,8 @@ abstract class CRM_Core_Payment {
    * @param null $entity
    * @param string $action
    *
-   * @return string
+   * @return string|null
+   * @throws \CRM_Core_Exception
    */
   public function subscriptionURL($entityID = NULL, $entity = NULL, $action = 'cancel') {
     // Set URL

--- a/CRM/Core/Payment/PayPalImpl.php
+++ b/CRM/Core/Payment/PayPalImpl.php
@@ -644,16 +644,23 @@ class CRM_Core_Payment_PayPalImpl extends CRM_Core_Payment {
   }
 
   /**
-   * @return null|string
-   * @throws \Civi\Payment\Exception\PaymentProcessorException
+   * Get url for users to manage this recurring contribution for this processor.
+   *
+   * @param int $entityID
+   * @param null $entity
+   * @param string $action
+   *
+   * @return string|null
+   * @throws \CRM_Core_Exception
    */
-  public function cancelSubscriptionURL() {
+  public function subscriptionURL($entityID = NULL, $entity = NULL, $action = 'cancel') {
     if ($this->isPayPalType($this::PAYPAL_STANDARD)) {
+      if ($action !== 'cancel') {
+        return NULL;
+      }
       return "{$this->_paymentProcessor['url_site']}cgi-bin/webscr?cmd=_subscr-find&alias=" . urlencode($this->_paymentProcessor['user_name']);
     }
-    else {
-      return NULL;
-    }
+    return parent::subscriptionURL($entityID, $entity, $action);
   }
 
   /**

--- a/tests/phpunit/CRM/Core/Payment/PayPalIPNTest.php
+++ b/tests/phpunit/CRM/Core/Payment/PayPalIPNTest.php
@@ -104,8 +104,11 @@ class CRM_Core_Payment_PayPalIPNTest extends CiviUnitTestCase {
    */
   public function testIPNPaymentRecurSuccess() {
     $this->setupRecurringPaymentProcessorTransaction([], ['total_amount' => '15.00']);
+    $mut = new CiviMailUtils($this, TRUE);
     $paypalIPN = new CRM_Core_Payment_PayPalIPN($this->getPaypalRecurTransaction());
     $paypalIPN->main();
+    $mut->checkMailLog(['https://www.sandbox.paypal.com/cgi-bin/webscr?cmd=_subscr-find'], ['civicrm/contribute/unsubscribe', 'civicrm/contribute/updatebilling']);
+    $mut->stop();
     $contribution1 = $this->callAPISuccess('Contribution', 'getsingle', ['id' => $this->_contributionID]);
     $this->assertEquals(1, $contribution1['contribution_status_id']);
     $this->assertEquals('8XA571746W2698126', $contribution1['trxn_id']);


### PR DESCRIPTION

Overview
----------------------------------------
Per https://lab.civicrm.org/dev/core/-/issues/2034 the wrong urls are included in paypal standard emails for cancellation

I think this likely regressed a long time ago - but the symptoms changed a little this year - so I am just putting
against master

Before
----------------------------------------
Email contains civicrm urls

This is a recurring contribution.
You can cancel future contributions at:
http://dmaster.local/civicrm/contribute/unsubscribe?reset=1&coid=98



After
----------------------------------------
Email contains paypal urls for paypal standard processor
https://www.sandbox.paypal.com/cgi-bin/webscr?cmd=_subscr-find

Technical Details
----------------------------------------
Overriding the parent class to provide the correct url for the processor

Comments
----------------------------------------

