### PR TITLE
Fix deprecation notice

### DIFF
--- a/CRM/Core/PrevNextCache/Sql.php
+++ b/CRM/Core/PrevNextCache/Sql.php
@@ -277,7 +277,7 @@ ORDER BY id
       AND        c.created_date < date_sub( NOW( ), INTERVAL %2 day )
     ";
     $params = [
-      1 => [CRM_Core_BAO_Cache::cleanKey('CiviCRM Search PrevNextCache'), 'String'],
+      1 => [CRM_Utils_Cache::cleanKey('CiviCRM Search PrevNextCache'), 'String'],
       2 => [self::cacheDays, 'Integer'],
     ];
     CRM_Core_DAO::executeQuery($sql, $params);


### PR DESCRIPTION
Overview
----------------------------------------
Fix deprecation notice'

Before
----------------------------------------
<img width="801" alt="Screen Shot 2020-09-21 at 2 35 02 PM" src="https://user-images.githubusercontent.com/336308/93729284-eda9d880-fc17-11ea-9dae-4fd86d4d3227.png">


After
----------------------------------------
poof

Technical Details
----------------------------------------
User deprecated function: Deprecated function CRM_Core_BAO_Cache::cleanKey, use CRM_Utils_Cache::cleanKey. Array ( [civi.tag] => deprecated ) in CRM_Core_Error_Log->log() (line 58 of /Users/eileenmcnaughton/buildkit/build/dmaster/sites/all/modules/civicrm/CRM/Core/Error/Log.php).


Comments
----------------------------------------

