### PR TITLE
Fix civi version for greenwich

### DIFF
--- a/ext/greenwich/info.xml
+++ b/ext/greenwich/info.xml
@@ -19,9 +19,9 @@
   <tags>
     <tag>mgmt:hidden</tag>
   </tags>
-  <develStage>alpha</develStage>
+  <develStage>stable</develStage>
   <compatibility>
-    <ver>5.0</ver>
+    <ver>5.31</ver>
   </compatibility>
   <classloader>
     <psr4 prefix="Civi\" path="Civi"/>


### PR DESCRIPTION


Overview
----------------------------------------
Updates info.xml for new extensionised theme to reflect the release version & the fact it is being released as 'stable'

Before
----------------------------------------
Compatibillity shows 5.0, shows as alpha


After
----------------------------------------
Compatibillity shows 5.31, shows as stable


Technical Details
----------------------------------------
We are releasing this as a stable part of 5.31 - xml should reflect that. Obviously this doesn't mean it won't change but it is as stable as we were when the css was in a different folder :-)

Comments
----------------------------------------

