### PR TITLE
[REF] Remove now used parameter & make function protected

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4155,11 +4155,11 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
    * Get the tax amount (misnamed function).
    *
    * @param array $params
-   * @param bool $isLineItem
    *
    * @return array
+   * @throws \CiviCRM_API3_Exception
    */
-  public static function checkTaxAmount($params, $isLineItem = FALSE) {
+  protected static function checkTaxAmount($params) {
     $taxRates = CRM_Core_PseudoConstant::getTaxRates();
 
     // Update contribution.
@@ -4205,8 +4205,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
 
     // New Contribution and update of contribution with tax rate financial type
     if (isset($params['financial_type_id']) && array_key_exists($params['financial_type_id'], $taxRates) &&
-      empty($params['skipLineItem']) && !$isLineItem
-    ) {
+      empty($params['skipLineItem'])) {
       $taxRateParams = $taxRates[$params['financial_type_id']];
       $taxAmount = CRM_Contribute_BAO_Contribution_Utils::calculateTaxAmount(CRM_Utils_Array::value('total_amount', $params), $taxRateParams);
       $params['tax_amount'] = round($taxAmount['tax_amount'], 2);


### PR DESCRIPTION


Overview
----------------------------------------
Follow up clean up from line item api work - remove now unused parameter

Before
----------------------------------------
```
public static function checkTaxAmount($params, $isLineItem = FALSE) {
```

After
----------------------------------------
```
protected static function checkTaxAmount($params) {
```

Technical Details
----------------------------------------
This function used to be called by LineItem api but we removed that when adding v4 line item api

A universe check shows it's not otherwise called so it's only called with the same class, and making
it protected makes that clear. isLineItem is not passed in that one place

Comments
----------------------------------------
