### PR TITLE
Set participant status notification to false by default

### DIFF
--- a/templates/CRM/Event/Form/Participant.tpl
+++ b/templates/CRM/Event/Form/Participant.tpl
@@ -437,7 +437,7 @@
     notificationStatusIds = notificationStatusIds.split(',');
     if (cj.inArray(cj('select#status_id option:selected').val(), notificationStatusIds) > -1) {
       cj("#notify").show();
-      cj("#is_notify").prop('checked', true);
+      cj("#is_notify").prop('checked', false);
     }
     else {
       cj("#notify").hide();


### PR DESCRIPTION
Overview
----------------------------------------
The checkbox to send a notification with some participant status changes is checked by default. For many organizations this had led to emails that were send by accident, where other 

Before
----------------------------------------
The 'Send notification' is checked by default when changing a status to 'cancelled' or from 'waitlist' to 'pending waitlist'

After
----------------------------------------
The checkbox is presented but not checked by default. Sending an email should be a conscious choice.

![Participant_Status_Default_notification](https://user-images.githubusercontent.com/2195908/93758721-3a39e780-fc09-11ea-8f6a-981859fe7787.png)

Technical Details
----------------------------------------
Changed the default value in templates/CRM/Event/Form/Participant.tpl

Comments
----------------------------------------
