### PR TITLE
Check if BACKDROP_ROOT is defined already

### DIFF
--- a/CRM/Utils/System/Backdrop.php
+++ b/CRM/Utils/System/Backdrop.php
@@ -525,7 +525,7 @@ AND    u.status = 1
     // load Backdrop bootstrap
     chdir($cmsPath);
     if (!defined('BACKDROP_ROOT')) {
-        define('BACKDROP_ROOT', $cmsPath);
+      define('BACKDROP_ROOT', $cmsPath);
     }
 
     // For Backdrop multi-site CRM-11313

--- a/CRM/Utils/System/Backdrop.php
+++ b/CRM/Utils/System/Backdrop.php
@@ -524,7 +524,9 @@ AND    u.status = 1
     }
     // load Backdrop bootstrap
     chdir($cmsPath);
-    define('BACKDROP_ROOT', $cmsPath);
+    if (!defined('BACKDROP_ROOT')) {
+        define('BACKDROP_ROOT', $cmsPath);
+    }
 
     // For Backdrop multi-site CRM-11313
     if ($realPath && strpos($realPath, 'sites/all/modules/') === FALSE) {


### PR DESCRIPTION
Overview
----------------------------------------
I'm seeing this in my Backdrop watchdog log:

> Notice: Constant BACKDROP_ROOT already defined in CRM_Utils_System_Backdrop->loadBootStrap() (line 526 of /app/modules/civicrm/CRM/Utils/System/Backdrop.php).

We should check to see if the constant is already defined before defining it again.