### PR TITLE
Fix customGroup getTableNameByEntityName to recognize all entities

### DIFF
--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -1121,53 +1121,16 @@ ORDER BY civicrm_custom_group.weight,
    * @see _apachesolr_civiAttachments_dereference_file_parent
    */
   public static function getTableNameByEntityName($entityType) {
-    $tableName = '';
     switch ($entityType) {
       case 'Contact':
       case 'Individual':
       case 'Household':
       case 'Organization':
-        $tableName = 'civicrm_contact';
-        break;
+        return 'civicrm_contact';
 
-      case 'Contribution':
-        $tableName = 'civicrm_contribution';
-        break;
-
-      case 'Group':
-        $tableName = 'civicrm_group';
-        break;
-
-      // DRAFTING: Verify if we cannot make it pluggable
-
-      case 'Activity':
-        $tableName = 'civicrm_activity';
-        break;
-
-      case 'Relationship':
-        $tableName = 'civicrm_relationship';
-        break;
-
-      case 'Membership':
-        $tableName = 'civicrm_membership';
-        break;
-
-      case 'Participant':
-        $tableName = 'civicrm_participant';
-        break;
-
-      case 'Event':
-        $tableName = 'civicrm_event';
-        break;
-
-      case 'Grant':
-        $tableName = 'civicrm_grant';
-        break;
-
-      // need to add cases for Location, Address
+      default:
+        return CRM_Core_DAO_AllCoreTables::getTableForEntityName($entityType);
     }
-
-    return $tableName;
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
This fixes a bug reported in https://www.drupal.org/project/webform_civicrm/issues/3172201

Before
----------------------------------------
Not possible via APIv3 to retrieve file attachments from Cases or other entities not in the hardcoded list.

After
----------------------------------------
Hardcoded list removed; all entities supported.

Technical Details
----------------------------------------
Code comment suggests that the hardcoded list was part of some early prototyping for the Attachment api. It has since been superseded by a function in `CRM_Core_DAO_AllCoreTables` which does in a more complete way what it was trying to do.
