### PR TITLE
api_v3_MultilingualTest - Skip Cxn entities

### DIFF
--- a/tests/phpunit/api/v3/MultilingualTest.php
+++ b/tests/phpunit/api/v3/MultilingualTest.php
@@ -101,6 +101,8 @@ class api_v3_MultilingualTest extends CiviUnitTestCase {
     ];
     // deprecated or API.Get is not supported/implemented
     $skippableEntities = [
+      'Cxn',
+      'CxnApp',
       'Logging',
       'MailingEventConfirm',
       'MailingEventResubscribe',


### PR DESCRIPTION
Overview
----------------------------------------

This addresses some recent failures reported in `api_v3_MultilingualTest::testAllEntities()`. The test is a generic one (akin to `SyntaxConformanceTest`) and generally geared toward locally hosted entities. However, this entity is based on external interaction, so it's not as amenable to the same style of testing.

This revision makes `api_v3_MultilingualTest` behave more like `api_v3_SyntaxConformanceTest` -- ie skipping the oddball entity.