### PR TITLE
Add bootstrap bundle to search

### DIFF
--- a/ext/search/CRM/Search/Page/Ang.php
+++ b/ext/search/CRM/Search/Page/Ang.php
@@ -42,6 +42,7 @@ class CRM_Search_Page_Ang extends CRM_Core_Page {
 
     Civi::resources()
       ->addPermissions(['edit groups', 'administer reserved groups'])
+      ->addBundle('bootstrap3')
       ->addVars('search', $vars);
 
     // Load angular module


### PR DESCRIPTION
Overview
----------------------------------------
Adds the bootstrap 3 bundle to search

Before
----------------------------------------
<img width="713" alt="Screen Shot 2020-09-22 at 8 02 12 PM" src="https://user-images.githubusercontent.com/336308/93857363-93d80a00-fd0e-11ea-8afa-4d2e78c69db5.png">


After
----------------------------------------
http://core-18550-8lhra.test-1.civicrm.org:8001/civicrm/search#/create/Contact/

<img width="783" alt="Screen Shot 2020-09-22 at 8 01 20 PM" src="https://user-images.githubusercontent.com/336308/93857267-73a84b00-fd0e-11ea-8ca1-498ef3c4c04f.png">


Technical Details
----------------------------------------


Comments
----------------------------------------
@colemanw looks like this does work on the test site
