### PR TITLE
Remove obsolete load-bootstrap.js

### DIFF
--- a/CRM/Api4/Page/Api4Explorer.php
+++ b/CRM/Api4/Page/Api4Explorer.php
@@ -43,7 +43,6 @@ class CRM_Api4_Page_Api4Explorer extends CRM_Core_Page {
       ->addBundle('bootstrap3')
       ->addVars('api4', $vars)
       ->addPermissions(['access debug output', 'edit groups', 'administer reserved groups'])
-      ->addScriptFile('civicrm', 'js/load-bootstrap.js')
       ->addScriptFile('civicrm', 'bower_components/js-yaml/dist/js-yaml.min.js')
       ->addScriptFile('civicrm', 'bower_components/marked/marked.min.js')
       ->addScriptFile('civicrm', 'bower_components/google-code-prettify/bin/prettify.min.js')

--- a/js/load-bootstrap.js
+++ b/js/load-bootstrap.js
@@ -1,7 +1,0 @@
-// Loads a copy of shoreditch's bootstrap if bootstrap is missing
-CRM.$(function($) {
-  if (!$.isFunction($.fn.dropdown)) {
-    //CRM.loadScript(CRM.vars.api4.basePath + 'lib/shoreditch/dropdown.js');
-    //$('head').append('<link type="text/css" rel="stylesheet" href="' + CRM.vars.api4.basePath + 'lib/shoreditch/bootstrap.css" />');
-  }
-});


### PR DESCRIPTION
Overview
----------------------------------------
Removes an old js file that's now obsolete.

Before
----------------------------------------
File exists but code commented out.

After
----------------------------------------
Gone.

Technical Details
----------------------------------------
This file was a hacky stopgap because we didn't have a way to load bootstrap css in core, but now we do.