### PR TITLE
[REF] Move daoName generation so we don't need to pass the variable name

### DIFF
--- a/CRM/Dedupe/MergeHandler.php
+++ b/CRM/Dedupe/MergeHandler.php
@@ -196,18 +196,19 @@ class CRM_Dedupe_MergeHandler {
    * This is intended as a refactoring step - not the long term function. Do not
    * call from any function other than the one it is taken from (Merger::mergeLocations).
    *
-   * @param string $daoName
    * @param int $otherBlockId
    * @param string $name
    * @param int $blkCount
    *
-   * @return mixed
+   * @return CRM_Core_DAO_Address|CRM_Core_DAO_Email|CRM_Core_DAO_IM|CRM_Core_DAO_Phone|CRM_Core_DAO_Website
+   *
+   * @throws \CRM_Core_Exception
    */
-  public function copyDataToNewBlockDAO(string $daoName, $otherBlockId, $name, $blkCount) {
+  public function copyDataToNewBlockDAO($otherBlockId, $name, $blkCount) {
     $locationBlocks = CRM_Dedupe_Merger::getLocationBlockInfo();
     $migrationInfo = $this->getMigrationInfo();
     // For the block which belongs to other-contact, link the location block to main-contact
-    $otherBlockDAO = new $daoName();
+    $otherBlockDAO = $this->getDAOForLocationEntity($name);
     $otherBlockDAO->contact_id = $this->getToKeepID();
 
     // Get the ID of this block on the 'other' contact, otherwise skip
@@ -223,6 +224,37 @@ class CRM_Dedupe_MergeHandler {
       $otherBlockDAO->{$locationBlocks[$name]['hasType']} = $typeTypeId;
     }
     return $otherBlockDAO;
+  }
+
+  /**
+   * Get the DAO object appropriate to the location entity.
+   *
+   * @param string $entity
+   *
+   * @return CRM_Core_DAO_Address|CRM_Core_DAO_Email|CRM_Core_DAO_IM|CRM_Core_DAO_Phone|CRM_Core_DAO_Website
+   * @throws \CRM_Core_Exception
+   */
+  public function getDAOForLocationEntity($entity) {
+    switch ($entity) {
+      case 'email':
+        return new CRM_Core_DAO_Email();
+
+      case 'address':
+        return new CRM_Core_DAO_Address();
+
+      case 'phone':
+        return new CRM_Core_DAO_Phone();
+
+      case 'website':
+        return new CRM_Core_DAO_Website();
+
+      case 'im':
+        return new CRM_Core_DAO_IM();
+
+      default:
+        // Mostly here, along with the switch over a more concise format, to help IDEs understand the possibilities.
+        throw new CRM_Core_Exception('Unsupported entity');
+    }
   }
 
 }

--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -1820,7 +1820,7 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
           if (!$otherBlockId) {
             continue;
           }
-          $otherBlockDAO = $mergeHandler->copyDataToNewBlockDAO($daoName, $otherBlockId, $name, $blkCount);
+          $otherBlockDAO = $mergeHandler->copyDataToNewBlockDAO($otherBlockId, $name, $blkCount);
 
           // If we're deliberately setting this as primary then add the flag
           // and remove it from the current primary location (if there is one).
@@ -1829,7 +1829,7 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
           if (!$changePrimary && $set_primary == "1") {
             $otherBlockDAO->is_primary = 1;
             if ($primaryDAOId) {
-              $removePrimaryDAO = new $daoName();
+              $removePrimaryDAO = $mergeHandler->getDAOForLocationEntity($name);
               $removePrimaryDAO->id = $primaryDAOId;
               $removePrimaryDAO->is_primary = 0;
               $blocksDAO[$name]['update'][$primaryDAOId] = $removePrimaryDAO;
@@ -1848,7 +1848,7 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
 
           // overwrite - need to delete block which belongs to main-contact.
           if (!empty($mainBlockId) && $values['is_replace']) {
-            $deleteDAO = new $daoName();
+            $deleteDAO = $mergeHandler->getDAOForLocationEntity($name);
             $deleteDAO->id = $mainBlockId;
             $deleteDAO->find(TRUE);
 


### PR DESCRIPTION
Overview
----------------------------------------
Minor code cleanup  - rather than pass around the name of the dao class just figure it out from the entity name when needed. This has the added benefit that we can declare the class in a way IDEs recognise

Before
----------------------------------------
```
 public function copyDataToNewBlockDAO(string $daoName, $otherBlockId, $name, $blkCount) {
```


After
----------------------------------------
```
  public function copyDataToNewBlockDAO($otherBlockId, $name, $blkCount) {
```

Technical Details
----------------------------------------
```$name``` is the name of the entity - I thought about renaming but in follow up patches I can remove most references to it so I've left for now


Comments
----------------------------------------

Note that we can remove some variables now - I've excluded from this PR as they clash with https://github.com/civicrm/civicrm-core/pull/18500