### PR TITLE
dev/core#2047 Fix merge code so that deleted contacts are not left without a primary address

### DIFF
--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -1861,6 +1861,7 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
           }
           $blocksDAO[$name]['update'][$otherBlockDAO->id] = $otherBlockDAO;
         }
+        $blocksDAO[$name]['update'] += $mergeHandler->getBlocksToUpdateForDeletedContact($name);
       }
     }
 

--- a/tests/phpunit/api/v3/JobTest.php
+++ b/tests/phpunit/api/v3/JobTest.php
@@ -45,15 +45,6 @@ class api_v3_JobTest extends CiviUnitTestCase {
   private $report_instance;
 
   /**
-   * Should location types be checked to ensure primary addresses are correctly assigned after each test.
-   *
-   * We cannot enable this until https://github.com/civicrm/civicrm-core/pull/18555 is merged
-   *
-   * @var bool
-   */
-  protected $isLocationTypesOnPostAssert = FALSE;
-
-  /**
    * Set up for tests.
    */
   public function setUp() {


### PR DESCRIPTION


Overview
----------------------------------------
Fixes dedupe code so the deleted contact does not wind up with 1 or more address/ emails etc where none are marked primary.

This was picked up through adding test cover for https://lab.civicrm.org/dev/core/-/issues/2039

I considered altering the test to exclude deleted contacts but we run the risk that if a contact
is undeleted they will have no primary address so I figured the integrity makes sense.

Before
----------------------------------------
When a contact with 2 addresses is merged and only the primary is moved over the deleted contact has an address still, but it is not marked is_primary. If it is subsequently undeleted then there is an integrity issue

After
----------------------------------------
Ensure the deleted contact's remaining location entities have at least one primary

Technical Details
----------------------------------------

Note there are a couple of queries in this code that can go (retrieving stuff
we already have) - depending how I go on getting review on this & related tidy up I'll remove them
in a later PR

Comments
----------------------------------------
If https://github.com/civicrm/civicrm-core/pull/18552 is merged first I'll need to rebase.  https://github.com/civicrm/civicrm-core/pull/18500 is also a related cleanup
