### PR TITLE
dev/core#2056 Only retrieve pcp & soft_credit info when needed

### DIFF
--- a/CRM/Contribute/BAO/ContributionSoft.php
+++ b/CRM/Contribute/BAO/ContributionSoft.php
@@ -53,39 +53,17 @@ class CRM_Contribute_BAO_ContributionSoft extends CRM_Contribute_DAO_Contributio
    * Process the soft contribution and/or link to personal campaign page.
    *
    * @param array $params
-   * @param object $contribution CRM_Contribute_DAO_Contribution
+   * @param CRM_Contribute_BAO_Contribution $contribution
    *
+   * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
    */
   public static function processSoftContribution($params, $contribution) {
-    //retrieve existing soft-credit and pcp id(s) if any against $contribution
-    $softIDs = self::getSoftCreditIds($contribution->id);
-    $pcpId = self::getSoftCreditIds($contribution->id, TRUE);
-
-    if ($pcp = CRM_Utils_Array::value('pcp', $params)) {
-      $softParams = [];
-      $softParams['id'] = $pcpId ? $pcpId : NULL;
-      $softParams['contribution_id'] = $contribution->id;
-      $softParams['pcp_id'] = $pcp['pcp_made_through_id'];
-      $softParams['contact_id'] = CRM_Core_DAO::getFieldValue('CRM_PCP_DAO_PCP',
-        $pcp['pcp_made_through_id'], 'contact_id'
-      );
-      $softParams['currency'] = $contribution->currency;
-      $softParams['amount'] = $contribution->total_amount;
-      $softParams['pcp_display_in_roll'] = $pcp['pcp_display_in_roll'] ?? NULL;
-      $softParams['pcp_roll_nickname'] = $pcp['pcp_roll_nickname'] ?? NULL;
-      $softParams['pcp_personal_note'] = $pcp['pcp_personal_note'] ?? NULL;
-      $softParams['soft_credit_type_id'] = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_ContributionSoft', 'soft_credit_type_id', 'pcp');
-      $contributionSoft = self::add($softParams);
-      //Send notification to owner for PCP
-      if ($contributionSoft->pcp_id && empty($pcpId)) {
-        CRM_Contribute_Form_Contribution_Confirm::pcpNotifyOwner($contribution, $contributionSoft);
-      }
-    }
-    //Delete PCP against this contribution and create new on submitted PCP information
-    elseif (array_key_exists('pcp', $params) && $pcpId) {
-      civicrm_api3('ContributionSoft', 'delete', ['id' => $pcpId]);
+    if (array_key_exists('pcp', $params)) {
+      self::processPCP($params['pcp'], $contribution);
     }
     if (isset($params['soft_credit'])) {
+      $softIDs = self::getSoftCreditIds($contribution->id);
       $softParams = $params['soft_credit'];
       foreach ($softParams as $softParam) {
         if (!empty($softIDs)) {
@@ -599,6 +577,44 @@ class CRM_Contribute_BAO_ContributionSoft extends CRM_Contribute_DAO_Contributio
     }
     else {
       $form->assign('honorName', $honorName);
+    }
+  }
+
+  /**
+   * Process the pcp associated with a contribution.
+   *
+   * @param array $pcp
+   * @param \CRM_Contribute_BAO_Contribution $contribution
+   *
+   * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
+   */
+  protected static function processPCP($pcp, $contribution) {
+    $pcpId = self::getSoftCreditIds($contribution->id, TRUE);
+
+    if ($pcp) {
+      $softParams = [];
+      $softParams['id'] = $pcpId ?: NULL;
+      $softParams['contribution_id'] = $contribution->id;
+      $softParams['pcp_id'] = $pcp['pcp_made_through_id'];
+      $softParams['contact_id'] = CRM_Core_DAO::getFieldValue('CRM_PCP_DAO_PCP',
+        $pcp['pcp_made_through_id'], 'contact_id'
+      );
+      $softParams['currency'] = $contribution->currency;
+      $softParams['amount'] = $contribution->total_amount;
+      $softParams['pcp_display_in_roll'] = $pcp['pcp_display_in_roll'] ?? NULL;
+      $softParams['pcp_roll_nickname'] = $pcp['pcp_roll_nickname'] ?? NULL;
+      $softParams['pcp_personal_note'] = $pcp['pcp_personal_note'] ?? NULL;
+      $softParams['soft_credit_type_id'] = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_ContributionSoft', 'soft_credit_type_id', 'pcp');
+      $contributionSoft = self::add($softParams);
+      //Send notification to owner for PCP
+      if ($contributionSoft->pcp_id && empty($pcpId)) {
+        CRM_Contribute_Form_Contribution_Confirm::pcpNotifyOwner($contribution, $contributionSoft);
+      }
+    }
+    //Delete PCP against this contribution and create new on submitted PCP information
+    elseif ($pcpId) {
+      civicrm_api3('ContributionSoft', 'delete', ['id' => $pcpId]);
     }
   }
 

--- a/tests/phpunit/CRM/PCP/BAO/PCPTest.php
+++ b/tests/phpunit/CRM/PCP/BAO/PCPTest.php
@@ -45,26 +45,15 @@ class CRM_PCP_BAO_PCPTest extends CiviUnitTestCase {
     $this->assertEquals($params['is_active'], $pcpBlock->is_active, 'Check for is_active.');
   }
 
-  public function testAddPCP() {
-    $blockParams = $this->pcpBlockParams();
-    $pcpBlock = CRM_PCP_BAO_PCPBlock::create($blockParams);
-
+  /**
+   * Basic create test.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testCreatePCP() {
     $params = $this->pcpParams();
-    $params['pcp_block_id'] = $pcpBlock->id;
-
-    $pcp = CRM_PCP_BAO_PCP::create($params);
-
-    $this->assertInstanceOf('CRM_PCP_DAO_PCP', $pcp, 'Check for created object');
-    $this->assertEquals($params['contact_id'], $pcp->contact_id, 'Check for entity table.');
-    $this->assertEquals($params['status_id'], $pcp->status_id, 'Check for status.');
-    $this->assertEquals($params['title'], $pcp->title, 'Check for title.');
-    $this->assertEquals($params['intro_text'], $pcp->intro_text, 'Check for intro_text.');
-    $this->assertEquals($params['page_text'], $pcp->page_text, 'Check for page_text.');
-    $this->assertEquals($params['donate_link_text'], $pcp->donate_link_text, 'Check for donate_link_text.');
-    $this->assertEquals($params['is_thermometer'], $pcp->is_thermometer, 'Check for is_thermometer.');
-    $this->assertEquals($params['is_honor_roll'], $pcp->is_honor_roll, 'Check for is_honor_roll.');
-    $this->assertEquals($params['goal_amount'], $pcp->goal_amount, 'Check for goal_amount.');
-    $this->assertEquals($params['is_active'], $pcp->is_active, 'Check for is_active.');
+    $pcpID = $this->createPCPBlock($params);
+    $this->getAndCheck($params, $pcpID, 'Pcp');
   }
 
   public function testAddPCPNoStatus() {

--- a/tests/phpunit/CRMTraits/PCP/PCPTestTrait.php
+++ b/tests/phpunit/CRMTraits/PCP/PCPTestTrait.php
@@ -73,4 +73,22 @@ trait CRMTraits_PCP_PCPTestTrait {
     return $params;
   }
 
+  /**
+   * Create a pcp block for testing.
+   *
+   * @param array $params
+   *
+   * @return int
+   */
+  protected function createPCPBlock(array $params):int {
+    $blockParams = $this->pcpBlockParams();
+    $pcpBlock = CRM_PCP_BAO_PCPBlock::create($blockParams);
+
+    $params = array_merge($this->pcpParams(), $params);
+    $params['pcp_block_id'] = $pcpBlock->id;
+
+    $pcp = CRM_PCP_BAO_PCP::create($params);
+    return (int) $pcp->id;
+  }
+
 }


### PR DESCRIPTION

Overview
----------------------------------------
Currently we do 2 queries per contribution create to retrieve pcp & soft credit info. However, the
results of the queries are only used if pcp or soft credit keys exist in the params array


Before
----------------------------------------
The following queries run every contribution create but the results of the queries are only used on those contribution.create calls which pass pcp or soft_credit data

examples

|timestamp|query|seconds|rows found|columns requested|
|----------|-------|-------|-------|-------|
| 15/09/20 2:54 |  SELECT id FROM  civicrm_contribution_soft WHERE contribution_id = 49769031 AND pcp_id IS NOT NULL | 0.000624 | 0 | 0 |
| 15/09/20 2:54 |  SELECT id FROM  civicrm_contribution_soft WHERE contribution_id = 49769031 AND pcp_id IS NULL     | 0.000616 | 0 | 0 |


After
----------------------------------------
2 less queries per contribution create, unless needed.

Technical Details
----------------------------------------
Basically an extraction & wrapping in an if

Comments
----------------------------------------

