### PR TITLE
[REF] Finally remove deprecated ids handling

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -445,8 +445,6 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution {
    *
    * @param array $params
    *   (reference ) an assoc array of name/value pairs.
-   * @param array $ids
-   *   The array that holds all the db ids.
    *
    * @return CRM_Contribute_BAO_Contribution
    *
@@ -454,15 +452,11 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution {
    * @throws \CRM_Core_Exception
    * @throws \CiviCRM_API3_Exception
    */
-  public static function create(&$params, $ids = []) {
+  public static function create(&$params) {
 
     $transaction = new CRM_Core_Transaction();
 
     try {
-      if (!isset($params['id']) && isset($ids['contribution'])) {
-        CRM_Core_Error::deprecatedFunctionWarning('ids should not be used for contribution create');
-        $params['id'] = $ids['contribution'];
-      }
       $contribution = self::add($params);
     }
     catch (CRM_Core_Exception $e) {


### PR DESCRIPTION


Overview
----------------------------------------
Remove deprecated code that handles $ids as an input param for Contribution::create()

Before
----------------------------------------
<img width="936" alt="Screen Shot 2020-09-22 at 4 08 16 PM" src="https://user-images.githubusercontent.com/336308/93843815-45ffd980-fcef-11ea-878e-7141ce1529dc.png">
<img width="1272" alt="Screen Shot 2020-09-22 at 4 08 06 PM" src="https://user-images.githubusercontent.com/336308/93843804-3d0f0800-fcef-11ea-8c8e-cebdbdc7896d.png">



After
----------------------------------------
poof

Technical Details
----------------------------------------
We've been pretty clear for a long time the only supported way to call crud functions is via the api.
We noisily deprecated ids about 9 months ago & it has been not-preferred for much longer
I only found one place in universe where ids IS passed in
https://github.com/lcdservices/biz.lcdservices.movecontrib/pull/4

Comments
----------------------------------------

