### PR TITLE
[REF] Remove wrangling on activityType param

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -1694,14 +1694,11 @@ WHERE      activity.id IN ($activityIds)";
    */
   public static function addActivity(
     $activity,
-    $activityType = 'Membership Signup',
+    $activityType,
     $targetContactID = NULL,
     $params = []
   ) {
     $date = date('YmdHis');
-    if ($activity->__table === 'civicrm_participant' && $activityType !== 'Email') {
-      $activityType = 'Event Registration';
-    }
     if ($activity->__table == 'civicrm_contribution') {
       // create activity record only for Completed Contributions
       $contributionCompletedStatusId = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Completed');
@@ -1712,7 +1709,6 @@ WHERE      activity.id IN ($activityIds)";
         }
         $params['status_id'] = CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_status_id', 'Scheduled');
       }
-      $activityType = 'Contribution';
 
       // retrieve existing activity based on source_record_id and activity_type
       if (empty($params['id'])) {

--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4493,7 +4493,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
         $targetContactID = $contribution->contact_id;
         $contribution->contact_id = $contributionContactID;
       }
-      CRM_Activity_BAO_Activity::addActivity($contribution, NULL, $targetContactID);
+      CRM_Activity_BAO_Activity::addActivity($contribution, 'Contribution', $targetContactID);
     }
 
     if (self::isEmailReceipt($input, $contribution->contribution_page_id, $recurringContributionID)) {


### PR DESCRIPTION
Overview
----------------------------------------
Removes an almost-redundant parameter & fixes the last place where it is still passed in

Before
----------------------------------------
Function called only from civi core & activityType almost always passed in (screenshot from slightly outdated civi-universe - in fact one of the 2 nulls is already fixed 

<img width="1130" alt="Screen Shot 2020-09-22 at 5 03 16 PM" src="https://user-images.githubusercontent.com/336308/93845587-86faec80-fcf5-11ea-93c3-9f0fd4941cfd.png">



After
----------------------------------------
<img width="1264" alt="Screen Shot 2020-09-22 at 4 42 12 PM" src="https://user-images.githubusercontent.com/336308/93845540-50bd6d00-fcf5-11ea-8f15-a117e83cd504.png">

Technical Details
----------------------------------------
There is only 1 remaining place that calls this function & does not specifiy activityType. This fixes
that place to pass in activityType and stops attempting to calculate activityType
based on in-function guess work

Comments
----------------------------------------

