### PR TITLE
[Ref] Merge code - Move determination about location type to the getDAOForLocation…

### DIFF
--- a/CRM/Dedupe/MergeHandler.php
+++ b/CRM/Dedupe/MergeHandler.php
@@ -205,20 +205,11 @@ class CRM_Dedupe_MergeHandler {
    * @throws \CRM_Core_Exception
    */
   public function copyDataToNewBlockDAO($otherBlockId, $name, $blkCount) {
-    $locationBlocks = CRM_Dedupe_Merger::getLocationBlockInfo();
-    $migrationInfo = $this->getMigrationInfo();
     // For the block which belongs to other-contact, link the location block to main-contact
-    $otherBlockDAO = $this->getDAOForLocationEntity($name, $this->getSelectedLocationType($name, $blkCount));
+    $otherBlockDAO = $this->getDAOForLocationEntity($name, $this->getSelectedLocationType($name, $blkCount), $this->getSelectedType($name, $blkCount));
     $otherBlockDAO->contact_id = $this->getToKeepID();
-
     // Get the ID of this block on the 'other' contact, otherwise skip
     $otherBlockDAO->id = $otherBlockId;
-
-    // Add/update location and type information from the form, if applicable
-    if ($locationBlocks[$name]['hasType']) {
-      $typeTypeId = $migrationInfo['location_blocks'][$name][$blkCount]['typeTypeId'] ?? NULL;
-      $otherBlockDAO->{$locationBlocks[$name]['hasType']} = $typeTypeId;
-    }
     return $otherBlockDAO;
   }
 
@@ -227,12 +218,13 @@ class CRM_Dedupe_MergeHandler {
    *
    * @param string $entity
    *
-   * @param null $locationTypeID
+   * @param int|null $locationTypeID
+   * @param int|null $typeID
    *
    * @return CRM_Core_DAO_Address|CRM_Core_DAO_Email|CRM_Core_DAO_IM|CRM_Core_DAO_Phone|CRM_Core_DAO_Website
    * @throws \CRM_Core_Exception
    */
-  public function getDAOForLocationEntity($entity, $locationTypeID = NULL) {
+  public function getDAOForLocationEntity($entity, $locationTypeID = NULL, $typeID = NULL) {
     switch ($entity) {
       case 'email':
         $dao = new CRM_Core_DAO_Email();
@@ -247,10 +239,13 @@ class CRM_Dedupe_MergeHandler {
       case 'phone':
         $dao = new CRM_Core_DAO_Phone();
         $dao->location_type_id = $locationTypeID;
+        $dao->phone_type_id = $typeID;
         return $dao;
 
       case 'website':
-        return new CRM_Core_DAO_Website();
+        $dao = new CRM_Core_DAO_Website();
+        $dao->website_type_id = $typeID;
+        return $dao;
 
       case 'im':
         $dao = new CRM_Core_DAO_IM();
@@ -275,6 +270,20 @@ class CRM_Dedupe_MergeHandler {
    */
   protected function getSelectedLocationType($entity, $blockIndex) {
     return $this->getMigrationInfo()['location_blocks'][$entity][$blockIndex]['locTypeId'] ?? NULL;
+  }
+
+  /**
+   * Get the selected type for the given location block.
+   *
+   * This will retrieve any user selection if they specified which type to move a block to (e.g 'Mobile' for phone).
+   *
+   * @param string $entity
+   * @param int $blockIndex
+   *
+   * @return int|null
+   */
+  protected function getSelectedType($entity, $blockIndex) {
+    return $this->getMigrationInfo()['location_blocks'][$entity][$blockIndex]['typeTypeId'] ?? NULL;
   }
 
 }


### PR DESCRIPTION

Overview
----------------------------------------
This switches us from having an array that we pass around with information as to which entities support location type & phone_type_id o website_type_id to putting it next to the various entities

Before
----------------------------------------
Hard to make sense of ```$locationBlocks``` variable

After
----------------------------------------
location_type_id set by entity

Technical Details
----------------------------------------
@colemanw this is where it starts to become more legible with the switch - easy to see how we are setting location_type_id

Comments
----------------------------------------

