### PR TITLE
Add Send reminder hook

### DIFF
--- a/CRM/Core/BAO/ActionSchedule.php
+++ b/CRM/Core/BAO/ActionSchedule.php
@@ -297,6 +297,9 @@ FROM civicrm_action_schedule cas
             if ($actionSchedule->mode == 'Email' or $actionSchedule->mode == 'User_Preference') {
               CRM_Utils_Array::extend($errors, self::sendReminderEmail($tokenRow, $actionSchedule, $dao->contactID));
             }
+
+            CRM_Utils_Hook::sendReminder($tokenRow, $actionSchedule, $dao->contactID, $errors);
+
             // insert activity log record if needed
             if ($actionSchedule->record_activity && empty($errors)) {
               $caseID = empty($dao->case_id) ? NULL : $dao->case_id;

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -2657,4 +2657,22 @@ abstract class CRM_Utils_Hook {
     );
   }
 
+  /**
+   * This hook is invoked when processing reminder.
+   *
+   * @param object $tokenRow
+   * @param object $actionSchedule
+   * @param int $contactID
+   * @param array $errors
+   *
+   * @return mixed
+   */
+  public static function sendReminder($tokenRow, $actionSchedule, $contactID, &$errors) {
+    return self::singleton()->invoke(
+      ['tokenRow', 'actionSchedule', 'contactID', 'errors'],
+      $tokenRow, $actionSchedule, $contactID, $errors, self::$_nullObject,
+      self::$_nullObject, 'civicrm_sendReminder'
+    );
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
This PR provides hook to allow send reminder via custom mode like SNS etc. 

Comments
----------------------------------------
Schedule reminder can be send either via SMS or Email at the moment. When adding new option in msg_mode option group, the schedule reminder form allows to save the reminder using custom mode, However when executed there is no way to call the custom method.
