### PR TITLE
dev/core#1838 Ensure that no fatal error is triggered if you try to a…

### DIFF
--- a/CRM/Contact/Page/View.php
+++ b/CRM/Contact/Page/View.php
@@ -311,7 +311,13 @@ class CRM_Contact_Page_View extends CRM_Core_Page {
     }
     if ($isDeleted) {
       $title = "<del>{$title}</del>";
-      $mergedTo = civicrm_api3('Contact', 'getmergedto', ['contact_id' => $contactId, 'api.Contact.get' => ['return' => 'display_name']]);
+      try {
+        $mergedTo = civicrm_api3('Contact', 'getmergedto', ['contact_id' => $contactId, 'api.Contact.get' => ['return' => 'display_name']]);
+      }
+      catch (CiviCRM_API3_Exception $e) {
+        CRM_Core_Session::singleton()->setStatus(ts('This contact was deleted during a merge operation. The contact it was merged into cannot be found and may have been deleted.'));
+        $mergedTo = ['count' => 0];
+      }
       if ($mergedTo['count']) {
         $mergedToContactID = $mergedTo['id'];
         $mergedToDisplayName = $mergedTo['values'][$mergedToContactID]['api.Contact.get']['values'][0]['display_name'];


### PR DESCRIPTION
…ccess a merged contact and the contact that it was merged into has been permanently deleted

Overview
----------------------------------------
Replication details are on the lab https://lab.civicrm.org/dev/core/-/issues/1838 but this seems like an easy fix

Before
----------------------------------------
Fatal error on viewing the merged contact

After
----------------------------------------
No fatal error

ping @eileenmcnaughton @andrew-cormick-dockery 