### PR TITLE
dev/core#2057 Fix 'sleeper-bug' in apiv4, BAO activity.create

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -368,10 +368,8 @@ class CRM_Activity_BAO_Activity extends CRM_Activity_DAO_Activity {
       $assignmentParams = ['activity_id' => $activityId];
 
       if (is_array($params['assignee_contact_id'])) {
-        if (CRM_Utils_Array::value('deleteActivityAssignment', $params, TRUE)) {
-          // first delete existing assignments if any
-          self::deleteActivityContact($activityId, $assigneeID);
-        }
+        // first delete existing assignments if any
+        self::deleteActivityContact($activityId, $assigneeID);
 
         foreach ($params['assignee_contact_id'] as $acID) {
           if ($acID) {
@@ -403,10 +401,8 @@ class CRM_Activity_BAO_Activity extends CRM_Activity_DAO_Activity {
         }
       }
     }
-    else {
-      if (CRM_Utils_Array::value('deleteActivityAssignment', $params, TRUE)) {
-        self::deleteActivityContact($activityId, $assigneeID);
-      }
+    elseif (isset($params['assignee_contact_id'])) {
+      self::deleteActivityContact($activityId, $assigneeID);
     }
 
     if (is_a($resultAssignment, 'CRM_Core_Error')) {
@@ -421,10 +417,8 @@ class CRM_Activity_BAO_Activity extends CRM_Activity_DAO_Activity {
       $targetParams = ['activity_id' => $activityId];
       $resultTarget = [];
       if (is_array($params['target_contact_id'])) {
-        if (CRM_Utils_Array::value('deleteActivityTarget', $params, TRUE)) {
-          // first delete existing targets if any
-          self::deleteActivityContact($activityId, $targetID);
-        }
+        // first delete existing targets if any
+        self::deleteActivityContact($activityId, $targetID);
 
         foreach ($params['target_contact_id'] as $tid) {
           if ($tid) {
@@ -456,10 +450,8 @@ class CRM_Activity_BAO_Activity extends CRM_Activity_DAO_Activity {
         }
       }
     }
-    else {
-      if (CRM_Utils_Array::value('deleteActivityTarget', $params, TRUE)) {
-        self::deleteActivityContact($activityId, $targetID);
-      }
+    elseif (isset($params['target_contact_id'])) {
+      self::deleteActivityContact($activityId, $targetID);
     }
 
     // write to changelog before transaction is committed/rolled

--- a/Civi/Test/ContactTestTrait.php
+++ b/Civi/Test/ContactTestTrait.php
@@ -74,7 +74,7 @@ trait ContactTestTrait {
    * @return int
    *   id of Individual created
    *
-   * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
    */
   public function individualCreate($params = [], $seq = 0, $random = FALSE) {
     $params = array_merge($this->sampleContact('Individual', $seq, $random), $params);

--- a/api/v3/Activity.php
+++ b/api/v3/Activity.php
@@ -95,20 +95,6 @@ function civicrm_api3_activity_create($params) {
     }
   }
 
-  $deleteActivityAssignment = FALSE;
-  if (isset($params['assignee_contact_id'])) {
-    $deleteActivityAssignment = TRUE;
-  }
-
-  $deleteActivityTarget = FALSE;
-  if (isset($params['target_contact_id'])) {
-    $deleteActivityTarget = TRUE;
-  }
-
-  // this should all be handled at the BAO layer
-  $params['deleteActivityAssignment'] = CRM_Utils_Array::value('deleteActivityAssignment', $params, $deleteActivityAssignment);
-  $params['deleteActivityTarget'] = CRM_Utils_Array::value('deleteActivityTarget', $params, $deleteActivityTarget);
-
   if ($case_id && $createRevision) {
     // This is very similar to the copy-to-case action.
     if (!CRM_Utils_Array::crmIsEmptyArray($oldActivityValues['target_contact'])) {

--- a/tests/phpunit/CRM/Activity/BAO/ActivityTest.php
+++ b/tests/phpunit/CRM/Activity/BAO/ActivityTest.php
@@ -276,9 +276,7 @@ class CRM_Activity_BAO_ActivityTest extends CiviUnitTestCase {
   }
 
   /**
-   * Test case for deleteActivityTarget() method.
-   *
-   * deleteActivityTarget($activityId) method deletes activity target for given activity id.
+   * Test case for deleteActivityContact() method.
    */
   public function testDeleteActivityTarget() {
     $contactId = $this->individualCreate();

--- a/tests/phpunit/api/v3/JobProcessMailingTest.php
+++ b/tests/phpunit/api/v3/JobProcessMailingTest.php
@@ -86,6 +86,7 @@ class api_v3_JobProcessMailingTest extends CiviUnitTestCase {
     //$this->_mut->clearMessages();
     $this->_mut->stop();
     CRM_Utils_Hook::singleton()->reset();
+    $this->quickCleanup(['civicrm_activity_contact', 'civicrm_activity']);
     // DGW
     CRM_Mailing_BAO_MailingJob::$mailsProcessed = 0;
     //$this->cleanupMailingTest();
@@ -474,11 +475,18 @@ class api_v3_JobProcessMailingTest extends CiviUnitTestCase {
    * Check that the earlier iterations's activity targets on the recorded
    * BulkEmail activity don't get wiped out by subsequent iterations when
    * using batches.
+   *
+   * @dataProvider getBooleanDataProvider
+   *
+   * @param bool $isBulk
+   *
+   * @throws \CRM_Core_Exception
    */
-  public function testBatchActivityTargets() {
+  public function testBatchActivityTargets($isBulk) {
     $loggedInUserId = $this->createLoggedInUser();
 
     \Civi::settings()->set('mailerBatchLimit', 2);
+    \Civi::settings()->set('civimail_multiple_bulk_emails', $isBulk);
 
     // We have such small batches we need to lower this interval to get it
     // to create the activity.


### PR DESCRIPTION
Overview
----------------------------------------
Fixes bug whereby APIv4 Activity updates and direct BAO::create updates (but not apiv3 updates) can delete activity assignee & activity target records


Before
----------------------------------------
Doing an apiv4 update will cause assignee & target records to be updated when the assignee_contact_id key is not set

After
----------------------------------------
Doing an apiv4 update will cause assignee & target records to be updated when the assignee_contact_id key is set but empty. No action if not set

Technical Details
----------------------------------------
It turns out that the Activity.create BAO
- deletes the existing source contact for an activity if the param 'source_contact_id' is set
- deletes existing assignee contacts for an activity if the param 'assignee_contact_id' is empty
- deletes existing target contacts for an activity if the param 'target_contact_id' is empty

The v3 api provides some fairly convoluted wrapping to effectively convert is empty
to isset (via 2 params deleteActivityAssignment, deleteActivityTarget which would only
be anything other than true if the relevant value key is not set or we are operating from
the one place in universe that passes in this param (well actually it's true then too
eileenmcnaughton/civicrm_entity@bd779c1
)

The v4 api does no handling and we can expect that on update activity contact records are
likely being lost - ditto with direct BAO calls that were probably QAd at some point but
may have changed over time.

This changes the BAO to treat the assignee & target params the same way as source
- ie do nothing if not set, but empty means to delete them



This is part of my effort to fix redundant queries in Activity.create regarding
activity contacts


Comments
----------------------------------------
@colemanw 
