### PR TITLE
Switch to non-deprecated/cached functions for membership pricesets

### DIFF
--- a/CRM/Price/Form/Field.php
+++ b/CRM/Price/Form/Field.php
@@ -556,12 +556,12 @@ class CRM_Price_Form_Field extends CRM_Core_Form {
             $foundDuplicate = FALSE;
             $orgIds = [];
             foreach ($memTypesIDS as $key => $val) {
-              $org = CRM_Member_BAO_MembershipType::getMembershipTypeOrganization($val);
-              if (in_array($org[$val], $orgIds)) {
+              $memTypeDetails = CRM_Member_BAO_MembershipType::getMembershipType($val);
+              if (in_array($memTypeDetails['member_of_contact_id'], $orgIds)) {
                 $foundDuplicate = TRUE;
                 break;
               }
-              $orgIds[$val] = $org[$val];
+              $orgIds[$val] = $memTypeDetails['member_of_contact_id'];
 
             }
             if ($foundDuplicate) {
@@ -573,7 +573,7 @@ class CRM_Price_Form_Field extends CRM_Core_Form {
           $foundAutorenew = FALSE;
           foreach ($memTypesIDS as $key => $val) {
             // see if any price field option values in this price field are for memberships with autorenew
-            $memTypeDetails = CRM_Member_BAO_MembershipType::getMembershipTypeDetails($val);
+            $memTypeDetails = CRM_Member_BAO_MembershipType::getMembershipType($val);
             if (!empty($memTypeDetails['auto_renew'])) {
               $foundAutorenew = TRUE;
               break;


### PR DESCRIPTION
Overview
----------------------------------------
`CRM_Member_BAO_MembershipType::getMembershipTypeDetails()` and `CRM_Member_BAO_MembershipType::getMembershipTypeOrganization()` functions are non-cached functions to get information about the membershipType.

Switch to `CRM_Member_BAO_MembershipType::getMembershipType()` which is a cached function to get information about the same thing.

Partial from #18398 which is attempting to rationalise and cleanup the use of multiple functions to get the same information.

Before
----------------------------------------
Using non-cached function to get membershipType detail.

After
----------------------------------------
Using "standard" cached function to get membershipType detail.

Technical Details
----------------------------------------
Pricesets are often built multiple times as forms load or are submitted. By using cached functions we reduce the number of database lookups to one when we need to get information about membershiptypes.

Comments
----------------------------------------

