### PR TITLE
SyntaxConformance::testSqlOperators cleanup fix - ensure entities are deleted

### DIFF
--- a/tests/phpunit/api/v3/SyntaxConformanceTest.php
+++ b/tests/phpunit/api/v3/SyntaxConformanceTest.php
@@ -1099,10 +1099,9 @@ class api_v3_SyntaxConformanceTest extends CiviUnitTestCase {
     $entities = array_keys($entities['values']);
     $totalEntities = count($entities);
     if ($totalEntities < 3) {
-      $ids = [];
       for ($i = 0; $i < 3 - $totalEntities; $i++) {
         $baoObj = CRM_Core_DAO::createTestObject($baoString, ['currency' => 'USD']);
-        $ids[] = $baoObj->id;
+        $this->deletableTestObjects[$baoString][] = $baoObj->id;
       }
       $totalEntities = 3;
     }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes SyntaxConformance::testSqlOperators to clean up after itself

Before
----------------------------------------
The tearDown works for other tests in the class but not this one

$ids var is unused but appears to have been for delete tracking

<img width="694" alt="Screen Shot 2020-09-24 at 6 57 16 AM" src="https://user-images.githubusercontent.com/336308/94057066-39849980-fe33-11ea-9237-b76ae0a61c4c.png">


After
----------------------------------------
Entities deleted

<img width="764" alt="Screen Shot 2020-09-24 at 6 59 06 AM" src="https://user-images.githubusercontent.com/336308/94057243-7781bd80-fe33-11ea-831b-d7ecb525ed9f.png">


Technical Details
----------------------------------------
Tear Down iterates ```$this->deletableTestObjects```


```
  public function tearDown() {
    foreach ($this->deletableTestObjects as $entityName => $entities) {
      foreach ($entities as $entityID) {
        CRM_Core_DAO::deleteTestObjects($entityName, ['id' => $entityID]);
      }
    }
  }
```

Comments
----------------------------------------

