### PR TITLE
dev/core#2061 PCP: call the hook_civicrm_links hook for PCP page user actions

### DIFF
--- a/CRM/PCP/BAO/PCP.php
+++ b/CRM/PCP/BAO/PCP.php
@@ -88,8 +88,6 @@ WHERE  civicrm_pcp.contact_id = civicrm_contact.id
    *   array of Pcp if found
    */
   public static function getPcpDashboardInfo($contactId) {
-    $links = self::pcpLinks();
-
     $query = '
 SELECT pcp.*, block.is_tellfriend_enabled FROM civicrm_pcp pcp
 LEFT JOIN civicrm_pcp_block block ON block.id = pcp.pcp_block_id
@@ -98,13 +96,13 @@ WHERE pcp.is_active = 1
 ORDER BY page_type, page_id';
 
     $params = [1 => [$contactId, 'Integer']];
-
     $pcpInfoDao = CRM_Core_DAO::executeQuery($query, $params);
-    $pcpInfo = [];
-    $hide = $mask = array_sum(array_keys($links['all']));
-    $contactPCPPages = [];
 
+    $links = self::pcpLinks();
+    $hide = $mask = array_sum(array_keys($links['all']));
     $approved = CRM_Core_PseudoConstant::getKey('CRM_PCP_BAO_PCP', 'status_id', 'Approved');
+    $contactPCPPages = [];
+    $pcpInfo = [];
 
     while ($pcpInfoDao->fetch()) {
       $mask = $hide;
@@ -264,10 +262,13 @@ WHERE pcp.id = %1 AND cc.contribution_status_id = %2 AND cc.is_test = 0";
   /**
    * Get action links.
    *
+   * @param int $pcpId
+   *   Contains the pcp ID. Defaults to NULL for backwards compatibility.
+   *
    * @return array
    *   (reference) of action links
    */
-  public static function &pcpLinks() {
+  public static function &pcpLinks($pcpId = NULL) {
     if (!(self::$_pcpLinks)) {
       $deleteExtra = ts('Are you sure you want to delete this Personal Campaign Page?') . '\n' . ts('This action cannot be undone.');
 
@@ -326,6 +327,8 @@ WHERE pcp.id = %1 AND cc.contribution_status_id = %2 AND cc.is_test = 0";
           'title' => ts('Delete'),
         ],
       ];
+
+      CRM_Utils_Hook::links('pcp.user.actions', 'Pcp', $pcpId, self::$_pcpLinks);
     }
     return self::$_pcpLinks;
   }

--- a/CRM/PCP/Page/PCPInfo.php
+++ b/CRM/PCP/Page/PCPInfo.php
@@ -141,7 +141,7 @@ class CRM_PCP_Page_PCPInfo extends CRM_Core_Page {
 
       $this->assign('owner', $owner);
 
-      $link = CRM_PCP_BAO_PCP::pcpLinks();
+      $link = CRM_PCP_BAO_PCP::pcpLinks($pcpInfo['id']);
 
       $hints = [
         CRM_Core_Action::UPDATE => ts('Change the content and appearance of your page'),


### PR DESCRIPTION
https://lab.civicrm.org/dev/core/-/issues/2061

Overview
----------------------------------------

As a user who creates a Personal Campaign Page (PCP), CiviCRM displays a list of actions to manage the PCP page:

![pcp-links](https://user-images.githubusercontent.com/254741/94064014-00a6df00-fdb7-11ea-8fc7-b056a582bc5d.jpg)

As site admins, we may want to customize the list of links that are displayed. CiviCRM already has a [hook_civicrm_links](https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_links/) hook, but it is not being called from here.

Before
----------------------------------------

PCP user action links cannot be customized.

After
----------------------------------------

PCP user action links can be customized.

Technical Details
----------------------------------------

It changes the signature on on the links() function to add the pcpId, but I added a default argument in case an extension is calling it.

If concept approved, will require a doc update to: https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_links/