### PR TITLE
APIv4 Search: Improve GROUP_CONCAT with :label prefix

### DIFF
--- a/Civi/Api4/Query/Api4SelectQuery.php
+++ b/Civi/Api4/Query/Api4SelectQuery.php
@@ -138,7 +138,7 @@ class Api4SelectQuery {
       }
       $results[] = $result;
     }
-    FormattingUtil::formatOutputValues($results, $this->apiFieldSpec, $this->getEntity());
+    FormattingUtil::formatOutputValues($results, $this->apiFieldSpec, $this->getEntity(), 'get', $this->selectAliases);
     return $results;
   }
 

--- a/Civi/Api4/Query/SqlExpression.php
+++ b/Civi/Api4/Query/SqlExpression.php
@@ -38,6 +38,14 @@ abstract class SqlExpression {
   public $expr = '';
 
   /**
+   * Whether or not pseudoconstant suffixes should be evaluated during output.
+   *
+   * @var bool
+   * @see \Civi\Api4\Utils\FormattingUtil::formatOutputValues
+   */
+  public $supportsExpansion = FALSE;
+
+  /**
    * SqlFunction constructor.
    * @param string $expr
    * @param string|null $alias

--- a/Civi/Api4/Query/SqlField.php
+++ b/Civi/Api4/Query/SqlField.php
@@ -16,6 +16,8 @@ namespace Civi\Api4\Query;
  */
 class SqlField extends SqlExpression {
 
+  public $supportsExpansion = TRUE;
+
   protected function initialize() {
     if ($this->alias && $this->alias !== $this->expr) {
       throw new \API_Exception("Aliasing field names is not allowed, only expressions can have an alias.");

--- a/Civi/Api4/Query/SqlFunction.php
+++ b/Civi/Api4/Query/SqlFunction.php
@@ -18,8 +18,14 @@ namespace Civi\Api4\Query;
  */
 abstract class SqlFunction extends SqlExpression {
 
+  /**
+   * @var array
+   */
   protected static $params = [];
 
+  /**
+   * @var array[]
+   */
   protected $args = [];
 
   /**
@@ -40,17 +46,22 @@ abstract class SqlFunction extends SqlExpression {
    */
   protected function initialize() {
     $arg = trim(substr($this->expr, strpos($this->expr, '(') + 1, -1));
-    foreach ($this->getParams() as $param) {
+    foreach ($this->getParams() as $idx => $param) {
       $prefix = $this->captureKeyword($param['prefix'], $arg);
+      $this->args[$idx] = [
+        'prefix' => $prefix,
+        'expr' => [],
+        'suffix' => NULL,
+      ];
       if ($param['expr'] && isset($prefix) || in_array('', $param['prefix']) || !$param['optional']) {
-        $this->captureExpressions($arg, $param['expr'], $param['must_be'], $param['cant_be']);
-        $this->captureKeyword($param['suffix'], $arg);
+        $this->args[$idx]['expr'] = $this->captureExpressions($arg, $param['expr'], $param['must_be'], $param['cant_be']);
+        $this->args[$idx]['suffix'] = $this->captureKeyword($param['suffix'], $arg);
       }
     }
   }
 
   /**
-   * Shift a keyword off the beginning of the argument string and into the argument array.
+   * Shift a keyword off the beginning of the argument string and return it.
    *
    * @param array $keywords
    *   Whitelist of keywords
@@ -60,7 +71,6 @@ abstract class SqlFunction extends SqlExpression {
   private function captureKeyword($keywords, &$arg) {
     foreach (array_filter($keywords) as $key) {
       if (strpos($arg, $key . ' ') === 0) {
-        $this->args[] = $key;
         $arg = ltrim(substr($arg, strlen($key)));
         return $key;
       }
@@ -69,35 +79,34 @@ abstract class SqlFunction extends SqlExpression {
   }
 
   /**
-   * Shifts 0 or more expressions off the argument string and into the argument array
+   * Shifts 0 or more expressions off the argument string and returns them
    *
    * @param string $arg
    * @param int $limit
    * @param array $mustBe
    * @param array $cantBe
+   * @return array
    * @throws \API_Exception
    */
   private function captureExpressions(&$arg, $limit, $mustBe, $cantBe) {
-    $captured = 0;
+    $captured = [];
     $arg = ltrim($arg);
     while ($arg) {
       $item = $this->captureExpression($arg);
       $arg = ltrim(substr($arg, strlen($item)));
       $expr = SqlExpression::convert($item, FALSE, $mustBe, $cantBe);
       $this->fields = array_merge($this->fields, $expr->getFields());
-      if ($captured) {
-        $this->args[] = ',';
-      }
-      $this->args[] = $expr;
+      $captured[] = $expr;
       $captured++;
       // Keep going if we have a comma indicating another expression follows
-      if ($captured < $limit && substr($arg, 0, 1) === ',') {
+      if (count($captured) < $limit && substr($arg, 0, 1) === ',') {
         $arg = ltrim(substr($arg, 1));
       }
       else {
-        return;
+        break;
       }
     }
+    return $captured;
   }
 
   /**
@@ -147,20 +156,50 @@ abstract class SqlFunction extends SqlExpression {
     return $item;
   }
 
+  /**
+   * Render the expression for insertion into the sql query
+   *
+   * @param array $fieldList
+   * @return string
+   */
   public function render(array $fieldList): string {
-    $output = $this->getName() . '(';
+    $output = '';
+    $params = $this->getParams();
     foreach ($this->args as $index => $arg) {
-      if ($index && $arg !== ',') {
-        $output .= ' ';
-      }
-      if (is_object($arg)) {
-        $output .= $arg->render($fieldList);
-      }
-      else {
-        $output .= $arg;
+      $rendered = $this->renderArg($arg, $params[$index], $fieldList);
+      if (strlen($rendered)) {
+        $output .= (strlen($output) ? ' ' : '') . $rendered;
       }
     }
-    return $output . ')';
+    return $this->getName() . '(' . $output . ')';
+  }
+
+  /**
+   * @param array $arg
+   * @param array $param
+   * @param array $fieldList
+   * @return string
+   */
+  private function renderArg($arg, $param, $fieldList): string {
+    // Supply api_default
+    if (!isset($arg['prefix']) && !isset($arg['suffix']) && empty($arg['expr']) && !empty($param['api_default'])) {
+      $arg = [
+        'prefix' => $param['api_default']['prefix'] ?? reset($param['prefix']),
+        'expr' => array_map([parent::class, 'convert'], $param['api_default']['expr'] ?? []),
+        'suffix' => $param['api_default']['suffix'] ?? reset($param['suffix']),
+      ];
+    }
+    $rendered = $arg['prefix'] ?? '';
+    foreach ($arg['expr'] ?? [] as $idx => $expr) {
+      if (strlen($rendered) || $idx) {
+        $rendered .= $idx ? ', ' : ' ';
+      }
+      $rendered .= $expr->render($fieldList);
+    }
+    if (isset($arg['suffix'])) {
+      $rendered .= (strlen($rendered) ? ' ' : '') . $arg['suffix'];
+    }
+    return $rendered;
   }
 
   /**
@@ -194,9 +233,18 @@ abstract class SqlFunction extends SqlExpression {
         'optional' => FALSE,
         'must_be' => [],
         'cant_be' => ['SqlWild'],
+        'api_default' => NULL,
       ];
     }
     return $params;
+  }
+
+  /**
+   * Get the arguments passed to this sql function instance.
+   * @return array[]
+   */
+  public function getArgs(): array {
+    return $this->args;
   }
 
   /**

--- a/Civi/Api4/Query/SqlFunctionCOUNT.php
+++ b/Civi/Api4/Query/SqlFunctionCOUNT.php
@@ -28,6 +28,17 @@ class SqlFunctionCOUNT extends SqlFunction {
   ];
 
   /**
+   * Reformat result as array if using default separator
+   *
+   * @see \Civi\Api4\Utils\FormattingUtil::formatOutputValues
+   * @param string $value
+   * @return string|array
+   */
+  public function formatOutputValue($value) {
+    return (int) $value;
+  }
+
+  /**
    * @return string
    */
   public static function getTitle(): string {

--- a/Civi/Api4/Query/SqlFunctionGREATEST.php
+++ b/Civi/Api4/Query/SqlFunctionGREATEST.php
@@ -16,6 +16,8 @@ namespace Civi\Api4\Query;
  */
 class SqlFunctionGREATEST extends SqlFunction {
 
+  public $supportsExpansion = TRUE;
+
   protected static $category = self::CATEGORY_COMPARISON;
 
   protected static $params = [

--- a/Civi/Api4/Query/SqlFunctionGROUP_CONCAT.php
+++ b/Civi/Api4/Query/SqlFunctionGROUP_CONCAT.php
@@ -16,6 +16,8 @@ namespace Civi\Api4\Query;
  */
 class SqlFunctionGROUP_CONCAT extends SqlFunction {
 
+  public $supportsExpansion = TRUE;
+
   protected static $category = self::CATEGORY_AGGREGATE;
 
   protected static $params = [
@@ -37,8 +39,27 @@ class SqlFunctionGROUP_CONCAT extends SqlFunction {
       'expr' => 1,
       'must_be' => ['SqlString'],
       'optional' => TRUE,
+      // @see self::formatOutput()
+      'api_default' => [
+        'expr' => ['"' . \CRM_Core_DAO::VALUE_SEPARATOR . '"'],
+      ],
     ],
   ];
+
+  /**
+   * Reformat result as array if using default separator
+   *
+   * @see \Civi\Api4\Utils\FormattingUtil::formatOutputValues
+   * @param string $value
+   * @return string|array
+   */
+  public function formatOutputValue($value) {
+    $exprArgs = $this->getArgs();
+    if (!$exprArgs[2]['prefix']) {
+      $value = explode(\CRM_Core_DAO::VALUE_SEPARATOR, $value);
+    }
+    return $value;
+  }
 
   /**
    * @return string

--- a/Civi/Api4/Query/SqlFunctionLEAST.php
+++ b/Civi/Api4/Query/SqlFunctionLEAST.php
@@ -16,6 +16,8 @@ namespace Civi\Api4\Query;
  */
 class SqlFunctionLEAST extends SqlFunction {
 
+  public $supportsExpansion = TRUE;
+
   protected static $category = self::CATEGORY_COMPARISON;
 
   protected static $params = [

--- a/Civi/Api4/Query/SqlFunctionMAX.php
+++ b/Civi/Api4/Query/SqlFunctionMAX.php
@@ -16,6 +16,8 @@ namespace Civi\Api4\Query;
  */
 class SqlFunctionMAX extends SqlFunction {
 
+  public $supportsExpansion = TRUE;
+
   protected static $category = self::CATEGORY_AGGREGATE;
 
   protected static $params = [

--- a/Civi/Api4/Query/SqlFunctionMIN.php
+++ b/Civi/Api4/Query/SqlFunctionMIN.php
@@ -16,6 +16,8 @@ namespace Civi\Api4\Query;
  */
 class SqlFunctionMIN extends SqlFunction {
 
+  public $supportsExpansion = TRUE;
+
   protected static $category = self::CATEGORY_AGGREGATE;
 
   protected static $params = [

--- a/Civi/Api4/Query/SqlFunctionNULLIF.php
+++ b/Civi/Api4/Query/SqlFunctionNULLIF.php
@@ -16,6 +16,8 @@ namespace Civi\Api4\Query;
  */
 class SqlFunctionNULLIF extends SqlFunction {
 
+  public $supportsExpansion = TRUE;
+
   protected static $category = self::CATEGORY_COMPARISON;
 
   protected static $params = [

--- a/ext/search/ang/search.module.js
+++ b/ext/search/ang/search.module.js
@@ -100,12 +100,14 @@
         getEntity: getEntity,
         getField: getField,
         parseExpr: function(expr) {
-          var result = {},
+          var result = {fn: null, modifier: ''},
             fieldName = expr,
             bracketPos = expr.indexOf('(');
           if (bracketPos >= 0) {
-            fieldName = expr.match(/[A-Z( _]*([\w.:]+)/)[1];
+            var parsed = expr.substr(bracketPos).match(/[ ]?([A-Z]+[ ]+)?([\w.:]+)/);
+            fieldName = parsed[2];
             result.fn = _.find(CRM.vars.search.functions, {name: expr.substring(0, bracketPos)});
+            result.modifier = _.trim(parsed[1]);
           }
           result.field = getField(fieldName);
           var split = fieldName.split(':'),

--- a/ext/search/ang/search/crmSearchFunction.component.js
+++ b/ext/search/ang/search/crmSearchFunction.component.js
@@ -17,10 +17,28 @@
         ctrl.path = fieldInfo.path + fieldInfo.suffix;
         ctrl.field = fieldInfo.field;
         ctrl.fn = !fieldInfo.fn ? '' : fieldInfo.fn.name;
+        ctrl.modifier = fieldInfo.modifier || null;
+        initFunction();
       };
 
+      function initFunction() {
+        ctrl.fnInfo = _.find(CRM.vars.search.functions, {name: ctrl.fn});
+        if (ctrl.fnInfo && _.includes(ctrl.fnInfo.params[0].prefix, 'DISTINCT')) {
+          ctrl.modifierAllowed = true;
+        }
+        else {
+          ctrl.modifierAllowed = false;
+          ctrl.modifier = null;
+        }
+      }
+
       this.selectFunction = function() {
-        ctrl.expr = ctrl.fn ? (ctrl.fn + '(' + ctrl.path + ')') : ctrl.path;
+        initFunction();
+        ctrl.writeExpr();
+      };
+
+      this.writeExpr = function() {
+        ctrl.expr = ctrl.fn ? (ctrl.fn + '(' + (ctrl.modifier ? ctrl.modifier + ' ' : '') + ctrl.path + ')') : ctrl.path;
       };
     }
   });

--- a/ext/search/ang/search/crmSearchFunction.component.js
+++ b/ext/search/ang/search/crmSearchFunction.component.js
@@ -14,7 +14,7 @@
 
       this.$onInit = function() {
         var fieldInfo = searchMeta.parseExpr(ctrl.expr);
-        ctrl.path = fieldInfo.path;
+        ctrl.path = fieldInfo.path + fieldInfo.suffix;
         ctrl.field = fieldInfo.field;
         ctrl.fn = !fieldInfo.fn ? '' : fieldInfo.fn.name;
       };

--- a/ext/search/ang/search/crmSearchFunction.html
+++ b/ext/search/ang/search/crmSearchFunction.html
@@ -1,4 +1,8 @@
 <div class="form-inline">
   <label>{{ $ctrl.field.label }}:</label>
   <input class="form-control" style="width: 15em;" ng-model="$ctrl.fn" crm-ui-select="{data: $ctrl.functions, placeholder: ts('Select')}" ng-change="$ctrl.selectFunction()">
+  <label ng-if="$ctrl.modifierAllowed">
+    <input type="checkbox" ng-model="$ctrl.modifier" ng-change="$ctrl.writeExpr()" ng-true-value="'DISTINCT'" ng-false-value="null">
+    {{ ts('Distinct') }}
+  </label>
 </div>

--- a/tests/phpunit/api/v4/Action/SqlFunctionTest.php
+++ b/tests/phpunit/api/v4/Action/SqlFunctionTest.php
@@ -39,14 +39,16 @@ class SqlFunctionTest extends UnitTestCase {
   public function testGroupAggregates() {
     $cid = Contact::create(FALSE)->addValue('first_name', 'bill')->execute()->first()['id'];
     Contribution::save(FALSE)
-      ->setDefaults(['contact_id' => $cid, 'financial_type_id' => 1])
+      ->setDefaults(['contact_id' => $cid, 'financial_type_id:name' => 'Donation'])
       ->setRecords([
         ['total_amount' => 100, 'receive_date' => '2020-01-01'],
         ['total_amount' => 200, 'receive_date' => '2020-01-01'],
-        ['total_amount' => 300, 'receive_date' => '2020-01-01'],
-        ['total_amount' => 400, 'receive_date' => '2020-01-01'],
+        ['total_amount' => 300, 'receive_date' => '2020-01-01', 'financial_type_id:name' => 'Member Dues'],
+        ['total_amount' => 400, 'receive_date' => '2020-01-01', 'financial_type_id:name' => 'Event Fee'],
       ])
       ->execute();
+
+    // Test AVG, SUM, MAX, MIN, COUNT
     $agg = Contribution::get(FALSE)
       ->addGroupBy('contact_id')
       ->addWhere('contact_id', '=', $cid)
@@ -57,11 +59,23 @@ class SqlFunctionTest extends UnitTestCase {
       ->addSelect('COUNT(*) AS count')
       ->execute()
       ->first();
-    $this->assertEquals(250, $agg['average']);
-    $this->assertEquals(1000, $agg['SUM:total_amount']);
-    $this->assertEquals(400, $agg['MAX:total_amount']);
-    $this->assertEquals(100, $agg['MIN:total_amount']);
-    $this->assertEquals(4, $agg['count']);
+    $this->assertTrue(250.0 === $agg['average']);
+    $this->assertTrue(1000.0 === $agg['SUM:total_amount']);
+    $this->assertTrue(400.0 === $agg['MAX:total_amount']);
+    $this->assertTrue(100.0 === $agg['MIN:total_amount']);
+    $this->assertTrue(4 === $agg['count']);
+
+    // Test GROUP_CONCAT
+    $agg = Contribution::get(FALSE)
+      ->addGroupBy('contact_id')
+      ->addWhere('contact_id', '=', $cid)
+      ->addSelect('GROUP_CONCAT(financial_type_id:name)')
+      ->addSelect('COUNT(*) AS count')
+      ->execute()
+      ->first();
+
+    $this->assertTrue(4 === $agg['count']);
+    $this->assertContains('Donation', $agg['GROUP_CONCAT:financial_type_id:name']);
   }
 
   public function testGroupHaving() {

--- a/tests/phpunit/api/v4/Query/SqlExpressionParserTest.php
+++ b/tests/phpunit/api/v4/Query/SqlExpressionParserTest.php
@@ -50,19 +50,31 @@ class SqlExpressionParserTest extends UnitTestCase {
     $sqlFn = new $className($fnName . '(total)');
     $this->assertEquals($fnName, $sqlFn->getName());
     $this->assertEquals(['total'], $sqlFn->getFields());
-    $this->assertCount(1, $this->getArgs($sqlFn));
+    $args = $sqlFn->getArgs();
+    $this->assertCount(1, $args);
+    $this->assertNull($args[0]['prefix']);
+    $this->assertNull($args[0]['suffix']);
+    $this->assertTrue(is_a($args[0]['expr'][0], 'Civi\Api4\Query\SqlField'));
 
     $sqlFn = SqlExpression::convert($fnName . '(DISTINCT stuff)');
     $this->assertEquals($fnName, $sqlFn->getName());
     $this->assertEquals("Civi\Api4\Query\SqlFunction$fnName", get_class($sqlFn));
     $this->assertEquals($params, $sqlFn->getParams());
     $this->assertEquals(['stuff'], $sqlFn->getFields());
-    $this->assertCount(2, $this->getArgs($sqlFn));
+    $args = $sqlFn->getArgs();
+    $this->assertCount(1, $args);
+    $this->assertEquals('DISTINCT', $args[0]['prefix']);
+    $this->assertNull($args[0]['suffix']);
+    $this->assertTrue(is_a($args[0]['expr'][0], 'Civi\Api4\Query\SqlField'));
 
     try {
       $sqlFn = SqlExpression::convert($fnName . '(*)');
       if ($fnName === 'COUNT') {
-        $this->assertTrue(is_a($this->getArgs($sqlFn)[0], 'Civi\Api4\Query\SqlWild'));
+        $args = $sqlFn->getArgs();
+        $this->assertCount(1, $args);
+        $this->assertNull($args[0]['prefix']);
+        $this->assertNull($args[0]['suffix']);
+        $this->assertTrue(is_a($args[0]['expr'][0], 'Civi\Api4\Query\SqlWild'));
       }
       else {
         $this->fail('SqlWild should only be allowed in COUNT.');
@@ -71,18 +83,6 @@ class SqlExpressionParserTest extends UnitTestCase {
     catch (\API_Exception $e) {
       $this->assertContains('Illegal', $e->getMessage());
     }
-  }
-
-  /**
-   * @param \Civi\Api4\Query\SqlFunction $fn
-   * @return array
-   * @throws \ReflectionException
-   */
-  private function getArgs($fn) {
-    $ref = new \ReflectionClass($fn);
-    $args = $ref->getProperty('args');
-    $args->setAccessible(TRUE);
-    return $args->getValue($fn);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
This moves handing of pseudoconstant suffix replacement from the UI level to the API level,
which allows APIv4 to return GROUP_CONCAT results as an array (by default, if no separator specified).

It also improves post-query formatting in general, with finer-grained formatting callbacks for sql functions.

In the search UI, it fixes currency formatting, GROUP_CONCAT with :label formatting, and also exposes the DISTINCT modifier to the UI.

Before
----------------------------------------
Intermittent `$ NAN` currency fields.
Intermittent raw numbers instead of pseudoconstant labels for fields with options.

After
----------------------------------------
Intermittent UI problems fixed.
Added support for DISTINCT modifier to the UI.
