### PR TITLE
dev/core#2044 Make contact_id optional on v4 api for Address, phone, email

### DIFF
--- a/Civi/Api4/Service/Spec/Provider/AddressCreationSpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/AddressCreationSpecProvider.php
@@ -27,7 +27,6 @@ class AddressCreationSpecProvider implements Generic\SpecProviderInterface {
    * @param \Civi\Api4\Service\Spec\RequestSpec $spec
    */
   public function modifySpec(RequestSpec $spec) {
-    $spec->getFieldByName('contact_id')->setRequired(TRUE);
     $spec->getFieldByName('location_type_id')->setRequired(TRUE);
   }
 

--- a/Civi/Api4/Service/Spec/Provider/EmailCreationSpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/EmailCreationSpecProvider.php
@@ -27,7 +27,6 @@ class EmailCreationSpecProvider implements Generic\SpecProviderInterface {
    * @inheritDoc
    */
   public function modifySpec(RequestSpec $spec) {
-    $spec->getFieldByName('contact_id')->setRequired(TRUE);
     $spec->getFieldByName('email')->setRequired(TRUE);
     $spec->getFieldByName('on_hold')->setRequired(FALSE);
     $spec->getFieldByName('is_bulkmail')->setRequired(FALSE);

--- a/Civi/Api4/Service/Spec/Provider/PhoneCreationSpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/PhoneCreationSpecProvider.php
@@ -27,7 +27,6 @@ class PhoneCreationSpecProvider implements Generic\SpecProviderInterface {
    * @inheritDoc
    */
   public function modifySpec(RequestSpec $spec) {
-    $spec->getFieldByName('contact_id')->setRequired(TRUE);
     $spec->getFieldByName('phone')->setRequired(TRUE);
   }
 

--- a/tests/phpunit/api/v3/AddressTest.php
+++ b/tests/phpunit/api/v3/AddressTest.php
@@ -57,11 +57,13 @@ class api_v3_AddressTest extends CiviUnitTestCase {
 
   /**
    * @param int $version
+   *
    * @dataProvider versionThreeAndFour
+   * @throws \CRM_Core_Exception
    */
   public function testCreateAddress($version) {
     $this->_apiversion = $version;
-    $result = $this->callAPIAndDocument('address', 'create', $this->_params, __FUNCTION__, __FILE__);
+    $result = $this->callAPIAndDocument('Address', 'create', $this->_params, __FUNCTION__, __FILE__);
     $this->assertEquals(1, $result['count']);
     $this->assertNotNull($result['values'][$result['id']]['id']);
     $this->getAndCheck($this->_params, $result['id'], 'address');


### PR DESCRIPTION
…



Overview
----------------------------------------
Make contact_id optional on v4 api for Address, phone, email - It's optional in the schema for events etc

https://lab.civicrm.org/dev/core/-/issues/2044

Before
----------------------------------------
Apiv4 cannot be used for creating event locations due to contact_id requirement

After
----------------------------------------
contact_id now optional, per the schema

Technical Details
----------------------------------------


Comments
----------------------------------------

