### PR TITLE
dev/core#1921 Remove handling for Civi4.2 date bug from paypalProIPN

### DIFF
--- a/CRM/Core/Payment/PayPalProIPN.php
+++ b/CRM/Core/Payment/PayPalProIPN.php
@@ -174,15 +174,6 @@ class CRM_Core_Payment_PayPalProIPN extends CRM_Core_Payment_BaseIPN {
 
     $now = date('YmdHis');
 
-    // fix dates that already exist
-    $dates = ['create', 'start', 'end', 'cancel', 'modified'];
-    foreach ($dates as $date) {
-      $name = "{$date}_date";
-      if ($recur->$name) {
-        $recur->$name = CRM_Utils_Date::isoToMysql($recur->$name);
-      }
-    }
-
     $sendNotification = FALSE;
     $subscriptionPaymentStatus = NULL;
     //List of Transaction Type


### PR DESCRIPTION


Overview
----------------------------------------
dev/core#1921 Remove handling for Civi4.2 date bug from paypalProIPN

All the tests in
CRM_Core_Payment_PayPalProIPNTest pass through this line

It used to be necessary to reformat dates on a DAO before resaving
- up until 2014

Before
----------------------------------------
Dates reformatted to cope with bug fixed 6 years ago

After
----------------------------------------
poof

Technical Details
----------------------------------------


Comments
----------------------------------------

