### PR TITLE
Set line_item qty via membership_num_terms and use on renewal

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -431,7 +431,7 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution {
    */
   public static function getNumTermsByContributionAndMembershipType($membershipTypeID, $contributionID) {
     $numTerms = CRM_Core_DAO::singleValueQuery("
-      SELECT (CONVERT(qty,SIGNED) * membership_num_terms)
+      SELECT (CONVERT(qty,SIGNED) * COALESCE(membership_num_terms,1))
       FROM civicrm_line_item li
       LEFT JOIN civicrm_price_field_value v ON li.price_field_value_id = v.id
       WHERE contribution_id = %1 AND membership_type_id = %2",

--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -2415,6 +2415,7 @@ WHERE {$whereClause}";
     $contributionParams['non_deductible_amount'] = 'null';
     $contributionParams['skipCleanMoney'] = TRUE;
     $contributionParams['payment_processor'] = $params['payment_processor_id'] ?? NULL;
+    $contributionParams['membership_num_terms'] = $params['num_terms'];
     $contributionSoftParams = $params['soft_credit'] ?? NULL;
     $recordContribution = [
       'contact_id',


### PR DESCRIPTION
Overview
----------------------------------------
Relevant to Gitlab issue https://lab.civicrm.org/dev/membership/-/issues/28#note_47353

Before
----------------------------------------
Memberships renewed with a Pending Contribution and with multiple terms end up being rolled forward only 1 term.  This is due to the `civicrm_line_item.qty` always being set to "1.00" and the fact that the renewal code ignores `qty` and instead utilizes `civicrm_line_item.membership_num_terms` instead.

The problem does not manifest on renewals that do not use a pending Contribution because an entirely different approach is used to roll the membership.

After
----------------------------------------
Memberships created with Pending Contributions and multiple terms will result in the `civicrm_line_item.qty` value being set to the value of the `num_terms` form value provided by the user when performing the renewal and the `unit_price` being set to the total amount divided by the quantity.  In addition, the calculation of terms during renewal will multiply the `civicrm_line_item.membership_num_terms` by the `qty` field value.

Comments
----------------------------------------
I'm not intimately familiar with all the renewal scenarios.
