### PR TITLE
Afform GUI: add bootstrap3

### DIFF
--- a/ext/afform/core/CRM/Afform/Page/AfformBase.php
+++ b/ext/afform/core/CRM/Afform/Page/AfformBase.php
@@ -21,7 +21,9 @@ class CRM_Afform_Page_AfformBase extends CRM_Core_Page {
       'afform' => [
         'open' => $afform['directive_name'],
       ],
-    ]);
+    ])
+      // TODO: Allow afforms to declare their own theming requirements
+      ->addBundle('bootstrap3');
     $loader->load();
 
     if (!empty($afform['title'])) {

--- a/ext/afform/core/afform.php
+++ b/ext/afform/core/afform.php
@@ -150,8 +150,7 @@ function afform_civicrm_caseTypes(&$caseTypes) {
 function afform_civicrm_angularModules(&$angularModules) {
   _afform_civix_civicrm_angularModules($angularModules);
 
-  $afforms = \Civi\Api4\Afform::get()
-    ->setCheckPermissions(FALSE)
+  $afforms = \Civi\Api4\Afform::get(FALSE)
     ->setSelect(['name', 'requires', 'module_name', 'directive_name'])
     ->execute();
 

--- a/ext/afform/gui/CRM/AfformGui/Upgrader.php
+++ b/ext/afform/gui/CRM/AfformGui/Upgrader.php
@@ -10,10 +10,11 @@ class CRM_AfformGui_Upgrader extends CRM_AfformGui_Upgrader_Base {
   // upgrade tasks. They are executed in order (like Drupal's hook_update_N).
 
   /**
-   * Setup navigation item on new installs
+   * Setup navigation item on new installs.
+   *
+   * Note: this path is not in the menu.xml because it is handled by afform
    */
   public function install() {
-    // $this->executeSqlFile('sql/myinstall.sql');
     try {
       $existing = civicrm_api3('Navigation', 'getcount', [
         'name' => 'afform_gui',

--- a/ext/afform/gui/xml/Menu/afform_gui.xml
+++ b/ext/afform/gui/xml/Menu/afform_gui.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0"?>
-<menu>
-  <item>
-    <path>civicrm/admin/afform</path>
-    <page_callback>CRM_AfformGui_Page_Gui</page_callback>
-    <title>Gui</title>
-    <access_arguments>access CiviCRM</access_arguments>
-  </item>
-</menu>


### PR DESCRIPTION
Overview
----------------------------------------
Add the Bootstrap3 bundle to Afform base pages, plus a little code cleanup.

Before
----------------------------------------
No Bootstrap theme.

After
----------------------------------------
Looks much better.

Comments
----------------------------------------
As I mentioned in a `TODO` comment, we could make this more flexible by allowing each afform to declare its own theming requirements.
