### PR TITLE
dev/core#2029 E2E.Core.PrevNextTest.testDeleteByCacheKey More debug attempts

### DIFF
--- a/tests/phpunit/E2E/Core/PrevNextTest.php
+++ b/tests/phpunit/E2E/Core/PrevNextTest.php
@@ -251,7 +251,10 @@ class PrevNextTest extends \CiviEndToEndTestCase {
     $this->testFillArray();
 
     $all = $this->prevNext->getSelection($this->cacheKey, 'getall')[$this->cacheKey];
-    $this->assertEquals([100, 400, 200, 300], array_keys($all));
+    $this->assertEquals([100, 400, 200, 300], array_keys($all), 'selected cache not correct for ' . $this->cacheKey
+      . ' defined keys are ' . $this->cacheKey . 'and ' . $this->cacheKeyB
+      . ' the prevNext cache is ' . print_r($this->prevNext, TRUE)
+    );
 
     list ($id1, $id2, $id3) = array_keys($all);
     $this->prevNext->markSelection($this->cacheKey, 'select', [$id1, $id3]);


### PR DESCRIPTION
Overview
----------------------------------------
Further attempt to get more info on the intermittent test fail on E2E.Core.PrevNextTest.testDeleteByCacheKey- see https://lab.civicrm.org/dev/core/-/issues/2029#note_47417

Before
----------------------------------------
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
 Array (
     0 => 100
-    1 => 400
-    2 => 200
-    3 => 300
 )

/home/jenkins/bknix-dfl/build/core-18581-8pwmi/web/sites/all/modules/civicrm/tests/phpunit/E2E/Core/PrevNextTest.php:254


After
----------------------------------------
Hopefully more info on fail

Technical Details
----------------------------------------


Comments
----------------------------------------
