### PR TITLE
dev/core#2046 Fix Phone:add to be a pseudonym for Phone.create

### DIFF
--- a/CRM/Core/BAO/Block.php
+++ b/CRM/Core/BAO/Block.php
@@ -331,6 +331,9 @@ class CRM_Core_BAO_Block {
         // and the primary handling is otherwise bypassed on importing an email update.
         $blocks[] = CRM_Core_BAO_Email::create($blockFields);
       }
+      elseif ($name === 'Phone') {
+        $blocks[] = CRM_Core_BAO_Phone::create($blockFields);
+      }
       else {
         $baoString = 'CRM_Core_BAO_' . $name;
         $blocks[] = $baoString::add($blockFields);

--- a/CRM/Core/BAO/Phone.php
+++ b/CRM/Core/BAO/Phone.php
@@ -39,25 +39,26 @@ class CRM_Core_BAO_Phone extends CRM_Core_DAO_Phone {
     ) {
       CRM_Core_BAO_Block::handlePrimary($params, get_class());
     }
-    $phone = self::add($params);
-
-    return $phone;
+    return self::writeRecord($params);
   }
 
   /**
    * Takes an associative array and adds phone.
+   *
+   * @deprecated use create.
    *
    * @param array $params
    *   (reference ) an assoc array of name/value pairs.
    *
    * @return object
    *   CRM_Core_BAO_Phone object on success, null otherwise
+   *
+   * @throws \API_Exception
+   * @throws \CRM_Core_Exception
    */
-  public static function add(&$params) {
-    // Ensure mysql phone function exists
-    CRM_Core_DAO::checkSqlFunctionsExist();
-
-    return self::writeRecord($params);
+  public static function add($params) {
+    CRM_Core_Error::deprecatedFunctionWarning('Use the v4 api');
+    return self::create($params);
   }
 
   /**

--- a/tests/phpunit/CRM/Contact/BAO/ContactTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/ContactTest.php
@@ -1446,7 +1446,7 @@ class CRM_Contact_BAO_ContactTest extends CiviUnitTestCase {
           'location_type_id' => 1,
           'contact_id' => $contactId,
         ];
-        CRM_Core_BAO_Phone::add($params);
+        CRM_Core_BAO_Phone::create($params);
         $test->assertDBQuery('202-555-1000',
           'SELECT phone FROM civicrm_phone WHERE contact_id = %1 ORDER BY id DESC LIMIT 1',
           [1 => [$contactId, 'Integer']]

--- a/tests/phpunit/CRM/Core/BAO/PhoneTest.php
+++ b/tests/phpunit/CRM/Core/BAO/PhoneTest.php
@@ -34,7 +34,7 @@ class CRM_Core_BAO_PhoneTest extends CiviUnitTestCase {
       'contact_id' => $contactId,
     ];
 
-    CRM_Core_BAO_Phone::add($params);
+    CRM_Core_BAO_Phone::create($params);
 
     $phoneId = $this->assertDBNotNull('CRM_Core_DAO_Phone', $contactId, 'id', 'contact_id',
       'Database check for created phone record.'
@@ -44,16 +44,15 @@ class CRM_Core_BAO_PhoneTest extends CiviUnitTestCase {
       "Check if phone field has expected value in new record ( civicrm_phone.id={$phoneId} )."
     );
 
-    // Now call add() to modify the existing phone number
+    // Now call create() to modify the existing phone number
 
-    $params = [];
     $params = [
       'id' => $phoneId,
       'contact_id' => $contactId,
       'phone' => '(415) 222-5432',
     ];
 
-    CRM_Core_BAO_Phone::add($params);
+    CRM_Core_BAO_Phone::create($params);
 
     $this->assertDBCompareValue('CRM_Core_DAO_Phone', $phoneId, 'phone', 'id', '(415) 222-5432',
       "Check if phone field has expected value in updated record ( civicrm_phone.id={$phoneId} )."


### PR DESCRIPTION


Overview
----------------------------------------
Per https://lab.civicrm.org/dev/core/-/issues/2046 we have discussed rationalising add vs create

In the case of phone making this change only affects one place - a place that currently has a
bug that relates specifically to the handling of is_primary & which is more solvable by
calling create with it's extra is_primary handling.



Before
----------------------------------------
Phone::create calls Phone::add, duplicating ```CRM_Core_DAO::checkSqlFunctionsExist();``` 
Phone::add does not handle 'is_primary'

After
----------------------------------------
```CRM_Core_DAO::checkSqlFunctionsExist();```  only called once - see https://lab.civicrm.org/dev/core/-/issues/27 for further proposal. is_primary handled in add which calls create & is deprecated

Technical Details
----------------------------------------

Comments
----------------------------------------
The related bug is that the is_primary handling in Block::create is unreliable &
to mitigate that we are doing an additional 10 queries on every contact create - so
handling is_primary right in the first place helps address that - see https://lab.civicrm.org/dev/core/-/issues/2039
