### PR TITLE
[REF]  Separate export form classes out & simplify task handling

### DIFF
--- a/CRM/Activity/Export/Form/Map.php
+++ b/CRM/Activity/Export/Form/Map.php
@@ -1,0 +1,23 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+/**
+ * This class gets the name of the file to upload
+ */
+class CRM_Activity_Export_Form_Map extends CRM_Export_Form_Map {
+
+}

--- a/CRM/Activity/Export/Form/Select.php
+++ b/CRM/Activity/Export/Form/Select.php
@@ -27,4 +27,13 @@ class CRM_Activity_Export_Form_Select extends CRM_Export_Form_Select {
     CRM_Activity_Form_Task::preProcessCommon($this);
   }
 
+  /**
+   * Does this export offer contact merging.
+   *
+   * @return bool
+   */
+  protected function isShowContactMergeOptions() {
+    return FALSE;
+  }
+
 }

--- a/CRM/Activity/Export/Form/Select.php
+++ b/CRM/Activity/Export/Form/Select.php
@@ -1,0 +1,30 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+/**
+ * This class gets the name of the file to upload
+ */
+class CRM_Activity_Export_Form_Select extends CRM_Export_Form_Select {
+
+  /**
+   * Call the pre-processing function.
+   */
+  protected function callPreProcessing(): void {
+    CRM_Activity_Form_Task::preProcessCommon($this);
+  }
+
+}

--- a/CRM/Activity/Task.php
+++ b/CRM/Activity/Task.php
@@ -44,8 +44,8 @@ class CRM_Activity_Task extends CRM_Core_Task {
         self::TASK_EXPORT => [
           'title' => ts('Export activities'),
           'class' => [
-            'CRM_Export_Form_Select',
-            'CRM_Export_Form_Map',
+            'CRM_Activity_Export_Form_Select',
+            'CRM_Activity_Export_Form_Map',
           ],
           'result' => FALSE,
         ],

--- a/CRM/Contact/Export/Form/Map.php
+++ b/CRM/Contact/Export/Form/Map.php
@@ -1,0 +1,23 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+/**
+ * This class gets the name of the file to upload
+ */
+class CRM_Contact_Export_Form_Map extends CRM_Export_Form_Map {
+
+}

--- a/CRM/Contact/Export/Form/Select.php
+++ b/CRM/Contact/Export/Form/Select.php
@@ -1,0 +1,30 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+/**
+ * This class gets the name of the file to upload
+ */
+class CRM_Contact_Export_Form_Select extends CRM_Export_Form_Select {
+
+  /**
+   * Call the pre-processing function.
+   */
+  protected function callPreProcessing(): void {
+    CRM_Contact_Form_Task::preProcessCommon($this);
+  }
+
+}

--- a/CRM/Contact/Export/Form/Select.php
+++ b/CRM/Contact/Export/Form/Select.php
@@ -27,4 +27,13 @@ class CRM_Contact_Export_Form_Select extends CRM_Export_Form_Select {
     CRM_Contact_Form_Task::preProcessCommon($this);
   }
 
+  /**
+   * Does this export offer contact merging.
+   *
+   * @return bool
+   */
+  protected function isShowContactMergeOptions() {
+    return TRUE;
+  }
+
 }

--- a/CRM/Contact/Task.php
+++ b/CRM/Contact/Task.php
@@ -71,8 +71,8 @@ class CRM_Contact_Task extends CRM_Core_Task {
         self::TASK_EXPORT => array(
           'title' => ts('Export contacts'),
           'class' => array(
-            'CRM_Export_Form_Select',
-            'CRM_Export_Form_Map',
+            'CRM_Contact_Export_Form_Select',
+            'CRM_Contact_Export_Form_Map',
           ),
           'result' => FALSE,
         ),

--- a/CRM/Contribute/Export/Form/Map.php
+++ b/CRM/Contribute/Export/Form/Map.php
@@ -1,0 +1,23 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+/**
+ * This class gets the name of the file to upload
+ */
+class CRM_Contribute_Export_Form_Map extends CRM_Export_Form_Map {
+
+}

--- a/CRM/Contribute/Export/Form/Select.php
+++ b/CRM/Contribute/Export/Form/Select.php
@@ -27,4 +27,13 @@ class CRM_Contribute_Export_Form_Select extends CRM_Export_Form_Select {
     CRM_Contribute_Form_Task::preProcessCommon($this);
   }
 
+  /**
+   * Does this export offer contact merging.
+   *
+   * @return bool
+   */
+  protected function isShowContactMergeOptions() {
+    return FALSE;
+  }
+
 }

--- a/CRM/Contribute/Export/Form/Select.php
+++ b/CRM/Contribute/Export/Form/Select.php
@@ -1,0 +1,30 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+/**
+ * This class gets the name of the file to upload
+ */
+class CRM_Contribute_Export_Form_Select extends CRM_Export_Form_Select {
+
+  /**
+   * Call the pre-processing function.
+   */
+  protected function callPreProcessing(): void {
+    CRM_Contribute_Form_Task::preProcessCommon($this);
+  }
+
+}

--- a/CRM/Contribute/Task.php
+++ b/CRM/Contribute/Task.php
@@ -59,8 +59,8 @@ class CRM_Contribute_Task extends CRM_Core_Task {
         self::TASK_EXPORT => [
           'title' => ts('Export contributions'),
           'class' => [
-            'CRM_Export_Form_Select',
-            'CRM_Export_Form_Map',
+            'CRM_Contribute_Export_Form_Select',
+            'CRM_Contribute_Export_Form_Map',
           ],
           'result' => FALSE,
         ],

--- a/CRM/Event/Export/Form/Map.php
+++ b/CRM/Event/Export/Form/Map.php
@@ -1,0 +1,23 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+/**
+ * This class gets the name of the file to upload
+ */
+class CRM_Event_Export_Form_Map extends CRM_Export_Form_Map {
+
+}

--- a/CRM/Event/Export/Form/Select.php
+++ b/CRM/Event/Export/Form/Select.php
@@ -1,0 +1,30 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+/**
+ * This class gets the name of the file to upload
+ */
+class CRM_Event_Export_Form_Select extends CRM_Export_Form_Select {
+
+  /**
+   * Call the pre-processing function.
+   */
+  protected function callPreProcessing(): void {
+    CRM_Event_Form_Task::preProcessCommon($this);
+  }
+
+}

--- a/CRM/Event/Export/Form/Select.php
+++ b/CRM/Event/Export/Form/Select.php
@@ -27,4 +27,13 @@ class CRM_Event_Export_Form_Select extends CRM_Export_Form_Select {
     CRM_Event_Form_Task::preProcessCommon($this);
   }
 
+  /**
+   * Does this export offer contact merging.
+   *
+   * @return bool
+   */
+  protected function isShowContactMergeOptions() {
+    return FALSE;
+  }
+
 }

--- a/CRM/Event/Task.php
+++ b/CRM/Event/Task.php
@@ -60,8 +60,8 @@ class CRM_Event_Task extends CRM_Core_Task {
         self::TASK_EXPORT => [
           'title' => ts('Export participants'),
           'class' => [
-            'CRM_Export_Form_Select',
-            'CRM_Export_Form_Map',
+            'CRM_Event_Export_Form_Select',
+            'CRM_Event_Export_Form_Map',
           ],
           'result' => FALSE,
         ],

--- a/CRM/Export/Controller/Standalone.php
+++ b/CRM/Export/Controller/Standalone.php
@@ -42,7 +42,7 @@ class CRM_Export_Controller_Standalone extends CRM_Core_Controller {
       $this->set('cids', implode(',', array_keys($perm['values'])));
     }
 
-    $this->_stateMachine = new CRM_Export_StateMachine_Standalone($this, $action);
+    $this->_stateMachine = new CRM_Export_StateMachine_Standalone($this, $action, $entity);
 
     // create and instantiate the pages
     $this->addPages($this->_stateMachine, $action);

--- a/CRM/Export/Form/Select.php
+++ b/CRM/Export/Form/Select.php
@@ -96,7 +96,7 @@ class CRM_Export_Form_Select extends CRM_Core_Form_Task {
     }
     $this->_exportMode = constant('CRM_Export_Form_Select::' . strtoupper($entityShortname) . '_EXPORT');
     $formTaskClassName = "CRM_{$entityShortname}_Form_Task";
-    $taskClassName = "CRM_{$entityShortname}_Task";
+
     if (isset($formTaskClassName::$entityShortname)) {
       $this::$entityShortname = $formTaskClassName::$entityShortname;
       if (isset($formTaskClassName::$tableName)) {
@@ -124,17 +124,13 @@ class CRM_Export_Form_Select extends CRM_Core_Form_Task {
       }
     }
 
-    $formTaskClassName::preProcessCommon($this);
+    $this->callPreProcessing();
 
     // $component is used on CRM/Export/Form/Select.tpl to display extra information for contact export
     ($this->_exportMode == self::CONTACT_EXPORT) ? $component = FALSE : $component = TRUE;
     $this->assign('component', $component);
 
-    // Set the task title
-    $componentTasks = $taskClassName::taskTitles();
-    $this->_task = $values['task'];
-    $taskName = $componentTasks[$this->_task];
-    $this->assign('taskName', $taskName);
+    $this->assign('isShowMergeOptions', $this->isShowContactMergeOptions());
 
     if ($this->_componentTable) {
       $query = "
@@ -439,6 +435,20 @@ FROM   {$this->_componentTable}
    */
   public function getQueryMode() {
     return (int) ($this->queryMode ?: $this->controller->get('component_mode'));
+  }
+
+  /**
+   * Call the pre-processing function.
+   */
+  protected function callPreProcessing(): void {
+    throw new CRM_Core_Exception('This must be over-ridden');
+  }
+
+  /**
+   * Assign the title of the task to the tpl.
+   */
+  protected function isShowContactMergeOptions() {
+    throw new CRM_Core_Exception('This must be over-ridden');
   }
 
   /**

--- a/CRM/Export/Form/Select/Case.php
+++ b/CRM/Export/Form/Select/Case.php
@@ -25,4 +25,20 @@ class CRM_Export_Form_Select_Case extends CRM_Export_Form_Select {
    */
   protected $queryMode = CRM_Contact_BAO_Query::MODE_CASE;
 
+  /**
+   * Call the pre-processing function.
+   */
+  protected function callPreProcessing(): void {
+    CRM_Case_Form_Task::preProcessCommon($this);
+  }
+
+  /**
+   * Does this export offer contact merging.
+   *
+   * @return bool
+   */
+  protected function isShowContactMergeOptions() {
+    return FALSE;
+  }
+
 }

--- a/CRM/Export/StateMachine/Standalone.php
+++ b/CRM/Export/StateMachine/Standalone.php
@@ -21,13 +21,16 @@ class CRM_Export_StateMachine_Standalone extends CRM_Core_StateMachine {
    *
    * @param object $controller
    * @param \const|int $action
+   * @param string $entity
    */
-  public function __construct($controller, $action = CRM_Core_Action::NONE) {
+  public function __construct($controller, $action = CRM_Core_Action::NONE, $entity = 'Contact') {
     parent::__construct($controller, $action);
 
+    $entityMap = ['Contribution' => 'Contribute', 'Membership' => 'Member', 'Participant' => 'Event'];
+    $entity = $entityMap[$entity] ?? $entity;
     $this->_pages = [
-      'CRM_Export_Form_Select' => NULL,
-      'CRM_Export_Form_Map' => NULL,
+      'CRM_' . $entity . '_Export_Form_Select' => NULL,
+      'CRM_' . $entity . '_Export_Form_Map' => NULL,
     ];
 
     $this->addSequentialPages($this->_pages, $action);

--- a/CRM/Grant/Export/Form/Map.php
+++ b/CRM/Grant/Export/Form/Map.php
@@ -1,0 +1,23 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+/**
+ * This class gets the name of the file to upload
+ */
+class CRM_Pledge_Export_Form_Map extends CRM_Export_Form_Map {
+
+}

--- a/CRM/Grant/Export/Form/Select.php
+++ b/CRM/Grant/Export/Form/Select.php
@@ -27,4 +27,13 @@ class CRM_Grant_Export_Form_Select extends CRM_Export_Form_Select {
     CRM_Grant_Form_Task::preProcessCommon($this);
   }
 
+  /**
+   * Does this export offer contact merging.
+   *
+   * @return bool
+   */
+  protected function isShowContactMergeOptions() {
+    return FALSE;
+  }
+
 }

--- a/CRM/Grant/Export/Form/Select.php
+++ b/CRM/Grant/Export/Form/Select.php
@@ -1,0 +1,30 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+/**
+ * This class gets the name of the file to upload
+ */
+class CRM_Grant_Export_Form_Select extends CRM_Export_Form_Select {
+
+  /**
+   * Call the pre-processing function.
+   */
+  protected function callPreProcessing(): void {
+    CRM_Grant_Form_Task::preProcessCommon($this);
+  }
+
+}

--- a/CRM/Grant/Task.php
+++ b/CRM/Grant/Task.php
@@ -55,8 +55,8 @@ class CRM_Grant_Task extends CRM_Core_Task {
         self::TASK_EXPORT => [
           'title' => ts('Export grants'),
           'class' => [
-            'CRM_Export_Form_Select',
-            'CRM_Export_Form_Map',
+            'CRM_Grant_Export_Form_Select',
+            'CRM_Grant_Export_Form_Map',
           ],
           'result' => FALSE,
         ],

--- a/CRM/Member/Export/Form/Select.php
+++ b/CRM/Member/Export/Form/Select.php
@@ -20,4 +20,20 @@
  */
 class CRM_Member_Export_Form_Select extends CRM_Export_Form_Select {
 
+  /**
+   * Call the pre-processing function.
+   */
+  protected function callPreProcessing(): void {
+    CRM_Member_Form_Task::preProcessCommon($this);
+  }
+
+  /**
+   * Does this export offer contact merging.
+   *
+   * @return bool
+   */
+  protected function isShowContactMergeOptions() {
+    return FALSE;
+  }
+
 }

--- a/CRM/Pledge/Export/Form/Map.php
+++ b/CRM/Pledge/Export/Form/Map.php
@@ -1,0 +1,23 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+/**
+ * This class gets the name of the file to upload
+ */
+class CRM_Pledge_Export_Form_Map extends CRM_Export_Form_Map {
+
+}

--- a/CRM/Pledge/Export/Form/Select.php
+++ b/CRM/Pledge/Export/Form/Select.php
@@ -27,4 +27,13 @@ class CRM_Pledge_Export_Form_Select extends CRM_Export_Form_Select {
     CRM_Pledge_Form_Task::preProcessCommon($this);
   }
 
+  /**
+   * Does this export offer contact merging.
+   *
+   * @return bool
+   */
+  protected function isShowContactMergeOptions() {
+    return FALSE;
+  }
+
 }

--- a/CRM/Pledge/Export/Form/Select.php
+++ b/CRM/Pledge/Export/Form/Select.php
@@ -1,0 +1,30 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+/**
+ * This class gets the name of the file to upload
+ */
+class CRM_Pledge_Export_Form_Select extends CRM_Export_Form_Select {
+
+  /**
+   * Call the pre-processing function.
+   */
+  protected function callPreProcessing(): void {
+    CRM_Pledge_Form_Task::preProcessCommon($this);
+  }
+
+}

--- a/CRM/Pledge/Task.php
+++ b/CRM/Pledge/Task.php
@@ -45,8 +45,8 @@ class CRM_Pledge_Task extends CRM_Core_Task {
         self::TASK_EXPORT => [
           'title' => ts('Export pledges'),
           'class' => [
-            'CRM_Export_Form_Select',
-            'CRM_Export_Form_Map',
+            'CRM_Pledge_Export_Form_Select',
+            'CRM_Pledge_Export_Form_Map',
           ],
           'result' => FALSE,
         ],

--- a/templates/CRM/Export/Form/Select.tpl
+++ b/templates/CRM/Export/Form/Select.tpl
@@ -40,7 +40,7 @@
       {/if}
   </div>
 
-  {if $taskName eq 'Export Contacts' OR $component eq false}
+  {if $isShowMergeOptions}
   <div class="crm-section crm-export-mergeOptions-section">
     <div class="label crm-label-mergeOptions">{ts}Merge Options{/ts} {help id="id-export_merge_options"}</div>
     <div class="content crm-content-mergeOptions">


### PR DESCRIPTION
Overview
----------------------------------------
This separates out the rest of the export classes to be separate classes extending the parent. 2 functions are switched to overrride

Before
----------------------------------------
Lots of wrangling to get entity specific information. Task title involves lots of noise to do one boolean check

<img width="1274" alt="Screen Shot 2020-09-25 at 2 04 10 PM" src="https://user-images.githubusercontent.com/336308/94218780-586d5380-ff39-11ea-97a8-2467a61a30c5.png">



After
----------------------------------------
Entity specific information is on the class (partially - in progress)

Technical Details
----------------------------------------


Comments
----------------------------------------
@colemanw 
