### PR TITLE
[REF] Remove unused taskName variable

### DIFF
--- a/CRM/Activity/Form/Task.php
+++ b/CRM/Activity/Form/Task.php
@@ -48,8 +48,6 @@ class CRM_Activity_Form_Task extends CRM_Core_Form_Task {
     $values = $form->controller->exportValues($form->get('searchFormName'));
 
     $form->_task = $values['task'];
-    $activityTasks = CRM_Activity_Task::tasks();
-    $form->assign('taskName', $activityTasks[$form->_task]);
 
     $ids = [];
     if ($values['radio_ts'] == 'ts_sel') {

--- a/CRM/Campaign/Form/Task.php
+++ b/CRM/Campaign/Form/Task.php
@@ -34,9 +34,6 @@ class CRM_Campaign_Form_Task extends CRM_Core_Form_Task {
     $values = $this->controller->exportValues('Search');
 
     $this->_task = $values['task'];
-    $campaignTasks = CRM_Campaign_Task::tasks();
-    $taskName = $campaignTasks[$this->_task] ?? NULL;
-    $this->assign('taskName', $taskName);
 
     $ids = [];
     if ($values['radio_ts'] == 'ts_sel') {

--- a/CRM/Contact/Form/Task.php
+++ b/CRM/Contact/Form/Task.php
@@ -129,8 +129,6 @@ class CRM_Contact_Form_Task extends CRM_Core_Form_Task {
     $cacheKey = "civicrm search {$qfKey}";
 
     $form->_task = self::$_searchFormValues['task'] ?? NULL;
-    $crmContactTaskTasks = CRM_Contact_Task::taskTitles();
-    $form->assign('taskName', CRM_Utils_Array::value($form->_task, $crmContactTaskTasks));
 
     // all contacts or action = save a search
     if ((CRM_Utils_Array::value('radio_ts', self::$_searchFormValues) == 'ts_all') ||

--- a/CRM/Contact/Form/Task/SaveSearch.php
+++ b/CRM/Contact/Form/Task/SaveSearch.php
@@ -53,9 +53,7 @@ class CRM_Contact_Form_Task_SaveSearch extends CRM_Contact_Form_Task {
     // Get Task name
     $modeValue = CRM_Contact_Form_Search::getModeValue(CRM_Utils_Array::value('component_mode', $values, CRM_Contact_BAO_Query::MODE_CONTACTS));
     $className = $modeValue['taskClassName'];
-    $taskList = $className::taskTitles();
     $this->_task = $values['task'] ?? NULL;
-    $this->assign('taskName', CRM_Utils_Array::value($this->_task, $taskList));
   }
 
   /**

--- a/CRM/Contribute/Form/Task.php
+++ b/CRM/Contribute/Form/Task.php
@@ -58,8 +58,6 @@ class CRM_Contribute_Form_Task extends CRM_Core_Form_Task {
     $values = $form->controller->exportValues($form->get('searchFormName'));
 
     $form->_task = $values['task'] ?? NULL;
-    $contributeTasks = CRM_Contribute_Task::tasks();
-    $form->assign('taskName', CRM_Utils_Array::value($form->_task, $contributeTasks));
 
     $ids = [];
     if (isset($values['radio_ts']) && $values['radio_ts'] == 'ts_sel') {

--- a/CRM/Core/Form/Task.php
+++ b/CRM/Core/Form/Task.php
@@ -95,9 +95,6 @@ abstract class CRM_Core_Form_Task extends CRM_Core_Form {
     $searchFormValues = $form->controller->exportValues($form->get('searchFormName'));
 
     $form->_task = $searchFormValues['task'];
-    $className = 'CRM_' . ucfirst($form::$entityShortname) . '_Task';
-    $entityTasks = $className::tasks();
-    $form->assign('taskName', $entityTasks[$form->_task]);
 
     $entityIds = [];
     if ($searchFormValues['radio_ts'] == 'ts_sel') {

--- a/CRM/Event/Form/Task.php
+++ b/CRM/Event/Form/Task.php
@@ -52,7 +52,6 @@ class CRM_Event_Form_Task extends CRM_Core_Form_Task {
     if (!array_key_exists($form->_task, $tasks)) {
       CRM_Core_Error::statusBounce(ts('You do not have permission to access this page.'));
     }
-    $form->assign('taskName', $tasks[$form->_task]);
 
     $ids = [];
     if ($values['radio_ts'] == 'ts_sel') {

--- a/CRM/Grant/Form/Task.php
+++ b/CRM/Grant/Form/Task.php
@@ -46,7 +46,6 @@ class CRM_Grant_Form_Task extends CRM_Core_Form_Task {
     if (!array_key_exists($form->_task, $tasks)) {
       CRM_Core_Error::statusBounce(ts('You do not have permission to access this page.'));
     }
-    $form->assign('taskName', $tasks[$form->_task]);
 
     $ids = [];
     if ($values['radio_ts'] == 'ts_sel') {

--- a/CRM/Mailing/Form/Task.php
+++ b/CRM/Mailing/Form/Task.php
@@ -35,8 +35,6 @@ class CRM_Mailing_Form_Task extends CRM_Core_Form_Task {
     $values = $form->controller->exportValues($form->get('searchFormName'));
 
     $form->_task = $values['task'] ?? NULL;
-    $mailingTasks = CRM_Mailing_Task::tasks();
-    $form->assign('taskName', CRM_Utils_Array::value('task', $values));
 
     // ids are mailing event queue ids
     $ids = [];

--- a/CRM/Member/Form/Task.php
+++ b/CRM/Member/Form/Task.php
@@ -55,7 +55,6 @@ class CRM_Member_Form_Task extends CRM_Core_Form_Task {
     if (!array_key_exists($form->_task, $tasks)) {
       CRM_Core_Error::statusBounce(ts('You do not have permission to access this page.'));
     }
-    $form->assign('taskName', $tasks[$form->_task]);
 
     $ids = [];
     if ($values['radio_ts'] === 'ts_sel') {

--- a/CRM/Pledge/Form/Task.php
+++ b/CRM/Pledge/Form/Task.php
@@ -46,8 +46,6 @@ class CRM_Pledge_Form_Task extends CRM_Core_Form_Task {
     $values = $form->controller->exportValues('Search');
 
     $form->_task = $values['task'];
-    $pledgeTasks = CRM_Pledge_Task::tasks();
-    $form->assign('taskName', $pledgeTasks[$form->_task]);
 
     $ids = [];
     if ($values['radio_ts'] == 'ts_sel') {


### PR DESCRIPTION
Overview
----------------------------------------
This variable is only used at the tpl layer in export - there is a separate PR
to change that usage to something more meaningful
https://github.com/civicrm/civicrm-core/pull/18589

Other than that all this task assignment appears to be just cruft



Before
----------------------------------------
<img width="34" alt="Screen Shot 2020-09-25 at 2 10 52 PM" src="https://user-images.githubusercontent.com/336308/94218618-f0b70880-ff38-11ea-9663-d190edfbd6ea.png">

After
----------------------------------------
<img width="32" alt="Screen Shot 2020-09-25 at 2 11 05 PM" src="https://user-images.githubusercontent.com/336308/94218633-f7458000-ff38-11ea-9497-d2f7058a42de.png">

Task titles still visible on page...
<img width="710" alt="Screen Shot 2020-09-25 at 2 12 18 PM" src="https://user-images.githubusercontent.com/336308/94218717-23610100-ff39-11ea-9f65-3a083c27a52d.png">

Only export still refers

<img width="1274" alt="Screen Shot 2020-09-25 at 2 04 10 PM" src="https://user-images.githubusercontent.com/336308/94218650-02001500-ff39-11ea-9eb1-9c86cd55b45c.png">


Technical Details
----------------------------------------
It's likely that it precedes other ways of setting the page title

Comments
----------------------------------------

