### PR TITLE
dev/core#2066 [WIP] Add support for calling (some) contribution actions in stand alone mode

### DIFF
--- a/CRM/Activity/Export/Form/Map.php
+++ b/CRM/Activity/Export/Form/Map.php
@@ -1,0 +1,23 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+/**
+ * This class gets the name of the file to upload
+ */
+class CRM_Activity_Export_Form_Map extends CRM_Export_Form_Map {
+
+}

--- a/CRM/Activity/Export/Form/Select.php
+++ b/CRM/Activity/Export/Form/Select.php
@@ -27,4 +27,13 @@ class CRM_Activity_Export_Form_Select extends CRM_Export_Form_Select {
     CRM_Activity_Form_Task::preProcessCommon($this);
   }
 
+  /**
+   * Does this export offer contact merging.
+   *
+   * @return bool
+   */
+  protected function isShowContactMergeOptions() {
+    return FALSE;
+  }
+
 }

--- a/CRM/Activity/Export/Form/Select.php
+++ b/CRM/Activity/Export/Form/Select.php
@@ -1,0 +1,30 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+/**
+ * This class gets the name of the file to upload
+ */
+class CRM_Activity_Export_Form_Select extends CRM_Export_Form_Select {
+
+  /**
+   * Call the pre-processing function.
+   */
+  protected function callPreProcessing(): void {
+    CRM_Activity_Form_Task::preProcessCommon($this);
+  }
+
+}

--- a/CRM/Activity/Task.php
+++ b/CRM/Activity/Task.php
@@ -44,8 +44,8 @@ class CRM_Activity_Task extends CRM_Core_Task {
         self::TASK_EXPORT => [
           'title' => ts('Export activities'),
           'class' => [
-            'CRM_Export_Form_Select',
-            'CRM_Export_Form_Map',
+            'CRM_Activity_Export_Form_Select',
+            'CRM_Activity_Export_Form_Map',
           ],
           'result' => FALSE,
         ],

--- a/CRM/Contact/Export/Form/Map.php
+++ b/CRM/Contact/Export/Form/Map.php
@@ -1,0 +1,23 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+/**
+ * This class gets the name of the file to upload
+ */
+class CRM_Contact_Export_Form_Map extends CRM_Export_Form_Map {
+
+}

--- a/CRM/Contact/Export/Form/Select.php
+++ b/CRM/Contact/Export/Form/Select.php
@@ -1,0 +1,30 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+/**
+ * This class gets the name of the file to upload
+ */
+class CRM_Contact_Export_Form_Select extends CRM_Export_Form_Select {
+
+  /**
+   * Call the pre-processing function.
+   */
+  protected function callPreProcessing(): void {
+    CRM_Contact_Form_Task::preProcessCommon($this);
+  }
+
+}

--- a/CRM/Contact/Export/Form/Select.php
+++ b/CRM/Contact/Export/Form/Select.php
@@ -27,4 +27,13 @@ class CRM_Contact_Export_Form_Select extends CRM_Export_Form_Select {
     CRM_Contact_Form_Task::preProcessCommon($this);
   }
 
+  /**
+   * Does this export offer contact merging.
+   *
+   * @return bool
+   */
+  protected function isShowContactMergeOptions() {
+    return TRUE;
+  }
+
 }

--- a/CRM/Contact/Task.php
+++ b/CRM/Contact/Task.php
@@ -71,8 +71,8 @@ class CRM_Contact_Task extends CRM_Core_Task {
         self::TASK_EXPORT => array(
           'title' => ts('Export contacts'),
           'class' => array(
-            'CRM_Export_Form_Select',
-            'CRM_Export_Form_Map',
+            'CRM_Contact_Export_Form_Select',
+            'CRM_Contact_Export_Form_Map',
           ),
           'result' => FALSE,
         ),

--- a/CRM/Contribute/Controller/Task.php
+++ b/CRM/Contribute/Controller/Task.php
@@ -1,0 +1,35 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * Class CRM_Export_Controller_Standalone
+ */
+class CRM_Contribute_Controller_Task extends CRM_Core_Controller_Task {
+
+  /**
+   * Get the name used to construct the class.
+   *
+   * @return string
+   */
+  public function getEntity():string {
+    return 'Contribution';
+  }
+
+  /**
+   * Get the available tasks for the entity.
+   *
+   * @return array
+   */
+  public function getAvailableTasks():array {
+    return CRM_Contribute_Task::tasks();
+  }
+
+}

--- a/CRM/Contribute/Export/Form/Map.php
+++ b/CRM/Contribute/Export/Form/Map.php
@@ -1,0 +1,23 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+/**
+ * This class gets the name of the file to upload
+ */
+class CRM_Contribute_Export_Form_Map extends CRM_Export_Form_Map {
+
+}

--- a/CRM/Contribute/Export/Form/Select.php
+++ b/CRM/Contribute/Export/Form/Select.php
@@ -27,4 +27,13 @@ class CRM_Contribute_Export_Form_Select extends CRM_Export_Form_Select {
     CRM_Contribute_Form_Task::preProcessCommon($this);
   }
 
+  /**
+   * Does this export offer contact merging.
+   *
+   * @return bool
+   */
+  protected function isShowContactMergeOptions() {
+    return FALSE;
+  }
+
 }

--- a/CRM/Contribute/Export/Form/Select.php
+++ b/CRM/Contribute/Export/Form/Select.php
@@ -1,0 +1,30 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+/**
+ * This class gets the name of the file to upload
+ */
+class CRM_Contribute_Export_Form_Select extends CRM_Export_Form_Select {
+
+  /**
+   * Call the pre-processing function.
+   */
+  protected function callPreProcessing(): void {
+    CRM_Contribute_Form_Task::preProcessCommon($this);
+  }
+
+}

--- a/CRM/Contribute/Form/Task/Delete.php
+++ b/CRM/Contribute/Form/Task/Delete.php
@@ -88,7 +88,7 @@ class CRM_Contribute_Form_Task_Delete extends CRM_Contribute_Form_Task {
    */
   public function postProcess() {
     $deleted = $failed = 0;
-    foreach ($this->_contributionIds as $contributionId) {
+    foreach ($this->getIDs() as $contributionId) {
       if (CRM_Contribute_BAO_Contribution::deleteContribution($contributionId)) {
         $deleted++;
       }

--- a/CRM/Contribute/Form/Task/PDF.php
+++ b/CRM/Contribute/Form/Task/PDF.php
@@ -39,11 +39,11 @@ class CRM_Contribute_Form_Task_PDF extends CRM_Contribute_Form_Task {
       $this, FALSE
     );
 
-    if ($id) {
-      $this->_contributionIds = [$id];
-      $this->_componentClause = " civicrm_contribution.id IN ( $id ) ";
-      $this->_single = TRUE;
-      $this->assign('totalSelectedContributions', 1);
+    if ($this->getIDs()) {
+      $this->_contributionIds = $this->getIDs();
+      $this->_componentClause = ' civicrm_contribution.id IN ( ' . implode(',', $this->getIDs()) . ' ) ';
+      $this->_single = count($this->getIDs()) === 1;
+      $this->assign('totalSelectedContributions', count($this->getIDs()));
     }
     else {
       parent::preProcess();
@@ -139,7 +139,7 @@ AND    {$this->_componentClause}";
     $template = CRM_Core_Smarty::singleton();
 
     $params = $this->controller->exportValues($this->_name);
-    $elements = self::getElements($this->_contributionIds, $params, $this->_contactIds);
+    $elements = self::getElements($this->getIDs(), $params, $this->_contactIds);
 
     foreach ($elements['details'] as $contribID => $detail) {
       $input = $ids = [];

--- a/CRM/Contribute/Form/Task/PDFLetterCommon.php
+++ b/CRM/Contribute/Form/Task/PDFLetterCommon.php
@@ -77,7 +77,7 @@ class CRM_Contribute_Form_Task_PDFLetterCommon extends CRM_Contact_Form_Task_PDF
     // skip some contacts ?
     $skipOnHold = $form->skipOnHold ?? FALSE;
     $skipDeceased = $form->skipDeceased ?? TRUE;
-    $contributionIDs = $form->getVar('_contributionIds');
+    $contributionIDs = $form->getIDs();
     if ($form->_includesSoftCredits) {
       //@todo - comment on what is stored there
       $contributionIDs = $form->getVar('_contributionContactIds');

--- a/CRM/Contribute/Selector/Search.php
+++ b/CRM/Contribute/Selector/Search.php
@@ -445,6 +445,7 @@ class CRM_Contribute_Selector_Search extends CRM_Core_Selector_Base implements C
           'title' => $buttonName,
         ];
       }
+      $links += CRM_Contribute_Task::getContextualLinks($row);
 
       $row['action'] = CRM_Core_Action::formLink(
         $links,

--- a/CRM/Contribute/Task.php
+++ b/CRM/Contribute/Task.php
@@ -59,8 +59,8 @@ class CRM_Contribute_Task extends CRM_Core_Task {
         self::TASK_EXPORT => [
           'title' => ts('Export contributions'),
           'class' => [
-            'CRM_Export_Form_Select',
-            'CRM_Export_Form_Map',
+            'CRM_Contribute_Export_Form_Select',
+            'CRM_Contribute_Export_Form_Map',
           ],
           'result' => FALSE,
         ],

--- a/CRM/Contribute/xml/Menu/Contribute.xml
+++ b/CRM/Contribute/xml/Menu/Contribute.xml
@@ -329,4 +329,10 @@
     <page_callback>CRM_Member_Page_RecurringContributions</page_callback>
     <access_arguments>access CiviContribute</access_arguments>
   </item>
+  <item>
+    <path>civicrm/contribute/task</path>
+    <title>Contribution Task</title>
+    <page_callback>CRM_Contribute_Controller_Task</page_callback>
+    <access_arguments>access CiviContribute</access_arguments>
+  </item>
 </menu>

--- a/CRM/Core/Controller/Task.php
+++ b/CRM/Core/Controller/Task.php
@@ -1,0 +1,84 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * Class CRM_Export_Controller_Standalone
+ */
+abstract class CRM_Core_Controller_Task extends CRM_Core_Controller {
+
+  /**
+   * Class constructor.
+   *
+   * @param string $title
+   * @param bool|int $action
+   * @param bool $modal
+   *
+   * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
+   */
+  public function __construct($title = NULL, $action = CRM_Core_Action::NONE, $modal = TRUE) {
+
+    parent::__construct($title, $modal);
+    $id = explode(',', CRM_Utils_Request::retrieve('id', 'CommaSeparatedIntegers', $this, TRUE));
+
+    // Check permissions
+    $perm = civicrm_api3($this->getEntity(), 'get', [
+      'return' => 'id',
+      'options' => ['limit' => 0],
+      'check_permissions' => 1,
+      'id' => ['IN' => $id],
+    ])['values'];
+    if (empty($perm)) {
+      throw new CRM_Core_Exception(ts('No records available'));
+    }
+    $this->set('id', array_keys($perm));
+    $pages = array_fill_keys($this->getTaskClass(), NULL);
+
+    $this->_stateMachine = new CRM_Core_StateMachine($this);
+    $this->_stateMachine->addSequentialPages($pages);
+    // create and instantiate the pages
+    $this->addPages($this->_stateMachine, $action);
+    // add all the actions
+    $this->addActions();
+  }
+
+  /**
+   * Get the name used to construct the class.
+   *
+   * @return string
+   */
+  abstract public function getEntity():string;
+
+  /**
+   * Get the available tasks for the entity.
+   *
+   * @return array
+   */
+  abstract public function getAvailableTasks():array;
+
+  /**
+   * Get the class for the action.
+   *
+   * @return array Array of the classes for the form controlle.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  protected function getTaskClass(): array {
+    $task = CRM_Utils_Request::retrieve('task', 'Alphanumeric', $this, TRUE);
+    foreach ($this->getAvailableTasks() as $taskAction) {
+      if ($taskAction['key'] === $task) {
+        return (array) $taskAction['class'];
+      }
+    }
+    throw new CRM_Core_Exception(ts('Invalid task'));
+  }
+
+}

--- a/CRM/Event/Export/Form/Map.php
+++ b/CRM/Event/Export/Form/Map.php
@@ -1,0 +1,23 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+/**
+ * This class gets the name of the file to upload
+ */
+class CRM_Event_Export_Form_Map extends CRM_Export_Form_Map {
+
+}

--- a/CRM/Event/Export/Form/Select.php
+++ b/CRM/Event/Export/Form/Select.php
@@ -1,0 +1,30 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+/**
+ * This class gets the name of the file to upload
+ */
+class CRM_Event_Export_Form_Select extends CRM_Export_Form_Select {
+
+  /**
+   * Call the pre-processing function.
+   */
+  protected function callPreProcessing(): void {
+    CRM_Event_Form_Task::preProcessCommon($this);
+  }
+
+}

--- a/CRM/Event/Export/Form/Select.php
+++ b/CRM/Event/Export/Form/Select.php
@@ -27,4 +27,13 @@ class CRM_Event_Export_Form_Select extends CRM_Export_Form_Select {
     CRM_Event_Form_Task::preProcessCommon($this);
   }
 
+  /**
+   * Does this export offer contact merging.
+   *
+   * @return bool
+   */
+  protected function isShowContactMergeOptions() {
+    return FALSE;
+  }
+
 }

--- a/CRM/Event/Task.php
+++ b/CRM/Event/Task.php
@@ -60,8 +60,8 @@ class CRM_Event_Task extends CRM_Core_Task {
         self::TASK_EXPORT => [
           'title' => ts('Export participants'),
           'class' => [
-            'CRM_Export_Form_Select',
-            'CRM_Export_Form_Map',
+            'CRM_Event_Export_Form_Select',
+            'CRM_Event_Export_Form_Map',
           ],
           'result' => FALSE,
         ],

--- a/CRM/Export/Controller/Standalone.php
+++ b/CRM/Export/Controller/Standalone.php
@@ -42,7 +42,7 @@ class CRM_Export_Controller_Standalone extends CRM_Core_Controller {
       $this->set('cids', implode(',', array_keys($perm['values'])));
     }
 
-    $this->_stateMachine = new CRM_Export_StateMachine_Standalone($this, $action);
+    $this->_stateMachine = new CRM_Export_StateMachine_Standalone($this, $action, $entity);
 
     // create and instantiate the pages
     $this->addPages($this->_stateMachine, $action);

--- a/CRM/Export/Form/Select.php
+++ b/CRM/Export/Form/Select.php
@@ -96,7 +96,7 @@ class CRM_Export_Form_Select extends CRM_Core_Form_Task {
     }
     $this->_exportMode = constant('CRM_Export_Form_Select::' . strtoupper($entityShortname) . '_EXPORT');
     $formTaskClassName = "CRM_{$entityShortname}_Form_Task";
-    $taskClassName = "CRM_{$entityShortname}_Task";
+
     if (isset($formTaskClassName::$entityShortname)) {
       $this::$entityShortname = $formTaskClassName::$entityShortname;
       if (isset($formTaskClassName::$tableName)) {
@@ -124,17 +124,13 @@ class CRM_Export_Form_Select extends CRM_Core_Form_Task {
       }
     }
 
-    $formTaskClassName::preProcessCommon($this);
+    $this->callPreProcessing();
 
     // $component is used on CRM/Export/Form/Select.tpl to display extra information for contact export
     ($this->_exportMode == self::CONTACT_EXPORT) ? $component = FALSE : $component = TRUE;
     $this->assign('component', $component);
 
-    // Set the task title
-    $componentTasks = $taskClassName::taskTitles();
-    $this->_task = $values['task'];
-    $taskName = $componentTasks[$this->_task];
-    $this->assign('taskName', $taskName);
+    $this->assign('isShowMergeOptions', $this->isShowContactMergeOptions());
 
     if ($this->_componentTable) {
       $query = "
@@ -439,6 +435,20 @@ FROM   {$this->_componentTable}
    */
   public function getQueryMode() {
     return (int) ($this->queryMode ?: $this->controller->get('component_mode'));
+  }
+
+  /**
+   * Call the pre-processing function.
+   */
+  protected function callPreProcessing(): void {
+    throw new CRM_Core_Exception('This must be over-ridden');
+  }
+
+  /**
+   * Assign the title of the task to the tpl.
+   */
+  protected function isShowContactMergeOptions() {
+    throw new CRM_Core_Exception('This must be over-ridden');
   }
 
   /**

--- a/CRM/Export/Form/Select/Case.php
+++ b/CRM/Export/Form/Select/Case.php
@@ -25,4 +25,20 @@ class CRM_Export_Form_Select_Case extends CRM_Export_Form_Select {
    */
   protected $queryMode = CRM_Contact_BAO_Query::MODE_CASE;
 
+  /**
+   * Call the pre-processing function.
+   */
+  protected function callPreProcessing(): void {
+    CRM_Case_Form_Task::preProcessCommon($this);
+  }
+
+  /**
+   * Does this export offer contact merging.
+   *
+   * @return bool
+   */
+  protected function isShowContactMergeOptions() {
+    return FALSE;
+  }
+
 }

--- a/CRM/Export/StateMachine/Standalone.php
+++ b/CRM/Export/StateMachine/Standalone.php
@@ -21,13 +21,16 @@ class CRM_Export_StateMachine_Standalone extends CRM_Core_StateMachine {
    *
    * @param object $controller
    * @param \const|int $action
+   * @param string $entity
    */
-  public function __construct($controller, $action = CRM_Core_Action::NONE) {
+  public function __construct($controller, $action = CRM_Core_Action::NONE, $entity = 'Contact') {
     parent::__construct($controller, $action);
 
+    $entityMap = ['Contribution' => 'Contribute', 'Membership' => 'Member', 'Participant' => 'Event'];
+    $entity = $entityMap[$entity] ?? $entity;
     $this->_pages = [
-      'CRM_Export_Form_Select' => NULL,
-      'CRM_Export_Form_Map' => NULL,
+      'CRM_' . $entity . '_Export_Form_Select' => NULL,
+      'CRM_' . $entity . '_Export_Form_Map' => NULL,
     ];
 
     $this->addSequentialPages($this->_pages, $action);

--- a/CRM/Grant/Export/Form/Map.php
+++ b/CRM/Grant/Export/Form/Map.php
@@ -1,0 +1,23 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+/**
+ * This class gets the name of the file to upload
+ */
+class CRM_Pledge_Export_Form_Map extends CRM_Export_Form_Map {
+
+}

--- a/CRM/Grant/Export/Form/Select.php
+++ b/CRM/Grant/Export/Form/Select.php
@@ -27,4 +27,13 @@ class CRM_Grant_Export_Form_Select extends CRM_Export_Form_Select {
     CRM_Grant_Form_Task::preProcessCommon($this);
   }
 
+  /**
+   * Does this export offer contact merging.
+   *
+   * @return bool
+   */
+  protected function isShowContactMergeOptions() {
+    return FALSE;
+  }
+
 }

--- a/CRM/Grant/Export/Form/Select.php
+++ b/CRM/Grant/Export/Form/Select.php
@@ -1,0 +1,30 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+/**
+ * This class gets the name of the file to upload
+ */
+class CRM_Grant_Export_Form_Select extends CRM_Export_Form_Select {
+
+  /**
+   * Call the pre-processing function.
+   */
+  protected function callPreProcessing(): void {
+    CRM_Grant_Form_Task::preProcessCommon($this);
+  }
+
+}

--- a/CRM/Grant/Task.php
+++ b/CRM/Grant/Task.php
@@ -55,8 +55,8 @@ class CRM_Grant_Task extends CRM_Core_Task {
         self::TASK_EXPORT => [
           'title' => ts('Export grants'),
           'class' => [
-            'CRM_Export_Form_Select',
-            'CRM_Export_Form_Map',
+            'CRM_Grant_Export_Form_Select',
+            'CRM_Grant_Export_Form_Map',
           ],
           'result' => FALSE,
         ],

--- a/CRM/Member/Export/Form/Select.php
+++ b/CRM/Member/Export/Form/Select.php
@@ -20,4 +20,20 @@
  */
 class CRM_Member_Export_Form_Select extends CRM_Export_Form_Select {
 
+  /**
+   * Call the pre-processing function.
+   */
+  protected function callPreProcessing(): void {
+    CRM_Member_Form_Task::preProcessCommon($this);
+  }
+
+  /**
+   * Does this export offer contact merging.
+   *
+   * @return bool
+   */
+  protected function isShowContactMergeOptions() {
+    return FALSE;
+  }
+
 }

--- a/CRM/Pledge/Export/Form/Map.php
+++ b/CRM/Pledge/Export/Form/Map.php
@@ -1,0 +1,23 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+/**
+ * This class gets the name of the file to upload
+ */
+class CRM_Pledge_Export_Form_Map extends CRM_Export_Form_Map {
+
+}

--- a/CRM/Pledge/Export/Form/Select.php
+++ b/CRM/Pledge/Export/Form/Select.php
@@ -27,4 +27,13 @@ class CRM_Pledge_Export_Form_Select extends CRM_Export_Form_Select {
     CRM_Pledge_Form_Task::preProcessCommon($this);
   }
 
+  /**
+   * Does this export offer contact merging.
+   *
+   * @return bool
+   */
+  protected function isShowContactMergeOptions() {
+    return FALSE;
+  }
+
 }

--- a/CRM/Pledge/Export/Form/Select.php
+++ b/CRM/Pledge/Export/Form/Select.php
@@ -1,0 +1,30 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+/**
+ * This class gets the name of the file to upload
+ */
+class CRM_Pledge_Export_Form_Select extends CRM_Export_Form_Select {
+
+  /**
+   * Call the pre-processing function.
+   */
+  protected function callPreProcessing(): void {
+    CRM_Pledge_Form_Task::preProcessCommon($this);
+  }
+
+}

--- a/CRM/Pledge/Task.php
+++ b/CRM/Pledge/Task.php
@@ -45,8 +45,8 @@ class CRM_Pledge_Task extends CRM_Core_Task {
         self::TASK_EXPORT => [
           'title' => ts('Export pledges'),
           'class' => [
-            'CRM_Export_Form_Select',
-            'CRM_Export_Form_Map',
+            'CRM_Pledge_Export_Form_Select',
+            'CRM_Pledge_Export_Form_Map',
           ],
           'result' => FALSE,
         ],

--- a/templates/CRM/Export/Form/Select.tpl
+++ b/templates/CRM/Export/Form/Select.tpl
@@ -40,7 +40,7 @@
       {/if}
   </div>
 
-  {if $taskName eq 'Export Contacts' OR $component eq false}
+  {if $isShowMergeOptions}
   <div class="crm-section crm-export-mergeOptions-section">
     <div class="label crm-label-mergeOptions">{ts}Merge Options{/ts} {help id="id-export_merge_options"}</div>
     <div class="content crm-content-mergeOptions">


### PR DESCRIPTION
Overview
----------------------------------------
Preliminary work on exposing core search actions outside the context of search. The intent is they can be called from search creator but in the interests of exploration I have exposed them via search results

Before
----------------------------------------
Awkward to send a receipt - need to go via search - unavailable from search creator extension

After
----------------------------------------
Ground work done to access some contribute tasks via url - ie

civicrm/civicrm/contribute/task?reset=1&id=98,99,100&task=delete
civicrm/civicrm/contribute/task?reset=1&id=98,99,100&task=invoice

Some are exposed

<img width="689" alt="Screen Shot 2020-09-25 at 7 24 40 PM" src="https://user-images.githubusercontent.com/336308/94239381-d21b3680-ff65-11ea-9c28-881328a396e3.png">

<img width="690" alt="Screen Shot 2020-09-25 at 7 24 49 PM" src="https://user-images.githubusercontent.com/336308/94239405-dcd5cb80-ff65-11ea-9d43-c718f3a8a9ae.png">



Technical Details
----------------------------------------
This is exploratory - my main focus is the cleanup to support using tasks in standalone mode. It's distinctly glitchy at the moment & the appropriateness of exposing specific actions

Comments
----------------------------------------
I think pre-existing enotices prevents the pop-up closing for send receipt

Note - this doesn't have to stay open - I'll probably spin off some parts - currently cleanup PR https://github.com/civicrm/civicrm-core/pull/18589
