### PR TITLE
Add an 'Execute Now' button to the job log

### DIFF
--- a/CRM/Admin/Form/Job.php
+++ b/CRM/Admin/Form/Job.php
@@ -24,6 +24,7 @@ class CRM_Admin_Form_Job extends CRM_Admin_Form {
   public function preProcess() {
 
     parent::preProcess();
+    $this->setContext();
 
     CRM_Utils_System::setTitle(ts('Manage - Scheduled Jobs'));
 
@@ -194,7 +195,15 @@ class CRM_Admin_Form_Job extends CRM_Admin_Form {
       $jm->executeJobById($this->_id);
       $jobName = self::getJobName($this->_id);
       CRM_Core_Session::setStatus(ts('%1 Scheduled Job has been executed. See the log for details.', [1 => $jobName]), ts("Executed"), "success");
-      CRM_Utils_System::redirect(CRM_Utils_System::url('civicrm/admin/job', 'reset=1'));
+
+      if ($this->getContext() === 'joblog') {
+        // If we were triggered via the joblog form redirect back there when we finish
+        $redirectUrl = CRM_Utils_System::url('civicrm/admin/joblog', 'reset=1&jid=' . $this->_id);
+      }
+      else {
+        $redirectUrl = CRM_Utils_System::url('civicrm/admin/job', 'reset=1');
+      }
+      CRM_Utils_System::redirect($redirectUrl);
       return;
     }
 

--- a/CRM/Admin/Page/Job.php
+++ b/CRM/Admin/Page/Job.php
@@ -117,6 +117,9 @@ class CRM_Admin_Page_Job extends CRM_Core_Page_Basic {
     $this->_action = CRM_Utils_Request::retrieve('action', 'String',
       $this, FALSE, 0
     );
+    $this->_context = CRM_Utils_Request::retrieve('context', 'String',
+      $this, FALSE, 0
+    );
 
     if (($this->_action & CRM_Core_Action::COPY) && (!empty($this->_id))) {
       try {

--- a/CRM/Admin/Page/JobLog.php
+++ b/CRM/Admin/Page/JobLog.php
@@ -73,16 +73,16 @@ class CRM_Admin_Page_JobLog extends CRM_Core_Page_Basic {
    * Browse all jobs.
    */
   public function browse() {
-    $jid = CRM_Utils_Request::retrieve('jid', 'Positive', $this);
+    $jid = CRM_Utils_Request::retrieve('jid', 'Positive');
 
     $sj = new CRM_Core_JobManager();
 
-    $jobName = NULL;
     if ($jid) {
       $jobName = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Job', $jid);
+      $this->assign('jobName', $jobName);
+      $jobRunUrl = CRM_Utils_System::url('civicrm/admin/job', 'action=view&reset=1&context=joblog&id=' . $jid);
+      $this->assign('jobRunUrl', $jobRunUrl);
     }
-
-    $this->assign('jobName', $jobName);
 
     $dao = new CRM_Core_DAO_JobLog();
     $dao->orderBy('id desc');

--- a/templates/CRM/Admin/Page/JobLog.tpl
+++ b/templates/CRM/Admin/Page/JobLog.tpl
@@ -19,6 +19,9 @@
 
   <div class="action-link">
     <a href="{crmURL p='civicrm/admin/job' q="reset=1"}" id="jobsList-top" class="button"><span><i class="crm-i fa-chevron-left" aria-hidden="true"></i> {ts}Back to Scheduled Jobs Listing{/ts}</span></a>
+    {if $jobRunUrl}
+      <a href="{$jobRunUrl}" id="jobsList-run-top" class="button"><span><i class="crm-i fa-play" aria-hidden="true"></i> {ts}Execute Now{/ts}</span></a>
+    {/if}
   </div>
 
 {if $rows}
@@ -60,5 +63,8 @@
 
   <div class="action-link">
     <a href="{crmURL p='civicrm/admin/job' q="reset=1"}" id="jobsList-bottom" class="button"><span><i class="crm-i fa-chevron-left" aria-hidden="true"></i> {ts}Back to Scheduled Jobs Listing{/ts}</span></a>
+    {if $jobRunUrl}
+      <a href="{$jobRunUrl}" id="jobsList-run-bottom" class="button"><span><i class="crm-i fa-play" aria-hidden="true"></i> {ts}Execute Now{/ts}</span></a>
+    {/if}
   </div>
 </div>


### PR DESCRIPTION
Overview
----------------------------------------
Small improvement to useability of job forms when manually triggering a scheduled job. Reduces the number of clicks to see results.

Before
----------------------------------------
Can only "execute scheduled job" from the list of scheduled jobs. List of jobs always reloads and you have to find the job and click "View job log" to see results.

The only button on the job log is "back to scheduled jobs list" and you can't re-trigger the job without returning to the list, finding it again and clicking execute.

After
----------------------------------------
Execute now button on job log:
![image](https://user-images.githubusercontent.com/2052161/94255206-cd339400-ff1f-11ea-8add-5365c0fe65b0.png)

Still get confirmation:
![image](https://user-images.githubusercontent.com/2052161/94255266-e0defa80-ff1f-11ea-8612-4c91e19a40b7.png)

See results of job execution immediately because page reloads directly into the log:
![image](https://user-images.githubusercontent.com/2052161/94255312-f3593400-ff1f-11ea-9932-c8f411bf2a04.png)

Technical Details
----------------------------------------
Form layer adds a context to indicate which page/form should load on completion of job execution.

Comments
----------------------------------------

