### PR TITLE
Remove double exception handling in repeattransaction

### DIFF
--- a/api/v3/Contribution.php
+++ b/api/v3/Contribution.php
@@ -610,31 +610,27 @@ function civicrm_api3_contribution_repeattransaction($params) {
     'return' => 'payment_processor_id',
     'id' => $contribution->contribution_recur_id,
   ]);
-  try {
-    if (!$contribution->loadRelatedObjects($input, $ids, TRUE)) {
-      throw new API_Exception('failed to load related objects');
-    }
 
-    unset($contribution->id, $contribution->receive_date, $contribution->invoice_id);
-    $contribution->receive_date = $params['receive_date'];
-
-    $passThroughParams = [
-      'trxn_id',
-      'total_amount',
-      'campaign_id',
-      'fee_amount',
-      'financial_type_id',
-      'contribution_status_id',
-      'membership_id',
-      'payment_processor_id',
-    ];
-    $input = array_intersect_key($params, array_fill_keys($passThroughParams, NULL));
-
-    return _ipn_process_transaction($params, $contribution, $input, $ids);
+  if (!$contribution->loadRelatedObjects($input, $ids, TRUE)) {
+    throw new API_Exception('failed to load related objects');
   }
-  catch (Exception $e) {
-    throw new API_Exception('failed to load related objects' . $e->getMessage() . "\n" . $e->getTraceAsString());
-  }
+
+  unset($contribution->id, $contribution->receive_date, $contribution->invoice_id);
+  $contribution->receive_date = $params['receive_date'];
+
+  $passThroughParams = [
+    'trxn_id',
+    'total_amount',
+    'campaign_id',
+    'fee_amount',
+    'financial_type_id',
+    'contribution_status_id',
+    'membership_id',
+    'payment_processor_id',
+  ];
+  $input = array_intersect_key($params, array_fill_keys($passThroughParams, NULL));
+
+  return _ipn_process_transaction($params, $contribution, $input, $ids);
 }
 
 /**


### PR DESCRIPTION
Overview
----------------------------------------
repeattransaction is wrapped in a try/catch unnecessarily (completetransaction API is not).

Before
----------------------------------------
If an exception is thrown catch it and throw it.

After
----------------------------------------
If an exception is thrown let it be thrown.

Technical Details
----------------------------------------
`loadRelatedObjects()` will be removed soon (hopefully). It throws a couple of exceptions if things go wrong. So does `_ipn_process_transaction()`. But there is no reason to catch those exceptions and then trigger a new exception.

Comments
----------------------------------------
@eileenmcnaughton Bit more cleanup