### PR TITLE
pass in "required" value when building preferred_language form element

### DIFF
--- a/CRM/Core/BAO/UFGroup.php
+++ b/CRM/Core/BAO/UFGroup.php
@@ -2019,7 +2019,7 @@ AND    ( entity_id IS NULL OR entity_id <= 0 )
       $form->add('select', $name, $title, CRM_Core_SelectValues::pmf());
     }
     elseif ($fieldName === 'preferred_language') {
-      $form->add('select', $name, $title, ['' => ts('- select -')] + CRM_Contact_BAO_Contact::buildOptions('preferred_language'));
+      $form->add('select', $name, $title, ['' => ts('- select -')] + CRM_Contact_BAO_Contact::buildOptions('preferred_language'), $required);
     }
     elseif ($fieldName == 'external_identifier') {
       $form->add('text', $name, $title, $attributes, $required);


### PR DESCRIPTION
Overview
----------------------------------------
As per https://lab.civicrm.org/dev/core/-/issues/1883

When Preferred Language is included in a profile and marked as "required", the form does not respect the 'required' configuration setting (not required in form, not marked as required).

Before
----------------------------------------
![1181](https://user-images.githubusercontent.com/168984/94294410-ca3fa000-ff2d-11ea-9274-515f6b8a2f66.png)


After
----------------------------------------
![1181-patched](https://user-images.githubusercontent.com/168984/94294421-d0ce1780-ff2d-11ea-8135-b1e2bf8e6d26.png)


Technical Details
----------------------------------------
Appears to have been a minor coding oversight from a million years ago.

Comments
----------------------------------------
This might go down as one of the simplest PRs in the history of CiviCRM.
