### PR TITLE
[REF] IPN - move unshared chunk of code out of shared function

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4377,6 +4377,8 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
   public static function completeOrder($input, $ids, $objects, $isPostPaymentCreate = FALSE) {
     $transaction = new CRM_Core_Transaction();
     $contribution = $objects['contribution'];
+    // Unset objects just to make it clear it's not used again.
+    unset($objects);
     // @todo see if we even need this - it's used further down to create an activity
     // but the BAO layer should create that - we just need to add a test to cover it & can
     // maybe remove $ids altogether.
@@ -4418,7 +4420,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
 
     $contributionParams['payment_processor'] = $paymentProcessorId;
 
-    if (empty($contributionParams['payment_instrument_id']) && isset($contribution->_relatedObjects['paymentProcessor']['payment_instrument_id'])) {
+    if (empty($contributionParams['payment_instrument_id']) && $paymentProcessorId) {
       $contributionParams['payment_instrument_id'] = PaymentProcessor::get(FALSE)->addWhere('id', '=', $paymentProcessorId)->addSelect('payment_instrument_id')->execute()->first()['payment_instrument_id'];
     }
 


### PR DESCRIPTION

Overview
----------------------------------------
[REF] IPN - move unshared chunk of code out of shared function

Before
----------------------------------------
We are passing variables into recur simply to do this processing - but it could be done in the calling function & we could stop constructing arrays just to call it

Also a couple of unused variables

<img width="810" alt="Screen Shot 2020-09-26 at 9 43 59 AM" src="https://user-images.githubusercontent.com/336308/94319378-953f5600-ffde-11ea-9314-d23da6995116.png">


After
----------------------------------------
Closer to getting rid of $objects

Technical Details
----------------------------------------
We are passing a lot of variables into recur (& going to a lot of work to construct them) when they are not
actually processed in a common way - returning them to the calling functions makes it clear we are
a skip & a jump from not needing to instantiate objects at all

Comments
----------------------------------------
Good test cover in CRM_Core_Payment_AuthorizeNetIPNTest

This is part of the completeOrder cleanup - now that we are not passing paymentProcessor object through my definition of 'done' for this round of work is to clean up / remove how that object is loaded in the IPN functions that call completeOrder
