### PR TITLE
dev/core#2035 Invoice template - show Amount paid even when it is fully paid

### DIFF
--- a/tests/phpunit/CRM/Contribute/Form/Task/InvoiceTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/Task/InvoiceTest.php
@@ -74,8 +74,7 @@ class CRM_Contribute_Form_Task_InvoiceTest extends CiviUnitTestCase {
     $this->assertContains('PAYMENT ADVICE', $invoiceHTML[$contribution['id']]);
 
     $this->assertContains('AMOUNT DUE:</font></b></td>
-                  <td style="text-align:right;"><b><font size="1">$ 92.00</font></b></td>', $invoiceHTML[$contribution3['id']]);
-
+                <td style="text-align:right;"><b><font size="1">$ 92.00</font></b></td>', $invoiceHTML[$contribution3['id']]);
   }
 
   /**

--- a/xml/templates/message_templates/contribution_invoice_receipt_html.tpl
+++ b/xml/templates/message_templates/contribution_invoice_receipt_html.tpl
@@ -126,29 +126,28 @@
                 <td style="text-align:right;white-space: nowrap"><b><font size="1">{ts 1=$defaultCurrency}TOTAL %1{/ts}</font></b></td>
                 <td style="text-align:right;"><font size="1">{$amount|crmMoney:$currency}</font></td>
               </tr>
-             {if $amountDue != 0}
-                <tr>
-                  <td colspan="3"></td>
-                  <td style="text-align:right;white-space: nowrap"><font size="1">
-                    {if $contribution_status_id == $refundedStatusId}
-                      {ts}Amount Credited{/ts}
-                    {else}
-                      {ts}Amount Paid{/ts}
-                    {/if}
-                   </font>
-                  </td>
-                  <td style="text-align:right;"><font size="1">{$amountPaid|crmMoney:$currency}</font></td>
-                </tr>
-                <tr>
-                  <td colspan="3"></td>
-                  <td colspan="2"><hr></hr></td>
-                </tr>
-                <tr>
-                  <td colspan="3"></td>
-                  <td style="text-align:right;white-space: nowrap" ><b><font size="1">{ts}AMOUNT DUE:{/ts}</font></b></td>
-                  <td style="text-align:right;"><b><font size="1">{$amountDue|crmMoney:$currency}</font></b></td>
-                </tr>
-              {/if}
+              <tr>
+                <td colspan="3"></td>
+                <td style="text-align:right;white-space: nowrap"><font size="1">
+                  {if $contribution_status_id == $refundedStatusId}
+                    {ts}Amount Credited{/ts}
+                  {else}
+                    {ts}Amount Paid{/ts}
+                  {/if}
+                 </font>
+                </td>
+                <td style="text-align:right;"><font size="1">{$amountPaid|crmMoney:$currency}</font></td>
+              </tr>
+              <tr>
+                <td colspan="3"></td>
+                <td colspan="2"><hr></hr></td>
+              </tr>
+              <tr>
+                <td colspan="3"></td>
+                <td style="text-align:right;white-space: nowrap" ><b><font size="1">{ts}AMOUNT DUE:{/ts}</font></b></td>
+                <td style="text-align:right;"><b><font size="1">{$amountDue|crmMoney:$currency}</font></b></td>
+              </tr>
+
               <br/><br/><br/>
               <tr>
                 <td colspan="5"></td>


### PR DESCRIPTION
Overview
----------------------------------------
Fixes invoice template so that Amount due displays (again) for fully paid invoices

<img src='https://lab.civicrm.org/dev/core/uploads/0be08c217b658a1886c73bbb12d3f922/9-15-2020_12-10-09_PM.png'/>


https://lab.civicrm.org/dev/core/-/issues/2035


Before
----------------------------------------
In 5.24 [this change](https://github.com/civicrm/civicrm-core/pull/16680/files?w=1#diff-b211e0dac858fdad5d480c118d645e0bR129) altered the if from
'show amount paid & due depending on pay-later status' to 'show amount paid & due depending on whether payment is due'

This has been experienced as a regression and, being an invoice, there seems no reason to only change it sometimes.



After
----------------------------------------
Display of Paid amount / Amount Due 'always on'

Technical Details
----------------------------------------
This change just alters the template that new installs will receive. If approved another step is needed to update existing
installs (unless they have customised the template)

Comments
----------------------------------------
@magnolia61 @lcdservices @jitendrapurohit 