### PR TITLE
[REF] Fix Syntax on contribution online receipt text

### DIFF
--- a/CRM/Upgrade/Incremental/MessageTemplates.php
+++ b/CRM/Upgrade/Incremental/MessageTemplates.php
@@ -225,7 +225,13 @@ class CRM_Upgrade_Incremental_MessageTemplates {
           ['name' => 'event_online_receipt', 'type' => 'text'],
         ],
       ],
-
+      [
+        'version' => '5.31.alpha1',
+        'upgrade_descriptor' => ts('Fix Smarty syntax on contribution receipt text'),
+        'templates' => [
+          ['name' => 'contribution_online_receipt', 'type' => 'text'],
+        ],
+      ],
     ];
   }
 

--- a/xml/templates/message_templates/contribution_online_receipt_text.tpl
+++ b/xml/templates/message_templates/contribution_online_receipt_text.tpl
@@ -53,7 +53,6 @@
 {else}
 {ts}Amount{/ts}: {$amount|crmMoney:$currency} {if $amount_level } - {$amount_level} {/if}
 {/if}
-{/if}
 {if $receive_date}
 
 {ts}Date{/ts}: {$receive_date|crmDate}

--- a/xml/templates/message_templates/contribution_online_receipt_text.tpl
+++ b/xml/templates/message_templates/contribution_online_receipt_text.tpl
@@ -53,6 +53,7 @@
 {else}
 {ts}Amount{/ts}: {$amount|crmMoney:$currency} {if $amount_level } - {$amount_level} {/if}
 {/if}
+{/if}
 {if $receive_date}
 
 {ts}Date{/ts}: {$receive_date|crmDate}
@@ -83,7 +84,6 @@
 
 {$updateSubscriptionUrl}
 
-{/if}
 {/if}
 
 {if $honor_block_is_active}


### PR DESCRIPTION
Overview
----------------------------------------
This fixes a syntax error that I found with a recently installed site

Before
----------------------------------------
Unmatched {\if}

After
----------------------------------------
poof

@eileenmcnaughton @demeritcowboy Can someone confirm my thinking that this is wrong?