### PR TITLE
dev/core#1393 - distmaker - Skip new file "vendor/bin/pscss"

### DIFF
--- a/distmaker/dists/common.sh
+++ b/distmaker/dists/common.sh
@@ -53,7 +53,7 @@ function dm_remove_files() {
   shift
 
   for file in "$@" ; do
-    [ -f "$tgt/$file" ] && rm -f "$tgt/$file"
+    [ -f "$tgt/$file" -o -L "$tgt/$file" ] && rm -f "$tgt/$file"
   done
 }
 
@@ -208,6 +208,8 @@ function dm_install_vendor() {
 
   [ ! -d "$to" ] && mkdir "$to"
   ${DM_RSYNC:-rsync} -avC $excludes_rsync "$repo/./" "$to/./"
+  ## We don't this use CLI script in production, and the symlink breaks D7/BD URL installs
+  dm_remove_files "$to" "bin/pscss"
 }
 
 ##  usage: dm_install_wordpress <wp_repo_path> <to_path>


### PR DESCRIPTION
Overview
----------------------------------------

This fixes the broken distmaker builds in `master`.

The file `vendor/bin/pscss` was recently added by way of `scssphp`.  We don't need it in the tarball, and it's  a symlink, so trying to include breaks some consumers (like in https://lab.civicrm.org/dev/core/-/issues/1393).

ping @seamuslee001 

Technical Details
----------------------------------------

* Before (last release): `vendor/bin/pscss` does not exist
* Before (current master): `vendor/bin/pscss` is created as symlink, copied to tarball
* After (this commit): `vendor/bin/pscss` is created on dev-builds but omitted from tarball
