### PR TITLE
dev/core#2039 [REF] Follow up cleanup from Event Location

### DIFF
--- a/CRM/Core/BAO/Address.php
+++ b/CRM/Core/BAO/Address.php
@@ -29,33 +29,20 @@ class CRM_Core_BAO_Address extends CRM_Core_DAO_Address {
    *   True if you need to fix (format) address values.
    *                               before inserting in db
    *
-   * @param null $entity
-   *
    * @return array|NULL
    *   array of created address
    */
-  public static function create(&$params, $fixAddress = TRUE, $entity = NULL) {
+  public static function create(&$params, $fixAddress = TRUE) {
     if (!isset($params['address']) || !is_array($params['address'])) {
       return NULL;
     }
     CRM_Core_BAO_Block::sortPrimaryFirst($params['address']);
-    $addresses = [];
     $contactId = NULL;
 
     $updateBlankLocInfo = CRM_Utils_Array::value('updateBlankLocInfo', $params, FALSE);
-    if (!$entity) {
-      $contactId = $params['contact_id'];
-      //get all the addresses for this contact
-      $addresses = self::allAddress($contactId);
-    }
-    else {
-      // get all address from location block
-      $entityElements = [
-        'entity_table' => $params['entity_table'],
-        'entity_id' => $params['entity_id'],
-      ];
-      $addresses = self::allEntityAddress($entityElements);
-    }
+    $contactId = $params['contact_id'];
+    //get all the addresses for this contact
+    $addresses = self::allAddress($contactId);
 
     $isPrimary = $isBilling = TRUE;
     $blocks = [];

--- a/CRM/Core/BAO/Block.php
+++ b/CRM/Core/BAO/Block.php
@@ -193,13 +193,11 @@ class CRM_Core_BAO_Block {
    *   Block name.
    * @param array $params
    *   Array of name/value pairs.
-   * @param string $entity
-   * @param int $contactId
    *
    * @return array|null
    *   Array of created location entities or NULL if none to create.
    */
-  public static function create($blockName, $params, $entity = NULL, $contactId = NULL) {
+  public static function create($blockName, $params) {
     if (!self::blockExists($blockName, $params)) {
       return NULL;
     }
@@ -210,15 +208,7 @@ class CRM_Core_BAO_Block {
     $resetPrimaryId = NULL;
     $primaryId = FALSE;
 
-    if ($entity) {
-      $entityElements = [
-        'entity_table' => $params['entity_table'],
-        'entity_id' => $params['entity_id'],
-      ];
-    }
-    else {
-      $contactId = $params['contact_id'];
-    }
+    $contactId = $params['contact_id'];
 
     $updateBlankLocInfo = CRM_Utils_Array::value('updateBlankLocInfo', $params, FALSE);
     $isIdSet = CRM_Utils_Array::value('isIdSet', $params[$blockName], FALSE);

--- a/tests/phpunit/CRM/Core/BAO/AddressTest.php
+++ b/tests/phpunit/CRM/Core/BAO/AddressTest.php
@@ -50,7 +50,7 @@ class CRM_Core_BAO_AddressTest extends CiviUnitTestCase {
 
     $fixAddress = TRUE;
 
-    CRM_Core_BAO_Address::create($params, $fixAddress, $entity = NULL);
+    CRM_Core_BAO_Address::create($params, $fixAddress);
     $addressId = $this->assertDBNotNull('CRM_Core_DAO_Address', 'Oberoi Garden', 'id', 'street_address',
       'Database check for created address.'
     );
@@ -76,7 +76,7 @@ class CRM_Core_BAO_AddressTest extends CiviUnitTestCase {
     ];
     $params['contact_id'] = $contactId;
 
-    $block = CRM_Core_BAO_Address::create($params, $fixAddress, $entity = NULL);
+    $block = CRM_Core_BAO_Address::create($params, $fixAddress);
 
     $this->assertDBNotNull('CRM_Core_DAO_Address', $contactId, 'id', 'contact_id',
       'Database check for updated address by contactId.'
@@ -253,7 +253,7 @@ class CRM_Core_BAO_AddressTest extends CiviUnitTestCase {
 
     $fixAddress = TRUE;
 
-    CRM_Core_BAO_Address::create($params, $fixAddress, $entity = NULL);
+    CRM_Core_BAO_Address::create($params, $fixAddress);
 
     $addressId = $this->assertDBNotNull('CRM_Core_DAO_Address', $contactId, 'id', 'contact_id',
       'Database check for created address.'


### PR DESCRIPTION
Overview
----------------------------------------
CRM_Core_BAO_Block::create & CRM_Core_BAO_Address::create are no longer called with the entity param
- remove support


Before
----------------------------------------
$entity param supported but never passed in

After
----------------------------------------
poof

<img width="1273" alt="Screen Shot 2020-09-26 at 3 32 29 PM" src="https://user-images.githubusercontent.com/336308/94329286-c5eab400-000d-11eb-9591-00594059a0f9.png">
<img width="1260" alt="Screen Shot 2020-09-26 at 3 33 19 PM" src="https://user-images.githubusercontent.com/336308/94329287-c8e5a480-000d-11eb-99f8-af1f6c25968a.png">

Technical Details
----------------------------------------
Usage removed in https://github.com/civicrm/civicrm-core/pull/18586

Comments
----------------------------------------
I did earlier do universe searches
