### PR TITLE
dev/drupal#119 - Avoid crash from recursion on unhandled exceptions

### DIFF
--- a/CRM/Core/Error.php
+++ b/CRM/Core/Error.php
@@ -529,11 +529,14 @@ class CRM_Core_Error extends PEAR_ErrorStack {
         $out = "\$$variable_name = $out";
       }
       else {
-        // use var_dump
-        ob_start();
-        var_dump($variable);
-        $dump = ob_get_contents();
-        ob_end_clean();
+        // Use Symfony var-dumper to avoid circular references that exhaust
+        // memory when using var_dump().
+        // Use its CliDumper since if we use the simpler `dump()` then it
+        // comes out as some overly decorated html which is hard to read.
+        $dump = (new \Symfony\Component\VarDumper\Dumper\CliDumper('php://output'))
+          ->dump(
+            (new \Symfony\Component\VarDumper\Cloner\VarCloner())->cloneVar($variable),
+            TRUE);
         $out = "\n\$$variable_name = $dump";
       }
       // reset if it is an array

--- a/composer.json
+++ b/composer.json
@@ -52,6 +52,7 @@
     "symfony/event-dispatcher": "~3.0 || ~4.4",
     "symfony/filesystem": "~3.0 || ~4.4",
     "symfony/process": "~3.0 || ~4.4",
+    "symfony/var-dumper": "~3.0 || ~4.4",
     "psr/log": "~1.0",
     "symfony/finder": "~3.0 || ~4.4",
     "tecnickcom/tcpdf" : "6.3.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2a5c933954791a798ec0f50db504c476",
+    "content-hash": "5b823c420fc0d96c61731dd45a7d2e3e",
     "packages": [
         {
             "name": "adrienrn/php-mimetyper",
@@ -242,7 +242,7 @@
                 {
                     "name": "Tobias Nyholm",
                     "email": "tobias.nyholm@gmail.com",
-                    "homepage": "https://github.com/Nyholm"
+                    "homepage": "https://github.com/nyholm"
                 },
                 {
                     "name": "Nicolas Grekas",
@@ -3004,6 +3004,89 @@
             "time": "2020-04-12T14:33:46+00:00"
         },
         {
+            "name": "symfony/var-dumper",
+            "version": "v3.4.44",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/var-dumper.git",
+                "reference": "3e31b82077039b1ea3b5a203ec1e3016606f4484"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/3e31b82077039b1ea3b5a203ec1e3016606f4484",
+                "reference": "3e31b82077039b1ea3b5a203ec1e3016606f4484",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5.9|>=7.0.8",
+                "symfony/polyfill-mbstring": "~1.0"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0"
+            },
+            "require-dev": {
+                "ext-iconv": "*",
+                "twig/twig": "~1.34|~2.4"
+            },
+            "suggest": {
+                "ext-iconv": "To convert non-UTF-8 strings to UTF-8 (or symfony/polyfill-iconv in case ext-iconv cannot be used).",
+                "ext-intl": "To show region name in time zone dump",
+                "ext-symfony_debug": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.4-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "Resources/functions/dump.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Component\\VarDumper\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony mechanism for exploring and dumping PHP variables",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "debug",
+                "dump"
+            ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-08-17T07:27:37+00:00"
+        },
+        {
             "name": "tecnickcom/tcpdf",
             "version": "6.3.5",
             "source": {
@@ -3593,5 +3676,6 @@
     "platform-dev": [],
     "platform-overrides": {
         "php": "7.1"
-    }
+    },
+    "plugin-api-version": "1.1.0"
 }


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/drupal/-/issues/119

It mostly happens on drupal 8 because the exception includes extra recursive stuff which var_dump chokes on.

To trigger it if you're impatient you can edit CRM/Core/Form.php and at the top of buildForm() add `throw new \ErrorException('hello');` and then visit any form.

It comes up any time there's an unhandled exception, so it doesn't happen for exceptions that display civi error messages. For me it's usually from some custom code.

Before
----------------------------------------
Hangs. Nothing useful in logs.

After
----------------------------------------
Log output.

Technical Details
----------------------------------------
Uses symfony/var-dumper instead.

Comments
----------------------------------------
I can't figure out how to get composer to apply just an update from a subpackage where you've updated the subpackage's composer.json, so for testing drupal 8 I just added the var-dumper line to the main composer.json and ran `composer update symfony/var-dumper`. On drupal 7 it works normally just running composer install inside the civi folder.

Related https://github.com/civicrm/civicrm-core/pull/17300, but everyone seems to like symfony.

Note that for normal logging you get something a little different than you're used to seeing in logs, but it's similar, e.g. what might look like this before:

```
$foo = object(stdClass)#1112 (4) {
  ["foo"]=>
  string(3) "faa"
  ["me"]=>
  array(1) {
    ["circular"]=>
    *RECURSION*
  }
  ["int_thing"]=>
  int(4)
  ["bool_thing"]=>
  bool(false)
}
```

now looks like

```
$foo = {#1112
  +"foo": "faa"
  +"me": array:1 [
    "circular" => {#1112}
  ]
  +"int_thing": 4
  +"bool_thing": false
}
```