### PR TITLE
Simplify call to loadRelatedObjects in repeat/completetransaction

### DIFF
--- a/api/v3/Contribution.php
+++ b/api/v3/Contribution.php
@@ -471,23 +471,15 @@ function _civicrm_api3_contribution_sendconfirmation_spec(&$params) {
  * @throws \Exception
  */
 function civicrm_api3_contribution_completetransaction($params) {
-  $input = $ids = [];
-
   $contribution = new CRM_Contribute_BAO_Contribution();
   $contribution->id = $params['id'];
   if (!$contribution->find(TRUE)) {
     throw new API_Exception('A valid contribution ID is required', 'invalid_data');
   }
-
-  if (isset($params['payment_processor_id'])) {
-    $input['payment_processor_id'] = $params['payment_processor_id'];
-  }
-  if (!$contribution->loadRelatedObjects($input, $ids, TRUE)) {
-    throw new API_Exception('failed to load related objects');
-  }
-  elseif ($contribution->contribution_status_id == CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Completed')) {
+  if ($contribution->contribution_status_id == CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Completed')) {
     throw new API_Exception(ts('Contribution already completed'), 'contribution_completed');
   }
+
   $params['trxn_id'] = $params['trxn_id'] ?? $contribution->trxn_id;
 
   $passThroughParams = [
@@ -496,6 +488,11 @@ function civicrm_api3_contribution_completetransaction($params) {
     'trxn_id',
   ];
   $input = array_intersect_key($params, array_fill_keys($passThroughParams, NULL));
+
+  $ids = [];
+  if (!$contribution->loadRelatedObjects(['payment_processor_id' => $input['payment_processor_id'] ?? NULL], $ids, TRUE)) {
+    throw new API_Exception('failed to load related objects');
+  }
 
   return _ipn_process_transaction($params, $contribution, $input, $ids);
 }
@@ -580,7 +577,6 @@ function _civicrm_api3_contribution_completetransaction_spec(&$params) {
  * @throws API_Exception
  */
 function civicrm_api3_contribution_repeattransaction($params) {
-  $input = $ids = [];
   civicrm_api3_verify_one_mandatory($params, NULL, ['contribution_recur_id', 'original_contribution_id']);
   if (empty($params['original_contribution_id'])) {
     //  CRM-19873 call with test mode.
@@ -606,17 +602,10 @@ function civicrm_api3_contribution_repeattransaction($params) {
     );
   }
 
-  $input['payment_processor_id'] = $params['payment_processor_id'] = civicrm_api3('contributionRecur', 'getvalue', [
+  $params['payment_processor_id'] = civicrm_api3('contributionRecur', 'getvalue', [
     'return' => 'payment_processor_id',
     'id' => $contribution->contribution_recur_id,
   ]);
-
-  if (!$contribution->loadRelatedObjects($input, $ids, TRUE)) {
-    throw new API_Exception('failed to load related objects');
-  }
-
-  unset($contribution->id, $contribution->receive_date, $contribution->invoice_id);
-  $contribution->receive_date = $params['receive_date'];
 
   $passThroughParams = [
     'trxn_id',
@@ -629,6 +618,13 @@ function civicrm_api3_contribution_repeattransaction($params) {
     'payment_processor_id',
   ];
   $input = array_intersect_key($params, array_fill_keys($passThroughParams, NULL));
+
+  $ids = [];
+  if (!$contribution->loadRelatedObjects(['payment_processor_id' => $input['payment_processor_id']], $ids, TRUE)) {
+    throw new API_Exception('failed to load related objects');
+  }
+  unset($contribution->id, $contribution->receive_date, $contribution->invoice_id);
+  $contribution->receive_date = $params['receive_date'];
 
   return _ipn_process_transaction($params, $contribution, $input, $ids);
 }


### PR DESCRIPTION
Overview
----------------------------------------
We're trying to remove loadRelatedObjects call from complete/repeattransaction but it's still a bit tangled up.

This simplifies it's usage in complete/repeattransaction and will make it easier to remove in a future step. There is still a bit of dis-entangling to do in `_ipn_process_transaction` before removing the call altogether.

Before
----------------------------------------
Less clear.

After
----------------------------------------
More clear. Technically there is a change in that for completetransaction the "Contribution already completed" exception will be thrown when previously the "failed to load related objects" might have triggered first - that doesn't seem like a problem though!

Technical Details
----------------------------------------


Comments
----------------------------------------
@eileenmcnaughton Small step towards removal.