### PR TITLE
Fix regression on back-office membership renewal by credit card

### DIFF
--- a/CRM/Member/Form.php
+++ b/CRM/Member/Form.php
@@ -358,19 +358,19 @@ class CRM_Member_Form extends CRM_Contribute_Form_AbstractEditPayment {
    *
    * @param array $contributionRecurParams
    *
-   * @param int $membershipID
+   * @param int $membershipTypeID
    *
    * @return array
    * @throws \CiviCRM_API3_Exception
    */
-  protected function processRecurringContribution($contributionRecurParams, $membershipID) {
+  protected function processRecurringContribution($contributionRecurParams, $membershipTypeID) {
 
     $mapping = [
       'frequency_interval' => 'duration_interval',
       'frequency_unit' => 'duration_unit',
     ];
     $membershipType = civicrm_api3('MembershipType', 'getsingle', [
-      'id' => $membershipID,
+      'id' => $membershipTypeID,
       'return' => $mapping,
     ]);
 

--- a/CRM/Member/Form/MembershipRenewal.php
+++ b/CRM/Member/Form/MembershipRenewal.php
@@ -553,7 +553,7 @@ class CRM_Member_Form_MembershipRenewal extends CRM_Member_Form {
           'is_email_receipt' => !empty($this->_params['send_receipt']),
           'payment_instrument_id' => $this->_params['payment_instrument_id'],
           'invoice_id' => $this->_params['invoice_id'],
-        ], $membershipID = $paymentParams['membership_type_id'][1]);
+        ], $paymentParams['membership_type_id'][1]);
 
         $contributionRecurID = $contributionRecurParams['contributionRecurID'];
         $paymentParams = array_merge($paymentParams, $contributionRecurParams);


### PR DESCRIPTION


Overview
----------------------------------------
Looking at the code I realised a mistake was made in  https://github.com/civicrm/civicrm-core/pull/17398 whereby
the actual membership id would not be passed through correctly

Before
----------------------------------------
```$membershipID = $paymentParams['membership_type_id'][1]``` is passed in as $membershipID

After
----------------------------------------
```
$this->_membershipId
```

passed in

Technical Details
----------------------------------------
Looks like a copy & paste error

Comments
----------------------------------------

