### PR TITLE
dev/membership#28 Fix pay-later membership renewal for more than one term

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -437,11 +437,7 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution {
       [1 => [$contributionID, 'Integer'], 2 => [$membershipTypeID, 'Integer']]
     );
     $result->fetch();
-    if (!$result->membership_num_terms) {
-      Civi::log()->debug('membership num terms not set in corresponding line items, assuming 1 but could indicate an issue, contribution id ' . $contributionID . '  membership type id ' . $membershipTypeID);
-      $result->membership_num_terms = 1;
-    }
-    return $result->membership_num_terms * $result->qty;
+    return ($result->membership_num_terms ?? 1) * ($result->qty ?? 1);
   }
 
   /**

--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -1565,14 +1565,28 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
       else {
         $params['cancel_date'] = $params['cancel_reason'] = 'null';
       }
-
+      $newContributionStatus = CRM_Core_PseudoConstant::getName('CRM_Contribute_BAO_Contribution', 'contribution_status_id', $params['contribution_status_id']);
       // Set is_pay_later flag for back-office offline Pending status contributions CRM-8996
       // else if contribution_status is changed to Completed is_pay_later flag is changed to 0, CRM-15041
-      if ($params['contribution_status_id'] == CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Pending')) {
+      if ($newContributionStatus === 'Pending') {
         $params['is_pay_later'] = 1;
       }
-      elseif ($params['contribution_status_id'] == CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Completed')) {
+      elseif ($newContributionStatus === 'Completed') {
         $params['is_pay_later'] = 0;
+        if ($this->_id) {
+          $amountToPay = CRM_Contribute_BAO_Contribution::getContributionBalance($this->_id);
+          if ($amountToPay) {
+            civicrm_api3('Payment', 'create', [
+              'contribution_id' => $this->_id,
+              'payment_instrument_id' => $params['payment_instrument_id'],
+              'check_number' => $params['check_number'] ?? '',
+              'trxn_date' => $params['receive_date'],
+              'total_amount' => $amountToPay,
+            ]);
+            unset($params['contribution_status_id']);
+            $params['is_post_payment_create'] = TRUE;
+          }
+        }
       }
 
       // Add Additional common information to formatted params.
@@ -1601,7 +1615,8 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
       $contribution = CRM_Contribute_BAO_Contribution::create($params);
 
       // process associated membership / participant, CRM-4395
-      if ($contribution->id && $action & CRM_Core_Action::UPDATE) {
+      // This is no longer be called for completed
+      if ($contribution->id && $action & CRM_Core_Action::UPDATE && empty($params['is_post_payment_create'])) {
         $this->statusMessage[] = CRM_Contribute_BAO_Contribution::transitionComponentWithReturnMessage($contribution->id,
           $contribution->contribution_status_id,
           CRM_Utils_Array::value('contribution_status_id',

--- a/CRM/Financial/BAO/Order.php
+++ b/CRM/Financial/BAO/Order.php
@@ -62,6 +62,30 @@ class CRM_Financial_BAO_Order {
   protected $overrideTotalAmount;
 
   /**
+   * Override for quantity.
+   *
+   * This would be used in the context of membership where we have a
+   * total amount override and a number of terms.
+   *
+   * @var int
+   */
+  protected $overrideQuantity;
+
+  /**
+   * @return int
+   */
+  public function getOverrideQuantity(): int {
+    return $this->overrideQuantity;
+  }
+
+  /**
+   * @param int $overrideQuantity
+   */
+  public function setOverrideQuantity(int $overrideQuantity): void {
+    $this->overrideQuantity = $overrideQuantity;
+  }
+
+  /**
    * Line items in the order.
    *
    * @var array
@@ -255,11 +279,13 @@ class CRM_Financial_BAO_Order {
         if ($taxRate) {
           // Total is tax inclusive.
           $lineItem['tax_amount'] = ($taxRate / 100) * $this->getOverrideTotalAmount() / (1 + ($taxRate / 100));
-          $lineItem['line_total'] = $lineItem['unit_price'] = $this->getOverrideTotalAmount() - $lineItem['tax_amount'];
+          $lineItem['line_total'] = $this->getOverrideTotalAmount() - $lineItem['tax_amount'];
         }
         else {
-          $lineItem['line_total'] = $lineItem['unit_price'] = $this->getOverrideTotalAmount();
+          $lineItem['line_total'] = $this->getOverrideTotalAmount();
         }
+        $lineItem['qty'] = $this->getOverrideQuantity() ?? 1;
+        $lineItem['unit_price'] = $lineItem['line_total'] / $lineItem['qty'];
       }
       elseif ($taxRate) {
         $lineItem['tax_amount'] = ($taxRate / 100) * $lineItem['line_total'];

--- a/CRM/Financial/BAO/Order.php
+++ b/CRM/Financial/BAO/Order.php
@@ -72,9 +72,9 @@ class CRM_Financial_BAO_Order {
   protected $overrideQuantity;
 
   /**
-   * @return int
+   * @return int|null
    */
-  public function getOverrideQuantity(): int {
+  public function getOverrideQuantity() {
     return $this->overrideQuantity;
   }
 

--- a/CRM/Member/Form/MembershipRenewal.php
+++ b/CRM/Member/Form/MembershipRenewal.php
@@ -811,6 +811,10 @@ class CRM_Member_Form_MembershipRenewal extends CRM_Member_Form {
     $order->setPriceSetID(self::getPriceSetID($this->_params));
     $order->setOverrideTotalAmount($this->_params['total_amount']);
     $order->setOverrideFinancialTypeID((int) $this->_params['financial_type_id']);
+    $numRenewTerms = $this->_params['num_terms'] ?? 1;
+    if ($numRenewTerms > 1) {
+      $order->setOverrideQuantity($numRenewTerms);
+    }
     return [
       'lineItems' => [$this->_priceSetId => $order->getLineItems()],
       // This is one of those weird & wonderful legacy params we aim to get rid of.

--- a/CRM/Price/BAO/PriceFieldValue.php
+++ b/CRM/Price/BAO/PriceFieldValue.php
@@ -78,6 +78,9 @@ class CRM_Price_BAO_PriceFieldValue extends CRM_Price_DAO_PriceFieldValue {
     }
     elseif (!$id) {
       CRM_Core_DAO::setCreateDefaults($params, self::getDefaults());
+      if (!empty($params['membership_type_id']) && !isset($params['membership_num_terms'])) {
+        $params['membership_num_terms'] = 1;
+      }
     }
 
     $financialType = $params['financial_type_id'] ?? NULL;

--- a/Civi/Test/Api3TestTrait.php
+++ b/Civi/Test/Api3TestTrait.php
@@ -218,7 +218,7 @@ trait Api3TestTrait {
    *
    * @return array|int
    */
-  public function callAPISuccessGetSingle($entity, $params, $checkAgainst = NULL) {
+  public function callAPISuccessGetSingle($entity, $params = [], $checkAgainst = NULL) {
     $params += [
       'version' => $this->_apiversion,
     ];

--- a/tests/phpunit/api/v3/MembershipTest.php
+++ b/tests/phpunit/api/v3/MembershipTest.php
@@ -186,7 +186,7 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
     // Pending Membership Status
     $pendingMembershipId = array_search('Pending', $memStatus);
     // New Membership Status
-    $newMembershipId = array_search('test status', $memStatus);
+    $newMembershipId = array_search('New', $memStatus);
 
     $membershipParam = [
       'membership_type_id' => $this->_membershipTypeID,
@@ -202,13 +202,11 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
     $membershipID1 = $this->contactMembershipCreate($membershipParam);
 
     // Pending Payment Status
-    $ContributionCreate = $this->callAPISuccess('Contribution', 'create', [
+    $ContributionCreate = $this->callAPISuccess('Order', 'create', [
       'financial_type_id' => '1',
       'total_amount' => 100,
       'contact_id' => $contactId1,
       'payment_instrument_id' => CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'payment_instrument_id', 'Check'),
-      'contribution_status_id' => 2,
-      'is_pay_later' => 1,
       'receive_date' => date('Ymd'),
     ]);
     $this->callAPISuccess('MembershipPayment', 'create', [
@@ -254,9 +252,7 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
       CRM_Core_Action::UPDATE);
 
     // check for Membership 1
-    $params = ['id' => $membershipID1];
-    $membership1 = $this->callAPISuccess('membership', 'get', $params);
-    $result1 = $membership1['values'][$membershipID1];
+    $result1 = $this->callAPISuccessGetSingle('Membership', ['id' => $membershipID1]);
     $this->assertEquals($result1['contact_id'], $contactId1);
     $this->assertEquals($result1['status_id'], $newMembershipId);
 


### PR DESCRIPTION
Overview
----------------------------------------
Alternate to https://github.com/civicrm/civicrm-core/pull/18582

Before
----------------------------------------
Per
https://github.com/civicrm/civicrm-core/pull/18582

After
----------------------------------------
Per
https://github.com/civicrm/civicrm-core/pull/18582

Technical Details
----------------------------------------
@jamie-tillman I've taken your fix & come up with a slightly different take. The difference is mostly that the line items are calculated correctly on the MembershipRenewal form using the BAO_Order object, which is fixed to handle this. The BAO_Order object is a new-ish object, currently only used on that form, intended to provide cleaner internal civicrm methods for calculating line items 

I also switched up the getNumTermsByContributionAndMembershipType slightly - mostly because the CONVERT seemed a bit weird. I think test cover is good enough that we'll get fails if it's not safe to assume qty / num_membership_terms if non-empty - but will see what Jenkins says ....


Comments
----------------------------------------

Adds test cover
