### PR TITLE
Enotice fix

### DIFF
--- a/CRM/Member/BAO/MembershipType.php
+++ b/CRM/Member/BAO/MembershipType.php
@@ -823,7 +823,7 @@ class CRM_Member_BAO_MembershipType extends CRM_Member_DAO_MembershipType {
     if (!Civi::cache('metadata')->has($cacheString)) {
       $types = civicrm_api3('MembershipType', 'get', ['options' => ['limit' => 0, 'sort' => 'weight']])['values'];
       $taxRates = CRM_Core_PseudoConstant::getTaxRates();
-      $keys = ['description', 'relationship_type_id', 'relationship_direction', 'max_related'];
+      $keys = ['description', 'relationship_type_id', 'relationship_direction', 'max_related', 'auto_renew'];
       // In order to avoid down-stream e-notices we undo api v3 filtering of NULL values. This is covered
       // in Unit tests & ideally we might switch to apiv4 but I would argue we should build caching
       // of metadata entities like this directly into apiv4.


### PR DESCRIPTION
Overview
----------------------------------------
Fixes an e-notice

Before
----------------------------------------
<img width="628" alt="Screen Shot 2020-09-28 at 10 46 51 AM" src="https://user-images.githubusercontent.com/336308/94377172-d0c35700-017b-11eb-8236-91e675628761.png">


After
----------------------------------------
poof

Technical Details
----------------------------------------
Sets the key to NULL rather than leaving it unset

Comments
----------------------------------------

