### PR TITLE
dev/membership#27 Update outdated membership statuses in preProcess rather than submit

### DIFF
--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -1125,13 +1125,13 @@ AND civicrm_membership.is_test = %2";
    *   Reference to the array.
    *   containing all values of
    *   the current membership
-   * @param string $changeToday
+   * @param string|null $changeToday
    *   In case today needs
    *   to be customised, null otherwise
    *
    * @throws \CRM_Core_Exception
    */
-  public static function fixMembershipStatusBeforeRenew(&$currentMembership, $changeToday) {
+  public static function fixMembershipStatusBeforeRenew(&$currentMembership, $changeToday = NULL) {
     $today = 'now';
     if ($changeToday) {
       $today = CRM_Utils_Date::processDate($changeToday, NULL, FALSE, 'Y-m-d');
@@ -1150,8 +1150,6 @@ AND civicrm_membership.is_test = %2";
     if (empty($status) || empty($status['id'])) {
       throw new CRM_Core_Exception(ts('Oops, it looks like there is no valid membership status corresponding to the membership start and end dates for this membership. Contact the site administrator for assistance.'));
     }
-
-    $currentMembership['today_date'] = $today;
 
     if ($status['id'] !== $currentMembership['status_id']) {
       $oldStatus = $currentMembership['status_id'];
@@ -1181,10 +1179,7 @@ AND civicrm_membership.is_test = %2";
           $currentMembership['end_date'],
           $format
         ),
-        'modified_date' => CRM_Utils_Date::customFormat(
-          $currentMembership['today_date'],
-          $format
-        ),
+        'modified_date' => date('Y-m-d H:i:s', strtotime($today)),
         'membership_type_id' => $currentMembership['membership_type_id'],
         'max_related' => $currentMembership['max_related'] ?? 0,
       ];

--- a/CRM/Member/Form/MembershipRenewal.php
+++ b/CRM/Member/Form/MembershipRenewal.php
@@ -137,10 +137,11 @@ class CRM_Member_Form_MembershipRenewal extends CRM_Member_Form {
     $this->assign('formClass', 'membershiprenew');
     parent::preProcess();
 
-    $this->assign('endDate', CRM_Utils_Date::customFormat(CRM_Core_DAO::getFieldValue('CRM_Member_DAO_Membership',
-      $this->_id, 'end_date'
-    )
-    ));
+    // @todo - we should store this as a property & re-use in setDefaults - for now that's a bigger change.
+    $currentMembership = civicrm_api3('Membership', 'getsingle', ['id' => $this->_id]);
+    CRM_Member_BAO_Membership::fixMembershipStatusBeforeRenew($currentMembership);
+
+    $this->assign('endDate', $currentMembership['end_date']);
     $this->assign('membershipStatus',
       CRM_Core_DAO::getFieldValue('CRM_Member_DAO_MembershipStatus',
         CRM_Core_DAO::getFieldValue('CRM_Member_DAO_Membership',
@@ -769,9 +770,6 @@ class CRM_Member_Form_MembershipRenewal extends CRM_Member_Form {
       ]);
       return CRM_Member_BAO_Membership::create($memParams);
     }
-
-    // Check and fix the membership if it is STALE
-    CRM_Member_BAO_Membership::fixMembershipStatusBeforeRenew($currentMembership, $changeToday);
 
     $isMembershipCurrent = CRM_Core_DAO::getFieldValue('CRM_Member_DAO_MembershipStatus', $currentMembership['status_id'], 'is_current_member');
 

--- a/templates/CRM/Member/Form/MembershipRenewal.tpl
+++ b/templates/CRM/Member/Form/MembershipRenewal.tpl
@@ -68,7 +68,7 @@
       </tr>
       <tr class="crm-member-membershiprenew-form-block-end_date">
         <td class="label">{ts}Membership End Date{/ts}</td>
-        <td class="html-adjust">&nbsp;{$endDate}</td>
+        <td class="html-adjust">&nbsp;{$endDate|crmDate}</td>
       </tr>
       <tr class="crm-member-membershiprenew-form-block-renewal_date">
         <td class="label">{$form.renewal_date.label}</td>


### PR DESCRIPTION
Overview
----------------------------------------
Moves the updating of any expired memberships from after the form is submitted to when it is loaded - - resulting in an accurate status showing on the form and also simplified code

Also addresses an unreleased regression found in the process


Before
----------------------------------------
fixMembershipBeforeRenew is called (in some flows) in the postProcess. If it is out of date the out-of-date status is displayed when the form loads

<img width="815" alt="Screen Shot 2020-09-28 at 1 11 29 PM" src="https://user-images.githubusercontent.com/336308/94379349-29025500-018c-11eb-9f39-d9a529870111.png">


After
----------------------------------------
fixMembershipBeforeRenew is always called in preProcess - resulting in an accurate status showing on the form and also simplified code

<img width="822" alt="Screen Shot 2020-09-28 at 1 08 30 PM" src="https://user-images.githubusercontent.com/336308/94379276-bd1fec80-018b-11eb-8dfa-af42dde7877b.png">


Technical Details
----------------------------------------

Per https://lab.civicrm.org/dev/membership/-/issues/27 the function fixMembershipBeforeRenew is agreed to be a useful part of the Membership renewal form flow

(ie we should set to expired before renewing if that is the correct pre-renewal status). As discussed on that
issue this moves that handling to the pre-process function.

In the process I hit what appears to be an unreleased regression affecting fixMembershipBeforeRenew borking
when changeDate = NULL from https://github.com/civicrm/civicrm-core/commit/2cb6497039fde605f5d64b2fe4fa0548cd5d1e07#diff-f43c8498e32f5b2d68ab27bcd243ca36L1136

The regression only affects master & is fixed in this line https://github.com/civicrm/civicrm-core/pull/18621/files#diff-f43c8498e32f5b2d68ab27bcd243ca36L1184

I also moved formatting of end_date to the tpl layer

Comments
----------------------------------------
I did look at calling 'Membership.create' with skipStatusCalc = FALSE  but it needs to be tweaked to support that without passing in dates (which I could have done but I felt it was better to clean up separately)
