### PR TITLE
Add options to Mail Account settings to improve inbound mail processing

### DIFF
--- a/CRM/Admin/Form/MailSettings.php
+++ b/CRM/Admin/Form/MailSettings.php
@@ -70,6 +70,8 @@ class CRM_Admin_Form_MailSettings extends CRM_Admin_Form {
     ];
     $this->add('select', 'is_default', ts('Used For?'), $usedfor);
     $this->addField('activity_status', ['placeholder' => FALSE]);
+
+    $this->add('checkbox', 'is_contact_creation_disabled_if_no_match', ts('Do not create new contacts when filing emails'));
   }
 
   /**
@@ -146,6 +148,7 @@ class CRM_Admin_Form_MailSettings extends CRM_Admin_Form {
       'is_ssl',
       'is_default',
       'activity_status',
+      'is_contact_creation_disabled_if_no_match',
     ];
 
     $params = [];
@@ -153,6 +156,7 @@ class CRM_Admin_Form_MailSettings extends CRM_Admin_Form {
       if (in_array($f, [
         'is_default',
         'is_ssl',
+        'is_contact_creation_disabled_if_no_match',
       ])) {
         $params[$f] = CRM_Utils_Array::value($f, $formValues, FALSE);
       }

--- a/CRM/Admin/Form/MailSettings.php
+++ b/CRM/Admin/Form/MailSettings.php
@@ -71,6 +71,7 @@ class CRM_Admin_Form_MailSettings extends CRM_Admin_Form {
     $this->add('select', 'is_default', ts('Used For?'), $usedfor);
     $this->addField('activity_status', ['placeholder' => FALSE]);
 
+    $this->add('checkbox', 'is_non_case_email_skipped', ts('Skip emails which do not have a Case ID or Case hash'));
     $this->add('checkbox', 'is_contact_creation_disabled_if_no_match', ts('Do not create new contacts when filing emails'));
   }
 
@@ -148,6 +149,7 @@ class CRM_Admin_Form_MailSettings extends CRM_Admin_Form {
       'is_ssl',
       'is_default',
       'activity_status',
+      'is_non_case_email_skipped',
       'is_contact_creation_disabled_if_no_match',
     ];
 
@@ -156,6 +158,7 @@ class CRM_Admin_Form_MailSettings extends CRM_Admin_Form {
       if (in_array($f, [
         'is_default',
         'is_ssl',
+        'is_non_case_email_skipped',
         'is_contact_creation_disabled_if_no_match',
       ])) {
         $params[$f] = CRM_Utils_Array::value($f, $formValues, FALSE);
@@ -168,7 +171,7 @@ class CRM_Admin_Form_MailSettings extends CRM_Admin_Form {
     $params['domain_id'] = CRM_Core_Config::domainID();
 
     // assign id only in update mode
-    $status = ts('Your New  Email Settings have been saved.');
+    $status = ts('Your New Email Settings have been saved.');
     if ($this->_action & CRM_Core_Action::UPDATE) {
       $params['id'] = $this->_id;
       $status = ts('Your Email Settings have been updated.');

--- a/CRM/Upgrade/Incremental/php/FiveThirtyOne.php
+++ b/CRM/Upgrade/Incremental/php/FiveThirtyOne.php
@@ -67,6 +67,17 @@ class CRM_Upgrade_Incremental_php_FiveThirtyOne extends CRM_Upgrade_Incremental_
     $this->addTask('Activate core extension "Greenwich"', 'installGreenwich');
   }
 
+  /**
+   * Upgrade function.
+   *
+   * @param string $rev
+   */
+  public function upgrade_5_31_0($rev) {
+    $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
+    $this->addTask('Add is_contact_creation_disabled_if_no_match column to civicrm_mail_settings', 'addColumn',
+      'civicrm_mail_settings', 'is_contact_creation_disabled_if_no_match', "TINYINT DEFAULT 0 NOT NULL COMMENT 'If this option is enabled, CiviCRM will not create new contacts when filing emails'");
+  }
+
   public static function enableEwaySingleExtension(CRM_Queue_TaskContext $ctx) {
     $eWAYPaymentProcessorType = CRM_Core_DAO::singleValueQuery("SELECT id FROM civicrm_payment_processor_type WHERE class_name = 'Payment_eWAY'");
     if ($eWAYPaymentProcessorType) {

--- a/CRM/Upgrade/Incremental/php/FiveThirtyOne.php
+++ b/CRM/Upgrade/Incremental/php/FiveThirtyOne.php
@@ -74,6 +74,8 @@ class CRM_Upgrade_Incremental_php_FiveThirtyOne extends CRM_Upgrade_Incremental_
    */
   public function upgrade_5_31_0($rev) {
     $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
+    $this->addTask('Add is_non_case_email_skipped column to civicrm_mail_settings', 'addColumn',
+      'civicrm_mail_settings', 'is_non_case_email_skipped', "TINYINT DEFAULT 0 NOT NULL COMMENT 'Skip emails which do not have a Case ID or Case hash'");
     $this->addTask('Add is_contact_creation_disabled_if_no_match column to civicrm_mail_settings', 'addColumn',
       'civicrm_mail_settings', 'is_contact_creation_disabled_if_no_match', "TINYINT DEFAULT 0 NOT NULL COMMENT 'If this option is enabled, CiviCRM will not create new contacts when filing emails'");
   }

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -1271,6 +1271,28 @@ abstract class CRM_Utils_Hook {
   }
 
   /**
+   * This hook is called when getting case email subject patterns.
+   *
+   * All emails related to cases have case hash/id in the subject, e.g:
+   * [case #ab12efg] Magic moment
+   * [case #1234] Magic is here
+   *
+   * Using this hook you can replace/enrich default list with some other
+   * patterns, e.g. include case type categories (see CiviCase extension) like:
+   * [(case|project|policy initiative) #hash]
+   * [(case|project|policy initiative) #id]
+   *
+   * @param array $subjectPatterns
+   *   Cases related email subject regexp patterns.
+   *
+   * @return mixed
+   */
+  public static function caseEmailSubjectPatterns(&$subjectPatterns) {
+    return self::singleton()
+      ->invoke(['caseEmailSubjectPatterns'], $subjectPatterns, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, 'civicrm_caseEmailSubjectPatterns');
+  }
+
+  /**
    * This hook is called soon after the CRM_Core_Config object has ben initialized.
    * You can use this hook to modify the config object and hence behavior of CiviCRM dynamically.
    *

--- a/CRM/Utils/Mail/CaseMail.php
+++ b/CRM/Utils/Mail/CaseMail.php
@@ -1,0 +1,127 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+/**
+ * Class CRM_Utils_Mail_CaseMail.
+ */
+class CRM_Utils_Mail_CaseMail {
+
+  /**
+   * A word that is used for cases by default (in email subject).
+   *
+   * @var string
+   */
+  private $caseLabel = 'case';
+
+  /**
+   * Default cases related email subject regexp patterns.
+   *
+   * All emails related to cases have case hash/id in the subject, e.g:
+   * [case #ab12efg] Magic moment
+   * [case #1234] Magic is here
+   * This variable is defined in constructor.
+   *
+   * @var array|string[]
+   */
+  private $subjectPatterns = [];
+
+  /**
+   * Cases related email subject regexp patterns extended by hooks.
+   *
+   * @var array|string[]
+   */
+  private $subjectPatternsHooked = [];
+
+  /**
+   * CRM_Utils_Mail_CaseMail constructor.
+   */
+  public function __construct() {
+    $this->subjectPatterns = [
+      '/\[' . $this->caseLabel . ' #([0-9a-f]{7})\]/i',
+      '/\[' . $this->caseLabel . ' #(\d+)\]/i',
+    ];
+  }
+
+  /**
+   * Checks if email is related to cases.
+   *
+   * @param string $subject
+   *   Email subject.
+   *
+   * @return bool
+   *   TRUE if email subject contains case ID or case hash, FALSE otherwise.
+   */
+  public function isCaseEmail ($subject) {
+    $subject = trim($subject);
+    $patterns = $this->getSubjectPatterns();
+    $res = FALSE;
+
+    for ($i = 0; !$res && $i < count($patterns); $i++) {
+      $res = preg_match($patterns[$i], $subject) === 1;
+    }
+
+    return $res;
+  }
+
+  /**
+   * Returns cases related email subject patterns.
+   *
+   * These patterns could be used to check if email is related to cases.
+   *
+   * @return array|string[]
+   */
+  public function getSubjectPatterns() {
+    // Allow others to change patterns using hook.
+    if (empty($this->subjectPatternsHooked)) {
+      $patterns = $this->subjectPatterns;
+      CRM_Utils_Hook::caseEmailSubjectPatterns($patterns);
+      $this->subjectPatternsHooked = $patterns;
+    }
+
+    return !empty($this->subjectPatternsHooked)
+      ? $this->subjectPatternsHooked
+      : $this->subjectPatterns;
+  }
+
+  /**
+   * Returns value of some class property.
+   *
+   * @param string $name
+   *   Property name.
+   *
+   * @return mixed|null
+   *   Property value or null if property does not exist.
+   */
+  public function get($name) {
+    return $this->{$name} ?? NULL;
+  }
+
+  /**
+   * Sets value of some class property.
+   *
+   * @param string $name
+   *   Property name.
+   * @param mixed $value
+   *   New property value.
+   */
+  public function set($name, $value) {
+    if (isset($this->{$name})) {
+      $this->{$name} = $value;
+    }
+  }
+
+}

--- a/CRM/Utils/Mail/EmailProcessor.php
+++ b/CRM/Utils/Mail/EmailProcessor.php
@@ -157,7 +157,7 @@ class CRM_Utils_Mail_EmailProcessor {
     try {
       $store = CRM_Mailing_MailStore::getStore($dao->name);
     }
-    catch (Exception$e) {
+    catch (Exception $e) {
       $message = ts('Could not connect to MailStore for ') . $dao->username . '@' . $dao->server . '<p>';
       $message .= ts('Error message: ');
       $message .= '<pre>' . $e->getMessage() . '</pre><p>';
@@ -226,7 +226,8 @@ class CRM_Utils_Mail_EmailProcessor {
         if ($usedfor == 0 || $is_create_activities) {
           // if its the activities that needs to be processed ..
           try {
-            $mailParams = CRM_Utils_Mail_Incoming::parseMailingObject($mail);
+            $createContact = !($dao->is_contact_creation_disabled_if_no_match ?? FALSE);
+            $mailParams = CRM_Utils_Mail_Incoming::parseMailingObject($mail, $createContact, FALSE);
           }
           catch (Exception $e) {
             echo $e->getMessage();
@@ -241,6 +242,7 @@ class CRM_Utils_Mail_EmailProcessor {
           if (!empty($dao->activity_status)) {
             $params['status_id'] = $dao->activity_status;
           }
+
           $result = civicrm_api('activity', 'create', $params);
 
           if ($result['is_error']) {

--- a/CRM/Utils/Mail/EmailProcessor.php
+++ b/CRM/Utils/Mail/EmailProcessor.php
@@ -224,6 +224,15 @@ class CRM_Utils_Mail_EmailProcessor {
 
         // preseve backward compatibility
         if ($usedfor == 0 || $is_create_activities) {
+          // Mail account may have 'Skip emails which do not have a Case ID
+          // or Case hash' option, if its enabled and email is not related
+          // to cases - then we need to put email to ignored folder.
+          $caseMailUtils = new CRM_Utils_Mail_CaseMail();
+          if (!empty($dao->is_non_case_email_skipped) && !$caseMailUtils->isCaseEmail($mail->subject)) {
+            $store->markIgnored($key);
+            continue;
+          }
+
           // if its the activities that needs to be processed ..
           try {
             $createContact = !($dao->is_contact_creation_disabled_if_no_match ?? FALSE);

--- a/templates/CRM/Admin/Form/MailSettings.tpl
+++ b/templates/CRM/Admin/Form/MailSettings.tpl
@@ -9,62 +9,71 @@
 *}
 {* this template is used for adding/editing email settings.  *}
 <div class="crm-block crm-form-block crm-mail-settings-form-block">
-<div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
-{if $action eq 8}
-  <div class="messages status no-popup">
+  <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
+  {if $action eq 8}
+    <div class="messages status no-popup">
       {icon icon="fa-info-circle"}{/icon}
-  {ts}WARNING: Deleting this option will result in the loss of mail settings data.{/ts} {ts}Do you want to continue?{/ts}
-  </div>
+      {ts}WARNING: Deleting this option will result in the loss of mail settings data.{/ts} {ts}Do you want to continue?{/ts}
+    </div>
     <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
-{else}
+  {else}
     <table class="form-layout-compressed">
 
-  <tr class="crm-mail-settings-form-block-name"><td class="label">{$form.name.label}</td><td>{$form.name.html}</td></tr>
-  <tr><td class="label">&nbsp;</td><td class="description">{ts}Name of this group of settings.{/ts}</td></tr>
+      <tr class="crm-mail-settings-form-block-name"><td class="label">{$form.name.label}</td><td>{$form.name.html}</td></tr>
+      <tr><td class="label">&nbsp;</td><td class="description">{ts}Name of this group of settings.{/ts}</td></tr>
 
-  <tr class="crm-mail-settings-form-block-server"><td class="label">{$form.server.label}</td><td>{$form.server.html}</td></tr>
-  <tr><td class="label">&nbsp;</td><td class="description">{ts}Name or IP address of mail server machine.{/ts}</td></tr>
+      <tr class="crm-mail-settings-form-block-server"><td class="label">{$form.server.label}</td><td>{$form.server.html}</td></tr>
+      <tr><td class="label">&nbsp;</td><td class="description">{ts}Name or IP address of mail server machine.{/ts}</td></tr>
 
-  <tr class="crm-mail-settings-form-block-username"><td class="label">{$form.username.label}</td><td>{$form.username.html}</td></tr>
-  <tr><td class="label">&nbsp;</td><td class="description">{ts}Username to use when polling (for IMAP and POP3).{/ts}</td></tr>
+      <tr class="crm-mail-settings-form-block-username"><td class="label">{$form.username.label}</td><td>{$form.username.html}</td></tr>
+      <tr><td class="label">&nbsp;</td><td class="description">{ts}Username to use when polling (for IMAP and POP3).{/ts}</td></tr>
 
-  <tr class="crm-mail-settings-form-block-password"><td class="label">{$form.password.label}</td><td>{$form.password.html}</td></tr>
-  <tr><td class="label">&nbsp;</td><td class="description">{ts}Password to use when polling (for IMAP and POP3).{/ts}</td></tr>
+      <tr class="crm-mail-settings-form-block-password"><td class="label">{$form.password.label}</td><td>{$form.password.html}</td></tr>
+      <tr><td class="label">&nbsp;</td><td class="description">{ts}Password to use when polling (for IMAP and POP3).{/ts}</td></tr>
 
-  <tr class="crm-mail-settings-form-block-localpart"><td class="label">{$form.localpart.label}</td><td>{$form.localpart.html}</td></tr>
-  <tr><td class="label">&nbsp;</td><td class="description">{ts}Optional local part (e.g., 'civimail+' for addresses like civimail+s.1.2@example.com).{/ts}</td></tr>
+      <tr class="crm-mail-settings-form-block-localpart"><td class="label">{$form.localpart.label}</td><td>{$form.localpart.html}</td></tr>
+      <tr><td class="label">&nbsp;</td><td class="description">{ts}Optional local part (e.g., 'civimail+' for addresses like civimail+s.1.2@example.com).{/ts}</td></tr>
 
-  <tr class="crm-mail-settings-form-block-domain"><td class="label">{$form.domain.label}</td><td>{$form.domain.html}</td></tr>
-  <tr><td class="label">&nbsp;</td><td class="description">{ts}Email address domain (the part after @).{/ts}</td></tr>
+      <tr class="crm-mail-settings-form-block-domain"><td class="label">{$form.domain.label}</td><td>{$form.domain.html}</td></tr>
+      <tr><td class="label">&nbsp;</td><td class="description">{ts}Email address domain (the part after @).{/ts}</td></tr>
 
-  <tr class="crm-mail-settings-form-block-return_path"><td class="label">{$form.return_path.label}</td><td>{$form.return_path.html}</td><tr>
-        <tr><td class="label">&nbsp;</td><td class="description">{ts}Contents of the Return-Path header.{/ts}</td></tr>
+      <tr class="crm-mail-settings-form-block-return_path"><td class="label">{$form.return_path.label}</td><td>{$form.return_path.html}</td><tr>
+      <tr><td class="label">&nbsp;</td><td class="description">{ts}Contents of the Return-Path header.{/ts}</td></tr>
 
-  <tr class="crm-mail-settings-form-block-protocol"><td class="label">{$form.protocol.label}</td><td>{$form.protocol.html}</td></tr>
-  <tr><td class="label">&nbsp;</td><td class="description">{ts}Name of the protocol to use for polling.{/ts}</td></tr>
+      <tr class="crm-mail-settings-form-block-protocol"><td class="label">{$form.protocol.label}</td><td>{$form.protocol.html}</td></tr>
+      <tr><td class="label">&nbsp;</td><td class="description">{ts}Name of the protocol to use for polling.{/ts}</td></tr>
 
-  <tr class="crm-mail-settings-form-block-source"><td class="label">{$form.source.label}</td><td>{$form.source.html}</td></tr>
-  <tr><td class="label">&nbsp;</td><td class="description">{ts}Folder to poll from when using IMAP (will default to INBOX when empty), path to poll from when using Maildir, etc..{/ts}</td></tr>
+      <tr class="crm-mail-settings-form-block-source"><td class="label">{$form.source.label}</td><td>{$form.source.html}</td></tr>
+      <tr><td class="label">&nbsp;</td><td class="description">{ts}Folder to poll from when using IMAP (will default to INBOX when empty), path to poll from when using Maildir, etc..{/ts}</td></tr>
 
-  <tr class="crm-mail-settings-form-block-is_ssl"><td class="label">{$form.is_ssl.label}</td><td>{$form.is_ssl.html}</td></tr>
-  <tr><td class="label">&nbsp;</td><td class="description">{ts}Whether to use SSL for IMAP and POP3 or not.{/ts}</td></tr>
+      <tr class="crm-mail-settings-form-block-is_ssl"><td class="label">{$form.is_ssl.label}</td><td>{$form.is_ssl.html}</td></tr>
+      <tr><td class="label">&nbsp;</td><td class="description">{ts}Whether to use SSL for IMAP and POP3 or not.{/ts}</td></tr>
 
-  <tr class="crm-mail-settings-form-block-is_default"><td class="label">{$form.is_default.label}</td><td>{$form.is_default.html}</td></tr>
-  <tr><td class="label">&nbsp;</td><td class="description">{ts}How this mail account will be used. Only one box may be used for bounce processing. It will also be used as the envelope email when sending mass mailings.{/ts}</td></tr>
+      <tr class="crm-mail-settings-form-block-is_default"><td class="label">{$form.is_default.label}</td><td>{$form.is_default.html}</td></tr>
+      <tr><td class="label">&nbsp;</td><td class="description">{ts}How this mail account will be used. Only one box may be used for bounce processing. It will also be used as the envelope email when sending mass mailings.{/ts}</td></tr>
 
-  <tr class="crm-mail-settings-form-block-activity_status"><td class="label">{$form.activity_status.label}</td><td>{$form.activity_status.html}</td></tr>
+      <tr class="crm-mail-settings-form-block-is_contact_creation_disabled_if_no_match"><td class="label">&nbsp;</td><td>{$form.is_contact_creation_disabled_if_no_match.html}{$form.is_contact_creation_disabled_if_no_match.label}</td></tr>
+
+      <tr class="crm-mail-settings-form-block-activity_status"><td class="label">&nbsp;</td><td>{$form.activity_status.label}<div>{$form.activity_status.html}</div></td></tr>
     </table>
-  <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
-{/if}
+
+    <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
+  {/if}
 </div>
+
 {literal}
 <script type="text/javascript">
   CRM.$(function($) {
     var $form = $('form.{/literal}{$form.formClass}{literal}');
-    function showActivityStatus() {
-      $('.crm-mail-settings-form-block-activity_status', $form).toggle($(this).val() === '0');
+    function showActivityFields() {
+      var fields = [
+        '.crm-mail-settings-form-block-activity_status',
+        '.crm-mail-settings-form-block-is_contact_creation_disabled_if_no_match',
+      ];
+
+      $(fields.join(', '), $form).toggle($(this).val() === '0');
     }
-    $('select[name=is_default]').each(showActivityStatus).change(showActivityStatus);
+    $('select[name="is_default"]').each(showActivityFields).change(showActivityFields);
   });
 </script>
 {/literal}

--- a/templates/CRM/Admin/Form/MailSettings.tpl
+++ b/templates/CRM/Admin/Form/MailSettings.tpl
@@ -52,7 +52,9 @@
       <tr class="crm-mail-settings-form-block-is_default"><td class="label">{$form.is_default.label}</td><td>{$form.is_default.html}</td></tr>
       <tr><td class="label">&nbsp;</td><td class="description">{ts}How this mail account will be used. Only one box may be used for bounce processing. It will also be used as the envelope email when sending mass mailings.{/ts}</td></tr>
 
-      <tr class="crm-mail-settings-form-block-is_contact_creation_disabled_if_no_match"><td class="label">&nbsp;</td><td>{$form.is_contact_creation_disabled_if_no_match.html}{$form.is_contact_creation_disabled_if_no_match.label}</td></tr>
+      <tr class="crm-mail-settings-form-block-is_non_case_email_skipped"><td class="label">&nbsp;</td><td>{$form.is_non_case_email_skipped.html}{$form.is_non_case_email_skipped.label} {help id='is_non_case_email_skipped'}</td></tr>
+
+      <tr class="crm-mail-settings-form-block-is_contact_creation_disabled_if_no_match"><td class="label">&nbsp;</td><td>{$form.is_contact_creation_disabled_if_no_match.html}{$form.is_contact_creation_disabled_if_no_match.label} {help id='is_contact_creation_disabled_if_no_match'}</td></tr>
 
       <tr class="crm-mail-settings-form-block-activity_status"><td class="label">&nbsp;</td><td>{$form.activity_status.label}<div>{$form.activity_status.html}</div></td></tr>
     </table>
@@ -68,9 +70,9 @@
     function showActivityFields() {
       var fields = [
         '.crm-mail-settings-form-block-activity_status',
+        '.crm-mail-settings-form-block-is_non_case_email_skipped',
         '.crm-mail-settings-form-block-is_contact_creation_disabled_if_no_match',
       ];
-
       $(fields.join(', '), $form).toggle($(this).val() === '0');
     }
     $('select[name="is_default"]').each(showActivityFields).change(showActivityFields);

--- a/templates/CRM/Admin/Page/MailSettings.hlp
+++ b/templates/CRM/Admin/Page/MailSettings.hlp
@@ -1,0 +1,30 @@
+{*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+*}
+
+{htxt id="is_non_case_email_skipped-title"}
+  {ts}Skip emails which do not have a Case ID or Case hash{/ts}
+{/htxt}
+
+{htxt id="is_non_case_email_skipped"}
+  <p>{ts}CiviCRM has functionality to file emails which contain the Case ID or Case Hash in the subject line in the format [case #1234] against a case record.{/ts}</p>
+  <p>{ts}Where the Case ID or Case Hash is not included CiviCRM will file the email against the contact record, by matching the email addresses on the email with any email addresses of Contact records in CiviCRM.{/ts}</p>
+  <p>{ts}Enabling this option will have CiviCRM skip any emails that do not have the Case ID or Case Hash so that the system will only process emails that can be placed on case records.{/ts}</p>
+  <p>{ts}Any emails that are not processed will be moved to the ignored folder.{/ts}</p>
+  <p>{ts}If email is skipped, no activities or contacts ("from"/"to"/"cc"/"bcc") will be created.{/ts}</p>
+{/htxt}
+
+{htxt id="is_contact_creation_disabled_if_no_match-title"}
+  {ts}Do not create new contacts when filing emails{/ts}
+{/htxt}
+
+{htxt id="is_contact_creation_disabled_if_no_match"}
+  <p>{ts}If this option is enabled, CiviCRM will not create new contacts ("from"/"to"/"cc"/"bcc") when filing emails.{/ts}</p>
+  <p>{ts}If the email subject contains a valid Case ID or Case hash, the email will be filed against the case.{/ts}</p>
+{/htxt}

--- a/tests/phpunit/CRM/Utils/Mail/EmailProcessorTest.php
+++ b/tests/phpunit/CRM/Utils/Mail/EmailProcessorTest.php
@@ -169,4 +169,37 @@ class CRM_Utils_Mail_EmailProcessorTest extends CiviUnitTestCase {
     $this->eventQueue = $this->callAPISuccess('MailingEventQueue', 'get', ['api.MailingEventQueue.create' => ['hash' => 'aaaaaaaaaaaaaaaa']]);
   }
 
+  /**
+   * Set up mail account with 'Do not create new contacts when filing emails'
+   * option enabled.
+   */
+  public function setUpDoNotCreateContact() {
+    $this->callAPISuccess('MailSettings', 'get', [
+      'api.MailSettings.create' => [
+        'name' => 'mailbox',
+        'protocol' => 'Localdir',
+        'source' => __DIR__ . '/data/mail',
+        'domain' => 'example.com',
+        'is_default' => '0',
+        'is_contact_creation_disabled_if_no_match' => TRUE,
+      ],
+    ]);
+  }
+
+  /**
+   * Test case email processing when is_non_case_email_skipped is enabled.
+   */
+  public function testInboundProcessingDoNotCreateContact() {
+    $this->setUpDoNotCreateContact();
+    $mail = 'test_non_cases_email.eml';
+
+    copy(__DIR__ . '/data/inbound/' . $mail, __DIR__ . '/data/mail/' . $mail);
+    $this->callAPISuccess('job', 'fetch_activities', []);
+    $result = civicrm_api3('Contact', 'get', [
+      'sequential' => 1,
+      'email' => "from@test.test",
+    ]);
+    $this->assertEmpty($result['values']);
+  }
+
 }

--- a/tests/phpunit/CRM/Utils/Mail/EmailProcessorTest.php
+++ b/tests/phpunit/CRM/Utils/Mail/EmailProcessorTest.php
@@ -37,7 +37,19 @@ class CRM_Utils_Mail_EmailProcessorTest extends CiviUnitTestCase {
   public function tearDown() {
     CRM_Utils_File::cleanDir(__DIR__ . '/data/mail');
     parent::tearDown();
-    $this->quickCleanup(['civicrm_group', 'civicrm_group_contact', 'civicrm_mailing', 'civicrm_mailing_job', 'civicrm_mailing_event_bounce', 'civicrm_mailing_event_queue', 'civicrm_mailing_group', 'civicrm_mailing_recipients', 'civicrm_contact', 'civicrm_email']);
+    $this->quickCleanup([
+      'civicrm_group',
+      'civicrm_group_contact',
+      'civicrm_mailing',
+      'civicrm_mailing_job',
+      'civicrm_mailing_event_bounce',
+      'civicrm_mailing_event_queue',
+      'civicrm_mailing_group',
+      'civicrm_mailing_recipients',
+      'civicrm_contact',
+      'civicrm_email',
+      'civicrm_activity',
+    ]);
   }
 
   /**
@@ -139,7 +151,6 @@ class CRM_Utils_Mail_EmailProcessorTest extends CiviUnitTestCase {
   }
 
   /**
-   *
    * Wrapper to check for mailing bounces.
    *
    * Normally we would call $this->callAPISuccessGetCount but there is not one & there is resistance to
@@ -167,6 +178,55 @@ class CRM_Utils_Mail_EmailProcessorTest extends CiviUnitTestCase {
     $this->createMailing(['scheduled_date' => 'now', 'groups' => ['include' => [$groupID]]]);
     $this->callAPISuccess('job', 'process_mailing', []);
     $this->eventQueue = $this->callAPISuccess('MailingEventQueue', 'get', ['api.MailingEventQueue.create' => ['hash' => 'aaaaaaaaaaaaaaaa']]);
+  }
+
+  /**
+   * Set up mail account with 'Skip emails which do not have a Case ID or
+   * Case hash' option enabled.
+   */
+  public function setUpSkipNonCasesEmail() {
+    $this->callAPISuccess('MailSettings', 'get', [
+      'api.MailSettings.create' => [
+        'name' => 'mailbox',
+        'protocol' => 'Localdir',
+        'source' => __DIR__ . '/data/mail',
+        'domain' => 'example.com',
+        'is_default' => '0',
+        'is_non_case_email_skipped' => TRUE,
+      ],
+    ]);
+  }
+
+  /**
+   * Test case email processing when is_non_case_email_skipped is enabled.
+   */
+  public function testInboundProcessingCaseEmail() {
+    $this->setUpSkipNonCasesEmail();
+    $mail = 'test_cases_email.eml';
+
+    copy(__DIR__ . '/data/inbound/' . $mail, __DIR__ . '/data/mail/' . $mail);
+    $this->callAPISuccess('job', 'fetch_activities', []);
+    $result = civicrm_api3('Activity', 'get', [
+      'sequential' => 1,
+      'subject' => ['LIKE' => "%[case #214bf6d]%"],
+    ]);
+    $this->assertNotEmpty($result['values'][0]['id']);
+  }
+
+  /**
+   * Test non case email processing when is_non_case_email_skipped is enabled.
+   */
+  public function testInboundProcessingNonCaseEmail() {
+    $this->setUpSkipNonCasesEmail();
+    $mail = 'test_non_cases_email.eml';
+
+    copy(__DIR__ . '/data/inbound/' . $mail, __DIR__ . '/data/mail/' . $mail);
+    $this->callAPISuccess('job', 'fetch_activities', []);
+    $result = civicrm_api3('Activity', 'get', [
+      'sequential' => 1,
+      'subject' => ['LIKE' => "%Love letter%"],
+    ]);
+    $this->assertEmpty($result['values']);
   }
 
   /**

--- a/tests/phpunit/CRM/Utils/Mail/data/inbound/test_cases_email.eml
+++ b/tests/phpunit/CRM/Utils/Mail/data/inbound/test_cases_email.eml
@@ -1,0 +1,15 @@
+Delivered-To: to@test.test
+Received: by 10.2.13.84 with SMTP id 1234567890;
+        Wed, 19 Dec 2018 10:01:11 +0100 (CET)
+Return-Path: <>
+Message-ID: <abc.def.fhi@test.test>
+Date: Wed, 19 Dec 2018 10:01:07 +0100
+MIME-Version: 1.0
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: 8bit
+Content-Disposition: inline
+From: from@test.test
+To: to@test.test
+Subject: [case #214bf6d] Magic is here
+
+This test case is full of fun.

--- a/tests/phpunit/CRM/Utils/Mail/data/inbound/test_non_cases_email.eml
+++ b/tests/phpunit/CRM/Utils/Mail/data/inbound/test_non_cases_email.eml
@@ -1,0 +1,15 @@
+Delivered-To: to@test.test
+Received: by 10.2.13.84 with SMTP id 1234567890;
+        Wed, 19 Dec 2018 10:01:11 +0100 (CET)
+Return-Path: <>
+Message-ID: <abc.def.fhi@test.test>
+Date: Wed, 19 Dec 2018 10:01:07 +0100
+MIME-Version: 1.0
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: 8bit
+Content-Disposition: inline
+From: from@test.test
+To: to@test.test
+Subject: Love letter
+
+I love you unit test, because you are not related to cases.

--- a/xml/schema/Core/MailSettings.xml
+++ b/xml/schema/Core/MailSettings.xml
@@ -151,6 +151,17 @@
     </html>
   </field>
   <field>
+    <name>is_non_case_email_skipped</name>
+    <title>Skip emails which do not have a Case ID or Case hash</title>
+    <type>boolean</type>
+    <default>0</default>
+    <html>
+      <type>CheckBox</type>
+    </html>
+    <comment>Enabling this option will have CiviCRM skip any emails that do not have the Case ID or Case Hash so that the system will only process emails that can be placed on case records. Any emails that are not processed will be moved to the ignored folder.</comment>
+    <add>5.31</add>
+  </field>
+  <field>
     <name>is_contact_creation_disabled_if_no_match</name>
     <type>boolean</type>
     <title>Do not create new contacts when filing emails</title>

--- a/xml/schema/Core/MailSettings.xml
+++ b/xml/schema/Core/MailSettings.xml
@@ -150,4 +150,15 @@
       <type>Select</type>
     </html>
   </field>
+  <field>
+    <name>is_contact_creation_disabled_if_no_match</name>
+    <type>boolean</type>
+    <title>Do not create new contacts when filing emails</title>
+    <default>0</default>
+    <html>
+      <type>CheckBox</type>
+    </html>
+    <description>If this option is enabled, CiviCRM will not create new contacts when filing emails.</description>
+    <add>5.31</add>
+  </field>
 </table>


### PR DESCRIPTION
Overview
----------------------------------------
According to new requirements we need to add an additional options to the **Mail Account** settings (see _Mail Accounts_ page `/civicrm/admin/mailSettings?action=add&reset=1`) to change the email to activity processing behavior - when `Email-to-Activity Processing` value is selected for **Used For?** field we need to:
1. Show an additional checkbox field - **Skip emails which do not have a Case ID or Case token** (defaults to unticked).
If checked: emails which do not have a valid case ID or case token should be moved into the `ignored` mail folder after processing and no activity should be created.
1. Show an additional checkbox field - **Do not create new contacts when filing emails** (defaults to unticked).
If checked: when CiviCRM checks for a matching contact, if no matching contact is found it will not create one and the email is filed.
So now administrator should be able to configure whether CiviCRM will create a new contact where a contact does not already exist within the system when filing inbound emails, so that he can ensure that new contacts are not created in the system when filing an email. The email should still be filed, even if no contacts are matched.

Email is considered to be related to cases if it's subject matches any of the following conditions:
- Starts with `[<any string> #<any string>]`, e.g: `[case #2cd8467]`, `[policy initiative #bdf3896]`.
- Ends with `Case ID <number>`, e.g: `Case ID 1298`, `case id 9`.

Also:
- Label of new field is printed to the right of the checkbox, not to the left, because left side is thin and long labels would look weird there.
- _Activity Status_ field label is also moved to the right for consistency. Thanks to this approach these fields would look more like _Used For?_ dependent fields, and this would make them look more intuitive hence will improve UX.


Before
----------------------------------------
Without the new options above enabled CiviCRM will process emails as normal i.e:
1. Will file emails without a case ID or case hash in the subject line against a contact record.
1. Will always create new contacts if no matching contact found.

And _Activity Status_ field label location is not changed.
![image](https://user-images.githubusercontent.com/39520000/94404970-82608900-0178-11eb-8787-7ccd26227cf8.png)

After
----------------------------------------
With the new options above enabled CiviCRM:
1. Will skip any emails that do not have either the case ID or case hash in the subject line and will instead move those emails to the `ignored` folder.
1. Will not create new contacts if no matching contact found (from / to / cc / bcc), but email still will be filed.

Now form looks like this:
![image](https://user-images.githubusercontent.com/39520000/94405049-a8862900-0178-11eb-9fc5-08cc43c6fdd7.png)

Technical Details
----------------------------------------
To make the **Skip emails which do not have a Case ID or Case token** checkbox work we:
1. Added new field to the `civicrm_mail_settings` db table - `is_non_case_email_skipped`. Respective upgrader is added.
1. Updated schema `MailSettings.xml` file to have new field.
1. Updated form related files - `Form/MailSettings.php` and `MailSettings.tpl` - to print new field and save the value on form submit. As it has long help text it was desided to move it to `MailSettings.hlp` file and use civicrm ajax help popup feature.
1. Updated `EmailProcessor.php` to handle new field during inbound email processing.
1. The `CRM_Utils_Mail_CaseMail` class is added to store `isCaseEmail()` method, which is used to check if email is related to cases or not before email processing (creating new activity). The regexp patterns are copied from `CRM_Activity_BAO_Activity->create()` method for consistency, as it also performs this check.
1. The `caseEmailSubjectPatterns()` hook is added to make it possible to change default email subject regexp patterns. It may be useful for example for _CiviCase_ extension to add case type category names to patterns.
1. Unit tests were added to test processing (with `is_non_case_email_skipped` enabled) of 2 emails: with case hash in subject and without case hash.
1. Also as part of this PR formatting of `MailSettings.tpl` file is fixed.

To make the **Do not create new contacts when filing emails** checkobx work we:
1. Added new field to the `civicrm_mail_settings` db table - `is_contact_creation_disabled_if_no_match`. Respective upgrader is added.
1. Updated `DAO/MailSettings.php` and schema `MailSettings.xml` files to have new field.
1. Updated form related files - `Form/MailSettings.php` and `MailSettings.tpl` - to print new field and save the value on form submit.
1. Updated `EmailProcessor.php` to handle new field during inbound email processing. This also involved updating the `Incoming.php` to make contact creation optional.
1. Unit tests were added to test processing with `is_contact_creation_disabled_if_no_match` enabled.

### About the new `CRM_Utils_Mail_CaseMail` class
This class has a potential to become generic and widely used class, thats why:
• Email subject patterns are not just hardcoded, but are reusable, see `getSubjectPatterns()` method.
• The `getSubjectPatterns()` method is written keeping in mind `CiviCase` extension (thats why  `caseEmailSubjectPatterns()` hook is added), which has case type categories, which names could be used in email subject, e.g: `[case #hahoheh] Super email` -> `[policy initiative #hahoheh] Super email`.

For now the most useful part of this class is `isCaseEmail()` method, but some other methods may be added later. For example:
1. Generate case hash - there is a code duplication in civicrm to generate case hash, i.e:
`$hash = substr(sha1(CIVICRM_SITE_KEY . $form->_caseId), 0, 7)`.
1. Generate case subject - there is a code duplication in civicrm to generate case related mail subject, i.e:
`$subject = "[case #$hash] $subject"`.

⚠  The email regexp patterns are copied from `CRM_Activity_BAO_Activity->create()` and now it makes sense to refactor that method to use `CRM_Utils_Mail_CaseMail->getSubjectPatterns()` to get patterns. But will skip it now as it's not in the scope of the task.

### One more comment
I've noticed that civicrm stops processing of inbound email if it failed to connect to some mail account. This may cause some issues in case if there are several accounts created: if processing would be stopped on first account - then no other accounts would be processed as well.
I guess this should be added to the todo list to fix in the nearest future.