### PR TITLE
dev/financial#152 [REF] Parse ids before sending to recur function (minor simplification)

### DIFF
--- a/CRM/Core/Payment/AuthorizeNetIPN.php
+++ b/CRM/Core/Payment/AuthorizeNetIPN.php
@@ -141,7 +141,14 @@ class CRM_Core_Payment_AuthorizeNetIPN extends CRM_Core_Payment_BaseIPN {
             $objects['contribution'] = &$contribution;
           }
           $input['payment_processor_id'] = $paymentProcessorID;
-          return $this->recur($input, $ids, $objects, $first);
+          return $this->recur($input, [
+            'related_contact' => $ids['related_contact'] ?? NULL,
+            'participant' => !empty($objects['participant']) ? $objects['participant']->id : NULL,
+            'contributionRecur' => !empty($objects['contributionRecur']) ? $objects['contributionRecur']->id : NULL,
+            'membership' => $ids['membership'] ?? NULL,
+            'contact' => $ids['contact'] ?? NULL,
+            'contributionPage' => $ids['contributionPage'] ?? NULL,
+          ], $objects, $first);
         }
       }
       return TRUE;
@@ -222,11 +229,7 @@ class CRM_Core_Payment_AuthorizeNetIPN extends CRM_Core_Payment_BaseIPN {
       return TRUE;
     }
 
-    CRM_Contribute_BAO_Contribution::completeOrder($input, [
-      'related_contact' => $ids['related_contact'] ?? NULL,
-      'participant' => !empty($objects['participant']) ? $objects['participant']->id : NULL,
-      'contributionRecur' => !empty($objects['contributionRecur']) ? $objects['contributionRecur']->id : NULL,
-    ], ['contribution' => $objects['contribution']]);
+    CRM_Contribute_BAO_Contribution::completeOrder($input, $ids, ['contribution' => $objects['contribution']]);
 
     // Only Authorize.net does this so it is on the a.net class. If there is a need for other processors
     // to do this we should make it available via the api, e.g as a parameter, changing the nuance


### PR DESCRIPTION
Overview
----------------------------------------
Minor simplification - parse ids into valid format & pass them into recur, rather than passing them in wrong & 'asking' recur to parse them

Before
----------------------------------------
parsing of ids into usable array done at the last minute, other values passes around unnecessarily

After
----------------------------------------
parsing done close to the point where they are derived

Technical Details
----------------------------------------
The goal here is to make it very clear & visible what is in ```$ids ``` and ```objects ``` so we can fix the building of them to only do what is needed,

Comments
----------------------------------------

