### PR TITLE
dev/core#2073 Memory drain

### DIFF
--- a/tests/phpunit/CRM/Contact/SelectorTest.php
+++ b/tests/phpunit/CRM/Contact/SelectorTest.php
@@ -453,7 +453,7 @@ AND (contact_a.is_deleted = 0)',
    */
   public function testSelectorQueryOnNonASCIIlocationType() {
     $contactID = $this->individualCreate();
-    $locationType = $this->locationTypeCreate([
+    $locationTypeID = $this->locationTypeCreate([
       'name' => 'Non ASCII Location Type',
       'display_name' => 'Дом Location type',
       'vcard_name' => 'Non ASCII Location Type',
@@ -461,7 +461,7 @@ AND (contact_a.is_deleted = 0)',
     ]);
     $this->callAPISuccess('Email', 'create', [
       'contact_id' => $contactID,
-      'location_type_id' => $locationType->id,
+      'location_type_id' => $locationTypeID,
       'email' => 'test@test.com',
     ]);
 
@@ -470,7 +470,7 @@ AND (contact_a.is_deleted = 0)',
       ['email' => ['IS NOT NULL' => 1]],
       [
         [
-          0 => 'email-' . $locationType->id,
+          0 => 'email-' . $locationTypeID,
           1 => 'IS NOT NULL',
           2 => NULL,
           3 => 1,
@@ -483,7 +483,7 @@ AND (contact_a.is_deleted = 0)',
         'sort_name' => 1,
         'location' => [
           'Non ASCII Location Type' => [
-            'location_type' => $locationType->id,
+            'location_type' => $locationTypeID,
             'email' => 1,
           ],
         ],

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -1230,7 +1230,7 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
     // clear getfields cache
     CRM_Core_PseudoConstant::flush();
     $this->callAPISuccess('phone', 'getfields', ['version' => 3, 'cache_clear' => 1]);
-    return $locationType;
+    return $locationType->id;
   }
 
   /**

--- a/tests/phpunit/api/v3/AddressTest.php
+++ b/tests/phpunit/api/v3/AddressTest.php
@@ -22,7 +22,7 @@
  */
 class api_v3_AddressTest extends CiviUnitTestCase {
   protected $_contactID;
-  protected $_locationType;
+  protected $_locationTypeID;
   protected $_params;
 
   protected $_entity;
@@ -32,12 +32,12 @@ class api_v3_AddressTest extends CiviUnitTestCase {
     parent::setUp();
 
     $this->_contactID = $this->organizationCreate();
-    $this->_locationType = $this->locationTypeCreate();
+    $this->_locationTypeID = $this->locationTypeCreate();
     CRM_Core_PseudoConstant::flush();
 
     $this->_params = [
       'contact_id' => $this->_contactID,
-      'location_type_id' => $this->_locationType->id,
+      'location_type_id' => $this->_locationTypeID,
       'street_name' => 'Ambachtstraat',
       'street_number' => '23',
       'street_address' => 'Ambachtstraat 23',
@@ -49,7 +49,7 @@ class api_v3_AddressTest extends CiviUnitTestCase {
   }
 
   public function tearDown() {
-    $this->locationTypeDelete($this->_locationType->id);
+    $this->locationTypeDelete($this->_locationTypeID);
     $this->contactDelete($this->_contactID);
     $this->quickCleanup(['civicrm_address', 'civicrm_relationship']);
     parent::tearDown();
@@ -78,7 +78,7 @@ class api_v3_AddressTest extends CiviUnitTestCase {
     $params = [
       'street_parsing' => 1,
       'street_address' => '54A Excelsior Ave. Apt 1C',
-      'location_type_id' => $this->_locationType->id,
+      'location_type_id' => $this->_locationTypeID,
       'contact_id' => $this->_contactID,
     ];
     $subfile = "AddressParse";
@@ -256,7 +256,7 @@ class api_v3_AddressTest extends CiviUnitTestCase {
     $this->_apiversion = $version;
     //check there are no address to start with
     $get = $this->callAPISuccess('address', 'get', [
-      'location_type_id' => $this->_locationType->id,
+      'location_type_id' => $this->_locationTypeID,
     ]);
     $this->assertEquals(0, $get['count'], 'Contact already exists ');
 
@@ -266,7 +266,7 @@ class api_v3_AddressTest extends CiviUnitTestCase {
     $result = $this->callAPIAndDocument('address', 'delete', ['id' => $create['id']], __FUNCTION__, __FILE__);
     $this->assertEquals(1, $result['count']);
     $get = $this->callAPISuccess('address', 'get', [
-      'location_type_id' => $this->_locationType->id,
+      'location_type_id' => $this->_locationTypeID,
     ]);
     $this->assertEquals(0, $get['count'], 'Contact not successfully deleted In line ' . __LINE__);
   }
@@ -434,7 +434,7 @@ class api_v3_AddressTest extends CiviUnitTestCase {
   public function testCreateDuplicateLocationTypes() {
     $address1 = $this->callAPISuccess('address', 'create', $this->_params);
     $address2 = $this->callAPISuccess('address', 'create', [
-      'location_type_id' => $this->_locationType->id,
+      'location_type_id' => $this->_locationTypeID,
       'street_address' => '1600 Pensilvania Avenue',
       'city' => 'Washington DC',
       'is_primary' => 0,
@@ -443,7 +443,7 @@ class api_v3_AddressTest extends CiviUnitTestCase {
     ]);
     $check = $this->callAPISuccess('address', 'getcount', [
       'contact_id' => $this->_contactID,
-      'location_type_id' => $this->_locationType->id,
+      'location_type_id' => $this->_locationTypeID,
     ]);
     $this->assertEquals(2, $check);
     $this->callAPISuccess('address', 'delete', ['id' => $address1['id']]);
@@ -454,7 +454,7 @@ class api_v3_AddressTest extends CiviUnitTestCase {
     $cid = $this->individualCreate([
       'api.Address.create' => [
         'street_address' => __FUNCTION__,
-        'location_type_id' => $this->_locationType->id,
+        'location_type_id' => $this->_locationTypeID,
       ],
     ]);
     $result = $this->callAPISuccess('address', 'getsingle', [

--- a/tests/phpunit/api/v3/EmailTest.php
+++ b/tests/phpunit/api/v3/EmailTest.php
@@ -16,8 +16,8 @@
  */
 class api_v3_EmailTest extends CiviUnitTestCase {
   protected $_contactID;
-  protected $_locationType;
-  protected $locationType2;
+  protected $_locationTypeID;
+  protected $locationType2ID;
   protected $_entity;
   protected $_params;
 
@@ -27,8 +27,8 @@ class api_v3_EmailTest extends CiviUnitTestCase {
     $this->useTransaction(TRUE);
 
     $this->_contactID = $this->organizationCreate(NULL);
-    $this->_locationType = $this->locationTypeCreate(NULL);
-    $this->locationType2 = $this->locationTypeCreate([
+    $this->_locationTypeID = $this->locationTypeCreate();
+    $this->locationType2ID = $this->locationTypeCreate([
       'name' => 'New Location Type 2',
       'vcard_name' => 'New Location Type 2',
       'description' => 'Another Location Type',
@@ -36,7 +36,7 @@ class api_v3_EmailTest extends CiviUnitTestCase {
     ]);
     $this->_params = [
       'contact_id' => $this->_contactID,
-      'location_type_id' => $this->_locationType->id,
+      'location_type_id' => $this->_locationTypeID,
       'email' => 'api@a-team.com',
       'is_primary' => 1,
 
@@ -57,7 +57,7 @@ class api_v3_EmailTest extends CiviUnitTestCase {
     $params = $this->_params;
     //check there are no emails to start with
     $get = $this->callAPISuccess('email', 'get', [
-      'location_type_id' => $this->_locationType->id,
+      'location_type_id' => $this->_locationTypeID,
     ]);
     $this->assertEquals(0, $get['count'], 'Contact not successfully deleted.');
 
@@ -167,7 +167,7 @@ class api_v3_EmailTest extends CiviUnitTestCase {
     $this->_apiversion = $version;
     $params = [
       'contact_id' => $this->_contactID,
-      'location_type_id' => $this->_locationType->id,
+      'location_type_id' => $this->_locationTypeID,
       'email' => 'api@a-team.com',
       'is_primary' => 1,
 
@@ -175,7 +175,7 @@ class api_v3_EmailTest extends CiviUnitTestCase {
     ];
     //check there are no emails to start with
     $get = $this->callAPISuccess('email', 'get', [
-      'location_type_id' => $this->_locationType->id,
+      'location_type_id' => $this->_locationTypeID,
     ]);
     $this->assertEquals(0, $get['count'], 'email already exists');
 
@@ -185,7 +185,7 @@ class api_v3_EmailTest extends CiviUnitTestCase {
     $result = $this->callAPIAndDocument('email', 'delete', ['id' => $create['id']], __FUNCTION__, __FILE__);
     $this->assertEquals(1, $result['count']);
     $get = $this->callAPISuccess('email', 'get', [
-      'location_type_id' => $this->_locationType->id,
+      'location_type_id' => $this->_locationTypeID,
     ]);
     $this->assertEquals(0, $get['count'], 'Contact not successfully deleted');
   }
@@ -209,27 +209,27 @@ class api_v3_EmailTest extends CiviUnitTestCase {
       'contact_id' => $this->_contactID,
       'values' => [
         [
-          'location_type_id' => $this->_locationType->id,
+          'location_type_id' => $this->_locationTypeID,
           'email' => '1-1@example.com',
           'is_primary' => 1,
         ],
         [
-          'location_type_id' => $this->_locationType->id,
+          'location_type_id' => $this->_locationTypeID,
           'email' => '1-2@example.com',
           'is_primary' => 0,
         ],
         [
-          'location_type_id' => $this->_locationType->id,
+          'location_type_id' => $this->_locationTypeID,
           'email' => '1-3@example.com',
           'is_primary' => 0,
         ],
         [
-          'location_type_id' => $this->locationType2->id,
+          'location_type_id' => $this->locationType2ID,
           'email' => '2-1@example.com',
           'is_primary' => 0,
         ],
         [
-          'location_type_id' => $this->locationType2->id,
+          'location_type_id' => $this->locationType2ID,
           'email' => '2-2@example.com',
           'is_primary' => 0,
         ],
@@ -247,7 +247,7 @@ class api_v3_EmailTest extends CiviUnitTestCase {
     // replace the subset of emails in location #1, but preserve location #2
     $replace2Params = [
       'contact_id' => $this->_contactID,
-      'location_type_id' => $this->_locationType->id,
+      'location_type_id' => $this->_locationTypeID,
       'values' => [
         [
           'email' => '1-4@example.com',
@@ -261,14 +261,14 @@ class api_v3_EmailTest extends CiviUnitTestCase {
     // check emails at location #1 -- all three replaced by one
     $get = $this->callAPISuccess('email', 'get', [
       'contact_id' => $this->_contactID,
-      'location_type_id' => $this->_locationType->id,
+      'location_type_id' => $this->_locationTypeID,
     ]);
     $this->assertEquals(1, $get['count'], 'Incorrect email count');
 
     // check emails at location #2 -- preserve the original two
     $get = $this->callAPISuccess('email', 'get', [
       'contact_id' => $this->_contactID,
-      'location_type_id' => $this->locationType2->id,
+      'location_type_id' => $this->locationType2ID,
     ]);
 
     $this->assertEquals(2, $get['count'], 'Incorrect email count');
@@ -314,27 +314,27 @@ class api_v3_EmailTest extends CiviUnitTestCase {
       'api.email.replace' => [
         'values' => [
           [
-            'location_type_id' => $this->_locationType->id,
+            'location_type_id' => $this->_locationTypeID,
             'email' => '1-1@example.com',
             'is_primary' => 1,
           ],
           [
-            'location_type_id' => $this->_locationType->id,
+            'location_type_id' => $this->_locationTypeID,
             'email' => '1-2@example.com',
             'is_primary' => 0,
           ],
           [
-            'location_type_id' => $this->_locationType->id,
+            'location_type_id' => $this->_locationTypeID,
             'email' => '1-3@example.com',
             'is_primary' => 0,
           ],
           [
-            'location_type_id' => $this->locationType2->id,
+            'location_type_id' => $this->locationType2ID,
             'email' => '2-1@example.com',
             'is_primary' => 0,
           ],
           [
-            'location_type_id' => $this->locationType2->id,
+            'location_type_id' => $this->locationType2ID,
             'email' => '2-2@example.com',
             'is_primary' => 0,
           ],
@@ -354,7 +354,7 @@ class api_v3_EmailTest extends CiviUnitTestCase {
     $getReplace2Params = [
       'id' => $this->_contactID,
       'api.email.replace' => [
-        'location_type_id' => $this->_locationType->id,
+        'location_type_id' => $this->_locationTypeID,
         'values' => [
           [
             'email' => '1-4@example.com',
@@ -370,7 +370,7 @@ class api_v3_EmailTest extends CiviUnitTestCase {
     // check emails at location #1 -- all three replaced by one
     $get = $this->callAPISuccess('email', 'get', [
       'contact_id' => $this->_contactID,
-      'location_type_id' => $this->_locationType->id,
+      'location_type_id' => $this->_locationTypeID,
     ]);
 
     $this->assertEquals(1, $get['count'], 'Incorrect email count');
@@ -378,7 +378,7 @@ class api_v3_EmailTest extends CiviUnitTestCase {
     // check emails at location #2 -- preserve the original two
     $get = $this->callAPISuccess('email', 'get', [
       'contact_id' => $this->_contactID,
-      'location_type_id' => $this->locationType2->id,
+      'location_type_id' => $this->locationType2ID,
     ]);
     $this->assertEquals(2, $get['count'], 'Incorrect email count');
   }
@@ -402,7 +402,7 @@ class api_v3_EmailTest extends CiviUnitTestCase {
       'contact_id' => $this->_contactID,
       'values' => [
         [
-          'location_type_id' => $this->_locationType->id,
+          'location_type_id' => $this->_locationTypeID,
           'email' => '1-1@example.com',
           'is_primary' => 1,
           'on_hold' => 1,
@@ -431,7 +431,7 @@ class api_v3_EmailTest extends CiviUnitTestCase {
     // ensure the 'email' was updated while other fields were preserved
     $get = $this->callAPISuccess('email', 'get', [
       'contact_id' => $this->_contactID,
-      'location_type_id' => $this->_locationType->id,
+      'location_type_id' => $this->_locationTypeID,
     ]);
 
     $this->assertEquals(1, $get['count'], 'Incorrect email count at ' . __LINE__);

--- a/tests/phpunit/api/v3/PhoneTest.php
+++ b/tests/phpunit/api/v3/PhoneTest.php
@@ -35,8 +35,7 @@ class api_v3_PhoneTest extends CiviUnitTestCase {
     $this->useTransaction();
 
     $this->_contactID = $this->organizationCreate();
-    $loc = $this->locationTypeCreate();
-    $this->_locationType = $loc->id;
+    $this->_locationType = $this->locationTypeCreate();
     CRM_Core_PseudoConstant::flush();
     $this->_params = [
       'contact_id' => $this->_contactID,


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a memory leak within 4 unit test classes

Update -in fact this is not a true memory leak - just a case of memory hogging. It turns out phpunit keeps all classes until the run is finished - so if we have a LocationType DAO as a property of the class it is retained for the entire phpunit run


Before
----------------------------------------
api_v3_AddressTest leaks 2.9211MB of memory (UPDATE - I realise that is only the leaks on strings - not the total leak)

<img width="1058" alt="Screen Shot 2020-09-29 at 3 56 50 PM" src="https://user-images.githubusercontent.com/336308/94509989-2712c180-0272-11eb-9e24-16d0e9ae6ac4.png">


After
----------------------------------------
api_v3_AddressTest 'only' leaks 2.715756 MB of memory (UPDATE - I realise that is only the leaks on strings - not the total leak)

<img width="1031" alt="Screen Shot 2020-09-29 at 4 31 15 PM" src="https://user-images.githubusercontent.com/336308/94510026-38f46480-0272-11eb-87f4-0e33152ec59f.png">

Technical Details
----------------------------------------
See https://lab.civicrm.org/dev/core/-/issues/2073 for a lot of detail on the methodology

Comments
----------------------------------------
