### PR TITLE
dev/core#2073 just tweak a memory leak

### DIFF
--- a/CRM/Core/CodeGen/Main.php
+++ b/CRM/Core/CodeGen/Main.php
@@ -5,6 +5,10 @@
  */
 class CRM_Core_CodeGen_Main {
   public $buildVersion;
+
+  /**
+   * @var string
+   */
   public $db_version;
   /**
    * drupal, joomla, wordpress
@@ -76,11 +80,11 @@ class CRM_Core_CodeGen_Main {
 
     $versionFile = $this->phpCodePath . "/xml/version.xml";
     $versionXML = CRM_Core_CodeGen_Util_Xml::parse($versionFile);
-    $this->db_version = $versionXML->version_no;
+    $this->db_version = (string) $versionXML->version_no;
     $this->buildVersion = preg_replace('/^(\d{1,2}\.\d{1,2})\.(\d{1,2}|\w{4,7})$/i', '$1', $this->db_version);
     if (isset($argVersion)) {
       // change the version to that explicitly passed, if any
-      $this->db_version = $argVersion;
+      $this->db_version = (string) $argVersion;
     }
 
     $this->schemaPath = $schemaPath;


### PR DESCRIPTION


Overview
----------------------------------------
This one is like https://github.com/civicrm/civicrm-core/pull/18632 but only
seems to have switched us from an xml leakage to a string leakage - it still
seems slightly better from a code quality point of view

Before
----------------------------------------
<img width="1031" alt="Screen Shot 2020-09-29 at 4 31 15 PM" src="https://user-images.githubusercontent.com/336308/94510026-38f46480-0272-11eb-87f4-0e33152ec59f.png">

After
----------------------------------------
No real change - 1 more string, one less xml

<img width="1028" alt="Screen Shot 2020-09-29 at 5 02 37 PM" src="https://user-images.githubusercontent.com/336308/94511451-dd2bda80-0275-11eb-8e6d-42ac6907881a.png">


Technical Details
----------------------------------------
This suggests that tracking down what's keeping CRM_Core_CodeGen_Main & it's 72 dependencies is the real question on this one

Comments
----------------------------------------

