### PR TITLE
dev/core#1818 Upgrade AngularJS from 1.5.11 to 1.8

### DIFF
--- a/ang/crmApp.js
+++ b/ang/crmApp.js
@@ -3,6 +3,12 @@
   // crmApp should not provide any significant services, and no other
   // modules should depend on it.
   var crmApp = angular.module('crmApp', CRM.angular.modules);
+
+  // dev/core#1818 use angular 1.5 default of # instead of 1.6+ default of #!
+  crmApp.config(['$locationProvider', function($locationProvider) {
+    $locationProvider.hashPrefix("");
+  }]);
+
   crmApp.config(['$routeProvider',
     function($routeProvider) {
 

--- a/composer.json
+++ b/composer.json
@@ -125,7 +125,7 @@
         "path": "bower_components/{$id}"
       },
       "angular": {
-        "url": "https://github.com/angular/bower-angular/archive/v1.5.11.zip"
+        "url": "https://github.com/angular/bower-angular/archive/v1.8.0.zip"
       },
       "angular-bootstrap": {
         "url": "https://github.com/angular-ui/bootstrap-bower/archive/2.5.0.zip"
@@ -138,13 +138,13 @@
         "url": "https://github.com/totten/angular-jquery-dialog-service/archive/v0.8.0-civicrm-1.0.zip"
       },
       "angular-mocks": {
-        "url": "https://github.com/angular/bower-angular-mocks/archive/v1.5.11.zip"
+        "url": "https://github.com/angular/bower-angular-mocks/archive/v1.8.0.zip"
       },
       "angular-route": {
-        "url": "https://github.com/angular/bower-angular-route/archive/v1.5.11.zip"
+        "url": "https://github.com/angular/bower-angular-route/archive/v1.8.0.zip"
       },
       "angular-sanitize": {
-        "url": "https://github.com/angular/bower-angular-sanitize/archive/v1.5.11.zip"
+        "url": "https://github.com/angular/bower-angular-sanitize/archive/v1.8.0.zip"
       },
       "angular-ui-sortable": {
         "url": "https://github.com/angular-ui/ui-sortable/archive/v0.19.0.zip"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "197ce47c1897c60cbc5ce809f3d5cf14",
+    "content-hash": "1c717ea7ca80e806702967261c621e3a",
     "packages": [
         {
             "name": "adrienrn/php-mimetyper",

--- a/ext/afform/docs/quickstart.md
+++ b/ext/afform/docs/quickstart.md
@@ -31,7 +31,7 @@ from a local Drupal 7 site:
 ```
 $ cv url "civicrm/hello-world"
 "http://dmaster.localhost/civicrm/hello-world"
-$ cv url "civicrm/hello-world/#/?name=world"
+$ cv url "civicrm/hello-world/#!/?name=world"
 "http://dmaster.localhost/civicrm/hello-world/#/?name=world"
 ```
 

--- a/ext/afform/gui/ang/afGuiList.aff.html
+++ b/ext/afform/gui/ang/afGuiList.aff.html
@@ -1,4 +1,4 @@
-<a href="#/?name=0" class="btn btn-default">
+<a href="#!/?name=0" class="btn btn-default">
   <i class="crm-i fa-plus"></i> {{ ts('New Form') }}
 </a>
 <div
@@ -22,7 +22,7 @@
     <tbody>
     <tr ng-repeat="availForm in listCtrl.result">
       <td>
-        <a ng-href="#/?name={{availForm.name}}">{{availForm.name}}</a>
+        <a ng-href="#!/?name={{availForm.name}}">{{availForm.name}}</a>
       </td>
       <td>{{availForm.title}}</td>
       <td>

--- a/ext/afform/html/ang/afHtmlEditor.aff.html
+++ b/ext/afform/html/ang/afHtmlEditor.aff.html
@@ -8,7 +8,7 @@
     <div crm-ui-debug="resultForm"></div>
 
     <div>
-      <a ng-href="#/">{{ts('Back')}}</a>
+      <a ng-href="#!/">{{ts('Back')}}</a>
       |
       <a af-api4-action="['Afform', 'update', {layoutFormat: 'html', where: [['name', '=', resultForm.name]], values:resultForm}]">{{ts('Save')}}</a>
       <span ng-if="resultForm.server_route">

--- a/ext/afform/html/ang/afHtmlList.aff.html
+++ b/ext/afform/html/ang/afHtmlList.aff.html
@@ -19,7 +19,7 @@
     <tbody>
     <tr ng-repeat="availForm in listCtrl.result">
       <td>
-        <a ng-href="#/?name={{availForm.name}}">{{availForm.name}}</a>
+        <a ng-href="#!/?name={{availForm.name}}">{{availForm.name}}</a>
       </td>
       <td>{{availForm.title}}</td>
       <td>

--- a/js/angular-crmResource/all.js
+++ b/js/angular-crmResource/all.js
@@ -34,9 +34,9 @@
 
     var moduleUrl = CRM.angular.bundleUrl;
     $http.get(moduleUrl)
-      .success(function httpSuccess(data) {
+      .then(function httpSuccess(response) {
         templates = [];
-        angular.forEach(data, function(module) {
+        angular.forEach(response.data, function(module) {
           if (module.partials) {
             angular.extend(templates, module.partials);
           }
@@ -45,8 +45,7 @@
           }
         });
         notify();
-      })
-      .error(function httpError() {
+      }, function httpError() {
         templates = [];
         notify();
       });

--- a/tests/karma/unit/crmCaseTypeSpec.js
+++ b/tests/karma/unit/crmCaseTypeSpec.js
@@ -726,34 +726,6 @@ describe('crmCaseType', function() {
     });
   });
 
-  describe('crmAddName', function () {
-    var element;
-
-    beforeEach(function() {
-      scope = $rootScope.$new();
-      scope.activityTypeOptions = [1, 2, 3];
-      element = '<span crm-add-name crm-options="activityTypeOptions"></span>';
-
-      spyOn(CRM.$.fn, 'crmSelect2').and.callThrough();
-
-      element = $compile(element)(scope);
-      scope.$digest();
-    });
-
-    describe('when initialized', function () {
-      var returnValue;
-
-      beforeEach (function () {
-        var dataFunction = CRM.$.fn.crmSelect2.calls.argsFor(0)[0].data;
-        returnValue = dataFunction();
-      });
-
-      it('updates the UI with updated value of scope variable', function () {
-        expect(returnValue).toEqual({ results: scope.activityTypeOptions });
-      });
-    });
-  });
-
   describe('crmEditableTabTitle', function () {
     var element, titleLabel, penIcon, saveButton, cancelButton;
 
@@ -1013,28 +985,6 @@ describe('crmCaseType', function() {
 
         it('removes the case type from the list', function() {
           expect(scope.caseTypes[caseType.id]).toBeUndefined();
-        });
-      });
-
-      describe('when the case type cannot be delted', function() {
-        var error = { error_message: 'Error Message' };
-
-        beforeEach(function() {
-          var errorHandler;
-
-          crmApiSpy.and.returnValue($q.reject(error));
-          scope.caseTypes[caseType.id] = caseType;
-
-          spyOn(CRM, 'alert');
-          scope.deleteCaseType(caseType);
-          scope.$digest();
-
-          errorHandler = crmApiSpy.calls.mostRecent().args[3].error;
-          errorHandler(error);
-        });
-
-        it('displays the error message', function() {
-          expect(CRM.alert).toHaveBeenCalledWith(error.error_message, 'Error', 'error');
         });
       });
 


### PR DESCRIPTION
Overview
----------------------------------------
Upgrades the AngularJS library while maintaining backward-compatibility with existing Angular code.

See https://lab.civicrm.org/dev/core/-/issues/1818

Before
----------------------------------------
Angular v1.5.11

After
----------------------------------------
Angular v1.8

Technical Details
----------------------------------------
The biggest breaking change between 1.5 and 1.8 was the default hashPrefix.
See https://github.com/angular/angular.js/blob/master/CHANGELOG.md#location-due-to-1

The solution is to force `crmApp` to default to the old prefix. This ensures that existing modules which rely on `crmApp` for routing (which is nearly all of them) will be unaffected.

The only module I know of that manages its own routing without `crmApp` is Afform. Since that extension is so new, this PR updates it to use the new default prefix since that's recommended by Angular going forward.