### PR TITLE
dev/core#2075 - E_NOTICE viewing an activity that has no details contents

### DIFF
--- a/CRM/Activity/Form/Activity.php
+++ b/CRM/Activity/Form/Activity.php
@@ -503,7 +503,7 @@ class CRM_Activity_Form_Activity extends CRM_Contact_Form_Task {
     }
 
     if ($this->_action & CRM_Core_Action::VIEW) {
-      $this->_values['details'] = CRM_Utils_String::purifyHtml($this->_values['details']);
+      $this->_values['details'] = CRM_Utils_String::purifyHtml($this->_values['details'] ?? '');
       $url = CRM_Utils_System::url(implode("/", $this->urlPath), "reset=1&id={$this->_activityId}&action=view&cid={$this->_values['source_contact_id']}");
       CRM_Utils_Recent::add(CRM_Utils_Array::value('subject', $this->_values, ts('(no subject)')),
         $url,


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/2075

1. Create an activity, e.g. a Meeting.
1. Don't put anything in the details field.
1. Save.
1. Turn off popups at admin - customize - display prefs, or in the next step use right-click and view in new tab/window.
1. View the activity.

Before
----------------------------------------
`Notice: Undefined index: details in CRM_Activity_Form_Activity->preProcess() (line 506 of .../CRM/Activity/Form/Activity.php)`

After
----------------------------------------
