### PR TITLE
[Test] Improve memory use

### DIFF
--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -494,6 +494,24 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
     $this->unsetExtensionSystem();
     $this->assertEquals([], CRM_Core_DAO::$_nullArray);
     $this->assertEquals(NULL, CRM_Core_DAO::$_nullObject);
+    static::stripProperties($this);
+  }
+
+  /**
+   * Unset any properties, freeing memory.
+   *
+   * https://tomnewby.net/posts/speed-up-phpunit-1-weird-trick/
+   *
+   * @param \object $target
+   */
+  public static function stripProperties($target): void {
+    $refl = new \ReflectionObject($target);
+    foreach ($refl->getProperties() as $prop) {
+      if (!$prop->isStatic() && 0 !== \strncmp($prop->getDeclaringClass()->getName(), 'PHPUnit_', 8)) {
+        $prop->setAccessible(TRUE);
+        $prop->setValue($target, NULL);
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
(just comparing locally at the moment)
https://tomnewby.net/posts/speed-up-phpunit-1-weird-trick/


Before
----------------------------------------
Running api_v3_ContactTest 

<img width="343" alt="Screen Shot 2020-09-30 at 1 58 23 PM" src="https://user-images.githubusercontent.com/336308/94631458-0bb4be80-0325-11eb-94b1-c40aa1f5bf77.png">


After
----------------------------------------
Running api_v3_ContactTest 
<img width="352" alt="Screen Shot 2020-09-30 at 1 47 30 PM" src="https://user-images.githubusercontent.com/336308/94630913-91376f00-0323-11eb-90b2-88d3b6d975bd.png">


Technical Details
----------------------------------------
I'm not too sure how meaningful the time difference is as other activity on my laptop will have an impact - total time with jenkins will be more informative

Comments
----------------------------------------
