### PR TITLE
dev/core#2073 Fix a real live leak

### DIFF
--- a/CRM/ACL/BAO/ACL.php
+++ b/CRM/ACL/BAO/ACL.php
@@ -204,8 +204,6 @@ SELECT      acl.*
   protected static function getGroupACLRoles($contact_id) {
     $contact_id = CRM_Utils_Type::escape($contact_id, 'Integer');
 
-    $rule = new CRM_ACL_BAO_ACL();
-
     $query = "   SELECT          acl.*
                         FROM            civicrm_acl acl
                         INNER JOIN      civicrm_option_group og
@@ -228,7 +226,7 @@ SELECT      acl.*
 
     $results = [];
 
-    $rule->query($query);
+    $rule = CRM_Core_DAO::executeQuery($query);
 
     while ($rule->fetch()) {
       $results[$rule->id] = $rule->toArray();
@@ -249,7 +247,7 @@ SELECT acl.*
    AND acl.entity_table   = 'civicrm_acl_role'
 ";
 
-    $rule->query($query);
+    $rule = CRM_Core_DAO::executeQuery($query);
     while ($rule->fetch()) {
       $results[$rule->id] = $rule->toArray();
     }


### PR DESCRIPTION

Overview
----------------------------------------
I used the same methods I had been playing with on the test class on a contribution
import script and found that the object that was increasing in memory in tandem with
me increasing iterations was an instance of DB_result

I tracked it down to here. In essence our main DAO functions clean up after themselves - e.g
when the DAO is destructed it cleans up the globals it has created.

However, this older ->query() function does not do that and each time is is called increases it's memory hold.

It's also worth better caching in this function...

Before
----------------------------------------
Processed 100 messages in 33 second(s)
Average performance is 182 per minute.

100 copies of DB_Result stored in globals at the end of processing 100 donations

<img width="461" alt="Screen Shot 2020-09-30 at 6 56 15 PM" src="https://user-images.githubusercontent.com/336308/94648252-a5dd2c80-034e-11eb-9241-dcf85c553ac5.png">


<img width="760" alt="Screen Shot 2020-09-30 at 6 52 06 PM" src="https://user-images.githubusercontent.com/336308/94647964-120b6080-034e-11eb-830f-04e3c828fdce.png">




After
----------------------------------------
No speed improvement over such a short run (but we have been seeing it slow over longer runs)

Processed 100 messages in 33 second(s)
Average performance is 182 per minute.

Only 2 sets of results still in globals

<img width="467" alt="Screen Shot 2020-09-30 at 6 49 23 PM" src="https://user-images.githubusercontent.com/336308/94647800-bd67e580-034d-11eb-8fbe-4a79eac3ba98.png">


and in the memory analysis
<img width="783" alt="Screen Shot 2020-09-30 at 6 46 59 PM" src="https://user-images.githubusercontent.com/336308/94647616-58ac8b00-034d-11eb-92ee-ecf9392c7e73.png">


Technical Details
----------------------------------------
The way the old method ->query() stores it's results is obviously different to other methods & hence is not released when the class is destructed

Comments
----------------------------------------
@jmcclelland  the other place I spotted this leaky old pattern is ... in the BAO mailing class.
