### PR TITLE
dev/core#334 Use the current in use collation and character sets when…

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -1610,10 +1610,15 @@ SELECT $columnName
    */
   public static function defaultCustomTableSchema($params) {
     // add the id and extends_id
+    $collation = CRM_Core_BAO_SchemaHandler::getInUseCollation();
+    $characterSet = 'utf8';
+    if (stripos($collation, 'utf8mb4') !== FALSE) {
+      $characterSet = 'utf8mb4';
+    }
     $table = [
       'name' => $params['name'],
       'is_multiple' => $params['is_multiple'],
-      'attributes' => "ENGINE=InnoDB DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci",
+      'attributes' => "ENGINE=InnoDB DEFAULT CHARACTER SET {$characterSet} COLLATE {$collation}",
       'fields' => [
         [
           'name' => 'id',


### PR DESCRIPTION
… creating new custom value tables

Overview
----------------------------------------
This changes the default attributes for new custom value tables to be dependant on the current in use collation.

Before
----------------------------------------
Only utf8 charset and utf8_unicode_ci collation were used to create new custom tables

After
----------------------------------------
Uses the relevant charset for the current collation of the civicrm_contact table.

ping @demeritcowboy @artfulrobot @mattwire 