### PR TITLE
Fix cache bypass

### DIFF
--- a/CRM/ACL/BAO/ACL.php
+++ b/CRM/ACL/BAO/ACL.php
@@ -480,7 +480,7 @@ SELECT g.*
       $cacheKey = CRM_Utils_Cache::cleanKey("$tableName-$aclKeys");
       $cache = CRM_Utils_Cache::singleton();
       $ids = $cache->get($cacheKey);
-      if (!$ids) {
+      if (!is_array($ids)) {
         $ids = [];
         $query = "
 SELECT   a.operation, a.object_id

--- a/CRM/ACL/BAO/ACL.php
+++ b/CRM/ACL/BAO/ACL.php
@@ -477,7 +477,7 @@ SELECT g.*
       $aclKeys = array_keys($acls);
       $aclKeys = implode(',', $aclKeys);
 
-      $cacheKey = CRM_Utils_Cache::cleanKey("$tableName-$aclKeys");
+      $cacheKey = CRM_Utils_Cache::cleanKey("$type-$tableName-$aclKeys");
       $cache = CRM_Utils_Cache::singleton();
       $ids = $cache->get($cacheKey);
       if (!is_array($ids)) {


### PR DESCRIPTION


Overview
----------------------------------------
Minor performance fix -  If the contact is not impacted by any acls then ids will be an empty array. However, currently
an empty array is treated as 'uncached' rather than 'cached by empty' which
would be represented by null

Before
----------------------------------------
If the contact does not have any applicable acls the cached empty array is ignored and the acls are computed each time

After
----------------------------------------
Code only does the queries if the cache returns NULL, not an empty array

Technical Details
----------------------------------------


Comments
----------------------------------------
