### PR TITLE
Search ext: support complex joins & HAVING clause in api4 smart groups

### DIFF
--- a/CRM/Utils/API/HTMLInputCoder.php
+++ b/CRM/Utils/API/HTMLInputCoder.php
@@ -109,6 +109,8 @@ class CRM_Utils_API_HTMLInputCoder extends CRM_Utils_API_AbstractFieldCoder {
         'header',
         // https://lab.civicrm.org/dev/core/issues/1286
         'footer',
+        // SavedSearch entity
+        'api_params',
       ];
       $custom = CRM_Core_DAO::executeQuery('SELECT id FROM civicrm_custom_field WHERE html_type = "RichTextEditor"');
       while ($custom->fetch()) {

--- a/ext/search/CRM/Search/Page/Ang.php
+++ b/ext/search/CRM/Search/Page/Ang.php
@@ -90,7 +90,7 @@ class CRM_Search_Page_Ang extends CRM_Core_Page {
       ->setChain([
         'get' => ['$name', 'getActions', ['where' => [['name', '=', 'get']]], ['params']],
       ])->execute();
-    $getFields = ['name', 'label', 'description', 'options', 'input_type', 'input_attrs', 'data_type', 'serialize'];
+    $getFields = ['name', 'label', 'description', 'options', 'input_type', 'input_attrs', 'data_type', 'serialize', 'fk_entity'];
     foreach ($schema as $entity) {
       // Skip if entity doesn't have a 'get' action or the user doesn't have permission to use get
       if ($entity['get']) {

--- a/ext/search/CRM/Search/Page/Ang.php
+++ b/ext/search/CRM/Search/Page/Ang.php
@@ -84,7 +84,7 @@ class CRM_Search_Page_Ang extends CRM_Core_Page {
    */
   private function getSchema() {
     $schema = \Civi\Api4\Entity::get()
-      ->addSelect('name', 'titlePlural', 'description', 'icon')
+      ->addSelect('name', 'title', 'titlePlural', 'description', 'icon')
       ->addWhere('name', '!=', 'Entity')
       ->addOrderBy('titlePlural')
       ->setChain([
@@ -99,6 +99,8 @@ class CRM_Search_Page_Ang extends CRM_Core_Page {
         if ($loadOptions) {
           $entity['optionsLoaded'] = TRUE;
         }
+        // Because multivalue custom pseudo-entities don't have titlePlural
+        $entity['titlePlural'] = $entity['titlePlural'] ?? $entity['title'];
         $entity['fields'] = civicrm_api4($entity['name'], 'getFields', [
           'select' => $getFields,
           'where' => [['permission', 'IS NULL']],

--- a/ext/search/ang/search/SaveSmartGroup.ctrl.js
+++ b/ext/search/ang/search/SaveSmartGroup.ctrl.js
@@ -1,13 +1,15 @@
 (function(angular, $, _) {
   "use strict";
 
-  angular.module('search').controller('SaveSmartGroup', function ($scope, $element, crmApi4, dialogService) {
+  angular.module('search').controller('SaveSmartGroup', function ($scope, $element, $timeout, crmApi4, dialogService, searchMeta) {
     var ts = $scope.ts = CRM.ts(),
-      model = $scope.model;
+      model = $scope.model,
+      joins = _.pluck((model.api_params.join || []), 0),
+      entityCount = {};
     $scope.groupEntityRefParams = {
       entity: 'Group',
       api: {
-        params: {is_hidden: 0, is_active: 1, 'saved_search_id.api_entity': model.entity},
+        params: {is_hidden: 0, is_active: 1, 'saved_search_id.api_entity': model.api_entity},
         extra: ['saved_search_id', 'description', 'visibility', 'group_type']
       },
       select: {
@@ -16,6 +18,36 @@
         placeholder: ts('Select existing group')
       }
     };
+    // Find all possible search columns that could serve as contact_id for the smart group
+    $scope.columns = _.transform([model.api_entity].concat(joins), function(columns, joinExpr) {
+      var joinName = joinExpr.split(' AS '),
+        entityName = joinName[0],
+        entity = searchMeta.getEntity(entityName),
+        prefix = joinName[1] ? joinName[1] + '.' : '';
+      _.each(entity.fields, function(field) {
+        if ((entityName === 'Contact' && field.name === 'id') || field.fk_entity === 'Contact') {
+          columns.push({
+            id: prefix + field.name,
+            text: entity.titlePlural + (entityCount[entityName] ? ' ' + entityCount[entityName] : '') + ': ' + field.label,
+            icon: entity.icon
+          });
+        }
+      });
+      entityCount[entityName] = 1 + (entityCount[entityName] || 1);
+    });
+
+    if (!$scope.columns.length) {
+      CRM.alert(ts('Cannot create smart group; search does not include any contacts.'), ts('Error'));
+      $timeout(function() {
+        dialogService.cancel('saveSearchDialog');
+      });
+      return;
+    }
+
+    // Pick the first applicable column for contact id
+    model.api_params.select[0] = _.intersection(model.api_params.select, _.pluck($scope.columns, 'id'))[0] || $scope.columns[0].name;
+    model.api_params.select.length = 1;
+
     if (!CRM.checkPerm('administer reserved groups')) {
       $scope.groupEntityRefParams.api.params.is_reserved = 0;
     }
@@ -45,8 +77,8 @@
       group.group_type = model.group_type;
       group.saved_search_id = '$id';
       var savedSearch = {
-        api_entity: model.entity,
-        api_params: model.params
+        api_entity: model.api_entity,
+        api_params: model.api_params
       };
       if (group.id) {
         savedSearch.id = model.saved_search_id;

--- a/ext/search/ang/search/SaveSmartGroup.ctrl.js
+++ b/ext/search/ang/search/SaveSmartGroup.ctrl.js
@@ -45,8 +45,7 @@
     }
 
     // Pick the first applicable column for contact id
-    model.api_params.select[0] = _.intersection(model.api_params.select, _.pluck($scope.columns, 'id'))[0] || $scope.columns[0].name;
-    model.api_params.select.length = 1;
+    model.api_params.select.unshift(_.intersection(model.api_params.select, _.pluck($scope.columns, 'id'))[0] || $scope.columns[0].id);
 
     if (!CRM.checkPerm('administer reserved groups')) {
       $scope.groupEntityRefParams.api.params.is_reserved = 0;
@@ -76,6 +75,7 @@
       group.visibility = model.visibility;
       group.group_type = model.group_type;
       group.saved_search_id = '$id';
+      model.api_params.select = _.unique(model.api_params.select);
       var savedSearch = {
         api_entity: model.api_entity,
         api_params: model.api_params

--- a/ext/search/ang/search/crmSearch.component.js
+++ b/ext/search/ang/search/crmSearch.component.js
@@ -343,12 +343,12 @@
 
       // Is a column eligible to use an aggregate function?
       this.canAggregate = function(col) {
+        var info = searchMeta.parseExpr(col);
         // If the column is used for a groupBy, no
-        if (ctrl.params.groupBy.indexOf(col) > -1) {
+        if (ctrl.params.groupBy.indexOf(info.path) > -1) {
           return false;
         }
         // If the entity this column belongs to is being grouped by id, then also no
-        var info = searchMeta.parseExpr(col);
         return ctrl.params.groupBy.indexOf(info.prefix + 'id') < 0;
       };
 

--- a/ext/search/ang/search/crmSearch.component.js
+++ b/ext/search/ang/search/crmSearch.component.js
@@ -558,21 +558,19 @@
       };
 
       $scope.saveGroup = function() {
-        var selectField = ctrl.entity === 'Contact' ? 'id' : 'contact_id';
-        if (ctrl.entity !== 'Contact' && !searchMeta.getField('contact_id')) {
-          CRM.alert(ts('Cannot create smart group from %1.', {1: searchMeta.getEntity(true).titlePlural}), ts('Missing contact_id'), 'error', {expires: 5000});
-          return;
-        }
         var model = {
           title: '',
           description: '',
           visibility: 'User and User Admin Only',
           group_type: [],
           id: ctrl.load ? ctrl.load.id : null,
-          entity: ctrl.entity,
-          params: angular.extend({}, ctrl.params, {version: 4})
+          api_entity: ctrl.entity,
+          api_params: _.cloneDeep(angular.extend({}, ctrl.params, {version: 4}))
         };
-        delete model.params.orderBy;
+        delete model.api_params.orderBy;
+        if (ctrl.load && ctrl.load.api_params) {
+          model.api_params.select = ctrl.load.api_params.select;
+        }
         var options = CRM.utils.adjustDialogDefaults({
           autoOpen: false,
           title: ts('Save smart group')

--- a/ext/search/ang/search/crmSearch.component.js
+++ b/ext/search/ang/search/crmSearch.component.js
@@ -568,8 +568,8 @@
           api_params: _.cloneDeep(angular.extend({}, ctrl.params, {version: 4}))
         };
         delete model.api_params.orderBy;
-        if (ctrl.load && ctrl.load.api_params) {
-          model.api_params.select = ctrl.load.api_params.select;
+        if (ctrl.load && ctrl.load.api_params && ctrl.load.api_params.select && ctrl.load.api_params.select[0]) {
+          model.api_params.select.unshift(ctrl.load.api_params.select[0]);
         }
         var options = CRM.utils.adjustDialogDefaults({
           autoOpen: false,

--- a/ext/search/ang/search/crmSearchActions.component.js
+++ b/ext/search/ang/search/crmSearchActions.component.js
@@ -12,10 +12,10 @@
     templateUrl: '~/search/crmSearchActions.html',
     controller: function($scope, crmApi4, dialogService, searchMeta) {
       var ts = $scope.ts = CRM.ts(),
-        entityTitle = searchMeta.getEntity(this.entity).titlePlural,
         ctrl = this;
 
-      this.init = function() {
+      this.$onInit = function() {
+        var entityTitle = searchMeta.getEntity(ctrl.entity).titlePlural;
         if (!ctrl.actions) {
           var actions = _.transform(_.cloneDeep(CRM.vars.search.actions), function (actions, action) {
             if (_.includes(action.entities, ctrl.entity)) {

--- a/ext/search/ang/search/crmSearchFunction.component.js
+++ b/ext/search/ang/search/crmSearchFunction.component.js
@@ -10,9 +10,9 @@
     controller: function($scope, formatForSelect2, searchMeta) {
       var ts = $scope.ts = CRM.ts(),
         ctrl = this;
-      this.functions = formatForSelect2(_.where(CRM.vars.search.functions, {category: this.cat}), 'name', 'title');
 
       this.$onInit = function() {
+        ctrl.functions = formatForSelect2(_.where(CRM.vars.search.functions, {category: ctrl.cat}), 'name', 'title');
         var fieldInfo = searchMeta.parseExpr(ctrl.expr);
         ctrl.path = fieldInfo.path + fieldInfo.suffix;
         ctrl.field = fieldInfo.field;

--- a/ext/search/ang/search/saveSmartGroup.html
+++ b/ext/search/ang/search/saveSmartGroup.html
@@ -1,22 +1,30 @@
 <form id="bootstrap-theme">
   <div ng-controller="SaveSmartGroup">
+    <div crm-ui-debug="model"></div>
     <input class="form-control" id="api-save-search-select-group" ng-model="model.id" crm-entityref="groupEntityRefParams" >
     <label ng-show="!model.id">{{:: ts('Or') }}</label>
-    <input class="form-control" placeholder="Create new group" ng-model="model.title" ng-show="!model.id">
+    <input class="form-control" placeholder="{{:: ts('Create new group') }}" ng-model="model.title" ng-show="!model.id">
+    <hr />
+    <div class="form-inline">
+     <label for="api-save-search-select-column">{{:: ts('Contact Column:') }}</label>
+      <input id="api-save-search-select-column" ng-model="model.api_params.select[0]" class="form-control" crm-ui-select="{data: columns}"/>
+    </div>
     <hr />
     <label>{{:: ts('Description:') }}</label>
     <textarea class="form-control" ng-model="model.description"></textarea>
-    <label>{{:: ts('Group Type:') }}</label>
     <div class="form-inline">
-      <div class="checkbox" ng-repeat="option in groupFields.group_type.options track by option.id">
+      <label>{{:: ts('Group Type:') }} </label>
+      <div class="checkbox" ng-repeat="option in groupFields.group_type.options track by option.id">&nbsp;
         <label>
           <input type="checkbox" checklist-model="model.group_type" checklist-value="option.id">
           {{ option.label }}
-        </label>
+        </label>&nbsp;
       </div>
     </div>
-    <label>{{:: ts('Visibility:') }}</label>
-    <select class="form-control" ng-model="model.visibility" ng-options="item.id as item.label for item in groupFields.visibility.options track by item.id"></select>
+    <div class="form-inline">
+      <label>{{:: ts('Visibility:') }}</label>
+      <select class="form-control" ng-model="model.visibility" ng-options="item.id as item.label for item in groupFields.visibility.options track by item.id" crm-ui-select></select>
+    </div>
     <hr />
     <div class="buttons pull-right">
       <button type="button" ng-click="cancel()" class="btn btn-danger">{{:: ts('Cancel') }}</button>

--- a/ext/search/ang/search/saveSmartGroup.html
+++ b/ext/search/ang/search/saveSmartGroup.html
@@ -1,6 +1,5 @@
 <form id="bootstrap-theme">
   <div ng-controller="SaveSmartGroup">
-    <div crm-ui-debug="model"></div>
     <input class="form-control" id="api-save-search-select-group" ng-model="model.id" crm-entityref="groupEntityRefParams" >
     <label ng-show="!model.id">{{:: ts('Or') }}</label>
     <input class="form-control" placeholder="{{:: ts('Create new group') }}" ng-model="model.title" ng-show="!model.id">


### PR DESCRIPTION
Overview
----------------------------------------
Improves the new search extension and APIv4 smart groups in core to support any entity that can join with Contact, including full support for calculated fields and the HAVING clause.

Before
----------------------------------------
Limited smart group support.

After
----------------------------------------
Improved smart group support; with test.
