### PR TITLE
Display public title and description on profiles and unsubscribe/subs…

### DIFF
--- a/CRM/Contact/BAO/Group.php
+++ b/CRM/Contact/BAO/Group.php
@@ -1030,6 +1030,7 @@ class CRM_Contact_BAO_Group extends CRM_Contact_DAO_Group {
    * @param string $parents
    * @param string $spacer
    * @param bool $titleOnly
+   * @param bool $public
    *
    * @return array
    */
@@ -1037,7 +1038,8 @@ class CRM_Contact_BAO_Group extends CRM_Contact_DAO_Group {
     $groupIDs,
     $parents = NULL,
     $spacer = '<span class="child-indent"></span>',
-    $titleOnly = FALSE
+    $titleOnly = FALSE,
+    $public = FALSE
   ) {
     if (empty($groupIDs)) {
       return [];
@@ -1055,7 +1057,7 @@ class CRM_Contact_BAO_Group extends CRM_Contact_DAO_Group {
     $groups = [];
     $args = [1 => [$groupIdString, 'String']];
     $query = "
-SELECT id, title, description, visibility, parents, saved_search_id
+SELECT id, title, frontend_title, description, frontend_description, visibility, parents, saved_search_id
 FROM   civicrm_group
 WHERE  id IN $groupIdString
 ";
@@ -1076,22 +1078,32 @@ WHERE  id IN $groupIdString
     $roots = [];
     $tree = [];
     while ($dao->fetch()) {
+      $title = $dao->title;
+      $description = $dao->description;
+      if ($public) {
+        if (!empty($dao->frontend_title)) {
+          $title = $dao->frontend_title;
+        }
+        if (!empty($dao->frontend_description)) {
+          $description = $dao->frontend_description;
+        }
+      }
       if ($dao->parents) {
         $parentArray = explode(',', $dao->parents);
         $parent = self::filterActiveGroups($parentArray);
         $tree[$parent][] = [
           'id' => $dao->id,
-          'title' => empty($dao->saved_search_id) ? $dao->title : '* ' . $dao->title,
+          'title' => empty($dao->saved_search_id) ? $title : '* ' . $title,
           'visibility' => $dao->visibility,
-          'description' => $dao->description,
+          'description' => $description,
         ];
       }
       else {
         $roots[] = [
           'id' => $dao->id,
-          'title' => empty($dao->saved_search_id) ? $dao->title : '* ' . $dao->title,
+          'title' => empty($dao->saved_search_id) ? $title : '* ' . $title,
           'visibility' => $dao->visibility,
-          'description' => $dao->description,
+          'description' => $description,
         ];
       }
     }

--- a/CRM/Contact/BAO/GroupContact.php
+++ b/CRM/Contact/BAO/GroupContact.php
@@ -304,6 +304,8 @@ class CRM_Contact_BAO_GroupContact extends CRM_Contact_DAO_GroupContact {
    *
    * @param bool $includeSmartGroups
    *   Include or Exclude Smart Group(s)
+   * @param bool $public
+   *   Are we returning groups for use on a public page.
    *
    * @return array|int
    *   the relevant data object values for the contact or the total count when $count is TRUE
@@ -317,7 +319,8 @@ class CRM_Contact_BAO_GroupContact extends CRM_Contact_DAO_GroupContact {
     $onlyPublicGroups = FALSE,
     $excludeHidden = TRUE,
     $groupId = NULL,
-    $includeSmartGroups = FALSE
+    $includeSmartGroups = FALSE,
+    $public = FALSE
   ) {
     if ($count) {
       $select = 'SELECT count(DISTINCT civicrm_group_contact.id)';
@@ -326,6 +329,7 @@ class CRM_Contact_BAO_GroupContact extends CRM_Contact_DAO_GroupContact {
       $select = 'SELECT
                     civicrm_group_contact.id as civicrm_group_contact_id,
                     civicrm_group.title as group_title,
+                    civicrm_group.frontend_title as group_public_title,
                     civicrm_group.visibility as visibility,
                     civicrm_group_contact.status as status,
                     civicrm_group.id as group_id,
@@ -393,7 +397,7 @@ class CRM_Contact_BAO_GroupContact extends CRM_Contact_DAO_GroupContact {
         $id = $dao->civicrm_group_contact_id;
         $values[$id]['id'] = $id;
         $values[$id]['group_id'] = $dao->group_id;
-        $values[$id]['title'] = $dao->group_title;
+        $values[$id]['title'] = ($public && !empty($group->group_public_title) ? $group->group_public_title : $dao->group_title);
         $values[$id]['visibility'] = $dao->visibility;
         $values[$id]['is_hidden'] = $dao->is_hidden;
         switch ($dao->status) {

--- a/CRM/Contact/Form/Edit/TagsAndGroups.php
+++ b/CRM/Contact/Form/Edit/TagsAndGroups.php
@@ -41,9 +41,10 @@ class CRM_Contact_Form_Edit_TagsAndGroups {
    *   If used for building tag block.
    * @param string $fieldName
    *   This is used in batch profile(i.e to build multiple blocks).
-   *
    * @param string $groupElementType
-   *
+   *   The html type of the element we are adding e.g. checkbox, select
+   * @param bool $public
+   *   Is this being used in a public form e.g. Profile.
    */
   public static function buildQuickForm(
     &$form,
@@ -54,7 +55,8 @@ class CRM_Contact_Form_Edit_TagsAndGroups {
     $groupName = 'Group(s)',
     $tagName = 'Tag(s)',
     $fieldName = NULL,
-    $groupElementType = 'checkbox'
+    $groupElementType = 'checkbox',
+    $public = FALSE
   ) {
     if (!isset($form->_tagGroup)) {
       $form->_tagGroup = [];
@@ -88,7 +90,7 @@ class CRM_Contact_Form_Edit_TagsAndGroups {
       }
 
       if ($groupID || !empty($group)) {
-        $groups = CRM_Contact_BAO_Group::getGroupsHierarchy($ids, NULL, '- ');
+        $groups = CRM_Contact_BAO_Group::getGroupsHierarchy($ids, NULL, '- ', FALSE, $public);
 
         $attributes['skiplabel'] = TRUE;
         $elements = [];

--- a/CRM/Contact/Page/View/UserDashBoard/GroupContact.php
+++ b/CRM/Contact/Page/View/UserDashBoard/GroupContact.php
@@ -25,7 +25,7 @@ class CRM_Contact_Page_View_UserDashBoard_GroupContact extends CRM_Contact_Page_
       NULL,
       NULL, TRUE, TRUE,
       $this->_onlyPublicGroups,
-      NULL, NULL, TRUE
+      NULL, NULL, TRUE, TRUE
     );
 
     $in = CRM_Contact_BAO_GroupContact::getContactGroup(
@@ -33,7 +33,7 @@ class CRM_Contact_Page_View_UserDashBoard_GroupContact extends CRM_Contact_Page_
       'Added',
       NULL, FALSE, TRUE,
       $this->_onlyPublicGroups,
-      NULL, NULL, TRUE
+      NULL, NULL, TRUE, TRUE
     );
 
     $pending = CRM_Contact_BAO_GroupContact::getContactGroup(
@@ -41,7 +41,7 @@ class CRM_Contact_Page_View_UserDashBoard_GroupContact extends CRM_Contact_Page_
       'Pending',
       NULL, FALSE, TRUE,
       $this->_onlyPublicGroups,
-      NULL, NULL, TRUE
+      NULL, NULL, TRUE, TRUE
     );
 
     $out = CRM_Contact_BAO_GroupContact::getContactGroup(
@@ -49,7 +49,7 @@ class CRM_Contact_Page_View_UserDashBoard_GroupContact extends CRM_Contact_Page_
       'Removed',
       NULL, FALSE, TRUE,
       $this->_onlyPublicGroups,
-      NULL, NULL, TRUE
+      NULL, NULL, TRUE, TRUE
     );
 
     $this->assign('groupCount', $count);

--- a/CRM/Core/BAO/UFGroup.php
+++ b/CRM/Core/BAO/UFGroup.php
@@ -2026,7 +2026,7 @@ AND    ( entity_id IS NULL OR entity_id <= 0 )
       CRM_Contact_Form_Edit_TagsAndGroups::buildQuickForm($form, $contactId,
         CRM_Contact_Form_Edit_TagsAndGroups::GROUP,
         TRUE, $required,
-        $title, NULL, $name
+        $title, NULL, $name, 'checkbox', TRUE
       );
     }
     elseif ($fieldName === 'tag') {

--- a/CRM/Group/Form/Edit.php
+++ b/CRM/Group/Form/Edit.php
@@ -67,6 +67,8 @@ class CRM_Group_Form_Edit extends CRM_Core_Form {
         'required' => TRUE,
       ],
       'description' => ['name' => 'description'],
+      'frontend_title' => ['name' => 'frontend_title'],
+      'frontend_description' => ['name' => 'frontend_description'],
     ];
   }
 

--- a/CRM/Mailing/Event/BAO/Unsubscribe.php
+++ b/CRM/Mailing/Event/BAO/Unsubscribe.php
@@ -234,6 +234,8 @@ WHERE  email = %2
     $do = CRM_Core_DAO::executeQuery("
             SELECT      grp.id as group_id,
                         grp.title as title,
+                        grp.frontend_title as frontend_title,
+                        grp.frontend_description as frontend_description,
                         grp.description as description
             FROM        civicrm_group grp
             LEFT JOIN   civicrm_group_contact gc
@@ -250,15 +252,15 @@ WHERE  email = %2
       $returnGroups = [];
       while ($do->fetch()) {
         $returnGroups[$do->group_id] = [
-          'title' => $do->title,
-          'description' => $do->description,
+          'title' => !empty($do->frontend_title) ? $do->frontend_title : $do->title,
+          'description' => !empty($do->frontend_description) ? $do->frontend_description : $do->description,
         ];
       }
       return $returnGroups;
     }
     else {
       while ($do->fetch()) {
-        $groups[$do->group_id] = $do->title;
+        $groups[$do->group_id] = !empty($do->frontend_title) ? $do->frontend_title : $do->title;
       }
     }
     $transaction = new CRM_Core_Transaction();

--- a/CRM/Mailing/Form/Subscribe.php
+++ b/CRM/Mailing/Form/Subscribe.php
@@ -34,7 +34,7 @@ class CRM_Mailing_Form_Subscribe extends CRM_Core_Form {
 
       // make sure requested qroup is accessible and exists
       $query = "
-SELECT   title, description
+SELECT   title, frontend_title, description, frontend_description
   FROM   civicrm_group
  WHERE   id={$this->_groupID}
    AND   visibility != 'User and User Admin Only'
@@ -42,8 +42,8 @@ SELECT   title, description
 
       $dao = CRM_Core_DAO::executeQuery($query);
       if ($dao->fetch()) {
-        $this->assign('groupName', $dao->title);
-        CRM_Utils_System::setTitle(ts('Subscribe to Mailing List - %1', [1 => $dao->title]));
+        $this->assign('groupName', !empty($dao->frontend_title) ? $dao->frontend_title : $dao->title);
+        CRM_Utils_System::setTitle(ts('Subscribe to Mailing List - %1', [1 => !empty($dao->frontend_title) ? $dao->frontend_title : $dao->title]));
       }
       else {
         CRM_Core_Error::statusBounce("The specified group is not configured for this action OR The group doesn't exist.");
@@ -77,7 +77,7 @@ SELECT   title, description
       $groupTypeCondition = CRM_Contact_BAO_Group::groupTypeCondition('Mailing');
 
       $query = "
-SELECT   id, title, description
+SELECT   id, title, frontend_title, description, frontend_description
   FROM   civicrm_group
  WHERE   ( saved_search_id = 0
     OR     saved_search_id IS NULL )
@@ -89,8 +89,8 @@ ORDER BY title";
       while ($dao->fetch()) {
         $row = [];
         $row['id'] = $dao->id;
-        $row['title'] = $dao->title;
-        $row['description'] = $dao->description;
+        $row['title'] = $dao->frontend_title ?? $dao->title;
+        $row['description'] = $dao->frontend_description ?? $dao->description;
         $row['checkbox'] = CRM_Core_Form::CB_PREFIX . $row['id'];
         $this->addElement('checkbox',
           $row['checkbox'],

--- a/templates/CRM/Group/Form/Edit.tpl
+++ b/templates/CRM/Group/Form/Edit.tpl
@@ -26,25 +26,23 @@
       </td>
     </tr>
 
-    {if $group.created_by}
-      <tr class="crm-group-form-block-created">
-        <td class="label">{ts}Created By{/ts}</td>
-        <td>{$group.created_by}</td>
-      </tr>
-    {/if}
-
-    {if $group.modified_by}
-      <tr class="crm-group-form-block-modified">
-        <td class="label">{ts}Modified By{/ts}</td>
-        <td>{$group.modified_by}</td>
-      </tr>
-    {/if}
-
     <tr class="crm-group-form-block-description">
       <td class="label">{$form.description.label}</td>
-      <td>{$form.description.html}<br />
-        <span class="description">{ts}Group description is displayed when groups are listed in Profiles and Mailing List Subscribe forms.{/ts}</span>
+      <td>{$form.description.html}</td>
+    </tr>
+
+    <tr><td colspan="2">If either of the following fields are filled out they will be used instead of the title or description field in profiles and Mailing List Subscription/unsubscribe forms</td></tr>
+
+    <tr class="crm-group-form-block-frontend-title">
+      <td class="label">{$form.frontend_title.label} {if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_group' field='frontend_title' id=$group.id}{/if}</td>
+      <td>{$form.frontend_title.html|crmAddClass:huge}
+        {if $group.saved_search_id}&nbsp;({ts}Smart Group{/ts}){/if}
       </td>
+    </tr>
+
+    <tr class="crm-group-form-block-frontend-description">
+      <td class="label">{$form.frontend_description.label} {if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_group' field='frontend_description' id=$group.id}{/if}</td>
+      <td>{$form.frontend_description.html}</td>
     </tr>
 
     {if $form.group_type}
@@ -70,6 +68,21 @@
       <td class="label">{$form.is_active.label}</td>
       <td>{$form.is_active.html}</td>
     </tr>
+
+   {if $group.created_by}
+      <tr class="crm-group-form-block-created">
+        <td class="label">{ts}Created By{/ts}</td>
+        <td>{$group.created_by}</td>
+      </tr>
+    {/if}
+
+    {if $group.modified_by}
+      <tr class="crm-group-form-block-modified">
+        <td class="label">{ts}Modified By{/ts}</td>
+        <td>{$group.modified_by}</td>
+      </tr>
+    {/if}
+
 
     <tr>
       <td colspan=2>{include file="CRM/Custom/Form/CustomData.tpl"}</td>


### PR DESCRIPTION
…cribe forms as appropriate if set

Overview
----------------------------------------
This starts to make use of the new frontend title and description fields if on unsubscribe / subscribe / user dashboard pages

Before
----------------------------------------
Internal / Private group title & description fields would be used all the time

After
----------------------------------------
Public title or description or both fields used if set otherwise fall back on the internal fields

ping @artfulrobot @agileware-justin @demeritcowboy 
