### PR TITLE
[REF] Add in css classes to make the save and preview button on the C…

### DIFF
--- a/CRM/Contribute/Form/ContributionPage/Widget.php
+++ b/CRM/Contribute/Form/ContributionPage/Widget.php
@@ -191,7 +191,7 @@ class CRM_Contribute_Form_ContributionPage_Widget extends CRM_Contribute_Form_Co
     $this->addElement('xbutton',
       $this->_refreshButtonName,
       ts('Save and Preview'),
-      ['type' => 'submit']
+      ['type' => 'submit', 'class' => 'crm-button crm-form-submit crm-button-type-submit']
     );
     parent::buildQuickForm();
     $this->addFormRule(['CRM_Contribute_Form_ContributionPage_Widget', 'formRule'], $this);


### PR DESCRIPTION
…ontribution Page widget settings form look consistant with the other buttons on the page

Overview
----------------------------------------
This adds in CSS classes to fix the look of the Save and Preview button on the Contribution Page Widget settings

Before
----------------------------------------
![button_class_before](https://user-images.githubusercontent.com/6799125/94749508-4c651400-03c7-11eb-9631-7bdc0f04d74c.jpg)


After
----------------------------------------
![button_class_after](https://user-images.githubusercontent.com/6799125/94749515-51c25e80-03c7-11eb-827d-63d6c2d0d798.jpg)


ping @eileenmcnaughton @agh1 
