### PR TITLE
Ensure that the crm-error class on the field is also remove when field is changed

### DIFF
--- a/js/Common.js
+++ b/js/Common.js
@@ -1322,7 +1322,7 @@ if (!CRM.vars) CRM.vars = {};
       setTimeout(function () {
         ele.one('change', function () {
           if (msg && msg.close) msg.close();
-          ele.removeClass('error');
+          ele.removeClass('crm-error');
           label.removeClass('crm-error');
         });
       }, 1000);


### PR DESCRIPTION
Overview
----------------------------------------
When using the crmError js function we append the crm-error class to the label and the element however when the contents of the element is changed then the crm-error class is only removed from the label not the element as well

Before
----------------------------------------
crm-error class remains attached to the element even after change

After
----------------------------------------
crm-error class is removed from the element as well

ping @colemanw @demeritcowboy note the class is added to the element on L1317