### PR TITLE
Fix complexity on cache key

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -332,7 +332,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
     $cacheKey .= $inline ? '_1_' : '_0_';
     $cacheKey .= $onlyParent ? '_1_' : '_0_';
     $cacheKey .= $onlySubType ? '_1_' : '_0_';
-    $cacheKey .= $checkPermission ? '_1_' : '_0_';
+    $cacheKey .= $checkPermission ? '_1_' . CRM_Core_Session::getLoggedInContactID() . '_' : '_0_0_';
     $cacheKey .= '_' . CRM_Core_Config::domainID() . '_';
 
     $cgTable = CRM_Core_DAO_CustomGroup::getTableName();


### PR DESCRIPTION

Overview
----------------------------------------
This seems a likely culprit for https://lab.civicrm.org/dev/core/-/issues/1984
but comments on the gl are inconclusive. Regardless, we can conclude the cacheKey
should not cross-populate values from different users


Before
----------------------------------------
Custom field cache for different users can potentially contaminate each other

After
----------------------------------------
user id added into the cachekey, when permissioned

Technical Details
----------------------------------------


Comments
----------------------------------------

