### PR TITLE
dev/core#2079 [Ref] Clarify calls to CRM_Utils_Token::getTokenDetails

### DIFF
--- a/CRM/Contribute/Form/Task/PDFLetterCommon.php
+++ b/CRM/Contribute/Form/Task/PDFLetterCommon.php
@@ -296,7 +296,7 @@ class CRM_Contribute_Form_Task_PDFLetterCommon extends CRM_Contact_Form_Task_PDF
     // Hooks allow more nuanced smarty usage here.
     CRM_Core_Smarty::singleton()->assign('contributions', $contributions);
     foreach ($contacts as $contactID => $contact) {
-      $tokenResolvedContacts = CRM_Utils_Token::getTokenDetails(['contact_id' => $contactID],
+      [$tokenResolvedContacts] = CRM_Utils_Token::getTokenDetails(['contact_id' => $contactID],
         $returnProperties,
         $skipOnHold,
         $skipDeceased,
@@ -304,7 +304,7 @@ class CRM_Contribute_Form_Task_PDFLetterCommon extends CRM_Contact_Form_Task_PDF
         $messageToken,
         $task
       );
-      $contacts[$contactID] = array_merge($tokenResolvedContacts[0][$contactID], $contact);
+      $contacts[$contactID] = array_merge($tokenResolvedContacts[$contactID], $contact);
     }
     return [$contributions, $contacts];
   }

--- a/CRM/Mailing/BAO/MailingJob.php
+++ b/CRM/Mailing/BAO/MailingJob.php
@@ -597,7 +597,7 @@ VALUES (%1, %2, %3, %4, %5, %6, %7)
       $params[] = $field['contact_id'];
     }
 
-    $details = CRM_Utils_Token::getTokenDetails(
+    [$details] = CRM_Utils_Token::getTokenDetails(
       $params,
       $returnProperties,
       $skipOnHold, TRUE, NULL,
@@ -606,11 +606,10 @@ VALUES (%1, %2, %3, %4, %5, %6, %7)
       $this->id
     );
 
-    $config = CRM_Core_Config::singleton();
     foreach ($fields as $key => $field) {
       $contactID = $field['contact_id'];
-      if (!array_key_exists($contactID, $details[0])) {
-        $details[0][$contactID] = [];
+      if (!array_key_exists($contactID, $details)) {
+        $details[$contactID] = [];
       }
 
       // Compose the mailing.
@@ -623,7 +622,7 @@ VALUES (%1, %2, %3, %4, %5, %6, %7)
       $message = $mailing->compose(
         $this->id, $field['id'], $field['hash'],
         $field['contact_id'], $field['email'],
-        $recipient, FALSE, $details[0][$contactID], $attachments,
+        $recipient, FALSE, $details[$contactID], $attachments,
         FALSE, NULL, $replyToEmail
       );
       if (empty($message)) {
@@ -640,8 +639,8 @@ VALUES (%1, %2, %3, %4, %5, %6, %7)
 
       if ($mailing->sms_provider_id) {
         $provider = CRM_SMS_Provider::singleton(['mailing_id' => $mailing->id]);
-        $body = $provider->getMessage($message, $field['contact_id'], $details[0][$contactID]);
-        $headers = $provider->getRecipientDetails($field, $details[0][$contactID]);
+        $body = $provider->getMessage($message, $field['contact_id'], $details[$contactID]);
+        $headers = $provider->getRecipientDetails($field, $details[$contactID]);
       }
 
       // make $recipient actually be the *encoded* header, so as not to baffle Mail_RFC822, CRM-5743

--- a/tests/phpunit/CRM/Utils/TokenTest.php
+++ b/tests/phpunit/CRM/Utils/TokenTest.php
@@ -129,9 +129,9 @@ class CRM_Utils_TokenTest extends CiviUnitTestCase {
     }
     unset($params['email']);
 
-    $resolvedTokens = CRM_Utils_Token::getTokenDetails($contactIDs);
+    [$resolvedTokens] = CRM_Utils_Token::getTokenDetails($contactIDs);
     foreach ($contactIDs as $contactID) {
-      $resolvedContactTokens = $resolvedTokens[0][$contactID];
+      $resolvedContactTokens = $resolvedTokens[$contactID];
       $this->assertEquals('Individual', $resolvedContactTokens['contact_type']);
       $this->assertEquals('Anderson, Anthony', $resolvedContactTokens['sort_name']);
       $this->assertEquals('en_US', $resolvedContactTokens['preferred_language']);


### PR DESCRIPTION

Overview
----------------------------------------
This changes the call to getTokenDetails to make it clearer that only the first parameter is used.

The second parameter is an unused query that we should eliminate but getting it
easier to scan is a good first step

Before
----------------------------------------
```
$tokenResolvedContacts = CRM_Utils_Token::getTokenDetails(['contact_id' => $contactID],
```

then used as ```$tokenResolvedContacts[0]```

After
----------------------------------------
```
[$tokenResolvedContacts] = CRM_Utils_Token::getTokenDetails(['contact_id' => $contactID],
```

then used without the [0]

Technical Details
----------------------------------------


Comments
----------------------------------------

