### PR TITLE
dev/core#2079  [REF] Fix some more calls to getTokens to make it clear only the first return value is used

### DIFF
--- a/CRM/Mailing/Page/Preview.php
+++ b/CRM/Mailing/Page/Preview.php
@@ -60,15 +60,15 @@ class CRM_Mailing_Page_Preview extends CRM_Core_Page {
     $returnProperties = $mailing->getReturnProperties();
     $params = ['contact_id' => $session->get('userID')];
 
-    $details = CRM_Utils_Token::getTokenDetails($params,
+    [$details] = CRM_Utils_Token::getTokenDetails($params,
       $returnProperties,
       TRUE, TRUE, NULL,
       $mailing->getFlattenedTokens(),
       get_class($this)
     );
-    // $details[0] is an array of [ contactID => contactDetails ]
+    // $details is an array of [ contactID => contactDetails ]
     $mime = &$mailing->compose(NULL, NULL, NULL, $session->get('userID'), $fromEmail, $fromEmail,
-      TRUE, $details[0][$session->get('userID')], $attachments
+      TRUE, $details[$session->get('userID')], $attachments
     );
 
     if ($type == 'html') {

--- a/CRM/Pledge/BAO/Pledge.php
+++ b/CRM/Pledge/BAO/Pledge.php
@@ -587,13 +587,13 @@ GROUP BY  currency
     foreach ($fields as $key => $val) {
       $returnProperties[$val] = TRUE;
     }
-    $details = CRM_Utils_Token::getTokenDetails($ids,
+    [$details] = CRM_Utils_Token::getTokenDetails($ids,
       $returnProperties,
       TRUE, TRUE, NULL,
       $tokens,
       get_class($form)
     );
-    $form->assign('contact', $details[0][$params['contact_id']]);
+    $form->assign('contact', $details[$params['contact_id']]);
 
     // handle custom data.
     if (!empty($params['hidden_custom'])) {


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#2079  [REF] Fix some more calls to getTokens to make it clear only the first return value is used

https://lab.civicrm.org/dev/core/-/issues/2079

Before
----------------------------------------
```
$details = CRM_Utils_Token::getTokenDetails($params,
```

uses ```$details[0]```

After
----------------------------------------
```[$details] = CRM_Utils_Token::getTokenDetails($params,```

Technical Details
----------------------------------------
Towards not returning the any second value

Comments
----------------------------------------
