### PR TITLE
dev/core#2079 [REF] Fix some more calls to getTokens to make it clear only the first return value is used

### DIFF
--- a/api/v3/Mailing.php
+++ b/api/v3/Mailing.php
@@ -567,8 +567,8 @@ function civicrm_api3_mailing_preview($params) {
     $details = $details[0][0] ?? NULL;
   }
   else {
-    $details = CRM_Utils_Token::getTokenDetails($mailingParams, $returnProperties, TRUE, TRUE, NULL, $mailing->getFlattenedTokens());
-    $details = $details[0][$contactID];
+    [$details] = CRM_Utils_Token::getTokenDetails($mailingParams, $returnProperties, TRUE, TRUE, NULL, $mailing->getFlattenedTokens());
+    $details = $details[$contactID];
   }
 
   $mime = $mailing->compose(NULL, NULL, NULL, $contactID, $fromEmail, $fromEmail,

--- a/tests/phpunit/CRM/Utils/TokenTest.php
+++ b/tests/phpunit/CRM/Utils/TokenTest.php
@@ -11,8 +11,8 @@ class CRM_Utils_TokenTest extends CiviUnitTestCase {
    */
   public function testGetTokenDetails() {
     $contactID = $this->individualCreate(['preferred_communication_method' => ['Phone', 'Fax']]);
-    $resolvedTokens = CRM_Utils_Token::getTokenDetails([$contactID]);
-    $this->assertEquals('Phone, Fax', $resolvedTokens[0][$contactID]['preferred_communication_method']);
+    [$resolvedTokens] = CRM_Utils_Token::getTokenDetails([$contactID]);
+    $this->assertEquals('Phone, Fax', $resolvedTokens[$contactID]['preferred_communication_method']);
   }
 
   /**
@@ -49,8 +49,8 @@ class CRM_Utils_TokenTest extends CiviUnitTestCase {
     $contactIDs = [$contactID];
 
     // when we are fetching contact details ON basis of primary address fields
-    $contactDetails = CRM_Utils_Token::getTokenDetails($contactIDs);
-    $this->assertEquals($primaryEmail, $contactDetails[0][$contactID]['email']);
+    [$contactDetails] = CRM_Utils_Token::getTokenDetails($contactIDs);
+    $this->assertEquals($primaryEmail, $contactDetails[$contactID]['email']);
 
     // restore setting
     Civi::settings()->set('searchPrimaryDetailsOnly', '1');


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#2079  [REF] Fix some more calls to getTokens to make it clear only the first return value is used

https://lab.civicrm.org/dev/core/-/issues/2079

Before
----------------------------------------
```
$details = CRM_Utils_Token::getTokenDetails($params,
```

uses ```$details[0]```

After
----------------------------------------
```[$details] = CRM_Utils_Token::getTokenDetails($params,```

Technical Details
----------------------------------------
Towards not returning the any second value

Comments
----------------------------------------