### PR TITLE
dev/core#2079 [REF] Remove reference to second param returned from CRM_Contact_BAO_Query::apiQuery

### DIFF
--- a/CRM/Contact/BAO/Group.php
+++ b/CRM/Contact/BAO/Group.php
@@ -118,7 +118,7 @@ class CRM_Contact_BAO_Group extends CRM_Contact_DAO_Group {
    */
   public static function getGroupContacts($id) {
     $params = [['group', 'IN', [1 => $id], 0, 0]];
-    list($contacts, $_) = CRM_Contact_BAO_Query::apiQuery($params, ['contact_id']);
+    [$contacts] = CRM_Contact_BAO_Query::apiQuery($params, ['contact_id']);
     return $contacts;
   }
 

--- a/CRM/Contact/BAO/GroupContact.php
+++ b/CRM/Contact/BAO/GroupContact.php
@@ -555,7 +555,7 @@ SELECT    *
       ['group', 'IN', [$groupID], 0, 0],
       ['contact_id', '=', $contactID, 0, 0],
     ];
-    list($contacts, $_) = CRM_Contact_BAO_Query::apiQuery($params, ['contact_id']);
+    [$contacts] = CRM_Contact_BAO_Query::apiQuery($params, ['contact_id']);
 
     if (!empty($contacts)) {
       return TRUE;

--- a/CRM/Core/BAO/MessageTemplate.php
+++ b/CRM/Core/BAO/MessageTemplate.php
@@ -238,7 +238,7 @@ class CRM_Core_BAO_MessageTemplate extends CRM_Core_DAO_MessageTemplate {
       }
 
       $params = [['contact_id', '=', $contactId, 0, 0]];
-      list($contact, $_) = CRM_Contact_BAO_Query::apiQuery($params);
+      [$contact] = CRM_Contact_BAO_Query::apiQuery($params);
 
       //CRM-4524
       $contact = reset($contact);
@@ -581,7 +581,7 @@ class CRM_Core_BAO_MessageTemplate extends CRM_Core_DAO_MessageTemplate {
 
     if ($params['toEmail']) {
       $contactParams = [['email', 'LIKE', $params['toEmail'], 0, 1]];
-      list($contact, $_) = CRM_Contact_BAO_Query::apiQuery($contactParams);
+      [$contact] = CRM_Contact_BAO_Query::apiQuery($contactParams);
 
       $prefs = array_pop($contact);
 

--- a/Civi/Token/TokenCompatSubscriber.php
+++ b/Civi/Token/TokenCompatSubscriber.php
@@ -58,7 +58,7 @@ class TokenCompatSubscriber implements EventSubscriberInterface {
         $params = [
           ['contact_id', '=', $contactId, 0, 0],
         ];
-        list($contact, $_) = \CRM_Contact_BAO_Query::apiQuery($params);
+        [$contact] = \CRM_Contact_BAO_Query::apiQuery($params);
         //CRM-4524
         $contact = reset($contact);
         if (!$contact || is_a($contact, 'CRM_Core_Error')) {

--- a/tests/phpunit/CRM/Contact/BAO/QueryTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/QueryTest.php
@@ -575,9 +575,9 @@ class CRM_Contact_BAO_QueryTest extends CiviUnitTestCase {
         $searchParams = [[$key, '=', strtolower($value), 0, 1]];
       }
 
-      $result = CRM_Contact_BAO_Query::apiQuery($searchParams);
-      $this->assertCount(1, $result[0], 'search for ' . $key);
-      $contact = reset($result[0]);
+      [$result] = CRM_Contact_BAO_Query::apiQuery($searchParams);
+      $this->assertCount(1, $result, 'search for ' . $key);
+      $contact = reset($result);
       $this->assertEquals('Minnie Mouse', $contact['display_name']);
       $this->assertEquals('BOb', $contact['current_employer']);
     }


### PR DESCRIPTION
Overview
----------------------------------------
Stop casting the unused return variable to an array

https://lab.civicrm.org/dev/core/-/issues/2079

Before
----------------------------------------
```
list($contacts, $_) = CRM_Contact_BAO_Query::apiQuery($params, ['contact_id']);
```

After
----------------------------------------
```
[$contacts] = CRM_Contact_BAO_Query::apiQuery($params, ['contact_id']);
```

Technical Details
----------------------------------------


Comments
----------------------------------------

