### PR TITLE
dev/core#2046 Migrate BAO_Address::create towards standardisation

### DIFF
--- a/CRM/Contact/Form/Inline/Address.php
+++ b/CRM/Contact/Form/Inline/Address.php
@@ -169,7 +169,7 @@ class CRM_Contact_Form_Inline_Address extends CRM_Contact_Form_Inline {
     }
 
     // save address changes
-    $address = CRM_Core_BAO_Address::create($params, TRUE);
+    $address = CRM_Core_BAO_Address::legacyCreate($params, TRUE);
 
     $this->log();
     $this->ajaxResponse['addressId'] = $address[0]->id;

--- a/CRM/Core/BAO/Location.php
+++ b/CRM/Core/BAO/Location.php
@@ -45,11 +45,11 @@ class CRM_Core_BAO_Location extends CRM_Core_DAO {
 
     // create location blocks.
     foreach (self::$blocks as $block) {
-      if ($block != 'address') {
+      if ($block !== 'address') {
         $location[$block] = CRM_Core_BAO_Block::create($block, $params);
       }
-      else {
-        $location[$block] = CRM_Core_BAO_Address::create($params, $fixAddress);
+      elseif (is_array($params['address'] ?? NULL)) {
+        $location[$block] = CRM_Core_BAO_Address::legacyCreate($params, $fixAddress);
       }
     }
 

--- a/tests/phpunit/CRM/Core/BAO/AddressTest.php
+++ b/tests/phpunit/CRM/Core/BAO/AddressTest.php
@@ -50,7 +50,7 @@ class CRM_Core_BAO_AddressTest extends CiviUnitTestCase {
 
     $fixAddress = TRUE;
 
-    CRM_Core_BAO_Address::create($params, $fixAddress);
+    CRM_Core_BAO_Address::legacyCreate($params, $fixAddress);
     $addressId = $this->assertDBNotNull('CRM_Core_DAO_Address', 'Oberoi Garden', 'id', 'street_address',
       'Database check for created address.'
     );
@@ -76,7 +76,7 @@ class CRM_Core_BAO_AddressTest extends CiviUnitTestCase {
     ];
     $params['contact_id'] = $contactId;
 
-    $block = CRM_Core_BAO_Address::create($params, $fixAddress);
+    $block = CRM_Core_BAO_Address::legacyCreate($params, $fixAddress);
 
     $this->assertDBNotNull('CRM_Core_DAO_Address', $contactId, 'id', 'contact_id',
       'Database check for updated address by contactId.'
@@ -253,7 +253,7 @@ class CRM_Core_BAO_AddressTest extends CiviUnitTestCase {
 
     $fixAddress = TRUE;
 
-    CRM_Core_BAO_Address::create($params, $fixAddress);
+    CRM_Core_BAO_Address::legacyCreate($params, $fixAddress);
 
     $addressId = $this->assertDBNotNull('CRM_Core_DAO_Address', $contactId, 'id', 'contact_id',
       'Database check for created address.'


### PR DESCRIPTION


Overview
----------------------------------------
This moves us towards standardisation on BAO_Address::create - as part of a wider BAO standardisation fix - per https://lab.civicrm.org/dev/core/-/issues/2046 and also as part of identifying and addressing places in the code where is_primary integrity is mismanaged

Our standard expectation is that each BAO will have a create action that handles a single entity. For legacy
reasons Address.create has special handling for multiple addresses. This extracts that handling
into a separate function (legacyCreate) and updates the (very few) places currently calling create to
call that.

Before
----------------------------------------
 BAO_Address::create does not operate like a standard crud action - it expects a key 'address' and creates multiple addresses based on that key

After
----------------------------------------
 BAO_Address::create still accepts the key 'address' and if present the call will be redirected to the original code (in a function now called ```legacyCreate```. However, it also accepts 'normal' crud calls (in which case it acts as a pseudonym for add

Technical Details
----------------------------------------


With this merged apis v3 & v4 can call Address.create  - currently v3 is hard coded to call add and
v4 bypasses the BAO altogether. The v4 api bypass means we are not managing is_primary integrity on v4 api calls

The next step would be to fix apiv4 to call this

Comments
----------------------------------------

