### PR TITLE
dev/core#1393 - distmaker - Skip new file "vendor/bin/cssmin"

### DIFF
--- a/distmaker/dists/common.sh
+++ b/distmaker/dists/common.sh
@@ -209,7 +209,7 @@ function dm_install_vendor() {
   [ ! -d "$to" ] && mkdir "$to"
   ${DM_RSYNC:-rsync} -avC $excludes_rsync "$repo/./" "$to/./"
   ## We don't this use CLI script in production, and the symlink breaks D7/BD URL installs
-  dm_remove_files "$to" "bin/pscss"
+  dm_remove_files "$to" "bin/pscss" "bin/cssmin"
 }
 
 ##  usage: dm_install_wordpress <wp_repo_path> <to_path>


### PR DESCRIPTION
Overview
----------------------------------------

This fixes the broken distmaker builds in `master`.

The file `vendor/bin/cssmin` was recently added by way of `composer-compile-lib => cssmin`. We don't need it in the tarball, and it's a symlink, so trying to include breaks some consumers (like in https://lab.civicrm.org/dev/core/-/issues/1393).

ping @seamuslee001

Technical Details
----------------------------------------

* Before (last release): `vendor/bin/cssmin` does not exist
* Before (current master): `vendor/bin/cssmin` is created as symlink, copied to tarball
* After (this commit): `vendor/bin/cssmin` is created on dev-builds but omitted from tarball
