### PR TITLE
(REF) Make it easier for extensions to define basic bundles

### DIFF
--- a/CRM/Core/Resources/Bundle.php
+++ b/CRM/Core/Resources/Bundle.php
@@ -38,4 +38,27 @@ class CRM_Core_Resources_Bundle implements CRM_Core_Resources_CollectionInterfac
     $this->types = $types ?: ['script', 'scriptFile', 'scriptUrl', 'settings', 'style', 'styleFile', 'styleUrl'];
   }
 
+  /**
+   * Fill in default values for the 'region' property.
+   *
+   * @return static
+   */
+  public function fillDefaults() {
+    $this->filter(function ($s) {
+      if (!isset($s['region'])) {
+        if ($s['type'] === 'settings') {
+          $s['region'] = NULL;
+        }
+        elseif (preg_match(';^(markup|template|callback);', $s['type'])) {
+          $s['region'] = 'page-header';
+        }
+        else {
+          $s['region'] = CRM_Core_Resources_Common::REGION;
+        }
+      }
+      return $s;
+    });
+    return $this;
+  }
+
 }

--- a/CRM/Core/Resources/Bundle.php
+++ b/CRM/Core/Resources/Bundle.php
@@ -32,10 +32,23 @@ class CRM_Core_Resources_Bundle implements CRM_Core_Resources_CollectionInterfac
    * @param string|NULL $name
    * @param string[]|NULL $types
    *   List of resource-types to permit in this bundle. NULL for a default list.
+   *   Ex: ['styleFile', 'styleUrl']
+   *   The following aliases are allowed: '*all*', '*default*', '*script*', '*style*'
    */
   public function __construct($name = NULL, $types = NULL) {
     $this->name = $name;
-    $this->types = $types ?: ['script', 'scriptFile', 'scriptUrl', 'settings', 'style', 'styleFile', 'styleUrl'];
+
+    $typeAliases = [
+      '*all*' => ['script', 'scriptFile', 'scriptUrl', 'settings', 'style', 'styleFile', 'styleUrl', 'markup', 'template', 'callback'],
+      '*default*' => ['script', 'scriptFile', 'scriptUrl', 'settings', 'style', 'styleFile', 'styleUrl'],
+      '*style*' => ['style', 'styleFile', 'styleUrl'],
+      '*script*' => ['script', 'scriptFile', 'scriptUrl'],
+    ];
+    $mapType = function ($t) use ($typeAliases) {
+      return $typeAliases[$t] ?? [$t];
+    };
+    $types = $types ?: ['*default*'];
+    $this->types = array_unique(array_merge(...array_map($mapType, (array) $types)));
   }
 
   /**

--- a/CRM/Core/Resources/Common.php
+++ b/CRM/Core/Resources/Common.php
@@ -17,16 +17,22 @@ class CRM_Core_Resources_Common {
   const REGION = 'html-header';
 
   /**
-   * A "basic" bundle has an
+   * Create a "basic" (generic) bundle.
+   *
+   * The bundle goes through some lifecycle events (like `hook_alterBundle`).
+   *
+   * To define default content for a basic bundle, you may either give an
+   * `$init` function or subscribe to `hook_alterBundle`.
    *
    * @param string $name
    *   Symbolic name of the bundle.
    * @param callable|NULL $init
    *   Optional initialization function. Populate default resources.
-   *   ie `function($bundle): void`
+   *   Signature: `function($bundle): void`
+   *   Example: `function myinit($b) { $b->addScriptFile(...)->addStyleFile(...); }`
    * @param string|string[] $types
    *   List of resource-types to permit in this bundle. NULL for a default list.
-   *   Ex: ['styleFile', 'styleUrl']
+   *   Example: ['styleFile', 'styleUrl']
    *   The following aliases are allowed: '*all*', '*default*', '*script*', '*style*'
    * @return CRM_Core_Resources_Bundle
    */

--- a/CRM/Core/Resources/Common.php
+++ b/CRM/Core/Resources/Common.php
@@ -17,6 +17,30 @@ class CRM_Core_Resources_Common {
   const REGION = 'html-header';
 
   /**
+   * A "basic" bundle has an
+   *
+   * @param string $name
+   *   Symbolic name of the bundle.
+   * @param callable|NULL $init
+   *   Optional initialization function. Populate default resources.
+   *   ie `function($bundle): void`
+   * @param string|string[] $types
+   *   List of resource-types to permit in this bundle. NULL for a default list.
+   *   Ex: ['styleFile', 'styleUrl']
+   *   The following aliases are allowed: '*all*', '*default*', '*script*', '*style*'
+   * @return CRM_Core_Resources_Bundle
+   */
+  public static function createBasicBundle($name, $init = NULL, $types = NULL) {
+    $bundle = new CRM_Core_Resources_Bundle($name, $types);
+    if ($init !== NULL) {
+      $init($bundle);
+    }
+    CRM_Utils_Hook::alterBundle($bundle);
+    $bundle->fillDefaults();
+    return $bundle;
+  }
+
+  /**
    * The 'bundle.bootstrap3' service is a collection of resources which are
    * loaded when a page needs to support Boostrap CSS v3.
    *

--- a/CRM/Core/Resources/Common.php
+++ b/CRM/Core/Resources/Common.php
@@ -47,7 +47,7 @@ class CRM_Core_Resources_Common {
     );
 
     CRM_Utils_Hook::alterBundle($bundle);
-    self::useRegion($bundle, self::REGION);
+    $bundle->fillDefaults();
     return $bundle;
   }
 
@@ -76,7 +76,7 @@ class CRM_Core_Resources_Common {
     $bundle->addStyleFile('civicrm', 'css/crm-i.css', -101);
 
     CRM_Utils_Hook::alterBundle($bundle);
-    self::useRegion($bundle, self::REGION);
+    $bundle->fillDefaults();
     return $bundle;
   }
 
@@ -133,7 +133,7 @@ class CRM_Core_Resources_Common {
     ]);
 
     CRM_Utils_Hook::alterBundle($bundle);
-    self::useRegion($bundle, self::REGION);
+    $bundle->fillDefaults();
     return $bundle;
   }
 
@@ -271,23 +271,6 @@ class CRM_Core_Resources_Common {
     }, $items);
 
     return $items;
-  }
-
-  /**
-   * Ensure that all elements of the bundle are in the same region.
-   *
-   * @param CRM_Core_Resources_Bundle $bundle
-   * @param string $region
-   * @return CRM_Core_Resources_Bundle
-   */
-  protected static function useRegion($bundle, $region) {
-    $bundle->filter(function ($s) use ($region) {
-      if ($s['type'] !== 'settings' && !isset($s['region'])) {
-        $s['region'] = $region;
-      }
-      return $s;
-    });
-    return $bundle;
   }
 
 }

--- a/tests/phpunit/CRM/Core/Resources/BundleTest.php
+++ b/tests/phpunit/CRM/Core/Resources/BundleTest.php
@@ -56,4 +56,20 @@ class CRM_Core_Resources_BundleTest extends CiviUnitTestCase {
     $this->assertEquals('http://example.com/region.css', $region->get('http://example.com/region.css')['styleUrl']);
   }
 
+  /**
+   * Add some resources - sometimes forgetting to set a 'region'. Fill in missing regions.
+   */
+  public function testFillDefaults() {
+    $bundle = new CRM_Core_Resources_Bundle(__FUNCTION__, ['scriptUrl', 'styleUrl', 'markup']);
+    $bundle->addScriptUrl('http://example.com/myscript.js');
+    $bundle->addStyleUrl('http://example.com/yonder-style.css', ['region' => 'yonder']);
+    $bundle->addMarkup('<b>Cheese</b>', ['name' => 'cheese']);
+
+    $bundle->fillDefaults();
+
+    $this->assertEquals('html-header', $bundle->get('http://example.com/myscript.js')['region']);
+    $this->assertEquals('yonder', $bundle->get('http://example.com/yonder-style.css')['region']);
+    $this->assertEquals('page-header', $bundle->get('cheese')['region']);
+  }
+
 }

--- a/tests/phpunit/CRM/Core/ResourcesTest.php
+++ b/tests/phpunit/CRM/Core/ResourcesTest.php
@@ -60,6 +60,25 @@ class CRM_Core_ResourcesTest extends CiviUnitTestCase {
     $_GET = $this->originalGet;
   }
 
+  public function testCreateBasicBundle() {
+    $hits = [];
+
+    $init = function(CRM_Core_Resources_Bundle $b) use (&$hits) {
+      $hits[] = 'init_' . $b->name;
+      $b->addScript('doStuff();');
+    };
+    $alter = function ($e) use (&$hits) {
+      $hits[] = 'alter_' . $e->bundle->name;
+      $e->bundle->addScript('alert();');
+    };
+
+    Civi::dispatcher()->addListener('hook_civicrm_alterBundle', $alter);
+    $b = CRM_Core_Resources_Common::createBasicBundle('cheese', $init);
+    $this->assertEquals('cheese', $b->name);
+    $this->assertEquals(['init_cheese', 'alter_cheese'], $hits);
+    $this->assertEquals(['doStuff();', 'alert();'], array_values(CRM_Utils_Array::collect('script', $b->getAll())));
+  }
+
   /**
    * Make two bundles (multi-regional). Add them to CRM_Core_Resources.
    * Ensure that the resources land in the right regions.


### PR DESCRIPTION
Overview
----------------------------------------

#18247 (same dev-cycle, 5.31.alpha1) allows one to define resource bundles. This improves developer experience, requiring a bit less boilerplate/duplication.

Before
----------------------------------------

To define a new bundle, one implements `hook_container` and creates a factory function.

```php
function mymodule_civicrm_container($container) {
  $container->setDefinition('bundle.mycalendar',  new \Symfony\Component\DependencyInjection\Definition(
    'CRM_Core_Resources_Bundle', [])
    )->setFactory('_mymodule_create_mybundle')->setPublic(TRUE);
}

function _mymodule_create_mybundle() {
  $bundle = new CRM_Core_Resources_Bundle('my_bundle', ['...allowed types...']);
  $bundle->addScriptFile(...)->addStyleFile(...)->addVars(...);
  CRM_Utils_Hook::alterBundle($bundle);
  CRM_Core_Resources_Common::useRegion($bundle, CRM_Core_Resources_Common::REGION);
  return $bundle;
}
```

Note that the factory function `_mymodule_create_mybundle` has some boilerplate around `alterBundle()` and `useRegion()`. It's important to include these to ensure that the bundle is modifiable.

After
----------------------------------------

You still create a definition, but the definition can use the pre-written function `createBasicBundle`:

```php
function mymodule_civicrm_container($container) {
  $container->setDefinition('bundle.mycalendar',  new \Symfony\Component\DependencyInjection\Definition(
    'CRM_Core_Resources_Bundle', ['my_bundle'])
    )->setFactory('CRM_Core_Resources_Common::createBasicBundle')->setPublic(TRUE);
}
```

Optionally, if you want to initialize the default content, you can still use a factory function - but it doesn't have to have the boilerplate. Note how `_mymodule_init_mybundle` is simpler than `_mymodule_create_mybundle`:

```php
function mymodule_civicrm_container($container) {
  $container->setDefinition('bundle.mycalendar',  new \Symfony\Component\DependencyInjection\Definition(
    'CRM_Core_Resources_Bundle', ['my_bundle', '_mymodule_init_mybundle'])
    )->setFactory('CRM_Core_Resources_Common::createBasicBundle')->setPublic(TRUE);
}

function _mymodule_init_mybundle($bundle) {
  $bundle->addScriptFile(...)->addStyleFile(...)->addVars(...);
}
```

Comments
----------------------------------------

I marked it as (REF) because it's still backward compatible and not visible to an end-user. The simplification only applies if you use `createBasicBundle`. Any existing bundles (like the bootstrap3 bundle) can still work as before. Additionally, note that this is refining something recently added in the same dev-cycle (5.31-alpah1).

I'd like to get this merged before 5.31-beta1 so that we can use the cleaner notation in the docs.