### PR TITLE
dev/core#2046 Fix blockDelete to delete while ensuring is_primary is valid

### DIFF
--- a/CRM/Core/BAO/Block.php
+++ b/CRM/Core/BAO/Block.php
@@ -337,15 +337,8 @@ class CRM_Core_BAO_Block {
       $name = 'OpenID';
     }
 
-    $baoString = 'CRM_Core_DAO_' . $name;
-    $block = new $baoString();
-
-    $block->copyValues($params);
-
-    // CRM-11006 add call to pre and post hook for delete action
-    CRM_Utils_Hook::pre('delete', $name, $block->id, CRM_Core_DAO::$_nullArray);
-    $block->delete();
-    CRM_Utils_Hook::post('delete', $name, $block->id, $block);
+    $baoString = 'CRM_Core_BAO_' . $name;
+    $baoString::del($params['id']);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
The del function on each of the location DAO ensures that after a delete at least one phone (etc) is
marked is_primary. This blockDelete does not do that & per the test it's possible to call this
in such a way that no addresses are primary. Whether this actually happens is a bit unknown.

However, this cleans up block delete in a way where we can demonstrate the tests work

Before
----------------------------------------
Under edge case circumstances it is possible to set up contacts to have no primary email or phone etc via ```Block::create```

After
----------------------------------------
All actions taken from ```Block::create``` call a BAO create or delete function - meaning it no longer needs to handle is_primary

Technical Details
----------------------------------------

Next steps
- call del directly from ``Block::create```
- remove extraneous is_primary handling from ``Block::create```
- remove code intended to fix data when old code caused bugs in ``Block::create```

Comments
----------------------------------------

