### PR TITLE
dev/core#2017 Deprecate an unused function

### DIFF
--- a/CRM/Core/BAO/Location.php
+++ b/CRM/Core/BAO/Location.php
@@ -240,6 +240,10 @@ WHERE e.id = %1";
   /**
    * Delete all the block associated with the location.
    *
+   * Note a universe search on 1 Oct 2020 found no calls to this function.
+   *
+   * @deprecated
+   *
    * @param int $contactId
    *   Contact id.
    * @param int $locationTypeId
@@ -247,6 +251,7 @@ WHERE e.id = %1";
    * @throws CRM_Core_Exception
    */
   public static function deleteLocationBlocks($contactId, $locationTypeId) {
+    CRM_Core_Error::deprecatedFunctionWarning('Use v4 api');
     // ensure that contactId has a value
     if (empty($contactId) ||
       !CRM_Utils_Rule::positiveInteger($contactId)


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#2017 Deprecate an unused function

Before
----------------------------------------
deleteLocationBlocks unused but not deprecated
<img width="1124" alt="Screen Shot 2020-10-02 at 2 44 48 PM" src="https://user-images.githubusercontent.com/336308/94879810-dabbc180-04bd-11eb-9c6e-a216a5f6291e.png">


After
----------------------------------------
deprecated

Technical Details
----------------------------------------


Comments
----------------------------------------