### PR TITLE
dev/core#2039 Remove extraneous location queries from contact.create->Location::block path

### DIFF
--- a/CRM/Core/BAO/Block.php
+++ b/CRM/Core/BAO/Block.php
@@ -225,29 +225,6 @@ class CRM_Core_BAO_Block {
           unset($value['id']);
         }
       }
-      //lets allow to update primary w/ more cleanly.
-      if (!$resetPrimaryId && !empty($value['is_primary'])) {
-        $primaryId = TRUE;
-        if (is_array($blockIds)) {
-          foreach ($blockIds as $blockId => $blockValue) {
-            if (!empty($blockValue['is_primary'])) {
-              $resetPrimaryId = $blockId;
-              break;
-            }
-          }
-        }
-        if ($resetPrimaryId) {
-          $baoString = 'CRM_Core_BAO_' . $blockName;
-          $block = new $baoString();
-          $block->selectAdd();
-          $block->selectAdd("id, is_primary");
-          $block->id = $resetPrimaryId;
-          if ($block->find(TRUE)) {
-            $block->is_primary = FALSE;
-            $block->save();
-          }
-        }
-      }
     }
 
     foreach ($params[$blockName] as $count => $value) {
@@ -299,12 +276,6 @@ class CRM_Core_BAO_Block {
         'contact_id' => $contactId,
         'location_type_id' => $value['location_type_id'] ?? NULL,
       ];
-
-      $contactFields['is_primary'] = 0;
-      if ($isPrimary && !empty($value['is_primary'])) {
-        $contactFields['is_primary'] = $value['is_primary'];
-        $isPrimary = FALSE;
-      }
 
       $contactFields['is_billing'] = 0;
       if ($isBilling && !empty($value['is_billing'])) {

--- a/CRM/Core/BAO/Location.php
+++ b/CRM/Core/BAO/Location.php
@@ -53,14 +53,6 @@ class CRM_Core_BAO_Location extends CRM_Core_DAO {
       }
     }
 
-    // when we come from a form which displays all the location elements (like the edit form or the inline block
-    // elements, we can skip the below check. The below check adds quite a feq queries to an already overloaded
-    // form
-    if (empty($params['updateBlankLocInfo'])) {
-      // make sure contact should have only one primary block, CRM-5051
-      self::checkPrimaryBlocks(CRM_Utils_Array::value('contact_id', $params));
-    }
-
     return $location;
   }
 

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -149,7 +149,7 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
    *
    * @var bool
    */
-  protected $isLocationTypesOnPostAssert = FALSE;
+  protected $isLocationTypesOnPostAssert = TRUE;
 
   /**
    * Class used for hooks during tests.

--- a/tests/phpunit/api/v3/JobTest.php
+++ b/tests/phpunit/api/v3/JobTest.php
@@ -45,6 +45,15 @@ class api_v3_JobTest extends CiviUnitTestCase {
   private $report_instance;
 
   /**
+   * Should location types be checked to ensure primary addresses are correctly assigned after each test.
+   *
+   * We cannot enable this until https://github.com/civicrm/civicrm-core/pull/18555 is merged
+   *
+   * @var bool
+   */
+  protected $isLocationTypesOnPostAssert = FALSE;
+
+  /**
    * Set up for tests.
    */
   public function setUp() {

--- a/tests/phpunit/api/v3/SyntaxConformanceTest.php
+++ b/tests/phpunit/api/v3/SyntaxConformanceTest.php
@@ -39,6 +39,16 @@ class api_v3_SyntaxConformanceTest extends CiviUnitTestCase {
   protected $_entity;
 
   /**
+   * Should location types be checked to ensure primary addresses are correctly assigned after each test.
+   *
+   * Turn off for this class as we use DAO methods that bypass business logic. Also, this test class
+   * takes a long time so might be good not to add another check.
+   *
+   * @var bool
+   */
+  protected $isLocationTypesOnPostAssert = FALSE;
+
+  /**
    * Map custom group entities to civicrm components.
    * @var array
    */


### PR DESCRIPTION
Overview
----------------------------------------
Removes 10 queries from each contact  create that are otherwise dealt with elsewhere
Updated version of https://github.com/civicrm/civicrm-core/pull/18477 

Before
----------------------------------------
After creating location blocks 2 queries are done for each of the 5 entities to ensure is_primary fields have not been messed up (ie contact has 1 or more phones but none are marked primary or contact has more than one primary phone).

After
----------------------------------------
Queries are removed as location entities are already created correctly


Technical Details
----------------------------------------
This PR is part of a series of PRs to make this possible - best documented at https://lab.civicrm.org/dev/core/-/issues/2039#note_47758 

Comments
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/2039

Note test cover added by adding a postAssert to ALL tests. This picked up multiple issues which I fixed in preparation for this

tldr is - I fixed this code to call create & delete functions that manage is_primary correctly (which I had to fix some of them to do) and no it is redundant in here