### PR TITLE
dev/core#2079 [REF] clean up call to apiQuery

### DIFF
--- a/CRM/Contact/Form/Task/LabelCommon.php
+++ b/CRM/Contact/Form/Task/LabelCommon.php
@@ -136,12 +136,9 @@ class CRM_Contact_Form_Task_LabelCommon {
     $numberofContacts = count($contactIDs);
     //this does the same as calling civicrm_api3('contact, get, array('id' => array('IN' => $this->_contactIds)
     // except it also handles multiple locations
-    $query = new CRM_Contact_BAO_Query($params, $returnProperties);
-    $details = $query->apiQuery($params, $returnProperties, NULL, NULL, 0, $numberofContacts);
+    [$details] = CRM_Contact_BAO_Query::apiQuery($params, $returnProperties, NULL, NULL, 0, $numberofContacts);
 
-    $messageToken = CRM_Utils_Token::getTokens($mailingFormat);
-    // $details[0] is an array of [ contactID => contactDetails ]
-    $details = $details[0];
+    // $details is an array of [ contactID => contactDetails ]
     $tokenFields = CRM_Contact_Form_Task_LabelCommon::getTokenData($details);
 
     foreach ($contactIDs as $value) {

--- a/CRM/Contact/Form/Task/LabelCommon.php
+++ b/CRM/Contact/Form/Task/LabelCommon.php
@@ -30,7 +30,10 @@ class CRM_Contact_Form_Task_LabelCommon {
    * @param string $fileName
    *   The name of the file to save the label in.
    */
-  public static function createLabel(&$contactRows, &$format, $fileName = 'MailingLabels_CiviCRM.pdf') {
+  public static function createLabel($contactRows, $format, $fileName = 'MailingLabels_CiviCRM.pdf') {
+    if (CIVICRM_UF === 'UnitTests') {
+      throw new CRM_Core_Exception_PrematureExitException('civiExit called', ['rows' => $contactRows, 'format' => $format, 'file_name' => $fileName]);
+    }
     $pdf = new CRM_Utils_PDF_Label($format, 'mm');
     $pdf->Open();
     $pdf->AddPage();

--- a/CRM/Member/Task.php
+++ b/CRM/Member/Task.php
@@ -40,77 +40,75 @@ class CRM_Member_Task extends CRM_Core_Task {
    *   the set of tasks for a group of contacts
    */
   public static function tasks() {
-    if (!self::$_tasks) {
-      self::$_tasks = [
-        self::TASK_DELETE => [
-          'title' => ts('Delete memberships'),
-          'class' => 'CRM_Member_Form_Task_Delete',
-          'result' => FALSE,
+    self::$_tasks = [
+      self::TASK_DELETE => [
+        'title' => ts('Delete memberships'),
+        'class' => 'CRM_Member_Form_Task_Delete',
+        'result' => FALSE,
+      ],
+      self::TASK_PRINT => [
+        'title' => ts('Print selected rows'),
+        'class' => 'CRM_Member_Form_Task_Print',
+        'result' => FALSE,
+      ],
+      self::TASK_EXPORT => [
+        'title' => ts('Export members'),
+        'class' => [
+          'CRM_Member_Export_Form_Select',
+          'CRM_Member_Export_Form_Map',
         ],
-        self::TASK_PRINT => [
-          'title' => ts('Print selected rows'),
-          'class' => 'CRM_Member_Form_Task_Print',
-          'result' => FALSE,
+        'result' => FALSE,
+      ],
+      self::TASK_EMAIL => [
+        'title' => ts('Email - send now (to %1 or less)', [
+          1 => Civi::settings()
+            ->get('simple_mail_limit'),
+        ]),
+        'class' => 'CRM_Member_Form_Task_Email',
+        'result' => TRUE,
+      ],
+      self::BATCH_UPDATE => [
+        'title' => ts('Update multiple memberships'),
+        'class' => [
+          'CRM_Member_Form_Task_PickProfile',
+          'CRM_Member_Form_Task_Batch',
         ],
-        self::TASK_EXPORT => [
-          'title' => ts('Export members'),
-          'class' => [
-            'CRM_Member_Export_Form_Select',
-            'CRM_Member_Export_Form_Map',
-          ],
-          'result' => FALSE,
+        'result' => TRUE,
+      ],
+      self::LABEL_MEMBERS => [
+        'title' => ts('Mailing labels - print'),
+        'class' => [
+          'CRM_Member_Form_Task_Label',
         ],
-        self::TASK_EMAIL => [
-          'title' => ts('Email - send now (to %1 or less)', [
-            1 => Civi::settings()
-              ->get('simple_mail_limit'),
-          ]),
-          'class' => 'CRM_Member_Form_Task_Email',
-          'result' => TRUE,
-        ],
-        self::BATCH_UPDATE => [
-          'title' => ts('Update multiple memberships'),
-          'class' => [
-            'CRM_Member_Form_Task_PickProfile',
-            'CRM_Member_Form_Task_Batch',
-          ],
-          'result' => TRUE,
-        ],
-        self::LABEL_MEMBERS => [
-          'title' => ts('Mailing labels - print'),
-          'class' => [
-            'CRM_Member_Form_Task_Label',
-          ],
-          'result' => TRUE,
-        ],
-        self::PDF_LETTER => [
-          'title' => ts('Print/merge document for memberships'),
-          'class' => 'CRM_Member_Form_Task_PDFLetter',
-          'result' => FALSE,
-        ],
-        self::SAVE_SEARCH => [
-          'title' => ts('Group - create smart group'),
-          'class' => 'CRM_Contact_Form_Task_SaveSearch',
-          'result' => TRUE,
-        ],
-        self::SAVE_SEARCH_UPDATE => [
-          'title' => ts('Group - update smart group'),
-          'class' => 'CRM_Contact_Form_Task_SaveSearch_Update',
-          'result' => TRUE,
-        ],
-      ];
+        'result' => TRUE,
+      ],
+      self::PDF_LETTER => [
+        'title' => ts('Print/merge document for memberships'),
+        'class' => 'CRM_Member_Form_Task_PDFLetter',
+        'result' => FALSE,
+      ],
+      self::SAVE_SEARCH => [
+        'title' => ts('Group - create smart group'),
+        'class' => 'CRM_Contact_Form_Task_SaveSearch',
+        'result' => TRUE,
+      ],
+      self::SAVE_SEARCH_UPDATE => [
+        'title' => ts('Group - update smart group'),
+        'class' => 'CRM_Contact_Form_Task_SaveSearch_Update',
+        'result' => TRUE,
+      ],
+    ];
 
-      //CRM-4418, check for delete
-      if (!CRM_Core_Permission::check('delete in CiviMember')) {
-        unset(self::$_tasks[self::TASK_DELETE]);
-      }
-      //CRM-12920 - check for edit permission
-      if (!CRM_Core_Permission::check('edit memberships')) {
-        unset(self::$_tasks[self::BATCH_UPDATE]);
-      }
-
-      parent::tasks();
+    //CRM-4418, check for delete
+    if (!CRM_Core_Permission::check('delete in CiviMember')) {
+      unset(self::$_tasks[self::TASK_DELETE]);
     }
+    //CRM-12920 - check for edit permission
+    if (!CRM_Core_Permission::check('edit memberships')) {
+      unset(self::$_tasks[self::BATCH_UPDATE]);
+    }
+
+    parent::tasks();
 
     return self::$_tasks;
   }

--- a/tests/phpunit/CRM/Member/Form/Task/LabelTest.php
+++ b/tests/phpunit/CRM/Member/Form/Task/LabelTest.php
@@ -1,0 +1,53 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * @package CiviCRM_APIv3
+ * @subpackage API_Contribution
+ * @group headless
+ */
+class CRM_Member_Form_Task_LabelTest extends CiviUnitTestCase {
+
+  /**
+   * Test print label.
+   *
+   * This is a 'no error' test to support refactoring. It ensures no fatal is hit & lays
+   * the basis for more tests later.
+   */
+  public function testMembershipTokenReplacementInPDF() {
+    // First check tasks are there is some weird static caching that could mess us up.
+    $tasks = CRM_Member_Task::tasks();
+    $this->assertArrayHasKey(201, $tasks, print_r($tasks, TRUE));
+    $tasks = CRM_Member_Task::permissionedTaskTitles(CRM_Core_Permission::EDIT);
+    $this->assertArrayHasKey(201, $tasks);
+    $membershipID = $this->contactMembershipCreate(['contact_id' => $this->individualCreate()]);
+    /* @var CRM_Member_Form_Task_Label $form */
+    $form = $this->getFormObject('CRM_Member_Form_Task_Label', [
+      'task' => 201,
+      'radio_ts' => 'ts_sel',
+    ], 'Search');
+
+    $_SESSION['_' . $form->controller->_name . '_container']['values']['Label'] = [
+      'location_type_id' => NULL,
+      'label_name' => 3475,
+    ];
+    $form->preProcess();
+    $form->ids = [$membershipID => $membershipID];
+    $form->buildForm();
+    try {
+      $form->postProcess();
+    }
+    catch (CRM_Core_Exception_PrematureExitException $e) {
+      $this->assertEquals(3475, $e->errorData['format']);
+    }
+  }
+
+}


### PR DESCRIPTION

Overview
----------------------------------------
This fixes a few things
1) fixes apiQuery to be called statically as it is a static function
2) casts results directly to details
3) removes unused variable

Before
----------------------------------------
<img width="770" alt="Screen Shot 2020-10-03 at 9 09 42 AM" src="https://user-images.githubusercontent.com/336308/94965862-be209780-0558-11eb-9cbd-9dec5bae6e26.png">

After
----------------------------------------
1) fixes apiQuery to be called statically as it is a static function
2) casts results directly to details
3) removes unused variable


Technical Details
----------------------------------------
The query object that is instantiated is not used in the static function, which instantiates it's own

Comments
----------------------------------------
