### PR TITLE
dev/core#2087 Remove extraneous  CRM_Core_BAO_UFMatch::updateUFName call

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -371,9 +371,6 @@ class CRM_Contact_BAO_Contact extends CRM_Contact_DAO_Contact {
       }
     }
 
-    // update the UF user_unique_id if that has changed
-    CRM_Core_BAO_UFMatch::updateUFName($contact->id);
-
     if (!empty($params['custom']) &&
       is_array($params['custom'])
     ) {
@@ -3531,6 +3528,9 @@ LEFT JOIN civicrm_address ON ( civicrm_address.contact_id = civicrm_contact.id )
         if ($dao->fetch()) {
           $dao->is_primary = 1;
           $dao->save();
+          if ($type === 'Email') {
+            CRM_Core_BAO_UFMatch::updateUFName($dao->contact_id);
+          }
         }
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------
Removes up to 3 queries from Contact.create

https://lab.civicrm.org/dev/core/-/issues/2087

Before
----------------------------------------
When calling contact.create the sequence is

create/ edit  the contact
do any email adds / deletes requested - this requires


if a primary email is added/ altered update the uf_name


update the the uf name

Within update the uf name there are 2 queries to see if the update is needed

check if they have a primary address
check if they have a uf match

After
----------------------------------------
1. Remove the update from Contact.create since it is done in Email.create
1. Add the update into Email.delete when promoting another email
1. check for uf_match before has primary when doing uf match

Technical Details
----------------------------------------

Comments
----------------------------------------

