### PR TITLE
dev/core#2090 - Undefined index on contact's activity tab when there's an activity that has no With Contact

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -2566,7 +2566,7 @@ INNER JOIN  civicrm_option_group grp ON (grp.id = option_group_id AND grp.name =
             }
           }
         }
-        elseif (!$values['target_contact_name']) {
+        elseif (empty($values['target_contact_name'])) {
           $activity['target_contact_name'] = '<em>n/a</em>';
         }
 

--- a/tests/phpunit/CRM/Activity/BAO/ActivityTest.php
+++ b/tests/phpunit/CRM/Activity/BAO/ActivityTest.php
@@ -214,6 +214,35 @@ class CRM_Activity_BAO_ActivityTest extends CiviUnitTestCase {
   }
 
   /**
+   * Check for errors when viewing a contact's activity tab when there
+   * is an activity that doesn't have a target (With Contact).
+   */
+  public function testActivitySelectorNoTargets() {
+    $contact_id = $this->individualCreate([], 0, TRUE);
+    $activity = $this->callAPISuccess('activity', 'create', [
+      'source_contact_id' => $contact_id,
+      'activity_type_id' => 'Meeting',
+      'subject' => 'Lonely Meeting',
+      'details' => 'Here at this meeting all by myself and no other contacts.',
+    ]);
+    $input = [
+      '_raw_values' => [],
+      'offset' => 0,
+      'rp' => 25,
+      'page' => 1,
+      'context' => 'activity',
+      'contact_id' => $contact_id,
+    ];
+    $output = CRM_Activity_BAO_Activity::getContactActivitySelector($input);
+    $this->assertEquals($activity['id'], $output['data'][0]['DT_RowId']);
+    $this->assertEquals('<em>n/a</em>', $output['data'][0]['target_contact_name']);
+    $this->assertEquals('Lonely Meeting', $output['data'][0]['subject']);
+
+    $this->callAPISuccess('activity', 'delete', ['id' => $activity['id']]);
+    $this->callAPISuccess('contact', 'delete', ['id' => $contact_id]);
+  }
+
+  /**
    * Test case for deleteActivity() method.
    *
    * deleteActivity($params) method deletes activity for given params.


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/2090

You can't see the error because ajax snippets hide it, but you can either:

1. Run the unit test and see the error.

OR

1. Install the [loudnotices](https://lab.civicrm.org/extensions/loudnotices) extension.
1. Create an activity and leave the With Contact blank.
1. Visit the contact's activity tab. It will hang.
1. Look in ConfigAndLog and you'll see the error/backtrace.

Before
----------------------------------------
Undefined index: target_contact_name in CRM\Activity\BAO\Activity.php line 2569

After
----------------------------------------

Technical Details
----------------------------------------

Comments
----------------------------------------
Has test.
