### PR TITLE
composer.json - Update compile-lib and compile-plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -80,7 +80,7 @@
     "ext-intl": "*",
     "pear/mail_mime": "~1.10",
     "pear/db": "1.10",
-    "civicrm/composer-compile-lib": "~0.2 || ~1.0"
+    "civicrm/composer-compile-lib": "~0.3 || ~1.0"
   },
   "scripts": {
     "post-install-cmd": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1c717ea7ca80e806702967261c621e3a",
+    "content-hash": "2a5c933954791a798ec0f50db504c476",
     "packages": [
         {
             "name": "adrienrn/php-mimetyper",
@@ -91,12 +91,6 @@
                 "brick",
                 "math"
             ],
-            "funding": [
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/brick/math",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-04-15T15:59:35+00:00"
         },
         {
@@ -142,12 +136,6 @@
                 "brick",
                 "currency",
                 "money"
-            ],
-            "funding": [
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/brick/money",
-                    "type": "tidelift"
-                }
             ],
             "time": "2020-05-31T14:17:02+00:00"
         },
@@ -311,16 +299,16 @@
         },
         {
             "name": "civicrm/composer-compile-lib",
-            "version": "v0.2",
+            "version": "v0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/civicrm/composer-compile-lib.git",
-                "reference": "ceed2f3abe500a8333470a1e916812391cd68261"
+                "reference": "980b26dcc3d51ecf47aa45c43564ab9b6dbac244"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/civicrm/composer-compile-lib/zipball/ceed2f3abe500a8333470a1e916812391cd68261",
-                "reference": "ceed2f3abe500a8333470a1e916812391cd68261",
+                "url": "https://api.github.com/repos/civicrm/composer-compile-lib/zipball/980b26dcc3d51ecf47aa45c43564ab9b6dbac244",
+                "reference": "980b26dcc3d51ecf47aa45c43564ab9b6dbac244",
                 "shasum": ""
             },
             "require": {
@@ -336,8 +324,12 @@
                     {
                         "title": "Generate <comment>CCL</comment> wrapper functions",
                         "run": [
-                            "@php-script src/StubsTpl.php"
+                            "@php-method \\CCL\\Tasks::template"
                         ],
+                        "tpl-file": "src/StubsTpl.php",
+                        "tpl-items": {
+                            "CCL.php": true
+                        },
                         "watch-files": [
                             "src/StubsTpl.php",
                             "src/Functions.php"
@@ -366,20 +358,20 @@
                 }
             ],
             "description": "Small library of compilation helpers",
-            "time": "2020-09-30T22:30:37+00:00"
+            "time": "2020-10-03T00:11:18+00:00"
         },
         {
             "name": "civicrm/composer-compile-plugin",
-            "version": "v0.10",
+            "version": "v0.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/civicrm/composer-compile-plugin.git",
-                "reference": "2624473090698cf813d14545a70b422b48f263e8"
+                "reference": "5ed863f2276a445775900ba18e99d14b15402640"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/civicrm/composer-compile-plugin/zipball/2624473090698cf813d14545a70b422b48f263e8",
-                "reference": "2624473090698cf813d14545a70b422b48f263e8",
+                "url": "https://api.github.com/repos/civicrm/composer-compile-plugin/zipball/5ed863f2276a445775900ba18e99d14b15402640",
+                "reference": "5ed863f2276a445775900ba18e99d14b15402640",
                 "shasum": ""
             },
             "require": {
@@ -411,7 +403,7 @@
                 }
             ],
             "description": "Define a 'compile' event for all packages in the dependency-graph",
-            "time": "2020-09-30T21:14:46+00:00"
+            "time": "2020-10-04T00:13:46+00:00"
         },
         {
             "name": "civicrm/composer-downloads-plugin",
@@ -2434,20 +2426,6 @@
             ],
             "description": "Symfony Config Component",
             "homepage": "https://symfony.com",
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-04-12T14:33:46+00:00"
         },
         {
@@ -2519,20 +2497,6 @@
             ],
             "description": "Symfony DependencyInjection Component",
             "homepage": "https://symfony.com",
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-04-13T09:33:40+00:00"
         },
         {
@@ -2596,20 +2560,6 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-03-15T09:38:08+00:00"
         },
         {
@@ -2660,20 +2610,6 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-04-12T16:54:01+00:00"
         },
         {
@@ -2781,20 +2717,6 @@
                 "polyfill",
                 "portable"
             ],
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-05-12T16:14:59+00:00"
         },
         {
@@ -2853,20 +2775,6 @@
                 "polyfill",
                 "portable",
                 "shim"
-            ],
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
             ],
             "time": "2020-05-12T16:47:27+00:00"
         },
@@ -2930,20 +2838,6 @@
                 "portable",
                 "shim"
             ],
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-05-12T16:47:27+00:00"
         },
         {
@@ -3003,20 +2897,6 @@
                 "portable",
                 "shim"
             ],
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-05-12T16:47:27+00:00"
         },
         {
@@ -3072,20 +2952,6 @@
                 "portable",
                 "shim"
             ],
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-05-12T16:47:27+00:00"
         },
         {
@@ -3135,20 +3001,6 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-04-12T14:33:46+00:00"
         },
         {
@@ -3741,6 +3593,5 @@
     "platform-dev": [],
     "platform-overrides": {
         "php": "7.1"
-    },
-    "plugin-api-version": "1.1.0"
+    }
 }


### PR DESCRIPTION
Overview
----------------------------------------
This updates the version of `composer-compile-lib` and `composer-compile-plugin`. It addresses a few issues:

* When installing on systems with `E_ALL` error-reporting, the file `CCL.php` was corrupted -- with PHP warnings misdirected into `CCL.php`. The update to `composer-compile-lib` fixes the underlying warning and directs future warnings to a better place (console output).
* When installing on Drupal 8.7.11, the CI fails because 8.7.11 has a quirky dependency-graph. (The `drupal/drupal` package indirectly depends on itself.) The update to `composer-compile-plugin` handles this quirk properly.

Before and After
----------------------------------------

```
  - Updating civicrm/composer-compile-plugin (v0.10 => v0.12)
  - Updating civicrm/composer-compile-lib (v0.2 => v0.3)
```

Technical Details
----------------------------------------

Strictly speaking, new installs and upgrades on D8/D9 should start using the updated packages without this PR. This just makes it a little clearer and brings D7/WP/BD along.

CC @seamuslee001 @eileenmcnaughton 