### PR TITLE
fix labels on new admin permissions

### DIFF
--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -903,11 +903,11 @@ class CRM_Core_Permission {
       ],
       'administer CiviCRM system' => [
         'label' => $prefix . ts('administer CiviCRM System'),
-        'description' => ts('Perform all system administration tasks in CiviCRM:'),
+        'description' => ts('Perform all system administration tasks in CiviCRM'),
       ],
       'administer CiviCRM data' => [
         'label' => $prefix . ts('administer CiviCRM Data'),
-        'description' => ts('Perform all system administration tasks in CiviCRM:'),
+        'description' => ts('Permit altering all restricted data options'),
       ],
     ];
     foreach (self::getImpliedPermissions() as $name => $includes) {


### PR DESCRIPTION
Overview
----------------------------------------
#16482 introduces new permissions.  They have the same label, and end with a colon, which other permissions do not.

Before
----------------------------------------
Same label, colons.

After
----------------------------------------
Differentiated labels, colectomy.

Comments
----------------------------------------
Picking a new label runs into one of the [two hard things about computer science](https://martinfowler.com/bliki/TwoHardThings.html).  If someone wants to bikeshed this, just go ahead and change it, I'm giving consent now.

Also, not technically a regression, but I believe fits the CiviCRM version of one.
