### PR TITLE
When exporting for composer-style deployment, exclude the `.gitignore` file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+.gitattributes export-ignore  
+.gitignore export-ignore


### PR DESCRIPTION
Overview
----------------------------------------

Updates the handling of the `.gitignore` file to improve support for deployments in which:

* (1) The full codebase is initially downloaded via `composer` (D8/D9), ***and***
* (2) The full codebase is then committed to a separate deployment-repo.

CC @KarinG @MegaphoneJon 

Before
----------------------------------------

* The `.gitignore` file is used on local/developmental repos to prevent clutter and merge-conflicts.
* The `.gitignore` file is also included in the auto-exported zipball provided via `github.com`; consequently, it appears in any downstream build prepared by `composer`. For deployment-repos, this may lead to files being inappropriately excluded.

After
----------------------------------------

* The `.gitignore` file is *still* used on local/developmental repos to prevent clutter and merge-conflicts.
* The `.gitignore` file is *now excluded* from the zipball used by `composer`; consequently, it does *not* appear in downstream builds prepared by `composer`.

Comments
----------------------------------------

This should only affect processes which download an auto-exported zipball from `github.com`, i.e.

* It does not affect `git clone`s (e.g. `civibuild` and `composer` with `dev-*`/VCS versions)
* It does not affect D7/BD/WP tarballs -- `distmaker` already skips the `.gitignore` file.

Note that I did a quick test with an identical `.gitattributes` file on https://github.com/totten/githubtest/commits/ignorance-is-bliss, e.g. one can see that it the zipballs no longer have `.gitignore`:

```bash
## Before gitattributes
wget 'https://github.com/totten/githubtest/archive/e275d75fb3f1b42fc9cfe011bfc1dbe5b8c9b76d.zip'
unzip -l e275d75fb3f1b42fc9cfe011bfc1dbe5b8c9b76d.zip

## After gitattributes
wget 'https://github.com/totten/githubtest/archive/fe85360bd403c036ea523c157943c9f3d9e62a14.zip'
unzip -l fe85360bd403c036ea523c157943c9f3d9e62a14.zip
```