### PR TITLE
dev/core#2087 move uf_match check above the primary check

### DIFF
--- a/CRM/Core/BAO/UFMatch.php
+++ b/CRM/Core/BAO/UFMatch.php
@@ -340,6 +340,14 @@ AND    domain_id    = %4
       return;
     }
 
+    // 1.do check for contact Id.
+    $ufmatch = new CRM_Core_DAO_UFMatch();
+    $ufmatch->contact_id = $contactId;
+    $ufmatch->domain_id = CRM_Core_Config::domainID();
+    if (!$ufmatch->find(TRUE)) {
+      return;
+    }
+
     $config = CRM_Core_Config::singleton();
     $ufName = CRM_Contact_BAO_Contact::getPrimaryEmail($contactId);
 
@@ -349,13 +357,6 @@ AND    domain_id    = %4
 
     $update = FALSE;
 
-    // 1.do check for contact Id.
-    $ufmatch = new CRM_Core_DAO_UFMatch();
-    $ufmatch->contact_id = $contactId;
-    $ufmatch->domain_id = CRM_Core_Config::domainID();
-    if (!$ufmatch->find(TRUE)) {
-      return;
-    }
     if ($ufmatch->uf_name != $ufName) {
       $update = TRUE;
     }


### PR DESCRIPTION

Overview
----------------------------------------
Reduces queries when creating /editing contacts without a UF match by doing the uf-match check before the hasPrimaryEmail check

Sub-PR for https://github.com/civicrm/civicrm-core/pull/18667 - this splits off the easier part of #18667 - I will rebase that if this is merged first

Before
----------------------------------------
4 queries for all edits

After
----------------------------------------
2 queries for edits on contacts with no uf_match, 4 if there is one

Technical Details
----------------------------------------
half the queries are still redundant - see #18667

Comments
----------------------------------------

