### PR TITLE
dev/core#2093 - Fix red error box on new individual form and ltrim typos and doubling-up of class attribute

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -700,7 +700,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
 
       // Search field is always multi-select
       if ($search || (self::isSerialized($field) && $widget === 'Select')) {
-        $fieldAttributes['class'] .= ltrim($fieldAttributes['class'] ?? '' . ' huge');
+        $fieldAttributes['class'] = ltrim(($fieldAttributes['class'] ?? '') . ' huge');
         $fieldAttributes['multiple'] = 'multiple';
         $fieldAttributes['placeholder'] = $placeholder;
       }
@@ -794,7 +794,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
 
       // For all select elements
       case 'Select':
-        $fieldAttributes['class'] .= ltrim($fieldAttributes['class'] ?? '' . ' crm-select2');
+        $fieldAttributes['class'] = ltrim(($fieldAttributes['class'] ?? '') . ' crm-select2');
         if ($field->is_search_range && $search && in_array($field->data_type, $rangeDataTypes)) {
           $qf->add('text', $elementName . '_from', $label . ' ' . ts('From'), $fieldAttributes);
           $qf->add('text', $elementName . '_to', ts('To'), $fieldAttributes);
@@ -870,7 +870,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
           if (!CRM_Core_Permission::check('access contact reference fields')) {
             break;
           }
-          $fieldAttributes['class'] = ltrim($fieldAttributes['class'] ?? '' . ' crm-form-contact-reference huge');
+          $fieldAttributes['class'] = ltrim(($fieldAttributes['class'] ?? '') . ' crm-form-contact-reference huge');
           $fieldAttributes['data-api-entity'] = 'Contact';
           $element = $qf->add('text', $elementName, $label, $fieldAttributes, $useRequired && !$search);
 

--- a/tests/phpunit/CRM/Contact/Form/IndividualTest.php
+++ b/tests/phpunit/CRM/Contact/Form/IndividualTest.php
@@ -35,4 +35,39 @@ class CRM_Contact_Form_IndividualTest extends CiviUnitTestCase {
     $this->assertStringContainsString('<label for="first_name">', $contents);
   }
 
+  /**
+   * This is the same as testOpeningNewIndividualForm but with a custom field
+   * defined. It maybe doesn't need to be a separate test but might make it
+   * easier to track down problems if one fails but not the other.
+   */
+  public function testOpeningNewIndividualFormWithCustomField() {
+    $custom_group = $this->customGroupCreate([]);
+    $custom_field1 = $this->customFieldCreate(['custom_group_id' => $custom_group['id']]);
+    $custom_field2 = $this->customFieldCreate([
+      'custom_group_id' => $custom_group['id'],
+      'label' => 'f2',
+      'html_type' => 'Select',
+      // being lazy, just re-use activity type choices
+      'option_group_id' => 'activity_type',
+    ]);
+    $custom_field3 = $this->customFieldCreate([
+      'custom_group_id' => $custom_group['id'],
+      'label' => 'f3',
+      'html_type' => 'Radio',
+      'option_group_id' => 'gender',
+    ]);
+    $form = new CRM_Contact_Form_Contact();
+    $form->controller = new CRM_Core_Controller_Simple('CRM_Contact_Form_Contact', 'New Individual');
+
+    $form->set('reset', '1');
+    $form->set('ct', 'Individual');
+
+    ob_start();
+    $form->controller->_actions['display']->perform($form, 'display');
+    $contents = ob_get_contents();
+    ob_end_clean();
+
+    $this->assertStringContainsString('<label for="first_name">', $contents);
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------

**** I think this needs to be in 5.31. If not merged by then I'll rebase to be against it. ****

https://lab.civicrm.org/dev/core/-/issues/2093

1. On dmaster.demo go to New Individual.
2. Red error box.

Technical Details
----------------------------------------
In a [recent commit](https://github.com/civicrm/civicrm-core/commit/4367e9641356b13764aceb289c46b6023c6c6bb8#diff-bdea9a3ec62827e6c90a70202ea9f7ccR797) this line was added:

`$fieldAttributes['class'] .= ltrim($fieldAttributes['class'] ?? '' . ' crm-select2');`

It has a couple issues:
1. You can't use `.=` if the field isn't set yet, hence the red box.
2. The `.=` is a typo to begin with. If the field is already set it doubles-up the class.
3. Using `??` and `.` on the same line together requires brackets since the `.` always wins which leads to sneaky bugs. It turns out here it doesn't matter, but should have brackets. This isn't new to `??` - it used to come up sometimes with `? :` too.

Comments
----------------------------------------
Has test. The existing version of a similar test didn't catch this because it didn't check custom fields.
