### PR TITLE
[REF] Fix compatability with Drupal 9 installing of var_dumper

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,7 @@
     "symfony/event-dispatcher": "~3.0 || ~4.4",
     "symfony/filesystem": "~3.0 || ~4.4",
     "symfony/process": "~3.0 || ~4.4",
-    "symfony/var-dumper": "~3.0 || ~4.4",
+    "symfony/var-dumper": "~3.0 || ~4.4 || ~5.1",
     "psr/log": "~1.0",
     "symfony/finder": "~3.0 || ~4.4",
     "tecnickcom/tcpdf" : "6.3.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5b823c420fc0d96c61731dd45a7d2e3e",
+    "content-hash": "5d304686f3edec04284e52a859321e0a",
     "packages": [
         {
             "name": "adrienrn/php-mimetyper",
@@ -242,7 +242,7 @@
                 {
                     "name": "Tobias Nyholm",
                     "email": "tobias.nyholm@gmail.com",
-                    "homepage": "https://github.com/nyholm"
+                    "homepage": "https://github.com/Nyholm"
                 },
                 {
                     "name": "Nicolas Grekas",


### PR DESCRIPTION
Overview
----------------------------------------
As pointed out by Dave D here https://github.com/civicrm/civicrm-core/pull/18610#issuecomment-704383364 Drupal 9 pulls in 5.1.0 var_dumper and this is currently blocked on our requirements so make it not blocked

Before
----------------------------------------
D9 install blocked

After
----------------------------------------
Not blocked

Technical Details
----------------------------------------
After updating the composer.json i just ran `composer update php` so that the only thing to get updated was the md5 hash

ping @demeritcowboy @totten 
