### PR TITLE
dev/core#1777 [REF] Only check for old files if the packages or vendor directory is…

### DIFF
--- a/CRM/Utils/Check/Component/Source.php
+++ b/CRM/Utils/Check/Component/Source.php
@@ -76,10 +76,15 @@ class CRM_Utils_Check_Component_Source extends CRM_Utils_Check_Component {
         ]);
       }
       if (file_exists($path)) {
-        $orphans[] = [
-          'name' => $file,
-          'path' => $path,
-        ];
+        if ((strpos($file, '[civicrm.vendor]') !== FALSE || strpos($file, '[ivicrm.packages]') !== FALSE) && strpos($path, 'civicrm/') === FALSE) {
+          continue;
+        }
+        else {
+          $orphans[] = [
+            'name' => $file,
+            'path' => $path,
+          ];
+        }
       }
     }
 


### PR DESCRIPTION
… within the civicrm directory i.e. in a situation where civicrm is within the webroot

Overview
----------------------------------------
The aim of this is to prevent the old files check from showing on the D8 and D9 demo sites where by the check isn't as important when the vendor or packages directory isn't within the webroot

Before
----------------------------------------
False positive check on D8 / D9

After
----------------------------------------
Correct checking as appropriate

ping @MikeyMJCO @totten @demeritcowboy thoughts?