### PR TITLE
[REF] Fix error when creating new AB test mailing because domain_id i…

### DIFF
--- a/ang/crmMailingAB/services.js
+++ b/ang/crmMailingAB/services.js
@@ -69,7 +69,6 @@
             mailing_id_a: null,
             mailing_id_b: null,
             mailing_id_c: null,
-            domain_id: null,
             testing_criteria: 'subject',
             winner_criteria: null,
             specific_url: '',


### PR DESCRIPTION
…s a required field

Overview
----------------------------------------
This fixes a bug that was introduced on new sites following https://github.com/civicrm/civicrm-core/commit/a63d3a16891c0a4ecff256dd19efb1f686f859ac#diff-f91ad3c24d803701b558759a9ecec9e8 which specified that the domain_id column is required but passing in a null value from the new AB test menu item stopped the API default from being used

Before
----------------------------------------
DB error on new sites

After
----------------------------------------
No DB error

ping @colemanw @eileenmcnaughton 
