### PR TITLE
dev/core#2073 Remove memory leak in heavily tested (merge) code

### DIFF
--- a/CRM/Dedupe/BAO/RuleGroup.php
+++ b/CRM/Dedupe/BAO/RuleGroup.php
@@ -212,7 +212,6 @@ class CRM_Dedupe_BAO_RuleGroup extends CRM_Dedupe_DAO_RuleGroup {
     $patternColumn = '/t1.(\w+)/';
     $exclWeightSum = [];
 
-    $dao = new CRM_Core_DAO();
     CRM_Utils_Hook::dupeQuery($this, 'table', $tableQueries);
 
     while (!empty($tableQueries)) {
@@ -257,7 +256,7 @@ class CRM_Dedupe_BAO_RuleGroup extends CRM_Dedupe_DAO_RuleGroup {
 
           // construct and execute the intermediate query
           $query = "{$insertClause} {$query} {$groupByClause} ON DUPLICATE KEY UPDATE weight = weight + VALUES(weight)";
-          $dao->query($query);
+          $dao = CRM_Core_DAO::executeQuery($query);
 
           // FIXME: we need to be more acurate with affected rows, especially for insert vs duplicate insert.
           // And that will help optimize further.
@@ -279,7 +278,7 @@ class CRM_Dedupe_BAO_RuleGroup extends CRM_Dedupe_DAO_RuleGroup {
         $fieldWeight = $fieldWeight[0];
         $query = array_shift($tableQueries);
         $query = "{$insertClause} {$query} {$groupByClause} ON DUPLICATE KEY UPDATE weight = weight + VALUES(weight)";
-        $dao->query($query);
+        $dao = CRM_Core_DAO::executeQuery($query);
         if ($dao->affectedRows() >= 1) {
           $exclWeightSum[] = substr($fieldWeight, strrpos($fieldWeight, '.') + 1);
         }

--- a/CRM/Dedupe/Finder.php
+++ b/CRM/Dedupe/Finder.php
@@ -47,13 +47,12 @@ class CRM_Dedupe_Finder {
     }
 
     $rgBao->fillTable();
-    $dao = new CRM_Core_DAO();
-    $dao->query($rgBao->thresholdQuery($checkPermissions));
+    $dao = CRM_Core_DAO::executeQuery($rgBao->thresholdQuery($checkPermissions));
     $dupes = [];
     while ($dao->fetch()) {
       $dupes[] = [$dao->id1, $dao->id2, $dao->weight];
     }
-    $dao->query($rgBao->tableDropQuery());
+    CRM_Core_DAO::executeQuery(($rgBao->tableDropQuery()));
 
     return $dupes;
   }


### PR DESCRIPTION

Overview
----------------------------------------
dev/core#2073 Remove memory leak in heavily tested (merge) code

Before
----------------------------------------
Use of ``` $dao->query($query);``` - which is a legacy pattern previously to cause memory leaks

After
----------------------------------------
```
  $dao = CRM_Core_DAO::executeQuery($query);
```

Technical Details
----------------------------------------
There are dozens of tests that pass through these lines - I used api_v3_JobTest:testBatchMerge to step through it
- note the dao->affectedRows uses a query to determine that - so it is no more or less accurate than before

Comments
----------------------------------------
Example tests

  message: 'Failure in api call for relationship create:  yep it is tested'
  severity: fail
  ...
  not ok 1970 - Failure: api_v3_RelationshipTest::testRelationshipCreateDuplicateWithCustomFields
  ---
  message: 'Failure in api call for relationship create:  yep it is tested'
  severity: fail
  ...
  not ok 1971 - Failure: api_v3_RelationshipTest::testRelationshipCreateDuplicateWithCustomFields2
  ---
  message: 'Failure in api call for relationship create:  yep it is tested'
  severity: fail
