### PR TITLE
dev/core#2073 Fix memory leak in well tested code

### DIFF
--- a/CRM/Contact/BAO/Relationship.php
+++ b/CRM/Contact/BAO/Relationship.php
@@ -983,8 +983,7 @@ WHERE  relationship_type_id = " . CRM_Utils_Type::escape($type, 'Integer');
       $queryString .= " AND id !=" . CRM_Utils_Type::escape($relationshipId, 'Integer');
     }
 
-    $relationship = new CRM_Contact_BAO_Relationship();
-    $relationship->query($queryString);
+    $relationship = CRM_Core_DAO::executeQuery($queryString);
     while ($relationship->fetch()) {
       // Check whether the custom field values are identical.
       $result = self::checkDuplicateCustomFields($params, $relationship->id);


### PR DESCRIPTION
Overview
----------------------------------------
Fixes memory leak in Relationship.create BAO

Before
----------------------------------------
leaky legacy method ```$relationship->query($queryString);```

After
----------------------------------------
```
 $relationship = CRM_Core_DAO::executeQuery($queryString); $relationship = CRM_Core_DAO::executeQuery($queryString);
```

Technical Details
----------------------------------------


Comments
----------------------------------------
Example tests from https://test.civicrm.org/job/CiviCRM-Core-PR/37334/#showFailuresLink

api_v3_ContactTest::testSortLimitChainedRelationshipGetCRM15983
api_v3_MembershipTest.testCreateWithRelationship
api_v3_MembershipTest.testCreateWithSpouseRelationship
api_v3_RelationshipTest.testRelationshipCreateAlreadyExists with data set "APIv3"
api_v3_RelationshipTest.testRelationshipCreateAlreadyExists with data set "APIv4"
api_v3_RelationshipTest.testRelationshipCreateUpdateAlreadyExists with data set "APIv3"
api_v3_RelationshipTest.testRelationshipCreateUpdateAlreadyExists with data set "APIv4"
api_v3_RelationshipTest.testRelationshipCreateUpdateDoesNotMangle with data set "APIv3"
api_v3_RelationshipTest.testRelationshipCreateUpdateDoesNotMangle with data set "APIv4"