### PR TITLE
Exclude api4 from IDS check

### DIFF
--- a/CRM/Core/IDS.php
+++ b/CRM/Core/IDS.php
@@ -47,7 +47,7 @@ class CRM_Core_IDS {
     }
 
     // lets bypass a few civicrm urls from this check
-    $skip = ['civicrm/admin/setting/updateConfigBackend', 'civicrm/admin/messageTemplates'];
+    $skip = ['civicrm/admin/setting/updateConfigBackend', 'civicrm/admin/messageTemplates', 'civicrm/ajax/api4'];
     CRM_Utils_Hook::idsException($skip);
     $this->path = $route['path'];
     if (in_array($this->path, $skip)) {


### PR DESCRIPTION
Overview
----------------------------------------
Fixes false-positive "suspicious activity" warnings in the IDS (Intrusion Detection System) when using APIv4.

Before
----------------------------------------
Using the api can result in "There is a validation error with your HTML input. Your activity is a bit suspicious, hence aborting"

After
----------------------------------------
Skip the check, because API calls are not actually HTML input.

Technical Details
----------------------------------------
There are perhaps fancier workarounds to parse the JSON input and apply the IDS checks selectively, but I'm not sure what value that would have. The API already does validation and sanitation of inputs.

Comments
------------------------
APIv3 also skips IDS checks, but in a different way (by adding `params` to the list of excluded fields).
