### PR TITLE
Greenwich - fix conflict btw bootstrap & jQuery UI button

### DIFF
--- a/ext/greenwich/greenwich.php
+++ b/ext/greenwich/greenwich.php
@@ -56,6 +56,9 @@ function greenwich_civicrm_alterBundle(CRM_Core_Resources_Bundle $bundle) {
       $bundle->addScriptFile('greenwich', 'extern/bootstrap3/assets/javascripts/bootstrap.min.js', [
         'translate' => FALSE,
       ]);
+      $bundle->addScriptFile('greenwich', 'js/noConflict.js', [
+        'translate' => FALSE,
+      ]);
       break;
   }
 }

--- a/ext/greenwich/js/noConflict.js
+++ b/ext/greenwich/js/noConflict.js
@@ -1,0 +1,4 @@
+// https://civicrm.org/licensing
+(function($) {
+  $.fn.button.noConflict();
+})(jQuery);


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a problem in the new Greenwich Bootstrap3 theme causing buttons to disappear.

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/2874912/95338265-c2aebe00-0880-11eb-84a3-91e14cb1cb8d.png)

After
----------------------------------------
![image](https://user-images.githubusercontent.com/2874912/95338154-a0b53b80-0880-11eb-9f80-76dbb0fef827.png)

Technical Details
----------------------------------------
This calls noConflict on the Bootstrap3 $.fn.button() method, essentially getting rid of it, as it is not used by CiviCRM, whereas the jQuery UI $.fn.button() is used.

If we needed the boostrap button function, we could rename it with something like:
`$.fn.btn = $.fn.button.noConflict();`

Comments
---------------------------------------
This file was copied over from Shoreditch, which employs the same fix.