### PR TITLE
dev/core#2076 Fix for standalone event registrations confirmation email

### DIFF
--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -1451,9 +1451,11 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
         foreach ($values as $fieldValue) {
           $isPublic = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_CustomGroup', $fieldValue['custom_group_id'], 'is_public');
           if ($isPublic) {
-            $customFields[$fieldID]['id'] = $fieldID;
-            $formattedValue = CRM_Core_BAO_CustomField::displayValue($fieldValue['value'], $fieldID, $participants[0]->id);
-            $customGroup[$customFields[$fieldID]['groupTitle']][$customFields[$fieldID]['label']] = str_replace('&nbsp;', '', $formattedValue);
+            if(!empty($fieldValue['value'])) {
+              $customFields[$fieldID]['id'] = $fieldID;
+              $formattedValue = CRM_Core_BAO_CustomField::displayValue($fieldValue['value'], $fieldID, $participants[0]->id);
+              $customGroup[$customFields[$fieldID]['groupTitle']][$customFields[$fieldID]['label']] = str_replace('&nbsp;', '', $formattedValue);
+            }
           }
         }
       }

--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -1451,7 +1451,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
         foreach ($values as $fieldValue) {
           $isPublic = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_CustomGroup', $fieldValue['custom_group_id'], 'is_public');
           if ($isPublic) {
-            if(!empty($fieldValue['value'])) {
+            if (!empty($fieldValue['value'])) {
               $customFields[$fieldID]['id'] = $fieldID;
               $formattedValue = CRM_Core_BAO_CustomField::displayValue($fieldValue['value'], $fieldID, $participants[0]->id);
               $customGroup[$customFields[$fieldID]['groupTitle']][$customFields[$fieldID]['label']] = str_replace('&nbsp;', '', $formattedValue);


### PR DESCRIPTION
Overview
----------------------------------------
Fix for standalone event registrations confirmation email (event_offline_receipt) so that empty fields are not included in the mail.

https://lab.civicrm.org/dev/core/-/issues/2076
