### PR TITLE
[NFC] dev/core#2053 Extend nextedGroup test to show that it will retu…

### DIFF
--- a/tests/phpunit/CRM/Contact/BAO/GroupTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/GroupTest.php
@@ -142,6 +142,7 @@ class CRM_Contact_BAO_GroupTest extends CiviUnitTestCase {
       'parents' => [
         $group2->id => 1,
       ],
+      'group_type' => ['2' => 1],
     ];
     $group3 = CRM_Contact_BAO_Group::create($params);
 
@@ -155,7 +156,10 @@ class CRM_Contact_BAO_GroupTest extends CiviUnitTestCase {
 
     // Check restrict to mailing groups
     $nestedGroup = CRM_Core_PseudoConstant::nestedGroup(TRUE, 'Mailing');
-    $this->assertSame([$group1->id => 'Parent Group A'], $nestedGroup);
+    $this->assertSame([
+      $group1->id => 'Parent Group A',
+      $group3->id => '&nbsp;&nbsp;Child Group C',
+    ], $nestedGroup);
   }
 
   /**


### PR DESCRIPTION
…rn child groups that are Mailing groups even when the parent isn't a mailing group

Overview
----------------------------------------
This extends the unit test coverage in aid of helping debugging for dev/core#2053

Before
----------------------------------------
Test didn't cover when a child group is mailing but parent isn't

After
----------------------------------------
Tests cover that

ping @eileenmcnaughton @MegaphoneJon 