### PR TITLE
dev/core#2073 Fix use of legacy leaky method in tested code

### DIFF
--- a/CRM/Contact/Import/Form/MapField.php
+++ b/CRM/Contact/Import/Form/MapField.php
@@ -149,14 +149,11 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
     }
     else {
       // get the field names from the temp. DB table
-      $dao = new CRM_Core_DAO();
-      $db = $dao->getDatabaseConnection();
-
       $columnsQuery = "SHOW FIELDS FROM $this->_importTableName
                          WHERE Field NOT LIKE '\_%'";
-      $columnsResult = $db->query($columnsQuery);
-      while ($row = $columnsResult->fetchRow(DB_FETCHMODE_ASSOC)) {
-        $columnNames[] = $row['Field'];
+      $columnsResult = CRM_Core_DAO::executeQuery($columnsQuery);
+      while ($columnsResult->fetch()) {
+        $columnNames[] = $columnsResult->Field;
       }
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
Fix use of legacy leaky method in tested code

Before
----------------------------------------

```$columnsResult = $db->query($columnsQuery);```

After
----------------------------------------
```$columnsResult = CRM_Core_DAO::executeQuery($columnsQuery);```

Technical Details
----------------------------------------
This is too low volume to really leak but it uses the leaky legacy method and
has test cover in

CRM_Contact_Import_Form_MapFieldTest.testSubmit with data set basic_data
CRM_Contact_Import_Form_MapFieldTest.testSubmit with data set save_mapping

Comments
----------------------------------------

