### PR TITLE
dev/core#2073 Fix use of legacy leaky method in tested code

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2270,8 +2270,7 @@ LEFT JOIN  civicrm_contribution contribution ON ( componentPayment.contribution_
               WHERE     membership_id=$membership->id
               ORDER BY  id DESC
               LIMIT     1;";
-            $dao = new CRM_Core_DAO();
-            $dao->query($sql);
+            $dao = CRM_Core_DAO::executeQuery($sql);
             if ($dao->fetch()) {
               if (!empty($dao->membership_type_id)) {
                 $membership->membership_type_id = $dao->membership_type_id;


### PR DESCRIPTION
Overview
----------------------------------------
Fix use of legacy leaky method in tested code

Before
----------------------------------------
```
$dao = new CRM_Core_DAO();
            $dao->query($sql);
```

After
----------------------------------------
```
$dao = CRM_Core_DAO::executeQuery($sql);
```

Technical Details
----------------------------------------
Has test cover in
CRM_Member_Form_MembershipTest.testSubmitUpdateMembershipFromPartiallyPaid
CRM_Member_Form_MembershipTest.testMembershipViewContributionOwnerDifferent
api_v3_ContributionTest.testPendingToCompleteContribution

Comments
----------------------------------------

