### PR TITLE
ParticipantListing Report: only display the View link for web, unhardcode others

### DIFF
--- a/CRM/Report/Form/Event/ParticipantListing.php
+++ b/CRM/Report/Form/Event/ParticipantListing.php
@@ -723,7 +723,7 @@ ORDER BY  cv.label
 
         $rows[$rowNum]['civicrm_contact_sort_name_linked'] = "<a title='$contactTitle' href=$url>$displayName</a>";
         // Add a "View" link to the participant record if this isn't a CSV/PDF/printed document.
-        if ($this->_outputMode !== 'csv' && $this->_outputMode !== 'pdf' && $this->_outputMode !== 'print') {
+        if (empty($this->getOutputMode())) {
           $rows[$rowNum]['civicrm_contact_sort_name_linked'] .=
             "<span style='float: right;'><a title='$participantTitle' href=$viewUrl>" .
             ts('View') . "</a></span>";


### PR DESCRIPTION
Overview
----------------------------------------

When using the Export to Excel extension (https://civicrm.org/extensions/export-native-excel), the Participant Listing report appends a "View" link to the participant name (which would otherwise further filter the report for that participant). The link does not get appended if we print or export to CSV.

![civi-part-list-2020-10-07_17-37](https://user-images.githubusercontent.com/254741/95390652-bdbf2e00-08c3-11eb-8da8-2c0ce26fb7da.png)

Technical Details
----------------------------------------

The report had a hardcoded list of "output modes". My undertanding that if the outputMode is empty, then we are displaying on the web.

Various core reports do similar conditions, but they can be a bit difficult to test, so I prefer to ignore them for now.