### PR TITLE
dev/core#1879 Fix inconsistent ability to view event information

### DIFF
--- a/CRM/ACL/BAO/ACL.php
+++ b/CRM/ACL/BAO/ACL.php
@@ -518,6 +518,8 @@ ORDER BY a.object_id
     if (empty($ids) && !empty($includedGroups) &&
       is_array($includedGroups)
     ) {
+      // This is pretty alarming - we 'sometimes' include all included groups
+      // seems problematic per https://lab.civicrm.org/dev/core/-/issues/1879
       $ids = $includedGroups;
     }
     if ($contactID) {

--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -730,7 +730,7 @@ WHERE civicrm_address.geo_code_1 IS NOT NULL
    * @return array
    *   array of all the events that are searched
    */
-  public static function &getCompleteInfo(
+  public static function getCompleteInfo(
     $start = NULL,
     $type = NULL,
     $eventId = NULL,
@@ -839,15 +839,15 @@ WHERE civicrm_event.is_active = 1
 
     // check 'view event info' permission
     //@todo - per CRM-14626 we have resolved that 'view event info' means 'view ALL event info'
-    // and passing in the specific permission here will short-circuit the evaluation of permission to
-    // see specific events (doesn't seem relevant to this call
-    // however, since this function is accessed only by a convoluted call from a joomla block function
-    // it seems safer not to touch here. Suggestion is that CRM_Core_Permission::check(array or relevant permissions) would
-    // be clearer & safer here
-    $permissions = CRM_Core_Permission::event(CRM_Core_Permission::VIEW);
+    if (CRM_Core_Permission::check('view event info')) {
+      $permissions = TRUE;
+    }
+    else {
+      $permissions = CRM_Core_Permission::event(CRM_Core_Permission::VIEW);
+    }
 
     while ($dao->fetch()) {
-      if (!empty($permissions) && in_array($dao->event_id, $permissions)) {
+      if (!empty($permissions) && ($permissions === TRUE || in_array($dao->event_id, $permissions))) {
         $info = [];
         $info['uid'] = "CiviCRM_EventID_{$dao->event_id}_" . md5($config->userFrameworkBaseURL) . $url;
 
@@ -1075,7 +1075,7 @@ WHERE civicrm_event.is_active = 1
             $email = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_UFGroup', $gId, 'notify');
             if ($email) {
               //get values of corresponding profile fields for notification
-              list($profileValues) = self::buildCustomDisplay($gId,
+              [$profileValues] = self::buildCustomDisplay($gId,
                 NULL,
                 $contactID,
                 $template,

--- a/tests/phpunit/CRM/Event/BAO/EventPermissionsTest.php
+++ b/tests/phpunit/CRM/Event/BAO/EventPermissionsTest.php
@@ -56,7 +56,7 @@ class CRM_Event_BAO_EventPermissionsTest extends CiviUnitTestCase {
   }
 
   public function testViewOwnEvent() {
-    self::setViewOwnEventPermissions();
+    $this->setViewOwnEventPermissions();
     unset(\Civi::$statics['CRM_Event_BAO_Event']['permissions']);
     $permissions = CRM_Event_BAO_Event::checkPermission($this->_ownEventId, CRM_Core_Permission::VIEW);
     $this->assertTrue($permissions);
@@ -67,7 +67,7 @@ class CRM_Event_BAO_EventPermissionsTest extends CiviUnitTestCase {
   }
 
   public function testEditOwnEvent() {
-    self::setViewOwnEventPermissions();
+    $this->setViewOwnEventPermissions();
     unset(\Civi::$statics['CRM_Event_BAO_Event']['permissions']);
     $this->_loggedInUser = CRM_Core_Session::singleton()->get('userID');
     $permissions = CRM_Event_BAO_Event::checkPermission($this->_ownEventId, CRM_Core_Permission::EDIT);
@@ -79,7 +79,7 @@ class CRM_Event_BAO_EventPermissionsTest extends CiviUnitTestCase {
    */
   public function testDeleteOwnEvent() {
     // Check that you can't delete your own event without "Delete in CiviEvent" permission
-    self::setViewOwnEventPermissions();
+    $this->setViewOwnEventPermissions();
     unset(\Civi::$statics['CRM_Event_BAO_Event']['permissions']);
     $permissions = CRM_Event_BAO_Event::checkPermission($this->_ownEventId, CRM_Core_Permission::DELETE);
     $this->assertFalse($permissions);
@@ -135,10 +135,20 @@ class CRM_Event_BAO_EventPermissionsTest extends CiviUnitTestCase {
 
   public function testDeleteOtherEventDenied() {
     // FIXME: This test could be improved, but for now it checks that we can't delete if we don't have "Delete in CiviEvent"
-    self::setEditAllEventPermissions();
+    $this->setEditAllEventPermissions();
     unset(\Civi::$statics['CRM_Event_BAO_Event']['permissions']);
     $permissions = CRM_Event_BAO_Event::checkPermission($this->_otherEventId, CRM_Core_Permission::DELETE);
     $this->assertFalse($permissions);
+  }
+
+  /**
+   * Test get complete info function returns all info for contacts with view all info.
+   */
+  public function testGetCompleteInfo() {
+    $this->setupScenarioCoreACLEveryonePermittedToEvent();
+    $info = CRM_Event_BAO_Event::getCompleteInfo('20000101');
+    $this->assertEquals('Annual CiviCRM meet', $info[0]['title']);
+    $this->assertEquals('Annual CiviCRM meet', $info[1]['title']);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Alternate to https://github.com/civicrm/civicrm-core/pull/17852

Before
----------------------------------------
A contact with 'view event info' who ALSO has permission via acl-given permission to view a specific will ONLY see that specific even in 'upcoming events'  eg http://dmaster.local/civicrm/event/list?reset=1

<img width="737" alt="Screen Shot 2020-10-08 at 4 46 00 PM" src="https://user-images.githubusercontent.com/336308/95412586-c415de80-0985-11eb-9b5f-e13a9324ec02.png">



After
----------------------------------------
<img width="785" alt="Screen Shot 2020-10-08 at 4 44 41 PM" src="https://user-images.githubusercontent.com/336308/95412615-dd1e8f80-0985-11eb-8822-46296da577e3.png">


Technical Details
----------------------------------------
@alifrumin I took another look at your PR - I would up being happier with this short-circuit approach which the code comments were already hinting at. I think your change might have allowed contacts with no event access some.

Comments
----------------------------------------