### PR TITLE
dev/core#2102 Fix hang on event edit

### DIFF
--- a/CRM/Event/Form/ManageEvent/Location.php
+++ b/CRM/Event/Form/ManageEvent/Location.php
@@ -231,7 +231,7 @@ class CRM_Event_Form_ManageEvent_Location extends CRM_Event_Form_ManageEvent {
       CRM_Event_BAO_Event::deleteEventLocBlock($this->_oldLocBlockId, $this->_id);
     }
 
-    $isUpdateToExistingLocationBlock = !empty($params['loc_event_id']) && (int) $params['loc_event_id'] === $this->locationBlock['loc_block_id'];
+    $isUpdateToExistingLocationBlock = !$deleteOldBlock && !empty($params['loc_event_id']) && (int) $params['loc_event_id'] === $this->locationBlock['loc_block_id'];
     // It should be impossible for there to be no default location type. Consider removing this handling
     $defaultLocationTypeID = CRM_Core_BAO_LocationType::getDefault()->id ?? 1;
 

--- a/tests/phpunit/CRM/Event/Form/ManageEvent/LocationTest.php
+++ b/tests/phpunit/CRM/Event/Form/ManageEvent/LocationTest.php
@@ -111,6 +111,76 @@ class CRM_Event_Form_ManageEvent_LocationTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test updating a location block.
+   *
+   * @throws \API_Exception
+   * @throws \CRM_Core_Exception
+   * @throws \Civi\API\Exception\UnauthorizedException
+   */
+  public function testUpdateLocationBlock() {
+    $eventID = (int) $this->eventCreate()['id'];
+    $this->submitForm([
+      'address' => [
+        '1' => [
+          'street_address' => 'Old address',
+          'supplemental_address_1' => 'Hallmark Ct',
+          'supplemental_address_2' => 'Jersey Village',
+          'supplemental_address_3' => 'My Town',
+          'city' => 'Newark',
+          'postal_code' => '01903',
+          'country_id' => 1228,
+          'state_province_id' => 1029,
+          'geo_code_1' => '18.219023',
+          'geo_code_2' => '-105.00973',
+          'is_primary' => 1,
+          'location_type_id' => 1,
+        ],
+      ],
+    ], $eventID);
+
+    $this->submitForm([
+      'location_option' => 1,
+      'loc_event_id' => Event::get()->addWhere('id', '=', $eventID)->addSelect('loc_block_id')->execute()->first()['loc_block_id'],
+      'address' => [
+        '1' => [
+          'street_address' => 'New address',
+          'supplemental_address_1' => 'Hallmark Ct',
+          'supplemental_address_2' => 'Jersey Village',
+          'supplemental_address_3' => 'My Town',
+          'city' => 'Newark',
+          'postal_code' => '01903',
+          'country_id' => 1228,
+          'state_province_id' => 1029,
+          'geo_code_1' => '18.219023',
+          'geo_code_2' => '-105.00973',
+        ],
+      ],
+      'email' => [
+        '1' => [
+          'email' => '',
+        ],
+        '2' => [
+          'email' => '',
+        ],
+      ],
+      'phone' => [
+        '1' => [
+          'phone_type_id' => 1,
+          'phone' => '',
+          'phone_ext' => '',
+        ],
+        '2' => [
+          'phone_type_id' => 1,
+          'phone' => '',
+          'phone_ext' => '',
+        ],
+      ],
+    ], $eventID);
+    // Cleanup.
+    $this->eventDelete($eventID);
+  }
+
+  /**
    * Get the values to submit for the form.
    *
    * @return array


### PR DESCRIPTION

Overview
----------------------------------------
Changing the address on an event causes hang (spinning logo)
Per https://lab.civicrm.org/dev/core/-/issues/2102



Before
----------------------------------------
Create an Event with a location & Save.
On Event configuration select 'Event Location' tab
Click Create new location radio
Enter address details
Click Save



-> Spinning logo.  On reloading the page, 'Create new location' is still selected with no address details

After
----------------------------------------
Save as normal

Technical details
----------------------------------------
It was trying to add an address it had deleted - test covers the related issue too