### PR TITLE
Financial#111: Contribution tokens always display amount with default…

### DIFF
--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -1802,7 +1802,10 @@ class CRM_Utils_Token {
       case 'net_amount':
       case 'fee_amount':
       case 'non_deductible_amount':
-        $value = CRM_Utils_Money::format(CRM_Utils_Array::retrieveValueRecursive($contribution, $token));
+        // FIXME: Is this ever a multi-dimensional array?  Why use retrieveValueRecursive()?
+        $amount = CRM_Utils_Array::retrieveValueRecursive($contribution, $token);
+        $currency = CRM_Utils_Array::retrieveValueRecursive($contribution, 'currency');
+        $value = CRM_Utils_Money::format($amount, $currency);
         break;
 
       case 'receive_date':


### PR DESCRIPTION
… currency

https://lab.civicrm.org/dev/financial/-/issues/111

Overview
----------------------------------------
When using a contribution token that displays an amount (total amount, fee amount, net amount, non-deductible amount) the token formats the currency with the system default, regardless of the currency of the contribution.

Replication steps are on the ticket.

Before
----------------------------------------
Token renders amounts with the system default currency.

After
----------------------------------------
Token renders amounts with the currency of the contribution.

Comments
----------------------------------------
This seems fairly easy to review.  Also, while submitting a Gitlab ticket for this, the auto-suggest actually pointed me to an existing ticket!  I think that's the first time that's ever been successful for me.