### PR TITLE
dev/core#2108 fix deprecation notice

### DIFF
--- a/CRM/Core/Form/Task/PDFLetterCommon.php
+++ b/CRM/Core/Form/Task/PDFLetterCommon.php
@@ -52,7 +52,6 @@ class CRM_Core_Form_Task_PDFLetterCommon {
       FALSE
     );
 
-    $form->add('static', 'pdf_format_header', NULL, ts('Page Format: %1', [1 => '<span class="pdf-format-header-label"></span>']));
     $form->addSelect('format_id', [
       'label' => ts('Select Format'),
       'placeholder' => ts('Default'),
@@ -68,7 +67,6 @@ class CRM_Core_Form_Task_PDFLetterCommon {
       FALSE,
       ['onChange' => "selectPaper( this.value ); showUpdateFormatChkBox();"]
     );
-    $form->add('static', 'paper_dimensions', NULL, ts('Width x Height'));
     $form->add(
       'select',
       'orientation',

--- a/templates/CRM/Contact/Form/Task/PDFLetterCommon.tpl
+++ b/templates/CRM/Contact/Form/Task/PDFLetterCommon.tpl
@@ -34,7 +34,7 @@
 
 <div class="crm-accordion-wrapper collapsed crm-pdf-format-accordion">
     <div class="crm-accordion-header">
-        {$form.pdf_format_header.html}
+      {ts}Page Format:{/ts} <span class="pdf-format-header-label"></span>
     </div>
     <div class="crm-accordion-body">
       <div class="crm-block crm-form-block">
@@ -52,7 +52,7 @@
         <td colspan="2">&nbsp;</td>
       </tr>
       <tr>
-        <td>{$form.paper_dimensions.html}</td><td id="paper_dimensions">&nbsp;</td>
+        <td>{ts}Width x Height{/ts}</td><td id="paper_dimensions">&nbsp;</td>
         <td colspan="2">&nbsp;</td>
       </tr>
       <tr>


### PR DESCRIPTION

Overview
----------------------------------------
This addresses the deprecation warning by moving the text to the tpl layer -

Before
----------------------------------------
hidden deprecation notice rendering this

<img width="544" alt="Screen Shot 2020-10-09 at 4 30 21 PM" src="https://user-images.githubusercontent.com/336308/95540626-bcba0800-0a4d-11eb-8e51-d587004063ba.png">


After
----------------------------------------
'static' form elements now defined in tpl - no appearance change - note the relevant elements are 
<img width="165" alt="Screen Shot 2020-10-09 at 4 38 31 PM" src="https://user-images.githubusercontent.com/336308/95540684-e70bc580-0a4d-11eb-9e91-07b1f0fbb3d1.png">

<img width="149" alt="Screen Shot 2020-10-09 at 4 38 36 PM" src="https://user-images.githubusercontent.com/336308/95540701-f68b0e80-0a4d-11eb-94d5-f77dd1d83700.png">




Technical Details
----------------------------------------
 we could ease up
on the deprecation for type = 'static' but the pattern didn't seem to make much sense or to be
consistent with how we normally do things. There are a handful of places in universe that use static - so maybe we remove in core AND loosen the deprecation notice 

<img width="1129" alt="Screen Shot 2020-10-09 at 4 40 44 PM" src="https://user-images.githubusercontent.com/336308/95540795-33570580-0a4e-11eb-8ace-95937f0ed0da.png">




Comments
----------------------------------------
@demeritcowboy 
