### PR TITLE
dev/core#2108 fix deprecation notice take 2

### DIFF
--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -370,7 +370,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
       CRM_Core_Error::deprecatedFunctionWarning('CRM_Core_Form::addRadio');
     }
 
-    if ($attributes && !is_array($attributes)) {
+    if ($type !== 'static' && $attributes && !is_array($attributes)) {
       // The $attributes param used to allow for strings and would default to an
       // empty string.  However, now that the variable is heavily manipulated,
       // we should expect it to always be an array.


### PR DESCRIPTION

Overview
----------------------------------------
Loosens the deprecation notice - 

Before
----------------------------------------
In 5.31 we deprecated passing $attributes as a string to $form->add - however this little known pattern of ```$form->add('static' ``` is spitting deprecation notices

After
----------------------------------------
```$form->add('static' ``` will not trigger the notice

Technical Details
----------------------------------------
alternative to https://github.com/civicrm/civicrm-core/pull/18716 but
we should merge both IMHO

Comments
----------------------------------------

