### PR TITLE
core#2105: Groups children now get shown with SPAN CSS error

### DIFF
--- a/CRM/Contact/Form/Edit/TagsAndGroups.php
+++ b/CRM/Contact/Form/Edit/TagsAndGroups.php
@@ -88,7 +88,7 @@ class CRM_Contact_Form_Edit_TagsAndGroups {
       }
 
       if ($groupID || !empty($group)) {
-        $groups = CRM_Contact_BAO_Group::getGroupsHierarchy($ids);
+        $groups = CRM_Contact_BAO_Group::getGroupsHierarchy($ids, NULL, '- ');
 
         $attributes['skiplabel'] = TRUE;
         $elements = [];

--- a/CRM/Contact/Form/Search/Basic.php
+++ b/CRM/Contact/Form/Search/Basic.php
@@ -49,7 +49,7 @@ class CRM_Contact_Form_Search_Basic extends CRM_Contact_Form_Search {
 
     // add select for groups
     // Get hierarchical listing of groups, respecting ACLs for CRM-16836.
-    $groupHierarchy = CRM_Contact_BAO_Group::getGroupsHierarchy($this->_group, NULL, '&nbsp;&nbsp;');
+    $groupHierarchy = CRM_Contact_BAO_Group::getGroupsHierarchy($this->_group, NULL, '- ');
     if (!empty($searchOptions['groups'])) {
       $this->addField('group', [
         'entity' => 'group_contact',

--- a/CRM/Contact/Form/Search/Criteria.php
+++ b/CRM/Contact/Form/Search/Criteria.php
@@ -42,7 +42,7 @@ class CRM_Contact_Form_Search_Criteria {
       // multiselect for groups
       if ($form->_group) {
         // Arrange groups into hierarchical listing (child groups follow their parents and have indentation spacing in title)
-        $groupHierarchy = CRM_Contact_BAO_Group::getGroupsHierarchy($form->_group, NULL, '&nbsp;&nbsp;', TRUE);
+        $groupHierarchy = CRM_Contact_BAO_Group::getGroupsHierarchy($form->_group, NULL, '- ', TRUE);
 
         $form->add('select', 'group', ts('Groups'), $groupHierarchy, FALSE,
          ['id' => 'group', 'multiple' => 'multiple', 'class' => 'crm-select2']


### PR DESCRIPTION
Overview
----------------------------------------
The child group label now show raw HTML before it. 

Before
----------------------------------------
<img width="528" alt="Screenshot 2020-10-09 at 9 53 45 AM" src="https://user-images.githubusercontent.com/3735621/95543163-68933180-0a15-11eb-8188-eddeab1a0a9a.png">
<img width="604" alt="Screenshot 2020-10-09 at 9 56 35 AM" src="https://user-images.githubusercontent.com/3735621/95543312-cde72280-0a15-11eb-81f0-3066b5ebd942.png">

After
----------------------------------------
<img width="676" alt="Screenshot 2020-10-09 at 9 54 44 AM" src="https://user-images.githubusercontent.com/3735621/95543201-8496d300-0a15-11eb-934b-69efe02730f1.png">
<img width="770" alt="Screenshot 2020-10-09 at 9 55 43 AM" src="https://user-images.githubusercontent.com/3735621/95543320-d4759a00-0a15-11eb-98fd-7b6d2f99d1a8.png">


Technical Details
----------------------------------------
I am not sure what is the recent style changes made which is affecting the group widget and didn't find the cause of the regression as this wasn't a issue before 5.29.0. I looked on my earlier PR https://github.com/civicrm/civicrm-core/pull/17927 and on reverting this patch it doesn't fix the problem and I tried to lookup further but still got no clue. As a quick fix I have used ```- ``` as a spacer for child group as this technique is already been used in [here](https://github.com/civicrm/civicrm-core/blob/master/CRM/Contact/BAO/GroupContact.php#L773) , meatime I will continue my work to find a correct fix so that use of HTML spacer text is possible to use. 


Comments
----------------------------------------
ping @eileenmcnaughton @lcdservices  @MikeyMJCO 