### PR TITLE
RelationshipCache - Trigger should adapt to active collation

### DIFF
--- a/CRM/Contact/BAO/RelationshipCache.php
+++ b/CRM/Contact/BAO/RelationshipCache.php
@@ -71,6 +71,9 @@ class CRM_Contact_BAO_RelationshipCache extends CRM_Contact_DAO_RelationshipCach
    */
   public static function onHookTriggerInfo($e) {
     $relUpdates = self::createInsertUpdateQueries();
+    // Use utf8mb4_bin or utf8_bin, depending on what's in use.
+    $collation = preg_replace('/^(utf8(?:mb4)?)_.*$/', '$1_bin', CRM_Core_BAO_SchemaHandler::getInUseCollation());
+
     foreach ($relUpdates as $relUpdate) {
       /**
        * This trigger runs whenever a "civicrm_relationship" record is inserted or updated.
@@ -97,8 +100,8 @@ class CRM_Contact_BAO_RelationshipCache extends CRM_Contact_DAO_RelationshipCach
         'sql' => sprintf("\nIF (%s) THEN\n %s;\n END IF;\n",
 
           // Condition
-          implode(' OR ', array_map(function ($col) {
-            return "(OLD.$col != NEW.$col COLLATE utf8_bin)";
+          implode(' OR ', array_map(function ($col) use ($collation) {
+            return "(OLD.$col != NEW.$col COLLATE $collation)";
           }, self::$relTypeWatchFields)),
 
           // Action


### PR DESCRIPTION
Overview
----------------------------------------

Upgrade your database to utf8mb4 and you can no longer edit relationship types (e.g. even trying to disable one fails) because of an SQL trigger that forces the `utf8_bin` collation on one side of a column comparison expression.


Before
----------------------------------------

Trigger forced invalid COLLATE. Cannot edit Relationship Types.


After
----------------------------------------

Can edit Relationship Types.

Trigger no longer specifies a collation, thereby inheriting the collation from the column(/table/database). Since these collations should all be the same (esp after running system.utf8conversion) then I don't see the need for the explicit colaltion.


Technical Details
----------------------------------------

This requires a trigger rebuild (`civicrm/menu/rebuild?reset=1&triggerRebuild=1` or `cv api System.flush triggers=1`)
