### PR TITLE
Search ext: misc cleanup & fixes

### DIFF
--- a/Civi/Api4/Action/Entity/Get.php
+++ b/Civi/Api4/Action/Entity/Get.php
@@ -20,6 +20,7 @@
 namespace Civi\Api4\Action\Entity;
 
 use Civi\Api4\CustomGroup;
+use Civi\Api4\Service\Schema\Joinable\CustomGroupJoinable;
 
 /**
  * Get the names & docblocks of all APIv4 entities.
@@ -91,10 +92,12 @@ class Get extends \Civi\Api4\Generic\BasicGetAction {
       ->execute();
     foreach ($customEntities as $customEntity) {
       $fieldName = 'Custom_' . $customEntity['name'];
+      $baseEntity = '\Civi\Api4\\' . CustomGroupJoinable::getEntityFromExtends($customEntity['extends']);
       $entities[$fieldName] = [
         'name' => $fieldName,
         'title' => $customEntity['title'],
-        'description' => 'Custom group - extends ' . $customEntity['extends'],
+        'titlePlural' => $customEntity['title'],
+        'description' => ts('Custom group for %1', [1 => $baseEntity::getInfo()['titlePlural']]),
         'see' => [
           'https://docs.civicrm.org/user/en/latest/organising-your-data/creating-custom-fields/#multiple-record-fieldsets',
           '\\Civi\\Api4\\CustomGroup',

--- a/ext/search/CRM/Search/Page/Ang.php
+++ b/ext/search/CRM/Search/Page/Ang.php
@@ -99,8 +99,6 @@ class CRM_Search_Page_Ang extends CRM_Core_Page {
         if ($loadOptions) {
           $entity['optionsLoaded'] = TRUE;
         }
-        // Because multivalue custom pseudo-entities don't have titlePlural
-        $entity['titlePlural'] = $entity['titlePlural'] ?? $entity['title'];
         $entity['fields'] = civicrm_api4($entity['name'], 'getFields', [
           'select' => $getFields,
           'where' => [['permission', 'IS NULL']],

--- a/ext/search/ang/search/crmSearch.component.js
+++ b/ext/search/ang/search/crmSearch.component.js
@@ -18,7 +18,7 @@
       this.page = 1;
       this.params = {};
       // After a search this.results is an object of result arrays keyed by page,
-      // Prior to searching it's an empty string because 1: falsey and 2: doesn't throw an error if you try to access undefined properties
+      // Initially this.results is an empty string because 1: it's falsey (unlike an empty object) and 2: it doesn't throw an error if you try to access undefined properties (unlike null)
       this.results = '';
       this.rowCount = false;
       // Have the filters (WHERE, HAVING, GROUP BY, JOIN) changed?
@@ -381,13 +381,6 @@
         return value;
       }
 
-      function getOption(field, value) {
-        return _.find(field.options, function(option) {
-          // Type coersion is intentional
-          return option.id == value;
-        });
-      }
-
       $scope.fieldsForGroupBy = function() {
         return {results: getAllFields('', function(key) {
             return _.contains(ctrl.params.groupBy, key);
@@ -413,7 +406,9 @@
       };
 
       function getDefaultSelect() {
-        return _.filter(['id', 'display_name', 'label', 'title', 'location_type_id:label'], searchMeta.getField);
+        return _.filter(['id', 'display_name', 'label', 'title', 'location_type_id:label'], function(field) {
+          return !!searchMeta.getField(field, ctrl.entity);
+        });
       }
 
       function getAllFields(suffix, disabledIf) {

--- a/ext/search/ang/search/crmSearch/controls.html
+++ b/ext/search/ang/search/crmSearch/controls.html
@@ -10,9 +10,9 @@
       {{:: ts('Auto') }}
     </button>
   </div>
-  <crm-search-actions entity="$ctrl.entity" ids="$ctrl.selectedRows"></crm-search-actions>
+  <crm-search-actions entity="$ctrl.entity" ids="$ctrl.selectedRows" refresh="$ctrl.refreshPage()"></crm-search-actions>
   <div class="btn-group pull-right">
-    <button type="button" class="btn form-control dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+    <button type="button" class="btn btn-default form-control dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
       <i class="crm-i fa-save"></i> {{:: ts('Create')}}
       <span class="caret"></span>
     </button>

--- a/ext/search/ang/search/crmSearchActions.component.js
+++ b/ext/search/ang/search/crmSearchActions.component.js
@@ -4,10 +4,8 @@
   angular.module('search').component('crmSearchActions', {
     bindings: {
       entity: '<',
+      refresh: '&',
       ids: '<'
-    },
-    require: {
-      search: '^crmSearch'
     },
     templateUrl: '~/search/crmSearchActions.html',
     controller: function($scope, crmApi4, dialogService, searchMeta) {
@@ -44,7 +42,7 @@
           var path = $scope.$eval(action.crmPopup.path, data),
             query = action.crmPopup.query && $scope.$eval(action.crmPopup.query, data);
           CRM.loadForm(CRM.url(path, query))
-            .on('crmFormSuccess', ctrl.search.refreshPage);
+            .on('crmFormSuccess', ctrl.refresh);
         }
         // If action uses dialogService
         else if (action.uiDialog) {
@@ -53,7 +51,7 @@
             title: action.title
           });
           dialogService.open('crmSearchAction', action.uiDialog.templateUrl, data, options)
-            .then(ctrl.search.refreshPage);
+            .then(ctrl.refresh);
         }
       };
     }

--- a/ext/search/ang/search/crmSearchActions.html
+++ b/ext/search/ang/search/crmSearchActions.html
@@ -1,5 +1,5 @@
 <div class="btn-group" title="{{:: ts('Perform action on selected items.') }}">
-  <button type="button" ng-disabled="!$ctrl.ids.length" ng-click="$ctrl.init()" class="btn form-control dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+  <button type="button" ng-disabled="!$ctrl.ids.length" ng-click="$ctrl.init()" class="btn form-control dropdown-toggle btn-default" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
     {{:: ts('Action') }} <span class="caret"></span>
   </button>
   <ul class="dropdown-menu" ng-if=":: $ctrl.actions">

--- a/ext/search/ang/search/crmSearchActions/crmSearchActionUpdate.ctrl.js
+++ b/ext/search/ang/search/crmSearchActions/crmSearchActionUpdate.ctrl.js
@@ -35,7 +35,7 @@
 
     this.availableFields = function() {
       var results = _.transform(ctrl.entity.fields, function(result, item) {
-        var formatted = {id: item.name, text: item.title, description: item.description};
+        var formatted = {id: item.name, text: item.label, description: item.description};
         if (fieldInUse(item.name)) {
           formatted.disabled = true;
         }

--- a/ext/search/ang/search/crmSearchActions/crmSearchActionUpdate.html
+++ b/ext/search/ang/search/crmSearchActions/crmSearchActionUpdate.html
@@ -10,7 +10,7 @@
     <hr />
     <div class="buttons pull-right">
       <button type="button" ng-click="$ctrl.cancel()" class="btn btn-danger">{{:: ts('Cancel') }}</button>
-      <button ng-click="$ctrl.save()" class="btn btn-primary" ng-disabled="!$ctrl.values.length">{{:: ts('Update %1 %2', {1: model.ids.length, 2: $ctrl.entity.title}) }}</button>
+      <button ng-click="$ctrl.save()" class="btn btn-primary" ng-disabled="!$ctrl.values.length">{{:: ts('Update %1 %2', {1: model.ids.length, 2: (model.ids.length === 1 ? $ctrl.entity.title : $ctrl.entity.titlePlural)}) }}</button>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Overview
----------------------------------------
- Fixes white on white button text by adding btn-default class
- Fixes missing field names in the bulk-update action
- Decouples searchActions from the main search controller
- Ensures APIv4 returns both `title` & `titlePlural` to fix sorting & a display issue in Search UI
- Misc cleanup

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/2874912/95630070-2ab2ff00-0a4f-11eb-8b7c-05f7a8b3633a.png)

![image](https://user-images.githubusercontent.com/2874912/95630134-4d451800-0a4f-11eb-9687-6d9a744f63b3.png)
After
----------------------------------------
![image](https://user-images.githubusercontent.com/2874912/95629977-fb03f700-0a4e-11eb-882e-927f7d00c66c.png)

![image](https://user-images.githubusercontent.com/2874912/95630205-6d74d700-0a4f-11eb-931c-a31be209321f.png)
Comments
----------------------------------------
The decoupling is in preparation for work on search displays, but doesn't hurt to have it in 5.31.
