### PR TITLE
dev/core#2110 - Warning "Non-static method CRM_Contact_Page_AJAX::pdfFormat() should not be called statically" when changing the page format on print/merge document

### DIFF
--- a/CRM/Contact/Page/AJAX.php
+++ b/CRM/Contact/Page/AJAX.php
@@ -862,7 +862,7 @@ LIMIT {$offset}, {$rowCount}
   /**
    * Retrieve a PDF Page Format for the PDF Letter form.
    */
-  public function pdfFormat() {
+  public static function pdfFormat() {
     $formatId = CRM_Utils_Type::escape($_REQUEST['formatId'], 'Integer');
 
     $pdfFormat = CRM_Core_BAO_PdfFormat::getById($formatId);


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/2110

1. It's a bit difficult to see the warning because it gets hidden somewhere during the ajax call. You can install the [loudnotices](https://lab.civicrm.org/extensions/loudnotices) extension to see it.
2. Go to admin - communications - print page formats.
3. Add a format. Details don't matter.
4. Search for contributions.
5. Select one and from the actions dropdown choose Thank You letter.
6. Expand the Page Format section and change the format.
7. If you have loudnotices installed you can either check ConfigAndLog or on the network tab in browser dev tools check the response.

Or, just look at the function and see it's not static but it's a routing endpoint as defined at https://github.com/civicrm/civicrm-core/blob/7d6e6b8da43a5abcf1b24f205221ab13f4deea02/CRM/Core/xml/Menu/Contact.xml#L310

All the other functions in this file are static too.
