### PR TITLE
dev/financial#152 Pass contribution directly to completeOrder

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4363,7 +4363,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
    *
    * @param array $input
    * @param array $ids
-   * @param array $objects
+   * @param \CRM_Contribute_BAO_Contribution $contribution
    * @param bool $isPostPaymentCreate
    *   Is this being called from the payment.create api. If so the api has taken care of financial entities.
    *   Note that our goal is that this would only ever be called from payment.create and never handle financials (only
@@ -4373,11 +4373,8 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
    * @throws \CRM_Core_Exception
    * @throws \CiviCRM_API3_Exception
    */
-  public static function completeOrder($input, $ids, $objects, $isPostPaymentCreate = FALSE) {
+  public static function completeOrder($input, $ids, $contribution, $isPostPaymentCreate = FALSE) {
     $transaction = new CRM_Core_Transaction();
-    $contribution = $objects['contribution'];
-    // Unset objects just to make it clear it's not used again.
-    unset($objects);
     // @todo see if we even need this - it's used further down to create an activity
     // but the BAO layer should create that - we just need to add a test to cover it & can
     // maybe remove $ids altogether.

--- a/CRM/Core/Payment/AuthorizeNetIPN.php
+++ b/CRM/Core/Payment/AuthorizeNetIPN.php
@@ -229,7 +229,7 @@ class CRM_Core_Payment_AuthorizeNetIPN extends CRM_Core_Payment_BaseIPN {
       return TRUE;
     }
 
-    CRM_Contribute_BAO_Contribution::completeOrder($input, $ids, ['contribution' => $objects['contribution']]);
+    CRM_Contribute_BAO_Contribution::completeOrder($input, $ids, $objects['contribution']);
 
     // Only Authorize.net does this so it is on the a.net class. If there is a need for other processors
     // to do this we should make it available via the api, e.g as a parameter, changing the nuance

--- a/CRM/Core/Payment/BaseIPN.php
+++ b/CRM/Core/Payment/BaseIPN.php
@@ -427,7 +427,7 @@ class CRM_Core_Payment_BaseIPN {
       'related_contact' => $ids['related_contact'] ?? NULL,
       'participant' => !empty($objects['participant']) ? $objects['participant']->id : NULL,
       'contributionRecur' => !empty($objects['contributionRecur']) ? $objects['contributionRecur']->id : NULL,
-    ], $objects);
+    ], $objects['contribution']);
   }
 
   /**

--- a/CRM/Core/Payment/PayPalIPN.php
+++ b/CRM/Core/Payment/PayPalIPN.php
@@ -252,7 +252,7 @@ class CRM_Core_Payment_PayPalIPN extends CRM_Core_Payment_BaseIPN {
       return;
     }
 
-    CRM_Contribute_BAO_Contribution::completeOrder($input, $ids, $objects);
+    CRM_Contribute_BAO_Contribution::completeOrder($input, $ids, $objects['contribution']);
   }
 
   /**

--- a/CRM/Core/Payment/PayPalProIPN.php
+++ b/CRM/Core/Payment/PayPalProIPN.php
@@ -368,7 +368,7 @@ class CRM_Core_Payment_PayPalProIPN extends CRM_Core_Payment_BaseIPN {
       return;
     }
 
-    CRM_Contribute_BAO_Contribution::completeOrder($input, $ids, $objects);
+    CRM_Contribute_BAO_Contribution::completeOrder($input, $ids, $objects['contribution']);
   }
 
   /**

--- a/CRM/Event/Form/Task/Batch.php
+++ b/CRM/Event/Form/Task/Batch.php
@@ -362,7 +362,7 @@ class CRM_Event_Form_Task_Batch extends CRM_Event_Form_Task {
       'related_contact' => NULL,
       'participant' => $params['component_id'],
       'contributionRecur' => NULL,
-    ], ['contribution' => $contribution]);
+    ], $contribution);
 
     // reset template values before processing next transactions
     $template->clearTemplateVars();

--- a/api/v3/Contribution.php
+++ b/api/v3/Contribution.php
@@ -679,7 +679,7 @@ function _ipn_process_transaction($params, $contribution, $input, $ids) {
     'related_contact' => $ids['related_contact'] ?? NULL,
     'participant' => !empty($objects['participant']) ? $objects['participant']->id : NULL,
     'contributionRecur' => !empty($objects['contributionRecur']) ? $objects['contributionRecur']->id : NULL,
-  ], $objects,
+  ], $objects['contribution'],
     $params['is_post_payment_create'] ?? NULL);
 }
 


### PR DESCRIPTION
Overview
----------------------------------------
Simplify function signature on internal completeOrder function

This addresses item 2 on https://lab.civicrm.org/dev/financial/-/issues/152

Before
----------------------------------------
```
 public static function completeOrder($input, $ids, $contribution, $isPostPaymentCreate = FALSE) {
    $contribution = $objects['contribution'];
    // Unset objects just to make it clear it's not used again.
    unset($objects);
```

After
----------------------------------------
```
public static function completeOrder($input, $ids, $contribution, $isPostPaymentCreate = FALSE) {
```

Technical Details
----------------------------------------
We have done quite a a bit of cleanup on this and the only value in objects now used is
contribution - this is really explicit in the code as we actually unset objects after
extracting contribution.

This alters the function signature such that it receives contribution directly rather than
in an array

Comments
----------------------------------------
These are the only places it is accessed from

<img width="1274" alt="Screen Shot 2020-10-11 at 8 48 08 AM" src="https://user-images.githubusercontent.com/336308/95664021-88a32c00-0ba0-11eb-9dc6-93218d4d848b.png">

All have test cover

@mattwire 