### PR TITLE
dev/financial#152 Clean up & test contributionPageID handling

### DIFF
--- a/tests/phpunit/CRM/Core/Payment/AuthorizeNetIPNTest.php
+++ b/tests/phpunit/CRM/Core/Payment/AuthorizeNetIPNTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Civi\Payment\Exception\PaymentProcessorException;
+use Civi\Api4\Contribution;
 
 /**
  * Class CRM_Core_Payment_PayPalProIPNTest
@@ -135,6 +136,11 @@ class CRM_Core_Payment_AuthorizeNetIPNTest extends CiviUnitTestCase {
     $this->assertEquals(date('Y-m-d'), substr($updatedContributionRecurAgain['end_date'], 0, 10));
     // There should not be any email.
     $mut->assertMailLogEmpty();
+
+    $contributions = Contribution::get()->addWhere('contribution_recur_id', '=', $this->_contributionRecurID)->addSelect('contribution_page_id')->execute();
+    foreach ($contributions as $contribution) {
+      $this->assertEquals($this->_contributionPageID, $contribution['contribution_page_id']);
+    }
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Cleans up & adds tests for handling of ```$ids['contributionPage']``` in AuthorizeNetIP

Before
----------------------------------------
Paypal specific code adding confusion,  contribution id being retrieved as a separate query in a separate place when we could just use the value when the bao is fetched

After
----------------------------------------
Handling simplified, test added.

Technical Details
----------------------------------------
The only use of loading it is that the authorize.net code later decides whether to send an email based on it. This is tested in the test that also now includes a check that it is copied over.

This is part of step 1 in https://lab.civicrm.org/dev/financial/-/issues/152 where the goal is to remove the use of the now irrelevant paymentProcessorID in 
```
        $this->loadObjects($input, $ids, $objects, TRUE, $paymentProcessorID);

```

However, it seems loadObjects can likely be bypasses altogether so I'm clarifying how $ids & $objects are used - a larger clarification can be done after https://github.com/civicrm/civicrm-core/pull/18728 is merged

Comments
----------------------------------------
