### PR TITLE
dev/financial#152 Remove unused parameters from BaseIPN->cancelled signature

### DIFF
--- a/CRM/Core/Payment/BaseIPN.php
+++ b/CRM/Core/Payment/BaseIPN.php
@@ -235,13 +235,11 @@ class CRM_Core_Payment_BaseIPN {
    * Process cancelled payment outcome.
    *
    * @param array $objects
-   * @param CRM_Core_Transaction $transaction
-   * @param array $input
    *
    * @return bool
-   * @throws \CiviCRM_API3_Exception
+   * @throws \CiviCRM_API3_Exception|\CRM_Core_Exception
    */
-  public function cancelled(&$objects, $transaction = NULL, $input = []) {
+  public function cancelled($objects) {
     $contribution = &$objects['contribution'];
     $memberships = [];
     if (!empty($objects['membership'])) {
@@ -264,7 +262,6 @@ class CRM_Core_Payment_BaseIPN {
     ]);
     $contribution->contribution_status_id = $contributionStatuses['Cancelled'];
     $contribution->cancel_date = self::$_now;
-    $contribution->cancel_reason = $input['reasonCode'] ?? NULL;
     $contribution->save();
 
     // Add line items for recurring payments.
@@ -291,9 +288,6 @@ class CRM_Core_Payment_BaseIPN {
       $this->cancelParticipant($participant->id);
     }
 
-    if ($transaction) {
-      $transaction->commit();
-    }
     Civi::log()->debug("Setting contribution status to Cancelled");
     return TRUE;
   }

--- a/tests/phpunit/CRM/Core/Payment/BaseIPNTest.php
+++ b/tests/phpunit/CRM/Core/Payment/BaseIPNTest.php
@@ -413,7 +413,7 @@ class CRM_Core_Payment_BaseIPNTest extends CiviUnitTestCase {
     ]);
 
     $transaction = new CRM_Core_Transaction();
-    $this->IPN->cancelled($this->objects, $transaction);
+    $this->IPN->cancelled($this->objects);
 
     $cancelledParticipantsCount = civicrm_api3('Participant', 'get', [
       'sequential' => 1,


### PR DESCRIPTION
Overview
----------------------------------------
Removes some unused parameters, removes pass-by reference

Before
----------------------------------------
Cancelled called from 2 places - they only pass in $objects & never use it again

```
 public function cancelled(&$objects, $transaction = NULL, $input = []) {
```

<img width="1276" alt="Screen Shot 2020-10-11 at 10 17 50 AM" src="https://user-images.githubusercontent.com/336308/95665291-8eead580-0bab-11eb-95f8-1aa986f4aa53.png">

After
----------------------------------------

```
public function cancelled($objects) {
```



Technical Details
----------------------------------------


Comments
----------------------------------------
