### PR TITLE
AngularLoader: Support 'settingsFactory' callbacks in angular modules.

### DIFF
--- a/Civi/Angular/Manager.php
+++ b/Civi/Angular/Manager.php
@@ -29,6 +29,10 @@ class Manager {
    *     This will be mapped to "~/moduleName" by crmResource.
    *   - settings: array(string $key => mixed $value)
    *     List of settings to preload.
+   *   - settingsFactory: callable
+   *     Callback function to fetch settings.
+   *   - requires: array
+   *     List of other modules required
    */
   protected $modules = NULL;
 
@@ -120,9 +124,19 @@ class Manager {
         $angularModules = array_merge($angularModules, $component->getAngularModules());
       }
       \CRM_Utils_Hook::angularModules($angularModules);
-      foreach (array_keys($angularModules) as $module) {
-        if (!isset($angularModules[$module]['basePages'])) {
-          $angularModules[$module]['basePages'] = ['civicrm/a'];
+      foreach ($angularModules as $module => $info) {
+        // Merge in defaults
+        $angularModules[$module] += ['basePages' => ['civicrm/a']];
+        // Validate settingsFactory callables
+        if (isset($info['settingsFactory'])) {
+          // To keep the cache small, we want `settingsFactory` to contain the string names of class & function, not an object
+          if (!is_array($info['settingsFactory']) && !is_string($info['settingsFactory'])) {
+            throw new \CRM_Core_Exception($module . ' settingsFactory must be a callable array or string');
+          }
+          // To keep the cache small, convert full object to just the class name
+          if (is_array($info['settingsFactory']) && is_object($info['settingsFactory'][0])) {
+            $angularModules[$module]['settingsFactory'][0] = get_class($info['settingsFactory'][0]);
+          }
         }
       }
       $this->modules = $this->resolvePatterns($angularModules);
@@ -397,6 +411,7 @@ class Manager {
               break;
 
             case 'settings':
+            case 'settingsFactory':
             case 'requires':
               if (!empty($module[$resType])) {
                 $result[$moduleName] = $module[$resType];

--- a/tests/phpunit/Civi/Angular/LoaderTest.php
+++ b/tests/phpunit/Civi/Angular/LoaderTest.php
@@ -1,0 +1,97 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Angular;
+
+/**
+ * Test the Angular loader.
+ */
+class LoaderTest extends \CiviUnitTestCase {
+
+  public static $dummy_setting_count = 0;
+  public static $dummy_callback_count = 0;
+
+  public function setUp() {
+    parent::setUp();
+    $this->hookClass->setHook('civicrm_angularModules', [$this, 'hook_angularModules']);
+    self::$dummy_setting_count = 0;
+    self::$dummy_callback_count = 0;
+    $this->createLoggedInUser();
+  }
+
+  public function factoryScenarios() {
+    return [
+      ['dummy1', 2, 1],
+      ['dummy2', 2, 0],
+      ['dummy3', 2, 2],
+    ];
+  }
+
+  /**
+   * Tests that AngularLoader only conditionally loads settings via factory functions for in-use modules.
+   * Our dummy settings callback functions keep a count of the number of times they have been called.
+   *
+   * @dataProvider factoryScenarios
+   * @param $module
+   * @param $expectedSettingCount
+   * @param $expectedCallbackCount
+   */
+  public function testSettingFactory($module, $expectedSettingCount, $expectedCallbackCount) {
+    (new \Civi\Angular\AngularLoader())
+      ->setModules([$module])
+      ->useApp()
+      ->load();
+
+    // Run factory callbacks
+    $factorySettings = \Civi::resources()->getSettings();
+
+    // Dummy1 module's factory setting should be set if it is loaded directly or required by dummy3
+    $this->assertTrue(($expectedCallbackCount > 0) === isset($factorySettings['dummy1']['dummy_setting_factory']));
+    // Dummy3 module's factory setting should be set if it is loaded directly
+    $this->assertTrue(($expectedCallbackCount > 1) === isset($factorySettings['dummy3']['dummy_setting_factory']));
+
+    // Dummy1 module's regular setting should be set if it is loaded directly or required by dummy3
+    $this->assertTrue(($module !== 'dummy2') === isset($factorySettings['dummy1']['dummy_setting']));
+    // Dummy2 module's regular setting should be set if loaded
+    $this->assertTrue(($module === 'dummy2') === isset($factorySettings['dummy2']['dummy_setting']));
+
+    // Assert the callback functions ran the expected number of times
+    $this->assertEquals($expectedSettingCount, self::$dummy_setting_count);
+    $this->assertEquals($expectedCallbackCount, self::$dummy_callback_count);
+  }
+
+  public function hook_angularModules(&$modules) {
+    $modules['dummy1'] = [
+      'ext' => 'civicrm',
+      'settings' => $this->getDummySetting(),
+      'settingsFactory' => [self::class, 'getDummySettingFactory'],
+    ];
+    $modules['dummy2'] = [
+      'ext' => 'civicrm',
+      'settings' => $this->getDummySetting(),
+    ];
+    $modules['dummy3'] = [
+      'ext' => 'civicrm',
+      // The string self::class is preferred but passing object $this should also work
+      'settingsFactory' => [$this, 'getDummySettingFactory'],
+      'requires' => ['dummy1'],
+    ];
+  }
+
+  public function getDummySetting() {
+    return ['dummy_setting' => self::$dummy_setting_count++];
+  }
+
+  public static function getDummySettingFactory() {
+    return ['dummy_setting_factory' => self::$dummy_callback_count++];
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
This allows Angular modules with complex/expensive data to provide it with a callback, which will only be invoked if the module is actively loaded on the page.

Docs updated at https://lab.civicrm.org/documentation/docs/dev/-/merge_requests/862

Before
----------------------------------------
Angular modules can declare `settings` which are calculated on every `AngularLoader->load()` and then discarded if the module isn't needed on the current page. This can get expensive.

After
----------------------------------------
Angular modules can declare `settingsFactory` which is only invoked when a module *is* needed on the current page. 

Comments
--------------------------------------
Currently (and I was a bit surprised by this) the full list of Angular modules is *not* cached anywhere. So `hook_civicrm_angularModules` runs on every page, and each module's `settings` is loaded every time. That's a good thing from the POV of permissions (if say a module's settings are different for different users) but it's terrible for performance.

Switching modules to use `settingsFactory` can save cycles in the short-term, and be even better in the long-term when we get around to caching the list of modules, as only the name of the callback will be cached, not the array of settings. This will also keep the per-user settings a possibility even with global caching of the modules.
