### PR TITLE
dev/financial#152 Remove unused parameters from BaseIPN->failed signature

### DIFF
--- a/CRM/Core/Payment/BaseIPN.php
+++ b/CRM/Core/Payment/BaseIPN.php
@@ -162,13 +162,11 @@ class CRM_Core_Payment_BaseIPN {
    * Set contribution to failed.
    *
    * @param array $objects
-   * @param object $transaction
-   * @param array $input
    *
    * @return bool
-   * @throws \CiviCRM_API3_Exception
+   * @throws \CiviCRM_API3_Exception|\CRM_Core_Exception
    */
-  public function failed(&$objects, $transaction = NULL, $input = []) {
+  public function failed($objects) {
     $contribution = &$objects['contribution'];
     $memberships = [];
     if (!empty($objects['membership'])) {
@@ -206,9 +204,6 @@ class CRM_Core_Payment_BaseIPN {
       $this->cancelParticipant($participant->id);
     }
 
-    if ($transaction) {
-      $transaction->commit();
-    }
     Civi::log()->debug("Setting contribution status to Failed");
     return TRUE;
   }

--- a/tests/phpunit/CRM/Core/Payment/BaseIPNTest.php
+++ b/tests/phpunit/CRM/Core/Payment/BaseIPNTest.php
@@ -441,8 +441,7 @@ class CRM_Core_Payment_BaseIPNTest extends CiviUnitTestCase {
       'status_id' => 'Pending from incomplete transaction',
     ]);
 
-    $transaction = new CRM_Core_Transaction();
-    $this->IPN->failed($this->objects, $transaction);
+    $this->IPN->failed($this->objects);
 
     $cancelledParticipantsCount = civicrm_api3('Participant', 'get', [
       'sequential' => 1,


### PR DESCRIPTION
Overview
----------------------------------------
Same as https://github.com/civicrm/civicrm-core/pull/18730 but for failed

Before
----------------------------------------
```
public function failed(&$objects, $transaction = NULL, $input = []) {
```
<img width="1274" alt="Screen Shot 2020-10-11 at 10 51 01 AM" src="https://user-images.githubusercontent.com/336308/95666263-6c10ef00-0bb4-11eb-990f-de8318c78796.png">


After
----------------------------------------
```
public function failed($objects) {
```

Technical Details
----------------------------------------


Comments
----------------------------------------
