### PR TITLE
dev/financial#152 Remove unreachable code

### DIFF
--- a/CRM/Core/Payment/PayPalProIPN.php
+++ b/CRM/Core/Payment/PayPalProIPN.php
@@ -275,28 +275,6 @@ class CRM_Core_Payment_PayPalProIPN extends CRM_Core_Payment_BaseIPN {
       return;
     }
 
-    if (!$first) {
-      //check if this contribution transaction is already processed
-      //if not create a contribution and then get it processed
-      $contribution = new CRM_Contribute_BAO_Contribution();
-      $contribution->trxn_id = $input['trxn_id'];
-      if ($contribution->trxn_id && $contribution->find()) {
-        Civi::log()->debug('PayPalProIPN: Returning since contribution has already been handled.');
-        echo "Success: Contribution has already been handled<p>";
-        return;
-      }
-
-      $contribution->contact_id = $recur->contact_id;
-      $contribution->financial_type_id = $objects['contributionType']->id;
-      $contribution->contribution_page_id = $ids['contributionPage'];
-      $contribution->contribution_recur_id = $ids['contributionRecur'];
-      $contribution->currency = $objects['contribution']->currency;
-      $contribution->payment_instrument_id = $objects['contribution']->payment_instrument_id;
-      $contribution->amount_level = $objects['contribution']->amount_level;
-      $contribution->campaign_id = $objects['contribution']->campaign_id;
-      $objects['contribution'] = &$contribution;
-      $contribution->invoice_id = md5(uniqid(rand(), TRUE));
-    }
     // CRM-13737 - am not aware of any reason why payment_date would not be set - this if is a belt & braces
     $objects['contribution']->receive_date = !empty($input['payment_date']) ? date('YmdHis', strtotime($input['payment_date'])) : $now;
 


### PR DESCRIPTION
Overview
----------------------------------------
Remove unreachable code

Before
----------------------------------------
Code chunk exists that is only reachable when ```$txnType``` is ```'recurring_payment'``` AND ```$first``` is truthy

<img width="574" alt="Screen Shot 2020-10-11 at 1 37 34 PM" src="https://user-images.githubusercontent.com/336308/95667764-efd3d700-0bc6-11eb-800c-816796aaf021.png">

BUT there is an early return a little earlier in the function if those conditions are true

<img width="830" alt="Screen Shot 2020-10-11 at 1 39 04 PM" src="https://user-images.githubusercontent.com/336308/95667786-36293600-0bc7-11eb-8cb3-ff8d27f71e6c.png">

 Ergo this code is unreachable - and would have been
since the earlier code switched to using the api to handle non-firsts

After
----------------------------------------
poof

Technical Details
----------------------------------------
There is test cover on this function in ```CRM_Core_Payment_PayPalProIPNTest``` but it can't actually test code that can't be reached


Comments
----------------------------------------

