### PR TITLE
dev/financial#152 simplify interaction with membership, deprecate function

### DIFF
--- a/CRM/Contribute/BAO/ContributionRecur.php
+++ b/CRM/Contribute/BAO/ContributionRecur.php
@@ -528,6 +528,7 @@ INNER JOIN civicrm_contribution       con ON ( con.id = mp.contribution_id )
    * @param bool $isFirstOrLastRecurringPayment
    */
   public static function sendRecurringStartOrEndNotification($ids, $recur, $isFirstOrLastRecurringPayment) {
+    CRM_Core_Error::deprecatedFunctionWarning('use CRM_Contribute_BAO_ContributionPage::recurringNotify');
     if ($isFirstOrLastRecurringPayment) {
       $autoRenewMembership = FALSE;
       if ($recur->id &&

--- a/tests/phpunit/CRM/Core/Payment/AuthorizeNetIPNTest.php
+++ b/tests/phpunit/CRM/Core/Payment/AuthorizeNetIPNTest.php
@@ -257,7 +257,7 @@ class CRM_Core_Payment_AuthorizeNetIPNTest extends CiviUnitTestCase {
   /**
    * Test IPN response mails don't leak.
    *
-   * @throws \CRM_Core_Exception
+   * @throws \CRM_Core_Exception|\CiviCRM_API3_Exception
    */
   public function testIPNPaymentMembershipRecurSuccessNoLeakage() {
     $mut = new CiviMailUtils($this, TRUE);


### PR DESCRIPTION
Overview
----------------------------------------
Minor code simplification in tested code

Before
----------------------------------------
```$ids['membership'] ``` is only used in one specific place in the IPN but it is determined early on & passed around

After
----------------------------------------
```$ids['membership'] ``` only determined where it is used.

Switch to calling ```sendRecurringStartOrEndNotification``` directly as the wrapper function only interprets ```$ids['membership']``` into a bool for ```$autoRenewMembership``` and duplicates the IF

Technical Details
----------------------------------------
ids['membership'] is only calculated in the Authorize.net IPN flow for the purpose of determining
the autoRenew membership parameter for recurringNotify. This is currently passed to sendRecurringStartOrEndNotification
but that does not add any simplification & cannot be used elsewhere - so deprecating.



Comments
----------------------------------------
This is tested in testIPNPaymentMembershipRecurSuccessNoLeakage