### PR TITLE
dev/financial#152 simplify passed parameters

### DIFF
--- a/CRM/Core/Payment/PayPalIPN.php
+++ b/CRM/Core/Payment/PayPalIPN.php
@@ -210,21 +210,20 @@ class CRM_Core_Payment_PayPalIPN extends CRM_Core_Payment_BaseIPN {
       'related_contact' => $ids['related_contact'] ?? NULL,
       'participant' => !empty($objects['participant']) ? $objects['participant']->id : NULL,
       'contributionRecur' => !empty($objects['contributionRecur']) ? $objects['contributionRecur']->id : NULL,
-    ], $objects, TRUE);
+    ], $objects['contribution'], TRUE);
   }
 
   /**
    * @param array $input
    * @param array $ids
-   * @param array $objects
+   * @param \CRM_Contribute_BAO_Contribution $contribution
    * @param bool $recur
    *
    * @return void
    * @throws \CRM_Core_Exception
    * @throws \CiviCRM_API3_Exception
    */
-  public function single($input, $ids, $objects, $recur = FALSE) {
-    $contribution = &$objects['contribution'];
+  public function single($input, $ids, $contribution, $recur = FALSE) {
 
     // make sure the invoice is valid and matches what we have in the contribution record
     if ($contribution->invoice_id != $input['invoice']) {
@@ -252,7 +251,7 @@ class CRM_Core_Payment_PayPalIPN extends CRM_Core_Payment_BaseIPN {
       return;
     }
 
-    CRM_Contribute_BAO_Contribution::completeOrder($input, $ids, $objects['contribution']);
+    CRM_Contribute_BAO_Contribution::completeOrder($input, $ids, $contribution);
   }
 
   /**
@@ -363,7 +362,7 @@ class CRM_Core_Payment_PayPalIPN extends CRM_Core_Payment_BaseIPN {
         'related_contact' => $ids['related_contact'] ?? NULL,
         'participant' => !empty($objects['participant']) ? $objects['participant']->id : NULL,
         'contributionRecur' => !empty($objects['contributionRecur']) ? $objects['contributionRecur']->id : NULL,
-      ], $objects);
+      ], $objects['contribution']);
     }
     catch (CRM_Core_Exception $e) {
       Civi::log()->debug($e->getMessage());


### PR DESCRIPTION

Overview
----------------------------------------
the ```single```  function now only requires  ```$contribution``` so this simplifies so it only receives that

Before
----------------------------------------
```
public function single($input, $ids, $objects, $recur = FALSE) {
    $contribution = &$objects['contribution'];
```


After
----------------------------------------
```
 public function single($input, $ids, $contribution, $recur = FALSE) {
```

Technical Details
----------------------------------------


Comments
----------------------------------------

Cover in PaypalIPNTest