### PR TITLE
dev/core#2115 remove reference to financialACLs in bounce

### DIFF
--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -470,8 +470,7 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
     $selOrgMemType[0][0] = $selMemTypeOrg[0] = ts('- select -');
 
     // Throw status bounce when no Membership type or priceset is present
-    if (CRM_Financial_BAO_FinancialType::isACLFinancialTypeStatus()
-      && empty($this->allMembershipTypeDetails) && empty($priceSets)
+    if (empty($this->allMembershipTypeDetails) && empty($priceSets)
     ) {
       CRM_Core_Error::statusBounce(ts('You do not have all the permissions needed for this page.'));
     }


### PR DESCRIPTION


Overview
----------------------------------------
Minor code simplification

Before
----------------------------------------
Status bounce on membership form when there are no available membership types AND that is because of the financial acl code

After
----------------------------------------
No available membership types is enough to trigger the bounce

Technical Details
----------------------------------------
I believe that the other 2 criteria suffice. allMembershipDetails is built from
CRM_Member_BAO_Membership::buildMembershipTypeValues()  which is altered by
financial acls but also potentially by other extensions so I don't think the bounce
should be restricted to when financial acls are in play

Comments
----------------------------------------

