### PR TITLE
More accurate language around social media sharing

### DIFF
--- a/CRM/Campaign/Form/Petition.php
+++ b/CRM/Campaign/Form/Petition.php
@@ -203,7 +203,7 @@ class CRM_Campaign_Form_Petition extends CRM_Core_Form {
     $this->add('checkbox', 'bypass_confirm', ts('Bypass email confirmation'));
 
     //is share through social media
-    $this->addElement('checkbox', 'is_share', ts('Allow sharing through social media?'));
+    $this->addElement('checkbox', 'is_share', ts('Add footer region with Twitter, Facebook and LinkedIn share buttons and scripts?'));
 
     // is active ?
     $this->add('checkbox', 'is_active', ts('Is Active?'));

--- a/CRM/Contribute/Form/ContributionPage/Settings.php
+++ b/CRM/Contribute/Form/ContributionPage/Settings.php
@@ -168,7 +168,7 @@ class CRM_Contribute_Form_ContributionPage_Settings extends CRM_Contribute_Form_
     $this->addElement('checkbox', 'is_confirm_enabled', ts('Use a confirmation page?'));
 
     // is this page shareable through social media ?
-    $this->addElement('checkbox', 'is_share', ts('Allow sharing through social media?'));
+    $this->addElement('checkbox', 'is_share', ts('Add footer region with Twitter, Facebook and LinkedIn share buttons and scripts?'));
 
     // is this page active ?
     $this->addElement('checkbox', 'is_active', ts('Is this Online Contribution Page Active?'));

--- a/CRM/Event/Form/ManageEvent/EventInfo.php
+++ b/CRM/Event/Form/ManageEvent/EventInfo.php
@@ -156,7 +156,7 @@ class CRM_Event_Form_ManageEvent_EventInfo extends CRM_Event_Form_ManageEvent {
     $this->add('textarea', 'summary', ts('Event Summary'), $attributes['summary']);
     $this->add('wysiwyg', 'description', ts('Complete Description'), $attributes['event_description'] + ['preset' => 'civievent']);
     $this->addElement('checkbox', 'is_public', ts('Public Event'));
-    $this->addElement('checkbox', 'is_share', ts('Allow sharing through social media?'));
+    $this->addElement('checkbox', 'is_share', ts('Add footer region with Twitter, Facebook and LinkedIn share buttons and scripts?'));
     $this->addElement('checkbox', 'is_map', ts('Include Map to Event Location'));
 
     $this->add('datepicker', 'start_date', ts('Start'), [], !$this->_isTemplate, ['time' => TRUE]);


### PR DESCRIPTION
Overview
----------------------------------------
The option to turn on and off the social media sharing footer suggests that an event, contribution or petition page cannot be shared without turning this setting on ("allow sharing through social media"). It also does not indiciate that turning this setting on will load buttons and scripts from specific social media networks. More details in this issue: https://lab.civicrm.org/dev/user-interface/-/issues/21.

Before
----------------------------------------
Checkbox label reads "Allow sharing through social media?:"
![image](https://user-images.githubusercontent.com/1175967/95759789-79100a00-0caa-11eb-8d29-19ea8ff83a9b.png)

After
----------------------------------------
Checkbox label reads "Add footer region with Twitter, Facebook and LinkedIn share buttons and scripts?".
<img width="551" alt="image" src="https://user-images.githubusercontent.com/1175967/95759995-c68c7700-0caa-11eb-98f3-f5e8caccd3bd.png">

Comments
----------------------------------------
Translations of this string will not be changed, this only works for English.
