### PR TITLE
backdrop#116 Override sessionStart function and use backdrop function…

### DIFF
--- a/CRM/Utils/System/Backdrop.php
+++ b/CRM/Utils/System/Backdrop.php
@@ -1033,4 +1033,20 @@ AND    u.status = 1
     $e->list[] = 'js/crm.backdrop.js';
   }
 
+  /**
+   * Start a new session.
+   */
+  public function sessionStart() {
+    if (function_exists('backdrop_session_start')) {
+      // https://issues.civicrm.org/jira/browse/CRM-14356
+      if (!(isset($GLOBALS['lazy_session']) && $GLOBALS['lazy_session'] == TRUE)) {
+        backdrop_session_start();
+      }
+      $_SESSION = [];
+    }
+    else {
+      session_start();
+    }
+  }
+
 }


### PR DESCRIPTION
…s as appropriate

Overview
----------------------------------------
As per https://github.com/civicrm/civicrm-backdrop/issues/110 This overrides the backdrop Session start function in DrupalBase.php to use the backdrop specific functions

Before
----------------------------------------
DrupalBase function used and drupal functions used in backdrop

After
----------------------------------------
Backdrop system class used and backdrop functions used

ping @herbdool @totten 