### PR TITLE
crmMailing - Only load Angular settings if they're needed

### DIFF
--- a/CRM/Mailing/Info.php
+++ b/CRM/Mailing/Info.php
@@ -26,6 +26,103 @@ class CRM_Mailing_Info extends CRM_Core_Component_Info {
   protected $keyword = 'mailing';
 
   /**
+   * @return array
+   */
+  public static function createAngularSettings():array {
+    $reportIds = [];
+    $reportTypes = ['detail', 'opened', 'bounce', 'clicks'];
+    foreach ($reportTypes as $report) {
+      $rptResult = civicrm_api3('ReportInstance', 'get', [
+        'sequential' => 1,
+        'report_id' => 'mailing/' . $report,
+      ]);
+      if (!empty($rptResult['values'])) {
+        $reportIds[$report] = $rptResult['values'][0]['id'];
+      }
+    }
+
+    $config = CRM_Core_Config::singleton();
+    $session = CRM_Core_Session::singleton();
+    $contactID = $session->get('userID');
+
+    // Generic params.
+    $params = [
+      'options' => ['limit' => 0],
+      'sequential' => 1,
+    ];
+    $groupNames = civicrm_api3('Group', 'get', $params + [
+      'is_active' => 1,
+      'check_permissions' => TRUE,
+      'return' => ['title', 'visibility', 'group_type', 'is_hidden'],
+    ]);
+    $headerfooterList = civicrm_api3('MailingComponent', 'get', $params + [
+      'is_active' => 1,
+      'return' => [
+        'name',
+        'component_type',
+        'is_default',
+        'body_html',
+        'body_text',
+      ],
+    ]);
+
+    $emailAdd = civicrm_api3('Email', 'get', [
+      'sequential' => 1,
+      'return' => "email",
+      'contact_id' => $contactID,
+    ]);
+
+    $mesTemplate = civicrm_api3('MessageTemplate', 'get', $params + [
+      'sequential' => 1,
+      'is_active' => 1,
+      'return' => ["id", "msg_title"],
+      'workflow_id' => ['IS NULL' => ""],
+    ]);
+    $mailTokens = civicrm_api3('Mailing', 'gettokens', [
+      'entity' => ['contact', 'mailing'],
+      'sequential' => 1,
+    ]);
+    $fromAddress = civicrm_api3('OptionValue', 'get', $params + [
+      'option_group_id' => "from_email_address",
+      'domain_id' => CRM_Core_Config::domainID(),
+    ]);
+    $enabledLanguages = CRM_Core_I18n::languages(TRUE);
+    $isMultiLingual = (count($enabledLanguages) > 1);
+    // FlexMailer is a refactoring of CiviMail which provides new hooks/APIs/docs. If the sysadmin has opted to enable it, then use that instead of CiviMail.
+    $requiredTokens = defined('CIVICRM_FLEXMAILER_HACK_REQUIRED_TOKENS') ? Civi\Core\Resolver::singleton()
+      ->call(CIVICRM_FLEXMAILER_HACK_REQUIRED_TOKENS,
+        []) : CRM_Utils_Token::getRequiredTokens();
+    $crmMailingSettings = [
+      'templateTypes' => CRM_Mailing_BAO_Mailing::getTemplateTypes(),
+      'civiMails' => [],
+      'campaignEnabled' => in_array('CiviCampaign', $config->enableComponents),
+      'groupNames' => [],
+      // @todo this is not used in core. Remove once Mosaico no longer depends on it.
+      'testGroupNames' => $groupNames['values'],
+      'headerfooterList' => $headerfooterList['values'],
+      'mesTemplate' => $mesTemplate['values'],
+      'emailAdd' => $emailAdd['values'],
+      'mailTokens' => $mailTokens['values'],
+      'contactid' => $contactID,
+      'requiredTokens' => $requiredTokens,
+      'enableReplyTo' => (int) Civi::settings()->get('replyTo'),
+      'disableMandatoryTokensCheck' => (int) Civi::settings()
+        ->get('disable_mandatory_tokens_check'),
+      'fromAddress' => $fromAddress['values'],
+      'defaultTestEmail' => civicrm_api3('Contact', 'getvalue', [
+        'id' => 'user_contact_id',
+        'return' => 'email',
+      ]),
+      'visibility' => CRM_Utils_Array::makeNonAssociative(CRM_Core_SelectValues::groupVisibility()),
+      'workflowEnabled' => CRM_Mailing_Info::workflowEnabled(),
+      'reportIds' => $reportIds,
+      'enabledLanguages' => $enabledLanguages,
+      'isMultiLingual' => $isMultiLingual,
+    ];
+    return ['crmMailing' => $crmMailingSettings];
+  }
+
+  /**
    * @inheritDoc
    * @return array
    */
@@ -57,94 +154,13 @@ class CRM_Mailing_Info extends CRM_Core_Component_Info {
     }
     global $civicrm_root;
 
-    $reportIds = [];
-    $reportTypes = ['detail', 'opened', 'bounce', 'clicks'];
-    foreach ($reportTypes as $report) {
-      $result = civicrm_api3('ReportInstance', 'get', [
-        'sequential' => 1,
-        'report_id' => 'mailing/' . $report,
-      ]);
-      if (!empty($result['values'])) {
-        $reportIds[$report] = $result['values'][0]['id'];
-      }
-    }
     $result = [];
     $result['crmMailing'] = include "$civicrm_root/ang/crmMailing.ang.php";
     $result['crmMailingAB'] = include "$civicrm_root/ang/crmMailingAB.ang.php";
     $result['crmD3'] = include "$civicrm_root/ang/crmD3.ang.php";
 
-    $config = CRM_Core_Config::singleton();
-    $session = CRM_Core_Session::singleton();
-    $contactID = $session->get('userID');
-
-    // Generic params.
-    $params = [
-      'options' => ['limit' => 0],
-      'sequential' => 1,
-    ];
-    $groupNames = civicrm_api3('Group', 'get', $params + [
-      'is_active' => 1,
-      'check_permissions' => TRUE,
-      'return' => ['title', 'visibility', 'group_type', 'is_hidden'],
-    ]);
-    $headerfooterList = civicrm_api3('MailingComponent', 'get', $params + [
-      'is_active' => 1,
-      'return' => ['name', 'component_type', 'is_default', 'body_html', 'body_text'],
-    ]);
-
-    $emailAdd = civicrm_api3('Email', 'get', [
-      'sequential' => 1,
-      'return' => "email",
-      'contact_id' => $contactID,
-    ]);
-
-    $mesTemplate = civicrm_api3('MessageTemplate', 'get', $params + [
-      'sequential' => 1,
-      'is_active' => 1,
-      'return' => ["id", "msg_title"],
-      'workflow_id' => ['IS NULL' => ""],
-    ]);
-    $mailTokens = civicrm_api3('Mailing', 'gettokens', [
-      'entity' => ['contact', 'mailing'],
-      'sequential' => 1,
-    ]);
-    $fromAddress = civicrm_api3('OptionValue', 'get', $params + [
-      'option_group_id' => "from_email_address",
-      'domain_id' => CRM_Core_Config::domainID(),
-    ]);
-    $enabledLanguages = CRM_Core_I18n::languages(TRUE);
-    $isMultiLingual = (count($enabledLanguages) > 1);
-    // FlexMailer is a refactoring of CiviMail which provides new hooks/APIs/docs. If the sysadmin has opted to enable it, then use that instead of CiviMail.
-    $requiredTokens = defined('CIVICRM_FLEXMAILER_HACK_REQUIRED_TOKENS') ? Civi\Core\Resolver::singleton()->call(CIVICRM_FLEXMAILER_HACK_REQUIRED_TOKENS, []) : CRM_Utils_Token::getRequiredTokens();
     CRM_Core_Resources::singleton()
-      ->addSetting([
-        'crmMailing' => [
-          'templateTypes' => CRM_Mailing_BAO_Mailing::getTemplateTypes(),
-          'civiMails' => [],
-          'campaignEnabled' => in_array('CiviCampaign', $config->enableComponents),
-          'groupNames' => [],
-          // @todo this is not used in core. Remove once Mosaico no longer depends on it.
-          'testGroupNames' => $groupNames['values'],
-          'headerfooterList' => $headerfooterList['values'],
-          'mesTemplate' => $mesTemplate['values'],
-          'emailAdd' => $emailAdd['values'],
-          'mailTokens' => $mailTokens['values'],
-          'contactid' => $contactID,
-          'requiredTokens' => $requiredTokens,
-          'enableReplyTo' => (int) Civi::settings()->get('replyTo'),
-          'disableMandatoryTokensCheck' => (int) Civi::settings()->get('disable_mandatory_tokens_check'),
-          'fromAddress' => $fromAddress['values'],
-          'defaultTestEmail' => civicrm_api3('Contact', 'getvalue', [
-            'id' => 'user_contact_id',
-            'return' => 'email',
-          ]),
-          'visibility' => CRM_Utils_Array::makeNonAssociative(CRM_Core_SelectValues::groupVisibility()),
-          'workflowEnabled' => CRM_Mailing_Info::workflowEnabled(),
-          'reportIds' => $reportIds,
-          'enabledLanguages' => $enabledLanguages,
-          'isMultiLingual' => $isMultiLingual,
-        ],
-      ])
+      ->addSetting(self::createAngularSettings())
       ->addPermissions([
         'view all contacts',
         'edit all contacts',

--- a/CRM/Mailing/Info.php
+++ b/CRM/Mailing/Info.php
@@ -119,7 +119,7 @@ class CRM_Mailing_Info extends CRM_Core_Component_Info {
       'enabledLanguages' => $enabledLanguages,
       'isMultiLingual' => $isMultiLingual,
     ];
-    return ['crmMailing' => $crmMailingSettings];
+    return $crmMailingSettings;
   }
 
   /**
@@ -160,7 +160,6 @@ class CRM_Mailing_Info extends CRM_Core_Component_Info {
     $result['crmD3'] = include "$civicrm_root/ang/crmD3.ang.php";
 
     CRM_Core_Resources::singleton()
-      ->addSetting(self::createAngularSettings())
       ->addPermissions([
         'view all contacts',
         'edit all contacts',

--- a/ang/crmMailing.ang.php
+++ b/ang/crmMailing.ang.php
@@ -14,5 +14,6 @@ return [
   ],
   'css' => ['ang/crmMailing.css'],
   'partials' => ['ang/crmMailing'],
+  'settingsFactory' => ['CRM_Mailing_Info', 'createAngularSettings'],
   'requires' => ['crmUtil', 'crmAttachment', 'crmAutosave', 'ngRoute', 'ui.utils', 'crmUi', 'dialogService', 'crmResource'],
 ];


### PR DESCRIPTION
Overview
----------------------------------------

This removes extraneous data from Angular-based screens which do *not* have a CiviMail UI.

This patch was written as an exercise in reviewing #18731.

Before
----------------------------------------

* If you navigate to `civicrm/a/#/mailing/1` and open a browser console, you can see that `CRM.crmMailing` is populated. This is good because we're on the mailing page.
* If you navigate to `civicrm/admin/afform` and open a browser console, you again see that `CRM.crmMailing` is populated. This is extraneous because `crmMailing` is never activated on this screen.

After
----------------------------------------

* (*Same*) If you navigate to `civicrm/a/#/mailing/1` and open a browser console, you can see that `CRM.crmMailing` is populated. This is good because we're on the mailing page.
* (*Changed*) If you navigate to `civicrm/admin/afform` and open a browser console, you can see that `CRM.crmMailing` is ***not*** populated.

Comments
----------------------------------------

In reading the diff, it looks slightly noisier than it should. What's actually happened is that I used a refactoring (Extract Method) to move several lines from `getAngularModules()` to a separate function `createAngularSettings()`. Due to the dependence on the other PR and the quirks in diff format, it makes  it appear as if some unrelated functions are removed+readded. 🤷‍♂️ 