### PR TITLE
Rebuild triggers after utf8mb4 conversion

### DIFF
--- a/CRM/Core/BAO/SchemaHandler.php
+++ b/CRM/Core/BAO/SchemaHandler.php
@@ -889,6 +889,9 @@ MODIFY      {$columnName} varchar( $length )
       // Disable i18n rewrite.
       CRM_Core_DAO::executeQuery($query, $params, TRUE, NULL, FALSE, FALSE);
     }
+    // Rebuild triggers and other schema reconciliation if needed.
+    $logging = new CRM_Logging_Schema();
+    $logging->fixSchemaDifferences();
     return TRUE;
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Follow-on from https://github.com/civicrm/civicrm-core/pull/18721

If you run the system.utf8conversion api call, the triggers for relationship_cache will still use utf8_bin instead of utf8mb4_bin. This adds a trigger rebuild at the end of the api call to resync. Ditto if you've switched back to utf8.
