### PR TITLE
dev/core#2118 supply better automatic placeholders for select (5.31 intra-rc)

### DIFF
--- a/CRM/Contact/Form/Edit/Address.php
+++ b/CRM/Contact/Form/Edit/Address.php
@@ -121,7 +121,7 @@ class CRM_Contact_Form_Edit_Address {
         $name = 'name';
       }
 
-      $params = ['entity' => 'address'];
+      $params = ['entity' => 'Address'];
 
       if ($name === 'postal_code_suffix') {
         $params['label'] = ts('Suffix');


### PR DESCRIPTION
Overview
----------------------------------------
The placeholders were not being set for certain Select fields generated from metadata.  The result is that the field defaults to the first option.

https://lab.civicrm.org/dev/core/-/issues/2118

Before
----------------------------------------
All your new contacts are from Afghanistan.

After
----------------------------------------
A field has a placeholder based upon the field label, field title, or entity name.

Comments
----------------------------------------
Related to #17675
