### PR TITLE
Angular Loader: Allow modules to specify permissions to add client-side

### DIFF
--- a/CRM/Mailing/Info.php
+++ b/CRM/Mailing/Info.php
@@ -159,18 +159,6 @@ class CRM_Mailing_Info extends CRM_Core_Component_Info {
     $result['crmMailingAB'] = include "$civicrm_root/ang/crmMailingAB.ang.php";
     $result['crmD3'] = include "$civicrm_root/ang/crmD3.ang.php";
 
-    CRM_Core_Resources::singleton()
-      ->addPermissions([
-        'view all contacts',
-        'edit all contacts',
-        'access CiviMail',
-        'create mailings',
-        'schedule mailings',
-        'approve mailings',
-        'delete in CiviMail',
-        'edit message templates',
-      ]);
-
     return $result;
   }
 

--- a/Civi/Angular/AngularLoader.php
+++ b/Civi/Angular/AngularLoader.php
@@ -120,8 +120,18 @@ class AngularLoader {
       foreach ($angular->getResources($moduleNames, 'settingsFactory', 'settingsFactory') as $moduleName => $factory) {
         $settingsByModule[$moduleName] = array_merge($settingsByModule[$moduleName] ?? [], $factory());
       }
+      // Add clientside permissions
+      $permissions = [];
+      $toCheck  = $angular->getResources($moduleNames, 'permissions', 'permissions');
+      foreach ($toCheck as $perms) {
+        foreach ((array) $perms as $perm) {
+          if (!isset($permissions[$perm])) {
+            $permissions[$perm] = \CRM_Core_Permission::check($perm);
+          }
+        }
+      }
       // TODO optimization; client-side caching
-      return array_merge($settingsByModule, [
+      return array_merge($settingsByModule, ['permissions' => $permissions], [
         'resourceUrls' => \CRM_Extension_System::singleton()->getMapper()->getActiveModuleUrls(),
         'angular' => [
           'modules' => $moduleNames,

--- a/Civi/Angular/Manager.php
+++ b/Civi/Angular/Manager.php
@@ -31,6 +31,8 @@ class Manager {
    *     List of settings to preload.
    *   - settingsFactory: callable
    *     Callback function to fetch settings.
+   *   - permissions: array
+   *     List of permissions to make available client-side
    *   - requires: array
    *     List of other modules required
    */
@@ -413,6 +415,7 @@ class Manager {
             case 'settings':
             case 'settingsFactory':
             case 'requires':
+            case 'permissions':
               if (!empty($module[$resType])) {
                 $result[$moduleName] = $module[$resType];
               }

--- a/ang/crmMailing.ang.php
+++ b/ang/crmMailing.ang.php
@@ -16,4 +16,14 @@ return [
   'partials' => ['ang/crmMailing'],
   'settingsFactory' => ['CRM_Mailing_Info', 'createAngularSettings'],
   'requires' => ['crmUtil', 'crmAttachment', 'crmAutosave', 'ngRoute', 'ui.utils', 'crmUi', 'dialogService', 'crmResource'],
+  'permissions' => [
+    'view all contacts',
+    'edit all contacts',
+    'access CiviMail',
+    'create mailings',
+    'schedule mailings',
+    'approve mailings',
+    'delete in CiviMail',
+    'edit message templates',
+  ],
 ];


### PR DESCRIPTION
Overview
----------------------------------------
Allow an angular module to declare an array of permission data it needs access to on the client-side. For example, the civimail Angular code needs to know if the logged-in user has `'access CiviMail'` permission, etc.

Docs updated at https://lab.civicrm.org/documentation/docs/dev/-/merge_requests/862

Before
----------------------------------------
Permissions would need to be shoehorned in at runtime by some other means, often resulting in them being added unnecessarily when the module wasn't even being loaded on the current path.

After
----------------------------------------
Permissions can be declared as part of the angular module definition.

Comments
----------------------------------------
This gets the last of the duct-tape out of the civimail angular code (at least the settings part).
