### PR TITLE
dev/event#43 Contact Dashboard: fix Event Participations

### DIFF
--- a/CRM/Event/Page/UserDashboard.php
+++ b/CRM/Event/Page/UserDashboard.php
@@ -25,19 +25,29 @@ class CRM_Event_Page_UserDashboard extends CRM_Contact_Page_View_UserDashBoard {
    *
    */
   public function listParticipations() {
-    $controller = new CRM_Core_Controller_Simple(
-      'CRM_Event_Form_Search',
-      ts('Events'),
-      NULL,
-      FALSE, FALSE, TRUE, FALSE
-    );
-    $controller->setEmbedded(TRUE);
-    $controller->reset();
-    $controller->set('context', 'user');
-    $controller->set('cid', $this->_contactId);
-    $controller->set('force', 1);
-    $controller->process();
-    $controller->run();
+    $event_rows = [];
+
+    $participants = \Civi\Api4\Participant::get(FALSE)
+      ->addSelect('id', 'contact_id', 'status_id:name', 'status_id:label', 'event.id', 'event.title', 'event.start_date', 'event.end_date')
+      ->addWhere('contact_id', '=', $this->_contactId)
+      ->addOrderBy('event.start_date', 'DESC')
+      ->execute()
+      ->indexBy('id');
+
+    // Flatten the results in the format expected by the template
+    foreach ($participants as $p) {
+      $p['participant_id'] = $p['id'];
+      $p['status'] = $p['status_id:name'];
+      $p['participant_status'] = $p['status_id:label'];
+      $p['event_id'] = $p['event.id'];
+      $p['event_title'] = $p['event.title'];
+      $p['event_start_date'] = $p['event.start_date'];
+      $p['event_end_date'] = $p['event.end_date'];
+
+      $event_rows[] = $p;
+    }
+
+    $this->assign('event_rows', $event_rows);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
PR of #18755 against the RC (5.31).

https://lab.civicrm.org/dev/event/-/issues/43

Using dmaster, change the following permissions for the "authenticated user":

* add: "CiviCRM: access AJAX API"
* add: "CiviEvent: register for events"

Then create a contact and a Drupal user with no special role (so that they are just 'authenticated user').

Register that contact for an event.

Finally, go to their "Contact Dashboard", and notice that their participation will be displayed:

![Capture d’écran de 2020-10-13 15-48-19](https://user-images.githubusercontent.com/254741/95909236-2565f500-0d6c-11eb-9755-a18a0c595332.png)


Now, login as the user, and go to their CiviCRM Contact Dashboard (`/civicrm/user?reset=1`). Notice that their participation is not visible:

![event-2020-10-13_15-49](https://user-images.githubusercontent.com/254741/95909242-27c84f00-0d6c-11eb-8e97-f3f464e39914.png)

Broken since 5.29.

Technical Details
----------------------------------------

I decided to replace the use of a controller/search because that is what `CRM/Contribute/Page/UserDashboard.php` does.

I tried debugging how the controller works, but it was not fun. :jazzhands: FALSE FALSE TRUE FALSE ;)

Comments
----------------------------------------

https://lab.civicrm.org/dev/event/-/issues/43
