### PR TITLE
dev/core#2117 Ensure that empty snippits do not cause fatal errors

### DIFF
--- a/CRM/Core/Region.php
+++ b/CRM/Core/Region.php
@@ -143,7 +143,7 @@ class CRM_Core_Region implements CRM_Core_Resources_CollectionInterface, CRM_Cor
     };
 
     foreach ($this->snippets as $snippet) {
-      if (empty($snippet['disabled'])) {
+      if (empty($snippet['disabled']) && !empty($snippet)) {
         $renderSnippet($snippet);
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------
This fixes the fatal error reported by Kevin and Justin on https://lab.civicrm.org/dev/core/-/issues/2117

Before
----------------------------------------
Fatal error cos no snippet type defined

After
----------------------------------------
No fatal error if the $snippet is actually empty

Technical Details
----------------------------------------
To trigger this you need to have a wp-demo site and then to enable the CiviCRM Admin utilities plugin and try and view an event registration page. For some reason we are winding up here after a `CRM_Core_Region::instance('html-header')->get('some url')` when that url may not exist in the snippets currently loaded so I presume the get function in CRM_Core_ResourcesCollectionTrait is returning an empty array or something

ping @totten @agileware-justin @kcristiano @haystack