### PR TITLE
[NFC/Unit test] dev/core#2114 - Failing unit test demonstrating that logging doesn't log changes in upper/lower case or accents

### DIFF
--- a/tests/phpunit/CRM/Logging/SchemaTest.php
+++ b/tests/phpunit/CRM/Logging/SchemaTest.php
@@ -363,6 +363,50 @@ class CRM_Logging_SchemaTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test that logging records changes in upper/lower-case and accents.
+   * e.g. changing e to E or e to é
+   * @dataProvider loggingSensitivityProvider
+   *
+   * @param array $input
+   */
+  public function testLoggingSensitivity(array $input) {
+    $schema = new CRM_Logging_Schema();
+    $schema->enableLogging();
+
+    // create a contact with all lower case/no accents
+    $contact_id = $this->individualCreate(['first_name' => 'pierre']);
+
+    $query_params = [
+      1 => [$contact_id, 'Integer'],
+      2 => [$input['first_name'], 'String'],
+    ];
+
+    // Clear out anything that api did twice during initial creation so that
+    // spurious update records don't give false results.
+    CRM_Core_DAO::executeQuery("DELETE FROM log_civicrm_contact WHERE id = %1 AND log_action = 'update'", $query_params);
+
+    // Change the first name
+    CRM_Core_DAO::executeQuery("UPDATE civicrm_contact SET first_name = %2 WHERE id = %1", $query_params);
+    // check the log
+    $dao = CRM_Core_DAO::executeQuery("SELECT first_name FROM log_civicrm_contact WHERE id = %1 AND log_action = 'update'", $query_params);
+    $first_name = NULL;
+    if ($dao->fetch()) {
+      $first_name = $dao->first_name;
+    }
+    $this->assertSame($input['first_name'], $first_name);
+  }
+
+  /**
+   * Dataprovider for testLoggingSensitivity
+   */
+  public function loggingSensitivityProvider():array {
+    return [
+      'upper' => [['first_name' => 'Pierre']],
+      'accent' => [['first_name' => 'pièrre']],
+    ];
+  }
+
+  /**
    * Determine if we are running on MySQL 8 version 8.0.19 or later.
    *
    * @return bool


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/2114

Unit test demonstrating the following:

1. Turn on trigger-based logging (Admin - system settings - misc - Logging).
1. Create a contact.
1. Change their first name just changing one letter to upper or lower case.
1. Check the contact logging report at CiviReport - Contact Reports - Contact Logging Summary, or look in the database at log_civicrm_contact. The change is not recorded.

Technical Details
----------------------------------------
The collations used in civi tables are likely case-insensitive and also accent-insensitive unless you've changed them. The logging triggers don't specify _bin collations explicitly so comparisons are done using the field/default collation.

Comments
----------------------------------------
Is test.
