### PR TITLE
dev/core#2117 - Add compatibility aliases for 'scriptFile' and 'styleFile' resources

### DIFF
--- a/CRM/Core/Resources/CollectionInterface.php
+++ b/CRM/Core/Resources/CollectionInterface.php
@@ -50,6 +50,7 @@
  *
  *   - type: string (markup, template, callback, script, scriptFile, scriptUrl, jquery, style, styleFile, styleUrl)
  *   - name: string, symbolic identifier for this resource
+ *   - aliases: string[], list of alternative names for this resource
  *   - weight: int, default=1. Lower weights come before higher weights.
  *     (If two resources have the same weight, then a secondary ordering will be
  *     used to ensure reproducibility. However, the secondary ordering is

--- a/CRM/Core/Resources/CollectionTrait.php
+++ b/CRM/Core/Resources/CollectionTrait.php
@@ -122,6 +122,10 @@ trait CRM_Core_Resources_CollectionTrait {
       $snippet['styleFileUrls'] = $theme->resolveUrls($theme->getActiveThemeKey(), $ext, $file);
     }
 
+    if (isset($snippet['aliases']) && !is_array($snippet['aliases'])) {
+      $snippet['aliases'] = [$snippet['aliases']];
+    }
+
     $this->snippets[$snippet['name']] = $snippet;
     $this->isSorted = FALSE;
     return $snippet;
@@ -149,8 +153,15 @@ trait CRM_Core_Resources_CollectionTrait {
    * @see CRM_Core_Resources_CollectionInterface::update()
    */
   public function update($name, $snippet) {
-    $this->snippets[$name] = array_merge($this->snippets[$name], $snippet);
-    $this->isSorted = FALSE;
+    foreach ($this->resolveName($name) as $realName) {
+      $this->snippets[$realName] = array_merge($this->snippets[$realName], $snippet);
+      $this->isSorted = FALSE;
+      return $this;
+    }
+
+    Civi::log()->warning('Failed to update resource by name ({name})', [
+      'name' => $name,
+    ]);
     return $this;
   }
 
@@ -174,7 +185,12 @@ trait CRM_Core_Resources_CollectionTrait {
    * @see CRM_Core_Resources_CollectionInterface::get()
    */
   public function &get($name) {
-    return $this->snippets[$name];
+    foreach ($this->resolveName($name) as $realName) {
+      return $this->snippets[$realName];
+    }
+
+    $null = NULL;
+    return $null;
   }
 
   /**
@@ -288,6 +304,24 @@ trait CRM_Core_Resources_CollectionTrait {
       $this->isSorted = TRUE;
     }
     return $this;
+  }
+
+  /**
+   * @param string $name
+   *   Name or alias.
+   * return array
+   *   List of real names.
+   */
+  protected function resolveName($name) {
+    if (isset($this->snippets[$name])) {
+      return [$name];
+    }
+    foreach ($this->snippets as $snippetName => $snippet) {
+      if (isset($snippet['aliases']) && in_array($name, $snippet['aliases'])) {
+        return [$snippetName];
+      }
+    }
+    return [];
   }
 
   /**

--- a/CRM/Core/Resources/CollectionTrait.php
+++ b/CRM/Core/Resources/CollectionTrait.php
@@ -114,12 +114,18 @@ trait CRM_Core_Resources_CollectionTrait {
       }
       $snippet['scriptFileUrls'] = [$res->getUrl($ext, $res->filterMinify($ext, $file), TRUE)];
     }
+    if ($snippet['type'] === 'scriptFile' && !isset($snippet['aliases'])) {
+      $snippet['aliases'] = $snippet['scriptFileUrls'];
+    }
 
     if ($snippet['type'] === 'styleFile' && !isset($snippet['styleFileUrls'])) {
       /** @var Civi\Core\Themes $theme */
       $theme = Civi::service('themes');
       list ($ext, $file) = $snippet['styleFile'];
       $snippet['styleFileUrls'] = $theme->resolveUrls($theme->getActiveThemeKey(), $ext, $file);
+    }
+    if ($snippet['type'] === 'styleFile' && !isset($snippet['aliases'])) {
+      $snippet['aliases'] = $snippet['styleFileUrls'];
     }
 
     if (isset($snippet['aliases']) && !is_array($snippet['aliases'])) {

--- a/tests/phpunit/CRM/Core/Resources/CollectionTestTrait.php
+++ b/tests/phpunit/CRM/Core/Resources/CollectionTestTrait.php
@@ -223,6 +223,45 @@ trait CRM_Core_Resources_CollectionTestTrait {
   }
 
   /**
+   * Create a few resources with aliases. Use a mix of reads+writes on both the
+   * canonical names and aliased names.
+   */
+  public function testAliases() {
+    $b = $this->createEmptyCollection();
+    $b->add([
+      'styleUrl' => 'https://example.com/foo.css',
+      'name' => 'foo',
+      'aliases' => ['bar', 'borg'],
+    ]);
+    $b->add([
+      'scriptUrl' => 'https://example.com/whiz.js',
+      'name' => 'whiz',
+      'aliases' => 'bang',
+    ]);
+
+    $this->assertEquals('foo', $b->get('foo')['name']);
+    $this->assertEquals('foo', $b->get('bar')['name']);
+    $this->assertEquals('foo', $b->get('borg')['name']);
+    $this->assertEquals('whiz', $b->get('whiz')['name']);
+    $this->assertEquals('whiz', $b->get('bang')['name']);
+    $this->assertEquals(NULL, $b->get('snafu'));
+
+    // Go back+forth, updating with one name then reading with the other.
+
+    $b->get('borg')['borgify'] = TRUE;
+    $this->assertEquals(TRUE, $b->get('foo')['borgify']);
+
+    $b->get('foo')['d'] = 'ie';
+    $this->assertEquals('ie', $b->get('borg')['d']);
+
+    $b->update('bang', ['b52' => 'love shack']);
+    $this->assertEquals('love shack', $b->get('whiz')['b52']);
+
+    $b->update('whiz', ['golly' => 'gee']);
+    $this->assertEquals('gee', $b->get('bang')['golly']);
+  }
+
+  /**
    * Add some items to a bundle - then clear() all of them.
    */
   public function testClear() {


### PR DESCRIPTION
Overview
----------------------------------------

In the resource/region subsystem, each "snippet" or "resource" has a `name`. This is sometimes used downstream to modify the resources.

In 5.31.beta, the default `name` for some resources changed. This patch improves backward-compatibility by adding aliases for the old names.

See: https://lab.civicrm.org/dev/core/-/issues/2117

Before & After
----------------------------------------

The patch changes the default naming when one calls  `addScriptFile($ext, $file)` or `addStyleFile($ext, $file)`:

* __Prior versions (e.g. 5.27)__: The `name` is the URL. (Roughly -- but not exactly -- the same as `getUrl($ext, $file, TRUE)`.)
* __Current 5.31.beta__: The `name` is the combination `$ext:$file`.
* __This Patch__: The `name` is the combination `$ext:$file`, and the `aliases` are based on the URL(s).

Comments
----------------------------------------

For testing on my local, I used this snippet in a throw-away extension. Both variant A+B work with the patch.

```php
function foobar_civicrm_alterBundle($b) {
  switch ($b->name) {
    case 'coreStyles':
       // Variant A: Use URL as name
      $url = Civi::resources()->getUrl('civicrm', 'css/civicrm.css', TRUE);
      $b->update($url, ['disabled' => TRUE]);

//      // Variant B: Use "ext:file" as name
//      $b->update("civicrm:css/civicrm.css", ['disabled' => TRUE]);
  }
}
```
