### PR TITLE
Fix unreleased regression on search tasks from basic search

### DIFF
--- a/CRM/Activity/Controller/Search.php
+++ b/CRM/Activity/Controller/Search.php
@@ -28,6 +28,8 @@
  */
 class CRM_Activity_Controller_Search extends CRM_Core_Controller {
 
+  protected $entity = 'Activity';
+
   /**
    * Class constructor.
    *
@@ -46,6 +48,7 @@ class CRM_Activity_Controller_Search extends CRM_Core_Controller {
 
     // Add all the actions.
     $this->addActions();
+    $this->set('entity', $this->entity);
   }
 
   /**

--- a/CRM/Campaign/Controller/Search.php
+++ b/CRM/Campaign/Controller/Search.php
@@ -28,6 +28,8 @@
  */
 class CRM_Campaign_Controller_Search extends CRM_Core_Controller {
 
+  protected $entity = 'Campaign';
+
   /**
    * Class constructor.
    *
@@ -45,8 +47,8 @@ class CRM_Campaign_Controller_Search extends CRM_Core_Controller {
     $this->addPages($this->_stateMachine, $action);
 
     // add all the actions
-    $config = CRM_Core_Config::singleton();
     $this->addActions();
+    $this->set('entity', $this->entity);
   }
 
 }

--- a/CRM/Case/Controller/Search.php
+++ b/CRM/Case/Controller/Search.php
@@ -28,6 +28,8 @@
  */
 class CRM_Case_Controller_Search extends CRM_Core_Controller {
 
+  protected $entity = 'Case';
+
   /**
    * Class constructor.
    *
@@ -45,8 +47,8 @@ class CRM_Case_Controller_Search extends CRM_Core_Controller {
     $this->addPages($this->_stateMachine, $action);
 
     // add all the actions
-    $config = CRM_Core_Config::singleton();
     $this->addActions();
+    $this->set('entity', $this->entity);
   }
 
 }

--- a/CRM/Contact/Controller/Search.php
+++ b/CRM/Contact/Controller/Search.php
@@ -27,6 +27,8 @@
  */
 class CRM_Contact_Controller_Search extends CRM_Core_Controller {
 
+  protected $entity = 'Contact';
+
   /**
    * Class constructor.
    *
@@ -44,6 +46,7 @@ class CRM_Contact_Controller_Search extends CRM_Core_Controller {
 
     // add all the actions
     $this->addActions();
+    $this->set('entity', $this->entity);
   }
 
   /**

--- a/CRM/Contribute/Controller/Search.php
+++ b/CRM/Contribute/Controller/Search.php
@@ -27,12 +27,16 @@
  */
 class CRM_Contribute_Controller_Search extends CRM_Core_Controller {
 
+  protected $entity = 'Contribution';
+
   /**
    * Class constructor.
    *
    * @param string $title
    * @param bool|int $action
    * @param bool $modal
+   *
+   * @throws \CRM_Core_Exception
    */
   public function __construct($title = NULL, $action = CRM_Core_Action::NONE, $modal = TRUE) {
 
@@ -40,6 +44,7 @@ class CRM_Contribute_Controller_Search extends CRM_Core_Controller {
     $this->_stateMachine = new CRM_Contribute_StateMachine_Search($this, $action);
     $this->addPages($this->_stateMachine, $action);
     $this->addActions();
+    $this->set('entity', $this->entity);
   }
 
 }

--- a/CRM/Event/Controller/Search.php
+++ b/CRM/Event/Controller/Search.php
@@ -22,6 +22,8 @@
  */
 class CRM_Event_Controller_Search extends CRM_Core_Controller {
 
+  protected $entity = 'Participant';
+
   /**
    * Class constructor.
    *
@@ -56,6 +58,7 @@ class CRM_Event_Controller_Search extends CRM_Core_Controller {
 
     // add all the actions
     $this->addActions($uploadDir, $uploadNames);
+    $this->set('entity', $this->entity);
   }
 
 }

--- a/CRM/Grant/Controller/Search.php
+++ b/CRM/Grant/Controller/Search.php
@@ -28,6 +28,8 @@
  */
 class CRM_Grant_Controller_Search extends CRM_Core_Controller {
 
+  protected $entity = 'Grant';
+
   /**
    * Class constructor.
    *
@@ -45,8 +47,8 @@ class CRM_Grant_Controller_Search extends CRM_Core_Controller {
     $this->addPages($this->_stateMachine, $action);
 
     // add all the actions
-    $config = CRM_Core_Config::singleton();
     $this->addActions();
+    $this->set('entity', $this->entity);
   }
 
 }

--- a/CRM/Member/Controller/Search.php
+++ b/CRM/Member/Controller/Search.php
@@ -28,6 +28,8 @@
  */
 class CRM_Member_Controller_Search extends CRM_Core_Controller {
 
+  protected $entity = 'Membership';
+
   /**
    * Class constructor.
    *
@@ -45,8 +47,8 @@ class CRM_Member_Controller_Search extends CRM_Core_Controller {
     $this->addPages($this->_stateMachine, $action);
 
     // add all the actions
-    $config = CRM_Core_Config::singleton();
     $this->addActions();
+    $this->set('entity', $this->entity);
   }
 
 }

--- a/CRM/Pledge/Controller/Search.php
+++ b/CRM/Pledge/Controller/Search.php
@@ -27,6 +27,8 @@
  */
 class CRM_Pledge_Controller_Search extends CRM_Core_Controller {
 
+  protected $entity = 'Pledge';
+
   /**
    * Class constructor.
    *
@@ -44,8 +46,8 @@ class CRM_Pledge_Controller_Search extends CRM_Core_Controller {
     $this->addPages($this->_stateMachine, $action);
 
     // add all the actions
-    $config = CRM_Core_Config::singleton();
     $this->addActions();
+    $this->set('entity', $this->entity);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes unreleased regression on generating a pdf from a selection from basic contact search



Before
----------------------------------------
<img width="919" alt="Screen Shot 2020-10-14 at 4 43 27 PM" src="https://user-images.githubusercontent.com/336308/95941129-85c46780-0e3c-11eb-9b92-d269b411f630.png">

selection not recognised

After
----------------------------------------
Fixed

Technical Details
----------------------------------------
The code determining the form name expects the entity to be either 'Contact' or 'not contact' but is actually at risk of being ' not set'

Comments
----------------------------------------

