### PR TITLE
dev/core#2066 Extract getSelectedIDs

### DIFF
--- a/CRM/Activity/Form/Task.php
+++ b/CRM/Activity/Form/Task.php
@@ -50,12 +50,8 @@ class CRM_Activity_Form_Task extends CRM_Core_Form_Task {
     $form->_task = $values['task'];
 
     $ids = [];
-    if ($values['radio_ts'] == 'ts_sel') {
-      foreach ($values as $name => $value) {
-        if (substr($name, 0, CRM_Core_Form::CB_PREFIX_LEN) == CRM_Core_Form::CB_PREFIX) {
-          $ids[] = substr($name, CRM_Core_Form::CB_PREFIX_LEN);
-        }
-      }
+    if ($values['radio_ts'] === 'ts_sel') {
+      $ids = $form->getSelectedIDs($values);
     }
     else {
       $queryParams = $form->get('queryParams');

--- a/CRM/Contribute/Form/Task.php
+++ b/CRM/Contribute/Form/Task.php
@@ -62,19 +62,15 @@ class CRM_Contribute_Form_Task extends CRM_Core_Form_Task {
     $form->_task = $values['task'] ?? NULL;
 
     $ids = [];
-    if (isset($values['radio_ts']) && $values['radio_ts'] == 'ts_sel') {
-      foreach ($values as $name => $value) {
-        if (substr($name, 0, CRM_Core_Form::CB_PREFIX_LEN) == CRM_Core_Form::CB_PREFIX) {
-          $ids[] = substr($name, CRM_Core_Form::CB_PREFIX_LEN);
-        }
-      }
+    if (isset($values['radio_ts']) && $values['radio_ts'] === 'ts_sel') {
+      $ids = $form->getSelectedIDs($values);
     }
     else {
       $queryParams = $form->get('queryParams');
       $isTest = FALSE;
       if (is_array($queryParams)) {
         foreach ($queryParams as $fields) {
-          if ($fields[0] == 'contribution_test') {
+          if ($fields[0] === 'contribution_test') {
             $isTest = TRUE;
             break;
           }

--- a/CRM/Core/Form/Task.php
+++ b/CRM/Core/Form/Task.php
@@ -101,6 +101,23 @@ abstract class CRM_Core_Form_Task extends CRM_Core_Form {
   }
 
   /**
+   * Get the ids the user has selected.
+   *
+   * @param array $values
+   *
+   * @return array
+   */
+  public function getSelectedIDs(array $values): array {
+    $ids = [];
+    foreach ($values as $name => $value) {
+      if (substr($name, 0, CRM_Core_Form::CB_PREFIX_LEN) == CRM_Core_Form::CB_PREFIX) {
+        $ids[] = substr($name, CRM_Core_Form::CB_PREFIX_LEN);
+      }
+    }
+    return $ids;
+  }
+
+  /**
    * Build all the data structures needed to build the form.
    *
    * @throws \CRM_Core_Exception


### PR DESCRIPTION
Overview
----------------------------------------
Minor extraction 

Before
----------------------------------------
Repeated code
```
 foreach ($values as $name => $value) {
        if (substr($name, 0, CRM_Core_Form::CB_PREFIX_LEN) == CRM_Core_Form::CB_PREFIX) {
          $ids[] = substr($name, CRM_Core_Form::CB_PREFIX_LEN);
        }
      }
```

After
----------------------------------------
shared code ```$ids = $form->getSelectedIDs($values);```

Technical Details
----------------------------------------
There are other classes with the same issues - just picked these 2 for now

Comments
----------------------------------------

