### PR TITLE
(core/dev#2104) Add target custom data to activity report

### DIFF
--- a/CRM/Report/Form/Activity.php
+++ b/CRM/Report/Form/Activity.php
@@ -17,7 +17,10 @@
 class CRM_Report_Form_Activity extends CRM_Report_Form {
   protected $_selectAliasesTotal = [];
 
-  protected $_customGroupExtends = ['Activity'];
+  protected $_customGroupExtends = [
+    'Activity',
+    'Individual',
+  ];
 
   protected $_nonDisplayFields = [];
 


### PR DESCRIPTION
Overview
----------------------------------------
Add target custom data to activity report

Before
----------------------------------------
Only activity custom data can be searched
![activity_before](https://user-images.githubusercontent.com/3455173/95961726-1130ff00-0e23-11eb-8b76-a2c2c5b98786.png)

After
----------------------------------------
Activity and target contact custom data can be searched
![activity_after](https://user-images.githubusercontent.com/3455173/95961738-14c48600-0e23-11eb-8e84-c11afaee801d.png)
