### PR TITLE
dev/core#2125 Ensure that the id that is used in the field is the gro…

### DIFF
--- a/CRM/Contact/Form/Edit/TagsAndGroups.php
+++ b/CRM/Contact/Form/Edit/TagsAndGroups.php
@@ -93,7 +93,8 @@ class CRM_Contact_Form_Edit_TagsAndGroups {
         $attributes['skiplabel'] = TRUE;
         $elements = [];
         $groupsOptions = [];
-        foreach ($groups as $id => $group) {
+        foreach ($groups as $group) {
+          $id = $group['id'];
           // make sure that this group has public visibility
           if ($visibility &&
             $group['visibility'] == 'User and User Admin Only'


### PR DESCRIPTION
…up id not the id of array key as that has changed from being a keyed array to a 2D array

Overview
----------------------------------------
This fixes an issue where by the group id is no longer used as part of the field name and as such can cause DB errors when submitting the form

Before
----------------------------------------
Possible DB errors because group id my not exist

After
----------------------------------------
No DB Errors

Technical Details
----------------------------------------
It would seem as tho in https://github.com/civicrm/civicrm-core/commit/78d0090bf8b4b909564b806e40d4b3dd78720572#diff-c113d6099b62e0ddbf3876a74fbf756f7743590dd27397dec4ebf9b24dfca578R1126 the hierarchy array changed from being keyed on the group id to just a sequential array which meant that $id in this no longer matched up to the group id from civicrm_group table

https://lab.civicrm.org/dev/core/-/issues/2125

ping @eileenmcnaughton 