### PR TITLE
dev/report#53: search on relationship and case

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -5819,14 +5819,15 @@ AND   displayRelType.is_active = 1
       $this->_qill[0][] = $iqill;
     }
     if (strpos($from, $qcache['from']) === FALSE) {
-      if (strpos($from, "INNER JOIN") !== false) {
+      if (strpos($from, "INNER JOIN") !== FALSE) {
         // lets replace all the INNER JOIN's in the $from so we dont exclude other data
         // this happens when we have an event_type in the quert (CRM-7969)
         $from = str_replace("INNER JOIN", "LEFT JOIN", $from);
         // Make sure the relationship join right after the FROM and other joins afterwards.
         // This gives us the possibility to change the join on civicrm case.
         $from = preg_replace("/LEFT JOIN/", $qcache['from'] . " LEFT JOIN", $from, 1);
-      } else {
+      }
+      else {
         $from .= $qcache['from'];
       }
       $where = $qcache['where'];


### PR DESCRIPTION
Overview
----------------------------------------
When doing an advanced search with case parameters set and displaying related contacts. Gives all clients of all the found cases which have this relationship. What we would expect is that related contact is linked to the found cases. 

Steps to reproduce
--------------------------

Preparation:
1. Create a contact **Contact A**
2. Create another contact **Contact B**
3. Create a third contact **Contact C**
4. Create a case of type **Housing Support** for **Contact A**
5. On the case assign the role **Health Service Coordinator** to **Contact B**
6. Create a relationship between **Contact A** and **Contact C** with the type **Healt Service Coordinator** (make sure contact a is on the _a_ side of the relationship)

Searching:
1. Go to advanced search
2. Click on **View contact as related contact**
3. Select **Health Service Coordinator** as relationship type
4. Go to tab cases and select **Housing Support** as case type

Expected results
-----------------------

I expected to see only Contact B as that one has a relationship on the case **Housing Support**.

Actual results
-------------------

I see both Contact B and Contact C.

Comments
----------------------------------------

See also the discussion of a similar related topic: https://lab.civicrm.org/dev/report/-/issues/53
