### PR TITLE
dev/core#2127 - import csv file with conflictive character (+ tests)

### DIFF
--- a/CRM/Import/DataSource/CSV.php
+++ b/CRM/Import/DataSource/CSV.php
@@ -222,9 +222,10 @@ class CRM_Import_DataSource_CSV extends CRM_Import_DataSource {
       $first = FALSE;
 
       // CRM-17859 Trim non-breaking spaces from columns.
+      // dev/core#2127 avoid breaking strings ending in à
       $row = array_map(
         function($string) {
-          return trim($string, chr(0xC2) . chr(0xA0));
+          return preg_replace("/^(\u{a0})+|(\u{a0})+$/", '', $string);
         }, $row);
       $row = array_map(['CRM_Core_DAO', 'escapeString'], $row);
       $sql .= "('" . implode("', '", $row) . "')";

--- a/tests/phpunit/CRM/Import/DataSource/CsvTest.php
+++ b/tests/phpunit/CRM/Import/DataSource/CsvTest.php
@@ -41,6 +41,10 @@ class CRM_Import_DataSource_CsvTest extends CiviUnitTestCase {
     $dataSource->postProcess($params, $db, $form);
     $tableName = $form->get('importTableName');
     $this->assertEquals(4,
+      CRM_Core_DAO::singleValueQuery("SELECT LENGTH(first_name) FROM $tableName"),
+      $fileName . ' failed on first_name'
+    );
+    $this->assertEquals(4,
       CRM_Core_DAO::singleValueQuery("SELECT LENGTH(last_name) FROM $tableName"),
       $fileName . ' failed on last_name'
     );
@@ -57,7 +61,7 @@ class CRM_Import_DataSource_CsvTest extends CiviUnitTestCase {
    * @return array
    */
   public function getCsvFiles() {
-    return [['import.csv'], ['yogi.csv']];
+    return [['import.csv'], ['yogi.csv'], ['specialchar.csv']];
   }
 
 }

--- a/tests/phpunit/CRM/Import/DataSource/specialchar.csv
+++ b/tests/phpunit/CRM/Import/DataSource/specialchar.csv
@@ -1,0 +1,2 @@
+First Name,Last Name,email
+Yogà,Berà ,yogi@yellowstone.park 


### PR DESCRIPTION
Overview
----------------------------------------
When importing a Contact with a CSV file, the strings that end with character `à` are replaced by a non-printing character.
Adding unit test for this specific case.

issue: https://lab.civicrm.org/dev/core/-/issues/2127

