### PR TITLE
dev/core#2114 - Changes in upper/lower case or accents are not logged when using trigger-based logging

### DIFF
--- a/CRM/Logging/Schema.php
+++ b/CRM/Logging/Schema.php
@@ -951,6 +951,9 @@ COLS;
       }
       $columns = $this->columnsOf($table, $force);
 
+      // Use utf8mb4_bin or utf8_bin, depending on what's in use.
+      $collation = preg_replace('/^(utf8(?:mb4)?)_.*$/', '$1_bin', CRM_Core_BAO_SchemaHandler::getInUseCollation());
+
       // only do the change if any data has changed
       $cond = [];
       foreach ($columns as $column) {
@@ -961,7 +964,7 @@ COLS;
         $excludeColumn = in_array($column, $tableExceptions) ||
           in_array(str_replace('`', '', $column), $tableExceptions);
         if (!$excludeColumn) {
-          $cond[] = "IFNULL(OLD.$column,'') <> IFNULL(NEW.$column,'')";
+          $cond[] = "IFNULL(OLD.$column,'') <> IFNULL(NEW.$column,'') COLLATE {$collation}";
         }
       }
       $suppressLoggingCond = "@civicrm_disable_logging IS NULL OR @civicrm_disable_logging = 0";


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/2114

1. Turn on trigger-based logging (Admin - system settings - misc - Logging).
1. Create a contact.
1. Change their first name just changing one letter to upper or lower case.
1. Check the contact logging report at CiviReport - Contact Reports - Contact Logging Summary, or look in the database at log_civicrm_contact. The change is not recorded.

Before
----------------------------------------
Logging doesn't record changes in upper/lower case or accents.

After
----------------------------------------
It does record them.

Technical Details
----------------------------------------
The collations used in civi tables are likely case-insensitive and also accent-insensitive unless you've changed them. The logging triggers don't specify _bin collations explicitly so comparisons are done using the field/default collation.

Regarding performance, I did a quickie test creating and updating thousands of contacts and while not scientific and my laptop isn't a good benchmarking system, it showed no real difference and in fact one run was faster with the change, which may or may not make sense.

Another thing I was concerned about was what it does with integer fields. It seems fine with them.

Comments
----------------------------------------
Test is at https://github.com/civicrm/civicrm-core/pull/18760

One side-effect of this is that if your mysql defaults are all utf8mb4, unit tests involving trigger logging will now fail for you locally unless you put `$this->callAPISuccess('System', 'utf8conversion', []);` in setup() or setupBeforeClass(). The test system installs as utf8, and so there's some kind of mismatch unless you convert the db before turning on logging. In a real system, I don't know why you'd have all utf8mb4 defaults but still be using utf8?