### PR TITLE
dev/core#2114 - Changes in upper/lower case or accents are not logged when using trigger-based logging

### DIFF
--- a/CRM/Logging/Schema.php
+++ b/CRM/Logging/Schema.php
@@ -948,6 +948,12 @@ COLS;
       }
       $columns = $this->columnsOf($table, $force);
 
+      // Use utf8mb4_bin or utf8_bin, depending on what's in use.
+      $charset = 'utf8';
+      if (stripos(CRM_Core_BAO_SchemaHandler::getInUseCollation(), 'utf8mb4') !== FALSE) {
+        $charset = 'utf8mb4';
+      }
+
       // only do the change if any data has changed
       $cond = [];
       foreach ($columns as $column) {
@@ -958,7 +964,12 @@ COLS;
         $excludeColumn = in_array($column, $tableExceptions) ||
           in_array(str_replace('`', '', $column), $tableExceptions);
         if (!$excludeColumn) {
-          $cond[] = "IFNULL(OLD.$column,'') <> IFNULL(NEW.$column,'')";
+          // The empty string needs charset signalling to avoid errors.
+          // Note that it is not a cast/convert. It just tells mysql
+          // that there isn't a conflict when your system/connection defaults
+          // happen to be different from $charset.
+          // See https://dev.mysql.com/doc/refman/5.7/en/charset-literal.html
+          $cond[] = "IFNULL(OLD.$column,_{$charset}'') <> IFNULL(NEW.$column,_{$charset}'') COLLATE {$charset}_bin";
         }
       }
       $suppressLoggingCond = "@civicrm_disable_logging IS NULL OR @civicrm_disable_logging = 0";


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/2114

1. Turn on trigger-based logging (Admin - system settings - misc - Logging).
1. Create a contact.
1. Change their first name just changing one letter to upper or lower case.
1. Check the contact logging report at CiviReport - Contact Reports - Contact Logging Summary, or look in the database at log_civicrm_contact. The change is not recorded.

Before
----------------------------------------
Logging doesn't record changes in upper/lower case or accents.

After
----------------------------------------
It does record them.

Technical Details
----------------------------------------
The collations used in civi tables are likely case-insensitive and also accent-insensitive unless you've changed them. The logging triggers don't specify _bin collations explicitly so comparisons are done using the field/default collation.

Regarding performance, I did a quickie test creating and updating thousands of contacts and while not scientific and my laptop isn't a good benchmarking system, it showed no real difference and in fact one run was faster with the change, which may or may not make sense.

Another thing I was concerned about was what it does with integer fields. It seems fine with them.

The [introducer](https://dev.mysql.com/doc/refman/5.7/en/charset-literal.html) in front of the empty string is not a cast/convert exactly. There is no processing happening there. In the event the system/connection defaults are not compatible with the collate, it just tells mysql that it can treat it the same as the collate. Since it's the empty string, it is compatible, but not unreasonably mysql seems to do its checking without considering that edge case.

Comments
----------------------------------------
Has test.
