### PR TITLE
dev/core#2034 Fix paypal standard cancel url and action links in dashboard

### DIFF
--- a/CRM/Contribute/Page/Tab.php
+++ b/CRM/Contribute/Page/Tab.php
@@ -101,7 +101,7 @@ class CRM_Contribute_Page_Tab extends CRM_Core_Page {
         unset($links[CRM_Core_Action::DISABLE]);
         unset($links[CRM_Core_Action::UPDATE]);
       }
-      
+
       if (!CRM_Core_Permission::check('view my contact') && $context === 'dashboard') {
         unset($links[CRM_Core_Action::VIEW]);
       }

--- a/CRM/Contribute/Page/Tab.php
+++ b/CRM/Contribute/Page/Tab.php
@@ -73,15 +73,18 @@ class CRM_Contribute_Page_Tab extends CRM_Core_Page {
       if ($paymentProcessorObj) {
         if ($paymentProcessorObj->supports('cancelRecurring')) {
           unset($links[CRM_Core_Action::DISABLE]['extra'], $links[CRM_Core_Action::DISABLE]['ref']);
-          $links[CRM_Core_Action::DISABLE]['url'] = "civicrm/contribute/unsubscribe";
+          $links[CRM_Core_Action::DISABLE]['url'] = $paymentProcessorObj->subscriptionURL(NULL, NULL, 'cancel');
           $links[CRM_Core_Action::DISABLE]['qs'] = "reset=1&crid=%%crid%%&cid=%%cid%%&context={$context}";
+        }
+        else {
+          unset($links[CRM_Core_Action::DISABLE]);
         }
 
         if ($paymentProcessorObj->supports('UpdateSubscriptionBillingInfo')) {
           $links[CRM_Core_Action::RENEW] = [
             'name' => ts('Change Billing Details'),
             'title' => ts('Change Billing Details'),
-            'url' => 'civicrm/contribute/updatebilling',
+            'url' => $paymentProcessorObj->subscriptionURL(NULL, NULL, 'billing'),
             'qs' => "reset=1&crid=%%crid%%&cid=%%cid%%&context={$context}",
           ];
         }

--- a/CRM/Contribute/Page/Tab.php
+++ b/CRM/Contribute/Page/Tab.php
@@ -101,6 +101,10 @@ class CRM_Contribute_Page_Tab extends CRM_Core_Page {
         unset($links[CRM_Core_Action::DISABLE]);
         unset($links[CRM_Core_Action::UPDATE]);
       }
+      
+      if (!CRM_Core_Permission::check('view my contact') && $context === 'dashboard') {
+        unset($links[CRM_Core_Action::VIEW]);
+      }
     }
 
     return $links;

--- a/CRM/Contribute/Page/UserDashboard.php
+++ b/CRM/Contribute/Page/UserDashboard.php
@@ -54,7 +54,7 @@ class CRM_Contribute_Page_UserDashboard extends CRM_Contact_Page_View_UserDashBo
           'label' => ts('Pay Now'),
           'url' => CRM_Utils_System::url('civicrm/contribute/transact', [
             'reset' => 1,
-            'id' => Civi::settings()->get('default_invoice_page'),
+            'id' => Civi::settings()->get('default_invoice_page'), // Should this be the contribution page of the original transaction?
             'ccid' => $row['contribution_id'],
             'cs' => $this->getUserChecksum(),
             'cid' => $row['contact_id'],
@@ -124,11 +124,17 @@ class CRM_Contribute_Page_UserDashboard extends CRM_Contact_Page_View_UserDashBo
     }
     if (is_array($recurIDs) && !empty($recurIDs)) {
       $getCount = CRM_Contribute_BAO_ContributionRecur::getCount($recurIDs);
+      $isLinked = CRM_Core_Permission::check('access CiviContribute');
       foreach ($getCount as $key => $val) {
         $recurRow[$key]['completed'] = $val;
-        $recurRow[$key]['link'] = CRM_Utils_System::url('civicrm/contribute/search',
-          "reset=1&force=1&recur=$key"
-        );
+        if ($isLinked) {
+          $recurRow[$key]['link'] = CRM_Utils_System::url('civicrm/contribute/search',
+            "reset=1&force=1&recur=$key"
+          );
+        }
+        else {
+          $recurRow[$key]['link'] = '';
+        }
       }
     }
 

--- a/CRM/Contribute/Page/UserDashboard.php
+++ b/CRM/Contribute/Page/UserDashboard.php
@@ -48,13 +48,14 @@ class CRM_Contribute_Page_UserDashboard extends CRM_Contact_Page_View_UserDashBo
       // This is required for tpl logic. We should move away from hard-code this to adding an array of actions to the row
       // which the tpl can iterate through - this should allow us to cope with competing attempts to add new buttons
       // and allow extensions to assign new ones through the pageRun hook
+	  // ALSO: Should 'id' be set to the contribution page of the original transaction?
       if ('Pending' === CRM_Core_PseudoConstant::getName('CRM_Contribute_BAO_Contribution', 'contribution_status_id', $row['contribution_status_id'])) {
         $row['buttons']['pay'] = [
           'class' => 'button',
           'label' => ts('Pay Now'),
           'url' => CRM_Utils_System::url('civicrm/contribute/transact', [
             'reset' => 1,
-            'id' => Civi::settings()->get('default_invoice_page'), // Should this be the contribution page of the original transaction?
+            'id' => Civi::settings()->get('default_invoice_page'),
             'ccid' => $row['contribution_id'],
             'cs' => $this->getUserChecksum(),
             'cid' => $row['contact_id'],

--- a/CRM/Core/Payment/PayPalImpl.php
+++ b/CRM/Core/Payment/PayPalImpl.php
@@ -105,6 +105,22 @@ class CRM_Core_Payment_PayPalImpl extends CRM_Core_Payment {
     }
     return FALSE;
   }
+  
+  /**
+   * Does this processor support cancelling recurring contributions through code.
+   *
+   * If the processor returns true it must be possible to take action from within CiviCRM
+   * that will result in no further payments being processed. In the case of token processors (e.g
+   * IATS, eWay) updating the contribution_recur table is probably sufficient.
+   *
+   * @return bool
+   */
+  protected function supportsCancelRecurring() {
+    if ($this->isPayPalType($this::PAYPAL_STANDARD)) {
+      return FALSE;
+    }
+    return parent::supportsCancelRecurring();
+  }
 
   /**
    * Does this processor support pre-approval.
@@ -123,6 +139,21 @@ class CRM_Core_Payment_PayPalImpl extends CRM_Core_Payment {
       return TRUE;
     }
     return FALSE;
+  }
+  
+  /**
+   * Does this processor support updating billing info for recurring contributions through code.
+   *
+   * If the processor returns true then it must be possible to update billing info from within CiviCRM
+   * that will be updated at the payment processor.
+   *
+   * @return bool
+   */
+  protected function supportsUpdateSubscriptionBillingInfo() {
+    if ($this->isPayPalType($this::PAYPAL_STANDARD)) {
+      return FALSE;
+    }
+    return parent::supportsUpdateSubscriptionBillingInfo();
   }
 
   /**

--- a/CRM/Core/Payment/PayPalImpl.php
+++ b/CRM/Core/Payment/PayPalImpl.php
@@ -155,6 +155,21 @@ class CRM_Core_Payment_PayPalImpl extends CRM_Core_Payment {
     }
     return parent::supportsUpdateSubscriptionBillingInfo();
   }
+  
+  /**
+   * Does this processor support changing the amount for recurring contributions through code.
+   *
+   * If the processor returns true then it must be possible to update the amount from within CiviCRM
+   * that will be updated at the payment processor.
+   *
+   * @return bool
+   */
+  protected function supportsChangeSubscriptionAmount() {
+    if (!$this->isPayPalType($this::PAYPAL_PRO)) {
+      return FALSE;
+    }
+    return parent::supportsChangeSubscriptionAmount();
+  }
 
   /**
    * Opportunity for the payment processor to override the entire form build.

--- a/CRM/Core/Payment/PayPalImpl.php
+++ b/CRM/Core/Payment/PayPalImpl.php
@@ -150,7 +150,7 @@ class CRM_Core_Payment_PayPalImpl extends CRM_Core_Payment {
    * @return bool
    */
   protected function supportsUpdateSubscriptionBillingInfo() {
-    if ($this->isPayPalType($this::PAYPAL_STANDARD)) {
+    if (!$this->isPayPalType($this::PAYPAL_PRO)) {
       return FALSE;
     }
     return parent::supportsUpdateSubscriptionBillingInfo();

--- a/CRM/Core/Payment/PayPalImpl.php
+++ b/CRM/Core/Payment/PayPalImpl.php
@@ -105,7 +105,7 @@ class CRM_Core_Payment_PayPalImpl extends CRM_Core_Payment {
     }
     return FALSE;
   }
-  
+
   /**
    * Does this processor support cancelling recurring contributions through code.
    *
@@ -140,7 +140,7 @@ class CRM_Core_Payment_PayPalImpl extends CRM_Core_Payment {
     }
     return FALSE;
   }
-  
+
   /**
    * Does this processor support updating billing info for recurring contributions through code.
    *
@@ -155,7 +155,7 @@ class CRM_Core_Payment_PayPalImpl extends CRM_Core_Payment {
     }
     return parent::supportsUpdateSubscriptionBillingInfo();
   }
-  
+
   /**
    * Does this processor support changing the amount for recurring contributions through code.
    *

--- a/templates/CRM/Contribute/Page/UserDashboard.tpl
+++ b/templates/CRM/Contribute/Page/UserDashboard.tpl
@@ -23,6 +23,7 @@
                       <th></th>
                     {/if}
                     {foreach from=$row.buttons item=button}
+                      {* @todo Fix this: doesn't work (doesn't add extra header cells) because $row does not exist in this context. See also comments below / in UserDashboard.php re changing to actions array *}
                       <th></th>
                     {/foreach}
                 </tr>
@@ -116,22 +117,19 @@
                 <div><label>{ts}Recurring Contribution(s){/ts}</label></div>
                 <table class="selector">
                     <tr class="columnheader">
-                        <th>{ts}Terms:{/ts}</th>
-                        <th>{ts}Status{/ts}</th>
+                        <th>{ts}Amount{/ts}</th>
+                        <th>{ts}Interval{/ts}</th>
                         <th>{ts}Installments{/ts}</th>
+                        <th>{ts}Status{/ts}</th>
                         <th>{ts}Created{/ts}</th>
                         <th></th>
                     </tr>
                     {foreach from=$recurRows item=row key=id}
                         <tr class="{cycle values="odd-row,even-row"}">
-                            <td><label>{$recurRows.$id.amount|crmMoney}</label>
-                                every {$recurRows.$id.frequency_interval} {$recurRows.$id.frequency_unit}
-                                for {$recurRows.$id.installments} installments
-                            </td>
+                            <td>{$recurRows.$id.amount|crmMoney}</td>
+                            <td>{$recurRows.$id.frequency_interval} {$recurRows.$id.frequency_unit}</td>
+                            <td>{if $recurRows.$id.link}<a href="{$recurRows.$id.link}">{/if}{if $recurRows.$id.completed}{$recurRows.$id.completed}{else}0{/if} / {if $recurRows.$id.installments}{$recurRows.$id.installments}{else}{ts}(Open-ended){/ts}{/if}{if $recurRows.$id.link}</a>{/if}</td>
                             <td>{$recurRows.$id.recur_status}</td>
-                            <td>{if $recurRows.$id.completed}<a href="{$recurRows.$id.link}">{$recurRows.$id.completed}
-                                    /{$recurRows.$id.installments}</a>
-                                {else}0/{$recurRows.$id.installments} {/if}</td>
                             <td>{$recurRows.$id.create_date|crmDate}</td>
                             <td>{$recurRows.$id.action|replace:'xx':$recurRows.id}</td>
                         </tr>


### PR DESCRIPTION
Overview
----------------------------------------
Further to https://github.com/civicrm/civicrm-core/pull/18540.
Per https://lab.civicrm.org/dev/core/-/issues/2034 the wrong urls are included in paypal standard emails for cancellation and changing billing details. Broken links are also shown on the contact dashboard (recurring contributions), which also has some formatting errors and other broken links.

Before
----------------------------------------
Email contains civicrm urls

This is a recurring contribution.
You can cancel future contributions at:
http://dmaster.local/civicrm/contribute/unsubscribe?reset=1&coid=98

Likewise, the contact dashboard recurring contributions section shows the following links:
View - does not work if the front-end user does not have "view my contact" permission (e.g. only allowed access through profiles)
Edit - inappropriate as paypal standard does not support editing contribution amount
Cancel - as above

The contact dashboard also has the following errors:
Incorrect spacing between amount and frequency values.
Zero values in instalments displayed as blank (default PHP representation of 0 when printing).
Instalments link to contributions search does not work if user does not have "access CiviContribute" permission.

After
----------------------------------------
Email contains paypal urls for paypal standard processor
https://www.sandbox.paypal.com/cgi-bin/webscr?cmd=_subscr-find

View, Edit and Cancel links in dashboard removed as appropriate based on permissions and payment processor supported methods.
Formatting corrected.
Link to instalments search disabled if user does not direct access to CiviContribute.

Technical Details
----------------------------------------
Overriding the parent class to provide the correct url for the processor.
Overriding the parent class to provide correct supportsCancelRecurring(), supportsUpdateSubscriptionBillingInfo() and supportsChangeSubscriptionAmount() methods.
Updating recurring contribution action links generation to take permissions and "supports" methods into account and also to use latest method of generating URLs.
Fixing UserDashboard template for contributions and updating accordingly to match above changes.

Comments
----------------------------------------
NOTE: In testing I found that if the front-end user has permission to "view my contact" and clicks 'View' next to a recurring contribution, the dialogs that appear include 'Edit' and 'Delete' links irrespective of permissions. (This is true for both the recurring contribution and associated membership dialogs).

For the recurring contribution dialog, the edit and delete links give an error message (window.alert) but, worryingly, seem to let the front end user actually complete those edit and delete operations for which they should not have permission.

I did not attempt to fix this as my use-case is to disable access to these dialogs entirely, however this seems to be a security risk for which I will raise a separate issue.