### PR TITLE
Fix sendconfirmation api to override receipt params

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2956,8 +2956,10 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
     //not really sure what params might be passed in but lets merge em into values
     $values = array_merge($this->_gatherMessageValues($input, $values, $ids), $values);
     $values['is_email_receipt'] = !$returnMessageText;
-    if (!empty($input['receipt_date'])) {
-      $values['receipt_date'] = $input['receipt_date'];
+    foreach (['receipt_date', 'cc_receipt', 'bcc_receipt', 'receipt_from_name', 'receipt_from_email', 'receipt_text'] as $fld) {
+      if (!empty($input[$fld])) {
+        $values[$fld] = $input[$fld];
+      }
     }
 
     $template = $this->_assignMessageVariablesToTemplate($values, $input, $returnMessageText);


### PR DESCRIPTION
Overview
----------------------------------------
Fix sendconfirmation to override receipt params.

Before
----------------------------------------
Receipt values set in Contribution page are used even if it is overridden in the api call. Eg

    civicrm_api3('Contribution', 'sendconfirmation', [
      'id' => contribution_id,
      'cc_receipt' => "customcc@email.com",
      'bcc_receipt' => "custombcc@email.com",
      'receipt_from_email' => "customfrom@email.com",
    ]);

uses cc, bcc & from email value from the related contribution page even if it is specified in the api params. 

After
----------------------------------------
Params set in api call takes precedence.


Comments
----------------------------------------
Added unit test.

ping @KarinG 