### PR TITLE
Add test for recurring links and clean up method of retrieving recurring

### DIFF
--- a/CRM/Contribute/BAO/ContributionRecur.php
+++ b/CRM/Contribute/BAO/ContributionRecur.php
@@ -163,6 +163,7 @@ class CRM_Contribute_BAO_ContributionRecur extends CRM_Contribute_DAO_Contributi
    *   (since it still makes sense to update / cancel
    */
   public static function getPaymentProcessorObject($id) {
+    CRM_Core_Error::deprecatedFunctionWarning('Use Civi\Payment\System');
     $processor = self::getPaymentProcessor($id);
     return is_array($processor) ? $processor['object'] : NULL;
   }

--- a/CRM/Contribute/Page/Tab.php
+++ b/CRM/Contribute/Page/Tab.php
@@ -69,7 +69,7 @@ class CRM_Contribute_Page_Tab extends CRM_Core_Page {
     ];
 
     if ($recurID) {
-      $paymentProcessorObj = CRM_Contribute_BAO_ContributionRecur::getPaymentProcessorObject($recurID);
+      $paymentProcessorObj = Civi\Payment\System::singleton()->getById(CRM_Contribute_BAO_ContributionRecur::getPaymentProcessorID($recurID));
       if ($paymentProcessorObj) {
         if ($paymentProcessorObj->supports('cancelRecurring')) {
           unset($links[CRM_Core_Action::DISABLE]['extra'], $links[CRM_Core_Action::DISABLE]['ref']);

--- a/Civi/Payment/System.php
+++ b/Civi/Payment/System.php
@@ -104,16 +104,19 @@ class System {
    *
    * @param int $id
    *
-   * @return \CRM_Core_Payment|NULL
+   * @return \CRM_Core_Payment
    *
-   * @throws \CiviCRM_API3_Exception
+   * @throws \CiviCRM_API3_Exception|\CRM_Core_Exception
    */
   public function getById($id) {
-    if ($id == 0) {
+    if (isset($this->cache[$id])) {
+      return $this->cache[$id];
+    }
+    if ((int) $id === 0) {
       return new \CRM_Core_Payment_Manual();
     }
     $processor = civicrm_api3('payment_processor', 'getsingle', ['id' => $id, 'is_test' => NULL]);
-    return self::getByProcessor($processor);
+    return $this->getByProcessor($processor);
   }
 
   /**

--- a/tests/phpunit/CRM/Contribute/Page/TabTest.php
+++ b/tests/phpunit/CRM/Contribute/Page/TabTest.php
@@ -1,0 +1,59 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | Use of this source code is governed by the AGPL license with some  |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+use Civi\Api4\Contribution;
+use Civi\Api4\ContributionRecur;
+
+/**
+ * Class CRM_Contribute_Page_AjaxTest
+ * @group headless
+ */
+class CRM_Contribute_Page_TabTest extends CiviUnitTestCase {
+
+  /**
+   * Test links render correctly for manual processor.
+   *
+   * @throws \API_Exception
+   * @throws \CiviCRM_API3_Exception
+   */
+  public function testLinks() {
+    $contactID = $this->individualCreate();
+    $recurID = ContributionRecur::create()->setValues([
+      'contact_id' => $contactID,
+      'amount' => 10,
+      'frequency_interval' => 'week',
+      'start_date' => 'now',
+      'is_active' => TRUE,
+      'contribution_status_id:name' => 'Pending',
+    ])
+      ->addChain(
+        'contribution',
+        Contribution::create()->setValues([
+          'contribution_id' => '$id',
+          'financial_type_id:name' => 'Donation',
+          'total_amount' => 60,
+          'receive_date' => 'now',
+          'contact_id' => $contactID,
+        ])
+      )->execute()->first()['id'];
+    $page = new CRM_Contribute_Page_Tab();
+    $page->_contactId = $contactID;
+    $page->_action = CRM_Core_Action::VIEW;
+    $page->browse();
+
+    $templateVariable = CRM_Core_Smarty::singleton()->get_template_vars();
+    $this->assertEquals('Mr. Anthony Anderson II', $templateVariable['displayName']);
+    $this->assertEquals("<span><a href=\"/index.php?q=civicrm/contact/view/contributionrecur&amp;reset=1&amp;id=" . $recurID . "&amp;cid=" . $contactID . "&amp;context=contribution\" class=\"action-item crm-hover-button\" title='View Recurring Payment' >View</a><a href=\"/index.php?q=civicrm/contribute/updaterecur&amp;reset=1&amp;action=update&amp;crid=1&amp;cid=3&amp;context=contribution\" class=\"action-item crm-hover-button\" title='Edit Recurring Payment' >Edit</a><a href=\"#\" class=\"action-item crm-hover-button crm-enable-disable\" title='Cancel' >Cancel</a></span>",
+      $templateVariable['activeRecurRows'][1]['action']
+    );
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
This helps address blockers on  #18787 and #18196 by
1) adding a preliminary unit test and
2) cleaning up the processor loading (for #18196 there is [some code around this](https://github.com/civicrm/civicrm-core/pull/18196/files#diff-93cddd016fbba993131d9d66d974a98fc5180fadd4423a25a54788bb59bf154eR316 )  but the reason for the change there is not clear & it's it some code that needn't apply since we just want the object, we are not checking for capabilities )

Before
----------------------------------------
- No test
- convoluted method of loading the processor object goes through complex code that doesn't add anything here

After
----------------------------------------
- test to prevent behaviour change
- we use our preferred method to just load the object - however, I felt I had to improve the caching in it a bit,  along with a couple of NFC changes

Technical Details
----------------------------------------


Comments
----------------------------------------

