### PR TITLE
Deprecate passing untrimmed dates into Membership::create

### DIFF
--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -254,8 +254,7 @@ class CRM_Member_BAO_Membership extends CRM_Member_DAO_Membership {
       foreach (['start_date', 'end_date', 'join_date'] as $dateField) {
         if (!empty($params[$dateField]) && $params[$dateField] !== 'null' && strpos($params[$dateField], date('Ymd', strtotime(trim($params[$dateField])))) !== 0) {
           $params[$dateField] = date('Ymd', strtotime(trim($params[$dateField])));
-          // @todo enable this once core is using the api.
-          // Civi::log()->warning('Relying on the BAO to clean up dates is deprecated. Call membership create via the api', ['civi.tag' => 'deprecated']);
+          Civi::log()->warning('Relying on the BAO to clean up dates is deprecated. Call membership create via the api', ['civi.tag' => 'deprecated']);
         }
         if (!empty($params['id']) && empty($params[$dateField])) {
           $fieldsToLoad[] = $dateField;

--- a/CRM/Member/Form/MembershipRenewal.php
+++ b/CRM/Member/Form/MembershipRenewal.php
@@ -732,7 +732,6 @@ class CRM_Member_Form_MembershipRenewal extends CRM_Member_Form {
     $ids = [];
     $currentMembership = civicrm_api3('Membership', 'getsingle', ['id' => $memParams['id']]);
 
-    $memParams['join_date'] = $currentMembership['join_date'];
     // Do NOT do anything.
     //1. membership with status : PENDING/CANCELLED (CRM-2395)
     //2. Paylater/IPN renew. CRM-4556.
@@ -741,14 +740,9 @@ class CRM_Member_Form_MembershipRenewal extends CRM_Member_Form {
       // CRM-15475
       array_search('Cancelled', CRM_Member_PseudoConstant::membershipStatus(NULL, " name = 'Cancelled' ", 'name', FALSE, TRUE)),
     ])) {
-      $memParams = array_merge($memParams, [
-        'status_id' => $currentMembership['status_id'],
-        'start_date' => $currentMembership['start_date'],
-        'end_date' => $currentMembership['end_date'],
-      ]);
       return CRM_Member_BAO_Membership::create($memParams);
     }
-
+    $memParams['join_date'] = date('Ymd', strtotime($currentMembership['join_date']));
     $isMembershipCurrent = CRM_Core_DAO::getFieldValue('CRM_Member_DAO_MembershipStatus', $currentMembership['status_id'], 'is_current_member');
 
     // CRM-7297 Membership Upsell - calculate dates based on new membership type


### PR DESCRIPTION


Overview
----------------------------------------
Deprecate passing weirdly formatted dates to Membership:create

Before
----------------------------------------
Membership BAO quietly does form level / api level wrangling on date fields - ie
```
$params['join_date'] = trim($params['join_date']) ? date('Ymd', strtotime(trim($params['join_date']))) : 'null';
```


After
----------------------------------------
Wrangling still done - but grumpily. Sites using the supported api interface will already have correct handling in play.

Technical Details
----------------------------------------
There are still a few places in core calling ```Membership::create``` directly - these are generally old scary code & I'm having to tweak them to comply. For non-core the message of 'use the api' has been around for a decade so a bit of deprecation should not be out of the blue

Comments
----------------------------------------

