### PR TITLE
Membership BAO - do not require date fields to be passed in on update

### DIFF
--- a/CRM/Member/Form/MembershipRenewal.php
+++ b/CRM/Member/Form/MembershipRenewal.php
@@ -732,7 +732,6 @@ class CRM_Member_Form_MembershipRenewal extends CRM_Member_Form {
     $ids = [];
     $currentMembership = civicrm_api3('Membership', 'getsingle', ['id' => $memParams['id']]);
 
-    $memParams['join_date'] = $currentMembership['join_date'];
     // Do NOT do anything.
     //1. membership with status : PENDING/CANCELLED (CRM-2395)
     //2. Paylater/IPN renew. CRM-4556.
@@ -741,14 +740,9 @@ class CRM_Member_Form_MembershipRenewal extends CRM_Member_Form {
       // CRM-15475
       array_search('Cancelled', CRM_Member_PseudoConstant::membershipStatus(NULL, " name = 'Cancelled' ", 'name', FALSE, TRUE)),
     ])) {
-      $memParams = array_merge($memParams, [
-        'status_id' => $currentMembership['status_id'],
-        'start_date' => $currentMembership['start_date'],
-        'end_date' => $currentMembership['end_date'],
-      ]);
       return CRM_Member_BAO_Membership::create($memParams);
     }
-
+    $memParams['join_date'] = date('Ymd', strtotime($currentMembership['join_date']));
     $isMembershipCurrent = CRM_Core_DAO::getFieldValue('CRM_Member_DAO_MembershipStatus', $currentMembership['status_id'], 'is_current_member');
 
     // CRM-7297 Membership Upsell - calculate dates based on new membership type


### PR DESCRIPTION
Overview
----------------------------------------
A lot of complexity in membership code is that the BAO currently REQUIRES already-saved date fields
to be passed in. This alters that such that the are loaded from the DB if not passed in.

Before
----------------------------------------
```Membership::create ``` BAO requires start_date, join_date, end_date to be already loaded

After
----------------------------------------
```Membership::create ```  will load fields if needed.

Technical Details
----------------------------------------
Currently the v3 api does this but we can start to remove from the v3 api once the BAO handles it. There are a small handful of places calling the BAO directly that need to be cleaned up - but also working towards having a v4 api

Comments
----------------------------------------
Building on https://github.com/civicrm/civicrm-core/pull/18793 (actually now flipped so that builds off this)
