### PR TITLE
[Test] - Fix some tests to call API not BAO

### DIFF
--- a/tests/phpunit/CRM/Member/BAO/MembershipTypeTest.php
+++ b/tests/phpunit/CRM/Member/BAO/MembershipTypeTest.php
@@ -9,6 +9,8 @@
  +--------------------------------------------------------------------+
  */
 
+use Civi\Api4\MembershipType;
+
 /**
  * Class CRM_Member_BAO_MembershipTypeTest
  * @group headless
@@ -281,7 +283,6 @@ class CRM_Member_BAO_MembershipTypeTest extends CiviUnitTestCase {
    *
    */
   public function testGetRenewalDatesForMembershipType() {
-    $ids = [];
     $params = [
       'name' => 'General',
       'domain_id' => 1,
@@ -296,11 +297,11 @@ class CRM_Member_BAO_MembershipTypeTest extends CiviUnitTestCase {
       'visibility' => 'Public',
       'is_active' => 1,
     ];
-    $membershipType = CRM_Member_BAO_MembershipType::add($params, $ids);
+    $membershipTypeID = MembershipType::create()->setValues($params)->execute()->first()['id'];
 
     $params = [
       'contact_id' => $this->_indiviContactID,
-      'membership_type_id' => $membershipType->id,
+      'membership_type_id' => $membershipTypeID,
       'join_date' => '20060121000000',
       'start_date' => '20060121000000',
       'end_date' => '20070120000000',
@@ -309,15 +310,15 @@ class CRM_Member_BAO_MembershipTypeTest extends CiviUnitTestCase {
       'status_id' => $this->_membershipStatusID,
     ];
 
-    $membership = CRM_Member_BAO_Membership::create($params);
+    $membership = $this->callAPISuccess('Membership', 'create', $params);
 
-    $membershipRenewDates = CRM_Member_BAO_MembershipType::getRenewalDatesForMembershipType($membership->id);
+    $membershipRenewDates = CRM_Member_BAO_MembershipType::getRenewalDatesForMembershipType($membership['id']);
 
-    $this->assertEquals($membershipRenewDates['start_date'], '20060121', 'Verify membership renewal start date.');
-    $this->assertEquals($membershipRenewDates['end_date'], '20080120', 'Verify membership renewal end date.');
+    $this->assertEquals('20060121', $membershipRenewDates['start_date'], 'Verify membership renewal start date.');
+    $this->assertEquals('20080120', $membershipRenewDates['end_date'], 'Verify membership renewal end date.');
 
-    $this->membershipDelete($membership->id);
-    $this->membershipTypeDelete(['id' => $membershipType->id]);
+    $this->membershipDelete($membership['id']);
+    $this->membershipTypeDelete(['id' => $membershipTypeID]);
   }
 
   /**

--- a/tests/phpunit/api/v3/MembershipTest.php
+++ b/tests/phpunit/api/v3/MembershipTest.php
@@ -1341,7 +1341,7 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
   /**
    * CRM-18503 - Test membership join date is correctly set for fixed memberships.
    *
-   * @throws \CRM_Core_Exception
+   * @throws \CRM_Core_Exception|\CiviCRM_API3_Exception
    */
   public function testMembershipJoinDateFixed() {
     $memStatus = CRM_Member_PseudoConstant::membershipStatus();
@@ -1354,20 +1354,20 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
       'membership_type_id' => $this->_membershipTypeID2,
       'source' => 'test membership',
       'is_pay_later' => 0,
-      'status_id' => array_search('Pending', $memStatus),
+      'status_id' => 'Pending',
       'skipStatusCal' => 1,
       'is_for_organization' => 1,
     ];
-    $membership = CRM_Member_BAO_Membership::create($params);
+    $membership = $this->callAPISuccess('Membership', 'create', $params);
 
     // Update membership to 'Completed' and check the dates.
     $memParams = [
-      'id' => $membership->id,
+      'id' => $membership['id'],
       'contact_id' => $contactId,
       'is_test' => 0,
       'membership_type_id' => $this->_membershipTypeID2,
       'num_terms' => 1,
-      'status_id' => array_search('New', $memStatus),
+      'status_id' => 'New',
     ];
     $result = $this->callAPISuccess('Membership', 'create', $memParams);
 
@@ -1380,11 +1380,11 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
       $rollOver = FALSE;
       $startDate = date('Y-m-d', strtotime(date('Y-03-01') . '- 1 year'));
     }
-    $membershipTypeDetails = CRM_Member_BAO_MembershipType::getMembershipTypeDetails($this->_membershipTypeID2);
+    $membershipTypeDetails = CRM_Member_BAO_MembershipType::getMembershipType($this->_membershipTypeID2);
     $fixedPeriodRollover = CRM_Member_BAO_MembershipType::isDuringFixedAnnualRolloverPeriod($joinDate, $membershipTypeDetails, $year, $startDate);
     $y = 1;
     if ($fixedPeriodRollover && $rollOver) {
-      $y += 1;
+      ++$y;
     }
 
     $expectedDates = [


### PR DESCRIPTION
Overview
----------------------------------------
Towards eliminating direct BAO calls like CRM_Member_BAO_Membership::create

Before
----------------------------------------
```
CRM_Member_BAO_Membership::create()
```

After
----------------------------------------
```
$this->callAPISuccess('Membership', 'create', $params);
```

Technical Details
----------------------------------------
We don't have a v4 membership api yet - mostly because it needs preliminary cleanup so using v3

Comments
----------------------------------------

