### PR TITLE
Switch to calling api

### DIFF
--- a/CRM/Contact/BAO/Relationship.php
+++ b/CRM/Contact/BAO/Relationship.php
@@ -2431,7 +2431,7 @@ SELECT count(*)
     AND is_current_member = 1";
     $result = CRM_Core_DAO::singleValueQuery($query);
     if ($result < CRM_Utils_Array::value('max_related', $membershipValues, PHP_INT_MAX)) {
-      CRM_Member_BAO_Membership::create($membershipValues);
+      civicrm_api3('Membership', 'create', $membershipValues);
     }
     return $membershipValues;
   }


### PR DESCRIPTION

Overview
----------------------------------------
Switches from direct BAO Membership::create to api in tested code place

Before
----------------------------------------
```
CRM_Member_BAO_Membership::create($params);
```


After
----------------------------------------
```
civicrm_api3('Membership', 'create', $params);
```

Technical Details
----------------------------------------
Working on getting rid of direct BAO calls as a step towards cleaning up the Membership create function so we can sort out v4


Test cover
----------------------------------------
Test cover in
CRM_Member_BAO_MembershipTest::testMembershipUpdateDoesNotDeleteRelatedMembershipsByMistake
