### PR TITLE
Replace BAO calls with api calls in test class

### DIFF
--- a/tests/phpunit/CRM/Member/BAO/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/BAO/MembershipTest.php
@@ -148,7 +148,7 @@ class CRM_Member_BAO_MembershipTest extends CiviUnitTestCase {
       'is_override' => 1,
       'status_id' => $this->_membershipStatusID,
     ];
-    CRM_Member_BAO_Membership::create($params);
+    $this->callAPISuccess('Membership', 'create', $params);
 
     $membershipTypeId = $this->assertDBNotNull('CRM_Member_BAO_Membership', $contactId,
       'membership_type_id', 'contact_id',
@@ -181,7 +181,7 @@ class CRM_Member_BAO_MembershipTest extends CiviUnitTestCase {
       'status_id' => $this->_membershipStatusID,
     ];
 
-    CRM_Member_BAO_Membership::create($params);
+    $this->callAPISuccess('Membership', 'create', $params);
 
     $membershipId1 = $this->assertDBNotNull('CRM_Member_BAO_Membership', $contactId, 'id',
       'contact_id', 'Database check for created membership.'
@@ -198,7 +198,7 @@ class CRM_Member_BAO_MembershipTest extends CiviUnitTestCase {
       'status_id' => $this->_membershipStatusID,
     ];
 
-    CRM_Member_BAO_Membership::create($params);
+    $this->callAPISuccess('Membership', 'create', $params);
 
     $membershipId2 = $this->assertDBNotNull('CRM_Member_BAO_Membership', 'source123', 'id',
       'source', 'Database check for created membership.'
@@ -242,7 +242,7 @@ class CRM_Member_BAO_MembershipTest extends CiviUnitTestCase {
       'status_id' => $this->_membershipStatusID,
     ];
 
-    CRM_Member_BAO_Membership::create($params);
+    $this->callAPISuccess('Membership', 'create', $params);
 
     $membershipId1 = $this->assertDBNotNull('CRM_Member_BAO_Membership', $contactId, 'id',
       'contact_id', 'Database check for created membership.'
@@ -264,7 +264,7 @@ class CRM_Member_BAO_MembershipTest extends CiviUnitTestCase {
       'status_id' => $this->_membershipStatusID,
     ];
 
-    CRM_Member_BAO_Membership::create($params);
+    $this->callAPISuccess('Membership', 'create', $params);
 
     $membershipId2 = $this->assertDBNotNull('CRM_Member_BAO_Membership', 'PaySource', 'id',
       'source', 'Database check for created membership.'
@@ -415,13 +415,12 @@ class CRM_Member_BAO_MembershipTest extends CiviUnitTestCase {
       'status_id' => $this->_membershipStatusID,
     ];
 
-    $membership = CRM_Member_BAO_Membership::create($params);
-    $membershipId = $this->assertDBNotNull('CRM_Member_BAO_Membership', $contactId, 'id',
-      'contact_id', 'Database check for created membership.'
-    );
+    $this->callAPISuccess('Membership', 'create', $params);
+
+    $membership = $this->callAPISuccessGetSingle('Membership', ['contact_id' => $contactId]);
 
     $this->assertDBNotNull('CRM_Member_BAO_MembershipLog',
-      $membership->id,
+      $membership['id'],
       'id',
       'membership_id',
       'Database checked on membershiplog record.'
@@ -448,7 +447,7 @@ class CRM_Member_BAO_MembershipTest extends CiviUnitTestCase {
       NULL,
       NULL
     );
-    $endDate = date("Y-m-d", strtotime($membership->end_date . " +1 year"));
+    $endDate = date("Y-m-d", strtotime($membership['end_date'] . " +1 year"));
 
     $this->assertDBNotNull('CRM_Member_BAO_MembershipLog',
       $MembershipRenew->id,
@@ -459,7 +458,7 @@ class CRM_Member_BAO_MembershipTest extends CiviUnitTestCase {
     $this->assertEquals($this->_membershipTypeID, $MembershipRenew->membership_type_id, 'Verify membership type is changed during renewal.');
     $this->assertEquals($endDate, $MembershipRenew->end_date, 'Verify correct end date is calculated after membership renewal');
 
-    $this->membershipDelete($membershipId);
+    $this->membershipDelete($membership['id']);
     $this->contactDelete($contactId);
   }
 
@@ -484,32 +483,20 @@ class CRM_Member_BAO_MembershipTest extends CiviUnitTestCase {
       'status_id' => $statusId,
     ];
 
-    $membership = CRM_Member_BAO_Membership::create($params);
+    $this->callAPISuccess('Membership', 'create', $params);
 
-    $membershipId = $this->assertDBNotNull('CRM_Member_BAO_Membership', $contactId, 'id',
-      'contact_id', 'Database check for created membership.'
-    );
+    $membership = $this->callAPISuccessGetSingle('Membership', [
+      'contact_id' => $contactId,
+      'start_date' => $startDate,
+      'join_date' => $joinDate,
+      'end_date' => $endDate,
+    ]);
 
-    $this->assertEquals($membership->status_id, $statusId, 'Verify correct status id is calculated.');
-    $this->assertEquals($membership->membership_type_id, $this->_membershipTypeID,
-      'Verify correct membership type id.'
-    );
-
-    //verify all dates.
-    $dates = [
-      'startDate' => 'start_date',
-      'joinDate' => 'join_date',
-      'endDate' => 'end_date',
-    ];
-
-    foreach ($dates as $date => $dbDate) {
-      $this->assertEquals($membership->$dbDate, $$date,
-        "Verify correct {$date} is present."
-      );
-    }
+    $this->assertEquals($membership['status_id'], $statusId, 'Verify correct status id is calculated.');
+    $this->assertEquals($membership['membership_type_id'], $this->_membershipTypeID);
 
     $this->assertDBNotNull('CRM_Member_BAO_MembershipLog',
-      $membership->id,
+      $membership['id'],
       'id',
       'membership_id',
       'Database checked on membership log record.'
@@ -538,7 +525,7 @@ class CRM_Member_BAO_MembershipTest extends CiviUnitTestCase {
       'Database checked on membership log record.'
     );
 
-    $this->membershipDelete($membershipId);
+    $this->membershipDelete($membership['id']);
     $this->contactDelete($contactId);
   }
 
@@ -555,17 +542,17 @@ class CRM_Member_BAO_MembershipTest extends CiviUnitTestCase {
       'status_id' => $this->_membershipStatusID,
     ];
 
-    $createdMembership = CRM_Member_BAO_Membership::create($params);
+    $createdMembershipID = $this->callAPISuccess('Membership', 'create', $params)['id'];
 
     civicrm_api3('Job', 'process_membership');
 
     $membershipAfterProcess = civicrm_api3('Membership', 'get', [
       'sequential' => 1,
-      'id' => $createdMembership->id,
+      'id' => $createdMembershipID,
       'return' => ['id', 'is_override', 'status_override_end_date'],
     ])['values'][0];
 
-    $this->assertEquals($createdMembership->id, $membershipAfterProcess['id']);
+    $this->assertEquals($createdMembershipID, $membershipAfterProcess['id']);
     $this->assertArrayNotHasKey('is_override', $membershipAfterProcess);
     $this->assertArrayNotHasKey('status_override_end_date', $membershipAfterProcess);
   }
@@ -583,17 +570,17 @@ class CRM_Member_BAO_MembershipTest extends CiviUnitTestCase {
       'status_id' => $this->_membershipStatusID,
     ];
 
-    $createdMembership = CRM_Member_BAO_Membership::create($params);
+    $createdMembershipID = $this->callAPISuccess('Membership', 'create', $params)['id'];
 
     civicrm_api3('Job', 'process_membership');
 
     $membershipAfterProcess = civicrm_api3('Membership', 'get', [
       'sequential' => 1,
-      'id' => $createdMembership->id,
+      'id' => $createdMembershipID,
       'return' => ['id', 'is_override', 'status_override_end_date'],
     ])['values'][0];
 
-    $this->assertEquals($createdMembership->id, $membershipAfterProcess['id']);
+    $this->assertEquals($createdMembershipID, $membershipAfterProcess['id']);
     $this->assertArrayNotHasKey('is_override', $membershipAfterProcess);
     $this->assertArrayNotHasKey('status_override_end_date', $membershipAfterProcess);
   }
@@ -610,17 +597,17 @@ class CRM_Member_BAO_MembershipTest extends CiviUnitTestCase {
       'status_id' => $this->_membershipStatusID,
     ];
 
-    $createdMembership = CRM_Member_BAO_Membership::create($params);
+    $createdMembershipID = $this->callAPISuccess('Membership', 'create', $params)['id'];
 
     civicrm_api3('Job', 'process_membership');
 
     $membershipAfterProcess = civicrm_api3('Membership', 'get', [
       'sequential' => 1,
-      'id' => $createdMembership->id,
+      'id' => $createdMembershipID,
       'return' => ['id', 'is_override', 'status_override_end_date'],
     ])['values'][0];
 
-    $this->assertEquals($createdMembership->id, $membershipAfterProcess['id']);
+    $this->assertEquals($createdMembershipID, $membershipAfterProcess['id']);
     $this->assertEquals(1, $membershipAfterProcess['is_override']);
   }
 
@@ -827,7 +814,7 @@ class CRM_Member_BAO_MembershipTest extends CiviUnitTestCase {
       'status_id' => $this->_membershipStatusID,
     ];
 
-    CRM_Member_BAO_Membership::create($params);
+    $this->callAPISuccess('Membership', 'create', $params);
 
     $membershipId = $this->assertDBNotNull('CRM_Member_BAO_Membership', $contactId, 'id',
       'contact_id', 'Database check for created membership.'


### PR DESCRIPTION
Overview
----------------------------------------
Switches from direct BAO Membership::create to api in test class

Before
----------------------------------------
```
CRM_Member_BAO_Membership::create($params);
```


After
----------------------------------------
```
civicrm_api3('Membership', 'create', $params);
```

Technical Details
----------------------------------------
Working on getting rid of direct BAO calls as a step towards cleaning up the Membership create function so we can sort out v4


Test cover
----------------------------------------

