### PR TITLE
CPS-332: Button markup fix in PremiumBlock.tpl

### DIFF
--- a/templates/CRM/Contribute/Form/Contribution/PremiumBlock.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/PremiumBlock.tpl
@@ -62,7 +62,9 @@
               <div class="premium-full-title">{$row.name}</div>
               <div class="premium-full-disabled">
                 {ts 1=$row.min_contribution|crmMoney}You must contribute at least %1 to get this item{/ts}<br/>
-                <button type="button" value="{ts 1=$row.min_contribution|crmMoney}Contribute %1 Instead{/ts}" amount="{$row.min_contribution}" />
+                <button type="button" amount="{$row.min_contribution}">
+                  {ts 1=$row.min_contribution|crmMoney}Contribute %1 Instead{/ts}
+                </button>
               </div>
               <div class="premium-full-description">
                 {$row.description}


### PR DESCRIPTION
Overview
----------------------------------------
In https://github.com/civicrm/civicrm-core/pull/18410/files#diff-6b993747c85ceec4b537726331c934f4aeac58a54152f850dab5aec2942a1009L65, the button markup was not fixed correctly, so this PR fixes the same.

Before
----------------------------------------
![2020-10-19 at 4 44 PM](https://user-images.githubusercontent.com/5058867/96443525-635e8f80-122a-11eb-9efa-9c559ce57346.png)

After
----------------------------------------
![2020-10-19 at 4 45 PM](https://user-images.githubusercontent.com/5058867/96443600-7ec99a80-122a-11eb-81b3-20986477737e.png)
