### PR TITLE
Remove always true if

### DIFF
--- a/CRM/Contribute/Page/Tab.php
+++ b/CRM/Contribute/Page/Tab.php
@@ -70,32 +70,26 @@ class CRM_Contribute_Page_Tab extends CRM_Core_Page {
 
     if ($recurID) {
       $paymentProcessorObj = Civi\Payment\System::singleton()->getById(CRM_Contribute_BAO_ContributionRecur::getPaymentProcessorID($recurID));
-      if ($paymentProcessorObj) {
-        if ($paymentProcessorObj->supports('cancelRecurring')) {
-          unset($links[CRM_Core_Action::DISABLE]['extra'], $links[CRM_Core_Action::DISABLE]['ref']);
-          $links[CRM_Core_Action::DISABLE]['url'] = "civicrm/contribute/unsubscribe";
-          $links[CRM_Core_Action::DISABLE]['qs'] = "reset=1&crid=%%crid%%&cid=%%cid%%&context={$context}";
-        }
-
-        if ($paymentProcessorObj->supports('UpdateSubscriptionBillingInfo')) {
-          $links[CRM_Core_Action::RENEW] = [
-            'name' => ts('Change Billing Details'),
-            'title' => ts('Change Billing Details'),
-            'url' => 'civicrm/contribute/updatebilling',
-            'qs' => "reset=1&crid=%%crid%%&cid=%%cid%%&context={$context}",
-          ];
-        }
-
-        if (
-        (!CRM_Core_Permission::check('edit contributions') && $context === 'contribution') ||
-        (!$paymentProcessorObj->supports('ChangeSubscriptionAmount')
-          && !$paymentProcessorObj->supports('EditRecurringContribution')
-        )) {
-          unset($links[CRM_Core_Action::UPDATE]);
-        }
+      if ($paymentProcessorObj->supports('cancelRecurring')) {
+        unset($links[CRM_Core_Action::DISABLE]['extra'], $links[CRM_Core_Action::DISABLE]['ref']);
+        $links[CRM_Core_Action::DISABLE]['url'] = "civicrm/contribute/unsubscribe";
+        $links[CRM_Core_Action::DISABLE]['qs'] = "reset=1&crid=%%crid%%&cid=%%cid%%&context={$context}";
       }
-      else {
-        unset($links[CRM_Core_Action::DISABLE]);
+
+      if ($paymentProcessorObj->supports('UpdateSubscriptionBillingInfo')) {
+        $links[CRM_Core_Action::RENEW] = [
+          'name' => ts('Change Billing Details'),
+          'title' => ts('Change Billing Details'),
+          'url' => 'civicrm/contribute/updatebilling',
+          'qs' => "reset=1&crid=%%crid%%&cid=%%cid%%&context={$context}",
+        ];
+      }
+
+      if (
+      (!CRM_Core_Permission::check('edit contributions') && $context === 'contribution') ||
+      (!$paymentProcessorObj->supports('ChangeSubscriptionAmount')
+        && !$paymentProcessorObj->supports('EditRecurringContribution')
+      )) {
         unset($links[CRM_Core_Action::UPDATE]);
       }
     }


### PR DESCRIPTION


Overview
----------------------------------------
Follow on to https://github.com/civicrm/civicrm-core/pull/18790 - remove always-true IF 

Before
----------------------------------------
Code wrapped in ``` if ($paymentProcessorObj) {``` - but that will always be true as the manual processor is returned if no id

After
----------------------------------------
poof

Technical Details
----------------------------------------
Since paymentProcessorObj is loaded as the manual processor where another does not exist
the processor condition is always true - so this if is obsolete

Comments
----------------------------------------
This is in it's own PR for whitespace readability reasons - the other IF should also be obsolete so that would be the next follow up
