### PR TITLE
Declare support for cancelRecurring in manual processor

### DIFF
--- a/CRM/Core/Payment/Manual.php
+++ b/CRM/Core/Payment/Manual.php
@@ -270,7 +270,18 @@ class CRM_Core_Payment_Manual extends CRM_Core_Payment {
         }
         return ts('To complete your contribution, click the <strong>Continue</strong> button below.');
 
+      default:
+        return parent::getText($context, $params);
     }
+  }
+
+  /**
+   * Does this processor support cancelling recurring contributions through code.
+   *
+   * @return bool
+   */
+  protected function supportsCancelRecurring() {
+    return TRUE;
   }
 
 }

--- a/tests/phpunit/CRM/Contribute/Page/TabTest.php
+++ b/tests/phpunit/CRM/Contribute/Page/TabTest.php
@@ -51,7 +51,7 @@ class CRM_Contribute_Page_TabTest extends CiviUnitTestCase {
 
     $templateVariable = CRM_Core_Smarty::singleton()->get_template_vars();
     $this->assertEquals('Mr. Anthony Anderson II', $templateVariable['displayName']);
-    $this->assertEquals("<span><a href=\"/index.php?q=civicrm/contact/view/contributionrecur&amp;reset=1&amp;id=" . $recurID . "&amp;cid=" . $contactID . "&amp;context=contribution\" class=\"action-item crm-hover-button\" title='View Recurring Payment' >View</a><a href=\"/index.php?q=civicrm/contribute/updaterecur&amp;reset=1&amp;action=update&amp;crid=1&amp;cid=3&amp;context=contribution\" class=\"action-item crm-hover-button\" title='Edit Recurring Payment' >Edit</a><a href=\"#\" class=\"action-item crm-hover-button crm-enable-disable\" title='Cancel' >Cancel</a></span>",
+    $this->assertEquals("<span><a href=\"/index.php?q=civicrm/contact/view/contributionrecur&amp;reset=1&amp;id=" . $recurID . "&amp;cid=" . $contactID . "&amp;context=contribution\" class=\"action-item crm-hover-button\" title='View Recurring Payment' >View</a><a href=\"/index.php?q=civicrm/contribute/updaterecur&amp;reset=1&amp;action=update&amp;crid=1&amp;cid=3&amp;context=contribution\" class=\"action-item crm-hover-button\" title='Edit Recurring Payment' >Edit</a><a href=\"/index.php?q=civicrm/contribute/unsubscribe&amp;reset=1&amp;crid=" . $recurID . "&amp;cid=" . $contactID . "&amp;context=contribution\" class=\"action-item crm-hover-button\" title='Cancel' >Cancel</a></span>",
       $templateVariable['activeRecurRows'][1]['action']
     );
   }


### PR DESCRIPTION


Overview
----------------------------------------
Reviewer's partial from https://github.com/civicrm/civicrm-core/pull/18196


Before
----------------------------------------
When no processor id is present the enable-disable form is loaded

After
----------------------------------------
When no processor id is present the cancel form is loaded

Technical Details
----------------------------------------

Comments
----------------------------------------

