### PR TITLE
Update CRM_Utils_Constant::value to support env variables

### DIFF
--- a/CRM/Core/Error.php
+++ b/CRM/Core/Error.php
@@ -603,15 +603,12 @@ class CRM_Core_Error extends PEAR_ErrorStack {
    * @param string $string
    */
   public static function debug_query($string) {
-    if (!defined('CIVICRM_DEBUG_LOG_QUERY')) {
-      // TODO: When its updated to support getenv(), call CRM_Utils_Constant::value('CIVICRM_DEBUG_LOG_QUERY', FALSE)
-      define('CIVICRM_DEBUG_LOG_QUERY', getenv('CIVICRM_DEBUG_LOG_QUERY'));
-    }
-    if (CIVICRM_DEBUG_LOG_QUERY === 'backtrace') {
+    $debugLogQuery = CRM_Utils_Constant::value('CIVICRM_DEBUG_LOG_QUERY', FALSE);
+    if ($debugLogQuery === 'backtrace') {
       CRM_Core_Error::backtrace($string, TRUE);
     }
-    elseif (CIVICRM_DEBUG_LOG_QUERY) {
-      CRM_Core_Error::debug_var('Query', $string, TRUE, TRUE, 'sql_log' . CIVICRM_DEBUG_LOG_QUERY, PEAR_LOG_DEBUG);
+    elseif ($debugLogQuery) {
+      CRM_Core_Error::debug_var('Query', $string, TRUE, TRUE, 'sql_log' . $debugLogQuery, PEAR_LOG_DEBUG);
     }
   }
 

--- a/CRM/Utils/Constant.php
+++ b/CRM/Utils/Constant.php
@@ -23,20 +23,23 @@ class CRM_Utils_Constant {
   /**
    * Determine the value of a constant, if any.
    *
-   * If the specified constant is undefined, return a default value.
+   * If the specified constant is undefined, check for an environment
+   * variable, defaulting the passed in default value.
    *
    * @param string $name
    * @param mixed $default
    *   (optional)
    * @return mixed
    */
-  public static function value($name, $default = NULL) {
+  public static function value(string $name, $default = NULL) {
     if (defined($name)) {
       return constant($name);
     }
-    else {
-      return $default;
+    if (($value = getenv($name)) !== FALSE) {
+      define($name, $value);
+      return $value;
     }
+    return $default;
   }
 
 }


### PR DESCRIPTION


Overview
----------------------------------------
Extends the ability to set a variable using env to any variable accessed via
```CRM_Utils_Constant::value```

e.g this already works
```
env CIVICRM_DEBUG_LOG_QUERY=backtrace drush cvapi
```

but 

```
nv CIVICRM_TEMP_FORCE_DURABLE=1 = drush cvapi
```
does not

Before
----------------------------------------
env solution is not generic

After
----------------------------------------
solution is generic - I don't have a particular use case but it was a follow up we talked about

Technical Details
----------------------------------------
@totten the only issue I can imagine is that defining to FALSE would not return anything

Comments
----------------------------------------
This is something I discussed with @totten earlier but as the rc was being cut at the time
we went for the more conservative approach of only adding env support to the debug_query
function.  This extends to all defines - meaning they can be defined at the script level e.
