### PR TITLE
Set id after save for the mailing component in the postProcess

### DIFF
--- a/CRM/Mailing/Form/Component.php
+++ b/CRM/Mailing/Form/Component.php
@@ -116,6 +116,10 @@ class CRM_Mailing_Form_Component extends CRM_Core_Form {
     }
 
     $component = CRM_Mailing_BAO_MailingComponent::add($params);
+
+    // set the id after save, so it can be used in a extension using the postProcess hook
+    $this->_id = $component->id;
+
     CRM_Core_Session::setStatus(ts('The mailing component \'%1\' has been saved.', [
       1 => $component->name,
     ]), ts('Saved'), 'success');


### PR DESCRIPTION
Overview
----------------------------------------
After save the mailing component (Headers, Footers, and Automated Messages) the id is set in the postProcess.

Before
----------------------------------------
After save of the mailing component the id is not set.

After
----------------------------------------
Now the id is set after the mailing component is saved.

Technical Details
----------------------------------------
The id is set after save $this->_id = $component->id;

Comments
----------------------------------------
No comments.
