### PR TITLE
SavedSearch: add UI_name index to upgrade script

### DIFF
--- a/CRM/Core/BAO/SchemaHandler.php
+++ b/CRM/Core/BAO/SchemaHandler.php
@@ -432,6 +432,8 @@ ADD UNIQUE INDEX `unique_entity_id` ( `entity_id` )";
           }
         }
 
+        $indexType = $createIndexPrefix === 'UI' ? 'UNIQUE' : '';
+
         // the index doesn't exist, so create it
         // if we're multilingual and the field is internationalised, do it for every locale
         // @todo remove is_array check & add multilingual support for combined indexes and add a test.
@@ -439,11 +441,11 @@ ADD UNIQUE INDEX `unique_entity_id` ( `entity_id` )";
         // entity_id + entity_table which are not multilingual.
         if (!is_array($field) && !CRM_Utils_System::isNull($locales) and isset($columns[$table][$fieldName])) {
           foreach ($locales as $locale) {
-            $queries[] = "CREATE INDEX {$createIndexPrefix}_{$fieldName}{$lengthName}_{$locale} ON {$table} ({$fieldName}_{$locale}{$lengthSize})";
+            $queries[] = "CREATE $indexType INDEX {$createIndexPrefix}_{$fieldName}{$lengthName}_{$locale} ON {$table} ({$fieldName}_{$locale}{$lengthSize})";
           }
         }
         else {
-          $queries[] = "CREATE INDEX {$createIndexPrefix}_{$fieldName}{$lengthName} ON {$table} (" . implode(',', (array) $field) . "{$lengthSize})";
+          $queries[] = "CREATE $indexType INDEX {$createIndexPrefix}_{$fieldName}{$lengthName} ON {$table} (" . implode(',', (array) $field) . "{$lengthSize})";
         }
       }
     }

--- a/CRM/Upgrade/Incremental/Base.php
+++ b/CRM/Upgrade/Incremental/Base.php
@@ -244,12 +244,13 @@ class CRM_Upgrade_Incremental_Base {
    *
    * @param CRM_Queue_TaskContext $ctx
    * @param string $table
-   * @param string|array $column
+   * @param string|array $columns
+   * @param string $prefix
    * @return bool
    */
-  public static function addIndex($ctx, $table, $column) {
-    $tables = [$table => (array) $column];
-    CRM_Core_BAO_SchemaHandler::createIndexes($tables);
+  public static function addIndex($ctx, $table, $columns, $prefix = 'index') {
+    $tables = [$table => (array) $columns];
+    CRM_Core_BAO_SchemaHandler::createIndexes($tables, $prefix);
 
     return TRUE;
   }

--- a/CRM/Upgrade/Incremental/php/FiveThirtyTwo.php
+++ b/CRM/Upgrade/Incremental/php/FiveThirtyTwo.php
@@ -56,6 +56,7 @@ class CRM_Upgrade_Incremental_php_FiveThirtyTwo extends CRM_Upgrade_Incremental_
     $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
     $this->addTask('Add column civicrm_saved_search.name', 'addColumn', 'civicrm_saved_search', 'name', "varchar(255)   DEFAULT NULL COMMENT 'Unique name of saved search'");
     $this->addTask('Add column civicrm_saved_search.label', 'addColumn', 'civicrm_saved_search', 'label', "varchar(255)   DEFAULT NULL COMMENT 'Administrative label for search'");
+    $this->addTask('Add index civicrm_saved_search.UI_name', 'addIndex', 'civicrm_saved_search', 'name', 'UI');
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
PR #18809 added 2 fields and an index to the schema. It also added an upgrader for the 2 fields but forgot the index. This adds the index to the upgrader.

Before
----------------------------------------
Missing index from upgrade.

After
----------------------------------------
Index added on upgrade.

Technical Details
----------------------------------------
Extends the `CRM_Core_BAO_SchemaHandler::createIndexes()` function to add the keyword "UNIQUE" when the prefix is "UI" (by convention we use "UI" to stand for "Unique Index").