### PR TITLE
dev/core#927 Enable contribution cancel actions extension

### DIFF
--- a/CRM/Upgrade/Incremental/php/FiveThirtyTwo.php
+++ b/CRM/Upgrade/Incremental/php/FiveThirtyTwo.php
@@ -48,6 +48,38 @@ class CRM_Upgrade_Incremental_php_FiveThirtyTwo extends CRM_Upgrade_Incremental_
   }
 
   /**
+   * Install contributioncancelactions extension.
+   *
+   * This feature is restructured as a core extension - which is primarily a code cleanup step but
+   * also permits sites / extensions to disable the core actions to do their own workflows.
+   *
+   * @param \CRM_Queue_TaskContext $ctx
+   *
+   * @return bool
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public static function installContributionCancelActions(CRM_Queue_TaskContext $ctx) {
+    // Install via direct SQL manipulation. Note that:
+    // (1) This extension has no activation logic.
+    // (2) On new installs, the extension is activated purely via default SQL INSERT.
+    // (3) Caches are flushed at the end of the upgrade.
+    // ($) Over long term, upgrade steps are more reliable in SQL. API/BAO sometimes don't work mid-upgrade.
+    $insert = CRM_Utils_SQL_Insert::into('civicrm_extension')->row([
+      'type' => 'module',
+      'full_name' => 'contributioncancelactions',
+      'name' => 'contributioncancelactions',
+      'label' => 'Contribution cancel actions',
+      'file' => 'contributioncancelactions',
+      'schema_version' => NULL,
+      'is_active' => 1,
+    ]);
+    CRM_Core_DAO::executeQuery($insert->usingReplace()->toSQL());
+
+    return TRUE;
+  }
+
+  /**
    * Upgrade function.
    *
    * @param string $rev
@@ -57,6 +89,7 @@ class CRM_Upgrade_Incremental_php_FiveThirtyTwo extends CRM_Upgrade_Incremental_
     $this->addTask('Add column civicrm_saved_search.name', 'addColumn', 'civicrm_saved_search', 'name', "varchar(255)   DEFAULT NULL COMMENT 'Unique name of saved search'");
     $this->addTask('Add column civicrm_saved_search.label', 'addColumn', 'civicrm_saved_search', 'label', "varchar(255)   DEFAULT NULL COMMENT 'Administrative label for search'");
     $this->addTask('Add index civicrm_saved_search.UI_name', 'addIndex', 'civicrm_saved_search', 'name', 'UI');
+    $this->addTask('Install contribution cancel actions extension', 'installContributionCancelActions');
   }
 
 }

--- a/xml/templates/civicrm_data.tpl
+++ b/xml/templates/civicrm_data.tpl
@@ -1782,3 +1782,4 @@ INSERT IGNORE INTO civicrm_extension (type, full_name, name, label, file, is_act
 INSERT IGNORE INTO civicrm_extension (type, full_name, name, label, file, is_active) VALUES ('module', 'greenwich', 'Theme: Greenwich', 'Theme: Greenwich', 'greenwich', 1);
 INSERT IGNORE INTO civicrm_extension (type, full_name, name, label, file, is_active) VALUES ('module', 'eventcart', 'Event cart', 'Event cart', 'eventcart', 1);
 INSERT IGNORE INTO civicrm_extension (type, full_name, name, label, file, is_active) VALUES ('module', 'financialacls', 'Financial ACLs', 'Financial ACLs', 'financialacls', 1);
+INSERT IGNORE INTO civicrm_extension (type, full_name, name, label, file, is_active) VALUES ('module', 'contributioncancelactions', 'Contribution cancel actions', 'Contribution cancel actions', 'contributioncancelactions', 1);


### PR DESCRIPTION

Overview
----------------------------------------
This enables the new shell extension contributioncancelactions on new installs and upgrades. 

The extension will hold current core logic for cancelling related entities when cancelling contributions.

Once completed this extension will be unhidden and available to disable - hopefully within the 5.32 release - allowing alternate workflows more cleanly.

Before
----------------------------------------
Shell extension exists -but not yet enabled

Enabled, & ready for us to start moving logic to it...

Technical Details
----------------------------------------

Comments

