### PR TITLE
dev/core#927 Remove code to update recur on cancel & fail where there is no recur

### DIFF
--- a/CRM/Contribute/BAO/ContributionRecur.php
+++ b/CRM/Contribute/BAO/ContributionRecur.php
@@ -557,6 +557,7 @@ INNER JOIN civicrm_contribution       con ON ( con.id = mp.contribution_id )
    * @param int $targetContributionId
    */
   public static function copyCustomValues($recurId, $targetContributionId) {
+    CRM_Core_Error::deprecatedFunctionWarning('no alternative');
     if ($recurId && $targetContributionId) {
       // get the initial contribution id of recur id
       $sourceContributionId = CRM_Core_DAO::getFieldValue('CRM_Contribute_DAO_Contribution', $recurId, 'id', 'contribution_recur_id');

--- a/CRM/Core/Payment/BaseIPN.php
+++ b/CRM/Core/Payment/BaseIPN.php
@@ -186,13 +186,6 @@ class CRM_Core_Payment_BaseIPN {
       CRM_Contribute_BAO_ContributionRecur::addRecurLineItems($objects['contributionRecur']->id, $contribution);
     }
 
-    //add new soft credit against current contribution id and
-    //copy initial contribution custom fields for recurring contributions
-    if (!empty($objects['contributionRecur']) && $objects['contributionRecur']->id) {
-      CRM_Contribute_BAO_ContributionRecur::addrecurSoftCredit($objects['contributionRecur']->id, $contribution->id);
-      CRM_Contribute_BAO_ContributionRecur::copyCustomValues($objects['contributionRecur']->id, $contribution->id);
-    }
-
     if (!empty($memberships)) {
       foreach ($memberships as $membership) {
         // @fixme Should we cancel only Pending memberships? per cancelled()
@@ -262,13 +255,6 @@ class CRM_Core_Payment_BaseIPN {
     // Add line items for recurring payments.
     if (!empty($objects['contributionRecur']) && $objects['contributionRecur']->id && $addLineItems) {
       CRM_Contribute_BAO_ContributionRecur::addRecurLineItems($objects['contributionRecur']->id, $contribution);
-    }
-
-    //add new soft credit against current $contribution and
-    //copy initial contribution custom fields for recurring contributions
-    if (!empty($objects['contributionRecur']) && $objects['contributionRecur']->id) {
-      CRM_Contribute_BAO_ContributionRecur::addrecurSoftCredit($objects['contributionRecur']->id, $contribution->id);
-      CRM_Contribute_BAO_ContributionRecur::copyCustomValues($objects['contributionRecur']->id, $contribution->id);
     }
 
     if (!empty($memberships)) {


### PR DESCRIPTION
Overview
----------------------------------------
Removes some code that I believe is not correct/used and a result of copy & paste

Before
----------------------------------------
Code that appears intended only for repeattransaction present in failed and cancelled flow for contributions which are either the first in the series, of not part of a series

```
  //add new soft credit against current contribution id and
    //copy initial contribution custom fields for recurring contributions
    if (!empty($objects['contributionRecur']) && $objects['contributionRecur']->id) {
      CRM_Contribute_BAO_ContributionRecur::addrecurSoftCredit($objects['contributionRecur']->id, $contribution->id);
      CRM_Contribute_BAO_ContributionRecur::copyCustomValues($objects['contributionRecur']->id, $contribution->id);
    }
```

in the latter function this early return should always apply
```

      // if the same contribution is being processed then return
      if ($sourceContributionId == $targetContributionId) {
        return;
      }
```

in the former it should result in resaving the soft credit unchanged

After
----------------------------------------
poof

Technical Details
----------------------------------------
I've been racking my brains as to why we do this and it just feels like copy & paste that has survived forever

This code is called only from the 2 PaypalPN classes. In both cases the classes follow the same flow - ie

if the payment is part of a recurring series, then call recur
if the payment is NOT the first in the series then call repeattransaction
only proceed to the 'single' function if we are confirming the
first recurring payment or it is not recurring

This means the cancelled & failed functions can only be reached when the flow is not
recurring OR the payment is the first - in neither case does it make sense to copy date
from one payment in the series to others - I'm pretty sure this precedes many many code changes

Comments
----------------------------------------
PR to put the remaining soft credit copy PR in the right place https://github.com/civicrm/civicrm-core/pull/18815/