### PR TITLE
Minor code cleanup - dedupe isNull checks

### DIFF
--- a/CRM/Member/Import/Parser/Membership.php
+++ b/CRM/Member/Import/Parser/Membership.php
@@ -327,7 +327,8 @@ class CRM_Member_Import_Parser_Membership extends CRM_Member_Import_Parser {
 
       $formatValues = [];
       foreach ($params as $key => $field) {
-        if ($field == NULL || $field === '') {
+        // ignore empty values or empty arrays etc
+        if (CRM_Utils_System::isNull($field)) {
           continue;
         }
 
@@ -621,10 +622,6 @@ class CRM_Member_Import_Parser_Membership extends CRM_Member_Import_Parser {
     $customFields = CRM_Core_BAO_CustomField::getFields('Membership');
 
     foreach ($params as $key => $value) {
-      // ignore empty values or empty arrays etc
-      if (CRM_Utils_System::isNull($value)) {
-        continue;
-      }
 
       //Handling Custom Data
       if ($customFieldID = CRM_Core_BAO_CustomField::getKeyID($key)) {


### PR DESCRIPTION
Overview
----------------------------------------
Minor code cleanup - dedupe isNull checks

Before
----------------------------------------
First we have a loop

```
  foreach ($params as $key => $field) {
        if ($field == NULL || $field === '') {
          continue;
        }

        $formatValues[$key] = $field;
      }
```

then formatValues is passed through a loop where

```
foreach ($params as $key => $value) {
      // ignore empty values or empty arrays etc
      if (CRM_Utils_System::isNull($value)) {
        continue;
      }
     // under certain circumstances transfer the value to $values which is then used...

```

After
----------------------------------------
The isNull check is just in the first place

Technical Details
----------------------------------------
The code goes through 3 rounds of going through each param & adjust the params

In this case the second 2 of these both skip any isNull values so combining them
& keeping the strictest makes sense


Comments
----------------------------------------

Generic test cover in ```CRM_Member_Import_Parser_MembershipTest```