### PR TITLE
dev/membership#30 switch Membership import to use the v3 api

### DIFF
--- a/CRM/Member/Import/Parser/Membership.php
+++ b/CRM/Member/Import/Parser/Membership.php
@@ -308,9 +308,6 @@ class CRM_Member_Import_Parser_Membership extends CRM_Member_Import_Parser {
               $params[$key] = $this->parsePseudoConstantField($val, $this->fieldMetadata[$key]);
               break;
 
-            case 'member_is_override':
-              $params[$key] = CRM_Utils_String::strtobool($val);
-              break;
           }
           if ($customFieldID = CRM_Core_BAO_CustomField::getKeyID($key)) {
             if ($customFields[$customFieldID]['data_type'] == 'Date') {
@@ -371,20 +368,9 @@ class CRM_Member_Import_Parser_Membership extends CRM_Member_Import_Parser {
               CRM_Price_BAO_LineItem::getLineItemArray($formatted, NULL, 'membership', $formatted['membership_type_id']);
             }
 
-            // @todo stop passing $ids array (and put details in $formatted if required)
-            $ids = [
-              'membership' => $formatValues['membership_id'],
-              'userId' => $session->get('userID'),
-            ];
-            $newMembership = CRM_Member_BAO_Membership::create($formatted, $ids, TRUE);
-            if (civicrm_error($newMembership)) {
-              array_unshift($values, $newMembership['is_error'] . ' for Membership ID ' . $formatValues['membership_id'] . '. Row was skipped.');
-              return CRM_Import_Parser::ERROR;
-            }
-            else {
-              $this->_newMemberships[] = $newMembership->id;
-              return CRM_Import_Parser::VALID;
-            }
+            $newMembership = civicrm_api3('Membership', 'create', $formatted);
+            $this->_newMemberships[] = $newMembership['id'];
+            return CRM_Import_Parser::VALID;
           }
           else {
             array_unshift($values, 'Matching Membership record not found for Membership ID ' . $formatValues['membership_id'] . '. Row was skipped.');


### PR DESCRIPTION
Overview
----------------------------------------
Fix for https://lab.civicrm.org/dev/membership/-/issues/30 whereby is_override is ignored on import

Before
----------------------------------------
Steps in the gitlab but TLDR = 'is_override' column does not reach the BAO as 'is_override' but as 'member_is_override' - whic the BAO ignores

After
----------------------------------------
Api handles unique names by passing both the the BAO - we could strip out a lot of the function now....


Technical Details
----------------------------------------
It turns out the addition of a unique name at some point caused is_override not to be passed in
inn a way the BAO recognises - the api has handling for this...

Comments
----------------------------------------
Tests in ```CRM_Member_Import_Parser_MembershipTest``` look like they should have detected this but didn't
