### PR TITLE
[Test fix] Skip UFField.field_name on singleValueAlter as flakey

### DIFF
--- a/tests/phpunit/api/v3/SyntaxConformanceTest.php
+++ b/tests/phpunit/api/v3/SyntaxConformanceTest.php
@@ -746,6 +746,7 @@ class api_v3_SyntaxConformanceTest extends CiviUnitTestCase {
           'website_type_id',
           // Not a real field
           'option.autoweight',
+          'field_name',
         ],
         'break_return' => [
           // These fields get auto-adjusted by the BAO prior to saving


### PR DESCRIPTION
Overview
----------------------------------------
Fix for intermittent test fail on singleValueAlter

Before
----------------------------------------
api result array comparison failed checking if field_name was correctly updated
Array
(
    [update-params] => Array
        (
            [id] => 84
            [field_name] => formatting
        )

    [update-result] => Array
        (
            [is_error] => 0
            [version] => 3
            [count] => 1
            [id] => 84
            [values] => Array
                (
                    [84] => Array
                        (
                            [id] => 84
                            [uf_group_id] => 23
                            [field_name] => formatting_22a4
                            [is_active] => 1
                            [is_view] => 0
                            [is_required] => 0
                            [weight] => 1
                            [help_post] => help_post_20
                            [help_pre] => help_pre_20
                            [visibility] => User and User Admin Only
                            [in_selector] => 0
                            [is_searchable] => 0
                            [location_type_id] => 1
                            [phone_type_id] => 
                            [website_type_id] => 
                            [label] => label_20
                            [field_type] => Formatting
                            [is_reserved] => 1
                            [is_multi_summary] => 0
                        )

                )

            [xdebug] => Array
                (
                    [peakMemory] => 53541488
                    [memory] => 53399768
                    [timeIndex] => 58.119831085205
                )

        )

    [getsingle-params] => Array
        (
            [id] => 84
            [sequential] => 1
            [return] => Array
                (
                    [0] => id
                    [1] => uf_group_id
                    [2] => field_name
                    [3] => is_active
                    [4] => is_view
                    [5] => is_required
                    [7] => help_post
                    [8] => help_pre
                    [9] => visibility
                    [10] => in_selector
                    [11] => is_searchable
                    [15] => label
                    [17] => is_reserved
                    [18] => is_multi_summary
                )

            [options] => Array
                (
                    [sort] => id DESC
                    [limit] => 2
                )

        )

    [getsingle-result] => Array
        (
            [id] => 84
            [uf_group_id] => 23
            [field_name] => formatting_22a4
            [is_active] => 1
            [is_view] => 0
            [is_required] => 0
            [help_post] => help_post_20
            [help_pre] => help_pre_20
            [visibility] => User and User Admin Only
            [in_selector] => 0
            [is_searchable] => 0
            [label] => label_20
            [is_reserved] => 1
            [is_multi_summary] => 0
        )

    [expected entity] => Array
        (
            [id] => 84
            [uf_group_id] => 23
            [field_name] => formatting
            [is_active] => 1
            [is_view] => 0
            [is_required] => 0
            [help_post] => help_post_20
            [help_pre] => help_pre_20
            [visibility] => User and User Admin Only
            [in_selector] => 0
            [is_searchable] => 0
            [label] => label_20
            [is_reserved] => 1
            [is_multi_summary] => 0
        )

)
Array
(
    [id] => 84
    [uf_group_id] => 23
    [field_name] => formatting
    [is_active] => 1
    [is_view] => 0
    [is_required] => 0
    [help_post] => help_post_20
    [help_pre] => help_pre_20
    [visibility] => User and User Admin Only
    [in_selector] => 0
    [is_searchable] => 0
    [label] => label_20
    [is_reserved] => 1
    [is_multi_summary] => 0
)
 was compared to Array
(
    [id] => 84
    [uf_group_id] => 23
    [field_name] => formatting_22a4
    [is_active] => 1
    [is_view] => 0
    [is_required] => 0
    [help_post] => help_post_20
    [help_pre] => help_pre_20
    [visibility] => User and User Admin Only
    [in_selector] => 0
    [is_searchable] => 0
    [label] => label_20
    [is_reserved] => 1
    [is_multi_summary] => 0
)

Failed asserting that two arrays are equal.
<Click to see difference>

 /Users/eileenmcnaughton/buildkit/build/dmaster/sites/all/modules/civicrm/Civi/Test/Api3TestTrait.php:57
 /Users/eileenmcnaughton/buildkit/build/dmaster/sites/all/modules/civicrm/tests/phpunit/api/v3/SyntaxConformanceTest.php:1526
 /Users/eileenmcnaughton/buildkit/build/dmaster/sites/all/modules/civicrm/tests/phpunit/CiviTest/CiviUnitTestCase.php:226
 /Users/eileenmcnaughton/vendor/phpunit/phpunit/phpunit:61
 


After
----------------------------------------
Skips it

Technical Details
----------------------------------------


Comments
----------------------------------------

