### PR TITLE
(core/dev#2104) Add birth date column for target contact to activity …

### DIFF
--- a/CRM/Report/Form/Activity.php
+++ b/CRM/Report/Form/Activity.php
@@ -94,6 +94,12 @@ class CRM_Report_Form_Activity extends CRM_Report_Form {
             'dbAlias' => "civicrm_contact_target.sort_name",
             'default' => TRUE,
           ],
+          'contact_target_birth' => [
+            'name' => 'birth_date',
+            'title' => ts('Target Birth Date'),
+            'alias' => 'civicrm_contact_target',
+            'dbAlias' => "civicrm_contact_target.birth_date",
+          ],
           'contact_source_id' => [
             'name' => 'id',
             'alias' => 'civicrm_contact_source',


### PR DESCRIPTION
…report

Overview
----------------------------------------
Add birth date column for target contact  to activity report

Before
----------------------------------------
No way to list birthdate on target contact

After
----------------------------------------
![activity_after](https://user-images.githubusercontent.com/3455173/96721024-309ecd80-13c9-11eb-807b-62eb5f85c5b8.png)
