### PR TITLE
put asset rendering call into a try/catch - dev/core #2137

### DIFF
--- a/Civi/Core/AssetBuilder.php
+++ b/Civi/Core/AssetBuilder.php
@@ -188,10 +188,14 @@ class AssetBuilder {
       if (!file_exists($this->getCachePath())) {
         mkdir($this->getCachePath());
       }
-
-      $rendered = $this->render($name, $params);
-      file_put_contents($this->getCachePath($fileName), $rendered['content']);
-      return $fileName;
+      try {
+        $rendered = $this->render($name, $params);
+        file_put_contents($this->getCachePath($fileName), $rendered['content']);
+        return $fileName;
+      }
+      catch (UnknownAssetException $e) {
+        // ignore possibly missing asset
+      }
     }
     return $fileName;
   }

--- a/Civi/Core/AssetBuilder.php
+++ b/Civi/Core/AssetBuilder.php
@@ -194,7 +194,8 @@ class AssetBuilder {
         return $fileName;
       }
       catch (UnknownAssetException $e) {
-        // ignore possibly missing asset
+        // unexpected error, log and continue
+        Civi::log()->error('Unexpected error while rendering a file in the AssetBuilder');
       }
     }
     return $fileName;


### PR DESCRIPTION
Overview
----------------------------------------
Fix error behavior in asset building

Before
----------------------------------------
php error, as per https://lab.civicrm.org/dev/core/-/issues/2137

After
----------------------------------------
Logs the error using a try/catch, doesn't break the site.

Comments
----------------------------------------
This PR doesn't solve the issue of why the asset might be missing in the first place, but at least makes the consequences less destructive.
