### PR TITLE
dev/core#2136 Fix the loading of groups on the contact Individual screen

### DIFF
--- a/CRM/Contact/Form/Edit/TagsAndGroups.php
+++ b/CRM/Contact/Form/Edit/TagsAndGroups.php
@@ -93,7 +93,7 @@ class CRM_Contact_Form_Edit_TagsAndGroups {
         $attributes['skiplabel'] = TRUE;
         $elements = [];
         $groupsOptions = [];
-        foreach ($groups as $group) {
+        foreach ($groups as $key => $group) {
           $id = $group['id'];
           // make sure that this group has public visibility
           if ($visibility &&
@@ -103,7 +103,7 @@ class CRM_Contact_Form_Edit_TagsAndGroups {
           }
 
           if ($groupElementType == 'select') {
-            $groupsOptions[$id] = $group;
+            $groupsOptions[$key] = $group;
           }
           else {
             $form->_tagGroup[$fName][$id]['description'] = $group['description'];


### PR DESCRIPTION
Overview
----------------------------------------
This fixes the issue where by groups would not load on the Edit Individual / Household etc screen

Before
----------------------------------------
Groups do not load

After
----------------------------------------
Groups load

Technical Details
----------------------------------------
The problem was when i fixed this up for profiles (which use checkboxes) https://github.com/civicrm/civicrm-core/pull/18776 which requires the options to be keyed by the group id to work correctly with Selects it needs to be keyed sequentially not by the group id

ping @demeritcowboy @eileenmcnaughton @MegaphoneJon 