### PR TITLE
dev/translation#56 Revert incorrect localization of options in search

### DIFF
--- a/CRM/Core/PseudoConstant.php
+++ b/CRM/Core/PseudoConstant.php
@@ -182,10 +182,7 @@ class CRM_Core_PseudoConstant {
   public static function get($daoName, $fieldName, $params = [], $context = NULL) {
     CRM_Core_DAO::buildOptionsContext($context);
     $flip = !empty($params['flip']);
-    // Historically this was 'false' but according to the notes in
-    // CRM_Core_DAO::buildOptionsContext it should be context dependent.
-    // timidly changing for 'search' only to fix world_region in search options.
-    $localizeDefault = in_array($context, ['search']);
+    $localizeDefault = FALSE;
     // Merge params with defaults
     $params += [
       'grouping' => FALSE,


### PR DESCRIPTION
Overview
----------------------------------------

In the Search forms (Advanced Search, Membership Search), Membership Types can be incorrectly translated.

To reproduce:

* Switch the locale to French
* Create a Membership Type called "Premium"
* Go to Find Membership screen

Notice how the "Premium" membership type is displayed as "Cadeau", but should be "Premium".

Example below with "Save", which is easier to reproduce in most languages:

![tr56](https://user-images.githubusercontent.com/254741/96789172-ae130f80-13c2-11eb-8adb-c81c5408d4a8.png)


Technical Details
----------------------------------------

This was done some time ago (65c86f7db8c) to workaround limitations on World Regions translation, which only have a `name` field, not a `label`, and are not translatable. It is an incorrect use of `ts`.

Merging this PR will cause a regression, but keeping this bug has odd effects (and could have an impact on other fields).

Other thoughts:

- We should fix the Membership Type to add a `label` localizable column.
- We could instead tweak the hack, so that it only applies to the `world_region` field, until that field is fixed?

Reported by @AlainBenbassat 
