### PR TITLE
dev/core#2136 Fix the loading of groups on the contact Individual screen

### DIFF
--- a/CRM/Contact/Form/Edit/TagsAndGroups.php
+++ b/CRM/Contact/Form/Edit/TagsAndGroups.php
@@ -93,7 +93,7 @@ class CRM_Contact_Form_Edit_TagsAndGroups {
         $attributes['skiplabel'] = TRUE;
         $elements = [];
         $groupsOptions = [];
-        foreach ($groups as $group) {
+        foreach ($groups as $key => $group) {
           $id = $group['id'];
           // make sure that this group has public visibility
           if ($visibility &&
@@ -103,7 +103,7 @@ class CRM_Contact_Form_Edit_TagsAndGroups {
           }
 
           if ($groupElementType == 'select') {
-            $groupsOptions[$id] = $group;
+            $groupsOptions[$key] = $group;
           }
           else {
             $form->_tagGroup[$fName][$id]['description'] = $group['description'];


### PR DESCRIPTION
Overview
----------------------------------------
5.30 backport for https://github.com/civicrm/civicrm-core/pull/18831

Before
----------------------------------------
Groups do not load properly on the Edit Individual/ household etc screen

After
----------------------------------------
Groups load

ping @eileenmcnaughton 
