### PR TITLE
Fix deprecated passing of string attributes to CRM_Core_Form::add for contact import

### DIFF
--- a/CRM/Import/DataSource/CSV.php
+++ b/CRM/Import/DataSource/CSV.php
@@ -58,7 +58,7 @@ class CRM_Import_DataSource_CSV extends CRM_Import_DataSource {
     }
     $uploadSize = round(($uploadFileSize / (1024 * 1024)), 2);
     $form->assign('uploadSize', $uploadSize);
-    $form->add('File', 'uploadFile', ts('Import Data File'), 'size=30 maxlength=255', TRUE);
+    $form->add('File', 'uploadFile', ts('Import Data File'), NULL, TRUE);
     $form->setMaxFileSize($uploadFileSize);
     $form->addRule('uploadFile', ts('File size should be less than %1 MBytes (%2 bytes)', [
       1 => $uploadSize,


### PR DESCRIPTION
Overview
----------------------------------------
This is the same as https://github.com/civicrm/civicrm-core/pull/18820 but for contact import.