### PR TITLE
dev/core#2140 Fix site path for Drupal 8 and 9

### DIFF
--- a/setup/plugins/init/Drupal8.civi-setup.php
+++ b/setup/plugins/init/Drupal8.civi-setup.php
@@ -32,7 +32,7 @@ if (!defined('CIVI_SETUP')) {
 
     // Compute settingsPath.
     $siteDir = \Civi\Setup\DrupalUtil::getDrupalSiteDir($cmsPath);
-    $model->settingsPath = implode(DIRECTORY_SEPARATOR, [$cmsPath, 'sites', $siteDir, 'civicrm.settings.php']);
+    $model->settingsPath = implode(DIRECTORY_SEPARATOR, [$cmsPath, $siteDir, 'civicrm.settings.php']);
 
     if (($loadGenerated = \Drupal\Core\Site\Settings::get('civicrm_load_generated', NULL)) !== NULL) {
       $model->loadGenerated = $loadGenerated;

--- a/setup/src/Setup/DrupalUtil.php
+++ b/setup/src/Setup/DrupalUtil.php
@@ -20,7 +20,7 @@ class DrupalUtil {
       return basename(conf_path());
     }
     elseif (class_exists('Drupal')) {
-      return basename(\Drupal::service('site.path'));
+      return \Drupal::service('site.path');
     }
     else {
       throw new \Exception('Cannot detect path under Drupal "sites/".');


### PR DESCRIPTION
This fixes hardcoded assumptions of the site path. This breaks testing integration, which has sites in a subdirectory of `simpletest`
