### PR TITLE
Fix offset not found exception When using the API(4) to populate the contact context as contact_id does not exist

### DIFF
--- a/Civi/Token/TokenCompatSubscriber.php
+++ b/Civi/Token/TokenCompatSubscriber.php
@@ -118,7 +118,7 @@ class TokenCompatSubscriber implements EventSubscriberInterface {
     $e->string = \CRM_Utils_Token::replaceDomainTokens($e->string, $domain, $isHtml, $e->message['tokens'], $useSmarty);
 
     if (!empty($e->context['contact'])) {
-      \CRM_Utils_Token::replaceGreetingTokens($e->string, $e->context['contact'], $e->context['contact']['contact_id'], NULL, $useSmarty);
+      \CRM_Utils_Token::replaceGreetingTokens($e->string, $e->context['contact'], $e->context['contact']['contact_id'] ?? $e->context['contactId'], NULL, $useSmarty);
       $e->string = \CRM_Utils_Token::replaceContactTokens($e->string, $e->context['contact'], $isHtml, $e->message['tokens'], TRUE, $useSmarty);
 
       // FIXME: This may depend on $contact being merged with hook values.


### PR DESCRIPTION
Overview
----------------------------------------
When using the tokenProcessor rowContext->contactId should always be defined if we are parsing contact tokens. If rowContext->contact has been set using API4 then the array offset `contact_id` won't exist and the tokenProcessor will crash with "offset doesn't exist" ArrayAccess error.

Before
----------------------------------------
When tokenProcessor rowContext is populated with API4 parsing contact tokens crashes with "array offset does not exist" because contact_id does not exist.

After
----------------------------------------
In theory rowContext->contactId should always exist if we are parsing contact tokens so we use that. But in case it doesn't we check the original rowContext->contact['contact_id'] first and fallback if not.

Technical Details
----------------------------------------


Comments
----------------------------------------
