### PR TITLE
dev/core#2029 exclude ornery test

### DIFF
--- a/tests/phpunit/E2E/Core/PrevNextTest.php
+++ b/tests/phpunit/E2E/Core/PrevNextTest.php
@@ -8,7 +8,7 @@ namespace E2E\Core;
  * Check that the active prev-next service behaves as expected.
  *
  * @package E2E\Core
- * @group e2e
+ * @group e2e ornery
  */
 class PrevNextTest extends \CiviEndToEndTestCase {
 


### PR DESCRIPTION

Overview
----------------------------------------
E2E.Core.PrevNextTest.testDeleteByCacheKey

Before
----------------------------------------
Test fails frequently on PRs (but not on matrix)

After
----------------------------------------
Test only runs on matrix

Technical Details
----------------------------------------


Comments
----------------------------------------

