### PR TITLE
dev/core#2115 Move filtering of unpermitted options for reports/ search select to financialacl extension

### DIFF
--- a/CRM/Contribute/BAO/Query.php
+++ b/CRM/Contribute/BAO/Query.php
@@ -931,9 +931,8 @@ class CRM_Contribute_BAO_Query extends CRM_Core_BAO_Query {
     );
 
     // CRM-13848
-    CRM_Financial_BAO_FinancialType::getAvailableFinancialTypes($financialTypes, CRM_Core_Action::VIEW);
     $form->addSelect('financial_type_id',
-      ['entity' => 'contribution', 'multiple' => 'multiple', 'context' => 'search', 'options' => $financialTypes]
+      ['entity' => 'contribution', 'multiple' => 'multiple', 'context' => 'search', 'options' => CRM_Contribute_BAO_Contribution::buildOptions('financial_type_id', 'search')]
     );
 
     // use contribution_payment_instrument_id instead of payment_instrument_id

--- a/CRM/Financial/BAO/FinancialType.php
+++ b/CRM/Financial/BAO/FinancialType.php
@@ -267,6 +267,12 @@ class CRM_Financial_BAO_FinancialType extends CRM_Financial_DAO_FinancialType {
   /**
    * Get available Financial Types.
    *
+   * This logic is being moved into the financialacls extension.
+   *
+   * Rather than call this function consider using
+   *
+   * $types = \CRM_Contribute_BAO_Contribution::buildOptions('financial_type_id', 'search');
+   *
    * @param array $financialTypes
    *   (reference ) an array of financial types
    * @param int|string $action

--- a/CRM/Report/Form/Contribute/Bookkeeping.php
+++ b/CRM/Report/Form/Contribute/Bookkeeping.php
@@ -245,7 +245,7 @@ class CRM_Report_Form_Contribute_Bookkeeping extends CRM_Report_Form {
             'title' => ts('Financial Type'),
             'type' => CRM_Utils_Type::T_INT,
             'operatorType' => CRM_Report_Form::OP_MULTISELECT,
-            'options' => CRM_Financial_BAO_FinancialType::getAvailableFinancialTypes(),
+            'options' => CRM_Contribute_BAO_Contribution::buildOptions('financial_type_id', 'search'),
           ],
         ],
         'order_bys' => [

--- a/CRM/Report/Form/Contribute/Detail.php
+++ b/CRM/Report/Form/Contribute/Detail.php
@@ -205,7 +205,7 @@ class CRM_Report_Form_Contribute_Detail extends CRM_Report_Form {
             'financial_type_id' => [
               'title' => ts('Financial Type'),
               'operatorType' => CRM_Report_Form::OP_MULTISELECT,
-              'options' => CRM_Financial_BAO_FinancialType::getAvailableFinancialTypes(),
+              'options' => CRM_Contribute_BAO_Contribution::buildOptions('financial_type_id', 'search'),
               'type' => CRM_Utils_Type::T_INT,
             ],
             'contribution_page_id' => [

--- a/CRM/Report/Form/Contribute/Lybunt.php
+++ b/CRM/Report/Form/Contribute/Lybunt.php
@@ -205,7 +205,7 @@ class CRM_Report_Form_Contribute_Lybunt extends CRM_Report_Form {
             'title' => ts('Financial Type'),
             'type' => CRM_Utils_Type::T_INT,
             'operatorType' => CRM_Report_Form::OP_MULTISELECT,
-            'options' => CRM_Financial_BAO_FinancialType::getAvailableFinancialTypes(),
+            'options' => CRM_Contribute_BAO_Contribution::buildOptions('financial_type_id', 'search'),
           ],
           'contribution_status_id' => [
             'title' => ts('Contribution Status'),

--- a/CRM/Report/Form/Contribute/Recur.php
+++ b/CRM/Report/Form/Contribute/Recur.php
@@ -185,7 +185,7 @@ class CRM_Report_Form_Contribute_Recur extends CRM_Report_Form {
           'financial_type_id' => [
             'title' => ts('Financial Type'),
             'operatorType' => CRM_Report_Form::OP_MULTISELECT,
-            'options' => CRM_Financial_BAO_FinancialType::getAvailableFinancialTypes(),
+            'options' => CRM_Contribute_BAO_Contribution::buildOptions('financial_type_id', 'search'),
             'type' => CRM_Utils_Type::T_INT,
           ],
           'frequency_unit' => [

--- a/CRM/Report/Form/Contribute/Repeat.php
+++ b/CRM/Report/Form/Contribute/Repeat.php
@@ -220,7 +220,7 @@ class CRM_Report_Form_Contribute_Repeat extends CRM_Report_Form {
             'title' => ts('Financial Type'),
             'type' => CRM_Utils_Type::T_INT,
             'operatorType' => CRM_Report_Form::OP_MULTISELECT,
-            'options' => CRM_Financial_BAO_FinancialType::getAvailableFinancialTypes(),
+            'options' => CRM_Contribute_BAO_Contribution::buildOptions('financial_type_id', 'search'),
           ),
           'contribution_status_id' => array(
             'title' => ts('Contribution Status'),

--- a/CRM/Report/Form/Contribute/SoftCredit.php
+++ b/CRM/Report/Form/Contribute/SoftCredit.php
@@ -206,7 +206,7 @@ class CRM_Report_Form_Contribute_SoftCredit extends CRM_Report_Form {
             'title' => ts('Financial Type'),
             'type' => CRM_Utils_Type::T_INT,
             'operatorType' => CRM_Report_Form::OP_MULTISELECT,
-            'options' => CRM_Financial_BAO_FinancialType::getAvailableFinancialTypes(),
+            'options' => CRM_Contribute_BAO_Contribution::buildOptions('financial_type_id', 'search'),
           ],
         ],
         'grouping' => 'softcredit-fields',

--- a/CRM/Report/Form/Contribute/Summary.php
+++ b/CRM/Report/Form/Contribute/Summary.php
@@ -171,7 +171,7 @@ class CRM_Report_Form_Contribute_Summary extends CRM_Report_Form {
           'financial_type_id' => [
             'title' => ts('Financial Type'),
             'operatorType' => CRM_Report_Form::OP_MULTISELECT,
-            'options' => CRM_Financial_BAO_FinancialType::getAvailableFinancialTypes(),
+            'options' => CRM_Contribute_BAO_Contribution::buildOptions('financial_type_id', 'search'),
             'type' => CRM_Utils_Type::T_INT,
           ],
           'contribution_page_id' => [

--- a/CRM/Report/Form/Contribute/Sybunt.php
+++ b/CRM/Report/Form/Contribute/Sybunt.php
@@ -209,7 +209,7 @@ class CRM_Report_Form_Contribute_Sybunt extends CRM_Report_Form {
             'title' => ts('Financial Type'),
             'type' => CRM_Utils_Type::T_INT,
             'operatorType' => CRM_Report_Form::OP_MULTISELECT,
-            'options' => CRM_Financial_BAO_FinancialType::getAvailableFinancialTypes(),
+            'options' => CRM_Contribute_BAO_Contribution::buildOptions('financial_type_id', 'search'),
           ],
           'contribution_status_id' => [
             'title' => ts('Contribution Status'),

--- a/CRM/Report/Form/Contribute/TopDonor.php
+++ b/CRM/Report/Form/Contribute/TopDonor.php
@@ -135,7 +135,7 @@ class CRM_Report_Form_Contribute_TopDonor extends CRM_Report_Form {
             'title' => ts('Financial Type'),
             'type' => CRM_Utils_Type::T_INT,
             'operatorType' => CRM_Report_Form::OP_MULTISELECT,
-            'options' => CRM_Financial_BAO_FinancialType::getAvailableFinancialTypes(),
+            'options' => CRM_Contribute_BAO_Contribution::buildOptions('financial_type_id', 'search'),
           ],
           'contribution_status_id' => [
             'title' => ts('Contribution Status'),

--- a/ext/financialacls/tests/phpunit/Civi/Financialacls/OptionsTest.php
+++ b/ext/financialacls/tests/phpunit/Civi/Financialacls/OptionsTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Civi\Financialacls;
+
+// I fought the Autoloader and the autoloader won.
+require_once 'BaseTestClass.php';
+
+/**
+ * @group headless
+ */
+class OptionsTest extends BaseTestClass {
+
+  /**
+   * Test buildMembershipTypes.
+   */
+  public function testBuildOptions() {
+    $this->setupLoggedInUserWithLimitedFinancialTypeAccess();
+    $options = \CRM_Financial_BAO_FinancialType::getAvailableFinancialTypes();
+    $this->assertEquals(['Donation'], array_merge($options));
+    $builtOptions = \CRM_Contribute_BAO_Contribution::buildOptions('financial_type_id', 'search');
+    $this->assertEquals(['Donation'], array_merge($builtOptions));
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Builds on https://github.com/civicrm/civicrm-core/pull/18848 & should be rebased once that is merged

Before
----------------------------------------
Use of specific function
```
 'options' => CRM_Financial_BAO_FinancialType::getAvailableFinancialTypes(),
```

After
----------------------------------------
Generic function with hook
```
 'options' =>  CRM_Contribute_BAO_Contribution::buildOptions('financial_type_id', 'search'),
```

Technical Details
----------------------------------------


Comments
----------------------------------------

