### PR TITLE
dev/core#2142 Adds performance improvement when browsing the report logs

### DIFF
--- a/templates/CRM/Report/Form/Layout/Overlay.tpl
+++ b/templates/CRM/Report/Form/Layout/Overlay.tpl
@@ -86,7 +86,11 @@
                             <a title="{$row.$fieldHover|escape}" href="{$row.$fieldLink}" {$row.$fieldClass}>
                         {/if}
 
-                        {if $row.$field eq 'Subtotal'}
+                        {if is_array($row.$field)}
+                            {foreach from=$row.$field item=fieldrow key=fieldid}
+                                <div class="crm-report-{$field}-row-{$fieldid}">{$fieldrow}</div>
+                            {/foreach}
+                        {elseif $row.$field eq 'Subtotal'}
                             {$row.$field}
                         {elseif $header.type & 4 OR $header.type & 256}
                             {if $header.group_by eq 'MONTH' or $header.group_by eq 'QUARTER'}

--- a/templates/CRM/Report/Form/Layout/Table.tpl
+++ b/templates/CRM/Report/Form/Layout/Table.tpl
@@ -100,7 +100,11 @@
                             <a title="{$row.$fieldHover|escape}" href="{$row.$fieldLink}"  {if $row.$fieldClass} class="{$row.$fieldClass}"{/if}>
                         {/if}
 
-                        {if $row.$field eq 'Subtotal'}
+                        {if is_array($row.$field)}
+                            {foreach from=$row.$field item=fieldrow key=fieldid}
+                                <div class="crm-report-{$field}-row-{$fieldid}">{$fieldrow}</div>
+                            {/foreach}
+                        {elseif $row.$field eq 'Subtotal'}
                             {$row.$field}
                         {elseif $header.type & 4 OR $header.type & 256}
                             {if $header.group_by eq 'MONTH' or $header.group_by eq 'QUARTER'}


### PR DESCRIPTION
Overview
----------------------------------------
This issue relates to a discussion we had in CiviCRM Dev channel where it was being identified that when we got advanced logging and a contact triggered batch updates/changes, the detailed report most of the time does not work due to extremely long delays. More info [on issue 2142](https://lab.civicrm.org/dev/core/-/issues/2142)

Before
----------------------------------------
If the records associated are too many, the report will never finish in a timely manner and produce a timeout.

After
----------------------------------------
* Report renders properly again by:
* Showing a list of first x records
* Optionally, rendering a pager for review

Technical Details
----------------------------------------
Adds `LIMIT` & `OFFSET` to the query inside function `getAllChangesForConnection` to support limit & offset of the rendering rows when displaying in report `CRM_Logging_ReportDetail`

Comments
----------------------------------------
All comments are on https://lab.civicrm.org/dev/core/-/issues/2142

