### PR TITLE
dev/core#927 Move cancelling of related memberships to extension from BaseIPN

### DIFF
--- a/ext/contributioncancelactions/contributioncancelactions.php
+++ b/ext/contributioncancelactions/contributioncancelactions.php
@@ -4,16 +4,40 @@ require_once 'contributioncancelactions.civix.php';
 // phpcs:disable
 use CRM_Contributioncancelactions_ExtensionUtil as E;
 // phpcs:enable
+use Civi\Api4\LineItem;
 
 /**
  * Implements hook_civicrm_preProcess().
+ *
+ * This enacts the following
+ * - find and cancel any related pending memberships
+ * - (not yet implemented) find and cancel any related pending participant records
+ * - (not yet implemented) find any related pledge payment records. Remove the contribution id.
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_post
  */
 function contributioncancelactions_civicrm_post($op, $objectName, $objectId, $objectRef) {
   if ($op === 'edit' && $objectName === 'Contribution') {
-    if ($objectRef->contribution_status_id === CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Cancelled')) {
-      // Do the stuff.
+    if ('Cancelled' === CRM_Core_PseudoConstant::getName('CRM_Contribute_BAO_Contribution', 'contribution_status_id', $objectRef->contribution_status_id)) {
+      // Find and cancel any pending memberships.
+      $connectedMemberships = (array) LineItem::get(FALSE)->setWhere([
+        ['contribution_id', '=', $objectId],
+        ['entity_table', '=', 'civicrm_membership'],
+      ])->execute()->indexBy('entity_id');
+      if (empty($connectedMemberships)) {
+        return;
+      }
+      // @todo we don't have v4 membership api yet so v3 for now.
+      $connectedMemberships = array_keys(civicrm_api3('Membership', 'get', [
+        'status_id' => 'Pending',
+        'id' => ['IN' => array_keys($connectedMemberships)],
+      ])['values']);
+      if (empty($connectedMemberships)) {
+        return;
+      }
+      foreach ($connectedMemberships as $membershipID) {
+        civicrm_api3('Membership', 'create', ['status_id' => 'Cancelled', 'id' => $membershipID, 'is_override' => 1]);
+      }
     }
   }
 }


### PR DESCRIPTION
Overview
----------------------------------------
This moves the code to cancel memberships on a related contribution cancel to the contributioncancelactions
core extension.

Before
----------------------------------------
The cancellations are done using convoluted & elsewhere duplicated logic in BaseIPN
using convoluted input params


After
----------------------------------------
When a contribution is updated & the status_id of 'Cancelled' is set then
the hook will kick in, look for any related pending memberships and cancel them.
The test demonstrates that the api call will ensure related pending memberships
are cancelled.


Technical Details
----------------------------------------

- Note that I am using line_items table to get the membership - we have been storing this
membership_payment link there for log enough it should be reliable but if there
are remaining data issues then this is a lower risk flow to flush them out.

- Also note that once this is cleaned up I'll move to the 2 other flows I'm aware of
Order.create api & Contribution form edits

- In the meantime it won't matter if they have already cancelled the memberships as this would only kick in if they were pending

- This is in the Post hook rather than the postCommit hook which represents a behaviour no-change (ie the whole transaction will fail if this part does). This represents 'no change' and I think I'd rather do the no change version & look at changing later if there is a case made to do so

Comments
----------------------------------------

