### PR TITLE
[REF] Extract function to retrieve the membership labels.

### DIFF
--- a/tests/phpunit/CRM/Member/Form/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/Form/MembershipTest.php
@@ -676,12 +676,11 @@ class CRM_Member_Form_MembershipTest extends CiviUnitTestCase {
    * @param string $thousandSeparator
    *   punctuation used to refer to thousands.
    *
-   * @dataProvider getThousandSeparators
-   *
    * @throws \CRM_Core_Exception
    * @throws \CiviCRM_API3_Exception
+   * @dataProvider getThousandSeparators
    */
-  public function testSubmitPartialPayment($thousandSeparator) {
+  public function testSubmitPartialPayment(string $thousandSeparator): void {
     $this->setCurrencySeparators($thousandSeparator);
     // Step 1: submit a partial payment for a membership via backoffice
     $form = $this->getForm();


### PR DESCRIPTION


Overview
----------------------------------------
Rather than construct an array (membershipTypes) early on with a db lookup
and pass it around we retrieve the labels when needed using a helper function
to retrieve the values from the already-available array on membership type
details

Before
----------------------------------------
```$membershipTypes``` array is constructed in one of the many loops through ```$this->_memTypeSelected``` using a DB looking to get the label. This is then imploded into $membershipType which is used when setting the status

After
----------------------------------------
When the membership type label is required it is retrieved using a helper function. Additional DB look up not required

Technical Details
----------------------------------------
There is a test in Form_MembershipTest that checks the status includes the membership label

Comments
----------------------------------------

