### PR TITLE
[REF] Simplify membership form code towards simplifying BAO

### DIFF
--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -335,12 +335,14 @@ class CRM_Member_BAO_Membership extends CRM_Member_DAO_Membership {
     $params['skipLineItem'] = TRUE;
 
     // Record contribution for this membership and create a MembershipPayment
+    // @todo deprecate this.
     if (!empty($params['contribution_status_id']) && empty($params['relate_contribution_id'])) {
       $memInfo = array_merge($params, ['membership_id' => $membership->id]);
       $params['contribution'] = self::recordMembershipContribution($memInfo);
     }
 
     // Add/update MembershipPayment record for this membership if it is a related contribution
+    // @todo remove this - called from one remaining place in CRM_Member_Form_Membership
     if (!empty($params['relate_contribution_id'])) {
       $membershipPaymentParams = [
         'membership_id' => $membership->id,
@@ -2405,7 +2407,6 @@ WHERE {$whereClause}";
    * @throws \CiviCRM_API3_Exception
    */
   public static function recordMembershipContribution(&$params) {
-    $membershipId = $params['membership_id'];
     $contributionParams = [];
     $config = CRM_Core_Config::singleton();
     $contributionParams['currency'] = $config->defaultCurrency;
@@ -2487,7 +2488,7 @@ WHERE {$whereClause}";
     ]);
     if (empty($membershipPayment['count'])) {
       civicrm_api3('MembershipPayment', 'create', [
-        'membership_id' => $membershipId,
+        'membership_id' => $params['membership_id'],
         'contribution_id' => $contribution->id,
       ]);
     }

--- a/tests/phpunit/CRM/Member/Form/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/Form/MembershipTest.php
@@ -582,7 +582,7 @@ class CRM_Member_Form_MembershipTest extends CiviUnitTestCase {
    * @throws \CRM_Core_Exception
    * @throws \CiviCRM_API3_Exception
    */
-  public function testContributionUpdateOnMembershipTypeChange() {
+  public function testContributionUpdateOnMembershipTypeChange(): void {
     // Step 1: Create a Membership via backoffice whose with 50.00 payment
     $form = $this->getForm();
     $form->preProcess();
@@ -647,9 +647,7 @@ class CRM_Member_Form_MembershipTest extends CiviUnitTestCase {
       'end_date' => '',
       // This format reflects the first number being the organisation & the 25 being the type.
       'membership_type_id' => [$this->ids['contact']['organization'], $secondMembershipType['id']],
-      'record_contribution' => 1,
       'status_id' => 1,
-      'total_amount' => 25,
       'receive_date' => date('Y-m-d', time()) . ' 20:36:00',
       'payment_instrument_id' => array_search('Check', $this->paymentInstruments),
       //Member dues, see data.xml
@@ -668,7 +666,7 @@ class CRM_Member_Form_MembershipTest extends CiviUnitTestCase {
     $this->assertEquals('Pending refund', $contribution['contribution_status']);
     // Earlier paid amount
     $this->assertEquals(50, $payment['paid']);
-    // balance remaning
+    // balance remaining
     $this->assertEquals(-25, $payment['balance']);
   }
 
@@ -1098,6 +1096,8 @@ Expires: ',
       $this->assertEquals($contributionResult['values'][0]['id'], $membershipPayment['contribution_id'], "membership payment's contribution ID should be the ID of the organization's membership contribution.");
       $this->assertContains($membershipPayment['membership_id'], $primaryMembershipIds, "membership payment's membership ID should be the ID of a primary membership.");
     }
+    // Check for orphan line items.
+    $this->callAPISuccessGetCount('LineItem', [], 2);
 
     // CRM-20966: check that deleting relationship used for inheritance does not delete contribution.
     $this->callAPISuccess('relationship', 'delete', [


### PR DESCRIPTION

Overview
----------------------------------------
[REF] Simplify membership form code towards simplifying BAO. This is one of 2 places where this odd pattern occurs (thanks Copy & Paste) & once both are gone we can strip the handling of 'relate_contribution_id' from the BAO & potentially deprecate handling of contribution_status_id from the Membership.create BAO function

Before
----------------------------------------
Both membership form AND Membership BAO tie themselves in knots trying to handle multiple line items on the Membership Form. The contribution is created after the first membership is created but before the second is created. The logic for the second them requires the form to figure out the contribution and pass a magic param to the BAO

After
----------------------------------------
Membership form handles the multiple line items itself, waiting until both memberships are created and then creating the contribution. 

Technical Details
----------------------------------------
On digging into the handling for the param relate_contribution_id in the BAO I found it is called
only from the membership form & it's really a hack for the way price sets were super-imposed on the form.



What is happening is that if there are 2 memberships in a price set Membership.create is called twice.

However, because the parameter contribution_status_id is passed in it attempts to create the contribution
twice. If we don't add this the second time then we wind up with the second membership payment not created
because that membership didn't exist the first round. So, an extra param relate_contribution_id got
added which says 'if this is passed in create the MembershipPayment record that didn't get created
the first time with the contribution id that we just did a lookup on.

All of this is needed because we create the contribution between the first Membership create
and the second. This removes both magic params from the create, and instead calls
recordMembershipContribution after both are done. I thought about calling Order.create or
just Contribution.create here but there is stuff to unravel around the soft credit creation
being done in RecordMembershipContribution and I am not yet clear if tests are adequate there

Comments
----------------------------------------
@monishdeb @pradpnayak I think I will need some combination of you 2 to work through his one.

This has really solid testing in testTwoInheritedMembershipsViaPriceSetInBackend (Thanks @davejenx)
and stepping through there is the best way to make sense of it.
