### PR TITLE
dev/core#2132 Fix for sort on search results

### DIFF
--- a/CRM/Contact/Selector.php
+++ b/CRM/Contact/Selector.php
@@ -1018,6 +1018,8 @@ class CRM_Contact_Selector extends CRM_Core_Selector_Base implements CRM_Core_Se
    */
   public function fillupPrevNextCache($sort, $cacheKey, $start = 0, $end = self::CACHE_SIZE) {
     $coreSearch = TRUE;
+    // This ensures exceptions are caught in the try-catch.
+    $handling = CRM_Core_TemporaryErrorScope::useException();
     // For custom searches, use the contactIDs method
     if (is_a($this, 'CRM_Contact_Selector_Custom')) {
       $sql = $this->_search->contactIDs($start, $end, $sort, TRUE);
@@ -1046,7 +1048,7 @@ class CRM_Contact_Selector extends CRM_Core_Selector_Base implements CRM_Core_Se
     try {
       Civi::service('prevnext')->fillWithSql($cacheKey, $sql);
     }
-    catch (CRM_Core_Exception $e) {
+    catch (\Exception $e) {
       if ($coreSearch) {
         // in the case of error, try rebuilding cache using full sql which is used for search selector display
         // this fixes the bugs reported in CRM-13996 & CRM-14438


### PR DESCRIPTION
Overview
----------------------------------------
Alternate to https://github.com/civicrm/civicrm-core/pull/18824

Simpler fix - accept bad sql but ensure the error is catchable



Before
----------------------------------------
Fatal error on sorting basic search results by post code

After
----------------------------------------
works

Technical Details
----------------------------------------
Ideally we would always be in exception mode but it seems that has been the goal since 4.2 & we still aren't

Comments
----------------------------------------
