### PR TITLE
dev/core#2143 Fix error caused by trying to populate prev next cache …

### DIFF
--- a/CRM/Contact/Selector.php
+++ b/CRM/Contact/Selector.php
@@ -1020,6 +1020,9 @@ class CRM_Contact_Selector extends CRM_Core_Selector_Base implements CRM_Core_Se
     $coreSearch = TRUE;
     // For custom searches, use the contactIDs method
     if (is_a($this, 'CRM_Contact_Selector_Custom')) {
+      if (is_a($this->_search, 'CRM_Contact_Form_Search_Custom_EventAggregate')) {
+        return;
+      }
       $sql = $this->_search->contactIDs($start, $end, $sort, TRUE);
       $coreSearch = FALSE;
     }


### PR DESCRIPTION
…on the event aggregate custom search

Overview
----------------------------------------
This prevents a fatal error executing the Event Aggregate custom search by preventing the prev_next_cache from being populated. 

Before
----------------------------------------
Fatal Error running the event aggregate custom search

After
----------------------------------------
No fatal error

Technical Details
----------------------------------------
I have chosen to just ignore the population here which I think is the right thing to do but I could also see an argument for trying to fix the query so that entity_id1 is the event_ids etc

ping @eileenmcnaughton @demeritcowboy @spalmstr 