### PR TITLE
APIv4 - Fix type coersion of non-string input

### DIFF
--- a/Civi/Api4/Utils/FormattingUtil.php
+++ b/Civi/Api4/Utils/FormattingUtil.php
@@ -124,7 +124,7 @@ class FormattingUtil {
     }
 
     $hic = \CRM_Utils_API_HTMLInputCoder::singleton();
-    if (!$hic->isSkippedField($fieldSpec['name'])) {
+    if (!$hic->isSkippedField($fieldSpec['name']) && is_string($value)) {
       $value = $hic->encodeValue($value);
     }
   }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes APIv4 to not accidentally change non-string input to string.

Before
----------------------------------------
Non-string input treated as string, causing incorrect data type to be saved.

After
----------------------------------------
Only run html encoder on strings; it doesn't apply to other data types.
