### PR TITLE
dev/core#2148 - Incorrect use of ts, quotes, escape in log call

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -758,8 +758,9 @@ class CRM_Core_DAO extends DB_DataObject {
         else {
           $maxLength = $field['maxlength'] ?? NULL;
           if (!is_array($value) && $maxLength && mb_strlen($value) > $maxLength && empty($field['pseudoconstant'])) {
-            Civi::log()->warning(ts('A string for field $dbName has been truncated. The original string was %1', [CRM_Utils_Type::escape($value, 'String')]));
-            // The string is too long - what to do what to do? Well losing data is generally bad so lets' truncate
+            // No ts() since this is a sysadmin-y string not seen by general users.
+            Civi::log()->warning('A string for field {dbName} has been truncated. The original string was {value}.', ['dbName' => $dbName, 'value' => $value]);
+            // The string is too long - what to do what to do? Well losing data is generally bad so let's truncate
             $value = CRM_Utils_String::ellipsify($value, $maxLength);
           }
           $this->$dbName = $value;


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/2148

* It's a sysadmin-y string not seen by end users, so ts() usually isn't used on those.
* It uses a variable inside the ts.
* The variable gets output as the literal `$dbName` instead of the value because the string uses single quotes.
* CRM_Utils_Type::escape is misused here. What it does when called on a string is escapes it for insertion into a SQL string. The default logger writes to a file. Even if the logger implemention/configuration ended up writing to a database, it should be that log implementation that escapes it at insertion time, not here. And for displaying on screen, it should be sanitized at display time (using a different method than CRM_Utils_Type::escape since it's not meant for screen).

Before
----------------------------------------
Well, the main functional problem is that it doesn't tell you what field it's talking about. It just literally calls it `$dbName`.

After
----------------------------------------
Better

Technical Details
----------------------------------------


Comments
----------------------------------------

