### PR TITLE
Add test for sort_name, display_name consistency

### DIFF
--- a/tests/phpunit/api/v3/ContactTest.php
+++ b/tests/phpunit/api/v3/ContactTest.php
@@ -1588,10 +1588,16 @@ class api_v3_ContactTest extends CiviUnitTestCase {
    */
   public function testCreateIndividualWithJustEmail($version) {
     $this->_apiversion = $version;
-    $params = [
-      'contact_type' => 'Individual',
-      'email' => 'garlic@example.com',
-    ];
+    $params = ['contact_type' => 'Individual'];
+    if ($version == 3) {
+      $params['email'] = 'garlic@example.com';
+    }
+    else {
+      $params['api.Email.create'] = [
+        'location_type_id' => CRM_Core_BAO_LocationType::getDefault()->id,
+        'email' => 'garlic@example.com',
+      ];
+    }
 
     $contact = $this->callAPISuccess('contact', 'create', $params);
     $created = Contact::get(FALSE)->addWhere('id', '=', $contact['id'])->addSelect('sort_name', 'display_name')->execute()->first();


### PR DESCRIPTION
Overview
----------------------------------------
Adds a test for an api3 vs 4 anomaly - test expected to fail - fix to be discussed

Before
----------------------------------------
No test

After
----------------------------------------
Test

Technical Details
----------------------------------------
@colemanw what this demonstrates is that if you create an individual knowing just the email in v3 the contact create will take
```
civicrm_api3('Contact', 'create', ['contact_type' => 'Individual', 'email' => 'coleman@example.org']);

```

And populate sort_name & display_name with those. For apiv4 it doesn't which I think needs some form of redress - since I don't think any currently recommended apiv4 pattern does.

The code doing it for apiv3 is in 2 places (both nasty)
1) in the api- - format for the other place https://github.com/civicrm/civicrm-core/blob/c3cea83f4e1f624d698d70a6ee943a655ee3be5f/api/v3/Contact.php#L58
2) in the BAO use the secret code formatting to do magic https://github.com/civicrm/civicrm-core/blob/dcb148082af818050ec0d9c56b04acd37967b34c/CRM/Contact/BAO/Individual.php#L213


Comments
----------------------------------------

