### PR TITLE
Set Smarty variables for the Campaign assigned to the Contribution which can then be used in Contribution Receipts

### DIFF
--- a/CRM/Contribute/BAO/ContributionPage.php
+++ b/CRM/Contribute/BAO/ContributionPage.php
@@ -333,6 +333,23 @@ class CRM_Contribute_BAO_ContributionPage extends CRM_Contribute_DAO_Contributio
 
       $title = $values['title'] ?? CRM_Contribute_BAO_Contribution_Utils::getContributionPageTitle($values['contribution_page_id']);
 
+      // Some workflows do not set the Campaign ID, so get it from the contribution.
+      if(!isset($values['campaign_id'])) {
+        $values['campaign_id'] = CRM_Core_DAO::getFieldValue('CRM_Contribute_BAO_Contribution', $values['contribution_id'], 'campaign_id');
+      }
+
+      // Look up related Campaign and set Campaign variables, if Campaign ID is set
+      if ($values['campaign_id']) {
+        $campaign = new CRM_Campaign_BAO_Campaign();
+        $campaign->id = $values['campaign_id'];
+
+        if ($campaign->find(TRUE)) {
+          $campaignTitle = $campaign->title;
+          $campaignDescription = $campaign->description;
+          $campaignGoals = $campaign->goal_general;
+        }
+      }
+
       // Set email variables explicitly to avoid leaky smarty variables.
       // All of these will be assigned to the template, replacing any that might be assigned elsewhere.
       $tplParams = [
@@ -361,6 +378,10 @@ class CRM_Contribute_BAO_ContributionPage extends CRM_Contribute_DAO_Contributio
         'pay_later_receipt' => $values['pay_later_receipt'] ?? NULL,
         'honor_block_is_active' => $values['honor_block_is_active'] ?? NULL,
         'contributionStatus' => $values['contribution_status'] ?? NULL,
+        'campaignID' => $values['campaign_id'] ?? NULL,
+        'campaignTitle' => $campaignTitle ?? NULL,
+        'campaignDescription' => $campaignDescription ?? NULL,
+        'campaignGoals' => $campaignGoals ?? NULL,
       ];
 
       if ($contributionTypeId = CRM_Utils_Array::value('financial_type_id', $values)) {


### PR DESCRIPTION
Set Smarty variables for the Campaign assigned to the Contribution which can then be used in Contribution Receipts

Overview
----------------------------------------
Currently, there are no Smarty variables available for the Campaign assigned to the Contribution. Which makes it difficult to customise the Contribution Receipt Text to include Campaign details without knowing how to use the CiviCRM API and custom Smarty programming.

Other people have requested the ability to refer to details from the Campaign, see below:
https://civicrm.stackexchange.com/questions/30935/how-to-add-campaign-token-in-system-contribution-receipt
https://civicrm.stackexchange.com/questions/15955/how-to-use-campaign-id-as-a-token-in-contribution-invoice-email-receipt-templa
https://civicrm.stackexchange.com/questions/27879/adding-contribution-campaign-to-the-invoice-template

Before
----------------------------------------
No Campaign variables available.

After
----------------------------------------
The following Campaign variables are now available:
{campaignID} = Campaign ID
{campaignTitle} = Campaign Title
{campaignDescription} = Campaign Description
{campaignGoals} = Campaign Goals

Technical Details
----------------------------------------
None.

Comments
----------------------------------------
This saves people from trying to program using Smarty and will no doubt, if accepted, save many lives.

Agileware Ref: CIVICRM-1591