### PR TITLE
Show only Active SMS provider List on Mass SMS form

### DIFF
--- a/CRM/SMS/Form/Group.php
+++ b/CRM/SMS/Form/Group.php
@@ -97,7 +97,7 @@ class CRM_SMS_Form_Group extends CRM_Contact_Form_Task {
 
     $this->add('select', 'sms_provider_id',
       ts('Select SMS Provider'),
-      CRM_Utils_Array::collect('title', CRM_SMS_BAO_Provider::getProviders()),
+      CRM_Utils_Array::collect('title', CRM_SMS_BAO_Provider::getProviders(NULL, ['is_active' => 1])),
       TRUE
     );
 


### PR DESCRIPTION
Overview
----------------------------------------
Show only Active SMS Provider List on Mass SMS Form

Before
----------------------------------------
All SMS provider List were available on Mass SMS form

After
----------------------------------------
only Active SMS provider List were available on Mass SMS form 

<img width="839" alt="Screenshot 2020-10-28 at 1 26 04 PM" src="https://user-images.githubusercontent.com/377735/97407922-6986f700-1921-11eb-9abb-f2a8a35083a1.png">
<img width="596" alt="Screenshot 2020-10-28 at 1 26 21 PM" src="https://user-images.githubusercontent.com/377735/97407941-6c81e780-1921-11eb-86bf-2227afa17a46.png">
