### PR TITLE
get log date from tables available in query with data instead of last table

### DIFF
--- a/CRM/Logging/Differ.php
+++ b/CRM/Logging/Differ.php
@@ -420,7 +420,8 @@ ORDER BY log_date
     $dao = CRM_Core_DAO::executeQuery($sql, $params);
     while ($dao->fetch()) {
       if (empty($this->log_date)) {
-        $this->log_date = CRM_Core_DAO::singleValueQuery("SELECT log_date FROM {$this->db}.log_{$table} WHERE log_conn_id = %1 LIMIT 1", $params);
+        // look for available table in above query instead of looking for last table. this will avoid multiple loops
+        $this->log_date = CRM_Core_DAO::singleValueQuery("SELECT log_date FROM {$this->db}.log_{$dao->table_name} WHERE log_conn_id = %1 LIMIT 1", $params);
       }
       $diffs = array_merge($diffs, $this->diffsInTableForId($dao->table_name, $dao->id));
     }


### PR DESCRIPTION
Overview
----------------------------------------

When Logging feature is enabled and CiviCRM have Millions of records for contact, membership, contribution , entity tag, custom fields etc..., so in log tables, each contact have thousand of change log entries.

When we visit contact `Change Log` tab and mouse over the update icon, civicrm will send log connection id to report to find out the difference.

CiviCRM collect all tables having reference with civicrm_contact tables. In this list, last tables is [civicrm_entity_tag](https://github.com/civicrm/civicrm-core/blob/1b3947b3d71c2f62ef69d2def8030650be22ff47/CRM/Logging/Schema.php#L1056)

To to fetch the log date value, civicrm uses last table `civicrm_entity_tag`, but there are possibility that, change log may not exist for that contact using specific connection id, but to find out  value, civicrm iterate entire table with out result.  

Then ultimately , either we get no log change or database error or server timeout. 

Instead of checking last table values, we should get table from [Query we prepared with all table using union](https://github.com/civicrm/civicrm-core/blob/1b3947b3d71c2f62ef69d2def8030650be22ff47/CRM/Logging/Differ.php#L416)
```
$tables = Array
(
    [0] => civicrm_contact
    [2] => civicrm_batch
    [4] => civicrm_financial_account
    [5] => civicrm_financial_item
    [6] => civicrm_campaign
    [7] => civicrm_survey
    [8] => civicrm_event_carts
    [9] => civicrm_dedupe_exception
    [10] => civicrm_grant
    [11] => civicrm_pcp
    [12] => civicrm_custom_group
    [13] => civicrm_domain
    [14] => civicrm_email
    [15] => civicrm_file
    [16] => civicrm_im
    [18] => civicrm_note
    [19] => civicrm_phone
    [20] => civicrm_tag
    [21] => civicrm_uf_match
    [22] => civicrm_openid
    [23] => civicrm_website
    [24] => civicrm_setting
    [25] => civicrm_print_label
    [27] => civicrm_group
    [28] => civicrm_subscription_history
    [30] => civicrm_group_organization
    [32] => civicrm_contribution_page
    [57] => civicrm_account_contact
    [58] => civicrm_stripe_paymentintent
    [59] => civicrm_value_summary_field_7
    [66] => civicrm_entity_tag
)
```

Before
----------------------------------------
log date were get from `civicrm_entity_tag` table only

After
----------------------------------------
Now log date get from `civicrm_contact` first, if not found , then next table get used.

