### PR TITLE
ClassLoader - Fix autoloading of `API_Exception`

### DIFF
--- a/CRM/Core/ClassLoader.php
+++ b/CRM/Core/ClassLoader.php
@@ -198,7 +198,7 @@ class CRM_Core_ClassLoader {
    * @param $class
    */
   public function loadClass($class) {
-    if ($class === 'CiviCRM_API3_Exception') {
+    if ($class === 'CiviCRM_API3_Exception' || $class === 'API_Exception') {
       //call internal error class api/Exception first
       // allow api/Exception class call external error class
       // CiviCRM_API3_Exception


### PR DESCRIPTION
Overview
----------------------------------------

When improvising requests to APIv4 (e.g. `cv ev 'Civi\Api4\...'`), I've occasionally hit cases where:

1. There's a problem in my initial request (e.g. insufficient access). Fair enough.
2. So it tries to raise `API_Exception`
3. But the class `API_Exception` isn't available, so instead it raises an error about `API_Exception`.

I haven't kept notes about these, but it seems almost immaterial - absent some strong/niche reason, we should have autoloading for all classes. 

Before
----------------------------------------

The class `API_Exception` does not do auto-loading. The file `api/Exception.php` must be explicitly loaded by some means.

After
----------------------------------------

If the class `API_Exception` is needed, then `api/Exception.php` will autoload.
