### PR TITLE
APIv4 - Add `$result->single()` helper

### DIFF
--- a/Civi/Api4/Generic/Result.php
+++ b/Civi/Api4/Generic/Result.php
@@ -68,6 +68,32 @@ class Result extends \ArrayObject implements \JsonSerializable {
   }
 
   /**
+   * Return the one-and-only result record.
+   *
+   * If there are too many or too few results, then throw an exception.
+   *
+   * @return array
+   * @throws \API_Exception
+   */
+  public function single() {
+    $result = NULL;
+    foreach ($this as $values) {
+      if ($result === NULL) {
+        $result = $values;
+      }
+      else {
+        throw new \API_Exception("Expected to find one {$this->entity} record, but there were multiple.");
+      }
+    }
+
+    if ($result === NULL) {
+      throw new \API_Exception("Expected to find one {$this->entity} record, but there were zero.");
+    }
+
+    return $result;
+  }
+
+  /**
    * @param int $index
    * @return array|null
    */

--- a/tests/phpunit/api/v4/Action/ContactGetTest.php
+++ b/tests/phpunit/api/v4/Action/ContactGetTest.php
@@ -88,6 +88,16 @@ class ContactGetTest extends \api\v4\UnitTestCase {
     $limit2 = Contact::get(FALSE)->setLimit(2)->addSelect('sort_name', 'row_count')->execute();
     $this->assertCount(2, (array) $limit2);
     $this->assertCount($num, $limit2);
+    try {
+      $limit2->single();
+    }
+    catch (\API_Exception $e) {
+      $this->assertRegExp(';Expected to find one Contact record;', $e->getMessage());
+    }
+    $limit1 = Contact::get(FALSE)->setLimit(1)->execute();
+    $this->assertCount(1, (array) $limit1);
+    $this->assertCount(1, $limit1);
+    $this->assertTrue(!empty($limit1->single()['sort_name']));
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------

This is a developer-experience improvement for the common case where one uses APIv4 to work with *exactly* one record  (e.g. because having fewer or more records indicates a violation of a pre-condition).

Before
----------------------------------------

I have found myself writing this guard several times:

```php
$result = civicrm_api4('Foo', 'bar', [
  'whiz' => 123,
  'bang' => 456,
]);
if ($result->count() !== 1) {
  throw new Exception(sprintf("This operation is defined for exactly one result. Found %d records.", 
    $result->count()));
}
$record = $result->first();
```

Note that the `Result` object has a `first()` method, which you could call fluently. That would be clean/pretty. However, this is a soft method which does not complain if there are zero or multiple records.

After
----------------------------------------

If the situation calls for exactly one record, then use `single()`:

```php
$record = civicrm_api4('Foo', 'bar', [
  'whiz' => 123,
  'bang' => 456,
])->single();
```
