### PR TITLE
dev/core#2150 Re-enact the recapture validation by validating the res…

### DIFF
--- a/CRM/Utils/ReCAPTCHA.php
+++ b/CRM/Utils/ReCAPTCHA.php
@@ -96,6 +96,7 @@ class CRM_Utils_ReCAPTCHA {
       TRUE
     );
     $form->registerRule('recaptcha', 'callback', 'validate', 'CRM_Utils_ReCAPTCHA');
+    $form->addRule('g-recaptcha-response', ts('Please go back and complete the CAPTCHA at the bottom of this form.'), 'recaptcha');
     if ($form->isSubmitted() && empty($form->_submitValues['g-recaptcha-response'])) {
       $form->setElementError(
         'g-recaptcha-response',
@@ -115,6 +116,20 @@ class CRM_Utils_ReCAPTCHA {
       $captcha->add($form);
       $form->assign('isCaptcha', TRUE);
     }
+  }
+
+  /**
+   * @param $value
+   * @param CRM_Core_Form $form
+   *
+   * @return mixed
+   */
+  public static function validate($value, $form) {
+    $resp = recaptcha_check_answer(CRM_Core_Config::singleton()->recaptchaPrivateKey,
+      $_SERVER['REMOTE_ADDR'],
+      $_POST['g-recaptcha-response']
+    );
+    return $resp->is_valid;
   }
 
 }


### PR DESCRIPTION
…ponse token on recapture

Overview
----------------------------------------
As per the lab ticket https://lab.civicrm.org/dev/core/-/issues/2150 this re-enables actual validation of the recapture response token from google to verify it is a valid submission for this to work it requires this PR https://github.com/civicrm/civicrm-packages/pull/311/files as well

Before
----------------------------------------
No validation checking of the v2 response token

After
----------------------------------------
Validation of the v2 response token

ping @johntwyman @mattwire @MikeyMJCO @eileenmcnaughton @agileware-justin @andrew-cormick-dockery 