### PR TITLE
APIv4 - Fix nonstandard camelCase of title_plural field

### DIFF
--- a/Civi/Api4/Action/Entity/Get.php
+++ b/Civi/Api4/Action/Entity/Get.php
@@ -96,8 +96,8 @@ class Get extends \Civi\Api4\Generic\BasicGetAction {
       $entities[$fieldName] = [
         'name' => $fieldName,
         'title' => $customEntity['title'],
-        'titlePlural' => $customEntity['title'],
-        'description' => ts('Custom group for %1', [1 => $baseEntity::getInfo()['titlePlural']]),
+        'title_plural' => $customEntity['title'],
+        'description' => ts('Custom group for %1', [1 => $baseEntity::getInfo()['title_plural']]),
         'see' => [
           'https://docs.civicrm.org/user/en/latest/organising-your-data/creating-custom-fields/#multiple-record-fieldsets',
           '\\Civi\\Api4\\CustomGroup',

--- a/Civi/Api4/Entity.php
+++ b/Civi/Api4/Entity.php
@@ -50,7 +50,11 @@ class Entity extends Generic\AbstractEntity {
         ],
         [
           'name' => 'title',
-          'description' => 'Localized title',
+          'description' => 'Localized title (singular)',
+        ],
+        [
+          'name' => 'title_plural',
+          'description' => 'Localized title (plural)',
         ],
         [
           'name' => 'type',

--- a/Civi/Api4/Generic/AbstractEntity.php
+++ b/Civi/Api4/Generic/AbstractEntity.php
@@ -123,7 +123,7 @@ abstract class AbstractEntity {
     $info = [
       'name' => static::getEntityName(),
       'title' => static::getEntityTitle(),
-      'titlePlural' => static::getEntityTitle(TRUE),
+      'title_plural' => static::getEntityTitle(TRUE),
       'type' => self::stripNamespace(get_parent_class(static::class)),
     ];
     $reflection = new \ReflectionClass(static::class);

--- a/ext/search/CRM/Search/Page/Ang.php
+++ b/ext/search/CRM/Search/Page/Ang.php
@@ -84,9 +84,9 @@ class CRM_Search_Page_Ang extends CRM_Core_Page {
    */
   private function getSchema() {
     $schema = \Civi\Api4\Entity::get()
-      ->addSelect('name', 'title', 'titlePlural', 'description', 'icon')
+      ->addSelect('name', 'title', 'title_plural', 'description', 'icon')
       ->addWhere('name', '!=', 'Entity')
-      ->addOrderBy('titlePlural')
+      ->addOrderBy('title_plural')
       ->setChain([
         'get' => ['$name', 'getActions', ['where' => [['name', '=', 'get']]], ['params']],
       ])->execute();

--- a/ext/search/ang/search/SaveSmartGroup.ctrl.js
+++ b/ext/search/ang/search/SaveSmartGroup.ctrl.js
@@ -28,7 +28,7 @@
         if ((entityName === 'Contact' && field.name === 'id') || field.fk_entity === 'Contact') {
           columns.push({
             id: prefix + field.name,
-            text: entity.titlePlural + (entityCount[entityName] ? ' ' + entityCount[entityName] : '') + ': ' + field.label,
+            text: entity.title_plural + (entityCount[entityName] ? ' ' + entityCount[entityName] : '') + ': ' + field.label,
             icon: entity.icon
           });
         }

--- a/ext/search/ang/search/crmSearch.component.js
+++ b/ext/search/ang/search/crmSearch.component.js
@@ -27,7 +27,7 @@
 
       $scope.controls = {};
       $scope.joinTypes = [{k: false, v: ts('Optional')}, {k: true, v: ts('Required')}];
-      $scope.entities = formatForSelect2(CRM.vars.search.schema, 'name', 'titlePlural', ['description', 'icon']);
+      $scope.entities = formatForSelect2(CRM.vars.search.schema, 'name', 'title_plural', ['description', 'icon']);
       this.perm = {
         editGroups: CRM.checkPerm('edit groups')
       };
@@ -44,7 +44,7 @@
           if (entity) {
             joinEntities.push({
               id: link.entity + ' AS ' + link.alias,
-              text: entity.titlePlural,
+              text: entity.title_plural,
               description: '(' + link.alias + ')',
               icon: entity.icon
             });
@@ -428,7 +428,7 @@
 
         var mainEntity = searchMeta.getEntity(ctrl.entity),
           result = [{
-            text: mainEntity.titlePlural,
+            text: mainEntity.title_plural,
             icon: mainEntity.icon,
             children: formatFields(ctrl.entity, '')
           }];
@@ -436,7 +436,7 @@
           var joinName = join[0].split(' AS '),
             joinEntity = searchMeta.getEntity(joinName[0]);
           result.push({
-            text: joinEntity.titlePlural + ' (' + joinName[1] + ')',
+            text: joinEntity.title_plural + ' (' + joinName[1] + ')',
             icon: joinEntity.icon,
             children: formatFields(joinEntity.name, joinName[1] + '.')
           });

--- a/ext/search/ang/search/crmSearch.html
+++ b/ext/search/ang/search/crmSearch.html
@@ -1,5 +1,5 @@
 <div id="bootstrap-theme" class="crm-search">
-  <h1 crm-page-title>{{:: ts('Search for %1', {1: $ctrl.getEntity($ctrl.entity).titlePlural}) }}</h1>
+  <h1 crm-page-title>{{:: ts('Search for %1', {1: $ctrl.getEntity($ctrl.entity).title_plural}) }}</h1>
 
   <!--This warning will show if bootstrap is unavailable. Normally it will be hidden by the bootstrap .collapse class.-->
   <div class="messages warning no-popup collapse">

--- a/ext/search/ang/search/crmSearchActions.component.js
+++ b/ext/search/ang/search/crmSearchActions.component.js
@@ -13,7 +13,7 @@
         ctrl = this;
 
       this.$onInit = function() {
-        var entityTitle = searchMeta.getEntity(ctrl.entity).titlePlural;
+        var entityTitle = searchMeta.getEntity(ctrl.entity).title_plural;
         if (!ctrl.actions) {
           var actions = _.transform(_.cloneDeep(CRM.vars.search.actions), function (actions, action) {
             if (_.includes(action.entities, ctrl.entity)) {

--- a/ext/search/ang/search/crmSearchActions/crmSearchActionUpdate.html
+++ b/ext/search/ang/search/crmSearchActions/crmSearchActionUpdate.html
@@ -10,7 +10,7 @@
     <hr />
     <div class="buttons pull-right">
       <button type="button" ng-click="$ctrl.cancel()" class="btn btn-danger">{{:: ts('Cancel') }}</button>
-      <button ng-click="$ctrl.save()" class="btn btn-primary" ng-disabled="!$ctrl.values.length">{{:: ts('Update %1 %2', {1: model.ids.length, 2: (model.ids.length === 1 ? $ctrl.entity.title : $ctrl.entity.titlePlural)}) }}</button>
+      <button ng-click="$ctrl.save()" class="btn btn-primary" ng-disabled="!$ctrl.values.length">{{:: ts('Update %1 %2', {1: model.ids.length, 2: (model.ids.length === 1 ? $ctrl.entity.title : $ctrl.entity.title_plural)}) }}</button>
     </div>
   </div>
 </div>

--- a/tests/phpunit/api/v4/Entity/ConformanceTest.php
+++ b/tests/phpunit/api/v4/Entity/ConformanceTest.php
@@ -116,6 +116,7 @@ class ConformanceTest extends UnitTestCase {
   public function testConformance($entity) {
     $entityClass = 'Civi\Api4\\' . $entity;
 
+    $this->checkEntityInfo($entityClass);
     $actions = $this->checkActions($entityClass);
 
     // Go no further if it's not a CRUD entity
@@ -136,7 +137,19 @@ class ConformanceTest extends UnitTestCase {
   }
 
   /**
-   * @param string $entityClass
+   * @param \Civi\Api4\Generic\AbstractEntity|string $entityClass
+   */
+  protected function checkEntityInfo($entityClass) {
+    $info = $entityClass::getInfo();
+    $this->assertNotEmpty($info['name']);
+    $this->assertNotEmpty($info['title']);
+    $this->assertNotEmpty($info['title_plural']);
+    $this->assertNotEmpty($info['type']);
+    $this->assertNotEmpty($info['description']);
+  }
+
+  /**
+   * @param \Civi\Api4\Generic\AbstractEntity|string $entityClass
    * @param string $entity
    */
   protected function checkFields($entityClass, $entity) {


### PR DESCRIPTION
Overview
----------------------------------------
In a feature recently added by @agh1 and myself, the api returns the name of each entity in plural form as `titlePlural`. However, api output by convention does not use camelCase. This fixes it, adds the field to the api spec, and backports the test from master with the updated case.

Before
----------------------------------------
Api returns `title` and `titlePlural` for each entity.

After
----------------------------------------
Api returns `title` and `title_plural` for each entity.

Comments
----------------------------------------
There may be a conflict in forward-merging this to master. I'll fix that when we merge this.