### PR TITLE
Participant Calculate/Fees: fix ts usage, simplify wording

### DIFF
--- a/templates/CRM/Price/Form/Calculate.tpl
+++ b/templates/CRM/Price/Form/Calculate.tpl
@@ -15,7 +15,11 @@
     {if ($extends eq 'Contribution') || ($extends eq 'Membership')}
       <span id='amount_sum_label'>{ts}Total Amount{/ts}</span>
     {else}
-      <span id='amount_sum_label'>{ts}Total Fee(s){/ts}{if $isAdditionalParticipants} {ts}for this participant{/ts}{/if}</span>
+      {if $isAdditionalParticipants}
+        <span id='amount_sum_label'>{ts}Total for this participant{/ts}</span>
+      {else}
+        <span id='amount_sum_label'>{ts}Total{/ts}</span>
+      {/if}
     {/if}
   </div>
   <div class="content calc-value" {if $hideTotal}style="display:none;"{/if} id="pricevalue"></div>


### PR DESCRIPTION
Overview
----------------------------------------

Fixes an incorrect use of `ts`, which assumes how strings can be concatenated. It also makes it difficult to use Word Replacements.

![Capture d’écran de 2020-10-29 14-38-41](https://user-images.githubusercontent.com/254741/97619931-3adb5000-19f7-11eb-8426-7bd0d158a092.png)

After:

![Capture d’écran de 2020-10-29 15-05-15](https://user-images.githubusercontent.com/254741/97620589-2ba8d200-19f8-11eb-976f-428b27f27e9b.png)


Comments
------------------

I wanted to override the wording to simplify display "Total". It was not possible because of how the strings are concatenated.

Using wording such as "Fee(s)" really looks clunky, but will avoid changing the priceset title for now.