### PR TITLE
GenCode DAO - Generate stylistically-approved 'use' statements

### DIFF
--- a/CRM/Core/CodeGen/Util/Template.php
+++ b/CRM/Core/CodeGen/Util/Template.php
@@ -82,6 +82,7 @@ class CRM_Core_CodeGen_Util_Template {
       ];
       $contents = str_replace(array_keys($replacements), array_values($replacements), $contents);
       $contents = preg_replace('#(\s*)\\/\\*\\*#', "\n\$1/**", $contents);
+      $contents = preg_replace(";\nuse \\\;", "\nuse ", $contents);
 
       // Convert old array syntax to new square brackets
       $contents = CRM_Core_CodeGen_Util_ArraySyntaxConverter::convert($contents);


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a problem where DAO's generated for extensions have a style error.

Before
----------------------------------------

Run `civix generate:entity-boilerplate` in an extension. The resulting DAO produces output like:

```php
use \CRM_OAuth_ExtensionUtil as E;
```

But civilint/phpcs rejects it because the leading slash goes against the style guide.

After
----------------------------------------

Run `civix generate:entity-boilerplate` in an extension. The resulting DAO produces output like:

```php
use CRM_OAuth_ExtensionUtil as E;
```

Technical Details
----------------------------------------

My first impulse was to find the thing which outputted the slash and remove it. Alas, it turns out that PHP_Beautifier takes a perfectly good `use Foo` statement and turns it into `useFoo` (no space). 

This patch still produces the slash in the initial template (to trick PHP_Beautifier), but -- as part of the code cleanup -- it takes it back it out. 🤷‍♂️ 

This seems to work fine for core DAOs:

```bash
GENCODE_FORCE=1 ./bin/setup.sh -g
git diff
```

And the results show no change into DAO output.