### PR TITLE
Fix extension generated DAO files to pass civilint

### DIFF
--- a/CRM/Core/CodeGen/Util/Template.php
+++ b/CRM/Core/CodeGen/Util/Template.php
@@ -78,7 +78,7 @@ class CRM_Core_CodeGen_Util_Template {
         '=> true,' => '=> TRUE,',
         '=> false,' => '=> FALSE,',
         'static ::' => 'static::',
-        'use\\' => 'use \\',
+        'use\\' => 'use ',
       ];
       $contents = str_replace(array_keys($replacements), array_values($replacements), $contents);
       $contents = preg_replace('#(\s*)\\/\\*\\*#', "\n\$1/**", $contents);


### PR DESCRIPTION
Overview
----------------------------------------
DAO files generated by `civix generate:entity-boilerplate` have a `use` statement at the top of them. This fixes the syntax of that line to avoid complaints by `civilint`.

Before
----------------------------------------
`civilint` says `"When importing a class with "use", do not include a leading \"`

After
----------------------------------------
`civilint` says nothing.

Technical Details
----------------------------------------
This is a stopgap. The longer-term is to get rid of php beautifier. 