### PR TITLE
dev/core#927 Move handling of participant.cancel from BaseIPN to  contributioncancelactions

### DIFF
--- a/CRM/Core/Payment/BaseIPN.php
+++ b/CRM/Core/Payment/BaseIPN.php
@@ -237,6 +237,7 @@ class CRM_Core_Payment_BaseIPN {
    * @throws \CiviCRM_API3_Exception|\CRM_Core_Exception
    */
   public function cancelled($objects) {
+    CRM_Core_Error::deprecatedFunctionWarning('Use Contribution create api to cancel the contribution');
     $contribution = &$objects['contribution'];
 
     if (empty($contribution->id)) {
@@ -270,17 +271,17 @@ class CRM_Core_Payment_BaseIPN {
           }
         }
       }
+      $participant = &$objects['participant'];
+
+      if ($participant) {
+        $this->cancelParticipant($participant->id);
+      }
     }
     else {
       Contribution::update(FALSE)->setValues([
         'cancel_date' => 'now',
         'contribution_status_id:name' => 'Cancelled',
       ])->addWhere('id', '=', $contribution->id)->execute();
-    }
-    $participant = &$objects['participant'];
-
-    if ($participant) {
-      $this->cancelParticipant($participant->id);
     }
 
     Civi::log()->debug("Setting contribution status to Cancelled");
@@ -308,6 +309,8 @@ class CRM_Core_Payment_BaseIPN {
   /**
    * Logic to cancel a participant record when the related contribution changes to failed/cancelled.
    * @todo This is part of a bigger refactor for dev/core/issues/927 - "duplicate" functionality exists in CRM_Contribute_BAO_Contribution::cancel()
+   *
+   * @deprecated
    *
    * @param $participantID
    *

--- a/CRM/Core/Payment/PayPalIPN.php
+++ b/CRM/Core/Payment/PayPalIPN.php
@@ -9,6 +9,8 @@
  +--------------------------------------------------------------------+
  */
 
+use Civi\Api4\Contribution;
+
 /**
  *
  * @package CRM
@@ -348,7 +350,11 @@ class CRM_Core_Payment_PayPalIPN extends CRM_Core_Payment_BaseIPN {
         return;
       }
       if ($status === 'Refunded' || $status === 'Reversed') {
-        $this->cancelled($objects);
+        Contribution::update(FALSE)->setValues([
+          'cancel_date' => 'now',
+          'contribution_status_id:name' => 'Cancelled',
+        ])->addWhere('id', '=', $contributionID)->execute();
+        Civi::log()->debug("Setting contribution status to Cancelled");
         return;
       }
       if ($status !== 'Completed') {

--- a/CRM/Core/Payment/PayPalProIPN.php
+++ b/CRM/Core/Payment/PayPalProIPN.php
@@ -9,6 +9,8 @@
  +--------------------------------------------------------------------+
  */
 
+use Civi\Api4\Contribution;
+
 /**
  *
  * @package CRM
@@ -327,8 +329,12 @@ class CRM_Core_Payment_PayPalProIPN extends CRM_Core_Payment_BaseIPN {
       Civi::log()->debug('Returning since contribution status is Pending');
       return;
     }
-    elseif ($status === 'Refunded' || $status === 'Reversed') {
-      $this->cancelled($objects);
+    if ($status === 'Refunded' || $status === 'Reversed') {
+      Contribution::update(FALSE)->setValues([
+        'cancel_date' => 'now',
+        'contribution_status_id:name' => 'Cancelled',
+      ])->addWhere('id', '=', $contribution->id)->execute();
+      Civi::log()->debug("Setting contribution status to Cancelled");
       return;
     }
     elseif ($status !== 'Completed') {

--- a/ext/contributioncancelactions/contributioncancelactions.php
+++ b/ext/contributioncancelactions/contributioncancelactions.php
@@ -5,6 +5,7 @@ require_once 'contributioncancelactions.civix.php';
 use CRM_Contributioncancelactions_ExtensionUtil as E;
 // phpcs:enable
 use Civi\Api4\LineItem;
+use Civi\Api4\Participant;
 
 /**
  * Implements hook_civicrm_preProcess().
@@ -19,25 +20,59 @@ use Civi\Api4\LineItem;
 function contributioncancelactions_civicrm_post($op, $objectName, $objectId, $objectRef) {
   if ($op === 'edit' && $objectName === 'Contribution') {
     if ('Cancelled' === CRM_Core_PseudoConstant::getName('CRM_Contribute_BAO_Contribution', 'contribution_status_id', $objectRef->contribution_status_id)) {
-      // Find and cancel any pending memberships.
-      $connectedMemberships = (array) LineItem::get(FALSE)->setWhere([
-        ['contribution_id', '=', $objectId],
-        ['entity_table', '=', 'civicrm_membership'],
-      ])->execute()->indexBy('entity_id');
-      if (empty($connectedMemberships)) {
-        return;
-      }
-      // @todo we don't have v4 membership api yet so v3 for now.
-      $connectedMemberships = array_keys(civicrm_api3('Membership', 'get', [
-        'status_id' => 'Pending',
-        'id' => ['IN' => array_keys($connectedMemberships)],
-      ])['values']);
-      if (empty($connectedMemberships)) {
-        return;
-      }
-      foreach ($connectedMemberships as $membershipID) {
-        civicrm_api3('Membership', 'create', ['status_id' => 'Cancelled', 'id' => $membershipID, 'is_override' => 1]);
-      }
+      contributioncancelactions_cancel_related_pending_memberships((int) $objectId);
+      contributioncancelactions_cancel_related_pending_participant_records((int) $objectId);
     }
+  }
+}
+
+/**
+ * Find and cancel any pending participant records.
+ *
+ * @param int $contributionID
+ * @throws CiviCRM_API3_Exception
+ */
+function contributioncancelactions_cancel_related_pending_participant_records($contributionID): void {
+  $pendingStatuses = CRM_Event_PseudoConstant::participantStatus(NULL, "class = 'Pending'");
+  $waitingStatuses = CRM_Event_PseudoConstant::participantStatus(NULL, "class = 'Waiting'");
+  $cancellableParticipantRecords = civicrm_api3('ParticipantPayment', 'get', [
+    'contribution_id' => $contributionID,
+    'participant_id.status_id' => ['IN' => array_merge(array_keys($pendingStatuses), array_keys($waitingStatuses))],
+  ])['values'];
+  if (empty($cancellableParticipantRecords)) {
+    return;
+  }
+  Participant::update(FALSE)
+    ->addWhere('id', 'IN', array_keys($cancellableParticipantRecords))
+    ->setValues(['status_id:name' => 'Cancelled'])
+    ->execute();
+}
+
+/**
+ * Find and cancel any pending memberships.
+ *
+ * @param int $contributionID
+ * @throws API_Exception
+ * @throws CiviCRM_API3_Exception
+ */
+function contributioncancelactions_cancel_related_pending_memberships($contributionID): void {
+  $connectedMemberships = (array) LineItem::get(FALSE)->setWhere([
+    ['contribution_id', '=', $contributionID],
+    ['entity_table', '=', 'civicrm_membership'],
+  ])->execute()->indexBy('entity_id');
+
+  if (empty($connectedMemberships)) {
+    return;
+  }
+  // @todo we don't have v4 membership api yet so v3 for now.
+  $connectedMemberships = array_keys(civicrm_api3('Membership', 'get', [
+    'status_id' => 'Pending',
+    'id' => ['IN' => array_keys($connectedMemberships)],
+  ])['values']);
+  if (empty($connectedMemberships)) {
+    return;
+  }
+  foreach ($connectedMemberships as $membershipID) {
+    civicrm_api3('Membership', 'create', ['status_id' => 'Cancelled', 'id' => $membershipID, 'is_override' => 1]);
   }
 }


### PR DESCRIPTION
Overview
----------------------------------------
Moves the code to cancel participants on contribution cancel to the contributioncancelactions
core extension.

Before
----------------------------------------
The cancellations are done using convoluted & elsewhere duplicated logic in BaseIPN
using convoluted input params

After
----------------------------------------
When a contribution is updated & the status_id of 'Cancelled' is set then
the hook will kick in, look for any related pending or waiting participant records and cancel them.

This is a slight change from the existing code - which cancels regardless of the status. My suspicion is that there is no practical difference but it seemed more consistent with the membership code.

Technical Details
----------------------------------------
With this change the BaseIPN cancelled function is also deprecated. There are still 3 places in the code calling transitionComponents on cancel, which need to be addressed and transition components has a little extra handling for pledge payments that has to be moved as part of that. Also todo is do all the same things for failed.

Comments
----------------------------------------

