### PR TITLE
[Ref] Use direct version of participant id

### DIFF
--- a/CRM/Core/Payment/PayPalIPN.php
+++ b/CRM/Core/Payment/PayPalIPN.php
@@ -357,7 +357,7 @@ class CRM_Core_Payment_PayPalIPN extends CRM_Core_Payment_BaseIPN {
       }
       $this->single($input, [
         'related_contact' => $ids['related_contact'] ?? NULL,
-        'participant' => !empty($objects['participant']) ? $objects['participant']->id : NULL,
+        'participant' => $ids['participant'] ?? NULL,
         'contributionRecur' => !empty($objects['contributionRecur']) ? $objects['contributionRecur']->id : NULL,
       ], $objects['contribution']);
     }


### PR DESCRIPTION


Overview
----------------------------------------
[Ref] Use direct version of participant id

Before
----------------------------------------
The value used for participantID is $participant->id which is derived from $ids['participantID]

After
----------------------------------------
Use $ids['participantID]

Technical Details
----------------------------------------
ids['Participant'] is taken from the url. It is then passed to loadRelatedObjects
where
https://github.com/civicrm/civicrm-core/blob/0bd5e6bfbe8f339dbe066e3e96e00760c93a57e2/CRM/Contribute/BAO/Contribution.php#L2890
loads an object based on it. We then set ids too the object's id - which is a long way around to
using the paramter we started from. This does that

Comments
----------------------------------------
