### PR TITLE
dev/core#2141 - "Add Mail Account" - Allow hookable listing of setup links

### DIFF
--- a/CRM/Admin/Page/MailSettings.php
+++ b/CRM/Admin/Page/MailSettings.php
@@ -107,6 +107,11 @@ class CRM_Admin_Page_MailSettings extends CRM_Core_Page_Basic {
     }
 
     $this->assign('rows', $allMailSettings);
+
+    $setupActions = CRM_Core_BAO_MailSettings::getSetupActions();
+    if (count($setupActions) > 1 || !isset($setupActions['standard'])) {
+      $this->assign('setupActions', $setupActions);
+    }
   }
 
   /**

--- a/CRM/Core/BAO/MailSettings.php
+++ b/CRM/Core/BAO/MailSettings.php
@@ -24,6 +24,30 @@ class CRM_Core_BAO_MailSettings extends CRM_Core_DAO_MailSettings {
   }
 
   /**
+   * Get a list of setup-actions.
+   *
+   * @return array
+   *   List of available actions. See description in the hook-docs.
+   * @see CRM_Utils_Hook::mailSetupActions()
+   */
+  public static function getSetupActions() {
+    $setupActions = [];
+    $setupActions['standard'] = [
+      'title' => ts('Standard Mail Account'),
+      'callback' => ['CRM_Core_BAO_MailSettings', 'setupStandardAccount'],
+    ];
+
+    CRM_Utils_Hook::mailSetupActions($setupActions);
+    return $setupActions;
+  }
+
+  public static function setupStandardAccount($setupAction) {
+    return [
+      'url' => CRM_Utils_System::url('civicrm/admin/mailSettings', 'action=add&reset=1', TRUE, NULL, FALSE),
+    ];
+  }
+
+  /**
    * Return the DAO object containing to the default row of
    * civicrm_mail_settings and cache it for further calls
    *

--- a/CRM/Mailing/Page/AJAX.php
+++ b/CRM/Mailing/Page/AJAX.php
@@ -21,6 +21,32 @@
 class CRM_Mailing_Page_AJAX {
 
   /**
+   * Kick off the "Add Mail Account" process for some given type of account.
+   *
+   * Ex: 'civicrm/ajax/setupMailAccount?type=standard'
+   * Ex: 'civicrm/ajax/setupMailAccount?type=oauth_1'
+   *
+   * @see CRM_Core_BAO_MailSettings::getSetupActions()
+   * @throws \CRM_Core_Exception
+   */
+  public static function setup() {
+    $type = CRM_Utils_Request::retrieve('type', 'String');
+    $setupActions = CRM_Core_BAO_MailSettings::getSetupActions();
+    $setupAction = $setupActions[$type] ?? NULL;
+    if ($setupAction === NULL) {
+      throw new \CRM_Core_Exception("Cannot setup mail account. Invalid type requested.");
+    }
+
+    $result = call_user_func($setupAction['callback'], $setupAction);
+    if (isset($result['url'])) {
+      CRM_Utils_System::redirect($result['url']);
+    }
+    else {
+      throw new \CRM_Core_Exception("Cannot setup mail account. Setup does not have a URL.");
+    }
+  }
+
+  /**
    * Fetch the template text/html messages
    */
   public static function template() {

--- a/CRM/Mailing/xml/Menu/Mailing.xml
+++ b/CRM/Mailing/xml/Menu/Mailing.xml
@@ -203,6 +203,11 @@
     <access_arguments>access CiviCRM</access_arguments>
   </item>
   <item>
+    <path>civicrm/ajax/setupMailAccount</path>
+    <page_callback>CRM_Mailing_Page_AJAX::setup</page_callback>
+    <access_arguments>access CiviCRM,access CiviMail</access_arguments>
+  </item>
+  <item>
     <path>civicrm/mailing/url</path>
     <page_callback>CRM_Mailing_Page_Url</page_callback>
     <access_arguments>*always allow*</access_arguments>

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -1043,6 +1043,24 @@ abstract class CRM_Utils_Hook {
   }
 
   /**
+   * When adding a new "Mail Account" (`MailSettings`), present a menu of setup
+   * options.
+   *
+   * @param array $setupActions
+   *   Each item has a symbolic-key, and it has the properties:
+   *     - title: string
+   *     - callback: string|array, the function which starts the setup process.
+   *        The function is expected to return a 'url' for the config screen.
+   * @return mixed
+   */
+  public static function mailSetupActions(&$setupActions) {
+    return self::singleton()->invoke(['setupActions'], $setupActions, self::$_nullObject, self::$_nullObject,
+      self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      'civicrm_mailSetupActions'
+    );
+  }
+
+  /**
    * This hook is called when composing a mailing. You can include / exclude other groups as needed.
    *
    * @param mixed $form

--- a/templates/CRM/Admin/Page/MailSettings.tpl
+++ b/templates/CRM/Admin/Page/MailSettings.tpl
@@ -58,9 +58,34 @@
       {ts}None found.{/ts}
     </div>
 {/if}
-  <div class="action-link">
-    {crmButton q="action=add&reset=1" id="newMailSettings"  icon="plus-circle"}{ts}Add Mail Account{/ts}{/crmButton}
-    {crmButton p="civicrm/admin" q="reset=1" class="cancel" icon="times"}{ts}Done{/ts}{/crmButton}
-  </div>
+    {if $setupActions}
+        <form>
+            <select id="crm-mail-setup" name="crm-mail-setup" class="crm-select2 crm-form-select" aria-label="{ts}Add Mail Account{/ts}">
+                <option value="" aria-hidden="true">{ts}Add Mail Account{/ts}</option>
+                {foreach from=$setupActions key=setupActionsName item=setupAction}
+                    <option value="{$setupActionsName|escape}">{$setupAction.title|escape}</option>
+                {/foreach}
+            </select>
+        </form>
+    {else}
+        <div class="action-link">
+            {crmButton q="action=add&reset=1" id="newMailSettings"  icon="plus-circle"}{ts}Add Mail Account{/ts}{/crmButton}
+            {crmButton p="civicrm/admin" q="reset=1" class="cancel" icon="times"}{ts}Done{/ts}{/crmButton}
+        </div>
+    {/if}
+
 {/if}
 </div>
+{literal}
+    <script type="text/javascript">
+        cj('#crm-mail-setup').val('');
+        cj('#crm-mail-setup').on('select2-selecting', function(event) {
+            if (!event.val) {
+                return;
+            }
+            event.stopPropagation();
+            var url = CRM.url('civicrm/ajax/setupMailAccount', {type: event.val});
+            window.location = url;
+        });
+    </script>
+{/literal}


### PR DESCRIPTION
Overview
--------

For certain types of mail accounts -- such as Google Mail and Microsoft Exchange Online -- the setup process may require interaction with a remote web-service.  The web-service provides some critical details (like authentication tokens) and some handy details (like their username / email address).

If the site supports one of these services, then this revision will enable a setup process.  It alters the "Add Mail Account" action to use a more fine-tuned procedure.

This is a part of the larger epic #18863.

Before
------

![Screenshot from 2020-10-30 03-42-50](https://user-images.githubusercontent.com/1336047/97696259-8d058b00-1a62-11eb-9754-33e46ef3eec7.png)

Steps:

* Navigate to "Administer => CiviMail => Mail Accounts".
* Below the table, there is a singular button "Add Mail Account".
* Click the button.
* It opens an empty form for configuring the account.

After
-----

By default, the UX is the same.  However, if you have an extension like `oauth-client`, then it changes:

![Screenshot from 2020-10-30 03-44-03](https://user-images.githubusercontent.com/1336047/97696256-8d058b00-1a62-11eb-85e5-d71619f7b332.png)

Steps:

* Navigate to "Administer => CiviMail => Mail Accounts".
* Below the table, there is a select box for "Add Mail Account". It lists different account types.
* Choose one of the dropdown options:
    * If you choose "Standard Mail Account", it opens the empty config form.
    * If you choose "Microsoft Exchange Online", it redirects to MS to get authorization  from the user. Then, it redirects and prefills the config form.

![Screenshot from 2020-10-30 03-45-03](https://user-images.githubusercontent.com/1336047/97696255-8c6cf480-1a62-11eb-80fc-7c7fc9782d02.png)

Technical Details
----------------------------------------

This defines a new hook, `hook_civicrm_mailSetupActions`, e.g.

```php
function mymod_civicrm_mailSetupActions($setupActions) {
  $setupActions['supermail'] = [
    'title' => ts('Super Mail'),
    'callback' => '_mymod_setup',
  ];
}

function _mymod_setup($setupAction) {
  return [
    'url' => '...the-next-setup-page...',
  ];
}
```

For standard mail accounts, 'the-next-setup-page' is just the normal/existing page. For an OAuth2-based provider like Microsoft, it is the OAuth2 URL. There is an implementation of the hook in #18863 (under `ext/oauth-client`) -- e.g. the `oauth_client_civicrm_mailSetupActions` delegates to [CRM_OAuth_MailSetup](https://github.com/totten/civicrm-core/blob/5.32-oauth-imap/ext/oauth-client/CRM/OAuth/MailSetup.php) and ultimately loads the mail config from [ms-exchange.dist.json](https://github.com/totten/civicrm-core/blob/5.32-oauth-imap/ext/oauth-client/providers/ms-exchange.dist.json)

Comments
----------------------------------------

In the basic/default layout, there is the "Add Mail Account" button and also a "Done" button. The "Done" button is weird. But I left it in the basic/default layout because it's hard to prove that it's weird.