### PR TITLE
(NFC) Fix typo in Money valueFormat depretation warning

### DIFF
--- a/CRM/Utils/Money.php
+++ b/CRM/Utils/Money.php
@@ -67,7 +67,7 @@ class CRM_Utils_Money {
     }
 
     if (!empty($valueFormat) && $valueFormat !== '%!i') {
-      CRM_Core_Error::deprecatedFunctionWarning('Having a Money Value format other than !%i is deprecated, please report this on the GitLab Issue https://lab.civicrm.org/dev/core/-/issues/1494 with the relevant moneyValueFormat you use.');
+      CRM_Core_Error::deprecatedFunctionWarning('Having a Money Value format other than %!i is deprecated, please report this on the GitLab Issue https://lab.civicrm.org/dev/core/-/issues/1494 with the relevant moneyValueFormat you use.');
     }
 
     if ($onlyNumber) {


### PR DESCRIPTION
Overview
----------------------------------------

This is pretty silly, but I stumbled on this warning on a site (civicrm.org!) and as a fix, I copy-pasted the format recommended in the deprecation warning, but it has a typo, which caused a formatting error.

* Before: `!%i`
* After: `%!i`

I'm not sure why it was complaining, since it was correctly set before:

```
MariaDB [civicrmorg]> select * from log_civicrm_setting where name = 'moneyvalueformat' order by log_date desc limit 100;
+------+------------------+-------------+-----------+------------+-----------+--------------+---------------------+------------+---------------------+---------------+-------------+----------------+
| id   | name             | value       | domain_id | contact_id | is_domain | component_id | created_date        | created_id | log_date            | log_conn_id   | log_user_id | log_action     |
+------+------------------+-------------+-----------+------------+-----------+--------------+---------------------+------------+---------------------+---------------+-------------+----------------+
|  568 | moneyvalueformat | s:3:"%!i";  |         1 |       NULL |         1 |         NULL | 2020-10-30 09:04:59 |       3039 | 2020-10-30 13:04:59 | 5f9c0f7adcb9b |        3039 | Update         |
|  568 | moneyvalueformat | s:4:".%!i"; -> me testing |         1 |       NULL |         1 |         NULL | 2020-10-30 09:03:52 |       3039 | 2020-10-30 13:03:52 | 5f9c0f37ec378 |        3039 | Update         |
|  568 | moneyvalueformat | s:3:"%!i";  |         1 |       NULL |         1 |         NULL | 2020-10-30 09:02:32 |       3039 | 2020-10-30 13:02:32 | 5f9c0ee8470fe |        3039 | Update         |
|  568 | moneyvalueformat | s:3:"!%i";  -> my bad |         1 |       NULL |         1 |         NULL | 2020-10-29 16:53:06 |       3039 | 2020-10-29 20:53:06 | 5f9b2bb1cd9b3 |        3039 | Update         |
|  568 | moneyvalueformat | s:3:"%!i";  |         1 |       NULL |         1 |         NULL | 2020-04-14 09:53:57 |       3039 | 2020-04-14 13:53:57 | 5e95c074e1b07 |        3039 | Update         |
|  568 | moneyvalueformat | s:3:"%!i";  |         1 |       NULL |         1 |         NULL | 2020-04-14 09:51:47 |       3039 | 2020-04-14 13:51:47 | 5e95bff3acbb5 |        3039 | Update         |
|  568 | moneyvalueformat | s:3:"%!i";  |         1 |       NULL |         1 |         NULL | 2020-03-26 11:10:31 |       3039 | 2020-03-26 15:10:31 | 5e7cc5e761958 |        3039 | Update         |
|  568 | moneyvalueformat | s:3:"%!i";  |         1 |       NULL |         1 |         NULL | 2019-09-02 14:43:58 |       3039 | 2019-09-02 18:43:58 | 5d6d62ee42391 |        3039 | Update         |
```