### PR TITLE
Deprecate hook_civicrm_crudLink

### DIFF
--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -2381,6 +2381,7 @@ abstract class CRM_Utils_Hook {
    *   - url: string (used in lieu of "path"/"query")
    *      Note: if making "url" CRM_Utils_System::url(), set $htmlize=false
    * @return mixed
+   * @deprecated
    */
   public static function crudLink($spec, $bao, &$link) {
     return self::singleton()->invoke(['spec', 'bao', 'link'], $spec, $bao, $link,

--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -1876,6 +1876,7 @@ class CRM_Utils_System {
    *   - query: array
    *   - title: string
    *   - url: string
+   * @deprecated
    */
   public static function createDefaultCrudLink($crudLinkSpec) {
     $crudLinkSpec['action'] = CRM_Utils_Array::value('action', $crudLinkSpec, CRM_Core_Action::VIEW);


### PR DESCRIPTION
Overview
----------------------------------------
Deprecates a hook that doesn't appear to be used anywhere in the CiviCRM Universe, which is called by a function that is only used in one place - the (possibly experimental/unfinished?) Full-Text file search.

Technical Details
----------------------------------------
The one place this function is called is via the smarty template for Full-Text file search: https://github.com/civicrm/civicrm-core/blob/dd7e23f250720223d8bb742bdbbc0486a8bf710a/templates/CRM/Contact/Form/Search/Custom/FullText.tpl#L387

There are some signs that tpl is part of unfinished WIP, so I'm not sure if it's even production code. If so, I'll go ahead and replace the smarty implementation using the new metadata from #18887 and we can delete the function & the hook entirely. If not, then we can just delete them all including the smarty function.