### PR TITLE
dev/core#2154 - Pass correct parameters to CRM_Core_Form::add() in fulltext custom search

### DIFF
--- a/CRM/Contact/Form/Search/Custom/FullText.php
+++ b/CRM/Contact/Form/Search/Custom/FullText.php
@@ -297,11 +297,7 @@ WHERE      t.table_name = 'Activity' AND
     $config = CRM_Core_Config::singleton();
 
     $form->applyFilter('__ALL__', 'trim');
-    $form->add('text',
-      'text',
-      ts('Find'),
-      TRUE
-    );
+    $form->add('text', 'text', ts('Find'), NULL, TRUE);
 
     // also add a select box to allow the search to be constrained
     $tables = ['' => ts('All tables')];

--- a/tests/phpunit/CRM/Core/FormTest.php
+++ b/tests/phpunit/CRM/Core/FormTest.php
@@ -72,6 +72,14 @@ class CRM_Core_FormTest extends CiviUnitTestCase {
           $form->_action = CRM_Core_Action::ADD;
         },
       ],
+      // Also a bit flawed, but catches simple stuff.
+      'Fulltext search' => [
+        'CRM_Contact_Form_Search_Custom',
+        function(CRM_Core_Form $form) {
+          $form->_action = CRM_Core_Action::BASIC;
+          $form->set('csid', 15);
+        },
+      ],
     ];
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/2154

Changes in 5.31 deprecate passing non-array attributes. But also this search was intending to make the field required but passing it in the wrong parameter.

To reproduce just open Search - Custom Searches - Fulltext search.

There's also something wrong with the styling in this form that comes from changes in 5.31, but will do separately.

Before
----------------------------------------
`User deprecated function: Attributes passed to CRM_Core_Form::add() are not an array. Array ( [civi.tag] => deprecated )`

After
----------------------------------------


Technical Details
----------------------------------------


Comments
----------------------------------------
Has test.
