### PR TITLE
dev/core#2154 Fix the output of the full text custom search form

### DIFF
--- a/templates/CRM/Contact/Form/Search/Custom/FullText.tpl
+++ b/templates/CRM/Contact/Form/Search/Custom/FullText.tpl
@@ -13,10 +13,14 @@
     <div class="form-item">
       <table class="form-layout-compressed">
         <tr>
-          <td class="label">{$form.text.label}</td>
-          <td>{$form.text.html}</td>
-          <td class="label">{ts}in...{/ts}</td>
-          <td>{$form.table.html}</td>
+          <td>
+            <label>{$form.text.label}</label>
+            {$form.text.html}
+          </td>
+          <td>
+            <label>{ts}in...{/ts}</label>
+            {$form.table.html}
+          </td>
           <td>{$form.buttons.html} {help id="id-fullText"}</td>
         </tr>
       </table>


### PR DESCRIPTION
Overview
----------------------------------------
This is a companion to https://github.com/civicrm/civicrm-core/pull/18889 which fixed the style problems Dave D has noted 

Before
----------------------------------------
![ft_before](https://user-images.githubusercontent.com/6799125/97762878-fc13da00-1b5d-11eb-957c-7def165f5e48.jpg)

After
----------------------------------------
![ft_after](https://user-images.githubusercontent.com/6799125/97762884-003ff780-1b5e-11eb-9725-7da3d5aea18b.jpg)

ping @demeritcowboy @eileenmcnaughton 