### PR TITLE
Hack away at false negative test fails

### DIFF
--- a/tests/phpunit/api/v4/Service/TestCreationParameterProvider.php
+++ b/tests/phpunit/api/v4/Service/TestCreationParameterProvider.php
@@ -53,6 +53,12 @@ class TestCreationParameterProvider {
     $requiredParams = [];
     foreach ($requiredFields as $requiredField) {
       $value = $this->getRequiredValue($requiredField);
+      if ($entity === 'UFField' && $requiredField->getName() === 'field_name') {
+        // This is a ruthless hack to avoid a unique constraint - but
+        // it's also a test class & hard to care enough to do something
+        // better
+        $value = 'activity_campaign_id';
+      }
       $requiredParams[$requiredField->getName()] = $value;
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
Nasty but effective way to reduce false fails on the test suite

Before
----------------------------------------
see https://test.civicrm.org/job/CiviCRM-Core-PR/37737/testReport/junit/api.v4.Entity/ConformanceTest/testConformance_with_data_set__UFField_/

After
----------------------------------------
poof

Technical Details
----------------------------------------


Comments
----------------------------------------

