### PR TITLE
Move call to update related pledges on contribution cancel to extension

### DIFF
--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -1502,6 +1502,7 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
         $params['contribution_id'] = $this->_onlinePendingContributionId;
         $params['componentId'] = $params['id'];
         $params['componentName'] = 'contribute';
+        // Only available statuses are Pending and completed so cancel or failed is not possible here.
         $result = CRM_Contribute_BAO_Contribution::transitionComponents($params, TRUE);
         if (!empty($result) && !empty($params['contribution_id'])) {
           $lineItem = [];

--- a/api/v3/Order.php
+++ b/api/v3/Order.php
@@ -196,7 +196,6 @@ function civicrm_api3_order_cancel($params) {
   $contributionStatuses = CRM_Contribute_PseudoConstant::contributionStatus(NULL, 'name');
   $params['contribution_status_id'] = array_search('Cancelled', $contributionStatuses);
   $result = civicrm_api3('Contribution', 'create', $params);
-  CRM_Contribute_BAO_Contribution::transitionComponents($params);
   return civicrm_api3_create_success($result['values'], $params, 'Order', 'cancel');
 }
 

--- a/ext/contributioncancelactions/contributioncancelactions.php
+++ b/ext/contributioncancelactions/contributioncancelactions.php
@@ -22,7 +22,31 @@ function contributioncancelactions_civicrm_post($op, $objectName, $objectId, $ob
     if ('Cancelled' === CRM_Core_PseudoConstant::getName('CRM_Contribute_BAO_Contribution', 'contribution_status_id', $objectRef->contribution_status_id)) {
       contributioncancelactions_cancel_related_pending_memberships((int) $objectId);
       contributioncancelactions_cancel_related_pending_participant_records((int) $objectId);
+      contributioncancelactions_update_related_pledge((int) $objectId, (int) $objectRef->contribution_status_id);
     }
+  }
+}
+
+/**
+ * Update any related pledge when a contribution is cancelled.
+ *
+ * This updates the status of the pledge and amount paid.
+ *
+ * The functionality should probably be give more thought in that it currently
+ * does not un-assign the contribution id from the pledge payment. However,
+ * at time of writing the goal is to move rather than fix functionality.
+ *
+ * @param int $contributionID
+ * @param int $contributionStatusID
+ *
+ * @throws CiviCRM_API3_Exception
+ */
+function contributioncancelactions_update_related_pledge(int $contributionID, int $contributionStatusID) {
+  $pledgePayments = civicrm_api3('PledgePayment', 'get', ['contribution_id' => $contributionID])['values'];
+  if (!empty($pledgePayments)) {
+    $pledgePaymentIDS = array_keys($pledgePayments);
+    $pledgePayment = reset($pledgePayments);
+    CRM_Pledge_BAO_PledgePayment::updatePledgePaymentStatus($pledgePayment['pledge_id'], $pledgePaymentIDS, $contributionStatusID);
   }
 }
 

--- a/tests/phpunit/api/v3/OrderTest.php
+++ b/tests/phpunit/api/v3/OrderTest.php
@@ -469,59 +469,6 @@ class api_v3_OrderTest extends CiviUnitTestCase {
   }
 
   /**
-   * Test cancel order api
-   */
-  public function testCancelWithParticipant() {
-    $event = $this->eventCreate();
-    $this->_eventId = $event['id'];
-    $eventParams = [
-      'id' => $this->_eventId,
-      'financial_type_id' => 4,
-      'is_monetary' => 1,
-    ];
-    $this->callAPISuccess('event', 'create', $eventParams);
-    $participantParams = [
-      'financial_type_id' => 4,
-      'event_id' => $this->_eventId,
-      'role_id' => 1,
-      'status_id' => 1,
-      'fee_currency' => 'USD',
-      'contact_id' => $this->_individualId,
-    ];
-    $participant = $this->callAPISuccess('Participant', 'create', $participantParams);
-    $extraParams = [
-      'contribution_mode' => 'participant',
-      'participant_id' => $participant['id'],
-    ];
-    $contribution = $this->addOrder(TRUE, 100, $extraParams);
-    $paymentParticipant = [
-      'participant_id' => $participant['id'],
-      'contribution_id' => $contribution['id'],
-    ];
-    $this->callAPISuccess('ParticipantPayment', 'create', $paymentParticipant);
-    $params = [
-      'contribution_id' => $contribution['id'],
-    ];
-    $this->callAPISuccess('order', 'cancel', $params);
-    $order = $this->callAPISuccess('Order', 'get', $params);
-    $expectedResult = [
-      $contribution['id'] => [
-        'total_amount' => 100,
-        'contribution_id' => $contribution['id'],
-        'contribution_status' => 'Cancelled',
-        'net_amount' => 100,
-      ],
-    ];
-    $this->checkPaymentResult($order, $expectedResult);
-    $participantPayment = $this->callAPISuccess('ParticipantPayment', 'getsingle', $params);
-    $participant = $this->callAPISuccess('participant', 'get', ['id' => $participantPayment['participant_id']]);
-    $this->assertEquals($participant['values'][$participant['id']]['participant_status'], 'Cancelled');
-    $this->callAPISuccess('Contribution', 'Delete', [
-      'id' => $contribution['id'],
-    ]);
-  }
-
-  /**
    * Test an exception is thrown if line items do not add up to total_amount, no tax.
    */
   public function testCreateOrderIfTotalAmountDoesNotMatchLineItemsAmountsIfNoTaxSupplied() {


### PR DESCRIPTION

Overview
----------------------------------------
This moves the functionality over from transitionComponents the cancelOrderExtension & switches Order api to be entirely relying on the
hook rather than a call to the deprecated transitionComponents function.

Before
----------------------------------------
Order api calls deprecated transitionComponents, cannot rely on hook as pledge handling not covered by hook

After
----------------------------------------
Order api relies on hook, pledge handling covered in the hook

Technical Details
----------------------------------------
I also renamed the test class to make it generic enough for all the relevant tests

Comments
----------------------------------------

