### PR TITLE
Remove IPN reference to _relatedObjects, deprecate property

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -44,9 +44,19 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution {
   public static $_trxnIDs = NULL;
 
   /**
-   * Field for all the objects related to this contribution
+   * Field for all the objects related to this contribution.
+   *
+   * This is used from
+   * 1) deprecated function transitionComponents
+   * 2) function to send contribution receipts _assignMessageVariablesToTemplate
+   * 3) some invoice code that is copied from 2
+   * 4) odds & sods that need to be investigated and fixed.
+   *
+   * However, it is no longer used by completeOrder.
    *
    * @var \CRM_Member_BAO_Membership|\CRM_Event_BAO_Participant[]
+   *
+   * @deprecated
    */
   public $_relatedObjects = [];
 

--- a/CRM/Core/Payment/AuthorizeNetIPN.php
+++ b/CRM/Core/Payment/AuthorizeNetIPN.php
@@ -107,7 +107,6 @@ class CRM_Core_Payment_AuthorizeNetIPN extends CRM_Core_Payment_BaseIPN {
           $contribution->amount_level = $objects['contribution']->amount_level;
           $contribution->address_id = $objects['contribution']->address_id;
           $contribution->campaign_id = $objects['contribution']->campaign_id;
-          $contribution->_relatedObjects = $objects['contribution']->_relatedObjects;
 
           $objects['contribution'] = &$contribution;
         }


### PR DESCRIPTION
Overview
----------------------------------------
Removes a line of cruft, adds deprecation

Before
----------------------------------------
No longer used property copied from one contribution to another
```
$contribution->_relatedObjects = $objects['contribution']->_relatedObjects;
```

After
----------------------------------------
Copy removed, comments updated to clarify that it is no longer used in completeOrder

Technical Details
----------------------------------------


Comments
----------------------------------------

