### PR TITLE
[Ref] Simplify params

### DIFF
--- a/CRM/Core/Payment/PayPalProIPN.php
+++ b/CRM/Core/Payment/PayPalProIPN.php
@@ -459,8 +459,8 @@ INNER JOIN civicrm_membership_payment mp ON m.id = mp.membership_id AND mp.contr
 
       $this->single($input, [
         'related_contact' => $ids['related_contact'] ?? NULL,
-        'participant' => !empty($objects['participant']) ? $objects['participant']->id : NULL,
-        'contributionRecur' => !empty($objects['contributionRecur']) ? $objects['contributionRecur']->id : NULL,
+        'participant' => $ids['participant'] ?? NULL,
+        'contributionRecur' => $ids['contributionRecur'] ?? NULL,
       ], $objects, FALSE, FALSE);
     }
     catch (CRM_Core_Exception $e) {


### PR DESCRIPTION


Overview
----------------------------------------
As with
https://github.com/civicrm/civicrm-core/commit/0d74d91cd340b9f1ea2224119c748e372dffe245

pass the retrieved parameters to the single function rather than the id of the
object retrieved based on them

Before
----------------------------------------
variable used is id of object loaded from id in $ids

After
----------------------------------------
variable used is  id in $ids

Technical Details
----------------------------------------


Comments
----------------------------------------

