### PR TITLE
[REF] Remove silly if

### DIFF
--- a/CRM/Core/Payment/PayPalIPN.php
+++ b/CRM/Core/Payment/PayPalIPN.php
@@ -328,18 +328,17 @@ class CRM_Core_Payment_PayPalIPN extends CRM_Core_Payment_BaseIPN {
 
       $input['payment_processor_id'] = $paymentProcessorID;
 
-      if ($component == 'contribute') {
-        if ($ids['contributionRecur']) {
-          // check if first contribution is completed, else complete first contribution
-          $first = TRUE;
-          $completedStatusId = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Completed');
-          if ($objects['contribution']->contribution_status_id == $completedStatusId) {
-            $first = FALSE;
-          }
-          $this->recur($input, $ids, $objects, $first);
-          return;
+      if (!empty($ids['contributionRecur'])) {
+        // check if first contribution is completed, else complete first contribution
+        $first = TRUE;
+        $completedStatusId = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Completed');
+        if ($objects['contribution']->contribution_status_id == $completedStatusId) {
+          $first = FALSE;
         }
+        $this->recur($input, $ids, $objects, $first);
+        return;
       }
+
       $status = $input['paymentStatus'];
       if ($status === 'Denied' || $status === 'Failed' || $status === 'Voided') {
         $this->failed($objects);


### PR DESCRIPTION


Overview
----------------------------------------
Checking component AND contributionRecur is silly - the latter will only
be set if relevant so remove the extra if

Before
----------------------------------------
```
 if ($component == 'contribute') {
        if ($ids['contributionRecur']) {
```

After
----------------------------------------
Just check ```$ids['contributionRecur']```

Technical Details
----------------------------------------
In practice component is event or contribute & ```$ids['contributionRecur']``` will only be loaded if the component is contribute - but we also just don't need to check both.

Comments
----------------------------------------
