### PR TITLE
dev/core#2147 Switch the groups search field on Simple search back fr…

### DIFF
--- a/CRM/Contact/Form/Search/Basic.php
+++ b/CRM/Contact/Form/Search/Basic.php
@@ -49,14 +49,13 @@ class CRM_Contact_Form_Search_Basic extends CRM_Contact_Form_Search {
 
     // add select for groups
     // Get hierarchical listing of groups, respecting ACLs for CRM-16836.
-    $groupHierarchy = CRM_Contact_BAO_Group::getGroupsHierarchy($this->_group, NULL, '- ');
+    $groupHierarchy = CRM_Contact_BAO_Group::getGroupsHierarchy($this->_group, NULL, '- ', TRUE);
     if (!empty($searchOptions['groups'])) {
       $this->addField('group', [
         'entity' => 'group_contact',
         'label' => ts('in'),
         'placeholder' => ts('- any group -'),
         'options' => $groupHierarchy,
-        'type' => 'Select2',
       ]);
     }
 


### PR DESCRIPTION
…om select2 to normal select

Overview
----------------------------------------
This fixes a the following bug https://lab.civicrm.org/dev/core/-/issues/2147 by switching this field back from Select2 to select.

Before
----------------------------------------
Select 2 field from https://github.com/civicrm/civicrm-core/pull/13958 back to  a select field

After
----------------------------------------
Select field used

Technical Details
----------------------------------------
In select 2 the value is like 1 or 1,2 as a string. With a select is it [1] or [1, 2] as arrays

ping @eileenmcnaughton @monishdeb 