### PR TITLE
Update composer-download-plugin to v3.0.0 to support usage of compose…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -72,7 +72,7 @@
     "cweagans/composer-patches": "~1.0",
     "pear/log": "1.13.2",
     "adrienrn/php-mimetyper": "0.2.2",
-    "civicrm/composer-downloads-plugin": "^2.0",
+    "civicrm/composer-downloads-plugin": "^3.0",
     "league/csv": "^9.2",
     "tplaner/when": "~3.0.0",
     "xkerman/restricted-unserialize": "~1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5d304686f3edec04284e52a859321e0a",
+    "content-hash": "724a188bee13cc82b52f8bdf1da31595",
     "packages": [
         {
             "name": "adrienrn/php-mimetyper",
@@ -407,25 +407,25 @@
         },
         {
             "name": "civicrm/composer-downloads-plugin",
-            "version": "v2.1.1",
+            "version": "v3.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/civicrm/composer-downloads-plugin.git",
-                "reference": "8722bc7d547315be39397a3078bb51ee053ca269"
+                "reference": "3aabb6d259a86158d01829fc2c62a2afb9618877"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/civicrm/composer-downloads-plugin/zipball/8722bc7d547315be39397a3078bb51ee053ca269",
-                "reference": "8722bc7d547315be39397a3078bb51ee053ca269",
+                "url": "https://api.github.com/repos/civicrm/composer-downloads-plugin/zipball/3aabb6d259a86158d01829fc2c62a2afb9618877",
+                "reference": "3aabb6d259a86158d01829fc2c62a2afb9618877",
                 "shasum": ""
             },
             "require": {
-                "composer-plugin-api": "^1.1",
+                "composer-plugin-api": "^1.1 || ^2.0",
                 "php": ">=5.6",
                 "togos/gitignore": "~1.1.1"
             },
             "require-dev": {
-                "composer/composer": "~1.0",
+                "composer/composer": "~1.0 || ~2.0",
                 "friendsofphp/php-cs-fixer": "^2.3",
                 "phpunit/phpunit": "^5.7",
                 "totten/process-helper": "^1.0.1"
@@ -454,7 +454,7 @@
                 }
             ],
             "description": "Composer plugin for downloading additional files within any composer package.",
-            "time": "2019-08-28T00:33:51+00:00"
+            "time": "2020-11-02T04:00:42+00:00"
         },
         {
             "name": "cweagans/composer-patches",
@@ -2896,6 +2896,20 @@
                 "polyfill",
                 "portable",
                 "shim"
+            ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
             ],
             "time": "2020-05-12T16:47:27+00:00"
         },


### PR DESCRIPTION
…r 2.x

Overview
----------------------------------------
This updates the composer-downloads plugin to 3.0.0 so it includes this PR https://github.com/civicrm/composer-downloads-plugin/pull/1 which makes it work with Composer 2.x

Before
----------------------------------------
Composer download plugin only works on composer 1.x

After
----------------------------------------
Composer download plugin works with composer 1.x and composer 2.x

This will fail on karma if it can't download the angular assets properly so if tests pass we should be fine