### PR TITLE
Remove deprecated code

### DIFF
--- a/CRM/Core/Payment/AuthorizeNetIPN.php
+++ b/CRM/Core/Payment/AuthorizeNetIPN.php
@@ -86,10 +86,6 @@ class CRM_Core_Payment_AuthorizeNetIPN extends CRM_Core_Payment_BaseIPN {
 
       $this->loadObjects($input, $ids, $objects, TRUE, $paymentProcessorID);
 
-      if (!empty($ids['paymentProcessor']) && $contributionRecur->payment_processor_id != $ids['paymentProcessor']) {
-        Civi::log()->warning('Payment Processor does not match the recurring processor id.', ['civi.tag' => 'deprecated']);
-      }
-
       if ($component == 'contribute') {
         // check if first contribution is completed, else complete first contribution
         $first = TRUE;


### PR DESCRIPTION

Overview
----------------------------------------
These few lines have had any meaning removed already....


Before
----------------------------------------
<img width="1170" alt="Screen Shot 2020-11-02 at 5 17 37 PM" src="https://user-images.githubusercontent.com/336308/97829898-39c85c80-1d30-11eb-9efe-e06f8d4010e0.png">

After
----------------------------------------
Poof

Technical Details
----------------------------------------
I'm not quite sure what we were trying to communicate at the time but I suspect we were causing tests to fail or something but it feels like the code has moved to make this meaningless now

Comments
----------------------------------------

