### PR TITLE
dev/core#2121 New Field Added In The Pdf Form For The Filename

### DIFF
--- a/CRM/Contact/Form/Task/PDF.php
+++ b/CRM/Contact/Form/Task/PDF.php
@@ -89,6 +89,14 @@ class CRM_Contact_Form_Task_PDF extends CRM_Contact_Form_Task {
     //enable form element
     $this->assign('suppressForm', FALSE);
     CRM_Contact_Form_Task_PDFLetterCommon::buildQuickForm($this);
+    $this->add(
+      'text',
+      'filename',
+      ts('Filename'),
+      ['size' => 45, 'maxlength' => 255],
+      TRUE
+    );
+    $this->addFormRule(['CRM_Contact_Form_Task_PDFLetterCommon', 'contactPdfFormRule'], $this);
   }
 
   /**

--- a/CRM/Contact/Form/Task/PDFLetterCommon.php
+++ b/CRM/Contact/Form/Task/PDFLetterCommon.php
@@ -101,6 +101,26 @@ class CRM_Contact_Form_Task_PDFLetterCommon extends CRM_Core_Form_Task_PDFLetter
   }
 
   /**
+   * Contact Form rule.
+   *
+   * @param array $fields
+   *   The input form values.
+   * @param array $files
+   * @param array $self
+   *   Additional values form 'this'.
+   *
+   * @return bool
+   *   TRUE if no errors, else array of errors.
+   */
+  public static function contactPdfFormRule($fields, $files, $self) {
+    $errors = [];
+    if (!CRM_Utils_Rule::longTitle($fields['filename'])) {
+      $errors['filename'] = ts('Filename should include alphanumeric, -, _ or . only');
+    }
+    return empty($errors) ? TRUE : $errors;
+  }
+
+  /**
    * Process the form after the input has been submitted and validated.
    *
    * @param CRM_Core_Form $form
@@ -178,8 +198,10 @@ class CRM_Contact_Form_Task_PDFLetterCommon extends CRM_Core_Form_Task_PDFLetter
     $mimeType = self::getMimeType($type);
     // ^^ Useful side-effect: consistently throws error for unrecognized types.
 
+    $fileName = !empty($formValues['filename']) ? $formValues['filename'] : "CiviLetter";
+    $fileName = !self::isLiveMode($form) ? $fileName . "_preview" : $fileName;
+    $fileName = "$fileName.$type";
     if ($type == 'pdf') {
-      $fileName = "CiviLetter.$type";
       CRM_Utils_PDF_Utils::html2pdf($html, $fileName, FALSE, $formValues);
     }
     elseif (!empty($formValues['document_file_path'])) {
@@ -187,7 +209,6 @@ class CRM_Contact_Form_Task_PDFLetterCommon extends CRM_Core_Form_Task_PDFLetter
       CRM_Utils_PDF_Document::printDocuments($html, $fileName, $type, $zip);
     }
     else {
-      $fileName = "CiviLetter.$type";
       CRM_Utils_PDF_Document::html2doc($html, $fileName, $formValues);
     }
 

--- a/templates/CRM/Contact/Form/Task/PDFLetterCommon.hlp
+++ b/templates/CRM/Contact/Form/Task/PDFLetterCommon.hlp
@@ -60,3 +60,7 @@
   {capture assign="pdfFormatsURL"}{crmURL p="civicrm/admin/pdfFormats" q="reset=1"}{/capture}
   <p>{ts 1=$pdfFormatsURL}Go to <strong><a href="%1">Administer CiviCRM &raquo; Communications &raquo; Print Page (PDF) Formats</a></strong> to add or edit formats or set the default format.{/ts}</p>
 {/htxt}
+{htxt id="id-contact-pdf-filename"}
+  <p>{ts}Provide filename for downloading the file.{/ts}</p>
+  <p>{ts}Filename should include alphanumeric, -, _ or . only.{/ts}</p>
+{/htxt}

--- a/templates/CRM/Contact/Form/Task/PDFLetterCommon.tpl
+++ b/templates/CRM/Contact/Form/Task/PDFLetterCommon.tpl
@@ -23,6 +23,15 @@
       <td class="label-left">{$form.subject.label}</td>
       <td>{$form.subject.html}</td>
     </tr>
+    <tr>
+      <td class="label-left">
+        {$form.filename.label}
+        {help id="id-contact-pdf-filename" title=$form.filename.label  file="CRM/Contact/Form/Task/PDFLetterCommon.hlp"}
+      </td>
+      <td>
+        {$form.filename.html}
+      </td>
+    </tr>
     {if $form.campaign_id}
     <tr>
       <td class="label-left">{$form.campaign_id.label}</td>


### PR DESCRIPTION
Overview
----------------------------------------
This pr allows the user to provide any name of his choice for the downloading file while creating pdf documents.

Before
----------------------------------------
Any pdf document that was created had a pre defined name of `CiviLetter.ext` and it was not customizable.

After
----------------------------------------
Now a new field has been added to the  form that is responsible for creating the pdf and user can provide any alphanumeric value in the field and that value will be used as a name for the file that will be downloaded once user clicks on download buttons. This pr also appends the filename with '_preview' if user is previewing the document instead of creating the document.