### PR TITLE
dev/core#2139 fix defaulting for multi-select custom fields

### DIFF
--- a/CRM/Core/BAO/CustomOption.php
+++ b/CRM/Core/BAO/CustomOption.php
@@ -137,7 +137,7 @@ class CRM_Core_BAO_CustomOption {
         $action -= CRM_Core_Action::DELETE;
       }
 
-      if (in_array($field->html_type, ['CheckBox', 'Multi-Select'])) {
+      if ($field->html_type == 'CheckBox' || ($field->html_type == 'Select' && $field->serialize == 1)) {
         $options[$dao->id]['is_default'] = (isset($defVal) && in_array($dao->value, $defVal));
       }
       else {

--- a/CRM/Custom/Form/Option.php
+++ b/CRM/Custom/Form/Option.php
@@ -95,9 +95,9 @@ class CRM_Custom_Form_Option extends CRM_Core_Form {
 
       $paramsField = ['id' => $this->_fid];
       CRM_Core_BAO_CustomField::retrieve($paramsField, $fieldDefaults);
-
       if ($fieldDefaults['html_type'] == 'CheckBox'
-        || $fieldDefaults['html_type'] == 'Multi-Select'
+        // Multi-Select
+        || ($fieldDefaults['html_type'] == 'Select' && $fieldDefaults['serialize'] == 1)
       ) {
         if (!empty($fieldDefaults['default_value'])) {
           $defaultCheckValues = explode(CRM_Core_DAO::VALUE_SEPARATOR,
@@ -420,7 +420,8 @@ SELECT count(*)
       $customField->find(TRUE) &&
       (
         $customField->html_type == 'CheckBox' ||
-        $customField->html_type == 'Multi-Select'
+        // Multi Value Select
+        ($customField->html_type == 'Select' && $customField->serialize == 1)
       )
     ) {
       $defVal = explode(


### PR DESCRIPTION
Overview
----------------------------------------
Fixes editing defaults for multi-select custom fields so that:

1. One can select multiple options to be defaulted
2. The default shows up on backend forms correctly (before there was a bug where on backend forms where edited multi-select custom fields were not displaying the defaults)

See https://lab.civicrm.org/dev/core/-/issues/2139 for more details.

Before
----------------------------------------
1. Create a new Multi-Select Field 
![Screenshot from 2020-11-02 13-04-47](https://user-images.githubusercontent.com/11323624/97908254-1095d500-1d0c-11eb-9d07-162bc0b04b05.png) 
2. enter a few options and set one to be the default.
3. Save the new field
4. Edit the field options for this field to have a different default.
5. Go to a form that displays that field on the backend (ex: if the field is on individuals, go to the "New Individual" Form).

EXPECTED RESULT
The field will not show anything defaulted.

After
----------------------------------------
The default should show correctly (and the user should be able to select multiple options to be defaults)
