### PR TITLE
CRM_Core_Error::formatFooException - Don't bomb on 'Error'

### DIFF
--- a/CRM/Core/Error.php
+++ b/CRM/Core/Error.php
@@ -817,11 +817,11 @@ class CRM_Core_Error extends PEAR_ErrorStack {
   /**
    * Render an exception as HTML string.
    *
-   * @param Exception $e
+   * @param Throwable $e
    * @return string
    *   printable HTML text
    */
-  public static function formatHtmlException(Exception $e) {
+  public static function formatHtmlException(Throwable $e) {
     $msg = '';
 
     // Exception metadata
@@ -856,11 +856,11 @@ class CRM_Core_Error extends PEAR_ErrorStack {
   /**
    * Write details of an exception to the log.
    *
-   * @param Exception $e
+   * @param Throwable $e
    * @return string
    *   printable plain text
    */
-  public static function formatTextException(Exception $e) {
+  public static function formatTextException(Throwable $e) {
     $msg = get_class($e) . ": \"" . $e->getMessage() . "\"\n";
 
     $ei = $e;

--- a/tests/phpunit/CRM/Core/ErrorTest.php
+++ b/tests/phpunit/CRM/Core/ErrorTest.php
@@ -46,6 +46,18 @@ class CRM_Core_ErrorTest extends CiviUnitTestCase {
     $this->assertRegexp('/CRM_Core_ErrorTest->testFormatBacktrace_exception/', $msg);
   }
 
+  public function testExceptionLogging() {
+    $e = new \Exception("the exception");
+    Civi::log()->notice('There was an exception!', [
+      'exception' => $e,
+    ]);
+
+    $e = new Error('the error');
+    Civi::log()->notice('There was an error!', [
+      'exception' => $e,
+    ]);
+  }
+
   /**
    * We have two coding conventions for writing to log. Make sure that they work together.
    *


### PR DESCRIPTION
[PHP 7 updated the class hierarchy for exceptions](https://www.php.net/manual/en/language.errors.php7.php). The top-level types for exceptions are now:

* `class Throwable`
* `class Error extends Throwable`
* `class Exception extends Throwable`

This patch fixes a problem when logging exceptions/errors/throwables, as in

```php
Civi::log()->warning('There was a problem', [
  'exception' => $e
]);
```

Before
------

If `$e` is an `Error`, then attempting to log generates a cascaded error.

After
-----

It works whether `$e` is an `Error` or `Exception`.

Comment
-------------

The log field `exception` is perhaps a misnomer now, but it fundamentally represents the same idea and needs similar processing (e.g. recording the message and backtrace).