### PR TITLE
dev/mail#2141 - MailSettings - Add button+API for testing a connection

### DIFF
--- a/CRM/Admin/Form/MailSettings.php
+++ b/CRM/Admin/Form/MailSettings.php
@@ -21,6 +21,8 @@
  */
 class CRM_Admin_Form_MailSettings extends CRM_Admin_Form {
 
+  protected $_testButtonName;
+
   /**
    * Build the form object.
    */
@@ -31,6 +33,16 @@ class CRM_Admin_Form_MailSettings extends CRM_Admin_Form {
     if ($this->_action & CRM_Core_Action::DELETE) {
       return;
     }
+
+    $this->_testButtonName = $this->getButtonName('refresh', 'test');
+    $buttons = $this->getElement('buttons')->getElements();
+    $buttons[] = $this->createElement(
+      'xbutton',
+      $this->_testButtonName,
+      CRM_Core_Page::crmIcon('fa-chain') . ' ' . ts('Save & Test'),
+      ['type' => 'submit', 'class' => 'crm-button']
+    );
+    $this->getElement('buttons')->setElements($buttons);
 
     $this->applyFilter('__ALL__', 'trim');
 
@@ -184,6 +196,14 @@ class CRM_Admin_Form_MailSettings extends CRM_Admin_Form {
     }
     else {
       CRM_Core_Session::setStatus("", ts('Changes Not Saved.'), "info");
+    }
+
+    if ($this->controller->getButtonName() == $this->_testButtonName) {
+      $test = civicrm_api4('MailSettings', 'testConnection', [
+        'where' => [['id', '=', $mailSettings->id]],
+      ])->single();
+      CRM_Core_Session::setStatus($test['details'], $test['title'],
+        $test['error'] ? 'error' : 'success');
     }
   }
 

--- a/CRM/Mailing/MailStore.php
+++ b/CRM/Mailing/MailStore.php
@@ -28,7 +28,7 @@ class CRM_Mailing_MailStore {
    *   Name of the settings set from civimail_mail_settings to use (null for default).
    *
    * @throws Exception
-   * @return object
+   * @return CRM_Mailing_MailStore
    *   mail store implementation for processing CiviMail-bound emails
    */
   public static function getStore($name = NULL) {

--- a/Civi/Api4/Action/MailSettings/TestConnection.php
+++ b/Civi/Api4/Action/MailSettings/TestConnection.php
@@ -1,0 +1,83 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Action\MailSettings;
+
+use Civi\Api4\Generic\BasicBatchAction;
+
+class TestConnection extends BasicBatchAction {
+
+  public function __construct($entityName, $actionName) {
+    parent::__construct($entityName, $actionName, ['id', 'name']);
+  }
+
+  /**
+   * @param array $item
+   * @return array
+   */
+  protected function doTask($item) {
+    try {
+      $mailStore = \CRM_Mailing_MailStore::getStore($item['name']);
+    }
+    catch (\Throwable $t) {
+      \Civi::log()->warning('MailSettings: Failed to establish test connection', [
+        'exception' => $t,
+      ]);
+
+      return [
+        'title' => ts("Failed to connect"),
+        'details' => $t->getMessage() . "\n" . ts('(See log for more details.)'),
+        'error' => TRUE,
+      ];
+    }
+
+    if (empty($mailStore)) {
+      return [
+        'title' => ts("Failed to connect"),
+        'details' => ts('The mail service was not instantiated.'),
+        'error' => TRUE,
+      ];
+    }
+
+    $limitTestCount = 5;
+    try {
+      $msgs = $mailStore->fetchNext($limitTestCount);
+    }
+    catch (\Throwable $t) {
+      \Civi::log()->warning('MailSettings: Failed to read test message', [
+        'exception' => $t,
+      ]);
+      return [
+        'title' => ts('Failed to read test message'),
+        'details' => $t->getMessage() . "\n" . ts('(See log for more details.)'),
+        'error' => TRUE,
+      ];
+    }
+
+    if (count($msgs) === 0) {
+      return [
+        'title' => ts('Connection succeeded.'),
+        'details' => ts('No new messages found.'),
+        'error' => FALSE,
+      ];
+    }
+    else {
+      return [
+        'title' => ts('Connection succeeded.'),
+        'details' => ts('Found at least %1 new messages.', [
+          1 => count($msgs),
+        ]),
+        'error' => FALSE,
+      ];
+    }
+  }
+
+}

--- a/Civi/Api4/MailSettings.php
+++ b/Civi/Api4/MailSettings.php
@@ -26,4 +26,15 @@ namespace Civi\Api4;
  */
 class MailSettings extends Generic\DAOEntity {
 
+  /**
+   * Check whether the mail store is accessible.
+   *
+   * @param bool $checkPermissions
+   * @return \Civi\Api4\Action\MailSettings\TestConnection
+   */
+  public static function testConnection($checkPermissions = TRUE) {
+    $action = new \Civi\Api4\Action\MailSettings\TestConnection(static::class, __FUNCTION__);
+    return $action->setCheckPermissions($checkPermissions);
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------

When an administrator creates inbound mail settings (`Administer => CiviMail => Mail Accounts`), it asks for a number of picky details -- like username, password, server, protocol, etc. This patch makes it easier to validate those details.

Before
----------------------------------------
There is no option to test a connection. You would have to configure a cron-worker for that connection, run it, and check its output. (Or, you have to figure out some complicated `cv php:eval` commands... which is what I was doing before...)

After
----------------------------------------

The "Edit Mail Account" presents a button "Save & Test" (inspired by the similar button used on "Outbound Mail" settings).

![Screenshot from 2020-11-02 22-43-19](https://user-images.githubusercontent.com/1336047/97956295-21226b80-1d5d-11eb-987b-cea076abe1e7.png)

If it succeeds, then it shows a happy message:

![Screenshot from 2020-11-02 22-44-19](https://user-images.githubusercontent.com/1336047/97956292-1ff13e80-1d5d-11eb-8178-60032da1bcb7.png)

And if it fails, then it shows a sad message:

![Screenshot from 2020-11-02 22-43-30](https://user-images.githubusercontent.com/1336047/97956293-2089d500-1d5d-11eb-8873-a8cb753a01b9.png)

Technical Details
----------------------------------------

The logic of the test is wrapped in a APIv4 action (`MailSettings.testConnection`) to make it easier to use in more contexts (eg CLI).