### PR TITLE
(dev/core#2153) BUG: when changing a custom group option value CiviCR…

### DIFF
--- a/CRM/Custom/Form/Option.php
+++ b/CRM/Custom/Form/Option.php
@@ -483,6 +483,7 @@ SELECT count(*)
       }
     }
 
+    CRM_Core_BAO_CustomOption::updateValue($customOption->id, $customOption->value);
     $customOption->save();
 
     $msg = ts('Your multiple choice option \'%1\' has been saved', [1 => $customOption->label]);


### PR DESCRIPTION
…M does not update existing records

Overview
----------------------------------------

Steps to replicate :
Create a custom field of type Alphanumeric and html Select
Create options one with value(1).
![s](https://user-images.githubusercontent.com/3455173/97974075-17e0df80-1ded-11eb-874b-2fd98218cc54.png)



Edit values for a contact with custom field selected as 'one' and save.
![Screenshot from 2020-10-30 18:34:27](https://user-images.githubusercontent.com/3455173/97973646-6477eb00-1dec-11eb-8c71-215839126b72.png)

Go to options and change value of one to 2.
![Screenshot from 2020-10-30 18:36:12](https://user-images.githubusercontent.com/3455173/97973702-7b1e4200-1dec-11eb-9a77-262916fe8d5a.png)



Contact will no longer display the value 'one' since in DB the value will not have been synce'd to 2 in custom field value table.




Before
----------------------------------------
![ssss](https://user-images.githubusercontent.com/3455173/97973792-a143e200-1dec-11eb-9bbc-20e1e75cea9a.png)

After
----------------------------------------
![Screenshot from 2020-10-30 18:34:27](https://user-images.githubusercontent.com/3455173/97973808-a9038680-1dec-11eb-928b-2ac4c69abfdb.png)
