### PR TITLE
Make civicrm-setup work with a unix-socket for database connection

### DIFF
--- a/Civi/Install/Requirements.php
+++ b/Civi/Install/Requirements.php
@@ -133,7 +133,7 @@ class Requirements {
       $host = $db_config['server'];
     }
     if (empty($db_config['ssl_params'])) {
-      $conn = @mysqli_connect($host, $db_config['username'], $db_config['password'], $db_config['database'], !empty($db_config['port']) ? $db_config['port'] : NULL);
+      $conn = @mysqli_connect($host, $db_config['username'], $db_config['password'], $db_config['database'], !empty($db_config['port']) ? $db_config['port'] : NULL, $db_config['socket'] ?? NULL);
     }
     else {
       $conn = NULL;
@@ -146,7 +146,7 @@ class Requirements {
         $db_config['ssl_params']['capath'] ?? NULL,
         $db_config['ssl_params']['cipher'] ?? NULL
       );
-      if (@mysqli_real_connect($init, $host, $db_config['username'], $db_config['password'], $db_config['database'], (!empty($db_config['port']) ? $db_config['port'] : NULL), NULL, MYSQLI_CLIENT_SSL)) {
+      if (@mysqli_real_connect($init, $host, $db_config['username'], $db_config['password'], $db_config['database'], (!empty($db_config['port']) ? $db_config['port'] : NULL), $db_config['socket'] ?? NULL, MYSQLI_CLIENT_SSL)) {
         $conn = $init;
       }
     }

--- a/setup/plugins/blocks/advanced.tpl.php
+++ b/setup/plugins/blocks/advanced.tpl.php
@@ -39,6 +39,7 @@ endif; ?>
           <p><?php echo ts('By default, CiviCRM uses the same database as your website. You may install on a separate database if you need more fine-grained control over permissions, replication, hardware capacity, etc.'); ?></p>
           <p><?php echo ts('<strong>Example</strong>: <code>%1</code>', array(1 => 'mysql://admin:secret@localhost/civicrm')); ?></p>
           <p><?php echo ts('<strong>Example</strong>: <code>%1</code>', array(1 => 'mysql://admin:secret@127.0.0.1:3306/otherdb')); ?></p>
+          <p><?php echo ts('<strong>Example</strong>: <code>%1</code>', array(1 => 'mysql://admin:secret@unix(/var/lib/mysql/mysql.sock)/otherdb')); ?></p>
         </div>
       </td>
     </tr>

--- a/setup/plugins/checkRequirements/CoreRequirementsAdapter.civi-setup.php
+++ b/setup/plugins/checkRequirements/CoreRequirementsAdapter.civi-setup.php
@@ -22,10 +22,11 @@ if (!defined('CIVI_SETUP')) {
     _corereqadapter_addMessages($e, 'system', $systemMsgs);
 
     \Civi\Setup::log()->info(sprintf('[%s] Run Requirements::checkDatabase()', basename(__FILE__)));
-    list ($host, $port) = \Civi\Setup\DbUtil::decodeHostPort($model->db['server']);
+    list ($host, $port, $socket) = \Civi\Setup\DbUtil::decodeHostPort($model->db['server']);
     $dbMsgs = $r->checkDatabase(array(
       'host' => $host,
       'port' => $port,
+      'socket' => $socket,
       'username' => $model->db['username'],
       'password' => $model->db['password'],
       'database' => $model->db['database'],

--- a/setup/plugins/init/Backdrop.civi-setup.php
+++ b/setup/plugins/init/Backdrop.civi-setup.php
@@ -40,6 +40,7 @@ if (!defined('CIVI_SETUP')) {
     // Compute DSN.
     global $databases;
     $ssl_params = \Civi\Setup\DrupalUtil::guessSslParams($databases['default']['default']);
+    // @todo Does Backdrop support unixsocket in config? Set 'server' => 'unix(/path/to/socket.sock)'
     $model->db = $model->cmsDb = array(
       'server' => \Civi\Setup\DbUtil::encodeHostPort($databases['default']['default']['host'], $databases['default']['default']['port'] ?: NULL),
       'username' => $databases['default']['default']['username'],

--- a/setup/plugins/init/Drupal.civi-setup.php
+++ b/setup/plugins/init/Drupal.civi-setup.php
@@ -38,6 +38,7 @@ if (!defined('CIVI_SETUP')) {
     // Compute DSN.
     global $databases;
     $ssl_params = \Civi\Setup\DrupalUtil::guessSslParams($databases['default']['default']);
+    // @todo Does Drupal support unixsocket in config? Set 'server' => 'unix(/path/to/socket.sock)'
     $model->db = $model->cmsDb = array(
       'server' => \Civi\Setup\DbUtil::encodeHostPort($databases['default']['default']['host'], $databases['default']['default']['port'] ?: NULL),
       'username' => $databases['default']['default']['username'],

--- a/setup/plugins/init/Drupal8.civi-setup.php
+++ b/setup/plugins/init/Drupal8.civi-setup.php
@@ -41,6 +41,7 @@ if (!defined('CIVI_SETUP')) {
     // Compute DSN.
     $connectionOptions = \Drupal::database()->getConnectionOptions();
     $ssl_params = \Civi\Setup\DrupalUtil::guessSslParams($connectionOptions);
+    // @todo Does Drupal support unixsocket in config? Set 'server' => 'unix(/path/to/socket.sock)'
     $model->db = $model->cmsDb = array(
       'server' => \Civi\Setup\DbUtil::encodeHostPort($connectionOptions['host'], $connectionOptions['port'] ?: NULL),
       'username' => $connectionOptions['username'],

--- a/setup/plugins/init/WordPress.civi-setup.php
+++ b/setup/plugins/init/WordPress.civi-setup.php
@@ -50,8 +50,9 @@ if (!defined('CIVI_SETUP')) {
     $model->templateCompilePath = implode(DIRECTORY_SEPARATOR, [$uploadDir['basedir'], 'civicrm', 'templates_c']);
 
     // Compute DSN.
+    list(/*$host*/, /*$port*/, $socket) = Civi\Setup\DbUtil::decodeHostPort(DB_HOST);
     $model->db = $model->cmsDb = array(
-      'server' => DB_HOST,
+      'server' => $socket ? sprintf('unix(%s)', $socket) : DB_HOST,
       'username' => DB_USER,
       'password' => DB_PASSWORD,
       'database' => DB_NAME,

--- a/setup/src/Setup/DbUtil.php
+++ b/setup/src/Setup/DbUtil.php
@@ -18,9 +18,9 @@ class DbUtil {
     //   ...
     // ]
     if ($parsed['host'] == 'unix(') {
-       preg_match('/(unix\(.*\))(\/(.+)?)?$/', $dsn, $matches);
-       $server = $matches[1];
-       $database = $matches[3] ?? NULL;
+      preg_match('/(unix\(.*\))(\/(.+)?)?$/', $dsn, $matches);
+      $server = $matches[1];
+      $database = $matches[3] ?? NULL;
     }
     else {
       $server = self::encodeHostPort($parsed['host'], $parsed['port'] ?? NULL);
@@ -109,9 +109,9 @@ class DbUtil {
   public static function decodeHostPort($host) {
     $port = NULL;
     $socket = NULL;
-    if(preg_match('/^unix\(([^)]+)\)$/', $host, $matches) === 1) {
-       $host = 'localhost';
-       $socket = $matches[1];
+    if (preg_match('/^unix\(([^)]+)\)$/', $host, $matches) === 1) {
+      $host = 'localhost';
+      $socket = $matches[1];
     }
     else {
       $hostParts = explode(':', $host);

--- a/setup/src/Setup/DbUtil.php
+++ b/setup/src/Setup/DbUtil.php
@@ -11,11 +11,27 @@ class DbUtil {
    */
   public static function parseDsn($dsn) {
     $parsed = parse_url($dsn);
+    // parse_url parses 'mysql://admin:secret@unix(/var/lib/mysql/mysql.sock)/otherdb' like:
+    // [
+    //   'host'   => 'unix(',
+    //   'path'   => '/var/lib/mysql/mysql.sock)/otherdb',
+    //   ...
+    // ]
+    if ($parsed['host'] == 'unix(') {
+       preg_match('/(unix\(.*\))(\/(.+)?)?$/', $dsn, $matches);
+       $server = $matches[1];
+       $database = $matches[3] ?? NULL;
+    }
+    else {
+      $server = self::encodeHostPort($parsed['host'], $parsed['port'] ?? NULL);
+      $database = $parsed['path'] ? ltrim($parsed['path'], '/') : NULL;
+    }
+
     return array(
-      'server' => self::encodeHostPort($parsed['host'], $parsed['port'] ?? NULL),
+      'server' => $server,
       'username' => $parsed['user'] ?: NULL,
       'password' => $parsed['pass'] ?: NULL,
-      'database' => $parsed['path'] ? ltrim($parsed['path'], '/') : NULL,
+      'database' => $database,
       'ssl_params' => self::parseSSL($parsed['query'] ?? NULL),
     );
   }
@@ -41,9 +57,9 @@ class DbUtil {
    * @return \mysqli
    */
   public static function softConnect($db) {
-    list($host, $port) = self::decodeHostPort($db['server']);
+    list($host, $port, $socket) = self::decodeHostPort($db['server']);
     if (empty($db['ssl_params'])) {
-      $conn = @mysqli_connect($host, $db['username'], $db['password'], $db['database'], $port);
+      $conn = @mysqli_connect($host, $db['username'], $db['password'], $db['database'], $port, $socket);
     }
     else {
       $conn = NULL;
@@ -56,8 +72,7 @@ class DbUtil {
         $db['ssl_params']['capath'] ?? NULL,
         $db['ssl_params']['cipher'] ?? NULL
       );
-      // @todo socket parameter, but if you're using sockets do you need SSL?
-      if (@mysqli_real_connect($init, $host, $db['username'], $db['password'], $db['database'], $port, NULL, MYSQLI_CLIENT_SSL)) {
+      if (@mysqli_real_connect($init, $host, $db['username'], $db['password'], $db['database'], $port, $socket, MYSQLI_CLIENT_SSL)) {
         $conn = $init;
       }
     }
@@ -84,21 +99,34 @@ class DbUtil {
    *   Ex: '127.0.0.1:123'
    *   Ex: '[1234:abcd]'
    *   Ex: '[1234:abcd]:123'
+   *   Ex: 'localhost:/path/to/socket.sock
+   *   Ex: 'unix(/path/to/socket.sock)
    * @return array
-   *   Combination: [0 => string $host, 1 => numeric|NULL $port].
-   *   Ex: ['localhost', NULL].
-   *   Ex: ['127.0.0.1', 3306]
+   *   Combination: [0 => string $host, 1 => numeric|NULL $port, 2 => string|NULL].
+   *   Ex: ['localhost', NULL, NULL].
+   *   Ex: ['127.0.0.1', 3306, NULL]
    */
   public static function decodeHostPort($host) {
-    $hostParts = explode(':', $host);
-    if (count($hostParts) > 1 && strrpos($host, ']') !== strlen($host) - 1) {
-      $port = array_pop($hostParts);
-      $host = implode(':', $hostParts);
+    $port = NULL;
+    $socket = NULL;
+    if(preg_match('/^unix\(([^)]+)\)$/', $host, $matches) === 1) {
+       $host = 'localhost';
+       $socket = $matches[1];
     }
     else {
-      $port = NULL;
+      $hostParts = explode(':', $host);
+      if (count($hostParts) > 1 && strrpos($host, ']') !== strlen($host) - 1) {
+        $portOrSocket = array_pop($hostParts);
+        if (substr($portOrSocket, /*start*/ 0, /*length*/ 1) == '/') {
+          $socket = $portOrSocket;
+        }
+        else {
+          $port = $portOrSocket;
+        }
+        $host = implode(':', $hostParts);
+      }
     }
-    return array($host, $port);
+    return array($host, $port, $socket);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
This makes `civicrm-setup` work with a unix-socket for database connection. If using WordPress as CMS, the setting is automatically detected.
See discussion here: https://lab.civicrm.org/dev/wordpress/-/issues/35

Before
----------------------------------------
CiviCRM supports unix socket for DB-connection. The format for the dsn is `mysql://admin:secret@unix(/var/lib/mysql/mysql.sock)/dbname`.
However the installer fails with an error, since it can't parse either the settings from the CRM, nor the dsn.

After
----------------------------------------
`civicrm-setup` can handle database connections with unix sockets.
DB-settings from WordPress with unix-socket are detected.
An extra example is shown to the user how to use a dsn with unix-socket.

Technical Details
----------------------------------------
`setup/src/Setup/DbUtil.php`is fixed to be able to deal with sockets. Also `Civi/Install/Requirements.php` is updated. However the later isn't tested. `setup/plugins/init/WordPress.civi-setup.php` is updated to detect WordPress settings. For Drupal and Backdrop there are insertet a comments in the code, if someone wants to fix automatic support for these.

When a unix-socket is used $db[`server`] is set to `unix(/path/to/socket.sock)`. (Unix sockets are always on localhost.)

Comments
----------------------------------------
No extensive testing is made, since I don't have the time to set up an developer environment for CiviCRM. The code is tested with latest WordPress, but WordPress version should not be an issue.
