### PR TITLE
Remove unused hook_civicrm_crudLink and switch to using metadata for crudLinks

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -715,47 +715,6 @@ WHERE     civicrm_contact.id = " . CRM_Utils_Type::escape($id, 'Integer');
   }
 
   /**
-   * Create last viewed link to recently updated contact.
-   *
-   * @param array $crudLinkSpec
-   *  - action: int, CRM_Core_Action::UPDATE or CRM_Core_Action::VIEW [default: VIEW]
-   *  - entity_table: string, eg "civicrm_contact"
-   *  - entity_id: int
-   *
-   * @return array|NULL
-   *   NULL if unavailable, or
-   *   [path: string, query: string, title: string]
-   * @see CRM_Utils_System::createDefaultCrudLink
-   */
-  public function createDefaultCrudLink($crudLinkSpec) {
-    switch ($crudLinkSpec['action']) {
-      case CRM_Core_Action::VIEW:
-        $result = [
-          'title' => $this->display_name,
-          'path' => 'civicrm/contact/view',
-          'query' => [
-            'reset' => 1,
-            'cid' => $this->id,
-          ],
-        ];
-        return $result;
-
-      case CRM_Core_Action::UPDATE:
-        $result = [
-          'title' => $this->display_name,
-          'path' => 'civicrm/contact/add',
-          'query' => [
-            'reset' => 1,
-            'action' => 'update',
-            'cid' => $this->id,
-          ],
-        ];
-        return $result;
-    }
-    return NULL;
-  }
-
-  /**
    * Get the values for pseudoconstants for name->value and reverse.
    *
    * @param array $defaults

--- a/CRM/Core/Smarty/plugins/function.crmCrudLink.php
+++ b/CRM/Core/Smarty/plugins/function.crmCrudLink.php
@@ -20,29 +20,26 @@
  *
  * @param array $params
  *   Array with keys:
- *   - table: string
+ *   - entity|table: string
  *   - id: int
- *   - action: string, 'VIEW' or 'UPDATE' [default: VIEW]
+ *   - action: string, 'view', 'update', 'delete', etc [default: view]
  *   - title: string [optionally override default title]
  * @param CRM_Core_Smarty $smarty
  *
  * @return string
  */
 function smarty_function_crmCrudLink($params, &$smarty) {
-  if (empty($params['action'])) {
-    $params['action'] = 'VIEW';
-  }
-
   $link = CRM_Utils_System::createDefaultCrudLink([
-    'action' => constant('CRM_Core_Action::' . $params['action']),
-    'entity_table' => $params['table'],
-    'entity_id' => $params['id'],
+    'action' => $params['action'] ?? 'view',
+    'entity' => $params['entity'] ?? NULL,
+    'entity_table' => $params['table'] ?? NULL,
+    'id' => $params['id'],
   ]);
 
   if ($link) {
     return sprintf('<a href="%s">%s</a>',
       htmlspecialchars($link['url']),
-      htmlspecialchars(CRM_Utils_Array::value('title', $params, $link['title']))
+      htmlspecialchars($params['title'] ?? $link['title'])
     );
   }
   else {

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -2410,32 +2410,6 @@ abstract class CRM_Utils_Hook {
   }
 
   /**
-   * Generate a default CRUD URL for an entity.
-   *
-   * @param array $spec
-   *   With keys:.
-   *   - action: int, eg CRM_Core_Action::VIEW or CRM_Core_Action::UPDATE
-   *   - entity_table: string
-   *   - entity_id: int
-   * @param CRM_Core_DAO $bao
-   * @param array $link
-   *   To define the link, add these keys to $link:.
-   *   - title: string
-   *   - path: string
-   *   - query: array
-   *   - url: string (used in lieu of "path"/"query")
-   *      Note: if making "url" CRM_Utils_System::url(), set $htmlize=false
-   * @return mixed
-   * @deprecated
-   */
-  public static function crudLink($spec, $bao, &$link) {
-    return self::singleton()->invoke(['spec', 'bao', 'link'], $spec, $bao, $link,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject,
-      'civicrm_crudLink'
-    );
-  }
-
-  /**
    * Modify the CiviCRM container - add new services, parameters, extensions, etc.
    *
    * ```

--- a/tests/phpunit/CRM/Utils/SystemTest.php
+++ b/tests/phpunit/CRM/Utils/SystemTest.php
@@ -250,6 +250,35 @@ class CRM_Utils_SystemTest extends CiviUnitTestCase {
     $this->assertTrue(CRM_Utils_System::isNull($arr));
   }
 
+  public function crudLinkExamples() {
+    return [
+      'Contact:update' => [
+        ['entity' => 'Contact', 'action' => 'update', 'id' => 123],
+        ['title' => 'Edit Contact', 'url' => '/index.php?q=civicrm/contact/add&reset=1&action=update&cid=123'],
+      ],
+      'civicrm_contact:UPDATE' => [
+        ['entity_table' => 'civicrm_contact', 'action' => CRM_Core_Action::UPDATE, 'entity_id' => 123],
+        ['title' => 'Edit Contact', 'url' => '/index.php?q=civicrm/contact/add&reset=1&action=update&cid=123'],
+      ],
+      'civicrm_activity:ADD' => [
+        ['entity_table' => 'civicrm_activity', 'action' => CRM_Core_Action::ADD],
+        ['title' => 'New Activity', 'url' => '/index.php?q=civicrm/activity&reset=1&action=add&context=standalone'],
+      ],
+      'Contribution:delete' => [
+        ['entity' => 'Contribution', 'action' => 'DELETE', 'id' => 456],
+        ['title' => 'Delete Contribution', 'url' => '/index.php?q=civicrm/contact/view/contribution&reset=1&action=delete&id=456'],
+      ],
+    ];
+  }
+
+  /**
+   * @dataProvider crudLinkExamples
+   */
+  public function testCrudLink($params, $expectedResult) {
+    $result = CRM_Utils_System::createDefaultCrudLink($params);
+    $this->assertEquals($expectedResult, $result);
+  }
+
   /**
    * Test that flushing cache clears the asset cache.
    */
@@ -258,7 +287,7 @@ class CRM_Utils_SystemTest extends CiviUnitTestCase {
     // method to get it, so create a file in the folder using public methods,
     // then get the path from that, then flush the cache, then check if the
     // folder is empty.
-    \Civi::dispatcher()->addListener('hook_civicrm_buildAsset', array($this, 'flushCacheClearsAssetCache_buildAsset'));
+    \Civi::dispatcher()->addListener('hook_civicrm_buildAsset', [$this, 'flushCacheClearsAssetCache_buildAsset']);
     $fakeFile = \Civi::service("asset_builder")->getPath('fakeFile.json');
 
     CRM_Utils_System::flushCache();


### PR DESCRIPTION
Overview
----------------------------------------
The hook `civicrm_crudLink` is unused according to a grep of 'civicrm_universe', and the function `CRM_Utils_System::createDefaultCrudLink` had poor entity coverage (despite the goal to be generic, it only worked for the Contact entity).
Switching that function to use the new 'paths' metadata vastly improves coverage.

Before
----------------------------------------
Function `CRM_Utils_System::createDefaultCrudLink` (which is only used in 2 places throughout the CiviCRM universe) fired a hook which is not implemented anywhere (core or universe). It relied on DAOs to either implement the hook (none did) or provide a callback function named `createDefaultCrudLink` (only Contact did so).

After
----------------------------------------
- Unused hook removed
- Callback on Contact BAO deleted in favor of new metadata
- Function now uses metadata to support more entities
- Function no longer looks up display name, that wasn't very efficient; instead uses entity title from metadata
- Function now generates relative urls by default with an option for absolute
- Test added :)