### PR TITLE
dev/core#2165 Test for Handle emojis less fatally where not supported

### DIFF
--- a/CRM/Core/BAO/SchemaHandler.php
+++ b/CRM/Core/BAO/SchemaHandler.php
@@ -877,11 +877,28 @@ MODIFY      {$columnName} varchar( $length )
    *
    * @return string
    */
-  public static function getInUseCollation() {
+  public static function getInUseCollation(): string {
     if (!isset(\Civi::$statics[__CLASS__][__FUNCTION__])) {
       $dao = CRM_Core_DAO::executeQuery('SHOW TABLE STATUS LIKE \'civicrm_contact\'');
       $dao->fetch();
       \Civi::$statics[__CLASS__][__FUNCTION__] = $dao->Collation;
+    }
+    return \Civi::$statics[__CLASS__][__FUNCTION__];
+  }
+
+  /**
+   * Does the database support utf8mb4.
+   *
+   * Utf8mb4 is required to support emojis but older databases may not have it enabled.
+   *
+   * This is aggressively cached despite just being a string function
+   * as it is expected it might be called many times.
+   *
+   * @return bool
+   */
+  public static function databaseSupportsUTF8MB4(): bool {
+    if (!isset(\Civi::$statics[__CLASS__][__FUNCTION__])) {
+      \Civi::$statics[__CLASS__][__FUNCTION__] = stripos(self::getInUseCollation(), 'utf8mb4') === TRUE;
     }
     return \Civi::$statics[__CLASS__][__FUNCTION__];
   }

--- a/Civi/Test/Api3TestTrait.php
+++ b/Civi/Test/Api3TestTrait.php
@@ -173,7 +173,7 @@ trait Api3TestTrait {
 
   /**
    * This function exists to wrap api getValue function & check the result
-   * so we can ensure they succeed & throw exceptions without litterering the test with checks
+   * so we can ensure they succeed & throw exceptions without littering the test with checks
    * There is a type check in this
    *
    * @param string $entity

--- a/tests/phpunit/api/v4/Action/ContactGetTest.php
+++ b/tests/phpunit/api/v4/Action/ContactGetTest.php
@@ -102,4 +102,34 @@ class ContactGetTest extends \api\v4\UnitTestCase {
     $this->assertTrue(!empty($limit1->single()['sort_name']));
   }
 
+  /**
+   * Test a lack of fatal errors when the where contains an emoji.
+   *
+   * By default our DBs are not 🦉 compliant. This test will age
+   * out when we are.
+   *
+   * @throws \API_Exception
+   */
+  public function testEmoji(): void {
+    $schemaNeedsAlter = \CRM_Core_BAO_SchemaHandler::databaseSupportsUTF8MB4();
+    if ($schemaNeedsAlter) {
+      \CRM_Core_DAO::executeQuery("
+        ALTER TABLE civicrm_contact MODIFY COLUMN
+        `first_name` VARCHAR(64) CHARACTER SET utf8 COLLATE utf8_unicode_ci DEFAULT NULL COMMENT 'First Name.',
+        CHARSET utf8
+      ");
+    }
+    Contact::get()
+      ->setDebug(TRUE)
+      ->addWhere('first_name', '=', '🦉Claire')
+      ->execute();
+    if ($schemaNeedsAlter) {
+      \CRM_Core_DAO::executeQuery("
+        ALTER TABLE civicrm_contact MODIFY COLUMN
+        `first_name` VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT 'First Name.',
+        CHARSET utf8mb4
+      ");
+    }
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Test for emoji find - demonstrates that using an emoji in the string currently results in a fatal error

Before
----------------------------------------
No test

After
----------------------------------------
test

Technical Details
----------------------------------------
What to do?

I'm honestly tempted just to swap the emoji for the word emoji when it is in the string - that would mean it's not found - which seems correct to me

We can use a construct something like

```
    $collation = CRM_Core_BAO_SchemaHandler::getInUseCollation();

    if (stripos($collation, 'utf8mb4') === FALSE) {
      // kill the owl
    }
```

Comments
----------------------------------------
