### PR TITLE
Add FinancialAccount table as BridgeEntity

### DIFF
--- a/Civi/Api4/FinancialAccount.php
+++ b/Civi/Api4/FinancialAccount.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+
+namespace Civi\Api4;
+
+/**
+ * FinancialAccount entity - exposes CiviCRM FinancialAccount.
+ *
+ * @package Civi\Api4
+ */
+class FinancialAccount extends Generic\BridgeEntity {
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Added the FinancialAccount table as a BridgeEntity class to allow for accessing the Financial Account date through the API v4.

Before
----------------------------------------
Only calls through Api3 were allowed for this table

After
----------------------------------------
Allows for making calls to Civi\Api4\FinancialAccount using standard Entity actions.

Comments
----------------------------------------
This is just adding missing api functionality for v4. @colemanw and @MikeyMJCO  confirmed this was missing and suggested the use of a BridgeEntity for this.
