### PR TITLE
dev/core#2121 Option for custom filename for pdf downloads

### DIFF
--- a/CRM/Contact/Form/Task/PDFLetterCommon.php
+++ b/CRM/Contact/Form/Task/PDFLetterCommon.php
@@ -178,8 +178,10 @@ class CRM_Contact_Form_Task_PDFLetterCommon extends CRM_Core_Form_Task_PDFLetter
     $mimeType = self::getMimeType($type);
     // ^^ Useful side-effect: consistently throws error for unrecognized types.
 
+    $fileName = self::getFileName($form);
+    $fileName = "$fileName.$type";
+
     if ($type == 'pdf') {
-      $fileName = "CiviLetter.$type";
       CRM_Utils_PDF_Utils::html2pdf($html, $fileName, FALSE, $formValues);
     }
     elseif (!empty($formValues['document_file_path'])) {
@@ -187,7 +189,6 @@ class CRM_Contact_Form_Task_PDFLetterCommon extends CRM_Core_Form_Task_PDFLetter
       CRM_Utils_PDF_Document::printDocuments($html, $fileName, $type, $zip);
     }
     else {
-      $fileName = "CiviLetter.$type";
       CRM_Utils_PDF_Document::html2doc($html, $fileName, $formValues);
     }
 
@@ -213,6 +214,29 @@ class CRM_Contact_Form_Task_PDFLetterCommon extends CRM_Core_Form_Task_PDFLetter
     $form->postProcessHook();
 
     CRM_Utils_System::civiExit();
+  }
+
+  /**
+   * Returns the filename for the pdf by striping off unwanted characters and limits the length to 200 characters.
+   *
+   * @param CRM_Core_Form $form
+   *
+   * @return string
+   *   The name of the file.
+   */
+  private static function getFileName(CRM_Core_Form $form) {
+    if (!empty($form->getVar('_submitValues')['filename'])) {
+      $fileName = CRM_Utils_String::munge($form->getVar('_submitValues')['filename'], '_', 200);
+    }
+    elseif (!empty($form->getElement('subject')) && !empty($form->getElement('subject')->getValue())) {
+      $fileName = CRM_Utils_String::munge($form->getElement('subject')->getValue(), '_', 200);
+    }
+    else {
+      $fileName = "CiviLetter";
+    }
+    $fileName = self::isLiveMode($form) ? $fileName : $fileName . "_preview";
+
+    return $fileName;
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
For Print/Merge Activities, the pdf filename was always downloaded with the name `CiviLetter.pdf`. So in this PR, we are allowing the filename to be customised. 
1. By default the Subject of the Activity will be considered as the file name.
2. If No Subject is available, then existing `CiviLetter` will still be used.
3. Also any 3rd party extensions can customise the name even further by submitting the form with `filename` field added.


Before
----------------------------------------
The filename was always `CiviLetter.pdf`.

After
----------------------------------------
![after](https://user-images.githubusercontent.com/5058867/98225504-c8c8b500-1f7a-11eb-982c-d3f581f1e3d2.gif)
