### PR TITLE
Fix crash when changing Country or StateProvince custom fields to single/multi select

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -85,9 +85,18 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
    * @return CRM_Core_DAO_CustomField
    */
   public static function create($params) {
+    $changeSerialize = self::getChangeSerialize($params);
     $customField = self::createCustomFieldRecord($params);
+    // When deserializing a field, the update needs to run before the schema change
+    if ($changeSerialize === 0) {
+      CRM_Core_DAO::singleValueQuery(self::getAlterSerializeSQL($customField));
+    }
     $op = empty($params['id']) ? 'add' : 'modify';
     self::createField($customField, $op);
+    // When serializing a field, the update needs to run after the schema change
+    if ($changeSerialize === 1) {
+      CRM_Core_DAO::singleValueQuery(self::getAlterSerializeSQL($customField));
+    }
 
     CRM_Utils_Hook::post(($op === 'add' ? 'create' : 'edit'), 'CustomField', $customField->id, $customField);
 
@@ -114,10 +123,18 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
    * @throws \CiviCRM_API3_Exception
    */
   public static function bulkSave($bulkParams, $defaults = []) {
-    $addedColumns = $sql = $tables = $customFields = [];
+    $addedColumns = $sql = $tables = $customFields = $pre = $post = [];
     foreach ($bulkParams as $index => $fieldParams) {
       $params = array_merge($defaults, $fieldParams);
+      $changeSerialize = self::getChangeSerialize($params);
       $customField = self::createCustomFieldRecord($params);
+      // Serialize/deserialize sql must run after/before the table is altered
+      if ($changeSerialize === 0) {
+        $pre[] = self::getAlterSerializeSQL($customField);
+      }
+      if ($changeSerialize === 1) {
+        $post[] = self::getAlterSerializeSQL($customField);
+      }
       $fieldSQL = self::getAlterFieldSQL($customField, empty($params['id']) ? 'add' : 'modify');
       if (!isset($params['custom_group_id'])) {
         $params['custom_group_id'] = civicrm_api3('CustomField', 'getvalue', ['id' => $customField->id, 'return' => 'custom_group_id']);
@@ -136,6 +153,10 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
       $customFields[$index] = $customField;
     }
 
+    foreach ($pre as $query) {
+      CRM_Core_DAO::executeQuery($query);
+    }
+
     foreach ($sql as $tableName => $statements) {
       // CRM-7007: do not i18n-rewrite this query
       CRM_Core_DAO::executeQuery("ALTER TABLE $tableName " . implode(', ', $statements), [], TRUE, NULL, FALSE, FALSE);
@@ -147,6 +168,11 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
 
       Civi::service('sql_triggers')->rebuild($params['table_name'], TRUE);
     }
+
+    foreach ($post as $query) {
+      CRM_Core_DAO::executeQuery($query);
+    }
+
     CRM_Utils_System::flushCache();
     foreach ($customFields as $index => $customField) {
       CRM_Utils_Hook::post(empty($bulkParams[$index]['id']) ? 'create' : 'edit', 'CustomField', $customField->id, $customField);
@@ -1699,22 +1725,21 @@ SELECT $columnName
   }
 
   /**
-   * Reformat existing values for a field when changing its serialize attribute
+   * Get query to reformat existing values for a field when changing its serialize attribute
    *
    * @param CRM_Core_DAO_CustomField $field
-   * @throws CRM_Core_Exception
+   * @return string
    */
-  private static function alterSerialize($field) {
+  private static function getAlterSerializeSQL($field) {
     $table = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_CustomGroup', $field->custom_group_id, 'table_name');
     $col = $field->column_name;
     $sp = CRM_Core_DAO::VALUE_SEPARATOR;
     if ($field->serialize) {
-      $sql = "UPDATE `$table` SET `$col` = CONCAT('$sp', `$col`, '$sp') WHERE `$col` IS NOT NULL AND `$col` NOT LIKE '$sp%' AND `$col` != ''";
+      return "UPDATE `$table` SET `$col` = CONCAT('$sp', `$col`, '$sp') WHERE `$col` IS NOT NULL AND `$col` NOT LIKE '$sp%' AND `$col` != ''";
     }
     else {
-      $sql = "UPDATE `$table` SET `$col` = SUBSTRING_INDEX(SUBSTRING(`$col`, 2), '$sp', 1) WHERE `$col` LIKE '$sp%'";
+      return "UPDATE `$table` SET `$col` = SUBSTRING_INDEX(SUBSTRING(`$col`, 2), '$sp', 1) WHERE `$col` LIKE '$sp%'";
     }
-    CRM_Core_DAO::executeQuery($sql);
   }
 
   /**
@@ -2010,9 +2035,6 @@ WHERE  id IN ( %1, %2 )
     $transaction = new CRM_Core_Transaction();
     $params = self::prepareCreate($params);
 
-    $alterSerialize = isset($params['serialize']) && !empty($params['id'])
-      && ($params['serialize'] != CRM_Core_DAO::getFieldValue('CRM_Core_DAO_CustomField', $params['id'], 'serialize'));
-
     $customField = new CRM_Core_DAO_CustomField();
     $customField->copyValues($params);
     $customField->save();
@@ -2033,11 +2055,20 @@ WHERE  id IN ( %1, %2 )
     // make sure all values are present in the object for further processing
     $customField->find(TRUE);
 
-    if ($alterSerialize) {
-      self::alterSerialize($customField);
-    }
-
     return $customField;
+  }
+
+  /**
+   * @param $params
+   * @return int|null
+   */
+  protected static function getChangeSerialize($params) {
+    if (isset($params['serialize']) && !empty($params['id'])) {
+      if ($params['serialize'] != CRM_Core_DAO::getFieldValue('CRM_Core_DAO_CustomField', $params['id'], 'serialize')) {
+        return (int) $params['serialize'];
+      }
+    }
+    return NULL;
   }
 
   /**
@@ -2650,13 +2681,9 @@ WHERE cf.id = %1 AND cg.is_multiple = 1";
       'searchable' => $field->is_searchable,
     ];
 
-    if ($operation == 'delete') {
-      $fkName = "{$tableName}_{$field->column_name}";
-      if (strlen($fkName) >= 48) {
-        $fkName = substr($fkName, 0, 32) . '_' . substr(md5($fkName), 0, 16);
-      }
-      $params['fkName'] = $fkName;
-    }
+    // For adding/dropping FK constraints
+    $params['fkName'] = CRM_Core_BAO_SchemaHandler::getIndexName($tableName, $field->column_name);
+
     if ($field->data_type == 'Country' && !self::isSerialized($field)) {
       $params['fk_table_name'] = 'civicrm_country';
       $params['fk_field_name'] = 'id';


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a crash & possible data loss when changing a custom field of type Country or State/Province from a multi-select to single or vice versa.

Technical Details
----------------------------------------
A single-valued country or state select field is stored as INTEGER with an FK constraint.
A multi-valued field is stored as VARCHAR with no constraint.

Switching back and forth between the two would cause a crash for 2 reasons:
1. The FK constraint was not being added/dropped.
2. Serialization was hapening prematurely and value separator characters were being inserted while the field was still type INTEGER.

Comments
----------------------------------------
Submitted against the 5.31 branch as this could be considered a regression.