### PR TITLE
dev/core#2166 - E_NOTICE when deleting mail account

### DIFF
--- a/CRM/Admin/Form/MailSettings.php
+++ b/CRM/Admin/Form/MailSettings.php
@@ -91,7 +91,7 @@ class CRM_Admin_Form_MailSettings extends CRM_Admin_Form {
    * Add local and global form rules.
    */
   public function addRules() {
-    $this->addFormRule(['CRM_Admin_Form_MailSettings', 'formRule']);
+    $this->addFormRule(['CRM_Admin_Form_MailSettings', 'formRule'], $this);
   }
 
   public function getDefaultEntity() {
@@ -119,15 +119,21 @@ class CRM_Admin_Form_MailSettings extends CRM_Admin_Form {
    *
    * @param array $fields
    *   Posted values of the form.
+   * @param array $files
+   *   Not used here.
+   * @param CRM_Core_Form $form
+   *   This form.
    *
    * @return array
    *   list of errors to be posted back to the form
    */
-  public static function formRule($fields) {
+  public static function formRule($fields, $files, $form) {
     $errors = [];
-    // Check for default from email address and organization (domain) name. Force them to change it.
-    if ($fields['domain'] == 'EXAMPLE.ORG') {
-      $errors['domain'] = ts('Please enter a valid domain for this mailbox account (the part after @).');
+    if ($form->_action != CRM_Core_Action::DELETE) {
+      // Check for default from email address and organization (domain) name. Force them to change it.
+      if ($fields['domain'] == 'EXAMPLE.ORG') {
+        $errors['domain'] = ts('Please enter a valid domain for this mailbox account (the part after @).');
+      }
     }
 
     return empty($errors) ? TRUE : $errors;


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/2166

1. Create a mail account at Administer - CiviMail - Mail Accounts.
2. Make sure to choose Email-to-Activity for the Used For field or else the delete link won't be available (this seems partly like a historical mixup which I'm not going to get into here).
3. Save it.
4. Now click the delete link to delete it.

Before
----------------------------------------
`Notice: Undefined index: domain in CRM_Admin_Form_MailSettings::formRule() (line 129 of ...\CRM\Admin\Form\MailSettings.php)`.

After
----------------------------------------

Technical Details
----------------------------------------
Just wraps the validation in an `if` to see if we're deleting first. The rest is because the function doesn't have enough input to check that as currently written.

Comments
----------------------------------------

