### PR TITLE
dev/core#2167 - Fulltext search drupal block has button on wrong side

### DIFF
--- a/templates/CRM/Block/FullTextSearch.tpl
+++ b/templates/CRM/Block/FullTextSearch.tpl
@@ -24,7 +24,7 @@
 <div class="block-crm crm-container">
     <form method="post" id="id_fulltext_search">
     <div style="margin-bottom: 8px;">
-    <input type="text" name="text" id='text' value="" class="crm-form-text" style="width: 10em;" />&nbsp;<button type="submit" name="submit" id="fulltext_submit" class="crm-button crm-form-submit" onclick='submitForm();'>{ts}Go{/ts}</button>
+    <input type="text" name="text" id='text' value="" class="crm-form-text" />
     <input type="hidden" name="qfKey" value="{crmKey name='CRM_Contact_Controller_Search' addSequence=1}" />
   </div>
   <select class="form-select" id="fulltext_table" name="fulltext_table">
@@ -46,5 +46,6 @@
         <option value="Membership">{ts}Memberships{/ts}</option>
 {/if}
     </select> {help id="id-fullText" file="CRM/Contact/Form/Search/Custom/FullText.hlp"}
+    <div class="crm-submit-buttons"><button type="submit" name="submit" id="fulltext_submit" class="crm-button crm-form-submit" onclick='submitForm();'>{ts}Search{/ts}</button></div>
     </form>
 </div>


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/2167

Technically a regression from the buttons changes in 5.31, so I've based against that, but if there's time constraints on the release this doesn't seem like a high-priority issue.

1. Enable the drupal block for fulltext search (In drupal 7 at admin/structure/block. In drupal 8 good luck figuring that screen out but it's also available.)
2. Note the Go button is weirdly on the left.

Before
----------------------------------------
Go button on left.

<img width="141" alt="1" src="https://user-images.githubusercontent.com/2967821/98260038-d6694500-1f50-11eb-832f-ff69c1f965fe.png">


After
----------------------------------------
Button now says "Search" and is on the bottom in its own buttons row.

<img width="124" alt="2" src="https://user-images.githubusercontent.com/2967821/98260050-d9fccc00-1f50-11eb-8755-1fb70e36939d.png">


Technical Details
----------------------------------------
I changed the button name for two reasons:
* The regular custom search itself which this block ends up running says Search on its button.
* I believe the original reason for "Go" was to save space so it could fit on one line, but this doesn't always work if the language isn't english anyway.

Comments
----------------------------------------

