### PR TITLE
APIv4 - Add FinancialAccount, FinancialType entities, and EntityFinancialType bridgeEntity

### DIFF
--- a/Civi/Api4/EntityFinancialAccount.php
+++ b/Civi/Api4/EntityFinancialAccount.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+
+namespace Civi\Api4;
+
+/**
+ * EntityFinancialAccount - links FinancialAccount to other entities such as FinancialType.
+ *
+ * @package Civi\Api4
+ */
+class EntityFinancialAccount extends Generic\DAOEntity {
+  use Generic\Traits\EntityBridge;
+
+}

--- a/Civi/Api4/FinancialAccount.php
+++ b/Civi/Api4/FinancialAccount.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+
+namespace Civi\Api4;
+
+/**
+ * FinancialAccount entity.
+ *
+ * @package Civi\Api4
+ */
+class FinancialAccount extends Generic\DAOEntity {
+
+}

--- a/Civi/Api4/FinancialType.php
+++ b/Civi/Api4/FinancialType.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+
+namespace Civi\Api4;
+
+/**
+ * FinancialType entity.
+ *
+ * @package Civi\Api4
+ */
+class FinancialType extends Generic\DAOEntity {
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Exposes 3 entities to the API.

Technical Details
----------------------------------------
Nothing fancy, just uses all the default DAOEntity settings.
Marked EntityFinancialType as an EntityBridge since it just serves to link other things together.
