### PR TITLE
closes financial/#156: Set contribution status to refunded even if cancelled_payment_id is set

### DIFF
--- a/tests/phpunit/api/v3/PaymentTest.php
+++ b/tests/phpunit/api/v3/PaymentTest.php
@@ -622,6 +622,33 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test negative payment using create API when the "cancelled_payment_id" param is set.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testRefundPaymentWithCancelledPaymentId() {
+    $result = $this->callAPISuccess('Contribution', 'create', [
+      'financial_type_id' => "Donation",
+      'total_amount' => 100,
+      'contact_id' => $this->_individualId,
+    ]);
+    $contributionID = $result['id'];
+
+    //Refund the complete amount.
+    $this->callAPISuccess('Payment', 'create', [
+      'contribution_id' => $contributionID,
+      'total_amount' => -100,
+      'cancelled_payment_id' => 12345,
+    ]);
+    $contribution = $this->callAPISuccessGetSingle('Contribution', [
+      'return' => ['contribution_status_id'],
+      'id' => $contributionID,
+    ]);
+    //Assert if main contribution status is updated to "Refunded".
+    $this->assertEquals($contribution['contribution_status'], 'Refunded Label**');
+  }
+
+  /**
    * Test cancel payment api
    *
    * @throws \CRM_Core_Exception


### PR DESCRIPTION
Overview
----------------------------------------
Details are on the ticket: https://lab.civicrm.org/dev/financial/-/issues/156

Before
----------------------------------------
Refunded contribution's status is "Completed".

After
----------------------------------------
Refunded contribution's status is "Refunded".

Technical Details
----------------------------------------
This change is already agreed on in #16148; however, the code returns early if `cancelled_payment_id` is set.  This removes the early return and encases code that shouldn't run in an `if...else` statement.

Comments
----------------------------------------
This is a very small change that looks bigger because of indentation issues.  I'm just removing the early `return` line and adding an `else {...}`.
