### PR TITLE
[REF] Minor variable cleanup

### DIFF
--- a/CRM/Core/Payment/PayPalIPN.php
+++ b/CRM/Core/Payment/PayPalIPN.php
@@ -208,8 +208,8 @@ class CRM_Core_Payment_PayPalIPN extends CRM_Core_Payment_BaseIPN {
 
     $this->single($input, [
       'related_contact' => $ids['related_contact'] ?? NULL,
-      'participant' => !empty($objects['participant']) ? $objects['participant']->id : NULL,
-      'contributionRecur' => !empty($objects['contributionRecur']) ? $objects['contributionRecur']->id : NULL,
+      'participant' => $ids['participant'] ?? NULL,
+      'contributionRecur' => $recur->id,
     ], $objects['contribution'], TRUE);
   }
 
@@ -363,7 +363,7 @@ class CRM_Core_Payment_PayPalIPN extends CRM_Core_Payment_BaseIPN {
       $this->single($input, [
         'related_contact' => $ids['related_contact'] ?? NULL,
         'participant' => $ids['participant'] ?? NULL,
-        'contributionRecur' => !empty($objects['contributionRecur']) ? $objects['contributionRecur']->id : NULL,
+        'contributionRecur' => $contributionRecurID,
       ], $objects['contribution']);
     }
     catch (CRM_Core_Exception $e) {


### PR DESCRIPTION


Overview
----------------------------------------
This continues the process of using the variables we have loaded within the IPN
rather than those that were loaded onto objects FROM the ones loaded in this IPN

Before
----------------------------------------
Variables used are the taken from $objects - an array of objects loaded based on the ids in this function

After
----------------------------------------
We use the ids directly

Technical Details
----------------------------------------


Comments
----------------------------------------

