### PR TITLE
[Ref] Use variables directly

### DIFF
--- a/CRM/Core/Payment/PayPalProIPN.php
+++ b/CRM/Core/Payment/PayPalProIPN.php
@@ -280,8 +280,8 @@ class CRM_Core_Payment_PayPalProIPN extends CRM_Core_Payment_BaseIPN {
 
     $this->single($input, [
       'related_contact' => $ids['related_contact'] ?? NULL,
-      'participant' => !empty($objects['participant']) ? $objects['participant']->id : NULL,
-      'contributionRecur' => !empty($objects['contributionRecur']) ? $objects['contributionRecur']->id : NULL,
+      'participant' => $ids['participant'] ?? NULL,
+      'contributionRecur' => $recur->id ?? NULL,
     ], $objects, TRUE, $first);
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Uses variables directly rather than getting them from the object they are transferred to

Before
----------------------------------------
$objects is loaded from $ids & then $ids are loaded from objects

After
----------------------------------------
just use ids

Technical Details
----------------------------------------

Comments
----------------------------------------

