### PR TITLE
Logging report Added support for table containing column created_id, modified_id

### DIFF
--- a/CRM/Logging/Differ.php
+++ b/CRM/Logging/Differ.php
@@ -105,6 +105,48 @@ LEFT JOIN civicrm_activity_contact source ON source.activity_id = lt.id AND sour
           $contactIdClause = "AND id = (select case_id FROM civicrm_case_contact WHERE contact_id = %3 LIMIT 1)";
           break;
 
+        case 'civicrm_batch':
+          $contactIdClause = "AND (created_id = %3 OR modified_id = %3)";
+          break;
+
+        case 'civicrm_group_organization':
+          $contactIdClause = "AND (organization_id = %3)";
+          break;
+
+        case 'civicrm_dedupe_exception':
+          $contactIdClause = "AND (contact_id1 = %3 OR contact_id2 = %3)";
+          break;
+
+        case 'civicrm_campaign':
+        case 'civicrm_survey':
+          $contactIdClause = "AND (created_id = %3 OR last_modified_id = %3)";
+          break;
+
+        case 'civicrm_event_carts':
+          $contactIdClause = "AND (user_id = %3)";
+          break;
+
+        case 'civicrm_membership_type':
+          $contactIdClause = "AND (member_of_contact_id = %3)";
+          break;
+
+        case 'civicrm_custom_group':
+        case 'civicrm_file':
+        case 'civicrm_tag':
+        case 'civicrm_print_label':
+        case 'civicrm_group':
+        case 'civicrm_contribution_page':
+        case 'civicrm_payment_token':
+        case 'civicrm_report_instance':
+        case 'civicrm_uf_group':
+        case 'civicrm_event':
+          $contactIdClause = "AND (created_id = %3)";
+          break;
+
+        case 'civicrm_mailing':
+          $contactIdClause = "AND (created_id = %3 OR scheduled_id = %3 OR approver_id = %3)";
+          break;
+
         default:
           if (array_key_exists($table, $addressCustomTables)) {
             $join = "INNER JOIN `{$this->db}`.`log_civicrm_address` et ON et.id = lt.entity_id";

--- a/CRM/Logging/ReportSummary.php
+++ b/CRM/Logging/ReportSummary.php
@@ -139,6 +139,34 @@ class CRM_Logging_ReportSummary extends CRM_Report_Form {
           'options' => CRM_Case_BAO_Case::buildOptions('case_type_id', 'search'),
         ],
       ],
+      'log_civicrm_event' => [
+        'fk' => 'created_id',
+        'log_type' => 'Event',
+      ],
+      'log_civicrm_tag' => [
+        'fk' => 'created_id',
+        'log_type' => 'Tag',
+      ],
+      'log_civicrm_group' => [
+        'fk' => 'created_id',
+        'log_type' => 'Group',
+      ],
+      'log_civicrm_contribution_page' => [
+        'fk' => 'created_id',
+        'log_type' => 'Contribution Page',
+      ],
+      'log_civicrm_uf_group' => [
+        'fk' => 'created_id',
+        'log_type' => 'Profile',
+      ],
+      'log_civicrm_survey' => [
+        'fk' => 'created_id',
+        'log_type' => 'Survey',
+      ],
+      'log_civicrm_campaign' => [
+        'fk' => 'created_id',
+        'log_type' => 'Campaign',
+      ],
     ];
 
     $logging = new CRM_Logging_Schema();

--- a/CRM/Logging/Schema.php
+++ b/CRM/Logging/Schema.php
@@ -147,6 +147,8 @@ AND    TABLE_NAME LIKE 'civicrm_%'
     // dev/core#1762 Don't log subscription_history
     $this->tables = preg_grep('/^civicrm_subscription_history/', $this->tables, PREG_GREP_INVERT);
 
+    $this->tables = preg_grep('/^civicrm_mailing_abtest/', $this->tables, PREG_GREP_INVERT);
+
     // do not log civicrm_mailing_recipients table, CRM-16193
     $this->tables = array_diff($this->tables, ['civicrm_mailing_recipients']);
     $this->logTableSpec = array_fill_keys($this->tables, []);


### PR DESCRIPTION
Overview
----------------------------------------
Logging ReportDetails were giving SQL Error 

```sql
-- 1
SELECT DISTINCT lt.id FROM `phpunit_civicrm_1`.`log_civicrm_batch` lt

WHERE lt.log_conn_id = '5f9fd7cb6fbd5'
    
    AND contact_id = 202 [nativecode=1054 ** Unknown column 'contact_id' in 'where clause']
-- 2
SELECT DISTINCT lt.id FROM `phpunit_civicrm_1`.`log_civicrm_mailing_abtest` lt

WHERE lt.log_conn_id = '5f9fd7cb6fbd5'
    
    AND contact_id = 202 [nativecode=1054 ** Unknown column 'contact_id' in 'where clause']
```

These table not handled in logging report.

Before
----------------------------------------
getting sql error and there was no support to give summary for log type `Group`, `Tag`, `Event`, `Contribution Page` etc..

After
----------------------------------------
No more sql error, now its show changed made in `Group`, `Tag`, `Event`, `Contribution Page` etc..

Comments
----------------------------------------
Above issue discovered while doing testing for https://github.com/civicrm/civicrm-core/pull/18851#issuecomment-722351612

Question :

Is there way to include `created_id` and `modified_id` in the summary report for same table ?
e.g  `civicrm_group` table have `created_id` and `modified_id` column.