### PR TITLE
Add support for multi-value contact reference custom fields

### DIFF
--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -1288,7 +1288,7 @@ ORDER BY civicrm_custom_group.weight,
         $serialize = CRM_Core_BAO_CustomField::isSerialized($field);
 
         if ($serialize) {
-          if ($field['data_type'] != 'Country' && $field['data_type'] != 'StateProvince') {
+          if ($field['data_type'] != 'Country' && $field['data_type'] != 'StateProvince' && $field['data_type'] != 'ContactReference') {
             $defaults[$elementName] = [];
             $customOption = CRM_Core_BAO_CustomOption::getCustomOption($field['id'], $inactiveNeeded);
             if ($viewMode) {
@@ -1885,13 +1885,19 @@ SELECT IF( EXISTS(SELECT name FROM civicrm_contact_type WHERE name like %1), 1, 
               $details[$groupID][$values['id']]['editable'] = TRUE;
             }
             // also return contact reference contact id if user has view all or edit all contacts perm
-            if ((CRM_Core_Permission::check('view all contacts') ||
-                CRM_Core_Permission::check('edit all contacts'))
-              &&
-              $details[$groupID][$values['id']]['fields'][$k]['field_data_type'] ==
-              'ContactReference'
+            if ($details[$groupID][$values['id']]['fields'][$k]['field_data_type'] === 'ContactReference'
+              && CRM_Core_Permission::check([['view all contacts', 'edit all contacts']])
             ) {
-              $details[$groupID][$values['id']]['fields'][$k]['contact_ref_id'] = $values['data'] ?? NULL;
+              $details[$groupID][$values['id']]['fields'][$k]['contact_ref_links'] = [];
+              $path = CRM_Contact_DAO_Contact::getEntityPaths()['view'];
+              foreach (CRM_Utils_Array::explodePadded($values['data'] ?? []) as $contactId) {
+                $displayName = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Contact', $contactId, 'display_name');
+                if ($displayName) {
+                  $url = CRM_Utils_System::url(str_replace('[id]', $contactId, $path));
+                  $details[$groupID][$values['id']]['fields'][$k]['contact_ref_links'][] = '<a href="' . $url . '" title="' . htmlspecialchars(ts('View Contact')) . '">' .
+                    $displayName . '</a>';
+                }
+              }
             }
           }
         }
@@ -1903,7 +1909,7 @@ SELECT IF( EXISTS(SELECT name FROM civicrm_contact_type WHERE name like %1), 1, 
           $details[$groupID][0]['collapse_display'] = $group['collapse_display'] ?? NULL;
           $details[$groupID][0]['collapse_adv_display'] = $group['collapse_adv_display'] ?? NULL;
           $details[$groupID][0]['style'] = $group['style'] ?? NULL;
-          $details[$groupID][0]['fields'][$k] = ['field_title' => CRM_Utils_Array::value('label', $properties)];
+          $details[$groupID][0]['fields'][$k] = ['field_title' => $properties['label'] ?? NULL];
         }
       }
     }

--- a/CRM/Core/BAO/CustomQuery.php
+++ b/CRM/Core/BAO/CustomQuery.php
@@ -215,6 +215,7 @@ class CRM_Core_BAO_CustomQuery {
           case 'String':
           case 'StateProvince':
           case 'Country':
+          case 'ContactReference':
 
             if ($field['is_search_range'] && is_array($value)) {
               //didn't found any field under any of these three data-types as searchable by range
@@ -276,12 +277,6 @@ class CRM_Core_BAO_CustomQuery {
               }
               $this->_qill[$grouping][] = $field['label'] . " $qillOp $qillValue";
             }
-            break;
-
-          case 'ContactReference':
-            $label = $value ? CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Contact', $value, 'sort_name') : '';
-            $this->_where[$grouping][] = CRM_Contact_BAO_Query::buildClause($fieldName, $op, $value, 'String');
-            $this->_qill[$grouping][] = $field['label'] . " $qillOp $label";
             break;
 
           case 'Int':

--- a/CRM/Core/BAO/CustomValueTable.php
+++ b/CRM/Core/BAO/CustomValueTable.php
@@ -34,6 +34,7 @@ class CRM_Core_BAO_CustomValueTable {
     }
 
     $paramFieldsExtendContactForEntities = [];
+    $VS = CRM_Core_DAO::VALUE_SEPARATOR;
 
     foreach ($customParams as $tableName => $tables) {
       foreach ($tables as $index => $fields) {
@@ -187,8 +188,17 @@ class CRM_Core_BAO_CustomValueTable {
               break;
 
             case 'ContactReference':
-              if ($value == NULL) {
+              if ($value == NULL || $value === '' || $value === $VS . $VS) {
                 $type = 'Timestamp';
+                $value = NULL;
+              }
+              elseif (strpos($value, $VS) !== FALSE) {
+                $type = 'String';
+                // Validate the string contains only integers and value-separators
+                $validChars = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, $VS];
+                if (str_replace($validChars, '', $value)) {
+                  throw new CRM_Core_Exception('Contact ID must be of type Integer');
+                }
               }
               else {
                 $type = 'Integer';

--- a/CRM/Custom/Form/Field.php
+++ b/CRM/Custom/Form/Field.php
@@ -740,7 +740,7 @@ SELECT count(*)
       }
     }
     elseif (in_array($htmlType, self::$htmlTypesWithOptions) &&
-      !in_array($dataType, ['Boolean', 'Country', 'StateProvince'])
+      !in_array($dataType, ['Boolean', 'Country', 'StateProvince', 'ContactReference'])
     ) {
       if (!$fields['option_group_id']) {
         $errors['option_group_id'] = ts('You must select a Multiple Choice Option set if you chose Reuse an existing set.');
@@ -956,7 +956,7 @@ AND    option_group_id = %2";
    *   The serialize type - CRM_Core_DAO::SERIALIZE_XXX or the string 'null'
    */
   public function determineSerializeType($params) {
-    if ($params['data_type'] !== 'ContactReference' && ($params['html_type'] === 'Select' || $params['html_type'] === 'Autocomplete-Select')) {
+    if ($params['html_type'] === 'Select' || $params['html_type'] === 'Autocomplete-Select') {
       return !empty($params['serialize']) ? CRM_Core_DAO::SERIALIZE_SEPARATOR_BOOKEND : 'null';
     }
     else {

--- a/templates/CRM/Contact/Page/View/CustomDataFieldView.tpl
+++ b/templates/CRM/Contact/Page/View/CustomDataFieldView.tpl
@@ -27,10 +27,10 @@
           </div>
         {else}
           <div class="crm-label">{$element.field_title}</div>
-          {if $element.field_data_type EQ 'ContactReference' && $element.contact_ref_id}
+          {if $element.field_data_type EQ 'ContactReference' && $element.contact_ref_links}
             {*Contact ref id passed if user has sufficient permissions - so make a link.*}
             <div class="crm-content crm-custom-data crm-contact-reference">
-              <a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=`$element.contact_ref_id`"}" title="view contact">{$element.field_value}</a>
+              {', '|implode:$element.contact_ref_links}
             </div>
           {elseif $element.field_data_type EQ 'Money'}
             <div class="crm-content crm-custom-data">{$element.field_value|crmMoney}</div>

--- a/templates/CRM/Custom/Form/ContactReference.tpl
+++ b/templates/CRM/Custom/Form/ContactReference.tpl
@@ -18,6 +18,7 @@
     $field.crmSelect2({
       placeholder: {/literal}'{ts escape="js"}- select contact -{/ts}'{literal},
       minimumInputLength: 1,
+      multiple: !!$field.attr('multiple'),
       ajax: {
         url: {/literal}"{$customUrls.$element_name}"{literal},
         quietMillis: 300,

--- a/templates/CRM/Custom/Form/Field.tpl
+++ b/templates/CRM/Custom/Form/Field.tpl
@@ -277,7 +277,7 @@
 
       $("#noteColumns, #noteRows, #noteLength", $form).toggle(dataType === 'Memo');
 
-      $(".crm-custom-field-form-block-serialize", $form).toggle((htmlType === 'Select' || htmlType === 'Autocomplete-Select') && dataType !== 'ContactReference');
+      $(".crm-custom-field-form-block-serialize", $form).toggle(htmlType === 'Select' || htmlType === 'Autocomplete-Select');
     }
 
     function makeDefaultValueField(dataType) {

--- a/templates/CRM/Custom/Page/CustomDataView.tpl
+++ b/templates/CRM/Custom/Page/CustomDataView.tpl
@@ -69,16 +69,12 @@
                         {/if}
                       {else}
                         <td class="html-adjust">
-                          {if $element.contact_ref_id}
-                            <a href='{crmURL p="civicrm/contact/view" q="reset=1&cid=`$element.contact_ref_id`"}'>
-                          {/if}
-                          {if $element.field_data_type == 'Memo'}
+                          {if $element.field_data_type EQ 'ContactReference' && $element.contact_ref_links}
+                            {', '|implode:$element.contact_ref_links}
+                          {elseif $element.field_data_type == 'Memo'}
                             {$element.field_value|nl2br}
                           {else}
                             {$element.field_value}
-                          {/if}
-                          {if $element.contact_ref_id}
-                            </a>
                           {/if}
                         </td>
                       {/if}
@@ -126,16 +122,12 @@
                   {/if}
                 {else}
                   <div class="content">
-                    {if $element.contact_ref_id}
-                      <a href='{crmURL p="civicrm/contact/view" q="reset=1&cid=`$element.contact_ref_id`"}'>
-                    {/if}
-                    {if $element.field_data_type == 'Memo'}
+                    {if $element.field_data_type EQ 'ContactReference' && $element.contact_ref_links}
+                      {', '|implode:$element.contact_ref_links}
+                    {elseif $element.field_data_type == 'Memo'}
                       {if $element.field_value}{$element.field_value|nl2br}{else}<br/>{/if}
                     {else}
                       {if $element.field_value}{$element.field_value} {else}<br/>{/if}
-                    {/if}
-                    {if $element.contact_ref_id}
-                      </a>
                     {/if}
                   </div>
                 {/if}

--- a/tests/phpunit/CRM/Custom/Form/FieldTest.php
+++ b/tests/phpunit/CRM/Custom/Form/FieldTest.php
@@ -372,7 +372,7 @@ class CRM_Custom_Form_FieldTest extends CiviUnitTestCase {
           'html_type' => 'Autocomplete-Select',
           'serialize' => '1',
         ],
-        'null',
+        CRM_Core_DAO::SERIALIZE_SEPARATOR_BOOKEND,
       ],
     ];
   }

--- a/tests/phpunit/api/v4/Action/CustomFieldAlterTest.php
+++ b/tests/phpunit/api/v4/Action/CustomFieldAlterTest.php
@@ -57,6 +57,14 @@ class CustomFieldAlterTest extends BaseCustomValueTest {
         ->addValue('data_type', 'Country')
         ->addValue('html_type', 'Select'), 0
       )
+      ->addChain('field4', CustomField::create()
+        ->addValue('custom_group_id', '$id')
+        ->addValue('serialize', TRUE)
+        ->addValue('is_required', TRUE)
+        ->addValue('label', 'TestContact')
+        ->addValue('data_type', 'ContactReference')
+        ->addValue('html_type', 'Autocomplete-Select'), 0
+      )
       ->execute()
       ->first();
 
@@ -144,6 +152,16 @@ class CustomFieldAlterTest extends BaseCustomValueTest {
     $this->assertCount(1, $result);
     // The two values originally entered will now be one value
     $this->assertEquals([1228], $result['A4']['MyFieldsToAlter.TestCountry']);
+
+    // Repeatedly change contact ref field to ensure FK index is correctly added/dropped with no SQL error
+    for ($i = 1; $i < 6; ++$i) {
+      CustomField::update(FALSE)
+        ->addWhere('id', '=', $customGroup['field4']['id'])
+        ->addValue('serialize', $i % 2 == 0)
+        ->addValue('is_required', $i % 2 == 0)
+        ->execute();
+    }
+
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Allows custom fields of type ContactReference to be multi-valued. See also https://lab.civicrm.org/dev/core/-/issues/2123

Before
----------
Contact reference fields must be single-valued.

After
------------
Multi-valued contact reference custom fields supported.