### PR TITLE
Remove always true if

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2623,18 +2623,16 @@ LEFT JOIN  civicrm_contribution contribution ON ( componentPayment.contribution_
         $contribution->total_amount = $contributionParams['total_amount'] = $input['amount'];
       }
 
-      if (!empty($contributionParams['contribution_recur_id'])) {
-        $recurringContribution = civicrm_api3('ContributionRecur', 'getsingle', [
-          'id' => $contributionParams['contribution_recur_id'],
-        ]);
-        if (!empty($recurringContribution['campaign_id'])) {
-          // CRM-17718 the campaign id on the contribution recur record should get precedence.
-          $contributionParams['campaign_id'] = $recurringContribution['campaign_id'];
-        }
-        if (!empty($recurringContribution['financial_type_id'])) {
-          // CRM-17718 the campaign id on the contribution recur record should get precedence.
-          $contributionParams['financial_type_id'] = $recurringContribution['financial_type_id'];
-        }
+      $recurringContribution = civicrm_api3('ContributionRecur', 'getsingle', [
+        'id' => $contributionParams['contribution_recur_id'],
+      ]);
+      if (!empty($recurringContribution['campaign_id'])) {
+        // CRM-17718 the campaign id on the contribution recur record should get precedence.
+        $contributionParams['campaign_id'] = $recurringContribution['campaign_id'];
+      }
+      if (!empty($recurringContribution['financial_type_id'])) {
+        // CRM-17718 the campaign id on the contribution recur record should get precedence.
+        $contributionParams['financial_type_id'] = $recurringContribution['financial_type_id'];
       }
       $templateContribution = CRM_Contribute_BAO_ContributionRecur::getTemplateContribution(
         $contributionParams['contribution_recur_id'],


### PR DESCRIPTION


Overview
----------------------------------------
Remove always true if

Before
----------------------------------------
```if (!empty($contributionParams['contribution_recur_id'])) {``` is always true, but checked

After
----------------------------------------
Poof

Technical Details
----------------------------------------
By the time the code reaches this point contributionParams['contribution_recur_id']
must be set. We can confirm this by the fact the call to getTemplateContribution
requires id to be passed in and uses it in a lookup. Also the
code just before repeatTransaction ensures it is called

<img width="813" alt="Screen Shot 2020-11-09 at 12 48 46 PM" src="https://user-images.githubusercontent.com/336308/98487778-ee5f0280-2289-11eb-894f-3c8b1d77b9a5.png">

repeattransaction is called from only 1 place

Comments
----------------------------------------

