### PR TITLE
dev/financial#148 dev/financial#148 Copy contents of validateDate onto paypalIPN

### DIFF
--- a/CRM/Core/Payment/PayPalIPN.php
+++ b/CRM/Core/Payment/PayPalIPN.php
@@ -322,8 +322,46 @@ class CRM_Core_Payment_PayPalIPN extends CRM_Core_Payment_BaseIPN {
           );
         }
       }
-      if (!$this->validateData($input, $ids, $objects, TRUE, $paymentProcessorID)) {
-        return;
+      $contribution = new CRM_Contribute_BAO_Contribution();
+      $contribution->id = $ids['contribution'];
+      if (!$contribution->find(TRUE)) {
+        throw new CRM_Core_Exception('Failure: Could not find contribution record for ' . (int) $contribution->id, NULL, ['context' => "Could not find contribution record: {$contribution->id} in IPN request: " . print_r($input, TRUE)]);
+      }
+
+      // make sure contact exists and is valid
+      // use the contact id from the contribution record as the id in the IPN may not be valid anymore.
+      $contact = new CRM_Contact_BAO_Contact();
+      $contact->id = $contribution->contact_id;
+      $contact->find(TRUE);
+      if ($contact->id != $ids['contact']) {
+        // If the ids do not match then it is possible the contact id in the IPN has been merged into another contact which is why we use the contact_id from the contribution
+        CRM_Core_Error::debug_log_message("Contact ID in IPN {$ids['contact']} not found but contact_id found in contribution {$contribution->contact_id} used instead");
+        echo "WARNING: Could not find contact record: {$ids['contact']}<p>";
+        $ids['contact'] = $contribution->contact_id;
+      }
+
+      if (!empty($ids['contributionRecur'])) {
+        $contributionRecur = new CRM_Contribute_BAO_ContributionRecur();
+        $contributionRecur->id = $ids['contributionRecur'];
+        if (!$contributionRecur->find(TRUE)) {
+          CRM_Core_Error::debug_log_message("Could not find contribution recur record: {$ids['ContributionRecur']} in IPN request: " . print_r($input, TRUE));
+          echo "Failure: Could not find contribution recur record: {$ids['ContributionRecur']}<p>";
+          return FALSE;
+        }
+      }
+
+      $objects['contact'] = &$contact;
+      $objects['contribution'] = &$contribution;
+
+      // CRM-19478: handle oddity when p=null is set in place of contribution page ID,
+      if (!empty($ids['contributionPage']) && !is_numeric($ids['contributionPage'])) {
+        // We don't need to worry if about removing contribution page id as it will be set later in
+        //  CRM_Contribute_BAO_Contribution::loadRelatedObjects(..) using $objects['contribution']->contribution_page_id
+        unset($ids['contributionPage']);
+      }
+
+      if (!$this->loadObjects($input, $ids, $objects, TRUE, $paymentProcessorID)) {
+        return FALSE;
       }
 
       $input['payment_processor_id'] = $paymentProcessorID;


### PR DESCRIPTION
Overview
----------------------------------------
dev/financial#148 dev/financial#148 Copy contents of validateDate onto paypalIPN

This code isn't really that shared & it can be simplified by NOT sharing it

Before
----------------------------------------
validateData shared - but sharing makes code more complex rather than less

After
----------------------------------------
Copied ready for simplification

Technical Details
----------------------------------------
The goal is to deprecate validateData. As early processors outside core use it due to copy & paste replicating is more appropriate that changing validateData (which adds little anyway) https://lab.civicrm.org/dev/financial/-/issues/148

Comments
----------------------------------------

