### PR TITLE
core#2172 - Fix 'Find Respondents' in CiviCampaigns

### DIFF
--- a/CRM/Campaign/Selector/Search.php
+++ b/CRM/Campaign/Selector/Search.php
@@ -267,7 +267,7 @@ class CRM_Campaign_Selector_Search extends CRM_Core_Selector_Base implements CRM
 
       $selectSQL = "
       SELECT %1, contact_a.id, contact_a.display_name
-FROM {$sql['from']}
+{$sql['from']}
 ";
 
       try {


### PR DESCRIPTION
Overview
----------------------------------------
**Campaigns > Find Respondents** produces fatal SQL error 

See https://lab.civicrm.org/dev/core/-/issues/2172

Before
----------------------------------------
Fatal SQL error

After
----------------------------------------
No error

Comments
----------------------------------------
_Should probably have a test ..._
