### PR TITLE
APIv3 - Fix legacy handling for html_type Autocomplete-Select

### DIFF
--- a/api/v3/CustomField.php
+++ b/api/v3/CustomField.php
@@ -179,7 +179,7 @@ function civicrm_api3_custom_field_get($params) {
         if (in_array($result['data_type'], $legacyDataTypes)) {
           $result['html_type'] = array_search($result['data_type'], $legacyDataTypes);
         }
-        if (!empty($result['serialize'])) {
+        if (!empty($result['serialize']) && $result['html_type'] !== 'Autocomplete-Select') {
           $result['html_type'] = str_replace('Select', 'Multi-Select', $result['html_type']);
         }
       }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes legacy output from APIv3 when returning custom fields.

Before
----------------------------------------
Legacy handling was returning "Autocomplete-Multi-Select" which was never an html_type.

After
----------------------------------------
 Returns "Autocomplete-Select"

Technical Details
--------------
The legacy handling was meant to return familiar `html_type` names for backward-compatibility. But "Autocomplete-Multi-Select"  never existed, so is not a useful transformation to do.