### PR TITLE
event#44: Don't allow self-service cancelling after an event when 'hours to cancel' is zero

### DIFF
--- a/CRM/Event/BAO/Participant.php
+++ b/CRM/Event/BAO/Participant.php
@@ -1922,7 +1922,7 @@ WHERE    civicrm_participant.contact_id = {$contactID} AND
       $start_date = $dao->start;
     }
     $timenow = new Datetime();
-    if (!$isBackOffice && !empty($time_limit)) {
+    if (!$isBackOffice && isset($time_limit)) {
       $cancelHours = abs($time_limit);
       $cancelInterval = new DateInterval("PT${cancelHours}H");
       $cancelInterval->invert = $time_limit < 0 ? 1 : 0;
@@ -1930,9 +1930,9 @@ WHERE    civicrm_participant.contact_id = {$contactID} AND
       if ($timenow > $cancelDeadline) {
         $details['eligible'] = FALSE;
         // Change the language of the status message based on whether the waitlist time limit is positive or negative.
-        $afterOrPrior = $time_limit < 0 ? 'after' : 'prior';
-        $moreOrLess = $time_limit < 0 ? 'more' : 'less';
-        $details['ineligible_message'] = ts("Registration for this event cannot be cancelled or transferred %1 than %2 hours %3 to the event's start time. Contact the event organizer if you have questions.",
+        $afterOrPrior = $time_limit <= 0 ? 'after' : 'prior to';
+        $moreOrLess = $time_limit <= 0 ? 'more' : 'fewer';
+        $details['ineligible_message'] = ts("Registration for this event cannot be cancelled or transferred %1 than %2 hours %3 the event's start time. Contact the event organizer if you have questions.",
         [1 => $moreOrLess, 2 => $cancelHours, 3 => $afterOrPrior]);
 
       }

--- a/tests/phpunit/CRM/Event/BAO/ParticipantTest.php
+++ b/tests/phpunit/CRM/Event/BAO/ParticipantTest.php
@@ -426,7 +426,13 @@ class CRM_Event_BAO_ParticipantTest extends CiviUnitTestCase {
   public function testGetSelfServiceEligibility($selfSvcEnabled, $selfSvcHours, $hoursToEvent, $participantStatusId, $isBackOffice, $successExpected) {
     $participantId = $this->participantCreate(['contact_id' => $this->_contactId, 'event_id' => $this->_eventId, 'status_id' => $participantStatusId]);
     $now = new Datetime();
-    $startDate = $now->add(new DateInterval("PT{$hoursToEvent}H"))->format('Y-m-d H:i:s');
+    if ($hoursToEvent >= 0) {
+      $startDate = $now->add(new DateInterval("PT{$hoursToEvent}H"))->format('Y-m-d H:i:s');
+    }
+    else {
+      $hoursAfterEvent = abs($hoursToEvent);
+      $startDate = $now->sub(new DateInterval("PT{$hoursAfterEvent}H"))->format('Y-m-d H:i:s');
+    }
     $this->callAPISuccess('Event', 'create', [
       'id' => $this->_eventId,
       'allow_selfcancelxfer' => $selfSvcEnabled,
@@ -501,6 +507,14 @@ class CRM_Event_BAO_ParticipantTest extends CiviUnitTestCase {
       'participantStatusId' => 1,
       'isBackOffice' => FALSE,
       'successExpected' => TRUE,
+    ];
+    $scenarios[] = [
+      'selfSvcEnabled' => 1,
+      'selfSvcHours' => 0,
+      'hoursToEvent' => -6,
+      'participantStatusId' => 1,
+      'isBackOffice' => FALSE,
+      'successExpected' => FALSE,
     ];
     return $scenarios;
   }


### PR DESCRIPTION
https://lab.civicrm.org/dev/event/-/issues/44

Overview
----------------------------------------
Self-service cancellation exhibits incorrect behavior when the "hours to cancel" is zero.

Before
----------------------------------------
Self-service cancel/transfer works even after the event's ended.

After
----------------------------------------
Self-service cancel/transfer cuts off when the event begins.

Technical Details
----------------------------------------
This is just an `!empty()` vs `!isset()` issue.

Comments
----------------------------------------
I made some grammatical fixes while I was in there.  I also extended the test to properly handle negative start times.