### PR TITLE
dev/mail#79 - Fix MS Exchange/IMAP. Use OpenID Connect.

### DIFF
--- a/ext/oauth-client/Civi/OAuth/CiviGenericProvider.php
+++ b/ext/oauth-client/Civi/OAuth/CiviGenericProvider.php
@@ -1,6 +1,23 @@
 <?php
 namespace Civi\OAuth;
 
+use League\OAuth2\Client\Token\AccessToken;
+
+/**
+ * Class CiviGenericProvider
+ * @package Civi\OAuth
+ *
+ * This is a variant of "GenericProvider" which tries to support some newer
+ * conventions out-of-the-box.
+ *
+ * - By default, do not send "approval_prompt" for auth-code requests. Providers
+ *   may prefer "prompt" nowadays.
+ * - Allow one to fetch claims about the resource-owner from the `id_token`
+ *   supported by OpenID Connect. This reduces the need for extra round-trips
+ *   and proprietary scopes+URLs. To use this, set the the option:
+ *
+ *    "urlResourceOwnerDetails": "{{use_id_token}}",
+ */
 class CiviGenericProvider extends \League\OAuth2\Client\Provider\GenericProvider {
 
   protected function getAuthorizationParameters(array $options) {
@@ -11,6 +28,43 @@ class CiviGenericProvider extends \League\OAuth2\Client\Provider\GenericProvider
       unset($newOptions['approval_prompt']);
     }
     return $newOptions;
+  }
+
+  /**
+   * Requests resource owner details.
+   *
+   * @param \League\OAuth2\Client\Token\AccessToken $token
+   * @return mixed
+   */
+  protected function fetchResourceOwnerDetails(AccessToken $token) {
+    $url = $this->getResourceOwnerDetailsUrl($token);
+
+    // If there is no resource-owner URL, and if there is an id_token, use it.
+    if ($url === '{{use_id_token}}') {
+      $tokenData = $token->jsonSerialize();
+      if (isset($tokenData['id_token'])) {
+        $idToken = $this->decodeUnauthenticatedJwt($tokenData['id_token']);
+
+        // As long as id_token comes from a secure source, we can skip signature check.
+        // Which is fortunate... because we don't what key to check against...
+        if (!preg_match(';^https:;', $this->getBaseAccessTokenUrl([]))) {
+          throw new \RuntimeException("Cannot decode ID token from insecure source.");
+        }
+
+        return $idToken['payload'];
+      }
+    }
+
+    return parent::fetchResourceOwnerDetails($token);
+  }
+
+  private function decodeUnauthenticatedJwt($t) {
+    list ($header, $payload) = explode('.', $t);
+
+    return [
+      'header' => json_decode(base64_decode($header), 1),
+      'payload' => json_decode(base64_decode($payload), 1),
+    ];
   }
 
 }

--- a/ext/oauth-client/providers/ms-exchange.dist.json
+++ b/ext/oauth-client/providers/ms-exchange.dist.json
@@ -3,24 +3,25 @@
   "options": {
     "urlAuthorize": "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
     "urlAccessToken": "https://login.microsoftonline.com/common/oauth2/v2.0/token",
-    "urlResourceOwnerDetails": "https://graph.microsoft.com/v1.0/me",
+    "urlResourceOwnerDetails": "{{use_id_token}}",
     "scopeSeparator": " ",
     "scopes": [
-      "User.Read",
       "https://outlook.office.com/IMAP.AccessAsUser.All",
       "https://outlook.office.com/POP.AccessAsUser.All",
       "https://outlook.office.com/SMTP.Send",
+      "openid",
+      "email",
       "offline_access"
     ]
   },
   "mailSettingsTemplate": {
-    "name": "{{token.resource_owner.mail}}",
-    "domain": "{{token.resource_owner.mail|getMailDomain}}",
+    "name": "{{token.resource_owner.email}}",
+    "domain": "{{token.resource_owner.email|getMailDomain}}",
     "localpart": null,
     "return_path": null,
     "protocol:name": "IMAP",
     "server": "outlook.office365.com",
-    "username": "{{token.resource_owner.mail}}",
+    "username": "{{token.resource_owner.email}}",
     "password": null,
     "is_ssl": true
   }


### PR DESCRIPTION
Overview
----------------------------------------

This addresses a bug (https://lab.civicrm.org/dev/mail/-/issues/79) where the OAuth2 implementation does not work with MS Exchange Online's IMAP.


Before
----------------------------------------

When requesting a token for the `ms-exchange` provider, Civi requests multiple permissions, including  `User.Read` (to determine the default email address) and `IMAP.AccessAsUser.All` (to connect the relevant mailbox).

Thanks to @demeritcowboy's debugging, we can see there is a problem in Microsoft's services: it treats these permissions as mutually-exclusive. (If you have `User.Read` permission, then `IMAP.AccessAsUser.All` does not work.)

After
----------------------------------------

Stop requesting `User.Read` permission. Consequently, we can't read the default email address from `https://graph.microsoft.com/v1.0/me`. Instead, we can use OpenID Connect to determine the email address.

Comments
----------------------------------------

Tested in local builds of 5.32.beta with both:

* https://github.com/totten/oauth2-imap-demo - Complete the consolidated pageflow, get some real IMAP data
* `dmaster`  - Apply patch and flush caches. Register a new "Mail Account" and run "Save & Test".