### PR TITLE
Standardise more params in completeOrder

### DIFF
--- a/CRM/Core/Payment/AuthorizeNetIPN.php
+++ b/CRM/Core/Payment/AuthorizeNetIPN.php
@@ -96,23 +96,16 @@ class CRM_Core_Payment_AuthorizeNetIPN extends CRM_Core_Payment_BaseIPN {
         // create a contribution and then get it processed
         $contribution = new CRM_Contribute_BAO_Contribution();
         $contribution->contact_id = $ids['contact'];
-        $contribution->financial_type_id = $objects['contributionType']->id;
         $contribution->contribution_page_id = $ids['contributionPage'];
         $contribution->contribution_recur_id = $ids['contributionRecur'];
         $contribution->receive_date = $input['receive_date'];
-        $contribution->currency = $objects['contribution']->currency;
-        $contribution->amount_level = $objects['contribution']->amount_level;
-        $contribution->address_id = $objects['contribution']->address_id;
-        $contribution->campaign_id = $objects['contribution']->campaign_id;
-
-        $objects['contribution'] = &$contribution;
       }
       $input['payment_processor_id'] = $paymentProcessorID;
       $isFirstOrLastRecurringPayment = $this->recur($input, [
         'related_contact' => $ids['related_contact'] ?? NULL,
-        'participant' => !empty($objects['participant']) ? $objects['participant']->id : NULL,
+        'participant' => NULL,
         'contributionRecur' => $contributionRecur->id,
-      ], $contributionRecur, $objects['contribution'], $first);
+      ], $contributionRecur, $contribution, $first);
 
       if ($isFirstOrLastRecurringPayment) {
         //send recurring Notification email for user

--- a/tests/phpunit/CRM/Core/Payment/AuthorizeNetIPNTest.php
+++ b/tests/phpunit/CRM/Core/Payment/AuthorizeNetIPNTest.php
@@ -164,10 +164,13 @@ class CRM_Core_Payment_AuthorizeNetIPNTest extends CiviUnitTestCase {
     $contribution = $this->callAPISuccess('contribution', 'get', [
       'contribution_recur_id' => $this->_contributionRecurID,
       'sequential' => 1,
-    ]);
-    $this->assertEquals(2, $contribution['count']);
-    $this->assertEquals('second_one', $contribution['values'][1]['trxn_id']);
-    $this->assertEquals(date('Y-m-d'), date('Y-m-d', strtotime($contribution['values'][1]['receive_date'])));
+    ])['values'];
+    $this->assertCount(2, $contribution);
+    $secondContribution = $contribution[1];
+    $this->assertEquals('second_one', $secondContribution['trxn_id']);
+    $this->assertEquals(date('Y-m-d'), date('Y-m-d', strtotime($secondContribution['receive_date'])));
+    $this->assertEquals('expensive', $secondContribution['amount_level']);
+    $this->assertEquals($this->ids['campaign'][0], $secondContribution['campaign_id']);
   }
 
   /**

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -2504,6 +2504,7 @@ VALUES
    * @throws \CRM_Core_Exception
    */
   public function setupRecurringPaymentProcessorTransaction($recurParams = [], $contributionParams = []) {
+    $this->ids['campaign'][0] = $this->callAPISuccess('Campaign', 'create', ['title' => 'get the money'])['id'];
     $contributionParams = array_merge([
       'total_amount' => '200',
       'invoice_id' => $this->_invoiceID,
@@ -2515,6 +2516,8 @@ VALUES
       'is_test' => 0,
       'receive_date' => '2019-07-25 07:34:23',
       'skipCleanMoney' => TRUE,
+      'amount_level' => 'expensive',
+      'campaign_id' => $this->ids['campaign'][0],
     ], $contributionParams);
     $contributionRecur = $this->callAPISuccess('contribution_recur', 'create', array_merge([
       'contact_id' => $this->_contactID,


### PR DESCRIPTION


Overview
----------------------------------------
Standardise more params in completeOrder

Before
----------------------------------------
Handling to load the following from the previous contribution is specific to Authorize.net for

- amount_level
- address_id
- campaign_id

After
----------------------------------------
Handling moved to completeOrder. In the case of campaign_id it is only used if not set in input params or contribution recur record

Technical Details
----------------------------------------
I also removed $objects from

```
 $isFirstOrLastRecurringPayment = $this->recur($input, [
        'related_contact' => $ids['related_contact'] ?? NULL,
        'participant' => !empty($objects['participant']) ? $objects['participant']->id : NULL,
        'participant' => NULL,
        'contributionRecur' => $contributionRecur->id,
      ], $contributionRecur, $objects['contribution'], $first);
      ], $contributionRecur, $contribution, $first);
```

In the case of participant we actually don't do A.net IPNs for events as they are only processed on recurring for A.net and we don't have expectations for participants here - this is just copy & paste. In the case of  ```$objects['contribution'], ``` this was only set to $contribution a few lines earlier
```
$objects['contribution'] = &$contribution;
```

Comments
----------------------------------------

