### PR TITLE
dev/core#2175 Only send receipts if the contribution status insn't pending or…

### DIFF
--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -1616,7 +1616,9 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
       $this->invoicingPostProcessHook($submittedValues, $action, $lineItem);
 
       //send receipt mail.
-      if ($contribution->id && !empty($formValues['is_email_receipt'])) {
+      // We only send this if the we have ticked we want to send an email receipt and also the contribution status is not pending or we are in live mode and the payment processsor supports sending receipts for pending contributions.
+      if ($contribution->id && !empty($formValues['is_email_receipt']) && ($contribution->contribution_status_id !== CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Pending')
+        || $this->_mode && $this->_paymentObject->isSendReceiptForPending())) {
         $formValues['contact_id'] = $this->_contactID;
         $formValues['contribution_id'] = $contribution->id;
 


### PR DESCRIPTION
… if it is pending then only send it if the payment processor supports sending receipt for Pending

Overview
----------------------------------------
This aims to change the email receipts sending so that if a contribution is pending even if we want the receipt to be sent it wouldn't be sent unless the Payment Processor supports sending receipts whilst pending. Should send receipt if contribution is any other status tho

Before
----------------------------------------
Contribution Receipt would be sent if Contribution is still pending

After
----------------------------------------
Contribution Receipt is only sent if contribution isn't pending or if it is pending if the payment processor permits it

ping @JoeMurray @monishdeb @mattwire @eileenmcnaughton @adixon 