### PR TITLE
dev/core#2141 - Tighten up new page `civicrm/oauth-client/return`

### DIFF
--- a/ext/oauth-client/templates/CRM/OAuth/Page/Return.tpl
+++ b/ext/oauth-client/templates/CRM/OAuth/Page/Return.tpl
@@ -1,10 +1,41 @@
-<h3>Welcome back</h3>
+{if $error}
+    <div class="crm-accordion-wrapper">
+        <div class="crm-accordion-header">
+            {ts}OAuth Error Details{/ts}
+        </div>
+        <div class="crm-accordion-body">
+            <ul>
+                <li><strong>{ts}Error type:{/ts}</strong> {$error.error|escape:'html'}</li>
+                <li><strong>{ts}Error description:{/ts}</strong>
+                    <pre>{$error.error_description|escape:'html'}</pre>
+                </li>
+                <li><strong>{ts}Error URI:{/ts}</strong> <code>{$error.error_uri|escape:'html'}</code></li>
+            </ul>
+        </div>
+    </div>
+{else}
+    <p>{ts}An OAuth token was created!{/ts}</p>
+    <p>{ts}There is no clear "next step", so this may be a new integration. Please update the integration to define a next step via "hook_civicrm_oauthReturn" or "landingUrl".{/ts}</p>
+{/if}
 
-<h4>State:</h4>
-<pre>{$state}</pre>
+{if $stateJson}
+    <div class="crm-accordion-wrapper collapsed">
+        <div class="crm-accordion-header">
+            {ts}OAuth State{/ts}
+        </div>
+        <div class="crm-accordion-body">
+            <pre>{$stateJson}</pre>
+        </div>
+    </div>
+{/if}
 
-<h4>Token:</h4>
-<pre>{$token}</pre>
-
-<h4>Error</h4>
-<pre>{$error}</pre>
+{if $tokenJson}
+    <div class="crm-accordion-wrapper collapsed">
+        <div class="crm-accordion-header">
+            {ts}OAuth Token{/ts}
+        </div>
+        <div class="crm-accordion-body">
+            <pre>{$tokenJson}</pre>
+        </div>
+    </div>
+{/if}


### PR DESCRIPTION
Overview
--------

The route `civicrm/oauth-client/return` is added in 5.32 as the main "Redirect URL".

In normal usage, the page shouldn't be visible to a user (because the developer should define some alternative UI) -- but one might see it (a) during development, (b) if there's an error, or (c) if a clever user mucks about.

Improvements:

* Error handling
    * Present error messages more nicely
    * Record errors in the log
    * Report more info via hook_oauthReturnError
* Other UI
    * Redact token details (dependent upon permission `manage OAuth client secrets`)
    * Set a more sensibile page title
    * Make output blobs conditional and collapsible

