### PR TITLE
dev/core#2153 Ensure that updateCustomValues correctly updates Select options

### DIFF
--- a/CRM/Core/BAO/CustomOption.php
+++ b/CRM/Core/BAO/CustomOption.php
@@ -244,7 +244,7 @@ WHERE  f.custom_group_id = g.id
           $query = "
 UPDATE {$dao->tableName}
 SET    {$dao->columnName} = %1
-WHERE  id = %2";
+WHERE  {$dao->columnName} = %2";
           if ($dao->dataType == 'Auto-complete') {
             $dataType = "String";
           }
@@ -257,8 +257,8 @@ WHERE  id = %2";
               $dataType,
             ],
             2 => [
-              $params['optionId'],
-              'Integer',
+              $oldValue,
+              $dataType,
             ],
           ];
           break;


### PR DESCRIPTION
Overview
----------------------------------------
This is a similar fix but an alternate to https://github.com/civicrm/civicrm-core/pull/18912 which is that the function that was meant to be doing the updating was constructing the wrong SQL statement to update values in the relevant custom field.

Before
----------------------------------------
Wrong SQL statement for Select fields e.g.

`UPDATE <some table> SET <some column> = new value where id = <option id>;`

After
----------------------------------------
Correct SQL generated
`UPDATE <some table> SET <some column> = new value where <some column> = <old value>;`

Technical Details
----------------------------------------
This PR is an alternate to https://github.com/civicrm/civicrm-core/pull/18912 in that it seeks to fix the original function. However it feels like we also have two functions CRM_Core_BAO_CustomOption::updateCustomValues and CRM_Core_BAO_CustomOption::updateValue that seem to do remarkably the same job but its a little unclear which should really be used

ping @nganivet @demeritcowboy @colemanw @eileenmcnaughton @yashodha 