### PR TITLE
API - Finer-grained permisions for the dashboard & dashlet entities

### DIFF
--- a/CRM/Contact/BAO/DashboardContact.php
+++ b/CRM/Contact/BAO/DashboardContact.php
@@ -14,4 +14,41 @@
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
 class CRM_Contact_BAO_DashboardContact extends CRM_Contact_DAO_DashboardContact {
+
+  /**
+   * @param array $record
+   * @return CRM_Contact_DAO_DashboardContact
+   * @throws CRM_Core_Exception
+   */
+  public static function writeRecord(array $record) {
+    self::checkEditPermission($record);
+    return parent::writeRecord($record);
+  }
+
+  /**
+   * @param array $record
+   * @return CRM_Contact_DAO_DashboardContact
+   * @throws CRM_Core_Exception
+   */
+  public static function deleteRecord(array $record) {
+    self::checkEditPermission($record);
+    return parent::deleteRecord($record);
+  }
+
+  /**
+   * Ensure that the current user has permission to create/edit/delete a DashboardContact record
+   *
+   * @param array $record
+   * @throws CRM_Core_Exception
+   * @throws \Civi\API\Exception\UnauthorizedException
+   */
+  public static function checkEditPermission(array $record) {
+    if (!empty($record['check_permissions']) && !CRM_Core_Permission::check('administer CiviCRM')) {
+      $cid = !empty($record['id']) ? self::getFieldValue(parent::class, $record['id'], 'contact_id') : $record['contact_id'];
+      if ($cid != CRM_Core_Session::getLoggedInContactID()) {
+        throw new \Civi\API\Exception\UnauthorizedException('You do not have permission to edit the dashboard for this contact.');
+      }
+    }
+  }
+
 }

--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -1491,6 +1491,18 @@ class CRM_Core_Permission {
       ],
     ];
 
+    // Dashboard permissions
+    $permissions['dashboard'] = [
+      'get' => [
+        'access CiviCRM',
+      ],
+    ];
+    $permissions['dashboard_contact'] = [
+      'default' => [
+        'access CiviCRM',
+      ],
+    ];
+
     // Profile permissions
     $permissions['profile'] = [
       // the profile will take care of this


### PR DESCRIPTION
Overview
----------------------------------------
This allows contacts without "administer CiviCRM" permission to access dashboard records via api.


Before
----------------------------------------
Only administrators could use the Dashboard or DashboardContact APIs at all.

After
----------------------------------------
Contacts with "access CiviCRM" can read dashboard records for contacts they have access to, and write permissions for non-admins are restricted to editing only their own dashboard.

Technical Details
----------------------------------------
I didn't have to do anything to restrict read access because the api automatically picks up the `contact_id` FK and applies ACLs.