### PR TITLE
Add a way to choose between nl_NL and nl_BE

### DIFF
--- a/CRM/Core/I18n/PseudoConstant.php
+++ b/CRM/Core/I18n/PseudoConstant.php
@@ -65,6 +65,7 @@ class CRM_Core_I18n_PseudoConstant {
       $longForShortMapping['fr'] = defined("CIVICRM_LANGUAGE_MAPPING_FR") ? CIVICRM_LANGUAGE_MAPPING_FR : 'fr_FR';
       $longForShortMapping['pt'] = defined("CIVICRM_LANGUAGE_MAPPING_PT") ? CIVICRM_LANGUAGE_MAPPING_PT : 'pt_PT';
       $longForShortMapping['es'] = defined("CIVICRM_LANGUAGE_MAPPING_ES") ? CIVICRM_LANGUAGE_MAPPING_ES : 'es_ES';
+      $longForShortMapping['nl'] = defined("CIVICRM_LANGUAGE_MAPPING_NL") ? CIVICRM_LANGUAGE_MAPPING_NL : 'nl_NL';
     }
     return $longForShortMapping;
   }


### PR DESCRIPTION
Overview
----------------------------------------
Support for nl_BE vs nl_NL as the locale was added recently.

Before
----------------------------------------
When nl is used in Drupal (or other CMS), the default inherited locale in CiviCRM is nl_BE.
It used to be nl_NL.

After
----------------------------------------
Default is nl_NL as before but it's possible to add a setting CIVICRM_LANGUAGE_MAPPING_NL to change this.

