### PR TITLE
dev/core#2155 Remove obscure broken handling for onlinePendingContribution

### DIFF
--- a/templates/CRM/Member/Form/Membership.tpl
+++ b/templates/CRM/Member/Form/Membership.tpl
@@ -163,9 +163,9 @@
             <span class="description">{ts}When <strong>Status Override</strong> is active, the selected status will remain in force (it will NOT be subject to membership status rules) until it is cancelled or become inactive.{/ts}</span></td></tr>
         {/if}
 
-        {if $accessContribution and !$membershipMode AND ($action neq 2 or (!$rows.0.contribution_id AND !$softCredit) or $onlinePendingContributionId)}
+        {if $accessContribution and !$membershipMode AND ($action neq 2 or (!$rows.0.contribution_id AND !$softCredit))}
           <tr id="contri">
-            <td class="label">{if $onlinePendingContributionId}{ts}Update Payment Status{/ts}{else}{$form.record_contribution.label}{/if}</td>
+            <td class="label">{$form.record_contribution.label}</td>
             <td>{$form.record_contribution.html}<br />
               <span class="description">{ts}Check this box to enter or update payment information. You will also be able to generate a customized receipt.{/ts}</span></td>
           </tr>
@@ -251,7 +251,7 @@
   </div> <!-- end form-block -->
 
   {if $action neq 8} {* Jscript additions not need for Delete action *}
-    {if $accessContribution and !$membershipMode AND ($action neq 2 or !$rows.0.contribution_id or $onlinePendingContributionId)}
+    {if $accessContribution and !$membershipMode AND ($action neq 2 or !$rows.0.contribution_id)}
 
     {include file="CRM/common/showHideByFieldValue.tpl"
     trigger_field_id    ="record_contribution"
@@ -268,7 +268,7 @@
       function setPaymentBlock(mode, checkboxEvent) {
         var memType = parseInt(cj('#membership_type_id_1').val( ));
         var isPriceSet = 0;
-        var existingAmount = {/literal}{if !empty($onlinePendingContributionId)}1{else}0{/if}{literal};
+        var existingAmount = 0;
 
         if ( cj('#price_set_id').length > 0 && cj('#price_set_id').val() ) {
           isPriceSet = 1;

--- a/templates/CRM/Member/Form/MembershipCommon.tpl
+++ b/templates/CRM/Member/Form/MembershipCommon.tpl
@@ -1,5 +1,5 @@
 {if !$membershipMode}
-  {if $accessContribution && ($action != 2 or (!$rows.0.contribution_id AND !$softCredit) or $onlinePendingContributionId)}
+  {if $accessContribution && ($action != 2 or (!$rows.0.contribution_id AND !$softCredit))}
     <table>
       <tr class="crm-{$formClass}-form-block-contribution-contact">
         <td class="label">{$form.is_different_contribution_contact.label}</td>


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#2155 Remove obscure broken handling for onlinePendingContribution

Per https://lab.civicrm.org/dev/core/-/issues/2155 there is some obscure functionality for
completing a pending contribution under some cases. My testing suggests it is long-term broken.


Before
----------------------------------------
Update payment status appears in rare circumstances - seems to be long term broken

![screenshot](https://lab.civicrm.org/dev/core/uploads/10211382f41b9d0fe92362f620e68d6e/Screen_Shot_2020-10-31_at_6.30.02_PM.png) 

After
----------------------------------------
poof

Technical Details
----------------------------------------
See GL for discussion to date Per https://lab.civicrm.org/dev/core/-/issues/2155

Comments
----------------------------------------
View with the ?w=1 as some if -else has been removed - ie https://github.com/civicrm/civicrm-core/pull/18964/files?w=1
