### PR TITLE
Don't break clickthrough URLs when there's leading whitespace

### DIFF
--- a/CRM/Mailing/Page/Url.php
+++ b/CRM/Mailing/Page/Url.php
@@ -32,7 +32,7 @@ class CRM_Mailing_Page_Url extends CRM_Core_Page {
   public function run() {
     $queue_id = CRM_Utils_Request::retrieveValue('qid', 'Integer');
     $url_id = CRM_Utils_Request::retrieveValue('u', 'Integer', NULL, TRUE);
-    $url = CRM_Mailing_Event_BAO_TrackableURLOpen::track($queue_id, $url_id);
+    $url = trim(CRM_Mailing_Event_BAO_TrackableURLOpen::track($queue_id, $url_id));
     $query_string = $this->extractPassthroughParameters();
 
     if (strlen($query_string) > 0) {


### PR DESCRIPTION
Overview
----------------------------------------
Clickthrough tracking breaks when a URL has a leading space.  See [the Gitlab ticket](https://lab.civicrm.org/dev/mail/-/issues/80) for replication steps.

Before
----------------------------------------
Clickthrough tracking pukes when a leading space exists.

After
----------------------------------------
Clickthrough tracking works.

Technical Details
----------------------------------------
It's just a `trim()`.