### PR TITLE
[NFC] Follow-on to 18963 to add example setting in civicrm.settings template for setting CMS inheritance for nl_BE

### DIFF
--- a/templates/CRM/common/civicrm.settings.php.template
+++ b/templates/CRM/common/civicrm.settings.php.template
@@ -443,6 +443,7 @@ if (!defined('CIVICRM_PSR16_STRICT')) {
 // define('CIVICRM_LANGUAGE_MAPPING_ES', 'es_MX');
 // define('CIVICRM_LANGUAGE_MAPPING_PT', 'pt_BR');
 // define('CIVICRM_LANGUAGE_MAPPING_ZH', 'zh_TW');
+// define('CIVICRM_LANGUAGE_MAPPING_NL', 'nl_BE');
 
 /**
  * Native gettext improves performance of localized CiviCRM installations


### PR DESCRIPTION
Overview
----------------------------------------
Follow-on from https://github.com/civicrm/civicrm-core/pull/18963. As per the code comment at https://github.com/civicrm/civicrm-core/pull/18963/files#diff-43a41b95e0f3e632eda0cf38a2bd5f0501f30583b03ac9095e40174852de4c6aR61-R62 this adds a corresponding line in the civicrm.settings.php template to show how to change the default.

Before
----------------------------------------
Mass confusion. Lions escaping from cages. Blue grapefruits.

After
----------------------------------------
Example set.

Technical Details
----------------------------------------

Comments
----------------------------------------
