### PR TITLE
dev/core#2178 Fix regression on adding contacts to a newly created group

### DIFF
--- a/CRM/Group/Controller.php
+++ b/CRM/Group/Controller.php
@@ -16,6 +16,8 @@
  */
 class CRM_Group_Controller extends CRM_Core_Controller {
 
+  protected $entity = 'Contact';
+
   /**
    * Class constructor.
    *
@@ -52,6 +54,7 @@ class CRM_Group_Controller extends CRM_Core_Controller {
 
     // add all the actions
     $this->addActions($uploadDir, $uploadNames);
+    $this->set('entity', $this->entity);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
This picks up the proposed solution from @demeritcowboy on the lab ticket https://lab.civicrm.org/dev/core/-/issues/2178 but does it in the more standard way that @eileenmcnaughton had done as per https://github.com/civicrm/civicrm-core/pull/18766/files

Before
----------------------------------------
Contacts are not able to be added after creating a brand new group

After
----------------------------------------
Contacts are able to be added to a brand new group

ping @andrew-cormick-dockery @johntwyman @kcristiano 
