### PR TITLE
dev/core#1191 MySQL 61-table join limit - patch SelectQuery to work with many custom groups

### DIFF
--- a/CRM/Utils/SQL/Select.php
+++ b/CRM/Utils/SQL/Select.php
@@ -476,7 +476,7 @@ class CRM_Utils_SQL_Select extends CRM_Utils_SQL_BaseParamQuery {
 
   /**
    * @return array
-   * The set of joins for this query
+   *   The set of joins for this query
    */
   public function getJoins() {
     return $this->joins;
@@ -487,18 +487,18 @@ class CRM_Utils_SQL_Select extends CRM_Utils_SQL_BaseParamQuery {
    * The string to search for
    *
    * @return bool
-   * Do any of the WHERE, GROUP BY, HAVING, or ORDER BY clauses contain $needle?
+   *   Do any of the WHERE, GROUP BY, HAVING, or ORDER BY clauses contain $needle?
    */
   public function latterClausesContainString($needle) {
     foreach ([$this->wheres, $this->groupBys, $this->havings, $this->orderBys] as $clauseName => $clauseType) {
       foreach ($clauseType as $clauseKey => $clauseDetail) {
-        if (strpos($clauseKey, $needle) !== false) {
-          return true;
+        if (strpos($clauseKey, $needle) !== FALSE) {
+          return TRUE;
           break 2;
         }
       }
     }
-    return false;
+    return FALSE;
   }
 
   /**
@@ -510,8 +510,8 @@ class CRM_Utils_SQL_Select extends CRM_Utils_SQL_BaseParamQuery {
    */
   public function removeTable($key) {
     foreach ($this->selects as $count => $select) {
-      if (strpos($select, $key) !== false) {
-        unset($this->selects[$count]); // According to docs, unset does not reindex the array
+      if (strpos($select, $key) !== FALSE) {
+        unset($this->selects[$count]);
       }
     }
     unset($this->joins[$key]);

--- a/CRM/Utils/SQL/Select.php
+++ b/CRM/Utils/SQL/Select.php
@@ -475,6 +475,49 @@ class CRM_Utils_SQL_Select extends CRM_Utils_SQL_BaseParamQuery {
   }
 
   /**
+   * @return array
+   * The set of joins for this query
+   */
+  public function getJoins() {
+    return $this->joins;
+  }
+
+  /**
+   * @param $needle string
+   * The string to search for
+   *
+   * @return bool
+   * Do any of the WHERE, GROUP BY, HAVING, or ORDER BY clauses contain $needle?
+   */
+  public function latterClausesContainString($needle) {
+    foreach ([$this->wheres, $this->groupBys, $this->havings, $this->orderBys] as $clauseName => $clauseType) {
+      foreach ($clauseType as $clauseKey => $clauseDetail) {
+        if (strpos($clauseKey, $needle) !== false) {
+          return true;
+          break 2;
+        }
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Remove references to the specified table
+   *
+   * @param $key string
+   * The name of the table which should be removed from the SELECT and FROM
+   * clauses.
+   */
+  public function removeTable($key) {
+    foreach ($this->selects as $count => $select) {
+      if (strpos($select, $key) !== false) {
+        unset($this->selects[$count]); // According to docs, unset does not reindex the array
+      }
+    }
+    unset($this->joins[$key]);
+  }
+
+  /**
    * @return string
    *   SQL statement
    */

--- a/Civi/API/SelectQuery.php
+++ b/Civi/API/SelectQuery.php
@@ -28,8 +28,13 @@ use Civi\API\Exception\UnauthorizedException;
 abstract class SelectQuery {
 
   const
-    SQL_JOIN_LIMIT = 60, // 60 joins plus the table in the "from" clause equals 61, the join limit for MySQL.
-    MAX_JOINS = 4, // Note that this refers to join depth, not total joins.
+
+    // 60 joins plus the table in the "from" clause equals 61, the join limit for MySQL.
+    SQL_JOIN_LIMIT = 60,
+
+    // Note that this refers to join depth, not total joins.
+    MAX_JOINS = 4,
+
     MAIN_TABLE_ALIAS = 'a';
 
   /**
@@ -171,7 +176,7 @@ abstract class SelectQuery {
       $mandatory = false;
       foreach ($this->joins as $check_key => $check_join) {
         // check the order - haystack, needle
-        if ((strpos($key, $check_join) !== false) 
+        if ((strpos($key, $check_join) !== false)
         || ($this->query->latterClausesContainString($key))) {
           $mandatory = true;
           break;
@@ -180,7 +185,7 @@ abstract class SelectQuery {
       if ($mandatory) {
         $classified['mandatory'][$key] = $join;
       }
-      else if (!isset($this->joins[$key])) {
+      elseif (!isset($this->joins[$key])) {
         $classified['depends'][$key] = $join;
       }
       else {
@@ -198,7 +203,7 @@ abstract class SelectQuery {
    */
   private function addJoinDependants($joins, $depends) {
     $additional = [];
-    foreach($joins as $joinKey => $join) {
+    foreach ($joins as $joinKey => $join) {
       foreach ($depends as $dependKey => $dependJoin) {
         if ($joinKey != $dependKey && (strpos($dependJoin, $joinKey) !== false)) {
           $additional[$dependKey] = $dependJoin;
@@ -223,10 +228,10 @@ abstract class SelectQuery {
 
   /**
    * Split the set of classified joins into multiple groups, each representing
-   * a query whose results can be collated (hopefully) into the result we 
+   * a query whose results can be collated (hopefully) into the result we
    * would have had if we could run a query with an arbitrary number of joins.
    * Note that this does not work if the query contains GROUP BY.
-   * 
+   *
    * @param array $classified
    * This is the output of $this->classifyJoins()
    * @return array
@@ -293,7 +298,7 @@ abstract class SelectQuery {
     foreach ($split_queries as $query) {
       $sql = $query->toSQL();
       $result_dao = \CRM_Core_DAO::executeQuery($sql);
-      while ($result_dao->fetch()) { // FIXME I have very low confidence that this will produce the desired outcome without understanding and tuning
+      while ($result_dao->fetch()) {
         if (in_array('count_rows', $this->select)) {
           return (int) $result_dao->c;
         }

--- a/Civi/API/SelectQuery.php
+++ b/Civi/API/SelectQuery.php
@@ -164,7 +164,7 @@ abstract class SelectQuery {
 
   /**
    * Classify the joins
-   * @return array 
+   * @return array
    */
   private function classifyJoins() {
     $classified = [
@@ -173,12 +173,12 @@ abstract class SelectQuery {
       'mandatory' => [],
     ];
     foreach ($this->query->getJoins() as $key => $join) {
-      $mandatory = false;
+      $mandatory = FALSE;
       foreach ($this->joins as $check_key => $check_join) {
         // check the order - haystack, needle
-        if ((strpos($key, $check_join) !== false)
+        if ((strpos($key, $check_join) !== FALSE)
         || ($this->query->latterClausesContainString($key))) {
-          $mandatory = true;
+          $mandatory = TRUE;
           break;
         }
       }
@@ -205,7 +205,7 @@ abstract class SelectQuery {
     $additional = [];
     foreach ($joins as $joinKey => $join) {
       foreach ($depends as $dependKey => $dependJoin) {
-        if ($joinKey != $dependKey && (strpos($dependJoin, $joinKey) !== false)) {
+        if ($joinKey != $dependKey && (strpos($dependJoin, $joinKey) !== FALSE)) {
           $additional[$dependKey] = $dependJoin;
         }
       }

--- a/tests/phpunit/api/v3/CustomFieldTooManyJoinsTest.php
+++ b/tests/phpunit/api/v3/CustomFieldTooManyJoinsTest.php
@@ -48,7 +48,7 @@ class api_v3_CustomFieldTooManyJoinsTest extends CiviUnitTestCase {
    *
    * @throws \CRM_Core_Exception
    */
-  public function tearDown() {
+  public function tearDown(): void {
     foreach ($this->createdCustomGroups as $customGroup) {
       $this->customGroupDelete($customGroup['id']);
     }

--- a/tests/phpunit/api/v3/CustomFieldTooManyJoinsTest.php
+++ b/tests/phpunit/api/v3/CustomFieldTooManyJoinsTest.php
@@ -1,0 +1,72 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *  Test excess custom fields (causing api3 to produce too many joins in the
+ *  constructed SQL)
+ *
+ * @package   CiviCRM
+ * @group headless
+ */
+class api_v3_CustomFieldTooManyJoinsTest extends CiviUnitTestCase {
+
+  protected $createdCustomGroups = [];
+
+  function testTooManyJoins() {
+    $activityTypes = civicrm_api3('Activity', 'getoptions', [
+      'sequential' => 1,
+      'field' => "activity_type_id",
+    ]);
+    $activity = $this->callAPISuccess('Activity', 'create', [
+      'source_contact_id' => 1,
+      'activity_type_id' => $activityTypes['values'][0]['key'],
+    ]);
+    for ($i = 0; $i < 130; $i++) {
+      $customGroup = $this->customGroupCreate([
+        'extends' => 'Activity',
+        'title' => "Test join limit $i"
+      ]);
+      $this->createdCustomGroups[] = $customGroup;
+      $customField = $this->customFieldCreate([
+        'custom_group_id' => $customGroup['id'],
+        'label' => "Activity Custom Field $i",
+      ]);
+    }
+    $this->callAPISuccess('Activity', 'get', ['id' => $activity['id']]);
+  }
+
+  /**
+   * Clean up after test.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function tearDown() {
+    foreach($this->createdCustomGroups as $customGroup) {
+      $this->customGroupDelete($customGroup['id']);
+    }
+    parent::tearDown();
+  }
+
+// Suggestion from Totten in developer chat
+// function testTooManyJoins() {
+//   $act = callApiSuccess('Activity', 'create', array(...));
+//   for ($i = 0; $i < 70; $i++) {
+//     $cg = callApiSuccess('CustomGroup', 'create', array(...'label' => "My custom group $i"...));
+//     $cf = callApiSuccess('CustomField', 'create', array(...'label' => "My custom field $i", 'custom_group_id' => $cg['id']...));
+//   }
+//   callApiSuccess('Activity', 'get', array('id' => $act['id']));
+// }
+// function tearDown() {
+//   // destroy the ~70 CustomGroups
+// }
+
+}
+

--- a/tests/phpunit/api/v3/CustomFieldTooManyJoinsTest.php
+++ b/tests/phpunit/api/v3/CustomFieldTooManyJoinsTest.php
@@ -20,7 +20,7 @@ class api_v3_CustomFieldTooManyJoinsTest extends CiviUnitTestCase {
 
   protected $createdCustomGroups = [];
 
-  function testTooManyJoins() {
+  public function testTooManyJoins() {
     $activityTypes = civicrm_api3('Activity', 'getoptions', [
       'sequential' => 1,
       'field' => "activity_type_id",
@@ -32,7 +32,7 @@ class api_v3_CustomFieldTooManyJoinsTest extends CiviUnitTestCase {
     for ($i = 0; $i < 130; $i++) {
       $customGroup = $this->customGroupCreate([
         'extends' => 'Activity',
-        'title' => "Test join limit $i"
+        'title' => "Test join limit $i",
       ]);
       $this->createdCustomGroups[] = $customGroup;
       $customField = $this->customFieldCreate([
@@ -49,24 +49,23 @@ class api_v3_CustomFieldTooManyJoinsTest extends CiviUnitTestCase {
    * @throws \CRM_Core_Exception
    */
   public function tearDown() {
-    foreach($this->createdCustomGroups as $customGroup) {
+    foreach ($this->createdCustomGroups as $customGroup) {
       $this->customGroupDelete($customGroup['id']);
     }
     parent::tearDown();
   }
 
-// Suggestion from Totten in developer chat
-// function testTooManyJoins() {
-//   $act = callApiSuccess('Activity', 'create', array(...));
-//   for ($i = 0; $i < 70; $i++) {
-//     $cg = callApiSuccess('CustomGroup', 'create', array(...'label' => "My custom group $i"...));
-//     $cf = callApiSuccess('CustomField', 'create', array(...'label' => "My custom field $i", 'custom_group_id' => $cg['id']...));
-//   }
-//   callApiSuccess('Activity', 'get', array('id' => $act['id']));
-// }
-// function tearDown() {
-//   // destroy the ~70 CustomGroups
-// }
+  // Suggestion from Totten in developer chat
+  // function testTooManyJoins() {
+  //   $act = callApiSuccess('Activity', 'create', array(...));
+  //   for ($i = 0; $i < 70; $i++) {
+  //     $cg = callApiSuccess('CustomGroup', 'create', array(...'label' => "My custom group $i"...));
+  //     $cf = callApiSuccess('CustomField', 'create', array(...'label' => "My custom field $i", 'custom_group_id' => $cg['id']...));
+  //   }
+  //   callApiSuccess('Activity', 'get', array('id' => $act['id']));
+  // }
+  // function tearDown() {
+  //   // destroy the ~70 CustomGroups
+  // }
 
 }
-


### PR DESCRIPTION
Overview
----------------------------------------
[Relevant issue](https://lab.civicrm.org/dev/core/-/issues/1191)
[Older stack exchange question](https://civicrm.stackexchange.com/questions/20890/too-many-tables-mysql-limitation-civicrm-api-errors)

When many custom groups relate to a given Entity, API calls start failing with a "DB Error" caused by the MySQL 61-table join limit. This patch splits large queries into smaller queries and collates the results.

This pull request is probably not suitable for merging, though we are considering applying it to our production site. I want to present the code for discussion and review, but it's a significant change which may have implications for parts of the system which I'm not aware of.

Before
----------------------------------------
The API failures when exceeding the join limit could produce various results. Sometimes the user would see a yellow banner with the message "DB Error: Unknown Error". Sometimes (e.g. in a modal window in a Manage Case screen when saving an Activity) the result would be an ever-spinning Civi logo, combined with an error in the Drupal log.

After
----------------------------------------
The system continues to operate normally, even when there are more than 60 Custom Groups applied to Activities.

Technical Details
----------------------------------------
If it sees that it's going to exceed the join limit, it will split the query into smaller queries. It does this by classifying the joins as "mandatory", "dependant", or "optional". Mandatory joins are the ones which appear in the latter clauses and so form part of the criteria.

Each smaller query contains all of the mandatory joins and any which depend upon them. The remaining joins are distributed between as many queries as are required. The results of the queries are collated into a single data set and returned.

This process is not valid if there is a GROUP BY clause. However, I have not found a way to generate such a query with APIv3.

It's worth noting that it's not just Custom Groups which contribute to the number of joins. Each Custom Field which refers to a Contact adds another join. For example, we have a custom group with two Contact references - a "Donor" and a "Courier". This custom group contributes three joins toward the limit.

Comments
----------------------------------------
When I ran the full suite of API tests, one extra test failed which didn't fail when the patch was not applied:

    not ok 1413 - Failure: api_v3_LoggingTest::testEnableDisableLogging

Also, I tried preparing this as an extension which would override the changed files, but I could not get it to operate in that form - it appeared to continue using the core Civi files. An extension may be a better format for this feature if I can get it working.