### PR TITLE
dev/core#2187 Allow sites to customise the default number of rows ret…

### DIFF
--- a/CRM/Activity/Selector/Activity.php
+++ b/CRM/Activity/Selector/Activity.php
@@ -285,7 +285,7 @@ class CRM_Activity_Selector_Activity extends CRM_Core_Selector_Base implements C
   public function getPagerParams($action, &$params) {
     $params['status'] = ts('Activities %%StatusMessage%%');
     $params['csvString'] = NULL;
-    $params['rowCount'] = CRM_Utils_Pager::ROWCOUNT;
+    $params['rowCount'] = Civi::settings()->get('default_pager_size');
 
     $params['buttonTop'] = 'PagerTopButton';
     $params['buttonBottom'] = 'PagerBottomButton';

--- a/CRM/Activity/Selector/Search.php
+++ b/CRM/Activity/Selector/Search.php
@@ -174,7 +174,7 @@ class CRM_Activity_Selector_Search extends CRM_Core_Selector_Base implements CRM
   public function getPagerParams($action, &$params) {
     $params['status'] = ts('Activities %%StatusMessage%%');
     $params['csvString'] = NULL;
-    $params['rowCount'] = CRM_Utils_Pager::ROWCOUNT;
+    $params['rowCount'] = Civi::settings()->get('default_pager_size');
     $params['buttonTop'] = 'PagerTopButton';
     $params['buttonBottom'] = 'PagerBottomButton';
   }

--- a/CRM/Admin/Form/Setting/Search.php
+++ b/CRM/Admin/Form/Setting/Search.php
@@ -35,6 +35,7 @@ class CRM_Admin_Form_Setting_Search extends CRM_Admin_Form_Setting {
     'contact_reference_options' => CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME,
     'search_autocomplete_count' => CRM_Core_BAO_Setting::SEARCH_PREFERENCES_NAME,
     'enable_innodb_fts' => CRM_Core_BAO_Setting::SEARCH_PREFERENCES_NAME,
+    'default_pager_size' => CRM_Core_BAO_Setting::SEARCH_PREFERENCES_NAME,
   ];
 
   /**

--- a/CRM/Campaign/Selector/Search.php
+++ b/CRM/Campaign/Selector/Search.php
@@ -175,7 +175,7 @@ class CRM_Campaign_Selector_Search extends CRM_Core_Selector_Base implements CRM
   public function getPagerParams($action, &$params) {
     $params['csvString'] = NULL;
     $params['status'] = ts('Respondents') . ' %%StatusMessage%%';
-    $params['rowCount'] = ($this->_limit) ? $this->_limit : CRM_Utils_Pager::ROWCOUNT;
+    $params['rowCount'] = ($this->_limit) ? $this->_limit : Civi::settings()->get('default_pager_size');
     $params['buttonTop'] = 'PagerTopButton';
     $params['buttonBottom'] = 'PagerBottomButton';
   }

--- a/CRM/Case/Selector/Search.php
+++ b/CRM/Case/Selector/Search.php
@@ -234,7 +234,7 @@ class CRM_Case_Selector_Search extends CRM_Core_Selector_Base {
       $params['rowCount'] = $this->_limit;
     }
     else {
-      $params['rowCount'] = CRM_Utils_Pager::ROWCOUNT;
+      $params['rowCount'] = Civi::settings()->get('default_pager_size');
     }
 
     $params['buttonTop'] = 'PagerTopButton';

--- a/CRM/Contact/Form/Search/Custom/FullText.php
+++ b/CRM/Contact/Form/Search/Custom/FullText.php
@@ -105,7 +105,7 @@ class CRM_Contact_Form_Search_Custom_FullText extends CRM_Contact_Form_Search_Cu
       // 1. this custom search has slightly different structure ,
       // 2. we are in constructor right now,
       // we 'll use a small hack -
-      $rowCount = CRM_Utils_Array::value('crmRowCount', $_REQUEST, CRM_Utils_Pager::ROWCOUNT);
+      $rowCount = CRM_Utils_Array::value('crmRowCount', $_REQUEST, Civi::settings()->get('default_pager_size'));
       $pageId = CRM_Utils_Array::value('crmPID', $_REQUEST, 1);
       $offset = ($pageId - 1) * $rowCount;
       $this->_limitClause = NULL;

--- a/CRM/Contact/Page/DedupeException.php
+++ b/CRM/Contact/Page/DedupeException.php
@@ -52,7 +52,7 @@ class CRM_Contact_Page_DedupeException extends CRM_Core_Page {
     $totalitems = civicrm_api3('Exception', "getcount", $params);
     $params           = [
       'total' => $totalitems,
-      'rowCount' => CRM_Utils_Pager::ROWCOUNT,
+      'rowCount' => Civi::settings()->get('default_pager_size'),
       'status' => ts('Dedupe Exceptions %%StatusMessage%%'),
       'buttonBottom' => 'PagerBottomButton',
       'buttonTop' => 'PagerTopButton',

--- a/CRM/Contact/Selector.php
+++ b/CRM/Contact/Selector.php
@@ -324,7 +324,7 @@ class CRM_Contact_Selector extends CRM_Core_Selector_Base implements CRM_Core_Se
   public function getPagerParams($action, &$params) {
     $params['status'] = ts('Contact %%StatusMessage%%');
     $params['csvString'] = NULL;
-    $params['rowCount'] = CRM_Utils_Pager::ROWCOUNT;
+    $params['rowCount'] = Civi::settings()->get('default_pager_size');
 
     $params['buttonTop'] = 'PagerTopButton';
     $params['buttonBottom'] = 'PagerBottomButton';

--- a/CRM/Contact/Selector/Custom.php
+++ b/CRM/Contact/Selector/Custom.php
@@ -191,7 +191,7 @@ class CRM_Contact_Selector_Custom extends CRM_Contact_Selector {
   public function getPagerParams($action, &$params) {
     $params['status'] = ts('Contact %%StatusMessage%%');
     $params['csvString'] = NULL;
-    $params['rowCount'] = CRM_Utils_Pager::ROWCOUNT;
+    $params['rowCount'] = Civi::settings()->get('default_pager_size');
 
     $params['buttonTop'] = 'PagerTopButton';
     $params['buttonBottom'] = 'PagerBottomButton';

--- a/CRM/Contribute/Page/ContributionPage.php
+++ b/CRM/Contribute/Page/ContributionPage.php
@@ -648,7 +648,7 @@ ORDER BY is_active desc, title asc
     $params['buttonBottom'] = 'PagerBottomButton';
     $params['rowCount'] = $this->get(CRM_Utils_Pager::PAGE_ROWCOUNT);
     if (!$params['rowCount']) {
-      $params['rowCount'] = CRM_Utils_Pager::ROWCOUNT;
+      $params['rowCount'] = Civi::settings()->get('default_pager_size');
     }
 
     $query = "

--- a/CRM/Contribute/Selector/Search.php
+++ b/CRM/Contribute/Selector/Search.php
@@ -248,7 +248,7 @@ class CRM_Contribute_Selector_Search extends CRM_Core_Selector_Base implements C
       $params['rowCount'] = $this->_limit;
     }
     else {
-      $params['rowCount'] = CRM_Utils_Pager::ROWCOUNT;
+      $params['rowCount'] = Civi::settings()->get('default_pager_size');
     }
 
     $params['buttonTop'] = 'PagerTopButton';

--- a/CRM/Core/Selector/Controller.php
+++ b/CRM/Core/Selector/Controller.php
@@ -228,7 +228,7 @@ class CRM_Core_Selector_Controller {
       $params['rowCount'] = $storeRowCount;
     }
     elseif (!isset($params['rowCount'])) {
-      $params['rowCount'] = CRM_Utils_Pager::ROWCOUNT;
+      $params['rowCount'] = Civi::settings()->get('default_pager_size');
     }
 
     $this->_pager = new CRM_Utils_Pager($params);

--- a/CRM/Event/Page/ManageEvent.php
+++ b/CRM/Event/Page/ManageEvent.php
@@ -575,7 +575,7 @@ ORDER BY start_date desc
     $params['buttonBottom'] = 'PagerBottomButton';
     $params['rowCount'] = $this->get(CRM_Utils_Pager::PAGE_ROWCOUNT);
     if (!$params['rowCount']) {
-      $params['rowCount'] = CRM_Utils_Pager::ROWCOUNT;
+      $params['rowCount'] = Civi::settings()->get('default_pager_size');
     }
 
     $query = "

--- a/CRM/Event/Page/ParticipantListing/NameStatusAndDate.php
+++ b/CRM/Event/Page/ParticipantListing/NameStatusAndDate.php
@@ -114,7 +114,7 @@ LIMIT    $offset, $rowCount";
     $params['buttonBottom'] = 'PagerBottomButton';
     $params['rowCount'] = $this->get(CRM_Utils_Pager::PAGE_ROWCOUNT);
     if (!$params['rowCount']) {
-      $params['rowCount'] = CRM_Utils_Pager::ROWCOUNT;
+      $params['rowCount'] = Civi::settings()->get('default_pager_size');
     }
 
     $query = "

--- a/CRM/Event/Page/ParticipantListing/Simple.php
+++ b/CRM/Event/Page/ParticipantListing/Simple.php
@@ -104,7 +104,7 @@ LIMIT    $offset, $rowCount";
     $params['buttonBottom'] = 'PagerBottomButton';
     $params['rowCount'] = $this->get(CRM_Utils_Pager::PAGE_ROWCOUNT);
     if (!$params['rowCount']) {
-      $params['rowCount'] = CRM_Utils_Pager::ROWCOUNT;
+      $params['rowCount'] = Civi::settings()->get('default_pager_size');
     }
 
     $query = "

--- a/CRM/Grant/Selector/Search.php
+++ b/CRM/Grant/Selector/Search.php
@@ -211,7 +211,7 @@ class CRM_Grant_Selector_Search extends CRM_Core_Selector_Base implements CRM_Co
       $params['rowCount'] = $this->_limit;
     }
     else {
-      $params['rowCount'] = CRM_Utils_Pager::ROWCOUNT;
+      $params['rowCount'] = Civi::settings()->get('default_pager_size');
     }
 
     $params['buttonTop'] = 'PagerTopButton';

--- a/CRM/Mailing/Selector/Browse.php
+++ b/CRM/Mailing/Selector/Browse.php
@@ -62,7 +62,7 @@ class CRM_Mailing_Selector_Browse extends CRM_Core_Selector_Base implements CRM_
    */
   public function getPagerParams($action, &$params) {
     $params['csvString'] = NULL;
-    $params['rowCount'] = CRM_Utils_Pager::ROWCOUNT;
+    $params['rowCount'] = Civi::settings()->get('default_pager_size');
     $params['status'] = ts('Mailings %%StatusMessage%%');
     $params['buttonTop'] = 'PagerTopButton';
     $params['buttonBottom'] = 'PagerBottomButton';

--- a/CRM/Mailing/Selector/Event.php
+++ b/CRM/Mailing/Selector/Event.php
@@ -107,7 +107,7 @@ class CRM_Mailing_Selector_Event extends CRM_Core_Selector_Base implements CRM_C
    */
   public function getPagerParams($action, &$params) {
     $params['csvString'] = NULL;
-    $params['rowCount'] = CRM_Utils_Pager::ROWCOUNT;
+    $params['rowCount'] = Civi::settings()->get('default_pager_size');
     $params['status'] = ts('%1 %%StatusMessage%%', [1 => $this->eventToTitle()]);
     $params['buttonTop'] = 'PagerTopButton';
     $params['buttonBottom'] = 'PagerBottomButton';

--- a/CRM/Mailing/Selector/Search.php
+++ b/CRM/Mailing/Selector/Search.php
@@ -213,7 +213,7 @@ class CRM_Mailing_Selector_Search extends CRM_Core_Selector_Base implements CRM_
       $params['rowCount'] = $this->_limit;
     }
     else {
-      $params['rowCount'] = CRM_Utils_Pager::ROWCOUNT;
+      $params['rowCount'] = Civi::settings()->get('default_pager_size');
     }
 
     $params['buttonTop'] = 'PagerTopButton';

--- a/CRM/Member/Selector/Search.php
+++ b/CRM/Member/Selector/Search.php
@@ -262,7 +262,7 @@ class CRM_Member_Selector_Search extends CRM_Core_Selector_Base implements CRM_C
       $params['rowCount'] = $this->_limit;
     }
     else {
-      $params['rowCount'] = CRM_Utils_Pager::ROWCOUNT;
+      $params['rowCount'] = Civi::settings()->get('default_pager_size');
     }
 
     $params['buttonTop'] = 'PagerTopButton';

--- a/CRM/Pledge/Selector/Search.php
+++ b/CRM/Pledge/Selector/Search.php
@@ -221,7 +221,7 @@ class CRM_Pledge_Selector_Search extends CRM_Core_Selector_Base {
       $params['rowCount'] = $this->_limit;
     }
     else {
-      $params['rowCount'] = CRM_Utils_Pager::ROWCOUNT;
+      $params['rowCount'] = Civi::settings()->get('default_pager_size');
     }
 
     $params['buttonTop'] = 'PagerTopButton';

--- a/CRM/Profile/Selector/Listings.php
+++ b/CRM/Profile/Selector/Listings.php
@@ -250,7 +250,7 @@ class CRM_Profile_Selector_Listings extends CRM_Core_Selector_Base implements CR
     $status = CRM_Utils_System::isNull($this->_multiRecordTableName) ? ts('Contact %%StatusMessage%%') : ts('Contact Multi Records %%StatusMessage%%');
     $params['status'] = $status;
     $params['csvString'] = NULL;
-    $params['rowCount'] = CRM_Utils_Pager::ROWCOUNT;
+    $params['rowCount'] = Civi::settings()->get('default_pager_size');
 
     $params['buttonTop'] = 'PagerTopButton';
     $params['buttonBottom'] = 'PagerBottomButton';

--- a/CRM/Utils/Pager.php
+++ b/CRM/Utils/Pager.php
@@ -32,7 +32,13 @@ class CRM_Utils_Pager extends Pager_Sliding {
   /**
    * Constants for static parameters of the pager
    */
-  const ROWCOUNT = 50, PAGE_ID = 'crmPID', PAGE_ID_TOP = 'crmPID', PAGE_ID_BOTTOM = 'crmPID_B', PAGE_ROWCOUNT = 'crmRowCount';
+  const PAGE_ID = 'crmPID', PAGE_ID_TOP = 'crmPID', PAGE_ID_BOTTOM = 'crmPID_B', PAGE_ROWCOUNT = 'crmRowCount';
+
+  /**
+   * Deprecated constants that might still be used by extensions but no longer by core
+   * @deprecated
+   */
+  const ROWCOUNT = 50;
 
   /**
    * The output of the pager. This is a name/value array with various keys
@@ -198,13 +204,13 @@ class CRM_Utils_Pager extends Pager_Sliding {
   /**
    * Get the number of rows to display from either a GET / POST variable
    *
-   * @param int $defaultPageRowCount
+   * @param int|null $defaultPageRowCount
    *   The default value if not set.
    *
    * @return int
    *   the rowCount value to use
    */
-  public function getPageRowCount($defaultPageRowCount = self::ROWCOUNT) {
+  public function getPageRowCount($defaultPageRowCount = NULL) {
     // POST has higher priority than GET vars
     if (isset($_POST[self::PAGE_ROWCOUNT])) {
       $rowCount = max((int ) @$_POST[self::PAGE_ROWCOUNT], 1);
@@ -213,7 +219,12 @@ class CRM_Utils_Pager extends Pager_Sliding {
       $rowCount = max((int ) @$_GET[self::PAGE_ROWCOUNT], 1);
     }
     else {
-      $rowCount = $defaultPageRowCount;
+      if (empty($defaultPageRowCount)) {
+        $rowcount = Civi::settings()->get('default_pager_size');
+      }
+      else {
+        $rowCount = $defaultPageRowCount;
+      }
     }
     return $rowCount;
   }

--- a/settings/Search.setting.php
+++ b/settings/Search.setting.php
@@ -228,4 +228,24 @@ return [
     'description' => ts("Which fields can be searched on in the menubar quicksearch box? Don't see your custom field here? Make sure it is marked as Searchable."),
     'help_text' => NULL,
   ],
+  'default_pager_size' => [
+    'group_name' => 'Search Preferences',
+    'group' => 'Search Preferences',
+    'name' => 'default_pager_size',
+    'type' => 'Integer',
+    'quick_form_type' => 'Element',
+    'html_type' => 'text',
+    'html_attributes' => [
+      'size' => 2,
+      'maxlength' => 3,
+    ],
+    'default' => 50,
+    'add' => '5.39',
+    'title' => ts('Default Search Pager size'),
+    'is_domain' => 1,
+    'is_contact' => 0,
+    'description' => ts('What is the default number of records to show on a search'),
+    'help_text' => NULL,
+  ],
+
 ];

--- a/tests/phpunit/CRM/Contact/Page/DedupeExceptionTest.php
+++ b/tests/phpunit/CRM/Contact/Page/DedupeExceptionTest.php
@@ -28,7 +28,7 @@ class CRM_Contact_Page_DedupeExceptionTest extends CiviUnitTestCase {
     $totalitems    = civicrm_api3('Exception', "getcount", []);
     $params        = [
       'total' => $totalitems,
-      'rowCount' => CRM_Utils_Pager::ROWCOUNT,
+      'rowCount' => Civi::settings()->get('default_pager_size'),
       'status' => ts('Dedupe Exceptions %%StatusMessage%%'),
       'buttonBottom' => 'PagerBottomButton',
       'buttonTop' => 'PagerTopButton',


### PR DESCRIPTION
…urned from QuickForm Searches

Overview
----------------------------------------
This allows sites to customise the default number of rows returned by a QuickForm search rather than it being hard coded to 50 and users having to manipulate the counter at the bottom on each search.

Before
----------------------------------------
Default number hard coded as a constant 50 in `CRM_Utils_Pager`

After
----------------------------------------
Site configurable setting for number of search results returned defaults to 50 which was the original constant value.

Technical Details
----------------------------------------
I left the constant in CRM_Utils_Pager in case extensions had copied across code from core that used it but separated it out from the others to show it was deprecated.

ping @mattwire @eileenmcnaughton @MikeyMJCO @JoeMurray 

You folks might be interested in this
