### PR TITLE
fix default 'is searchable' to prevent breaking advanced search

### DIFF
--- a/CRM/Custom/Form/Field.php
+++ b/CRM/Custom/Form/Field.php
@@ -161,7 +161,7 @@ class CRM_Custom_Form_Field extends CRM_Core_Form {
       $defaults['html_type'] = 'Text';
       $defaults['is_active'] = 1;
       $defaults['option_type'] = 1;
-      $defaults['is_search_range'] = 1;
+      $defaults['is_search_range'] = 0;
       $defaults['weight'] = CRM_Utils_Weight::getDefaultWeight('CRM_Core_DAO_CustomField', ['custom_group_id' => $this->_gid]);
       $defaults['text_length'] = 255;
       $defaults['note_columns'] = 60;


### PR DESCRIPTION
https://lab.civicrm.org/dev/core/-/issues/2188

Overview
----------------------------------------
Searchable custom fields of type "Integer" with radio buttons can cause Advanced Search to break.

Before
----------------------------------------
a JS error in Advanced Search that breaks other JS, e.g.:
```
Uncaught query function not defined for Select2 custom_9_from
```

After
----------------------------------------
Advanced Search works correctly.

Technical Details
----------------------------------------
The "Add Custom Field" form has a default for "Search by Range" set to "Yes", which is hidden by JS until someone sets "Is Searchable" to "Yes".

However, there's no widget to search by range on a multiple-choice field (it doesn't really make sense) so "Search by Range" remains hidden.  Unfortunately, that means the field takes the default of "Yes".  Advanced Search breaks because the widget doesn't exist.

The solution IMO is to change the default for the "Search by Range" field.  I think the argument in defaulting to "Yes" is weak in general.

Comments
----------------------------------------
This issue exists in master, but has existed at least as far back as 5.13.

No test because it's 100% form level.  This doesn't happen when adding fields via API.