### PR TITLE
dev/core#2178 Fix regression on adding contacts to a newly created group

### DIFF
--- a/CRM/Group/Controller.php
+++ b/CRM/Group/Controller.php
@@ -16,6 +16,8 @@
  */
 class CRM_Group_Controller extends CRM_Core_Controller {
 
+  protected $entity = 'Contact';
+
   /**
    * Class constructor.
    *
@@ -52,6 +54,7 @@ class CRM_Group_Controller extends CRM_Core_Controller {
 
     // add all the actions
     $this->addActions($uploadDir, $uploadNames);
+    $this->set('entity', $this->entity);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Backport PR of https://github.com/civicrm/civicrm-core/pull/18967

Before
----------------------------------------
Cannot add contacts to a group immediately after creating the group.

After
----------------------------------------
Can add contacts to a group immediately after creating the group.

ping @eileenmcnaughton 