### PR TITLE
Fix undeclared afform requirement of ngRoute

### DIFF
--- a/ext/afform/core/ang/afCore.ang.php
+++ b/ext/afform/core/ang/afCore.ang.php
@@ -10,7 +10,7 @@ return [
     'ang/afCore/*/*.js',
   ],
   'css' => ['ang/afCore.css'],
-  'requires' => ['crmUi', 'crmUtil', 'api4', 'checklist-model'],
+  'requires' => ['crmUi', 'crmUtil', 'api4', 'checklist-model', 'ngRoute'],
   'partials' => ['ang/afCore'],
   'settings' => [],
   'basePages' => [],


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a crash when embedding an afform directive on other Angular pages.

Before
----------------------------------------
Afform dependency ngRoute fails to load.

After
----------------------------------------
Works correctly.
