### PR TITLE
Search ext: use crmRouteBinder to expose params for new searches to url

### DIFF
--- a/ext/search/ang/crmSearchAdmin.ang.php
+++ b/ext/search/ang/crmSearchAdmin.ang.php
@@ -13,6 +13,6 @@ return [
     'ang/crmSearchAdmin',
   ],
   'basePages' => ['civicrm/admin/search'],
-  'requires' => ['crmUi', 'crmUtil', 'ngRoute', 'ui.sortable', 'ui.bootstrap', 'api4', 'crmSearchDisplay', 'crmSearchActions', 'crmSearchKit'],
+  'requires' => ['crmUi', 'crmUtil', 'ngRoute', 'ui.sortable', 'ui.bootstrap', 'api4', 'crmSearchDisplay', 'crmSearchActions', 'crmSearchKit', 'crmRouteBinder'],
   'settingsFactory' => ['\Civi\Search\Admin', 'getAdminSettings'],
 ];

--- a/ext/search/ang/crmSearchAdmin.module.js
+++ b/ext/search/ang/crmSearchAdmin.module.js
@@ -21,7 +21,7 @@
                 'name',
                 'label',
                 'api_entity',
-                'form_values',
+                'api_params',
                 'GROUP_CONCAT(display.name ORDER BY display.id) AS display_name',
                 'GROUP_CONCAT(display.label ORDER BY display.id) AS display_label',
                 'GROUP_CONCAT(display.type:icon ORDER BY display.id) AS display_icon',

--- a/ext/search/ang/crmSearchAdmin/searchList.controller.js
+++ b/ext/search/ang/crmSearchAdmin/searchList.controller.js
@@ -11,6 +11,10 @@
 
     this.searchPath = window.location.href.split('#')[0].replace('civicrm/admin/search', 'civicrm/search');
 
+    this.encode = function(params) {
+      return encodeURI(angular.toJson(params));
+    };
+
     this.deleteSearch = function(search) {
       var index = _.findIndex(savedSearches, {id: search.id});
       if (index > -1) {

--- a/ext/search/ang/crmSearchAdmin/searchList.html
+++ b/ext/search/ang/crmSearchAdmin/searchList.html
@@ -39,7 +39,8 @@
         </td>
         <td>{{ search.groups.join(', ') }}</td>
         <td class="text-right">
-          <a class="btn btn-xs btn-default" href="#/edit/{{ search.id }}">{{:: ts('Edit') }}</a>
+          <a class="btn btn-xs btn-default" href="#/edit/{{:: search.id }}">{{:: ts('Edit') }}</a>
+          <a class="btn btn-xs btn-default" href="#/create/{{:: search.api_entity + '?params=' + $ctrl.encode(search.api_params) }}">{{:: ts('Clone') }}</a>
           <a href class="btn btn-xs btn-danger" crm-confirm="{type: 'delete', obj: search}" on-yes="$ctrl.deleteSearch(search)">{{:: ts('Delete') }}</a>
         </td>
       </tr>


### PR DESCRIPTION
Overview
----------------------------------------
This makes it easier to bookmark, copy, paste and share searches in search kit by exposing params to the url bar.

Before
----------------------------------------
Params not exposed as url args.

After
----------------------------------------
For *unsaved* searches: params are exposed to url, for easy bookmarking & sharing
For *saved* searches: params not exposed while editing
For *saved* searches: a "clone" button has been added which links to create a new search with url params from existing search
