### PR TITLE
dev/core#2162: allow reports to filter multi-select fields and find entities with multiple selections

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -3912,7 +3912,8 @@ WHERE cg.extends IN ('" . implode("','", $this->_customGroupExtends) . "') AND
     }
     $sql = "
 SELECT cg.table_name, cg.title, cg.extends, cf.id as cf_id, cf.label,
-       cf.column_name, cf.data_type, cf.html_type, cf.option_group_id, cf.time_format
+       cf.column_name, cf.data_type, cf.html_type, cf.option_group_id, cf.time_format,
+       cf.serialize as serialize
 FROM   civicrm_custom_group cg
 INNER  JOIN civicrm_custom_field cf ON cg.id = cf.custom_group_id
 WHERE cg.extends IN ('" . implode("','", $this->_customGroupExtends) . "') AND


### PR DESCRIPTION
Currently, Reports which filter on multi-select fields will only find entities with single selections. The generated SQL syntax is not compatible with the storage format of multi-select custom fields.

Overview
----------------------------------------
Here is the issue which this fix addresses:
https://lab.civicrm.org/dev/core/-/issues/2162

The detailed description and reproduction steps are documented there.

Before
----------------------------------------
Contacts with multiple selections in a multi-select custom field would never appear in a Report which filters on that custom field. I believe this is a regression, though I haven't worked out exactly when it changed.

After
----------------------------------------
With this change, reports can filter correctly on these fields.

Technical Details
----------------------------------------
The addCustomDataToColumns function constructs a $customDAO object, which is then used to determine the operator (among other things). It wasn't fetching the civicrm_custom_field.serialize field when it constructed this object, so it concluded that custom fields are never serialized.

By fetching this field, it appears to function as intended.

Comments
----------------------------------------
When I wrote the initial issue description, I was under the impression that the change may have been deliberate. I now think that it was probably accidental, and reports filtering for "is one of" a multi-select field should find entities with more than one selection.