### PR TITLE
Extensionsuitweak

### DIFF
--- a/templates/CRM/Admin/Page/ExtensionDetails.tpl
+++ b/templates/CRM/Admin/Page/ExtensionDetails.tpl
@@ -1,23 +1,12 @@
 <table class="crm-info-panel">
-    {if $extension.name}
-    <tr>
-        <td class="label">{ts}Name (key){/ts}</td><td>{$extension.name} ({$extension.key})</td>
-    </tr>
-    {/if}
-    <tr>
-        <td class="label">{ts}Description{/ts}</td><td>{$extension.description}</td>
-    </tr>
-    <tr>
-        <td class="label">{ts}Download location{/ts}</td><td>{$extension.downloadUrl}</td>
-    </tr>
-    <tr>
-        <td class="label">{ts}Local path{/ts}</td><td>{$extension.path}</td>
-    </tr>
         {foreach from=$extension.urls key=label item=url}
             <tr><td class="label">{$label}</td><td><a href="{$url}">{$url}</a></td></tr>
         {/foreach}
     <tr>
         <td class="label">{ts}Author{/ts}</td><td>{$extension.maintainer.author} (<a href="mailto:{$extension.maintainer.email}">{$extension.maintainer.email}</a>)</td>
+    </tr>
+    <tr>
+      <td class="label">{ts}Comments{/ts}</td><td>{$extension.comments}</td>
     </tr>
     <tr>
         <td class="label">{ts}Version{/ts}</td><td>{$extension.version}</td>
@@ -55,6 +44,12 @@
         </td>
     </tr>
     <tr>
-        <td class="label">{ts}Comments{/ts}</td><td>{$extension.comments}</td>
+      <td class="label">{ts}Local path{/ts}</td><td>{$extension.path}</td>
+    </tr>
+    <tr>
+      <td class="label">{ts}Download location{/ts}</td><td>{$extension.downloadUrl}</td>
+    </tr>
+    <tr>
+      <td class="label">{ts}Key{/ts}</td><td>{$extension.key}</td>
     </tr>
 </table>

--- a/templates/CRM/Admin/Page/Extensions/Main.tpl
+++ b/templates/CRM/Admin/Page/Extensions/Main.tpl
@@ -10,7 +10,7 @@ Depends: CRM/common/enableDisableApi.tpl and CRM/common/jsortable.tpl
     <table id="extensions" class="display">
       <thead>
         <tr>
-          <th>{ts}Extension name (key){/ts}</th>
+          <th>{ts}Name{/ts}</th>
           <th>{ts}Status{/ts}</th>
           <th>{ts}Version{/ts}</th>
           <th>{ts}Type{/ts}</th>
@@ -21,7 +21,7 @@ Depends: CRM/common/enableDisableApi.tpl and CRM/common/jsortable.tpl
         {foreach from=$localExtensionRows key=extKey item=row}
         <tr id="extension-{$row.file}" class="crm-entity crm-extension-{$row.file}{if $row.status eq 'disabled'} disabled{/if}{if $row.status eq 'installed-missing' or $row.status eq 'disabled-missing'} extension-missing{/if}{if $row.upgradable} extension-upgradable{elseif $row.status eq 'installed'} extension-installed{/if}">
           <td class="crm-extensions-label">
-              <a class="collapsed" href="#"></a>&nbsp;<strong>{$row.label}</strong><br/>({$row.key})
+              <a class="collapsed" href="#"></a>&nbsp;<strong>{$row.label}</strong><br/>{$row.description}
               {if $extAddNewEnabled && $remoteExtensionRows[$extKey] && $remoteExtensionRows[$extKey].is_upgradeable}
                 {capture assign='upgradeURL'}{crmURL p='civicrm/admin/extensions' q="action=update&id=$extKey&key=$extKey"}{/capture}
                 <div class="crm-extensions-upgrade">{ts 1=$upgradeURL}Version {$remoteExtensionRows[$extKey].version} is available. <a href="%1">Upgrade</a>{/ts}</div>


### PR DESCRIPTION
Overview
----------------------------------------
As pointed out in https://lab.civicrm.org/extensions/stripe/-/issues/275 we are displaying information on the extensions UI in a way that is more helpful to developers than end-users.

Before
----------------------------------------
Name + extension key shown. Then in details name/key repeated and download location / local path at top.

![image](https://user-images.githubusercontent.com/2052161/99308883-8479c680-2850-11eb-859d-3f1e935a45eb.png)


After
----------------------------------------
Name + description shown. Then in details we don't show name/description again. We move more useful information (links/comments) to the top and less useful information towards the bottom (local path, key etc).
![image](https://user-images.githubusercontent.com/2052161/99308815-6ad87f00-2850-11eb-8384-db173051a282.png)


Technical Details
----------------------------------------
template change only.

Comments
----------------------------------------
I'm sure there are multiple opinions and multiple ways this could be improved further. Hopefully this is a good start :-)

@joemurray