### PR TITLE
dev/wordpress#82 Add support for creating WordPress accounts from the contact record

### DIFF
--- a/CRM/Contact/Form/Task/Useradd.php
+++ b/CRM/Contact/Form/Task/Useradd.php
@@ -64,14 +64,20 @@ class CRM_Contact_Form_Task_Useradd extends CRM_Core_Form {
    * Build the form object.
    */
   public function buildQuickForm() {
+    $config = CRM_Core_Config::singleton();
+
     $element = $this->add('text', 'name', ts('Full Name'), ['class' => 'huge']);
     $element->freeze();
     $this->add('text', 'cms_name', ts('Username'), ['class' => 'huge']);
     $this->addRule('cms_name', 'Username is required', 'required');
-    $this->add('password', 'cms_pass', ts('Password'), ['class' => 'huge']);
-    $this->add('password', 'cms_confirm_pass', ts('Confirm Password'), ['class' => 'huge']);
-    $this->addRule('cms_pass', 'Password is required', 'required');
-    $this->addRule(['cms_pass', 'cms_confirm_pass'], 'ERROR: Password mismatch', 'compare');
+
+    if (!$config->userSystem->isUserRegistrationPermitted()) {
+      $this->add('password', 'cms_pass', ts('Password'), ['class' => 'huge']);
+      $this->add('password', 'cms_confirm_pass', ts('Confirm Password'), ['class' => 'huge']);
+      $this->addRule('cms_pass', 'Password is required', 'required');
+      $this->addRule(['cms_pass', 'cms_confirm_pass'], 'ERROR: Password mismatch', 'compare');
+    }
+
     $this->add('text', 'email', ts('Email:'), ['class' => 'huge'])->freeze();
     $this->addRule('email', 'Email is required', 'required');
     $this->add('hidden', 'contactID');


### PR DESCRIPTION
https://lab.civicrm.org/dev/wordpress/-/issues/82

Overview
----------------------------------------

To reproduce:

- As a WP admin, create a new contact record that has an email
- Click on the Actions menu

Expected: an option to create a new CMS account for this contact.

References:

- https://civicrm.stackexchange.com/questions/9092/wordpress-creating-new-wp-users-from-civi-contacts

Before
----------------------------------------

Users cannot create WP accounts from CiviCRM.

After
----------------------------------------

Users can create WP accounts.

Technical Details / Comments
----------------------------------------

I wasn't too sure how to avoid the automatic login. It didn't seem very obvious how this is handled in Drupal/Joomla.

There is one WIP issue: after the account is created, we are redirected back to the front page of the site, instead of the contact record. Everything seems fine, except the redirect, which looks like an exception bounce?