### PR TITLE
dev/core#2194 - Email sent to primary email if non primary email fiel…

### DIFF
--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -1099,6 +1099,7 @@ WHERE civicrm_event.is_active = 1
 
     if ($values['event']['is_email_confirm'] || $returnMessageText) {
       list($displayName, $email) = CRM_Contact_BAO_Contact_Location::getEmailDetails($contactID);
+      $email = CRM_Utils_Array::valueByRegexKey('/^email-/', $participantParams) ?? $email;
 
       //send email only when email is present
       if (isset($email) || $returnMessageText) {

--- a/CRM/Event/Form/Registration/ThankYou.php
+++ b/CRM/Event/Form/Registration/ThankYou.php
@@ -73,7 +73,10 @@ class CRM_Event_Form_Registration_ThankYou extends CRM_Event_Form_Registration {
     // Assign the email address from a contact id lookup as in CRM_Event_BAO_Event->sendMail()
     $primaryContactId = $this->get('primaryContactId');
     if ($primaryContactId) {
-      list($displayName, $email) = CRM_Contact_BAO_Contact_Location::getEmailDetails($primaryContactId);
+      $email = CRM_Utils_Array::valueByRegexKey('/^email-/', current($this->_params));
+      if (empty($email)) {
+        $email = CRM_Contact_BAO_Contact::getPrimaryEmail($primaryContactId);
+      }
       $this->assign('email', $email);
     }
     $this->assignToTemplate();


### PR DESCRIPTION
…d is included on the registration page

Overview
----------------------------------------
Email sent to primary email if non primary email field is included on the registration page

Before
----------------------------------------
To replicate

- Create a profile with Fname, Lname, Email (non primary loc type).
- Use this on an event registration page.
- Now, if a user registers on this event and enters a value in the email field, the invoice is sent to the primary email stored in civicrm. Not on the email which was entered while registering.

![image](https://user-images.githubusercontent.com/5929648/99380808-7085a180-28f0-11eb-8649-a5e906400782.png)

Thankyou page confirms that the email was sent to the primary address.

![image](https://user-images.githubusercontent.com/5929648/99380827-78454600-28f0-11eb-9afe-7cc118b654bd.png)

After
----------------------------------------
Email is sent to the address entered while filling the form.

Comments
----------------------------------------
Gitlab - https://lab.civicrm.org/dev/core/-/issues/2194