### PR TITLE
dev/drupal#146 - Wrong link for Drupal 8 permissions page / Make CMS permissions url lookup more OO-ey

### DIFF
--- a/CRM/Admin/Page/Access.php
+++ b/CRM/Admin/Page/Access.php
@@ -17,8 +17,6 @@
 
 /**
  * Dashboard page for managing Access Control.
- *
- * For initial version, this page only contains static links - so this class is empty for now.
  */
 class CRM_Admin_Page_Access extends CRM_Core_Page {
 
@@ -26,40 +24,12 @@ class CRM_Admin_Page_Access extends CRM_Core_Page {
    * @return string
    */
   public function run() {
-    $config = CRM_Core_Config::singleton();
-
-    switch ($config->userFramework) {
-      case 'Drupal':
-        $this->assign('ufAccessURL', url('admin/people/permissions'));
-        break;
-
-      case 'Drupal6':
-        $this->assign('ufAccessURL', url('admin/user/permissions'));
-        break;
-
-      case 'Joomla':
-        //condition based on Joomla version; <= 2.5 uses modal window; >= 3.0 uses full page with return value
-        if (version_compare(JVERSION, '3.0', 'lt')) {
-          JHTML::_('behavior.modal');
-          $url = $config->userFrameworkBaseURL . 'index.php?option=com_config&view=component&component=com_civicrm&tmpl=component';
-          $jparams = 'rel="{handler: \'iframe\', size: {x: 875, y: 550}, onClose: function() {}}" class="modal"';
-
-          $this->assign('ufAccessURL', $url);
-          $this->assign('jAccessParams', $jparams);
-        }
-        else {
-          $uri = (string) JUri::getInstance();
-          $return = urlencode(base64_encode($uri));
-          $url = $config->userFrameworkBaseURL . 'index.php?option=com_config&view=component&component=com_civicrm&return=' . $return;
-
-          $this->assign('ufAccessURL', $url);
-          $this->assign('jAccessParams', '');
-        }
-        break;
-
-      case 'WordPress':
-        $this->assign('ufAccessURL', CRM_Utils_System::url('civicrm/admin/access/wp-permissions', 'reset=1'));
-        break;
+    $urlParams = CRM_Utils_System::getCMSPermissionsUrlParams();
+    if (isset($urlParams['ufAccessURL'])) {
+      $this->assign('ufAccessURL', $urlParams['ufAccessURL']);
+    }
+    if (isset($urlParams['jAccessParams'])) {
+      $this->assign('jAccessParams', $urlParams['jAccessParams']);
     }
     return parent::run();
   }

--- a/CRM/Utils/System/Backdrop.php
+++ b/CRM/Utils/System/Backdrop.php
@@ -1049,4 +1049,12 @@ AND    u.status = 1
     }
   }
 
+  /**
+   * Return the CMS-specific url for its permissions page
+   * @return array
+   */
+  public function getCMSPermissionsUrlParams() {
+    return ['ufAccessURL' => url('admin/config/people/permissions')];
+  }
+
 }

--- a/CRM/Utils/System/Base.php
+++ b/CRM/Utils/System/Base.php
@@ -1004,4 +1004,12 @@ abstract class CRM_Utils_System_Base {
   public function prePostRedirect() {
   }
 
+  /**
+   * Return the CMS-specific url for its permissions page
+   * @return array
+   */
+  public function getCMSPermissionsUrlParams() {
+    return [];
+  }
+
 }

--- a/CRM/Utils/System/Drupal6.php
+++ b/CRM/Utils/System/Drupal6.php
@@ -809,4 +809,12 @@ class CRM_Utils_System_Drupal6 extends CRM_Utils_System_DrupalBase {
     ];
   }
 
+  /**
+   * Return the CMS-specific url for its permissions page
+   * @return array
+   */
+  public function getCMSPermissionsUrlParams() {
+    return ['ufAccessURL' => url('admin/user/permissions')];
+  }
+
 }

--- a/CRM/Utils/System/Drupal8.php
+++ b/CRM/Utils/System/Drupal8.php
@@ -827,4 +827,12 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
     return FALSE;
   }
 
+  /**
+   * Return the CMS-specific url for its permissions page
+   * @return array
+   */
+  public function getCMSPermissionsUrlParams() {
+    return ['ufAccessURL' => \Drupal\Core\Url::fromRoute('user.admin_permissions')->toString()];
+  }
+
 }

--- a/CRM/Utils/System/DrupalBase.php
+++ b/CRM/Utils/System/DrupalBase.php
@@ -701,4 +701,12 @@ abstract class CRM_Utils_System_DrupalBase extends CRM_Utils_System_Base {
     return FALSE;
   }
 
+  /**
+   * Return the CMS-specific url for its permissions page
+   * @return array
+   */
+  public function getCMSPermissionsUrlParams() {
+    return ['ufAccessURL' => url('admin/people/permissions')];
+  }
+
 }

--- a/CRM/Utils/System/Joomla.php
+++ b/CRM/Utils/System/Joomla.php
@@ -917,4 +917,29 @@ class CRM_Utils_System_Joomla extends CRM_Utils_System_Base {
     ];
   }
 
+  /**
+   * Return the CMS-specific url for its permissions page
+   * @return array
+   */
+  public function getCMSPermissionsUrlParams() {
+    $ufAccessURL = '';
+    $jAccessParams = '';
+    $config = CRM_Core_Config::singleton();
+    //condition based on Joomla version; <= 2.5 uses modal window; >= 3.0 uses full page with return value
+    if (version_compare(JVERSION, '3.0', 'lt')) {
+      JHTML::_('behavior.modal');
+      $ufAccessURL = $config->userFrameworkBaseURL . 'index.php?option=com_config&view=component&component=com_civicrm&tmpl=component';
+      $jAccessParams = 'rel="{handler: \'iframe\', size: {x: 875, y: 550}, onClose: function() {}}" class="modal"';
+    }
+    else {
+      $uri = (string) JUri::getInstance();
+      $return = urlencode(base64_encode($uri));
+      $ufAccessURL = $config->userFrameworkBaseURL . 'index.php?option=com_config&view=component&component=com_civicrm&return=' . $return;
+    }
+    return [
+      'ufAccessURL' => $ufAccessURL,
+      'jAccessParams' => $jAccessParams,
+    ];
+  }
+
 }

--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -1244,4 +1244,12 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
     $_COOKIE[$name] = $value;
   }
 
+  /**
+   * Return the CMS-specific url for its permissions page
+   * @return array
+   */
+  public function getCMSPermissionsUrlParams() {
+    return ['ufAccessURL' => CRM_Utils_System::url('civicrm/admin/access/wp-permissions', 'reset=1')];
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/drupal/-/issues/146

At Administer - Users and Permissions - Permissions there's a link to the CMS's permissions page. It's wrong for drupal 8/9.

This started smaller but then I noticed backdrop was completely missing so figured I might as well do it right. So this moves the hardcoded CMS names code into their respective System subclasses.

Before
----------------------------------------
Drupal 8/9 link is wrong. Backdrop also wrong.

After
----------------------------------------
Right

Technical Details
----------------------------------------
OO

Comments
----------------------------------------

