### PR TITLE
Allow Angular modules to require Resource bundles

### DIFF
--- a/Civi/Angular/AngularLoader.php
+++ b/Civi/Angular/AngularLoader.php
@@ -175,6 +175,10 @@ class AngularLoader {
         $res->addStyleUrl($url, self::DEFAULT_MODULE_WEIGHT + (++$headOffset), $this->getRegion());
       }
     }
+    // Add bundles
+    foreach ($this->angular->getResources($moduleNames, 'bundles', 'bundles') as $bundles) {
+      $res->addBundle($bundles);
+    }
 
     return $this;
   }

--- a/Civi/Angular/Manager.php
+++ b/Civi/Angular/Manager.php
@@ -417,6 +417,7 @@ class Manager {
             case 'settingsFactory':
             case 'requires':
             case 'permissions':
+            case 'bundles':
               if (!empty($module[$resType])) {
                 $result[$moduleName] = $module[$resType];
               }


### PR DESCRIPTION
Overview
----------------------------------------
Permits Angular modules to require "bundles" from `Civi::Resources`.

Before
----------------------------------------
N/A

After
----------------------------------------
An angular module can require 'bundles' from its `.ang.php`

