### PR TITLE
afform/gui - Fix rendering of the "Form Settings"

### DIFF
--- a/ext/afform/gui/ang/afGuiEditor/config-form.html
+++ b/ext/afform/gui/ang/afGuiEditor/config-form.html
@@ -5,7 +5,7 @@
 <label for="af_config_form_description">
   {{ ts('Description:') }}
 </label>
-<textarea ng-model="afform.description" class="form-control" id="af_config_form_description" />
+<textarea ng-model="afform.description" class="form-control" id="af_config_form_description"></textarea>
 <label for="af_config_form_server_route">
   {{ ts('URL:') }}
 </label>


### PR DESCRIPTION
Overview
----------------------------------------

In the "Form Settings", some of the properties (such as "URL" and "Permissions") are not displayed.

Before
----------------------------------------

<img width="402" alt="Screen Shot 2020-11-18 at 2 20 57 AM" src="https://user-images.githubusercontent.com/1336047/99517874-b8ceaf00-2944-11eb-8486-335d1e196307.png">

After
----------------------------------------

<img width="407" alt="Screen Shot 2020-11-18 at 2 20 26 AM" src="https://user-images.githubusercontent.com/1336047/99517806-a5234880-2944-11eb-9b3e-8bef8ab535ce.png">

Technical Details
----------------------------------------

The `<textarea/>` tag is not interpreted as you might expect - it seems to be treated like `<textarea>` (without a closing). The subsequent text shows up in the DOM as subordinate content (but that initial DOM content is ultimately invisible because it's overriden by a data-binding `ng-model="afform.description".`).
