### PR TITLE
dev/core#2196 - serialize E_NOTICE when saving custom field

### DIFF
--- a/CRM/Custom/Form/Field.php
+++ b/CRM/Custom/Form/Field.php
@@ -844,12 +844,7 @@ AND    option_group_id = %2";
       $params['is_search_range'] = 0;
     }
 
-    if ($params['data_type'] !== 'ContactReference' && ($params['html_type'] === 'Select' || $params['html_type'] === 'Autocomplete-Select')) {
-      $params['serialize'] = $params['serialize'] ? CRM_Core_DAO::SERIALIZE_SEPARATOR_BOOKEND : 'null';
-    }
-    else {
-      $params['serialize'] = $params['html_type'] == 'CheckBox' ? CRM_Core_DAO::SERIALIZE_SEPARATOR_BOOKEND : 'null';
-    }
+    $params['serialize'] = $this->determineSerializeType($params);
 
     $filter = 'null';
     if ($params['data_type'] == 'ContactReference' && !empty($params['filter_selected'])) {
@@ -952,6 +947,21 @@ AND    option_group_id = %2";
    */
   public function getDefaultEntity() {
     return 'CustomField';
+  }
+
+  /**
+   * Determine the serialize type based on form values.
+   * @param array $params The submitted form values.
+   * @return int|string
+   *   The serialize type - CRM_Core_DAO::SERIALIZE_XXX or the string 'null'
+   */
+  public function determineSerializeType($params) {
+    if ($params['data_type'] !== 'ContactReference' && ($params['html_type'] === 'Select' || $params['html_type'] === 'Autocomplete-Select')) {
+      return !empty($params['serialize']) ? CRM_Core_DAO::SERIALIZE_SEPARATOR_BOOKEND : 'null';
+    }
+    else {
+      return $params['html_type'] == 'CheckBox' ? CRM_Core_DAO::SERIALIZE_SEPARATOR_BOOKEND : 'null';
+    }
   }
 
 }

--- a/tests/phpunit/CRM/Custom/Form/FieldTest.php
+++ b/tests/phpunit/CRM/Custom/Form/FieldTest.php
@@ -1,0 +1,380 @@
+<?php
+
+/**
+ * Class CRM_Custom_Form_FieldTest
+ * @group headless
+ */
+class CRM_Custom_Form_FieldTest extends CiviUnitTestCase {
+
+  public function setUp() {
+    parent::setUp();
+  }
+
+  /**
+   * Test the serialize type is determined properly based on form input.
+   *
+   * @dataProvider serializeDataProvider
+   *
+   * @param array $input
+   * @param int|string $expected
+   */
+  public function testDetermineSerializeType(array $input, $expected) {
+    $form = new CRM_Custom_Form_Field();
+    $this->assertSame($expected, $form->determineSerializeType($input));
+  }
+
+  /**
+   * DataProvider for testDetermineSerializeType
+   * @return array
+   */
+  public function serializeDataProvider():array {
+    return [
+      0 => [
+        [
+          'data_type' => 'String',
+          'html_type' => 'Text',
+        ],
+        'null',
+      ],
+      1 => [
+        [
+          'data_type' => 'String',
+          'html_type' => 'Select',
+        ],
+        'null',
+      ],
+      2 => [
+        [
+          'data_type' => 'String',
+          'html_type' => 'Radio',
+        ],
+        'null',
+      ],
+      3 => [
+        [
+          'data_type' => 'String',
+          'html_type' => 'CheckBox',
+        ],
+        CRM_Core_DAO::SERIALIZE_SEPARATOR_BOOKEND,
+      ],
+      4 => [
+        [
+          'data_type' => 'String',
+          'html_type' => 'Autocomplete-Select',
+        ],
+        'null',
+      ],
+      5 => [
+        [
+          'data_type' => 'String',
+          'html_type' => 'Text',
+          'serialize' => '1',
+        ],
+        'null',
+      ],
+      6 => [
+        [
+          'data_type' => 'String',
+          'html_type' => 'Select',
+          'serialize' => '1',
+        ],
+        CRM_Core_DAO::SERIALIZE_SEPARATOR_BOOKEND,
+      ],
+      7 => [
+        [
+          'data_type' => 'String',
+          'html_type' => 'Radio',
+          'serialize' => '1',
+        ],
+        'null',
+      ],
+      8 => [
+        [
+          'data_type' => 'String',
+          'html_type' => 'CheckBox',
+          'serialize' => '1',
+        ],
+        CRM_Core_DAO::SERIALIZE_SEPARATOR_BOOKEND,
+      ],
+      9 => [
+        [
+          'data_type' => 'String',
+          'html_type' => 'Autocomplete-Select',
+          'serialize' => '1',
+        ],
+        CRM_Core_DAO::SERIALIZE_SEPARATOR_BOOKEND,
+      ],
+      10 => [
+        [
+          'data_type' => 'Int',
+          'html_type' => 'Text',
+        ],
+        'null',
+      ],
+      11 => [
+        [
+          'data_type' => 'Int',
+          'html_type' => 'Select',
+        ],
+        'null',
+      ],
+      12 => [
+        [
+          'data_type' => 'Int',
+          'html_type' => 'Radio',
+        ],
+        'null',
+      ],
+      13 => [
+        [
+          'data_type' => 'Int',
+          'html_type' => 'Text',
+          'serialize' => '1',
+        ],
+        'null',
+      ],
+      14 => [
+        [
+          'data_type' => 'Int',
+          'html_type' => 'Select',
+          'serialize' => '1',
+        ],
+        CRM_Core_DAO::SERIALIZE_SEPARATOR_BOOKEND,
+      ],
+      15 => [
+        [
+          'data_type' => 'Int',
+          'html_type' => 'Radio',
+          'serialize' => '1',
+        ],
+        'null',
+      ],
+      16 => [
+        [
+          'data_type' => 'Float',
+          'html_type' => 'Text',
+        ],
+        'null',
+      ],
+      17 => [
+        [
+          'data_type' => 'Float',
+          'html_type' => 'Select',
+        ],
+        'null',
+      ],
+      18 => [
+        [
+          'data_type' => 'Float',
+          'html_type' => 'Radio',
+        ],
+        'null',
+      ],
+      19 => [
+        [
+          'data_type' => 'Float',
+          'html_type' => 'Text',
+          'serialize' => '1',
+        ],
+        'null',
+      ],
+      20 => [
+        [
+          'data_type' => 'Float',
+          'html_type' => 'Select',
+          'serialize' => '1',
+        ],
+        CRM_Core_DAO::SERIALIZE_SEPARATOR_BOOKEND,
+      ],
+      21 => [
+        [
+          'data_type' => 'Float',
+          'html_type' => 'Radio',
+          'serialize' => '1',
+        ],
+        'null',
+      ],
+      22 => [
+        [
+          'data_type' => 'Money',
+          'html_type' => 'Text',
+        ],
+        'null',
+      ],
+      23 => [
+        [
+          'data_type' => 'Money',
+          'html_type' => 'Select',
+        ],
+        'null',
+      ],
+      24 => [
+        [
+          'data_type' => 'Money',
+          'html_type' => 'Radio',
+        ],
+        'null',
+      ],
+      25 => [
+        [
+          'data_type' => 'Money',
+          'html_type' => 'Text',
+          'serialize' => '1',
+        ],
+        'null',
+      ],
+      26 => [
+        [
+          'data_type' => 'Money',
+          'html_type' => 'Select',
+          'serialize' => '1',
+        ],
+        CRM_Core_DAO::SERIALIZE_SEPARATOR_BOOKEND,
+      ],
+      27 => [
+        [
+          'data_type' => 'Money',
+          'html_type' => 'Radio',
+          'serialize' => '1',
+        ],
+        'null',
+      ],
+      28 => [
+        [
+          'data_type' => 'Memo',
+          'html_type' => 'TextArea',
+        ],
+        'null',
+      ],
+      29 => [
+        [
+          'data_type' => 'Memo',
+          'html_type' => 'RichTextEditor',
+        ],
+        'null',
+      ],
+      30 => [
+        [
+          'data_type' => 'Memo',
+          'html_type' => 'TextArea',
+          'serialize' => '1',
+        ],
+        'null',
+      ],
+      31 => [
+        [
+          'data_type' => 'Memo',
+          'html_type' => 'RichTextEditor',
+          'serialize' => '1',
+        ],
+        'null',
+      ],
+      32 => [
+        [
+          'data_type' => 'Date',
+          'html_type' => 'Select Date',
+        ],
+        'null',
+      ],
+      33 => [
+        [
+          'data_type' => 'Date',
+          'html_type' => 'Select Date',
+          'serialize' => '1',
+        ],
+        'null',
+      ],
+      34 => [
+        [
+          'data_type' => 'Boolean',
+          'html_type' => 'Radio',
+        ],
+        'null',
+      ],
+      35 => [
+        [
+          'data_type' => 'Boolean',
+          'html_type' => 'Radio',
+          'serialize' => '1',
+        ],
+        'null',
+      ],
+      36 => [
+        [
+          'data_type' => 'StateProvince',
+          'html_type' => 'Select',
+        ],
+        'null',
+      ],
+      37 => [
+        [
+          'data_type' => 'StateProvince',
+          'html_type' => 'Select',
+          'serialize' => '1',
+        ],
+        CRM_Core_DAO::SERIALIZE_SEPARATOR_BOOKEND,
+      ],
+      38 => [
+        [
+          'data_type' => 'Country',
+          'html_type' => 'Select',
+        ],
+        'null',
+      ],
+      39 => [
+        [
+          'data_type' => 'Country',
+          'html_type' => 'Select',
+          'serialize' => '1',
+        ],
+        CRM_Core_DAO::SERIALIZE_SEPARATOR_BOOKEND,
+      ],
+      40 => [
+        [
+          'data_type' => 'File',
+          'html_type' => 'File',
+        ],
+        'null',
+      ],
+      41 => [
+        [
+          'data_type' => 'File',
+          'html_type' => 'File',
+          'serialize' => '1',
+        ],
+        'null',
+      ],
+      42 => [
+        [
+          'data_type' => 'Link',
+          'html_type' => 'Link',
+        ],
+        'null',
+      ],
+      43 => [
+        [
+          'data_type' => 'Link',
+          'html_type' => 'Link',
+          'serialize' => '1',
+        ],
+        'null',
+      ],
+      44 => [
+        [
+          'data_type' => 'ContactReference',
+          'html_type' => 'Autocomplete-Select',
+        ],
+        'null',
+      ],
+      45 => [
+        [
+          'data_type' => 'ContactReference',
+          'html_type' => 'Autocomplete-Select',
+          'serialize' => '1',
+        ],
+        'null',
+      ],
+    ];
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/2196

1. Turn off popups so you can see the error. (Admin - Customize - Display Prefs - uncheck Enable Popup Forms)
1. Create a custom field of type alphanumeric and drop-down select list.
1. Doesn't matter what the options are.
1. Click save.
1. Notice: `Undefined index: serialize in CRM_Custom_Form_Field->postProcess() (line 848 of .../CRM/Custom/Form/Field.php).`

Technical Details
----------------------------------------
I pulled the block into its own little function to be able to write the test. It's the same except for the `empty()`.

At the point `$params['serialize']` needs the empty check it represents the value of a checkbox field on the form, so can be missing since that's how checkboxes work.

Comments
----------------------------------------
Has test.