### PR TITLE
dev/financial#153 Fix redirect to PayPal

### DIFF
--- a/CRM/Core/Payment/PayPalImpl.php
+++ b/CRM/Core/Payment/PayPalImpl.php
@@ -843,9 +843,10 @@ class CRM_Core_Payment_PayPalImpl extends CRM_Core_Payment {
     }
     $this->_component = $params['component'];
     $token = $this->setExpressCheckOut($params);
+    $siteUrl = rtrim($this->_paymentProcessor['url_site'], '/');
     return [
       'pre_approval_parameters' => ['token' => $token],
-      'redirect_url' => $this->_paymentProcessor['url_site'] . "/cgi-bin/webscr?cmd=_express-checkout&token=$token",
+      'redirect_url' => $siteUrl . "/cgi-bin/webscr?cmd=_express-checkout&token=$token",
     ];
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Fixes problem where PayPal redirects to https://cgi-bin/webscr after it's captcha page.

Before
----------------------------------------
If you clicked on the PayPal button on a donate or event registration form and then PayPal decides to give you it's captcha, PayPal would redirect you to https://cgi-bin/webscr after the captcha.

After
----------------------------------------
The redirect after filling out PayPal's captcha continues to the next page in PayPal's payment process.

Technical Details
----------------------------------------
If you put in double slashes in the path part of the PayPal URL and then PayPal asks you to do their captcha, they have some sort of bug where they do the wrong redirect after the captcha to https://cgi-bin/webscr. The URL that CiviCRM uses to send you to PayPal is made up of the configured "url_site" for the PaymentProcess plus a hardcoded path starting with "/cgi-bin/webscr". This change removes the trailing slash from the url_site string if it's there before combining it with the rest of the path.


https://lab.civicrm.org/dev/financial/-/issues/153