### PR TITLE
crm-ui-debug - If in debug mode, then load pretty-printer for JSON data

### DIFF
--- a/Civi/Angular/Manager.php
+++ b/Civi/Angular/Manager.php
@@ -111,6 +111,7 @@ class Manager {
       $angularModules['crmUi'] = include "$civicrm_root/ang/crmUi.ang.php";
       $angularModules['crmUtil'] = include "$civicrm_root/ang/crmUtil.ang.php";
       $angularModules['dialogService'] = include "$civicrm_root/ang/dialogService.ang.php";
+      $angularModules['jsonFormatter'] = include "$civicrm_root/ang/jsonFormatter.ang.php";
       $angularModules['ngRoute'] = include "$civicrm_root/ang/ngRoute.ang.php";
       $angularModules['ngSanitize'] = include "$civicrm_root/ang/ngSanitize.ang.php";
       $angularModules['ui.utils'] = include "$civicrm_root/ang/ui.utils.ang.php";

--- a/ang/crmUi.ang.php
+++ b/ang/crmUi.ang.php
@@ -3,12 +3,18 @@
 // in CiviCRM. See also:
 // http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_angularModules
 
+$isDebug = Civi::settings()->get('debug_enabled');
+
 return [
   'ext' => 'civicrm',
   'js' => ['ang/crmUi.js'],
   'partials' => ['ang/crmUi'],
-  'requires' => [
-    'crmResource',
-    'ui.utils',
-  ],
+  'requires' => array_merge(
+    [
+      'crmResource',
+      'ui.utils',
+    ],
+    // Only require the +10kb if we're likely to need it.
+    $isDebug ? ['jsonFormatter'] : []
+  ),
 ];

--- a/ang/crmUi.js
+++ b/ang/crmUi.js
@@ -106,7 +106,11 @@
         },
         template: function() {
           var args = $location.search();
-          return (args && args.angularDebug) ? '<div crm-ui-accordion=\'{title: ts("Debug (%1)", {1: crmUiDebug}), collapsed: true}\'><pre>{{data|json}}</pre></div>' : '';
+          if (args && args.angularDebug) {
+            var jsonTpl = (CRM.angular.modules.indexOf('jsonFormatter') < 0) ? '<pre>{{data|json}}</pre>' : '<json-formatter json="data" open="1"></json-formatter>';
+            return '<div crm-ui-accordion=\'{title: ts("Debug (%1)", {1: crmUiDebug}), collapsed: true}\'>' + jsonTpl + '</div>';
+          }
+          return '';
         },
         link: function(scope, element, attrs) {
           var args = $location.search();

--- a/ang/jsonFormatter.ang.php
+++ b/ang/jsonFormatter.ang.php
@@ -1,0 +1,11 @@
+<?php
+
+return [
+  'ext' => 'civicrm',
+  'js' => ['bower_components/json-formatter/dist/json-formatter.min.js'],
+  'css' => ['bower_components/json-formatter/dist/json-formatter.min.css'],
+  'requires' => [],
+  'exports' => [
+    'json-formatter' => 'E',
+  ],
+];

--- a/composer.json
+++ b/composer.json
@@ -231,6 +231,11 @@
         "url": "https://github.com/jquery-validation/jquery-validation/archive/1.19.1.zip",
         "ignore": [".*", "node_modules", "bower_components", "test", "demo", "lib"]
       },
+      "json-formatter": {
+        "url": "https://github.com/mohsen1/json-formatter/archive/v{$version}.zip",
+        "version": "0.7.0",
+        "ignore": ["demo", "test", "screenshot.png"]
+      },
       "jstree": {
         "url": "https://github.com/vakata/jstree/archive/3.3.8.zip",
         "ignore": [".*", "docs", "demo", "libs", "node_modules", "test", "libs", "jstree.jquery.json", "gruntfile.js", "package.json", "bower.json", "component.json", "LICENCE-MIT", "README.md"]

--- a/tests/phpunit/Civi/Angular/ManagerTest.php
+++ b/tests/phpunit/Civi/Angular/ManagerTest.php
@@ -181,8 +181,12 @@ class ManagerTest extends \CiviUnitTestCase {
       'ngSanitize',
       'ui.utils',
     ];
+    $ignore = [
+      'jsonFormatter',
+    ];
     $input = ['crmMailing', 'crmCxn'];
     $actual = $this->angular->resolveDependencies($input);
+    $actual = array_diff($actual, $ignore);
     sort($expected);
     sort($actual);
     $this->assertEquals($expected, $actual);


### PR DESCRIPTION
Overview
----------------------------------------

The Angular directive `crm-ui-debug` is used to conditionally dump debug details on an AngularJS-based page (i.e. if the user requests `?angularDebug=1`).  This patch improves the formatting.

Before
----------------------------------------

The debug data is serialized to JSON and dumped as a large text blob (`<pre>{{myData|json}}</pre>`).

<img width="1041" alt="Screen Shot 2020-11-19 at 1 38 31 AM" src="https://user-images.githubusercontent.com/1336047/99648511-f9433100-2a07-11eb-9f02-b480efbecf3e.png">

For objects with deep graphs, it's hard to see the structure.

After
----------------------------------------

The debug data is printed as a pretty tree with highlighting and expandable/collapsible sections.

<img width="1030" alt="Screen Shot 2020-11-19 at 1 38 04 AM" src="https://user-images.githubusercontent.com/1336047/99648506-f8120400-2a07-11eb-8b13-a57625a57ce5.png">


Technical Details
----------------------------------------

The pretty printer adds ~10kb to every page that uses `crmUi` (ie every Angular page in Civi), which seems a little gratuitious for production page-views. Alas, the `angularDebug=1` preference is a client-side thing that we don't know about server-side, so there's no way to anticipate if it's worth sending.

As a mitigation, this patch consults the global debug setting (`Civi::setting()->get('debug_enabled')`):

* If the server has debug enabled, then it sends the pretty-print library.
* If the server does not have debug enabled, then it sends the el-cheapo version (`<pre>{{myData|json}}</pre>`).

CC @colemanw @seamuslee001 