### PR TITLE
Add pre() and post() hooks for ufgroup entity

### DIFF
--- a/CRM/Core/BAO/UFGroup.php
+++ b/CRM/Core/BAO/UFGroup.php
@@ -1459,6 +1459,10 @@ class CRM_Core_BAO_UFGroup extends CRM_Core_DAO_UFGroup {
     if (!empty($params['group_type']) && is_array($params['group_type'])) {
       $params['group_type'] = implode(',', $params['group_type']);
     }
+
+    $hook = empty($params['id']) ? 'create' : 'edit';
+    CRM_Utils_Hook::pre($hook, 'UFGroup', ($params['id'] ?? NULL), $params);
+
     $ufGroup = new CRM_Core_DAO_UFGroup();
     $ufGroup->copyValues($params);
 
@@ -1474,6 +1478,8 @@ class CRM_Core_BAO_UFGroup extends CRM_Core_DAO_UFGroup {
       $ufGroup->name = $ufGroup->name . "_{$ufGroup->id}";
       $ufGroup->save();
     }
+
+    CRM_Utils_Hook::post($hook, 'UFGroup', $ufGroup->id, $ufGroup);
 
     return $ufGroup;
   }

--- a/tests/phpunit/CRM/Core/BAO/UFGroupTest.php
+++ b/tests/phpunit/CRM/Core/BAO/UFGroupTest.php
@@ -1,0 +1,109 @@
+<?php
+
+/**
+ * Class CRM_Core_BAO_UFGroupTest
+ * @group headless
+ */
+class CRM_Core_BAO_UFGroupTest extends CiviUnitTestCase {
+
+  public function implementHookPre($op, $objectName, $id, &$params) {
+    if ($objectName == 'UFGroup') {
+      if ($op == 'create') {
+        $params['is_active'] = 0;
+      }
+      elseif ($op == 'delete') {
+        $systemLog = $this->callAPISuccess('SystemLog', 'create', [
+          'message' => "CRM_Core_BAO_UFGroupTest::implementHookPre $id",
+          'level' => 'info',
+        ]);
+      }
+    }
+  }
+
+  public function implementHookPost($op, $objectName, $objectId, &$objectRef) {
+    if ($objectName == 'UFGroup') {
+      if ($op == 'create') {
+        $objectRef->is_active = 0;
+      }
+      elseif ($op == 'delete') {
+        $systemLog = $this->callAPISuccess('SystemLog', 'create', [
+          'message' => "CRM_Core_BAO_UFGroupTest::implementHookPost $objectId",
+          'level' => 'info',
+        ]);
+      }
+    }
+  }
+
+  public function testPreHookIsCalledForCreate() {
+    // Specify pre hook implementation.
+    $this->hookClass->setHook('civicrm_pre', array($this, 'implementHookPre'));
+
+    // Create a ufgroup with BAO.
+    $params = [
+      'title' => 'testPreHookIsCalledForCreate',
+      'is_active' => 1,
+    ];
+    $ufGroup = CRM_Core_BAO_UFGroup::add($params);
+
+    // Assert that pre hook implemntation was called.
+    $this->assertEquals('testPreHookIsCalledForCreate', $ufGroup->title);
+    $this->assertEquals(0, $ufGroup->is_active, 'Is active should be 0');
+  }
+
+  public function testPreHookIsCalledForDelete() {
+    // Specify pre hook implementation.
+    $this->hookClass->setHook('civicrm_pre', array($this, 'implementHookPre'));
+
+    // Create a ufgroup with BAO.
+    $params = [
+      'title' => 'testPreHookIsCalledForDelete',
+      'is_active' => 1,
+    ];
+    $ufGroup = CRM_Core_BAO_UFGroup::add($params);
+    $ufGroupID = $ufGroup->id;
+    $ufGroup = CRM_Core_BAO_UFGroup::del($ufGroupID);
+
+    // Assert that pre hook implemntation was called for delete op.
+    $systemLogCount = $this->callAPISuccess('SystemLog', 'getcount', [
+      'message' => "CRM_Core_BAO_UFGroupTest::implementHookPre $ufGroupID",
+      'level' => 'info',
+    ]);
+
+    $this->assertEquals(1, $systemLogCount, 'There should be one system log entry with message "CRM_Core_BAO_UFGroupTest::implementHookPre ' . $ufGroupID . '"');
+  }
+
+  public function testPostHookIsCalledForCreate() {
+    $this->hookClass->setHook('civicrm_post', array($this, 'implementHookPost'));
+
+    $params = [
+      'title' => 'testPostHookIsCalledForCreate',
+      'is_active' => 1,
+    ];
+    $ufGroup = CRM_Core_BAO_UFGroup::add($params);
+
+    // Assert that pre hook implemntation was called.
+    $this->assertEquals('testPostHookIsCalledForCreate', $ufGroup->title);
+    $this->assertEquals(0, $ufGroup->is_active, 'Is active should be 0');
+  }
+
+  public function testPostHookIsCalledForDelete() {
+    $this->hookClass->setHook('civicrm_post', array($this, 'implementHookPost'));
+
+    $params = [
+      'title' => 'testPostHookIsCalledForDelete',
+      'is_active' => 1,
+    ];
+    $ufGroup = CRM_Core_BAO_UFGroup::add($params);
+    $ufGroupID = $ufGroup->id;
+    $ufGroup = CRM_Core_BAO_UFGroup::del($ufGroupID);
+
+    // Assert that pre hook implemntation was called for delete op.
+    $systemLogCount = $this->callAPISuccess('SystemLog', 'getcount', [
+      'message' => "CRM_Core_BAO_UFGroupTest::implementHookPost $ufGroupID",
+      'level' => 'info',
+    ]);
+
+    $this->assertEquals(1, $systemLogCount, 'There should be one system log entry with message "CRM_Core_BAO_UFGroupTest::implementHookPost ' . $ufGroupID . '"');
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
This is to add ufgroup support for pre() and post() hooks

Gitlab Issue: https://lab.civicrm.org/dev/core/-/issues/2199

Before
----------------------------------------
ufgroup was not supported with pre() and post() hooks.

After
----------------------------------------
ufgroup will be supported with pre() and post() hooks.