### PR TITLE
dev/core#1931 Prevent PayPal from double-encoding the IPN Notify URL 5.32 backport

### DIFF
--- a/CRM/Core/Payment/PayPalImpl.php
+++ b/CRM/Core/Payment/PayPalImpl.php
@@ -976,6 +976,14 @@ class CRM_Core_Payment_PayPalImpl extends CRM_Core_Payment {
     // Allow further manipulation of the arguments via custom hooks ..
     CRM_Utils_Hook::alterPaymentProcessorParams($this, $params, $paypalParams);
 
+    /*
+     * PayPal urlencodes the IPN Notify URL. For sites not using Clean URLs (or
+     * using Shortcodes in WordPress) this results in "%2F" becoming "%252F" and
+     * therefore incomplete transactions. We need to prevent that.
+     * @see https://lab.civicrm.org/dev/core/-/issues/1931
+     */
+    $paypalParams['notify_url'] = rawurldecode($paypalParams['notify_url']);
+
     $uri = '';
     foreach ($paypalParams as $key => $value) {
       if ($value === NULL) {


### PR DESCRIPTION
## Overview
Solves [this issue on the Lab](https://lab.civicrm.org/dev/core/-/issues/1931).

Backport of https://github.com/civicrm/civicrm-core/pull/18980
 
## Before
PayPal IPN return URLs contain double-encoded entities, e.g.
 
 ```
 "POST /2020/09/04/donation-shortcode/?civiwp=CiviCRM&q=civicrm%252Fpayment%252Fipn%252F3 HTTP/1.1" 200
 ```
 
 ## After
 PayPal IPN return URLs do not contain double-encoded entities, e.g.
 
 ```
 "POST /2020/09/04/donation-shortcode/?civiwp=CiviCRM&q=civicrm/payment/ipn/3 HTTP/1.1"
 ```
 
 ## Technical Details
 When CiviCRM does not use Clean URLs (or, in WordPress, if a Shortcode is used for a Contribution Page) then IPN notifications fail to register contributions as "Completed". This applies to all CMSes where Clean URLs are not in use.