### PR TITLE
Remove unused params, return params from processFail

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -1357,22 +1357,18 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution {
   /**
    * Process failed contribution.
    *
-   * @param $processContributionObject
    * @param $memberships
    * @param $contributionId
    * @param array $membershipStatuses
-   * @param array $updateResult
    * @param $participant
    * @param $pledgePayment
    * @param $pledgeID
    * @param array $pledgePaymentIDs
    * @param $contributionStatusId
    *
-   * @return array
    * @throws \CRM_Core_Exception
    */
-  protected static function processFail($processContributionObject, $memberships, $contributionId, array $membershipStatuses, array $updateResult, $participant, $pledgePayment, $pledgeID, array $pledgePaymentIDs, $contributionStatusId): array {
-    $processContribution = FALSE;
+  protected static function processFail($memberships, $contributionId, array $membershipStatuses, array $participant, $pledgePayment, $pledgeID, array $pledgePaymentIDs, $contributionStatusId): void {
     if (is_array($memberships)) {
       foreach ($memberships as $membership) {
         $update = TRUE;
@@ -1392,11 +1388,6 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution {
           $membership->is_override = TRUE;
           $membership->status_override_end_date = 'null';
           $membership->save();
-
-          $updateResult['updatedComponents']['CiviMember'] = $membership->status_id;
-          if ($processContributionObject) {
-            $processContribution = TRUE;
-          }
         }
       }
     }
@@ -1408,22 +1399,11 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution {
       $participantStatuses = CRM_Event_PseudoConstant::participantStatus();
       $updatedStatusId = array_search('Cancelled', $participantStatuses);
       CRM_Event_BAO_Participant::updateParticipantStatus($participant->id, $oldStatus, $updatedStatusId, TRUE);
-
-      $updateResult['updatedComponents']['CiviEvent'] = $updatedStatusId;
-      if ($processContributionObject) {
-        $processContribution = TRUE;
-      }
     }
 
     if ($pledgePayment) {
       CRM_Pledge_BAO_PledgePayment::updatePledgePaymentStatus($pledgeID, $pledgePaymentIDs, $contributionStatusId);
-
-      $updateResult['updatedComponents']['CiviPledge'] = $contributionStatusId;
-      if ($processContributionObject) {
-        $processContribution = TRUE;
-      }
     }
-    return [$updateResult, $processContribution];
   }
 
   /**
@@ -2234,7 +2214,7 @@ LEFT JOIN  civicrm_contribution contribution ON ( componentPayment.contribution_
       list($updateResult, $processContribution) = self::cancel(FALSE, $memberships, $contributionId, $membershipStatuses, $updateResult, $participant, $oldStatus, $pledgePayment, $pledgeID, $pledgePaymentIDs, $contributionStatusId);
     }
     elseif ($contributionStatusId == array_search('Failed', $contributionStatuses)) {
-      list($updateResult, $processContribution) = self::processFail(FALSE, $memberships, $contributionId, $membershipStatuses, $updateResult, $participant, $pledgePayment, $pledgeID, $pledgePaymentIDs, $contributionStatusId);
+      self::processFail($memberships, $contributionId, $membershipStatuses, $participant, $pledgePayment, $pledgeID, $pledgePaymentIDs, $contributionStatusId);
     }
     elseif ($contributionStatusId == array_search('Completed', $contributionStatuses)) {
 


### PR DESCRIPTION
Overview
----------------------------------------
Same as #18997 but for the process fail function

Before
----------------------------------------
Always FALSE variables passed in & returned

After
----------------------------------------
simplified

Technical Details
----------------------------------------
This has been made possible by reducing the information transitionComponents has to return in previous changes

Comments
----------------------------------------

