### PR TITLE
Afform - Generate dashlets based on `Afform.is_dashlet` property.

### DIFF
--- a/ext/afform/core/CRM/Afform/AfformScanner.php
+++ b/ext/afform/core/CRM/Afform/AfformScanner.php
@@ -132,6 +132,7 @@ class CRM_Afform_AfformScanner {
       'requires' => [],
       'title' => '',
       'description' => '',
+      'is_dashlet' => FALSE,
       'is_public' => FALSE,
       'permission' => 'access CiviCRM',
     ];

--- a/ext/afform/core/Civi/Api4/Action/Afform/Get.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/Get.php
@@ -114,6 +114,7 @@ class Get extends \Civi\Api4\Generic\BasicGetAction {
         'requires' => [],
         'title' => ts('%1 block (default)', [1 => $custom['title']]),
         'description' => '',
+        'is_dashlet' => FALSE,
         'is_public' => FALSE,
         'permission' => 'access CiviCRM',
         'join' => 'Custom_' . $custom['name'],

--- a/ext/afform/core/Civi/Api4/Afform.php
+++ b/ext/afform/core/Civi/Api4/Afform.php
@@ -132,6 +132,10 @@ class Afform extends Generic\AbstractEntity {
           'name' => 'description',
         ],
         [
+          'name' => 'is_dashlet',
+          'data_type' => 'Boolean',
+        ],
+        [
           'name' => 'is_public',
           'data_type' => 'Boolean',
         ],

--- a/ext/afform/core/Civi/Api4/Utils/AfformSaveTrait.php
+++ b/ext/afform/core/Civi/Api4/Utils/AfformSaveTrait.php
@@ -64,6 +64,16 @@ trait AfformSaveTrait {
     $isChanged = function($field) use ($item, $orig) {
       return ($item[$field] ?? NULL) !== ($orig[$field] ?? NULL);
     };
+
+    if ($isChanged('is_dashlet')) {
+      // FIXME: more targetted reconciliation
+      \CRM_Core_ManagedEntities::singleton()->reconcile();
+    }
+    elseif ($orig['is_dashlet'] && $isChanged('title')) {
+      // FIXME: more targetted reconciliation
+      \CRM_Core_ManagedEntities::singleton()->reconcile();
+    }
+
     // Right now, permission-checks are completely on-demand.
     if ($isChanged('server_route') /* || $isChanged('permission') */) {
       \CRM_Core_Menu::store();

--- a/ext/afform/core/afform.php
+++ b/ext/afform/core/afform.php
@@ -127,6 +127,40 @@ function afform_civicrm_upgrade($op, CRM_Queue_Queue $queue = NULL) {
  */
 function afform_civicrm_managed(&$entities) {
   _afform_civix_civicrm_managed($entities);
+
+  /** @var \CRM_Afform_AfformScanner $scanner */
+  if (\Civi::container()->has('afform_scanner')) {
+    $scanner = \Civi::service('afform_scanner');
+  }
+  else {
+    // This might happen at oddballs points - e.g. while you're in the middle of re-enabling the ext.
+    // This AfformScanner instance only lives during this method call, and it feeds off the regular cache.
+    $scanner = new CRM_Afform_AfformScanner();
+  }
+
+  foreach ($scanner->getMetas() as $afform) {
+    if (empty($afform['is_dashlet']) || empty($afform['name'])) {
+      continue;
+    }
+    $entities[] = [
+      'module' => E::LONG_NAME,
+      'name' => 'afform_dashlet_' . $afform['name'],
+      'entity' => 'Dashboard',
+      'update' => 'always',
+      // ideal cleanup policy might be to (a) deactivate if used and (b) remove if unused
+      'cleanup' => 'always',
+      'params' => [
+        'version' => 3,
+        // Q: Should we loop through all domains?
+        'domain_id' => CRM_Core_BAO_Domain::getDomain()->id,
+        'is_active' => TRUE,
+        'name' => $afform['name'],
+        'label' => $afform['title'] ?? ts('(Untitled)'),
+        'directive' => _afform_angular_module_name($afform['name'], 'dash'),
+        'permission' => "@afform:" . $afform['name'],
+      ],
+    ];
+  }
 }
 
 /**

--- a/ext/afform/docs/crud.md
+++ b/ext/afform/docs/crud.md
@@ -13,6 +13,7 @@ $ cv api4 afform.get +w name=helloWorld
         ],
         "title": "",
         "description": "",
+        "is_dashlet": false,
         "is_public": false,
         "server_route": "civicrm/hello-world",
         "layout": {

--- a/ext/afform/gui/ang/afGuiEditor/config-form.html
+++ b/ext/afform/gui/ang/afGuiEditor/config-form.html
@@ -28,4 +28,11 @@
   <input ng-model="afform.permission" class="form-control" id="af_config_form_permission" crm-ui-select="{data: editor.meta.permissions, placeholder: ts('Open access')}" />
 </div>
 
+<div class="form-group">
+  <label for="af_config_form_is_dashlet">
+    <input type="checkbox" id="af_config_form_is_dashlet" ng-model="afform.is_dashlet">
+    {{ ts('Enable dashlet') }}
+  </label>
+</div>
+
 </ng-form>

--- a/ext/afform/gui/ang/afGuiEditor/config-form.html
+++ b/ext/afform/gui/ang/afGuiEditor/config-form.html
@@ -1,16 +1,31 @@
-<label for="af_config_form_title">
-  {{ ts('Title:') }} <span class="crm-marker">*</span>
-</label>
-<input ng-model="afform.title" class="form-control" id="af_config_form_title" required />
-<label for="af_config_form_description">
-  {{ ts('Description:') }}
-</label>
-<textarea ng-model="afform.description" class="form-control" id="af_config_form_description"></textarea>
-<label for="af_config_form_server_route">
-  {{ ts('URL:') }}
-</label>
-<input ng-model="afform.server_route" class="form-control" id="af_config_form_server_route" />
-<label for="af_config_form_permission">
-  {{ ts('Permission:') }}
-</label>
-<input ng-model="afform.permission" class="form-control" id="af_config_form_permission" crm-ui-select="{data: editor.meta.permissions, placeholder: ts('Open access')}" />
+<ng-form name="config_form">
+
+<div class="form-group">
+  <label for="af_config_form_title">
+    {{ ts('Title:') }} <span class="crm-marker">*</span>
+  </label>
+  <input ng-model="afform.title" class="form-control" id="af_config_form_title" required />
+</div>
+
+<div class="form-group">
+  <label for="af_config_form_description">
+    {{ ts('Description:') }}
+  </label>
+  <textarea ng-model="afform.description" class="form-control" id="af_config_form_description"></textarea>
+</div>
+
+<div class="form-group">
+  <label for="af_config_form_server_route">
+    {{ ts('URL:') }}
+  </label>
+  <input ng-model="afform.server_route" class="form-control" id="af_config_form_server_route" />
+</div>
+
+<div class="form-group">
+  <label for="af_config_form_permission">
+    {{ ts('Permission:') }}
+  </label>
+  <input ng-model="afform.permission" class="form-control" id="af_config_form_permission" crm-ui-select="{data: editor.meta.permissions, placeholder: ts('Open access')}" />
+</div>
+
+</ng-form>

--- a/ext/afform/mock/ang/mockPage.aff.json
+++ b/ext/afform/mock/ang/mockPage.aff.json
@@ -1,1 +1,1 @@
-{"server_route": "civicrm/mock-page", "requires":["mockBespoke"], "permission": "access Foobar" }
+{"server_route": "civicrm/mock-page", "requires":["mockBespoke"], "permission": "access Foobar", "is_dashlet": true }

--- a/ext/afform/mock/phpunit.xml.dist
+++ b/ext/afform/mock/phpunit.xml.dist
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<phpunit backupGlobals="false" backupStaticAttributes="false" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" syntaxCheck="false" bootstrap="tests/phpunit/bootstrap.php">
+<phpunit backupGlobals="false" backupStaticAttributes="false" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" bootstrap="tests/phpunit/bootstrap.php">
   <testsuites>
     <testsuite name="My Test Suite">
       <directory>./tests/phpunit</directory>

--- a/ext/afform/mock/tests/phpunit/api/v4/AfformTest.php
+++ b/ext/afform/mock/tests/phpunit/api/v4/AfformTest.php
@@ -30,8 +30,8 @@ class api_v4_AfformTest extends api_v4_AfformTestCase {
 
   public function getBasicDirectives() {
     return [
-      ['mockPage', ['title' => '', 'description' => '', 'server_route' => 'civicrm/mock-page', 'permission' => 'access Foobar']],
-      ['mockBareFile', ['title' => '', 'description' => '', 'permission' => 'access CiviCRM']],
+      ['mockPage', ['title' => '', 'description' => '', 'server_route' => 'civicrm/mock-page', 'permission' => 'access Foobar', 'is_dashlet' => TRUE]],
+      ['mockBareFile', ['title' => '', 'description' => '', 'permission' => 'access CiviCRM', 'is_dashlet' => FALSE]],
       ['mockFoo', ['title' => '', 'description' => '', 'permission' => 'access CiviCRM']],
       ['mock-weird-name', ['title' => 'Weird Name', 'description' => '', 'permission' => 'access CiviCRM']],
     ];
@@ -58,6 +58,7 @@ class api_v4_AfformTest extends api_v4_AfformTestCase {
     $this->assertEquals($get($originalMetadata, 'title'), $get($result[0], 'title'), $message);
     $this->assertEquals($get($originalMetadata, 'description'), $get($result[0], 'description'), $message);
     $this->assertEquals($get($originalMetadata, 'server_route'), $get($result[0], 'server_route'), $message);
+    $this->assertEquals($get($originalMetadata, 'is_dashlet'), $get($result[0], 'is_dashlet'), $message);
     $this->assertEquals($get($originalMetadata, 'permission'), $get($result[0], 'permission'), $message);
     $this->assertTrue(is_array($result[0]['layout']), $message);
     $this->assertEquals(TRUE, $get($result[0], 'has_base'), $message);
@@ -68,6 +69,7 @@ class api_v4_AfformTest extends api_v4_AfformTestCase {
       ->addWhere('name', '=', $formName)
       ->addValue('description', 'The temporary description')
       ->addValue('permission', 'access foo')
+      ->addValue('is_dashlet', TRUE)
       ->execute();
     $this->assertEquals($formName, $result[0]['name'], $message);
     $this->assertEquals('The temporary description', $result[0]['description'], $message);
@@ -77,6 +79,7 @@ class api_v4_AfformTest extends api_v4_AfformTestCase {
     $this->assertEquals($formName, $result[0]['name'], $message);
     $this->assertEquals($get($originalMetadata, 'title'), $get($result[0], 'title'), $message);
     $this->assertEquals('The temporary description', $get($result[0], 'description'), $message);
+    $this->assertEquals(TRUE, $get($result[0], 'is_dashlet'), $message);
     $this->assertEquals($get($originalMetadata, 'server_route'), $get($result[0], 'server_route'), $message);
     $this->assertEquals('access foo', $get($result[0], 'permission'), $message);
     $this->assertTrue(is_array($result[0]['layout']), $message);


### PR DESCRIPTION
Overview
----------------------------------------
This makes it easier to expose a custom form on the CiviCRM dashboard. Each `Afform` can be flagged with `is_dashlet=1`; when toggled, it will register or unregister the dashlet.

@colemanw @eileenmcnaughton - The patch basically does what we had anticipated, but there are a couple issues/discussion-points covered below -- hence the "POC" label.

Before
----------------------------------------

To expose a form on the dashboard, you have to manually call the `Dashboard` API to register the dashlet.

After
----------------------------------------

The `Afform` entity supports a boolean field, `is_dashlet` (default: `false`). This appears in the GUI editor as the "Dashlet" toggle:

<img width="1027" alt="Screen Shot 2020-11-19 at 8 49 54 PM" src="https://user-images.githubusercontent.com/1336047/99760548-cd2bbc80-2aa8-11eb-82e5-394bb93ff297.png">

Based on the list of flagged forms (`cv api4 Afform.get +w is_dashlet=1`), the extension will generate a list of `Dashboard` records and install/uninstall via `hook_managed`. You can then use it on the dashboard.

<img width="1032" alt="Screen Shot 2020-11-19 at 9 29 58 PM" src="https://user-images.githubusercontent.com/1336047/99763050-b7b99100-2aae-11eb-9a9f-47660053e773.png">

Comments
----------------------------------------

A few issues to note (in no particular order):

* I initially tried to use a checkbox [after the fashion of BS3's guide](https://getbootstrap.com/docs/3.4/css/#forms-example). It looked a bit awful.
    <img width="425" alt="Screen Shot 2020-11-19 at 9 00 55 PM" src="https://user-images.githubusercontent.com/1336047/99761193-57c0eb80-2aaa-11eb-82fe-c61291c8b616.png">
* Improvising some markup (inspired by the quasi-checkboxes in other parts of this screen) produced something more pleasant with relative ease, but it feels a little wrong to continue improvising this in-situ.  Instead, the patchset adds a component `<crm-ui-bool model="my.field" />` which looks better IMHO. Of course, this then begs the question if the contract is alright.
* Using `hook_managed` gets *close* to what one wants. If I use the CLI and toggle the `is_dashlet` property, then I can see the record being created/removed. (If I added an API test, I'm pretty sure it'd do the same.) And, as expected, the dashlet is available on the dashboard GUI.
* What's wrong? Well, in practice, there will be several references to this dashlet in `civicrm_dashboard_contact`. (The webapp tends to make several of these very quickly without prompting...) So what happens when you decide to *unregister* the dashlet. The options for `cleanup` policy are: 
    * Set `cleanup=unused`. Thanks to the records in `civicrm_dashboard_contact`, the record appears to be in-use (valid SQL FKs/references) even if they're really inactive. In fact, it will never cleanup (unless, trivially, you delete all the `civicrm_contact` records of people who used the dashboard 😜 ).
    * Set `cleanup=always`. The dashlet will be thoroughly removed, including any policies/preferences in `civicrm_dashboard_contact`. Of course, if an administrator is fiddling about in the GUI (weighing options, turning things off+on+off+on -- as one does), then it will quietly remove all per-contact preferences about the dashlet.
* The ideal would probably require a policy along these lines:
    * When setting `is_dashlet=1`, create the `Dashboard` record. If it already exists, update its properties (esp `is_active=1`).
    * When setting `is_dashlet=0`, check the refcount. Delete if it's unused. If it's used, then set it inactive.
    * When removing the extension (eg `afform`), then delete the `Dashboard` and any corresponding `DashboardContact` records.