### PR TITLE
Improve bootstrap3 checkbox theming

### DIFF
--- a/ang/api4Explorer/Explorer.html
+++ b/ang/api4Explorer/Explorer.html
@@ -22,14 +22,18 @@
         </div>
         <div class="panel-body">
           <div class="api4-input form-inline">
-            <label class="form-control" ng-mouseenter="help(name, param)" ng-mouseleave="help()" ng-class="{'api4-option-selected': params[name]}" ng-repeat="(name, param) in ::getGenericParams(['bool'], false)">
-              <input type="checkbox" id="api4-param-{{:: name }}" ng-model="params[name]"/>
-              {{:: name }}<span class="crm-marker" ng-if="::param.required"> *</span>
-            </label>
-            <label class="form-control" ng-mouseenter="help('selectRowCount', availableParams.select)" ng-mouseleave="help()" ng-class="{'api4-option-selected': isSelectRowCount()}" ng-if="::availableParams.select">
-              <input type="checkbox" id="api4-param-selectRowCount" ng-checked="isSelectRowCount()" ng-click="selectRowCount()" />
-              SelectRowCount
-            </label>
+            <div class="checkbox-inline form-control" ng-mouseenter="help(name, param)" ng-mouseleave="help()" ng-repeat="(name, param) in ::getGenericParams(['bool'], false)">
+              <label>
+                <input type="checkbox" id="api4-param-{{:: name }}" ng-model="params[name]"/>
+                <span>{{:: name }}</span><span class="crm-marker" ng-if="::param.required"> *</span>
+              </label>
+            </div>
+            <div class="checkbox-inline form-control" ng-mouseenter="help('selectRowCount', availableParams.select)" ng-mouseleave="help()" ng-if="::availableParams.select">
+              <label>
+                <input type="checkbox" id="api4-param-selectRowCount" ng-checked="isSelectRowCount()" ng-click="selectRowCount()" />
+                <span>SelectRowCount</span>
+              </label>
+            </div>
           </div>
           <div class="api4-input form-inline" ng-mouseenter="help(name, param)" ng-mouseleave="help()" ng-repeat="(name, param) in ::getGenericParams(['bool'], true)">
             <label>{{ name }}<span class="crm-marker" ng-if="::param.required"> *</span></label>

--- a/css/api4-explorer.css
+++ b/css/api4-explorer.css
@@ -103,27 +103,6 @@
   background-color: rgba(255, 255, 255, .9);
 }
 
-#bootstrap-theme.api4-explorer-page div.api4-input.form-inline label.form-control {
-  margin-right: 6px;
-}
-#bootstrap-theme.api4-explorer-page div.api4-input.form-inline label.form-control input[type=checkbox] {
-  margin: 0 2px 0 0;
-}
-
-#bootstrap-theme.api4-explorer-page div.api4-input.form-inline label.form-control:not(.api4-option-selected) {
-  transition: none;
-  box-shadow: none;
-  -webkit-box-shadow: none;
-  -moz-box-shadow: none;
-  font-weight: normal;
-}
-
-#bootstrap-theme.api4-explorer-page div.api4-input.form-inline .form-control label {
-  font-weight: normal;
-  position: relative;
-  top: -2px;
-}
-
 #bootstrap-theme.api4-explorer-page .api4-clause-fieldset fieldset {
   float: right;
   width: calc(100% - 58px);

--- a/ext/greenwich/scss/_tweaks.scss
+++ b/ext/greenwich/scss/_tweaks.scss
@@ -1,0 +1,8 @@
+/* Supports adding form-control class to the checkbox-inline class to achieve an outer border around the checkbox&label */
+.form-control.checkbox-inline > label {
+  margin-left: 9px;
+}
+/* Adds a nice effect if you place the checkbox label text inside a <span> it will only be bold if the checkbox is checked */
+label input[type=checkbox]:not(:checked) + * {
+  font-weight: normal;
+}

--- a/ext/greenwich/scss/main.scss
+++ b/ext/greenwich/scss/main.scss
@@ -1,5 +1,6 @@
 #bootstrap-theme {
   @import "greenwich";
   @import "bootstrap";
+  @import "tweaks";
   @import "select2-bootstrap";
 }

--- a/ext/search/ang/crmSearchAdmin/displays/searchAdminDisplayList.html
+++ b/ext/search/ang/crmSearchAdmin/displays/searchAdminDisplayList.html
@@ -15,7 +15,9 @@
   </div>
     <label for="crm-search-admin-display-limit">{{:: ts('Results to display (0 for no limit):') }}</label>
     <input id="crm-search-admin-display-limit" type="number" min="0" step="1" class="form-control" ng-model="$ctrl.display.settings.limit">
-    <label><input type="checkbox" ng-model="$ctrl.display.settings.pager"> {{:: ts('Use Pager') }}</label>
+    <div class="checkbox-inline form-control">
+      <label><input type="checkbox" ng-model="$ctrl.display.settings.pager"> <span>{{:: ts('Use Pager') }}</span></label>
+    </div>
   </div>
 </fieldset>
 <div class="crm-flex-box crm-search-admin-edit-columns-wrapper">
@@ -25,7 +27,9 @@
       <legend>{{ $ctrl.getFieldLabel(col.expr) }}</legend>
       <div class="form-inline">
         <label>{{:: ts('Label:') }}</label> <input class="form-control" type="text" ng-model="col.label" >
-        <label ng-show="col.label.length" title="{{:: ts('Show label for every record even when this field is blank') }}"><input type="checkbox" ng-model="col.forceLabel"> {{:: ts('Always show') }}</label>
+        <div class="form-control checkbox-inline" ng-show="col.label.length" title="{{:: ts('Show label for every record even when this field is blank') }}">
+          <label><input type="checkbox" ng-model="col.forceLabel"> <span>{{:: ts('Always show') }}</span></label>
+        </div>
         <button class="btn-xs pull-right" ng-click="$ctrl.removeCol($index)" title="{{:: ts('Hide') }}">
           <i class="crm-i fa-ban"></i>
         </button>
@@ -35,7 +39,9 @@
         <input class="form-control" ng-model="col.prefix" size="4">
         <label>{{:: ts('Suffix:') }}</label>
         <input class="form-control" ng-model="col.suffix" size="4">
-        <label><input type="checkbox" ng-model="col.break"> {{:: ts('New line') }}</label>
+        <div class="form-control checkbox-inline">
+          <label><input type="checkbox" ng-model="col.break"> <span>{{:: ts('New line') }}</span></label>
+        </div>
       </div>
       <div class="form-inline">
         <label>{{:: ts('Link:') }}</label>

--- a/ext/search/ang/crmSearchAdmin/displays/searchAdminDisplayTable.html
+++ b/ext/search/ang/crmSearchAdmin/displays/searchAdminDisplayTable.html
@@ -2,8 +2,12 @@
   <div class="form-inline">
     <label for="crm-search-admin-display-limit">{{:: ts('Results to display (0 for no limit):') }}</label>
     <input id="crm-search-admin-display-limit" type="number" min="0" step="1" class="form-control" ng-model="$ctrl.display.settings.limit">
-    <label><input type="checkbox" ng-model="$ctrl.display.settings.pager"> {{:: ts('Use Pager') }}</label>
-    <label><input type="checkbox" ng-model="$ctrl.display.settings.actions"> {{:: ts('Enable Actions') }}</label>
+    <div class="checkbox-inline form-control">
+      <label><input type="checkbox" ng-model="$ctrl.display.settings.pager"> <span>{{:: ts('Use Pager') }}</span></label>
+    </div>
+    <div class="checkbox-inline form-control">
+      <label><input type="checkbox" ng-model="$ctrl.display.settings.actions"> <span>{{:: ts('Enable Actions') }}</span></label>
+    </div>
   </div>
 </fieldset>
 <div class="crm-flex-box crm-search-admin-edit-columns-wrapper">

--- a/ext/search/css/search.css
+++ b/ext/search/css/search.css
@@ -77,26 +77,6 @@
   background-color: rgba(255, 255, 255, .9);
 }
 
-#bootstrap-theme.crm-search div.api4-input.form-inline label.form-control {
-  margin-right: 6px;
-}
-#bootstrap-theme.crm-search div.api4-input.form-inline label.form-control input[type=checkbox] {
-  margin: 0 2px 0 0;
-}
-
-#bootstrap-theme.crm-search div.api4-input.form-inline label.form-control:not(.api4-option-selected) {
-  transition: none;
-  box-shadow: none;
-  -webkit-box-shadow: none;
-  -moz-box-shadow: none;
-  font-weight: normal;
-}
-
-#bootstrap-theme.crm-search div.api4-input.form-inline .form-control label {
-  font-weight: normal;
-  position: relative;
-  top: -2px;
-}
 #bootstrap-theme.crm-search .api4-clause-fieldset fieldset {
   float: right;
   width: calc(100% - 58px);


### PR DESCRIPTION
Overview
----------------------------------------
Adds some reusable styling for checkboxes in Bootstrap.

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/2874912/99847920-d53a3980-2b46-11eb-93df-9b4277bc3eb6.png)


After
----------------------------------------
Checkboxes appear in form-control styled boxes. Their label text is bold when checked.

![image](https://user-images.githubusercontent.com/2874912/99847811-a623c800-2b46-11eb-8809-8dac5eaa8446.png)


Technical Details
----------------------------------------
This moves us toward the following markup as a standard:
```html
<div class="checkbox-inline form-control">
  <label>
    <input type="checkbox"> <span>The Label</span>
  </label>
</div>
```

This differs from vanilla bootstrap markup in 2 ways:
1. The added class `form-control` on the outer div. It's kinda hacking the theme a little bit, but it adds a nice box around the checkbox & label that visually matches other form elements.
2. The extra `<span>` is so css rules can style the label text based on the checkbox state (using the **`+`** operator).

Both of these tweaks are compatible with vanilla bootstrap themes and do not require extra css (it just won't get the cool text effect).

