### PR TITLE
Check for membership type fee before applying tax

### DIFF
--- a/CRM/Member/BAO/MembershipType.php
+++ b/CRM/Member/BAO/MembershipType.php
@@ -841,6 +841,9 @@ class CRM_Member_BAO_MembershipType extends CRM_Member_DAO_MembershipType {
         if ($types[$id]['tax_rate'] !== 0.0) {
           $multiplier += ($types[$id]['tax_rate'] / 100);
         }
+        if (!array_key_exists('minimum_fee', $types[$id])) {
+          $types[$id]['minimum_fee'] = 0;
+        }
         $types[$id]['minimum_fee_with_tax'] = (float) $types[$id]['minimum_fee'] * $multiplier;
       }
       Civi::cache('metadata')->set($cacheString, $types);


### PR DESCRIPTION
Overview
----------------------------------------
Membership Types have an optional minimum fee which cause a PHP notice when no minimum is set and tax is applied.

Before
----------------------------------------
`minimum_fee` is used directly and can be unset.

After
----------------------------------------
Check for `minimum_fee` using `array_key_exists()` before using.

Technical Details
----------------------------------------
In `CRM_Member_BAO_MembershipType::getAllMembershipTypes()`, `minimum_fee` can be unset which causes a

`Notice: Undefined index: minimum_fee`

When trying to calculate `minimum_fee_with_tax`. 

