### PR TITLE
Fix APIv4 test to assert an exception is thrown

### DIFF
--- a/tests/phpunit/api/v4/Action/ContactGetTest.php
+++ b/tests/phpunit/api/v4/Action/ContactGetTest.php
@@ -88,12 +88,14 @@ class ContactGetTest extends \api\v4\UnitTestCase {
     $limit2 = Contact::get(FALSE)->setLimit(2)->addSelect('sort_name', 'row_count')->execute();
     $this->assertCount(2, (array) $limit2);
     $this->assertCount($num, $limit2);
+    $msg = '';
     try {
       $limit2->single();
     }
     catch (\API_Exception $e) {
-      $this->assertRegExp(';Expected to find one Contact record;', $e->getMessage());
+      $msg = $e->getMessage();
     }
+    $this->assertRegExp(';Expected to find one Contact record;', $msg);
     $limit1 = Contact::get(FALSE)->setLimit(1)->execute();
     $this->assertCount(1, (array) $limit1);
     $this->assertCount(1, $limit1);


### PR DESCRIPTION
Overview
----------------------------------------
Fixes an APIv4 unit test

Before
----------------------------------------
The test had only run its assertion in the catch block which would have been skipped if an exception wasn't thrown.

After
----------------------------------------
Test always asserts the exception is thrown as expected.