### PR TITLE
Use trait instead of class for Entity Bridges; add OptionList trait

### DIFF
--- a/Civi/Api4/ActivityContact.php
+++ b/Civi/Api4/ActivityContact.php
@@ -29,6 +29,7 @@ namespace Civi\Api4;
  * @see \Civi\Api4\Activity
  * @package Civi\Api4
  */
-class ActivityContact extends Generic\BridgeEntity {
+class ActivityContact extends Generic\DAOEntity {
+  use Generic\Traits\EntityBridge;
 
 }

--- a/Civi/Api4/Country.php
+++ b/Civi/Api4/Country.php
@@ -24,5 +24,6 @@ namespace Civi\Api4;
  * @package Civi\Api4
  */
 class Country extends Generic\DAOEntity {
+  use Generic\Traits\OptionList;
 
 }

--- a/Civi/Api4/DashboardContact.php
+++ b/Civi/Api4/DashboardContact.php
@@ -26,6 +26,7 @@ namespace Civi\Api4;
  * @see \Civi\Api4\Dashboard
  * @package Civi\Api4
  */
-class DashboardContact extends Generic\BridgeEntity {
+class DashboardContact extends Generic\DAOEntity {
+  use Generic\Traits\EntityBridge;
 
 }

--- a/Civi/Api4/Entity.php
+++ b/Civi/Api4/Entity.php
@@ -58,8 +58,15 @@ class Entity extends Generic\AbstractEntity {
         ],
         [
           'name' => 'type',
+          'data_type' => 'Array',
           'description' => 'Base class for this entity',
-          'options' => ['DAOEntity' => 'DAOEntity', 'BasicEntity' => 'BasicEntity', 'BridgeEntity' => 'BridgeEntity', 'AbstractEntity' => 'AbstractEntity'],
+          'options' => [
+            'AbstractEntity' => 'AbstractEntity',
+            'DAOEntity' => 'DAOEntity',
+            'BasicEntity' => 'BasicEntity',
+            'EntityBridge' => 'EntityBridge',
+            'OptionList' => 'OptionList',
+          ],
         ],
         [
           'name' => 'description',

--- a/Civi/Api4/EntityTag.php
+++ b/Civi/Api4/EntityTag.php
@@ -25,6 +25,7 @@ namespace Civi\Api4;
  *
  * @package Civi\Api4
  */
-class EntityTag extends Generic\BridgeEntity {
+class EntityTag extends Generic\DAOEntity {
+  use Generic\Traits\EntityBridge;
 
 }

--- a/Civi/Api4/Generic/AbstractEntity.php
+++ b/Civi/Api4/Generic/AbstractEntity.php
@@ -133,9 +133,12 @@ abstract class AbstractEntity {
       'name' => static::getEntityName(),
       'title' => static::getEntityTitle(),
       'title_plural' => static::getEntityTitle(TRUE),
-      'type' => self::stripNamespace(get_parent_class(static::class)),
+      'type' => [self::stripNamespace(get_parent_class(static::class))],
       'paths' => static::getEntityPaths(),
     ];
+    foreach (ReflectionUtils::getTraits(static::class) as $trait) {
+      $info['type'][] = self::stripNamespace($trait);
+    }
     $reflection = new \ReflectionClass(static::class);
     $info += ReflectionUtils::getCodeDocs($reflection, NULL, ['entity' => $info['name']]);
     unset($info['package'], $info['method']);

--- a/Civi/Api4/Generic/DAOGetAction.php
+++ b/Civi/Api4/Generic/DAOGetAction.php
@@ -59,13 +59,13 @@ class DAOGetAction extends AbstractGetAction {
    *
    * - `Entity`: the name of the api entity to join onto.
    * - `Required`: `TRUE` for an `INNER JOIN`, `FALSE` for a `LEFT JOIN`.
-   * - `Bridge` (optional): Name of a BridgeEntity to incorporate into the join.
+   * - `Bridge` (optional): Name of a Bridge to incorporate into the join.
    * - `[field, op, value]...`: zero or more conditions for the ON clause, using the same nested format as WHERE and HAVING
    *     but with the difference that "value" is interpreted as an expression (e.g. can be the name of a field).
    *     Enclose literal values with quotes.
    *
    * @var array
-   * @see \Civi\Api4\Generic\BridgeEntity
+   * @see \Civi\Api4\Generic\Traits\EntityBridge
    */
   protected $join = [];
 

--- a/Civi/Api4/Generic/Traits/EntityBridge.php
+++ b/Civi/Api4/Generic/Traits/EntityBridge.php
@@ -9,13 +9,13 @@
  +--------------------------------------------------------------------+
  */
 
-namespace Civi\Api4\Generic;
+namespace Civi\Api4\Generic\Traits;
 
 /**
  * A bridge is a small table that provides an intermediary link between two other tables.
  *
- * The API can automatically incorporate a bridgeEntity into a join expression.
+ * The API can automatically incorporate a Bridge into a join expression.
  */
-class BridgeEntity extends DAOEntity {
+trait EntityBridge {
 
 }

--- a/Civi/Api4/Generic/Traits/OptionList.php
+++ b/Civi/Api4/Generic/Traits/OptionList.php
@@ -1,5 +1,4 @@
 <?php
-
 /*
  +--------------------------------------------------------------------+
  | Copyright CiviCRM LLC. All rights reserved.                        |
@@ -10,22 +9,13 @@
  +--------------------------------------------------------------------+
  */
 
-/**
- *
- * @package CRM
- * @copyright CiviCRM LLC https://civicrm.org/licensing
- */
-
-
-namespace Civi\Api4;
+namespace Civi\Api4\Generic\Traits;
 
 /**
- * OptionValue entity.
+ * An optionList is a small entity whose primary purpose is to supply a semi-static list of options to fields in other entities.
  *
- * @see \Civi\Api4\OptionGroup
- * @package Civi\Api4
+ * The options appear in the field metadata for other entities that reference this one via pseudoconstant.
  */
-class OptionValue extends Generic\DAOEntity {
-  use Generic\Traits\OptionList;
+trait OptionList {
 
 }

--- a/Civi/Api4/GroupContact.php
+++ b/Civi/Api4/GroupContact.php
@@ -28,7 +28,8 @@ namespace Civi\Api4;
  *
  * @package Civi\Api4
  */
-class GroupContact extends Generic\BridgeEntity {
+class GroupContact extends Generic\DAOEntity {
+  use Generic\Traits\EntityBridge;
 
   /**
    * @param bool $checkPermissions

--- a/Civi/Api4/LocationType.php
+++ b/Civi/Api4/LocationType.php
@@ -18,5 +18,6 @@ namespace Civi\Api4;
  * @package Civi\Api4
  */
 class LocationType extends Generic\DAOEntity {
+  use Generic\Traits\OptionList;
 
 }

--- a/Civi/Api4/MembershipType.php
+++ b/Civi/Api4/MembershipType.php
@@ -18,5 +18,6 @@ namespace Civi\Api4;
  * @package Civi\Api4
  */
 class MembershipType extends Generic\DAOEntity {
+  use Generic\Traits\OptionList;
 
 }

--- a/Civi/Api4/PaymentProcessorType.php
+++ b/Civi/Api4/PaymentProcessorType.php
@@ -25,5 +25,6 @@ namespace Civi\Api4;
  * @package Civi\Api4
  */
 class PaymentProcessorType extends Generic\DAOEntity {
+  use Generic\Traits\OptionList;
 
 }

--- a/Civi/Api4/Query/Api4SelectQuery.php
+++ b/Civi/Api4/Query/Api4SelectQuery.php
@@ -594,7 +594,7 @@ class Api4SelectQuery {
   }
 
   /**
-   * Join onto a BridgeEntity table
+   * Join onto a Bridge table
    *
    * @param array $joinTree
    * @param string $joinEntity
@@ -604,13 +604,15 @@ class Api4SelectQuery {
    */
   protected function getBridgeJoin(&$joinTree, $joinEntity, $alias) {
     $bridgeEntity = array_shift($joinTree);
-    if (!is_a('\Civi\Api4\\' . $bridgeEntity, '\Civi\Api4\Generic\BridgeEntity', TRUE)) {
+    /* @var \Civi\Api4\Generic\DAOEntity $bridgeEntityClass */
+    $bridgeEntityClass = '\Civi\Api4\\' . $bridgeEntity;
+    if (!in_array('EntityBridge', $bridgeEntityClass::getInfo()['type'], TRUE)) {
       throw new \API_Exception("Illegal bridge entity specified: " . $bridgeEntity);
     }
     $bridgeAlias = $alias . '_via_' . strtolower($bridgeEntity);
     $bridgeTable = CoreUtil::getTableName($bridgeEntity);
     $joinTable = CoreUtil::getTableName($joinEntity);
-    $bridgeEntityGet = \Civi\API\Request::create($bridgeEntity, 'get', ['version' => 4, 'checkPermissions' => $this->getCheckPermissions()]);
+    $bridgeEntityGet = $bridgeEntityClass::get($this->getCheckPermissions());
     $fkToJoinField = $fkToBaseField = NULL;
     // Find the bridge field that links to the joinEntity (either an explicit FK or an entity_id/entity_table combo)
     foreach ($bridgeEntityGet->entityFields() as $name => $field) {

--- a/Civi/Api4/RelationshipCache.php
+++ b/Civi/Api4/RelationshipCache.php
@@ -27,6 +27,7 @@ namespace Civi\Api4;
  * @package Civi\Api4
  */
 class RelationshipCache extends Generic\AbstractEntity {
+  use Generic\Traits\EntityBridge;
 
   /**
    * @param bool $checkPermissions

--- a/Civi/Api4/RelationshipType.php
+++ b/Civi/Api4/RelationshipType.php
@@ -27,5 +27,6 @@ namespace Civi\Api4;
  * @package Civi\Api4
  */
 class RelationshipType extends Generic\DAOEntity {
+  use Generic\Traits\OptionList;
 
 }

--- a/Civi/Api4/StateProvince.php
+++ b/Civi/Api4/StateProvince.php
@@ -24,5 +24,6 @@ namespace Civi\Api4;
  * @package Civi\Api4
  */
 class StateProvince extends Generic\DAOEntity {
+  use Generic\Traits\OptionList;
 
 }

--- a/Civi/Api4/UFJoin.php
+++ b/Civi/Api4/UFJoin.php
@@ -26,5 +26,6 @@ namespace Civi\Api4;
  * @package Civi\Api4
  */
 class UFJoin extends Generic\DAOEntity {
+  use Generic\Traits\EntityBridge;
 
 }

--- a/Civi/Api4/UFMatch.php
+++ b/Civi/Api4/UFMatch.php
@@ -24,6 +24,7 @@ namespace Civi\Api4;
  *
  * @package Civi\Api4
  */
-class UFMatch extends Generic\BridgeEntity {
+class UFMatch extends Generic\DAOEntity {
+  use Generic\Traits\EntityBridge;
 
 }

--- a/ang/api4Explorer/Explorer.js
+++ b/ang/api4Explorer/Explorer.js
@@ -57,7 +57,7 @@
     $scope.controls = {};
     $scope.langs = ['php', 'js', 'ang', 'cli'];
     $scope.joinTypes = [{k: false, v: 'FALSE (LEFT JOIN)'}, {k: true, v: 'TRUE (INNER JOIN)'}];
-    $scope.bridgeEntities = _.filter(schema, {type: 'BridgeEntity'});
+    $scope.bridgeEntities = _.filter(schema, function(entity) {return _.includes(entity.type, 'EntityBridge');});
     $scope.code = {
       php: [
         {name: 'oop', label: ts('OOP Style'), code: ''},
@@ -873,6 +873,7 @@
       setHelp($scope.entity, {
         description: entityInfo.description,
         comment: entityInfo.comment,
+        type: entityInfo.type,
         see: entityInfo.see
       });
     }

--- a/ext/search/Civi/Search/Admin.php
+++ b/ext/search/Civi/Search/Admin.php
@@ -58,7 +58,7 @@ class Admin {
   public static function getSchema() {
     $schema = [];
     $entities = \Civi\Api4\Entity::get()
-      ->addSelect('name', 'title', 'title_plural', 'description', 'icon', 'paths')
+      ->addSelect('name', 'title', 'type', 'title_plural', 'description', 'icon', 'paths')
       ->addWhere('name', '!=', 'Entity')
       ->addOrderBy('title_plural')
       ->setChain([

--- a/ext/search/ang/crmSearchAdmin/crmSearchAdmin.component.js
+++ b/ext/search/ang/crmSearchAdmin/crmSearchAdmin.component.js
@@ -27,7 +27,12 @@
       $scope.controls = {tab: 'compose'};
       $scope.joinTypes = [{k: false, v: ts('Optional')}, {k: true, v: ts('Required')}];
       $scope.groupOptions = CRM.crmSearchActions.groupOptions;
-      $scope.entities = formatForSelect2(CRM.vars.search.schema, 'name', 'title_plural', ['description', 'icon']);
+      // Try to create a sensible list of entities one might want to search for,
+      // excluding those whos primary purpose is to provide joins or option lists to other entities
+      var primaryEntities = _.filter(CRM.vars.search.schema, function(entity) {
+        return !_.includes(entity.type, 'EntityBridge') && !_.includes(entity.type, 'OptionList');
+      });
+      $scope.entities = formatForSelect2(primaryEntities, 'name', 'title_plural', ['description', 'icon']);
       this.perm = {
         editGroups: CRM.checkPerm('edit groups')
       };


### PR DESCRIPTION
Overview
----------------------------------------
Improves APIv4 categorization of entities, which is then used to improve the Search Kit UI.

Before
----------------------------------------
BridgeEntity is a class.
SearchKit shows all entities.

After
----------------------------------------
EntityBridge and OptionList are traits.
SearchKit list of entities excludes less useful ones.

Technical Details
----------------------------------------
Traits allow each entity to have > 1 type
This excludes both EntityBridge and OptionList types from the main search dropdown.