### PR TITLE
E_NOTICE when deleting participant

### DIFF
--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -797,8 +797,8 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
     // $values['event_id'] is empty, then return
     // instead of proceeding further.
 
-    if ((CRM_Utils_Array::value('_qf_Participant_next', $values) == 'Delete') ||
-      (!$values['event_id'])
+    if ((($values['_qf_Participant_next'] ?? NULL) === 'Delete') ||
+      empty($values['event_id'])
     ) {
       return TRUE;
     }


### PR DESCRIPTION
Overview
----------------------------------------
1. Turn off popups at administer - customize - display prefs - Enable popup forms, so that you can see the error.
1. Delete a participant, e.g. from a contact's Events tab or participant search results.
1. `Notice: Undefined index: event_id in CRM_Event_Form_Participant::formRule() (line 801 of .../CRM/Event/Form/Participant.php).`
