### PR TITLE
dev/core#927 Add test demonstrating that an extraneous activity is being created & fix

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -952,24 +952,10 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution {
         if ($membership && $update) {
           $newStatus = array_search('Cancelled', $membershipStatuses);
 
-          // Create activity
-          $allStatus = CRM_Member_BAO_Membership::buildOptions('status_id', 'get');
-          $activityParam = [
-            'subject' => "Status changed from {$allStatus[$membership->status_id]} to {$allStatus[$newStatus]}",
-            'source_contact_id' => CRM_Core_Session::singleton()->get('userID'),
-            'target_contact_id' => $membership->contact_id,
-            'source_record_id' => $membership->id,
-            'activity_type_id' => 'Change Membership Status',
-            'status_id' => 'Completed',
-            'priority_id' => 'Normal',
-            'activity_date_time' => 'now',
-          ];
-
           $membership->status_id = $newStatus;
           $membership->is_override = TRUE;
           $membership->status_override_end_date = 'null';
           $membership->save();
-          civicrm_api3('activity', 'create', $activityParam);
         }
       }
     }

--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -935,31 +935,6 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution {
   protected static function cancel($memberships, $contributionId, $membershipStatuses, $participant, $oldStatus, $pledgePayment, $pledgeID, $pledgePaymentIDs, $contributionStatusId) {
     // @fixme https://lab.civicrm.org/dev/core/issues/927 Cancelling membership etc is not desirable for all use-cases and we should be able to disable it
     $participantStatuses = CRM_Event_PseudoConstant::participantStatus();
-    if (is_array($memberships)) {
-      foreach ($memberships as $membership) {
-        $update = TRUE;
-        //Update Membership status if there is no other completed contribution associated with the membership.
-        $relatedContributions = CRM_Member_BAO_Membership::getMembershipContributionId($membership->id, TRUE);
-        foreach ($relatedContributions as $contriId) {
-          if ($contriId == $contributionId) {
-            continue;
-          }
-          $statusId = CRM_Core_DAO::getFieldValue('CRM_Contribute_BAO_Contribution', $contriId, 'contribution_status_id');
-          if (CRM_Core_PseudoConstant::getName('CRM_Contribute_BAO_Contribution', 'contribution_status_id', $statusId) === 'Completed') {
-            $update = FALSE;
-          }
-        }
-        if ($membership && $update) {
-          $newStatus = array_search('Cancelled', $membershipStatuses);
-
-          $membership->status_id = $newStatus;
-          $membership->is_override = TRUE;
-          $membership->status_override_end_date = 'null';
-          $membership->save();
-        }
-      }
-    }
-
     if ($participant) {
       $updatedStatusId = array_search('Cancelled', $participantStatuses);
       CRM_Event_BAO_Participant::updateParticipantStatus($participant->id, $oldStatus, $updatedStatusId, TRUE);

--- a/ext/contributioncancelactions/contributioncancelactions.php
+++ b/ext/contributioncancelactions/contributioncancelactions.php
@@ -97,6 +97,6 @@ function contributioncancelactions_cancel_related_pending_memberships($contribut
     return;
   }
   foreach ($connectedMemberships as $membershipID) {
-    civicrm_api3('Membership', 'create', ['status_id' => 'Cancelled', 'id' => $membershipID, 'is_override' => 1]);
+    civicrm_api3('Membership', 'create', ['status_id' => 'Cancelled', 'id' => $membershipID, 'is_override' => 1, 'status_override_end_date' => 'null']);
   }
 }

--- a/tests/phpunit/CRMTraits/Financial/OrderTrait.php
+++ b/tests/phpunit/CRMTraits/Financial/OrderTrait.php
@@ -74,7 +74,7 @@ trait CRMTraits_Financial_OrderTrait {
    *
    * @throws \CRM_Core_Exception
    */
-  protected function createContributionAndMembershipOrder() {
+  protected function createContributionAndMembershipOrder(): void {
     $this->ids['membership_type'][0] = $this->membershipTypeCreate();
     $orderID = $this->callAPISuccess('Order', 'create', [
       'financial_type_id' => 'Donation',
@@ -110,6 +110,10 @@ trait CRMTraits_Financial_OrderTrait {
             'contact_id' => $this->_contactID,
             'membership_type_id' => 'General',
             'source' => 'Payment',
+            // This is necessary because Membership_BAO otherwise ignores the
+            // pending status. I do have a fix but it's held up behind other pending-review PRs
+            // so this should be temporary until we get the membership PRs flowing.
+            'skipStatusCal' => TRUE,
           ],
           'line_item' => $this->getMembershipLineItem(),
         ],

--- a/tests/phpunit/api/v3/MembershipTest.php
+++ b/tests/phpunit/api/v3/MembershipTest.php
@@ -139,24 +139,17 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
 
   /**
    * Test Activity creation on cancellation of membership contribution.
+   *
+   * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
    */
-  public function testActivityForCancelledContribution() {
+  public function testActivityForCancelledContribution(): void {
     $contactId = $this->createLoggedInUser();
-    $membershipID = $this->contactMembershipCreate($this->_params);
 
-    $ContributionCreate = $this->callAPISuccess('Contribution', 'create', [
-      'financial_type_id' => 'Member Dues',
-      'total_amount' => 100,
-      'contact_id' => $this->_params['contact_id'],
-    ]);
-    $this->callAPISuccess('MembershipPayment', 'create', [
-      'sequential' => 1,
-      'contribution_id' => $ContributionCreate['id'],
-      'membership_id' => $membershipID,
-    ]);
-
+    $this->createContributionAndMembershipOrder();
+    $membershipID = $this->callAPISuccessGetValue('MembershipPayment', ['return' => 'id']);
     $form = new CRM_Contribute_Form_Contribution();
-    $form->_id = $ContributionCreate['id'];
+    $form->_id = $this->ids['Contribution'][0];
     $form->testSubmit([
       'total_amount' => 100,
       'financial_type_id' => 1,
@@ -169,7 +162,7 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
     $this->callAPISuccessGetSingle('Activity', [
       'activity_type_id' => 'Membership Signup',
       'source_record_id' => $membershipID,
-      'subject' => 'General - Payment - Status: test status',
+      'subject' => 'General - Payment - Status: Pending',
     ]);
     $this->callAPISuccessGetSingle('Activity', [
       'activity_type_id' => 'Change Membership Status',


### PR DESCRIPTION
Overview
----------------------------------------
Adds a test & fixes such that  only 1 activity is created when a membership is cancelled because the related contribution is cancelled.



Before
----------------------------------------
Activity created in legacy cancel function and in api call

After
----------------------------------------
Activity only created via membership api call

Technical Details
----------------------------------------
The cancel function is very close to being fully removed. I'm still just ensuring there are no pieces in it that are not duplicated in the contributioncancelactions extension


UPDATE - this oriignally caused a test fail in api_v3_testActivityForCancelledContribution. In fixing that I extended this to rip our all the membership processing from the fail function - this is the commit message from that second commit


    Further fixes on membership processing transfer.
    
    It turned out to be necessary to do the following to make this test pass
    1) fix test set up - it wasn't using Order api & hence not creating the right line items
    2) hack test trait to force correct status in order api - once my various membership
    PRs are merged I'll start getting the proper fix through review again (I have it
    in a local branch)
    3) (Bigger) stop the duplicate membership cancelling by ripping it out fully.
    Actually this might not have been necessary as 1 & 2 finally turned out to be the reason
    that the membership status was not pending. However, it was the intended next step anyway
    and working through this test 'proved' the change

Comments
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/927