### PR TITLE
dev/core#927 Update ContributionCancelActions to also handle 'failed'

### DIFF
--- a/CRM/Core/Payment/BaseIPN.php
+++ b/CRM/Core/Payment/BaseIPN.php
@@ -165,10 +165,13 @@ class CRM_Core_Payment_BaseIPN {
    *
    * @param array $objects
    *
+   * @deprecated use the api.
+   *
    * @return bool
    * @throws \CiviCRM_API3_Exception|\CRM_Core_Exception
    */
   public function failed($objects) {
+    CRM_Core_Error::deprecatedFunctionWarning('use the api');
     $contribution = &$objects['contribution'];
     $memberships = [];
     if (!empty($objects['membership'])) {

--- a/ext/contributioncancelactions/contributioncancelactions.php
+++ b/ext/contributioncancelactions/contributioncancelactions.php
@@ -12,14 +12,21 @@ use Civi\Api4\Participant;
  *
  * This enacts the following
  * - find and cancel any related pending memberships
- * - (not yet implemented) find and cancel any related pending participant records
- * - (not yet implemented) find any related pledge payment records. Remove the contribution id.
+ * - (not yet implemented) find and cancel any related pending participant
+ * records
+ * - (not yet implemented) find any related pledge payment records. Remove the
+ * contribution id.
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_post
+ *
+ * @throws \CiviCRM_API3_Exception
+ * @throws \API_Exception
  */
 function contributioncancelactions_civicrm_post($op, $objectName, $objectId, $objectRef) {
   if ($op === 'edit' && $objectName === 'Contribution') {
-    if ('Cancelled' === CRM_Core_PseudoConstant::getName('CRM_Contribute_BAO_Contribution', 'contribution_status_id', $objectRef->contribution_status_id)) {
+    if (in_array(CRM_Core_PseudoConstant::getName('CRM_Contribute_BAO_Contribution', 'contribution_status_id', $objectRef->contribution_status_id),
+      ['Cancelled', 'Failed']
+    )) {
       contributioncancelactions_cancel_related_pending_memberships((int) $objectId);
       contributioncancelactions_cancel_related_pending_participant_records((int) $objectId);
       contributioncancelactions_update_related_pledge((int) $objectId, (int) $objectRef->contribution_status_id);

--- a/tests/phpunit/CRM/Member/Form/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/Form/MembershipTest.php
@@ -1030,36 +1030,6 @@ Expires: ',
   }
 
   /**
-   * Test membership form with Failed Contribution.
-   *
-   * @throws \CRM_Core_Exception
-   */
-  public function testFormWithFailedContribution() {
-    $form = $this->getForm();
-    $form->preProcess();
-    $this->createLoggedInUser();
-    $params = $this->getBaseSubmitParams();
-    unset($params['price_set_id']);
-    unset($params['credit_card_number']);
-    unset($params['cvv2']);
-    unset($params['credit_card_exp_date']);
-    unset($params['credit_card_type']);
-    unset($params['send_receipt']);
-    unset($params['is_recur']);
-
-    $params['record_contribution'] = TRUE;
-    $params['contribution_status_id'] = array_search('Failed', CRM_Contribute_PseudoConstant::contributionStatus(NULL, 'name'));
-    $form->_mode = NULL;
-    $form->_contactID = $this->_individualId;
-
-    $form->testSubmit($params);
-    $this->callAPISuccessGetSingle('Membership', ['contact_id' => $this->_individualId]);
-    $form->testSubmit($params);
-    $membership = $this->callAPISuccessGetSingle('Membership', ['contact_id' => $this->_individualId]);
-    $this->assertEquals($membership['status_id'], array_search('Pending', CRM_Member_PseudoConstant::membershipStatus(), TRUE));
-  }
-
-  /**
    * CRM-20955, CRM-20966:
    * Test creating two memberships with inheritance via price set in the back end,
    * checking that the correct primary & secondary memberships, contributions, line items


### PR DESCRIPTION

Overview
----------------------------------------
This extends the contributioncancelactions extension to also work for Failed contributions

Before
----------------------------------------
Failed contributions still handled in the IPN

After
----------------------------------------
Failed contributions handled via the hook

Technical Details
----------------------------------------
The failed action has no discernable difference from the no-longer-used cancel action. The cancel action had some minor refactoring
done to work through the conclusion that the call to addRecurLineItems was never reached in a meaningful way
but I think we can skip all that & see that fail is not functionally different to cancel & just deprecate the function.

At this point we are very close to simply removing the last core handling for failed & cance & making the extension visible.

The only thing I can see that still needs checking in the 2 functions still to be removed is the handling of
is_override & override_date is tested - which I will do as a follow up

I removed the test CRM_Member_Form_MembershipTest::testFormWithFailedContribution as this is no longer possible in the UI & hence not valid. The test coverred adding / editing a membership and recording a failed contribution in the process. However the only exposed statuses are Pending & Completed

Comments
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/927