### PR TITLE
dev/financial#152 remove determination of source

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -12,7 +12,6 @@
 use Civi\Api4\Activity;
 use Civi\Api4\ContributionPage;
 use Civi\Api4\ContributionRecur;
-use Civi\Api4\Participant;
 use Civi\Api4\PaymentProcessor;
 
 /**
@@ -2602,7 +2601,7 @@ LEFT JOIN  civicrm_contribution contribution ON ( componentPayment.contribution_
         // or loadable from the recurring contribution.
         $contributionParams['campaign_id'] = $templateContribution['campaign_id'];
       }
-      $contributionParams['source'] = $contributionParams['source'] ?: ts('Recurring contribution');
+      $contributionParams['source'] = $contributionParams['source'] ?? ts('Recurring contribution');
 
       //CRM-18805 -- Contribution page not recorded on recurring transactions, Recurring contribution payments
       //do not create CC or BCC emails or profile notifications.
@@ -4368,7 +4367,6 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
 
     $contributionParams = array_merge([
       'contribution_status_id' => $completedContributionStatusID,
-      'source' => self::getRecurringContributionDescription($contribution, $participantID),
     ], array_intersect_key($input, array_fill_keys($inputContributionWhiteList, 1)
     ));
 
@@ -4570,40 +4568,6 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
       }
     }
     return $ids;
-  }
-
-  /**
-   * Get the description (source field) for the recurring contribution.
-   *
-   * @param CRM_Contribute_BAO_Contribution $contribution
-   * @param int|null $participantID
-   *
-   * @return string
-   * @throws \CiviCRM_API3_Exception
-   * @throws \API_Exception
-   */
-  protected static function getRecurringContributionDescription($contribution, $participantID) {
-    if (!empty($contribution->source)) {
-      return $contribution->source;
-    }
-    elseif (!empty($contribution->contribution_page_id) && is_numeric($contribution->contribution_page_id)) {
-      $contributionPageTitle = civicrm_api3('ContributionPage', 'getvalue', [
-        'id' => $contribution->contribution_page_id,
-        'return' => 'title',
-      ]);
-      return ts('Online Contribution') . ': ' . $contributionPageTitle;
-    }
-    elseif ($participantID) {
-      $eventTitle = Participant::get(FALSE)
-        ->addSelect('event.title')
-        ->addWhere('id', '=', (int) $participantID)
-        ->execute()->first()['event.title'];
-      return ts('Online Event Registration') . ': ' . $eventTitle;
-    }
-    elseif (!empty($contribution->contribution_recur_id)) {
-      return 'recurring contribution';
-    }
-    return '';
   }
 
   /**

--- a/tests/phpunit/CRM/Core/Payment/AuthorizeNetIPNTest.php
+++ b/tests/phpunit/CRM/Core/Payment/AuthorizeNetIPNTest.php
@@ -221,11 +221,13 @@ class CRM_Core_Payment_AuthorizeNetIPNTest extends CiviUnitTestCase {
   }
 
   /**
-   * Test IPN response updates contribution_recur & contribution for first & second contribution
+   * Test IPN response updates contribution_recur & contribution for first &
+   * second contribution
    *
    * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
    */
-  public function testIPNPaymentMembershipRecurSuccess() {
+  public function testIPNPaymentMembershipRecurSuccess(): void {
     $this->createRepeatMembershipOrder();
     $IPN = new CRM_Core_Payment_AuthorizeNetIPN($this->getRecurTransaction());
     $IPN->main();

--- a/tests/phpunit/CRMTraits/Financial/OrderTrait.php
+++ b/tests/phpunit/CRMTraits/Financial/OrderTrait.php
@@ -9,6 +9,8 @@
  +--------------------------------------------------------------------+
  */
 
+use Civi\Test\Api3TestTrait;
+
 /**
  * Trait OrderTrait
  *
@@ -16,14 +18,14 @@
  */
 trait CRMTraits_Financial_OrderTrait {
 
-  use \Civi\Test\Api3TestTrait;
+  use Api3TestTrait;
 
   /**
    * Create a pending membership from a recurring order.
    *
    * @throws \CRM_Core_Exception
    */
-  public function createRepeatMembershipOrder() {
+  public function createRepeatMembershipOrder(): void {
     $this->createExtraneousContribution();
     $this->ids['contact'][0] = $this->individualCreate();
     $this->ids['membership_type'][0] = $this->membershipTypeCreate();
@@ -45,6 +47,7 @@ trait CRMTraits_Financial_OrderTrait {
     $orderID = $this->callAPISuccess('Order', 'create', [
       'total_amount' => '200',
       'financial_type_id' => 'Donation',
+      'source' => 'Online Contribution: form payment',
       'contact_id' => $this->_contactID,
       'contribution_page_id' => $this->_contributionPageID,
       'payment_processor_id' => $this->_paymentProcessorID,

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -2518,6 +2518,7 @@ VALUES
       'skipCleanMoney' => TRUE,
       'amount_level' => 'expensive',
       'campaign_id' => $this->ids['campaign'][0],
+      'source' => 'Online Contribution: Page name',
     ], $contributionParams);
     $contributionRecur = $this->callAPISuccess('contribution_recur', 'create', array_merge([
       'contact_id' => $this->_contactID,

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -2806,10 +2806,12 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
   /**
    * Test financial_type_id override behaviour with a single line item.
    *
-   * CRM-17718 a passed in financial_type_id is not allowed to override the original contribution where there
-   * is more than one line item.
+   * CRM-17718 a passed in financial_type_id is not allowed to override the
+   * original contribution where there is more than one line item.
+   *
+   * @throws \CRM_Core_Exception
    */
-  public function testRepeatTransactionPassedInFinancialTypeTwoLineItems() {
+  public function testRepeatTransactionPassedInFinancialTypeTwoLineItems(): void {
     $this->_params = $this->getParticipantOrderParams();
     $originalContribution = $this->setUpRecurringContribution();
 
@@ -2837,7 +2839,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
   /**
    * CRM-17718 test appropriate action if financial type has changed for single line items.
    */
-  public function testRepeatTransactionUpdatedFinancialType() {
+  public function testRepeatTransactionUpdatedFinancialType(): void {
     $originalContribution = $this->setUpRecurringContribution([], ['financial_type_id' => 2]);
 
     $this->callAPISuccess('contribution', 'repeattransaction', [
@@ -3348,12 +3350,11 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
    *
    * @throws \CRM_Core_Exception
    */
-  public function testCompleteTransactionWithParticipantRecord() {
+  public function testCompleteTransactionWithParticipantRecord(): void {
     $mut = new CiviMailUtils($this, TRUE);
     $mut->clearMessages();
     $this->_individualId = $this->createLoggedInUser();
-    // Unset source to test whether one is generated if not set already on the contribution.
-    unset($this->_params['source']);
+    $this->_params['source'] = 'Online Event Registration: Annual CiviCRM meet';
     $contributionID = $this->createPendingParticipantContribution();
     $this->createJoinedProfile(['entity_id' => $this->_ids['event']['test'], 'entity_table' => 'civicrm_event']);
     $this->createJoinedProfile(['entity_id' => $this->_ids['event']['test'], 'entity_table' => 'civicrm_event', 'weight' => 2], ['name' => 'post_1', 'title' => 'title_post_2', 'frontend_title' => 'public 2']);
@@ -3912,7 +3913,10 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
   }
 
   /**
-   * Create a pending contribution & linked pending participant record (along with an event).
+   * Create a pending contribution & linked pending participant record (along
+   * with an event).
+   *
+   * @throws \CRM_Core_Exception
    */
   public function createPendingParticipantContribution() {
     $this->_ids['event']['test'] = $this->eventCreate(['is_email_confirm' => 1, 'confirm_from_email' => 'test@civicrm.org'])['id'];


### PR DESCRIPTION
Overview
----------------------------------------
This removes a chunk of code used to determine the source to be given to a contribution in completeOrder because I believe it's extraneous 

Either
1 ) we are completing an existing contribution - in which case the source will already exist or
2 ) we are repeating a contribution - in which case the source will be derived from the template contribution
(with recurring appended).


Before
----------------------------------------
lotsa code 

After
----------------------------------------
poof

Technical Details
----------------------------------------
Removing this brings us close to the point where contribution is unnessary as an input parameter on the function

I believe the logic dates back to when this function was part of the IPN and it may have been necessary to create a new contribution because ... 4.x

Comments
----------------------------------------
