### PR TITLE
dev/core#2205 - Deprecated function warning when choosing task from Find Cases results

### DIFF
--- a/CRM/Case/Form/Task.php
+++ b/CRM/Case/Form/Task.php
@@ -68,4 +68,22 @@ class CRM_Case_Form_Task extends CRM_Core_Form_Task {
     return 'ORDER BY ' . implode(',', $order_array);
   }
 
+  /**
+   * Get the name of the table for the relevant entity.
+   *
+   * @return string
+   */
+  public function getTableName() {
+    return 'civicrm_case';
+  }
+
+  /**
+   * Get the entity alias field.
+   *
+   * @return string
+   */
+  public function getEntityAliasField() {
+    return 'case_id';
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/2205

1. Find Cases.
2. Select some.
3. Pick something from the actions dropdown.
4. `User deprecated function: Deprecated function CRM_Core_Form_Task::getTableName, use function should be overridden. Array ( [civi.tag] => deprecated ) in CRM_Core_Error_Log->log() (line 58 of .../CRM/Core/Error/Log.php).`

`User deprecated function: Deprecated function CRM_Core_Form_Task::getEntityAliasField, use function should be overridden. Array ( [civi.tag] => deprecated ) in CRM_Core_Error_Log->log() (line 58 of .../CRM/Core/Error/Log.php).`

Before
----------------------------------------


After
----------------------------------------


Technical Details
----------------------------------------
Seems to be from here: https://github.com/civicrm/civicrm-core/pull/18783/files#diff-d3f50e6b56f73404b1de848be304c52ce8fbd3c126f120268778ea44ffb2dff8R305

Comments
----------------------------------------

