### PR TITLE
Add Grant v4 api

### DIFF
--- a/Civi/Api4/Grant.php
+++ b/Civi/Api4/Grant.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+namespace Civi\Api4;
+
+/**
+ * Grant entity.
+ *
+ * Grants are designed to be used by organisations that distribute funds to others.
+ *
+ * @see https://docs.civicrm.org/user/en/latest/grants/what-is-civigrant/
+ *
+ * @package Civi\Api4
+ */
+class Grant extends Generic\DAOEntity {
+
+}

--- a/Civi/Api4/Service/Spec/Provider/FieldCurrencySpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/FieldCurrencySpecProvider.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+
+namespace Civi\Api4\Service\Spec\Provider;
+
+use Civi\Api4\Service\Spec\RequestSpec;
+
+class FieldCurrencySpecProvider implements Generic\SpecProviderInterface {
+
+  /**
+   * Generic create spec function to set sensible defaults for any entity with a "currency" field.
+   *
+   * @param \Civi\Api4\Service\Spec\RequestSpec $spec
+   */
+  public function modifySpec(RequestSpec $spec): void {
+    $currencyField = $spec->getFieldByName('currency');
+    if ($currencyField && $currencyField->isRequired()) {
+      $currencyField->setRequired(FALSE)->setDefaultValue(\CRM_Core_Config::singleton()->defaultCurrency);
+    }
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function applies($entity, $action) {
+    return $action === 'create';
+  }
+
+}


### PR DESCRIPTION

Overview
----------------------------------------
Add v4 api for grant

Before
----------------------------------------
No v4 api

After
----------------------------------------
tada

Technical Details
----------------------------------------
I created a spec provider for a default currency as I didn't think it made sense to require it.

There are 13 tables with currency in them - in most cases they are not required at the db level - but really should be. If this is right we should likely fix the others to require currency

Comments
----------------------------------------
We have some intent to split civigrant off into it's own core extension. However, we currently have 3 in progress (event cart, financialacls & contriubutioncancelactions) so that seems like it should not be a priority until we have resolved the DAO issue on install (which also impacts event cart) and gotten at least one of the others to completion. 3 seems like about the max we would want on the go at once