### PR TITLE
Feature to provide mostly used countries in top section of Country select list

### DIFF
--- a/CRM/Admin/Form/Setting/Localization.php
+++ b/CRM/Admin/Form/Setting/Localization.php
@@ -25,6 +25,7 @@ class CRM_Admin_Form_Setting_Localization extends CRM_Admin_Form_Setting {
     'countryLimit' => CRM_Core_BAO_Setting::LOCALIZATION_PREFERENCES_NAME,
     'customTranslateFunction' => CRM_Core_BAO_Setting::LOCALIZATION_PREFERENCES_NAME,
     'defaultContactCountry' => CRM_Core_BAO_Setting::LOCALIZATION_PREFERENCES_NAME,
+    'favouriteContactCountries' => CRM_Core_BAO_Setting::LOCALIZATION_PREFERENCES_NAME,
     'defaultContactStateProvince' => CRM_Core_BAO_Setting::LOCALIZATION_PREFERENCES_NAME,
     'defaultCurrency' => CRM_Core_BAO_Setting::LOCALIZATION_PREFERENCES_NAME,
     'fieldSeparator' => CRM_Core_BAO_Setting::LOCALIZATION_PREFERENCES_NAME,

--- a/settings/Localization.setting.php
+++ b/settings/Localization.setting.php
@@ -528,4 +528,27 @@ return [
     'help_text' => 'If a contact is created with no language this setting will determine the language data (if any) to save.'
     . 'You may or may not wish to make an assumption here about whether it matches the site language',
   ],
+  'favouriteContactCountries' => [
+    'group_name' => 'Localization Preferences',
+    'group' => 'localization',
+    'name' => 'favouriteContactCountries',
+    'type' => 'Array',
+    'quick_form_type' => 'Element',
+    'html_type' => 'advmultiselect',
+    'html_attributes' => [
+      'size' => 5,
+      'style' => 'width:150px',
+      'class' => 'advmultiselect',
+    ],
+    'default' => [],
+    'add' => '5.31',
+    'title' => ts('Favourite Countries'),
+    'is_domain' => 1,
+    'is_contact' => 0,
+    'description' => ts('Appear in Top section of select list'),
+    'help_text' => 'Selected countries will appear in top section of country list',
+    'pseudoconstant' => [
+      'callback' => 'CRM_Admin_Form_Setting_Localization::getAvailableCountries',
+    ],
+  ],
 ];

--- a/templates/CRM/Admin/Form/Setting/Localization.hlp
+++ b/templates/CRM/Admin/Form/Setting/Localization.hlp
@@ -65,3 +65,8 @@
     {ts}State/province listings are populated dynamically based on the selected Country for all standard contact address editing forms, as well as for <strong>Profile forms which include both a Country and a State/Province field</strong>.  This setting controls which countries' states and/or provinces are available in the State/Province selection field <strong>for Custom Fields</strong> or for Profile forms which do NOT include a Country field.{/ts}
   </p>
 {/htxt}
+{htxt id="favouriteContactCountries"}
+  <p>
+      {ts}Selected countries will appear in top section of country list.{/ts}
+  </p>
+{/htxt}

--- a/templates/CRM/Admin/Form/Setting/Localization.tpl
+++ b/templates/CRM/Admin/Form/Setting/Localization.tpl
@@ -92,6 +92,10 @@
                 <td class="label">{$form.defaultContactCountry.label} {help id='defaultContactCountry' title=$form.defaultContactCountry.label}</td>
                 <td>{$form.defaultContactCountry.html}</td>
             </tr>
+            <tr class="crm-localization-form-block-favouriteContactCountries">
+                <td class="label">{$form.favouriteContactCountries.label} {help id='favouriteContactCountries' title=$form.favouriteContactCountries.label}</td>
+                <td>{$form.favouriteContactCountries.html}</td>
+            </tr>
            <tr class="crm-localization-form-block-defaultContactStateProvince">
                 <td class="label">{$form.defaultContactStateProvince.label} {help id='defaultContactCountry' title=$form.defaultContactStateProvince.label}</td>
                 <td>{$form.defaultContactStateProvince.html}</td>


### PR DESCRIPTION
Overview
----------------------------------------
Functionality to provide mostly used (Favourite) countries in top  section after default country. So user don't have type to search country name again.

Before
----------------------------------------
<img width="512" alt="before_setting" src="https://user-images.githubusercontent.com/377735/99942916-6f43f100-2d96-11eb-950b-6e4fa6d1909a.png">


After
----------------------------------------
Billing form and contact address both will have mostly used countries in top section.
<img width="628" alt="Screenshot 2020-11-23 at 2 09 57 PM" src="https://user-images.githubusercontent.com/377735/99943056-afa36f00-2d96-11eb-952f-481cad76aee0.png">

<img width="513" alt="after_setting" src="https://user-images.githubusercontent.com/377735/99943063-b4682300-2d96-11eb-9753-a3736b4f1fbd.png">

