### PR TITLE
Feature to provide mostly used countries in top section of Country select list

### DIFF
--- a/CRM/Admin/Form/Setting/Localization.php
+++ b/CRM/Admin/Form/Setting/Localization.php
@@ -25,7 +25,7 @@ class CRM_Admin_Form_Setting_Localization extends CRM_Admin_Form_Setting {
     'countryLimit' => CRM_Core_BAO_Setting::LOCALIZATION_PREFERENCES_NAME,
     'customTranslateFunction' => CRM_Core_BAO_Setting::LOCALIZATION_PREFERENCES_NAME,
     'defaultContactCountry' => CRM_Core_BAO_Setting::LOCALIZATION_PREFERENCES_NAME,
-    'favouriteContactCountries' => CRM_Core_BAO_Setting::LOCALIZATION_PREFERENCES_NAME,
+    'pinnedContactCountries' => CRM_Core_BAO_Setting::LOCALIZATION_PREFERENCES_NAME,
     'defaultContactStateProvince' => CRM_Core_BAO_Setting::LOCALIZATION_PREFERENCES_NAME,
     'defaultCurrency' => CRM_Core_BAO_Setting::LOCALIZATION_PREFERENCES_NAME,
     'fieldSeparator' => CRM_Core_BAO_Setting::LOCALIZATION_PREFERENCES_NAME,

--- a/CRM/Admin/Form/Setting/Localization.php
+++ b/CRM/Admin/Form/Setting/Localization.php
@@ -25,6 +25,7 @@ class CRM_Admin_Form_Setting_Localization extends CRM_Admin_Form_Setting {
     'countryLimit' => CRM_Core_BAO_Setting::LOCALIZATION_PREFERENCES_NAME,
     'customTranslateFunction' => CRM_Core_BAO_Setting::LOCALIZATION_PREFERENCES_NAME,
     'defaultContactCountry' => CRM_Core_BAO_Setting::LOCALIZATION_PREFERENCES_NAME,
+    'favouriteContactCountries' => CRM_Core_BAO_Setting::LOCALIZATION_PREFERENCES_NAME,
     'defaultContactStateProvince' => CRM_Core_BAO_Setting::LOCALIZATION_PREFERENCES_NAME,
     'defaultCurrency' => CRM_Core_BAO_Setting::LOCALIZATION_PREFERENCES_NAME,
     'fieldSeparator' => CRM_Core_BAO_Setting::LOCALIZATION_PREFERENCES_NAME,

--- a/CRM/Core/BAO/Country.php
+++ b/CRM/Core/BAO/Country.php
@@ -95,30 +95,30 @@ class CRM_Core_BAO_Country extends CRM_Core_DAO_Country {
   }
 
   /**
-   * Provide list of favourite contries.
+   * Provide list of Pinned countries.
    *
    * @param $availableCountries
    * @return array
    */
-  public static function favouriteContactCountries($availableCountries) {
-    static $cachedFavouriteContactCountries = [];
-    $favouriteContactCountries = Civi::settings()->get('favouriteContactCountries');
+  public static function pinnedContactCountries($availableCountries) {
+    static $cachedPinnedContactCountries = [];
+    $pinnedContactCountries = Civi::settings()->get('pinnedContactCountries');
 
-    if (!empty($favouriteContactCountries) && !$cachedFavouriteContactCountries) {
-      $favouriteCountries = [];
-      foreach($favouriteContactCountries as $favouriteContactCountry) {
-        if (array_key_exists($favouriteContactCountry, $availableCountries)) {
-          $favouriteCountries[$favouriteContactCountry] = $availableCountries[$favouriteContactCountry];
+    if (!empty($pinnedContactCountries) && !$cachedPinnedContactCountries) {
+      $pinnedCountries = [];
+      foreach($pinnedContactCountries as $pinnedContactCountry) {
+        if (array_key_exists($pinnedContactCountry, $availableCountries)) {
+          $pinnedCountries[$pinnedContactCountry] = $availableCountries[$pinnedContactCountry];
         }
       }
-      $cachedFavouriteContactCountries = $favouriteCountries;
+      $cachedPinnedContactCountries = $pinnedCountries;
     }
-    return $cachedFavouriteContactCountries;
+    return $cachedPinnedContactCountries;
   }
 
   /**
    * Provide sorted list of countries with default country with first position
-   * then favourite countries then rest of countries.
+   * then Pinned countries then rest of countries.
    *
    * @param $availableCountries
    * @return array
@@ -133,7 +133,7 @@ class CRM_Core_BAO_Country extends CRM_Core_DAO_Country {
       ]);
       $availableCountries = CRM_Utils_Array::asort($availableCountries);
     }
-    $favouriteContactCountries = CRM_Core_BAO_Country::favouriteContactCountries($availableCountries);
+    $pinnedContactCountries = CRM_Core_BAO_Country::pinnedContactCountries($availableCountries);
     // if default country is set, percolate it to the top
     if ($defaultContactCountry = CRM_Core_BAO_Country::defaultContactCountry()) {
       $countryIsoCodes = CRM_Core_PseudoConstant::countryIsoCode();
@@ -141,11 +141,11 @@ class CRM_Core_BAO_Country extends CRM_Core_DAO_Country {
       if ($defaultID !== FALSE) {
         $default = [];
         $default[$defaultID] = $availableCountries[$defaultID] ?? NULL;
-        $availableCountries = $default + $favouriteContactCountries + $availableCountries;
+        $availableCountries = $default + $pinnedContactCountries + $availableCountries;
       }
     }
-    elseif (!empty($favouriteContactCountries)) {
-      $availableCountries = $favouriteContactCountries + $availableCountries;
+    elseif (!empty($pinnedContactCountries)) {
+      $availableCountries = $pinnedContactCountries + $availableCountries;
     }
 
     return $availableCountries;

--- a/CRM/Core/Config/MagicMerge.php
+++ b/CRM/Core/Config/MagicMerge.php
@@ -120,6 +120,7 @@ class CRM_Core_Config_MagicMerge {
       // renamed.
       'debug' => ['setting', 'debug_enabled'],
       'defaultContactCountry' => ['setting'],
+      'pinnedContactCountries' => ['setting'],
       'defaultContactStateProvince' => ['setting'],
       'defaultCurrency' => ['setting'],
       'defaultSearchProfileID' => ['setting'],

--- a/settings/Localization.setting.php
+++ b/settings/Localization.setting.php
@@ -542,7 +542,7 @@ return [
     ],
     'default' => [],
     'add' => '5.33',
-    'title' => ts('Pinned countries'),
+    'title' => ts('Pinned Countries'),
     'is_domain' => 1,
     'is_contact' => 0,
     'description' => ts('Appear in Top section of select list'),

--- a/settings/Localization.setting.php
+++ b/settings/Localization.setting.php
@@ -528,10 +528,10 @@ return [
     'help_text' => 'If a contact is created with no language this setting will determine the language data (if any) to save.'
     . 'You may or may not wish to make an assumption here about whether it matches the site language',
   ],
-  'favouriteContactCountries' => [
+  'pinnedContactCountries' => [
     'group_name' => 'Localization Preferences',
     'group' => 'localization',
-    'name' => 'favouriteContactCountries',
+    'name' => 'pinnedContactCountries',
     'type' => 'Array',
     'quick_form_type' => 'Element',
     'html_type' => 'advmultiselect',
@@ -541,8 +541,8 @@ return [
       'class' => 'advmultiselect',
     ],
     'default' => [],
-    'add' => '5.31',
-    'title' => ts('Favourite Countries'),
+    'add' => '5.33',
+    'title' => ts('Pinned countries'),
     'is_domain' => 1,
     'is_contact' => 0,
     'description' => ts('Appear in Top section of select list'),

--- a/settings/Localization.setting.php
+++ b/settings/Localization.setting.php
@@ -528,4 +528,27 @@ return [
     'help_text' => 'If a contact is created with no language this setting will determine the language data (if any) to save.'
     . 'You may or may not wish to make an assumption here about whether it matches the site language',
   ],
+  'favouriteContactCountries' => [
+    'group_name' => 'Localization Preferences',
+    'group' => 'localization',
+    'name' => 'favouriteContactCountries',
+    'type' => 'Array',
+    'quick_form_type' => 'Element',
+    'html_type' => 'advmultiselect',
+    'html_attributes' => [
+      'size' => 5,
+      'style' => 'width:150px',
+      'class' => 'advmultiselect',
+    ],
+    'default' => [],
+    'add' => '5.31',
+    'title' => ts('Favourite Countries'),
+    'is_domain' => 1,
+    'is_contact' => 0,
+    'description' => ts('Appear in Top section of select list'),
+    'help_text' => 'Selected countries will appear in top section of country list',
+    'pseudoconstant' => [
+      'callback' => 'CRM_Admin_Form_Setting_Localization::getAvailableCountries',
+    ],
+  ],
 ];

--- a/settings/Localization.setting.php
+++ b/settings/Localization.setting.php
@@ -546,7 +546,7 @@ return [
     'is_domain' => 1,
     'is_contact' => 0,
     'description' => ts('Appear in Top section of select list'),
-    'help_text' => 'Selected countries will appear in top section of country list',
+    'help_text' => ts('Selected countries will appear in top section of country list'),
     'pseudoconstant' => [
       'callback' => 'CRM_Admin_Form_Setting_Localization::getAvailableCountries',
     ],

--- a/templates/CRM/Admin/Form/Setting/Localization.hlp
+++ b/templates/CRM/Admin/Form/Setting/Localization.hlp
@@ -65,3 +65,8 @@
     {ts}State/province listings are populated dynamically based on the selected Country for all standard contact address editing forms, as well as for <strong>Profile forms which include both a Country and a State/Province field</strong>.  This setting controls which countries' states and/or provinces are available in the State/Province selection field <strong>for Custom Fields</strong> or for Profile forms which do NOT include a Country field.{/ts}
   </p>
 {/htxt}
+{htxt id="favouriteContactCountries"}
+  <p>
+      {ts}Selected countries will appear in top section of country list.{/ts}
+  </p>
+{/htxt}

--- a/templates/CRM/Admin/Form/Setting/Localization.hlp
+++ b/templates/CRM/Admin/Form/Setting/Localization.hlp
@@ -65,7 +65,7 @@
     {ts}State/province listings are populated dynamically based on the selected Country for all standard contact address editing forms, as well as for <strong>Profile forms which include both a Country and a State/Province field</strong>.  This setting controls which countries' states and/or provinces are available in the State/Province selection field <strong>for Custom Fields</strong> or for Profile forms which do NOT include a Country field.{/ts}
   </p>
 {/htxt}
-{htxt id="favouriteContactCountries"}
+{htxt id="pinnedContactCountries"}
   <p>
       {ts}Selected countries will appear in top section of country list.{/ts}
   </p>

--- a/templates/CRM/Admin/Form/Setting/Localization.tpl
+++ b/templates/CRM/Admin/Form/Setting/Localization.tpl
@@ -92,6 +92,10 @@
                 <td class="label">{$form.defaultContactCountry.label} {help id='defaultContactCountry' title=$form.defaultContactCountry.label}</td>
                 <td>{$form.defaultContactCountry.html}</td>
             </tr>
+            <tr class="crm-localization-form-block-favouriteContactCountries">
+                <td class="label">{$form.favouriteContactCountries.label} {help id='favouriteContactCountries' title=$form.favouriteContactCountries.label}</td>
+                <td>{$form.favouriteContactCountries.html}</td>
+            </tr>
            <tr class="crm-localization-form-block-defaultContactStateProvince">
                 <td class="label">{$form.defaultContactStateProvince.label} {help id='defaultContactCountry' title=$form.defaultContactStateProvince.label}</td>
                 <td>{$form.defaultContactStateProvince.html}</td>

--- a/templates/CRM/Admin/Form/Setting/Localization.tpl
+++ b/templates/CRM/Admin/Form/Setting/Localization.tpl
@@ -92,9 +92,9 @@
                 <td class="label">{$form.defaultContactCountry.label} {help id='defaultContactCountry' title=$form.defaultContactCountry.label}</td>
                 <td>{$form.defaultContactCountry.html}</td>
             </tr>
-            <tr class="crm-localization-form-block-favouriteContactCountries">
-                <td class="label">{$form.favouriteContactCountries.label} {help id='favouriteContactCountries' title=$form.favouriteContactCountries.label}</td>
-                <td>{$form.favouriteContactCountries.html}</td>
+            <tr class="crm-localization-form-block-pinnedContactCountries">
+                <td class="label">{$form.pinnedContactCountries.label} {help id='pinnedContactCountries' title=$form.pinnedContactCountries.label}</td>
+                <td>{$form.pinnedContactCountries.html}</td>
             </tr>
            <tr class="crm-localization-form-block-defaultContactStateProvince">
                 <td class="label">{$form.defaultContactStateProvince.label} {help id='defaultContactCountry' title=$form.defaultContactStateProvince.label}</td>

--- a/tests/phpunit/CRM/Core/BAO/AddressTest.php
+++ b/tests/phpunit/CRM/Core/BAO/AddressTest.php
@@ -644,4 +644,53 @@ class CRM_Core_BAO_AddressTest extends CiviUnitTestCase {
 
   }
 
+  /**
+   * Pinned countries with Default country
+   */
+  public function testPinnedCountriesWithDefaultCountry() {
+    // Guyana, Netherlands, United States
+    $pinnedCountries = ['1093', '1152', '1228'];
+
+    // set default country to Netherlands
+    $this->callAPISuccess('Setting', 'create', ['defaultContactCountry' => 1152, 'pinnedContactCountries' => $pinnedCountries]);
+    // get the list of country
+    $availableCountries = CRM_Core_PseudoConstant::country(FALSE, FALSE);
+    // get the order of country id using their keys
+    $availableCountries = array_keys($availableCountries);
+
+    // default country is set, so first country should be Netherlands, then rest from pinned countries.
+
+    // Netherlands
+    $this->assertEquals(1152, $availableCountries[0]);
+    // Guyana
+    $this->assertEquals(1093, $availableCountries[1]);
+    // United States
+    $this->assertEquals(1228, $availableCountries[2]);
+  }
+
+  /**
+   * Pinned countries with out Default country
+   */
+  public function testPinnedCountriesWithOutDefaultCountry() {
+    // Guyana, Netherlands, United States
+    $pinnedCountries = ['1093', '1152', '1228'];
+
+    // unset default country
+    $this->callAPISuccess('Setting', 'create', ['defaultContactCountry' => NULL, 'pinnedContactCountries' => $pinnedCountries]);
+
+    // get the list of country
+    $availableCountries = CRM_Core_PseudoConstant::country(FALSE, FALSE);
+    // get the order of country id using their keys
+    $availableCountries = array_keys($availableCountries);
+
+    // no default country, so sequnece should be present as per pinned countries.
+
+    // Guyana
+    $this->assertEquals(1093, $availableCountries[0]);
+    // Netherlands
+    $this->assertEquals(1152, $availableCountries[1]);
+    // United States
+    $this->assertEquals(1228, $availableCountries[2]);
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Functionality to provide mostly used (Favourite) countries in top  section after default country. So user don't have type to search country name again.

Before
----------------------------------------
<img width="512" alt="before_setting" src="https://user-images.githubusercontent.com/377735/99942916-6f43f100-2d96-11eb-950b-6e4fa6d1909a.png">


After
----------------------------------------
Billing form and contact address both will have mostly used countries in top section.
<img width="628" alt="Screenshot 2020-11-23 at 2 09 57 PM" src="https://user-images.githubusercontent.com/377735/99943056-afa36f00-2d96-11eb-952f-481cad76aee0.png">

<img width="513" alt="after_setting" src="https://user-images.githubusercontent.com/377735/99943063-b4682300-2d96-11eb-9753-a3736b4f1fbd.png">

