### PR TITLE
Respect ACL for multi-value custom field (originally PR#15347)

### DIFF
--- a/CRM/ACL/BAO/ACL.php
+++ b/CRM/ACL/BAO/ACL.php
@@ -476,7 +476,7 @@ SELECT g.*
     if (!empty($acls)) {
       $aclKeys = array_keys($acls);
       $aclKeys = implode(',', $aclKeys);
-      $cacheKey = CRM_Utils_Cache::cleanKey("{$tableName}-{$type}-{$aclKeys}");
+      $cacheKey = CRM_Utils_Cache::cleanKey("$type-$tableName-$aclKeys");
       $cache = CRM_Utils_Cache::singleton();
       $ids = $cache->get($cacheKey);
       if (!is_array($ids)) {

--- a/CRM/ACL/BAO/ACL.php
+++ b/CRM/ACL/BAO/ACL.php
@@ -476,7 +476,7 @@ SELECT g.*
     if (!empty($acls)) {
       $aclKeys = array_keys($acls);
       $aclKeys = implode(',', $aclKeys);
-      $cacheKey = CRM_Utils_Cache::cleanKey("{$tableName}-{$type}-{$aclKeys}");	  
+      $cacheKey = CRM_Utils_Cache::cleanKey("{$tableName}-{$type}-{$aclKeys}");
       $cache = CRM_Utils_Cache::singleton();
       $ids = $cache->get($cacheKey);
       if (!is_array($ids)) {

--- a/CRM/ACL/BAO/ACL.php
+++ b/CRM/ACL/BAO/ACL.php
@@ -476,8 +476,7 @@ SELECT g.*
     if (!empty($acls)) {
       $aclKeys = array_keys($acls);
       $aclKeys = implode(',', $aclKeys);
-
-      $cacheKey = CRM_Utils_Cache::cleanKey("$type-$tableName-$aclKeys");
+      $cacheKey = CRM_Utils_Cache::cleanKey("{$tableName}-{$type}-{$aclKeys}");	  
       $cache = CRM_Utils_Cache::singleton();
       $ids = $cache->get($cacheKey);
       if (!is_array($ids)) {

--- a/CRM/Contact/Form/CustomData.php
+++ b/CRM/Contact/Form/CustomData.php
@@ -125,6 +125,12 @@ class CRM_Contact_Form_CustomData extends CRM_Core_Form {
 
     $this->_contactType = CRM_Contact_BAO_Contact::getContactType($this->_tableID);
     $this->_contactSubType = CRM_Contact_BAO_Contact::getContactSubType($this->_tableID, ',');
+	// check if the user has permission to edit the custom data for the contact.
+	if (!CRM_Core_BAO_CustomGroup::isCustomGroupAllowed(
+	  $this->_groupID, $entityId, CRM_Core_Permission::EDIT
+	)) {
+	  CRM_Core_Error::statusBounce(ts('You do not have the necessary permission to add/edit this contact\'s custom data.'));
+	}																	 
     $this->assign('contact_type', $this->_contactType);
     $this->assign('contact_subtype', $this->_contactSubType);
     list($displayName, $contactImage) = CRM_Contact_BAO_Contact::getDisplayAndImage($this->_tableID);

--- a/CRM/Contact/Form/CustomData.php
+++ b/CRM/Contact/Form/CustomData.php
@@ -125,12 +125,12 @@ class CRM_Contact_Form_CustomData extends CRM_Core_Form {
 
     $this->_contactType = CRM_Contact_BAO_Contact::getContactType($this->_tableID);
     $this->_contactSubType = CRM_Contact_BAO_Contact::getContactSubType($this->_tableID, ',');
-	// check if the user has permission to edit the custom data for the contact.
-	if (!CRM_Core_BAO_CustomGroup::isCustomGroupAllowed(
-	  $this->_groupID, $entityId, CRM_Core_Permission::EDIT
-	)) {
-	  CRM_Core_Error::statusBounce(ts('You do not have the necessary permission to add/edit this contact\'s custom data.'));
-	}																	 
+    // check if the user has permission to edit the custom data for the contact.
+    if (!CRM_Core_BAO_CustomGroup::isCustomGroupAllowed(
+      $this->_groupID, $entityId, CRM_Core_Permission::EDIT
+    )) {
+      CRM_Core_Error::statusBounce(ts('You do not have the necessary permission to add/edit this contact\'s custom data.'));
+    }
     $this->assign('contact_type', $this->_contactType);
     $this->assign('contact_subtype', $this->_contactSubType);
     list($displayName, $contactImage) = CRM_Contact_BAO_Contact::getDisplayAndImage($this->_tableID);

--- a/CRM/Contact/Page/AJAX.php
+++ b/CRM/Contact/Page/AJAX.php
@@ -293,6 +293,11 @@ class CRM_Contact_Page_AJAX {
     $customValueID = CRM_Utils_Type::escape($_REQUEST['valueID'], 'Positive');
     $customGroupID = CRM_Utils_Type::escape($_REQUEST['groupID'], 'Positive');
     $contactId = CRM_Utils_Request::retrieve('contactId', 'Positive');
+	if (!CRM_Core_BAO_CustomGroup::isCustomGroupAllowed(
+      $customGroupID, $contactId, CRM_Core_Permission::EDIT
+    )) {
+      CRM_Utils_System::permissionDenied();
+    }		
     CRM_Core_BAO_CustomValue::deleteCustomValue($customValueID, $customGroupID);
     if ($contactId) {
       echo CRM_Contact_BAO_Contact::getCountComponent('custom_' . $customGroupID, $contactId);

--- a/CRM/Contact/Page/AJAX.php
+++ b/CRM/Contact/Page/AJAX.php
@@ -293,11 +293,9 @@ class CRM_Contact_Page_AJAX {
     $customValueID = CRM_Utils_Type::escape($_REQUEST['valueID'], 'Positive');
     $customGroupID = CRM_Utils_Type::escape($_REQUEST['groupID'], 'Positive');
     $contactId = CRM_Utils_Request::retrieve('contactId', 'Positive');
-	if (!CRM_Core_BAO_CustomGroup::isCustomGroupAllowed(
-      $customGroupID, $contactId, CRM_Core_Permission::EDIT
-    )) {
+    if (!CRM_Core_BAO_CustomGroup::isCustomGroupAllowed($customGroupID, $contactId, CRM_Core_Permission::EDIT)) {
       CRM_Utils_System::permissionDenied();
-    }		
+    }
     CRM_Core_BAO_CustomValue::deleteCustomValue($customValueID, $customGroupID);
     if ($contactId) {
       echo CRM_Contact_BAO_Contact::getCountComponent('custom_' . $customGroupID, $contactId);

--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -269,7 +269,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
    *   Return only custom data for subtype.
    * @param bool $checkPermission
    *   If false, do not include permissioning clause.
-   * @param int $permissionType					   
+   * @param int $permissionType
    *
    * @return array
    *   an array of active custom fields.
@@ -284,7 +284,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
     $onlyParent = FALSE,
     $onlySubType = FALSE,
     $checkPermission = TRUE,
-    $permissionType = CRM_Core_Permission::VIEW											   
+    $permissionType = CRM_Core_Permission::VIEW
   ) {
     if (empty($customDataType)) {
       $customDataType = ['Contact', 'Individual', 'Organization', 'Household'];
@@ -333,7 +333,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
 
     // also get the permission stuff here
     if ($checkPermission) {
-     $permissionClause = CRM_Core_Permission::customGroupClause($permissionType,																		  
+      $permissionClause = CRM_Core_Permission::customGroupClause($permissionType,
         "{$cgTable}."
       );
     }
@@ -448,7 +448,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
 
         // also get the permission stuff here
         if ($checkPermission) {
-           $permissionClause = CRM_Core_Permission::customGroupClause($permissionType,																	   
+          $permissionClause = CRM_Core_Permission::customGroupClause($permissionType,
             "{$cgTable}.", TRUE
           );
         }
@@ -528,7 +528,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
    *   If false, do not include permissioning clause.
    *
    * @param bool $withMultiple
-   * @param int $permissionType							   
+   * @param int $permissionType
    *
    * @return array
    */
@@ -539,7 +539,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
     $search = FALSE,
     $checkPermission = TRUE,
     $withMultiple = FALSE,
-	$permissionType = CRM_Core_Permission::VIEW
+    $permissionType = CRM_Core_Permission::VIEW
   ) {
     // Note: there are situations when we want getFieldsForImport() return fields related
     // ONLY to basic contact types, but NOT subtypes. And thats where $onlyParent is helpful
@@ -551,7 +551,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
       $onlyParent,
       FALSE,
       $checkPermission,
-      $permissionType		 
+      $permissionType
     );
 
     $importableFields = [];

--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -269,6 +269,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
    *   Return only custom data for subtype.
    * @param bool $checkPermission
    *   If false, do not include permissioning clause.
+   * @param int $permissionType					   
    *
    * @return array
    *   an array of active custom fields.
@@ -282,7 +283,8 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
     $customDataSubName = NULL,
     $onlyParent = FALSE,
     $onlySubType = FALSE,
-    $checkPermission = TRUE
+    $checkPermission = TRUE,
+    $permissionType = CRM_Core_Permission::VIEW											   
   ) {
     if (empty($customDataType)) {
       $customDataType = ['Contact', 'Individual', 'Organization', 'Household'];
@@ -331,7 +333,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
 
     // also get the permission stuff here
     if ($checkPermission) {
-      $permissionClause = CRM_Core_Permission::customGroupClause(CRM_Core_Permission::VIEW,
+     $permissionClause = CRM_Core_Permission::customGroupClause($permissionType,																		  
         "{$cgTable}."
       );
     }
@@ -446,7 +448,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
 
         // also get the permission stuff here
         if ($checkPermission) {
-          $permissionClause = CRM_Core_Permission::customGroupClause(CRM_Core_Permission::VIEW,
+           $permissionClause = CRM_Core_Permission::customGroupClause($permissionType,																	   
             "{$cgTable}.", TRUE
           );
         }
@@ -526,6 +528,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
    *   If false, do not include permissioning clause.
    *
    * @param bool $withMultiple
+   * @param int $permissionType							   
    *
    * @return array
    */
@@ -535,7 +538,8 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
     $onlyParent = FALSE,
     $search = FALSE,
     $checkPermission = TRUE,
-    $withMultiple = FALSE
+    $withMultiple = FALSE,
+	$permissionType = CRM_Core_Permission::VIEW
   ) {
     // Note: there are situations when we want getFieldsForImport() return fields related
     // ONLY to basic contact types, but NOT subtypes. And thats where $onlyParent is helpful
@@ -546,7 +550,8 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
       NULL,
       $onlyParent,
       FALSE,
-      $checkPermission
+      $checkPermission,
+      $permissionType		 
     );
 
     $importableFields = [];

--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -2171,5 +2171,23 @@ SELECT  civicrm_custom_group.id as groupID, civicrm_custom_group.title as groupT
     }
     return [$multipleFieldGroups, $groupTree];
   }
+   /**
+   * Check if user has permission for CRUD operation on custom data.
+   *
+   * @param int $customGroupId
+   * @param int $contactId
+   * @param int $permissionType
+   *
+   * @return bool
+   */
+  public static function isCustomGroupAllowed($customGroupId, $contactId, $permissionType) {
+    if (CRM_Contact_BAO_Contact_Permission::allow($contactId, CRM_Core_Permission::EDIT)
+      && $customGroupId && in_array($customGroupId,
+      CRM_Core_Permission::customGroup($permissionType)
+    )) {
+      return TRUE;
+    }
+    return FALSE;
+  }
 
 }

--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -2171,15 +2171,16 @@ SELECT  civicrm_custom_group.id as groupID, civicrm_custom_group.title as groupT
     }
     return [$multipleFieldGroups, $groupTree];
   }
-   /**
-   * Check if user has permission for CRUD operation on custom data.
-   *
-   * @param int $customGroupId
-   * @param int $contactId
-   * @param int $permissionType
-   *
-   * @return bool
-   */
+
+  /**
+    * Check if user has permission for CRUD operation on custom data.
+    *
+    * @param int $customGroupId
+    * @param int $contactId
+    * @param int $permissionType
+    *
+    * @return bool
+    */
   public static function isCustomGroupAllowed($customGroupId, $contactId, $permissionType) {
     if (CRM_Contact_BAO_Contact_Permission::allow($contactId, CRM_Core_Permission::EDIT)
       && $customGroupId && in_array($customGroupId,

--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -2173,14 +2173,14 @@ SELECT  civicrm_custom_group.id as groupID, civicrm_custom_group.title as groupT
   }
 
   /**
-    * Check if user has permission for CRUD operation on custom data.
-    *
-    * @param int $customGroupId
-    * @param int $contactId
-    * @param int $permissionType
-    *
-    * @return bool
-    */
+   * Check if user has permission for CRUD operation on custom data.
+   *
+   * @param int $customGroupId
+   * @param int $contactId
+   * @param int $permissionType
+   *
+   * @return bool
+   */
   public static function isCustomGroupAllowed($customGroupId, $contactId, $permissionType) {
     if (CRM_Contact_BAO_Contact_Permission::allow($contactId, CRM_Core_Permission::EDIT)
       && $customGroupId && in_array($customGroupId,

--- a/CRM/Core/BAO/UFGroup.php
+++ b/CRM/Core/BAO/UFGroup.php
@@ -722,7 +722,7 @@ class CRM_Core_BAO_UFGroup extends CRM_Core_DAO_UFGroup {
 
   /**
    * @param string $ctype
-   * @param int $permissionType				   
+   * @param int $permissionType
    *
    * @return mixed
    */
@@ -734,7 +734,7 @@ class CRM_Core_BAO_UFGroup extends CRM_Core_DAO_UFGroup {
         $permissionType = CRM_Core_Permission::EDIT;
       }
       $customFields = CRM_Core_BAO_CustomField::getFieldsForImport($ctype, FALSE, FALSE, FALSE, TRUE, TRUE, $permissionType);
-	 
+
       // hack to add custom data for components
       $components = ['Contribution', 'Participant', 'Membership', 'Activity', 'Case'];
       foreach ($components as $value) {

--- a/CRM/Core/BAO/UFGroup.php
+++ b/CRM/Core/BAO/UFGroup.php
@@ -721,15 +721,20 @@ class CRM_Core_BAO_UFGroup extends CRM_Core_DAO_UFGroup {
   }
 
   /**
-   * @param $ctype
+   * @param string $ctype
+   * @param int $permissionType				   
    *
    * @return mixed
    */
-  protected static function getCustomFields($ctype) {
+  protected static function getCustomFields($ctype, $permissionType = CRM_Core_Permission::VIEW) {
     $cacheKey = 'uf_group_custom_fields_' . $ctype;
     if (!Civi::cache('metadata')->has($cacheKey)) {
-      $customFields = CRM_Core_BAO_CustomField::getFieldsForImport($ctype, FALSE, FALSE, FALSE, TRUE, TRUE);
-
+      // Only Edit and View is supported in ACL for custom field.
+      if ($permissionType == CRM_Core_Permission::CREATE) {
+        $permissionType = CRM_Core_Permission::EDIT;
+      }
+      $customFields = CRM_Core_BAO_CustomField::getFieldsForImport($ctype, FALSE, FALSE, FALSE, TRUE, TRUE, $permissionType);
+	 
       // hack to add custom data for components
       $components = ['Contribution', 'Participant', 'Membership', 'Activity', 'Case'];
       foreach ($components as $value) {

--- a/CRM/Profile/Page/MultipleRecordFieldsListing.php
+++ b/CRM/Profile/Page/MultipleRecordFieldsListing.php
@@ -243,12 +243,10 @@ class CRM_Profile_Page_MultipleRecordFieldsListing extends CRM_Core_Page_Basic {
     }
 
     if (!empty($fieldIDs) && $this->_contactId) {
-	  if (!CRM_Core_BAO_CustomGroup::isCustomGroupAllowed(
-        $customGroupId, $this->_contactId, CRM_Core_Permission::EDIT
-      )) {
+      if (!CRM_Core_BAO_CustomGroup::isCustomGroupAllowed($customGroupId, $this->_contactId, CRM_Core_Permission::EDIT)) {
         $linkAction -= (CRM_Core_Action::COPY + CRM_Core_Action::UPDATE + CRM_Core_Action::DELETE);
-      }												  
-	  $DTparams = !empty($this->_DTparams) ? $this->_DTparams : NULL;
+      }
+      $DTparams = !empty($this->_DTparams) ? $this->_DTparams : NULL;
       // commonly used for both views i.e profile listing view (profileDataView) and custom data listing view (customDataView)
       $result = CRM_Core_BAO_CustomValueTable::getEntityValues($this->_contactId, NULL, $fieldIDs, TRUE, $DTparams);
       $resultCount = !empty($result['count']) ? $result['count'] : count($result);
@@ -435,13 +433,11 @@ class CRM_Profile_Page_MultipleRecordFieldsListing extends CRM_Core_Page_Basic {
         }
       }
     }
-	
-	if (CRM_Core_BAO_CustomGroup::isCustomGroupAllowed(
-      $customGroupId, $this->_contactId, CRM_Core_Permission::EDIT
-    )) {
+
+    if (CRM_Core_BAO_CustomGroup::isCustomGroupAllowed($customGroupId, $this->_contactId, CRM_Core_Permission::EDIT)) {
       $this->assign('showAddButton', TRUE);
     }
-	
+
     $this->assign('dateFields', $dateFields);
     $this->assign('dateFieldsVals', $dateFieldsVals);
     $this->assign('cgcount', $cgcount);

--- a/CRM/Profile/Page/MultipleRecordFieldsListing.php
+++ b/CRM/Profile/Page/MultipleRecordFieldsListing.php
@@ -243,7 +243,12 @@ class CRM_Profile_Page_MultipleRecordFieldsListing extends CRM_Core_Page_Basic {
     }
 
     if (!empty($fieldIDs) && $this->_contactId) {
-      $DTparams = !empty($this->_DTparams) ? $this->_DTparams : NULL;
+	  if (!CRM_Core_BAO_CustomGroup::isCustomGroupAllowed(
+        $customGroupId, $this->_contactId, CRM_Core_Permission::EDIT
+      )) {
+        $linkAction -= (CRM_Core_Action::COPY + CRM_Core_Action::UPDATE + CRM_Core_Action::DELETE);
+      }												  
+	  $DTparams = !empty($this->_DTparams) ? $this->_DTparams : NULL;
       // commonly used for both views i.e profile listing view (profileDataView) and custom data listing view (customDataView)
       $result = CRM_Core_BAO_CustomValueTable::getEntityValues($this->_contactId, NULL, $fieldIDs, TRUE, $DTparams);
       $resultCount = !empty($result['count']) ? $result['count'] : count($result);
@@ -430,6 +435,13 @@ class CRM_Profile_Page_MultipleRecordFieldsListing extends CRM_Core_Page_Basic {
         }
       }
     }
+	
+	if (CRM_Core_BAO_CustomGroup::isCustomGroupAllowed(
+      $customGroupId, $this->_contactId, CRM_Core_Permission::EDIT
+    )) {
+      $this->assign('showAddButton', TRUE);
+    }
+	
     $this->assign('dateFields', $dateFields);
     $this->assign('dateFieldsVals', $dateFieldsVals);
     $this->assign('cgcount', $cgcount);

--- a/templates/CRM/Admin/Form/Setting/Url.hlp
+++ b/templates/CRM/Admin/Form/Setting/Url.hlp
@@ -29,22 +29,8 @@
   {ts}Resource URL{/ts}
 {/htxt}
 {htxt id='id-resource_url'}
-{ts}Absolute URL of the location where the civicrm module or component has been installed.{/ts}
-<table class="form-layout-compressed">
-    <tr><td>
-    <strong>{ts}Example{/ts}</strong><br />
-    {ts 1=http://www.example.com/}If your site's home url is %1 ... then your CiviCRM Resource URL would be:{/ts}
-    <div class="font-italic description">
-    {if $config->userSystem->is_drupal EQ '1'}
-     &nbsp;&nbsp; http://www.example.com/sites/all/modules/civicrm/
-    {elseif $config->userFramework EQ 'Joomla'}
-     &nbsp;&nbsp; http://www.example.com/administrator/components/com_civicrm/civicrm/
-    {else}
-     &nbsp;&nbsp; http://www.example.com/
-    {/if}
-    </div>
-    </td></tr>
-</table>
+{ts}Location where the civicrm module or component has been installed.{/ts}
+{ts}By default, your CiviCRM Resource URL should be:{/ts} <strong>{ts}[civicrm.root]/{/ts}</strong>
 {/htxt}
 
 {htxt id='id-image_url-title'}

--- a/templates/CRM/Admin/Form/Setting/Url.hlp
+++ b/templates/CRM/Admin/Form/Setting/Url.hlp
@@ -29,8 +29,22 @@
   {ts}Resource URL{/ts}
 {/htxt}
 {htxt id='id-resource_url'}
-{ts}Location where the civicrm module or component has been installed.{/ts}
-{ts}By default, your CiviCRM Resource URL should be:{/ts} <strong>{ts}[civicrm.root]/{/ts}</strong>
+{ts}Absolute URL of the location where the civicrm module or component has been installed.{/ts}
+<table class="form-layout-compressed">
+    <tr><td>
+    <strong>{ts}Example{/ts}</strong><br />
+    {ts 1=http://www.example.com/}If your site's home url is %1 ... then your CiviCRM Resource URL would be:{/ts}
+    <div class="font-italic description">
+    {if $config->userSystem->is_drupal EQ '1'}
+     &nbsp;&nbsp; http://www.example.com/sites/all/modules/civicrm/
+    {elseif $config->userFramework EQ 'Joomla'}
+     &nbsp;&nbsp; http://www.example.com/administrator/components/com_civicrm/civicrm/
+    {else}
+     &nbsp;&nbsp; http://www.example.com/
+    {/if}
+    </div>
+    </td></tr>
+</table>
 {/htxt}
 
 {htxt id='id-image_url-title'}

--- a/templates/CRM/Profile/Page/MultipleRecordFieldsListing.tpl
+++ b/templates/CRM/Profile/Page/MultipleRecordFieldsListing.tpl
@@ -98,7 +98,7 @@
     <div id='{$dialogId}' class="hiddenElement"></div>
   {/if}
 
-  {if !$reachedMax}
+  {if !$reachedMax && $showAddButton}
     <div class="action-link">
       {if $pageViewType eq 'customDataView'}
         <br/><a accesskey="N" title="{ts 1=$customGroupTitle}Add %1 Record{/ts}" href="{crmURL p='civicrm/contact/view/cd/edit' q="reset=1&type=$ctype&groupID=$customGroupId&entityID=$contactId&cgcount=$newCgCount&multiRecordDisplay=single&mode=add"}"


### PR DESCRIPTION
Merge of original PR: https://github.com/civicrm/civicrm-core/pull/15347

Overview
----------------------------------------
This PR repeats the code cut by Pradeep to respect ACLs for multi value "tab with table" display.

Before
----------------------------------------

ACLs were not respects when view "Tab with table" custom groups. This has the effect of users being able to edit custom data for contacts not in their ACL groups.

After
----------------------------------------
ACLs are now respected and if the user has only "View" access, then edit and add buttons are removed.

Technical Details
----------------------------------------
7 x PHP files changed, plus 1 z .tpl file.

Comments
----------------------------------------
none.
