### PR TITLE
Remove legacy check

### DIFF
--- a/CRM/Core/Payment/BaseIPN.php
+++ b/CRM/Core/Payment/BaseIPN.php
@@ -153,9 +153,6 @@ class CRM_Core_Payment_BaseIPN {
     $contribution = &$objects['contribution'];
     $ids['paymentProcessor'] = $paymentProcessorID;
     $success = $contribution->loadRelatedObjects($input, $ids);
-    if ($required && empty($contribution->_relatedObjects['paymentProcessor'])) {
-      throw new CRM_Core_Exception("Could not find payment processor for contribution record: " . $contribution->id);
-    }
     $objects = array_merge($objects, $contribution->_relatedObjects);
     return $success;
   }

--- a/CRM/Core/Payment/PayPalIPN.php
+++ b/CRM/Core/Payment/PayPalIPN.php
@@ -360,9 +360,6 @@ class CRM_Core_Payment_PayPalIPN extends CRM_Core_Payment_BaseIPN {
       if (!$contribution->loadRelatedObjects($input, $ids)) {
         return;
       }
-      if (empty($contribution->_relatedObjects['paymentProcessor'])) {
-        throw new CRM_Core_Exception("Could not find payment processor for contribution record: " . $contribution->id);
-      }
 
       $input['payment_processor_id'] = $paymentProcessorID;
 

--- a/tests/phpunit/CRM/Core/Payment/BaseIPNTest.php
+++ b/tests/phpunit/CRM/Core/Payment/BaseIPNTest.php
@@ -315,32 +315,8 @@ class CRM_Core_Payment_BaseIPNTest extends CiviUnitTestCase {
   public function testLoadPledgeObjectsInvalidPledgeID() {
     $this->_setUpPledgeObjects();
     $this->ids['pledge_payment'][0] = 0;
-    try {
-      $this->IPN->loadObjects($this->input, $this->ids, $this->objects, TRUE, NULL);
-    }
-    catch (CRM_Core_Exception $e) {
-      $this->assertEquals('Could not find payment processor for contribution record: 1', $e->getMessage());
-    }
-    $this->assertArrayNotHasKey('pledge_payment', $this->objects);
 
-    $this->ids['pledge_payment'][0] = NULL;
-    try {
-      $this->IPN->loadObjects($this->input, $this->ids, $this->objects, TRUE, NULL);
-    }
-    catch (CRM_Core_Exception $e) {
-      $this->assertEquals('Could not find payment processor for contribution record: 1', $e->getMessage());
-    }
-    $this->assertArrayNotHasKey('pledge_payment', $this->objects);
-
-    $this->ids['pledge_payment'][0] = '';
-
-    try {
-      $result = $this->IPN->loadObjects($this->input, $this->ids, $this->objects, TRUE, NULL);
-      $this->assertArrayHasKey('error_message', $result);
-    }
-    catch (CRM_Core_Exception $e) {
-      $this->assertEquals('Could not find payment processor for contribution record: 1', $e->getMessage());
-    }
+    $this->IPN->loadObjects($this->input, $this->ids, $this->objects, TRUE, NULL);
     $this->assertArrayNotHasKey('pledge_payment', $this->objects);
 
     $this->ids['pledge_payment'][0] = 999;
@@ -368,12 +344,6 @@ class CRM_Core_Payment_BaseIPNTest extends CiviUnitTestCase {
    */
   public function testRequiredWithoutProcessorID() {
     $this->_setUpPledgeObjects();
-    try {
-      $this->IPN->loadObjects($this->input, $this->ids, $this->objects, TRUE, NULL);
-    }
-    catch (CRM_Core_Exception $e) {
-      $this->assertEquals('Could not find payment processor for contribution record: 1', $e->getMessage());
-    }
     // error is only returned if $required set to True
     $result = $this->IPN->loadObjects($this->input, $this->ids, $this->objects, FALSE, NULL);
     $this->assertEquals(TRUE, $result);
@@ -388,21 +358,6 @@ class CRM_Core_Payment_BaseIPNTest extends CiviUnitTestCase {
     $this->_setUpContributionObjects();
     $this->input = array_merge($this->input, ['payment_processor_id' => $this->_processorId]);
     $this->assertTrue($this->IPN->loadObjects($this->input, $this->ids, $this->objects, TRUE, NULL));
-  }
-
-  /**
-   * Test that an error is returned if required set & contribution page exists
-   */
-  public function testRequiredWithContributionPageError() {
-    $this->_setUpContributionObjects();
-    try {
-      $this->IPN->loadObjects($this->input, $this->ids, $this->objects, TRUE, NULL);
-    }
-    catch (CRM_Core_Exception $e) {
-      $this->assertEquals('Could not find payment processor for contribution record: 1', $e->getMessage());
-    }
-    // error is only returned if $required set to True
-    $this->IPN->loadObjects($this->input, $this->ids, $this->objects, FALSE, NULL);
   }
 
   public function testThatCancellingEventPaymentWillCancelAllAdditionalPendingParticipantsAndCreateCancellationActivities() {


### PR DESCRIPTION
Overview
----------------------------------------
Removes a check that dates right back to when we started extracting IPN code from code blocks in the processor. I don't believe it's meaningful

Before
----------------------------------------
Confusing check basically tells us whether the paymentProcessorID is loadable.

```
    if ($paymentProcessorID) {
      $paymentProcessor = CRM_Financial_BAO_PaymentProcessor::getPayment($paymentProcessorID,
        $this->is_test ? 'test' : 'live'
      );
      $ids['paymentProcessor'] = $paymentProcessorID;
      $this->_relatedObjects['paymentProcessor'] = $paymentProcessor;
    }
```

After
----------------------------------------
While we are not technically checking for it / loading now - there are multiple api calls that should fail if the processor_id is invalid - e.g when creating the financial transaction

Technical Details
----------------------------------------


Comments
----------------------------------------

