### PR TITLE
dev/financial#148 fully deprecate validateData function

### DIFF
--- a/CRM/Core/Payment/BaseIPN.php
+++ b/CRM/Core/Payment/BaseIPN.php
@@ -85,10 +85,12 @@ class CRM_Core_Payment_BaseIPN {
    * @param int $paymentProcessorID
    *   Id of the payment processor ID in use.
    *
+   * @deprecated
+   *
    * @return bool
    */
   public function validateData($input, &$ids, &$objects, $required = TRUE, $paymentProcessorID = NULL) {
-
+    CRM_Core_Error::deprecatedFunctionWarning('unused');
     // Check if the contribution exists
     // make sure contribution exists and is valid
     $contribution = new CRM_Contribute_BAO_Contribution();

--- a/CRM/Core/Payment/PayPalProIPN.php
+++ b/CRM/Core/Payment/PayPalProIPN.php
@@ -448,7 +448,47 @@ INNER JOIN civicrm_membership_payment mp ON m.id = mp.membership_id AND mp.contr
         $paymentProcessorID = self::getPayPalPaymentProcessorID();
       }
 
-      if (!$this->validateData($input, $ids, $objects, TRUE, $paymentProcessorID)) {
+      // Check if the contribution exists
+      // make sure contribution exists and is valid
+      $contribution = new CRM_Contribute_BAO_Contribution();
+      $contribution->id = $ids['contribution'];
+      if (!$contribution->find(TRUE)) {
+        throw new CRM_Core_Exception('Failure: Could not find contribution record for ' . (int) $contribution->id, NULL, ['context' => "Could not find contribution record: {$contribution->id} in IPN request: " . print_r($input, TRUE)]);
+      }
+
+      // make sure contact exists and is valid
+      // use the contact id from the contribution record as the id in the IPN may not be valid anymore.
+      $contact = new CRM_Contact_BAO_Contact();
+      $contact->id = $contribution->contact_id;
+      $contact->find(TRUE);
+      if ($contact->id != $ids['contact']) {
+        // If the ids do not match then it is possible the contact id in the IPN has been merged into another contact which is why we use the contact_id from the contribution
+        CRM_Core_Error::debug_log_message("Contact ID in IPN {$ids['contact']} not found but contact_id found in contribution {$contribution->contact_id} used instead");
+        echo "WARNING: Could not find contact record: {$ids['contact']}<p>";
+        $ids['contact'] = $contribution->contact_id;
+      }
+
+      if (!empty($ids['contributionRecur'])) {
+        $contributionRecur = new CRM_Contribute_BAO_ContributionRecur();
+        $contributionRecur->id = $ids['contributionRecur'];
+        if (!$contributionRecur->find(TRUE)) {
+          CRM_Core_Error::debug_log_message("Could not find contribution recur record: {$ids['ContributionRecur']} in IPN request: " . print_r($input, TRUE));
+          echo "Failure: Could not find contribution recur record: {$ids['ContributionRecur']}<p>";
+          return;
+        }
+      }
+
+      $objects['contact'] = &$contact;
+      $objects['contribution'] = &$contribution;
+
+      // CRM-19478: handle oddity when p=null is set in place of contribution page ID,
+      if (!empty($ids['contributionPage']) && !is_numeric($ids['contributionPage'])) {
+        // We don't need to worry if about removing contribution page id as it will be set later in
+        //  CRM_Contribute_BAO_Contribution::loadRelatedObjects(..) using $objects['contribution']->contribution_page_id
+        unset($ids['contributionPage']);
+      }
+
+      if (!$this->loadObjects($input, $ids, $objects, TRUE, $paymentProcessorID)) {
         return;
       }
 


### PR DESCRIPTION
Overview
----------------------------------------
Removes the final call to BaseIPN->validateData, deprecating the function

Before
----------------------------------------
validateData called from one last place

After
----------------------------------------
poof

Technical Details
----------------------------------------
Part of larger cleanup

Comments
----------------------------------------
