### PR TITLE
dev/drupal#149 Override sessionStart function for Drupal8 using appro…

### DIFF
--- a/CRM/Utils/System/Drupal8.php
+++ b/CRM/Utils/System/Drupal8.php
@@ -835,4 +835,16 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
     return ['ufAccessURL' => \Drupal\Core\Url::fromRoute('user.admin_permissions')->toString()];
   }
 
+  /**
+   * Start a new session.
+   */
+  public function sessionStart() {
+    if (\Drupal::hasContainer()) {
+      $session = \Drupal::service('session');
+      if (!$session->isStarted()) {
+        $session->start();
+      }
+    }
+  }
+
 }


### PR DESCRIPTION
…priate session functions

Overview
----------------------------------------
This overrides the sessionStart function to fix Session already started errors when running cron.php and as per the [Drupal Documentation](https://www.drupal.org/node/2228871)

Before
----------------------------------------
deprecated methods from DrupalBase.php used for Drupal8/9

After
----------------------------------------
Correct Session functions used for Drupal8/9

ping @demeritcowboy @KarinG @mglaman @MikeyMJCO 