### PR TITLE
[REF] Decouple crmD3 angular module from CiviMail

### DIFF
--- a/CRM/Mailing/Info.php
+++ b/CRM/Mailing/Info.php
@@ -157,7 +157,6 @@ class CRM_Mailing_Info extends CRM_Core_Component_Info {
     $result = [];
     $result['crmMailing'] = include "$civicrm_root/ang/crmMailing.ang.php";
     $result['crmMailingAB'] = include "$civicrm_root/ang/crmMailingAB.ang.php";
-    $result['crmD3'] = include "$civicrm_root/ang/crmD3.ang.php";
 
     return $result;
   }

--- a/Civi/Angular/Manager.php
+++ b/Civi/Angular/Manager.php
@@ -123,6 +123,7 @@ class Manager {
       $angularModules['api4Explorer'] = include "$civicrm_root/ang/api4Explorer.ang.php";
       $angularModules['api4'] = include "$civicrm_root/ang/api4.ang.php";
       $angularModules['crmDashboard'] = include "$civicrm_root/ang/crmDashboard.ang.php";
+      $angularModules['crmD3'] = include "$civicrm_root/ang/crmD3.ang.php";
 
       foreach (\CRM_Core_Component::getEnabledComponents() as $component) {
         $angularModules = array_merge($angularModules, $component->getAngularModules());

--- a/ang/crmD3.ang.php
+++ b/ang/crmD3.ang.php
@@ -1,13 +1,9 @@
 <?php
-// This file declares an Angular module which can be autoloaded
-// in CiviCRM. See also:
-// http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_angularModules
-
-// ODDITY: Only loads if you have CiviMail permissions.
-// ODDITY: Extra resources loaded via CRM_Mailing_Info::getAngularModules.
+// This module provides the D3 graphing library
 
 return [
   'ext' => 'civicrm',
+  'basePages' => [],
   'js' => [
     'ang/crmD3.js',
     'bower_components/d3/d3.min.js',

--- a/ang/crmMailing.ang.php
+++ b/ang/crmMailing.ang.php
@@ -4,7 +4,6 @@
 // http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_angularModules
 
 // ODDITY: Only loads if you have CiviMail permissions.
-// ODDITY: Extra resources loaded via CRM_Mailing_Info::getAngularModules.
 
 return [
   'ext' => 'civicrm',

--- a/ang/crmMailingAB.ang.php
+++ b/ang/crmMailingAB.ang.php
@@ -4,7 +4,6 @@
 // http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_angularModules
 
 // ODDITY: Only loads if you have CiviMail permissions.
-// ODDITY: Extra resources loaded via CRM_Mailing_Info::getAngularModules.
 
 return [
   'ext' => 'civicrm',


### PR DESCRIPTION
Overview
----------------------------------------
Makes the D3 graphing library load in a more standard way.

Before
----------------------------------------
The `crmD3` module was being conditionally declared based on whether CiviMail is enabled, then automatically loaded on the `civicrm/a` base page.

After
----------------------------------------
`crmD3` module always exists, but is not automatically loaded on any base page. The `crmMailingAB` will load it as a dependency.

Technical Details
----------------------------------------
From the user's POV there is no change here. It just manages the Angular dependencies in a more standard, reusable way.

Comments
----------------
This is with an eye toward using D3 for Search Kit displays.
