### PR TITLE
[NFC] Remove boilerplate comment from .ang.php files

### DIFF
--- a/ang/angularFileUpload.ang.php
+++ b/ang/angularFileUpload.ang.php
@@ -1,8 +1,5 @@
 <?php
 // This file declares an Angular module which can be autoloaded
-// in CiviCRM. See also:
-// http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_angularModules
-
 return [
   'ext' => 'civicrm',
   'js' => ['bower_components/angular-file-upload/angular-file-upload.min.js'],

--- a/ang/checklist-model.ang.php
+++ b/ang/checklist-model.ang.php
@@ -1,8 +1,5 @@
 <?php
 // This file declares an Angular module which can be autoloaded
-// in CiviCRM. See also:
-// http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_angularModules
-
 return [
   'ext' => 'civicrm',
   'basePages' => [],

--- a/ang/crmApp.ang.php
+++ b/ang/crmApp.ang.php
@@ -1,8 +1,5 @@
 <?php
 // This file declares an Angular module which can be autoloaded
-// in CiviCRM. See also:
-// http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_angularModules
-
 return [
   'ext' => 'civicrm',
   'js' => ['ang/crmApp.js'],

--- a/ang/crmAttachment.ang.php
+++ b/ang/crmAttachment.ang.php
@@ -1,8 +1,5 @@
 <?php
 // This file declares an Angular module which can be autoloaded
-// in CiviCRM. See also:
-// http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_angularModules
-
 return [
   'ext' => 'civicrm',
   'js' => ['ang/crmAttachment.js'],

--- a/ang/crmAutosave.ang.php
+++ b/ang/crmAutosave.ang.php
@@ -1,8 +1,5 @@
 <?php
 // This file declares an Angular module which can be autoloaded
-// in CiviCRM. See also:
-// http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_angularModules
-
 return [
   'ext' => 'civicrm',
   'js' => ['ang/crmAutosave.js'],

--- a/ang/crmCaseType.ang.php
+++ b/ang/crmCaseType.ang.php
@@ -1,8 +1,5 @@
 <?php
 // This file declares an Angular module which can be autoloaded
-// in CiviCRM. See also:
-// http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_angularModules
-
 // ODDITY: This only loads if CiviCase is active.
 
 return [

--- a/ang/crmCxn.ang.php
+++ b/ang/crmCxn.ang.php
@@ -1,8 +1,5 @@
 <?php
 // This file declares an Angular module which can be autoloaded
-// in CiviCRM. See also:
-// http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_angularModules
-
 return [
   'ext' => 'civicrm',
   'js' => ['ang/crmCxn.js', 'ang/crmCxn/*.js'],

--- a/ang/crmMailing.ang.php
+++ b/ang/crmMailing.ang.php
@@ -1,8 +1,5 @@
 <?php
 // This file declares an Angular module which can be autoloaded
-// in CiviCRM. See also:
-// http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_angularModules
-
 // ODDITY: Only loads if you have CiviMail permissions.
 // ODDITY: Extra resources loaded via CRM_Mailing_Info::getAngularModules.
 

--- a/ang/crmMailingAB.ang.php
+++ b/ang/crmMailingAB.ang.php
@@ -1,8 +1,5 @@
 <?php
 // This file declares an Angular module which can be autoloaded
-// in CiviCRM. See also:
-// http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_angularModules
-
 // ODDITY: Only loads if you have CiviMail permissions.
 // ODDITY: Extra resources loaded via CRM_Mailing_Info::getAngularModules.
 

--- a/ang/crmResource.ang.php
+++ b/ang/crmResource.ang.php
@@ -1,8 +1,5 @@
 <?php
 // This file declares an Angular module which can be autoloaded
-// in CiviCRM. See also:
-// http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_angularModules
-
 return [
   'ext' => 'civicrm',
   // 'js' => array('js/angular-crmResource/byModule.js'), // One HTTP request per module.

--- a/ang/crmRouteBinder.ang.php
+++ b/ang/crmRouteBinder.ang.php
@@ -1,8 +1,5 @@
 <?php
 // This file declares an Angular module which can be autoloaded
-// in CiviCRM. See also:
-// http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_angularModules
-
 return [
   'ext' => 'civicrm',
   'js' => ['ang/crmRouteBinder.js'],

--- a/ang/crmStatusPage.ang.php
+++ b/ang/crmStatusPage.ang.php
@@ -1,8 +1,5 @@
 <?php
 // This file declares an Angular module which can be autoloaded
-// in CiviCRM. See also:
-// http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_angularModules
-
 // ODDITY: Angular name 'statuspage' doesn't match the file name 'crmStatusPage'.
 
 return [

--- a/ang/crmUi.ang.php
+++ b/ang/crmUi.ang.php
@@ -1,8 +1,5 @@
 <?php
 // This file declares an Angular module which can be autoloaded
-// in CiviCRM. See also:
-// http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_angularModules
-
 $isDebug = Civi::settings()->get('debug_enabled');
 
 return [

--- a/ang/crmUtil.ang.php
+++ b/ang/crmUtil.ang.php
@@ -1,8 +1,5 @@
 <?php
 // This file declares an Angular module which can be autoloaded
-// in CiviCRM. See also:
-// http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_angularModules
-
 return [
   'ext' => 'civicrm',
   'js' => ['ang/crmUtil.js'],

--- a/ang/dialogService.ang.php
+++ b/ang/dialogService.ang.php
@@ -1,8 +1,5 @@
 <?php
 // This file declares an Angular module which can be autoloaded
-// in CiviCRM. See also:
-// http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_angularModules
-
 // https://github.com/jwstadler/angular-jquery-dialog-service
 
 return [

--- a/ang/ngRoute.ang.php
+++ b/ang/ngRoute.ang.php
@@ -1,8 +1,5 @@
 <?php
 // This file declares an Angular module which can be autoloaded
-// in CiviCRM. See also:
-// http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_angularModules
-
 return [
   'ext' => 'civicrm',
   'js' => ['bower_components/angular-route/angular-route.min.js'],

--- a/ang/ngSanitize.ang.php
+++ b/ang/ngSanitize.ang.php
@@ -1,8 +1,5 @@
 <?php
 // This file declares an Angular module which can be autoloaded
-// in CiviCRM. See also:
-// http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_angularModules
-
 return [
   'ext' => 'civicrm',
   'js' => ['bower_components/angular-sanitize/angular-sanitize.min.js'],

--- a/ang/ui.bootstrap.ang.php
+++ b/ang/ui.bootstrap.ang.php
@@ -1,8 +1,5 @@
 <?php
 // This file declares an Angular module which can be autoloaded
-// in CiviCRM. See also:
-// http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_angularModules
-
 return [
   'ext' => 'civicrm',
   'basePages' => [],

--- a/ang/ui.sortable.ang.php
+++ b/ang/ui.sortable.ang.php
@@ -1,8 +1,5 @@
 <?php
 // This file declares an Angular module which can be autoloaded
-// in CiviCRM. See also:
-// http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_angularModules
-
 return [
   'ext' => 'civicrm',
   'js' => ['bower_components/angular-ui-sortable/sortable.min.js'],

--- a/ang/ui.utils.ang.php
+++ b/ang/ui.utils.ang.php
@@ -1,8 +1,5 @@
 <?php
 // This file declares an Angular module which can be autoloaded
-// in CiviCRM. See also:
-// http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_angularModules
-
 return [
   'ext' => 'civicrm',
   'js' => ['bower_components/angular-ui-utils/ui-utils.min.js'],

--- a/ang/unsavedChanges.ang.php
+++ b/ang/unsavedChanges.ang.php
@@ -1,8 +1,5 @@
 <?php
 // This file declares an Angular module which can be autoloaded
-// in CiviCRM. See also:
-// http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_angularModules
-
 return [
   'ext' => 'civicrm',
   'js' => ['bower_components/angular-unsavedChanges/dist/unsavedChanges.min.js'],

--- a/ext/afform/core/ang/af.ang.php
+++ b/ext/afform/core/ang/af.ang.php
@@ -1,8 +1,5 @@
 <?php
 // This file declares an Angular module which can be autoloaded
-// in CiviCRM. See also:
-// http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_angularModules
-
 return [
   'js' => [
     'ang/af.js',

--- a/ext/afform/core/ang/afCore.ang.php
+++ b/ext/afform/core/ang/afCore.ang.php
@@ -1,8 +1,5 @@
 <?php
 // This file declares an Angular module which can be autoloaded
-// in CiviCRM. See also:
-// http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_angularModules
-
 return [
   'js' => [
     'ang/afCore.js',

--- a/ext/afform/core/ang/afformStandalone.ang.php
+++ b/ext/afform/core/ang/afformStandalone.ang.php
@@ -1,8 +1,5 @@
 <?php
 // This file declares an Angular module which can be autoloaded
-// in CiviCRM. See also:
-// http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_angularModules
-
 return [
   'js' => [
     'ang/afformStandalone.js',

--- a/ext/afform/html/ang/afMonaco.ang.php
+++ b/ext/afform/html/ang/afMonaco.ang.php
@@ -1,8 +1,5 @@
 <?php
 // This file declares an Angular module which can be autoloaded
-// in CiviCRM. See also:
-// http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_angularModules
-
 return array(
   'js' => [
     AFFORM_HTML_MONACO . '/loader.js',


### PR DESCRIPTION
Overview
----------------------------------------
Minor cleanup to our Angular module files.
Removes outdated and unhelpful comment from the top of every `.ang.php` file.

Before
----------------------------------------
Boilerplate comment links to outdated wiki page.

After
----------------------------------------
Gone.