### PR TITLE
[REF] Cleanup Ang modules in core to follow conventions

### DIFF
--- a/CRM/Core/Page/AJAX/Attachment.php
+++ b/CRM/Core/Page/AJAX/Attachment.php
@@ -131,6 +131,15 @@ class CRM_Core_Page_AJAX_Attachment {
   }
 
   /**
+   * @return array
+   */
+  public static function angularSettings() {
+    return [
+      'token' => self::createToken(),
+    ];
+  }
+
+  /**
    * @return string
    */
   public static function createToken() {

--- a/Civi/Angular/Manager.php
+++ b/Civi/Angular/Manager.php
@@ -118,7 +118,7 @@ class Manager {
       $angularModules['ui.bootstrap'] = include "$civicrm_root/ang/ui.bootstrap.ang.php";
       $angularModules['ui.sortable'] = include "$civicrm_root/ang/ui.sortable.ang.php";
       $angularModules['unsavedChanges'] = include "$civicrm_root/ang/unsavedChanges.ang.php";
-      $angularModules['statuspage'] = include "$civicrm_root/ang/crmStatusPage.ang.php";
+      $angularModules['crmStatusPage'] = include "$civicrm_root/ang/crmStatusPage.ang.php";
       $angularModules['exportui'] = include "$civicrm_root/ang/exportui.ang.php";
       $angularModules['api4Explorer'] = include "$civicrm_root/ang/api4Explorer.ang.php";
       $angularModules['api4'] = include "$civicrm_root/ang/api4.ang.php";

--- a/ang/crmAttachment.ang.php
+++ b/ang/crmAttachment.ang.php
@@ -5,8 +5,6 @@ return [
   'js' => ['ang/crmAttachment.js'],
   'css' => ['ang/crmAttachment.css'],
   'partials' => ['ang/crmAttachment'],
-  'settings' => [
-    'token' => \CRM_Core_Page_AJAX_Attachment::createToken(),
-  ],
+  'settingsFactory' => ['CRM_Core_Page_AJAX_Attachment', 'angularSettings'],
   'requires' => ['angularFileUpload', 'crmResource'],
 ];

--- a/ang/crmStatusPage.ang.php
+++ b/ang/crmStatusPage.ang.php
@@ -1,6 +1,5 @@
 <?php
 // This file declares an Angular module which can be autoloaded
-// ODDITY: Angular name 'statuspage' doesn't match the file name 'crmStatusPage'.
 
 return [
   'ext' => 'civicrm',

--- a/ang/crmStatusPage.ang.php
+++ b/ang/crmStatusPage.ang.php
@@ -7,6 +7,5 @@ return [
   'js' => ['ang/crmStatusPage.js', 'ang/crmStatusPage/*.js'],
   'css' => ['ang/crmStatusPage.css'],
   'partials' => ['ang/crmStatusPage'],
-  'settings' => [],
   'requires' => ['crmUi', 'crmUtil', 'ngRoute', 'crmResource'],
 ];

--- a/ang/crmStatusPage.js
+++ b/ang/crmStatusPage.js
@@ -1,11 +1,11 @@
 (function(angular, $, _) {
-  angular.module('statuspage', CRM.angRequires('statuspage'));
+  angular.module('crmStatusPage', CRM.angRequires('crmStatusPage'));
 
   // router
-  angular.module('statuspage').config( function($routeProvider) {
+  angular.module('crmStatusPage').config( function($routeProvider) {
     $routeProvider.when('/status', {
-      controller: 'statuspageStatusPage',
-      templateUrl: '~/statuspage/StatusPage.html',
+      controller: 'crmStatusPageCtrl',
+      templateUrl: '~/crmStatusPage/StatusPage.html',
 
       resolve: {
         statusData: function(crmApi) {

--- a/ang/crmStatusPage/StatusPageCtrl.js
+++ b/ang/crmStatusPage/StatusPageCtrl.js
@@ -1,6 +1,6 @@
 (function(angular, $, _) {
 
-  angular.module('statuspage').controller('statuspageStatusPage',
+  angular.module('crmStatusPage').controller('crmStatusPageCtrl',
     function($scope, crmApi, crmStatus, statusData) {
       $scope.ts = CRM.ts();
       $scope.help = CRM.help;
@@ -40,7 +40,7 @@
           }]
         ], 'Set preference');
       };
-      
+
       $scope.countVisible = function(visibility) {
         return _.filter($scope.statuses, function(s) {
           return s.is_visible == visibility && s.severity_id >= 2;

--- a/ang/crmStatusPage/StatusPageServices.js
+++ b/ang/crmStatusPage/StatusPageServices.js
@@ -1,12 +1,12 @@
 (function(angular, $, _) {
 
-  angular.module('statuspage')
+  angular.module('crmStatusPage')
     .filter('trusted', function($sce){ return $sce.trustAsHtml; })
 
     // Todo: abstract this into a generic crmUi directive?
     .directive('statuspagePopupMenu', function($timeout) {
       return {
-        templateUrl: '~/statuspage/SnoozeOptions.html',
+        templateUrl: '~/crmStatusPage/SnoozeOptions.html',
         transclude: true,
 
         link: function(scope, element, attr) {

--- a/ang/exportui.ang.php
+++ b/ang/exportui.ang.php
@@ -19,5 +19,4 @@ return [
     'ui.sortable',
     'dialogService',
   ],
-  'settings' => [],
 ];

--- a/tests/phpunit/Civi/Angular/ManagerTest.php
+++ b/tests/phpunit/Civi/Angular/ManagerTest.php
@@ -48,6 +48,7 @@ class ManagerTest extends \CiviUnitTestCase {
       'css' => 0,
       'partials' => 0,
       'settings' => 0,
+      'settingsFactory' => 0,
     ];
 
     foreach ($modules as $module) {
@@ -80,12 +81,17 @@ class ManagerTest extends \CiviUnitTestCase {
           $counts['settings']++;
         }
       }
+      if (isset($module['settingsFactory'])) {
+        $this->assertTrue(is_callable($module['settingsFactory']));
+        $counts['settingsFactory']++;
+      }
     }
 
     $this->assertTrue($counts['js'] > 0, 'Expect to find at least one JS file');
     $this->assertTrue($counts['css'] > 0, 'Expect to find at least one CSS file');
     $this->assertTrue($counts['partials'] > 0, 'Expect to find at least one partial HTML file');
-    $this->assertTrue($counts['settings'] > 0, 'Expect to find at least one setting');
+    $this->assertTrue($counts['settingsFactory'] > 0, 'Expect to find at least one settingsFactory');
+    $this->assertEquals(0, $counts['settings'], 'Angular settings are deprecated in favor of settingsFactory');
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Each Angular module has a "definition" (typically in an `.ang.php` file) which consists of a small amount of information about where the html, js & css files are kept. Our goal is to cache Angular module definitions for performance, which means the data must be static. Historically `.ang.php` files were allowed to return an array of "settings" which could contain dynamic information (e.g. the current user's permission levels). That can't be cached, so instead modules can declare "settingsFactory" which is the name of a function which will return the settings.

**Attention Extension Authors:** You can refactor your own extensions simply by moving the `settings` array into a function.
- [Example 1](https://github.com/civicrm/civicrm-core/pull/19052/commits/d56e4a996cf9de952db80c3823d572d2889365c0)
- [Example 2](https://github.com/veda-consulting-company/uk.co.vedaconsulting.mosaico/pull/617/commits/c6f2793f8db792b80834308ed7c9f96f898a30bd)

Before
----------------------------------------
- `crmAttachment` module loaded settings at runtime.

After
----------------------------------------
- `crmAttachment` module loads settings via factory. Other references to `settings` removed.

Technical Details
----------------------------------------
This gets us another step closer to being able to autoload Angular modules in core and cache the list of modules.

Also renamed module `statuspage` to `crmStatusPage` to match file name `crmStatusPage.ang.php`.