### PR TITLE
Search ext: Fix search action button

### DIFF
--- a/ext/search/ang/crmSearchActions/crmSearchActions.html
+++ b/ext/search/ang/crmSearchActions/crmSearchActions.html
@@ -1,5 +1,6 @@
 <div class="btn-group" title="{{:: ts('Perform action on selected items.') }}">
-  <button type="button" ng-disabled="!$ctrl.ids.length" class="btn form-control dropdown-toggle btn-default" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+  <button type="button" ng-disabled="!$ctrl.ids.length" class="btn dropdown-toggle btn-default" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+    <i class="crm-i fa-pencil"></i>
     {{:: ts('Action') }} <span class="caret"></span>
   </button>
   <ul class="dropdown-menu" ng-if=":: $ctrl.actions">


### PR DESCRIPTION
Overview
----------------------------------------
Fixes markup for the search kit action menu button.

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/2874912/100302529-8b978780-2f68-11eb-8678-16baa90d7b26.png)

After
----------------------------------------
![image](https://user-images.githubusercontent.com/2874912/100302467-6276f700-2f68-11eb-8b15-aa37921477a0.png)

Technical Details
----------------------------------------
Don't know how the `form-control` class got in there but it definitely doesn't belong in a button.