### PR TITLE
Adapt filters with empty and null values in alphanumeric custom fields

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -2103,9 +2103,25 @@ class CRM_Report_Form extends CRM_Core_Form {
         break;
 
       case 'nll':
+        if ($type == 'String') {
+          $sqlOP = $this->getSQLOperator($op);
+          $clause = "( {$field['dbAlias']} $sqlOP OR {$field['dbAlias']} = '' )";
+        }
+        else {
+          $sqlOP = $this->getSQLOperator($op);
+          $clause = "( {$field['dbAlias']} $sqlOP )";
+        }
+        break;
+
       case 'nnll':
-        $sqlOP = $this->getSQLOperator($op);
-        $clause = "( {$field['dbAlias']} $sqlOP )";
+        if ($type == 'String') {
+          $sqlOP = $this->getSQLOperator($op);
+          $clause = "( {$field['dbAlias']} $sqlOP AND {$field['dbAlias']} <> '' )";
+        }
+        else {
+          $sqlOP = $this->getSQLOperator($op);
+          $clause = "( {$field['dbAlias']} $sqlOP )";
+        }
         break;
 
       case 'eq':


### PR DESCRIPTION
Overview
----------------------------------------
Hello,

I have created a group of custom fields and a new custom field type "Alphanumeric". Then I have created two contacts without assigning them any value in the custom field. Finally I have tried to filter the field in the reports as "is empty (NULL)" and the report shows only the null results. (When the contact is created it is assigned as empty)

Before
----------------------------------------
Reports don't filter with empty values in alphanumeric custom fields

After
----------------------------------------
The reports filter with empty values and null values in alphanumeric fields (Include default fields, ex: contact source)

Comments
----------------------------------------
issue: https://lab.civicrm.org/dev/core/-/issues/2173