### PR TITLE
wordpress#63 Add action parameter to PCP shortcode

### DIFF
--- a/CRM/Core/Form/ShortCode.php
+++ b/CRM/Core/Form/ShortCode.php
@@ -129,6 +129,14 @@ class CRM_Core_Form_ShortCode extends CRM_Core_Form {
         ],
       ],
       [
+        'key' => 'action',
+        'components' => ['pcp'],
+        'options' => [
+          'info' => ts('Info Page'),
+          'transact' => ts('Contribution Page'),
+        ],
+      ],
+      [
         'key' => 'mode',
         'components' => ['contribution', 'pcp', 'event'],
         'options' => [


### PR DESCRIPTION
Overview
----------------------------------------
Add action parameter to PCP shortcode per https://lab.civicrm.org/dev/wordpress/-/issues/63

The parameters chosen are "info" and "transact" because I think this makes more sense than using "register" as used by event.

See https://github.com/civicrm/civicrm-wordpress/pull/226 for the UI part of this

Before
----------------------------------------
No action parameter for PCP shortcodes.

After
----------------------------------------
Action parameter for PCP shortcodes.

Technical Details
----------------------------------------


Comments
----------------------------------------
@kcristiano @christianwach 