### PR TITLE
Deprecate UFGroup::add parameter ids

### DIFF
--- a/CRM/Core/BAO/UFGroup.php
+++ b/CRM/Core/BAO/UFGroup.php
@@ -1425,12 +1425,16 @@ class CRM_Core_BAO_UFGroup extends CRM_Core_DAO_UFGroup {
    * @param array $params
    *   Reference array contains the values submitted by the form.
    * @param array $ids
-   *   Reference array contains the id.
+   *   Deprecated array.
    *
    *
    * @return object
    */
   public static function add(&$params, $ids = []) {
+    if (empty($params['id']) && !empty($ids['ufgroup'])) {
+      $params['id'] = $ids['ufgroup'];
+      Civi::log()->warning('ids parameter is deprecated', ['civi.tag' => 'deprecated']);
+    }
     $fields = [
       'is_active',
       'add_captcha',

--- a/CRM/UF/Form/Group.php
+++ b/CRM/UF/Form/Group.php
@@ -363,7 +363,6 @@ class CRM_UF_Form_Group extends CRM_Core_Form {
     }
     else {
       // get the submitted form values.
-      $ids = [];
       $params = $this->controller->exportValues($this->_name);
 
       if (!array_key_exists('is_active', $params)) {
@@ -371,7 +370,7 @@ class CRM_UF_Form_Group extends CRM_Core_Form {
       }
 
       if ($this->_action & (CRM_Core_Action::UPDATE)) {
-        $ids['ufgroup'] = $this->_id;
+        $params['id'] = $this->_id;
         // CRM-5284
         // lets skip trying to mess around with profile weights and allow the user to do as needed.
       }
@@ -382,7 +381,7 @@ class CRM_UF_Form_Group extends CRM_Core_Form {
       }
 
       // create uf group
-      $ufGroup = CRM_Core_BAO_UFGroup::add($params, $ids);
+      $ufGroup = CRM_Core_BAO_UFGroup::add($params);
 
       if (!empty($params['is_active'])) {
         //make entry in uf join table


### PR DESCRIPTION

Overview
----------------------------------------
This is only passed in from one place. This PR removes it & adds noisy deprecation

Before
----------------------------------------
![Screenshot from 2020-11-27 20-12-16](https://user-images.githubusercontent.com/336308/100421710-c971e880-30ed-11eb-9867-891bcde4538b.png)


After
----------------------------------------
poof

Technical Details
----------------------------------------


Comments
----------------------------------------
