### PR TITLE
Prevent "add_action" from being called multiple times

### DIFF
--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -271,6 +271,7 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
       add_action('wp_head', [__CLASS__, '_showHTMLHead']);
       // back-end views
       add_action('admin_head', [__CLASS__, '_showHTMLHead']);
+      $registered = TRUE;
     }
     CRM_Core_Region::instance('wp_head')->add([
       'markup' => $head,


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [this minor issue on Lab](https://lab.civicrm.org/dev/core/-/issues/2217).

Before
----------------------------------------
`CRM_Utils_System_WordPress::addHTMLHead()` can potentially add multiple callbacks to `wp_head` and/or `admin_head` because `$registered` is never set.

After
----------------------------------------
Multiple callbacks cannot be added to `wp_head` and/or `admin_head` because `$registered` is set.