### PR TITLE
Protect against 404s when wpBasePage is mixed case but page slug isn't

### DIFF
--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -24,7 +24,7 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
    * Get a normalized version of the wpBasePage.
    */
   public static function getBasePage() {
-    return rtrim(Civi::settings()->get('wpBasePage'), '/');
+    return strtolower(rtrim(Civi::settings()->get('wpBasePage'), '/'));
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Partial fix for [this issue on Lab](https://lab.civicrm.org/dev/core/-/issues/2213).

Before
----------------------------------------
WordPress shows a 404 when `wpBasePage` is saved in mixed-case (e.g. "CiviCRM") and no CiviCRM content is rendered.

After
----------------------------------------
WordPress does not show a 404 when `wpBasePage` is saved in mixed-case (e.g. "CiviCRM") and renders CiviCRM content as expected.

Technical Details
----------------------------------------
WordPress requires `wpBasePage` to be lowercase or else it won't find the Base Page. If I understand how `$config->wpBasePage` is read, then this PR should always force it to lowercase regardless of what is saved.

This is only a partial fix because it papers over a deeper issue, which is that ideally the `$post->post_name` value that is stored in `wpBasePage` should be replaced with a `wpBasePageID` setting that saves the `$post->ID`.