### PR TITLE
dev/wordpress#80 Users cannot be created if no unsupervised deduping rule exists

### DIFF
--- a/CRM/Core/BAO/UFMatch.php
+++ b/CRM/Core/BAO/UFMatch.php
@@ -188,7 +188,11 @@ class CRM_Core_BAO_UFMatch extends CRM_Core_DAO_UFMatch {
           $params['contact_id'] = $params['contactID'];
         }
 
-        $ids = CRM_Contact_BAO_Contact::getDuplicateContacts($params, 'Individual', 'Unsupervised', [], FALSE);
+        try {
+          $ids = CRM_Contact_BAO_Contact::getDuplicateContacts($params, 'Individual', 'Unsupervised', [], FALSE);
+        } catch (\Exception $e) {
+          $ids = array();
+        }
 
         if (!empty($ids) && Civi::settings()->get('uniq_email_per_site')) {
           // restrict dupeIds to ones that belong to current domain/site.


### PR DESCRIPTION
Overview
----------------------------------------
When CiviCRM is configured with no unsupervised deduping rule, adding users is broken in WordPress. I also believe this could affect other CMSs. 

https://lab.civicrm.org/dev/wordpress/-/issues/80

Before
----------------------------------------
The following exception was logged: `Unsupervised rule for Individual does not exist`. An error page was shown, but the user was added/ saved.

After
----------------------------------------
The user is added/ saved with no error shown.

Comments
----------------------------------------
The exception is captured, but not logged. This felt like the correct thing to do, as the lack of configured deduping doesn't impact the actual user action (adding a user), and the lack of deduping could be intentional. However, I equally wouldn't object to logging being added.
