### PR TITLE
Minor tabs cleanup toward fixing dev/core#2215

### DIFF
--- a/CRM/Campaign/Page/DashBoard.php
+++ b/CRM/Campaign/Page/DashBoard.php
@@ -29,6 +29,8 @@ class CRM_Campaign_Page_DashBoard extends CRM_Core_Page {
   private static $_surveyActionLinks;
   private static $_petitionActionLinks;
 
+  public $_tabs;
+
   /**
    * Get the action links for this page.
    *
@@ -439,6 +441,7 @@ class CRM_Campaign_Page_DashBoard extends CRM_Core_Page {
     ];
 
     $subPageType = CRM_Utils_Request::retrieve('type', 'String', $this);
+    // Load the data for a specific tab
     if ($subPageType) {
       if (!isset($this->_tabs[$subPageType])) {
         CRM_Utils_System::permissionDenied();
@@ -447,17 +450,10 @@ class CRM_Campaign_Page_DashBoard extends CRM_Core_Page {
       $this->{'browse' . ucfirst($subPageType)}();
       $this->assign('subPageType', ucfirst($subPageType));
     }
+    // Initialize tabs
     else {
-      //build the tabs.
       $this->buildTabs();
     }
-    CRM_Core_Resources::singleton()
-      ->addScriptFile('civicrm', 'templates/CRM/common/TabHeader.js', 1, 'html-header')
-      ->addSetting([
-        'tabSettings' => [
-          'active' => strtolower(CRM_Utils_Array::value('subPage', $_GET, 'campaign')),
-        ],
-      ]);
   }
 
   /**
@@ -485,6 +481,13 @@ class CRM_Campaign_Page_DashBoard extends CRM_Core_Page {
     }
     $allTabs['campaign']['class'] = 'livePage';
     $this->assign('tabHeader', $allTabs);
+    CRM_Core_Resources::singleton()
+      ->addScriptFile('civicrm', 'templates/CRM/common/TabHeader.js', 1, 'html-header')
+      ->addSetting([
+        'tabSettings' => [
+          'active' => strtolower(CRM_Utils_Array::value('subPage', $_GET, 'campaign')),
+        ],
+      ]);
   }
 
 }

--- a/templates/CRM/common/TabHeader.js
+++ b/templates/CRM/common/TabHeader.js
@@ -1,66 +1,68 @@
 // https://civicrm.org/licensing
-/**
- * By default this simply loads tabs via ajax CRM.loadPage method
- * Tabs with class 'ajaxForm' will use CRM.loadForm instead, suitable for most forms
- * Tabs with class 'livePage' will get popup action links, suitable for crud tables
- */
-CRM.$(function($) {
-  var tabSettings = CRM.tabSettings || {};
-  tabSettings.active = tabSettings.active ? $('#tab_' + tabSettings.active).prevAll().length : 0;
-  $("#mainTabContainer")
-    .on('tabsbeforeactivate', function(e, ui) {
-      // CRM-14353 - Warn of unsaved changes for all forms except those which have opted out
-      if (CRM.utils.initialValueChanged($('form:not([data-warn-changes=false])', ui.oldPanel))) {
-        CRM.alert(ts('Your changes in the <em>%1</em> tab have not been saved.', {1: ui.oldTab.text()}), ts('Unsaved Changes'), 'warning');
-      }
-    })
-    .on('tabsbeforeload', function(e, ui) {
-      // Use civicrm ajax wrappers rather than the default $.load
-      if (!ui.panel.data("civiCrmSnippet")) {
-        var method = ui.tab.hasClass('ajaxForm') ? 'loadForm' : 'loadPage';
-        var params = {target: ui.panel};
-        if (method === 'loadForm') {
-          params.autoClose = params.openInline = params.cancelButton = params.refreshAction = false;
-          ui.panel.on('crmFormLoad', function() {
-            // Hack: "Save and done" and "Cancel" buttons submit without ajax
-            $('.cancel.crm-form-submit, button[name$=upload_done]', this).on('click', function(e) {
-              $(this).closest('form').ajaxFormUnbind();
+(function($, _) {
+  /**
+   * By default this simply loads tabs via ajax CRM.loadPage method
+   * Tabs with class 'ajaxForm' will use CRM.loadForm instead, suitable for most forms
+   * Tabs with class 'livePage' will get popup action links, suitable for crud tables
+   */
+  $(function($) {
+    // CRM.tabSettings.active is the name of the tab which should open on page load
+    var tabSettings = CRM.tabSettings ? _.cloneDeep(CRM.tabSettings) : {};
+    tabSettings.active = tabSettings.active ? $('#tab_' + tabSettings.active).prevAll().length : 0;
+    $("#mainTabContainer")
+      .on('tabsbeforeactivate', function(e, ui) {
+        // CRM-14353 - Warn of unsaved changes for all forms except those which have opted out
+        if (CRM.utils.initialValueChanged($('form:not([data-warn-changes=false])', ui.oldPanel))) {
+          CRM.alert(ts('Your changes in the <em>%1</em> tab have not been saved.', {1: ui.oldTab.text()}), ts('Unsaved Changes'), 'warning');
+        }
+      })
+      .on('tabsbeforeload', function(e, ui) {
+        // Use civicrm ajax wrappers rather than the default $.load
+        if (!ui.panel.data("civiCrmSnippet")) {
+          var method = ui.tab.hasClass('ajaxForm') ? 'loadForm' : 'loadPage';
+          var params = {target: ui.panel};
+          if (method === 'loadForm') {
+            params.autoClose = params.openInline = params.cancelButton = params.refreshAction = false;
+            ui.panel.on('crmFormLoad', function() {
+              // Hack: "Save and done" and "Cancel" buttons submit without ajax
+              $('.cancel.crm-form-submit, button[name$=upload_done]', this).on('click', function(e) {
+                $(this).closest('form').ajaxFormUnbind();
+              });
             });
-          });
-        }
-        if (ui.tab.hasClass('livePage') && CRM.config.ajaxPopupsEnabled) {
+          }
+          if (ui.tab.hasClass('livePage') && CRM.config.ajaxPopupsEnabled) {
+            ui.panel
+              .off('click.crmLivePage')
+              .on('click.crmLivePage', 'a.button, a.action-item', CRM.popup)
+              .on('crmPopupFormSuccess.crmLivePage', 'a.button, a.action-item:not(.crm-enable-disable)', CRM.refreshParent);
+          }
           ui.panel
-            .off('click.crmLivePage')
-            .on('click.crmLivePage', 'a.button, a.action-item', CRM.popup)
-            .on('crmPopupFormSuccess.crmLivePage', 'a.button, a.action-item:not(.crm-enable-disable)', CRM.refreshParent);
+            .off('.tabInfo')
+            .on('crmLoad.tabInfo crmFormSuccess.tabInfo', function(e, data) {
+              if (data) {
+                if (typeof(data.tabCount) !== 'undefined') {
+                  CRM.tabHeader.updateCount(ui.tab, data.tabCount);
+                }
+                if (typeof(data.tabValid) !== 'undefined') {
+                  var method = data.tabValid ? 'removeClass' : 'addClass';
+                  ui.tab[method]('disabled');
+                }
+              }
+            });
+          CRM[method]($('a', ui.tab).attr('href'), params);
         }
-        ui.panel
-          .off('.tabInfo')
-          .on('crmLoad.tabInfo crmFormSuccess.tabInfo', function(e, data) {
-            if (data) {
-              if (typeof(data.tabCount) !== 'undefined') {
-                CRM.tabHeader.updateCount(ui.tab, data.tabCount);
-              }
-              if (typeof(data.tabValid) !== 'undefined') {
-                var method = data.tabValid ? 'removeClass' : 'addClass';
-                ui.tab[method]('disabled');
-              }
-            }
-          });
-        CRM[method]($('a', ui.tab).attr('href'), params);
+        e.preventDefault();
+      })
+      .tabs(tabSettings);
+    // Any load/submit event could potentially call for tabs to refresh.
+    $(document).on('crmLoad.tabInfo crmFormSuccess.tabInfo', function(e, data) {
+      if (data && $.isPlainObject(data.updateTabs)) {
+        $.each(data.updateTabs, CRM.tabHeader.updateCount);
+        $.each(data.updateTabs, CRM.tabHeader.resetTab);
       }
-      e.preventDefault();
-    })
-    .tabs(tabSettings);
-  // Any load/submit event could potentially call for tabs to refresh.
-  $(document).on('crmLoad.tabInfo crmFormSuccess.tabInfo', function(e, data) {
-    if (data && $.isPlainObject(data.updateTabs)) {
-      $.each(data.updateTabs, CRM.tabHeader.updateCount);
-      $.each(data.updateTabs, CRM.tabHeader.resetTab);
-    }
+    });
   });
-});
-(function($) {
+
   // Utility functions
   CRM.tabHeader = CRM.tabHeader || {};
 
@@ -146,4 +148,4 @@ CRM.$(function($) {
       $panel.crmSnippet('destroy');
     }
   };
-})(CRM.$);
+})(CRM.$, CRM._);


### PR DESCRIPTION
Overview
----------------------------------------
A little code cleanup as a precursor to fixing https://lab.civicrm.org/dev/core/-/issues/2215

Before
----------------------------------------
1. Variable `CRM.tabSettings.active` was overwritten when initializing tabs
2. Campaign dashboard page initialized tabs again on every tab load.

After
----------------------------------------
1. Avoid overwriting `CRM.tabSettings.active` by cloning the variable rather than copying by reference
2. Initialize tabs only once on the Campaign dashboard
