### PR TITLE
Fix dev/core#2215 & remove the tab selection inline script from TabHeader.tpl

### DIFF
--- a/CRM/Admin/Page/MessageTemplates.php
+++ b/CRM/Admin/Page/MessageTemplates.php
@@ -274,6 +274,11 @@ class CRM_Admin_Page_MessageTemplates extends CRM_Core_Page_Basic {
     $this->assign('canEditSystemTemplates', CRM_Core_Permission::check('edit system workflow message templates'));
     $this->assign('canEditMessageTemplates', CRM_Core_Permission::check('edit message templates'));
     $this->assign('canEditUserDrivenMessageTemplates', CRM_Core_Permission::check('edit user-driven message templates'));
+    Civi::resources()
+      ->addScriptFile('civicrm', 'templates/CRM/common/TabHeader.js', 1, 'html-header')
+      ->addSetting([
+        'tabSettings' => ['active' => $_GET['selectedChild'] ?? NULL],
+      ]);
   }
 
 }

--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -2693,6 +2693,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
     if (!empty($selectedChild)) {
       $this->set('selectedChild', $selectedChild);
       $this->assign('selectedChild', $selectedChild);
+      Civi::resources()->addSetting(['tabSettings' => ['active' => $selectedChild]]);
     }
   }
 

--- a/templates/CRM/Admin/Page/MessageTemplates.tpl
+++ b/templates/CRM/Admin/Page/MessageTemplates.tpl
@@ -157,7 +157,6 @@
     {/foreach}
   </div>
 </div>
-{include file="CRM/common/TabHeader.tpl"}
 
 {elseif $action ne 1 and $action ne 2 and $action ne 4 and $action ne 8}
   <div class="messages status no-popup">

--- a/templates/CRM/common/TabHeader.tpl
+++ b/templates/CRM/common/TabHeader.tpl
@@ -37,4 +37,3 @@
   {/if}
   <div class="clear"></div>
 </div> {* crm-content-block ends here *}
-{include file="CRM/common/TabSelected.tpl" defaultTab="settings"}

--- a/templates/CRM/common/TabSelected.tpl
+++ b/templates/CRM/common/TabSelected.tpl
@@ -1,3 +1,4 @@
+{* DEPRECATED script, should be refactored out and removed *}
 <script type='text/javascript'>
   var selectedTab = '{$defaultTab}';
   var tabContainer = '#mainTabContainer';

--- a/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
@@ -1773,7 +1773,7 @@ Price Field - Price Field 1        1   $ 100.00      $ 100.00
 
     // The page contents load later by ajax, so there's just the surrounding
     // html available now, but we can check at least one thing while we're here.
-    $this->assertStringContainsString("selectedTab = 'widget';", $contents);
+    $this->assertContains("mainTabContainer", $contents);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Removes some redundant code that was selecting the default tab twice. https://lab.civicrm.org/dev/core/-/issues/2215

Before
----------------------------------------
Default tab set by `tabHeader.js` and then set again (sometimes incorrectly) by `TabSelected.tpl`.
In the case of Campaigns/Surveys, it was incorrect.

After
----------------------------------------
Default tab set just once.

Technical Details
----------------------------------------
This mostly gets the logic for selecting default tab out of the tpl. The final step would be to delete `CRM/common/TabSelected.tpl` and all references to it and the variables it uses.

