### PR TITLE
Quick fix on summary actions conflict

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -3181,6 +3181,11 @@ LEFT JOIN civicrm_email    ON ( civicrm_contact.id = civicrm_email.contact_id )
         }
 
         // finally get menu item for -more- action widget.
+        while (!empty($contextMenu['moreActions'][$values['weight']])) {
+          // Quick & dirty way of handling 2 items with the same weight
+          // without clobbering one.
+          $values['weight']++;
+        }
         $contextMenu['moreActions'][$values['weight']] = [
           'title' => $values['title'],
           'ref' => $values['ref'],
@@ -3198,6 +3203,11 @@ LEFT JOIN civicrm_email    ON ( civicrm_contact.id = civicrm_email.contact_id )
           }
 
           // finally get menu item for -more- action widget.
+          while (!empty($contextMenu['otherActions'][$value['weight']])) {
+            // Quick & dirty way of handling 2 items with the same weight
+            // without clobbering one.
+            $value['weight']++;
+          }
           $contextMenu['otherActions'][$value['weight']] = [
             'title' => $value['title'],
             'ref' => $value['ref'],

--- a/tests/phpunit/CRM/Contact/Form/Search/CriteriaTest.php
+++ b/tests/phpunit/CRM/Contact/Form/Search/CriteriaTest.php
@@ -22,7 +22,7 @@ class CRM_Contact_Form_Search_CriteriaTest extends CiviUnitTestCase {
    * Test that the 'multiple bulk email' setting correctly affects the type of
    * field used for the 'email on hold' criteria in Advanced Search.
    */
-  public function testAdvancedHSearchObservesMultipleBulkEmailSetting() {
+  public function testAdvancedHSearchObservesMultipleBulkEmailSetting(): void {
 
     // If setting is enabled, criteria should be a select element.
     Civi::settings()->set('civimail_multiple_bulk_emails', 1);


### PR DESCRIPTION

Overview
----------------------------------------
Per https://github.com/eileenmcnaughton/org.wikimedia.contacteditor/issues/8 &
https://github.com/mattwire/uk.co.mjwconsult.checksum/issues/1

menu items are indexed by weight, resulting in a conflict between 2 items with the same weight -
this is just a quick & dirty fix to ensure we don't overwrite one menu item with another

Before
----------------------------------------
If 2 extensions add menu links with the same weight only the second one processed is displayed as the values are keyed by weight & the first is overwritten by the second

After
----------------------------------------
The weight is bumped up if already in use, avoiding some being lost

Technical Details
----------------------------------------

Comments
----------------------------------------