### PR TITLE
Remove unreachable customGroup section in online event receipt

### DIFF
--- a/xml/templates/message_templates/event_online_receipt_html.tpl
+++ b/xml/templates/message_templates/event_online_receipt_html.tpl
@@ -474,25 +474,6 @@
 {/foreach}
 {/if}
 
-    {if $customGroup}
-      {foreach from=$customGroup item=value key=customName}
-       <tr>
-        <th {$headerStyle}>
-         {$customName}
-        </th>
-       </tr>
-       {foreach from=$value item=v key=n}
-        <tr>
-         <td {$labelStyle}>
-          {$n}
-         </td>
-         <td {$valueStyle}>
-          {$v}
-         </td>
-        </tr>
-       {/foreach}
-      {/foreach}
-     {/if}
     </table>
     {if $event.allow_selfcancelxfer }
      <tr>

--- a/xml/templates/message_templates/event_online_receipt_text.tpl
+++ b/xml/templates/message_templates/event_online_receipt_text.tpl
@@ -277,18 +277,6 @@ You were registered by: {$payer.name}
 {/foreach}
 {/foreach}
 {/if}
-{if $customGroup}
-{foreach from=$customGroup item=value key=customName}
-=========================================================={if $pricesetFieldsCount }===================={/if}
-
-{$customName}
-=========================================================={if $pricesetFieldsCount }===================={/if}
-
-{foreach from=$value item=v key=n}
-{$n}: {$v}
-{/foreach}
-{/foreach}
-{/if}
 
 {if $event.allow_selfcancelxfer }
 {ts 1=$selfcancelxfer_time 2=$selfservice_preposition}You may transfer your registration to another participant or cancel your registration up to %1 hours %2 the event.{/ts} {if $totalAmount}{ts}Cancellations are not refundable.{/ts}{/if}


### PR DESCRIPTION


Overview
----------------------------------------
Remove unreachable customGroup section in online event receipt 

Before
----------------------------------------
Section for including custom fields when assigned as $customGroup - but I can find no evidence nor think of a reason why it would be assigned.

After
----------------------------------------
The section is removed from the template - meaning it would not be present on new installs

Technical Details
----------------------------------------
After digging into https://github.com/civicrm/civicrm-core/pull/18697 I came to the
conclusion that currently both the online & offline event receipts have
sections for custom profiles and custom data (marked as customGroup).

The profiles are only assigned from the online flow and the data only from the offline
flow so in each receipt template one is unused.

I agree with the discussion on https://lab.civicrm.org/dev/core/-/issues/2076
that suggests that since every event has (potentially) assigned profiles
we could use those in both scenarios and never use the generic 'customGroup'.
The situation is less clear for contributions (where there is no profile
if there is no contribution page). Thus, I am inclined
to remove customGroup from the offline template too, after fixing to
include the profiles. However, there are additional
steps to get to the point where that is doable - at this stage I think
we CAN remove it from the online template because I cannot find anywhere
in the code where customGroup is assigned in that flow, nor logically
think of any reason other than copy and paste for it

Comments
----------------------------------------

