### PR TITLE
Extract function that generates upgrade link for extensions

### DIFF
--- a/CRM/Admin/Page/Extensions.php
+++ b/CRM/Admin/Page/Extensions.php
@@ -234,6 +234,7 @@ class CRM_Admin_Page_Extensions extends CRM_Core_Page_Basic {
     // build list of available downloads
     $remoteExtensionRows = [];
     $compat = CRM_Extension_System::getCompatibilityInfo();
+    $mapper = CRM_Extension_System::singleton()->getMapper();
 
     foreach ($remoteExtensions as $info) {
       if (!empty($compat[$info->key]['obsolete'])) {
@@ -257,7 +258,7 @@ class CRM_Admin_Page_Extensions extends CRM_Core_Page_Basic {
       if (isset($localExtensionRows[$info->key])) {
         if (array_key_exists('version', $localExtensionRows[$info->key])) {
           if (version_compare($localExtensionRows[$info->key]['version'], $info->version, '<')) {
-            $row['is_upgradeable'] = TRUE;
+            $row['upgradelink'] = $mapper->getUpgradeLink($remoteExtensions[$info->key], $localExtensionRows[$info->key]);
           }
         }
       }

--- a/CRM/Extension/Mapper.php
+++ b/CRM/Extension/Mapper.php
@@ -535,4 +535,24 @@ class CRM_Extension_Mapper {
     CRM_Extension_System::singleton()->getClassLoader()->refresh();
   }
 
+  /**
+   * This returns a formatted string containing an extension upgrade link for the UI.
+   * @todo We should improve this to return more appropriate text. eg. when an extension is not installed
+   *   it should not say "version xx is installed".
+   *
+   * @param array $remoteExtensionInfo
+   * @param array $localExtensionInfo
+   *
+   * @return string
+   */
+  public function getUpgradeLink($remoteExtensionInfo, $localExtensionInfo) {
+    if (!empty($remoteExtensionInfo) && version_compare($localExtensionInfo['version'], $remoteExtensionInfo->version, '<')) {
+      return ts('Version %1 is installed. <a %2>Upgrade to version %3</a>.', [
+        1 => $localExtensionInfo['version'],
+        2 => 'href="' . CRM_Utils_System::url('civicrm/admin/extensions', "action=update&id={$localExtensionInfo['key']}&key={$localExtensionInfo['key']}") . '"',
+        3 => $remoteExtensionInfo->version,
+      ]);
+    }
+  }
+
 }

--- a/CRM/Utils/Check/Component/Env.php
+++ b/CRM/Utils/Check/Component/Env.php
@@ -620,23 +620,16 @@ class CRM_Utils_Check_Component_Env extends CRM_Utils_Check_Component {
 
         case CRM_Extension_Manager::STATUS_INSTALLED:
           if (!empty($remotes[$key]) && version_compare($row['version'], $remotes[$key]->version, '<')) {
-            $updates[] = ts('%1 (%2) version %3 is installed. <a %4>Upgrade to version %5</a>.', [
-              1 => $row['label'] ?? NULL,
-              2 => $key,
-              3 => $row['version'],
-              4 => 'href="' . CRM_Utils_System::url('civicrm/admin/extensions', "action=update&id=$key&key=$key") . '"',
-              5 => $remotes[$key]->version,
-            ]);
+            $updates[] = $row['label'] . ': ' . $mapper->getUpgradeLink($remotes[$key], $row);
           }
           else {
             if (empty($row['label'])) {
               $okextensions[] = $key;
             }
             else {
-              $okextensions[] = ts('%1 (%2) version %3', [
+              $okextensions[] = ts('%1: Version %2', [
                 1 => $row['label'],
-                2 => $key,
-                3 => $row['version'],
+                2 => $row['version'],
               ]);
             }
           }

--- a/templates/CRM/Admin/Page/Extensions/Main.tpl
+++ b/templates/CRM/Admin/Page/Extensions/Main.tpl
@@ -22,9 +22,8 @@ Depends: CRM/common/enableDisableApi.tpl and CRM/common/jsortable.tpl
         <tr id="extension-{$row.file}" class="crm-entity crm-extension-{$row.file}{if $row.status eq 'disabled'} disabled{/if}{if $row.status eq 'installed-missing' or $row.status eq 'disabled-missing'} extension-missing{/if}{if $row.upgradable} extension-upgradable{elseif $row.status eq 'installed'} extension-installed{/if}">
           <td class="crm-extensions-label">
               <a class="collapsed" href="#"></a>&nbsp;<strong>{$row.label}</strong><br/>{$row.description}
-              {if $extAddNewEnabled && $remoteExtensionRows[$extKey] && $remoteExtensionRows[$extKey].is_upgradeable}
-                {capture assign='upgradeURL'}{crmURL p='civicrm/admin/extensions' q="action=update&id=$extKey&key=$extKey"}{/capture}
-                <div class="crm-extensions-upgrade">{ts 1=$upgradeURL}Version {$remoteExtensionRows[$extKey].version} is available. <a href="%1">Upgrade</a>{/ts}</div>
+              {if $extAddNewEnabled && $remoteExtensionRows[$extKey] && $remoteExtensionRows[$extKey].upgradelink}
+                <div class="crm-extensions-upgrade">{$remoteExtensionRows[$extKey].upgradelink}</div>
               {/if}
           </td>
           <td class="crm-extensions-label">{$row.statusLabel} {if $row.upgradable}<br/>({ts}Outdated{/ts}){/if}</td>


### PR DESCRIPTION
Overview
----------------------------------------
Extract function that generates extension upgrade link. It was being generated in two places - for env check and for extensions dir.
On the extensions directory it is not very "UI friendly" to display the "upgrade available" on extensions that are not installed and a follow up PR will allow us to show a different message in this case. Also, I'd like to introduce a mgmt tag to disable the upgrade option which can be applied when using custom versions of an extension (ie. patched versions).

Before
----------------------------------------
Upgrade links generated in multiple places (environment check + extension dir template).

![image](https://user-images.githubusercontent.com/2052161/100552685-901db200-3280-11eb-8e89-7dc3ceda22ca.png)

![image](https://user-images.githubusercontent.com/2052161/100552695-99a71a00-3280-11eb-82ec-43aa8f69319c.png)

![image](https://user-images.githubusercontent.com/2052161/100552700-a3308200-3280-11eb-833b-1a9d266a9edc.png)

After
----------------------------------------
Upgrade link generated in one place.

There is a small change in this PR - we are no longer showing the extension key in brackets after the extension name - that follows on from the change we made in https://github.com/civicrm/civicrm-core/pull/18981.

![image](https://user-images.githubusercontent.com/2052161/100552612-45039f00-3280-11eb-8d88-c6f3b97f7f49.png)

![image](https://user-images.githubusercontent.com/2052161/100552636-564cab80-3280-11eb-9c12-8ae4c1e23ecd.png)

![image](https://user-images.githubusercontent.com/2052161/100552652-6795b800-3280-11eb-91f6-54e39d4ff085.png)


Technical Details
----------------------------------------


Comments
----------------------------------------
