### PR TITLE
Add alias tokens framework to tokenProcessor (and support activity.id as well as activity.activity_id)

### DIFF
--- a/CRM/Activity/Tokens.php
+++ b/CRM/Activity/Tokens.php
@@ -122,14 +122,21 @@ class CRM_Activity_Tokens extends \Civi\Token\AbstractTokenSubscriber {
   }
 
   /**
+   * Returns a mapping of alias tokens to actual token.
+   * For example to support {activity.activity_id} in addition to {activity.id} we return ['activity_id => 'id]
+   *
+   * @return array
+   */
+  protected function getAliasTokens() {
+    return [
+      'activity_id' => 'id',
+    ];
+  }
+
+  /**
    * @inheritDoc
    */
   public function evaluateToken(\Civi\Token\TokenRow $row, $entity, $field, $prefetch = NULL) {
-    // maps token name to api field
-    $mapping = [
-      'activity_id' => 'id',
-    ];
-
     // Get ActivityID either from actionSearchResult (for scheduled reminders) if exists
     $activityId = $row->context['actionSearchResult']->entityID ?? $row->context[$this->getEntityContextSchema()];
 
@@ -138,8 +145,8 @@ class CRM_Activity_Tokens extends \Civi\Token\AbstractTokenSubscriber {
     if (in_array($field, ['activity_date_time', 'created_date', 'modified_date'])) {
       $row->tokens($entity, $field, \CRM_Utils_Date::customFormat($activity[$field]));
     }
-    elseif (isset($mapping[$field]) and (isset($activity[$mapping[$field]]))) {
-      $row->tokens($entity, $field, $activity[$mapping[$field]]);
+    elseif (isset($this->getAliasTokens()[$field]) and (isset($activity[$this->getAliasTokens()[$field]]))) {
+      $row->tokens($entity, $field, $activity[$this->getAliasTokens()[$field]]);
     }
     elseif (in_array($field, ['activity_type'])) {
       $row->tokens($entity, $field, $this->activityTypes[$activity['activity_type_id']]);
@@ -175,14 +182,14 @@ class CRM_Activity_Tokens extends \Civi\Token\AbstractTokenSubscriber {
   protected function getBasicTokens() {
     if (!isset($this->basicTokens)) {
       $this->basicTokens = [
-        'activity_id' => ts('Activity ID'),
+        'id' => ts('Activity ID'),
         'activity_type' => ts('Activity Type'),
+        'activity_type_id' => ts('Activity Type ID'),
         'subject' => ts('Activity Subject'),
         'details' => ts('Activity Details'),
         'activity_date_time' => ts('Activity Date-Time'),
         'created_date' => ts('Activity Created Date'),
         'modified_date' => ts('Activity Modified Date'),
-        'activity_type_id' => ts('Activity Type ID'),
         'status' => ts('Activity Status'),
         'status_id' => ts('Activity Status ID'),
         'location' => ts('Activity Location'),

--- a/CRM/Core/TokenTrait.php
+++ b/CRM/Core/TokenTrait.php
@@ -36,7 +36,7 @@ trait CRM_Core_TokenTrait {
     $activeTokens = [];
     // if message token contains '_\d+_', then treat as '_N_'
     foreach ($messageTokens[$this->entity] as $msgToken) {
-      if (array_key_exists($msgToken, $this->tokenNames)) {
+      if (array_key_exists($msgToken, $this->tokenNames) || array_key_exists($msgToken, $this->getAliasTokens())) {
         $activeTokens[] = $msgToken;
       }
       else {
@@ -82,6 +82,16 @@ trait CRM_Core_TokenTrait {
       $this->customFieldTokens = \CRM_Utils_Token::getCustomFieldTokens(ucfirst($this->getEntityName()));
     }
     return $this->customFieldTokens;
+  }
+
+  /**
+   * Returns a mapping of alias tokens to actual token.
+   * For example to support {activity.activity_id} in addition to {activity.id} we return ['activity_id => 'id]
+   *
+   * @return array
+   */
+  protected function getAliasTokens() {
+    return [];
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Mostly for compatibility reasons we sometimes want to support aliases, different tokens that map to the same thing.

For example we currently implement `{activity.activity_id}` but the more logical token would be `{activity.id}` which maps directly to the API parameter. When providing a list of tokens we don't want to define both.

Before
----------------------------------------
No way to define alias tokens (though a hardcoded mapping exists in `evaluateTokens()` but doesn't work because `activeTokens()` filters it out).

After
----------------------------------------
Specific function defined `getAliasTokens()` which allows you to define mappings for any aliases. Both `{activity.activity_id}` and `{activity.id}` work.

Technical Details
----------------------------------------


Comments
----------------------------------------
