### PR TITLE
CiviCRM Send Email action for individual contact fails w…

### DIFF
--- a/CRM/Contact/Form/Task/EmailCommon.php
+++ b/CRM/Contact/Form/Task/EmailCommon.php
@@ -595,7 +595,7 @@ class CRM_Contact_Form_Task_EmailCommon {
   public static function bounceIfSimpleMailLimitExceeded($count) {
     CRM_Core_Error::deprecatedFunctionWarning('This code is no longer used in core and will be removed');
 
-    $limit = Civi::settings()->get('simple_mail_limit');
+    $limit = Civi::settings()->get('simple_mail_limit') ?? CRM_Contact_Form_Task_EmailCommon::MAX_EMAILS_KILL_SWITCH;
     if ($count > $limit) {
       CRM_Core_Error::statusBounce(ts('Please do not use this task to send a lot of emails (greater than %1). Many countries have legal requirements when sending bulk emails and the CiviMail framework has opt out functionality and domain tokens to help meet these.',
         [1 => $limit]

--- a/CRM/Contact/Form/Task/EmailTrait.php
+++ b/CRM/Contact/Form/Task/EmailTrait.php
@@ -358,7 +358,7 @@ trait CRM_Contact_Form_Task_EmailTrait {
    *  The number of emails the user is attempting to send
    */
   protected function bounceIfSimpleMailLimitExceeded($count) {
-    $limit = Civi::settings()->get('simple_mail_limit');
+    $limit = Civi::settings()->get('simple_mail_limit') ?? CRM_Contact_Form_Task_EmailCommon::MAX_EMAILS_KILL_SWITCH;
     if ($count > $limit) {
       CRM_Core_Error::statusBounce(ts('Please do not use this task to send a lot of emails (greater than %1). Many countries have legal requirements when sending bulk emails and the CiviMail framework has opt out functionality and domain tokens to help meet these.',
         [1 => $limit]


### PR DESCRIPTION
…ith error: "Please do not use this task to send a lot of emails (greater than ). " - indicates that there is no sending limit set

Overview
----------------------------------------

CiviCRM Send Email action for individual contact fails with error: "Please do not use this task to send a lot of emails (greater than ). " - indicates that there is no sending limit set.
For older CiviCRM sites, there is no setting for simple_mail_limit and the code does not have any default value, resulting in null value being returned and the condition failing.


Before
----------------------------------------
Unable to send an email to a contact using the Send Email action.

After
----------------------------------------
Can send an email to a contact using the Send Email action.

Technical Details
----------------------------------------
Fix for older CiviCRM sites where simple_mail_limit is undefined.

Comments
----------------------------------------
See https://lab.civicrm.org/dev/core/-/issues/2220

Agileware Ref: CIVICRM-1615

![1024px-SNice svg](https://user-images.githubusercontent.com/58866555/100569372-ee4ea180-3321-11eb-823f-97bedd89bf22.png)
