### PR TITLE
[NFC] Update Cache/integration-tests version as new version recently …

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
   },
   "require": {
     "php": "~7.1",
-    "cache/integration-tests": "~0.16.0",
+    "cache/integration-tests": "~0.17.0",
     "dompdf/dompdf" : "~0.8",
     "electrolinux/phpquery": "^0.9.6",
     "symfony/config": "~3.0 || ~4.4",
@@ -253,11 +253,6 @@
     "patches": {
       "adrienrn/php-mimetyper": {
         "Update gitignore to ensure that sites that manage via git don't miss out on the important db.json file": "https://patch-diff.githubusercontent.com/raw/adrienrn/php-mimetyper/pull/15.patch"
-      },
-      "cache/integration-tests": {
-        "Allow adding tests": "https://github.com/php-cache/integration-tests/commit/05f97174c09364dc10c084a38ba0cfd5124f4cec.patch",
-        "Support PHPUnit 6+": "https://github.com/php-cache/integration-tests/commit/1ec7362962185df91d3d749bc3fa7e7b99cb9fc7.patch",
-        "Add tests for binary data round trip": "https://github.com/php-cache/integration-tests/commit/89cd7068e83aa776774bfc44f6bcba858c085616.patch"
       },
       "electrolinux/phpquery": {
         "PHP7.4 Fix for array access using {} instead of []": "https://raw.githubusercontent.com/civicrm/civicrm-core/fe45bdfc4f3e3d3deb27e3d853cdbc7f616620a9/tools/scripts/composer/patches/php74_array_access_fix_phpquery.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7e6ef8d4248bce0f976048cabc185289",
+    "content-hash": "20c9c6b1d5bb65490586559ff73c296b",
     "packages": [
         {
             "name": "adrienrn/php-mimetyper",
@@ -141,39 +141,35 @@
         },
         {
             "name": "cache/integration-tests",
-            "version": "0.16.0",
+            "version": "0.17.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-cache/integration-tests.git",
-                "reference": "a8d9538a44ed5a70d551f9b87f534c98dfe6b0ee"
+                "reference": "eda2e6b8bc5abcd623c8047e2345cda38dd6479e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-cache/integration-tests/zipball/a8d9538a44ed5a70d551f9b87f534c98dfe6b0ee",
-                "reference": "a8d9538a44ed5a70d551f9b87f534c98dfe6b0ee",
+                "url": "https://api.github.com/repos/php-cache/integration-tests/zipball/eda2e6b8bc5abcd623c8047e2345cda38dd6479e",
+                "reference": "eda2e6b8bc5abcd623c8047e2345cda38dd6479e",
                 "shasum": ""
             },
             "require": {
                 "cache/tag-interop": "^1.0",
-                "php": "^5.4|^7",
+                "php": ">=5.5.9",
                 "psr/cache": "~1.0"
             },
+            "conflict": {
+                "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0"
+            },
             "require-dev": {
-                "cache/cache": "dev-master",
-                "illuminate/cache": "^5.0",
-                "madewithlove/illuminate-psr-cache-bridge": "^1.0",
-                "phpunit/phpunit": "^4.0|^5.0",
-                "symfony/cache": "^3.1",
-                "tedivm/stash": "dev-master"
+                "cache/cache": "^1.0",
+                "illuminate/cache": "^5.4|^5.5|^5.6",
+                "mockery/mockery": "^1.0",
+                "symfony/cache": "^3.4.31|^4.3.4|^5.0",
+                "symfony/phpunit-bridge": "^5.1",
+                "tedivm/stash": "^0.14"
             },
             "type": "library",
-            "extra": {
-                "patches_applied": {
-                    "Allow adding tests": "https://github.com/php-cache/integration-tests/commit/05f97174c09364dc10c084a38ba0cfd5124f4cec.patch",
-                    "Support PHPUnit 6+": "https://github.com/php-cache/integration-tests/commit/1ec7362962185df91d3d749bc3fa7e7b99cb9fc7.patch",
-                    "Add tests for binary data round trip": "https://github.com/php-cache/integration-tests/commit/89cd7068e83aa776774bfc44f6bcba858c085616.patch"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Cache\\IntegrationTests\\": "src/"
@@ -192,7 +188,7 @@
                 {
                     "name": "Tobias Nyholm",
                     "email": "tobias.nyholm@gmail.com",
-                    "homepage": "https://github.com/Nyholm"
+                    "homepage": "https://github.com/nyholm"
                 }
             ],
             "description": "Integration tests for PSR-6 and PSR-16 cache implementations",
@@ -203,7 +199,7 @@
                 "psr6",
                 "test"
             ],
-            "time": "2017-02-02T14:29:50+00:00"
+            "time": "2020-11-03T12:52:23+00:00"
         },
         {
             "name": "cache/tag-interop",
@@ -454,7 +450,7 @@
                 }
             ],
             "description": "Composer plugin for downloading additional files within any composer package.",
-            "time": "2020-11-02T04:00:42+00:00"
+            "time": "2020-11-02T05:26:23+00:00"
         },
         {
             "name": "cweagans/composer-patches",


### PR DESCRIPTION
…released that contains the patches already applied

Overview
----------------------------------------
Updates Cache/integration-tests version to a released version that includes the patches we needed

Before
----------------------------------------
Patches needed

After
----------------------------------------
No patches needed

Technical Details
----------------------------------------
E2E Unit tests will fail if this doesn't work

ping @eileenmcnaughton @totten 