### PR TITLE
dev/core#2213 Protect against 404s when wpBasePage is mixed case

### DIFF
--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -24,7 +24,7 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
    * Get a normalized version of the wpBasePage.
    */
   public static function getBasePage() {
-    return rtrim(Civi::settings()->get('wpBasePage'), '/');
+    return strtolower(rtrim(Civi::settings()->get('wpBasePage'), '/'));
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Port of #19063 to 5.32 as per https://chat.civicrm.org/civicrm/pl/bi75q9bc37ns3kesgjxrgh5efy

Before
----------------------------------------
WordPress shows a 404 when wpBasePage is saved in mixed-case (e.g. "CiviCRM") and no CiviCRM content is rendered.

After
----------------------------------------
WordPress does not show a 404 when wpBasePage is saved in mixed-case (e.g. "CiviCRM") and renders CiviCRM content as expected.


