### PR TITLE
[NFC] Add in an Emoji test for APIv3 as per Eileen's PR

### DIFF
--- a/tests/phpunit/api/v3/ContactTest.php
+++ b/tests/phpunit/api/v3/ContactTest.php
@@ -4936,4 +4936,34 @@ class api_v3_ContactTest extends CiviUnitTestCase {
     return $this->callAPISuccessGetSingle('Contact', ['id' => $isReverse ? $this->ids['contact'][1] : $this->ids['contact'][0]]);
   }
 
+  /**
+   * Test a lack of fatal errors when the where contains an emoji.
+   *
+   * By default our DBs are not 🦉 compliant. This test will age
+   * out when we are.
+   *
+   * @throws \API_Exception
+   */
+  public function testEmojiInWhereClause(): void {
+    $schemaNeedsAlter = \CRM_Core_BAO_SchemaHandler::databaseSupportsUTF8MB4();
+    if ($schemaNeedsAlter) {
+      \CRM_Core_DAO::executeQuery("
+        ALTER TABLE civicrm_contact MODIFY COLUMN
+        `first_name` VARCHAR(64) CHARACTER SET utf8 COLLATE utf8_unicode_ci DEFAULT NULL COMMENT 'First Name.',
+        CHARSET utf8
+      ");
+    }
+    $this->callAPISuccess('Contact', 'get', [
+      'debug' => 1,
+      'first_name' => '🦉Claire',
+    ]);
+    if ($schemaNeedsAlter) {
+      \CRM_Core_DAO::executeQuery("
+        ALTER TABLE civicrm_contact MODIFY COLUMN
+        `first_name` VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT 'First Name.',
+        CHARSET utf8mb4
+      ");
+    }
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
This adds in a unit test as per https://github.com/civicrm/civicrm-core/pull/18918 but for APIv3 where as that only covered APIv4

Before
----------------------------------------
No Test

After
----------------------------------------
Test

ping @eileenmcnaughton 
