### PR TITLE
dev/core#1790: Add short delay before closing tooltip elements

### DIFF
--- a/js/Common.js
+++ b/js/Common.js
@@ -1048,6 +1048,8 @@ if (!CRM.vars) CRM.vars = {};
   };
 
   $.fn.crmtooltip = function () {
+    var TOOLTIP_HIDE_DELAY = 300;
+
     $(document)
       .on('mouseover', 'a.crm-summary-link:not(.crm-processed)', function (e) {
         $(this).addClass('crm-processed crm-tooltip-active');
@@ -1062,8 +1064,13 @@ if (!CRM.vars) CRM.vars = {};
             .load(this.href);
         }
       })
-      .on('mouseout', 'a.crm-summary-link', function () {
-        $(this).removeClass('crm-processed crm-tooltip-active crm-tooltip-down');
+      .on('mouseleave', 'a.crm-summary-link', function () {
+        var tooltipLink = $(this);
+        setTimeout(function () {
+          if (tooltipLink.filter(':hover').length === 0) {
+            tooltipLink.removeClass('crm-processed crm-tooltip-active crm-tooltip-down');
+          }
+        }, TOOLTIP_HIDE_DELAY);
       })
       .on('click', 'a.crm-summary-link', false);
   };


### PR DESCRIPTION
Overview
----------------------------------------
This PR prevents tooltips from closing as long as the user's mouse is inside of the tooltip element.

Before
----------------------------------------
![gif](https://user-images.githubusercontent.com/1642119/100681658-9e380500-334a-11eb-98f8-5882dd8298b6.gif)

After
----------------------------------------
![gif](https://user-images.githubusercontent.com/1642119/100681586-7183ed80-334a-11eb-9073-e4d6dcd94ab9.gif)

Technical Details
----------------------------------------

The `crmtooltip` function was updated so it only hides the tooltip after leaving the tooltip element, or after a `300ms` delay.

The tooltip was closing too soon because the `mouseout` event was being triggered for the triggering element only.

The new code works because `mouseleave` is triggered every time the mouse mouse leaves one of the tooltip's elements. Since the triggering element is a parent of the tooltip's contents it will also get this event because of bubbling. We use `tooltipLink.filter(':hover')` to determine if the `mouseleave` event was triggered, but the mouse is still not inside any of the tooltip's children. In this case the tooltip is closed as usual.