### PR TITLE
CIVICRM-1617: Only make line_item array if it doesn't exist already.

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -168,6 +168,16 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution {
       unset($params['revenue_recognition_date']);
     }
 
+    // Get Line Items if we don't have them already.
+    if (empty($params['line_item'])) {
+      if (isset($params['id'])) {
+        CRM_Price_BAO_LineItem::getLineItemArray($params, [$params['id']]);
+      }
+      else {
+        CRM_Price_BAO_LineItem::getLineItemArray($params);
+      }
+    }
+
     if (!isset($params['tax_amount']) && $setPrevContribution && (isset($params['total_amount']) ||
      isset($params['financial_type_id']))) {
       $params = CRM_Contribute_BAO_Contribution::checkTaxAmount($params);
@@ -4111,7 +4121,6 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
         // Assign tax Amount on update of contribution
         if (!empty($params['prevContribution']->tax_amount)) {
           $params['tax_amount'] = 'null';
-          CRM_Price_BAO_LineItem::getLineItemArray($params, [$params['id']]);
           foreach ($params['line_item'] as $setID => $priceField) {
             foreach ($priceField as $priceFieldID => $priceFieldValue) {
               $params['line_item'][$setID][$priceFieldID]['tax_amount'] = $params['tax_amount'];
@@ -4128,13 +4137,6 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
       $taxAmount = CRM_Contribute_BAO_Contribution_Utils::calculateTaxAmount(CRM_Utils_Array::value('total_amount', $params), $taxRateParams);
       $params['tax_amount'] = round($taxAmount['tax_amount'], 2);
 
-      // Get Line Item on update of contribution
-      if (isset($params['id'])) {
-        CRM_Price_BAO_LineItem::getLineItemArray($params, [$params['id']]);
-      }
-      else {
-        CRM_Price_BAO_LineItem::getLineItemArray($params);
-      }
       foreach ($params['line_item'] as $setID => $priceField) {
         foreach ($priceField as $priceFieldID => $priceFieldValue) {
           $params['line_item'][$setID][$priceFieldID]['tax_amount'] = $params['tax_amount'];


### PR DESCRIPTION
Overview
----------------------------------------
Fixes the issue described on [dev/financial#159](https://lab.civicrm.org/dev/financial/-/issues/159) where extra line items are added to recurring contributions (and possibly others) with tax enabled

Before
----------------------------------------
Repeating a recurring transaction from a quickconfig type contribution page on a tax-enabled financial type results in extra line items being added from the default price set for contributions. Possible this could happen in other situations too.
See [dev/financial#159](https://lab.civicrm.org/dev/financial/-/issues/159) for details of the setup required to trigger the bug.

After
----------------------------------------
Extra line items are no longer added in the described situation.

Technical Details
----------------------------------------
Make creation of the `line_item` array during Contribution adding contingent on it not already being present.  Additionally moves it outside of the `checkTaxAmount` callback as that should be able to assume a line item is present.