### PR TITLE
Fix fatal error on payment edit form

### DIFF
--- a/CRM/Financial/Form/PaymentEdit.php
+++ b/CRM/Financial/Form/PaymentEdit.php
@@ -67,11 +67,7 @@ class CRM_Financial_Form_PaymentEdit extends CRM_Core_Form {
    */
   public function setDefaultValues() {
     $defaults = $this->_values;
-    // Format money fields - localize for display
-    $moneyFields = ['total_amount', 'fee_amount', 'net_amount'];
-    foreach ($moneyFields as $field) {
-      $defaults[$field] = CRM_Utils_Money::formatLocaleNumericRoundedForDefaultCurrency($this->_values[$field]);
-    }
+    $defaults['total_amount'] = CRM_Utils_Money::formatLocaleNumericRoundedForDefaultCurrency($this->_values['total_amount']);
     return $defaults;
   }
 
@@ -195,7 +191,7 @@ class CRM_Financial_Form_PaymentEdit extends CRM_Core_Form {
       $previousFinanciaTrxn['contribution_id'] = $newFinancialTrxn['contribution_id'] = $this->_contributionID;
 
       $newFinancialTrxn['to_financial_account_id'] = CRM_Financial_BAO_FinancialTypeAccount::getInstrumentFinancialAccount($submittedValues['payment_instrument_id']);
-      foreach (['total_amount', 'fee_amount', 'net_amount', 'currency', 'is_payment', 'status_id'] as $fieldName) {
+      foreach (['total_amount', 'currency', 'is_payment', 'status_id'] as $fieldName) {
         $newFinancialTrxn[$fieldName] = $this->_values[$fieldName];
       }
 


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a fatal error when editing a payment

Before
----------------------------------------
fatal error / network error when editing a payment from here

![Screenshot from 2020-12-03 14-32-22](https://user-images.githubusercontent.com/336308/100951932-6b715500-3574-11eb-9253-29f92f1aaf6b.png)


After
----------------------------------------
works

Technical Details
----------------------------------------
For what looks like copy & paste reasons defaults are loaded for 2 fields that are not on the form -net_amount & fee_amount. The switch to brick money caused passing in NULL for these to result in fatal errors.

While a case could be made to add fee amount to the form this just adjusts the form to be correct for the fields already there

Comments
----------------------------------------
@seamuslee001 