### PR TITLE
dev/core#2228 Fix issue where by changing location type tries to pass…

### DIFF
--- a/ang/crmMailing/EditRecipOptionsDialogCtrl.html
+++ b/ang/crmMailing/EditRecipOptionsDialogCtrl.html
@@ -20,7 +20,7 @@
           >
           <option value="">{{:: ts('Automatic') }}</option>
           <option ng-repeat="locType in model.fields.location_type_id.options"
-                  ng-value="locType.key">{{locType.value}}</option>
+                  value="{{ locType.key }}">{{locType.value}}</option>
         </select>
       </div>
 
@@ -32,7 +32,7 @@
           ng-model="model.mailing.email_selection_method"
           >
           <option ng-repeat="selMet in model.fields.email_selection_method.options"
-                  ng-value="selMet.key">{{selMet.value}}</option>
+                  value="{{ selMet.key }}">{{selMet.value}}</option>
         </select>
       </div>
 

--- a/ang/crmMailingAB/BlockMailing.html
+++ b/ang/crmMailingAB/BlockMailing.html
@@ -26,7 +26,7 @@ processed by Angular; if false, the field will be hidden and completely ignored 
             ng-change="loadTemplate(abtest.mailings.a, abtest.mailings.a.msg_template_id)"
             >
             <option value=""></option>
-            <option ng-repeat="frm in crmMsgTemplates.getAll() | orderBy:'msg_title'" ng-value="frm.id">{{frm.msg_title}}</option>
+            <option ng-repeat="frm in crmMsgTemplates.getAll() | orderBy:'msg_title'" value="{{ frm.id }}">{{frm.msg_title}}</option>
           </select>
           <a crm-icon="fa-floppy-o" ng-click="saveTemplate(abtest.mailings.a)" class="crm-hover-button" title="{{:: ts('Save As') }}"></a>
         </div>
@@ -42,7 +42,7 @@ processed by Angular; if false, the field will be hidden and completely ignored 
             ng-change="loadTemplate(abtest.mailings.a, abtest.mailings.a.msg_template_id)"
             >
             <option value=""></option>
-            <option ng-repeat="frm in crmMsgTemplates.getAll() | orderBy:'msg_title'" ng-value="frm.id">{{frm.msg_title}}</option>
+            <option ng-repeat="frm in crmMsgTemplates.getAll() | orderBy:'msg_title'" value="{{ frm.id }}">{{frm.msg_title}}</option>
           </select>
           <a crm-icon="fa-floppy-o" ng-click="saveTemplate(abtest.mailings.a)" class="crm-hover-button" title="{{:: ts('Save As') }}"></a>
         </div>
@@ -58,7 +58,7 @@ processed by Angular; if false, the field will be hidden and completely ignored 
             ng-change="loadTemplate(abtest.mailings.b, abtest.mailings.b.msg_template_id)"
             >
             <option value=""></option>
-            <option ng-repeat="frm in crmMsgTemplates.getAll() | orderBy:'msg_title'" ng-value="frm.id">{{frm.msg_title}}</option>
+            <option ng-repeat="frm in crmMsgTemplates.getAll() | orderBy:'msg_title'" value="{{ frm.id }}">{{frm.msg_title}}</option>
           </select>
           <a crm-icon="fa-floppy-o" ng-click="saveTemplate(abtest.mailings.b)" class="crm-hover-button" title="{{:: ts('Save As') }}"></a>
         </div>

--- a/ang/crmMailingAB/ListCtrl.html
+++ b/ang/crmMailingAB/ListCtrl.html
@@ -13,13 +13,13 @@ Required vars: mailingABList
     <span>
       <select crm-ui-select style="width: 10em;" ng-model="filter.status">
         <option value="">{{:: ts('- Status -') }}</option>
-        <option ng-repeat="o in fields.status.options" ng-value="o.key">{{o.value}}</option>
+        <option ng-repeat="o in fields.status.options" value="{{o.key}}">{{o.value}}</option>
       </select>
     </span>
     <span>
       <select crm-ui-select style="width: 20em;" ng-model="filter.testing_criteria">
         <option value="">{{:: ts('- Test Type -') }}</option>
-        <option ng-repeat="o in fields.testing_criteria.options" ng-value="o.key">{{o.value}}</option>
+        <option ng-repeat="o in fields.testing_criteria.options" value="{{o.key}}">{{o.value}}</option>
       </select>
     </span>
   </form>


### PR DESCRIPTION
… in number:... in the API

Overview
----------------------------------------
This fixes the issue reported in the lab https://lab.civicrm.org/dev/core/-/issues/2228 where by when you go to change the location type selected to use for a mailing the mailing doesn't save due to an API error

Before
----------------------------------------
API Error on save

After
----------------------------------------
No API error on save

Technical Details
----------------------------------------
This seems to relate to the following change in AngularJS https://github.com/angular/angular.js/blob/master/CHANGELOG.md#select-due-to-1 which seems to only affect when ng-value is used, there is another place that this seems to be affected which is in api4 explorer but not sure if its directly affected

ping @agileware-justin @eileenmcnaughton @colemanw 