### PR TITLE
Issue#537: Fix syntax to check pcp_id is NULL in api params

### DIFF
--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -1483,7 +1483,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
 
     $isEmpty = array_keys(array_flip($submittedValues['soft_credit_contact_id']));
     if ($this->_id && count($isEmpty) == 1 && key($isEmpty) == NULL) {
-      civicrm_api3('ContributionSoft', 'get', ['contribution_id' => $this->_id, 'pcp_id' => NULL, 'api.ContributionSoft.delete' => 1]);
+      civicrm_api3('ContributionSoft', 'get', ['contribution_id' => $this->_id, 'pcp_id' => ['IS NULL' => 1], 'api.ContributionSoft.delete' => 1]);
     }
 
     // set the contact, when contact is selected


### PR DESCRIPTION
Overview
----------------------------------------
Owner notification email sending every time the contribution is resaved. When someone donates to a fundraising page, and then the site's staff member goes and edits the contribution that is related to the fundraising page, and saves the changes (even if there is no change just resaving the contribution) the fundraiser will receive the same email notification again.
Issue reported here: https://lab.civicrm.org/dev/core/-/issues/537

Before
----------------------------------------
Email notification was sent to pcp owner everytime a related contribution was resaved.

After
----------------------------------------
Prevented email notification from being sent everytime a related contribution is resaved. Email will be only be sent
1. When the contribution is made.
2. When `send receipt` checkbox is checked.

Technical Details
----------------------------------------
The syntax to check if `pcp_id` is `NULL` was wrong in the api call. 
Fixed it by replacing `'pcp_id' => NULL,` with `'pcp_id' => ['IS NULL' => 1]`
