### PR TITLE
dev/core#521: PCP Send notification after successful contribution payment

### DIFF
--- a/CRM/Contribute/BAO/ContributionSoft.php
+++ b/CRM/Contribute/BAO/ContributionSoft.php
@@ -607,8 +607,9 @@ class CRM_Contribute_BAO_ContributionSoft extends CRM_Contribute_DAO_Contributio
       $softParams['pcp_personal_note'] = $pcp['pcp_personal_note'] ?? NULL;
       $softParams['soft_credit_type_id'] = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_ContributionSoft', 'soft_credit_type_id', 'pcp');
       $contributionSoft = self::add($softParams);
-      //Send notification to owner for PCP
-      if ($contributionSoft->pcp_id && empty($pcpId)) {
+      // Send notification to owner for PCP.
+      $completedStatusID = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Completed');
+      if ($contributionSoft->pcp_id && empty($pcpId) && empty($contribution->contribution_page_id) && $contribution->contribution_status_id == $completedStatusID) {
         CRM_Contribute_Form_Contribution_Confirm::pcpNotifyOwner($contribution, (array) $contributionSoft);
       }
     }

--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -1395,7 +1395,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
    *
    * @param object $contribution
    * @param array $contributionSoft
-   *   Contribution object.
+   *   Contribution array.
    *
    * @throws \API_Exception
    * @throws \CRM_Core_Exception


### PR DESCRIPTION
Overview
----------------------------------------
Owner notification email sending before payment. When you are the owner of a fundraising page, you are supposed to receive a notification email after a successful donation has been made to your fundraising page. However when you are using a payment processor that navigates you out from civicrm to its own payment page (like sagepay, or paypal standard) the owner notification is sent before the payment has been made.
Core issue: https://lab.civicrm.org/dev/core/-/issues/521

Before
----------------------------------------
PCP Owner received notification for contribution before the payment was done.

After
----------------------------------------
PCP Owner receives notification only after successful contribution payment is done.

Technical Details
----------------------------------------
`CRM_Contribute_Form_Contribution_Confirm::pcpNotifyOwner` function will be called at two places now.
1. in `protected static function processPCP($pcp, $contribution)` for backend pcp contributions.
2. in  `public static function completeOrder` for contributions made by using PCP page.

