### PR TITLE
[REF] Duplicate possibly-used parts of createProfileContact onto Parser_Contact

### DIFF
--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -1690,7 +1690,51 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Contact_Import_Parser {
 
       // Resetting and rebuilding cache could be expensive.
       CRM_Core_Config::setPermitCacheFlushMode(FALSE);
-      $cid = CRM_Contact_BAO_Contact::createProfileContact($formatted, $contactFields, $contactId, NULL, NULL, $formatted['contact_type']);
+
+      // If a user has logged in, or accessed via a checksum
+      // Then deliberately 'blanking' a value in the profile should remove it from their record
+      // @todo this should either be TRUE or FALSE in the context of import - once
+      // we figure out which we can remove all the rest.
+      // Also note the meaning of this parameter is less than it used to
+      // be following block cleanup.
+      $formatted['updateBlankLocInfo'] = TRUE;
+      if ((CRM_Core_Session::singleton()->get('authSrc') & (CRM_Core_Permission::AUTH_SRC_CHECKSUM + CRM_Core_Permission::AUTH_SRC_LOGIN)) == 0) {
+        $formatted['updateBlankLocInfo'] = FALSE;
+      }
+
+      list($data, $contactDetails) = CRM_Contact_BAO_Contact::formatProfileContactParams($formatted, $contactFields, $contactId, NULL, $formatted['contact_type']);
+
+      // manage is_opt_out
+      if (array_key_exists('is_opt_out', $contactFields) && array_key_exists('is_opt_out', $formatted)) {
+        $wasOptOut = $contactDetails['is_opt_out'] ?? FALSE;
+        $isOptOut = $formatted['is_opt_out'];
+        $data['is_opt_out'] = $isOptOut;
+        // on change, create new civicrm_subscription_history entry
+        if (($wasOptOut != $isOptOut) && !empty($contactDetails['contact_id'])) {
+          $shParams = [
+            'contact_id' => $contactDetails['contact_id'],
+            'status' => $isOptOut ? 'Removed' : 'Added',
+            'method' => 'Web',
+          ];
+          CRM_Contact_BAO_SubscriptionHistory::create($shParams);
+        }
+      }
+
+      $contact = CRM_Contact_BAO_Contact::create($data);
+      $cid = $contact->id;
+
+      // Process group and tag
+      if (isset($formatted['group'])) {
+        $method = 'Admin';
+        CRM_Contact_BAO_GroupContact::create($formatted['group'], $cid, FALSE, $method);
+      }
+
+      if (!empty($fields['tag']) && array_key_exists('tag', $formatted)) {
+        // Convert comma separated form values from select2 v3
+        $tags = is_array($formatted['tag']) ? $formatted['tag'] : array_fill_keys(array_filter(explode(',', $formatted['tag'])), 1);
+        CRM_Core_BAO_EntityTag::create($tags, 'civicrm_contact', $cid);
+      }
+
       CRM_Core_Config::setPermitCacheFlushMode(TRUE);
 
       $contact = [


### PR DESCRIPTION
Overview
----------------------------------------
[REF] Duplicate possibly-used parts of createProfileContact onto Parser_Contact

Before
----------------------------------------
Lots of work done to call toxic function - very opaque

After
----------------------------------------
Possibly salient parts duplicated, facilitating more cleanup

Technical Details
----------------------------------------
The parser_Contact class should call the api. Getting to that point is
complicated because
1) it's such a mess and
2) it does a lot of work to prepare to call createProfileContact
and it's hard to unravel that.

By copying most of createProfileContact onto the class we can start to
unravel it & pare down to calling the api (note we went through
this process in the dedupe class, at least in part).

I'm pretty sure the hooks reflect 'the way the code grew up' rather than
any logical use/ requirement for the profile hook

Comments
----------------------------------------
