### PR TITLE
[REF] Deprecate passing a blank currecny to CRM_Utils_Money::format a…

### DIFF
--- a/CRM/Core/Error.php
+++ b/CRM/Core/Error.php
@@ -1039,7 +1039,15 @@ class CRM_Core_Error extends PEAR_ErrorStack {
       $callerClass = $dbt[1]['class'] ?? NULL;
       $oldMethod = "{$callerClass}::{$callerFunction}";
     }
-    Civi::log()->warning("Deprecated function $oldMethod, use $newMethod.", ['civi.tag' => 'deprecated']);
+    self::deprecatedWarning("Deprecated function $oldMethod, use $newMethod.");
+  }
+
+  /**
+   * Output a deprecated notice about a deprecated call path, rather than deprecating a whole function.
+   * @param string $message
+   */
+  public static function deprecatedWarning($message) {
+    Civi::log()->warning($message, ['civi.tag' => 'deprecated']);
   }
 
 }

--- a/CRM/Utils/Money.php
+++ b/CRM/Utils/Money.php
@@ -67,14 +67,15 @@ class CRM_Utils_Money {
     }
 
     if (!empty($valueFormat) && $valueFormat !== '%!i') {
-      CRM_Core_Error::deprecatedFunctionWarning('Having a Money Value format other than %!i is deprecated, please report this on the GitLab Issue https://lab.civicrm.org/dev/core/-/issues/1494 with the relevant moneyValueFormat you use.');
+      CRM_Core_Error::deprecatedWarning('Having a Money Value format other than %!i is deprecated, please report this on the GitLab Issue https://lab.civicrm.org/dev/core/-/issues/1494 with the relevant moneyValueFormat you use.');
+    }
+
+    if (!$currency) {
+      $currency = $config->defaultCurrency;
     }
 
     if ($onlyNumber) {
-      // money_format() exists only in certain PHP install (CRM-650)
-      if (is_numeric($amount) and function_exists('money_format')) {
-        $amount = money_format($valueFormat, $amount);
-      }
+      $amount = self::formatLocaleNumericRoundedByCurrency($amount, $currency);
       return $amount;
     }
 
@@ -85,14 +86,14 @@ class CRM_Utils_Money {
       ]);
     }
 
-    if (!$currency) {
-      $currency = $config->defaultCurrency;
-    }
-
     // ensure $currency is a valid currency code
     // for backwards-compatibility, also accept one space instead of a currency
     if ($currency != ' ' && !array_key_exists($currency, self::$_currencySymbols)) {
       throw new CRM_Core_Exception("Invalid currency \"{$currency}\"");
+    }
+
+    if ($currency === ' ') {
+      CRM_Core_Error::deprecatedWarning('Passing empty currency to CRM_Utils_Money::format is deprecated if you need it for display without currency call CRM_Utils_Money::formatLocaleNumericRounded');
     }
 
     $amount = self::formatNumericByFormat($amount, $valueFormat);
@@ -181,7 +182,7 @@ class CRM_Utils_Money {
    */
   protected static function formatLocaleNumeric($amount) {
     if (CRM_Core_Config::singleton()->moneyvalueformat !== '%!i') {
-      CRM_Core_Error::deprecatedFunctionWarning('Having a Money Value format other than !%i is deprecated, please report this on GitLab with the relevant moneyValueFormat you use.');
+      CRM_Core_Error::deprecatedWarning('Having a Money Value format other than !%i is deprecated, please report this on GitLab with the relevant moneyValueFormat you use.');
     }
     return self::formatNumericByFormat($amount, CRM_Core_Config::singleton()->moneyvalueformat);
   }

--- a/tests/phpunit/CRM/Utils/MoneyTest.php
+++ b/tests/phpunit/CRM/Utils/MoneyTest.php
@@ -105,13 +105,6 @@ class CRM_Utils_MoneyTest extends CiviUnitTestCase {
   }
 
   /**
-   * Test that using the space character as a currency works
-   */
-  public function testSpaceCurrency() {
-    $this->assertEquals('  8,950.37', CRM_Utils_Money::format(8950.37, ' '));
-  }
-
-  /**
    * Test that passing an invalid currency throws an error
    */
   public function testInvalidCurrency() {


### PR DESCRIPTION
…nd also update function call to remove at least one usage of money_format

Overview
----------------------------------------
This updates the call for when CRM_Utils_Money::format is passed with asking for just the number to use an appropriate internal money formatting function instead of the deprecated money_format function. It also deprecates passing in  ' ' a blank string as a param for $currency. 

Before
----------------------------------------
$currency = ' ' not deprecated and money_format used in at least 1 place

After
----------------------------------------
$currecny = ' ' deprecated and money_format only used in one place

ping @eileenmcnaughton @mattwire 