### PR TITLE
[REF] use early return for errors rather than confusing assignment

### DIFF
--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -1680,8 +1680,9 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Contact_Import_Parser {
     if ((is_null($error)) && (civicrm_error(_civicrm_api3_deprecated_validate_formatted_contact($formatted)))) {
       $error = _civicrm_api3_deprecated_validate_formatted_contact($formatted);
     }
-
-    $newContact = $error;
+    if (!is_null($error)) {
+      return $error;
+    }
 
     if (is_null($error)) {
       if ($contactId) {


### PR DESCRIPTION
Overview
----------------------------------------
[REF] use early return for errors rather than confusing assignment

Before
----------------------------------------
newContact set to = error & returned

After
----------------------------------------
error returned

Technical Details
----------------------------------------
This just makes the code slightly clearer. The next if can go, but
needs to wait on another PR to be merged to avoid conflict

Comments
----------------------------------------
