### PR TITLE
Unable to export contacts in Civi 5.32+

### DIFF
--- a/CRM/Export/BAO/ExportProcessor.php
+++ b/CRM/Export/BAO/ExportProcessor.php
@@ -797,7 +797,7 @@ class CRM_Export_BAO_ExportProcessor {
     list($select, $from, $where, $having) = $query->query();
     $this->setQueryFields($query->_fields);
     $whereClauses = ['trash_clause' => "contact_a.is_deleted != 1"];
-    if ($this->getRequestedFields() && ($this->getComponentTable())) {
+    if ($this->getRequestedFields() && $this->getComponentTable() &&  $this->getComponentTable() !== 'civicrm_contact') {
       $from .= " INNER JOIN " . $this->getComponentTable() . " ctTable ON ctTable.contact_id = contact_a.id ";
     }
     elseif ($this->getComponentClause()) {


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/2230

Before
----------------------------------------
DB Error when you try to export contacts without selecting "All Primary Fields"

After
----------------------------------------
Export works.

Technical Details
----------------------------------------
The issue is that `$this->getComponentTable()` returns `civicrm_contact`, and the rest of the SQL on the line I modified will never work.  But nothing's been changed in this file in months - so  `$this->getComponentTable()` must have previously returned a false value.

Comments
----------------------------------------
Coleman just now figured out why my buildkit site is failing, so I'm going to do a `git bisect` and see if I can find the root cause of this issue.
