### PR TITLE
Search Kit: Support robust joins in UI

### DIFF
--- a/ext/search/CRM/Search/Page/Admin.php
+++ b/ext/search/CRM/Search/Page/Admin.php
@@ -21,23 +21,6 @@ class CRM_Search_Page_Admin extends CRM_Core_Page {
     ];
     CRM_Utils_System::appendBreadCrumb([$breadCrumb]);
 
-    $schema = \Civi\Search\Admin::getSchema();
-
-    // If user does not have permission to search any entity, bye bye.
-    if (!$schema) {
-      CRM_Utils_System::permissionDenied();
-    }
-
-    // Add client-side vars for the search UI
-    $vars = [
-      'schema' => $schema,
-      'links' => \Civi\Search\Admin::getLinks(array_column($schema, 'name')),
-    ];
-
-    Civi::resources()
-      ->addBundle('bootstrap3')
-      ->addVars('search', $vars);
-
     // Load angular module
     $loader = new Civi\Angular\AngularLoader();
     $loader->setPageName('civicrm/admin/search');

--- a/ext/search/ang/crmSearchAdmin.ang.php
+++ b/ext/search/ang/crmSearchAdmin.ang.php
@@ -12,6 +12,7 @@ return [
   'partials' => [
     'ang/crmSearchAdmin',
   ],
+  'bundles' => ['bootstrap3'],
   'basePages' => ['civicrm/admin/search'],
   'requires' => ['crmUi', 'crmUtil', 'ngRoute', 'ui.sortable', 'ui.bootstrap', 'api4', 'crmSearchActions', 'crmSearchKit', 'crmRouteBinder'],
   'settingsFactory' => ['\Civi\Search\Admin', 'getAdminSettings'],

--- a/ext/search/ang/crmSearchAdmin/compose/criteria.html
+++ b/ext/search/ang/crmSearchAdmin/compose/criteria.html
@@ -8,7 +8,7 @@
           <select class="form-control" ng-model="join[1]" ng-options="o.k as o.v for o in ::joinTypes" ></select>
         </div>
         <fieldset class="api4-clause-fieldset">
-          <crm-search-clause clauses="join" format="json" skip="2" op="AND" label="{{ ts('If') }}" fields="fieldsForWhere" ></crm-search-clause>
+          <crm-search-clause clauses="join" format="json" skip="2 + getJoin(join[0]).conditions.length" op="AND" label="{{ ts('If') }}" fields="fieldsForWhere" ></crm-search-clause>
         </fieldset>
       </fieldset>
       <fieldset>

--- a/ext/search/ang/crmSearchAdmin/searchList.controller.js
+++ b/ext/search/ang/crmSearchAdmin/searchList.controller.js
@@ -5,7 +5,7 @@
     var ts = $scope.ts = CRM.ts(),
       ctrl = $scope.$ctrl = this;
     this.savedSearches = savedSearches;
-    this.entityTitles = _.transform(CRM.vars.search.schema, function(titles, entity) {
+    this.entityTitles = _.transform(CRM.crmSearchAdmin.schema, function(titles, entity) {
       titles[entity.name] = entity.title_plural;
     }, {});
 


### PR DESCRIPTION
Overview
----------------------------------------
Vastly improves support for joins in the Search Kit UI.

Before
----------------------------------------
Only a few joins supported, others appeared to work but would fail due to ambiguities in the multiple ways 2 entities can be joined.

After
----------------------------------------
This uses better join metadata to give explicit conditions for each join, removing the ambiguity when more than one type of join is possible between the same 2 entities.
It also adds support for joins via EntityBridge APIs.