### PR TITLE
Remove extraneous handling duplicated from createProfileContact

### DIFF
--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -1630,18 +1630,6 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Contact_Import_Parser {
     $contact = CRM_Contact_BAO_Contact::create($data);
     $cid = $contact->id;
 
-    // Process group and tag
-    if (isset($formatted['group'])) {
-      $method = 'Admin';
-      CRM_Contact_BAO_GroupContact::create($formatted['group'], $cid, FALSE, $method);
-    }
-
-    if (!empty($fields['tag']) && array_key_exists('tag', $formatted)) {
-      // Convert comma separated form values from select2 v3
-      $tags = is_array($formatted['tag']) ? $formatted['tag'] : array_fill_keys(array_filter(explode(',', $formatted['tag'])), 1);
-      CRM_Core_BAO_EntityTag::create($tags, 'civicrm_contact', $cid);
-    }
-
     CRM_Core_Config::setPermitCacheFlushMode(TRUE);
 
     $contact = [


### PR DESCRIPTION


Overview
----------------------------------------
Follow up cleanup on duplicating & removing call to createProfileContact

Before
----------------------------------------
calls copied in to handle tag & group creation

After
----------------------------------------
removed

Technical Details
----------------------------------------
I checked and tag and group are not available as import fields

While it's possible to add a contact to a group or tag them that is done elsewhere
- see
https://github.com/civicrm/civicrm-core/blob/0a66a182969ae3fde9f8e54308c4a35fa415685b/CRM/Contact/Import/ImportJob.php#L248

Comments
----------------------------------------
