### PR TITLE
APIv4 - Add "Permission.get" for listing available permissions

### DIFF
--- a/CRM/Core/Permission/Backdrop.php
+++ b/CRM/Core/Permission/Backdrop.php
@@ -101,6 +101,31 @@ class CRM_Core_Permission_Backdrop extends CRM_Core_Permission_DrupalBase {
   /**
    * @inheritDoc
    */
+  public function getAvailablePermissions() {
+    // We want to list *only* Backdrop perms, so we'll *skip* Civi perms.
+    $allCorePerms = \CRM_Core_Permission::basicPermissions(TRUE);
+
+    $permissions = [];
+    $modules = system_get_info('module');
+    foreach ($modules as $moduleName => $module) {
+      $prefix = isset($module['name']) ? ($module['name'] . ': ') : '';
+      foreach (module_invoke($moduleName, 'permission') as $permName => $perm) {
+        if (isset($allCorePerms[$permName])) {
+          continue;
+        }
+
+        $permissions["Drupal:$permName"] = [
+          'title' => $prefix . strip_tags($perm['title']),
+          'description' => $perm['description'] ?? NULL,
+        ];
+      }
+    }
+    return $permissions;
+  }
+
+  /**
+   * @inheritDoc
+   */
   public function isModulePermissionSupported() {
     return TRUE;
   }

--- a/CRM/Core/Permission/Base.php
+++ b/CRM/Core/Permission/Base.php
@@ -163,6 +163,26 @@ class CRM_Core_Permission_Base {
   }
 
   /**
+   * Get the palette of available permissions in the CMS's user-management system.
+   *
+   * @return array
+   *   List of permissions, keyed by symbolic name. Each item may have fields:
+   *     - title: string
+   *     - description: string
+   *
+   *   The permission-name should correspond to the Civi notation used by
+   *   'CRM_Core_Permission::check()'. For CMS-specific permissions, these are
+   *   translated names (eg "WordPress:list_users" or "Drupal:post comments").
+   *
+   *   The list should include *only* CMS permissions. Exclude Civi-native permissions.
+   *
+   * @see \CRM_Core_Permission_Base::translatePermission()
+   */
+  public function getAvailablePermissions() {
+    return [];
+  }
+
+  /**
    * Get all the contact emails for users that have a specific permission.
    *
    * @param string $permissionName

--- a/CRM/Core/Permission/Drupal.php
+++ b/CRM/Core/Permission/Drupal.php
@@ -100,6 +100,31 @@ class CRM_Core_Permission_Drupal extends CRM_Core_Permission_DrupalBase {
   /**
    * @inheritDoc
    */
+  public function getAvailablePermissions() {
+    // We want to list *only* Drupal perms, so we'll *skip* Civi perms.
+    $allCorePerms = \CRM_Core_Permission::basicPermissions(TRUE);
+
+    $permissions = [];
+    $modules = system_get_info('module');
+    foreach ($modules as $moduleName => $module) {
+      $prefix = isset($module['name']) ? ($module['name'] . ': ') : '';
+      foreach (module_invoke($moduleName, 'permission') as $permName => $perm) {
+        if (isset($allCorePerms[$permName])) {
+          continue;
+        }
+
+        $permissions["Drupal:$permName"] = [
+          'title' => $prefix . strip_tags($perm['title']),
+          'description' => $perm['description'] ?? NULL,
+        ];
+      }
+    }
+    return $permissions;
+  }
+
+  /**
+   * @inheritDoc
+   */
   public function isModulePermissionSupported() {
     return TRUE;
   }

--- a/CRM/Core/Permission/Drupal8.php
+++ b/CRM/Core/Permission/Drupal8.php
@@ -46,6 +46,38 @@ class CRM_Core_Permission_Drupal8 extends CRM_Core_Permission_DrupalBase {
   }
 
   /**
+   * Get the palette of available permissions in the CMS's user-management system.
+   *
+   * @return array
+   *   List of permissions, keyed by symbolic name. Each item may have fields:
+   *     - title: string
+   *     - description: string
+   */
+  public function getAvailablePermissions() {
+    // We want to list *only* Drupal perms, so we'll *skip* Civi perms.
+    $allCorePerms = \CRM_Core_Permission::basicPermissions(TRUE);
+
+    $dperms = \Drupal::service('user.permissions')->getPermissions();
+    $modules = system_get_info('module');
+
+    $permissions = [];
+    foreach ($dperms as $permName => $dperm) {
+      if (isset($allCorePerms[$permName])) {
+        continue;
+      }
+
+      $module = $modules[$dperm['provider']] ?? [];
+      $prefix = isset($module['name']) ? ($module['name'] . ': ') : '';
+      $permissions["Drupal:$permName"] = [
+        'title' => $prefix . strip_tags($dperm['title']),
+        'description' => $perm['description'] ?? NULL,
+      ];
+    }
+
+    return $permissions;
+  }
+
+  /**
    * Get all the contact emails for users that have a specific permission.
    *
    * @param string $permissionName

--- a/CRM/Core/Permission/List.php
+++ b/CRM/Core/Permission/List.php
@@ -1,0 +1,99 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+use Civi\Core\Event\GenericHookEvent;
+
+/**
+ * Class CRM_Core_Permission_List
+ *
+ * When presenting the administrator with a list of available permissions (`Permission.get`),
+ * the methods in provide the default implementations.
+ *
+ * These methods are not intended for public consumption or frequent execution.
+ *
+ * @see \Civi\Api4\Action\Permission\Get
+ */
+class CRM_Core_Permission_List {
+
+  /**
+   * Enumerate concrete permissions that originate in CiviCRM (core or extension).
+   *
+   * @param \Civi\Core\Event\GenericHookEvent $e
+   * @see \CRM_Utils_Hook::permissionList
+   */
+  public static function findCiviPermissions(GenericHookEvent $e) {
+    $activeCorePerms = \CRM_Core_Permission::basicPermissions(FALSE);
+    $allCorePerms = \CRM_Core_Permission::basicPermissions(TRUE, TRUE);
+    foreach ($allCorePerms as $permName => $corePerm) {
+      $e->permissions[$permName] = [
+        'group' => 'civicrm',
+        'title' => $corePerm['label'] ?? $corePerm[0] ?? $permName,
+        'description' => $corePerm['description'] ?? $corePerm[1] ?? NULL,
+        'is_active' => isset($activeCorePerms[$permName]),
+      ];
+    }
+  }
+
+  /**
+   * Enumerate permissions that originate in the CMS (core or module/plugin),
+   * excluding any Civi permissions.
+   *
+   * @param \Civi\Core\Event\GenericHookEvent $e
+   * @see \CRM_Utils_Hook::permissionList
+   */
+  public static function findCmsPermissions(GenericHookEvent $e) {
+    $config = \CRM_Core_Config::singleton();
+
+    $ufPerms = $config->userPermissionClass->getAvailablePermissions();
+    foreach ($ufPerms as $permName => $cmsPerm) {
+      $e->permissions[$permName] = [
+        'group' => 'cms',
+        'title' => $cmsPerm['title'] ?? $permName,
+        'description' => $cmsPerm['description'] ?? NULL,
+      ];
+    }
+
+    // There are a handful of special permissions defined in CRM/Core/Permission/*.php
+    // using the `translatePermission()` mechanism.
+    $e->permissions['cms:view user account'] = [
+      'group' => 'cms',
+      'title' => ts('CMS') . ': ' . ts('View user accounts'),
+      'description' => ts('View user accounts. (Synthetic permission - adapts to local CMS)'),
+      'is_synthetic' => TRUE,
+    ];
+    $e->permissions['cms:administer users'] = [
+      'group' => 'cms',
+      'title' => ts('CMS') . ': ' . ts('Administer user accounts'),
+      'description' => ts('Administer user accounts. (Synthetic permission - adapts to local CMS)'),
+      'is_synthetic' => TRUE,
+    ];
+  }
+
+  /**
+   * @param \Civi\Core\Event\GenericHookEvent $e
+   * @see \CRM_Utils_Hook::permissionList
+   */
+  public static function findConstPermissions(GenericHookEvent $e) {
+    // There are a handful of special permissions defined in CRM/Core/Permission.
+    $e->permissions[\CRM_Core_Permission::ALWAYS_DENY_PERMISSION] = [
+      'group' => 'const',
+      'title' => ts('Constant: Always deny'),
+      'is_synthetic' => TRUE,
+    ];
+    $e->permissions[\CRM_Core_Permission::ALWAYS_ALLOW_PERMISSION] = [
+      'group' => 'const',
+      'title' => ts('Constant: Always allow'),
+      'is_synthetic' => TRUE,
+    ];
+  }
+
+}

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -2000,7 +2000,7 @@ abstract class CRM_Utils_Hook {
   }
 
   /**
-   * This hook is called when loading CMS permissions; use this hook to modify
+   * This hook is called when exporting Civi's permission to the CMS. Use this hook to modify
    * the array of system permissions for CiviCRM.
    *
    * @param array $permissions
@@ -2014,6 +2014,31 @@ abstract class CRM_Utils_Hook {
     return self::singleton()->invoke(['permissions'], $permissions,
       self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
       'civicrm_permission'
+    );
+  }
+
+  /**
+   * This hook is used to enumerate the list of available permissions. It may
+   * include concrete permissions defined by Civi, concrete permissions defined
+   * by the CMS, and/or synthetic permissions.
+   *
+   * @param array $permissions
+   *   Array of permissions, keyed by symbolic name. Each is an array with fields:
+   *     - group: string (ex: "civicrm", "cms")
+   *     - title: string (ex: "CiviEvent: Register for events")
+   *     - description: string (ex: "Register for events online")
+   *     - is_synthetic: bool (TRUE for synthetic permissions with a bespoke evaluation. FALSE for concrete permissions that registered+granted in the UF user-management layer.
+   *        Default TRUE iff name begins with '@')
+   *     - is_active: bool (TRUE if this permission is defined by. Default: TRUE)
+   *
+   * @return null
+   *   The return value is ignored
+   * @see Civi\Api4\Permission::get()
+   */
+  public static function permissionList(&$permissions) {
+    return self::singleton()->invoke(['permissions'], $permissions,
+      self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      'civicrm_permissionList'
     );
   }
 

--- a/Civi/Api4/Action/Permission/Get.php
+++ b/Civi/Api4/Action/Permission/Get.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Action\Permission;
+
+use Civi\Api4\Generic\BasicGetAction;
+
+/**
+ * Get a list of extant permissions.
+ *
+ * NOTE: This is a high-level API intended for introspective use by administrative tools.
+ * It may be poorly suited to recursive usage (e.g. permissions defined dynamically
+ * on top of permissions!) or during install/uninstall processes.
+ *
+ * The list of permissions is generated via hook, and there is a standard/default
+ * listener.
+ *
+ * @see CRM_Core_Permission_List
+ * @see \CRM_Utils_Hook::permissionList
+ */
+class Get extends BasicGetAction {
+
+  public function getRecords() {
+    $cacheKey = 'list_' . $GLOBALS['tsLocale'];
+    if (!isset(\Civi::$statics[__CLASS__][$cacheKey])) {
+      $perms = [];
+      \CRM_Utils_Hook::permissionList($perms);
+      foreach (array_keys($perms) as $permName) {
+        $defaults = [
+          'name' => $permName,
+          'group' => 'unknown',
+          'is_synthetic' => ($permName[0] === '@'),
+          'is_active' => TRUE,
+        ];
+        $perms[$permName] = array_merge($defaults, $perms[$permName]);
+      }
+      \Civi::$statics[__CLASS__][$cacheKey] = $perms;
+    }
+
+    return \Civi::$statics[__CLASS__][$cacheKey];
+  }
+
+}

--- a/Civi/Api4/Permission.php
+++ b/Civi/Api4/Permission.php
@@ -1,0 +1,100 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+namespace Civi\Api4;
+
+/**
+ * (Read-only) Available permissions
+ *
+ * NOTE: This is a high-level API intended for introspective use by administrative tools.
+ * It may be poorly suited to recursive usage (e.g. permissions defined dynamically
+ * on top of permissions!) or during install/uninstall processes.
+ *
+ * @searchable false
+ * @package Civi\Api4
+ */
+class Permission extends Generic\AbstractEntity {
+
+  /**
+   * @param bool $checkPermissions
+   * @return \Civi\Api4\Generic\BasicGetAction
+   */
+  public static function get($checkPermissions = TRUE) {
+    return (new \Civi\Api4\Action\Permission\Get(__CLASS__, __FUNCTION__))->setCheckPermissions($checkPermissions);
+  }
+
+  /**
+   * @param bool $checkPermissions
+   * @return Generic\BasicGetFieldsAction
+   */
+  public static function getFields($checkPermissions = TRUE) {
+    return (new Generic\BasicGetFieldsAction(__CLASS__, __FUNCTION__, function() {
+      return [
+        [
+          'name' => 'group',
+          'title' => 'Group',
+          'required' => TRUE,
+          'data_type' => 'String',
+        ],
+        [
+          'name' => 'name',
+          'title' => 'Name',
+          'required' => TRUE,
+          'data_type' => 'String',
+        ],
+        [
+          'name' => 'title',
+          'title' => 'Title',
+          'required' => TRUE,
+          'data_type' => 'String',
+        ],
+        [
+          'name' => 'description',
+          'title' => 'Description',
+          'required' => FALSE,
+          'data_type' => 'String',
+        ],
+        [
+          'name' => 'is_synthetic',
+          'title' => 'Is Synthetic',
+          'required' => FALSE,
+          'data_type' => 'Boolean',
+        ],
+        [
+          'name' => 'is_active',
+          'title' => 'Is Active',
+          'description' => '',
+          'default' => TRUE,
+          'required' => FALSE,
+          'data_type' => 'Boolean',
+        ],
+      ];
+    }))->setCheckPermissions($checkPermissions);
+  }
+
+  /**
+   * @return array
+   */
+  public static function permissions() {
+    return [
+      "meta" => ["access CiviCRM"],
+      "default" => ["access CiviCRM"],
+    ];
+  }
+
+}

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -366,6 +366,10 @@ class Container {
     $dispatcher->addListener('hook_civicrm_coreResourceList', ['\CRM_Utils_System', 'appendCoreResources']);
     $dispatcher->addListener('hook_civicrm_getAssetUrl', ['\CRM_Utils_System', 'alterAssetUrl']);
     $dispatcher->addListener('hook_civicrm_alterExternUrl', ['\CRM_Utils_System', 'migrateExternUrl'], 1000);
+    $dispatcher->addListener('hook_civicrm_permissionList', ['CRM_Core_Permission_List', 'findConstPermissions'], 975);
+    $dispatcher->addListener('hook_civicrm_permissionList', ['CRM_Core_Permission_List', 'findCiviPermissions'], 950);
+    $dispatcher->addListener('hook_civicrm_permissionList', ['CRM_Core_Permission_List', 'findCmsPermissions'], 925);
+
     $dispatcher->addListener('hook_civicrm_triggerInfo', ['\CRM_Contact_BAO_RelationshipCache', 'onHookTriggerInfo']);
     $dispatcher->addListener('civi.dao.postInsert', ['\CRM_Core_BAO_RecurringEntity', 'triggerInsert']);
     $dispatcher->addListener('civi.dao.postUpdate', ['\CRM_Core_BAO_RecurringEntity', 'triggerUpdate']);

--- a/ext/afform/core/afform.php
+++ b/ext/afform/core/afform.php
@@ -543,6 +543,23 @@ function afform_civicrm_permission_check($permission, &$granted, $contactId) {
 }
 
 /**
+ * Implements hook_civicrm_permissionList().
+ *
+ * @see CRM_Utils_Hook::permissionList()
+ */
+function afform_civicrm_permissionList(&$permissions) {
+  $scanner = Civi::service('afform_scanner');
+  foreach ($scanner->getMetas() as $name => $meta) {
+    $permissions['@afform:' . $name] = [
+      'group' => 'afform',
+      'title' => ts('Afform: Inherit permission of %1', [
+        1 => $name,
+      ]),
+    ];
+  }
+}
+
+/**
  * Clear any local/in-memory caches based on afform data.
  */
 function _afform_clear() {

--- a/tests/phpunit/E2E/Api4/PermissionTest.php
+++ b/tests/phpunit/E2E/Api4/PermissionTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace E2E\Api4;
+
+/**
+ * Class PermissionTest
+ * @package E2E\Api4
+ * @group e2e
+ */
+class PermissionTest extends \CiviEndToEndTestCase {
+
+  /**
+   * The "Permission.get" API provides a combined list of permissions, including
+   * Civi and CMS permissions. The underlying implementations are split among
+   * different CMS integrations.
+   *
+   * This is a general sanity-check/well-formed-ness
+   */
+  public function testGet() {
+    // If the CMS integration is working,t hen you should expect one of these "smoke-test" permissions to be present.
+    $smokeTest = [
+      'Backdrop' => 'Drupal:post comments',
+      'Drupal' => 'Drupal:post comments',
+      'Drupal8' => 'Drupal:post comments',
+      'WordPress' => 'WordPress:list_users',
+    ];
+
+    $perms = \civicrm_api4('Permission', 'get')->indexBy('name');
+    $this->assertTrue(isset($perms['administer CiviCRM']));
+
+    $isOptionalString = function($arr, $key) {
+      return !array_key_exists($key, $arr)
+        || is_string($arr[$key])
+        || $arr[$key] === NULL;
+    };
+
+    foreach ($perms as $permName => $perm) {
+      $ser = json_encode($perm, JSON_UNESCAPED_SLASHES);
+      $this->assertTrue(is_string($permName), 'Permission name should be a string');
+      $this->assertTrue($isOptionalString($perm, 'title'), "Permission \"$permName\" should have string \"title\" ($ser)");
+      $this->assertTrue($isOptionalString($perm, 'description'), "Permission \"$permName\" should have string \"description\" ($ser)");
+      $this->assertTrue($isOptionalString($perm, 'group'), "Permission \"$permName\" should have string \"group\" ($ser)");
+      $this->assertTrue(is_bool($perm['is_active']), "Permission \"$permName\" should have boolean \"is_active\" ($ser)");
+      $this->assertTrue(is_bool($perm['is_synthetic']), "Permission \"$permName\" should have boolean \"is_synthetic\" ($ser)");
+    }
+
+    $groups = array_unique(\CRM_Utils_Array::collect('group', $perms->getArrayCopy()));
+    $this->assertTrue(in_array('civicrm', $groups), 'There should be at least one permission in the "civicrm" group.');
+    $this->assertTrue(in_array('cms', $groups), 'There should be at least one permission in the "cms" group.');
+    $this->assertTrue(in_array('const', $groups), 'There should be at least one permission in the "const" group.');
+
+    if (isset($smokeTest[CIVICRM_UF])) {
+      $smokeTestPerm = $smokeTest[CIVICRM_UF];
+      $this->assertTrue(isset($perms[$smokeTestPerm]));
+      $this->assertTrue(is_bool($perm['is_active']), "Smoke-test permission \"$smokeTestPerm\" should have boolean \"is_active\"");
+    }
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
This adds a new API method "Permission.get". This is a better building-block for administrative tools that allow one to choose/assign a permission.

Before
----------------------------------------

* There is a method `CRM_Core_Permission::basicPermissions()` which lists concrete permissions defined by CiviCRM (built-in as well as `hook_civicrm_permission`). 
* There are a number of additional permissions notations that cannot be discovered, including:
    * Constant permissions (e.g. `*always allow*`, `*always deny*`)
    * CMS-specific permissions (e.g. `Drupal:post comment`, `WordPress:list_users`)
    * Synthetic permissions which are mapped to different CMS equivalents (e.g. `cms:view user account`)
    * Synthetic permissions defined via extension (e.g. `@afform:<form-name>`)

After
----------------------------------------

The APIv4 method `Permission.get` provides a full accounting of all available permissions. It also supports sorting, filtering, etc.

<img width="1178" alt="Screen Shot 2020-12-03 at 11 45 03 PM" src="https://user-images.githubusercontent.com/1336047/101136063-9766f780-35c1-11eb-9fc3-0e32f697f5e5.png">

This captures permissions from all the sources referenced above, eg

* CiviCRM permissions (built-in as well as `hook_civicrm_permission`)
* Constant permissions (e.g. `*always allow*`, `*always deny*`)
* CMS-specific permissions (e.g. `Drupal:post comment`, `WordPress:list_users`)
* Synthetic permissions which are mapped to different CMS equivalents (e.g. `cms:view user account`)
* Synthetic permissions defined via extension (e.g. `@afform:<form-name>`)

For the last case (*synthetic permissions defined via extension*), one must implement `hook_civicrm_permissionList`. There's an example in `afform.php`:

```php
function afform_civicrm_permissionList(&$permissions) {
  $scanner = Civi::service('afform_scanner');
  foreach ($scanner->getMetas() as $name => $meta) {
    $permissions['@afform:' . $name] = [
      'group' => 'afform',
      'title' => ts('Afform: Inherit permission of %1', [
        1 => $name,
      ]),
    ];
  }
}
```

Comments
----------------------------------------

* This patch does not add, remove, or rename any specific permissions - it makes it easier to discover existing permissions.
* The UF layer didn't have a mechanism to enumerate the CMS-specific permissions. So...
    * I added support for Backdrop, Drupal 7, Drupal 8(+9?), and WordPress. Tested locally.
    * For Joomla, it won't list CMS-specific permissions. (I don't have a sane setup for patching Joomla.) But all the other permissions (constant & synthetic) should work.
* The unit-test is written as end-to-end. This allows it to provide some coverage for the CMS-specific bits.
