### PR TITLE
Fix Payment edit form to use Payment.cancel & payment.create api

### DIFF
--- a/api/v3/Payment.php
+++ b/api/v3/Payment.php
@@ -94,6 +94,7 @@ function civicrm_api3_payment_cancel($params) {
   $eftParams = [
     'entity_table' => 'civicrm_contribution',
     'financial_trxn_id' => $params['id'],
+    'return' => ['entity', 'amount', 'entity_id', 'financial_trxn_id.check_number'],
   ];
   $entity = civicrm_api3('EntityFinancialTrxn', 'getsingle', $eftParams);
 
@@ -102,6 +103,7 @@ function civicrm_api3_payment_cancel($params) {
     'contribution_id' => $entity['entity_id'],
     'trxn_date' => $params['trxn_date'] ?? 'now',
     'cancelled_payment_id' => $params['id'],
+    'check_number' => $entity['financial_trxn_id.check_number'] ?? NULL,
   ];
 
   foreach (['trxn_id', 'payment_instrument_id'] as $permittedParam) {

--- a/tests/phpunit/CRM/Financial/Form/PaymentEditTest.php
+++ b/tests/phpunit/CRM/Financial/Form/PaymentEditTest.php
@@ -28,6 +28,8 @@ class CRM_Financial_Form_PaymentEditTest extends CiviUnitTestCase {
 
   /**
    * Clean up after each test.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function tearDown() {
     $this->quickCleanUpFinancialEntities();
@@ -36,8 +38,12 @@ class CRM_Financial_Form_PaymentEditTest extends CiviUnitTestCase {
 
   /**
    * Test the submit function of payment edit form.
+   *
+   * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
+   * @throws \Civi\Payment\Exception\PaymentProcessorException
    */
-  public function testSubmitOnPaymentInstrumentChange() {
+  public function testSubmitOnPaymentInstrumentChange(): void {
     // First create a contribution using 'Check' as payment instrument
     $form = new CRM_Contribute_Form_Contribution();
     $form->testSubmit([
@@ -61,7 +67,7 @@ class CRM_Financial_Form_PaymentEditTest extends CiviUnitTestCase {
       'payment_instrument_id' => CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'payment_instrument_id', 'Credit Card'),
       'card_type_id' => CRM_Core_PseudoConstant::getKey('CRM_Financial_DAO_FinancialTrxn', 'card_type_id', 'Visa'),
       'pan_truncation' => 1111,
-      'trnx_id' => 'txn_12AAAA',
+      'trxn_id' => 'txn_12AAAA',
       'trxn_date' => date('Y-m-d H:i:s'),
       'contribution_id' => $contribution['id'],
     ];
@@ -81,7 +87,7 @@ class CRM_Financial_Form_PaymentEditTest extends CiviUnitTestCase {
         'total_amount' => -50.00,
         'financial_type' => 'Donation',
         'payment_instrument' => 'Check',
-        'status' => 'Completed',
+        'status' => 'Refunded Label**',
         'receive_date' => $params['trxn_date'],
         'check_number' => '123XA',
       ],


### PR DESCRIPTION
Overview
----------------------------------------
Fix Payment edit form to use Payment.cancel & payment.create api

Before
----------------------------------------
Form uses it's own special sauce to cancel the payment & create a new one

After
----------------------------------------
Form uses api.

Technical Details
----------------------------------------
The form retains the check_number on the cancelled payment - that seemed sensible so I updated payment api to do that 

Comments
----------------------------------------
