### PR TITLE
CiviEvent - Error registering through advanced search task

### DIFF
--- a/templates/CRM/Event/Form/Task/Register.tpl
+++ b/templates/CRM/Event/Form/Task/Register.tpl
@@ -1,0 +1,10 @@
+{*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+*}
+{include file="CRM/Event/Form/Participant.tpl"}


### PR DESCRIPTION
Overview
----------------------------------------
This aims to fix smarty fatal error on using a search-task to register contacts for an event. Steps to reproduce:

* Perform an advanced search
* Select one or more contacts
* Choose the register contacts to an event search task

Before
----------------------------------------
Form does not display. There's a Smarty error.

After
----------------------------------------
Form displays. No error.

ping @eileenmcnaughton @petednz