### PR TITLE
dev/core#2231 - Fix failure to calculate next_scheduled_date

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -210,7 +210,7 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution {
       CRM_Contribute_BAO_ContributionRecur::updateOnNewPayment(
         (!empty($params['contribution_recur_id']) ? $params['contribution_recur_id'] : $params['prevContribution']->contribution_recur_id),
         $contributionStatus,
-        $params['receive_date'] ?? NULL
+        $params['receive_date'] ?? 'now'
       );
     }
 

--- a/CRM/Contribute/BAO/ContributionRecur.php
+++ b/CRM/Contribute/BAO/ContributionRecur.php
@@ -840,7 +840,7 @@ INNER JOIN civicrm_contribution       con ON ( con.id = mp.contribution_id )
    *
    * @throws \CiviCRM_API3_Exception
    */
-  public static function updateOnNewPayment($recurringContributionID, $paymentStatus, $effectiveDate) {
+  public static function updateOnNewPayment($recurringContributionID, $paymentStatus, string $effectiveDate = 'now') {
 
     if (!in_array($paymentStatus, ['Completed', 'Failed'])) {
       return;


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a bug where the completeOrder flow was not setting the next scheduled date on recurrings. This is important for processors who rely on that date for billing ie
- IATS (confirmed affected)
- Omnipay (unconfirmed, likely)
- Stripe (unconfirmed, less likely)
- Eway (unconfirmed, less likely)

This bug affects recurring contribution series initiated on civicrm 5.29 or later

Before
----------------------------------------
0 (1970-00-00) stored as the next scheduled contribution date - confirmed in back office recurring data entry + add Payment flow

After
----------------------------------------
correct date calculated.

Technical Details
----------------------------------------
Regression arose from a reviewer's commit where I tried to meld 2 prs together but git-fu-d a line in from 1 that should not have been included.  It resulted in no date being calculated when receive_date is unset - this is in the completeOrder flow. I have since put a test against master that would have prevented this

Comments
----------------------------------------
