### PR TITLE
Handle possibility of fee_amount = ''

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -343,7 +343,7 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution {
    * @throws \CiviCRM_API3_Exception
    */
   public static function calculateMissingAmountParams(&$params, $contributionID) {
-    if (!$contributionID && !isset($params['fee_amount'])) {
+    if (!$contributionID && (!isset($params['fee_amount']) || $params['fee_amount'] === '')) {
       if (isset($params['total_amount']) && isset($params['net_amount'])) {
         $params['fee_amount'] = $params['total_amount'] - $params['net_amount'];
       }


### PR DESCRIPTION
Overview
----------------------------------------

This patch responds a [report from edgimar on Mattermost (WordPress)](https://chat.civicrm.org/civicrm/pl/39cd33je43yqx879ghj4uyru5w):

> ```
> Warning: A non-numeric value encountered in /home/mywebsite.com/wp-content/plugins/civicrm/civicrm/CRM/Contribute. /BAO/Contribution.php on line 356"
>
> Warning: Cannot modify header information - headers already sent by 
>(output started at /home/mywebsite.com/wp-content/plugins/civicrm/civicrm/CRM/Contribute/BAO/Contribution.php:356)
> in /home/mywebsite.com/wp-content/plugins/civicrm/civicrm/CRM/Utils/System/Base.php on line 948"
> ```
>
> These messages just show up on an empty white webpage after pressing submit.

The error appears to involve processing a contribution with `fee_amount=''` (empty-string). We cannot reproduce this circumstance organically. The fix is based on the assumption that it's happening *somehow*.

Before
----------------------------------------
An empty string is invalid for fee amount, leading to a fatal error.

After
----------------------------------------
The empty string is cast to 0.