### PR TITLE
dev/core#2188 - Upgrader - Cleanup any invalid combinations of is_search_range

### DIFF
--- a/CRM/Upgrade/Incremental/sql/5.33.beta2.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.33.beta2.mysql.tpl
@@ -1,1 +1,4 @@
 {* file to handle db changes in 5.33.beta2 during upgrade *}
+
+{* dev/core#2188, dev/core#337 (redux) - Ranges aren't support on these widgets. Note: This same change ran previously in 5.9.beta and contemporaneously in 5.32.1, and that's OK. *}
+UPDATE civicrm_custom_field SET is_search_range = 0 WHERE html_type IN ('Radio', 'Select') AND data_type IN ('Money', 'Float', 'Int');

--- a/CRM/Upgrade/Incremental/sql/5.33.beta2.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.33.beta2.mysql.tpl
@@ -1,0 +1,1 @@
+{* file to handle db changes in 5.33.beta2 during upgrade *}

--- a/sql/civicrm_generated.mysql
+++ b/sql/civicrm_generated.mysql
@@ -399,7 +399,7 @@ UNLOCK TABLES;
 
 LOCK TABLES `civicrm_domain` WRITE;
 /*!40000 ALTER TABLE `civicrm_domain` DISABLE KEYS */;
-INSERT INTO `civicrm_domain` (`id`, `name`, `description`, `version`, `contact_id`, `locales`, `locale_custom_strings`) VALUES (1,'Default Domain Name',NULL,'5.33.beta1',1,NULL,'a:1:{s:5:\"en_US\";a:0:{}}');
+INSERT INTO `civicrm_domain` (`id`, `name`, `description`, `version`, `contact_id`, `locales`, `locale_custom_strings`) VALUES (1,'Default Domain Name',NULL,'5.33.beta2',1,NULL,'a:1:{s:5:\"en_US\";a:0:{}}');
 /*!40000 ALTER TABLE `civicrm_domain` ENABLE KEYS */;
 UNLOCK TABLES;
 

--- a/sql/test_data_second_domain.mysql
+++ b/sql/test_data_second_domain.mysql
@@ -963,4 +963,4 @@ INSERT INTO civicrm_navigation
 VALUES
     ( @domainID, CONCAT('civicrm/report/instance/', @instanceID,'&reset=1'), 'Mailing Detail Report', 'Mailing Detail Report', 'administer CiviMail', 'OR', @reportlastID, '1', NULL, @instanceID+2 );
 UPDATE civicrm_report_instance SET navigation_id = LAST_INSERT_ID() WHERE id = @instanceID;
-UPDATE civicrm_domain SET version = '5.33.beta1';
+UPDATE civicrm_domain SET version = '5.33.beta2';

--- a/xml/version.xml
+++ b/xml/version.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="iso-8859-1" ?>
 <version>
-  <version_no>5.33.beta1</version_no>
+  <version_no>5.33.beta2</version_no>
 </version>


### PR DESCRIPTION
Overview
----------------------------------------

Certain custom-field configurations are not sensible - notably, `#11` below:

```
+----+-----------+-----------+---------------+-----------------+--------------+
| id | data_type | html_type | is_searchable | is_search_range | comment      |
+----+-----------+-----------+---------------+-----------------+--------------+
| 00 | Int       | Radio     |             0 |               0 | Sensible     |
| 10 | Int       | Radio     |             1 |               0 | Sensible     |
| 11 | Int       | Radio     |             1 |               1 | Not sensible |
+----+-----------+-----------+---------------+-----------------+--------------+
```

In 5.30, the search screen was forgiving about these - but in 5.31+, it became unforgiving.

The previous fix (#18970) prevents creation of new fields in configuration `#11`. However, existing fields would still be problematic.

Before
----------------------------------------

Upgraders retain problematic configurations, which become symptomatic in newer versions.

After
----------------------------------------

Upgraders get valid configurations.
