### PR TITLE
CiviEvent - Error registering participants via search task

### DIFF
--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -367,6 +367,9 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
 
     // when fee amount is included in form
     if (!empty($_POST['hidden_feeblock']) || !empty($_POST['send_receipt'])) {
+      if ($this->_submitValues['event_id']) {
+        $this->_eventId = $this->_submitValues['event_id'];
+      }
       CRM_Event_Form_EventFees::preProcess($this);
       $this->buildEventFeeForm($this);
       CRM_Event_Form_EventFees::setDefaultValues($this);

--- a/CRM/Event/Form/Task/Register.php
+++ b/CRM/Event/Form/Task/Register.php
@@ -71,7 +71,7 @@ class CRM_Event_Form_Task_Register extends CRM_Event_Form_Participant {
     $this->_contactId = NULL;
 
     //set ajax path, this used for custom data building
-    $this->assign('urlPath', $urlString);
+    $this->assign('urlPath', 'civicrm/contact/view/participant');
     $this->assign('urlPathVar', "_qf_Participant_display=true&qfKey={$this->controller->_key}");
   }
 

--- a/CRM/Event/Form/Task/Register.php
+++ b/CRM/Event/Form/Task/Register.php
@@ -72,7 +72,11 @@ class CRM_Event_Form_Task_Register extends CRM_Event_Form_Participant {
 
     //set ajax path, this used for custom data building
     $this->assign('urlPath', 'civicrm/contact/view/participant');
-    $this->assign('urlPathVar', "_qf_Participant_display=true&qfKey={$this->controller->_key}");
+
+    $key = CRM_Core_Key::get('CRM_Event_Form_Participant', TRUE);
+    $this->assign('participantQfKey', $key);
+    $this->assign('participantAction', CRM_Core_Action::ADD);
+    $this->assign('urlPathVar', "_qf_Participant_display=true");
   }
 
 }

--- a/CRM/Event/Form/Task/Register.php
+++ b/CRM/Event/Form/Task/Register.php
@@ -76,7 +76,7 @@ class CRM_Event_Form_Task_Register extends CRM_Event_Form_Participant {
     $key = CRM_Core_Key::get('CRM_Event_Form_Participant', TRUE);
     $this->assign('participantQfKey', $key);
     $this->assign('participantAction', CRM_Core_Action::ADD);
-    $this->assign('urlPathVar', "_qf_Participant_display=true");
+    $this->assign('urlPathVar', "_qf_Participant_display=true&context=search");
   }
 
 }

--- a/CRM/Event/Page/Tab.php
+++ b/CRM/Event/Page/Tab.php
@@ -90,7 +90,7 @@ class CRM_Event_Page_Tab extends CRM_Core_Page {
     $controller = new CRM_Core_Controller_Simple(
       'CRM_Event_Form_Participant',
       'Create Participation',
-      $this->_action
+      $this->_action, FALSE, FALSE, TRUE
     );
 
     $controller->setEmbedded(TRUE);
@@ -122,7 +122,7 @@ class CRM_Event_Page_Tab extends CRM_Core_Page {
       $this->_action = CRM_Core_Action::ADD;
     }
     else {
-      $this->_contactId = CRM_Utils_Request::retrieve('cid', 'Positive', $this, TRUE);
+      $this->_contactId = CRM_Utils_Request::retrieve('cid', 'Positive', $this);
       $this->assign('contactId', $this->_contactId);
 
       // check logged in url permission

--- a/CRM/Event/Page/Tab.php
+++ b/CRM/Event/Page/Tab.php
@@ -118,7 +118,7 @@ class CRM_Event_Page_Tab extends CRM_Core_Page {
     $this->_action = CRM_Utils_Request::retrieve('action', 'String', $this, FALSE, 'browse');
     $this->_id = CRM_Utils_Request::retrieve('id', 'Positive', $this);
 
-    if ($context == 'standalone') {
+    if ($context == 'standalone' || $context === 'search') {
       $this->_action = CRM_Core_Action::ADD;
     }
     else {

--- a/CRM/Event/Page/Tab.php
+++ b/CRM/Event/Page/Tab.php
@@ -90,7 +90,7 @@ class CRM_Event_Page_Tab extends CRM_Core_Page {
     $controller = new CRM_Core_Controller_Simple(
       'CRM_Event_Form_Participant',
       'Create Participation',
-      $this->_action, FALSE, FALSE, TRUE
+      $this->_action
     );
 
     $controller->setEmbedded(TRUE);

--- a/templates/CRM/Event/Form/Task/Register.tpl
+++ b/templates/CRM/Event/Form/Task/Register.tpl
@@ -1,0 +1,10 @@
+{*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+*}
+{include file="CRM/Event/Form/Participant.tpl"}

--- a/templates/CRM/Event/Form/Task/Register.tpl
+++ b/templates/CRM/Event/Form/Task/Register.tpl
@@ -7,4 +7,6 @@
  | and copyright information, see https://civicrm.org/licensing       |
  +--------------------------------------------------------------------+
 *}
-{include file="CRM/Event/Form/Participant.tpl"}
+{crmScope qfKey=$participantQfKey action=$participantAction}
+  {include file="CRM/Event/Form/Participant.tpl"}
+{/crmScope}


### PR DESCRIPTION
Overview
----------------------------------------
This aims to fix smarty fatal error on using a search-task to register contacts for an event. Steps to reproduce:

* Perform an advanced search
* Select one or more contacts
* Choose the register contacts to an event search task

Before
----------------------------------------
Form does not display. There's a Smarty error.

After
----------------------------------------
Form displays. No error.

Comment
----------------------------------------
This is an expansion on the prior draft #19118. It is working for me but I think warrants a better fix in master (separate the forms)

