### PR TITLE
Allow Sendconfirmation api to override pay later receipt text

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2839,7 +2839,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
     //not really sure what params might be passed in but lets merge em into values
     $values = array_merge($this->_gatherMessageValues($input, $values, $ids), $values);
     $values['is_email_receipt'] = !$returnMessageText;
-    foreach (['receipt_date', 'cc_receipt', 'bcc_receipt', 'receipt_from_name', 'receipt_from_email', 'receipt_text'] as $fld) {
+    foreach (['receipt_date', 'cc_receipt', 'bcc_receipt', 'receipt_from_name', 'receipt_from_email', 'receipt_text', 'pay_later_receipt'] as $fld) {
       if (!empty($input[$fld])) {
         $values[$fld] = $input[$fld];
       }

--- a/api/v3/Contribution.php
+++ b/api/v3/Contribution.php
@@ -401,6 +401,7 @@ function civicrm_api3_contribution_sendconfirmation($params) {
     'cc_receipt',
     'bcc_receipt',
     'receipt_text',
+    'pay_later_receipt',
     'payment_processor_id',
   ];
   $input = array_intersect_key($params, array_flip($allowedParams));
@@ -439,6 +440,10 @@ function _civicrm_api3_contribution_sendconfirmation_spec(&$params) {
   ];
   $params['receipt_text'] = [
     'title' => ts('Message (string)'),
+    'type' => CRM_Utils_Type::T_STRING,
+  ];
+  $params['pay_later_receipt'] = [
+    'title' => ts('Pay Later Message (string)'),
     'type' => CRM_Utils_Type::T_STRING,
   ];
   $params['receipt_update'] = [

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -3751,7 +3751,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
     ], [
       'Event',
     ]);
-    $this->checkReceiptDetails($mut, $contributionPage['id'], $contribution['id']);
+    $this->checkReceiptDetails($mut, $contributionPage['id'], $contribution['id'], $pageParams);
     $mut->stop();
   }
 
@@ -3786,21 +3786,24 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
    * @param CiviMailUtils $mut
    * @param int $pageID Page ID
    * @param int $contributionID Contribution ID
+   * @param array $pageParams
    *
    * @throws \CRM_Core_Exception
    */
-  public function checkReceiptDetails($mut, $pageID, $contributionID) {
+  public function checkReceiptDetails($mut, $pageID, $contributionID, $pageParams) {
     $pageReceipt = [
       'receipt_from_name' => "Page FromName",
       'receipt_from_email' => "page_from@email.com",
       'cc_receipt' => "page_cc@email.com",
       'receipt_text' => "Page Receipt Text",
+      'pay_later_receipt' => $pageParams['pay_later_receipt'],
     ];
     $customReceipt = [
       'receipt_from_name' => "Custom FromName",
       'receipt_from_email' => "custom_from@email.com",
       'cc_receipt' => "custom_cc@email.com",
       'receipt_text' => "Test Custom Receipt Text",
+      'pay_later_receipt' => 'Mail your check to test@example.com within 3 business days.',
     ];
     $this->callAPISuccess('ContributionPage', 'create', array_merge([
       'id' => $pageID,
@@ -3813,6 +3816,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
     ], $customReceipt));
 
     //Verify if custom receipt details are present in email.
+    //Page receipt details shouldn't be included.
     $mut->checkMailLog(array_values($customReceipt), array_values($pageReceipt));
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
An extension of fix done in https://github.com/civicrm/civicrm-core/pull/18789 to allow pay later receipt text in sendconfirmation api.

Before
----------------------------------------
Pay Later text from the contribution page is used even if it is overridden in the api call. Eg

```
civicrm_api3('Contribution', 'sendconfirmation', [
  'id' => contribution_id,
  'receipt_from_email' => "customfrom@email.com",
  'pay_later_receipt' => 'Mail your check to test@example.com within 3 business days.',
]);
```

uses the pay later text set in the contribution page of the contribution. If contribution is not attached to any page, there is no way to send a pay later text in the receipt using sendconfirmation api.


After
----------------------------------------
Pay Later text included.

Comments
----------------------------------------
Added unit test.