### PR TITLE
Fix extensions tabs following deprecation of old tab code

### DIFF
--- a/CRM/Admin/Page/Extensions.php
+++ b/CRM/Admin/Page/Extensions.php
@@ -132,6 +132,12 @@ class CRM_Admin_Page_Extensions extends CRM_Core_Page_Basic {
 
     $remoteExtensionRows = $this->formatRemoteExtensionRows($localExtensionRows);
     $this->assign('remoteExtensionRows', $remoteExtensionRows);
+
+    Civi::resources()
+      ->addScriptFile('civicrm', 'templates/CRM/common/TabHeader.js', 1, 'html-header')
+      ->addSetting([
+        'tabSettings' => ['active' => $_GET['selectedChild'] ?? NULL],
+      ]);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Fix extensions tabs following changes in #19066

Before
----------------------------------------
Tabs stopped rendering on extensions page.

After
----------------------------------------
Tabs load and selectedChild works.

Technical Details
----------------------------------------
Add tab javascript resource.

Comments
----------------------------------------
@demeritcowboy @colemanw This is the fix I think!