### PR TITLE
dev/core#2234 - Don't display the word 'null' after adding a new tagset

### DIFF
--- a/templates/CRM/Tag/Page/Tag.tpl
+++ b/templates/CRM/Tag/Page/Tag.tpl
@@ -573,7 +573,7 @@
       <% if(is_reserved == 1) {ldelim} %><strong>{ts}Reserved{/ts}</strong><% {rdelim} %>
       <% if(undefined === display_name) {ldelim} var display_name = null; {rdelim} %>
       {ts 1="<%= used_for_label.join(', ') %>" 2="<%= date %>" 3="<%= display_name %>"}Tag Set for %1 (created %2 by %3).{/ts}
-      <% if(typeof description === 'string' && description.length) {ldelim} %><p><em><%- description %></em></p><% {rdelim} %>
+      <% if(typeof description === 'string' && description.length && description !== 'null') {ldelim} %><p><em><%- description %></em></p><% {rdelim} %>
     </div>
     <input class="crm-form-text big" name="filter_tag_tree" placeholder="{ts}Filter List{/ts}" allowclear="1"/>
     <a class="crm-hover-button crm-clear-link" style="visibility:hidden;" title="{ts}Clear{/ts}"><i class="crm-i fa-times" aria-hidden="true"></i></a>


### PR DESCRIPTION
Overview
----------------------------------------
1. On the tags admin page, click the plus sign to add a new tagset.
1. Do NOT fill in the description field.
1. After returning from the popup form, it shows the word "null".

Before
----------------------------------------
<img width="117" alt="Untitled" src="https://user-images.githubusercontent.com/2967821/101247662-c4fa9080-36e8-11eb-8942-abb3aeafbf4e.png">

After
----------------------------------------
Null nullified.

Technical Details
----------------------------------------
I debated whether to get into the api or the dao layer where this 'null'-as-a-string stuff is happening (which is a known PEAR::DB issue that's come up before) but I'm not sure I want to really dive in there, so I just updated the template which is using some kind of moon language that looks like javascript.

Comments
----------------------------------------
Moon language.
