### PR TITLE
[REF] dev/core#2232 Re-Register Extension Class Loader after performi…

### DIFF
--- a/CRM/Upgrade/Form.php
+++ b/CRM/Upgrade/Form.php
@@ -780,6 +780,11 @@ SET    version = '$version'
     // Rebuild all triggers and re-enable logging if needed
     $logging = new CRM_Logging_Schema();
     $logging->fixSchemaDifferences();
+
+    // Re-Register Extension Class loader because we have changed the hook dispatch policy which might affect things.
+    $extensionSystem = CRM_Extension_System::singleton(TRUE);
+    $extensionClassLoader = $extensionSystem->getClassLoader();
+    $extensionClassLoader->refresh();
   }
 
   /**


### PR DESCRIPTION
…ng an upgrade

Overview
----------------------------------------
This aims to try to fix an issue where by it seems that the Extension Classloader Cache can be built problematically during upgrade perhaps and on WordPress at least may cause non-existent service error

Before
----------------------------------------
Potential for non-existent service error

After
----------------------------------------
Classloader rebuilt again and hopefully resolving the non-existent service error

ping @eileenmcnaughton @kcristiano can one of you check this if possible?