### PR TITLE
Manage Event: avoid E_NOTICE in smarty

### DIFF
--- a/CRM/Event/Form/ManageEvent/Registration.php
+++ b/CRM/Event/Form/ManageEvent/Registration.php
@@ -126,7 +126,6 @@ class CRM_Event_Form_ManageEvent_Registration extends CRM_Event_Form_ManageEvent
 
       if (!empty($defaults['is_multiple_registrations'])) {
         // CRM-4377: set additional participants’ profiles – set to ‘none’ if explicitly unset (non-active)
-
         $ufJoinAddParams = [
           'entity_table' => 'civicrm_event',
           'module' => 'CiviEvent_Additional',
@@ -151,6 +150,10 @@ class CRM_Event_Form_ManageEvent_Registration extends CRM_Event_Form_ManageEvent
           }
         }
         $this->assign('profilePostMultipleAdd', CRM_Utils_Array::value('additional_custom_post', $defaults, []));
+      }
+      else {
+        // Avoid PHP notices in the template
+        $this->assign('profilePostMultipleAdd', []);
       }
     }
     else {


### PR DESCRIPTION
Overview
----------------------------------------

To reproduce:

* Display e-notices
* Create a new Event
* Go to Manage Event > Online Registration

When using a dev environment that displays notices, or throws exceptions, it will fail to load the page.

Technical Details
----------------------------------------

The associated Smarty tpl has "if" statements in other places to check against empty values, but it throws a notice on this:

```
    var profileBottomCount = Number({/literal}{$profilePostMultiple|@count}{literal});
    var profileBottomCountAdd = Number({/literal}{$profilePostMultipleAdd|@count}{literal});
```

whereas in other places, the code does this:

```
      {if $profilePostMultipleAdd}
        {foreach from=$profilePostMultipleAdd item=profilePostIdA key=profilePostNumA name=profilePostIdAName}
```

I figured it was preferable to assign upstream, rather than add "ifs" in smarty.