### PR TITLE
dev/core#2233 - Fix broken tabs on profiles admin page

### DIFF
--- a/CRM/UF/Page/Group.php
+++ b/CRM/UF/Page/Group.php
@@ -361,6 +361,12 @@ class CRM_UF_Page_Group extends CRM_Core_Page {
     }
 
     $this->assign('rows', $ufGroup);
+
+    Civi::resources()
+      ->addScriptFile('civicrm', 'templates/CRM/common/TabHeader.js', 1, 'html-header')
+      ->addSetting([
+        'tabSettings' => ['active' => $_GET['selectedChild'] ?? NULL],
+      ]);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/2233

Same as https://github.com/civicrm/civicrm-core/pull/19130 but for the profiles admin page.

@mattwire @colemanw 

