### PR TITLE
dev/core#2232 Permit hook_civicrm_container and some other prebootish…

### DIFF
--- a/CRM/Upgrade/DispatchPolicy.php
+++ b/CRM/Upgrade/DispatchPolicy.php
@@ -59,6 +59,10 @@ class CRM_Upgrade_DispatchPolicy {
     // It's more restrictive, preventing interference from unexpected callpaths.
     $policies['upgrade.main'] = [
       'hook_civicrm_config' => 'run',
+      'hook_civicrm_container' => 'run',
+      'hook_civicrm_alterSettingsFolders' => 'run',
+      'hook_civicrm_alterSettingsMetaData' => 'run',
+      'hook_civicrm_permission' => 'run',
       '/^hook_civicrm_(pre|post)$/' => 'drop',
       '/^hook_civicrm_/' => $strict ? 'warn-drop' : 'drop',
       '/^civi\./' => 'run',

--- a/CRM/Upgrade/Form.php
+++ b/CRM/Upgrade/Form.php
@@ -780,6 +780,8 @@ SET    version = '$version'
     // Rebuild all triggers and re-enable logging if needed
     $logging = new CRM_Logging_Schema();
     $logging->fixSchemaDifferences();
+    // Force a rebuild of CiviCRM asset cache in case things have changed.
+    \Civi::service('asset_builder')->clear(FALSE);
   }
 
   /**


### PR DESCRIPTION
… hooks to run during upgrade and clear out the asset builder cache post upgrade

Overview
----------------------------------------
This is an alternate to https://github.com/civicrm/civicrm-core/pull/19133 This aims to achieve the same result of a smooth upgrade by permitting the hook_civicrm_container running during the upgrade and some other hooks which might assist end users and also when I tested locally I found I couldn't create a new mosaico mailing after upgrade from 5.32 to 5.34 because aset builder cache was problematic so this clears it as well

Before
----------------------------------------
Error about undefined service

After
----------------------------------------
No error and smooth upgrade

ping @eileenmcnaughton @kcristiano 