### PR TITLE
dev/core#2238 Added possibility to set objectType for hook_searchTasks in a custom search.

### DIFF
--- a/CRM/Contact/CustomSearchTask.php
+++ b/CRM/Contact/CustomSearchTask.php
@@ -1,0 +1,55 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+/**
+ * Class to represent the actions that can be performed on a group of contacts used by the search forms.
+ */
+class CRM_Contact_CustomSearchTask extends CRM_Core_Task {
+
+  /**
+   * @var string
+   */
+  public static $objectType = 'contact';
+
+  public static function tasks() {
+    if (!self::$_tasks) {
+      parent::tasks();
+    }
+    return self::$_tasks;
+  }
+
+  /**
+   * Show tasks selectively based on the permission level
+   * of the user
+   * This function should be overridden by the child class which would normally call parent::corePermissionedTaskTitles
+   *
+   * @param int $permission
+   * @param array $params
+   *             "ssID: Saved Search ID": If !empty we are in saved search context
+   *
+   * @return array
+   *   set of tasks that are valid for the user
+   */
+  public static function permissionedTaskTitles($permission, $params) {
+    $tasks = self::taskTitles();
+    if (!is_array($tasks)) {
+      $tasks = array();
+    }
+    return self::corePermissionedTaskTitles($tasks, $permission, $params);
+  }
+
+}

--- a/CRM/Contact/CustomSearchTask.php
+++ b/CRM/Contact/CustomSearchTask.php
@@ -25,13 +25,6 @@ class CRM_Contact_CustomSearchTask extends CRM_Core_Task {
    */
   public static $objectType = 'contact';
 
-  public static function tasks() {
-    if (!self::$_tasks) {
-      parent::tasks();
-    }
-    return self::$_tasks;
-  }
-
   /**
    * Show tasks selectively based on the permission level
    * of the user
@@ -45,10 +38,7 @@ class CRM_Contact_CustomSearchTask extends CRM_Core_Task {
    *   set of tasks that are valid for the user
    */
   public static function permissionedTaskTitles($permission, $params) {
-    $tasks = self::taskTitles();
-    if (!is_array($tasks)) {
-      $tasks = array();
-    }
+    $tasks = (array) self::taskTitles();
     return self::corePermissionedTaskTitles($tasks, $permission, $params);
   }
 

--- a/CRM/Contact/Form/Search.php
+++ b/CRM/Contact/Form/Search.php
@@ -368,6 +368,15 @@ class CRM_Contact_Form_Search extends CRM_Core_Form_Search {
       }
       $className = $this->_modeValue['taskClassName'];
       $taskParams['ssID'] = $this->_ssID ?? NULL;
+      if ($this instanceof CRM_Contact_Form_Search_Custom) {
+        // We set the $objectType for the searchTasks hook if it differs from 'contact'.
+        // 'contact' is the default task list so no need to replace this with a custom task list.
+        $customSearchClass = new $this->_customSearchClass($this->_formValues);
+        if ($customSearchClass instanceof CRM_Contact_Form_Search_Custom_Base) {
+          $className = $customSearchClass->getTasklistClass();
+          $className::$objectType = $customSearchClass->getObjectTypeForTaskList();
+        }
+      }
       $this->_taskList += $className::permissionedTaskTitles(CRM_Core_Permission::getPermission(), $taskParams);
     }
 

--- a/CRM/Contact/Form/Search/Custom/Base.php
+++ b/CRM/Contact/Form/Search/Custom/Base.php
@@ -55,7 +55,7 @@ class CRM_Contact_Form_Search_Custom_Base {
    * @return string
    */
   public function getObjectTypeForTaskList() {
-    return 'contact';
+    return 'Contact';
   }
 
   /**
@@ -67,7 +67,7 @@ class CRM_Contact_Form_Search_Custom_Base {
    * @return string
    */
   public function getTasklistClass() {
-    if ($this->getObjectTypeForTaskList() != 'contact') {
+    if ($this->getObjectTypeForTaskList() != 'Contact') {
       return 'CRM_Contact_CustomSearchTask';
     }
     return 'CRM_Contact_Task';

--- a/CRM/Contact/Form/Search/Custom/Base.php
+++ b/CRM/Contact/Form/Search/Custom/Base.php
@@ -45,6 +45,35 @@ class CRM_Contact_Form_Search_Custom_Base {
   }
 
   /**
+   * Override this when you want to implement a custom task list.
+   * By default the custom search has the same actions as a basic contact search, or
+   * an advanced search.
+   * Override this in your class and specify your own type.
+   *
+   * The type is passed the hook_civicrm_searchTasks.
+   *
+   * @return string
+   */
+  public function getObjectTypeForTaskList() {
+    return 'contact';
+  }
+
+  /**
+   * Override this when you want to make use of your own task list class.
+   * E.g. when you want to have the contribution tasks at your custom search
+   * return 'CRM_Contribute_Task'
+   * and return 'contribution' in getObjectTypeForTaskList
+   *
+   * @return string
+   */
+  public function getTasklistClass() {
+    if ($this->getObjectTypeForTaskList() != 'contact') {
+      return 'CRM_Contact_CustomSearchTask';
+    }
+    return 'CRM_Contact_Task';
+  }
+
+  /**
    * @return null|string
    */
   public function count() {

--- a/CRM/Contact/StateMachine/Search.php
+++ b/CRM/Contact/StateMachine/Search.php
@@ -55,7 +55,7 @@ class CRM_Contact_StateMachine_Search extends CRM_Core_StateMachine {
         $this->_pages[$t] = NULL;
       }
     }
-    else {
+    elseif ($task != NULL) {
       $this->_pages[$task] = NULL;
     }
 
@@ -90,6 +90,18 @@ class CRM_Contact_StateMachine_Search extends CRM_Core_StateMachine {
     $componentMode = $this->_controller->get('component_mode');
     $modeValue = CRM_Contact_Form_Search::getModeValue($componentMode);
     $taskClassName = $modeValue['taskClassName'];
+    if ($formName == 'Custom') {
+      // The task list is build for a custom search.
+      // Check which custom search class is used and check whether the custom search
+      // has another object for the searchTasks hook.
+      $csID = $componentMode = $this->_controller->get('csid') ?? CRM_Utils_Request::retrieve('csid', 'Integer');
+      $ssID = $componentMode = $this->_controller->get('ssID') ?? CRM_Utils_Request::retrieve('ssID', 'Integer');
+      $customSearchClass = CRM_Contact_BAO_SearchCustom::customClass($csID, $ssID);
+      if ($customSearchClass instanceof CRM_Contact_Form_Search_Custom_Base) {
+        $taskClassName = $customSearchClass->getTasklistClass();
+        $taskClassName::$objectType = $customSearchClass->getObjectTypeForTaskList();
+      }
+    }
     return $taskClassName::getTask($value);
   }
 


### PR DESCRIPTION
Overview
----------------------------------------

This PR adds the possibility to set the `$objectType` passed to hook_civicrm_searchTasks from within a custom search. 
Why is this needed? It could be that a developer writes a custom search for a specific business context and that within this context all the default contact action don't make sense. And that the developer adds its own actions which are only needed in this specific context. 

**Example: custom search for participants in a study and invite them**
An example a search for everyone who participates in a certain study and the only actions possible is to invite them or to move them out of the study. In this case study, invitation etc.. are all custom development for this specific context. 

Before
----------------------------------------

In the example above we can develop the custom search. That custom search ends up with the default actions, such as add to group, send e-mail, etc..

We can use the `hook_civicrm_searchTasks` to add the action for inviting the participants
However we will end up with the action also available at advanced search (where it doesn't make sense) and if we unset specific actions here they are not available any more the advanced search as well. 

After
----------------------------------------

In our implementation of the custom search we can implement the following function:

```php

public function getObjectTypeForTaskList() {
    return 'study_participantt';
  }

```

In the `hook_civicrm_searchTasks` we can then check for `$objectType == 'study_participantt')` and then add our own custom action for invitation.

Technical Details
----------------------------------------

Two new functions are added `CRM_Contact_Form_Search_Custom_Base`:

* `getObjectTypeForTaskList`: returns the name of the object type for the `hook_civicrm_searchTasks`
* `getTasklistClass`: returns the class name of the class holding all the tasks. Default to `CRM_Contact_Task` and with a custom search to `CRM_Contact_CustomSearchTask`

Those two functions are then used in the `CRM_Contact_StateMachine_Search` to build the task list. And in `CRM_Contact_Form_Search::buildTasklist` in which the drop down with possible tasks are filled.


Comments
----------------------------------------

See also: https://lab.civicrm.org/dev/core/-/issues/2238
