### PR TITLE
CRM_Core_Key - Provide more debugging hints about mismatched`qfKey`s

### DIFF
--- a/tests/phpunit/CRM/Core/KeyTest.php
+++ b/tests/phpunit/CRM/Core/KeyTest.php
@@ -1,0 +1,36 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * Class CRM_Core_KeyTest
+ * @group headless
+ */
+class CRM_Core_KeyTest extends CiviUnitTestCase {
+
+  public function testOK() {
+    $key = CRM_Core_Key::get('CRM_Bread_Butter');
+    $this->assertTrue(CRM_Core_Key::valid($key));
+    $this->assertEquals($key, CRM_Core_Key::validate($key, 'CRM_Bread_Butter'));
+  }
+
+  public function testMalformed() {
+    $key = CRM_Core_Key::get('CRM_Bread_Butter') . '<script>';
+    $this->assertFalse(CRM_Core_Key::valid($key));
+    $this->assertEquals(NULL, CRM_Core_Key::validate($key, 'CRM_Bread_Butter'));
+  }
+
+  public function testMixedUp() {
+    $key = CRM_Core_Key::get('CRM_Toast_Jam');
+    $this->assertTrue(CRM_Core_Key::valid($key));
+    $this->assertEquals(NULL, CRM_Core_Key::validate($key, 'CRM_Bread_Butter'));
+  }
+
+}


### PR DESCRIPTION
Overview
--------

The `qfKey` parameter is a security mechanism (CSRF). The content of `qfKey` is also inscrutable - so when there's a problem with `qfKey`, it can be difficult to determine the origin/nature of the problem. This patch makes it slightly easier to debug `qfKey` problems.

Before
------

The `qfKey` provides a digital signature based on (1) session ID, (2) the form being processed, (3) a random private-key (unique to the user/session). In some cases, the `qfKey` also has a random nonce appended to distinguish between concurrent tabs that work with the same form.

* Ex: `2abc4b7f23d9ae4dfcdbb0c692cc666e5f11256fe84ace7662b0e075834b81958` (w/o nonce)
* Ex: `2abc4b7f23d9ae4dfcdbb0c692cc666e5f11256fe84ace7662b0e075834b81958_9527` (w/nonce)

If there is a logic problem where the `qfKey` of form A gets mixed-up with form B, then it's extremely hard to understand the mismatch All you see are two long random codes.

* Inputted qfKey: `2abc4b7f23d9ae4dfcdbb0c692cc666e5f11256fe84ace7662b0e075834b81958`
* Expected fqKey: `89874b7a23192e4d6aab10c622ca369e5e11226f784a5c7652b95075536b81a5e`

After
-----

The `qfKey` has a prefix to indicate the token's intended usage (as well as a digital signature).

* Ex: `CRMContactControllerSearch154eitbf74v3ko0sw94k08gogo8448asdfw4goggkkwgkww08c` (w/o nonce)
* Ex: `CRMContactControllerSearch154eitbf74v3ko0sw94k08gogo8448asdfw4goggkkwgkww08c_9355` (w/ nonce)

If there is a logic problem where the `qfKey` of form A gets mixed-up with form B, then the prefix can help you understand. Compare:

* Inputted qfKey: `CRMContactControllerSearch154eitbf74v3ko0sw94k08gogo8448asdfw4goggkkwgkww08c`
* Expected qfKey: `CRMContributeFormContribution5o2due205mp0384080sgc8omw8kwggoksw47sswchs80gw0kgs`

This tells you that there's logical mismatch - it's trying to render the contribution screen using the key for the contact-search screen.

Comments
--------

* The identity of the `formname` is not sensitive information.
* The `qfKey` might look prettier with more delimeters (`{formname}_{signature}_{nonce}`). However, I believe there are random bits of existing code which use `explode('_')` to split apart the signature and the nonce. This formula seems to be drop-in/interoperable.
* I switched the encoding of the signature from hex (0-9a-f) to base-36 (0-9a-z) to make it a bit shorter.
* Regarding upgrade impacts... if we change the qfKey formula, will it break the form-state of any active users? Practically speaking... that doesn't matter. The upgrade already clears caches, which already breaks the form-state of any active users.  (Which is appropriate - because internal form-state is not guaranteed to be interoperable across versions.) We've already accepted  that upgrades/cache-clears will reset form-states. This should be no different.
