### PR TITLE
Fix notice error on using max() with only one variable

### DIFF
--- a/CRM/Utils/Pager.php
+++ b/CRM/Utils/Pager.php
@@ -186,7 +186,7 @@ class CRM_Utils_Pager extends Pager_Sliding {
         $currentPage = max((int ) @$_POST[self::PAGE_ID], 1);
       }
       elseif (isset($_POST[self::PAGE_ID_BOTTOM])) {
-        $currentPage = max((int ) @$_POST[self::PAGE_ID_BOTTOM]);
+        $currentPage = max((int ) @$_POST[self::PAGE_ID_BOTTOM], 1);
       }
     }
     elseif (isset($_GET[self::PAGE_ID])) {


### PR DESCRIPTION
Overview
----------------------------------------
This fixes a notice error `Warning: max(): When only one parameter is given, it must be an array in CRM_Utils_Pager->getPageID()`

Before
----------------------------------------
Warning notice error

After
----------------------------------------
no error

ping @eileenmcnaughton @demeritcowboy this is consistent with the other uses of max in this function 