### PR TITLE
Search kit joins

### DIFF
--- a/ext/search/ang/crmSearchAdmin/compose/criteria.html
+++ b/ext/search/ang/crmSearchAdmin/compose/criteria.html
@@ -4,7 +4,7 @@
       <fieldset ng-repeat="join in $ctrl.savedSearch.api_params.join">
         <div class="form-inline">
           <label for="crm-search-join-{{ $index }}">{{:: ts('With') }}</label>
-          <input id="crm-search-join-{{ $index }}" class="form-control" ng-model="join[0]" crm-ui-select="{placeholder: ' ', data: getJoinEntities}" ng-change="changeJoin($index)" />
+          <input id="crm-search-join-{{ $index }}" class="form-control huge" ng-model="join[0]" crm-ui-select="{placeholder: ' ', data: getJoinEntities}" ng-change="changeJoin($index)" />
           <select class="form-control" ng-model="join[1]" ng-options="o.k as o.v for o in ::joinTypes" ></select>
         </div>
         <fieldset class="api4-clause-fieldset">
@@ -13,18 +13,18 @@
       </fieldset>
       <fieldset>
         <div class="form-inline">
-          <input id="crm-search-add-join" class="form-control crm-action-menu fa-plus" ng-model="controls.join" crm-ui-select="{placeholder: ts('With'), data: getJoinEntities}" ng-change="addJoin()"/>
+          <input id="crm-search-add-join" class="form-control crm-action-menu fa-plus huge" ng-model="controls.join" crm-ui-select="{placeholder: ts('With'), data: getJoinEntities}" ng-change="addJoin()"/>
         </div>
       </fieldset>
     </div>
     <fieldset ng-if=":: $ctrl.paramExists('groupBy')">
       <div class="form-inline" ng-repeat="groupBy in $ctrl.savedSearch.api_params.groupBy">
         <label for="crm-search-groupBy-{{ $index }}">{{:: ts('Group By') }}</label>
-        <input id="crm-search-groupBy-{{ $index }}" class="form-control" ng-model="$ctrl.savedSearch.api_params.groupBy[$index]" crm-ui-select="{placeholder: ' ', data: fieldsForGroupBy}" ng-change="changeGroupBy($index)" />
+        <input id="crm-search-groupBy-{{ $index }}" class="form-control huge" ng-model="$ctrl.savedSearch.api_params.groupBy[$index]" crm-ui-select="{placeholder: ' ', data: fieldsForGroupBy}" ng-change="changeGroupBy($index)" />
         <hr>
       </div>
       <div class="form-inline">
-        <input id="crm-search-add-groupBy" class="form-control crm-action-menu fa-plus" ng-model="controls.groupBy" crm-ui-select="{placeholder: ts('Group By'), data: fieldsForGroupBy}" ng-change="addParam('groupBy')"/>
+        <input id="crm-search-add-groupBy" class="form-control crm-action-menu fa-plus huge" ng-model="controls.groupBy" crm-ui-select="{placeholder: ts('Group By'), data: fieldsForGroupBy}" ng-change="addParam('groupBy')"/>
       </div>
       <fieldset id="crm-search-build-group-aggregate" ng-if="$ctrl.savedSearch.api_params.groupBy.length" class="crm-collapsible collapsed">
         <legend class="collapsible-title">{{:: ts('Aggregate fields') }}</legend>

--- a/ext/search/ang/crmSearchAdmin/crmSearchAdmin.html
+++ b/ext/search/ang/crmSearchAdmin/crmSearchAdmin.html
@@ -18,7 +18,7 @@
       </div>
       <div class="crm-flex-4 form-inline">
         <label for="crm-search-main-entity">{{:: ts('Search for:') }}</label>
-        <input id="crm-search-main-entity" class="form-control" ng-model="$ctrl.savedSearch.api_entity" crm-ui-select="::{allowClear: false, data: entities}" ng-disabled="$ctrl.savedSearch.id" />
+        <input id="crm-search-main-entity" class="form-control huge" ng-model="$ctrl.savedSearch.api_entity" crm-ui-select="::{allowClear: false, data: entities}" ng-disabled="$ctrl.savedSearch.id" />
         <div class="btn-group btn-group-md pull-right">
           <button type="submit" class="btn" ng-class="{'btn-primary': status === 'unsaved', 'btn-warning': status === 'saving', 'btn-success': status === 'saved'}" ng-disabled="status !== 'unsaved'" ng-click="$ctrl.save()">
             <i class="crm-i" ng-class="{'fa-check': status !== 'saving', 'fa-spin fa-spinner': status === 'saving'}"></i>

--- a/ext/search/ang/crmSearchAdmin/group.html
+++ b/ext/search/ang/crmSearchAdmin/group.html
@@ -6,7 +6,7 @@
   <label for="crm-search-admin-group-title">{{ ts('Group Title:') }} <span class="crm-marker">*</span></label>
   <input id="crm-search-admin-group-title" class="form-control" placeholder="{{:: ts('Untitled') }}" ng-model="$ctrl.savedSearch.groups[0].title" ng-disabled="!smartGroupColumns.length" ng-required="smartGroupColumns.length">
   <label for="api-save-search-select-column">{{:: ts('Contact Column:') }}</label>
-  <input id="api-save-search-select-column" ng-model="$ctrl.savedSearch.api_params.select[0]" class="form-control" crm-ui-select="{data: smartGroupColumns}"/>
+  <input id="api-save-search-select-column" ng-model="$ctrl.savedSearch.api_params.select[0]" class="form-control huge" crm-ui-select="{data: smartGroupColumns}"/>
 </div>
 <fieldset ng-show="smartGroupColumns.length">
   <label>{{:: ts('Description:') }}</label>

--- a/ext/search/css/search.css
+++ b/ext/search/css/search.css
@@ -14,6 +14,10 @@
   margin-top: 20px;
 }
 
+#bootstrap-theme.crm-search .form-control.huge {
+  width: 275px;
+}
+
 #bootstrap-theme.crm-search input.ng-invalid {
   border-color: #8A1F11;
 }

--- a/ext/search/info.xml
+++ b/ext/search/info.xml
@@ -13,11 +13,11 @@
     <url desc="Issues">https://lab.civicrm.org/dev/report/-/issues</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2020-12-02</releaseDate>
-  <version>1.0.beta2</version>
+  <releaseDate>2021-01-06</releaseDate>
+  <version>1.0.beta3</version>
   <develStage>beta</develStage>
   <compatibility>
-    <ver>5.31</ver>
+    <ver>5.33</ver>
   </compatibility>
   <comments>This extension is still in beta. Click on the chat link above to discuss development, report problems or ask questions.</comments>
   <classloader>


### PR DESCRIPTION
Overview
----------------------------------------
This adds support for multiple and multi-layered joins in Search Kit.

Before
----------------------------------------
Ability to join once from the main entity to related entities.

After
----------------------------------------
- Ability to join two entities more than once (ex. joining from Contact to Email twice, once for home email, once for work email).
- Ability to join onto joins multiple levels down. (ex. joining from Activity to Contact to Contribution to Line Item)

Technical Details
----------------------------------------
It's cool.
