### PR TITLE
dev/core#1019 Fix currency formatting of Total Amount (with multi-currency form support)

### DIFF
--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -58,6 +58,9 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
     $this->assign('isShare', CRM_Utils_Array::value('is_share', $this->_values));
     $this->assign('isConfirmEnabled', CRM_Utils_Array::value('is_confirm_enabled', $this->_values));
 
+    // Required for currency formatting in the JS layer
+    $this->assign('moneyFormat', CRM_Utils_Money::format(1234.56));
+
     $this->assign('reset', CRM_Utils_Request::retrieve('reset', 'Boolean'));
     $this->assign('mainDisplay', CRM_Utils_Request::retrieve('_qf_Main_display', 'Boolean',
       CRM_Core_DAO::$_nullObject));

--- a/CRM/Event/Form/Registration/Register.php
+++ b/CRM/Event/Form/Registration/Register.php
@@ -319,6 +319,9 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
     // CRM-18399: used by template to pass pre profile id as a url arg
     $this->assign('custom_pre_id', $this->_values['custom_pre_id']);
 
+    // Required for currency formatting in the JS layer
+    $this->assign('moneyFormat', CRM_Utils_Money::format(1234.56));
+
     CRM_Core_Payment_ProcessorForm::buildQuickForm($this);
 
     $contactID = $this->getContactID();

--- a/templates/CRM/Price/Form/Calculate.tpl
+++ b/templates/CRM/Price/Form/Calculate.tpl
@@ -31,6 +31,7 @@
 var thousandMarker = '{/literal}{$config->monetaryThousandSeparator}{literal}';
 var separator      = '{/literal}{$config->monetaryDecimalPoint}{literal}';
 var symbol         = '{/literal}{$currencySymbol}{literal}';
+var moneyFormat    = '{/literal}{$moneyFormat}{literal}';
 var optionSep      = '|';
 
 // Recalculate the total fees based on user selection
@@ -161,7 +162,10 @@ function display(totalfee) {
   // totalfee is monetary, round it to 2 decimal points so it can
   // go as a float - CRM-13491
   totalfee = Math.round(totalfee*100)/100;
-  var totalFormattedFee = symbol + ' ' + CRM.formatMoney(totalfee, true);
+  // dev/core#1019 Use the moneyFormat assigned to the template, to support
+  // forms using a currency other that the site default. Also make sure to
+  // support various currency formatting options, supported by formatMoney.
+  var totalFormattedFee = CRM.formatMoney(totalfee, false, moneyFormat);
   cj('#pricevalue').html(totalFormattedFee);
 
   cj('#total_amount').val( totalfee );


### PR DESCRIPTION
- Followup to: #17703
- Original issue: https://lab.civicrm.org/dev/core/-/issues/1019

Overview
----------------------------------------

Many/most non-English locales place the currency symbol after the numeric amount.

#16487 tried to fix this, but presumably caused a regression for contribution pages that use a currency other than the default site currency, which @mattwire reverted in #17703.

So for example, on an Event Registration page with a PriceSet, the currency amount is incorrectly displayed before the amount:

![totalamount-2020-12-09_09-34](https://user-images.githubusercontent.com/254741/101643120-c934ef80-3a01-11eb-9b70-2ed2469254be.png)

To reproduce:

- Go to Administer > Localization > Language, and set `%a %c`  as the currency formatting option.
- Setup a contribution/event page with a priceset (so that "Total Amount" is displayed).

@mattwire Can you test if this fix works for you?
