### PR TITLE
Remove meaningless calls to ignoreException

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -2284,7 +2284,6 @@ SELECT contact_id
     // test for create view and trigger permissions and if allowed, add the option to go multilingual
     // and logging
     // I'm not sure why we use the getStaticProperty for an error, rather than checking for DB_Error
-    CRM_Core_TemporaryErrorScope::ignoreException();
     $dao = new CRM_Core_DAO();
     if ($view) {
       $result = $dao->query('CREATE OR REPLACE VIEW civicrm_domain_view AS SELECT * FROM civicrm_domain');

--- a/CRM/Logging/Schema.php
+++ b/CRM/Logging/Schema.php
@@ -619,7 +619,6 @@ AND    (TABLE_NAME LIKE 'log_civicrm_%' $nonStandardTableNameString )
   private function columnsOf($table, $force = FALSE) {
     if ($force || !isset(\Civi::$statics[__CLASS__]['columnsOf'][$table])) {
       $from = (substr($table, 0, 4) == 'log_') ? "`{$this->db}`.$table" : $table;
-      CRM_Core_TemporaryErrorScope::ignoreException();
       $dao = CRM_Core_DAO::executeQuery("SHOW COLUMNS FROM $from", [], TRUE, NULL, FALSE, FALSE);
       if (is_a($dao, 'DB_Error')) {
         return [];
@@ -649,7 +648,7 @@ AND    (TABLE_NAME LIKE 'log_civicrm_%' $nonStandardTableNameString )
         $dao = new CRM_Contact_DAO_Contact();
         $civiDB = $dao->_database;
       }
-      CRM_Core_TemporaryErrorScope::ignoreException();
+
       // NOTE: W.r.t Performance using one query to find all details and storing in static array is much faster
       // than firing query for every given table.
       $query = "


### PR DESCRIPTION


Overview
----------------------------------------
Remove meaningless calls to ignoreException

Before
----------------------------------------
Calls to ignoreException - but they actually do nothing because they do not assign the output to a variable - presumably the work of the cleaning fairies

After
----------------------------------------
poof

Technical Details
----------------------------------------
The way ignoreException works is the exception mode is called until it is
deconstructed. In other words the result needs to be assigned to a variable
and when it is unset then the exception mode reverts back.

However, over time cleaner-uppers spot these unused variables & remove them -
meaning the line no longer actually does anything. Since these lines are already
borked they can go....

Comments
----------------------------------------
This leaves 9 remaining instances of ignoreException - the goal is to entirely eliminate them