### PR TITLE
APIv4 - Fix dynamic bridge joins (used by Search Kit)

### DIFF
--- a/CRM/Core/DAO/AllCoreTables.php
+++ b/CRM/Core/DAO/AllCoreTables.php
@@ -337,6 +337,17 @@ class CRM_Core_DAO_AllCoreTables {
   }
 
   /**
+   * Convert table name to brief entity name.
+   *
+   * @param string $tableName
+   *
+   * @return FALSE|string
+   */
+  public static function getEntityNameForTable(string $tableName) {
+    return self::getBriefName(self::getClassForTable($tableName));
+  }
+
+  /**
    * Reinitialise cache.
    *
    * @param bool $fresh

--- a/CRM/Core/Reference/Basic.php
+++ b/CRM/Core/Reference/Basic.php
@@ -72,6 +72,14 @@ class CRM_Core_Reference_Basic implements CRM_Core_Reference_Interface {
   }
 
   /**
+   * @return array
+   *   [table_name => EntityName]
+   */
+  public function getTargetEntities(): array {
+    return [$this->targetTable => CRM_Core_DAO_AllCoreTables::getEntityNameForTable($this->targetTable)];
+  }
+
+  /**
    * @param CRM_Core_DAO $targetDao
    *
    * @return Object

--- a/CRM/Core/Reference/Dynamic.php
+++ b/CRM/Core/Reference/Dynamic.php
@@ -13,7 +13,21 @@ class CRM_Core_Reference_Dynamic extends CRM_Core_Reference_Basic {
    * @return bool
    */
   public function matchesTargetTable($tableName) {
+    // FIXME: Shouldn't this check against keys returned by getTargetEntities?
     return TRUE;
+  }
+
+  /**
+   * @return array
+   *   [table_name => EntityName]
+   */
+  public function getTargetEntities(): array {
+    $targetEntities = [];
+    $bao = CRM_Core_DAO_AllCoreTables::getClassForTable($this->refTable);
+    foreach ($bao::buildOptions($this->refTypeColumn) as $table => $label) {
+      $targetEntities[$table] = CRM_Core_DAO_AllCoreTables::getEntityNameForTable($table);
+    }
+    return $targetEntities;
   }
 
   /**

--- a/ext/search/Civi/Search/Admin.php
+++ b/ext/search/Civi/Search/Admin.php
@@ -142,25 +142,13 @@ class Admin {
           ) {
             continue;
           }
-          // Dynamic references use a column like "entity_table"
-          $dynamicCol = $reference->getTypeColumn();
-          if ($dynamicCol) {
-            $targetTables = $daoClass::buildOptions($dynamicCol);
-            if (!$targetTables) {
-              continue;
-            }
-            $targetTables = array_keys($targetTables);
-          }
-          else {
-            $targetTables = [$reference->getTargetTable()];
-          }
-          foreach ($targetTables as $targetTable) {
-            $targetDao = \CRM_Core_DAO_AllCoreTables::getClassForTable($targetTable);
-            $targetEntityName = \CRM_Core_DAO_AllCoreTables::getBriefName($targetDao);
+          foreach ($reference->getTargetEntities() as $targetTable => $targetEntityName) {
             if (!isset($allowedEntities[$targetEntityName]) || $targetEntityName === $entity['name']) {
               continue;
             }
             $targetEntity = $allowedEntities[$targetEntityName];
+            // Dynamic references use a column like "entity_table"
+            $dynamicCol = $reference->getTypeColumn();
             // Non-bridge joins directly between 2 entities
             if (!$bridge) {
               // Add the straight 1-1 join


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a few bugs in Search Kit where extra rows were returned due to a misconstructed join in APIv4, or in some cases the join would completely fail between e.g. related contacts.

Before
----------------------------------------
APIv4 joins less reliable.

After
----------------------------------------
Joins more reliable. Tests added.

Technical Details
----------------------------------------
- Move ON clause conditions to the first join when they reference the bridge entity itself
- Ensure bridge joins work with joining the same table to itself (e.g. Contact to Contact via RelationshipCache)
