### PR TITLE
Switch to non-static functions

### DIFF
--- a/CRM/Member/Form.php
+++ b/CRM/Member/Form.php
@@ -416,7 +416,7 @@ class CRM_Member_Form extends CRM_Contribute_Form_AbstractEditPayment {
    *
    * @return array
    */
-  protected static function getPriceSetDetails($params) {
+  protected function getPriceSetDetails(array $params): ?array {
     $priceSetID = $params['price_set_id'] ?? NULL;
     if ($priceSetID) {
       return CRM_Price_BAO_PriceSet::getSetDetail($priceSetID);
@@ -436,10 +436,10 @@ class CRM_Member_Form extends CRM_Contribute_Form_AbstractEditPayment {
    *
    * @return int
    */
-  protected static function getPriceSetID($params) {
+  protected function getPriceSetID(array $params): int {
     $priceSetID = $params['price_set_id'] ?? NULL;
     if (!$priceSetID) {
-      $priceSetDetails = self::getPriceSetDetails($params);
+      $priceSetDetails = $this->getPriceSetDetails($params);
       return (int) key($priceSetDetails);
     }
     return (int) $priceSetID;
@@ -452,9 +452,9 @@ class CRM_Member_Form extends CRM_Contribute_Form_AbstractEditPayment {
    *
    * @return array
    */
-  protected function setPriceSetParameters($formValues) {
-    $this->_priceSetId = self::getPriceSetID($formValues);
-    $priceSetDetails = self::getPriceSetDetails($formValues);
+  protected function setPriceSetParameters(array $formValues): array {
+    $this->_priceSetId = $this->getPriceSetID($formValues);
+    $priceSetDetails = $this->getPriceSetDetails($formValues);
     $this->_priceSet = $priceSetDetails[$this->_priceSetId];
     // process price set and get total amount and line items.
     $this->ensurePriceParamsAreSet($formValues);

--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -651,8 +651,8 @@ DESC limit 1");
   public static function formRule($params, $files, $self) {
     $errors = [];
 
-    $priceSetId = self::getPriceSetID($params);
-    $priceSetDetails = self::getPriceSetDetails($params);
+    $priceSetId = $self->getPriceSetID($params);
+    $priceSetDetails = $self->getPriceSetDetails($params);
 
     $selectedMemberships = self::getSelectedMemberships($priceSetDetails[$priceSetId], $params);
 

--- a/CRM/Member/Form/MembershipRenewal.php
+++ b/CRM/Member/Form/MembershipRenewal.php
@@ -782,7 +782,7 @@ class CRM_Member_Form_MembershipRenewal extends CRM_Member_Form {
   protected function getOrderParams(): array {
     $order = new CRM_Financial_BAO_Order();
     $order->setPriceSelectionFromUnfilteredInput($this->_params);
-    $order->setPriceSetID(self::getPriceSetID($this->_params));
+    $order->setPriceSetID($this->getPriceSetID($this->_params));
     $order->setOverrideTotalAmount($this->_params['total_amount']);
     $order->setOverrideFinancialTypeID((int) $this->_params['financial_type_id']);
     return [


### PR DESCRIPTION

Overview
----------------------------------------
Switch to non-static functions

Before
----------------------------------------
Functions used only by the form objects are static - this appears to be in order to use them from formRule

After
----------------------------------------
Functions non-static. Form rule calls them on the form object it was passed. Note this is rather more powerful as it can potentially access & set properties. This means that a property may not need to be fetched as many times

Technical Details
----------------------------------------
I realise these functions are static so that the formRule can call them - but
the formRule has access to the form object and the intention was obviously always
that the formRule can call functions on the form. This cleans that up:

Comments
----------------------------------------
