### PR TITLE
dev/financial#162 Simplify decision as to whether to use a pdf on membership emails

### DIFF
--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -986,20 +986,8 @@ DESC limit 1");
         $form->_receiptContactId = $formValues['contact_id'];
       }
     }
-    // @todo determine isEmailPdf in calling function.
-    $template = CRM_Core_Smarty::singleton();
-    $taxAmt = $template->get_template_vars('dataArray');
-    $eventTaxAmt = $template->get_template_vars('totalTaxAmount');
-    $prefixValue = Civi::settings()->get('contribution_invoice_settings');
-    $invoicing = $prefixValue['invoicing'] ?? NULL;
-    if ((!empty($taxAmt) || isset($eventTaxAmt)) && (isset($invoicing) && isset($prefixValue['is_email_pdf']))) {
-      $isEmailPdf = TRUE;
-    }
-    else {
-      $isEmailPdf = FALSE;
-    }
 
-    list($mailSend, $subject, $message, $html) = CRM_Core_BAO_MessageTemplate::sendTemplate(
+    CRM_Core_BAO_MessageTemplate::sendTemplate(
       [
         'groupName' => 'msg_tpl_workflow_membership',
         'valueName' => 'membership_offline_receipt',
@@ -1008,7 +996,7 @@ DESC limit 1");
         'toName' => $form->_contributorDisplayName,
         'toEmail' => $form->_contributorEmail,
         'PDFFilename' => ts('receipt') . '.pdf',
-        'isEmailPdf' => $isEmailPdf,
+        'isEmailPdf' => Civi::settings()->get('invoicing') && Civi::settings()->get('is_email_pdf'),
         'contributionId' => $formValues['contribution_id'],
         'isTest' => (bool) ($form->_action & CRM_Core_Action::PREVIEW),
       ]


### PR DESCRIPTION

Overview
----------------------------------------
Currently the code that determines whether to attach a pdf for membership emails only attaches it as a pdf if the tax amount is non-zero
This seems both confusing and pointless  - the proposal here is to send as a pdf as long as

is_email_pdf is true and
invoicing is enabled


https://lab.civicrm.org/dev/financial/-/issues/162

Before
----------------------------------------
Membership mail only sent as a pdf if it is configured to via settings AND it calculates there is a tax amount

After
----------------------------------------
Only these 2 settings are relevant
is_email_pdf is true and
invoicing is enabled

Technical Details
----------------------------------------
I feel like 1 and 2 could be separated but they are currently linked so I would suggest any proposals to change that are a follow up

Comments
----------------------------------------
I will include this in the dev-digest but @jamienovick @yashodha @agileware-justin you may have an interest