### PR TITLE
dev/financial#163 Rename / remove internal references to contributionTypeID

### DIFF
--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -480,12 +480,12 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
       $statuses = array_flip(CRM_Event_PseudoConstant::participantStatus());
       $defaults[$this->_id]['status_id'] = $statuses['Registered'] ?? NULL;
       if (!empty($defaults[$this->_id]['event_id'])) {
-        $contributionTypeId = CRM_Core_DAO::getFieldValue('CRM_Event_DAO_Event',
+        $financialTypeID = CRM_Core_DAO::getFieldValue('CRM_Event_DAO_Event',
           $defaults[$this->_id]['event_id'],
           'financial_type_id'
         );
-        if ($contributionTypeId) {
-          $defaults[$this->_id]['financial_type_id'] = $contributionTypeId;
+        if ($financialTypeID) {
+          $defaults[$this->_id]['financial_type_id'] = $financialTypeID;
         }
       }
 

--- a/tests/phpunit/CRM/Core/Payment/AuthorizeNetTest.php
+++ b/tests/phpunit/CRM/Core/Payment/AuthorizeNetTest.php
@@ -147,7 +147,6 @@ class CRM_Core_Payment_AuthorizeNetTest extends CiviUnitTestCase {
       'email' => 'john.smith@example.com',
       'contactID' => $contactId,
       'contributionID' => $contribution['id'],
-      'contributionTypeID' => $this->_financialTypeId,
       'contributionRecurID' => $recur['id'],
     ]);
 

--- a/tests/phpunit/api/v3/MembershipPaymentTest.php
+++ b/tests/phpunit/api/v3/MembershipPaymentTest.php
@@ -19,7 +19,6 @@
 class api_v3_MembershipPaymentTest extends CiviUnitTestCase {
   protected $_apiversion = 3;
   protected $_contactID;
-  protected $_contributionTypeID;
   protected $_membershipTypeID;
   protected $_membershipStatusID;
   protected $_contribution = [];

--- a/tests/phpunit/api/v3/MembershipStatusTest.php
+++ b/tests/phpunit/api/v3/MembershipStatusTest.php
@@ -16,7 +16,6 @@
 class api_v3_MembershipStatusTest extends CiviUnitTestCase {
 
   protected $_contactID;
-  protected $_contributionTypeID;
   protected $_membershipTypeID;
   protected $_membershipStatusID;
 


### PR DESCRIPTION
Overview
----------------------------------------
dev/financial#163 Rename / remove internal references to contributionTypeID

https://lab.civicrm.org/dev/financial/-/issues/163

Before
----------------------------------------
2 types of reference to contributionTypeID exist in core
- purely internal ones
- ones exposed to extensions

After
----------------------------------------
Some of the purely internal ones removed - will PR up others

Technical Details
----------------------------------------

Comments
----------------------------------------
