### PR TITLE
Unused writeLegacyWarnings() in PropertyBag

### DIFF
--- a/Civi/Payment/PropertyBag.php
+++ b/Civi/Payment/PropertyBag.php
@@ -2,7 +2,6 @@
 namespace Civi\Payment;
 
 use InvalidArgumentException;
-use Civi;
 use CRM_Core_Error;
 use CRM_Core_PseudoConstant;
 
@@ -213,19 +212,6 @@ class PropertyBag implements \ArrayAccess {
   public function offsetUnset ($offset) {
     $prop = $this->handleLegacyPropNames($offset);
     unset($this->props['default'][$prop]);
-  }
-
-  /**
-   * Save any legacy warnings to log.
-   *
-   * Called as a shutdown function.
-   */
-  public static function writeLegacyWarnings() {
-    if (!empty(static::$legacyWarnings)) {
-      $message = "Civi\\Payment\\PropertyBag related deprecation warnings:\n"
-        . implode("\n", array_keys(static::$legacyWarnings));
-      Civi::log()->warning($message, ['civi.tag' => 'deprecated']);
-    }
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Putting this up partly as a question since it came up while looking at stuff.

The thing that registered this function as a shutdown function was removed here: https://github.com/civicrm/civicrm-core/commit/aa29942d08a4fbe2e4b0a66d514e0d77124fcb31#diff-c8d9bcea3e41ecc2ae13f5b654fefbbe3e95a73c9066b83017af82204533f9d2L197

And the same commit removed the `$legacyWarnings[]` class member that holds the warnings, but left this block still there. I'm thinking just oversight since I can't find any other references to that property or this function.
