### PR TITLE
Remove extraneous elses

### DIFF
--- a/CRM/Activity/Import/Parser/Activity.php
+++ b/CRM/Activity/Import/Parser/Activity.php
@@ -298,85 +298,80 @@ class CRM_Activity_Import_Parser_Activity extends CRM_Activity_Import_Parser {
           array_unshift($values, 'Multiple matching contact records detected for this row. The activity was not imported');
           return CRM_Import_Parser::ERROR;
         }
-        else {
-          $cid = $matchedIDs[0];
-          $params['target_contact_id'] = $cid;
-          $params['version'] = 3;
-          $newActivity = civicrm_api('activity', 'create', $params);
-          if (!empty($newActivity['is_error'])) {
-            array_unshift($values, $newActivity['error_message']);
-            return CRM_Import_Parser::ERROR;
-          }
-
-          $this->_newActivity[] = $newActivity['id'];
-          return CRM_Import_Parser::VALID;
+        $cid = $matchedIDs[0];
+        $params['target_contact_id'] = $cid;
+        $params['version'] = 3;
+        $newActivity = civicrm_api('activity', 'create', $params);
+        if (!empty($newActivity['is_error'])) {
+          array_unshift($values, $newActivity['error_message']);
+          return CRM_Import_Parser::ERROR;
         }
+
+        $this->_newActivity[] = $newActivity['id'];
+        return CRM_Import_Parser::VALID;
+
       }
-      else {
-        // Using new Dedupe rule.
-        $ruleParams = [
-          'contact_type' => 'Individual',
-          'used' => 'Unsupervised',
-        ];
-        $fieldsArray = CRM_Dedupe_BAO_Rule::dedupeRuleFields($ruleParams);
+      // Using new Dedupe rule.
+      $ruleParams = [
+        'contact_type' => 'Individual',
+        'used' => 'Unsupervised',
+      ];
+      $fieldsArray = CRM_Dedupe_BAO_Rule::dedupeRuleFields($ruleParams);
 
-        $disp = NULL;
-        foreach ($fieldsArray as $value) {
-          if (array_key_exists(trim($value), $params)) {
-            $paramValue = $params[trim($value)];
-            if (is_array($paramValue)) {
-              $disp .= $params[trim($value)][0][trim($value)] . " ";
-            }
-            else {
-              $disp .= $params[trim($value)] . " ";
-            }
-          }
-        }
-
-        if (!empty($params['external_identifier'])) {
-          if ($disp) {
-            $disp .= "AND {$params['external_identifier']}";
+      $disp = NULL;
+      foreach ($fieldsArray as $value) {
+        if (array_key_exists(trim($value), $params)) {
+          $paramValue = $params[trim($value)];
+          if (is_array($paramValue)) {
+            $disp .= $params[trim($value)][0][trim($value)] . " ";
           }
           else {
-            $disp = $params['external_identifier'];
+            $disp .= $params[trim($value)] . " ";
           }
         }
-
-        array_unshift($values, 'No matching Contact found for (' . $disp . ')');
-        return CRM_Import_Parser::ERROR;
       }
-    }
-    else {
-      if (!empty($params['external_identifier'])) {
-        $targetContactId = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Contact',
-          $params['external_identifier'], 'id', 'external_identifier'
-        );
 
-        if (!empty($params['target_contact_id']) &&
-          $params['target_contact_id'] != $targetContactId
-        ) {
-          array_unshift($values, 'Mismatch of External ID:' . $params['external_identifier'] . ' and Contact Id:' . $params['target_contact_id']);
-          return CRM_Import_Parser::ERROR;
-        }
-        elseif ($targetContactId) {
-          $params['target_contact_id'] = $targetContactId;
+      if (!empty($params['external_identifier'])) {
+        if ($disp) {
+          $disp .= "AND {$params['external_identifier']}";
         }
         else {
-          array_unshift($values, 'No Matching Contact for External ID:' . $params['external_identifier']);
-          return CRM_Import_Parser::ERROR;
+          $disp = $params['external_identifier'];
         }
       }
 
-      $params['version'] = 3;
-      $newActivity = civicrm_api('activity', 'create', $params);
-      if (!empty($newActivity['is_error'])) {
-        array_unshift($values, $newActivity['error_message']);
+      array_unshift($values, 'No matching Contact found for (' . $disp . ')');
+      return CRM_Import_Parser::ERROR;
+    }
+    if (!empty($params['external_identifier'])) {
+      $targetContactId = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Contact',
+        $params['external_identifier'], 'id', 'external_identifier'
+      );
+
+      if (!empty($params['target_contact_id']) &&
+        $params['target_contact_id'] != $targetContactId
+      ) {
+        array_unshift($values, 'Mismatch of External ID:' . $params['external_identifier'] . ' and Contact Id:' . $params['target_contact_id']);
         return CRM_Import_Parser::ERROR;
       }
-
-      $this->_newActivity[] = $newActivity['id'];
-      return CRM_Import_Parser::VALID;
+      if ($targetContactId) {
+        $params['target_contact_id'] = $targetContactId;
+      }
+      else {
+        array_unshift($values, 'No Matching Contact for External ID:' . $params['external_identifier']);
+        return CRM_Import_Parser::ERROR;
+      }
     }
+
+    $params['version'] = 3;
+    $newActivity = civicrm_api('activity', 'create', $params);
+    if (!empty($newActivity['is_error'])) {
+      array_unshift($values, $newActivity['error_message']);
+      return CRM_Import_Parser::ERROR;
+    }
+
+    $this->_newActivity[] = $newActivity['id'];
+    return CRM_Import_Parser::VALID;
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
This looks like a huge code change but it's just removing meaningless elses and reformatting


Before
----------------------------------------
Constructs like

```
if ($a = 1) {
  return;
}
else {
  // do the thing
}
```

After
----------------------------------------

```
if ($a = 1) {
  return;
}
 // do the thing

```

Technical Details
----------------------------------------


Comments
----------------------------------------

Use w=1 to see this better https://github.com/civicrm/civicrm-core/pull/19168/files?w=1