### PR TITLE
dev/core#2246 Fix failure to filter exports

### DIFF
--- a/CRM/Export/BAO/ExportProcessor.php
+++ b/CRM/Export/BAO/ExportProcessor.php
@@ -797,11 +797,11 @@ class CRM_Export_BAO_ExportProcessor {
     list($select, $from, $where, $having) = $query->query();
     $this->setQueryFields($query->_fields);
     $whereClauses = ['trash_clause' => "contact_a.is_deleted != 1"];
-    if ($this->getRequestedFields() && $this->getComponentTable() &&  $this->getComponentTable() !== 'civicrm_contact') {
-      $from .= " INNER JOIN " . $this->getComponentTable() . " ctTable ON ctTable.contact_id = contact_a.id ";
-    }
-    elseif ($this->getComponentClause()) {
+    if ($this->getComponentClause()) {
       $whereClauses[] = $this->getComponentClause();
+    }
+    elseif ($this->getRequestedFields() && $this->getComponentTable() &&  $this->getComponentTable() !== 'civicrm_contact') {
+      $from .= " INNER JOIN " . $this->getComponentTable() . " ctTable ON ctTable.contact_id = contact_a.id ";
     }
 
     // CRM-13982 - check if is deleted


### PR DESCRIPTION

Overview
----------------------------------------
Fixes a failure to apply limits to member exports per https://lab.civicrm.org/dev/core/-/issues/2246

Before
----------------------------------------
All memberships exported when selecting specific ones

After
----------------------------------------
Only the specific ones are exported

Technical Details
----------------------------------------
This fixes regression caused by us more consistently setting componentTable. Unfortunately it turned out componentTable is a bit of a magic parameter in this code that triggers the first part of an if clause - leading us to miss the else bit,

The short version here is that the presence of a componentClause should take precedences
over the inner join intended as a blunt, and maybe unnecessary, measure to
limit the export to the entity in question

Comments
----------------------------------------
