### PR TITLE
[NFC] Convert civi.tag-deprecated to use central function

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4761,8 +4761,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
     }
     elseif (empty($lineItemDetails['line_total'])) {
       // follow legacy code path
-      Civi::log()
-        ->warning('Deprecated bit of code, please log a ticket explaining how you got here!', ['civi.tag' => 'deprecated']);
+      CRM_Core_Error::deprecatedWarning('Deprecated bit of code, please log a ticket explaining how you got here!');
       return $params['total_amount'];
     }
     else {

--- a/CRM/Core/BAO/PrevNextCache.php
+++ b/CRM/Core/BAO/PrevNextCache.php
@@ -325,7 +325,7 @@ FROM   civicrm_prevnext_cache pn
     CRM_Core_Error::deprecatedFunctionWarning('Deprecated function');
     // If entity table is an array we are passing in an older format where this function only had 1 param $values. We put a deprecation warning.
     if (!empty($entity_table) && is_array($entity_table)) {
-      Civi::log()->warning('Deprecated code path. Values should not be set this is going away in the future in favour of specific function params for each column.', array('civi.tag' => 'deprecated'));
+      CRM_Core_Error::deprecatedWarning('Deprecated code path. Values should not be set this is going away in the future in favour of specific function params for each column.');
       foreach ($values as $value) {
         $valueArray = self::convertSetItemValues($value);
         self::setItem($valueArray[0], $valueArray[1], $valueArray[2], $valueArray[3], $valueArray[4]);

--- a/CRM/Core/BAO/Setting.php
+++ b/CRM/Core/BAO/Setting.php
@@ -186,7 +186,7 @@ class CRM_Core_BAO_Setting extends CRM_Core_DAO_Setting {
 
     foreach ($fieldsToSet as $settingField => &$settingValue) {
       if (empty($fields['values'][$settingField])) {
-        Civi::log()->warning('Deprecated Path: There is a setting (' . $settingField . ') not correctly defined. You may see unpredictability due to this. CRM_Core_Setting::setItems', ['civi.tag' => 'deprecated']);
+        CRM_Core_Error::deprecatedWarning('Deprecated Path: There is a setting (' . $settingField . ') not correctly defined. You may see unpredictability due to this. CRM_Core_Setting::setItems');
         $fields['values'][$settingField] = [];
       }
       self::validateSetting($settingValue, $fields['values'][$settingField]);

--- a/CRM/Core/BAO/UFGroup.php
+++ b/CRM/Core/BAO/UFGroup.php
@@ -1437,7 +1437,7 @@ class CRM_Core_BAO_UFGroup extends CRM_Core_DAO_UFGroup {
   public static function add(&$params, $ids = []) {
     if (empty($params['id']) && !empty($ids['ufgroup'])) {
       $params['id'] = $ids['ufgroup'];
-      Civi::log()->warning('ids parameter is deprecated', ['civi.tag' => 'deprecated']);
+      CRM_Core_Error::deprecatedWarning('ids parameter is deprecated');
     }
     $fields = [
       'is_active',

--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -373,7 +373,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
       // The $attributes param used to allow for strings and would default to an
       // empty string.  However, now that the variable is heavily manipulated,
       // we should expect it to always be an array.
-      Civi::log()->warning('Attributes passed to CRM_Core_Form::add() are not an array.', ['civi.tag' => 'deprecated']);
+      CRM_Core_Error::deprecatedWarning('Attributes passed to CRM_Core_Form::add() are not an array.');
     }
     // Fudge some extra types that quickform doesn't support
     $inputType = $type;

--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -233,8 +233,7 @@ class CRM_Dedupe_Merger {
 
     CRM_Utils_Hook::merge('cidRefs', $contactReferences);
     if ($contactReferences !== $coreReferences) {
-      Civi::log()
-        ->warning("Deprecated hook ::merge in context of 'cidRefs. Use entityTypes instead.", ['civi.tag' => 'deprecated']);
+      CRM_Core_Error::deprecatedWarning("Deprecated hook ::merge in context of 'cidRefs. Use entityTypes instead.");
     }
     \Civi::$statics[__CLASS__]['contact_references'] = $contactReferences;
     return \Civi::$statics[__CLASS__]['contact_references'];

--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -1446,7 +1446,7 @@ ORDER BY   civicrm_email.is_bulkmail DESC
     $id = $params['id'] ?? $ids['mailing_id'] ?? NULL;
 
     if (empty($params['id']) && !empty($ids)) {
-      \Civi::log('Parameter $ids is no longer used by Mailing::add. Use the api or just pass $params', ['civi.tag' => 'deprecated']);
+      CRM_Core_Error::deprecatedWarning('Parameter $ids is no longer used by Mailing::add. Use the api or just pass $params');
     }
 
     if ($id) {
@@ -1525,7 +1525,7 @@ ORDER BY   civicrm_email.is_bulkmail DESC
 
     if (empty($params['id']) && (array_filter($ids) !== [])) {
       $params['id'] = $ids['mailing_id'] ?? $ids['id'];
-      \Civi::log('Parameter $ids is no longer used by Mailing::create. Use the api or just pass $params', ['civi.tag' => 'deprecated']);
+      CRM_Core_Error::deprecatedWarning('Parameter $ids is no longer used by Mailing::create. Use the api or just pass $params');
     }
 
     // CRM-#1843
@@ -2493,7 +2493,7 @@ LEFT JOIN civicrm_mailing_group g ON g.mailing_id   = m.id
       throw new CRM_Core_Exception(ts('No id passed to mailing delJob function'));
     }
 
-    \Civi::log('This function is deprecated, use CRM_Mailing_BAO_MailingJob::del instead', ['civi.tag' => 'deprecated']);
+    CRM_Core_Error::deprecatedWarning('This function is deprecated, use CRM_Mailing_BAO_MailingJob::del instead');
 
     CRM_Mailing_BAO_MailingJob::del($id);
   }

--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -255,7 +255,7 @@ class CRM_Member_BAO_Membership extends CRM_Member_DAO_Membership {
         if (!empty($params[$dateField]) && $params[$dateField] !== 'null' && strpos($params[$dateField], date('Ymd', strtotime(trim($params[$dateField])))) !== 0) {
           $params[$dateField] = date('Ymd', strtotime(trim($params[$dateField])));
           // @todo enable this once core is using the api.
-          // Civi::log()->warning('Relying on the BAO to clean up dates is deprecated. Call membership create via the api', ['civi.tag' => 'deprecated']);
+          // CRM_Core_Error::deprecatedWarning('Relying on the BAO to clean up dates is deprecated. Call membership create via the api');
         }
         if (!empty($params['id']) && empty($params[$dateField])) {
           $fieldsToLoad[] = $dateField;

--- a/CRM/Member/BAO/Query.php
+++ b/CRM/Member/BAO/Query.php
@@ -182,10 +182,7 @@ class CRM_Member_BAO_Query extends CRM_Core_BAO_Query {
     switch ($name) {
       case 'member_join_date_low':
       case 'member_join_date_high':
-        Civi::log()->warning(
-          'member_join_date field is deprecated please use membership_join_date field instead',
-          ['civi.tag' => 'deprecated']
-        );
+        CRM_Core_Error::deprecatedWarning('member_join_date field is deprecated please use membership_join_date field instead');
         $fldName = str_replace(['_low', '_high'], '', $name);
         $query->dateQueryBuilder($values,
           'civicrm_membership', $fldName, 'join_date',
@@ -195,10 +192,7 @@ class CRM_Member_BAO_Query extends CRM_Core_BAO_Query {
 
       case 'member_start_date_low':
       case 'member_start_date_high':
-        Civi::log()->warning(
-          'member_start_date field is deprecated please use membership_start_date field instead',
-          ['civi.tag' => 'deprecated']
-        );
+        CRM_Core_Error::deprecatedWarning('member_start_date field is deprecated please use membership_start_date field instead');
         $fldName = str_replace(['_low', '_high'], '', $name);
         $query->dateQueryBuilder($values,
           'civicrm_membership', $fldName, 'start_date',
@@ -208,10 +202,7 @@ class CRM_Member_BAO_Query extends CRM_Core_BAO_Query {
 
       case 'member_end_date_low':
       case 'member_end_date_high':
-        Civi::log()->warning(
-          'member_end_date field is deprecated please use membership_end_date field instead',
-          ['civi.tag' => 'deprecated']
-        );
+        CRM_Core_Error::deprecatedWarning('member_end_date field is deprecated please use membership_end_date field instead');
         $fldName = str_replace(['_low', '_high'], '', $name);
         $query->dateQueryBuilder($values,
           'civicrm_membership', $fldName, 'end_date',

--- a/CRM/Utils/Geocode.php
+++ b/CRM/Utils/Geocode.php
@@ -31,10 +31,7 @@ class CRM_Utils_Geocode {
    *   Class name, or empty.
    */
   public static function getProviderClass() {
-    Civi::log()->warning(
-      'CRM_Utils_Geocode is deprecated and will be removed from core soon, use CRM_Utils_GeocodeProvider::getUsableClassName()',
-      ['civi.tag' => 'deprecated']
-    );
+    CRM_Core_Error::deprecatedWarning('CRM_Utils_Geocode is deprecated and will be removed from core soon, use CRM_Utils_GeocodeProvider::getUsableClassName()');
 
     return (string) CRM_Utils_GeocodeProvider::getUsableClassName();
   }

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -155,7 +155,7 @@ abstract class CRM_Utils_Hook {
     if (!is_array($names)) {
       // We were called with the old contract wherein $names is actually an int.
       // Symfony dispatcher requires some kind of name.
-      Civi::log()->warning("hook_$fnSuffix should be updated to pass an array of parameter names to CRM_Utils_Hook::invoke().", ['civi.tag' => 'deprecated']);
+      CRM_Core_Error::deprecatedWarning("hook_$fnSuffix should be updated to pass an array of parameter names to CRM_Utils_Hook::invoke().");
       $compatNames = ['arg1', 'arg2', 'arg3', 'arg4', 'arg5', 'arg6'];
       $names = array_slice($compatNames, 0, (int) $names);
     }


### PR DESCRIPTION
Overview
----------------------------------------
Converts usage of Civi::log() with the civi.tag deprecated to use a newly added central function which does the same thing. Have marked NFC since that's all it does but feel free to remove if it doesn't meet the criteria.

Before
----------------------------------------
`Civi::log()->...(... ['civi.tag' => 'deprecated']);`

After
----------------------------------------
`CRM_Core_Error::deprecatedWarning('...');`

Technical Details
----------------------------------------

Comments
----------------------------------------
There is one spot not included which is dealt with at https://github.com/civicrm/civicrm-core/pull/19167.

There are two other spots not included for which I have a most excellent reason but the margins here are too small to contain it.

@eileenmcnaughton @seamuslee001 