### PR TITLE
APIv4: Support relative date range input

### DIFF
--- a/CRM/Utils/Date.php
+++ b/CRM/Utils/Date.php
@@ -867,7 +867,7 @@ class CRM_Utils_Date {
    * @return array
    *   start date, end date
    */
-  public static function getFromTo($relative, $from, $to, $fromTime = NULL, $toTime = '235959') {
+  public static function getFromTo($relative, $from = NULL, $to = NULL, $fromTime = NULL, $toTime = '235959') {
     if ($relative) {
       list($term, $unit) = explode('.', $relative, 2);
       $dateRange = self::relativeToAbsolute($term, $unit);

--- a/Civi/Api4/Query/Api4SelectQuery.php
+++ b/Civi/Api4/Query/Api4SelectQuery.php
@@ -369,7 +369,7 @@ class Api4SelectQuery {
     // For WHERE clause, expr must be the name of a field.
     if ($type === 'WHERE') {
       $field = $this->getField($expr, TRUE);
-      FormattingUtil::formatInputValue($value, $expr, $field);
+      FormattingUtil::formatInputValue($value, $expr, $field, $operator);
       $fieldAlias = $field['sql_name'];
     }
     // For HAVING, expr must be an item in the SELECT clause
@@ -380,7 +380,7 @@ class Api4SelectQuery {
         // Attempt to format if this is a real field
         if (isset($this->apiFieldSpec[$expr])) {
           $field = $this->getField($expr);
-          FormattingUtil::formatInputValue($value, $expr, $field);
+          FormattingUtil::formatInputValue($value, $expr, $field, $operator);
         }
       }
       // Expr references a non-field expression like a function; convert to alias
@@ -394,7 +394,7 @@ class Api4SelectQuery {
           list($selectField) = explode(':', $selectAlias);
           if ($selectAlias === $selectExpr && $fieldName === $selectField && isset($this->apiFieldSpec[$fieldName])) {
             $field = $this->getField($fieldName);
-            FormattingUtil::formatInputValue($value, $expr, $field);
+            FormattingUtil::formatInputValue($value, $expr, $field, $operator);
             $fieldAlias = $selectAlias;
             break;
           }
@@ -412,13 +412,13 @@ class Api4SelectQuery {
       if (is_string($value)) {
         $valExpr = $this->getExpression($value);
         if ($fieldName && $valExpr->getType() === 'SqlString') {
-          FormattingUtil::formatInputValue($valExpr->expr, $fieldName, $this->apiFieldSpec[$fieldName]);
+          FormattingUtil::formatInputValue($valExpr->expr, $fieldName, $this->apiFieldSpec[$fieldName], $operator);
         }
         return sprintf('%s %s %s', $fieldAlias, $operator, $valExpr->render($this->apiFieldSpec));
       }
       elseif ($fieldName) {
         $field = $this->getField($fieldName);
-        FormattingUtil::formatInputValue($value, $fieldName, $field);
+        FormattingUtil::formatInputValue($value, $fieldName, $field, $operator);
       }
     }
 

--- a/tests/phpunit/api/v4/Action/DateTest.php
+++ b/tests/phpunit/api/v4/Action/DateTest.php
@@ -19,6 +19,7 @@
 
 namespace api\v4\Action;
 
+use Civi\Api4\Activity;
 use Civi\Api4\Contact;
 use Civi\Api4\Relationship;
 use api\v4\UnitTestCase;
@@ -58,6 +59,79 @@ class DateTest extends UnitTestCase {
       ->execute()
       ->indexBy('id');
     $this->assertArrayNotHasKey($r, $result);
+  }
+
+  public function testRelativeDateRanges() {
+    $c1 = Contact::create()
+      ->addValue('first_name', 'c')
+      ->addValue('last_name', 'one')
+      ->execute()
+      ->first()['id'];
+    $act = Activity::save()
+      ->setDefaults(['activity_type_id:name' => 'Meeting', 'source_contact_id' => $c1])
+      ->addRecord(['activity_date_time' => 'now - 3 year'])
+      ->addRecord(['activity_date_time' => 'now - 1 year'])
+      ->addRecord(['activity_date_time' => 'now - 1 month'])
+      ->addRecord(['activity_date_time' => 'now'])
+      ->addRecord(['activity_date_time' => 'now + 1 month'])
+      ->addRecord(['activity_date_time' => 'now + 1 year'])
+      ->addRecord(['activity_date_time' => 'now + 3 year'])
+      ->execute()->column('id');
+
+    $result = Activity::get(FALSE)->addSelect('id')
+      ->addWhere('activity_date_time', '>', 'previous.year')
+      ->execute()->column('id');
+    $this->assertNotContains($act[0], $result);
+    $this->assertContains($act[3], $result);
+    $this->assertContains($act[4], $result);
+    $this->assertContains($act[5], $result);
+    $this->assertContains($act[6], $result);
+
+    $result = Activity::get(FALSE)->addSelect('id')
+      ->addWhere('activity_date_time', '>', 'this.year')
+      ->execute()->column('id');
+    $this->assertNotContains($act[0], $result);
+    $this->assertNotContains($act[1], $result);
+    $this->assertNotContains($act[2], $result);
+    $this->assertNotContains($act[3], $result);
+    $this->assertContains($act[5], $result);
+    $this->assertContains($act[6], $result);
+
+    $result = Activity::get(FALSE)->addSelect('id')
+      ->addWhere('activity_date_time', '>=', 'this.year')
+      ->execute()->column('id');
+    $this->assertNotContains($act[0], $result);
+    $this->assertNotContains($act[1], $result);
+    $this->assertContains($act[3], $result);
+    $this->assertContains($act[4], $result);
+    $this->assertContains($act[5], $result);
+    $this->assertContains($act[6], $result);
+
+    $result = Activity::get(FALSE)->addSelect('id')
+      ->addWhere('activity_date_time', '<', 'previous.year')
+      ->execute()->column('id');
+    $this->assertContains($act[0], $result);
+    $this->assertNotContains($act[4], $result);
+    $this->assertNotContains($act[5], $result);
+    $this->assertNotContains($act[6], $result);
+
+    $result = Activity::get(FALSE)->addSelect('id')
+      ->addWhere('activity_date_time', '=', 'next.month')
+      ->execute()->column('id');
+    $this->assertNotContains($act[0], $result);
+    $this->assertNotContains($act[1], $result);
+    $this->assertNotContains($act[2], $result);
+    $this->assertContains($act[4], $result);
+    $this->assertNotContains($act[5], $result);
+    $this->assertNotContains($act[6], $result);
+
+    $result = Activity::get(FALSE)->addSelect('id')
+      ->addWhere('activity_date_time', 'BETWEEN', ['previous.year', 'this.year'])
+      ->execute()->column('id');
+    $this->assertContains($act[2], $result);
+    $this->assertContains($act[3], $result);
+    $this->assertNotContains($act[0], $result);
+    $this->assertNotContains($act[6], $result);
   }
 
 }

--- a/tests/phpunit/api/v4/Entity/ParticipantTest.php
+++ b/tests/phpunit/api/v4/Entity/ParticipantTest.php
@@ -180,6 +180,29 @@ class ParticipantTest extends UnitTestCase {
       $otherParticipantResult->offsetExists($firstParticipantId),
       'excluded wrong record');
 
+    // check syntax for date-range
+
+    $getParticipantsById = function($wheres = []) {
+      return Participant::get(FALSE)
+        ->setWhere($wheres)
+        ->execute()
+        ->indexBy('id');
+    };
+
+    $thisYearParticipants = $getParticipantsById([['register_date', '=', 'this.year']]);
+    $this->assertFalse(isset($thisYearParticipants[$firstParticipantId]));
+
+    $otherYearParticipants = $getParticipantsById([['register_date', '!=', 'this.year']]);
+    $this->assertTrue(isset($otherYearParticipants[$firstParticipantId]));
+
+    Participant::update()->setCheckPermissions(FALSE)
+      ->addWhere('id', '=', $firstParticipantId)
+      ->addValue('register_date', 'now')
+      ->execute();
+
+    $thisYearParticipants = $getParticipantsById([['register_date', '=', 'this.year']]);
+    $this->assertTrue(isset($thisYearParticipants[$firstParticipantId]));
+
     // retrieve a participant record and update some records
     $patchRecord = [
       'source' => "not " . $firstResult['source'],


### PR DESCRIPTION
Overview
----------------------------------------
Supports relative date range expressions with most operators and adds test coverage.

Before
----------------------------------------
Relative date expressions not accepted by APIv4.

After
----------------------------------------
All relative date expressions from core now work with most APIv4 operators.

Technical Details
----------------------------------------
This is different from the proposal in #17475 which invented a new pseudo-operator "IS". In this PR, we use the same familiar operators which gives greater flexibility. This supports not just `IS (=)` or `IS NOT (!=)` but also other comparisons like greater than, less than, & BETWEEN.

All of the following work:

- `('date_field', '=', 'this.year')`
- `('date_field', '!=', 'this.month')`
- `('date_field', '<', 'next.year')`
- `('date_field', '>=', 'previous.year')`

And the BETWEEN operator support mixing and matching relative and static dates

- `('date_field', 'BETWEEN', ['previous.year', 'next.year'])`
- `('date_field', 'BETWEEN', ['2019-01-01', 'next.year'])`