### PR TITLE
dev/core#2248 Ensure variables are assigned to tpl for urls

### DIFF
--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -2299,6 +2299,10 @@ INNER JOIN civicrm_price_field_value value ON ( value.id = lineItem.price_field_
 
       CRM_Utils_System::appendBreadCrumb($breadCrumbs);
     }
+    else {
+      $this->assign('id', $this->_id);
+      $this->assign('contact_id', $this->_contactId);
+    }
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a regression where the edit link from the view participant page doesn't work when reached from search results

Before
----------------------------------------
When viewing a "Participant" record, the "Edit" button is broken.
1. Navigate to "Events" => "Find Participants"
1. Enter some search criteria (or blank criteria). Run the search.
1. On one of the "Participant" records, click "View"
1. The "View" screen has a button bar which includes an "Edit" button. Click it.

After
----------------------------------------
Fixed

Technical Details
----------------------------------------
This is the same place the urlPath is assigned to is logical. Adding them conditionally is mostly precautionary

Comments
----------------------------------------
