### PR TITLE
Fix failure to assign view tpl variables to view page if context=search is in the url

### DIFF
--- a/CRM/Event/Page/Tab.php
+++ b/CRM/Event/Page/Tab.php
@@ -118,7 +118,7 @@ class CRM_Event_Page_Tab extends CRM_Core_Page {
     $this->_action = CRM_Utils_Request::retrieve('action', 'String', $this, FALSE, 'browse');
     $this->_id = CRM_Utils_Request::retrieve('id', 'Positive', $this);
 
-    if ($context == 'standalone' || $context === 'search') {
+    if (($context == 'standalone' || $context === 'search') && $this->_action !== CRM_Core_Action::VIEW) {
       $this->_action = CRM_Core_Action::ADD;
     }
     else {


### PR DESCRIPTION
port of https://github.com/civicrm/civicrm-core/pull/19189