### PR TITLE
Fix failure to assign view tpl variables to view page if context=search is in the url

### DIFF
--- a/CRM/Event/Page/Tab.php
+++ b/CRM/Event/Page/Tab.php
@@ -118,7 +118,7 @@ class CRM_Event_Page_Tab extends CRM_Core_Page {
     $this->_action = CRM_Utils_Request::retrieve('action', 'String', $this, FALSE, 'browse');
     $this->_id = CRM_Utils_Request::retrieve('id', 'Positive', $this);
 
-    if ($context == 'standalone' || $context === 'search') {
+    if (($context == 'standalone' || $context === 'search') && $this->_action !== CRM_Core_Action::VIEW) {
       $this->_action = CRM_Core_Action::ADD;
     }
     else {


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a regression where the participant view screen was not displaying correctly if context=search is in the url - which it current is when accessing the screen from search results

Before
----------------------------------------
![Screenshot from 2020-12-12 15-46-16](https://user-images.githubusercontent.com/336308/101970758-37dbac80-3c91-11eb-9355-8a51c3deeaf4.png)


After
----------------------------------------
![Screenshot from 2020-12-12 15-47-28](https://user-images.githubusercontent.com/336308/101970780-6063a680-3c91-11eb-9dd4-c34eb9006e95.png)

Technical Details
----------------------------------------
I suspect a url change inadvertantly triggering it to treat the mode as edit has been at the root of what we've been seeing. I want to fix properly in master

Comments
----------------------------------------
Whack-a-mole round 10