### PR TITLE
Squash 2 if clauses into 1

### DIFF
--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -2016,10 +2016,7 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Contact_Import_Parser {
       civicrm_api('contact', 'delete', $vals);
       $cid = CRM_Contact_BAO_Contact::createProfileContact($formatted, $contactFields, $contactId, NULL, NULL, $formatted['contact_type']);
     }
-    elseif ($onDuplicate == CRM_Import_Parser::DUPLICATE_UPDATE) {
-      $newContact = $this->createContact($formatted, $contactFields, $onDuplicate, $contactId);
-    }
-    elseif ($onDuplicate == CRM_Import_Parser::DUPLICATE_FILL) {
+    if (in_array((int) $onDuplicate, [CRM_Import_Parser::DUPLICATE_UPDATE, CRM_Import_Parser::DUPLICATE_FILL], TRUE)) {
       $newContact = $this->createContact($formatted, $contactFields, $onDuplicate, $contactId);
     }
     // else skip does nothing and just returns an error code.


### PR DESCRIPTION


Overview
----------------------------------------
Very minor code tidy up  - The action is the same for both criteria so in_array rather than 2 * if =
makes it more readable

Before
----------------------------------------
pattern be like
```
if ($animal == 'dog) {
  stroke();
elseif($animail === 'cat') {
  stroke();
}
```

After
----------------------------------------
pattern be like

```
if (in_array($animal, ['cat', 'dog'], TRUE)) {
  stroke();
}
```

Technical Details
----------------------------------------

Comments
----------------------------------------
