### PR TITLE
REF Allow for fields of type Blob or Mediumblob in Apiv4

### DIFF
--- a/Civi/Api4/Service/Spec/FieldSpec.php
+++ b/Civi/Api4/Service/Spec/FieldSpec.php
@@ -395,7 +395,7 @@ class FieldSpec {
    * @return array
    */
   private function getValidDataTypes() {
-    $extraTypes = ['Boolean', 'Text', 'Float', 'Url', 'Array'];
+    $extraTypes = ['Boolean', 'Text', 'Float', 'Url', 'Array', 'Blob', 'Mediumblob'];
     $extraTypes = array_combine($extraTypes, $extraTypes);
 
     return array_merge(\CRM_Utils_Type::dataTypes(), $extraTypes);


### PR DESCRIPTION
Overview
----------------------------------------
These are currently known data types but not supported by APIv4 https://github.com/civicrm/civicrm-core/blob/master/CRM/Utils/Type.php#L27 https://github.com/civicrm/civicrm-core/blob/master/CRM/Utils/Type.php#L34

Before
----------------------------------------
Cannot expose any column of type mediumblob or blob in APIv4 e.g. document column in civicrm_file

After
----------------------------------------
Can expose them

ping @colemanw @eileenmcnaughton 