### PR TITLE
NFC When printing out the result of the correctly update in single va…

### DIFF
--- a/tests/phpunit/api/v3/SyntaxConformanceTest.php
+++ b/tests/phpunit/api/v3/SyntaxConformanceTest.php
@@ -1516,6 +1516,7 @@ class api_v3_SyntaxConformanceTest extends CiviUnitTestCase {
       }
       unset($entity['xdebug']);
       unset($checkEntity['xdebug']);
+      unset($update['xdebug']);
       $this->assertAPIArrayComparison($entity, $checkEntity, [], "checking if $fieldName was correctly updated\n" . print_r([
         'update-params' => $updateParams,
         'update-result' => $update,


### PR DESCRIPTION
…lue alter ensure that xdebug isn't printed

@eileenmcnaughton I'm hoping this might help with your test failure on those new action schedule fields