### PR TITLE
dev/core#2242 Ensure that when a custom field is deleted any associat…

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -1005,12 +1005,12 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
       //not delete the option group and related option values
       self::checkOptionGroup($field->option_group_id);
     }
-
     // next drop the column from the custom value table
     self::createField($field, 'delete');
 
     $field->delete();
     CRM_Core_BAO_UFField::delUFField($field->id);
+    CRM_Core_BAO_Mapping::removeFieldFromMapping('custom_' . $field->id);
     CRM_Utils_Weight::correctDuplicateWeights('CRM_Core_DAO_CustomField');
 
     CRM_Utils_Hook::post('delete', 'CustomField', $field->id, $field);

--- a/CRM/Core/BAO/Mapping.php
+++ b/CRM/Core/BAO/Mapping.php
@@ -1213,4 +1213,14 @@ class CRM_Core_BAO_Mapping extends CRM_Core_DAO_Mapping {
     }
   }
 
+  /**
+   * Remove references to a specific field from save Mappings
+   * @param string $fieldName
+   */
+  public static function removeFieldFromMapping($fieldName): void {
+    $mappingField = new CRM_Core_DAO_MappingField();
+    $mappingField->name = $fieldName;
+    $mappingField->delete();
+  }
+
 }

--- a/CRM/Upgrade/Incremental/sql/5.34.alpha1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.34.alpha1.mysql.tpl
@@ -4,3 +4,8 @@
 SELECT @country_id := id from civicrm_country where name = 'Korea, Republic of' AND iso_code = 'KR';
 INSERT IGNORE INTO `civicrm_state_province` (`id`, `country_id`, `abbreviation`, `name`) VALUES
 (NULL, @country_id, '50', 'Sejong');
+
+-- Remove any references to custom fields from mapping field table that no longer exist
+DELETE FROM civicrm_mapping_field
+WHERE name NOT IN ( SELECT concat('custom_', id) FROM civicrm_custom_field)
+AND name LIKE 'custom_%';


### PR DESCRIPTION
…ed mapping field records are also deleted to avoid DB errors when doing exports

Overview
----------------------------------------
Does what it says above

Before
----------------------------------------
Possible DB error if re-using a saved field mapping for export which contains a reference to a custom field that has been deleted

After
----------------------------------------
No DB error

Technical Details
----------------------------------------
I suspect we will want to use an Upgrade to clean up stuff here as well

ping @eileenmcnaughton @jusfreeman 