### PR TITLE
Fix preferred repeattransaction flow to correctly create the activity contacts for the contribution

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2442,7 +2442,7 @@ LEFT JOIN  civicrm_contribution contribution ON ( componentPayment.contribution_
       else {
         $contributionParams['financial_type_id'] = $templateContribution['financial_type_id'];
       }
-      foreach (['contact_id', 'currency', 'source', 'amount_level', 'address_id'] as $fieldName) {
+      foreach (['contact_id', 'currency', 'source', 'amount_level', 'address_id', 'on_behalf', 'source_contact_id'] as $fieldName) {
         if (isset($templateContribution[$fieldName])) {
           $contributionParams[$fieldName] = $templateContribution[$fieldName];
         }
@@ -4266,18 +4266,6 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
     // @todo - check if Contribution::create does this, test, remove.
     CRM_Contribute_BAO_ContributionRecur::updateRecurLinkedPledge($contributionID, $recurringContributionID,
       $contributionParams['contribution_status_id'], $input['amount']);
-
-    // create an activity record
-    // @todo - check if Contribution::create does this, test, remove.
-    if ($input['component'] == 'contribute') {
-      //CRM-4027
-      $targetContactID = NULL;
-      if ($contributionContactID) {
-        $targetContactID = $contribution->contact_id;
-        $contribution->contact_id = $contributionContactID;
-      }
-      CRM_Activity_BAO_Activity::addActivity($contribution, 'Contribution', $targetContactID);
-    }
 
     if (self::isEmailReceipt($input, $contribution->contribution_page_id, $recurringContributionID)) {
       civicrm_api3('Contribution', 'sendconfirmation', [

--- a/CRM/Contribute/BAO/ContributionPage.php
+++ b/CRM/Contribute/BAO/ContributionPage.php
@@ -45,7 +45,7 @@ class CRM_Contribute_BAO_ContributionPage extends CRM_Contribute_DAO_Contributio
       CRM_Price_BAO_PriceFieldValue::updateFinancialType($params['id'], 'civicrm_contribution_page', $params['financial_type_id']);
     }
     CRM_Utils_Hook::post($hook, 'ContributionPage', $dao->id, $dao);
-    unset(\Civi::$statics['CRM_Core_PseudoConstant']);
+    CRM_Core_PseudoConstant::flush();
     return $dao;
   }
 

--- a/CRM/Contribute/BAO/ContributionPage.php
+++ b/CRM/Contribute/BAO/ContributionPage.php
@@ -45,6 +45,7 @@ class CRM_Contribute_BAO_ContributionPage extends CRM_Contribute_DAO_Contributio
       CRM_Price_BAO_PriceFieldValue::updateFinancialType($params['id'], 'civicrm_contribution_page', $params['financial_type_id']);
     }
     CRM_Utils_Hook::post($hook, 'ContributionPage', $dao->id, $dao);
+    unset(\Civi::$statics['CRM_Core_PseudoConstant']);
     return $dao;
   }
 

--- a/CRM/Contribute/BAO/ContributionRecur.php
+++ b/CRM/Contribute/BAO/ContributionRecur.php
@@ -450,6 +450,13 @@ INNER JOIN civicrm_contribution       con ON ( con.id = mp.contribution_id )
       }
       $result = array_merge($templateContribution, $overrides);
       $result['line_item'] = self::reformatLineItemsForRepeatContribution($result['total_amount'], $result['financial_type_id'], $lineItems, (array) $templateContribution);
+      // If the template contribution was made on-behalf then add the
+      // relevant values to ensure the activity reflects that.
+      $relatedContact = CRM_Contribute_BAO_Contribution::getOnbehalfIds($result['id']);
+      if (!empty($relatedContact['individual_id'])) {
+        $result['on_behalf'] = TRUE;
+        $result['source_contact_id'] = $relatedContact['individual_id'];
+      }
       return $result;
     }
     return [];

--- a/CRM/Financial/BAO/Payment.php
+++ b/CRM/Financial/BAO/Payment.php
@@ -155,6 +155,7 @@ class CRM_Financial_BAO_Payment {
           'is_email_receipt' => $params['is_send_contribution_notification'],
           'trxn_date' => $params['trxn_date'],
           'payment_instrument_id' => $paymentTrxnParams['payment_instrument_id'],
+          'payment_processor_id' => $paymentTrxnParams['payment_processor_id'] ?? NULL,
         ]);
         // Get the trxn
         $trxnId = CRM_Core_BAO_FinancialTrxn::getFinancialTrxnId($contribution['id'], 'DESC');

--- a/tests/phpunit/CRM/Contribute/Form/Contribution/ConfirmTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/Contribution/ConfirmTest.php
@@ -26,53 +26,38 @@ class CRM_Contribute_Form_Contribution_ConfirmTest extends CiviUnitTestCase {
   }
 
   /**
-   * CRM-21200: Test that making online payment for pending contribution doesn't overwite the contribution details
+   * CRM-21200: Test that making online payment for pending contribution
+   * doesn't overwite the contribution details
+   *
+   * @throws \CiviCRM_API3_Exception
+   * @throws \CRM_Core_Exception
    */
-  public function testPayNowPayment() {
-    $contactID = $this->individualCreate();
+  public function testPayNowPayment(): void {
+    $individualID = $this->individualCreate();
     $paymentProcessorID = $this->paymentProcessorCreate(['payment_processor_type_id' => 'Dummy']);
     CRM_Core_Config::singleton()->userPermissionClass->permissions = [];
 
     // create a contribution page which is later used to make pay-later contribution
-    $result = $this->callAPISuccess('ContributionPage', 'create', [
-      'title' => 'Test Contribution Page',
-      'financial_type_id' => CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'financial_type_id', 'Campaign Contribution'),
-      'currency' => 'USD',
-      'financial_account_id' => 1,
-      'payment_processor' => $paymentProcessorID,
-      'is_active' => 1,
-      'is_allow_other_amount' => 1,
-      'min_amount' => 20,
-      'max_amount' => 2000,
-    ]);
-    $contributionPageID1 = $result['id'];
+    $contributionPageID1 = $this->createContributionPage(['payment_processor' => $paymentProcessorID]);
+
     // create pending contribution
     $contribution = $this->callAPISuccess('Contribution', 'create', [
-      'contact_id' => $contactID,
-      'financial_type_id' => CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'financial_type_id', 'Campaign Contribution'),
+      'contact_id' => $individualID,
+      'financial_type_id' => 'Campaign Contribution',
       'currency' => 'USD',
       'total_amount' => 100.00,
-      'contribution_status_id' => CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Pending'),
+      'contribution_status_id' => 'Pending',
       'contribution_page_id' => $contributionPageID1,
       'source' => 'backoffice pending contribution',
     ]);
 
     // create a contribution page which is later used to make online payment for pending contribution
-    $result = $this->callAPISuccess('ContributionPage', 'create', [
-      'title' => 'Test Contribution Page',
-      'financial_type_id' => CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'financial_type_id', 'Campaign Contribution'),
-      'currency' => 'USD',
-      'financial_account_id' => 1,
-      'payment_processor' => $paymentProcessorID,
-      'is_active' => 1,
-      'is_allow_other_amount' => 1,
-      'min_amount' => 10,
-      'max_amount' => 1000,
-    ]);
-    $form = new CRM_Contribute_Form_Contribution_Confirm();
-    $contributionPageID2 = $result['id'];
+    $contributionPageID2 = $this->createContributionPage(['payment_processor' => $paymentProcessorID]);
+
+    /* @var CRM_Contribute_Form_Contribution_Confirm $form*/
+    $form = $this->getFormObject('CRM_Contribute_Form_Contribution_Confirm');
     $form->_id = $contributionPageID2;
-    $form->_values = $result['values'][$contributionPageID2];
+
     $form->_paymentProcessor = [
       'id' => $paymentProcessorID,
       'billing_mode' => CRM_Core_Payment::BILLING_MODE_FORM,
@@ -81,7 +66,6 @@ class CRM_Contribute_Form_Contribution_ConfirmTest extends CiviUnitTestCase {
       'payment_instrument_id' => CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'payment_instrument_id', 'Credit card'),
     ];
     $form->_params = [
-      'qfKey' => 'do not care',
       'contribution_id' => $contribution['id'],
       'credit_card_number' => 4111111111111111,
       'cvv2' => 234,
@@ -103,17 +87,19 @@ class CRM_Contribute_Form_Contribution_ConfirmTest extends CiviUnitTestCase {
       'is_quick_config' => 1,
       'description' => $contribution['values'][$contribution['id']]['source'],
       'skipLineItem' => 0,
+      'frequency_interval' => 1,
+      'frequency_unit' => 'month',
     ];
 
     $processConfirmResult = $form->processConfirm(
       $form->_params,
-      $contactID,
-      $form->_values['financial_type_id'],
+      $individualID,
+      CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'financial_type_id', 'Campaign Contribution'),
       0, FALSE
     );
 
     // Make sure that certain parameters are set on return from processConfirm
-    $this->assertEquals($form->_values['financial_type_id'], $processConfirmResult['financial_type_id']);
+    $this->assertEquals('Campaign Contribution', CRM_Core_PseudoConstant::getName('CRM_Contribute_BAO_Contribution', 'financial_type_id', $processConfirmResult['financial_type_id']));
 
     // Based on the processed contribution, complete transaction which update the contribution status based on payment result.
     if (!empty($processConfirmResult['contribution'])) {
@@ -140,39 +126,80 @@ class CRM_Contribute_Form_Contribution_ConfirmTest extends CiviUnitTestCase {
     // check that contribution status is changed to 'Completed' from 'Pending'
     $this->assertEquals('Completed', $contribution['contribution_status']);
 
-    //delete contribution.
+    // Delete contribution.
+    // @todo - figure out why & document properly. If this is just to partially
+    // re-use some test set up then split into 2 tests.
     $this->callAPISuccess('contribution', 'delete', [
       'id' => $processConfirmResult['contribution']->id,
     ]);
 
     //Process on behalf contribution.
     unset($form->_params['contribution_id']);
-    $form->_contactID = $form->_values['related_contact'] = $form->_params['onbehalf_contact_id'] = $contactID;
-    $form->_params['contact_id'] = $this->organizationCreate();
+    $form->_contactID = $form->_values['related_contact'] = $form->_params['onbehalf_contact_id'] = $individualID;
+    $organizationID = $this->organizationCreate();
+    $form->_params['contact_id'] = $organizationID;
     $this->callAPISuccess('Relationship', 'create', [
-      'contact_id_a' => $contactID,
-      'contact_id_b' => $form->_params['contact_id'],
+      'contact_id_a' => $individualID,
+      'contact_id_b' => $organizationID,
       'relationship_type_id' => 5,
       'is_current_employer' => 1,
     ]);
+
+    $form->_params['onbehalf_contact_id'] = $individualID;
+    $form->_values['id'] = $contributionPageID1;
     $form->processConfirm(
       $form->_params,
-      $form->_params['onbehalf_contact_id'],
-      $form->_values['financial_type_id'],
-      0, FALSE
+      $organizationID,
+      CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'financial_type_id', 'Campaign Contribution'),
+      0, TRUE
     );
     //check if contribution is created on org.
     $contribution = $this->callAPISuccessGetSingle('Contribution', [
-      'contact_id' => $form->_params['onbehalf_contact_id'],
+      'contact_id' => $organizationID,
     ]);
 
-    $activity = civicrm_api3('Activity', 'get', [
-      'sequential' => 1,
+    $activity = $this->callAPISuccessGetSingle('Activity', [
       'source_record_id' => $contribution['id'],
       'contact_id' => $form->_params['onbehalf_contact_id'],
       'activity_type_id' => 'Contribution',
+      'return' => 'target_contact_id',
     ]);
-    $this->assertEquals(1, $activity['count']);
+    $this->assertEquals([$form->_params['contact_id']], $activity['target_contact_id']);
+    $this->assertEquals($individualID, $activity['source_contact_id']);
+    $repeatContribution = $this->callAPISuccess('Contribution', 'repeattransaction', [
+      'original_contribution_id' => $contribution['id'],
+      'contribution_status_id' => 'Pending',
+      'api.Payment.create' => [
+        'total_amount' => 100,
+        'payment_processor_id' => $paymentProcessorID,
+      ],
+    ]);
+    $activity = $this->callAPISuccessGetSingle('Activity', [
+      'source_record_id' => $repeatContribution['id'],
+      'activity_type_id' => 'Contribution',
+      'return' => ['target_contact_id', 'source_contact_id'],
+    ]);
+    $this->assertEquals([$organizationID], $activity['target_contact_id']);
+    $this->assertEquals($individualID, $activity['source_contact_id']);
+  }
+
+  /**
+   * @param array $params
+   *
+   * @return mixed
+   * @throws \CRM_Core_Exception
+   */
+  protected function createContributionPage(array $params): int {
+    return (int) $this->callAPISuccess('ContributionPage', 'create', array_merge([
+      'title' => 'Test Contribution Page',
+      'financial_type_id' => 'Campaign Contribution',
+      'currency' => 'USD',
+      'financial_account_id' => 1,
+      'is_active' => 1,
+      'is_allow_other_amount' => 1,
+      'min_amount' => 20,
+      'max_amount' => 2000,
+    ], $params))['id'];
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Our preferred flow for repeattransaction is to create a pending contribution using Contribution.repeattransaction with contribution_status_id = Pending and then to use Payment.create to add a payment. However in this flow the activity contacts from the original contribution were not being picked up. This fixes and also removes a chunk of code that was only working 

Before
----------------------------------------
When a recurring contribution exists and the original contribution has been paid on behalf then the source contact id is the individual who filled in the form and the target is the organization. However, the activity contacts are not perpetuated onto the next contribution in the series under the (now tested) flow

```
civicrm_api3('Contribution', 'repeattransaction', ['contribution_status_id' => "Pending",
   'api.Payment.create => [
   .....
```

After
----------------------------------------
The activity contact detail is loaded as part of getTemplateContribution and passed through

Technical Details
----------------------------------------
The code that was in the completeOrder function to create the activity was duplicating code in Contribution.create (per the code comments) 

Comments
----------------------------------------
