### PR TITLE
Fix Contribution.create to not attempt to set contacts on activity update

### DIFF
--- a/tests/phpunit/CRM/Activity/Form/SearchTest.php
+++ b/tests/phpunit/CRM/Activity/Form/SearchTest.php
@@ -24,9 +24,12 @@ class CRM_Activity_Form_SearchTest extends CiviUnitTestCase {
   }
 
   /**
-   *  Test submitted the search form.
+   * Test submitted the search form.
+   *
+   * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
    */
-  public function testSearch() {
+  public function testSearch(): void {
 
     $form = new CRM_Activity_Form_Search();
     $_SERVER['REQUEST_METHOD'] = 'GET';

--- a/tests/phpunit/api/v3/JobTest.php
+++ b/tests/phpunit/api/v3/JobTest.php
@@ -462,8 +462,9 @@ class api_v3_JobTest extends CiviUnitTestCase {
    * Note the group combinations & expected results:
    *
    * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
    */
-  public function testBatchMergeWithAssets() {
+  public function testBatchMergeWithAssets(): void {
     $contactID = $this->individualCreate();
     $contact2ID = $this->individualCreate();
     $this->contributionCreate(['contact_id' => $contactID]);


### PR DESCRIPTION
Overview
----------------------------------------
This fixes a bug whereby updating the status of a contribution where the related activity exists and has attached contacts results in the contacts being overwritten. This is relevant to the case where a pending activity is attached to more than one contact

Note this is in PR #19200 and covered in that test but I pulled it out for readability.

https://github.com/civicrm/civicrm-core/pull/19200

Before
----------------------------------------
The values passed to Activity->save() contain target & source contacts regardless of whether it is an update or a new activity. The ids used are less likely to be accurate during the update than in the original create as the create is likely to be in a form context

After
----------------------------------------
Original values are not overwritten

Technical Details
----------------------------------------

Comments
----------------------------------------
