### PR TITLE
#REF Migrate the print_array smarty plugin from in packages into core…

### DIFF
--- a/CRM/Core/Smarty/plugins/modifier.print_array.php
+++ b/CRM/Core/Smarty/plugins/modifier.print_array.php
@@ -1,0 +1,106 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+/**
+ * Smarty print_array modifier plugin
+ *
+ * Type:     modifier<br>
+ * Name:     print_array<br>
+ * Purpose:  formats array for output in DAO files and in APIv3 Examples
+ * To find where this is used do a grep in Smarty templates for |@print_array
+ * @param array|object $var
+ * @param integer $depth
+ * @param integer $length
+ * @return string
+ */
+function smarty_modifier_print_array($var, $depth = 0, $length = 40) {
+
+  switch (gettype($var)) {
+    case 'array':
+      $results = "array(\n";
+      foreach ($var as $curr_key => $curr_val) {
+        $depth++;
+        $results .= str_repeat('  ', ($depth + 1))
+        . "'" . $curr_key . "' => "
+        . smarty_modifier_print_array($curr_val, $depth, $length) . ",\n";
+        $depth--;
+      }
+      $results .= str_repeat('  ', ($depth + 1)) . ")";
+      break;
+
+    case 'object':
+      $object_vars = get_object_vars($var);
+      $results = get_class($var) . ' Object (' . count($object_vars) . ')';
+      foreach ($object_vars as $curr_key => $curr_val) {
+        $depth++;
+        $results .= str_repeat('', $depth + 1)
+        . '->' . $curr_key . ' = '
+        . smarty_modifier_debug_print_var($curr_val, $depth, $length);
+        $depth--;
+      }
+      break;
+
+    case 'boolean':
+    case 'NULL':
+    case 'resource':
+      if (TRUE === $var) {
+        $results .= 'TRUE';
+      }
+      elseif (FALSE === $var) {
+        $results .= 'FALSE';
+      }
+      elseif (NULL === $var) {
+        $results .= '';
+      }
+      else {
+        $results = $var;
+      }
+      $results = $results;
+      break;
+
+    case 'integer':
+    case 'float':
+      $results = $var;
+      break;
+
+    case 'string':
+      if (strlen($var) > $length) {
+        $results = substr($var, 0, $length - 3) . '...';
+      }
+      $results = "'" . $var . "'";
+      break;
+
+    case 'unknown type':
+    default:
+      if (strlen($results) > $length) {
+        $results = substr($results, 0, $length - 3) . '...';
+      }
+      $results = "'" . $var . "'";
+  }
+  if (empty($var)) {
+    if (is_array($var)) {
+      $results = "array()";
+    }
+    elseif ($var === '0' || $var === 0) {
+      $results = 0;
+    }
+    else {
+      $results = "''";
+    }
+  }
+  return $results;
+}


### PR DESCRIPTION
… as it seems to not be supplied by the upstream package

Overview
----------------------------------------
This migrates the print_array modifier that is used by DAO processing and I think the Examples processing into civicrm_core from civicrm_packages as it seems it isn't provided by the upstream plugin as per https://github.com/smarty-php/smarty/tree/Smarty2/libs/plugins

Before
----------------------------------------
Modifier in packages

After
----------------------------------------
Modifier in core

ping @eileenmcnaughton 