### PR TITLE
Recurring Contribution Is Email receipt fix

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -1087,7 +1087,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     $recurParams['invoice_id'] = $params['invoiceID'] ?? NULL;
     $recurParams['contribution_status_id'] = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Pending');
     $recurParams['payment_processor_id'] = $params['payment_processor_id'] ?? NULL;
-    $recurParams['is_email_receipt'] = $params['is_email_receipt'] ?? NULL;
+    $recurParams['is_email_receipt'] = $params['is_email_receipt'] ?? '';
     // we need to add a unique trxn_id to avoid a unique key error
     // in paypal IPN we reset this when paypal sends us the real trxn id, CRM-2991
     $recurParams['trxn_id'] = $params['trxn_id'] ?? $params['invoiceID'];

--- a/tests/phpunit/CRM/Contribute/BAO/ContributionRecurTest.php
+++ b/tests/phpunit/CRM/Contribute/BAO/ContributionRecurTest.php
@@ -564,4 +564,32 @@ class CRM_Contribute_BAO_ContributionRecurTest extends CiviUnitTestCase {
     ];
   }
 
+  /**
+   * Test Recurring Contribution Email Receipt Flag
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testContributionEmailReceipt() {
+    $createParams = $this->_params;
+    unset($createParams['trxn_id'], $createParams['invoice_id']);
+
+    // pass null value to is_email_receipt
+    $createParams['is_email_receipt'] = NULL;
+    $recurring1 = CRM_Contribute_BAO_ContributionRecur::add($createParams);
+    $recurring1Get = $this->callAPISuccess('ContributionRecur', 'getsingle', ['id' => $recurring1->id]);
+    // default is_email_receipt column value is 1
+    $this->assertEquals('1', $recurring1Get['is_email_receipt']);
+
+    // pass empty value to is_email_receipt
+    $createParams['is_email_receipt'] = '';
+    $recurring2 = CRM_Contribute_BAO_ContributionRecur::add($createParams);
+    $this->assertEquals('null', $recurring2->is_email_receipt);
+
+    // pass 0 value to is_email_receipt
+    $createParams['is_email_receipt'] = 0;
+    $recurring3 = CRM_Contribute_BAO_ContributionRecur::add($createParams);
+    $recurring3Get = $this->callAPISuccess('ContributionRecur', 'getsingle', ['id' => $recurring3->id]);
+    $this->assertEquals('0', $recurring3Get['is_email_receipt']);
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
In Table `civicrm_contribution_recur` , column default value of `is_email_receipt` is 1,

When you setup Online Contribution Page with recurring option and unchecked 'Email Receipt to Contributor' checkbox. 

When actual transaction happened, we were passing `NULL`, this set default value for `is_email_receipt` column to `1`.

There after each renewal/recurring payment , contact receive email notification.


Before
----------------------------------------
If we don't pass `is_email_receipt` parameter or if value set to `NULL` then in DB value set to `1`

After
----------------------------------------
Passing '' (empty) value instead of `NULL`, this set `NULL` value in DB.

No Email Notification on recurring payment.
