### PR TITLE
dev/core#2211 Make sure addressee field fits column

### DIFF
--- a/CRM/Export/BAO/ExportProcessor.php
+++ b/CRM/Export/BAO/ExportProcessor.php
@@ -1985,7 +1985,7 @@ SET    addressee = %1, postal_greeting = %2, email_greeting = %3
 WHERE  id = %4
 ";
       $params = [
-        1 => [$values['addressee'], 'String'],
+        1 => [CRM_Utils_String::ellipsify($values['addressee'], 255), 'String'],
         2 => [$values['postalGreeting'], 'String'],
         3 => [$values['emailGreeting'], 'String'],
         4 => [$masterID, 'Integer'],


### PR DESCRIPTION
Truncate if addressee field goes beyond the available 255 characters in an export that merges contacts by shared address.
https://lab.civicrm.org/dev/core/-/issues/2211

Overview
----------------------------------------
When many contacts have matching addresses, exporting them and selecting "Merge All Contacts with the Same Address" crashes cryptically with the "sorry the system is unavailable right now" error. It turns out many addressees combined can exceed the "Addressee" column limits in the temporary search/export table.

`[nativecode=1406 ** Data too long for column 'addressee' at row 1]`

Before
----------------------------------------
Fatal error screen.

After
----------------------------------------
Export completes with truncated 'addressee' field (if they exceeded 255 characters).
