### PR TITLE
Fully deprecate ids from Membership::create BAO

### DIFF
--- a/tests/phpunit/CRM/Member/BAO/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/BAO/MembershipTest.php
@@ -467,7 +467,7 @@ class CRM_Member_BAO_MembershipTest extends CiviUnitTestCase {
    * @throws \CRM_Core_Exception
    * @throws \CiviCRM_API3_Exception
    */
-  public function testStaleMembership() {
+  public function testStaleMembership(): void {
     $statusId = 3;
     $contactId = $this->individualCreate();
     $joinDate = $startDate = date("Ymd", strtotime(date("Ymd") . " -1 year -15 days"));
@@ -501,7 +501,7 @@ class CRM_Member_BAO_MembershipTest extends CiviUnitTestCase {
       'Database checked on membership log record.'
     );
 
-    list($MembershipRenew) = CRM_Member_BAO_Membership::processMembership(
+    [$MembershipRenew] = CRM_Member_BAO_Membership::processMembership(
       $contactId,
       $this->_membershipTypeID,
       FALSE,

--- a/tests/phpunit/CRM/Member/Form/MembershipRenewalTest.php
+++ b/tests/phpunit/CRM/Member/Form/MembershipRenewalTest.php
@@ -696,7 +696,7 @@ class CRM_Member_Form_MembershipRenewalTest extends CiviUnitTestCase {
    * @throws \CRM_Core_Exception
    * @throws \CiviCRM_API3_Exception
    */
-  public function testSubmitRenewExpired() {
+  public function testSubmitRenewExpired(): void {
     $form = $this->getForm(NULL);
     $this->createLoggedInUser();
     $originalMembership = $this->callAPISuccessGetSingle('membership', []);


### PR DESCRIPTION


Overview
----------------------------------------
Fully deprecate ids from Membership::create BAO

Before
----------------------------------------
ids['membership'] referred to in Membership.create BAO

After
----------------------------------------
$params['id'] used. ids['membership used as a deprecated fallback

Technical Details
----------------------------------------
We are now down to the point where we can see the ids membership is only
used to determine if it is an exisiting membership. In which case,
absent a linked contribution, the line items should be deleted
& rebuilt. There is no reason for this to be a magic param
and indeed the api will set ids['membership'] based off params['id']
so we can fully deprecate with a view to removal

Comments
----------------------------------------
