### PR TITLE
Fix lab issue 2254 is_bulkmail cannot be set through UI

### DIFF
--- a/CRM/Core/BAO/Email.php
+++ b/CRM/Core/BAO/Email.php
@@ -44,13 +44,17 @@ class CRM_Core_BAO_Email extends CRM_Core_DAO_Email {
       $email->email = $strtolower($email->email);
     }
 
-    /*
-     * since we're setting bulkmail for 1 of this contact's emails, first reset all their other emails to is_bulkmail false
-     *  We shouldn't set the current email to false even though we
-     *  are about to reset it to avoid contaminating the changelog if logging is enabled.
-     * (only 1 email address can have is_bulkmail = true)
-     */
-    if ($email->is_bulkmail && !empty($params['contact_id']) && !self::isMultipleBulkMail()) {
+    //
+    // Since we're setting bulkmail for 1 of this contact's emails, first reset
+    // all their other emails to is_bulkmail false. We shouldn't set the current
+    // email to false even though we are about to reset it to avoid
+    // contaminating the changelog if logging is enabled.  (only 1 email
+    // address can have is_bulkmail = true)
+    //
+    // Note setting a the is_bulkmail to '' in $params results in $email->is_bulkmail === 'null'.
+    // @see https://lab.civicrm.org/dev/core/-/issues/2254
+    //
+    if ($email->is_bulkmail == 1 && !empty($params['contact_id']) && !self::isMultipleBulkMail()) {
       $sql = "
 UPDATE civicrm_email
 SET    is_bulkmail = 0


### PR DESCRIPTION
Overview
----------------------------------------

Fix [lab 2254](https://lab.civicrm.org/dev/core/-/issues/2254)


Technical Details
----------------------------------------

Setting the BAO `is_bulkmail` to `''` actually sets it to `'null'` and therefore the test for "is bulkmail set?" written as `if ($email->is_bulkmail...)` returns TRUE since `'null'` is not empty.

I don't really understand the wisdom of using the string `'null'` when we have `NULL`, but that's what we have. I think this PR could be optimised but without understanding the whys and wherefores of when data is and isn't cast to something weird, I played it safe.
