### PR TITLE
Greenwich: Fix Select2 free-tagging css bug

### DIFF
--- a/ext/greenwich/scss/_tweaks.scss
+++ b/ext/greenwich/scss/_tweaks.scss
@@ -6,3 +6,7 @@
 label input[type=checkbox]:not(:checked) + * {
   font-weight: normal;
 }
+/* Fix tagging-style select2 */
+.select2-choices {
+  margin-bottom: 0;
+}


### PR DESCRIPTION
Overview
----------------------------------------
Adds a CSS tweak to Greenwich that fixes a style conflict between Bootstrap and Select2.

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/2874912/102232284-e9125a80-3ebc-11eb-8c0a-bd92d6aa0ece.png)


After
----------------------------------------
![image](https://user-images.githubusercontent.com/2874912/102232178-cd0eb900-3ebc-11eb-9b4a-3ef6d21fbe08.png)

