### PR TITLE
Remove unused tpl assigns

### DIFF
--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -932,9 +932,6 @@ DESC limit 1");
 
       $valuesForForm = CRM_Contribute_Form_AbstractEditPayment::formatCreditCardDetails($form->_params);
       $form->assignVariables($valuesForForm, ['credit_card_exp_date', 'credit_card_type', 'credit_card_number']);
-
-      $form->assign('contributeMode', 'direct');
-      $form->assign('isAmountzero', 0);
       $form->assign('is_pay_later', 0);
       $form->assign('isPrimary', 1);
     }


### PR DESCRIPTION
These really look like they were copied over from participant forms -
they are not used in the membership tpl receipts

Overview
----------------------------------------
Remove unused tpl assigns

Before
----------------------------------------
ContributeMode and isAmountZero are assigned to the tpl but these are used in participant message templates, not membership ones. 

After
----------------------------------------
poof

Technical Details
----------------------------------------
This looks to me like code that came from the Participant code rather than was ever relevant to membership tpls, of else it is long gone from them

Comments
----------------------------------------
