### PR TITLE
Remove duplicated tax assignments from copied code

### DIFF
--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -1492,6 +1492,8 @@ DESC limit 1");
         $isRecur, $calcDates));
     }
 
+    // This would always be true as we always add price set id into both
+    // quick config & non quick config price sets.
     if (!empty($lineItem[$this->_priceSetId])) {
       $invoicing = Civi::settings()->get('invoicing');
       $taxAmount = FALSE;
@@ -1937,29 +1939,6 @@ DESC limit 1");
       $contributionParams['total_amount'] = $params['amount'];
 
       $contribution = CRM_Contribute_BAO_Contribution::add($contributionParams);
-
-      $invoiceSettings = Civi::settings()->get('contribution_invoice_settings');
-      $invoicing = $invoiceSettings['invoicing'] ?? NULL;
-      if ($invoicing) {
-        $dataArray = [];
-        // @todo - interrogate the line items passed in on the params array.
-        // No reason to assume line items will be set on the form.
-        foreach ($form->_lineItem as $lineItemKey => $lineItemValue) {
-          foreach ($lineItemValue as $key => $value) {
-            if (isset($value['tax_amount']) && isset($value['tax_rate'])) {
-              if (isset($dataArray[$value['tax_rate']])) {
-                $dataArray[$value['tax_rate']] = $dataArray[$value['tax_rate']] + $value['tax_amount'];
-              }
-              else {
-                $dataArray[$value['tax_rate']] = $value['tax_amount'];
-              }
-            }
-          }
-        }
-        $smarty = CRM_Core_Smarty::singleton();
-        $smarty->assign('dataArray', $dataArray);
-        $smarty->assign('totalTaxAmount', $params['tax_amount'] ?? NULL);
-      }
 
       // lets store it in the form variable so postProcess hook can get to this and use it
       $form->_contributionID = $contribution->id;


### PR DESCRIPTION

Overview
----------------------------------------
Remove duplicated tax assignments from copied code

Before
----------------------------------------
Tax data for the template being assigned twice in the recurring payment for membership back-office form flow. The instance being removed is from a previously shared function - very little of which is actually relevant to this form
```
  $smarty->assign('dataArray', $dataArray);
        $smarty->assign('totalTaxAmount', $params['tax_amount'] ?? NULL);
```

After
----------------------------------------
poof

Technical Details
----------------------------------------
The assignment of tax data is happening twice on the form - once in generic
code and once in code only reached for recurring contributions that
was in previously-shared code. We can be fairly comfortable that
in this latter case we don't need it as this is a marginal flow
on this form whereas the main flow is being used 90% of the time
& is doing the assignment

Comments
----------------------------------------
