### PR TITLE
Convert previously shared function from static to non-static

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -1442,8 +1442,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
         CRM_Price_BAO_LineItem::getLineItemArray($membershipParams);
 
       }
-      $paymentResult = self::processConfirm(
-        $form,
+      $paymentResult = $form->processConfirm(
         $membershipParams,
         $contactID,
         $financialTypeID,
@@ -2301,7 +2300,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
         }
       }
 
-      $result = self::processConfirm($this, $paymentParams,
+      $result = $this->processConfirm($paymentParams,
         $contactID,
         $this->wrangleFinancialTypeID($this->_values['financial_type_id']),
         ($this->_mode == 'test') ? 1 : 0,
@@ -2522,8 +2521,6 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
   /**
    * Process payment after confirmation.
    *
-   * @param CRM_Core_Form $form
-   *   Form object.
    * @param array $paymentParams
    *   Array with payment related key.
    *   value pairs
@@ -2539,14 +2536,14 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
    * @return array
    *   associated array
    */
-  public static function processConfirm(
-    &$form,
+  public function processConfirm(
     &$paymentParams,
     $contactID,
     $financialTypeID,
     $isTest,
     $isRecur
   ): array {
+    $form = $this;
     CRM_Core_Payment_Form::mapParams($form->_bltID, $form->_params, $paymentParams, TRUE);
     $isPaymentTransaction = self::isPaymentTransaction($form);
 

--- a/tests/phpunit/CRM/Contribute/Form/Contribution/ConfirmTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/Contribution/ConfirmTest.php
@@ -105,7 +105,7 @@ class CRM_Contribute_Form_Contribution_ConfirmTest extends CiviUnitTestCase {
       'skipLineItem' => 0,
     ];
 
-    $processConfirmResult = CRM_Contribute_Form_Contribution_Confirm::processConfirm($form,
+    $processConfirmResult = $form->processConfirm(
       $form->_params,
       $contactID,
       $form->_values['financial_type_id'],
@@ -155,7 +155,7 @@ class CRM_Contribute_Form_Contribution_ConfirmTest extends CiviUnitTestCase {
       'relationship_type_id' => 5,
       'is_current_employer' => 1,
     ]);
-    CRM_Contribute_Form_Contribution_Confirm::processConfirm($form,
+    $form->processConfirm(
       $form->_params,
       $form->_params['onbehalf_contact_id'],
       $form->_values['financial_type_id'],


### PR DESCRIPTION


Overview
----------------------------------------
Convert previously shared function from static to non-static

Before
----------------------------------------
processConfirm is static

After
----------------------------------------
processConfirm is not static

Technical Details
----------------------------------------
This no longer needs to be static as it is no longer shared with other forms
(although it needs to be public to support the test class)

Comments
----------------------------------------
