### PR TITLE
Add min-width to flex columns for responsive layout on small screens

### DIFF
--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -21,6 +21,7 @@
 
 .crm-container .crm-flex-box {
   display: flex;
+  flex-wrap: wrap;
 }
 .crm-container .crm-flex-box > * {
   flex: 1;

--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -2,6 +2,13 @@
   min-height: 200px;
 }
 
+#civicrm-dashboard > .crm-flex-box > .crm-flex-2 {
+  min-width: 300px;
+}
+#civicrm-dashboard > .crm-flex-box > .crm-flex-3 {
+  min-width: 450px;
+}
+
 .crm-container .crm-dashlet {
   margin: 10px;
   box-shadow: 1px 1px 4px 1px rgba(0,0,0,0.2);

--- a/ext/search/ang/crmSearchAdmin/compose/criteria.html
+++ b/ext/search/ang/crmSearchAdmin/compose/criteria.html
@@ -1,5 +1,5 @@
 <div class="crm-flex-box">
-  <div>
+  <div class="crm-search-criteria-column">
     <div ng-if=":: $ctrl.paramExists('join')">
       <fieldset ng-repeat="join in $ctrl.savedSearch.api_params.join">
         <div class="form-inline">
@@ -36,7 +36,7 @@
       </fieldset>
     </fieldset>
   </div>
-  <div>
+  <div class="crm-search-criteria-column">
     <fieldset class="api4-clause-fieldset">
       <crm-search-clause clauses="$ctrl.savedSearch.api_params.where" format="string" op="AND" label="{{ ts('Where') }}" fields="fieldsForWhere" ></crm-search-clause>
     </fieldset>

--- a/ext/search/css/search.css
+++ b/ext/search/css/search.css
@@ -1,3 +1,7 @@
+#bootstrap-theme .crm-search-criteria-column {
+  min-width: 500px;
+}
+
 #bootstrap-theme #crm-search-results-page-size {
   width: 5em;
 }


### PR DESCRIPTION
Overview
----------------------------------------
Adjusts 2-column layouts in main dashboard and Search Kit to collapse to 1 column on small screens.

Before
----------------------------------------
Small screens look like:
![image](https://user-images.githubusercontent.com/2874912/102414495-a5a31380-3fc4-11eb-9611-2ee8ed921b94.png)


After
----------------------------------------
Small screens look like:
![image](https://user-images.githubusercontent.com/2874912/102414436-899f7200-3fc4-11eb-9d70-e61496a00f2f.png)

Technical Details
----------------------------------------
The .crm-flex-box class is new and only used in 2 places: Search Kit & the Dashboard.
This sets a min-width on those layouts so the 2 columns collapse to 1 on small screens.