### PR TITLE
dev/core#2258 - Add services to support encryption

### DIFF
--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -1760,6 +1760,23 @@ abstract class CRM_Utils_Hook {
   }
 
   /**
+   * Initialize the cryptographic service.
+   *
+   * This may be used to register additional keys or cipher-suites.
+   *
+   * @param \Civi\Crypto\CryptoRegistry $crypto
+   *
+   * @return mixed
+   */
+  public static function crypto($crypto) {
+    return self::singleton()->invoke(['crypto'], $crypto, self::$_nullObject,
+      self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      self::$_nullObject,
+      'civicrm_crypto'
+    );
+  }
+
+  /**
    * This hook collects the trigger definition from all components.
    *
    * @param $info

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -1760,9 +1760,12 @@ abstract class CRM_Utils_Hook {
   }
 
   /**
-   * Initialize the cryptographic service.
+   * Register cryptographic resources, such as keys and cipher-suites.
    *
-   * This may be used to register additional keys or cipher-suites.
+   * Ex: $crypto->addSymmetricKey([
+   *   'key' => hash_hkdf('sha256', 'abcd1234'),
+   *   'suite' => 'aes-cbc-hs',
+   * ]);
    *
    * @param \Civi\Crypto\CryptoRegistry $crypto
    *

--- a/CRM/Utils/String.php
+++ b/CRM/Utils/String.php
@@ -222,6 +222,31 @@ class CRM_Utils_String {
   }
 
   /**
+   * Encode string using URL-safe Base64.
+   *
+   * @param string $v
+   *
+   * @return string
+   * @see https://tools.ietf.org/html/rfc4648#section-5
+   */
+  public static function base64UrlEncode($v) {
+    return rtrim(str_replace(['+', '/'], ['-', '_'], base64_encode($v)), '=');
+  }
+
+  /**
+   * Decode string using URL-safe Base64.
+   *
+   * @param string $v
+   *
+   * @return false|string
+   * @see https://tools.ietf.org/html/rfc4648#section-5
+   */
+  public static function base64UrlDecode($v) {
+    // PHP base64_decode() is already forgiving about padding ("=").
+    return base64_decode(str_replace(['-', '_'], ['+', '/'], $v));
+  }
+
+  /**
    * Determine the string replacements for redaction.
    * on the basis of the regular expressions
    *

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -221,10 +221,8 @@ class Container {
     $container->setDefinition('crypto.registry', new Definition('Civi\Crypto\CryptoService'))
       ->setFactory(__CLASS__ . '::createCryptoRegistry')->setPublic(TRUE);
 
-    $container->setDefinition('crypto.token', new Definition(
-      'Civi\Crypto\CryptoToken',
-      [new Reference('crypto.registry')]
-    ))->setPublic(TRUE);
+    $container->setDefinition('crypto.token', new Definition('Civi\Crypto\CryptoToken', []))
+      ->setPublic(TRUE);
 
     if (empty(\Civi::$statics[__CLASS__]['boot'])) {
       throw new \RuntimeException('Cannot initialize container. Boot services are undefined.');

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -221,6 +221,11 @@ class Container {
     $container->setDefinition('crypto.registry', new Definition('Civi\Crypto\CryptoService'))
       ->setFactory(__CLASS__ . '::createCryptoRegistry')->setPublic(TRUE);
 
+    $container->setDefinition('crypto.token', new Definition(
+      'Civi\Crypto\CryptoToken',
+      [new Reference('crypto.registry')]
+    ))->setPublic(TRUE);
+
     if (empty(\Civi::$statics[__CLASS__]['boot'])) {
       throw new \RuntimeException('Cannot initialize container. Boot services are undefined.');
     }

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -218,6 +218,9 @@ class Container {
     $container->setDefinition('pear_mail', new Definition('Mail'))
       ->setFactory('CRM_Utils_Mail::createMailer')->setPublic(TRUE);
 
+    $container->setDefinition('crypto.registry', new Definition('Civi\Crypto\CryptoService'))
+      ->setFactory(__CLASS__ . '::createCryptoRegistry')->setPublic(TRUE);
+
     if (empty(\Civi::$statics[__CLASS__]['boot'])) {
       throw new \RuntimeException('Cannot initialize container. Boot services are undefined.');
     }
@@ -497,6 +500,48 @@ class Container {
     $settings = \CRM_Utils_Cache::getCacheSettings($driver);
     $settings['driver'] = $driver;
     return new \ArrayObject($settings);
+  }
+
+  /**
+   * Initialize the cryptogrpahic registry. It tracks available ciphers and keys.
+   *
+   * @return \Civi\Crypto\CryptoRegistry
+   * @throws \CRM_Core_Exception
+   * @throws \Civi\Crypto\Exception\CryptoException
+   */
+  public static function createCryptoRegistry() {
+    $crypto = new \Civi\Crypto\CryptoRegistry();
+
+    $crypto->addPlainText(['tags' => ['CRED']]);
+    if (defined('CIVICRM_CRED_KEYS')) {
+      foreach (explode(' ', CIVICRM_CRED_KEYS) as $n => $keyExpr) {
+        $crypto->addSymmetricKey($crypto->parseKey($keyExpr) + [
+          'tags' => ['CRED'],
+          'weight' => $n,
+        ]);
+      }
+    }
+    if (defined('CIVICRM_SITE_KEY')) {
+      // Recent upgrades may not have CIVICRM_CRED_KEYS. Transitional support - the CIVICRM_SITE_KEY is last-priority option for credentials.
+      $crypto->addSymmetricKey([
+        'key' => hash_hkdf('sha256', CIVICRM_SITE_KEY),
+        'suite' => 'aes-cbc',
+        'tags' => ['CRED'],
+        'weight' => 30000,
+      ]);
+    }
+    //if (isset($_COOKIE['CIVICRM_FORM_KEY'])) {
+    //  $crypto->addSymmetricKey([
+    //    'key' => base64_decode($_COOKIE['CIVICRM_FORM_KEY']),
+    //    'suite' => 'aes-cbc',
+    //    'tag' => ['FORM'],
+    //  ]);
+    //  // else: somewhere in CRM_Core_Form, we may need to initialize CIVICRM_FORM_KEY
+    //}
+
+    // Allow plugins to add/replace any keys and ciphers.
+    \CRM_Utils_Hook::crypto($crypto);
+    return $crypto;
   }
 
   /**

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -219,7 +219,7 @@ class Container {
       ->setFactory('CRM_Utils_Mail::createMailer')->setPublic(TRUE);
 
     $container->setDefinition('crypto.registry', new Definition('Civi\Crypto\CryptoService'))
-      ->setFactory(__CLASS__ . '::createCryptoRegistry')->setPublic(TRUE);
+      ->setFactory('Civi\Crypto\CryptoRegistry::createDefaultRegistry')->setPublic(TRUE);
 
     $container->setDefinition('crypto.token', new Definition('Civi\Crypto\CryptoToken', []))
       ->setPublic(TRUE);
@@ -503,49 +503,6 @@ class Container {
     $settings = \CRM_Utils_Cache::getCacheSettings($driver);
     $settings['driver'] = $driver;
     return new \ArrayObject($settings);
-  }
-
-  /**
-   * Initialize the cryptogrpahic registry. It tracks available ciphers and keys.
-   *
-   * @return \Civi\Crypto\CryptoRegistry
-   * @throws \CRM_Core_Exception
-   * @throws \Civi\Crypto\Exception\CryptoException
-   */
-  public static function createCryptoRegistry() {
-    $crypto = new \Civi\Crypto\CryptoRegistry();
-    $crypto->addCipherSuite(new \Civi\Crypto\PhpseclibCipherSuite());
-
-    $crypto->addPlainText(['tags' => ['CRED']]);
-    if (defined('CIVICRM_CRED_KEYS')) {
-      foreach (explode(' ', CIVICRM_CRED_KEYS) as $n => $keyExpr) {
-        $crypto->addSymmetricKey($crypto->parseKey($keyExpr) + [
-          'tags' => ['CRED'],
-          'weight' => $n,
-        ]);
-      }
-    }
-    if (defined('CIVICRM_SITE_KEY')) {
-      // Recent upgrades may not have CIVICRM_CRED_KEYS. Transitional support - the CIVICRM_SITE_KEY is last-priority option for credentials.
-      $crypto->addSymmetricKey([
-        'key' => hash_hkdf('sha256', CIVICRM_SITE_KEY),
-        'suite' => 'aes-cbc',
-        'tags' => ['CRED'],
-        'weight' => 30000,
-      ]);
-    }
-    //if (isset($_COOKIE['CIVICRM_FORM_KEY'])) {
-    //  $crypto->addSymmetricKey([
-    //    'key' => base64_decode($_COOKIE['CIVICRM_FORM_KEY']),
-    //    'suite' => 'aes-cbc',
-    //    'tag' => ['FORM'],
-    //  ]);
-    //  // else: somewhere in CRM_Core_Form, we may need to initialize CIVICRM_FORM_KEY
-    //}
-
-    // Allow plugins to add/replace any keys and ciphers.
-    \CRM_Utils_Hook::crypto($crypto);
-    return $crypto;
   }
 
   /**

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -511,6 +511,7 @@ class Container {
    */
   public static function createCryptoRegistry() {
     $crypto = new \Civi\Crypto\CryptoRegistry();
+    $crypto->addCipherSuite(new \Civi\Crypto\PhpseclibCipherSuite());
 
     $crypto->addPlainText(['tags' => ['CRED']]);
     if (defined('CIVICRM_CRED_KEYS')) {

--- a/Civi/Crypto/CipherSuiteInterface.php
+++ b/Civi/Crypto/CipherSuiteInterface.php
@@ -1,0 +1,51 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+namespace Civi\Crypto;
+
+/**
+ * @package Civi\Crypt
+ */
+interface CipherSuiteInterface {
+
+  /**
+   * Get a list of supported cipher suites.
+   *
+   * @return array
+   *   Ex: ['aes-cbc', 'aes-bbc', 'aes-pbs']
+   */
+  public function getSuites(): array;
+
+  /**
+   * Encrypt a string
+   *
+   * @param string $plainText
+   * @param array $key
+   *
+   * @return string
+   *   Encrypted content as a binary string.
+   *   Depending on the suite, this may include related values (eg HMAC + IV).
+   */
+  public function encrypt(string $plainText, array $key): string;
+
+  /**
+   * Decrypt a string
+   *
+   * @param string $cipherText
+   *   Encrypted content as a binary string.
+   *   Depending on the suite, this may include related values (eg HMAC + IV).
+   * @param array $key
+   *
+   * @return string
+   *   Decrypted string
+   */
+  public function decrypt(string $cipherText, array $key): string;
+
+}

--- a/Civi/Crypto/CryptoRegistry.php
+++ b/Civi/Crypto/CryptoRegistry.php
@@ -54,6 +54,49 @@ class CryptoRegistry {
 
   protected $cipherSuites = [];
 
+  /**
+   * Initialize a default instance of the registry.
+   *
+   * @return \Civi\Crypto\CryptoRegistry
+   * @throws \CRM_Core_Exception
+   * @throws \Civi\Crypto\Exception\CryptoException
+   */
+  public static function createDefaultRegistry() {
+    $registry = new static();
+    $registry->addCipherSuite(new \Civi\Crypto\PhpseclibCipherSuite());
+
+    $registry->addPlainText(['tags' => ['CRED']]);
+    if (defined('CIVICRM_CRED_KEYS')) {
+      foreach (explode(' ', CIVICRM_CRED_KEYS) as $n => $keyExpr) {
+        $registry->addSymmetricKey($registry->parseKey($keyExpr) + [
+          'tags' => ['CRED'],
+          'weight' => $n,
+        ]);
+      }
+    }
+    if (defined('CIVICRM_SITE_KEY')) {
+      // Recent upgrades may not have CIVICRM_CRED_KEYS. Transitional support - the CIVICRM_SITE_KEY is last-priority option for credentials.
+      $registry->addSymmetricKey([
+        'key' => hash_hkdf('sha256', CIVICRM_SITE_KEY),
+        'suite' => 'aes-cbc',
+        'tags' => ['CRED'],
+        'weight' => 30000,
+      ]);
+    }
+    //if (isset($_COOKIE['CIVICRM_FORM_KEY'])) {
+    //  $crypto->addSymmetricKey([
+    //    'key' => base64_decode($_COOKIE['CIVICRM_FORM_KEY']),
+    //    'suite' => 'aes-cbc',
+    //    'tag' => ['FORM'],
+    //  ]);
+    //  // else: somewhere in CRM_Core_Form, we may need to initialize CIVICRM_FORM_KEY
+    //}
+
+    // Allow plugins to add/replace any keys and ciphers.
+    \CRM_Utils_Hook::crypto($registry);
+    return $registry;
+  }
+
   public function __construct() {
     $this->cipherSuites['plain'] = TRUE;
     $this->keys['plain'] = [

--- a/Civi/Crypto/CryptoRegistry.php
+++ b/Civi/Crypto/CryptoRegistry.php
@@ -74,15 +74,7 @@ class CryptoRegistry {
         ]);
       }
     }
-    if (defined('CIVICRM_SITE_KEY')) {
-      // Recent upgrades may not have CIVICRM_CRED_KEYS. Transitional support - the CIVICRM_SITE_KEY is last-priority option for credentials.
-      $registry->addSymmetricKey([
-        'key' => hash_hkdf('sha256', CIVICRM_SITE_KEY),
-        'suite' => 'aes-cbc',
-        'tags' => ['CRED'],
-        'weight' => 30000,
-      ]);
-    }
+
     //if (isset($_COOKIE['CIVICRM_FORM_KEY'])) {
     //  $crypto->addSymmetricKey([
     //    'key' => base64_decode($_COOKIE['CIVICRM_FORM_KEY']),

--- a/Civi/Crypto/CryptoRegistry.php
+++ b/Civi/Crypto/CryptoRegistry.php
@@ -68,10 +68,13 @@ class CryptoRegistry {
     $registry->addPlainText(['tags' => ['CRED']]);
     if (defined('CIVICRM_CRED_KEYS')) {
       foreach (explode(' ', CIVICRM_CRED_KEYS) as $n => $keyExpr) {
-        $registry->addSymmetricKey($registry->parseKey($keyExpr) + [
-          'tags' => ['CRED'],
-          'weight' => $n,
-        ]);
+        $key = ['tags' => ['CRED'], 'weight' => $n];
+        if ($keyExpr === 'plain') {
+          $registry->addPlainText($key);
+        }
+        else {
+          $registry->addSymmetricKey($registry->parseKey($keyExpr) + $key);
+        }
       }
     }
 
@@ -169,14 +172,15 @@ class CryptoRegistry {
    * @return array
    */
   public function addPlainText($options) {
-    if (!isset($this->keys['plain'])) {
-    }
-    if (isset($options['tags'])) {
-      $this->keys['plain']['tags'] = array_merge(
-        $options['tags']
-      );
-    }
-    return $this->keys['plain'];
+    static $n = 0;
+    $defaults = [
+      'suite' => 'plain',
+      'weight' => self::LAST_WEIGHT,
+    ];
+    $options = array_merge($defaults, $options);
+    $options['id'] = 'plain' . ($n++);
+    $this->keys[$options['id']] = $options;
+    return $options;
   }
 
   /**

--- a/Civi/Crypto/CryptoRegistry.php
+++ b/Civi/Crypto/CryptoRegistry.php
@@ -1,0 +1,244 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Crypto;
+
+use Civi\Crypto\Exception\CryptoException;
+
+/**
+ * The CryptoRegistry tracks a list of available keys and cipher suites:
+ *
+ * - A registered cipher suite is an instance of CipherSuiteInterface that
+ *   provides a list of encryption options ("aes-cbc", "aes-ctr", etc) and
+ *   an implementation for them.
+ * - A registered key is an array that indicates a set of cryptographic options:
+ *     - key: string, binary representation of the key
+ *     - suite: string, e.g. "aes-cbc" or "aes-cbc-hs"
+ *     - id: string, unique (non-sensitive) ID. Usually a fingerprint.
+ *     - tags: string[], list of symbolic names/use-cases that may call upon this key
+ *     - weight: int, when choosing a key for encryption, two similar keys will be
+ *       be differentiated by weight. (Low values chosen before high values.)
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+class CryptoRegistry {
+
+  const LAST_WEIGHT = 32768;
+
+  const DEFAULT_SUITE = 'aes-cbc';
+
+  const DEFAULT_KDF = 'hkdf-sha256';
+
+  /**
+   * List of available keys.
+   *
+   * @var array[]
+   */
+  protected $keys = [];
+
+  /**
+   * List of key-derivation functions. Used when loading keys.
+   *
+   * @var array
+   */
+  protected $kdfs = [];
+
+  protected $cipherSuites = [];
+
+  public function __construct() {
+    $this->cipherSuites['plain'] = TRUE;
+    $this->keys['plain'] = [
+      'key' => '',
+      'suite' => 'plain',
+      'tags' => [],
+      'id' => 'plain',
+      'weight' => self::LAST_WEIGHT,
+    ];
+
+    // Base64 - Useful for precise control. Relatively quick decode. Please bring your own entropy.
+    $this->kdfs['b64'] = 'base64_decode';
+
+    // HKDF - Forgiving about diverse inputs. Relatively quick decode. Please bring your own entropy.
+    $this->kdfs['hkdf-sha256'] = function($v) {
+      // NOTE: 256-bit output by default. Useful for pairing with AES-256.
+      return hash_hkdf('sha256', $v);
+    };
+
+    // Possible future options: Read from PEM file. Run PBKDF2 on a passphrase.
+  }
+
+  /**
+   * @param string|array $options
+   *   Additional options:
+   *     - key: string, a representation of the key as binary
+   *     - suite: string, ex: 'aes-cbc'
+   *     - tags: string[]
+   *     - weight: int, default 0
+   *     - id: string, a unique identifier for this key. (default: fingerprint the key+suite)
+   *
+   * @return array
+   *   The full key record. (Same format as $options)
+   * @throws \Civi\Crypto\Exception\CryptoException
+   */
+  public function addSymmetricKey($options) {
+    $defaults = [
+      'suite' => self::DEFAULT_SUITE,
+      'weight' => 0,
+    ];
+    $options = array_merge($defaults, $options);
+
+    if (!isset($options['key'])) {
+      throw new CryptoException("Missing crypto key");
+    }
+
+    if (!isset($options['id'])) {
+      $options['id'] = \CRM_Utils_String::base64UrlEncode(sha1($options['suite'] . chr(0) . $options['key'], TRUE));
+    }
+    // Manual key IDs should be validated.
+    elseif (!$this->isValidKeyId($options['id'])) {
+      throw new CryptoException("Malformed key ID");
+    }
+
+    $this->keys[$options['id']] = $options;
+    return $options;
+  }
+
+  /**
+   * Determine if a key ID is well-formed.
+   *
+   * @param string $id
+   * @return bool
+   */
+  public function isValidKeyId($id) {
+    if (strpos($id, "\n") !== FALSE) {
+      return FALSE;
+    }
+    return (bool) preg_match(';^[a-zA-Z0-9_\-\.:,=+/\;\\\\]+$;s', $id);
+  }
+
+  /**
+   * Enable plain-text encoding.
+   *
+   * @param array $options
+   *   Array with options:
+   *   - tags: string[]
+   * @return array
+   */
+  public function addPlainText($options) {
+    if (!isset($this->keys['plain'])) {
+    }
+    if (isset($options['tags'])) {
+      $this->keys['plain']['tags'] = array_merge(
+        $options['tags']
+      );
+    }
+    return $this->keys['plain'];
+  }
+
+  /**
+   * @param CipherSuiteInterface $cipherSuite
+   *   The encryption/decryption callback/handler
+   * @param string[]|NULL $names
+   *   Symbolic names. Ex: 'aes-cbc'
+   *   If NULL, probe $cipherSuite->getNames()
+   */
+  public function addCipherSuite(CipherSuiteInterface $cipherSuite, $names = NULL) {
+    $names = $names ?: $cipherSuite->getSuites();
+    foreach ($names as $name) {
+      $this->cipherSuites[$name] = $cipherSuite;
+    }
+  }
+
+  public function getKeys() {
+    return $this->keys;
+  }
+
+  /**
+   * Locate a key in the list of available keys.
+   *
+   * @param string|string[] $keyIds
+   *   List of IDs or tags. The first match in the list is returned.
+   *   If multiple keys match the same tag, then the one with lowest 'weight' is returned.
+   * @return array
+   * @throws \Civi\Crypto\Exception\CryptoException
+   */
+  public function findKey($keyIds) {
+    $keyIds = (array) $keyIds;
+    foreach ($keyIds as $keyIdOrTag) {
+      if (isset($this->keys[$keyIdOrTag])) {
+        return $this->keys[$keyIdOrTag];
+      }
+
+      $matchKeyId = NULL;
+      $matchWeight = self::LAST_WEIGHT;
+      foreach ($this->keys as $key) {
+        if (in_array($keyIdOrTag, $key['tags']) && $key['weight'] <= $matchWeight) {
+          $matchKeyId = $key['id'];
+          $matchWeight = $key['weight'];
+        }
+      }
+      if ($matchKeyId !== NULL) {
+        return $this->keys[$matchKeyId];
+      }
+    }
+
+    throw new CryptoException("Failed to find key by ID or tag (" . implode(' ', $keyIds) . ")");
+  }
+
+  /**
+   * @param string $name
+   * @return \Civi\Crypto\CipherSuiteInterface
+   * @throws \Civi\Crypto\Exception\CryptoException
+   */
+  public function findSuite($name) {
+    if (isset($this->cipherSuites[$name])) {
+      return $this->cipherSuites[$name];
+    }
+    else {
+      throw new CryptoException('Unknown cipher suite ' . $name);
+    }
+  }
+
+  /**
+   * @param string $keyExpr
+   *   String in the form "<suite>:<key-encoding>:<key-value>".
+   *
+   *   'aes-cbc:b64:cGxlYXNlIHVzZSAzMiBieXRlcyBmb3IgYWVzLTI1NiE='
+   *   'aes-cbc:hkdf-sha256:ABCD1234ABCD1234ABCD1234ABCD1234'
+   *   '::ABCD1234ABCD1234ABCD1234ABCD1234'
+   *
+   * @return array
+   *   Properties:
+   *    - key: string, binary representation
+   *    - suite: string, ex: 'aes-cbc'
+   * @throws CryptoException
+   */
+  public function parseKey($keyExpr) {
+    list($suite, $keyFunc, $keyVal) = explode(':', $keyExpr);
+    if ($suite === '') {
+      $suite = self::DEFAULT_SUITE;
+    }
+    if ($keyFunc === '') {
+      $keyFunc = self::DEFAULT_KDF;
+    }
+    if (isset($this->kdfs[$keyFunc])) {
+      return [
+        'suite' => $suite,
+        'key' => call_user_func($this->kdfs[$keyFunc], $keyVal),
+      ];
+    }
+    else {
+      throw new CryptoException("Crypto key has unrecognized type");
+    }
+  }
+
+}

--- a/Civi/Crypto/CryptoRegistry.php
+++ b/Civi/Crypto/CryptoRegistry.php
@@ -234,6 +234,24 @@ class CryptoRegistry {
   }
 
   /**
+   * Find all the keys that apply to a tag.
+   *
+   * @param string $keyTag
+   *
+   * @return array
+   *   List of keys, indexed by id, ordered by weight.
+   */
+  public function findKeysByTag($keyTag) {
+    $keys = array_filter($this->keys, function ($key) use ($keyTag) {
+      return in_array($keyTag, $key['tags'] ?? []);
+    });
+    uasort($keys, function($a, $b) {
+      return ($a['weight'] ?? 0) - ($b['weight'] ?? 0);
+    });
+    return $keys;
+  }
+
+  /**
    * @param string $name
    * @return \Civi\Crypto\CipherSuiteInterface
    * @throws \Civi\Crypto\Exception\CryptoException

--- a/Civi/Crypto/CryptoToken.php
+++ b/Civi/Crypto/CryptoToken.php
@@ -1,0 +1,140 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Crypto;
+
+use Civi\Crypto\Exception\CryptoException;
+
+/**
+ * The "Crypto Token" service supports a token format suitable for
+ * storing specific values in the database with encryption. Characteristics:
+ *
+ * - Primarily designed to defend confidentiality in case of data-leaks
+ *   (SQL injections, lost backups, etc).
+ * - NOT appropriate for securing data-transmission. Data-transmission
+ *   requires more protections (eg mandatory TTLs + signatures). If you need
+ *   that, consider adding a JWT/JWS/JWE implementation.
+ * - Data-format allows phase-in/phase-out. If you have a datum that was written
+ *   with an old key or with no key, it will still be readable.
+ *
+ * USAGE: The "encrypt()" and "decrypt()" methods are the primary interfaces.
+ *
+ *   $encrypted = Civi::service('crypto.token')->encrypt('my-mail-password, 'KEY_ID_OR_TAG');
+ *   $decrypted = Civi::service('crypto.token')->decrypt($encrypted, '*');
+ *
+ * FORMAT: An encoded token may be in either of these formats:
+ *
+ *   - Plain text: Any string which does not begin with chr(2)
+ *   - Encrypted text: A string in the format:
+ *        TOKEN := DLM + VERSION + DLM + KEY_ID + DLM + CIPHERTEXT
+ *        DLM := ASCII CHAR #2
+ *        VERSION := String, 4-digit, alphanumeric (as in "CTK0")
+ *        KEY_ID := String, alphanumeric and symbols "_-.,:;=+/\"
+ *
+ * @package Civi\Crypto
+ */
+class CryptoToken {
+
+  const VERSION_1 = 'CTK0';
+
+  /**
+   * @var CryptoRegistry
+   */
+  protected $registry;
+
+  protected $delim;
+
+  /**
+   * CryptoToken constructor.
+   * @param \Civi\Crypto\CryptoRegistry $registry
+   */
+  public function __construct(\Civi\Crypto\CryptoRegistry $registry) {
+    $this->delim = chr(2);
+    $this->registry = $registry;
+  }
+
+  /**
+   * Determine if a string looks like plain-text.
+   *
+   * @param string $plainText
+   * @return bool
+   */
+  public function isPlainText($plainText) {
+    return is_string($plainText) && ($plainText === '' || $plainText{0} !== $this->delim);
+  }
+
+  /**
+   * Create an encrypted token (given the plaintext).
+   *
+   * @param string $plainText
+   *   The secret value to encode (e.g. plain-text password).
+   * @param string|string[] $keyIdOrTag
+   *   List of key IDs or key tags to check. First available match wins.
+   * @return string
+   *   A token
+   * @throws \Civi\Crypto\Exception\CryptoException
+   */
+  public function encrypt($plainText, $keyIdOrTag) {
+    $key = $this->registry->findKey($keyIdOrTag);
+    if ($key['suite'] === 'plain') {
+      if (!$this->isPlainText($plainText)) {
+        throw new CryptoException("Cannot use plaintext encoding for data with reserved delimiter.");
+      }
+      return $plainText;
+    }
+
+    /** @var \Civi\Crypto\CipherSuiteInterface $cipherSuite */
+    $cipherSuite = $this->registry->findSuite($key['suite']);
+    $cipherText = $cipherSuite->encrypt($plainText, $key);
+    return $this->delim . self::VERSION_1 . $this->delim . $key['id'] . $this->delim . base64_encode($cipherText);
+  }
+
+  /**
+   * Get the plaintext (given an encrypted token).
+   *
+   * @param string $token
+   * @param string|string[] $keyIdOrTag
+   *   Whitelist of acceptable keys. Wildcard '*' will allow it to use
+   *   any/all available means to decode the token.
+   * @return string
+   * @throws \Civi\Crypto\Exception\CryptoException
+   */
+  public function decrypt($token, $keyIdOrTag = '*') {
+    $keyIdOrTag = (array) $keyIdOrTag;
+
+    if ($this->isPlainText($token)) {
+      if (in_array('*', $keyIdOrTag) || in_array('plain', $keyIdOrTag)) {
+        return $token;
+      }
+      else {
+        throw new CryptoException("Cannot decrypt token. Unexpected key: plain");
+      }
+    }
+
+    $parts = explode($this->delim, $token);
+    if ($parts[1] !== self::VERSION_1) {
+      throw new CryptoException("Unrecognized encoding");
+    }
+    $keyId = $parts[2];
+    $cipherText = base64_decode($parts[3]);
+
+    $key = $this->registry->findKey($keyId);
+    if (!in_array('*', $keyIdOrTag) && !in_array($keyId, $keyIdOrTag) && empty(array_intersect($keyIdOrTag, $key['tags']))) {
+      throw new CryptoException("Cannot decrypt token. Unexpected key: $keyId");
+    }
+
+    /** @var \Civi\Crypto\CipherSuiteInterface $cipherSuite */
+    $cipherSuite = $this->registry->findSuite($key['suite']);
+    $plainText = $cipherSuite->decrypt($cipherText, $key);
+    return $plainText;
+  }
+
+}

--- a/Civi/Crypto/CryptoToken.php
+++ b/Civi/Crypto/CryptoToken.php
@@ -118,9 +118,9 @@ class CryptoToken {
     /** @var CryptoRegistry $registry */
     $registry = \Civi::service('crypto.registry');
 
-    $parts = explode($this->delim, $token);
-    if ($parts[1] !== self::VERSION_1) {
-      throw new CryptoException("Unrecognized encoding");
+    $parts = explode($this->delim, $token, 4);
+    if (count($parts) !== 4 || $parts[1] !== self::VERSION_1) {
+      throw new CryptoException("Cannot decrypt token. Invalid format.");
     }
     $keyId = $parts[2];
     $cipherText = base64_decode($parts[3]);

--- a/Civi/Crypto/Exception/CryptoException.php
+++ b/Civi/Crypto/Exception/CryptoException.php
@@ -1,0 +1,9 @@
+<?php
+namespace Civi\Crypto\Exception;
+
+/**
+ * Class CryptException
+ */
+class CryptoException extends \CRM_Core_Exception {
+
+}

--- a/Civi/Crypto/PhpseclibCipherSuite.php
+++ b/Civi/Crypto/PhpseclibCipherSuite.php
@@ -1,0 +1,213 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Crypto;
+
+use Civi\Crypto\Exception\CryptoException;
+
+/**
+ * This is an implementation of CipherSuiteInterface based on phpseclib 1.x/2.x.
+ *
+ * It supports multiple ciphers:
+ *
+ * - aes-cbc: AES-256 w/CBC, no authentication
+ * - aes-ctr: AES-256 w/CTR, no authentication
+ * - aes-cbc-hs: AES-256 w/CBC, HMAC-SHA256 authentication. Enc+auth use derived keys.
+ * - aes-ctr-hs: AES-256 w/CTR, HMAC-SHA256 authentication. Enc+auth use derived keys.
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+class PhpseclibCipherSuite implements CipherSuiteInterface {
+
+  /**
+   * List of phpseclib "Cipher" objects. These are template objects
+   * which may be cloned for use with specific keys.
+   *
+   * @var array|null
+   */
+  protected $ciphers = NULL;
+
+  public function __construct() {
+    $this->ciphers = [];
+    if (class_exists('\phpseclib\Crypt\AES')) {
+      // phpseclib v2
+      $this->ciphers['aes-cbc'] = new \phpseclib\Crypt\AES(\phpseclib\Crypt\AES::MODE_CBC);
+      $this->ciphers['aes-cbc']->setKeyLength(256);
+      $this->ciphers['aes-ctr'] = new \phpseclib\Crypt\AES(\phpseclib\Crypt\AES::MODE_CTR);
+      $this->ciphers['aes-ctr']->setKeyLength(256);
+    }
+    elseif (class_exists('Crypt_AES')) {
+      // phpseclib v1
+      $this->ciphers['aes-cbc'] = new \Crypt_AES(\Crypt_AES::MODE_CBC);
+      $this->ciphers['aes-cbc']->setKeyLength(256);
+      $this->ciphers['aes-ctr'] = new \Crypt_AES(\Crypt_AES::MODE_CTR);
+      $this->ciphers['aes-ctr']->setKeyLength(256);
+    }
+    else {
+      throw new CryptoException("Failed to find phpseclib");
+    }
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public function getSuites(): array {
+    return ['aes-cbc', 'aes-ctr', 'aes-cbc-hs', 'aes-ctr-hs'];
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public function encrypt(string $plainText, array $key): string {
+    switch ($key['suite']) {
+      case 'aes-cbc-hs':
+      case 'aes-ctr-hs':
+        return $this->encryptThenSign($plainText, substr($key['suite'], 0, -3), 'sha256', $key['key']);
+
+      case 'aes-cbc':
+      case 'aes-ctr':
+        return $this->encryptOnly($plainText, $key['suite'], $key['key']);
+    }
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public function decrypt(string $cipherText, array $key): string {
+    switch ($key['suite']) {
+      case 'aes-cbc-hs':
+      case 'aes-ctr-hs':
+        return $this->authenticateThenDecrypt($cipherText, substr($key['suite'], 0, -3), 'sha256', $key['key']);
+
+      case 'aes-cbc':
+      case 'aes-ctr':
+        return $this->decryptOnly($cipherText, $key['suite'], $key['key']);
+    }
+  }
+
+  /**
+   * Given an master key, derive a pair of encryption+authentication keys.
+   *
+   * @param string $masterKey
+   * @return array
+   */
+  protected function createEncAuthKeys($masterKey) {
+    return [
+      hash_hmac('sha256', 'enc', $masterKey, TRUE),
+      hash_hmac('sha256', 'auth', $masterKey, TRUE),
+    ];
+  }
+
+  protected function encryptOnly($plainText, $suite, $key) {
+    $cipher = $this->createCipher($suite, $key);
+    $blockBytes = $cipher->getBlockLength() >> 3;
+    $iv = random_bytes($blockBytes);
+    $cipher->setIV($iv);
+    return $iv . $cipher->encrypt($plainText);
+  }
+
+  protected function decryptOnly(string $cipherText, $suite, $key) {
+    $cipher = $this->createCipher($suite, $key);
+    $blockBytes = $cipher->getBlockLength() >> 3;
+    $iv = substr($cipherText, 0, $blockBytes);
+    $cipher->setIV($iv);
+    return $cipher->decrypt(substr($cipherText, $blockBytes));
+  }
+
+  /**
+   * @param string $plainText
+   * @param string $suite
+   *   The encryption algorithms
+   *   Ex: aes-cbc, aes-ctr
+   * @param string $digest
+   *   The authentication algorithm
+   *   Ex: sha256
+   * @param string $masterKey
+   *   Binary representation of the key
+   *
+   * @return string
+   *   The concatenation of IV, ciphertext, signature
+   */
+  protected function encryptThenSign($plainText, $suite, $digest, $masterKey) {
+    list ($encKey, $authKey) = $this->createEncAuthKeys($masterKey);
+    $cipher = $this->createCipher($suite, $encKey);
+    $blockBytes = $cipher->getBlockLength() >> 3;
+    $iv = random_bytes($blockBytes);
+    $cipher->setIV($iv);
+    $ivText = $iv . $cipher->encrypt($plainText);
+    $sig = hash_hmac($digest, $ivText, $authKey, TRUE);
+    $this->assertLen($this->getDigestBytes($digest), $sig);
+    return $ivText . $sig;
+  }
+
+  /**
+   * @param string $cipherText
+   *   Combined ciphertext (IV + encrypted text + signature)
+   * @param string $suite
+   *   The encryption algorithms
+   *   Ex: aes-cbc, aes-ctr
+   * @param string $digest
+   *   The authentication algorithm
+   *   Ex: sha256
+   * @param string $masterKey
+   *   Binary representation of the key
+   *
+   * @return string
+   *   Decrypted text
+   * @throws CryptoException
+   *   Throws an exception if authentication fails.
+   */
+  protected function authenticateThenDecrypt($cipherText, $suite, $digest, $masterKey) {
+    list ($encKey, $authKey) = $this->createEncAuthKeys($masterKey);
+    $cipher = $this->createCipher($suite, $encKey);
+    $blockBytes = $cipher->getBlockLength() >> 3;
+    $digestBytes = $this->getDigestBytes($digest);
+    $sigExpect = substr($cipherText, -1 * $digestBytes);
+    $sigActual = hash_hmac($digest, substr($cipherText, 0, -1 * $digestBytes), $authKey, TRUE);
+    if (!hash_equals($sigActual, $sigExpect)) {
+      throw new CryptoException("Failed to decrypt token. Invalid digest.");
+    }
+    $cipher->setIV(substr($cipherText, 0, $blockBytes));
+    return $cipher->decrypt(substr($cipherText, $blockBytes, -1 * $digestBytes));
+  }
+
+  /**
+   * @param $suite
+   * @param $key
+   * @return \phpseclib\Crypt\Base|\Crypt_Base
+   */
+  protected function createCipher($suite, $key) {
+    if (!isset($this->ciphers[$suite])) {
+      throw new \RuntimeException("Cipher suite does not support " . $suite);
+    }
+
+    $cipher = clone $this->ciphers[$suite];
+    $this->assertLen($cipher->getKeyLength() >> 3, $key);
+    $cipher->setKey($key);
+    return $cipher;
+  }
+
+  protected function getDigestBytes($digest) {
+    if ($digest === 'sha256') {
+      return 32;
+    }
+    throw new \RuntimeException('Unrecognized digest');
+  }
+
+  private function assertLen($bytes, $value) {
+    if ($bytes != strlen($value)) {
+      throw new \InvalidArgumentException("Malformed AES key");
+    }
+  }
+
+}

--- a/tests/phpunit/CRM/Utils/StringTest.php
+++ b/tests/phpunit/CRM/Utils/StringTest.php
@@ -10,6 +10,19 @@ class CRM_Utils_StringTest extends CiviUnitTestCase {
     parent::setUp();
   }
 
+  public function testBase64Url() {
+    $examples = [
+      'a' => 'YQ',
+      'ab' => 'YWI',
+      'abc' => 'YWJj',
+      '3f>' => 'M2Y-',
+    ];
+    foreach ($examples as $raw => $b64) {
+      $this->assertEquals($b64, CRM_Utils_String::base64UrlEncode($raw));
+      $this->assertEquals($raw, CRM_Utils_String::base64UrlDecode($b64));
+    }
+  }
+
   public function testStripPathChars() {
     $testSet = [
       '' => '',

--- a/tests/phpunit/Civi/Crypto/CryptoRegistryTest.php
+++ b/tests/phpunit/Civi/Crypto/CryptoRegistryTest.php
@@ -1,0 +1,109 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Crypto;
+
+use Civi\Crypto\Exception\CryptoException;
+
+/**
+ * Test major use-cases of the 'crypto.registry' service.
+ */
+class CryptoRegistryTest extends \CiviUnitTestCase {
+
+  use CryptoTestTrait;
+
+  protected function setUp() {
+    parent::setUp();
+    \CRM_Utils_Hook::singleton()->setHook('civicrm_crypto', [$this, 'registerExampleKeys']);
+  }
+
+  public function testParseKey() {
+    $examples = self::getExampleKeys();
+    $registry = \Civi::service('crypto.registry');
+
+    $key0 = $registry->parseKey($examples[0]);
+    $this->assertEquals("please use 32 bytes for aes-256!", $key0['key']);
+    $this->assertEquals('aes-cbc', $key0['suite']);
+
+    $key1 = $registry->parseKey($examples[1]);
+    $this->assertEquals(32, strlen($key1['key']));
+    $this->assertEquals('aes-cbc', $key1['suite']);
+    $this->assertEquals('0ao5eC7C/rwwk2qii4oLd6eG3KJq8ZDX2K9zWbvaLdo=', base64_encode($key1['key']));
+
+    $key2 = $registry->parseKey($examples[2]);
+    $this->assertEquals(32, strlen($key2['key']));
+    $this->assertEquals('aes-ctr', $key2['suite']);
+    $this->assertEquals('0ao5eC7C/rwwk2qii4oLd6eG3KJq8ZDX2K9zWbvaLdo=', base64_encode($key2['key']));
+
+    $key3 = $registry->parseKey($examples[3]);
+    $this->assertEquals(32, strlen($key3['key']));
+    $this->assertEquals('aes-cbc-hs', $key3['suite']);
+    $this->assertEquals('0ao5eC7C/rwwk2qii4oLd6eG3KJq8ZDX2K9zWbvaLdo=', base64_encode($key3['key']));
+  }
+
+  public function testRegisterAndFindKeys() {
+    /** @var CryptoRegistry $registry */
+    $registry = \Civi::service('crypto.registry');
+
+    $key = $registry->findKey('asdf-key-0');
+    $this->assertEquals(32, strlen($key['key']));
+    $this->assertEquals('aes-cbc', $key['suite']);
+
+    $key = $registry->findKey('asdf-key-1');
+    $this->assertEquals(32, strlen($key['key']));
+    $this->assertEquals('aes-cbc', $key['suite']);
+
+    $key = $registry->findKey('asdf-key-2');
+    $this->assertEquals(32, strlen($key['key']));
+    $this->assertEquals('aes-ctr', $key['suite']);
+
+    $key = $registry->findKey('asdf-key-3');
+    $this->assertEquals(32, strlen($key['key']));
+    $this->assertEquals('aes-cbc-hs', $key['suite']);
+
+    $key = $registry->findKey('UNIT-TEST');
+    $this->assertEquals(32, strlen($key['key']));
+    $this->assertEquals('asdf-key-1', $key['id']);
+  }
+
+  public function testValidKeyId() {
+    $valids = ['abc', 'a.b-c_d+e/', 'f\\g:h;i='];
+    $invalids = [chr(0), chr(1), chr(1) . 'abc', 'a b', "ab\n", "ab\nc", "\r", "\n"];
+
+    /** @var CryptoRegistry $registry */
+    $registry = \Civi::service('crypto.registry');
+
+    foreach ($valids as $valid) {
+      $this->assertEquals(TRUE, $registry->isValidKeyId($valid), "Key ID \"$valid\" should be valid");
+    }
+
+    foreach ($invalids as $invalid) {
+      $this->assertEquals(FALSE, $registry->isValidKeyId($invalid), "Key ID \"$invalid\" should be invalid");
+    }
+  }
+
+  public function testAddBadKeyId() {
+    /** @var CryptoRegistry $registry */
+    $registry = \Civi::service('crypto.registry');
+
+    try {
+      $registry->addSymmetricKey([
+        'key' => 'abcd',
+        'id' => "foo\n",
+      ]);
+      $this->fail("Expected crypto exception");
+    }
+    catch (CryptoException $e) {
+      $this->assertRegExp(';Malformed key ID;', $e->getMessage());
+    }
+  }
+
+}

--- a/tests/phpunit/Civi/Crypto/CryptoTestTrait.php
+++ b/tests/phpunit/Civi/Crypto/CryptoTestTrait.php
@@ -1,0 +1,63 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Crypto;
+
+trait CryptoTestTrait {
+
+  public static function getExampleKeys() {
+    return [
+      ':b64:cGxlYXNlIHVzZSAzMiBieXRlcyBmb3IgYWVzLTI1NiE',
+      'aes-cbc:hkdf-sha256:abcd1234abcd1234',
+      'aes-ctr::abcd1234abcd1234',
+      'aes-cbc-hs::abcd1234abcd1234',
+    ];
+  }
+
+  /**
+   * @param CryptoRegistry $registry
+   * @see \CRM_Utils_Hook::crypto()
+   */
+  public function registerExampleKeys($registry) {
+    $origCount = count($registry->getKeys());
+
+    $examples = self::getExampleKeys();
+    $key = $registry->addSymmetricKey($registry->parseKey($examples[0]) + [
+      'tags' => ['UNIT-TEST'],
+      'weight' => 10,
+      'id' => 'asdf-key-0',
+    ]);
+    $this->assertEquals(10, $key['weight']);
+
+    $key = $registry->addSymmetricKey($registry->parseKey($examples[1]) + [
+      'tags' => ['UNIT-TEST'],
+      'weight' => -10,
+      'id' => 'asdf-key-1',
+    ]);
+    $this->assertEquals(-10, $key['weight']);
+
+    $key = $registry->addSymmetricKey($registry->parseKey($examples[2]) + [
+      'tags' => ['UNIT-TEST'],
+      'id' => 'asdf-key-2',
+    ]);
+    $this->assertEquals(0, $key['weight']);
+
+    $key = $registry->addSymmetricKey($registry->parseKey($examples[3]) + [
+      'tags' => ['UNIT-TEST'],
+      'id' => 'asdf-key-3',
+    ]);
+    $this->assertEquals(0, $key['weight']);
+
+    $this->assertEquals(4, count($examples));
+    $this->assertEquals(4 + $origCount, count($registry->getKeys()));
+  }
+
+}

--- a/tests/phpunit/Civi/Crypto/CryptoTokenTest.php
+++ b/tests/phpunit/Civi/Crypto/CryptoTokenTest.php
@@ -1,0 +1,69 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Crypto;
+
+/**
+ * Test major use-cases of the 'crypto.token' service.
+ */
+class CryptoTokenTest extends \CiviUnitTestCase {
+
+  use CryptoTestTrait;
+
+  protected function setUp() {
+    parent::setUp();
+    \CRM_Utils_Hook::singleton()->setHook('civicrm_crypto', [$this, 'registerExampleKeys']);
+  }
+
+  public function testIsPlainText() {
+    $token = \Civi::service('crypto.token');
+
+    $this->assertFalse($token->isPlainText(chr(2)));
+    $this->assertFalse($token->isPlainText(chr(2) . 'asdf'));
+
+    $this->assertTrue($token->isPlainText(\CRM_Utils_Array::implodePadded(['a', 'b', 'c'])));
+    $this->assertTrue($token->isPlainText(""));
+    $this->assertTrue($token->isPlainText("\r"));
+    $this->assertTrue($token->isPlainText("\n"));
+  }
+
+  public function getExampleTokens() {
+    return [
+      // [ 'Plain text', 'Encryption Key ID', 'expectTokenRegex', 'expectTokenLen', 'expectPlain' ]
+      ['hello world. can you see me', 'plain', '/^hello world. can you see me/', 27, TRUE],
+      ['hello world. i am secret.', 'UNIT-TEST', '/^.CTK0.asdf-key-1./', 81, FALSE],
+      ['hello world. we b secret.', 'asdf-key-0', '/^.CTK0.asdf-key-0./', 81, FALSE],
+      ['hello world. u ur secret.', 'asdf-key-1', '/^.CTK0.asdf-key-1./', 81, FALSE],
+      ['hello world. he z secret.', 'asdf-key-2', '/^.CTK0.asdf-key-2./', 73, FALSE],
+      ['hello world. whos secret.', 'asdf-key-3', '/^.CTK0.asdf-key-3./', 125, FALSE],
+    ];
+  }
+
+  /**
+   * @param string $inputText
+   * @param string $inputKeyIdOrTag
+   * @param string $expectTokenRegex
+   * @param int $expectTokenLen
+   * @param bool $expectPlain
+   *
+   * @dataProvider getExampleTokens
+   */
+  public function testRoundtrip($inputText, $inputKeyIdOrTag, $expectTokenRegex, $expectTokenLen, $expectPlain) {
+    $token = \Civi::service('crypto.token')->encrypt($inputText, $inputKeyIdOrTag);
+    $this->assertRegExp($expectTokenRegex, $token);
+    $this->assertEquals($expectTokenLen, strlen($token));
+    $this->assertEquals($expectPlain, \Civi::service('crypto.token')->isPlainText($token));
+
+    $actualText = \Civi::service('crypto.token')->decrypt($token);
+    $this->assertEquals($inputText, $actualText);
+  }
+
+}

--- a/tests/phpunit/Civi/Crypto/CryptoTokenTest.php
+++ b/tests/phpunit/Civi/Crypto/CryptoTokenTest.php
@@ -66,4 +66,12 @@ class CryptoTokenTest extends \CiviUnitTestCase {
     $this->assertEquals($inputText, $actualText);
   }
 
+  public function testReadPlainTextWithoutRegistry() {
+    // This is performance optimization - don't initialize crypto.registry unless
+    // you actually need it.
+    $this->assertFalse(\Civi::container()->initialized('crypto.registry'));
+    $this->assertEquals("Hello world", \Civi::service('crypto.token')->decrypt("Hello world"));
+    $this->assertFalse(\Civi::container()->initialized('crypto.registry'));
+  }
+
 }

--- a/tests/phpunit/Civi/Crypto/CryptoTokenTest.php
+++ b/tests/phpunit/Civi/Crypto/CryptoTokenTest.php
@@ -51,7 +51,8 @@ class CryptoTokenTest extends \CiviUnitTestCase {
     $this->assertEquals('mess with me', $cryptoToken->decrypt($goodExample));
 
     try {
-      $badExample = preg_replace(';CTK0;', 'ctk9', $goodExample);
+      $badExample = preg_replace(';CTK\?;', 'ctk9', $goodExample);
+      $this->assertTrue($badExample !== $goodExample);
       $cryptoToken->decrypt($badExample);
       $this->fail("Expected CryptoException");
     }
@@ -64,11 +65,11 @@ class CryptoTokenTest extends \CiviUnitTestCase {
     return [
       // [ 'Plain text', 'Encryption Key ID', 'expectTokenRegex', 'expectTokenLen', 'expectPlain' ]
       ['hello world. can you see me', 'plain', '/^hello world. can you see me/', 27, TRUE],
-      ['hello world. i am secret.', 'UNIT-TEST', '/^.CTK0.asdf-key-1./', 81, FALSE],
-      ['hello world. we b secret.', 'asdf-key-0', '/^.CTK0.asdf-key-0./', 81, FALSE],
-      ['hello world. u ur secret.', 'asdf-key-1', '/^.CTK0.asdf-key-1./', 81, FALSE],
-      ['hello world. he z secret.', 'asdf-key-2', '/^.CTK0.asdf-key-2./', 73, FALSE],
-      ['hello world. whos secret.', 'asdf-key-3', '/^.CTK0.asdf-key-3./', 125, FALSE],
+      ['hello world. i am secret.', 'UNIT-TEST', '/^.CTK\?k=asdf-key-1&/', 84, FALSE],
+      ['hello world. we b secret.', 'asdf-key-0', '/^.CTK\?k=asdf-key-0&/', 84, FALSE],
+      ['hello world. u ur secret.', 'asdf-key-1', '/^.CTK\?k=asdf-key-1&/', 84, FALSE],
+      ['hello world. he z secret.', 'asdf-key-2', '/^.CTK\?k=asdf-key-2&/', 75, FALSE],
+      ['hello world. whos secret.', 'asdf-key-3', '/^.CTK\?k=asdf-key-3&/', 127, FALSE],
     ];
   }
 


### PR DESCRIPTION
Overview
----------------------------------------

Storing specific fields as encrypted values provides a way to protect confidentiality of particularly sensitive data even if an attacker gains the ability to read the database (e.g. via SQL injection or leaked SQL backup).

In the past, CiviCRM has protected the SMTP password in this way (specifically, using the helper `CRM_Utils_Crypt`). However, `CRM_Utils_Crypt` has faced multiple issues which prevented broader/systematic usage.

This patchset provides a more robust take on `CRM_Utils_Crypt` which aims to allow broader/systematic usage. It is work toward https://lab.civicrm.org/dev/core/-/issues/2258

Before
----------------------------------------

```php
define('CIVICRM_SITE_KEY', 'abcdefghijklmnopqrstuvwxyz');

$encrypted = CRM_Utils_Crypt::encrypt("my-mail-password");
$decrypted = CRM_Utils_Crypt::decrypt($encrypted);
```

There is a helper, `CRM_Utils_Crypt`, which provides encrypt and decrypt methods. However, it is problematic in a few ways:

* When the output of `encrypt()` is written to disk, it becomes ambiguous. A program which reads the "SMTP password" cannot tell if "YWJjZGVmZ2hp" is a plain-text password or a base64-encoded ciphertext.
* All values must be encrypted with the same key+cipher+mode. There is no way to rotate keys or to read old data.
* The encryption uses a poor set of parameters (e.g. we have not found a way to exchange data between mcrypt's  Rijndael-256 and other crypto providers; e.g. ECB is not suited to recording multiple values)
* The `CIVICRM_SITE_KEY` has competing uses. You can get boxed-in to situations where you need to change for one reason (e.g. pro-actively rotating crypto keys) but must keep it for another reason (e.g. providing stable CiviCase IDs).

The saving grace is that this has only been used on one internal field. But the flip-side is that we have not been able to expand crypto storage to other fields.

After
----------------------------------------

The `CRM_Utils_Crypt` helper still exists exactly as before. This ensures that existing third-party extensions that use it will continue working as-is. But now there is another helper:

```php
define('CIVICRM_CRED_KEYS', '::abcdefghijklmnopqrstuvwxyz ::123456789');

$encrypted = Civi::service('crypto.token')->encrypt('my-mail-password', 'CRED');
$decrypted = Civi::service('crypto.token')->decrypt($encrypted, '*');
```

New characteristics:

* The encryption key is a distinct setting, `CIVICRM_CRED_KEYS`, that can be managed separately.
* The `CIVICRM_CRED_KEYS` may list multiple, space-delimited keys.
    * When encrypting a new value, it uses the first key.
    * When decrypting an old value, it uses whichever key matches.
* The return value (`$encrypted`) is unambiguous. One can programmatically distinguish values which were:
    * Not encrypted
    * Encrypted with `::abcdefghijklmnopqrstuvwxyz`
    * Encrypted with `::123456789`
* One may programmatically register additional keys and ciphers. 
 
Technical details
-------------------

This patch-set actually introduces a few programmatic interfaces:

* `CryptoRegistry` (`crypto.registry`): Tracks the list of available keys and ciphers
* `hook_civicrm_crypto`: Runs when initializing the registry. Allows one to add more keys and ciphers.
* `CryptoToken` (`crypto.token`): Defines a data-format for the encrypted field values. Includes encrypt/decrypt methods.

This arrangement makes the system fairly extensible. For example, suppose you were developing a patch to the session-store and wanted to encrypt it with a distinct key. Part of the patch-set would say:

```php
// Register some keys. Tag them as 'SESSION'.
function hook_civicrm_crypto($registry) {
  $registry->addSymmetricKey([
    'key' => '12345678901234567890123456789012',
    'suite' => 'aes-cbc-hs',
    'tags' => ['SESSION'],
    'weight' => -1, // Preferred for new encrypting new values
  ]);
  $registry->addSymmetricKey([
    'key' => 'abcdefghijklmnopqrstuvwxyz123456',
    'suite' => 'aes-cbc-hs',
    'tags' => ['SESSION'],
    'weight' => 10, // Available for decrypting old values
  ]);
}

// Encrypt/decrypt data using one of the 'SESSION' keys.
$encrypted = Civi::service('crypto.token')->encrypt('my-session-data, 'SESSION');
$decrypted = Civi::service('crypto.token')->decrypt($encrypted, '*');
```

