### PR TITLE
Fix pledge on contribution page when the site has a WR for "contribution"

### DIFF
--- a/CRM/Contribute/Form/ContributionPage/Amount.php
+++ b/CRM/Contribute/Form/ContributionPage/Amount.php
@@ -752,7 +752,7 @@ class CRM_Contribute_Form_ContributionPage_Amount extends CRM_Contribute_Form_Co
             $deletePledgeBlk = FALSE;
             $pledgeBlockParams = [
               'entity_id' => $contributionPageID,
-              'entity_table' => ts('civicrm_contribution_page'),
+              'entity_table' => 'civicrm_contribution_page',
             ];
             if ($this->_pledgeBlockID) {
               $pledgeBlockParams['id'] = $this->_pledgeBlockID;


### PR DESCRIPTION
Overview
----------------------------------------
Pledge on contribution page is not saved when the site has a word replacement for contribution.

Before
----------------------------------------
To replicate

- Add a word replacement for contribution -> payment.
- Save pledge on the contribution page. 
- The pledge isn't displayed on the main page when submitting the contribution page.

After
----------------------------------------
Fixed. Pledge loads fine on the contribution page.

Technical Details
----------------------------------------
The table civicrm_pledge_block stores the value as civicrm_payment_page in entity_table. The PR ensures the storage value is not translated.

Comments
----------------------------------------
Gitlab - https://lab.civicrm.org/dev/core/-/issues/2261