### PR TITLE
dev/core#2258 - Read+write SMTP password using 'crypto.token'

### DIFF
--- a/CRM/Admin/Form/Setting/Smtp.php
+++ b/CRM/Admin/Form/Setting/Smtp.php
@@ -201,7 +201,7 @@ class CRM_Admin_Form_Setting_Smtp extends CRM_Admin_Form_Setting {
 
     // if password is present, encrypt it
     if (!empty($formValues['smtpPassword'])) {
-      $formValues['smtpPassword'] = CRM_Utils_Crypt::encrypt($formValues['smtpPassword']);
+      $formValues['smtpPassword'] = \Civi::service('crypto.token')->encrypt($formValues['smtpPassword'], 'CRED');
     }
 
     Civi::settings()->set('mailing_backend', $formValues);
@@ -257,7 +257,7 @@ class CRM_Admin_Form_Setting_Smtp extends CRM_Admin_Form_Setting {
         $this->_defaults = $mailingBackend;
 
         if (!empty($this->_defaults['smtpPassword'])) {
-          $this->_defaults['smtpPassword'] = CRM_Utils_Crypt::decrypt($this->_defaults['smtpPassword']);
+          $this->_defaults['smtpPassword'] = \Civi::service('crypto.token')->decrypt($this->_defaults['smtpPassword']);
         }
       }
       else {

--- a/CRM/Upgrade/DispatchPolicy.php
+++ b/CRM/Upgrade/DispatchPolicy.php
@@ -73,6 +73,7 @@ class CRM_Upgrade_DispatchPolicy {
       'hook_civicrm_config' => 'run',
       // cleanupPermissions() in some UF's can be destructive. Running prematurely could be actively harmful.
       'hook_civicrm_permission' => 'fail',
+      'hook_civicrm_crypto' => 'drop',
       '/^hook_civicrm_(pre|post)$/' => 'drop',
       '/^hook_civicrm_/' => $strict ? 'warn-drop' : 'drop',
       '/^civi\./' => 'run',

--- a/CRM/Upgrade/Incremental/php/FiveThirtyFour.php
+++ b/CRM/Upgrade/Incremental/php/FiveThirtyFour.php
@@ -33,6 +33,30 @@ class CRM_Upgrade_Incremental_php_FiveThirtyFour extends CRM_Upgrade_Incremental
         }
       }
     }
+
+    if ($rev === '5.34.alpha1') {
+      if (extension_loaded('mcrypt') && !empty(self::findSmtpPasswords())) {
+        // NOTE: We don't re-encrypt automatically because the old "civicrm.settings.php" lacks a good key, and we don't keep the old encryption because the format is ambiguous.
+        // The admin may forget to re-enable. That's OK -- this only affects 1 field, this is a secondary defense, and (in the future) we can remind the admin via status-checks.
+        $preUpgradeMessage .= '<p>' . ts('This system has an SMTP password which should be migrated to a new encryption mechanism. The upgrader will remove the old encryption. After upgrading, you may enable the new encryption.') . '</p>';
+      }
+      foreach ($GLOBALS['civicrm_setting'] ?? [] as $entity => $overrides) {
+        if (extension_loaded('mcrypt') && !empty($overrides['mailing_backend']['smtpPassword']) && $overrides['mailing_backend']['outBound_option'] == 0) {
+          // This is a fairly unlikely situation. I'm sure it's *useful* to set smtpPassword via $civicrm_setting (eg for dev or multitenant).
+          // But historically it had to follow the rules of CRM_Utils_Crypt:
+          // - For non-mcrypt servers, that was easy/plaintext. That'll work just as well going forward. We don't show any warnings about that.
+          // - For mcrypt servers, the value had to be encrypted. It's not easy to pick the right value for that. Maybe someone with multitenant would have had
+          //   enough incentive to figure this out... but they'd probably get stymied by the fact that each tenant has a different SITE_KEY.
+          // All of which is to say: if someone has gotten into a valid+working scenario of overriding smtpPassword on an mcrypt-enabled system, then they're
+          // savvy enough to figure out the migration details. We just need to point them at the problem.
+          $settingPath = sprintf('$civicrm_setting[%s][%s][%s]', var_export($entity, 1), var_export('mailing_backend', 1), var_export('smtpPassword', 1));
+          $prose = ts('This system has a PHP override for the SMTP password (%1). The override was most likely encrypted with an old mechanism. After upgrading, you must verify and/or revise this setting.', [
+            1 => $settingPath,
+          ]);
+          $preUpgradeMessage = '<p>' . $prose . '</p>';
+        }
+      }
+    }
   }
 
   /**
@@ -67,6 +91,11 @@ class CRM_Upgrade_Incremental_php_FiveThirtyFour extends CRM_Upgrade_Incremental
    */
   public function upgrade_5_34_alpha1(string $rev): void {
     $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
+
+    if (extension_loaded('mcrypt') && !empty(self::findSmtpPasswords())) {
+      $this->addTask('Migrate SMTP password', 'migrateSmtpPasswords');
+    }
+
     $this->addTask('core-issue#365 - Add created_date to civicrm_action_schedule', 'addColumn',
       'civicrm_action_schedule', 'created_date', "timestamp NULL  DEFAULT CURRENT_TIMESTAMP COMMENT 'When was the schedule reminder created.'");
 
@@ -83,6 +112,48 @@ class CRM_Upgrade_Incremental_php_FiveThirtyFour extends CRM_Upgrade_Incremental
     $this->addTask('Set defaults and required on pledge fields', 'updatePledgeTable');
 
     $this->addTask('Remove never used IMAP_XOAUTH2 option value', 'removeUnusedXOAUTH2');
+  }
+
+  /**
+   * @return array
+   *   A list of "civicrm_setting" records which have
+   *   SMTP passwords, or NULL.
+   */
+  protected static function findSmtpPasswords() {
+    $query = CRM_Utils_SQL_Select::from('civicrm_setting')
+      ->where('name = "mailing_backend"');
+
+    $matches = [];
+    foreach ($query->execute()->fetchAll() as $setting) {
+      $value = unserialize($setting['value']);
+      if (!empty($value['smtpPassword'])) {
+        $matches[] = $setting;
+      }
+    }
+
+    return $matches;
+  }
+
+  /**
+   * Find any SMTP passwords. Remove the CRM_Utils_Crypt encryption.
+   *
+   * Note: This task is only enqueued if mcrypt is active.
+   *
+   * @param \CRM_Queue_TaskContext $ctx
+   *
+   * @return bool
+   */
+  public static function migrateSmtpPasswords(CRM_Queue_TaskContext $ctx) {
+    $settings = self::findSmtpPasswords();
+    foreach ($settings as $setting) {
+      $value = unserialize($setting['value']);
+      $value['smtpPassword'] = CRM_Utils_Crypt::decrypt($value['smtpPassword']);
+      CRM_Core_DAO::executeQuery('UPDATE civicrm_setting SET value = %2 WHERE id = %1', [
+        1 => [$setting['id'], 'Positive'],
+        2 => [serialize($value), 'String'],
+      ]);
+    }
+    return TRUE;
   }
 
   /**

--- a/CRM/Utils/Mail.php
+++ b/CRM/Utils/Mail.php
@@ -48,7 +48,7 @@ class CRM_Utils_Mail {
 
       if ($mailingInfo['smtpAuth']) {
         $params['username'] = $mailingInfo['smtpUsername'];
-        $params['password'] = CRM_Utils_Crypt::decrypt($mailingInfo['smtpPassword']);
+        $params['password'] = \Civi::service('crypto.token')->decrypt($mailingInfo['smtpPassword']);
         $params['auth'] = TRUE;
       }
       else {

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -361,6 +361,7 @@ class Container {
     $dispatcher->addListener('hook_civicrm_post::Case', ['\Civi\CCase\Events', 'fireCaseChange']);
     $dispatcher->addListener('hook_civicrm_caseChange', ['\Civi\CCase\Events', 'delegateToXmlListeners']);
     $dispatcher->addListener('hook_civicrm_caseChange', ['\Civi\CCase\SequenceListener', 'onCaseChange_static']);
+    $dispatcher->addListener('hook_civicrm_cryptoRotateKey', ['\Civi\Crypto\RotateKeys', 'rotateSmtp']);
     $dispatcher->addListener('hook_civicrm_eventDefs', ['\Civi\Core\CiviEventInspector', 'findBuiltInEvents']);
     // TODO We need a better code-convention for metadata about non-hook events.
     $dispatcher->addListener('hook_civicrm_eventDefs', ['\Civi\API\Events', 'hookEventDefs']);

--- a/Civi/Crypto/CryptoToken.php
+++ b/Civi/Crypto/CryptoToken.php
@@ -56,10 +56,18 @@ class CryptoToken {
   protected $delim;
 
   /**
-   * CryptoToken constructor.
+   * @var \Civi\Crypto\CryptoRegistry|null
    */
-  public function __construct() {
+  private $registry;
+
+  /**
+   * CryptoToken constructor.
+   *
+   * @param CryptoRegistry $registry
+   */
+  public function __construct($registry = NULL) {
     $this->delim = chr(2);
+    $this->registry = $registry;
   }
 
   /**
@@ -85,7 +93,7 @@ class CryptoToken {
    */
   public function encrypt($plainText, $keyIdOrTag) {
     /** @var CryptoRegistry $registry */
-    $registry = \Civi::service('crypto.registry');
+    $registry = $this->getRegistry();
 
     $key = $registry->findKey($keyIdOrTag);
     if ($key['suite'] === 'plain') {
@@ -128,7 +136,7 @@ class CryptoToken {
     }
 
     /** @var CryptoRegistry $registry */
-    $registry = \Civi::service('crypto.registry');
+    $registry = $this->getRegistry();
 
     $tokenData = $this->parse($token);
 
@@ -156,7 +164,7 @@ class CryptoToken {
    */
   public function rekey($oldToken, $keyTag) {
     /** @var \Civi\Crypto\CryptoRegistry $registry */
-    $registry = \Civi::service('crypto.registry');
+    $registry = $this->getRegistry();
 
     $sourceKeys = $registry->findKeysByTag($keyTag);
     $targetKey = array_shift($sourceKeys);
@@ -198,6 +206,16 @@ class CryptoToken {
         throw new CryptoException("Cannot decrypt token. Invalid format.");
     }
     return $tokenData;
+  }
+
+  /**
+   * @return CryptoRegistry
+   */
+  protected function getRegistry(): CryptoRegistry {
+    if ($this->registry === NULL) {
+      $this->registry = \Civi::service('crypto.registry');
+    }
+    return $this->registry;
   }
 
 }

--- a/Civi/Crypto/RotateKeys.php
+++ b/Civi/Crypto/RotateKeys.php
@@ -1,0 +1,50 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Crypto;
+
+use Civi\Core\Event\GenericHookEvent;
+
+/**
+ * Class RotateKeys
+ *
+ * @package Civi\Crypto
+ */
+class RotateKeys {
+
+  /**
+   * The SMTP password is stored inside of the 'mailing_backend' setting.
+   *
+   * @see CRM_Utils_Hook::cryptoRotateKey()
+   */
+  public static function rotateSmtp(GenericHookEvent $e) {
+    if ($e->tag !== 'CRED') {
+      return;
+    }
+
+    $mand = \Civi::settings()->getMandatory('mailing_backend');
+    if ($mand !== NULL && !empty($mand['smtpPassword'])) {
+      $e->log->warning('The settings override for smtpPassword cannot be changed automatically.');
+    }
+
+    $exp = \Civi::settings()->getExplicit('mailing_backend');
+    if ($exp !== NULL && !empty($exp['smtpPassword'])) {
+      $cryptoToken = \Civi::service('crypto.token');
+      $newValue = $cryptoToken->rekey($exp['smtpPassword'], 'CRED');
+      if ($newValue !== NULL) {
+        $exp['smtpPassword'] = $newValue;
+        \Civi::settings()->set('mailing_backend', $exp);
+        $e->log->info('Updated mailing_backend.smtpPassword');
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------

This converts the `smtpPassword` subfield from `CRM_Utils_Crypt` to the `crypto.token` service, which means:

* It supports more robust key-management.
* When storing `smtpPassword` in SQL, the on-disk format is less ambiguous.
* When storing `smtpPassword` in `civicrm.settings.php`, the on-disk format is less ambiguous and more forgiving.

See also: https://lab.civicrm.org/dev/core/-/issues/2258

(NOTE: This depends on #19236 an #19251.)

(NOTE: A few edits added to the description after-the-fact. It originally spoke of the old plaintext as, well, plaintext. It was actually Base64-encoded plaintext.)

Before
----------------------------------------

The format of the `smtpPassword` subfield depends on the available PHP/PECL extensions:

* The field is *Base64* plaintext... if and only if PHP has `mcrypt` disabled
* The field is encrypted... if and only if PHP has `mcrypt` enabled

Additionally, note that:

* There is no way to discern (*based on the data*) if a value like `YWJjZGVm` is random password or ciphertext. It remains legible only as long as both the PHP configuration and SITE_KEY stay the same.
* There is no sensible way to rotate the encryption key.

After
----------------------------------------

The format of the `smtpPassword` subfield is specified by `crypto.token` which means:

* The field is *normal* plaintext... if and only if the content begins with a printable character (*not `chr(2)`*).
* The field is encrypted... if and only if the content begins with `chr(2)` (in which case the string looks like `^CTK?k=<keyid>&t=<ciphertext>`)

Additionally, note that:

* One can unambiguously distinguish between between plaintext and ciphertext (and, among ciphertexts, you can identify the key needed for decoding).
* The `System.rotateKey` API can be used to phase-out old keys (per #19251).

Technical Details: Review of upgrade scenarios
----------------------------------------

There are three variables which determine different upgrade scenarios:

* __Storage__: Is the password stored in the DB (`civicrm_settings`) or in PHP (`civicrm.settings.php`)?
* __Old Crypto__: Does the environment have `mcrypt` (ie the old crypto system) enabled?
* __New Crypto__: Has the administrator pre-configured `CIVICRM_CRED_KEYS`  (ie the new crypto system)?

Here are how the scenarios work out:

| # | Storage?  | Old crypto? | New crypto? | Comments | 
|--| -- | -- | -- | -- |
| 1 | DB (`civicrm_settings`) | No | No | `smtpPassword` starts as *Base64* plain-text and ends as *normal* plain-text. |
| 2 | DB (`civicrm_settings`) | No | Yes | `smtpPassword` converts from plain-text to new-encryption. |
| 3 | DB (`civicrm_settings`) | Yes | No | `smtpPassword` converts from old-encryption to plain-text. |
| 4 | DB (`civicrm_settings`) | Yes | Yes | `smtpPassword` converts from old-encryption to new-encryption. |
| 5 | PHP (`civicrm.settings.php`) | No | * | ~~`smtpPassword` was stored in PHP as plain-text, and the same plain-text will work post-upgrade.~~ :warning: `smtpPassword` was stored in PHP with the old Base64 plain-text, and the upgrader cannot change it.  After upgrading, you must manually edit `civicrm.settings.php` to set `smtpPassword` as normal plain-text. |
| 6 | PHP (`civicrm.settings.php`) | Yes | * | :warning: `smtpPassword` was stored in PHP with the old encrypted format, and the upgrader cannot change it. After upgrading, you must manually edit `civicrm.settings.php` to set `smtpPassword` using plain-text or the new encryption format. |

Scenarios 1-4 all end with a working/readable variant of `smtpPassword`. After upgrade, one has the option to change the crypto by updating `CIVICRM_CRED_KEYS` and calling `System.rotateKeys`.

Scenarios 5-6 are annoying, but there's not much we can do besides show a warning. However, I don't expect this to be common because it has always been tricky to understand/setup. If you have managed to figure it out before, then you're probably clever enough to sort out the migration - as long as you see the warning provided by the upgrader. (There are more comments in `ThirtyFour.php` alongside the relevant warning.)
 
Technical Details: Sysadmin usability
----------------------------------------

This patch incidentally makes it easier to set the SMTP password via `civicrm.settings.php` / `$civicrm_settings`.

```php
$civicrm_setting['domain']['mailing_backend'] =  array(
        'outBound_option' => '0',
        'sendmail_path' => '',
        'sendmail_args' => '',
        'smtpServer' => 'localhost',
        'smtpPort' => '1025',
        'smtpAuth' => '1',
        'smtpUsername' => '',
        'smtpPassword' => '********',
      );
```

Compare:

* With `CRM_Utils_Crypt`, the format of `********` was determined by the PECL configuration, which is usually out-of-sight/out-of-mind. Consequently, I would wager that the behavior seems unreliable/confusing to administrators -- on one deployment/server, `********` is interpreted as plaintext, and it works intuitively. On another, the `********` is interpreted as ciphertext, and it's very difficult to set correctly.
* With `crypto.token`, the PECL configuration is not decisive. The sysadmin can put the `smtpPassword` as plain-text (`'smtpPassword' => 'mySecret'`), and that will work on any server. If they prefer to enter the override as an encrypted value, that works too (`'smtpPassword' => chr(2).'CTK?k=...&t=...'` -- although I think the audience for this would be quite limited).