### PR TITLE
Issue #2263 Multiple available languages disables kcfinder

### DIFF
--- a/CRM/Utils/System/DrupalBase.php
+++ b/CRM/Utils/System/DrupalBase.php
@@ -675,7 +675,7 @@ abstract class CRM_Utils_System_DrupalBase extends CRM_Utils_System_Base {
       }
       $_SESSION = [];
     }
-    else {
+    elseif (!preg_match('/kcfinder/', $_SERVER['SCRIPT_NAME'])) {
       session_start();
     }
   }


### PR DESCRIPTION
Overview
----------------------------------------
See https://lab.civicrm.org/dev/core/-/issues/2263

Technical Details
----------------------------------------
It's a bootstrapping problem. File browsing is done with the `kcfinder` package. It uses the script `kcfinder/browse.php` that is neither CiviCRM and Drupal. So it does its own bootstrapping.

It first executes  `$config = CRM_Core_Config::singleton();` This leads to a call to `CRM_Core_BAO_ConfigSetting::applyLocale` and then when more that two languages are configured this function tries to set something on the session with `$session->set('lcMessages', $chosenLocale);`. Unfortunately there is no session yet, so it tries to create it with start DrupalBase->sessionStart(). However the system is not completly bootstrapped yet, so the drupal classes are not available to it falls so the standard PHP `session_start();` is executed instead of the ` drupal_session_start();`

Later on in the code, an official Drupal bootstrap is executed, and then the right `drupal_session_start();` is done. But then its to late, that does not work well in combination with standard PHP one, so it does not work completely. It fails in getting the user_id, and that was just the thing needed to authorization. So the code quite with an exception.

This is the long story. The short one is, Something goes wrong, and I blame an obsolete start_session call.

Bootstrapping is a complicated process and I do not know how it works for other scripts so I disable this call only for the `kcfinders` script.

Comments
----------------------------------------
It's a clever bug. It manifests itself only in a multilingual environment and has effects on a seemingly unrelated place. So it's mostly unnoticed and occasionally drives someone mad. 
