### PR TITLE
dev/core#2252 remove all handling of strict mode as it has aged out of relevance

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -186,16 +186,6 @@ class CRM_Core_DAO extends DB_DataObject {
     }
     $factory = new CRM_Contact_DAO_Factory();
     CRM_Core_DAO::setFactory($factory);
-    $currentModes = CRM_Utils_SQL::getSqlModes();
-    if (CRM_Utils_Constant::value('CIVICRM_MYSQL_STRICT', CRM_Utils_System::isDevelopment())) {
-      if (CRM_Utils_SQL::supportsFullGroupBy() && !in_array('ONLY_FULL_GROUP_BY', $currentModes) && CRM_Utils_SQL::isGroupByModeInDefault()) {
-        $currentModes[] = 'ONLY_FULL_GROUP_BY';
-      }
-      if (!in_array('STRICT_TRANS_TABLES', $currentModes)) {
-        $currentModes = array_merge(['STRICT_TRANS_TABLES'], $currentModes);
-      }
-      CRM_Core_DAO::executeQuery("SET SESSION sql_mode = %1", [1 => [implode(',', $currentModes), 'String']]);
-    }
     CRM_Core_DAO::executeQuery('SET NAMES utf8mb4');
     CRM_Core_DAO::executeQuery('SET @uniqueID = %1', [1 => [CRM_Utils_Request::id(), 'String']]);
   }

--- a/CRM/Utils/File.php
+++ b/CRM/Utils/File.php
@@ -332,9 +332,6 @@ class CRM_Utils_File {
     if (PEAR::isError($db)) {
       die("Cannot open $dsn: " . $db->getMessage());
     }
-    if (CRM_Utils_Constant::value('CIVICRM_MYSQL_STRICT', CRM_Utils_System::isDevelopment())) {
-      $db->query('SET SESSION sql_mode = STRICT_TRANS_TABLES');
-    }
     $db->query('SET NAMES utf8mb4');
     $transactionId = CRM_Utils_Type::escape(CRM_Utils_Request::id(), 'String');
     $db->query('SET @uniqueID = ' . "'$transactionId'");

--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -1829,7 +1829,17 @@ class CRM_Utils_System {
   }
 
   /**
-   * Determine whether this is a developmental system.
+   * Determine whether this system is deployed using version control.
+   *
+   * Normally sites would tune their php error settings to prevent deprecation
+   * notices appearing on a live site. However, on some systems the user
+   * does not have control over this setting. Sites with version-controlled
+   * deployments are unlikely to be in a situation where they cannot alter their
+   * php error level reporting so we can trust that the are able to set them
+   * to suppress deprecation / php error level warnings if appropriate but
+   * in order to phase in deprecation warnings we originally chose not to
+   * show them on sites who might not be able to set their error_level in
+   * a way that is appropriate to their site.
    *
    * @return bool
    */

--- a/distmaker/utils/joomlaxml.php
+++ b/distmaker/utils/joomlaxml.php
@@ -1,5 +1,5 @@
 <?php
-define('CIVICRM_MYSQL_STRICT', 0);
+
 if (isset($GLOBALS['_SERVER']['DM_SOURCEDIR'])) {
   $sourceCheckoutDir = $GLOBALS['_SERVER']['DM_SOURCEDIR'];
 }

--- a/templates/CRM/common/civicrm.settings.php.template
+++ b/templates/CRM/common/civicrm.settings.php.template
@@ -468,19 +468,8 @@ if (!defined('CIVICRM_PSR16_STRICT')) {
  */
 define('CIVICRM_DEADLOCK_RETRIES', 3);
 
-/**
- * Configure MySQL to throw more errors when encountering unusual SQL expressions.
- *
- * If undefined, the value is determined automatically. For CiviCRM tarballs, it defaults
- * to FALSE; for SVN checkouts, it defaults to TRUE.
- */
-// if (!defined('CIVICRM_MYSQL_STRICT')) {
-// define('CIVICRM_MYSQL_STRICT', TRUE );
-// }
-
 if (CIVICRM_UF === 'UnitTests') {
   if (!defined('CIVICRM_CONTAINER_CACHE')) define('CIVICRM_CONTAINER_CACHE', 'auto');
-  if (!defined('CIVICRM_MYSQL_STRICT')) define('CIVICRM_MYSQL_STRICT', true);
 }
 
 /**


### PR DESCRIPTION
Overview
----------------------------------------
Per https://lab.civicrm.org/dev/core/-/issues/2252 we agreed that we are appropriately setting strict mode via other means now (mostly by it being the default) and it is no longer needed now - this removes

Before
----------------------------------------
Option to set ```CIVICRM_MYSQL_STRICT``` and have it increase the strictness configured in mysql

After
----------------------------------------
Expectation that mysql configuration would be adequate.

Technical Details
----------------------------------------
Discussion largely in https://lab.civicrm.org/dev/core/-/issues/2252

I considered also renaming the isDevelopment function to be isUnderVersionControl but lef that out of scope - settling for updating the comment block comments to better explaining how it is used

Comments
----------------------------------------
@seamuslee001 @demeritcowboy you both engaged on the relevant gitlab