### PR TITLE
dev/core#2263 Do not try and store items in the session if the sessio…

### DIFF
--- a/CRM/Core/BAO/ConfigSetting.php
+++ b/CRM/Core/BAO/ConfigSetting.php
@@ -205,15 +205,17 @@ class CRM_Core_BAO_ConfigSetting {
         $chosenLocale = $defaultLocale;
       }
 
-      // Always assign the chosen locale to the session.
-      $session->set('lcMessages', $chosenLocale);
-
     }
     else {
 
       // CRM-11993 - Use default when it's a single-language install.
       $chosenLocale = $defaultLocale;
 
+    }
+
+    if (!$session->isEmpty()) {
+      // Always assign the chosen locale to the session.
+      $session->set('lcMessages', $chosenLocale);
     }
 
     /*


### PR DESCRIPTION
…n is currently empty

Store the locale in the session even if we are in a single lingual instance

Overview
----------------------------------------
This aims to fix an issue where by if you have multiple languages enabled on your civicrm instance the KcFinder breaks because the session is tried to written to before Drupal has booted

Before
----------------------------------------
1. Create a Drupal test site
2. Enable multiple languages
3. Try to access KCFinder say from managing a contribution page and get errors

After
----------------------------------------
The above works

Technical Details
----------------------------------------
There is more investigation information found on the alternate PR https://github.com/civicrm/civicrm-core/pull/19242. However this to me tries to target the actual underlying source of the problem where was that feels like it is just putting a bandaid on the issue

ping @haystack @kainuk @mlutfy 

Are any of you able to test this and let me know if it works for you?