### PR TITLE
[REF] Switch to using shared function to call deprecated function

### DIFF
--- a/CRM/Contribute/Import/Parser/Contribution.php
+++ b/CRM/Contribute/Import/Parser/Contribution.php
@@ -352,10 +352,6 @@ class CRM_Contribute_Import_Parser_Contribution extends CRM_Contribute_Import_Pa
     }
 
     if ($this->_contactIdIndex < 0) {
-      // set the contact type if its not set
-      if (!isset($paramValues['contact_type'])) {
-        $paramValues['contact_type'] = $this->_contactType;
-      }
 
       $error = $this->checkContactDuplicate($paramValues);
 
@@ -911,7 +907,7 @@ class CRM_Contribute_Import_Parser_Contribution extends CRM_Contribute_Import_Pa
             }
             else {
               // we need to get contribution contact using de dupe
-              $error = _civicrm_api3_deprecated_check_contact_dedupe($params);
+              $error = $this->checkContactDuplicate($params);
 
               if (isset($error['error_message']['params'][0])) {
                 $matchedIDs = explode(',', $error['error_message']['params'][0]);

--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -524,7 +524,7 @@ abstract class CRM_Import_Parser {
    */
   protected function checkContactDuplicate(&$formatValues) {
     //retrieve contact id using contact dedupe rule
-    $formatValues['contact_type'] = $this->_contactType;
+    $formatValues['contact_type'] = $formatValues['contact_type'] ?? $this->_contactType;
     $formatValues['version'] = 3;
     require_once 'CRM/Utils/DeprecatedUtils.php';
     $error = _civicrm_api3_deprecated_check_contact_dedupe($formatValues);


### PR DESCRIPTION


Overview
----------------------------------------
Minor code consolidation

Before
----------------------------------------
Other import places call a function on the class but this instance still calling the deprecated function directly

After
----------------------------------------
Class calling function on parent

Technical Details
----------------------------------------
With this done all the functionality in the deprecated function can be moved into the shared function

Comments
----------------------------------------
