### PR TITLE
Fatal error on contribution summary report (and probably others) when adding contacts to group

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -4962,7 +4962,11 @@ LEFT JOIN civicrm_contact {$field['alias']} ON {$field['alias']}.id = {$this->_a
       $select = preg_replace('/SELECT(\s+SQL_CALC_FOUND_ROWS)?\s+/i', $select, $this->_select);
       $sql = "{$select} {$this->_from} {$this->_where} {$this->_groupBy} {$this->_having} {$this->_orderBy}";
       $sql = str_replace('WITH ROLLUP', '', $sql);
+      if (!$this->optimisedForOnlyFullGroupBy) {
+        CRM_Core_DAO::disableFullGroupByMode();
+      }
       $dao = CRM_Core_DAO::executeQuery($sql);
+      CRM_Core_DAO::reenableFullGroupByMode();
 
       $contact_ids = [];
       // Add resulting contacts to group


### PR DESCRIPTION
Overview
----------------------------------------
Fatal error on contribution summary report (and probably others).

Before
----------------------------------------
To replicate

- Make sure ONLY_FULL_GROUP_BY mode is enabled in mysql.
- Load contribution summary report, enable contact name and search.
- Select the action to add contacts to one of the groups.

![image](https://user-images.githubusercontent.com/5929648/102770737-a49a2980-43aa-11eb-9e71-a0f2f3f8f5f8.png)



After
----------------------------------------
No error, the contacts are added to the group.

Technical Details
----------------------------------------
Query stilll the same, we've disabled the full group by mode for the reports that are not optimized to work with this mode.

Comments
----------------------------------------
Gitlab - https://lab.civicrm.org/dev/core/-/issues/2265