### PR TITLE
(dev/core#2258) Add API+hook to rotate keys for encrypted fields

### DIFF
--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -2084,6 +2084,47 @@ abstract class CRM_Utils_Hook {
   }
 
   /**
+   * Rotate the cryptographic key used in the database.
+   *
+   * The purpose of this hook is to visit any encrypted values in the database
+   * and re-encrypt the content.
+   *
+   * For values encoded via `CryptoToken`, you can use `CryptoToken::rekey($oldToken, $tag)`
+   *
+   * @param string $tag
+   *   The type of crypto-key that is currently being rotated.
+   *   The hook-implementer should use this to decide which (if any) fields to visit.
+   *   Ex: 'CRED'
+   * @param \Psr\Log\LoggerInterface $log
+   *   List of messages about re-keyed values.
+   *
+   * @code
+   * function example_civicrm_rekey($tag, &$log) {
+   *   if ($tag !== 'CRED') return;
+   *
+   *   $cryptoToken = Civi::service('crypto.token');
+   *   $rows = sql('SELECT id, secret_column FROM some_table');
+   *   foreach ($rows as $row) {
+   *     $new = $cryptoToken->rekey($row['secret_column']);
+   *     if ($new !== NULL) {
+   *       sql('UPDATE some_table SET secret_column = %1 WHERE id = %2',
+   *         $new, $row['id']);
+   *     }
+   *   }
+   * }
+   * @endCode
+   *
+   * @return null
+   *   The return value is ignored
+   */
+  public static function cryptoRotateKey($tag, $log) {
+    return self::singleton()->invoke(['tag', 'log'], $tag, $log, self::$_nullObject,
+      self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      'civicrm_cryptoRotateKey'
+    );
+  }
+
+  /**
    * @param CRM_Core_Exception $exception
    * @param mixed $request
    *   Reserved for future use.

--- a/Civi/Api4/Action/System/RotateKey.php
+++ b/Civi/Api4/Action/System/RotateKey.php
@@ -1,0 +1,81 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Action\System;
+
+use Civi\Api4\Generic\AbstractAction;
+use Civi\Api4\Generic\Result;
+
+/**
+ * Rotate the keys used for encrypted database content.
+ *
+ * Crypto keys are loaded from the CryptoRegistry based on tag name. Each tag will
+ * have one preferred key and 0+ legacy keys. They rekey operation finds any
+ * old content (based on legacy keys) and rewrites it (using the preferred key).
+ *
+ * @method string getTag()
+ * @method $this setTag(string $tag)
+ */
+class RotateKey extends AbstractAction {
+
+  /**
+   * Tag name (e.g. "CRED")
+   *
+   * @var string
+   */
+  protected $tag;
+
+  /**
+   * @param \Civi\Api4\Generic\Result $result
+   *
+   * @throws \API_Exception
+   * @throws \Civi\Crypto\Exception\CryptoException
+   */
+  public function _run(Result $result) {
+    if (empty($this->tag)) {
+      throw new \API_Exception("Missing required argument: tag");
+    }
+
+    // Track log of changes in memory.
+    $logger = new class() extends \Psr\Log\AbstractLogger {
+
+      /**
+       * @var array
+       */
+      public $log = [];
+
+      /**
+       * Logs with an arbitrary level.
+       *
+       * @param mixed $level
+       * @param string $message
+       * @param array $context
+       */
+      public function log($level, $message, array $context = []) {
+        $evalVar = function($m) use ($context) {
+          return $context[$m[1]] ?? '';
+        };
+
+        $this->log[] = [
+          'level' => $level,
+          'message' => preg_replace_callback('/\{([a-zA-Z0-9\.]+)\}/', $evalVar, $message),
+        ];
+      }
+
+    };
+
+    \CRM_Utils_Hook::cryptoRotateKey($this->tag, $logger);
+
+    $result->exchangeArray($logger->log);
+  }
+
+}

--- a/Civi/Api4/System.php
+++ b/Civi/Api4/System.php
@@ -45,6 +45,16 @@ class System extends Generic\AbstractEntity {
 
   /**
    * @param bool $checkPermissions
+   *
+   * @return Action\System\RotateKey
+   */
+  public static function rotateKey($checkPermissions = TRUE) {
+    return (new Action\System\RotateKey(__CLASS__, __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
+  }
+
+  /**
+   * @param bool $checkPermissions
    * @return Generic\BasicGetFieldsAction
    */
   public static function getFields($checkPermissions = TRUE) {

--- a/tests/phpunit/api/v4/Entity/SystemRotateKeyTest.php
+++ b/tests/phpunit/api/v4/Entity/SystemRotateKeyTest.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+
+namespace api\v4\Entity;
+
+use api\v4\UnitTestCase;
+use Civi\Crypto\CryptoTestTrait;
+use Psr\Log\LoggerInterface;
+
+/**
+ * @group headless
+ */
+class RotateKeyTest extends UnitTestCase {
+
+  use CryptoTestTrait;
+
+  /**
+   * Set up baseline for testing
+   */
+  public function setUp() {
+    parent::setUp();
+    \CRM_Utils_Hook::singleton()->setHook('civicrm_crypto', [$this, 'registerExampleKeys']);
+    \CRM_Utils_Hook::singleton()->setHook('civicrm_cryptoRotateKey', [$this, 'onRotateKey']);
+  }
+
+  public function testRekey() {
+    $result = \Civi\Api4\System::rotateKey(0)->setTag('UNIT-TEST')->execute();
+    $this->assertEquals(2, count($result));
+    $this->assertEquals('Updated field A using UNIT-TEST.', $result[0]['message']);
+    $this->assertEquals('info', $result[0]['level']);
+    $this->assertEquals('Updated field B using UNIT-TEST.', $result[1]['message']);
+    $this->assertEquals('info', $result[1]['level']);
+  }
+
+  public function onRotateKey(string $tag, LoggerInterface $log) {
+    $this->assertEquals('UNIT-TEST', $tag);
+    $log->info('Updated field A using {tag}.', [
+      'tag' => $tag,
+    ]);
+    $log->info('Updated field B using {tag}.', [
+      'tag' => $tag,
+    ]);
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------

*Key rotation* is the process of phasing-out an old cryptographic-key and phasing-in a new one. This patchset introduces support for rotating the key used for encrypted values in the database. 

Many security practitioners regard key-rotation as best-practice because it:

* Limits the risk/damage of leaking a key. (*Ex: If a backup file leaks to the web, or if an old contractor forgets to delete work notes, or if a sysadmin's workstation gets malware, then an old key could leak. But if you rotate keys periodically, then leaking the old key doesn't pose much risk.*)
* Limits the feasibility of brute-force attacks. (*When a key is rotated, the attacker has to start over.*)

See also: https://lab.civicrm.org/dev/core/-/issues/2258

(NOTE: This builds on #19236, and it is a step towards #19239.)

Before
----------------------------------------

#19236 was a partial step towards key-rotation. Specifically, it allowed one to define multiple keys. For example, suppose `civicrm.settings.php` starts with the configuration:

```php
define('CIVICRM_CRED_KEYS', '::aaaa');
```

You could add a higher-priority key in the list:

```php
define('CIVICRM_CRED_KEYS', '::bbbb ::aaaa');
```

Any new credential-content will be encrypted with `::bbbb`. However, existing content still uses `::aaaa`. There is no defined mechanism for re-encrypting values with `::bbbb`.

After
----------------------------------------

The `System.rotateKey` API can migrate data from the old `::aaaa` to the new `::bbbb`, e.g.

```
cv api4 System.rotateKey tag=CRED
```

This fires `hook_civicrm_cryptoRotateKey('CRED', $log)` to ensure that any data based on `CRED` is re-encrypted with the current key (`::bbbb`).

Comments
----------------------------------------

Why is there a hook? Consider that there are several bits of content that should be plausibly re-encryped, e.g.

1. Within `civicrm_settings`, and within the record for `mailing_backend`, there is a subfield for `smtpPassword` which should be encryptable/rotateable.
2. Within `civicrm_settings`, there are some `value`s (*likely defined in extensions*) which should be encryptable/rotateable.
3. Within `civicrm_payment_processor`, the `password` should be encryptable/rotateable.

These are 3 different data-structures, and there is no singular SQL statement to touch all of them. We have to define multiple re-encryption steps (and some of them may be extension-dependent). Using a hook provides a flexible starting point.

Here's pseudocode for a hook-implementation:

```php
/**
 * Ensure that `some_table`.`secret_column` is encrypted with the `CRED` key.
 * Use the method `CryptoToken::rekey(...)` to re-encrypt specific values.
 */
function example_civicrm_cryptoRotateKey($tag, $log) {
  if ($tag !== 'CRED') return;
  
  $cryptoToken = Civi::service('crypto.token');

  $rows = sql('SELECT id, secret_column FROM some_table');
  foreach ($rows as $row) {
    $new = $cryptoToken->rekey($row['secret_column'], 'CRED');
    if ($new !== NULL) {
      sql('UPDATE some_table SET secret_column = %1 WHERE id = %2', $new, $row['id']);
      $log->info("Updated secret_column for #{id}", ['id' => $row['id']]);
    }
  }
}
```

For a working example, see #19239 which addresses the `civicrm_setting`.`mailing_backend`.`smtpPassword`.
