### PR TITLE
Improve logging when a contribution is created/updated

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4254,8 +4254,8 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
 
     $contribution->contribution_status_id = $contributionParams['contribution_status_id'];
 
-    CRM_Core_Error::debug_log_message('Contribution record updated successfully');
     $transaction->commit();
+    \Civi::log()->info("Contribution {$contributionParams['id']} updated successfully");
 
     // @todo - check if Contribution::create does this, test, remove.
     CRM_Contribute_BAO_ContributionRecur::updateRecurLinkedPledge($contributionID, $recurringContributionID,
@@ -4278,10 +4278,9 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
         'id' => $contributionID,
         'payment_processor_id' => $paymentProcessorId,
       ]);
-      CRM_Core_Error::debug_log_message("Receipt sent");
+      \Civi::log()->info("Contribution {$contributionParams['id']} Receipt sent");
     }
 
-    CRM_Core_Error::debug_log_message("Success: Database updated");
     return $contributionResult;
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
When a contribution is created in CiviCRM up to 3 log messages are created. Compared with other actions in CiviCRM this is very verbose (ie. most things don't log anything by default). The messages that are logged are not very useful because they don't give enough information to use them for forensics/debugging:
```
1. Contribution record updated successfully
2. Receipt sent
3. Success: Database updated
```

This PR removes the 3rd one entirely and updates the first two messages to include the contribution ID making them far more useful:
```
Contribution {$contributionParams['id']} updated successfully
Contribution {$contributionParams['id']} Receipt sent
```

Before
----------------------------------------
```
1. Contribution record updated successfully
2. Receipt sent
3. Success: Database updated
```

After
----------------------------------------
```
Contribution {$contributionParams['id']} updated successfully
Contribution {$contributionParams['id']} Receipt sent
```

Technical Details
----------------------------------------
Explained above.

Comments
----------------------------------------
These have annoyed me for a while as they are are often found in the logs but are not very helpful...