### PR TITLE
[APIv4] Permit using other SQL functions such as CONCAT within a GROU…

### DIFF
--- a/Civi/Api4/Query/SqlFunctionGROUP_CONCAT.php
+++ b/Civi/Api4/Query/SqlFunctionGROUP_CONCAT.php
@@ -24,7 +24,7 @@ class SqlFunctionGROUP_CONCAT extends SqlFunction {
     [
       'prefix' => ['', 'DISTINCT', 'ALL'],
       'expr' => 1,
-      'must_be' => ['SqlField'],
+      'must_be' => ['SqlField', 'sqlFunction'],
       'optional' => FALSE,
     ],
     [

--- a/tests/phpunit/api/v4/Action/SqlFunctionTest.php
+++ b/tests/phpunit/api/v4/Action/SqlFunctionTest.php
@@ -76,6 +76,18 @@ class SqlFunctionTest extends UnitTestCase {
 
     $this->assertTrue(4 === $agg['count']);
     $this->assertContains('Donation', $agg['GROUP_CONCAT:financial_type_id:name']);
+
+    // Test GROUP_CONCAT with a CONCAT as well
+    $agg = Contribution::get(FALSE)
+      ->addGroupBy('contact_id')
+      ->addWhere('contact_id', '=', $cid)
+      ->addSelect("GROUP_CONCAT(CONCAT(financial_type_id, ', ', contact_id, ', ', total_amount))")
+      ->addSelect('COUNT(*) AS count')
+      ->execute()
+      ->first();
+
+    $this->assertTrue(4 === $agg['count']);
+    $this->assertContains('1, ' . $cid . ', 100.00', $agg['GROUP_CONCAT:financial_type_id_contact_id_total_amount']);
   }
 
   public function testGroupHaving() {


### PR DESCRIPTION
…P_CONCAT

Overview
----------------------------------------
This allows for SQL functions such as CONCAT to be used within a GROUP CONCAT, this maybe useful if your trying to get all the line items associated with a contribution into one field perhaps

Before
----------------------------------------
Cannot use SQL functions within a GROUP_CONCAT in APIv4

After
----------------------------------------
Can do so

ping @eileenmcnaughton @colemanw 