### PR TITLE
dev/core#2240 and dev/core#2241 - Move non-compliant trigger_error out of logging

### DIFF
--- a/CRM/Core/Error.php
+++ b/CRM/Core/Error.php
@@ -1047,7 +1047,10 @@ class CRM_Core_Error extends PEAR_ErrorStack {
    * @param string $message
    */
   public static function deprecatedWarning($message) {
+    // Even though the tag is no longer used within the log() function,
+    // \Civi\API\LogObserver instances may still be monitoring it.
     Civi::log()->warning($message, ['civi.tag' => 'deprecated']);
+    trigger_error($message, E_USER_DEPRECATED);
   }
 
 }

--- a/CRM/Core/Error/Log.php
+++ b/CRM/Core/Error/Log.php
@@ -53,10 +53,6 @@ class CRM_Core_Error_Log extends \Psr\Log\AbstractLogger {
         $context['exception'] = CRM_Core_Error::formatTextException($context['exception']);
       }
       $message .= "\n" . print_r($context, 1);
-
-      if (CRM_Utils_System::isDevelopment() && CRM_Utils_Array::value('civi.tag', $context) === 'deprecated') {
-        trigger_error($message, E_USER_DEPRECATED);
-      }
     }
     CRM_Core_Error::debug_log_message($message, FALSE, '', $this->map[$level]);
   }


### PR DESCRIPTION
Overview
----------------------------------------
Much longer discussion at https://lab.civicrm.org/dev/core/-/issues/2240 and https://lab.civicrm.org/dev/core/-/issues/2241 but this commit is about making CRM_Core_Error_Log more PSR3-compliant by not throwing errors itself, and removing dependence on the presence of a .git folder.
