### PR TITLE
dev/core#2270 - Editing a smartgroup created through the search builder renders the new block by force

### DIFF
--- a/CRM/Contact/Form/Search/Builder.php
+++ b/CRM/Contact/Form/Search/Builder.php
@@ -51,7 +51,9 @@ class CRM_Contact_Form_Search_Builder extends CRM_Contact_Form_Search {
     // Initialize new form
     if (!$this->_blockCount) {
       $this->_blockCount = 4;
-      $this->set('newBlock', 1);
+      if (!$this->_ssID) {
+        $this->set('newBlock', 1);
+      }
     }
 
     //get the column count


### PR DESCRIPTION
Overview
----------------------------------------
This is a PR of issue https://lab.civicrm.org/dev/core/-/issues/2270 where the new block (select record type / operator) is render on both cases: on a new search builder form and on existing search builder forms (when editing the smartgroup)

Before
----------------------------------------
The new record type/operator line is now appearing on either an existing smartgroup done via the searchbuilder or on a new searchbuilder form. 

After
----------------------------------------
The new record type + operator line should appear only on the new searchbuilder form

Technical Details
----------------------------------------
Assuming that I am not skipping anything, there should be a check happening [here](https://lab.civicrm.org/dev/core/-/blob/master/CRM/Contact/Form/Search/Builder.php#L54) .
For example, right now it's :

for example this:
```php
    // Initialize new form
    if (!$this->_blockCount) {
      $this->_blockCount = 4;
      $this->set('newBlock', 1);
    }
```
should be something like this:
```php
    // Initialize new form
    if (!$this->_blockCount) {
      $this->_blockCount = 4;
      if (!$this->_ssID) {
        $this->set('newBlock', 1);
      }
    }
```