### PR TITLE
Convert contributionSoft to an array

### DIFF
--- a/CRM/Contribute/BAO/ContributionSoft.php
+++ b/CRM/Contribute/BAO/ContributionSoft.php
@@ -609,7 +609,7 @@ class CRM_Contribute_BAO_ContributionSoft extends CRM_Contribute_DAO_Contributio
       $contributionSoft = self::add($softParams);
       //Send notification to owner for PCP
       if ($contributionSoft->pcp_id && empty($pcpId)) {
-        CRM_Contribute_Form_Contribution_Confirm::pcpNotifyOwner($contribution, $contributionSoft);
+        CRM_Contribute_Form_Contribution_Confirm::pcpNotifyOwner($contribution, (array) $contributionSoft);
       }
     }
     //Delete PCP against this contribution and create new on submitted PCP information


### PR DESCRIPTION

Overview
----------------------------------------
Convert contributionSoft to an array

This is a partial of #19096 which requires contributionSoft to be an array & just simplifies that commit (which
is still failing tests


Before
----------------------------------------
param expected to be an object

After
----------------------------------------
Param expected to be an array - as it will be when that is fully implemented

Technical Details
----------------------------------------

Comments
----------------------------------------
