### PR TITLE
  Remove code to retrieve premium data

### DIFF
--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -1901,7 +1901,6 @@ DESC limit 1");
         $result, $receiptDate,
         $recurringContributionID), $contributionParams
       );
-      $contributionParams['non_deductible_amount'] = CRM_Contribute_Form_Contribution_Confirm::getNonDeductibleAmount($params, $financialType, FALSE, $form);
       $contributionParams['skipCleanMoney'] = TRUE;
       // @todo this is the wrong place for this - it should be done as close to form submission
       // as possible


### PR DESCRIPTION
Overview
----------------------------------------
Remove code to retrieve premium data from previous shared function

Before
----------------------------------------
Code attempts to calculate deductible amount (ie the donation less the cost of the premium) in code that has been copied from a shared function. However, I looked in the UI & the code & concluded premiums are not available on the back office membership form

After
----------------------------------------
poof

Technical Details
----------------------------------------
This is only in one obscure code path on the form - recurring card contributions. If premiums were handled they would be in more than this flow which appears to have shared a lot of code in order to do very little in common

Comments
----------------------------------------
