### PR TITLE
REF use addRadio function to add in the radio fields to these forms

### DIFF
--- a/CRM/Campaign/Form/Survey/Results.php
+++ b/CRM/Campaign/Form/Survey/Results.php
@@ -123,12 +123,11 @@ class CRM_Campaign_Form_Survey_Results extends CRM_Campaign_Form_Survey {
     }
 
     // form fields of Custom Option rows
-    $defaultOption = [];
+    $defaultOptionValues = [];
     $_showHide = new CRM_Core_ShowHideBlocks('', '');
 
     $optionAttributes = CRM_Core_DAO::getAttribute('CRM_Core_DAO_OptionValue');
     $optionAttributes['label']['size'] = $optionAttributes['value']['size'] = 25;
-
     for ($i = 1; $i <= self::NUM_OPTION; $i++) {
       //the show hide blocks
       $showBlocks = 'optionField_' . $i;
@@ -161,11 +160,11 @@ class CRM_Campaign_Form_Survey_Results extends CRM_Campaign_Form_Survey {
         CRM_Core_DAO::getAttribute('CRM_Campaign_DAO_Survey', 'release_frequency')
       );
 
-      $defaultOption[$i] = $this->createElement('radio', NULL, NULL, NULL, $i);
+      $defaultOptionValues[$i] = NULL;
     }
 
     //default option selection
-    $this->addGroup($defaultOption, 'default_option');
+    $this->addRadio('default_option', '', $defaultOptionValues);
 
     $_showHide->addToTemplate();
 

--- a/CRM/Export/Form/Select.php
+++ b/CRM/Export/Form/Select.php
@@ -165,46 +165,24 @@ FROM   {$this->_componentTable}
    */
   public function buildQuickForm() {
     //export option
-    $exportOptions = $mergeOptions = $postalMailing = [];
-    $exportOptions[] = $this->createElement('radio',
-      NULL, NULL,
-      ts('Export PRIMARY fields'),
-      self::EXPORT_ALL,
-      ['onClick' => 'showMappingOption( );']
-    );
-    $exportOptions[] = $this->createElement('radio',
-      NULL, NULL,
-      ts('Select fields for export'),
-      self::EXPORT_SELECTED,
-      ['onClick' => 'showMappingOption( );']
-    );
-
-    $mergeOptions[] = $this->createElement('radio',
-      NULL, NULL,
-      ts('Do not merge'),
-      self::EXPORT_MERGE_DO_NOT_MERGE,
-      ['onclick' => 'showGreetingOptions( );']
-    );
-    $mergeOptions[] = $this->createElement('radio',
-      NULL, NULL,
-      ts('Merge All Contacts with the Same Address'),
-      self::EXPORT_MERGE_SAME_ADDRESS,
-      ['onclick' => 'showGreetingOptions( );']
-    );
-    $mergeOptions[] = $this->createElement('radio',
-      NULL, NULL,
-      ts('Merge Household Members into their Households'),
-      self::EXPORT_MERGE_HOUSEHOLD,
-      ['onclick' => 'showGreetingOptions( );']
-    );
-
+    $exportOptions = $exportOptionsJS = $mergeOptions = $mergeOptionsJS = $postalMailing = [];
+    $exportOptions[self::EXPORT_ALL] = ts('Export PRIMARY fields');
+    $exportOptions[self::EXPORT_SELECTED] = ts('Select fields for export');
+    $mergeOptions[self::EXPORT_MERGE_DO_NOT_MERGE] = ts('Do not merge');
+    $mergeOptions[self::EXPORT_MERGE_SAME_ADDRESS] = ts('Merge All Contacts with the Same Address');
+    $mergeOptions[self::EXPORT_MERGE_HOUSEHOLD] = ts('Merge Household Members into their Households');
+    foreach (array_keys($exportOptions) as $key) {
+      $exportOptionsJS[$key] = ['onClick' => 'showMappingOption( );'];
+    }
+    foreach (array_keys($mergeOptions) as $key) {
+      $mergeOptionsJS[$key] = ['onclick' => 'showGreetingOptions( );'];
+    }
+    $this->addRadio('exportOption', ts('Export Type'), $exportOptions, [], '<br/>', FALSE, $exportOptionsJS);
     $postalMailing[] = $this->createElement('advcheckbox',
       'postal_mailing_export',
       NULL,
       NULL
     );
-
-    $this->addGroup($exportOptions, 'exportOption', ts('Export Type'), '<br/>');
 
     if ($this->_matchingContacts) {
       $this->_greetingOptions = self::getGreetingOptions();
@@ -219,7 +197,7 @@ FROM   {$this->_componentTable}
     }
 
     if ($this->_exportMode == self::CONTACT_EXPORT) {
-      $this->addGroup($mergeOptions, 'mergeOption', ts('Merge Options'), '<br/>');
+      $this->addRadio('mergeOption', ts('Merge Options'), $mergeOptions, [], '<br/>', FALSE, $mergeOptionsJS);
       $this->addGroup($postalMailing, 'postal_mailing_export', ts('Postal Mailing Export'), '<br/>');
 
       $this->addElement('select', 'additional_group', ts('Additional Group for Export'),


### PR DESCRIPTION
Overview
----------------------------------------
This refactors these 2 forms to use the addRadio function in CRM_Core_Form rather than manually creating radio elements then adding them to a group

Before
----------------------------------------
Using non centralised code 

After
----------------------------------------
Using a centralised function

ping @demeritcowboy @eileenmcnaughton 