### PR TITLE
dev/core#2240 - Convert remaining two deprecatedWarning calls

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -126,7 +126,7 @@ class CRM_Core_DAO extends DB_DataObject {
    */
   public static function getEntityTitle() {
     $className = static::class;
-    Civi::log()->warning("$className needs to be regenerated. Missing getEntityTitle method.", ['civi.tag' => 'deprecated']);
+    CRM_Core_Error::deprecatedWarning("$className needs to be regenerated. Missing getEntityTitle method.");
     return CRM_Core_DAO_AllCoreTables::getBriefName($className);
   }
 

--- a/Civi/Angular/Manager.php
+++ b/Civi/Angular/Manager.php
@@ -180,6 +180,7 @@ class Manager {
    * @return array
    *   List of Angular modules, include all dependencies.
    *   Ex: array('crmMailing', 'crmUi', 'crmUtil', 'ngRoute').
+   * @throws \CRM_Core_Exception
    */
   public function resolveDependencies($names) {
     $allModules = $this->getModules();
@@ -189,10 +190,7 @@ class Manager {
       foreach ($missingModules as $module) {
         $visited[$module] = 1;
         if (!isset($allModules[$module])) {
-          \Civi::log()->warning('Unrecognized Angular module {name}. Please ensure that all Angular modules are declared.', [
-            'name' => $module,
-            'civi.tag' => 'deprecated',
-          ]);
+          throw new \CRM_Core_Exception("Unrecognized Angular module {$module}. Please ensure that all Angular modules are declared.");
         }
         elseif (isset($allModules[$module]['requires'])) {
           $result = array_unique(array_merge($result, $allModules[$module]['requires']));


### PR DESCRIPTION
Overview
----------------------------------------
Follow-on to https://github.com/civicrm/civicrm-core/pull/19179. Converts remaining two civi.tag-deprecated to central function.

Technical Details
----------------------------------------
I left these out of the previous PR these mostly because I wasn't sure if these are deprecations or they should be actual exceptions. I'm still not sure.

The first one I can sort of see the argument if the system still functions without it.

The second one though I think there's a stronger reason to throw an exception instead, since it's 4 years old, and if there are still undeclared modules that seems like a real error now. Also, on a smaller note, for this one either way the concept of placeholders isn't supported so I've flattened the string.

So I dunno. I've left them as deprecations for now, but if people agree they should be exceptions instead it's an easy change.

Comments
----------------------------------------

