### PR TITLE
[REF] Unshared another function back onto Membership_Form

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -1096,10 +1096,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
       }
       CRM_Utils_System::redirect(CRM_Utils_System::url($urlString, $urlParams));
     }
-    // Only set contribution recur ID for contributions since offline membership recur payments are handled somewhere else.
-    if (!is_a($form, "CRM_Member_Form_Membership")) {
-      $form->_params['contributionRecurID'] = $recurring->id;
-    }
+    $form->_params['contributionRecurID'] = $recurring->id;
 
     return $recurring->id;
   }

--- a/tests/phpunit/CRM/Member/Form/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/Form/MembershipTest.php
@@ -177,7 +177,7 @@ class CRM_Member_Form_MembershipTest extends CiviUnitTestCase {
    * @throws \CiviCRM_API3_Exception
    * @throws \CRM_Core_Exception
    */
-  public function testFormRuleEmptyContact() {
+  public function testFormRuleEmptyContact(): void {
     $params = [
       'contact_select_id' => 0,
       'membership_type_id' => [1 => NULL],


### PR DESCRIPTION

Overview
----------------------------------------
[REF] Unshared another function back onto Membership_Form

As with the other functions there is more not in common than in common & subsequent cleanup can remove
much of the copied function

Before
----------------------------------------
Code shared from Confirm form, much unrelated

After
----------------------------------------
Code duplicated

Technical Details
----------------------------------------
As with other places - sharing code between functions is only good if much of the code is in common / not much preparation is needed
 
Comments
----------------------------------------
After this there is just this one https://github.com/civicrm/civicrm-core/pull/19262/files & one more really unnecessary one & the form will be 'on it's own', My take is that 90% of the previously shared code will be removed in cleanup