### PR TITLE
[REF] Fix tax_amount to be consistent & load from the templateContribution

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2442,7 +2442,7 @@ LEFT JOIN  civicrm_contribution contribution ON ( componentPayment.contribution_
       else {
         $contributionParams['financial_type_id'] = $templateContribution['financial_type_id'];
       }
-      foreach (['contact_id', 'currency', 'source', 'amount_level', 'address_id', 'on_behalf', 'source_contact_id'] as $fieldName) {
+      foreach (['contact_id', 'currency', 'source', 'amount_level', 'address_id', 'on_behalf', 'source_contact_id', 'tax_amount'] as $fieldName) {
         if (isset($templateContribution[$fieldName])) {
           $contributionParams[$fieldName] = $templateContribution[$fieldName];
         }
@@ -2464,9 +2464,6 @@ LEFT JOIN  civicrm_contribution contribution ON ( componentPayment.contribution_
       // but per CRM-19478 it seems it can be 'null'
       if (isset($contribution->contribution_page_id) && is_numeric($contribution->contribution_page_id)) {
         $contributionParams['contribution_page_id'] = $contribution->contribution_page_id;
-      }
-      if (!empty($contribution->tax_amount)) {
-        $contributionParams['tax_amount'] = $contribution->tax_amount;
       }
 
       $createContribution = civicrm_api3('Contribution', 'create', $contributionParams);

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -4721,8 +4721,10 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
   /**
    * Test Repeat Transaction Contribution with Tax amount.
    * https://lab.civicrm.org/dev/core/issues/806
+   *
+   * @throws \CRM_Core_Exception
    */
-  public function testRepeatContributionWithTaxAmount() {
+  public function testRepeatContributionWithTaxAmount(): void {
     $this->enableTaxAndInvoicing();
     $financialType = $this->callAPISuccess('financial_type', 'create', [
       'name' => 'Test taxable financial Type',
@@ -4740,7 +4742,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
     $this->callAPISuccess('contribution', 'repeattransaction', [
       'original_contribution_id' => $contribution['id'],
       'contribution_status_id' => 'Completed',
-      'trxn_id' => uniqid(),
+      'trxn_id' => 'test',
     ]);
     $payments = $this->callAPISuccess('Contribution', 'get', ['sequential' => 1])['values'];
     //Assert if first payment and repeated payment has the same contribution amount.


### PR DESCRIPTION


Overview
----------------------------------------
[REF] Fix tax_amount to be consistent & load from the templateContribution 

This leverages the work done in https://github.com/civicrm/civicrm-core/pull/15517/files (the test in particular)
but alters it to be more consistent. The original fix relied on the tax_amount on the contribution object
passed in - this fixes it to get the amount from the templateContribution (which is more consistent
now than when the patch was likely written

Before
----------------------------------------
tax_amount taken from the contribution object that is passed in which is likely to be the same as the template contribution but might not be  - if there were a difference template contribution would be correct

After
----------------------------------------
template contribution value used

Technical Details
----------------------------------------

Comments
----------------------------------------
