### PR TITLE
(dev/core#2273) Contact type incorrectly set to Contribution due to '…

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -2066,7 +2066,7 @@ ORDER BY civicrm_email.is_primary DESC";
     else {
       //we should get contact type only if contact
       if ($ufGroupId) {
-        $data['contact_type'] = CRM_Core_BAO_UFField::getProfileType($ufGroupId);
+        $data['contact_type'] = CRM_Core_BAO_UFField::getProfileType($ufGroupId,TRUE, FALSE, TRUE);
 
         //special case to handle profile with only contact fields
         if ($data['contact_type'] == 'Contact') {

--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -2066,7 +2066,7 @@ ORDER BY civicrm_email.is_primary DESC";
     else {
       //we should get contact type only if contact
       if ($ufGroupId) {
-        $data['contact_type'] = CRM_Core_BAO_UFField::getProfileType($ufGroupId,TRUE, FALSE, TRUE);
+        $data['contact_type'] = CRM_Core_BAO_UFField::getProfileType($ufGroupId, TRUE, FALSE, TRUE);
 
         //special case to handle profile with only contact fields
         if ($data['contact_type'] == 'Contact') {


### PR DESCRIPTION
…Honoree Profile'

Overview
----------------------------------------
Steps to replicate:

- Create a contribution page with _Honoree Section Enabled_.

- Choose a profile that includes a contribution field.

- Make a contribution with this page with soft credit contact.

![Screenshot from 2020-12-23 19:01:36](https://user-images.githubusercontent.com/3455173/103085092-a7915600-4606-11eb-95f7-5293991a57a6.png)

- Check contact type of the newly created soft credit contact in DB. It will be _Contribution_  which is why it will not show up in some places and throws errors on various screens.

![Screenshot from 2020-12-23 19:01:14](https://user-images.githubusercontent.com/3455173/103085067-99dbd080-4606-11eb-9f18-7f4304371d3a.png)

![Screenshot from 2020-12-23 19:01:05](https://user-images.githubusercontent.com/3455173/103085048-921c2c00-4606-11eb-8a98-35dbb73dd60c.png)

I was able to replicate the scenario on dmaster. We should restrict the profile type to Contact types when calculating for honoree profile.

Before
----------------------------------------
![before](https://user-images.githubusercontent.com/3455173/103085015-7a44a800-4606-11eb-9d44-fb675d123f81.png)


After
----------------------------------------
![after](https://user-images.githubusercontent.com/3455173/103085017-7fa1f280-4606-11eb-935e-602777e92e34.png)

