### PR TITLE
[REF] Remove unreachable code

### DIFF
--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -1980,19 +1980,6 @@ DESC limit 1");
     $recurParams['currency'] = $params['currency'] ?? NULL;
     $recurParams['payment_instrument_id'] = $params['payment_instrument_id'];
 
-    // CRM-14354: For an auto-renewing membership with an additional contribution,
-    // if separate payments is not enabled, make sure only the membership fee recurs
-    if (!empty($form->_membershipBlock)
-      && $form->_membershipBlock['is_separate_payment'] === '0'
-      && isset($params['selectMembership'])
-      && $form->_values['is_allow_other_amount'] == '1'
-      // CRM-16331
-      && !empty($form->_membershipTypeValues)
-      && !empty($form->_membershipTypeValues[$params['selectMembership']]['minimum_fee'])
-    ) {
-      $recurParams['amount'] = $form->_membershipTypeValues[$params['selectMembership']]['minimum_fee'];
-    }
-
     $recurParams['is_test'] = 0;
     if (($form->_action & CRM_Core_Action::PREVIEW) ||
       (isset($form->_mode) && ($form->_mode == 'test'))


### PR DESCRIPTION

Overview
----------------------------------------
[REF] Remove unreachable code

Before
----------------------------------------
This code was copied from the previously shared function & supports some really weird stuff for the contribution form.

I tested & was unable to reach this from the back office membership form - note it is only reachable
when processing recurring which in turn relies on the membership type being configured and the
processor. It seems that recurring is not available with price sets

After
----------------------------------------
poof

Technical Details
----------------------------------------
This whole function was copied from the function on the front end form & then the parts (almost all) that are irrelevant removed. With this gone it does 2 things
- creates the recurring
- creates the contribution
- 
The second of these actually also needs to go as there is handling later on to cope with the fact it has been done here rather than further in

Comments
----------------------------------------
