### PR TITLE
Move financial acl warning from FinancialType BAO to extension.

### DIFF
--- a/ext/financialacls/financialacls.php
+++ b/ext/financialacls/financialacls.php
@@ -168,6 +168,15 @@ function financialacls_civicrm_pre($op, $objectName, $id, &$params) {
       throw new API_Exception('You do not have permission to ' . $op . ' this line item');
     }
   }
+  if ($objectName === 'FinancialType' && !empty($params['id']) && !empty($params['name'])) {
+    $prevName = CRM_Core_DAO::getFieldValue('CRM_Financial_DAO_FinancialType', $params['id']);
+    if ($prevName !== $params['name']) {
+      CRM_Core_Session::setStatus(ts("Changing the name of a Financial Type will result in losing the current permissions associated with that Financial Type.
+            Before making this change you should likely note the existing permissions at Administer > Users and Permissions > Permissions (Access Control),
+            then clicking the Access Control link for your Content Management System, then noting down the permissions for 'CiviCRM: {financial type name} view', etc.
+            Then after making the change of name, reset the permissions to the way they were."), ts('Warning'), 'warning');
+    }
+  }
 }
 
 /**
@@ -288,7 +297,7 @@ function financialacls_civicrm_fieldOptions($entity, $field, &$options, $params)
  *
  * @return bool
  */
-function financialacls_is_acl_limiting_enabled() {
+function financialacls_is_acl_limiting_enabled(): bool {
   return (bool) Civi::settings()->get('acl_financial_type');
 }
 

--- a/ext/financialacls/tests/phpunit/Civi/Financialacls/FinancialTypeTest.php
+++ b/ext/financialacls/tests/phpunit/Civi/Financialacls/FinancialTypeTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Civi\Financialacls;
+
+use Civi;
+use CRM_Core_Session;
+
+// I fought the Autoloader and the autoloader won.
+require_once 'BaseTestClass.php';
+
+/**
+ * @group headless
+ */
+class FinancialTypeTest extends BaseTestClass {
+
+  /**
+   * Test that a message is put in session when changing the name of a
+   * financial type.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testChangeFinancialTypeName(): void {
+    Civi::settings()->set('acl_financial_type', TRUE);
+    $type = $this->callAPISuccess('FinancialType', 'create', [
+      'name' => 'my test',
+    ]);
+    $this->callAPISuccess('FinancialType', 'create', [
+      'name' => 'your test',
+      'id' => $type['id'],
+    ]);
+    $status = CRM_Core_Session::singleton()->getStatus(TRUE);
+    $this->assertEquals('Changing the name', substr($status[0]['text'], 0, 17));
+  }
+
+}

--- a/tests/phpunit/api/v3/FinancialTypeTest.php
+++ b/tests/phpunit/api/v3/FinancialTypeTest.php
@@ -17,8 +17,10 @@ class api_v3_FinancialTypeTest extends CiviUnitTestCase {
 
   /**
    * Test Create, Read, Update Financial type with custom field.
+   *
+   * @throws \CRM_Core_Exception
    */
-  public function testCreateUpdateFinancialTypeCustomField() {
+  public function testCreateUpdateFinancialTypeCustomField(): void {
     $this->callAPISuccess('OptionValue', 'create', [
       'label' => ts('Financial Type'),
       'name' => 'civicrm_financial_type',
@@ -81,7 +83,7 @@ class api_v3_FinancialTypeTest extends CiviUnitTestCase {
 
       // get financial type to check custom field value
       $expectedResult = array_filter(array_merge($params, $customFields), function($var) {
-        return (!is_null($var) && $var != '');
+        return (!is_null($var) && $var !== '');
       });
       $this->callAPISuccessGetSingle('FinancialType', [
         'id' => $financialType['id'],


### PR DESCRIPTION

Overview
----------------------------------------
Move financial acl warning from FinancialType BAO to extension.

Before
----------------------------------------
When renaming a financial type a warning is saved in the session to indicate that it may invalidate existing financial acls (if enabled). This is in the FinancialType BAO. It does not work via the api.

After
----------------------------------------
Code moved to the financial acls extension as a pre hook, works via the api too.

Technical Details
----------------------------------------
It turns out this is not currently triggered by the api as the api passes in the key FinancialType in
ids and it is looking for financialType. This is actually fixed in this PR
Setting in the session as currently sometimes works makes sense (at least enough to
move rather than remove).

Also I had to add pre & post hooks for this. As part of our rationalise-to-create push I put this in a new create function & commented the intent to deprecate & remove add. There are a few existing calls to add  but mostly in unit tests - one is fixed in https://github.com/civicrm/civicrm-core/pull/19282

Comments
----------------------------------------
