### PR TITLE
Use specific function when formatting money for a default

### DIFF
--- a/CRM/Contribute/Form/AdditionalPayment.php
+++ b/CRM/Contribute/Form/AdditionalPayment.php
@@ -154,7 +154,7 @@ class CRM_Contribute_Form_AdditionalPayment extends CRM_Contribute_Form_Abstract
     }
 
     if ($this->isARefund() && $this->amountDue < 0) {
-      $defaults['total_amount'] = CRM_Utils_Money::format(abs($this->amountDue), NULL, NULL, TRUE);
+      $defaults['total_amount'] = CRM_Utils_Money::formatLocaleNumericRoundedForDefaultCurrency(abs($this->amountDue));
     }
     elseif ($this->_owed && $this->amountDue > 0) {
       $defaults['total_amount'] = CRM_Utils_Money::formatLocaleNumericRoundedForDefaultCurrency($this->_owed);

--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -359,11 +359,11 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
     // Fix the display of the monetary value, CRM-4038.
     if (isset($defaults['total_amount'])) {
       $total_value = $defaults['total_amount'];
-      $defaults['total_amount'] = CRM_Utils_Money::format($total_value, NULL, '%a');
+      $defaults['total_amount'] = CRM_Utils_Money::formatLocaleNumericRoundedForDefaultCurrency($total_value);
       if (!empty($defaults['tax_amount'])) {
         $componentDetails = CRM_Contribute_BAO_Contribution::getComponentDetails($this->_id);
         if (empty($componentDetails['membership']) && empty($componentDetails['participant'])) {
-          $defaults['total_amount'] = CRM_Utils_Money::format($total_value - $defaults['tax_amount'], NULL, '%a');
+          $defaults['total_amount'] = CRM_Utils_Money::formatLocaleNumericRoundedForDefaultCurrency($total_value - $defaults['tax_amount']);
         }
       }
     }

--- a/CRM/Grant/Form/Grant.php
+++ b/CRM/Grant/Form/Grant.php
@@ -107,13 +107,13 @@ class CRM_Grant_Form_Grant extends CRM_Core_Form {
 
       // fix the display of the monetary value, CRM-4038
       if (isset($defaults['amount_total'])) {
-        $defaults['amount_total'] = CRM_Utils_Money::format($defaults['amount_total'], NULL, '%a');
+        $defaults['amount_total'] = CRM_Utils_Money::formatLocaleNumericRoundedForDefaultCurrency($defaults['amount_total']);
       }
       if (isset($defaults['amount_requested'])) {
-        $defaults['amount_requested'] = CRM_Utils_Money::format($defaults['amount_requested'], NULL, '%a');
+        $defaults['amount_requested'] = CRM_Utils_Money::formatLocaleNumericRoundedForDefaultCurrency($defaults['amount_requested']);
       }
       if (isset($defaults['amount_granted'])) {
-        $defaults['amount_granted'] = CRM_Utils_Money::format($defaults['amount_granted'], NULL, '%a');
+        $defaults['amount_granted'] = CRM_Utils_Money::formatLocaleNumericRoundedForDefaultCurrency($defaults['amount_granted']);
       }
     }
     else {

--- a/CRM/Member/Form.php
+++ b/CRM/Member/Form.php
@@ -161,7 +161,7 @@ class CRM_Member_Form extends CRM_Contribute_Form_AbstractEditPayment {
       $params = ['id' => $this->_id];
       CRM_Member_BAO_Membership::retrieve($params, $defaults);
       if (isset($defaults['minimum_fee'])) {
-        $defaults['minimum_fee'] = CRM_Utils_Money::format($defaults['minimum_fee'], NULL, '%a');
+        $defaults['minimum_fee'] = CRM_Utils_Money::formatLocaleNumericRoundedForDefaultCurrency($defaults['minimum_fee']);
       }
 
       if (isset($defaults['status'])) {


### PR DESCRIPTION

Overview
----------------------------------------
Use specific function when formatting money for a default

Before
----------------------------------------
A mix of params is used to bully the money::format function into formatting without the currency when formatting for a field default usage

After
----------------------------------------
Specific function is used

Technical Details
----------------------------------------
It seems that there are really only 2 ways money::format is called
1) for presenting money - with symbols - in this case only 2 params are passed in
2) for prefilling the form value - in which case some combination of the last 3 are passed in

We have an alternate function that works in the latter case - at which point we could deprecate all
3 in the former case (after a bit more grepping).

The function name is formatLocaleNumericRoundedForDefaultCurrency

I have to admit I'm tempted to remove 'locale' from that name - although
I guess it denotes the swapping of thousand separators

Comments
----------------------------------------
@seamuslee001 @mattwire maybe merge this for the next rc & then once it's cut rip out the remaining places where params other than amount & money are passed into money::format? At that point we should be good to go fully brick money