### PR TITLE
Stop using refresh_date in civicrm_group table

### DIFF
--- a/tests/phpunit/CRM/Contact/BAO/GroupContactCacheTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/GroupContactCacheTest.php
@@ -390,8 +390,7 @@ class CRM_Contact_BAO_GroupContactCacheTest extends CiviUnitTestCase {
     );
 
     $afterGroup = $this->callAPISuccessGetSingle('Group', ['id' => $group->id]);
-    $this->assertTrue(empty($afterGroup['cache_date']), 'refresh date should not be set as the cache is not built');
-    $this->assertTrue(empty($afterGroup['refresh_date']), 'refresh date should not be set as the cache is not built');
+    $this->assertTrue(empty($afterGroup['cache_date']), 'cache date should not be set as the cache is not built');
   }
 
   /**


### PR DESCRIPTION

Overview
----------------------------------------
Stop using refresh_date in civicrm_group table 

Before
----------------------------------------
We use a  mix of cache_date & refresh_date but refresh date doesn't seem to confer any extra value

After
----------------------------------------
We just use cache_date

Technical Details
----------------------------------------
I was looking to add indexes to civicrm_group.cache_date & civicrm_group.refresh_date - but I couldn't figure out why
the latter exists / is used. I went through the places it's used and it is simply a calculated version of
cache_date + smartGroupCacheTime and I can't see any value.

I can follow up on this with a removal if no-one else can see the point of it

Comments
----------------------------------------
