### PR TITLE
dev/core#2206 Move cancel pledge into Contribution.create and fix

### DIFF
--- a/ext/contributioncancelactions/contributioncancelactions.php
+++ b/ext/contributioncancelactions/contributioncancelactions.php
@@ -29,31 +29,7 @@ function contributioncancelactions_civicrm_post($op, $objectName, $objectId, $ob
     )) {
       contributioncancelactions_cancel_related_pending_memberships((int) $objectId);
       contributioncancelactions_cancel_related_pending_participant_records((int) $objectId);
-      contributioncancelactions_update_related_pledge((int) $objectId, (int) $objectRef->contribution_status_id);
     }
-  }
-}
-
-/**
- * Update any related pledge when a contribution is cancelled.
- *
- * This updates the status of the pledge and amount paid.
- *
- * The functionality should probably be give more thought in that it currently
- * does not un-assign the contribution id from the pledge payment. However,
- * at time of writing the goal is to move rather than fix functionality.
- *
- * @param int $contributionID
- * @param int $contributionStatusID
- *
- * @throws CiviCRM_API3_Exception
- */
-function contributioncancelactions_update_related_pledge(int $contributionID, int $contributionStatusID) {
-  $pledgePayments = civicrm_api3('PledgePayment', 'get', ['contribution_id' => $contributionID])['values'];
-  if (!empty($pledgePayments)) {
-    $pledgePaymentIDS = array_keys($pledgePayments);
-    $pledgePayment = reset($pledgePayments);
-    CRM_Pledge_BAO_PledgePayment::updatePledgePaymentStatus($pledgePayment['pledge_id'], $pledgePaymentIDS, $contributionStatusID);
   }
 }
 

--- a/ext/contributioncancelactions/tests/phpunit/CancelTest.php
+++ b/ext/contributioncancelactions/tests/phpunit/CancelTest.php
@@ -257,30 +257,6 @@ class CancelTest extends TestCase implements HeadlessInterface, HookInterface, T
   }
 
   /**
-   * Test cancel order api when a pledge is linked.
-   *
-   * The pledge status should be updated. I believe the contribution should also be unlinked but
-   * the goal at this point is no change.
-   *
-   * @throws CRM_Core_Exception
-   * @throws API_Exception
-   */
-  public function testCancelOrderWithPledge(): void {
-    $this->createContact();
-    $pledgeID = (int) $this->callAPISuccess('Pledge', 'create', ['contact_id' => $this->ids['contact'][0], 'amount' => 4, 'installments' => 2, 'frequency_unit' => 'month', 'original_installment_amount' => 2, 'create_date' => 'now', 'financial_type_id' => 'Donation', 'start_date' => '+5 days'])['id'];
-    $orderID = (int) $this->callAPISuccess('Order', 'create', ['contact_id' => $this->ids['contact'][0], 'total_amount' => 2, 'financial_type_id' => 'Donation', 'api.Payment.create' => ['total_amount' => 2]])['id'];
-    $pledgePayments = $this->callAPISuccess('PledgePayment', 'get')['values'];
-    $this->callAPISuccess('PledgePayment', 'create', ['id' => key($pledgePayments), 'pledge_id' => $pledgeID, 'contribution_id' => $orderID, 'status_id' => 'Completed', 'actual_amount' => 2]);
-    $beforePledge = $this->callAPISuccessGetSingle('Pledge', ['id' => $pledgeID]);
-    $this->assertEquals(2, $beforePledge['pledge_total_paid']);
-    $this->callAPISuccess('Order', 'cancel', ['contribution_id' => $orderID]);
-
-    $this->callAPISuccessGetSingle('Contribution', ['contribution_status_id' => 'Cancelled']);
-    $afterPledge = $this->callAPISuccessGetSingle('Pledge', ['id' => $pledgeID]);
-    $this->assertEquals('', $afterPledge['pledge_total_paid']);
-  }
-
-  /**
    * Test cancelling a contribution with a membership on the contribution edit
    * form.
    *


### PR DESCRIPTION

Overview
----------------------------------------
dev/core#2206 Move cancel pledge into Contribution.create and fix

Before
----------------------------------------
Cancelling (or failing) a contribution does not properly update the pledge payment, such that it can have a new contribution added to it.

After
----------------------------------------
When the contribution is cancelled the contribution id is removed from any pledge payments, they are updated to be pending again & actual_amount is unset

Technical Details
----------------------------------------
Per https://lab.civicrm.org/dev/core/-/issues/2206 I think updating pledge payments is a data issue
rather than a business process issue. Notably you can't record a new contribution against the pledge
unless the existing one is removed


Comments
----------------------------------------
This is the last thing that needs to be done before we can unhide contributioncancelactions
