### PR TITLE
dev/core#2269 Use contribution's currency instead of the default

### DIFF
--- a/CRM/Contribute/Form/Task/Invoice.php
+++ b/CRM/Contribute/Form/Task/Invoice.php
@@ -363,6 +363,7 @@ class CRM_Contribute_Form_Task_Invoice extends CRM_Contribute_Form_Task {
         'resourceBase' => $config->userFrameworkResourceURL,
         'defaultCurrency' => $config->defaultCurrency,
         'amount' => $contribution->total_amount,
+        'currency' => $contribution->currency,
         'amountDue' => $amountDue,
         'amountPaid' => $amountPaid,
         'invoice_date' => $invoiceDate,

--- a/tests/phpunit/CRM/Contribute/Form/Task/InvoiceTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/Task/InvoiceTest.php
@@ -161,4 +161,43 @@ class CRM_Contribute_Form_Task_InvoiceTest extends CiviUnitTestCase {
 
   }
 
+  /**
+   * Test invoices if payment is made with different currency.
+   *
+   * https://lab.civicrm.org/dev/core/issues/2269
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testThatInvoiceShowTheActuallContributionCurrencyInsteadOfTheDefaultOne() {
+    $this->setDefaultCurrency('USD');
+
+    $this->_individualId = $this->individualCreate();
+
+    $contributionParams = [
+      'contact_id' => $this->_individualId,
+      'total_amount' => 100,
+      'currency' => 'GBP',
+      'financial_type_id' => 'Donation',
+      'contribution_status_id' => 1,
+    ];
+
+    $contribution = $this->callAPISuccess('Contribution', 'create', $contributionParams);
+
+    $params = [
+      'output' => 'pdf_invoice',
+      'forPage' => 1,
+    ];
+
+    $invoiceHTML = CRM_Contribute_Form_Task_Invoice::printPDF([$contribution['id']], $params, [$this->_individualId]);
+
+    $this->assertNotContains('$', $invoiceHTML);
+    $this->assertNotContains('Amount USD', $invoiceHTML);
+    $this->assertNotContains('TOTAL USD', $invoiceHTML);
+    $this->assertContains('£ 0.00', $invoiceHTML);
+    $this->assertContains('£ 100.00', $invoiceHTML);
+    $this->assertContains('Amount GBP', $invoiceHTML);
+    $this->assertContains('TOTAL GBP', $invoiceHTML);
+
+  }
+
 }

--- a/xml/templates/message_templates/contribution_invoice_receipt_html.tpl
+++ b/xml/templates/message_templates/contribution_invoice_receipt_html.tpl
@@ -76,7 +76,7 @@
                 <th style="text-align:right;font-weight:bold;white-space: nowrap"><font size="1">{ts}Quantity{/ts}</font></th>
                 <th style="text-align:right;font-weight:bold;white-space: nowrap"><font size="1">{ts}Unit Price{/ts}</font></th>
                 <th style="text-align:right;font-weight:bold;white-space: nowrap"><font size="1">{$taxTerm}</font></th>
-                <th style="text-align:right;font-weight:bold;white-space: nowrap"><font size="1">{ts 1=$defaultCurrency}Amount %1{/ts}</font></th>
+                <th style="text-align:right;font-weight:bold;white-space: nowrap"><font size="1">{ts 1=$currency}Amount %1{/ts}</font></th>
               </tr>
               {foreach from=$lineItem item=value key=priceset name=taxpricevalue}
                 {if $smarty.foreach.taxpricevalue.index eq 0}
@@ -123,7 +123,7 @@
               {/foreach}
               <tr>
                 <td colspan="3"></td>
-                <td style="text-align:right;white-space: nowrap"><b><font size="1">{ts 1=$defaultCurrency}TOTAL %1{/ts}</font></b></td>
+                <td style="text-align:right;white-space: nowrap"><b><font size="1">{ts 1=$currency}TOTAL %1{/ts}</font></b></td>
                 <td style="text-align:right;"><font size="1">{$amount|crmMoney:$currency}</font></td>
               </tr>
               <tr>
@@ -302,7 +302,7 @@
                 <th style="padding-left:28px;text-align:right;font-weight:bold;"><font size="1">{ts}Quantity{/ts}</font></th>
                 <th style="padding-left:28px;text-align:right;font-weight:bold;"><font size="1">{ts}Unit Price{/ts}</font></th>
                 <th style="padding-left:28px;text-align:right;font-weight:bold;"><font size="1">{$taxTerm}</font></th>
-                <th style="padding-left:28px;text-align:right;font-weight:bold;"><font size="1">{ts 1=$defaultCurrency}Amount %1{/ts}</font></th>
+                <th style="padding-left:28px;text-align:right;font-weight:bold;"><font size="1">{ts 1=$currency}Amount %1{/ts}</font></th>
               </tr>
               {foreach from=$lineItem item=value key=priceset name=pricevalue}
                 {if $smarty.foreach.pricevalue.index eq 0}
@@ -357,7 +357,7 @@
               </tr>
               <tr>
                 <td colspan="3"></td>
-                <td style="padding-left:28px;text-align:right;"><b><font size="1">{ts 1=$defaultCurrency}TOTAL %1{/ts}</font></b></td>
+                <td style="padding-left:28px;text-align:right;"><b><font size="1">{ts 1=$currency}TOTAL %1{/ts}</font></b></td>
                 <td style="padding-left:28px;text-align:right;"><font size="1">{$amount|crmMoney:$currency}</font></td>
               </tr>
               {if $is_pay_later == 0}


### PR DESCRIPTION
Overview
----------------------------------------
Default currency shown on invoices if payment is made with different currency.

Before
----------------------------------------
For a contribution paid in GBP (USD is the default currency)
Invoice shows default currency rather than contribution's currency.
![Screenshot from 2020-12-22 12-35-12](https://user-images.githubusercontent.com/74309109/103344832-67175980-4a98-11eb-94de-3e9db64cc7c3.png)


After
----------------------------------------
For a contribution paid in GBP (USD is the default currency)
Invoice shows contribution's currency.
![103090962-52037c00-45fb-11eb-88f9-74f58c707371](https://user-images.githubusercontent.com/74309109/103344792-51a22f80-4a98-11eb-932d-449606147423.png)


Technical Details
----------------------------------------
In contribution_invoice_receipt_html.tpl the currency variable is null and smarty modifier `crmMoney` will always use default currency instead.
The second change is replacing any usage of `defaultCurrency` with `currency` in contribution_invoice_receipt_html.tpl.

**Please note** that we need to manually change the invoice template in live CiviCRM sites  "Go to Mailings > Message Templates > System Workflow Messages > Contributions - Invoice" with replacing any usage of `defaultCurrency` with `currency` so that "Total USD" become "Total GBP"

Comments
----------------------------------------
Issue: https://lab.civicrm.org/dev/core/-/issues/2269