### PR TITLE
dev/core#527 use public title for on behalf profile and confirm/thankyou pages

### DIFF
--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -843,9 +843,11 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
    * @param int $id
    * @param CRM_Core_Form $form
    *
+   * @throws \API_Exception
    * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
    */
-  public function buildComponentForm($id, $form) {
+  public function buildComponentForm($id, $form): void {
     if (empty($id)) {
       return;
     }
@@ -969,7 +971,7 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
           }
         }
 
-        $form->assign('fieldSetTitle', CRM_Core_BAO_UFGroup::getTitle($form->_values['onbehalf_profile_id']));
+        $form->assign('fieldSetTitle', CRM_Core_BAO_UFGroup::getFrontEndTitle($form->_values['onbehalf_profile_id']));
 
         if (!empty($form->_values['is_for_organization'])) {
           if ($form->_values['is_for_organization'] == 2) {
@@ -1007,7 +1009,7 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
 
         foreach ($profileFields as $name => $field) {
           if (in_array($field['field_type'], $fieldTypes)) {
-            list($prefixName, $index) = CRM_Utils_System::explode('-', $name, 2);
+            [$prefixName, $index] = CRM_Utils_System::explode('-', $name, 2);
             if (in_array($prefixName, ['organization_name', 'email']) && empty($field['is_required'])) {
               $field['is_required'] = 1;
             }

--- a/templates/CRM/UF/Form/Fields.tpl
+++ b/templates/CRM/UF/Form/Fields.tpl
@@ -25,7 +25,7 @@
     {/if}
 
     {if ($form.formName eq 'Confirm' OR $form.formName eq 'ThankYou') AND $prefix neq 'honor'}
-      <div class="header-dark">{$field.groupTitle} </div>
+      <div class="header-dark">{$field.groupDisplayTitle} </div>
     {/if}
     {assign var=fieldset  value=`$field.groupTitle`}
     {assign var=groupHelpPost  value=`$field.groupHelpPost`}


### PR DESCRIPTION

Overview
----------------------------------------

This is a partial reviewer's commit of https://github.com/civicrm/civicrm-core/pull/19144

That PR is stale. I tested one flow & added in the 2 changes from there that I could see in my test
& which I was comfortable would not affect anything else. The flow I tested was a contribution
page flow with an on behalf profile. I did not check the email as that would need
a test anyway

Before
----------------------------------------
- use a user defined profile for on behalf of on a contribution page
- give it a front end title
- front end title does not show on main, confirm or thank you pages
- 
After
----------------------------------------
Title does show on those pages

Technical Details
----------------------------------------

Comments
----------------------------------------
