### PR TITLE
(REF) Civi\Test\Invasive - Add helper for checking protected/private members

### DIFF
--- a/Civi/Test/Invasive.php
+++ b/Civi/Test/Invasive.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Civi\Test;
+
+/**
+ * The "Invasive"  helper makes it a bit easier to write unit-tests which
+ * touch upon private or protected members.
+ *
+ * @package Civi\Test
+ */
+class Invasive {
+
+  /**
+   * Call a private/protected method.
+   *
+   * This is only intended for unit-testing.
+   *
+   * @param array $callable
+   *   Ex: [$myObject, 'myPrivateMethod']
+   *   Ex: ['MyClass', 'myPrivateStaticMethod']
+   * @param array $args
+   *   Ordered list of arguments.
+   * @return mixed
+   */
+  public static function call($callable, $args = []) {
+    list ($class, $object, $member) = self::parseRef($callable);
+    $reflection = new \ReflectionMethod($class, $member);
+    $reflection->setAccessible(TRUE);
+    return $reflection->invokeArgs($object, $args);
+  }
+
+  /**
+   * Get the content of a private/protected method.
+   *
+   * This is only intended for unit-testing.
+   *
+   * @param array $ref
+   *   A reference to class+property.
+   *   Ex: [$myObject, 'myPrivateField']
+   *   Ex: ['MyClass', 'myPrivateStaticField']
+   * @return mixed
+   */
+  public static function get($ref) {
+    list ($class, $object, $member) = self::parseRef($ref);
+    $reflection = new \ReflectionProperty($class, $member);
+    $reflection->setAccessible(TRUE);
+    return $reflection->getValue($object);
+  }
+
+  /**
+   * Get the content of a private/protected method.
+   *
+   * This is only intended for unit-testing.
+   *
+   * @param array $ref
+   *   A reference to class+property.
+   *   Ex: [$myObject, 'myPrivateField']
+   *   Ex: ['MyClass', 'myPrivateStaticField']
+   * @param mixed $value
+   * @return mixed
+   */
+  public static function set($ref, $value) {
+    list ($class, $object, $member) = self::parseRef($ref);
+    $reflection = new \ReflectionProperty($class, $member);
+    $reflection->setAccessible(TRUE);
+    $reflection->setValue($object, $value);
+  }
+
+  /**
+   * @param array $callable
+   *   Ex: [$myObject, 'myPrivateMember']
+   *   Ex: ['MyClass', 'myPrivateStaticMember']
+   * @return array
+   *   Ordered array of [string $class, object? $object, string $memberName].
+   */
+  private static function parseRef($callable) {
+    if (is_string($callable)) {
+      list ($class, $member) = explode('::', $callable);
+      return [$class, NULL, $member];
+    }
+    elseif (is_string($callable[0])) {
+      return [$callable[0], NULL, $callable[1]];
+    }
+    elseif (is_object($callable[0])) {
+      return [get_class($callable[0]), $callable[0], $callable[1]];
+    }
+    else {
+      throw new \RuntimeException("Cannot parse reference to private member");
+    }
+  }
+
+}

--- a/tests/phpunit/CRM/Activity/Form/ActivityTest.php
+++ b/tests/phpunit/CRM/Activity/Form/ActivityTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use Civi\Test\Invasive;
+
 /**
  *  Include dataProvider for tests
  * @group headless
@@ -39,10 +41,7 @@ class CRM_Activity_Form_ActivityTest extends CiviUnitTestCase {
       'activity_type_id' => $activityTypeId,
     ];
 
-    $activityRef = new ReflectionClass('CRM_Activity_Form_Activity');
-    $method = $activityRef->getMethod('processActivity');
-    $method->setAccessible(TRUE);
-    $method->invokeArgs($form, [&$params]);
+    Invasive::call([$form, 'processActivity'], [&$params]);
 
     $msg = $mut->getMostRecentEmail();
     $this->assertNotEmpty($msg);
@@ -51,7 +50,8 @@ class CRM_Activity_Form_ActivityTest extends CiviUnitTestCase {
     //Block Meeting notification.
     Civi::settings()->set('do_not_notify_assignees_for', [$activityTypeId]);
     $params['assignee_contact_id'] = [$this->assignee2];
-    $method->invokeArgs($form, [&$params]);
+    Invasive::call([$form, 'processActivity'], [&$params]);
+
     $msg = $mut->getMostRecentEmail();
     $this->assertEmpty($msg);
   }

--- a/tests/phpunit/CRM/Core/PaymentTest.php
+++ b/tests/phpunit/CRM/Core/PaymentTest.php
@@ -9,6 +9,8 @@
  +--------------------------------------------------------------------+
  */
 
+use Civi\Test\Invasive;
+
 /**
  * Class CRM_Core_PaymentTest
  * @group headless
@@ -64,14 +66,8 @@ class CRM_Core_PaymentTest extends CiviUnitTestCase {
     $processor->setCancelUrl($cancel);
     $processor->setSuccessUrl($success);
 
-    // Using ReflectionUtils to access protected methods
-    $successGetter = new ReflectionMethod($processor, 'getReturnSuccessUrl');
-    $successGetter->setAccessible(TRUE);
-    $this->assertEquals($success, $successGetter->invoke($processor, NULL));
-
-    $cancelGetter = new ReflectionMethod($processor, 'getReturnFailUrl');
-    $cancelGetter->setAccessible(TRUE);
-    $this->assertEquals($cancel, $cancelGetter->invoke($processor, NULL));
+    $this->assertEquals($success, Invasive::call([$processor, 'getReturnSuccessUrl'], [NULL]));
+    $this->assertEquals($cancel, Invasive::call([$processor, 'getReturnFailUrl'], [NULL]));
   }
 
 }

--- a/tests/phpunit/CRM/Mailing/BAO/MailingJobTest.php
+++ b/tests/phpunit/CRM/Mailing/BAO/MailingJobTest.php
@@ -9,21 +9,13 @@
  +--------------------------------------------------------------------+
  */
 
+use Civi\Test\Invasive;
+
 /**
  * Class CRM_Mailing_BAO_MailingTest
  * @group headless
  */
 class CRM_Mailing_BAO_MailingJobTest extends CiviUnitTestCase {
-
-  /**
-   * Calls a protected method.
-   */
-  public static function callMethod($obj, $name, $args) {
-    $class = new ReflectionClass($obj);
-    $method = $class->getMethod($name);
-    $method->setAccessible(TRUE);
-    return $method->invokeArgs($obj, $args);
-  }
 
   /**
    * Tests CRM_Mailing_BAO_MailingJob::isTemporaryError() method.
@@ -38,7 +30,7 @@ class CRM_Mailing_BAO_MailingJobTest extends CiviUnitTestCase {
     $testcases[] = ['return' => FALSE, 'message' => 'authentication failure [SMTP: Invalid response code received from SMTP server while sending email.  This is often caused by a misconfiguration in Outbound Email settings. Please verify the settings at Administer CiviCRM >> Global Settings >> Outbound Email (SMTP). (code: 454, response: Temporary authentication failure)]'];
     $object = new CRM_Mailing_BAO_MailingJob();
     foreach ($testcases as $testcase) {
-      $isTemporaryError = self::callMethod($object, 'isTemporaryError', [$testcase['message']]);
+      $isTemporaryError = Invasive::call([$object, 'isTemporaryError'], [$testcase['message']]);
       if ($testcase['return']) {
         $this->assertTrue($isTemporaryError);
       }

--- a/tests/phpunit/CRM/Report/Form/TestCaseTest.php
+++ b/tests/phpunit/CRM/Report/Form/TestCaseTest.php
@@ -11,6 +11,8 @@
 
 require_once 'CiviTest/CiviReportTestCase.php';
 
+use Civi\Test\Invasive;
+
 /**
  * Verify that the CiviReportTestCase provides a working set of
  * primitives for tests. Do this by running various scenarios
@@ -174,25 +176,19 @@ class CRM_Report_Form_TestCaseTest extends CiviReportTestCase {
    * Test processReportMode() Function in Reports
    */
   public function testOutputMode() {
-    $clazz = new ReflectionClass('CRM_Report_Form');
     $reportForm = new CRM_Report_Form();
 
-    $params = $clazz->getProperty('_params');
-    $params->setAccessible(TRUE);
-    $outputMode = $clazz->getProperty('_outputMode');
-    $outputMode->setAccessible(TRUE);
-
-    $params->setValue($reportForm, ['groups' => 4]);
+    Invasive::set([$reportForm, '_params'], ['groups' => 4]);
     $reportForm->processReportMode();
-    $this->assertEquals('group', $outputMode->getValue($reportForm));
+    $this->assertEquals('group', Invasive::get([$reportForm, '_outputMode']));
 
-    $params->setValue($reportForm, ['task' => 'copy']);
+    Invasive::set([$reportForm, '_params'], ['task' => 'copy']);
     $reportForm->processReportMode();
-    $this->assertEquals('copy', $outputMode->getValue($reportForm));
+    $this->assertEquals('copy', Invasive::get([$reportForm, '_outputMode']));
 
-    $params->setValue($reportForm, ['task' => 'print']);
+    Invasive::set([$reportForm, '_params'], ['task' => 'print']);
     $reportForm->processReportMode();
-    $this->assertEquals('print', $outputMode->getValue($reportForm));
+    $this->assertEquals('print', Invasive::get([$reportForm, '_outputMode']));
   }
 
 }

--- a/tests/phpunit/CRM/Utils/versionCheckTest.php
+++ b/tests/phpunit/CRM/Utils/versionCheckTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use Civi\Test\Invasive;
+
 /**
  * Class CRM_Utils_versionCheckTest
  * @group headless
@@ -163,16 +165,9 @@ class CRM_Utils_versionCheckTest extends CiviUnitTestCase {
     $address_result = civicrm_api3('address', 'create', $address_params);
 
     // Build stats and test them.
-    $vc = new ReflectionClass('CRM_Utils_VersionCheck');
-    $vc_instance = $vc->newInstance();
-
-    $statsBuilder = $vc->getMethod('getSiteStats');
-    $statsBuilder->setAccessible(TRUE);
-    $statsBuilder->invoke($vc_instance, NULL);
-
-    $statsProperty = $vc->getProperty('stats');
-    $statsProperty->setAccessible(TRUE);
-    $stats = $statsProperty->getValue($vc_instance);
+    $vc = new CRM_Utils_VersionCheck();
+    Invasive::call([$vc, 'getSiteStats']);
+    $stats = Invasive::get([$vc, 'stats']);
 
     // Stats array should have correct elements.
     $this->assertArrayHasKey('version', $stats);

--- a/tests/phpunit/Civi/Test/InvasiveExample.php
+++ b/tests/phpunit/Civi/Test/InvasiveExample.php
@@ -1,0 +1,60 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Test;
+
+/**
+ * Class InvasiveExample
+ *
+ * This is a dummy/placeholder for use with InvasiveTest.
+ *
+ * @package Civi\Test
+ */
+class InvasiveExample {
+
+  private $privateField = 10;
+
+  private static $protectedStaticField = 20;
+
+  /**
+   * @return int
+   */
+  private function getPrivateField(): int {
+    return $this->privateField;
+  }
+
+  /**
+   * @param int $privateField
+   */
+  private function setPrivateField(int $privateField) {
+    $this->privateField = $privateField;
+  }
+
+  private function twiddlePrivateField(&$output) {
+    $output = $this->privateField * 100;
+    return $this->privateField * 10000;
+  }
+
+  /**
+   * @return int
+   */
+  protected static function getProtectedStaticField(): int {
+    return self::$protectedStaticField;
+  }
+
+  /**
+   * @param int $protectedStaticField
+   */
+  protected static function setProtectedStaticField(int $protectedStaticField) {
+    self::$protectedStaticField = $protectedStaticField;
+  }
+
+}

--- a/tests/phpunit/Civi/Test/InvasiveTest.php
+++ b/tests/phpunit/Civi/Test/InvasiveTest.php
@@ -1,0 +1,36 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Test;
+
+class InvasiveTest extends \CiviUnitTestCase {
+
+  public function testPrivate() {
+    $tgt = new InvasiveExample();
+    $this->assertEquals(10, Invasive::get([$tgt, 'privateField']));
+    $this->assertEquals(10, Invasive::call([$tgt, 'getPrivateField']));
+    Invasive::call([$tgt, 'setPrivateField'], [11]);
+    $this->assertEquals(11, Invasive::call([$tgt, 'getPrivateField']));
+
+    $theRef = NULL;
+    $this->assertEquals(110000, Invasive::call([$tgt, 'twiddlePrivateField'], [&$theRef]));
+    $this->assertEquals(1100, $theRef);
+  }
+
+  public function testProtectedStatic() {
+    $tgt = InvasiveExample::class;
+    $this->assertEquals(20, Invasive::get([$tgt, 'protectedStaticField']));
+    $this->assertEquals(20, Invasive::call([$tgt, 'getProtectedStaticField']));
+    Invasive::call([$tgt, 'setProtectedStaticField'], [21]);
+    $this->assertEquals(21, Invasive::call([$tgt, 'getProtectedStaticField']));
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------

Suppose you're writing a unit-test for a class with some `private` or `protected` members. You want to include some assertions about those members. What do you do?

This patch adds a helper to momentarily bypass the restrictions within the test. It doesn't require compromising the class-contract and it is pithy/easy to read.

Before
----------------------------------------

Your options are to:

* Promote the member to be fully `public` (and implicitly endorse external usage)
* Promote the member to be fully `public` (and add docblocks to tell people to not use it)
* Write a long incantation using `ReflectionProperty` and/or `ReflectionMethod`.

After
----------------------------------------

You may keep the preferred visibility (`private` or `protected`). Use `Invasive::call($callable, $args)` or `Invasve::get()` to access the method/property.

Several examples of the `ReflectionProperty` and `ReflectionMethod`  incantations have been switched over to shorter calls.
