### PR TITLE
Rename PledgePayment create function

### DIFF
--- a/CRM/Pledge/BAO/Pledge.php
+++ b/CRM/Pledge/BAO/Pledge.php
@@ -197,7 +197,7 @@ class CRM_Pledge_BAO_Pledge extends CRM_Pledge_DAO_Pledge {
       foreach ($paymentKeys as $key) {
         $paymentParams[$key] = $params[$key] ?? NULL;
       }
-      CRM_Pledge_BAO_PledgePayment::create($paymentParams);
+      CRM_Pledge_BAO_PledgePayment::createMultiple($paymentParams);
     }
 
     $transaction->commit();

--- a/CRM/Pledge/BAO/PledgePayment.php
+++ b/CRM/Pledge/BAO/PledgePayment.php
@@ -76,11 +76,13 @@ WHERE     pledge_id = %1
   }
 
   /**
+   * Create pledge payments.
+   *
    * @param array $params
    *
-   * @return pledge
+   * @return CRM_Pledge_DAO_PledgePayment
    */
-  public static function create($params) {
+  public static function createMultiple(array $params) {
     $transaction = new CRM_Core_Transaction();
     $overdueStatusID = CRM_Core_PseudoConstant::getKey('CRM_Pledge_BAO_PledgePayment', 'status_id', 'Overdue');
     $pendingStatusId = CRM_Core_PseudoConstant::getKey('CRM_Pledge_BAO_PledgePayment', 'status_id', 'Pending');
@@ -145,20 +147,34 @@ WHERE     pledge_id = %1
   }
 
   /**
-   * Add pledge payment.
+   * Create individual pledge payment.
    *
    * @param array $params
-   *   Associate array of field.
    *
    * @return CRM_Pledge_DAO_PledgePayment
-   *   pledge payment id
+   * @throws \CRM_Core_Exception
    */
-  public static function add($params) {
+  public static function create(array $params): CRM_Pledge_DAO_PledgePayment {
     // set currency for CRM-1496
     if (empty($params['id']) && !isset($params['currency'])) {
       $params['currency'] = CRM_Core_Config::singleton()->defaultCurrency;
     }
     return self::writeRecord($params);
+  }
+
+  /**
+   * Add pledge payment.
+   *
+   * @deprecated - use the api which will use create (soon).
+   *
+   * @param array $params
+   *   Fields in line with the database entity.
+   *
+   * @return CRM_Pledge_DAO_PledgePayment
+   * @throws \CRM_Core_Exception
+   */
+  public static function add(array $params): CRM_Pledge_DAO_PledgePayment {
+    return self::create($params);
   }
 
   /**


### PR DESCRIPTION
Plege payment has a non-standard create function. It is only called from one place in universe. This updates that
1 place to use a new name and puts in the create function in a more correct way.

Overview
----------------------------------------
Standardisation of create function for pledge payment

Before
----------------------------------------
- add does what create should do
- create does something custom

After
----------------------------------------
-create renamed to createMultiple
- add renamed to create
- new add function calls create as a migration path. This is deprecated but not noisily so as there are still multiple places calling it that way, including v3 api. 

Technical Details
----------------------------------------

Comments
----------------------------------------