### PR TITLE
[REF] Fix import signature on activity parser, add preliminary test

### DIFF
--- a/CRM/Activity/Import/Form/MapField.php
+++ b/CRM/Activity/Import/Form/MapField.php
@@ -357,26 +357,10 @@ class CRM_Activity_Import_Form_MapField extends CRM_Import_Form_MapField {
     $mapper = [];
     $mapperKeys = $this->controller->exportValue($this->_name, 'mapper');
     $mapperKeysMain = [];
-    $mapperLocType = [];
-    $mapperPhoneType = [];
 
     for ($i = 0; $i < $this->_columnCount; $i++) {
       $mapper[$i] = $this->_mapperFields[$mapperKeys[$i][0]];
       $mapperKeysMain[$i] = $mapperKeys[$i][0];
-
-      if ((CRM_Utils_Array::value(1, $mapperKeys[$i])) && (is_numeric($mapperKeys[$i][1]))) {
-        $mapperLocType[$i] = $mapperKeys[$i][1];
-      }
-      else {
-        $mapperLocType[$i] = NULL;
-      }
-
-      if ((CRM_Utils_Array::value(2, $mapperKeys[$i])) && (!is_numeric($mapperKeys[$i][2]))) {
-        $mapperPhoneType[$i] = $mapperKeys[$i][2];
-      }
-      else {
-        $mapperPhoneType[$i] = NULL;
-      }
     }
 
     $this->set('mapper', $mapper);
@@ -430,7 +414,7 @@ class CRM_Activity_Import_Form_MapField extends CRM_Import_Form_MapField {
       $this->set('savedMapping', $saveMappingFields->mapping_id);
     }
 
-    $parser = new CRM_Activity_Import_Parser_Activity($mapperKeysMain, $mapperLocType, $mapperPhoneType);
+    $parser = new CRM_Activity_Import_Parser_Activity($mapperKeysMain);
     $parser->run($fileName, $separator, $mapper, $skipColumnHeader,
       CRM_Import_Parser::MODE_PREVIEW
     );

--- a/CRM/Activity/Import/Form/Preview.php
+++ b/CRM/Activity/Import/Form/Preview.php
@@ -100,28 +100,12 @@ class CRM_Activity_Import_Form_Preview extends CRM_Import_Form_Preview {
 
     $mapper = $this->controller->exportValue('MapField', 'mapper');
     $mapperKeys = [];
-    $mapperLocType = [];
-    $mapperPhoneType = [];
 
     foreach ($mapper as $key => $value) {
       $mapperKeys[$key] = $mapper[$key][0];
-
-      if (!empty($mapper[$key][1]) && is_numeric($mapper[$key][1])) {
-        $mapperLocType[$key] = $mapper[$key][1];
-      }
-      else {
-        $mapperLocType[$key] = NULL;
-      }
-
-      if (!empty($mapper[$key][2]) && (!is_numeric($mapper[$key][2]))) {
-        $mapperPhoneType[$key] = $mapper[$key][2];
-      }
-      else {
-        $mapperPhoneType[$key] = NULL;
-      }
     }
 
-    $parser = new CRM_Activity_Import_Parser_Activity($mapperKeys, $mapperLocType, $mapperPhoneType);
+    $parser = new CRM_Activity_Import_Parser_Activity($mapperKeys);
 
     $mapFields = $this->get('fields');
 

--- a/CRM/Activity/Import/Parser/Activity.php
+++ b/CRM/Activity/Import/Parser/Activity.php
@@ -40,9 +40,9 @@ class CRM_Activity_Import_Parser_Activity extends CRM_Activity_Import_Parser {
    *
    * @param array $mapperKeys
    */
-  public function __construct(&$mapperKeys) {
+  public function __construct($mapperKeys) {
     parent::__construct();
-    $this->_mapperKeys = &$mapperKeys;
+    $this->_mapperKeys = $mapperKeys;
   }
 
   /**


### PR DESCRIPTION

Overview
----------------------------------------
Minor preliminary cleanup

Before
----------------------------------------
```
public function __construct(&$mapperKeys)
```

2/3 of the places that instantiate it pass in unused parameters

After
----------------------------------------
```
public function __construct($mapperKeys)
```

Technical Details
----------------------------------------
The construct class does not need to receive mapperKeys as a reference - this
was removed for Membership Parser here https://github.com/civicrm/civicrm-core/commit/14b9e069607c6cbcbbaf21a209f647ba422b8e04#diff-36f5db3555445d26df2de015a18598fd5d5682b76c62aee4f14dde95b7948274L65

In addition 2 places that instantiate this class pass in unused params (go copy & paste) so
that is removed. The test tests very little so far....

Comments
----------------------------------------
