### PR TITLE
(POC#C) MembershipRenewalTest - Address assertions that started failing circa Jan 1, 2021

### DIFF
--- a/tests/phpunit/CRM/Member/Form/MembershipRenewalTest.php
+++ b/tests/phpunit/CRM/Member/Form/MembershipRenewalTest.php
@@ -78,6 +78,8 @@ class CRM_Member_Form_MembershipRenewalTest extends CiviUnitTestCase {
   public function setUp() {
     parent::setUp();
 
+    timecop_travel(mktime(1, 0, 0, 8, 1, 2020));
+
     $this->_individualId = $this->individualCreate();
     $this->_paymentProcessorID = $this->processorCreate();
     $this->financialTypeID = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'financial_type_id', 'Member Dues');
@@ -126,6 +128,7 @@ class CRM_Member_Form_MembershipRenewalTest extends CiviUnitTestCase {
     foreach ($this->ids['contact'] as $contactID) {
       $this->callAPISuccess('contact', 'delete', ['id' => $contactID, 'skip_undelete' => TRUE]);
     }
+    timecop_return();
   }
 
   /**


### PR DESCRIPTION
(Description TODO. Variant C - use `timecop` from PECL)

See also: https://lab.civicrm.org/dev/core/-/issues/2284