### PR TITLE
(dev/core#2284) MembershipRenewalTest - Address assertions that started failing circa Jan 1, 2021

### DIFF
--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -98,7 +98,7 @@ class CRM_Member_BAO_Membership extends CRM_Member_DAO_Membership {
       'status_id' => $membership->status_id,
       'start_date' => $logStartDate,
       'end_date' => CRM_Utils_Date::isoToMysql($membership->end_date),
-      'modified_date' => date('Ymd'),
+      'modified_date' => CRM_Utils_Time::date('Ymd'),
       'membership_type_id' => $values[$membership->id]['membership_type_id'],
       'max_related' => $membership->max_related,
     ];
@@ -283,7 +283,7 @@ class CRM_Member_BAO_Membership extends CRM_Member_DAO_Membership {
         'now', $excludeIsAdmin, $params['membership_type_id'] ?? NULL, $params
       );
       if (empty($calcStatus)) {
-        throw new CRM_Core_Exception(ts("The membership cannot be saved because the status cannot be calculated for start_date: {$params['start_date']} end_date {$params['end_date']} join_date {$params['join_date']} as at " . date('Y-m-d H:i:s')));
+        throw new CRM_Core_Exception(ts("The membership cannot be saved because the status cannot be calculated for start_date: {$params['start_date']} end_date {$params['end_date']} join_date {$params['join_date']} as at " . CRM_Utils_Time::date('Y-m-d H:i:s')));
       }
       $params['status_id'] = $calcStatus['id'];
     }
@@ -2739,7 +2739,7 @@ WHERE {$whereClause}";
           'start_date' => CRM_Utils_Date::isoToMysql($dao->start_date),
           'end_date' => CRM_Utils_Date::isoToMysql($dao->end_date),
           'modified_id' => $userId,
-          'modified_date' => date('Ymd'),
+          'modified_date' => CRM_Utils_Time::date('Ymd'),
           'membership_type_id' => $dao->membership_type_id,
           'max_related' => $dao->max_related,
         ];
@@ -2756,7 +2756,7 @@ WHERE {$whereClause}";
           'status_id' => 2,
           'version' => 3,
           'priority_id' => 2,
-          'activity_date_time' => date('Y-m-d H:i:s'),
+          'activity_date_time' => CRM_Utils_Time::date('Y-m-d H:i:s'),
           'is_auto' => 0,
           'is_current_revision' => 1,
           'is_deleted' => 0,

--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -2713,7 +2713,7 @@ WHERE {$whereClause}";
         return $updateMembershipMsg;
       }
 
-      $today = time();
+      $today = CRM_Utils_Time::time();
       if ($deceasedDate && CRM_Utils_Time::strtotime($deceasedDate) > $today) {
         return $updateMembershipMsg;
       }

--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -252,8 +252,8 @@ class CRM_Member_BAO_Membership extends CRM_Member_DAO_Membership {
     if (empty($params['is_override']) && empty($params['skipStatusCal'])) {
       $fieldsToLoad = [];
       foreach (['start_date', 'end_date', 'join_date'] as $dateField) {
-        if (!empty($params[$dateField]) && $params[$dateField] !== 'null' && strpos($params[$dateField], date('Ymd', strtotime(trim($params[$dateField])))) !== 0) {
-          $params[$dateField] = date('Ymd', strtotime(trim($params[$dateField])));
+        if (!empty($params[$dateField]) && $params[$dateField] !== 'null' && strpos($params[$dateField], date('Ymd', CRM_Utils_Time::strtotime(trim($params[$dateField])))) !== 0) {
+          $params[$dateField] = date('Ymd', CRM_Utils_Time::strtotime(trim($params[$dateField])));
           // @todo enable this once core is using the api.
           // CRM_Core_Error::deprecatedWarning('Relying on the BAO to clean up dates is deprecated. Call membership create via the api');
         }
@@ -1012,7 +1012,7 @@ INNER JOIN  civicrm_membership_type type ON ( type.id = membership.membership_ty
     $dates = ['startDate', 'endDate'];
     foreach ($dates as $date) {
       if (strlen($$date) === 8) {
-        $$date = date('Y-m-d', strtotime($$date));
+        $$date = date('Y-m-d', CRM_Utils_Time::strtotime($$date));
       }
     }
 
@@ -1200,7 +1200,7 @@ AND civicrm_membership.is_test = %2";
           $currentMembership['end_date'],
           $format
         ),
-        'modified_date' => date('Y-m-d H:i:s', strtotime($today)),
+        'modified_date' => date('Y-m-d H:i:s', CRM_Utils_Time::strtotime($today)),
         'membership_type_id' => $currentMembership['membership_type_id'],
         'max_related' => $currentMembership['max_related'] ?? 0,
       ];
@@ -2102,7 +2102,7 @@ INNER JOIN  civicrm_contact contact ON ( contact.id = membership.contact_id AND 
    */
   protected static function matchesRequiredMembership($params, $membership) {
     foreach (['start_date', 'end_date'] as $date) {
-      if (strtotime($params[$date]) !== strtotime($membership[$date])) {
+      if (CRM_Utils_Time::strtotime($params[$date]) !== CRM_Utils_Time::strtotime($membership[$date])) {
         return FALSE;
       }
       if ((int) $params['status_id'] !== (int) $membership['status_id']) {
@@ -2714,7 +2714,7 @@ WHERE {$whereClause}";
       }
 
       $today = time();
-      if ($deceasedDate && strtotime($deceasedDate) > $today) {
+      if ($deceasedDate && CRM_Utils_Time::strtotime($deceasedDate) > $today) {
         return $updateMembershipMsg;
       }
 

--- a/CRM/Member/BAO/MembershipStatus.php
+++ b/CRM/Member/BAO/MembershipStatus.php
@@ -218,7 +218,7 @@ class CRM_Member_BAO_MembershipStatus extends CRM_Member_DAO_MembershipStatus {
       CRM_Core_Error::deprecatedFunctionWarning('pass now rather than today in');
     }
 
-    $statusDate = date('Ymd', strtotime($statusDate));
+    $statusDate = date('Ymd', CRM_Utils_Time::strtotime($statusDate));
 
     //fix for CRM-3570, if we have statuses with is_admin=1,
     //exclude these statuses from calculatation during import.
@@ -236,9 +236,9 @@ class CRM_Member_BAO_MembershipStatus extends CRM_Member_DAO_MembershipStatus {
     $membershipStatus = CRM_Core_DAO::executeQuery($query);
 
     $dates = [
-      'start' => ($startDate && $startDate !== 'null') ? date('Ymd', strtotime($startDate)) : '',
-      'end' => ($endDate && $endDate !== 'null') ? date('Ymd', strtotime($endDate)) : '',
-      'join' => ($joinDate && $joinDate !== 'null') ? date('Ymd', strtotime($joinDate)) : '',
+      'start' => ($startDate && $startDate !== 'null') ? date('Ymd', CRM_Utils_Time::strtotime($startDate)) : '',
+      'end' => ($endDate && $endDate !== 'null') ? date('Ymd', CRM_Utils_Time::strtotime($endDate)) : '',
+      'join' => ($joinDate && $joinDate !== 'null') ? date('Ymd', CRM_Utils_Time::strtotime($joinDate)) : '',
     ];
 
     while ($membershipStatus->fetch()) {
@@ -253,9 +253,9 @@ class CRM_Member_BAO_MembershipStatus extends CRM_Member_DAO_MembershipStatus {
             if ($membershipStatus->{$eve . '_event_adjust_unit'} &&
               $membershipStatus->{$eve . '_event_adjust_interval'}
             ) {
-              $month = date('m', strtotime($date));
-              $day = date('d', strtotime($date));
-              $year = date('Y', strtotime($date));
+              $month = date('m', CRM_Utils_Time::strtotime($date));
+              $day = date('d', CRM_Utils_Time::strtotime($date));
+              $year = date('Y', CRM_Utils_Time::strtotime($date));
               // add in months
               if ($membershipStatus->{$eve . '_event_adjust_unit'} === 'month') {
                 ${$eve . 'Event'} = date('Ymd', mktime(0, 0, 0,

--- a/CRM/Member/BAO/MembershipType.php
+++ b/CRM/Member/BAO/MembershipType.php
@@ -324,7 +324,7 @@ class CRM_Member_BAO_MembershipType extends CRM_Member_DAO_MembershipType {
       }
     }
     if (!$joinDate) {
-      $joinDate = date('Y-m-d');
+      $joinDate = CRM_Utils_Time::date('Y-m-d');
     }
     $actualStartDate = $joinDate;
     if ($startDate) {
@@ -531,7 +531,7 @@ class CRM_Member_BAO_MembershipType extends CRM_Member_DAO_MembershipType {
       // CRM=7297 Membership Upsell: we need to handle null end_date in case we are switching
       // from a lifetime to a different membership type
       if (is_null($membershipDetails->end_date)) {
-        $date = date('Y-m-d');
+        $date = CRM_Utils_Time::date('Y-m-d');
       }
       else {
         $date = $membershipDetails->end_date;
@@ -581,14 +581,14 @@ class CRM_Member_BAO_MembershipType extends CRM_Member_DAO_MembershipType {
           $year
         ));
       }
-      $today = date('Y-m-d');
+      $today = CRM_Utils_Time::date('Y-m-d');
       $membershipDates['today'] = CRM_Utils_Date::customFormat($today, '%Y%m%d');
       $membershipDates['start_date'] = CRM_Utils_Date::customFormat($startDate, '%Y%m%d');
       $membershipDates['end_date'] = CRM_Utils_Date::customFormat($endDate, '%Y%m%d');
       $membershipDates['log_start_date'] = CRM_Utils_Date::customFormat($logStartDate, '%Y%m%d');
     }
     else {
-      $today = date('Y-m-d');
+      $today = CRM_Utils_Time::date('Y-m-d');
       if ($changeToday) {
         $today = CRM_Utils_Date::processDate($changeToday, NULL, FALSE, 'Y-m-d');
       }

--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -290,7 +290,7 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
 
     //setting default join date and receive date
     if ($this->_action == CRM_Core_Action::ADD) {
-      $defaults['receive_date'] = date('Y-m-d H:i:s');
+      $defaults['receive_date'] = CRM_Utils_Time::date('Y-m-d H:i:s');
     }
 
     $defaults['num_terms'] = 1;
@@ -352,7 +352,7 @@ DESC limit 1");
 
     //setting default join date if there is no join date
     if (empty($defaults['join_date'])) {
-      $defaults['join_date'] = date('Y-m-d');
+      $defaults['join_date'] = CRM_Utils_Time::date('Y-m-d');
     }
 
     if (!empty($defaults['membership_end_date'])) {
@@ -554,7 +554,7 @@ DESC limit 1");
         CRM_Member_StatusOverrideTypes::getSelectOptions()
       );
 
-      $this->add('datepicker', 'status_override_end_date', ts('Status Override End Date'), '', FALSE, ['minDate' => date('Y-m-d'), 'time' => FALSE]);
+      $this->add('datepicker', 'status_override_end_date', ts('Status Override End Date'), '', FALSE, ['minDate' => CRM_Utils_Time::date('Y-m-d'), 'time' => FALSE]);
 
       $this->addElement('checkbox', 'record_contribution', ts('Record Membership Payment?'));
 
@@ -1256,7 +1256,7 @@ DESC limit 1");
 
       //get the payment processor id as per mode. Try removing in favour of beginPostProcess.
       $params['payment_processor_id'] = $formValues['payment_processor_id'] = $this->_paymentProcessor['id'];
-      $params['register_date'] = date('YmdHis');
+      $params['register_date'] = CRM_Utils_Time::date('YmdHis');
 
       // add all the additional payment params we need
       $formValues['amount'] = $params['total_amount'];
@@ -1360,8 +1360,8 @@ DESC limit 1");
         }
         $endDate = $startDate = NULL;
       }
-      $now = date('YmdHis');
-      $params['receive_date'] = date('Y-m-d H:i:s');
+      $now = CRM_Utils_Time::date('YmdHis');
+      $params['receive_date'] = CRM_Utils_Time::date('Y-m-d H:i:s');
       $params['invoice_id'] = $formValues['invoiceID'];
       $params['contribution_source'] = ts('%1 Membership Signup: Credit card or direct debit (by %2)',
         [1 => $this->getSelectedMembershipLabels(), 2 => $userName]
@@ -1434,7 +1434,7 @@ DESC limit 1");
 
         // @todo figure out why recieve_date isn't being set right here.
         if (empty($params['receive_date'])) {
-          $params['receive_date'] = date('Y-m-d H:i:s');
+          $params['receive_date'] = CRM_Utils_Time::date('Y-m-d H:i:s');
         }
         $membershipParams = array_merge($params, $membershipTypeValues[$lineItemValues['membership_type_id']]);
 
@@ -1874,7 +1874,7 @@ DESC limit 1");
     $params['payment_instrument_id'] = $contributionParams['payment_instrument_id'] ?? NULL;
     $recurringContributionID = $this->legacyProcessRecurringContribution($params, $contactID);
 
-    $now = date('YmdHis');
+    $now = CRM_Utils_Time::date('YmdHis');
     $receiptDate = $params['receipt_date'] ?? NULL;
     if ($isEmailReceipt) {
       $receiptDate = $now;
@@ -1882,7 +1882,7 @@ DESC limit 1");
 
     if (isset($params['amount'])) {
       $contributionParams = array_merge([
-        'receive_date' => !empty($params['receive_date']) ? CRM_Utils_Date::processDate($params['receive_date']) : date('YmdHis'),
+        'receive_date' => !empty($params['receive_date']) ? CRM_Utils_Date::processDate($params['receive_date']) : CRM_Utils_Time::date('YmdHis'),
         'tax_amount' => $params['tax_amount'] ?? NULL,
         'invoice_id' => $params['invoiceID'],
         'currency' => $params['currencyID'],
@@ -1964,7 +1964,7 @@ DESC limit 1");
       $recurParams['is_test'] = 1;
     }
 
-    $recurParams['start_date'] = $recurParams['create_date'] = $recurParams['modified_date'] = date('YmdHis');
+    $recurParams['start_date'] = $recurParams['create_date'] = $recurParams['modified_date'] = CRM_Utils_Time::date('YmdHis');
     if (!empty($params['receive_date'])) {
       $recurParams['start_date'] = date('YmdHis', CRM_Utils_Time::strtotime($params['receive_date']));
     }

--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -1966,7 +1966,7 @@ DESC limit 1");
 
     $recurParams['start_date'] = $recurParams['create_date'] = $recurParams['modified_date'] = date('YmdHis');
     if (!empty($params['receive_date'])) {
-      $recurParams['start_date'] = date('YmdHis', strtotime($params['receive_date']));
+      $recurParams['start_date'] = date('YmdHis', CRM_Utils_Time::strtotime($params['receive_date']));
     }
     $recurParams['invoice_id'] = $params['invoiceID'] ?? NULL;
     $recurParams['contribution_status_id'] = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Pending');

--- a/CRM/Member/Form/MembershipRenewal.php
+++ b/CRM/Member/Form/MembershipRenewal.php
@@ -737,7 +737,7 @@ class CRM_Member_Form_MembershipRenewal extends CRM_Member_Form {
     ])) {
       return CRM_Member_BAO_Membership::create($memParams);
     }
-    $memParams['join_date'] = date('Ymd', strtotime($currentMembership['join_date']));
+    $memParams['join_date'] = date('Ymd', CRM_Utils_Time::strtotime($currentMembership['join_date']));
     $isMembershipCurrent = CRM_Core_DAO::getFieldValue('CRM_Member_DAO_MembershipStatus', $currentMembership['status_id'], 'is_current_member');
 
     // CRM-7297 Membership Upsell - calculate dates based on new membership type

--- a/CRM/Member/Form/MembershipRenewal.php
+++ b/CRM/Member/Form/MembershipRenewal.php
@@ -180,9 +180,9 @@ class CRM_Member_Form_MembershipRenewal extends CRM_Member_Form {
     $defaults = parent::setDefaultValues();
 
     // set renewal_date and receive_date to today in correct input format (setDateDefaults uses today if no value passed)
-    $now = date('Y-m-d');
+    $now = CRM_Utils_Time::date('Y-m-d');
     $defaults['renewal_date'] = $now;
-    $defaults['receive_date'] = $now . ' ' . date('H:i:s');
+    $defaults['receive_date'] = $now . ' ' . CRM_Utils_Time::date('H:i:s');
 
     if ($defaults['id']) {
       $defaults['record_contribution'] = CRM_Core_DAO::getFieldValue('CRM_Member_DAO_MembershipPayment',
@@ -487,7 +487,7 @@ class CRM_Member_Form_MembershipRenewal extends CRM_Member_Form {
     $this->storeContactFields($this->_params);
     $this->beginPostProcess();
     $now = CRM_Utils_Date::getToday(NULL, 'YmdHis');
-    $this->assign('receive_date', CRM_Utils_Array::value('receive_date', $this->_params, date('Y-m-d H:i:s')));
+    $this->assign('receive_date', CRM_Utils_Array::value('receive_date', $this->_params, CRM_Utils_Time::date('Y-m-d H:i:s')));
     $this->processBillingAddress();
 
     $this->_params['total_amount'] = CRM_Utils_Array::value('total_amount', $this->_params,

--- a/CRM/Member/Form/MembershipType.php
+++ b/CRM/Member/Form/MembershipType.php
@@ -364,14 +364,14 @@ class CRM_Member_Form_MembershipType extends CRM_Member_Form_MembershipConfig {
     }
 
     if ($params['fixed_period_start_day'] && !empty($params['fixed_period_start_day'])) {
-      $params['fixed_period_start_day']['Y'] = date('Y');
+      $params['fixed_period_start_day']['Y'] = CRM_Utils_Time::date('Y');
       if (!CRM_Utils_Rule::qfDate($params['fixed_period_start_day'])) {
         $errors['fixed_period_start_day'] = ts('Please enter valid Fixed Period Start Day');
       }
     }
 
     if ($params['fixed_period_rollover_day'] && !empty($params['fixed_period_rollover_day'])) {
-      $params['fixed_period_rollover_day']['Y'] = date('Y');
+      $params['fixed_period_rollover_day']['Y'] = CRM_Utils_Time::date('Y');
       if (!CRM_Utils_Rule::qfDate($params['fixed_period_rollover_day'])) {
         $errors['fixed_period_rollover_day'] = ts('Please enter valid Fixed Period Rollover Day');
       }

--- a/CRM/Member/Import/Parser.php
+++ b/CRM/Member/Import/Parser.php
@@ -117,7 +117,7 @@ abstract class CRM_Member_Import_Parser extends CRM_Import_Parser {
     }
     if ($statusID) {
       $this->progressImport($statusID);
-      $startTimestamp = $currTimestamp = $prevTimestamp = time();
+      $startTimestamp = $currTimestamp = $prevTimestamp = CRM_Utils_Time::time();
     }
 
     while (!feof($fd)) {

--- a/CRM/Utils/Time.php
+++ b/CRM/Utils/Time.php
@@ -31,15 +31,36 @@ class CRM_Utils_Time {
   static private $callback = NULL;
 
   /**
-   * Get the time.
+   * Evaluate a time expression (relative to current time).
    *
-   * @param string $returnFormat
-   *   Format in which date is to be retrieved.
-   *
-   * @return string
+   * @param string $str
+   *   Ex: '2001-02-03 04:05:06' or '+2 days'
+   * @param string|int $now
+   *   For relative time strings, $now determines the base time.
+   * @return false|int
+   *   The indicated time (seconds since epoch)
+   * @see strtotime()
    */
-  public static function getTime($returnFormat = 'YmdHis') {
-    return date($returnFormat, self::getTimeRaw());
+  public static function strtotime($str, $now = 'time()') {
+    if ($now === NULL || $now === 'time()') {
+      $now = self::time();
+    }
+    return strtotime($str, $now);
+  }
+
+  /**
+   * Format a date/time expression.
+   *
+   * @param string $format
+   *   Ex: 'Y-m-d H:i:s'
+   * @param null|int $timestamp
+   *   The time (seconds since epoch). NULL will use current time.
+   * @return string
+   *   Ex: '2001-02-03 04:05:06'
+   * @see date()
+   */
+  public static function date($format, $timestamp = NULL) {
+    return date($format, $timestamp ?: self::time());
   }
 
   /**
@@ -47,9 +68,36 @@ class CRM_Utils_Time {
    *
    * @return int
    *   seconds since epoch
+   * @see time()
+   */
+  public static function time() {
+    return self::$callback === NULL ? time() : call_user_func(self::$callback);
+  }
+
+  /**
+   * Get the time.
+   *
+   * @param string $returnFormat
+   *   Format in which date is to be retrieved.
+   *
+   * @return string
+   * @deprecated
+   *   Prefer CRM_Utils_Time::date(), whose name looks similar to the stdlib work-a-like.
+   */
+  public static function getTime($returnFormat = 'YmdHis') {
+    return date($returnFormat, self::time());
+  }
+
+  /**
+   * Get the time.
+   *
+   * @return int
+   *   seconds since epoch
+   * @deprecated
+   *   Prefer CRM_Utils_Time::time(), whose name looks similar to the stdlib work-a-like.
    */
   public static function getTimeRaw() {
-    return self::$callback === NULL ? time() : call_user_func(self::$callback);
+    return self::time();
   }
 
   /**

--- a/Civi/Test/CiviTestListener.php
+++ b/Civi/Test/CiviTestListener.php
@@ -85,6 +85,7 @@ else {
       if ($test instanceof HookInterface) {
         \CRM_Utils_Hook::singleton()->reset();
       }
+      \CRM_Utils_Time::resetTime();
       if ($this->isCiviTest($test)) {
         error_reporting(E_ALL & ~E_NOTICE);
         $this->errorScope = NULL;

--- a/Civi/Test/CiviTestListenerPHPUnit7.php
+++ b/Civi/Test/CiviTestListenerPHPUnit7.php
@@ -78,6 +78,7 @@ class CiviTestListenerPHPUnit7 implements \PHPUnit\Framework\TestListener {
     if ($test instanceof HookInterface) {
       \CRM_Utils_Hook::singleton()->reset();
     }
+    \CRM_Utils_Time::resetTime();
     if ($this->isCiviTest($test)) {
       error_reporting(E_ALL & ~E_NOTICE);
       $this->errorScope = NULL;

--- a/Civi/Test/Legacy/CiviTestListener.php
+++ b/Civi/Test/Legacy/CiviTestListener.php
@@ -74,6 +74,7 @@ class CiviTestListener extends \PHPUnit_Framework_BaseTestListener {
     if ($test instanceof \Civi\Test\HookInterface) {
       \CRM_Utils_Hook::singleton()->reset();
     }
+    \CRM_Utils_Time::resetTime();
     if ($this->isCiviTest($test)) {
       error_reporting(E_ALL & ~E_NOTICE);
       $this->errorScope = NULL;

--- a/tests/phpunit/CRM/Member/Form/MembershipRenewalTest.php
+++ b/tests/phpunit/CRM/Member/Form/MembershipRenewalTest.php
@@ -78,7 +78,8 @@ class CRM_Member_Form_MembershipRenewalTest extends CiviUnitTestCase {
   public function setUp() {
     parent::setUp();
 
-    timecop_travel(mktime(1, 0, 0, 8, 1, 2020));
+    // NOTE: This will mock time for PHP. However, some values populated by MySQL ("modified_date") may leak through.
+    CRM_Utils_Time::setTime('2020-08-01 01:00:00');
 
     $this->_individualId = $this->individualCreate();
     $this->_paymentProcessorID = $this->processorCreate();
@@ -128,7 +129,7 @@ class CRM_Member_Form_MembershipRenewalTest extends CiviUnitTestCase {
     foreach ($this->ids['contact'] as $contactID) {
       $this->callAPISuccess('contact', 'delete', ['id' => $contactID, 'skip_undelete' => TRUE]);
     }
-    timecop_return();
+    CRM_Utils_Time::resetTime();
   }
 
   /**
@@ -245,7 +246,7 @@ class CRM_Member_Form_MembershipRenewalTest extends CiviUnitTestCase {
     $membership = $this->callAPISuccessGetSingle('Membership', ['contact_id' => $this->_individualId]);
     $this->assertEquals($newMembershipTypeID, $membership['membership_type_id']);
     // The date (31 Dec this year) should be progressed by 2 months to 28 Dec next year.
-    $this->assertEquals(date('Y', strtotime($membershipBefore['end_date'])) + 1 . '-02-28', $membership['end_date']);
+    $this->assertEquals(CRM_Utils_Time::date('Y', strtotime($membershipBefore['end_date'])) + 1 . '-02-28', $membership['end_date']);
   }
 
   /**
@@ -268,7 +269,7 @@ class CRM_Member_Form_MembershipRenewalTest extends CiviUnitTestCase {
     $params = [
       'cid' => $this->_individualId,
       'price_set_id' => 0,
-      'join_date' => date('m/d/Y'),
+      'join_date' => CRM_Utils_Time::date('m/d/Y'),
       'start_date' => '',
       'end_date' => '',
       'campaign_id' => '',
@@ -288,7 +289,7 @@ class CRM_Member_Form_MembershipRenewalTest extends CiviUnitTestCase {
       'cvv2' => '123',
       'credit_card_exp_date' => [
         'M' => '9',
-        'Y' => date('Y') + 1,
+        'Y' => CRM_Utils_Time::date('Y') + 1,
       ],
       'credit_card_type' => 'Visa',
       'billing_first_name' => 'Test',
@@ -307,7 +308,6 @@ class CRM_Member_Form_MembershipRenewalTest extends CiviUnitTestCase {
     $membership = $this->callAPISuccessGetSingle('Membership', ['contact_id' => $this->_individualId]);
     $contributionRecur = $this->callAPISuccessGetSingle('ContributionRecur', ['contact_id' => $this->_individualId]);
     $this->assertEquals(1, $contributionRecur['is_email_receipt']);
-    $this->assertEquals(date('Y-m-d'), date('Y-m-d', strtotime($contributionRecur['modified_date'])));
     $this->assertEquals(date('Y-m-d'), date('Y-m-d', strtotime($contributionRecur['modified_date'])));
     $this->assertNotEmpty($contributionRecur['invoice_id']);
     $this->assertEquals(CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id',
@@ -373,23 +373,23 @@ class CRM_Member_Form_MembershipRenewalTest extends CiviUnitTestCase {
     $form->testSubmit($params);
     $membership = $this->callAPISuccessGetSingle('Membership', ['contact_id' => $this->_individualId]);
     $this->assertEquals('2020-04-13', $membership['join_date']);
-    $this->assertEquals(date('Y-01-01'), $membership['start_date']);
-    $nextYear = date('Y') + 1;
-    $this->assertEquals(date($nextYear . '-01-31'), $membership['end_date']);
-    $expectedStatus = (strtotime(date('Y-07-14')) > time()) ? 'New' : 'Current';
+    $this->assertEquals(CRM_Utils_Time::date('Y-01-01'), $membership['start_date']);
+    $nextYear = CRM_Utils_Time::date('Y') + 1;
+    $this->assertEquals(CRM_Utils_Time::date($nextYear . '-01-31'), $membership['end_date']);
+    $expectedStatus = (strtotime(CRM_Utils_Time::date('Y-07-14')) > CRM_Utils_Time::time()) ? 'New' : 'Current';
     $this->assertEquals(CRM_Core_PseudoConstant::getKey('CRM_Member_BAO_Membership', 'status_id', $expectedStatus), $membership['status_id']);
     $this->assertNotEmpty($membership['contribution_recur_id']);
     $this->assertNotEmpty('original_source', $membership['source']);
 
     $log = $this->callAPISuccessGetSingle('MembershipLog', ['membership_id' => $membership['id'], 'options' => ['limit' => 1, 'sort' => 'id DESC']]);
-    $this->assertEquals(date($nextYear . '-01-01'), $log['start_date']);
-    $this->assertEquals(date($nextYear . '-01-31'), $log['end_date']);
-    $this->assertEquals(date('Y-m-d'), $log['modified_date']);
+    $this->assertEquals(CRM_Utils_Time::date($nextYear . '-01-01'), $log['start_date']);
+    $this->assertEquals(CRM_Utils_Time::date($nextYear . '-01-31'), $log['end_date']);
+    $this->assertEquals(CRM_Utils_Time::date('Y-m-d'), $log['modified_date']);
 
     $contributionRecur = $this->callAPISuccessGetSingle('ContributionRecur', ['contact_id' => $this->_individualId]);
     $this->assertEquals($contributionRecur['id'], $membership['contribution_recur_id']);
     $this->assertEquals(0, $contributionRecur['is_email_receipt']);
-    $this->assertEquals(date('Y-m-d'), date('Y-m-d', strtotime($contributionRecur['modified_date'])));
+    $this->assertEquals(date('Y-m-d'), CRM_Utils_Time::date('Y-m-d', strtotime($contributionRecur['modified_date'])));
     $this->assertNotEmpty($contributionRecur['invoice_id']);
     // @todo fix this part!
     /*
@@ -486,7 +486,7 @@ class CRM_Member_Form_MembershipRenewalTest extends CiviUnitTestCase {
     $originalMembership = $this->callAPISuccessGetSingle('membership', []);
     $params = [
       'cid' => $this->_individualId,
-      'join_date' => date('m/d/Y'),
+      'join_date' => CRM_Utils_Time::date('m/d/Y'),
       'start_date' => '',
       'end_date' => '',
       // This format reflects the 23 being the organisation & the 25 being the type.
@@ -597,7 +597,7 @@ class CRM_Member_Form_MembershipRenewalTest extends CiviUnitTestCase {
     $originalMembership = $this->callAPISuccessGetSingle('membership', []);
     $params = [
       'cid' => $this->_individualId,
-      'join_date' => date('m/d/Y'),
+      'join_date' => CRM_Utils_Time::date('m/d/Y'),
       'start_date' => '',
       'end_date' => '',
       // This format reflects the 23 being the organisation & the 25 being the type.
@@ -680,7 +680,7 @@ class CRM_Member_Form_MembershipRenewalTest extends CiviUnitTestCase {
       'cvv2' => '123',
       'credit_card_exp_date' => [
         'M' => '9',
-        'Y' => date('Y') + 1,
+        'Y' => CRM_Utils_Time::date('Y') + 1,
       ],
       'credit_card_type' => 'Visa',
       'billing_first_name' => 'Test',
@@ -729,13 +729,13 @@ class CRM_Member_Form_MembershipRenewalTest extends CiviUnitTestCase {
     $form->testSubmit($params);
     $renewedMembership = $this->callAPISuccessGetSingle('Membership', ['id' => $originalMembership['id']]);
     $this->assertEquals('sauce', $renewedMembership['source']);
-    $this->assertEquals(date('Y-01-01'), $renewedMembership['start_date']);
-    $this->assertEquals(date('2019-03-01'), $renewedMembership['join_date']);
-    $this->assertEquals(date('Y-12-31'), $renewedMembership['end_date']);
+    $this->assertEquals(CRM_Utils_Time::date('Y-01-01'), $renewedMembership['start_date']);
+    $this->assertEquals(CRM_Utils_Time::date('2019-03-01'), $renewedMembership['join_date']);
+    $this->assertEquals(CRM_Utils_Time::date('Y-12-31'), $renewedMembership['end_date']);
     $log = $this->callAPISuccessGetSingle('MembershipLog', ['membership_id' => $renewedMembership['id'], 'options' => ['limit' => 1, 'sort' => 'id DESC']]);
-    $this->assertEquals(date('Y-01-01'), $log['start_date']);
-    $this->assertEquals(date('Y-12-31'), $log['end_date']);
-    $this->assertEquals(date('Y-m-d'), $log['modified_date']);
+    $this->assertEquals(CRM_Utils_Time::date('Y-01-01'), $log['start_date']);
+    $this->assertEquals(CRM_Utils_Time::date('Y-12-31'), $log['end_date']);
+    $this->assertEquals(CRM_Utils_Time::date('Y-m-d'), $log['modified_date']);
     $this->assertEquals(CRM_Core_PseudoConstant::getKey('CRM_Member_BAO_Membership', 'status_id', 'Current'), $log['status_id']);
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
This fixes a recent symptom wherein `MembershipRenewalTest` started to fail circa Jan 1, 2021.

See also: https://lab.civicrm.org/dev/core/-/issues/2284

Before
----------------------------------------

* `MembershipRenewalTest` has some assertions that only work out if the test executes within a specific time-frame (roughly Apr 2020 through Dec 2020, inclusive).
* `MembershipRenewalTest` (and the underlying logic of `CRM/Member/*`) work in strictly real/current time (e.g. based on PHP `time()` , `date()`, etc)

After
----------------------------------------

* `MembershipRenewalTest` has substantively the same assertions as before, but explicitly indicates a preferred/mocked time (`CRM_Utils_Time::setTime(...)`).
* `MembershipRenewalTest` (and the underlying logic of `CRM/Member/*`) perform time operations through `CRM_Utils_Time`, which allows mocking the current-time for the duration of a unit-test.

Comments
----------------------------------------

This PR includes a couple of ancillary changes which could potentially be their own PRs:

* Update DX of `CRM_Utils_Time` so that it's a bit easier to convert from PHP stdlib to the wrapper (e.g. `time()` <=> `CRM_Utils_Time::time()`)
* Update `CiviTestListener`(s) to always cleanup the mocked time. This addresses some issues where *other* (pre-existing/not-membership-related) tests neglect to cleanup. The omission had caused some funny knock-on effects.