### PR TITLE
dev/core#766 fix failure to save custom data on template-based-event

### DIFF
--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -2297,6 +2297,13 @@ LEFT  JOIN  civicrm_price_field_value value ON ( value.id = lineItem.price_field
       'template_title',
     ];
     $defaults = array_diff_key($defaults, array_flip($fieldsToExclude));
+    foreach ($defaults as $key => $value) {
+      $customFieldInfo = CRM_Core_BAO_CustomField::getKeyID($key, TRUE);
+      if (!empty($customFieldInfo[1])) {
+        $defaults[str_replace($customFieldInfo[1], '-' . $customFieldInfo[1], $key)] = $value;
+        unset($defaults[$key]);
+      }
+    }
     return $defaults;
   }
 

--- a/CRM/Event/Form/ManageEvent/EventInfo.php
+++ b/CRM/Event/Form/ManageEvent/EventInfo.php
@@ -228,13 +228,6 @@ class CRM_Event_Form_ManageEvent_EventInfo extends CRM_Event_Form_ManageEvent {
     //merge params with defaults from templates
     if (!empty($params['template_id'])) {
       $params = array_merge(CRM_Event_BAO_Event::getTemplateDefaultValues($params['template_id']), $params);
-      foreach ($params as $key => $value) {
-        $customFieldInfo = CRM_Core_BAO_CustomField::getKeyID($key, TRUE);
-        if (!empty($customFieldInfo[1])) {
-          $params[str_replace($customFieldInfo[1], '-' . $customFieldInfo[1], $key)] = $value;
-          unset($params[$key]);
-        }
-      }
     }
 
     $params['custom'] = CRM_Core_BAO_CustomField::postProcess($params,


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/766

Before
----------------------------------------
custom data fails to save
![image](https://lab.civicrm.org/dev/core/uploads/e455d72ff78057b5f354a3a4d643eb9d/766-Event-Template-Custom-Data-not-saved-5.34.alpha1.gif)

After
----------------------------------------
saves

Technical Details
----------------------------------------
I decided that this was not a regression but that the fix was trying to format custom data in a way that was needed for the custom data retrieved from the template defaults but not for submitted custom data so I moved it

Comments
----------------------------------------
