### PR TITLE
dev/core#2282 Use the proper content type for ICalendar link

### DIFF
--- a/CRM/Event/ICalendar.php
+++ b/CRM/Event/ICalendar.php
@@ -70,7 +70,7 @@ class CRM_Event_ICalendar extends CRM_Core_Page {
         CRM_Utils_ICalendar::send($calendar, 'text/xml', 'utf-8');
       }
       else {
-        CRM_Utils_ICalendar::send($calendar, 'text/plain', 'utf-8');
+        CRM_Utils_ICalendar::send($calendar, 'text/calendar', 'utf-8');
       }
     }
     else {

--- a/CRM/Utils/ICalendar.php
+++ b/CRM/Utils/ICalendar.php
@@ -85,8 +85,7 @@ class CRM_Utils_ICalendar {
 
   /**
    * Send the ICalendar to the browser with the specified content type
-   * - 'text/calendar' : used for downloaded ics file
-   * - 'text/plain'    : used for iCal formatted feed
+   * - 'text/calendar' : used for iCal formatted feed
    * - 'text/xml'      : used for gData or rss formatted feeds
    *
    *
@@ -106,7 +105,7 @@ class CRM_Utils_ICalendar {
     CRM_Utils_System::setHttpHeader("Content-Language", $lang);
     CRM_Utils_System::setHttpHeader("Content-Type", "$content_type; charset=$charset");
 
-    if ($content_type == 'text/calendar') {
+    if ($fileName) {
       CRM_Utils_System::setHttpHeader('Content-Length', strlen($calendar));
       CRM_Utils_System::setHttpHeader("Content-Disposition", "$disposition; filename=\"$fileName\"");
       CRM_Utils_System::setHttpHeader("Pragma", "no-cache");

--- a/tests/phpunit/CRM/Utils/ICalendarTest.php
+++ b/tests/phpunit/CRM/Utils/ICalendarTest.php
@@ -38,4 +38,107 @@ class CRM_Utils_ICalendarTest extends CiviUnitTestCase {
     $this->assertEquals($testString, CRM_Utils_ICalendar::unformatText(CRM_Utils_ICalendar::formatText($testString)));
   }
 
+  /**
+   * @return array
+   */
+  public function getSendParameters() {
+    return [
+      [
+        ['calendar_data', 'text/xml', 'utf-8', NULL, NULL],
+        [
+          'Content-Language' => 'en_US',
+          'Content-Type' => 'text/xml; charset=utf-8',
+        ],
+      ],
+      [
+        ['calendar_data', 'text/calendar', 'utf-8', NULL, NULL],
+        [
+          'Content-Language' => 'en_US',
+          'Content-Type' => 'text/calendar; charset=utf-8',
+        ],
+      ],
+    ];
+  }
+
+  /**
+   * Test provided send parameters.
+   *
+   * @dataProvider getSendParameters
+   */
+  public function testSendParametersWithoutAttachment($parameters, $expected) {
+    // we need to capture echo output
+    ob_start();
+    CRM_Utils_ICalendar::send(
+      $parameters[0],
+      $parameters[1],
+      $parameters[2],
+      $parameters[3],
+      $parameters[4]
+    );
+    ob_end_clean();
+
+    $headerList = \Civi::$statics['CRM_Utils_System_UnitTests']['header'];
+
+    // Convert headers from simple array to associative array
+    $headers = [];
+    foreach ($headerList as $header) {
+      $headerParts = explode(': ', $header);
+      $headers[$headerParts[0]] = $headerParts[1];
+    }
+
+    $this->assertEquals($expected['Content-Language'], $headers['Content-Language']);
+    $this->assertEquals($expected['Content-Type'], $headers['Content-Type']);
+    $this->assertArrayNotHasKey('Content-Length', $headers);
+    $this->assertArrayNotHasKey('Content-Disposition', $headers);
+    $this->assertArrayNotHasKey('Pragma', $headers);
+    $this->assertArrayNotHasKey('Expires', $headers);
+    $this->assertArrayNotHasKey('Cache-Control', $headers);
+  }
+
+  /**
+   * Test Send with attachment.
+   */
+  public function testSendWithAttachment() {
+    $parameters = [
+      'calendar_data', 'text/calendar', 'utf-8', 'civicrm_ical.ics', 'attachment',
+    ];
+    $expected = [
+      'Content-Language' => 'en_US',
+      'Content-Type' => 'text/calendar; charset=utf-8',
+      'Content-Length' => '13',
+      'Content-Disposition' => 'attachment; filename="civicrm_ical.ics"',
+      'Pragma' => 'no-cache',
+      'Expires' => '0',
+      'Cache-Control' => 'no-cache, must-revalidate',
+    ];
+
+    // we need to capture echo output
+    ob_start();
+    CRM_Utils_ICalendar::send(
+      $parameters[0],
+      $parameters[1],
+      $parameters[2],
+      $parameters[3],
+      $parameters[4]
+    );
+    ob_end_clean();
+
+    $headerList = \Civi::$statics['CRM_Utils_System_UnitTests']['header'];
+
+    // Convert headers from simple array to associative array
+    $headers = [];
+    foreach ($headerList as $header) {
+      $headerParts = explode(': ', $header);
+      $headers[$headerParts[0]] = $headerParts[1];
+    }
+
+    $this->assertEquals($expected['Content-Language'], $headers['Content-Language']);
+    $this->assertEquals($expected['Content-Type'], $headers['Content-Type']);
+    $this->assertEquals($expected['Content-Length'], $headers['Content-Length']);
+    $this->assertEquals($expected['Content-Disposition'], $headers['Content-Disposition']);
+    $this->assertEquals($expected['Pragma'], $headers['Pragma']);
+    $this->assertEquals($expected['Expires'], $headers['Expires']);
+    $this->assertEquals($expected['Cache-Control'], $headers['Cache-Control']);
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
iCalendar (RFC 5545) is a standard method of transferring calendar information between computer systems and is used to import and synchronize events on various platforms and using the proper content type will Improve the end-user experience.

Before
----------------------------------------
CiviCRM will use the content type of `text/plain` for ICalendar feed.

After
----------------------------------------
CiviCRM will use the content type of `text/calendar` for ICalendar feed.

Technical Details
----------------------------------------
Because of `CRM_Utils_ICalendar::send` will check for content type of `text/calendar` and send a content disposition header with empty filename, I updated it to check for `$filename` instead.

Comments
----------------------------------------
Adds test cover

Issue: https://lab.civicrm.org/dev/core/-/issues/2282