### PR TITLE
dev/core#2285 Fix civicrm_alterReportVar hook for contribute detail r…

### DIFF
--- a/CRM/Report/Form/Contribute/Detail.php
+++ b/CRM/Report/Form/Contribute/Detail.php
@@ -572,6 +572,7 @@ GROUP BY {$this->_aliases['civicrm_contribution']}.currency";
 
     // we inner join with temp1 to restrict soft contributions to those in temp1 table.
     // no group by here as we want to display as many soft credit rows as actually exist.
+    CRM_Utils_Hook::alterReportVar('sql', $this, $this);
     $sql = "{$select} {$this->_from} {$this->_where} $this->_groupBy";
     $this->createTemporaryTable('civireport_contribution_detail_temp2', $sql);
 

--- a/tests/phpunit/CRM/Report/Form/Contribute/fixtures/value_extension_tng55_table.sql
+++ b/tests/phpunit/CRM/Report/Form/Contribute/fixtures/value_extension_tng55_table.sql
@@ -1,0 +1,26 @@
+-- phpMyAdmin SQL Dump
+-- version 4.9.7
+-- https://www.phpmyadmin.net/
+--
+-- Host: 127.0.0.1
+-- Generation Time: Jan 04, 2021 at 06:30 AM
+-- Server version: 5.7.32
+-- PHP Version: 7.4.3
+
+SET SQL_MODE="NO_AUTO_VALUE_ON_ZERO";
+SET FOREIGN_KEY_CHECKS=0;
+
+--
+-- Database: `civicrm_tests_dev`
+--
+
+--
+-- Dumping data for table `civicrm_value_extension_tng55`
+--
+
+CREATE TABLE `civicrm_value_extension_tng55` (
+  `id` int(10) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'Default MySQL primary key',
+  `entity_id` int(10) UNSIGNED NOT NULL,
+  `title` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;


### PR DESCRIPTION
Overview
----------------------------------------
The `civicrm_alterReportVar` is not working for contribute detail report.

Before
----------------------------------------
We're getting a "DB Error: no such field" when using the hook.

After
----------------------------------------
No Errors.

Technical Details
----------------------------------------

Here at [Detail.php#L956](https://github.com/civicrm/civicrm-core/blob/3662d5a75d79d6c259b632df748b1beb66db6faf/CRM/Report/Form/Contribute/Detail.php#L956) our changes to the `_form` attribute are lost and the error will be fired here [Detail.php#L576](https://github.com/civicrm/civicrm-core/blob/3662d5a75d79d6c259b632df748b1beb66db6faf/CRM/Report/Form/Contribute/Detail.php#L576)  

    Unknown column 'some_table.some_column' in 'where clause'


Comments
----------------------------------------
Maybe it is not a good idea to fire the same hook twice so I am open to suggestions.
Adds test cover.

Issue: https://lab.civicrm.org/dev/core/-/issues/2285