### PR TITLE
[tests] Fix join syntax conversion for APIv4 in v3 unit tests

### DIFF
--- a/Civi/Test/Api3TestTrait.php
+++ b/Civi/Test/Api3TestTrait.php
@@ -425,10 +425,9 @@ trait Api3TestTrait {
             $v4Params['select'][] = 'id';
           }
           // Convert join syntax
-          foreach ($v4Params['select'] as &$select) {
+          foreach ($v4Params['select'] as $idx => $select) {
             if (strstr($select, '_id.')) {
-              $joins[$select] = explode('.', str_replace('_id.', '.', $select));
-              $select = str_replace('_id.', '.', $select);
+              $joins[$select] = $v4Params['select'][$idx] = str_replace('_id.', '.', $select);
             }
           }
         }
@@ -598,8 +597,8 @@ trait Api3TestTrait {
         $result[$index][$key] = $this->runApi4LegacyChain($key, $params, $v4Entity, $row, $sequential);
       }
       // Convert join format
-      foreach ($joins as $api3Key => $api4Path) {
-        $result[$index][$api3Key] = \CRM_Utils_Array::pathGet($result[$index], $api4Path);
+      foreach ($joins as $api3Key => $api4Key) {
+        $result[$index][$api3Key] = $result[$index][$api4Key] ?? NULL;
       }
       // Resolve custom field names
       foreach ($custom as $group => $fields) {

--- a/tests/phpunit/api/v3/ContactTest.php
+++ b/tests/phpunit/api/v3/ContactTest.php
@@ -650,8 +650,7 @@ class api_v3_ContactTest extends CiviUnitTestCase {
       'contact_id' => $contactId,
       'return' => 'contact_id.api_key',
     ]);
-    $field = $this->_apiversion == 4 ? 'contact.api_key' : 'contact_id.api_key';
-    $this->assertEquals('abcd1234', $joinResult[$field]);
+    $this->assertEquals('abcd1234', $joinResult['contact_id.api_key']);
 
     // Restricted return -- because we don't have permission
     $config->userPermissionClass->permissions = ['access CiviCRM', 'view all contacts', 'edit all contacts'];


### PR DESCRIPTION
Overview
----------------------------------------
Test-only fix for performing joins in APIv4 from within the v3 tests.