### PR TITLE
Mailing default domain error: force a backend URL for WP

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -2749,8 +2749,9 @@ WHERE  civicrm_mailing_job.id = %1
     $config = CRM_Core_Config::singleton();
 
     if ($mode == NULL && CRM_Core_BAO_MailSettings::defaultDomain() == "EXAMPLE.ORG") {
+      // Using forceBackend=TRUE because WordPress sometimes fails to detect cron
       throw new CRM_Core_Exception(ts('The <a href="%1">default mailbox</a> has not been configured. You will find <a href="%2">more info in the online system administrator guide</a>', [
-        1 => CRM_Utils_System::url('civicrm/admin/mailSettings', 'reset=1'),
+        1 => CRM_Utils_System::url('civicrm/admin/mailSettings', 'reset=1', FALSE, NULL, TRUE, FALSE, TRUE),
         2 => "https://docs.civicrm.org/sysadmin/en/latest/setup/civimail/",
       ]));
     }


### PR DESCRIPTION
Overview
----------------------------------------

This might be a bit silly, and might not be the right fix, but I stumbled on a very specific scenario where the `CRM_Utils_System::url()` function on WordPress generates a frontend URL instead of a backend URL.

To reproduce:

* Configure mailings
* Do not configure the "default domain" (defaults to FIXME.ORG)
* Run a mailing.

The `process_mail` Scheduled Job log will have something like this:

![wp-2021-01-04_16-13](https://user-images.githubusercontent.com/254741/103580336-0462fb00-4ea8-11eb-86dc-c983d9b1cfd0.png)

Translation: The default mailbox has not been configured. You will find more info in the online system administrator guide.

and the URL highlighted in the above screenshot uses a frontend URL, which won't work on WordPress.

Technical Details
----------------------------------------

`CRM_Utils_System_WordPress::url` checks for `is_admin`, which does not work for when crons are running. Maybe it's an issue with `wp-cli`, but it's a bit obscure and very specific.

Comments
----------------------------------------

Feel free to reject this patch, as those function parameters make the code difficult to read. Although it does make me wonder why `forceBackend` was introduced on top of the `frontend` parameter. I didn't feel like going down that rabbit hole.

On the other hand, a bug on a bug is rather cringe for admins.

Happy new year :-)