### PR TITLE
Fix APIv3 profile.getfields to return correctly keyed phone field

### DIFF
--- a/api/v3/Profile.php
+++ b/api/v3/Profile.php
@@ -632,23 +632,23 @@ function _civicrm_api3_map_profile_fields_to_entity(&$field) {
     $entity = 'contact';
   }
   $entity = _civicrm_api_get_entity_name_from_camel($entity);
-  $locationFields = ['email' => 'email'];
+  $locationFields = ['email', 'phone'];
   $fieldName = $field['field_name'];
   if (!empty($field['location_type_id'])) {
-    if ($fieldName == 'email') {
-      $entity = 'email';
+    if (in_array($fieldName, $locationFields)) {
+      $entity = $fieldName;
     }
     else {
       $entity = 'address';
     }
     $fieldName .= '-' . $field['location_type_id'];
   }
-  elseif (array_key_exists($fieldName, $locationFields)) {
+  elseif (in_array($fieldName, $locationFields)) {
+    $entity = $fieldName;
     $fieldName .= '-Primary';
-    $entity = 'email';
   }
   if (!empty($field['phone_type_id'])) {
-    $fieldName .= '-' . $field['location_type_id'];
+    $fieldName .= '-' . $field['phone_type_id'];
     $entity = 'phone';
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
This fixes the phone profile field to have the correct field key to match profile forms.
Fixes https://github.com/civicrm/org.civicrm.contactlayout/issues/91

Before
----------------------------------------
Key returned by api does not match form key for the phone field.

After
----------------------------------------
Matches and ContactLayout is able to function correctly.

Technical Details
----------------------------------------
The field key is supposed to be `phone-[location_type_id|'Primary']-[phone_type_id]`.