### PR TITLE
dev/core#2286 - Avoid notice on missing db port during install

### DIFF
--- a/setup/plugins/init/Drupal8.civi-setup.php
+++ b/setup/plugins/init/Drupal8.civi-setup.php
@@ -43,7 +43,7 @@ if (!defined('CIVI_SETUP')) {
     $ssl_params = \Civi\Setup\DrupalUtil::guessSslParams($connectionOptions);
     // @todo Does Drupal support unixsocket in config? Set 'server' => 'unix(/path/to/socket.sock)'
     $model->db = $model->cmsDb = array(
-      'server' => \Civi\Setup\DbUtil::encodeHostPort($connectionOptions['host'], $connectionOptions['port'] ?: NULL),
+      'server' => \Civi\Setup\DbUtil::encodeHostPort($connectionOptions['host'], $connectionOptions['port'] ?? NULL),
       'username' => $connectionOptions['username'],
       'password' => $connectionOptions['password'],
       'database' => $connectionOptions['database'],


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/2286

It's hard to explain how to reproduce this since it only comes up during a certain type of unit test for which there aren't any docs yet, but it comes up there as a fatal error. I'm hoping this is just an easy one from looking at the one-line change.

If the `$connectionOptions` array does not have a `port` member, then the current code gives a notice.

Comments
----------------------------------------
Companion to https://github.com/civicrm/civicrm-drupal-8/pull/56
