### PR TITLE
Add explicit box-sizing to crm-flex-box style

### DIFF
--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -22,9 +22,11 @@
 .crm-container .crm-flex-box {
   display: flex;
   flex-wrap: wrap;
+  box-sizing: border-box;
 }
 .crm-container .crm-flex-box > * {
   flex: 1;
+  box-sizing: border-box;
   min-width: 0; /* prevents getting squashed by whitespace:nowrap content */
 }
 .crm-container .crm-flex-box > .crm-flex-2 {


### PR DESCRIPTION
Overview
----------------------------------------
This ensures consistent box sizing when using the new `crm-flex-box` css class, for consistency with or without Bootstrap 3.

Technical Details
----------------------------------------
Bootstrap 3 sets this box-sizing value explicitly. We should too.