### PR TITLE
$frequency_unit is not translated

### DIFF
--- a/templates/CRM/Contribute/Form/Contribution/Confirm.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Confirm.tpl
@@ -80,14 +80,15 @@
         {/if}
 
         {if $is_recur}
+          {capture assign=ts_frequency_unit}{ts}{$frequency_unit}{/ts}{/capture}
           {if !empty($auto_renew)} {* Auto-renew membership confirmation *}
             {crmRegion name="contribution-confirm-recur-membership"}
               <br/>
               <strong>
                 {if $autoRenewOption == 1}
-                  {ts 1=$frequency_interval 2=$frequency_unit}I want this membership to be renewed automatically every %1 %2(s).{/ts}
+                  {ts 1=$frequency_interval 2=$ts_frequency_unit}I want this membership to be renewed automatically every %1 %2(s).{/ts}
                 {elseif $autoRenewOption == 2}
-                  {ts 1=$frequency_interval 2=$frequency_unit}This membership will be renewed automatically every %1 %2(s).{/ts}
+                  {ts 1=$frequency_interval 2=$ts_frequency_unit}This membership will be renewed automatically every %1 %2(s).{/ts}
                 {/if}
               </strong>
               </p>
@@ -101,20 +102,20 @@
             {if $installments}
               {if $frequency_interval > 1}
                 <p>
-                  <strong>{ts 1=$frequency_interval 2=$frequency_unit 3=$installments}I want to contribute this amount every %1 %2s for %3 installments.{/ts}</strong>
+                  <strong>{ts 1=$frequency_interval 2=$ts_frequency_unit 3=$installments}I want to contribute this amount every %1 %2s for %3 installments.{/ts}</strong>
                 </p>
               {else}
                 <p>
-                  <strong>{ts 1=$frequency_unit 2=$installments}I want to contribute this amount every %1 for %2 installments.{/ts}</strong>
+                  <strong>{ts 1=$ts_frequency_unit 2=$installments}I want to contribute this amount every %1 for %2 installments.{/ts}</strong>
                 </p>
               {/if}
             {else}
               {if $frequency_interval > 1}
                 <p>
-                  <strong>{ts 1=$frequency_interval 2=$frequency_unit}I want to contribute this amount every %1 %2s.{/ts}</strong>
+                  <strong>{ts 1=$frequency_interval 2=$ts_frequency_unit}I want to contribute this amount every %1 %2s.{/ts}</strong>
                 </p>
               {else}
-                <p><strong>{ts 1=$frequency_unit }I want to contribute this amount every %1.{/ts}</strong></p>
+                <p><strong>{ts 1=$ts_frequency_unit }I want to contribute this amount every %1.{/ts}</strong></p>
               {/if}
             {/if}
               <p>{ts}Your initial contribution will be processed once you complete the confirmation step. You will be able to cancel the recurring contribution by visiting the web page link that will be included in your receipt.{/ts}</p>
@@ -123,13 +124,14 @@
         {/if}
 
         {if $is_pledge }
+          {capture assign=ts_pledge_frequency_unit}{ts}{$pledge_frequency_unit}{/ts}{/capture}
           {if $pledge_frequency_interval GT 1}
             <p>
-              <strong>{ts 1=$pledge_frequency_interval 2=$pledge_frequency_unit 3=$pledge_installments}I pledge to contribute this amount every %1 %2s for %3 installments.{/ts}</strong>
+              <strong>{ts 1=$pledge_frequency_interval 2=$ts_pledge_frequency_unit 3=$pledge_installments}I pledge to contribute this amount every %1 %2s for %3 installments.{/ts}</strong>
             </p>
           {else}
             <p>
-              <strong>{ts 1=$pledge_frequency_interval 2=$pledge_frequency_unit 3=$pledge_installments}I pledge to contribute this amount every %2 for %3 installments.{/ts}</strong>
+              <strong>{ts 1=$pledge_frequency_interval 2=$ts_pledge_frequency_unit 3=$pledge_installments}I pledge to contribute this amount every %2 for %3 installments.{/ts}</strong>
             </p>
           {/if}
           {if $is_pay_later}

--- a/templates/CRM/Contribute/Form/Contribution/Main.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Main.tpl
@@ -150,7 +150,7 @@
               {$form.frequency_interval.html}
             {/if}
             {if $one_frequency_unit}
-              {$frequency_unit}
+              {ts}{$frequency_unit}{/ts}
             {else}
               {$form.frequency_unit.html}
             {/if}


### PR DESCRIPTION
When I have only one frequency unit, `$frequency_unit` is not translated and it appears always in english.