### PR TITLE
Correctly check button to allow duplicate contact saving from profiles

### DIFF
--- a/CRM/Profile/Form.php
+++ b/CRM/Profile/Form.php
@@ -994,7 +994,7 @@ class CRM_Profile_Form extends CRM_Core_Form {
     }
 
     // don't check for duplicates during registration validation: CRM-375
-    if (!$register && empty($fields['_qf_Edit_upload_duplicate'])) {
+    if (!$register && !array_key_exists('_qf_Edit_upload_duplicate', $fields)) {
       // fix for CRM-3240
       if (!empty($fields['email-Primary'])) {
         $fields['email'] = $fields['email-Primary'] ?? NULL;


### PR DESCRIPTION
Overview
----------------------------------------
Fixes the regression described in https://lab.civicrm.org/dev/core/-/issues/2287

Before
----------------------------------------
Popup profiles failed to save duplicate contacts.

After
----------------------------------------
Popup profiles correctly save duplicate contacts when user chooses to.

Technical Details
----------------------------------------
Changing the button from `type=submit` to `type=button` changed the values submitted back to the server. The value for the button came back as an empty string instead of the button label because submit elements have a value but buttons do not.