### PR TITLE
Stop preventing test runs and dev sites from seeing PHP deprecation notices

### DIFF
--- a/CRM/Core/Config.php
+++ b/CRM/Core/Config.php
@@ -89,10 +89,6 @@ class CRM_Core_Config extends CRM_Core_Config_MagicMerge {
       $GLOBALS['civicrm_default_error_scope'] = CRM_Core_TemporaryErrorScope::create(['CRM_Core_Error', 'handle']);
       $errorScope = CRM_Core_TemporaryErrorScope::create(['CRM_Core_Error', 'simpleHandler']);
 
-      if (defined('E_DEPRECATED')) {
-        error_reporting(error_reporting() & ~E_DEPRECATED);
-      }
-
       self::$_singleton = new CRM_Core_Config();
       \Civi\Core\Container::boot($loadFromDB);
       if ($loadFromDB && self::$_singleton->dsn) {


### PR DESCRIPTION
Overview
----------------------------------------
PHP deprecations are hidden sometimes because of these lines. It seems to come from https://issues.civicrm.org/jira/browse/CRM-6327, which says _"CiviCRM should automatically set E_DEPRECATED when running under PHP 5.3. Set this mode automatically to minimize support issues."_ In fairness, and I think I'm remembering now, it was a new constant, and by default live sites were including these notices if they had inherited the php 5.2 error_reporting settings, because the default was something like `E_ALL & ~E_STRICT`. These lines may have even been lifted verbatim from drupal 6.

You can reproduce the problem by using e.g. php 7.4 and setting your error_reporting to E_ALL and doing `cv ev "$s = 'foo'; echo $s{0};"`. Before the patch you get no notice. After the patch you get the deprecation notice as you should.

Before
-------
Even dev sites or test runs don't see deprecation notices sometimes, regardless of what you've set for error_reporting.

After
------
Notices appear depending on your error_reporting settings.

