### PR TITLE
php 7.4 compatibility - Array and string offset access syntax with curly braces is deprecated

### DIFF
--- a/Civi/Core/Paths.php
+++ b/Civi/Core/Paths.php
@@ -200,7 +200,7 @@ class Paths {
     }
 
     $defaultContainer = self::DEFAULT_PATH;
-    if ($value && $value{0} == '[' && preg_match(';^\[([a-zA-Z0-9\._]+)\]/(.*);', $value, $matches)) {
+    if ($value && $value[0] == '[' && preg_match(';^\[([a-zA-Z0-9\._]+)\]/(.*);', $value, $matches)) {
       $defaultContainer = $matches[1];
       $value = $matches[2];
     }


### PR DESCRIPTION
Overview
----------------------------------------
Using $string{0} to get the first letter is deprecated in php 7.4

Noted at https://civicrm.stackexchange.com/questions/38565/activating-civicrm-in-wordpress-returns-a-fatal-error-this-is-on-windows10-all

Comments
----------------------------------------
It's curious this doesn't come up during edge tests since this function is used all the time. It might be because of https://github.com/civicrm/civicrm-core/blob/843a46fb80b6caaf8ecb6827f0d1717d0ebdfa85/CRM/Core/Config.php#L92 - why is that there?
