### PR TITLE
dev/core#2288 - Fix search range for select/radio custom fields (again)

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -811,12 +811,12 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
 
       // For all select elements
       case 'Select':
-        $fieldAttributes['class'] = ltrim(($fieldAttributes['class'] ?? '') . ' crm-select2');
         if ($field->is_search_range && $search && in_array($field->data_type, $rangeDataTypes)) {
           $qf->add('text', $elementName . '_from', $label . ' ' . ts('From'), $fieldAttributes);
           $qf->add('text', $elementName . '_to', ts('To'), $fieldAttributes);
         }
         else {
+          $fieldAttributes['class'] = ltrim(($fieldAttributes['class'] ?? '') . ' crm-select2');
           if (empty($fieldAttributes['multiple'])) {
             $options = ['' => $placeholder] + $options;
           }


### PR DESCRIPTION
Overview
----------------------------------------
A description of the issue can be found at https://lab.civicrm.org/dev/core/-/issues/2288 .

Also https://github.com/civicrm/civicrm-core/pull/13314/commits has useful information.


Technical Details
----------------------------------------
The fix prevents the setting of the `crm-select2` attribute on a text field (what causes havoc on the javascript side). It just solves the problem I found at my customer. I did a small search if something comparable is done in the code, but I could not find it.

Comments
----------------------------------------
Another and maybe a better solution would be to remove the combination of search range and radio buttons. There is no easy way to configure it. So it's no accident that the tester that dit look into the change that added the `crm-select2` did overlook it. 
