### PR TITLE
Fix ts usage for CiviCRM 5.33

### DIFF
--- a/CRM/Report/Form/Contribute/SoftCredit.php
+++ b/CRM/Report/Form/Contribute/SoftCredit.php
@@ -567,7 +567,7 @@ GROUP BY   {$this->_aliases['civicrm_contribution']}.currency
           $this->_absoluteUrl
         );
         $rows[$rowNum]['civicrm_contact_display_name_creditor_link'] = $url;
-        $rows[$rowNum]['civicrm_contact_display_name_creditor_hover'] = ts("view contact summary");
+        $rows[$rowNum]['civicrm_contact_display_name_creditor_hover'] = ts("View contact summary");
       }
 
       // make subtotals look nicer

--- a/CRM/Upgrade/Incremental/php/FiveTwentyEight.php
+++ b/CRM/Upgrade/Incremental/php/FiveTwentyEight.php
@@ -58,21 +58,19 @@ class CRM_Upgrade_Incremental_php_FiveTwentyEight extends CRM_Upgrade_Incrementa
 
     $table = '<table><tbody>'
       . sprintf('<tr><th colspan="2">%s</th></tr>', ts('<b>[civicrm.files]</b> Path'))
-      . sprintf('<tr><td>%s</td><td><code>%s</code></td></tr>', ts('5.29 Default:'), wp_upload_dir()['basedir'] . DIRECTORY_SEPARATOR . 'civicrm' . DIRECTORY_SEPARATOR)
-      . sprintf('<tr><td>%s</td><td><code>%s</code></td></tr>', ts('5.28 Default:'), CRM_Core_Config::singleton()->userSystem->getDefaultFileStorage()['path'])
+      . sprintf('<tr><td>%s</td><td><code>%s</code></td></tr>', ts('5.29 Default value:'), wp_upload_dir()['basedir'] . DIRECTORY_SEPARATOR . 'civicrm' . DIRECTORY_SEPARATOR)
+      . sprintf('<tr><td>%s</td><td><code>%s</code></td></tr>', ts('5.28 Default value:'), CRM_Core_Config::singleton()->userSystem->getDefaultFileStorage()['path'])
       . sprintf('<tr><td>%s</td><td><code>%s</code></td></tr>', ts('Active Value:'), Civi::paths()->getVariable('civicrm.files', 'path'))
       . sprintf('<tr><th colspan="2">%s</th></tr>', ts('<b>[civicrm.files]</b> URL'))
-      . sprintf('<tr><td>%s</td><td><code>%s</code></td></tr>', ts('5.29 Default:'), wp_upload_dir()['baseurl'] . '/civicrm/')
-      . sprintf('<tr><td>%s</td><td><code>%s</code></td></tr>', ts('5.28 Default:'), CRM_Core_Config::singleton()->userSystem->getDefaultFileStorage()['url'])
+      . sprintf('<tr><td>%s</td><td><code>%s</code></td></tr>', ts('5.29 Default value:'), wp_upload_dir()['baseurl'] . '/civicrm/')
+      . sprintf('<tr><td>%s</td><td><code>%s</code></td></tr>', ts('5.28 Default value:'), CRM_Core_Config::singleton()->userSystem->getDefaultFileStorage()['url'])
       . sprintf('<tr><td>%s</td><td><code>%s</code></td></tr>', ts('Active Value:'), Civi::paths()->getVariable('civicrm.files', 'url'))
       . '</tbody></table>';
 
-    return '<p>' . ts('Starting with version 5.29.0, CiviCRM on WordPress may make a subtle change in the calculation of <code>[civicrm.files]</code>.
-         To ensure a smooth upgrade, please review the following table. All paths and URLs should appear the same. If there is <strong><em>any</em></strong> discrepancy,
-         then consult <a href=\'%1\' target=\'_blank\'>the upgrade documentation</a>.', [
-           1 => 'https://docs.civicrm.org/sysadmin/en/latest/upgrade/version-specific/#civicrm-5.29',
-           2 => '...wp-content/uploads/civicrm',
-         ]) . '</p>' . $table;
+    return '<p>' . ts('Starting with version 5.29.0, CiviCRM on WordPress may make a subtle change in the calculation of <code>[civicrm.files]</code>. To ensure a smooth upgrade, please review the following table. All paths and URLs should appear the same. If there is <strong><em>any</em></strong> discrepancy, then consult <a %1>the upgrade documentation</a>.', [
+      1 => 'href="https://docs.civicrm.org/sysadmin/en/latest/upgrade/version-specific/#civicrm-5.29" target="_blank"',
+      2 => '...wp-content/uploads/civicrm',
+    ]) . '</p>' . $table;
   }
 
   /*

--- a/CRM/Upgrade/Incremental/php/FiveTwentySeven.php
+++ b/CRM/Upgrade/Incremental/php/FiveTwentySeven.php
@@ -30,10 +30,7 @@ class CRM_Upgrade_Incremental_php_FiveTwentySeven extends CRM_Upgrade_Incrementa
     //   $preUpgradeMessage .= '<p>' . ts('A new permission, "%1", has been added. This permission is now used to control access to the Manage Tags screen.', array(1 => ts('manage tags'))) . '</p>';
     // }
     if ($rev == '5.27.alpha1') {
-      $preUpgradeMessage .= '<p>' . ts('Starting with version 5.28.0, CiviCRM will
-        require the PHP Internationalization extension (PHP-Intl).  In preparation
-        for this, the system check will show a warning beginning in 5.27.0 if your
-        site lacks this extension.') . '</p>';
+      $preUpgradeMessage .= '<p>' . ts('Starting with version 5.28.0, CiviCRM will require the PHP Internationalization extension (PHP-Intl). In preparation for this, the system check will show a warning beginning in 5.27.0 if your site lacks this extension.') . '</p>';
     }
   }
 

--- a/templates/CRM/Contribute/Form/Contribution.tpl
+++ b/templates/CRM/Contribute/Form/Contribution.tpl
@@ -18,13 +18,16 @@
   {if $contributionMode}
     <div class="help">
       {if $contactId && $payNow}
-        {ts 1=$displayName 2=$contributionMode|upper}Use this form to edit a contribution on behalf of %1. <strong>A
-          %2 transaction will be submitted</strong> using the selected payment processor.{/ts}
+        {ts 1=$displayName}Use this form to edit a contribution on behalf of %1.{/ts}
       {elseif $contactId}
-        {ts 1=$displayName 2=$contributionMode|upper}Use this form to submit a new contribution on behalf of %1. <strong>A
-          %2 transaction will be submitted</strong> using the selected payment processor.{/ts}
+        {ts 1=$displayName}Use this form to submit a new contribution on behalf of %1.{/ts}
       {else}
-        {ts 1=$displayName 2=$contributionMode|upper}Use this form to submit a new contribution. <strong>A %2 transaction will be submitted</strong> using the selected payment processor.{/ts}
+        {ts 1=$displayName}Use this form to submit a new contribution.{/ts}
+      {/if}
+      {if $contributionMode == 'live'}
+        <strong>A LIVE transaction will be submitted</strong> using the selected payment processor.{/ts}
+      {else}
+        <strong>A TEST transaction will be submitted</strong> using the selected payment processor.{/ts}
       {/if}
     </div>
   {/if}

--- a/templates/CRM/Member/Form/MembershipRenewal.tpl
+++ b/templates/CRM/Member/Form/MembershipRenewal.tpl
@@ -21,18 +21,23 @@
   {/if}
   {if $membershipMode}
     <div class="help">
-      {ts 1=$displayName 2=$registerMode}Use this form to Renew Membership Record on behalf of %1.
-        <strong>A %2 transaction will be submitted</strong>
-        using the selected payment processor.{/ts}
+      {ts 1=$displayName}Use this form to Renew Membership Record on behalf of %1.{/ts}
+      {if $registerMode == 'LIVE'}
+        {ts}<strong>A LIVE transaction will be submitted</strong> using the selected payment processor.{/ts}
+      {else}
+        {ts}<strong>A TEST transaction will be submitted</strong> using the selected payment processor.{/ts}
+      {/if}
     </div>
   {/if}
   {if $action eq 32768}
     {if $cancelAutoRenew}
       <div class="messages status no-popup">
         {icon icon="fa-info-circle"}{/icon}
-        <p>{ts 1=$cancelAutoRenew}This membership is set to renew automatically {if $renewalDate}on {$renewalDate|crmDate}{/if}. You will need to cancel the auto-renew option if you want to modify the Membership Type, End Date or Membership Status.
-            <a href="%1">Click here</a>
-            if you want to cancel the automatic renewal option.{/ts}</p>
+        {if $renewalDate}
+          <p>{ts 1=$cancelAutoRenew 2=$renewalDate|crmDate}This membership is set to renew automatically on %2. You will need to cancel the auto-renew option if you want to modify the Membership Type, End Date or Membership Status. <a href="%1">Click here</a> if you want to cancel the automatic renewal option.{/ts}</p>
+        {else}
+          <p>{ts 1=$cancelAutoRenew}This membership is set to renew automatically. You will need to cancel the auto-renew option if you want to modify the Membership Type, End Date or Membership Status. <a href="%1">Click here</a> if you want to cancel the automatic renewal option.{/ts}</p>
+        {/if}
       </div>
     {/if}
   {/if}


### PR DESCRIPTION
Overview
----------------------------------------

Minor fixes to translations strings, incorrect use of "ts". I'll add comments on the code to clarify.

PR against 5.33 because it's an ESR, and I will postpone updating Transifex until it's fixed.