### PR TITLE
DB changes for already-made schema changes

### DIFF
--- a/CRM/Upgrade/Incremental/php/FiveThirtyFour.php
+++ b/CRM/Upgrade/Incremental/php/FiveThirtyFour.php
@@ -70,10 +70,64 @@ class CRM_Upgrade_Incremental_php_FiveThirtyFour extends CRM_Upgrade_Incremental
 
     $this->addTask('core-issue#365 - Add effective_end_date to civicrm_action_schedule', 'addColumn',
       'civicrm_action_schedule', 'effective_end_date', "timestamp NULL COMMENT 'Latest date to consider end events from.'");
+
+    $this->addTask('Set defaults and required on financial type boolean fields', 'updateFinancialTypeTable');
+    $this->addTask('Set defaults and required on pledge fields', 'updatePledgeTable');
   }
 
-  // public static function taskFoo(CRM_Queue_TaskContext $ctx, ...) {
-  //   return TRUE;
-  // }
+  /**
+   * Update financial type table to reflect recent schema changes.
+   *
+   * @param \CRM_Queue_TaskContext $ctx
+   *
+   * @return bool
+   */
+  public static function updateFinancialTypeTable(CRM_Queue_TaskContext $ctx): bool {
+    // Make sure there are no existing NULL values in the fields we are about to make required.
+    CRM_Core_DAO::executeQuery('
+      UPDATE civicrm_financial_type
+      SET is_active = COALESCE(is_active, 0),
+          is_reserved = COALESCE(is_reserved, 0),
+          is_deductible = COALESCE(is_deductible, 0)
+      WHERE is_reserved IS NULL OR is_active IS NULL OR is_deductible IS NULL
+    ');
+    CRM_Core_DAO::executeQuery("
+      ALTER TABLE civicrm_financial_type
+      MODIFY COLUMN `is_deductible` tinyint(4) DEFAULT 0 NOT NULL COMMENT 'Is this financial type tax-deductible? If true, contributions of this type may be fully OR partially deductible - non-deductible amount is stored in the Contribution record.',
+      MODIFY COLUMN `is_reserved` tinyint(4) DEFAULT 0 NOT NULL COMMENT 'Is this a predefined system object?',
+      MODIFY COLUMN `is_active` tinyint(4) DEFAULT 1 NOT NULL COMMENT 'Is this property active?'
+    ");
+
+    return TRUE;
+  }
+
+  /**
+   * Update pledge table to reflect recent schema changes making fields required.
+   *
+   * @param \CRM_Queue_TaskContext $ctx
+   *
+   * @return bool
+   */
+  public static function updatePledgeTable(CRM_Queue_TaskContext $ctx): bool {
+    // Make sure there are no existing NULL values in the fields we are about to make required.
+    CRM_Core_DAO::executeQuery('
+      UPDATE civicrm_pledge
+      SET is_test = COALESCE(is_test, 0),
+          frequency_unit = COALESCE(frequency_unit, "month"),
+          # Cannot imagine this would be null but if it were...
+          installments = COALESCE(installments, 0),
+          # this does not seem plausible either.
+          status_id = COALESCE(status_id, 1)
+      WHERE is_test IS NULL OR frequency_unit IS NULL OR installments IS NULL OR status_id IS NULL
+    ');
+    CRM_Core_DAO::executeQuery("
+      ALTER TABLE civicrm_pledge
+      MODIFY COLUMN `frequency_unit` varchar(8) DEFAULT 'month' NOT NULL COMMENT 'Time units for recurrence of pledge payments.',
+      MODIFY COLUMN `installments` int(10) unsigned DEFAULT 1 NOT NULL COMMENT 'Total number of payments to be made.',
+      MODIFY COLUMN `status_id` int(10) unsigned NOT NULL COMMENT 'Implicit foreign key to civicrm_option_values in the pledge_status option group.',
+      MODIFY COLUMN `is_test` tinyint(4) DEFAULT 0 NOT NULL
+    ");
+    return TRUE;
+  }
 
 }


### PR DESCRIPTION

Overview
----------------------------------------
Alters financial type schema by making the following boolean fields required:
is_reserved (default 0)
is_deductible (default 0)
is_active (default 1)

And pledge schema
installments (default 1)
status (no default)
is_test (default 0)
frequency_unit (default 'month')

Before
----------------------------------------
Above changes have been altered in new installs but not updated in existing installs

After
----------------------------------------
existing installs will be updated

Technical Details
----------------------------------------
Completes work started in #19281 & continued in  https://github.com/civicrm/civicrm-core/pull/19296  and work started in #19309

Comments
----------------------------------------
@colemanw @seamuslee001 