### PR TITLE
dev/core#2288 - Alternative fix search range for select/radio custom fields - now disabling the combination

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -812,27 +812,22 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
       // For all select elements
       case 'Select':
         $fieldAttributes['class'] = ltrim(($fieldAttributes['class'] ?? '') . ' crm-select2');
-        if ($field->is_search_range && $search && in_array($field->data_type, $rangeDataTypes)) {
-          $qf->add('text', $elementName . '_from', $label . ' ' . ts('From'), $fieldAttributes);
-          $qf->add('text', $elementName . '_to', ts('To'), $fieldAttributes);
-        }
-        else {
-          if (empty($fieldAttributes['multiple'])) {
-            $options = ['' => $placeholder] + $options;
-          }
-          $element = $qf->add('select', $elementName, $label, $options, $useRequired && !$search, $fieldAttributes);
 
-          // Add and/or option for fields that store multiple values
-          if ($search && self::isSerialized($field)) {
-            $qf->addRadio($elementName . '_operator', '', [
-              'or' => ts('Any'),
-              'and' => ts('All'),
-            ], [], NULL, FALSE, [
-              'or' => ['title' => ts('Results may contain any of the selected options')],
-              'and' => ['title' => ts('Results must have all of the selected options')],
-            ]);
-            $qf->setDefaults([$elementName . '_operator' => 'or']);
-          }
+        if (empty($fieldAttributes['multiple'])) {
+          $options = ['' => $placeholder] + $options;
+        }
+        $element = $qf->add('select', $elementName, $label, $options, $useRequired && !$search, $fieldAttributes);
+
+        // Add and/or option for fields that store multiple values
+        if ($search && self::isSerialized($field)) {
+          $qf->addRadio($elementName . '_operator', '', [
+            'or' => ts('Any'),
+            'and' => ts('All'),
+          ], [], NULL, FALSE, [
+            'or' => ['title' => ts('Results may contain any of the selected options')],
+            'and' => ['title' => ts('Results must have all of the selected options')],
+          ]);
+          $qf->setDefaults([$elementName . '_operator' => 'or']);
         }
         break;
 
@@ -929,7 +924,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
     switch ($field->data_type) {
       case 'Int':
         // integers will have numeric rule applied to them.
-        if ($field->is_search_range && $search) {
+        if ($field->is_search_range && $search && $widget != 'Select') {
           $qf->addRule($elementName . '_from', ts('%1 From must be an integer (whole number).', [1 => $label]), 'integer');
           $qf->addRule($elementName . '_to', ts('%1 To must be an integer (whole number).', [1 => $label]), 'integer');
         }

--- a/CRM/Custom/Form/Field.php
+++ b/CRM/Custom/Form/Field.php
@@ -836,7 +836,7 @@ AND    option_group_id = %2";
 
     //fix for 'is_search_range' field.
     if (in_array($params['data_type'], ['Int', 'Float', 'Money', 'Date'])) {
-      if (empty($params['is_searchable'])) {
+      if (empty($params['is_searchable']) || in_array($params['html_type'], ['Radio', 'Select'])) {
         $params['is_search_range'] = 0;
       }
     }

--- a/templates/CRM/Case/Form/Search/Common.tpl
+++ b/templates/CRM/Case/Form/Search/Common.tpl
@@ -58,8 +58,8 @@
   <tr>
     <td colspan="3">{include file="CRM/common/Tagset.tpl" tagsetType='case'}</td>
   </tr>
+
   {if $caseGroupTree}
-    <tr> <td colspan="3">Keboom</td></tr>
     <tr>
       <td colspan="3">
         {include file="CRM/Custom/Form/Search.tpl" groupTree=$caseGroupTree showHideLinks=false}

--- a/templates/CRM/Case/Form/Search/Common.tpl
+++ b/templates/CRM/Case/Form/Search/Common.tpl
@@ -58,8 +58,8 @@
   <tr>
     <td colspan="3">{include file="CRM/common/Tagset.tpl" tagsetType='case'}</td>
   </tr>
-
   {if $caseGroupTree}
+    <tr> <td colspan="3">Keboom</td></tr>
     <tr>
       <td colspan="3">
         {include file="CRM/Custom/Form/Search.tpl" groupTree=$caseGroupTree showHideLinks=false}


### PR DESCRIPTION
Overview
----------------------------------------
This is an alternative fix for  https://github.com/civicrm/civicrm-core/pull/19332 . 

It follows a different assumption. PR 19332 assumes the combination search range and radio buttons makes sense, and it must be fixed. This PR argues it does make less sense and disallows it. It makes saving this combination impossible.  

Technical
----------------------------------------
The range code from the template is also removed. It cannot be used anymore.

Comments
---------------------------------------
There maybe some users that have this combination in use. The effect of the patch is that the field will disappear in the screen. Opening the definition and saving it will solve the problem





