### PR TITLE
dev/core#2258 - Define CIVICRM_CRED_KEYS during installation

### DIFF
--- a/Civi/Crypto/CryptoRegistry.php
+++ b/Civi/Crypto/CryptoRegistry.php
@@ -66,7 +66,7 @@ class CryptoRegistry {
     $registry->addCipherSuite(new \Civi\Crypto\PhpseclibCipherSuite());
 
     $registry->addPlainText(['tags' => ['CRED']]);
-    if (defined('CIVICRM_CRED_KEYS')) {
+    if (defined('CIVICRM_CRED_KEYS') && CIVICRM_CRED_KEYS !== '') {
       foreach (explode(' ', CIVICRM_CRED_KEYS) as $n => $keyExpr) {
         $key = ['tags' => ['CRED'], 'weight' => $n];
         if ($keyExpr === 'plain') {

--- a/setup/plugins/installFiles/GenerateCredKey.civi-setup.php
+++ b/setup/plugins/installFiles/GenerateCredKey.civi-setup.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * @file
+ *
+ * Generate the credential key(s).
+ */
+
+if (!defined('CIVI_SETUP')) {
+  exit("Installation plugins must only be loaded by the installer.\n");
+}
+
+\Civi\Setup::dispatcher()
+  ->addListener('civi.setup.installFiles', function (\Civi\Setup\Event\InstallFilesEvent $e) {
+    \Civi\Setup::log()->info(sprintf('[%s] Handle %s', basename(__FILE__), 'installFiles'));
+
+    $toAlphanum = function($bits) {
+      return preg_replace(';[^a-zA-Z0-9];', '', base64_encode($bits));
+    };
+
+  if (empty($e->getModel()->credKeys)) {
+    $e->getModel()->credKeys = ['aes-cbc:hkdf-sha256:' . $toAlphanum(random_bytes(32))];
+  }
+
+  if (is_string($e->getModel()->credKeys)) {
+    $e->getModel()->credKeys = [$e->getModel()->credKeys];
+  }
+
+    \Civi\Setup::log()->info(sprintf('[%s] Done %s', basename(__FILE__), 'installFiles'));
+
+  }, \Civi\Setup::PRIORITY_PREPARE);

--- a/setup/plugins/installFiles/InstallSettingsFile.civi-setup.php
+++ b/setup/plugins/installFiles/InstallSettingsFile.civi-setup.php
@@ -98,6 +98,7 @@ if (!defined('CIVI_SETUP')) {
     // need to use %20 for spaces.
     $params['CMSdbSSL'] = empty($m->cmsDb['ssl_params']) ? '' : addslashes('&' . http_build_query($m->cmsDb['ssl_params'], '', '&', PHP_QUERY_RFC3986));
     $params['siteKey'] = addslashes($m->siteKey);
+    $params['credKeys'] = addslashes(implode(' ', $m->credKeys));
 
     $extraSettings = array();
 

--- a/setup/src/Setup/Model.php
+++ b/setup/src/Setup/Model.php
@@ -28,6 +28,8 @@ namespace Civi\Setup;
  *   Ex: ['server'=>'localhost:3306', 'username'=>'admin', 'password'=>'s3cr3t', 'database'=>'mydb']
  * @property string $siteKey
  *   Ex: 'abcd1234ABCD9876'.
+ * @property string[] $credKeys
+ *   Ex: ['::abcd1234ABCD9876'].
  * @property string|NULL $lang
  *   The language of the default dataset.
  *   Ex: 'fr_FR'.
@@ -108,6 +110,11 @@ class Model {
       'description' => 'Site key',
       'name' => 'siteKey',
       'type' => 'string',
+    ));
+    $this->addField(array(
+      'description' => 'Credential encryption keys',
+      'name' => 'credKeys',
+      'type' => 'array',
     ));
     $this->addField(array(
       'description' => 'Load example data',

--- a/templates/CRM/common/civicrm.settings.php.template
+++ b/templates/CRM/common/civicrm.settings.php.template
@@ -301,6 +301,30 @@ if (!defined('CIVICRM_SITE_KEY')) {
 }
 
 /**
+ * If credentials are stored in the database, the CIVICRM_CRED_KEYS will be
+ * used to encrypt+decrypt them. This is a space-delimited list of keys (ordered by
+ * priority). Put the preferred key first. Any old/deprecated keys may be
+ * listed after.
+ *
+ * Each key is in format "<cipher-suite>:<key-encoding>:<key-content>", as in:
+ *
+ * Ex: define('CIVICRM_CRED_KEYS', 'aes-cbc:hkdf-sha256:RANDOM_1')
+ * Ex: define('CIVICRM_CRED_KEYS', 'aes-ctr-hs:b64:RANDOM_2 aes-ctr-hs:b64:RANDOM_3')
+ * Ex: define('CIVICRM_CRED_KEYS', '::MY_NEW_KEY ::MY_OLD_KEY')
+ *
+ * If cipher-suite or key-encoding is blank, they will use defaults ("aes-cbc"
+ * and "hkdf-sha256", respectively).
+ *
+ * More info at https://docs.civicrm.org/sysadmin/en/latest/setup/cred-key/
+ */
+if (!defined('CIVICRM_CRED_KEYS') ) {
+  define( '_CIVICRM_CRED_KEYS', '%%credKeys%%');
+  define( 'CIVICRM_CRED_KEYS', _CIVICRM_CRED_KEYS === '%%' . 'credKeys' . '%%' ? '' : _CIVICRM_CRED_KEYS );
+  // Some old installers may not set a decent value, and this extra complexity is a failsafe.
+  // Feel free to simplify post-install.
+}
+
+/**
  * Enable this constant, if you want to send your email through the smarty
  * templating engine(allows you to do conditional and more complex logic)
  *


### PR DESCRIPTION
Overview
----------------------------------------

The constant `CIVICRM_CRED_KEYS` (introduced in #19236) may be used to specify an encryption-key for credentials stored in the database. This PR updates the installer to define `CIVICRM_CRED_KEYS` by default.

See also: https://lab.civicrm.org/dev/core/-/issues/2258

Before
----------------------------------------

New installations do not have `CIVICRM_CRED_KEYS` in `civicrm.settings.php`.

After
----------------------------------------

Some new installations have `CIVICRM_CRED_KEYS`

* Working -- Installations based on `civicrm-setup`, i.e. web-based installs on Drupal/Backdrop/WordPress and cv-based installs.
* TODO -- Installations based on civibuild, drush, Joomla, and wp-cli. The relevant code is not in this repo and will require separate updates. For the moment, the `civicrm.settings.php` degrades gracefully. (If an installer doesn't specify `%%credKeys%%`, then it will be left blank.)

Comments
----------------------------------------

#19239 already added an upgrade notification about `CIVICRM_CRED_KEYS`.

For testing, I used these installation procedures

* Run `civibuild reinstall dmaster`. (This has an unpatched installer. It degrades gracefully, yielding a blank `CIVICRM_CRED_KEYS`.)
* Take an existing `dmaster`. Uninstall (`cv core:uninstall -f`). Then use the web-based installer. This yields a random `CIVICRM_CRED_KEYS`.
* Take an existing `dmaster`.  Uninstall (`cv core:uninstall -f`). Then install via CLI (`cv core:install --cms-base-url=... --db=...`). This yields a random `CIVICRM_CRED_KEYS`

To determine if the installer worked, you can both:

* Read `civicrm.settings.php` and search for `CIVICRM_CRED_KEYS`; and...
* Run this command:
    ```
    cv ev 'print_r(Civi::service("crypto.registry")->getKeys()); print_r([CIVICRM_CRED_KEYS]);'
    ```