### PR TITLE
[NFC] Fix Contribution Soft Credit entity translation

### DIFF
--- a/CRM/Contribute/DAO/ContributionSoft.php
+++ b/CRM/Contribute/DAO/ContributionSoft.php
@@ -110,7 +110,7 @@ class CRM_Contribute_DAO_ContributionSoft extends CRM_Core_DAO {
    *   Whether to return the plural version of the title.
    */
   public static function getEntityTitle($plural = FALSE) {
-    return $plural ? ts('Contribution Softs') : ts('Contribution Soft');
+    return $plural ? ts('Contribution Soft Credits') : ts('Contribution Soft Credit');
   }
 
   /**

--- a/CRM/Mailing/DAO/Recipients.php
+++ b/CRM/Mailing/DAO/Recipients.php
@@ -79,7 +79,7 @@ class CRM_Mailing_DAO_Recipients extends CRM_Core_DAO {
    *   Whether to return the plural version of the title.
    */
   public static function getEntityTitle($plural = FALSE) {
-    return $plural ? ts('Recipientses') : ts('Recipients');
+    return $plural ? ts('Recipients') : ts('Recipient');
   }
 
   /**

--- a/CRM/Mailing/Event/DAO/Delivered.php
+++ b/CRM/Mailing/Event/DAO/Delivered.php
@@ -65,7 +65,7 @@ class CRM_Mailing_Event_DAO_Delivered extends CRM_Core_DAO {
    *   Whether to return the plural version of the title.
    */
   public static function getEntityTitle($plural = FALSE) {
-    return $plural ? ts('Delivereds') : ts('Delivered');
+    return $plural ? ts('Mailing Delivered Events') : ts('Mailing Delivered Event');
   }
 
   /**

--- a/CRM/Mailing/Event/DAO/Opened.php
+++ b/CRM/Mailing/Event/DAO/Opened.php
@@ -65,7 +65,7 @@ class CRM_Mailing_Event_DAO_Opened extends CRM_Core_DAO {
    *   Whether to return the plural version of the title.
    */
   public static function getEntityTitle($plural = FALSE) {
-    return $plural ? ts('Openeds') : ts('Opened');
+    return $plural ? ts('Mailing Opened Events') : ts('Mailing Opened Event');
   }
 
   /**

--- a/xml/schema/Contribute/ContributionSoft.xml
+++ b/xml/schema/Contribute/ContributionSoft.xml
@@ -4,9 +4,13 @@
   <base>CRM/Contribute</base>
   <class>ContributionSoft</class>
   <name>civicrm_contribution_soft</name>
+  <title>Contribution Soft Credit</title>
+  <titlePlural>Contribution Soft Credits</titlePlural>
   <add>2.2</add>
   <log>true</log>
   <component>CiviContribute</component>
+  <title>Contribution Soft Credit</title>
+  <titlePlural>Contribution Soft Credits</titlePlural>
   <field>
     <name>id</name>
     <uniqueName>contribution_soft_id</uniqueName>

--- a/xml/schema/Contribute/PremiumsProduct.xml
+++ b/xml/schema/Contribute/PremiumsProduct.xml
@@ -8,6 +8,8 @@
   <add>1.4</add>
   <log>true</log>
   <component>CiviContribute</component>
+  <title>Product Premium</title>
+  <titlePlural>Product Premiums</titlePlural>
   <field>
     <name>id</name>
     <title>Premium Product ID</title>

--- a/xml/schema/Mailing/Event/Bounce.xml
+++ b/xml/schema/Mailing/Event/Bounce.xml
@@ -7,6 +7,8 @@
   <comment>Tracks when and why an email bounced.</comment>
   <archive>true</archive>
   <component>CiviMail</component>
+  <title>Mailing Bounce Event</title>
+  <titlePlural>Mailing Bounce Events</titlePlural>
   <field>
     <name>id</name>
     <title>Bounce ID</title>

--- a/xml/schema/Mailing/Event/Confirm.xml
+++ b/xml/schema/Mailing/Event/Confirm.xml
@@ -7,6 +7,8 @@
   <comment>Tracks when a subscription event is confirmed by email</comment>
   <archive>true</archive>
   <component>CiviMail</component>
+  <title>Mailing Confirmation Event</title>
+  <titlePlural>Mailing Contribution Events</titlePlural>
   <field>
     <name>id</name>
     <title>Mailing Confirmation ID</title>

--- a/xml/schema/Mailing/Event/Delivered.xml
+++ b/xml/schema/Mailing/Event/Delivered.xml
@@ -7,6 +7,8 @@
   <comment>Tracks when a queued email is actually delivered to the MTA</comment>
   <archive>true</archive>
   <component>CiviMail</component>
+  <title>Mailing Delivery Event</title>
+  <titlePlural>Mailing Delivery Events</titlePlural>
   <field>
     <name>id</name>
     <title>Delivered ID</title>

--- a/xml/schema/Mailing/Event/Forward.xml
+++ b/xml/schema/Mailing/Event/Forward.xml
@@ -7,6 +7,8 @@
   <comment>Tracks when a contact forwards a mailing to a (new) contact</comment>
   <archive>true</archive>
   <component>CiviMail</component>
+  <title>Mailing Forwarded Event</title>
+  <titlePlural>Mailing Forwarded Events</titlePlural>
   <field>
     <name>id</name>
     <title>Forward ID</title>

--- a/xml/schema/Mailing/Event/Opened.xml
+++ b/xml/schema/Mailing/Event/Opened.xml
@@ -7,6 +7,8 @@
   <comment>Tracks when a delivered email is opened by the recipient</comment>
   <archive>true</archive>
   <component>CiviMail</component>
+  <title>Mailing Opened Event</title>
+  <titlePlural>Mailing Opened Events</titlePlural>
   <field>
     <name>id</name>
     <title>Mailing Opened ID</title>

--- a/xml/schema/Mailing/Event/Queue.xml
+++ b/xml/schema/Mailing/Event/Queue.xml
@@ -7,6 +7,8 @@
   <comment>A collection of all intended recipients of a job</comment>
   <archive>true</archive>
   <component>CiviMail</component>
+  <title>Mailing Queue Event</title>
+  <titlePlural>Mailing Queue Events</titlePlural>
   <field>
     <name>id</name>
     <type>int unsigned</type>


### PR DESCRIPTION
Overview
----------------------------------------

Fixes a string that is not valid English, and therefore confusing to translators.

Before / After
----------------------------------------

Entity "Contribution Softs" renamed to "Contribution Soft Credits".

ping @colemanw I think you may have added this string. Was there a length issue that required a shorter string?

Reported by @r4zoli on mattermost