### PR TITLE
php 7.4 compatiblity - Clarify order for nested ternary operator

### DIFF
--- a/ext/afform/core/Civi/Api4/Utils/AfformSaveTrait.php
+++ b/ext/afform/core/Civi/Api4/Utils/AfformSaveTrait.php
@@ -16,7 +16,7 @@ trait AfformSaveTrait {
 
     // If no name given, create a unique name based on the title
     if (empty($item['name'])) {
-      $prefix = !empty($item['join']) ? "afjoin-{$item['join']}" : !empty($item['block']) ? 'afblock-' . str_replace('*', 'all', $item['block']) : 'afform';
+      $prefix = !empty($item['join']) ? "afjoin-{$item['join']}" : (!empty($item['block']) ? ('afblock-' . str_replace('*', 'all', $item['block'])) : 'afform');
       $item['name'] = _afform_angular_module_name($prefix . '-' . \CRM_Utils_String::munge($item['title'], '-'));
       $suffix = '';
       while (


### PR DESCRIPTION
Overview
----------------------------------------
In php 7.4 you need to be more specific about the order when `a ? b : c` is nested. Also this one has the dot string concatenation operator in there too.