### PR TITLE
dev/core#2292 - Add Timeline dropdown on Manage Case not working after buttons UI changes

### DIFF
--- a/CRM/Case/Form/CaseView.php
+++ b/CRM/Case/Form/CaseView.php
@@ -425,7 +425,7 @@ class CRM_Case_Form_CaseView extends CRM_Core_Form {
     $session = CRM_Core_Session::singleton();
     $session->pushUserContext($url);
 
-    if (!empty($params['timeline_id']) && !empty($_POST['_qf_CaseView_next'])) {
+    if (!empty($params['timeline_id']) && $buttonName == '_qf_CaseView_next') {
       civicrm_api3('Case', 'addtimeline', [
         'case_id' => $this->_caseID,
         'timeline' => $params['timeline_id'],


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/2292

The dropdown works by clicking a hidden button when you change the value. The button name no longer submits the same way in $_POST.

Before
----------------------------------------
Add timeline appears to submit but nothing is added.

After
----------------------------------------
Works

Technical Details
----------------------------------------

Comments
----------------------------------------
