### PR TITLE
distmaker - Don't require dummy config file for building Joomla

### DIFF
--- a/distmaker/utils/joomlaxml.php
+++ b/distmaker/utils/joomlaxml.php
@@ -33,7 +33,12 @@ else {
 ini_set('include_path',
   "{$sourceCheckoutDir}:{$sourceCheckoutDir}/packages:" . ini_get('include_path')
 );
-require_once "$sourceCheckoutDir/civicrm.config.php";
+
+define('CIVICRM_UF', 'Joomla');
+$GLOBALS['civicrm_root'] = $sourceCheckoutDir;
+require_once $sourceCheckoutDir . '/CRM/Core/ClassLoader.php';
+CRM_Core_ClassLoader::singleton()->register();
+
 require_once 'Smarty/Smarty.class.php';
 
 generateJoomlaConfig($version);

--- a/distmaker/utils/joomlaxml.php
+++ b/distmaker/utils/joomlaxml.php
@@ -1,34 +1,9 @@
 <?php
 
-if (isset($GLOBALS['_SERVER']['DM_SOURCEDIR'])) {
-  $sourceCheckoutDir = $GLOBALS['_SERVER']['DM_SOURCEDIR'];
-}
-else {
-  $sourceCheckoutDir = $argv[1];
-}
-$sourceCheckoutDirLength = strlen($sourceCheckoutDir);
-
-if (isset($GLOBALS['_SERVER']['DM_TMPDIR'])) {
-  $targetDir = $GLOBALS['_SERVER']['DM_TMPDIR'] . '/com_civicrm';
-}
-else {
-  $targetDir = $argv[2];
-}
-$targetDirLength = strlen($targetDir);
-
-if (isset($GLOBALS['_SERVER']['DM_VERSION'])) {
-  $version = $GLOBALS['_SERVER']['DM_VERSION'];
-}
-else {
-  $version = $argv[3];
-}
-
-if (isset($GLOBALS['_SERVER']['DM_PKGTYPE'])) {
-  $pkgType = $GLOBALS['_SERVER']['DM_PKGTYPE'];
-}
-else {
-  $pkgType = $argv[4];
-}
+$sourceCheckoutDir = $GLOBALS['_SERVER']['DM_SOURCEDIR'] ?? $argv[1];
+$targetDir = $GLOBALS['_SERVER']['DM_TMPDIR'] . '/com_civicrm' ?? $argv[2];
+$version = $GLOBALS['_SERVER']['DM_VERSION'] ?? $argv[3];
+$pkgType = $GLOBALS['_SERVER']['DM_PKGTYPE'] ?? $argv[4];
 
 ini_set('include_path',
   "{$sourceCheckoutDir}:{$sourceCheckoutDir}/packages:" . ini_get('include_path')


### PR DESCRIPTION
Overview
----------------------------------------

This addresses a quirky requirement in the workflow for building Civi-Joomla.

Before
----------------------------------------

To run distmaker and produce Joomla ZIPs, you need to create two dummy files.

For example, this is how `cividist` does it: https://github.com/civicrm/civicrm-buildkit/blob/v19.07.0/bin/cividist#L119-L121

It seems that is just a long-winded way of setting up the Civi classloader. (It wouldn't make sense to use any other Civi services as this is a pre-bootstrap environment.)

After
----------------------------------------

The dummy file is neither needed nor used. We just get the classloader directly.
