### PR TITLE
dev/core#2241 - Deprecate direct calls to isDevelopment()

### DIFF
--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -1829,6 +1829,7 @@ class CRM_Utils_System {
   }
 
   /**
+   * @deprecated
    * Determine whether this system is deployed using version control.
    *
    * Normally sites would tune their php error settings to prevent deprecation
@@ -1844,6 +1845,7 @@ class CRM_Utils_System {
    * @return bool
    */
   public static function isDevelopment() {
+    CRM_Core_Error::deprecatedWarning('isDevelopment() is deprecated. Set your php error_reporting or MySQL settings appropriately instead.');
     static $cache = NULL;
     if ($cache === NULL) {
       global $civicrm_root;

--- a/api/v3/System.php
+++ b/api/v3/System.php
@@ -238,7 +238,7 @@ function civicrm_api3_system_get($params) {
       ],
       'civi' => [
         'version' => CRM_Utils_System::version(),
-        'dev' => (bool) CRM_Utils_System::isDevelopment(),
+        'dev' => (\Civi::settings()->get('environment') === 'Development'),
         'components' => array_keys(CRM_Core_Component::getEnabledComponents()),
         'extensions' => preg_grep('/^uninstalled$/', CRM_Extension_System::singleton()->getManager()->getStatuses(), PREG_GREP_INVERT),
         'multidomain' => CRM_Core_DAO::singleValueQuery('SELECT count(*) FROM civicrm_domain') > 1,


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/2241

There's only one (real) use of isDevelopment left that I can find in universe and it's that api3 System.get [returns a 'dev' element](https://github.com/civicrm/civicrm-core/blob/4ebb255dbfbb3350c64891f1a1ec84468fc1c00c/api/v3/System.php#L241) that calls this function. Checking universe for where that 'dev' return value is used is a little more difficult, but even with some creative grepping I can't find any real uses of it.

So, the tricky part is that while making isDevelopment() give a deprecation notice is straightforward, making just _uses_ of the 'dev' element give one is escaping me. I.e. all calls to System.get would give the notice whether they use the 'dev' element in the return value or not. This is what I've come up with.

Before
----------------------------------------
Probably unused function. It's known to no longer be _directly_ called in universe.

After
----------------------------------------
Probably unused function, with at least direct calls giving a deprecation notice.

Technical Details
----------------------------------------
Long discussion in lab ticket if interested.

Comments
----------------------------------------

