### PR TITLE
Use php to require an array

### DIFF
--- a/CRM/Activity/Import/Parser.php
+++ b/CRM/Activity/Import/Parser.php
@@ -44,7 +44,7 @@ abstract class CRM_Activity_Import_Parser extends CRM_Import_Parser {
   protected $_haveColumnHeader;
 
   /**
-   * @param string $fileName
+   * @param array $fileName
    * @param string $separator
    * @param $mapper
    * @param bool $skipColumnHeader
@@ -57,7 +57,7 @@ abstract class CRM_Activity_Import_Parser extends CRM_Import_Parser {
    * @throws Exception
    */
   public function run(
-    $fileName,
+    array $fileName,
     $separator = ',',
     &$mapper,
     $skipColumnHeader = FALSE,
@@ -66,9 +66,7 @@ abstract class CRM_Activity_Import_Parser extends CRM_Import_Parser {
     $statusID = NULL,
     $totalRowCount = NULL
   ) {
-    if (!is_array($fileName)) {
-      throw new CRM_Core_Exception('Unable to determine import file');
-    }
+
     $fileName = $fileName['name'];
 
     $this->init();


### PR DESCRIPTION
Overview
----------------------------------------
Removes is_array check in favour of php strict typing

Before
----------------------------------------
lines of code to check if fileName is an array

After
----------------------------------------
strict typing

Technical Details
----------------------------------------

To be clear - there is no reason why it shouldn't be an array - in the bad old days a lot of error handling was put in to help developers who didn't have good debug tools

Comments
----------------------------------------