### PR TITLE
[REF] Simplify activity import validation

### DIFF
--- a/CRM/Activity/Import/Form/MapField.php
+++ b/CRM/Activity/Import/Form/MapField.php
@@ -265,7 +265,7 @@ class CRM_Activity_Import_Form_MapField extends CRM_Import_Form_MapField {
       $contactFieldsBelowWeightMessage = self::validateRequiredContactMatchFields('Individual', $importKeys);
       foreach ($requiredFields as $field => $title) {
         if (!in_array($field, $importKeys)) {
-          if ($field == 'target_contact_id') {
+          if ($field === 'target_contact_id') {
             if (!$contactFieldsBelowWeightMessage || in_array('external_identifier', $importKeys)) {
               continue;
             }
@@ -275,7 +275,7 @@ class CRM_Activity_Import_Form_MapField extends CRM_Import_Form_MapField {
                 . '<br />';
             }
           }
-          elseif ($field == 'activity_type_id') {
+          elseif ($field === 'activity_type_id') {
             if (in_array('activity_label', $importKeys)) {
               continue;
             }


### PR DESCRIPTION
Overview
----------------------------------------

[REF] Simplify activity import validation

Before
----------------------------------------
Validation of field mapping done in 2 places

After
----------------------------------------

Validation of field mapping done in just 1 place

Technical Details
----------------------------------------
There are 2 types of validation on importing
1) the correct fields have been mapped
2) the specific row has all the required fields

These generally live in different places
- field mapping is validated on the MapField::formRule validation function
- the specific row is validated in the (badly named) 'summary' function.

However, the second function is also doing some validation of the
mapping, checking that either activity_type_id or label is mapped
& ditto activity_date_time. This duplicates the MapField rule
and is hard to read, while making a larger cleanup difficult

Comments
----------------------------------------
