### PR TITLE
check admin menu from admin menu module is present before hiding CiviCRM menu toggle button

### DIFF
--- a/js/crm.drupal7.js
+++ b/js/crm.drupal7.js
@@ -11,7 +11,7 @@
     $(document).ready(function () {
       setTimeout(function () {
         if (!$('#toolbar').length) {
-          // check admin menu with different id present before remoding toggle button.
+          // check admin menu with different id present before removing toggle button.
           if (!$('#admin-menu').length) {
             CRM.menubar.removeToggleButton();
           }

--- a/js/crm.drupal7.js
+++ b/js/crm.drupal7.js
@@ -8,11 +8,17 @@
    * Hides the Menu Toggle Button when the Admin Menu is not available for the user.
    */
   function hideMenuToggleButtonForNonAdminUsers() {
-    $(document).ready(function() {
-      if (!$('#toolbar').length) {
-        CRM.menubar.removeToggleButton();
-      }
+    $(document).ready(function () {
+      setTimeout(function () {
+        if (!$('#toolbar').length) {
+          // check admin menu with different id present before remoding toggle button.
+          if (!$('#admin-menu').length) {
+            CRM.menubar.removeToggleButton();
+          }
+        }
+    }, 2000);
     });
   }
 
 })(CRM.$);
+

--- a/js/crm.drupal7.js
+++ b/js/crm.drupal7.js
@@ -9,14 +9,12 @@
    */
   function hideMenuToggleButtonForNonAdminUsers() {
     $(document).ready(function () {
-      setTimeout(function () {
-        if (!$('#toolbar').length) {
+      setTimeout(function() {
+        if (!($('#toolbar').length || $('#admin-menu').length)) {
           // check admin menu with different id present before removing toggle button.
-          if (!$('#admin-menu').length) {
-            CRM.menubar.removeToggleButton();
-          }
+          CRM.menubar.removeToggleButton();
         }
-    }, 2000);
+      }, 1000);
     });
   }
 


### PR DESCRIPTION

Overview
----------------------------------------
Drupal 7 provide Toolbar module to show the admin menus, but does not provide drop down option of sub menus on mouse over. There is another module which is commonly used is 'Admin Menu' which provide sub menu selection on mouse hover.

In CiviCRM, We have feature to toggle CiviCRM Menu if Drupal Admin menus are present. To check Drupal menu exist or not we refer `toolbar` module id `#toolbar`, In case site admin not using `toolbar` module and instead using 'Admin Menu' module. 

The `Admin menu` generate different id `#admin-menu`, But civicrm only checking for `#toolbar`.

So even admin menu are present CiviCRM hide the toggle button and also hide the Drupal menu.

These change make sure to check first `#toolbar` is exist, if  `#toolbar` is not present then it look for `#admin-menu`, If both not found then it hide the toggle button and Drupal Menu too.

Before
----------------------------------------
Toggle but was missing.
<img width="841" alt="Screenshot 2021-01-13 at 7 53 33 PM" src="https://user-images.githubusercontent.com/377735/104465694-53acd800-55da-11eb-825e-8e652c19f23d.png">


After
----------------------------------------
Toggle button is present
