### PR TITLE
Fix naming regression dev/core#2298

### DIFF
--- a/CRM/Grant/Export/Form/Map.php
+++ b/CRM/Grant/Export/Form/Map.php
@@ -18,6 +18,6 @@
 /**
  * This class gets the name of the file to upload
  */
-class CRM_Pledge_Export_Form_Map extends CRM_Export_Form_Map {
+class CRM_Grant_Export_Form_Map extends CRM_Export_Form_Map {
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/2298

Before
----------------------------------------
The class `CRM_Grant_Export_Form_Map` is misnamed.

After
----------------------------------------

The class `CRM_Grant_Export_Form_Map` is named properly.
