### PR TITLE
"Admin => Misc" - Fix validation of "Maximum File Size"

### DIFF
--- a/CRM/Admin/Form/Setting/Miscellaneous.php
+++ b/CRM/Admin/Form/Setting/Miscellaneous.php
@@ -102,7 +102,7 @@ class CRM_Admin_Form_Setting_Miscellaneous extends CRM_Admin_Form_Setting {
     $inputBytes = CRM_Utils_Number::formatUnitSize($fields['maxFileSize'] . 'M', FALSE);
 
     if ($inputBytes > $iniBytes) {
-      $errors['maxFileSize'] = ts("Maximum file size cannot exceed limit defined in \"php.ini\" (\"upload_max_filesize=%1\") .", [
+      $errors['maxFileSize'] = ts("Maximum file size cannot exceed limit defined in \"php.ini\" (\"upload_max_filesize=%1\").", [
         1 => ini_get('upload_max_filesize'),
       ]);
     }

--- a/CRM/Admin/Form/Setting/Miscellaneous.php
+++ b/CRM/Admin/Form/Setting/Miscellaneous.php
@@ -44,13 +44,10 @@ class CRM_Admin_Form_Setting_Miscellaneous extends CRM_Admin_Form_Setting {
     'prevNextBackend' => CRM_Core_BAO_Setting::SEARCH_PREFERENCES_NAME,
   ];
 
-  public $_uploadMaxSize;
-
   /**
    * Basic setup.
    */
   public function preProcess() {
-    $this->_uploadMaxSize = (int) ini_get('upload_max_filesize');
     // check for post max size
     CRM_Utils_Number::formatUnitSize(ini_get('post_max_size'), TRUE);
     // This is a temp hack for the fact we really don't need to hard-code each setting in the tpl but
@@ -101,8 +98,13 @@ class CRM_Admin_Form_Setting_Miscellaneous extends CRM_Admin_Form_Setting {
     $errors = [];
 
     // validate max file size
-    if ($fields['maxFileSize'] > $options->_uploadMaxSize) {
-      $errors['maxFileSize'] = ts("Maximum file size cannot exceed Upload max size ('upload_max_filesize') as defined in PHP.ini.");
+    $iniBytes = CRM_Utils_Number::formatUnitSize(ini_get('upload_max_filesize'), FALSE);
+    $inputBytes = CRM_Utils_Number::formatUnitSize($fields['maxFileSize'] . 'M', FALSE);
+
+    if ($inputBytes > $iniBytes) {
+      $errors['maxFileSize'] = ts("Maximum file size cannot exceed limit defined in \"php.ini\" (\"upload_max_filesize=%1\") .", [
+        1 => ini_get('upload_max_filesize'),
+      ]);
     }
 
     // validate recent items stack size


### PR DESCRIPTION
Overview
----------------------------------------

The form "Administer => System Settings => Miscellaneous" has a field for "Maximum File Size".

I was on a workstation where the PHP-default and the Civi-default were disagreeable, so
(by default) I couldn't submit the form, which forced me to notice some quirks in the validation.

Before
------

<img width="364" alt="Screen Shot 2021-01-13 at 7 46 10 PM" src="https://user-images.githubusercontent.com/1336047/104542259-062f6b80-55d8-11eb-8073-610136617636.png">

* The error message tells you that the "Maximum File Size" disagrees with a setting in `php.ini`. Hopefully, you have SSH access so you can find and read `PHP.ini` (sic)... otherwise you'll be at a loss for what value is acceptable.
* The validation assumes that `upload_max_filesize` is expressed in unit-megabytes. But `php.ini` actually
  allows different units (`2m`, `2048k`, `1g`, `2097152`). The comparison is incorrect
  if any other unit is used. (ex: If `php.ini` has `upload_max_filesize=1g`, and if the requested
  limit is `2` megabytes, then it should accept - but it rejects due to mismatched units.)

After
-----

<img width="372" alt="Screen Shot 2021-01-13 at 7 45 40 PM" src="https://user-images.githubusercontent.com/1336047/104542254-04fe3e80-55d8-11eb-9ae4-5375787e9235.png">

* Error message tells you what you need to know. Capitalization is correct.
* Validator correctly interprets the units used in `php.ini`'s `upload_max_filesize`.
