### PR TITLE
(dev/wordpress#85) Fix version number reported within WordPress admin UI

### DIFF
--- a/distmaker/dists/common.sh
+++ b/distmaker/dists/common.sh
@@ -232,8 +232,8 @@ function dm_install_wordpress() {
     "$repo/./"  "$to/./"
   ## Need --exclude=civicrm for self-building on WP site
 
-  dm_preg_edit '/^Version: [0-9\.]+/m' "Version: $DM_VERSION" "$to/civicrm.php"
-  dm_preg_edit "/^define\( \'CIVICRM_PLUGIN_VERSION\',\W'[0-9\.]+/m" "define( 'CIVICRM_PLUGIN_VERSION', '$DM_VERSION" "$to/civicrm.php"
+  dm_preg_edit '/^([ \*]*)Version: [0-9\.]+/m' "\1Version: $DM_VERSION" "$to/civicrm.php"
+  dm_preg_edit "/^define\( *\'CIVICRM_PLUGIN_VERSION\', *'[0-9\.]+/m" "define('CIVICRM_PLUGIN_VERSION', '$DM_VERSION" "$to/civicrm.php"
 }
 
 ## Generate the composer "vendor" folder


### PR DESCRIPTION
Overview
----------------------------------------

Updates `distmaker` so that WordPress zipballs include more accurate metadata about the Civi version.

More info: https://lab.civicrm.org/dev/wordpress/-/issues/85 

Before
----------------------------------------

Only works if `civicrm-wordpress:civicrm.php` has the `Version:` header at the start of a line

After
----------------------------------------

Works with `Version:` header in an indented docblock.

Comments
----------------------------------------

Regressed in 5.33 due to code-cleanup in https://github.com/civicrm/civicrm-wordpress/commit/ec410b08