### PR TITLE
dev/core#2204 Bump Minimum install PHP 7.2

### DIFF
--- a/CRM/Upgrade/Incremental/General.php
+++ b/CRM/Upgrade/Incremental/General.php
@@ -40,7 +40,7 @@ class CRM_Upgrade_Incremental_General {
    *
    * @see install/index.php
    */
-  const MIN_INSTALL_PHP_VER = '7.1.0';
+  const MIN_INSTALL_PHP_VER = '7.2.0';
 
   /**
    * The minimum recommended MySQL/MariaDB version.

--- a/composer.json
+++ b/composer.json
@@ -38,11 +38,11 @@
   "include-path": ["vendor/tecnickcom"],
   "config": {
     "platform": {
-      "php": "7.1"
+      "php": "7.2"
     }
   },
   "require": {
-    "php": "~7.1",
+    "php": "~7.2",
     "cache/integration-tests": "~0.17.0",
     "dompdf/dompdf" : "~0.8",
     "electrolinux/phpquery": "^0.9.6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3877832b2ea8b061992a614b7a73a456",
+    "content-hash": "65312dbe20aaae9cb2a94b32937a24e0",
     "packages": [
         {
             "name": "adrienrn/php-mimetyper",
@@ -3854,12 +3854,12 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "~7.1",
+        "php": "~7.2",
         "ext-intl": "*"
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "7.1"
+        "php": "7.2"
     },
     "plugin-api-version": "2.0.0"
 }


### PR DESCRIPTION
Overview
----------------------------------------
As Per [dev/core#2204](https://lab.civicrm.org/dev/core/-/issues/2204) we are making the minimum install requirement for php to be 7.2 

Before
----------------------------------------
Minimum install php is 7.1

After
----------------------------------------
Minimum install php is 7.2

Technical Details
----------------------------------------
requires https://github.com/civicrm/civicrm-buildkit/pull/594

ping @totten @eileenmcnaughton 
