### PR TITLE
REF Permit installing of replacement extensions during upgrade for ob…

### DIFF
--- a/CRM/Extension/Manager.php
+++ b/CRM/Extension/Manager.php
@@ -310,11 +310,12 @@ class CRM_Extension_Manager {
 
     $this->statuses = NULL;
     $this->mapper->refresh();
-    CRM_Core_Invoke::rebuildMenuAndCaches(TRUE);
+    if (!CRM_Core_Config::isUpgradeMode()) {
+      CRM_Core_Invoke::rebuildMenuAndCaches(TRUE);
 
-    $schema = new CRM_Logging_Schema();
-    $schema->fixSchemaDifferences();
-
+      $schema = new CRM_Logging_Schema();
+      $schema->fixSchemaDifferences();
+    }
     foreach ($keys as $key) {
       // throws Exception
       list ($info, $typeManager) = $this->_getInfoTypeHandler($key);

--- a/CRM/Upgrade/Form.php
+++ b/CRM/Upgrade/Form.php
@@ -616,6 +616,7 @@ SET    version = '$version'
     $messages = [];
     $manager = CRM_Extension_System::singleton()->getManager();
     foreach ($manager->getStatuses() as $key => $status) {
+      $enableReplacement = CRM_Core_DAO::singleValueQuery('SELECT is_active FROM civicrm_extension WHERE full_name = %1', [1 => [$key, 'String']]);
       $obsolete = $manager->isIncompatible($key);
       if ($obsolete) {
         if (!empty($obsolete['disable']) && in_array($status, [$manager::STATUS_INSTALLED, $manager::STATUS_INSTALLED_MISSING])) {
@@ -646,6 +647,15 @@ SET    version = '$version'
           CRM_Core_DAO::executeQuery('UPDATE civicrm_extension SET is_active = 0 WHERE full_name = %1', [
             1 => [$key, 'String'],
           ]);
+        }
+        if (!empty($obsolete['replacement']) && $enableReplacement) {
+          try {
+            $manager->enable($manager->install($obsolete['replacement']));
+            $messages[] = ts('A replacement extension %1 has been installed as you had the obsolete extension %2 installed', [1 => $obsolete['replacement'], 2 => $key]);
+          }
+          catch (CRM_Extension_Exception $e) {
+            $messages[] = ts('The replacement extension %1 could not be installed due to an error. It is recommended to enable this extension manually.', [1 => $obsolete['replacement']]);
+          }
         }
       }
     }

--- a/extension-compatibility.json
+++ b/extension-compatibility.json
@@ -1,7 +1,8 @@
 {
   "org.civicrm.afform-gui": {
     "obsolete": "5.35",
-    "force-uninstall": true
+    "force-uninstall": true,
+    "replacement": "org.civicrm.afform_admin"
   },
   "com.civibridge.quickmenu": {
     "obsolete": "5.24",


### PR DESCRIPTION
…solete extensions

Overview
----------------------------------------
This allows for when an extension is marked as obsolete to automatically install a replacement extension if such exists

Before
----------------------------------------
If you had the afform-gui extension installed, it would be uninstalled and the sysadmin would have to manually install the afform_admin extension to restore some functionality

After
----------------------------------------
Sysadmin has to do nothing as the system will install afform_admin as a replacement for afform-gui

Technical Details
----------------------------------------
This does prevent the rebuilding of the menu cache and the fixing up of the logging schema but this should be fine as it should be taken care of in the doFinish part of the general upgrade process

ping @eileenmcnaughton @colemanw @totten 