### PR TITLE
Issue 2301

### DIFF
--- a/templates/CRM/Form/body.tpl
+++ b/templates/CRM/Form/body.tpl
@@ -14,7 +14,10 @@
 {if $form.hidden}
   <div>{$form.hidden}</div>
 {/if}
-
+{if (isset($form.errors))}
+    {*
+        If $form.errors isn't set, we get warning messages
+    *}
 {if ($snippet !== 'json') and !$suppressForm and count($form.errors) gt 0}
    <div class="messages crm-error">
        <i class="crm-i fa-exclamation-triangle crm-i-red" aria-hidden="true"></i>
@@ -29,6 +32,7 @@
      {/foreach}
      </ul>
    </div>
+{/if}
 {/if}
 
 {* Add all the form elements sent in by the hook *}


### PR DESCRIPTION
Overview
----------------------------------------
_A brief description of the pull request. Keep technical jargon to a minimum. Hyperlink relevant discussions._

Before
----------------------------------------
Under some circumstances, a contact logged in to CiviCRM under Drupal would get.
```
Warning: count(): Parameter must be an array or an object that implements Countable in include() (line 15 of sites\default\files\civicrm\templates_c\en_GB\%%4D\4DC\4DC76B26%%body.tpl.php).
```

After
----------------------------------------
_What changed? What is new old user-interface or technical-contract?_

The error disappeared.

Technical Details
----------------------------------------

The change to templates/CRM/Form/body.tpl eliminates the error as the PHP file generated no longer tries to obtain the count of a non-existent array.  There shouldn't be any error if the error array doesn't exist, so I suspect there is little risk of applying this PR.

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
It seems to be dependent on certain data in the database; in other words, it is hard to reproduce.