### PR TITLE
(dev/wordpress#85) Fix version number reported within WordPress admin UI

### DIFF
--- a/distmaker/dists/common.sh
+++ b/distmaker/dists/common.sh
@@ -232,8 +232,8 @@ function dm_install_wordpress() {
     "$repo/./"  "$to/./"
   ## Need --exclude=civicrm for self-building on WP site
 
-  dm_preg_edit '/^Version: [0-9\.]+/m' "Version: $DM_VERSION" "$to/civicrm.php"
-  dm_preg_edit "/^define\( \'CIVICRM_PLUGIN_VERSION\',\W'[0-9\.]+/m" "define( 'CIVICRM_PLUGIN_VERSION', '$DM_VERSION" "$to/civicrm.php"
+  dm_preg_edit '/^([ \*]*)Version: [0-9\.]+/m' "\1Version: $DM_VERSION" "$to/civicrm.php"
+  dm_preg_edit "/^define\( *\'CIVICRM_PLUGIN_VERSION\', *'[0-9\.]+/m" "define('CIVICRM_PLUGIN_VERSION', '$DM_VERSION" "$to/civicrm.php"
 }
 
 ## Generate the composer "vendor" folder


### PR DESCRIPTION
Overview
----------------------------------------
Ports PR https://github.com/civicrm/civicrm-core/pull/19384 to 5.33

Before
----------------------------------------
Version not correctly update in civicrm.php file

After
----------------------------------------
Version details correctly update in civicrm.php file

ping @kcristiano @totten 