### PR TITLE
REF Ensure that when doing RLIKE BINARY the field is cast as BINARY t…

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -5628,7 +5628,7 @@ civicrm_relationship.start_date > {$today}
         return $clause;
 
       case 'RLIKE':
-        return " {$clause} BINARY '{$value}' ";
+        return " CAST({$field} AS BINARY) RLIKE BINARY '{$value}' ";
 
       case 'IN':
       case 'NOT IN':

--- a/tests/phpunit/CRM/Contact/SelectorTest.php
+++ b/tests/phpunit/CRM/Contact/SelectorTest.php
@@ -552,7 +552,7 @@ AND ( 1 ) AND (contact_a.is_deleted = 0)',
       // case insensitive check
       'LIKE' => "( contact_a.first_name LIKE '%Ad%' )",
       // case sensitive check
-      'RLIKE' => "(  contact_a.first_name RLIKE BINARY '^A[a-z]{3}$'  )",
+      'RLIKE' => "(  CAST(contact_a.first_name AS BINARY) RLIKE BINARY '^A[a-z]{3}$'  )",
       // case sensitive check
       'IN' => '( contact_a.first_name IN ("Adam") )',
     ];


### PR DESCRIPTION
…o prevent issue on MySQL 8

Overview
----------------------------------------
This fixes an error on MySQL 8.0.22 nativecode=3995 ** Character set 'utf8mb4_unicode_ci' cannot be used in conjunction with 'binary' in call to regexp_like.

Before
----------------------------------------
MySQL 8 errors

After
----------------------------------------
No Error

ping @demeritcowboy @eileenmcnaughton @totten 