### PR TITLE
[Test] Extend new membership form to cover multi-line renew + minor cleanup

### DIFF
--- a/CRM/Member/Form.php
+++ b/CRM/Member/Form.php
@@ -466,7 +466,7 @@ class CRM_Member_Form extends CRM_Contribute_Form_AbstractEditPayment {
    *
    * @param array $formValues
    */
-  public function testSubmit($formValues) {
+  public function testSubmit(array $formValues): void {
     $this->setContextVariables($formValues);
     $this->_memType = $formValues['membership_type_id'][1];
     $this->_params = $formValues;

--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -1939,13 +1939,10 @@ DESC limit 1");
    * @param array $params
    * @param int $contactID
    *
-   * @return int|null
+   * @return int
    */
-  protected function legacyProcessRecurringContribution(&$params, $contactID) {
+  protected function legacyProcessRecurringContribution(array $params, $contactID): int {
     $form = $this;
-    if (empty($params['is_recur'])) {
-      return NULL;
-    }
 
     $recurParams = ['contact_id' => $contactID];
     $recurParams['amount'] = $params['amount'] ?? NULL;
@@ -1978,12 +1975,7 @@ DESC limit 1");
 
     $campaignId = $params['campaign_id'] ?? $form->_values['campaign_id'] ?? NULL;
     $recurParams['campaign_id'] = $campaignId;
-    $recurring = CRM_Contribute_BAO_ContributionRecur::add($recurParams);
-    if (is_a($recurring, 'CRM_Core_Error')) {
-      throw new CRM_Core_Exception(CRM_Core_Error::getMessages($recurring));
-    }
-
-    return $recurring->id;
+    return CRM_Contribute_BAO_ContributionRecur::add($recurParams)->id;
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Extends test cover on membership form and minor cleanup


Before
----------------------------------------
Handling for CRM_Core_Error but always being in exception mode should make this obsolete, handling for is_recur not being 1 when this is impossible, unnecessary pass by ref

After
----------------------------------------
Above fixed + additional test

Technical Details
----------------------------------------

Comments
----------------------------------------
