### PR TITLE
Remove call to loadRelatedObjects

### DIFF
--- a/CRM/Core/Payment/AuthorizeNetIPN.php
+++ b/CRM/Core/Payment/AuthorizeNetIPN.php
@@ -37,6 +37,7 @@ class CRM_Core_Payment_AuthorizeNetIPN extends CRM_Core_Payment_BaseIPN {
    * @return bool|void
    *
    * @throws \CiviCRM_API3_Exception
+   * @throws \API_Exception
    */
   public function main() {
     try {
@@ -73,9 +74,6 @@ class CRM_Core_Payment_AuthorizeNetIPN extends CRM_Core_Payment_BaseIPN {
       if (!$contributionRecur->find(TRUE)) {
         throw new CRM_Core_Exception("Could not find contribution recur record: {$ids['ContributionRecur']} in IPN request: " . print_r($input, TRUE));
       }
-
-      $ids['paymentProcessor'] = $paymentProcessorID;
-      $contribution->loadRelatedObjects($input, $ids);
 
       // check if first contribution is completed, else complete first contribution
       $first = TRUE;


### PR DESCRIPTION


Overview
----------------------------------------
Remove call to loadRelatedObjects

Before
----------------------------------------
```
$ids['paymentProcessor'] = $paymentProcessorID;
      $contribution->loadRelatedObjects($input, $ids);
```
but the loaded ids are never used

After
----------------------------------------
poof

Technical Details
----------------------------------------
None of the ids loaded in this function are used anymore so we can remove the call to it
The only reference to ids after this line is to contribution page id, which is loaded earlier

Comments
----------------------------------------
Test cover in AuthorizenetIPNTest class is pretty solid