### PR TITLE
dev/core#2303 Extract function to load the messageContent for a template

### DIFF
--- a/CRM/Core/BAO/MessageTemplate.php
+++ b/CRM/Core/BAO/MessageTemplate.php
@@ -635,6 +635,11 @@ class CRM_Core_BAO_MessageTemplate extends CRM_Core_DAO_MessageTemplate {
       'text' => $messageTemplate['msg_text'],
       'html' => $messageTemplate['msg_html'],
       'format' => $messageTemplate['pdf_format_id'],
+      // Workflow name is the field in the message templates table that denotes the
+      // workflow the template is used for. This is intended to eventually
+      // replace the non-standard option value/group implementation - see
+      // https://github.com/civicrm/civicrm-core/pull/17227 and the longer
+      // discussion on https://github.com/civicrm/civicrm-core/pull/17180
       'workflow_name' => $workflowName,
       // Note messageTemplateID is the id but when present we also know it was specifically requested.
       'messageTemplateID' => $messageTemplateID,

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -2422,23 +2422,27 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
 
   /**
    * Test repeat contribution successfully creates is_test transaction.
+   *
+   * @throws \CRM_Core_Exception
    */
-  public function testRepeatTransactionIsTest() {
+  public function testRepeatTransactionIsTest(): void {
     $this->_params['is_test'] = 1;
     $originalContribution = $this->setUpRepeatTransaction(['is_test' => 1], 'single');
 
     $this->callAPISuccess('contribution', 'repeattransaction', [
       'original_contribution_id' => $originalContribution['id'],
       'contribution_status_id' => 'Completed',
-      'trxn_id' => uniqid(),
+      'trxn_id' => '1234',
     ]);
     $this->callAPISuccessGetCount('Contribution', ['contribution_test' => 1], 2);
   }
 
   /**
    * Test repeat contribution passed in status.
+   *
+   * @throws \CRM_Core_Exception
    */
-  public function testRepeatTransactionPassedInStatus() {
+  public function testRepeatTransactionPassedInStatus(): void {
     $originalContribution = $this->setUpRepeatTransaction($recurParams = [], 'single');
 
     $this->callAPISuccess('contribution', 'repeattransaction', [


### PR DESCRIPTION

Overview
----------------------------------------
This is a fairly straightforward extraction, seeking to break down the very-busy sendtemplate function
into the sub-functions within it. Essentially we load the template content, we swap out the tokens
and we send it.

Note that I have added a parameter to the output sent to alterMailContent
of 'workflow_name' which is more accurate - I updated the docs

Before
----------------------------------------
Function part of metafunction

After
----------------------------------------
Extracted

Technical Details
----------------------------------------

Comments
----------------------------------------
It seems to have committed rather than PR-d my docs change
https://lab.civicrm.org/documentation/docs/dev/-/blob/master/docs/hooks/hook_civicrm_alterMailContent.md