### PR TITLE
Fix Issue 2307

### DIFF
--- a/CRM/Contact/Form/Task/Map.php
+++ b/CRM/Contact/Form/Task/Map.php
@@ -168,7 +168,12 @@ class CRM_Contact_Form_Task_Map extends CRM_Contact_Form_Task {
         }
         $session->pushUserContext(CRM_Utils_System::url('civicrm/event/info', "{$args}{$ids}"));
       }
-      CRM_Utils_System::appendBreadCrumb($bcTitle, $redirect);
+      // Issue 2307
+      // CRM_Utils_System::appendBreadCrumb only takes one argument, an array
+      // of breadcrumbs, not two.
+      $breadcrumbs[0]['title'] = $bcTitle;
+      $breadcrumbs[0]['url'] = $redirect;
+      CRM_Utils_System::appendBreadCrumb($breadcrumbs);
     }
 
     $page->assign_by_ref('locations', $locations);


### PR DESCRIPTION
Overview
----------------------------------------
_A brief description of the pull request. Keep technical jargon to a minimum. Hyperlink relevant discussions._
This PR fixes [Issue 2307](https://lab.civicrm.org/dev/core/-/issues/2307).

Before
----------------------------------------
Viewing the map for the address of a contact gives:
```
Invalid argument supplied for foreach() in CRM_Utils_System_Drupal8->appendBreadCrumb() ,,,
```
before the map is displayed.

After
----------------------------------------
Just the map.

Technical Details
----------------------------------------
<CiviCRM core>CRM/Contact/Form/Task/Map.php line 171 reads:
```
CRM_Utils_System::appendBreadCrumb($bcTitle, $redirect);
```
but ```CRM_Utils_System::appendBreadCrumb``` only takes a single parameter, an array.  This PR creates just such an array and then calls ```CRM_Utils_System::appendBreadCrumb```, with that array as a parameter.


Comments
----------------------------------------
_Anything else you would like the reviewer to note_
Whilst demonstrated in Drupal 9, the same issue applies in other platforms even if the error does not manifest itself.
