### PR TITLE
[#REF] Cleanup recently added code fixing dev/core#2307 for the fact …

### DIFF
--- a/CRM/Contact/Form/Task/Map.php
+++ b/CRM/Contact/Form/Task/Map.php
@@ -168,11 +168,10 @@ class CRM_Contact_Form_Task_Map extends CRM_Contact_Form_Task {
         }
         $session->pushUserContext(CRM_Utils_System::url('civicrm/event/info', "{$args}{$ids}"));
       }
-      // Issue 2307
+      // dev/core#2307
       // CRM_Utils_System::appendBreadCrumb only takes one argument, an array
       // of breadcrumbs, not two.
-      $breadcrumbs[0]['title'] = $bcTitle;
-      $breadcrumbs[0]['url'] = $redirect;
+      $breadcrumbs = [0 => ['title' => $bcTitle, 'url' => $redirect]];
       CRM_Utils_System::appendBreadCrumb($breadcrumbs);
     }
 


### PR DESCRIPTION
…at  wasn't a variable before these lines

Overview
----------------------------------------
This does a slight code cleanup of the code added in https://github.com/civicrm/civicrm-core/pull/19414 to fix the breadcrumbs issue

Before
----------------------------------------
$breadcrumbs not a variable so may run into e-notices

After
----------------------------------------
no e-notices 

ping @demeritcowboy @eileenmcnaughton 