### PR TITLE
dev/financial#148 fully deprecate loadObjects function

### DIFF
--- a/CRM/Core/Payment/BaseIPN.php
+++ b/CRM/Core/Payment/BaseIPN.php
@@ -140,6 +140,8 @@ class CRM_Core_Payment_BaseIPN {
   /**
    * Load objects related to contribution.
    *
+   * @deprecated
+   *
    * @input array information from Payment processor
    *
    * @param array $input
@@ -152,6 +154,7 @@ class CRM_Core_Payment_BaseIPN {
    * @throws \CRM_Core_Exception
    */
   public function loadObjects($input, &$ids, &$objects, $required, $paymentProcessorID) {
+    CRM_Core_Error::deprecatedFunctionWarning('use api methods in ipn');
     $contribution = &$objects['contribution'];
     $ids['paymentProcessor'] = $paymentProcessorID;
     $success = $contribution->loadRelatedObjects($input, $ids);

--- a/CRM/Core/Payment/PayPalProIPN.php
+++ b/CRM/Core/Payment/PayPalProIPN.php
@@ -482,9 +482,10 @@ INNER JOIN civicrm_membership_payment mp ON m.id = mp.membership_id AND mp.contr
         unset($ids['contributionPage']);
       }
 
-      if (!$this->loadObjects($input, $ids, $objects, TRUE, $paymentProcessorID)) {
-        return;
-      }
+      $contribution = &$objects['contribution'];
+      $ids['paymentProcessor'] = $paymentProcessorID;
+      $contribution->loadRelatedObjects($input, $ids);
+      $objects = array_merge($objects, $contribution->_relatedObjects);
 
       $input['payment_processor_id'] = $paymentProcessorID;
 
@@ -640,9 +641,11 @@ INNER JOIN civicrm_membership_payment mp ON m.id = mp.membership_id AND mp.contr
       unset($ids['contributionPage']);
     }
 
-    if (!$this->loadObjects($input, $ids, $objects, TRUE, $paymentProcessorID)) {
-      throw new CRM_Core_Exception('Data did not validate');
-    }
+    $contribution = &$objects['contribution'];
+    $ids['paymentProcessor'] = $paymentProcessorID;
+    $contribution->loadRelatedObjects($input, $ids);
+    $objects = array_merge($objects, $contribution->_relatedObjects);
+
     $this->recur($input, $ids, $objects['contributionRecur'], $objects['contribution'], $isFirst);
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
dev/financial#148 fully deprecate loadObjects function

Before
----------------------------------------
Function still in use

After
----------------------------------------
Function fully deprecated

Technical Details
----------------------------------------
the check for $success is meaningful as it either returns success or fails along the way

Comments
----------------------------------------
