### PR TITLE
Greenwich - fix list margin added by some CMS themes

### DIFF
--- a/ext/greenwich/scss/_tweaks.scss
+++ b/ext/greenwich/scss/_tweaks.scss
@@ -1,3 +1,9 @@
+/* Fix some cms themes which add margin to lists */
+ul, ol {
+  margin-left: 0;
+  margin-right: 0;
+}
+
 /* Supports adding form-control class to the checkbox-inline class to achieve an outer border around the checkbox&label */
 .form-control.checkbox-inline > label {
   margin-left: 9px;


### PR DESCRIPTION
Overview
----------------------------------------
Fix a style conflict between some CMS themes and Greenwich, causing tabs to shift to the right.

Before
----------------------------------------
Drupal "Seven" Theme:

![image](https://user-images.githubusercontent.com/2874912/105064698-11a4eb80-5a4b-11eb-9028-38c624c49b89.png)


After
----------------------------------------
Drupal "Seven" Theme:

![image](https://user-images.githubusercontent.com/2874912/105064482-dc989900-5a4a-11eb-8558-f63e9f4b9d78.png)

