### PR TITLE
[Test framework] Prevent intermittently failing relationship test

### DIFF
--- a/tests/phpunit/api/v4/Service/TestCreationParameterProvider.php
+++ b/tests/phpunit/api/v4/Service/TestCreationParameterProvider.php
@@ -107,7 +107,7 @@ class TestCreationParameterProvider {
    */
   private function getOption(FieldSpec $field) {
     $options = array_column($field->getOptions(), 'label', 'id');
-    return array_rand($options);
+    return key($options);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
The problem is that both contacts are of type individual, so when it uses array_rand() to pick a relationship type it might not be the right kind of relationship type, e.g. it might be employer individual-to-org, so it randomly fails. As per chat change it so that no tests are random.

A separate problem is that both contacts have the same contact id. That doesn't make the test fail, it's just not a realistic test. This patch doesn't address that.

Before
----------------------------------------
Random fails for api\v4\entity\conformanceTest::testConformance for relationship entity.

After
----------------------------------------
Success

Technical Details
----------------------------------------


Comments
----------------------------------------
Is test.
