### PR TITLE
dev/core#2312 SearchKit - Improve results loading time in admin UI

### DIFF
--- a/ext/search/ang/crmSearchAdmin/compose/pager.html
+++ b/ext/search/ang/crmSearchAdmin/compose/pager.html
@@ -1,7 +1,7 @@
 <div class="crm-flex-box">
   <div>
     <div class="form-inline">
-      <label ng-if="loading && $ctrl.rowCount === false"><i class="crm-i fa-spin fa-spinner"></i></label>
+      <label ng-if="$ctrl.rowCount === false"><i class="crm-i fa-spin fa-spinner"></i></label>
       <label ng-if="$ctrl.rowCount === 1">
         {{ $ctrl.selectedRows.length ? ts('%1 selected of 1 result', {1: $ctrl.selectedRows.length}) : ts('1 result') }}
       </label>

--- a/ext/search/ang/crmSearchAdmin/compose/results.html
+++ b/ext/search/ang/crmSearchAdmin/compose/results.html
@@ -2,7 +2,7 @@
   <thead>
     <tr ng-model="$ctrl.savedSearch.api_params.select" ui-sortable="sortableColumnOptions">
       <th class="crm-search-result-select">
-        <input type="checkbox" ng-checked="$ctrl.allRowsSelected" ng-click="selectAllRows()" ng-disabled="!(loading === false && !loadingAllRows && $ctrl.results[$ctrl.page] && $ctrl.results[$ctrl.page][0].id)">
+        <input type="checkbox" ng-checked="$ctrl.allRowsSelected" ng-click="selectAllRows()" ng-disabled="!($ctrl.rowCount && loading === false && !loadingAllRows && $ctrl.results[$ctrl.page] && $ctrl.results[$ctrl.page][0].id)">
       </th>
       <th ng-repeat="col in $ctrl.savedSearch.api_params.select" ng-click="setOrderBy(col, $event)" title="{{$index || !$ctrl.groupExists ? ts('Drag to reorder columns, click to sort results (shift-click to sort by multiple).') : ts('Column reserved for smart group.')}}">
         <i class="crm-i {{ getOrderBy(col) }}"></i>

--- a/ext/search/ang/crmSearchAdmin/crmSearchAdmin.component.js
+++ b/ext/search/ang/crmSearchAdmin/crmSearchAdmin.component.js
@@ -396,16 +396,18 @@
           ctrl.page = 1;
           ctrl.rowCount = false;
         }
-        if (ctrl.rowCount === false) {
-          params.select.push('row_count');
-        }
         params.offset = ctrl.limit * (ctrl.page - 1);
         crmApi4(ctrl.savedSearch.api_entity, 'get', params).then(function(success) {
           if (ctrl.stale) {
             ctrl.results = {};
-          }
-          if (ctrl.rowCount === false) {
-            ctrl.rowCount = success.count;
+            // Get row count for pager
+            // Select is only needed needed by HAVING
+            params.select = params.having && params.having.length ? params.select : [];
+            params.select.push('row_count');
+            delete params.debug;
+            crmApi4(ctrl.savedSearch.api_entity, 'get', params).then(function(result) {
+              ctrl.rowCount = result.count;
+            });
           }
           ctrl.debug = success.debug;
           // populate this page & the next
@@ -537,7 +539,9 @@
         // If more than one page of results, use ajax to fetch all ids
         $scope.loadingAllRows = true;
         var params = _.cloneDeep(ctrl.savedSearch.api_params);
-        params.select = ['id'];
+        // Select is only needed needed by HAVING
+        params.select = params.having && params.having.length ? params.select : [];
+        params.select.push('id');
         crmApi4(ctrl.savedSearch.api_entity, 'get', params, ['id']).then(function(ids) {
           $scope.loadingAllRows = false;
           ctrl.selectedRows = _.toArray(ids);

--- a/ext/search/ang/crmSearchAdmin/crmSearchAdmin.html
+++ b/ext/search/ang/crmSearchAdmin/crmSearchAdmin.html
@@ -37,7 +37,7 @@
           <div ng-include="'~/crmSearchAdmin/compose/controls.html'"></div>
           <div ng-include="'~/crmSearchAdmin/compose/debug.html'" ng-if="$ctrl.debug"></div>
           <div ng-include="'~/crmSearchAdmin/compose/results.html'" class="crm-search-results"></div>
-          <div ng-include="'~/crmSearchAdmin/compose/pager.html'"></div>
+          <div ng-include="'~/crmSearchAdmin/compose/pager.html'" ng-if="$ctrl.results"></div>
         </div>
         <div ng-switch-when="group">
           <fieldset ng-include="'~/crmSearchAdmin/group.html'"></fieldset>


### PR DESCRIPTION
Overview
----------------------------------------
Per https://lab.civicrm.org/dev/core/-/issues/2312 this separates the ajax calls for fetching search results & the pager count for a snappier UX.

This addresses the issue on the admin screen but not yet for search displays, which need reworking anyway to go through a permissioned wrapper api.

Before
----------------------------------------
Single api call for rows & count might be very slow.

After
----------------------------------------
Fetch a page of results before loading pager count for asynchronous speed.
