### PR TITLE
Select2 - Improve styles for disabled, loading elements

### DIFF
--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -2972,9 +2972,13 @@ tbody.scrollContent tr.alternateRow {
 .crm-container .select2-container-multi.crm-ajax-select .select2-choices:before {
   background-position: right -26px;
 }
+.crm-container .select2-container.select2-container-disabled .select2-choice .select2-arrow b {
+  visibility: hidden;
+}
 .crm-container .select2-container-multi.loading .select2-choices:before,
 .crm-container .select2-container.loading .select2-choice .select2-arrow b {
-  background: url('../i/loading.gif') no-repeat center center;
+  background: url('../i/loading.gif') no-repeat center center !important;
+  visibility: visible;
 }
 /* Reduce select2 size to match other inputs */
 .crm-container .select2-container-multi .select2-choices {


### PR DESCRIPTION
Overview
----------------------------------------
A couple style tweaks to Select2. Disabled containers should not show the dropdown arrow since they can't be opened. And the "loading" style was broken in Greenwich.

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/2874912/105380969-79d70700-5bdc-11eb-82ea-445ec6e4c331.png)

After
----------------------------------------
![image](https://user-images.githubusercontent.com/2874912/105380697-3381a800-5bdc-11eb-812a-3d406b35e12f.png)
