### PR TITLE
Show disabled membership types on contact tab

### DIFF
--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -1575,11 +1575,15 @@ WHERE  civicrm_membership.contact_id = civicrm_contact.id
    * @return null|string
    */
   public static function getContactMembershipCount($contactID, $activeOnly = FALSE) {
-    CRM_Financial_BAO_FinancialType::getAvailableMembershipTypes($membershipTypes);
+    $membershipTypes = \Civi\Api4\MembershipType::get(TRUE)
+      ->execute()
+      ->indexBy('id')
+      ->column('name');
     $addWhere = " AND membership_type_id IN (0)";
     if (!empty($membershipTypes)) {
       $addWhere = " AND membership_type_id IN (" . implode(',', array_keys($membershipTypes)) . ")";
     }
+
     $select = "SELECT count(*) FROM civicrm_membership ";
     $where = "WHERE civicrm_membership.contact_id = {$contactID} AND civicrm_membership.is_test = 0 ";
 

--- a/CRM/Member/Page/Tab.php
+++ b/CRM/Member/Page/Tab.php
@@ -32,7 +32,10 @@ class CRM_Member_Page_Tab extends CRM_Core_Page {
    */
   public function browse() {
     $links = self::links('all', $this->_isPaymentProcessor, $this->_accessContribution);
-    CRM_Financial_BAO_FinancialType::getAvailableMembershipTypes($membershipTypes);
+    $membershipTypes = \Civi\Api4\MembershipType::get(TRUE)
+      ->execute()
+      ->indexBy('id')
+      ->column('name');
     $addWhere = "membership_type_id IN (0)";
     if (!empty($membershipTypes)) {
       $addWhere = "membership_type_id IN (" . implode(',', array_keys($membershipTypes)) . ")";

--- a/ext/financialacls/financialacls.php
+++ b/ext/financialacls/financialacls.php
@@ -188,15 +188,20 @@ function financialacls_civicrm_selectWhereClause($entity, &$clauses) {
   if (!financialacls_is_acl_limiting_enabled()) {
     return;
   }
-  if ($entity === 'LineItem') {
-    $types = [];
-    CRM_Financial_BAO_FinancialType::getAvailableFinancialTypes($types);
-    if ($types) {
-      $clauses['financial_type_id'] = 'IN (' . implode(',', array_keys($types)) . ')';
-    }
-    else {
-      $clauses['financial_type_id'] = '= 0';
-    }
+
+  switch ($entity) {
+    case 'LineItem':
+    case 'MembershipType':
+      $types = [];
+      CRM_Financial_BAO_FinancialType::getAvailableFinancialTypes($types);
+      if ($types) {
+        $clauses['financial_type_id'] = 'IN (' . implode(',', array_keys($types)) . ')';
+      }
+      else {
+        $clauses['financial_type_id'] = '= 0';
+      }
+      break;
+
   }
 
 }

--- a/tests/phpunit/api/v3/FinancialTypeACLTest.php
+++ b/tests/phpunit/api/v3/FinancialTypeACLTest.php
@@ -316,12 +316,13 @@ class api_v3_FinancialTypeACLTest extends CiviUnitTestCase {
     $this->assertEquals($contribution['count'], 1);
   }
 
-  public function testMembersipTypeACLFinancialTypeACL() {
+  public function testMembershipTypeACLFinancialTypeACL() {
     $contactID = $this->individualCreate();
     $this->contactMembershipCreate(['contact_id' => $contactID]);
     $this->enableFinancialACLs();
     $this->setPermissions([
       'access CiviCRM',
+      'access CiviMember',
       'access CiviContribute',
       'view all contacts',
       'add contributions of type Donation',


### PR DESCRIPTION
Overview
----------------------------------------
Replacement for #17143 / #17435 using API4 and retaining financialacl code.

Contacts may still have disabled membership types. But new memberships of that type cannot be created.

Before
----------------------------------------
Disabled memberships show in searches but not contact tab.

After
----------------------------------------
Disabled memberships show in searches and contact tab.

Technical Details
----------------------------------------
Use API4 MembershipType API to retrieve all membership types that the user has permission for. Added a comment that the code should be moved to the financialacl extension instead.
Set checkPermissions explicitly to TRUE (that is the default) because this allows the API to accurately return the membership types that the user has permission to access. For example another extension could control access.

Comments
----------------------------------------
@seamuslee001 
