### PR TITLE
composer.json - Ignore unused variants of Monaco ("dev"/"esm")

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -215,7 +215,8 @@
       },
       "monaco-editor": {
         "url": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.16.2.tgz",
-        "path": "bower_components/monaco-editor"
+        "path": "bower_components/monaco-editor",
+        "ignore": ["dev", "esm"]
       },
       "google-code-prettify": {
         "url": "https://github.com/tcollard/google-code-prettify/archive/v1.0.5.zip",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "65312dbe20aaae9cb2a94b32937a24e0",
+    "content-hash": "a2171f9e6a9a0cffa1fcaebc3df8ea51",
     "packages": [
         {
             "name": "adrienrn/php-mimetyper",
@@ -3861,5 +3861,5 @@
     "platform-overrides": {
         "php": "7.2"
     },
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "1.1.0"
 }


### PR DESCRIPTION
Overview
----------

Tweak the composer downloads. Save ~50mb in the on-disk size of `bower_components`.

Before
------

`bower_components` has a full developmental tree for `monaco-editor`, including three different variants (`dev`, `esm`, `min`).

After
-----

`bower_components` only has the `min` variant of `monaco-editor`

Comments
--------------

Tested in `afform_admin`. Confirmed it only uses the `min` variant.
