### PR TITLE
[REF] Remove seemingly unreachable attempt to format activity_date_time

### DIFF
--- a/CRM/Activity/Import/Parser/Activity.php
+++ b/CRM/Activity/Import/Parser/Activity.php
@@ -221,10 +221,7 @@ class CRM_Activity_Import_Parser_Activity extends CRM_Activity_Import_Parser {
 
     foreach ($params as $key => $val) {
       if ($customFieldID = CRM_Core_BAO_CustomField::getKeyID($key)) {
-        if ($key === 'activity_date_time' && $val) {
-          $params[$key] = CRM_Utils_Date::formatDate($val, $dateType);
-        }
-        elseif (!empty($customFields[$customFieldID]) && $customFields[$customFieldID]['data_type'] == 'Date') {
+        if (!empty($customFields[$customFieldID]) && $customFields[$customFieldID]['data_type'] == 'Date') {
           CRM_Contact_Import_Parser_Contact::formatCustomDate($params, $params, $dateType, $key);
         }
         elseif (!empty($customFields[$customFieldID]) && $customFields[$customFieldID]['data_type'] == 'Boolean') {


### PR DESCRIPTION

Overview
----------------------------------------
[REF] Remove seemingly unreachable attempt to format activity_date_time

Before
----------------------------------------
Check for $key === 'activity_date_time' within a check whether $key is in the format 'custom_4' would never be true

After
----------------------------------------
poof

Technical Details
----------------------------------------

This is within the if custom field section - it would never be true but formatting exists further down


Comments
----------------------------------------
