### PR TITLE
Afform - Drop directive support for attribute, only support elements as afforms

### DIFF
--- a/ext/afform/auditor/backlog.md
+++ b/ext/afform/auditor/backlog.md
@@ -19,3 +19,4 @@ validator to catch. Loosely/informally:
 * Accept a restricted subset of BootstrapCSS
 * Accept a restricted subset of Angular HTML
 * Accept directives created via Afform
+* Circa 5.35, afforms became strictly (e)lement mode and dropped (a)ttribute mode (#19438)

--- a/ext/afform/core/afform.php
+++ b/ext/afform/core/afform.php
@@ -198,7 +198,7 @@ function afform_civicrm_angularModules(&$angularModules) {
       'partialsCallback' => '_afform_get_partials',
       '_afform' => $afform['name'],
       'exports' => [
-        $afform['directive_name'] => 'AE',
+        $afform['directive_name'] => 'E',
       ],
     ];
   }

--- a/ext/afform/core/ang/afCore.js
+++ b/ext/afform/core/ang/afCore.js
@@ -5,9 +5,9 @@
   // Use `afCoreDirective(string name)` to generate an AngularJS directive.
   angular.module('afCore').service('afCoreDirective', function($routeParams, crmApi4, crmStatus, crmUiAlert) {
     return function(camelName, meta, d) {
-      d.restrict = 'AE';
+      d.restrict = 'E';
       d.scope = {};
-      d.scope.options = '=' + camelName;
+      d.scope.options = '<';
       d.link = {
         pre: function($scope, $el, $attr) {
           $scope.ts = CRM.ts(camelName);

--- a/ext/afform/core/ang/afformStandalone.js
+++ b/ext/afform/core/ang/afformStandalone.js
@@ -7,7 +7,7 @@
       $routeProvider.when('/', {
         controller: 'AfformStandalonePageCtrl',
         template: function() {
-          return '<div id="bootstrap-theme" ' + CRM.afform.open + '="{}"></div>';
+          return '<div id="bootstrap-theme"><' + CRM.afform.open + '></' + CRM.afform.open + '></div>';
         }
       });
     })

--- a/ext/afform/docs/embed.md
+++ b/ext/afform/docs/embed.md
@@ -8,13 +8,13 @@ sub-forms*.
 How does this work?  Every `afform` is an *AngularJS directive*.  For example, `hello-world` can be embedded with:
 
 ```html
-<div hello-world=""></div>
+<hello-world></hello-world>
 ```
 
 Moreover, you can pass options to `helloWorld`:
 
 ```html
-<div hello-world="{phaseOfMoon: 'waxing'}"></div>
+<hello-world options="{phaseOfMoon: 'waxing'}"></hello-world>
 ```
 
 Now, in `ang/helloWorld.aff.html`, you can use `options.phaseOfMoon`:
@@ -38,13 +38,13 @@ Next, we should create an overall `ang/myContact.aff.html` which uses these buil
 ```html
 <div ng-form="contactForm">
   <div crm-ui-accordion="{title: ts('Name')}">
-    <div my-contact-name="{cid: routeParams.cid}"></div>
+    <my-contact-name options="{cid: routeParams.cid}"></my-contact-name>
   </div>
   <div crm-ui-accordion="{title: ts('Street Addresses')}">
-    <div my-contact-addresses="{cid: routeParams.cid}"></div>
+    <my-contact-addresses options="{cid: routeParams.cid}"></my-contact-addresses>
   </div>
   <div crm-ui-accordion="{title: ts('Emails')}">
-    <div my-contact-emails="{cid: routeParams.cid}"></div>
+    <my-contact-emails options="{cid: routeParams.cid}"></my-contact-emails>
   </div>
 </div>
 ```
@@ -53,11 +53,11 @@ And we should create a `ang/myContact.aff.json` looking like
 
 ```json
 {
-  "server_route": "civicrm/contact", 
+  "server_route": "civicrm/contact",
   "requires" : ["myContactName", "myContactEmails", "myContactAddresses"]
 }
 ```
-> *(FIXME: In the parent form's `*.aff.json`, we need to manually add `myContactName`, `myContactAddresses`, `myContactEmails` to the `requires` list. We should autodetect these instead.)*
+> *Note: The parent afform will automatically require the `myContactName`, `myContactAddresses`, `myContactEmails` directives. You do not need to manually include them.*
 
 We've created new files, so we'll need to flush the file-index
 

--- a/ext/afform/html/ang/afHtmlAdmin.aff.html
+++ b/ext/afform/html/ang/afHtmlAdmin.aff.html
@@ -1,9 +1,7 @@
-<div class="bootstrap-theme">
-  <div ng-if="!routeParams.name">
-    <div af-html-list=""></div>
-  </div>
+<div ng-if="!routeParams.name">
+  <af-html-list></af-html-list>
+</div>
 
-  <div ng-if="routeParams.name">
-    <div af-html-editor="{name: routeParams.name}"></div>
-  </div>
+<div ng-if="routeParams.name">
+  <af-html-editor options="{name: routeParams.name}"></af-html-editor>
 </div>

--- a/ext/afform/mock/ang/mockPage.aff.html
+++ b/ext/afform/mock/ang/mockPage.aff.html
@@ -1,3 +1,3 @@
 <div>Hello {{routeParams.name}}.</div>
-<div>The foo says "<span mock-foo/>".</div>
-<div>The bare file says "<span mock-bare-file/>"</div>
+<div>The foo says "<mock-foo></mock-foo>".</div>
+<div>The bare file says "<mock-bare-file></mock-bare-file>"</div>

--- a/ext/afform/mock/tests/phpunit/api/v4/AfformTest.php
+++ b/ext/afform/mock/tests/phpunit/api/v4/AfformTest.php
@@ -258,7 +258,7 @@ class api_v4_AfformTest extends api_v4_AfformTestCase {
     Civi\Api4\Afform::update()
       ->addWhere('name', '=', $formName)
       ->setLayoutFormat('html')
-      ->setValues(['layout' => '<div>The bare file says "<span mock-bare-file/>"</div>'])
+      ->setValues(['layout' => '<div>The bare file says "<mock-bare-file/>"</div>'])
       ->execute();
     $angModule = Civi::service('angular')->getModule($formName);
     $this->assertEquals(['afCore', 'mockBespoke', 'mockBareFile'], $angModule['requires']);

--- a/ext/oauth-client/ang/oauthClientAdmin.aff.html
+++ b/ext/oauth-client/ang/oauthClientAdmin.aff.html
@@ -2,10 +2,10 @@
 
 <div id="bootstrap-theme">
   <div ng-if="!routeParams.provider">
-    <div oauth-provider-list></div>
+    <oauth-provider-list></oauth-provider-list>
   </div>
 
   <div ng-if="routeParams.provider">
-    <div oauth-provider-detail="{provider: theProviders[routeParams.provider]}"></div>
+    <oauth-provider-detail options="{provider: theProviders[routeParams.provider]}"></oauth-provider-detail>
   </div>
 </div>

--- a/ext/oauth-client/ang/oauthProviderDetail.aff.html
+++ b/ext/oauth-client/ang/oauthProviderDetail.aff.html
@@ -18,7 +18,7 @@
       <div ng-form="editClientForm">
         <h4>{{ts('Tokens')}}</h4>
 
-        <div oauth-client-tokens="{clientId: resultClient.id}"></div>
+        <oauth-client-tokens options="{clientId: resultClient.id}"></oauth-client-tokens>
 
         <div class="btn-group" oauth-util-grant-ctrl="granter">
           <a class="btn btn-primary" ng-click="granter.authCode(resultClient.id)">{{ts('Add (Auth Code)')}}</a>
@@ -26,7 +26,7 @@
 
         <h4>{{ts('Properties')}}</h4>
 
-        <div oauth-client-editor="{client: resultClient}"></div>
+        <oauth-client-editor options="{client: resultClient}"></oauth-client-editor>
         <div class="btn-group">
           <a class="btn btn-primary"
              af-api4-action="['OAuthClient', 'update', {where: [['id', '=', resultClient.id]], values:resultClient}]">{{ts('Save')}}</a>
@@ -40,9 +40,9 @@
     </div>
 
     <div class="panel-body" ng-if="selected.tab === 'new'" ng-form="newClientForm" ng-init="theNew = {provider: options.provider.name}">
-      <div oauth-client-create-help="{provider: options.provider}"></div>
+      <oauth-client-create-help options="{provider: options.provider}"></oauth-client-create-help>
       <div crm-ui-debug="theNew"></div>
-      <div oauth-client-creator="{client: theNew}"></div>
+      <oauth-client-creator options="{client: theNew}"></oauth-client-creator>
       <div class="btn-group">
         <a class="btn btn-primary"
            af-api4-action="['OAuthClient', 'create', {values:theNew}]"


### PR DESCRIPTION
Overview
----------------------------------------
This changes every afform directive from AE to only E.

Before
----------------------------------------
Afforms could be invoked in these ways:

```html
<!-- Basic call -->
<div my-afform></div>
<my-afform></my-afform>

<!-- Call with data -->
<div my-afform="{...}"></div>
```

After
----------------------------------------
Afforms can only be invoked like this:

```html
<!-- Basic call -->
<my-afform></my-afform>

<!-- Call with data -->
<my-afform options="{...}"></my-afform>
```

Comments
----------------------------------------
My reasons for wanting this change are:

1. It's recommended best-practice by Angular docs.
2. It allows us to migrate afforms from directives to components.
3. Makes it easier to scan an html document for afforms - you don't have to look through it twice.