### PR TITLE
dev/core#2326 - Status check for invalid case type `name`s

### DIFF
--- a/CRM/Utils/Check/Component/Case.php
+++ b/CRM/Utils/Check/Component/Case.php
@@ -491,4 +491,32 @@ class CRM_Utils_Check_Component_Case extends CRM_Utils_Check_Component {
     return $messages;
   }
 
+  /**
+   * At some point the valid names changed so that you can't have e.g. spaces.
+   * For systems upgraded that use external xml files it's then not clear why
+   * the other messages about outdated filenames are coming up because when
+   * you then fix it as suggested it then gives a red error just saying it
+   * can't find it.
+   */
+  public function checkCaseTypeNameValidity() {
+    $messages = [];
+    $dao = CRM_Core_DAO::executeQuery("SELECT id, name, title FROM civicrm_case_type");
+    while ($dao->fetch()) {
+      if (!CRM_Case_BAO_CaseType::isValidName($dao->name)) {
+        $messages[] = new CRM_Utils_Check_Message(
+          __FUNCTION__ . "invalidcasetypename",
+          '<p>' . ts('Case Type "<em>%1</em>" has invalid characters in the internal machine name (<em>%2</em>). Only letters, numbers, and underscore are allowed.',
+          [
+            1 => htmlspecialchars(empty($dao->title) ? $dao->id : $dao->title),
+            2 => htmlspecialchars($dao->name),
+          ]) . '</p>',
+          ts('Invalid Case Type Name'),
+          \Psr\Log\LogLevel::ERROR,
+          'fa-exclamation'
+        );
+      }
+    }
+    return $messages;
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/2326

What happens is you get a status check message telling you the name of the file should be "Basket Weaving.xml" instead of "BasketWeaving.xml", but then when you change it you then get a status check message telling you the file is missing. It's not easy to figure out what it wants, which is that you need to remove the space from the name field in the database and then also from the filename.

Before
----------------------------------------
Not sure what you're supposed to do.

After
----------------------------------------
A bit clearer.

Technical Details
----------------------------------------
Spaces aren't allowed. Not sure why but they aren't.

Comments
----------------------------------------
An alternative would be to update `checkCaseTypeNameConsistency()`, but it already has a couple if-else blocks. And it seems like it only checks active case types.

To test this the quickest is probably:
1. Copy/paste one of the files in CRM/Case/xml/configuration.sample into CRM/Case/xml/configuration.
2. Change the filename so that underscores become spaces.
3. Inside the file change the `<name>` to match.
4. Inside the database change civicrm_case_type so the `name` field also has a space.
5. Visit the status checks page.
6. Try to resolve the error without knowing that you need to remove spaces.