### PR TITLE
dev/core#2327 - In the sample casetype xml files the <name> is the label not the name

### DIFF
--- a/CRM/Case/xml/configuration.sample/adult_day_care_referral.xml
+++ b/CRM/Case/xml/configuration.sample/adult_day_care_referral.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="iso-8859-1" ?>
 
 <CaseType>
-  <name>Adult Day Care Referral</name>
+  <name>adult_day_care_referral</name>
   <ActivityTypes>
     <ActivityType>
       <name>Open Case</name>

--- a/CRM/Case/xml/configuration.sample/housing_support.xml
+++ b/CRM/Case/xml/configuration.sample/housing_support.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="iso-8859-1" ?>
 
 <CaseType>
-  <name>Housing Support</name>
+  <name>housing_support</name>
   <ActivityTypes>
     <ActivityType>
       <name>Open Case</name>


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/2327

The `<name>` inside the file isn't used as much as I think it used to be. ~~But you can see the effect for example when using the "Print Report" feature on manage case.~~

~~Probably quickest way to test is:~~
~~1. Copy one of the casetype files from CRM/Case/xml/configuration.sample into CRM/Case/xml/configuration~~
~~2. Create or visit a case of that type and then click Print Report.~~
~~3. Now visit a regular civi page like /civicrm/admin and you'll see a big red box with all the errors it generated.~~

Ok actually looking closer I can't see where it's used at all.

Before
----------------------------------------
label

After
----------------------------------------
name

Technical Details
----------------------------------------
name - label

Comments
----------------------------------------
