### PR TITLE
[REF] Move sendNotification out of recur, remove unused related_contact

### DIFF
--- a/CRM/Core/Payment/PayPalProIPN.php
+++ b/CRM/Core/Payment/PayPalProIPN.php
@@ -274,7 +274,6 @@ class CRM_Core_Payment_PayPalProIPN extends CRM_Core_Payment_BaseIPN {
     $contribution->receive_date = !empty($input['payment_date']) ? date('YmdHis', strtotime($input['payment_date'])) : $now;
 
     $this->single($input, [
-      'related_contact' => $ids['related_contact'] ?? NULL,
       'participant' => $ids['participant'] ?? NULL,
       'contributionRecur' => $recur->id ?? NULL,
     ], $contribution, TRUE, $first);
@@ -493,7 +492,6 @@ INNER JOIN civicrm_membership_payment mp ON m.id = mp.membership_id AND mp.contr
       }
 
       $this->single($input, [
-        'related_contact' => $ids['related_contact'] ?? NULL,
         'participant' => $ids['participant'] ?? NULL,
         'contributionRecur' => $ids['contributionRecur'] ?? NULL,
       ], $contribution, FALSE, FALSE);


### PR DESCRIPTION

Overview
----------------------------------------
[REF] Move sendNotification out of recur, remove unused related_contact

Before
----------------------------------------
Send notification in the recur function, needing extra ids to be passed into the function

After
----------------------------------------
Outside the function

Technical Details
----------------------------------------
We no longer use ids['related_contact'] & are attempting to simplify (& eventually remove
the ids variable). Note the surrounding if means it will only be called on specific trxn_types

Comments
----------------------------------------
