### PR TITLE
dev/core#2328 - Make the description line breaks on the custom field edit form consistent

### DIFF
--- a/templates/CRM/Custom/Form/Field.tpl
+++ b/templates/CRM/Custom/Form/Field.tpl
@@ -99,6 +99,7 @@
       <td class="label">{$form.weight.label}</td>
       <td>{$form.weight.html|crmAddClass:two}
         {if $action neq 4}
+          <br />
           <span class="description">{ts}Weight controls the order in which fields are displayed in a group. Enter a positive or negative integer - lower numbers are displayed ahead of higher numbers.{/ts}</span>
         {/if}
       </td>
@@ -119,6 +120,7 @@
       <td class="label">{$form.help_post.label} {if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_custom_field' field='help_post' id=$id}{/if}</td>
       <td class="html-adjust">{$form.help_post.html|crmAddClass:huge}
         {if $action neq 4}
+          <br />
           <span class="description">{ts}Explanatory text displayed on back-end forms. Pre help is displayed inline on the form (above the field). Post help is displayed in a pop-up - users click the help balloon to view help text.{/ts}</span>
         {/if}
       </td>
@@ -150,7 +152,10 @@
     <tr class="crm-custom-field-form-block-is_view">
       <td class="label">{$form.is_view.label}</td>
       <td class="html-adjust">{$form.is_view.html}
-        <span class="description">{ts}Is this field set by PHP code (via a custom hook). This field will not be updated by CiviCRM.{/ts}</span>
+        {if $action neq 4}
+          <br />
+          <span class="description">{ts}Is this field set by PHP code (via a custom hook). This field will not be updated by CiviCRM.{/ts}</span>
+        {/if}
       </td>
     </tr>
   </table>


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/2328

Some of these things are not like the others, but some of these things are kind of the same.

If it's not obvious this is at e.g. civicrm/admin/custom/group/field/add?reset=1&action=add&gid=1

Before
----------------------------------------
<img width="324" alt="Untitled" src="https://user-images.githubusercontent.com/2967821/105778652-c737d900-5f3a-11eb-956b-759ee1279b99.png">


After
----------------------------------------
<img width="241" alt="Untitled-after" src="https://user-images.githubusercontent.com/2967821/105778662-cbfc8d00-5f3a-11eb-87ea-47a0cf9e42ad.png">


Technical Details
----------------------------------------


Comments
----------------------------------------

