### PR TITLE
Remove unnecessary call to error_reporting in drupal 7 integration code

### DIFF
--- a/CRM/Utils/System/Backdrop.php
+++ b/CRM/Utils/System/Backdrop.php
@@ -541,9 +541,6 @@ AND    u.status = 1
     require_once "$cmsPath/core/includes/config.inc";
     backdrop_bootstrap(BACKDROP_BOOTSTRAP_FULL);
 
-    // Explicitly setting error reporting, since we cannot handle Backdrop
-    // related notices.
-    error_reporting(1);
     if (!function_exists('module_exists') || !module_exists('civicrm')) {
       if ($throwError) {
         echo '<br />Sorry, could not load Backdrop bootstrap.';

--- a/CRM/Utils/System/Drupal.php
+++ b/CRM/Utils/System/Drupal.php
@@ -493,10 +493,6 @@ AND    u.status = 1
     // @ to suppress notices eg 'DRUPALFOO already defined'.
     @drupal_bootstrap(DRUPAL_BOOTSTRAP_FULL);
 
-    // explicitly setting error reporting, since we cannot handle drupal related notices
-    // @todo 1 = E_ERROR, but more to the point setting error reporting deep in code
-    // causes grief with debugging scripts
-    error_reporting(1);
     if (!function_exists('module_exists')) {
       if ($throwError) {
         throw new Exception('Sorry, could not load drupal bootstrap.');


### PR DESCRIPTION
Overview
----------------------------------------
There's an unneccessary call to error_reporting in drupal 7 integration code for certain entry points to turn off everything except E_ERROR.

The history on this seems to be:
* Drupal 7 was in RC and this was part of getting Civi ready for drupal 7.
* Since the integration was new there were likely lots of noisy messages. I'm interpreting the phrase we "cannot handle drupal related notices" to mean some of those messages were things that couldn't be fixed by making a change a civi and required drupal itself to fix them, so was a distraction even just for developers.
* The 2nd and 3rd lines of comments were added later in https://github.com/civicrm/civicrm-core/pull/9616 and based on that I interpret those comment lines to mean "the error_reporting call should be taken out".

I've effectively been running locally with it taken out for a long while now since the loudnotices extension mostly overrides it. Only good things have happened.

One admittedly contrived but easy and harmless way to test this is to run `cv ev "theme_user_list([]);"`. Before the patch you won't see anything in drupal watchdog. After the warnings will appear there.

Before
----------------------------------------
Sometimes hard to debug problems.

If you use CLI or REST to run code on D7 which emits a PHP warning, *the warning is hidden/obscured/unavailable*.

After
----------------------------------------
Can tell what's happening.

If you use CLI or REST to run code on D7 which emits a PHP warning, *the warning is written to D7's `watchdog` table*.
