### PR TITLE
Fix PHP notice if membershipBlock is not defined

### DIFF
--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -1167,7 +1167,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
       $this->assign('pay_later_receipt', CRM_Utils_Array::value('pay_later_receipt', $this->_values));
     }
 
-    if ($this->_membershipBlock['is_separate_payment'] && !empty($params['separate_amount'])) {
+    if ($this->_membershipBlock && $this->_membershipBlock['is_separate_payment'] && !empty($params['separate_amount'])) {
       $this->set('amount', $params['separate_amount']);
     }
     else {


### PR DESCRIPTION
Overview
----------------------------------------
Check that `$this->_membershipBlock` is defined before use.

Before
----------------------------------------
PHP notice

After
----------------------------------------
No PHP notice

Technical Details
----------------------------------------


Comments
----------------------------------------

