### PR TITLE
Payment API - Add description of `order_reference` parameter

### DIFF
--- a/api/v3/Payment.php
+++ b/api/v3/Payment.php
@@ -350,6 +350,11 @@ function _civicrm_api3_payment_get_spec(&$params) {
       'description' => ts('Transaction id supplied by external processor. This may not be unique.'),
       'type' => CRM_Utils_Type::T_STRING,
     ],
+    'order_reference' => [
+      'title' => ts('Order Reference'),
+      'description' => ts('Payment Processor external order reference'),
+      'type' => CRM_Utils_Type::T_STRING,
+    ],
     'trxn_date' => [
       'title' => ts('Payment Date'),
       'type' => CRM_Utils_Type::T_TIMESTAMP,


### PR DESCRIPTION
Overview
----------------------------------------
The `order_reference` parameter has been supported since 5.27 but is missing from the spec.

Before
----------------------------------------
Param missing

After
----------------------------------------
Param added

Technical Details
----------------------------------------


Comments
----------------------------------------
Just makes this parameter a little bit more discoverable