### PR TITLE
API Explorer - Fix URL encoding in REST examples

### DIFF
--- a/templates/CRM/Admin/Page/APIExplorer.js
+++ b/templates/CRM/Admin/Page/APIExplorer.js
@@ -19,6 +19,7 @@
     chainTpl = _.template($('#api-chain-tpl').html()),
     docCodeTpl = _.template($('#doc-code-tpl').html()),
     joinTpl = _.template($('#join-tpl').html()),
+    restTpl = _.template($('#api-rest-tpl').html()),
 
     // The following apis do not use Api3SelectQuery so do not support advanced features like joins or OR
     NO_JOINS = ['Contact', 'Contribution', 'Pledge', 'Participant'],
@@ -699,6 +700,11 @@
    * Render the api request in various formats
    */
   function formatQuery() {
+    var http = {
+      url: CRM.config.resourceBase + "extern/rest.php",
+      method:  action.startsWith('get') ? 'GET' : 'POST',
+      query: {entity: entity, action: action, json: JSON.stringify(params), api_key: 'FIXME_USER_KEY', key: 'FIXME_SITE_KEY'}
+    };
     var i = 0, q = {
       smarty: "{crmAPI var='result' entity='" + entity + "' action='" + action + "'" + (params.sequential ? '' : ' sequential=0'),
       php: "$result = civicrm_api3('" + entity + "', '" + action + "'",
@@ -706,7 +712,9 @@
       cv: "cv api " + entity + '.' + action + ' ',
       drush: "drush cvapi " + entity + '.' + action + ' ',
       wpcli: "wp cv api " + entity + '.' + action + ' ',
-      rest: CRM.config.resourceBase + "extern/rest.php?entity=" + encodeURI(entity) + "&action=" + encodeURI(action) + "&api_key=FIXME_USER_KEY&key=FIXME_SITE_KEY&json=" + encodeURI(JSON.stringify(params))
+      curl: http.method === 'GET' ?
+        "curl '" + http.url + "?" + $.param(http.query) + "'"
+        : "curl -X " + http.method + " -d '" + $.param(http.query) +"' \\\n  '" + http.url + "'"
     };
     smartyPhp = [];
     $.each(params, function(key, value) {
@@ -743,6 +751,7 @@
     } else if (smartyPhp.length) {
       q.smarty = "{php}\n  " + smartyPhp.join("\n  ") + "\n{/php}\n" + q.smarty;
     }
+    $('#api-rest').html(restTpl(http));
     $.each(q, function(type, val) {
       $('#api-' + type).text(val);
     });

--- a/templates/CRM/Admin/Page/APIExplorer.js
+++ b/templates/CRM/Admin/Page/APIExplorer.js
@@ -706,7 +706,7 @@
       cv: "cv api " + entity + '.' + action + ' ',
       drush: "drush cvapi " + entity + '.' + action + ' ',
       wpcli: "wp cv api " + entity + '.' + action + ' ',
-      rest: CRM.config.resourceBase + "extern/rest.php?entity=" + entity + "&action=" + action + "&api_key=userkey&key=sitekey&json=" + JSON.stringify(params)
+      rest: CRM.config.resourceBase + "extern/rest.php?entity=" + encodeURI(entity) + "&action=" + encodeURI(action) + "&api_key=FIXME_USER_KEY&key=FIXME_SITE_KEY&json=" + encodeURI(JSON.stringify(params))
     };
     smartyPhp = [];
     $.each(params, function(key, value) {

--- a/templates/CRM/Admin/Page/APIExplorer.tpl
+++ b/templates/CRM/Admin/Page/APIExplorer.tpl
@@ -271,7 +271,7 @@
       <div id="api-generated-wraper">
         <table id="api-generated" border=1>
           <caption>{ts}Code{/ts}</caption>
-          <tr><td>Rest</td><td><pre id="api-rest"></pre></td></tr>
+          <tr><td>Rest</td><td><div id="api-rest"></div></td></tr>
           <tr><td>Smarty</td><td><pre class="linenums" id="api-smarty" title='smarty syntax (for get actions)'></pre></td></tr>
           <tr><td>Php</td><td><pre class="linenums" id="api-php" title='php syntax'></pre></td></tr>
           <tr><td>Javascript</td><td><pre class="linenums" id="api-json" title='javascript syntax'></pre></td></tr>
@@ -282,6 +282,7 @@
           {if $config->userSystem->is_wordpress}
             <tr><td><a href="http://wp-cli.org/" target="_blank">wp-cli</a></td><td><pre id="api-wpcli" title='wp-cli syntax'></pre></td></tr>
           {/if}
+          <tr><td><a href="https://curl.se/">curl</a></td><td><pre id="api-curl"></pre></td></tr>
         </table>
       </div>
       <div class="crm-submit-buttons">
@@ -347,6 +348,15 @@
 </div>
 </div>
 {strip}
+<script type="text/template" id="api-rest-tpl">
+  <pre><%- method %> <%- url %></pre>
+  <ul>{literal}
+    <% _.forEach(query, function(value, field){ %>
+      <li><b><%- field %></b>: <pre style="display: inline-block"><%- value %></pre></li>
+    <% }); %>
+  {/literal}</ul>
+</script>
+
 <script type="text/template" id="api-param-tpl">
   <tr class="api-param-row">
     <td>

--- a/templates/CRM/Admin/Page/APIExplorer.tpl
+++ b/templates/CRM/Admin/Page/APIExplorer.tpl
@@ -203,6 +203,19 @@
     text-align: right;
     font-style: italic;
   }
+  .crm-container .api-rest-params pre {
+    display: inline-block;
+  }
+  .crm-container .api-rest-params tr td:first-child {
+    text-align: right;
+  }
+  .crm-container .api-rest-params tr td:first-child + td {
+    text-align: center;
+    width: 1em;
+  }
+  .crm-container .api-rest-params tr td:first-child + td + td {
+    text-align: left;
+  }
   {/literal}
 </style>
 
@@ -349,12 +362,16 @@
 </div>
 {strip}
 <script type="text/template" id="api-rest-tpl">
-  <pre><%- method %> <%- url %></pre>
-  <ul>{literal}
+  <pre class="api-rest-url"><%- method %> <%- url %></pre>
+  <table class="api-rest-params"><tbody>{literal}
     <% _.forEach(query, function(value, field){ %>
-      <li><b><%- field %></b>: <pre style="display: inline-block"><%- value %></pre></li>
+    <tr>
+      <td><pre><%- field %></pre></td>
+      <td>=</td>
+      <td><pre><%- value %></pre></td>
+    </tr>
     <% }); %>
-  {/literal}</ul>
+  {/literal}</table>
 </script>
 
 <script type="text/template" id="api-param-tpl">


### PR DESCRIPTION
Overview
----------------------------------------
This improves the REST examples generated in "Support => Developer => Api Explorer v3".

Before
----------------------------------------

If you use `Contact`.`get` with `id=1`, it generates a "Rest" URL like this:

```
http://dmaster.bknix:8001/sites/all/modules/civicrm/extern/rest.php
  ?entity=Contact&action=get&api_key=userkey&key=sitekey&json={"sequential":1,"id":1}
```

After
----------------------------------------

In initial iteration of this PR, it simply updated the URL:

```
http://dmaster.bknix:8001/sites/all/modules/civicrm/extern/rest.php
  ?entity=Contact&action=get&api_key=FIXME_USER_KEY&key=FIXME_SITE_KEY&json=%7B%22sequential%22%3A1%2C%22id%22%3A1%7D
```

Based on some PR discussion, it seems that the single "Rest" URL was trying to do two things (explain the structure and provide a working example) - but it didn't quite achieve either, and they're a bit at-odds. So the final iteration of the PR splits this into two sections:

* "Rest" describes the HTTP request in general/readable terms.
* "curl" provides a working example of an HTTP request

Screenshots are in the discussion.

Technical Details
----------------------------------------

Notable elements:

* Apply URL encoding to the `json` param. (*This is the main thing that needed fixing.*)
* Apply URL encoding to the `entity` and `action` params. (*In practice, with normal values, this doesn't change anything.*)
* Make the placeholder/example values more obvious (eg `userkey` => `FIXME_USER_KEY`).

How much does it matter to have the `json` param encoded? Depends on the HTTP client and the specific data. Ex:

* `wget` escapes invalid characters automatically (`{` => `%7B`). 
* `curl` treats the `{...}` expression as a list for use in permutation (much like `bash` would). It sends multiple/different calls (one with `json="sequential":1`; the other with `json="id":1`).

There are some cases where these rules still yield a valid call. There are other cases where it will always yield an incorrect call. (Ex: if you set `first_name` to `Alice&Bob`, the `json` includes an unencoded `&` which mucks up the params).