### PR TITLE
SearchKit: Add support for multi-record custom field groups

### DIFF
--- a/Civi/Api4/Action/Entity/Get.php
+++ b/Civi/Api4/Action/Entity/Get.php
@@ -102,6 +102,9 @@ class Get extends \Civi\Api4\Generic\BasicGetAction {
         'title' => $customEntity['title'],
         'title_plural' => $customEntity['title'],
         'description' => ts('Custom group for %1', [1 => $baseEntity::getInfo()['title_plural']]),
+        'searchable' => TRUE,
+        'type' => ['CustomValue'],
+        'paths' => [],
         'see' => [
           'https://docs.civicrm.org/user/en/latest/organising-your-data/creating-custom-fields/#multiple-record-fieldsets',
           '\\Civi\\Api4\\CustomGroup',


### PR DESCRIPTION
Overview
----------------------------------------
This adds support for multi-record custom field group pseudo-entities to be added to the search as joins.

Before
----------------------------------------
Multi-record custom groups not available.

After
----------------------------------------
Multi-record custom groups available

Technical Details
----------------------------------------
It was just a matter of telling SearchKit about them. Everything at the API level appears to already work.