### PR TITLE
[dev/financial#164] Cannot edit contribution with revenue recognition date in a past year 

### DIFF
--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -682,7 +682,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
 
     // CRM-16189, add Revenue Recognition Date
     if (Civi::settings()->get('deferred_revenue_enabled')) {
-      $revenueDate = $this->add('date', 'revenue_recognition_date', ts('Revenue Recognition Date'), CRM_Core_SelectValues::date(NULL, 'M Y', NULL, 5));
+      $revenueDate = $this->add('datepicker', 'revenue_recognition_date', ts('Revenue Recognition Date'), [], FALSE, ['time' => FALSE]);
       if ($this->_id && !CRM_Contribute_BAO_Contribution::allowUpdateRevenueRecognitionDate($this->_id)) {
         $revenueDate->freeze();
       }
@@ -1543,12 +1543,8 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
       }
 
       $params['revenue_recognition_date'] = NULL;
-      if (!empty($formValues['revenue_recognition_date'])
-        && count(array_filter($formValues['revenue_recognition_date'])) == 2
-      ) {
-        $params['revenue_recognition_date'] = CRM_Utils_Date::processDate(
-          '01-' . implode('-', $formValues['revenue_recognition_date'])
-        );
+      if (!empty($formValues['revenue_recognition_date'])) {
+        $params['revenue_recognition_date'] = $formValues['revenue_recognition_date'];
       }
 
       if (!empty($formValues['is_email_receipt'])) {


### PR DESCRIPTION
Overview
----------------------------------------
If you are on a site with "Enable Deferred Revenue" turned on (this is a setting on the "CiviContribute Component Settings" form CiviCRM Admin Menu-> Administer -> CiviContribute -> CiviContribute Component Settings). A "Revenue Recognition Date" field is added to all contribution records.

If you try and edit a contribution with a "Revenue Recognition Date" with a date before the current year you will get an error "Month and Year are required field for Revenue Recognition."

This is because the year options for the "Revenue Recognition Date" field are defined as the next this year and the next 5 years. Previous years are not considered a valid entry and fail validation.

This change switches the "Revenue Recognition Date" field to a datepicker field where all dates are available.

Before
----------------------------------------
1. On a site with Deferred Revenue set up
2. Create a contribution with a "Revenue Recognition Date" in 2020 (you can't do this in the UI since only the years 2021 - 2026 are available)
3. edit the contribution
4. save the contribution 

RESULT: save fails with "Month and Year are required field for Revenue Recognition." error
 
After
----------------------------------------
1. On a site with Deferred Revenue set up
2. Create a contribution with a "Revenue Recognition Date" in 2020 (you can do this in the UI because the field now uses the standard datepicker)
3. edit the contribution
4. save the contribution

RESULT: Contribution saves as expected