### PR TITLE
Afform GUI enhancements & Search Kit integration

### DIFF
--- a/CRM/Utils/Array.php
+++ b/CRM/Utils/Array.php
@@ -81,6 +81,41 @@ class CRM_Utils_Array {
   }
 
   /**
+   * Recursively searches through a given array for all matches
+   *
+   * @param $collection
+   * @param $predicate
+   * @return array
+   */
+  public static function findAll($collection, $predicate) {
+    $results = [];
+    $search = function($collection) use (&$search, &$results, $predicate) {
+      if (is_array($collection)) {
+        if (is_callable($predicate)) {
+          if ($predicate($collection)) {
+            $results[] = $collection;
+          }
+        }
+        elseif (is_array($predicate)) {
+          if (count(array_intersect_assoc($collection, $predicate)) === count($predicate)) {
+            $results[] = $collection;
+          }
+        }
+        else {
+          if (array_key_exists($predicate, $collection)) {
+            $results[] = $collection;
+          }
+        }
+        foreach ($collection as $item) {
+          $search($item);
+        }
+      }
+    };
+    $search($collection);
+    return $results;
+  }
+
+  /**
    * Wraps and slightly changes the behavior of PHP's array_search().
    *
    * This function reproduces the behavior of array_search() from PHP prior to

--- a/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php
+++ b/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php
@@ -51,7 +51,10 @@ class AfformAdminMeta {
         'label' => $contactTypes[$entityName]['label'],
       ];
     }
-    $info = ("\Civi\Api4\\{$entityName}")::getInfo();
+    $info = \Civi\Api4\Entity::get(FALSE)
+      ->addWhere('name', '=', $entityName)
+      ->addSelect('title', 'icon')
+      ->execute()->first();
     return [
       'entity' => $entityName,
       'label' => $info['title'],

--- a/ext/afform/admin/Civi/Api4/Action/Afform/LoadAdminData.php
+++ b/ext/afform/admin/Civi/Api4/Action/Afform/LoadAdminData.php
@@ -1,0 +1,190 @@
+<?php
+
+namespace Civi\Api4\Action\Afform;
+
+use Civi\AfformAdmin\AfformAdminMeta;
+use Civi\Api4\Afform;
+
+/**
+ * This action is used by the Afform Admin extension to load metadata for the Admin GUI.
+ *
+ * @package Civi\Api4\Action\Afform
+ */
+class LoadAdminData extends \Civi\Api4\Generic\AbstractAction {
+
+  /**
+   * Any properties already known about the afform
+   * @var array
+   */
+  protected $definition;
+
+  /**
+   * Entity type when creating a new form
+   * @var string
+   */
+  protected $entity;
+
+  public function _run(\Civi\Api4\Generic\Result $result) {
+    $info = ['fields' => [], 'blocks' => []];
+    $entities = [];
+    $newForm = empty($this->definition['name']);
+
+    if (!$newForm) {
+      // Load existing afform if name provided
+      $info['definition'] = $this->loadForm($this->definition['name']);
+    }
+    else {
+      // Create new blank afform
+      switch ($this->definition['type']) {
+        case 'form':
+          $info['definition'] = $this->definition + [
+            'title' => '',
+            'permission' => 'access CiviCRM',
+            'layout' => [
+              [
+                '#tag' => 'af-form',
+                'ctrl' => 'afform',
+                '#children' => [],
+              ],
+            ],
+          ];
+          break;
+
+        case 'block':
+          $info['definition'] = $this->definition + [
+            'title' => '',
+            'layout' => [],
+          ];
+          break;
+      }
+    }
+
+    $getFieldsMode = 'create';
+
+    // Generate list of possibly embedded afform tags to search for
+    $allAfforms = \Civi::service('afform_scanner')->findFilePaths();
+    foreach ($allAfforms as $name => $path) {
+      $allAfforms[$name] = _afform_angular_module_name($name, 'dash');
+    }
+    // Find all entities by recursing into embedded afforms
+    $scanBlocks = function($layout) use (&$scanBlocks, &$info, &$entities, $allAfforms) {
+      // Find declared af-entity tags
+      foreach (\CRM_Utils_Array::findAll($layout, ['#tag' => 'af-entity']) as $afEntity) {
+        // Convert "Contact" to "Individual", "Organization" or "Household"
+        if ($afEntity['type'] === 'Contact' && !empty($afEntity['data'])) {
+          $data = \CRM_Utils_JS::decode($afEntity['data']);
+          $entities[] = $data['contact_type'] ?? $afEntity['type'];
+        }
+        else {
+          $entities[] = $afEntity['type'];
+        }
+      }
+      $joins = array_column(\CRM_Utils_Array::findAll($layout, 'af-join'), 'af-join');
+      $entities = array_unique(array_merge($entities, $joins));
+      $blockTags = array_unique(array_column(\CRM_Utils_Array::findAll($layout, function($el) use ($allAfforms) {
+        return in_array($el['#tag'], $allAfforms);
+      }), '#tag'));
+      foreach ($blockTags as $blockTag) {
+        if (!isset($info['blocks'][$blockTag])) {
+          // Load full contents of block used on the form, then recurse into it
+          $embeddedForm = Afform::get($this->checkPermissions)
+            ->setFormatWhitespace(TRUE)
+            ->setLayoutFormat('shallow')
+            ->addWhere('directive_name', '=', $blockTag)
+            ->execute()->first();
+          if ($embeddedForm['type'] === 'block') {
+            $info['blocks'][$blockTag] = $embeddedForm;
+          }
+          if (!empty($embeddedForm['join'])) {
+            $entities = array_unique(array_merge($entities, [$embeddedForm['join']]));
+          }
+          $scanBlocks($embeddedForm['layout']);
+        }
+      }
+    };
+
+    if ($info['definition']['type'] === 'form') {
+      if ($newForm) {
+        $entities[] = $this->entity;
+        $defaultEntity = AfformAdminMeta::getAfformEntity($this->entity);
+        if (!empty($defaultEntity['boilerplate'])) {
+          $scanBlocks($defaultEntity['boilerplate']);
+        }
+      }
+      else {
+        $scanBlocks($info['definition']['layout']);
+      }
+
+      if (array_intersect($entities, ['Individual', 'Household', 'Organization'])) {
+        $entities[] = 'Contact';
+      }
+
+      // The full contents of blocks used on the form have been loaded. Get basic info about others relevant to these entities.
+      $blockInfo = Afform::get($this->checkPermissions)
+        ->addSelect('name', 'title', 'block', 'join', 'directive_name')
+        ->addWhere('type', '=', 'block')
+        ->addWhere('block', 'IN', $entities)
+        ->addWhere('directive_name', 'NOT IN', array_keys($info['blocks']))
+        ->execute();
+      $info['blocks'] = array_merge(array_values($info['blocks']), (array) $blockInfo);
+    }
+
+    if ($info['definition']['type'] === 'block') {
+      $entities[] = $info['definition']['join'] ?? $info['definition']['block'];
+    }
+
+    // Optimization - since contact fields are a combination of these three,
+    // we'll combine them client-side rather than sending them via ajax.
+    if (array_intersect($entities, ['Individual', 'Household', 'Organization'])) {
+      $entities = array_diff($entities, ['Contact']);
+    }
+
+    foreach ($entities as $entity) {
+      $info['entities'][$entity] = AfformAdminMeta::getApiEntity($entity);
+      $info['fields'][$entity] = AfformAdminMeta::getFields($entity, ['action' => $getFieldsMode]);
+    }
+
+    $result[] = $info;
+  }
+
+  private function loadForm($name) {
+    return Afform::get($this->checkPermissions)
+      ->setFormatWhitespace(TRUE)
+      ->setLayoutFormat('shallow')
+      ->addWhere('name', '=', $name)
+      ->execute()->first();
+  }
+
+  public function fields() {
+    return [
+      [
+        'name' => 'definition',
+        'data_type' => 'Array',
+      ],
+      [
+        'name' => 'blocks',
+        'data_type' => 'Array',
+      ],
+      [
+        'name' => 'fields',
+        'data_type' => 'Array',
+      ],
+    ];
+  }
+
+  /**
+   * @return array
+   */
+  public function getDefinition():array {
+    return $this->definition;
+  }
+
+  /**
+   * @param array $definition
+   */
+  public function setDefinition(array $definition) {
+    $this->definition = $definition;
+    return $this;
+  }
+
+}

--- a/ext/afform/admin/afformEntities/Activity.php
+++ b/ext/afform/admin/afformEntities/Activity.php
@@ -1,7 +1,6 @@
 <?php
 return [
   'entity' => 'Activity',
-  'label' => ts('Activity'),
   'defaults' => "{'url-autofill': '1'}",
   'boilerplate' => [
     ['#tag' => 'af-field', 'name' => 'subject'],

--- a/ext/afform/admin/afformEntities/Activity.php
+++ b/ext/afform/admin/afformEntities/Activity.php
@@ -3,4 +3,7 @@ return [
   'entity' => 'Activity',
   'label' => ts('Activity'),
   'defaults' => "{'url-autofill': '1'}",
+  'boilerplate' => [
+    ['#tag' => 'af-field', 'name' => 'subject'],
+  ],
 ];

--- a/ext/afform/admin/afformEntities/Household.php
+++ b/ext/afform/admin/afformEntities/Household.php
@@ -9,6 +9,7 @@ return [
     },
     'url-autofill': '1'
   }",
+  'icon' => 'fa-home',
   'boilerplate' => [
     ['#tag' => 'afblock-name-household'],
   ],

--- a/ext/afform/admin/afformEntities/Household.php
+++ b/ext/afform/admin/afformEntities/Household.php
@@ -9,4 +9,7 @@ return [
     },
     'url-autofill': '1'
   }",
+  'boilerplate' => [
+    ['#tag' => 'afblock-name-household'],
+  ],
 ];

--- a/ext/afform/admin/afformEntities/Individual.php
+++ b/ext/afform/admin/afformEntities/Individual.php
@@ -9,4 +9,7 @@ return [
     },
     'url-autofill': '1'
   }",
+  'boilerplate' => [
+    ['#tag' => 'afblock-name-individual'],
+  ],
 ];

--- a/ext/afform/admin/afformEntities/Individual.php
+++ b/ext/afform/admin/afformEntities/Individual.php
@@ -9,6 +9,7 @@ return [
     },
     'url-autofill': '1'
   }",
+  'icon' => 'fa-user',
   'boilerplate' => [
     ['#tag' => 'afblock-name-individual'],
   ],

--- a/ext/afform/admin/afformEntities/Organization.php
+++ b/ext/afform/admin/afformEntities/Organization.php
@@ -9,4 +9,7 @@ return [
     },
     'url-autofill': '1'
   }",
+  'boilerplate' => [
+    ['#tag' => 'afblock-name-organization'],
+  ],
 ];

--- a/ext/afform/admin/afformEntities/Organization.php
+++ b/ext/afform/admin/afformEntities/Organization.php
@@ -9,6 +9,7 @@ return [
     },
     'url-autofill': '1'
   }",
+  'icon' => 'fa-building',
   'boilerplate' => [
     ['#tag' => 'afblock-name-organization'],
   ],

--- a/ext/afform/admin/ang/afAdmin.ang.php
+++ b/ext/afform/admin/ang/afAdmin.ang.php
@@ -9,7 +9,7 @@ return [
   'css' => [],
   'partials' => ['ang/afAdmin'],
   'requires' => ['api4', 'afGuiEditor', 'crmRouteBinder'],
-  'settingsFactory' => ['CRM_AfformAdmin_Utils', 'getAdminSettings'],
+  'settingsFactory' => ['Civi\AfformAdmin\AfformAdminMeta', 'getAdminSettings'],
   'basePages' => ['civicrm/admin/afform'],
   'bundles' => ['bootstrap3'],
 ];

--- a/ext/afform/admin/ang/afAdmin.js
+++ b/ext/afform/admin/ang/afAdmin.js
@@ -42,6 +42,18 @@
           }
         }
       });
+      $routeProvider.when('/clone/:name', {
+        controller: 'afAdminGui',
+        template: '<af-gui-editor mode="clone" data="$ctrl.data"></af-gui-editor>',
+        resolve: {
+          // Load data for gui editor
+          data: function($route, crmApi4) {
+            return crmApi4('Afform', 'loadAdminData', {
+              definition: {name: $route.current.params.name}
+            }, 0);
+          }
+        }
+      });
     });
 
 })(angular, CRM.$, CRM._);

--- a/ext/afform/admin/ang/afAdmin.js
+++ b/ext/afform/admin/ang/afAdmin.js
@@ -17,13 +17,30 @@
           }
         }
       });
-      $routeProvider.when('/create/:type', {
+      $routeProvider.when('/create/:type/:entity', {
         controller: 'afAdminGui',
-        template: '<af-gui-editor type="$ctrl.type"></af-gui-editor>',
+        template: '<af-gui-editor mode="create" data="$ctrl.data" entity="$ctrl.entity"></af-gui-editor>',
+        resolve: {
+          // Load data for gui editor
+          data: function($route, crmApi4) {
+            return crmApi4('Afform', 'loadAdminData', {
+              definition: {type: $route.current.params.type},
+              entity: $route.current.params.entity
+            }, 0);
+          }
+        }
       });
       $routeProvider.when('/edit/:name', {
         controller: 'afAdminGui',
-        template: '<af-gui-editor name="$ctrl.name"></af-gui-editor>',
+        template: '<af-gui-editor mode="edit" data="$ctrl.data"></af-gui-editor>',
+        resolve: {
+          // Load data for gui editor
+          data: function($route, crmApi4) {
+            return crmApi4('Afform', 'loadAdminData', {
+              definition: {name: $route.current.params.name}
+            }, 0);
+          }
+        }
       });
     });
 

--- a/ext/afform/admin/ang/afAdmin/afAdminGui.controller.js
+++ b/ext/afform/admin/ang/afAdmin/afAdminGui.controller.js
@@ -1,15 +1,11 @@
 (function(angular, $, _) {
   "use strict";
 
-  angular.module('afAdmin').controller('afAdminGui', function($scope, $routeParams) {
-    var ts = $scope.ts = CRM.ts(),
-      ctrl = $scope.$ctrl = this;
-
-    // Edit mode
-    this.name = $routeParams.name;
-    // Create mode
-    this.type = $routeParams.type;
-
+  angular.module('afAdmin').controller('afAdminGui', function($scope, $route, data) {
+    $scope.$ctrl = this;
+    this.entity = $route.current.params.entity;
+    // Pass through result from api Afform.loadAdminData
+    this.data = data;
   });
 
 })(angular, CRM.$, CRM._);

--- a/ext/afform/admin/ang/afAdmin/afAdminList.controller.js
+++ b/ext/afform/admin/ang/afAdmin/afAdminList.controller.js
@@ -63,6 +63,21 @@
         });
         $scope.tabs.block.options = _.sortBy(links, 'Label');
       }
+
+      if (ctrl.tab === 'search') {
+        crmApi4('SearchDisplay', 'get', {
+          select: ['name', 'label', 'type:icon', 'saved_search.name', 'saved_search.label']
+        }).then(function(searchDisplays) {
+          _.each(searchDisplays, function(searchDisplay) {
+            links.push({
+              url: '#create/search/' + searchDisplay['saved_search.name'] + '.' + searchDisplay.name,
+              label: searchDisplay['saved_search.label'] + ': ' + searchDisplay.label,
+              icon: searchDisplay['type:icon']
+            });
+          });
+          $scope.tabs.search.options = _.sortBy(links, 'Label');
+        });
+      }
     };
 
     this.revert = function(afform) {

--- a/ext/afform/admin/ang/afAdmin/afAdminList.controller.js
+++ b/ext/afform/admin/ang/afAdmin/afAdminList.controller.js
@@ -8,11 +8,20 @@
     $scope.crmUrl = CRM.url;
 
     this.tabs = CRM.afAdmin.afform_type;
+    $scope.tabs = _.indexBy(ctrl.tabs, 'name');
+    _.each(['form', 'block', 'search'], function(type) {
+      if ($scope.tabs[type]) {
+        $scope.tabs[type].options = [];
+        if (type === 'form') {
+          $scope.tabs.form.default = '#create/form/Individual';
+        }
+      }
+    });
 
     this.afforms = _.transform(afforms, function(afforms, afform) {
-      var type = afform.type || 'system';
-      afforms[type] = afforms[type] || [];
-      afforms[type].push(afform);
+      afform.type = afform.type || 'system';
+      afforms[afform.type] = afforms[afform.type] || [];
+      afforms[afform.type].push(afform);
     }, {});
 
     $scope.$bindToRoute({
@@ -21,6 +30,40 @@
       format: 'raw',
       default: ctrl.tabs[0].name
     });
+
+    this.createLinks = function() {
+      ctrl.searchCreateLinks = '';
+      if ($scope.tabs[ctrl.tab].options.length) {
+        return;
+      }
+      var links = [];
+
+      if (ctrl.tab === 'form') {
+        _.each(CRM.afGuiEditor.entities, function(entity, name) {
+          if (entity.defaults) {
+            links.push({
+              url: '#create/form/' + name,
+              label: entity.label,
+              icon: entity.icon
+            });
+          }
+        });
+        $scope.tabs.form.options = _.sortBy(links, 'Label');
+      }
+
+      if (ctrl.tab === 'block') {
+        _.each(CRM.afGuiEditor.entities, function(entity, name) {
+          if (entity.defaults) {
+            links.push({
+              url: '#create/block/' + name,
+              label: entity.label,
+              icon: entity.icon
+            });
+          }
+        });
+        $scope.tabs.block.options = _.sortBy(links, 'Label');
+      }
+    };
 
     this.revert = function(afform) {
       var index = _.findIndex(ctrl.afforms[ctrl.tab], {name: afform.name});

--- a/ext/afform/admin/ang/afAdmin/afAdminList.html
+++ b/ext/afform/admin/ang/afAdmin/afAdminList.html
@@ -57,6 +57,7 @@
       <td>{{afform.is_public ? ts('Frontend') : ts('Backend')}}</td>
       <td>
         <a ng-if="afform.type !== 'system'" href="#/edit/{{ afform.name }}" class="btn btn-xs btn-primary">{{ ts('Edit') }}</a>
+        <a ng-if="afform.type !== 'system'" href="#/clone/{{ afform.name }}" class="btn btn-xs btn-primary">{{ ts('Clone') }}</a>
         <a href ng-if="afform.has_local" class="btn btn-xs btn-danger" crm-confirm="{type: afform.has_base ? 'revert' : 'delete', obj: afform}" on-yes="$ctrl.revert(afform)">
           {{ afform.has_base ? ts('Revert') : ts('Delete') }}
         </a>

--- a/ext/afform/admin/ang/afAdmin/afAdminList.html
+++ b/ext/afform/admin/ang/afAdmin/afAdminList.html
@@ -38,8 +38,8 @@
     <tr>
       <th>{{:: ts('Title') }}</th>
       <th>{{:: ts('Name') }}</th>
-      <th>{{:: ts('Server Route') }}</th>
-      <th>{{:: ts('Frontend?') }}</th>
+      <th>{{:: ts('Page') }}</th>
+      <th>{{:: ts('Style') }}</th>
       <th></th>
     </tr>
     </thead>

--- a/ext/afform/admin/ang/afAdmin/afAdminList.html
+++ b/ext/afform/admin/ang/afAdmin/afAdminList.html
@@ -1,21 +1,36 @@
 <div id="bootstrap-theme" class="afadmin-list">
   <h1 crm-page-title>{{:: ts('Configurable Forms') }}</h1>
 
-  <div class="form-inline text-right">
-    <a class="btn btn-primary" href="#/create/form">
-      <i class="crm-i fa-plus"></i>
-      {{:: ts('New Form') }}
-    </a>
-  </div>
-
   <ul class="nav nav-tabs">
     <li role="presentation" ng-repeat="tab in $ctrl.tabs" ng-class="{active: tab.name === $ctrl.tab}">
-      <a href ng-click="$ctrl.tab = tab.name"><i class="crm-i {{ tab.icon }}"></i> {{:: tab.label }}</a>
+      <a href ng-click="$ctrl.tab = tab.name; $ctrl.searchAfformList = ''"><i class="crm-i {{ tab.icon }}"></i> {{:: tab.label }}</a>
     </li>
   </ul>
 
   <div class="form-inline">
-    <input class="form-control" type="search" ng-model="$ctrl.search" placeholder="{{:: ts('Filter') }}">
+    <label for="afform-list-filter">{{:: ts('Filter:') }}</label>
+    <input class="form-control" type="search" id="afform-list-filter" ng-model="$ctrl.searchAfformList" placeholder="&#xf002">
+    <div class="btn-group pull-right" ng-if="tabs[$ctrl.tab].options">
+      <a ng-if="tabs[$ctrl.tab].default" href="{{ tabs[$ctrl.tab].default }}" class="btn btn-primary">
+        {{ ts('New %1', {1: tabs[$ctrl.tab].label }) }}
+      </a>
+      <button ng-click="$ctrl.createLinks()" type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+        <span ng-class="{'sr-only': tabs[$ctrl.tab].default}">{{ ts('New %1', {1: tabs[$ctrl.tab].label }) }}</span>
+        <span class="caret"></span>
+      </button>
+      <ul class="dropdown-menu">
+        <li>
+          <input ng-if="tabs[$ctrl.tab].options.length" type="search" class="form-control" placeholder="&#xf002" ng-model="$ctrl.searchCreateLinks">
+          <a href ng-if="!tabs[$ctrl.tab].options.length"><i class="crm-i fa-spinner fa-spin"></i></a>
+        </li>
+        <li ng-repeat="link in tabs[$ctrl.tab].options | filter:$ctrl.searchCreateLinks">
+          <a href="{{ link.url }}">
+            <i class="crm-i {{ link.icon }}"></i>
+            {{ link.label }}
+          </a>
+        </li>
+      </ul>
+    </div>
   </div>
 
   <table>
@@ -29,7 +44,7 @@
     </tr>
     </thead>
     <tbody>
-    <tr ng-repeat="afform in $ctrl.afforms[$ctrl.tab] | filter:$ctrl.search">
+    <tr ng-repeat="afform in $ctrl.afforms[$ctrl.tab] | filter:$ctrl.searchAfformList">
       <td>{{afform.title}}</td>
       <td>
         <code>{{afform.name}}</code>
@@ -41,7 +56,7 @@
       </td>
       <td>{{afform.is_public ? ts('Frontend') : ts('Backend')}}</td>
       <td>
-        <a href="#/edit/{{ afform.name }}" class="btn btn-xs btn-primary">{{ ts('Edit') }}</a>
+        <a ng-if="afform.type !== 'system'" href="#/edit/{{ afform.name }}" class="btn btn-xs btn-primary">{{ ts('Edit') }}</a>
         <a href ng-if="afform.has_local" class="btn btn-xs btn-danger" crm-confirm="{type: afform.has_base ? 'revert' : 'delete', obj: afform}" on-yes="$ctrl.revert(afform)">
           {{ afform.has_base ? ts('Revert') : ts('Delete') }}
         </a>

--- a/ext/afform/admin/ang/afGuiEditor.ang.php
+++ b/ext/afform/admin/ang/afGuiEditor.ang.php
@@ -9,7 +9,7 @@ return [
   'css' => ['ang/afGuiEditor.css'],
   'partials' => ['ang/afGuiEditor'],
   'requires' => ['crmUi', 'crmUtil', 'dialogService', 'api4', 'crmMonaco', 'ui.sortable'],
-  'settingsFactory' => ['CRM_AfformAdmin_Utils', 'getGuiSettings'],
+  'settingsFactory' => ['Civi\AfformAdmin\AfformAdminMeta', 'getGuiSettings'],
   'basePages' => [],
   'exports' => [
     'af-gui-editor' => 'E',

--- a/ext/afform/admin/ang/afGuiEditor.css
+++ b/ext/afform/admin/ang/afGuiEditor.css
@@ -120,6 +120,11 @@
   background-color: #b3b3b3;
 }
 
+#afGuiEditor .af-gui-bar > .form-inline > span {
+  color: #696969;
+  font-style: italic;
+}
+
 #afGuiEditor .af-gui-element {
   position: relative;
   padding: 0 3px 3px;
@@ -138,6 +143,13 @@
 #afGuiEditor af-gui-field,
 #afGuiEditor af-gui-edit-options {
   display: block;
+}
+
+#afGuiEditor .af-gui-search-display {
+  border: 1px dotted gray;
+  color: gray;
+  padding: 3em;
+  background-color: #f9f9f9;
 }
 
 #afGuiEditor .af-gui-container-type-fieldset {

--- a/ext/afform/admin/ang/afGuiEditor.css
+++ b/ext/afform/admin/ang/afGuiEditor.css
@@ -81,15 +81,15 @@
   font-size: 12px;
 }
 
-#afGuiEditor input[type=search]::placeholder {
+#bootstrap-theme input[type=search]::placeholder {
   font-family: FontAwesome;
   text-align: right;
 }
-#afGuiEditor input[type=search]:-ms-input-placeholder {
+#bootstrap-theme input[type=search]:-ms-input-placeholder {
   font-family: FontAwesome;
   text-align: right;
 }
-#afGuiEditor input[type=search]::-ms-input-placeholder {
+#bootstrap-theme input[type=search]::-ms-input-placeholder {
   font-family: FontAwesome;
   text-align: right;
 }

--- a/ext/afform/admin/ang/afGuiEditor.js
+++ b/ext/afform/admin/ang/afGuiEditor.js
@@ -72,6 +72,7 @@
             delete entity.fields;
           });
           CRM.afGuiEditor.blocks = {};
+          CRM.afGuiEditor.searchDisplays = {};
         },
 
         // Takes the results from api.Afform.loadAdminData and processes the metadata
@@ -111,6 +112,9 @@
               (CRM.afGuiEditor.entities.Organization || {}).fields
             );
           }
+          _.each(data.search_displays, function(display) {
+            CRM.afGuiEditor.searchDisplays[display['saved_search.name'] + '.' + display.name] = display;
+          });
         },
 
         meta: CRM.afGuiEditor,
@@ -120,7 +124,8 @@
         },
 
         getField: function(entityName, fieldName) {
-          return CRM.afGuiEditor.entities[entityName].fields[fieldName];
+          var fields = CRM.afGuiEditor.entities[entityName].fields;
+          return fields[fieldName] || fields[fieldName.substr(fieldName.indexOf('.') + 1)];
         },
 
         // Recursively searches a collection and its children using _.filter

--- a/ext/afform/admin/ang/afGuiEditor.js
+++ b/ext/afform/admin/ang/afGuiEditor.js
@@ -115,8 +115,12 @@
 
         meta: CRM.afGuiEditor,
 
-        getField: function(entityType, fieldName) {
-          return CRM.afGuiEditor.entities[entityType].fields[fieldName];
+        getEntity: function(entityName) {
+          return CRM.afGuiEditor.entities[entityName];
+        },
+
+        getField: function(entityName, fieldName) {
+          return CRM.afGuiEditor.entities[entityName].fields[fieldName];
         },
 
         // Recursively searches a collection and its children using _.filter

--- a/ext/afform/admin/ang/afGuiEditor/afGuiEditor.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiEditor.component.js
@@ -51,7 +51,7 @@
           }
         }
 
-        else if ($scope.afform.type === 'block') {
+        if ($scope.afform.type === 'block') {
           editor.layout['#children'] = $scope.afform.layout;
           editor.blockEntity = $scope.afform.join || $scope.afform.block;
           $scope.entities[editor.blockEntity] = {
@@ -59,6 +59,11 @@
             name: editor.blockEntity,
             label: afGui.getEntity(editor.blockEntity).label
           };
+        }
+
+        if ($scope.afform.type === 'search') {
+          editor.layout['#children'] = afGui.findRecursive($scope.afform.layout, {'af-fieldset': ''})[0]['#children'];
+
         }
 
         // Set changesSaved to true on initial load, false thereafter whenever changes are made to the model

--- a/ext/afform/admin/ang/afGuiEditor/afGuiEditor.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiEditor.component.js
@@ -33,12 +33,28 @@
         }
         $scope.canvasTab = 'layout';
         $scope.layoutHtml = '';
-        editor.layout = afGui.findRecursive($scope.afform.layout, {'#tag': 'af-form'})[0];
-        $scope.entities = afGui.findRecursive(editor.layout['#children'], {'#tag': 'af-entity'}, 'name');
+        editor.layout = {'#children': []};
+        $scope.entities = {};
 
-        if (editor.mode === 'create') {
-          editor.addEntity(editor.entity);
-          editor.layout['#children'].push(afGui.meta.elements.submit.element);
+        if ($scope.afform.type === 'form') {
+          editor.allowEntityConfig = true;
+          editor.layout['#children'] = afGui.findRecursive($scope.afform.layout, {'#tag': 'af-form'})[0]['#children'];
+          $scope.entities = afGui.findRecursive(editor.layout['#children'], {'#tag': 'af-entity'}, 'name');
+
+          if (editor.mode === 'create') {
+            editor.addEntity(editor.entity);
+            editor.layout['#children'].push(afGui.meta.elements.submit.element);
+          }
+        }
+
+        else if ($scope.afform.type === 'block') {
+          editor.layout['#children'] = $scope.afform.layout;
+          editor.blockEntity = $scope.afform.join || $scope.afform.block;
+          $scope.entities[editor.blockEntity] = {
+            type: editor.blockEntity,
+            name: editor.blockEntity,
+            label: afGui.getEntity(editor.blockEntity).label
+          };
         }
 
         // Set changesSaved to true on initial load, false thereafter whenever changes are made to the model

--- a/ext/afform/admin/ang/afGuiEditor/afGuiEditor.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiEditor.component.js
@@ -31,6 +31,10 @@
         if (!$scope.afform) {
           alert('Error: unknown form');
         }
+        if (editor.mode === 'clone') {
+          delete $scope.afform.name;
+          $scope.afform.title += ' ' + ts('(copy)');
+        }
         $scope.canvasTab = 'layout';
         $scope.layoutHtml = '';
         editor.layout = {'#children': []};

--- a/ext/afform/admin/ang/afGuiEditor/afGuiEditor.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiEditor.component.js
@@ -90,10 +90,10 @@
         var fieldset = _.cloneDeep(afGui.meta.elements.fieldset.element);
         fieldset['af-fieldset'] = type + num;
         fieldset['#children'][0]['#children'][0]['#text'] = meta.label + ' ' + num;
-        // Add default contact name block
-        if (meta.entity === 'Contact') {
-          fieldset['#children'].push({'#tag': 'afblock-name-' + type.toLowerCase()});
-        }
+        // Add boilerplate contents
+        _.each(meta.boilerplate, function(tag) {
+          fieldset['#children'].push(tag);
+        });
         // Attempt to place the new af-fieldset after the last one on the form
         pos = 1 + _.findLastIndex(editor.layout['#children'], 'af-fieldset');
         if (pos) {

--- a/ext/afform/admin/ang/afGuiEditor/afGuiEditor.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiEditor.component.js
@@ -75,7 +75,7 @@
 
       $scope.updateLayoutHtml = function() {
         $scope.layoutHtml = '...Loading...';
-        crmApi4('Afform', 'convert', {layout: [editor.layout], from: 'deep', to: 'html', formatWhitespace: true})
+        crmApi4('Afform', 'convert', {layout: $scope.afform.layout, from: 'deep', to: 'html', formatWhitespace: true})
           .then(function(r){
             $scope.layoutHtml = r[0].layout || '(Error)';
           })

--- a/ext/afform/admin/ang/afGuiEditor/afGuiEditorCanvas.html
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiEditorCanvas.html
@@ -25,7 +25,7 @@
 
   </div>
   <div id="afGuiEditor-canvas-body" class="panel-body" ng-if="canvasTab === 'layout'">
-    <af-gui-container ng-if="editor.layout" node="editor.layout" entity-name="" ></af-gui-container>
+    <af-gui-container ng-if="editor.layout" node="editor.layout" entity-name="editor.blockEntity" data-entity="{{ editor.blockEntity }}" ></af-gui-container>
   </div>
   <div class="panel-body" ng-if="canvasTab === 'markup'">
     <p class="help-block">{{:: ts('This is a read-only preview of the auto-generated markup.') }}</p>

--- a/ext/afform/admin/ang/afGuiEditor/afGuiEditorPalette.html
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiEditorPalette.html
@@ -7,12 +7,13 @@
       </li>
       <li role="presentation" ng-repeat="entity in entities" ng-class="{active: selectedEntityName === entity.name}">
         <a href ng-click="editor.selectEntity(entity.name)">
-          <span ng-if="!entity.loading" af-gui-editable ng-model="entity.label">{{ entity.label }}</span>
+          <span ng-if="!entity.loading && editor.allowEntityConfig" af-gui-editable ng-model="entity.label">{{ entity.label }}</span>
+          <span ng-if="!entity.loading && !editor.allowEntityConfig">{{ entity.label }}</span>
           <i ng-if="entity.loading" class="crm-i fa-spin fa-spinner"></i>
         </a>
       </li>
-      <li role="presentation" class="dropdown">
-        <a href class="dropdown-toggle" data-toggle="dropdown">
+      <li role="presentation" class="dropdown" ng-if="editor.allowEntityConfig">
+        <a href class="dropdown-toggle" data-toggle="dropdown" title="{{ ts('Add Entity') }}">
           <span><i class="crm-i fa-plus"></i></span>
         </a>
         <ul class="dropdown-menu">

--- a/ext/afform/admin/ang/afGuiEditor/afGuiEditorPalette.html
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiEditorPalette.html
@@ -7,7 +7,8 @@
       </li>
       <li role="presentation" ng-repeat="entity in entities" ng-class="{active: selectedEntityName === entity.name}">
         <a href ng-click="editor.selectEntity(entity.name)">
-          <span af-gui-editable ng-model="entity.label">{{ entity.label }}</span>
+          <span ng-if="!entity.loading" af-gui-editable ng-model="entity.label">{{ entity.label }}</span>
+          <i ng-if="entity.loading" class="crm-i fa-spin fa-spinner"></i>
         </a>
       </li>
       <li role="presentation" class="dropdown">
@@ -16,7 +17,10 @@
         </a>
         <ul class="dropdown-menu">
           <li ng-repeat="(entityName, entity) in editor.meta.entities" ng-if="entity.defaults">
-            <a href ng-click="addEntity(entityName)">{{ entity.label }}</a>
+            <a href ng-click="editor.addEntity(entityName, true)">
+              <i class="crm-i {{:: entity.icon }}"></i>
+              {{:: entity.label }}
+            </a>
           </li>
         </ul>
       </li>

--- a/ext/afform/admin/ang/afGuiEditor/afGuiEditorPalette.html
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiEditorPalette.html
@@ -12,6 +12,11 @@
           <i ng-if="entity.loading" class="crm-i fa-spin fa-spinner"></i>
         </a>
       </li>
+      <li role="presentation" ng-repeat="(key, searchDisplay) in editor.meta.searchDisplays" ng-class="{active: selectedEntityName === key}">
+        <a href ng-click="editor.selectEntity(key)">
+          <span>{{ searchDisplay.label }}</span>
+        </a>
+      </li>
       <li role="presentation" class="dropdown" ng-if="editor.allowEntityConfig">
         <a href class="dropdown-toggle" data-toggle="dropdown" title="{{ ts('Add Entity') }}">
           <span><i class="crm-i fa-plus"></i></span>
@@ -29,5 +34,8 @@
   <div class="panel-body" ng-include="'~/afGuiEditor/config-form.html'" ng-if="selectedEntityName === null"></div>
   <div class="panel-body" ng-repeat="entity in entities" ng-if="selectedEntityName === entity.name">
     <af-gui-entity entity="entity"></af-gui-entity>
+  </div>
+  <div class="panel-body" ng-repeat="(key, searchDisplay) in editor.meta.searchDisplays" ng-if="selectedEntityName === key">
+    <af-gui-search display="searchDisplay"></af-gui-search>
   </div>
 </div>

--- a/ext/afform/admin/ang/afGuiEditor/afGuiEntity.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiEntity.component.js
@@ -110,6 +110,9 @@
           if (!search || _.contains(name, search) || _.contains(element.title.toLowerCase(), search)) {
             var node = _.cloneDeep(element.element);
             if (name === 'fieldset') {
+              if (!ctrl.editor.allowEntityConfig) {
+                return;
+              }
               node['af-fieldset'] = ctrl.entity.name;
             }
             $scope.elementList.push(node);

--- a/ext/afform/admin/ang/afGuiEditor/afGuiEntity.html
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiEntity.html
@@ -50,11 +50,11 @@
   </fieldset>
 </div>
 
-<a href ng-click="$ctrl.editor.removeEntity($ctrl.entity.name)" class="btn btn-sm btn-danger-outline af-gui-remove-entity" title="{{ ts('Remove %1', {1: getMeta().label}) }}">
+<a ng-if="!$ctrl.entity.loading && $ctrl.editor.allowEntityConfig" href ng-click="$ctrl.editor.removeEntity($ctrl.entity.name)" class="btn btn-sm btn-danger-outline af-gui-remove-entity" title="{{ ts('Remove %1', {1: getMeta().label}) }}">
   <i class="crm-i fa-trash"></i>
 </a>
 
-<fieldset ng-if="!$ctrl.entity.loading">
+<fieldset ng-if="!$ctrl.entity.loading && $ctrl.editor.allowEntityConfig">
   <legend>{{:: ts('Options') }}</legend>
   <div ng-include="'~/afGuiEditor/entityConfig/' + $ctrl.entity.type + '.html'"></div>
 </fieldset>

--- a/ext/afform/admin/ang/afGuiEditor/afGuiEntity.html
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiEntity.html
@@ -1,4 +1,4 @@
-<div class="af-gui-columns crm-flex-box">
+<div class="af-gui-columns crm-flex-box" ng-if="!$ctrl.entity.loading">
   <fieldset class="af-gui-entity-values">
     <legend>{{:: ts('Values:') }}</legend>
     <div class="form-inline" ng-if="getMeta().fields[fieldName]" ng-repeat="(fieldName, value) in $ctrl.entity.data">
@@ -54,7 +54,7 @@
   <i class="crm-i fa-trash"></i>
 </a>
 
-<fieldset>
+<fieldset ng-if="!$ctrl.entity.loading">
   <legend>{{:: ts('Options') }}</legend>
   <div ng-include="'~/afGuiEditor/entityConfig/' + $ctrl.entity.type + '.html'"></div>
 </fieldset>

--- a/ext/afform/admin/ang/afGuiEditor/afGuiSearch.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiSearch.component.js
@@ -1,0 +1,127 @@
+// https://civicrm.org/licensing
+(function(angular, $, _) {
+  "use strict";
+
+  angular.module('afGuiEditor').component('afGuiSearch', {
+    templateUrl: '~/afGuiEditor/afGuiSearch.html',
+    bindings: {
+      display: '<'
+    },
+    require: {editor: '^^afGuiEditor'},
+    controller: function ($scope, $timeout, afGui) {
+      var ts = $scope.ts = CRM.ts();
+      var ctrl = this;
+      $scope.controls = {};
+      $scope.fieldList = [];
+      $scope.elementList = [];
+      $scope.elementTitles = [];
+
+      $scope.getField = afGui.getField;
+
+      function buildPaletteLists() {
+        var search = $scope.controls.fieldSearch ? $scope.controls.fieldSearch.toLowerCase() : null;
+        buildFieldList(search);
+        buildElementList(search);
+      }
+
+      function buildFieldList(search) {
+        $scope.fieldList.length = 0;
+        var entity = afGui.getEntity(ctrl.display['saved_search.api_entity']),
+          entityCount = {};
+        entityCount[entity.entity] = 1;
+        $scope.fieldList.push({
+          entityType: entity.entity,
+          label: ts('%1 Fields', {1: entity.label}),
+          fields: filterFields(entity.fields)
+        });
+
+        _.each(ctrl.display['saved_search.api_params'].join, function(join) {
+          var joinInfo = join[0].split(' AS '),
+            entity = afGui.getEntity(joinInfo[0]),
+            alias = joinInfo[1];
+          entityCount[entity.entity] = entityCount[entity.entity] ? entityCount[entity.entity] + 1 : 1;
+          $scope.fieldList.push({
+            entityType: entity.entity,
+            label: ts('%1 Fields', {1: entity.label + (entityCount[entity.entity] > 1 ? ' ' + entityCount[entity.entity] : '')}),
+            fields: filterFields(entity.fields, alias)
+          });
+        });
+
+        function filterFields(fields, prefix) {
+          return _.transform(fields, function(fieldList, field) {
+            if (!search || _.contains(field.name, search) || _.contains(field.label.toLowerCase(), search)) {
+              fieldList.push({
+                "#tag": "af-field",
+                name: (prefix ? prefix + '.' : '') + field.name
+              });
+            }
+          }, []);
+        }
+      }
+
+      function buildElementList(search) {
+        $scope.elementList.length = 0;
+        $scope.elementTitles.length = 0;
+        _.each(afGui.meta.elements, function(element, name) {
+          if (!search || _.contains(name, search) || _.contains(element.title.toLowerCase(), search)) {
+            var node = _.cloneDeep(element.element);
+            if (name === 'fieldset') {
+              return;
+            }
+            $scope.elementList.push(node);
+            $scope.elementTitles.push(element.title);
+          }
+        });
+      }
+
+      $scope.clearSearch = function() {
+        $scope.controls.fieldSearch = '';
+      };
+
+      // This gets called from jquery-ui so we have to manually apply changes to scope
+      $scope.buildPaletteLists = function() {
+        $timeout(function() {
+          $scope.$apply(function() {
+            buildPaletteLists();
+          });
+        });
+      };
+
+      // Checks if a field is on the form or set as a value
+      $scope.fieldInUse = function(fieldName) {
+        return check(ctrl.editor.layout['#children'], {'#tag': 'af-field', name: fieldName});
+      };
+
+      // Check for a matching item for this entity
+      // Recursively checks the form layout, including block directives
+      function check(group, criteria, found) {
+        if (!found) {
+          found = {};
+        }
+        if (_.find(group, criteria)) {
+          found.match = true;
+          return true;
+        }
+        _.each(group, function(item) {
+          if (found.match) {
+            return false;
+          }
+          if (_.isPlainObject(item)) {
+            // Recurse through everything
+            if (item['#children']) {
+              check(item['#children'], criteria, found);
+            }
+            // Recurse into block directives
+            else if (item['#tag'] && item['#tag'] in afGui.meta.blocks) {
+              check(afGui.meta.blocks[item['#tag']].layout, criteria, found);
+            }
+          }
+        });
+        return found.match;
+      }
+
+      $scope.$watch('controls.fieldSearch', buildPaletteLists);
+    }
+  });
+
+})(angular, CRM.$, CRM._);

--- a/ext/afform/admin/ang/afGuiEditor/afGuiSearch.html
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiSearch.html
@@ -1,0 +1,28 @@
+<div>
+  <fieldset class="af-gui-entity-palette">
+    <legend class="form-inline">
+      {{:: ts('Add:') }}
+      <input ng-model="controls.fieldSearch" class="form-control" type="search" placeholder="&#xf002" title="{{:: ts('Search fields') }}" />
+    </legend>
+    <div class="af-gui-entity-palette-select-list">
+      <div ng-if="elementList.length">
+        <label>{{:: ts('Elements') }}</label>
+        <div ui-sortable="{update: buildPaletteLists, items: '&gt; div:not(.disabled)', connectWith: '[ui-sortable]', placeholder: 'af-gui-dropzone'}" ui-sortable-update="$ctrl.editor.onDrop" ng-model="elementList">
+          <div ng-repeat="element in elementList" >
+            {{:: elementTitles[$index] }}
+          </div>
+        </div>
+      </div>
+      <div ng-repeat="fieldGroup in fieldList">
+        <div ng-if="fieldGroup.fields.length">
+          <label>{{:: fieldGroup.label }}</label>
+          <div ui-sortable="{update: buildPaletteLists, items: '&gt; div:not(.disabled)', connectWith: '[ui-sortable]', placeholder: 'af-gui-dropzone'}" ui-sortable-update="$ctrl.editor.onDrop" ng-model="fieldGroup.fields">
+            <div ng-repeat="field in fieldGroup.fields" ng-class="{disabled: fieldInUse(field.name)}">
+              {{:: getField(fieldGroup.entityType, field.name).label }}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </fieldset>
+</div>

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiContainer.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiContainer.component.js
@@ -16,7 +16,7 @@
         ctrl = this;
 
       this.$onInit = function() {
-        if ((ctrl.node['#tag'] in afGui.meta.blocks) || ctrl.join) {
+        if (ctrl.node['#tag'] && ((ctrl.node['#tag'] in afGui.meta.blocks) || ctrl.join)) {
           var blockNode = getBlockNode(),
             blockTag = blockNode ? blockNode['#tag'] : null;
           if (blockTag && (blockTag in afGui.meta.blocks) && !afGui.meta.blocks[blockTag].layout) {
@@ -234,7 +234,7 @@
       this.node = ctrl.node;
 
       this.getNodeType = function(node) {
-        if (!node) {
+        if (!node || !node['#tag']) {
           return null;
         }
         if (node['#tag'] === 'af-field') {

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiContainer.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiContainer.component.js
@@ -17,6 +17,18 @@
 
       this.$onInit = function() {
         if ((ctrl.node['#tag'] in afGui.meta.blocks) || ctrl.join) {
+          var blockNode = getBlockNode(),
+            blockTag = blockNode ? blockNode['#tag'] : null;
+          if (blockTag && (blockTag in afGui.meta.blocks) && !afGui.meta.blocks[blockTag].layout) {
+            ctrl.loading = true;
+            crmApi4('Afform', 'loadAdminData', {
+              definition: {name: afGui.meta.blocks[blockTag].name}
+            }, 0).then(function(data) {
+              afGui.addMeta(data);
+              initializeBlockContainer();
+              ctrl.loading = false;
+            });
+          }
           initializeBlockContainer();
         }
       };

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiContainer.html
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiContainer.html
@@ -2,7 +2,7 @@
   <div ng-if="!$ctrl.loading" class="form-inline" af-gui-menu>
     <span ng-if="$ctrl.getNodeType($ctrl.node) == 'fieldset'">{{ $ctrl.editor.getEntity($ctrl.entityName).label }}</span>
     <span ng-if="block">{{ $ctrl.join ? ts($ctrl.join) + ':' : ts('Block:') }}</span>
-    <span ng-if="!block">{{ tags[$ctrl.node['#tag']].toLowerCase() }}</span>
+    <span ng-if="!block">{{ tags[$ctrl.node['#tag']] }}</span>
     <select ng-if="block" ng-model="block.directive" ng-change="selectBlockDirective()">
       <option value="">{{:: ts('Custom') }}</option>
       <option ng-value="option.id" ng-repeat="option in block.options track by option.id">{{ option.text }}</option>
@@ -25,6 +25,7 @@
       <af-gui-text ng-switch-when="text" node="item" delete-this="$ctrl.removeElement(item)" class="af-gui-element af-gui-text" ></af-gui-text>
       <af-gui-markup ng-switch-when="markup" node="item" delete-this="$ctrl.removeElement(item)" class="af-gui-markup" ></af-gui-markup>
       <af-gui-button ng-switch-when="button" node="item" delete-this="$ctrl.removeElement(item)" class="af-gui-element af-gui-button" ></af-gui-button>
+      <af-gui-search-display ng-switch-when="searchDisplay" node="item" class="af-gui-element"></af-gui-search-display>
     </div>
   </div>
 </div>

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiContainer.html
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiContainer.html
@@ -1,5 +1,5 @@
 <div class="af-gui-bar" ng-if="$ctrl.node['#tag'] !== 'af-form'" ng-click="selectEntity()" >
-  <div class="form-inline" af-gui-menu>
+  <div ng-if="!$ctrl.loading" class="form-inline" af-gui-menu>
     <span ng-if="$ctrl.getNodeType($ctrl.node) == 'fieldset'">{{ $ctrl.editor.getEntity($ctrl.entityName).label }}</span>
     <span ng-if="block">{{ $ctrl.join ? ts($ctrl.join) + ':' : ts('Block:') }}</span>
     <span ng-if="!block">{{ tags[$ctrl.node['#tag']].toLowerCase() }}</span>
@@ -13,8 +13,9 @@
     </button>
     <ul class="dropdown-menu dropdown-menu-right" ng-if="menu.open" ng-include="'~/afGuiEditor/elements/afGuiContainer-menu.html'"></ul>
   </div>
+  <div ng-if="$ctrl.loading"><i class="crm-i fa-spin fa-spinner"></i></div>
 </div>
-<div ui-sortable="{handle: '.af-gui-bar', connectWith: '[ui-sortable]', cancel: 'input,textarea,button,select,option,a,.dropdown-menu', placeholder: 'af-gui-dropzone', containment: '#afGuiEditor-canvas-body'}" ui-sortable-update="$ctrl.editor.onDrop" ng-model="getSetChildren" ng-model-options="{getterSetter: true}" class="af-gui-layout {{ getLayout() }}">
+<div ng-if="!$ctrl.loading" ui-sortable="{handle: '.af-gui-bar', connectWith: '[ui-sortable]', cancel: 'input,textarea,button,select,option,a,.dropdown-menu', placeholder: 'af-gui-dropzone', containment: '#afGuiEditor-canvas-body'}" ui-sortable-update="$ctrl.editor.onDrop" ng-model="getSetChildren" ng-model-options="{getterSetter: true}" class="af-gui-layout {{ getLayout() }}">
   <div ng-repeat="item in getSetChildren()" >
     <div ng-switch="$ctrl.getNodeType(item)">
       <af-gui-container ng-switch-when="fieldset" node="item" delete-this="$ctrl.removeElement(item)" style="{{ item.style }}" class="af-gui-container af-gui-fieldset af-gui-container-type-{{ item['#tag'] }}" ng-class="{'af-entity-selected': isSelectedFieldset(item['af-fieldset'])}" entity-name="item['af-fieldset']" data-entity="{{ item['af-fieldset'] }}" ></af-gui-container>

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiContainer.html
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiContainer.html
@@ -1,4 +1,4 @@
-<div class="af-gui-bar" ng-if="$ctrl.node['#tag'] !== 'af-form'" ng-click="selectEntity()" >
+<div class="af-gui-bar" ng-if="$ctrl.node['#tag']" ng-click="selectEntity()" >
   <div ng-if="!$ctrl.loading" class="form-inline" af-gui-menu>
     <span ng-if="$ctrl.getNodeType($ctrl.node) == 'fieldset'">{{ $ctrl.editor.getEntity($ctrl.entityName).label }}</span>
     <span ng-if="block">{{ $ctrl.join ? ts($ctrl.join) + ':' : ts('Block:') }}</span>

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
@@ -26,24 +26,32 @@
         $scope.meta = afGui.meta;
       };
 
-      $scope.getEntity = function() {
-        return ctrl.editor ? ctrl.editor.getEntity(ctrl.container.getEntityName()) : {};
+      // $scope.getEntity = function() {
+      //   return ctrl.editor ? ctrl.editor.getEntity(ctrl.container.getEntityName()) : {};
+      // };
+
+      // Returns the original field definition from metadata
+      this.getDefn = function() {
+        return ctrl.editor ? afGui.getField(ctrl.container.getFieldEntityType(ctrl.node.name), ctrl.node.name) : {};
       };
 
-      $scope.getDefn = this.getDefn = function() {
-        return ctrl.editor ? afGui.getField(ctrl.container.getFieldEntityType(), ctrl.node.name) : {};
+      $scope.getOriginalLabel = function() {
+        if (ctrl.container.getEntityName()) {
+          return ctrl.editor.getEntity(ctrl.container.getEntityName()).label + ': ' + ctrl.getDefn().label;
+        }
+        return afGui.getEntity(ctrl.container.getFieldEntityType(ctrl.node.name)).label + ': ' + ctrl.getDefn().label;
       };
 
       $scope.hasOptions = function() {
         var inputType = $scope.getProp('input_type');
-        return _.contains(['CheckBox', 'Radio', 'Select'], inputType) && !(inputType === 'CheckBox' && !$scope.getDefn().options);
+        return _.contains(['CheckBox', 'Radio', 'Select'], inputType) && !(inputType === 'CheckBox' && !ctrl.getDefn().options);
       };
 
       $scope.getOptions = this.getOptions = function() {
         if (ctrl.node.defn && ctrl.node.defn.options) {
           return ctrl.node.defn.options;
         }
-        return $scope.getDefn().options || ($scope.getProp('input_type') === 'CheckBox' ? null : yesNo);
+        return ctrl.getDefn().options || ($scope.getProp('input_type') === 'CheckBox' ? null : yesNo);
       };
 
       $scope.resetOptions = function() {
@@ -56,7 +64,7 @@
       };
 
       $scope.inputTypeCanBe = function(type) {
-        var defn = $scope.getDefn();
+        var defn = ctrl.getDefn();
         switch (type) {
           case 'CheckBox':
           case 'Radio':
@@ -78,7 +86,7 @@
         if (typeof localDefn[item] !== 'undefined') {
           return localDefn[item];
         }
-        return drillDown($scope.getDefn(), path)[item];
+        return drillDown(ctrl.getDefn(), path)[item];
       };
 
       // Checks for a value in either the local field defn or the base defn
@@ -102,7 +110,7 @@
       };
 
       $scope.toggleHelp = function(position) {
-        getSet('help_' + position, $scope.propIsset('help_' + position) ? null : ($scope.getDefn()['help_' + position] || ts('Enter text')));
+        getSet('help_' + position, $scope.propIsset('help_' + position) ? null : (ctrl.getDefn()['help_' + position] || ts('Enter text')));
         return false;
       };
 
@@ -117,7 +125,7 @@
           var path = propName.split('.'),
             item = path.pop(),
             localDefn = drillDown(ctrl.node, ['defn'].concat(path)),
-            fieldDefn = drillDown($scope.getDefn(), path);
+            fieldDefn = drillDown(ctrl.getDefn(), path);
           // Set the value if different than the field defn, otherwise unset it
           if (typeof val !== 'undefined' && (val !== fieldDefn[item] && !(!val && !fieldDefn[item]))) {
             localDefn[item] = val;

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.html
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.html
@@ -1,8 +1,9 @@
 <af-gui-edit-options ng-if="editingOptions" class="af-gui-content-editing-area"></af-gui-edit-options>
 <div ng-if="!editingOptions" class="af-gui-element af-gui-field" >
-  <div class="af-gui-bar" title="{{ getEntity().label + ': ' + getDefn().label }}">
-    <div class="form-inline pull-right">
-      <div class="btn-group" af-gui-menu >
+  <div class="af-gui-bar" title="{{:: getOriginalLabel() }}">
+    <div class="form-inline">
+      <span ng-if="$ctrl.node.defn.label === false">{{:: getOriginalLabel() }}</span>
+      <div class="btn-group pull-right" af-gui-menu >
         <button type="button" class="btn btn-default btn-xs dropdown-toggle af-gui-add-element-button" data-toggle="dropdown" title="{{:: ts('Configure') }}">
           <span><i class="crm-i fa-gear"></i></span>
         </button>
@@ -11,13 +12,13 @@
     </div>
   </div>
   <label ng-style="{visibility: $ctrl.node.defn.label === false ? 'hidden' : 'visible'}" ng-class="{'af-gui-field-required': getProp('required')}" class="af-gui-node-title">
-    <span af-gui-editable ng-model="getSet('label')" ng-model-options="{getterSetter: true}" default-value="getDefn().label">{{ getProp('label') }}</span>
+    <span af-gui-editable ng-model="getSet('label')" ng-model-options="{getterSetter: true}" default-value="$ctrl.getDefn().label">{{ getProp('label') }}</span>
   </label>
   <div class="af-gui-field-help" ng-if="propIsset('help_pre')">
-    <span af-gui-editable ng-model="getSet('help_pre')" ng-model-options="{getterSetter: true}" default-value="getDefn().help_pre">{{ getProp('help_pre') }}</span>
+    <span af-gui-editable ng-model="getSet('help_pre')" ng-model-options="{getterSetter: true}" default-value="$ctrl.getDefn().help_pre">{{ getProp('help_pre') }}</span>
   </div>
   <div class="af-gui-field-input af-gui-field-input-type-{{ getProp('input_type').toLowerCase() }}" ng-include="'~/afGuiEditor/inputType/' + getProp('input_type') + '.html'"></div>
   <div class="af-gui-field-help" ng-if="propIsset('help_post')">
-    <span af-gui-editable ng-model="getSet('help_post')" ng-model-options="{getterSetter: true}" default-value="getDefn().help_post">{{ getProp('help_post') }}</span>
+    <span af-gui-editable ng-model="getSet('help_post')" ng-model-options="{getterSetter: true}" default-value="$ctrl.getDefn().help_post">{{ getProp('help_post') }}</span>
   </div>
 </div>

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiSearchDisplay.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiSearchDisplay.component.js
@@ -1,0 +1,21 @@
+// https://civicrm.org/licensing
+(function(angular, $, _) {
+  "use strict";
+
+  angular.module('afGuiEditor').component('afGuiSearchDisplay', {
+    templateUrl: '~/afGuiEditor/elements/afGuiSearchDisplay.html',
+    bindings: {
+      node: '='
+    },
+    controller: function($scope, afGui) {
+      var ts = $scope.ts = CRM.ts(),
+        ctrl = this;
+
+      this.$onInit = function() {
+        ctrl.display = afGui.meta.searchDisplays[ctrl.node['search-name'] + '.' + ctrl.node['display-name']];
+      };
+
+    }
+  });
+
+})(angular, CRM.$, CRM._);

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiSearchDisplay.html
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiSearchDisplay.html
@@ -1,0 +1,8 @@
+<div class="af-gui-bar">
+  <div class="form-inline">
+    <span>{{ $ctrl.display.label }}</span>
+  </div>
+</div>
+<p class="text-center af-gui-search-display">
+  <i class="crm-i fa-3x {{ $ctrl.display['type:icon'] }}"></i>
+</p>

--- a/ext/afform/admin/ang/afGuiEditor/entityDefaults/Activity.json
+++ b/ext/afform/admin/ang/afGuiEditor/entityDefaults/Activity.json
@@ -1,5 +1,0 @@
-// Default values for creating a new entity.
-// Note this is not strict JSON - it passes through angular.$parse - $scope variables are available.
-{
-  'url-autofill': '1'
-}

--- a/ext/afform/admin/ang/afGuiEditor/entityDefaults/Contact.json
+++ b/ext/afform/admin/ang/afGuiEditor/entityDefaults/Contact.json
@@ -1,9 +1,0 @@
-// Default values for creating a new entity.
-// Note this is not strict JSON - it passes through angular.$parse - $scope variables are available.
-{
-  data: {
-    contact_type: 'Individual',
-    source: afform.title
-  },
-  'url-autofill': '1'
-}

--- a/ext/afform/admin/info.xml
+++ b/ext/afform/admin/info.xml
@@ -27,4 +27,7 @@
   <civix>
     <namespace>CRM/AfformAdmin</namespace>
   </civix>
+  <classloader>
+    <psr4 prefix="Civi\" path="Civi" />
+  </classloader>
 </extension>

--- a/ext/afform/core/Civi/Afform/AngularDependencyMapper.php
+++ b/ext/afform/core/Civi/Afform/AngularDependencyMapper.php
@@ -1,0 +1,130 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Afform;
+
+/**
+ * Class AngularDependencyMapper
+ * @package Civi\Afform
+ */
+class AngularDependencyMapper {
+
+  /**
+   * Scan the list of Angular modules and inject automatic-requirements.
+   *
+   * TLDR: if an afform uses element "<other-el/>", and if another module defines
+   * `$angularModules['otherMod']['exports']['el'][0] === 'other-el'`, then
+   * the 'otherMod' is automatically required.
+   *
+   * @param \Civi\Core\Event\GenericHookEvent $e
+   * @see CRM_Utils_Hook::angularModules()
+   */
+  public static function autoReq($e) {
+    /** @var \CRM_Afform_AfformScanner $scanner */
+    $scanner = \Civi::service('afform_scanner');
+    $moduleEnvId = md5(\CRM_Core_Config_Runtime::getId() . implode(',', array_keys($e->angularModules)));
+    $depCache = \CRM_Utils_Cache::create([
+      'name' => 'afdep_' . substr($moduleEnvId, 0, 32 - 6),
+      'type' => ['*memory*', 'SqlGroup', 'ArrayCache'],
+      'withArray' => 'fast',
+      'prefetch' => TRUE,
+    ]);
+    $depCacheTtl = 2 * 60 * 60;
+
+    $revMap = self::reverseDeps($e->angularModules);
+
+    $formNames = array_keys($scanner->findFilePaths());
+    foreach ($formNames as $formName) {
+      $angModule = _afform_angular_module_name($formName, 'camel');
+      $cacheLine = $depCache->get($formName, NULL);
+
+      $jFile = $scanner->findFilePath($formName, 'aff.json');
+      $hFile = $scanner->findFilePath($formName, 'aff.html');
+
+      $jStat = stat($jFile);
+      $hStat = stat($hFile);
+
+      if ($cacheLine === NULL) {
+        $needsUpdate = TRUE;
+      }
+      elseif ($jStat !== FALSE && $jStat['size'] !== $cacheLine['js']) {
+        $needsUpdate = TRUE;
+      }
+      elseif ($jStat !== FALSE && $jStat['mtime'] > $cacheLine['jm']) {
+        $needsUpdate = TRUE;
+      }
+      elseif ($hStat !== FALSE && $hStat['size'] !== $cacheLine['hs']) {
+        $needsUpdate = TRUE;
+      }
+      elseif ($hStat !== FALSE && $hStat['mtime'] > $cacheLine['hm']) {
+        $needsUpdate = TRUE;
+      }
+      else {
+        $needsUpdate = FALSE;
+      }
+
+      if ($needsUpdate) {
+        $cacheLine = [
+          'js' => $jStat['size'] ?? NULL,
+          'jm' => $jStat['mtime'] ?? NULL,
+          'hs' => $hStat['size'] ?? NULL,
+          'hm' => $hStat['mtime'] ?? NULL,
+          'r' => array_values(array_unique(array_merge(
+            [\CRM_Afform_AfformScanner::DEFAULT_REQUIRES],
+            $e->angularModules[$angModule]['requires'] ?? [],
+            self::reverseDepsFind(file_get_contents($hFile), $revMap)
+          ))),
+        ];
+        $depCache->set($formName, $cacheLine, $depCacheTtl);
+      }
+
+      $e->angularModules[$angModule]['requires'] = $cacheLine['r'];
+    }
+  }
+
+  /**
+   * @param $angularModules
+   * @return array
+   *   'attr': array(string $attrName => string $angModuleName)
+   *   'el': array(string $elementName => string $angModuleName)
+   */
+  private static function reverseDeps($angularModules):array {
+    $revMap = ['attr' => [], 'el' => []];
+    foreach (array_keys($angularModules) as $module) {
+      if (!isset($angularModules[$module]['exports'])) {
+        continue;
+      }
+      foreach ($angularModules[$module]['exports'] as $symbolName => $symbolTypes) {
+        if (strpos($symbolTypes, 'A') !== FALSE) {
+          $revMap['attr'][$symbolName] = $module;
+        }
+        if (strpos($symbolTypes, 'E') !== FALSE) {
+          $revMap['el'][$symbolName] = $module;
+        }
+      }
+    }
+    return $revMap;
+  }
+
+  /**
+   * @param string $html
+   * @param array $revMap
+   *   The reverse-dependencies map from reverseDeps().
+   * @return array
+   */
+  private static function reverseDepsFind($html, $revMap):array {
+    $symbols = \Civi\Afform\Symbols::scan($html);
+    $elems = array_intersect_key($revMap['el'], $symbols->elements);
+    $attrs = array_intersect_key($revMap['attr'], $symbols->attributes);
+    return array_values(array_unique(array_merge($elems, $attrs)));
+  }
+
+}

--- a/ext/afform/core/Civi/Api4/Action/Afform/Get.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/Get.php
@@ -88,7 +88,7 @@ class Get extends \Civi\Api4\Generic\BasicGetAction {
     }
     $customApi = CustomGroup::get()
       ->setCheckPermissions(FALSE)
-      ->setSelect(['name', 'title', 'help_pre', 'help_post'])
+      ->setSelect(['name', 'title', 'help_pre', 'help_post', 'extends'])
       ->addWhere('is_multiple', '=', 1)
       ->addWhere('is_active', '=', 1);
     if ($groupNames) {
@@ -111,6 +111,7 @@ class Get extends \Civi\Api4\Generic\BasicGetAction {
       }
       $item = [
         'name' => $name,
+        'type' => 'block',
         'requires' => [],
         'title' => ts('%1 block (default)', [1 => $custom['title']]),
         'description' => '',
@@ -118,7 +119,7 @@ class Get extends \Civi\Api4\Generic\BasicGetAction {
         'is_public' => FALSE,
         'permission' => 'access CiviCRM',
         'join' => 'Custom_' . $custom['name'],
-        'extends' => 'Contact',
+        'block' => $custom['extends'],
         'repeat' => TRUE,
         'has_base' => TRUE,
       ];

--- a/ext/afform/core/afform.php
+++ b/ext/afform/core/afform.php
@@ -51,7 +51,7 @@ function afform_civicrm_config(&$config) {
 
   Civi::dispatcher()->addListener(Submit::EVENT_NAME, [Submit::class, 'processContacts'], 500);
   Civi::dispatcher()->addListener(Submit::EVENT_NAME, [Submit::class, 'processGenericEntity'], -1000);
-  Civi::dispatcher()->addListener('hook_civicrm_angularModules', '_afform_civicrm_angularModules_autoReq', -1000);
+  Civi::dispatcher()->addListener('hook_civicrm_angularModules', ['\Civi\Afform\AngularDependencyMapper', 'autoReq'], -1000);
   Civi::dispatcher()->addListener('hook_civicrm_alterAngular', ['\Civi\Afform\AfformMetadataInjector', 'preprocess']);
 }
 
@@ -227,119 +227,6 @@ function _afform_get_partials($moduleName, $module) {
   return [
     "~/$moduleName/$moduleName.aff.html" => $afform['layout'],
   ];
-}
-
-/**
- * Scan the list of Angular modules and inject automatic-requirements.
- *
- * TLDR: if an afform uses element "<other-el/>", and if another module defines
- * `$angularModules['otherMod']['exports']['el'][0] === 'other-el'`, then
- * the 'otherMod' is automatically required.
- *
- * @param \Civi\Core\Event\GenericHookEvent $e
- * @see CRM_Utils_Hook::angularModules()
- */
-function _afform_civicrm_angularModules_autoReq($e) {
-  /** @var CRM_Afform_AfformScanner $scanner */
-  $scanner = Civi::service('afform_scanner');
-  $moduleEnvId = md5(\CRM_Core_Config_Runtime::getId() . implode(',', array_keys($e->angularModules)));
-  $depCache = CRM_Utils_Cache::create([
-    'name' => 'afdep_' . substr($moduleEnvId, 0, 32 - 6),
-    'type' => ['*memory*', 'SqlGroup', 'ArrayCache'],
-    'withArray' => 'fast',
-    'prefetch' => TRUE,
-  ]);
-  $depCacheTtl = 2 * 60 * 60;
-
-  $revMap = _afform_reverse_deps($e->angularModules);
-
-  $formNames = array_keys($scanner->findFilePaths());
-  foreach ($formNames as $formName) {
-    $angModule = _afform_angular_module_name($formName, 'camel');
-    $cacheLine = $depCache->get($formName, NULL);
-
-    $jFile = $scanner->findFilePath($formName, 'aff.json');
-    $hFile = $scanner->findFilePath($formName, 'aff.html');
-
-    $jStat = stat($jFile);
-    $hStat = stat($hFile);
-
-    if ($cacheLine === NULL) {
-      $needsUpdate = TRUE;
-    }
-    elseif ($jStat !== FALSE && $jStat['size'] !== $cacheLine['js']) {
-      $needsUpdate = TRUE;
-    }
-    elseif ($jStat !== FALSE && $jStat['mtime'] > $cacheLine['jm']) {
-      $needsUpdate = TRUE;
-    }
-    elseif ($hStat !== FALSE && $hStat['size'] !== $cacheLine['hs']) {
-      $needsUpdate = TRUE;
-    }
-    elseif ($hStat !== FALSE && $hStat['mtime'] > $cacheLine['hm']) {
-      $needsUpdate = TRUE;
-    }
-    else {
-      $needsUpdate = FALSE;
-    }
-
-    if ($needsUpdate) {
-      $cacheLine = [
-        'js' => $jStat['size'] ?? NULL,
-        'jm' => $jStat['mtime'] ?? NULL,
-        'hs' => $hStat['size'] ?? NULL,
-        'hm' => $hStat['mtime'] ?? NULL,
-        'r' => array_values(array_unique(array_merge(
-          [CRM_Afform_AfformScanner::DEFAULT_REQUIRES],
-          $e->angularModules[$angModule]['requires'] ?? [],
-          _afform_reverse_deps_find($formName, file_get_contents($hFile), $revMap)
-        ))),
-      ];
-      // print_r(['cache update:' . $formName => $cacheLine]);
-      $depCache->set($formName, $cacheLine, $depCacheTtl);
-    }
-
-    $e->angularModules[$angModule]['requires'] = $cacheLine['r'];
-  }
-}
-
-/**
- * @param $angularModules
- * @return array
- *   'attr': array(string $attrName => string $angModuleName)
- *   'el': array(string $elementName => string $angModuleName)
- */
-function _afform_reverse_deps($angularModules) {
-  $revMap = ['attr' => [], 'el' => []];
-  foreach (array_keys($angularModules) as $module) {
-    if (!isset($angularModules[$module]['exports'])) {
-      continue;
-    }
-    foreach ($angularModules[$module]['exports'] as $symbolName => $symbolTypes) {
-      if (strpos($symbolTypes, 'A') !== FALSE) {
-        $revMap['attr'][$symbolName] = $module;
-      }
-      if (strpos($symbolTypes, 'E') !== FALSE) {
-        $revMap['el'][$symbolName] = $module;
-      }
-    }
-  }
-  return $revMap;
-}
-
-/**
- * @param string $formName
- * @param string $html
- * @param array $revMap
- *   The reverse-dependencies map from _afform_reverse_deps().
- * @return array
- * @see _afform_reverse_deps()
- */
-function _afform_reverse_deps_find($formName, $html, $revMap) {
-  $symbols = \Civi\Afform\Symbols::scan($html);
-  $elems = array_intersect_key($revMap['el'], $symbols->elements);
-  $attrs = array_intersect_key($revMap['attr'], $symbols->attributes);
-  return array_values(array_unique(array_merge($elems, $attrs)));
 }
 
 /**

--- a/ext/search/Civi/Search/Admin.php
+++ b/ext/search/Civi/Search/Admin.php
@@ -28,6 +28,14 @@ class Admin {
       'operators' => \CRM_Utils_Array::makeNonAssociative(self::getOperators()),
       'functions' => \CRM_Api4_Page_Api4Explorer::getSqlFunctions(),
       'displayTypes' => Display::getDisplayTypes(['id', 'name', 'label', 'description', 'icon']),
+      'afformEnabled' => (bool) \CRM_Utils_Array::findAll(
+        \CRM_Extension_System::singleton()->getMapper()->getActiveModuleFiles(),
+        ['fullName' => 'org.civicrm.afform']
+      ),
+      'afformAdminEnabled' => (bool) \CRM_Utils_Array::findAll(
+        \CRM_Extension_System::singleton()->getMapper()->getActiveModuleFiles(),
+        ['fullName' => 'org.civicrm.afform_admin']
+      ),
     ];
   }
 

--- a/ext/search/Civi/Search/Admin.php
+++ b/ext/search/Civi/Search/Admin.php
@@ -27,7 +27,7 @@ class Admin {
       'joins' => self::getJoins(array_column($schema, NULL, 'name')),
       'operators' => \CRM_Utils_Array::makeNonAssociative(self::getOperators()),
       'functions' => \CRM_Api4_Page_Api4Explorer::getSqlFunctions(),
-      'displayTypes' => Display::getDisplayTypes(['name', 'label', 'description', 'icon']),
+      'displayTypes' => Display::getDisplayTypes(['id', 'name', 'label', 'description', 'icon']),
     ];
   }
 

--- a/ext/search/Civi/Search/AfformSearchMetadataInjector.php
+++ b/ext/search/Civi/Search/AfformSearchMetadataInjector.php
@@ -26,11 +26,10 @@ class AfformSearchMetadataInjector {
   public static function preprocess($e) {
     $changeSet = \Civi\Angular\ChangeSet::create('searchSettings')
       ->alterHtml(';\\.aff\\.html$;', function($doc, $path) {
-        $displayTypes = array_column(\Civi\Search\Display::getDisplayTypes(['name']), 'name');
+        $displayTags = array_column(\Civi\Search\Display::getDisplayTypes(['name']), 'name');
 
-        if ($displayTypes) {
-          $displayTypeTags = 'crm-search-display-' . implode(', crm-search-display-', $displayTypes);
-          foreach (pq($displayTypeTags, $doc) as $component) {
+        if ($displayTags) {
+          foreach (pq(implode(',', $displayTags), $doc) as $component) {
             $searchName = pq($component)->attr('search-name');
             $displayName = pq($component)->attr('display-name');
             if ($searchName && $displayName) {

--- a/ext/search/Civi/Search/AfformSearchMetadataInjector.php
+++ b/ext/search/Civi/Search/AfformSearchMetadataInjector.php
@@ -39,15 +39,15 @@ class AfformSearchMetadataInjector {
                 ->addSelect('settings', 'saved_search.api_entity', 'saved_search.api_params')
                 ->execute()->first();
               if ($display) {
-                pq($component)->attr('settings', \CRM_Utils_JS::encode($display['settings'] ?? []));
-                pq($component)->attr('api-entity', \CRM_Utils_JS::encode($display['saved_search.api_entity']));
-                pq($component)->attr('api-params', \CRM_Utils_JS::encode($display['saved_search.api_params']));
+                pq($component)->attr('settings', htmlspecialchars(\CRM_Utils_JS::encode($display['settings'] ?? [])));
+                pq($component)->attr('api-entity', htmlspecialchars(\CRM_Utils_JS::encode($display['saved_search.api_entity'])));
+                pq($component)->attr('api-params', htmlspecialchars(\CRM_Utils_JS::encode($display['saved_search.api_params'])));
 
                 // Add entity names to the fieldset so that afform can populate field metadata
                 $fieldset = pq($component)->parents('[af-fieldset]');
                 if ($fieldset->length) {
                   $entityList = array_merge([$display['saved_search.api_entity']], array_column($display['saved_search.api_params']['join'] ?? [], 0));
-                  $fieldset->attr('api-entities', \CRM_Utils_JS::encode($entityList));
+                  $fieldset->attr('api-entities', htmlspecialchars(\CRM_Utils_JS::encode($entityList)));
                 }
               }
             }

--- a/ext/search/Civi/Search/Display.php
+++ b/ext/search/Civi/Search/Display.php
@@ -20,20 +20,22 @@ class Display {
   /**
    * @return array
    */
-  public static function getPageSettings():array {
-    return [
-      'displayTypes' => self::getDisplayTypes(['name']),
-    ];
+  public static function getPartials($moduleName, $module) {
+    $partials = [];
+    foreach (self::getDisplayTypes(['id', 'name']) as $type) {
+      $partials["~/$moduleName/displayType/{$type['id']}.html"] =
+        '<' . $type['name'] . ' api-entity="$ctrl.apiEntity" api-params="$ctrl.apiParams" settings="$ctrl.display.settings"></' . $type['name'] . '>';
+    }
+    return $partials;
   }
 
   /**
-   * @param array $props
    * @return array
    */
   public static function getDisplayTypes(array $props):array {
     try {
       return \Civi\Api4\SearchDisplay::getFields(FALSE)
-        ->setLoadOptions($props)
+        ->setLoadOptions(array_diff($props, ['tag']))
         ->addWhere('name', '=', 'type')
         ->execute()
         ->first()['options'];

--- a/ext/search/ang/crmSearchAdmin/crmSearchAdmin.component.js
+++ b/ext/search/ang/crmSearchAdmin/crmSearchAdmin.component.js
@@ -15,7 +15,7 @@
       this.selectedRows = [];
       this.limit = CRM.cache.get('searchPageSize', 30);
       this.page = 1;
-      this.displayTypes = _.indexBy(CRM.crmSearchAdmin.displayTypes, 'name');
+      this.displayTypes = _.indexBy(CRM.crmSearchAdmin.displayTypes, 'id');
       // After a search this.results is an object of result arrays keyed by page,
       // Initially this.results is an empty string because 1: it's falsey (unlike an empty object) and 2: it doesn't throw an error if you try to access undefined properties (unlike null)
       this.results = '';

--- a/ext/search/ang/crmSearchAdmin/crmSearchAdminDisplay.component.js
+++ b/ext/search/ang/crmSearchAdmin/crmSearchAdminDisplay.component.js
@@ -13,8 +13,8 @@
         '<div ng-switch="$ctrl.display.type">\n';
       _.each(CRM.crmSearchAdmin.displayTypes, function(type) {
         html +=
-          '<div ng-switch-when="' + type.name + '">\n' +
-          '  <search-admin-display-' + type.name + ' api-entity="$ctrl.savedSearch.api_entity" api-params="$ctrl.savedSearch.api_params" display="$ctrl.display"></search-admin-display-' + type.name + '>\n' +
+          '<div ng-switch-when="' + type.id + '">\n' +
+          '  <search-admin-display-' + type.id + ' api-entity="$ctrl.savedSearch.api_entity" api-params="$ctrl.savedSearch.api_params" display="$ctrl.display"></search-admin-display-' + type.id + '>\n' +
           '  <hr>\n' +
           '  <button type="button" class="btn btn-{{ !$ctrl.stale ? \'success\' : $ctrl.preview ? \'warning\' : \'primary\' }}" ng-click="$ctrl.previewDisplay()" ng-disabled="!$ctrl.stale">\n' +
           '  <i class="crm-i ' + type.icon + '"></i>' +
@@ -22,7 +22,7 @@
           '  </button>\n' +
           '  <hr>\n' +
           '  <div ng-if="$ctrl.preview">\n' +
-          '    <crm-search-display-' + type.name + ' api-entity="$ctrl.savedSearch.api_entity" api-params="$ctrl.savedSearch.api_params" settings="$ctrl.display.settings"></crm-search-display-' + type.name + '>\n' +
+          '    <' + type.name + ' api-entity="$ctrl.savedSearch.api_entity" api-params="$ctrl.savedSearch.api_params" settings="$ctrl.display.settings"></' + type.name + '>\n' +
           '  </div>\n' +
           '</div>\n';
       });

--- a/ext/search/ang/crmSearchAdmin/searchList.controller.js
+++ b/ext/search/ang/crmSearchAdmin/searchList.controller.js
@@ -5,11 +5,15 @@
     var ts = $scope.ts = CRM.ts(),
       ctrl = $scope.$ctrl = this;
     this.savedSearches = savedSearches;
+    this.afformEnabled = CRM.crmSearchAdmin.afformEnabled;
+    this.afformAdminEnabled = CRM.crmSearchAdmin.afformAdminEnabled;
+
     this.entityTitles = _.transform(CRM.crmSearchAdmin.schema, function(titles, entity) {
       titles[entity.name] = entity.title_plural;
     }, {});
 
-    this.searchPath = window.location.href.split('#')[0].replace('civicrm/admin/search', 'civicrm/search');
+    this.searchPath = CRM.url('civicrm/search');
+    this.newFormPath = CRM.url('civicrm/admin/afform');
 
     this.encode = function(params) {
       return encodeURI(angular.toJson(params));
@@ -25,6 +29,31 @@
         savedSearches.splice(index, 1);
       }
     };
+
+    this.loadAfforms = function() {
+      if (ctrl.afforms || ctrl.afforms === null) {
+        return;
+      }
+      ctrl.afforms = null;
+      crmApi4('Afform', 'get', {
+        select: ['layout', 'name', 'title', 'server_route'],
+        where: [['type', '=', 'search']],
+        layoutFormat: 'html'
+      }).then(function(afforms) {
+        ctrl.afforms = {};
+        _.each(afforms, function(afform) {
+          var searchName = afform.layout.match(/<crm-search-display-[^>]+search-name[ ]*=[ ]*['"]([^"']+)/);
+          if (searchName) {
+            ctrl.afforms[searchName[1]] = ctrl.afforms[searchName[1]] || [];
+            ctrl.afforms[searchName[1]].push({
+              title: afform.title,
+              url: afform.server_route ? CRM.url(afform.server_route) : null
+            });
+          }
+        });
+      });
+    };
+
   });
 
 })(angular, CRM.$, CRM._);

--- a/ext/search/ang/crmSearchAdmin/searchList.html
+++ b/ext/search/ang/crmSearchAdmin/searchList.html
@@ -1,6 +1,8 @@
 <div id="bootstrap-theme" class="crm-search">
   <h1 crm-page-title>{{:: ts('Saved Searches') }}</h1>
   <div class="form-inline">
+    <label for="search-list-filter">{{:: ts('Filter:') }}</label>
+    <input class="form-control" type="search" id="search-list-filter" ng-model="$ctrl.searchFilter" placeholder="&#xf002">
     <a class="btn btn-primary pull-right" href="#/create/Contact/">
       <i class="crm-i fa-plus"></i>
       {{:: ts('New Search') }}
@@ -14,11 +16,12 @@
         <th>{{:: ts('For') }}</th>
         <th>{{:: ts('Displays') }}</th>
         <th>{{:: ts('Smart Group') }}</th>
+        <th ng-if="$ctrl.afformEnabled">{{:: ts('Forms') }}</th>
         <th></th>
       </tr>
     </thead>
     <tbody>
-      <tr ng-repeat="search in $ctrl.savedSearches">
+      <tr ng-repeat="search in $ctrl.savedSearches | filter:$ctrl.searchFilter">
         <td>{{ search.id }}</td>
         <td>{{ search.label }}</td>
         <td>{{ $ctrl.entityTitles[search.api_entity] }}</td>
@@ -32,12 +35,41 @@
             </button>
             <ul class="dropdown-menu" ng-if=":: search.display_name.length">
               <li ng-repeat="display_name in search.display_name">
-                <a href="{{:: $ctrl.searchPath + '#/display/' + search.name + '/' + display_name }}"><i class="fa {{:: search.display_icon[$index] }}"></i> {{:: search.display_label[$index] }}</a>
+                <a href="{{:: $ctrl.searchPath + '#/display/' + search.name + '/' + display_name }}" target="_blank">
+                  <i class="fa {{:: search.display_icon[$index] }}"></i>
+                  {{:: search.display_label[$index] }}
+                </a>
               </li>
             </ul>
           </div>
         </td>
         <td>{{ search.groups.join(', ') }}</td>
+        <td ng-if="$ctrl.afformEnabled">
+          <div class="btn-group">
+            <button type="button" ng-click="$ctrl.loadAfforms()" ng-if="search.display_name" class="btn btn-xs dropdown-toggle btn-primary-outline" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+              {{:: ts('Forms') }} <span class="caret"></span>
+            </button>
+            <ul class="dropdown-menu">
+              <li ng-repeat="display_name in search.display_name" ng-if="::$ctrl.afformAdminEnabled">
+                <a href="{{:: $ctrl.newFormPath + '#/create/search/' + search.name + '.' + display_name }}">
+                  <i class="fa fa-plus"></i> {{:: ts('Create form for %1', {1: search.display_label[$index]}) }}
+                </a>
+              </li>
+              <li class="divider" role="separator" ng-if="::$ctrl.afformAdminEnabled"></li>
+              <li ng-if="!$ctrl.afforms || !$ctrl.afforms[search.name]" class="disabled">
+                <a href>
+                  <i ng-if="!$ctrl.afforms" class="crm-i fa-spinner fa-spin"></i>
+                  <em ng-if="$ctrl.afforms && !$ctrl.afforms[search.name]">{{:: ts('None Found') }}</em>
+                </a>
+              </li>
+              <li ng-if="$ctrl.afforms" ng-repeat="afform in $ctrl.afforms[search.name]" ng-class="{disabled: !afform.url}">
+                <a href="{{:: afform.url }}" target="_blank">
+                  {{:: afform.title }}
+                </a>
+              </li>
+            </ul>
+          </div>
+        </td>
         <td class="text-right">
           <a class="btn btn-xs btn-default" href="#/edit/{{:: search.id }}">{{:: ts('Edit') }}</a>
           <a class="btn btn-xs btn-default" href="#/create/{{:: search.api_entity + '?params=' + $ctrl.encode(search.api_params) }}">{{:: ts('Clone') }}</a>

--- a/ext/search/ang/crmSearchAdmin/tabs.html
+++ b/ext/search/ang/crmSearchAdmin/tabs.html
@@ -35,7 +35,7 @@
     </li>
     <li class="dropdown-header">{{ ts('Display:') }}</li>
     <li ng-repeat="type in ::$ctrl.displayTypes">
-      <a href ng-click="$ctrl.addDisplay(type.name)">
+      <a href ng-click="$ctrl.addDisplay(type.id)">
         <i class="crm-i {{:: type.icon }}"></i>
         {{:: type.label }}
       </a>

--- a/ext/search/ang/crmSearchPage.ang.php
+++ b/ext/search/ang/crmSearchPage.ang.php
@@ -6,10 +6,7 @@ return [
     'ang/crmSearchPage/*.js',
     'ang/crmSearchPage/*/*.js',
   ],
-  'partials' => [
-    'ang/crmSearchPage',
-  ],
   'basePages' => ['civicrm/search'],
   'requires' => ['ngRoute', 'api4', 'crmUi'],
-  'settingsFactory' => ['\Civi\Search\Display', 'getPageSettings'],
+  'partialsCallback' => ['\Civi\Search\Display', 'getPartials'],
 ];

--- a/ext/search/ang/crmSearchPage.module.js
+++ b/ext/search/ang/crmSearchPage.module.js
@@ -9,19 +9,8 @@
       $routeProvider.when('/display/:savedSearchName/:displayName', {
         controller: 'crmSearchPageDisplay',
         // Dynamic template generates the directive for each display type
-        template: function() {
-          var html =
-            '<h1 crm-page-title>{{:: $ctrl.display.label }}</h1>\n' +
-            '<div ng-switch="$ctrl.display.type" id="bootstrap-theme">\n';
-          _.each(CRM.crmSearchPage.displayTypes, function(type) {
-            html +=
-            '  <div ng-switch-when="' + type.name + '">\n' +
-            '    <crm-search-display-' + type.name + ' api-entity="$ctrl.apiEntity" api-params="$ctrl.apiParams" settings="$ctrl.display.settings"></crm-search-display-' + type.name + '>\n' +
-            '  </div>\n';
-          });
-          html += '</div>';
-          return html;
-        },
+        template: '<h1 crm-page-title>{{:: $ctrl.display.label }}</h1>\n' +
+          '<div ng-include="\'~/crmSearchPage/displayType/\' + $ctrl.display.type + \'.html\'" id="bootstrap-theme"></div>',
         resolve: {
           // Load saved search display
           display: function($route, crmApi4) {

--- a/ext/search/css/crmSearchAdmin.css
+++ b/ext/search/css/crmSearchAdmin.css
@@ -152,3 +152,16 @@
   right: 0;
   top: 0;
 }
+
+#bootstrap-theme input[type=search]::placeholder {
+  font-family: FontAwesome;
+  text-align: right;
+}
+#bootstrap-theme input[type=search]:-ms-input-placeholder {
+  font-family: FontAwesome;
+  text-align: right;
+}
+#bootstrap-theme input[type=search]::-ms-input-placeholder {
+  font-family: FontAwesome;
+  text-align: right;
+}

--- a/ext/search/managed/SearchDisplayType.mgd.php
+++ b/ext/search/managed/SearchDisplayType.mgd.php
@@ -15,8 +15,8 @@ return [
     'entity' => 'OptionValue',
     'params' => [
       'option_group_id' => 'search_display_type',
-      'name' => 'table',
       'value' => 'table',
+      'name' => 'crm-search-display-table',
       'label' => 'Table',
       'icon' => 'fa-table',
     ],
@@ -26,8 +26,8 @@ return [
     'entity' => 'OptionValue',
     'params' => [
       'option_group_id' => 'search_display_type',
-      'name' => 'list',
       'value' => 'list',
+      'name' => 'crm-search-display-list',
       'label' => 'List',
       'icon' => 'fa-list',
     ],


### PR DESCRIPTION
Overview
----------------------------------------
Adds major improvements to the Afform GUI, notably the ability to edit Blocks & Search Display forms, plus a clone button, & search bar.

Before
----------------------------------------
Only able to edit Afforms of type Form. Attempts to edit other types in the GUI would crash.

After
----------------------------------------
GUI works with Forms, Blocks, & Search Displays.
![image](https://user-images.githubusercontent.com/2874912/106192146-cb056e80-6179-11eb-906c-adadc0805d7b.png)


Technical Details
----------------------------------------
This PR starts with refactoring the way the Afform GUI loads metadata, which boosts performance while improving flexibility for types of forms that can be worked with.

It then adds several points of integration between Search Kit and Afform, with cross-links between the two UIs, and shared metadata processing under-the-hood.

Comments
----------------------------------------
This doesn't create any hard dependencies between Afform & Search Kit, all the integration is done conditionally
