### PR TITLE
Do not set source_contact_id in summary function

### DIFF
--- a/CRM/Activity/Import/Parser/Activity.php
+++ b/CRM/Activity/Import/Parser/Activity.php
@@ -157,11 +157,6 @@ class CRM_Activity_Import_Parser_Activity extends CRM_Activity_Import_Parser {
 
     $errorMessage = NULL;
 
-    // For date-Formats
-    $session = CRM_Core_Session::singleton();
-    if (!isset($params['source_contact_id'])) {
-      $params['source_contact_id'] = $session->get('userID');
-    }
     foreach ($params as $key => $val) {
       if ($key == 'activity_engagement_level' && $val &&
         !CRM_Utils_Rule::positiveInteger($val)


### PR DESCRIPTION

Overview
----------------------------------------
Do not set source_contact_id in summary function

Before
----------------------------------------
Value set in $params but never used

After
----------------------------------------
poof

Technical Details
----------------------------------------
This params array is discarded so this acheives nothing

Comments
----------------------------------------
