### PR TITLE
dev/core#2324 Update jquery-validaton to be 1.19.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -228,7 +228,7 @@
         "url": "https://github.com/components/jqueryui/archive/1.12.1.zip"
       },
       "jquery-validation": {
-        "url": "https://github.com/jquery-validation/jquery-validation/archive/1.19.1.zip",
+        "url": "https://github.com/jquery-validation/jquery-validation/archive/1.19.3.zip",
         "ignore": [".*", "node_modules", "bower_components", "test", "demo", "lib"]
       },
       "json-formatter": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3877832b2ea8b061992a614b7a73a456",
+    "content-hash": "6b9e928525569378f6351fcf139b481f",
     "packages": [
         {
             "name": "adrienrn/php-mimetyper",


### PR DESCRIPTION
Overview
----------------------------------------
This updates the jquery-validation version to be 1.19.3 https://lab.civicrm.org/dev/core/-/issues/2324

Before
----------------------------------------
Jquery validation version 1.19.1 used

After
----------------------------------------
Jquery validation version 1.19.3 used

ping @demeritcowboy @eileenmcnaughton 