### PR TITLE
dev/core#2335 Ensure row_format is dymnamic to ensure new rows can be added

### DIFF
--- a/CRM/Upgrade/Incremental/sql/5.34.alpha1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.34.alpha1.mysql.tpl
@@ -9,3 +9,9 @@ INSERT IGNORE INTO `civicrm_state_province` (`id`, `country_id`, `abbreviation`,
 DELETE FROM civicrm_mapping_field
 WHERE name NOT IN ( SELECT concat('custom_', id) FROM civicrm_custom_field)
 AND name LIKE 'custom_%';
+
+-- Ensure action_schedule has dynamic row format to prevent
+-- https://lab.civicrm.org/dev/core/-/issues/2335
+-- should be the case on new installs
+-- this runs before the php column adds (good).
+ALTER TABLE `civicrm_action_schedule` ROW_FORMAT=DYNAMIC;


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#2335 Ensure row_format is dymnamic to ensure new rows can be added

Before
----------------------------------------
Older databases may fail on attempting to upgrade the action schedule table to add new 5.34 fields because of row-to-large errors. More recent installs will already have row_format=dynamic & hence will not fail

After
----------------------------------------
Older dbs can upgrade

Technical Details
----------------------------------------
https://mariadb.com/kb/en/troubleshooting-row-size-too-large-errors-with-innodb/

Comments
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/2335