### PR TITLE
Greenwich: Fix BS3 conflict with html5 search clear button

### DIFF
--- a/ext/greenwich/scss/_tweaks.scss
+++ b/ext/greenwich/scss/_tweaks.scss
@@ -16,3 +16,7 @@ label input[type=checkbox]:not(:checked) + * {
 .select2-choices {
   margin-bottom: 0;
 }
+/* Fix for https://github.com/twbs/bootstrap/issues/5624 */
+input[type="search"]::-webkit-search-cancel-button {
+  -webkit-appearance: searchfield-cancel-button;
+}


### PR DESCRIPTION
Overview
----------------------------------------
This fixes a Bootstrap 3 bug that conflicted with the clear button on `<input type="search">` elements.
Ref: https://github.com/twbs/bootstrap/issues/5624

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/2874912/106316577-fb611180-623a-11eb-8715-cacb14b25015.png)


After
----------------------------------------
![image](https://user-images.githubusercontent.com/2874912/106316532-e84e4180-623a-11eb-9eae-87b69cbe0399.png)

