### PR TITLE
dev/core#2340 Skip rather than fail on bad menu item

### DIFF
--- a/CRM/Core/Menu.php
+++ b/CRM/Core/Menu.php
@@ -265,14 +265,19 @@ class CRM_Core_Menu {
    */
   public static function build(&$menu) {
     foreach ($menu as $path => $menuItems) {
-      self::buildBreadcrumb($menu, $path);
-      self::fillMenuValues($menu, $path);
-      self::fillComponentIds($menu, $path);
-      self::buildReturnUrl($menu, $path);
+      try {
+        self::buildBreadcrumb($menu, $path);
+        self::fillMenuValues($menu, $path);
+        self::fillComponentIds($menu, $path);
+        self::buildReturnUrl($menu, $path);
 
-      // add add page_type if not present
-      if (!isset($menu[$path]['page_type'])) {
-        $menu[$path]['page_type'] = 0;
+        // add add page_type if not present
+        if (!isset($menu[$path]['page_type'])) {
+          $menu[$path]['page_type'] = 0;
+        }
+      }
+      catch (CRM_Core_Exception $e) {
+        Civi::log()->error('Menu path skipped:' . $e->getMessage());
       }
     }
 
@@ -465,7 +470,7 @@ class CRM_Core_Menu {
    */
   public static function buildReturnUrl(&$menu, $path) {
     if (!isset($menu[$path]['return_url'])) {
-      list($menu[$path]['return_url'], $menu[$path]['return_url_args']) = self::getReturnUrl($menu, $path);
+      [$menu[$path]['return_url'], $menu[$path]['return_url_args']] = self::getReturnUrl($menu, $path);
     }
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Reduces the severity of having an invalid menu item by displaying an error rather rather tha not loading the page

Before
----------------------------------------
After configuring an afform with a path of 'trxn' (instead of 'civicrm/trxn') the api explorer, the main dashboard and various other pages faile to load with an uncaught exception
![image](https://user-images.githubusercontent.com/336308/106342596-64fa2200-6306-11eb-8593-d13f4b8fef43.png)

After
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/106342546-47c55380-6306-11eb-8da0-677b010c393d.png)

Technical Details
----------------------------------------


Comments
----------------------------------------

