### PR TITLE
dev/core#2341 Set data_type on various fields in Afform API

### DIFF
--- a/ext/afform/core/Civi/Api4/Afform.php
+++ b/ext/afform/core/Civi/Api4/Afform.php
@@ -130,6 +130,7 @@ class Afform extends Generic\AbstractEntity {
         ],
         [
           'name' => 'requires',
+          'data_type' => 'Array',
         ],
         [
           'name' => 'block',
@@ -164,6 +165,7 @@ class Afform extends Generic\AbstractEntity {
         ],
         [
           'name' => 'layout',
+          'data_type' => 'Array',
         ],
       ];
 
@@ -176,9 +178,11 @@ class Afform extends Generic\AbstractEntity {
         ];
         $fields[] = [
           'name' => 'has_local',
+          'data_type' => 'Boolean',
         ];
         $fields[] = [
           'name' => 'has_base',
+          'data_type' => 'Boolean',
         ];
       }
 


### PR DESCRIPTION
Overview
----------------------------------------
Sets correct data_type for fields in the Afform api.

See https://lab.civicrm.org/dev/core/-/issues/2341

