### PR TITLE
Don't build priceSet multiple times. If we have a membership priceSet it's already been built

### DIFF
--- a/CRM/Price/BAO/PriceSet.php
+++ b/CRM/Price/BAO/PriceSet.php
@@ -827,8 +827,12 @@ WHERE  id = %1";
       $validFieldsOnly = FALSE;
     }
 
-    $priceSet = self::getSetDetail($priceSetId, TRUE, $validFieldsOnly);
-    $form->_priceSet = $priceSet[$priceSetId] ?? NULL;
+    // Don't build priceSet multiple times. If called via a contributionPage it was already built by
+    // CRM_Price_BAO_PriceSet::initSet()
+    if (!$form->_priceSet) {
+      $priceSet = self::getSetDetail($priceSetId, TRUE, $validFieldsOnly);
+      $form->_priceSet = $priceSet[$priceSetId] ?? NULL;
+    }
     $validPriceFieldIds = array_keys($form->_priceSet['fields']);
     $form->_quickConfig = $quickConfig = 0;
     if (CRM_Core_DAO::getFieldValue('CRM_Price_DAO_PriceSet', $priceSetId, 'is_quick_config')) {


### PR DESCRIPTION
Overview
----------------------------------------
Price Set on contribution page gets built multiple times - we don't need to do that!
Should improve loading performance of contribution pages a little bit.

Before
----------------------------------------
Price Set built twice.

After
----------------------------------------
Price Set built once.

Technical Details
----------------------------------------
For contribution pages the price set has already been built by `CRM_Price_BAO_PriceSet::initSet()` which calls the same `getSetDetail()` function to build the price set.

Comments
----------------------------------------

