### PR TITLE
dev/core#2333 Fix issue when clicking on alpha links from 'amtg' search

### DIFF
--- a/CRM/Utils/PagerAToZ.php
+++ b/CRM/Utils/PagerAToZ.php
@@ -114,6 +114,7 @@ class CRM_Utils_PagerAToZ {
    *
    * @return array
    *   with links
+   * @throws \CRM_Core_Exception
    */
   public static function createLinks(&$query, $sortByCharacter, $isDAO) {
     $AToZBar = self::getStaticCharacters();
@@ -151,7 +152,17 @@ class CRM_Utils_PagerAToZ {
           $element['class'] = "active";
           $klass = 'class="active"';
         }
-        $url = CRM_Utils_System::url($path, "force=1&qfKey=$qfKey&sortByCharacter=");
+        $urlParams = [
+          'force' => 1,
+          'qfKey' => $qfKey,
+        ];
+        if ($query->_context === 'amtg') {
+          // See https://lab.civicrm.org/dev/core/-/issues/2333
+          // Seems to be needed in add to group flow.
+          $urlParams['_qf_Basic_display'] = 1;
+        }
+        $urlParams['sortByCharacter'] = '';
+        $url = CRM_Utils_System::url($path, $urlParams);
         // we do it this way since we want the url to be encoded but not the link character
         // since that seems to mess up drupal utf-8 encoding etc
         $url .= urlencode($link);


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#2333 Fix issue when clicking on alpha links from 'amtg' search

https://lab.civicrm.org/dev/core/-/issues/2333

Before
----------------------------------------
Add New Group via Manage Groups screen
Make it a mailing list
search for all contacts
click on letter M (or any letter)

Expected - see Contacts with last name M
Actual: Bounced back to group creation page

After
----------------------------------------
Fixed

Technical Details
----------------------------------------
Awful code but should be a fairly narrow fix as amtg context = add Members to Group I think

Comments
----------------------------------------
@kcristiano @demeritcowboy  - note I'm targetting master as this doesn't seem very recent