### PR TITLE
Don't load expired priceSet elements when building contributionpage

### DIFF
--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -364,7 +364,7 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
       // get price info
       // CRM-5095
       $priceSetId = CRM_Price_BAO_PriceSet::getFor('civicrm_contribution_page', $this->_id);
-      CRM_Price_BAO_PriceSet::initSet($this, 'civicrm_contribution_page', FALSE, $priceSetId);
+      CRM_Price_BAO_PriceSet::initSet($this, 'civicrm_contribution_page', TRUE, $priceSetId);
 
       // this avoids getting E_NOTICE errors in php
       $setNullFields = [


### PR DESCRIPTION
Overview
----------------------------------------
Found via #19469.

It makes *one* change to call `initSet()` with `doNotIncludeExpiredFields`=TRUE on contribution pages. The priceset later gets overwritten to do this anyway without this change.

I think the ultimate goal would be to a) load the priceset data once; b) Get rid of some of these supplementary functions and maybe replace with API - eg. we should only need one of `buildPriceSet()` and `initSet()`!

Before
----------------------------------------
priceSet on contribution pages built with all fields, then rebuilt to only include non-expired fields.

After
----------------------------------------
priceSet on contribution pages built with non-expired fields, then rebuilt with non-expired fields.

Technical Details
----------------------------------------
`CRM_Price_BAO_PriceSet::initSet()` is used by contribution and registration pages. It "initialises" the priceSet for the form and calls `CRM_Price_BAO_PriceSet::getSetDetail()` internally.
Later `CRM_Price_BAO_PriceSet::getSetDetail()` is called directly followed by `CRM_Price_BAO_PriceSet::buildPriceSet()` which builds the priceSet again...

So lot's of duplicate effort happening all to wrap around whether fields should be shown or not - which is basically controlled by whether the fields have expired (controlled by the date) or whether they are admin only (visibility controlled by the logged in user).

Comments
----------------------------------------
