### PR TITLE
Fix membership form to correctly calculate tax when a discount is applied

### DIFF
--- a/CRM/Member/Form.php
+++ b/CRM/Member/Form.php
@@ -71,6 +71,20 @@ class CRM_Member_Form extends CRM_Contribute_Form_AbstractEditPayment {
   protected $order;
 
   /**
+   * This string is the used for passing to the buildAmount hook.
+   *
+   * @var string
+   */
+  protected $formContext = 'membership';
+
+  /**
+   * @return string
+   */
+  public function getFormContext(): string {
+    return $this->formContext;
+  }
+
+  /**
    * Explicitly declare the entity api name.
    */
   public function getDefaultEntity() {
@@ -465,7 +479,10 @@ class CRM_Member_Form extends CRM_Contribute_Form_AbstractEditPayment {
     $this->order = new CRM_Financial_BAO_Order();
     $this->order->setPriceSelectionFromUnfilteredInput($formValues);
     $this->order->setPriceSetID($this->getPriceSetID($formValues));
-    if (isset($formValues['total_amount'])) {
+    $this->order->setForm($this);
+    if ($priceSetDetails[$this->order->getPriceSetID()]['is_quick_config'] && isset($formValues['total_amount'])) {
+      // Amount overrides only permitted on quick config.
+      // Possibly Order object should enforce this...
       $this->order->setOverrideTotalAmount($formValues['total_amount']);
     }
     $this->order->setOverrideFinancialTypeID((int) $formValues['financial_type_id']);

--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -1072,20 +1072,10 @@ DESC limit 1");
 
     $termsByType = [];
 
-    $lineItem = [$this->_priceSetId => []];
+    $lineItem = [$this->order->getPriceSetID() => $this->order->getLineItems()];
 
-    // BEGIN Fix for dev/core/issues/860
-    // Prepare fee block and call buildAmount hook - based on CRM_Price_BAO_PriceSet::buildPriceSet().
-    CRM_Utils_Hook::buildAmount('membership', $this, $this->_priceSet['fields']);
-    // END Fix for dev/core/issues/860
-
-    CRM_Price_BAO_PriceSet::processAmount($this->_priceSet['fields'],
-      $formValues, $lineItem[$this->_priceSetId], $this->_priceSetId);
-
-    if (!empty($formValues['tax_amount'])) {
-      $params['tax_amount'] = $formValues['tax_amount'];
-    }
-    $params['total_amount'] = $formValues['amount'] ?? NULL;
+    $params['tax_amount'] = $this->order->getTotalTaxAmount();
+    $params['total_amount'] = $this->order->getTotalAmount();
     if (!empty($lineItem[$this->_priceSetId])) {
       foreach ($lineItem[$this->_priceSetId] as &$li) {
         if (!empty($li['membership_type_id'])) {

--- a/tests/phpunit/CRM/Member/Form/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/Form/MembershipTest.php
@@ -1153,12 +1153,14 @@ Expires: ',
   public function testTwoMembershipsViaPriceSetInBackendWithDiscount(): void {
     // Register buildAmount hook to apply discount.
     $this->hookClass->setHook('civicrm_buildAmount', [$this, 'buildAmountMembershipDiscount']);
-
+    $this->enableTaxAndInvoicing();
+    $this->addTaxAccountToFinancialType(2);
     // Create two memberships for individual $this->_individualId, via a price set in the back end.
     $this->createTwoMembershipsViaPriceSetInBackEnd($this->_individualId);
     $contribution = $this->callAPISuccessGetSingle('Contribution', [
       'contact_id' => $this->_individualId,
     ]);
+
     // Note: we can't check for the contribution total being discounted, because the total is set
     // when the contribution is created via $form->testSubmit(), but buildAmount isn't called
     // until testSubmit() runs. Fixing that might involve making testSubmit() more sophisticated,
@@ -1170,6 +1172,7 @@ Expires: ',
     $this->assertEquals(2, $lineItemResult['count']);
     $discountedItems = 0;
     foreach ($lineItemResult['values'] as $lineItem) {
+      $this->assertEquals($lineItem['line_total'] * .1, $lineItem['tax_amount']);
       if (CRM_Utils_String::startsWith($lineItem['label'], 'Long Haired Goat')) {
         $this->assertEquals(15.0, $lineItem['line_total']);
         $this->assertEquals('Long Haired Goat - one leg free!', $lineItem['label']);


### PR DESCRIPTION
Overview
----------------------------------------
Fixes taxes when a discount is applied via buildAmount - e.g through cividiscount

Before
----------------------------------------
Configure a 50% discount with cividiscount - I used an autodiscount for 'Individual' contact type and configure member dues to hae a 10% tax

Scenario 1)
Do a back office registration - the amount will show as $660 with the 50% membership and it will declare that tax will be $60. However, after submitting the total_amount on the contribution is $600 and the tax is $120 and the line has the total amount $480 and tax amount $48

Scenario2)
As per about but alter the total_amount to $600. The total amount on the contribution is $600, all other values unchanged

After
----------------------------------------
Scenario 1 - total_amount  = 660, tax 60, line item matches
Scenrio 2 - total_amount - 600, tax 54.x, line item matches

Technical Details
----------------------------------------
This calculates the tax after the line item values are updated by the hook and the total tax for the contribution is the sum of the line items. I don't think the obligation to calculate tax on line items belongs in the extensions.

Getting away from processAmount also makes it much easier code wise as it takes a bit of work to understand what it does - essentially
- calculates the line items
- calculates tax_amount
- duplicates the work done by ``` $this->ensurePriceParamsAreSet($formValues);``` on this form

Comments
----------------------------------------
I'm experiencing other issues around cividiscount in my testing but trying to limit the scope to this one issue - so any non-regressive issues shouldn't block this