### PR TITLE
[NFC] Fix PHP 7.4 Syntax issue in Afform HTML Extension

### DIFF
--- a/ext/afform/core/CRM/Afform/ArrayHtml.php
+++ b/ext/afform/core/CRM/Afform/ArrayHtml.php
@@ -105,7 +105,7 @@ class CRM_Afform_ArrayHtml {
 
     $buf = $indent . '<' . $tag;
     foreach ($array as $attrName => $attrValue) {
-      if ($attrName{0} === '#') {
+      if ($attrName[0] === '#') {
         continue;
       }
       if (!preg_match('/^[a-zA-Z0-9\-]+$/', $attrName)) {


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a PHP 7.4 syntax error about using {} for array access

Before
----------------------------------------
PHP 7.4 syntax error

After
----------------------------------------
No Syntax error

ping @demeritcowboy @eileenmcnaughton 