### PR TITLE
Search Kit - Fix display pager and improve error handling

### DIFF
--- a/ext/afform/core/Civi/Afform/AfformMetadataInjector.php
+++ b/ext/afform/core/Civi/Afform/AfformMetadataInjector.php
@@ -60,7 +60,8 @@ class AfformMetadataInjector {
           else {
             $entityName = pq($fieldset)->attr('af-fieldset');
             if (!preg_match(';^[a-zA-Z0-9\_\-\. ]+$;', $entityName)) {
-              throw new \CRM_Core_Exception("Cannot process $path: malformed entity name ($entityName)");
+              \Civi::log()->error("Afform error: cannot process $path: malformed entity name ($entityName)");
+              return;
             }
             $entityType = $entities[$entityName]['type'];
           }

--- a/ext/search/ang/crmSearchDisplay/Pager.html
+++ b/ext/search/ang/crmSearchDisplay/Pager.html
@@ -5,7 +5,7 @@
       total-items="$ctrl.rowCount"
       ng-model="$ctrl.page"
       ng-change="$ctrl.getResults()"
-      items-per-page="$ctrl.limit"
+      items-per-page="$ctrl.apiParams.limit"
       max-size="6"
       force-ellipses="true"
       previous-text="&lsaquo;"


### PR DESCRIPTION
Overview
----------------------------------------
Fixes missing Search Kit display pagers, and avoids a crash when processing an afform with missing entities.

Before
----------------------------------------
Pager missing from search displays, possible crash if a search display is embedded in afform dashlet and then search kit extension is disabled.

After
----------------------------------------
Pager fixed.
Afform error logged instead of crashing site.
