### PR TITLE
dev/core#2344 unit test for fix regression affecting sending thank you letters when grouped

### DIFF
--- a/CRM/Utils/PDF/Utils.php
+++ b/CRM/Utils/PDF/Utils.php
@@ -191,11 +191,15 @@ class CRM_Utils_PDF_Utils {
     if ($output) {
       return $dompdf->output();
     }
-    else {
-      // CRM-19183 remove .pdf extension from filename
-      $fileName = basename($fileName, ".pdf");
-      $dompdf->stream($fileName);
+    // CRM-19183 remove .pdf extension from filename
+    $fileName = basename($fileName, ".pdf");
+    if (CIVICRM_UF === 'UnitTests') {
+      throw new CRM_Core_Exception_PrematureExitException('_html2pdf_dompdf called', [
+        'html' => $html,
+        'fileName' => $fileName,
+      ]);
     }
+    $dompdf->stream($fileName);
   }
 
   /**

--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -169,7 +169,7 @@ class CRM_Utils_Token {
    * @return string
    *   The processed string
    */
-  public static function &token_replace($type, $var, $value, &$str, $escapeSmarty = FALSE) {
+  public static function token_replace($type, $var, $value, &$str, $escapeSmarty = FALSE) {
     $token = preg_quote('{' . "$type.$var") . '(\|([^\}]+?))?' . preg_quote('}');
     if (!$value) {
       $value = '$3';


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#2344 fix regression affecting sending thank you letters when grouped

Before
----------------------------------------
1. Select multiple contributions from same contact in find contribution.
1. selected send thank you letters.
1. Put the token {contribution.total_amount} into the thank you letter and set grouping to contact (so that it groups multiple transactions into one letter)
1. Error is shown and no letter is created.

After
----------------------------------------
PDF rendered, added test passes

Technical Details
----------------------------------------
The regression was caused by https://github.com/civicrm/civicrm-core/pull/18714 - however, the fix makes the approach less flakey,. ``` replaceMultipleContributionTokens``` (only called from one place) was passing in an array where the tokens were already concatenated & expecting the ``` replaceContributionTokens``` to swap them out as is.

The new approach uses replaceContributionTokens to do the replacing on each contribution (one at a time) and then concatenates the resolved tokens, before using a different function ```token_replace``` to do the actual replacements.

Although this code is a bit hardwork it is mostly not called from other places

Comments
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/2344