### PR TITLE
dev/core#2348 fix unreleased regression

### DIFF
--- a/CRM/Event/Import/Parser/Participant.php
+++ b/CRM/Event/Import/Parser/Participant.php
@@ -626,13 +626,15 @@ class CRM_Event_Import_Parser_Participant extends CRM_Event_Import_Parser {
   }
 
   /**
-   * @deprecated - this is part of the import parser not the API & needs to be moved on out
-   *
    * @param array $params
    * @param $onDuplicate
    *
    * @return array|bool
    *   <type>
+   * @throws \CiviCRM_API3_Exception
+   * @deprecated - this is part of the import parser not the API & needs to be
+   *   moved on out
+   *
    */
   protected function deprecated_create_participant_formatted($params, $onDuplicate) {
     if ($onDuplicate != CRM_Import_Parser::DUPLICATE_NOCHECK) {
@@ -642,7 +644,7 @@ class CRM_Event_Import_Parser_Participant extends CRM_Event_Import_Parser {
         return $error;
       }
     }
-    return civicrm_api3_participant_create($params);
+    return civicrm_api3('Participant', 'create', $params);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#2348 fix unreleased regression on participant import

Before
----------------------------------------
Fatal error on importing participants in 5.34

After
----------------------------------------
_What changed? What is new old user-interface or technical-contract?_
fixed

Technical Details
----------------------------------------
the require_once got lost - switching to a proper api call should fix

Comments
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/2348
