### PR TITLE
Token Processor: fix PHP syntax for purifyHTML

### DIFF
--- a/Civi/Token/TokenRow.php
+++ b/Civi/Token/TokenRow.php
@@ -268,7 +268,7 @@ class TokenRow {
               }
               elseif (\CRM_Utils_Array::value('data_type', \CRM_Utils_Array::value($field, $entityFields['values'])) == 'Memo') {
                 // Memo fields aka custom fields of type Note are html.
-                $htmlTokens[$entity][$field] = CRM_Utils_String::purifyHTML($value);
+                $htmlTokens[$entity][$field] = \CRM_Utils_String::purifyHTML($value);
               }
               else {
                 $htmlTokens[$entity][$field] = htmlentities($value);


### PR DESCRIPTION
Overview
----------------------------------------

I was playing around with the Token Processor and stumbled on this error:

```
PHP Fatal error:  Uncaught Error: Class 'Civi\Token\CRM_Utils_String' not found
in [...]/plugins/civicrm/civicrm/Civi/Token/TokenRow.php:271
```

Technical Details
----------------------------------------

Admittedly I was testing in an extension for ways to generate tokens in non-standard ways (my extensions sends custom emails, not using the EmailAPI extension, because I need to pass random tokens not based on the Contact ID or the Activity ID).
