### PR TITLE
dev/core#2350 - Oauth extension - Setting a fatalErrorHandler might override the redirect url because typo

### DIFF
--- a/ext/oauth-client/settings/OAuthClient.setting.php
+++ b/ext/oauth-client/settings/OAuthClient.setting.php
@@ -3,7 +3,7 @@ return [
   'oauthClientRedirectUrl' => [
     'group_name' => 'Developer Preferences',
     'group' => 'developer',
-    'name' => 'fatalErrorHandler',
+    'name' => 'oauthClientRedirectUrl',
     'type' => 'String',
     'quick_form_type' => 'Element',
     'html_type' => 'text',


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/2350

This seems like a copy/paste typo.