### PR TITLE
[REF] Stop passing contributionPageID to isEmailReceipt

### DIFF
--- a/tests/phpunit/api/v3/ContributionPageTest.php
+++ b/tests/phpunit/api/v3/ContributionPageTest.php
@@ -421,7 +421,7 @@ class api_v3_ContributionPageTest extends CiviUnitTestCase {
    *
    * @throws \CRM_Core_Exception
    */
-  public function testSubmitMembershipBlockNotSeparatePaymentWithEmail() {
+  public function testSubmitMembershipBlockNotSeparatePaymentWithEmail(): void {
     $mut = new CiviMailUtils($this, TRUE);
     $this->setUpMembershipContributionPage();
     $this->addProfile('supporter_profile', $this->_ids['contribution_page']);


### PR DESCRIPTION
Overview
----------------------------------------
[REF] Stop passing contributionPageID to isEmailReceipt

Before
----------------------------------------
code does a lot of work in various places to pass in contribution_page_id

After
----------------------------------------
is_email_receipt looked up based on contribution - we can remove those places after this

Technical Details
----------------------------------------

Comments
----------------------------------------
