### PR TITLE
Pass membershipID through in messagetemplate params

### DIFF
--- a/CRM/Contribute/BAO/ContributionPage.php
+++ b/CRM/Contribute/BAO/ContributionPage.php
@@ -372,13 +372,17 @@ class CRM_Contribute_BAO_ContributionPage extends CRM_Contribute_DAO_Contributio
         $tplParams['contributionTypeName'] = $tplParams['financialTypeName'];
       }
 
-      if ($contributionPageId = CRM_Utils_Array::value('id', $values)) {
-        $tplParams['contributionPageId'] = $contributionPageId;
+      if (isset($values['id'])) {
+        $tplParams['contributionPageId'] = $values['id'];
       }
 
       // address required during receipt processing (pdf and email receipt)
-      if ($displayAddress = CRM_Utils_Array::value('address', $values)) {
-        $tplParams['address'] = $displayAddress;
+      if (isset($values['address'])) {
+        $tplParams['address'] = $values['address'];
+      }
+
+      if (isset($values['membership_id'])) {
+        $tplParams['membershipID'] = $values['membership_id'];
       }
 
       // CRM-6976


### PR DESCRIPTION
Overview
----------------------------------------
When sending a system workflow message the membership ID is usually available but not passed through with the template params. Instead a number of membership variables are assigned to the template before calling `sendTemplate()`. By passing it through we can use it via the `alterMailParams` hook and it makes us more prepared for switching the `sendTemplate()` function to use the newer tokenProcessor code.

Before
----------------------------------------
membershipID not available via `sendTemplate()` / mailing hooks.

After
----------------------------------------
membershipID available via `sendTemplate()` / mailing hooks.

Technical Details
----------------------------------------


Comments
----------------------------------------

