### PR TITLE
CRM_Core_BAO_MessageTemplate::sendReminder() is not used anywhere

### DIFF
--- a/CRM/Core/BAO/MessageTemplate.php
+++ b/CRM/Core/BAO/MessageTemplate.php
@@ -221,6 +221,7 @@ class CRM_Core_BAO_MessageTemplate extends CRM_Core_DAO_MessageTemplate {
    * @throws \CRM_Core_Exception
    */
   public static function sendReminder($contactId, $email, $messageTemplateID, $from) {
+    CRM_Core_Error::deprecatedWarning('CRM_Core_BAO_MessageTemplate::sendReminder is deprecated and will be removed in a future version of CiviCRM');
 
     $messageTemplates = new CRM_Core_DAO_MessageTemplate();
     $messageTemplates->id = $messageTemplateID;


### PR DESCRIPTION
Overview
----------------------------------------
As far as I can tell this function is not used anywhere and can be removed.

I searched through the code and could not find any usages. `CRM_Core_BAO_ActionSchedule` implements it's own functions.
