### PR TITLE
Use exceptions when enabling case component / checking for 'CREATE VIEW' permissions

### DIFF
--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -2784,35 +2784,20 @@ WHERE id IN (' . implode(',', $copiedActivityIds) . ')';
   }
 
   /**
-   * Used during case component enablement and during ugprade.
+   * Used during case component enablement and during upgrade.
    *
    * @return bool
    */
   public static function createCaseViews() {
-    $errorScope = CRM_Core_TemporaryErrorScope::ignoreException();
     $dao = new CRM_Core_DAO();
+    try {
+      $sql = self::createCaseViewsQuery('upcoming');
+      $dao->query($sql);
 
-    $sql = self::createCaseViewsQuery('upcoming');
-    $dao->query($sql);
-    if (PEAR::getStaticProperty('DB_DataObject', 'lastError')) {
-      return FALSE;
+      $sql = self::createCaseViewsQuery('recent');
+      $dao->query($sql);
     }
-
-    // Above error doesn't get caught?
-    $doublecheck = $dao->singleValueQuery("SELECT count(id) FROM civicrm_view_case_activity_upcoming");
-    if (is_null($doublecheck)) {
-      return FALSE;
-    }
-
-    $sql = self::createCaseViewsQuery('recent');
-    $dao->query($sql);
-    if (PEAR::getStaticProperty('DB_DataObject', 'lastError')) {
-      return FALSE;
-    }
-
-    // Above error doesn't get caught?
-    $doublecheck = $dao->singleValueQuery("SELECT count(id) FROM civicrm_view_case_activity_recent");
-    if (is_null($doublecheck)) {
+    catch (Exception $e) {
       return FALSE;
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
See #18466. This removes another use of `ignoreException()`. In this case the `civicrm/admin/setting/component` form was hanging because `ignoreException()` was not enabled and the DB error exception was not trapped. This fixes that and removes ignoreException() from the enable case function.

To test, remove "CREATE VIEW" permission from your mysql user. It is clear from the comments that this code was never working very well.

Before
----------------------------------------
`ignoreException()` used when testing for/creating views.

After
----------------------------------------
Exceptions thrown and feedback provided to user.

Technical Details
----------------------------------------
Explained above.

Comments
----------------------------------------
@seamuslee001 @eileenmcnaughton 
