### PR TITLE
Fix display of membership dates on receipts when lineitems do not have a price_set_id

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -3024,12 +3024,16 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
             $values['priceSetID'] = $priceSet['id'];
           }
           foreach ($lineItems as &$eachItem) {
-            if (isset($this->_relatedObjects['membership'])
-              && is_array($this->_relatedObjects['membership'])
-              && array_key_exists($eachItem['entity_id'] . '_' . $eachItem['membership_type_id'], $this->_relatedObjects['membership'])) {
-              $eachItem['join_date'] = CRM_Utils_Date::customFormat($this->_relatedObjects['membership'][$eachItem['entity_id'] . '_' . $eachItem['membership_type_id']]->join_date);
-              $eachItem['start_date'] = CRM_Utils_Date::customFormat($this->_relatedObjects['membership'][$eachItem['entity_id'] . '_' . $eachItem['membership_type_id']]->start_date);
-              $eachItem['end_date'] = CRM_Utils_Date::customFormat($this->_relatedObjects['membership'][$eachItem['entity_id'] . '_' . $eachItem['membership_type_id']]->end_date);
+            if ($eachItem['entity_table'] === 'civicrm_membership') {
+              $membership = reset(civicrm_api3('Membership', 'get', [
+                'id' => $eachItem['entity_id'],
+                'return' => ['join_date', 'start_date', 'end_date'],
+              ])['values']);
+              if ($membership) {
+                $eachItem['join_date'] = CRM_Utils_Date::customFormat($membership['join_date']);
+                $eachItem['start_date'] = CRM_Utils_Date::customFormat($membership['start_date']);
+                $eachItem['end_date'] = CRM_Utils_Date::customFormat($membership['end_date']);
+              }
             }
             // This is actually used in conjunction with is_quick_config in the template & we should deprecate it.
             // However, that does create upgrade pain so would be better to be phased in.


### PR DESCRIPTION
Overview
----------------------------------------
An "online" membership receipt has various ways of displaying. If `useForMember` is set and `is_quick_config` is not set then it displays a list of lineitems. This happens if the lineitems do not have a `price_set_id` associated with them. The memberships were being loaded and keyed via `membershipID_membershipTypeID` but membershipTypeID was never set in the list of lineitems (because it's not linked to a priceset) so the membership was never found in the list of relatedObjects.

Before
----------------------------------------
Membership lineitems without a priceset do not show start and end date on online receipts.

![image](https://user-images.githubusercontent.com/2052161/106661346-000a2a80-6599-11eb-8f1e-5e1c94b85f3d.png)


After
----------------------------------------
Membership lineitems without a priceset do show start and end date on online receipts.

![image](https://user-images.githubusercontent.com/2052161/106662264-12d12f00-659a-11eb-905c-5580534a8f45.png)

Technical Details
----------------------------------------
As we don't need the `membership_type_id` we can bypass _relatedObjects and load each membership directly.

Comments
----------------------------------------
@eileenmcnaughton This one might be a bit easier to review - this is all that's required for the bugfix