### PR TITLE
Set api default for contributionRecur to Pending

### DIFF
--- a/api/v3/ContributionRecur.php
+++ b/api/v3/ContributionRecur.php
@@ -43,6 +43,7 @@ function _civicrm_api3_contribution_recur_create_spec(&$params) {
   $params['amount']['api.required'] = 1;
   $params['start_date']['api.default'] = 'now';
   $params['modified_date']['api.default'] = 'now';
+  $params['contribution_status_id'] = 'Pending';
 }
 
 /**


### PR DESCRIPTION

Overview
----------------------------------------
Set api default for contributionRecur to Pending - note this is one options - see techical details


Before
----------------------------------------
A contribution created with the v3 ContributionRecur.create api will have a status of 'Completed' if contribution_status_id is not specified 

After
----------------------------------------
A contribution created with the v3 ContributionRecur.create api will have a status of 'Pending' if contribution_status_id is not specified. 

Per existing behaviour adding a completed contribution record (through contribution.create) to a recurring contribution or (better) updating an already attached contribution record to completed will update the recurring contribution record to 'In Progress' or to 'Completed' depending on the number of installments vs the number of contributions

Technical Details
----------------------------------------
This has a DB default of 'Completed' which is not right as far as I'm concerned - the right
default is 'Pending' IMHO.  

There are 2 ways we could address this

1) We could update the DB default via a schema change
2) add defaults on both v3 & v4 api. (this is a placeholder for the latter approach but I increasingly prefer the former)

I think we would need to advise of this change via change log, release notes, dev-digest
but I doubt it would be that controversial since contributions need to be
add to to contribution recur after it is created & if enough
contributions are added to complete it it would be updated to Completed

Comments
----------------------------------------
@mattwire @seamuslee001 @colemanw @artfulrobot @adixon  @agh1 @KarinG  - thoughts