### PR TITLE
Move require once in api kernel to support edge cases

### DIFF
--- a/Civi/API/Kernel.php
+++ b/Civi/API/Kernel.php
@@ -159,12 +159,15 @@ class Kernel {
    */
   public function boot($apiRequest) {
     require_once 'api/Exception.php';
+    // the create error function loads some functions from utils
+    // so this require is also needed for apiv4 until such time as
+    // we alter create error.
+    require_once 'api/v3/utils.php';
     switch ($apiRequest['version']) {
       case 3:
         if (!is_array($apiRequest['params'])) {
           throw new \API_Exception('Input variable `params` is not an array', 2000);
         }
-        require_once 'api/v3/utils.php';
         _civicrm_api3_initialize();
         break;
 


### PR DESCRIPTION


Overview
----------------------------------------
Move require once in api kernel to support edge cases


Before
----------------------------------------
```
 drush  cvapi  Contribution.get version=4
```

fails with a require_once error

After
----------------------------------------
Above fails (correctly) with a permissions error

Technical Details
----------------------------------------
The function 'createError' on the kernel class calls 3 functions that are in the api v3 utils file.
It is possible to reach this from apiv4 using drush (I realise we
don't really know much about how to support api v4 with drush but it DOES work with a simple
api with this patch in my testing). We could go with only including utils.php in
v4 api AND the createError function. I think it's more readable this way.

To test this try

 drush  cvapi  Contribution.get version=4

it will legitimately fail without checkPermissions=0 but it will fail with a
require_once error without this patch


Comments
----------------------------------------
