### PR TITLE
APIv4 - Fix bug when using relative date filters in ON clause of a join

### DIFF
--- a/Civi/Api4/Query/Api4SelectQuery.php
+++ b/Civi/Api4/Query/Api4SelectQuery.php
@@ -412,9 +412,14 @@ class Api4SelectQuery {
       if (is_string($value)) {
         $valExpr = $this->getExpression($value);
         if ($fieldName && $valExpr->getType() === 'SqlString') {
-          FormattingUtil::formatInputValue($valExpr->expr, $fieldName, $this->apiFieldSpec[$fieldName], $operator);
+          $value = $valExpr->getExpr();
+          FormattingUtil::formatInputValue($value, $fieldName, $this->apiFieldSpec[$fieldName], $operator);
+          return \CRM_Core_DAO::createSQLFilter($fieldAlias, [$operator => $value]);
         }
-        return sprintf('%s %s %s', $fieldAlias, $operator, $valExpr->render($this->apiFieldSpec));
+        else {
+          $value = $valExpr->render($this->apiFieldSpec);
+          return sprintf('%s %s %s', $fieldAlias, $operator, $value);
+        }
       }
       elseif ($fieldName) {
         $field = $this->getField($fieldName);


### PR DESCRIPTION
Overview
----------------------------------------
This fixes an api bug noticeable in Search Kit when using a relative date range as part of a join e.g.

![image](https://user-images.githubusercontent.com/2874912/106753157-4becbc00-65f9-11eb-9ed9-5b5c41904977.png)


Before
----------------------------------------
Above search causes SQL error.
This PR adds a test which would fail.

After
----------------------------------------
Search works correctly, test passes.