### PR TITLE
APIv4 - Enable getFields to find fields across implicit FK joins

### DIFF
--- a/Civi/Api4/Service/Spec/RequestSpec.php
+++ b/Civi/Api4/Service/Spec/RequestSpec.php
@@ -101,13 +101,15 @@ class RequestSpec {
     if (!$fieldNames) {
       return $this->fields;
     }
-    $fields = [];
-    foreach ($this->fields as $field) {
-      if (in_array($field->getName(), $fieldNames)) {
-        $fields[] = $field;
+    // Return all exact matches plus partial matches (to support retrieving fk fields)
+    return array_filter($this->fields, function($field) use($fieldNames) {
+      foreach ($fieldNames as $fieldName) {
+        if (strpos($fieldName, $field->getName()) === 0) {
+          return TRUE;
+        }
       }
-    }
-    return $fields;
+      return FALSE;
+    });
   }
 
   /**

--- a/tests/phpunit/api/v4/Action/GetExtraFieldsTest.php
+++ b/tests/phpunit/api/v4/Action/GetExtraFieldsTest.php
@@ -64,4 +64,18 @@ class GetExtraFieldsTest extends UnitTestCase {
     $this->assertContains('Alberta', $caOptions['options']);
   }
 
+  public function testGetFkFields() {
+    $fields = \Civi\Api4\Participant::getFields()
+      ->setLoadOptions(TRUE)
+      ->addWhere('name', 'IN', ['event_id', 'event_id.created_id', 'contact_id.gender_id', 'event_id.created_id.sort_name'])
+      ->execute()
+      ->indexBy('name');
+
+    $this->assertCount(4, $fields);
+    $this->assertEquals('Participant', $fields['event_id']['entity']);
+    $this->assertEquals('Event', $fields['event_id.created_id']['entity']);
+    $this->assertEquals('Contact', $fields['event_id.created_id.sort_name']['entity']);
+    $this->assertGreaterThan(1, count($fields['contact_id.gender_id']['options']));
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Now it is possible to retrieve field metadata for a joined entity via APIv4. E.g. from the Participant GetFields api, specifying the fieldName "event_id.title" will automatically retrieve field metadata from the Event API.

Before
----------------------------------------
Only entities own fields could be returned.

After
----------------------------------------
Possible to return fields from other entities.

Comments
----------------------------------------
This is the first step toward supporting implicit join fields in Search Kit.
