### PR TITLE
Override the DrupalBase getUserObject function with a Drupal8/9 compa…

### DIFF
--- a/CRM/Utils/System/Drupal8.php
+++ b/CRM/Utils/System/Drupal8.php
@@ -847,4 +847,15 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
     }
   }
 
+  /**
+   * Load the user object.
+   *
+   * @param int $userID
+   *
+   * @return object
+   */
+  public function getUserObject($userID) {
+    return \Drupal::entityTypeManager()->getStorage('user')->load($userID);
+  }
+
 }


### PR DESCRIPTION
…tible version

Overview
----------------------------------------
This fixes an error when trying to use the User v3 API on Drupal 9 as per https://civicrm.stackexchange.com/questions/38766/call-to-undefined-function-user-load-using-drupal-9-and-api3

Before
----------------------------------------
Undefined function user_load

After
----------------------------------------
no undefined function

ping @adixon @KarinG @MikeyMJCO @eileenmcnaughton 