### PR TITLE
user_load is deprecated

### DIFF
--- a/CRM/Utils/System/Drupal8.php
+++ b/CRM/Utils/System/Drupal8.php
@@ -570,6 +570,17 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
   }
 
   /**
+   * Load the user object.
+   *
+   * @param int $userID
+   *
+   * @return object
+   */
+  public function getUserObject($userID) {
+    return \Drupal\user\Entity\User::load($userID);
+  }
+
+  /**
    * @inheritDoc
    */
   public function getUniqueIdentifierFromUserObject($user) {


### PR DESCRIPTION
Overview
----------------------------------------
As noted by @adixon at https://civicrm.stackexchange.com/questions/38766/call-to-undefined-function-user-load-using-drupal-9-and-api3

Before
----------------------------------------
`Error: Call to undefined function user_load() in ...\CRM\Utils\System\DrupalBase.php on line 558` when calling civicrm_api3('user', 'get', ['id' => 1]);`

After
----------------------------------------
Good

Technical Details
----------------------------------------


Comments
----------------------------------------

