### PR TITLE
[REF] Simplify is_email_receipt handling

### DIFF
--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -179,6 +179,19 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
   public $submitOnce = FALSE;
 
   /**
+   * Values submitted by the user.
+   *
+   * These values have been checked for injection per
+   * https://pear.php.net/manual/en/package.html.html-quickform.html-quickform.exportvalues.php
+   * and are as submitted.
+   *
+   * Once set this array should be treated as read only.
+   *
+   * @var array
+   */
+  protected $exportedValues = [];
+
+  /**
    * @return string
    */
   public function getContext() {
@@ -2717,6 +2730,23 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
     }
     $userChecksum = CRM_Utils_Request::retrieve('cs', 'String', $this);
     return CRM_Contact_BAO_Contact_Utils::validChecksum($contactID, $userChecksum) ? $contactID : FALSE;
+  }
+
+  /**
+   * Get values submitted by the user.
+   *
+   * These values have been validated against the fields added to the form.
+   * https://pear.php.net/manual/en/package.html.html-quickform.html-quickform.exportvalues.php
+   *
+   * @param string $fieldName
+   *
+   * @return mixed|null
+   */
+  protected function getSubmittedValue(string $fieldName) {
+    if (empty($this->exportedValues)) {
+      $this->exportedValues = $this->controller->exportValues($this->_name);
+    }
+    return $this->exportedValues[$fieldName] ?? NULL;
   }
 
 }

--- a/CRM/Member/Form.php
+++ b/CRM/Member/Form.php
@@ -478,6 +478,7 @@ class CRM_Member_Form extends CRM_Contribute_Form_AbstractEditPayment {
    * @param array $formValues
    */
   public function testSubmit(array $formValues): void {
+    $this->exportedValues = $formValues;
     $this->setContextVariables($formValues);
     $this->_memType = $formValues['membership_type_id'][1];
     $this->_params = $formValues;


### PR DESCRIPTION
Overview
----------------------------------------
[REF] Simplify is_email_receipt handling

Before
----------------------------------------
different, hard to track, ways to refer to whether the send_email checkbox was ticked - some have been copied & pasted from other forms or previously shared functions

After
----------------------------------------
The function $form->getSubmittedValue('send_receipt') is used directly

Technical Details
----------------------------------------
This removes a chunk of confusing handling from the previously shared code.

Philosophically we have a lot of arrays of data being passed around. The difference
between these arrays is unclear & the array that appears to exist specifically to
how what was actually submitted (formValues) is edited rather than left intact.

Where we are not dealing with a calcuated value, but rather referring to
what was submitted the quickform function getSubmittedValue() seems
like a good pick. It's clear we are looking up the submitted value not
some calculated value & when code is moved around we know this
value is not dependent on where it is sitting in the code.

The function returns 1 or NULL - hence I cast to boolean where I'm not
sure NULL is good enough

Comments
----------------------------------------
