### PR TITLE
[REF] Remove unused pcp & soft credit handling from previously shared code

### DIFF
--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -1907,12 +1907,6 @@ DESC limit 1");
       $form->_contributionID = $contribution->id;
     }
 
-    // process soft credit / pcp params first
-    CRM_Contribute_BAO_ContributionSoft::formatSoftCreditParams($params, $form);
-
-    //CRM-13981, processing honor contact into soft-credit contribution
-    CRM_Contribute_BAO_ContributionSoft::processSoftContribution($params, $contribution);
-
     $transaction->commit();
     return $contribution;
   }


### PR DESCRIPTION

Overview
----------------------------------------
[REF] Remove unused pcp & soft credit handling from previously shared code

Before
----------------------------------------
Lines exist, do nothing

After
----------------------------------------
poof

Technical Details
----------------------------------------
the ProcessContribution function has been split out from a shared function used by front end forms
and I'm pretty sure it was only relevant for those other forms. The only code that calls this function
is when a payment processor is used in recurring mode to pay for a membership.

I tested doing this and selected 'record payment from a different contact' without these
lines & it created the soft credit (using the code elsewhere in the function that
would be used if it were not recurring or not credit card payment)

Comments
----------------------------------------
