### PR TITLE
[REF] Complete order Unset contribution once we have finished with it.

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4279,6 +4279,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
 
     $contributionResult = self::repeatTransaction($contribution, $input, $contributionParams);
     $contributionID = (int) $contribution->id;
+    unset($contribution);
 
     if ($input['component'] == 'contribute') {
       if ($contributionParams['contribution_status_id'] === $completedContributionStatusID) {
@@ -4302,8 +4303,6 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
     if (!$contributionResult) {
       $contributionResult = civicrm_api3('Contribution', 'create', $contributionParams);
     }
-
-    $contribution->contribution_status_id = $contributionParams['contribution_status_id'];
 
     $transaction->commit();
     \Civi::log()->info("Contribution {$contributionParams['id']} updated successfully");

--- a/CRM/Core/Payment/AuthorizeNetIPN.php
+++ b/CRM/Core/Payment/AuthorizeNetIPN.php
@@ -62,7 +62,7 @@ class CRM_Core_Payment_AuthorizeNetIPN extends CRM_Core_Payment_BaseIPN {
       // Check if the contribution exists
       // make sure contribution exists and is valid
       $contribution = new CRM_Contribute_BAO_Contribution();
-      $contribution->id = $ids['contribution'];
+      $contribution->id = $contributionID = $ids['contribution'];
       if (!$contribution->find(TRUE)) {
         throw new CRM_Core_Exception('Failure: Could not find contribution record for ' . (int) $contribution->id, NULL, ['context' => "Could not find contribution record: {$contribution->id} in IPN request: " . print_r($input, TRUE)]);
       }
@@ -92,7 +92,7 @@ class CRM_Core_Payment_AuthorizeNetIPN extends CRM_Core_Payment_BaseIPN {
           $contributionRecur->contact_id,
           $ids['contributionPage'],
           $contributionRecur,
-          (bool) $this->getMembershipID($contribution->id, $contributionRecur->id)
+          (bool) $this->getMembershipID($contributionID, $contributionRecur->id)
         );
       }
 


### PR DESCRIPTION

Overview
----------------------------------------
[REF] Complete order Unset contribution once we have finished with it.

Before
----------------------------------------
A whole lotta stuff is happening with the contribution object - but we can't see to what end

After
----------------------------------------
Checked whether it IS still used after repeatransaction & altered the one place that does use it, unset it to make that clear & avoid that checking work needing to be re-done

Technical Details
----------------------------------------

This patch does very little but it takes a bit of searching to check the handful of places
that call completeOrder and check that none of them use the contribution
object after this function call. With this merged it will be possible to
cleanup the references to the contribution in the repeattransaction
code safe in the knowledge that the object is not needed after that
function (or within it from my reading). It seems likely we can switch to
passing in contributionID rather than the whole object.


Comments
----------------------------------------
