### PR TITLE
5.34.0 release notes: Miscategorized item

### DIFF
--- a/release-notes/5.34.0.md
+++ b/release-notes/5.34.0.md
@@ -63,6 +63,12 @@ Released February 3, 2021
 
   The pre and post hooks are now triggered when modifying profiles.
 
+- **Add a unique event ID so we can match pre/post Insert/Update
+  ([19209](https://github.com/civicrm/civicrm-core/pull/19209))**
+
+  Makes it so developers can use the event ID to link pre/post Insert/Update
+  events for the same change.
+
 - **Add support for multi-value contact reference custom fields
   ([18941](https://github.com/civicrm/civicrm-core/pull/18941))**
 
@@ -167,14 +173,6 @@ Released February 3, 2021
 
   Improves logging when a Contribution is created/updated to improve the
   debugging experience.
-
-### CiviEvent
-
-- **Add a unique event ID so we can match pre/post Insert/Update
-  ([19209](https://github.com/civicrm/civicrm-core/pull/19209))**
-
-  Makes it so developers can use the event ID to link pre/post Insert/Update
-  events for the same change.
 
 ### Search Kit
 


### PR DESCRIPTION
Overview
----------------------------------------
#19209 is miscategorized in the 5.34.0 release notes.

Before
----------------------------------------
It's under Features - CiviEvent.  This "event ID" is not the ID of CiviEvent events but an ID of an EventDispatcher event.

After
----------------------------------------
It's under Features - Core CiviCRM.

Comments
----------------------------------------
Thanks to @MegaphoneJon for reading and catching it! https://github.com/civicrm/civicrm-core/pull/19520#issuecomment-773267142
