### PR TITLE
[WIP] highly contrived unit test to show passing test that should fail

### DIFF
--- a/tests/phpunit/CRM/Core/SssTest.php
+++ b/tests/phpunit/CRM/Core/SssTest.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * Class CRM_Core_SssTest
+ * @group headless
+ */
+class CRM_Core_SssTest extends CiviUnitTestCase {
+
+  /**
+   * Test
+   */
+  public function testA() {
+    CRM_Core_DAO::executeQuery("ALTER TABLE civicrm_country DROP COLUMN is_active");
+    $result = $this->callAPISuccess('Address', 'getfield', array('entity' => 'Address', 'context' => 'create', 'name' => 'country_id', 'action' => 'create', ));
+  }
+
+}

--- a/tests/phpunit/CRM/Core/SssTest.php
+++ b/tests/phpunit/CRM/Core/SssTest.php
@@ -11,7 +11,7 @@ class CRM_Core_SssTest extends CiviUnitTestCase {
    */
   public function testA() {
     CRM_Core_DAO::executeQuery("ALTER TABLE civicrm_country DROP COLUMN is_active");
-    $result = $this->callAPISuccess('Address', 'getfield', array('entity' => 'Address', 'context' => 'create', 'name' => 'country_id', 'action' => 'create', ));
+    $result = $this->callAPISuccess('Address', 'getfield', array('entity' => 'Address', 'context' => 'create', 'name' => 'country_id', 'action' => 'create'));
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Highly contrived example to show change in what happens during api calls when a db error occurs after https://github.com/civicrm/civicrm-core/pull/19323

Locally at least, this failed before. Now it passes. Seeing what happens here.