### PR TITLE
APIv4 - Fix HTTP status code selection

### DIFF
--- a/CRM/Api4/Page/AJAX.php
+++ b/CRM/Api4/Page/AJAX.php
@@ -84,7 +84,7 @@ class CRM_Api4_Page_AJAX extends CRM_Core_Page {
       $statusMap = [
         \Civi\API\Exception\UnauthorizedException::class => 403,
       ];
-      http_response_code($statusMap[get_class($e) ?? 500]);
+      http_response_code($statusMap[get_class($e)] ?? 500);
       $response = [];
       if (CRM_Core_Permission::check('view debug output')) {
         $response['error_code'] = $e->getCode();


### PR DESCRIPTION
This is a follow-up to #19526 which addresses a typo that causes a misbehavior in reporting the HTTP status code.

Before
------

If an API request encounters an exception, then it always returns HTTP 403.

After
-----

If an API request encounters an exception, then:

* It may return HTTP 403 (for an authorization exception)
* It may return HTTP 500 (for any other/unrecognized exception)

Comments
----------------------------------------

To test this, I just hacked an API locally and then ran it via curl or Firefox:

```diff
diff --git a/Civi/Api4/Entity.php b/Civi/Api4/Entity.php
index 5689252494..8aee88f04e 100644
--- a/Civi/Api4/Entity.php
+++ b/Civi/Api4/Entity.php
@@ -33,6 +33,8 @@ class Entity extends Generic\AbstractEntity {
    * @return Action\Entity\Get
    */
   public static function get($checkPermissions = TRUE) {
+//A//    throw new \Exception('asdfasdf');
+//B//    throw new \Civi\API\Exception\UnauthorizedException('fdsa');
     return (new Action\Entity\Get('Entity', __FUNCTION__))
       ->setCheckPermissions($checkPermissions);
   }
```