### PR TITLE
dev/core#2360 - Escape the word `rows` in sql query

### DIFF
--- a/Civi/Api4/Query/Api4SelectQuery.php
+++ b/Civi/Api4/Query/Api4SelectQuery.php
@@ -164,7 +164,7 @@ class Api4SelectQuery {
       $this->buildHavingClause();
       $this->buildGroupBy();
       $subquery = $this->query->toSQL();
-      $sql = "SELECT count(*) AS `c` FROM ( $subquery ) AS rows";
+      $sql = "SELECT count(*) AS `c` FROM ( $subquery ) AS `rows`";
     }
     $this->debug('sql', $sql);
     return (int) \CRM_Core_DAO::singleValueQuery($sql);


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a sql crash in mysql 8.0.2+ documented in https://lab.civicrm.org/dev/core/-/issues/2360

Before
----------------------------------------
Search Kit crashes.

After
----------------------------------------
It doesn't.
