### PR TITLE
Afform (et al) - Fetch more complete list of permissions via APIv4

### DIFF
--- a/CRM/Admin/Form/Navigation.php
+++ b/CRM/Admin/Form/Navigation.php
@@ -57,7 +57,7 @@ class CRM_Admin_Form_Navigation extends CRM_Admin_Form {
 
     $getPerms = (array) \Civi\Api4\Permission::get(0)
       ->addWhere('group', 'IN', ['civicrm', 'cms', 'const'])
-      ->setOrderBy(['group' => 'ASC', 'name' => 'ASC'])
+      ->setOrderBy(['title' => 'ASC'])
       ->execute();
     $permissions = [];
     foreach ($getPerms as $perm) {

--- a/CRM/Admin/Form/Navigation.php
+++ b/CRM/Admin/Form/Navigation.php
@@ -55,9 +55,13 @@ class CRM_Admin_Form_Navigation extends CRM_Admin_Form {
 
     $this->add('text', 'icon', ts('Icon'), ['class' => 'crm-icon-picker', 'title' => ts('Choose Icon'), 'allowClear' => TRUE]);
 
+    $getPerms = (array) \Civi\Api4\Permission::get(0)
+      ->addWhere('group', 'IN', ['civicrm', 'cms', 'const'])
+      ->setOrderBy(['group' => 'ASC', 'name' => 'ASC'])
+      ->execute();
     $permissions = [];
-    foreach (CRM_Core_Permission::basicPermissions(TRUE, TRUE) as $id => $vals) {
-      $permissions[] = ['id' => $id, 'text' => $vals[0], 'description' => (array) CRM_Utils_Array::value(1, $vals)];
+    foreach ($getPerms as $perm) {
+      $permissions[] = ['id' => $perm['name'], 'text' => $perm['title'], 'description' => $perm['description'] ?? ''];
     }
     $this->add('select2', 'permission', ts('Permission'), $permissions, FALSE,
       ['placeholder' => ts('Unrestricted'), 'class' => 'huge', 'multiple' => TRUE]

--- a/CRM/Core/Permission/Backdrop.php
+++ b/CRM/Core/Permission/Backdrop.php
@@ -109,7 +109,7 @@ class CRM_Core_Permission_Backdrop extends CRM_Core_Permission_DrupalBase {
     $modules = system_get_info('module');
     foreach ($modules as $moduleName => $module) {
       $prefix = isset($module['name']) ? ($module['name'] . ': ') : '';
-      foreach (module_invoke($moduleName, 'permission') as $permName => $perm) {
+      foreach (module_invoke($moduleName, 'permission') ?? [] as $permName => $perm) {
         if (isset($allCorePerms[$permName])) {
           continue;
         }

--- a/CRM/Core/Permission/Drupal.php
+++ b/CRM/Core/Permission/Drupal.php
@@ -108,7 +108,7 @@ class CRM_Core_Permission_Drupal extends CRM_Core_Permission_DrupalBase {
     $modules = system_get_info('module');
     foreach ($modules as $moduleName => $module) {
       $prefix = isset($module['name']) ? ($module['name'] . ': ') : '';
-      foreach (module_invoke($moduleName, 'permission') as $permName => $perm) {
+      foreach (module_invoke($moduleName, 'permission') ?? [] as $permName => $perm) {
         if (isset($allCorePerms[$permName])) {
           continue;
         }

--- a/CRM/Core/Permission/List.php
+++ b/CRM/Core/Permission/List.php
@@ -86,12 +86,12 @@ class CRM_Core_Permission_List {
     // There are a handful of special permissions defined in CRM/Core/Permission.
     $e->permissions[\CRM_Core_Permission::ALWAYS_DENY_PERMISSION] = [
       'group' => 'const',
-      'title' => ts('Constant: Always deny'),
+      'title' => ts('Generic: Deny all users'),
       'is_synthetic' => TRUE,
     ];
     $e->permissions[\CRM_Core_Permission::ALWAYS_ALLOW_PERMISSION] = [
       'group' => 'const',
-      'title' => ts('Constant: Always allow'),
+      'title' => ts('Generic: Allow all users (including anonymous)'),
       'is_synthetic' => TRUE,
     ];
   }

--- a/CRM/Report/Form/Instance.php
+++ b/CRM/Report/Form/Instance.php
@@ -102,10 +102,17 @@ class CRM_Report_Form_Instance {
       $form->freeze('is_reserved');
     }
 
+    $getPerms = \Civi\Api4\Permission::get(0)
+      ->addWhere('is_active', '=', 1)
+      ->addWhere('group', 'IN', ['civicrm', 'cms', 'const'])
+      ->setOrderBy(['group' => 'ASC', 'name' => 'ASC'])
+      ->execute();
     $form->addElement('select',
       'permission',
       ts('Permission'),
-      ['0' => ts('Everyone (includes anonymous)')] + CRM_Core_Permission::basicPermissions()
+      // FIXME: Historically, CiviReport hard-coded an extra '0' option. This should change to the more general ALWAYS_ALLOW_PERMISSION (but may require testing/migration).
+      ['0' => ts('Everyone (includes anonymous)')] + array_combine($getPerms->column('name'), $getPerms->column('title')),
+      ['class' => 'crm-select2']
     );
 
     // prepare user_roles to save as names not as ids

--- a/CRM/Report/Form/Instance.php
+++ b/CRM/Report/Form/Instance.php
@@ -105,7 +105,7 @@ class CRM_Report_Form_Instance {
     $getPerms = \Civi\Api4\Permission::get(0)
       ->addWhere('is_active', '=', 1)
       ->addWhere('group', 'IN', ['civicrm', 'cms', 'const'])
-      ->setOrderBy(['group' => 'ASC', 'name' => 'ASC'])
+      ->setOrderBy(['title' => 'ASC'])
       ->execute();
     $form->addElement('select',
       'permission',

--- a/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php
+++ b/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php
@@ -219,7 +219,7 @@ class AfformAdminMeta {
     $perms = \Civi\Api4\Permission::get()
       ->addWhere('group', 'IN', ['afformGeneric', 'const', 'civicrm', 'cms'])
       ->addWhere('is_active', '=', 1)
-      ->setOrderBy(['group' => 'ASC', 'name' => 'ASC'])
+      ->setOrderBy(['title' => 'ASC'])
       ->execute();
     foreach ($perms as $perm) {
       $data['permissions'][] = [

--- a/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php
+++ b/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php
@@ -216,11 +216,16 @@ class AfformAdminMeta {
     ];
 
     $data['permissions'] = [];
-    foreach (\CRM_Core_Permission::basicPermissions(TRUE, TRUE) as $name => $perm) {
+    $perms = \Civi\Api4\Permission::get()
+      ->addWhere('group', 'IN', ['afformGeneric', 'const', 'civicrm', 'cms'])
+      ->addWhere('is_active', '=', 1)
+      ->setOrderBy(['group' => 'ASC', 'name' => 'ASC'])
+      ->execute();
+    foreach ($perms as $perm) {
       $data['permissions'][] = [
-        'id' => $name,
-        'text' => $perm[0],
-        'description' => $perm[1] ?? NULL,
+        'id' => $perm['name'],
+        'text' => $perm['title'],
+        'description' => $perm['description'] ?? NULL,
       ];
     }
 


### PR DESCRIPTION
Overview
----------------------------------------

In a handful of configuration screens (for Afform, CiviReport, and the "Navigation Menu"), the administrator may choose from a list of permissions. With this PR, it fetches the list of permissions via APIv4 - yielding a more complete, more filterable, and more alterable list.

(This has been extracted from #19428.)

Before
----------------------------------------

The screens fetch the list via `CRM_Core_Permission::basicPermissions(...)`. The signature of this function is a little funny, and it's missing options (such as `*always allow*` and such as permissions defined in Drupal/WordPress). Here's an example:

<img width="668" alt="Screen Shot 2021-02-04 at 2 17 24 PM" src="https://user-images.githubusercontent.com/1336047/106973674-2c908480-6708-11eb-8ddb-f1c8cf2d34f9.png">

After
----------------------------------------

The screens fetch the list via `Civi\Api4\Permission::get()`, which is more clearly defined and which yields a more complete list.

This reveals additional options, such as `*always allow*` permission:

<img width="391" alt="Screen Shot 2021-02-04 at 4 49 12 PM" src="https://user-images.githubusercontent.com/1336047/106977547-6b760880-670f-11eb-80e8-62ef48eb31a4.png">

For CiviReport, the UI widget switches to `select2`:

<img width="576" alt="Screen Shot 2021-02-04 at 2 16 57 PM" src="https://user-images.githubusercontent.com/1336047/106973669-2a2e2a80-6708-11eb-833c-71aa4a0cb77f.png">


This patch also tweaks `Permission::get()` to (a) use gentler title for `*always allow*` and (b) resolve some warnings on Drupal/Backdrop.