### PR TITLE
APIv4 - Increase alias max length to 256

### DIFF
--- a/Civi/Api4/Query/Api4SelectQuery.php
+++ b/Civi/Api4/Query/Api4SelectQuery.php
@@ -534,7 +534,7 @@ class Api4SelectQuery {
       // Which might contain an alias. Split on the keyword "AS"
       list($entity, $alias) = array_pad(explode(' AS ', $entity), 2, NULL);
       // Ensure alias is a safe string, and supply default if not given
-      $alias = $alias ? \CRM_Utils_String::munge($alias) : strtolower($entity);
+      $alias = $alias ? \CRM_Utils_String::munge($alias, '_', 256) : strtolower($entity);
       // First item in the array is a boolean indicating if the join is required (aka INNER or LEFT).
       // The rest are join conditions.
       $side = array_shift($join) ? 'INNER' : 'LEFT';

--- a/Civi/Api4/Query/SqlExpression.php
+++ b/Civi/Api4/Query/SqlExpression.php
@@ -73,7 +73,7 @@ abstract class SqlExpression {
   public static function convert(string $expression, $parseAlias = FALSE, $mustBe = [], $cantBe = ['SqlWild']) {
     $as = $parseAlias ? strrpos($expression, ' AS ') : FALSE;
     $expr = $as ? substr($expression, 0, $as) : $expression;
-    $alias = $as ? \CRM_Utils_String::munge(substr($expression, $as + 4)) : NULL;
+    $alias = $as ? \CRM_Utils_String::munge(substr($expression, $as + 4), '_', 256) : NULL;
     $bracketPos = strpos($expr, '(');
     $firstChar = substr($expr, 0, 1);
     $lastChar = substr($expr, -1);
@@ -153,7 +153,7 @@ abstract class SqlExpression {
    * @return string
    */
   public function getAlias(): string {
-    return $this->alias ?? $this->fields[0] ?? \CRM_Utils_String::munge($this->expr);
+    return $this->alias ?? $this->fields[0] ?? \CRM_Utils_String::munge($this->expr, '_', 256);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a bug in Search Kit where fields derived from long complex joins would disappear because their alias was longer than the default length of 63 output by `CRM_Utils_String::munge()`.

Before
----------------------------------------
Some fields appear missing in Search Kit results table.

After
----------------------------------------
Fixed.

Comments
----------------------------------------
I'm not sure Search Kit would ever generate an alias longer than 256 characters but we should maybe do some abbreviating in the alias construction to avoid ever running into that problem.