### PR TITLE
[REF] [Repeattransaction] use financial_type_id from getTemplateContribution (which already has handling)

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2484,15 +2484,7 @@ LEFT JOIN  civicrm_contribution contribution ON ( componentPayment.contribution_
     $input['line_item'] = $contributionParams['line_item'] = $templateContribution['line_item'];
     $contributionParams['status_id'] = 'Pending';
 
-    if (isset($contributionParams['financial_type_id']) && count($input['line_item']) === 1) {
-      // We permit the financial type to be overridden for single line items.
-      // More comments on this are in getTemplateTransaction.
-      $contribution->financial_type_id = $contributionParams['financial_type_id'];
-    }
-    else {
-      $contributionParams['financial_type_id'] = $templateContribution['financial_type_id'];
-    }
-    foreach (['contact_id', 'currency', 'source', 'amount_level', 'address_id', 'on_behalf', 'source_contact_id', 'tax_amount', 'contribution_page_id'] as $fieldName) {
+    foreach (['contact_id', 'financial_type_id', 'currency', 'source', 'amount_level', 'address_id', 'on_behalf', 'source_contact_id', 'tax_amount', 'contribution_page_id'] as $fieldName) {
       if (isset($templateContribution[$fieldName])) {
         $contributionParams[$fieldName] = $templateContribution[$fieldName];
       }


### PR DESCRIPTION
Overview
----------------------------------------
[REF] use financial_type_id from getTemplateContribution (which already has handling)

Before
----------------------------------------
Functionality to apply override financial type duplicated in repeattransaction and in getTemplateContribution

After
----------------------------------------
Values from getTemplateContribution is used

Technical Details
----------------------------------------
The removed code is already incorporated into getTemplateContribution
and has test cover in testRepeatTransactionPassedInFinancialType

Comments
----------------------------------------
