### PR TITLE
[REF] [Repeattransaction] Remove loading contribution page id from passed in object

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2508,14 +2508,6 @@ LEFT JOIN  civicrm_contribution contribution ON ( componentPayment.contribution_
     }
     $contributionParams['source'] = $contributionParams['source'] ?? ts('Recurring contribution');
 
-    //CRM-18805 -- Contribution page not recorded on recurring transactions, Recurring contribution payments
-    //do not create CC or BCC emails or profile notifications.
-    //The if is just to be safe. Not sure if we can ever arrive with this unset
-    // but per CRM-19478 it seems it can be 'null'
-    if (isset($contribution->contribution_page_id) && is_numeric($contribution->contribution_page_id)) {
-      $contributionParams['contribution_page_id'] = $contribution->contribution_page_id;
-    }
-
     $createContribution = civicrm_api3('Contribution', 'create', $contributionParams);
     $contribution->id = $createContribution['id'];
     $contribution->copyCustomFields($templateContribution['id'], $contribution->id);


### PR DESCRIPTION

Overview
----------------------------------------
[REF] [Repeattransaction] Remove loading contribution page id from passed in object

Before
----------------------------------------
Extraneous code

After
----------------------------------------
poof

Technical Details
----------------------------------------
I believe this became obsolete with this PR
https://github.com/civicrm/civicrm-core/commit/6c3e774c322267c8e4449006db9cc14202b7028f

The other 2 (paypal) IPN classes no longer set contribution_page_id deliberately so
would be relying on the same data used for getTemplateContribution


Comments
----------------------------------------
