### PR TITLE
afform_mock - Hide extension. Clearly indicate as development-only

### DIFF
--- a/ext/afform/mock/info.xml
+++ b/ext/afform/mock/info.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 <extension key="org.civicrm.afform-mock" type="module">
   <file>afform_mock</file>
-  <name>Afform: Mocks</name>
-  <description>Mock extension used for testing the framework</description>
+  <name>Afform: Mock Form Collection</name>
+  <description>(DEVELOPMENT ONLY) List of example forms used for automated testing</description>
   <license>AGPL-3.0</license>
   <maintainer>
     <author>Tim Otten</author>
@@ -16,6 +16,9 @@
   </urls>
   <releaseDate>2020-01-09</releaseDate>
   <version>0.5</version>
+  <tags>
+    <tag>mgmt:hidden</tag>
+  </tags>
   <develStage>alpha</develStage>
   <compatibility>
     <ver>5.23</ver>


### PR DESCRIPTION
Overview
----------------------------------------

The `afform_mock` extension includes a set of example forms and test-cases. As the examples will eventually demonstrate variations in the security policy, it won't be appropriate to run on production systems. Therefore, we should hide it.

Before
----------------------------------------

`afform_mock` can be enabled via GUI or CLI.

After
----------------------------------------

`afform_mock` can be enabled via CLI, but it is hidden from GUI.

