### PR TITLE
[REF] Fix array access on NULL error when running afform unit tests o…

### DIFF
--- a/ext/afform/core/Civi/Api4/Utils/AfformSaveTrait.php
+++ b/ext/afform/core/Civi/Api4/Utils/AfformSaveTrait.php
@@ -69,7 +69,7 @@ trait AfformSaveTrait {
       // FIXME: more targetted reconciliation
       \CRM_Core_ManagedEntities::singleton()->reconcile();
     }
-    elseif ($orig['is_dashlet'] && $isChanged('title')) {
+    elseif (array_key_exists('is_dashlet', (array) $orig) && $orig['is_dashlet'] && $isChanged('title')) {
       // FIXME: more targetted reconciliation
       \CRM_Core_ManagedEntities::singleton()->reconcile();
     }


### PR DESCRIPTION
…n PHP 7.4

Overview
----------------------------------------
Fixes the following test fails on PHP7.4

* api_v4_AfformUsageTest::testAboutMeAllowed
* api_v4_AfformUsageTest::testAboutMeForbidden

Error is Trying to access array offset on value of type null

Before
----------------------------------------
Tests fail

After
----------------------------------------
Tests pass

ping @totten @eileenmcnaughton @colemanw 