### PR TITLE
dev/core#2365 - Delayed drawing of contribution charts seems unnecessary

### DIFF
--- a/templates/CRM/common/chart.tpl
+++ b/templates/CRM/common/chart.tpl
@@ -138,14 +138,11 @@ function createChart( chartID, divName, xSize, ySize, data ) {
       .turnOnControls(true)
       .renderTitle(true);
   }
-  // Delay rendering so that animation looks good.
-  window.setTimeout(() => {
-    div.appendChild(heading);
-    div.appendChild(chartNode);
-    div.appendChild(links);
+  div.appendChild(heading);
+  div.appendChild(chartNode);
+  div.appendChild(links);
 
-    dc.renderAll();
-  }, 1500);
+  dc.renderAll();
 }
 </script>
 {/literal}


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/2365

Maybe there's a reason, in which case I'm happy to close this, but it seems unnecessary.

Steps to reproduce.
1. Visit contribution dashboard.


Before
----------------------------------------
* Purposely delayed 1.5 seconds before chart appears.
* I'll often start to click on something in the table and then the row moves and I end up clicking on something else.

After
----------------------------------------
It just draws.

Technical Details
----------------------------------------


Comments
----------------------------------------

