### PR TITLE
php 7.4 - E_NOTICE on membership dashboard

### DIFF
--- a/CRM/Member/Selector/Search.php
+++ b/CRM/Member/Selector/Search.php
@@ -188,7 +188,7 @@ class CRM_Member_Selector_Search extends CRM_Core_Selector_Base implements CRM_C
       $extraParams .= "&key={$qfKey}";
     }
 
-    if (!self::$_links['view']) {
+    if (empty(self::$_links['view'])) {
       self::$_links['view'] = [
         CRM_Core_Action::VIEW => [
           'name' => ts('View'),


### PR DESCRIPTION
Overview
----------------------------------------
1. Visit membership dashboard
2. E_NOTICE: `Trying to access array offset on value of type null`

Before
----------------------------------------
notice

After
----------------------------------------
no notice

Technical Details
----------------------------------------
php 7.4 seems a bit stricter about `self::` arrays when you access a nonexistent member.

In php 7.3 trying to access `self::$foo['bar']` when `bar` doesn't exist doesn't seem to give a notice.

Comments
----------------------------------------

