### PR TITLE
APIv4 - Fix label_field to use underscore instead of camelCase

### DIFF
--- a/Civi/Api4/Entity.php
+++ b/Civi/Api4/Entity.php
@@ -85,7 +85,7 @@ class Entity extends Generic\AbstractEntity {
           'description' => 'Class name for dao-based entities',
         ],
         [
-          'name' => 'labelField',
+          'name' => 'label_field',
           'description' => 'Field to show when displaying a record',
         ],
         [

--- a/Civi/Api4/Generic/AbstractEntity.php
+++ b/Civi/Api4/Generic/AbstractEntity.php
@@ -143,7 +143,7 @@ abstract class AbstractEntity {
     if ($dao) {
       $info['paths'] = $dao::getEntityPaths();
       $info['icon'] = $dao::$_icon;
-      $info['labelField'] = $dao::$_labelField;
+      $info['label_field'] = $dao::$_labelField;
       $info['dao'] = $dao;
     }
     foreach (ReflectionUtils::getTraits(static::class) as $trait) {


### PR DESCRIPTION
Overview
----------------------------------------
This is a followup to #19504, which incorrectly used camelCase in API output, which by convention uses lower_case_with_underscores.

Before
----------------------------------------
APIv4 `Entity.get` output contains a key named `labelField`

After
----------------------------------------
APIv4 `Entity.get` output contains a key named `label_field`

Comments
----------------------------------------
This PR is against 5.35 because it was introduced in that version.
