### PR TITLE
 Convert token processing to use token processor 

### DIFF
--- a/tests/phpunit/CRM/Core/BAO/MessageTemplateTest.php
+++ b/tests/phpunit/CRM/Core/BAO/MessageTemplateTest.php
@@ -117,7 +117,6 @@ London, 90210
   /**
    * Test rendering of smarty tokens.
    *
-   * @throws \CRM_Core_Exception
    */
   public function testRenderMessageTemplateIgnoreSmarty(): void {
     $messageContent = CRM_Core_BAO_MessageTemplate::renderMessageTemplate([
@@ -187,7 +186,7 @@ Default Domain Name
     foreach (array_keys($tokenData) as $key) {
       $tokenString .= "{$key}:{contact.{$key}}\n";
     }
-    $tokenProcessor = new TokenProcessor(\Civi::dispatcher(), []);
+    $tokenProcessor = new TokenProcessor(Civi::dispatcher(), []);
     $tokenProcessor->addMessage('html', $tokenString, 'text/html');
     $tokenProcessor->addRow(['contactId' => $tokenData['contact_id']]);
     $tokenProcessor->evaluate();
@@ -398,7 +397,7 @@ sort_name:Smith, Robert
 display_name:Mr. Robert Smith II
 nick_name:Bob
 image_URL:https://example.com
-preferred_communication_method:
+preferred_communication_method:Phone
 preferred_language:fr_CA
 preferred_mail_format:Both
 hash:xyz


### PR DESCRIPTION
Overview
----------------------------------------
Convert token processing to use token processor 


This is intended to be a no-change patch to simply use newer/ more preferred coding conventions - however, it does throw up a small handful is discrepancies between them that need to be considered.

Before
----------------------------------------
Use of functions like
```
CRM_Utils_Token::replaceDomainTokens
```


After
----------------------------------------
Use of [token processor](https://docs.civicrm.org/dev/en/latest/framework/token/#token-processor) - this in turn calls the tokenCompat subscriber which has functionality to replace the domain & contact tokens & do the smary parsing.

However, it does turn out that there are some minor differences between the 2 approaches & we need to agree what to do about them. The 'expected' on the left is with the existing code & on the right with this change.

![image](https://user-images.githubusercontent.com/336308/107108804-adce4f80-689f-11eb-9903-0f49e68505e6.png)

![image](https://user-images.githubusercontent.com/336308/107108833-f2f28180-689f-11eb-8f54-c74f65c90181.png)

![image](https://user-images.githubusercontent.com/336308/107108848-1ddcd580-68a0-11eb-832f-dd877cf40e20.png)



Technical Details
----------------------------------------
The test is in this PR (currently) but is also in a separate PR #19551 - which I recommend merging asap - at which point I'll rebase out of this

I think it would be OK to stop supporting or to deprectate some of these tokens as I believe they were added more or less accidentally - we would need to do some messaging. The contact reference custom field is probably the biggest deal IMHO

Comments
----------------------------------------
