### PR TITLE
php 7.4 E_NOTICE in Contact/BAO/Query

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -1112,8 +1112,10 @@ class CRM_Contact_BAO_Query {
         }
 
         $field = $this->_fields[$elementName] ?? NULL;
-        if (isset($this->_pseudoConstantsSelect[$field['name']])) {
-          $this->_pseudoConstantsSelect[$name . '-' . $field['name']] = $this->_pseudoConstantsSelect[$field['name']];
+        if (!empty($field)) {
+          if (isset($this->_pseudoConstantsSelect[$field['name']])) {
+            $this->_pseudoConstantsSelect[$name . '-' . $field['name']] = $this->_pseudoConstantsSelect[$field['name']];
+          }
         }
 
         // hack for profile, add location id


### PR DESCRIPTION
Overview
----------------------------------------
There might be other ways to reproduce this but one way is on a contact record hover over the little man icon. At line 1115 $field can be null.

Before
----------------------------------------
`E_NOTICE: Trying to access array offset on value of type null`

After
----------------------------------------


Technical Details
----------------------------------------
In php 7.3 this is silent. In php 7.4 it's not.

Comments
----------------------------------------

