### PR TITLE
dev/core#2308 - Fix Activity Import Parser test and convert to civi statics

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -38,13 +38,6 @@ class CRM_Activity_BAO_Activity extends CRM_Activity_DAO_Activity {
   public static $_exportableFields = NULL;
 
   /**
-   * Static field for all the activity information that we can potentially import.
-   *
-   * @var array
-   */
-  public static $_importableFields = NULL;
-
-  /**
    * Check if there is absolute minimum of data to add the object.
    *
    * @param array $params
@@ -1505,10 +1498,8 @@ class CRM_Activity_BAO_Activity extends CRM_Activity_DAO_Activity {
    *   array of importable Fields
    */
   public static function &importableFields($status = FALSE) {
-    if (!self::$_importableFields) {
-      if (!self::$_importableFields) {
-        self::$_importableFields = [];
-      }
+    if (empty(Civi::$statics[__CLASS__][__FUNCTION__])) {
+      Civi::$statics[__CLASS__][__FUNCTION__] = [];
       if (!$status) {
         $fields = ['' => ['title' => ts('- do not import -')]];
       }
@@ -1544,9 +1535,9 @@ class CRM_Activity_BAO_Activity extends CRM_Activity_DAO_Activity {
       $fields = array_merge($fields, $tmpConatctField);
       $fields = array_merge($fields, $tmpFields);
       $fields = array_merge($fields, CRM_Core_BAO_CustomField::getFieldsForImport('Activity'));
-      self::$_importableFields = $fields;
+      Civi::$statics[__CLASS__][__FUNCTION__] = $fields;
     }
-    return self::$_importableFields;
+    return Civi::$statics[__CLASS__][__FUNCTION__];
   }
 
   /**

--- a/tests/phpunit/CRM/Activity/Import/Parser/ActivityTest.php
+++ b/tests/phpunit/CRM/Activity/Import/Parser/ActivityTest.php
@@ -1,12 +1,6 @@
 <?php
 
 /**
- *  File for the TestActivityType class
- *
- *  (PHP 5)
- *
- * @package   CiviCRM
- *
  *   This file is part of CiviCRM
  *
  *   CiviCRM is free software; you can redistribute it and/or
@@ -25,7 +19,7 @@
  */
 
 /**
- *  Test CRM/Member/BAO Membership Log add , delete functions
+ *  Test Activity Import Parser functions
  *
  * @package   CiviCRM
  * @group headless
@@ -47,7 +41,7 @@ class CRM_Activity_Import_Parser_ActivityTest extends CiviUnitTestCase {
    * @throws \CRM_Core_Exception
    */
   public function tearDown():void {
-    $this->quickCleanup(['civicrm_contact', 'civicrm_activity'], TRUE);
+    $this->quickCleanup(['civicrm_contact', 'civicrm_activity', 'civicrm_activity_contact'], TRUE);
     parent::tearDown();
   }
 
@@ -64,11 +58,11 @@ class CRM_Activity_Import_Parser_ActivityTest extends CiviUnitTestCase {
   public function testImport(): void {
     $this->createCustomGroupWithFieldOfType(['extends' => 'Activity'], 'checkbox');
     $values = [
-      'activity_detail' => 'fascinating',
+      'activity_details' => 'fascinating',
       'activity_type_id' => 1,
       'activity_date_time' => '2010-01-06',
       'target_contact_id' => $this->individualCreate(),
-      'subject' => 'riveting stuff',
+      'activity_subject' => 'riveting stuff',
       $this->getCustomFieldName('checkbox') => 'L',
     ];
     $this->importValues($values);
@@ -83,6 +77,10 @@ class CRM_Activity_Import_Parser_ActivityTest extends CiviUnitTestCase {
    * @return \CRM_Activity_Import_Parser_Activity
    */
   protected function createImportObject(array $fields): \CRM_Activity_Import_Parser_Activity {
+    // @todo Eyes are weary so sanity-check this later:
+    // This loop seems the same as array_values($fields)? And this appears
+    // to only be called from one place that already has them sequentially
+    // indexed so is it even needed?
     $fieldMapper = [];
     foreach ($fields as $index => $field) {
       $fieldMapper[] = $field;


### PR DESCRIPTION
Overview
----------------------------------------
Came up while reviewing https://github.com/civicrm/civicrm-core/pull/19421. The test has a few typos and the importableFields static in CRM_Activity_BAO_Activity can cause problems with tests when run in a loop.

Before
----------------------------------------
Details and subject field were not being imported/validated correctly.

After
----------------------------------------
More correcter.

Technical Details
----------------------------------------
Statics. Tests.

Comments
----------------------------------------
$_importableFields is public but I didn't see anywhere else where it was referenced.
