### PR TITLE
[REF] Rename variable to clarify it's usage

### DIFF
--- a/CRM/Event/Form/Registration.php
+++ b/CRM/Event/Form/Registration.php
@@ -592,12 +592,12 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
    *
    * @param CRM_Core_Form $form
    * @param int $eventID
-   * @param bool $includeExpiredFields
+   * @param bool $doNotIncludeExpiredFields
    *   See CRM-16456.
    *
    * @throws Exception
    */
-  public static function initEventFee(&$form, $eventID, $includeExpiredFields = TRUE) {
+  public static function initEventFee(&$form, $eventID, $doNotIncludeExpiredFields = TRUE) {
     // get price info
 
     // retrive all active price set fields.
@@ -608,12 +608,11 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
 
     if ($discountId) {
       $priceSetId = CRM_Core_DAO::getFieldValue('CRM_Core_BAO_Discount', $discountId, 'price_set_id');
-      CRM_Price_BAO_PriceSet::initSet($form, 'civicrm_event', $includeExpiredFields, $priceSetId);
     }
     else {
       $priceSetId = CRM_Price_BAO_PriceSet::getFor('civicrm_event', $eventID);
-      CRM_Price_BAO_PriceSet::initSet($form, 'civicrm_event', $includeExpiredFields, $priceSetId);
     }
+    CRM_Price_BAO_PriceSet::initSet($form, 'civicrm_event', $doNotIncludeExpiredFields, $priceSetId);
 
     if (property_exists($form, '_context') && ($form->_context == 'standalone'
         || $form->_context == 'participant')

--- a/CRM/Price/BAO/PriceSet.php
+++ b/CRM/Price/BAO/PriceSet.php
@@ -413,13 +413,13 @@ WHERE     cpf.price_set_id = %1";
    *   Price Set ID.
    * @param bool $required
    *   Appears to have no effect based on reading the code.
-   * @param bool $validOnly
+   * @param bool $doNotIncludeExpiredFields
    *   Should only fields where today's date falls within the valid range be returned?
    *
    * @return array
    *   Array consisting of field details
    */
-  public static function getSetDetail($setID, $required = TRUE, $validOnly = FALSE) {
+  public static function getSetDetail($setID, $required = TRUE, $doNotIncludeExpiredFields = FALSE) {
     // create a new tree
     $setTree = [];
 
@@ -459,7 +459,7 @@ AND is_active = 1
 AND ( active_on IS NULL OR active_on <= {$currentTime} )
 ";
     $dateSelect = '';
-    if ($validOnly) {
+    if ($doNotIncludeExpiredFields) {
       $dateSelect = "
 AND ( expire_on IS NULL OR expire_on >= {$currentTime} )
 ";
@@ -554,11 +554,11 @@ WHERE  id = %1";
    * @param CRM_Core_Form $form
    *   Form entity id.
    * @param string $entityTable
-   * @param bool $validOnly
+   * @param bool $doNotIncludeExpiredFields
    * @param int $priceSetId
    *   Price Set ID
    */
-  public static function initSet(&$form, $entityTable = 'civicrm_event', $validOnly = FALSE, $priceSetId = NULL) {
+  public static function initSet(&$form, $entityTable = 'civicrm_event', $doNotIncludeExpiredFields = FALSE, $priceSetId = NULL) {
 
     //check if price set is is_config
     if (is_numeric($priceSetId)) {
@@ -599,7 +599,7 @@ WHERE  id = %1";
       }
 
       $form->_priceSetId = $priceSetId;
-      $priceSet = self::getSetDetail($priceSetId, $required, $validOnly);
+      $priceSet = self::getSetDetail($priceSetId, $required, $doNotIncludeExpiredFields);
       $form->_priceSet = $priceSet[$priceSetId] ?? NULL;
       $form->_values['fee'] = $form->_priceSet['fields'] ?? NULL;
 


### PR DESCRIPTION
Overview
----------------------------------------
Found while looking into building pricesets for contributionpages (see #19475).

This variable is misleading because the code works correctly but does the opposite of what the variable makes you think!

Before
----------------------------------------
Misleading variable name.

After
----------------------------------------
Clear, consistent variable name.

Technical Details
----------------------------------------

Comments
----------------------------------------
