### PR TITLE
WIP Add in Proximity Search functionality into APIv4

### DIFF
--- a/Civi/Api4/Query/Api4SelectQuery.php
+++ b/Civi/Api4/Query/Api4SelectQuery.php
@@ -447,7 +447,18 @@ class Api4SelectQuery {
           break;
       }
     }
-
+    if ($operator === 'PROXIMITY') {
+      $fieldParts = explode('.', $fieldAlias);
+      [$latitude, $longditude, $distance, $unit] = $value;
+      $unit = $unit ?? 'km';
+      if ($unit === 'mile') {
+        $conversionFactor = 1609.344;
+      }
+      else {
+        $conversionFactor = 1000;
+      }
+      return \CRM_Core_BAO_ProximityQuery::where($latitude, $longditude, $distance * $conversionFactor, $fieldParts[0]);
+    }
     $sql_clause = \CRM_Core_DAO::createSQLFilter($fieldAlias, [$operator => $value]);
     if ($sql_clause === NULL) {
       throw new \API_Exception("Invalid value in $type clause for '$expr'");

--- a/Civi/Api4/Utils/CoreUtil.php
+++ b/Civi/Api4/Utils/CoreUtil.php
@@ -77,6 +77,7 @@ class CoreUtil {
   public static function getOperators() {
     $operators = \CRM_Core_DAO::acceptedSQLOperators();
     $operators[] = 'CONTAINS';
+    $operators[] = 'PROXIMITY';
     return $operators;
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Add in Proximity search filter to APIv4 for use in Search Kit

Before
----------------------------------------
No Proximity Search filter in APIv4

After
----------------------------------------
Proximity Search

@colemanw @totten @eileenmcnaughton @JoeMurray This is work in progress at the moment but figured its worthwhile sharing to see where I am going, We have a fairly generic function but that needs to have at least 4 params passed through the lat and long, the distance of the radius and the unit of measurement (KM or Miles) I'm not sure if I'm going about this quite the right way but would appreciate some feedback. Also I'm thinking we may need to lock this down to certain fields perhaps but not 100% sure how that happens