### PR TITLE
dev/core#2137 - Enhance log message to include the actual error

### DIFF
--- a/Civi/Core/AssetBuilder.php
+++ b/Civi/Core/AssetBuilder.php
@@ -195,7 +195,7 @@ class AssetBuilder {
       }
       catch (UnknownAssetException $e) {
         // unexpected error, log and continue
-        Civi::log()->error('Unexpected error while rendering a file in the AssetBuilder');
+        Civi::log()->error('Unexpected error while rendering a file in the AssetBuilder: ' . $e->getMessage(), ['exception' => $e]);
       }
     }
     return $fileName;


### PR DESCRIPTION
Overview
----------------------------------------
Some logging was added in https://github.com/civicrm/civicrm-core/pull/18830 but it doesn't include the lower-level error message.

Before
----------------------------------------
`Unexpected error while rendering a file in the AssetBuilder`

After
----------------------------------------
`Unexpected error while rendering a file in the AssetBuilder: Something something something` followed by stack trace.

Technical Details
----------------------------------------
Also take advantage of PSR3 special context variable 'exception': https://www.php-fig.org/psr/psr-3/#13-context

Comments
----------------------------------------

