### PR TITLE
Fix 'Unsupported html-element' error on forms using EntityFormTrait

### DIFF
--- a/CRM/Core/Form/EntityFormTrait.php
+++ b/CRM/Core/Form/EntityFormTrait.php
@@ -256,7 +256,7 @@ trait CRM_Core_Form_EntityFormTrait {
         if ($spec['localizable']) {
           $this->entityFields[$fieldName]['is_add_translate_dialog'] = TRUE;
         }
-        if (empty($spec['html'])) {
+        if (empty($spec['html']['type'])) {
           $this->entityFields[$fieldName]['not-auto-addable'] = TRUE;
         }
       }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes crash when loading some forms.

Before
----------------------------------------
Website crashes when e.g editing a payment processor.

After
----------------------------------------
No more crash.

Technical Details
----------------------------------------
The `EntityFormTrait` was trying to auto-add fields with any `html` information, but was crashing if that information did not include `type`.