### PR TITLE
Expose mapping search task to Search Kit

### DIFF
--- a/CRM/Contact/Form/Task.php
+++ b/CRM/Contact/Form/Task.php
@@ -86,7 +86,7 @@ class CRM_Contact_Form_Task extends CRM_Core_Form_Task {
     $form->_contactIds = [];
     $form->_contactTypes = [];
 
-    $isStandAlone = in_array('task', $form->urlPath) || in_array('standalone', $form->urlPath);
+    $isStandAlone = in_array('task', $form->urlPath) || in_array('standalone', $form->urlPath) || in_array('map', $form->urlPath);
     if ($isStandAlone) {
       [$form->_task, $title] = CRM_Contact_Task::getTaskAndTitleByClass(get_class($form));
       if (!array_key_exists($form->_task, CRM_Contact_Task::permissionedTaskTitles(CRM_Core_Permission::getPermission()))) {

--- a/CRM/Contact/Task.php
+++ b/CRM/Contact/Task.php
@@ -228,6 +228,8 @@ class CRM_Contact_Task extends CRM_Core_Task {
           'title' => ts('Map contacts'),
           'class' => 'CRM_Contact_Form_Task_Map',
           'result' => FALSE,
+          'url' => 'civicrm/contact/map',
+          'icon' => 'fa-map',
         );
       }
 

--- a/templates/CRM/Contact/Form/Task/Map/OpenStreetMaps.tpl
+++ b/templates/CRM/Contact/Form/Task/Map/OpenStreetMaps.tpl
@@ -153,11 +153,12 @@
         popup.create(evt);
     }
 
-    if (window.addEventListener) {
-        window.addEventListener("load", initMap, false);
-    } else if (window.attachEvent) {
-        document.attachEvent("onreadystatechange", initMap);
-    }
+    var checkExist = setInterval(function() {
+      if (typeof OpenLayers !== 'undefined') {
+        clearInterval(checkExist);
+        initMap();
+      }
+    }, 100); // check every 100ms
 
     function gpopUp() {
         var from   = document.getElementById('from').value;


### PR DESCRIPTION
Overview
----------------------------------------
Expose Contact Mapping task to Search Kit

Before
----------------------------------------
No Mapping task

After
----------------------------------------
Mapping task option

Technical Details
----------------------------------------
This is also a work in progress but it at least gets it show in the list of search tasks, the issue I am currently running into is that at least with Open Street Maps is that when the popup opens this code https://github.com/civicrm/civicrm-core/blob/master/templates/CRM/Contact/Form/Task/Map/OpenStreetMaps.tpl#L156 doesn't seem to fire correctly so initmap doesn't get run not sure what the correct change should be

ping @colemanw @eileenmcnaughton @JoeMurray 