### PR TITLE
APIv4 - Improve handling of joins & custom fields

### DIFF
--- a/CRM/Core/SelectValues.php
+++ b/CRM/Core/SelectValues.php
@@ -204,8 +204,7 @@ class CRM_Core_SelectValues {
       'Address' => ts('Addresses'),
       'Campaign' => ts('Campaigns'),
     ];
-    $contactTypes = self::contactType();
-    $contactTypes = !empty($contactTypes) ? ['Contact' => 'Contacts'] + $contactTypes : [];
+    $contactTypes = ['Contact' => ts('Contacts')] + self::contactType();
     $extendObjs = CRM_Core_OptionGroup::values('cg_extend_objects');
     $customGroupExtends = array_merge($contactTypes, $customGroupExtends, $extendObjs);
     return $customGroupExtends;

--- a/Civi/Api4/Query/Api4SelectQuery.php
+++ b/Civi/Api4/Query/Api4SelectQuery.php
@@ -211,10 +211,12 @@ class Api4SelectQuery {
         return strpos($item, '*') !== FALSE && strpos($item, '.') !== FALSE && strpos($item, '(') === FALSE && strpos($item, ' ') === FALSE;
       });
 
-      foreach ($wildFields as $item) {
-        $pos = array_search($item, array_values($select));
-        $this->autoJoinFK($item);
-        $matches = SelectUtil::getMatchingFields($item, array_keys($this->apiFieldSpec));
+      foreach ($wildFields as $wildField) {
+        $pos = array_search($wildField, array_values($select));
+        // If the joined_entity.id isn't in the fieldspec already, autoJoinFK will attempt to add the entity.
+        $idField = substr($wildField, 0, strrpos($wildField, '.')) . '.id';
+        $this->autoJoinFK($idField);
+        $matches = SelectUtil::getMatchingFields($wildField, array_keys($this->apiFieldSpec));
         array_splice($select, $pos, 1, $matches);
       }
       $select = array_unique($select);

--- a/Civi/Api4/Service/Spec/SpecGatherer.php
+++ b/Civi/Api4/Service/Spec/SpecGatherer.php
@@ -48,7 +48,7 @@ class SpecGatherer {
     // Real entities
     if (strpos($entity, 'Custom_') !== 0) {
       $this->addDAOFields($entity, $action, $specification, $values);
-      if ($includeCustom && array_key_exists($entity, \CRM_Core_SelectValues::customGroupExtends())) {
+      if ($includeCustom) {
         $this->addCustomFields($entity, $specification, $values);
       }
     }
@@ -118,14 +118,16 @@ class SpecGatherer {
    * @throws \API_Exception
    */
   private function addCustomFields($entity, RequestSpec $specification, $values = []) {
-    // Custom_group.extends pretty much maps 1-1 with entity names, except for a couple oddballs (Contact, Participant).
-    $extends = [$entity];
-    if ($entity === 'Contact') {
-      $contactType = !empty($values['contact_type']) ? [$values['contact_type']] : \CRM_Contact_BAO_ContactType::basicTypes();
-      $extends = array_merge(['Contact'], $contactType);
+    $customInfo = \Civi\Api4\Utils\CoreUtil::getCustomGroupExtends($entity);
+    if (!$customInfo) {
+      return;
     }
-    if ($entity === 'Participant') {
-      $extends = ['Participant', 'ParticipantRole', 'ParticipantEventName', 'ParticipantEventType'];
+    // If a contact_type was passed in, exclude custom groups for other contact types
+    if ($entity === 'Contact' && !empty($values['contact_type'])) {
+      $extends = ['Contact', $values['contact_type']];
+    }
+    else {
+      $extends = $customInfo['extends'];
     }
     $customFields = CustomField::get(FALSE)
       ->addWhere('custom_group.extends', 'IN', $extends)

--- a/Civi/Api4/Utils/CoreUtil.php
+++ b/Civi/Api4/Utils/CoreUtil.php
@@ -80,4 +80,42 @@ class CoreUtil {
     return $operators;
   }
 
+  /**
+   * For a given API Entity, return the types of custom fields it supports and the column they join to.
+   *
+   * @param string $entityName
+   * @return array|mixed|null
+   * @throws \API_Exception
+   * @throws \Civi\API\Exception\UnauthorizedException
+   */
+  public static function getCustomGroupExtends(string $entityName) {
+    // Custom_group.extends pretty much maps 1-1 with entity names, except for a couple oddballs (Contact, Participant).
+    switch ($entityName) {
+      case 'Contact':
+        return [
+          'extends' => array_merge(['Contact'], array_keys(\CRM_Core_SelectValues::contactType())),
+          'column' => 'id',
+        ];
+
+      case 'Participant':
+        return [
+          'extends' => ['Participant', 'ParticipantRole', 'ParticipantEventName', 'ParticipantEventType'],
+          'column' => 'id',
+        ];
+
+      case 'RelationshipCache':
+        return [
+          'extends' => ['Relationship'],
+          'column' => 'relationship_id',
+        ];
+    }
+    if (array_key_exists($entityName, \CRM_Core_SelectValues::customGroupExtends())) {
+      return [
+        'extends' => [$entityName],
+        'column' => 'id',
+      ];
+    }
+    return NULL;
+  }
+
 }

--- a/ext/search/ang/crmSearchAdmin/compose/criteria.html
+++ b/ext/search/ang/crmSearchAdmin/compose/criteria.html
@@ -6,7 +6,7 @@
           <label for="crm-search-join-{{ $index }}">{{:: ts('With') }}</label>
           <input id="crm-search-join-{{ $index }}" class="form-control huge" ng-model="join[0]" crm-ui-select="{placeholder: ' ', data: getJoinEntities}" disabled >
           <select class="form-control" ng-model="join[1]" ng-options="o.k as o.v for o in ::joinTypes" ></select>
-          <button class="btn btn-xs btn-danger-outline" ng-click="$ctrl.clearParam('join', $index)" title="{{:: ts('Remove join') }}">
+          <button class="btn btn-xs btn-danger-outline" ng-click="$ctrl.removeJoin($index)" title="{{:: ts('Remove join') }}">
             <i class="crm-i fa-trash" aria-hidden="true"></i>
           </button>
         </div>

--- a/ext/search/ang/crmSearchAdmin/crmSearchAdmin.component.js
+++ b/ext/search/ang/crmSearchAdmin/crmSearchAdmin.component.js
@@ -510,17 +510,11 @@
             ctrl.stale = true;
           }
         }
-        if (ctrl.load) {
-          ctrl.saved = false;
-        }
       }
 
       function onChangeFilters() {
         ctrl.stale = true;
         ctrl.selectedRows.length = 0;
-        if (ctrl.load) {
-          ctrl.saved = false;
-        }
         if (ctrl.autoSearch) {
           ctrl.refreshAll();
         }

--- a/ext/search/ang/crmSearchAdmin/crmSearchAdmin.component.js
+++ b/ext/search/ang/crmSearchAdmin/crmSearchAdmin.component.js
@@ -259,6 +259,23 @@
         });
       };
 
+      // Remove an explicit join + all SELECT, WHERE & other JOINs that use it
+      this.removeJoin = function(index) {
+        var alias = searchMeta.getJoin(ctrl.savedSearch.api_params.join[index][0]).alias;
+        ctrl.clearParam('join', index);
+        _.remove(ctrl.savedSearch.api_params.select, function(item) {
+          return item.indexOf(alias + '.') === 0;
+        });
+        _.remove(ctrl.savedSearch.api_params.where, function(clause) {
+          return clauseUsesJoin(clause, alias);
+        });
+        _.eachRight(ctrl.savedSearch.api_params.join, function(item, i) {
+          if (searchMeta.getJoin(item[0]).alias.indexOf(alias) === 0) {
+            ctrl.removeJoin(i);
+          }
+        });
+      };
+
       $scope.changeGroupBy = function(idx) {
         if (!ctrl.savedSearch.api_params.groupBy[idx]) {
           ctrl.clearParam('groupBy', idx);
@@ -275,6 +292,35 @@
           });
         }
       };
+
+      function clauseUsesJoin(clause, alias) {
+        if (clause[0].indexOf(alias + '.') === 0) {
+          return true;
+        }
+        if (_.isArray(clause[1])) {
+          return clause[1].some(function(subClause) {
+            return clauseUsesJoin(subClause, alias);
+          });
+        }
+        return false;
+      }
+
+      // Returns true if a clause contains one of the
+      function clauseUsesFields(clause, fields) {
+        console.log('clauseUsesFields', fields);
+        if (!fields || !fields.length) {
+          return false;
+        }
+        if (_.includes(fields, clause[0])) {
+          return true;
+        }
+        if (_.isArray(clause[1])) {
+          return clause[1].some(function(subClause) {
+            return clauseUsesField(subClause, fields);
+          });
+        }
+        return false;
+      }
 
       function validate() {
         var errors = [],
@@ -502,6 +548,12 @@
         _.each(_.difference(_.keys(ctrl.savedSearch.api_params.orderBy), newSelect), function(col) {
           delete ctrl.savedSearch.api_params.orderBy[col];
         });
+        // After removing a field from SELECT, also remove it from HAVING
+        if (oldSelect && oldSelect.length && ctrl.savedSearch.api_params.having && ctrl.savedSearch.api_params.having.length) {
+          _.remove(ctrl.savedSearch.api_params.having, function(clause) {
+            return clauseUsesFields(clause, _.difference(oldSelect, newSelect));
+          });
+        }
         // Re-arranging or removing columns doesn't merit a refresh, only adding columns does
         if (!oldSelect || _.difference(newSelect, oldSelect).length) {
           if (ctrl.autoSearch) {

--- a/tests/phpunit/api/v4/Action/FkJoinTest.php
+++ b/tests/phpunit/api/v4/Action/FkJoinTest.php
@@ -99,6 +99,16 @@ class FkJoinTest extends UnitTestCase {
     $this->assertEquals('1', $contacts[0]['phone.location_type_id']);
   }
 
+  public function testImplicitJoinOnExplicitJoin() {
+    $contacts = Contact::get(FALSE)
+      ->addWhere('id', '=', $this->getReference('test_contact_1')['id'])
+      ->addJoin('Address AS address', TRUE, ['id', '=', 'address.contact_id'], ['address.location_type_id', '=', 1])
+      ->addSelect('id', 'address.country.iso_code')
+      ->execute();
+    $this->assertCount(1, $contacts);
+    $this->assertEquals('US', $contacts[0]['address.country.iso_code']);
+  }
+
   public function testJoinToTheSameTableTwice() {
     $cid1 = Contact::create(FALSE)
       ->addValue('first_name', 'Aaa')

--- a/tests/phpunit/api/v4/DataSets/DefaultDataSet.json
+++ b/tests/phpunit/api/v4/DataSets/DefaultDataSet.json
@@ -41,5 +41,14 @@
       "phone": "+3538733439483",
       "location_type_id": "2"
     }
+  ],
+  "Address": [
+    {
+      "contact_id": "@ref test_contact_1.id",
+      "street_address": "123 Sesame St.",
+      "country_id": "1228",
+      "location_type_id": "1",
+      "@ref": "test_address_1"
+    }
   ]
 }


### PR DESCRIPTION
Overview
----------------------------------------
This fixes some apparent bugs in SearchKit where certain fields were apparently supported in the UI but the API would crash when trying to query them.

It also improves related contact searches by allowing the query to include relationship custom fields.

It also improves the SearchKit UI to clean up other related params when deleting a join.

Before
----------------------------------------
SearchKit crashes when e.g. building a search for Contacts with Contributions, and selecting the Contribution Campaign Title as a column.

Relationship custom fields not available.

Invalid params persist in UI after deleting a join.

After
----------------------------------------
Above query works, and relationship custom fields are available. Deleting a join cascades to other related params.

Technical Details
----------------------------------------
Implicit joins were always assumed to be based on the main entity. This allows them to be based on explicitly joined entities as well.

Because the RelationshipCache entity is meant to be used without requiring a join to the Relationship table, this permits direct access to Relationship custom fields as if they belong to the RelationshipCache table.