### PR TITLE
Fix unreleased regression from mistake extracting function

### DIFF
--- a/CRM/Core/BAO/MessageTemplate.php
+++ b/CRM/Core/BAO/MessageTemplate.php
@@ -616,7 +616,7 @@ class CRM_Core_BAO_MessageTemplate extends CRM_Core_DAO_MessageTemplate {
     $domain = CRM_Core_BAO_Domain::getDomain();
     $mailContent['subject'] = CRM_Utils_Token::replaceDomainTokens($mailContent['subject'], $domain, FALSE, $tokens['subject'], $escapeSmarty);
     $mailContent['text'] = CRM_Utils_Token::replaceDomainTokens($mailContent['text'], $domain, FALSE, $tokens['text'], $escapeSmarty);
-    $mailContent['html'] = CRM_Utils_Token::replaceDomainTokens($mailContent['html'], $domain, TRUE, $tokens, $escapeSmarty);
+    $mailContent['html'] = CRM_Utils_Token::replaceDomainTokens($mailContent['html'], $domain, TRUE, $tokens['html'], $escapeSmarty);
     return $mailContent;
   }
 


### PR DESCRIPTION

Overview
----------------------------------------
Ports this line (merged to master) to 5.35 as the mistake turns out to affect 5.35
https://github.com/civicrm/civicrm-core/pull/19551/files#diff-447cfa0a0ec021e7cf54c6f207d94c3e3343eec930130a995355fec37a590a22R597

Before
----------------------------------------
Error in extraction (picked up & fixed in master through tests)

After
----------------------------------------
Also fixed in 5.35

Technical Details
----------------------------------------

Comments
----------------------------------------
Test cover prior to latest addition seems to have been fooled by the 'text' version working