### PR TITLE
dev/core#2370 - Installer - Bump up entropy for autogenerated cred keys

### DIFF
--- a/setup/plugins/installFiles/GenerateCredKey.civi-setup.php
+++ b/setup/plugins/installFiles/GenerateCredKey.civi-setup.php
@@ -18,7 +18,7 @@ if (!defined('CIVI_SETUP')) {
     };
 
   if (empty($e->getModel()->credKeys)) {
-    $e->getModel()->credKeys = ['aes-cbc:hkdf-sha256:' . $toAlphanum(random_bytes(32))];
+    $e->getModel()->credKeys = ['aes-cbc:hkdf-sha256:' . $toAlphanum(random_bytes(37))];
   }
 
   if (is_string($e->getModel()->credKeys)) {


### PR DESCRIPTION
This slightly expands the amount of entropy for certain auto-generated values.

Before
-----

`>99%` of generated values have `>=232` bits

After
-----

`>99%` of generated values have `>=260` bits

Technical details
--------

I ran 10,000 iterations with `$toAlphanum(random_bytes(37))` as a source - and checked the size of the resulting keys (each key is a case-senstive alphanumeric, but the lengths vary; each char has 62 possibilities or ~5.95 bits). Distribution:

```
50 alphanum chars (297.50 bits)- occured 2053 times (~20.53% of all cases; percentile=~21)
49 alphanum chars (291.55 bits)- occured 3359 times (~33.59% of all cases; percentile=~54)
48 alphanum chars (285.60 bits)- occured 2652 times (~26.52% of all cases; percentile=~81)
47 alphanum chars (279.65 bits)- occured 1286 times (~12.86% of all cases; percentile=~94)
46 alphanum chars (273.70 bits)- occured 457 times (~4.57% of all cases; percentile=~98)
45 alphanum chars (267.75 bits)- occured 148 times (~1.48% of all cases; percentile=~100)
44 alphanum chars (261.80 bits)- occured 41 times (~0.41% of all cases; percentile=~100)
43 alphanum chars (255.85 bits)- occured 3 times (~0.03% of all cases; percentile=~100)
42 alphanum chars (249.90 bits)- occured 1 times (~0.01% of all cases; percentile=~100)
```

Even in the worst case (42 alphanums, 249 bits), it still significantly exceeded NIST minimum of 112 bits for symmetric crypto keys.

See also: https://lab.civicrm.org/dev/core/-/issues/2370#note_53832
