### PR TITLE
[REF] Stop passing contribution into completeOrder, id is enough

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4182,7 +4182,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
    *
    * @param array $input
    * @param array $ids
-   * @param \CRM_Contribute_BAO_Contribution $contribution
+   * @param int|null $contributionID
    * @param bool $isPostPaymentCreate
    *   Is this being called from the payment.create api. If so the api has taken care of financial entities.
    *   Note that our goal is that this would only ever be called from payment.create and never handle financials (only
@@ -4193,7 +4193,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
    * @throws \CRM_Core_Exception
    * @throws \CiviCRM_API3_Exception
    */
-  public static function completeOrder($input, $ids, $contribution, $isPostPaymentCreate = FALSE) {
+  public static function completeOrder($input, $ids, $contributionID, $isPostPaymentCreate = FALSE) {
     $transaction = new CRM_Core_Transaction();
     // @todo see if we even need this - it's used further down to create an activity
     // but the BAO layer should create that - we just need to add a test to cover it & can
@@ -4203,7 +4203,6 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
 
     // Unset ids just to make it clear it's not used again.
     unset($ids);
-    $contributionID = !empty($contribution->id) ? (int) $contribution->id : NULL;
 
     $inputContributionWhiteList = [
       'fee_amount',

--- a/CRM/Core/Payment/AuthorizeNetIPN.php
+++ b/CRM/Core/Payment/AuthorizeNetIPN.php
@@ -176,7 +176,7 @@ class CRM_Core_Payment_AuthorizeNetIPN extends CRM_Core_Payment_BaseIPN {
     CRM_Contribute_BAO_Contribution::completeOrder($input, [
       'participant' => NULL,
       'contributionRecur' => $recur->id,
-    ], $contribution);
+    ], $contribution->id ?? NULL);
     return $isFirstOrLastRecurringPayment;
   }
 

--- a/CRM/Core/Payment/BaseIPN.php
+++ b/CRM/Core/Payment/BaseIPN.php
@@ -425,7 +425,7 @@ class CRM_Core_Payment_BaseIPN {
       'related_contact' => $ids['related_contact'] ?? NULL,
       'participant' => !empty($objects['participant']) ? $objects['participant']->id : NULL,
       'contributionRecur' => !empty($objects['contributionRecur']) ? $objects['contributionRecur']->id : NULL,
-    ], $objects['contribution']);
+    ], $objects['contribution']->id ?? NULL);
   }
 
   /**

--- a/CRM/Core/Payment/PayPalIPN.php
+++ b/CRM/Core/Payment/PayPalIPN.php
@@ -225,7 +225,7 @@ class CRM_Core_Payment_PayPalIPN extends CRM_Core_Payment_BaseIPN {
       return;
     }
 
-    CRM_Contribute_BAO_Contribution::completeOrder($input, $ids, $contribution);
+    CRM_Contribute_BAO_Contribution::completeOrder($input, $ids, $contribution->id ?? NULL);
   }
 
   /**

--- a/CRM/Core/Payment/PayPalProIPN.php
+++ b/CRM/Core/Payment/PayPalProIPN.php
@@ -351,7 +351,7 @@ class CRM_Core_Payment_PayPalProIPN extends CRM_Core_Payment_BaseIPN {
       return;
     }
 
-    CRM_Contribute_BAO_Contribution::completeOrder($input, $ids, $contribution);
+    CRM_Contribute_BAO_Contribution::completeOrder($input, $ids, $contribution->id ?? NULL);
   }
 
   /**

--- a/CRM/Event/Form/Task/Batch.php
+++ b/CRM/Event/Form/Task/Batch.php
@@ -362,7 +362,7 @@ class CRM_Event_Form_Task_Batch extends CRM_Event_Form_Task {
       'related_contact' => NULL,
       'participant' => $params['component_id'],
       'contributionRecur' => NULL,
-    ], $contribution);
+    ], $contribution->id ?? NULL);
 
     // reset template values before processing next transactions
     $template->clearTemplateVars();

--- a/api/v3/Contribution.php
+++ b/api/v3/Contribution.php
@@ -684,7 +684,7 @@ function _ipn_process_transaction($params, $contribution, $input, $ids) {
     'related_contact' => $ids['related_contact'] ?? NULL,
     'participant' => !empty($objects['participant']) ? $objects['participant']->id : NULL,
     'contributionRecur' => !empty($objects['contributionRecur']) ? $objects['contributionRecur']->id : NULL,
-  ], $objects['contribution'],
+  ], $objects['contribution']->id ?? NULL,
     $params['is_post_payment_create'] ?? NULL);
 }
 


### PR DESCRIPTION
Overview
----------------------------------------
[REF] Stop passing contribution into completeOrder, id is enough

Before
----------------------------------------
$contribution object is a parameter but only the id is used

After
----------------------------------------
contributionID is a parameter

Technical Details
----------------------------------------

Comments
----------------------------------------
