### PR TITLE
event#48: Fix partially paid events in a modal dialog

### DIFF
--- a/templates/CRM/Event/Form/Participant.tpl
+++ b/templates/CRM/Event/Form/Participant.tpl
@@ -130,7 +130,7 @@
       userModifiedAmount = cj(this).val();
       userModifiedAmount = Number(userModifiedAmount.replace(/[^0-9\.]+/g,""));
       if (userModifiedAmount < feeAmount) {
-        cj('#status_id').val(partiallyPaidStatusId).change();
+        cj('.crm-participant-form-block-status_id #status_id').val(partiallyPaidStatusId).change();
       }
     }
   );
@@ -143,8 +143,8 @@
           return true;
         }
       }
-      var userSubmittedStatus = cj('#status_id').val();
-      var statusLabel = cj('#status_id option:selected').text();
+      var userSubmittedStatus = cj('.crm-participant-form-block-status_id #status_id').val();
+      var statusLabel = cj('.crm-participant-form-block-status_id #status_id option:selected').text();
       if (userModifiedAmount < feeAmount && userSubmittedStatus != partiallyPaidStatusId) {
         var msg = "{/literal}{ts escape="js" 1="%1"}Payment amount is less than the amount owed. Expected participant status is 'Partially paid'. Are you sure you want to set the participant status to %1? Click OK to continue, Cancel to change your entries.{/ts}{literal}";
         var result = confirm(ts(msg, {1: statusLabel}));
@@ -435,7 +435,7 @@
   function sendNotification() {
     var notificationStatusIds = {/literal}"{$notificationStatusIds}"{literal};
     notificationStatusIds = notificationStatusIds.split(',');
-    if (cj.inArray(cj('select#status_id option:selected').val(), notificationStatusIds) > -1) {
+    if (cj.inArray(cj('.crm-participant-form-block-status_id select#status_id option:selected').val(), notificationStatusIds) > -1) {
       cj("#notify").show();
       cj("#is_notify").prop('checked', false);
     }


### PR DESCRIPTION
Overview
----------------------------------------
When registering an event with a partial payment on the backend, an error arises if the "Register Event Participant" is in a modal dialog.

Before
----------------------------------------
The following error appears (with its missing word): "Payment amount is less than the amount owed. Expected participant status is 'Partially paid'. Are you sure you want to set the participant status to ? Click OK to continue, Cancel to change your entries".  Event Status is not "Partially Paid".

After
----------------------------------------
Event's payment is correctly set to partially paid.

Technical Details
----------------------------------------
There are two elements that both have the ID `status_id`.  JavaScript intended to set the event to Partially Paid status targets the wrong element.

Comments
----------------------------------------
Ideally we would change the element IDs here, but that seems like it could have a negative effect on extensions that may rely on these element IDs.  This solution - targeting the element more specifically - is less technically correct, but should have the least impact.

I tested that the `.crm-participant-form-block-status_id` is present on this form in all the permutations I could find to load it.
