### PR TITLE
dev/core#2370 - Installer - Bump up entropy for autogenerated cred keys

### DIFF
--- a/setup/plugins/installFiles/GenerateCredKey.civi-setup.php
+++ b/setup/plugins/installFiles/GenerateCredKey.civi-setup.php
@@ -18,7 +18,7 @@ if (!defined('CIVI_SETUP')) {
     };
 
   if (empty($e->getModel()->credKeys)) {
-    $e->getModel()->credKeys = ['aes-cbc:hkdf-sha256:' . $toAlphanum(random_bytes(32))];
+    $e->getModel()->credKeys = ['aes-cbc:hkdf-sha256:' . $toAlphanum(random_bytes(37))];
   }
 
   if (is_string($e->getModel()->credKeys)) {


### PR DESCRIPTION
This slightly expands the amount of entropy for certain auto-generated values.

Before
-----

~99% of generated values have >=232 bits

After
-----

~99% of generated values have >=260 bits

Technical details
--------

https://lab.civicrm.org/dev/core/-/issues/2370#note_53832