### PR TITLE
serialize as boolean setting value for checkbox in CRM_Admin_Form_Gen…

### DIFF
--- a/CRM/Admin/Form/SettingTrait.php
+++ b/CRM/Admin/Form/SettingTrait.php
@@ -340,7 +340,7 @@ trait CRM_Admin_Form_SettingTrait {
       }
       elseif ($this->getQuickFormType($settingMetaData) === 'CheckBox') {
         // This will be an array with one value.
-        $settings[$setting] = (int) reset($settings[$setting]);
+        $settings[$setting] = (bool) reset($settings[$setting]);
       }
     }
     civicrm_api3('setting', 'create', $settings);


### PR DESCRIPTION
Overview
----------------------------------------
Serialize setting value as boolean for checkbox in CRM_Admin_Form_Generic.  
Issue: https://lab.civicrm.org/dev/core/-/issues/2371

Before
----------------------------------------
When a setting is defined as "Boolean / Checkbox" in its metadata, the Form `CRM_Admin_Form_Generic` saves it as integer value (serialized in `civicrm_setting.value` table)

After
----------------------------------------
The setting is serialized as **bool**

Technical Details
----------------------------------------
cast checkbox value as bool

Comments
----------------------------------------
Something similar happens with setting "Integer / Textbox" where the value is serialized as **string** in MySQL. But I'd tackle that issue in a different PR
