### PR TITLE
Apply bootstrap theme to searchKit dashlets

### DIFF
--- a/CRM/Contact/Page/DashBoard.php
+++ b/CRM/Contact/Page/DashBoard.php
@@ -79,7 +79,9 @@ class CRM_Contact_Page_DashBoard extends CRM_Core_Page {
     $partials = [];
     foreach (CRM_Core_BAO_Dashboard::getContactDashlets() as $dashlet) {
       if (!empty($dashlet['directive'])) {
-        $partials["~/$moduleName/directives/{$dashlet['directive']}.html"] = "<{$dashlet['directive']}></{$dashlet['directive']}>";
+        // FIXME: Wrapping each directive in <div id='bootstrap-theme'> produces invalid html (duplicate ids in the dom)
+        // but it's the only practical way to selectively apply boostrap3 theming to specific dashlets
+        $partials["~/$moduleName/directives/{$dashlet['directive']}.html"] = "<div id='bootstrap-theme'><{$dashlet['directive']}></{$dashlet['directive']}></div>";
       }
     }
     return $partials;

--- a/ext/search/ang/crmSearchDisplayList.ang.php
+++ b/ext/search/ang/crmSearchDisplayList.ang.php
@@ -10,6 +10,7 @@ return [
   ],
   'basePages' => ['civicrm/search', 'civicrm/admin/search'],
   'requires' => ['crmSearchDisplay', 'crmUi', 'ui.bootstrap'],
+  'bundles' => ['bootstrap3'],
   'exports' => [
     'crm-search-display-list' => 'E',
   ],

--- a/ext/search/ang/crmSearchDisplayTable.ang.php
+++ b/ext/search/ang/crmSearchDisplayTable.ang.php
@@ -10,6 +10,7 @@ return [
   ],
   'basePages' => ['civicrm/search', 'civicrm/admin/search'],
   'requires' => ['crmSearchDisplay', 'crmUi', 'crmSearchActions', 'ui.bootstrap'],
+  'bundles' => ['bootstrap3'],
   'exports' => [
     'crm-search-display-table' => 'E',
   ],


### PR DESCRIPTION
Overview
----------------------------------------
This conditionally loads Bootstrap3 onto the Civi home dashboard if a Search display is embedded in a dashlet, and wraps that dashlet with a bootstrap-theme tag.

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/2874912/107528932-5d4d3f80-6b88-11eb-95fe-6e34f3a36c16.png)

After
----------------------------------------
![image](https://user-images.githubusercontent.com/2874912/107529049-7b1aa480-6b88-11eb-8687-d32c14fc07bd.png)


Technical Details
----------------------------------------
Technically, this produces invalid markup because more than one dashlet could contain `<div id='bootstrap-theme'>`. Oh well, I couldn't think of a better solution that was reasonably expedient, and browsers don't seem to care.