### PR TITLE
core#1132 - don't fire hook_civicrm_fieldOptions before hook_civicrm_…

### DIFF
--- a/CRM/Core/I18n.php
+++ b/CRM/Core/I18n.php
@@ -184,8 +184,11 @@ class CRM_Core_I18n {
     static $enabled = NULL;
 
     if (!$all) {
-      $all = CRM_Contact_BAO_Contact::buildOptions('preferred_language');
+      // Use `getValues`, not `buildOptions` to bypass hook_civicrm_fieldOptions.  See core#1132.
+      CRM_Core_OptionValue::getValues(['name' => 'languages'], $optionValues, 'weight', TRUE);
+      $all = array_column($optionValues, 'label', 'name');
 
+      // FIXME: How is this not duplicative of the lines above?
       // get labels
       $rows = [];
       $labels = [];


### PR DESCRIPTION
…config loads all files

https://lab.civicrm.org/dev/core/-/issues/1132

Overview
----------------------------------------
`hook_civicrm_config` is responsible for adding files to the autoloader.  `hook_civicrm_config` calls `hook_civicrm_fieldOptions`.  As a result, `hook_civicrm_fieldOptions` crashes if you reference a class that's not in core (i.e. in an extension).

Before
----------------------------------------
Crashes.

After
----------------------------------------
No crashes.

Technical Details
----------------------------------------
The backtrace is on https://lab.civicrm.org/dev/core/-/issues/1132, which explains why this happens.

Comments
----------------------------------------
This will hopefully fix the conflict that Mosaico 2.6 has with other extensions (like Areas).

#### Steps to replicate
* Create a new extension.
* Create a method on a class in that extension.  Here's an example:
```php
<?php

class CRM_Contribute_BAO_PaymentMethodByDomain {

  public static function getPaymentInstrument() {
    return TRUE;
  }

}
```
* In `hook_civicrm_fieldOptions`, call this method.
At this point, most of CiviCRM will be broken.  Clearing cache will certainly trigger the bug.