### PR TITLE
Remove check for safe_mode/open_basedir on extension downloader because it triggers false positives

### DIFF
--- a/CRM/Extension/Downloader.php
+++ b/CRM/Extension/Downloader.php
@@ -71,11 +71,6 @@ class CRM_Extension_Downloader {
       );
     }
 
-    if (empty($errors) && !CRM_Utils_HttpClient::singleton()->isRedirectSupported()) {
-      CRM_Core_Session::setStatus(ts('WARNING: The downloader may be unable to download files which require HTTP redirection. This may be a configuration issue with PHP\'s open_basedir or safe_mode.'));
-      Civi::log()->debug('WARNING: The downloader may be unable to download files which require HTTP redirection. This may be a configuration issue with PHP\'s open_basedir or safe_mode.');
-    }
-
     if ($extensionInfo) {
       $requiredExtensions = CRM_Extension_System::singleton()->getManager()->findInstallRequirements([$extensionInfo->key], $extensionInfo);
       foreach ($requiredExtensions as $extension) {


### PR DESCRIPTION
Overview
----------------------------------------
`safe_mode` is removed from PHP 7.2: https://www.php.net/manual/en/ini.core.php#ini.sql.safe-mode and there are other error messages that will alert the user if an extension fails to download / install. In most cases it will work perfectly well with a sensibly configured `open_basedir` (eg. webroot + tmp).

Before
----------------------------------------
False positive errors triggered when `open_basedir` is not empty.

After
----------------------------------------
No error triggered if `open_basedir` is empty. Errors will still be triggered later in the process if extension cannot be downloaded/unzipped.

Technical Details
----------------------------------------


Comments
----------------------------------------
