### PR TITLE
dev/drupal#156 - system_get_info() is gone in drupal 9

### DIFF
--- a/CRM/Core/Permission/Drupal8.php
+++ b/CRM/Core/Permission/Drupal8.php
@@ -58,7 +58,7 @@ class CRM_Core_Permission_Drupal8 extends CRM_Core_Permission_DrupalBase {
     $allCorePerms = \CRM_Core_Permission::basicPermissions(TRUE);
 
     $dperms = \Drupal::service('user.permissions')->getPermissions();
-    $modules = system_get_info('module');
+    $modules = \Drupal::service('extension.list.module')->getAllInstalledInfo();
 
     $permissions = [];
     foreach ($dperms as $permName => $dperm) {


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/drupal/-/issues/156

Before
----------------------------------------
crash when viewing any civireport

After
----------------------------------------
not crash

Technical Details
----------------------------------------
Because of the recent change at https://github.com/civicrm/civicrm-core/pull/19536/files#diff-7ba495841aab2d42ef2b0562aa3e28287be4cfc675fa526801fd3421a0092fdc it now ends up calling this function.

Comments
----------------------------------------

