### PR TITLE
core#2379 - avoid validation error on saving geocodes

### DIFF
--- a/CRM/Core/BAO/Address.php
+++ b/CRM/Core/BAO/Address.php
@@ -1304,12 +1304,21 @@ SELECT is_primary,
   public static function addGeocoderData(&$params) {
     try {
       $provider = CRM_Utils_GeocodeProvider::getConfiguredProvider();
+      $providerExists = TRUE;
     }
     catch (CRM_Core_Exception $e) {
-      return FALSE;
+      $providerExists = FALSE;
     }
-    $provider::format($params);
-    return TRUE;
+    if ($providerExists) {
+      $provider::format($params);
+    }
+    // core#2379 - Limit geocode length to 14 characters to avoid validation error on save in UI.
+    foreach (['geo_code_1', 'geo_code_2'] as $geocode) {
+      if ($params[$geocode] ?? FALSE) {
+        $params[$geocode] = (float) substr($params[$geocode], 0, 14);
+      }
+    }
+    return $providerExists;
   }
 
   /**

--- a/tests/phpunit/CRM/Core/BAO/AddressTest.php
+++ b/tests/phpunit/CRM/Core/BAO/AddressTest.php
@@ -693,4 +693,38 @@ class CRM_Core_BAO_AddressTest extends CiviUnitTestCase {
     $this->assertEquals(1228, $availableCountries[2]);
   }
 
+  /**
+   * Test core#2379 fix - geocodes shouldn't be > 14 characters.
+   */
+  public function testLongGeocodes() {
+    $contactId = $this->individualCreate();
+
+    $fixParams = [
+      'street_address' => 'E 906N Pine Pl W',
+      'supplemental_address_1' => 'Editorial Dept',
+      'supplemental_address_2' => '',
+      'supplemental_address_3' => '',
+      'city' => 'El Paso',
+      'postal_code' => '88575',
+      'postal_code_suffix' => '',
+      'state_province_id' => '1001',
+      'country_id' => '1228',
+      'geo_code_1' => '41.701308979563',
+      'geo_code_2' => '-73.91941868639',
+      'location_type_id' => '1',
+      'is_primary' => '1',
+      'is_billing' => '0',
+      'contact_id' => $contactId,
+    ];
+
+    $addAddress = CRM_Core_BAO_Address::add($fixParams, TRUE);
+
+    $addParams = $this->assertDBNotNull('CRM_Core_DAO_Address', $contactId, 'id', 'contact_id',
+      'Database check for created contact address.'
+    );
+
+    $this->assertEquals('41.70130897956', $addAddress->geo_code_1, 'In line' . __LINE__);
+    $this->assertEquals('-73.9194186863', $addAddress->geo_code_2, 'In line' . __LINE__);
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
The CiviCRM UI doesn't allow saving more than 14 characters in a geocoding field.  However, geocoders themselves aren't restricted to 14 characters.  This means that geocoders can enter a geocode that prevents editing the address.

Before
----------------------------------------
![Screen Shot 2021-02-09 at 9 47 59 AM](https://user-images.githubusercontent.com/1796012/107815832-e9569700-6d41-11eb-87e6-56506e591550.png)

After
----------------------------------------
Geocoders won't save more than 14 characters.

Technical Details
----------------------------------------
I changed the flow of this function slightly to ensure this code runs regardless of whether a geocoder is installed.  This is to handle existing data with too many characters (e.g. geocodes added via import).

Comments
----------------------------------------
14 characters guarantees at least 9 significant digits, which is accurate to 110 microns, so we're not losing "real" data by shortening the geocodes.
