### PR TITLE
Fix Redis deprecated warning

### DIFF
--- a/CRM/Core/PrevNextCache/Redis.php
+++ b/CRM/Core/PrevNextCache/Redis.php
@@ -46,10 +46,7 @@ class CRM_Core_PrevNextCache_Redis implements CRM_Core_PrevNextCache_Interface {
   }
 
   public function fillWithSql($cacheKey, $sql, $sqlParams = []) {
-    $dao = CRM_Core_DAO::executeQuery($sql, $sqlParams, FALSE, NULL, FALSE, TRUE, TRUE);
-    if (is_a($dao, 'DB_Error')) {
-      throw new CRM_Core_Exception($dao->message);
-    }
+    $dao = CRM_Core_DAO::executeQuery($sql, $sqlParams, FALSE);
 
     list($allKey, $dataKey, , $maxScore) = $this->initCacheKey($cacheKey);
 


### PR DESCRIPTION
Overview
----------------------------------------
Fixes deprecation warning on sites using Redis

Before
----------------------------------------
Deprecation message

After
----------------------------------------
poof

Technical Details
----------------------------------------
It's not obvious why we would pass trapException here. I believe the issue is that
some custom searches result in 'acceptable' bad sql here but
https://github.com/civicrm/civicrm-core/commit/6dc40f3250ede0f38ce2aed7c3fabd3f1f667c1b
already fixed to catch any exception so we don't
need to convert. There is one other place that calls fillWithSql but there
is no evidence it is subject to the random issue on custom searches / needs
any attention at the moment


Comments
----------------------------------------
Maybe this should be on the RC - in which case merge https://github.com/civicrm/civicrm-core/pull/19593 & close this