### PR TITLE
Alternate to 19587 - dev/core#2381 - crash with blob columns and logging enabled

### DIFF
--- a/CRM/Logging/Schema.php
+++ b/CRM/Logging/Schema.php
@@ -951,7 +951,7 @@ COLS;
         // which makes sense, in particular, for calculated fields.
         continue;
       }
-      $columns = $this->columnsOf($table, $force);
+      $columns = $this->columnSpecsOf($table, $force);
 
       // Use utf8mb4_bin or utf8_bin, depending on what's in use.
       $charset = 'utf8';
@@ -961,7 +961,7 @@ COLS;
 
       // only do the change if any data has changed
       $cond = [];
-      foreach ($columns as $column) {
+      foreach ($columns as $column => $columnSpec) {
         $tableExceptions = array_key_exists('exceptions', $this->logTableSpec[$table]) ? $this->logTableSpec[$table]['exceptions'] : [];
         // ignore modified_date changes
         $tableExceptions[] = 'modified_date';
@@ -986,7 +986,7 @@ COLS;
       else {
         $sqlStmt = "INSERT INTO log_{tableName} (";
       }
-      foreach ($columns as $column) {
+      foreach ($columns as $column => $columnSpec) {
         $sqlStmt .= "$column, ";
       }
       $sqlStmt .= "log_conn_id, log_user_id, log_action) VALUES (";
@@ -995,7 +995,7 @@ COLS;
       $updateSQL .= $sqlStmt;
 
       $sqlStmt = '';
-      foreach ($columns as $column) {
+      foreach ($columns as $column => $columnSpec) {
         $sqlStmt .= "NEW.$column, ";
         $deleteSQL .= "OLD.$column, ";
       }

--- a/CRM/Logging/Schema.php
+++ b/CRM/Logging/Schema.php
@@ -635,12 +635,13 @@ AND    (TABLE_NAME LIKE 'log_civicrm_%' $nonStandardTableNameString )
    * Get an array of columns and their details like DATA_TYPE, IS_NULLABLE, COLUMN_DEFAULT for the given table.
    *
    * @param string $table
+   * @param bool $force
    *
    * @return array
    */
-  private function columnSpecsOf($table) {
+  private function columnSpecsOf($table, $force = FALSE) {
     static $civiDB = NULL;
-    if (empty(\Civi::$statics[__CLASS__]['columnSpecs'])) {
+    if ($force || empty(\Civi::$statics[__CLASS__]['columnSpecs'])) {
       \Civi::$statics[__CLASS__]['columnSpecs'] = [];
     }
     if (empty(\Civi::$statics[__CLASS__]['columnSpecs']) || !isset(\Civi::$statics[__CLASS__]['columnSpecs'][$table])) {


### PR DESCRIPTION
Overview
----------------------------------------
Alternate to https://github.com/civicrm/civicrm-core/pull/19587 which is a bit bigger but maybe cleaner.

* Commit 1 adds a force parameter to columnSpecsOf
* Commit 2 uses columnSpecsOf
* Commit 3 moves the wordiness to a separate function and fixes the bug
* Commit 4 adds test
* Commit 5 helps avoid requerying and rebuilding the same large array 40 times when force=true

To reproduce the crash:
1. Turn on logging at Admin - System Settings - Misc.
2. Manually run a SQL UPDATE on civicrm_file, or turn on civicase and then edit and save a case type.