### PR TITLE
dev/mail#89 Fix unreleased regression where civimember is not permitted/enabled

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -2657,7 +2657,7 @@ LEFT JOIN civicrm_email    ON ( civicrm_contact.id = civicrm_email.contact_id )
         return CRM_Contribute_BAO_Contribution::contributionCount($contactId);
 
       case 'membership':
-        return CRM_Member_BAO_Membership::getContactMembershipCount($contactId, TRUE);
+        return CRM_Member_BAO_Membership::getContactMembershipCount((int) $contactId, TRUE);
 
       case 'participant':
         return CRM_Event_BAO_Participant::getContactParticipantCount($contactId);


### PR DESCRIPTION

Overview
----------------------------------------
Fixes a regression introduced in https://github.com/civicrm/civicrm-core/pull/19431 where users with no access to civimember get an error when saving relationships as an api exception is thrown

Before
----------------------------------------
Uncaught exception results in modal just spinning and if done outside a model it can be seen that ane exception was not caught

After
----------------------------------------
Exception caught in the function and 0 returned

Technical Details
----------------------------------------

Comments
----------------------------------------
This can be particularly confusing on sites where civimember is not enabled at all