### PR TITLE
[NFC] Code cleanup - use use statements, hints

### DIFF
--- a/CRM/Activity/Tokens.php
+++ b/CRM/Activity/Tokens.php
@@ -15,6 +15,10 @@
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
 
+use Civi\Token\AbstractTokenSubscriber;
+use Civi\Token\Event\TokenValueEvent;
+use Civi\Token\TokenRow;
+
 /**
  * Class CRM_Member_Tokens
  *
@@ -29,7 +33,7 @@
  *
  * This has been enhanced to work with PDF/letter merge
  */
-class CRM_Activity_Tokens extends \Civi\Token\AbstractTokenSubscriber {
+class CRM_Activity_Tokens extends AbstractTokenSubscriber {
 
   use CRM_Core_TokenTrait;
 
@@ -85,7 +89,7 @@ class CRM_Activity_Tokens extends \Civi\Token\AbstractTokenSubscriber {
   /**
    * @inheritDoc
    */
-  public function prefetch(\Civi\Token\Event\TokenValueEvent $e) {
+  public function prefetch(TokenValueEvent $e) {
     // Find all the entity IDs
     $entityIds
       = $e->getTokenProcessor()->getContextValues('actionSearchResult', 'entityID')
@@ -124,7 +128,7 @@ class CRM_Activity_Tokens extends \Civi\Token\AbstractTokenSubscriber {
   /**
    * @inheritDoc
    */
-  public function evaluateToken(\Civi\Token\TokenRow $row, $entity, $field, $prefetch = NULL) {
+  public function evaluateToken(TokenRow $row, $entity, $field, $prefetch = NULL) {
     // maps token name to api field
     $mapping = [
       'activity_id' => 'id',
@@ -172,7 +176,7 @@ class CRM_Activity_Tokens extends \Civi\Token\AbstractTokenSubscriber {
    *
    * @return array token name => token label
    */
-  protected function getBasicTokens() {
+  protected function getBasicTokens(): array {
     if (!isset($this->basicTokens)) {
       $this->basicTokens = [
         'activity_id' => ts('Activity ID'),

--- a/CRM/Contribute/Tokens.php
+++ b/CRM/Contribute/Tokens.php
@@ -10,6 +10,11 @@
  +--------------------------------------------------------------------+
  */
 
+use Civi\ActionSchedule\Event\MailingQueryEvent;
+use Civi\Token\AbstractTokenSubscriber;
+use Civi\Token\TokenProcessor;
+use Civi\Token\TokenRow;
+
 /**
  * Class CRM_Contribute_Tokens
  *
@@ -18,13 +23,13 @@
  * At time of writing, we don't have any particularly special tokens -- we just
  * do some basic formatting based on the corresponding DB field.
  */
-class CRM_Contribute_Tokens extends \Civi\Token\AbstractTokenSubscriber {
+class CRM_Contribute_Tokens extends AbstractTokenSubscriber {
 
   /**
    * Get a list of tokens whose name and title match the DB fields.
    * @return array
    */
-  protected function getPassthruTokens() {
+  protected function getPassthruTokens(): array {
     return [
       'contribution_page_id',
       'receive_date',
@@ -46,7 +51,7 @@ class CRM_Contribute_Tokens extends \Civi\Token\AbstractTokenSubscriber {
    *
    * @return array
    */
-  protected function getAliasTokens() {
+  protected function getAliasTokens(): array {
     return [
       'id' => 'contribution_id',
       'payment_instrument' => 'payment_instrument_id',
@@ -81,7 +86,7 @@ class CRM_Contribute_Tokens extends \Civi\Token\AbstractTokenSubscriber {
    *
    * @return bool
    */
-  public function checkActive(\Civi\Token\TokenProcessor $processor) {
+  public function checkActive(TokenProcessor $processor) {
     return !empty($processor->context['actionMapping'])
       && $processor->context['actionMapping']->getEntity() === 'civicrm_contribution';
   }
@@ -91,7 +96,7 @@ class CRM_Contribute_Tokens extends \Civi\Token\AbstractTokenSubscriber {
    *
    * @param \Civi\ActionSchedule\Event\MailingQueryEvent $e
    */
-  public function alterActionScheduleQuery(\Civi\ActionSchedule\Event\MailingQueryEvent $e) {
+  public function alterActionScheduleQuery(MailingQueryEvent $e): void {
     if ($e->mapping->getEntity() !== 'civicrm_contribution') {
       return;
     }
@@ -108,7 +113,7 @@ class CRM_Contribute_Tokens extends \Civi\Token\AbstractTokenSubscriber {
   /**
    * @inheritDoc
    */
-  public function evaluateToken(\Civi\Token\TokenRow $row, $entity, $field, $prefetch = NULL) {
+  public function evaluateToken(TokenRow $row, $entity, $field, $prefetch = NULL) {
     $actionSearchResult = $row->context['actionSearchResult'];
     $fieldValue = $actionSearchResult->{"contrib_$field"} ?? NULL;
 

--- a/CRM/Core/TokenTrait.php
+++ b/CRM/Core/TokenTrait.php
@@ -1,5 +1,8 @@
 <?php
 
+use Civi\Token\Event\TokenValueEvent;
+use Civi\Token\TokenProcessor;
+
 trait CRM_Core_TokenTrait {
 
   private $basicTokens;
@@ -18,7 +21,7 @@ trait CRM_Core_TokenTrait {
   /**
    * @inheritDoc
    */
-  public function checkActive(\Civi\Token\TokenProcessor $processor) {
+  public function checkActive(TokenProcessor $processor) {
     return in_array($this->getEntityContextSchema(), $processor->context['schema']) ||
       (!empty($processor->context['actionMapping'])
         && $processor->context['actionMapping']->getEntity() === $this->getEntityTableName());
@@ -27,7 +30,7 @@ trait CRM_Core_TokenTrait {
   /**
    * @inheritDoc
    */
-  public function getActiveTokens(\Civi\Token\Event\TokenValueEvent $e) {
+  public function getActiveTokens(TokenValueEvent $e) {
     $messageTokens = $e->getTokenProcessor()->getMessageTokens();
     if (!isset($messageTokens[$this->entity])) {
       return NULL;
@@ -77,7 +80,7 @@ trait CRM_Core_TokenTrait {
    * Get the tokens for custom fields
    * @return array token name => token label
    */
-  protected function getCustomFieldTokens() {
+  protected function getCustomFieldTokens(): array {
     if (!isset($this->customFieldTokens)) {
       $this->customFieldTokens = \CRM_Utils_Token::getCustomFieldTokens(ucfirst($this->getEntityName()));
     }


### PR DESCRIPTION

Overview
----------------------------------------
Minor cleanup on token classes from https://github.com/civicrm/civicrm-core/pull/19584

Before
----------------------------------------
e.g 
```
class CRM_Activity_Tokens extends \Civi\Token\AbstractTokenSubscriber {
```

After
----------------------------------------
use statement +

class CRM_Activity_Tokens extends AbstractTokenSubscriber {

Technical Details
----------------------------------------


Comments
----------------------------------------
