### PR TITLE
APIv4 - Add option lists to getFields html_type and data_type

### DIFF
--- a/Civi/Api4/Generic/BasicGetFieldsAction.php
+++ b/Civi/Api4/Generic/BasicGetFieldsAction.php
@@ -254,10 +254,30 @@ class BasicGetFieldsAction extends BasicGetAction {
       [
         'name' => 'data_type',
         'data_type' => 'String',
+        'options' => [
+          'Integer' => ts('Integer'),
+          'Boolean' => ts('Boolean'),
+          'String' => ts('String'),
+          'Text' => ts('Text'),
+          'Date' => ts('Date'),
+          'Timestamp' => ts('Timestamp'),
+          'Array' => ts('Array'),
+        ],
       ],
       [
         'name' => 'input_type',
         'data_type' => 'String',
+        'options' => [
+          'Text' => ts('Text'),
+          'Number' => ts('Number'),
+          'Select' => ts('Select'),
+          'CheckBox' => ts('CheckBox'),
+          'Radio' => ts('Radio'),
+          'Date' => ts('Date'),
+          'File' => ts('File'),
+          'EntityRef' => ts('EntityRef'),
+          'ChainSelect' => ts('ChainSelect'),
+        ],
       ],
       [
         'name' => 'input_attrs',


### PR DESCRIPTION
Overview
----------------------------------------
Adds option lists to `html_type` and `data_type` in APIv4 getFields to make them easier to discover in the API Explorer.

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/2874912/107894667-4f881900-6efe-11eb-9d10-7397d98b73dd.png)

After
----------------------------------------
![image](https://user-images.githubusercontent.com/2874912/107894618-2bc4d300-6efe-11eb-837d-8ce070a04c0b.png)

Comments
----------------------------------------
This is mainly to make the Explorer more friendly. It shouldn't otherwise impact api functionality.