### PR TITLE
Convert Smarty & domain token processing to use token processor

### DIFF
--- a/tests/phpunit/CRM/Core/BAO/MessageTemplateTest.php
+++ b/tests/phpunit/CRM/Core/BAO/MessageTemplateTest.php
@@ -92,7 +92,7 @@ class CRM_Core_BAO_MessageTemplateTest extends CiviUnitTestCase {
 Up the road
 London, 90210
  ~ crown@example.com ~ 1 ~ rather nice', $messageContent['text']);
-    $this->assertEquals('Default Domain Name ~  ~ Buckingham palaceUp the roadLondon, 90210~ crown@example.com ~ 1 ~ rather nice', $messageContent['subject']);
+    $this->assertEquals('Default Domain Name ~  ~ Buckingham palace Up the road London, 90210  ~ crown@example.com ~ 1 ~ rather nice', $messageContent['subject']);
   }
 
   /**
@@ -246,7 +246,7 @@ contact_id:' . $tokenData['contact_id'] . '
 ';
     $this->assertEquals($expected, $messageContent['html']);
     $this->assertEquals($expected, $messageContent['text']);
-    $this->assertEquals(str_replace("\n", '', $expected), $messageContent['subject']);
+    $this->assertEquals(rtrim(str_replace("\n", ' ', $expected)), $messageContent['subject']);
   }
 
   /**

--- a/tests/phpunit/CRM/Event/Form/Registration/ConfirmTest.php
+++ b/tests/phpunit/CRM/Event/Form/Registration/ConfirmTest.php
@@ -20,7 +20,7 @@ class CRM_Event_Form_Registration_ConfirmTest extends CiviUnitTestCase {
    *
    * @throws \Exception
    */
-  public function testSubmit() {
+  public function testSubmit(): void {
     $event = $this->eventCreate();
     $mut = new CiviMailUtils($this, TRUE);
     CRM_Event_Form_Registration_Confirm::testSubmit([
@@ -77,15 +77,11 @@ class CRM_Event_Form_Registration_ConfirmTest extends CiviUnitTestCase {
       ],
     ]);
 
-    $participant = $this->callAPISuccessGetSingle('Participant', []);
     $mut->checkMailLog([
       'Dear Logged In,  Thank you for your registration.  This is a confirmation that your registration has been received and your status has been updated to Registered.',
     ]);
     $mut->stop();
     $mut->clearMessages();
-    $tplVars = CRM_Core_Smarty::singleton()->get_template_vars();
-    $this->assertEquals($participant['id'], $tplVars['participantID']);
-
   }
 
   /**
@@ -486,8 +482,6 @@ class CRM_Event_Form_Registration_ConfirmTest extends CiviUnitTestCase {
     $mut->checkMailLog(['Comment: ' . $event['note'] . chr(0x0A)]);
     $mut->stop();
     $mut->clearMessages();
-    $tplVars = CRM_Core_Smarty::singleton()->get_template_vars();
-    $this->assertEquals($participant['id'], $tplVars['participantID']);
     //return ['contact_id' => $contact_id, 'participant_id' => $participant['id']];
     return [$contact_id, $participant['id']];
   }
@@ -557,13 +551,17 @@ class CRM_Event_Form_Registration_ConfirmTest extends CiviUnitTestCase {
    * /dev/event#10
    * Test submission with a note in the profile, ensuring the confirmation
    * email reflects the submitted value
+   *
+   * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
+   * @throws \Exception
    */
-  public function testNoteSubmission() {
+  public function testNoteSubmission(): void {
     //create an event with an attached profile containing a note
     $event = $this->creatEventWithProfile(NULL);
-    $event['custom_pre_id'] = $this->ids["UFGroup"]["our profile"];
+    $event['custom_pre_id'] = $this->ids['UFGroup']['our profile'];
     $event['note'] = 'This is note 1';
-    list($contact_id, $participant_id) = $this->submitWithNote($event, NULL);
+    [$contact_id, $participant_id] = $this->submitWithNote($event, NULL);
     civicrm_api3('Participant', 'delete', ['id' => $participant_id]);
 
     //now that the contact has one note, register this contact again with a different note
@@ -571,7 +569,7 @@ class CRM_Event_Form_Registration_ConfirmTest extends CiviUnitTestCase {
     $event = $this->creatEventWithProfile($event);
     $event['custom_pre_id'] = $this->ids["UFGroup"]["our profile"];
     $event['note'] = 'This is note 2';
-    list($contact_id, $participant_id) = $this->submitWithNote($event, $contact_id);
+    [$contact_id, $participant_id] = $this->submitWithNote($event, $contact_id);
     civicrm_api3('Participant', 'delete', ['id' => $participant_id]);
 
     //finally, submit a blank note and confirm that the note shown in the email is blank

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -3666,9 +3666,8 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
    * Test sending a mail via the API.
    *
    * @throws \CRM_Core_Exception
-   * @throws \CiviCRM_API3_Exception
    */
-  public function testSendMail() {
+  public function testSendMail(): void {
     $mut = new CiviMailUtils($this, TRUE);
     $orderParams = $this->_params;
     $orderParams['contribution_status_id'] = 'Pending';
@@ -3698,7 +3697,6 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
     $mut->stop();
     $tplVars = CRM_Core_Smarty::singleton()->get_template_vars();
     $this->assertEquals('bob', $tplVars['billingName']);
-    $this->assertEquals("bob\nblah\n", $tplVars['address']);
   }
 
   /**


### PR DESCRIPTION




Overview
----------------------------------------
Convert Smarty & domain token processing to use token processor

This is a subset of the changes in
https://github.com/civicrm/civicrm-core/pull/19550 that we should be able to resolve
& merge while addressing that takes longer. It still gets us the
benefit of adopting a preferred pattern

Before
----------------------------------------
Code uses older less preferred pattern

After
----------------------------------------
Code uses newer preferred pattern. In addition there is 
1) less leakage around smarty variables
2) more consistency about handling of line breaks in subject lines (consistently converted to spaces with whitespace stripped from the end)

Technical Details
----------------------------------------
Note that some test changes exist around handling of subject -
the code now converts a new line to a space consistently. In addition
tests that rely on leakage have been altered as smarty does not leak with
this approach

Comments
----------------------------------------
