### PR TITLE
Crypto - Add support for signing and verifying JSON Web Tokens

### DIFF
--- a/CRM/Upgrade/Incremental/php/FiveThirtySix.php
+++ b/CRM/Upgrade/Incremental/php/FiveThirtySix.php
@@ -29,6 +29,15 @@ class CRM_Upgrade_Incremental_php_FiveThirtySix extends CRM_Upgrade_Incremental_
     // if ($rev == '5.12.34') {
     //   $preUpgradeMessage .= '<p>' . ts('A new permission, "%1", has been added. This permission is now used to control access to the Manage Tags screen.', array(1 => ts('manage tags'))) . '</p>';
     // }
+    if ($rev === '5.36.alpha1') {
+      if (empty(CRM_Utils_Constant::value('CIVICRM_SIGN_KEYS'))) {
+        // NOTE: We don't re-encrypt automatically because the old "civicrm.settings.php" lacks a good key, and we don't keep the old encryption because the format is ambiguous.
+        // The admin may forget to re-enable. That's OK -- this only affects 1 field, this is a secondary defense, and (in the future) we can remind the admin via status-checks.
+        $preUpgradeMessage .= '<p>' . ts('CiviCRM v5.36 introduces a new configuration option to support digital signatures. You may <a href="%1" target="_blank">setup CIVICRM_SIGN_KEYS</a> before or after upgrading. The option is not critical in v5.36, but it may be required for extensions or future upgrades.', [
+          1 => 'https://docs.civicrm.org/sysadmin/en/latest/upgrade/version-specific/#sign-key',
+        ]) . '</p>';
+      }
+    }
   }
 
   /**

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -224,6 +224,9 @@ class Container {
     $container->setDefinition('crypto.token', new Definition('Civi\Crypto\CryptoToken', []))
       ->setPublic(TRUE);
 
+    $container->setDefinition('crypto.jwt', new Definition('Civi\Crypto\CryptoJwt', []))
+      ->setPublic(TRUE);
+
     if (empty(\Civi::$statics[__CLASS__]['boot'])) {
       throw new \RuntimeException('Cannot initialize container. Boot services are undefined.');
     }

--- a/Civi/Crypto/CryptoJwt.php
+++ b/Civi/Crypto/CryptoJwt.php
@@ -1,0 +1,125 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Crypto;
+
+use Civi\Crypto\Exception\CryptoException;
+use Firebase\JWT\JWT;
+
+/**
+ * The "Crypto JWT" service supports a token format suitable for
+ * exchanging/transmitting with external consumers (e.g. web-browsers).
+ * It integrates with the CryptoRegistry (which is a source of valid signing keys).
+ *
+ * By default, tokens are signed and validated using any 'SIGN'ing keys
+ * (ie 'CIVICRM_SIGN_KEYS').
+ *
+ * @package Civi\Crypto
+ * @see https://jwt.io/
+ */
+class CryptoJwt {
+
+  /**
+   * @var \Civi\Crypto\CryptoRegistry
+   */
+  protected $registry;
+
+  /**
+   * @param array $payload
+   *   List of JWT claims. See IANA link below.
+   * @param string $keyIdOrTag
+   *   Choose a valid key from the CryptoRegistry using $keyIdOrTag.
+   * @return string
+   * @throws \Civi\Crypto\Exception\CryptoException
+   *
+   * @see https://www.iana.org/assignments/jwt/jwt.xhtml
+   */
+  public function encode($payload, $keyIdOrTag = 'SIGN') {
+    $key = $this->getRegistry()->findKey($keyIdOrTag);
+    $alg = $this->suiteToAlg($key['suite']);
+    // Currently, registry only has symmetric keys in $key['key']. For public key-pairs, might need to change.
+    return JWT::encode($payload, $key['key'], $alg, $key['id']);
+  }
+
+  /**
+   * @param string $token
+   *   The JWT token.
+   * @param string $keyTag
+   *   Lookup valid keys from the CryptoRegistry using $keyTag.
+   * @return array
+   *   List of validated JWT claims.
+   * @throws CryptoException
+   */
+  public function decode($token, $keyTag = 'SIGN') {
+    $keyRows = $this->getRegistry()->findKeysByTag($keyTag);
+
+    // We want to call JWT::decode(), but there's a slight mismatch -- the
+    // registry contains whitelisted permutations of ($key,$alg), but
+    // JWT::decode() accepts all permutations ($keys x $algs).
+
+    // Grouping by alg will give proper granularity and also produces one
+    // call to JWT::decode() in typical usage.
+
+    // Defn: $keysByAlg[$alg][$keyId] === $keyData
+    $keysByAlg = [];
+    foreach ($keyRows as $key) {
+      if ($alg = $this->suiteToAlg($key['suite'])) {
+        // Currently, registry only has symmetric keys in $key['key']. For public key-pairs, might need to change.
+        $keysByAlg[$alg][$key['id']] = $key['key'];
+      }
+    }
+
+    foreach ($keysByAlg as $alg => $keys) {
+      try {
+        return (array) JWT::decode($token, $keys, [$alg]);
+      }
+      catch (\UnexpectedValueException $e) {
+        // Depending on the error, we might able to try other algos
+        if (
+          !preg_match(';unable to lookup correct key;', $e->getMessage())
+          &&
+          !preg_match(';Signature verification failed;', $e->getMessage())
+        ) {
+          // Keep our signature independent of the implementation.
+          throw new CryptoException(get_class($e) . ': ' . $e->getMessage());
+        }
+      }
+    }
+
+    throw new CryptoException('Signature verification failed');
+  }
+
+  /**
+   * @param string $suite
+   *   Ex: 'jwt-hs256', 'jwt-hs384'
+   * @return string
+   *   Ex: 'HS256', 'HS384'
+   */
+  protected static function suiteToAlg($suite) {
+    if (substr($suite, 0, 4) === 'jwt-') {
+      return strtoupper(substr($suite, 4));
+    }
+    else {
+      return NULL;
+    }
+  }
+
+  /**
+   * @return CryptoRegistry
+   */
+  protected function getRegistry(): CryptoRegistry {
+    if ($this->registry === NULL) {
+      $this->registry = \Civi::service('crypto.registry');
+    }
+    return $this->registry;
+  }
+
+}

--- a/Civi/Crypto/CryptoRegistry.php
+++ b/Civi/Crypto/CryptoRegistry.php
@@ -78,6 +78,13 @@ class CryptoRegistry {
       }
     }
 
+    if (defined('CIVICRM_SIGN_KEYS') && CIVICRM_SIGN_KEYS !== '') {
+      foreach (explode(' ', CIVICRM_SIGN_KEYS) as $n => $keyExpr) {
+        $key = ['tags' => ['SIGN'], 'weight' => $n];
+        $registry->addSymmetricKey($registry->parseKey($keyExpr) + $key);
+      }
+    }
+
     //if (isset($_COOKIE['CIVICRM_FORM_KEY'])) {
     //  $crypto->addSymmetricKey([
     //    'key' => base64_decode($_COOKIE['CIVICRM_FORM_KEY']),

--- a/composer.json
+++ b/composer.json
@@ -45,6 +45,7 @@
     "php": "~7.2",
     "cache/integration-tests": "~0.17.0",
     "dompdf/dompdf" : "~0.8",
+    "firebase/php-jwt": ">=3 <6",
     "electrolinux/phpquery": "^0.9.6",
     "symfony/config": "~3.0 || ~4.4",
     "symfony/polyfill-iconv": "~1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "82b5858849e9897be2cc6ab415600c90",
+    "content-hash": "2d1dfc8bddd169a9064a89c693bb5218",
     "packages": [
         {
             "name": "adrienrn/php-mimetyper",
@@ -667,6 +667,56 @@
             "description": "phpQuery is a server-side, chainable, CSS3 selector driven Document Object Model (DOM) API based on jQuery JavaScript Library",
             "homepage": "http://code.google.com/p/phpquery/",
             "time": "2013-03-21T12:39:33+00:00"
+        },
+        {
+            "name": "firebase/php-jwt",
+            "version": "v5.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/firebase/php-jwt.git",
+                "reference": "f42c9110abe98dd6cfe9053c49bc86acc70b2d23"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/firebase/php-jwt/zipball/f42c9110abe98dd6cfe9053c49bc86acc70b2d23",
+                "reference": "f42c9110abe98dd6cfe9053c49bc86acc70b2d23",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": ">=4.8 <=9"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Firebase\\JWT\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Neuman Vong",
+                    "email": "neuman+pear@twilio.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Anant Narayanan",
+                    "email": "anant@php.net",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A simple library to encode and decode JSON Web Tokens (JWT) in PHP. Should conform to the current spec.",
+            "homepage": "https://github.com/firebase/php-jwt",
+            "keywords": [
+                "jwt",
+                "php"
+            ],
+            "time": "2021-02-12T00:02:00+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",
@@ -3861,5 +3911,5 @@
     "platform-overrides": {
         "php": "7.2"
     },
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "1.1.0"
 }

--- a/setup/plugins/installFiles/GenerateSignKey.civi-setup.php
+++ b/setup/plugins/installFiles/GenerateSignKey.civi-setup.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * @file
+ *
+ * Generate the signing key(s).
+ */
+
+if (!defined('CIVI_SETUP')) {
+  exit("Installation plugins must only be loaded by the installer.\n");
+}
+
+\Civi\Setup::dispatcher()
+  ->addListener('civi.setup.installFiles', function (\Civi\Setup\Event\InstallFilesEvent $e) {
+    \Civi\Setup::log()->info(sprintf('[%s] Handle %s', basename(__FILE__), 'installFiles'));
+
+    $toAlphanum = function($bits) {
+      return preg_replace(';[^a-zA-Z0-9];', '', base64_encode($bits));
+    };
+
+  if (empty($e->getModel()->signKeys)) {
+    $e->getModel()->signKeys = ['jwt-hs256:hkdf-sha256:' . $toAlphanum(random_bytes(40))];
+    // toAlpanum() occasionally loses a few bits of entropy, but random_bytes() has significant excess, so it's still more than ample for 256 bit hkdf.
+  }
+
+  if (is_string($e->getModel()->signKeys)) {
+    $e->getModel()->signKeys = [$e->getModel()->signKeys];
+  }
+
+    \Civi\Setup::log()->info(sprintf('[%s] Done %s', basename(__FILE__), 'installFiles'));
+
+  }, \Civi\Setup::PRIORITY_PREPARE);

--- a/setup/plugins/installFiles/InstallSettingsFile.civi-setup.php
+++ b/setup/plugins/installFiles/InstallSettingsFile.civi-setup.php
@@ -99,6 +99,7 @@ if (!defined('CIVI_SETUP')) {
     $params['CMSdbSSL'] = empty($m->cmsDb['ssl_params']) ? '' : addslashes('&' . http_build_query($m->cmsDb['ssl_params'], '', '&', PHP_QUERY_RFC3986));
     $params['siteKey'] = addslashes($m->siteKey);
     $params['credKeys'] = addslashes(implode(' ', $m->credKeys));
+    $params['signKeys'] = addslashes(implode(' ', $m->signKeys));
 
     $extraSettings = array();
 

--- a/setup/src/Setup/Model.php
+++ b/setup/src/Setup/Model.php
@@ -30,6 +30,8 @@ namespace Civi\Setup;
  *   Ex: 'abcd1234ABCD9876'.
  * @property string[] $credKeys
  *   Ex: ['::abcd1234ABCD9876'].
+ * @property string[] $signKeys
+ *   Ex: ['jwt-hs256::abcd1234ABCD9876'].
  * @property string|NULL $lang
  *   The language of the default dataset.
  *   Ex: 'fr_FR'.
@@ -114,6 +116,11 @@ class Model {
     $this->addField(array(
       'description' => 'Credential encryption keys',
       'name' => 'credKeys',
+      'type' => 'array',
+    ));
+    $this->addField(array(
+      'description' => 'Signing keys',
+      'name' => 'signKeys',
       'type' => 'array',
     ));
     $this->addField(array(

--- a/templates/CRM/common/civicrm.settings.php.template
+++ b/templates/CRM/common/civicrm.settings.php.template
@@ -325,6 +325,27 @@ if (!defined('CIVICRM_CRED_KEYS') ) {
 }
 
 /**
+ * The signing key is used to generate and verify shareable tokens.
+ *
+ * This is a space-delimited list of keys (ordered by priority). Put the preferred
+ * key first. Any old/deprecated keys may be listed after.
+ *
+ * Each key is in format "<cipher-suite>:<key-encoding>:<key-content>", as in:
+ *
+ * Ex: define('CIVICRM_SIGN_KEYS', 'jwt-hs256:hkdf-sha256:RANDOM_1')
+ * Ex: define('CIVICRM_SIGN_KEYS', 'jwt-hs256::RANDOM_2 jwt-hs256::RANDOM_3')
+ * Ex: define('CIVICRM_SIGN_KEYS', 'jwt-hs256:b64:RANDOM_4 jwt-hs256:b64:RANDOM_5')
+ *
+ * If key-encoding is blank, it will default to "hkdf-sha256".
+ */
+if (!defined('CIVICRM_SIGN_KEYS') ) {
+  define( '_CIVICRM_SIGN_KEYS', '%%signKeys%%');
+  define( 'CIVICRM_SIGN_KEYS', _CIVICRM_SIGN_KEYS === '%%' . 'signKeys' . '%%' ? '' : _CIVICRM_SIGN_KEYS );
+  // Some old installers may not set a decent value, and this extra complexity is a failsafe.
+  // Feel free to simplify post-install.
+}
+
+/**
  * Enable this constant, if you want to send your email through the smarty
  * templating engine(allows you to do conditional and more complex logic)
  *

--- a/tests/phpunit/Civi/Crypto/CryptoJwtTest.php
+++ b/tests/phpunit/Civi/Crypto/CryptoJwtTest.php
@@ -1,0 +1,102 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Crypto;
+
+use Civi\Crypto\Exception\CryptoException;
+use Civi\Test\Invasive;
+use Firebase\JWT\JWT;
+
+/**
+ * Test major use-cases of the 'crypto.token' service.
+ */
+class CryptoJwtTest extends \CiviUnitTestCase {
+
+  use CryptoTestTrait;
+
+  protected function setUp() {
+    parent::setUp();
+    \CRM_Utils_Hook::singleton()->setHook('civicrm_crypto', [$this, 'registerExampleKeys']);
+    JWT::$timestamp = NULL;
+  }
+
+  public function testSignVerifyExpire() {
+    /** @var \Civi\Crypto\CryptoJwt $cryptoJwt */
+    $cryptoJwt = \Civi::service('crypto.jwt');
+
+    $enc = $cryptoJwt->encode([
+      'exp' => \CRM_Utils_Time::time() + 60,
+      'sub' => 'me',
+    ], 'SIGN-TEST');
+    $this->assertTrue(is_string($enc) && !empty($enc), 'CryptoJwt::encode() should return valid string');
+
+    $dec = $cryptoJwt->decode($enc, 'SIGN-TEST');
+    $this->assertTrue(is_array($dec) && !empty($dec));
+    $this->assertEquals('me', $dec['sub']);
+
+    JWT::$timestamp = \CRM_Utils_Time::time() + 90;
+    try {
+      $cryptoJwt->decode($enc, 'SIGN-TEST');
+      $this->fail('Expected decode to fail with exception');
+    }
+    catch (CryptoException $e) {
+      $this->assertRegExp(';Expired token;', $e->getMessage());
+    }
+  }
+
+  public function getMixKeyExamples() {
+    return [
+      ['SIGN-TEST', 'SIGN-TEST', TRUE],
+      ['sign-key-0', 'SIGN-TEST', TRUE],
+      ['sign-key-1', 'SIGN-TEST', TRUE],
+      ['sign-key-alt', 'SIGN-TEST', FALSE],
+    ];
+  }
+
+  /**
+   * @param $encKey
+   * @param $decKey
+   * @param $expectOk
+   * @throws \Civi\Crypto\Exception\CryptoException
+   * @dataProvider  getMixKeyExamples
+   */
+  public function testSignMixKeys($encKey, $decKey, $expectOk) {
+    /** @var \Civi\Crypto\CryptoJwt $cryptoJwt */
+    $cryptoJwt = \Civi::service('crypto.jwt');
+
+    $enc = $cryptoJwt->encode([
+      'exp' => \CRM_Utils_Time::time() + 60,
+      'sub' => 'me',
+    ], $encKey);
+    $this->assertTrue(is_string($enc) && !empty($enc), 'CryptoJwt::encode() should return valid string');
+
+    if ($expectOk) {
+      $dec = $cryptoJwt->decode($enc, $decKey);
+      $this->assertTrue(is_array($dec) && !empty($dec));
+      $this->assertEquals('me', $dec['sub']);
+    }
+    else {
+      try {
+        $cryptoJwt->decode($enc, $decKey);
+        $this->fail('Expected decode to fail with exception');
+      }
+      catch (CryptoException $e) {
+        $this->assertRegExp(';Signature verification failed;', $e->getMessage());
+      }
+    }
+  }
+
+  public function testSuiteToAlg() {
+    $this->assertEquals('HS256', Invasive::call([CryptoJwt::class, 'suiteToAlg'], ['jwt-hs256']));
+    $this->assertEquals(NULL, Invasive::call([CryptoJwt::class, 'suiteToAlg'], ['aes-cbc']));
+  }
+
+}

--- a/tests/phpunit/Civi/Crypto/CryptoTestTrait.php
+++ b/tests/phpunit/Civi/Crypto/CryptoTestTrait.php
@@ -19,6 +19,9 @@ trait CryptoTestTrait {
       'aes-cbc:hkdf-sha256:abcd1234abcd1234',
       'aes-ctr::abcd1234abcd1234',
       'aes-cbc-hs::abcd1234abcd1234',
+      'jwt-hs256::abcd1234abcd1234',
+      'jwt-hs384:b64:8h5wNGnJbdVHpXms2RwcVx+jxCNdYEsYCdNlPpVgNLRMg9Q2xKYnxSfuihS6YCRi',
+      'jwt-hs256::fdsafdsafdsa',
     ];
   }
 
@@ -56,8 +59,27 @@ trait CryptoTestTrait {
     ]);
     $this->assertEquals(0, $key['weight']);
 
-    $this->assertEquals(4, count($examples));
-    $this->assertEquals(4 + $origCount, count($registry->getKeys()));
+    $key = $registry->addSymmetricKey($registry->parseKey($examples[4]) + [
+      'tags' => ['SIGN-TEST'],
+      'id' => 'sign-key-1',
+      'weight' => 1,
+    ]);
+    $this->assertEquals(1, $key['weight']);
+
+    $key = $registry->addSymmetricKey($registry->parseKey($examples[4]) + [
+      'tags' => ['SIGN-TEST'],
+      'id' => 'sign-key-0',
+    ]);
+    $this->assertEquals(0, $key['weight']);
+
+    $key = $registry->addSymmetricKey($registry->parseKey($examples[4]) + [
+      'tags' => ['SIGN-TEST-ALT'],
+      'id' => 'sign-key-alt',
+    ]);
+    $this->assertEquals(0, $key['weight']);
+
+    $this->assertEquals(7, count($examples));
+    $this->assertEquals(7 + $origCount, count($registry->getKeys()));
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
This introduces a mechanism for working with JSON Web Tokens (https://jwt.io/introduction). It enables a dataflow in which:

1. CiviCRM generates a signed token with a flexible list of [security claims](https://tools.ietf.org/html/rfc7519#section-4) (e.g. expiration-time).
2. CiviCRM gives the token to a consumer app (e.g. browser, remote server, or mobile app).
3. Later on, the consumer app submits the token CiviCRM.
4. CiviCRM verifies that the token is properly signed and current - then reports back any claims.

The process requires that CiviCRM has a private signing key. The PR introduces a configuration element `CIVICRM_SIGN_KEYS` to track this. 

The encoding and validation of JWT is handled via [firebase/php-jwt](https://github.com/firebase/php-jwt).

Before
----------------------------------------

No support for JWT.

After
----------------------------------------

For system administrators -- the installer and upgrader encourage one to setup `CIVICRM_SIGN_KEYS` in `civicrm.settings.php`, e.g.

```php
define('CIVICRM_SIGN_KEYS', 'jwt-hs256:b64:ABCDefgh1234==');
define('CIVICRM_SIGN_KEYS', 'jwt-hs256:hkdf-sha256:ABCDefgh1234');
```

For developers -- one may generate and verify JWTs with the `crypto.jwt` service, e.g.

```php
// 1. Generate a token. It expires in 60 seconds.
$token = \Civi::service('crypto.jwt')->encode([
  'exp' => \CRM_Utils_Time::time() + 60,
  'sub' => 'me',
], $encKey);

// 2. Verify a token
$claims = \Civi::service('crypto.jwt')->decode($token);
// ^^ If that call succeeds, then the token has a valid signature, and we can trust its claims.
printf("The other party is %s.\n", $claims['sub']);
```

Comments
----------------------------------------

* This PR only introduces the baseline support for encoding and decoding tokens. The use-cases for JWT are somewhat open-ended. For example, #19590 would use JWT for authenticating HTTP/API calls.
* As with `CIVICRM_CRED_KEYS`, we'll want to update a few more installers (eg drush/wp-cli/joomla). But it should be safe to merge this before opening the follow-up PRs in other repos.