### PR TITLE
Use specific function when formatting money for a default

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -1187,7 +1187,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
         if ($field['data_type'] == 'Money' && isset($value)) {
           // $value can also be an array(while using IN operator from search builder or api).
           foreach ((array) $value as $val) {
-            $disp[] = CRM_Utils_Money::format($val, NULL, NULL, TRUE);
+            $disp[] = CRM_Utils_Money::formatLocaleNumericRoundedForDefaultCurrency($val);
           }
           $display = implode(', ', $disp);
         }

--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -1383,7 +1383,7 @@ ORDER BY civicrm_custom_group.weight,
             elseif ($field['data_type'] == 'Money' &&
               $field['html_type'] == 'Text'
             ) {
-              $defaults[$elementName] = CRM_Utils_Money::format($value, NULL, '%a');
+              $defaults[$elementName] = CRM_Utils_Money::formatLocaleNumericRoundedForDefaultCurrency($value);
             }
             else {
               $defaults[$elementName] = $value;

--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -488,7 +488,7 @@ DESC limit 1");
       // - set the max related block
       $allMembershipInfo[$key] = [
         'financial_type_id' => $values['financial_type_id'] ?? NULL,
-        'total_amount' => CRM_Utils_Money::format($totalAmount, NULL, '%a'),
+        'total_amount' => CRM_Utils_Money::formatLocaleNumericRoundedForDefaultCurrency($totalAmount),
         'total_amount_numeric' => $totalAmount,
         'auto_renew' => $values['auto_renew'] ?? NULL,
         'has_related' => isset($values['relationship_type_id']),

--- a/CRM/Member/Form/MembershipConfig.php
+++ b/CRM/Member/Form/MembershipConfig.php
@@ -52,7 +52,7 @@ class CRM_Member_Form_MembershipConfig extends CRM_Core_Form {
     }
 
     if (isset($defaults['minimum_fee'])) {
-      $defaults['minimum_fee'] = CRM_Utils_Money::format($defaults['minimum_fee'], NULL, '%a');
+      $defaults['minimum_fee'] = CRM_Utils_Money::formatLocaleNumericRoundedForDefaultCurrency($defaults['minimum_fee']);
     }
 
     if (isset($defaults['status'])) {

--- a/CRM/Member/Page/AJAX.php
+++ b/CRM/Member/Page/AJAX.php
@@ -46,7 +46,7 @@ WHERE   id = %1";
     }
     $details['total_amount_numeric'] = $details['total_amount'];
     // fix the display of the monetary value, CRM-4038
-    $details['total_amount'] = CRM_Utils_Money::format($details['total_amount'], NULL, '%a');
+    $details['total_amount'] = CRM_Utils_Money::formatLocaleNumericRoundedForDefaultCurrency($details['total_amount']);
     $options = CRM_Core_SelectValues::memberAutoRenew();
     $details['auto_renew'] = $options[$details]['auto_renew'] ?? NULL;
     CRM_Utils_JSON::output($details);

--- a/CRM/Member/Tokens.php
+++ b/CRM/Member/Tokens.php
@@ -79,7 +79,7 @@ class CRM_Member_Tokens extends \Civi\Token\AbstractTokenSubscriber {
       $row->tokens($entity, $field, \CRM_Utils_Date::customFormat($actionSearchResult->$field));
     }
     elseif ($field == 'fee') {
-      $row->tokens($entity, $field, \CRM_Utils_Money::format($actionSearchResult->$field, NULL, NULL, TRUE));
+      $row->tokens($entity, $field, \CRM_Utils_Money::formatLocaleNumericRoundedForDefaultCurrency($actionSearchResult->$field));
     }
     elseif (isset($actionSearchResult->$field)) {
       $row->tokens($entity, $field, $actionSearchResult->$field);

--- a/CRM/PCP/Form/Campaign.php
+++ b/CRM/PCP/Form/Campaign.php
@@ -65,7 +65,7 @@ class CRM_PCP_Form_Campaign extends CRM_Core_Form {
       }
       // fix the display of the monetary value, CRM-4038
       if (isset($defaults['goal_amount'])) {
-        $defaults['goal_amount'] = CRM_Utils_Money::format($defaults['goal_amount'], NULL, '%a');
+        $defaults['goal_amount'] = CRM_Utils_Money::formatLocaleNumericRoundedForDefaultCurrency($defaults['goal_amount']);
       }
 
       $defaults['pcp_title'] = $defaults['title'] ?? NULL;


### PR DESCRIPTION
Overview
----------------------------------------
Use specific function when formatting money for a default


Before
----------------------------------------
Uses the Money::format(..) to format the money without currency. or expects only number

After
----------------------------------------
Replace with CRM_Utils_Money::formatLocaleNumericRoundedForDefaultCurrency(..) 

Comments
----------------------------------------
ping @eileenmcnaughton @mattwire 