### PR TITLE
core#2226: Scheduled Reminder fails to send if From Name includes comma

### DIFF
--- a/CRM/Core/BAO/ActionSchedule.php
+++ b/CRM/Core/BAO/ActionSchedule.php
@@ -588,7 +588,7 @@ FROM civicrm_action_schedule cas
     $domainValues = CRM_Core_BAO_Domain::getNameAndEmail();
     $fromEmailAddress = "$domainValues[0] <$domainValues[1]>";
     if ($actionSchedule->from_email) {
-      $fromEmailAddress = "$actionSchedule->from_name <$actionSchedule->from_email>";
+      $fromEmailAddress = "\"$actionSchedule->from_name\" <$actionSchedule->from_email>";
       return $fromEmailAddress;
     }
     return $fromEmailAddress;


### PR DESCRIPTION
Overview
----------------------------------------
Scheduled Reminder fails to send if From Name includes comma

Before
----------------------------------------
Include comma in From name while composing schedule reminder. Cron job fails 

After
----------------------------------------
Quote the from name. No cron failure

Technical Details
----------------------------------------
Ref.- https://github.com/civicrm/civicrm-core/blob/master/CRM/Mailing/BAO/Mailing.php#L994

Comments
----------------------------------------
@eileenmcnaughton @larssandergreen @jaapjansma 
