### PR TITLE
core#2309: Validate weight and weight threshold

### DIFF
--- a/CRM/Contact/Form/DedupeRules.php
+++ b/CRM/Contact/Form/DedupeRules.php
@@ -136,10 +136,14 @@ class CRM_Contact_Form_DedupeRules extends CRM_Admin_Form {
   public static function formRule($fields, $files, $self) {
     $errors = [];
     $fieldSelected = FALSE;
+    $actualThreshold = 0;
     for ($count = 0; $count < self::RULES_COUNT; $count++) {
       if (!empty($fields["where_$count"]) || (isset($self->_defaults['is_reserved']) && !empty($self->_defaults["where_$count"]))) {
         $fieldSelected = TRUE;
         break;
+      }
+      if (!empty($self->_defaults["weight_$count"])) {
+        $actualThreshold += $self->_defaults["weight_$count"];
       }
     }
     if (empty($fields['threshold'])) {
@@ -147,6 +151,11 @@ class CRM_Contact_Form_DedupeRules extends CRM_Admin_Form {
       if (!(CRM_Utils_Array::value('is_reserved', $fields) &&
         CRM_Utils_File::isIncludable("CRM/Dedupe/BAO/QueryBuilder/{$self->_defaultValues['name']}.php"))) {
         $errors['threshold'] = ts('Threshold weight cannot be empty or zero.');
+      }
+    }
+    else {
+      if ($actualThreshold < $fields['threshold']) {
+        $errors['threshold'] = ts('Total weight must be greater than or equal to the Weight Threshold.');
       }
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
CiviCRM Find and Merge Duplicate Contacts, does not validate the weight and weight threshold, possible to set a weight threshold which can never be achieved. Resulting in a defunct duplicate matching rule and lots of duplicate contacts.

Before
----------------------------------------
Doesn't Validate the field weight(s) with weight threshold:


After
----------------------------------------
Validate the field weight(s) with weight threshold
<img width="1323" alt="Screenshot 2021-02-15 at 9 37 04 PM" src="https://user-images.githubusercontent.com/3735621/107969827-4b2f2f00-6fd6-11eb-9816-560d617ec89a.png">

Comments
----------------------------------------
ping @eileenmcnaughton @jusfreeman 