### PR TITLE
[NFC/Unit Test] Fix passing test that should pass but also should fail

### DIFF
--- a/tests/phpunit/CRM/Case/BAO/CaseTest.php
+++ b/tests/phpunit/CRM/Case/BAO/CaseTest.php
@@ -104,7 +104,16 @@ class CRM_Case_BAO_CaseTest extends CiviUnitTestCase {
     $caseRoles = CRM_Case_BAO_Case::getCaseRoles($loggedInUser, $caseId);
 
     $this->assertEquals($caseCount, $upcomingCases, 'Upcoming case count must be ' . $caseCount);
-    $this->assertEquals($caseCount, $summary['rows']['Housing Support']['Ongoing']['count'], 'Housing Support Ongoing case summary must be ' . $caseCount);
+    if ($caseCount === 0) {
+      // If there really are 0 cases then there won't be any subelements for
+      // status and count, so we get a false error if we use the assertEquals
+      // check since it tries to get a subelement on type int. In this case
+      // the summary rows are just the case type pseudoconstant list.
+      $this->assertSame(array_flip(CRM_Case_PseudoConstant::caseType()), $summary['rows']);
+    }
+    else {
+      $this->assertEquals($caseCount, $summary['rows']['Housing Support']['Ongoing']['count'], 'Housing Support Ongoing case summary must be ' . $caseCount);
+    }
     $this->assertEquals($caseCount, count($caseRoles), 'Total case roles for logged in users must be ' . $caseCount);
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
It should pass because the test itself seems good. But it should fail because it's comparing something that in php < 7.4 silently casts to 0 and so happens to assertEqual to 0. In php 7.4 it correctly points out that it's trying to access an array key on a variable of type int.

CRM_Case_BAO_CaseTest::testInactiveCaseRole
Notice: Trying to access array offset on value of type int ... line 107