### PR TITLE
WordPress - If we hit a "permission denied" error, return HTTP 403

### DIFF
--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -503,6 +503,7 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
    * @throws \CRM_Core_Exception
    */
   public function permissionDenied() {
+    status_header(403);
     throw new CRM_Core_Exception(ts('You do not have permission to access this page.'));
   }
 


### PR DESCRIPTION
Overview
--------

On WordPress, any CiviCRM page that produces a "permission denied" shows a message about the failure -- but the HTTP status code is 200. This incorrectly signals that the request was successful. The patch sends a more semantically correct 403.

The misleading status-code was problematic while working #19590 which adds some significant test-coverage for various (un)authenticated states (`Civi\Authx\AllFlowsTest`). Consequently, there is relevant E2E test-coverage in that PR.

Before
------

```
$ curl -vv 'http://wpmaster.127.0.0.1.nip.io:8001/civicrm/dashboard' 2>&1 |grep HTTP
> GET /civicrm/dashboard HTTP/1.1
< HTTP/1.1 200 OK
```

After
-----

```
$ curl -vv 'http://wpmaster.127.0.0.1.nip.io:8001/civicrm/dashboard' 2>&1 |grep HTTP
> GET /civicrm/dashboard HTTP/1.1
< HTTP/1.1 403 Forbidden
```
