### PR TITLE
Add contactlayouteditor to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ tools/scripts/releaser/releaser.conf
 tools/tests/reports/logfile.tap
 tools/tests/reports/testdox.html
 tools/tests/reports/testdox.txt
+tools/extensions/org.civicrm.contactlayout
 l10n
 vendor
 civicrm.settings.php


### PR DESCRIPTION

Overview
----------------------------------------
Add contactlayouteditor to gitignore

Before
----------------------------------------
After a buildkit install 

![image](https://user-images.githubusercontent.com/336308/108144547-d02d5c00-712e-11eb-8347-27468303102d.png)


After
----------------------------------------
Clean git repo after buildkit install

Technical Details
----------------------------------------
This is put in the tools directory during a buildkit install but we don't want to
accidentally commit it

Comments
----------------------------------------
