### PR TITLE
Afform - SearchKit support for calculated fields

### DIFF
--- a/Civi/Api4/Query/Api4SelectQuery.php
+++ b/Civi/Api4/Query/Api4SelectQuery.php
@@ -103,6 +103,9 @@ class Api4SelectQuery {
     // Add ACLs first to avoid redundant subclauses
     $baoName = CoreUtil::getBAOFromApiName($this->getEntity());
     $this->query->where($this->getAclClause(self::MAIN_TABLE_ALIAS, $baoName));
+
+    // Add explicit joins. Other joins implied by dot notation may be added later
+    $this->addExplicitJoins();
   }
 
   /**
@@ -113,8 +116,6 @@ class Api4SelectQuery {
    * @throws \CRM_Core_Exception
    */
   public function getSql() {
-    // Add explicit joins. Other joins implied by dot notation may be added later
-    $this->addExplicitJoins();
     $this->buildSelectClause();
     $this->buildWhereClause();
     $this->buildOrderBy();
@@ -152,7 +153,6 @@ class Api4SelectQuery {
    * @throws \API_Exception
    */
   public function getCount() {
-    $this->addExplicitJoins();
     $this->buildWhereClause();
     // If no having or groupBy, we only need to select count
     if (!$this->getHaving() && !$this->getGroupBy()) {

--- a/ext/afform/admin/ang/afGuiEditor/afGuiSearch.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiSearch.component.js
@@ -13,6 +13,7 @@
       var ctrl = this;
       $scope.controls = {};
       $scope.fieldList = [];
+      $scope.calcFieldList = [];
       $scope.blockList = [];
       $scope.blockTitles = [];
       $scope.elementList = [];
@@ -22,10 +23,20 @@
 
       this.buildPaletteLists = function() {
         var search = $scope.controls.fieldSearch ? $scope.controls.fieldSearch.toLowerCase() : null;
+        buildCalcFieldList(search);
         buildFieldList(search);
         buildBlockList(search);
         buildElementList(search);
       };
+
+      function buildCalcFieldList(search) {
+        $scope.calcFieldList.length = 0;
+        _.each(_.cloneDeep(ctrl.display.calc_fields), function(field) {
+          if (!search || _.contains(field.defn.label.toLowerCase(), search)) {
+            $scope.calcFieldList.push(field);
+          }
+        });
+      }
 
       function buildBlockList(search) {
         $scope.blockList.length = 0;

--- a/ext/afform/admin/ang/afGuiEditor/afGuiSearch.html
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiSearch.html
@@ -21,6 +21,14 @@
           </div>
         </div>
       </div>
+      <div ng-if="calcFieldList.length">
+        <label>{{:: ts('Calculated Fields') }}</label>
+        <div ui-sortable="{update: buildPaletteLists, items: '&gt; div:not(.disabled)', connectWith: '[ui-sortable]', placeholder: 'af-gui-dropzone'}" ui-sortable-update="$ctrl.editor.onDrop" ng-model="calcFieldList">
+          <div ng-repeat="field in calcFieldList" ng-class="{disabled: fieldInUse(field.name)}">
+            {{:: field.defn.label }}
+          </div>
+        </div>
+      </div>
       <div ng-repeat="fieldGroup in fieldList">
         <div ng-if="fieldGroup.fields.length">
           <label>{{:: fieldGroup.label }}</label>

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
@@ -26,13 +26,14 @@
         $scope.meta = afGui.meta;
       };
 
-      // $scope.getEntity = function() {
-      //   return ctrl.editor ? ctrl.editor.getEntity(ctrl.container.getEntityName()) : {};
-      // };
-
       // Returns the original field definition from metadata
       this.getDefn = function() {
-        return ctrl.editor ? afGui.getField(ctrl.container.getFieldEntityType(ctrl.node.name), ctrl.node.name) : {};
+        var defn = afGui.getField(ctrl.container.getFieldEntityType(ctrl.node.name), ctrl.node.name);
+        return defn ||  {
+          label: ts('Untitled'),
+          requred: false,
+          input_attrs: []
+        };
       };
 
       $scope.getOriginalLabel = function() {


### PR DESCRIPTION
Overview
----------------------------------------
Adds support for calculated fields as afform search filters. E.g. an aggregated field like `SUM: Contribution Total Amount` can now be dragged into the search form from the afform palette.

See https://lab.civicrm.org/dev/core/-/issues/2361

![image](https://user-images.githubusercontent.com/2874912/108146514-5ef09900-709b-11eb-83dc-bcf41be78213.png)
