### PR TITLE
Fix on recently merged asset builder catch patch

### DIFF
--- a/Civi/Core/AssetBuilder.php
+++ b/Civi/Core/AssetBuilder.php
@@ -195,7 +195,7 @@ class AssetBuilder {
       }
       catch (UnknownAssetException $e) {
         // unexpected error, log and continue
-        Civi::log()->error('Unexpected error while rendering a file in the AssetBuilder: ' . $e->getMessage(), ['exception' => $e]);
+        \Civi::log()->error('Unexpected error while rendering a file in the AssetBuilder: ' . $e->getMessage(), ['exception' => $e]);
       }
     }
     return $fileName;


### PR DESCRIPTION


Overview
----------------------------------------
Fixes an obscure in-master-only regression (albeit it's not worse that before the change)

This log line got added in review & I think not tested. Only in master

https://github.com/civicrm/civicrm-core/pull/18830

Before
----------------------------------------

![image](https://user-images.githubusercontent.com/336308/108156354-653b4f80-7145-11eb-8cd7-f2f7c4976d64.png)

After
----------------------------------------
No fatal error - site loads (albeit without a menu as whatever is the problem with my menu is the reason that asset builder is failing)

Technical Details
----------------------------------------
https://github.com/civicrm/civicrm-core/pull/18830/commits/f555d59e9536cc2f611a32a49f9990300d6a779b

Comments
----------------------------------------
