### PR TITLE
Ensure dispatcher has loaded listeners

### DIFF
--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -569,7 +569,8 @@ class Container {
         $container->set($name, $obj);
       }
       \Civi::$statics[__CLASS__]['container'] = $container;
-      // Ensure api factory has loaded (in case other roots have been bypassed)
+      // Ensure all container-based serivces have a chance to add their listeners.
+      // Without this, it's a matter of happenstance (dependent upon particular page-request/configuration/etc).
       $container->get('dispatcher');
 
     }

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -569,6 +569,9 @@ class Container {
         $container->set($name, $obj);
       }
       \Civi::$statics[__CLASS__]['container'] = $container;
+      // Ensure api factory has loaded (in case other roots have been bypassed)
+      $container->get('dispatcher');
+
     }
     else {
       $bootServices['dispatcher.boot']->setDispatchPolicy($mainDispatchPolicy);


### PR DESCRIPTION
Overview
----------------------------------------
Fixes an edge case where the dispatcher can fail to load listeners

Before
----------------------------------------
The edge case I experienced was assetBuilder listeners failing to fire on a new civibuild  - notably no menu or angular pages

After
----------------------------------------
listeners firing

Technical Details
----------------------------------------
We didn't quite get to the bottom of why this was occurring on my site

Comments
----------------------------------------
