### PR TITLE
Joomla - Implement getUfId(). Fix `@user:<name>`.

### DIFF
--- a/CRM/Utils/System/Joomla.php
+++ b/CRM/Utils/System/Joomla.php
@@ -456,6 +456,12 @@ class CRM_Utils_System_Joomla extends CRM_Utils_System_Base {
     return TRUE;
   }
 
+  public function getUfId($username) {
+    jimport('joomla.user.helper');
+    $uid = JUserHelper::getUserId($username);
+    return empty($uid) ? NULL : $uid;
+  }
+
   /**
    * FIXME: Use CMS-native approach
    * @throws \CRM_Core_Exception.


### PR DESCRIPTION
Overview
--------

APIv3 includes shorthand support for referencing a contact by their username, e.g.

```
cv api contact.get id=@user:admin return=display_name
```

Before
------

On Joomla, this emits an error because `getUfId($username):int` is not implemented.

After
-----

On Joomla, this works.

Comments
--------

There is implicit E2E test-coverage in the pending work for authx (#19590).
