### PR TITLE
Joomla - Allow E2E unit-test. Use Joomla Session API (and fake it when neceesary)

### DIFF
--- a/CRM/Utils/FakeJoomlaSession.php
+++ b/CRM/Utils/FakeJoomlaSession.php
@@ -1,0 +1,108 @@
+<?php
+jimport('joomla.session.handler.interface');
+
+class CRM_Utils_FakeJoomlaSession implements JSessionHandlerInterface {
+
+  /**
+   * This consumer's session ID.
+   *
+   * @var  string
+   */
+  protected $id = '';
+
+  /**
+   * Logical session name
+   *
+   * @var  string
+   */
+  protected $name;
+
+  /**
+   * @var  array
+   */
+  protected $data = array();
+
+  /**
+   * Constructor.
+   *
+   * @param string $name Session name
+   */
+  public function __construct($name = 'FAKE') {
+    $this->name = $name;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function start() {
+    if (empty($this->id)) {
+      $this->setId($this->generateId());
+    }
+
+    return TRUE;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function regenerate($destroy = FALSE, $lifetime = NULL) {
+    $this->id = $this->generateId();
+    return TRUE;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function getId() {
+    return $this->id;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function setId($id) {
+    $this->id = $id;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function getName() {
+    return $this->name;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function setName($name) {
+    $this->name = $name;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function save() {
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function clear() {
+    $this->data = array();
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function isStarted() {
+    return TRUE;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  protected function generateId() {
+    return hash('sha256', random_bytes(32));
+  }
+
+}

--- a/CRM/Utils/System/Joomla.php
+++ b/CRM/Utils/System/Joomla.php
@@ -465,10 +465,17 @@ class CRM_Utils_System_Joomla extends CRM_Utils_System_Base {
   }
 
   /**
+   * Start a new session.
+   */
+  public function sessionStart() {
+    JFactory::getSession()->start();
+  }
+
+  /**
    * @inheritDoc
    */
   public function logout() {
-    session_destroy();
+    JFactory::getSession()->destroy();
     CRM_Utils_System::setHttpHeader("Location", "index.php");
   }
 
@@ -586,6 +593,10 @@ class CRM_Utils_System_Joomla extends CRM_Utils_System_Base {
     if (!defined('JDEBUG')) {
       define('JDEBUG', FALSE);
     }
+
+    // loadBootStrap() is only used for `extern` scripts like 'rest.php' or 'open.php'
+    // which should not have sessions.
+    JFactory::getSession()->setHandler(new CRM_Utils_FakeJoomlaSession('CIVISCRIPT'));
 
     // Set timezone for Joomla on Cron
     $config = JFactory::getConfig();


### PR DESCRIPTION
Overview
--------

The goal of this work is to allow running some end-to-end tests on Joomla with PHPUnit+cv. Specifically, it's aimed at the `authx` test (#19590).

The effect and approach involves realigning APIs -- ensuring that the Joomla integration uses the Joomla Session APIs instead of the PHP Session APIs.

Before
------

* When running authx E2E test on Joomla, the phpunit process emits warnings   and/or failures about session management.

* If Civi needs to request that a session be started or ended, it uses the PHP Session APIs (eg `session_start()`). This *mostly* lines up with what Joomla does (since its default behavior is to wrap PHP Session APIs).

* There are a few use-cases based on `loadBootstrap()` -- namely, CLI (`cv`, `phpunit`, `bin/cli.php`) and extern (`extern/rest.php`, `extern/url.php`, etc).  In all these cases, it is not desirable to start standard PHP session. But you may get one incidentally.

After
-----

* When running authx E2E test on Joomla, the phpunit process has no warnings or failures about session management.

* If Civi needs to request that a session be started or ended, it uses Joomla Session APIs (e.g. `JFactory::getSession()->start();`).  For normal/default scenarios, this still passes through to the PHP Session API.  Importantly, if there's an alternative session-handler, then it will be respected.

* The use-cases based on `loadBootstrap()` (CLI + extern) now use an ephemeral session with fake data storage. The technique is inspired by the technique used in Joomla's upstream unit-testing.

Comments
--------

You might ask -- if CLI and extern scripts do not merit session-handling, then why bother with the fake/ephemeral session object?  Wouldn't it be cleaner to omit all mention of session-handling?  The main reason: user-integration.  Any services that involve the "current user" will check the session.  Thus, even if the process is substantively stateless/sessionless, it must still have 'session' object for identifying the current user.
