### PR TITLE
dev/core#2389 SearchKit - Show edit link to searchDisplay afforms

### DIFF
--- a/ext/search/ang/crmSearchAdmin/searchList.controller.js
+++ b/ext/search/ang/crmSearchAdmin/searchList.controller.js
@@ -13,7 +13,7 @@
     }, {});
 
     this.searchPath = CRM.url('civicrm/search');
-    this.newFormPath = CRM.url('civicrm/admin/afform');
+    this.afformPath = CRM.url('civicrm/admin/afform');
 
     this.encode = function(params) {
       return encodeURI(angular.toJson(params));
@@ -47,6 +47,8 @@
             ctrl.afforms[searchName[1]] = ctrl.afforms[searchName[1]] || [];
             ctrl.afforms[searchName[1]].push({
               title: afform.title,
+              name: afform.name,
+              // FIXME: This is the view url, currently not exposed to the UI, as BS3 doesn't support submenus.
               url: afform.server_route ? CRM.url(afform.server_route) : null
             });
           }

--- a/ext/search/ang/crmSearchAdmin/searchList.html
+++ b/ext/search/ang/crmSearchAdmin/searchList.html
@@ -52,7 +52,7 @@
             </button>
             <ul class="dropdown-menu">
               <li ng-repeat="display_name in search.display_name" ng-if="::$ctrl.afformAdminEnabled">
-                <a href="{{:: $ctrl.newFormPath + '#/create/search/' + search.name + '.' + display_name }}">
+                <a href="{{:: $ctrl.afformPath + '#/create/search/' + search.name + '.' + display_name }}">
                   <i class="fa fa-plus"></i> {{:: ts('Create form for %1', {1: search.display_label[$index]}) }}
                 </a>
               </li>
@@ -63,9 +63,9 @@
                   <em ng-if="$ctrl.afforms && !$ctrl.afforms[search.name]">{{:: ts('None Found') }}</em>
                 </a>
               </li>
-              <li ng-if="$ctrl.afforms" ng-repeat="afform in $ctrl.afforms[search.name]" ng-class="{disabled: !afform.url}" title="{{:: afform.url ? ts('Open form in new tab') : ts('This form does not have a page') }}">
-                <a href="{{:: afform.url }}" target="_blank">
-                  <i class="crm-i {{:: afform.url ? 'fa-external-link' : 'fa-list-alt' }}"></i>
+              <li ng-if="$ctrl.afforms" ng-repeat="afform in $ctrl.afforms[search.name]" title="{{:: ts('Edit form') }}">
+                <a href="{{:: $ctrl.afformPath + '#/edit/' + afform.name }}">
+                  <i class="crm-i fa-pencil-square-o"></i>
                   {{:: afform.title }}
                 </a>
               </li>


### PR DESCRIPTION
Overview
----------------------------------------
Show edit rather than view links to afforms on the SearchKit admin page.

See https://lab.civicrm.org/dev/core/-/issues/2389

Before
----------------------------------------
![Screenshot from 2021-02-17 08-46-12](https://user-images.githubusercontent.com/2874912/108213396-f934f900-70fc-11eb-8e78-2fef0adba1fa.png)


After
----------------------------------------
![Screenshot from 2021-02-17 08-45-28](https://user-images.githubusercontent.com/2874912/108213410-fd611680-70fc-11eb-9d95-5e67e3b57095.png)

Comments
----------------------------------------
I can't think of a good way to also show the view links in the same menu as BS3 doesn't support submenus, so I just left it as a fixme in the code for now.