### PR TITLE
Code fix and Test for dev/searchandreport#53

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ sql/dummy_processor.mysql
 distmaker/distmaker.conf
 distmaker/out
 /tmp
+/.idea/

--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -2635,6 +2635,8 @@ class CRM_Contact_BAO_Query {
 
       $from .= ' ' . trim(self::getEntitySpecificJoins($name, $mode, $side, $primaryLocation)) . ' ';
     }
+
+    $from .= self::getCaseTypeAndActivityTypeJoin($tables);
     return $from;
   }
 
@@ -2808,6 +2810,24 @@ class CRM_Contact_BAO_Query {
         return $from;
     }
   }
+
+
+  /**
+   * The join statement required when both CaseType and ActivityType are specified
+   * https://lab.civicrm.org/dev/report/-/issues/53
+   *
+   * @param array $tables
+   * @return string
+   */
+  protected static function getCaseTypeAndActivityTypeJoin($tables) {
+    $join_statement = "";
+    if (array_key_exists("civicrm_case",$tables) && array_key_exists("civicrm_activity",$tables)){
+      $join_statement = "\n INNER JOIN civicrm_case_activity";
+      $join_statement .= "\nON (civicrm_case_activity.case_id = civicrm_case.id AND civicrm_case_activity.activity_id = civicrm_activity.id)\n";
+    }
+    return $join_statement;
+  }
+
 
   /**
    * WHERE / QILL clause for deleted_contacts

--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -2810,8 +2810,7 @@ class CRM_Contact_BAO_Query {
         return $from;
     }
   }
-
-
+  
   /**
    * The join statement required when both CaseType and ActivityType are specified
    * https://lab.civicrm.org/dev/report/-/issues/53
@@ -2821,13 +2820,12 @@ class CRM_Contact_BAO_Query {
    */
   protected static function getCaseTypeAndActivityTypeJoin($tables) {
     $join_statement = "";
-    if (array_key_exists("civicrm_case",$tables) && array_key_exists("civicrm_activity",$tables)){
+    if (array_key_exists("civicrm_case", $tables) && array_key_exists("civicrm_activity", $tables)) {
       $join_statement = "\n INNER JOIN civicrm_case_activity";
       $join_statement .= "\nON (civicrm_case_activity.case_id = civicrm_case.id AND civicrm_case_activity.activity_id = civicrm_activity.id)\n";
     }
     return $join_statement;
   }
-
 
   /**
    * WHERE / QILL clause for deleted_contacts

--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -2810,7 +2810,7 @@ class CRM_Contact_BAO_Query {
         return $from;
     }
   }
-  
+
   /**
    * The join statement required when both CaseType and ActivityType are specified
    * https://lab.civicrm.org/dev/report/-/issues/53

--- a/tests/phpunit/CRM/Contact/BAO/QueryAdvancedSearchTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/QueryAdvancedSearchTest.php
@@ -1,0 +1,121 @@
+<?php
+
+/**
+ *  Test class for Advanced Searches
+ *
+ * @group headless
+ */
+class CRM_Contact_BAO_QueryAdvancedSearchTest extends CiviCaseTestCase {
+  protected $_params;
+  protected $_entity;
+  protected $_apiversion = 3;
+  protected $followup_activity_type_value;
+  /**
+   * Activity ID of created case.
+   *
+   * @var int
+   */
+  protected $_caseActivityId;
+
+  /**
+   * @var \Civi\Core\SettingsStack
+   */
+  protected $settingsStack;
+
+  /**
+   * Test setup for every test.
+   *
+   * Connect to the database, truncate the tables that will be used
+   * and redirect stdin to a temporary file.
+   */
+  public function setUp() {
+    $this->_entity = 'case';
+
+    parent::setUp();
+
+    $this->settingsStack = new \Civi\Core\SettingsStack();
+  }
+
+  public function tearDown() {
+    $this->settingsStack->popAll();
+    parent::tearDown();
+  }
+
+  /**
+   *  Checks that CRM_Contact_BAO_Query::getCaseTypeAndActivityTypeJoin()
+   *  adds the join needed when both CaseType and ActivityType are specified
+   *  https://lab.civicrm.org/dev/report/-/issues/53
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testCaseTypeAndActivityTypeSearch() {
+    // Collect the ids from the test database that are needed in the search
+    $contact = $this-> callAPIsuccess('contact', 'get', ['display_name' => 'Test Contact']);
+    $contact_id = $contact['id'];
+    $medical = $this->callAPISuccess('OptionValue', 'Get', ['name' => 'Medical evaluation']);
+    $option_value_id = $medical['id'];
+    $medical_activity_type_id = $medical['values'][$option_value_id]['value'];
+    $housing_case_type = $this->callAPISuccess('case_type', 'get', ['name' => 'housing_support']);
+    $housing_case_type_id = $housing_case_type['id'];
+
+    // Two new cases of different CaseTypes for the same contact
+    // By default both are created with a Medical evaluation activity scheduled
+    $params = [
+      'contact_id' => $contact_id,
+      'case_type' => "housing_support",
+      'subject' => "HousingSupportTest"
+    ];
+    $this->callAPISuccess('case', 'create', $params);
+
+    $params = [
+      'contact_id' => $contact_id,
+      'case_type' => "adult_day_care_referral",
+      'subject' => "AdultDayCareTest"
+    ];
+    $this->callAPISuccess('case', 'create', $params);
+
+    // Parameters for Contact + ActivityType + ActivityStatus + CaseType
+    $params = [
+      [
+        0 => 'contact_id',
+        1 => '=',
+        2 => $contact_id,
+        3 => 0,
+        4 => 0,
+      ],
+      [
+        0 => 'activity_type_id',
+        1 => '=',
+        2 => $medical_activity_type_id,
+        3 => 0,
+        4 => 0,
+      ],
+      [
+        0 => 'activity_status_id',
+        1 => '=',
+        2 => 1, //scheduled
+        3 => 0,
+        4 => 0,
+      ],
+      [
+        0 => 'case_type_id',
+        1 => '=',
+        2 => $housing_case_type_id,
+        3 => 0,
+        4 => 0,
+      ],
+    ];
+    // Query to find the activities that meet the search criteria
+    $query = new CRM_Contact_BAO_Query($params, NULL, NULL, FALSE, FALSE, CRM_Contact_BAO_Query::MODE_ACTIVITY);
+
+    $dao = $query->searchQuery();
+    $activity_array = [];
+    while ($dao->fetch()) {
+      $activity_array[] = $dao->activity_id;
+    }
+    // There are two activities that meet the ActivityType criterion
+    // but only one also meets the CaseType criterion
+    $this->assertEquals(1, count($activity_array));
+  }
+
+}

--- a/tests/phpunit/CRM/Contact/BAO/QueryAdvancedSearchTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/QueryAdvancedSearchTest.php
@@ -50,7 +50,7 @@ class CRM_Contact_BAO_QueryAdvancedSearchTest extends CiviCaseTestCase {
    */
   public function testCaseTypeAndActivityTypeSearch() {
     // Collect the ids from the test database that are needed in the search
-    $contact = $this-> callAPIsuccess('contact', 'get', ['display_name' => 'Test Contact']);
+    $contact = $this->callAPIsuccess('contact', 'get', ['display_name' => 'Test Contact']);
     $contact_id = $contact['id'];
     $medical = $this->callAPISuccess('OptionValue', 'Get', ['name' => 'Medical evaluation']);
     $option_value_id = $medical['id'];
@@ -63,14 +63,14 @@ class CRM_Contact_BAO_QueryAdvancedSearchTest extends CiviCaseTestCase {
     $params = [
       'contact_id' => $contact_id,
       'case_type' => "housing_support",
-      'subject' => "HousingSupportTest"
+      'subject' => "HousingSupportTest",
     ];
     $this->callAPISuccess('case', 'create', $params);
 
     $params = [
       'contact_id' => $contact_id,
       'case_type' => "adult_day_care_referral",
-      'subject' => "AdultDayCareTest"
+      'subject' => "AdultDayCareTest",
     ];
     $this->callAPISuccess('case', 'create', $params);
 
@@ -93,7 +93,7 @@ class CRM_Contact_BAO_QueryAdvancedSearchTest extends CiviCaseTestCase {
       [
         0 => 'activity_status_id',
         1 => '=',
-        2 => 1, //scheduled
+        2 => 1,
         3 => 0,
         4 => 0,
       ],


### PR DESCRIPTION
Overview
----------------------------------------
This change is to fix a problem in the Advanced Search described in this issue:   
https://lab.civicrm.org/dev/report/-/issues/53

Before
----------------------------------------
An Advanced Search (constructed using the user interface) to collect Activities using the criteria:   
Contact + ActivityType + ActivityStatus + CaseType  
failed and collected all the Activities of the selected ActivityType and Status in any of the Cases involving the Contact.  

The error was tracked to a missing join involving the civicrm_case_activity table. After manually testing, no other missing joins were found. (The same bug affected the results from searches constructed with the Search Builder).  

After
----------------------------------------
The error was fixed by adding a helper method to append an additional join statement to the end of the fromClause when both civicrm_case and civicrm_activity were listed in the $tables array used to generate the fromClause in the method:      
CRM/Contact/BAO/Query::fromClause()
The change also fixed the behaviour of the Search Builder, so that the correct list of Contacts was returned for searches of the same type as above.

Technical Details
----------------------------------------   
Notes on the phpunit test created.   
- The test checks more that just the construction of the fromClause in the SQL query, and includes running the query to check that the correct number of items is returned. This seemed a good idea even if it is therefore something more than a 'unit test'.
- The test is very dependent on the setup creating CaseTypes that contain default ActivityTypes when Cases are created from them.   
- The test collects the different identifiers needed from the test database rather than hard coding them to try to make it tolerant of updates to the setup.
-  No real attempt was made to get the use of exceptions correct.    
-  All the tests in tests/phpunit/CRM/Contact/AllTests.php still passed following these changes.

Comments
----------------------------------------
As someone quite new to PHP as a language. I am happy the fix works, and will not be at all offended if the code is radically restructured.