### PR TITLE
dev/core#2392 - Deprecated url parameters in contribution dashboard detail links

### DIFF
--- a/CRM/Contribute/Page/DashBoard.php
+++ b/CRM/Contribute/Page/DashBoard.php
@@ -60,7 +60,7 @@ class CRM_Contribute_Page_DashBoard extends CRM_Core_Page {
       foreach ($status as $s) {
         ${$aName}[$s] = CRM_Contribute_BAO_Contribution::getTotalAmountAndCount($s, $$dName, $nowWithTime);
         ${$aName}[$s]['url'] = CRM_Utils_System::url('civicrm/contribute/search',
-          "reset=1&force=1&status=1&start={$$dName}&end=$now&test=0"
+          "reset=1&force=1&status=1&receive_date_low={$$dName}&receive_date_high=$now&test=0"
         );
       }
 


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/2392

1. Contribution dashboard
2. Click the table layout "button" near the top.
3. Click on one of the "view details" links.
4. `User deprecated function: Deprecated function CRM_Contribute_Form_Search::setDeprecatedDefaults, use pass receive_date_high not end`

Before
----------------------------------------
All results returned from search

After
----------------------------------------
Correct results

Technical Details
----------------------------------------


Comments
----------------------------------------
Don't get blinded by all the double `$$`'s in this block of code.
