### PR TITLE
Remove empty {ts}

### DIFF
--- a/templates/CRM/Admin/Form/Setting/SettingForm.tpl
+++ b/templates/CRM/Admin/Form/Setting/SettingForm.tpl
@@ -19,7 +19,7 @@
           {$form.$setting_name.html}
         {/if}
         <div class="description">
-          {ts}{$setting_detail.description}{/ts}
+          {$setting_detail.description}
         </div>
         {if $setting_detail.help_text}
           {assign var='tplhelp_id' value = $setting_name|cat:'-id'|replace:'_':'-'}{help id="$tplhelp_id"}


### PR DESCRIPTION
Overview
----------------------------------------
While there might be some exceptional times to use {ts} against just a variable and no actual text, this doesn't seem to be one of them. Use ts() or E::ts() in the original `settings['description']` definition where the actual words are.

Before
----------------------------------------
There's nothing to extract for translators to translate here.

After
----------------------------------------
Use ts() or E::ts() where the description text is defined.

Technical Details
----------------------------------------


Comments
----------------------------------------
See also https://docs.civicrm.org/dev/en/latest/translation/#ensure-that-strings-have-some-words-in-them
