### PR TITLE
SearchKit - Add links to view multi-record custom data

### DIFF
--- a/Civi/Api4/Action/Entity/Get.php
+++ b/Civi/Api4/Action/Entity/Get.php
@@ -104,7 +104,9 @@ class Get extends \Civi\Api4\Generic\BasicGetAction {
         'description' => ts('Custom group for %1', [1 => $baseEntity::getInfo()['title_plural']]),
         'searchable' => TRUE,
         'type' => ['CustomValue'],
-        'paths' => [],
+        'paths' => [
+          'view' => "civicrm/contact/view/cd?reset=1&gid={$customEntity['id']}&recId=[id]&multiRecordDisplay=single",
+        ],
         'see' => [
           'https://docs.civicrm.org/user/en/latest/organising-your-data/creating-custom-fields/#multiple-record-fieldsets',
           '\\Civi\\Api4\\CustomGroup',


### PR DESCRIPTION
Overview
----------------------------------------
When creating a search display, you can now add a link to view a Multi-Record custom entity.

Before
----------------------------------------
No link option

After
----------------------------------------
Not all types of links available but at least we have VIEW now:

![image](https://user-images.githubusercontent.com/2874912/108370985-47183280-71cb-11eb-91e4-2d5b4e275607.png)


Technical Details
----------------------------------------
Ideally custom entities would have a full set of CRUD links, but the form code is a bizarre mess and requires a bunch of extra url params that have to be calculated when constructing the links.

Just getting the VIEW link was difficult because I had to remove the requirement of passing CID & teach the form to look it up.