### PR TITLE
core#2386 - metadata-driven chain-select fields

### DIFF
--- a/CRM/Admin/Form/SettingTrait.php
+++ b/CRM/Admin/Form/SettingTrait.php
@@ -213,9 +213,7 @@ trait CRM_Admin_Form_SettingTrait {
           );
         }
         elseif ($add === 'addChainSelect') {
-          $this->addChainSelect($setting, [
-            'label' => $props['title'],
-          ]);
+          $this->addChainSelect($setting, ['label' => $props['title']] + $props['chain_select_settings']);
         }
         elseif ($add === 'addMonthDay') {
           $this->add('date', $setting, $props['title'], CRM_Core_SelectValues::date(NULL, 'M d'));
@@ -288,6 +286,7 @@ trait CRM_Admin_Form_SettingTrait {
       'text' => 'Element',
       'entity_reference' => 'EntityRef',
       'advmultiselect' => 'Element',
+      'chainselect' => 'ChainSelect',
     ];
     $mapping += array_fill_keys(CRM_Core_Form::$html5Types, '');
     return $mapping[$htmlType] ?? '';

--- a/settings/Localization.setting.php
+++ b/settings/Localization.setting.php
@@ -155,6 +155,9 @@ return [
     'type' => 'Integer',
     'quick_form_type' => 'ChainSelect',
     'html_type' => 'ChainSelect',
+    'chain_select_settings' => [
+      'control_field' => 'defaultContactCountry',
+    ],
     //'pseudoconstant' => array(
     //  'callback' => 'CRM_Core_PseudoConstant::stateProvince',
     //),


### PR DESCRIPTION
https://lab.civicrm.org/dev/core/-/issues/2386

Overview
----------------------------------------
As we move to metadata-based settings, we need to support existing use cases such as chain-select.

Before
----------------------------------------
It looks like someone started writing code to allow defining chain-selects in `*.setting.php` but didn't finish.

After
----------------------------------------
Chain-selects work., we can create metadata-driven chain-select fields.

Technical Details
----------------------------------------
This adds a new property for settings, `chain_select_properties`.  These values are passed to `CRM_Core_Form::addChainSelect`.

Comments
----------------------------------------
I'm not sure how tightly the properties of `CRM_Core_Form::addChainSelect` are coupled to Quickform.  If they are, we may need a more generic solution - like a settings property that defines a JS function to run on an `onclick` event.

If this PR is accepted, I will add documentation in the [Settings Reference](https://docs.civicrm.org/dev/en/latest/framework/setting/).