### PR TITLE
SearchKit - Enable links for implicit joins

### DIFF
--- a/ext/search/Civi/Search/Admin.php
+++ b/ext/search/Civi/Search/Admin.php
@@ -75,7 +75,7 @@ class Admin {
       ->setChain([
         'get' => ['$name', 'getActions', ['where' => [['name', '=', 'get']]], ['params']],
       ])->execute();
-    $getFields = ['name', 'title', 'label', 'description', 'options', 'input_type', 'input_attrs', 'data_type', 'serialize', 'fk_entity'];
+    $getFields = ['name', 'title', 'label', 'description', 'options', 'input_type', 'input_attrs', 'data_type', 'serialize', 'entity', 'fk_entity'];
     foreach ($entities as $entity) {
       // Skip if entity doesn't have a 'get' action or the user doesn't have permission to use get
       if ($entity['get']) {

--- a/ext/search/ang/crmSearchAdmin.module.js
+++ b/ext/search/ang/crmSearchAdmin.module.js
@@ -148,7 +148,7 @@
         if (dotSplit.length === 2) {
           field = _.find(getEntity(entityName).fields, {name: dotSplit[0] + '.' + name});
           if (field) {
-            field.entity = entityName;
+            field.baseEntity = entityName;
             return {field: field};
           }
         }
@@ -161,7 +161,7 @@
           field = _.find(getEntity(join.bridge).fields, {name: name});
         }
         if (field) {
-          field.entity = entityName;
+          field.baseEntity = entityName;
           return {field: field, join: join};
         }
       }

--- a/ext/search/ang/crmSearchAdmin/crmSearchAdminLinkSelect.component.js
+++ b/ext/search/ang/crmSearchAdmin/crmSearchAdminLinkSelect.component.js
@@ -7,6 +7,9 @@
       apiEntity: '<',
       apiParams: '<'
     },
+    require: {
+      crmSearchAdmin: '^^crmSearchAdmin'
+    },
     templateUrl: '~/crmSearchAdmin/crmSearchAdminLinkSelect.html',
     controller: function ($scope, $element, $timeout, searchMeta) {
       var ts = $scope.ts = CRM.ts(),
@@ -14,7 +17,9 @@
 
       // Return all possible links to main entity or join entities
       function getLinks() {
+        // Links to main entity
         var links = _.cloneDeep(searchMeta.getEntity(ctrl.apiEntity).paths || []);
+        // Links to explicitly joined entities
         _.each(ctrl.apiParams.join, function(join) {
           var joinName = join[0].split(' AS '),
             joinEntity = searchMeta.getEntity(joinName[0]);
@@ -23,6 +28,23 @@
             link.path = link.path.replace(/\[/g, '[' + joinName[1] + '.');
             links.push(link);
           });
+        });
+        // Links to implicit joins
+        _.each(ctrl.crmSearchAdmin.savedSearch.api_params.select, function(fieldName) {
+          if (!_.includes(fieldName, ' AS ')) {
+            var info = searchMeta.parseExpr(fieldName);
+            if (info.field && !info.suffix && !info.fn && (info.field.fk_entity || info.field.entity !== info.field.baseEntity)) {
+              var idField = info.field.fk_entity ? fieldName : fieldName.substr(0, fieldName.lastIndexOf('.')) + '_id';
+              if (!ctrl.crmSearchAdmin.canAggregate(idField)) {
+                var joinEntity = searchMeta.getEntity(info.field.fk_entity || info.field.entity);
+                _.each(joinEntity.paths, function(path) {
+                  var link = _.cloneDeep(path);
+                  link.path = link.path.replace(/\[id/g, '[' + idField);
+                  links.push(link);
+                });
+              }
+            }
+          }
         });
         return links;
       }


### PR DESCRIPTION
Overview
----------------------------------------
Improves SearchKit to show links for implicitly joined entities.

Before
----------------------------------------
A search such as `civicrm/admin/search#/create/Email?params=%7B"version":4,"select":%5B"id","email","contact.display_name"%5D,"orderBy":%7B%7D,"where":%5B%5D,"groupBy":%5B%5D,"join":%5B%5D,"having":%5B%5D%7D` would not show the contact Display Name as a link.

After
----------------------------------------
Now it does, plus links to the contact are available in search displays.
