### PR TITLE
Afform - Support date range filters for search displays

### DIFF
--- a/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php
+++ b/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php
@@ -234,6 +234,8 @@ class AfformAdminMeta {
       ];
     }
 
+    $data['dateRanges'] = \CRM_Utils_Array::makeNonAssociative(\CRM_Core_OptionGroup::values('relative_date_filters'), 'id', 'label');
+
     return $data;
   }
 

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
@@ -52,6 +52,9 @@
         if (ctrl.node.defn && ctrl.node.defn.options) {
           return ctrl.node.defn.options;
         }
+        if (_.includes(['Date', 'Timestamp'], $scope.getProp('data_type'))) {
+          return CRM.afGuiEditor.dateRanges;
+        }
         return ctrl.getDefn().options || ($scope.getProp('input_type') === 'CheckBox' ? null : yesNo);
       };
 
@@ -69,14 +72,24 @@
         switch (type) {
           case 'CheckBox':
           case 'Radio':
+            return defn.options || defn.data_type === 'Boolean';
+
           case 'Select':
-            return !(!defn.options && defn.data_type !== 'Boolean');
+            return defn.options || defn.data_type === 'Boolean' || defn.input_type === 'Date';
+
+          case 'Date':
+            return defn.input_type === 'Date';
 
           case 'TextArea':
           case 'RichTextEditor':
             return (defn.data_type === 'Text' || defn.data_type === 'String');
+
+          case 'ChainSelect':
+            return defn.input_type === 'ChainSelect';
+
+          default:
+            return true;
         }
-        return true;
       };
 
       // Returns a value from either the local field defn or the base defn

--- a/ext/afform/core/Civi/Afform/AfformMetadataInjector.php
+++ b/ext/afform/core/Civi/Afform/AfformMetadataInjector.php
@@ -113,6 +113,12 @@ class AfformMetadataInjector {
       }
 
       $fieldDefn = $existingFieldDefn ? \CRM_Utils_JS::getRawProps($existingFieldDefn) : [];
+
+      if ('Date' === $fieldInfo['input_type'] && !empty($fieldDefn['input_type']) && \CRM_Utils_JS::decode($fieldDefn['input_type']) === 'Select') {
+        $fieldInfo['input_attrs']['placeholder'] = ts('Select');
+        $fieldInfo['options'] = \CRM_Utils_Array::makeNonAssociative(\CRM_Core_OptionGroup::values('relative_date_filters'), 'id', 'label');
+      }
+
       foreach ($fieldInfo as $name => $prop) {
         // Merge array props 1 level deep
         if (in_array($name, $deep) && !empty($fieldDefn[$name])) {


### PR DESCRIPTION
Overview
----------------------------------------
This allows afform date fields to be changed to type "Select" to choose a relative date range. 

Before
----------------------------------------
Date fields could only be dates.

After
----------------------------------------
Date fields can be select list of relative date ranges.