### PR TITLE
[Regression] campaign name no longer accepted

### DIFF
--- a/api/v3/utils.php
+++ b/api/v3/utils.php
@@ -2062,7 +2062,7 @@ function _civicrm_api3_validate_integer(&$params, $fieldName, &$fieldInfo, $enti
         $fieldValue = NULL;
       }
     }
-    if (!empty($fieldInfo['pseudoconstant']) || !empty($fieldInfo['options'])) {
+    if (!empty($fieldInfo['pseudoconstant']) || !empty($fieldInfo['options']) || $fieldName === 'campaign_id') {
       $additional_lookup_params = [];
       if (strtolower($entity) == 'address' && $fieldName == 'state_province_id') {
         $country_id = _civicrm_api3_resolve_country_id($params);

--- a/tests/phpunit/api/v3/MailingTest.php
+++ b/tests/phpunit/api/v3/MailingTest.php
@@ -79,8 +79,9 @@ class api_v3_MailingTest extends CiviUnitTestCase {
   /**
    * Test civicrm_mailing_create.
    */
-  public function testMailerCreateSuccess() {
-    $result = $this->callAPIAndDocument('mailing', 'create', $this->_params + ['scheduled_date' => 'now'], __FUNCTION__, __FILE__);
+  public function testMailerCreateSuccess(): void {
+    $this->callAPISuccess('Campaign', 'create', ['name' => 'big campaign', 'title' => 'abc']);
+    $result = $this->callAPIAndDocument('mailing', 'create', $this->_params + ['scheduled_date' => 'now', 'campaign_id' => 'big campaign'], __FUNCTION__, __FILE__);
     $jobs = $this->callAPISuccess('mailing_job', 'get', ['mailing_id' => $result['id']]);
     $this->assertEquals(1, $jobs['count']);
     // return isn't working on this in getAndCheck so lets not check it for now


### PR DESCRIPTION
Overview
----------------------------------------
In master we removed the pseudoconstants on `campaign_id` fields with the intent they would rely on the FKs.

This adds a shim for APIv3 to maintain legacy support for getoptions on fields named `campaign_id`.

