### PR TITLE
dev/core#2398 - Fix save'n'test button on mail account form

### DIFF
--- a/CRM/Admin/Form/MailSettings.php
+++ b/CRM/Admin/Form/MailSettings.php
@@ -34,7 +34,7 @@ class CRM_Admin_Form_MailSettings extends CRM_Admin_Form {
       return;
     }
 
-    $this->_testButtonName = $this->getButtonName('refresh', 'test');
+    $this->_testButtonName = $this->getButtonName('upload', 'test');
     $buttons = $this->getElement('buttons')->getElements();
     $buttons[] = $this->createElement(
       'xbutton',


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/2398

1. Add a new mail account.
2. Fill it out. It doesn't have to be real info.
3. Click save and test.
4. Click save.
5. You now have two accounts.

Before
----------------------------------------
Two accounts.

After
----------------------------------------
One account. Sometimes two is better than one, but not here.

Technical Details
----------------------------------------
The button was using the "refresh" action, which even though it results in a submit it prevents completing the form cycle.

Comments
----------------------------------------
Not related to button-rama. Maybe technically a regression since the button was introduced in 5.32, but it's not a critical issue since you can just delete the duplicate account.
