### PR TITLE
dev/event#50 - Non static function called statically for event ical downloads

### DIFF
--- a/CRM/Event/ICalendar.php
+++ b/CRM/Event/ICalendar.php
@@ -12,7 +12,7 @@
 /**
  * Class to generate various "icalendar" type event feeds
  */
-class CRM_Event_ICalendar extends CRM_Core_Page {
+class CRM_Event_ICalendar {
 
   /**
    * Heart of the iCalendar data assignment process. The runner gets all the meta
@@ -21,7 +21,7 @@ class CRM_Event_ICalendar extends CRM_Core_Page {
    * Else outputs iCalendar format per IETF RFC2445. Page param true means send
    * to browser as inline content. Else, we send .ics file as attachment.
    */
-  public function run() {
+  public static function run() {
     $id = CRM_Utils_Request::retrieveValue('id', 'Positive', NULL, FALSE, 'GET');
     $type = CRM_Utils_Request::retrieveValue('type', 'Positive', 0);
     $start = CRM_Utils_Request::retrieveValue('start', 'Positive', 0);


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/event/-/issues/50

1. Click any of the icons at the top of the manage events page.
2. You don't see the error right away for downloads, but if you then refresh the manage events page you'll see `Deprecated function: Non-static method CRM_Event_ICalendar::run() should not be called statically in CRM_Core_Invoke::runItem()`

Before
----------------------------------------
Warning

After
----------------------------------------
No warning

Technical Details
----------------------------------------
The run() function for CRM_Core_Page is non-static because it needs to access non-static things. This particular event page isn't really a Page and doesn't have any non-static things it does, so I think the answer is to _not_ extend Page and make the function static.

The pattern of calling `::run` for a menu routing entry is only ever used one other place for CRM_Core_Page_AJAX in CRM/Core/xml/Menu/Misc.xml and it also does not extend Page.

Comments
----------------------------------------

