### PR TITLE
Remove single use of extraParams in CRM_Utils_Token::getTokenDetails()

### DIFF
--- a/CRM/Contact/BAO/Contact/Utils.php
+++ b/CRM/Contact/BAO/Contact/Utils.php
@@ -967,16 +967,13 @@ INNER JOIN civicrm_contact contact_target ON ( contact_target.id = act.contact_i
     }
 
     if (empty($filterContactFldIds)) {
+      $greetingDetails = [];
       $filterContactFldIds[] = 0;
     }
-
-    // retrieve only required contact information
-    $extraParams[] = ['contact_type', '=', $contactType, 0, 0];
-    // we do token replacement in the replaceGreetingTokens hook
-    list($greetingDetails) = CRM_Utils_Token::getTokenDetails(array_keys($filterContactFldIds),
-      $greetingsReturnProperties,
-      FALSE, FALSE, $extraParams
-    );
+    else {
+      // we do token replacement in the replaceGreetingTokens hook
+      [$greetingDetails] = CRM_Utils_Token::getTokenDetails(array_keys($filterContactFldIds), $greetingsReturnProperties, FALSE, FALSE);
+    }
     // perform token replacement and build update SQL
     $contactIds = [];
     $cacheFieldQuery = "UPDATE civicrm_contact SET {$greeting}_display = CASE id ";

--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -1157,7 +1157,7 @@ class CRM_Utils_Token {
    * @param bool $skipDeceased Don't return deceased contact info.
    *   Don't return deceased contact info.
    * @param array $extraParams
-   *   Extra params.
+   *   Extra params - DEPRECATED
    * @param array $tokens
    *   The list of tokens we've extracted from the content.
    * @param string|null $className
@@ -1199,6 +1199,7 @@ class CRM_Utils_Token {
     }
 
     if ($extraParams) {
+      CRM_Core_Error::deprecatedWarning('Passing $extraParams to getTokenDetails() is not supported and will be removed in a future version');
       $params = array_merge($params, $extraParams);
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
I wanted to switch `CRM_Utils_Token::getTokenDetails()` to API4 but the existence of `$extraParams` makes this difficult. Turns out it's only used in one place and can easily be removed.

Before
----------------------------------------
$extraParams may be passed to tokens query.

After
----------------------------------------
$extraParams not used.

Technical Details
----------------------------------------
Calling getTokenDetails with [0] makes no sense because nothing is returned.

Comments
----------------------------------------
@eileenmcnaughton I started looking at some of the differences in contact token parsing and thought that both old/new functions would be simplified a lot if we switched them to API4.