### PR TITLE
[REF] Load participant id within completeOrder rather than passing it in

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4198,7 +4198,6 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
     // @todo see if we even need this - it's used further down to create an activity
     // but the BAO layer should create that - we just need to add a test to cover it & can
     // maybe remove $ids altogether.
-    $participantID = $ids['participant'];
     $recurringContributionID = $ids['contributionRecur'];
 
     // Unset ids just to make it clear it's not used again.
@@ -4253,8 +4252,9 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
       }
     }
     else {
-      if (empty($input['IAmAHorribleNastyBeyondExcusableHackInTheCRMEventFORMTaskClassThatNeedsToBERemoved'])) {
-        $participantParams['id'] = $participantID;
+      $participantPayment = civicrm_api3('ParticipantPayment', 'get', ['contribution_id' => $contributionID, 'return' => 'participant_id', 'sequential' => 1])['values'];
+      if (!empty($participantPayment) && empty($input['IAmAHorribleNastyBeyondExcusableHackInTheCRMEventFORMTaskClassThatNeedsToBERemoved'])) {
+        $participantParams['id'] = $participantPayment[0]['participant_id'];
         $participantParams['status_id'] = 'Registered';
         civicrm_api3('Participant', 'create', $participantParams);
       }


### PR DESCRIPTION

Overview
----------------------------------------
Simplifies input to completeOrder by accepting loading the participant id rather than expecting it to be passed in

Before
----------------------------------------
Participant id loaded by querying the participant payment table & passed in

After
----------------------------------------
Participant id not passed in, query done within completeOrder

Technical Details
----------------------------------------
The participantID passed in is simply loaded by retrieving participant_id from
the participant payment table earlier on. By doing it in the function
instead we can simplify the code that does that. There is no apiv4 for
participant payment as yet and once we start thinking about adding that
other questions arise (should we retrieve it via the line item instead)
so I went for a very limited change that simply replicates the
way it is currently retrieved (and does not, for example, increase the scope
to consider whether Attended should be updated to Registered) - in other
words this is as close to no-change as possible

I also deliberately left any changes to the nasty by-pass out of scope - that
needs to be tackled from the other end - ie removing the reason for the bypass
first and in the meantime we don't want to make it look any less hacky as we
don't want anyone to try to 'use' it


Comments
----------------------------------------
Test cover in testRepeatTransactionPassedInFinancialTypeTwoLineItems
