### PR TITLE
dev/core#2385 and dev/core#2262 - Case db views are no longer needed

### DIFF
--- a/CRM/Admin/Form/Setting/Component.php
+++ b/CRM/Admin/Form/Setting/Component.php
@@ -55,11 +55,6 @@ class CRM_Admin_Form_Setting_Component extends CRM_Admin_Form_Setting {
       ) {
         $errors['enable_components'] = ts('You need to enable CiviContribute before enabling CiviPledge.');
       }
-      if (!empty($fields['enable_components']['CiviCase']) &&
-        !CRM_Core_DAO::checkTriggerViewPermission(TRUE, FALSE)
-      ) {
-        $errors['enable_components'] = ts('CiviCase requires CREATE VIEW and DROP VIEW permissions for the database.');
-      }
     }
 
     return $errors;

--- a/CRM/Case/Info.php
+++ b/CRM/Case/Info.php
@@ -239,9 +239,6 @@ class CRM_Case_Info extends CRM_Core_Component_Info {
     ) {
       $pathToCaseSampleTpl = __DIR__ . '/xml/configuration.sample/';
       self::loadCaseSampleData($pathToCaseSampleTpl . 'case_sample.mysql.tpl');
-      if (!CRM_Case_BAO_Case::createCaseViews()) {
-        throw new CRM_Core_Exception(ts("Could not create the MySQL views for CiviCase. Your mysql user needs to have the 'CREATE VIEW' permission"));
-      }
     }
   }
 

--- a/CRM/Upgrade/Incremental/php/FiveFourteen.php
+++ b/CRM/Upgrade/Incremental/php/FiveFourteen.php
@@ -59,33 +59,9 @@ class CRM_Upgrade_Incremental_php_FiveFourteen extends CRM_Upgrade_Incremental_B
    */
   public function upgrade_5_14_alpha1($rev) {
     $this->addTask(ts('Upgrade DB to %1: SQL', array(1 => $rev)), 'runSql', $rev);
-
-    // Only need to rebuild view if CiviCase is enabled: otherwise will be
-    // rebuilt when component is enabled
-    $config = CRM_Core_Config::singleton();
-    if (in_array('CiviCase', $config->enableComponents)) {
-      $this->addTask('Rebuild case activity views', 'rebuildCaseActivityView', $rev);
-    }
     // Additional tasks here...
     // Note: do not use ts() in the addTask description because it adds unnecessary strings to transifex.
     // The above is an exception because 'Upgrade DB to %1: SQL' is generic & reusable.
-  }
-
-  /**
-   * Rebuild the view of recent and upcoming case activities
-   *
-   * See https://github.com/civicrm/civicrm-core/pull/14086 and
-   * https://lab.civicrm.org/dev/core/issues/832
-   *
-   * @param CRM_Queue_TaskContext $ctx
-   * @return bool
-   */
-  public static function rebuildCaseActivityView($ctx) {
-    if (!CRM_Case_BAO_Case::createCaseViews()) {
-      CRM_Core_Error::debug_log_message(ts("Could not create the MySQL views for CiviCase. Your mysql user needs to have the 'CREATE VIEW' permission"));
-      return FALSE;
-    }
-    return TRUE;
   }
 
 }

--- a/CRM/Upgrade/Incremental/sql/5.37.alpha1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.37.alpha1.mysql.tpl
@@ -1,1 +1,4 @@
 {* file to handle db changes in 5.37.alpha1 during upgrade *}
+
+DROP VIEW IF EXISTS civicrm_view_case_activity_upcoming;
+DROP VIEW IF EXISTS civicrm_view_case_activity_recent;


### PR DESCRIPTION
Overview
---------
https://lab.civicrm.org/dev/core/-/issues/2385 and https://lab.civicrm.org/dev/core/-/issues/2262

A long time ago in a country far away (for some), a group of Civizens armed with enormously heavy laptops commandeered a local cafe at 6am and, among other things, out of that tea-feuled coding session came an improvement to the case dashboard that took a query taking 25 seconds down to under 1 second, and it introduced a new thing into civicrm: MySQL Views.

While using mysql views wasn't directly a performance improvement (they are just canned subqueries still evaluated at runtime), it had a couple uses such as:
* Avoided copy/paste and made the query a little shorter to look at.
* Facilitated keeping full-group-by compliance and self-joins.
* Possibly preventing the query optimizer from doing the same subquery three times, in case it didn't notice.

Over time, the query was updated to take performance advantage of the fact that mysql will let you write queries that aren't full-group-by compliant. In turn this also led to the self-joins being removed.

So now, the view no longer serves a purpose and it causes a couple problems.

Before
---------
* Moving to a new server or doing a dump/restore can result in errors if you forget to include or recreate the views, or the view DEFINER is a different db user in the new location.
* The number 14 and activity status id's are hardcoded in the view.
* Otherwise unneeded db permissions are needed.

After
--------
* The opposite of the above, except:
  * The number 14 and activity status id's are still hardcoded in the query, but are maybe now a little less mysterious.

Technical Details
---------
All this really does is copy the view query verbatim into getCaseActivityQuery() which is the only place it's used.

A check of the civiverse suggests nothing accesses the views directly (and why would anything?)

Comments
----------
There are a couple tests that call getCases() which indirectly test the query, and I added a direct test at https://github.com/civicrm/civicrm-core/pull/19609. I did have trouble providing a larger amount of test coverage because several variations of the query will fail because of full-group-by, even on mysql 5.7 which is more lenient.

Install docs would need updating re: permissions.
