### PR TITLE
SearchKit - Don't save on enter key

### DIFF
--- a/ext/search/ang/crmSearchAdmin/compose/controls.html
+++ b/ext/search/ang/crmSearchAdmin/compose/controls.html
@@ -1,11 +1,11 @@
 <hr>
 <div class="form-inline">
   <div class="btn-group" role="group">
-    <button class="btn btn-primary{{ $ctrl.autoSearch ? '-outline' : '' }}" ng-click="onClickSearch()" ng-disabled="loading || (!$ctrl.autoSearch && !$ctrl.stale)">
+    <button type="button" class="btn btn-primary{{ $ctrl.autoSearch ? '-outline' : '' }}" ng-click="onClickSearch()" ng-disabled="loading || (!$ctrl.autoSearch && !$ctrl.stale)">
       <i class="crm-i {{ loading ? 'fa-spin fa-spinner' : 'fa-search' }}"></i>
       {{:: ts('Search') }}
     </button>
-    <button class="btn crm-search-auto-toggle btn-primary{{ $ctrl.autoSearch ? '' : '-outline' }}" ng-click="onClickAuto()">
+    <button type="button" class="btn crm-search-auto-toggle btn-primary{{ $ctrl.autoSearch ? '' : '-outline' }}" ng-click="onClickAuto()">
       <i class="crm-i fa-toggle-{{ $ctrl.autoSearch ? 'on' : 'off' }}"></i>
       {{:: ts('Auto') }}
     </button>

--- a/ext/search/ang/crmSearchAdmin/compose/criteria.html
+++ b/ext/search/ang/crmSearchAdmin/compose/criteria.html
@@ -6,7 +6,7 @@
           <label for="crm-search-join-{{ $index }}">{{:: ts('With') }}</label>
           <input id="crm-search-join-{{ $index }}" class="form-control huge" ng-model="join[0]" crm-ui-select="{placeholder: ' ', data: getJoinEntities}" disabled >
           <select class="form-control" ng-model="join[1]" ng-options="o.k as o.v for o in ::joinTypes" ></select>
-          <button class="btn btn-xs btn-danger-outline" ng-click="$ctrl.removeJoin($index)" title="{{:: ts('Remove join') }}">
+          <button type="button" class="btn btn-xs btn-danger-outline" ng-click="$ctrl.removeJoin($index)" title="{{:: ts('Remove join') }}">
             <i class="crm-i fa-trash" aria-hidden="true"></i>
           </button>
         </div>

--- a/ext/search/ang/crmSearchAdmin/crmSearchAdmin.html
+++ b/ext/search/ang/crmSearchAdmin/crmSearchAdmin.html
@@ -20,7 +20,7 @@
         <label for="crm-search-main-entity">{{:: ts('Search for:') }}</label>
         <input id="crm-search-main-entity" class="form-control huge" ng-model="$ctrl.savedSearch.api_entity" crm-ui-select="::{allowClear: false, data: entities}" ng-disabled="$ctrl.savedSearch.id" />
         <div class="btn-group btn-group-md pull-right">
-          <button type="submit" class="btn" ng-class="{'btn-primary': status === 'unsaved', 'btn-warning': status === 'saving', 'btn-success': status === 'saved'}" ng-disabled="status !== 'unsaved'" ng-click="$ctrl.save()">
+          <button type="button" class="btn" ng-class="{'btn-primary': status === 'unsaved', 'btn-warning': status === 'saving', 'btn-success': status === 'saved'}" ng-disabled="status !== 'unsaved'" ng-click="$ctrl.save()">
             <i class="crm-i" ng-class="{'fa-check': status !== 'saving', 'fa-spin fa-spinner': status === 'saving'}"></i>
             <span ng-if="status === 'saved'">{{ ts('Saved') }}</span>
             <span ng-if="status === 'unsaved'">{{ ts('Save') }}</span>

--- a/ext/search/ang/crmSearchAdmin/crmSearchClause.html
+++ b/ext/search/ang/crmSearchAdmin/crmSearchClause.html
@@ -1,6 +1,6 @@
 <legend>{{ $ctrl.label || ts('%1 group', {1: $ctrl.conjunctions[$ctrl.op]}) }}</legend>
 <div class="btn-group btn-group-xs" ng-if=":: $ctrl.hasParent">
-  <button class="btn btn-danger-outline" ng-click="$ctrl.deleteGroup()" title="{{:: ts('Remove group') }}">
+  <button type="button" class="btn btn-danger-outline" ng-click="$ctrl.deleteGroup()" title="{{:: ts('Remove group') }}">
     <i class="crm-i fa-trash" aria-hidden="true"></i>
   </button>
 </div>

--- a/ext/search/ang/crmSearchAdmin/displays/searchAdminDisplayList.html
+++ b/ext/search/ang/crmSearchAdmin/displays/searchAdminDisplayList.html
@@ -31,7 +31,7 @@
         <div class="form-control checkbox-inline" ng-show="col.label.length" title="{{:: ts('Show label for every record even when this field is blank') }}">
           <label><input type="checkbox" ng-model="col.forceLabel"> <span>{{:: ts('Always show') }}</span></label>
         </div>
-        <button class="btn-xs pull-right" ng-click="$ctrl.parent.removeCol($index)" title="{{:: ts('Hide') }}">
+        <button type="button" class="btn-xs pull-right" ng-click="$ctrl.parent.removeCol($index)" title="{{:: ts('Hide') }}">
           <i class="crm-i fa-ban"></i>
         </button>
       </div>
@@ -61,7 +61,7 @@
       <legend>{{ $ctrl.parent.getFieldLabel(col.key) }}</legend>
       <div class="form-inline">
         <label>{{:: ts('Label:') }}</label> <input disabled class="form-control" type="text" ng-model="col.label" />
-        <button class="btn-xs pull-right" ng-click="$ctrl.parent.restoreCol($index)" title="{{:: ts('Show') }}">
+        <button type="button" class="btn-xs pull-right" ng-click="$ctrl.parent.restoreCol($index)" title="{{:: ts('Show') }}">
           <i class="crm-i fa-undo"></i>
         </button>
       </div>

--- a/ext/search/ang/crmSearchAdmin/displays/searchAdminDisplayTable.html
+++ b/ext/search/ang/crmSearchAdmin/displays/searchAdminDisplayTable.html
@@ -18,7 +18,7 @@
       <legend>{{ $ctrl.parent.getFieldLabel(col.key) }}</legend>
       <div class="form-inline">
         <label>{{:: ts('Label:') }}</label> <input class="form-control" type="text" ng-model="col.label" />
-        <button class="btn-xs pull-right" ng-click="$ctrl.parent.removeCol($index)" title="{{:: ts('Hide') }}">
+        <button type="button" class="btn-xs pull-right" ng-click="$ctrl.parent.removeCol($index)" title="{{:: ts('Hide') }}">
           <i class="crm-i fa-ban"></i>
         </button>
       </div>
@@ -47,7 +47,7 @@
       <legend>{{ $ctrl.parent.getFieldLabel(col.key) }}</legend>
       <div class="form-inline">
         <label>{{:: ts('Label:') }}</label> <input disabled class="form-control" type="text" ng-model="col.label" />
-        <button class="btn-xs pull-right" ng-click="$ctrl.parent.restoreCol($index)" title="{{:: ts('Show') }}">
+        <button type="button" class="btn-xs pull-right" ng-click="$ctrl.parent.restoreCol($index)" title="{{:: ts('Show') }}">
           <i class="crm-i fa-undo"></i>
         </button>
       </div>

--- a/ext/search/ang/crmSearchAdmin/tabs.html
+++ b/ext/search/ang/crmSearchAdmin/tabs.html
@@ -9,7 +9,7 @@
     <i class="crm-i fa-users"></i>
     {{:: ts('Smart Group:') }} {{ $ctrl.savedSearch.groups[0].title }}
   </a>
-  <button class="btn-xs btn-danger-outline crm-search-delete-display" ng-click="$ctrl.removeGroup()" title="{{ $ctrl.groupExists ? ts('Delete') : ts('Undelete') }}">
+  <button type="button" class="btn-xs btn-danger-outline crm-search-delete-display" ng-click="$ctrl.removeGroup()" title="{{ $ctrl.groupExists ? ts('Delete') : ts('Undelete') }}">
     <i class="crm-i fa-{{ $ctrl.groupExists ? 'trash' : 'undo' }}"></i>
   </button>
 </li>
@@ -18,7 +18,7 @@
     <i class="crm-i {{ $ctrl.displayTypes[display.type].icon }}"></i>
     {{ display.label || ts('Untitled') }}
   </a>
-  <button class="btn-xs btn-danger-outline crm-search-delete-display" ng-click="$ctrl.removeDisplay($index)" title="{{ display.trashed ? ts('Undelete') : ts('Delete') }}">
+  <button type="button" class="btn-xs btn-danger-outline crm-search-delete-display" ng-click="$ctrl.removeDisplay($index)" title="{{ display.trashed ? ts('Undelete') : ts('Delete') }}">
     <i class="crm-i fa-{{ display.trashed ? 'undo' : 'trash' }}"></i>
   </button>
 </li>


### PR DESCRIPTION
Overview
----------------------------------------
In search kit, don't try to save when the user presses enter.

Before
----------------------------------------
Search saves when user presses enter.

After
----------------------------------------
Nothing happens when user presses enter.

Technical Details
----------------------------------------
Browsers automatically click the first `<button type="submit">` they find when the user presses enter in a text field. So the fix was to make sure all buttons are type "button"