### PR TITLE
[REF] Remove unused variables

### DIFF
--- a/templates/CRM/Member/Form/Membership.tpl
+++ b/templates/CRM/Member/Form/Membership.tpl
@@ -268,7 +268,6 @@
       function setPaymentBlock(mode, checkboxEvent) {
         var memType = parseInt(cj('#membership_type_id_1').val( ));
         var isPriceSet = 0;
-        var existingAmount = 0;
 
         if ( cj('#price_set_id').length > 0 && cj('#price_set_id').val() ) {
           isPriceSet = 1;
@@ -318,13 +317,6 @@
           if (taxRate) {
             var feeTotal = parseFloat(Number((taxRate/100) * allMemberships[memType]['total_amount'])+Number(allMemberships[memType]['total_amount_numeric'])).toFixed(2);
             cj("#total_amount").val(CRM.formatMoney(feeTotal, true));
-          }
-          else {
-            var feeTotal = allMemberships[memType]['total_amount'];
-            if (!existingAmount) {
-              // CRM-16680 don't set amount if there is an existing contribution.
-              cj("#total_amount").val(allMemberships[memType]['total_amount']);
-            }
           }
         }
         var taxMessage = taxRate!=undefined ? 'Includes '+taxTerm+' amount of '+currency+' '+taxAmount:'';


### PR DESCRIPTION


Overview
----------------------------------------
[REF] Remove unused variables

Before
----------------------------------------
existingAmount is never used except in this if so cannot be true. feeTotal
is used above this point but not below it - so this code is extraneous

After
----------------------------------------
poof

Technical Details
----------------------------------------

Comments
----------------------------------------
Touches same code as https://github.com/civicrm/civicrm-core/pull/19644 but this is particularly straight forward so likely to get a quick merge - I'll rebase that if so (or this if that is merged first)