### PR TITLE
Remove unreachable code & variable cleanup in membership back office form template

### DIFF
--- a/templates/CRM/Member/Form/Membership.tpl
+++ b/templates/CRM/Member/Form/Membership.tpl
@@ -313,12 +313,7 @@
           }
           cj("#total_amount").val(CRM.formatMoney(feeTotal, true));
         }
-        else {
-          if (taxRate) {
-            var feeTotal = parseFloat(Number((taxRate/100) * allMemberships[memType]['total_amount'])+Number(allMemberships[memType]['total_amount_numeric'])).toFixed(2);
-            cj("#total_amount").val(CRM.formatMoney(feeTotal, true));
-          }
-        }
+
         var taxMessage = taxRate!=undefined ? 'Includes '+taxTerm+' amount of '+currency+' '+taxAmount:'';
         cj('.totaltaxAmount').html(taxMessage);
       }

--- a/templates/CRM/Member/Form/Membership.tpl
+++ b/templates/CRM/Member/Form/Membership.tpl
@@ -564,12 +564,12 @@
       if (!processorId) {
         processorId = cj( '#payment_processor_id' ).val( );
       }
-      if (!membershipType) {
-        membershipType = parseInt( cj('#membership_type_id_1').val( ) );
+      if (!membershipTypeID) {
+        membershipTypeID = parseInt( cj('#membership_type_id_1').val( ) );
       }
 
       //we don't have both required values.
-      if (!processorId || !membershipType) {
+      if (!processorId || !membershipTypeID) {
         cj("#auto_renew").prop('checked', false);
         cj("#autoRenew").hide();
         showEmailOptions();
@@ -578,7 +578,7 @@
 
       var recurProcessors  = {/literal}{$recurProcessor}{literal};
       var autoRenewOptions = {/literal}{$autoRenewOptions}{literal};
-      var currentOption    = autoRenewOptions[membershipType];
+      var currentOption    = autoRenewOptions[membershipTypeID];
 
       if (!currentOption || !recurProcessors[processorId]) {
         cj("#auto_renew").prop('checked', false );

--- a/templates/CRM/Member/Form/Membership.tpl
+++ b/templates/CRM/Member/Form/Membership.tpl
@@ -268,7 +268,6 @@
       function setPaymentBlock(mode, checkboxEvent) {
         var memType = parseInt(cj('#membership_type_id_1').val( ));
         var isPriceSet = 0;
-        var existingAmount = 0;
 
         if ( cj('#price_set_id').length > 0 && cj('#price_set_id').val() ) {
           isPriceSet = 1;
@@ -318,13 +317,6 @@
           if (taxRate) {
             var feeTotal = parseFloat(Number((taxRate/100) * allMemberships[memType]['total_amount'])+Number(allMemberships[memType]['total_amount_numeric'])).toFixed(2);
             cj("#total_amount").val(CRM.formatMoney(feeTotal, true));
-          }
-          else {
-            var feeTotal = allMemberships[memType]['total_amount'];
-            if (!existingAmount) {
-              // CRM-16680 don't set amount if there is an existing contribution.
-              cj("#total_amount").val(allMemberships[memType]['total_amount']);
-            }
           }
         }
         var taxMessage = taxRate!=undefined ? 'Includes '+taxTerm+' amount of '+currency+' '+taxAmount:'';

--- a/templates/CRM/Member/Form/Membership.tpl
+++ b/templates/CRM/Member/Form/Membership.tpl
@@ -266,23 +266,21 @@
     {literal}
     <script type="text/javascript">
       function setPaymentBlock(mode, checkboxEvent) {
-        var memType = parseInt(cj('#membership_type_id_1').val( ));
-        var isPriceSet = 0;
-
-        if ( cj('#price_set_id').length > 0 && cj('#price_set_id').val() ) {
-          isPriceSet = 1;
+        if (cj('#price_set_id').length > 0 && cj('#price_set_id').val()) {
+          return;
         }
-
-        if ( !memType || isPriceSet ) {
+        var membershipTypeID = parseInt(cj('#membership_type_id_1').val());
+        if (!membershipTypeID) {
           return;
         }
 
         var allMemberships = {/literal}{$allMembershipInfo}{literal};
+        membershipType = allMemberships[membershipTypeID];
         if (!mode) {
           //check the record_contribution checkbox if membership is a paid one
           {/literal}{if $action eq 1}{literal}
           if (!checkboxEvent) {
-            if (allMemberships[memType]['total_amount_numeric'] > 0) {
+            if (membershipType['total_amount_numeric'] > 0) {
               cj('#record_contribution').prop('checked','checked');
               cj('#recordContribution').show();
             }
@@ -295,21 +293,21 @@
         }
 
         // skip this for test and live modes because financial type is set automatically
-        cj("#financial_type_id").val(allMemberships[memType]['financial_type_id']);
+        cj("#financial_type_id").val(membershipType['financial_type_id']);
         var term = cj('#num_terms').val();
         var taxRates = {/literal}{$taxRates}{literal};
         var taxTerm = {/literal}{$taxTerm|@json_encode}{literal};
-        var taxRate = taxRates[allMemberships[memType]['financial_type_id']];
+        var taxRate = taxRates[membershipType['financial_type_id']];
         var currency = {/literal}{$currency_symbol|@json_encode}{literal};
-        var taxAmount = (taxRate/100)*allMemberships[memType]['total_amount_numeric'];
+        var taxAmount = (taxRate/100)*membershipType['total_amount_numeric'];
         taxAmount = isNaN (taxAmount) ? 0:taxAmount;
         if (term) {
           if (!taxRate) {
-            var feeTotal = allMemberships[memType]['total_amount_numeric'] * term;
+            var feeTotal = membershipType['total_amount_numeric'] * term;
           }
           else {
-            var feeTotal = Number((taxRate/100) * (allMemberships[memType]['total_amount_numeric'] * term))+Number
-           (allMemberships[memType]['total_amount_numeric'] * term );
+            var feeTotal = Number((taxRate/100) * (membershipType['total_amount_numeric'] * term))+Number
+           (membershipType['total_amount_numeric'] * term );
           }
           cj("#total_amount").val(CRM.formatMoney(feeTotal, true));
         }


### PR DESCRIPTION
Overview
----------------------------------------
Removes some unreachable code and cleans up some variables


Before
----------------------------------------
- The 'else' part of the if (term) {} else {} is unreachable
-References to membershipType are allMemberships[memType] which is confusing

After
----------------------------------------
else bit gone
Values assigned to array membershipType. membershipTypeID consistently used for the variable meaning membership type id - was memType AND membershipType - both retrieved from the same jquery


Technical Details
----------------------------------------
Term is always set at this point unless we are dealing with a priceset - in which case the early return would have been hit - ergo term is always set
    
    We also know that this code is unreachable as in the 6 years it has been in the
    codebase no-one has reported the bug in it. It uses total_amount not total_amount_numerci
    in the first part of the calculation - this would fail when the decimal separator
    is not a decimal


Comments
----------------------------------------

