### PR TITLE
Mark Old Cividiscount hook support deprecated

### DIFF
--- a/templates/CRM/Form/body.tpl
+++ b/templates/CRM/Form/body.tpl
@@ -31,7 +31,7 @@
    </div>
 {/if}
 
-{* Add all the form elements sent in by the hook *}
+{* Add all the form elements sent in by the hook  - formerly used by civiDiscount, now deprecated*}
 {if $beginHookFormElements}
   <table class="form-layout-compressed">
   {foreach from=$beginHookFormElements key=dontCare item=hookFormElement}


### PR DESCRIPTION


Overview
----------------------------------------
This seems to have existed to support a really old approach
(pre regions). It's gone from cividiscount with
https://github.com/civicrm/org.civicrm.module.cividiscount/pull/251
merged so this just adds comments

Before
----------------------------------------

After
----------------------------------------
comment discourages use

Technical Details
----------------------------------------
Comments
----------------------------------------
