### PR TITLE
dev/core#2360 - Escape the word `rows` in sql query

### DIFF
--- a/Civi/Api4/Query/Api4SelectQuery.php
+++ b/Civi/Api4/Query/Api4SelectQuery.php
@@ -164,7 +164,7 @@ class Api4SelectQuery {
       $this->buildHavingClause();
       $this->buildGroupBy();
       $subquery = $this->query->toSQL();
-      $sql = "SELECT count(*) AS `c` FROM ( $subquery ) AS rows";
+      $sql = "SELECT count(*) AS `c` FROM ( $subquery ) AS `rows`";
     }
     $this->debug('sql', $sql);
     return (int) \CRM_Core_DAO::singleValueQuery($sql);


### PR DESCRIPTION
Overview
----------------------------------------
port https://github.com/civicrm/civicrm-core/pull/19535 to the rc

While not strictly a regression it feels like this will save some sites finding their first experience of search kit to be pretty frustrating & it's a small safe patch

@colemanw