### PR TITLE
[REF] Simplfy parameter

### DIFF
--- a/CRM/Member/Form.php
+++ b/CRM/Member/Form.php
@@ -503,4 +503,19 @@ class CRM_Member_Form extends CRM_Contribute_Form_AbstractEditPayment {
     ];
   }
 
+  /**
+   * Get the currency in use.
+   *
+   * This just defaults to getting the default currency
+   * as other currencies are not supported on the membership
+   * forms at the moment.
+   *
+   * @param array $submittedValues
+   *
+   * @return string
+   */
+  public function getCurrency($submittedValues = []): string {
+    return CRM_Core_Config::singleton()->defaultCurrency;
+  }
+
 }

--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -1254,8 +1254,7 @@ DESC limit 1");
 
       // add all the additional payment params we need
       $formValues['amount'] = $params['total_amount'];
-      // @todo this is a candidate for beginPostProcessFunction.
-      $formValues['currencyID'] = CRM_Core_Config::singleton()->defaultCurrency;
+      $formValues['currencyID'] = $this->getCurrency();
       $formValues['description'] = ts("Contribution submitted by a staff person using member's credit card for signup");
       $formValues['invoiceID'] = $this->getInvoiceID();
       $formValues['financial_type_id'] = $params['financial_type_id'];
@@ -1296,6 +1295,12 @@ DESC limit 1");
             'source' => CRM_Utils_Array::value('source', $paymentParams, CRM_Utils_Array::value('description', $paymentParams)),
             'payment_instrument_id' => $paymentInstrumentID,
             'financial_type_id' => $params['financial_type_id'],
+            'receive_date' => CRM_Utils_Time::date('YmdHis'),
+            'tax_amount' => $params['tax_amount'] ?? NULL,
+            'invoice_id' => $this->getInvoiceID(),
+            'currency' => $this->getCurrency(),
+            'is_pay_later' => $params['is_pay_later'] ?? 0,
+            'skipLineItem' => $params['skipLineItem'] ?? 0,
           ]
         );
 
@@ -1862,16 +1867,6 @@ DESC limit 1");
     if ($params['is_email_receipt']) {
       $receiptDate = $now;
     }
-
-    $contributionParams = array_merge([
-      'receive_date' => !empty($params['receive_date']) ? CRM_Utils_Date::processDate($params['receive_date']) : CRM_Utils_Time::date('YmdHis'),
-      'tax_amount' => $params['tax_amount'] ?? NULL,
-      'invoice_id' => $this->getInvoiceID(),
-      'currency' => $params['currencyID'],
-      'is_pay_later' => $params['is_pay_later'] ?? 0,
-      //setting to make available to hook - although seems wrong to set on form for BAO hook availability
-      'skipLineItem' => $params['skipLineItem'] ?? 0,
-    ], $contributionParams);
 
     if ($this->getSubmittedValue('send_receipt')) {
       $contributionParams += [


### PR DESCRIPTION


Overview
----------------------------------------
[REF] Simplfiy parameter

Before
----------------------------------------
We pass $contribution params into the function and then add some values to it from $params that we also pass into the function via array_merge which makes it hard to track the params

After
----------------------------------------
Contribution params originally built up more accurately

Technical Details
----------------------------------------
Rather than pass in contributionParams & params & combine in the function,
combine when passing in. Note receive_date is always 'now' in this
workflow as it is specifically the card payment workflow (for recurring)
being altered here & that field is not displayed on
credit card payments

Comments
----------------------------------------