### PR TITLE
dev/translation#32 Contribution ThankYou: partial fix for recurring units

### DIFF
--- a/templates/CRM/Contribute/Form/Contribution/ThankYou.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/ThankYou.tpl
@@ -139,7 +139,16 @@
                   {if $frequency_interval > 1}
                     <p><strong>{ts 1=$frequency_interval 2=$frequency_unit}This recurring contribution will be automatically processed every %1 %2s.{/ts}</strong></p>
                   {else}
-                    <p><strong>{ts 1=$frequency_unit}This recurring contribution will be automatically processed every %1.{/ts}</strong></p>
+                    {* dev/translation#32 All 'every %1' strings are incorrectly using ts, but focusing on the most important one until we find a better fix. *}
+                    {if $frequency_unit eq 'day'}
+                      <p><strong>{ts}This contribution will be automatically processed every day.{/ts}</strong></p>
+                    {elseif $frequency_unit eq 'week'}
+                      <p><strong>{ts}This contribution will be automatically processed every week.{/ts}</strong></p>
+                    {elseif $frequency_unit eq 'month'}
+                      <p><strong>{ts}This contribution will be automatically processed every month.{/ts}</strong></p>
+                    {elseif $frequency_unit eq 'year'}
+                      <p><strong>{ts}This contribution will be automatically processed every year.{/ts}</strong></p>
+                    {/if}
                   {/if}
                 {/if}
                   <p>


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/translation/-/issues/32

Workaround for a very long-running bug around unit translation.

To reproduce:

- Configure CiviCRM to non-English (ex: French)
- Setup a recurring contribution page
- Contribute a recurring amount (ex: 5$ every month)

Result:

> "Cette contribution périodique sera automatiquement prélevée chaque month."

(i.e. the frequency unit is not translated)

From the string:

> This recurring contribution will be automatically processed every %1.

Technical Details
----------------------------------------

Any kind of string such as `every %1` is an incorrect use of `ts()`, since it makes too many grammatical assumptions.

I only tried fixing the most important one to me, because this kind of code piles duct tape over existing duct tape.

Older buggy PR: #15363