### PR TITLE
dev/core#2404 - Afform - Resolve ambiguity of omitted permissions

### DIFF
--- a/ext/afform/admin/ang/afGuiEditor/config-form.html
+++ b/ext/afform/admin/ang/afGuiEditor/config-form.html
@@ -44,7 +44,7 @@
   <label for="af_config_form_permission">
     {{:: ts('Permission:') }}
   </label>
-  <input ng-model="afform.permission" class="form-control" id="af_config_form_permission" crm-ui-select="{data: editor.meta.permissions, placeholder: ts('Open access')}" />
+  <input ng-model="afform.permission" class="form-control" id="af_config_form_permission" crm-ui-select="{data: editor.meta.permissions}" />
   <p class="help-block">{{:: ts('What permission is required to use this form?') }}</p>
 </div>
 

--- a/ext/afform/core/CRM/Afform/AfformScanner.php
+++ b/ext/afform/core/CRM/Afform/AfformScanner.php
@@ -139,7 +139,12 @@ class CRM_Afform_AfformScanner {
 
     $metaFile = $this->findFilePath($name, self::METADATA_FILE);
     if ($metaFile !== NULL) {
-      return array_merge($defaults, json_decode(file_get_contents($metaFile), 1));
+      $r = array_merge($defaults, json_decode(file_get_contents($metaFile), 1));
+      // Previous revisions of GUI allowed permission==''. array_merge() doesn't catch all forms of missing-ness.
+      if ($r['permission'] === '') {
+        $r['permission'] = $defaults['permission'];
+      }
+      return $r;
     }
     elseif ($this->findFilePath($name, self::LAYOUT_FILE)) {
       return $defaults;


### PR DESCRIPTION
Overview
----------------------------------------

This addresses some ambiguities/confusion in `permission` for Afform. The basic question -- if `permission` is omitted (in various ways -- unset, `null`, empty-string), then what is the effective permission?

https://lab.civicrm.org/dev/core/-/issues/2404

Before
----------------------------------------

1. If `*.aff.json` does not specify a `permission` -- or specifies a `null` permission -- then it uses a default (`access CiviCRM`).
2. If `*.aff.json` specifies `permission` as an empty-string, then the runtime generates errors.
3. When editing a form in the GUI, the "Permission" field provides an "x". Clicking "x" produces the text "Open access" and sets `permission` to an empty-string.
    ![Screenshot from 2021-02-22 15-02-08](https://user-images.githubusercontent.com/1336047/108781601-026bfe80-751f-11eb-8bf9-be86932ad862.png)
    ![Screenshot from 2021-02-22 15-02-21](https://user-images.githubusercontent.com/1336047/108781600-01d36800-751f-11eb-8032-94d6a3c8565f.png)


After
----------------------------------------

1. If `*.aff.json` does not specify a `permission` -- or specifies a `null` permission *or empty-string permission* -- then it uses a default (`access CiviCRM`).
2. When editing a form in the GUI, the "Permission" field cannot be removed. You must have some value.

Comments
----------------------------------------

There are a few differing ways one might go at this:

1. Apply a consistent default of `access CiviCRM`
2. Apply a consistent default of `*always allow*`
3. Apply inconsistent defaults (where `null` and empty-string produce different behaviors).

IMHO, option 1 is less bad than the others:

* Option 1 effectively takes a small number of forms that never worked as labeled -and  gives valid but tighter permissions than expected.
* Option 2 effectively takes a small number of working forms that were semi-private -- and changes them to fully public.
* Option 3 will be more confusing over the long-term.