### PR TITLE
[REF] Move code that relates to receipts when paying by credit card out of the shared function

### DIFF
--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -917,19 +917,6 @@ DESC limit 1");
       $formValues['paidBy'] = $paymentInstrument[$formValues['payment_instrument_id']];
     }
 
-    if ($form->_mode) {
-      // @todo move this outside shared code as Batch entry just doesn't
-      $form->assign('address', CRM_Utils_Address::getFormattedBillingAddressFieldsFromParameters(
-        $form->_params,
-        $form->_bltID
-      ));
-
-      $valuesForForm = CRM_Contribute_Form_AbstractEditPayment::formatCreditCardDetails($form->_params);
-      $form->assignVariables($valuesForForm, ['credit_card_exp_date', 'credit_card_type', 'credit_card_number']);
-      $form->assign('is_pay_later', 0);
-      $form->assign('isPrimary', 1);
-    }
-
     $form->assign('module', 'Membership');
     $form->assign('contactID', $formValues['contact_id']);
 
@@ -1765,6 +1752,18 @@ DESC limit 1");
     $customValues = $this->getCustomValuesForReceipt($formValues, $membership);
     $this->assign('customValues', $customValues);
 
+    if ($this->_mode) {
+      // @todo move this outside shared code as Batch entry just doesn't
+      $this->assign('address', CRM_Utils_Address::getFormattedBillingAddressFieldsFromParameters(
+        $this->_params,
+        $this->_bltID
+      ));
+
+      $valuesForForm = CRM_Contribute_Form_AbstractEditPayment::formatCreditCardDetails($this->_params);
+      $this->assignVariables($valuesForForm, ['credit_card_exp_date', 'credit_card_type', 'credit_card_number']);
+      $this->assign('is_pay_later', 0);
+      $this->assign('isPrimary', 1);
+    }
     return self::emailReceipt($this, $formValues, $membership);
   }
 


### PR DESCRIPTION

Overview
----------------------------------------
[REF] Move code that relates to receipts when paying by credit card out of the shared function

Before
----------------------------------------
Code only used by back office membership form is in a function shared with the Batch Entry form

After
----------------------------------------
Code is in a function only used by back office membership form

Technical Details
----------------------------------------

The emailReceipt function is shared between the Batch Entry form and the backoffice
credit card form, while the emailMembershipReceipt is only used in this function.

I aim to copy the function onto the Batch Entry form & split them up but
am first moving this out of the shared code as it only
relates to credit card payments, which are not reachable from the Batch Entry form


Comments
----------------------------------------
