### PR TITLE
Afform - Add support for email tokens `{afform.myFormUrl}`

### DIFF
--- a/ext/afform/admin/ang/afGuiEditor/config-form.html
+++ b/ext/afform/admin/ang/afGuiEditor/config-form.html
@@ -32,6 +32,14 @@
   <p class="help-block">{{ts('The general look/feel should match the frontend')}}</p>
 </div>
 
+<div class="form-group" ng-if="!!afform.server_route">
+  <label for="af_config_form_is_token">
+    <input type="checkbox" id="af_config_form_is_token" ng-model="afform.is_token">
+    {{:: ts('Enable email token') }}
+  </label>
+  <p class="help-block">{{ts('Allow email authors to easily link to this form')}}</p>
+</div>
+
 <div class="form-group">
   <label for="af_config_form_is_dashlet">
     <input type="checkbox" id="af_config_form_is_dashlet" ng-model="afform.is_dashlet">

--- a/ext/afform/core/CRM/Afform/AfformScanner.php
+++ b/ext/afform/core/CRM/Afform/AfformScanner.php
@@ -134,6 +134,7 @@ class CRM_Afform_AfformScanner {
       'description' => '',
       'is_dashlet' => FALSE,
       'is_public' => FALSE,
+      'is_token' => FALSE,
       'permission' => 'access CiviCRM',
     ];
 

--- a/ext/afform/core/Civi/Afform/StatusChecks.php
+++ b/ext/afform/core/Civi/Afform/StatusChecks.php
@@ -1,0 +1,67 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Afform;
+
+use CRM_Afform_ExtensionUtil as E;
+
+class StatusChecks {
+
+  /**
+   * Afform has a soft dependency on Authx, which is used to generate authenticated email links.
+   *
+   * @param \Civi\Core\Event\GenericHookEvent $e
+   * @see CRM_Utils_Hook::check()
+   */
+  public static function hook_civicrm_check($e) {
+    $hasAuthx = \CRM_Extension_System::singleton()->getMapper()->isActiveModule('authx');
+    $tokenFormCount = count(Tokens::getTokenForms());
+    if (!$hasAuthx) {
+      if ($tokenFormCount) {
+        $e->messages[] = new \CRM_Utils_Check_Message(
+          'afform_token_authx',
+          E::ts('Email token support has been configured for %2 form(s), which requires extended authentication services. Please enable "AuthX" in <a href="%1">Manage Extensions</a>.', [
+            1 => \CRM_Utils_System::url('civicrm/admin/extensions', 'reset=1'),
+            2 => $tokenFormCount,
+          ]),
+          E::ts('AuthX Required'),
+          \Psr\Log\LogLevel::ERROR,
+          'fa-chain-broken'
+        );
+      }
+      else {
+        $e->messages[] = new \CRM_Utils_Check_Message(
+          'afform_token_authx',
+          E::ts('To generate authenticated email links for custom forms, enable extended authentication services (AuthX) in <a href="%1">Manage Extensions</a>.', [
+            1 => \CRM_Utils_System::url('civicrm/admin/extensions', 'reset=1'),
+          ]),
+          E::ts('AuthX Suggested'),
+          \Psr\Log\LogLevel::INFO,
+          'fa-lightbulb-o'
+        );
+      }
+    }
+
+    if ($hasAuthx && $tokenFormCount > 0 && !in_array('jwt', \Civi::settings()->get('authx_auto_cred'))) {
+      $e->messages[] = new \CRM_Utils_Check_Message(
+        'afform_token_authx',
+        E::ts('Email token support has been configured for %1 form(s). This requires JWT authentication, <code>authx_auto_cred</code> does not include JWT. ', [
+          1 => $tokenFormCount,
+        ]),
+        E::ts('AuthX Configuration'),
+        \Psr\Log\LogLevel::ERROR,
+        'fa-chain-broken'
+      );
+
+    }
+  }
+
+}

--- a/ext/afform/core/Civi/Afform/Tokens.php
+++ b/ext/afform/core/Civi/Afform/Tokens.php
@@ -1,0 +1,204 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Afform;
+
+use Civi\Core\Event\GenericHookEvent;
+use Civi\Crypto\Exception\CryptoException;
+use CRM_Afform_ExtensionUtil as E;
+
+/**
+ * Every afform with the property `is_token=true` should have a corresponding
+ * set of tokens, `{afform.myFormUrl}` and `{afform.myFormLink}`.
+ *
+ * @see MockPublicFormTest
+ * @package Civi\Afform
+ */
+class Tokens {
+
+  /**
+   * CKEditor makes it hard to set an `href` to a token, so we often get
+   * this munged `'http://{token}` data.
+   *
+   * @see CRM_Utils_Hook::alterMailContent
+   */
+  public static function applyCkeditorWorkaround(GenericHookEvent $e) {
+    foreach (array_keys($e->content) as $field) {
+      $e->content[$field] = preg_replace(';https?://(\{afform.*Url\});', '$1', $e->content[$field]);
+    }
+  }
+
+  /**
+   * Expose tokens for use in UI.
+   *
+   * @param \Civi\Core\Event\GenericHookEvent $e
+   * @see \CRM_Utils_Hook::tokens()
+   */
+  public static function hook_civicrm_tokens(GenericHookEvent $e) {
+    $tokenForms = static::getTokenForms();
+    foreach ($tokenForms as $tokenName => $afform) {
+      $e->tokens['afform']["afform.{$tokenName}Url"] = E::ts('%1 (URL)', [1 => $afform['title'] ?? $afform['name']]);
+      $e->tokens['afform']["afform.{$tokenName}Link"] = E::ts('%1 (Full Hyperlink)', [1 => $afform['title'] ?? $afform['name']]);
+    }
+  }
+
+  /**
+   * Substitute any tokens of the form `{afform.myFormUrl}` or `{afform.myFormLink}` with actual values.
+   *
+   * @param \Civi\Core\Event\GenericHookEvent $e
+   * @see \CRM_Utils_Hook::tokenValues()
+   */
+  public static function hook_civicrm_tokenValues(GenericHookEvent $e) {
+    try {
+      // Depending on the caller, $tokens['afform'] might be ['fooUrl'] or ['fooUrl'=>1]. Because... why not!
+      $activeAfformTokens = array_merge(array_keys($e->tokens['afform'] ?? []), array_values($e->tokens['afform'] ?? []));
+
+      $tokenForms = static::getTokenForms();
+      foreach ($tokenForms as $formName => $afform) {
+        if (!array_intersect($activeAfformTokens, ["{$formName}Url", "{$formName}Link"])) {
+          continue;
+        }
+
+        if (empty($afform['server_route'])) {
+          continue;
+        }
+
+        if (!is_array($e->contactIDs)) {
+          $url = self::createUrl($afform, $e->contactIDs);
+          $e->details["afform.{$formName}Url"] = $url;
+          $e->details["afform.{$formName}Link"] = sprintf('<a href="%s">%s</a>', htmlentities($url), htmlentities($afform['title'] ?? $afform['name']));
+        }
+        else {
+          foreach ($e->contactIDs as $cid) {
+            $url = self::createUrl($afform, $cid);
+            $e->details[$cid]["afform.{$formName}Url"] = $url;
+            $e->details[$cid]["afform.{$formName}Link"] = sprintf('<a href="%s">%s</a>', htmlentities($url), htmlentities($afform['title'] ?? $afform['name']));
+          }
+        }
+      }
+    }
+    catch (CryptoException $ex) {
+      \Civi::log()->warning('Civi\Afform\LegacyTokens cannot generate tokens due to crypto exception.', ['exception' => $ex]);
+    }
+  }
+
+  ///**
+  // * Expose tokens for use in UI.
+  // *
+  // * @param \Civi\Token\Event\TokenRegisterEvent $e
+  // */
+  //public static function onRegister(\Civi\Token\Event\TokenRegisterEvent $e) {
+  //  $tokenForms = static::getTokenForms();
+  //  foreach ($tokenForms as $tokenName => $afform) {
+  //    $e->register([
+  //      'entity' => 'afform',
+  //      'field' => $tokenName . 'Url',
+  //      'label' => E::ts('View Form: %1 (URL)', [1 => $afform['title'] ?? $afform['name']]),
+  //    ]);
+  //    $e->register([
+  //      'entity' => 'afform',
+  //      'field' => $tokenName . 'Link',
+  //      'label' => E::ts('View Form: %1 (Full Hyperlink)', [1 => $afform['title'] ?? $afform['name']]),
+  //    ]);
+  //  }
+  //}
+
+  ///**
+  // * Substitute any tokens of the form `{afform.myFormUrl}` or `{afform.myFormLink}` with actual values.
+  // *
+  // * @param \Civi\Token\Event\TokenValueEvent $e
+  // */
+  //public static function onEvaluate(\Civi\Token\Event\TokenValueEvent $e) {
+  //  $activeTokens = $e->getTokenProcessor()->getMessageTokens();
+  //  if (empty($activeTokens['afform'])) {
+  //    return;
+  //  }
+  //
+  //  $tokenForms = static::getTokenForms();
+  //  foreach ($tokenForms as $formName => $afform) {
+  //    if (!array_intersect($activeTokens['afform'], ["{$formName}Url", "{$formName}Link"])) {
+  //      continue;
+  //    }
+  //
+  //    if (empty($afform['server_route'])) {
+  //      \Civi::log()
+  //        ->warning('Civi\Afform\Tokens: Cannot generate link for {formName} -- missing server_route', [
+  //          'formName' => $formName,
+  //        ]);
+  //      continue;
+  //    }
+  //
+  //    foreach ($e->getRows() as $row) {
+  //      /** @var \Civi\Token\TokenRow $row */
+  //      try {
+  //        $url = self::createUrl($afform, $row->context['contactId']);
+  //        $row->format('text/plain')->tokens('afform', "{$formName}Url", $url);
+  //        $row->format('text/html')->tokens('afform', "{$formName}Link",
+  //          sprintf('<a href="%s">%s</a>', htmlentities($url), htmlentities($afform['title'] ?? $afform['name'])));
+  //      }
+  //      catch (CryptoException $e) {
+  //        \Civi::log()->warning('Civi\Afform\Tokens cannot generate tokens due to crypto exception.', ['exception' => $e]);
+  //      }
+  //    }
+  //  }
+  //}
+
+  /**
+   * Get a list of forms that have token support enabled.
+   *
+   * @return array
+   *   $result[$formName] = ['name' => $formName, 'title' => $formTitle, 'server_route' => $route];
+   */
+  public static function getTokenForms() {
+    if (!isset(\Civi::$statics[__CLASS__]['tokenForms'])) {
+      $tokenForms = (array) \Civi\Api4\Afform::get(0)
+        ->addWhere('is_token', '=', TRUE)
+        ->addSelect('name', 'title', 'server_route', 'is_public')
+        ->execute()
+        ->indexBy('name');
+      \Civi::$statics[__CLASS__]['tokenForms'] = $tokenForms;
+    }
+    return \Civi::$statics[__CLASS__]['tokenForms'];
+  }
+
+  /**
+   * Generate an authenticated URL for viewing this form.
+   *
+   * @param array $afform
+   * @param int $contactId
+   *
+   * @return string
+   * @throws \Civi\Crypto\Exception\CryptoException
+   */
+  public static function createUrl($afform, $contactId): string {
+    $expires = \CRM_Utils_Time::time() +
+      (\Civi::settings()->get('checksum_timeout') * 24 * 60 * 60);
+
+    /** @var \Civi\Crypto\CryptoJwt $jwt */
+    $jwt = \Civi::service('crypto.jwt');
+
+    $bearerToken = "Bearer " . $jwt->encode([
+      'exp' => $expires,
+      'sub' => "cid:" . $contactId,
+      'scope' => 'authx',
+    ]);
+
+    $url = \CRM_Utils_System::url($afform['server_route'],
+      ['_authx' => $bearerToken, '_authxSes' => 1],
+      TRUE,
+      NULL,
+      FALSE,
+      $afform['is_public'] ?? TRUE
+    );
+    return $url;
+  }
+
+}

--- a/ext/afform/core/Civi/Api4/Action/Afform/Get.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/Get.php
@@ -117,6 +117,7 @@ class Get extends \Civi\Api4\Generic\BasicGetAction {
         'description' => '',
         'is_dashlet' => FALSE,
         'is_public' => FALSE,
+        'is_token' => FALSE,
         'permission' => 'access CiviCRM',
         'join' => 'Custom_' . $custom['name'],
         'block' => $custom['extends'],

--- a/ext/afform/core/Civi/Api4/Afform.php
+++ b/ext/afform/core/Civi/Api4/Afform.php
@@ -154,6 +154,10 @@ class Afform extends Generic\AbstractEntity {
           'data_type' => 'Boolean',
         ],
         [
+          'name' => 'is_token',
+          'data_type' => 'Boolean',
+        ],
+        [
           'name' => 'repeat',
           'data_type' => 'Mixed',
         ],

--- a/ext/afform/core/afform.php
+++ b/ext/afform/core/afform.php
@@ -54,11 +54,14 @@ function afform_civicrm_config(&$config) {
   $dispatcher->addListener(Submit::EVENT_NAME, [Submit::class, 'processGenericEntity'], -1000);
   $dispatcher->addListener('hook_civicrm_angularModules', ['\Civi\Afform\AngularDependencyMapper', 'autoReq'], -1000);
   $dispatcher->addListener('hook_civicrm_alterAngular', ['\Civi\Afform\AfformMetadataInjector', 'preprocess']);
+  $dispatcher->addListener('hook_civicrm_check', ['\Civi\Afform\StatusChecks', 'hook_civicrm_check']);
 
   // Register support for email tokens
-  $dispatcher->addListener('hook_civicrm_alterMailContent', ['\Civi\Afform\Tokens', 'applyCkeditorWorkaround']);
-  $dispatcher->addListener('hook_civicrm_tokens', ['\Civi\Afform\Tokens', 'hook_civicrm_tokens']);
-  $dispatcher->addListener('hook_civicrm_tokenValues', ['\Civi\Afform\Tokens', 'hook_civicrm_tokenValues']);
+  if (CRM_Extension_System::singleton()->getMapper()->isActiveModule('authx')) {
+    $dispatcher->addListener('hook_civicrm_alterMailContent', ['\Civi\Afform\Tokens', 'applyCkeditorWorkaround']);
+    $dispatcher->addListener('hook_civicrm_tokens', ['\Civi\Afform\Tokens', 'hook_civicrm_tokens']);
+    $dispatcher->addListener('hook_civicrm_tokenValues', ['\Civi\Afform\Tokens', 'hook_civicrm_tokenValues']);
+  }
 }
 
 /**

--- a/ext/afform/core/afform.php
+++ b/ext/afform/core/afform.php
@@ -49,10 +49,16 @@ function afform_civicrm_config(&$config) {
   }
   Civi::$statics[__FUNCTION__] = 1;
 
-  Civi::dispatcher()->addListener(Submit::EVENT_NAME, [Submit::class, 'processContacts'], 500);
-  Civi::dispatcher()->addListener(Submit::EVENT_NAME, [Submit::class, 'processGenericEntity'], -1000);
-  Civi::dispatcher()->addListener('hook_civicrm_angularModules', ['\Civi\Afform\AngularDependencyMapper', 'autoReq'], -1000);
-  Civi::dispatcher()->addListener('hook_civicrm_alterAngular', ['\Civi\Afform\AfformMetadataInjector', 'preprocess']);
+  $dispatcher = Civi::dispatcher();
+  $dispatcher->addListener(Submit::EVENT_NAME, [Submit::class, 'processContacts'], 500);
+  $dispatcher->addListener(Submit::EVENT_NAME, [Submit::class, 'processGenericEntity'], -1000);
+  $dispatcher->addListener('hook_civicrm_angularModules', ['\Civi\Afform\AngularDependencyMapper', 'autoReq'], -1000);
+  $dispatcher->addListener('hook_civicrm_alterAngular', ['\Civi\Afform\AfformMetadataInjector', 'preprocess']);
+
+  // Register support for email tokens
+  $dispatcher->addListener('hook_civicrm_alterMailContent', ['\Civi\Afform\Tokens', 'applyCkeditorWorkaround']);
+  $dispatcher->addListener('hook_civicrm_tokens', ['\Civi\Afform\Tokens', 'hook_civicrm_tokens']);
+  $dispatcher->addListener('hook_civicrm_tokenValues', ['\Civi\Afform\Tokens', 'hook_civicrm_tokenValues']);
 }
 
 /**

--- a/ext/afform/docs/crud.md
+++ b/ext/afform/docs/crud.md
@@ -15,6 +15,7 @@ $ cv api4 afform.get +w name=helloWorld
         "description": "",
         "is_dashlet": false,
         "is_public": false,
+        "is_token": false,
         "server_route": "civicrm/hello-world",
         "layout": {
             "#tag": "div",

--- a/ext/afform/html/ang/afHtmlEditor.aff.html
+++ b/ext/afform/html/ang/afHtmlEditor.aff.html
@@ -41,6 +41,13 @@
               </label>
               <p class="help-block">{{ts('The general look/feel should match the frontend')}}</p>
             </div>
+            <div class="form-group" ng-if="!!resultForm.server_route">
+              <label for="af_config_form_is_token">
+                <input type="checkbox" id="af_config_form_is_token" ng-model="resultForm.is_token">
+                {{ ts('Enable email token') }}
+              </label>
+              <p class="help-block">{{ts('Allow email authors to easily link to this form')}}</p>
+            </div>
             <div class="form-group">
               <label for="af_config_form_is_dashlet">
                 <input type="checkbox" id="af_config_form_is_dashlet" ng-model="resultForm.is_dashlet">

--- a/ext/afform/mock/ang/mockPublicForm.aff.json
+++ b/ext/afform/mock/ang/mockPublicForm.aff.json
@@ -2,5 +2,6 @@
   "type": "form",
   "title": "My public form",
   "server_route": "civicrm/mock-public-form",
-  "permission": "*always allow*"
+  "permission": "*always allow*",
+  "is_token": true
 }

--- a/ext/afform/mock/ang/mockPublicForm.test.php
+++ b/ext/afform/mock/ang/mockPublicForm.test.php
@@ -63,4 +63,117 @@ class MockPublicFormTest extends \Civi\AfformMock\FormTestCase {
     $this->assertEquals(0, CRM_Core_DAO::singleValueQuery('SELECT count(*) FROM civicrm_contact WHERE first_name=%1', [1 => ["Firsty{$r}", 'String']]));
   }
 
+  /**
+   * The email token `{afform.mockPublicFormUrl}` should evaluate to an authenticated URL.
+   */
+  public function testAuthenticatedUrlToken_Plain() {
+    if (!function_exists('authx_civicrm_config')) {
+      $this->fail('Cannot test without authx');
+    }
+
+    $lebowski = $this->getLebowskiCID();
+    $text = $this->renderTokens($lebowski, 'Please go to {afform.mockPublicFormUrl}', 'text/plain');
+    if (!preg_match(';Please go to ([^\s]+);', $text, $m)) {
+      $this->fail('Plain text message did not have URL in expected place: ' . $text);
+    }
+    $url = $m[1];
+    $this->assertRegExp(';^https?:.*civicrm/mock-public-form.*;', $url, "URL should look plausible");
+
+    // Going to this page will cause us to authenticate as the target contact
+    $http = $this->createGuzzle(['http_errors' => FALSE, 'cookies' => new \GuzzleHttp\Cookie\CookieJar()]);
+    $response = $http->get($url);
+    $r = (string) $response->getBody();
+    $this->assertStatusCode(200, $response);
+    $response = $http->get('civicrm/authx/id');
+    $this->assertContactJson($lebowski, $response);
+  }
+
+  /**
+   * The email token `{afform.mockPublicFormUrl}` should evaluate to an authenticated URL.
+   */
+  public function testAuthenticatedUrlToken_Html() {
+    if (!function_exists('authx_civicrm_config')) {
+      $this->fail('Cannot test without authx');
+    }
+
+    $lebowski = $this->getLebowskiCID();
+    $html = $this->renderTokens($lebowski, 'Please go to <a href="{afform.mockPublicFormUrl}">my form</a>', 'text/html');
+
+    if (!preg_match(';a href="([^"]+)";', $html, $m)) {
+      $this->fail('HTML message did not have URL in expected place: ' . $html);
+    }
+    $url = html_entity_decode($m[1]);
+    $this->assertRegExp(';^https?:.*civicrm/mock-public-form.*;', $url, "URL should look plausible");
+
+    // Going to this page will cause us to authenticate as the target contact
+    $http = $this->createGuzzle(['cookies' => new \GuzzleHttp\Cookie\CookieJar()]);
+    $response = $http->get($url);
+    $this->assertStatusCode(200, $response);
+    $response = $http->get('civicrm/authx/id');
+    $this->assertContactJson($lebowski, $response);
+  }
+
+  /**
+   * The email token `{afform.mockPublicFormLink}` should evaluate to an authenticated URL.
+   */
+  public function testAuthenticatedLinkToken_Html() {
+    if (!function_exists('authx_civicrm_config')) {
+      $this->fail('Cannot test without authx');
+    }
+
+    $lebowski = $this->getLebowskiCID();
+    $html = $this->renderTokens($lebowski, 'Please go to {afform.mockPublicFormLink}', 'text/html');
+    $doc = \phpQuery::newDocument($html, 'text/html');
+    $this->assertEquals(1, $doc->find('a')->count(), 'Document should have hyperlink');
+    foreach ($doc->find('a') as $item) {
+      /** @var \DOMElement $item */
+      $this->assertRegExp(';^https?:.*civicrm/mock-public-form.*;', $item->getAttribute('href'));
+      $this->assertEquals('My public form', $item->firstChild->data);
+      $url = $item->getAttribute('href');
+    }
+
+    // Going to this page will cause us to authenticate as the target contact
+    $http = $this->createGuzzle(['cookies' => new \GuzzleHttp\Cookie\CookieJar()]);
+    $response = $http->get($url);
+    $this->assertStatusCode(200, $response);
+    $response = $http->get('civicrm/authx/id');
+    $this->assertContactJson($lebowski, $response);
+  }
+
+  protected function renderTokens($cid, $body, $format) {
+    $tp = new \Civi\Token\TokenProcessor(\Civi::dispatcher(), []);
+    $tp->addRow()->context('contactId', $cid);
+    $tp->addMessage('example', $body, $format);
+    $tp->evaluate();
+    return $tp->getRow(0)->render('example');
+  }
+
+  protected function getLebowskiCID() {
+    $contact = \civicrm_api3('Contact', 'create', [
+      'contact_type' => 'Individual',
+      'first_name' => 'Jeffrey',
+      'last_name' => 'Lebowski',
+      'external_identifier' => __CLASS__,
+      'options' => [
+        'match' => 'external_identifier',
+      ],
+    ]);
+    return $contact['id'];
+  }
+
+  /**
+   * Assert the AJAX request provided the expected contact.
+   *
+   * @param int $cid
+   *   The expected contact ID
+   * @param \Psr\Http\Message\ResponseInterface $response
+   */
+  public function assertContactJson($cid, $response) {
+    $this->assertContentType('application/json', $response);
+    $this->assertStatusCode(200, $response);
+    $j = json_decode((string) $response->getBody(), 1);
+    $formattedFailure = $this->formatFailure($response);
+    $this->assertEquals($cid, $j['contact_id'], "Response did not give expected contact ID\n" . $formattedFailure);
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------

This PR provides integration between Afform and email tools. The author may give the recipient an authenticated URL by embedding a suitable token:

```html
Please fill out <a href="{afform.myFormUrl}">the important form</a>.
```

This builds on `authx` (#19590)'s JWT support, which allows one to generate an authenticated URL for any page/form/route (including any afform).

Before
----------------------------------------

#19590 provides programmatic interfaces for hyperlinking to Afforms, eg

* You can compose a JWT with `Civi::service('crypto.jwt')->encode([...])`.
* The authentication system can accept JWT in the URL (e.g. `civicrm/my-page?_authx=TOKEN&_authxSes=1`).

But it is missing glue that makes it accessible to a web-based staff-user.

After
----------------------------------------

The Afform data-model includes another field, `is_token`, which is similar to `is_dashlet`. 

<img width="392" alt="Screen Shot 2021-02-23 at 5 23 42 AM" src="https://user-images.githubusercontent.com/1336047/108849700-54e90180-7597-11eb-9c68-5adb4369e202.png">

Enabling it will create corresponding email tokens.

<img width="1114" alt="Screen Shot 2021-02-23 at 5 26 28 AM" src="https://user-images.githubusercontent.com/1336047/108850040-b9a45c00-7597-11eb-9b06-6013b3535a30.png">

The resulting token works in various permutations of CiviMail and individual emails with/without Flexmailer. It will produce content like:

```html
<!-- Input -->
Please go to <a href="{afform.myFormUrl}">the form</a>.

<!-- Output -->
Please go to <a href="http://dmaster.127.0.0.1.nip.io:8001/civicrm/mock-public-form?_authx=Bearer+ABCDEFG.123456.HIJK-789&_authxSes=1">the form</a>.
```

When you click the link, it will do one of the following:

* Login as the recipient and open the requested form.
* If the user is already logged in, and if the contact matches -- then show the requested form.
* If the user is already logged in, and if the contact differs -- then show an error.

Comments
----------------------------------------

(1) There is some test coverage attached to the `mockPublicForm.test.php`.

(2) For the scenario where you are already logged-in as a different user, it shows an error - and obviously errors are not desirable. However, this is a direct consequence of pursuing the less-effort form of authentication. There are ways to improve it, eg

* Show a nicer error screen. Give the option to logout+login with the new identity.
* Deliver a narrower JWT -- e.g. instead of granting permission for a login (`scope=authx`), grant permission just to process the one form. However, we won't have a cookie to handle during AJAX calls. Instead, I believe we'd need a JS revision so that the `?_authx` parameter is passed-through to any AJAX calls (`Afform.prefill`, `Afform.submit`, etc).

(3) Since `is_token` requires `authx` to work correctly, this is basically a soft-dependency. The `afform` status-checks will display a suggestion to enable `authx` (with severity increasing or decreasing depending on whether the token functionality is enabled on any forms).

