### PR TITLE
SearchKit - cleanup display configuration and add "rewrite" feature

### DIFF
--- a/ext/search/ang/crmSearchAdmin/crmSearchAdminDisplay.component.js
+++ b/ext/search/ang/crmSearchAdmin/crmSearchAdminDisplay.component.js
@@ -70,20 +70,26 @@
         return searchMeta.getDefaultLabel(expr);
       };
 
-      function fieldToColumn(fieldExpr) {
-        var info = searchMeta.parseExpr(fieldExpr);
-        return {
-          key: info.alias,
-          label: searchMeta.getDefaultLabel(fieldExpr),
-          dataType: (info.fn && info.fn.name === 'COUNT') ? 'Integer' : info.field.data_type
-        };
+      function fieldToColumn(fieldExpr, defaults) {
+        var info = searchMeta.parseExpr(fieldExpr),
+          values = _.cloneDeep(defaults);
+        if (defaults.key) {
+          values.key = info.alias;
+        }
+        if (defaults.label) {
+          values.label = searchMeta.getDefaultLabel(fieldExpr);
+        }
+        if (defaults.dataType) {
+          values.dataType = (info.fn && info.fn.name === 'COUNT') ? 'Integer' : info.field && info.field.data_type;
+        }
+        return values;
       }
 
       // Helper function to sort active from hidden columns and initialize each column with defaults
-      this.initColumns = function() {
+      this.initColumns = function(defaults) {
         if (!ctrl.display.settings.columns) {
           ctrl.display.settings.columns = _.transform(ctrl.savedSearch.api_params.select, function(columns, fieldExpr) {
-            columns.push(fieldToColumn(fieldExpr));
+            columns.push(fieldToColumn(fieldExpr, defaults));
           });
           ctrl.hiddenColumns = [];
         } else {
@@ -94,7 +100,7 @@
           ctrl.hiddenColumns = _.transform(ctrl.savedSearch.api_params.select, function(hiddenColumns, fieldExpr) {
             var key = _.last(fieldExpr.split(' AS '));
             if (!_.includes(activeColumns, key)) {
-              hiddenColumns.push(fieldToColumn(fieldExpr));
+              hiddenColumns.push(fieldToColumn(fieldExpr, defaults));
             }
           });
           _.eachRight(activeColumns, function(key, index) {

--- a/ext/search/ang/crmSearchAdmin/crmSearchAdminLinkSelect.component.js
+++ b/ext/search/ang/crmSearchAdmin/crmSearchAdminLinkSelect.component.js
@@ -49,22 +49,31 @@
         return links;
       }
 
-      function onChange() {
-        var val = $('select', $element).val();
-        if (val !== ctrl.column.link) {
-          var link = ctrl.getLink(val);
-          if (link) {
-            ctrl.column.link = link.path;
-            ctrl.column.title = link.title;
-          } else if (val === 'civicrm/') {
+      this.setValue = function(val) {
+        var link = ctrl.getLink(val),
+          oldLink = ctrl.getLink(ctrl.column.link);
+        if (link) {
+          ctrl.column.link = link.path;
+          ctrl.column.title = link.title;
+        } else {
+          if (val === 'civicrm/') {
             ctrl.column.link = val;
-            $timeout(function() {
-              $('input', $element).focus();
+            $timeout(function () {
+              $('input[type=text]', $element).focus();
             });
           } else {
             ctrl.column.link = '';
+          }
+          if (oldLink && ctrl.column.title === oldLink.title) {
             ctrl.column.title = '';
           }
+        }
+      };
+
+      function onChange() {
+        var val = $('select', $element).val();
+        if (val !== ctrl.column.link) {
+          ctrl.setValue(val);
         }
       }
 

--- a/ext/search/ang/crmSearchAdmin/crmSearchAdminLinkSelect.html
+++ b/ext/search/ang/crmSearchAdmin/crmSearchAdminLinkSelect.html
@@ -1,5 +1,9 @@
-<select class="form-control">
-  <option value="" ng-selected="!$ctrl.column.link" >{{ ts('None') }}</option>
+<label title="{{ ts('Display as clickable link') }}" >
+  <input type="checkbox" ng-checked="$ctrl.column.link" ng-click="$ctrl.setValue($ctrl.column.link ? '' : ($ctrl.links[0] && $ctrl.links[0].path || 'civicrm/'))" >
+  {{ $ctrl.column.link ? ts('Link:') : ts('Link') }}
+</label>
+<select class="form-control" ng-show="$ctrl.links.length && $ctrl.column.link">
+  <option value="">{{ ts('None') }}</option>
   <option ng-repeat="link in $ctrl.links" value="{{ link.path }}" ng-selected="$ctrl.column.link === link.path">
     {{ link.title }}
   </option>
@@ -7,7 +11,5 @@
     {{ ts('Other...') }}
   </option>
 </select>
-<div class="form-group" ng-if="$ctrl.column.link && !$ctrl.getLink($ctrl.column.link)">
-  <input class="form-control" type="text" ng-model="$ctrl.column.link" ng-model-options="{updateOn: 'blur'}" />
-  <crm-search-admin-token-select api-entity="$ctrl.apiEntity" api-params="$ctrl.apiParams" model="$ctrl.column" field="link"></crm-search-admin-token-select>
-</div>
+<input class="form-control" type="text" ng-if="$ctrl.column.link && !$ctrl.getLink($ctrl.column.link)" ng-model="$ctrl.column.link" ng-model-options="{updateOn: 'blur'}" />
+<crm-search-admin-token-select ng-if="$ctrl.column.link && !$ctrl.getLink($ctrl.column.link)" api-entity="$ctrl.apiEntity" api-params="$ctrl.apiParams" model="$ctrl.column" field="link"></crm-search-admin-token-select>

--- a/ext/search/ang/crmSearchAdmin/displays/common/fieldOptions.html
+++ b/ext/search/ang/crmSearchAdmin/displays/common/fieldOptions.html
@@ -1,9 +1,9 @@
-<div class="form-inline">
-  <label>{{:: ts('Link:') }}</label>
-  <crm-search-admin-link-select column="col" api-entity="$ctrl.apiEntity" api-params="$ctrl.apiParams"></crm-search-admin-link-select>
-</div>
-<div class="form-inline">
-  <label>{{:: ts('Tooltip:') }}</label>
-  <input class="form-control" type="text" ng-model="col.title" />
-  <crm-search-admin-token-select api-entity="$ctrl.apiEntity" api-params="$ctrl.apiParams" model="col" field="title"></crm-search-admin-token-select>
+<crm-search-admin-link-select class="form-inline crm-search-admin-flex-row" column="col" api-entity="$ctrl.apiEntity" api-params="$ctrl.apiParams"></crm-search-admin-link-select>
+<div class="form-inline crm-search-admin-flex-row">
+  <label>
+    <input type="checkbox" ng-checked="col.title" ng-click="col.title = col.title ? null : $ctrl.parent.getFieldLabel(col.key)" >
+    {{ col.title ? ts('Tooltip:') : ts('Tooltip') }}
+  </label>
+  <input class="form-control" type="text" ng-model="col.title" ng-if="col.title" ng-model-options="{updateOn: 'blur'}" />
+  <crm-search-admin-token-select ng-if="col.title" api-entity="$ctrl.apiEntity" api-params="$ctrl.apiParams" model="col" field="title"></crm-search-admin-token-select>
 </div>

--- a/ext/search/ang/crmSearchAdmin/displays/common/fieldOptions.html
+++ b/ext/search/ang/crmSearchAdmin/displays/common/fieldOptions.html
@@ -1,0 +1,9 @@
+<div class="form-inline">
+  <label>{{:: ts('Link:') }}</label>
+  <crm-search-admin-link-select column="col" api-entity="$ctrl.apiEntity" api-params="$ctrl.apiParams"></crm-search-admin-link-select>
+</div>
+<div class="form-inline">
+  <label>{{:: ts('Tooltip:') }}</label>
+  <input class="form-control" type="text" ng-model="col.title" />
+  <crm-search-admin-token-select api-entity="$ctrl.apiEntity" api-params="$ctrl.apiParams" model="col" field="title"></crm-search-admin-token-select>
+</div>

--- a/ext/search/ang/crmSearchAdmin/displays/common/fieldOptions.html
+++ b/ext/search/ang/crmSearchAdmin/displays/common/fieldOptions.html
@@ -7,3 +7,11 @@
   <input class="form-control" type="text" ng-model="col.title" ng-if="col.title" ng-model-options="{updateOn: 'blur'}" />
   <crm-search-admin-token-select ng-if="col.title" api-entity="$ctrl.apiEntity" api-params="$ctrl.apiParams" model="col" field="title"></crm-search-admin-token-select>
 </div>
+<div class="form-inline crm-search-admin-flex-row">
+  <label title="{{ ts('Change the contents of this field, or combine multiple field values.') }}">
+    <input type="checkbox" ng-checked="col.rewrite" ng-click="col.rewrite = col.rewrite ? null : '['+col.key+']'" >
+    {{ col.rewrite ? ts('Rewrite:') : ts('Rewrite') }}
+  </label>
+  <input type="text" class="form-control" ng-if="col.rewrite" ng-model="col.rewrite" ng-model-options="{updateOn: 'blur'}">
+  <crm-search-admin-token-select ng-if="col.rewrite" api-entity="$ctrl.apiEntity" api-params="$ctrl.apiParams" model="col" field="rewrite"></crm-search-admin-token-select>
+</div>

--- a/ext/search/ang/crmSearchAdmin/displays/common/unusedColumns.html
+++ b/ext/search/ang/crmSearchAdmin/displays/common/unusedColumns.html
@@ -1,0 +1,12 @@
+<fieldset class="crm-search-admin-edit-columns" ng-model="$ctrl.parent.hiddenColumns" ui-sortable="$ctrl.parent.sortableOptions">
+  <legend>{{:: ts('Unused') }}</legend>
+  <fieldset ng-repeat="col in $ctrl.parent.hiddenColumns" class="crm-draggable">
+    <legend>{{ $ctrl.parent.getFieldLabel(col.key) }}</legend>
+    <div class="form-inline">
+      <label>{{:: ts('Label:') }}</label> <input disabled class="form-control" type="text" ng-model="col.label" />
+      <button type="button" class="btn-xs pull-right" ng-click="$ctrl.parent.restoreCol($index)" title="{{:: ts('Show') }}">
+        <i class="crm-i fa-undo"></i>
+      </button>
+    </div>
+  </fieldset>
+</fieldset>

--- a/ext/search/ang/crmSearchAdmin/displays/common/unusedColumns.html
+++ b/ext/search/ang/crmSearchAdmin/displays/common/unusedColumns.html
@@ -1,9 +1,8 @@
-<fieldset class="crm-search-admin-edit-columns" ng-model="$ctrl.parent.hiddenColumns" ui-sortable="$ctrl.parent.sortableOptions">
+<fieldset class="crm-search-admin-edit-columns crm-search-admin-unused-columns" ng-model="$ctrl.parent.hiddenColumns" ui-sortable="$ctrl.parent.sortableOptions">
   <legend>{{:: ts('Unused') }}</legend>
   <fieldset ng-repeat="col in $ctrl.parent.hiddenColumns" class="crm-draggable">
     <legend>{{ $ctrl.parent.getFieldLabel(col.key) }}</legend>
     <div class="form-inline">
-      <label>{{:: ts('Label:') }}</label> <input disabled class="form-control" type="text" ng-model="col.label" />
       <button type="button" class="btn-xs pull-right" ng-click="$ctrl.parent.restoreCol($index)" title="{{:: ts('Show') }}">
         <i class="crm-i fa-undo"></i>
       </button>

--- a/ext/search/ang/crmSearchAdmin/displays/searchAdminDisplayList.component.js
+++ b/ext/search/ang/crmSearchAdmin/displays/searchAdminDisplayList.component.js
@@ -38,7 +38,7 @@
             pager: true
           };
         }
-        ctrl.parent.initColumns();
+        ctrl.parent.initColumns({key: true, dataType: true});
       };
 
     }

--- a/ext/search/ang/crmSearchAdmin/displays/searchAdminDisplayList.html
+++ b/ext/search/ang/crmSearchAdmin/displays/searchAdminDisplayList.html
@@ -44,27 +44,8 @@
           <label><input type="checkbox" ng-model="col.break"> <span>{{:: ts('New line') }}</span></label>
         </div>
       </div>
-      <div class="form-inline">
-        <label>{{:: ts('Link:') }}</label>
-        <crm-search-admin-link-select column="col" api-entity="$ctrl.apiEntity" api-params="$ctrl.apiParams"></crm-search-admin-link-select>
-      </div>
-      <div class="form-inline">
-        <label>{{:: ts('Tooltip:') }}</label>
-        <input class="form-control" type="text" ng-model="col.title" />
-        <crm-search-admin-token-select api-entity="$ctrl.apiEntity" api-params="$ctrl.apiParams" model="col" field="title"></crm-search-admin-token-select>
-      </div>
+      <div ng-include="'~/crmSearchAdmin/displays/common/fieldOptions.html'"></div>
     </fieldset>
   </fieldset>
-  <fieldset class="crm-search-admin-edit-columns" ng-model="$ctrl.parent.hiddenColumns" ui-sortable="$ctrl.parent.sortableOptions">
-    <legend>{{:: ts('Hidden Fields') }}</legend>
-    <fieldset ng-repeat="col in $ctrl.parent.hiddenColumns" class="crm-draggable">
-      <legend>{{ $ctrl.parent.getFieldLabel(col.key) }}</legend>
-      <div class="form-inline">
-        <label>{{:: ts('Label:') }}</label> <input disabled class="form-control" type="text" ng-model="col.label" />
-        <button type="button" class="btn-xs pull-right" ng-click="$ctrl.parent.restoreCol($index)" title="{{:: ts('Show') }}">
-          <i class="crm-i fa-undo"></i>
-        </button>
-      </div>
-    </fieldset>
-  </fieldset>
+  <div ng-include="'~/crmSearchAdmin/displays/common/unusedColumns.html'"></div>
 </div>

--- a/ext/search/ang/crmSearchAdmin/displays/searchAdminDisplayList.html
+++ b/ext/search/ang/crmSearchAdmin/displays/searchAdminDisplayList.html
@@ -26,22 +26,24 @@
     <legend>{{:: ts('Fields') }}</legend>
     <fieldset ng-repeat="col in $ctrl.display.settings.columns" class="crm-draggable">
       <legend>{{ $ctrl.parent.getFieldLabel(col.key) }}</legend>
-      <div class="form-inline">
-        <label>{{:: ts('Label:') }}</label> <input class="form-control" type="text" ng-model="col.label" >
-        <div class="form-control checkbox-inline" ng-show="col.label.length" title="{{:: ts('Show label for every record even when this field is blank') }}">
-          <label><input type="checkbox" ng-model="col.forceLabel"> <span>{{:: ts('Always show') }}</span></label>
-        </div>
+      <div class="form-inline" title="{{ ts('Should this item display on its own line or inline with other items?') }}">
+        <label><input type="checkbox" ng-model="col.break"> {{:: ts('Display on new line') }}</label>
         <button type="button" class="btn-xs pull-right" ng-click="$ctrl.parent.removeCol($index)" title="{{:: ts('Hide') }}">
           <i class="crm-i fa-ban"></i>
         </button>
       </div>
-      <div class="form-inline">
-        <label>{{:: ts('Prefix:') }}</label>
-        <input class="form-control" ng-model="col.prefix" size="4">
-        <label>{{:: ts('Suffix:') }}</label>
-        <input class="form-control" ng-model="col.suffix" size="4">
-        <div class="form-control checkbox-inline">
-          <label><input type="checkbox" ng-model="col.break"> <span>{{:: ts('New line') }}</span></label>
+      <div class="form-inline crm-search-admin-flex-row">
+        <label>
+          <input type="checkbox" ng-checked="col.label" ng-click="col.label = col.label ? null : $ctrl.parent.getFieldLabel(col.key)" >
+          {{ col.label ? ts('Label:') : ts('Label') }}
+        </label>
+        <input ng-if="col.label" class="form-control" type="text" ng-model="col.label" ng-model-options="{updateOn: 'blur'}">
+        <crm-search-admin-token-select ng-if="col.label" api-entity="$ctrl.apiEntity" api-params="$ctrl.apiParams" model="col" field="label"></crm-search-admin-token-select>
+      </div>
+      <div class="form-inline" ng-if="col.label">
+        <label style="visibility: hidden"><input type="checkbox" disabled></label>
+        <div class="checkbox">
+          <label><input type="checkbox" ng-model="col.forceLabel"> {{:: ts('Show label even when field is blank') }}</label>
         </div>
       </div>
       <div ng-include="'~/crmSearchAdmin/displays/common/fieldOptions.html'"></div>

--- a/ext/search/ang/crmSearchAdmin/displays/searchAdminDisplayTable.component.js
+++ b/ext/search/ang/crmSearchAdmin/displays/searchAdminDisplayTable.component.js
@@ -22,7 +22,7 @@
             pager: true
           };
         }
-        ctrl.parent.initColumns();
+        ctrl.parent.initColumns({key: true, label: true, dataType: true});
       };
 
     }

--- a/ext/search/ang/crmSearchAdmin/displays/searchAdminDisplayTable.html
+++ b/ext/search/ang/crmSearchAdmin/displays/searchAdminDisplayTable.html
@@ -16,9 +16,11 @@
     <legend>{{:: ts('Columns') }}</legend>
     <fieldset ng-repeat="col in $ctrl.display.settings.columns" class="crm-draggable">
       <legend>{{ $ctrl.parent.getFieldLabel(col.key) }}</legend>
-      <div class="form-inline">
-        <label>{{:: ts('Label:') }}</label> <input class="form-control" type="text" ng-model="col.label" />
-        <button type="button" class="btn-xs pull-right" ng-click="$ctrl.parent.removeCol($index)" title="{{:: ts('Hide') }}">
+      <div class="form-inline crm-search-admin-flex-row">
+        <label for="crm-search-admin-edit-col-{{ $index }}">{{:: ts('Header:') }}</label>
+        <input id="crm-search-admin-edit-col-{{ $index }}" class="form-control" type="text" ng-model="col.label" >
+        &nbsp;&nbsp;&nbsp;&nbsp;
+        <button type="button" class="btn-xs" ng-click="$ctrl.parent.removeCol($index)" title="{{:: ts('Hide') }}">
           <i class="crm-i fa-ban"></i>
         </button>
       </div>

--- a/ext/search/ang/crmSearchAdmin/displays/searchAdminDisplayTable.html
+++ b/ext/search/ang/crmSearchAdmin/displays/searchAdminDisplayTable.html
@@ -30,27 +30,8 @@
           <option value="text-right">{{:: ts('Right') }}</option>
         </select>
       </div>
-      <div class="form-inline">
-        <label>{{:: ts('Link:') }}</label>
-        <crm-search-admin-link-select column="col" api-entity="$ctrl.apiEntity" api-params="$ctrl.apiParams"></crm-search-admin-link-select>
-      </div>
-      <div class="form-inline">
-        <label>{{:: ts('Tooltip:') }}</label>
-        <input class="form-control" type="text" ng-model="col.title" />
-        <crm-search-admin-token-select api-entity="$ctrl.apiEntity" api-params="$ctrl.apiParams" model="col" field="title"></crm-search-admin-token-select>
-      </div>
+      <div ng-include="'~/crmSearchAdmin/displays/common/fieldOptions.html'"></div>
     </fieldset>
   </fieldset>
-  <fieldset class="crm-search-admin-edit-columns" ng-model="$ctrl.parent.hiddenColumns" ui-sortable="$ctrl.parent.sortableOptions">
-    <legend>{{:: ts('Hidden Columns') }}</legend>
-    <fieldset ng-repeat="col in $ctrl.parent.hiddenColumns" class="crm-draggable">
-      <legend>{{ $ctrl.parent.getFieldLabel(col.key) }}</legend>
-      <div class="form-inline">
-        <label>{{:: ts('Label:') }}</label> <input disabled class="form-control" type="text" ng-model="col.label" />
-        <button type="button" class="btn-xs pull-right" ng-click="$ctrl.parent.restoreCol($index)" title="{{:: ts('Show') }}">
-          <i class="crm-i fa-undo"></i>
-        </button>
-      </div>
-    </fieldset>
-  </fieldset>
+  <div ng-include="'~/crmSearchAdmin/displays/common/unusedColumns.html'"></div>
 </div>

--- a/ext/search/ang/crmSearchDisplayList/crmSearchDisplayList.component.js
+++ b/ext/search/ang/crmSearchDisplayList/crmSearchDisplayList.component.js
@@ -41,19 +41,13 @@
         ctrl.getResults();
       }
 
-      $scope.formatResult = function(row, col) {
-        var value = row[col.key],
-          formatted = searchDisplayUtils.formatSearchValue(row, col, value),
-          output = '';
-        if (formatted.length || (col.label && col.forceLabel)) {
-          if (col.label && (formatted.length || col.forceLabel)) {
-            output += '<label>' + _.escape(col.label) + '</label> ';
-          }
-          if (formatted.length) {
-            output += (col.prefix || '') + formatted + (col.suffix || '');
-          }
+      $scope.formatResult = function(rowData, col) {
+        var formatted = searchDisplayUtils.formatDisplayValue(rowData, col.key, ctrl.settings.columns);
+        if (col.label && (formatted.length || col.forceLabel)) {
+          var label = searchDisplayUtils.replaceTokens(col.label, rowData, ctrl.settings.columns);
+          formatted = '<label>' + _.escape(label) + '</label> ' + formatted;
         }
-        return output;
+        return formatted;
       };
 
     }

--- a/ext/search/ang/crmSearchDisplayList/crmSearchDisplayListItems.html
+++ b/ext/search/ang/crmSearchDisplayList/crmSearchDisplayListItems.html
@@ -1,4 +1,4 @@
 <li ng-repeat="row in $ctrl.results">
-  <div ng-repeat="col in $ctrl.settings.columns" ng-bind-html="formatResult(row, col)" title="{{:: displayUtils.replaceTokens(col.title, row) }}" class="{{:: col.break ? '' : 'crm-inline-block' }}">
+  <div ng-repeat="col in $ctrl.settings.columns" ng-bind-html="formatResult(row, col)" title="{{:: displayUtils.replaceTokens(col.title, row, $ctrl.settings.columns) }}" class="{{:: col.break ? '' : 'crm-inline-block' }}">
   </div>
 </li>

--- a/ext/search/ang/crmSearchDisplayTable/crmSearchDisplayTable.component.js
+++ b/ext/search/ang/crmSearchDisplayTable/crmSearchDisplayTable.component.js
@@ -76,9 +76,8 @@
         ctrl.getResults();
       };
 
-      $scope.formatResult = function(row, col) {
-        var value = row[col.key];
-        return searchDisplayUtils.formatSearchValue(row, col, value);
+      $scope.formatResult = function(rowData, col) {
+        return searchDisplayUtils.formatDisplayValue(rowData, col.key, ctrl.settings.columns);
       };
 
       $scope.selectAllRows = function() {

--- a/ext/search/ang/crmSearchDisplayTable/crmSearchDisplayTable.html
+++ b/ext/search/ang/crmSearchDisplayTable/crmSearchDisplayTable.html
@@ -18,7 +18,7 @@
       <td ng-if="$ctrl.settings.actions">
         <input type="checkbox" ng-checked="isRowSelected(row)" ng-click="selectRow(row)" ng-disabled="!(!loadingAllRows && row.id)">
       </td>
-      <td ng-repeat="col in $ctrl.settings.columns" ng-bind-html="formatResult(row, col)" title="{{:: displayUtils.replaceTokens(col.title, row) }}" class="{{:: col.alignment }}">
+      <td ng-repeat="col in $ctrl.settings.columns" ng-bind-html="formatResult(row, col)" title="{{:: displayUtils.replaceTokens(col.title, row, $ctrl.settings.columns) }}" class="{{:: col.alignment }}">
       </td>
       <td></td>
     </tr>

--- a/ext/search/css/crmSearchAdmin.css
+++ b/ext/search/css/crmSearchAdmin.css
@@ -153,6 +153,17 @@
   top: 0;
 }
 
+#bootstrap-theme .crm-search-admin-flex-row {
+  display: flex;
+  align-items: center;
+}
+#bootstrap-theme .crm-search-admin-flex-row > *:not(:first-child) {
+  margin-left: 6px;
+}
+#bootstrap-theme .crm-search-admin-flex-row > input[type=text] {
+  flex: 1;
+}
+
 #bootstrap-theme input[type=search]::placeholder {
   font-family: FontAwesome;
   text-align: right;

--- a/ext/search/css/crmSearchAdmin.css
+++ b/ext/search/css/crmSearchAdmin.css
@@ -164,6 +164,10 @@
   flex: 1;
 }
 
+#bootstrap-theme .crm-search-admin-unused-columns fieldset {
+  min-height: 60px;
+}
+
 #bootstrap-theme input[type=search]::placeholder {
   font-family: FontAwesome;
   text-align: right;


### PR DESCRIPTION
Overview
----------------------------------------
Adds the ability to rewrite fields in search displays, while streamlining the display administration screen.

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/2874912/108933358-02502980-7619-11eb-922b-2d9f5ca7a8ae.png)

After
----------------------------------------
![image](https://user-images.githubusercontent.com/2874912/108933229-c87f2300-7618-11eb-90d2-e593b4b06dec.png)

Comments
----------------------------------------
De-cluttering inspired by conversation with David Tarrant
