### PR TITLE
Afform: Only permit Date fields to be made into a select list if it i…

### DIFF
--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
@@ -26,6 +26,10 @@
         $scope.meta = afGui.meta;
       };
 
+      this.isSearch = function() {
+        return !_.isEmpty($scope.meta.searchDisplays);
+      };
+
       // Returns the original field definition from metadata
       this.getDefn = function() {
         var defn = afGui.getField(ctrl.container.getFieldEntityType(ctrl.node.name), ctrl.node.name);
@@ -75,7 +79,7 @@
             return defn.options || defn.data_type === 'Boolean';
 
           case 'Select':
-            return defn.options || defn.data_type === 'Boolean' || defn.input_type === 'Date';
+            return defn.options || defn.data_type === 'Boolean' || (defn.input_type === 'Date' && ctrl.isSearch());
 
           case 'Date':
             return defn.input_type === 'Date';


### PR DESCRIPTION
…s a search form

Overview
----------------------------------------
This limits the forms that can have date fields as a select list to just search forms

Before
----------------------------------------
Any Afform can have a date field as a select list

After
----------------------------------------
Only search display afforms can have date field as a select list

ping @eileenmcnaughton @colemanw @JoeMurray 