### PR TITLE
dev/core#2420 Add text to report template saying no results found if that is the case

### DIFF
--- a/templates/CRM/Logging/ReportDetail.tpl
+++ b/templates/CRM/Logging/ReportDetail.tpl
@@ -22,7 +22,7 @@
     <p>{ts 1=$whom_url 2=$whom_name|escape 3=$who_url 4=$who_name|escape 5=$log_date}Change to <a href='%1'>%2</a> made by <a href='%3'>%4</a> on %5:{/ts}</p>
     {if $layout eq 'overlay'}
       {include file="CRM/Report/Form/Layout/Overlay.tpl"}
-    {else}
+    {elseif !$chartEnabled || !$chartSupported}
       {include file="CRM/Report/Form/Layout/Table.tpl"}
     {/if}
   {else}

--- a/templates/CRM/Report/Form.tpl
+++ b/templates/CRM/Report/Form.tpl
@@ -16,7 +16,9 @@
 {elseif $section eq 2}
   <div class="crm-block crm-content-block crm-report-layoutTable-form-block">
     {*include the table layout*}
-    {include file="CRM/Report/Form/Layout/Table.tpl"}
+    {if !$chartEnabled || !$chartSupported}
+      {include file="CRM/Report/Form/Layout/Table.tpl"}
+    {/if}
   </div>
 {else}
   {if $criteriaForm OR $instanceForm OR $instanceFormError}
@@ -36,7 +38,10 @@
     {include file="CRM/Report/Form/Layout/Graph.tpl"}
 
     {*include the table layout*}
-    {include file="CRM/Report/Form/Layout/Table.tpl"}
+
+    {if !$chartEnabled || !$chartSupported}
+      {include file="CRM/Report/Form/Layout/Table.tpl"}
+    {/if}
     <br />
     {*Statistics at the bottom of the page*}
     {include file="CRM/Report/Form/Statistics.tpl" bottom=true}

--- a/templates/CRM/Report/Form/Layout/Table.tpl
+++ b/templates/CRM/Report/Form/Layout/Table.tpl
@@ -7,7 +7,9 @@
  | and copyright information, see https://civicrm.org/licensing       |
  +--------------------------------------------------------------------+
 *}
-{if (!$chartEnabled || !$chartSupported )&& $rows}
+{if !$rows}
+  <p>{ts}None found.{/ts}</p>
+{else}
     {if $pager and $pager->_response and $pager->_response.numPages > 1}
         <div class="report-pager">
             {include file="CRM/common/pager.tpl" location="top"}


### PR DESCRIPTION


Overview
----------------------------------------
Adds explanatory text in place of results when a report returns no results

Before
----------------------------------------
![before](https://user-images.githubusercontent.com/336308/109080515-9929fc80-7765-11eb-82b4-26e463e60d0d.png)

After
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/109086439-7224f800-7770-11eb-98f5-b26dd48f5fdf.png)


Technical Details
----------------------------------------
This is very much the minimum required to reduce confusion & leave all worms in their cans

Note this is done to create minimum white space change. I actuallY
think the criteria around charts should be in the tpl that
makes the decision to include Table.tpl rather than in Table.tpl
and this would become {if !$rows}{/else}{ts}No results found{/ts}{/if}

I can do that as a follow up if agreed

Comments
----------------------------------------

