### PR TITLE
Switch afform back to '=' to unbreak deduper

### DIFF
--- a/ext/afform/core/ang/afCore.js
+++ b/ext/afform/core/ang/afCore.js
@@ -7,7 +7,7 @@
     return function(camelName, meta, d) {
       d.restrict = 'E';
       d.scope = {};
-      d.scope.options = '<';
+      d.scope.options = '=';
       d.link = {
         pre: function($scope, $el, $attr) {
           $scope.ts = CRM.ts(camelName);


### PR DESCRIPTION


Overview
----------------------------------------
Fixes a regression in deduper cause by the afform changes in 5.35 

Before
----------------------------------------
Console errors as described in https://github.com/eileenmcnaughton/deduper/pull/9

After
----------------------------------------
works again 

Technical Details
----------------------------------------
@colemanw - @totten & I discussed this in chat - wondering what issues you see with the change that fixes the breakage
https://chat.civicrm.org/civicrm/pl/oihjuqjxtfnhicdtroguad3quy

Comments
----------------------------------------
