### PR TITLE
Fixes dev/core#2424 navigation items order

### DIFF
--- a/CRM/Core/BAO/Navigation.php
+++ b/CRM/Core/BAO/Navigation.php
@@ -302,7 +302,7 @@ FROM civicrm_navigation WHERE domain_id = $domainID";
     });
 
     // If any of the $navigations have children, recurse
-    foreach ($navigations as $navigation) {
+    foreach ($navigations as &$navigation) {
       if (isset($navigation['child'])) {
         self::orderByWeight($navigation['child']);
       }


### PR DESCRIPTION
Overview
----------------------------------------

Changing the order of navigation menu items by programming code doesn't work.

For example in my extension I have a navigation item which I want to show at the top of the search menu.
So I give it a weight of -100. (A lower weight means sorting to top, a higher weight sorting to bottom).

```php
_testnav_civix_insert_navigation_menu($menu, 'Search', array(
    'label' => E::ts('Test Navigation'),
    'name' => 'test_navigation',
    'url' => 'civicrm/mypage',
    'permission' => 'access CiviCRM',
    'operator' => 'OR',
    'separator' => 0,
    'weight' => -100
  ));
  _testnav_civix_navigationMenu($menu);
}
```

However the code above does't work.

Before
----------------------------------------

The foreach loop in the `orderByWeight` function in `CRM_Core_BAO_Navigation` did pass back the changed array when calling the function recursively.

After
----------------------------------------

Added an `&` and now the foreach loop in the `orderByWeight` function in `CRM_Core_BAO_Navigation` does pass back the changes in the navigation menu.

See https://lab.civicrm.org/dev/core/-/issues/2424
