### PR TITLE
dev/core#1400 - Put dashlets back to only showing open cases by default

### DIFF
--- a/CRM/Dashlet/Page/AllCases.php
+++ b/CRM/Dashlet/Page/AllCases.php
@@ -42,6 +42,13 @@ class CRM_Dashlet_Page_AllCases extends CRM_Core_Page {
     );
     $controller->setEmbedded(TRUE);
     $controller->process();
+
+    // Default to cases with statuses that represent Open
+    $caseStatusGroupings = CRM_Core_OptionGroup::values('case_status', TRUE, TRUE, FALSE, NULL, 'value');
+    $caseStatuses = array_keys(array_intersect($caseStatusGroupings, ['Opened']));
+    $form = current($controller->_pages);
+    $form->setDefaults(['case_status_id' => $caseStatuses]);
+
     $controller->run();
 
     if (CRM_Case_BAO_Case::getCases(TRUE, ['type' => 'any'], 'dashboard', TRUE)) {

--- a/CRM/Dashlet/Page/MyCases.php
+++ b/CRM/Dashlet/Page/MyCases.php
@@ -42,6 +42,13 @@ class CRM_Dashlet_Page_MyCases extends CRM_Core_Page {
     );
     $controller->setEmbedded(TRUE);
     $controller->process();
+
+    // Default to cases with statuses that represent Open
+    $caseStatusGroupings = CRM_Core_OptionGroup::values('case_status', TRUE, TRUE, FALSE, NULL, 'value');
+    $caseStatuses = array_keys(array_intersect($caseStatusGroupings, ['Opened']));
+    $form = current($controller->_pages);
+    $form->setDefaults(['case_status_id' => $caseStatuses]);
+
     $controller->run();
 
     if (CRM_Case_BAO_Case::getCases(FALSE, ['type' => 'any'], $context, TRUE)) {


### PR DESCRIPTION
Overview
----------------------------------------
This is pending what happens with #19666.

Before
----------------------------------------
Before 19666, case dashlets only show open cases when first displayed.

After
----------------------------------------
After 19666, it causes them to start showing closed cases too. This puts it back to open cases.

Technical Details
----------------------------------------


Comments
----------------------------------------

