### PR TITLE
Fix converting to a managed entity

### DIFF
--- a/CRM/Core/ManagedEntities.php
+++ b/CRM/Core/ManagedEntities.php
@@ -236,6 +236,14 @@ class CRM_Core_ManagedEntities {
    *   Entity specification (per hook_civicrm_managedEntities).
    */
   public function insertNewEntity($todo) {
+    // If you have an existing entity and you want to convert it to managed you have to check if it already exists.
+    // Otherwise it will crash with DB error duplicate entry (eg. for PaymentProcessorType)
+    $existingEntity = civicrm_api3($todo['entity'], 'get', $todo['params']);
+    if (!empty($existingEntity['id'])) {
+      \Civi::log()->warning('Found existing entity, overwriting with managed version.', ['todoparams' => $todo['params']]);
+      $todo['params']['id'] = $existingEntity['id'];
+    }
+
     $result = civicrm_api($todo['entity'], 'create', $todo['params']);
     if ($result['is_error']) {
       $this->onApiError($todo['entity'], 'create', $todo['params'], $result);

--- a/api/v3/CustomSearch.php
+++ b/api/v3/CustomSearch.php
@@ -16,6 +16,23 @@
  */
 
 /**
+ * Adjust Metadata for Get action.
+ *
+ * The metadata is used for setting defaults, documentation & validation.
+ *
+ * @param array $params
+ *   Array of parameters determined by getfields.
+ */
+function _civicrm_api3_custom_search_get_spec(&$params) {
+  require_once 'api/v3/OptionValue.php';
+  _civicrm_api3_option_value_get_spec($params);
+  $params['option_group_id']['api.default'] = CRM_Core_DAO::getFieldValue(
+    'CRM_Core_DAO_OptionGroup', 'custom_search', 'id', 'name'
+  );
+  $params['name']['api.aliases'] = ['class_name'];
+}
+
+/**
  * Retrieve custom searches.
  *
  * @param array $params


### PR DESCRIPTION
Overview
----------------------------------------
If you have an entity that is already installed and does *not* use a managed entity you cannot convert it to a managed entity without renaming/deleting it first. Adding the managed entity definition causes the rebuild (cacheclear) to crash with "Cannot insert duplicate entry.

Before
----------------------------------------
Cannot convert to managed entity without mess.

After
----------------------------------------
Can easily convert to managed entity using identical parameters.

Technical Details
----------------------------------------
See eg. https://lab.civicrm.org/extensions/redsys

I suggested converting this to use a managed entity. eg. create the file redsys.mgd.php:
```
<?php

/**
 * The record will be automatically inserted, updated, or deleted from the
 * database as appropriate. For more details, see "hook_civicrm_managed" at:
 * https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_managed/
 */
return [
  0 => [
    'name' => 'Redsys',
    'entity' => 'PaymentProcessorType',
    'params' => [
      'name' => 'Redsys',
    'title' => 'Redsys Payment Processor',
    'description' => 'Works with Servired (Sermepa) and 4B (Pasat).',
    'class_name' => 'Payment_Redsys',
    'billing_mode' => 'notify',
    'user_name_label' => 'Número de comercio',
    'password_label' => 'Clave secreta de encriptación',
    'url_site_default' => 'https://sis.redsys.es/sis/realizarPago',
    'url_site_test_default' => 'https://sis-t.redsys.es:25443/sis/realizarPago',
    'is_recur' => 0,
    'payment_type' => 1,
    ],
  ]
];
```

but we can't do that because it has already been installed manually via the API in `CRM_Redsys_Upgrader::addRedsysPayment()`.

Comments
----------------------------------------
As the entity loader can be used with multiple entities I'm checking for an exact match. For PaymentProcessorType we have a unique key on "name" which is why the conversion fails. For other entities the parameters are different (eg. Scheduled Job allows you to add multiple of the same name).  I don't see any reason to *automatically* add a duplicate job.

From what I understand from @kcristiano adding jobs per domain in multisite doesn't happen automatically so this will make that situation no worse. Perhaps the ManagedEntity loader is not domain aware? We should look at that as a follow-up PR?

@sluc23 This should fix the problems you had with redsys / managed entities conversion.
