### PR TITLE
Joomla::synchronizeUsers - Fix notice due to old style reference

### DIFF
--- a/CRM/Utils/System/Joomla.php
+++ b/CRM/Utils/System/Joomla.php
@@ -842,7 +842,7 @@ class CRM_Utils_System_Joomla extends CRM_Utils_System_Base {
     $mail = 'email';
     $name = 'name';
 
-    $JUserTable = &JTable::getInstance('User', 'JTable');
+    $JUserTable = JTable::getInstance('User', 'JTable');
 
     $db = $JUserTable->getDbo();
     $query = $db->getQuery(TRUE);


### PR DESCRIPTION
Overview
----------------------------------------

This fixes a PHP notice when synchronizing all users/contacts.

Before
----------------------------------------

```
PHP Notice:  Only variables should be assigned by reference in ...CRM/Utils/System/Joomla.php:855
```

After
----------------------------------------

No notice.

Comments
----------------------------------------

I think I got this notice originally while running authx's `AllFlowsTest`. You can probably replicate with something like

```
cv ev '\CRM_Utils_System::synchronizeUsers();'
```