### PR TITLE
dev/financial#166 Fix for inconsistency around currency symbol

### DIFF
--- a/CRM/Utils/Money.php
+++ b/CRM/Utils/Money.php
@@ -215,8 +215,7 @@ class CRM_Utils_Money {
     // fix to allow us to resolve formatLocaleNumericRoundedByPrecision
     // and to make the function comments correct - but, we need to reconsider this
     // in master as it is probably better to use locale than our currency separator fields.
-    $formatter = new \NumberFormatter('en_US', NumberFormatter::CURRENCY);
-    $formatter->setSymbol(\NumberFormatter::CURRENCY_SYMBOL, '');
+    $formatter = new \NumberFormatter('en_US', NumberFormatter::DECIMAL);
     $formatter->setAttribute(\NumberFormatter::MIN_FRACTION_DIGITS, $numberOfPlaces);
     return $money->formatWith($formatter);
   }


### PR DESCRIPTION

Overview
----------------------------------------
Potential fix for inconsistencies around money handling in code that should not display a currency symbol

Before
----------------------------------------
On some (most?) installs 
```
CRM_Utils_Money::formatLocaleNumericRounded(20.453, 2)
```
returns 20.45 or 20,45 depending on the locale

But on others appears to return $20.45


After
----------------------------------------
Hopefully it's more consistent (pending response from @MegaphoneJon & @larssandergreen )

Technical Details
----------------------------------------

From https://lab.civicrm.org/dev/financial/-/issues/166 we learn that the existing code
(tested via testFormatLocaleNumericRoundedByCurrency) is not consistent across
all platforms. I think this may be

Comments
----------------------------------------
