### PR TITLE
dev/core#2394: Editting money values in a CiviCase custom field

### DIFF
--- a/CRM/Case/Form/CustomData.php
+++ b/CRM/Case/Form/CustomData.php
@@ -156,12 +156,7 @@ class CRM_Case_Form_CustomData extends CRM_Core_Form {
         if (!empty($customFieldId) && is_numeric($customFieldId)) {
           // Got a custom field ID
           $label = civicrm_api3('CustomField', 'getvalue', ['id' => $customFieldId, 'return' => 'label']);
-          $oldValue = civicrm_api3('CustomValue', 'getdisplayvalue', [
-            'custom_field_id' => $customFieldId,
-            'entity_id' => $this->_entityID,
-            'custom_field_value' => $this->_defaults[$customField],
-          ]);
-          $oldValue = $oldValue['values'][$customFieldId]['display'];
+          $oldValue = $this->_defaults[$customField];
           $newValue = civicrm_api3('CustomValue', 'getdisplayvalue', [
             'custom_field_id' => $customFieldId,
             'entity_id' => $this->_entityID,


### PR DESCRIPTION
Overview
----------------------------------------

Issue with Money custom fields on a case and with a localized settings.

To reproduce create a money text field on a case. Set your civicrm localiszation settings to ',' as a decimal separator.

Then add a value to the custom field on a case. Save it. It went well. Now try to change the existing values. 
The popup does not go away and civicrm logo keeps running. 

Behind the screen this error is shown (visible when you have a tool like Network inspector open in your browser). 

![Screenshot_20210226_134756](https://user-images.githubusercontent.com/4126292/109306656-c0ed9300-783f-11eb-8a66-971368cbfd46.png)

Before
----------------------------------------

Changing a money field on a case would result in an error. 

After
----------------------------------------

Changing a money field on a case would work as expected. 

Technical Details
----------------------------------------

The `CRM_Case_Form_CustomData` class contains a function which compared the old displayed value with the new displayed value. The old displayed value was retrieved with the api `CustomField.getdisplayvalue` and the value passed in was the old value formatted for display and which is retrieved with the function `CRM_Core_BAO_CustomGroup::setDefaults`.

Comments
----------------------------------------

I am not sure whether this is the right fix but that is caused by that I do not understand fully what and why this code is the way it is. 
