### PR TITLE
Reduce wasted space in civicrm dashboard margins

### DIFF
--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -1,5 +1,6 @@
 #civicrm-dashboard > .crm-flex-box {
   min-height: 200px;
+  column-gap: 10px;
 }
 
 #civicrm-dashboard > .crm-flex-box > .crm-flex-2 {
@@ -10,7 +11,7 @@
 }
 
 .crm-container .crm-dashlet {
-  margin: 10px;
+  margin-bottom: 10px;
   box-shadow: 1px 1px 4px 1px rgba(0,0,0,0.2);
   border-radius: 3px;
 }


### PR DESCRIPTION
Overview
----------------------------------------
This removes the extra margins to the top and sides of the home dashboard page, only placing margins between the dashlets.

Per https://lab.civicrm.org/dev/core/-/issues/2421

Comments
----------------------------------------
The change is too subtle to show up in screenshots but the effect is 10 more pixels of dashboard on the top and sides.
