### PR TITLE
info.xml - Allow multiple `<author>`s

### DIFF
--- a/CRM/Extension/Info.php
+++ b/CRM/Extension/Info.php
@@ -51,6 +51,21 @@ class CRM_Extension_Info {
   public $tags = [];
 
   /**
+   * @var array
+   *   List of authors.
+   *   Ex: [0 => ['name' => 'Alice', 'email' => 'a@b', 'homepage' => 'https://example.com', 'role' => 'Person']]
+   */
+  public $authors = [];
+
+  /**
+   * @var array|null
+   *   The current maintainer at time of publication.
+   *   This is deprecated in favor of $authors.
+   * @deprecated
+   */
+  public $maintainer = NULL;
+
+  /**
    * Load extension info an XML file.
    *
    * @param $file
@@ -169,6 +184,22 @@ class CRM_Extension_Info {
       }
       elseif ($attr === 'requires') {
         $this->requires = $this->filterRequirements($val);
+      }
+      elseif ($attr === 'maintainer') {
+        $this->maintainer = CRM_Utils_XML::xmlObjToArray($val);
+        $this->authors[] = [
+          'name' => (string) $val->author,
+          'email' => (string) $val->email,
+          'role' => 'Maintainer',
+        ];
+      }
+      elseif ($attr === 'authors') {
+        foreach ($val->author as $author) {
+          $this->authors[] = $thisAuthor = CRM_Utils_XML::xmlObjToArray($author);
+          if ('maintainer' === strtolower($thisAuthor['role'] ?? '')) {
+            $this->maintainer = ['author' => $thisAuthor['name'], 'email' => $thisAuthor['email'] ?? NULL];
+          }
+        }
       }
       else {
         $this->$attr = CRM_Utils_XML::xmlObjToArray($val);

--- a/templates/CRM/Admin/Page/ExtensionDetails.tpl
+++ b/templates/CRM/Admin/Page/ExtensionDetails.tpl
@@ -3,7 +3,17 @@
             <tr><td class="label">{$label}</td><td><a href="{$url}">{$url}</a></td></tr>
         {/foreach}
     <tr>
-        <td class="label">{ts}Author{/ts}</td><td>{$extension.maintainer.author} (<a href="mailto:{$extension.maintainer.email}">{$extension.maintainer.email}</a>)</td>
+        <td class="label">{ts}Author{/ts}</td>
+        <td>
+          {foreach from=$extension.authors item=author}
+            {capture assign=authorDetails}
+              {if $author.role}{$author.role|escape};{/if}
+              {if $author.email}<a href="mailto:{$author.email|escape}">{$author.email|escape}</a>;{/if}
+              {if $author.homepage}<a href="{$author.homepage|escape}">{$author.homepage|escape}</a>;{/if}
+            {/capture}
+            {$author.name|escape} {if $authorDetails}({$authorDetails|trim:'; '}){/if}<br/>
+          {/foreach}
+        </td>
     </tr>
     <tr>
       <td class="label">{ts}Comments{/ts}</td><td>{$extension.comments}</td>

--- a/tests/phpunit/CRM/Extension/InfoTest.php
+++ b/tests/phpunit/CRM/Extension/InfoTest.php
@@ -68,6 +68,38 @@ class CRM_Extension_InfoTest extends CiviUnitTestCase {
     $this->assertEquals(['org.civicrm.a', 'org.civicrm.b'], $info->requires);
   }
 
+  public function getExampleAuthors() {
+    $authorAliceXml = '<author><name>Alice</name><email>alice@example.org</email><role>Maintainer</role></author>';
+    $authorAliceArr = ['name' => 'Alice', 'email' => 'alice@example.org', 'role' => 'Maintainer'];
+    $authorBobXml = ' <author><name>Bob</name><homepage>https://example.com/bob</homepage><role>Developer</role></author>';
+    $authorBobArr = ['name' => 'Bob', 'homepage' => 'https://example.com/bob', 'role' => 'Developer'];
+
+    $maintAliceXml = '<maintainer><author>Alice</author><email>alice@example.org</email></maintainer>';
+    $maintAliceArr = ['author' => 'Alice', 'email' => 'alice@example.org'];
+
+    $hdr = "<extension key='test.author' type='module'><file>testauthor</file>";
+    $ftr = "</extension>";
+
+    // Maintainers can be inputted via either <maintainer> or <authors> (with role).
+    // Maintainers are outputted via both `$info->maintainer` and `$info->authors` (with role)
+
+    $cases = [];
+    $cases[] = ["{$hdr}{$maintAliceXml}{$ftr}", [$authorAliceArr], $maintAliceArr];
+    $cases[] = ["{$hdr}<authors>{$authorAliceXml}</authors>{$ftr}", [$authorAliceArr], $maintAliceArr];
+    $cases[] = ["{$hdr}<authors>{$authorAliceXml}{$authorBobXml}</authors>{$ftr}", [$authorAliceArr, $authorBobArr], $maintAliceArr];
+    $cases[] = ["{$hdr}<authors>{$authorBobXml}</authors>{$ftr}", [$authorBobArr], NULL];
+    return $cases;
+  }
+
+  /**
+   * @dataProvider getExampleAuthors
+   */
+  public function testAuthors($xmlString, $expectAuthors, $expectMaintainer) {
+    $info = CRM_Extension_Info::loadFromString($xmlString);
+    $this->assertEquals($expectAuthors, $info->authors);
+    $this->assertEquals($expectMaintainer, $info->maintainer);
+  }
+
   public function testBad_string() {
     // <file> vs file>
     $data = "<extension key='test.foo' type='module'>file>foo</file></extension>";


### PR DESCRIPTION
Overview
----------------------------------------

Per https://lab.civicrm.org/dev/core/-/issues/2418, this expands the schema for `info.xml` to accept additional authors. The revised schema is designed to allow backward/forward compatibility and to match the semantics of [composer.json authors](https://getcomposer.org/doc/04-schema.md#authors).

ping @MikeyMJCO @mattwire @twomice 

Before
----------------------------------------

The `info.xml` can track one `<maintainer>`.

```xml
<maintainer>
  <author>Alice</author>
  <email>alice@example.org</email>
</maintainer>
```

After
----------------------------------------

The `info.xml` may still indicate a primary `<maintainer>`. This ensures compatibility with older versions of Civi and other parts of the distribution system. Additional authors (with roles and contact info) can be listed in `<authors>`, eg

```xml
  <authors>
    <author>
      <name>Bob</name>
      <email>bob@example.com</email>
      <homepage>https://example.com/bob</homepage>
      <role>Maintainer</role>
    </author>
  </authors>
```

Here's a longer example with multiple maintainers/authors.

```xml
  <maintainer>
    <author>Alice</author>
    <email>alice@example.org</email>
  </maintainer>
  <authors>
    <author><name>Bob</name><homepage>https://example.com/bob</homepage></author>
    <author><name>Carol</name><email>carol@example.org</email><role>Maintainer</role></author>
  </authors>
```

Note that they are combined into one list:

![Screenshot from 2021-02-26 14-17-23](https://user-images.githubusercontent.com/1336047/109361218-6bb08200-783d-11eb-83de-7a508852053d.png)

(Note: To control the order in display, just reorder the tags..)

Comments
----------------------------------------

If we update the other parts of the distribution system and wait a year, then we can deprecate `<maintainer>` in favor of the more flexible `<authors>`. 