### PR TITLE
dev/core:2394 Fix for number formatting regression

### DIFF
--- a/CRM/Utils/Money.php
+++ b/CRM/Utils/Money.php
@@ -208,7 +208,14 @@ class CRM_Utils_Money {
       return self::formatNumericByFormat($amount, '%!.' . $numberOfPlaces . 'i');
     }
     $money = Money::of($amount, CRM_Core_Config::singleton()->defaultCurrency, new CustomContext($numberOfPlaces), RoundingMode::CEILING);
-    $formatter = new \NumberFormatter(CRM_Core_I18n::getLocale(), NumberFormatter::CURRENCY);
+    // @todo - we specify en_US here because we don't want this function to do
+    // currency replacement at the moment because
+    // formatLocaleNumericRoundedByPrecision is doing it and if it
+    // is done there then it is swapped back in there.. This is a short term
+    // fix to allow us to resolve formatLocaleNumericRoundedByPrecision
+    // and to make the function comments correct - but, we need to reconsider this
+    // in master as it is probably better to use locale than our currency separator fields.
+    $formatter = new \NumberFormatter('en_US', NumberFormatter::CURRENCY);
     $formatter->setSymbol(\NumberFormatter::CURRENCY_SYMBOL, '');
     $formatter->setAttribute(\NumberFormatter::MIN_FRACTION_DIGITS, $numberOfPlaces);
     return $money->formatWith($formatter);


### PR DESCRIPTION

Overview
----------------------------------------
Regression fix for https://lab.civicrm.org/dev/core/-/issues/2394

Before
----------------------------------------
Currency separators messed up in some cases (see ticket)

After
----------------------------------------
@MegaphoneJon I'm hoping the answer here is 'fixed'

Technical Details
----------------------------------------
This function has been picking up the formatting for the locale
meaning that the currency separator replacement is already done and
is swapped back by formatLocaleNumericRoundedByPrecision

Doing it via brickmoney is better than our custom
separator replacement  - but we need a quick fix for the rc

Comments
----------------------------------------
