### PR TITLE
SearchKit - Fix clearing selection behavior

### DIFF
--- a/ext/search/ang/crmSearchAdmin/crmSearchAdmin.component.js
+++ b/ext/search/ang/crmSearchAdmin/crmSearchAdmin.component.js
@@ -520,7 +520,7 @@
 
       this.refreshAll = function() {
         ctrl.stale = true;
-        ctrl.selectedRows.length = 0;
+        clearSelection();
         loadResults();
       };
 
@@ -577,17 +577,21 @@
 
       function onChangeFilters() {
         ctrl.stale = true;
-        ctrl.selectedRows.length = 0;
+        clearSelection();
         if (ctrl.autoSearch) {
           ctrl.refreshAll();
         }
       }
 
+      function clearSelection() {
+        ctrl.allRowsSelected = false;
+        ctrl.selectedRows.length = 0;
+      }
+
       $scope.selectAllRows = function() {
         // Deselect all
         if (ctrl.allRowsSelected) {
-          ctrl.allRowsSelected = false;
-          ctrl.selectedRows.length = 0;
+          clearSelection();
           return;
         }
         // Select all


### PR DESCRIPTION
Overview
-----------
This fixes the bug documented in https://lab.civicrm.org/dev/core/-/issues/2419

Before
----------------------------------------
After selecting all rows and updating search criteria, the rows would all still appear to be selected but the Actions menu would be disabled.

After
----------------------------------------
After selecting all (or any) rows and updating search criteria, the selection will be cleared (which was the original intent).

Technical Details
----------------------------------------
The variables `allRowsSelected` and `selectedRows` were sometimes getting out-of-sync.
This adds a function to help ensure they both get updated at the same time when the selection needs to be cleared.