### PR TITLE
Afform - Support embedding forms via WP shortcodes.

### DIFF
--- a/api/v3/Generic/Getlist.php
+++ b/api/v3/Generic/Getlist.php
@@ -27,7 +27,7 @@ function civicrm_api3_generic_getList($apiRequest) {
   $meta = civicrm_api3_generic_getfields(['action' => 'get'] + $apiRequest, FALSE);
 
   // If the user types an integer into the search
-  $forceIdSearch = empty($request['id']) && !empty($request['input']) && CRM_Utils_Rule::positiveInteger($request['input']);
+  $forceIdSearch = empty($request['id']) && !empty($request['input']) && !empty($meta['id']) && CRM_Utils_Rule::positiveInteger($request['input']);
   // Add an extra page of results for the record with an exact id match
   if ($forceIdSearch) {
     $request['page_num'] = ($request['page_num'] ?? 1) - 1;
@@ -230,7 +230,7 @@ function _civicrm_api3_generic_getlist_output($result, $request, $entity, $field
             }
           }
         }
-      };
+      }
       if (!empty($request['image_field'])) {
         $data['image'] = $row[$request['image_field']] ?? '';
       }

--- a/ext/afform/core/api/v3/Afform.php
+++ b/ext/afform/core/api/v3/Afform.php
@@ -1,0 +1,119 @@
+<?php
+
+/**
+ * Get a list of afforms.
+ *
+ * This API exists solely for the purpose of entityRef widgets.
+ * All other Afform api functionality is v4.
+ *
+ * @param array $params
+ *
+ * @return array
+ *   API result
+ */
+function civicrm_api3_afform_get($params) {
+  /** @var \CRM_Afform_AfformScanner $scanner */
+  $scanner = \Civi::service('afform_scanner');
+
+  $names = array_keys($scanner->findFilePaths());
+  $result = [];
+
+  foreach ($names as $name) {
+    $info = [
+      'name' => $name,
+      'module_name' => _afform_angular_module_name($name, 'camel'),
+      'directive_name' => _afform_angular_module_name($name, 'dash'),
+    ];
+    $record = $scanner->getMeta($name);
+    $result[$name] = array_merge($record, $info);
+  }
+
+  $allFields = [];
+  _civicrm_api3_afform_get_spec($allFields);
+  return _civicrm_api3_basic_array_get('Afform', $params, $result, 'name', array_keys($allFields));
+}
+
+/**
+ * @param array $fields
+ */
+function _civicrm_api3_afform_get_spec(&$fields) {
+  $fields['name'] = [
+    'title' => 'Name',
+    'type' => CRM_Utils_Type::T_STRING,
+  ];
+  $fields['title'] = [
+    'title' => 'Title',
+    'type' => CRM_Utils_Type::T_STRING,
+  ];
+  $fields['module_name'] = [
+    'title' => 'Module Name',
+    'type' => CRM_Utils_Type::T_STRING,
+  ];
+  $fields['directive_name'] = [
+    'title' => 'Directive Name',
+    'type' => CRM_Utils_Type::T_STRING,
+  ];
+  $fields['description'] = [
+    'title' => 'Description',
+    'type' => CRM_Utils_Type::T_STRING,
+  ];
+  $fields['server_route'] = [
+    'title' => 'Server Route',
+    'type' => CRM_Utils_Type::T_STRING,
+  ];
+  $fields['type'] = [
+    'title' => 'Type',
+    'type' => CRM_Utils_Type::T_STRING,
+  ];
+  $fields['is_dashlet'] = [
+    'title' => 'Dashlet',
+    'type' => CRM_Utils_Type::T_BOOLEAN,
+  ];
+  $fields['is_public'] = [
+    'title' => 'Public',
+    'type' => CRM_Utils_Type::T_BOOLEAN,
+  ];
+}
+
+/**
+ * Augment parameters for Afform entityRef list.
+ *
+ * @see _civicrm_api3_generic_getlist_params
+ *
+ * @param array $request
+ *   API request.
+ */
+function _civicrm_api3_afform_getlist_params(&$request) {
+  $fieldsToReturn = ['name', 'title', 'type', 'description'];
+  $request['params']['return'] = array_unique(array_merge($fieldsToReturn, $request['extra']));
+}
+
+/**
+ * Format output for Afform entityRef list.
+ *
+ * @see _civicrm_api3_generic_getlist_output
+ *
+ * @param array $result
+ * @param array $request
+ *
+ * @return array
+ */
+function _civicrm_api3_afform_getlist_output($result, $request) {
+  $output = [];
+  if (!empty($result['values'])) {
+    $icons = CRM_Core_OptionGroup::values('afform_type', FALSE, FALSE, FALSE, NULL, 'icon', FALSE);
+    foreach ($result['values'] as $row) {
+      $data = [
+        'id' => $row[$request['id_field']],
+        'label' => $row[$request['label_field']],
+        'description' => [],
+        'icon' => $icons[$row['type']],
+      ];
+      if (!empty($row['description'])) {
+        $data['description'][] = $row['description'];
+      }
+      $output[] = $data;
+    }
+  }
+  return $output;
+}

--- a/js/Common.js
+++ b/js/Common.js
@@ -756,6 +756,7 @@ if (!CRM.vars) CRM.vars = {};
     }
     markup += '<div><div class="crm-select2-row-label '+(row.label_class || '')+'">' +
       (row.color ? '<span class="crm-select-item-color" style="background-color: ' + row.color + '"></span> ' : '') +
+      (row.icon ? '<i class="crm-i ' + row.icon + '" aria-hidden="true"></i> ' : '') +
       _.escape((row.prefix !== undefined ? row.prefix + ' ' : '') + row.label + (row.suffix !== undefined ? ' ' + row.suffix : '')) +
       '</div>' +
       '<div class="crm-select2-row-description">';


### PR DESCRIPTION
Overview
----------------------------------------
This adds support for Afform shortcodes. It allows any Custom Form or Search Form to be embedded in a WP page or post.

![image](https://user-images.githubusercontent.com/2874912/109405419-57a07980-793e-11eb-864f-b81c88be4dab.png)

<hr>

![image](https://user-images.githubusercontent.com/2874912/109393716-64e34700-78f1-11eb-97d5-6dbd7cf68c52.png)

Technical Details
----------------------------------------
There were 2 technical challenges that have been fixed for this PR:

1. In order for the EntityRef widget to fully work, a v3 API needed to be added for Afform, and APIv3 needed improvements to  the `_civicrm_api3_basic_array_get` function to accept more operators than just `=`. Fixed via #19690 

2. Civi's shortcode handling needed to be updated so that content could be loaded via callback instead of running a server route. Fixed via https://github.com/civicrm/civicrm-wordpress/pull/244