### PR TITLE
Fix for missing function CodeGen_Util::removeDir

### DIFF
--- a/CRM/Core/CodeGen/Util/File.php
+++ b/CRM/Core/CodeGen/Util/File.php
@@ -38,7 +38,7 @@ class CRM_Core_CodeGen_Util_File {
   public static function createTempDir($prefix) {
     $newTempDir = tempnam(sys_get_temp_dir(), $prefix) . '.d';
     if (file_exists($newTempDir)) {
-      self::removeDir($newTempDir);
+      self::cleanTempDir($newTempDir);
     }
     self::createDir($newTempDir);
 


### PR DESCRIPTION
Overview
----------------------------------------
The removeDir function was renamed a long time ago at https://github.com/civicrm/civicrm-core/commit/0eed9eccea7dcedff96953e7745c3f76f2b247e0 but a call to it was left in. It would be really rare to trigger this line but this actually came up for me running unit tests locally.

Before
----------------------------------------
error

After
----------------------------------------
not error

Technical Details
----------------------------------------
I didn't calculate the odds of this coming up, but true story: I don't usually buy lottery tickets but did yesterday. I didn't win any money but the fact that this line got triggered makes me think the two must be connected somehow. Calculating the odds of a lottery win vs this line coming up is left as an exercise to the reader.

Comments
----------------------------------------
