### PR TITLE
dev/core#1207 - My Cases dashlet shouldn't crash for users with only my cases access

### DIFF
--- a/templates/CRM/Case/Page/DashboardSelector.tpl
+++ b/templates/CRM/Case/Page/DashboardSelector.tpl
@@ -31,11 +31,19 @@
       var selectorClass = '.case-selector-' + list;
       var filterClass = '.case-search-options-' + list;
 
+      // Determine the url `type` parameter which is a combination of `list` and the `upcoming` checkbox.
+      // @todo This seems fragile. It makes `list` serve double-duty, and also relies on the fact that when list=all-cases that can only happen for users with all cases permission, which itself is what determines whether the upcoming checkbox is present.
+      var computeGetCasesType = function(selectorListType) {
+        return (!$("input[name='upcoming']").length) ?
+          (selectorListType == 'my-cases' ? 'any' : selectorListType) :
+          ($("input[name='upcoming']").prop('checked') ? 'upcoming' : 'any');
+      }
+
       CRM.$('table' + selectorClass).data({
         "ajax": {
           "url": {/literal}'{crmURL p="civicrm/ajax/get-cases" h=0 q="snippet=4&all=`$all`"}'{literal},
           "data": function (d) {
-            d.type = (!$("input[name='upcoming']").length) ? list : $("input[name='upcoming']").prop('checked') ? 'upcoming' : 'any';
+            d.type = computeGetCasesType(list);
             d.case_type_id = $(filterClass + ' select#case_type_id').val() || [];
             d.case_type_id = d.case_type_id.join(',');
             d.status_id = $(filterClass + ' select#case_status_id').val() || [];


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/1207

1. Turn on civicase.
2. Make a user that has access my cases and activities permission but not access all cases and activities permission.
3. Log in as that user.
4. Create a case (the problem doesn't appear if there aren't any cases).
5. Add the My Cases dashlet to the dashboard.
6. Cursor spins.

Before
----------------------------------------
* Spinning logo.
* DB error: no such field
  * Unknown column 't_act.activity_type_id' in 'field list'

After
----------------------------------------
Dashlet loads

Technical Details
----------------------------------------
The ajax call is passing an invalid value for the `type` url parameter, but it only happens when the user only has Access My Cases permission and only for the My Cases dashlet. When type isn't one of the valid values then there's a missing table in the query that gets generated. See ticket for more details.

The material code change here is that the middle expression in the if-else-then is replaced with an expression that converts "my-cases" to "any". The rest is I just moved it into a function.

Note that `list` is also used as part of the css class names and ultimately how the datatable is targeted, so I didn't want to change anything around that.

Comments
----------------------------------------
I can't think of how to write a test for this since it's in the javascript and the problem is an invalid value is being put in the url.
