### PR TITLE
APIv3 - Improve array-based apis to support sorting and operators

### DIFF
--- a/tests/phpunit/api/v3/UtilsTest.php
+++ b/tests/phpunit/api/v3/UtilsTest.php
@@ -376,14 +376,44 @@ class api_v3_UtilsTest extends CiviUnitTestCase {
 
     $cases[] = [
       $records,
-      ['version' => 3, 'cheese' => 'cheddar'],
+      ['version' => 3, 'cheese' => 'cheddar', 'options' => ['sort' => 'fruit desc']],
       ['b', 'c'],
+    ];
+
+    $cases[] = [
+      $records,
+      ['version' => 3, 'cheese' => 'cheddar', 'options' => ['sort' => 'fruit']],
+      ['c', 'b'],
+    ];
+
+    $cases[] = [
+      $records,
+      ['version' => 3, 'cheese' => ['IS NOT NULL' => 1], 'options' => ['sort' => 'fruit, cheese']],
+      ['c', 'd', 'e', 'a', 'b'],
     ];
 
     $cases[] = [
       $records,
       ['version' => 3, 'id' => 'd'],
       ['d'],
+    ];
+
+    $cases[] = [
+      $records,
+      ['version' => 3, 'fruit' => ['!=' => 'apple']],
+      ['b'],
+    ];
+
+    $cases[] = [
+      $records,
+      ['version' => 3, 'cheese' => ['LIKE' => '%o%']],
+      ['d', 'e'],
+    ];
+
+    $cases[] = [
+      $records,
+      ['version' => 3, 'cheese' => ['IN' => ['swiss', 'cheddar', 'gouda']]],
+      ['a', 'b', 'c', 'd'],
     ];
 
     return $cases;
@@ -423,7 +453,9 @@ class api_v3_UtilsTest extends CiviUnitTestCase {
     $this->assertEquals($resultIds, array_values(CRM_Utils_Array::collect('snack_id', $r2['values'])));
     $this->assertEquals($resultIds, array_values(CRM_Utils_Array::collect('id', $r2['values'])));
 
-    $r3 = $kernel->runSafe('Widget', 'get', $params + ['options' => ['offset' => 1, 'limit' => 2]]);
+    $params['options']['offset'] = 1;
+    $params['options']['limit'] = 2;
+    $r3 = $kernel->runSafe('Widget', 'get', $params);
     $slice = array_slice($resultIds, 1, 2);
     $this->assertEquals(count($slice), $r3['count']);
     $this->assertEquals($slice, array_values(CRM_Utils_Array::collect('snack_id', $r3['values'])));


### PR DESCRIPTION
Overview
----------------------------------------
This backports some APIv4 code to v3, for the purpose of supporting entityRef widgets for Afform.

PR broken off from #19687 for easier review.

Before
----------------------------------------
Array-based apis such as Afform would have very limited support for searching and sorting.

After
----------------------------------------
Full range of search operators supported. Sorting supported.

Comments
------------------
Adds some corresponding unit test coverage.