### PR TITLE
Afform - Add link to edit form in breadcrumbs

### DIFF
--- a/ext/afform/core/CRM/Afform/Page/AfformBase.php
+++ b/ext/afform/core/CRM/Afform/Page/AfformBase.php
@@ -30,7 +30,19 @@ class CRM_Afform_Page_AfformBase extends CRM_Core_Page {
     if (!empty($afform['title'])) {
       $title = strip_tags($afform['title']);
       CRM_Utils_System::setTitle($title);
-      CRM_Utils_System::appendBreadCrumb([['title' => $title, 'url' => CRM_Utils_System::url(implode('/', $pagePath), NULL, FALSE, '!/')]]);
+    }
+
+    // If the user has "access civicrm" append home breadcrumb
+    if (CRM_Core_Permission::check('access CiviCRM')) {
+      CRM_Utils_System::appendBreadCrumb([['title' => ts('CiviCRM'), 'url' => CRM_Utils_System::url('civicrm')]]);
+      // If the user has "admin civicrm" & the admin extension is enabled
+      if (CRM_Core_Permission::check('administer CiviCRM') && CRM_Utils_Array::findAll(
+          \CRM_Extension_System::singleton()->getMapper()->getActiveModuleFiles(),
+          ['fullName' => 'org.civicrm.afform_admin']
+        )) {
+        CRM_Utils_System::appendBreadCrumb([['title' => E::ts('Form Builder'), 'url' => CRM_Utils_System::url('civicrm/admin/afform')]]);
+        CRM_Utils_System::appendBreadCrumb([['title' => E::ts('Edit Form'), 'url' => CRM_Utils_System::url('civicrm/admin/afform', NULL, FALSE, '/edit/' . $pageArgs['afform'])]]);
+      }
     }
 
     parent::run();


### PR DESCRIPTION
Overview
----------------------------------------
If this user has permission to edit the form (and the afform_admin extension is enabled), shows a breadcrumb back to edit the form.

![image](https://user-images.githubusercontent.com/2874912/109408682-b6bfb780-7959-11eb-8b40-db7224ea0505.png)
