### PR TITLE
Enable & do single field metadata conversion for defaultContactCountry

### DIFF
--- a/templates/CRM/Admin/Form/Setting/Localization.tpl
+++ b/templates/CRM/Admin/Form/Setting/Localization.tpl
@@ -69,7 +69,7 @@
                 <td class="label">{$form.moneyformat.label} {help id='moneyformat' title=$form.moneyformat.label}</td>
                 <td>{$form.moneyformat.html}</td>
             </tr>
-                      <tr class="crm-localization-form-block-customTranslateFunction">
+            <tr class="crm-localization-form-block-customTranslateFunction">
                 <td class="label">{$form.customTranslateFunction.label} {help id='customTranslateFunction' title=$form.customTranslateFunction.label}</td>
                 <td>{$form.customTranslateFunction.html}</td>
             </tr>
@@ -84,10 +84,7 @@
         </table>
     <h3>{ts}Contact Address Fields - Selection Values{/ts}</h3>
         <table class="form-layout-compressed">
-            <tr class="crm-localization-form-block-defaultContactCountry">
-                <td class="label">{$form.defaultContactCountry.label} {help id='defaultContactCountry' title=$form.defaultContactCountry.label}</td>
-                <td>{$form.defaultContactCountry.html}</td>
-            </tr>
+            {include file='CRM/Admin/Form/Setting/SettingField.tpl' setting_name='defaultContactCountry' fieldSpec=$settings_fields.defaultContactCountry}
             <tr class="crm-localization-form-block-pinnedContactCountries">
                 <td class="label">{$form.pinnedContactCountries.label} {help id='pinnedContactCountries' title=$form.pinnedContactCountries.label}</td>
                 <td>{$form.pinnedContactCountries.html}</td>

--- a/templates/CRM/Admin/Form/Setting/SettingField.tpl
+++ b/templates/CRM/Admin/Form/Setting/SettingField.tpl
@@ -1,0 +1,18 @@
+{* Display setting field from metadata - todo consolidate with CRM_Core_Form_Field.tpl *}
+<tr class="crm-setting-form-block-{$setting_name}">
+  <td class="label">{$form.$setting_name.label}</td>
+  <td>
+    {if !empty($fieldSpec.wrapper_element)}
+      {$fieldSpec.wrapper_element.0}{$form.$setting_name.html}{$fieldSpec.wrapper_element.1}
+    {else}
+      {$form.$setting_name.html}
+    {/if}
+    <div class="description">
+      {$fieldSpec.description}
+    </div>
+    {if $fieldSpec.help_text}
+      {* @todo the appended -id here appears to be inconsistent in the hlp files *}
+      {assign var='tplhelp_id' value = $setting_name|cat:'-id'|replace:'_':'-'}{help id="$tplhelp_id"}
+    {/if}
+  </td>
+</tr>

--- a/templates/CRM/Admin/Form/Setting/SettingForm.tpl
+++ b/templates/CRM/Admin/Form/Setting/SettingForm.tpl
@@ -9,23 +9,8 @@
 *}
 <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
 <table class="form-layout-compressed">
-  {foreach from=$settings_fields key="setting_name" item="setting_detail"}
-    <tr class="crm-mail-form-block-{$setting_name}">
-      <td class="label">{$form.$setting_name.label}</td>
-      <td>
-        {if !empty($setting_detail.wrapper_element)}
-          {$setting_detail.wrapper_element.0}{$form.$setting_name.html}{$setting_detail.wrapper_element.1}
-        {else}
-          {$form.$setting_name.html}
-        {/if}
-        <div class="description">
-          {$setting_detail.description}
-        </div>
-        {if $setting_detail.help_text}
-          {assign var='tplhelp_id' value = $setting_name|cat:'-id'|replace:'_':'-'}{help id="$tplhelp_id"}
-        {/if}
-      </td>
-    </tr>
+  {foreach from=$settings_fields key="setting_name" item="fieldSpec"}
+    {include file="CRM/Admin/Form/Setting/SettingField.tpl"}
   {/foreach}
 </table>
 <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>


### PR DESCRIPTION

Overview
----------------------------------------
Enable & do single field metadata conversion for defaultContactCountry

Before
----------------------------------------
tpl for defaultContactCountry does not use metadata for the field

After
----------------------------------------
Metadata used, ability to convert field-by-field to break it up

Technical Details
----------------------------------------
This builds on https://github.com/civicrm/civicrm-core/pull/19629

Our intention is that we should be building functionality into this
form that is actually used in core. It's a bit tricky to swap out
all fields at once but this makes them individually swap-outable.

Only defaultContactCountry is swapped out. I looked a little at the
help_text issue - the text actually does work if you
add it since it's already in the hlp file but I decided this
broke consistency less (using description) as other fields
on the form do that and look similar. Also, when the text is
really just a bit of text (not a long help text) it makes sense.

(Otherwise I'd need to trawl through resolving the bigger issue
and I didn't want to bring that into scope)

This shows it with the description AND the help icon - note the help icon is not aligned as the overall 
form is not yet standardised


![image](https://user-images.githubusercontent.com/336308/109444127-58055580-7aa1-11eb-86cc-952df8b3297f.png)

With just the description
![image](https://user-images.githubusercontent.com/336308/109444289-ca763580-7aa1-11eb-8a99-bb427d71a43d.png)

And other fields on the same form

![image](https://user-images.githubusercontent.com/336308/109444329-e11c8c80-7aa1-11eb-9b7d-4059b42b31fd.png)



Comments
----------------------------------------
