### PR TITLE
dev/core#2423 Fix quasi-regression around serialized custom fields

### DIFF
--- a/CRM/Contact/Form/CustomData.php
+++ b/CRM/Contact/Form/CustomData.php
@@ -104,7 +104,7 @@ class CRM_Contact_Form_CustomData extends CRM_Core_Form {
         $this->_contactType = CRM_Contact_BAO_Contact::getContactType($this->_tableID);
         $mode = CRM_Utils_Request::retrieve('mode', 'String', $this);
         $hasReachedMax = CRM_Core_BAO_CustomGroup::hasReachedMaxLimit($this->_groupID, $this->_tableID);
-        if ($hasReachedMax && $mode == 'add') {
+        if ($hasReachedMax && $mode === 'add') {
           CRM_Core_Error::statusBounce(ts('The maximum record limit is reached'));
         }
         $this->_copyValueId = CRM_Utils_Request::retrieve('copyValueId', 'Positive', $this);

--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -2687,16 +2687,15 @@ WHERE cf.id = %1 AND cg.is_multiple = 1";
     ];
     if (isset($fkFields[$field->data_type])) {
       // Serialized fields store value-separated strings which are incompatible with FK constraints
-      if ($field->serialize) {
-        $params['type'] = 'varchar(255)';
-      }
-      else {
+      if (!$field->serialize) {
         $params['fk_table_name'] = $fkFields[$field->data_type];
         $params['fk_field_name'] = 'id';
         $params['fk_attributes'] = 'ON DELETE SET NULL';
       }
     }
-
+    if ($field->serialize) {
+      $params['type'] = 'varchar(255)';
+    }
     if (isset($field->default_value)) {
       $params['default'] = "'{$field->default_value}'";
     }

--- a/CRM/Core/BAO/CustomValueTable.php
+++ b/CRM/Core/BAO/CustomValueTable.php
@@ -229,7 +229,9 @@ class CRM_Core_BAO_CustomValueTable {
             $set[$field['column_name']] = "%{$count}";
             // The second parameter is the type of the db field, which
             // would be 'String' for a concatenated set of integers.
-            $params[$count] = [$value, $field['is_multiple'] ? 'String' : $type];
+            // However, the god-forsaken timestamp hack also needs to be kept
+            // if value is NULL.
+            $params[$count] = [$value, ($value && $field['is_multiple']) ? 'String' : $type];
             $count++;
           }
 

--- a/CRM/Core/BAO/CustomValueTable.php
+++ b/CRM/Core/BAO/CustomValueTable.php
@@ -227,7 +227,9 @@ class CRM_Core_BAO_CustomValueTable {
           }
           else {
             $set[$field['column_name']] = "%{$count}";
-            $params[$count] = [$value, $type];
+            // The second parameter is the type of the db field, which
+            // would be 'String' for a concatenated set of integers.
+            $params[$count] = [$value, $field['is_multiple'] ? 'String' : $type];
             $count++;
           }
 
@@ -266,7 +268,7 @@ class CRM_Core_BAO_CustomValueTable {
           else {
             $query = "$sqlOP SET $setClause $where";
           }
-          $dao = CRM_Core_DAO::executeQuery($query, $params);
+          CRM_Core_DAO::executeQuery($query, $params);
 
           CRM_Utils_Hook::custom($hookOP,
             $hookID,

--- a/tests/phpunit/CRM/Core/BAO/CustomValueTableSetGetTest.php
+++ b/tests/phpunit/CRM/Core/BAO/CustomValueTableSetGetTest.php
@@ -12,9 +12,10 @@ class CRM_Core_BAO_CustomValueTableSetGetTest extends CiviUnitTestCase {
 
   /**
    * Test setValues() and GetValues() methods with custom Date field
+   *
+   * @throws \CiviCRM_API3_Exception
    */
-  public function testSetGetValuesDate() {
-    $params = [];
+  public function testSetGetValuesDate(): void {
     $contactID = $this->individualCreate();
 
     //create Custom Group


### PR DESCRIPTION

Overview
----------------------------------------
dev/core#2423 Fix quasi-regression around serialized custom fields

https://lab.civicrm.org/dev/core/-/issues/2423


Before
----------------------------------------
2 issues - first create a custom field of type 'Integer' with html 'drop down select' and choose 'mutliple.
Issue 1 - the table with be created with the fields having the mysql type of Integer
Issue 2 - the field validation will expect the field to be an integer and reject concatenated values

After
----------------------------------------
Much better

Technical Details
----------------------------------------

Comments
----------------------------------------
@colemanw 