### PR TITLE
APIv4 - Rename 'controlField' property to 'control_field'

### DIFF
--- a/Civi/Api4/Generic/AbstractAction.php
+++ b/Civi/Api4/Generic/AbstractAction.php
@@ -498,7 +498,7 @@ abstract class AbstractAction implements \ArrayAccess {
             'val' => $record[$expr],
             'field' => $field,
             'suffix' => substr($expr, $suffix + 1),
-            'depends' => $field['input_attrs']['controlField'] ?? NULL,
+            'depends' => $field['input_attrs']['control_field'] ?? NULL,
           ];
           unset($record[$expr]);
         }

--- a/Civi/Api4/Service/Spec/SpecFormatter.php
+++ b/Civi/Api4/Service/Spec/SpecFormatter.php
@@ -172,6 +172,14 @@ class SpecFormatter {
         }
       }
     }
+    // Ensure all keys use lower_case not camelCase
+    foreach ($inputAttrs as $key => $val) {
+      if ($key !== strtolower($key)) {
+        unset($inputAttrs[$key]);
+        $key = strtolower(preg_replace('/(?=[A-Z])/', '_$0', $key));
+        $inputAttrs[$key] = $val;
+      }
+    }
     $fieldSpec
       ->setInputType($inputType)
       ->setInputAttrs($inputAttrs);

--- a/ext/afform/core/ang/af/afField.component.js
+++ b/ext/afform/core/ang/af/afField.component.js
@@ -45,7 +45,7 @@
 
         // ChainSelect - watch control field & reload options as needed
         if (ctrl.defn.input_type === 'ChainSelect') {
-          $scope.$watch('dataProvider.getFieldData()[defn.input_attrs.controlField]', function(val) {
+          $scope.$watch('dataProvider.getFieldData()[defn.input_attrs.control_field]', function(val) {
             if (val) {
               var params = {
                 where: [['name', '=', ctrl.fieldName]],
@@ -53,7 +53,7 @@
                 loadOptions: ['id', 'label'],
                 values: {}
               };
-              params.values[ctrl.defn.input_attrs.controlField] = val;
+              params.values[ctrl.defn.input_attrs.control_field] = val;
               crmApi4($scope.dataProvider.getEntityType(), 'getFields', params, 0)
                 .then(function(data) {
                   ctrl.defn.options = data.options;


### PR DESCRIPTION
Overview
----------------------------------------
By convention, all keys returned from the api should be lowercase.

This renames a key that was not. It was only used in 2 places.

Before
----------------------------------------
`\Civi\Api4\Address::getFields()` returns `'input_type' => ['controlField' => ...`

After
----------------------------------------
`\Civi\Api4\Address::getFields()` returns `'input_type' => ['control_field' => ...`


Comments
----------------------------------------
In general, it's not good to make "breaking changes" to our API, but this is a **very** obscure sub-property of only one entity that is only used by Afform so far, and APIv4 is still relatively new. IMO this is reasonably safe, and better now than later.
