### PR TITLE
Fix SMTP Upgrade by avoiding escaping to ensure that if there is any …

### DIFF
--- a/CRM/Upgrade/Incremental/php/FiveThirtyFour.php
+++ b/CRM/Upgrade/Incremental/php/FiveThirtyFour.php
@@ -153,10 +153,11 @@ class CRM_Upgrade_Incremental_php_FiveThirtyFour extends CRM_Upgrade_Incremental
       $value = unserialize($setting['value']);
       $plain = CRM_Utils_Crypt::decrypt($value['smtpPassword']);
       $value['smtpPassword'] = $cryptoToken->encrypt($plain, 'CRED');
-      CRM_Core_DAO::executeQuery('UPDATE civicrm_setting SET value = %2 WHERE id = %1', [
-        1 => [$setting['id'], 'Positive'],
-        2 => [serialize($value), 'String'],
-      ]);
+      $dao = new CRM_Core_BAO_Setting();
+      $dao->id = $setting['id'];
+      $dao->find(TRUE);
+      $dao->value = serialize($value);
+      $dao->save();
     }
     return TRUE;
   }


### PR DESCRIPTION
…random strings they don't get double escaped

Overview
----------------------------------------
On the assumption that there might be double escaping going on because of special chars such as `'` in passwords and given that re-saving the SMTP form works which suggests that the code here https://github.com/civicrm/civicrm-core/blob/master/Civi/Core/SettingsBag.php#L371 is working correctly, this replicates that style but in the Upgrade step

Before
----------------------------------------
Upgrade can hard fail if password has mysql special chars in it

After
----------------------------------------
Upgrade should succeed

ping @totten @agileware-justin @eileenmcnaughton 
