### PR TITLE
Afform - Remove ngRoute from afformStandalone page

### DIFF
--- a/Civi/Angular/AngularLoader.php
+++ b/Civi/Angular/AngularLoader.php
@@ -73,7 +73,7 @@ class AngularLoader {
     $this->res = \CRM_Core_Resources::singleton();
     $this->angular = \Civi::service('angular');
     $this->region = \CRM_Utils_Request::retrieve('snippet', 'String') ? 'ajax-snippet' : 'html-header';
-    $this->pageName = $_GET['q'] ?? NULL;
+    $this->pageName = \CRM_Utils_System::currentPath();
     $this->modules = [];
   }
 

--- a/ext/afform/core/CRM/Afform/Page/AfformBase.php
+++ b/ext/afform/core/CRM/Afform/Page/AfformBase.php
@@ -7,25 +7,18 @@ class CRM_Afform_Page_AfformBase extends CRM_Core_Page {
     // To avoid php complaints about the number of args passed to this function vs the base function
     [$pagePath, $pageArgs] = func_get_args();
 
+    // The api will throw an exception if afform is not found (because of the index 0 param)
     $afform = civicrm_api4('Afform', 'get', [
       'checkPermissions' => FALSE,
       'where' => [['name', '=', $pageArgs['afform']]],
       'select' => ['title', 'module_name', 'directive_name'],
     ], 0);
 
-    $this->set('afModule', $afform['module_name']);
+    $this->assign('directive', $afform['directive_name']);
 
-    $loader = new \Civi\Angular\AngularLoader();
-    $loader->setModules([$afform['module_name'], 'afformStandalone']);
-    $loader->setPageName(implode('/', $pagePath));
-    $loader->getRes()->addSetting([
-      'afform' => [
-        'open' => $afform['directive_name'],
-      ],
-    ])
-      // TODO: Allow afforms to declare their own theming requirements
-      ->addBundle('bootstrap3');
-    $loader->load();
+    (new \Civi\Angular\AngularLoader())
+      ->setModules([$afform['module_name'], 'afformStandalone'])
+      ->load();
 
     if (!empty($afform['title'])) {
       $title = strip_tags($afform['title']);

--- a/ext/afform/core/afform.php
+++ b/ext/afform/core/afform.php
@@ -197,6 +197,8 @@ function afform_civicrm_angularModules(&$angularModules) {
       'basePages' => [],
       'partialsCallback' => '_afform_get_partials',
       '_afform' => $afform['name'],
+      // TODO: Allow afforms to declare their own theming requirements
+      'bundles' => ['bootstrap3'],
       'exports' => [
         $afform['directive_name'] => 'E',
       ],

--- a/ext/afform/core/ang/afCore.js
+++ b/ext/afform/core/ang/afCore.js
@@ -3,7 +3,7 @@
   angular.module('afCore', CRM.angRequires('afCore'));
 
   // Use `afCoreDirective(string name)` to generate an AngularJS directive.
-  angular.module('afCore').service('afCoreDirective', function($routeParams, crmApi4, crmStatus, crmUiAlert) {
+  angular.module('afCore').service('afCoreDirective', function($location, crmApi4, crmStatus, crmUiAlert) {
     return function(camelName, meta, d) {
       d.restrict = 'E';
       d.scope = {};
@@ -11,12 +11,16 @@
       d.link = {
         pre: function($scope, $el, $attr) {
           $scope.ts = CRM.ts(camelName);
-          $scope.routeParams = $routeParams;
           $scope.meta = meta;
           $scope.crmApi4 = crmApi4;
           $scope.crmStatus = crmStatus;
           $scope.crmUiAlert = crmUiAlert;
           $scope.crmUrl = CRM.url;
+
+          // Afforms do not use routing, but some forms get input from search params
+          $scope.$watch(function() {return $location.search();}, function(params) {
+            $scope.routeParams = params;
+          });
         }
       };
       return d;

--- a/ext/afform/core/ang/afformStandalone.ang.php
+++ b/ext/afform/core/ang/afformStandalone.ang.php
@@ -6,5 +6,5 @@ return [
   ],
   'css' => [],
   'settings' => [],
-  'requires' => ['ngRoute'],
+  'requires' => [],
 ];

--- a/ext/afform/core/ang/afformStandalone.js
+++ b/ext/afform/core/ang/afformStandalone.js
@@ -1,16 +1,5 @@
 (function(angular, $, _) {
-  // Declare a list of dependencies.
-  angular.module('afformStandalone', CRM.angRequires('afformStandalone'));
-
-  angular.module('afformStandalone', CRM.angular.modules)
-    .config(function($routeProvider) {
-      $routeProvider.when('/', {
-        controller: 'AfformStandalonePageCtrl',
-        template: function() {
-          return '<div id="bootstrap-theme"><' + CRM.afform.open + '></' + CRM.afform.open + '></div>';
-        }
-      });
-    })
-    .controller('AfformStandalonePageCtrl', function($scope) {});
+  // Empty module just loads all available modules.
+  angular.module('afformStandalone', CRM.angular.modules);
 
 })(angular, CRM.$, CRM._);

--- a/ext/afform/core/templates/CRM/Afform/Page/AfformBase.tpl
+++ b/ext/afform/core/templates/CRM/Afform/Page/AfformBase.tpl
@@ -1,5 +1,5 @@
-{literal}
-  <div ng-app="afformStandalone">
-    <form ng-view></form>
-  </div>
-{/literal}
+<div ng-app="afformStandalone">
+  <form id="bootstrap-theme">
+    <{$directive}></{$directive}>
+  </form>
+</div>

--- a/ext/afform/mock/tests/phpunit/api/v4/AfformRoutingTest.php
+++ b/ext/afform/mock/tests/phpunit/api/v4/AfformRoutingTest.php
@@ -37,7 +37,7 @@ class api_v4_AfformRoutingTest extends \PHPUnit\Framework\TestCase implements \C
     };
 
     $result = $http->get($url('civicrm/mock-page'));
-    $this->assertNotAuthorized($result);
+    $this->assertNotAuthorized($result, 'mock-page');
 
     Civi\Api4\Afform::update()
       ->setCheckPermissions(FALSE)
@@ -62,7 +62,7 @@ class api_v4_AfformRoutingTest extends \PHPUnit\Framework\TestCase implements \C
       ->execute();
 
     $this->assertOpensPage($http->get($url('civicrm/mock-page')), 'mock-page');
-    $this->assertNotAuthorized($http->get($url('civicrm/mock-page-renamed')));
+    $this->assertNotAuthorized($http->get($url('civicrm/mock-page-renamed')), 'mock-page');
 
     Civi\Api4\Afform::update()
       ->setCheckPermissions(FALSE)
@@ -70,18 +70,19 @@ class api_v4_AfformRoutingTest extends \PHPUnit\Framework\TestCase implements \C
       ->addValue('server_route', 'civicrm/mock-page-renamed')
       ->execute();
 
-    $this->assertNotAuthorized($http->get($url('civicrm/mock-page')));
+    $this->assertNotAuthorized($http->get($url('civicrm/mock-page')), 'mock-page');
     $this->assertOpensPage($http->get($url('civicrm/mock-page-renamed')), 'mock-page');
   }
 
   /**
    * @param $result
+   * @param string $directive
    */
-  private function assertNotAuthorized(Psr\Http\Message\ResponseInterface $result) {
+  private function assertNotAuthorized(Psr\Http\Message\ResponseInterface $result, $directive) {
     $contents = $result->getBody()->getContents();
     $this->assertEquals(403, $result->getStatusCode());
     $this->assertRegExp(';You are not authorized to access;', $contents);
-    $this->assertNotRegExp(';afform":\{"open":".*"\};', $contents);
+    $this->assertNotRegExp(';' . preg_quote("<$directive>", ';') . ';', $contents);
   }
 
   /**
@@ -93,7 +94,7 @@ class api_v4_AfformRoutingTest extends \PHPUnit\Framework\TestCase implements \C
     $contents = $result->getBody()->getContents();
     $this->assertEquals(200, $result->getStatusCode());
     $this->assertNotRegExp(';You are not authorized to access;', $contents);
-    $this->assertRegExp(';afform":\{"open":"' . preg_quote($directive, ';') . '"\};', $contents);
+    $this->assertRegExp(';' . preg_quote("<$directive>", ';') . ';', $contents);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
This removes an unused dependency from the Afform standalone page, making it more flexible and reusable.

Before
----------------------------------------
Afforms in "standalone" mode required ngRoute, limiting the usefulness of the Afform Standalone controller as it could only handle one afform per page.

After
----------------------------------------
Dependency removed.

Technical Details
----------------------------------------
Might need to do more to get AfformStandaloneCtrl working in multiple instances per page because `ngApp` is also limited to single-use. But this is a start.