### PR TITLE
dev/core#2417 Change language label from to Spanish (Latin America)

### DIFF
--- a/install/langs.php
+++ b/install/langs.php
@@ -40,7 +40,7 @@
   'sk_SK' => 'Slovak',
   'sl_SI' => 'Slovene',
   'es_ES' => 'Spanish; Castilian (Spain)',
-  'es_MX' => 'Spanish; Castilian (Mexico)',
+  'es_MX' => 'Spanish; Castilian (Latin America)',
   'es_PR' => 'Spanish; Castilian (Puerto Rico)',
   'sv_SE' => 'Swedish',
   'te_IN' => 'Telugu',

--- a/xml/templates/languages.tpl
+++ b/xml/templates/languages.tpl
@@ -174,7 +174,7 @@ VALUES
   (@option_group_id_languages, 0, 0, 'so_SO', 'so', {localize}'{ts escape="sql"}Somali{/ts}'{/localize}, @counter := @counter + 1),
   (@option_group_id_languages, 0, 0, 'st_ZA', 'st', {localize}'{ts escape="sql"}Southern Sotho{/ts}'{/localize}, @counter := @counter + 1),
   (@option_group_id_languages, 0, 1, 'es_ES', 'es', {localize}'{ts escape="sql"}Spanish; Castilian (Spain){/ts}'{/localize}, @counter := @counter + 1),
-  (@option_group_id_languages, 0, 1, 'es_MX', 'es', {localize}'{ts escape="sql"}Spanish; Castilian (Mexico){/ts}'{/localize}, @counter := @counter + 1),
+  (@option_group_id_languages, 0, 1, 'es_MX', 'es', {localize}'{ts escape="sql"}Spanish; Castilian (Latin America){/ts}'{/localize}, @counter := @counter + 1),
   (@option_group_id_languages, 0, 1, 'es_PR', 'es', {localize}'{ts escape="sql"}Spanish; Castilian (Puerto Rico){/ts}'{/localize}, @counter := @counter + 1),
   (@option_group_id_languages, 0, 0, 'su_ID', 'su', {localize}'{ts escape="sql"}Sundanese{/ts}'{/localize}, @counter := @counter + 1),
   (@option_group_id_languages, 0, 0, 'sw_TZ', 'sw', {localize}'{ts escape="sql"}Swahili{/ts}'{/localize}, @counter := @counter + 1),


### PR DESCRIPTION


Overview
----------------------------------------
dev/core#2417 Change language label from to Spanish (Latin America)

Before
----------------------------------------
The label for es_MX is Spanish; Castilian (Mexico)

After
----------------------------------------
The label for es_MX is Spanish; Castilian (Latin America) - on new installs

Technical Details
----------------------------------------
As discussed in https://lab.civicrm.org/dev/core/-/issues/2417
es_MX is really a stand in for Latin American spanish. There was
agreement on there to re-label it, although I think for new installs
is enough


Comments
----------------------------------------
@mlutfy 