### PR TITLE
Add is empty filter to search / api

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -2782,6 +2782,16 @@ SELECT contact_id
       if (in_array($operator, self::acceptedSQLOperators(), TRUE)) {
         switch ($operator) {
           // unary operators
+          case 'IS EMPTY':
+            if ($type === 'String') {
+              return (sprintf('%s', "$fieldName = '' OR $fieldName IS NULL"));
+            }
+
+          case 'IS NOT EMPTY':
+            if ($type === 'String') {
+              return (sprintf('%s', "$fieldName <> '' AND $fieldName IS NOT NULL"));
+            }
+
           case 'IS NULL':
           case 'IS NOT NULL':
             if (!$returnSanitisedArray) {
@@ -2859,6 +2869,8 @@ SELECT contact_id
       'NOT BETWEEN',
       'IS NOT NULL',
       'IS NULL',
+      'IS EMPTY',
+      'IS NOT EMPTY',
     ];
   }
 

--- a/Civi/Api4/Query/Api4SelectQuery.php
+++ b/Civi/Api4/Query/Api4SelectQuery.php
@@ -468,7 +468,7 @@ class Api4SelectQuery {
       }
     }
 
-    $sql_clause = \CRM_Core_DAO::createSQLFilter($fieldAlias, [$operator => $value]);
+    $sql_clause = \CRM_Core_DAO::createSQLFilter($fieldAlias, [$operator => $value], isset($field) ? $field['data_type'] : NULL);
     if ($sql_clause === NULL) {
       throw new \API_Exception("Invalid value in $type clause for '$expr'");
     }

--- a/ang/api4Explorer/Explorer.js
+++ b/ang/api4Explorer/Explorer.js
@@ -1138,7 +1138,7 @@
             op = field.serialize || dataType === 'Array' ? 'IN' : '=';
           }
           multi = _.includes(['IN', 'NOT IN', 'BETWEEN', 'NOT BETWEEN'], op);
-          if (op === 'IS NULL' || op === 'IS NOT NULL') {
+          if (op === 'IS NULL' || op === 'IS NOT NULL' || op === 'IS EMPTY' || op === 'IS NOT EMPTY') {
             $el.hide();
             return;
           }


### PR DESCRIPTION

Overview
---------------------------------------
Add is empty filter to search / api

Before
----------------------------------------

After
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/109649417-c12fba80-7bc0-11eb-93cc-4480b9ea065e.png)


Technical Details
----------------------------------------
This is already offered in Query
https://github.com/civicrm/civicrm-core/blob/5db2212e2d408f4611439734db1a31ab32dced2f/CRM/Contact/BAO/Query.php#L3420-L3428

And in Report
https://github.com/civicrm/civicrm-core/blob/c3fffe27cb8203634c7a2c047686ba3d12cc38bd/CRM/Report/Form.php#L2105-L2124

(the latter munges it in with NULL but as we often save empty strings NULL
does not alwasy work for strings)

Comments
----------------------------------------
@colemanw we talked about this - note that I am struggling to make sense of the v4 api tests to add it in - they seem awfully clever but I don't know how to add to them