### PR TITLE
update to lifetime membership does not clear the end date

### DIFF
--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -246,6 +246,11 @@ class CRM_Member_BAO_Membership extends CRM_Member_DAO_Membership {
    * @throws CRM_Core_Exception
    */
   public static function create(&$params, $ids = []) {
+    $isLifeTime = FALSE;
+    if (!empty($params['membership_type_id'])) {
+      $memTypeDetails = CRM_Member_BAO_MembershipType::getMembershipType($params['membership_type_id']);
+      $isLifeTime = $memTypeDetails['duration_unit'] === 'lifetime' ? TRUE : FALSE;
+    }
     // always calculate status if is_override/skipStatusCal is not true.
     // giving respect to is_override during import.  CRM-4012
 
@@ -260,7 +265,7 @@ class CRM_Member_BAO_Membership extends CRM_Member_DAO_Membership {
           // @todo enable this once core is using the api.
           // CRM_Core_Error::deprecatedWarning('Relying on the BAO to clean up dates is deprecated. Call membership create via the api');
         }
-        if (!empty($params['id']) && empty($params[$dateField])) {
+        if (!empty($params['id']) && empty($params[$dateField]) && !($isLifeTime && $dateField == 'end_date')) {
           $fieldsToLoad[] = $dateField;
         }
       }

--- a/tests/phpunit/CRM/Member/Form/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/Form/MembershipTest.php
@@ -672,6 +672,13 @@ class CRM_Member_Form_MembershipTest extends CiviUnitTestCase {
     $this->assertEquals(50, $payment['paid']);
     // balance remaining
     $this->assertEquals(-25, $payment['balance']);
+
+    //Update to lifetime membership.
+    $params['membership_type_id'] = [$this->ids['contact']['organization'], $this->ids['membership_type']['lifetime']];
+    $form->testSubmit($params);
+    $membership = $this->callAPISuccessGetSingle('Membership', ['contact_id' => $this->_individualId]);
+    $this->assertEquals($this->ids['membership_type']['lifetime'], $membership['membership_type_id']);
+    $this->assertTrue(empty($membership['end_date']), 'Lifetime Membership on the individual has an End date.');
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Fix membership to clear end date if type is updated to lifetime.

Before
----------------------------------------
Updating the existing membership to lifetime does not emty the end date value. to replicate -

- Create a membership on the contact with type = General.

![image](https://user-images.githubusercontent.com/5929648/109809787-b91e5c00-7c4e-11eb-801a-f63dc56da5dd.png)

- Renew/Edit this membership and change the type to Lifetime. Save
-  The membership is saved, but it still has an end date. The status is not updated.

![image](https://user-images.githubusercontent.com/5929648/109809854-cb989580-7c4e-11eb-9c06-3f558c267745.png)

After
----------------------------------------
Fixed.


![image](https://user-images.githubusercontent.com/5929648/109810393-7dd05d00-7c4f-11eb-9b72-aa5a7a2337a9.png)


Comments
----------------------------------------
@eileenmcnaughton Looks like https://github.com/civicrm/civicrm-core/pull/18794 added the flexibility to modify the date fields in the create() function. Think this should ignore the end date value for lifetime memberships?

Unit test added.