### PR TITLE
dev/core#2432 remove limit on maximum number of characters during input

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -839,7 +839,8 @@ class CRM_Core_DAO extends DB_DataObject {
         $attributes['size'] = 6;
         $attributes['maxlength'] = 14;
         return $attributes;
-      } elseif (CRM_Utils_Array::value('type', $field) == CRM_Utils_Type::T_MONEY) {
+      }
+      elseif (CRM_Utils_Array::value('type', $field) == CRM_Utils_Type::T_MONEY) {
         $attributes['size'] = 6;
         return $attributes;
       }

--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -835,7 +835,11 @@ class CRM_Core_DAO extends DB_DataObject {
         $attributes['cols'] = $cols;
         return $attributes;
       }
-      elseif (CRM_Utils_Array::value('type', $field) == CRM_Utils_Type::T_INT || CRM_Utils_Array::value('type', $field) == CRM_Utils_Type::T_FLOAT || CRM_Utils_Array::value('type', $field) == CRM_Utils_Type::T_MONEY) {
+      elseif (CRM_Utils_Array::value('type', $field) == CRM_Utils_Type::T_INT || CRM_Utils_Array::value('type', $field) == CRM_Utils_Type::T_FLOAT) {
+        $attributes['size'] = 6;
+        $attributes['maxlength'] = 14;
+        return $attributes;
+      } elseif (CRM_Utils_Array::value('type', $field) == CRM_Utils_Type::T_MONEY) {
         $attributes['size'] = 6;
         return $attributes;
       }

--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -837,7 +837,6 @@ class CRM_Core_DAO extends DB_DataObject {
       }
       elseif (CRM_Utils_Array::value('type', $field) == CRM_Utils_Type::T_INT || CRM_Utils_Array::value('type', $field) == CRM_Utils_Type::T_FLOAT || CRM_Utils_Array::value('type', $field) == CRM_Utils_Type::T_MONEY) {
         $attributes['size'] = 6;
-        $attributes['maxlength'] = 14;
         return $attributes;
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------

Fixes the input of money fields where the amount is limited to maximum of 14 characters and an amount such as `1,789,789,789.35` is impossible to enter. 

Before
----------------------------------------

Not possible to enter an amount such as `1,789,789,789.35` on the add contribution form.

After
----------------------------------------

Possible to enter an amount such as `1,789,789,789.35` on the add contribution form.

Technical Details
----------------------------------------

According to the discussion in https://lab.civicrm.org/dev/core/-/issues/2432 there is a hard limit of 14 digits in php floating point or 20 in mysql.

