### PR TITLE
dev/core#2436 On WordPress, redirect back to the event registration o…

### DIFF
--- a/CRM/Utils/System/Base.php
+++ b/CRM/Utils/System/Base.php
@@ -436,7 +436,7 @@ abstract class CRM_Utils_System_Base {
    * Get user login URL for hosting CMS (method declared in each CMS system class)
    *
    * @param string $destination
-   *   If present, add destination to querystring (works for Drupal only).
+   *   If present, add destination to querystring (works for Drupal and WordPress only).
    *
    * @return string
    *   loginURL for the current CMS

--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -926,20 +926,42 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
    * @inheritDoc
    */
   public function getLoginURL($destination = '') {
-    $config = CRM_Core_Config::singleton();
-    $loginURL = wp_login_url();
-    return $loginURL;
+    return wp_login_url($destination);
   }
 
   /**
-   * FIXME: Do something.
-   *
    * @param \CRM_Core_Form $form
    *
    * @return NULL|string
    */
   public function getLoginDestination(&$form) {
-    return NULL;
+    $args = NULL;
+
+    $id = $form->get('id');
+    if ($id) {
+      $args .= "&id=$id";
+    }
+    else {
+      $gid = $form->get('gid');
+      if ($gid) {
+        $args .= "&gid=$gid";
+      }
+      else {
+        // Setup Personal Campaign Page link uses pageId
+        $pageId = $form->get('pageId');
+        if ($pageId) {
+          $component = $form->get('component');
+          $args .= "&pageId=$pageId&component=$component&action=add";
+        }
+      }
+    }
+
+    $destination = NULL;
+    if ($args) {
+      // append destination so user is returned to form they came from after login
+      $destination = CRM_Utils_System::url(CRM_Utils_System::currentPath(), 'reset=1' . $args);
+    }
+    return $destination;
   }
 
   /**


### PR DESCRIPTION
…r contribution page that prompted the user to login.

Mostly copied from CRM_Utils_System_DrupalBase.php

Overview
----------------------------------------
See https://lab.civicrm.org/dev/core/-/issues/2436

Before
----------------------------------------
On WP,  event registration and contribution page display a message inviting user to login if the page includes a profile that allows or requires a CMS user registration.  After logging in, the user is left at the WP profile page.

After
----------------------------------------
After logging in, the user is redirected to the original event registration or contribution page.


