### PR TITLE
dev/drupal#156 - system_get_info() is gone in Drupal 9 

### DIFF
--- a/CRM/Core/Permission/Drupal8.php
+++ b/CRM/Core/Permission/Drupal8.php
@@ -58,7 +58,7 @@ class CRM_Core_Permission_Drupal8 extends CRM_Core_Permission_DrupalBase {
     $allCorePerms = \CRM_Core_Permission::basicPermissions(TRUE);
 
     $dperms = \Drupal::service('user.permissions')->getPermissions();
-    $modules = system_get_info('module');
+    $modules = \Drupal::service('extension.list.module')->getAllInstalledInfo();
 
     $permissions = [];
     foreach ($dperms as $permName => $dperm) {

--- a/release-notes/5.35.0.md
+++ b/release-notes/5.35.0.md
@@ -460,7 +460,10 @@ Released March 3, 2021
   ([dev/drupal#65](https://lab.civicrm.org/dev/drupal/-/issues/65):
   [580](https://github.com/civicrm/civicrm-drupal/pull/580))**
 
-- **fix deceased date format
+- **Drupal9: system_get_info() not available. CiviReport crash.**
+  ([dev/drupal#156](https://lab.civicrm.org/dev/drupal/-/issues/156): [#19725](https://github.com/civicrm/civicrm-core/pull/19725))
+
+- **Fix deceased date format
   ([607](https://github.com/civicrm/civicrm-drupal/pull/607))**
 
 ### WordPress Integration


### PR DESCRIPTION
Backport of #19583 from 5.36.alpha to 5.35.beta

This problem is apparent in 5.35 on the D8 test matrix.