### PR TITLE
(dev/core#2077) AuthX - Allow optional "guards"

### DIFF
--- a/ext/authx/Civi/Authx/Meta.php
+++ b/ext/authx/Civi/Authx/Meta.php
@@ -31,6 +31,16 @@ class Meta {
   /**
    * @return array
    */
+  public static function getGuardTypes() {
+    return [
+      'perm' => E::ts('User Permission'),
+      'site_key' => E::ts('Site Key'),
+    ];
+  }
+
+  /**
+   * @return array
+   */
   public static function getFlowTypes() {
     return [
       'param' => E::ts('Ephemeral: Paramter'),

--- a/ext/authx/authx.php
+++ b/ext/authx/authx.php
@@ -220,8 +220,8 @@ function authx_civicrm_themes(&$themes) {
  * @see CRM_Utils_Hook::permission()
  */
 function authx_civicrm_permission(&$permissions) {
-  $permissions['authenticate with password'] = ts('AuthX: Authenticate to services with password');
-  $permissions['authenticate with api key'] = ts('AuthX: Authenticate to services with API key');
+  $permissions['authenticate with password'] = E::ts('AuthX: Authenticate to services with password');
+  $permissions['authenticate with api key'] = E::ts('AuthX: Authenticate to services with API key');
 }
 
 // --- Functions below this ship commented out. Uncomment as required. ---

--- a/ext/authx/settings/authx.setting.php
+++ b/ext/authx/settings/authx.setting.php
@@ -27,6 +27,22 @@ $_authx_settings = function() {
   ];
 
   $s = [];
+  $s["authx_guards"] = $basic + [
+    'name' => 'authx_guards',
+    'type' => 'Array',
+    'quick_form_type' => 'Select',
+    'html_type' => 'Select',
+    'html_attributes' => [
+      'multiple' => 1,
+      'class' => 'crm-select2',
+    ],
+    'default' => ['site_key', 'perm'],
+    'title' => ts('Authentication guard'),
+    'help_text' => ts('Enable an authentication guard if you want to limit which users may authenticate via authx. The permission-based guard is satisfied by checking user permissions. The key-based guard is satisfied by checking the secret site-key. The JWT guard is satisfied if the user presents a signed token. If there are no guards, then any user can authenticate.'),
+    'pseudoconstant' => [
+      'callback' => ['\Civi\Authx\Meta', 'getGuardTypes'],
+    ],
+  ];
   foreach ($flows as $flow) {
     $s["authx_{$flow}_cred"] = $basic + [
       'name' => "authx_{$flow}_cred",

--- a/ext/authx/tests/phpunit/Civi/Authx/AllFlowsTest.php
+++ b/ext/authx/tests/phpunit/Civi/Authx/AllFlowsTest.php
@@ -56,10 +56,12 @@ class AllFlowsTest extends \PHPUnit\Framework\TestCase implements EndToEndInterf
     parent::setUp();
     $this->settingsBackup = [];
     foreach (\Civi\Authx\Meta::getFlowTypes() as $flowType) {
-      foreach (["authx_{$flowType}_cred", "authx_{$flowType}_user"] as $setting) {
+      foreach (["authx_{$flowType}_cred", "authx_{$flowType}_user", "authx_guards"] as $setting) {
         $this->settingsBackup[$setting] = \Civi::settings()->get($setting);
       }
     }
+
+    \Civi::settings()->set('authx_guards', []);
   }
 
   public function tearDown() {
@@ -164,6 +166,52 @@ class AllFlowsTest extends \PHPUnit\Framework\TestCase implements EndToEndInterf
     if (!in_array('sendsExcessCookies', $this->quirks)) {
       $this->assertNoCookies($response);
     }
+  }
+
+  /**
+   * The setting "authx_guard" may be used to require (or not require) the site_key.
+   *
+   * @throws \CiviCRM_API3_Exception
+   * @throws \GuzzleHttp\Exception\GuzzleException
+   */
+  public function testStatelessGuardSiteKey() {
+    if (!defined('CIVICRM_SITE_KEY')) {
+      $this->markTestIncomplete("Cannot run test without CIVICRM_SITE_KEY");
+    }
+
+    $addParam = function($request, $key, $value) {
+      $query = $request->getUri()->getQuery();
+      return $request->withUri(
+        $request->getUri()->withQuery($query . '&' . urlencode($key) . '=' . urlencode($value))
+      );
+    };
+
+    [$credType, $flowType] = ['pass', 'header'];
+    $http = $this->createGuzzle(['http_errors' => FALSE]);
+    \Civi::settings()->set("authx_{$flowType}_cred", [$credType]);
+
+    /** @var \Psr\Http\Message\RequestInterface $request */
+    $request = $this->applyAuth($this->requestMyContact(), $credType, $flowType, $this->getDemoCID());
+
+    // Request OK. Policy requires site_key, and we have one.
+    \Civi::settings()->set("authx_guards", ['site_key']);
+    $response = $http->send($request->withHeader('X-Civi-Key', CIVICRM_SITE_KEY));
+    $this->assertMyContact($this->getDemoCID(), $this->getDemoUID(), $response);
+
+    // Request OK. Policy does not require site_key, and we do not have one
+    \Civi::settings()->set("authx_guards", []);
+    $response = $http->send($request);
+    $this->assertMyContact($this->getDemoCID(), $this->getDemoUID(), $response);
+
+    // Request fails. Policy requires site_key, but we don't have the wrong value.
+    \Civi::settings()->set("authx_guards", ['site_key']);
+    $response = $http->send($request->withHeader('X-Civi-Key', 'not-the-site-key'));
+    $this->assertFailedDueToProhibition($response);
+
+    // Request fails. Policy requires site_key, but we don't have one.
+    \Civi::settings()->set("authx_guards", ['site_key']);
+    $response = $http->send($request);
+    $this->assertFailedDueToProhibition($response);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------

AuthX (#19590) provides additional ways to authenticate HTTP requests in CiviCRM. It is intended to provide an upgrade/replacement for certain backend scripts (eg `extern/rest.php` can be replaced by `civicrm/ajax/rest`). However, the new style currently lacks a function that the old style had -- the ability to guard backend requests with a semi-secret "site key".

This re-creates that functionality, and it aims to do it better.

(Note: I originally wrote/tested this patch in tandem with #19727 - one may or may not prefer to test/review them together. However, I believe they can work independently.)

ping @seamuslee001 @MikeyMJCO 

Discussion
----------------------------------------

Let us first consider why a backend script (`extern/rest.php`) accepts the parameters that it does. There are two different credentials: 

1. The user's API key (`civicrm_contact.api_key` aka `?api_key=...`) demonstrates the identity of the caller.
2. The site key (`CIVICRM_SITE_KEY` aka `?key=...`) demonstrates the sysadmin trusts this user enough to call the scripts.

The `api_key` is manifestly appropriate. The `site_key` is more debatable, but I think we should concede it is useful to allow a sysadmin to limit *which users* can authenticate to `extern/rest.php`.  For example, they may have a policy to allow service-principals but prohibit regular user-principals. However, there are some issues:

* If you have a desktop/mobile app, it is onerous (for admins+users) to distribute the `CIVICRM_SITE_KEY`. At the same time, it must be shared widely -- which reduces the secrecy and security-benefit. If you change the key, then you must update all deployments/references.
* The `extern/rest.php` script already does/should/must enforce permissions based on the users role/access-level/system-policy. In many cases, with or without this backend interface, the user can still script equivalent actions (via browser-console, GreaseMonkey, screenscraper, etc) -- because (notwithstanding hypothetical bugs) it's the same access-level.

From a certain POV, we put a burden on users/admins that feels redundant.

I believe there is a better way for the syadmin to indicate their trust in the user -- by assigning roles/permissions. If the sysadmin grants permission `AuthX: authenticate with password` or `AuthX: authenticate with api key`, then that should be enough - without involving the `CIVICRM_SITE_KEY`.

Of course, we do have existing code/integrations/practices which rely on `CIVICRM_SITE_KEY`, so removing it would be problematic. This PR allows the sysadmin to choose a mix of approaches.

Before
----------------------------------------

Service requests made to `extern/rest.php` are required to submit `CIVICRM_SITE_KEY`.

Service requests  made to `civicrm/ajax/rest` are not.

After
----------------------------------------

`extern/rest.php` remains the same as before, but `civicrm/ajax/rest` is more configurable. The setting `authx_guards` determines what is required to authenticate. It allows for these cases:

* If there are no guards (`authx_guards=[]`), then any user is allowed to authenticate via authx.
* The site-key can be used as a guard (`authx_guards=["site_key"]`), in which case users must submit the extra credential. The site key can be submitted via:
    * Header (`X-Civi-Key: ...`)
    * Parameter (`?_authxSiteKey=...`)
    * Legacy parameter (`?key=...`, but only for `civicrm/ajax/rest`'s legacy/compat mode).
* User permissions can be used as a guard (`authx_guards=["perm"]`). In this case, the user must have permission `authentciate with password` or `authenticate with api key`.
* If both guards are enabled (`authx_guards=["site_key","perm"]`), then *either* is sufficient.
