### PR TITLE
Fix ts() namespace in searchKit & afform extensions

### DIFF
--- a/ext/afform/admin/CRM/AfformAdmin/Page/Base.php
+++ b/ext/afform/admin/CRM/AfformAdmin/Page/Base.php
@@ -8,6 +8,7 @@
  | and copyright information, see https://civicrm.org/licensing       |
  +--------------------------------------------------------------------+
  */
+use CRM_AfformAdmin_ExtensionUtil as E;
 
 /**
  * Base page for Afform admin
@@ -16,7 +17,7 @@ class CRM_AfformAdmin_Page_Base extends CRM_Core_Page {
 
   public function run() {
     $breadCrumb = [
-      'title' => ts('Form Builder'),
+      'title' => E::ts('Form Builder'),
       'url' => CRM_Utils_System::url('civicrm/admin/afform', NULL, FALSE, '/'),
     ];
     CRM_Utils_System::appendBreadCrumb([$breadCrumb]);

--- a/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php
+++ b/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php
@@ -18,10 +18,10 @@ class AfformAdminMeta {
       ->execute();
     // Pluralize tabs (too bad option groups only store a single label)
     $plurals = [
-      'form' => ts('Custom Forms'),
-      'search' => ts('Search Displays'),
-      'block' => ts('Field Blocks'),
-      'system' => ts('System Forms'),
+      'form' => E::ts('Custom Forms'),
+      'search' => E::ts('Search Displays'),
+      'block' => E::ts('Field Blocks'),
+      'system' => E::ts('System Forms'),
     ];
     foreach ($afformTypes as $index => $type) {
       $afformTypes[$index]['plural'] = $plurals[$type['name']] ?? \CRM_Utils_String::pluralize($type['label']);

--- a/ext/afform/admin/ang/afAdmin/afAdminList.controller.js
+++ b/ext/afform/admin/ang/afAdmin/afAdminList.controller.js
@@ -2,7 +2,7 @@
   "use strict";
 
   angular.module('afAdmin').controller('afAdminList', function($scope, afforms, crmApi4, crmStatus) {
-    var ts = $scope.ts = CRM.ts(),
+    var ts = $scope.ts = CRM.ts('org.civicrm.afform_admin'),
       ctrl = $scope.$ctrl = this;
 
     $scope.crmUrl = CRM.url;

--- a/ext/afform/admin/ang/afGuiEditor/afGuiEditOptions.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiEditOptions.component.js
@@ -6,7 +6,7 @@
     templateUrl: '~/afGuiEditor/afGuiEditOptions.html',
     require: {field: '^^afGuiField'},
     controller: function($scope) {
-      var ts = $scope.ts = CRM.ts(),
+      var ts = $scope.ts = CRM.ts('org.civicrm.afform_admin'),
         ctrl = this;
 
       this.$onInit = function() {

--- a/ext/afform/admin/ang/afGuiEditor/afGuiEditor.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiEditor.component.js
@@ -19,7 +19,7 @@
     },
     controllerAs: 'editor',
     controller: function($scope, crmApi4, afGui, $parse, $timeout, $location) {
-      var ts = $scope.ts = CRM.ts('afform');
+      var ts = $scope.ts = CRM.ts('org.civicrm.afform_admin');
       $scope.crmUrl = CRM.url;
 
       $scope.afform = null;

--- a/ext/afform/admin/ang/afGuiEditor/afGuiEntity.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiEntity.component.js
@@ -9,7 +9,7 @@
     },
     require: {editor: '^^afGuiEditor'},
     controller: function ($scope, $timeout, afGui) {
-      var ts = $scope.ts = CRM.ts();
+      var ts = $scope.ts = CRM.ts('org.civicrm.afform_admin');
       var ctrl = this;
       $scope.controls = {};
       $scope.fieldList = [];

--- a/ext/afform/admin/ang/afGuiEditor/afGuiFieldValue.directive.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiFieldValue.directive.js
@@ -10,7 +10,7 @@
       },
       require: 'ngModel',
       link: function (scope, element, attrs, ctrl) {
-        var ts = scope.ts = CRM.ts(),
+        var ts = scope.ts = CRM.ts('org.civicrm.afform_admin'),
           multi;
 
         function destroyWidget() {

--- a/ext/afform/admin/ang/afGuiEditor/afGuiMenuItemBackground.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiMenuItemBackground.component.js
@@ -9,7 +9,7 @@
       node: '='
     },
     controller: function($scope, afGui) {
-      var ts = $scope.ts = CRM.ts(),
+      var ts = $scope.ts = CRM.ts('org.civicrm.afform_admin'),
         ctrl = this;
 
       $scope.getSetBackgroundColor = function(color) {

--- a/ext/afform/admin/ang/afGuiEditor/afGuiMenuItemBorder.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiMenuItemBorder.component.js
@@ -9,7 +9,7 @@
       node: '='
     },
     controller: function($scope, afGui) {
-      var ts = $scope.ts = CRM.ts(),
+      var ts = $scope.ts = CRM.ts('org.civicrm.afform_admin'),
         ctrl = this;
 
       $scope.getSetBorderWidth = function(width) {

--- a/ext/afform/admin/ang/afGuiEditor/afGuiSaveBlock.controller.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiSaveBlock.controller.js
@@ -3,7 +3,7 @@
   "use strict";
 
   angular.module('afGuiEditor').controller('afGuiSaveBlock', function($scope, crmApi4, dialogService) {
-    var ts = $scope.ts = CRM.ts(),
+    var ts = $scope.ts = CRM.ts('org.civicrm.afform_admin'),
       model = $scope.model,
       original = $scope.original = {
         title: model.title,

--- a/ext/afform/admin/ang/afGuiEditor/afGuiSearch.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiSearch.component.js
@@ -9,7 +9,7 @@
     },
     require: {editor: '^^afGuiEditor'},
     controller: function ($scope, $timeout, afGui) {
-      var ts = $scope.ts = CRM.ts();
+      var ts = $scope.ts = CRM.ts('org.civicrm.afform_admin');
       var ctrl = this;
       $scope.controls = {};
       $scope.fieldList = [];

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiButton.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiButton.component.js
@@ -9,7 +9,7 @@
       deleteThis: '&'
     },
     controller: function($scope, afGui) {
-      var ts = $scope.ts = CRM.ts(),
+      var ts = $scope.ts = CRM.ts('org.civicrm.afform_admin'),
         ctrl = this;
 
       // TODO: Add action selector to UI

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiContainer.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiContainer.component.js
@@ -12,7 +12,7 @@
     },
     require: {editor: '^^afGuiEditor'},
     controller: function($scope, crmApi4, dialogService, afGui) {
-      var ts = $scope.ts = CRM.ts(),
+      var ts = $scope.ts = CRM.ts('org.civicrm.afform_admin'),
         ctrl = this;
 
       this.$onInit = function() {

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
@@ -13,7 +13,7 @@
       container: '^^afGuiContainer'
     },
     controller: function($scope, afGui) {
-      var ts = $scope.ts = CRM.ts(),
+      var ts = $scope.ts = CRM.ts('org.civicrm.afform_admin'),
         ctrl = this;
 
       $scope.editingOptions = false;

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiMarkup.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiMarkup.component.js
@@ -11,7 +11,7 @@
       deleteThis: '&'
     },
     controller: function($scope, $sce, $timeout) {
-      var ts = $scope.ts = CRM.ts(),
+      var ts = $scope.ts = CRM.ts('org.civicrm.afform_admin'),
         ctrl = this;
 
       this.$onInit = function() {

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiSearchDisplay.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiSearchDisplay.component.js
@@ -8,7 +8,7 @@
       node: '='
     },
     controller: function($scope, afGui) {
-      var ts = $scope.ts = CRM.ts(),
+      var ts = $scope.ts = CRM.ts('org.civicrm.afform_admin'),
         ctrl = this;
 
       this.$onInit = function() {

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiText.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiText.component.js
@@ -9,7 +9,7 @@
       deleteThis: '&'
     },
     controller: function($scope, afGui) {
-      var ts = $scope.ts = CRM.ts(),
+      var ts = $scope.ts = CRM.ts('org.civicrm.afform_admin'),
         ctrl = this;
 
       $scope.tags = {

--- a/ext/afform/core/CRM/Afform/Page/AfformBase.php
+++ b/ext/afform/core/CRM/Afform/Page/AfformBase.php
@@ -27,7 +27,7 @@ class CRM_Afform_Page_AfformBase extends CRM_Core_Page {
 
     // If the user has "access civicrm" append home breadcrumb
     if (CRM_Core_Permission::check('access CiviCRM')) {
-      CRM_Utils_System::appendBreadCrumb([['title' => ts('CiviCRM'), 'url' => CRM_Utils_System::url('civicrm')]]);
+      CRM_Utils_System::appendBreadCrumb([['title' => E::ts('CiviCRM'), 'url' => CRM_Utils_System::url('civicrm')]]);
       // If the user has "admin civicrm" & the admin extension is enabled
       if (CRM_Core_Permission::check('administer CiviCRM') && CRM_Utils_Array::findAll(
           \CRM_Extension_System::singleton()->getMapper()->getActiveModuleFiles(),

--- a/ext/afform/core/Civi/Afform/AfformMetadataInjector.php
+++ b/ext/afform/core/Civi/Afform/AfformMetadataInjector.php
@@ -11,6 +11,8 @@
 
 namespace Civi\Afform;
 
+use CRM_Afform_ExtensionUtil as E;
+
 /**
  * Class AfformMetadataInjector
  * @package Civi\Afform
@@ -109,13 +111,13 @@ class AfformMetadataInjector {
       }
       // Default placeholder for select inputs
       if ($fieldInfo['input_type'] === 'Select') {
-        $fieldInfo['input_attrs'] = ($fieldInfo['input_attrs'] ?? []) + ['placeholder' => ts('Select')];
+        $fieldInfo['input_attrs'] = ($fieldInfo['input_attrs'] ?? []) + ['placeholder' => E::ts('Select')];
       }
 
       $fieldDefn = $existingFieldDefn ? \CRM_Utils_JS::getRawProps($existingFieldDefn) : [];
 
       if ('Date' === $fieldInfo['input_type'] && !empty($fieldDefn['input_type']) && \CRM_Utils_JS::decode($fieldDefn['input_type']) === 'Select') {
-        $fieldInfo['input_attrs']['placeholder'] = ts('Select');
+        $fieldInfo['input_attrs']['placeholder'] = E::ts('Select');
         $fieldInfo['options'] = \CRM_Utils_Array::makeNonAssociative(\CRM_Core_OptionGroup::values('relative_date_filters'), 'id', 'label');
       }
 

--- a/ext/afform/core/Civi/Api4/Action/Afform/Get.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/Get.php
@@ -4,6 +4,7 @@ namespace Civi\Api4\Action\Afform;
 
 use Civi\Api4\CustomField;
 use Civi\Api4\CustomGroup;
+use CRM_Afform_ExtensionUtil as E;
 
 /**
  * @inheritDoc
@@ -126,7 +127,7 @@ class Get extends \Civi\Api4\Generic\BasicGetAction {
         'name' => $name,
         'type' => 'block',
         'requires' => [],
-        'title' => ts('%1 block (default)', [1 => $custom['title']]),
+        'title' => E::ts('%1 block (default)', [1 => $custom['title']]),
         'description' => '',
         'is_dashlet' => FALSE,
         'is_public' => FALSE,

--- a/ext/afform/core/afform.php
+++ b/ext/afform/core/afform.php
@@ -12,7 +12,7 @@ use Civi\Api4\Action\Afform\Submit;
  */
 function _afform_fields_filter($params) {
   $result = [];
-  $fields = \Civi\Api4\Afform::getfields()->setCheckPermissions(FALSE)->setAction('create')->execute()->indexBy('name');
+  $fields = \Civi\Api4\Afform::getfields(FALSE)->setAction('create')->execute()->indexBy('name');
   foreach ($fields as $fieldName => $field) {
     if (isset($params[$fieldName])) {
       $result[$fieldName] = $params[$fieldName];
@@ -156,7 +156,7 @@ function afform_civicrm_managed(&$entities) {
         'domain_id' => CRM_Core_BAO_Domain::getDomain()->id,
         'is_active' => TRUE,
         'name' => $afform['name'],
-        'label' => $afform['title'] ?? ts('(Untitled)'),
+        'label' => $afform['title'] ?? E::ts('(Untitled)'),
         'directive' => _afform_angular_module_name($afform['name'], 'dash'),
         'permission' => "@afform:" . $afform['name'],
       ],
@@ -348,7 +348,7 @@ function afform_civicrm_permissionList(&$permissions) {
   foreach ($scanner->getMetas() as $name => $meta) {
     $permissions['@afform:' . $name] = [
       'group' => 'afform',
-      'title' => ts('Afform: Inherit permission of %1', [
+      'title' => E::ts('Afform: Inherit permission of %1', [
         1 => $name,
       ]),
     ];

--- a/ext/afform/core/ang/af/afField.component.js
+++ b/ext/afform/core/ang/af/afField.component.js
@@ -13,7 +13,7 @@
       defn: '='
     },
     controller: function($scope, $element, crmApi4) {
-      var ts = $scope.ts = CRM.ts('afform'),
+      var ts = $scope.ts = CRM.ts('org.civicrm.afform'),
         ctrl = this,
         boolOptions = [{id: true, label: ts('Yes')}, {id: false, label: ts('No')}],
         // Only used for is_primary radio button

--- a/ext/search/CRM/Search/Page/Admin.php
+++ b/ext/search/CRM/Search/Page/Admin.php
@@ -9,6 +9,8 @@
  +--------------------------------------------------------------------+
  */
 
+use CRM_Search_ExtensionUtil as E;
+
 /**
  * Angular base page for search admin
  */
@@ -16,7 +18,7 @@ class CRM_Search_Page_Admin extends CRM_Core_Page {
 
   public function run() {
     $breadCrumb = [
-      'title' => ts('Search Kit'),
+      'title' => E::ts('Search Kit'),
       'url' => CRM_Utils_System::url('civicrm/admin/search', NULL, FALSE, '/list'),
     ];
     CRM_Utils_System::appendBreadCrumb([$breadCrumb]);

--- a/ext/search/Civi/Search/Actions.php
+++ b/ext/search/Civi/Search/Actions.php
@@ -11,6 +11,8 @@
 
 namespace Civi\Search;
 
+use CRM_Search_ExtensionUtil as E;
+
 /**
  * Class Tasks
  * @package Civi\Search
@@ -47,7 +49,7 @@ class Actions {
     // Note: the placeholder %1 will be replaced with entity name on the clientside
     $tasks = [
       'export' => [
-        'title' => ts('Export %1'),
+        'title' => E::ts('Export %1'),
         'icon' => 'fa-file-excel-o',
         'entities' => array_keys(\CRM_Export_BAO_Export::getComponents()),
         'crmPopup' => [
@@ -56,13 +58,13 @@ class Actions {
         ],
       ],
       'update' => [
-        'title' => ts('Update %1'),
+        'title' => E::ts('Update %1'),
         'icon' => 'fa-save',
         'entities' => [],
         'uiDialog' => ['templateUrl' => '~/crmSearchActions/crmSearchActionUpdate.html'],
       ],
       'delete' => [
-        'title' => ts('Delete %1'),
+        'title' => E::ts('Delete %1'),
         'icon' => 'fa-trash',
         'entities' => [],
         'uiDialog' => ['templateUrl' => '~/crmSearchActions/crmSearchActionDelete.html'],

--- a/ext/search/ang/crmSearchActions/crmSearchActionDelete.ctrl.js
+++ b/ext/search/ang/crmSearchActions/crmSearchActionDelete.ctrl.js
@@ -2,7 +2,7 @@
   "use strict";
 
   angular.module('crmSearchActions').controller('crmSearchActionDelete', function($scope, dialogService) {
-    var ts = $scope.ts = CRM.ts(),
+    var ts = $scope.ts = CRM.ts('org.civicrm.search'),
       model = $scope.model,
       ctrl = $scope.$ctrl = this;
 

--- a/ext/search/ang/crmSearchActions/crmSearchActionUpdate.ctrl.js
+++ b/ext/search/ang/crmSearchActions/crmSearchActionUpdate.ctrl.js
@@ -2,7 +2,7 @@
   "use strict";
 
   angular.module('crmSearchActions').controller('crmSearchActionUpdate', function ($scope, $timeout, crmApi4, dialogService) {
-    var ts = $scope.ts = CRM.ts(),
+    var ts = $scope.ts = CRM.ts('org.civicrm.search'),
       model = $scope.model,
       ctrl = $scope.$ctrl = this;
 

--- a/ext/search/ang/crmSearchActions/crmSearchActions.component.js
+++ b/ext/search/ang/crmSearchActions/crmSearchActions.component.js
@@ -9,7 +9,7 @@
     },
     templateUrl: '~/crmSearchActions/crmSearchActions.html',
     controller: function($scope, crmApi4, dialogService) {
-      var ts = $scope.ts = CRM.ts(),
+      var ts = $scope.ts = CRM.ts('org.civicrm.search'),
         ctrl = this,
         initialized = false,
         unwatchIDs = $scope.$watch('$ctrl.ids.length', watchIDs);

--- a/ext/search/ang/crmSearchActions/crmSearchBatchRunner.component.js
+++ b/ext/search/ang/crmSearchActions/crmSearchBatchRunner.component.js
@@ -12,7 +12,7 @@
     },
     templateUrl: '~/crmSearchActions/crmSearchBatchRunner.html',
     controller: function($scope, $timeout, $interval, crmApi4) {
-      var ts = $scope.ts = CRM.ts(),
+      var ts = $scope.ts = CRM.ts('org.civicrm.search'),
         ctrl = this,
         currentBatch = 0,
         totalBatches,

--- a/ext/search/ang/crmSearchActions/crmSearchInput/crmSearchInput.component.js
+++ b/ext/search/ang/crmSearchActions/crmSearchInput/crmSearchInput.component.js
@@ -11,7 +11,7 @@
     require: {ngModel: 'ngModel'},
     templateUrl: '~/crmSearchActions/crmSearchInput/crmSearchInput.html',
     controller: function($scope) {
-      var ts = $scope.ts = CRM.ts(),
+      var ts = $scope.ts = CRM.ts('org.civicrm.search'),
         ctrl = this;
 
       this.isMulti = function() {

--- a/ext/search/ang/crmSearchActions/crmSearchInput/crmSearchInputVal.component.js
+++ b/ext/search/ang/crmSearchActions/crmSearchInput/crmSearchInputVal.component.js
@@ -10,7 +10,7 @@
     require: {ngModel: 'ngModel'},
     template: '<div class="form-group" ng-include="$ctrl.getTemplate()"></div>',
     controller: function($scope, formatForSelect2) {
-      var ts = $scope.ts = CRM.ts(),
+      var ts = $scope.ts = CRM.ts('org.civicrm.search'),
         ctrl = this;
 
       this.$onInit = function() {

--- a/ext/search/ang/crmSearchAdmin/crmSearchAdmin.component.js
+++ b/ext/search/ang/crmSearchAdmin/crmSearchAdmin.component.js
@@ -7,7 +7,7 @@
     },
     templateUrl: '~/crmSearchAdmin/crmSearchAdmin.html',
     controller: function($scope, $element, $location, $timeout, crmApi4, dialogService, searchMeta, formatForSelect2) {
-      var ts = $scope.ts = CRM.ts(),
+      var ts = $scope.ts = CRM.ts('org.civicrm.search'),
         ctrl = this;
 
       this.DEFAULT_AGGREGATE_FN = 'GROUP_CONCAT';

--- a/ext/search/ang/crmSearchAdmin/crmSearchAdminDisplay.component.js
+++ b/ext/search/ang/crmSearchAdmin/crmSearchAdminDisplay.component.js
@@ -33,7 +33,7 @@
       return html;
     },
     controller: function($scope, $timeout, searchMeta) {
-      var ts = $scope.ts = CRM.ts(),
+      var ts = $scope.ts = CRM.ts('org.civicrm.search'),
         ctrl = this;
 
       this.preview = this.stale = false;

--- a/ext/search/ang/crmSearchAdmin/crmSearchAdminLinkGroup.component.js
+++ b/ext/search/ang/crmSearchAdmin/crmSearchAdminLinkGroup.component.js
@@ -10,7 +10,7 @@
     },
     templateUrl: '~/crmSearchAdmin/crmSearchAdminLinkGroup.html',
     controller: function ($scope, $element, $timeout, searchMeta) {
-      var ts = $scope.ts = CRM.ts(),
+      var ts = $scope.ts = CRM.ts('org.civicrm.search'),
         ctrl = this;
 
       this.styles = CRM.crmSearchAdmin.styles;

--- a/ext/search/ang/crmSearchAdmin/crmSearchAdminLinkSelect.component.js
+++ b/ext/search/ang/crmSearchAdmin/crmSearchAdminLinkSelect.component.js
@@ -10,7 +10,7 @@
     },
     templateUrl: '~/crmSearchAdmin/crmSearchAdminLinkSelect.html',
     controller: function ($scope, $element, $timeout) {
-      var ts = $scope.ts = CRM.ts(),
+      var ts = $scope.ts = CRM.ts('org.civicrm.search'),
         ctrl = this;
 
       this.setValue = function(val) {

--- a/ext/search/ang/crmSearchAdmin/crmSearchAdminTokenSelect.component.js
+++ b/ext/search/ang/crmSearchAdmin/crmSearchAdminTokenSelect.component.js
@@ -10,7 +10,7 @@
     },
     templateUrl: '~/crmSearchAdmin/crmSearchAdminTokenSelect.html',
     controller: function ($scope, $element, searchMeta) {
-      var ts = $scope.ts = CRM.ts(),
+      var ts = $scope.ts = CRM.ts('org.civicrm.search'),
         ctrl = this;
 
       this.initTokens = function() {

--- a/ext/search/ang/crmSearchAdmin/crmSearchClause.component.js
+++ b/ext/search/ang/crmSearchAdmin/crmSearchClause.component.js
@@ -13,7 +13,7 @@
     },
     templateUrl: '~/crmSearchAdmin/crmSearchClause.html',
     controller: function ($scope, $element, $timeout, searchMeta) {
-      var ts = $scope.ts = CRM.ts(),
+      var ts = $scope.ts = CRM.ts('org.civicrm.search'),
         ctrl = this,
         meta = {};
       this.conjunctions = {AND: ts('And'), OR: ts('Or'), NOT: ts('Not')};

--- a/ext/search/ang/crmSearchAdmin/crmSearchFunction.component.js
+++ b/ext/search/ang/crmSearchAdmin/crmSearchFunction.component.js
@@ -8,7 +8,7 @@
     },
     templateUrl: '~/crmSearchAdmin/crmSearchFunction.html',
     controller: function($scope, formatForSelect2, searchMeta) {
-      var ts = $scope.ts = CRM.ts(),
+      var ts = $scope.ts = CRM.ts('org.civicrm.search'),
         ctrl = this;
 
       this.$onInit = function() {

--- a/ext/search/ang/crmSearchAdmin/displays/searchAdminDisplayList.component.js
+++ b/ext/search/ang/crmSearchAdmin/displays/searchAdminDisplayList.component.js
@@ -12,7 +12,7 @@
     },
     templateUrl: '~/crmSearchAdmin/displays/searchAdminDisplayList.html',
     controller: function($scope) {
-      var ts = $scope.ts = CRM.ts(),
+      var ts = $scope.ts = CRM.ts('org.civicrm.search'),
         ctrl = this;
 
       this.symbols = {

--- a/ext/search/ang/crmSearchAdmin/displays/searchAdminDisplayTable.component.js
+++ b/ext/search/ang/crmSearchAdmin/displays/searchAdminDisplayTable.component.js
@@ -12,7 +12,7 @@
     },
     templateUrl: '~/crmSearchAdmin/displays/searchAdminDisplayTable.html',
     controller: function($scope) {
-      var ts = $scope.ts = CRM.ts(),
+      var ts = $scope.ts = CRM.ts('org.civicrm.search'),
         ctrl = this;
 
       this.$onInit = function () {

--- a/ext/search/ang/crmSearchAdmin/searchList.controller.js
+++ b/ext/search/ang/crmSearchAdmin/searchList.controller.js
@@ -2,7 +2,7 @@
   "use strict";
 
   angular.module('crmSearchAdmin').controller('searchList', function($scope, savedSearches, crmApi4) {
-    var ts = $scope.ts = CRM.ts(),
+    var ts = $scope.ts = CRM.ts('org.civicrm.search'),
       ctrl = $scope.$ctrl = this;
     this.savedSearches = savedSearches;
     this.afformEnabled = CRM.crmSearchAdmin.afformEnabled;

--- a/ext/search/ang/crmSearchDisplayList/crmSearchDisplayList.component.js
+++ b/ext/search/ang/crmSearchDisplayList/crmSearchDisplayList.component.js
@@ -15,7 +15,7 @@
     },
     templateUrl: '~/crmSearchDisplayList/crmSearchDisplayList.html',
     controller: function($scope, crmApi4, searchDisplayUtils) {
-      var ts = $scope.ts = CRM.ts(),
+      var ts = $scope.ts = CRM.ts('org.civicrm.search'),
         ctrl = this;
 
       this.page = 1;

--- a/ext/search/ang/crmSearchDisplayTable/crmSearchDisplayTable.component.js
+++ b/ext/search/ang/crmSearchDisplayTable/crmSearchDisplayTable.component.js
@@ -14,7 +14,7 @@
     },
     templateUrl: '~/crmSearchDisplayTable/crmSearchDisplayTable.html',
     controller: function($scope, crmApi4, searchDisplayUtils) {
-      var ts = $scope.ts = CRM.ts(),
+      var ts = $scope.ts = CRM.ts('org.civicrm.search'),
         ctrl = this;
 
       this.page = 1;


### PR DESCRIPTION
Overview
----------------------------------------
Ensures all translatable strings in SearchKit & Afform extensions are translated using the extension namespace.

Before
----------------------------------------
Translatable strings not namespaced.

After
----------------------------------------
Fixed.

Comments
----------------------------------------
Also a little minor code cleanup in this PR.
