### PR TITLE
WordPress: avoid PHP notice if the anonymous user does not have any capabilities

### DIFF
--- a/CRM/Core/Permission/WordPress.php
+++ b/CRM/Core/Permission/WordPress.php
@@ -76,10 +76,8 @@ class CRM_Core_Permission_WordPress extends CRM_Core_Permission_Base {
     else {
       //check the capabilities of Anonymous user)
       $roleObj = new WP_Roles();
-      if (
-        $roleObj->get_role('anonymous_user') != NULL &&
-        array_key_exists($str, $roleObj->get_role('anonymous_user')->capabilities)
-      ) {
+      $anonObj = $roleObj->get_role('anonymous_user');
+      if (!empty($anonObj->capabilities) && array_key_exists($str, $anonObj->capabilities)) {
         return TRUE;
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------

On a site where debug mode is set (i.e. where a PHP E_NOTICE will cause fatal errors), visiting a CiviCRM form as an anonymous user will cause a confusing `array_key_exists expects param 2 to be an array`  fatal error if the anonymous user role does not have any permissions/capabilities.

To reproduce:

* Setup a new site
* Enable strict PHP mode - see below
* Visit a contribution page as an anonymous user.

Because the anonymous user does not have any capabilities, it will cause a confusing fatal error, instead of a "permission denied".

Example to enable fatal triggers, if xdebug is enabled, add to `civicrm.settings.php`:

```
<?php
ini_set('xdebug.halt_level', E_WARNING|E_NOTICE|E_USER_WARNING|E_USER_NOTICE);
```

I haven't really tested. I was debugging a site using [Themosis](https://framework.themosis.com/) (not an endorsement, I was helping out another shop).

Before
----------------------------------------

![before-0](https://user-images.githubusercontent.com/254741/110035748-0a3f5600-7d0a-11eb-8226-fd589bf27376.jpg)


![fatal](https://user-images.githubusercontent.com/254741/110034618-ac5e3e80-7d08-11eb-8fed-3410aae38d8d.png)


After
----------------------------------------

![before-1](https://user-images.githubusercontent.com/254741/110035766-11666400-7d0a-11eb-9cac-b2583902046c.png)


Comments
----------------------------------------

cc @christianwach @kcristiano 