### PR TITLE
Export UI - Only present "save mapping" button to permissioned users

### DIFF
--- a/ang/exportui.ang.php
+++ b/ang/exportui.ang.php
@@ -13,6 +13,7 @@ return [
     'ang/exportui',
   ],
   'basePages' => [],
+  'permissions' => ['administer CiviCRM'],
   'requires' => [
     'crmUi',
     'crmUtil',

--- a/ang/exportui/export.html
+++ b/ang/exportui/export.html
@@ -19,7 +19,7 @@
     <tr>
       <td colspan="6">
         <input class="crm-action-menu fa-plus crm-export-add-field" crm-ui-select="{data: getFields, placeholder: ts('Add field')}" ng-model="new.col" />
-        <span ng-if="data.columns.length">
+        <span ng-if="data.columns.length && perms.admin">
           <button type="button" ng-click="saveMappingDialog()" crm-icon="fa-save">
             {{:: ts('Save Fields') }}
           </button>

--- a/ang/exportui/exportui.js
+++ b/ang/exportui/exportui.js
@@ -22,6 +22,9 @@
       contact_type: '',
       columns: []
     };
+    $scope.perms = {
+      admin: CRM.checkPerm('administer CiviCRM')
+    };
     // For the "add new field" dropdown
     $scope.new = {col: ''};
     var contactTypes = _.transform($scope.contact_types, function(result, type) {


### PR DESCRIPTION
Overview
----------------------------------------
The button was showing for all users which would result in confusion when it didn't work because they lacked permission.

See https://lab.civicrm.org/dev/core/-/issues/2435

Before
----------------------------------------
Button shows for all users, then fails to work.

After
----------------------------------------
Button hidden for non-admins.

Comments
--------

Currently the APIv3 Mapping.create api requires "administer CiviCRM." I don't know if that's right or if there's another
permission it ought to be checking, but at least this brings the UI in alignment with what's currently allowed.