### PR TITLE
APIv4 Explorer - Fix layout in code tab

### DIFF
--- a/ang/api4Explorer/Explorer.html
+++ b/ang/api4Explorer/Explorer.html
@@ -199,12 +199,10 @@
           </li>
         </ul>
         <div class="panel-body">
-          <table>
-            <tr ng-repeat="style in code[selectedTab.code]">
-              <td>{{:: style.label }}</td>
-              <td><pre class="prettyprint" ng-bind-html="style.code"></pre></td>
-            </tr>
-          </table>
+          <div ng-repeat="style in code[selectedTab.code]">
+            <label>{{:: style.label }}</label>
+            <div><pre class="prettyprint" ng-bind-html="style.code"></pre></div>
+          </div>
         </div>
       </div>
       <div class="panel explorer-result-panel panel-{{ status }}" >

--- a/css/api4-explorer.css
+++ b/css/api4-explorer.css
@@ -39,12 +39,10 @@
 #bootstrap-theme .panel-heading>li>a {
   background-color: #f1f1f18c
 }
-#bootstrap-theme.api4-explorer-page .explorer-code-panel table td:first-child {
-  width: 6em;
-  word-break: break-word;
-}
-#bootstrap-theme.api4-explorer-page .explorer-code-panel table td pre {
+#bootstrap-theme.api4-explorer-page .explorer-code-panel pre {
   min-height: 3.3em;
+  word-break: break-all;
+  white-space: pre-wrap;
 }
 #bootstrap-theme.api4-explorer-page .explorer-code-panel .panel-heading.nav li a {
   text-transform: uppercase;


### PR DESCRIPTION
Overview
----------------------------------------
This makes better use of space in the APIv4 Explorer "Code" panel, and prevents label text from getting squashed.

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/2874912/110039996-13cbbc80-7d10-11eb-80ae-48ce2911b11b.png)


After
----------------------------------------
![image](https://user-images.githubusercontent.com/2874912/110039767-bc2d5100-7d0f-11eb-84e2-23e5e966239f.png)
