### PR TITLE
dev/core#542 dev/core#1947 - Show inactive active case role for closed cases

### DIFF
--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -776,6 +776,8 @@ SELECT civicrm_case.id, case_status.label AS case_status, status_id, civicrm_cas
             civicrm_email.email as email,
             civicrm_phone.phone as phone,
             con.id as civicrm_contact_id,
+            rel.is_active as is_active,
+            rel.end_date as end_date,
             IF(rel.contact_id_a = %1, civicrm_relationship_type.label_a_b, civicrm_relationship_type.label_b_a) as relation,
             civicrm_relationship_type.id as relation_type,
             IF(rel.contact_id_a = %1, "a_b", "b_a") as relationship_direction
@@ -800,6 +802,7 @@ SELECT civicrm_case.id, case_status.label AS case_status, status_id, civicrm_cas
       $query .= ' AND rel.id = %3 ';
       $params[3] = [$relationshipID, 'Integer'];
     }
+
     $dao = CRM_Core_DAO::executeQuery($query, $params);
 
     $values = [];
@@ -807,9 +810,11 @@ SELECT civicrm_case.id, case_status.label AS case_status, status_id, civicrm_cas
       $rid = $dao->civicrm_relationship_id;
       $values[$rid]['cid'] = $dao->civicrm_contact_id;
       $values[$rid]['relation'] = $dao->relation;
-      $values[$rid]['name'] = $dao->sort_name;
+      $values[$rid]['sort_name'] = $dao->sort_name;
       $values[$rid]['email'] = $dao->email;
       $values[$rid]['phone'] = $dao->phone;
+      $values[$rid]['is_active'] = $dao->is_active;
+      $values[$rid]['end_date'] = $dao->end_date;
       $values[$rid]['relation_type'] = $dao->relation_type;
       $values[$rid]['rel_id'] = $dao->civicrm_relationship_id;
       $values[$rid]['client_id'] = $contactID;
@@ -1723,20 +1728,24 @@ HERESQL;
       if (substr($managerRoleId, -4) == '_a_b') {
         $managerRoleQuery = "
           SELECT civicrm_contact.id as casemanager_id,
-                 civicrm_contact.sort_name as casemanager
+                 civicrm_contact.sort_name as casemanager,
+                 civicrm_relationship.is_active,
+                 civicrm_relationship.end_date
            FROM civicrm_contact
            LEFT JOIN civicrm_relationship ON (civicrm_relationship.contact_id_b = civicrm_contact.id AND civicrm_relationship.relationship_type_id = %1) AND civicrm_relationship.is_active
            LEFT JOIN civicrm_case ON civicrm_case.id = civicrm_relationship.case_id
-           WHERE civicrm_case.id = %2 AND is_active = 1";
+           WHERE civicrm_case.id = %2";
       }
       if (substr($managerRoleId, -4) == '_b_a') {
         $managerRoleQuery = "
           SELECT civicrm_contact.id as casemanager_id,
-                 civicrm_contact.sort_name as casemanager
+                 civicrm_contact.sort_name as casemanager,
+                 civicrm_relationship.is_active,
+                 civicrm_relationship.end_date
            FROM civicrm_contact
            LEFT JOIN civicrm_relationship ON (civicrm_relationship.contact_id_a = civicrm_contact.id AND civicrm_relationship.relationship_type_id = %1) AND civicrm_relationship.is_active
            LEFT JOIN civicrm_case ON civicrm_case.id = civicrm_relationship.case_id
-           WHERE civicrm_case.id = %2 AND is_active = 1";
+           WHERE civicrm_case.id = %2";
       }
 
       $managerRoleParams = [
@@ -1745,10 +1754,28 @@ HERESQL;
       ];
 
       $dao = CRM_Core_DAO::executeQuery($managerRoleQuery, $managerRoleParams);
-      if ($dao->fetch()) {
+      // Pull an array of ALL case managers related to the case.
+      $caseManagerNameArray = [];
+      while ($dao->fetch()) {
+        $caseManagerNameArray[$dao->casemanager_id]['casemanager_id'] = $dao->casemanager_id;
+        $caseManagerNameArray[$dao->casemanager_id]['is_active'] = $dao->is_active;
+        $caseManagerNameArray[$dao->casemanager_id]['end_date'] = $dao->end_date;
+        $caseManagerNameArray[$dao->casemanager_id]['casemanager'] = $dao->casemanager;
+      }
+
+      // Look for an active case manager, when no active case manager (like a closed case) show the most recently expired case manager.
+      // Get the index of the manager if set to active
+      $activekey = array_search(1, array_combine(array_keys($caseManagerNameArray), array_column($caseManagerNameArray, 'is_active')));
+      if (!empty($activekey)) {
         $caseManagerName = sprintf('<a href="%s">%s</a>',
-          CRM_Utils_System::url('civicrm/contact/view', ['cid' => $dao->casemanager_id]),
-          $dao->casemanager
+          CRM_Utils_System::url('civicrm/contact/view', ['cid' => $activekey]), $caseManagerNameArray[$activekey]['casemanager']
+        );
+      }
+      elseif (!empty($caseManagerNameArray)) {
+        // if there is no active case manager, get the index of the most recent end_date
+        $max = array_search(max(array_combine(array_keys($caseManagerNameArray), array_column($caseManagerNameArray, 'end_date'))), array_combine(array_keys($caseManagerNameArray), array_column($caseManagerNameArray, 'end_date')));
+        $caseManagerName = sprintf('<a href="%s">%s</a>',
+          CRM_Utils_System::url('civicrm/contact/view', ['cid' => $max]), $caseManagerNameArray[$max]['casemanager']
         );
       }
     }

--- a/CRM/Case/Form/CaseView.php
+++ b/CRM/Case/Form/CaseView.php
@@ -78,12 +78,18 @@ class CRM_Case_Form_CaseView extends CRM_Core_Form {
     $statuses = CRM_Case_PseudoConstant::caseStatus('label', FALSE);
     $caseTypeName = CRM_Case_BAO_Case::getCaseType($this->_caseID, 'name');
     $caseType = CRM_Case_BAO_Case::getCaseType($this->_caseID);
+    $statusClass = civicrm_api3('OptionValue', 'getsingle', [
+      'option_group_id' => "case_status",
+      'value' => $values['case_status_id'],
+      'return' => 'grouping',
+    ]);
 
     $this->_caseDetails = [
       'case_type' => $caseType,
       'case_status' => $statuses[$values['case_status_id']] ?? NULL,
       'case_subject' => $values['subject'] ?? NULL,
       'case_start_date' => $values['case_start_date'],
+      'status_class' => $statusClass['grouping'],
     ];
     $this->_caseType = $caseTypeName;
     $this->assign('caseDetails', $this->_caseDetails);
@@ -286,7 +292,7 @@ class CRM_Case_Form_CaseView extends CRM_Core_Form {
     self::activityForm($this, $aTypes);
 
     //get case related relationships (Case Role)
-    $caseRelationships = CRM_Case_BAO_Case::getCaseRoles($this->_contactID, $this->_caseID);
+    $caseRelationships = CRM_Case_BAO_Case::getCaseRoles($this->_contactID, $this->_caseID, NULL, FALSE);
 
     //save special label because we unset it in the loop
     $managerLabel = empty($managerRoleId) ? '' : $caseRoles[$managerRoleId];
@@ -467,7 +473,7 @@ class CRM_Case_Form_CaseView extends CRM_Core_Form {
     //build reporter select
     $reporters = ["" => ts(' - any reporter - ')];
     foreach ($caseRelationships as $key => & $value) {
-      $reporters[$value['cid']] = $value['name'] . " ( {$value['relation']} )";
+      $reporters[$value['cid']] = $value['sort_name'] . " ( {$value['relation']} )";
     }
     $form->add('select', 'reporter_id', ts('Reporter/Role'), $reporters, FALSE, ['id' => 'reporter_id_' . $form->_caseID]);
 

--- a/templates/CRM/Case/Form/CaseView.tpl
+++ b/templates/CRM/Case/Form/CaseView.tpl
@@ -150,14 +150,40 @@
         <div><label for="edit_role_contact_id">{ts}Change To{/ts}:</label></div>
         <div><input name="edit_role_contact_id" placeholder="{ts}- select contact -{/ts}" class="huge" /></div>
       </div>
-
+      <div id="caseRoles-selector-show-active">
+        {* add checkbox to show only active role on case, default value is unchecked (it show all roles) *}
+        {if $caseDetails.status_class eq 'Opened'}{assign var=statusclass value='0'}{else}{assign var=statusclass value='1'}{/if}
+        <label><input type="checkbox" id="role_inactive" name="role_inactive[]">{ts}Show Inactive relationships{/ts}</label>
+      </div>
+      {literal}
+        <script type="text/javascript">
+            (function($) {
+                var statusClass = {/literal}{$statusclass}{literal};
+                // for closed cases, 'Show Inactive relationships' checkbox is checked on page load.
+                if (statusClass) {
+                  CRM.$("#role_inactive").prop("checked", true);
+                }
+                // hide the inactive role when checkbox is checked
+                $('input[type=checkbox][id=role_inactive]').change(function() {
+                  if (this.checked == true) {
+                    CRM.$('[id^=caseRoles-selector] tbody tr').not('.disabled').hide();
+                    CRM.$('[id^=caseRoles-selector] tbody tr.disabled').show();
+                  } else if (this.checked == false) {
+                    CRM.$('[id^=caseRoles-selector] tbody tr').not('.disabled').show();
+                    CRM.$('[id^=caseRoles-selector] tbody tr.disabled').hide();
+                  }
+                });
+            })(CRM.$);
+        </script>
+      {/literal}
       <table id="caseRoles-selector-{$caseID}"  class="report-layout crm-ajax-table" data-page-length="10">
         <thead>
           <tr>
             <th data-data="relation">{ts}Case Role{/ts}</th>
-            <th data-data="name">{ts}Name{/ts}</th>
+            <th data-data="sort_name">{ts}Name{/ts}</th>
             <th data-data="phone">{ts}Phone{/ts}</th>
             <th data-data="email">{ts}Email{/ts}</th>
+            <th data-data="end_date">{ts}End Date{/ts}</th>
             {if $relId neq 'client' and $hasAccessToAllCases}
               <th data-data="actions" data-orderable="false">{ts}Actions{/ts}</th>
             {/if}
@@ -170,7 +196,17 @@
             var caseId = {/literal}{$caseID}{literal};
             CRM.$('table#caseRoles-selector-' + caseId).data({
               "ajax": {
-                "url": {/literal}'{crmURL p="civicrm/ajax/caseroles" h=0 q="snippet=4&caseID=$caseId&cid=$contactID&userID=$userID"}'{literal}
+                "url": {/literal}'{crmURL p="civicrm/ajax/caseroles" h=0 q="snippet=4&caseID=$caseId&cid=$contactID&userID=$userID"}'{literal},
+                "complete" : function(){
+                  if (CRM.$('input[type=checkbox][id=role_inactive]').prop('checked')) {
+                    CRM.$('[id^=caseRoles-selector] tbody tr').not('.disabled').hide();
+                    CRM.$('[id^=caseRoles-selector] tbody tr.disabled').show();
+                  }
+                  else {
+                    CRM.$('[id^=caseRoles-selector] tbody tr').not('.disabled').show();
+                    CRM.$('[id^=caseRoles-selector] tbody tr.disabled').hide();
+                  }
+                }
               }
             });
           })(CRM.$);


### PR DESCRIPTION
Overview
----------------------------------------
Currently when any case is closed , the all the roles on case contact marked to inactive but putting current date on their relationship record. there is no other way to find out who were these inactive role  at-least through case manage screen.


Before
----------------------------------------
For closed case there was no way to find out Inactive role on case with different role type.

After
----------------------------------------
Closed case will show all roles (active and inactive) by default. if case manager want to see only active roles then checkbox will be available to see only 

![2021-03-10 13 22 09](https://user-images.githubusercontent.com/377735/110595319-e4033580-81a3-11eb-8a7a-1cdd1a26e618.gif)


If any open case does not contain any inactive relationship then checkbox  is invisible 

Comments
----------------------------------------
I have reworked on https://github.com/civicrm/civicrm-core/pull/13510 