### PR TITLE
dev/translation#58 further regression fix: don't make group title NOT NULL even for a moment

### DIFF
--- a/CRM/Upgrade/Incremental/php/FiveThirtyOne.php
+++ b/CRM/Upgrade/Incremental/php/FiveThirtyOne.php
@@ -58,7 +58,7 @@ class CRM_Upgrade_Incremental_php_FiveThirtyOne extends CRM_Upgrade_Incremental_
    * @param string $rev
    */
   public function upgrade_5_31_alpha1($rev) {
-    $this->addTask('Expand internal civicrm group title field to be 255 in length', 'grouptitlefieldExpand');
+    $this->addTask('Expand internal civicrm group title field to be 255 in length', 'groupTitleRestore');
     $this->addTask('Add in optional public title group table', 'addColumn', 'civicrm_group', 'frontend_title', "varchar(255)   DEFAULT NULL COMMENT 'Alternative public title for this Group.'", TRUE, '5.31.alpha1', FALSE);
     $this->addTask('Add in optional public description group table', 'addColumn', 'civicrm_group', 'frontend_description', "text   DEFAULT NULL COMMENT 'Alternative public description of the group.'", TRUE, '5.31.alpha1');
     $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
@@ -142,30 +142,6 @@ class CRM_Upgrade_Incremental_php_FiveThirtyOne extends CRM_Upgrade_Incremental_
     ]);
     CRM_Core_DAO::executeQuery($insert->usingReplace()->toSQL());
 
-    return TRUE;
-  }
-
-  /**
-   * Expands the length of the civicrm_group.title field in the database to be 255.
-   *
-   * @param \CRM_Queue_TaskContext $ctx
-   *
-   * @return bool
-   */
-  public static function grouptitlefieldExpand(CRM_Queue_TaskContext $ctx) {
-    $locales = CRM_Core_I18n::getMultilingual();
-    $queries = [];
-    if ($locales) {
-      foreach ($locales as $locale) {
-        $queries[] = "ALTER TABLE civicrm_group CHANGE `title_{$locale}` `title_{$locale}` varchar(255) NOT NULL COMMENT 'Name of Group.'";
-      }
-    }
-    else {
-      $queries[] = "ALTER TABLE civicrm_group CHANGE `title` `title` varchar(255) NOT NULL COMMENT 'Name of Group.'";
-    }
-    foreach ($queries as $query) {
-      CRM_Core_DAO::executeQuery($query, [], TRUE, NULL, FALSE, FALSE);
-    }
     return TRUE;
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
The upgrade to 5.31.alpha1 makes the group title NOT NULL.  The upgrade to 5.35.beta2 removes that constraint.  This prevents upgrade problems by not making it NOT NULL in the first place.

Before
----------------------------------------
When upgrading a site from 5.30 or older, `civicrm_group.title` field is set to NOT NULL.  This breaks the upgrade if there are null values in that field.

```sql
ALTER TABLE civicrm_group CHANGE `title` `title` varchar(255) NOT NULL COMMENT 'Name of Group.'
```

It's also needless because the field is subsequently set to allow null values.  5.31.beta2 has

```sql
ALTER TABLE civicrm_group CHANGE `title` `title` varchar(255) DEFAULT NULL COMMENT 'Name of Group.'
```

After
----------------------------------------
When upgrading a site from 5.30 or older, `civicrm_group.title` is modified to have a length of 255 (the real purpose of the query), and presumably expected by the code at that point, but not NOT NULL.

```sql
ALTER TABLE civicrm_group CHANGE `title` `title` varchar(255) DEFAULT NULL COMMENT 'Name of Group.'
```

Technical Details
----------------------------------------
The `CRM_Upgrade_Incremental_php_FiveThirtyOne::groupTitleRestore()` function is identical to `CRM_Upgrade_Incremental_php_FiveThirtyOne::grouptitlefieldExpand()` except for this NULL business, and it doesn't hurt to run the query twice, so I just had that function be called in 5.31.alpha1.

It's still in 5.31.beta2 because theoretically there could be sites out there in 5.31.alpha1 that would want to upgrade to 5.35 or newer.

Comments
----------------------------------------
See [dev/translation#58](https://lab.civicrm.org/dev/translation/-/issues/58) and #18925 for detail on why NULL is allowed.
