### PR TITLE
dev/core#2019 - Don't create an empty activity if nothing changed when changing case custom data

### DIFF
--- a/CRM/Case/Form/CustomData.php
+++ b/CRM/Case/Form/CustomData.php
@@ -112,24 +112,27 @@ class CRM_Case_Form_CustomData extends CRM_Core_Form {
     $session = CRM_Core_Session::singleton();
     $session->pushUserContext(CRM_Utils_System::url('civicrm/contact/view/case', "reset=1&id={$this->_entityID}&cid={$this->_contactID}&action=view"));
 
-    $activityTypeID = CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_type_id', 'Change Custom Data');
-    $activityParams = [
-      'activity_type_id' => $activityTypeID,
-      'source_contact_id' => $session->get('userID'),
-      'is_auto' => TRUE,
-      'subject' => $this->_customTitle . " : change data",
-      'status_id' => CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_status_id', 'Completed'),
-      'target_contact_id' => $this->_contactID,
-      'details' => $this->formatCustomDataChangesForDetail($params),
-      'activity_date_time' => date('YmdHis'),
-    ];
-    $activity = CRM_Activity_BAO_Activity::create($activityParams);
+    $formattedDetails = $this->formatCustomDataChangesForDetail($params);
+    if (!empty($formattedDetails)) {
+      $activityTypeID = CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_type_id', 'Change Custom Data');
+      $activityParams = [
+        'activity_type_id' => $activityTypeID,
+        'source_contact_id' => $session->get('userID'),
+        'is_auto' => TRUE,
+        'subject' => $this->_customTitle . " : change data",
+        'status_id' => CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_status_id', 'Completed'),
+        'target_contact_id' => $this->_contactID,
+        'details' => $formattedDetails,
+        'activity_date_time' => date('YmdHis'),
+      ];
+      $activity = CRM_Activity_BAO_Activity::create($activityParams);
 
-    $caseParams = [
-      'activity_id' => $activity->id,
-      'case_id' => $this->_entityID,
-    ];
-    CRM_Case_BAO_Case::processCaseActivity($caseParams);
+      $caseParams = [
+        'activity_id' => $activity->id,
+        'case_id' => $this->_entityID,
+      ];
+      CRM_Case_BAO_Case::processCaseActivity($caseParams);
+    }
 
     $transaction->commit();
   }


### PR DESCRIPTION
Overview
----------------------------------------
Part 2 of https://lab.civicrm.org/dev/core/-/issues/2019

1. Create a custom field for cases.
2. Create a case and set the custom field value to, let's say, ScoobyDoo.
3. Edit the custom field and don't change the value and click Save.
4. A useless Change Custom Data activity gets created saying nothing.

Before
----------------------------------------
USELESS

After
----------------------------------------
Nothing, which maybe technically also meets the definition of useless but is less calories.

Technical Details
----------------------------------------
There's not much to this. Just check if anything changed first.

Comments
----------------------------------------
Has test.

Easier to review with whitespace changes hidden (add `w=1` to PR url)
