### PR TITLE
(REF) CRM_Upgrade_Form - Remove unused method getRevisionPart()

### DIFF
--- a/CRM/Upgrade/Form.php
+++ b/CRM/Upgrade/Form.php
@@ -311,19 +311,6 @@ SET    version = '$version'
   }
 
   /**
-   * @param $rev
-   * @param int $index
-   *
-   * @return null
-   */
-  public static function getRevisionPart($rev, $index = 1) {
-    $revPattern = '/^((\d{1,2})\.\d{1,2})\.(\d{1,2}|\w{4,7})?$/i';
-    preg_match($revPattern, $rev, $matches);
-
-    return array_key_exists($index, $matches) ? $matches[$index] : NULL;
-  }
-
-  /**
    * @param $tplFile
    * @param $rev
    *


### PR DESCRIPTION
Before
----------------------------------------

The method isn't used.

After
----------------------------------------

The method doesn't exist.
