### PR TITLE
dev/release#16 - Allow omission of empty upgrade steps

### DIFF
--- a/CRM/Upgrade/Form.php
+++ b/CRM/Upgrade/Form.php
@@ -88,9 +88,11 @@ class CRM_Upgrade_Form extends CRM_Core_Form {
   }
 
   /**
-   * @param $version
+   * @param string $version
+   *   Ex: '5.22' or '5.22.3'
    *
-   * @return mixed
+   * @return CRM_Upgrade_Incremental_Base
+   *   Ex: CRM_Upgrade_Incremental_php_FiveTwentyTwo
    */
   public static function &incrementalPhpObject($version) {
     static $incrementalPhpObject = [];

--- a/CRM/Upgrade/Incremental/php/FiveThirtySeven.php
+++ b/CRM/Upgrade/Incremental/php/FiveThirtySeven.php
@@ -16,8 +16,8 @@ class CRM_Upgrade_Incremental_php_FiveThirtySeven extends CRM_Upgrade_Incrementa
   /**
    * Compute any messages which should be displayed beforeupgrade.
    *
-   * Note: This function is called iteratively for each upcoming
-   * revision to the database.
+   * Note: This function is called iteratively for each incremental upgrade step.
+   * There must be a concrete step (eg 'X.Y.Z.mysql.tpl' or 'upgrade_X_Y_Z()').
    *
    * @param string $preUpgradeMessage
    * @param string $rev
@@ -33,6 +33,9 @@ class CRM_Upgrade_Incremental_php_FiveThirtySeven extends CRM_Upgrade_Incrementa
 
   /**
    * Compute any messages which should be displayed after upgrade.
+   *
+   * Note: This function is called iteratively for each incremental upgrade step.
+   * There must be a concrete step (eg 'X.Y.Z.mysql.tpl' or 'upgrade_X_Y_Z()').
    *
    * @param string $postUpgradeMessage
    *   alterable.

--- a/CRM/Upgrade/Incremental/php/FiveZero.php
+++ b/CRM/Upgrade/Incremental/php/FiveZero.php
@@ -47,15 +47,6 @@ class CRM_Upgrade_Incremental_php_FiveZero extends CRM_Upgrade_Incremental_Base 
     //}
   }
 
-  /**
-   * Upgrade function.
-   *
-   * @param string $rev
-   */
-  public function upgrade_5_0_0($rev) {
-    $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
-  }
-
   /*
    * Important! All upgrade functions MUST add a 'runSql' task.
    * Uncomment and use the following template for a new upgrade version

--- a/CRM/Upgrade/Incremental/php/Template.php
+++ b/CRM/Upgrade/Incremental/php/Template.php
@@ -22,8 +22,8 @@ class CRM_Upgrade_Incremental_php_<?php echo $camelNumber; ?> extends CRM_Upgrad
   /**
    * Compute any messages which should be displayed beforeupgrade.
    *
-   * Note: This function is called iteratively for each upcoming
-   * revision to the database.
+   * Note: This function is called iteratively for each incremental upgrade step.
+   * There must be a concrete step (eg 'X.Y.Z.mysql.tpl' or 'upgrade_X_Y_Z()').
    *
    * @param string $preUpgradeMessage
    * @param string $rev
@@ -39,6 +39,9 @@ class CRM_Upgrade_Incremental_php_<?php echo $camelNumber; ?> extends CRM_Upgrad
 
   /**
    * Compute any messages which should be displayed after upgrade.
+   *
+   * Note: This function is called iteratively for each incremental upgrade step.
+   * There must be a concrete step (eg 'X.Y.Z.mysql.tpl' or 'upgrade_X_Y_Z()').
    *
    * @param string $postUpgradeMessage
    *   alterable.

--- a/tests/phpunit/CRM/Utils/EnglishNumberTest.php
+++ b/tests/phpunit/CRM/Utils/EnglishNumberTest.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * Class CRM_Utils_EnglishNumberTest
+ *
+ * @group headless
+ */
+class CRM_Utils_EnglishNumberTest extends CiviUnitTestCase {
+
+  public function setUp() {
+    parent::setUp();
+    $this->useTransaction();
+  }
+
+  public function testRoundTrip() {
+    for ($i = 0; $i < 100; $i++) {
+      $camel = CRM_Utils_EnglishNumber::toCamelCase($i);
+      $camelToInt = CRM_Utils_EnglishNumber::toInt($camel);
+      $this->assertEquals($camelToInt, $i);
+
+      $hyphen = CRM_Utils_EnglishNumber::toHyphen($i);
+      $hyphenToInt = CRM_Utils_EnglishNumber::toInt($hyphen);
+      $this->assertEquals($hyphenToInt, $i);
+    }
+  }
+
+  public function testCamel() {
+    $this->assertEquals('Seven', CRM_Utils_EnglishNumber::toCamelCase(7));
+    $this->assertEquals('Nineteen', CRM_Utils_EnglishNumber::toCamelCase(19));
+    $this->assertEquals('Thirty', CRM_Utils_EnglishNumber::toCamelCase(30));
+    $this->assertEquals('FiftyFour', CRM_Utils_EnglishNumber::toCamelCase(54));
+    $this->assertEquals('NinetyNine', CRM_Utils_EnglishNumber::toCamelCase(99));
+  }
+
+  public function testHyphen() {
+    $this->assertEquals('seven', CRM_Utils_EnglishNumber::toHyphen(7));
+    $this->assertEquals('nineteen', CRM_Utils_EnglishNumber::toHyphen(19));
+    $this->assertEquals('thirty', CRM_Utils_EnglishNumber::toHyphen(30));
+    $this->assertEquals('fifty-four', CRM_Utils_EnglishNumber::toHyphen(54));
+    $this->assertEquals('ninety-nine', CRM_Utils_EnglishNumber::toHyphen(99));
+  }
+
+  public function testIsNumeric() {
+    $assertNumeric = function($expectBool, $string) {
+      $this->assertEquals($expectBool, CRM_Utils_EnglishNumber::isNumeric($string), "isNumeric($string) should return " . (int) $expectBool);
+    };
+    $assertNumeric(TRUE, 'FiveThirtyEight');
+    $assertNumeric(TRUE, 'Seventeen');
+    $assertNumeric(TRUE, 'four-one-one');
+    $assertNumeric(FALSE, 'Eleventy');
+    $assertNumeric(FALSE, 'Bazillions');
+  }
+
+}


### PR DESCRIPTION
Overview
-----------

This PR prepares to streamline the upgrader steps - by making it possible to skip increments which do not actually require DB updates.

(A companion PR will be opened momentarily to remove a large batch of old/unnecessary increments.)

ping @colemanw re: https://lab.civicrm.org/dev/release/-/issues/16

Before
-----------

(General) Often, when setting up the initial `X.Y.beta1` and when setting up the final `X.Y.0` stable release, there are no upgrade steps.  However, we're required to create the files anyway to ensure that the upgrader continues to work normally. As a byproduct, we create a large number of empty incremental steps. Each incremental step requries 3x AJAX calls in the web-based upgrader -- so this adds up.

(Technical) The incremental revision sequence -- and the final DB version-number -- are strictly determined by the list of `X.Y.Z.mysql.tpl` files. If you omit a SQL file, then it will not execute corresponding PHP code, and it will not set
the final version in DB appropriately.

After
-----------

(General) The upgrader does not need SQL files for every `X.Y.Z` revision.

(Technical) The incremental revision sequence is determined by scanning *both* the list of `X.Y.Z.mysql.tpl`  files *and* the list of `upgrade_X_Y_Z()` functions. It is valid to have a version which uses both, either, or neither. In cases where neither style of increment is used, it will still set the final version appropriately.

Technical Details
-----------

Writing upgrade steps has always been a bit particular. This is now slightly more robust, but some quirks remain, so it may be worth summarizing the resulting behavior. You *may* do any of these::

* (As before) Define `vX.Y.Z` with only a file `X.Y.Z.mysql.tpl`. The SQL script is called automatically.
* (New) Define `vX.Y.Z` with only a `upgrade_X_Y_Z()` step. The PHP function is called automatically.
* (As before) Define `vX.Y.Z` with both function `upgrade_X_Y_Z()` and file `X.Y.Z.mysql.tpl`. The flow-control for PHP takes precedence, and it decides if/when to call the SQL file.
* (New) Define `vX.Y.Z` without any incremental upgrade steps. This only makes sense for the HEAD version. The UI+DB will be updated to reflect the new number, but no incremental steps are actually executed.

This allows us to change the default policy (`set-version.php`) with respect to initializing upgrade files:

* Whenever we start the `X.Y.alpha1` release, it will create a skeletal `FiveUmpteen.php`, create a skeletal `X.Y.alpha1.mysql.tpl`, and bump `xmll/version.xml`. (Most schema changes occur during alpha1.)
* Whenever we start the `X.Y.beta1` or `X.Y.0` release, it will only bump up `xml/version.xml`. It does not (by default) create any PHP or SQL files.

Comments
----------

This slightly affects the workflow for a developer who seeks to change the upgrader during RC/beta/stable. (*They need to manually bump the version and create any SQL files -- there is no pre-existing skeleton.*) When this is merged, we need to send a PSA to `civicrm-dev@`.

If you want to inspect what it does with different commits (eg pre/post patch) or with some local hacks to the upgrade-steps, then these commands may be interesting:

```bash
## Print the list of incremental revisions
cv ev 'return (new CRM_Upgrade_Form())->getRevisionSequence();'

## Preview the upgrade tasks
cv upgrade:db -vv --dry-run

## Run the upgrade tasks
cv upgrade:db -vv

## Run the upgrade test using DB snapshots from 4.6.36
civibuild upgrade-test dmaster 4.6.36*
```

I have not done much in the way of end-to-end validation. There should be a question-mark with respect to `4.4.7` -- that file does not load right now (because the loading process requires the currently-non-existent `FourSeven.php`).