### PR TITLE
dev/release#16 - Cleanup empty upgrade steps

### DIFF
--- a/CRM/Upgrade/Incremental/php/FiveEighteen.php
+++ b/CRM/Upgrade/Incremental/php/FiveEighteen.php
@@ -58,7 +58,7 @@ class CRM_Upgrade_Incremental_php_FiveEighteen extends CRM_Upgrade_Incremental_B
    * @param string $rev
    */
   public function upgrade_5_18_alpha1($rev) {
-    $this->addTask(ts('Upgrade DB to %1: SQL', array(1 => $rev)), 'runSql', $rev);
+    // Not used // $this->addTask(ts('Upgrade DB to %1: SQL', array(1 => $rev)), 'runSql', $rev);
     $this->addTask('Update smart groups to reflect change of unique name for is_override', 'updateSmartGroups', [
       'renameField' => [
         ['old' => 'is_override', 'new' => 'member_is_override'],

--- a/CRM/Upgrade/Incremental/php/FiveEleven.php
+++ b/CRM/Upgrade/Incremental/php/FiveEleven.php
@@ -58,7 +58,7 @@ class CRM_Upgrade_Incremental_php_FiveEleven extends CRM_Upgrade_Incremental_Bas
    * @param string $rev
    */
   public function upgrade_5_11_alpha1($rev) {
-    $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
+    // Not used // $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
     $this->addTask('Update smart groups where jcalendar fields have been converted to datepicker', 'updateSmartGroups', [
       'datepickerConversion' => [
         'grant_application_received_date',
@@ -78,6 +78,7 @@ class CRM_Upgrade_Incremental_php_FiveEleven extends CRM_Upgrade_Incremental_Bas
    * @param string $rev
    */
   public function upgrade_5_11_beta1($rev) {
+    // Not used // $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
     if (Civi::settings()->get('civimail_multiple_bulk_emails')) {
       $this->addTask('Update any on hold groups to reflect field change', 'updateOnHold', $rev);
     }

--- a/CRM/Upgrade/Incremental/php/FiveFourteen.php
+++ b/CRM/Upgrade/Incremental/php/FiveFourteen.php
@@ -58,7 +58,7 @@ class CRM_Upgrade_Incremental_php_FiveFourteen extends CRM_Upgrade_Incremental_B
    * @param string $rev
    */
   public function upgrade_5_14_alpha1($rev) {
-    $this->addTask(ts('Upgrade DB to %1: SQL', array(1 => $rev)), 'runSql', $rev);
+    // Not used // $this->addTask(ts('Upgrade DB to %1: SQL', array(1 => $rev)), 'runSql', $rev);
     // Additional tasks here...
     // Note: do not use ts() in the addTask description because it adds unnecessary strings to transifex.
     // The above is an exception because 'Upgrade DB to %1: SQL' is generic & reusable.

--- a/CRM/Upgrade/Incremental/php/FiveNineteen.php
+++ b/CRM/Upgrade/Incremental/php/FiveNineteen.php
@@ -52,7 +52,7 @@ class CRM_Upgrade_Incremental_php_FiveNineteen extends CRM_Upgrade_Incremental_B
    * @param string $rev
    */
   public function upgrade_5_19_alpha1($rev) {
-    $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
+    // Not used // $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
     $this->addTask('Add api4 menu', 'api4Menu');
     $this->addTask('Add is_active field to civicrm_status_pref', 'addColumn', 'civicrm_status_pref', 'is_active',
       "tinyint(4) DEFAULT '1' COMMENT 'Is this status check active'", FALSE, '5.19.0');

--- a/CRM/Upgrade/Incremental/php/FiveSeventeen.php
+++ b/CRM/Upgrade/Incremental/php/FiveSeventeen.php
@@ -96,6 +96,7 @@ class CRM_Upgrade_Incremental_php_FiveSeventeen extends CRM_Upgrade_Incremental_
    * @param string $rev
    */
   public function upgrade_5_17_1($rev) {
+    // Not used // $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
     // Need to do this again because the alpha1 version had a typo and so didn't do anything.
     $this->addTask(ts('Add pptx to accepted attachment file types'), 'updateFileTypes');
   }

--- a/CRM/Upgrade/Incremental/php/FiveSix.php
+++ b/CRM/Upgrade/Incremental/php/FiveSix.php
@@ -58,7 +58,7 @@ class CRM_Upgrade_Incremental_php_FiveSix extends CRM_Upgrade_Incremental_Base {
    * @param string $rev
    */
   public function upgrade_5_6_beta2($rev) {
-    $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
+    // Not used // $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
     $this->addTask('dev/core#107 - Add Activity\'s default assignee options', 'addActivityDefaultAssigneeOptions');
   }
 

--- a/CRM/Upgrade/Incremental/php/FiveThirtyOne.php
+++ b/CRM/Upgrade/Incremental/php/FiveThirtyOne.php
@@ -73,7 +73,7 @@ class CRM_Upgrade_Incremental_php_FiveThirtyOne extends CRM_Upgrade_Incremental_
 
   public function upgrade_5_31_beta2($rev) {
     $this->addTask('Restore null-ity of "civicrm_group.title" field', 'groupTitleRestore');
-    $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
+    // Not used // $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
   }
 
   public static function enableEwaySingleExtension(CRM_Queue_TaskContext $ctx) {

--- a/CRM/Upgrade/Incremental/php/FiveThirtySix.php
+++ b/CRM/Upgrade/Incremental/php/FiveThirtySix.php
@@ -67,7 +67,7 @@ class CRM_Upgrade_Incremental_php_FiveThirtySix extends CRM_Upgrade_Incremental_
    * @param string $rev
    */
   public function upgrade_5_36_alpha1(string $rev): void {
-    $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
+    // Not used // $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
 
     $this->addTask('core-issue#2422 - Add created_id to civicrm_saved_search', 'addColumn',
       'civicrm_saved_search', 'created_id', "int(10) unsigned DEFAULT NULL COMMENT 'FK to contact table.'");

--- a/CRM/Upgrade/Incremental/php/FiveThirtyThree.php
+++ b/CRM/Upgrade/Incremental/php/FiveThirtyThree.php
@@ -52,7 +52,7 @@ class CRM_Upgrade_Incremental_php_FiveThirtyThree extends CRM_Upgrade_Incrementa
    * @param string $rev
    */
   public function upgrade_5_33_alpha1($rev) {
-    $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
+    // Not used // $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
     $this->addTask('Add column civicrm_dashboard.directive', 'addColumn', 'civicrm_dashboard', 'directive', "varchar(255) COMMENT 'Element name of angular directive to invoke (lowercase hyphenated format)'");
   }
 

--- a/CRM/Upgrade/Incremental/php/FiveTwentyFive.php
+++ b/CRM/Upgrade/Incremental/php/FiveTwentyFive.php
@@ -80,7 +80,7 @@ class CRM_Upgrade_Incremental_php_FiveTwentyFive extends CRM_Upgrade_Incremental
   }
 
   public function upgrade_5_25_beta3($rev) {
-    $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
+    // Not used // $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
     $this->addTask('Convert CiviContribute settings', 'updateContributeSettings');
   }
 

--- a/CRM/Upgrade/Incremental/php/FiveTwentyNine.php
+++ b/CRM/Upgrade/Incremental/php/FiveTwentyNine.php
@@ -81,7 +81,7 @@ class CRM_Upgrade_Incremental_php_FiveTwentyNine extends CRM_Upgrade_Incremental
    * @param string $rev
    */
   public function upgrade_5_29_beta1($rev) {
-    $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
+    // Not used // $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
     $this->addTask('Make label field non required on price field value', 'priceFieldValueLabelNonRequired');
   }
 

--- a/CRM/Upgrade/Incremental/sql/5.0.beta1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.0.beta1.mysql.tpl
@@ -1,1 +1,0 @@
-{* file to handle db changes in 5.0.beta1 during upgrade *}

--- a/CRM/Upgrade/Incremental/sql/5.1.0.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.1.0.mysql.tpl
@@ -1,1 +1,0 @@
-{* file to handle db changes in 5.1.0 during upgrade *}

--- a/CRM/Upgrade/Incremental/sql/5.1.1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.1.1.mysql.tpl
@@ -1,1 +1,0 @@
-{* file to handle db changes in 5.1.1 during upgrade *}

--- a/CRM/Upgrade/Incremental/sql/5.1.alpha1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.1.alpha1.mysql.tpl
@@ -1,1 +1,0 @@
-{* file to handle db changes in 5.1.alpha1 during upgrade *}

--- a/CRM/Upgrade/Incremental/sql/5.1.beta1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.1.beta1.mysql.tpl
@@ -1,1 +1,0 @@
-{* file to handle db changes in 5.1.beta1 during upgrade *}

--- a/CRM/Upgrade/Incremental/sql/5.10.beta1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.10.beta1.mysql.tpl
@@ -1,1 +1,0 @@
-{* file to handle db changes in 5.10.beta1 during upgrade *}

--- a/CRM/Upgrade/Incremental/sql/5.11.0.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.11.0.mysql.tpl
@@ -1,1 +1,0 @@
-{* file to handle db changes in 5.11.0 during upgrade *}

--- a/CRM/Upgrade/Incremental/sql/5.11.alpha1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.11.alpha1.mysql.tpl
@@ -1,1 +1,0 @@
-{* file to handle db changes in 5.11.alpha1 during upgrade *}

--- a/CRM/Upgrade/Incremental/sql/5.11.beta1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.11.beta1.mysql.tpl
@@ -1,1 +1,0 @@
-{* file to handle db changes in 5.11.beta1 during upgrade *}

--- a/CRM/Upgrade/Incremental/sql/5.12.beta1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.12.beta1.mysql.tpl
@@ -1,1 +1,0 @@
-{* file to handle db changes in 5.12.beta1 during upgrade *}

--- a/CRM/Upgrade/Incremental/sql/5.13.beta1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.13.beta1.mysql.tpl
@@ -1,1 +1,0 @@
-{* file to handle db changes in 5.13.beta1 during upgrade *}

--- a/CRM/Upgrade/Incremental/sql/5.14.alpha1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.14.alpha1.mysql.tpl
@@ -1,1 +1,0 @@
-{* file to handle db changes in 5.14.alpha1 during upgrade *}

--- a/CRM/Upgrade/Incremental/sql/5.15.0.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.15.0.mysql.tpl
@@ -1,1 +1,0 @@
-{* file to handle db changes in 5.15.0 during upgrade *}

--- a/CRM/Upgrade/Incremental/sql/5.15.beta1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.15.beta1.mysql.tpl
@@ -1,1 +1,0 @@
-{* file to handle db changes in 5.15.beta1 during upgrade *}

--- a/CRM/Upgrade/Incremental/sql/5.16.beta1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.16.beta1.mysql.tpl
@@ -1,1 +1,0 @@
-{* file to handle db changes in 5.16.beta1 during upgrade *}

--- a/CRM/Upgrade/Incremental/sql/5.17.1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.17.1.mysql.tpl
@@ -1,1 +1,0 @@
-{* file to handle db changes in 5.17.1 during upgrade *}

--- a/CRM/Upgrade/Incremental/sql/5.17.beta1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.17.beta1.mysql.tpl
@@ -1,1 +1,0 @@
-{* file to handle db changes in 5.17.beta1 during upgrade *}

--- a/CRM/Upgrade/Incremental/sql/5.18.0.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.18.0.mysql.tpl
@@ -1,1 +1,0 @@
-{* file to handle db changes in 5.18.0 during upgrade *}

--- a/CRM/Upgrade/Incremental/sql/5.18.alpha1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.18.alpha1.mysql.tpl
@@ -1,1 +1,0 @@
-{* file to handle db changes in 5.18.alpha1 during upgrade *}

--- a/CRM/Upgrade/Incremental/sql/5.18.beta1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.18.beta1.mysql.tpl
@@ -1,1 +1,0 @@
-{* file to handle db changes in 5.18.beta1 during upgrade *}

--- a/CRM/Upgrade/Incremental/sql/5.19.alpha1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.19.alpha1.mysql.tpl
@@ -1,1 +1,0 @@
-{* file to handle db changes in 5.19.alpha1 during upgrade *}

--- a/CRM/Upgrade/Incremental/sql/5.19.beta1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.19.beta1.mysql.tpl
@@ -1,1 +1,0 @@
-{* file to handle db changes in 5.19.beta1 during upgrade *}

--- a/CRM/Upgrade/Incremental/sql/5.2.beta1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.2.beta1.mysql.tpl
@@ -1,1 +1,0 @@
-{* file to handle db changes in 5.2.beta1 during upgrade *}

--- a/CRM/Upgrade/Incremental/sql/5.20.beta1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.20.beta1.mysql.tpl
@@ -1,1 +1,0 @@
-{* file to handle db changes in 5.20.beta1 during upgrade *}

--- a/CRM/Upgrade/Incremental/sql/5.21.beta1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.21.beta1.mysql.tpl
@@ -1,1 +1,0 @@
-{* file to handle db changes in 5.21.beta1 during upgrade *}

--- a/CRM/Upgrade/Incremental/sql/5.22.alpha1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.22.alpha1.mysql.tpl
@@ -1,1 +1,0 @@
-{* file to handle db changes in 5.22.alpha1 during upgrade *}

--- a/CRM/Upgrade/Incremental/sql/5.22.beta1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.22.beta1.mysql.tpl
@@ -1,1 +1,0 @@
-{* file to handle db changes in 5.22.beta1 during upgrade *}

--- a/CRM/Upgrade/Incremental/sql/5.23.beta1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.23.beta1.mysql.tpl
@@ -1,1 +1,0 @@
-{* file to handle db changes in 5.23.beta1 during upgrade *}

--- a/CRM/Upgrade/Incremental/sql/5.24.beta1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.24.beta1.mysql.tpl
@@ -1,1 +1,0 @@
-{* file to handle db changes in 5.24.beta1 during upgrade *}

--- a/CRM/Upgrade/Incremental/sql/5.25.0.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.25.0.mysql.tpl
@@ -1,1 +1,0 @@
-{* file to handle db changes in 5.25.0 during upgrade *}

--- a/CRM/Upgrade/Incremental/sql/5.25.beta1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.25.beta1.mysql.tpl
@@ -1,1 +1,0 @@
-{* file to handle db changes in 5.25.beta1 during upgrade *}

--- a/CRM/Upgrade/Incremental/sql/5.25.beta2.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.25.beta2.mysql.tpl
@@ -1,1 +1,0 @@
-{* file to handle db changes in 5.25.beta2 during upgrade *}

--- a/CRM/Upgrade/Incremental/sql/5.25.beta3.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.25.beta3.mysql.tpl
@@ -1,1 +1,0 @@
-{* file to handle db changes in 5.25.beta3 during upgrade *}

--- a/CRM/Upgrade/Incremental/sql/5.26.beta1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.26.beta1.mysql.tpl
@@ -1,1 +1,0 @@
-{* file to handle db changes in 5.26.beta1 during upgrade *}

--- a/CRM/Upgrade/Incremental/sql/5.28.beta1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.28.beta1.mysql.tpl
@@ -1,1 +1,0 @@
-{* file to handle db changes in 5.28.beta1 during upgrade *}

--- a/CRM/Upgrade/Incremental/sql/5.29.beta1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.29.beta1.mysql.tpl
@@ -1,1 +1,0 @@
-{* file to handle db changes in 5.29.beta1 during upgrade *}

--- a/CRM/Upgrade/Incremental/sql/5.3.beta1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.3.beta1.mysql.tpl
@@ -1,1 +1,0 @@
-{* file to handle db changes in 5.3.beta1 during upgrade *}

--- a/CRM/Upgrade/Incremental/sql/5.30.beta1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.30.beta1.mysql.tpl
@@ -1,1 +1,0 @@
-{* file to handle db changes in 5.30.beta1 during upgrade *}

--- a/CRM/Upgrade/Incremental/sql/5.31.beta1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.31.beta1.mysql.tpl
@@ -1,1 +1,0 @@
-{* file to handle db changes in 5.31.beta1 during upgrade *}

--- a/CRM/Upgrade/Incremental/sql/5.31.beta2.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.31.beta2.mysql.tpl
@@ -1,1 +1,0 @@
-{* file to handle db changes in 5.31.beta2 during upgrade *}

--- a/CRM/Upgrade/Incremental/sql/5.32.beta1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.32.beta1.mysql.tpl
@@ -1,1 +1,0 @@
-{* file to handle db changes in 5.32.beta1 during upgrade *}

--- a/CRM/Upgrade/Incremental/sql/5.33.alpha1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.33.alpha1.mysql.tpl
@@ -1,1 +1,0 @@
-{* file to handle db changes in 5.33.alpha1 during upgrade *}

--- a/CRM/Upgrade/Incremental/sql/5.33.beta1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.33.beta1.mysql.tpl
@@ -1,1 +1,0 @@
-{* file to handle db changes in 5.33.beta1 during upgrade *}

--- a/CRM/Upgrade/Incremental/sql/5.34.beta1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.34.beta1.mysql.tpl
@@ -1,1 +1,0 @@
-{* file to handle db changes in 5.34.beta1 during upgrade *}

--- a/CRM/Upgrade/Incremental/sql/5.35.beta1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.35.beta1.mysql.tpl
@@ -1,1 +1,0 @@
-{* file to handle db changes in 5.35.beta1 during upgrade *}

--- a/CRM/Upgrade/Incremental/sql/5.36.alpha1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.36.alpha1.mysql.tpl
@@ -1,1 +1,0 @@
-{* file to handle db changes in 5.36.alpha1 during upgrade *}

--- a/CRM/Upgrade/Incremental/sql/5.36.beta1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.36.beta1.mysql.tpl
@@ -1,1 +1,0 @@
-{* file to handle db changes in 5.36.beta1 during upgrade *}

--- a/CRM/Upgrade/Incremental/sql/5.4.beta1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.4.beta1.mysql.tpl
@@ -1,1 +1,0 @@
-{* file to handle db changes in 5.4.beta1 during upgrade *}

--- a/CRM/Upgrade/Incremental/sql/5.6.beta1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.6.beta1.mysql.tpl
@@ -1,1 +1,0 @@
-{* file to handle db changes in 5.6.beta1 during upgrade *}

--- a/CRM/Upgrade/Incremental/sql/5.6.beta2.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.6.beta2.mysql.tpl
@@ -1,1 +1,0 @@
-{* file to handle db changes in 5.6.beta2 during upgrade *}

--- a/CRM/Upgrade/Incremental/sql/5.7.0.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.7.0.mysql.tpl
@@ -1,1 +1,0 @@
-{* file to handle db changes in 5.7.0 during upgrade *}

--- a/CRM/Upgrade/Incremental/sql/5.7.alpha1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.7.alpha1.mysql.tpl
@@ -1,1 +1,0 @@
-{* file to handle db changes in 5.7.alpha1 during upgrade *}

--- a/CRM/Upgrade/Incremental/sql/5.8.beta1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.8.beta1.mysql.tpl
@@ -1,1 +1,0 @@
-{* file to handle db changes in 5.8.beta1 during upgrade *}

--- a/CRM/Upgrade/Incremental/sql/5.9.0.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.9.0.mysql.tpl
@@ -1,1 +1,0 @@
-{* file to handle db changes in 5.9.0 during upgrade *}


### PR DESCRIPTION
Overview
----------------------------------------

Streamline the upgrader by removing a number of empty upgrade steps.

This patch is blocked on the dependency #19743 (which accounts for the first half-dozen commits). It furthers https://lab.civicrm.org/dev/release/-/issues/16.

ping @colemanw 


Technical Details
----------------------------------------

Here was my process:

* `cd` into `CRM/Upgrade/Incremental/sql`
* Run `ls -l` on subset of files
* Make a list of files that were 55-63 bytes long. Display them and confirm that they contain no real instructions.
* Take the list of removed versions. Grep to see if those versions have PHP functions.
* If there is a PHP function, it may have a `runSql()` step that needs to be disabled.

In reviewing the diffs, you should generally see two kinds of changes:

* Several `*.mysql.tpl` files are removed -- all of these empty, notwithstanding boilerplate comments.
* In some of the `upgrade_X_Y_Z()` functions, calls to `runSql()` are commented out. That's because the identified files no longer exist. (One can verify they don't exist by skimming, eg, `ls CRM/Upgrade/Incremental/sql/ | sort  | grep ^5`)