### PR TITLE
[REF] Remove now redundant code to set line item financial type

### DIFF
--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -1066,14 +1066,6 @@ DESC limit 1");
             $termsByType[$li['membership_type_id']] = $li['membership_num_terms'];
           }
         }
-
-        ///CRM-11529 for quick config backoffice transactions
-        //when financial_type_id is passed in form, update the
-        //lineitems with the financial type selected in form
-        $submittedFinancialType = $formValues['financial_type_id'] ?? NULL;
-        if ($isQuickConfig && $submittedFinancialType) {
-          $li['financial_type_id'] = $submittedFinancialType;
-        }
       }
     }
 

--- a/tests/phpunit/CRM/Member/Form/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/Form/MembershipTest.php
@@ -17,6 +17,8 @@
  * @author Walt Haas <walt@dharmatech.org> (801) 534-1262
  */
 
+use Civi\Api4\FinancialType;
+
 /**
  *  Test CRM_Member_Form_Membership functions.
  *
@@ -753,6 +755,7 @@ class CRM_Member_Form_MembershipTest extends CiviUnitTestCase {
   /**
    * Test the submit function of the membership form.
    *
+   * @throws \API_Exception
    * @throws \CRM_Core_Exception
    * @throws \CiviCRM_API3_Exception
    */
@@ -776,6 +779,8 @@ class CRM_Member_Form_MembershipTest extends CiviUnitTestCase {
       'auto_renew' => TRUE,
     ]);
     $params = $this->getBaseSubmitParams();
+    // Change financial_type_id to test our override flows through to the line item.
+    $params['financial_type_id'] = FinancialType::get(FALSE)->addWhere('id', '!=', $params['financial_type_id'])->addSelect('id')->execute()->first()['id'];
     $form = $this->getForm();
     $this->createLoggedInUser();
     $form->_mode = 'test';
@@ -800,6 +805,7 @@ class CRM_Member_Form_MembershipTest extends CiviUnitTestCase {
       'entity_id' => $membership['id'],
       'entity_table' => 'civicrm_membership',
       'contribution_id' => $contribution['id'],
+      'financial_type_id' => $params['financial_type_id'],
     ], 1);
     $this->assertEquals([
       [
@@ -1286,7 +1292,6 @@ Expires: ',
       'join_date' => date('Y-m-d'),
       'start_date' => '',
       'end_date' => '',
-      // This format reflects the 23 being the organisation & the 25 being the type.
       "price_" . $this->getPriceFieldID() => $pfvIDs,
       'price_set_id' => $this->getPriceSetID(),
       'membership_type_id' => [1 => 0],


### PR DESCRIPTION

Overview
----------------------------------------
[REF] Remove now redundant code to set line item financial type

Before
----------------------------------------
Code that duplicates the work done higher up in Order->getLineItems()

After
----------------------------------------
poof

Technical Details
----------------------------------------
Added test cover to demonstrate the financial type is still being copied to the line item

Comments
----------------------------------------
