### PR TITLE
[REF] Clean up code around is_email_receipt

### DIFF
--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -1842,21 +1842,13 @@ DESC limit 1");
 
     // add these values for the recurringContrib function ,CRM-10188
     $params['financial_type_id'] = $contributionParams['financial_type_id'];
-
-    $params['is_email_receipt'] = (bool) $this->getSubmittedValue('send_receipt');
     $params['is_recur'] = TRUE;
     $params['payment_instrument_id'] = $contributionParams['payment_instrument_id'] ?? NULL;
     $recurringContributionID = $this->legacyProcessRecurringContribution($params, $contactID);
 
-    $now = CRM_Utils_Time::date('YmdHis');
-    $receiptDate = $params['receipt_date'] ?? NULL;
-    if ($params['is_email_receipt']) {
-      $receiptDate = $now;
-    }
-
     if ($this->getSubmittedValue('send_receipt')) {
       $contributionParams += [
-        'receipt_date' => $receiptDate,
+        'receipt_date' => CRM_Utils_Time::date('YmdHis'),
       ];
     }
 


### PR DESCRIPTION

Overview
----------------------------------------
[REF] Clean up code around is_email_receipt

Before
----------------------------------------
Brain exploding

After
----------------------------------------
Thash better

Technical Details
----------------------------------------
The is_email_receipt param is passed into legacyProcessRecurringContribution
but not used. It is also used to set now to receipt date which is then
only used in a loop that uses a more direct method to check
if an email receipt is used.

Comments
----------------------------------------
