### PR TITLE
SearchKit - Fix removing all related fields from SELECT when removing a JOIN

### DIFF
--- a/ext/search/ang/crmSearchAdmin/crmSearchAdmin.component.js
+++ b/ext/search/ang/crmSearchAdmin/crmSearchAdmin.component.js
@@ -264,7 +264,8 @@
         var alias = searchMeta.getJoin(ctrl.savedSearch.api_params.join[index][0]).alias;
         ctrl.clearParam('join', index);
         _.remove(ctrl.savedSearch.api_params.select, function(item) {
-          return item.indexOf(alias + '.') === 0;
+          var pattern = new RegExp('\\b' + alias + '\\.');
+          return pattern.test(item.split(' AS ')[0]);
         });
         _.remove(ctrl.savedSearch.api_params.where, function(clause) {
           return clauseUsesJoin(clause, alias);


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a small bug in SearchKit where not all columns get cleaned up when deleting a JOIN.

Before
----------------------------------------
1. Search for Contacts
2. Add GROUP BY id
3. Add a join to Activity
4. Activity subject will appear as a column
5. Choose an aggregate function for the subject column (or click search and it will add one automatically)
6. Delete the join to Activity

Result: the column is still there.

After
----------------------------------------
Repeat steps above.

Result: the column gets auto-deleted.

Technical Details
----------------------------------------
This bug wasn't causing a db error because the API silently ignores any unknown fields in the SELECT clause. So it was just annoying and confusing (even to Eileen).