### PR TITLE
Fix apiv4 test sloppiness

### DIFF
--- a/tests/phpunit/api/v4/UnitTestCase.php
+++ b/tests/phpunit/api/v4/UnitTestCase.php
@@ -41,7 +41,7 @@ class UnitTestCase extends \PHPUnit\Framework\TestCase implements HeadlessInterf
    */
   public function __construct($name = NULL, array $data = [], $dataName = '') {
     parent::__construct($name, $data, $dataName);
-    error_reporting(E_ALL & ~E_NOTICE);
+    error_reporting(E_ALL);
   }
 
   public function setUpHeadless() {


### PR DESCRIPTION

Overview
----------------------------------------
Removes a hack that stops apiv4 unit tests finding all code problems (I hate to think)

Before
----------------------------------------
All canaries are shot before entering the mine

After
----------------------------------------
Personalised health care tracking available to canaries

Technical Details
----------------------------------------
Why would we exclude e-notices from causing test fails - I suspect this
canary-killer got added a long time back & no-one noticed

Comments
----------------------------------------
