### PR TITLE
dev/core#2415 Add api support for aggregate without group by

### DIFF
--- a/tests/phpunit/api/v4/Action/ComplexQueryTest.php
+++ b/tests/phpunit/api/v4/Action/ComplexQueryTest.php
@@ -22,6 +22,7 @@ namespace api\v4\Action;
 use api\v4\UnitTestCase;
 use Civi\Api4\Activity;
 use Civi\Api4\Contact;
+use Civi\Test\CiviEnvBuilder;
 
 /**
  * @group headless
@@ -31,22 +32,27 @@ use Civi\Api4\Contact;
  */
 class ComplexQueryTest extends UnitTestCase {
 
-  public function setUpHeadless() {
+  public function setUpHeadless(): CiviEnvBuilder {
+    $this->loadDataSet('DefaultDataSet');
+    return parent::setUpHeadless();
+  }
+
+  public function tearDown(): void {
     $relatedTables = [
       'civicrm_activity',
       'civicrm_activity_contact',
     ];
     $this->cleanup(['tablesToTruncate' => $relatedTables]);
-    $this->loadDataSet('DefaultDataSet');
-
-    return parent::setUpHeadless();
+    parent::tearDown();
   }
 
   /**
    * Fetch all phone call activities
    * Expects at least one activity loaded from the data set.
+   *
+   * @throws \API_Exception
    */
-  public function testGetAllHousingSupportActivities() {
+  public function testGetAllHousingSupportActivities(): void {
     $results = Activity::get(FALSE)
       ->addWhere('activity_type_id:name', '=', 'Phone Call')
       ->execute();

--- a/tests/phpunit/api/v4/Action/FkJoinTest.php
+++ b/tests/phpunit/api/v4/Action/FkJoinTest.php
@@ -34,15 +34,19 @@ use Civi\Api4\Tag;
 class FkJoinTest extends UnitTestCase {
 
   public function setUpHeadless() {
+    $this->loadDataSet('DefaultDataSet');
+
+    return parent::setUpHeadless();
+  }
+
+  public function tearDown() {
     $relatedTables = [
       'civicrm_activity',
       'civicrm_phone',
       'civicrm_activity_contact',
     ];
     $this->cleanup(['tablesToTruncate' => $relatedTables]);
-    $this->loadDataSet('DefaultDataSet');
-
-    return parent::setUpHeadless();
+    parent::tearDown();
   }
 
   /**


### PR DESCRIPTION


Overview
----------------------------------------
dev/core#2415 Add api support for aggregate without group by

For example

SELECT SUM(amount) FROM civicrm_pledge

Should be doable with no group by if none is desired

Before
----------------------------------------
SELECT SUM(amount) FROM civicrm_pledge is not possible via the api as it adds an id field to the select

After
----------------------------------------
Tada

Technical Details
----------------------------------------


Comments
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/2415#note_54981