### PR TITLE
SearchKit - Fix broken update dialog and add input type float

### DIFF
--- a/ext/search/ang/crmSearchActions/crmSearchActionDelete.ctrl.js
+++ b/ext/search/ang/crmSearchActions/crmSearchActionDelete.ctrl.js
@@ -4,7 +4,7 @@
   angular.module('crmSearchActions').controller('crmSearchActionDelete', function($scope, dialogService) {
     var ts = $scope.ts = CRM.ts(),
       model = $scope.model,
-      ctrl = $scope.$ctrl = this;
+      ctrl = this;
 
     this.entityTitle = model.ids.length === 1 ? model.entityInfo.title : model.entityInfo.title_plural;
 

--- a/ext/search/ang/crmSearchActions/crmSearchActionDelete.html
+++ b/ext/search/ang/crmSearchActions/crmSearchActionDelete.html
@@ -1,5 +1,5 @@
 <div id="bootstrap-theme">
-  <form ng-controller="crmSearchActionDelete">
+  <form ng-controller="crmSearchActionDelete as $ctrl">
     <p><strong>{{:: ts('Are you sure you want to delete %1 %2?', {1: model.ids.length, 2: $ctrl.entityTitle}) }}</strong></p>
     <hr />
     <div ng-if="$ctrl.run" class="crm-search-action-progress">

--- a/ext/search/ang/crmSearchActions/crmSearchActionUpdate.ctrl.js
+++ b/ext/search/ang/crmSearchActions/crmSearchActionUpdate.ctrl.js
@@ -4,7 +4,7 @@
   angular.module('crmSearchActions').controller('crmSearchActionUpdate', function ($scope, $timeout, crmApi4, dialogService) {
     var ts = $scope.ts = CRM.ts(),
       model = $scope.model,
-      ctrl = $scope.$ctrl = this;
+      ctrl = this;
 
     this.entityTitle = model.ids.length === 1 ? model.entityInfo.title : model.entityInfo.title_plural;
     this.values = [];
@@ -61,6 +61,7 @@
         if (fieldInUse(item.name)) {
           formatted.disabled = true;
         }
+        result.push(formatted);
       }, []);
       return {results: results};
     };

--- a/ext/search/ang/crmSearchActions/crmSearchActionUpdate.html
+++ b/ext/search/ang/crmSearchActions/crmSearchActionUpdate.html
@@ -1,5 +1,5 @@
 <div id="bootstrap-theme">
-  <form ng-controller="crmSearchActionUpdate">
+  <form ng-controller="crmSearchActionUpdate as $ctrl">
     <p><strong>{{:: ts('Update the %1 selected %2 with the following values:', {1: model.ids.length, 2: $ctrl.entityTitle}) }}</strong></p>
     <div class="form-inline" ng-repeat="clause in $ctrl.values" >
       <input class="form-control" ng-change="$ctrl.updateField($index)" ng-disabled="$ctrl.run" ng-model="clause[0]" crm-ui-select="{data: $ctrl.availableFields, allowClear: true, placeholder: 'Field'}" />

--- a/ext/search/ang/crmSearchActions/crmSearchInput/crmSearchInputVal.component.js
+++ b/ext/search/ang/crmSearchActions/crmSearchInput/crmSearchInputVal.component.js
@@ -106,6 +106,10 @@
           return '~/crmSearchActions/crmSearchInput/integer.html';
         }
 
+        if (ctrl.field.data_type === 'Float') {
+          return '~/crmSearchActions/crmSearchInput/float.html';
+        }
+
         return '~/crmSearchActions/crmSearchInput/text.html';
       };
 

--- a/ext/search/ang/crmSearchActions/crmSearchInput/float.html
+++ b/ext/search/ang/crmSearchActions/crmSearchInput/float.html
@@ -1,5 +1,5 @@
 <div class="form-group" ng-if="!$ctrl.multi" >
-  <input type="number" step="1" class="form-control" ng-model="$ctrl.value">
+  <input type="number" step="any" class="form-control" ng-model="$ctrl.value">
 </div>
 <div class="form-group" ng-if="$ctrl.multi" >
   <input class="form-control" ng-model="$ctrl.value" crm-ui-select="{multiple: true, tags: [], tokenSeparators: [','], formatNoMatches: ''}" ng-list>


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a SearchKit regression in 5.36 where the bulk update action failed to show any fields. Also adds a widget for floating-point number fields.

Before
----------------------------------------
Cannot select fields in bulk update action. Floating point fields have input type=text.

After
----------------------------------------
Can select fields in bulk update action. Floating point fields have input type=number.
