### PR TITLE
Fix batch transaction export on D8/9

### DIFF
--- a/CRM/Batch/BAO/Batch.php
+++ b/CRM/Batch/BAO/Batch.php
@@ -450,8 +450,8 @@ class CRM_Batch_BAO_Batch extends CRM_Batch_DAO_Batch {
         'export' => [
           'name' => ts('Export'),
           'title' => ts('Export Batch'),
-          'url' => '#',
-          'extra' => 'rel="export"',
+          'url' => 'civicrm/financial/batch/export',
+          'qs' => 'reset=1&id=%%id%%&status=1',
         ],
         'reopen' => [
           'name' => ts('Re-open'),

--- a/CRM/Financial/Form/Search.php
+++ b/CRM/Financial/Form/Search.php
@@ -41,8 +41,6 @@ class CRM_Financial_Form_Search extends CRM_Core_Form {
   }
 
   public function buildQuickForm() {
-    CRM_Core_Resources::singleton()
-      ->addScriptFile('civicrm', 'packages/jquery/plugins/jquery.redirect.min.js', 0, 'html-header');
     $attributes = CRM_Core_DAO::getAttribute('CRM_Batch_DAO_Batch');
     $attributes['total']['class'] = $attributes['item_count']['class'] = 'number';
     $this->add('text', 'title', ts('Batch Name'), $attributes['title']);

--- a/CRM/Financial/Page/AJAX.php
+++ b/CRM/Financial/Page/AJAX.php
@@ -198,10 +198,6 @@ class CRM_Financial_Page_AJAX {
             $params['id'] = $recordID;
             break;
 
-          case 'export':
-            CRM_Utils_System::redirect("civicrm/financial/batch/export?reset=1&id=$recordID");
-            break;
-
           case 'delete':
             $params = $recordID;
             break;

--- a/templates/CRM/Financial/Form/Search.tpl
+++ b/templates/CRM/Financial/Form/Search.tpl
@@ -214,9 +214,6 @@ CRM.$(function($) {
   }
 
   function saveRecords(records, op) {
-    if (op == 'export') {
-      return exportRecords(records);
-    }
     var postUrl = CRM.url('civicrm/ajax/rest', 'className=CRM_Financial_Page_AJAX&fnName=assignRemove');
     //post request and get response
     $.post(postUrl, {records: records, recordBAO: 'CRM_Batch_BAO_Batch', op: op, key: {/literal}"{crmKey name='civicrm/ajax/ar'}"{literal}},
@@ -232,19 +229,6 @@ CRM.$(function($) {
         }
       },
       'json').error(serverError);
-  }
-
-  function exportRecords(records) {
-    var query = {'batch_id': records, 'export_format': $('select.export-format').val()};
-    var exportUrl = CRM.url('civicrm/financial/batch/export', 'reset=1');
-    // jQuery redirect expects all query args as an object, so extract them from crm url
-    var urlParts = exportUrl.split('?');
-    $.each(urlParts[1].split('&'), function(key, val) {
-      var q = val.split('=');
-      query[q[0]] = q[1];
-    });
-    $().redirect(urlParts[0], query, 'GET');
-    setTimeout(function() {batchSelector.fnDraw();}, 4000);
   }
 
   function validateOp(records, op) {
@@ -302,6 +286,11 @@ CRM.$(function($) {
       $("input.select-row:checked").each(function() {
         records.push($(this).attr('id').replace('check_', ''));
       });
+      if (op == 'export') {
+        // No need for the modal pop-up, just proceed to the next screen.
+        window.location = CRM.url("civicrm/financial/batch/export", {reset: 1, id: records[0], status: 1});
+        return false;
+      }
       editRecords(records, op);
     }
     return false;


### PR DESCRIPTION
https://lab.civicrm.org/dev/financial/-/issues/169

Overview
----------------------------------------
2 of the 3 methods to export a batch on D8/9 fail because `jquery.redirect.min.js` can't be found.  Full replication details on the ticket.

Before
----------------------------------------
No response when you press "Export".

After
----------------------------------------
Export proceeds.  Also saves an unnecessary modal from popping up.

Technical Details
----------------------------------------
The Dev console shows the error - "jquery.redirect.min.js" can't be found.  This has to do with how the Resource URLs are split into core and packages inside <webroot>/libraries/civicrm.  It's impossible to call jquery.redirect.min.js.

Comments
----------------------------------------
* This is the last reference in the Civi code to `jquery.redirect.min.js`.  Perhaps this jQuery plugin can be removed/deprecated?
* This UI has always been a bit flaky.  If you click Transactions on the Open Batches screen, the Export button will bring you to the next screen.  The two methods I outlined on the PR bring up an extra modal dialog, the options of which are repeated on the next screen.  So rather than fix the bug, I removed the modal altogether.