### PR TITLE
Include the timezone for date values in the Event iCal

### DIFF
--- a/templates/CRM/Core/Calendar/ICal.tpl
+++ b/templates/CRM/Core/Calendar/ICal.tpl
@@ -24,15 +24,15 @@ CATEGORIES:{$event.event_type|crmICalText}
 {/if}
 CALSCALE:GREGORIAN
 {if $event.start_date}
-DTSTAMP;VALUE=DATE-TIME:{$event.start_date|crmICalDate}
-DTSTART;VALUE=DATE-TIME:{$event.start_date|crmICalDate}
+DTSTAMP;TZID={$timezone}:{$event.start_date|crmICalDate}
+DTSTART;TZID={$timezone}:{$event.start_date|crmICalDate}
 {else}
-DTSTAMP;VALUE=DATE-TIME:{$smarty.now|date_format:'%Y-%m-%d %H:%M:%S'|crmICalDate}
+DTSTAMP;TZID={$timezone}:{$smarty.now|date_format:'%Y-%m-%d %H:%M:%S'|crmICalDate}
 {/if}
 {if $event.end_date}
-DTEND;VALUE=DATE-TIME:{$event.end_date|crmICalDate}
+DTEND;TZID={$timezone}:{$event.end_date|crmICalDate}
 {else}
-DTEND;VALUE=DATE-TIME:{$event.start_date|crmICalDate}
+DTEND;TZID={$timezone}:{$event.start_date|crmICalDate}
 {/if}
 {if $event.is_show_location EQ 1 && $event.location}
 LOCATION:{$event.location|crmICalText}


### PR DESCRIPTION
Overview
----------------------------------------
Include the timezone for date values in the Event iCal

Before
----------------------------------------
Timezone not specified for date values in the Event iCal

After
----------------------------------------
Timezone is specified for date values in the Event iCal

Technical Details
----------------------------------------
tpl was missing TZ attribute.

Comments
----------------------------------------
Odd no one picked this up earlier.


Agileware Ref: CIVICRM-1676