### PR TITLE
dev/core#2451 Faster processing of optgroups in select2 elements

### DIFF
--- a/js/Common.js
+++ b/js/Common.js
@@ -420,6 +420,8 @@ if (!CRM.vars) CRM.vars = {};
         };
 
       // quickform doesn't support optgroups so here's a hack :(
+      // Instead of using wrapAll or similar that repeatedly appends options to the group and redraw the page (=> very slow on large lists),
+      // build bulk HTML and insert in single shot
       var optGroups = {};
       $('option[value^=crm_optgroup]', this).each(function () {
         var groupHtml = '';

--- a/js/Common.js
+++ b/js/Common.js
@@ -418,11 +418,24 @@ if (!CRM.vars) CRM.vars = {};
           formatResult: formatCrmSelect2,
           formatSelection: formatCrmSelect2
         };
+
       // quickform doesn't support optgroups so here's a hack :(
+      var optGroups = {};
       $('option[value^=crm_optgroup]', this).each(function () {
-        $(this).nextUntil('option[value^=crm_optgroup]').wrapAll('<optgroup label="' + $(this).text() + '" />');
+        var groupHtml = '';
+          $(this).nextUntil('option[value^=crm_optgroup]').each(function () {
+          groupHtml += this.outerHTML;
+        });
+        optGroups[$(this).text()] = groupHtml;
         $(this).remove();
       });
+      var replacedHtml = '';
+      for (var groupLabel in optGroups) {
+        replacedHtml += '<optgroup label="' + groupLabel + '">' + optGroups[groupLabel] + '</optgroup>';
+      }
+      if (replacedHtml) {
+        $el.html(replacedHtml);
+      }
 
       // quickform does not support disabled option, so yet another hack to
       // add disabled property for option values


### PR DESCRIPTION
Overview
----------------------------------------
Replace the option groups HTML for select2 in one chunk to improve performance when many campaigns
See https://lab.civicrm.org/dev/core/-/issues/2451

Before
----------------------------------------
the jQuery function `wrapAll` is used to wrap a list of selection options into a group, but the function seems to trigger DOM change events for each of the options

After
----------------------------------------
A loop first generates the new HTML and replaces the DOM element in one shot.
With my browser and my database of ~2000 campaigns, this brings the loading time of the mailings screen or advanced search (activities section) from ~30 seconds to one order of magnitude less.

Comments
----------------------------------------
I was worried that this method may cause the loss of event handlers attached to individual select elements, but according to my tests there are no such handler and the campaign picking behaves as before.
