### PR TITLE
Fix incorrect placeholder text on 'Create Campaign' form

### DIFF
--- a/CRM/Campaign/Form/Campaign.php
+++ b/CRM/Campaign/Form/Campaign.php
@@ -188,10 +188,10 @@ class CRM_Campaign_Form_Campaign extends CRM_Core_Form {
     $this->add('datepicker', 'end_date', ts('End Date'));
 
     // add campaign type
-    $this->addSelect('campaign_type_id', ['onChange' => "CRM.buildCustomData( 'Campaign', this.value );"], TRUE);
+    $this->addSelect('campaign_type_id', ['placeholder' => ts('- select type -'), 'onChange' => "CRM.buildCustomData( 'Campaign', this.value );"], TRUE);
 
     // add campaign status
-    $this->addSelect('status_id');
+    $this->addSelect('status_id', ['placeholder' => ts('- select status -')]);
 
     // add External Identifier Element
     $this->add('text', 'external_identifier', ts('External ID'),


### PR DESCRIPTION
Overview
----------------------------------------
Fixes some incorrect placeholder text on the form to create/edit a campaign, for the select fields "Campaign Type" and "Campaign Status"

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/2874912/110524166-0c762b80-80e1-11eb-89c3-6558722e11f9.png)


After
----------------------------------------
![image](https://user-images.githubusercontent.com/2874912/110524107-f7999800-80e0-11eb-84de-00a5fdb3686f.png)
