### PR TITLE
[REF] remove unused code in recordFinancialAccounts

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -3458,10 +3458,6 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
         $trxnParams['payment_processor_id'] = $params['payment_processor'];
       }
 
-      if (isset($fromFinancialAccountId)) {
-        $trxnParams['from_financial_account_id'] = $fromFinancialAccountId;
-      }
-
       // consider external values passed for recording transaction entry
       if (!empty($financialTrxnValues)) {
         $trxnParams = array_merge($trxnParams, $financialTrxnValues);


### PR DESCRIPTION
Overview
----------------------------------------
Removing an `if` statement that will never evaluate to `TRUE`.  The variable `$fromFinancialAccountId` is never initialized.

Before
----------------------------------------
lines.

After
----------------------------------------
no lines.

Technical Details
----------------------------------------
`$fromFinancialAccountId` used to be potentially set on partial payments, but it was removed in https://github.com/civicrm/civicrm-core/pull/18328.