### PR TITLE
Include the timezone for date values in the Activity iCal

### DIFF
--- a/templates/CRM/Activity/Calendar/ICal.tpl
+++ b/templates/CRM/Activity/Calendar/ICal.tpl
@@ -16,8 +16,8 @@ BEGIN:VEVENT
 UID:CIVICRMACTIVITY{$activity->id}
 SUMMARY:{$activity->subject|crmICalText}
 CALSCALE:GREGORIAN
-DTSTAMP;VALUE=DATE-TIME:{$smarty.now|date_format:'%Y-%m-%d %H:%M:%S'|crmICalDate}
-DTSTART;VALUE=DATE-TIME:{$activity->activity_date_time|crmICalDate}
+DTSTAMP;TZID={$timezone}:{$smarty.now|date_format:'%Y-%m-%d %H:%M:%S'|crmICalDate}
+DTSTART;TZID={$timezone}:{$activity->activity_date_time|crmICalDate}
 DURATION:PT{$activity->duration}M
 {if $activity->location}
 LOCATION:{$activity->location|crmICalText}


### PR DESCRIPTION
Overview
----------------------------------------
Include the timezone for date values in the Activity iCal

Before
----------------------------------------
Timezone not specified for start date value in the Activity iCal

After
----------------------------------------
Timezone is specified for start date value in the Activity iCal

Technical Details
----------------------------------------
tpl was missing TZ attribute.

Comments
----------------------------------------
Follow on from https://github.com/civicrm/civicrm-core/pull/19762

Ping @demeritcowboy 


Agileware Ref: CIVICRM-1679
