### PR TITLE
dev/core#2452 - Make upgrade to 5.36 more robust when creating foreign key

### DIFF
--- a/CRM/Upgrade/Incremental/php/FiveThirtySix.php
+++ b/CRM/Upgrade/Incremental/php/FiveThirtySix.php
@@ -92,15 +92,24 @@ class CRM_Upgrade_Incremental_php_FiveThirtySix extends CRM_Upgrade_Incremental_
    * @return bool
    */
   public static function taskAddConstraints(CRM_Queue_TaskContext $ctx): bool {
-    CRM_Core_DAO::executeQuery("
-      ALTER TABLE `civicrm_saved_search`
-        ADD CONSTRAINT `FK_civicrm_saved_search_created_id`
-          FOREIGN KEY (`created_id`) REFERENCES `civicrm_contact` (`id`)
-          ON DELETE SET NULL,
-        ADD CONSTRAINT `FK_civicrm_saved_search_modified_id`
-          FOREIGN KEY (`modified_id`) REFERENCES `civicrm_contact` (`id`)
-          ON DELETE SET NULL;
-    ");
+    if (!self::checkFKExists('civicrm_saved_search', 'FK_civicrm_saved_search_created_id')) {
+      CRM_Core_DAO::executeQuery("
+        ALTER TABLE `civicrm_saved_search`
+          ADD CONSTRAINT `FK_civicrm_saved_search_created_id`
+            FOREIGN KEY (`created_id`) REFERENCES `civicrm_contact` (`id`)
+            ON DELETE SET NULL;
+      ");
+    }
+
+    if (!self::checkFKExists('civicrm_saved_search', 'FK_civicrm_saved_search_modified_id')) {
+      CRM_Core_DAO::executeQuery("
+        ALTER TABLE `civicrm_saved_search`
+          ADD CONSTRAINT `FK_civicrm_saved_search_modified_id`
+            FOREIGN KEY (`modified_id`) REFERENCES `civicrm_contact` (`id`)
+            ON DELETE SET NULL;
+      ");
+    }
+
     return TRUE;
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/2452

Upgrade to 5.36 can't be run twice because foreign key already exists.

Before
----------------------------------------
crash

After
----------------------------------------
good

Technical Details
----------------------------------------
I looked for the equivalent of addColumn() but there's just safeRemoveFK() and checkFKExists(), so I used checkFKExists.

Comments
----------------------------------------

