### PR TITLE
Remove unused variables/assigns from buildMembershipBlock function

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -675,7 +675,6 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
       $membershipTypeIds = $membershipTypes = $radio = $radioOptAttrs = [];
       $membershipPriceset = (!empty($this->_priceSetId) && $this->_useForMember);
 
-      $allowAutoRenewMembership = $autoRenewOption = FALSE;
       $autoRenewMembershipTypeOptions = [];
 
       $separateMembershipPayment = $this->_membershipBlock['is_separate_payment'] ?? NULL;
@@ -803,7 +802,6 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
       $this->assign('membershipBlock', $this->_membershipBlock);
       $this->assign('showRadio', FALSE);
       $this->assign('membershipTypes', $membershipTypes);
-      $this->assign('allowAutoRenewMembership', $allowAutoRenewMembership);
       $this->assign('autoRenewMembershipTypeOptions', json_encode($autoRenewMembershipTypeOptions));
       //give preference to user submitted auto_renew value.
       $takeUserSubmittedAutoRenew = (!empty($_POST) || $this->isSubmitted());

--- a/CRM/Contribute/Form/Contribution/ThankYou.php
+++ b/CRM/Contribute/Form/Contribution/ThankYou.php
@@ -310,7 +310,6 @@ class CRM_Contribute_Form_Contribution_ThankYou extends CRM_Contribute_Form_Cont
       $membershipTypeIds = $membershipTypes = $radio = $radioOptAttrs = [];
       $membershipPriceset = (!empty($this->_priceSetId) && $this->_useForMember);
 
-      $allowAutoRenewMembership = $autoRenewOption = FALSE;
       $autoRenewMembershipTypeOptions = [];
 
       $separateMembershipPayment = $this->_membershipBlock['is_separate_payment'] ?? NULL;
@@ -428,7 +427,6 @@ class CRM_Contribute_Form_Contribution_ThankYou extends CRM_Contribute_Form_Cont
       $this->assign('membershipBlock', $this->_membershipBlock);
       $this->assign('showRadio', FALSE);
       $this->assign('membershipTypes', $membershipTypes);
-      $this->assign('allowAutoRenewMembership', $allowAutoRenewMembership);
       $this->assign('autoRenewMembershipTypeOptions', json_encode($autoRenewMembershipTypeOptions));
       //give preference to user submitted auto_renew value.
       $takeUserSubmittedAutoRenew = (!empty($_POST) || $this->isSubmitted());


### PR DESCRIPTION
Overview
----------------------------------------
Further simplification of the `buildMembershipBlock()` function that was moved from contributionBase.

This removes an unused assign and variables from the Confirm and ThankYou pages.

Before
----------------------------------------
Unused variable assigned

After
----------------------------------------
Unused variable not assigned or created.

Technical Details
----------------------------------------
`allowAutoRenewMembership` is used in Main.tpl and MembershipBlock.tpl. Only MembershipBlock.tpl is included from Confirm.tpl and ThankYou.tpl.
If you look here https://github.com/civicrm/civicrm-core/blob/master/templates/CRM/Contribute/Form/Contribution/MembershipBlock.tpl#L274 you can see that `allowAutoRenewMembership` is used in an if statement that makes no sense for Confirm/ThankYou pages because it's setting the status of a checkbox that doesn't exist.

Comments
----------------------------------------

