### PR TITLE
dev/core#2137 - Backport of 18830 and its followups to not crash when asset builder can't do its thing

### DIFF
--- a/Civi/Core/AssetBuilder.php
+++ b/Civi/Core/AssetBuilder.php
@@ -189,9 +189,15 @@ class AssetBuilder {
         mkdir($this->getCachePath());
       }
 
-      $rendered = $this->render($name, $params);
-      file_put_contents($this->getCachePath($fileName), $rendered['content']);
-      return $fileName;
+      try {
+        $rendered = $this->render($name, $params);
+        file_put_contents($this->getCachePath($fileName), $rendered['content']);
+        return $fileName;
+      }
+      catch (UnknownAssetException $e) {
+        // unexpected error, log and continue
+        \Civi::log()->error('Unexpected error while rendering a file in the AssetBuilder: ' . $e->getMessage(), ['exception' => $e]);
+      }
     }
     return $fileName;
   }


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/2137

Backport of #18830 and its followups since many people will be upgrading to 5.35 next week and it seems people keep hitting this. Some causes appear to be known, others are not. This allows site to load, albeit without a menubar or what-have-you.