### PR TITLE
dev/core#2453 cast balance due to float

### DIFF
--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -1472,7 +1472,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
 
     $paymentBalance = CRM_Contribute_BAO_Contribution::getContributionBalance($this->_ccid);
     //bounce if the contribution is not pending.
-    if ((int) $paymentBalance <= 0) {
+    if ((float) $paymentBalance <= 0) {
       CRM_Core_Error::statusBounce(ts("Returning since contribution has already been handled."));
     }
     if (!empty($paymentBalance)) {


### PR DESCRIPTION
Overview
----------------------------------------
When loading a contribution form and passing a contribution ID, we check to ensure there is a balance due and bounce if otherwise. However, the balance due was being cast as an Int, which meant a balance due less than 1 would get bounced.

Ref: https://lab.civicrm.org/dev/core/-/issues/2453

Before
----------------------------------------
Form bounced if balance due was less than 1.

After
----------------------------------------
Form loads if balance due is anything greater than 0.