### PR TITLE
Improve quicksearch result presentation to enable browser link functions

### DIFF
--- a/js/crm.menubar.js
+++ b/js/crm.menubar.js
@@ -336,7 +336,33 @@
               CRM.menubar.open('QuickSearch');
             }
           }
-        });
+        })
+        .autocomplete( "instance" )._renderItem = function( ul, item ) {
+          var uiMenuItemWrapper = $("<div class='ui-menu-item-uiMenuItemWrapper'>");
+          if (item.value == 0) {
+            uiMenuItemWrapper.text(item.label);
+          }
+          else {
+            uiMenuItemWrapper.append($('<a>')
+              .attr('href', CRM.url('civicrm/contact/view', {reset: 1, cid: item.value}))
+              .css({ display: 'block' })
+              .text(item.label)
+              .click(function(e) {
+                if (e.ctrlKey || e.shiftKey || e.altKey) {
+                  // Special-clicking lets you open several tabs.
+                  e.stopPropagation();
+                }
+                else {
+                  // Fall back to original behaviour.
+                  e.preventDefault();
+                }
+              }));
+          }
+
+          return $( "<li class='ui-menu-item'>" )
+            .append(uiMenuItemWrapper)
+            .appendTo( ul );
+        };
       $('#crm-qsearch > a').keyup(function(e) {
         if ($(e.target).is(this)) {
           $('#crm-qsearch-input').focus();


### PR DESCRIPTION
Overview
----------------------------------------

Quicksearch does not present the search results as links which means you can't use any helpful browser builtins like open in new tab, private window, copy link etc. With this PR it does.


Before
----------------------------------------

Clicking an item causes menu to close and redirects to that contact's page. Ctrl-clicking, (option/shift/alt clicking) has no effect; and the context menu does not offer any link-related goodies:

![menu-before](https://user-images.githubusercontent.com/870343/110662863-d195f580-81bd-11eb-9c3b-b1fa23d9316a.gif)


After
----------------------------------------

- Search results rendered as links, so you get your browser's link related capabilities restored.
- holding a special key while clicking (e.g. Ctrl-clicking often means "open in new tab") gives you your browser's native functionality and leaves the menu open - enabling you to open several contacts at once.
- normal clicking is handled in the old way: menu closes and page redirects

![menu-after](https://user-images.githubusercontent.com/870343/110662988-f5593b80-81bd-11eb-9412-04feec3ca9fb.gif)




Technical Details
----------------------------------------

This is just done using the jQuery autocomplete's API, providing a render function for the items.


Comments
----------------------------------------

This has been annoying me for ages - e.g. for ambiguous search results you can now open both and see which one it was you needed. Today a client piped up with the same gripes and so I thought I'd do something about it!

