### PR TITLE
Remove addressee, email_greeting_id, postal_greeting_id from exposed tokens

### DIFF
--- a/CRM/Core/SelectValues.php
+++ b/CRM/Core/SelectValues.php
@@ -619,6 +619,9 @@ class CRM_Core_SelectValues {
         'legal_identifier',
         'contact_sub_type',
         'user_unique_id',
+        'addressee_id',
+        'email_greeting_id',
+        'postal_greeting_id',
       ];
 
       $customFields = CRM_Core_BAO_CustomField::getFields(['Individual', 'Address']);

--- a/tests/phpunit/CRM/Core/BAO/MessageTemplateTest.php
+++ b/tests/phpunit/CRM/Core/BAO/MessageTemplateTest.php
@@ -192,9 +192,6 @@ individual_prefix:Mr.
 individual_suffix:II
 formal_title:Dogsbody
 communication_style:Formal
-email_greeting_id:Dear {contact.first_name}
-postal_greeting_id:Dear {contact.first_name}
-addressee_id:{contact.individual_prefix}{ } {contact.first_name}{ }{contact.middle_name}{ }{contact.last_name}{ }{contact.individual_suffix}
 job_title:Busy person
 gender:Female
 birth_date:December 31st, 1998
@@ -317,9 +314,6 @@ contact_id:' . $tokenData['contact_id'] . '
       'individual_suffix' => 'II',
       'formal_title' => 'Dogsbody',
       'communication_style' => 'Formal',
-      'email_greeting_id' => 1,
-      'postal_greeting_id' => 1,
-      'addressee_id' => 1,
       'job_title' => 'Busy person',
       'gender' => 'Female',
       'birth_date' => '1998-12-31',


### PR DESCRIPTION

Overview
------------------------
Per discussion on https://github.com/civicrm/civicrm-core/pull/19550#issuecomment-781597319
there appears to be agreement that supporting tokens like
addressee_id (which resolves to '{contact.individual_prefix}{ }.....')
should not be exposed / supported as they seem both unuseful and likely
to be breaky.


Before
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/110763251-890e3300-82b6-11eb-89ca-c0c8e3bf2c2c.png)


After
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/110762926-36cd1200-82b6-11eb-95c5-457fe766b796.png)

Technical Details
----------------------------------------
These were exposed unintentionally as part of a change to make them
available as WHERE filters on apiv3
https://github.com/civicrm/civicrm-core/commit/54e389ac6565ff534b87e5e46137a57d48d6c5c8

The discussion suggests that by contrast we should
add support to hash in the token compat subscriber

Comments
----------------------------------------
