### PR TITLE
SearchKit - Refactor loading actions list & support custom fields for groups

### DIFF
--- a/ext/search/Civi/Api4/Action/SearchDisplay/GetSearchTasks.php
+++ b/ext/search/Civi/Api4/Action/SearchDisplay/GetSearchTasks.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Civi\Api4\Action\SearchDisplay;
+
+use CRM_Search_ExtensionUtil as E;
+use Civi\Api4\Entity;
+
+/**
+ * Load the available tasks for a given entity.
+ *
+ * @package Civi\Api4\Action\SearchDisplay
+ */
+class GetSearchTasks extends \Civi\Api4\Generic\AbstractAction {
+
+  /**
+   * Name of entity
+   * @var string
+   * @required
+   */
+  protected $entity;
+
+  /**
+   * @param \Civi\Api4\Generic\Result $result
+   * @throws \API_Exception
+   */
+  public function _run(\Civi\Api4\Generic\Result $result) {
+    $entity = Entity::get($this->checkPermissions)->addWhere('name', '=', $this->entity)
+      ->addSelect('name', 'title_plural')
+      ->setChain(['actions' => [$this->entity, 'getActions', ['where' => [['name', 'IN', ['update', 'delete']]]], 'name']])
+      ->execute()->first();
+
+    if (!$entity) {
+      return;
+    }
+    $tasks = [];
+
+    if (array_key_exists($entity['name'], \CRM_Export_BAO_Export::getComponents())) {
+      $tasks[] = [
+        'name' => 'export',
+        'title' => E::ts('Export %1', [1 => $entity['title_plural']]),
+        'icon' => 'fa-file-excel-o',
+        'crmPopup' => [
+          'path' => "'civicrm/export/standalone'",
+          'query' => "{entity: {$entity['name']}, id: ids.join(',')}",
+        ],
+      ];
+    }
+
+    if (array_key_exists('update', $entity['actions'])) {
+      $tasks[] = [
+        'name' => 'update',
+        'title' => E::ts('Update %1', [1 => $entity['title_plural']]),
+        'icon' => 'fa-save',
+        'uiDialog' => ['templateUrl' => '~/crmSearchActions/crmSearchActionUpdate.html'],
+      ];
+    }
+
+    if (array_key_exists('delete', $entity['actions'])) {
+      $tasks[] = [
+        'name' => 'delete',
+        'title' => E::ts('Delete %1', [1 => $entity['title_plural']]),
+        'icon' => 'fa-trash',
+        'uiDialog' => ['templateUrl' => '~/crmSearchActions/crmSearchActionDelete.html'],
+      ];
+    }
+
+    if ($entity['name'] === 'Contact') {
+      // Add contact tasks which support standalone mode (with a 'url' property)
+      $contactTasks = \CRM_Contact_Task::permissionedTaskTitles(\CRM_Core_Permission::getPermission());
+      foreach (\CRM_Contact_Task::tasks() as $id => $task) {
+        if (isset($contactTasks[$id]) && !empty($task['url']) && $task['url'] !== 'civicrm/task/delete-contact') {
+          if ($task['url'] === 'civicrm/task/pick-profile') {
+            $task['title'] = E::ts('Profile Update');
+          }
+          $tasks[] = [
+            'name' => 'contact.' . $id,
+            'title' => $task['title'],
+            'icon' => $task['icon'] ?? 'fa-gear',
+            'crmPopup' => [
+              'path' => "'{$task['url']}'",
+              'query' => "{cids: ids.join(',')}",
+            ],
+          ];
+        }
+      }
+    }
+
+    usort($tasks, function($a, $b) {
+      return strnatcasecmp($a['title'], $b['title']);
+    });
+
+    $result->exchangeArray($tasks);
+  }
+
+}

--- a/ext/search/Civi/Api4/SearchDisplay.php
+++ b/ext/search/Civi/Api4/SearchDisplay.php
@@ -20,4 +20,13 @@ class SearchDisplay extends Generic\DAOEntity {
       ->setCheckPermissions($checkPermissions);
   }
 
+  /**
+   * @param bool $checkPermissions
+   * @return Action\SearchDisplay\GetSearchTasks
+   */
+  public static function getSearchTasks($checkPermissions = TRUE) {
+    return (new Action\SearchDisplay\GetSearchTasks(__CLASS__, __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
+  }
+
 }

--- a/ext/search/Civi/Search/Actions.php
+++ b/ext/search/Civi/Search/Actions.php
@@ -24,57 +24,8 @@ class Actions {
    */
   public static function getActionSettings():array {
     return [
-      'tasks' => self::getTasks(),
       'dateRanges' => \CRM_Utils_Array::makeNonAssociative(\CRM_Core_OptionGroup::values('relative_date_filters'), 'id', 'text'),
     ];
-  }
-
-  /**
-   * @return array
-   */
-  public static function getTasks():array {
-    // Note: the placeholder %1 will be replaced with entity name on the clientside
-    $tasks = [
-      'export' => [
-        'title' => E::ts('Export %1'),
-        'icon' => 'fa-file-excel-o',
-        'entities' => array_keys(\CRM_Export_BAO_Export::getComponents()),
-        'crmPopup' => [
-          'path' => "'civicrm/export/standalone'",
-          'query' => "{entity: entity, id: ids.join(',')}",
-        ],
-      ],
-      'update' => [
-        'title' => E::ts('Update %1'),
-        'icon' => 'fa-save',
-        'entities' => [],
-        'uiDialog' => ['templateUrl' => '~/crmSearchActions/crmSearchActionUpdate.html'],
-      ],
-      'delete' => [
-        'title' => E::ts('Delete %1'),
-        'icon' => 'fa-trash',
-        'entities' => [],
-        'uiDialog' => ['templateUrl' => '~/crmSearchActions/crmSearchActionDelete.html'],
-      ],
-    ];
-
-    // Add contact tasks which support standalone mode (with a 'url' property)
-    $contactTasks = \CRM_Contact_Task::permissionedTaskTitles(\CRM_Core_Permission::getPermission());
-    foreach (\CRM_Contact_Task::tasks() as $id => $task) {
-      if (isset($contactTasks[$id]) && !empty($task['url']) && $task['url'] !== 'civicrm/task/delete-contact') {
-        $tasks['contact.' . $id] = [
-          'title' => $task['title'],
-          'entities' => ['Contact'],
-          'icon' => $task['icon'] ?? 'fa-gear',
-          'crmPopup' => [
-            'path' => "'{$task['url']}'",
-            'query' => "{cids: ids.join(',')}",
-          ],
-        ];
-      }
-    }
-
-    return $tasks;
   }
 
 }

--- a/ext/search/Civi/Search/Actions.php
+++ b/ext/search/Civi/Search/Actions.php
@@ -25,21 +25,8 @@ class Actions {
   public static function getActionSettings():array {
     return [
       'tasks' => self::getTasks(),
-      'groupOptions' => self::getGroupOptions(),
       'dateRanges' => \CRM_Utils_Array::makeNonAssociative(\CRM_Core_OptionGroup::values('relative_date_filters'), 'id', 'text'),
     ];
-  }
-
-  /**
-   * @return array
-   */
-  public static function getGroupOptions():array {
-    return \Civi\Api4\Group::getFields(FALSE)
-      ->setLoadOptions(['id', 'label'])
-      ->addWhere('name', 'IN', ['group_type', 'visibility'])
-      ->execute()
-      ->indexBy('name')
-      ->column('options');
   }
 
   /**

--- a/ext/search/ang/crmSearchActions/crmSearchActions.component.js
+++ b/ext/search/ang/crmSearchActions/crmSearchActions.component.js
@@ -25,19 +25,10 @@
       function initialize() {
         crmApi4({
           entityInfo: ['Entity', 'get', {select: ['name', 'title', 'title_plural'], where: [['name', '=', ctrl.entity]]}, 0],
-          allowed: [ctrl.entity, 'getActions', {where: [['name', 'IN', ['update', 'delete']]]}, ['name']]
+          tasks: ['SearchDisplay', 'getSearchTasks', {entity: ctrl.entity}]
         }).then(function(result) {
           ctrl.entityInfo = result.entityInfo;
-          _.each(result.allowed, function(action) {
-            CRM.crmSearchActions.tasks[action].entities.push(ctrl.entity);
-          });
-          var actions = _.transform(_.cloneDeep(CRM.crmSearchActions.tasks), function(actions, action) {
-            if (_.includes(action.entities, ctrl.entity)) {
-              action.title = action.title.replace('%1', ctrl.entityInfo.title_plural);
-              actions.push(action);
-            }
-          }, []);
-          ctrl.actions = _.sortBy(actions, 'title');
+          ctrl.tasks = result.tasks;
         });
       }
 

--- a/ext/search/ang/crmSearchActions/crmSearchActions.html
+++ b/ext/search/ang/crmSearchActions/crmSearchActions.html
@@ -4,10 +4,10 @@
     {{:: ts('Action') }} <span class="caret"></span>
   </button>
   <ul class="dropdown-menu">
-    <li ng-disabled="!$ctrl.isActionAllowed(action)" ng-repeat="action in $ctrl.actions">
+    <li ng-disabled="!$ctrl.isActionAllowed(action)" ng-repeat="action in $ctrl.tasks">
       <a href ng-click="$ctrl.doAction(action)"><i class="fa {{:: action.icon }}"></i> {{:: action.title }}</a>
     </li>
-    <li class="disabled" ng-if="!$ctrl.actions">
+    <li class="disabled" ng-if="!$ctrl.tasks">
       <a href><i class="fa fa-spinner fa-spin"></i></a>
     </li>
   </ul>

--- a/ext/search/ang/crmSearchActions/crmSearchActions.html
+++ b/ext/search/ang/crmSearchActions/crmSearchActions.html
@@ -3,9 +3,12 @@
     <i class="crm-i fa-pencil"></i>
     {{:: ts('Action') }} <span class="caret"></span>
   </button>
-  <ul class="dropdown-menu" ng-if=":: $ctrl.actions">
+  <ul class="dropdown-menu">
     <li ng-disabled="!$ctrl.isActionAllowed(action)" ng-repeat="action in $ctrl.actions">
-      <a href ng-click="$ctrl.doAction(action)"><i class="fa {{action.icon}}"></i> {{ action.title }}</a>
+      <a href ng-click="$ctrl.doAction(action)"><i class="fa {{:: action.icon }}"></i> {{:: action.title }}</a>
+    </li>
+    <li class="disabled" ng-if="!$ctrl.actions">
+      <a href><i class="fa fa-spinner fa-spin"></i></a>
     </li>
   </ul>
 </div>

--- a/ext/search/ang/crmSearchActions/crmSearchInput/entityRef.html
+++ b/ext/search/ang/crmSearchActions/crmSearchInput/entityRef.html
@@ -1,5 +1,5 @@
 <div class="form-group" ng-if="!$ctrl.multi">
-  <input class="form-control" ng-model="$ctrl.value" crm-entityref="{entity: $ctrl.entity, static: $ctrl.entity === 'Contact' ? ['user_contact_id'] : []}">
+  <input class="form-control" ng-model="$ctrl.value" crm-entityref="{entity: $ctrl.entity, select:{allowClear: true, placeholder: ts('Select')}, static: $ctrl.entity === 'Contact' ? ['user_contact_id'] : []}">
 </div>
 <div class="form-group" ng-if="$ctrl.multi">
   <input class="form-control" ng-model="$ctrl.value" crm-entityref="{entity: $ctrl.entity, select: {multiple: true}, static: $ctrl.entity === 'Contact' ? ['user_contact_id'] : []}" ng-list >

--- a/ext/search/ang/crmSearchAdmin.module.js
+++ b/ext/search/ang/crmSearchAdmin.module.js
@@ -50,7 +50,7 @@
             return crmApi4('SavedSearch', 'get', {
               where: [['id', '=', params.id]],
               chain: {
-                groups: ['Group', 'get', {select: ['id', 'title', 'description', 'visibility', 'group_type'], where: [['saved_search_id', '=', '$id']]}],
+                groups: ['Group', 'get', {select: ['id', 'title', 'description', 'visibility', 'group_type', 'custom.*'], where: [['saved_search_id', '=', '$id']]}],
                 displays: ['SearchDisplay', 'get', {where: [['saved_search_id', '=', '$id']]}]
               }
             }, 0);

--- a/ext/search/ang/crmSearchAdmin/group.html
+++ b/ext/search/ang/crmSearchAdmin/group.html
@@ -9,19 +9,29 @@
   <input id="api-save-search-select-column" ng-model="$ctrl.savedSearch.api_params.select[0]" class="form-control huge" crm-ui-select="{data: smartGroupColumns}"/>
 </div>
 <fieldset ng-show="smartGroupColumns.length">
-  <label>{{:: ts('Description:') }}</label>
+  <label>{{:: getField('description', 'Group').label }}</label>
   <textarea class="form-control" ng-model="$ctrl.savedSearch.groups[0].description"></textarea>
-  <div class="form-inline">
-    <label>{{:: ts('Group Type:') }} </label>
-    <div class="checkbox" ng-repeat="option in groupOptions.group_type track by option.id">&nbsp;
-      <label>
-        <input type="checkbox" checklist-model="$ctrl.savedSearch.groups[0].group_type" checklist-value="option.id">
-        {{ option.label }}
-      </label>&nbsp;
+  <div ng-if="getEntity('Group').optionsLoaded">
+    <div class="form-inline">
+      <label>{{:: getField('group_type', 'Group').label }}</label>
+      <div class="checkbox" ng-repeat="option in getField('group_type', 'Group').options">&nbsp;
+        <label>
+          <input type="checkbox" checklist-model="$ctrl.savedSearch.groups[0].group_type" checklist-value="option.id">
+          {{:: option.label }}
+        </label>&nbsp;
+      </div>
+    </div>
+    <div class="form-inline">
+      <label>{{:: getField('visibility', 'Group').label }}</label>
+      <crm-search-input-val field=":: getField('visibility', 'Group')" ng-model="$ctrl.savedSearch.groups[0].visibility"></crm-search-input-val>
+    </div>
+    <hr>
+    <div class="form-inline" ng-repeat="field in getEntity('Group').fields | filter:{name: '.', entity: 'Group'}">
+      <label>{{:: field.label }}</label>
+      <crm-search-input-val field="field" ng-model="$ctrl.savedSearch.groups[0][field.name]"></crm-search-input-val>
     </div>
   </div>
-  <div class="form-inline">
-    <label>{{:: ts('Visibility:') }}</label>
-    <select class="form-control" ng-model="$ctrl.savedSearch.groups[0].visibility" ng-options="item.id as item.label for item in groupOptions.visibility track by item.id" crm-ui-select></select>
+  <div ng-if="!getEntity('Group').optionsLoaded">
+    <i class="crm-i fa-spinner fa-spin"></i>
   </div>
 </fieldset>


### PR DESCRIPTION
Overview
----------------------------------------
This reduces the amount of pre-loaded data needed by Search Displays, adds support for custom fields when saving a smart group, and adds a little spinner while the task list is loading.

Before
----------------------------------------
Select a row and immediately click the Actions menu. Depending on network lag time, the menu might not open right away.

Save a smart group. If your site has custom fields which extend the Group entity, they won't be available.

After
----------------------------------------
If the menu contents haven't loaded yet, it will show a spinner, letting the user know that they can stop yelling at the screen and wait patiently for it to load.

Custom fields available when saving a smart group.

Comments
---------

SearchKit is clever about loading the **Actions** menu... it waits until you select a row (or the "select all" checkbox at top) and then fires the ajax request to load the actions. Hopefully by the time you've finished making your selection the ajax will be done and the menu will have loaded before you even click on it. But if you're really fast and the server is slow, you might click on it first, and be confused by nothing happening. This fixes it.