### PR TITLE
[REF] Extract code to get generic membership parameters

### DIFF
--- a/tests/phpunit/CRM/Member/Form/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/Form/MembershipTest.php
@@ -1221,9 +1221,7 @@ Expires: ',
     if (isset($_REQUEST['cid'])) {
       unset($_REQUEST['cid']);
     }
-    $form = new CRM_Member_Form_Membership();
-    $_SERVER['REQUEST_METHOD'] = 'GET';
-    $form->controller = new CRM_Core_Controller();
+    $form = $this->getFormObject('CRM_Member_Form_Membership');
     $form->preProcess();
     return $form;
   }


### PR DESCRIPTION
Overview
----------------------------------------
[REF] Extract code to get generic membership parameters

Before
----------------------------------------
Hard to see the linkage between where variables are coming from and where they are used. Moving code around can break fragile parameter-passing

After
----------------------------------------
Variables logically grouped into 'stuff we get pretty directly from the form that applies to all memberships created by the form

Technical Details
----------------------------------------
The form has 2 types of membership parameters
1) submitted parameters
2) calculated parameters that are per membership type

This extracts the portion that are submitted to be fetched
from a single place that will return the same result whereever
it is called from (allows us to move
code around without breaking the fragile parameter chain)


Comments
----------------------------------------
