### PR TITLE
[Ref] Remove copy and paste overkill

### DIFF
--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -1819,8 +1819,6 @@ DESC limit 1");
     $params,
     $contributionParams
   ) {
-    $form = $this;
-    $transaction = new CRM_Core_Transaction();
     $contactID = $contributionParams['contact_id'];
 
     // add these values for the recurringContrib function ,CRM-10188
@@ -1833,13 +1831,7 @@ DESC limit 1");
       $contributionParams['contribution_recur_id'] = $recurringContributionID;
     }
 
-    $contribution = CRM_Contribute_BAO_Contribution::add($contributionParams);
-
-    // lets store it in the form variable so postProcess hook can get to this and use it
-    $form->_contributionID = $contribution->id;
-
-    $transaction->commit();
-    return $contribution;
+    return CRM_Contribute_BAO_Contribution::add($contributionParams);
   }
 
   /**


### PR DESCRIPTION

Overview
----------------------------------------
Remove some code that is on this form due to previously being present in code shared with the front end form but doesn't make sense here

Before
----------------------------------------
- A transaction is used - but not in a way that reflects the form
- A form variable is used - but only in one of many flows through the form

After
----------------------------------------
poof

Technical Details
----------------------------------------
This is a previously shared function that was copied and pasted back. However in the
context of this form they don't make sense because

1) It doesn't make sense to try to maintain the integrity (via the transaction)
of the contribution & recurring contribution over & above the other
items on the form - without the memberships they don't actually have integrity
and this might have made a little more sense front end in terms
of ensuring they were committed if a payment is made but
we can expect a back office user to observe an error

2) setting the contribution id on the form here doesn't make sense as
this line is only hit for credit-card recurring contributions and
either we are doing it elsewhere anyway or we should do it nowhere - there
is no logic for 'only do this in this one obscure flow' that makes
sense back office. Front office this was likely added for an otherwise missed
scenario

Comments
----------------------------------------
