### PR TITLE
dev/financial#170 - Cancel button on financial batch export is no longer an input so code needs updating

### DIFF
--- a/templates/CRM/Financial/Form/Export.tpl
+++ b/templates/CRM/Financial/Form/Export.tpl
@@ -40,7 +40,8 @@
     $('input[name="export_format"]').filter('[value=IIF]').prop('checked', true);
     $('#_qf_Export_next').click(function(){
       $(this).hide();
-      $('#_qf_Export_cancel').val('{/literal}{ts}Done{/ts}{literal}');
+      {/literal}{capture assign=tsdone}{ts}Done{/ts}{/capture}{literal}
+      $('#_qf_Export_cancel').html('<i aria-hidden="true" class="crm-i fa-check"></i> {/literal}{$tsdone|escape}{literal}');
     });
   });
 </script>


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/financial/-/issues/170

Button isn't supposed to still say Cancel after you export a financial batch.

Before
----------------------------------------
Before buttonrama, the button text would change to say Done after you did the export. It currently does nothing because it's no longer an `<input>`.

After
----------------------------------------
Says "Done".

Technical Details
----------------------------------------
I decided to also change the icon when the text changes since leaving the "X" doesn't make sense.

Comments
----------------------------------------

