### PR TITLE
Financial type hook clean up and fix towards dev/core#2454 Extend financial acls view limitations to ContributionR…

### DIFF
--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -632,7 +632,6 @@ class CRM_Core_Permission {
     // Add any permissions defined in hook_civicrm_permission implementations.
     $module_permissions = $config->userPermissionClass->getAllModulePermissions($descriptions);
     $permissions = array_merge($permissions, $module_permissions);
-    CRM_Financial_BAO_FinancialType::permissionedFinancialTypes($permissions, $descriptions);
     return $permissions;
   }
 

--- a/CRM/Financial/BAO/FinancialType.php
+++ b/CRM/Financial/BAO/FinancialType.php
@@ -200,6 +200,7 @@ class CRM_Financial_BAO_FinancialType extends CRM_Financial_DAO_FinancialType {
    * @return bool
    */
   public static function permissionedFinancialTypes(&$permissions, $descriptions) {
+    CRM_Core_Error::deprecatedFunctionWarning('not done via hook.');
     if (!self::isACLFinancialTypeStatus()) {
       return FALSE;
     }

--- a/ext/financialacls/financialacls.php
+++ b/ext/financialacls/financialacls.php
@@ -254,6 +254,38 @@ function financialacls_civicrm_membershipTypeValues($form, &$membershipTypeValue
 }
 
 /**
+ * Add permissions.
+ *
+ * @see https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_permission/
+ *
+ * @param array $permissions
+ */
+function financialacls_civicrm_permission(&$permissions) {
+  if (!financialacls_is_acl_limiting_enabled()) {
+    return;
+  }
+  $actions = [
+    'add' => ts('add'),
+    'view' => ts('view'),
+    'edit' => ts('edit'),
+    'delete' => ts('delete'),
+  ];
+  $financialTypes = \CRM_Contribute_BAO_Contribution::buildOptions('financial_type_id', 'validate');
+  foreach ($financialTypes as $id => $type) {
+    foreach ($actions as $action => $action_ts) {
+      $permissions[$action . ' contributions of type ' . $type] = [
+        ts("CiviCRM: %1 contributions of type %2", [1 => $action_ts, 2 => $type]),
+        ts('%1 contributions of type %2', [1 => $action_ts, 2 => $type]),
+      ];
+    }
+  }
+  $permissions['administer CiviCRM Financial Types'] = [
+    ts('CiviCRM: administer CiviCRM Financial Types'),
+    ts('Administer access to Financial Types'),
+  ];
+}
+
+/**
  * Remove unpermitted financial types from field Options in search context.
  *
  * Search context is described as

--- a/ext/financialacls/financialacls.php
+++ b/ext/financialacls/financialacls.php
@@ -192,6 +192,7 @@ function financialacls_civicrm_selectWhereClause($entity, &$clauses) {
   switch ($entity) {
     case 'LineItem':
     case 'MembershipType':
+    case 'ContributionRecur':
       $types = [];
       CRM_Financial_BAO_FinancialType::getAvailableFinancialTypes($types);
       if ($types) {
@@ -303,7 +304,7 @@ function financialacls_civicrm_fieldOptions($entity, $field, &$options, $params)
   if (!financialacls_is_acl_limiting_enabled()) {
     return;
   }
-  if ($entity === 'Contribution' && $field === 'financial_type_id' && $params['context'] === 'search') {
+  if (in_array($entity, ['Contribution', 'ContributionRecur'], TRUE) && $field === 'financial_type_id' && $params['context'] === 'search') {
     $action = CRM_Core_Action::VIEW;
     // At this stage we are only considering the view action. Code from
     // CRM_Financial_BAO_FinancialType::getAvailableFinancialTypes().

--- a/ext/financialacls/tests/phpunit/Civi/Financialacls/FinancialTypeTest.php
+++ b/ext/financialacls/tests/phpunit/Civi/Financialacls/FinancialTypeTest.php
@@ -32,4 +32,34 @@ class FinancialTypeTest extends BaseTestClass {
     $this->assertEquals('Changing the name', substr($status[0]['text'], 0, 17));
   }
 
+  /**
+   * Check method testPermissionedFinancialTypes()
+   */
+  public function testPermissionedFinancialTypes(): void {
+    Civi::settings()->set('acl_financial_type', TRUE);
+    $permissions = \CRM_Core_Permission::basicPermissions(FALSE, TRUE);
+    $actions = [
+      'add' => ts('add'),
+      'view' => ts('view'),
+      'edit' => ts('edit'),
+      'delete' => ts('delete'),
+    ];
+    $financialTypes = \CRM_Contribute_BAO_Contribution::buildOptions('financial_type_id', 'validate');
+    foreach ($financialTypes as $id => $type) {
+      foreach ($actions as $action => $action_ts) {
+        $this->assertEquals(
+          [
+            ts("CiviCRM: %1 contributions of type %2", [1 => $action_ts, 2 => $type]),
+            ts('%1 contributions of type %2', [1 => $action_ts, 2 => $type]),
+          ],
+          $permissions[$action . ' contributions of type ' . $type]
+        );
+      }
+    }
+    $this->assertEquals([
+      ts('CiviCRM: administer CiviCRM Financial Types'),
+      ts('Administer access to Financial Types'),
+    ], $permissions['administer CiviCRM Financial Types']);
+  }
+
 }

--- a/tests/phpunit/CRM/Financial/BAO/FinancialTypeTest.php
+++ b/tests/phpunit/CRM/Financial/BAO/FinancialTypeTest.php
@@ -217,36 +217,6 @@ class CRM_Financial_BAO_FinancialTypeTest extends CiviUnitTestCase {
   }
 
   /**
-   * Check method testPermissionedFinancialTypes()
-   */
-  public function testPermissionedFinancialTypes() {
-    // First get all core permissions
-    $permissions = $checkPerms = CRM_Core_Permission::getCorePermissions();
-    $this->setACL();
-    CRM_Financial_BAO_FinancialType::permissionedFinancialTypes($permissions, TRUE);
-    $financialTypes = CRM_Contribute_PseudoConstant::financialType();
-    $actions = [
-      'add' => ts('add'),
-      'view' => ts('view'),
-      'edit' => ts('edit'),
-      'delete' => ts('delete'),
-    ];
-    foreach ($financialTypes as $id => $type) {
-      foreach ($actions as $action => $action_ts) {
-        $checkPerms[$action . ' contributions of type ' . $type] = [
-          ts("CiviCRM: %1 contributions of type %2", [1 => $action_ts, 2 => $type]),
-          ts('%1 contributions of type %2', [1 => $action_ts, 2 => $type]),
-        ];
-      }
-    }
-    $checkPerms['administer CiviCRM Financial Types'] = [
-      ts('CiviCRM: administer CiviCRM Financial Types'),
-      ts('Administer access to Financial Types'),
-    ];
-    $this->assertEquals($permissions, $checkPerms, 'Verify that permissions for each financial type have been added');
-  }
-
-  /**
    * Check method testcheckPermissionedLineItems()
    *
    * @throws \CRM_Core_Exception


### PR DESCRIPTION
Overview
----------------------------------------
This does some cleanup on the financial type acl code moving the addition of permissions to a hook in the extension and adds ContributionRecur to the entities which get financial_type_id added as a filter for non-permissioned users 

Before
----------------------------------------
Code all in core. No handling for contribution recur entity

After
----------------------------------------
Contribution recur should be limited via the api / any functions that actually call the api with checkPermissions (which many likely don't)

Technical Details
----------------------------------------

Comments
----------------------------------------
