### PR TITLE
[REF]  getCorePermissions cleanup

### DIFF
--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -588,12 +588,7 @@ class CRM_Core_Permission {
    */
   public static function assembleBasicPermissions($all = FALSE, $descriptions = FALSE) {
     $config = CRM_Core_Config::singleton();
-    $prefix = ts('CiviCRM') . ': ';
     $permissions = self::getCorePermissions();
-
-    if (self::isMultisiteEnabled()) {
-      $permissions['administer Multiple Organizations'] = [$prefix . ts('administer Multiple Organizations')];
-    }
 
     if (!$descriptions) {
       foreach ($permissions as $name => $attr) {
@@ -909,6 +904,14 @@ class CRM_Core_Permission {
         'description' => ts('Permit altering all restricted data options'),
       ],
     ];
+    if (self::isMultisiteEnabled()) {
+      // This could arguably be moved to the multisite extension but
+      // within core it does permit editing group-organization records.
+      $permissions['administer Multiple Organizations'] = [
+        'label' => $prefix . ts('administer Multiple Organizations'),
+        'description' => ts('Administer multiple organizations. In practice this allows editing the group organization link'),
+      ];
+    }
     foreach (self::getImpliedPermissions() as $name => $includes) {
       foreach ($includes as $permission) {
         $permissions[$name][] = $permissions[$permission];

--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -589,7 +589,7 @@ class CRM_Core_Permission {
   public static function assembleBasicPermissions($all = FALSE, $descriptions = FALSE) {
     $config = CRM_Core_Config::singleton();
     $prefix = ts('CiviCRM') . ': ';
-    $permissions = self::getCorePermissions($descriptions);
+    $permissions = self::getCorePermissions();
 
     if (self::isMultisiteEnabled()) {
       $permissions['administer Multiple Organizations'] = [$prefix . ts('administer Multiple Organizations')];

--- a/distmaker/utils/joomlaxml.php
+++ b/distmaker/utils/joomlaxml.php
@@ -61,7 +61,7 @@ function generateJoomlaConfig($version) {
   require_once 'CRM/Core/Permission.php';
   require_once 'CRM/Utils/String.php';
   require_once 'CRM/Core/I18n.php';
-  $permissions = CRM_Core_Permission::getCorePermissions(TRUE);
+  $permissions = CRM_Core_Permission::getCorePermissions();
 
   $crmFolderDir = $sourceCheckoutDir . DIRECTORY_SEPARATOR . 'CRM';
 


### PR DESCRIPTION
Overview
----------------------------------------
- Stop passing paramter not recognised by getCorePermissions. 
- Standardise description of administer multiple organizations

Before
----------------------------------------
administer multiple organizations set up differently to all the other core permissions
Parameter passed to getCorePermissions even though the function signaure does not accept one

After
----------------------------------------
poof

Technical Details
----------------------------------------
I'm pretty sure this is just 'I don't want to touch it' that led to this permission being different. Either it's in core & is a core permission & should be subject to the same formatting etc or it should be moved to the multisite extension - while I can see the appeal of the latter it might be too big a lift for right now.

I need to rationalise getCorePermissions vs getBasicPermissions in order to extend the implied permissions concept

Comments
----------------------------------------
@seamuslee001 