### PR TITLE
Fix rc regression - js error on autorenew checkbox

### DIFF
--- a/templates/CRM/Member/Form/Membership.tpl
+++ b/templates/CRM/Member/Form/Membership.tpl
@@ -528,7 +528,7 @@
       buildAutoRenew( null, null, '{$membershipMode}');
     {/if}
     {literal}
-    function buildAutoRenew( membershipType, processorId, mode ) {
+    function buildAutoRenew(membershipTypeID, processorId, mode ) {
       var action = {/literal}'{$action}'{literal};
 
       //for update lets hide it when not already recurring.


### PR DESCRIPTION


Overview
----------------------------------------
Fixes a regression in the rc resulting in a js error on the new membership by credit card form and the auto renew checkbox being always present

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/110904330-ab16bc80-836d-11eb-9aae-ac9a0a1c88ae.png)


After
----------------------------------------
no more red ink

Technical Details
----------------------------------------
This commit
https://github.com/civicrm/civicrm-core/pull/19647/commits/cfab7c9d1dc5d1e8438131354685928cd9da3877 renamed membershipType to membershipTypeID but missed this spot,
resulting in js errors on the new membership by credit card form

Comments
----------------------------------------
