### PR TITLE
dev/core#2459 Fix custom fields changed from multiple-choice data type to Text

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -1994,6 +1994,11 @@ WHERE  id IN ( %1, %2 )
       }
     }
 
+    // Remove option group IDs from fields changed to Text html_type.
+    if ($htmlType == 'Text') {
+      $params['option_group_id'] = '';
+    }
+
     // check for orphan option groups
     if (!empty($params['option_group_id'])) {
       if (!empty($params['id'])) {

--- a/tests/phpunit/CRM/Core/BAO/CustomFieldTest.php
+++ b/tests/phpunit/CRM/Core/BAO/CustomFieldTest.php
@@ -51,6 +51,34 @@ class CRM_Core_BAO_CustomFieldTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test changing a data type from multiple-choice to Text.
+   */
+  public function testChangeDataType() {
+    $customGroup = $this->createCustomField();
+    $fields = [
+      'label' => 'Radio to Text',
+      'is_active' => 1,
+      'data_type' => 'String',
+      'html_type' => 'Radio',
+      'custom_group_id' => $customGroup['id'],
+      'option_type' => 1,
+      'option_label' => ["One", "Two"],
+      'option_value' => [1, 2],
+      'option_weight' => [1, 2],
+      'option_status' => [1, 1],
+    ];
+    $customField = CRM_Core_BAO_CustomField::create($fields);
+    $this->assertNotNull($customField->option_group_id);
+    $fieldsNew = [
+      'id' => $customField->id,
+      'html_type' => 'Text',
+      'custom_group_id' => $customGroup['id'],
+    ];
+    $customFieldModified = CRM_Core_BAO_CustomField::create($fieldsNew);
+    $this->assertFalse($customFieldModified->option_group_id ?? FALSE);
+  }
+
+  /**
    * Test custom field create accepts passed column name.
    */
   public function testCreateCustomFieldColumnName() {


### PR DESCRIPTION
https://lab.civicrm.org/dev/core/-/issues/2459

Overview
----------------------------------------
Changing a custom field from a multiple choice (Radio, Checkboxes, etc.) to a free-entry text box works, until you try to write to the custom field via the API.

Reproduction steps are on the ticket.

Before
----------------------------------------
API Error - your value isn't an accepted value for this field.

After
----------------------------------------
A custom field with a data type of "String" and HTML type of "Text" should take any alphanumeric value.

Technical Details
----------------------------------------
Changing the HTML type doesn't remove the Option Group ID.  While arguably the API code should ignore that, it seems more important that the data be correct.
