### PR TITLE
Add `resetPaths` as per issue #2458 #1

### DIFF
--- a/Civi/Api4/Action/System/ResetPaths.php
+++ b/Civi/Api4/Action/System/ResetPaths.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Action\System;
+
+/**
+ * Clear CiviCRM caches, and optionally rebuild triggers and reset sessions.
+ *
+ * @method bool getTriggers
+ * @method $this setTriggers(bool $triggers)
+ * @method bool getSession
+ * @method $this setSession(bool $session)
+ */
+class ResetPaths extends \Civi\Api4\Generic\AbstractAction {
+
+  public function _run(\Civi\Api4\Generic\Result $result) {
+    \CRM_Core_BAO_ConfigSetting::doSiteMove();
+  }
+
+}

--- a/Civi/Api4/Action/System/ResetPaths.php
+++ b/Civi/Api4/Action/System/ResetPaths.php
@@ -13,12 +13,7 @@
 namespace Civi\Api4\Action\System;
 
 /**
- * Clear CiviCRM caches, and optionally rebuild triggers and reset sessions.
- *
- * @method bool getTriggers
- * @method $this setTriggers(bool $triggers)
- * @method bool getSession
- * @method $this setSession(bool $session)
+ * Reset paths using doSiteMove().
  */
 class ResetPaths extends \Civi\Api4\Generic\AbstractAction {
 

--- a/Civi/Api4/System.php
+++ b/Civi/Api4/System.php
@@ -63,4 +63,13 @@ class System extends Generic\AbstractEntity {
     }))->setCheckPermissions($checkPermissions);
   }
 
+  /**
+   * @param bool $checkPermissions
+   * @return Action\System\ResetPaths
+   */
+  public static function resetPaths($checkPermissions = TRUE) {
+    return (new Action\System\ResetPaths(__CLASS__, __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
This was raised as [issue 2458](https://lab.civicrm.org/dev/core/issues/2458) when deploying sites programatically through CI or CD pipelines it's often useful to be able to reset paths quickly and easily. This PR adds an APIv4 endpoint that can perform this task as `System.resetPaths`

Before
----------------------------------------
No way to reset paths using the API.

After
----------------------------------------
APIv4 endpoint to resetPaths in a similar way to the API endpoint for cache clearing `system.Flush`. Uses existing core functions to perform the "heavy lifting".

Technical Details
----------------------------------------
Essentially an APIv4 wrapper around `CRM_Core_Bao_ConfigSetting::doSiteMove()` relying on the existing core method entirely.