### PR TITLE
Add new Super-duper-no-permissions-apply permission

### DIFF
--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -911,12 +911,17 @@ class CRM_Core_Permission {
    * @return array
    */
   public static function getImpliedPermissionsFor(string $permission): array {
+    if (in_array($permission[0], ['@', '*'], TRUE)) {
+      // Special permissions like '*always deny*' - see DynamicFKAuthorizationTest.
+      // Also '@afform - see AfformUsageTest.
+      return [];
+    }
     $implied = Civi::cache('metadata')->get('implied_permissions', []);
     if (isset($implied[$permission])) {
       return $implied[$permission];
     }
-    $implied[$permission] = [];
-    foreach (self::basicPermissions(FALSE, TRUE) as $key => $details) {
+    $implied[$permission] = ['all CiviCRM permissions and ACLs'];
+    foreach (self::getImpliedAdminPermissions() as $key => $details) {
       if (in_array($permission, $details['implied_permissions'] ?? [], TRUE)) {
         $implied[$permission][] = $key;
       }

--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -591,7 +591,7 @@ class CRM_Core_Permission {
     $permissions = self::getCoreAndComponentPermissions($all);
 
     // Add any permissions defined in hook_civicrm_permission implementations.
-    $module_permissions = CRM_Core_Config::singleton()->userPermissionClass->getAllModulePermissions(TRUE);
+    $module_permissions = CRM_Core_Config::singleton()->userPermissionClass->getAllModulePermissions(TRUE, $permissions);
     $permissions = array_merge($permissions, $module_permissions);
     if (!$descriptions) {
       foreach ($permissions as $name => $attr) {
@@ -874,6 +874,10 @@ class CRM_Core_Permission {
         'label' => $prefix . ts('administer CiviCRM Data'),
         'description' => ts('Permit altering all restricted data options'),
       ],
+      'all CiviCRM permissions and ACLs' => [
+        'label' => $prefix . ts('all CiviCRM permissions and ACLs'),
+        'description' => ts('Administer and use CiviCRM bypassing any other permission or ACL checks and enabling the creation of displays and forms that allow others to bypass checks. This permission should be given out with care'),
+      ],
     ];
     if (self::isMultisiteEnabled()) {
       // This could arguably be moved to the multisite extension but
@@ -883,11 +887,6 @@ class CRM_Core_Permission {
         'description' => ts('Administer multiple organizations. In practice this allows editing the group organization link'),
       ];
     }
-    foreach (self::getImpliedPermissions() as $name => $includes) {
-      foreach ($includes as $permission) {
-        $permissions[$name][] = $permissions[$permission];
-      }
-    }
     return $permissions;
   }
 
@@ -896,11 +895,11 @@ class CRM_Core_Permission {
    *
    * @return array
    */
-  public static function getImpliedPermissions() {
+  public static function getImpliedAdminPermissions(): array {
     return [
-      'administer CiviCRM' => ['administer CiviCRM system', 'administer CiviCRM data'],
-      'administer CiviCRM data' => ['edit message templates', 'administer dedupe rules'],
-      'administer CiviCRM system' => ['edit system workflow message templates'],
+      'administer CiviCRM' => ['implied_permissions' => ['administer CiviCRM system', 'administer CiviCRM data']],
+      'administer CiviCRM data' => ['implied_permissions' => ['edit message templates', 'administer dedupe rules']],
+      'administer CiviCRM system' => ['implied_permissions' => ['edit system workflow message templates']],
     ];
   }
 
@@ -911,14 +910,19 @@ class CRM_Core_Permission {
    *
    * @return array
    */
-  public static function getImpliedPermissionsFor(string $permission) {
-    $return = [];
-    foreach (self::getImpliedPermissions() as $superPermission => $components) {
-      if (in_array($permission, $components, TRUE)) {
-        $return[$superPermission] = $superPermission;
+  public static function getImpliedPermissionsFor(string $permission): array {
+    $implied = Civi::cache('metadata')->get('implied_permissions', []);
+    if (isset($implied[$permission])) {
+      return $implied[$permission];
+    }
+    $implied[$permission] = [];
+    foreach (self::basicPermissions(FALSE, TRUE) as $key => $details) {
+      if (in_array($permission, $details['implied_permissions'] ?? [], TRUE)) {
+        $implied[$permission][] = $key;
       }
     }
-    return $return;
+    Civi::cache('metadata')->set('implied_permissions', $implied);
+    return $implied[$permission];
   }
 
   /**
@@ -1728,6 +1732,7 @@ class CRM_Core_Permission {
   protected static function getCoreAndComponentPermissions(bool $all): array {
     $permissions = self::getCorePermissions();
     $permissions = array_merge($permissions, self::getComponentPermissions($all));
+    $permissions['all CiviCRM permissions and ACLs']['implied_permissions'] = array_keys($permissions);
     return $permissions;
   }
 

--- a/CRM/Core/Permission/Base.php
+++ b/CRM/Core/Permission/Base.php
@@ -57,7 +57,7 @@ class CRM_Core_Permission_Base {
    *   a permission name
    */
   public function translatePermission($perm, $nativePrefix, $map) {
-    list ($civiPrefix, $name) = CRM_Utils_String::parsePrefix(':', $perm, NULL);
+    [$civiPrefix, $name] = CRM_Utils_String::parsePrefix(':', $perm, NULL);
     switch ($civiPrefix) {
       case $nativePrefix:
         return $name;
@@ -272,9 +272,12 @@ class CRM_Core_Permission_Base {
    *   The permission to check.
    * @param int $userId
    *
+   * @return bool;
+   *
    */
   public function check($str, $userId = NULL) {
     //no default behaviour
+    return FALSE;
   }
 
   /**
@@ -374,7 +377,7 @@ class CRM_Core_Permission_Base {
    *   Array of permissions, in the same format as CRM_Core_Permission::getCorePermissions().
    * @see CRM_Core_Permission::getCorePermissions
    */
-  public static function getModulePermissions($module) {
+  public function getModulePermissions($module): array {
     $return_permissions = [];
     $fn_name = "{$module}_civicrm_permission";
     if (function_exists($fn_name)) {
@@ -390,14 +393,15 @@ class CRM_Core_Permission_Base {
    * in all enabled CiviCRM module extensions.
    *
    * @param bool $descriptions
+   * @param array $permissions
    *
    * @return array
    *   Array of permissions, in the same format as CRM_Core_Permission::getCorePermissions().
    */
-  public function getAllModulePermissions($descriptions = FALSE) {
-    // Passing in false here is to be deprecated.
-    $permissions = [];
-    CRM_Utils_Hook::permission($permissions);
+  public function getAllModulePermissions($descriptions = FALSE, &$permissions): array {
+    $newPermissions = [];
+    CRM_Utils_Hook::permission($newPermissions, $permissions);
+    $permissions = array_merge($permissions, $newPermissions);
 
     if ($descriptions) {
       foreach ($permissions as $permission => $label) {
@@ -405,6 +409,7 @@ class CRM_Core_Permission_Base {
       }
     }
     else {
+      // Passing in false here is to be deprecated.
       foreach ($permissions as $permission => $label) {
         $permissions[$permission] = (is_array($label)) ? array_shift($label) : $label;
       }

--- a/CRM/Core/Permission/Drupal6.php
+++ b/CRM/Core/Permission/Drupal6.php
@@ -192,7 +192,7 @@ class CRM_Core_Permission_Drupal6 extends CRM_Core_Permission_DrupalBase {
    * @return array
    *   Array of permissions, in the same format as CRM_Core_Permission::getCorePermissions().
    */
-  public static function getModulePermissions($module) {
+  public function getModulePermissions($module):array {
     $return_permissions = [];
     $fn_name = "{$module}_civicrm_permission";
     if (function_exists($fn_name)) {

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -2023,16 +2023,19 @@ abstract class CRM_Utils_Hook {
    * This hook is called when exporting Civi's permission to the CMS. Use this hook to modify
    * the array of system permissions for CiviCRM.
    *
+   * @param array $newPermissions
+   *   Array to be filled with permissions.
    * @param array $permissions
-   *   Array of permissions. See CRM_Core_Permission::getCorePermissions() for
-   *   the format of this array.
+   *   Already calculated permissions. These can be altered. Notably an
+   *   extension might want to add it's permissions to 'implied' or to
+   *   remove some permissions.
    *
    * @return null
    *   The return value is ignored
    */
-  public static function permission(&$permissions) {
-    return self::singleton()->invoke(['permissions'], $permissions,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
+  public static function permission(&$newPermissions, &$permissions) {
+    return self::singleton()->invoke(['permissions', 'all_permissions'], $newPermissions, $permissions,
+      self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
       'civicrm_permission'
     );
   }

--- a/tests/phpunit/CRM/Core/Permission/BaseTest.php
+++ b/tests/phpunit/CRM/Core/Permission/BaseTest.php
@@ -12,7 +12,7 @@ class CRM_Core_Permission_BaseTest extends CiviUnitTestCase {
    * @return array
    *   (0 => input to translatePermission, 1 => expected output from translatePermission)
    */
-  public function translateData() {
+  public function translateData(): array {
     $cases = [];
 
     $cases[] = ['administer CiviCRM', 'administer CiviCRM'];
@@ -35,7 +35,7 @@ class CRM_Core_Permission_BaseTest extends CiviUnitTestCase {
    * @param string $expected
    *   The name of an actual permission (based on translation matrix for "runtime").
    */
-  public function testTranslate($input, $expected) {
+  public function testTranslate(string $input, string $expected): void {
     $perm = new CRM_Core_Permission_Base();
     $actual = $perm->translatePermission($input, 'myruntime', [
       'universal name' => 'local name',
@@ -48,12 +48,23 @@ class CRM_Core_Permission_BaseTest extends CiviUnitTestCase {
   /**
    * Test that the user has the implied permission of administer CiviCRM data by virtue of having administer CiviCRM.
    */
-  public function testImpliedPermission() {
+  public function testImpliedPermission(): void {
     $this->createLoggedInUser();
     CRM_Core_Config::singleton()->userPermissionClass->permissions = [
       'administer CiviCRM',
     ];
     $this->assertTrue(CRM_Core_Permission::check('administer CiviCRM data'));
+  }
+
+  /**
+   * Test that the super permission gives the implied permission of the whole shebang.
+   */
+  public function testImpliedPermissionSuperDuper(): void {
+    $this->createLoggedInUser();
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = [
+      'all CiviCRM permissions and ACLs',
+    ];
+    $this->assertTrue(CRM_Core_Permission::check('view all contacts'));
   }
 
 }

--- a/tests/phpunit/Civi/API/Subscriber/DynamicFKAuthorizationTest.php
+++ b/tests/phpunit/Civi/API/Subscriber/DynamicFKAuthorizationTest.php
@@ -2,6 +2,7 @@
 namespace Civi\API\Subscriber;
 
 use Civi\API\Kernel;
+use Civi\API\Provider\StaticProvider;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 
 /**
@@ -27,12 +28,12 @@ class DynamicFKAuthorizationTest extends \CiviUnitTestCase {
    */
   public $kernel;
 
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
     \CRM_Core_DAO_AllCoreTables::init(TRUE);
 
     \CRM_Core_DAO_AllCoreTables::registerEntityType('FakeFile', 'CRM_Fake_DAO_FakeFile', 'fake_file');
-    $fileProvider = new \Civi\API\Provider\StaticProvider(
+    $fileProvider = new StaticProvider(
       3,
       'FakeFile',
       ['id', 'entity_table', 'entity_id'],
@@ -44,7 +45,7 @@ class DynamicFKAuthorizationTest extends \CiviUnitTestCase {
     );
 
     \CRM_Core_DAO_AllCoreTables::registerEntityType('Widget', 'CRM_Fake_DAO_Widget', 'fake_widget');
-    $widgetProvider = new \Civi\API\Provider\StaticProvider(3, 'Widget',
+    $widgetProvider = new StaticProvider(3, 'Widget',
       ['id', 'title'],
       [],
       [
@@ -53,7 +54,7 @@ class DynamicFKAuthorizationTest extends \CiviUnitTestCase {
     );
 
     \CRM_Core_DAO_AllCoreTables::registerEntityType('Forbidden', 'CRM_Fake_DAO_Forbidden', 'fake_forbidden');
-    $forbiddenProvider = new \Civi\API\Provider\StaticProvider(
+    $forbiddenProvider = new StaticProvider(
       3,
       'Forbidden',
       ['id', 'label'],
@@ -90,18 +91,18 @@ class DynamicFKAuthorizationTest extends \CiviUnitTestCase {
         else null
       end as entity_table,
       case %1
-        when " . self::FILE_WIDGET_ID . " then " . self::WIDGET_ID . "
-        when " . self::FILE_FORBIDDEN_ID . " then " . self::FORBIDDEN_ID . "
+        when " . self::FILE_WIDGET_ID . ' then ' . self::WIDGET_ID . '
+        when ' . self::FILE_FORBIDDEN_ID . ' then ' . self::FORBIDDEN_ID . '
         else null
       end as entity_id
-      ",
+      ',
       // Get a list of custom fields (field_name,table_name,extends)
-      "select",
+      'select',
       ['fake_widget', 'fake_forbidden']
     ));
   }
 
-  protected function tearDown() {
+  protected function tearDown(): void {
     parent::tearDown();
     \CRM_Core_DAO_AllCoreTables::init(TRUE);
   }
@@ -196,10 +197,10 @@ class DynamicFKAuthorizationTest extends \CiviUnitTestCase {
   }
 
   /**
-   * @param $entity
-   * @param $action
+   * @param string $entity
+   * @param int $action
    * @param array $params
-   * @param $expectedError
+   * @param array $expectedError
    * @dataProvider badDataProvider
    */
   public function testBad($entity, $action, $params, $expectedError) {


### PR DESCRIPTION
Overview
----------------------------------------
Adds a new super duper permission that is the equivalent of the drupal user 1 or 'implicitly has all other permissions'.

Search kit  allows search displays to be create and shared. To make this useful for things like event participant listings for anonymous users it has to be possible to make these displays bypass permissions.


This effectively means we are giving people the power to create displays
that set check_permissions to FALSE. This would potentially enable people
to not just bypass ACLs applied to others but also acls applied to them.
In order words it could be a privellege escallation. It could also be an opportunity for 
a mildly savy CiviCRM user to inadvertantly expose data.

To prevent any unexpected escallation we decided that this ability
should only be given to contacts who explicitly have access to everything
anyway. 

Currently there is no existing permission that does this (although
many people eroneously think Administer CiviCRM does)

This PR adds that role.

Note that it only gives access to all core permissions (not those added by modules) - see technical discussion for more on this

Before
----------------------------------------
There is no role that implicitly has full permission to CiviCRM including 'view all contacts' and view all entities (including payment processors and workflow templates) - sites with ACLs are likely to give 'Administer CiviCRM' 
but not 'View all Contacts' and if the acls are created by hooks the restricted person cannot edit them to bypass.

After
----------------------------------------
A new permission exists which implicitly contains every other access.
![image](https://user-images.githubusercontent.com/336308/111018342-27b4a400-841d-11eb-891b-f4bd19b6295e.png)

Technical Details
----------------------------------------
The new permission is declare in the declaration of core and component permissions and all permissions declare up until that point are added as implied_permissions

This happens before extensions add in permissions and they must actively add their permissions to this array
if they want the super duper role to have them. Whether the need to opt in vs opt out is good or bad could be
argued but it did it that way so that extensions could also alter the permissions otherwise implied. In particular I think
we would patch the multisite extension such that it unsets the implied permissions on the child sites to avoid
privellege escallation


![image](https://user-images.githubusercontent.com/336308/111018479-dbb62f00-841d-11eb-8d3b-080fd8b4e91a.png)

In order to allow extensions to modify already set permissions there is an issue with the hook. Before this the hook call 
does not make previously declared permissions available - it's an add in only story

![image](https://user-images.githubusercontent.com/336308/111018596-a1995d00-841e-11eb-9840-ec2b0a276e91.png)

I've added a second parameter with the already configured array


Comments
----------------------------------------
Docs PR https://lab.civicrm.org/documentation/docs/dev/-/merge_requests/887
Also note that https://github.com/civicrm/civicrm-core/pull/19796 is a sub-pr and I can re-base that cleanup out of this once merged


@colemanw @seamuslee001 @totten 