### PR TITLE
APIv4 - Code cleanup & improve links to @see annotations in Explorer

### DIFF
--- a/Civi/Api4/Action/Permission/Get.php
+++ b/Civi/Api4/Action/Permission/Get.php
@@ -21,27 +21,29 @@ use Civi\Api4\Generic\BasicGetAction;
  * It may be poorly suited to recursive usage (e.g. permissions defined dynamically
  * on top of permissions!) or during install/uninstall processes.
  *
- * The list of permissions is generated via hook, and there is a standard/default
- * listener.
+ * The list of permissions is generated via hook, and there is a standard/default listener.
  *
  * @see CRM_Core_Permission_List
  * @see \CRM_Utils_Hook::permissionList
  */
 class Get extends BasicGetAction {
 
-  public function getRecords() {
+  /**
+   * @return array[]
+   */
+  protected function getRecords() {
     $cacheKey = 'list_' . $GLOBALS['tsLocale'];
     if (!isset(\Civi::$statics[__CLASS__][$cacheKey])) {
       $perms = [];
       \CRM_Utils_Hook::permissionList($perms);
-      foreach (array_keys($perms) as $permName) {
+      foreach ($perms as $permName => $permission) {
         $defaults = [
           'name' => $permName,
           'group' => 'unknown',
           'is_synthetic' => ($permName[0] === '@'),
           'is_active' => TRUE,
         ];
-        $perms[$permName] = array_merge($defaults, $perms[$permName]);
+        $perms[$permName] = array_merge($defaults, $permission);
       }
       \Civi::$statics[__CLASS__][$cacheKey] = $perms;
     }

--- a/Civi/Api4/Permission.php
+++ b/Civi/Api4/Permission.php
@@ -32,10 +32,11 @@ class Permission extends Generic\AbstractEntity {
 
   /**
    * @param bool $checkPermissions
-   * @return \Civi\Api4\Generic\BasicGetAction
+   * @return Action\Permission\Get
    */
   public static function get($checkPermissions = TRUE) {
-    return (new \Civi\Api4\Action\Permission\Get(__CLASS__, __FUNCTION__))->setCheckPermissions($checkPermissions);
+    return (new Action\Permission\Get(__CLASS__, __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
   }
 
   /**
@@ -48,31 +49,26 @@ class Permission extends Generic\AbstractEntity {
         [
           'name' => 'group',
           'title' => 'Group',
-          'required' => TRUE,
           'data_type' => 'String',
         ],
         [
           'name' => 'name',
           'title' => 'Name',
-          'required' => TRUE,
           'data_type' => 'String',
         ],
         [
           'name' => 'title',
           'title' => 'Title',
-          'required' => TRUE,
           'data_type' => 'String',
         ],
         [
           'name' => 'description',
           'title' => 'Description',
-          'required' => FALSE,
           'data_type' => 'String',
         ],
         [
           'name' => 'is_synthetic',
           'title' => 'Is Synthetic',
-          'required' => FALSE,
           'data_type' => 'Boolean',
         ],
         [
@@ -80,7 +76,6 @@ class Permission extends Generic\AbstractEntity {
           'title' => 'Is Active',
           'description' => '',
           'default' => TRUE,
-          'required' => FALSE,
           'data_type' => 'Boolean',
         ],
       ];

--- a/Civi/Api4/Route.php
+++ b/Civi/Api4/Route.php
@@ -33,14 +33,13 @@ class Route extends \Civi\Api4\Generic\AbstractEntity {
 
   /**
    * @param bool $checkPermissions
-   * @return \Civi\Api4\Generic\BasicGetAction
+   * @return Generic\BasicGetAction
    */
   public static function get($checkPermissions = TRUE) {
-    return (new \Civi\Api4\Generic\BasicGetAction(__CLASS__, __FUNCTION__, function ($get) {
-      // Pulling from ::items() rather than DB -- because it provides the final/live/altered data.
-      $items = \CRM_Core_Menu::items();
+    return (new Generic\BasicGetAction(__CLASS__, __FUNCTION__, function ($get) {
       $result = [];
-      foreach ($items as $path => $item) {
+      // Pulling from ::items() rather than DB -- because it provides the final/live/altered data.
+      foreach (\CRM_Core_Menu::items() as $path => $item) {
         $result[] = ['path' => $path] + $item;
       }
       return $result;
@@ -57,37 +56,31 @@ class Route extends \Civi\Api4\Generic\AbstractEntity {
         [
           'name' => 'path',
           'title' => 'Relative Path',
-          'required' => TRUE,
           'data_type' => 'String',
         ],
         [
           'name' => 'title',
           'title' => 'Page Title',
-          'required' => TRUE,
           'data_type' => 'String',
         ],
         [
           'name' => 'page_callback',
           'title' => 'Page Callback',
-          'required' => TRUE,
           'data_type' => 'String',
         ],
         [
           'name' => 'page_arguments',
           'title' => 'Page Arguments',
-          'required' => FALSE,
           'data_type' => 'String',
         ],
         [
           'name' => 'path_arguments',
           'title' => 'Path Arguments',
-          'required' => FALSE,
           'data_type' => 'String',
         ],
         [
           'name' => 'access_arguments',
           'title' => 'Access Arguments',
-          'required' => FALSE,
           'data_type' => 'Array',
         ],
       ];

--- a/ang/api4Explorer/Explorer.js
+++ b/ang/api4Explorer/Explorer.js
@@ -194,16 +194,20 @@
       $scope.helpContent = helpContent = formatHelp(content);
     }
 
-    // Convert plain-text help to markdown; replace variables and format links
+    // Format help text with markdown; replace variables and format links
     function formatHelp(rawContent) {
       function formatRefs(see) {
         _.each(see, function(ref, idx) {
-          var match = ref.match(/^\\Civi\\Api4\\([a-zA-Z]+)$/);
+          var match = ref.match(/^(\\Civi\\Api4\\)?([a-zA-Z]+)$/);
           if (match) {
-            ref = '#/explorer/' + match[1];
+            ref = '#/explorer/' + match[2];
           }
-          if (ref[0] === '\\') {
-            ref = 'https://github.com/civicrm/civicrm-core/blob/master' + ref.replace(/\\/i, '/') + '.php';
+          // Link to php classes on GitHub.
+          // Fixme: Only works for files in the core repo
+          if (ref[0] === '\\' || ref.indexOf('Civi\\') === 0 || ref.indexOf('CRM_') === 0) {
+            var classFunction = _.trim(ref, '\\').split('::'),
+              replacement = new RegExp(classFunction[0].indexOf('CRM_') === 0 ? '_' : '\\\\', 'g');
+            ref = 'https://github.com/civicrm/civicrm-core/blob/master/' + classFunction[0].replace(replacement, '/') + '.php';
           }
           see[idx] = '<a target="' + (ref[0] === '#' ? '_self' : '_blank') + '" href="' + ref + '">' + see[idx] + '</a>';
         });


### PR DESCRIPTION
Overview
----------------------------------------
Minor code cleanup in a few APIv4 classes, and improve rendering of links to `@see` annoations in the APIv4 explorer help panel.

Before/After
------------
Links for e.g. `Permission::get` in the APIv4 explorer were not correct (the ones at the bottom under **See:**). Now they are at least more correct.

![image](https://user-images.githubusercontent.com/2874912/111037433-f1adfa80-83f1-11eb-8773-cdd07229374c.png)
