### PR TITLE
[REF] Remove setting of unused variables

### DIFF
--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -1035,8 +1035,6 @@ DESC limit 1");
           'frequency_interval' => 'duration_interval',
           'frequency_unit' => 'duration_unit',
         ] as $mapVal => $mapParam) {
-          $membershipTypeValues[$memType][$mapVal] = $recurMembershipTypeValues[$mapParam];
-
           if (!$count) {
             $formValues[$mapVal] = CRM_Utils_Array::value($mapParam,
               $recurMembershipTypeValues


### PR DESCRIPTION
Overview
----------------------------------------
[REF] Remove setting on unused variables

Before
----------------------------------------
Line exists to set

```
$membershipValues[2]['frequency_interval']
$membershipValues[2]['frequency_duration']
```
(where 2 is the membership type id)

However I can see no evidence these are ever used anymore. The membershipValues
array is an array of values to pass to the membership create action which
does not reference them at all.

They ARE referenced from the legacyProcessRecurringContribution as
they defined the frequency of these - but they take the value set in
formValues which is not removed



After
----------------------------------------
poof

Technical Details
----------------------------------------
Removing this one line opens up quite a lot more simplification and
I can't see any evidence it plays a function these days

Comments
----------------------------------------
