### PR TITLE
core#2461 - allow booleans to be of type boolean

### DIFF
--- a/CRM/Utils/Rule.php
+++ b/CRM/Utils/Rule.php
@@ -625,6 +625,10 @@ class CRM_Utils_Rule {
    * @return bool
    */
   public static function boolean($value) {
+    if ($value === TRUE || $value === FALSE) {
+      return TRUE;
+    }
+    // This is intentionally not using === comparison - but will fail on FALSE.
     return preg_match(
       '/(^(1|0)$)|(^(Y(es)?|N(o)?)$)|(^(T(rue)?|F(alse)?)$)/i', $value
     ) ? TRUE : FALSE;

--- a/tests/phpunit/CRM/Utils/RuleTest.php
+++ b/tests/phpunit/CRM/Utils/RuleTest.php
@@ -80,6 +80,28 @@ class CRM_Utils_RuleTest extends CiviUnitTestCase {
   }
 
   /**
+   * @dataProvider booleanDataProvider
+   * @param $inputData
+   * @param $expectedResult
+   */
+  public function testBoolean($inputData, $expectedResult) {
+    $this->assertEquals($expectedResult, CRM_Utils_Rule::boolean($inputData));
+  }
+
+  /**
+   * @return array
+   */
+  public function booleanDataProvider() {
+    return [
+      [TRUE, TRUE],
+      ['TRUE', TRUE],
+      [FALSE, TRUE],
+      ['false', TRUE],
+      ['banana', FALSE],
+    ];
+  }
+
+  /**
    * @dataProvider moneyDataProvider
    * @param $inputData
    * @param $decimalPoint

--- a/tests/phpunit/CRM/Utils/TypeTest.php
+++ b/tests/phpunit/CRM/Utils/TypeTest.php
@@ -131,6 +131,11 @@ class CRM_Utils_TypeTest extends CiviUnitTestCase {
       ['field(contribution_status_id,4,5,6) asc, contact_id asc', 'MysqlOrderBy', 'field(`contribution_status_id`,4,5,6) asc, `contact_id` asc'],
       ['table.civicrm_column_name desc,other_column,another_column desc', 'MysqlOrderBy', '`table`.`civicrm_column_name` desc, `other_column`, `another_column` desc'],
       ['table.`Home-street_address` asc, `table-alias`.`Home-street_address` desc,`table-alias`.column', 'MysqlOrderBy', '`table`.`Home-street_address` asc, `table-alias`.`Home-street_address` desc, `table-alias`.`column`'],
+      [TRUE, 'Boolean', TRUE],
+      [FALSE, 'Boolean', FALSE],
+      ['TRUE', 'Boolean', 'TRUE'],
+      ['false', 'Boolean', 'false'],
+      ['banana', 'Boolean', NULL],
     ];
   }
 


### PR DESCRIPTION
https://lab.civicrm.org/dev/core/-/issues/2461

Overview
----------------------------------------
The regex match for validating booleans assumes you're passing a string.  With APIv4 we're also passing booleans.  Since the tested value is implicitly cast to a string, `TRUE` passes but `FALSE` doesn't 

Before
----------------------------------------
Passing the value `FALSE` doesn't pass validation.  If you're using the API, this returns an exception.

After
----------------------------------------
`FALSE` is acceptable as a boolean value.

Technical Details
----------------------------------------
```php
php > $temp = (string) TRUE;
php > echo $temp;                                                                                                                                                                                                                             
1
php > $temp = (string) FALSE;                                                                                                                                                                                                            
php > echo $temp;                                                                                                                                                                                                                             
php > 
```

Comments
----------------------------------------
I wrote tests on `CRM_Utils_Type::escape()` and `CRM_Utils_Rule::boolean()` while I was still puzzling through this.  They're not both necessary, but who's going to turn down extra (passing) tests?