### PR TITLE
Align most of the tokens in the token processor handling with the legacy handling

### DIFF
--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -732,22 +732,12 @@ class CRM_Utils_Token {
       $value = "cs={$cs}";
     }
     else {
-      $value = CRM_Utils_Array::retrieveValueRecursive($contact, $token);
+      $value = (array) CRM_Utils_Array::retrieveValueRecursive($contact, $token);
 
-      // FIXME: for some pseudoconstants we get array ( 0 => id, 1 => label )
-      if (is_array($value)) {
-        $value = $value[1];
+      foreach ($value as $index => $item) {
+        $value[$index] = self::convertPseudoConstantsUsingMetadata($value[$index], $token);
       }
-      // Convert pseudoconstants using metadata
-      elseif ($value && is_numeric($value)) {
-        $allFields = CRM_Contact_BAO_Contact::exportableFields('All');
-        if (!empty($allFields[$token]['pseudoconstant'])) {
-          $value = CRM_Core_PseudoConstant::getLabel('CRM_Contact_BAO_Contact', $token, $value);
-        }
-      }
-      elseif ($value && CRM_Utils_String::endsWith($token, '_date')) {
-        $value = CRM_Utils_Date::customFormat($value);
-      }
+      $value = implode(', ', $value);
     }
 
     if (!$html) {
@@ -1895,6 +1885,26 @@ class CRM_Utils_Token {
     }
 
     return $output;
+  }
+
+  /**
+   * @param $value
+   * @param $token
+   *
+   * @return bool|int|mixed|string|null
+   */
+  protected static function convertPseudoConstantsUsingMetadata($value, $token) {
+    // Convert pseudoconstants using metadata
+    if ($value && is_numeric($value)) {
+      $allFields = CRM_Contact_BAO_Contact::exportableFields('All');
+      if (!empty($allFields[$token]['pseudoconstant'])) {
+        $value = CRM_Core_PseudoConstant::getLabel('CRM_Contact_BAO_Contact', $token, $value);
+      }
+    }
+    elseif ($value && CRM_Utils_String::endsWith($token, '_date')) {
+      $value = CRM_Utils_Date::customFormat($value);
+    }
+    return $value;
   }
 
 }

--- a/tests/phpunit/CRM/Core/BAO/MessageTemplateTest.php
+++ b/tests/phpunit/CRM/Core/BAO/MessageTemplateTest.php
@@ -2,6 +2,7 @@
 
 use Civi\Api4\Address;
 use Civi\Api4\Contact;
+use Civi\Token\TokenProcessor;
 
 /**
  * Class CRM_Core_BAO_MessageTemplateTest
@@ -17,7 +18,7 @@ class CRM_Core_BAO_MessageTemplateTest extends CiviUnitTestCase {
    * @throws \CRM_Core_Exception
    */
   public function tearDown():void {
-    $this->quickCleanup(['civicrm_address', 'civicrm_phone', 'civicrm_im', 'civicrm_website', 'civicrm_openid', 'civicrm_email']);
+    $this->quickCleanup(['civicrm_address', 'civicrm_phone', 'civicrm_im', 'civicrm_website', 'civicrm_openid', 'civicrm_email'], TRUE);
     parent::tearDown();
   }
 
@@ -141,13 +142,7 @@ London, 90210
   public function testContactTokens(): void {
     $this->createCustomGroupWithFieldsOfAllTypes([]);
     $tokenData = $this->getAllContactTokens();
-    $this->callAPISuccess('Contact', 'create', $tokenData);
-    $address = $this->callAPISuccess('Address', 'create', array_merge($tokenData, ['is_primary' => TRUE]));
-    $this->callAPISuccess('Phone', 'create', array_merge($tokenData, ['is_primary' => TRUE]));
-    $this->callAPISuccess('Email', 'create', array_merge($tokenData, ['is_primary' => TRUE]));
-    $this->callAPISuccess('Website', 'create', array_merge($tokenData, ['is_primary' => TRUE]));
-    $this->callAPISuccess('Im', 'create', ['is_primary' => TRUE, 'name' => $tokenData['im'], 'provider_id' => $tokenData['im_provider'], 'contact_id' => $tokenData['contact_id']]);
-    $this->callAPISuccess('OpenID', 'create', array_merge($tokenData, ['is_primary' => TRUE, 'contact_id' => $tokenData['contact_id'], 'openid' => $tokenData['openid']]));
+    $address = $this->setupContactFromTokeData($tokenData);
 
     CRM_Core_Smarty::singleton()->assign('pre_assigned_smarty', 'wee');
     // This string contains the 4 types of possible replaces just to be sure they
@@ -164,97 +159,48 @@ London, 90210
       'subject' => $tokenString . ' ',
       'text' => $tokenString,
     ], FALSE, $tokenData['contact_id'], ['passed_smarty' => 'whoa']);
-    $checksum = substr($messageContent['html'], (strpos($messageContent['html'], 'cs=') + 3), 47);
-    $contact = Contact::get(FALSE)->addWhere('id', '=', $tokenData['contact_id'])->setSelect(['modified_date', 'employer_id'])->execute()->first();
     $expected = 'weewhoa
 Default Domain Name
-contact_type:Individual
-do_not_email:1
-do_not_phone:
-do_not_mail:1
-do_not_sms:1
-do_not_trade:1
-is_opt_out:1
-external_identifier:blah
-sort_name:Smith, Robert
-display_name:Mr. Robert Smith II
-nick_name:Bob
-image_URL:https://example.com
-preferred_communication_method:
-preferred_language:fr_CA
-preferred_mail_format:Both
-hash:xyz
-contact_source:Contact Source
-first_name:Robert
-middle_name:Frank
-last_name:Smith
-individual_prefix:Mr.
-individual_suffix:II
-formal_title:Dogsbody
-communication_style:Formal
-job_title:Busy person
-gender:Female
-birth_date:December 31st, 1998
-current_employer_id:' . $contact['employer_id'] . '
-contact_is_deleted:
-created_date:January 1st, 2020 12:00 AM
-modified_date:' . CRM_Utils_Date::customFormat($contact['modified_date']) . '
-addressee:Mr. Robert Frank Smith II
-email_greeting:Dear Robert
-postal_greeting:Dear Robert
-current_employer:Unit Test Organization
-location_type:Home
-address_id:' . $address['id'] . '
-street_address:Street Address
-street_number:123
-street_number_suffix:S
-street_name:Main St
-street_unit:45B
-supplemental_address_1:Round the corner
-supplemental_address_2:Up the road
-supplemental_address_3:By the big tree
-city:New York
-postal_code_suffix:4578
-postal_code:90210
-geo_code_1:48.858093
-geo_code_2:2.294694
-manual_geo_code:1
-address_name:The white house
-master_id:' . $tokenData['master_id'] . '
-county:
-state_province:TX
-country:United States
-phone:123-456
-phone_ext:77
-phone_type_id:
-phone_type:Mobile
-email:anthony_anderson@civicrm.org
-on_hold:
-signature_text:Yours sincerely
-signature_html:&lt;p&gt;Yours&lt;/p&gt;
-im_provider:1
-im:IM Screen Name
-openid:OpenID
-world_region:America South, Central, North and Caribbean
-url:http://civicrm.org
-custom_1:Bobsled
-custom_2:Red
-custom_3:01/20/2021 12:00AM
-custom_4:999
-custom_5:<a href="http://civicrm.org" target="_blank">http://civicrm.org</a>
-custom_7:New Zealand
-custom_8:France, Canada
-custom_9:Mr. Spider Man II
-custom_10:Queensland
-custom_11:Victoria, New South Wales
-custom_12:Yes
-custom_13:Purple
-checksum:cs=' . $checksum . '
-contact_id:' . $tokenData['contact_id'] . '
 ';
+    $expected .= $this->getExpectedContactOutput($address['id'], $tokenData, $messageContent['html']);
     $this->assertEquals($expected, $messageContent['html']);
     $this->assertEquals($expected, $messageContent['text']);
     $this->assertEquals(rtrim(str_replace("\n", ' ', $expected)), $messageContent['subject']);
+  }
+
+  /**
+   * Test the contact tokens rendered by the token processor.
+   *
+   * This test will be obsolete once the renderMessageTemplate
+   * function uses the token processor - at that point the test above
+   * will be testing the same thing.
+   *
+   * @throws \API_Exception
+   * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
+   */
+  public function testContactTokensRenderedByTokenProcessor(): void {
+    $this->createCustomGroupWithFieldsOfAllTypes([]);
+    $tokenData = $this->getAllContactTokens();
+    // @todo - these 2 still need fixing/ syncing.
+    unset($tokenData['preferred_communication_method'], $tokenData['addressee']);
+    $address = $this->setupContactFromTokeData($tokenData);
+    $tokenString ='';
+    foreach (array_keys($tokenData) as $key) {
+      $tokenString .= "{$key}:{contact.{$key}}\n";
+    }
+    $tokenProcessor = new TokenProcessor(\Civi::dispatcher(), []);
+    $tokenProcessor->addMessage('html', $tokenString, 'text/html');
+    $tokenProcessor->addRow(['contactId' => $tokenData['contact_id']]);
+    $tokenProcessor->evaluate();
+    $rendered = '';
+    foreach ($tokenProcessor->getRows() as $row) {
+      $rendered = (string) $row->render('html');
+    }
+    $expected = $this->getExpectedContactOutput($address['id'], $tokenData, $rendered);
+    // @todo - fix these 2 & stop stripping them out.
+    $expected = str_replace(["preferred_communication_method:\n", "addressee:Mr. Robert Frank Smith II\n"], '', $expected);
+    $this->assertEquals($expected, $rendered);
   }
 
   /**
@@ -400,6 +346,130 @@ contact_id:' . $tokenData['contact_id'] . '
       'checksum' => 'Checksum',
       'contact_id' => $this->individualCreate(['first_name' => 'Peter', 'last_name' => 'Parker']),
     ];
+  }
+
+  /**
+   * @param array $tokenData
+   *
+   * @return array|int
+   * @throws \CRM_Core_Exception
+   */
+  protected function setupContactFromTokeData(array $tokenData) {
+    $this->callAPISuccess('Contact', 'create', $tokenData);
+    $address = $this->callAPISuccess('Address', 'create', array_merge($tokenData, ['is_primary' => TRUE]));
+    $this->callAPISuccess('Phone', 'create', array_merge($tokenData, ['is_primary' => TRUE]));
+    $this->callAPISuccess('Email', 'create', array_merge($tokenData, ['is_primary' => TRUE]));
+    $this->callAPISuccess('Website', 'create', array_merge($tokenData, ['is_primary' => TRUE]));
+    $this->callAPISuccess('Im', 'create', [
+      'is_primary' => TRUE,
+      'name' => $tokenData['im'],
+      'provider_id' => $tokenData['im_provider'],
+      'contact_id' => $tokenData['contact_id']
+    ]);
+    $this->callAPISuccess('OpenID', 'create', array_merge($tokenData, [
+      'is_primary' => TRUE,
+      'contact_id' => $tokenData['contact_id'],
+      'openid' => $tokenData['openid']
+    ]));
+    return $address;
+  }
+
+  /**
+   * @param array|null $contact
+   * @param $id
+   * @param array $tokenData
+   * @param bool $checksum
+   *
+   * @return string
+   */
+  protected function getExpectedContactOutput($id, array $tokenData, string $actualOutput): string {
+    $checksum = substr($actualOutput, (strpos($actualOutput, 'cs=') + 3), 47);
+    $contact = Contact::get(FALSE)->addWhere('id', '=', $tokenData['contact_id'])->setSelect(['modified_date', 'employer_id'])->execute()->first();
+    $expected = 'contact_type:Individual
+do_not_email:1
+do_not_phone:
+do_not_mail:1
+do_not_sms:1
+do_not_trade:1
+is_opt_out:1
+external_identifier:blah
+sort_name:Smith, Robert
+display_name:Mr. Robert Smith II
+nick_name:Bob
+image_URL:https://example.com
+preferred_communication_method:
+preferred_language:fr_CA
+preferred_mail_format:Both
+hash:xyz
+contact_source:Contact Source
+first_name:Robert
+middle_name:Frank
+last_name:Smith
+individual_prefix:Mr.
+individual_suffix:II
+formal_title:Dogsbody
+communication_style:Formal
+job_title:Busy person
+gender:Female
+birth_date:December 31st, 1998
+current_employer_id:' . $contact['employer_id'] . '
+contact_is_deleted:
+created_date:January 1st, 2020 12:00 AM
+modified_date:' . CRM_Utils_Date::customFormat($contact['modified_date']) . '
+addressee:Mr. Robert Frank Smith II
+email_greeting:Dear Robert
+postal_greeting:Dear Robert
+current_employer:Unit Test Organization
+location_type:Home
+address_id:' . $id . '
+street_address:Street Address
+street_number:123
+street_number_suffix:S
+street_name:Main St
+street_unit:45B
+supplemental_address_1:Round the corner
+supplemental_address_2:Up the road
+supplemental_address_3:By the big tree
+city:New York
+postal_code_suffix:4578
+postal_code:90210
+geo_code_1:48.858093
+geo_code_2:2.294694
+manual_geo_code:1
+address_name:The white house
+master_id:' . $tokenData['master_id'] . '
+county:
+state_province:TX
+country:United States
+phone:123-456
+phone_ext:77
+phone_type_id:
+phone_type:Mobile
+email:anthony_anderson@civicrm.org
+on_hold:
+signature_text:Yours sincerely
+signature_html:&lt;p&gt;Yours&lt;/p&gt;
+im_provider:1
+im:IM Screen Name
+openid:OpenID
+world_region:America South, Central, North and Caribbean
+url:http://civicrm.org
+custom_1:Bobsled
+custom_2:Red
+custom_3:01/20/2021 12:00AM
+custom_4:999
+custom_5:<a href="http://civicrm.org" target="_blank">http://civicrm.org</a>
+custom_7:New Zealand
+custom_8:France, Canada
+custom_9:Mr. Spider Man II
+custom_10:Queensland
+custom_11:Victoria, New South Wales
+custom_12:Yes
+custom_13:Purple
+checksum:cs=' . $checksum . '
+contact_id:' . $tokenData['contact_id'] . '
+';
+    return $expected;
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
There are 2 ways in the code that tokens can be rendered -
- legacy Utils_Token class (the main way)
- the token processor (the preferred way)

We want to consistently use the token processor - but in order to do so we need to align it as a replacement.

Currently it is not rendering a few fields and presenting the db values, rather than the formatted values of the custom fields.


Before
----------------------------------------
The 'main' token routine was rendering tokens per the image on the right - the token processor was rendering them per the image on the left.

![image](https://user-images.githubusercontent.com/336308/111109400-89ad0f00-85bf-11eb-9523-bb78773eac20.png)
![image](https://user-images.githubusercontent.com/336308/111109440-99c4ee80-85bf-11eb-873f-0168be7b70fc.png)
![image](https://user-images.githubusercontent.com/336308/111109485-b2350900-85bf-11eb-8cd7-62626d822732.png)
![image](https://user-images.githubusercontent.com/336308/111109509-c0832500-85bf-11eb-9d1c-12bb068404bc.png)


After
----------------------------------------
Both render them per the image on the right 

The main differences are that the token processor was outputing the data directly from the database but now it is formatting. In addition it was unable to render multiple option values (that is not captured in the screen shot as I had to fix that to get the test to complete.

Technical Details
----------------------------------------
This revists 2 changes 
1)  https://issues.civicrm.org/jira/browse/CRM-13161 - the expectations that ```$value``` might hold an array like [0 => 'id', 1 => 'label'] no longer appear to be true -and I've added tests for all fields that are offered up
2) The decision not to format this data at this point seems like a non decision https://github.com/civicrm/civicrm-core/commit/a0fcf9925d8ba218d80d1f4ac80819b267cf7c5f#diff-3f93091ccbe99a7c1ae88473057539b1021099b37852cfea68ff948f9f8d1a86R66 - it looks like the custom data was not available and hence code was added to fetch it whereas in all other places it was already available and code was added to format it


Comments
----------------------------------------
If we merge this it unblocks a lot of code rationalisation but it DOES change token behaviour and we need to warn people. I believe it affects scheduled reminders and CiviMail in some cases.

We probably should just do a pre-upgrade message and warn people. 

This is groundwork for https://github.com/civicrm/civicrm-core/pull/19806