### PR TITLE
Fixed issue dev/core#2449: remove an unnecessary call to cleanMoney

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -2772,10 +2772,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
       if (!empty($form->_paymentProcessor)) {
         $contributionParams['payment_instrument_id'] = $paymentParams['payment_instrument_id'] = $form->_paymentProcessor['payment_instrument_id'];
       }
-
-      // @todo this is the wrong place for this - it should be done as close to form submission
-      // as possible
-      $paymentParams['amount'] = CRM_Utils_Rule::cleanMoney($paymentParams['amount']);
+      
       $contribution = CRM_Contribute_Form_Contribution_Confirm::processFormContribution(
         $form,
         $paymentParams,

--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -2772,7 +2772,6 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
       if (!empty($form->_paymentProcessor)) {
         $contributionParams['payment_instrument_id'] = $paymentParams['payment_instrument_id'] = $form->_paymentProcessor['payment_instrument_id'];
       }
-      
       $contribution = CRM_Contribute_Form_Contribution_Confirm::processFormContribution(
         $form,
         $paymentParams,


### PR DESCRIPTION
Overview
----------------------------------------

Removes an unnecessary call to `CRM_Utils_Rule::cleanMoney`

Before
----------------------------------------
When your locaization settings decimal separator where set to `,` and you had a contribution page with an amount of `12,987654321` it resulted in paying a wrong amount. 

After
----------------------------------------
Through the contribution page the right amount is paid. 

Technical Details
----------------------------------------

The call to `CRM_Utils_Rule::cleanMoney` is removed which was at a weird place. We should sanitize/validate/clean user input early. 

Comments
----------------------------------------

See https://lab.civicrm.org/dev/core/-/issues/2449
