### PR TITLE
Fix for dev/core#2446: issue with custom money fields and drop downs.

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -1517,7 +1517,7 @@ SELECT id
         $value = 0;
       }
 
-      if ($customFields[$customFieldId]['data_type'] == 'Money') {
+      if ($customFields[$customFieldId]['data_type'] == 'Money' && $customFields[$customFieldId]['html_type'] == 'Text') {
         $value = CRM_Utils_Rule::cleanMoney($value);
       }
     }
@@ -2695,6 +2695,9 @@ WHERE cf.id = %1 AND cg.is_multiple = 1";
     }
     if ($field->serialize) {
       $params['type'] = 'varchar(255)';
+    }
+    if ($field->data_type == 'Money' && $field->html_type !== 'Text') {
+      $params['type'] = 'varchar(512)';
     }
     if (isset($field->default_value)) {
       $params['default'] = "'{$field->default_value}'";


### PR DESCRIPTION
Overview
----------------------------------------

There is an issue with custom fields of type money with a drop down. 
As soon as localization setting decimal separator is set to `,` and you have an option value of `12,34567899` the selected value disappears. 

This was caused by calling `CRM_Utils_Rule::cleanMoney` on the selected value and because the column of the database of a money field (with option values) was set to `decimal (20,2)`. Meaning that a value with more than two decimals could exists in the option value but not in the actual column in the database. 

Before
----------------------------------------

If a custom drop down money field held a value of `12,3456789` and localization setting decimal separator was set to `,` the selected value was not saved.

After
----------------------------------------

If a custom drop down money field held a value of `12,3456789` and localization setting decimal separator was set to `,` the selected value is saved.

Technical Details
----------------------------------------

This PR contains two changes:

1. Only call `CRM_Utils_Rule::cleanMoney` when the input data type is `Money` **and when the input html type is `Text`**
2. Change the column database type from money to varchar (512) as soon as in the input data type is Money and html type is not Text. Then the column type is exactly the same as the option value table. 

Comments
----------------------------------------

See this issue: https://lab.civicrm.org/dev/core/-/issues/2446
