### PR TITLE
Fix for dev/core#2447: wrong event fee stored

### DIFF
--- a/CRM/Event/BAO/Participant.php
+++ b/CRM/Event/BAO/Participant.php
@@ -80,10 +80,6 @@ class CRM_Event_BAO_Participant extends CRM_Event_DAO_Participant {
       $params['participant_fee_amount'] = CRM_Utils_Rule::cleanMoney($params['participant_fee_amount']);
     }
 
-    if (!empty($params['fee_amount'])) {
-      $params['fee_amount'] = CRM_Utils_Rule::cleanMoney($params['fee_amount']);
-    }
-
     // ensure that role ids are encoded as a string
     if (isset($params['role_id']) && is_array($params['role_id'])) {
       if (in_array(key($params['role_id']), CRM_Core_DAO::acceptedSQLOperators(), TRUE)) {


### PR DESCRIPTION
Overview
----------------------------------------

Removed a late call to `CRM_Utils_Rule::cleanMoney` so that a price set with a value of `12,987654321` and localization decimal separator setting of `,` works for the event fee.

Before
----------------------------------------

If you had the following:

* Localization decimal separator setting set to `,`
* An event price set field with a value of `12,987654321`

After registration the `event_fee` in the database would contain `12987654321.00` (note the move of the decimal sign).

After
----------------------------------------

After registration the `event_fee` in the database would contain `12.99` (note the rounding which is correct).

Technical Details
----------------------------------------

In the function `CRM_Event_BAO_Participant::add` a call was done to `CRM_Utils_Rule::cleanMoney`. 
This call is removed as we should sanitize/validate/clean early and to clean fee_amount here is way too late and causing this issue. 

Comments
----------------------------------------

See: https://lab.civicrm.org/dev/core/-/issues/2447
