### PR TITLE
Tighten mysql mode in test environment

### DIFF
--- a/CRM/Contact/BAO/GroupContactCache.php
+++ b/CRM/Contact/BAO/GroupContactCache.php
@@ -483,6 +483,8 @@ WHERE  id IN ( $groupIDs )
       CRM_Core_DAO::executeQuery("INSERT IGNORE INTO $tempTable (group_id, contact_id) {$contactQuery}");
     }
 
+    CRM_Core_DAO::reenableFullGroupByMode();
+
     if ($group->children) {
 
       // Store a list of contacts who are removed from the parent group

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -372,12 +372,13 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
 
     $this->renameLabels();
     $this->_sethtmlGlobals();
+    $this->ensureMySQLMode(['IGNORE_SPACE', 'ERROR_FOR_DIVISION_BY_ZERO', 'STRICT_TRANS_TABLES']);
   }
 
   /**
    * Read everything from the datasets directory and insert into the db.
    */
-  public function loadAllFixtures() {
+  public function loadAllFixtures(): void {
     $fixturesDir = __DIR__ . '/../../fixtures';
 
     CRM_Core_DAO::executeQuery("SET FOREIGN_KEY_CHECKS = 0;");
@@ -3788,6 +3789,17 @@ WHERE a1.is_primary = 0
   AND a2.id IS NULL
   AND a1.contact_id IS NOT NULL) as primary_descrepancies
     '));
+  }
+
+  /**
+   * Ensure the specified mysql mode/s are activated.
+   *
+   * @param array $modes
+   */
+  protected function ensureMySQLMode(array $modes): void {
+    $currentModes = array_fill_keys(CRM_Utils_SQL::getSqlModes(), 1);
+    $currentModes = array_merge($currentModes, array_fill_keys($modes, 1));
+    CRM_Core_DAO::executeQuery("SET GLOBAL sql_mode = '" . implode(',', array_keys($currentModes)) . "'");
   }
 
 }

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -3800,6 +3800,7 @@ WHERE a1.is_primary = 0
     $currentModes = array_fill_keys(CRM_Utils_SQL::getSqlModes(), 1);
     $currentModes = array_merge($currentModes, array_fill_keys($modes, 1));
     CRM_Core_DAO::executeQuery("SET GLOBAL sql_mode = '" . implode(',', array_keys($currentModes)) . "'");
+    CRM_Core_DAO::executeQuery("SET sql_mode = '" . implode(',', array_keys($currentModes)) . "'");
   }
 
 }


### PR DESCRIPTION
At least one test fails (and the corresponding bug appears on our live site)
with the mysql mode IGNORE_SPACE.

Let's throw it at jenkins & see how many friends it has

Update - no fails here -but some locally - some combo must be in play