### PR TITLE
Fix to dev#2462. Leave end_date as-it-is (if empty) when editing a li…

### DIFF
--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -261,7 +261,11 @@ class CRM_Member_BAO_Membership extends CRM_Member_DAO_Membership {
           // CRM_Core_Error::deprecatedWarning('Relying on the BAO to clean up dates is deprecated. Call membership create via the api');
         }
         if (!empty($params['id']) && empty($params[$dateField])) {
-          $fieldsToLoad[] = $dateField;
+          // Fix to dev#2462. Leave end_date as-it-is (if empty) when editing a lifetime Membership
+          $membershipType = CRM_Member_BAO_MembershipType::getMembershipType($params['membership_type_id']);
+          if ($membershipType["duration_unit"] != "lifetime") {
+            $fieldsToLoad[] = $dateField;
+          }
         }
       }
       if (!empty($fieldsToLoad)) {


### PR DESCRIPTION
…fetime Membership

Overview
----------------------------------------
When editing a Membership of duration unit lifetime, and I want to clean `end_date` field (i.e.: Status Current), the field is always kept with original value after saving.

[Original Issue #2462](https://lab.civicrm.org/dev/core/-/issues/2462)
