### PR TITLE
dev/core#2464: Fix Drupal Base 'isFrontEndPage' Returns Wrong Value After Saving A Settings Page

### DIFF
--- a/CRM/Admin/Form/Setting.php
+++ b/CRM/Admin/Form/Setting.php
@@ -117,6 +117,7 @@ class CRM_Admin_Form_Setting extends CRM_Core_Form {
     Civi::cache('session')->clear();
     CRM_Utils_System::flushCache();
     CRM_Core_Resources::singleton()->resetCacheCode();
+    $this->rebuildMenu();
 
     CRM_Core_Session::setStatus(" ", ts('Changes Saved'), "success");
   }

--- a/CRM/Admin/Form/Setting/Path.php
+++ b/CRM/Admin/Form/Setting/Path.php
@@ -58,8 +58,6 @@ class CRM_Admin_Form_Setting_Path extends CRM_Admin_Form_Setting {
 
   public function postProcess() {
     parent::postProcess();
-
-    parent::rebuildMenu();
   }
 
 }

--- a/CRM/Admin/Form/Setting/Url.php
+++ b/CRM/Admin/Form/Setting/Url.php
@@ -81,8 +81,6 @@ class CRM_Admin_Form_Setting_Url extends CRM_Admin_Form_Setting {
     $session->getStatus(TRUE);
 
     parent::postProcess();
-
-    parent::rebuildMenu();
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
This [PR](https://github.com/civicrm/civicrm-core/pull/18397) fixed the way civicrm tells a civicrm page from a non civicrm page. 
However when a settings page such as Civicase settings (civicrm/admin/setting/case), Mailing settings (civicrm/admin/mail) and most of the setting pages are saved, the `CRM_Utils_System_DrupalBase::isFrontEndPage` function reports that the `civicrm/admin` page redirected to after a setting is saved is a frontend page (Which is actually a backend civicrm page) which could have a significant impact on functions that rely on this. For example, the shoreditch theme [relies on this function](https://github.com/civicrm/org.civicrm.shoreditch/blob/master/shoreditch.php#L188) to know whether the shoreditch JS and CSS assets need to be included for a particular page. This wrong value makes the shoreditch theme not to be applied after saving the settings page and the page is not shoreditch themed and loses the styling. Refreshing the page a second time however fixes the issue but this glitch needs to be fixed. 

Before
----------------------------------------
Page without shoreditch style applied immediately after saving a settings page
<img width="1279" alt="Administer CiviCRM | c8008 2021-03-17 14-14-56" src="https://user-images.githubusercontent.com/6951813/111481127-f268c880-8732-11eb-81ea-fe822d34ab5f.png">


After
----------------------------------------
Page with shoreditch style applied immediately after saving a settings page
<img width="1280" alt="Administer CiviCRM | c8008 2021-03-17 14-15-12" src="https://user-images.githubusercontent.com/6951813/111481180-feed2100-8732-11eb-8183-408fc0453a36.png">


Technical Details
----------------------------------------
In the Post Process function for the Admin Setting form class which is the base class for most settings page, this [line](https://github.com/civicrm/civicrm-core/blob/master/CRM/Admin/Form/Setting.php#L115) clears the db cache including the `civicrm_menu` table. When the form is redirected to a new page after saving, the civicrm initialization calls the `civicrm_html_head` function which calls this [line](https://github.com/civicrm/civicrm-core/blob/master/CRM/Utils/System/DrupalBase.php#L662) in the `CRM_Utils_System_DrupalBase::isFrontEndPage` 
 function, because the menu table has been cleared and empty, the `$item` variable is empty and the given path is returned as a frontend page, as a result, necessary shoreditch styles are not added. 

The fix in this PR is to call the form's menu rebuild function [here](https://github.com/civicrm/civicrm-core/blob/master/CRM/Admin/Form/Setting.php#L120) to rebuild the menu table after it is cleared, same as is done for few of the forms e.g [the URL setting form](https://github.com/civicrm/civicrm-core/blob/master/CRM/Admin/Form/Setting/Url.php#L85) which is why the few forms that implement this does not have this issue. Since the rebuild function is now present in the `CRM_Admin_Form_Setting`, the function is removed from some child settings class calling this function.

