### PR TITLE
Remove now-empty function

### DIFF
--- a/CRM/Admin/Form/Setting/Path.php
+++ b/CRM/Admin/Form/Setting/Path.php
@@ -31,6 +31,8 @@ class CRM_Admin_Form_Setting_Path extends CRM_Admin_Form_Setting {
 
   /**
    * Build the form object.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function buildQuickForm() {
     CRM_Utils_System::setTitle(ts('Settings - Upload Directories'));
@@ -54,10 +56,6 @@ class CRM_Admin_Form_Setting_Path extends CRM_Admin_Form_Setting {
       );
     }
 
-  }
-
-  public function postProcess() {
-    parent::postProcess();
   }
 
 }


### PR DESCRIPTION
follow up on https://github.com/civicrm/civicrm-core/pull/19823/files#diff-df26b0295128798bac0302eec663d681ea75de4398dfc59b6d193d251ccde1bbL61