### PR TITLE
dev/core#2463 - Remove loop that since at least 5.23 does nothing for single cases and crashes for multiple, and for multiple recipients only uses the last activity id for 5.36+

### DIFF
--- a/CRM/Contact/Form/Task/EmailTrait.php
+++ b/CRM/Contact/Form/Task/EmailTrait.php
@@ -447,20 +447,6 @@ trait CRM_Contact_Form_Task_EmailTrait {
         'plural' => '%count Messages Not Sent',
       ]), 'info');
     }
-
-    if (isset($this->_caseId)) {
-      // if case-id is found in the url, create case activity record
-      $cases = explode(',', $this->_caseId);
-      foreach ($cases as $key => $val) {
-        if (is_numeric($val)) {
-          $caseParams = [
-            'activity_id' => $activityId,
-            'case_id' => $val,
-          ];
-          CRM_Case_BAO_Case::processCaseActivity($caseParams);
-        }
-      }
-    }
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/2463

A feature was added many many years ago which allows passing multiple case id's in the url to the email activity form. It's been broken since 5.23 and became buggy even before that. The changes in 5.36 to record a separate activity for each recipient compound the problem. In order to fix it, it would also require taking into account how to deal with case tokens for multiple cases and multiple recipients, and the token stuff is what broke it in 5.23.

Hence propose to remove it, and possibly in a future PR, make the resulting activity ids available to hooks, which is what I was originally trying to get at when this came up since there's now multiple activities.

Before
----------------------------------------
1. Create at least 2 cases.
1. Visit http://your.site/civicrm/activity/email/add?reset=1&action=add&atype=3&cid=2&caseid=1,2 where caseid's 1 and 2 are some case ids and cid is some contact.
1. Fill it out and send the email.
1. Kapow! `Not a valid integer`.

After
----------------------------------------
No change for single case ids in the url, which is what it looks like when you use the email icon on Manage Case in the roles section.
Still a crash if you use multiple case ids in the url, but that's the point.

Technical Details
----------------------------------------
This is hard to describe briefly. See ticket. But the main part is that the loop isn't necessary for single case ids because the change to use the api introduced by the 5.23 breaking change takes care of it already.

Comments
----------------------------------------
There's some existing test coverage at https://github.com/civicrm/civicrm-core/blob/d5d750b4e96730cde63ce4c599080642da8b2eea/tests/phpunit/CRM/Activity/BAO/ActivityTest.php#L1518, where it shows that even without this loop an email still gets filed on the case.
