### PR TITLE
Add .clear class to break inline flow on social share footer

### DIFF
--- a/templates/CRM/common/SocialNetwork.tpl
+++ b/templates/CRM/common/SocialNetwork.tpl
@@ -17,18 +17,16 @@
         <a href="https://facebook.com/sharer/sharer.php?u={$url|escape:'url'}" target="_blank" class="btn btn-default" role="button">{ts}Share on Facebook{/ts}</a>
         <a href="ttps://www.linkedin.com/shareArticle?mini=true&amp;url={$url|escape:'url'}&amp;title={$title}" target="_blank" rel="noopener" class="btn btn-default">{ts}Share on LinkedIn{/ts}</a>
     {else}
-    	<button onclick="window.open('https://twitter.com/intent/tweet?url={$url|escape:'url'}&amp;text={$title}','_blank')" type="button" class="btn btn-default crm-button" id="crm-tw"><i aria-hidden="true" class="crm-i fa-twitter"></i>&nbsp;&nbsp;{ts}Tweet{/ts}</button>
+        <button onclick="window.open('https://twitter.com/intent/tweet?url={$url|escape:'url'}&amp;text={$title}','_blank')" type="button" class="btn btn-default crm-button" id="crm-tw"><i aria-hidden="true" class="crm-i fa-twitter"></i>&nbsp;&nbsp;{ts}Tweet{/ts}</button>
         <button onclick="window.open('https://facebook.com/sharer/sharer.php?u={$url|escape:'url'}','_blank')" type="button" class="btn btn-default crm-button" role="button" id="crm-fb"><i aria-hidden="true" class="crm-i fa-facebook"></i>&nbsp;&nbsp;{ts}Share on Facebook{/ts}</button>
         <button onclick="window.open('https://www.linkedin.com/shareArticle?mini=true&amp;url={$url|escape:'url'}&amp;title={$title}','_blank')" type="button" rel="noopener" class="btn btn-default crm-button" id="crm-li"><i aria-hidden="true" class="crm-i fa-linkedin"></i>&nbsp;&nbsp;{ts}Share on LinkedIn{/ts}</button>
         <button onclick="window.open('mailto:?subject={$title}&amp;body={$url|escape:'url'}','_self')" type="button" rel="noopener" class="btn btn-default crm-button" id="crm-email"><i aria-hidden="true" class="crm-i fa-envelope"></i>&nbsp;&nbsp;{ts}Email{/ts}</button>
-        {/if}
+    {/if}
     {if $pageURL}
-    	{if $emailMode neq true}
-        <br/>
-		{/if}
-    <br/>
-    <p><strong>{ts}You can also share the below link in an email or on your website:{/ts}</strong><br />
+    <p class="clear">
+    <br/><strong>{ts}You can also share the below link in an email or on your website:{/ts}</strong><br />
     <a href="{$pageURL}">{$pageURL}</a></p>
     {else}
+    <div class="clear"></div>
     {/if}
 </div>


### PR DESCRIPTION
Overview
----------------------------------------
`.crm-button` was added to the share links in #18880 and has a `float: left`, which can in some front-end themes cause the subsequent line to flow back inline. This addresses that by adding `.clear`, and repositions the `<br />` to ensure space between the buttons and this next line. Also removes a redundant `<br />` and adds a `div.clear`, for when no page URL is included, just in case.

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/1175967/111644260-f44c8d80-87ff-11eb-8c29-53f740a82cd6.png)

After
----------------------------------------
![image](https://user-images.githubusercontent.com/1175967/111643993-b2bbe280-87ff-11eb-84ba-77be897258fd.png)

Comments
----------------------------------------
This issue didn't emerge during previous testing - and isn't widespread - ie see https://wpmaster.demo.civicrm.org/event-page/. I think it's linked with how the buttons themselves are given a height in the css defining them (be it via Civi, Civi theme or CMS theme). This fix should just make the layout a bit more robust across theme variants.