### PR TITLE
Fix deprecated Redis::delete() (issue #2468)

### DIFF
--- a/CRM/Utils/Cache/Redis.php
+++ b/CRM/Utils/Cache/Redis.php
@@ -145,7 +145,7 @@ class CRM_Utils_Cache_Redis implements CRM_Utils_Cache_Interface {
    */
   public function delete($key) {
     CRM_Utils_Cache::assertValidKey($key);
-    $this->_cache->delete($this->_prefix . $key);
+    $this->_cache->del($this->_prefix . $key);
     return TRUE;
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
We receive a notification on flushing CiviCRM cache

```
Deprecated function: Function Redis::delete() is deprecated in CRM_Utils_Cache_Redis->delete() (line 148 of /var/www/html/vendor/civicrm/civicrm-core/CRM/Utils/Cache/Redis.php). 
```

Issue: https://lab.civicrm.org/dev/core/-/issues/2468

Reproduction steps
----------------------------------------
1. Setup environment like below
1. Flush CiviCRM cache

Environment information
----------------------------------------

* __CiviCRM:__ 5.35.1
* __PHP:__ 7.4.15
* __CMS:__ Drupal 8
* __Redis__ 5.3.3 
