### PR TITLE
Upgrade angularJs from 1.8.0 to 1.8.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -129,7 +129,7 @@
         "path": "bower_components/{$id}"
       },
       "angular": {
-        "url": "https://github.com/angular/bower-angular/archive/v1.8.0.zip"
+        "url": "https://github.com/angular/bower-angular/archive/v1.8.2.zip"
       },
       "angular-bootstrap": {
         "url": "https://github.com/angular-ui/bootstrap-bower/archive/2.5.0.zip"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2d1dfc8bddd169a9064a89c693bb5218",
+    "content-hash": "ec5c7533d5c9d49d54530eb94958e55b",
     "packages": [
         {
             "name": "adrienrn/php-mimetyper",
@@ -3116,20 +3116,6 @@
                 "polyfill",
                 "portable",
                 "shim"
-            ],
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
             ],
             "time": "2020-05-12T16:47:27+00:00"
         },


### PR DESCRIPTION
Overview
----------------------------------------
Per https://lab.civicrm.org/dev/core/-/issues/1818
this gives a minor version bump to the AngularJS library.

Before
----------------------------------------
1.8.0

After
----------------------------------------
1.8.2

Notes
--------------
According to the [release notes](https://github.com/angular/angular.js/blob/master/CHANGELOG.md) there are no breaking changes in this upgrade.