### PR TITLE
[NFC] Add in Void statements on varios Core Ext Tests to future support PHP…

### DIFF
--- a/ext/afform/core/tests/phpunit/CRM/Afform/UtilTest.php
+++ b/ext/afform/core/tests/phpunit/CRM/Afform/UtilTest.php
@@ -56,7 +56,7 @@ class CRM_Afform_UtilTest extends \PHPUnit\Framework\TestCase implements Headles
    * @dataProvider getNameExamples
    * @throws \Exception
    */
-  public function testNameConversion($inputFileName, $toFormat, $expected) {
+  public function testNameConversion($inputFileName, $toFormat, $expected): void {
     $actual = _afform_angular_module_name($inputFileName, $toFormat);
     $this->assertEquals($expected, $actual);
   }

--- a/ext/afform/core/tests/phpunit/Civi/Afform/FilterTest.php
+++ b/ext/afform/core/tests/phpunit/Civi/Afform/FilterTest.php
@@ -34,7 +34,7 @@ class FilterTest extends \PHPUnit\Framework\TestCase implements HeadlessInterfac
     return $htmls[$fileName];
   }
 
-  public function testDefnInjection() {
+  public function testDefnInjection(): void {
     $inputHtml = sprintf(self::PERSON_TPL,
       '<div af-fieldset="person"><af-field name="first_name" /></div>');
     $filteredHtml = $this->htmlFilter('~/afform/MyForm.aff.html', $inputHtml);
@@ -46,7 +46,7 @@ class FilterTest extends \PHPUnit\Framework\TestCase implements HeadlessInterfac
     $this->assertEquals('First Name', $myField['defn']['label']);
   }
 
-  public function testDefnInjectionNested() {
+  public function testDefnInjectionNested(): void {
     $inputHtml = sprintf(self::PERSON_TPL,
       '<span><div af-fieldset="person"><foo><af-field name="first_name" /></foo></div></span>');
     $filteredHtml = $this->htmlFilter('~/afform/MyForm.aff.html', $inputHtml);
@@ -58,7 +58,7 @@ class FilterTest extends \PHPUnit\Framework\TestCase implements HeadlessInterfac
     $this->assertEquals('First Name', $myField['defn']['label']);
   }
 
-  public function testDefnOverrideTitle() {
+  public function testDefnOverrideTitle(): void {
     $inputHtml = sprintf(self::PERSON_TPL,
       '<div af-fieldset="person"><af-field name="first_name" defn="{label: \'Given name\'}" /></div>');
     $filteredHtml = $this->htmlFilter('~/afform/MyForm.aff.html', $inputHtml);

--- a/ext/afform/core/tests/phpunit/Civi/Afform/FormDataModelTest.php
+++ b/ext/afform/core/tests/phpunit/Civi/Afform/FormDataModelTest.php
@@ -99,7 +99,7 @@ class FormDataModelTest extends \PHPUnit\Framework\TestCase implements HeadlessI
    * @param $expectEntities
    * @dataProvider getEntityExamples
    */
-  public function testGetEntities($html, $expectEntities) {
+  public function testGetEntities($html, $expectEntities): void {
     $parser = new \CRM_Afform_ArrayHtml();
     $fdm = new FormDataModel($parser->convertHtmlToArray($html));
     $this->assertEquals($expectEntities, $fdm->getEntities());

--- a/ext/afform/core/tests/phpunit/Civi/Afform/SymbolsTest.php
+++ b/ext/afform/core/tests/phpunit/Civi/Afform/SymbolsTest.php
@@ -90,7 +90,7 @@ class SymbolsTest extends \PHPUnit\Framework\TestCase implements HeadlessInterfa
    *   Types are (e)lement, (a)ttribute, (c)lass
    * @dataProvider getExamples
    */
-  public function testSymbols($html, $expect) {
+  public function testSymbols($html, $expect): void {
     $expectDefaults = ['e' => [], 'a' => [], 'c' => []];
     $expect = array_merge($expectDefaults, $expect);
     $actual = Symbols::scan($html);

--- a/ext/afform/mock/tests/phpunit/api/v4/AfformRoutingTest.php
+++ b/ext/afform/mock/tests/phpunit/api/v4/AfformRoutingTest.php
@@ -14,7 +14,7 @@ class api_v4_AfformRoutingTest extends \PHPUnit\Framework\TestCase implements \C
       ->apply();
   }
 
-  public function setUp() {
+  public function setUp(): void {
     parent::setUp();
     Civi\Api4\Afform::revert()
       ->setCheckPermissions(FALSE)
@@ -22,7 +22,7 @@ class api_v4_AfformRoutingTest extends \PHPUnit\Framework\TestCase implements \C
       ->execute();
   }
 
-  public function tearDown() {
+  public function tearDown(): void {
     parent::tearDown();
     Civi\Api4\Afform::revert()
       ->setCheckPermissions(FALSE)
@@ -30,7 +30,7 @@ class api_v4_AfformRoutingTest extends \PHPUnit\Framework\TestCase implements \C
       ->execute();
   }
 
-  public function testChangingPermissions() {
+  public function testChangingPermissions(): void {
     $http = new \GuzzleHttp\Client(['http_errors' => FALSE]);
     $url = function ($path, $query = NULL) {
       return CRM_Utils_System::url($path, $query, TRUE, NULL, FALSE);
@@ -49,7 +49,7 @@ class api_v4_AfformRoutingTest extends \PHPUnit\Framework\TestCase implements \C
     $this->assertOpensPage($result, 'mock-page');
   }
 
-  public function testChangingPath() {
+  public function testChangingPath(): void {
     $http = new \GuzzleHttp\Client(['http_errors' => FALSE]);
     $url = function ($path, $query = NULL) {
       return CRM_Utils_System::url($path, $query, TRUE, NULL, FALSE);

--- a/ext/afform/mock/tests/phpunit/api/v4/AfformTest.php
+++ b/ext/afform/mock/tests/phpunit/api/v4/AfformTest.php
@@ -45,7 +45,7 @@ class api_v4_AfformTest extends api_v4_AfformTestCase {
    * @param array $originalMetadata
    * @dataProvider getBasicDirectives
    */
-  public function testGetUpdateRevert($formName, $originalMetadata) {
+  public function testGetUpdateRevert($formName, $originalMetadata): void {
     $get = function($arr, $key) {
       return isset($arr[$key]) ? $arr[$key] : NULL;
     };
@@ -134,7 +134,7 @@ class api_v4_AfformTest extends api_v4_AfformTestCase {
    *   (For debug messages) A symbolic name of the example data-set being tested.
    * @dataProvider getFormatExamples
    */
-  public function testBasicConvert($formName, $updateFormat, $updateLayout, $readFormat, $readLayout, $exampleName) {
+  public function testBasicConvert($formName, $updateFormat, $updateLayout, $readFormat, $readLayout, $exampleName): void {
     $actual = Civi\Api4\Afform::convert()->setLayout($updateLayout)
       ->setFrom($updateFormat)
       ->setTo($readFormat)
@@ -177,7 +177,7 @@ class api_v4_AfformTest extends api_v4_AfformTestCase {
    *   (For debug messages) A symbolic name of the example data-set being tested.
    * @dataProvider getFormatExamples
    */
-  public function testUpdateAndGetFormat($formName, $updateFormat, $updateLayout, $readFormat, $readLayout, $exampleName) {
+  public function testUpdateAndGetFormat($formName, $updateFormat, $updateLayout, $readFormat, $readLayout, $exampleName): void {
     Civi\Api4\Afform::revert()->addWhere('name', '=', $formName)->execute();
 
     Civi\Api4\Afform::update()
@@ -213,7 +213,7 @@ class api_v4_AfformTest extends api_v4_AfformTestCase {
    *
    * @dataProvider getWhitespaceExamples
    */
-  public function testWhitespaceFormat($directiveName, $example, $exampleName) {
+  public function testWhitespaceFormat($directiveName, $example, $exampleName): void {
     Civi\Api4\Afform::save()
       ->addRecord(['name' => $directiveName, 'layout' => $example['html']])
       ->setLayoutFormat('html')
@@ -243,7 +243,7 @@ class api_v4_AfformTest extends api_v4_AfformTestCase {
     $this->assertEquals($example['pretty'], $this->fudgeMarkup($result['layout']));
   }
 
-  public function testAutoRequires() {
+  public function testAutoRequires(): void {
     $formName = 'mockPage';
     $this->createLoggedInUser();
 

--- a/ext/afform/mock/tests/phpunit/api/v4/AfformUsageTest.php
+++ b/ext/afform/mock/tests/phpunit/api/v4/AfformUsageTest.php
@@ -13,7 +13,7 @@ class api_v4_AfformUsageTest extends api_v4_AfformTestCase {
 
   protected $formName;
 
-  public static function setUpBeforeClass() {
+  public static function setUpBeforeClass(): void {
     parent::setUpBeforeClass();
     self::$layouts['aboutMe'] = <<<EOHTML
 <af-form ctrl="modelListCtrl">
@@ -26,12 +26,12 @@ class api_v4_AfformUsageTest extends api_v4_AfformTestCase {
 EOHTML;
   }
 
-  public function setUp() {
+  public function setUp(): void {
     parent::setUp();
     $this->formName = 'mock' . rand(0, 100000);
   }
 
-  public function tearDown() {
+  public function tearDown(): void {
     Civi\Api4\Afform::revert()
       ->setCheckPermissions(FALSE)
       ->addWhere('name', '=', $this->formName)
@@ -39,7 +39,7 @@ EOHTML;
     parent::tearDown();
   }
 
-  public function testAboutMeAllowed() {
+  public function testAboutMeAllowed(): void {
     $this->useValues([
       'layout' => self::$layouts['aboutMe'],
       'permission' => CRM_Core_Permission::ALWAYS_ALLOW_PERMISSION,
@@ -71,7 +71,7 @@ EOHTML;
     $this->assertEquals('Lasty', $contact['last_name']);
   }
 
-  public function testAboutMeForbidden() {
+  public function testAboutMeForbidden(): void {
     $this->useValues([
       'layout' => self::$layouts['aboutMe'],
       'permission' => CRM_Core_Permission::ALWAYS_DENY_PERMISSION,

--- a/ext/authx/tests/phpunit/Civi/Authx/AllFlowsTest.php
+++ b/ext/authx/tests/phpunit/Civi/Authx/AllFlowsTest.php
@@ -34,7 +34,7 @@ class AllFlowsTest extends \PHPUnit\Framework\TestCase implements EndToEndInterf
    */
   protected $quirks = [];
 
-  public static function setUpBeforeClass() {
+  public static function setUpBeforeClass(): void {
     \Civi\Test::e2e()
       ->installMe(__DIR__)
       ->callback(
@@ -46,7 +46,7 @@ class AllFlowsTest extends \PHPUnit\Framework\TestCase implements EndToEndInterf
       ->apply();
   }
 
-  public function setUp() {
+  public function setUp(): void {
     $quirks = [
       'Joomla' => ['sendsExcessCookies', 'authErrorShowsForm'],
       'WordPress' => ['sendsExcessCookies'],
@@ -62,7 +62,7 @@ class AllFlowsTest extends \PHPUnit\Framework\TestCase implements EndToEndInterf
     }
   }
 
-  public function tearDown() {
+  public function tearDown(): void {
     foreach ($this->settingsBackup as $setting => $value) {
       \Civi::settings()->set($setting, $value);
     }
@@ -91,7 +91,7 @@ class AllFlowsTest extends \PHPUnit\Framework\TestCase implements EndToEndInterf
     return $exs;
   }
 
-  public function testAnonymous() {
+  public function testAnonymous(): void {
     $http = $this->createGuzzle(['http_errors' => FALSE]);
 
     /** @var \Psr\Http\Message\RequestInterface $request */
@@ -111,7 +111,7 @@ class AllFlowsTest extends \PHPUnit\Framework\TestCase implements EndToEndInterf
    * @throws \GuzzleHttp\Exception\GuzzleException
    * @dataProvider getStatelessExamples
    */
-  public function testStatelessContactOnly($credType, $flowType) {
+  public function testStatelessContactOnly($credType, $flowType): void {
     if ($credType === 'pass') {
       $this->assertTrue(TRUE, 'No need to test password credentials with non-user contacts');
       return;
@@ -146,7 +146,7 @@ class AllFlowsTest extends \PHPUnit\Framework\TestCase implements EndToEndInterf
    * @throws \GuzzleHttp\Exception\GuzzleException
    * @dataProvider getStatelessExamples
    */
-  public function testStatelessUserContact($credType, $flowType) {
+  public function testStatelessUserContact($credType, $flowType): void {
     $http = $this->createGuzzle(['http_errors' => FALSE]);
 
     /** @var \Psr\Http\Message\RequestInterface $request */
@@ -176,7 +176,7 @@ class AllFlowsTest extends \PHPUnit\Framework\TestCase implements EndToEndInterf
    * @throws \GuzzleHttp\Exception\GuzzleException
    * @dataProvider getCredTypes
    */
-  public function testStatefulLoginAllowed($credType) {
+  public function testStatefulLoginAllowed($credType): void {
     $flowType = 'login';
     $credFunc = 'cred' . ucfirst(preg_replace(';[^a-zA-Z0-9];', '', $credType));
 
@@ -222,7 +222,7 @@ class AllFlowsTest extends \PHPUnit\Framework\TestCase implements EndToEndInterf
    * @throws \GuzzleHttp\Exception\GuzzleException
    * @dataProvider getCredTypes
    */
-  public function testStatefulLoginProhibited($credType) {
+  public function testStatefulLoginProhibited($credType): void {
     $flowType = 'login';
     $http = $this->createGuzzle(['http_errors' => FALSE]);
     $credFunc = 'cred' . ucfirst(preg_replace(';[^a-zA-Z0-9];', '', $credType));
@@ -244,7 +244,7 @@ class AllFlowsTest extends \PHPUnit\Framework\TestCase implements EndToEndInterf
    * @throws \GuzzleHttp\Exception\GuzzleException
    * @dataProvider getCredTypes
    */
-  public function testStatefulAutoAllowed($credType) {
+  public function testStatefulAutoAllowed($credType): void {
     $flowType = 'auto';
     $cookieJar = new CookieJar();
     $http = $this->createGuzzle(['http_errors' => FALSE, 'cookies' => $cookieJar]);
@@ -271,7 +271,7 @@ class AllFlowsTest extends \PHPUnit\Framework\TestCase implements EndToEndInterf
    * @throws \GuzzleHttp\Exception\GuzzleException
    * @dataProvider getCredTypes
    */
-  public function testStatefulAutoProhibited($credType) {
+  public function testStatefulAutoProhibited($credType): void {
     $flowType = 'auto';
     $cookieJar = new CookieJar();
     $http = $this->createGuzzle(['http_errors' => FALSE, 'cookies' => $cookieJar]);
@@ -291,7 +291,7 @@ class AllFlowsTest extends \PHPUnit\Framework\TestCase implements EndToEndInterf
    * @throws \CiviCRM_API3_Exception
    * @throws \GuzzleHttp\Exception\GuzzleException
    */
-  public function testStatefulStatelessOverlap() {
+  public function testStatefulStatelessOverlap(): void {
     \Civi::settings()->set("authx_login_cred", ['api_key']);
     \Civi::settings()->set("authx_header_cred", ['api_key']);
 
@@ -329,7 +329,7 @@ class AllFlowsTest extends \PHPUnit\Framework\TestCase implements EndToEndInterf
    * @throws \CiviCRM_API3_Exception
    * @throws \GuzzleHttp\Exception\GuzzleException
    */
-  public function testMultipleStateless() {
+  public function testMultipleStateless(): void {
     \Civi::settings()->set("authx_header_cred", ['api_key']);
     $cookieJar = new CookieJar();
     $http = $this->createGuzzle(['http_errors' => FALSE, 'cookies' => $cookieJar]);
@@ -417,7 +417,7 @@ class AllFlowsTest extends \PHPUnit\Framework\TestCase implements EndToEndInterf
    *   The expected user ID
    * @param \Psr\Http\Message\ResponseInterface $response
    */
-  public function assertMyContact($cid, $uid, ResponseInterface $response) {
+  public function assertMyContact($cid, $uid, ResponseInterface $response): void {
     $this->assertContentType('application/json', $response);
     $this->assertStatusCode(200, $response);
     $j = json_decode((string) $response->getBody(), 1);
@@ -431,7 +431,7 @@ class AllFlowsTest extends \PHPUnit\Framework\TestCase implements EndToEndInterf
    *
    * @param \Psr\Http\Message\ResponseInterface $response
    */
-  public function assertAnonymousContact(ResponseInterface $response) {
+  public function assertAnonymousContact(ResponseInterface $response): void {
     $formattedFailure = $this->formatFailure($response);
     $this->assertContentType('application/json', $response);
     $this->assertStatusCode(200, $response);
@@ -448,7 +448,7 @@ class AllFlowsTest extends \PHPUnit\Framework\TestCase implements EndToEndInterf
    *
    * @param \Psr\Http\Message\ResponseInterface $response
    */
-  public function assertDashboardUnauthorized($response = NULL) {
+  public function assertDashboardUnauthorized($response = NULL): void {
     $response = $this->resolveResponse($response);
     if (!in_array('authErrorShowsForm', $this->quirks)) {
       $this->assertStatusCode(403, $response);
@@ -459,7 +459,7 @@ class AllFlowsTest extends \PHPUnit\Framework\TestCase implements EndToEndInterf
     );
   }
 
-  public function assertDashboardOk($response = NULL) {
+  public function assertDashboardOk($response = NULL): void {
     $response = $this->resolveResponse($response);
     $this->assertStatusCode(200, $response);
     $this->assertContentType('text/html', $response);
@@ -569,7 +569,7 @@ class AllFlowsTest extends \PHPUnit\Framework\TestCase implements EndToEndInterf
   /**
    * @param \Psr\Http\Message\ResponseInterface $response
    */
-  private function assertFailedDueToProhibition($response) {
+  private function assertFailedDueToProhibition($response): void {
     $this->assertBodyRegexp(';HTTP 401;', $response);
     $this->assertContentType('text/plain', $response);
     if (!in_array('sendsExcessCookies', $this->quirks)) {

--- a/ext/ewaysingle/tests/phpunit/CRM/Core/Payment/EwayTest.php
+++ b/ext/ewaysingle/tests/phpunit/CRM/Core/Payment/EwayTest.php
@@ -31,13 +31,13 @@ class CRM_Core_Payment_EwayTest extends \PHPUnit\Framework\TestCase implements H
       ->apply();
   }
 
-  public function setUp() {
+  public function setUp(): void {
     $this->setUpEwayProcessor();
     $this->processor = \Civi\Payment\System::singleton()->getById($this->ids['PaymentProcessor']['eWAY']);
     parent::setUp();
   }
 
-  public function tearDown() {
+  public function tearDown(): void {
     $this->callAPISuccess('PaymentProcessor', 'delete', ['id' => $this->ids['PaymentProcessor']['eWAY']]);
     parent::tearDown();
   }
@@ -45,7 +45,7 @@ class CRM_Core_Payment_EwayTest extends \PHPUnit\Framework\TestCase implements H
   /**
    * Test making a once off payment
    */
-  public function testSinglePayment() {
+  public function testSinglePayment(): void {
     $this->setupMockHandler();
     $params = $this->getBillingParams();
     $params['amount'] = 10.00;
@@ -69,7 +69,7 @@ class CRM_Core_Payment_EwayTest extends \PHPUnit\Framework\TestCase implements H
   /**
    * Test making a failed once off payment
    */
-  public function testErrorSinglePayment() {
+  public function testErrorSinglePayment(): void {
     $this->setupMockHandler(NULL, TRUE);
     $params = $this->getBillingParams();
     $params['amount'] = 5.24;
@@ -125,7 +125,7 @@ class CRM_Core_Payment_EwayTest extends \PHPUnit\Framework\TestCase implements H
     ];
   }
 
-  public function setUpEwayProcessor() {
+  public function setUpEwayProcessor(): void {
     $params = [
       'name' => 'demo',
       'domain_id' => CRM_Core_Config::domainID(),
@@ -164,7 +164,7 @@ class CRM_Core_Payment_EwayTest extends \PHPUnit\Framework\TestCase implements H
    *
    * @throws \CiviCRM_API3_Exception
    */
-  protected function setupMockHandler($id = NULL, $error = FALSE) {
+  protected function setupMockHandler($id = NULL, $error = FALSE): void {
     if ($id) {
       $this->processor = Civi\Payment\System::singleton()->getById($id);
     }
@@ -181,7 +181,7 @@ class CRM_Core_Payment_EwayTest extends \PHPUnit\Framework\TestCase implements H
    *
    * @return array
    */
-  public function getExpectedSinglePaymentResponses() {
+  public function getExpectedSinglePaymentResponses(): array {
     return [
       '<ewayResponse><ewayTrxnStatus>True</ewayTrxnStatus><ewayTrxnNumber>10002</ewayTrxnNumber><ewayTrxnReference>xyz</ewayTrxnReference><ewayTrxnOption1/><ewayTrxnOption2/><ewayTrxnOption3/><ewayAuthCode>123456</ewayAuthCode><ewayReturnAmount>1000</ewayReturnAmount><ewayTrxnError>00,Transaction Approved(Test Gateway)</ewayTrxnError></ewayResponse>',
     ];
@@ -192,7 +192,7 @@ class CRM_Core_Payment_EwayTest extends \PHPUnit\Framework\TestCase implements H
    *
    * @return array
    */
-  public function getExpectedSinglePaymentRequests() {
+  public function getExpectedSinglePaymentRequests(): array {
     return [
       '<ewaygateway><ewayCustomerID>87654321</ewayCustomerID><ewayTotalAmount>1000</ewayTotalAmount><ewayCardHoldersName>John O&apos;Connor</ewayCardHoldersName><ewayCardNumber>4444333322221111</ewayCardNumber><ewayCardExpiryMonth>10</ewayCardExpiryMonth><ewayCardExpiryYear>22</ewayCardExpiryYear><ewayTrxnNumber>xyz</ewayTrxnNumber><ewayCustomerInvoiceDescription>Test Contribution</ewayCustomerInvoiceDescription><ewayCustomerFirstName>John</ewayCustomerFirstName><ewayCustomerLastName>O&apos;Connor</ewayCustomerLastName><ewayCustomerEmail>unittesteway@civicrm.org</ewayCustomerEmail><ewayCustomerAddress>8 Hobbitton Road, The Shire, NSW.</ewayCustomerAddress><ewayCustomerPostcode>5010</ewayCustomerPostcode><ewayCustomerInvoiceRef>xyz</ewayCustomerInvoiceRef><ewayCVN>123</ewayCVN><ewayOption1></ewayOption1><ewayOption2></ewayOption2><ewayOption3></ewayOption3><ewayCustomerIPAddress>127.0.0.1</ewayCustomerIPAddress><ewayCustomerBillingCountry>AUS</ewayCustomerBillingCountry></ewaygateway>',
     ];
@@ -203,7 +203,7 @@ class CRM_Core_Payment_EwayTest extends \PHPUnit\Framework\TestCase implements H
    *
    * @return array
    */
-  public function getExpectedSinglePaymentErrorResponses() {
+  public function getExpectedSinglePaymentErrorResponses(): array {
     return [
       '<ewayResponse><ewayTrxnStatus>False</ewayTrxnStatus><ewayTrxnNumber>10003</ewayTrxnNumber><ewayTrxnReference>xyz</ewayTrxnReference><ewayTrxnOption1/><ewayTrxnOption2/><ewayTrxnOption3/><ewayAuthCode>123456</ewayAuthCode><ewayReturnAmount>524</ewayReturnAmount><ewayTrxnError>24,Do Not Honour(Test Gateway)</ewayTrxnError></ewayResponse>',
     ];

--- a/ext/financialacls/tests/phpunit/Civi/Financialacls/BuildAmountHookTest.php
+++ b/ext/financialacls/tests/phpunit/Civi/Financialacls/BuildAmountHookTest.php
@@ -19,7 +19,7 @@ class BuildAmountHookTest extends BaseTestClass {
   /**
    * Test api applies permissions on line item actions (delete & get).
    */
-  public function testBuildAmount() {
+  public function testBuildAmount(): void {
     $priceSet = PriceSet::create()->setValues(['name' => 'test', 'title' => 'test', 'extends' => 'CiviMember'])->execute()->first();
     PriceField::create()->setValues([
       'financial_type_id:name' => 'Donation',

--- a/ext/financialacls/tests/phpunit/Civi/Financialacls/LineItemTest.php
+++ b/ext/financialacls/tests/phpunit/Civi/Financialacls/LineItemTest.php
@@ -28,7 +28,7 @@ class LineItemTest extends BaseTestClass {
    *
    * @dataProvider versionThreeAndFour
    */
-  public function testLineItemApiPermissions($version) {
+  public function testLineItemApiPermissions($version): void {
     $contact1 = $this->individualCreate();
     $defaultPriceFieldID = $this->getDefaultPriceFieldID();
     $order = $this->callAPISuccess('Order', 'create', [

--- a/ext/financialacls/tests/phpunit/Civi/Financialacls/MembershipTypesTest.php
+++ b/ext/financialacls/tests/phpunit/Civi/Financialacls/MembershipTypesTest.php
@@ -15,7 +15,7 @@ class MembershipTypesTest extends BaseTestClass {
   /**
    * Test buildMembershipTypes.
    */
-  public function testMembershipTypesHook() {
+  public function testMembershipTypesHook(): void {
     $types = MembershipType::save(FALSE)->setRecords([
       ['name' => 'Forbidden', 'financial_type_id:name' => 'Member Dues'],
       ['name' => 'Go for it', 'financial_type_id:name' => 'Donation'],

--- a/ext/financialacls/tests/phpunit/Civi/Financialacls/OptionsTest.php
+++ b/ext/financialacls/tests/phpunit/Civi/Financialacls/OptionsTest.php
@@ -13,7 +13,7 @@ class OptionsTest extends BaseTestClass {
   /**
    * Test buildMembershipTypes.
    */
-  public function testBuildOptions() {
+  public function testBuildOptions(): void {
     $this->setupLoggedInUserWithLimitedFinancialTypeAccess();
     $options = \CRM_Financial_BAO_FinancialType::getAvailableFinancialTypes();
     $this->assertEquals(['Donation'], array_merge($options));

--- a/ext/flexmailer/tests/phpunit/Civi/FlexMailer/ClickTracker/HtmlClickTrackerTest.php
+++ b/ext/flexmailer/tests/phpunit/Civi/FlexMailer/ClickTracker/HtmlClickTrackerTest.php
@@ -19,7 +19,7 @@ use Civi\FlexMailer\ClickTracker\HtmlClickTracker;
  */
 class HtmlClickTrackerTest extends \CiviUnitTestCase {
 
-  public function setUp() {
+  public function setUp(): void {
     // Activate before transactions are setup.
     $manager = \CRM_Extension_System::singleton()->getManager();
     if ($manager->getStatus('org.civicrm.flexmailer') !== \CRM_Extension_Manager::STATUS_INSTALLED) {
@@ -79,7 +79,7 @@ class HtmlClickTrackerTest extends \CiviUnitTestCase {
    * @param $expectHtml
    * @dataProvider getHrefExamples
    */
-  public function testReplaceHref($inputHtml, $expectHtml) {
+  public function testReplaceHref($inputHtml, $expectHtml): void {
     $actual = HtmlClickTracker::replaceHrefUrls($inputHtml, function($url) {
       return "tracking($url)";
     });

--- a/ext/flexmailer/tests/phpunit/Civi/FlexMailer/ClickTracker/TextClickTrackerTest.php
+++ b/ext/flexmailer/tests/phpunit/Civi/FlexMailer/ClickTracker/TextClickTrackerTest.php
@@ -19,7 +19,7 @@ use Civi\FlexMailer\ClickTracker\TextClickTracker;
  */
 class TextClickTrackerTest extends \CiviUnitTestCase {
 
-  public function setUp() {
+  public function setUp(): void {
     // Activate before transactions are setup.
     $manager = \CRM_Extension_System::singleton()->getManager();
     if ($manager->getStatus('org.civicrm.flexmailer') !== \CRM_Extension_Manager::STATUS_INSTALLED) {
@@ -79,7 +79,7 @@ class TextClickTrackerTest extends \CiviUnitTestCase {
    * @param $expectHtml
    * @dataProvider getHrefExamples
    */
-  public function testReplaceTextUrls($inputHtml, $expectHtml) {
+  public function testReplaceTextUrls($inputHtml, $expectHtml): void {
     $inputText = \CRM_Utils_String::htmlToText($inputHtml);
     $expectText = \CRM_Utils_String::htmlToText($expectHtml);
     $expectText = str_replace('/tracking', 'tracking', $expectText);

--- a/ext/flexmailer/tests/phpunit/Civi/FlexMailer/ClickTrackerTest.php
+++ b/ext/flexmailer/tests/phpunit/Civi/FlexMailer/ClickTrackerTest.php
@@ -25,7 +25,7 @@ class ClickTrackerTest extends \PHPUnit\Framework\TestCase implements HeadlessIn
       ->apply();
   }
 
-  public function setUp() {
+  public function setUp(): void {
     // Mock the getTrackerURL call; we don't need to test creating a row in a table.
     // If you want this to work without runkit, then either (a) make the dummy rows or (b) switch this to a hook/event that is runtime-configurable.
     require_once 'CRM/Mailing/BAO/TrackableURL.php';
@@ -34,7 +34,7 @@ class ClickTrackerTest extends \PHPUnit\Framework\TestCase implements HeadlessIn
     parent::setUp();
   }
 
-  public function tearDown() {
+  public function tearDown(): void {
     // Reset the class.
     runkit7_method_remove('\CRM_Mailing_BAO_TrackableURL', 'getBasicTrackerURL');
     runkit7_method_rename('\CRM_Mailing_BAO_TrackableURL', 'orig_getBasicTrackerURL', 'getBasicTrackerURL');
@@ -44,7 +44,7 @@ class ClickTrackerTest extends \PHPUnit\Framework\TestCase implements HeadlessIn
   /**
    * Example: Test that a link without any tokens works.
    */
-  public function testLinkWithoutTokens() {
+  public function testLinkWithoutTokens(): void {
     $filter = new TextClickTracker();
     $msg = 'See this: https://example.com/foo/bar?a=b&c=d#frag';
     $result = $filter->filterContent($msg, 1, 1);
@@ -54,7 +54,7 @@ class ClickTrackerTest extends \PHPUnit\Framework\TestCase implements HeadlessIn
   /**
    * Example: Test that a link with tokens in the query works.
    */
-  public function testLinkWithTokensInQueryWithStaticParams() {
+  public function testLinkWithTokensInQueryWithStaticParams(): void {
     $filter = new TextClickTracker();
     $msg = 'See this: https://example.com/foo/bar?a=b&cid={contact.id}';
     $result = $filter->filterContent($msg, 1, 1);
@@ -64,7 +64,7 @@ class ClickTrackerTest extends \PHPUnit\Framework\TestCase implements HeadlessIn
   /**
    * Example: Test that a link with tokens in the query works.
    */
-  public function testLinkWithTokensInQueryWithMultipleStaticParams() {
+  public function testLinkWithTokensInQueryWithMultipleStaticParams(): void {
     $filter = new TextClickTracker();
     $msg = 'See this: https://example.com/foo/bar?cs={contact.checksum}&a=b&cid={contact.id}';
     $result = $filter->filterContent($msg, 1, 1);
@@ -74,7 +74,7 @@ class ClickTrackerTest extends \PHPUnit\Framework\TestCase implements HeadlessIn
   /**
    * Example: Test that a link with tokens in the query works.
    */
-  public function testLinkWithTokensInQueryWithMultipleStaticParamsHtml() {
+  public function testLinkWithTokensInQueryWithMultipleStaticParamsHtml(): void {
     $filter = new HtmlClickTracker();
     $msg = '<a href="https://example.com/foo/bar?cs={contact.checksum}&amp;a=b&amp;cid={contact.id}">See this</a>';
     $result = $filter->filterContent($msg, 1, 1);
@@ -84,7 +84,7 @@ class ClickTrackerTest extends \PHPUnit\Framework\TestCase implements HeadlessIn
   /**
    * Example: Test that a link with tokens in the query works.
    */
-  public function testLinkWithTokensInQueryWithoutStaticParams() {
+  public function testLinkWithTokensInQueryWithoutStaticParams(): void {
     $filter = new TextClickTracker();
     $msg = 'See this: https://example.com/foo/bar?cid={contact.id}';
     $result = $filter->filterContent($msg, 1, 1);
@@ -97,7 +97,7 @@ class ClickTrackerTest extends \PHPUnit\Framework\TestCase implements HeadlessIn
    * Seems browsers maintain the fragment when they receive a redirect, so a
    * token here might still work.
    */
-  public function testLinkWithTokensInFragment() {
+  public function testLinkWithTokensInFragment(): void {
     $filter = new TextClickTracker();
     $msg = 'See this: https://example.com/foo/bar?a=b#cid={contact.id}';
     $result = $filter->filterContent($msg, 1, 1);
@@ -110,7 +110,7 @@ class ClickTrackerTest extends \PHPUnit\Framework\TestCase implements HeadlessIn
    * Seems browsers maintain the fragment when they receive a redirect, so a
    * token here might still work.
    */
-  public function testLinkWithTokensInQueryAndFragment() {
+  public function testLinkWithTokensInQueryAndFragment(): void {
     $filter = new TextClickTracker();
     $msg = 'See this: https://example.com/foo/bar?a=b&cid={contact.id}#cid={contact.id}';
     $result = $filter->filterContent($msg, 1, 1);
@@ -120,7 +120,7 @@ class ClickTrackerTest extends \PHPUnit\Framework\TestCase implements HeadlessIn
   /**
    * We can't handle tokens in the domain so it should not be tracked.
    */
-  public function testLinkWithTokensInDomainFails() {
+  public function testLinkWithTokensInDomainFails(): void {
     $filter = new TextClickTracker();
     $msg = 'See this: https://{some.domain}.com/foo/bar';
     $result = $filter->filterContent($msg, 1, 1);
@@ -130,7 +130,7 @@ class ClickTrackerTest extends \PHPUnit\Framework\TestCase implements HeadlessIn
   /**
    * We can't handle tokens in the path so it should not be tracked.
    */
-  public function testLinkWithTokensInPathFails() {
+  public function testLinkWithTokensInPathFails(): void {
     $filter = new TextClickTracker();
     $msg = 'See this: https://example.com/{some.path}';
     $result = $filter->filterContent($msg, 1, 1);

--- a/ext/flexmailer/tests/phpunit/Civi/FlexMailer/ConcurrentDeliveryTest.php
+++ b/ext/flexmailer/tests/phpunit/Civi/FlexMailer/ConcurrentDeliveryTest.php
@@ -33,7 +33,7 @@ require_once 'tests/phpunit/api/v3/JobProcessMailingTest.php';
  */
 class ConcurrentDeliveryTest extends \api_v3_JobProcessMailingTest {
 
-  public function setUp() {
+  public function setUp(): void {
     // Activate before transactions are setup.
     $manager = \CRM_Extension_System::singleton()->getManager();
     if ($manager->getStatus('org.civicrm.flexmailer') !== \CRM_Extension_Manager::STATUS_INSTALLED) {
@@ -45,7 +45,7 @@ class ConcurrentDeliveryTest extends \api_v3_JobProcessMailingTest {
     \Civi::settings()->set('flexmailer_traditional', 'flexmailer');
   }
 
-  public function tearDown() {
+  public function tearDown(): void {
     // We're building on someone else's test and don't fully trust them to
     // protect our settings. Make sure they did.
     $ok = ('flexmailer' == \Civi::settings()->get('flexmailer_traditional'))
@@ -65,11 +65,11 @@ class ConcurrentDeliveryTest extends \api_v3_JobProcessMailingTest {
    * @dataProvider concurrencyExamples
    * @see          _testConcurrencyCommon
    */
-  public function testConcurrency($settings, $expectedTallies, $expectedTotal) {
+  public function testConcurrency($settings, $expectedTallies, $expectedTotal): void {
     parent::testConcurrency($settings, $expectedTallies, $expectedTotal);
   }
 
-  public function testBasic() {
+  public function testBasic(): void {
     parent::testBasic();
   }
 

--- a/ext/flexmailer/tests/phpunit/Civi/FlexMailer/FlexMailerSystemTest.php
+++ b/ext/flexmailer/tests/phpunit/Civi/FlexMailer/FlexMailerSystemTest.php
@@ -39,7 +39,7 @@ class FlexMailerSystemTest extends \CRM_Mailing_BaseMailingSystemTest {
 
   private $counts;
 
-  public function setUp() {
+  public function setUp(): void {
     // Activate before transactions are setup.
     $manager = \CRM_Extension_System::singleton()->getManager();
     if ($manager->getStatus('org.civicrm.flexmailer') !== \CRM_Extension_Manager::STATUS_INSTALLED) {
@@ -80,7 +80,7 @@ class FlexMailerSystemTest extends \CRM_Mailing_BaseMailingSystemTest {
     $this->assertEquals('flexmailer', $context);
   }
 
-  public function tearDown() {
+  public function tearDown(): void {
     parent::tearDown();
     $this->assertNotEmpty($this->counts['hook_alterMailParams']);
     foreach (FlexMailer::getEventTypes() as $event => $class) {
@@ -106,7 +106,7 @@ class FlexMailerSystemTest extends \CRM_Mailing_BaseMailingSystemTest {
     $htmlUrlRegex,
     $textUrlRegex,
     $params
-  ) {
+  ): void {
     parent::testUrlTracking($inputHtml, $htmlUrlRegex, $textUrlRegex, $params);
   }
 
@@ -132,19 +132,19 @@ class FlexMailerSystemTest extends \CRM_Mailing_BaseMailingSystemTest {
     return $cases;
   }
 
-  public function testBasicHeaders() {
+  public function testBasicHeaders(): void {
     parent::testBasicHeaders();
   }
 
-  public function testText() {
+  public function testText(): void {
     parent::testText();
   }
 
-  public function testHtmlWithOpenTracking() {
+  public function testHtmlWithOpenTracking(): void {
     parent::testHtmlWithOpenTracking();
   }
 
-  public function testHtmlWithOpenAndUrlTracking() {
+  public function testHtmlWithOpenAndUrlTracking(): void {
     parent::testHtmlWithOpenAndUrlTracking();
   }
 

--- a/ext/flexmailer/tests/phpunit/Civi/FlexMailer/Listener/SimpleFilterTest.php
+++ b/ext/flexmailer/tests/phpunit/Civi/FlexMailer/Listener/SimpleFilterTest.php
@@ -29,7 +29,7 @@ use Civi\FlexMailer\FlexMailerTask;
  */
 class SimpleFilterTest extends \CiviUnitTestCase {
 
-  public function setUp() {
+  public function setUp(): void {
     // Activate before transactions are setup.
     $manager = \CRM_Extension_System::singleton()->getManager();
     if ($manager->getStatus('org.civicrm.flexmailer') !== \CRM_Extension_Manager::STATUS_INSTALLED) {
@@ -42,7 +42,7 @@ class SimpleFilterTest extends \CiviUnitTestCase {
   /**
    * Ensure that the utility `SimpleFilter::byValue()` correctly filters.
    */
-  public function testByValue() {
+  public function testByValue(): void {
     $test = $this;
     list($tasks, $e) = $this->createExampleBatch();
 
@@ -63,7 +63,7 @@ class SimpleFilterTest extends \CiviUnitTestCase {
   /**
    * Ensure that the utility `SimpleFilter::byColumn()` correctly filters.
    */
-  public function testByColumn() {
+  public function testByColumn(): void {
     $test = $this;
     list($tasks, $e) = $this->createExampleBatch();
 

--- a/ext/flexmailer/tests/phpunit/Civi/FlexMailer/MailingPreviewTest.php
+++ b/ext/flexmailer/tests/phpunit/Civi/FlexMailer/MailingPreviewTest.php
@@ -21,7 +21,7 @@ class MailingPreviewTest extends \CiviUnitTestCase {
    */
   protected $footer;
 
-  public function setUp() {
+  public function setUp(): void {
     // Activate before transactions are setup.
     $manager = \CRM_Extension_System::singleton()->getManager();
     if ($manager->getStatus('org.civicrm.flexmailer') !== \CRM_Extension_Manager::STATUS_INSTALLED) {
@@ -56,13 +56,13 @@ class MailingPreviewTest extends \CiviUnitTestCase {
     ));
   }
 
-  public function tearDown() {
+  public function tearDown(): void {
     // DGW
     \CRM_Mailing_BAO_MailingJob::$mailsProcessed = 0;
     parent::tearDown();
   }
 
-  public function testMailerPreview() {
+  public function testMailerPreview(): void {
     // BEGIN SAMPLE DATA
     $contactID = $this->individualCreate();
     $displayName = $this->callAPISuccess('contact', 'get',
@@ -99,7 +99,7 @@ class MailingPreviewTest extends \CiviUnitTestCase {
     $this->assertEquals('flexmailer', $previewResult['values']['_rendered_by_']);
   }
 
-  public function testMailerPreviewWithoutId() {
+  public function testMailerPreviewWithoutId(): void {
     // BEGIN SAMPLE DATA
     $contactID = $this->createLoggedInUser();
     $displayName = $this->callAPISuccess('contact', 'get', ['id' => $contactID]);
@@ -147,7 +147,7 @@ class MailingPreviewTest extends \CiviUnitTestCase {
    * @param array $expectMaxIds
    *   Array(string $table => int $maxId).
    */
-  protected function assertMaxIds($expectMaxIds) {
+  protected function assertMaxIds($expectMaxIds): void {
     foreach ($expectMaxIds as $table => $maxId) {
       $this->assertDBQuery($expectMaxIds[$table], 'SELECT MAX(id) FROM ' . $table, [], "Table $table should have a maximum ID of $maxId");
     }

--- a/ext/flexmailer/tests/phpunit/Civi/FlexMailer/ValidatorTest.php
+++ b/ext/flexmailer/tests/phpunit/Civi/FlexMailer/ValidatorTest.php
@@ -17,7 +17,7 @@ namespace Civi\FlexMailer;
  */
 class ValidatorTest extends \CiviUnitTestCase {
 
-  public function setUp() {
+  public function setUp(): void {
     // Activate before transactions are setup.
     $manager = \CRM_Extension_System::singleton()->getManager();
     if ($manager->getStatus('org.civicrm.flexmailer') !== \CRM_Extension_Manager::STATUS_INSTALLED) {
@@ -85,7 +85,7 @@ class ValidatorTest extends \CiviUnitTestCase {
    * @param array $expectedErrors
    * @dataProvider getExamples
    */
-  public function testExamples($mailingData, $expectedErrors) {
+  public function testExamples($mailingData, $expectedErrors): void {
     $mailing = new \CRM_Mailing_DAO_Mailing();
     $mailing->copyValues($mailingData);
     $actualErrors = Validator::createAndRun($mailing);

--- a/ext/oauth-client/tests/phpunit/CRM/OAuth/MailSetupTest.php
+++ b/ext/oauth-client/tests/phpunit/CRM/OAuth/MailSetupTest.php
@@ -18,15 +18,15 @@ class CRM_OAuth_MailSetupTest extends \PHPUnit\Framework\TestCase implements Hea
     return \Civi\Test::headless()->install('oauth-client')->apply();
   }
 
-  public function setUp() {
+  public function setUp(): void {
     parent::setUp();
   }
 
-  public function tearDown() {
+  public function tearDown(): void {
     parent::tearDown();
   }
 
-  public function testEvalArrayTemplate() {
+  public function testEvalArrayTemplate(): void {
     $vars = array(
       'token' => [
         'client_id' => 10,

--- a/ext/oauth-client/tests/phpunit/api/v4/OAuthClientGrantTest.php
+++ b/ext/oauth-client/tests/phpunit/api/v4/OAuthClientGrantTest.php
@@ -18,19 +18,19 @@ class api_v4_OAuthClientGrantTest extends \PHPUnit\Framework\TestCase implements
     return \Civi\Test::headless()->install('oauth-client')->apply();
   }
 
-  public function setUp() {
+  public function setUp(): void {
     parent::setUp();
     $this->assertEquals(0, CRM_Core_DAO::singleValueQuery('SELECT count(*) FROM civicrm_oauth_client'));
   }
 
-  public function tearDown() {
+  public function tearDown(): void {
     parent::tearDown();
   }
 
   /**
    * Basic sanity check - create, read, and delete a client.
    */
-  public function testAuthorizationCode() {
+  public function testAuthorizationCode(): void {
     $usePerms = function($ps) {
       $base = ['access CiviCRM'];
       \CRM_Core_Config::singleton()->userPermissionClass->permissions = array_merge($base, $ps);

--- a/ext/oauth-client/tests/phpunit/api/v4/OAuthClientTest.php
+++ b/ext/oauth-client/tests/phpunit/api/v4/OAuthClientTest.php
@@ -18,19 +18,19 @@ class api_v4_OAuthClientTest extends \PHPUnit\Framework\TestCase implements Head
     return \Civi\Test::headless()->install('oauth-client')->apply();
   }
 
-  public function setUp() {
+  public function setUp(): void {
     parent::setUp();
     $this->assertEquals(0, CRM_Core_DAO::singleValueQuery('SELECT count(*) FROM civicrm_oauth_client'));
   }
 
-  public function tearDown() {
+  public function tearDown(): void {
     parent::tearDown();
   }
 
   /**
    * Basic sanity check - create, read, and delete a client.
    */
-  public function testBasic() {
+  public function testBasic(): void {
     $random = CRM_Utils_String::createRandom(16, CRM_Utils_String::ALPHANUMERIC);
     $usePerms = function($ps) {
       $base = ['access CiviCRM'];
@@ -83,7 +83,7 @@ class api_v4_OAuthClientTest extends \PHPUnit\Framework\TestCase implements Head
     }
   }
 
-  public function testUpdateBadProvider() {
+  public function testUpdateBadProvider(): void {
     $random = CRM_Utils_String::createRandom(16, CRM_Utils_String::ALPHANUMERIC);
     $usePerms = function($ps) {
       $base = ['access CiviCRM'];

--- a/ext/oauth-client/tests/phpunit/api/v4/OAuthProviderTest.php
+++ b/ext/oauth-client/tests/phpunit/api/v4/OAuthProviderTest.php
@@ -17,18 +17,18 @@ class api_v4_OAuthProviderTest extends \PHPUnit\Framework\TestCase implements He
     return \Civi\Test::headless()->install('oauth-client')->apply();
   }
 
-  public function setUp() {
+  public function setUp(): void {
     parent::setUp();
   }
 
-  public function tearDown() {
+  public function tearDown(): void {
     parent::tearDown();
   }
 
   /**
    * Create, read, and destroy token - with full access to secrets.
    */
-  public function testGet() {
+  public function testGet(): void {
     \CRM_Core_Config::singleton()->userPermissionClass->permissions = ['access CiviCRM'];
 
     $examples = Civi\Api4\OAuthProvider::get()

--- a/ext/oauth-client/tests/phpunit/api/v4/OAuthSysTokenTest.php
+++ b/ext/oauth-client/tests/phpunit/api/v4/OAuthSysTokenTest.php
@@ -18,20 +18,20 @@ class api_v4_OAuthSysTokenTest extends \PHPUnit\Framework\TestCase implements He
     return \Civi\Test::headless()->install('oauth-client')->apply();
   }
 
-  public function setUp() {
+  public function setUp(): void {
     parent::setUp();
     $this->assertEquals(0, CRM_Core_DAO::singleValueQuery('SELECT count(*) FROM civicrm_oauth_client'));
     $this->assertEquals(0, CRM_Core_DAO::singleValueQuery('SELECT count(*) FROM civicrm_oauth_systoken'));
   }
 
-  public function tearDown() {
+  public function tearDown(): void {
     parent::tearDown();
   }
 
   /**
    * Create, read, and destroy token - with full access to secrets.
    */
-  public function testFullApiAccess() {
+  public function testFullApiAccess(): void {
     $random = CRM_Utils_String::createRandom(16, CRM_Utils_String::ALPHANUMERIC);
     $usePerms = function($ps) {
       $base = ['access CiviCRM'];
@@ -86,7 +86,7 @@ class api_v4_OAuthSysTokenTest extends \PHPUnit\Framework\TestCase implements He
   /**
    * Create, read, and destroy a token - with limited API access (cannot access token secrets).
    */
-  public function testLimitedApiAccess() {
+  public function testLimitedApiAccess(): void {
     $random = CRM_Utils_String::createRandom(16, CRM_Utils_String::ALPHANUMERIC);
     $usePerms = function($ps) {
       $base = ['access CiviCRM'];
@@ -159,7 +159,7 @@ class api_v4_OAuthSysTokenTest extends \PHPUnit\Framework\TestCase implements He
     $this->assertEquals("example-refresh-token-$random", $token['refresh_token']);
   }
 
-  public function testGetByScope() {
+  public function testGetByScope(): void {
     $random = CRM_Utils_String::createRandom(16, CRM_Utils_String::ALPHANUMERIC);
     $usePerms = function($ps) {
       $base = ['access CiviCRM'];

--- a/ext/sequentialcreditnotes/tests/phpunit/SequentialcreditnotesTest.php
+++ b/ext/sequentialcreditnotes/tests/phpunit/SequentialcreditnotesTest.php
@@ -45,7 +45,7 @@ class SequentialcreditnotesTest extends \PHPUnit\Framework\TestCase implements H
    * @throws \CRM_Core_Exception
    * @throws \CiviCRM_API3_Exception
    */
-  public function testCreateCreditNoteId() {
+  public function testCreateCreditNoteId(): void {
     $this->_apiversion = 4;
     $contactId = $this->callAPISuccess('Contact', 'create', ['contact_type' => 'Individual', 'email' => 'b@example.com'])['id'];
 


### PR DESCRIPTION
…Unit8

Overview
----------------------------------------
This adds in void type hints to various functions to future support PHPUnit8

Before
----------------------------------------
No Void Type Hint

After
----------------------------------------
Void Type Hints

ping @eileenmcnaughton 