### PR TITLE
Remove legacy phpunit param

### DIFF
--- a/ext/afform/core/phpunit.xml.dist
+++ b/ext/afform/core/phpunit.xml.dist
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<phpunit backupGlobals="false" backupStaticAttributes="false" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" syntaxCheck="false" bootstrap="tests/phpunit/bootstrap.php">
+<phpunit backupGlobals="false" backupStaticAttributes="false" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" bootstrap="tests/phpunit/bootstrap.php">
   <testsuites>
     <testsuite name="My Test Suite">
       <directory>./tests/phpunit</directory>

--- a/ext/sequentialcreditnotes/phpunit.xml.dist
+++ b/ext/sequentialcreditnotes/phpunit.xml.dist
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<phpunit backupGlobals="false" backupStaticAttributes="false" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" syntaxCheck="false" bootstrap="tests/phpunit/bootstrap.php">
+<phpunit backupGlobals="false" backupStaticAttributes="false" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" bootstrap="tests/phpunit/bootstrap.php">
   <testsuites>
     <testsuite name="My Test Suite">
       <directory>./tests/phpunit</directory>


### PR DESCRIPTION
Overview
----------------------------------------
Removes legacy phpunit param syntaxCheck

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/111720992-e52f1380-88c3-11eb-9d3a-26c3d9d0069c.png)

https://test.civicrm.org/job/CiviCRM-Core-Edge/CIVIVER=master,label=test-3/1081/console


After
----------------------------------------
poof

Technical Details
----------------------------------------
@totten I'm sure this is gone from civix but it seems to be added in recent vendor things of yours

Comments
----------------------------------------
@seamuslee001 