### PR TITLE
(dev/core#2466) - Drop HTML markup in exports for link custom fields

### DIFF
--- a/CRM/Export/BAO/ExportProcessor.php
+++ b/CRM/Export/BAO/ExportProcessor.php
@@ -1120,6 +1120,11 @@ class CRM_Export_BAO_ExportProcessor {
           return $result['values'][$result['id']]['url'];
         }
 
+        // Do not export HTML markup for links
+        if ($html_type === 'Link' && $fieldValue) {
+          return $fieldValue;
+        }
+
         return CRM_Core_BAO_CustomField::displayValue($fieldValue, $cfID);
       }
       elseif (in_array($field, [

--- a/tests/phpunit/CRM/Export/BAO/ExportTest.php
+++ b/tests/phpunit/CRM/Export/BAO/ExportTest.php
@@ -734,6 +734,7 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
       $longString .= 'Blah';
     }
     $this->addOptionToCustomField('select_string', ['label' => $longString, 'name' => 'blah']);
+    $longUrl = 'https://stage.example.org/system/files/webform/way_too_long_url_that_still_fits_in_a_link_custom_field_but_would_fail_to_export_with_html.jpg';
 
     $this->callAPISuccess('Contact', 'create', [
       'id' => $this->contactIDs[1],
@@ -741,12 +742,14 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
       $this->getCustomFieldName('country') => 'LA',
       $this->getCustomFieldName('select_string') => 'blah',
       'api.Address.create' => ['location_type_id' => 'Billing', 'city' => 'Waipu'],
+      $this->getCustomFieldName('link') => $longUrl,
     ]);
     $selectedFields = [
       ['name' => 'city', 'location_type_id' => CRM_Core_PseudoConstant::getKey('CRM_Core_BAO_Address', 'location_type_id', 'Billing')],
       ['name' => $this->getCustomFieldName('text')],
       ['name' => $this->getCustomFieldName('country')],
       ['name' => $this->getCustomFieldName('select_string')],
+      ['name' => $this->getCustomFieldName('link')],
     ];
 
     $this->doExportTest([
@@ -758,6 +761,7 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
     $this->assertEquals('Waipu', $row['Billing-City']);
     $this->assertEquals("Lao People's Democratic Republic", $row['Country']);
     $this->assertEquals($longString, $row['Pick Color']);
+    $this->assertEquals($longUrl, $row['test_link']);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
It is currently not possible to export custom fields of type link with length above around 110 chars. The added HTML markup pushes the length of the string above 256 chars in the export column for this field.

https://lab.civicrm.org/dev/core/-/issues/2466

Before
----------------------------------------
Export fails if it contains a long link.

After
----------------------------------------
Export works if it contains a long link. 
Has a test.

Comments
----------------------------------------
HTML is dropped from the export format.
