### PR TITLE
Explicitly throw an error/status bounce on Edit/New if no types.

### DIFF
--- a/CRM/Member/Page/Tab.php
+++ b/CRM/Member/Page/Tab.php
@@ -261,6 +261,17 @@ class CRM_Member_Page_Tab extends CRM_Core_Page {
    * @return null
    */
   public function edit() {
+    // We're trying to edit existing memberships or create a new one so we'll first check that a membership
+    // type is configured and active, if we don't do this we instead show a permissions error and status bounce.
+    $membershipTypes = \Civi\Api4\MembershipType::get(TRUE)
+      ->addWhere('is_active', '=', TRUE)
+      // we only need one, more is great but a single result lets us proceed!
+      ->setLimit(1)
+      ->execute();
+    if (empty($membershipTypes)) {
+      CRM_Core_Error::statusBounce(ts('You do not appear to have any active membership types configured, please add an active membership type and try again.'));
+    }
+
     // set https for offline cc transaction
     $mode = CRM_Utils_Request::retrieve('mode', 'Alphanumeric', $this);
     if ($mode == 'test' || $mode == 'live') {


### PR DESCRIPTION
Explicitly throw an error/status bounce if no memberships are configured and we're trying to add/update.

Overview
----------------------------------------
_Following this [discussion on MatterMost](https://chat.civicrm.org/civicrm/pl/ot5sq48mk3bammtrrzo4h5kdpc) it was pointed out that trying to add a new membership when no types exists throws a permissions error, not helpful!_

Before
----------------------------------------
_Adding a new membership with no types configured throws a permissions error._

After
----------------------------------------
_A helpful, descriptive error is returned instead giving the user context and the solution._

Technical Details
----------------------------------------
_N/A_
