### PR TITLE
Fixing allowing use of xvfb-run in wkhtmltopdf path in env.php verification checks

### DIFF
--- a/CRM/Utils/Check/Component/Env.php
+++ b/CRM/Utils/Check/Component/Env.php
@@ -963,7 +963,7 @@ class CRM_Utils_Check_Component_Env extends CRM_Utils_Check_Component {
   public function checkWkHtmlToPDFPath() {
     $messages = [];
     $wkhtmltopdfPath = CRM_Core_Config::singleton()->wkhtmltopdfPath;
-    if (!empty($wkhtmltopdfPath) {
+    if (!empty($wkhtmltopdfPath)) {
       // check and ensure that this leads to the wkhtmltopdf binary
       // and it is a valid executable binary
       // Only check the first space separated piece to allow for a value

--- a/CRM/Utils/Check/Component/Env.php
+++ b/CRM/Utils/Check/Component/Env.php
@@ -970,11 +970,8 @@ class CRM_Utils_Check_Component_Env extends CRM_Utils_Check_Component {
       // such as /usr/bin/xvfb-run -- wkhtmltopdf (CRM-13292)
       $pieces = explode(' ', $fields['wkhtmltopdfPath']);
       $path = $pieces[0];
-      if (
-        !file_exists($path) ||
-        !is_executable($path)
-      ) {  
-        (
+      if (!file_exists($path) || !is_executable($path)) {  
+        $messages[] = new CRM_Utils_Check_Message(
         __FUNCTION__,
         ts('CiviCRM is configured to use the wkhtmltopdf package to produce PDFs however it is missing, as such the system will fall back to using the DOMPDF package, this may mean that the output is different to what was expected. You should resolve this by either clearing the setting at Administer -> System Settings -> Miscellaneous or by getting your system administrator to install the wkhtmltopdf package'),
         ts('Missing System Package: wkhtmltopdf'),

--- a/CRM/Utils/Check/Component/Env.php
+++ b/CRM/Utils/Check/Component/Env.php
@@ -960,27 +960,26 @@ class CRM_Utils_Check_Component_Env extends CRM_Utils_Check_Component {
     return $messages;
   }
 
-  public function checkWkHtmlToPDFPath() {
+   public function checkWkHtmlToPDFPath() {
     $messages = [];
-    $wkhtmltopdfPath = CRM_Core_Config::singleton()->wkhtmltopdfPath;
-    if (!empty($wkhtmltopdfPath)) {
+		$wkhtmltopdfPath = CRM_Core_Config::singleton()->wkhtmltopdfPath;
+		if (!empty($wkhtmltopdfPath)) {
       // check and ensure that this leads to the wkhtmltopdf binary
       // and it is a valid executable binary
       // Only check the first space separated piece to allow for a value
       // such as /usr/bin/xvfb-run -- wkhtmltopdf (CRM-13292)
-      $pieces = explode(' ', $fields['wkhtmltopdfPath']);
-      $path = $pieces[0];
-      if (!file_exists($path) || !is_executable($path)) {  
+			$pieces = explode(' ',$wkhtmltopdfPath);
+			$path = $pieces[0];
+      if (!file_exists($path) || !is_executable($path)) {
         $messages[] = new CRM_Utils_Check_Message(
-          __FUNCTION__,
-          ts('CiviCRM is configured to use the wkhtmltopdf package to produce PDFs however it is missing, as such the system will fall back to using the DOMPDF package, this may mean that the output is different to what was expected. You should resolve this by either clearing the setting at Administer -> System Settings -> Miscellaneous or by getting your system administrator to install the wkhtmltopdf package'),
-          ts('Missing System Package: wkhtmltopdf'),
-          \Psr\Log\LogLevel::WARNING,
-          'fa-server'
+        __FUNCTION__,
+        ts('CiviCRM is configured to use the wkhtmltopdf package to produce PDFs however it is missing, as such the system will fall back to using the DOMPDF package, this may mean that the output is different to what was expected. You should resolve this by either clearing the setting at Administer -> System Settings -> Miscellaneous or by getting your system administrator to install the wkhtmltopdf package'),
+        ts('Missing System Package: wkhtmltopdf'),
+        \Psr\Log\LogLevel::WARNING,
+        'fa-server'
         );
       }
-    }
     return $messages;
+    }
   }
-
 }

--- a/CRM/Utils/Check/Component/Env.php
+++ b/CRM/Utils/Check/Component/Env.php
@@ -963,14 +963,25 @@ class CRM_Utils_Check_Component_Env extends CRM_Utils_Check_Component {
   public function checkWkHtmlToPDFPath() {
     $messages = [];
     $wkhtmltopdfPath = CRM_Core_Config::singleton()->wkhtmltopdfPath;
-    if (!empty($wkhtmltopdfPath) && !file_exists($wkhtmltopdfPath)) {
-      $messages[] = new CRM_Utils_Check_Message(
+    if (!empty($wkhtmltopdfPath) {
+      // check and ensure that this leads to the wkhtmltopdf binary
+      // and it is a valid executable binary
+      // Only check the first space separated piece to allow for a value
+      // such as /usr/bin/xvfb-run -- wkhtmltopdf (CRM-13292)
+      $pieces = explode(' ', $fields['wkhtmltopdfPath']);
+      $path = $pieces[0];
+      if (
+        !file_exists($path) ||
+        !is_executable($path)
+      ) {  
+        (
         __FUNCTION__,
         ts('CiviCRM is configured to use the wkhtmltopdf package to produce PDFs however it is missing, as such the system will fall back to using the DOMPDF package, this may mean that the output is different to what was expected. You should resolve this by either clearing the setting at Administer -> System Settings -> Miscellaneous or by getting your system administrator to install the wkhtmltopdf package'),
         ts('Missing System Package: wkhtmltopdf'),
         \Psr\Log\LogLevel::WARNING,
         'fa-server'
       );
+      }
     }
     return $messages;
   }

--- a/CRM/Utils/Check/Component/Env.php
+++ b/CRM/Utils/Check/Component/Env.php
@@ -972,12 +972,12 @@ class CRM_Utils_Check_Component_Env extends CRM_Utils_Check_Component {
       $path = $pieces[0];
       if (!file_exists($path) || !is_executable($path)) {  
         $messages[] = new CRM_Utils_Check_Message(
-        __FUNCTION__,
-        ts('CiviCRM is configured to use the wkhtmltopdf package to produce PDFs however it is missing, as such the system will fall back to using the DOMPDF package, this may mean that the output is different to what was expected. You should resolve this by either clearing the setting at Administer -> System Settings -> Miscellaneous or by getting your system administrator to install the wkhtmltopdf package'),
-        ts('Missing System Package: wkhtmltopdf'),
-        \Psr\Log\LogLevel::WARNING,
-        'fa-server'
-      );
+          __FUNCTION__,
+          ts('CiviCRM is configured to use the wkhtmltopdf package to produce PDFs however it is missing, as such the system will fall back to using the DOMPDF package, this may mean that the output is different to what was expected. You should resolve this by either clearing the setting at Administer -> System Settings -> Miscellaneous or by getting your system administrator to install the wkhtmltopdf package'),
+          ts('Missing System Package: wkhtmltopdf'),
+          \Psr\Log\LogLevel::WARNING,
+          'fa-server'
+        );
       }
     }
     return $messages;

--- a/CRM/Utils/PDF/Utils.php
+++ b/CRM/Utils/PDF/Utils.php
@@ -215,8 +215,12 @@ class CRM_Utils_PDF_Utils {
   public static function _html2pdf_wkhtmltopdf($paper_size, $orientation, $margins, $html, $output, $fileName) {
     $config = CRM_Core_Config::singleton();
     // if the path doesn't exist fall back on the current backup which is DOMPDF.
-    if (!file_exists($config->wkhtmltopdfPath)) {
-      return self::_html2pdf_dompdf($paper_size, $orientation, $html, $output, $fileName);
+    if (!empty($config->wkhtmltopdfPath)) {
+      $pieces = explode(' ',$config->wkhtmltopdfPath);
+      $path = $pieces[0];
+      if (!file_exists($path) || !is_executable($path)) {
+        return self::_html2pdf_dompdf($paper_size, $orientation, $html, $output, $fileName);
+      }
     }
     require_once 'snappy/src/autoload.php';
     $snappy = new Knp\Snappy\Pdf($config->wkhtmltopdfPath);


### PR DESCRIPTION

Overview
----------------------------------------
Applying the fix from previous commit to CRM/Admin/Form/Setting/Miscellaneous.php to this file
https://github.com/civicrm/civicrm-core/commit/1834031f7e325f7a35144639e812516898ff65d7
http://issues.civicrm.org/jira/browse/CRM-13292

Before
----------------------------------------

System status page showed `Missing System Package: wkhtmltopdf`, when using `/usr/bin/xvfb-run -- wkhtmltopdf` as the wkhtmltopdf path.

After
----------------------------------------

Using `/usr/bin/xvfb-run -- wkhtmltopdf` as the wkhtmltopdf path works without errors.

