### PR TITLE
[REF] Fix APIv3 MembershipJob test failure on php7.4 by only doing ch…

### DIFF
--- a/api/v3/Membership.php
+++ b/api/v3/Membership.php
@@ -281,12 +281,14 @@ function _civicrm_api3_membership_relationsship_get_customv2behaviour(&$params, 
   $relationships = [];
   foreach ($membershipValues as $membershipId => $values) {
     // populate the membership type name for the membership type id
-    $membershipType = CRM_Member_BAO_MembershipType::getMembershipTypeDetails($values['membership_type_id']);
+    $membershipType = CRM_Member_BAO_MembershipType::getMembershipTypeDetails($values['membership_type_id']) ?? [];
 
-    $membershipValues[$membershipId]['membership_name'] = $membershipType['name'];
+    if (!empty($membershipType)) {
+      $membershipValues[$membershipId]['membership_name'] = $membershipType['name'];
 
-    if (!empty($membershipType['relationship_type_id'])) {
-      $relationships[$membershipType['relationship_type_id']] = $membershipId;
+      if (!empty($membershipType['relationship_type_id'])) {
+        $relationships[$membershipType['relationship_type_id']] = $membershipId;
+      }
     }
 
     // populating relationship type name.


### PR DESCRIPTION
…ecking  if it is not empty

Overview
----------------------------------------
This fixes a test failure on PHP7.4 caused by trying to do array access on NULL

Before
----------------------------------------
Test failure on PHP 7.4

```
        <error type="Exception">api_v3_JobProcessMembershipTest::testByDefaultInactiveAreExcluded
Exception: CRM_Core_Exception: "Invalid getsingle resultArray
(
    [trace] =&gt; #0 /home/jenkins/bknix-edge/build/build-2/web/sites/all/modules/civicrm/api/v3/Membership.php(286): PHPUnit\Util\ErrorHandler::handleError()
```

After
----------------------------------------
Test passes on PHP 7.4

ping @eileenmcnaughton