### PR TITLE
[NFC] Fix Membership Type Test error on php7.4

### DIFF
--- a/tests/phpunit/api/v3/MembershipTypeTest.php
+++ b/tests/phpunit/api/v3/MembershipTypeTest.php
@@ -323,7 +323,7 @@ class api_v3_MembershipTypeTest extends CiviUnitTestCase {
     ];
     foreach ($memType as $rowCount => $type) {
       $membetype = CRM_Member_BAO_MembershipType::getMembershipTypeDetails($type);
-      $fieldParams['option_id'] = [1 => $priceFieldValue['id']];
+      $fieldParams['option_id'] = [1 => $priceFieldValue];
       $fieldParams['option_label'][$rowCount] = $membetype['name'] ?? NULL;
       $fieldParams['option_amount'][$rowCount] = $membetype['minimum_fee'] ?? 0;
       $fieldParams['option_weight'][$rowCount] = $membetype['weight'] ?? NULL;


### PR DESCRIPTION
Overview
----------------------------------------
This fixes a test failure on the MembershipType Test suite on PHP 7.4 caused by trying to do array access on value of type int

Before
----------------------------------------
Test fails on PHP 7.4

```
<error type="PHPUnit\Framework\Error\Notice">api_v3_MembershipTypeTest::testEnableMembershipTypeOnContributionPage
Trying to access array offset on value of type int

**/home/jenkins/bknix-edge/build/build-2/web/sites/all/modules/civicrm/tests/phpunit/api/v3/MembershipTypeTest.php:326**
```

After
----------------------------------------
Test passes

ping @eileenmcnaughton 