### PR TITLE
[NFC] Fix PHP 7.4 errors on ContributionPage tests

### DIFF
--- a/tests/phpunit/CRM/Contribute/Form/Contribution/ConfirmTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/Contribution/ConfirmTest.php
@@ -65,6 +65,9 @@ class CRM_Contribute_Form_Contribution_ConfirmTest extends CiviUnitTestCase {
       'is_recur' => FALSE,
       'payment_instrument_id' => CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'payment_instrument_id', 'Credit card'),
     ];
+    $form->_values = [
+      'id' => $contributionPageID2,
+    ];
     $form->_params = [
       'contribution_id' => $contribution['id'],
       'credit_card_number' => 4111111111111111,

--- a/tests/phpunit/CRM/Contribute/Form/Contribution/ThankYouTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/Contribution/ThankYouTest.php
@@ -77,6 +77,10 @@ class CRM_Contribute_Form_Contribution_ThankYouTest extends CiviUnitTestCase {
     if ($isTestContribution) {
       $form->_mode = 'test';
     }
+    $form->_values = [
+      'custom_pre_id' => NULL,
+      'custom_post_id' => NULL,
+    ];
 
     return $form;
   }


### PR DESCRIPTION
Overview
----------------------------------------
This fixes 2 test failures when running the unit tests on PHP 7.4

Before
----------------------------------------
Tests fail

```
          <error type="PHPUnit\Framework\Error\Notice">CRM_Contribute_Form_Contribution_ConfirmTest::testPayNowPayment
Trying to access array offset on value of type null

/home/jenkins/bknix-edge/build/build-2/web/sites/all/modules/civicrm/CRM/Contribute/Form/Contribution/Confirm.php:2718


          <error type="PHPUnit\Framework\Error\Notice">CRM_Contribute_Form_Contribution_ThankYouTest::testLiveAndTestContributionStatus
Trying to access array offset on value of type null

/home/jenkins/bknix-edge/build/build-2/web/sites/all/modules/civicrm/CRM/Contribute/Form/Contribution/ThankYou.php:183
````

After
----------------------------------------
Tests pass

ping @eileenmcnaughton 