### PR TITLE
[NFC] Fix Test failures on MySQL 8 caused by change in output of eith…

### DIFF
--- a/tests/phpunit/CRM/Dedupe/MergerTest.php
+++ b/tests/phpunit/CRM/Dedupe/MergerTest.php
@@ -1429,8 +1429,8 @@ class CRM_Dedupe_MergerTest extends CiviUnitTestCase {
     $cidRefs = [];
     $sql = "
 SELECT
-    table_name,
-    column_name
+    table_name AS table_name,
+    column_name AS column_name
 FROM information_schema.key_column_usage
 WHERE
     referenced_table_schema = database() AND

--- a/tests/phpunit/CRM/Logging/LoggingTest.php
+++ b/tests/phpunit/CRM/Logging/LoggingTest.php
@@ -52,6 +52,8 @@ class CRM_Logging_LoggingTest extends CiviUnitTestCase {
     $this->assertTrue(
       in_array("  `logging_test` int(11) DEFAULT '0'", $create)
       || in_array("  `logging_test` int(11) DEFAULT 0", $create)
+      || in_array("  `logging_test` int DEFAULT '0'", $create)
+      || in_array("  `logging_test` int DEFAULT 0", $create)
     );
     CRM_Core_DAO::executeQuery("ALTER TABLE `civicrm_option_value` DROP COLUMN `logging_test`", [], FALSE, NULL, FALSE, FALSE);
     $query = CRM_Core_DAO::executeQuery("SHOW CREATE TABLE `log_civicrm_option_value`", [], TRUE, NULL, FALSE, FALSE);
@@ -65,7 +67,10 @@ class CRM_Logging_LoggingTest extends CiviUnitTestCase {
     Civi::service('sql_triggers')->rebuild('civicrm_option_value');
     $this->assertTrue(
       in_array("  `logging_test` int(11) DEFAULT '0'", $create)
-      || in_array("  `logging_test` int(11) DEFAULT 0", $create));
+      || in_array("  `logging_test` int(11) DEFAULT 0", $create)
+      || in_array("  `logging_test` int DEFAULT '0'", $create)
+      || in_array("  `logging_test` int DEFAULT 0", $create)
+    );
     $logging->disableLogging();
   }
 


### PR DESCRIPTION
…er create table or Column names in queries

Overview
----------------------------------------
This fixes a couple of test failures caused by MySQL 8

in the dedupe case we were getting Table_Name back rather than being all lower case and in the logging one the int length is now not shown by default I believe

Before
----------------------------------------
Tests fail

After
----------------------------------------
Tests pass

ping @eileenmcnaughton 