### PR TITLE
Add support for receipt task outside the search process

### DIFF
--- a/CRM/Contribute/Controller/Task.php
+++ b/CRM/Contribute/Controller/Task.php
@@ -1,0 +1,52 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * Class CRM_Export_Controller_Standalone
+ */
+class CRM_Contribute_Controller_Task extends CRM_Core_Controller_Task {
+
+  /**
+   * Get the name used to construct the class.
+   *
+   * @return string
+   */
+  public function getEntity():string {
+    return 'Contribution';
+  }
+
+  /**
+   * Get the available tasks for the entity.
+   *
+   * @return array
+   */
+  public function getAvailableTasks():array {
+    return CRM_Contribute_Task::tasks();
+  }
+
+  /**
+   * Override parent to avoid e-notice if the page is 'Search'.
+   *
+   * There are no form values for Search when the standalone processor is used
+   * - move along.
+   *
+   * @param string $pageName
+   *
+   * @return array
+   */
+  public function exportValues($pageName = NULL) {
+    if ($pageName === 'Search') {
+      return [];
+    }
+    return parent::exportValues($pageName);
+  }
+
+}

--- a/CRM/Contribute/Form/Task/PDF.php
+++ b/CRM/Contribute/Form/Task/PDF.php
@@ -66,6 +66,8 @@ AND    {$this->_componentClause}";
     parent::setContactIDs();
     CRM_Utils_System::appendBreadCrumb($breadCrumb);
     CRM_Utils_System::setTitle(ts('Print Contribution Receipts'));
+    // Ajax submit would interfere with pdf file download
+    $this->preventAjaxSubmit();
   }
 
   /**

--- a/CRM/Contribute/Selector/Search.php
+++ b/CRM/Contribute/Selector/Search.php
@@ -353,6 +353,7 @@ class CRM_Contribute_Selector_Search extends CRM_Core_Selector_Base implements C
           $qfKey,
           $componentContext
       );
+
       $checkLineItem = FALSE;
       $row = [];
       // Now check for lineItems
@@ -445,6 +446,7 @@ class CRM_Contribute_Selector_Search extends CRM_Core_Selector_Base implements C
           'title' => $buttonName,
         ];
       }
+      $links = $links + CRM_Contribute_Task::getContextualLinks($row);
 
       $row['action'] = CRM_Core_Action::formLink(
         $links,

--- a/CRM/Contribute/xml/Menu/Contribute.xml
+++ b/CRM/Contribute/xml/Menu/Contribute.xml
@@ -337,4 +337,10 @@
     <weight>0</weight>
     <is_public>true</is_public>
   </item>
+  <item>
+    <path>civicrm/contribute/task</path>
+    <title>Contribution Task</title>
+    <page_callback>CRM_Contribute_Controller_Task</page_callback>
+    <access_arguments>access CiviContribute</access_arguments>
+  </item>
 </menu>

--- a/CRM/Core/Controller/Task.php
+++ b/CRM/Core/Controller/Task.php
@@ -1,0 +1,84 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * Class CRM_Export_Controller_Standalone
+ */
+abstract class CRM_Core_Controller_Task extends CRM_Core_Controller {
+
+  /**
+   * Class constructor.
+   *
+   * @param string $title
+   * @param bool|int $action
+   * @param bool $modal
+   *
+   * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
+   */
+  public function __construct($title = NULL, $action = CRM_Core_Action::NONE, $modal = TRUE) {
+
+    parent::__construct($title, $modal);
+    $id = explode(',', CRM_Utils_Request::retrieve('id', 'CommaSeparatedIntegers', $this, TRUE));
+
+    // Check permissions
+    $perm = civicrm_api3($this->getEntity(), 'get', [
+      'return' => 'id',
+      'options' => ['limit' => 0],
+      'check_permissions' => 1,
+      'id' => ['IN' => $id],
+    ])['values'];
+    if (empty($perm)) {
+      throw new CRM_Core_Exception(ts('No records available'));
+    }
+    $this->set('id', implode(',', array_keys($perm)));
+    $pages = array_fill_keys($this->getTaskClass(), NULL);
+
+    $this->_stateMachine = new CRM_Core_StateMachine($this);
+    $this->_stateMachine->addSequentialPages($pages);
+    // create and instantiate the pages
+    $this->addPages($this->_stateMachine, $action);
+    // add all the actions
+    $this->addActions();
+  }
+
+  /**
+   * Get the name used to construct the class.
+   *
+   * @return string
+   */
+  abstract public function getEntity():string;
+
+  /**
+   * Get the available tasks for the entity.
+   *
+   * @return array
+   */
+  abstract public function getAvailableTasks():array;
+
+  /**
+   * Get the class for the action.
+   *
+   * @return array Array of the classes for the form controlle.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  protected function getTaskClass(): array {
+    $task = CRM_Utils_Request::retrieve('task', 'Alphanumeric', $this, TRUE);
+    foreach ($this->getAvailableTasks() as $taskAction) {
+      if (($taskAction['key'] ?? '') === $task) {
+        return (array) $taskAction['class'];
+      }
+    }
+    throw new CRM_Core_Exception(ts('Invalid task'));
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Adds support for url-based receipt sending - eg.

https://dmaster.localhost/civicrm/contribute/task?task=receipt&id=40,41

Before
----------------------------------------
Receipt functionality deeply tied to search process

After
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/111849063-9f308900-8971-11eb-8412-1e1650484f39.png)


Technical Details
----------------------------------------
@colemanw this is a first step towards adding more search tasks. I probably need to revisit it a little myself & do more testing but it builds on the cleanup I did a while back towards this

I exposed the action on the contribution tab of a contact - partly because it has been requested in the past but mostly to highlight this change & also the challenges - notably

1) the action is only available for some statuses - this has been implemented using the contexttualLinks function
2) when it opens in a pop-up the pdf won't download. This second one is something of a blocker to exposing it (although we can merge with it not exposed - but I suspect it will also be an issue in search-kit)
![image](https://user-images.githubusercontent.com/336308/113703094-77417380-972e-11eb-8a8a-c08b05ff208e.png)

*** I renamed from Receipt to Send Receipt so the above screenshot is a bit superceded ***

Comments
----------------------------------------
Remember to do a menu rebuild if you pull locally