### PR TITLE
[NFC] Fix test failures on PHP 7.4 caused by either NULL being set fo…

### DIFF
--- a/CRM/Member/Form.php
+++ b/CRM/Member/Form.php
@@ -497,7 +497,7 @@ class CRM_Member_Form extends CRM_Contribute_Form_AbstractEditPayment {
   public function testSubmit(array $formValues): void {
     $this->exportedValues = $formValues;
     $this->setContextVariables($formValues);
-    $this->_memType = $formValues['membership_type_id'][1];
+    $this->_memType = !empty($formValues['membership_type_id']) ? $formValues['membership_type_id'][1] : NULL;
     $this->_params = $formValues;
     $this->submit();
   }

--- a/tests/phpunit/CRM/Event/Form/ParticipantTest.php
+++ b/tests/phpunit/CRM/Event/Form/ParticipantTest.php
@@ -351,6 +351,7 @@ class CRM_Event_Form_ParticipantTest extends CiviUnitTestCase {
       $form->_bltID = 5;
       $form->_isPaidEvent = TRUE;
       CRM_Event_Form_EventFees::preProcess($form);
+      $form->assignProcessors();
       $form->buildEventFeeForm($form);
     }
     else {


### PR DESCRIPTION
…r the membership_type_id or Payment Processor not being set on the form

Overview
----------------------------------------
This fixes 2 test failures on PHP 7.4 as per title

Before
----------------------------------------
Tests fail

```
          <error type="PHPUnit\Framework\Error\Notice">CRM_Event_Form_ParticipantTest::testSubmitUnpaidPriceChangeWhileStillPending
Trying to access array offset on value of type null

/home/jenkins/bknix-edge/build/build-2/web/sites/all/modules/civicrm/CRM/Contribute/Form/AbstractEditPayment.php:695

            <error type="PHPUnit\Framework\Error\Notice">CRM_Member_Form_MembershipTest::testSubmitRecurTwoRows
Trying to access array offset on value of type null

/home/jenkins/bknix-edge/build/build-2/web/sites/all/modules/civicrm/CRM/Member/Form.php:500
```

After
----------------------------------------
Tests pass

ping @eileenmcnaughton 