### PR TITLE
[NFC] Fix logging schema test to work on MySQL8 as it no longer outpu…

### DIFF
--- a/tests/phpunit/CRM/Logging/SchemaTest.php
+++ b/tests/phpunit/CRM/Logging/SchemaTest.php
@@ -415,8 +415,8 @@ class CRM_Logging_SchemaTest extends CiviUnitTestCase {
     $dao = CRM_Core_DAO::executeQuery("SHOW CREATE TABLE civicrm_test_table");
     $dao->fetch();
     // using regex since not sure it's always int(10), so accept int(10), int(11), integer, etc...
-    $this->assertRegExp('/`id` int(.+) unsigned NOT NULL AUTO_INCREMENT/', $dao->Create_Table);
-    $this->assertRegExp('/`activity_id` int(.+) unsigned NOT NULL/', $dao->Create_Table);
+    $this->assertRegExp('/`id` int(.*) unsigned NOT NULL AUTO_INCREMENT/', $dao->Create_Table);
+    $this->assertRegExp('/`activity_id` int(.*) unsigned NOT NULL/', $dao->Create_Table);
     $this->assertStringContainsString('`texty` varchar(255)', $dao->Create_Table);
     $this->assertStringContainsString('ENGINE=InnoDB', $dao->Create_Table);
     $this->assertStringContainsString('FOREIGN KEY (`activity_id`) REFERENCES `civicrm_activity` (`id`) ON DELETE CASCADE', $dao->Create_Table);
@@ -426,8 +426,8 @@ class CRM_Logging_SchemaTest extends CiviUnitTestCase {
     $dao->fetch();
     $this->assertStringNotContainsString('AUTO_INCREMENT', $dao->Create_Table);
     // This seems debatable whether `id` should lose its NOT NULL status
-    $this->assertRegExp('/`id` int(.+) unsigned DEFAULT NULL/', $dao->Create_Table);
-    $this->assertRegExp('/`activity_id` int(.+) unsigned DEFAULT NULL/', $dao->Create_Table);
+    $this->assertRegExp('/`id` int(.*) unsigned DEFAULT NULL/', $dao->Create_Table);
+    $this->assertRegExp('/`activity_id` int(.*) unsigned DEFAULT NULL/', $dao->Create_Table);
     $this->assertStringContainsString('`texty` varchar(255)', $dao->Create_Table);
     $this->assertStringContainsString('ENGINE=InnoDB', $dao->Create_Table);
     $this->assertStringNotContainsString('FOREIGN KEY', $dao->Create_Table);


### PR DESCRIPTION
…ts a length for int columns

Overview
----------------------------------------
This fixes the Logging Schema test to work on MySQL 8 as per this test failure https://test.civicrm.org/job/CiviCRM-Core-Edge/CIVIVER=master,label=test-3/1084/testReport/junit/(root)/CRM_Logging_SchemaTest/testCreateTableWithLogging/ the issue is that MySQL 8 doesn't output column length for Ints see also https://stackoverflow.com/questions/60892749/mysql-8-ignoring-integer-lengths 

Before
----------------------------------------
Tests fail on MySQL 8 >= 8.0.19

After
----------------------------------------
Tests pass

ping @eileenmcnaughton @totten 
