### PR TITLE
dev/core#2366 - Failing test for php 7.4 and IDS for non-admins

### DIFF
--- a/tests/phpunit/CRM/Core/InvokeTest.php
+++ b/tests/phpunit/CRM/Core/InvokeTest.php
@@ -1,0 +1,33 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * @group headless
+ */
+class CRM_Core_InvokeTest extends CiviUnitTestCase {
+
+  /**
+   * Test that no php errors come up invoking dashboard url for non-admins
+   * Motivation: This currently fails on php 7.4 because of IDS and magicquotes.
+   */
+  public function testInvokeDashboardForNonAdmin(): void {
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = ['access CiviCRM'];
+
+    $_SERVER['REQUEST_URI'] = 'civicrm/dashboard?reset=1';
+    $_GET['q'] = 'civicrm/dashboard';
+
+    $item = CRM_Core_Invoke::getItem(['civicrm/dashboard?reset=1']);
+    ob_start();
+    CRM_Core_Invoke::runItem($item);
+    ob_end_clean();
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/2366

This will pass here, but will fail on edge tests with php 7.4. Because magic_quotes.

See possible solution at https://github.com/civicrm/civicrm-packages/pull/315

Before
----------------------------------------
php

After
----------------------------------------
php

Technical Details
----------------------------------------
Magic quotes

Comments
----------------------------------------
Is test

@seamuslee001 
