### PR TITLE
Api4 Explorer - Prevent long results from breaking layout

### DIFF
--- a/ang/api4Explorer/Explorer.html
+++ b/ang/api4Explorer/Explorer.html
@@ -5,8 +5,8 @@
     {{:: ts('CiviCRM APIv4') }}{{ entity ? (' (' + entity + '::' + action + ')') : '' }}
   </h1>
 
-  <div class="api4-explorer-row">
-      <form name="api4-explorer" class="panel panel-default explorer-params-panel">
+  <div class="api4-explorer-row crm-flex-box">
+      <form name="api4-explorer" class="panel panel-default explorer-params-panel crm-flex-2">
         <div class="panel-heading">
           <div class="form-inline">
             <span ng-mouseenter="help('entity', paramDoc('$entity'))" ng-mouseleave="help()">
@@ -189,7 +189,7 @@
         </div>
       </div>
   </div>
-  <div class="api4-explorer-row">
+  <div class="api4-explorer-row crm-flex-box">
       <div class="panel panel-info explorer-code-panel">
         <ul class="panel-heading nav nav-tabs">
           <li role="presentation" ng-repeat="lang in ::langs" ng-class="{active: selectedTab.code === lang}">

--- a/css/api4-explorer.css
+++ b/css/api4-explorer.css
@@ -16,16 +16,9 @@
 #bootstrap-theme .explorer-params-panel .panel-heading .form-inline > .select2-container {
   max-width: 25% !important;
 }
-#bootstrap-theme.api4-explorer-page .api4-explorer-row {
-  display: flex;
-}
-#bootstrap-theme.api4-explorer-page > div > .panel {
-  flex: 1;
+#bootstrap-theme .api4-explorer-row > .panel {
   margin: 10px;
   min-height: 500px;
-}
-#bootstrap-theme.api4-explorer-page > div > form.panel {
-  flex: 2;
 }
 /* Fix weird shorditch style */
 #bootstrap-theme.api4-explorer-page .api4-explorer-row .panel .panel-heading {


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a layout problem with the APIv4 Explorer when something in the Results panel is very long (e.g. a long query in the Debug tab).

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/2874912/111917724-eb55f900-8a57-11eb-97ea-6100896f0775.png)


After
----------------------------------------
![image](https://user-images.githubusercontent.com/2874912/111917688-c8c3e000-8a57-11eb-8c7a-e2fb4cf2ff51.png)


Technical Details
----------------------------------------
Solution was to use Civi's new flex-box css :)
