### PR TITLE
SearchKit - Include custom group title with custom field label

### DIFF
--- a/Civi/Api4/Service/Schema/Joinable/CustomGroupJoinable.php
+++ b/Civi/Api4/Service/Schema/Joinable/CustomGroupJoinable.php
@@ -60,7 +60,7 @@ class CustomGroupJoinable extends Joinable {
     $entityFields = (array) \Civi::cache('metadata')->get($cacheKey);
     if (!$entityFields) {
       $fields = CustomField::get(FALSE)
-        ->setSelect(['custom_group.name', 'custom_group.extends', 'custom_group.table_name', '*'])
+        ->setSelect(['custom_group.name', 'custom_group.extends', 'custom_group.table_name', 'custom_group.title', '*'])
         ->addWhere('custom_group.table_name', '=', $this->getTargetTable())
         ->execute();
       foreach ($fields as $field) {

--- a/Civi/Api4/Service/Spec/SpecFormatter.php
+++ b/Civi/Api4/Service/Spec/SpecFormatter.php
@@ -63,7 +63,8 @@ class SpecFormatter {
       $field->setColumnName($data['column_name']);
       $field->setCustomFieldId($data['id'] ?? NULL);
       $field->setCustomGroupName($data['custom_group.name']);
-      $field->setTitle($data['label'] ?? NULL);
+      $field->setTitle($data['label']);
+      $field->setLabel($data['custom_group.title'] . ': ' . $data['label']);
       $field->setHelpPre($data['help_pre'] ?? NULL);
       $field->setHelpPost($data['help_post'] ?? NULL);
       $field->setOptions(self::customFieldHasOptions($data));

--- a/Civi/Api4/Service/Spec/SpecGatherer.php
+++ b/Civi/Api4/Service/Spec/SpecGatherer.php
@@ -132,7 +132,7 @@ class SpecGatherer {
     $customFields = CustomField::get(FALSE)
       ->addWhere('custom_group.extends', 'IN', $extends)
       ->addWhere('custom_group.is_multiple', '=', '0')
-      ->setSelect(['custom_group.name', '*'])
+      ->setSelect(['custom_group.name', 'custom_group.title', '*'])
       ->execute();
 
     foreach ($customFields as $fieldArray) {
@@ -148,7 +148,7 @@ class SpecGatherer {
   private function getCustomGroupFields($customGroup, RequestSpec $specification) {
     $customFields = CustomField::get(FALSE)
       ->addWhere('custom_group.name', '=', $customGroup)
-      ->setSelect(['custom_group.name', 'custom_group.table_name', '*'])
+      ->setSelect(['custom_group.name', 'custom_group.table_name', 'custom_group.title', '*'])
       ->execute();
 
     foreach ($customFields as $fieldArray) {

--- a/tests/phpunit/api/v4/Spec/SpecFormatterTest.php
+++ b/tests/phpunit/api/v4/Spec/SpecFormatterTest.php
@@ -62,8 +62,10 @@ class SpecFormatterTest extends UnitTestCase {
     $data = [
       'custom_group_id' => $customGroupId,
       'custom_group.name' => 'my_group',
+      'custom_group.title' => 'My Group',
       'id' => $customFieldId,
       'name' => $name,
+      'label' => $name,
       'data_type' => 'String',
       'html_type' => 'Select',
       'column_name' => $name,


### PR DESCRIPTION
Overview
----------------------------------------
This makes it easier to tell custom fields apart in SearchKit when they have similar names to core or other custom fields.

Before
----------------------------------------
Custom fields identified by title in the ui.

After
----------------------------------------
Custom field labels include custom group title + custom field title.

Technical Details
----------------------------------------
This takes advantage of API4.getFields returning both a "title" and "label" attribute.
Previously both values were the same for custom fields.
This leaves "title" unchanged while appending group title to "label".