### PR TITLE
Fix loop

### DIFF
--- a/CRM/Core/Error.php
+++ b/CRM/Core/Error.php
@@ -829,7 +829,7 @@ class CRM_Core_Error extends PEAR_ErrorStack {
     // Exception backtrace
     if ($e instanceof PEAR_Exception) {
       $ei = $e;
-      while (is_callable([$ei, 'getCause'])) {
+      if (is_callable([$ei, 'getCause'])) {
         // DB_ERROR doesn't have a getCause but does have a __call function which tricks is_callable.
         if (!$ei instanceof DB_Error) {
           if ($ei->getCause() instanceof PEAR_Error) {


### PR DESCRIPTION


Overview
----------------------------------------
It turns out that if you 'break' advanced search (in my case
I applied a patch that caused invalid sql) it enters a loop.

I really can't see why 'while' would have ever made sense here.

There is nothing to cause it to 'move along'

Before
----------------------------------------
Loop

After
----------------------------------------
error

Technical Details
----------------------------------------

Comments
----------------------------------------
@demeritcowboy I got a loop testing https://github.com/civicrm/civicrm-core/pull/19619 - wondering if you did or if not what is different