### PR TITLE
Add handling for error at smarty level

### DIFF
--- a/Civi/Token/TokenCompatSubscriber.php
+++ b/Civi/Token/TokenCompatSubscriber.php
@@ -127,8 +127,16 @@ class TokenCompatSubscriber implements EventSubscriberInterface {
 
     if ($useSmarty) {
       $smarty = \CRM_Core_Smarty::singleton();
+      $handler = set_error_handler([$this, 'handleSmartyError']);
       $e->string = $smarty->fetch("string:" . $e->string);
+      set_error_handler($handler);
     }
+  }
+
+  public function handleSmartyError($errno, $errstr, $errfile, $errline) {
+    $event = new \Civi\Core\Event\SmartyErrorEvent($errno, $errstr);
+    \Civi::dispatcher()->dispatch('civi.smarty.error', $event);
+    throw new \CRM_Core_Exception($errno, $errstr);
   }
 
 }


### PR DESCRIPTION
This is the fix for https://github.com/civicrm/civicrm-packages/pull/313 that avoids hacking
an external package.

I just did it in order to test https://github.com/civicrm/civicrm-core/pull/18466
& am not intending on keeping this open as a PR

Overview
----------------------------------------
_A brief description of the pull request. Keep technical jargon to a minimum. Hyperlink relevant discussions._

Before
----------------------------------------
_What is the old user-interface or technical-contract (as appropriate)?_
_For optimal clarity, include a concrete example such as a screenshot, GIF ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)), or code-snippet._

After
----------------------------------------
_What changed? What is new old user-interface or technical-contract?_
_For optimal clarity, include a concrete example such as a screenshot, GIF ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)), or code-snippet._

Technical Details
----------------------------------------
_If the PR involves technical details/changes/considerations which would not be manifest to a casual developer skimming the above sections, please describe the details here._

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
