### PR TITLE
Flexmailer - Enable `traditional` mailing support by default

### DIFF
--- a/ext/flexmailer/settings/flexmailer.setting.php
+++ b/ext/flexmailer/settings/flexmailer.setting.php
@@ -11,7 +11,7 @@ return [
     'html_type' => 'select',
     'html_attributes' => ['class' => 'crm-select2'],
     'pseudoconstant' => ['callback' => '_flexmailer_traditional_options'],
-    'default' => 'auto',
+    'default' => 'flexmailer',
     'add' => '5.13',
     'title' => E::ts('Traditional Mailing Handler'),
     'is_domain' => 1,

--- a/ext/flexmailer/settings/flexmailer.setting.php
+++ b/ext/flexmailer/settings/flexmailer.setting.php
@@ -11,7 +11,7 @@ return [
     'html_type' => 'select',
     'html_attributes' => ['class' => 'crm-select2'],
     'pseudoconstant' => ['callback' => '_flexmailer_traditional_options'],
-    'default' => 'flexmailer',
+    'default' => 'auto',
     'add' => '5.13',
     'title' => E::ts('Traditional Mailing Handler'),
     'is_domain' => 1,

--- a/ext/flexmailer/src/Listener/Abdicator.php
+++ b/ext/flexmailer/src/Listener/Abdicator.php
@@ -40,15 +40,10 @@ class Abdicator {
     }
 
     switch (\Civi::settings()->get('flexmailer_traditional')) {
-      case 'auto':
-        // Transitional support for old hidden setting "experimentalFlexMailerEngine" (bool)
-        // TODO: Remove this. Maybe after Q4 2019.
-        // TODO: Change this to default to flexmailer
-        return (bool) \Civi::settings()->get('experimentalFlexMailerEngine');
-
       case 'bao':
         return FALSE;
 
+      case 'auto':
       case 'flexmailer':
         return TRUE;
 

--- a/tests/phpunit/CRM/Mailing/MailingSystemTest.php
+++ b/tests/phpunit/CRM/Mailing/MailingSystemTest.php
@@ -40,7 +40,9 @@ class CRM_Mailing_MailingSystemTest extends CRM_Mailing_BaseMailingSystemTest {
 
   public function setUp() {
     parent::setUp();
-    Civi::settings()->add(['experimentalFlexMailerEngine' => FALSE]);
+    // If we happen to execute with flexmailer active, use BAO mode.
+    // There is a parallel FlexMailerSystemTest which runs in flexmailer mode.
+    Civi::settings()->add(['flexmailer_traditional' => 'bao']);
 
     $hooks = \CRM_Utils_Hook::singleton();
     $hooks->setHook('civicrm_alterMailParams',


### PR DESCRIPTION

Overview
----------------------------------------
Switches to defaulting to flexmailer, if enabled.

This should be merged in conjunction with https://github.com/civicrm/civicrm-core/pull/19806
in order to keep those on the default in consistent state
(ie they will already be getting display-rendering for custom fields
and that will still be the case if 19806 is merged)

Before
----------------------------------------
If not otherwise set flexmailer defaults to using Mailing_BAO classes

After
----------------------------------------
If not otherwise set flexmailer defaults to flexmailer class

Technical Details
----------------------------------------
Step towards only having one code path to maintain

Comments
----------------------------------------
