### PR TITLE
SearchKit - remove extra irrelevant fields from bridge joins

### DIFF
--- a/ext/search/Civi/Search/Admin.php
+++ b/ext/search/Civi/Search/Admin.php
@@ -133,15 +133,17 @@ class Admin {
     // Add in FK fields for implicit joins
     // For example, add a `campaign.title` field to the Contribution entity
     foreach ($schema as &$entity) {
-      foreach (array_reverse($entity['fields'], TRUE) as $index => $field) {
-        if (!empty($field['fk_entity']) && !$field['options'] && !empty($schema[$field['fk_entity']]['label_field'])) {
-          // The original field will get title instead of label since it represents the id (title usually ends in ID but label does not)
-          $entity['fields'][$index]['label'] = $field['title'];
-          // Add the label field from the other entity to this entity's list of fields
-          $newField = \CRM_Utils_Array::findAll($schema[$field['fk_entity']]['fields'], ['name' => $schema[$field['fk_entity']]['label_field']])[0];
-          $newField['name'] = str_replace('_id', '', $field['name']) . '.' . $schema[$field['fk_entity']]['label_field'];
-          $newField['label'] = $field['label'] . ' ' . $newField['label'];
-          array_splice($entity['fields'], $index, 0, [$newField]);
+      if (in_array('DAOEntity', $entity['type'], TRUE) && !in_array('EntityBridge', $entity['type'], TRUE)) {
+        foreach (array_reverse($entity['fields'], TRUE) as $index => $field) {
+          if (!empty($field['fk_entity']) && !$field['options'] && !empty($schema[$field['fk_entity']]['label_field'])) {
+            // The original field will get title instead of label since it represents the id (title usually ends in ID but label does not)
+            $entity['fields'][$index]['label'] = $field['title'];
+            // Add the label field from the other entity to this entity's list of fields
+            $newField = \CRM_Utils_Array::findAll($schema[$field['fk_entity']]['fields'], ['name' => $schema[$field['fk_entity']]['label_field']])[0];
+            $newField['name'] = str_replace('_id', '', $field['name']) . '.' . $schema[$field['fk_entity']]['label_field'];
+            $newField['label'] = $field['label'] . ' ' . $newField['label'];
+            array_splice($entity['fields'], $index, 0, [$newField]);
+          }
         }
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------
Removes a few confusingly redundant fields from searchKit when using a bridge join.

Before
----------------------------------------
Search for: Contacts
With: Related Contacts
Where: (notice that contact A display name and contact B display names are options in the list)

After
----------------------------------------
Redundant options gone

Technical Details
----------------------------------------
Those fields are redundant and would have caused unnecessary extra joins to be added to the query.