### PR TITLE
info.xml - Allow PSR-0 style class-loader declarations

### DIFF
--- a/CRM/Extension/ClassLoader.php
+++ b/CRM/Extension/ClassLoader.php
@@ -15,6 +15,13 @@
 class CRM_Extension_ClassLoader {
 
   /**
+   * List of class-loader features that are valid in this version of Civi.
+   *
+   * This may be useful for some extensions which enable/disable polyfills based on environment.
+   */
+  const FEATURES = ',psr0,psr4,';
+
+  /**
    * @var CRM_Extension_Mapper
    */
   protected $mapper;
@@ -92,6 +99,10 @@ class CRM_Extension_ClassLoader {
       if (!empty($info->classloader)) {
         foreach ($info->classloader as $mapping) {
           switch ($mapping['type']) {
+            case 'psr0':
+              $loader->add($mapping['prefix'], CRM_Utils_File::addTrailingSlash($path . '/' . $mapping['path']));
+              break;
+
             case 'psr4':
               $loader->addPsr4($mapping['prefix'], $path . '/' . $mapping['path']);
               break;

--- a/CRM/Extension/Info.php
+++ b/CRM/Extension/Info.php
@@ -175,6 +175,13 @@ class CRM_Extension_Info {
             'path' => (string) $psr4->attributes()->path,
           ];
         }
+        foreach ($val->psr0 as $psr0) {
+          $this->classloader[] = [
+            'type' => 'psr0',
+            'prefix' => (string) $psr0->attributes()->prefix,
+            'path' => (string) $psr0->attributes()->path,
+          ];
+        }
       }
       elseif ($attr === 'tags') {
         $this->tags = [];

--- a/tests/phpunit/CRM/Extension/InfoTest.php
+++ b/tests/phpunit/CRM/Extension/InfoTest.php
@@ -55,7 +55,10 @@ class CRM_Extension_InfoTest extends CiviUnitTestCase {
 
   public function testGood_string_extras() {
     $data = "<extension key='test.bar' type='module'><file>testbar</file>
-      <classloader><psr4 prefix=\"Civi\\\" path=\"Civi\"/></classloader>
+      <classloader>
+        <psr4 prefix=\"Civi\\\" path=\"Civi\"/>
+        <psr0 prefix=\"CRM_\" path=\"\"/>
+      </classloader>
       <requires><ext>org.civicrm.a</ext><ext>org.civicrm.b</ext></requires>
     </extension>
     ";
@@ -65,6 +68,10 @@ class CRM_Extension_InfoTest extends CiviUnitTestCase {
     $this->assertEquals('testbar', $info->file);
     $this->assertEquals('Civi\\', $info->classloader[0]['prefix']);
     $this->assertEquals('Civi', $info->classloader[0]['path']);
+    $this->assertEquals('psr4', $info->classloader[0]['type']);
+    $this->assertEquals('CRM_', $info->classloader[1]['prefix']);
+    $this->assertEquals('', $info->classloader[1]['path']);
+    $this->assertEquals('psr0', $info->classloader[1]['type']);
     $this->assertEquals(['org.civicrm.a', 'org.civicrm.b'], $info->requires);
   }
 


### PR DESCRIPTION
Before
------

If an extension defines a class in the style of `CRM_Foo_Bar`, then it *must* use `hook_civicrm_config` and modify the `include_path`.

```php
function mymod_civicrm_config(&$config = NULL) {
  $extRoot = dirname(__FILE__) . DIRECTORY_SEPARATOR;
  $include_path = $extRoot . PATH_SEPARATOR . get_include_path();
  set_include_path($include_path);
}
```

Consequently:

* The `include_path` gets rather long.
* Setting up the extension class-loader is not sufficient for loading these classes. You must wait until the DB has initialized and the `hook_civicrm_config` has fired.

After
-----

An extension *may* setup classloading in `info.xml`, e.g.

```xml
<classloader>
  <psr0 prefix="CRM_" path="" />
</classloader>
```

If the `<psr0>` style is used, then it is possible to scan the extension classes without fully booting the extension.  This is a pre-req for using interfaces, annotations, or similar for performant event-registration.

Comments
--------

* This style closely parallels the `<psr4>` support in `info.xml`, and it parallels the semantics of `composer.json`.
* `CRM_*` naming is the de facto standard for extensions. The merit of that is debatable, but it's a separate topic. My main aim here is to make the pre-conditions/post-conditions of `CRM_Extension_ClassLoader` clearer -- ie it should (in fact) setup classloading for extensions, and right now there's a common situation for which it cannot (*unless one imposes invasive changes*).
* It is still valid for an extension to set `include_path` -- that works the same as ever.
