### PR TITLE
Return from getACLRoles when contactID is not null

### DIFF
--- a/CRM/ACL/BAO/ACL.php
+++ b/CRM/ACL/BAO/ACL.php
@@ -122,7 +122,7 @@ class CRM_ACL_BAO_ACL extends CRM_ACL_DAO_ACL {
     $where = ['acl.entity_table = "civicrm_acl_role" AND acl.entity_id IN (' . implode(',', array_keys(CRM_Core_OptionGroup::values('acl_role'))) . ')'];
 
     if (!empty($contact_id)) {
-      $where[] = " acl.entity_table  = 'civicrm_contact' AND acl.is_active = 1 AND acl.entity_id = $contact_id";
+      return [];
     }
 
     $results = [];


### PR DESCRIPTION

Overview
----------------------------------------
Return empty array from getACLRoles when contactID is null

This one line patch is the thinking part of cleaning up this function - ie it involves reading through the code & figuring out why the query doesn't make sense / will never return anything if contact_id is not empty.


Before
----------------------------------------
getACLRoles always returns empty when $contact_id is not NULL - but it hurts our brains

Basically the where is 

```WHERE acl.entity_table='civicrm_acl_role'....```

if contact_id is set it becomes 

```AND acl.entity_table = 'civicrm_contact'```

Which means that it would only ever return empty results

After
----------------------------------------
getACLRoles always returns empty when $contact_id is not NULL - but with less pain

Technical Details
----------------------------------------
I've made this patch the least possible code wise to allow brain space to think about the query....


(once this is merged more cleanup can happen but I wanted to
make this change easy to think through)

Comments
----------------------------------------
@colemanw @seamuslee001 this really is the state of the acl code - it's mad