### PR TITLE
dev/core#2463 - Adjust returned list of activity ids when sending emails since it changes in 5.36+

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -1017,7 +1017,9 @@ class CRM_Activity_BAO_Activity extends CRM_Activity_DAO_Activity {
    * @param int $caseId
    *
    * @return array
-   *   ( sent, activityId) if any email is sent and activityId
+   *   bool $sent FIXME: this only indicates the status of the last email sent.
+   *   array $activityIds The activity ids created, one per "To" recipient.
+   *
    * @throws \CRM_Core_Exception
    * @throws \CiviCRM_API3_Exception
    */
@@ -1116,6 +1118,7 @@ class CRM_Activity_BAO_Activity extends CRM_Activity_DAO_Activity {
 
     $sent = $notSent = [];
     $attachmentFileIds = [];
+    $activityIds = [];
     $firstActivityCreated = FALSE;
     foreach ($contactDetails as $values) {
       $contactId = $values['contact_id'];
@@ -1178,6 +1181,7 @@ class CRM_Activity_BAO_Activity extends CRM_Activity_DAO_Activity {
 
       // Create email activity.
       $activityID = self::createEmailActivity($userID, $tokenSubject, $tokenHtml, $tokenText, $additionalDetails, $campaignId, $attachments, $caseId);
+      $activityIds[] = $activityID;
 
       if ($firstActivityCreated == FALSE && !empty($attachments)) {
         $attachmentFileIds = self::getAttachmentFileIds($activityID, $attachments);
@@ -1203,7 +1207,7 @@ class CRM_Activity_BAO_Activity extends CRM_Activity_DAO_Activity {
       }
     }
 
-    return [$sent, $activityID];
+    return [$sent, $activityIds];
   }
 
   /**

--- a/CRM/Contact/Form/Task/EmailTrait.php
+++ b/CRM/Contact/Form/Task/EmailTrait.php
@@ -413,7 +413,7 @@ trait CRM_Contact_Form_Task_EmailTrait {
     }
 
     // send the mail
-    list($sent, $activityId) = CRM_Activity_BAO_Activity::sendEmail(
+    list($sent, $activityIds) = CRM_Activity_BAO_Activity::sendEmail(
       $formattedContactDetails,
       $this->getSubject($formValues['subject']),
       $formValues['text_message'],
@@ -432,7 +432,12 @@ trait CRM_Contact_Form_Task_EmailTrait {
     );
 
     if ($sent) {
-      $followupStatus = $this->createFollowUpActivities($formValues, $activityId);
+      // Only use the first activity id if there's multiple.
+      // If there's multiple recipients the idea behind multiple activities
+      // is to record the token value replacements separately, but that
+      // has no meaning for followup activities, and this doesn't prevent
+      // creating more manually if desired.
+      $followupStatus = $this->createFollowUpActivities($formValues, $activityIds[0]);
       $count_success = count($this->_toContactDetails);
       CRM_Core_Session::setStatus(ts('One message was sent successfully. ', [
         'plural' => '%count messages were sent successfully. ',


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/2463

Followup to https://github.com/civicrm/civicrm-core/pull/19826 and towards making the recorded activity ids available to hooks.

I'm a bit conflicted about changing the signature for a public static function. But at the same time any extensions that call this function and act on the single activity id it returns are now doing it wrong as of 5.36, since they're missing all the other activity ids. Universe suggests there's a small handful. An alternative would be to keep the signature and provide some other way to get at the ids, which doesn't seem hard, but does it really help the existing extensions?

Before
----------------------------------------
In 5.35 and earlier, only one activity was recorded when there were multiple recipients when sending a (non-bulk) email. In 5.36 it now records multiple activities, but the code still returns just the last activity id to its caller.

After
----------------------------------------
Returns all the ids.

Technical Details
----------------------------------------
One thing that came up during the original review of the [multiple activities PR](https://github.com/civicrm/civicrm-core/pull/18299) had to do with any scheduled followups. I've left that as-is so it still only links the followup to one of the activity ids. The original quote:

> For scheduled followups (the section at the bottom of the email form where you can create a supplementary activity at the same time as sending the email), it doesn't quite match my understanding of the discussion and the "multiple" policy, but this doesn't have anything to do with tokens and seems fine to me. In the multiple policy, there'd be a separate followup activity for each To recipient, but I think it's fine that it creates just one with the combined To's. If you really want separate ones, you can still make more manually.

Comments
----------------------------------------
This doesn't do anything with the returned ids yet. Making it available to hooks would be a followup.

There's some coverage for multiple recipients at testSendEmailWillReplaceTokensUniquelyForEachContact. But I should probably add something to explicitly test the returned values.