### PR TITLE
[WIP] dev/core#2473 - Don't crash when assignee left blank when creating followup on email activity

### DIFF
--- a/CRM/Contact/Form/Task/EmailTrait.php
+++ b/CRM/Contact/Form/Task/EmailTrait.php
@@ -630,7 +630,7 @@ trait CRM_Contact_Form_Task_EmailTrait {
       $params['followup_activity_subject'] = $formValues['followup_activity_subject'];
       $params['followup_date'] = $formValues['followup_date'];
       $params['target_contact_id'] = $this->_contactIds;
-      $params['followup_assignee_contact_id'] = explode(',', $formValues['followup_assignee_contact_id']);
+      $params['followup_assignee_contact_id'] = array_filter(explode(',', $formValues['followup_assignee_contact_id']));
       $followupActivity = CRM_Activity_BAO_Activity::createFollowupActivity($activityId, $params);
       $followupStatus = ts('A followup activity has been scheduled.');
 


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/2473

Before
----------------------------------------
1. Create an email activity.
2. Fill out the followup section near the bottom but leave the assignee there blank.
3. Crash.

After
----------------------------------------
No crash.

Technical Details
----------------------------------------
The function ends up passing in `array(0 => "")`, which technically is not an empty array. Some changes in 5.31 end up converting the `""` to a 0 instead of ignoring it which then causes a violation constraint for the assignee id.

Comments
----------------------------------------

