### PR TITLE
Reorganize contact summary template to support non-ajax tabs

### DIFF
--- a/CRM/Contact/Page/View/Summary.php
+++ b/CRM/Contact/Page/View/Summary.php
@@ -297,7 +297,7 @@ class CRM_Contact_Page_View_Summary extends CRM_Contact_Page_View {
     return [
       [
         'id' => 'summary',
-        'url' => '#contact-summary',
+        'template' => 'CRM/Contact/Page/View/Summary-tab.tpl',
         'title' => ts('Summary'),
         'weight' => 0,
         'icon' => 'crm-i fa-address-card-o',

--- a/templates/CRM/Contact/Page/View/Summary-tab.tpl
+++ b/templates/CRM/Contact/Page/View/Summary-tab.tpl
@@ -1,0 +1,156 @@
+{*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+*}
+{* Summary tab from Contact Summary screen *}
+
+{if (isset($hookContentPlacement) and ($hookContentPlacement neq 3)) or empty($hookContentPlacement)}
+
+  {if !empty($hookContent) and isset($hookContentPlacement) and $hookContentPlacement eq 2}
+    {include file="CRM/Contact/Page/View/SummaryHook.tpl"}
+  {/if}
+
+  <div class="contactTopBar contact_panel">
+    <div class="contactCardLeft">
+      {crmRegion name="contact-basic-info-left"}
+        <div class="crm-summary-contactinfo-block">
+          <div class="crm-summary-block" id="contactinfo-block">
+            {include file="CRM/Contact/Page/Inline/ContactInfo.tpl"}
+          </div>
+        </div>
+      {/crmRegion}
+    </div>
+    <div class="contactCardRight">
+      {crmRegion name="contact-basic-info-right"}
+      {if !empty($imageURL)}
+        <div id="crm-contact-thumbnail">
+          {include file="CRM/Contact/Page/ContactImage.tpl"}
+        </div>
+      {/if}
+        <div class="{if !empty($imageURL)} float-left{/if}">
+          <div class="crm-summary-basic-block crm-summary-block">
+            {include file="CRM/Contact/Page/Inline/Basic.tpl"}
+          </div>
+        </div>
+      {/crmRegion}
+    </div>
+  </div>
+  <div class="contact_details">
+    <div class="contact_panel">
+      <div class="contactCardLeft">
+        {crmRegion name="contact-details-left"}
+          <div >
+            {if $showEmail}
+              <div class="crm-summary-email-block crm-summary-block" id="email-block">
+                {include file="CRM/Contact/Page/Inline/Email.tpl"}
+              </div>
+            {/if}
+            {if $showWebsite}
+              <div class="crm-summary-website-block crm-summary-block" id="website-block">
+                {include file="CRM/Contact/Page/Inline/Website.tpl"}
+              </div>
+            {/if}
+          </div>
+        {/crmRegion}
+      </div><!-- #contactCardLeft -->
+
+      <div class="contactCardRight">
+        {crmRegion name="contact-details-right"}
+          <div>
+            {if $showPhone}
+              <div class="crm-summary-phone-block crm-summary-block" id="phone-block">
+                {include file="CRM/Contact/Page/Inline/Phone.tpl"}
+              </div>
+            {/if}
+            {if $showIM}
+              <div class="crm-summary-im-block crm-summary-block" id="im-block">
+                {include file="CRM/Contact/Page/Inline/IM.tpl"}
+              </div>
+            {/if}
+            {if $showOpenID}
+              <div class="crm-summary-openid-block crm-summary-block" id="openid-block">
+                {include file="CRM/Contact/Page/Inline/OpenID.tpl"}
+              </div>
+            {/if}
+          </div>
+        {/crmRegion}
+      </div><!-- #contactCardRight -->
+
+      <div class="clear"></div>
+    </div><!-- #contact_panel -->
+    {if $showAddress}
+      <div class="contact_panel">
+        {crmRegion name="contact-addresses"}
+        {assign var='locationIndex' value=1}
+        {if $address}
+          {foreach from=$address item=add key=locationIndex}
+            <div class="{if $locationIndex is odd}contactCardLeft{else}contactCardRight{/if} crm-address_{$locationIndex} crm-address-block crm-summary-block">
+              {include file="CRM/Contact/Page/Inline/Address.tpl"}
+            </div>
+          {/foreach}
+          {assign var='locationIndex' value=$locationIndex+1}
+        {/if}
+          {* add new link *}
+        {if $permission EQ 'edit'}
+          {assign var='add' value=0}
+          <div class="{if $locationIndex is odd}contactCardLeft{else}contactCardRight{/if} crm-address-block crm-summary-block">
+            {include file="CRM/Contact/Page/Inline/Address.tpl"}
+          </div>
+        {/if}
+        {/crmRegion}
+      </div> <!-- end of contact panel -->
+    {/if}
+    <div class="contact_panel">
+      {if $showCommunicationPreferences}
+        <div class="contactCardLeft">
+          {crmRegion name="contact-comm-pref"}
+            <div class="crm-summary-comm-pref-block">
+              <div class="crm-summary-block" id="communication-pref-block" >
+                {include file="CRM/Contact/Page/Inline/CommunicationPreferences.tpl"}
+              </div>
+            </div>
+          {/crmRegion}
+        </div> <!-- contactCardLeft -->
+      {/if}
+      {if $contact_type eq 'Individual' AND $showDemographics}
+        <div class="contactCardRight">
+          {crmRegion name="contact-demographic"}
+            <div class="crm-summary-demographic-block">
+              <div class="crm-summary-block" id="demographic-block">
+                {include file="CRM/Contact/Page/Inline/Demographics.tpl"}
+              </div>
+            </div>
+          {/crmRegion}
+        </div> <!-- contactCardRight -->
+      {/if}
+      <div class="clear"></div>
+      <div class="separator"></div>
+    </div> <!-- contact panel -->
+  </div><!--contact_details-->
+
+  {if $showCustomData}
+    <div id="customFields">
+      <div class="contact_panel">
+        <div class="contactCardLeft">
+          {include file="CRM/Contact/Page/View/CustomDataView.tpl" side='1'}
+        </div><!--contactCardLeft-->
+        <div class="contactCardRight">
+          {include file="CRM/Contact/Page/View/CustomDataView.tpl" side='0'}
+        </div>
+
+        <div class="clear"></div>
+      </div>
+    </div>
+  {/if}
+
+  {if !empty($hookContent) and isset($hookContentPlacement) and $hookContentPlacement eq 1}
+    {include file="CRM/Contact/Page/View/SummaryHook.tpl"}
+  {/if}
+{else}
+  {include file="CRM/Contact/Page/View/SummaryHook.tpl"}
+{/if}

--- a/templates/CRM/Contact/Page/View/Summary.tpl
+++ b/templates/CRM/Contact/Page/View/Summary.tpl
@@ -107,9 +107,9 @@
   <div class="crm-block crm-content-block crm-contact-page crm-inline-edit-container">
     <div id="mainTabContainer">
       <ul class="crm-contact-tabs-list">
-        {foreach from=$allTabs key=tabName item=tabValue}
+        {foreach from=$allTabs item=tabValue}
           <li id="tab_{$tabValue.id}" class="crm-tab-button ui-corner-all crm-count-{$tabValue.count}{if isset($tabValue.class)} {$tabValue.class}{/if}">
-            <a href="{$tabValue.url}" title="{$tabValue.title|escape}">
+            <a href="{if !empty($tabValue.template)}#contact-{$tabValue.id}{else}{$tabValue.url}{/if}" title="{$tabValue.title|escape}">
               <i class="{if $tabValue.icon}{$tabValue.icon}{else}crm-i fa-puzzle-piece{/if}" aria-hidden="true"></i>
               <span>{$tabValue.title}</span>
               {if empty($tabValue.hideCount)}<em>{$tabValue.count}</em>{/if}
@@ -118,158 +118,16 @@
         {/foreach}
       </ul>
 
-      <div id="contact-summary" class="ui-tabs-panel ui-widget-content ui-corner-bottom">
-        {if (isset($hookContentPlacement) and ($hookContentPlacement neq 3)) or empty($hookContentPlacement)}
-
-          {if !empty($hookContent) and isset($hookContentPlacement) and $hookContentPlacement eq 2}
-            {include file="CRM/Contact/Page/View/SummaryHook.tpl"}
-          {/if}
-
-          <div class="contactTopBar contact_panel">
-            <div class="contactCardLeft">
-              {crmRegion name="contact-basic-info-left"}
-                <div class="crm-summary-contactinfo-block">
-                  <div class="crm-summary-block" id="contactinfo-block">
-                    {include file="CRM/Contact/Page/Inline/ContactInfo.tpl"}
-                  </div>
-                </div>
-              {/crmRegion}
-            </div> <!-- end of left side -->
-            <div class="contactCardRight">
-              {crmRegion name="contact-basic-info-right"}
-              {if !empty($imageURL)}
-                <div id="crm-contact-thumbnail">
-                  {include file="CRM/Contact/Page/ContactImage.tpl"}
-                </div>
-              {/if}
-                <div class="{if !empty($imageURL)} float-left{/if}">
-                  <div class="crm-summary-basic-block crm-summary-block">
-                    {include file="CRM/Contact/Page/Inline/Basic.tpl"}
-                  </div>
-                </div>
-              {/crmRegion}
-            </div>
-            <!-- end of right side -->
-        </div>
-        <div class="contact_details">
-          <div class="contact_panel">
-            <div class="contactCardLeft">
-              {crmRegion name="contact-details-left"}
-                <div >
-                  {if $showEmail}
-                    <div class="crm-summary-email-block crm-summary-block" id="email-block">
-                      {include file="CRM/Contact/Page/Inline/Email.tpl"}
-                    </div>
-                  {/if}
-                  {if $showWebsite}
-                    <div class="crm-summary-website-block crm-summary-block" id="website-block">
-                      {include file="CRM/Contact/Page/Inline/Website.tpl"}
-                    </div>
-                  {/if}
-                </div>
-              {/crmRegion}
-            </div><!-- #contactCardLeft -->
-
-            <div class="contactCardRight">
-              {crmRegion name="contact-details-right"}
-                <div>
-                  {if $showPhone}
-                    <div class="crm-summary-phone-block crm-summary-block" id="phone-block">
-                      {include file="CRM/Contact/Page/Inline/Phone.tpl"}
-                    </div>
-                  {/if}
-                  {if $showIM}
-                    <div class="crm-summary-im-block crm-summary-block" id="im-block">
-                      {include file="CRM/Contact/Page/Inline/IM.tpl"}
-                    </div>
-                  {/if}
-                  {if $showOpenID}
-                    <div class="crm-summary-openid-block crm-summary-block" id="openid-block">
-                      {include file="CRM/Contact/Page/Inline/OpenID.tpl"}
-                    </div>
-                  {/if}
-                </div>
-              {/crmRegion}
-            </div><!-- #contactCardRight -->
-
-            <div class="clear"></div>
-          </div><!-- #contact_panel -->
-          {if $showAddress}
-            <div class="contact_panel">
-              {crmRegion name="contact-addresses"}
-              {assign var='locationIndex' value=1}
-              {if $address}
-                {foreach from=$address item=add key=locationIndex}
-                  <div class="{if $locationIndex is odd}contactCardLeft{else}contactCardRight{/if} crm-address_{$locationIndex} crm-address-block crm-summary-block">
-                    {include file="CRM/Contact/Page/Inline/Address.tpl"}
-                  </div>
-                {/foreach}
-                {assign var='locationIndex' value=$locationIndex+1}
-              {/if}
-              {* add new link *}
-              {if $permission EQ 'edit'}
-                {assign var='add' value=0}
-                <div class="{if $locationIndex is odd}contactCardLeft{else}contactCardRight{/if} crm-address-block crm-summary-block">
-                  {include file="CRM/Contact/Page/Inline/Address.tpl"}
-                </div>
-              {/if}
-              {/crmRegion}
-              </div> <!-- end of contact panel -->
-            {/if}
-            <div class="contact_panel">
-              {if $showCommunicationPreferences}
-                <div class="contactCardLeft">
-                  {crmRegion name="contact-comm-pref"}
-                  <div class="crm-summary-comm-pref-block">
-                    <div class="crm-summary-block" id="communication-pref-block" >
-                      {include file="CRM/Contact/Page/Inline/CommunicationPreferences.tpl"}
-                    </div>
-                  </div>
-                  {/crmRegion}
-                </div> <!-- contactCardLeft -->
-              {/if}
-              {if $contact_type eq 'Individual' AND $showDemographics}
-                <div class="contactCardRight">
-                  {crmRegion name="contact-demographic"}
-                  <div class="crm-summary-demographic-block">
-                    <div class="crm-summary-block" id="demographic-block">
-                      {include file="CRM/Contact/Page/Inline/Demographics.tpl"}
-                    </div>
-                  </div>
-                  {/crmRegion}
-                </div> <!-- contactCardRight -->
-              {/if}
-              <div class="clear"></div>
-                <div class="separator"></div>
-              </div> <!-- contact panel -->
-            </div><!--contact_details-->
-
-            {if $showCustomData}
-              <div id="customFields">
-                <div class="contact_panel">
-                  <div class="contactCardLeft">
-                    {include file="CRM/Contact/Page/View/CustomDataView.tpl" side='1'}
-                  </div><!--contactCardLeft-->
-                  <div class="contactCardRight">
-                    {include file="CRM/Contact/Page/View/CustomDataView.tpl" side='0'}
-                  </div>
-
-                  <div class="clear"></div>
-                </div>
-              </div>
-            {/if}
-
-            {if !empty($hookContent) and isset($hookContentPlacement) and $hookContentPlacement eq 1}
-              {include file="CRM/Contact/Page/View/SummaryHook.tpl"}
-            {/if}
-          {else}
-             {include file="CRM/Contact/Page/View/SummaryHook.tpl"}
-          {/if}
-        </div>
-      <div class="clear"></div>
+      {foreach from=$allTabs item=tabValue}
+        {if !empty($tabValue.template)}
+          <div id="contact-{$tabValue.id}">
+            {include file=$tabValue.template}
+          </div>
+        {/if}
+      {/foreach}
     </div>
     <div class="clear"></div>
-  </div><!-- /.crm-content-block -->
+  </div>
 {/if}
 
 {* CRM-10560 *}

--- a/templates/CRM/common/TabHeader.tpl
+++ b/templates/CRM/common/TabHeader.tpl
@@ -28,7 +28,7 @@
     </ul>
       {foreach from=$tabHeader key=tabName item=tabValue}
         {if !empty($tabValue.template)}
-          <div id="#panel_{$tabName}">
+          <div id="panel_{$tabName}">
             {include file=$tabValue.template}
           </div>
         {/if}


### PR DESCRIPTION
Overview
----------------------------------------
Plucked out of #19887 to facilitate review. This cleanup allows non-ajax tabs to be placed on the contact summary page via hook.

Before
----------------------------------------
No hook support for non-ajax tabs.

After
----------------------------------------
Non ajax tabs can be declared. As part of the cleanup I moved the summary tab into its own template & used the new feature to include the template by declaring it in the tabs array.

Technical Details
----------------------------------------
There was some non-functional (due to a typo) code in `TabHeader.tpl` to allow tabs to load from a .tpl instead of ajax.
This fixes that typo and copies the functionality into the contact summary tabs as well.
The functionality is demonstrated here by moving the main tab into a sub-template.
