### PR TITLE
dev/financial#171 - Don't

### DIFF
--- a/templates/CRM/Core/Form/Field.tpl
+++ b/templates/CRM/Core/Form/Field.tpl
@@ -17,7 +17,7 @@
     {/capture}{help id=$help.id file=$help.file}{/if}
     {if $action == 2 && $fieldSpec.is_add_translate_dialog}{include file='CRM/Core/I18n/Dialog.tpl' table=$entityTable field=$fieldName id=$entityID}{/if}
   </td>
-  <td>{$fieldSpec.pre_html_text}{if $form.$fieldName.html}{if $fieldSpec.formatter === 'crmMoney'}{$form.$fieldName.html|crmMoney:$fieldSpec.formatterParam}{else}{$form.$fieldName.html}{/if}{else}{$fieldSpec.place_holder}{/if}{$fieldSpec.post_html_text}<br />
+  <td>{$fieldSpec.pre_html_text}{if $form.$fieldName.html}{$form.$fieldName.html}{else}{$fieldSpec.place_holder}{/if}{$fieldSpec.post_html_text}<br />
     {if $fieldSpec.description}<span class="description">{$fieldSpec.description}</span>{/if}
     {if $fieldSpec.documentation_link}{docURL page=$fieldSpec.documentation_link.page resource=$fieldSpec.documentation_link.resource}{/if}
   </td>


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/financial/-/issues/171

Before
----------------------------------------
Does

After
----------------------------------------
Doesn't

Technical Details
----------------------------------------
It's about money. The term markup can apply to the price of things. That's normal business, but it seems to be confused here with hypertext markup (html).

That's meant to be a pun - maybe a bit too involved.

Comments
----------------------------------------
This is a pretty generic form, so it may cause some fields to no longer display currency symbols or convert decimal separators.