### PR TITLE
dev/financial#171 - Don't pass already formatted data to crmMoney on contact summary for custom fields

### DIFF
--- a/templates/CRM/Contact/Page/View/CustomDataFieldView.tpl
+++ b/templates/CRM/Contact/Page/View/CustomDataFieldView.tpl
@@ -32,8 +32,6 @@
             <div class="crm-content crm-custom-data crm-contact-reference">
               {', '|implode:$element.contact_ref_links}
             </div>
-          {elseif $element.field_data_type EQ 'Money'}
-            <div class="crm-content crm-custom-data">{$element.field_value|crmMoney}</div>
           {else}
             <div class="crm-content crm-custom-data">{$element.field_value}</div>
           {/if}


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/financial/-/issues/171

Passing already formatted data to crmMoney gives a false warning about a missing INTL because it also checks if the input is non-numeric. If you have a custom field of type money dropdown with a currency symbol included in the option choice labels it triggers this.

Before
----------------------------------------
warning

After
----------------------------------------
No warning, but now if you have a money text field the currency symbol no longer displays. But at the same time, this also "fixes" some double decimal separator replacement I was seeing a while ago and didn't know where it was coming from. i.e. `12,34` (US 12.34) would get displayed as `12 34` (thousands separator here was a space).

Technical Details
----------------------------------------

Comments
----------------------------------------