### PR TITLE
[REF] Store the getSearchQueryResults so it can be re-accessed

### DIFF
--- a/CRM/Contribute/Form/Task/TaskTrait.php
+++ b/CRM/Contribute/Form/Task/TaskTrait.php
@@ -21,6 +21,13 @@
 trait CRM_Contribute_Form_Task_TaskTrait {
 
   /**
+   * Query result object.
+   *
+   * @var \CRM_Core_DAO
+   */
+  protected $queryBAO;
+
+  /**
    * Get the results from the BAO_Query object based search.
    *
    * @return CRM_Core_DAO
@@ -28,31 +35,34 @@ trait CRM_Contribute_Form_Task_TaskTrait {
    * @throws \CRM_Core_Exception
    */
   public function getSearchQueryResults(): CRM_Core_DAO {
-    $form = $this;
-    $queryParams = $this->getQueryParams();
-    $returnProperties = ['contribution_id' => 1];
-    $sortOrder = $sortCol = NULL;
-    if ($form->get(CRM_Utils_Sort::SORT_ORDER)) {
-      $sortOrder = $form->get(CRM_Utils_Sort::SORT_ORDER);
-      //Include sort column in select clause.
-      $sortCol = trim(str_replace(['`', 'asc', 'desc'], '', $sortOrder));
-      $returnProperties[$sortCol] = 1;
-    }
+    if (!$this->queryBAO) {
+      $form = $this;
+      $queryParams = $this->getQueryParams();
+      $returnProperties = ['contribution_id' => 1];
+      $sortOrder = $sortCol = NULL;
+      if ($form->get(CRM_Utils_Sort::SORT_ORDER)) {
+        $sortOrder = $form->get(CRM_Utils_Sort::SORT_ORDER);
+        //Include sort column in select clause.
+        $sortCol = trim(str_replace(['`', 'asc', 'desc'], '', $sortOrder));
+        $returnProperties[$sortCol] = 1;
+      }
 
-    $query = new CRM_Contact_BAO_Query($queryParams, $returnProperties, NULL, FALSE, FALSE,
-      CRM_Contact_BAO_Query::MODE_CONTRIBUTE
-    );
-    // @todo the function CRM_Contribute_BAO_Query::isSoftCreditOptionEnabled should handle this
-    // can we remove? if not why not?
-    if ($this->isQueryIncludesSoftCredits()) {
-      $query->_rowCountClause = ' count(civicrm_contribution.id)';
-      $query->_groupByComponentClause = ' GROUP BY contribution_search_scredit_combined.id, contribution_search_scredit_combined.contact_id, contribution_search_scredit_combined.scredit_id ';
+      $query = new CRM_Contact_BAO_Query($queryParams, $returnProperties, NULL, FALSE, FALSE,
+        CRM_Contact_BAO_Query::MODE_CONTRIBUTE
+      );
+      // @todo the function CRM_Contribute_BAO_Query::isSoftCreditOptionEnabled should handle this
+      // can we remove? if not why not?
+      if ($this->isQueryIncludesSoftCredits()) {
+        $query->_rowCountClause = ' count(civicrm_contribution.id)';
+        $query->_groupByComponentClause = ' GROUP BY contribution_search_scredit_combined.id, contribution_search_scredit_combined.contact_id, contribution_search_scredit_combined.scredit_id ';
+      }
+      else {
+        $query->_distinctComponentClause = ' civicrm_contribution.id';
+        $query->_groupByComponentClause = ' GROUP BY civicrm_contribution.id ';
+      }
+      $this->queryBAO = $query->searchQuery(0, 0, $sortOrder);
     }
-    else {
-      $query->_distinctComponentClause = ' civicrm_contribution.id';
-      $query->_groupByComponentClause = ' GROUP BY civicrm_contribution.id ';
-    }
-    return $query->searchQuery(0, 0, $sortOrder);
+    return $this->queryBAO;
   }
 
   /**

--- a/tests/phpunit/CRM/Contribute/Form/TaskTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/TaskTest.php
@@ -10,7 +10,7 @@
  */
 
 /**
- * Class CRM_Contribute_Form_Tasktest
+ * Class CRM_Contribute_Form_TaskTest
  */
 class CRM_Contribute_Form_TaskTest extends CiviUnitTestCase {
 
@@ -18,10 +18,12 @@ class CRM_Contribute_Form_TaskTest extends CiviUnitTestCase {
 
   /**
    * Clean up after each test.
+   *
+   * @throws \CRM_Core_Exception
    */
-  public function tearDown() {
+  public function tearDown(): void {
     $this->quickCleanUpFinancialEntities();
-    CRM_Utils_Hook::singleton()->reset();
+    parent::tearDown();
   }
 
   /**
@@ -29,13 +31,15 @@ class CRM_Contribute_Form_TaskTest extends CiviUnitTestCase {
    * executes without any error after sorting the search result.
    *
    * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
    */
-  public function testPreProcessCommonAfterSorting() {
+  public function testPreProcessCommonAfterSorting(): void {
     $fields = [
       'source' => 'contribution_source',
       'status' => 'contribution_status',
       'financialTypes' => 'financial_type',
     ];
+    $contributionIds = [];
     $financialTypes = ['Member Dues', 'Event Fee', 'Donation'];
     $status = ['Completed', 'Partially paid', 'Pending'];
     $source = ['test source text', 'check source text', 'source text'];
@@ -65,9 +69,10 @@ class CRM_Contribute_Form_TaskTest extends CiviUnitTestCase {
       $expectedValues[$fld] = $sortedFields;
     }
 
-    // Assert contribIds are returned in a sorted order.
-    $form = $this->getFormObject('CRM_Contribute_Form_Task', ['radio_ts' => 'ts_all'], 'Search');
     foreach ($fields as $val) {
+      // Assert contribIds are returned in a sorted order.
+      /* @var CRM_Contribute_Form_Task $form */
+      $form = $this->getFormObject('CRM_Contribute_Form_Task', ['radio_ts' => 'ts_all'], 'Search');
       $form->set(CRM_Utils_Sort::SORT_ORDER, "`{$val}` asc");
       CRM_Contribute_Form_Task::preProcessCommon($form);
 


### PR DESCRIPTION
Overview
----------------------------------------
This just fixes the function to only do the hard work once even if you call it multiple times
 - it really just adds an IF so use the white-space-less view

https://github.com/civicrm/civicrm-core/pull/19881/files?w=1

Before
----------------------------------------
Query BAO not stored on the form, has to be instantiated whenever needed

After
----------------------------------------
Reduce, re-use, recycle

Technical Details
----------------------------------------

Comments
----------------------------------------
