### PR TITLE
Fix for importing preferred language (and other fields) by label

### DIFF
--- a/CRM/Member/Import/Parser/Membership.php
+++ b/CRM/Member/Import/Parser/Membership.php
@@ -664,8 +664,6 @@ class CRM_Member_Import_Parser_Membership extends CRM_Member_Import_Parser {
       }
     }
 
-    _civicrm_api3_custom_format_params($params, $values, 'Membership');
-
     if ($create) {
       // CRM_Member_BAO_Membership::create() handles membership_start_date, membership_join_date,
       // membership_end_date and membership_source. So, if $values contains

--- a/api/v3/utils.php
+++ b/api/v3/utils.php
@@ -1077,6 +1077,11 @@ function _civicrm_api3_object_to_array_unique_fields(&$dao, &$values) {
  *   ID of entity per $extends.
  */
 function _civicrm_api3_custom_format_params($params, &$values, $extends, $entityId = NULL) {
+  if (!empty($params['custom'])) {
+    // The Import class does the formatting first - ideally it wouldn't but this early return
+    // provides transitional support.
+    return;
+  }
   $values['custom'] = [];
   $checkCheckBoxField = FALSE;
   $entity = $extends;

--- a/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
+++ b/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
@@ -461,7 +461,7 @@ class CRM_Contact_Import_Parser_ContactTest extends CiviUnitTestCase {
    * @throws \CRM_Core_Exception
    * @throws \CiviCRM_API3_Exception
    */
-  public function testPrefixLabel() {
+  public function testPrefixLabel(): void {
     $this->callAPISuccess('OptionValue', 'create', ['option_group_id' => 'individual_prefix', 'name' => 'new_one', 'label' => 'special', 'value' => 70]);
     $mapping = [
       ['name' => 'first_name', 'column_number' => 0],
@@ -491,9 +491,11 @@ class CRM_Contact_Import_Parser_ContactTest extends CiviUnitTestCase {
   /**
    * Test that labels work for importing custom data.
    *
+   * @throws \API_Exception
    * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
    */
-  public function testCustomDataLabel() {
+  public function testCustomDataLabel(): void {
     $this->createCustomGroupWithFieldOfType([], 'select');
     $contactValues = [
       'first_name' => 'Bill',

--- a/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
+++ b/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
@@ -527,6 +527,22 @@ class CRM_Contact_Import_Parser_ContactTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test importing in the Preferred Language Field
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testPreferredLanguageImport() {
+    $contactValues = [
+      'first_name' => 'Bill',
+      'last_name' => 'Gates',
+      'email' => 'bill.gates@microsoft.com',
+      'nick_name' => 'Billy-boy',
+      'preferred_language' => 'English (Australia)',
+    ];
+    $this->runImport($contactValues, CRM_Import_Parser::DUPLICATE_UPDATE, CRM_Import_Parser::VALID, [NULL, NULL, 'Primary', NULL, NULL]);
+  }
+
+  /**
    * Test that the import parser adds the address to the primary location.
    *
    * @throws \Exception

--- a/tests/phpunit/CRM/Member/Import/Parser/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/Import/Parser/MembershipTest.php
@@ -53,7 +53,7 @@ class CRM_Member_Import_Parser_MembershipTest extends CiviUnitTestCase {
    * @throws \CRM_Core_Exception
    * @throws \CiviCRM_API3_Exception
    */
-  public function setUp() {
+  public function setUp(): void {
     parent::setUp();
 
     $params = [
@@ -96,7 +96,7 @@ class CRM_Member_Import_Parser_MembershipTest extends CiviUnitTestCase {
    *
    * @throws \CRM_Core_Exception
    */
-  public function tearDown() {
+  public function tearDown(): void {
     $tablesToTruncate = [
       'civicrm_membership',
       'civicrm_membership_log',
@@ -114,6 +114,7 @@ class CRM_Member_Import_Parser_MembershipTest extends CiviUnitTestCase {
    *  Test Import.
    *
    * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
    */
   public function testImport() {
     $this->individualCreate();
@@ -334,9 +335,9 @@ class CRM_Member_Import_Parser_MembershipTest extends CiviUnitTestCase {
    * Test importing to a custom field.
    *
    * @throws \API_Exception
-   * @throws \CRM_Core_Exception
+   * @throws \CRM_Core_Exception|\CiviCRM_API3_Exception
    */
-  public function testImportCustomData() {
+  public function testImportCustomData(): void {
     $donaldDuckID = $this->individualCreate(['first_name' => 'Donald', 'last_name' => 'Duck']);
     $this->createCustomGroupWithFieldsOfAllTypes(['extends' => 'Membership']);
     $membershipImporter = $this->createImportObject([


### PR DESCRIPTION
Overview
----------------------------------------
Fix for failure to handle label on import
    
    This adds generic handling for where label has been submitted and flips to using the api
    to provide generic handling for names

Fix for https://github.com/civicrm/civicrm-core/pull/19074

Before
----------------------------------------
Label not accepted for preferred_language (& probably others)

After
----------------------------------------
Generic handling for label

Technical Details
----------------------------------------

Comments
----------------------------------------
@seamuslee001 this should be the fix to your test