### PR TITLE
Embed afforms & search displays on contact summary screen as blocks and tabs

### DIFF
--- a/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php
+++ b/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php
@@ -84,7 +84,7 @@ class AfformAdminMeta {
       'includeCustom' => TRUE,
       'loadOptions' => ['id', 'label'],
       'action' => 'create',
-      'select' => ['name', 'label', 'input_type', 'input_attrs', 'required', 'options', 'help_pre', 'help_post', 'serialize', 'data_type'],
+      'select' => ['name', 'label', 'input_type', 'input_attrs', 'required', 'options', 'help_pre', 'help_post', 'serialize', 'data_type', 'fk_entity'],
       'where' => [['input_type', 'IS NOT NULL']],
     ];
     if (in_array($entityName, ['Individual', 'Household', 'Organization'])) {

--- a/ext/afform/admin/ang/afGuiEditor.js
+++ b/ext/afform/admin/ang/afGuiEditor.js
@@ -6,15 +6,17 @@
     .service('afGui', function(crmApi4, $parse, $q) {
 
       // Parse strings of javascript that php couldn't interpret
+      // TODO: Figure out which attributes actually need to be evaluated, as a whitelist would be less error-prone than a blacklist
+      var doNotEval = ['filters'];
       function evaluate(collection) {
         _.each(collection, function(item) {
           if (_.isPlainObject(item)) {
             evaluate(item['#children']);
-            _.each(item, function(node, idx) {
-              if (_.isString(node)) {
-                var str = _.trim(node);
+            _.each(item, function(prop, key) {
+              if (_.isString(prop) && !_.includes(doNotEval, key)) {
+                var str = _.trim(prop);
                 if (str[0] === '{' || str[0] === '[' || str.slice(0, 3) === 'ts(') {
-                  item[idx] = $parse(str)({ts: CRM.ts('afform')});
+                  item[key] = $parse(str)({ts: CRM.ts('afform')});
                 }
               }
             });

--- a/ext/afform/admin/ang/afGuiEditor/config-form.html
+++ b/ext/afform/admin/ang/afGuiEditor/config-form.html
@@ -1,59 +1,63 @@
 <ng-form name="config_form">
 
-<div class="form-group">
-  <label for="af_config_form_title">
-    {{:: ts('Title:') }} <span class="crm-marker">*</span>
-  </label>
-  <input ng-model="afform.title" class="form-control" id="af_config_form_title" required title="{{:: ts('Required') }}" />
-</div>
+  <div class="form-group">
+    <label for="af_config_form_title">
+      {{:: ts('Title:') }} <span class="crm-marker">*</span>
+    </label>
+    <p class="help-block">{{:: ts('Public title (usually displayed at the top of the form).') }}</p>
+    <input ng-model="afform.title" class="form-control" id="af_config_form_title" required title="{{:: ts('Required') }}" />
+  </div>
 
-<div class="form-group">
-  <label for="af_config_form_description">
-    {{:: ts('Description:') }}
-  </label>
-  <textarea ng-model="afform.description" class="form-control" id="af_config_form_description"></textarea>
-  <p class="help-block">{{:: ts('Semi-private description about the form\'s purpose.') }}</p>
-  <!-- "Semi-private": not generally public, but not audited for secrecy -->
-</div>
+  <div class="form-group">
+    <label for="af_config_form_description">
+      {{:: ts('Description:') }}
+    </label>
+    <textarea ng-model="afform.description" class="form-control" id="af_config_form_description"></textarea>
+    <p class="help-block">{{:: ts("Internal note about the form's purpose (not displayed on form).") }}</p>
+    <!-- Description is "semi-private": not generally public, but not audited for secrecy -->
+  </div>
 
-<div class="form-group" ng-class="{'has-error': !!config_form.server_route.$error.pattern}">
-  <label for="af_config_form_server_route">
-    {{:: ts('Page:') }}
-  </label>
-  <input ng-model="afform.server_route" name="server_route" class="form-control" id="af_config_form_server_route" pattern="^civicrm\/[-0-9a-zA-z\/_]+$" onfocus="this.value = this.value || 'civicrm/'" onblur="if (this.value === 'civicrm/') this.value = ''" title="{{:: ts('Path must begin with &quot;civicrm/&quot;') }}">
-  <p class="help-block">{{:: ts('Expose the form as a standalone webpage. (Example: "civicrm/my-form")') }}</p>
-</div>
+  <div class="form-group">
+    <label for="af_config_form_permission">
+      {{:: ts('Permission:') }}
+    </label>
+    <input ng-model="afform.permission" class="form-control" id="af_config_form_permission" crm-ui-select="{data: editor.meta.permissions}" />
+    <p class="help-block">{{:: ts('What permission is required to use this form?') }}</p>
+  </div>
 
-<div class="form-group" ng-if="!!afform.server_route">
-  <label for="af_config_form_is_public">
-    <input type="checkbox" id="af_config_form_is_public" ng-model="afform.is_public">
-    {{:: ts('Enable frontend styling') }}
-  </label>
-  <p class="help-block">{{ts('The general look/feel should match the frontend')}}</p>
-</div>
+  <fieldset>
+    <legend>{{:: ts('Placement') }}</legend>
 
-<div class="form-group" ng-if="!!afform.server_route">
-  <label for="af_config_form_is_token">
-    <input type="checkbox" id="af_config_form_is_token" ng-model="afform.is_token">
-    {{:: ts('Enable email token') }}
-  </label>
-  <p class="help-block">{{ts('Allow email authors to easily link to this form')}}</p>
-</div>
+    <div class="form-group" ng-class="{'has-error': !!config_form.server_route.$error.pattern}">
+      <label for="af_config_form_server_route">
+        {{:: ts('Page:') }}
+      </label>
+      <input ng-model="afform.server_route" name="server_route" class="form-control" id="af_config_form_server_route" pattern="^civicrm\/[-0-9a-zA-z\/_]+$" onfocus="this.value = this.value || 'civicrm/'" onblur="if (this.value === 'civicrm/') this.value = ''" title="{{:: ts('Path must begin with &quot;civicrm/&quot;') }}">
+      <p class="help-block">{{:: ts('Expose the form as a standalone webpage. (Example: "civicrm/my-form")') }}</p>
+    </div>
 
-<div class="form-group">
-  <label for="af_config_form_is_dashlet">
-    <input type="checkbox" id="af_config_form_is_dashlet" ng-model="afform.is_dashlet">
-    {{:: ts('Enable dashlet') }}
-  </label>
-  <p class="help-block">{{:: ts('Allow backend users to embed the form on the dashboard.') }}</p>
-</div>
+    <div class="form-group" ng-if="!!afform.server_route">
+      <label>
+        <input type="checkbox" ng-model="afform.is_public">
+        {{:: ts('Style page to match front-end website') }}
+      </label>
+    </div>
 
-<div class="form-group">
-  <label for="af_config_form_permission">
-    {{:: ts('Permission:') }}
-  </label>
-  <input ng-model="afform.permission" class="form-control" id="af_config_form_permission" crm-ui-select="{data: editor.meta.permissions}" />
-  <p class="help-block">{{:: ts('What permission is required to use this form?') }}</p>
-</div>
+    <div class="form-group" ng-if="!!afform.server_route">
+      <label>
+        <input type="checkbox" ng-model="afform.is_token">
+        {{:: ts('Provide email token') }}
+      </label>
+      <p class="help-block">{{:: ts('Allows CiviMail authors to easily link to this page') }}</p>
+    </div>
+
+    <div class="form-group">
+      <label>
+        <input type="checkbox" ng-model="afform.is_dashlet">
+        {{:: ts('Add to dashboard') }}
+      </label>
+      <p class="help-block">{{:: ts('Allow CiviCRM users to add the form to their home dashboard.') }}</p>
+    </div>
+  </fieldset>
 
 </ng-form>

--- a/ext/afform/admin/ang/afGuiEditor/config-form.html
+++ b/ext/afform/admin/ang/afGuiEditor/config-form.html
@@ -58,6 +58,31 @@
       </label>
       <p class="help-block">{{:: ts('Allow CiviCRM users to add the form to their home dashboard.') }}</p>
     </div>
+
+    <div class="form-group">
+      <div class="form-inline">
+        <label>
+          <input type="checkbox" ng-checked="afform.contact_summary" ng-click="editor.toggleContactSummary()">
+          {{:: ts('Add to contact summary page') }}
+        </label>
+        <select class="form-control" ng-model="afform.contact_summary" ng-if="afform.contact_summary">
+          <option value="block">{{:: ts('As Block') }}</option>
+          <option value="tab">{{:: ts('As Tab') }}</option>
+        </select>
+      </div>
+      <p class="help-block">{{:: ts('Placement can be configured using the Contact Layout Editor.') }}</p>
+    </div>
+    <div class="form-group" ng-if="afform.contact_summary && editor.searchDisplay && editor.searchFilters.length > 1">
+      <div class="form-inline">
+        <label for="af_config_form_search_filters">
+          {{:: ts('Filter on:') }}
+        </label>
+        <select class="form-control" id="af_config_form_search_filters" ng-model="editor.searchDisplay.filters">
+          <option ng-repeat="option in editor.searchFilters" value="{{ option.key }}">{{ option.label }}</option>
+        </select>
+      </div>
+      <p class="help-block">{{:: ts('Choose which contact from the search should match the contact being viewed.') }}</p>
+    </div>
   </fieldset>
 
 </ng-form>

--- a/ext/afform/core/Civi/Api4/Afform.php
+++ b/ext/afform/core/Civi/Api4/Afform.php
@@ -158,6 +158,10 @@ class Afform extends Generic\AbstractEntity {
           'data_type' => 'Boolean',
         ],
         [
+          'name' => 'contact_summary',
+          'data_type' => 'String',
+        ],
+        [
           'name' => 'repeat',
           'data_type' => 'Mixed',
         ],
@@ -172,7 +176,7 @@ class Afform extends Generic\AbstractEntity {
           'data_type' => 'Array',
         ],
       ];
-
+      // Calculated fields returned by get action
       if ($self->getAction() === 'get') {
         $fields[] = [
           'name' => 'module_name',

--- a/ext/afform/core/templates/afform/contactSummary/AfformBlock.tpl
+++ b/ext/afform/core/templates/afform/contactSummary/AfformBlock.tpl
@@ -1,0 +1,5 @@
+<crm-angular-js modules="{$block.module}">
+  <div id="bootstrap-theme">
+    <{$block.directive} options="{ldelim}contact_id: {$contactId}{rdelim}"></{$block.directive}>
+  </div>
+</crm-angular-js>

--- a/ext/afform/core/templates/afform/contactSummary/AfformTab.tpl
+++ b/ext/afform/core/templates/afform/contactSummary/AfformTab.tpl
@@ -1,0 +1,5 @@
+<crm-angular-js modules="{$tabValue.module}">
+  <div id="bootstrap-theme">
+    <{$tabValue.directive} options="{ldelim}contact_id: {$contactId}{rdelim}"></{$tabValue.directive}>
+  </div>
+</crm-angular-js>

--- a/ext/search/ang/crmSearchDisplay.module.js
+++ b/ext/search/ang/crmSearchDisplay.module.js
@@ -81,10 +81,10 @@
         return crmApi4('SearchDisplay', 'run', getApiParams(ctrl)).then(function(results) {
           ctrl.results = results;
           ctrl.editing = false;
-          if (ctrl.settings.pager && !ctrl.rowCount) {
-            if (results.length < ctrl.settings.limit) {
+          if (!ctrl.rowCount) {
+            if (!ctrl.settings.limit || results.length < ctrl.settings.limit) {
               ctrl.rowCount = results.length;
-            } else {
+            } else if (ctrl.settings.pager) {
               var params = getApiParams(ctrl, 'row_count');
               crmApi4('SearchDisplay', 'run', params).then(function(result) {
                 ctrl.rowCount = result.count;

--- a/ext/search/ang/crmSearchDisplayList/crmSearchDisplayList.component.js
+++ b/ext/search/ang/crmSearchDisplayList/crmSearchDisplayList.component.js
@@ -14,7 +14,7 @@
       afFieldset: '?^^afFieldset'
     },
     templateUrl: '~/crmSearchDisplayList/crmSearchDisplayList.html',
-    controller: function($scope, crmApi4, searchDisplayUtils) {
+    controller: function($scope, $element, crmApi4, searchDisplayUtils) {
       var ts = $scope.ts = CRM.ts('org.civicrm.search'),
         ctrl = this;
 
@@ -24,6 +24,17 @@
       this.$onInit = function() {
         this.sort = this.settings.sort ? _.cloneDeep(this.settings.sort) : [];
         $scope.displayUtils = searchDisplayUtils;
+
+        // If search is embedded in contact summary tab, display count in tab-header
+        var contactTab = $element.closest('.crm-contact-page .ui-tabs-panel').attr('id');
+        if (contactTab) {
+          var unwatchCount = $scope.$watch('$ctrl.rowCount', function(rowCount) {
+            if (typeof rowCount === 'number') {
+              unwatchCount();
+              CRM.tabHeader.updateCount(contactTab.replace('contact-', '#tab_'), rowCount);
+            }
+          });
+        }
 
         if (this.afFieldset) {
           $scope.$watch(this.afFieldset.getFieldData, onChangeFilters, true);

--- a/ext/search/ang/crmSearchDisplayTable/crmSearchDisplayTable.component.js
+++ b/ext/search/ang/crmSearchDisplayTable/crmSearchDisplayTable.component.js
@@ -13,7 +13,7 @@
       afFieldset: '?^^afFieldset'
     },
     templateUrl: '~/crmSearchDisplayTable/crmSearchDisplayTable.html',
-    controller: function($scope, crmApi4, searchDisplayUtils) {
+    controller: function($scope, $element, crmApi4, searchDisplayUtils) {
       var ts = $scope.ts = CRM.ts('org.civicrm.search'),
         ctrl = this;
 
@@ -25,6 +25,17 @@
       this.$onInit = function() {
         this.sort = this.settings.sort ? _.cloneDeep(this.settings.sort) : [];
         $scope.displayUtils = searchDisplayUtils;
+
+        // If search is embedded in contact summary tab, display count in tab-header
+        var contactTab = $element.closest('.crm-contact-page .ui-tabs-panel').attr('id');
+        if (contactTab) {
+          var unwatchCount = $scope.$watch('$ctrl.rowCount', function(rowCount) {
+            if (typeof rowCount === 'number') {
+              unwatchCount();
+              CRM.tabHeader.updateCount(contactTab.replace('contact-', '#tab_'), rowCount);
+            }
+          });
+        }
 
         if (this.afFieldset) {
           $scope.$watch(this.afFieldset.getFieldData, onChangeFilters, true);


### PR DESCRIPTION
Overview
----------------------------------------
This enables the creation of blocks and tabs on the contact summary screen, using Afform & SearchKit.

Forms containing a search display will automatically receive the id of the contact being viewed as a filter. Tabs will automatically show a counter in the tab of the number of rows (like core tabs do).

The blocks/tabs will be placed in default positions, but can be rearranged with the Contact Layout Editor extension.

**Embed Afform Like This:**
![image](https://user-images.githubusercontent.com/2874912/112325618-3d7e6080-8c8a-11eb-894d-cc7cc0a1f04c.png)

**This is the Contribution tab from core:**
![image](https://user-images.githubusercontent.com/2874912/112326467-ecbb3780-8c8a-11eb-9d45-fccb6d6de3a5.png)

**And here is the one I made with SearchKit:**
![image](https://user-images.githubusercontent.com/2874912/112327034-74a14180-8c8b-11eb-9912-36d3ae320f63.png)


Technical Details
----------------------------------------
One of the technical challenges was the ability to boostrap Angular more than once per page. This has been solved by #19922.