### PR TITLE
Fix for dev/drupal#158

### DIFF
--- a/CRM/Core/Menu.php
+++ b/CRM/Core/Menu.php
@@ -338,6 +338,13 @@ class CRM_Core_Menu {
 
       $menu->save();
     }
+
+    // Little hack for drupal 8 and drupal 9 to rebuild the router of drupal
+    // so that drupal will reconignize any new menu items.
+    // See https://lab.civicrm.org/dev/drupal/-/issues/158
+    if (class_exists('Drupal', FALSE)) {
+      \Drupal::service('router.builder')->rebuild();
+    }
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------

This fixes an annoying bug in Drupal 8 and Drupal 9 where Drupal does not recognize any urls defined in a newly installed extension. 

The work aorund is to clear the drupal caches. 

Before
----------------------------------------

After installing an extension drupal will return Page not found when going to a page defined in the extension.

After
----------------------------------------

After installing an extension drupal will show the content when going to a page defined in the extension.

Technical Details
----------------------------------------

There is a little hack needed, we need to check whether the `Drupal` class is available and if so we assume we are in drupal 8/9 and we rebuild the router.

Comments
----------------------------------------

I am not completely sure whether this is the right place to fix this. 

See https://lab.civicrm.org/dev/drupal/-/issues/158 and https://lab.civicrm.org/dev/drupal/-/issues/37
