### PR TITLE
APIv4 - Standardize generic entity name resolution

### DIFF
--- a/Civi/Api4/Generic/AbstractEntity.php
+++ b/Civi/Api4/Generic/AbstractEntity.php
@@ -46,7 +46,7 @@ abstract class AbstractEntity {
    * @return \Civi\Api4\Action\GetActions
    */
   public static function getActions($checkPermissions = TRUE) {
-    return (new \Civi\Api4\Action\GetActions(self::getEntityName(), __FUNCTION__))
+    return (new \Civi\Api4\Action\GetActions(static::getEntityName(), __FUNCTION__))
       ->setCheckPermissions($checkPermissions);
   }
 
@@ -109,7 +109,7 @@ abstract class AbstractEntity {
    * @throws NotImplementedException
    */
   public static function __callStatic($action, $args) {
-    $entity = self::getEntityName();
+    $entity = static::getEntityName();
     $nameSpace = str_replace('Civi\Api4\\', 'Civi\Api4\Action\\', static::class);
     // Find class for this action
     $entityAction = "$nameSpace\\" . ucfirst($action);

--- a/Civi/Api4/Generic/BasicEntity.php
+++ b/Civi/Api4/Generic/BasicEntity.php
@@ -87,7 +87,7 @@ abstract class BasicEntity extends AbstractEntity {
    * @return BasicGetAction
    */
   public static function get($checkPermissions = TRUE) {
-    return (new BasicGetAction(static::class, __FUNCTION__, static::$getter))
+    return (new BasicGetAction(static::getEntityName(), __FUNCTION__, static::$getter))
       ->setCheckPermissions($checkPermissions);
   }
 
@@ -96,7 +96,7 @@ abstract class BasicEntity extends AbstractEntity {
    * @return BasicCreateAction
    */
   public static function create($checkPermissions = TRUE) {
-    return (new BasicCreateAction(static::class, __FUNCTION__, static::$setter))
+    return (new BasicCreateAction(static::getEntityName(), __FUNCTION__, static::$setter))
       ->setCheckPermissions($checkPermissions);
   }
 
@@ -105,7 +105,7 @@ abstract class BasicEntity extends AbstractEntity {
    * @return BasicSaveAction
    */
   public static function save($checkPermissions = TRUE) {
-    return (new BasicSaveAction(static::class, __FUNCTION__, static::$idField, static::$setter))
+    return (new BasicSaveAction(static::getEntityName(), __FUNCTION__, static::$idField, static::$setter))
       ->setCheckPermissions($checkPermissions);
   }
 
@@ -114,7 +114,7 @@ abstract class BasicEntity extends AbstractEntity {
    * @return BasicUpdateAction
    */
   public static function update($checkPermissions = TRUE) {
-    return (new BasicUpdateAction(static::class, __FUNCTION__, static::$idField, static::$setter))
+    return (new BasicUpdateAction(static::getEntityName(), __FUNCTION__, static::$idField, static::$setter))
       ->setCheckPermissions($checkPermissions);
   }
 
@@ -123,7 +123,7 @@ abstract class BasicEntity extends AbstractEntity {
    * @return BasicBatchAction
    */
   public static function delete($checkPermissions = TRUE) {
-    return (new BasicBatchAction(static::class, __FUNCTION__, static::$idField, static::$deleter))
+    return (new BasicBatchAction(static::getEntityName(), __FUNCTION__, static::$idField, static::$deleter))
       ->setCheckPermissions($checkPermissions);
   }
 
@@ -132,7 +132,7 @@ abstract class BasicEntity extends AbstractEntity {
    * @return BasicReplaceAction
    */
   public static function replace($checkPermissions = TRUE) {
-    return (new BasicReplaceAction(static::class, __FUNCTION__))
+    return (new BasicReplaceAction(static::getEntityName(), __FUNCTION__))
       ->setCheckPermissions($checkPermissions);
   }
 

--- a/Civi/Api4/Generic/DAOEntity.php
+++ b/Civi/Api4/Generic/DAOEntity.php
@@ -32,7 +32,7 @@ abstract class DAOEntity extends AbstractEntity {
    * @return DAOGetAction
    */
   public static function get($checkPermissions = TRUE) {
-    return (new DAOGetAction(static::class, __FUNCTION__))
+    return (new DAOGetAction(static::getEntityName(), __FUNCTION__))
       ->setCheckPermissions($checkPermissions);
   }
 
@@ -41,7 +41,7 @@ abstract class DAOEntity extends AbstractEntity {
    * @return DAOSaveAction
    */
   public static function save($checkPermissions = TRUE) {
-    return (new DAOSaveAction(static::class, __FUNCTION__))
+    return (new DAOSaveAction(static::getEntityName(), __FUNCTION__))
       ->setCheckPermissions($checkPermissions);
   }
 
@@ -50,7 +50,7 @@ abstract class DAOEntity extends AbstractEntity {
    * @return DAOGetFieldsAction
    */
   public static function getFields($checkPermissions = TRUE) {
-    return (new DAOGetFieldsAction(static::class, __FUNCTION__))
+    return (new DAOGetFieldsAction(static::getEntityName(), __FUNCTION__))
       ->setCheckPermissions($checkPermissions);
   }
 
@@ -59,7 +59,7 @@ abstract class DAOEntity extends AbstractEntity {
    * @return DAOCreateAction
    */
   public static function create($checkPermissions = TRUE) {
-    return (new DAOCreateAction(static::class, __FUNCTION__))
+    return (new DAOCreateAction(static::getEntityName(), __FUNCTION__))
       ->setCheckPermissions($checkPermissions);
   }
 
@@ -68,7 +68,7 @@ abstract class DAOEntity extends AbstractEntity {
    * @return DAOUpdateAction
    */
   public static function update($checkPermissions = TRUE) {
-    return (new DAOUpdateAction(static::class, __FUNCTION__))
+    return (new DAOUpdateAction(static::getEntityName(), __FUNCTION__))
       ->setCheckPermissions($checkPermissions);
   }
 
@@ -77,7 +77,7 @@ abstract class DAOEntity extends AbstractEntity {
    * @return DAODeleteAction
    */
   public static function delete($checkPermissions = TRUE) {
-    return (new DAODeleteAction(static::class, __FUNCTION__))
+    return (new DAODeleteAction(static::getEntityName(), __FUNCTION__))
       ->setCheckPermissions($checkPermissions);
   }
 
@@ -86,7 +86,7 @@ abstract class DAOEntity extends AbstractEntity {
    * @return BasicReplaceAction
    */
   public static function replace($checkPermissions = TRUE) {
-    return (new BasicReplaceAction(static::class, __FUNCTION__))
+    return (new BasicReplaceAction(static::getEntityName(), __FUNCTION__))
       ->setCheckPermissions($checkPermissions);
   }
 

--- a/Civi/Api4/MailSettings.php
+++ b/Civi/Api4/MailSettings.php
@@ -34,7 +34,7 @@ class MailSettings extends Generic\DAOEntity {
    * @return \Civi\Api4\Action\MailSettings\TestConnection
    */
   public static function testConnection($checkPermissions = TRUE) {
-    $action = new \Civi\Api4\Action\MailSettings\TestConnection(static::class, __FUNCTION__);
+    $action = new \Civi\Api4\Action\MailSettings\TestConnection(__CLASS__, __FUNCTION__);
     return $action->setCheckPermissions($checkPermissions);
   }
 

--- a/Civi/Api4/RelationshipCache.php
+++ b/Civi/Api4/RelationshipCache.php
@@ -35,7 +35,7 @@ class RelationshipCache extends Generic\AbstractEntity {
    * @return Generic\DAOGetAction
    */
   public static function get($checkPermissions = TRUE) {
-    return (new Generic\DAOGetAction(static::class, __FUNCTION__))
+    return (new Generic\DAOGetAction(__CLASS__, __FUNCTION__))
       ->setCheckPermissions($checkPermissions);
   }
 
@@ -44,7 +44,7 @@ class RelationshipCache extends Generic\AbstractEntity {
    * @return Generic\DAOGetFieldsAction
    */
   public static function getFields($checkPermissions = TRUE) {
-    return (new Generic\DAOGetFieldsAction(static::class, __FUNCTION__))
+    return (new Generic\DAOGetFieldsAction(__CLASS__, __FUNCTION__))
       ->setCheckPermissions($checkPermissions);
   }
 

--- a/ang/api4Explorer/Explorer.js
+++ b/ang/api4Explorer/Explorer.js
@@ -713,13 +713,14 @@
 
     // Format oop params
     function formatOOP(entity, action, params, indent) {
-      var code = '',
+      var info = getEntity(entity),
         newLine = "\n" + _.repeat(' ', indent),
+        code = '\\' + info.class + '::' + action + '(',
         perm = params.checkPermissions === false ? 'FALSE' : '';
       if (entity.substr(0, 7) !== 'Custom_') {
-        code = "\\Civi\\Api4\\" + entity + '::' + action + '(' + perm + ')';
+        code += perm + ')';
       } else {
-        code = "\\Civi\\Api4\\CustomValue::" + action + "('" + entity.substr(7) + "'" + (perm ? ', ' : '') + perm + ")";
+        code += "'" + entity.substr(7) + "'" + (perm ? ', ' : '') + perm + ")";
       }
       _.each(params, function(param, key) {
         var val = '';


### PR DESCRIPTION
Overview
----------------------------------------
APIv4 code cleanup to enable the addition of a Case api.

Before
----------------------------------------
Trying to add an entity with a different class name than the entity name crashes.

After
----------------------------------------
It's possible to add such an entity.

Technical Details
----------------------------------------
A CiviCase API cannot have the className "Case" because that is a reserved php keyword.

Comments
-----------------
Also cleans up other entities that use `static::class` in place of entityName because it's not a good pattern and we don't want people duplicating it.
