### PR TITLE
File CustomField: avoid renaming an empty file

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -1551,6 +1551,13 @@ SELECT id
           $mimeType = $fileDAO->mime_type;
         }
       }
+      elseif (empty($value['name'])) {
+        // Happens when calling the API to update custom fields values, but the filename
+        // is empty, for an existing entity (in a specific case, was from a d7-webform
+        // that was updating a relationship with a File customfield, so $value['id'] was
+        // not empty, but the filename was empty.
+        return;
+      }
       else {
         $fName = $value['name'];
         $mimeType = $value['type'];


### PR DESCRIPTION
Overview
----------------------------------------

This is a workaround for an obscure bug encountered with d7 webform:

- the webform was setup to update some relationship information, which has a "file" custom field.
- while submitting the form, the filename was empty (or maybe not even on the form)
- the relationship  already existed, so there was a custom field entry with an ID, but empty filename.

Before
----------------------------------------

Submitting the form was causing a statusBounce to the home page, because the function could not move an empty filename.

After
----------------------------------------

The form is submitted correctly, and it appears that no data was harmed.

Comments
----------------------------------------

Was curious to see how the tests react to this change, because it feels like duct-tape. The function has an early return earlier for something similar, but normally this function should return an array, so it's a bit odd.

It should be possible to reproduce the bug using a PHP snippet using the APIv3, but haven't gotten to that part yet.