### PR TITLE
APIv4 - Fix GetActions function to work with entityNames that don't match className

### DIFF
--- a/Civi/Api4/Action/GetActions.php
+++ b/Civi/Api4/Action/GetActions.php
@@ -14,6 +14,7 @@ namespace Civi\Api4\Action;
 
 use Civi\API\Exception\NotImplementedException;
 use Civi\Api4\Generic\BasicGetAction;
+use Civi\Api4\Utils\CoreUtil;
 use Civi\Api4\Utils\ReflectionUtils;
 
 /**
@@ -30,7 +31,8 @@ class GetActions extends BasicGetAction {
   protected function getRecords() {
     $this->_actionsToGet = $this->_itemsToGet('name');
 
-    $entityReflection = new \ReflectionClass('\Civi\Api4\\' . $this->_entityName);
+    $className = CoreUtil::getApiClass($this->_entityName);
+    $entityReflection = new \ReflectionClass($className);
     foreach ($entityReflection->getMethods(\ReflectionMethod::IS_STATIC | \ReflectionMethod::IS_PUBLIC) as $method) {
       $actionName = $method->getName();
       if ($actionName != 'permissions' && $actionName != 'getInfo' && $actionName[0] != '_') {
@@ -39,28 +41,30 @@ class GetActions extends BasicGetAction {
     }
     if (!$this->_actionsToGet || count($this->_actionsToGet) > count($this->_actions)) {
       // Search for entity-specific actions in extensions
+      $nameSpace = str_replace('Civi\Api4\\', 'Civi\Api4\Action\\', $className);
       foreach (\CRM_Extension_System::singleton()->getMapper()->getActiveModuleFiles() as $ext) {
         $dir = \CRM_Utils_File::addTrailingSlash(dirname($ext['filePath']));
-        $this->scanDir($dir . 'Civi/Api4/Action/' . $this->_entityName);
+        $this->scanDir($dir, $nameSpace);
       }
       // Search for entity-specific actions in core
-      $this->scanDir(\CRM_Utils_File::addTrailingSlash(__DIR__) . $this->_entityName);
+      global $civicrm_root;
+      $this->scanDir(\CRM_Utils_File::addTrailingSlash($civicrm_root), $nameSpace);
     }
     ksort($this->_actions);
     return $this->_actions;
   }
 
   /**
-   * @param $dir
+   * @param string $dir
+   * @param string $nameSpace
    */
-  private function scanDir($dir) {
+  private function scanDir($dir, $nameSpace) {
+    $dir .= str_replace('\\', '/', $nameSpace);
     if (is_dir($dir)) {
       foreach (glob("$dir/*.php") as $file) {
-        $matches = [];
-        preg_match('/(\w*)\.php$/', $file, $matches);
-        $actionName = array_pop($matches);
-        $actionClass = new \ReflectionClass('\\Civi\\Api4\\Action\\' . $this->_entityName . '\\' . $actionName);
-        if ($actionClass->isInstantiable() && $actionClass->isSubclassOf('\\Civi\\Api4\\Generic\\AbstractAction')) {
+        $actionName = basename($file, '.php');
+        $actionClass = new \ReflectionClass($nameSpace . '\\' . $actionName);
+        if ($actionClass->isInstantiable() && $actionClass->isSubclassOf('\Civi\\Api4\Generic\AbstractAction')) {
           $this->loadAction(lcfirst($actionName));
         }
       }


### PR DESCRIPTION
Overview
----------------------------------------
This is a followup to #19867 and #19889. It fixes the GetActions api to work with e.g. a CiviCase entity.
