### PR TITLE
Rebuild the Drupal route cache.

### DIFF
--- a/CRM/Core/Invoke.php
+++ b/CRM/Core/Invoke.php
@@ -394,6 +394,7 @@ class CRM_Core_Invoke {
       CRM_Utils_Request::retrieve('triggerRebuild', 'Boolean', CRM_Core_DAO::$_nullObject, FALSE, 0, 'GET')
     ) {
       CRM_Core_DAO::triggerRebuild();
+      $config->userSystem->invalidateRouteCache();
     }
     CRM_Core_DAO_AllCoreTables::reinitializeCache(TRUE);
     CRM_Core_ManagedEntities::singleton(TRUE)->reconcile();

--- a/CRM/Utils/System/Base.php
+++ b/CRM/Utils/System/Base.php
@@ -1012,4 +1012,10 @@ abstract class CRM_Utils_System_Base {
     return [];
   }
 
+  /**
+   * Invalidates the cache of dynamic routes and forces a rebuild.
+   */
+  public function invalidateRouteCache() {
+  }
+
 }

--- a/CRM/Utils/System/Drupal8.php
+++ b/CRM/Utils/System/Drupal8.php
@@ -858,4 +858,14 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
     return \Drupal::entityTypeManager()->getStorage('user')->load($userID);
   }
 
+  /**
+   * Helper function to rebuild the Drupal 8 or 9 dynamic routing cache.
+   * We need to do this after enabling extensions that add routes and it's worth doing when we reset Civi paths.
+   */
+  public function invalidateRouteCache() {
+    if (class_exists('\Drupal') && \Drupal::hasContainer()) {
+      \Drupal::service('router.builder')->rebuild();
+    }
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
_This is linked to [issue 158](https://lab.civicrm.org/dev/drupal/-/issues/158) and [issue 37](https://lab.civicrm.org/dev/drupal/-/issues/37)._

_It takes an alternative approach to #19888, adding a Utils/System function to rebuild the routes which we can then invoke from multiple places if required with an invocation added to the rebuildMenuandCaches function in invoke.php._

Before
----------------------------------------
_Enabling a CiviCRM extension that adds a route on Drupal 8 or 9 results in a 404 until the routes are rebuilt in Drupal._

After
----------------------------------------
_Enabling/disabling an extension rebuilds Drupal's routes and routes added in CiviCRM work as expected.._

Technical Details
----------------------------------------
_There might be a more performant option for this but I can't find anything..._

