### PR TITLE
[REF] Fix Creating of Recurring Contribution using PayFlow Pro Processor

### DIFF
--- a/CRM/Core/Payment/PayflowPro.php
+++ b/CRM/Core/Payment/PayflowPro.php
@@ -147,7 +147,8 @@ class CRM_Core_Payment_PayflowPro extends CRM_Core_Payment {
       //attempts occur until the term is complete.
       // $payflow_query_array['RETRYNUMDAYS'] = (not set as can't assume business rule
 
-      switch ($params['frequency_unit']) {
+      $interval = $params['frequency_interval'] . " " . $params['frequency_unit'];
+      switch ($interval) {
         case '1 week':
           $params['next_sched_contribution_date'] = mktime(0, 0, 0, date("m"), date("d") + 7,
             date("Y")


### PR DESCRIPTION
Overview
----------------------------------------
This fixes a semi obvious bug in the way PayFlow Pro works with creating recurring contributions

Before
----------------------------------------
Cannot create a recurring contribution 

After
----------------------------------------
Can create recurring contribution

Technical Details
----------------------------------------
The cases in the switch are all interval  unit but the switch was only occurring on the unit e.g. Week Month 

ping @eileenmcnaughton @JoeMurray 