### PR TITLE
[REF] Fix error where entryURL does not contain id of the contributio…

### DIFF
--- a/CRM/Core/Controller.php
+++ b/CRM/Core/Controller.php
@@ -241,6 +241,11 @@ class CRM_Core_Controller extends HTML_QuickForm_Controller {
       // in this case we'll also cache the url as a hidden form variable, this allows us to
       // redirect in case the session has disappeared on us
       $this->_entryURL = CRM_Utils_System::makeURL(NULL, TRUE, FALSE, NULL, TRUE);
+      // In WordPress Shortcodes the standard entryURL generated via makeURL doesn't generally have id=x&reset=1 included so we add them here
+      // This prevents infinite loops caused when the session has timed out.
+      if (stripos($this->_entryURL, 'id') === FALSE && (stripos($this->_entryURL, 'transact') !== FALSE || stripos($this->_entryURL, 'register') !== FALSE)) {
+        $this->_entryURL .= '&id=' . CRM_Utils_Request::retrieveValue('id', 'Positive') . '&reset=1';
+      }
       $this->set('entryURL', $this->_entryURL);
     }
 


### PR DESCRIPTION
…n page when coming from a shortcode which leads to infinite redirect loop if session timesout

Overview
----------------------------------------
This fixes a slightly unusal issue that can create a very bad situation. To reproduce you can use a local buildkit build of wordpress using the wp-demo build. 

Navigate to https://<buildkit domain>/contribution-page/ and fill in the page and then navigate to the Confirm step.

Now the important thing is to let it sit there for 10-15m, however if you are not patient then you can login to MySQL and truncate the `civicrm_cache` table (i.e. basically destroy the current session information).

Now if you click back your meant to be taken back to the original main step of the process with a status message saying "We have reset your session because it timed out" or similar.

Before
----------------------------------------
Infinite loop created

After
----------------------------------------
No Infinite loop and user is correctly taken back to the original page and status message shows up. 

Technical Details
----------------------------------------
The issue is that the entryUrl doesn't contain the page id but more importantly doesn't have reset=1 to trigger the reset of the session when you are coming from a page built using shortcode

ping @eileenmcnaughton @haystack @kcristiano @JoeMurray 