### PR TITLE
Set the `Other Amount` input in a price set to not autocomplete

### DIFF
--- a/CRM/Price/BAO/PriceField.php
+++ b/CRM/Price/BAO/PriceField.php
@@ -330,7 +330,7 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
             $qf->assign('priceset', $elementName);
             $extra = [
               'onclick' => 'useAmountOther();',
-              'autocomplete' => 'off'
+              'autocomplete' => 'off',
             ];
           }
         }

--- a/CRM/Price/BAO/PriceField.php
+++ b/CRM/Price/BAO/PriceField.php
@@ -328,7 +328,10 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
           if (!empty($qf->_quickConfig) && !empty($qf->_contributionAmount) && strtolower($fieldOptions[$optionKey]['name']) == 'other_amount') {
             $label .= '  ' . $currencySymbol;
             $qf->assign('priceset', $elementName);
-            $extra = ['onclick' => 'useAmountOther();'];
+            $extra = [
+              'onclick' => 'useAmountOther();',
+              'autocomplete' => 'off'
+            ];
           }
         }
 


### PR DESCRIPTION
Overview
----------------------------------------
_I can't see a use case where autocomplete in this field is useful, but not having it explicitly set to off is becoming an issue in recent versions of Chrome which guess wildly at what the field is for. https://chat.civicrm.org/civicrm/pl/qyrpehyojffwxdm8s1fzf3pmsr._

Before
----------------------------------------
_Browser guesses at autocomplete type for this field (reproduced in Chrome on Windows and Ubuntu 20.04 but could not reproduce on Mac OS (thanks @KarinG <3 )_

After
----------------------------------------
_Explicitly sets the field to `autocomplete=off` telling browsers not to try and autocomplete this field._