### PR TITLE
dev/financial#171 - False INTL warning when adding a price field

### DIFF
--- a/CRM/Member/Page/AJAX.php
+++ b/CRM/Member/Page/AJAX.php
@@ -46,9 +46,9 @@ WHERE   id = %1";
     }
     $details['total_amount_numeric'] = $details['total_amount'];
     // fix the display of the monetary value, CRM-4038
-    $details['total_amount'] = CRM_Utils_Money::formatLocaleNumericRoundedForDefaultCurrency($details['total_amount']);
+    $details['total_amount'] = CRM_Utils_Money::formatLocaleNumericRoundedForDefaultCurrency($details['total_amount'] ?? 0);
     $options = CRM_Core_SelectValues::memberAutoRenew();
-    $details['auto_renew'] = $options[$details]['auto_renew'] ?? NULL;
+    $details['auto_renew'] = $options[$details['auto_renew']] ?? NULL;
     CRM_Utils_JSON::output($details);
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/financial/-/issues/171#note_56522

1. Turn off popups. (You don't have to but you won't see the message as easily.)
1. Make a membership type and leave minimum fee blank.
1. Make a price set for memberships.
1. Add a price field and make it a radio or select.
1. In the option choice rows there's a dropdown for the type. Pick the type you made.
1. What's supposed to happen is the row is supposed to autofill. It doesn't.
1. Click cancel.
1. Message about missing INTL even though it's installed.

Before
----------------------------------------
False warning about missing INTL extension.
Hidden php type error.
Row doesn't autofill.

After
----------------------------------------
Good.

Technical Details
----------------------------------------
The field allows both null and 0. A blank gets stored as null, but then is_numeric is false when it tries to round it and the INTL message comes up when is_numeric is false. There's also then a type error which causes the ajax call to 500, so it doesn't autofill.

Comments
----------------------------------------
The second change is something not used at this point on the form but is clearly wrong and gives its own warning. It's been like that for about 8 years.
