### PR TITLE
dev/core#2477 Add setting to allow opportunistic cache flushing for acls

### DIFF
--- a/CRM/ACL/BAO/Cache.php
+++ b/CRM/ACL/BAO/Cache.php
@@ -116,9 +116,22 @@ WHERE contact_id = %1
   }
 
   /**
+   * Do an opportunistic cache refresh if the site is configured for these.
+   *
+   * Sites that use acls and do not run the acl cache clearing cron job should
+   * refresh the caches on demand. The user session will be forced to wait
+   * and this is a common source of deadlocks, so it is less ideal.
+   */
+  public static function opportunisticCacheFlush(): void {
+    if (Civi::settings()->get('acl_cache_refresh_mode') === 'opportunistic') {
+      self::resetCache();
+    }
+  }
+
+  /**
    * Deletes all the cache entries.
    */
-  public static function resetCache() {
+  public static function resetCache(): void {
     if (!CRM_Core_Config::isPermitCacheFlushMode()) {
       return;
     }

--- a/CRM/Contact/BAO/Contact/Utils.php
+++ b/CRM/Contact/BAO/Contact/Utils.php
@@ -866,7 +866,7 @@ INNER JOIN civicrm_contact contact_target ON ( contact_target.id = act.contact_i
    *   likely affect user experience in unexpected ways. Existing behaviour retained
    *   ... reluctantly.
    */
-  public static function clearContactCaches($isEmptyPrevNextTable = FALSE) {
+  public static function clearContactCaches($isEmptyPrevNextTable = FALSE): void {
     if (!CRM_Core_Config::isPermitCacheFlushMode()) {
       return;
     }
@@ -876,8 +876,8 @@ INNER JOIN civicrm_contact contact_target ON ( contact_target.id = act.contact_i
       Civi::service('prevnext')->deleteItem();
       CRM_Core_BAO_PrevNextCache::deleteItem();
     }
-    // clear acl cache if any.
-    CRM_ACL_BAO_Cache::resetCache();
+
+    CRM_ACL_BAO_Cache::opportunisticCacheFlush();
     CRM_Contact_BAO_GroupContactCache::opportunisticCacheFlush();
   }
 

--- a/api/v3/Job.php
+++ b/api/v3/Job.php
@@ -711,18 +711,38 @@ function civicrm_api3_job_group_rebuild($params) {
 /**
  * Flush smart groups caches.
  *
- * This job purges aged smart group cache data (based on the timeout value). Sites can decide whether they want this
- * job and / or the group cache rebuild job to run. In some cases performance is better when old caches are cleared out
- * prior to any attempt to rebuild them. Also, many sites are very happy to have caches built on demand, provided the
- * user is not having to wait for deadlocks to clear when invalidating them.
+ * This job purges aged smart group cache data (based on the timeout value).
+ * Sites can decide whether they want this job and / or the group cache rebuild
+ * job to run. In some cases performance is better when old caches are cleared
+ * out prior to any attempt to rebuild them. Also, many sites are very happy to
+ * have caches built on demand, provided the user is not having to wait for
+ * deadlocks to clear when invalidating them.
  *
  * @param array $params
  *
  * @return array
- * @throws \API_Exception
+ * @throws \CiviCRM_API3_Exception
  */
-function civicrm_api3_job_group_cache_flush($params) {
+function civicrm_api3_job_group_cache_flush(array $params): array {
   CRM_Contact_BAO_GroupContactCache::deterministicCacheFlush();
+  return civicrm_api3_create_success();
+}
+
+/**
+ * Flush acl caches.
+ *
+ * This job flushes the acl cache. For many sites it is better to do
+ * this by cron (or not at all if acls are not used) than whenever
+ * a contact is edited.
+ *
+ * @param array $params
+ *
+ * @return array
+ *
+ * @throws \CiviCRM_API3_Exception
+ */
+function civicrm_api3_job_acl_cache_flush(array $params): array {
+  CRM_ACL_BAO_Cache::resetCache();
   return civicrm_api3_create_success();
 }
 

--- a/settings/Core.setting.php
+++ b/settings/Core.setting.php
@@ -358,8 +358,25 @@ return [
     'pseudoconstant' => [
       'callback' => 'CRM_Contact_BAO_GroupContactCache::getModes',
     ],
-    'description' => ts('Should the smart groups be by cron jobs or user actions'),
+    'description' => ts('Should the smart groups be flushed by cron jobs or user actions'),
     'help_text' => ts('In "Opportunistic Flush" mode, caches are flushed in response to user actions; this mode is broadly compatible but may add latency during form-submissions. In "Cron Flush" mode, you should schedule a cron job to flush caches; this can improve latency on form-submissions but requires more setup.'),
+  ],
+  'acl_cache_refresh_mode' => [
+    'group_name' => 'CiviCRM Preferences',
+    'group' => 'core',
+    'name' => 'acl_cache_refresh_mode',
+    'type' => 'String',
+    'html_type' => 'radio',
+    'default' => 'opportunistic',
+    'add' => '5.37.0',
+    'title' => ts('ACL Group Refresh Mode'),
+    'is_domain' => 1,
+    'is_contact' => 0,
+    'pseudoconstant' => [
+      'callback' => 'CRM_Contact_BAO_GroupContactCache::getModes',
+    ],
+    'description' => ts('Should the acl cache be by cron jobs or user actions'),
+    'help_text' => ts('In "Opportunistic Flush" mode, caches are flushed in response to user actions; this mode is broadly compatible but may add latency during form-submissions. In "Cron Flush" mode, you should schedule a cron job to flush caches if your site uses ACLs; this can improve latency on form-submissions but requires more setup.'),
   ],
   'installed' => [
     'bootstrap_comment' => 'This is a boot setting which may be loaded during bootstrap. Defaults are loaded via SettingsBag::getSystemDefaults().',


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#2477 Add setting to allow opportunistic cache flushing for acls ie

Setting.create acl_cache_refresh_mode = 'deterministic'

Before
----------------------------------------
civicrm_acl_contact_cache truncated on every contact edit, regardless of whether the site uses acls.  This truncating is a common cause of deadlocks (even on sites with no acls in use) as it will happen multiple times per second on sites where frequent contact creation and editing

After
----------------------------------------
It is now possible to set a new setting to disable truncating. The setting is not currently exposed (as the smart_group_cache_refresh_mode setting was not exposed either) but I will look to document in the same way

Technical Details
----------------------------------------
This adds the same mechanism as the group contact cache to reduce site contention.
A job api is also added which people can optionally configure.

It would be especially worth setting on sites that do not use ACLs at all

Note this was in the dev-digest 

Comments
----------------------------------------
@seamuslee001 