### PR TITLE
Only include completed contributions in the aggregate custom search

### DIFF
--- a/CRM/Contact/Form/Search/Custom/ContributionAggregate.php
+++ b/CRM/Contact/Form/Search/Custom/ContributionAggregate.php
@@ -194,9 +194,11 @@ civicrm_contact AS contact_a {$this->_aclFrom}
    * @return string
    */
   public function where($includeContactIDs = FALSE) {
+    $contributionCompletedStatusId = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Completed');
     $clauses = [
       "contrib.contact_id = contact_a.id",
       "contrib.is_test = 0",
+      "contrib.contribution_status_id = " . intval($contributionCompletedStatusId),
     ];
 
     foreach ([


### PR DESCRIPTION
Overview
----------------------------------------
The Contribution Aggregate custom search is a useful way to calculate total giving across a time period. However, it provides no way to filter by contribution status, so all contributions, regardless of the status, are included in the totals.

Before
----------------------------------------

With the old technical contract, the Contribution Aggregate search provided a total of all contributions per contact, including failed, pending, cancelled etc. There is a small chance that some CiviCRM users depend on this functionality and *expect* to get all contributions. But I assume the vast majority expect this search to be restricted to contributions that are completed.

After
----------------------------------------
With this change, the search automatically filters contributions to just those that are completed.


Comments
----------------------------------------
Perhaps a better fix would be to expose the contribution status field.
