### PR TITLE
dev/core#527 use public title for on behalf profile and confirm/thank you profile in emails

### DIFF
--- a/CRM/Contribute/BAO/ContributionPage.php
+++ b/CRM/Contribute/BAO/ContributionPage.php
@@ -483,7 +483,7 @@ class CRM_Contribute_BAO_ContributionPage extends CRM_Contribute_DAO_Contributio
         $fields = CRM_Core_BAO_UFGroup::getFields($gid, FALSE, CRM_Core_Action::VIEW, NULL, NULL, FALSE, NULL, FALSE, NULL, CRM_Core_Permission::CREATE, NULL);
         foreach ($fields as $k => $v) {
           if (!$groupTitle) {
-            $groupTitle = !empty($v['groupDisplayTitle']) ? $v['groupDisplayTitle'] : $v['groupTitle'];
+            $groupTitle = $v['groupDisplayTitle'];
           }
           // suppress all file fields from display and formatting fields
           if (

--- a/CRM/Contribute/BAO/ContributionPage.php
+++ b/CRM/Contribute/BAO/ContributionPage.php
@@ -483,7 +483,7 @@ class CRM_Contribute_BAO_ContributionPage extends CRM_Contribute_DAO_Contributio
         $fields = CRM_Core_BAO_UFGroup::getFields($gid, FALSE, CRM_Core_Action::VIEW, NULL, NULL, FALSE, NULL, FALSE, NULL, CRM_Core_Permission::CREATE, NULL);
         foreach ($fields as $k => $v) {
           if (!$groupTitle) {
-            $groupTitle = $v['groupTitle'];
+            $groupTitle = !empty($v['groupDisplayTitle']) ? $v['groupDisplayTitle'] : $v['groupTitle'];
           }
           // suppress all file fields from display and formatting fields
           if (

--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -1320,7 +1320,7 @@ WHERE civicrm_event.is_active = 1
         $groupTitle = NULL;
         foreach ($fields as $k => $v) {
           if (!$groupTitle) {
-            $groupTitle = $v['groupTitle'];
+            $groupTitle = !empty($v['groupDisplayTitle']) ? $v['groupDisplayTitle'] : $v['groupTitle'];
           }
           // suppress all file fields from display
           if (

--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -1320,7 +1320,7 @@ WHERE civicrm_event.is_active = 1
         $groupTitle = NULL;
         foreach ($fields as $k => $v) {
           if (!$groupTitle) {
-            $groupTitle = !empty($v['groupDisplayTitle']) ? $v['groupDisplayTitle'] : $v['groupTitle'];
+            $groupTitle = $v['groupDisplayTitle'];
           }
           // suppress all file fields from display
           if (


### PR DESCRIPTION
Overview
----------------------------------------

Following on https://github.com/civicrm/civicrm-core/pull/19144 and https://github.com/civicrm/civicrm-core/pull/19291

Screens have been fixed in PR19291. The remaining PR is to fix profile title in receipt emails. It should use frontend title if available.

Before
----------------------------------------
With a frontend title defined in a profile used in a contribution page or an event page, the receipt displays the administrative title.

After
----------------------------------------
The receipt email shows the frontend title.
