### PR TITLE
dev/financial#171 - Trigger an error if non-numeric value passed to Money::format()

### DIFF
--- a/CRM/Utils/Money.php
+++ b/CRM/Utils/Money.php
@@ -192,7 +192,12 @@ class CRM_Utils_Money {
     if (!extension_loaded('intl') || !is_numeric($amount)) {
       // @todo - we should not attempt to format non-numeric strings. For now
       // these will not fail but will give notices on php 7.4
-      self::missingIntlNotice();
+      if (!is_numeric($amount)) {
+        CRM_Core_Error::deprecatedWarning('Formatting non-numeric values is no longer supported: ' . htmlspecialchars($amount));
+      }
+      else {
+        self::missingIntlNotice();
+      }
       return self::formatNumericByFormat($amount, '%!.' . $numberOfPlaces . 'i');
     }
     $money = Money::of($amount, CRM_Core_Config::singleton()->defaultCurrency, new CustomContext($numberOfPlaces), RoundingMode::HALF_UP);


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/financial/-/issues/171#note_56673

To trigger this you can do something like put `{'aaa'|crmMoney}` in any template and then visit that page. You should see an error if you have on-screen errors turned on (drupal).

Before
----------------------------------------
Confusing warning about missing INTL when non-numeric values are passed to Money::format()

After
----------------------------------------
`User deprecated function: Formatting non-numeric values is no longer supported: <the offending value>`

Technical Details
----------------------------------------
It was being intercepted before because it made tests fail on php 7.4 prematurely. No longer a need to do this so this will also see if any more tests fail now.

Comments
----------------------------------------
