### PR TITLE
Stop passing html to crmMoney

### DIFF
--- a/templates/CRM/Contribute/Form/Contribution/Main.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Main.tpl
@@ -96,7 +96,7 @@
       {else}
         <div class="display-block">
           <td class="label">{$form.total_amount.label}</td>
-          <td><span>{$form.total_amount.html|crmMoney}&nbsp;&nbsp;{if $taxAmount}{ts 1=$taxTerm 2=$taxAmount|crmMoney}(includes %1 of %2){/ts}{/if}</span></td>
+          <td><span>{$form.total_amount.html}&nbsp;&nbsp;{if $taxAmount}{ts 1=$taxTerm 2=$taxAmount|crmMoney}(includes %1 of %2){/ts}{/if}</span></td>
         </div>
       {/if}
     {else}

--- a/templates/CRM/Contribute/Form/ManagePremiums.tpl
+++ b/templates/CRM/Contribute/Form/ManagePremiums.tpl
@@ -64,19 +64,19 @@
     </tr>
     <tr class="crm-contribution-form-block-min_contribution">
        <td class="label">{$form.min_contribution.label}</td>
-       <td class="html-adjust">{$form.min_contribution.html|crmMoney}<br />
+       <td class="html-adjust">{$form.min_contribution.html}<br />
           <span class="description">{ts}The minimum contribution amount required to be eligible to select this premium. If you want to offer it to all contributors regardless of contribution amount, enter '0'. If display of minimum contribution amounts is enabled then this text is displayed:{/ts} <em>{ts}(Contribute at least X to be eligible for this gift.){/ts}</em></span>
        </td>
     </tr>
     <tr class="crm-contribution-form-block-price">
        <td class="label">{$form.price.label}</td>
-       <td class="html-adjust">{$form.price.html|crmMoney}<br />
+       <td class="html-adjust">{$form.price.html}<br />
      <span class="description">{ts}The market value of this premium (e.g. retail price). For tax-deductible contributions, this amount will be used to set the non-deductible amount in the contribution record and receipt.{/ts}</span>
        </td>
     </tr>
     <tr class="crm-contribution-form-block-cost">
        <td class="label">{$form.cost.label}</td>
-       <td class="html-adjust">{$form.cost.html|crmMoney}<br />
+       <td class="html-adjust">{$form.cost.html}<br />
         <span class="description">{ts}You may optionally record the actual cost of this premium to your organization. This may be useful when evaluating net return for this incentive.{/ts}</span>
        </td>
     </tr>

--- a/templates/CRM/Event/Form/EventFees.tpl
+++ b/templates/CRM/Event/Form/EventFees.tpl
@@ -68,7 +68,7 @@
                     <td class="label">{$form.financial_type_id.label}<span class="crm-marker"> *</span></td>
                     <td>{$form.financial_type_id.html}<br /><span class="description">{ts}Select the appropriate financial type for this payment.{/ts}</span></td>
                 </tr>
-                <tr class="crm-event-eventfees-form-block-total_amount"><td class="label">{$form.total_amount.label}</td><td>{$form.total_amount.html|crmMoney:$currency}</td></tr>
+                <tr class="crm-event-eventfees-form-block-total_amount"><td class="label">{$form.total_amount.label}</td><td>{$form.total_amount.html}</td></tr>
                 <tr>
                     <td class="label" >{$form.receive_date.label}</td>
                     <td>{$form.receive_date.html}</td>

--- a/templates/CRM/Event/Form/ManageEvent/Fee.tpl
+++ b/templates/CRM/Event/Form/ManageEvent/Fee.tpl
@@ -146,7 +146,7 @@
         <tr class="columnheader"><td scope="column">{ts}Fee Label{/ts}</td><td scope="column">{ts}Amount{/ts}</td><td scope="column">{ts}Default?{/ts}<br />{$form.default.0.html}</td></tr>
         {section name=loop start=1 loop=11}
            {assign var=idx value=$smarty.section.loop.index}
-           <tr><td class="even-row crm-event-manage-fee-form-block-label_{$idx}">{$form.label.$idx.html}</td><td class="crm-event-manage-fee-form-block-value_{$idx}">{$form.value.$idx.html|crmMoney}</td><td class="even-row crm-event-manage-fee-form-block-default_{$idx}">{$form.default.$idx.html}</td></tr>
+           <tr><td class="even-row crm-event-manage-fee-form-block-label_{$idx}">{$form.label.$idx.html}</td><td class="crm-event-manage-fee-form-block-value_{$idx}">{$form.value.$idx.html}</td><td class="even-row crm-event-manage-fee-form-block-default_{$idx}">{$form.default.$idx.html}</td></tr>
         {/section}
         </table>
         </fieldset>
@@ -208,7 +208,7 @@
             {section name=loop1 start=1 loop=6}
                      {assign var=idy value=$smarty.section.loop1.index}
           {if $form.discount_name.$idy.value}
-                <td>{$form.discounted_value.$idx.$idy.html|crmMoney}</td>
+                <td>{$form.discounted_value.$idx.$idy.html}</td>
           {/if}
             {/section}
             <td class="even-row">{$form.discounted_default.$idx.html}</td>

--- a/templates/CRM/Pledge/Form/Pledge.tpl
+++ b/templates/CRM/Pledge/Form/Pledge.tpl
@@ -51,7 +51,7 @@
             <td>{$form.installments.html} {ts}installments of{/ts}
               <span class='currency-symbol'>
                 {if $action eq 1 or $isPending}
-                  {$form.eachPaymentAmount.html|crmMoney:$currency}
+                  {$form.eachPaymentAmount.html}
                 {elseif $action eq 2 and !$isPending}
                   {$eachPaymentAmount|crmMoney:$currency}
                 {/if}


### PR DESCRIPTION
Overview
----------------------------------------
crmMoney should not receive html for format - this fixes

Before
----------------------------------------
See https://github.com/civicrm/civicrm-core/pull/19938

After
----------------------------------------
@demeritcowboy can't make the tests fail

Technical Details
----------------------------------------
@demeritcowboy I haven't checked how these impact the forms yet - in theory we should be handling in the QF layer

Comments
----------------------------------------
