### PR TITLE
Revert "dev/core#2028 Add in a status check for checking if the wkhtm…

### DIFF
--- a/CRM/Utils/Check/Component/Env.php
+++ b/CRM/Utils/Check/Component/Env.php
@@ -960,19 +960,4 @@ class CRM_Utils_Check_Component_Env extends CRM_Utils_Check_Component {
     return $messages;
   }
 
-  public function checkWkHtmlToPDFPath() {
-    $messages = [];
-    $wkhtmltopdfPath = CRM_Core_Config::singleton()->wkhtmltopdfPath;
-    if (!empty($wkhtmltopdfPath) && !file_exists($wkhtmltopdfPath)) {
-      $messages[] = new CRM_Utils_Check_Message(
-        __FUNCTION__,
-        ts('CiviCRM is configured to use the wkhtmltopdf package to produce PDFs however it is missing, as such the system will fall back to using the DOMPDF package, this may mean that the output is different to what was expected. You should resolve this by either clearing the setting at Administer -> System Settings -> Miscellaneous or by getting your system administrator to install the wkhtmltopdf package'),
-        ts('Missing System Package: wkhtmltopdf'),
-        \Psr\Log\LogLevel::WARNING,
-        'fa-server'
-      );
-    }
-    return $messages;
-  }
-
 }

--- a/CRM/Utils/PDF/Utils.php
+++ b/CRM/Utils/PDF/Utils.php
@@ -213,12 +213,8 @@ class CRM_Utils_PDF_Utils {
    * @param string $fileName
    */
   public static function _html2pdf_wkhtmltopdf($paper_size, $orientation, $margins, $html, $output, $fileName) {
-    $config = CRM_Core_Config::singleton();
-    // if the path doesn't exist fall back on the current backup which is DOMPDF.
-    if (!file_exists($config->wkhtmltopdfPath)) {
-      return self::_html2pdf_dompdf($paper_size, $orientation, $html, $output, $fileName);
-    }
     require_once 'snappy/src/autoload.php';
+    $config = CRM_Core_Config::singleton();
     $snappy = new Knp\Snappy\Pdf($config->wkhtmltopdfPath);
     $snappy->setOption("page-width", $paper_size[2] . "pt");
     $snappy->setOption("page-height", $paper_size[3] . "pt");


### PR DESCRIPTION

Overview
----------------------------------------
Revert "dev/core#2028 Add in a status check for checking if the wkhtmltopdf package is installed in the expected location, Also ensure if it isn't then the pdf generation falls back on the current default which is DOMPDF"

This reverts commit 6bbe0cf6c513c49f89179aa153cabad3a2a059b7.


Before
----------------------------------------
https://github.com/civicrm/civicrm-core/pull/19311 triggering regressions

After
----------------------------------------
reverted - original, less severe, issue is back

Technical Details
----------------------------------------
@seamuslee001 

Comments
----------------------------------------
