### PR TITLE
[REF] Extract portion of GroupContact load that builds the temporary table

### DIFF
--- a/CRM/Contact/BAO/SearchCustom.php
+++ b/CRM/Contact/BAO/SearchCustom.php
@@ -87,7 +87,7 @@ class CRM_Contact_BAO_SearchCustom {
    * @param int $ssID
    *
    * @return CRM_Contact_Form_Search_Custom_Base
-   * @throws Exception
+   * @throws CRM_Core_Exception
    */
   public static function customClass($csID, $ssID) {
     list($customSearchID, $customSearchClass, $formValues) = self::details($csID, $ssID);


### PR DESCRIPTION
Overview
----------------------------------------
[REF] Extract portion of GroupContact load that builds the temporary table

Before
----------------------------------------
Yawn really long

After
----------------------------------------
Pithy (er)

Technical Details
----------------------------------------

This is mostly a straight extraction. I chose to pass groupIDs in as an array
as I think that creates greater flexibility and I chose to pass CRM_Utils_SQL_TempTable
in rather than load it in the function because I have some ideas I'm working through
about how that might also provide more flexibilty

Those things can be changed later if we want as it IS a protected function

Roughly a gazillion tests run through this function

Comments
----------------------------------------
@seamuslee001 @colemanw I realised the api part of how to do a group filter is pretty tricky but I figured I could help by cleaning up the code it might call - I have some interesting ideas brewing but I'm gonna try to write them elsewhere so they don't snarl up what is a fairly straight forward extraction