### PR TITLE
dev/core#2463 - Pass on generated activity ids to email hooks

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -1528,6 +1528,8 @@ WHERE entity_id =%1 AND entity_table = %2";
       'text' => $text_message,
       'html' => $html_message,
       'attachments' => $attachments,
+      'activityID' => $activityID,
+      'toContactID' => $toID,
     ];
 
     if (!CRM_Utils_Mail::send($mailParams)) {


### PR DESCRIPTION
Overview
----------------------------------------
When sending a non-bulk email, the mail hooks have no robust way to get at the activity id for the recorded activity(ies).

Before
----------------------------------------
Can't act on the activities.

After
----------------------------------------
Activity id and contact id now available for alterMailParams and postEmailSend.

Technical Details
----------------------------------------
This is just for non-bulk emails, not mass mailings.

Comments
----------------------------------------
Has test.

It would also be useful to have them in the form postProcess hook if sent via the form, but have left that out here.