### PR TITLE
dev/financial#172 - Warning when saving a contribution with a recognition date

### DIFF
--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -910,11 +910,6 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
         $errors['trxn_id'] = ts('Transaction ID\'s must be unique. Transaction \'%1\' already exists in your database.', [1 => $fields['trxn_id']]);
       }
     }
-    if (!empty($fields['revenue_recognition_date'])
-      && count(array_filter($fields['revenue_recognition_date'])) == 1
-    ) {
-      $errors['revenue_recognition_date'] = ts('Month and Year are required field for Revenue Recognition.');
-    }
     // CRM-16189
     try {
       CRM_Financial_BAO_FinancialAccount::checkFinancialTypeHasDeferred($fields, $self->_id, $self->_priceSet['fields']);


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/financial/-/issues/172

Before
----------------------------------------
1. Turn on deferred revenue in civicontribute settings.
1. Create a contribution and fill in the recognition date.

```
Warning: array_filter() expects parameter 1 to be array, string given in CRM_Contribute_Form_Contribution::formRule() (line 914 of /home/jenkins/bknix-dfl/build/core-19940-91yka/web/sites/all/modules/civicrm/CRM/Contribute/Form/Contribution.php).
    Warning: count(): Parameter must be an array or an object that implements Countable in CRM_Contribute_Form_Contribution::formRule() (line 914 of /home/jenkins/bknix-dfl/build/core-19940-91yka/web/sites/all/modules/civicrm/CRM/Contribute/Form/Contribution.php).
```

After
----------------------------------------
Ok

Technical Details
----------------------------------------
I think this is leftover from datepicker switches? It's checking that the date has a year and a month, but it's not separate components now.

Comments
----------------------------------------

