### PR TITLE
Donot over-ride total amount incase contribution has more than one line item

### DIFF
--- a/CRM/Price/BAO/LineItem.php
+++ b/CRM/Price/BAO/LineItem.php
@@ -529,7 +529,7 @@ WHERE li.contribution_id = %1";
             $params['is_quick_config'] = CRM_Core_DAO::getFieldValue('CRM_Price_DAO_PriceSet', $setID, 'is_quick_config');
           }
           if (!empty($params['is_quick_config']) && array_key_exists('total_amount', $params)
-            && $totalEntityId == 1
+            && $totalEntityId == 1 && count($lineItems) == 1
           ) {
             $values['line_total'] = $values['unit_price'] = $params['total_amount'];
           }


### PR DESCRIPTION
Overview
----------------------------------------
When a contribution has more than one quickconfig line item and update the contribution details without change in the financial fields results in over-ride of line total with contribution total amount for all the line items resulting in mismatch for sum of line total with contribution total. 

CiviCRM UI doesn't allow to create more than one quick config line item for a contribution. This is only possible if you are using order or contribution api to create one. 

Use case: Mother buys membership of type 'Eco membership' £100 for herself and Additional membership for her daughter and son of type 'Additional membership' £50 each. So in Civi it ends up with 3 membership, 3 line items, 3 membership payment and single contribution of total amount £200.  

The above use case is not possible in Civi unless we have custom extension, but can be possible using drupal webform. Webform creates 3 line items of type quick config for a single contribution. And when a api for contribution is called later after some days by payment processor to update other details it updates the line items line total to total amount. 

Before
----------------------------------------
line total  over-rides with contribution total amount when update to contribution.

After
----------------------------------------
Sum of line total matches with contribution total amount.

Technical Details
----------------------------------------
Line total should be equal to contribution total amount when there is only one line item against contribution. Sum of line total should always match with contribution total amount.