### PR TITLE
dev/financial#171 - Don't try to money_format html

### DIFF
--- a/tests/phpunit/CRM/Core/Smarty/plugins/CrmMoneyTest.php
+++ b/tests/phpunit/CRM/Core/Smarty/plugins/CrmMoneyTest.php
@@ -22,10 +22,6 @@ class CRM_Core_Smarty_plugins_CrmMoneyTest extends CiviUnitTestCase {
     $cases = [];
     $cases[] = ['$ 4.00', '{assign var="amount" value="4.00"}{$amount|crmMoney:USD}'];
     $cases[] = ['€ 1,234.00', '{assign var="amount" value="1234.00"}{$amount|crmMoney:EUR}'];
-    $cases[] = [
-      '$ <input size="10" style="background-color:#EBECE4" readonly="readonly" name="eachPaymentAmount" type="text" id="eachPaymentAmount" class="crm-form-text">',
-      '{assign var="amount" value=\'<input size="10" style="background-color:#EBECE4" readonly="readonly" name="eachPaymentAmount" type="text" id="eachPaymentAmount" class="crm-form-text">\'}{$amount|crmMoney:USD}',
-    ];
     return $cases;
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/financial/-/issues/171
https://lab.civicrm.org/dev/translation/-/issues/65

In line with other PRs addressing the false INTL warning and moving to replacing money_format in php 7.4

Before
----------------------------------------
Test enforces the ability to pass html into crmMoney.

After
----------------------------------------
No

Technical Details
----------------------------------------


Comments
----------------------------------------
Is Test.
