### PR TITLE
SearchKit - Support implied operators in exposed search forms

### DIFF
--- a/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php
+++ b/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php
@@ -234,7 +234,8 @@ class AfformAdminMeta {
       ];
     }
 
-    $data['dateRanges'] = \CRM_Utils_Array::makeNonAssociative(\CRM_Core_OptionGroup::values('relative_date_filters'), 'id', 'label');
+    $dateRanges = \CRM_Utils_Array::makeNonAssociative(\CRM_Core_OptionGroup::values('relative_date_filters'), 'id', 'label');
+    $data['dateRanges'] = array_merge([['id' => '{}', 'label' => E::ts('Choose Date Range')]], $dateRanges);
 
     return $data;
   }

--- a/ext/afform/admin/ang/afGuiEditor.css
+++ b/ext/afform/admin/ang/afGuiEditor.css
@@ -281,6 +281,7 @@
 #afGuiEditor .af-gui-layout.af-layout-inline > div {
   display: inline-block;
   width: 300px;
+  vertical-align: top;
 }
 
 #afGuiEditor .af-gui-button {

--- a/ext/afform/admin/ang/afGuiEditor/afGuiEditor.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiEditor.component.js
@@ -52,7 +52,7 @@
         editor.layout = {'#children': []};
         $scope.entities = {};
 
-        if ($scope.afform.type === 'form') {
+        if (editor.getFormType() === 'form') {
           editor.allowEntityConfig = true;
           editor.layout['#children'] = afGui.findRecursive($scope.afform.layout, {'#tag': 'af-form'})[0]['#children'];
           $scope.entities = _.mapValues(afGui.findRecursive(editor.layout['#children'], {'#tag': 'af-entity'}, 'name'), backfillEntityDefaults);
@@ -63,7 +63,7 @@
           }
         }
 
-        if ($scope.afform.type === 'block') {
+        else if (editor.getFormType() === 'block') {
           editor.layout['#children'] = $scope.afform.layout;
           editor.blockEntity = $scope.afform.join || $scope.afform.block;
           $scope.entities[editor.blockEntity] = backfillEntityDefaults({
@@ -73,9 +73,8 @@
           });
         }
 
-        if ($scope.afform.type === 'search') {
+        else if (editor.getFormType() === 'search') {
           editor.layout['#children'] = afGui.findRecursive($scope.afform.layout, {'af-fieldset': ''})[0]['#children'];
-
         }
 
         // Set changesSaved to true on initial load, false thereafter whenever changes are made to the model
@@ -84,6 +83,10 @@
           $scope.changesSaved = $scope.changesSaved === 1;
         }, true);
       }
+
+      this.getFormType = function() {
+        return $scope.afform.type;
+      };
 
       $scope.updateLayoutHtml = function() {
         $scope.layoutHtml = '...Loading...';

--- a/ext/afform/admin/ang/afGuiEditor/afGuiEntity.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiEntity.component.js
@@ -54,7 +54,7 @@
           label: ts('%1 Fields', {1: $scope.getMeta().label}),
           fields: filterFields($scope.getMeta().fields)
         });
-
+        // Add fields for af-join blocks
         _.each(afGui.meta.entities, function(entity, entityName) {
           if (check(ctrl.editor.layout['#children'], {'af-join': entityName})) {
             $scope.fieldList.push({
@@ -69,12 +69,17 @@
         function filterFields(fields) {
           return _.transform(fields, function(fieldList, field) {
             if (!search || _.contains(field.name, search) || _.contains(field.label.toLowerCase(), search)) {
-              fieldList.push({
-                "#tag": "af-field",
-                name: field.name
-              });
+              fieldList.push(fieldDefaults(field));
             }
           }, []);
+        }
+
+        function fieldDefaults(field) {
+          var tag = {
+            "#tag": "af-field",
+            name: field.name
+          };
+          return tag;
         }
       }
 

--- a/ext/afform/admin/ang/afGuiEditor/afGuiSearch.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiSearch.component.js
@@ -76,12 +76,24 @@
         function filterFields(fields, prefix) {
           return _.transform(fields, function(fieldList, field) {
             if (!search || _.contains(field.name, search) || _.contains(field.label.toLowerCase(), search)) {
-              fieldList.push({
-                "#tag": "af-field",
-                name: (prefix ? prefix + '.' : '') + field.name
-              });
+              fieldList.push(fieldDefaults(field, prefix));
             }
           }, []);
+        }
+
+        function fieldDefaults(field, prefix) {
+          var tag = {
+            "#tag": "af-field",
+            name: (prefix ? prefix + '.' : '') + field.name
+          };
+          if (field.input_type === 'Select') {
+            tag.defn = {input_attrs: {multiple: true}};
+          } else if (field.input_type === 'Date') {
+            tag.defn = {input_type: 'Select', search_range: true};
+          } else if (field.options) {
+            tag.defn = {input_type: 'Select', input_attrs: {multiple: true}};
+          }
+          return tag;
         }
       }
 

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiButton-menu.html
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiButton-menu.html
@@ -7,4 +7,4 @@
   </div>
 </li>
 <li role="separator" class="divider"></li>
-<li><a href ng-click="$ctrl.deleteThis()"><span class="text-danger">{{:: ts('Delete this button') }}</span></a></li>
+<li><a href ng-click="$ctrl.deleteThis()"><span class="text-danger"><i class="crm-i fa-trash"></i> {{:: ts('Delete this button') }}</span></a></li>

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiContainer-menu.html
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiContainer-menu.html
@@ -33,4 +33,4 @@
 <li><af-gui-menu-item-border node="$ctrl.node"></af-gui-menu-item-border></li>
 <li><af-gui-menu-item-background node="$ctrl.node"></af-gui-menu-item-background></li>
 <li role="separator" class="divider"></li>
-<li><a href ng-click="$ctrl.deleteThis()"><span class="text-danger">{{ !block ? ts('Delete this container') : ts('Delete this block') }}</span></a></li>
+<li><a href ng-click="$ctrl.deleteThis()"><span class="text-danger"><i class="crm-i fa-trash"></i> {{ !block ? ts('Delete this container') : ts('Delete this block') }}</span></a></li>

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiField-menu.html
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiField-menu.html
@@ -8,26 +8,39 @@
 </li>
 <li>
   <a href ng-click="toggleRequired(); $event.stopPropagation();" title="{{:: ts('Require this field') }}">
-    <i class="crm-i" ng-class="{'fa-square-o': !getProp('required'), 'fa-check-square-o': getProp('required')}"></i>
+    <i class="crm-i fa-{{ getProp('required') ? 'check-' : '' }}square-o"></i>
     {{:: ts('Required') }}
   </a>
 </li>
 <li>
   <a href ng-click="toggleLabel(); $event.stopPropagation();" title="{{:: ts('Show field label') }}">
-    <i class="crm-i" ng-class="{'fa-square-o': $ctrl.node.defn.title === false, 'fa-check-square-o': $ctrl.node.defn.title !== false}"></i>
+    <i class="crm-i fa-{{ $ctrl.node.defn.label === false ? '' : 'check-' }}square-o"></i>
     {{:: ts('Label') }}
   </a>
 </li>
 <li>
   <a href ng-click="toggleHelp('pre'); $event.stopPropagation();" title="{{:: ts('Show help text above this field') }}">
-    <i class="crm-i" ng-class="{'fa-square-o': !propIsset('help_pre'), 'fa-check-square-o': propIsset('help_pre')}"></i>
+    <i class="crm-i fa-{{ propIsset('help_pre') ? 'check-' : '' }}square-o"></i>
     {{:: ts('Pre help text') }}
   </a>
 </li>
 <li>
   <a href ng-click="toggleHelp('post'); $event.stopPropagation();" title="{{:: ts('Show help text below this field') }}">
-    <i class="crm-i" ng-class="{'fa-square-o': !propIsset('help_post'), 'fa-check-square-o': propIsset('help_post')}"></i>
+    <i class="crm-i fa-{{ propIsset('help_post') ? 'check-' : '' }}square-o" ></i>
     {{:: ts('Post help text') }}
+  </a>
+</li>
+<li role="separator" class="divider" ng-if="$ctrl.canBeRange() || $ctrl.canBeMultiple()"></li>
+<li ng-if="$ctrl.canBeMultiple()" ng-click="$event.stopPropagation()">
+  <a href ng-click="toggleMultiple()" title="{{:: ts('Search multiple values') }}">
+    <i class="crm-i fa-{{ !$ctrl.node.defn.input_attrs.multiple ? '' : 'check-' }}square-o"></i>
+    {{:: ts('Multi-Select') }}
+  </a>
+</li>
+<li ng-if="$ctrl.canBeRange()" ng-click="$event.stopPropagation()">
+  <a href ng-click="toggleSearchRange()" title="{{:: ts('Search between low & high values') }}">
+    <i class="crm-i fa-{{ !$ctrl.node.defn.search_range ? '' : 'check-' }}square-o"></i>
+    {{:: ts('Search by range') }}
   </a>
 </li>
 <li role="separator" class="divider" ng-if="hasOptions()"></li>
@@ -46,6 +59,6 @@
 <li role="separator" class="divider"></li>
 <li>
   <a href ng-click="$ctrl.deleteThis()" title="{{:: ts('Remove field from form') }}">
-    <span class="text-danger">{{:: ts('Delete this field') }}</span>
+    <span class="text-danger"><i class="crm-i fa-trash"></i> {{:: ts('Delete this field') }}</span>
   </a>
 </li>

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
@@ -33,7 +33,7 @@
       };
 
       this.isSearch = function() {
-        return !_.isEmpty($scope.meta.searchDisplays);
+        return ctrl.editor.getFormType() === 'search';
       };
 
       this.canBeRange = function() {

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
@@ -37,10 +37,16 @@
       };
 
       this.canBeRange = function() {
+        // Range search only makes sense for search display forms
         return this.isSearch() &&
-          !ctrl.getDefn().input_attrs.multiple &&
-          _.includes(['Date', 'Timestamp', 'Integer', 'Float'], ctrl.getDefn().data_type) &&
-          _.includes(['Date', 'Number', 'Select'], $scope.getProp('input_type'));
+          // Hack for postal code which is not stored as a number but can act like one
+          (ctrl.node.name.substr(-11) === 'postal_code' || (
+            // Multiselects cannot use range search
+            !ctrl.getDefn().input_attrs.multiple &&
+            // DataType & inputType must make sense for a range
+            _.includes(['Date', 'Timestamp', 'Integer', 'Float'], ctrl.getDefn().data_type) &&
+            _.includes(['Date', 'Number', 'Select'], $scope.getProp('input_type'))
+        ));
       };
 
       this.canBeMultiple = function() {

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiMarkup-menu.html
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiMarkup-menu.html
@@ -6,5 +6,5 @@
 <li><af-gui-menu-item-background node="$ctrl.node"></af-gui-menu-item-background></li>
 <li role="separator" class="divider"></li>
 <li>
-  <a href ng-click="$ctrl.deleteThis()"><span class="text-danger">{{:: ts('Delete this content') }}</span></a>
+  <a href ng-click="$ctrl.deleteThis()"><span class="text-danger"><i class="crm-i fa-trash"></i> {{:: ts('Delete this content') }}</span></a>
 </li>

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiText-menu.html
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiText-menu.html
@@ -25,5 +25,5 @@
 </li>
 <li role="separator" class="divider"></li>
 <li>
-  <a href ng-click="$ctrl.deleteThis()"><span class="text-danger">{{:: ts('Delete this text') }}</span></a>
+  <a href ng-click="$ctrl.deleteThis()"><span class="text-danger"><i class="crm-i fa-trash"></i> {{:: ts('Delete this text') }}</span></a>
 </li>

--- a/ext/afform/admin/ang/afGuiEditor/inputType/CheckBox.html
+++ b/ext/afform/admin/ang/afGuiEditor/inputType/CheckBox.html
@@ -1,7 +1,7 @@
-<ul class="crm-checkbox-list" id="{{ fieldId }}" ng-if="getOptions()">
-  <li ng-repeat="opt in getOptions()" >
-    <input type="checkbox" disabled />
+<ul class="crm-checkbox-list" ng-if="$ctrl.getOptions()">
+  <li ng-repeat="opt in $ctrl.getOptions()" >
+    <input type="checkbox" disabled >
     <label>{{ opt.label }}</label>
   </li>
 </ul>
-<input type="checkbox" disabled ng-if="!getOptions()" />
+<input type="checkbox" disabled ng-if="!$ctrl.getOptions()" >

--- a/ext/afform/admin/ang/afGuiEditor/inputType/Date.html
+++ b/ext/afform/admin/ang/afGuiEditor/inputType/Date.html
@@ -1,5 +1,8 @@
 <div class="form-inline">
-  <input autocomplete="off" class="form-control crm-form-date crm-placeholder-icon" placeholder="&#xF073" ng-model="getSet('input_attrs.placeholder')" ng-model-options="{getterSetter: true}" type="text" title="{{:: ts('Click to add placeholder text') }}" />
-  <span class="addon fa fa-calendar"></span>
-  <input autocomplete="off" ng-if="getProp('input_attrs.time')" placeholder="&#xF017" class="form-control crm-form-time crm-placeholder-icon" ng-model="getSet('input_attrs.timePlaceholder')" ng-model-options="{getterSetter: true}" type="text" title="{{:: ts('Click to add placeholder text') }}" />
+  <div class="form-group" ng-repeat="i in $ctrl.getRangeElements('Date')">
+    <span class="af-field-range-sep" ng-if="i">-</span>
+    <input autocomplete="off" class="form-control crm-form-date crm-placeholder-icon" placeholder="&#xF073" ng-model="getSet('input_attrs.placeholder' + i)" ng-model-options="{getterSetter: true}" type="text" title="{{:: ts('Click to add placeholder text') }}" />
+    <span class="addon fa fa-calendar"></span>
+    <input autocomplete="off" ng-if="getProp('input_attrs.time')" placeholder="&#xF017" class="form-control crm-form-time crm-placeholder-icon" ng-model="getSet('input_attrs.timePlaceholder' + i)" ng-model-options="{getterSetter: true}" type="text" title="{{:: ts('Click to add placeholder text') }}" />
+  </div>
 </div>

--- a/ext/afform/admin/ang/afGuiEditor/inputType/Number.html
+++ b/ext/afform/admin/ang/afGuiEditor/inputType/Number.html
@@ -1,1 +1,6 @@
-<input autocomplete="off" class="form-control" ng-model="getSet('input_attrs.placeholder')" ng-model-options="{getterSetter: true}" type="text" title="{{:: ts('Click to add placeholder text') }}" />
+<div class="form-inline">
+  <div class="form-group" ng-repeat="i in $ctrl.getRangeElements('Number')">
+    <span class="af-field-range-sep" ng-if="i">-</span>
+    <input autocomplete="off" class="form-control" ng-model="getSet('input_attrs.placeholder' + i)" ng-model-options="{getterSetter: true}" type="text" title="{{:: ts('Click to add placeholder text') }}"/>
+  </div>
+</div>

--- a/ext/afform/admin/ang/afGuiEditor/inputType/Radio.html
+++ b/ext/afform/admin/ang/afGuiEditor/inputType/Radio.html
@@ -1,5 +1,5 @@
 <div class="form-inline">
-  <label ng-repeat="opt in getOptions()" class="radio" >
+  <label ng-repeat="opt in $ctrl.getOptions()" class="radio" >
     <input class="crm-form-radio" type="radio" disabled />
     {{ opt.label }}
   </label>

--- a/ext/afform/admin/ang/afGuiEditor/inputType/Select.html
+++ b/ext/afform/admin/ang/afGuiEditor/inputType/Select.html
@@ -1,13 +1,17 @@
 <div class="form-inline">
-  <div class="input-group">
-    <input autocomplete="off" class="form-control" placeholder="{{:: ts('Select') }}" title="{{:: ts('Click to add placeholder text') }}" ng-model="getSet('input_attrs.placeholder')" ng-model-options="{getterSetter: true}" type="text" />
-    <div class="input-group-btn" af-gui-menu>
-      <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><i class="crm-i fa-caret-down"></i></button>
-      <ul class="dropdown-menu" ng-if="menu.open">
-        <li ng-repeat="opt in getOptions()" >
-          <a href>{{ opt.label }}</a>
-        </li>
-      </ul>
+  <div class="form-group" ng-repeat="i in $ctrl.getRangeElements('Select')">
+    <span class="af-field-range-sep" ng-if="i">-</span>
+    <div class="input-group">
+      <input autocomplete="off" class="form-control" placeholder="{{:: ts('Select') }}" title="{{:: ts('Click to add placeholder text') }}" ng-model="getSet('input_attrs.placeholder' + i)" ng-model-options="{getterSetter: true}" type="text" />
+      <div class="input-group-btn" af-gui-menu>
+        <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><i class="crm-i fa-caret-down"></i></button>
+        <ul class="dropdown-menu" ng-if="menu.open">
+          <li ng-repeat="opt in $ctrl.getOptions()" >
+            <a href>{{ opt.label }}</a>
+          </li>
+        </ul>
+      </div>
     </div>
   </div>
+  <div ng-if="getProp('search_range') && $ctrl.getDefn().input_type === 'Date'" class="form-group" ng-include="'~/afGuiEditor/inputType/Date.html'"></div>
 </div>

--- a/ext/afform/admin/ang/afGuiEditor/inputType/Text.html
+++ b/ext/afform/admin/ang/afGuiEditor/inputType/Text.html
@@ -1,1 +1,6 @@
-<input autocomplete="off" class="form-control" ng-model="getSet('input_attrs.placeholder')" ng-model-options="{getterSetter: true}" type="text" title="{{:: ts('Click to add placeholder text') }}" />
+<div class="form-inline">
+  <div class="form-group" ng-repeat="i in $ctrl.getRangeElements('Text')">
+    <span class="af-field-range-sep" ng-if="i">-</span>
+    <input autocomplete="off" class="form-control" ng-model="getSet('input_attrs.placeholder' + i)" ng-model-options="{getterSetter: true}" type="text" title="{{:: ts('Click to add placeholder text') }}"/>
+  </div>
+</div>

--- a/ext/afform/core/Civi/Afform/AfformMetadataInjector.php
+++ b/ext/afform/core/Civi/Afform/AfformMetadataInjector.php
@@ -91,7 +91,7 @@ class AfformMetadataInjector {
     $params = [
       'action' => $action,
       'where' => [['name', '=', $fieldName]],
-      'select' => ['label', 'input_type', 'input_attrs', 'options'],
+      'select' => ['label', 'input_type', 'input_attrs', 'help_pre', 'help_post', 'options'],
       'loadOptions' => ['id', 'label'],
       // If the admin included this field on the form, then it's OK to get metadata about the field regardless of user permissions.
       'checkPermissions' => FALSE,

--- a/ext/afform/core/ang/af/afField.component.js
+++ b/ext/afform/core/ang/af/afField.component.js
@@ -19,12 +19,36 @@
         // Only used for is_primary radio button
         noOptions = [{id: true, label: ''}];
 
+      // Attributes for each of the low & high date fields when using search_range
+      this.inputAttrs = [];
+
       this.$onInit = function() {
         var closestController = $($element).closest('[af-fieldset],[af-join],[af-repeat-item]');
         $scope.dataProvider = closestController.is('[af-repeat-item]') ? ctrl.afRepeatItem : ctrl.afJoin || ctrl.afFieldset;
         $scope.fieldId = ctrl.fieldName + '-' + id++;
 
         $element.addClass('af-field-type-' + _.kebabCase(ctrl.defn.input_type));
+
+
+        if (ctrl.defn.search_range) {
+          // Initialize value as object unless using relative date select
+          var initialVal = $scope.dataProvider.getFieldData()[ctrl.fieldName];
+          if (!_.isArray($scope.dataProvider.getFieldData()[ctrl.fieldName]) &&
+            (ctrl.defn.input_type !== 'Select' || !ctrl.defn.is_date || initialVal !== '{}')
+          ) {
+            $scope.dataProvider.getFieldData()[ctrl.fieldName] = {};
+          }
+          // Initialize inputAttrs (only used for datePickers at the moment)
+          if (ctrl.defn.is_date) {
+            this.inputAttrs.push(ctrl.defn.input_attrs || {});
+            for (var i = 1; i <= 2; ++i) {
+              var attrs = _.cloneDeep(ctrl.defn.input_attrs || {});
+              attrs.placeholder = attrs['placeholder' + i];
+              attrs.timePlaceholder = attrs['timePlaceholder' + i];
+              ctrl.inputAttrs.push(attrs);
+            }
+          }
+        }
 
         // is_primary field - watch others in this afRepeat block to ensure only one is selected
         if (ctrl.fieldName === 'is_primary' && 'repeatIndex' in $scope.dataProvider) {
@@ -74,6 +98,41 @@
             result.push({id: opt.id, text: opt.label});
           }, [])
         };
+      };
+
+      // Getter/Setter function for fields of type select.
+      $scope.getSetSelect = function(val) {
+        var currentVal = $scope.dataProvider.getFieldData()[ctrl.fieldName];
+        // Setter
+        if (arguments.length) {
+          if (ctrl.defn.is_date) {
+            // The '{}' string is a placeholder for "choose date range"
+            if (val === '{}') {
+              val = !_.isPlainObject(currentVal) ? {} : currentVal;
+            }
+          }
+          // If search_range, this select is the "low" value (the high value uses ng-model without a getterSetter fn)
+          else if (ctrl.defn.search_range) {
+            return ($scope.dataProvider.getFieldData()[ctrl.fieldName]['>='] = val);
+          }
+          // A multi-select needs to split string value into an array
+          if (ctrl.defn.input_attrs && ctrl.defn.input_attrs.multiple) {
+            val = val ? val.split(',') : [];
+          }
+          return ($scope.dataProvider.getFieldData()[ctrl.fieldName] = val);
+        }
+        // Getter
+        if (_.isArray(currentVal)) {
+          return currentVal.join(',');
+        }
+        if (ctrl.defn.is_date) {
+          return _.isPlainObject(currentVal) ? '{}' : currentVal;
+        }
+        // If search_range, this select is the "low" value (the high value uses ng-model without a getterSetter fn)
+        else if (ctrl.defn.search_range) {
+          return currentVal['>='];
+        }
+        return currentVal;
       };
 
     }

--- a/ext/afform/core/ang/af/afField.html
+++ b/ext/afform/core/ang/af/afField.html
@@ -1,6 +1,6 @@
-<label class="crm-af-field-label" ng-if="$ctrl.defn.label" for="{{:: fieldId }}">
+<label class="crm-af-field-label" ng-if=":: $ctrl.defn.label" for="{{:: fieldId }}">
   {{:: $ctrl.defn.label }}
 </label>
-<p class="crm-af-field-help-pre" ng-if="$ctrl.defn.help_pre">{{:: $ctrl.defn.help_pre }}</p>
+<p class="crm-af-field-help-pre" ng-if=":: $ctrl.defn.help_pre">{{:: $ctrl.defn.help_pre }}</p>
 <div class="crm-af-field" ng-include="'~/af/fields/' + $ctrl.defn.input_type + '.html'"></div>
-<p class="crm-af-field-help-post" ng-if="$ctrl.defn.help_post">{{:: $ctrl.defn.help_post }}</p>
+<p class="crm-af-field-help-post" ng-if=":: $ctrl.defn.help_post">{{:: $ctrl.defn.help_post }}</p>

--- a/ext/afform/core/ang/af/fields/ChainSelect.html
+++ b/ext/afform/core/ang/af/fields/ChainSelect.html
@@ -1,1 +1,1 @@
-<input crm-ui-select="{data: select2Options, multiple: $ctrl.defn.input_attrs.multiple, placeholder: $ctrl.defn.input_attrs.placeholder}" id="{{:: fieldId }}" ng-model="dataProvider.getFieldData()[$ctrl.fieldName]" />
+<input class="form-control" crm-ui-select="{data: select2Options, multiple: $ctrl.defn.input_attrs.multiple, placeholder: $ctrl.defn.input_attrs.placeholder}" id="{{:: fieldId }}" ng-model="dataProvider.getFieldData()[$ctrl.fieldName]" />

--- a/ext/afform/core/ang/af/fields/CheckBox.html
+++ b/ext/afform/core/ang/af/fields/CheckBox.html
@@ -1,7 +1,7 @@
 <ul class="crm-checkbox-list" id="{{ fieldId }}" ng-if="$ctrl.defn.options">
   <li ng-repeat="opt in $ctrl.defn.options track by opt.id" >
     <input type="checkbox" checklist-model="dataProvider.getFieldData()[$ctrl.fieldName]" id="{{ fieldId + opt.id }}" checklist-value="opt.id" />
-    <label for="{{ fieldId + opt.id }}">{{ opt.label }}</label>
+    <label for="{{ fieldId + opt.id }}">{{:: opt.label }}</label>
   </li>
 </ul>
-<input type="checkbox" ng-if="!$ctrl.defn.options" id="{{ fieldId }}" ng-model="dataProvider.getFieldData()[$ctrl.fieldName]" />
+<input type="checkbox" ng-if="!$ctrl.defn.options" id="{{:: fieldId }}" ng-model="dataProvider.getFieldData()[$ctrl.fieldName]" />

--- a/ext/afform/core/ang/af/fields/Date.html
+++ b/ext/afform/core/ang/af/fields/Date.html
@@ -1,1 +1,6 @@
-<input class="form-control" crm-ui-datepicker="$ctrl.defn.input_attrs" id="{{ fieldId }}" ng-model="dataProvider.getFieldData()[$ctrl.fieldName]" />
+<input ng-if=":: !$ctrl.defn.search_range" class="form-control" crm-ui-datepicker=":: $ctrl.defn.input_attrs" id="{{:: fieldId }}" ng-model="dataProvider.getFieldData()[$ctrl.fieldName]" />
+<div ng-if=":: $ctrl.defn.search_range" class="form-inline">
+  <input class="form-control" crm-ui-datepicker=":: $ctrl.inputAttrs[1]" id="{{:: fieldId }}1" ng-model="dataProvider.getFieldData()[$ctrl.fieldName]['>=']" />
+  <span class="af-field-range-sep">-</span>
+  <input class="form-control" crm-ui-datepicker=":: $ctrl.inputAttrs[2]" id="{{:: fieldId }}2" ng-model="dataProvider.getFieldData()[$ctrl.fieldName]['<=']" />
+</div>

--- a/ext/afform/core/ang/af/fields/Date.html
+++ b/ext/afform/core/ang/af/fields/Date.html
@@ -1,1 +1,1 @@
-<input crm-ui-datepicker="$ctrl.defn.input_attrs" id="{{ fieldId }}" ng-model="dataProvider.getFieldData()[$ctrl.fieldName]" />
+<input class="form-control" crm-ui-datepicker="$ctrl.defn.input_attrs" id="{{ fieldId }}" ng-model="dataProvider.getFieldData()[$ctrl.fieldName]" />

--- a/ext/afform/core/ang/af/fields/Number.html
+++ b/ext/afform/core/ang/af/fields/Number.html
@@ -1,1 +1,1 @@
-<input class="crm-form-text" type="number" id="{{ fieldId }}" ng-model="dataProvider.getFieldData()[$ctrl.fieldName]" placeholder="{{ $ctrl.defn.input_attrs.placeholder }}" />
+<input class="form-control" type="number" id="{{ fieldId }}" ng-model="dataProvider.getFieldData()[$ctrl.fieldName]" placeholder="{{ $ctrl.defn.input_attrs.placeholder }}" />

--- a/ext/afform/core/ang/af/fields/Number.html
+++ b/ext/afform/core/ang/af/fields/Number.html
@@ -1,1 +1,6 @@
-<input class="form-control" type="number" id="{{ fieldId }}" ng-model="dataProvider.getFieldData()[$ctrl.fieldName]" placeholder="{{ $ctrl.defn.input_attrs.placeholder }}" />
+<input ng-if=":: !$ctrl.defn.search_range" class="form-control" type="number" id="{{:: fieldId }}" ng-model="dataProvider.getFieldData()[$ctrl.fieldName]" placeholder="{{:: $ctrl.defn.input_attrs.placeholder }}" >
+<div ng-if=":: $ctrl.defn.search_range" class="form-inline">
+  <input class="form-control" type="number" id="{{:: fieldId }}" ng-model="dataProvider.getFieldData()[$ctrl.fieldName]['>=']" placeholder="{{:: $ctrl.defn.input_attrs.placeholder }}" >
+  <span class="af-field-range-sep">-</span>
+  <input class="form-control" type="number" id="{{:: fieldId }}2" ng-model="dataProvider.getFieldData()[$ctrl.fieldName]['<=']" placeholder="{{:: $ctrl.defn.input_attrs.placeholder2 }}" >
+</div>

--- a/ext/afform/core/ang/af/fields/Radio.html
+++ b/ext/afform/core/ang/af/fields/Radio.html
@@ -1,4 +1,4 @@
 <label ng-repeat="opt in getOptions() track by opt.id" >
   <input class="crm-form-radio" type="radio" ng-model="dataProvider.getFieldData()[$ctrl.fieldName]" ng-value="opt.id" />
-  {{ opt.label }}
+  {{:: opt.label }}
 </label>

--- a/ext/afform/core/ang/af/fields/RichTextEditor.html
+++ b/ext/afform/core/ang/af/fields/RichTextEditor.html
@@ -1,1 +1,1 @@
-<textarea crm-ui-richtext id="{{ fieldId }}" ng-model="dataProvider.getFieldData()[$ctrl.fieldName]" ></textarea>
+<textarea crm-ui-richtext id="{{:: fieldId }}" ng-model="dataProvider.getFieldData()[$ctrl.fieldName]" ></textarea>

--- a/ext/afform/core/ang/af/fields/Select.html
+++ b/ext/afform/core/ang/af/fields/Select.html
@@ -1,1 +1,1 @@
-<input crm-ui-select="{data: select2Options, multiple: $ctrl.defn.input_attrs.multiple, placeholder: $ctrl.defn.input_attrs.placeholder}" id="{{:: fieldId }}" ng-model="dataProvider.getFieldData()[$ctrl.fieldName]" />
+<input class="form-control" crm-ui-select="{data: select2Options, multiple: $ctrl.defn.input_attrs.multiple, placeholder: $ctrl.defn.input_attrs.placeholder}" id="{{:: fieldId }}" ng-model="dataProvider.getFieldData()[$ctrl.fieldName]" />

--- a/ext/afform/core/ang/af/fields/Select.html
+++ b/ext/afform/core/ang/af/fields/Select.html
@@ -1,1 +1,5 @@
-<input class="form-control" crm-ui-select="{data: select2Options, multiple: $ctrl.defn.input_attrs.multiple, placeholder: $ctrl.defn.input_attrs.placeholder}" id="{{:: fieldId }}" ng-model="dataProvider.getFieldData()[$ctrl.fieldName]" />
+<div class="{{:: $ctrl.defn.search_range ? 'form-inline' : 'form-group' }}">
+  <input class="form-control" id="{{:: fieldId }}" crm-ui-select="{data: select2Options, multiple: $ctrl.defn.input_attrs.multiple, placeholder: $ctrl.defn.input_attrs.placeholder}" ng-model="getSetSelect" ng-model-options="{getterSetter: true}" >
+  <input class="form-control" ng-if=":: $ctrl.defn.search_range && !$ctrl.defn.is_date" id="{{:: fieldId }}2" crm-ui-select="{data: select2Options, placeholder: $ctrl.defn.input_attrs.placeholder2 || $ctrl.defn.input_attrs.placeholder}" ng-model="dataProvider.getFieldData()[$ctrl.fieldName]['<=']" >
+  <div ng-if="$ctrl.defn.search_range && $ctrl.defn.is_date && getSetSelect() === '{}'" class="form-group" ng-include="'~/af/fields/Date.html'"></div>
+</div>

--- a/ext/afform/core/ang/af/fields/Text.html
+++ b/ext/afform/core/ang/af/fields/Text.html
@@ -1,1 +1,6 @@
-<input class="form-control" type="text" id="{{:: fieldId }}" ng-model="dataProvider.getFieldData()[$ctrl.fieldName]" placeholder="{{:: $ctrl.defn.input_attrs.placeholder }}" >
+<input ng-if=":: !$ctrl.defn.search_range" class="form-control" type="text" id="{{:: fieldId }}" ng-model="dataProvider.getFieldData()[$ctrl.fieldName]" placeholder="{{:: $ctrl.defn.input_attrs.placeholder }}" >
+<div ng-if=":: $ctrl.defn.search_range" class="form-inline">
+  <input class="form-control" type="text" id="{{:: fieldId }}" ng-model="dataProvider.getFieldData()[$ctrl.fieldName]['>=']" placeholder="{{:: $ctrl.defn.input_attrs.placeholder }}" >
+  <span class="af-field-range-sep">-</span>
+  <input class="form-control" type="text" id="{{:: fieldId }}2" ng-model="dataProvider.getFieldData()[$ctrl.fieldName]['<=']" placeholder="{{:: $ctrl.defn.input_attrs.placeholder2 }}" >
+</div>

--- a/ext/afform/core/ang/af/fields/Text.html
+++ b/ext/afform/core/ang/af/fields/Text.html
@@ -1,1 +1,1 @@
-<input class="crm-form-text" type="text" id="{{:: fieldId }}" ng-model="dataProvider.getFieldData()[$ctrl.fieldName]" placeholder="{{ $ctrl.defn.input_attrs.placeholder }}" />
+<input class="form-control" type="text" id="{{:: fieldId }}" ng-model="dataProvider.getFieldData()[$ctrl.fieldName]" placeholder="{{ $ctrl.defn.input_attrs.placeholder }}" />

--- a/ext/afform/core/ang/af/fields/Text.html
+++ b/ext/afform/core/ang/af/fields/Text.html
@@ -1,1 +1,1 @@
-<input class="form-control" type="text" id="{{:: fieldId }}" ng-model="dataProvider.getFieldData()[$ctrl.fieldName]" placeholder="{{ $ctrl.defn.input_attrs.placeholder }}" />
+<input class="form-control" type="text" id="{{:: fieldId }}" ng-model="dataProvider.getFieldData()[$ctrl.fieldName]" placeholder="{{:: $ctrl.defn.input_attrs.placeholder }}" >

--- a/ext/afform/core/ang/afCore.css
+++ b/ext/afform/core/ang/afCore.css
@@ -15,7 +15,7 @@ a.af-api4-action-idle {
 .af-container.af-layout-inline > * {
     display: inline-block;
     margin-right: .5em;
-    vertical-align: bottom;
+    vertical-align: top;
 }
 
 [af-repeat-item] {

--- a/ext/search/Civi/Api4/Action/SearchDisplay/Run.php
+++ b/ext/search/Civi/Api4/Action/SearchDisplay/Run.php
@@ -32,7 +32,7 @@ class Run extends \Civi\Api4\Generic\AbstractAction {
    * Array of fields to use for ordering the results
    * @var array
    */
-  protected $sort;
+  protected $sort = [];
 
   /**
    * Should this api call return a page of results or the row_count or the ids

--- a/ext/search/Civi/Api4/Action/SearchDisplay/Run.php
+++ b/ext/search/Civi/Api4/Action/SearchDisplay/Run.php
@@ -5,6 +5,7 @@ namespace Civi\Api4\Action\SearchDisplay;
 use Civi\API\Exception\UnauthorizedException;
 use Civi\Api4\SavedSearch;
 use Civi\Api4\SearchDisplay;
+use Civi\Api4\Utils\CoreUtil;
 
 /**
  * Load the results for rendering a SearchDisplay.
@@ -151,13 +152,24 @@ class Run extends \Civi\Api4\Generic\AbstractAction {
   }
 
   /**
+   * Checks if a filter contains a non-empty value
+   *
+   * "Empty" search values are [], '', and NULL.
+   * Also recursively checks arrays to ensure they contain at least one non-empty value.
+   *
+   * @param $value
+   * @return bool
+   */
+  private function hasValue($value) {
+    return $value !== '' && $value !== NULL && (!is_array($value) || array_filter($value, [$this, 'hasValue']));
+  }
+
+  /**
    * Applies supplied filters to the where clause
    */
   private function applyFilters() {
     // Ignore empty strings
-    $filters = array_filter($this->filters, function($value) {
-      return isset($value) && (strlen($value) || !is_string($value));
-    });
+    $filters = array_filter($this->filters, [$this, 'hasValue']);
     if (!$filters) {
       return;
     }
@@ -184,37 +196,42 @@ class Run extends \Civi\Api4\Generic\AbstractAction {
 
   /**
    * @param string $fieldName
-   * @param string $value
+   * @param mixed $value
    */
-  private function applyFilter(string $fieldName, string $value) {
-    $field = $this->getField($fieldName);
-
-    // Global setting determines if % wildcard should be added to both sides (default) or only the end of the search term
+  private function applyFilter(string $fieldName, $value) {
+    // Global setting determines if % wildcard should be added to both sides (default) or only the end of a search string
     $prefixWithWildcard = \Civi::settings()->get('includeWildCardInName');
 
-    // Not a real field. It must be an aggregated column. Add to HAVING clause.
-    if (!$field) {
-      if ($prefixWithWildcard) {
-        $this->savedSearch['api_params']['having'][] = [$fieldName, 'CONTAINS', $value];
+    $field = $this->getField($fieldName);
+    // If field is not found it must be an aggregated column & belongs in the HAVING clause.
+    $clause = $field ? 'where' : 'having';
+
+    $dataType = $field['data_type'] ?? NULL;
+
+    // Array is either associative `OP => VAL` or sequential `IN (...)`
+    if (is_array($value)) {
+      $value = array_filter($value, [$this, 'hasValue']);
+      // Use IN if array does not contain operators as keys
+      if (array_diff_key($value, array_flip(CoreUtil::getOperators()))) {
+        $this->savedSearch['api_params'][$clause][] = [$fieldName, 'IN', $value];
       }
       else {
-        $this->savedSearch['api_params']['having'][] = [$fieldName, 'LIKE', $value . '%'];
+        foreach ($value as $operator => $val) {
+          $this->savedSearch['api_params'][$clause][] = [$fieldName, $operator, $val];
+        }
       }
-      return;
     }
-
-    $dataType = $field['data_type'];
-    if (!empty($field['serialize'])) {
-      $this->savedSearch['api_params']['where'][] = [$fieldName, 'CONTAINS', $value];
+    elseif (!empty($field['serialize'])) {
+      $this->savedSearch['api_params'][$clause][] = [$fieldName, 'CONTAINS', $value];
     }
     elseif (!empty($field['options']) || in_array($dataType, ['Integer', 'Boolean', 'Date', 'Timestamp'])) {
-      $this->savedSearch['api_params']['where'][] = [$fieldName, '=', $value];
+      $this->savedSearch['api_params'][$clause][] = [$fieldName, '=', $value];
     }
     elseif ($prefixWithWildcard) {
-      $this->savedSearch['api_params']['where'][] = [$fieldName, 'CONTAINS', $value];
+      $this->savedSearch['api_params'][$clause][] = [$fieldName, 'CONTAINS', $value];
     }
     else {
-      $this->savedSearch['api_params']['where'][] = [$fieldName, 'LIKE', $value . '%'];
+      $this->savedSearch['api_params'][$clause][] = [$fieldName, 'LIKE', $value . '%'];
     }
   }
 

--- a/ext/search/phpunit.xml.dist
+++ b/ext/search/phpunit.xml.dist
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<phpunit backupGlobals="false" backupStaticAttributes="false" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" bootstrap="tests/phpunit/bootstrap.php">
+  <testsuites>
+    <testsuite name="SearchKit Test Suite">
+      <directory>./tests/phpunit</directory>
+    </testsuite>
+  </testsuites>
+  <filter>
+    <whitelist>
+      <directory suffix=".php">./</directory>
+    </whitelist>
+  </filter>
+  <listeners>
+    <listener class="Civi\Test\CiviTestListener">
+      <arguments/>
+    </listener>
+  </listeners>
+</phpunit>

--- a/ext/search/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
+++ b/ext/search/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
@@ -1,0 +1,105 @@
+<?php
+namespace api\v4\SearchDisplay;
+
+use Civi\Api4\Contact;
+use Civi\Test\HeadlessInterface;
+use Civi\Test\TransactionalInterface;
+
+/**
+ * @group headless
+ */
+class SearchRunTest extends \PHPUnit\Framework\TestCase implements HeadlessInterface, TransactionalInterface {
+
+  public function setUpHeadless() {
+    // Civi\Test has many helpers, like install(), uninstall(), sql(), and sqlFile().
+    // See: https://docs.civicrm.org/dev/en/latest/testing/phpunit/#civitest
+    return \Civi\Test::headless()
+      ->installMe(__DIR__)
+      ->apply();
+  }
+
+  public function setUp() {
+    parent::setUp();
+  }
+
+  public function tearDown() {
+    parent::tearDown();
+  }
+
+  /**
+   * Test running a searchDisplay with various filters.
+   */
+  public function testRunDisplay() {
+    $lastName = uniqid(__FUNCTION__);
+    $sampleData = [
+      ['first_name' => 'One', 'last_name' => $lastName],
+      ['first_name' => 'Two', 'last_name' => $lastName],
+      ['first_name' => 'Three', 'last_name' => $lastName],
+      ['first_name' => 'Four', 'last_name' => $lastName],
+    ];
+    Contact::save(FALSE)->setRecords($sampleData)->execute();
+
+    $params = [
+      'checkPermissions' => FALSE,
+      'return' => 'page:1',
+      'savedSearch' => [
+        'api_entity' => 'Contact',
+        'api_params' => [
+          'version' => 4,
+          'select' => ['id', 'first_name', 'last_name'],
+          'where' => [],
+        ],
+      ],
+      'display' => [
+        'type' => 'table',
+        'label' => '',
+        'settings' => [
+          'limit' => 20,
+          'pager' => TRUE,
+          'columns' => [
+            [
+              'key' => 'id',
+              'label' => 'Contact ID',
+              'dataType' => 'Integer',
+              'type' => 'field',
+            ],
+            [
+              'key' => 'first_name',
+              'label' => 'First Name',
+              'dataType' => 'String',
+              'type' => 'field',
+            ],
+            [
+              'key' => 'last_name',
+              'label' => 'Last Name',
+              'dataType' => 'String',
+              'type' => 'field',
+            ],
+          ],
+          'sort' => [
+            ['id', 'ASC'],
+          ],
+        ],
+      ],
+      'filters' => ['last_name' => $lastName],
+      'afform' => NULL,
+    ];
+
+    $result = civicrm_api4('SearchDisplay', 'run', $params);
+    $this->assertCount(4, $result);
+
+    $params['filters']['first_name'] = ['One', 'Two'];
+    $result = civicrm_api4('SearchDisplay', 'run', $params);
+    $this->assertCount(2, $result);
+    $this->assertEquals('One', $result[0]['first_name']);
+    $this->assertEquals('Two', $result[1]['first_name']);
+
+    $params['filters'] = ['id' => ['>' => $result[0]['id'], '<=' => $result[1]['id'] + 1]];
+    $params['sort'] = [['first_name', 'ASC']];
+    $result = civicrm_api4('SearchDisplay', 'run', $params);
+    $this->assertCount(2, $result);
+    $this->assertEquals('Three', $result[0]['first_name']);
+    $this->assertEquals('Two', $result[1]['first_name']);
+  }
+
+}

--- a/ext/search/tests/phpunit/bootstrap.php
+++ b/ext/search/tests/phpunit/bootstrap.php
@@ -1,0 +1,63 @@
+<?php
+
+ini_set('memory_limit', '2G');
+ini_set('safe_mode', 0);
+// phpcs:disable
+eval(cv('php:boot --level=classloader', 'phpcode'));
+// phpcs:enable
+// Allow autoloading of PHPUnit helper classes in this extension.
+$loader = new \Composer\Autoload\ClassLoader();
+$loader->add('CRM_', __DIR__);
+$loader->add('Civi\\', __DIR__);
+$loader->add('api_', __DIR__);
+$loader->add('api\\', __DIR__);
+$loader->register();
+
+/**
+ * Call the "cv" command.
+ *
+ * @param string $cmd
+ *   The rest of the command to send.
+ * @param string $decode
+ *   Ex: 'json' or 'phpcode'.
+ * @return string
+ *   Response output (if the command executed normally).
+ * @throws \RuntimeException
+ *   If the command terminates abnormally.
+ */
+function cv($cmd, $decode = 'json') {
+  $cmd = 'cv ' . $cmd;
+  $descriptorSpec = array(0 => array("pipe", "r"), 1 => array("pipe", "w"), 2 => STDERR);
+  $oldOutput = getenv('CV_OUTPUT');
+  putenv("CV_OUTPUT=json");
+
+  // Execute `cv` in the original folder. This is a work-around for
+  // phpunit/codeception, which seem to manipulate PWD.
+  $cmd = sprintf('cd %s; %s', escapeshellarg(getenv('PWD')), $cmd);
+
+  $process = proc_open($cmd, $descriptorSpec, $pipes, __DIR__);
+  putenv("CV_OUTPUT=$oldOutput");
+  fclose($pipes[0]);
+  $result = stream_get_contents($pipes[1]);
+  fclose($pipes[1]);
+  if (proc_close($process) !== 0) {
+    throw new RuntimeException("Command failed ($cmd):\n$result");
+  }
+  switch ($decode) {
+    case 'raw':
+      return $result;
+
+    case 'phpcode':
+      // If the last output is /*PHPCODE*/, then we managed to complete execution.
+      if (substr(trim($result), 0, 12) !== "/*BEGINPHP*/" || substr(trim($result), -10) !== "/*ENDPHP*/") {
+        throw new \RuntimeException("Command failed ($cmd):\n$result");
+      }
+      return $result;
+
+    case 'json':
+      return json_decode($result, 1);
+
+    default:
+      throw new RuntimeException("Bad decoder format ($decode)");
+  }
+}


### PR DESCRIPTION
Overview
----------------------------------------
This opens up a lot more possibilities for exposed filters with searchKit displays.

Before
----------------------------------------
Only single-value filters accepted.

After
----------------------------------------
New "Multi-Select" and "Search by range" options will allow searches like `IN(...)` or `BETWEEN [...]` respectively.

![image](https://user-images.githubusercontent.com/2874912/113204284-236cf100-923b-11eb-9ae6-d9b75178e4c4.png)

The most complex one is Date fields, which allows you to change the widget to Select *and* enable "Search by range". If you do both then you get the familiar dropdown of relative dates plus a "Choose Date Range" option:

![image](https://user-images.githubusercontent.com/2874912/113205061-da696c80-923b-11eb-941d-1be9a6589b35.png)


Technical Details
----------------------------------------
Adds a basic unit test to ensure operators are functioning.

Comments
----------------------------------------
This doesn't implement exposed filters, but it doesn't box us out of that possibility either. The filter syntax will accept operators.
