### PR TITLE
dev/core#2502 Proposed fix/workaround for CORE-2502

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -3293,7 +3293,8 @@ WHERE  $smartGroupClause
     $tagTree = CRM_Core_BAO_Tag::getChildTags();
     foreach ((array) $value as $tagID) {
       if (!empty($tagTree[$tagID])) {
-        $value = array_unique(array_merge($value, $tagTree[$tagID]));
+        // make sure value is an array here (see CORE-2502)
+        $value = array_unique(array_merge((array) $value, $tagTree[$tagID]));
       }
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
Searching for contact tags using the '=' operator is broken, if they have child tags: you get an SQL error. See [CORE-2502](https://lab.civicrm.org/dev/core/-/issues/2502).

Before
----------------------------------------
Search causes DB error

After
----------------------------------------
Search works

Technical Details
----------------------------------------
This PR is more of a mitigation than a fix, but it seems like it cannot do any harm at that point.

