### PR TITLE
Fix for dev/core#2503

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -4004,7 +4004,9 @@ ORDER BY cg.weight, cf.weight";
         case 'Money':
           $curFilters[$fieldName]['operatorType'] = CRM_Report_Form::OP_FLOAT;
           $curFilters[$fieldName]['type'] = CRM_Utils_Type::T_MONEY;
-          $curFields[$fieldName]['type'] = CRM_Utils_Type::T_MONEY;
+          // Use T_FLOAT instead of T_MONEY as the money number format happens
+          // by calling CRM_Core_BAO_CustomField::displayValue in alterCustomDataDisplay
+          $curFields[$fieldName]['type'] = CRM_Utils_Type::T_FLOAT;
           break;
 
         case 'Float':


### PR DESCRIPTION
Overview
----------------------------------------

CiviReport does not localize custom fields of type Money.

Before
----------------------------------------

Reports did not localize the display value of custom fields of type Money.

After
----------------------------------------

Reports localizes the display value of custom fields of type Money.

Technical Details
----------------------------------------

This PR sets the field type in the report to `T_FLOAT` instead of `T_MONEY`. 
This will do two things:
1. `CRM_Core_BAO_CustomField::displayValue` is called in `alterCustomDataDisplay` which results in correctly localize the value
2. In the report template the smarty modifier `|crmMoney` is called for money fields. Setting it to `T_FLOAT` will prevent this being called for an already localized custom money field. 

Comments
----------------------------------------

See as well: https://lab.civicrm.org/dev/core/-/issues/2503
