### PR TITLE
Remove reference to trxn_id, not on form, from previously shared code

### DIFF
--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -1737,7 +1737,7 @@ DESC limit 1");
     $recurParams['is_email_receipt'] = (bool) $this->getSubmittedValue('send_receipt');
     // we need to add a unique trxn_id to avoid a unique key error
     // in paypal IPN we reset this when paypal sends us the real trxn id, CRM-2991
-    $recurParams['trxn_id'] = $params['trxn_id'] ?? $this->getInvoiceID();
+    $recurParams['trxn_id'] = $this->getInvoiceID();
     $recurParams['campaign_id'] = $this->getSubmittedValue('campaign_id');
     return CRM_Contribute_BAO_ContributionRecur::add($recurParams)->id;
   }


### PR DESCRIPTION
Overview
----------------------------------------
Remove reference to trxn_id, not on form, from previously shared code

Before
----------------------------------------
Handling for an entered trxn_id but no way to enter it on the form - this code comes from previously shared code and may make sense on other forms. 

After
----------------------------------------
poof

Technical Details
----------------------------------------

Comments
----------------------------------------
