### PR TITLE
dev/user-interface#35 civicrm.css: add support for mobile devices on forms

### DIFF
--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -413,10 +413,13 @@ input.crm-form-entityref {
   margin-bottom: 1em;
 }
 
-.crm-container .crm-section .label {
-  float: left;
-  width: 17%;
-  text-align: right;
+/* todo: See PR#19968 to move towards configurable breakpoints */
+@media (min-width: 480px) {
+  .crm-container .crm-section .label {
+    float: left;
+    width: 17%;
+    text-align: right;
+  }
 }
 
 .crm-container .crm-section .label label{
@@ -427,8 +430,10 @@ input.crm-form-entityref {
   text-align: left;
 }
 
-.crm-container .crm-section .content {
-  margin-left: 19%;
+@media (min-width: 480px) {
+  .crm-container .crm-section .content {
+    margin-left: 19%;
+  }
 }
 
 .crm-container .no-label .content {


### PR DESCRIPTION
Overview
----------------------------------------

CSS tweak so that CiviCRM forms are less hostile to use on mobile devices (https://en.wikipedia.org/wiki/Mobile_device).

https://lab.civicrm.org/dev/user-interface/-/issues/35

Before
----------------------------------------

![mobile-before-2021-04-05_09-42](https://user-images.githubusercontent.com/254741/113580765-29285500-95f4-11eb-9e27-c8fed8e1e7a0.png)

After
----------------------------------------

![mobile-after-2021-04-05_09-43](https://user-images.githubusercontent.com/254741/113581288-f6329100-95f4-11eb-8097-f2a6bfbf3fa6.png)

Technical Details
----------------------------------------

Added media queries (https://developer.mozilla.org/en-US/docs/Web/CSS/Media_Queries/Using_media_queries).

The impact should be minor, assuming 99.99999% people override this on their custom CSS.

Comments
----------------------------------------

The above screenshots are from the WordPress wpmaster test site (https://wpmaster.demo.civicrm.org/contribution-page/), which uses the "twentythirteen" theme. The default Drupal7 theme does not support mobile devices (I guess mobile was fairly new in 2011, with the arrival of 4G), but Drupal9 seems cutting edge fortunately does (https://d9-master.demo.civicrm.org/civicrm/contribute/transact?id=1).