### PR TITLE
E-notice fix on serialized setting

### DIFF
--- a/CRM/Admin/Form/SettingTrait.php
+++ b/CRM/Admin/Form/SettingTrait.php
@@ -305,8 +305,8 @@ trait CRM_Admin_Form_SettingTrait {
     foreach (array_keys($this->_settings) as $setting) {
       $this->_defaults[$setting] = civicrm_api3('setting', 'getvalue', ['name' => $setting]);
       $spec = $this->getSettingsMetaData()[$setting];
-      if (!empty($spec['serialize'])) {
-        $this->_defaults[$setting] = CRM_Core_DAO::unSerializeField($this->_defaults[$setting], $spec['serialize']);
+      if (!empty($spec['serialize']) && !is_array($this->_defaults[$setting])) {
+        $this->_defaults[$setting] = CRM_Core_DAO::unSerializeField((string) $this->_defaults[$setting], $spec['serialize']);
       }
       if ($this->getQuickFormType($spec) === 'CheckBoxes') {
         $this->_defaults[$setting] = array_fill_keys($this->_defaults[$setting], 1);


### PR DESCRIPTION

Overview
----------------------------------------
E-notice fix on serialized setting

Before
----------------------------------------
E-notice when using the setting page trait to render a settings form in an extension with a serialized field and declaring field defaults as an array 

After
----------------------------------------
poof

Technical Details
----------------------------------------
We do actually support settings declaring defaults for a serialized field as an array rather
than as a serialised string. However, this setting form, if used, will display an
e-notice in that case as it will still try to unserialize - this adds a simple check first

Comments
----------------------------------------
