### PR TITLE
Fix re-calculation of payment dates on pledge

### DIFF
--- a/CRM/Pledge/BAO/Pledge.php
+++ b/CRM/Pledge/BAO/Pledge.php
@@ -128,6 +128,7 @@ class CRM_Pledge_BAO_Pledge extends CRM_Pledge_DAO_Pledge {
       $params = array_merge($defaults, $params);
     }
 
+    $isRecalculatePledgePayment = self::isPaymentsRequireRecalculation($params);
     $transaction = new CRM_Core_Transaction();
 
     $paymentParams = [];
@@ -172,10 +173,10 @@ class CRM_Pledge_BAO_Pledge extends CRM_Pledge_DAO_Pledge {
     }
 
     // skip payment stuff in edit mode
-    if (empty($params['id']) || self::isPaymentsRequireRecalculation($params)) {
+    if (empty($params['id']) || $isRecalculatePledgePayment) {
 
       // if pledge is pending delete all payments and recreate.
-      if (!empty(empty($params['id']))) {
+      if ($isRecalculatePledgePayment) {
         CRM_Pledge_BAO_PledgePayment::deletePayments($pledge->id);
       }
 


### PR DESCRIPTION
Overview
----------------------------------------
Fix re-calculation of payment dates on pledge

Before
----------------------------------------
Payment schedule on the pledge is not recalculated when the start date is changed on a pending pledge. To replicate -

- Create a pledge of $1200 for 12 installments to start on 4th April, 2021.
- The pledge payments will be created for 4th April, 4 May, 4 June...
- Update the pledge start date to 1st May (instead of 4th April) => Save.
- The pledge payment dates are unchanged and are still starting from 4 April, 4 May....

After
----------------------------------------
If the pledge start date is changed to 1st May, the payment dates are recalculated and are updated to start fro 1st May, 1st June, 1st July....and so on.

Technical Details
----------------------------------------
This PR partially reverts https://github.com/civicrm/civicrm-core/pull/19297. 

`isPaymentsRequireRecalculation()` checks the existing db values of the pledge and returns true only if it mismatches the filled values.

19297 moved the call AFTER the pledge is saved. So it is now comparing the "updated" values with the passed params which will always match and hence no recalculation is done in any case. 

Comments
----------------------------------------
@eileenmcnaughton thoughts?