### PR TITLE
dev/core#2425 - php 7.4 - E_NOTICE every time you save a contribution

### DIFF
--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -911,8 +911,14 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
       }
     }
     // CRM-16189
+    $order = new CRM_Financial_BAO_Order();
+    $order->setPriceSelectionFromUnfilteredInput($fields);
+    if (isset($fields['total_amount'])) {
+      $order->setOverrideTotalAmount($fields['total_amount']);
+    }
+    $lineItems = $order->getLineItems();
     try {
-      CRM_Financial_BAO_FinancialAccount::checkFinancialTypeHasDeferred($fields, $self->_id, $self->_priceSet['fields']);
+      CRM_Financial_BAO_FinancialAccount::checkFinancialTypeHasDeferred($fields, $self->_id, $lineItems);
     }
     catch (CRM_Core_Exception $e) {
       $errors['financial_type_id'] = ' ';

--- a/CRM/Financial/BAO/FinancialAccount.php
+++ b/CRM/Financial/BAO/FinancialAccount.php
@@ -375,13 +375,13 @@ LIMIT 1";
    * @param int $contributionID
    *   Contribution ID
    *
-   * @param array $priceSetFields
-   *   Array of price fields of a price set.
+   * @param array $orderLineItems
+   *   The line items from the Order.
    *
    * @return bool
    *
    */
-  public static function checkFinancialTypeHasDeferred($params, $contributionID = NULL, $priceSetFields = NULL) {
+  public static function checkFinancialTypeHasDeferred($params, $contributionID = NULL, $orderLineItems = []) {
     if (!Civi::settings()->get('deferred_revenue_enabled')) {
       return FALSE;
     }
@@ -399,16 +399,7 @@ LIMIT 1";
       $financialTypeID = $params['prevContribution']->financial_type_id;
     }
     if (($contributionID || !empty($params['price_set_id'])) && empty($lineItems)) {
-      if (!$contributionID) {
-        CRM_Price_BAO_PriceSet::processAmount($priceSetFields,
-          $params, $items);
-      }
-      else {
-        $items = CRM_Price_BAO_LineItem::getLineItems($contributionID, 'contribution', TRUE, TRUE, TRUE);
-      }
-      if (!empty($items)) {
-        $lineItems[] = $items;
-      }
+      $lineItems[] = $orderLineItems;
     }
     $deferredFinancialType = self::getDeferredFinancialType();
     $isError = FALSE;

--- a/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
@@ -2046,4 +2046,131 @@ Price Field - Price Field 1        1   $ 100.00      $ 100.00
     ];
   }
 
+  /**
+   * Test formRule
+   */
+  public function testContributionFormRule() {
+    $fields = [
+      'contact_id' => $this->_individualId,
+      'financial_type_id' => CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'financial_type_id', 'Donation'),
+      'currency' => 'USD',
+      'total_amount' => '10',
+      'price_set_id' => '',
+      'source' => '',
+      'contribution_status_id' => CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Completed'),
+      'cancel_date' => '',
+      'cancel_reason' => '',
+      'receive_date' => date('Y-m-d H:i:s'),
+      'from_email_address' => key(CRM_Core_BAO_Email::getFromEmail()),
+      'receipt_date' => '',
+      'payment_instrument_id' => CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'payment_instrument_id', 'Check'),
+      'trxn_id' => '',
+      'check_number' => '',
+      'soft_credit_contact_id' => [
+        1 => '',
+        2 => '',
+        3 => '',
+        4 => '',
+        5 => '',
+        6 => '',
+        7 => '',
+        8 => '',
+        9 => '',
+        10 => '',
+      ],
+      'soft_credit_amount' => [
+        1 => '',
+        2 => '',
+        3 => '',
+        4 => '',
+        5 => '',
+        6 => '',
+        7 => '',
+        8 => '',
+        9 => '',
+        10 => '',
+      ],
+      'soft_credit_type' => [
+        1 => '',
+        2 => '',
+        3 => '',
+        4 => '',
+        5 => '',
+        6 => '',
+        7 => '',
+        8 => '',
+        9 => '',
+        10 => '',
+      ],
+    ];
+
+    $form = new CRM_Contribute_Form_Contribution();
+    $this->assertSame([], $form->formRule($fields, [], $form));
+  }
+
+  /**
+   * Check that formRule validates you can only have one contribution with a
+   * given trxn_id.
+   */
+  public function testContributionFormRuleDuplicateTrxn() {
+    $contribution = $this->callAPISuccess('Contribution', 'create', array_merge($this->_params, ['trxn_id' => '1234']));
+
+    $fields = [
+      'contact_id' => $this->_individualId,
+      'financial_type_id' => CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'financial_type_id', 'Donation'),
+      'currency' => 'USD',
+      'total_amount' => '10',
+      'price_set_id' => '',
+      'source' => '',
+      'contribution_status_id' => CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Completed'),
+      'cancel_date' => '',
+      'cancel_reason' => '',
+      'receive_date' => date('Y-m-d H:i:s'),
+      'from_email_address' => key(CRM_Core_BAO_Email::getFromEmail()),
+      'receipt_date' => '',
+      'payment_instrument_id' => CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'payment_instrument_id', 'Check'),
+      'trxn_id' => '1234',
+      'check_number' => '',
+      'soft_credit_contact_id' => [
+        1 => '',
+        2 => '',
+        3 => '',
+        4 => '',
+        5 => '',
+        6 => '',
+        7 => '',
+        8 => '',
+        9 => '',
+        10 => '',
+      ],
+      'soft_credit_amount' => [
+        1 => '',
+        2 => '',
+        3 => '',
+        4 => '',
+        5 => '',
+        6 => '',
+        7 => '',
+        8 => '',
+        9 => '',
+        10 => '',
+      ],
+      'soft_credit_type' => [
+        1 => '',
+        2 => '',
+        3 => '',
+        4 => '',
+        5 => '',
+        6 => '',
+        7 => '',
+        8 => '',
+        9 => '',
+        10 => '',
+      ],
+    ];
+
+    $form = new CRM_Contribute_Form_Contribution();
+    $this->assertEquals(['trxn_id' => "Transaction ID's must be unique. Transaction '1234' already exists in your database."], $form->formRule($fields, [], $form));
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/2425

Before
----------------------------------------
1. Use php 7.4
2. Make a contribution in the backend.
3. Save it.

`Notice: Trying to access array offset on value of type null in CRM_Contribute_Form_Contribution::formRule() (line 915 of CRM\Contribute\Form\Contribution.php).`

After
----------------------------------------
No notice.

If you want to check that the financial account validation is still working you can:
1. Turn on deferred revenue in civicontribute settings.
2. Make a contribution _with a price set_ that uses a financial type that doesn't have a corresponding deferred revenue account, like Donation by default.
3. Enter a recognition date on the form.
4. You should get an alert box validation error.

Technical Details
----------------------------------------
See lab ticket. The gist is to not calculate the line items from the `_priceSet` variable which is missing and instead get the line items from the order and pass it in.

In terms of the affected scope:

* If deferred revenue isn't enabled nothing changes and it just returns early.
* If you don't fill in a recognition date, nothing changes it just returns early.
* If it's a new contribution and you don't use a price set, the line items are empty and both before and after it skips trying to get them (line 401), so again nothing changes.
* When you're editing a contribution, I'm not sure what 'prevContribution' is or when it would be present, but when it isn't then again it returns early.
* checkFinancialTypeHasDeferred() is only called from the one place in the contribution formRule, in core at least.
* In the call to processAmount() before, $params was passed by reference and updated, however it's never used again in checkFinancialTypeHasDeferred() and was passed into there by value, so removing the call to processAmount() doesn't change that.
* The purpose of calling processAmount() was to get the line items, but we already have it now.
* The only element of the line item it actually uses is the financial_type_id.

So the scope is pretty limited. It might miss the validation warning if for some reason the order'ized version of the line items is somehow different than before. I don't know enough about it so I'm just assuming it always matches up.

I'm sure there is more here to clean up but I really just want the problem to go away since it comes up every single time you save a contribution.

Comments
----------------------------------------
Has test. Note it passes on php 7.3 or lower even before the patch, but fails on php 7.4.
