### PR TITLE
Fix scrollbars on fullscreen dashboard dashlet

### DIFF
--- a/ang/crmDashboard/FullscreenDialog.html
+++ b/ang/crmDashboard/FullscreenDialog.html
@@ -1,1 +1,3 @@
-<crm-dashlet dashlet="model" is-fullscreen="true"></crm-dashlet>
+<div>
+  <crm-dashlet dashlet="model" is-fullscreen="true"></crm-dashlet>
+</div>


### PR DESCRIPTION
Overview
----------------------------------------
Fixes the bug described in https://lab.civicrm.org/dev/core/-/issues/2513

Before
----------------------------------------
Clicking the "expand" arrows on a dashboard dashlet appears cut-off with no scrollbars.

After
----------------------------------------
Dialog appears with proper size, position, and scrollbars.

Technical Details
----------------------------------------
Apparently angular dialogService expects templates to be wrapped in an outer div, as that becomes the `.ui-dialog-content` element.