### PR TITLE
dev/core#2516 Invalidate only smart groups

### DIFF
--- a/CRM/Contact/BAO/GroupContactCache.php
+++ b/CRM/Contact/BAO/GroupContactCache.php
@@ -578,7 +578,7 @@ ORDER BY   gc.contact_id, g.children
   public static function invalidateGroupContactCache($groupID) {
     CRM_Core_DAO::executeQuery("UPDATE civicrm_group
       SET cache_date = NULL
-      WHERE id = %1 AND saved_search_id IS NOT NULL", [
+      WHERE id = %1 AND (saved_search_id IS NOT NULL OR children IS NOT NULL)", [
         1 => [$groupID, 'Positive'],
       ]);
   }

--- a/CRM/Contact/BAO/GroupContactCache.php
+++ b/CRM/Contact/BAO/GroupContactCache.php
@@ -578,7 +578,7 @@ ORDER BY   gc.contact_id, g.children
   public static function invalidateGroupContactCache($groupID) {
     CRM_Core_DAO::executeQuery("UPDATE civicrm_group
       SET cache_date = NULL
-      WHERE id = %1", [
+      WHERE id = %1 AND saved_search_id IS NOT NULL", [
         1 => [$groupID, 'Positive'],
       ]);
   }


### PR DESCRIPTION
described here https://lab.civicrm.org/dev/core/-/issues/2516, abstract:

Method CRM_Contact_BAO_GroupContactCache::invalidateGroupContactCache() is described as touching smart groups but there is no condition for smart groups.

Current behaviour produced too much traffic on database (deadlocks).

