### PR TITLE
Activity type weights

### DIFF
--- a/CRM/Upgrade/Incremental/sql/5.37.alpha1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.37.alpha1.mysql.tpl
@@ -9,3 +9,11 @@ UPDATE civicrm_state_province s
  SET s.abbreviation = 'CMN';
 
 ALTER TABLE `civicrm_case_type` CHANGE `is_active`  `is_active` tinyint DEFAULT 1 COMMENT 'Is this case type enabled?';
+
+-- https://lab.civicrm.org/dev/core/-/issues/2442
+
+SELECT @option_group_id_activity_contacts := id FROM civicrm_option_group WHERE name = 'activity_contacts';
+
+UPDATE civicrm_option_value SET weight = 1 WHERE name = 'Activity Targets' AND option_group_id = @option_group_id_activity_contacts;
+UPDATE civicrm_option_value SET weight = 2 WHERE name = 'Activity Source' AND option_group_id = @option_group_id_activity_contacts;
+UPDATE civicrm_option_value SET weight = 3 WHERE name = 'Activity Assignees' AND option_group_id = @option_group_id_activity_contacts;

--- a/xml/templates/civicrm_data.tpl
+++ b/xml/templates/civicrm_data.tpl
@@ -850,9 +850,9 @@ VALUES
   (@option_group_id_paperSize, '{ts escape="sql"}ISO SRA4{/ts}',        '{literal}{"metric":"pt","width":637.8,"height":907.09}{/literal}',    'sra4',        NULL, NULL, 0, 62, NULL, 0, 0, 1, NULL, NULL, NULL),
 
 -- activity_contacts
-   (@option_group_id_aco, '{ts escape="sql"}Activity Assignees{/ts}', 1, 'Activity Assignees', NULL, 0, NULL, 1, NULL, 0, 0, 1, NULL, NULL, NULL),
+   (@option_group_id_aco, '{ts escape="sql"}Activity Assignees{/ts}', 1, 'Activity Assignees', NULL, 0, NULL, 3, NULL, 0, 0, 1, NULL, NULL, NULL),
    (@option_group_id_aco, '{ts escape="sql"}Activity Source{/ts}', 2, 'Activity Source', NULL, 0, NULL, 2, NULL, 0, 0, 1, NULL, NULL, NULL),
-   (@option_group_id_aco, '{ts escape="sql"}Activity Targets{/ts}', 3, 'Activity Targets', NULL, 0, NULL, 3, NULL, 0, 0, 1, NULL, NULL, NULL),
+   (@option_group_id_aco, '{ts escape="sql"}Activity Targets{/ts}', 3, 'Activity Targets', NULL, 0, NULL, 1, NULL, 0, 0, 1, NULL, NULL, NULL),
 
 -- financial_account_type
 -- grouping field is specific to Quickbooks for mapping to .iif format


### PR DESCRIPTION
Overview
----------------------------------------
This reorders the weights of activity contact types so that "Activity Target" appears at the top of the list for search kit.

Ids and values remain unchanged, so this should not affect extensions or other integrations.

Check: https://lab.civicrm.org/dev/core/-/issues/2442
