### PR TITLE
dev/core#2501 - uf_group is_active should default to true if not specified

### DIFF
--- a/CRM/Core/BAO/UFGroup.php
+++ b/CRM/Core/BAO/UFGroup.php
@@ -1449,7 +1449,7 @@ class CRM_Core_BAO_UFGroup extends CRM_Core_DAO_UFGroup {
       'is_cms_user',
     ];
     foreach ($fields as $field) {
-      $params[$field] = CRM_Utils_Array::value($field, $params, FALSE);
+      $params[$field] = CRM_Utils_Array::value($field, $params, $field === 'is_active');
     }
 
     $params['limit_listings_group_id'] = $params['group'] ?? NULL;

--- a/tests/phpunit/api/v3/UFGroupTest.php
+++ b/tests/phpunit/api/v3/UFGroupTest.php
@@ -101,6 +101,22 @@ class api_v3_UFGroupTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test what happens if you don't set is_active
+   * @param int $version
+   * @dataProvider versionThreeAndFour
+   */
+  public function testUpdateUFGroupActiveMissing($version) {
+    $this->_apiversion = $version;
+    $this->callAPISuccess('uf_group', 'create', [
+      'sequential' => 1,
+      'title' => 'Edited Test Profile',
+      'id' => $this->_ufGroupId,
+    ]);
+    $result = $this->callAPISuccess('uf_group', 'getsingle', ['id' => $this->_ufGroupId]);
+    $this->assertSame($this->_apiversion === 3 ? '1' : TRUE, $result['is_active']);
+  }
+
+  /**
    * @param int $version
    * @dataProvider versionThreeAndFour
    */


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/2501

For whatever reason ufgroup::create sets is_active to FALSE if you don't specify, so for example updating just the title disables your profile. I can't think why this would be intentional.

Before
----------------------------------------
0

After
----------------------------------------
1

Technical Details
----------------------------------------
There's a loop where it sets some fields to false if missing. The others make some sense but not is_active.

Comments
----------------------------------------
Has test
