### PR TITLE
dev/core#2490 Drupal8: Fix CMS intergration table mapping

### DIFF
--- a/CRM/Admin/Form/Setting/UF.php
+++ b/CRM/Admin/Form/Setting/UF.php
@@ -45,7 +45,13 @@ class CRM_Admin_Form_Setting_UF extends CRM_Admin_Form_Setting {
     }
 
     // find out if drupal has its database prefixed
-    global $databases;
+    if ($this->_uf == 'Drupal8') {
+      $databases['default'] = Drupal\Core\Database\Database::getConnectionInfo('default');
+    }
+    else {
+      global $databases;
+    }
+    
     $drupal_prefix = '';
     if (isset($databases['default']['default']['prefix'])) {
       if (is_array($databases['default']['default']['prefix'])) {

--- a/CRM/Admin/Form/Setting/UF.php
+++ b/CRM/Admin/Form/Setting/UF.php
@@ -51,7 +51,7 @@ class CRM_Admin_Form_Setting_UF extends CRM_Admin_Form_Setting {
     else {
       global $databases;
     }
-    
+
     $drupal_prefix = '';
     if (isset($databases['default']['default']['prefix'])) {
       if (is_array($databases['default']['default']['prefix'])) {


### PR DESCRIPTION
In Drupal8, CMS intergration don't show table mapping, because $database global variable is no more defined and can be retreived using Drupal\Core\Database\Database::getConnectionInfo()

Before
----------------------------------------

On the "CMS database integration" page, when running CiviCRM/Drupal on separate databases, the CMS database settings are not visible:

![cms-2021-04-20_09-43](https://user-images.githubusercontent.com/254741/115406191-ee5e1980-a1bc-11eb-8e2b-706e3f7cd91e.png)

After
----------------------------------------

![cms-2021-04-20_09-45](https://user-images.githubusercontent.com/254741/115406423-26fdf300-a1bd-11eb-91c2-52e996206881.png)

Technical Details
----------------------------------------

Fetches the Drupal8 database info from the place where D8/D9 now manages this.

Comments
----------------------------------------

edits by mlutfy.