### PR TITLE
dev/core#2493 Default to not cleaning money for order.create api

### DIFF
--- a/api/v3/Order.php
+++ b/api/v3/Order.php
@@ -239,6 +239,11 @@ function _civicrm_api3_order_create_spec(&$params) {
     'name' => 'total_amount',
     'title' => 'Total Amount',
   ];
+  $params['skipCleanMoney'] = [
+    'api.default' => TRUE,
+    'title' => 'Do not attempt to convert money values',
+    'type' => CRM_Utils_Type::T_BOOLEAN,
+  ];
   $params['financial_type_id'] = [
     'name' => 'financial_type_id',
     'title' => 'Financial Type',

--- a/tests/phpunit/CRM/Contribute/BAO/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/BAO/ContributionTest.php
@@ -1123,6 +1123,7 @@ WHERE eft.entity_id = %1 AND ft.to_financial_account_id <> %2";
       'receipt_date' => '20080522000000',
       'total_amount' => '20,000.00',
       'api.Payment.create' => ['total_amount' => '8,000.00'],
+      'skipCleanMoney' => FALSE,
     ];
 
     $contribution = $this->callAPISuccess('Order', 'create', $params);


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#2493 Default to not cleaning money for order.create api

Before
----------------------------------------
Per https://lab.civicrm.org/dev/core/-/issues/2493#note_57387 there seem to be a lot of issues now with money being truncated which is what the clean function does if called twice on the same string. By default Order v3 create api gets the same default for skipCleanMoney (FALSE) as Contribution.create api.

However, it seems implicated in some of the cases and also one that can be more easily changed since Order api always involves some wrangling (and is less used) and the most broadly used cases appear to be implicated


After
----------------------------------------
Order v3 api defaults to skipCleanMoney

Technical Details
----------------------------------------
@kcristiano does this fix the case you can replicate? @agileware-justin may fix some of the case/s you hit

Comments
----------------------------------------
