### PR TITLE
APIv4 - Prevent api adding default join conditions when it shouldn't

### DIFF
--- a/Civi/Api4/Query/Api4SelectQuery.php
+++ b/Civi/Api4/Query/Api4SelectQuery.php
@@ -658,7 +658,7 @@ class Api4SelectQuery {
         return FALSE;
       }
       foreach ([$sideA, $sideB] as $expr) {
-        if ($expr === "$alias.id" || !empty($joinEntityFields["$alias.$expr"]['fk_entity'])) {
+        if ($expr === "$alias.id" || !empty($joinEntityFields[str_replace("$alias.", '', $expr)]['fk_entity'])) {
           return TRUE;
         }
       }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a bug in SearchKit where e.g. joining email to related contact returns no emails.

Before
----------------------------------------
This search returns no emails:
http://wp.demo/wp-admin/admin.php?page=CiviCRM&q=civicrm%2Fadmin%2Fsearch#/create/Contact?params=%7B%22version%22:4,%22select%22:%5B%22id%22,%22display_name%22,%22Contact_RelationshipCache_Contact_01.display_name%22,%22Contact_RelationshipCache_Contact_01_Contact_Email_contact_id_01.email%22%5D,%22orderBy%22:%7B%7D,%22where%22:%5B%5D,%22groupBy%22:%5B%5D,%22join%22:%5B%5B%22Contact%20AS%20Contact_RelationshipCache_Contact_01%22,%22INNER%22,%22RelationshipCache%22,%5B%22id%22,%22%3D%22,%22Contact_RelationshipCache_Contact_01.far_contact_id%22%5D%5D,%5B%22Email%20AS%20Contact_RelationshipCache_Contact_01_Contact_Email_contact_id_01%22,%22LEFT%22,%5B%22Contact_RelationshipCache_Contact_01.id%22,%22%3D%22,%22Contact_RelationshipCache_Contact_01_Contact_Email_contact_id_01.contact_id%22%5D%5D%5D,%22having%22:%5B%5D%7D

After
----------------------------------------
Emails are returned as they should be.

Technical Details
----------------------------------------
When adding an explicit join, the api will search for a default condition unlessan fk field has been explicitly set. This fixes an error when the api thought no fk field was present when it actually was.

The alias was being added when it should have been removed. Oops.