### PR TITLE
dev/core#2501 - api uf_group.create overwrites existing fields when updating if they aren't specified

### DIFF
--- a/CRM/Core/BAO/UFGroup.php
+++ b/CRM/Core/BAO/UFGroup.php
@@ -1439,21 +1439,16 @@ class CRM_Core_BAO_UFGroup extends CRM_Core_DAO_UFGroup {
       $params['id'] = $ids['ufgroup'];
       CRM_Core_Error::deprecatedWarning('ids parameter is deprecated');
     }
-    $fields = [
-      'is_active',
-      'add_captcha',
-      'is_map',
-      'is_update_dupe',
-      'is_edit_link',
-      'is_uf_link',
-      'is_cms_user',
-    ];
-    foreach ($fields as $field) {
-      $params[$field] = CRM_Utils_Array::value($field, $params, FALSE);
-    }
 
-    $params['limit_listings_group_id'] = $params['group'] ?? NULL;
-    $params['add_to_group_id'] = $params['add_contact_to_group'] ?? NULL;
+    // Convert parameter names but don't overwrite existing data on updates
+    // unless explicitly specified. And allow setting to null, so use
+    // array_key_exists. i.e. we need to treat missing and empty separately.
+    if (array_key_exists('group', $params)) {
+      $params['limit_listings_group_id'] = $params['group'];
+    }
+    if (array_key_exists('add_contact_to_group', $params)) {
+      $params['add_to_group_id'] = $params['add_contact_to_group'];
+    }
 
     //CRM-15427
     if (!empty($params['group_type']) && is_array($params['group_type'])) {


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/2501

There are several fields that UFGroup::add() sets to FALSE if you don't specify, so for example updating just the title disables your profile because it sets is_active to 0. I can't think why this would be intentional and looking back through the history there doesn't seem to be a reason I can find.

To reproduce:
1. Create a profile.
1. Set some of the affected fields like the CMS user creation option and the Enable Mapping option.
1. `cv api uf_group.create id=15 title=testing`, where id is the profile id. Or use api explorer.
1. Back in the UI or in the database look at the fields. The profile is now disabled and those affected fields you set are cleared out.

Before
----------------------------------------
is_active, the setting for whether to offer cms user creation, mapping, etc, all get turned off.

After
----------------------------------------
As expected and the way other api calls work.

Technical Details
----------------------------------------
There are two additional parameters that have different names than their fields, so we need to keep that, but currently they overwrite with null if they're missing. But you might want to blank out a field, so we need to treat missing differently than empty.

Comments
----------------------------------------
Has test.
