### PR TITLE
Afform - Fix endless spinner on "New Search Display" dropdown

### DIFF
--- a/ext/afform/admin/ang/afAdmin/afAdminList.controller.js
+++ b/ext/afform/admin/ang/afAdmin/afAdminList.controller.js
@@ -13,12 +13,12 @@
     $scope.types = _.indexBy(ctrl.tabs, 'name');
     _.each(['form', 'block', 'search'], function(type) {
       if ($scope.types[type]) {
-        $scope.types[type].options = [];
         if (type === 'form') {
           $scope.types.form.default = '#create/form/Individual';
         }
       }
     });
+    $scope.types.system.options = false;
 
     this.afforms = _.transform(afforms, function(afforms, afform) {
       afform.type = afform.type || 'system';
@@ -35,7 +35,7 @@
 
     this.createLinks = function() {
       ctrl.searchCreateLinks = '';
-      if ($scope.types[ctrl.tab].options.length) {
+      if ($scope.types[ctrl.tab].options) {
         return;
       }
       var links = [];
@@ -66,6 +66,7 @@
         $scope.types.block.options = _.sortBy(links, function(item) {
           return item.url === '#create/block/*' ? '0' : item.label;
         });
+        // Add divider after the * entity (content block)
         $scope.types.block.options.splice(1, 0, {'class': 'divider', label: ''});
       }
 

--- a/ext/afform/admin/ang/afAdmin/afAdminList.html
+++ b/ext/afform/admin/ang/afAdmin/afAdminList.html
@@ -10,7 +10,7 @@
   <div class="form-inline">
     <label for="afform-list-filter">{{:: ts('Filter:') }}</label>
     <input class="form-control" type="search" id="afform-list-filter" ng-model="$ctrl.searchAfformList" placeholder="&#xf002">
-    <div class="btn-group pull-right" ng-if="types[$ctrl.tab].options">
+    <div class="btn-group pull-right" ng-if="types[$ctrl.tab].options !== false">
       <a ng-if="types[$ctrl.tab].default" href="{{ types[$ctrl.tab].default }}" class="btn btn-primary">
         {{ ts('New %1', {1: types[$ctrl.tab].label }) }}
       </a>
@@ -19,9 +19,10 @@
         <span class="caret"></span>
       </button>
       <ul class="dropdown-menu">
-        <li>
-          <input ng-if="types[$ctrl.tab].options.length" type="search" class="form-control" placeholder="&#xf002" ng-model="searchCreateLinks.label">
-          <a href ng-if="!types[$ctrl.tab].options.length"><i class="crm-i fa-spinner fa-spin"></i></a>
+        <li ng-class="{disabled: !types[$ctrl.tab].options || !types[$ctrl.tab].options.length}">
+          <input ng-if="types[$ctrl.tab].options && types[$ctrl.tab].options.length" type="search" class="form-control" placeholder="&#xf002" ng-model="searchCreateLinks.label">
+          <a href ng-if="!types[$ctrl.tab].options"><i class="crm-i fa-spinner fa-spin"></i></a>
+          <a href ng-if="types[$ctrl.tab].options && !types[$ctrl.tab].options.length">{{:: ts('None Found') }}</a>
         </li>
         <li ng-repeat="link in types[$ctrl.tab].options | filter:searchCreateLinks" class="{{:: link.class }}">
           <a ng-if=":: link.url" href="{{:: link.url }}">


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a seemingly endless spinner when no search displays exist

Before
----------------------------------------
When there are no search displays in the database, this just keeps spinning:

![image](https://user-images.githubusercontent.com/2874912/113958249-c18a2980-97ee-11eb-9ce3-bea9f739e390.png)


After
----------------------------------------
![image](https://user-images.githubusercontent.com/2874912/113958092-78d27080-97ee-11eb-9086-5c5072316e1f.png)


