### PR TITLE
Afform - Refresh assetBuilder when saving a form

### DIFF
--- a/Civi/Angular/Manager.php
+++ b/Civi/Angular/Manager.php
@@ -70,6 +70,8 @@ class Manager {
     $this->cache->clear();
     $this->modules = NULL;
     $this->changeSets = NULL;
+    // Force-refresh assetBuilder files
+    \Civi::container()->get('asset_builder')->clear(FALSE);
     return $this;
   }
 

--- a/ext/afform/core/Civi/Api4/Utils/AfformSaveTrait.php
+++ b/ext/afform/core/Civi/Api4/Utils/AfformSaveTrait.php
@@ -79,7 +79,6 @@ trait AfformSaveTrait {
       \CRM_Core_Menu::store();
       \CRM_Core_BAO_Navigation::resetNavigation();
     }
-    // FIXME if asset-caching is enabled, then flush the asset cache.
 
     $item['module_name'] = _afform_angular_module_name($item['name'], 'camel');
     $item['directive_name'] = _afform_angular_module_name($item['name'], 'dash');


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a caching problem where saving an afform would not show changes until caches were manually flushed.

Before
----------------------------------------
(reproduced on a stock Wordpress-Demo site)
1. Set site to production mode with asset caching enabled.
2. Create an afform with a url.
3. View the form at that url.
4. Edit the form and view again. Changes do not appear.

After
----------------------------------------
Changes to afforms are immediately visible.

Technical Details
----------------------------------------
All it needed was an assetBuilder cache flush
