### PR TITLE
dev/report#53: search on relationship and case (2)

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -5780,7 +5780,7 @@ INNER JOIN civicrm_relationship displayRelType ON ( displayRelType.contact_id_a 
 INNER JOIN $tableName transform_temp ON ( transform_temp.contact_id = displayRelType.contact_id_a OR transform_temp.contact_id = displayRelType.contact_id_b )
 ";
         $qcache['where'] = "
-WHERE displayRelType.relationship_type_id = {$this->_displayRelationshipType}
+AND displayRelType.relationship_type_id = {$this->_displayRelationshipType}
 AND   displayRelType.is_active = 1
 ";
       }
@@ -5801,7 +5801,7 @@ INNER JOIN $tableName transform_temp ON ( transform_temp.contact_id = displayRel
 ";
         }
         $qcache['where'] = "
-WHERE displayRelType.relationship_type_id = $relType
+AND displayRelType.relationship_type_id = $relType
 AND   displayRelType.is_active = 1
 ";
       }
@@ -5825,10 +5825,11 @@ AND   displayRelType.is_active = 1
       else {
         $from .= $qcache['from'];
       }
-      $where = $qcache['where'];
+      $where .= $qcache['where'];
       if (!empty($this->_tables['civicrm_case'])) {
         // Change the join on CiviCRM case so that it joins on the right contac from the relationship.
         $from = str_replace("ON civicrm_case_contact.contact_id = contact_a.id", "ON civicrm_case_contact.contact_id = transform_temp.contact_id", $from);
+        $where = str_replace("AND civicrm_case_contact.contact_id = contact_a.id", "AND civicrm_case_contact.contact_id = transform_temp.contact_id", $where);
         $where .= " AND displayRelType.case_id = civicrm_case_contact.case_id ";
       }
       if (!empty($this->_permissionFromClause) && !stripos($from, 'aclContactCache')) {

--- a/CRM/Upgrade/Incremental/sql/5.35.0.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.35.0.mysql.tpl
@@ -1,0 +1,1 @@
+{* file to handle db changes in 5.35.0 during upgrade *}

--- a/sql/civicrm_generated.mysql
+++ b/sql/civicrm_generated.mysql
@@ -399,7 +399,7 @@ UNLOCK TABLES;
 
 LOCK TABLES `civicrm_domain` WRITE;
 /*!40000 ALTER TABLE `civicrm_domain` DISABLE KEYS */;
-INSERT INTO `civicrm_domain` (`id`, `name`, `description`, `version`, `contact_id`, `locales`, `locale_custom_strings`) VALUES (1,'Default Domain Name',NULL,'5.35.beta1',1,NULL,'a:1:{s:5:\"en_US\";a:0:{}}');
+INSERT INTO `civicrm_domain` (`id`, `name`, `description`, `version`, `contact_id`, `locales`, `locale_custom_strings`) VALUES (1,'Default Domain Name',NULL,'5.35.0',1,NULL,'a:1:{s:5:\"en_US\";a:0:{}}');
 /*!40000 ALTER TABLE `civicrm_domain` ENABLE KEYS */;
 UNLOCK TABLES;
 

--- a/sql/test_data_second_domain.mysql
+++ b/sql/test_data_second_domain.mysql
@@ -963,4 +963,4 @@ INSERT INTO civicrm_navigation
 VALUES
     ( @domainID, CONCAT('civicrm/report/instance/', @instanceID,'&reset=1'), 'Mailing Detail Report', 'Mailing Detail Report', 'administer CiviMail', 'OR', @reportlastID, '1', NULL, @instanceID+2 );
 UPDATE civicrm_report_instance SET navigation_id = LAST_INSERT_ID() WHERE id = @instanceID;
-UPDATE civicrm_domain SET version = '5.35.beta1';
+UPDATE civicrm_domain SET version = '5.35.0';

--- a/xml/version.xml
+++ b/xml/version.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="iso-8859-1" ?>
 <version>
-  <version_no>5.35.beta1</version_no>
+  <version_no>5.35.0</version_no>
 </version>


### PR DESCRIPTION
Overview
----------------------------------------
When doing an advanced search with case parameters set and displaying related contacts. Gives all clients of all the found cases which have this relationship. What we would expect is that related contact is linked to the found cases. 

Steps to reproduce
--------------------------

Preparation:
1. Create a contact **Contact A**
2. Create another contact **Contact B**
3. Create a third contact **Contact C**
4. Create a case of type **Housing Support** for **Contact A**
5. On the case assign the role **Benefit specialist is** to **Contact B**
6. Create a second case of type **Adult day care referral**
7. On the case assign the role **Benefit specialist is** to **Contact C**

Searching:
1. Go to advanced search
2. Click on **View contact as related contact**
3. Select **Benefit Specialist** as relationship type
4. Go to tab cases and select **Housing Support** as case type

Expected results
-----------------------

I expected to see only Contact B as that one has a relationship on the case **Housing Support**.

Actual results
-------------------

I see both Contact B and Contact C.

Comments
----------------------------------------

See also the discussion of a similar related topic: https://lab.civicrm.org/dev/report/-/issues/53
