### PR TITLE
SearchKit - Fix broken export action

### DIFF
--- a/ext/search/Civi/Api4/Action/SearchDisplay/GetSearchTasks.php
+++ b/ext/search/Civi/Api4/Action/SearchDisplay/GetSearchTasks.php
@@ -41,7 +41,7 @@ class GetSearchTasks extends \Civi\Api4\Generic\AbstractAction {
         'icon' => 'fa-file-excel-o',
         'crmPopup' => [
           'path' => "'civicrm/export/standalone'",
-          'query' => "{entity: {$entity['name']}, id: ids.join(',')}",
+          'query' => "{entity: '{$entity['name']}', id: ids.join(',')}",
         ],
       ];
     }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a regression in SearchKit where the Export action stopped working.

Before
----------------------------------------
Selecting the "Export" action (e.g. from a Contact search) gives an error.

After
----------------------------------------
Works as expected.