### PR TITLE
SearchKit - Make contribution tasks available as actions

### DIFF
--- a/CRM/Contribute/Task.php
+++ b/CRM/Contribute/Task.php
@@ -91,8 +91,9 @@ class CRM_Contribute_Task extends CRM_Core_Task {
           'result' => FALSE,
           'title_single_mode' => ts('Send Receipt'),
           'name' => ts('Send Receipt'),
-          'is_support_standalone' => TRUE,
+          'url' => 'civicrm/contribute/task?reset=1&task=receipt',
           'key' => 'receipt',
+          'icon' => 'fa-envelope-o',
           'filters' => ['contribution_status_id' => [CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Completed')]],
           'is_single_mode' => TRUE,
         ],
@@ -151,8 +152,8 @@ class CRM_Contribute_Task extends CRM_Core_Task {
           }
         }
       }
-      $tasks[$key]['url'] = 'civicrm/contribute/task';
-      $tasks[$key]['qs'] = ['reset' => 1, 'id' => $row['contribution_id'], 'task' => $task['key']];
+      $tasks[$key]['url'] = $task['url'];
+      $tasks[$key]['qs'] = ['id' => $row['contribution_id']];
       $tasks[$key]['title'] = $task['title_single_mode'] ?? $task['title'];
     }
     return $tasks;

--- a/ext/search/Civi/Api4/Action/SearchDisplay/GetSearchTasks.php
+++ b/ext/search/Civi/Api4/Action/SearchDisplay/GetSearchTasks.php
@@ -41,7 +41,7 @@ class GetSearchTasks extends \Civi\Api4\Generic\AbstractAction {
         'icon' => 'fa-file-excel-o',
         'crmPopup' => [
           'path' => "'civicrm/export/standalone'",
-          'query' => "{entity: '{$entity['name']}', id: ids.join(',')}",
+          'query' => "{reset: 1, entity: '{$entity['name']}', id: ids.join(',')}",
         ],
       ];
     }
@@ -78,7 +78,23 @@ class GetSearchTasks extends \Civi\Api4\Generic\AbstractAction {
             'icon' => $task['icon'] ?? 'fa-gear',
             'crmPopup' => [
               'path' => "'{$task['url']}'",
-              'query' => "{cids: ids.join(',')}",
+              'query' => "{reset: 1, cids: ids.join(',')}",
+            ],
+          ];
+        }
+      }
+    }
+
+    if ($entity['name'] === 'Contribution') {
+      foreach (\CRM_Contribute_Task::tasks() as $id => $task) {
+        if (!empty($task['url'])) {
+          $tasks[] = [
+            'name' => 'contribution.' . $id,
+            'title' => $task['title'],
+            'icon' => $task['icon'] ?? 'fa-gear',
+            'crmPopup' => [
+              'path' => "'{$task['url']}'",
+              'query' => "{id: ids.join(',')}",
             ],
           ];
         }


### PR DESCRIPTION
Overview
----------------------------------------
Exposes contribution tasks to searchKit.

![image](https://user-images.githubusercontent.com/2874912/114083181-a9f98200-987c-11eb-9d13-9879bb53b255.png)

Technical Details
----------------------------------------
So far there is only one action (Send Receipt) available, and it only works for contributions with status=Completed.

SearchKit doesn't yet respect that limitation and shows the action for every record. I don't have an easy solution for that, as the `"status_id"` column isn't even guaranteed to be included in the search, making it difficult to auto-apply filters. It's also annoying that the filter is keyed by the obsolete "unique name" `'contribution_status_id'`.

Comments
------------------
Adding standalone actions from a 2nd entity into the mix highlights the fact that this is all just duct-taped together, as there are big inconsistencies between how contact actions and contribution actions are retrieved & constructed (argument `id=` vs `cids=`, generic url vs per-action urls, permission checks inconsistently in the `tasks()` function vs in a `permissionedTaskTitles()` function...).