### PR TITLE
Use standard function to add reCAPTCHA to PCPAccount form

### DIFF
--- a/CRM/PCP/Form/PCPAccount.php
+++ b/CRM/PCP/Form/PCPAccount.php
@@ -152,9 +152,7 @@ class CRM_PCP_Form_PCPAccount extends CRM_Core_Form {
       }
 
       if ($addCaptcha) {
-        $captcha = &CRM_Utils_ReCAPTCHA::singleton();
-        $captcha->add($this);
-        $this->assign('isCaptcha', TRUE);
+        CRM_Utils_ReCAPTCHA::enableCaptchaOnForm($this);
       }
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
This fixes the *only* place in CiviCRM core that does not use `enableCaptchaOnForm()` to add the reCAPTCHA.

Before
----------------------------------------
Add reCAPTCHA to PCP account form using multiple lines of code.

After
----------------------------------------
Add reCAPTCHA to PCP account form using standard helper function.

Technical Details
----------------------------------------
Loading reCAPTCHA on the form was refactored to use the helper function some time ago but this one was missed.

Comments
----------------------------------------
@seamuslee001 I have put this against the 5.37RC because that gives us a consistent state with the core ext functionality and all core instances of reCAPTCHA loaded via `enableCaptchaOnForm()`. For master/5.38 I'm hoping to move all those across to the extension.