### PR TITLE
Use propertyBag in doPayment

### DIFF
--- a/CRM/Core/Payment.php
+++ b/CRM/Core/Payment.php
@@ -1343,13 +1343,14 @@ abstract class CRM_Core_Payment {
    * @throws \Civi\Payment\Exception\PaymentProcessorException
    */
   public function doPayment(&$params, $component = 'contribute') {
+    $propertyBag = \Civi\Payment\PropertyBag::cast($params);
     $this->_component = $component;
     $statuses = CRM_Contribute_BAO_Contribution::buildOptions('contribution_status_id', 'validate');
 
     // If we have a $0 amount, skip call to processor and set payment_status to Completed.
     // Conceivably a processor might override this - perhaps for setting up a token - but we don't
-    // have an example of that at the mome.
-    if ($params['amount'] == 0) {
+    // have an example of that at the moment.
+    if ($propertyBag->getAmount() == 0) {
       $result['payment_status_id'] = array_search('Completed', $statuses);
       return $result;
     }


### PR DESCRIPTION
Overview
----------------------------------------
This fixes the test failure in https://github.com/civicrm/civicrm-core/pull/17886. If a propertyBag is passed into doPayment you get a PHP notice:
`Deprecated function PropertyBag array access for core property 'amount', use getAmount().`

Currently the eventcart PR is the only place that passes a propertyBag into doPayment so it triggers this notice.

Before
----------------------------------------
PHP notice because a property is not accessed via it's standard method.

After
----------------------------------------
Property is not accessed via it's standard method.

Technical Details
----------------------------------------


Comments
----------------------------------------
