### PR TITLE
dev/core#2505: fix formatting of numbers in civireport

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -1191,6 +1191,13 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
           }
           $display = implode(', ', $disp);
         }
+        elseif ($field['data_type'] == 'Float' && isset($value)) {
+          // $value can also be an array(while using IN operator from search builder or api).
+          foreach ((array) $value as $val) {
+            $disp[] = CRM_Utils_Number::formatNumber($val);
+          }
+          $display = implode(', ', $disp);
+        }
         break;
     }
     return $display;

--- a/CRM/Utils/Number.php
+++ b/CRM/Utils/Number.php
@@ -104,4 +104,20 @@ class CRM_Utils_Number {
     }
   }
 
+  /**
+   * Format a number (float)
+   *
+   * @param float $amount
+   *
+   * @return string
+   */
+  public static function formatNumber($amount) {
+    $config = CRM_Core_Config::singleton();
+    $rep = [
+      ',' => $config->monetaryThousandSeparator,
+      '.' => $config->monetaryDecimalPoint,
+    ];
+    return strtr($amount, $rep);
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------

Localize the display of custom fields of type number. 

Before
----------------------------------------

When a report displayed a custom field of type number it wont localize the decimal separator. 

After
----------------------------------------

Display of custom field of type number correctly shows the decimal separator. This is on the report screen as on other screens in CiviCRM.

Technical Details
----------------------------------------

* A new function in `CRM_Utils_Number::formatNumber` to format a float to a localized string.
* In the function `CRM_Core_BAO_CustomField::formatDisplayValue`  the formatting of number fields is added. 

Comments
----------------------------------------

See https://lab.civicrm.org/dev/core/-/issues/2505
