### PR TITLE
Soft credit fails when membership is created using backend form

### DIFF
--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -1295,7 +1295,7 @@ DESC limit 1");
         $membershipParams = array_merge($params, $membershipTypeValues[$lineItemValues['membership_type_id']]);
 
         if (!empty($softParams)) {
-          $membershipParams['soft_credit'] = $softParams;
+          $params['soft_credit'] = $softParams;
         }
         unset($membershipParams['contribution_status_id']);
         $membershipParams['skipLineItem'] = TRUE;

--- a/tests/phpunit/CRM/Member/Form/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/Form/MembershipTest.php
@@ -904,6 +904,43 @@ class CRM_Member_Form_MembershipTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test membership with soft credits.
+   */
+  public function testMembershipSoftCredit() {
+    $this->_softIndividualId = $this->individualCreate();
+
+    $form = $this->getForm();
+    $form->preProcess();
+    $this->createLoggedInUser();
+    $params = $this->getBaseSubmitParams();
+    unset($params['auto_renew'], $params['is_recur']);
+    $params['record_contribution'] = TRUE;
+    $params['soft_credit_type_id'] = $this->callAPISuccessGetValue('OptionValue', [
+      'return' => "value",
+      'name' => "Gift",
+      'option_group_id' => "soft_credit_type",
+    ]);
+    $params['soft_credit_contact_id'] = $this->_softIndividualId;
+    $form->_contactID = $this->_individualId;
+    // $form->_mode = 'test';
+    $form->testSubmit($params);
+    // Membership is created on main contact.
+    $this->callAPISuccessGetSingle('Membership', ['contact_id' => $this->_individualId]);
+
+    // Verify is main contribution is created on soft contact.
+    $contribution = $this->callAPISuccessGetSingle('Contribution', [
+      'contact_id' => $this->_softIndividualId,
+    ]);
+    $this->assertEquals($contribution['soft_credit'][1]['contact_id'], $this->_individualId);
+
+    // Verify if soft credit is created.
+    $this->callAPISuccessGetSingle('ContributionSoft', [
+      'contact_id' => $this->_individualId,
+      'contribution_id' => $contribution['id'],
+    ]);
+  }
+
+  /**
    * Test the submit function of the membership form.
    *
    * @throws \CRM_Core_Exception


### PR DESCRIPTION
Overview
----------------------------------------
Fix soft credit on creating membership using backend form

Before
----------------------------------------
Soft credit fails to create when membership is recorded from a backend form. To replicate -

- Navigate to contact sumary page https://dmaster.demo.civicrm.org/civicrm/contact/view?reset=1&cid=203 => Membership tab.
- Click on Add Membership button.
- Record payment from a different contact and save.

![image](https://user-images.githubusercontent.com/5929648/114195184-de00a000-996d-11eb-807d-d143e7d7a46f.png)

- The contribution is recorded on Margaret, but no soft credit record is recorded on the main contact.

After
----------------------------------------
Fixed. Soft credit is created on main contact.

![image](https://user-images.githubusercontent.com/5929648/114195600-3c2d8300-996e-11eb-92d9-b1ed27de6227.png)


Technical Details
----------------------------------------

Seems to be related to this change - https://github.com/civicrm/civicrm-core/pull/18855/files#diff-e7ba7553d0e3638ecd45d305f95eabe0fec73ff33609a9cfb4cf0f148fb118e0R1482

Ideally, [recordMembershipContribution()](https://github.com/civicrm/civicrm-core/blob/master/CRM/Member/BAO/Membership.php#L2431) in CRM/Member/BAO/Membership.php is responsible for handling the soft credit part which is called from create but only when it has `contribution_status_id` in it. See https://github.com/civicrm/civicrm-core/blob/master/CRM/Member/BAO/Membership.php#L347. This key was removed in the above commit. 

Since we already call recordMembershipContribution further in  the code to process the contribution, it make sense to fill `$params` instead of `$membershipParams` with the soft_credit value? @eileenmcnaughton 


Comments
----------------------------------------
Raised it in rc since it was regressed few months ago.

Includes unit test.