### PR TITLE
Authx - Retain authentication outcome/metadata

### DIFF
--- a/ext/authx/CRM/Authx/Page/AJAX.php
+++ b/ext/authx/CRM/Authx/Page/AJAX.php
@@ -12,9 +12,13 @@ class CRM_Authx_Page_AJAX {
   public static function getId() {
     $authxUf = _authx_uf();
 
+    /** @var array $authx */
+    $authx = CRM_Core_Session::singleton()->get('authx');
     $response = [
       'contact_id' => CRM_Core_Session::getLoggedInContactID(),
       'user_id' => $authxUf->getCurrentUserId(),
+      'flow' => $authx['flow'] ?? NULL,
+      'cred' => $authx['credType'] ?? NULL,
     ];
 
     CRM_Utils_JSON::output($response);

--- a/ext/authx/Civi/Authx/Authenticator.php
+++ b/ext/authx/Civi/Authx/Authenticator.php
@@ -213,6 +213,7 @@ class Authenticator {
     // Post-login Civi stuff...
 
     $session = \CRM_Core_Session::singleton();
+    $session->set('authx', $tgt->createRedacted());
     $session->set('ufID', $tgt->userId);
     $session->set('userID', $tgt->contactId);
 
@@ -346,6 +347,28 @@ class AuthenticatorTarget {
    */
   public function hasPrincipal(): bool {
     return !empty($this->userId) || !empty($this->contactId);
+  }
+
+  /**
+   * Create a variant of the authentication record which omits any secret values. It may be
+   * useful to examining metadata and outcomes.
+   *
+   * The redacted version may be retained in the (real or fake) session and consulted by more
+   * fine-grained access-controls.
+   *
+   * @return array
+   */
+  public function createRedacted(): array {
+    return [
+      // omit: cred
+      // omit: siteKey
+      'flow' => $this->flow,
+      'credType' => $this->credType,
+      'jwt' => $this->jwt,
+      'useSession' => $this->useSession,
+      'userId' => $this->userId,
+      'contactId' => $this->contactId,
+    ];
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------

This improves the internal APIs for Authx.  Authx supports additional ways to authenticate requests (e.g. passwords, API keys, JWTs). With this patchset, we have an internal way to see *how* the user was authenticated, e.g.

```php
CRM_Core_Session::singleton()->get('authx')['credType']
CRM_Core_Session::singleton()->get('authx')['jwt']
```

Example Use-cases
----------------------------------------

* Suppose you wish to generate a JWT with a limited `scope` that allows access a handful of APIs. The JWT is parsed during authentication, but you should preserve the `scope` so that it can be consulted during authorization. (*"Did the `scope` authorize access to this specific entity?"*) 
* The end-point `civicrm/ajax/rest` may be used in different ways (e.g.  for AJAX or for REST). When evaluating an AJAX request (with implicit/automatic identification based on session-cookie), you should enforce the full CSRF guards. When evaluating a REST request (submitted by a non-browser agent with an API key), the form of the credential may indicate that it's not a CSRF attack. (*If an attacker can construct a cross-site request that includes a valid API key, then they've already compromised the account and don't need CSRF shananigans.*) Enforcing CSRF may require discriminating based on authentication info.

(This patch does not address those example use-cases -- it merely retains data so that it's possible.)

Before
----------------------------------------

While processing an authentication request, `authx` creates a private/short-lived object containing details of the authentication process (credential-type, user ID, etc).

The object is lost/destroyed after we make a decision about authenticating.

After
----------------------------------------

As before, `authx` creates a private/short-lived object containing details of the authentication process (credential-type, user ID, etc).

However, with successful authentication, key metadata is now copied to the session. This includes `credType`, `jwt` claims, and more. However, it omits any literal credentials (e.g. passwords and API keys).

Technical Details
----------------------------------------

I originally tried to retain the data as an object (e.g. `\Civi\Authx\AuthenticatorTarget` or `\Civi\Authx\Authentication`). This proved problematic during deserialization. (*We don't decide when to deserialize - and our classloader may not be available early enough*). So instead the `authx` variable is a basic `array`.