### PR TITLE
SearchKit - Flush Angular cache when saving

### DIFF
--- a/CRM/Contact/BAO/SavedSearch.php
+++ b/CRM/Contact/BAO/SavedSearch.php
@@ -362,6 +362,11 @@ LEFT JOIN civicrm_email ON (contact_a.id = civicrm_email.contact_id AND civicrm_
       }
       $params['modified_id'] = $loggedInContactID;
     }
+
+    // Flush angular caches to refresh search displays
+    if (isset($params['api_params'])) {
+      Civi::container()->get('angular')->clear();
+    }
     return self::writeRecord($params);
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Fixes caching issue for search displays embedded in Afforms (as pages, dashlets, tabs, blocks, etc).

Before
----------------------------------------
Cache must be manually refreshed after updating search.

After
----------------------------------------
Saving the search will refresh the Angular cache and update embedded search displays.


Comments
----------------------------------------
This is a follow-up to #19998