### PR TITLE
dev/report#58 SearchKit - Rename 'Filters' to 'Having' for clarity

### DIFF
--- a/ext/search/ang/crmSearchAdmin/compose/criteria.html
+++ b/ext/search/ang/crmSearchAdmin/compose/criteria.html
@@ -10,7 +10,7 @@
           </button>
         </div>
         <fieldset class="api4-clause-fieldset">
-          <crm-search-clause clauses="join" format="json" skip="2 + getJoin(join[0]).conditions.length" op="AND" label="{{ ts('If') }}" fields="fieldsForWhere" ></crm-search-clause>
+          <crm-search-clause clauses="join" format="json" skip="2 + getJoin(join[0]).conditions.length" op="AND" label="{{:: ts('If') }}" fields="fieldsForWhere" ></crm-search-clause>
         </fieldset>
       </fieldset>
       <fieldset>
@@ -41,10 +41,10 @@
   </div>
   <div class="crm-search-criteria-column">
     <fieldset class="api4-clause-fieldset">
-      <crm-search-clause clauses="$ctrl.savedSearch.api_params.where" format="string" op="AND" label="{{ ts('Where') }}" fields="fieldsForWhere" ></crm-search-clause>
+      <crm-search-clause clauses="$ctrl.savedSearch.api_params.where" format="string" op="AND" label="{{:: ts('Where') }}" fields="fieldsForWhere" ></crm-search-clause>
     </fieldset>
     <fieldset ng-if="$ctrl.paramExists('having') && $ctrl.savedSearch.api_params.groupBy.length" class="api4-clause-fieldset">
-      <crm-search-clause clauses="$ctrl.savedSearch.api_params.having" format="string" op="AND" label="{{ ts('Filter') }}" fields="fieldsForHaving" ></crm-search-clause>
+      <crm-search-clause clauses="$ctrl.savedSearch.api_params.having" format="string" op="AND" label="{{:: ts('Having') }}" fields="fieldsForHaving" ></crm-search-clause>
     </fieldset>
   </div>
 </div>


### PR DESCRIPTION
Overview
----------------------------------------
Per https://lab.civicrm.org/dev/report/-/issues/58 this renames 'Filters' to 'Having' which is clearer for users familiar with SQL terms.