### PR TITLE
[wip] Use hook for checkAccess

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -2960,7 +2960,7 @@ SELECT contact_id
         $clauses[$fieldName] = CRM_Utils_SQL::mergeSubquery('Contact');
       }
       // Clause for an entity_table/entity_id combo
-      if ($fieldName == 'entity_id' && isset($fields['entity_table'])) {
+      if ($fieldName === 'entity_id' && isset($fields['entity_table'])) {
         $relatedClauses = [];
         $relatedEntities = $this->buildOptions('entity_table', 'get');
         foreach ((array) $relatedEntities as $table => $ent) {
@@ -3008,8 +3008,27 @@ SELECT contact_id
   }
 
   /**
+   * Check whether the given action can be performed on these values.
+   *
+   * The return is the input values array with inaccessible items filtered out.
+   *
+   * @param string $action
+   * @param array $values
+   * @param null $contactID
+   *
+   * @return array
+   */
+  public function checkAccess(string $action, array $values, $contactID = NULL): array {
+    if (is_null($contactID)) {
+      $contactID = CRM_Core_Session::getLoggedInContactID();
+    }
+    CRM_Utils_Hook::checkAccess(CRM_Core_DAO_AllCoreTables::getBriefName(get_class($this)), $action, $contactID, $values);
+    return $values;
+  }
+
+  /**
    * ensure database name is 'safe', i.e. only contains word characters (includes underscores)
-   * and dashes, and contains at least one [a-z] case insenstive.
+   * and dashes, and contains at least one [a-z] case insensitive.
    *
    * @param $database
    *

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -2087,6 +2087,25 @@ abstract class CRM_Utils_Hook {
   }
 
   /**
+   * Check whether the given contact has access to perform the given action.
+   *
+   * If the contact cannot perform the action the
+   *
+   * @param string $entity
+   * @param string $action
+   * @param int|null $contactID
+   * @param array $values
+   *
+   * @return mixed
+   */
+  public static function checkAccess(string $entity, string $action, ?int $contactID, array &$values) {
+    return self::singleton()->invoke(['entity', 'action', 'contactID', 'values'], $entity, $action, $contactID,
+      $values, self::$_nullObject, self::$_nullObject,
+      'civicrm_checkAccess'
+    );
+  }
+
+  /**
    * Rotate the cryptographic key used in the database.
    *
    * The purpose of this hook is to visit any encrypted values in the database

--- a/api/v3/Contribution.php
+++ b/api/v3/Contribution.php
@@ -204,23 +204,17 @@ function _civicrm_api3_contribution_create_legacy_support_45(&$params) {
 function civicrm_api3_contribution_delete($params) {
 
   $contributionID = !empty($params['contribution_id']) ? $params['contribution_id'] : $params['id'];
-  // First check contribution financial type
-  $financialType = CRM_Core_DAO::getFieldValue('CRM_Contribute_DAO_Contribution', $contributionID, 'financial_type_id');
-  // Now check permissioned lineitems & permissioned contribution
-  if (!empty($params['check_permissions']) && CRM_Financial_BAO_FinancialType::isACLFinancialTypeStatus() &&
-    (
-      !CRM_Core_Permission::check('delete contributions of type ' . CRM_Contribute_PseudoConstant::financialType($financialType))
-      || !CRM_Financial_BAO_FinancialType::checkPermissionedLineItems($contributionID, 'delete', FALSE)
-    )
-  ) {
-    throw new API_Exception('You do not have permission to delete this contribution');
+  if (!empty($params['check_permissions'])) {
+    $contribution = new CRM_Contribute_BAO_Contribution();
+    $values = $contribution->checkAccess('delete', [$contributionID => ['id' => $contributionID]]);
+    if (empty($values)) {
+      throw new API_Exception('You do not have permission to delete this contribution');
+    }
   }
   if (CRM_Contribute_BAO_Contribution::deleteContribution($contributionID)) {
     return civicrm_api3_create_success([$contributionID => 1]);
   }
-  else {
-    throw new API_Exception('Could not delete contribution');
-  }
+  throw new API_Exception('Could not delete contribution');
 }
 
 /**
@@ -670,7 +664,7 @@ function _ipn_process_transaction($params, $contribution, $input, $ids) {
     static $domainFromName;
     static $domainFromEmail;
     if (empty($domainFromEmail) && (empty($params['receipt_from_name']) || empty($params['receipt_from_email']))) {
-      list($domainFromName, $domainFromEmail) = CRM_Core_BAO_Domain::getNameAndEmail(TRUE);
+      [$domainFromName, $domainFromEmail] = CRM_Core_BAO_Domain::getNameAndEmail(TRUE);
     }
     $input['receipt_from_name'] = CRM_Utils_Array::value('receipt_from_name', $params, $domainFromName);
     $input['receipt_from_email'] = CRM_Utils_Array::value('receipt_from_email', $params, $domainFromEmail);

--- a/tests/phpunit/api/v3/FinancialTypeACLTest.php
+++ b/tests/phpunit/api/v3/FinancialTypeACLTest.php
@@ -291,8 +291,10 @@ class api_v3_FinancialTypeACLTest extends CiviUnitTestCase {
 
   /**
    * Test that acl contributions can be deleted.
+   *
+   * @throws \CRM_Core_Exception
    */
-  public function testDeleteACLContribution() {
+  public function testDeleteACLContribution(): void {
     $this->enableFinancialACLs();
 
     $this->setPermissions([
@@ -313,7 +315,7 @@ class api_v3_FinancialTypeACLTest extends CiviUnitTestCase {
     $this->addFinancialAclPermissions([['delete', 'Donation']]);
     $contribution = $this->callAPISuccess('Contribution', 'delete', $params);
 
-    $this->assertEquals($contribution['count'], 1);
+    $this->assertEquals(1, $contribution['count']);
   }
 
   public function testMembershipTypeACLFinancialTypeACL() {


### PR DESCRIPTION
Overview
----------------------------------------
@colemanw @seamuslee001 @totten - I decided to take a pass at the checkAccess function we discussed. This works in this limited context - with the trickiest part here being convergence on which pseudoconstant / string to use to denote the action. However, for v4 api we have the ability for update & delete with WHERE clauses - so mysql might make more sense - eg. 'WHERE id NOT IN ()';

Note the test class I touched is a pretty good starting place for finding 'already-tested-code-that-is-relevant'


Before
----------------------------------------
The way to prevent an unpermissioned update is the pre-hook - but this can't be tested before taking action

After
----------------------------------------
We have a starting point for how a hook might look to do a pre-check

Technical Details
----------------------------------------
Note this is an example of an existing pre-hook implementation

```
function financialacls_civicrm_pre($op, $objectName, $id, &$params) {
  if (!financialacls_is_acl_limiting_enabled()) {
    return;
  }
  if ($objectName === 'LineItem' && !empty($params['check_permissions'])) {
    $operationMap = ['delete' => CRM_Core_Action::DELETE, 'edit' => CRM_Core_Action::UPDATE, 'create' => CRM_Core_Action::ADD];
    CRM_Financial_BAO_FinancialType::getAvailableFinancialTypes($types, $operationMap[$op]);
    if (empty($params['financial_type_id'])) {
      $params['financial_type_id'] = CRM_Core_DAO::getFieldValue('CRM_Price_DAO_LineItem', $params['id'], 'financial_type_id');
    }
    if (!in_array($params['financial_type_id'], array_keys($types))) {
      throw new API_Exception('You do not have permission to ' . $op . ' this line item');
    }
  }
```

Comments
----------------------------------------
