### PR TITLE
Alter dedupe code to call api rather than bao->save() 

### DIFF
--- a/tests/phpunit/api/v3/ContactTest.php
+++ b/tests/phpunit/api/v3/ContactTest.php
@@ -4040,7 +4040,7 @@ class api_v3_ContactTest extends CiviUnitTestCase {
    *
    * @throws \CRM_Core_Exception
    */
-  public function testMergeWithBlankLocationData($isReverse) {
+  public function testMergeWithBlankLocationData($isReverse): void {
     $this->createLoggedInUser();
     $this->ids['contact'][0] = $this->callAPISuccess('contact', 'create', $this->_params)['id'];
     $this->ids['contact'][1] = $this->callAPISuccess('contact', 'create', $this->_params)['id'];


### PR DESCRIPTION
Overview
----------------------------------------
Alter dedupe code to call api rather than bao->save()

This achieves 2 things
1) hooks are no longer  bypassed
2) it leverages core handling for is_primary rather than this somewhat unreliable attempt



Before
----------------------------------------
```
$bao->save()
```


After
----------------------------------------
api call.

Technical Details
----------------------------------------
I feel pretty sure we've had requests to not bypass hooks in the past but my current reason is that I can't figure out a way to handle a particular situation in an extension - this is where the contacts have the same email but one is on hold and I want to update the email to be on hold but not wind up with no primary emails (which is what is happening) and not make a change before the dedupe actually runs.

If we call the BAO::create (via the api) then we get the benefit of core is_primary handling

Comments
----------------------------------------
@JKingsnorth @pfigel are either of you up for review on some more deduper work 