### PR TITLE
Add amount as standard property to PaymentPropertyBag

### DIFF
--- a/Civi/Payment/PropertyBag.php
+++ b/Civi/Payment/PropertyBag.php
@@ -25,6 +25,7 @@ class PropertyBag implements \ArrayAccess {
   protected $props = ['default' => []];
 
   protected static $propMap = [
+    'amount'                      => TRUE,
     'billingStreetAddress'        => TRUE,
     'billingSupplementalAddress1' => TRUE,
     'billingSupplementalAddress2' => TRUE,


### PR DESCRIPTION
Overview
----------------------------------------
`amount` is already a standard property and has no aliases so technically it doesn't matter if it's in the list of properties or not. But a developer reading the code expects it to be there.

If in the future we needed to add an alias to support some old code (eg. `total_amount`/`gross_amount`) you'd need this and then you'd add the aliases to point to it.
I think those properties have gone from core now but if they were still there this would allow transitioning them to `amount`

Before
----------------------------------------
`amount` missing from list of properties.

After
----------------------------------------
`amount` in list of properties.

Technical Details
----------------------------------------
Explained above.

Comments
----------------------------------------
