### PR TITLE
Suppress legacy warnings by default in propertyBag to allow transition to propertyBag without hitting legacy warnings on unconverted payment processors

### DIFF
--- a/Civi/Payment/PropertyBag.php
+++ b/Civi/Payment/PropertyBag.php
@@ -77,8 +77,29 @@ class PropertyBag implements \ArrayAccess {
    * @var bool
    * Temporary, internal variable to help ease transition to PropertyBag.
    * Used by cast() to suppress legacy warnings.
+   * For paymentprocessors that have not converted to propertyBag we need to support "legacy" properties - eg. "is_recur"
+   *   without warnings. Setting this allows us to pass a propertyBag into doPayment() and expect it to "work" with
+   *   existing payment processors.
    */
-  protected $suppressLegacyWarnings = FALSE;
+  protected $suppressLegacyWarnings = TRUE;
+
+  /**
+   * Get the value of the suppressLegacyWarnings parameter
+   * @return bool
+   */
+  public function getSuppressLegacyWarnings() {
+    return $this->suppressLegacyWarnings;
+  }
+
+  /**
+   * Set the suppressLegacyWarnings parameter - useful for unit tests.
+   * Eg. you could set to FALSE for unit tests on a paymentprocessor to capture use of legacy keys in that processor
+   * code.
+   * @param bool $suppressLegacyWarnings
+   */
+  public function setSuppressLegacyWarnings(bool $suppressLegacyWarnings) {
+    $this->suppressLegacyWarnings = $suppressLegacyWarnings;
+  }
 
   /**
    * Get the property bag.

--- a/tests/phpunit/Civi/Payment/PropertyBagTest.php
+++ b/tests/phpunit/Civi/Payment/PropertyBagTest.php
@@ -109,6 +109,7 @@ class PropertyBagTest extends \PHPUnit\Framework\TestCase implements HeadlessInt
    */
   public function testSetContactIDLegacyWay() {
     $propertyBag = new PropertyBag();
+    $propertyBag->setSuppressLegacyWarnings(FALSE);
 
     // To prevent E_USER_DEPRECATED errors during phpunit tests we take a copy
     // of the existing error_reporting.
@@ -191,6 +192,7 @@ class PropertyBagTest extends \PHPUnit\Framework\TestCase implements HeadlessInt
 
     // Test we can do this with array, although we should get a warning.
     $propertyBag = new PropertyBag();
+    $propertyBag->setSuppressLegacyWarnings(FALSE);
 
     // Set by array access should cause deprecated error.
     try {


### PR DESCRIPTION
Overview
----------------------------------------
Per mattermost thread https://chat.civicrm.org/civicrm/pl/3tzw46wtfidwbjhbdxqg6y6qfa

This allows us to actually implement propertyBag and pass it to `doPayment()` - example in https://github.com/civicrm/civicrm-core/pull/17886/commits/0bed925baefa93f7b87d57d9c7c374a1b81a446a#diff-32a00907a954b52a78852aca14a4d2cca61f9dba805905c9053a1f2ec8ef70c0R340 without causing tests to fail when payment processors are accessing legacy properties.

By passing propertyBag we have full control over what parameters are being passed to the paymentprocessor and do not need to worry about setting multiple keys in case the processor looks for one rather than the other - eg. we use `$this->setIsRecur()` and the processor ideally accesses via `$this->getIsRecur()` but can also access using ArrayAccess via `$params['is_recur']` or `$params['isRecur']`.

Before
----------------------------------------
Payment processors that do not cast to propertyBag trigger deprecated warnings on the legacy parameters if accessing them - eg. `$params['is_recur']` instead of `$params['isRecur']`. Both keys contain the same value.

After
----------------------------------------
Payment processors that do not cast to propertyBag DO NOT trigger deprecated warnings on the legacy parameters if accessing them - eg. `$params['is_recur']` instead of `$params['isRecur']`. Both keys contain the same value.

Technical Details
----------------------------------------
Explained above.

Comments
----------------------------------------
@eileenmcnaughton 
