### PR TITLE
dev/core#2493 Stop attempting to format money in the processor class

### DIFF
--- a/CRM/Core/Payment.php
+++ b/CRM/Core/Payment.php
@@ -1164,6 +1164,10 @@ abstract class CRM_Core_Payment {
    * @throws \CRM_Core_Exception
    */
   protected function getAmount($params = []) {
+    if (!CRM_Utils_Rule::numeric($params['amount'])) {
+      CRM_Core_Error::deprecatedWarning('Passing Amount value that is not numeric is deprecated please report this in gitlab');
+      return filter_var($params['amount'], FILTER_SANITIZE_NUMBER_FLOAT, FILTER_FLAG_ALLOW_FRACTION);
+    }
     return $params['amount'];
   }
 

--- a/CRM/Core/Payment.php
+++ b/CRM/Core/Payment.php
@@ -1164,7 +1164,7 @@ abstract class CRM_Core_Payment {
    * @throws \CRM_Core_Exception
    */
   protected function getAmount($params = []) {
-    return CRM_Utils_Money::format($params['amount'], NULL, NULL, TRUE);
+    return $params['amount'];
   }
 
   /**


### PR DESCRIPTION


Overview
----------------------------------------
Addresses a regression whereby values are being mis-formatted before being sent to the payment processor

Before
----------------------------------------
Per https://lab.civicrm.org/dev/core/-/issues/2493#note_57664 paypal flow (& maybe others) is not handling $1000 + values 

After
----------------------------------------
Gitlab comments advise this works

Technical Details
----------------------------------------
We've said this is wrong before but it has survived until now because it seemed scarier to change it. However,
now the reverse seems true.

The value in amount should always be machine friendly and there are no known processors
that expect locale specific formatting.

On the other hand the format() function is intended to prepare money for DISPLAY which
is not what is going on here.



Comments
----------------------------------------
@mattwire @seamuslee001 