### PR TITLE
Update WP permission page for new string array keys

### DIFF
--- a/CRM/ACL/Form/WordPress/Permissions.php
+++ b/CRM/ACL/Form/WordPress/Permissions.php
@@ -69,7 +69,7 @@ class CRM_ACL_Form_WordPress_Permissions extends CRM_Core_Form {
     $descArray = [];
     foreach ($permissionsDesc as $perm => $attr) {
       if (count($attr) > 1) {
-        $descArray[$perm] = $attr[1];
+        $descArray[$perm] = $attr['description'] ?? $attr[1];
       }
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
This fixes an undefined index notice for permissions that use the new-style 'label' and 'description' array keys instead of numeric keys.

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/2874912/114555545-cc511e00-9c35-11eb-92ef-6e88366d03d7.png)

![image](https://user-images.githubusercontent.com/2874912/114555683-ef7bcd80-9c35-11eb-971b-aa426b057094.png)

After
----------------------------------------
No notice and descriptions are visible:
![image](https://user-images.githubusercontent.com/2874912/114555865-1c2fe500-9c36-11eb-9447-f484f5702fe5.png)


Technical Details
----------------------------------------
It seems there is a new syntax supported by the permission system and this WordPress page didn't get the memo.