### PR TITLE
dev/core#2531 Fix field Tag(s) on update multiple contacts action

### DIFF
--- a/CRM/Contact/Form/Edit/TagsAndGroups.php
+++ b/CRM/Contact/Form/Edit/TagsAndGroups.php
@@ -135,7 +135,7 @@ class CRM_Contact_Form_Edit_TagsAndGroups {
       $tags = CRM_Core_BAO_Tag::getColorTags('civicrm_contact');
 
       if (!empty($tags)) {
-        $form->add('select2', 'tag', ts('Tag(s)'), $tags, FALSE, ['class' => 'huge', 'placeholder' => ts('- select -'), 'multiple' => TRUE]);
+        $form->add('select2', $fieldName, $tagName, $tags, FALSE, ['class' => 'huge', 'placeholder' => ts('- select -'), 'multiple' => TRUE]);
       }
 
       // build tag widget


### PR DESCRIPTION
described here https://lab.civicrm.org/dev/core/-/issues/2531, abstract:

Tag(s) field from profile is not editable on Update multiple contacts action

Example use-case
----------------------------------------
1. Create any profile with Tag(s) field
1. Search for any contacts
1. Select several contacts and choose action "Update multiple contacts"
1. Choose newly created profile with Tag(s) field


Current behaviour
----------------------------------------
Opened list contains column Tag(s) but without any field, it is empty

Proposed behaviour
----------------------------------------
Tag(s) field has to be editable.