### PR TITLE
Fix local images rendering when generating PDFs with Dompdf

### DIFF
--- a/CRM/Utils/PDF/Utils.php
+++ b/CRM/Utils/PDF/Utils.php
@@ -182,6 +182,8 @@ class CRM_Utils_PDF_Utils {
     // CRM-12165 - Remote file support required for image handling.
     $options = new Options();
     $options->set('isRemoteEnabled', TRUE);
+    $cmsRootPath = \CRM_Core_Config::singleton()->userSystem->cmsRootPath() . '/';
+    $options->set('chroot', $cmsRootPath);
 
     $dompdf = new DOMPDF($options);
     $dompdf->set_paper($paper_size, $orientation);


### PR DESCRIPTION
Overview
----------------------------------------
Fix local images rendering when generating PDFs with Dompdf

Before
----------------------------------------
Images do not appear in generated PDFs that contains local images. 

Here is an example with the Contribution invoice template, hence that is a local image is used : 

![2021-04-13 18_10_23-Message Templates _ compuvag6master](https://user-images.githubusercontent.com/6275540/114576413-04c31d00-9c73-11eb-90fd-e46f49860a85.png)


Then try to print the invoice for any completed contribution (hence that tax processing should be enabled before completing the contribution for this button to appear)
![2021-04-13 18_10_39-](https://user-images.githubusercontent.com/6275540/114576484-199fb080-9c73-11eb-9a97-ea8f33942fee.png)

And here is the resulted PDF : 
![2021-04-13 18_11_19-INV_95_2 pdf - Adobe Acrobat Reader DC (32-bit)](https://user-images.githubusercontent.com/6275540/114576633-3936d900-9c73-11eb-868e-d2b94316e557.png)




After
----------------------------------------
Images appear in generated PDFs that contains local images. 

![2021-04-13 18_11_29-INV_95 pdf - Adobe Acrobat Reader DC (32-bit)](https://user-images.githubusercontent.com/6275540/114576665-42c04100-9c73-11eb-8ad2-633b423f939e.png)


Technical Details
----------------------------------------
Since CiviCRM version 5.32.0 (https://github.com/civicrm/civicrm-core/pull/18688), DomPDF was upgraded to version v0.8.6 (https://github.com/dompdf/dompdf/releases/tag/v0.8.6), this new version now honours the chroot settings in DomPDF and ensure that no local image will be rendered if it is not inside the chroot directory or subdirectories. So now any PDF file we generate in CiviCRM that contains
local images, then these images will not appear in the generated PDF file.

The default chroot directory set by DomPDF is DomPDF directory itself, which is very limiting since no one put their custom images in that location.

In this PR I set the chroot to point to the CMS root directory, this will give users more flexibility, and allow them to use any image under the CMS root directory or subdirectories and get them loaded as part of any PDF they want to generate.

Comments
----------------------------------------
I only tested this with Drupal 7, and while I don't see a reason why it shouldn't work with other CMSs, It would worth if someone who have sites set up with other CMSs to test it.
