### PR TITLE
APIv4 - Fix unserialize settings

### DIFF
--- a/Civi/Api4/Action/Setting/Get.php
+++ b/Civi/Api4/Action/Setting/Get.php
@@ -55,9 +55,9 @@ class Get extends AbstractSettingAction {
         ];
       }
     }
-    foreach ($result as $name => &$setting) {
-      if (isset($setting['value']) && !empty($meta[$name]['serialize'])) {
-        $setting['value'] = \CRM_Core_DAO::unSerializeField($setting['value'], $meta[$name]['serialize']);
+    foreach ($result as &$setting) {
+      if (isset($setting['value']) && !empty($meta[$setting['name']]['serialize'])) {
+        $setting['value'] = \CRM_Core_DAO::unSerializeField($setting['value'], $meta[$setting['name']]['serialize']);
       }
     }
   }

--- a/tests/phpunit/api/v4/Entity/SettingTest.php
+++ b/tests/phpunit/api/v4/Entity/SettingTest.php
@@ -50,4 +50,11 @@ class SettingTest extends UnitTestCase {
     $this->assertContains('setting', $message);
   }
 
+  public function testSerailizedSetting() {
+    $settings = \Civi\Api4\Setting::get(FALSE)
+      ->addSelect('contact_edit_options')
+      ->execute();
+    $this->assertTrue(is_array($settings[0]['value']));
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a bug in the APIv4 "Setting" entity where serialized values were not getting returned properly. Adds a unit test.