### PR TITLE
Fix entity-ref search by id & update search prompt

### DIFF
--- a/CRM/Core/Resources.php
+++ b/CRM/Core/Resources.php
@@ -425,8 +425,8 @@ class CRM_Core_Resources implements CRM_Core_Resources_CollectionAdderInterface 
     $config = CRM_Core_Config::singleton();
     $vars = [
       'moneyFormat' => json_encode(CRM_Utils_Money::format(1234.56)),
-      'contactSearch' => json_encode($config->includeEmailInName ? ts('Start typing a name or email...') : ts('Start typing a name...')),
-      'otherSearch' => json_encode(ts('Enter search term...')),
+      'contactSearch' => json_encode($config->includeEmailInName ? ts('Search by name/email or id...') : ts('Search by name or id...')),
+      'otherSearch' => json_encode(ts('Enter search term or id...')),
       'entityRef' => self::getEntityRefMetadata(),
       'ajaxPopupsEnabled' => self::singleton()->ajaxPopupsEnabled,
       'allowAlertAutodismissal' => (bool) Civi::settings()->get('allow_alert_autodismissal'),

--- a/api/v3/Generic/Getlist.php
+++ b/api/v3/Generic/Getlist.php
@@ -24,7 +24,7 @@
 function civicrm_api3_generic_getList($apiRequest) {
   $entity = CRM_Core_DAO_AllCoreTables::convertEntityNameToLower($apiRequest['entity']);
   $request = $apiRequest['params'];
-  $meta = civicrm_api3_generic_getfields(['action' => 'get'] + $apiRequest, FALSE);
+  $meta = civicrm_api3_generic_getfields(['action' => 'get'] + $apiRequest, FALSE)['values'];
 
   // If the user types an integer into the search
   $forceIdSearch = empty($request['id']) && !empty($request['input']) && !empty($meta['id']) && CRM_Utils_Rule::positiveInteger($request['input']);
@@ -40,7 +40,7 @@ function civicrm_api3_generic_getList($apiRequest) {
   // Hey api, would you like to provide default values?
   $fnName = "_civicrm_api3_{$entity}_getlist_defaults";
   $defaults = function_exists($fnName) ? $fnName($request) : [];
-  _civicrm_api3_generic_getList_defaults($entity, $request, $defaults, $meta['values']);
+  _civicrm_api3_generic_getList_defaults($entity, $request, $defaults, $meta);
 
   // Hey api, would you like to format the search params?
   $fnName = "_civicrm_api3_{$entity}_getlist_params";
@@ -78,7 +78,7 @@ function civicrm_api3_generic_getList($apiRequest) {
   // Hey api, would you like to format the output?
   $fnName = "_civicrm_api3_{$entity}_getlist_output";
   $fnName = function_exists($fnName) ? $fnName : '_civicrm_api3_generic_getlist_output';
-  $values = $fnName($result, $request, $entity, $meta['values']);
+  $values = $fnName($result, $request, $entity, $meta);
 
   _civicrm_api3_generic_getlist_postprocess($result, $request, $values);
 


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a bug where searching by id wasn't working.
Also updates search prompt to indicate that searching by id is possible.

Ref: https://lab.civicrm.org/dev/core/-/issues/2532

Before
----------------------------------------
Search by id removed from "Refine search" menu and broken.

After
----------------------------------------
Search by id still removed from "Refine search" because that never worked very well. Now you can simply type an id in the main search box. Search prompt updated to indicate that to users.
