### PR TITLE
Fix AuthX Setting Labels

### DIFF
--- a/ext/authx/settings/authx.setting.php
+++ b/ext/authx/settings/authx.setting.php
@@ -54,7 +54,7 @@ $_authx_settings = function() {
         'class' => 'crm-select2',
       ],
       'default' => ['jwt'],
-      'title' => ts('Acceptable credentials (%1)', [ 1 => $flow ]),
+      'title' => ts('Acceptable credentials (%1)', [1 => $flow]),
       'help_text' => NULL,
       'pseudoconstant' => [
         'callback' => ['\Civi\Authx\Meta', 'getCredentialTypes'],
@@ -69,7 +69,7 @@ $_authx_settings = function() {
         'class' => 'crm-select2',
       ],
       'default' => 'optional',
-      'title' => ts('User account requirements (%1)', [ 1 => $flow ]),
+      'title' => ts('User account requirements (%1)', [1 => $flow]),
       'help_text' => NULL,
       'pseudoconstant' => [
         'callback' => ['\Civi\Authx\Meta', 'getUserModes'],

--- a/ext/authx/settings/authx.setting.php
+++ b/ext/authx/settings/authx.setting.php
@@ -69,7 +69,7 @@ $_authx_settings = function() {
         'class' => 'crm-select2',
       ],
       'default' => 'optional',
-      'title' => ts('User account requirements (%1)', [ 1 => $flow]),
+      'title' => ts('User account requirements (%1)', [ 1 => $flow ]),
       'help_text' => NULL,
       'pseudoconstant' => [
         'callback' => ['\Civi\Authx\Meta', 'getUserModes'],

--- a/ext/authx/settings/authx.setting.php
+++ b/ext/authx/settings/authx.setting.php
@@ -54,7 +54,7 @@ $_authx_settings = function() {
         'class' => 'crm-select2',
       ],
       'default' => ['jwt'],
-      'title' => ts('Acceptable credentials (%s)'),
+      'title' => ts('Acceptable credentials (%1)', [ 1 => $flow ]),
       'help_text' => NULL,
       'pseudoconstant' => [
         'callback' => ['\Civi\Authx\Meta', 'getCredentialTypes'],
@@ -69,7 +69,7 @@ $_authx_settings = function() {
         'class' => 'crm-select2',
       ],
       'default' => 'optional',
-      'title' => ts('User account requirements (%s)'),
+      'title' => ts('User account requirements (%1)', [ 1 => $flow]),
       'help_text' => NULL,
       'pseudoconstant' => [
         'callback' => ['\Civi\Authx\Meta', 'getUserModes'],


### PR DESCRIPTION
Overview
----------------------------------------
AuthX Setting Labels did not have a replace variable for the flow name. This PR adds that information.

Before
----------------------------------------
![image (1)](https://user-images.githubusercontent.com/9373380/114667538-6e175000-9cb4-11eb-9dd4-1c69f625b891.png)

After
----------------------------------------
![image (2)](https://user-images.githubusercontent.com/9373380/114667587-7b343f00-9cb4-11eb-9c58-19783facce2a.png)

Technical Details
----------------------------------------
Nothing significant.

Comments
----------------------------------------
(none)