### PR TITLE
dev/mail#90 - Allow re-use mailing on draft mailings and adhoc mailings

### DIFF
--- a/CRM/Mailing/Controller/Send.php
+++ b/CRM/Mailing/Controller/Send.php
@@ -51,7 +51,7 @@ class CRM_Mailing_Controller_Send extends CRM_Core_Controller {
       $clone = civicrm_api3('Mailing', 'clone', ['id' => $mid]);
       civicrm_api3('Mailing', 'create', [
         'id' => $clone['id'],
-        'name' => $clone['values'][$clone['id']]['name'] . " - Copy",
+        'name' => "Copy of " . $clone['values'][$clone['id']]['name'],
       ]);
       CRM_Utils_System::redirect(CRM_Utils_System::url('civicrm/a/', NULL, TRUE, '/mailing/' . $clone['id']));
     }

--- a/CRM/Mailing/Controller/Send.php
+++ b/CRM/Mailing/Controller/Send.php
@@ -51,7 +51,7 @@ class CRM_Mailing_Controller_Send extends CRM_Core_Controller {
       $clone = civicrm_api3('Mailing', 'clone', ['id' => $mid]);
       civicrm_api3('Mailing', 'create', [
         'id' => $clone['id'],
-        'name' => "Copy of " . $clone['values'][$clone['id']]['name'],
+        'name' => ts('Copy of %1', [1 => $clone['values'][$clone['id']]['name']]),
       ]);
       CRM_Utils_System::redirect(CRM_Utils_System::url('civicrm/a/', NULL, TRUE, '/mailing/' . $clone['id']));
     }

--- a/CRM/Mailing/Controller/Send.php
+++ b/CRM/Mailing/Controller/Send.php
@@ -49,6 +49,10 @@ class CRM_Mailing_Controller_Send extends CRM_Core_Controller {
     }
     if ($mid && !$continue) {
       $clone = civicrm_api3('Mailing', 'clone', ['id' => $mid]);
+      civicrm_api3('Mailing', 'create', [
+        'id' => $clone['id'],
+        'name' => $clone['values'][$clone['id']]['name'] . " - Copy",
+      ]);
       CRM_Utils_System::redirect(CRM_Utils_System::url('civicrm/a/', NULL, TRUE, '/mailing/' . $clone['id']));
     }
   }

--- a/CRM/Mailing/Selector/Browse.php
+++ b/CRM/Mailing/Selector/Browse.php
@@ -259,10 +259,10 @@ LEFT JOIN  civicrm_contact scheduledContact ON ( $mailing.scheduled_id = schedul
           'title' => ts('Continue Mailing'),
         ],
         CRM_Core_Action::UPDATE => [
-          'name' => ts('Re-Use'),
+          'name' => ts('Copy'),
           'url' => 'civicrm/mailing/send',
           'qs' => 'mid=%%mid%%&reset=1',
-          'title' => ts('Re-Send Mailing'),
+          'title' => ts('Copy Mailing'),
         ],
         CRM_Core_Action::DELETE => [
           'name' => ts('Delete'),

--- a/CRM/Mailing/Selector/Browse.php
+++ b/CRM/Mailing/Selector/Browse.php
@@ -405,7 +405,7 @@ LEFT JOIN  civicrm_contact scheduledContact ON ( $mailing.scheduled_id = schedul
 
         if ($allAccess || $showCreateLinks) {
           $actionMask |= CRM_Core_Action::UPDATE;
-          }
+        }
 
         // check for delete permission.
         if ($allowToDelete) {

--- a/CRM/Mailing/Selector/Browse.php
+++ b/CRM/Mailing/Selector/Browse.php
@@ -245,12 +245,6 @@ LEFT JOIN  civicrm_contact scheduledContact ON ( $mailing.scheduled_id = schedul
           'qs' => 'mid=%%mid%%&reset=1',
           'title' => ts('View Mailing Report'),
         ],
-        CRM_Core_Action::UPDATE => [
-          'name' => ts('Re-Use'),
-          'url' => 'civicrm/mailing/send',
-          'qs' => 'mid=%%mid%%&reset=1',
-          'title' => ts('Re-Send Mailing'),
-        ],
         CRM_Core_Action::DISABLE => [
           'name' => ts('Cancel'),
           'url' => 'civicrm/mailing/browse',
@@ -263,6 +257,12 @@ LEFT JOIN  civicrm_contact scheduledContact ON ( $mailing.scheduled_id = schedul
           'url' => 'civicrm/mailing/send',
           'qs' => 'mid=%%mid%%&continue=true&reset=1',
           'title' => ts('Continue Mailing'),
+        ],
+        CRM_Core_Action::UPDATE => [
+          'name' => ts('Re-Use'),
+          'url' => 'civicrm/mailing/send',
+          'qs' => 'mid=%%mid%%&reset=1',
+          'title' => ts('Re-Send Mailing'),
         ],
         CRM_Core_Action::DELETE => [
           'name' => ts('Delete'),
@@ -363,12 +363,6 @@ LEFT JOIN  civicrm_contact scheduledContact ON ( $mailing.scheduled_id = schedul
           if ($allAccess || $showCreateLinks) {
             $actionMask = CRM_Core_Action::VIEW;
           }
-
-          if (!in_array($row['id'], $searchMailings)) {
-            if ($allAccess || $showCreateLinks) {
-              $actionMask |= CRM_Core_Action::UPDATE;
-            }
-          }
         }
         else {
           if ($allAccess || ($showCreateLinks || $showScheduleLinks)) {
@@ -408,6 +402,10 @@ LEFT JOIN  civicrm_contact scheduledContact ON ( $mailing.scheduled_id = schedul
             $actionMask |= CRM_Core_Action::RENEW;
           }
         }
+
+        if ($allAccess || $showCreateLinks) {
+          $actionMask |= CRM_Core_Action::UPDATE;
+          }
 
         // check for delete permission.
         if ($allowToDelete) {


### PR DESCRIPTION
See also : https://lab.civicrm.org/dev/mail/-/issues/90

## Before

* "Re-use" was shown only on scheduled/sent and archived mailings pages.
* "Re-use" was shown only on mailings with standard groups (omitting maliings that used adhoc targets).

## After

* "Re-use" is also shown on draft/unscheduled mailings (i.e. on all mailings).
* "Re-use" is also shown on mailings with adhoc targets.
* The list of actions has been reordered, so that "Continue" comes before "Re-use"/"Copy".
    ![image](https://user-images.githubusercontent.com/25517556/114755428-d9920980-9d16-11eb-9562-d7e0a42c9d1b.png)
    ![image](https://user-images.githubusercontent.com/25517556/114755442-dd259080-9d16-11eb-8a6b-9928288aeac8.png)
* The action "Re-use" has been renamed to "Copy".

NOTE: Description updated April 19 to indicate that  the PR also affects adhoc mailings.