### PR TITLE
dev/core#2479 Adjust generic copy for localizable fields

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -1778,11 +1778,9 @@ LIKE %1
       $newObject = new $daoName();
 
       $fields = $object->fields();
-      if (!is_array($fieldsFix)) {
-        $fieldsToPrefix = [];
-        $fieldsToSuffix = [];
-        $fieldsToReplace = [];
-      }
+      $fieldsToPrefix = [];
+      $fieldsToSuffix = [];
+      $fieldsToReplace = [];
       if (!empty($fieldsFix['prefix'])) {
         $fieldsToPrefix = $fieldsFix['prefix'];
       }

--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -1853,7 +1853,6 @@ LIKE %1
     return $newObject;
   }
 
-
   /**
    * Method that copies localizable fields from an old entity to a new one.
    *
@@ -1862,6 +1861,9 @@ LIKE %1
    *
    * @param int $entityID
    * @param int $newEntityID
+   * @param array $fieldsToPrefix
+   * @param array $fieldsToSuffix
+   * @param array $fieldsToReplace
    */
   protected function copyLocalizable($entityID, $newEntityID, $fieldsToPrefix, $fieldsToSuffix, $fieldsToReplace) {
     $entity = get_class($this);
@@ -1911,7 +1913,6 @@ LIKE %1
 
     }
   }
-
 
   /**
    * Method that copies custom fields values from an old entity to a new one.

--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -1793,6 +1793,7 @@ LIKE %1
         $fieldsToReplace = $fieldsFix['replace'];
       }
 
+      $localizableFields = FALSE;
       foreach ($fields as $name => $value) {
         if ($name == 'id' || $value['name'] == 'id') {
           // copy everything but the id!
@@ -1816,11 +1817,33 @@ LIKE %1
           $newObject->$dbName = CRM_Utils_Date::isoToMysql($newObject->$dbName);
         }
 
+        if (!empty($value['localizable'])) {
+          $localizableFields = TRUE;
+        }
+
         if ($newData) {
           $newObject->copyValues($newData);
         }
       }
       $newObject->save();
+
+      // ensure we copy all localized fields as well
+      if (CRM_Core_I18n::isMultilingual() && $localizableFields) {
+        global $dbLocale;
+        $locales = CRM_Core_I18n::getMultilingual();
+        $curLocale = CRM_Core_I18n::getLocale();
+        // loop on other locales
+        foreach ($locales as $locale) {
+          if ($locale != $curLocale) {
+            // setLocale doesn't seems to be reliable to set dbLocale and we only need to change the db locale
+            $dbLocale = '_' . $locale;
+            $newObject->copyLocalizable($object->id, $newObject->id, $fieldsToPrefix, $fieldsToSuffix, $fieldsToReplace);
+          }
+        }
+        // restore dbLocale to starting value
+        $dbLocale = '_' . $curLocale;
+      }
+
       if (!$blockCopyofCustomValues) {
         $newObject->copyCustomFields($object->id, $newObject->id);
       }
@@ -1829,6 +1852,66 @@ LIKE %1
 
     return $newObject;
   }
+
+
+  /**
+   * Method that copies localizable fields from an old entity to a new one.
+   *
+   * Fixes bug dev/core#2479,
+   * where non current locale fields are copied from current locale losing translation when copying
+   *
+   * @param int $entityID
+   * @param int $newEntityID
+   */
+  protected function copyLocalizable($entityID, $newEntityID, $fieldsToPrefix, $fieldsToSuffix, $fieldsToReplace) {
+    $entity = get_class($this);
+    $object = new $entity();
+    $object->id = $entityID;
+    $object->find();
+
+    $newObject = new $entity();
+    $newObject->id = $newEntityID;
+
+    $newObject->find();
+
+    if ($object->fetch() && $newObject->fetch()) {
+
+      $fields = $object->fields();
+      foreach ($fields as $name => $value) {
+
+        if ($name == 'id' || $value['name'] == 'id') {
+          // copy everything but the id!
+          continue;
+        }
+
+        // only copy localizable fields
+        if (!$value['localizable']) {
+          continue;
+        }
+
+        $dbName = $value['name'];
+        $type = CRM_Utils_Type::typeToString($value['type']);
+        $newObject->$dbName = $object->$dbName;
+        if (isset($fieldsToPrefix[$dbName])) {
+          $newObject->$dbName = $fieldsToPrefix[$dbName] . $newObject->$dbName;
+        }
+        if (isset($fieldsToSuffix[$dbName])) {
+          $newObject->$dbName .= $fieldsToSuffix[$dbName];
+        }
+        if (isset($fieldsToReplace[$dbName])) {
+          $newObject->$dbName = $fieldsToReplace[$dbName];
+        }
+
+        if ($type == 'Timestamp' || $type == 'Date') {
+          $newObject->$dbName = CRM_Utils_Date::isoToMysql($newObject->$dbName);
+        }
+
+      }
+      $newObject->save();
+
+    }
+  }
+
 
   /**
    * Method that copies custom fields values from an old entity to a new one.

--- a/tests/phpunit/CRM/Core/CopyTest.php
+++ b/tests/phpunit/CRM/Core/CopyTest.php
@@ -1,0 +1,116 @@
+<?php
+
+/**
+ * @group headless
+ */
+class CRM_Core_CopyTest extends CiviUnitTestCase {
+
+  public function testEventCopy() {
+
+    $event = $this->eventCreate();
+    $eventId = $event['id'];
+    $eventRes = $event['values'][$eventId];
+    $eventCopy = CRM_Event_BAO_Event::copy($eventId);
+
+    $identicalParams = [
+      'summary',
+      'description',
+      'event_type_id',
+      'is_public',
+      'start_date',
+      'end_date',
+      'is_online_registration',
+      'registration_start_date',
+      'registration_end_date',
+      'max_participants',
+      'event_full_text',
+      'is_monetary',
+      'is_active',
+      'is_show_location',
+      'is_email_confirm',
+    ];
+
+    foreach ($identicalParams as $name) {
+      $this->assertEquals($eventCopy->$name, $eventRes[$name]);
+    }
+
+    $this->assertEquals($eventCopy->title, 'Copy of ' . $eventRes['title']);
+
+  }
+
+  public function testI18nEventCopy() {
+
+    $otherLocale = 'fr_CA';
+    $locSuffix = " ({$otherLocale})";
+
+    $this->enableMultilingual();
+    CRM_Core_I18n_Schema::addLocale($otherLocale, 'en_US');
+
+    CRM_Core_I18n::singleton()->setLocale('en_US');
+
+    $event = $this->eventCreate();
+    $eventId = $event['id'];
+    $eventData = civicrm_api3('Event', 'getsingle', ['id' => $eventId]);
+
+    // change localizable fields
+    $locParams = [
+      'summary',
+      'description',
+    ];
+
+    CRM_Core_I18n::singleton()->setLocale($otherLocale);
+    $ploc = ['id' => $eventId];
+    foreach ($locParams as $field) {
+      $ploc[$field] = $eventData[$field] . $locSuffix;
+    }
+    $this->callAPISuccess('Event', 'create', $ploc);
+
+    CRM_Core_I18n::singleton()->setLocale('en_US');
+    $eventCopy = CRM_Event_BAO_Event::copy($eventId);
+    $eventCopyId = $eventCopy->id;
+
+    $identicalParams = [
+      'event_type_id',
+      'is_public',
+      'start_date',
+      'end_date',
+      'is_online_registration',
+      'registration_start_date',
+      'registration_end_date',
+      'max_participants',
+      'event_full_text',
+      'is_monetary',
+      'is_active',
+      'is_show_location',
+      'is_email_confirm',
+    ];
+
+    // en_US should be as the original
+    CRM_Core_I18n::singleton()->setLocale('en_US');
+    $eventCopy = civicrm_api3('Event', 'getsingle', ['id' => $eventCopyId]);
+    foreach ($identicalParams as $name) {
+      $this->assertEquals($eventCopy[$name], $eventData[$name]);
+    }
+    // title is special
+    $this->assertEquals($eventCopy['title'], 'Copy of ' . $eventData['title']);
+
+    // localized fields should be different
+    CRM_Core_I18n::singleton()->setLocale($otherLocale);
+    $eventCopy = civicrm_api3('Event', 'getsingle', ['id' => $eventCopyId]);
+    foreach ($identicalParams as $name) {
+      $this->assertEquals($eventCopy[$name], $eventData[$name]);
+    }
+    foreach ($locParams as $name) {
+      $this->assertEquals($eventCopy[$name], $eventData[$name] . $locSuffix);
+    }
+    // title is special
+    $this->assertEquals($eventCopy['title'], 'Copy of ' . $eventData['title']);
+
+    // reset to en_US only
+    CRM_Core_I18n::singleton()->setLocale('en_US');
+    CRM_Core_I18n_Schema::makeSinglelingual('en_US');
+
+  }
+
+}
+

--- a/tests/phpunit/CRM/Core/CopyTest.php
+++ b/tests/phpunit/CRM/Core/CopyTest.php
@@ -30,11 +30,15 @@ class CRM_Core_CopyTest extends CiviUnitTestCase {
       'is_email_confirm',
     ];
 
+    // same format for better comparison
+    $eventData = civicrm_api3('Event', 'getsingle', ['id' => $eventId]);
+    $eventCopy = civicrm_api3('Event', 'getsingle', ['id' => $eventCopy->id]);
+
     foreach ($identicalParams as $name) {
-      $this->assertEquals($eventCopy->$name, $eventRes[$name]);
+      $this->assertEquals($eventCopy[$name], $eventData[$name], "{$name} should be equals between source and copy");
     }
 
-    $this->assertEquals($eventCopy->title, 'Copy of ' . $eventRes['title']);
+    $this->assertEquals($eventCopy['title'], 'Copy of ' . $eventRes['title']);
 
   }
 
@@ -135,10 +139,10 @@ class CRM_Core_CopyTest extends CiviUnitTestCase {
   protected function compareLocalizedCopy($source, $dest, $locParams, $identicalParams, $locSuffix) {
 
     foreach ($identicalParams as $name) {
-      $this->assertEquals($dest[$name], $source[$name]);
+      $this->assertEquals($dest[$name], $source[$name], "{$name} should be equals between source and copy");
     }
     foreach ($locParams as $name) {
-      $this->assertEquals($dest[$name], $source[$name] . $locSuffix);
+      $this->assertEquals($dest[$name], $source[$name] . $locSuffix, "copy of {$name} is not properly localized");
     }
 
   }

--- a/tests/phpunit/CRM/Core/CopyTest.php
+++ b/tests/phpunit/CRM/Core/CopyTest.php
@@ -113,4 +113,3 @@ class CRM_Core_CopyTest extends CiviUnitTestCase {
   }
 
 }
-


### PR DESCRIPTION
Overview
----------------------------------------
Add multilingual support when copying entities (event, contribution page, price set, profile).

See https://lab.civicrm.org/dev/core/-/issues/2479

Before
----------------------------------------
Example for event:
![Peek_26-03-2021_15-25](https://user-images.githubusercontent.com/372004/114745612-d3069080-9d1c-11eb-8dd2-e76b8449be4c.gif)

After
----------------------------------------
All translatable fields are copied based on the localized field of the original entity.

Technical Details
----------------------------------------
The general idea is to:
* loop over the other non current locale,
* change the db locale
* loop over the translatable field to get the original value in the new locale
* persist the updated translatable fields

Comments
----------------------------------------
I'm going to do more tests but it seems to generally work.
