### PR TITLE
dev/core#2509 - Search kit display link for grant view is wrong

### DIFF
--- a/xml/schema/Grant/Grant.xml
+++ b/xml/schema/Grant/Grant.xml
@@ -10,7 +10,7 @@
   <component>CiviGrant</component>
   <paths>
     <add>civicrm/grant/add?reset=1&amp;action=add&amp;context=standalone</add>
-    <view>contact/view/grant?reset=1&amp;action=view&amp;id=[id]&amp;cid=[contact_id]</view>
+    <view>civicrm/contact/view/grant?reset=1&amp;action=view&amp;id=[id]&amp;cid=[contact_id]</view>
     <update>civicrm/contact/view/grant?reset=1&amp;action=update&amp;id=[id]&amp;cid=[contact_id]</update>
     <delete>civicrm/contact/view/grant?reset=1&amp;action=delete&amp;id=[id]&amp;cid=[contact_id]</delete>
   </paths>


### PR DESCRIPTION
Overview
----------------------------------------
Came up during https://lab.civicrm.org/dev/core/-/issues/2509.

If you create a search kit search on grants and make a display table and make one of the fields a link to Grant View, it's the wrong link.

Note also that unless the search includes a contact-related column the generated link has the literal `[contact_id]` in it which fatals when visited, and the link requires a contact id. This PR doesn't address that, but good to know for review purposes.

Before
----------------------------------------
Missing civicrm

After
----------------------------------------
Civified

Technical Details
----------------------------------------


Comments
----------------------------------------

