### PR TITLE
Fix PayPal IPN URL and WordPress URLs when Permalinks are set to "Plain"

### DIFF
--- a/CRM/Core/Payment.php
+++ b/CRM/Core/Payment.php
@@ -1275,7 +1275,7 @@ abstract class CRM_Core_Payment {
    *   URL to notify outcome of transaction.
    */
   protected function getNotifyUrl() {
-    $url = CRM_Utils_System::url(
+    $url = CRM_Utils_System::getNotifyUrl(
       'civicrm/payment/ipn/' . $this->_paymentProcessor['id'],
       [],
       TRUE,

--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -282,6 +282,43 @@ class CRM_Utils_System {
   }
 
   /**
+   * Return the Notification URL for Payments.
+   *
+   * @param string $path
+   *   The path being linked to, such as "civicrm/add".
+   * @param array|string $query
+   *   A query string to append to the link, or an array of key-value pairs.
+   * @param bool $absolute
+   *   Whether to force the output to be an absolute link (beginning with a
+   *   URI-scheme such as 'http:'). Useful for links that will be displayed
+   *   outside the site, such as in an RSS feed.
+   * @param string $fragment
+   *   A fragment identifier (named anchor) to append to the link.
+   * @param bool $htmlize
+   *   Whether to encode special html characters such as &.
+   * @param bool $frontend
+   *   This link should be to the CMS front end (applies to WP & Joomla).
+   * @param bool $forceBackend
+   *   This link should be to the CMS back end (applies to WP & Joomla).
+   *
+   * @return string
+   *   The Notification URL.
+   */
+  public static function getNotifyUrl(
+    $path = NULL,
+    $query = NULL,
+    $absolute = FALSE,
+    $fragment = NULL,
+    $htmlize = TRUE,
+    $frontend = FALSE,
+    $forceBackend = FALSE
+  ) {
+    $config = CRM_Core_Config::singleton();
+    $query = self::makeQueryString($query);
+    return $config->userSystem->getNotifyUrl($path, $query, $absolute, $fragment, $frontend, $forceBackend, $htmlize);
+  }
+
+  /**
    * Generates an extern url.
    *
    * @param string $path

--- a/CRM/Utils/System/Base.php
+++ b/CRM/Utils/System/Base.php
@@ -142,6 +142,45 @@ abstract class CRM_Utils_System_Base {
   }
 
   /**
+   * Return the Notification URL for Payments.
+   *
+   * The default is to pass the params through to `url()`. However the WordPress
+   * CMS class overrides this method because Notification URLs must always target
+   * the Base Page to avoid IPN failures when Forms are embedded in pages that
+   * require authentication.
+   *
+   * @param string $path
+   *   The path being linked to, such as "civicrm/add".
+   * @param string $query
+   *   A query string to append to the link.
+   * @param bool $absolute
+   *   Whether to force the output to be an absolute link (beginning with http).
+   *   Useful for links that will be displayed outside the site, such as in an RSS feed.
+   * @param string $fragment
+   *   A fragment identifier (named anchor) to append to the link.
+   * @param bool $frontend
+   *   This link should be to the CMS front end (applies to WP & Joomla).
+   * @param bool $forceBackend
+   *   This link should be to the CMS back end (applies to WP & Joomla).
+   * @param bool $htmlize
+   *   Whether to encode special html characters such as &.
+   *
+   * @return string
+   *   The Notification URL.
+   */
+  public function getNotifyUrl(
+    $path = NULL,
+    $query = NULL,
+    $absolute = FALSE,
+    $fragment = NULL,
+    $frontend = FALSE,
+    $forceBackend = FALSE,
+    $htmlize = TRUE
+  ) {
+    return $this->url($path, $query, $absolute, $fragment, $frontend, $forceBackend, $htmlize);
+  }
+
+  /**
    * Authenticate the user against the CMS db.
    *
    * @param string $name


### PR DESCRIPTION
Overview
----------------------------------------
This was meant to be simply a fix for [this issue on Lab](https://lab.civicrm.org/dev/wordpress/-/issues/93), but in the process of creating that fix, it became evident that a deeper dive into WordPress URLs was necessary to untangle what was needed.

Before
----------------------------------------
1. PayPal IPN URLs always pointed back to the Page/Post where the form was embedded
2. CiviCRM URLs were broken when Permalinks are set to "Plain"

After
----------------------------------------
1. PayPal IPN URLs always point to the WordPress Base Page
2. CiviCRM URLs work as expected when Permalinks are set to "Plain"

Technical Details
----------------------------------------
This PR does a few things to achieve its ends:

1. Introduces a `getNotifyUrl()` family of methods to the `CRM_Utils_System*` classes so that the PayPal IPN URL always targets the WordPress Base Page.
2. Introduces `CRM_Utils_System_WordPress::getBasePageUrl()` in order to build URLs that target the WordPress Base Page when in a Shortcode context.
3. Simplifies and clarifies `CRM_Utils_System_WordPress::url()` because WordPress URLs were broken when Permalinks are set to "Plain". Since `CRM_Utils_System_WordPress::getNotifyUrl()` is a stripped-down version of `CRM_Utils_System_WordPress::url()` that needs to respect both (a) Permalink settings and (b) whether Clean URLs are used, it became necessary to audit `CRM_Utils_System_WordPress::url()` in order to strip it down!
4. Makes `CRM_Utils_System_WordPress::getBaseUrl()` a public method so that [the duplicate method](https://github.com/civicrm/civicrm-wordpress/blob/b4cb14a416bd4371b8590e6ca44e96a1bba42105/civicrm.php#L1392-L1421) in the CiviCRM-WordPress plugin can be removed.

Comments
----------------------------------------
I'm opening this PR against `master` so that there's plenty of time to evaluate the changes to `CRM_Utils_System_WordPress::url()` in particular.

Many thanks to Agileware who part-funded this PR.