### PR TITLE
dev/core#2536 Trim strings from info.xml in extensions

### DIFF
--- a/CRM/Extension/Info.php
+++ b/CRM/Extension/Info.php
@@ -156,7 +156,7 @@ class CRM_Extension_Info {
     // we want them in special format.
     foreach ($info as $attr => $val) {
       if (count($val->children()) == 0) {
-        $this->$attr = (string) $val;
+        $this->$attr = trim((string) $val);
       }
       elseif ($attr === 'urls') {
         $this->urls = [];


### PR DESCRIPTION
Overview
----------------------------------------
Fixes bug reported in https://lab.civicrm.org/dev/core/-/issues/2536

Before
----------------------------------------
```
<requires>
</requires>
```
and 
```
<requires></requires>
``` 
are not equivalent and the former breaks stuff

After
----------------------------------------
All strings coming in from the xml that do not have children have preceding & trailing white space removed

Technical Details
----------------------------------------
I don't think we should limit whitespace trimming to this field

Comments
----------------------------------------
