### PR TITLE
REF Hide newly created Payflow Pro Extension in the UI

### DIFF
--- a/ext/payflowpro/info.xml
+++ b/ext/payflowpro/info.xml
@@ -16,6 +16,9 @@
   </urls>
   <releaseDate>2021-04-13</releaseDate>
   <version>1.0</version>
+  <tags>
+    <tag>mgmt:hidden</tag>
+  </tags>
   <develStage>stable</develStage>
   <compatibility>
     <ver>5.0</ver>


### PR DESCRIPTION
Overview
----------------------------------------
This hides the newly created Payflow Pro Extension

Before
----------------------------------------
Extension visible in the UI

After
----------------------------------------
Extension hidden in the UI

ping @eileenmcnaughton @JoeMurray 

I am kind of split on if we should do this

Like the EwaySingle one Payflow Pro had been marked as not active on newly installed sites previously to this. However unlike ewaySingle Payment Processor there are no other Payflow Pro extensions in the community that are recommended to be used instead of this. Also Payflow Pro is documented in the SysAdmin guide unlike the ewaySignle payment processor