### PR TITLE
dev/core#2528 Set Modified date to be current timestamp in civicrm_co…

### DIFF
--- a/CRM/Upgrade/Incremental/php/FiveThirtySeven.php
+++ b/CRM/Upgrade/Incremental/php/FiveThirtySeven.php
@@ -129,6 +129,7 @@ class CRM_Upgrade_Incremental_php_FiveThirtySeven extends CRM_Upgrade_Incrementa
    */
   public static function updateDBDefaultsForContributionRecur(CRM_Queue_TaskContext $ctx): bool {
     $pendingID = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_ContributionRecur', 'contribution_status_id', 'Pending');
+    CRM_Core_DAO::executeQuery("UPDATE `civicrm_contribution_recur` SET `modified_date` = CURRENT_TIMESTAMP() WHERE `modified_date` IS NULL");
     CRM_Core_DAO::executeQuery("
       ALTER TABLE `civicrm_contribution_recur`
       MODIFY COLUMN `start_date` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'The date the first scheduled recurring contribution occurs.',


### PR DESCRIPTION
…ntribution_recur if it is null before setting the field to NOT NULL

Overview
----------------------------------------
This fixes an upgrade fail by setting the modified date field to be current_timestamp when it is NULL before processing the field

Before
----------------------------------------
Error on DB Upgrade

After
----------------------------------------
No Error

ping @eileenmcnaughton I believe this is as discussed in the meeting today