### PR TITLE
Removed limit of 25 groups and past mailings

### DIFF
--- a/ang/crmMailing/services.js
+++ b/ang/crmMailing/services.js
@@ -127,7 +127,7 @@
       },
       // Call MailingGroup.get and merge results into "mailing"
       _loadGroups: function (mailing) {
-        return crmApi('MailingGroup', 'get', {mailing_id: mailing.id})
+        return crmApi('MailingGroup', 'get', {mailing_id: mailing.id, 'options': {'limit':0}})
           .then(function (groupResult) {
             mailing.recipients = {};
             mailing.recipients.groups = {include: [], exclude: [], base: []};


### PR DESCRIPTION
Before: Saving a mailing with more than 25 groups or past mailing recipients caused the number of groups to be reduced to 25.
After: As many groups as desired can be added.