### PR TITLE
dev/core#2498 dedupe rule saving fix

### DIFF
--- a/CRM/Contact/Form/DedupeRules.php
+++ b/CRM/Contact/Form/DedupeRules.php
@@ -143,7 +143,6 @@ class CRM_Contact_Form_DedupeRules extends CRM_Admin_Form {
         if (!empty($fields["weight_$count"])) {
           $actualThreshold += $fields["weight_$count"];
         }
-        break;
       }
     }
     if (empty($fields['threshold'])) {


### PR DESCRIPTION
Overview
----------------------------------------
See 
https://lab.civicrm.org/dev/core/-/issues/2498#note_57962

Before
----------------------------------------
!(image)[https://lab.civicrm.org/dev/core/uploads/18e570bc65d810d1012c33196b590700/ksnip_20210414-124001.png]

After
----------------------------------------
savable

Technical Details
----------------------------------------
Reporter tested this change comments in gitlab. This regression was already 'fixed' but only when a single field was in use, due to this extraneous break

Comments
----------------------------------------
