### PR TITLE
APIv4 - Fix Setting api to work with index param

### DIFF
--- a/api/api.php
+++ b/api/api.php
@@ -63,8 +63,8 @@ function civicrm_api4(string $entity, string $action, array $params = [], $index
   $indexField = $index && is_string($index) && !CRM_Utils_Rule::integer($index) ? $index : NULL;
   $removeIndexField = FALSE;
 
-  // If index field is not part of the select query, we add it here and remove it below
-  if ($indexField && !empty($params['select']) && is_array($params['select']) && !\Civi\Api4\Utils\SelectUtil::isFieldSelected($indexField, $params['select'])) {
+  // If index field is not part of the select query, we add it here and remove it below (except for oddball "Setting" api)
+  if ($indexField && !empty($params['select']) && is_array($params['select']) && $entity !== 'Setting' && !\Civi\Api4\Utils\SelectUtil::isFieldSelected($indexField, $params['select'])) {
     $params['select'][] = $indexField;
     $removeIndexField = TRUE;
   }
@@ -73,7 +73,8 @@ function civicrm_api4(string $entity, string $action, array $params = [], $index
   if ($index && is_array($index)) {
     $indexCol = reset($index);
     $indexField = key($index);
-    if (property_exists($apiCall, 'select')) {
+    // Index array indicates only 1 or 2 fields need to be selected (except for oddball "Setting" api)
+    if ($entity !== 'Setting' && property_exists($apiCall, 'select')) {
       $apiCall->setSelect([$indexCol]);
       if ($indexField && $indexField != $indexCol) {
         $apiCall->addSelect($indexField);

--- a/tests/phpunit/api/v4/Entity/SettingTest.php
+++ b/tests/phpunit/api/v4/Entity/SettingTest.php
@@ -57,4 +57,25 @@ class SettingTest extends UnitTestCase {
     $this->assertTrue(is_array($settings[0]['value']));
   }
 
+  /**
+   * Ensure settings work with the "index" mode.
+   */
+  public function testSettingsWithIndexParam() {
+    $settings = civicrm_api4('Setting', 'get', [], ['name' => 'value']);
+    $stringValues = FALSE;
+    $arrayValues = FALSE;
+    // With indexing by [name => value], keys should be string and values should be string/array
+    foreach ($settings as $name => $value) {
+      $this->assertTrue(is_string($name) && !is_numeric($name));
+      if (is_string($value)) {
+        $stringValues = TRUE;
+      }
+      elseif (is_array($value)) {
+        $arrayValues = TRUE;
+      }
+    }
+    $this->assertTrue($stringValues);
+    $this->assertTrue($arrayValues);
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes an APIv4 bug when using the Settings api with the index param.

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/2874912/114928886-20f4c480-9e01-11eb-926a-a7ec67feb95f.png)


After
----------------------------------------
![image](https://user-images.githubusercontent.com/2874912/114928837-10444e80-9e01-11eb-9a3a-29e3d859654a.png)


Technical Details
----------------------------------------
The api tries to force index params into the "Select" clause, which doesn't make sense for the oddball "Setting" api.