### PR TITLE
dev/core#403 Fix Petition Confirmation Email template by removing the…

### DIFF
--- a/CRM/Upgrade/Incremental/MessageTemplates.php
+++ b/CRM/Upgrade/Incremental/MessageTemplates.php
@@ -232,6 +232,13 @@ class CRM_Upgrade_Incremental_MessageTemplates {
           ['name' => 'contribution_invoice_receipt', 'type' => 'html'],
         ],
       ],
+      [
+        'version' => '5.38.alpha1',
+        'upgrade_descriptor' => ts('Fix Petition Confirmation email having a blank space at the end of url'),
+        'templates' => [
+          ['name' => 'petition_confirmation_needed', 'type' => 'html'],
+        ],
+      ],
     ];
   }
 

--- a/xml/templates/message_templates/petition_confirmation_needed_html.tpl
+++ b/xml/templates/message_templates/petition_confirmation_needed_html.tpl
@@ -7,6 +7,6 @@
 Please do so by visiting the following web page by clicking
 on the link below or pasting the link into your browser.
 <br /><br />
-Email confirmation page: <a href="{$petition.confirmUrl} ">{$petition.confirmUrl}</a></p>
+Email confirmation page: <a href="{$petition.confirmUrl}">{$petition.confirmUrl}</a></p>
 
 <p>If you did not sign this petition, please ignore this message.</p>


### PR DESCRIPTION
… trailing space on the confirmation url from the href tag

Overview
----------------------------------------
This fixes a silent bug found because the href tag contains a trailing white space 

Before
----------------------------------------
URL doesn't work unless copied into the browser because of a trailing white space

After
----------------------------------------
No trailing whitespace

@eileenmcnaughton this should be a pretty easy one to review