### PR TITLE
authx - Accept API keys by default

### DIFF
--- a/ext/authx/settings/authx.setting.php
+++ b/ext/authx/settings/authx.setting.php
@@ -76,6 +76,11 @@ $_authx_settings = function() {
       ],
     ];
   }
+
+  $s['authx_param_cred']['default'] = ['jwt', 'api_key'];
+  $s['authx_header_cred']['default'] = ['jwt', 'api_key'];
+  $s['authx_xheader_cred']['default'] = ['jwt', 'api_key'];
+
   return $s;
 };
 


### PR DESCRIPTION
Overview
--------

This slightly relaxes the default settings so that it is easier to use `authx` as a replacement for `extern/rest.php` (which
uses the `api_key` for authentication).

Before
------

`extern/rest.php` accepts `api_key`s.

`authx` can accept `api_key`s, but you have to change some settings to allow it.

After
-----

Both `extern/rest.php` and `authx` accept `api_key`s by default.

Comments
-----------------

The defaults in authx were designed to be a bit paranoid.  The basic goal -- don't let anyone open up access accidentally.  However, the current protections are a bit of overkill.  Suppose  you're setting up an API key for use with `civicrm/ajax/*`. Here are the sysadmin tasks:

1. Create an API key (`civicrm_contact.api_key`). (*Doing this requires `edit api keys` or `edit own api keys`.*)
2. Enable `authx` (*It's inert otherwise.*)
3. Grant the user permission `authenticate via api key`, or convey the `SITE_KEY` to the user, or disable all `authx_guards`
4. Update the setting `authx_header_cred` or `authx_xheader_cred` or `authx_param_cred` to allow `api_key`

Notably, the default in `#4` was chosen during earlier drafting... before `authx_guards` existed. But now we have the guards, and we have even more steps to go through.

This change relaxes the defaults so that step `#4` is not necessary. This arrangement is still fairly paranoid (ie we still have 1+2+3). Compared to `extern/rest.php`, there's still an extra opt-in hoop.
