### PR TITLE
Add warning when url_site is not specified for paypal (it won't work if not set)

### DIFF
--- a/CRM/Core/Payment/PayPalImpl.php
+++ b/CRM/Core/Payment/PayPalImpl.php
@@ -677,6 +677,11 @@ class CRM_Core_Payment_PayPalImpl extends CRM_Core_Payment {
     if (empty($this->_paymentProcessor['user_name'])) {
       $error[] = ts('User Name is not set in the Administer &raquo; System Settings &raquo; Payment Processors.');
     }
+    if ($this->isPayPalType($this::PAYPAL_STANDARD)) {
+      if (empty($this->_paymentProcessor['url_site'])) {
+        $error[] = ts('Site URL is not set (eg. https://www.paypal.com/ - https://www.sandbox.paypal.com/)');
+      }
+    }
 
     if (!empty($error)) {
       return implode('<p>', $error);


### PR DESCRIPTION
Overview
----------------------------------------
I tracked down an issue with the Stripe extension that was hiding URL fields for processors other than itself and meant that configuring paypal standard after Stripe was enabled caused the configuration to silently be broken - the fix for Stripe is here: https://lab.civicrm.org/extensions/stripe/-/merge_requests/153

This "fix" adds a UI warning for Paypal standard that will be triggered if `url_site` is not set. If it is not set the system redirects back to the contribution page with no warnings or errors and never redirects to Paypal.

Before
----------------------------------------
No warning if url_site not set.

After
----------------------------------------
Error if url_site not set when configuring paypal standard

Technical Details
----------------------------------------

Comments
----------------------------------------
