### PR TITLE
dev/core#2543 Fix Membership Edit PHP fatal when no recorded payment

### DIFF
--- a/CRM/Member/Form.php
+++ b/CRM/Member/Form.php
@@ -483,7 +483,7 @@ class CRM_Member_Form extends CRM_Contribute_Form_AbstractEditPayment {
     if ($priceSetDetails[$this->order->getPriceSetID()]['is_quick_config'] && isset($formValues['total_amount'])) {
       // Amount overrides only permitted on quick config.
       // Possibly Order object should enforce this...
-      $this->order->setOverrideTotalAmount($formValues['total_amount']);
+      $this->order->setOverrideTotalAmount((float) $formValues['total_amount']);
     }
     $this->order->setOverrideFinancialTypeID((int) $formValues['financial_type_id']);
     return $formValues;


### PR DESCRIPTION
Overview
----------------------------------------

https://lab.civicrm.org/dev/core/-/issues/2543

To reproduce:

* https://dmaster.demo.civicrm.org/civicrm/contact/view?reset=1&cid=203
* Add a membership of type general
  * Important: Do not recurd a payment
  * save
* Then click "edit" on that new membership
  * do not edit anything
  * click save

Causes a PHP fatal error because the function typed parameters expect a float:

>  TypeError: Argument 1 passed to CRM_Financial_BAO_Order::setOverrideTotalAmount() must be of the type float, string given

```
      $this->order->setOverrideTotalAmount($formValues['total_amount']);
```

Technical Details
----------------------------------------

Casting to float seems OK. It's also what the function call just below also does, so I did not bother cluttering with a code comment.