### PR TITLE
Fix Drupal8 CiviCRM menu translation on multilingual (and ajax calls)

### DIFF
--- a/js/crm.ajax.js
+++ b/js/crm.ajax.js
@@ -22,14 +22,19 @@
       mode = CRM.config && CRM.config.isFrontend ? 'front' : 'back';
     }
     query = query || '';
-    var frag = path.split('?');
-    var url = tplURL[mode].replace("civicrm/placeholder-url-path", frag[0]);
-
-    if (!query) {
-      url = url.replace(/[?&]civicrm-placeholder-url-query=1/, '');
+    var url,
+      frag = path.split('?');
+    // Encode url path only if slashes in placeholder were also encoded
+    if (tplURL[mode].indexOf('civicrm/placeholder-url-path') >= 0) {
+      url = tplURL[mode].replace('civicrm/placeholder-url-path', frag[0]);
+    } else {
+      url = tplURL[mode].replace('civicrm%2Fplaceholder-url-path', encodeURIComponent(frag[0]));
     }
-    else {
-      url = url.replace("civicrm-placeholder-url-query=1", typeof query === 'string' ? query : $.param(query));
+
+    if (_.isEmpty(query)) {
+      url = url.replace(/[?&]civicrm-placeholder-url-query=1/, '');
+    } else {
+      url = url.replace('civicrm-placeholder-url-query=1', typeof query === 'string' ? query : $.param(query));
     }
     if (frag[1]) {
       url += (url.indexOf('?') < 0 ? '?' : '&') + frag[1];

--- a/js/crm.ajax.js
+++ b/js/crm.ajax.js
@@ -23,7 +23,7 @@
     }
     query = query || '';
     var frag = path.split('?');
-    var url = tplURL[mode].replace("civicrm-placeholder-url-path", frag[0]);
+    var url = tplURL[mode].replace("civicrm/placeholder-url-path", frag[0]);
 
     if (!query) {
       url = url.replace(/[?&]civicrm-placeholder-url-query=1/, '');

--- a/templates/CRM/common/l10n.js.tpl
+++ b/templates/CRM/common/l10n.js.tpl
@@ -29,7 +29,7 @@
   CRM.config.entityRef = $.extend({ldelim}{rdelim}, {$entityRef|@json_encode}, CRM.config.entityRef || {ldelim}{rdelim});
 
   // Initialize CRM.url and CRM.formatMoney
-  CRM.url({ldelim}back: '{crmURL p="civicrm-placeholder-url-path" q="civicrm-placeholder-url-query=1" h=0 fb=1}', front: '{crmURL p="civicrm-placeholder-url-path" q="civicrm-placeholder-url-query=1" h=0 fe=1}'{rdelim});
+  CRM.url({ldelim}back: '{crmURL p="civicrm/placeholder-url-path" q="civicrm-placeholder-url-query=1" h=0 fb=1}', front: '{crmURL p="civicrm/placeholder-url-path" q="civicrm-placeholder-url-query=1" h=0 fe=1}'{rdelim});
   CRM.formatMoney('init', false, {$moneyFormat});
 
   // Localize select2

--- a/tests/karma/unit/crmMailingSpec.js
+++ b/tests/karma/unit/crmMailingSpec.js
@@ -17,7 +17,7 @@ describe('crmMailing', function() {
         $provide.value('crmNavigator', navigator);
       });
       inject(['crmLegacy', function(crmLegacy) {
-        crmLegacy.url({back: '/civicrm-placeholder-url-path?civicrm-placeholder-url-query=1', front: '/civicrm-placeholder-url-path?civicrm-placeholder-url-query=1'});
+        crmLegacy.url({back: '/civicrm/placeholder-url-path?civicrm-placeholder-url-query=1', front: '/civicrm/placeholder-url-path?civicrm-placeholder-url-query=1'});
       }]);
       inject(['$controller', function($controller) {
         ctrl = $controller('ListMailingsCtrl', {});


### PR DESCRIPTION
Overview
----------------------------------------

Using Drupal8 on a multilingual site using "inherit locale", the menu often does not display in the correct language.

To reproduce:

* Enable Drupal locale, and add a second language, use language prefix as the language detection method.
* Enable multilingual in CiviCRM, add a second language, enable "inherit CMS language".

It will help to clear the localStorage regularly while testing this, because the menu gets cached. So get ready to do `localStorage.clear(); ` after each request (F12 -> Console). 

The first problem is that the menu is loaded with `/civicrm/ajax/navmenu`, instead of, `/fr/civicrm/ajax/navmenu`. Sure, the request passes a `language=fr_CA` argument, but when using the "inheritLanguage" setting, this language argument is ignored.

Sure, we can patch that code, but this missing prefix causes other issues (more on that later), and the code is already pretty messy.

So anyway, the menu is not loading correctly because of the `civicrm-placeholder-url-path`. Drupal8 only adds the language prefix when the path has a route:

## Before the patch

```
Path: civicrm-placeholder-url-path
Base: internal:/
Result: /civicrm-placeholder-url-path?civicrm-placeholder-url-query=1
```

## After the patch :cake:

```
Path: civicrm/placeholder-url-path <- slashed
Base: internal:/
Result: /fr/civicrm/placeholder-url-path?civicrm-placeholder-url-query=1  <- language prefix
```

## Other bugfix

This also resolves any URL generated with `CRM.url()`.

Technical Details
----------------------------------------

The above debug was added to `CRM_Utils_System_Drupal8::url()`.

Comments
----------------------------------------

Why don't crabs give to charity? Because they're shellfish. :drum: 