### PR TITLE
[NFC/Unit Test] - Help avoid problems when using assertApproxEquals with integers instead of fractions

### DIFF
--- a/Civi/Test/GenericAssertionsTrait.php
+++ b/Civi/Test/GenericAssertionsTrait.php
@@ -57,6 +57,10 @@ trait GenericAssertionsTrait {
    * @param string $message
    */
   public function assertApproxEquals($expected, $actual, $tolerance, $message = NULL) {
+    if ($tolerance == 1 && is_int($expected) && is_int($actual)) {
+      //           ^^ loose equality is on purpose
+      throw new \CRM_Core_Exception('assertApproxEquals is a fractions-first thinking function and compares integers with a tolerance of 1 as if they are identical. You want a bigger number, such as 2, or 5.');
+    }
     $diff = abs($actual - $expected);
     if ($message === NULL) {
       $message = sprintf("approx-equals: expected=[%.3f] actual=[%.3f] diff=[%.3f] tolerance=[%.3f]", $expected, $actual, $diff, $tolerance);


### PR DESCRIPTION
Overview
----------------------------------------
> Pick up my guitar and play
> Just like yesterday
> Then I'll get on my knees and pray
> We don't get fooled again

This makes your test fail if you pass integers into assertApproxEquals with a threshold of 1. It's come up twice that I know of. It gives you a helpful message to use a bigger number, such as 2, or 5.

Before
----------------------------------------
Kinda

After
----------------------------------------
Sorta

Technical Details
----------------------------------------
Integers-first is how humans think, not fractions as do Alpha-Centaurans, or complex numbers as do humpback whales (source: Star Trek IV). But the approxEquals function is a fractions-first thinking function, where a threshold of 1 when applied to integers means they need to be identical.

> Fool me once shame on you. Fool me ... can't get fooled again.

Comments
----------------------------------------
Is test

@seamuslee001