### PR TITLE
Extensions - Setup `<classloader>` during installation

### DIFF
--- a/CRM/Extension/Manager/Module.php
+++ b/CRM/Extension/Manager/Module.php
@@ -29,6 +29,7 @@ class CRM_Extension_Manager_Module extends CRM_Extension_Manager_Base {
    * @param CRM_Extension_Info $info
    */
   public function onPreInstall(CRM_Extension_Info $info) {
+    CRM_Extension_System::singleton()->getClassLoader()->installExtension($info, dirname($this->mapper->keyToPath($info->key)));
     $this->callHook($info, 'install');
     $this->callHook($info, 'enable');
   }


### PR DESCRIPTION
Overview
----------------------------------------

Extensions may define `<classloader>` rules, such as:

```xml
  <classloader>
    <psr0 prefix="CRM_" path="" />
    <psr4 prefix="Civi\" path="Civi"/>
  </classloader>
```

Any classloaders should take effect promptly during installation, to allow code like this:

```php
function whizbang_civicrm_install() {
  \Civi\Whizbang\Setup::doStuff();
  \CRM_Whizbang_Setup::doMoreStuff();
}
```

For a more complete example, see: https://gist.github.com/totten/02e6e15c8a50aaca929b2206f2492de4

This is an extract from #20090.

Before
----------------------------------------

Classloaders are not available during installation.

The example doesn't work -- because `hook_civicrm_install` fires before `./Civi` has been added to the classloader.

```
[bknix-min:~/bknix/build/dmaster/web/sites/all/modules/civicrm] cv en whizbang
Enabling extension "whizbang"


  [Symfony\Component\Debug\Exception\FatalThrowableError]
  Class 'Civi\Whizbang\Setup' not found


ext:enable [-r|--refresh] [--ignore-missing] [--level LEVEL] [-t|--test] [-U|--user USER] [--] [<key-or-name>]...
```

After
----------------------------------------

The classloader is updated before running install logic.

The example works:

```
[bknix-min:~/bknix/build/dmaster/web/sites/all/modules/civicrm/ext/whizbang] cv en whizbang
Enabling extension "whizbang"
Hello from /Users/totten/bknix/build/dmaster/web/sites/all/modules/civicrm/ext/whizbang/Civi/Whizbang/Setup.php@7 circa 2021-04-17 04:47:13
Hello from /Users/totten/bknix/build/dmaster/web/sites/all/modules/civicrm/ext/whizbang/CRM/Whizbang/Setup.php@6 circa 2021-04-17 04:47:13
```

Technical Details
----------------------------------------

In theory, `CRM_Extension_ClassLoader` has a property `$this->loader` which (purported to) track the real/live loader. We need access to `$this->loader` to register extra classloading rules. Alas,`$this->loader` was `null`. So the patch fixes that.