### PR TITLE
dev/core#1452 Put text inside label tags for recurring contribution selection

### DIFF
--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -741,7 +741,6 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
 
     $unitVals = explode(CRM_Core_DAO::VALUE_SEPARATOR, $frUnits);
 
-
     // FIXME: Ideally we should freeze select box if there is only
     // one option but looks there is some problem /w QF freeze.
     //if ( count( $units ) == 1 ) {
@@ -764,7 +763,8 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
       if (!empty($form->_values['is_recur_interval']) || $className == 'CRM_Contribute_Form_Contribution') {
         $unit .= "(s)";
         $form->assign('frequency_unit', $unit);
-      } else {
+      }
+      else {
         $is_recur_label = ts('I want to contribute this amount every %1',
           [1 => $unit]
         );

--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -753,7 +753,6 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
     $form->addRule('installments', ts('Number of installments must be a whole number.'), 'integer');
 
     $is_recur_label = ts('I want to contribute this amount every');
-    $unit_label = ts('Every');
 
     // CRM 10860, display text instead of a dropdown if there's only 1 frequency unit
     if (count($unitVals) == 1) {

--- a/templates/CRM/Contribute/Form/Contribution/Main.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Main.tpl
@@ -145,14 +145,16 @@
         <div class="crm-public-form-item crm-section {$form.is_recur.name}-section">
           <div class="label">&nbsp;</div>
           <div class="content">
-            {$form.is_recur.html} {$form.is_recur.label} {ts}every{/ts}
+            {$form.is_recur.html} {$form.is_recur.label}
             {if $is_recur_interval}
               {$form.frequency_interval.html}
             {/if}
-            {if $one_frequency_unit}
-              {$frequency_unit}
-            {else}
-              {$form.frequency_unit.html}
+            {if !$all_text_recur}
+              {if $one_frequency_unit}
+                {$form.frequency_interval.label}
+              {else}
+                {$form.frequency_unit.html}
+              {/if}
             {/if}
             {if $is_recur_installments}
               <span id="recur_installments_num">


### PR DESCRIPTION
Before: Part of text for recurring contributions selection on contribution page was outside label tags, making it impossible to style labels.

After: All text now inside label tags except for the "for" when offering instalments. This allows styling.

Once I got into this, it became clear that it was quite messy to do this as I intended. I'm not sure this is the best approach, so I'm putting up this pull request as is to see if folks have a better idea how to tackle this or support this ugly approach. I think I have maintained translatability here, but will need to test that further before merging. Will also see if I can get the "for" inside tags as well.
