### PR TITLE
dev/core#2100 Improve A/B test report page and API Mailing stats

### DIFF
--- a/CRM/Mailing/Event/BAO/Bounce.php
+++ b/CRM/Mailing/Event/BAO/Bounce.php
@@ -91,15 +91,13 @@ class CRM_Mailing_Event_BAO_Bounce extends CRM_Mailing_Event_DAO_Bounce {
    *   ID of the mailing.
    * @param int $job_id
    *   Optional ID of a job to filter on.
-   * @param bool $is_distinct
-   *   Group by queue ID?.
    *
    * @param string|null $toDate
    *
    * @return int
    *   Number of rows in result set
    */
-  public static function getTotalCount($mailing_id, $job_id = NULL, $is_distinct = FALSE, $toDate = NULL) {
+  public static function getTotalCount($mailing_id, $job_id = NULL, $toDate = NULL) {
     $dao = new CRM_Core_DAO();
 
     $bounce = self::getTableName();
@@ -124,10 +122,6 @@ class CRM_Mailing_Event_BAO_Bounce extends CRM_Mailing_Event_DAO_Bounce {
 
     if (!empty($job_id)) {
       $query .= " AND $job.id = " . CRM_Utils_Type::escape($job_id, 'Integer');
-    }
-
-    if ($is_distinct) {
-      $query .= " GROUP BY $queue.id ";
     }
 
     // query was missing

--- a/CRM/Mailing/Event/BAO/Delivered.php
+++ b/CRM/Mailing/Event/BAO/Delivered.php
@@ -68,14 +68,12 @@ class CRM_Mailing_Event_BAO_Delivered extends CRM_Mailing_Event_DAO_Delivered {
    *   ID of the mailing.
    * @param int $job_id
    *   Optional ID of a job to filter on.
-   * @param bool $is_distinct
-   *   Group by queue ID?.
    * @param string $toDate
    *
    * @return int
    *   Number of rows in result set
    */
-  public static function getTotalCount($mailing_id, $job_id = NULL, $is_distinct = FALSE, $toDate = NULL) {
+  public static function getTotalCount($mailing_id, $job_id = NULL, $toDate = NULL) {
     $dao = new CRM_Core_DAO();
 
     $delivered = self::getTableName();
@@ -105,10 +103,6 @@ class CRM_Mailing_Event_BAO_Delivered extends CRM_Mailing_Event_DAO_Delivered {
 
     if (!empty($job_id)) {
       $query .= " AND $job.id = " . CRM_Utils_Type::escape($job_id, 'Integer');
-    }
-
-    if ($is_distinct) {
-      $query .= " GROUP BY $queue.id ";
     }
 
     // query was missing
@@ -182,10 +176,6 @@ class CRM_Mailing_Event_BAO_Delivered extends CRM_Mailing_Event_DAO_Delivered {
 
     if (!empty($job_id)) {
       $query .= " AND $job.id = " . CRM_Utils_Type::escape($job_id, 'Integer');
-    }
-
-    if ($is_distinct) {
-      $query .= " GROUP BY $queue.id, $delivered.id";
     }
 
     $orderBy = "sort_name ASC, {$delivered}.time_stamp DESC";

--- a/ang/crmMailing/services.js
+++ b/ang/crmMailing/services.js
@@ -481,15 +481,15 @@
 
   angular.module('crmMailing').factory('crmMailingStats', function (crmApi, crmLegacy) {
     var statTypes = [
-      // {name: 'Recipients', title: ts('Intended Recipients'),   searchFilter: '',                           eventsFilter: '&event=queue', reportType: 'detail', reportFilter: ''},
-      {name: 'Delivered',     title: ts('Successful Deliveries'), searchFilter: '&mailing_delivery_status=Y', eventsFilter: '&event=delivered', reportType: 'detail', reportFilter: '&delivery_status_value=successful'},
-      {name: 'Opened',        title: ts('Tracked Opens'),         searchFilter: '&mailing_open_status=Y',     eventsFilter: '&event=opened', reportType: 'opened', reportFilter: ''},
-      {name: 'Unique Clicks', title: ts('Click-throughs'),        searchFilter: '&mailing_click_status=Y',    eventsFilter: '&event=click&distinct=1', reportType: 'clicks', reportFilter: ''},
-      // {name: 'Forward',    title: ts('Forwards'),              searchFilter: '&mailing_forward=1',         eventsFilter: '&event=forward', reportType: 'detail', reportFilter: '&is_forwarded_value=1'},
-      // {name: 'Replies',    title: ts('Replies'),               searchFilter: '&mailing_reply_status=Y',    eventsFilter: '&event=reply', reportType: 'detail', reportFilter: '&is_replied_value=1'},
-      {name: 'Bounces',       title: ts('Bounces'),               searchFilter: '&mailing_delivery_status=N', eventsFilter: '&event=bounce', reportType: 'bounce', reportFilter: ''},
-      {name: 'Unsubscribers', title: ts('Unsubscribes'),          searchFilter: '&mailing_unsubscribe=1',     eventsFilter: '&event=unsubscribe', reportType: 'detail', reportFilter: '&is_unsubscribed_value=1'},
-      // {name: 'OptOuts',    title: ts('Opt-Outs'),              searchFilter: '&mailing_optout=1',          eventsFilter: '&event=optout', reportType: 'detail', reportFilter: ''}
+      {name: 'Recipients',    title: ts('Intended Recipients'),     searchFilter: '',                           eventsFilter: '&event=queue', reportType: 'detail', reportFilter: ''},
+      {name: 'Delivered',     title: ts('Successful Deliveries'),   searchFilter: '&mailing_delivery_status=Y', eventsFilter: '&event=delivered', reportType: 'detail', reportFilter: '&delivery_status_value=successful'},
+      {name: 'Opened',        title: ts('Unique Opens'),           searchFilter: '&mailing_open_status=Y',     eventsFilter: '&event=opened', reportType: 'opened', reportFilter: ''},
+      {name: 'Unique Clicks', title: ts('Unique Clicks'),          searchFilter: '&mailing_click_status=Y',    eventsFilter: '&event=click&distinct=1', reportType: 'clicks', reportFilter: ''},
+      // {name: 'Forward',    title: ts('Forwards'),                searchFilter: '&mailing_forward=1',         eventsFilter: '&event=forward', reportType: 'detail', reportFilter: '&is_forwarded_value=1'},
+      // {name: 'Replies',    title: ts('Replies'),                 searchFilter: '&mailing_reply_status=Y',    eventsFilter: '&event=reply', reportType: 'detail', reportFilter: '&is_replied_value=1'},
+      {name: 'Bounces',       title: ts('Bounces'),                 searchFilter: '&mailing_delivery_status=N', eventsFilter: '&event=bounce', reportType: 'bounce', reportFilter: ''},
+      {name: 'Unsubscribers', title: ts('Unsubscribes & Opt-outs'), searchFilter: '&mailing_unsubscribe=1',     eventsFilter: '&event=unsubscribe', reportType: 'detail', reportFilter: '&is_unsubscribed_value=1'},
+      // {name: 'OptOuts',    title: ts('Opt-Outs'),                searchFilter: '&mailing_optout=1',          eventsFilter: '&event=optout', reportType: 'detail', reportFilter: ''}
     ];
 
     return {
@@ -507,7 +507,7 @@
       getStats: function(mailingIds) {
         var params = {};
         angular.forEach(mailingIds, function(mailingId, name) {
-          params[name] = ['Mailing', 'stats', {mailing_id: mailingId, is_distinct: 0}];
+          params[name] = ['Mailing', 'stats', {mailing_id: mailingId, is_distinct: 1}];
         });
         return crmApi(params).then(function(result) {
           var stats = {};

--- a/ang/crmMailingAB/EditCtrl/report.html
+++ b/ang/crmMailingAB/EditCtrl/report.html
@@ -78,7 +78,7 @@
           class="crm-hover-button action-item"
           ng-href="{{statUrl(am.mailing, statType, 'events')}}"
           title="{{ts('Browse events of type \'%1\'', {1: statType.title})}}"
-          >{{stats[am.name][statType.name] || ts('n/a')}} </a> {{stats[am.name][rateStats[statType.name]] || ' '}}
+          >{{stats[am.name][statType.name] || 0}} </a> {{stats[am.name][rateStats[statType.name]] || ' '}}
         <a
           class="crm-hover-button action-item"
           ng-href="{{statUrl(am.mailing, statType, 'report')}}"

--- a/api/v3/Mailing.php
+++ b/api/v3/Mailing.php
@@ -738,17 +738,23 @@ function civicrm_api3_mailing_stats($params) {
   if (empty($params['job_id'])) {
     $params['job_id'] = NULL;
   }
-  foreach (['Delivered', 'Bounces', 'Unsubscribers', 'Unique Clicks', 'Opened'] as $detail) {
+  foreach (['Recipients', 'Delivered', 'Bounces', 'Unsubscribers', 'Unique Clicks', 'Opened'] as $detail) {
     switch ($detail) {
+      case 'Recipients':
+        $stats[$params['mailing_id']] += [
+          $detail => CRM_Mailing_Event_BAO_Queue::getTotalCount($params['mailing_id'], $params['job_id']),
+        ];
+        break;
+
       case 'Delivered':
         $stats[$params['mailing_id']] += [
-          $detail => CRM_Mailing_Event_BAO_Delivered::getTotalCount($params['mailing_id'], $params['job_id'], (bool) $params['is_distinct'], $params['date']),
+          $detail => CRM_Mailing_Event_BAO_Delivered::getTotalCount($params['mailing_id'], $params['job_id'], $params['date']),
         ];
         break;
 
       case 'Bounces':
         $stats[$params['mailing_id']] += [
-          $detail => CRM_Mailing_Event_BAO_Bounce::getTotalCount($params['mailing_id'], $params['job_id'], (bool) $params['is_distinct'], $params['date']),
+          $detail => CRM_Mailing_Event_BAO_Bounce::getTotalCount($params['mailing_id'], $params['job_id'], $params['date']),
         ];
         break;
 

--- a/tests/phpunit/api/v3/MailingTest.php
+++ b/tests/phpunit/api/v3/MailingTest.php
@@ -776,6 +776,7 @@ SELECT event_queue_id, time_stamp FROM {$temporaryTableName}";
     $result = $this->callAPISuccess('mailing', 'stats', ['mailing_id' => $mail['id']]);
     $expectedResult = [
       //since among 100 mails 20 has been bounced
+      'Recipients' => 100,
       'Delivered' => 80,
       'Bounces' => 20,
       'Opened' => 20,


### PR DESCRIPTION
Before: A/B test report pages were confusing and incorrect because API Mailing stats were incomplete or incorrect.
1. Showed Tracked Opens as the total number of opens.
2. Showed Clicks-throughs as the total number of clicks.
3. Showed Unsubscribes as the total number of unsubscribes and opt-outs.
4. Intended Recipients not shown and not included in API Mailing stats.
5. Showed n/a for some stats that had 0 results.

After: A/B test report pages are more accurate and API is more complete and correct.
1. Show Unique Opens as the total number of unique opens (i.e. the number of recipients opening the email).
2. Show Unique Clicks as the number of unique clicks (i.e. the number of recipients clicking one or more links in the email).
3. Show Unsubscribes & Opt-outs as the number of unique unsubscribes and opt-outs (i.e. the number of recipients who either unsubscribed or opted out).
4. Intended Recipients shown and included in API mailing stats.
5. Shows 0 for all stats with no results (or that aren't applicable).

This makes changes to the API, giving a different results for mailing - stats with distinct:1. I can't see this would be used elsewhere, but I hope someone with more experienced can chime in.

I'm willing to do some more work on this to improve the report page, but need some guidance on what the vision is in the long term. There's the normal mailing report and then there's this A/B mailing report that uses the API. It would make sense to use only one of these only in the future. Does that mean fixing up the A/B /API version and using it for all mailings? Does anyone have thoughts on the way forward here?

API Mailing stats still doesn't return forwards, replies, or opt out and unsub separately, but I can add them. The normal mailing only gives total clicks and not unique, so it might also make sense to add total clicks to the A/B version through a Mailing stats call with distinct:0 (so it would list both the number of contacts who clicked and the number of links clicked). If this was used for the single mailing report, that would be an improvement as that page currently reports click throughs and a click through rate as total clicks / delivered, while this is usually (contacts who clicked at least one link) / delivered.

If we plan to use this for normal mailing reports as well, I could do a little work to make the format of that page a little easier to read.

There is also a time zone issue that results in results not showing until N hours later than they should if server time is UTC - N. I think what's happening is that the time of clicks, opens, etc are being recorded as UTC. However, the API is using the current time in the server time zone here for the query, with the result that if you are in GMT -6, for instance, the query won't return any results from the last six hours because those are in the future relative to server time. What's the solution here? My first thought is do we need to pass the time at all? Perhaps just leaving the time out would give us the full results, but I haven't tried this yet. This has been solved on the normal mailing report page, so I can look there, but welcome any suggestions if someone knows the answer here.

EDIT: Fixed and updated wording of Click-throughs, Unique Clicks in 1 & 2 above
