### PR TITLE
dev/core#2512 Set membership's status properly when recording the payment

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4384,11 +4384,8 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
         'membership_activity_status' => 'Completed',
       ];
 
-      $currentMembership = CRM_Member_BAO_Membership::getContactMembership($membershipParams['contact_id'],
-        $membershipParams['membership_type_id'],
-        $membershipParams['is_test'],
-        $membershipParams['id']
-      );
+      $currentMembership = [];
+      CRM_Member_BAO_Membership::retrieve($membershipParams, $currentMembership);
 
       // CRM-8141 update the membership type with the value recorded in log when membership created/renewed
       // this picks up membership type changes during renewals
@@ -4406,7 +4403,8 @@ LIMIT 1;";
           $membershipParams['membership_type_id'] = $dao->membership_type_id;
         }
       }
-      if (empty($membership['end_date']) || (int) $membership['status_id'] !== CRM_Core_PseudoConstant::getKey('CRM_Member_BAO_Membership', 'status_id', 'Pending')) {
+      $pendingMembershipStatusID = CRM_Core_PseudoConstant::getKey('CRM_Member_BAO_Membership', 'status_id', 'Pending');
+      if (empty($membership['end_date']) || (int) $membership['status_id'] !== $pendingMembershipStatusID) {
         // Passing num_terms to the api triggers date calculations, but for pending memberships these may be already calculated.
         // sigh - they should  be  consistent but removing the end date check causes test failures & maybe UI too?
         // The api assumes num_terms is a special sauce for 'is_renewal' so we need to not pass it when updating a pending to completed.
@@ -4424,7 +4422,16 @@ LIMIT 1;";
         'start_date',
         'end_date',
       ], NULL);
-      if ($currentMembership) {
+      if ($currentMembership && (int) $currentMembership['status_id'] === $pendingMembershipStatusID) {
+        $currentMembership['join_date'] = $currentMembership['join_date'] ?? NULL;
+        $currentMembership['start_date'] = $currentMembership['start_date'] ?? NULL;
+        $currentMembership['end_date'] = $currentMembership['end_date'] ?? NULL;
+
+        $dates = CRM_Member_BAO_MembershipType::getDatesForMembershipType($membershipParams['membership_type_id'],
+          $currentMembership['join_date'], $currentMembership['start_date'], $currentMembership['end_date']
+        );
+      }
+      else {
         /*
          * Fixed FOR CRM-4433
          * In BAO/Membership.php(renewMembership function), we skip the extend membership date and status

--- a/tests/phpunit/CRM/Contribute/Form/AdditionalPaymentTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/AdditionalPaymentTest.php
@@ -316,6 +316,33 @@ class CRM_Contribute_Form_AdditionalPaymentTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test the Membership status renaming after completing the pending pay later Contribution.
+   *
+   * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
+   */
+  public function testMembershipStatusAfterCompletingPayLaterContributionWithRenamedMembershipStatus() {
+    $this->renameNewMembershipStatus('Fresh');
+    $membership = $this->createContributionAndMembershipOrder();
+    $this->submitPayment(300);
+    $this->callAPISuccessGetSingle('Contribution', ['id' => $this->ids['Contribution'][0]]);
+    $this->callAPISuccessGetSingle('Membership', ['id' => $this->ids['Membership']['order'], 'status_id' => 'Fresh']);
+  }
+
+  /**
+   * @param $membershipStatusName
+   *
+   * @throws \CRM_Core_Exception
+   */
+  private function renameNewMembershipStatus($membershipStatusName) {
+    $params = [
+      'name' => 'New',
+      'api.MembershipStatus.create' => ['name' => $membershipStatusName],
+    ];
+    $this->callAPISuccess('MembershipStatus', 'get', $params);
+  }
+
+  /**
    * @param $contributionId
    *
    * @return array|int


### PR DESCRIPTION
Overview
----------------------------------------
The PR https://github.com/civicrm/civicrm-core/pull/19975 was reverted.

Created this PR to resume the review.

Overview
----------------------------------------
Some Admins will delete the `New` membership status rule and that is possible because CiviCRM allow adding/editing/removing membership status rules.

Before
----------------------------------------
Recording a payment for a pending membership will not work.
![Peek 2021-04-01 21-46](https://user-images.githubusercontent.com/74309109/113690227-d756fc00-96d3-11eb-93d7-2b0b9dda3a14.gif)


After
----------------------------------------
Recording a payment for a pending membership should work.
![Peek 2021-04-01 21-49](https://user-images.githubusercontent.com/74309109/113690261-e2aa2780-96d3-11eb-935a-d5f4d671762a.gif)


Technical Details
----------------------------------------

The main issue is `$calcStatus` at [Contribution.php#L4863](https://github.com/civicrm/civicrm-core/blob/5.35.1/CRM/Contribute/BAO/Contribution.php#L4863)

```php
      //get the status for membership.
      $calcStatus = CRM_Member_BAO_MembershipStatus::getMembershipStatusByDate($dates['start_date'],
        $dates['end_date'],
        $dates['join_date'],
        'now',
        TRUE,
        $membershipParams['membership_type_id'],
        $membershipParams
      );

      unset($dates['end_date']);
      $membershipParams['status_id'] = CRM_Utils_Array::value('id', $calcStatus, 'New');
```

will be an empty array because the keys  `start_date`,  `end_date` and `join_date` of `$dates` array are `Null`.


I used `CRM_Member_BAO_Membership::retrieve` instead of `CRM_Member_BAO_Membership::getContactMembership` because the second will not get the pending membership and used `CRM_Member_BAO_MembershipType::getDatesForMembershipType` to populate the `$dates` array.


Issue: https://lab.civicrm.org/dev/core/-/issues/2512