### PR TITLE
Make final mailing from A/B test same template type and options as A/B so it can be copied

### DIFF
--- a/api/v3/MailingAB.php
+++ b/api/v3/MailingAB.php
@@ -197,6 +197,8 @@ function _civicrm_api3_mailing_a_b_fill_winner($winner_id, $final_id) {
     'resubscribe_id',
     'unsubscribe_id',
     'template_type',
+    'template_options',
+    'language',
   ];
   $f = CRM_Utils_SQL_Select::from('civicrm_mailing')
     ->where('id = #id', ['id' => $winner_id])

--- a/api/v3/MailingAB.php
+++ b/api/v3/MailingAB.php
@@ -196,6 +196,7 @@ function _civicrm_api3_mailing_a_b_fill_winner($winner_id, $final_id) {
     'reply_id',
     'resubscribe_id',
     'unsubscribe_id',
+    'template_type',
   ];
   $f = CRM_Utils_SQL_Select::from('civicrm_mailing')
     ->where('id = #id', ['id' => $winner_id])


### PR DESCRIPTION
Before: When selecting the final mailing for an A/B test, the template_type and template_options were not copied to the final (C) mailing. The mailing still seemed to work fine, but if you copied the C mailing, the copy was a traditional mailing. Language was also not copied.

After: template_type and template_options are copied to the final mailing, so if a copy is made, it has the same content as the original. Language is also copied for good measure.

I previously submitted [an issue](https://github.com/veda-consulting-company/uk.co.vedaconsulting.mosaico/issues/416) on Mosaico for this.