### PR TITLE
dev/core#2549 Fix undefined index when merging websites

### DIFF
--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -2409,7 +2409,7 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
             ) {
               // Set this value as the default against the 'other' contact value
               $rows["move_location_{$blockName}_{$count}"]['main'] = $mainValueCheck[$blockInfo['displayField']];
-              $rows["move_location_{$blockName}_{$count}"]['main_is_primary'] = $mainValueCheck['is_primary'];
+              $rows["move_location_{$blockName}_{$count}"]['main_is_primary'] = $mainValueCheck['is_primary'] ?? 0;
               $rows["move_location_{$blockName}_{$count}"]['location_entity'] = $blockName;
               $mainContactBlockId = $mainValueCheck['id'];
               break;


### PR DESCRIPTION
Websites do not have 'is_primary', this causes an undefined index error on merge.

To fix this, we default is_primary to 0 if it is not present as a value (NULL).

See https://lab.civicrm.org/dev/core/-/issues/2549 / part 2

Ping @eileenmcnaughton 