### PR TITLE
Save entities created by api v4 to managed

### DIFF
--- a/CRM/Core/ManagedEntities.php
+++ b/CRM/Core/ManagedEntities.php
@@ -245,7 +245,9 @@ class CRM_Core_ManagedEntities {
     $dao->module = $todo['module'];
     $dao->name = $todo['name'];
     $dao->entity_type = $todo['entity'];
-    $dao->entity_id = $result['id'];
+    // A fatal error will result if there is no valid id but if
+    // this is v4 api we might need to access it via ->first().
+    $dao->entity_id = $result['id'] ?? $result->first()['id'];
     $dao->cleanup = $todo['cleanup'] ?? NULL;
     $dao->save();
   }

--- a/api/api.php
+++ b/api/api.php
@@ -16,7 +16,7 @@
  * @param array $params
  *   array to be passed to function
  *
- * @return array|int
+ * @return array|int|Civi\Api4\Generic\Result
  */
 function civicrm_api(string $entity, string $action, array $params) {
   return \Civi::service('civi_api_kernel')->runSafe($entity, $action, $params);


### PR DESCRIPTION



Overview
----------------------------------------
Save entities created by api v4 to managed

Before
----------------------------------------
It is possible to define a v4 api entity in the .mgd.php file but it does not save correctly due to the id retrieval being apiv3 specific

After
----------------------------------------
The id is fetched & will save

Technical Details
----------------------------------------
We are increasingly only adding v4 apis to new entities so we need to be able to save them. Other than this snaffu apiv4 works fine (although the format requires an extra ['values'] level in the params array.

I was a bit surprised that the civicrm_api() wrapper didn't populate ['id'] since I thought that wrapper was intended to provide some compatibility but if it has not been an issue for anything else I don't think it's worth fixing for this

Comments
----------------------------------------
@colemanw @totten 
