### PR TITLE
dev/core#2509 - Remove unnecessary variable to make it easier to extract function that creates action links

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -2620,10 +2620,6 @@ INNER JOIN  civicrm_option_group grp ON (grp.id = option_group_id AND grp.name =
 
         // build links
         $activity['links'] = '';
-        $accessMailingReport = FALSE;
-        if (!empty($values['mailingId'])) {
-          $accessMailingReport = TRUE;
-        }
 
         // Get action links.
 
@@ -2682,7 +2678,7 @@ INNER JOIN  civicrm_option_group grp ON (grp.id = option_group_id AND grp.name =
           $actionLinks = CRM_Activity_Selector_Activity::actionLinks(
             CRM_Utils_Array::value('activity_type_id', $values),
             CRM_Utils_Array::value('source_record_id', $values),
-            $accessMailingReport,
+            !empty($values['mailingId']),
             CRM_Utils_Array::value('activity_id', $values)
           );
           $actionMask = array_sum(array_keys($actionLinks)) & $mask;

--- a/CRM/Activity/Selector/Activity.php
+++ b/CRM/Activity/Selector/Activity.php
@@ -412,15 +412,10 @@ class CRM_Activity_Selector_Activity extends CRM_Core_Selector_Base implements C
         $row['engagement_level'] = CRM_Utils_Array::value($engagementLevel, $engagementLevels, $engagementLevel);
       }
 
-      // CRM-3553
-      $accessMailingReport = FALSE;
-      if (!empty($row['mailingId'])) {
-        $accessMailingReport = TRUE;
-      }
-
       $actionLinks = $this->actionLinks(CRM_Utils_Array::value('activity_type_id', $row),
         CRM_Utils_Array::value('source_record_id', $row),
-        $accessMailingReport,
+        // CRM-3553
+        !empty($row['mailingId']),
         CRM_Utils_Array::value('activity_id', $row),
         $this->_key
       );


### PR DESCRIPTION
Overview
----------------------------------------
My end goal is to pull out the bit that makes the action links to make it reusable. Removing this unnecessary variable makes one less variable to pass around.

Before
----------------------------------------
Same

After
----------------------------------------
Same

Technical Details
----------------------------------------
Variable isn't used elsewhere in the function and value just passed to another function.

Comments
----------------------------------------
