### PR TITLE
Pass the logger channel through as a prefix

### DIFF
--- a/CRM/Core/Error/Log.php
+++ b/CRM/Core/Error/Log.php
@@ -23,6 +23,26 @@ class CRM_Core_Error_Log extends \Psr\Log\AbstractLogger {
   public $map;
 
   /**
+   * The logging channel - this is used as a prefix to distinguish the files.
+   *
+   * @var string
+   */
+  protected $channel;
+
+  /**
+   * Set a prefix for the log file.
+   *
+   * Note this is ignored if the characters are not alphanumeric or _ or -.
+   *
+   * @param string $channel
+   */
+  public function setChannel(string $channel): void {
+    if (CRM_Utils_Rule::alphanumeric($channel)) {
+      $this->channel = $channel;
+    }
+  }
+
+  /**
    * CRM_Core_Error_Log constructor.
    */
   public function __construct() {
@@ -54,7 +74,7 @@ class CRM_Core_Error_Log extends \Psr\Log\AbstractLogger {
       }
       $message .= "\n" . print_r($context, 1);
     }
-    CRM_Core_Error::debug_log_message($message, FALSE, '', $this->map[$level]);
+    CRM_Core_Error::debug_log_message($message, FALSE, $this->channel, $this->map[$level]);
   }
 
 }

--- a/Civi/Core/LogManager.php
+++ b/Civi/Core/LogManager.php
@@ -39,6 +39,9 @@ class LogManager {
       $c = \Civi::container();
       $svc = "log." . $channel;
       $this->channels[$channel] = $c->has($svc) ? $c->get($svc) : $c->get(self::DEFAULT_LOGGER);
+      if ($channel !== 'default' && method_exists($this->channels[$channel], 'setChannel')) {
+        $this->channels[$channel]->setChannel($channel);
+      }
     }
     return $this->channels[$channel];
   }


### PR DESCRIPTION
Overview
----------------------------------------
This builds on the recently added PR #20079
and changes the default behaviour such that if a channel is used, without any other intervention,
it will result in a change to the file name to reflect the channel

Channels are a new feature so this won't affect existing sites but
I think adding the prefix is a thing that people using different channels might
reasonably expect as a helpful default. I kept it such that we ignore anything
beyond a narrow range of characters - we could throw an exception
rather than silently ignore if we prefer

Before
----------------------------------------
Instantiating a logger with a channel logs to the same file as everything else, if a service is not defined

After
----------------------------------------
Instantiating a logger with a channel logs to a file prefixed by the channel name , if a service is not defined.

If the service uses letters that are no alphanumeric or '-' or '_' it will be silently ignored for security

Technical Details
----------------------------------------
@totten I think this adds some incentive to start updating existing calls to have a channel as it will separate them out - there are some existing payment processors that already use a prefix (bypassing the Civi::log() ) 

Comments
----------------------------------------