### PR TITLE
[REF] Fix Security status check urls to work on WordPress

### DIFF
--- a/CRM/Utils/Check/Component/Security.php
+++ b/CRM/Utils/Check/Component/Security.php
@@ -28,6 +28,9 @@ class CRM_Utils_Check_Component_Security extends CRM_Utils_Check_Component {
       case 'Joomla':
         return '/media/';
 
+      case 'WordPress':
+        return '/uploads/';
+
       default:
         return '/files/';
     }


### PR DESCRIPTION
Overview
----------------------------------------
This fixes a bug where by in the status check it tries to user a url for the temporaryUploads and customUploads directory checks that adds /files on the end of the image upload url.

Before
----------------------------------------
Wrong url constructed for the check on temporaryUploads and CustomUploads folders in WordPress
e.g. `/wp-content/uploads/civicrm/persist/contribute/files`

After
----------------------------------------
Correct url for temporary uploads etc
e.g. `/wp-content/uploads/civicrm/custom`

Technical Details
----------------------------------------
Because there is no specific setting for these urls it uses this fileMarker to split up the imageUploadURL into a base url that it then can replace with the target directory e.g. uploads/civicrm/custom here https://github.com/civicrm/civicrm-core/blob/master/CRM/Utils/Check/Component/Security.php#L382 because of fact it was using /files/ instead of /uploads/ it meant that the $heuristicURL here wasn't checking either the uploadDIr or customFileUploadDir correctly so was potentially giving off a false negative on WordPress (potentially) https://github.com/civicrm/civicrm-core/blob/master/CRM/Utils/Check/Component/Security.php#L119.

I am concerned that this may not work well for those that still have the file uploads for civicrm within the plugin directory but it might be ok

ping @kcristiano @haystack @totten 