### PR TITLE
Return NULL if variable to convert isoToMysql is null

### DIFF
--- a/CRM/Utils/Date.php
+++ b/CRM/Utils/Date.php
@@ -505,7 +505,7 @@ class CRM_Utils_Date {
    *   date/datetime in MySQL format
    */
   public static function isoToMysql($iso) {
-    if (CRM_Utils_System::isNull($iso)) {
+    if (empty($iso)) {
       return NULL;
     }
     $dropArray = ['-' => '', ':' => '', ' ' => ''];

--- a/CRM/Utils/Date.php
+++ b/CRM/Utils/Date.php
@@ -505,6 +505,9 @@ class CRM_Utils_Date {
    *   date/datetime in MySQL format
    */
   public static function isoToMysql($iso) {
+    if (CRM_Utils_System::isNull($iso)) {
+      return NULL;
+    }
     $dropArray = ['-' => '', ':' => '', ' ' => ''];
     return strtr($iso, $dropArray);
   }


### PR DESCRIPTION
Overview
----------------------------------------
When copying a event or creating new from template having schedule reminder, throws DB:error

Incorrect datetime value: '0' for column civicrm_action_schedule.effective_start_date at row 1

Before
----------------------------------------
When copying a event or creating new from template having schedule reminder, throws DB:error

After
----------------------------------------
Event created with schedule reminder 

Technical Details
----------------------------------------
When event is copied, the CRM_Event_BAO_Event::copy() uses DAO copyGeneric() function to copy Action Schedule data linked to event. When a schedule reminder has effective_start_date set to NULL in database the [CRM_Utils_Date::isoToMysql()](https://github.com/civicrm/civicrm-core/blob/master/CRM/Core/DAO.php#L1816) returns empty string instead of NULL which i guess causes db package to set the value to 0. I am not sure if i need fix the code in copyGeneric() function to not call isoToMysql() if the value is NULL, but thought this might occur of any date field across the code.
