### PR TITLE
dev/core#2509 - Remove duplicate setting of activity subject field and replace a few CRM_Utils_Array::value

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -2628,8 +2628,6 @@ INNER JOIN  civicrm_option_group grp ON (grp.id = option_group_id AND grp.name =
           // This activity belongs to a case.
           $caseId = current($values['case_id']);
 
-          $activity['subject'] = $values['subject'];
-
           // Get the view and edit (update) links:
           $caseActionLinks =
             $actionLinks = array_intersect_key(
@@ -2676,10 +2674,10 @@ INNER JOIN  civicrm_option_group grp ON (grp.id = option_group_id AND grp.name =
         else {
           // Non-case activity
           $actionLinks = CRM_Activity_Selector_Activity::actionLinks(
-            CRM_Utils_Array::value('activity_type_id', $values),
-            CRM_Utils_Array::value('source_record_id', $values),
+            $values['activity_type_id'] ?? NULL,
+            $values['source_record_id'] ?? NULL,
             !empty($values['mailingId']),
-            CRM_Utils_Array::value('activity_id', $values)
+            $values['activity_id'] ?? NULL
           );
           $actionMask = array_sum(array_keys($actionLinks)) & $mask;
 


### PR DESCRIPTION
Overview
----------------------------------------
Similar to https://github.com/civicrm/civicrm-core/pull/20106 my end goal is to pull out the bit that makes the action links to make it reusable. This smaller simplification will make it easier to see later that all I'll be doing is moving some code into its own function.

Before
----------------------------------------
Subject is set to the same thing it's already set to on line 2521 near the start of the loop.
Some use of CRM_Utils_Array::value.

After
----------------------------------------
No double-setting of subject.
CRM_Utils_Array::value replaced.

Technical Details
----------------------------------------


Comments
----------------------------------------
You can verify subject is already set by:

1. Create a case.
2. Fill in some subjects on the autopopulated activities to make it obvious what the subject is, otherwise they'll be blank in step 4 which will be disconcerting.
3. Under Admin - CiviCase - CiviCase settings, turn on the option for "Include case activities in general activity views".
4. Visit the client contact's activity tab. The activities from the case you created will show the subject.
