### PR TITLE
Do not add tracking to internal anchor URLs

### DIFF
--- a/CRM/Mailing/BAO/TrackableURL.php
+++ b/CRM/Mailing/BAO/TrackableURL.php
@@ -54,10 +54,11 @@ class CRM_Mailing_BAO_TrackableURL extends CRM_Mailing_DAO_TrackableURL {
     }
 
     // hack for basic CRM-1014 and CRM-1151 and CRM-3492 compliance:
-    // let's not replace possible image URLs and CiviMail ones
+    // let's not replace possible image URLs, CiviMail URLs or internal anchor URLs
     if (preg_match('/\.(png|jpg|jpeg|gif|css)[\'"]?$/i', $url)
       or substr_count($url, 'civicrm/extern/')
       or substr_count($url, 'civicrm/mailing/')
+      or ($url[0] === '#')
     ) {
       // let's not cache these, so they don't get &qid= appended to them
       return $url;


### PR DESCRIPTION
Before
----------------------------------------
Tracking is added to internal anchor links, breaking them.

After
----------------------------------------
Internal anchor links do not have tracking added and so they work in emails (where the email client supports them).

Tested and works in both traditional and Mosaico mailings. Based on @totten's suggestion [here](https://github.com/civicrm/org.civicrm.flexmailer/pull/51).
