### PR TITLE
Extensions - Setup <classloader> during "enable" and "uninstall"

### DIFF
--- a/CRM/Extension/Manager/Module.php
+++ b/CRM/Extension/Manager/Module.php
@@ -29,7 +29,7 @@ class CRM_Extension_Manager_Module extends CRM_Extension_Manager_Base {
    * @param CRM_Extension_Info $info
    */
   public function onPreInstall(CRM_Extension_Info $info) {
-    CRM_Extension_System::singleton()->getClassLoader()->installExtension($info, dirname($this->mapper->keyToPath($info->key)));
+    $this->registerClassloader($info);
     $this->callHook($info, 'install');
     $this->callHook($info, 'enable');
   }
@@ -71,6 +71,7 @@ class CRM_Extension_Manager_Module extends CRM_Extension_Manager_Base {
    * @return bool
    */
   public function onPreUninstall(CRM_Extension_Info $info) {
+    $this->registerClassloader($info);
     $this->callHook($info, 'uninstall');
     return TRUE;
   }
@@ -92,7 +93,15 @@ class CRM_Extension_Manager_Module extends CRM_Extension_Manager_Base {
    * @param CRM_Extension_Info $info
    */
   public function onPreEnable(CRM_Extension_Info $info) {
+    $this->registerClassloader($info);
     $this->callHook($info, 'enable');
+  }
+
+  /**
+   * @param CRM_Extension_Info $info
+   */
+  private function registerClassloader($info) {
+    CRM_Extension_System::singleton()->getClassLoader()->installExtension($info, dirname($this->mapper->keyToPath($info->key)));
   }
 
 }

--- a/CRM/Extension/Manager/Module.php
+++ b/CRM/Extension/Manager/Module.php
@@ -101,7 +101,16 @@ class CRM_Extension_Manager_Module extends CRM_Extension_Manager_Base {
    * @param CRM_Extension_Info $info
    */
   private function registerClassloader($info) {
-    CRM_Extension_System::singleton()->getClassLoader()->installExtension($info, dirname($this->mapper->keyToPath($info->key)));
+    try {
+      $extPath = dirname($this->mapper->keyToPath($info->key));
+    }
+    catch (CRM_Extension_Exception_MissingException $e) {
+      // This could happen if there was a dirty removal (i.e. deleting ext-code before uninstalling).
+      return;
+    }
+
+    $classloader = CRM_Extension_System::singleton()->getClassLoader();
+    $classloader->installExtension($info, $extPath);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------

The builds on the theme of PR #20091. Recall from the previous PR that an extension  might declare classloaders:

```xml
<classloader>
  <psr0 prefix="CRM_" path="" />
  <psr4 prefix="Civi\" path="Civi"/>
</classloader>
```

and then use them for installation:

```php
function whizbang_civicrm_install() {
  \Civi\Whizbang\Setup::doInstall();
  \CRM_Whizbang_Setup::doInstall();
}
```

This PR extends classloading support to other stages of the lifecycle:

```php
function whizbang_civicrm_enable() {
  \Civi\Whizbang\Setup::doEnable();
  \CRM_Whizbang_Setup::doEnable();
}

function whizbang_civicrm_disable() {
  \Civi\Whizbang\Setup::doDisable();
  \CRM_Whizbang_Setup::doDisable();
}

function whizbang_civicrm_uninstall() {
  \Civi\Whizbang\Setup::doUninstall();
  \CRM_Whizbang_Setup::doUninstall();
}
```

For a more complete example, see https://gist.github.com/totten/4864a530b078c6ea86b52d7b578d7c16

Before
----------------------------------------

Some of these workflows fail:

* :heavy_check_mark:  Enable WF: `cv en whizbang`
* :red_circle:  Re-enable WF: `cv en whizbang && cv dis whizbang && cv en whizbang`
* :red_circle:  Long uninstall WF: `cv en whizbang && cv dis whizbang && cv ext:uninstall whizbang`
* :heavy_check_mark:  Quick uninstall WF: `cv en whizbang && cv ext:uninstall whizbang`
 
After
----------------------------------------

All of these workflows pass:

* :heavy_check_mark:  Enable WF: `cv en whizbang`
* :heavy_check_mark:  Re-enable WF: `cv en whizbang && cv dis whizbang && cv en whizbang`
* :heavy_check_mark:  Long uninstall WF: `cv en whizbang && cv dis whizbang && cv ext:uninstall whizbang`
* :heavy_check_mark:  Quick uninstall WF: `cv en whizbang && cv ext:uninstall whizbang`

Technical Details
----------------------------------------

Why is this necessary? Recall that (for a typical admin) the lifecycle of an extension is:

1. Enable extension `$x`
2. Disable extension `$x`
3. Either:
   * (a) Re-enable extension `$x`
   * (b) Uninstall extension `$x`

Step `#2` disables the classloader for purposes of regular page-loading. However, when you get to step `#3a` or `#3b`, then you need the classloader again. Of course, it would be premature to fully activate the extension (*e.g. do not fire `hook_civicrm_config` on a disabled module*). But you should have access to the classes.
