### PR TITLE
SearchKit - Fix display of contact reference fields (single-value)

### DIFF
--- a/tests/phpunit/api/v4/Action/CustomJoinTest.php
+++ b/tests/phpunit/api/v4/Action/CustomJoinTest.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+
+namespace api\v4\Action;
+
+use Civi\Api4\Contact;
+use Civi\Api4\CustomField;
+use Civi\Api4\CustomGroup;
+
+/**
+ * @group headless
+ */
+class CustomJoinTest extends BaseCustomValueTest {
+
+  public function testGetWithJoin() {
+
+    $customGroup = CustomGroup::create(FALSE)
+      ->addValue('name', 'MyContactRef')
+      ->addValue('extends', 'Individual')
+      ->execute()
+      ->first();
+
+    CustomField::create(FALSE)
+      ->addValue('label', 'FavPerson')
+      ->addValue('custom_group_id', $customGroup['id'])
+      ->addValue('html_type', 'Autocomplete-Select')
+      ->addValue('data_type', 'ContactReference')
+      ->execute();
+
+    $favPersonId = Contact::create(FALSE)
+      ->addValue('first_name', 'Favorite')
+      ->addValue('last_name', 'Person')
+      ->addValue('contact_type', 'Individual')
+      ->execute()
+      ->first()['id'];
+
+    $contactId = Contact::create(FALSE)
+      ->addValue('first_name', 'Mya')
+      ->addValue('last_name', 'Tester')
+      ->addValue('contact_type', 'Individual')
+      ->addValue('MyContactRef.FavPerson', $favPersonId)
+      ->execute()
+      ->first()['id'];
+
+    $contact = Contact::get(FALSE)
+      ->addSelect('display_name')
+      ->addSelect('MyContactRef.FavPerson.first_name')
+      ->addSelect('MyContactRef.FavPerson.last_name')
+      ->addWhere('id', '=', $contactId)
+      ->execute()
+      ->first();
+
+    $this->assertEquals('Favorite', $contact['MyContactRef.FavPerson.first_name']);
+    $this->assertEquals('Person', $contact['MyContactRef.FavPerson.last_name']);
+  }
+
+}

--- a/tests/phpunit/api/v4/AllTests.php
+++ b/tests/phpunit/api/v4/AllTests.php
@@ -16,37 +16,6 @@
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
 
-// vim: set si ai expandtab tabstop=4 shiftwidth=4 softtabstop=4:
-
-/**
- *  File for the api_v4_AllTests class
- *
- *  (PHP 5)
- *
- * @author Walt Haas <walt@dharmatech.org> (801) 534-1262
- * @copyright Copyright CiviCRM LLC (C) 2009
- * @license   http://www.fsf.org/licensing/licenses/agpl-3.0.html
- *              GNU Affero General Public License version 3
- * @version   $Id: AllTests.php 40328 2012-05-11 23:06:13Z allen $
- * @package   CiviCRM
- *
- *   This file is part of CiviCRM
- *
- *   CiviCRM is free software; you can redistribute it and/or
- *   modify it under the terms of the GNU Affero General Public License
- *   as published by the Free Software Foundation; either version 3 of
- *   the License, or (at your option) any later version.
- *
- *   CiviCRM is distributed in the hope that it will be useful,
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *   GNU Affero General Public License for more details.
- *
- *   You should have received a copy of the GNU Affero General Public
- *   License along with this program.  If not, see
- *   <http://www.gnu.org/licenses/>.
- */
-
 /**
  *  Class containing the APIv4 test suite
  *
@@ -73,13 +42,3 @@ class api_v4_AllTests extends CiviTestSuite {
   }
 
 }
-// class AllTests
-
-// -- set Emacs parameters --
-// Local variables:
-// mode: php;
-// tab-width: 4
-// c-basic-offset: 4
-// c-hanging-comment-ender-p: nil
-// indent-tabs-mode: nil
-// End:


### PR DESCRIPTION
Overview
----------------------------------------
This fixes the display of contact reference fields, giving feature parity with other FK fields. Both ID and Display Name are shown as available columns.

Ref https://lab.civicrm.org/dev/core/-/issues/2553

Before
----------------------------------------
ContactRef Display Name column shows error in header and no data.

After
----------------------------------------
Display name works correctly.

Comments
----------------------------------------
This does not address the more difficult question of how to join multi-valued contact reference fields with contact display names.