### PR TITLE
Switch l10n.js from ajax callback to assetBuilder

### DIFF
--- a/CRM/Admin/Form/Preferences.php
+++ b/CRM/Admin/Form/Preferences.php
@@ -126,9 +126,6 @@ class CRM_Admin_Form_Preferences extends CRM_Core_Form {
       CRM_Core_Session::setStatus($e->getMessage(), ts('Save Failed'), 'error');
     }
 
-    // Update any settings stored in dynamic js
-    CRM_Core_Resources::singleton()->resetCacheCode();
-
     CRM_Core_Session::setStatus(ts('Your changes have been saved.'), ts('Saved'), 'success');
   }
 

--- a/CRM/Admin/Form/PreferencesDate.php
+++ b/CRM/Admin/Form/PreferencesDate.php
@@ -109,9 +109,6 @@ class CRM_Admin_Form_PreferencesDate extends CRM_Admin_Form {
 
     $dao->save();
 
-    // Update dynamic js to reflect new date settings
-    CRM_Core_Resources::singleton()->resetCacheCode();
-
     CRM_Core_Session::setStatus(ts("The date type '%1' has been saved.",
       [1 => $params['name']]
     ), ts('Saved'), 'success');

--- a/CRM/Core/Config.php
+++ b/CRM/Core/Config.php
@@ -425,18 +425,6 @@ class CRM_Core_Config extends CRM_Core_Config_MagicMerge {
       return TRUE;
     }
 
-    if ($path && preg_match('/^civicrm\/ajax\/l10n-js/', $path)
-      && !empty($_SERVER['HTTP_REFERER'])
-    ) {
-      $ref = parse_url($_SERVER['HTTP_REFERER']);
-      if (
-        (!empty($ref['path']) && preg_match('/civicrm\/upgrade/', $ref['path'])) ||
-        (!empty($ref['query']) && preg_match('/civicrm\/upgrade/', urldecode($ref['query'])))
-      ) {
-        return TRUE;
-      }
-    }
-
     return FALSE;
   }
 

--- a/CRM/Core/Resources.php
+++ b/CRM/Core/Resources.php
@@ -420,22 +420,18 @@ class CRM_Core_Resources implements CRM_Core_Resources_CollectionAdderInterface 
   /**
    * Create dynamic script for localizing js widgets.
    */
-  public static function outputLocalizationJS() {
-    CRM_Core_Page_AJAX::setJsHeaders();
-    $config = CRM_Core_Config::singleton();
-    $vars = [
-      'moneyFormat' => json_encode(CRM_Utils_Money::format(1234.56)),
-      'contactSearch' => json_encode($config->includeEmailInName ? ts('Search by name/email or id...') : ts('Search by name or id...')),
+  public static function renderL10nJs(GenericHookEvent $e) {
+    if ($e->asset !== 'crm-l10n.js') {
+      return;
+    }
+    $e->mimeType = 'application/javascript';
+    $params = $e->params;
+    $params += [
+      'contactSearch' => json_encode($params['includeEmailInName'] ? ts('Search by name/email or id...') : ts('Search by name or id...')),
       'otherSearch' => json_encode(ts('Enter search term or id...')),
       'entityRef' => self::getEntityRefMetadata(),
-      'ajaxPopupsEnabled' => self::singleton()->ajaxPopupsEnabled,
-      'allowAlertAutodismissal' => (bool) Civi::settings()->get('allow_alert_autodismissal'),
-      'resourceCacheCode' => self::singleton()->getCacheCode(),
-      'locale' => CRM_Core_I18n::getLocale(),
-      'cid' => (int) CRM_Core_Session::getLoggedInContactID(),
     ];
-    print CRM_Core_Smarty::singleton()->fetchWith('CRM/common/l10n.js.tpl', $vars);
-    CRM_Utils_System::civiExit();
+    $e->content = CRM_Core_Smarty::singleton()->fetchWith('CRM/common/l10n.js.tpl', $params);
   }
 
   /**

--- a/CRM/Core/xml/Menu/Misc.xml
+++ b/CRM/Core/xml/Menu/Misc.xml
@@ -206,12 +206,6 @@
      <title>Confirm dates</title>
   </item>
   <item>
-    <path>civicrm/ajax/l10n-js</path>
-    <page_callback>CRM_Core_Resources::outputLocalizationJS</page_callback>
-    <access_callback>1</access_callback>
-    <is_public>true</is_public>
-  </item>
-  <item>
     <path>civicrm/shortcode</path>
     <page_callback>CRM_Core_Form_ShortCode</page_callback>
     <access_arguments>access CiviCRM</access_arguments>

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -381,6 +381,7 @@ class Container {
     $dispatcher->addListener('hook_civicrm_buildAsset', ['\CRM_Utils_VisualBundle', 'buildAssetJs']);
     $dispatcher->addListener('hook_civicrm_buildAsset', ['\CRM_Utils_VisualBundle', 'buildAssetCss']);
     $dispatcher->addListener('hook_civicrm_buildAsset', ['\CRM_Core_Resources', 'renderMenubarStylesheet']);
+    $dispatcher->addListener('hook_civicrm_buildAsset', ['\CRM_Core_Resources', 'renderL10nJs']);
     $dispatcher->addListener('hook_civicrm_coreResourceList', ['\CRM_Utils_System', 'appendCoreResources']);
     $dispatcher->addListener('hook_civicrm_getAssetUrl', ['\CRM_Utils_System', 'alterAssetUrl']);
     $dispatcher->addListener('hook_civicrm_alterExternUrl', ['\CRM_Utils_System', 'migrateExternUrl'], 1000);

--- a/templates/CRM/common/l10n.js.tpl
+++ b/templates/CRM/common/l10n.js.tpl
@@ -16,11 +16,11 @@
   CRM.config.resourceBase = {$config->userFrameworkResourceURL|@json_encode};
   {* packageseBase: The URL of `civicrm-packages` assets. Ends with "/". *}
   CRM.config.packagesBase = {capture assign=packagesBase}{crmResURL expr='[civicrm.packages]/'}{/capture}{$packagesBase|@json_encode};
-  CRM.config.lcMessages = {$config->lcMessages|@json_encode};
+  CRM.config.lcMessages = {$lcMessages|@json_encode};
   CRM.config.locale = {$locale|@json_encode};
   CRM.config.cid = {$cid|@json_encode};
-  $.datepicker._defaults.dateFormat = CRM.config.dateInputFormat = {$config->dateInputFormat|@json_encode};
-  CRM.config.timeIs24Hr = {if $config->timeInputFormat eq 2}true{else}false{/if};
+  $.datepicker._defaults.dateFormat = CRM.config.dateInputFormat = {$dateInputFormat|@json_encode};
+  CRM.config.timeIs24Hr = {if $timeInputFormat eq 2}true{else}false{/if};
   CRM.config.ajaxPopupsEnabled = {$ajaxPopupsEnabled|@json_encode};
   CRM.config.allowAlertAutodismissal = {$allowAlertAutodismissal|@json_encode};
   CRM.config.resourceCacheCode = {$resourceCacheCode|@json_encode};
@@ -30,7 +30,7 @@
 
   // Initialize CRM.url and CRM.formatMoney
   CRM.url({ldelim}back: '{crmURL p="civicrm/placeholder-url-path" q="civicrm-placeholder-url-query=1" h=0 fb=1}', front: '{crmURL p="civicrm/placeholder-url-path" q="civicrm-placeholder-url-query=1" h=0 fe=1}'{rdelim});
-  CRM.formatMoney('init', false, {$moneyFormat});
+  CRM.formatMoney('init', false, {$moneyFormat|@json_encode});
 
   // Localize select2
   $.fn.select2.defaults.formatNoMatches = "{ts escape='js'}None found.{/ts}";


### PR DESCRIPTION
Overview
----------------------------------------
The generated javascript in `l10n.js` predates assetBuilder; had it been avaiable at the time, assetBuilder would have been the way to write it. Now it does.

Before
----------------------------------------
Ajax callback pretending to be a script.

After
----------------------------------------
Actual generated script by assetBuilder.

Technical Details
----------------------------------------
Reviewers can search for the string "l10n" in their page source and click on the script to open it. The script itself will have a different name before/after, but aside from that, a diff tool should show them to be exactly the same.

Comments
---------------------
AssetBuilder is very reliable at this point; for example it preprocesses the menubar css, and all AngularJS code.