### PR TITLE
Fixed dev/core#2505  fix formatting of numbers in civireport

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -1191,6 +1191,13 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
           }
           $display = implode(', ', $disp);
         }
+        elseif ($field['data_type'] == 'Float' && isset($value)) {
+          // $value can also be an array(while using IN operator from search builder or api).
+          foreach ((array) $value as $val) {
+            $disp[] = CRM_Utils_Number::formatLocaleNumeric($val);
+          }
+          $display = implode(', ', $disp);
+        }
         break;
     }
     return $display;

--- a/CRM/Utils/Number.php
+++ b/CRM/Utils/Number.php
@@ -104,4 +104,23 @@ class CRM_Utils_Number {
     }
   }
 
+  /**
+   * Format number for display according to the current or supplied locale.
+   *
+   * Note this should not be used in conjunction with any calls to
+   * replaceCurrencySeparators as this function already does that.
+   *
+   * @param string $amount
+   * @param string $locale
+   *
+   * @return string
+   * @throws \Brick\Money\Exception\UnknownCurrencyException
+   */
+  public static function formatLocaleNumeric(string $amount, $locale = NULL): string {
+    $formatter = new \NumberFormatter($locale ?? CRM_Core_I18n::getLocale(), NumberFormatter::DECIMAL);
+    $formatter->setSymbol(\NumberFormatter::DECIMAL_SEPARATOR_SYMBOL, CRM_Core_Config::singleton()->monetaryDecimalPoint);
+    $formatter->setSymbol(\NumberFormatter::GROUPING_SEPARATOR_SYMBOL, CRM_Core_Config::singleton()->monetaryThousandSeparator);
+    return $formatter->format($amount);
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------

Localize the display of custom fields of type number. 

Before
----------------------------------------

When a report displayed a custom field of type number it wont localize the decimal separator. 

After
----------------------------------------

Display of custom field of type number correctly shows the decimal separator. This is on the report screen as on other screens in CiviCRM.

Technical Details
----------------------------------------

* The function in `CRM_Utils_Number::formatLocaleNumeric` is added (which is almost a copy from `CRM_Utils_Money::formatLocaleNumeric` but without the precision (`$numberOfPlaces`) paramater.
* In the function `CRM_Core_BAO_CustomField::formatDisplayValue`  the formatting of number fields is added. 
* Also added a couple of test for checking the localized numbers. 

Comments
----------------------------------------

See https://lab.civicrm.org/dev/core/-/issues/2505
