### PR TITLE
SearchKit - Fix updating Entity Ref fields

### DIFF
--- a/Civi/Api4/Generic/Traits/DAOActionTrait.php
+++ b/Civi/Api4/Generic/Traits/DAOActionTrait.php
@@ -185,6 +185,14 @@ trait DAOActionTrait {
           formatCheckBoxField($value, 'custom_' . $field['id'], $this->getEntityName());
         }
 
+        if ($field['data_type'] === 'ContactReference' && !is_numeric($value)) {
+          require_once 'api/v3/utils.php';
+          $value = \_civicrm_api3_resolve_contactID($value);
+          if ('unknown-user' === $value) {
+            throw new \API_Exception("\"{$field['name']}\" \"{$value}\" cannot be resolved to a contact ID", 2002, ['error_field' => $field['name'], "type" => "integer"]);
+          }
+        }
+
         \CRM_Core_BAO_CustomField::formatCustomField(
           $field['id'],
           $customParams,
@@ -223,7 +231,7 @@ trait DAOActionTrait {
     if (!isset($info[$fieldName])) {
       $info = [];
       $fields = CustomField::get(FALSE)
-        ->addSelect('id', 'name', 'html_type', 'custom_group.extends')
+        ->addSelect('id', 'name', 'html_type', 'data_type', 'custom_group.extends')
         ->addWhere('custom_group.name', '=', $groupName)
         ->execute()->indexBy('name');
       foreach ($fields as $name => $field) {

--- a/ext/search_kit/ang/crmSearchActions/crmSearchActionUpdate.ctrl.js
+++ b/ext/search_kit/ang/crmSearchActions/crmSearchActionUpdate.ctrl.js
@@ -13,7 +13,7 @@
 
     crmApi4(model.entity, 'getFields', {
       action: 'update',
-      select: ['name', 'label', 'description', 'data_type', 'serialize', 'options'],
+      select: ['name', 'label', 'description', 'data_type', 'serialize', 'options', 'fk_entity'],
       loadOptions: ['id', 'name', 'label', 'description', 'color', 'icon'],
       where: [["readonly", "=", false]],
     }).then(function(fields) {

--- a/tests/phpunit/api/v4/Action/CustomContactRefTest.php
+++ b/tests/phpunit/api/v4/Action/CustomContactRefTest.php
@@ -26,7 +26,7 @@ use Civi\Api4\CustomGroup;
 /**
  * @group headless
  */
-class CustomJoinTest extends BaseCustomValueTest {
+class CustomContactRefTest extends BaseCustomValueTest {
 
   public function testGetWithJoin() {
 
@@ -68,6 +68,40 @@ class CustomJoinTest extends BaseCustomValueTest {
 
     $this->assertEquals('Favorite', $contact['MyContactRef.FavPerson.first_name']);
     $this->assertEquals('Person', $contact['MyContactRef.FavPerson.last_name']);
+  }
+
+  public function testCurrentUser() {
+    $currentUser = $this->createLoggedInUser();
+
+    $customGroup = CustomGroup::create(FALSE)
+      ->addValue('name', 'MyContactRef')
+      ->addValue('extends', 'Individual')
+      ->execute()
+      ->first();
+
+    CustomField::create(FALSE)
+      ->addValue('label', 'FavPerson')
+      ->addValue('custom_group_id', $customGroup['id'])
+      ->addValue('html_type', 'Autocomplete-Select')
+      ->addValue('data_type', 'ContactReference')
+      ->execute();
+
+    $contactId = Contact::create(FALSE)
+      ->addValue('first_name', 'Mya')
+      ->addValue('last_name', 'Tester')
+      ->addValue('contact_type', 'Individual')
+      ->addValue('MyContactRef.FavPerson', 'user_contact_id')
+      ->execute()
+      ->first()['id'];
+
+    $contact = Contact::get(FALSE)
+      ->addSelect('display_name')
+      ->addSelect('MyContactRef.FavPerson')
+      ->addWhere('id', '=', $contactId)
+      ->execute()
+      ->first();
+
+    $this->assertEquals($currentUser, $contact['MyContactRef.FavPerson']);
   }
 
 }

--- a/tests/phpunit/api/v4/UnitTestCase.php
+++ b/tests/phpunit/api/v4/UnitTestCase.php
@@ -20,6 +20,7 @@
 namespace api\v4;
 
 use api\v4\Traits\TestDataLoaderTrait;
+use Civi\Api4\UFMatch;
 use Civi\Test\HeadlessInterface;
 use Civi\Test\TransactionalInterface;
 
@@ -75,6 +76,28 @@ class UnitTestCase extends \PHPUnit\Framework\TestCase implements HeadlessInterf
   public function getRowCount($table_name) {
     $sql = "SELECT count(id) FROM $table_name";
     return (int) \CRM_Core_DAO::singleValueQuery($sql);
+  }
+
+  /**
+   * Emulate a logged in user since certain functions use that.
+   * value to store a record in the DB (like activity)
+   * @see https://issues.civicrm.org/jira/browse/CRM-8180
+   *
+   * @return int
+   *   Contact ID of the created user.
+   */
+  public function createLoggedInUser() {
+    $contactID = $this->createEntity(['type' => 'Individual'])['id'];
+    UFMatch::delete(FALSE)->addWhere('uf_id', '=', 6)->execute();
+    UFMatch::create(FALSE)->setValues([
+      'contact_id' => $contactID,
+      'uf_name' => 'superman',
+      'uf_id' => 6,
+    ])->execute();
+
+    $session = \CRM_Core_Session::singleton();
+    $session->set('userID', $contactID);
+    return $contactID;
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Fix a couple bugs in SearchKit handling bulk-updates of Entity Ref fields.

Before
----------------------------------------
1. Create a custom field type Contact Reference.
2. Create a search, select one or more rows & choose "Update Contacts" from the Actions menu.
3. Select the custom field.

Problem 1: Field appears as an integer
Problem 2: Fixing first bug, then selecting "Current User" from the EntityRef widget will fail.

After
----------------------------------------
Both issues fixed.