### PR TITLE
Set default terms = 1 in (edit) Membership form javascript

### DIFF
--- a/templates/CRM/Member/Form/Membership.tpl
+++ b/templates/CRM/Member/Form/Membership.tpl
@@ -294,7 +294,8 @@
 
         // skip this for test and live modes because financial type is set automatically
         cj("#financial_type_id").val(membershipType['financial_type_id']);
-        var term = cj('#num_terms').val();
+        // Get the number of terms from the form, default to 1 if no num_terms element.
+        var term = cj('#num_terms').val() || 1;
         var taxTerm = {/literal}{$taxTerm|@json_encode}{literal};
         var currency = {/literal}{$currency_symbol|@json_encode}{literal};
         var taxExclusiveAmount = membershipType['total_amount_numeric'] * term;


### PR DESCRIPTION
Overview
----------------------------------------
Relates to [dev/core#2560](https://lab.civicrm.org/dev/core/-/issues/2560)

Fix the number of terms variable in the membership form tpl javascript to use "1" as the default if the #num_terms element is not available (e.g. edit Membership form)

Before
----------------------------------------
Amount is shown as NaN.N

After
----------------------------------------
Amount is correct for a single term of the chosen membership type

Comments
----------------------------------------
This fixes a regression introduction in CiviCRM 5.36 (Hence the PR against 5.37 branch)