### PR TITLE
dev/core#2554 Print/Merge document tokens for cases

### DIFF
--- a/CRM/Case/Form/Task/PDF.php
+++ b/CRM/Case/Form/Task/PDF.php
@@ -53,10 +53,6 @@ class CRM_Case_Form_Task_PDF extends CRM_Case_Form_Task {
    */
   public function buildQuickForm() {
     CRM_Case_Form_Task_PDFLetterCommon::buildQuickForm($this);
-    // Remove types other than pdf as they are not working (have never worked) and don't want fix
-    // for them to block pdf.
-    // @todo debug & fix....
-    $this->add('select', 'document_type', ts('Document Type'), ['pdf' => ts('Portable Document Format (.pdf)')]);
   }
 
   /**

--- a/CRM/Case/Form/Task/PDF.php
+++ b/CRM/Case/Form/Task/PDF.php
@@ -34,10 +34,9 @@ class CRM_Case_Form_Task_PDF extends CRM_Case_Form_Task {
    * Build all the data structures needed to build the form.
    */
   public function preProcess() {
-    CRM_Contact_Form_Task_PDFLetterCommon::preProcess($this);
     $this->skipOnHold = $this->skipDeceased = FALSE;
     parent::preProcess();
-    $this->setContactIDs();
+    CRM_Case_Form_Task_PDFLetterCommon::preProcess($this);
   }
 
   /**
@@ -46,21 +45,25 @@ class CRM_Case_Form_Task_PDF extends CRM_Case_Form_Task {
    * @return array
    */
   public function setDefaultValues() {
-    return CRM_Contact_Form_Task_PDFLetterCommon::setDefaultValues();
+    return CRM_Case_Form_Task_PDFLetterCommon::setDefaultValues();
   }
 
   /**
    * Build the form object.
    */
   public function buildQuickForm() {
-    CRM_Contact_Form_Task_PDFLetterCommon::buildQuickForm($this);
+    CRM_Case_Form_Task_PDFLetterCommon::buildQuickForm($this);
+    // Remove types other than pdf as they are not working (have never worked) and don't want fix
+    // for them to block pdf.
+    // @todo debug & fix....
+    $this->add('select', 'document_type', ts('Document Type'), ['pdf' => ts('Portable Document Format (.pdf)')]);
   }
 
   /**
    * Process the form after the input has been submitted and validated.
    */
   public function postProcess() {
-    CRM_Contact_Form_Task_PDFLetterCommon::postProcess($this);
+    CRM_Case_Form_Task_PDFLetterCommon::postProcess($this);
   }
 
   /**
@@ -69,12 +72,7 @@ class CRM_Case_Form_Task_PDF extends CRM_Case_Form_Task {
    * @return array
    */
   public function listTokens() {
-    $tokens = CRM_Core_SelectValues::contactTokens();
-    foreach ($this->_entityIds as $key => $caseId) {
-      $caseTypeId = CRM_Core_DAO::getFieldValue('CRM_Case_DAO_Case', $caseId, 'case_type_id');
-      $tokens += CRM_Core_SelectValues::caseTokens($caseTypeId);
-    }
-    return $tokens;
+    return CRM_Case_Form_Task_PDFLetterCommon::listTokens();
   }
 
 }

--- a/CRM/Case/Form/Task/PDFLetterCommon.php
+++ b/CRM/Case/Form/Task/PDFLetterCommon.php
@@ -1,0 +1,76 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+use Civi\Token\TokenProcessor;
+
+/**
+ * This class provides the common functionality for creating PDF letter for
+ * activities.
+ *
+ */
+class CRM_Case_Form_Task_PDFLetterCommon extends CRM_Core_Form_Task_PDFLetterCommon {
+
+  /**
+   * Process the form after the input has been submitted and validated.
+   *
+   * @param CRM_Core_Form $form
+   *
+   * @return void
+   */
+  public static function postProcess(&$form) {
+    $caseIds = $form->_caseIds;
+    $formValues = $form->controller->exportValues($form->getName());
+    $html_message = self::processTemplate($formValues);
+
+    // Do the rest in another function to make testing easier
+    self::createDocument($caseIds, $html_message, $formValues);
+
+    $form->postProcessHook();
+
+    CRM_Utils_System::civiExit(1);
+  }
+
+  /**
+   * Produce the document from the activities
+   * This uses the new token processor
+   *
+   * @param  array $caseIds  array of case ids
+   * @param  string $html_message message text with tokens
+   * @param  array $formValues   formValues from the form
+   *
+   * @return string
+   */
+  public static function createDocument($caseIds, $html_message, $formValues) {
+    $tp = self::createTokenProcessor();
+    $tp->addMessage('body_html', $html_message, 'text/html');
+
+    foreach ($caseIds as $caseId) {
+      $tp->addRow()->context('caseId', $caseId);
+    }
+    $tp->evaluate();
+
+    return self::renderFromRows($tp->getRows(), 'body_html', $formValues);
+  }
+
+  /**
+   * Create a token processor
+   *
+   * @return \Civi\Token\TokenProcessor
+   */
+  public static function createTokenProcessor() {
+    return new TokenProcessor(\Civi::dispatcher(), [
+      'controller' => get_class(),
+      'smarty' => FALSE,
+      'schema' => ['caseId'],
+    ]);
+  }
+
+}

--- a/CRM/Case/Tokens.php
+++ b/CRM/Case/Tokens.php
@@ -1,0 +1,141 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * Class CRM_Case_Tokens
+ *
+ * Generate "case.*" tokens.
+ *
+ */
+class CRM_Case_Tokens extends \Civi\Token\AbstractTokenSubscriber {
+
+  use CRM_Core_TokenTrait;
+
+  /**
+   * @return string
+   */
+  private function getEntityName(): string {
+    return 'case';
+  }
+
+  /**
+   * @return string
+   */
+  private function getEntityTableName(): string {
+    return 'civicrm_case';
+  }
+
+  /**
+   * @return string
+   */
+  private function getEntityContextSchema(): string {
+    return 'caseId';
+  }
+
+  /**
+   * Mapping from tokenName to api return field
+   * Use lists since we might need multiple fields
+   *
+   * @var array
+   */
+  private static $fieldMapping = [
+    'type' => ['case_type_id'],
+    'status' => ['status_id'],
+  ];
+
+  /**
+   * @inheritDoc
+   */
+  public function prefetch(\Civi\Token\Event\TokenValueEvent $e) {
+    // Find all the entity IDs
+    $entityIds
+      = $e->getTokenProcessor()->getContextValues('actionSearchResult', 'entityID')
+      + $e->getTokenProcessor()->getContextValues($this->getEntityContextSchema());
+
+    if (!$entityIds) {
+      return NULL;
+    }
+
+    // Get data on all activities for basic and customfield tokens
+    $prefetch['case'] = civicrm_api3('Case', 'get', [
+      'id' => ['IN' => $entityIds],
+      'options' => ['limit' => 0],
+      'return' => self::getReturnFields($this->activeTokens),
+    ])['values'];
+
+    // Store the case types if needed
+    if (in_array('type', $this->activeTokens)) {
+      $this->caseTypes = CRM_Case_BAO_Case::buildOptions('case_type_id');
+    }
+
+    // Store the case statuses if needed
+    if (in_array('status', $this->activeTokens)) {
+      $this->caseStatuses = CRM_Case_BAO_Case::buildOptions('case_status_id');
+    }
+
+    return $prefetch;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function evaluateToken(\Civi\Token\TokenRow $row, $entity, $field, $prefetch = NULL) {
+    // Get entityID either from actionSearchResult (for scheduled reminders) if exists
+    $entityID = $row->context['actionSearchResult']->entityID ?? $row->context[$this->getEntityContextSchema()];
+
+    $case = (object) $prefetch['case'][$entityID];
+
+    if (substr($field, -5) === '_date') {
+      $row->tokens($entity, $field, \CRM_Utils_Date::customFormat($case->$field));
+    }
+    elseif (isset(self::$fieldMapping[$field]) and (isset($case->{self::$fieldMapping[$field]}))) {
+      $row->tokens($entity, $field, $case->{self::$fieldMapping[$field]});
+    }
+    elseif (in_array($field, ['type'])) {
+      $row->tokens($entity, $field, $this->caseTypes[$case->case_type_id]);
+    }
+    elseif (in_array($field, ['status'])) {
+      $row->tokens($entity, $field, $this->caseStatuses[$case->status_id]);
+    }
+    elseif (array_key_exists($field, $this->customFieldTokens)) {
+      $row->tokens($entity, $field,
+        isset($case->$field)
+          ? \CRM_Core_BAO_CustomField::displayValue($case->$field, $field)
+          : ''
+      );
+    }
+    elseif (isset($case->$field)) {
+      $row->tokens($entity, $field, $case->$field);
+    }
+  }
+
+  /**
+   * Get the basic tokens provided.
+   *
+   * @return array token name => token label
+   * @throws \CiviCRM_API3_Exception
+   */
+  protected function getBasicTokens() {
+    if (!isset($this->basicTokens)) {
+      $caseFields = civicrm_api3('Case', 'getfields')['values'];
+      foreach ($caseFields as $name => $detail) {
+        $this->basicTokens[$detail['name']] = $detail['title'];
+      }
+      $this->basicTokens['status'] = $this->basicTokens['status_id'];
+      $this->basicTokens['status_id'] = ts('Case Status ID');
+      $this->basicTokens['type'] = $this->basicTokens['case_type_id'];
+      $this->basicTokens['case_type_id'] = ts('Case Type ID');
+    }
+    return $this->basicTokens;
+  }
+
+}

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -332,7 +332,7 @@ class Container {
       []
     ))->addTag('kernel.event_subscriber')->setPublic(TRUE);
 
-    foreach (['Activity', 'Contribute', 'Event', 'Mailing', 'Member'] as $comp) {
+    foreach (['Activity', 'Case', 'Contribute', 'Event', 'Mailing', 'Member'] as $comp) {
       $container->setDefinition("crm_" . strtolower($comp) . "_tokens", new Definition(
         "CRM_{$comp}_Tokens",
         []

--- a/tests/phpunit/CRM/Case/Form/Task/PDFLetterCommonTest.php
+++ b/tests/phpunit/CRM/Case/Form/Task/PDFLetterCommonTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * Class CRM_Case_Form_Task_PDFLetterCommonTest
+ * @group headless
+ */
+class CRM_Case_Form_Task_PDFLetterCommonTest extends CiviCaseTestCase {
+
+  protected $custom_group;
+
+  /**
+   * Set up for tests.
+   */
+  public function setUp(): void {
+    parent::setUp();
+    $this->custom_group = $this->customGroupCreate(['extends' => 'Case']);
+    $this->custom_group = $this->custom_group['values'][$this->custom_group['id']];
+  }
+
+  public function testCaseTokenFunctionality(): void {
+    // set up custom field, with any overrides from input params
+    $custom_field = $this->callAPISuccess('custom_field', 'create', [
+      'custom_group_id' => $this->custom_group['id'],
+      'label' => 'What?',
+      'data_type' => 'String',
+      'html_type' => 'Text',
+      'is_active' => 1,
+    ]);
+    $custom_field = $custom_field['values'][$custom_field['id']];
+
+    // set up case and set the custom field initial value
+    $client_id = $this->individualCreate([], 0, TRUE);
+    $caseObj = $this->createCase($client_id, $this->_loggedInUser);
+    $this->callAPISuccess('CustomValue', 'create', [
+      "custom_{$custom_field['id']}" => 'I like it',
+      'entity_id' => $caseObj->id,
+    ]);
+
+    $availableTokens = CRM_Case_Form_Task_PDFLetterCommon::listTokens();
+    $expectedTokens = [
+      '{case.case_type_id}',
+      '{case.subject}',
+      '{case.start_date}',
+      '{case.end_date}',
+      '{case.details}',
+      '{case.status_id}',
+      '{case.is_deleted}',
+      '{case.created_date}',
+      '{case.modified_date}',
+      '{case.contact_id}',
+      '{case.activity_id}',
+      '{case.tag_id}',
+      '{case.status}',
+      '{case.type}',
+      '{case.id}',
+      '{case.custom_' . $custom_field['id'] . '}',
+    ];
+    foreach ($expectedTokens as $expectedToken) {
+      $this->assertArrayKeyExists($expectedToken, $availableTokens);
+    }
+    $this->assertEquals('What?', $availableTokens['{case.custom_' . $custom_field['id'] . '}']);
+
+    $expected_output = "Subject: Case Subject\nId: " . $caseObj->id . "\nCustom field: I like it";
+    $html_message = "Subject: {case.subject}\nId: {case.id}\nCustom field: {case.custom_" . $custom_field['id'] . "}";
+    $output = CRM_Case_Form_Task_PDFLetterCommon::createDocument([$caseObj->id], $html_message, ['is_unit_test' => TRUE]);
+
+    $this->assertEquals($expected_output, $output[0]);
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------

Implementation of `tokenProcessor` for the action **Print/Merge document** after a case search.

Before
----------------------------------------

Print/Merge document after a case search used the old way of replacing tokens which had an inconsitent format of the array of `$contactIds` passed to `hook_civicrm_tokenValues`. 

After
----------------------------------------

Instead of making the call to `hook_civicrm_tokenValues` consistent I have implemented the `tokenProcessor`.


Comments
----------------------------------------

See https://lab.civicrm.org/dev/core/-/issues/2554
