### PR TITLE
dev/mailing#95 Only track <a> urls in Flexmailer for HTML emails

### DIFF
--- a/ext/flexmailer/src/ClickTracker/HtmlClickTracker.php
+++ b/ext/flexmailer/src/ClickTracker/HtmlClickTracker.php
@@ -51,9 +51,9 @@ class HtmlClickTracker implements ClickTrackerInterface {
 
     // Find anything like href="..." or href='...' inside a tag.
     $tmp = preg_replace_callback(
-      ';(\<a[^>]*href *= *")([^">]+)(");', $callback, $html);
+      ';(\<a[^>]*href *= *")([^">]+)(");i', $callback, $html);
     return preg_replace_callback(
-      ';(\<a[^>]*href *= *\')([^\'>]+)(\');', $callback, $tmp);
+      ';(\<a[^>]*href *= *\')([^\'>]+)(\');i', $callback, $tmp);
   }
 
   //  /**

--- a/ext/flexmailer/src/ClickTracker/HtmlClickTracker.php
+++ b/ext/flexmailer/src/ClickTracker/HtmlClickTracker.php
@@ -51,9 +51,9 @@ class HtmlClickTracker implements ClickTrackerInterface {
 
     // Find anything like href="..." or href='...' inside a tag.
     $tmp = preg_replace_callback(
-      ';(\<[^>]*href *= *")([^">]+)(");', $callback, $html);
+      ';(\<a[^>]*href *= *")([^">]+)(");', $callback, $html);
     return preg_replace_callback(
-      ';(\<[^>]*href *= *\')([^\'>]+)(\');', $callback, $tmp);
+      ';(\<a[^>]*href *= *\')([^\'>]+)(\');', $callback, $tmp);
   }
 
   //  /**


### PR DESCRIPTION
[Issue here.](https://lab.civicrm.org/dev/mail/-/issues/95)

Before
----------------------------------------
Link tracking was applied to all URLs inside tags, including tags like &lt;link&gt;.

After
----------------------------------------
Link tracking is applied only to URLs inside &lt;a&gt; tags. Regex simply looks for &lt;a anything href=URL&gt; instead of &lt;anything href=URL&gt; (edited to add "anything" for clarity).