### PR TITLE
APIv4 - Deprecate nonstandard syntax for implicit joins

### DIFF
--- a/Civi/Api4/Action/Entity/GetLinks.php
+++ b/Civi/Api4/Action/Entity/GetLinks.php
@@ -40,7 +40,9 @@ class GetLinks extends \Civi\Api4\Generic\BasicGetAction {
           'links' => [],
         ];
         foreach ($table->getTableLinks() as $link) {
-          $item['links'][] = $link->toArray();
+          if (!$link->isDeprecated()) {
+            $item['links'][] = $link->toArray();
+          }
         }
         $result[] = $item;
       }

--- a/Civi/Api4/Service/Schema/Joinable/Joinable.php
+++ b/Civi/Api4/Service/Schema/Joinable/Joinable.php
@@ -79,6 +79,11 @@ class Joinable {
   protected $entity;
 
   /**
+   * @var bool
+   */
+  protected $deprecated = FALSE;
+
+  /**
    * @param $targetTable
    * @param $targetColumn
    * @param string|null $alias
@@ -249,6 +254,23 @@ class Joinable {
   public function setJoinType($joinType) {
     $this->joinType = $joinType;
 
+    return $this;
+  }
+
+  /**
+   * @return bool
+   */
+  public function isDeprecated() {
+    return $this->deprecated;
+  }
+
+  /**
+   * @param bool $deprecated
+   *
+   * @return $this
+   */
+  public function setDeprecated(bool $deprecated = TRUE) {
+    $this->deprecated = $deprecated;
     return $this;
   }
 

--- a/Civi/Api4/Service/Schema/SchemaMapBuilder.php
+++ b/Civi/Api4/Service/Schema/SchemaMapBuilder.php
@@ -91,9 +91,15 @@ class SchemaMapBuilder {
     if ($fkClass) {
       $tableName = AllCoreTables::getTableForClass($fkClass);
       $fkKey = $data['FKKeyColumn'] ?? 'id';
-      // Fixme: Clumsy string manipulation to transform e.g. "contact_id" to "contact" - we never should have done this
-      $alias = str_replace('_id', '', $field);
-      $joinable = new Joinable($tableName, $fkKey, $alias);
+      // Backward-compatibility for older api calls using e.g. "contact" instead of "contact_id"
+      if (strpos($field, '_id')) {
+        $alias = str_replace('_id', '', $field);
+        $joinable = new Joinable($tableName, $fkKey, $alias);
+        $joinable->setJoinType($joinable::JOIN_TYPE_MANY_TO_ONE);
+        $joinable->setDeprecated();
+        $table->addTableLink($field, $joinable);
+      }
+      $joinable = new Joinable($tableName, $fkKey, $field);
       $joinable->setJoinType($joinable::JOIN_TYPE_MANY_TO_ONE);
       $table->addTableLink($field, $joinable);
     }

--- a/tests/phpunit/api/v4/Entity/ContactJoinTest.php
+++ b/tests/phpunit/api/v4/Entity/ContactJoinTest.php
@@ -46,19 +46,35 @@ class ContactJoinTest extends UnitTestCase {
     return parent::setUpHeadless();
   }
 
-  public function testContactJoin() {
-
+  public function testContactJoinDeprecated() {
     $contact = $this->getReference('test_contact_1');
     $entitiesToTest = ['Address', 'OpenID', 'IM', 'Website', 'Email', 'Phone'];
 
     foreach ($entitiesToTest as $entity) {
       $results = civicrm_api4($entity, 'get', [
         'where' => [['contact_id', '=', $contact['id']]],
+        // Deprecated syntax (new syntax is `contact_id.*` not `contact.*`)
         'select' => ['contact.*_name', 'contact.id'],
       ]);
       foreach ($results as $result) {
         $this->assertEquals($contact['id'], $result['contact.id']);
         $this->assertEquals($contact['display_name'], $result['contact.display_name']);
+      }
+    }
+  }
+
+  public function testContactJoin() {
+    $contact = $this->getReference('test_contact_1');
+    $entitiesToTest = ['Address', 'OpenID', 'IM', 'Website', 'Email', 'Phone'];
+
+    foreach ($entitiesToTest as $entity) {
+      $results = civicrm_api4($entity, 'get', [
+        'where' => [['contact_id', '=', $contact['id']]],
+        'select' => ['contact_id.*_name', 'contact_id.id'],
+      ]);
+      foreach ($results as $result) {
+        $this->assertEquals($contact['id'], $result['contact_id.id']);
+        $this->assertEquals($contact['display_name'], $result['contact_id.display_name']);
       }
     }
   }


### PR DESCRIPTION
Overview
----------------------------------------
The APIv4 prototype used a string-manipulation hack to make implicit joins appear more friendly, e.g. it would transform `contact_id.*` to `contact.*`.
However this made the generation of such joins less predictable, as not all FK fields end in `_id` (notably, custom ContactRef fields do not).

This preserves the nonstandard syntax for backward-compat while favoring the new syntax in the API Explorer.

Comments
----------------------------------------
For now the deprecated syntax works normally, just isn't advertised in the Api Explorer. Someday we can emit deprecation warnings, and maybe in the future remove them altogether.