### PR TITLE
Import: trimNonBreakingSpaces: allow null values

### DIFF
--- a/CRM/Import/DataSource/CSV.php
+++ b/CRM/Import/DataSource/CSV.php
@@ -253,10 +253,10 @@ class CRM_Import_DataSource_CSV extends CRM_Import_DataSource {
    * See also dev/core#2127 - avoid breaking strings ending in à or any other
    * unicode character sharing the same 0xA0 byte as a non-breaking space.
    *
-   * @param string $string
+   * @param string $string Allow null values from empty rows
    * @return string The trimmed string
    */
-  public static function trimNonBreakingSpaces(string $string): string {
+  public static function trimNonBreakingSpaces(?string $string): string {
     $encoding = mb_detect_encoding($string, NULL, TRUE);
     if ($encoding === FALSE) {
       // This could mean a couple things. One is that the string is


### PR DESCRIPTION
Overview
----------------------------------------

Importing a CSV file with empty lines will result in a fatal error.

To reproduce, create a CSV file with a few emails, and also empty rows at the end of the file.

Then go to Contacts > Import, and import the file.

Before
----------------------------------------

> TypeError: Argument 1 passed to CRM_Import_DataSource_CSV::trimNonBreakingSpaces() must be of the type string, null given in CRM_Import_DataSource_CSV::trimNonBreakingSpaces() (line 259 of /srv/buildkit/build/dmaster/web/sites/all/modules/civicrm/CRM/Import/DataSource/CSV.php).

After
----------------------------------------

Success.

Technical Details
----------------------------------------

fgetcsv will return a row with null values, which causes a type hint fatal error.

Since PHP 7.1, we can make optional type hints.

Comments
----------------------------------------


cc @demeritcowboy 
