### PR TITLE
Replace string org.civicrm.search -> org.civicrm.search_kit

### DIFF
--- a/ext/afform/core/managed/AfformType.mgd.php
+++ b/ext/afform/core/managed/AfformType.mgd.php
@@ -50,7 +50,7 @@ $mgd = [
 
 try {
   $search = civicrm_api3('Extension', 'getsingle', [
-    'full_name' => "org.civicrm.search",
+    'full_name' => 'org.civicrm.search_kit',
   ]);
   if ($search['status'] === 'installed') {
     $mgd[] = [

--- a/ext/search_kit/ang/crmSearchActions/crmSearchActionDelete.ctrl.js
+++ b/ext/search_kit/ang/crmSearchActions/crmSearchActionDelete.ctrl.js
@@ -2,7 +2,7 @@
   "use strict";
 
   angular.module('crmSearchActions').controller('crmSearchActionDelete', function($scope, dialogService) {
-    var ts = $scope.ts = CRM.ts('org.civicrm.search'),
+    var ts = $scope.ts = CRM.ts('org.civicrm.search_kit'),
       model = $scope.model,
       ctrl = this;
 

--- a/ext/search_kit/ang/crmSearchActions/crmSearchActionUpdate.ctrl.js
+++ b/ext/search_kit/ang/crmSearchActions/crmSearchActionUpdate.ctrl.js
@@ -2,7 +2,7 @@
   "use strict";
 
   angular.module('crmSearchActions').controller('crmSearchActionUpdate', function ($scope, $timeout, crmApi4, dialogService) {
-    var ts = $scope.ts = CRM.ts('org.civicrm.search'),
+    var ts = $scope.ts = CRM.ts('org.civicrm.search_kit'),
       model = $scope.model,
       ctrl = this;
 

--- a/ext/search_kit/ang/crmSearchActions/crmSearchActions.component.js
+++ b/ext/search_kit/ang/crmSearchActions/crmSearchActions.component.js
@@ -9,7 +9,7 @@
     },
     templateUrl: '~/crmSearchActions/crmSearchActions.html',
     controller: function($scope, crmApi4, dialogService) {
-      var ts = $scope.ts = CRM.ts('org.civicrm.search'),
+      var ts = $scope.ts = CRM.ts('org.civicrm.search_kit'),
         ctrl = this,
         initialized = false,
         unwatchIDs = $scope.$watch('$ctrl.ids.length', watchIDs);

--- a/ext/search_kit/ang/crmSearchActions/crmSearchBatchRunner.component.js
+++ b/ext/search_kit/ang/crmSearchActions/crmSearchBatchRunner.component.js
@@ -12,7 +12,7 @@
     },
     templateUrl: '~/crmSearchActions/crmSearchBatchRunner.html',
     controller: function($scope, $timeout, $interval, crmApi4) {
-      var ts = $scope.ts = CRM.ts('org.civicrm.search'),
+      var ts = $scope.ts = CRM.ts('org.civicrm.search_kit'),
         ctrl = this,
         currentBatch = 0,
         totalBatches,

--- a/ext/search_kit/ang/crmSearchActions/crmSearchInput/crmSearchInput.component.js
+++ b/ext/search_kit/ang/crmSearchActions/crmSearchInput/crmSearchInput.component.js
@@ -11,7 +11,7 @@
     require: {ngModel: 'ngModel'},
     templateUrl: '~/crmSearchActions/crmSearchInput/crmSearchInput.html',
     controller: function($scope) {
-      var ts = $scope.ts = CRM.ts('org.civicrm.search'),
+      var ts = $scope.ts = CRM.ts('org.civicrm.search_kit'),
         ctrl = this;
 
       this.isMulti = function() {

--- a/ext/search_kit/ang/crmSearchActions/crmSearchInput/crmSearchInputVal.component.js
+++ b/ext/search_kit/ang/crmSearchActions/crmSearchInput/crmSearchInputVal.component.js
@@ -10,7 +10,7 @@
     require: {ngModel: 'ngModel'},
     template: '<div class="form-group" ng-include="$ctrl.getTemplate()"></div>',
     controller: function($scope, formatForSelect2) {
-      var ts = $scope.ts = CRM.ts('org.civicrm.search'),
+      var ts = $scope.ts = CRM.ts('org.civicrm.search_kit'),
         ctrl = this;
 
       this.$onInit = function() {

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
@@ -7,7 +7,7 @@
     },
     templateUrl: '~/crmSearchAdmin/crmSearchAdmin.html',
     controller: function($scope, $element, $location, $timeout, crmApi4, dialogService, searchMeta, formatForSelect2) {
-      var ts = $scope.ts = CRM.ts('org.civicrm.search'),
+      var ts = $scope.ts = CRM.ts('org.civicrm.search_kit'),
         ctrl = this;
 
       this.DEFAULT_AGGREGATE_FN = 'GROUP_CONCAT';

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminDisplay.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminDisplay.component.js
@@ -33,7 +33,7 @@
       return html;
     },
     controller: function($scope, $timeout, searchMeta) {
-      var ts = $scope.ts = CRM.ts('org.civicrm.search'),
+      var ts = $scope.ts = CRM.ts('org.civicrm.search_kit'),
         ctrl = this;
 
       this.preview = this.stale = false;

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminLinkGroup.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminLinkGroup.component.js
@@ -10,7 +10,7 @@
     },
     templateUrl: '~/crmSearchAdmin/crmSearchAdminLinkGroup.html',
     controller: function ($scope, $element, $timeout, searchMeta) {
-      var ts = $scope.ts = CRM.ts('org.civicrm.search'),
+      var ts = $scope.ts = CRM.ts('org.civicrm.search_kit'),
         ctrl = this;
 
       this.styles = CRM.crmSearchAdmin.styles;

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminLinkSelect.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminLinkSelect.component.js
@@ -11,7 +11,7 @@
     },
     templateUrl: '~/crmSearchAdmin/crmSearchAdminLinkSelect.html',
     controller: function ($scope, $element, $timeout) {
-      var ts = $scope.ts = CRM.ts('org.civicrm.search'),
+      var ts = $scope.ts = CRM.ts('org.civicrm.search_kit'),
         ctrl = this;
 
       this.setValue = function(val) {

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminTokenSelect.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminTokenSelect.component.js
@@ -10,7 +10,7 @@
     },
     templateUrl: '~/crmSearchAdmin/crmSearchAdminTokenSelect.html',
     controller: function ($scope, $element, searchMeta) {
-      var ts = $scope.ts = CRM.ts('org.civicrm.search'),
+      var ts = $scope.ts = CRM.ts('org.civicrm.search_kit'),
         ctrl = this;
 
       this.initTokens = function() {

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchClause.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchClause.component.js
@@ -13,7 +13,7 @@
     },
     templateUrl: '~/crmSearchAdmin/crmSearchClause.html',
     controller: function ($scope, $element, $timeout, searchMeta) {
-      var ts = $scope.ts = CRM.ts('org.civicrm.search'),
+      var ts = $scope.ts = CRM.ts('org.civicrm.search_kit'),
         ctrl = this,
         meta = {};
       this.conjunctions = {AND: ts('And'), OR: ts('Or'), NOT: ts('Not')};

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchFunction.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchFunction.component.js
@@ -8,7 +8,7 @@
     },
     templateUrl: '~/crmSearchAdmin/crmSearchFunction.html',
     controller: function($scope, formatForSelect2, searchMeta) {
-      var ts = $scope.ts = CRM.ts('org.civicrm.search'),
+      var ts = $scope.ts = CRM.ts('org.civicrm.search_kit'),
         ctrl = this;
 
       this.$onInit = function() {

--- a/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayList.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayList.component.js
@@ -12,7 +12,7 @@
     },
     templateUrl: '~/crmSearchAdmin/displays/searchAdminDisplayList.html',
     controller: function($scope) {
-      var ts = $scope.ts = CRM.ts('org.civicrm.search'),
+      var ts = $scope.ts = CRM.ts('org.civicrm.search_kit'),
         ctrl = this;
 
       this.symbols = {

--- a/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayTable.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayTable.component.js
@@ -12,7 +12,7 @@
     },
     templateUrl: '~/crmSearchAdmin/displays/searchAdminDisplayTable.html',
     controller: function($scope) {
-      var ts = $scope.ts = CRM.ts('org.civicrm.search'),
+      var ts = $scope.ts = CRM.ts('org.civicrm.search_kit'),
         ctrl = this;
 
       this.$onInit = function () {

--- a/ext/search_kit/ang/crmSearchAdmin/searchList.controller.js
+++ b/ext/search_kit/ang/crmSearchAdmin/searchList.controller.js
@@ -2,7 +2,7 @@
   "use strict";
 
   angular.module('crmSearchAdmin').controller('searchList', function($scope, savedSearches, crmApi4) {
-    var ts = $scope.ts = CRM.ts('org.civicrm.search'),
+    var ts = $scope.ts = CRM.ts('org.civicrm.search_kit'),
       ctrl = $scope.$ctrl = this;
     $scope.formatDate = CRM.utils.formatDate;
     this.savedSearches = savedSearches;

--- a/ext/search_kit/ang/crmSearchDisplayList/crmSearchDisplayList.component.js
+++ b/ext/search_kit/ang/crmSearchDisplayList/crmSearchDisplayList.component.js
@@ -15,7 +15,7 @@
     },
     templateUrl: '~/crmSearchDisplayList/crmSearchDisplayList.html',
     controller: function($scope, $element, crmApi4, searchDisplayUtils) {
-      var ts = $scope.ts = CRM.ts('org.civicrm.search'),
+      var ts = $scope.ts = CRM.ts('org.civicrm.search_kit'),
         ctrl = this;
 
       this.page = 1;

--- a/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTable.component.js
+++ b/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTable.component.js
@@ -14,7 +14,7 @@
     },
     templateUrl: '~/crmSearchDisplayTable/crmSearchDisplayTable.html',
     controller: function($scope, $element, crmApi4, searchDisplayUtils) {
-      var ts = $scope.ts = CRM.ts('org.civicrm.search'),
+      var ts = $scope.ts = CRM.ts('org.civicrm.search_kit'),
         ctrl = this;
 
       this.page = 1;


### PR DESCRIPTION
Overview
----------------------------------------
Followup to renaming the extension, this fixes strings with the old name.

Before
----------------------------------------
`'org.civicrm.search'`

After
----------------------------------------
`'org.civicrm.search_kit'`