### PR TITLE
dev/core#2535 Improve UI for setting date and time of scheduled reminders

### DIFF
--- a/templates/CRM/Admin/Form/ScheduleReminders.tpl
+++ b/templates/CRM/Admin/Form/ScheduleReminders.tpl
@@ -25,12 +25,14 @@
         <td class="label">{$form.entity.label}</td>
         <td>{$form.entity.html}</td>
     </tr>
-
     <tr class="crm-scheduleReminder-form-block-when">
         <td class="right">{$form.start_action_offset.label}</td>
-        <td colspan="3">{$form.absolute_date.html} <strong id='OR'>OR</strong><br /></td>
+        <td>{$form.absolute_or_relative_date.html}</td>
     </tr>
-
+    <tr class="crm-scheduleReminder-form-block-when" id="absoluteDate">
+        <td class="right"></td>
+        <td colspan="3">{$form.absolute_date.html}</td>
+    </tr>
     <tr id="relativeDate" class="crm-scheduleReminder-form-block-description">
         <td class="right"></td>
         <td colspan="3">{$form.start_action_offset.html}&nbsp;&nbsp;&nbsp;{$form.start_action_unit.html}&nbsp;&nbsp;&nbsp;{$form.start_action_condition.html}&nbsp;&nbsp;&nbsp;{$form.start_action_date.html}</td>
@@ -129,6 +131,24 @@
     <div>
   </fieldset>
   {/if}
+
+{include file="CRM/common/showHideByFieldValue.tpl"
+    trigger_field_id    = "absolute_or_relative_date"
+    trigger_value       = 'absolute'
+    target_element_id   = "absoluteDate"
+    target_element_type = "table-row"
+    field_type          = "select"
+    invert              = 0
+}
+
+{include file="CRM/common/showHideByFieldValue.tpl"
+    trigger_field_id    = "absolute_or_relative_date"
+    trigger_value       = 'relative'
+    target_element_id   = "relativeDate"
+    target_element_type = "table-row"
+    field_type          = "select"
+    invert              = 0
+}
 
 {include file="CRM/common/showHideByFieldValue.tpl"
     trigger_field_id    = "is_repeat"


### PR DESCRIPTION
Overview
----------------------------------------
The UI to set the scheduled date or relative date/time for a scheduled reminder was confusing, as you had could set both at once, but only the date would be used if both were set.

Before
----------------------------------------
Both options were shown in the form and the user had to clear the date field in order to get a relative date/time to save (but it was not clear that this was required).
![image](https://user-images.githubusercontent.com/25517556/115964019-a2beaf00-a4df-11eb-8f61-c21f38776330.png)
In this case, the 4 hours before setting will be silently ignored.

After
----------------------------------------
The user selects relative or specific date from a select, which shows the appropriate form element.
![image](https://user-images.githubusercontent.com/25517556/115963998-7c990f00-a4df-11eb-8de0-411dba8c1495.png)
![image](https://user-images.githubusercontent.com/25517556/115963999-80c52c80-a4df-11eb-8f3a-755dc6765410.png)

Comments
----------------------------------------
I set the default scheduled type to absolute, as it is more reliable and understandable.
I also needed to add or change a few strings that will need translating. I used the term 'Specific date' instead of 'Absolute date' as I'm not sure that 'Absolute date' is readily understood by non-technical users.

Now that I've done this, I'm somewhat doubting that this is an improvement over the much simpler change of just showing an error when the form is submitted with both fields filled in. If reviewers think that would be better, I'm happy to chalk this one up to not thinking it through properly from the start and instead submit that PR.
