### PR TITLE
dev/core#2546 Add settings button to group page

### DIFF
--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -2087,6 +2087,11 @@ a.crm-i:hover {
   opacity: .8;
 }
 
+.crm-submit-buttons .helpicon {
+    float: left;
+    padding-right: 6px;
+}
+
 .crm-container  a.helpicon:hover,
 .crm-container  a.helpicon:focus {
   opacity: 1;

--- a/templates/CRM/Contact/Form/Search/Intro.tpl
+++ b/templates/CRM/Contact/Form/Search/Intro.tpl
@@ -10,19 +10,24 @@
 {* $context indicates where we are searching, values = "search,advanced,smog,amtg" *}
 {* smog = 'show members of group'; amtg = 'add members to group' *}
 {if $context EQ 'smog'}
+  <div class="crm-submit-buttons">
+
   {* Provide link to modify smart group search criteria if we are viewing a smart group (ssID = saved search ID) *}
   {if $permissionEditSmartGroup && !empty($editSmartGroupURL)}
-      <div class="crm-submit-buttons">
-        <a href="{$editSmartGroupURL}" class="button no-popup"><span><i class="crm-i fa-pencil" aria-hidden="true"></i> {ts 1=$group.title}Edit Smart Group Search Criteria for %1{/ts}</span></a>
-        {help id="id-edit-smartGroup"}
-      </div>
+      <a href="{$editSmartGroupURL}" class="button no-popup"><span><i class="crm-i fa-pencil" aria-hidden="true"></i> {ts 1=$group.title}Edit Smart Group Search Criteria for %1{/ts}</span></a>
+      {help id="id-edit-smartGroup"}
   {/if}
 
   {if $permissionedForGroup}
     {capture assign=addMembersURL}{crmURL q="context=amtg&amtgID=`$group.id`&reset=1"}{/capture}
-    <div class="crm-submit-buttons">
       <a href="{$addMembersURL}" class="button no-popup"><span><i class="crm-i fa-user-plus" aria-hidden="true"></i> {ts 1=$group.title}Add Contacts to %1{/ts}</span></a>
       {if $ssID}{help id="id-add-to-smartGroup"}{/if}
-    </div>
   {/if}
+  {if $permissionEditSmartGroup}
+    {capture assign=groupSettingsURL}{crmURL p='civicrm/group' q="action=update&id=`$group.id`&reset=1"}{/capture}
+        <a href="{$groupSettingsURL}" class="action-item button"><span><i class="crm-i fa-wrench" aria-hidden="true"></i> {ts}Edit Group Settings{/ts}</span></a>
+  {/if}
+  </div>
 {/if}
+
+


### PR DESCRIPTION
Overview
----------------------------------------
It would be nice to be able to edit group settings (e.g to make a group a mailing group, to change the public title) directly from the group page. This adds an Edit Group Settings button that pops up the group settings edit overlay to the smog group page.

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/25517556/115974254-a6225c80-a518-11eb-84e2-6f62a0567be8.png)

After
----------------------------------------
![image](https://user-images.githubusercontent.com/25517556/115975225-25fff500-a520-11eb-83d5-19b9a7152fc4.png)

Comments
----------------------------------------
You'll see that I've put all three buttons on one line (there are only two buttons if the group isn't smart and potentially less if the user doesn't have permissions), when previously the two buttons were one per line. I needed to add some rules to civicrm.css to put float: left on the help icons (otherwise, they both were to the left of the buttons) and a bit more spacing. Not super happy about how this looks or works, so welcome suggestions to make this prettier or handle it without having to add css. Or I can put them back to one per line, but that's a bit weird with three buttons.

I had originally planned to add the disable and delete buttons as well, but it looks like adding disable will be a fair bit of work, so I left both out (I think they should either both be there or neither, but I can see an argument for adding delete only for convenience). If I'm wrong and adding disable won't be too much work, I'm happy to do that too if someone points me in the right direction. I think adding settings is the most helpful.
