### PR TITLE
[REF] Move functions back to class that uses it

### DIFF
--- a/CRM/Contribute/Form/Task/PDFLetterCommon.php
+++ b/CRM/Contribute/Form/Task/PDFLetterCommon.php
@@ -88,7 +88,7 @@ class CRM_Contribute_Form_Task_PDFLetterCommon extends CRM_Contact_Form_Task_PDF
         $contributionIDs["{$result->contact_id}-{$result->contribution_id}"] = $result->contribution_id;
       }
     }
-    [$contributions, $contacts] = self::buildContributionArray($groupBy, $contributionIDs, $returnProperties, $skipOnHold, $skipDeceased, $messageToken, $task, $separator, $form->isQueryIncludesSoftCredits());
+    [$contributions, $contacts] = CRM_Contribute_Form_Task_PDFLetter::buildContributionArray($groupBy, $contributionIDs, $returnProperties, $skipOnHold, $skipDeceased, $messageToken, $task, $separator, $form->isQueryIncludesSoftCredits());
     $html = [];
     $contactHtml = $emailedHtml = [];
     foreach ($contributions as $contributionId => $contribution) {
@@ -102,7 +102,7 @@ class CRM_Contribute_Form_Task_PDFLetterCommon extends CRM_Contact_Form_Task_PDF
       }
 
       if (empty($groupBy) || empty($contact['is_sent'][$groupBy][$groupByID])) {
-        $html[$contributionId] = self::generateHtml($contact, $contribution, $groupBy, $contributions, $realSeparator, $tableSeparators, $messageToken, $html_message, $separator, $grouped, $groupByID);
+        $html[$contributionId] = CRM_Contribute_Form_Task_PDFLetter::generateHtml($contact, $contribution, $groupBy, $contributions, $realSeparator, $tableSeparators, $messageToken, $html_message, $separator, $grouped, $groupByID);
         $contactHtml[$contact['contact_id']][] = $html[$contributionId];
         if (!empty($formValues['email_options'])) {
           if (self::emailLetter($contact, $html[$contributionId], $isPDF, $formValues, $emailParams)) {
@@ -227,7 +227,7 @@ class CRM_Contribute_Form_Task_PDFLetterCommon extends CRM_Contact_Form_Task_PDF
    * @return string
    * @throws \CRM_Core_Exception
    */
-  private static function resolveTokens(string $html_message, $contact, $contribution, $messageToken, $grouped, $separator, $contributions): string {
+  public static function resolveTokens(string $html_message, $contact, $contribution, $messageToken, $grouped, $separator, $contributions): string {
     $categories = self::getTokenCategories();
     $domain = CRM_Core_BAO_Domain::getDomain();
     $tokenHtml = CRM_Utils_Token::replaceDomainTokens($html_message, $domain, TRUE, $messageToken);
@@ -247,111 +247,6 @@ class CRM_Contribute_Form_Task_PDFLetterCommon extends CRM_Contact_Form_Task_PDF
       $tokenHtml = $smarty->fetch("string:$tokenHtml");
     }
     return $tokenHtml;
-  }
-
-  /**
-   * Generate the contribution array from the form, we fill in the contact details and determine any aggregation
-   * around contact_id of contribution_recur_id
-   *
-   * @param string $groupBy
-   * @param array $contributionIDs
-   * @param array $returnProperties
-   * @param bool $skipOnHold
-   * @param bool $skipDeceased
-   * @param array $messageToken
-   * @param string $task
-   * @param string $separator
-   * @param bool $isIncludeSoftCredits
-   *
-   * @return array
-   */
-  public static function buildContributionArray($groupBy, $contributionIDs, $returnProperties, $skipOnHold, $skipDeceased, $messageToken, $task, $separator, $isIncludeSoftCredits) {
-    $contributions = $contacts = [];
-    foreach ($contributionIDs as $item => $contributionId) {
-      $contribution = CRM_Contribute_BAO_Contribution::getContributionTokenValues($contributionId, $messageToken)['values'][$contributionId];
-      $contribution['campaign'] = $contribution['contribution_campaign_title'] ?? NULL;
-      $contributions[$contributionId] = $contribution;
-
-      if ($isIncludeSoftCredits) {
-        //@todo find out why this happens & add comments
-        [$contactID] = explode('-', $item);
-        $contactID = (int) $contactID;
-      }
-      else {
-        $contactID = $contribution['contact_id'];
-      }
-      if (!isset($contacts[$contactID])) {
-        $contacts[$contactID] = [];
-        $contacts[$contactID]['contact_aggregate'] = 0;
-        $contacts[$contactID]['combined'] = $contacts[$contactID]['contribution_ids'] = [];
-      }
-
-      $contacts[$contactID]['contact_aggregate'] += $contribution['total_amount'];
-      $groupByID = empty($contribution[$groupBy]) ? 0 : $contribution[$groupBy];
-
-      $contacts[$contactID]['contribution_ids'][$groupBy][$groupByID][$contributionId] = TRUE;
-      if (!isset($contacts[$contactID]['combined'][$groupBy]) || !isset($contacts[$contactID]['combined'][$groupBy][$groupByID])) {
-        $contacts[$contactID]['combined'][$groupBy][$groupByID] = $contribution;
-        $contacts[$contactID]['aggregates'][$groupBy][$groupByID] = $contribution['total_amount'];
-      }
-      else {
-        $contacts[$contactID]['combined'][$groupBy][$groupByID] = self::combineContributions($contacts[$contactID]['combined'][$groupBy][$groupByID], $contribution, $separator);
-        $contacts[$contactID]['aggregates'][$groupBy][$groupByID] += $contribution['total_amount'];
-      }
-    }
-    // Assign the available contributions before calling tokens so hooks parsing smarty can access it.
-    // Note that in core code you can only use smarty here if enable if for the whole site, incl
-    // CiviMail, with a big performance impact.
-    // Hooks allow more nuanced smarty usage here.
-    CRM_Core_Smarty::singleton()->assign('contributions', $contributions);
-    foreach ($contacts as $contactID => $contact) {
-      [$tokenResolvedContacts] = CRM_Utils_Token::getTokenDetails(['contact_id' => $contactID],
-        $returnProperties,
-        $skipOnHold,
-        $skipDeceased,
-        NULL,
-        $messageToken,
-        $task
-      );
-      $contacts[$contactID] = array_merge($tokenResolvedContacts[$contactID], $contact);
-    }
-    return [$contributions, $contacts];
-  }
-
-  /**
-   * We combine the contributions by adding the contribution to each field with the separator in
-   * between the existing value and the new one. We put the separator there even if empty so it is clear what the
-   * value for previous contributions was
-   *
-   * @param array $existing
-   * @param array $contribution
-   * @param string $separator
-   *
-   * @return array
-   */
-  public static function combineContributions($existing, $contribution, $separator) {
-    foreach ($contribution as $field => $value) {
-      $existing[$field] = isset($existing[$field]) ? $existing[$field] . $separator : '';
-      $existing[$field] .= $value;
-    }
-    return $existing;
-  }
-
-  /**
-   * We are going to retrieve the combined contribution and if smarty mail is enabled we
-   * will also assign an array of contributions for this contact to the smarty template
-   *
-   * @param array $contact
-   * @param array $contributions
-   * @param $groupBy
-   * @param int $groupByID
-   */
-  public static function assignCombinedContributionValues($contact, $contributions, $groupBy, $groupByID) {
-    CRM_Core_Smarty::singleton()->assign('contact_aggregate', $contact['contact_aggregate']);
-    CRM_Core_Smarty::singleton()
-      ->assign('contributions', $contributions);
-    CRM_Core_Smarty::singleton()->assign('contribution_aggregate', $contact['aggregates'][$groupBy][$groupByID]);
-
   }
 
   /**
@@ -408,43 +303,6 @@ class CRM_Contribute_Form_Task_PDFLetterCommon extends CRM_Contact_Form_Task_PDF
     catch (CRM_Core_Exception $e) {
       return FALSE;
     }
-  }
-
-  /**
-   * @param $contact
-   * @param $formValues
-   * @param $contribution
-   * @param $groupBy
-   * @param $contributions
-   * @param $realSeparator
-   * @param $tableSeparators
-   * @param $messageToken
-   * @param $html_message
-   * @param $separator
-   * @param $categories
-   * @param bool $grouped
-   * @param int $groupByID
-   *
-   * @return string
-   * @throws \CRM_Core_Exception
-   */
-  protected static function generateHtml(&$contact, $contribution, $groupBy, $contributions, $realSeparator, $tableSeparators, $messageToken, $html_message, $separator, $grouped, $groupByID) {
-    static $validated = FALSE;
-    $html = NULL;
-
-    $groupedContributions = array_intersect_key($contributions, $contact['contribution_ids'][$groupBy][$groupByID]);
-    self::assignCombinedContributionValues($contact, $groupedContributions, $groupBy, $groupByID);
-
-    if (empty($groupBy) || empty($contact['is_sent'][$groupBy][$groupByID])) {
-      if (!$validated && in_array($realSeparator, $tableSeparators) && !self::isValidHTMLWithTableSeparator($messageToken, $html_message)) {
-        $realSeparator = ', ';
-        CRM_Core_Session::setStatus(ts('You have selected the table cell separator, but one or more token fields are not placed inside a table cell. This would result in invalid HTML, so comma separators have been used instead.'));
-      }
-      $validated = TRUE;
-      $html = str_replace($separator, $realSeparator, self::resolveTokens($html_message, $contact, $contribution, $messageToken, $grouped, $separator, $groupedContributions));
-    }
-
-    return $html;
   }
 
 }

--- a/CRM/Core/Smarty.php
+++ b/CRM/Core/Smarty.php
@@ -154,6 +154,8 @@ class CRM_Core_Smarty extends Smarty {
    *
    * Method providing static instance of SmartTemplate, as
    * in Singleton pattern.
+   *
+   * @return \CRM_Core_Smarty
    */
   public static function &singleton() {
     if (!isset(self::$_singleton)) {

--- a/tests/phpunit/CRM/Contribute/Form/Task/PDFLetterCommonTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/Task/PDFLetterCommonTest.php
@@ -152,7 +152,7 @@ class CRM_Contribute_Form_Task_PDFLetterCommonTest extends CiviUnitTestCase {
       ],
     ];
 
-    [$contributions, $contacts] = CRM_Contribute_Form_Task_PDFLetterCommon::buildContributionArray('contact_id', $contributionIDs, $returnProperties, TRUE, TRUE, $messageToken, 'test', '**', FALSE);
+    [$contributions, $contacts] = CRM_Contribute_Form_Task_PDFLetter::buildContributionArray('contact_id', $contributionIDs, $returnProperties, TRUE, TRUE, $messageToken, 'test', '**', FALSE);
 
     $this->assertEquals('Anthony', $contacts[$this->_individualId]['first_name']);
     $this->assertEquals('emo', $contacts[$this->_individualId]['favourite_emoticon']);


### PR DESCRIPTION
Overview
----------------------------------------
[REF] Move function back to class that uses it

Before
----------------------------------------
The class CRM_Contribute_Form_Task_PDFLetterCommon is not called from anywhere else in the git universe but functions that are really part of CRM_Contribute_Form_Task_PDF as 'distributed' onto it

After
----------------------------------------
some of the functions moved back - will move more in a bit

Technical Details
----------------------------------------
A couple of functions have been made public but in the end they won't be

Note these PDFLetterCommon classes are a pretty weird structure - I think they are about 10% trying to emulate a trait & 90% copy and paste

Comments
----------------------------------------
CRM_Contribute_Form_Task_PDFLetterCommonTest tests pass through all these lines of code