### PR TITLE
dev/core#2506 Fix unserializing custom values during form reload

### DIFF
--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -1355,8 +1355,13 @@ ORDER BY civicrm_custom_group.weight,
                 CRM_Utils_Array::formatArrayKeys($value);
                 $checkedValue = $value;
               }
+              // Serialized values from db
+              elseif ($value === '' || strpos($value, CRM_Core_DAO::VALUE_SEPARATOR) !== FALSE) {
+                $checkedValue = CRM_Utils_Array::explodePadded($value);
+              }
+              // Comma-separated values e.g. from a select2 widget during reload on form error
               else {
-                $checkedValue = explode(CRM_Core_DAO::VALUE_SEPARATOR, substr($value, 1, -1));
+                $checkedValue = explode(',', $value);
               }
               foreach ($checkedValue as $val) {
                 if ($val) {


### PR DESCRIPTION
Overview
----------------------------------------
Fixes https://lab.civicrm.org/dev/core/-/issues/2506

MultiValued custom ContactRef fields were losing their value during form reload if there was a validation error.
