### PR TITLE
Remove defunct default return property

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -4451,7 +4451,6 @@ civicrm_relationship.start_date > {$today}
 
       if (empty(self::$_defaultReturnProperties[$mode])) {
         self::$_defaultReturnProperties[$mode] = [
-          'home_URL' => 1,
           'image_URL' => 1,
           'legal_identifier' => 1,
           'external_identifier' => 1,


### PR DESCRIPTION

Overview
----------------------------------------
Remove defunct default return property

Before
----------------------------------------
I was unable to get anything returned in this field - I think it predates websites having
their own table & is unused. Note that the BAO_MessageTemplateTest classs
shows 'url' being populated in tokens but this not being populated

After
----------------------------------------
No-one else should have to think about this ever again

Technical Details
----------------------------------------

Comments
----------------------------------------
