### PR TITLE
AfformGui - Specify admin tpl in entity config file & fall-back to ge…

### DIFF
--- a/ext/afform/admin/afformEntities/Household.php
+++ b/ext/afform/admin/afformEntities/Household.php
@@ -13,4 +13,5 @@ return [
   'boilerplate' => [
     ['#tag' => 'afblock-name-household'],
   ],
+  'admin_tpl' => '~/afGuiEditor/entityConfig/Contact.html',
 ];

--- a/ext/afform/admin/afformEntities/Individual.php
+++ b/ext/afform/admin/afformEntities/Individual.php
@@ -13,4 +13,5 @@ return [
   'boilerplate' => [
     ['#tag' => 'afblock-name-individual'],
   ],
+  'admin_tpl' => '~/afGuiEditor/entityConfig/Contact.html',
 ];

--- a/ext/afform/admin/afformEntities/Organization.php
+++ b/ext/afform/admin/afformEntities/Organization.php
@@ -13,4 +13,5 @@ return [
   'boilerplate' => [
     ['#tag' => 'afblock-name-organization'],
   ],
+  'admin_tpl' => '~/afGuiEditor/entityConfig/Contact.html',
 ];

--- a/ext/afform/admin/ang/afGuiEditor/afGuiEntity.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiEntity.component.js
@@ -26,6 +26,10 @@
         return afGui.meta.entities[getEntityType()];
       };
 
+      $scope.getAdminTpl = function() {
+        return $scope.getMeta().admin_tpl || '~/afGuiEditor/entityConfig/Generic.html';
+      };
+
       $scope.getField = afGui.getField;
 
       $scope.valuesFields = function() {

--- a/ext/afform/admin/ang/afGuiEditor/afGuiEntity.html
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiEntity.html
@@ -56,5 +56,5 @@
 
 <fieldset ng-if="!$ctrl.entity.loading && $ctrl.editor.allowEntityConfig">
   <legend>{{:: ts('Options') }}</legend>
-  <div ng-include="::'~/afGuiEditor/entityConfig/' + $ctrl.entity.type + '.html'"></div>
+  <div ng-include=":: getAdminTpl()"></div>
 </fieldset>

--- a/ext/afform/admin/ang/afGuiEditor/entityConfig/Activity.html
+++ b/ext/afform/admin/ang/afGuiEditor/entityConfig/Activity.html
@@ -1,1 +1,0 @@
-<div ng-include="'~/afGuiEditor/entityConfig/Generic.html'"></div>


### PR DESCRIPTION
Overview
----------------------------------------
Fixes https://lab.civicrm.org/dev/core/-/issues/2533

This lowers the bar to exposing an entity to Afform, as now only one config file is required; the form template is now optional.

Before
----------------------------------------
Exposing an entity to the Afform GUI required a php config file + an html form template.

After
----------------------------------------
The form template is no longer required, and its location is now specified in the php config file, making it easier to include it from an extension.

Comments
----------------------------------------
This one's for you @eileenmcnaughton 