### PR TITLE
Fix hard crash when deduping if any multiValued ContactRef fields exist

### DIFF
--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -503,6 +503,7 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
     $cpTables = self::cpTables();
     $paymentTables = self::paymentTables();
     self::filterRowBasedCustomDataFromCustomTables($cidRefs);
+    $multiValueCidRefs = self::getMultiValueCidRefs();
 
     $affected = array_merge(array_keys($cidRefs), array_keys($eidRefs));
 
@@ -581,7 +582,14 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
 
           $preOperationSqls = self::operationSql($mainId, $otherId, $table, $tableOperations);
           $sqls = array_merge($sqls, $preOperationSqls);
-          $sqls[] = "UPDATE $table SET $field = $mainId WHERE $field = $otherId";
+
+          if (!empty($multiValueCidRefs[$table][$field])) {
+            $sep = CRM_Core_DAO::VALUE_SEPARATOR;
+            $sqls[] = "UPDATE $table SET $field = REPLACE($field, '$sep$otherId$sep', '$sep$mainId$sep') WHERE $field LIKE '%$sep$otherId$sep%'";
+          }
+          else {
+            $sqls[] = "UPDATE $table SET $field = $mainId WHERE $field = $otherId";
+          }
         }
       }
 
@@ -635,6 +643,28 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
         unset($cidRefs[$tableName]);
       }
     }
+  }
+
+  /**
+   * Return an array of tables & fields which hold serialized arrays of contact ids
+   *
+   * Return format is ['table_name' => ['field_name' => SERIALIZE_METHOD]]
+   *
+   * For now, only custom fields can be serialized and the only
+   * method used is CRM_Core_DAO::SERIALIZE_SEPARATOR_BOOKEND.
+   */
+  protected static function getMultiValueCidRefs() {
+    $fields = \Civi\Api4\CustomField::get(FALSE)
+      ->addSelect('custom_group.table_name', 'column_name', 'serialize')
+      ->addWhere('data_type', '=', 'ContactReference')
+      ->addWhere('serialize', 'IS NOT EMPTY')
+      ->execute();
+
+    $map = [];
+    foreach ($fields as $field) {
+      $map[$field['custom_group.table_name']][$field['column_name']] = $field['serialize'];
+    }
+    return $map;
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Fixes https://lab.civicrm.org/dev/core/-/issues/2561

If any multi-valued ContactRef custom fields exist in the system, it will crash the dedupe merger.

Before
----------------------------------------
Merging any two contacts will crash.

After
----------------------------------------
No crash.

Comments
----------------------------------------
I wish the dedupe merger code was more flexible about dealing with multi-valued fields. I had to kind of shoehorn some extra field metadata & special handling into the existing code, whereas I think its arrays of table => column pairs ought to be arrays of arrays of metadata about the columns, which can include the serialization method used if any.