### PR TITLE
Move more functions to the pdfLetter class

### DIFF
--- a/tests/phpunit/CRM/Contribute/Form/Task/PDFLetterCommonTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/Task/PDFLetterCommonTest.php
@@ -435,7 +435,7 @@ value=$contact_aggregate+$contribution.total_amount}
    */
   public function testIsHtmlTokenInTableCell($token, $entity, $textToSearch, $expected) {
     $this->assertEquals($expected,
-      CRM_Contribute_Form_Task_PDFLetterCommon::isHtmlTokenInTableCell($token, $entity, $textToSearch)
+      CRM_Contribute_Form_Task_PDFLetter::isHtmlTokenInTableCell($token, $entity, $textToSearch)
     );
   }
 


### PR DESCRIPTION

Overview
----------------------------------------
Move more functions to the pdfLetter function

Before
----------------------------------------
Functions on 'common' class that isn't really common and is only used by this class within git universe

After
----------------------------------------
More functions moved back to the 'real' class. Instances of 'self' replaces to make the process less fraught

Technical Details
----------------------------------------
This 'common' form isn't really common - it's silly. This PR removes all
the gotcha instances of 'self::' to make it easier to decommission this file

Note that there are no calls to the class outside core in git universe

Unit tests cover the code in question & any fail would be a hard fail

Comments
----------------------------------------
