### PR TITLE
hook_managed - do not try to disable managed entities if is_active is not available to api3.create

### DIFF
--- a/CRM/Core/ManagedEntities.php
+++ b/CRM/Core/ManagedEntities.php
@@ -264,7 +264,10 @@ class CRM_Core_ManagedEntities {
     $doUpdate = ($policy == 'always');
 
     if ($doUpdate) {
-      $defaults = ['id' => $dao->entity_id, 'is_active' => 1];
+      $defaults = ['id' => $dao->entity_id];
+      if ($this->isActivationSupported($dao->entity_type)) {
+        $defaults['is_active'] = 1;
+      }
       $params = array_merge($defaults, $todo['params']);
 
       $manager = CRM_Extension_System::singleton()->getManager();

--- a/CRM/Core/ManagedEntities.php
+++ b/CRM/Core/ManagedEntities.php
@@ -301,10 +301,17 @@ class CRM_Core_ManagedEntities {
    * inactive.
    *
    * @param CRM_Core_DAO_Managed $dao
+   *
+   * @throws \CiviCRM_API3_Exception
    */
-  public function disableEntity($dao) {
-    // FIXME: if ($dao->entity_type supports is_active) {
-    if (TRUE) {
+  public function disableEntity($dao): void {
+    $actions = civicrm_api3($dao->entity_type, 'getactions', [])['values'];
+    $supportsDisable = FALSE;
+    if (in_array('create', $actions, TRUE) && in_array('getfields', $actions)) {
+      $fields = civicrm_api3($dao->entity_type, 'getfields', ['action' => 'create'])['values'];
+      $supportsDisable = array_key_exists('is_active', $fields);
+    }
+    if ($supportsDisable) {
       // FIXME cascading for payproc types?
       $params = [
         'version' => 3,


### PR DESCRIPTION
Overview
----------------------------------------
Only try to disable disable-able entities from managed
~~Respect cleanup = never on disableEntities~~

Before
----------------------------------------
```
 // FIXME: if ($dao->entity_type supports is_active) {
    if (TRUE) {
```
~~Currently cleanup=never is respected on ininstall but not on disable~~

After
----------------------------------------
Check is done to ensure the entity can be disabled (using v3 api)

Technical Details
----------------------------------------
I'm hitting this as a bug on a cleanup=never entity which has a v4 api and not a v3 api so it could be
solved using more failure tolerance in the disable function or checking more values/ entity availability

We discussed adding the 'activate' key and while I think that is a good idea I hit some implementation issues - I couldn't see how to do that without adding a field to civicrm_managed since the information is otherwise unavailable at the right time.

However, I did note that I could resolve a TODO in the code and at the same time ameliorate the issue I was dealing with

~~However, I actually think the intuitive meaning of cleanup = never is 'never try to clean this up
' and I don't see why that would apply to uninstall & not disable~~

Comments
----------------------------------------
@totten @colemanw 