### PR TITLE
Afform - Fix loading entities from url args

### DIFF
--- a/ext/afform/core/ang/af/afForm.component.js
+++ b/ext/afform/core/ang/af/afForm.component.js
@@ -4,7 +4,7 @@
     bindings: {
       ctrl: '@'
     },
-    controller: function($scope, $routeParams, $timeout, crmApi4, crmStatus, $window, $location) {
+    controller: function($scope, $timeout, crmApi4, crmStatus, $window, $location) {
       var schema = {},
         data = {},
         ctrl = this;
@@ -35,14 +35,15 @@
         return $scope.$parent.meta;
       };
       this.loadData = function() {
-        var toLoad = 0;
+        var toLoad = 0,
+          args = $scope.$parent.routeParams || {};
         _.each(schema, function(entity, entityName) {
-          if ($routeParams[entityName] || entity.autofill) {
+          if (args[entityName] || entity.autofill) {
             toLoad++;
           }
         });
         if (toLoad) {
-          crmApi4('Afform', 'prefill', {name: ctrl.getFormMeta().name, args: $routeParams})
+          crmApi4('Afform', 'prefill', {name: ctrl.getFormMeta().name, args: args})
             .then(function(result) {
               _.each(result, function(item) {
                 data[item.name] = data[item.name] || {};
@@ -53,7 +54,7 @@
       };
 
       this.submit = function submit() {
-        var submission = crmApi4('Afform', 'submit', {name: ctrl.getFormMeta().name, args: $routeParams, values: data});
+        var submission = crmApi4('Afform', 'submit', {name: ctrl.getFormMeta().name, args: $scope.$parent.routeParams || {}, values: data});
         var metaData = ctrl.getFormMeta();
         if (metaData.redirect) {
           submission.then(function() {

--- a/ext/afform/core/ang/afCore.ang.php
+++ b/ext/afform/core/ang/afCore.ang.php
@@ -7,7 +7,7 @@ return [
     'ang/afCore/*/*.js',
   ],
   'css' => ['ang/afCore.css'],
-  'requires' => ['crmUi', 'crmUtil', 'api4', 'checklist-model', 'ngRoute'],
+  'requires' => ['crmUi', 'crmUtil', 'api4', 'checklist-model'],
   'partials' => ['ang/afCore'],
   'settings' => [],
   'basePages' => [],


### PR DESCRIPTION
Overview
----------------------------------------
Fixes https://lab.civicrm.org/dev/core/-/issues/2567

Loading existing entities via url args was not working.

Before
----------------------------------------
Url arguments ignored.

After
----------------------------------------
Now entities can be loaded with a url like `civicrm/my/afform#!?Individual1=123`

Comments
----------------------------------------
This broke when we stopped using ngRoute.
