### PR TITLE
Fix enotice when Log service is swapped out

### DIFF
--- a/CRM/Core/Error/Log.php
+++ b/CRM/Core/Error/Log.php
@@ -26,7 +26,14 @@ class CRM_Core_Error_Log extends \Psr\Log\AbstractLogger {
    * CRM_Core_Error_Log constructor.
    */
   public function __construct() {
-    $this->map = [
+    $this->map = self::getMap();
+  }
+
+  /**
+   * @return array
+   */
+  public static function getMap():array {
+    return [
       \Psr\Log\LogLevel::DEBUG => PEAR_LOG_DEBUG,
       \Psr\Log\LogLevel::INFO => PEAR_LOG_INFO,
       \Psr\Log\LogLevel::NOTICE => PEAR_LOG_NOTICE,

--- a/Civi/API/LogObserver.php
+++ b/Civi/API/LogObserver.php
@@ -23,7 +23,7 @@ class LogObserver extends \Log_observer {
    * @param array $event
    */
   public function notify($event) {
-    $levels = \Civi::log()->map;
+    $levels = \CRM_Core_Error_Log::getMap();
     $event['level'] = array_search($event['priority'], $levels);
     // Extract [civi.tag] from message string
     // As noted in \CRM_Core_Error_Log::log() the $context array gets prematurely converted to string with print_r() so we have to un-flatten it here


### PR DESCRIPTION
Overview
----------------------------------------
Fix enotice when Log service is swapped out

Before
----------------------------------------
If the service retrieved by Civi::log() is NOT an instance of CRM_Core_Error_Log then there will be an enotice as there is no map property in the interface & there cannot be expected to be one in any alternate services

After
----------------------------------------
The array can be retrieved from a public function.

Technical Details
----------------------------------------
This function is calling a property on the psr_log service that may not exist. If the
service is swapped out there is no reason the replacement should have this property.
