### PR TITLE
dev/core#2564 Fix class constants for when using phpseclib v1

### DIFF
--- a/Civi/Crypto/PhpseclibCipherSuite.php
+++ b/Civi/Crypto/PhpseclibCipherSuite.php
@@ -48,9 +48,9 @@ class PhpseclibCipherSuite implements CipherSuiteInterface {
     }
     elseif (class_exists('Crypt_AES')) {
       // phpseclib v1
-      $this->ciphers['aes-cbc'] = new \Crypt_AES(\Crypt_AES::MODE_CBC);
+      $this->ciphers['aes-cbc'] = new \Crypt_AES(\Crypt_AES::CRYPT_MODE_CBC);
       $this->ciphers['aes-cbc']->setKeyLength(256);
-      $this->ciphers['aes-ctr'] = new \Crypt_AES(\Crypt_AES::MODE_CTR);
+      $this->ciphers['aes-ctr'] = new \Crypt_AES(\Crypt_AES::CRYPT_MODE_CTR);
       $this->ciphers['aes-ctr']->setKeyLength(256);
     }
     else {

--- a/Civi/Crypto/PhpseclibCipherSuite.php
+++ b/Civi/Crypto/PhpseclibCipherSuite.php
@@ -48,9 +48,9 @@ class PhpseclibCipherSuite implements CipherSuiteInterface {
     }
     elseif (class_exists('Crypt_AES')) {
       // phpseclib v1
-      $this->ciphers['aes-cbc'] = new \Crypt_AES(\Crypt_AES::CRYPT_MODE_CBC);
+      $this->ciphers['aes-cbc'] = new \Crypt_AES(CRYPT_MODE_CBC);
       $this->ciphers['aes-cbc']->setKeyLength(256);
-      $this->ciphers['aes-ctr'] = new \Crypt_AES(\Crypt_AES::CRYPT_MODE_CTR);
+      $this->ciphers['aes-ctr'] = new \Crypt_AES(CRYPT_MODE_CBC);
       $this->ciphers['aes-ctr']->setKeyLength(256);
     }
     else {


### PR DESCRIPTION
Overview
----------------------------------------
This fixes a recent regression issue involving the new crypto library in that in phpseclib v1 the class constants are prefixed with CRYPTO_

Before
----------------------------------------
Incorrect class constants used in phpseclibv1 code

After
----------------------------------------
Correct class constants

ping @totten @colemanw 

Relevant lab ticket https://lab.civicrm.org/dev/core/-/issues/2564
