### PR TITLE
dev/events#49 Hide additional participant text when only registering one participant

### DIFF
--- a/CRM/Event/Form/Registration/Register.php
+++ b/CRM/Event/Form/Registration/Register.php
@@ -351,7 +351,7 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
           ts('How many people are you registering?'),
           $additionalOptions,
           NULL,
-          ['onChange' => "allowParticipant()"]
+          ['onChange' => "additionalParticipantsChange()"]
         );
         $isAdditionalParticipants = TRUE;
       }

--- a/templates/CRM/Event/Form/Registration/Register.tpl
+++ b/templates/CRM/Event/Form/Registration/Register.tpl
@@ -60,10 +60,9 @@
       <div class="crm-public-form-item crm-section additional_participants-section" id="noOfparticipants">
         <div class="label">{$form.additional_participants.label} <span class="crm-marker" title="{ts}This field is required.{/ts}">*</span></div>
         <div class="content">
-          {$form.additional_participants.html}{if $contact_id || $contact_id == NULL}{ts}(including yourself){/ts}{/if}
+          {$form.additional_participants.html}{if $contact_id || $contact_id == NULL}&nbsp;{ts}(including yourself){/ts}{/if}
           <br/>
-          <span
-            class="description">{ts}Fill in your registration information on this page. If you are registering additional people, you will be able to enter their registration information after you complete this page and click &quot;Review your registration&quot;.{/ts}</span>
+          <div class="description" id="additionalParticipantsDescription" style="display: none;">{ts}Fill in your registration information on this page. You will be able to enter their registration information for additional people after you complete this page and click &quot;Review your registration&quot;.{/ts}</div>
         </div>
         <div class="clear"></div>
       </div>
@@ -167,6 +166,23 @@
     pcpAnonymous();
   {/if}
   {literal}
+
+  function additionalParticipantsChange() {
+    toggleAdditionalParticipantsDescription();
+    allowParticipant();
+  }
+
+  function toggleAdditionalParticipantsDescription() {
+    if (cj('#additional_participants').val()) {
+      cj("#additionalParticipantsDescription").show();
+    } else {
+      cj("#additionalParticipantsDescription").hide();
+    }
+  }
+
+  window.onload = function() {
+    toggleAdditionalParticipantsDescription();
+  };
 
   function allowParticipant() {
     {/literal}{if $allowGroupOnWaitlist}{literal}


### PR DESCRIPTION
Before
----------------------------------------
Lengthy text about additional participants is shown to all event registrants when additional participants is enabled.
![image](https://user-images.githubusercontent.com/25517556/116103855-340f5c00-a66d-11eb-8d2c-2c4b3b312b18.png)

After
----------------------------------------
Additional participants text is only show when 2 or more is selected for total number of participants.
![image](https://user-images.githubusercontent.com/25517556/116112399-c2d3a700-a674-11eb-9cbb-66db964390ed.png)
![image](https://user-images.githubusercontent.com/25517556/116112419-c6672e00-a674-11eb-9947-9ffce8f0f526.png)

Comments
----------------------------------------
I used window.onload to toggle visibility as needed when the user uses the back button (in the browser or on the page). Not sure if this is how this is usually handled here.

This will require new translations. Also added a space before (including yourself).

EDIT: Added window.onload.
