### PR TITLE
allow event transfer on backend when self-service transfer is disabled

### DIFF
--- a/CRM/Event/BAO/Participant.php
+++ b/CRM/Event/BAO/Participant.php
@@ -1898,7 +1898,7 @@ WHERE    civicrm_participant.contact_id = {$contactID} AND
       $eventTitle = $dao->title;
       $eventId = $dao->event_id;
     }
-    if (!$details['allow_selfcancelxfer']) {
+    if (!$details['allow_selfcancelxfer'] && !$isBackOffice) {
       $details['eligible'] = FALSE;
       $details['ineligible_message'] = ts('This event registration can not be transferred or cancelled. Contact the event organizer if you have questions.');
       return $details;

--- a/tests/phpunit/CRM/Event/BAO/ParticipantTest.php
+++ b/tests/phpunit/CRM/Event/BAO/ParticipantTest.php
@@ -516,6 +516,15 @@ class CRM_Event_BAO_ParticipantTest extends CiviUnitTestCase {
       'isBackOffice' => FALSE,
       'successExpected' => FALSE,
     ];
+    // Update from back office even when self-service is disabled
+    $scenarios[] = [
+      'selfSvcEnabled' => 0,
+      'selfSvcHours' => 12,
+      'hoursToEvent' => 16,
+      'participantStatusId' => 1,
+      'isBackOffice' => TRUE,
+      'successExpected' => TRUE,
+    ];
     return $scenarios;
   }
 


### PR DESCRIPTION
https://lab.civicrm.org/dev/event/-/issues/54

Overview
----------------------------------------
When self-service transfer/cancellation is disabled, back-office transfer/cancellation is also disabled.

Before
----------------------------------------
Error message: "This event registration can not be transferred or cancelled. Contact the event organizer if you have questions."

After
----------------------------------------
You can reach the transfer/cancellation screen (which has its own bug, but that's out of scope here).

Technical Details
----------------------------------------
Pretty sure this regressed on event#35 (aka me).

Comments
----------------------------------------
I refactored a bunch of this code last year, but there's still some very poor code here.  If we move the transfer and cancellation functions from the form layer to the BAO that will improve matters considerably.
