### PR TITLE
Globally reset angular hashPrefix

### DIFF
--- a/Civi/Angular/AngularLoader.php
+++ b/Civi/Angular/AngularLoader.php
@@ -155,6 +155,7 @@ class AngularLoader {
     $headOffset = 0;
     $config = \CRM_Core_Config::singleton();
     if ($config->debug) {
+      $res->addScriptFile('civicrm', 'ang/resetLocationProviderHashPrefix.js', 101, $this->getRegion(), FALSE);
       foreach ($moduleNames as $moduleName) {
         foreach ($this->angular->getResources($moduleName, 'css', 'cacheUrl') as $url) {
           $res->addStyleUrl($url, self::DEFAULT_MODULE_WEIGHT + (++$headOffset), $this->getRegion());

--- a/Civi/Angular/AngularLoader.php
+++ b/Civi/Angular/AngularLoader.php
@@ -155,6 +155,7 @@ class AngularLoader {
     $headOffset = 0;
     $config = \CRM_Core_Config::singleton();
     if ($config->debug) {
+      // FIXME: The `resetLocationProviderHashPrefix.js` has to stay in sync with `\Civi\Angular\Page\Modules::buildAngularModules()`.
       $res->addScriptFile('civicrm', 'ang/resetLocationProviderHashPrefix.js', 101, $this->getRegion(), FALSE);
       foreach ($moduleNames as $moduleName) {
         foreach ($this->angular->getResources($moduleName, 'css', 'cacheUrl') as $url) {

--- a/Civi/Angular/Page/Modules.php
+++ b/Civi/Angular/Page/Modules.php
@@ -85,7 +85,11 @@ class Modules extends \CRM_Core_Page {
       case 'angular-modules.js':
         $moduleNames = $page->parseModuleNames($event->params['modules'] ?? NULL, $angular);
         $event->mimeType = 'application/javascript';
-        $event->content = $page->digestJs($angular->getResources($moduleNames, 'js', 'path'));
+        $files = array_merge(
+          [\Civi::resources()->getPath('civicrm', 'ang/resetLocationProviderHashPrefix.js')],
+          $angular->getResources($moduleNames, 'js', 'path')
+        );
+        $event->content = $page->digestJs($files);
         break;
 
       case 'angular-modules.css':

--- a/Civi/Angular/Page/Modules.php
+++ b/Civi/Angular/Page/Modules.php
@@ -86,6 +86,7 @@ class Modules extends \CRM_Core_Page {
         $moduleNames = $page->parseModuleNames($event->params['modules'] ?? NULL, $angular);
         $event->mimeType = 'application/javascript';
         $files = array_merge(
+          // FIXME: The `resetLocationProviderHashPrefix.js` has to stay in sync with `\Civi\Angular\AngularLoader::load()`.
           [\Civi::resources()->getPath('civicrm', 'ang/resetLocationProviderHashPrefix.js')],
           $angular->getResources($moduleNames, 'js', 'path')
         );

--- a/ang/crmApp.js
+++ b/ang/crmApp.js
@@ -4,11 +4,6 @@
   // modules should depend on it.
   var crmApp = angular.module('crmApp', CRM.angular.modules);
 
-  // dev/core#1818 use angular 1.5 default of # instead of 1.6+ default of #!
-  crmApp.config(['$locationProvider', function($locationProvider) {
-    $locationProvider.hashPrefix("");
-  }]);
-
   crmApp.config(['$routeProvider',
     function($routeProvider) {
 

--- a/ang/resetLocationProviderHashPrefix.js
+++ b/ang/resetLocationProviderHashPrefix.js
@@ -1,0 +1,9 @@
+(function(angular, $, _) {
+
+  // dev/core#1818 use angular 1.5 default of # instead of 1.6+ default of #!
+  angular.module('ng')
+    .config(['$locationProvider', function($locationProvider) {
+      $locationProvider.hashPrefix('');
+    }]);
+
+})(angular, CRM.$, CRM._);


### PR DESCRIPTION
Overview
----------------------------------------
Globally reset the AngularJS hash prefix for consistency across all modules and pages in CiviCRM.

Before
----------------------------------------
Pages using `crmApp` would have no prefix, other pages would use the new AngularJS default of `!`

After
----------------------------------------
No prefix, consistently for all pages in Civi.

Technical Details
----------------------------------------
A bit of background on the `#!?` thing, (See [`dev/core#1818`](https://lab.civicrm.org/dev/core/-/issues/1818)):
Angular 1.8 uses a default prefix of `!` after the hash and before the route.
Previous versions of Angular did not use that prefix.
When we upgraded to 1.8 I added a setting to `crmApp` to disable the new prefix for backward-compatability.
But Afform doesn't use `crmApp` so defaults to urls with the prefix.
I actually think that's bad, since afforms can be embedded anywhere (including pages which use `crmApp`) it would lead to inconsistencies.