### PR TITLE
SearchKit - Exclude serialized fields from implicit join selection

### DIFF
--- a/ext/search_kit/Civi/Search/Admin.php
+++ b/ext/search_kit/Civi/Search/Admin.php
@@ -123,7 +123,7 @@ class Admin {
     foreach ($schema as &$entity) {
       if (in_array('DAOEntity', $entity['type'], TRUE) && !in_array('EntityBridge', $entity['type'], TRUE)) {
         foreach (array_reverse($entity['fields'], TRUE) as $index => $field) {
-          if (!empty($field['fk_entity']) && !$field['options'] && !empty($schema[$field['fk_entity']]['label_field'])) {
+          if (!empty($field['fk_entity']) && !$field['options'] && empty($field['serialize']) && !empty($schema[$field['fk_entity']]['label_field'])) {
             $isCustom = strpos($field['name'], '.');
             // Custom fields: append "Contact ID" to original field label
             if ($isCustom) {


### PR DESCRIPTION
Overview
----------------------------------------
SearchKit automatically makes certain fields available, e.g. email contact -> display_name. This type of join is not possible with serialized values (e.g. a multi-valued ContactReference custom field).

See https://lab.civicrm.org/dev/core/-/issues/2553#note_58551

Before
----------------------------------------
"Display Name" shown as an option for multi-valued ContactReference custom fields, but didn't actually work.

After
----------------------------------------
Still doesn't work, but not shown as an option.