### PR TITLE
Fix priceset widget on Membership tab

### DIFF
--- a/CRM/Member/Form/MembershipBlock.php
+++ b/CRM/Member/Form/MembershipBlock.php
@@ -174,7 +174,7 @@ class CRM_Member_Form_MembershipBlock extends CRM_Contribute_Form_ContributionPa
     //$this->add('select', 'member_price_set_id', ts('Membership Price Set'), (['' => ts('- none -')] + $price));
 
     $this->addField('member_price_set_id', [
-      'entity' => 'PriceSet',
+      'entity' => 'PriceField',
       'name' => 'price_set_id',
       'options' => $price,
     ]);


### PR DESCRIPTION
Overview
----------------------------------------
Fix priceset widget on Membership tab

Before
----------------------------------------
Priceset widget is not loaded as dropdown on Membership Tab of the contribution settings page https://dmaster.demo.civicrm.org/civicrm/admin/contribute/membership?reset=1&action=update&id=2

![image](https://user-images.githubusercontent.com/5929648/116188961-dc90ef00-a745-11eb-89fe-06e4ab58b3db.png)


After
----------------------------------------
Fixed.

![image](https://user-images.githubusercontent.com/5929648/116189025-f7fbfa00-a745-11eb-81e1-3bc817e9ce81.png)

Technical Details
----------------------------------------
Possibly a missed file when the regression was fixed in https://github.com/civicrm/civicrm-core/pull/19723? @eileenmcnaughton 
