### PR TITLE
[REF] Post move cleanup - switch from $form to $this

### DIFF
--- a/tests/phpunit/CRM/Contribute/Form/Task/PDFLetterCommonTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/Task/PDFLetterCommonTest.php
@@ -152,7 +152,8 @@ class CRM_Contribute_Form_Task_PDFLetterCommonTest extends CiviUnitTestCase {
       ],
     ];
 
-    [$contributions, $contacts] = CRM_Contribute_Form_Task_PDFLetter::buildContributionArray('contact_id', $contributionIDs, $returnProperties, TRUE, TRUE, $messageToken, 'test', '**', FALSE);
+    $form = $this->getFormObject('CRM_Contribute_Form_Task_PDFLetter');
+    [$contributions, $contacts] = $form->buildContributionArray('contact_id', $contributionIDs, $returnProperties, TRUE, TRUE, $messageToken, 'test', '**', FALSE);
 
     $this->assertEquals('Anthony', $contacts[$this->_individualId]['first_name']);
     $this->assertEquals('emo', $contacts[$this->_individualId]['favourite_emoticon']);


### PR DESCRIPTION
Overview
----------------------------------------
[REF] Post move cleanup - switch from $form to $this

Before
----------------------------------------
```$form = $this``` & $form used

After
----------------------------------------
```$this``` used

Technical Details
----------------------------------------

Comments
----------------------------------------
