### PR TITLE
Remove apparent copy & paste from Contribution pdf letter function

### DIFF
--- a/CRM/Contribute/Form/Task/PDFLetter.php
+++ b/CRM/Contribute/Form/Task/PDFLetter.php
@@ -37,26 +37,8 @@ class CRM_Contribute_Form_Task_PDFLetter extends CRM_Contribute_Form_Task {
   public function preProcess() {
     $this->skipOnHold = $this->skipDeceased = FALSE;
     CRM_Contact_Form_Task_PDFLetterCommon::preProcess($this);
-    // store case id if present
-    $this->_caseId = CRM_Utils_Request::retrieve('caseid', 'CommaSeparatedIntegers', $this, FALSE);
-    if (!empty($this->_caseId) && strpos($this->_caseId, ',')) {
-      $this->_caseIds = explode(',', $this->_caseId);
-      unset($this->_caseId);
-    }
-
-    // retrieve contact ID if this is 'single' mode
-    $cid = CRM_Utils_Request::retrieve('cid', 'CommaSeparatedIntegers', $this, FALSE);
-
-    $this->_activityId = CRM_Utils_Request::retrieve('id', 'Positive', $this, FALSE);
-
-    if ($cid) {
-      CRM_Contact_Form_Task_PDFLetterCommon::preProcessSingle($this, $cid);
-      $this->_single = TRUE;
-    }
-    else {
-      parent::preProcess();
-    }
-    $this->assign('single', $this->_single);
+    parent::preProcess();
+    $this->assign('single', $this->isSingle());
   }
 
   /**

--- a/CRM/Contribute/Form/Task/TaskTrait.php
+++ b/CRM/Contribute/Form/Task/TaskTrait.php
@@ -138,4 +138,13 @@ trait CRM_Contribute_Form_Task_TaskTrait {
     return ' civicrm_contribution.id IN ( ' . implode(',', $this->getIDs()) . ' ) ';
   }
 
+  /**
+   * Is only one entity being processed?
+   *
+   * @return false
+   */
+  public function isSingle() {
+    return $this->_single ?? FALSE;
+  }
+
 }


### PR DESCRIPTION


Overview
----------------------------------------
Remove apparent copy & paste from Contribution pdf letter function

Before
----------------------------------------
url params handled but I can't find any way to call this code with them and they look like copy & paste

After
----------------------------------------
Simplified

Technical Details
----------------------------------------
I have done a bit of digging and I can't see any way these url parameters could be passed in
to this form. I also can't think of any reason, other than our old friend copy
& paste, for us to be retrieving activity or case in the url

I kept the isSingle logic but redirected it to focus on a single contribution which
is something we do want

Comments
----------------------------------------
@demeritcowboy maybe you could put your super-sleuth skills to work to validate my conclusions here. I want to expose this (and other) contribution actions to search kit and as single row actions but this handling complicates it and 'hogs' the id parameter which shoud be available for the actual id