### PR TITLE
community/feature-request#12 Logging - On new deployments, direct channels to separate log files. Accept CIVICRM_LOG_FILE.

### DIFF
--- a/CRM/Core/Error/Log.php
+++ b/CRM/Core/Error/Log.php
@@ -23,6 +23,26 @@ class CRM_Core_Error_Log extends \Psr\Log\AbstractLogger {
   public $map;
 
   /**
+   * The logging channel - this is used as a prefix to distinguish the files.
+   *
+   * @var string
+   */
+  protected $channel;
+
+  /**
+   * Set a prefix for the log file.
+   *
+   * Note this is ignored if the characters are not alphanumeric or _ or -.
+   *
+   * @param string $channel
+   */
+  public function setChannel(string $channel): void {
+    if (CRM_Utils_Rule::alphanumeric($channel)) {
+      $this->channel = $channel;
+    }
+  }
+
+  /**
    * CRM_Core_Error_Log constructor.
    */
   public function __construct() {
@@ -54,7 +74,7 @@ class CRM_Core_Error_Log extends \Psr\Log\AbstractLogger {
       }
       $message .= "\n" . print_r($context, 1);
     }
-    CRM_Core_Error::debug_log_message($message, FALSE, '', $this->map[$level]);
+    CRM_Core_Error::debug_log_message($message, FALSE, $this->channel, $this->map[$level]);
   }
 
 }

--- a/Civi/Core/LogManager.php
+++ b/Civi/Core/LogManager.php
@@ -39,6 +39,9 @@ class LogManager {
       $c = \Civi::container();
       $svc = "log." . $channel;
       $this->channels[$channel] = $c->has($svc) ? $c->get($svc) : $c->get(self::DEFAULT_LOGGER);
+      if ($channel !== 'default' && method_exists($this->channels[$channel], 'setChannel')) {
+        $this->channels[$channel]->setChannel($channel);
+      }
     }
     return $this->channels[$channel];
   }

--- a/Civi/Core/LogManager.php
+++ b/Civi/Core/LogManager.php
@@ -38,10 +38,17 @@ class LogManager {
     if (!isset($this->channels[$channel])) {
       $c = \Civi::container();
       $svc = "log." . $channel;
-      $this->channels[$channel] = $c->has($svc) ? $c->get($svc) : $c->get(self::DEFAULT_LOGGER);
-      if ($channel !== 'default' && method_exists($this->channels[$channel], 'setChannel')) {
-        $this->channels[$channel]->setChannel($channel);
+      if ($c->has($svc)) {
+        $log = $c->get($svc);
       }
+      else {
+        $log = $c->get(self::DEFAULT_LOGGER);;
+        if (is_callable([$log, 'setChannel'])) {
+          $log = clone $log;
+          $log->setChannel($channel);
+        }
+      }
+      $this->channels[$channel] = $log;
     }
     return $this->channels[$channel];
   }

--- a/templates/CRM/common/civicrm.settings.php.template
+++ b/templates/CRM/common/civicrm.settings.php.template
@@ -518,9 +518,37 @@ if (CIVICRM_UF === 'UnitTests') {
 }
 
 /**
+ * Define the naming convention for log files.
+ *
+ * By default, paths are relative to the standard CiviCRM log dir. However, an absolute path may be used.
+ *
+ * The following variables are accepted:
+ *   - {{HASH}}: A unique/hard-to-guess code which identifies the deployment. Use this to mitigate the risk that logs could be leaked by a misconfigured web-server.
+ *   - {{CHANNEL}}: The name of the log-channel. If channel is blank, use "default".
+ *   - {{LEGACY_CHANNEL}}: (Backward compat) The name of the log-channel followed by ".". If channel is blank, then "".
+ *   - {{LEGACY_HASH}}: (Backward compat) Depending on "CIVICRM_LOG_HASH", this is either an empty-string or HASH-plus-".".
+ *   - {{YYYY-MM-DD}}: The current date (eg "2021-01-02")
+ */
+if (!defined('CIVICRM_LOG_FILE'))  {
+     define('CIVICRM_LOG_FILE', 'CiviCRM.{{CHANNEL}}.{{HASH}}.log');                // Default on new deployments
+//   define('CIVICRM_LOG_FILE', 'CiviCRM.{{LEGACY_CHANNEL}}{{LEGACY_HASH}}log');    // Default on old/existing deployments
+//   define('CIVICRM_LOG_FILE', 'CiviCRM.{{HASH}}.log');                            // Consolidate logs in one per-site/uniquely-named file.
+//   define('CIVICRM_LOG_FILE', '/var/log/php/CiviCRM.log');                        // Consolidate logs in one file.
+//   define('CIVICRM_LOG_FILE', '[civicrm.log]/{{HASH}}/{{CHANNEL}}/{{YYYY-MM-DD}}.log');
+//   define('CIVICRM_LOG_FILE', '[cms.root]/../var/log/civicrm-{{CHANNEL}}-{{YYYY-MM-DD}}.log');
+//   define('CIVICRM_LOG_FILE', '/var/log/civicrm/{{HASH}}/{{CHANNEL}}-{{YYYY-MM-DD}}.log');
+//   define('CIVICRM_LOG_FILE', '/tmp/civicrm-{{HASH}}-{{CHANNEL}}-{{YYYY-MM-DD}}.log');
+//   define('CIVICRM_LOG_FILE', getenv('CIVICRM_LOG_FILE') ?: 'CiviCRM.{{HASH}}.log');
+}
+
+/**
+ * (Deprecated; superceded by CIVICRM_LOG_FILE)
+ *
  * Whether to include the hash in config log filenames. Defaults to TRUE.
  * Disable only if you have configured the logfiles to be outside the docroot
  * using the civicrm.log path setting.
+ *
+ * This is only relevant on older deployments that lack CIVICRM_LOG_FILE.
  *
  */
 // if (!defined('CIVICRM_LOG_HASH'))  {


### PR DESCRIPTION
Overview
----------------------------------------

```php
// Sending logs with channel information
Civi::log()->error('Insufficient mozzarella');
Civi::log('ipn')->info('Not enough gouda');
Civi::log('mail')->warning('Missing camembert');

// Routing logs, optionally with channel information
define('CIVICRM_LOG_FILE', 'CiviCRM.{{CHANNEL}}.{{HASH}}.log');
define('CIVICRM_LOG_FILE', 'CiviCRM.log');
define('CIVICRM_LOG_FILE', '[cms.root]/../var/log/civicrm-{{CHANNEL}}-{{YYYY-MM-DD}}.log');
define('CIVICRM_LOG_FILE', '[civicrm.log]/{{HASH}}/{{CHANNEL}}/{{YYYY-MM-DD}}.log');
```

This changes the default routing of log-messages on new deployments.(@eileenmcnaughton, this is a variation/expansion on #20109.) It has the same basic goal of expanding the use of channels and reconciling the file-names to the list of channels. However, it addresses the transitional-process differently - by providing a configuration option `CIVICRM_LOG_FILE`.

Before
----------------------------------------

Log files are named `$config->configAndLogDir . 'CiviCRM.' . $prefixString . $hash . 'log';`

`Civi::log($channelName)` always routes to the same file, `CiviCRM.abcd1234abcd123.log`.

After
----------------------------------------

`Civi::log($channelName)`  may be routed to different files, depending on the configuration of `CIVICRM_LOG_FILE`.

The value of this constant can vary, with a few notable examples:

* For existing deployments, the default `CiviCRM.{{LEGACY_CHANNEL}}{{LEGACY_HASH}}log`. This fairly strictly matches the existing behavior -- all core messages hit `CiviCRM.1234abcd1234abcd.log` (with a few exceptions from contrib - which go to `CiviCRM.foobar.1234abcd1234abcd.log`).
* For new deployments, the default is `CiviCRM.{{CHANNEL}}.{{HASH}}.log`. This will actively encourage splitting logs/channels into separate files.
* For sysadmins that want highly predictable output (ie to feed into a log-aggregator), they can customize it - e.g. `CiviCRM.log` or `CiviCRM.{{HASH}}.log`.

The `civicrm.settings.php.template` provides several examples.

Comments
----------------------------------------

To `r-run` with different paths, I ran this command various configurations:

```bash
 cv ev 'Civi::log()->info("default stuff"); Civi::log("ipn")->info("payment stuff");'
```

Specifically, https://gist.github.com/totten/bd0df4478653330cf812bd481cb76ffc ran through the configurations.

Here's how the generated files came out with a few example configurations:

```
== Default on new deployments
== define('CIVICRM_LOG_FILE', 'CiviCRM.{{CHANNEL}}.{{HASH}}.log');
~/bknix/build/dmaster/web/sites/default/files/civicrm/ConfigAndLog/CiviCRM.default.0123abcd0123abcd99999999.log
~/bknix/build/dmaster/web/sites/default/files/civicrm/ConfigAndLog/CiviCRM.ipn.0123abcd0123abcd99999999.log

== Default on old/unconfigured deployments
== define('CIVICRM_LOG_FILE', 'CiviCRM.{{LEGACY_CHANNEL}}{{LEGACY_HASH}}log');
~/bknix/build/dmaster/web/sites/default/files/civicrm/ConfigAndLog/CiviCRM.0123abcd0123abcd99999999.log

== Use one combined log for everything
== define('CIVICRM_LOG_FILE', '/tmp/my-log/CiviCRM.log');
/tmp/my-log/CiviCRM.log

== Store logs in the normal `[civicrm.log]` folder, but with deep directories
== define('CIVICRM_LOG_FILE', '[civicrm.log]/{{HASH}}/{{CHANNEL}}/{{YYYY-MM-DD}}.log');
~/bknix/build/dmaster/web/sites/default/files/civicrm/ConfigAndLog/0123abcd0123abcd99999999/default/2021-04-27.log
~/bknix/build/dmaster/web/sites/default/files/civicrm/ConfigAndLog/0123abcd0123abcd99999999/ipn/2021-04-27.log

== Store logs in an alternate part of the `[civicrm.private]` folder
== define('CIVICRM_LOG_FILE', '[civicrm.private]/logging/{{HASH}}/{{CHANNEL}}/{{YYYY-MM-DD}}.log');
~/bknix/build/dmaster/web/sites/default/files/civicrm/logging/0123abcd0123abcd99999999/default/2021-04-27.log
~/bknix/build/dmaster/web/sites/default/files/civicrm/logging/0123abcd0123abcd99999999/ipn/2021-04-27.log

== Store logs outside of the web-root -- but as part of the project
== define('CIVICRM_LOG_FILE', '[cms.root]/../var/log/civicrm-{{CHANNEL}}-{{YYYY-MM-DD}}.log');
/Users/totten/bknix/build/dmaster/web/../var/log/civicrm-ipn-2021-04-27.log
/Users/totten/bknix/build/dmaster/web/../var/log/civicrm-default-2021-04-27.log

== Store logs in `/tmp` with long file names
== define('CIVICRM_LOG_FILE', '/tmp/my-log/civicrm-{{HASH}}-{{CHANNEL}}-{{YYYY-MM-DD}}.log');
/tmp/my-log/civicrm-0123abcd0123abcd99999999-default-2021-04-27.log
/tmp/my-log/civicrm-0123abcd0123abcd99999999-ipn-2021-04-27.log
```