### PR TITLE
REF reCAPTCHA Simplify buildCustom function on Registration form

### DIFF
--- a/CRM/Campaign/Form/Petition/Signature.php
+++ b/CRM/Campaign/Form/Petition/Signature.php
@@ -74,7 +74,7 @@ class CRM_Campaign_Form_Petition_Signature extends CRM_Core_Form {
   public $_activityProfileFields;
 
   /**
-   * The id of the survey (petition) we are proceessing
+   * The id of the survey (petition) we are processing
    *
    * @var int
    */

--- a/CRM/Event/Form/Registration.php
+++ b/CRM/Event/Form/Registration.php
@@ -30,21 +30,21 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
   const LOCATION_BLOCKS = 1;
 
   /**
-   * The id of the event we are proceessing.
+   * The id of the event we are processing.
    *
    * @var int
    */
   public $_eventId;
 
   /**
-   * The array of ids of all the participant we are proceessing.
+   * The array of ids of all the participant we are processing.
    *
    * @var int
    */
   protected $_participantIDS = NULL;
 
   /**
-   * The id of the participant we are proceessing.
+   * The id of the participant we are processing.
    *
    * @var int
    */
@@ -108,7 +108,7 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
   public $_fields;
 
   /**
-   * The billing location id for this contribiution page.
+   * The billing location id for this contribution page.
    *
    * @var int
    */
@@ -138,8 +138,6 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
    * @var bool
    *
    */
-
-
   public $_isEventFull;
 
   public $_lineItem;
@@ -210,7 +208,6 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
 
     //get the additional participant ids.
     $this->_additionalParticipantIds = $this->get('additionalParticipantIds');
-    $config = CRM_Core_Config::singleton();
 
     if (!$this->_values) {
       // create redirect URL to send folks back to event info page is registration not available
@@ -299,7 +296,7 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
       // get the profile ids
       $ufJoinParams = [
         'entity_table' => 'civicrm_event',
-        // CRM-4377: CiviEvent for the main participant, CiviEvent_Additional for additional participants
+        // CRM-4377: CiviEvent for the main participant, CiviEvent_Additional for additional participants
         'module' => 'CiviEvent',
         'entity_id' => $this->_eventId,
       ];
@@ -309,14 +306,14 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
 
       // set profiles for additional participants
       if ($this->_values['event']['is_multiple_registrations']) {
-        // CRM-4377: CiviEvent for the main participant, CiviEvent_Additional for additional participants
+        // CRM-4377: CiviEvent for the main participant, CiviEvent_Additional for additional participants
         $ufJoinParams['module'] = 'CiviEvent_Additional';
 
         list($this->_values['additional_custom_pre_id'],
           $this->_values['additional_custom_post_id'], $preActive, $postActive
           ) = CRM_Core_BAO_UFJoin::getUFGroupIds($ufJoinParams);
 
-        // CRM-4377: we need to maintain backward compatibility, hence if there is profile for main contact
+        // CRM-4377: we need to maintain backward compatibility, hence if there is profile for main contact
         // set same profile for additional contacts.
         if ($this->_values['custom_pre_id'] && !$this->_values['additional_custom_pre_id']) {
           $this->_values['additional_custom_pre_id'] = $this->_values['custom_pre_id'];
@@ -466,9 +463,6 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
         CRM_Utils_System::mungeCreditCard(CRM_Utils_Array::value('credit_card_number', $params))
       );
     }
-
-    // get the email that the confirmation would have been sent to
-    $session = CRM_Core_Session::singleton();
 
     // assign is_email_confirm to templates
     if (isset($this->_values['event']['is_email_confirm'])) {

--- a/CRM/Event/Form/Registration.php
+++ b/CRM/Event/Form/Registration.php
@@ -487,9 +487,8 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
    *
    * @param int $id
    * @param string $name
-   * @param bool $viewOnly
    */
-  public function buildCustom($id, $name, $viewOnly = FALSE) {
+  public function buildCustom($id, $name) {
     if (!$id) {
       return;
     }
@@ -553,13 +552,6 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
     if (is_array($fields)) {
       $button = substr($this->controller->getButtonName(), -4);
       foreach ($fields as $key => $field) {
-        if ($viewOnly &&
-          isset($field['data_type']) &&
-          $field['data_type'] == 'File' || ($viewOnly && $field['name'] == 'image_URL')
-        ) {
-          // ignore file upload fields
-          continue;
-        }
         //make the field optional if primary participant
         //have been skip the additional participant.
         if ($button == 'skip') {
@@ -576,7 +568,7 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
       }
     }
 
-    if ($addCaptcha && !$viewOnly) {
+    if ($addCaptcha) {
       CRM_Utils_ReCAPTCHA::enableCaptchaOnForm($this);
     }
   }


### PR DESCRIPTION
Overview
----------------------------------------
This is a refactor in preparation for moving the reCAPTCHA code to the new reCAPTCHA extension for the event registration pages.
See https://lab.civicrm.org/dev/core/-/issues/2571

Before
----------------------------------------
More complex code

After
----------------------------------------
Simpler code, will be easier to review next step which actually moves the code that adds the reCAPTCHA.

Technical Details
----------------------------------------
Split into 3 commits for ease of review.
1. Typos in comments and unused code lines.
2. Simplify the buildCustom function (use ?w=1 in URL to see that this is only removing the if that wraps everything in the function, switching to `CRM_Core_Session::getLoggedInContactID();` and moving the `$button` to nearer the only place it is used.
3. `$viewOnly` parameter is never used in this function (looks like a copy/paste from other code that left it in place).

Comments
----------------------------------------
