### PR TITLE
Simplify reCAPTCHA on ContributionBase form

### DIFF
--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -292,7 +292,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
 
     if (count($this->_paymentProcessors) >= 1 && !$this->get_template_vars("isCaptcha") && $this->hasToAddForcefully()) {
       if (!$this->_userID) {
-        $this->enableCaptchaOnForm();
+        CRM_Utils_ReCAPTCHA::enableCaptchaOnForm($this);
       }
       else {
         $this->displayCaptchaWarning();

--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -294,9 +294,6 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
       if (!$this->_userID) {
         CRM_Utils_ReCAPTCHA::enableCaptchaOnForm($this);
       }
-      else {
-        $this->displayCaptchaWarning();
-      }
     }
 
     // Build payment processor form

--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -821,17 +821,6 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
   }
 
   /**
-   * Display ReCAPTCHA warning on Contribution form
-   */
-  protected function displayCaptchaWarning() {
-    if (CRM_Core_Permission::check("administer CiviCRM")) {
-      if (!CRM_Utils_ReCAPTCHA::hasSettingsAvailable()) {
-        $this->assign('displayCaptchaWarning', TRUE);
-      }
-    }
-  }
-
-  /**
    * Check if ReCAPTCHA has to be added on Contribution form forcefully.
    */
   protected function hasToAddForcefully() {

--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -756,17 +756,10 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
         }
 
         if ($addCaptcha && !$viewOnly) {
-          $this->enableCaptchaOnForm();
+          CRM_Utils_ReCAPTCHA::enableCaptchaOnForm($this);
         }
       }
     }
-  }
-
-  /**
-   * Enable ReCAPTCHA on Contribution form
-   */
-  protected function enableCaptchaOnForm() {
-    CRM_Utils_ReCAPTCHA::enableCaptchaOnForm($this);
   }
 
   /**

--- a/templates/CRM/Contribute/Form/Contribution/Main.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Main.tpl
@@ -50,12 +50,6 @@
     {include file="CRM/Contribute/Form/Contribution/PreviewHeader.tpl"}
   {/if}
 
-  {if $displayCaptchaWarning}
-    <div class="messages status no-popup">
-      {ts}To display reCAPTCHA on form you must get an API key from<br /> <a href='https://www.google.com/recaptcha/admin/create'>https://www.google.com/recaptcha/admin/create</a>{/ts}
-    </div>
-  {/if}
-
   {if call_user_func(array('CRM_Core_Permission','check'), 'administer CiviCRM') }
     {capture assign="buttonTitle"}{ts}Configure Contribution Page{/ts}{/capture}
     {crmButton target="_blank" p="civicrm/admin/contribute/settings" q="reset=1&action=update&id=`$contributionPageID`" fb=1 title="$buttonTitle" icon="fa-wrench"}{ts}Configure{/ts}{/crmButton}


### PR DESCRIPTION
Overview
----------------------------------------
This is a refactor in preparation for moving the reCAPTCHA code to the new reCAPTCHA extension for the campaign signature form.
See https://lab.civicrm.org/dev/core/-/issues/2571

Before
----------------------------------------
More complex code.

After
----------------------------------------
Simpler code, will be easier to review next step which actually moves the code that adds the reCAPTCHA.

Technical Details
----------------------------------------
* Use CRM_Utils_ReCAPTCHA::enableCaptchaOnForm directly in ContributionBase - this was left over from a previous older refactor.
* Remove warning about reCaptcha missing key from contribution page - this is the only place that implements this "check" for reCAPTCHA enabled but not configured. It does not seem necessary as it is not implemented elsewhere - we could implement a system status check in the extension once all the code is moved across to check the reCAPTCHA configuration if required - but it seems unnecessary as the reCAPTCHA element will not be displayed if not configured and that should be trigger enough to check the settings..

Comments
----------------------------------------
