### PR TITLE
Fixes issue with state/province & country not translating values

### DIFF
--- a/CRM/Report/Form/Grant/Detail.php
+++ b/CRM/Report/Form/Grant/Detail.php
@@ -245,6 +245,9 @@ HERESQL;
         }
         $entryFound = TRUE;
       }
+
+      $entryFound = $this->alterDisplayAddressFields($row, $rows, $rowNum, NULL, NULL) ? TRUE : $entryFound;
+
       if (!$entryFound) {
         break;
       }


### PR DESCRIPTION
Overview
----------------------------------------
This is the PR to issue : https://lab.civicrm.org/dev/core/-/issues/2574
On the Detailed Grant report, the state/province shows the numeric values instead of the actual text labels.

Before
----------------------------------------
Fields `Country` and `state/province` appeared as numbers

![grantreportscreen](https://user-images.githubusercontent.com/14973113/116291454-8004f280-a78c-11eb-8149-a135d755ff52.png)

After
----------------------------------------
Fields `Country` and `state/province` should show up proper text labels

Technical Details
----------------------------------------
Code is replicated from https://lab.civicrm.org/dev/core/-/commit/b990cf153ab5a0a2f26284138a7c00745f31bf14

Comments
----------------------------------------

