### PR TITLE
Add checkAccess API & BAO functions + hook_civicrm_checkAccess

### DIFF
--- a/CRM/Contact/AccessTrait.php
+++ b/CRM/Contact/AccessTrait.php
@@ -1,0 +1,41 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+/**
+ * Trait shared with entities attached to the contact record.
+ */
+trait CRM_Contact_AccessTrait {
+
+  /**
+   * @param string $action
+   * @param array $record
+   * @param $userID
+   */
+  public static function _checkAccess(string $action, array $record, $userID) {
+    $cid = $record['contact_id'] ?? NULL;
+    if (!$cid && !empty($record['id'])) {
+      $cid = CRM_Core_DAO::getFieldValue(__CLASS__, $record['id'], 'contact_id');
+    }
+    if (!$cid) {
+      // With no contact id this must be part of an event locblock
+      return in_array(__CLASS__, ['CRM_Core_BAO_Phone', 'CRM_Core_BAO_Email', 'CRM_Core_BAO_Address']) &&
+        CRM_Core_Permission::check('edit all events', $userID);
+    }
+    return CRM_Contact_BAO_Contact::checkAccess($action, ['id' => $cid], $userID);
+  }
+
+}

--- a/CRM/Contact/AccessTrait.php
+++ b/CRM/Contact/AccessTrait.php
@@ -23,7 +23,9 @@ trait CRM_Contact_AccessTrait {
   /**
    * @param string $action
    * @param array $record
-   * @param $userID
+   * @param int|NULL $userID
+   * @return bool
+   * @see CRM_Core_DAO::checkAccess
    */
   public static function _checkAccess(string $action, array $record, $userID) {
     $cid = $record['contact_id'] ?? NULL;

--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -3728,4 +3728,30 @@ LEFT JOIN civicrm_address ON ( civicrm_address.contact_id = civicrm_contact.id )
     ];
   }
 
+  /**
+   * @param string $action
+   * @param array $record
+   * @param $userID
+   */
+  public static function _checkAccess(string $action, array $record, $userID) {
+    switch ($action) {
+      case 'create':
+        return CRM_Core_Permission::check('add contacts', $userID);
+
+      case 'get':
+        $actionType = CRM_Core_Permission::VIEW;
+        break;
+
+      case 'delete':
+        $actionType = CRM_Core_Permission::DELETE;
+        break;
+
+      default:
+        $actionType = CRM_Core_Permission::EDIT;
+        break;
+    }
+
+    return CRM_Contact_BAO_Contact_Permission::allow($record['id'], $actionType, $userID);
+  }
+
 }

--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -3732,6 +3732,8 @@ LEFT JOIN civicrm_address ON ( civicrm_address.contact_id = civicrm_contact.id )
    * @param string $action
    * @param array $record
    * @param $userID
+   * @return bool
+   * @see CRM_Core_DAO::checkAccess
    */
   public static function _checkAccess(string $action, array $record, $userID) {
     switch ($action) {

--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -3735,7 +3735,7 @@ LEFT JOIN civicrm_address ON ( civicrm_address.contact_id = civicrm_contact.id )
    * @return bool
    * @see CRM_Core_DAO::checkAccess
    */
-  public static function _checkAccess(string $action, array $record, $userID) {
+  public static function _checkAccess(string $action, array $record, $userID): bool {
     switch ($action) {
       case 'create':
         return CRM_Core_Permission::check('add contacts', $userID);

--- a/CRM/Core/BAO/Address.php
+++ b/CRM/Core/BAO/Address.php
@@ -19,6 +19,7 @@
  * This is class to handle address related functions.
  */
 class CRM_Core_BAO_Address extends CRM_Core_DAO_Address {
+  use CRM_Contact_AccessTrait;
 
   /**
    * Takes an associative array and creates a address.

--- a/CRM/Core/BAO/Email.php
+++ b/CRM/Core/BAO/Email.php
@@ -19,6 +19,7 @@
  * This class contains functions for email handling.
  */
 class CRM_Core_BAO_Email extends CRM_Core_DAO_Email {
+  use CRM_Contact_AccessTrait;
 
   /**
    * Create email address.

--- a/CRM/Core/BAO/EntityTag.php
+++ b/CRM/Core/BAO/EntityTag.php
@@ -16,6 +16,7 @@
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
 class CRM_Core_BAO_EntityTag extends CRM_Core_DAO_EntityTag {
+  use CRM_Core_DynamicFKAccessTrait;
 
   /**
    * Given a contact id, it returns an array of tag id's the contact belongs to.

--- a/CRM/Core/BAO/IM.php
+++ b/CRM/Core/BAO/IM.php
@@ -19,6 +19,7 @@
  * This class contain function for IM handling
  */
 class CRM_Core_BAO_IM extends CRM_Core_DAO_IM {
+  use CRM_Contact_AccessTrait;
 
   /**
    * Create or update IM record.

--- a/CRM/Core/BAO/Note.php
+++ b/CRM/Core/BAO/Note.php
@@ -19,6 +19,7 @@
  * BAO object for crm_note table.
  */
 class CRM_Core_BAO_Note extends CRM_Core_DAO_Note {
+  use CRM_Core_DynamicFKAccessTrait;
 
   /**
    * Const the max number of notes we display at any given time.

--- a/CRM/Core/BAO/OpenID.php
+++ b/CRM/Core/BAO/OpenID.php
@@ -19,6 +19,7 @@
  * This class contains function for Open Id
  */
 class CRM_Core_BAO_OpenID extends CRM_Core_DAO_OpenID {
+  use CRM_Contact_AccessTrait;
 
   /**
    * Create or update OpenID record.

--- a/CRM/Core/BAO/Phone.php
+++ b/CRM/Core/BAO/Phone.php
@@ -19,6 +19,7 @@
  * Class contains functions for phone.
  */
 class CRM_Core_BAO_Phone extends CRM_Core_DAO_Phone {
+  use CRM_Contact_AccessTrait;
 
   /**
    * Create phone object - note that the create function calls 'add' but

--- a/CRM/Core/BAO/UFJoin.php
+++ b/CRM/Core/BAO/UFJoin.php
@@ -175,4 +175,15 @@ class CRM_Core_BAO_UFJoin extends CRM_Core_DAO_UFJoin {
     ];
   }
 
+  /**
+   * Override base method which assumes permissions should be based on entity_table.
+   *
+   * @return array
+   */
+  public function addSelectWhereClause() {
+    $clauses = [];
+    CRM_Utils_Hook::selectWhereClause($this, $clauses);
+    return $clauses;
+  }
+
 }

--- a/CRM/Core/BAO/Website.php
+++ b/CRM/Core/BAO/Website.php
@@ -19,6 +19,7 @@
  * This class contain function for Website handling.
  */
 class CRM_Core_BAO_Website extends CRM_Core_DAO_Website {
+  use CRM_Contact_AccessTrait;
 
   /**
    * Create or update Website record.

--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -3043,14 +3043,16 @@ SELECT contact_id
   /**
    * Check whether action can be performed on a given record.
    *
-   * Dispatches to internal BAO function + hook_civicrm_checkAccess
+   * Dispatches to internal BAO function ('static::_checkAccess())` and `hook_civicrm_checkAccess`.
    *
    * @param string $action
-   *   Corresponds to APIv4 action names
+   *   APIv4 action name.
+   *   Ex: 'create', 'get', 'delete'
    * @param array $record
-   *   Array of all known values for the record
+   *   All (known/loaded) values of individual record being accessed.
+   *   The record should provide an 'id' but may otherwise be incomplete; guard accordingly.
    * @param int $userID
-   *   User id
+   *   Contact ID of the active user (whose access we must check).
    * @param bool $granted
    *   Initial value (usually TRUE, but the API might pass FALSE if gatekeeper permissions fail)
    *

--- a/CRM/Core/DAO/AllCoreTables.php
+++ b/CRM/Core/DAO/AllCoreTables.php
@@ -203,7 +203,7 @@ class CRM_Core_DAO_AllCoreTables {
    */
   public static function getBAOClassName($daoName) {
     $baoName = str_replace('_DAO_', '_BAO_', $daoName);
-    return class_exists($baoName) ? $baoName : $daoName;
+    return $daoName === $baoName || class_exists($baoName) ? $baoName : $daoName;
   }
 
   /**

--- a/CRM/Core/DynamicFKAccessTrait.php
+++ b/CRM/Core/DynamicFKAccessTrait.php
@@ -27,7 +27,7 @@ trait CRM_Core_DynamicFKAccessTrait {
    * @return bool
    * @see CRM_Core_DAO::checkAccess
    */
-  public static function _checkAccess(string $action, array $record, $userID) {
+  public static function _checkAccess(string $action, array $record, $userID): bool {
     $eid = $record['entity_id'] ?? NULL;
     $table = $record['entity_table'] ?? NULL;
     if (!$eid && !empty($record['id'])) {
@@ -40,6 +40,7 @@ trait CRM_Core_DynamicFKAccessTrait {
       $bao = CRM_Core_DAO_AllCoreTables::getBAOClassName(CRM_Core_DAO_AllCoreTables::getClassForTable($table));
       return $bao::checkAccess(CRM_Core_Permission::EDIT, ['id' => $eid], $userID);
     }
+    return TRUE;
   }
 
 }

--- a/CRM/Core/DynamicFKAccessTrait.php
+++ b/CRM/Core/DynamicFKAccessTrait.php
@@ -23,7 +23,9 @@ trait CRM_Core_DynamicFKAccessTrait {
   /**
    * @param string $action
    * @param array $record
-   * @param $userID
+   * @param int|NULL $userID
+   * @return bool
+   * @see CRM_Core_DAO::checkAccess
    */
   public static function _checkAccess(string $action, array $record, $userID) {
     $eid = $record['entity_id'] ?? NULL;

--- a/CRM/Financial/BAO/FinancialType.php
+++ b/CRM/Financial/BAO/FinancialType.php
@@ -420,20 +420,20 @@ class CRM_Financial_BAO_FinancialType extends CRM_Financial_DAO_FinancialType {
    * @param string $op
    *   the mode of operation, can be add, view, edit, delete
    * @param bool $force
+   * @param int $contactID
    *
    * @return bool
    */
-  public static function checkPermissionedLineItems($id, $op, $force = TRUE) {
+  public static function checkPermissionedLineItems($id, $op, $force = TRUE, $contactID = NULL) {
     if (!self::isACLFinancialTypeStatus()) {
       return TRUE;
     }
     $lineItems = CRM_Price_BAO_LineItem::getLineItemsByContributionID($id);
     $flag = FALSE;
     foreach ($lineItems as $items) {
-      if (!CRM_Core_Permission::check($op . ' contributions of type ' . CRM_Contribute_PseudoConstant::financialType($items['financial_type_id']))) {
+      if (!CRM_Core_Permission::check($op . ' contributions of type ' . CRM_Contribute_PseudoConstant::financialType($items['financial_type_id']), $contactID)) {
         if ($force) {
           throw new CRM_Core_Exception(ts('You do not have permission to access this page.'));
-          break;
         }
         $flag = FALSE;
         break;

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -2088,9 +2088,16 @@ abstract class CRM_Utils_Hook {
    * If the contact cannot perform the action the
    *
    * @param string $entity
+   *   APIv4 entity name.
+   *   Ex: 'Contact', 'Email', 'Event'
    * @param string $action
+   *   APIv4 action name.
+   *   Ex: 'create', 'get', 'delete'
    * @param array $record
+   *   All (known/loaded) values of individual record being accessed.
+   *   The record should provide an 'id' but may otherwise be incomplete; guard accordingly.
    * @param int|null $contactID
+   *   Contact ID of the active user (whose access we must check).
    * @param bool $granted
    */
   public static function checkAccess(string $entity, string $action, array $record, ?int $contactID, bool &$granted) {

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -2083,6 +2083,24 @@ abstract class CRM_Utils_Hook {
   }
 
   /**
+   * Check whether the given contact has access to perform the given action.
+   *
+   * If the contact cannot perform the action the
+   *
+   * @param string $entity
+   * @param string $action
+   * @param array $record
+   * @param int|null $contactID
+   * @param bool $granted
+   */
+  public static function checkAccess(string $entity, string $action, array $record, ?int $contactID, bool &$granted) {
+    self::singleton()->invoke(['entity', 'action', 'record', 'contactID', 'granted'], $entity, $action, $record,
+      $contactID, $granted, self::$_nullObject,
+      'civicrm_checkAccess'
+    );
+  }
+
+  /**
    * Rotate the cryptographic key used in the database.
    *
    * The purpose of this hook is to visit any encrypted values in the database

--- a/Civi/Api4/CustomValue.php
+++ b/Civi/Api4/CustomValue.php
@@ -123,6 +123,13 @@ class CustomValue {
   }
 
   /**
+   * @return \Civi\Api4\Generic\CheckAccessAction
+   */
+  public static function checkAccess($customGroup) {
+    return new Generic\CheckAccessAction("Custom_$customGroup", __FUNCTION__);
+  }
+
+  /**
    * @see \Civi\Api4\Generic\AbstractEntity::permissions()
    * @return array
    */

--- a/Civi/Api4/Generic/AbstractCreateAction.php
+++ b/Civi/Api4/Generic/AbstractCreateAction.php
@@ -19,6 +19,9 @@
 
 namespace Civi\Api4\Generic;
 
+use Civi\API\Exception\UnauthorizedException;
+use Civi\Api4\Utils\CoreUtil;
+
 /**
  * Base class for all `Create` api actions.
  *
@@ -57,11 +60,15 @@ abstract class AbstractCreateAction extends AbstractAction {
 
   /**
    * @throws \API_Exception
+   * @throws \Civi\API\Exception\UnauthorizedException
    */
   protected function validateValues() {
     $unmatched = $this->checkRequiredFields($this->getValues());
     if ($unmatched) {
       throw new \API_Exception("Mandatory values missing from Api4 {$this->getEntityName()}::{$this->getActionName()}: " . implode(", ", $unmatched), "mandatory_missing", ["fields" => $unmatched]);
+    }
+    if ($this->checkPermissions && !CoreUtil::checkAccess($this->getEntityName(), $this->getActionName(), $this->getValues())) {
+      throw new UnauthorizedException("ACL check failed");
     }
   }
 

--- a/Civi/Api4/Generic/AbstractEntity.php
+++ b/Civi/Api4/Generic/AbstractEntity.php
@@ -56,6 +56,13 @@ abstract class AbstractEntity {
   abstract public static function getFields();
 
   /**
+   * @return \Civi\Api4\Generic\CheckAccessAction
+   */
+  public static function checkAccess() {
+    return new CheckAccessAction(self::getEntityName(), __FUNCTION__);
+  }
+
+  /**
    * Returns a list of permissions needed to access the various actions in this api.
    *
    * @return array

--- a/Civi/Api4/Generic/AbstractSaveAction.php
+++ b/Civi/Api4/Generic/AbstractSaveAction.php
@@ -19,6 +19,9 @@
 
 namespace Civi\Api4\Generic;
 
+use Civi\API\Exception\UnauthorizedException;
+use Civi\Api4\Utils\CoreUtil;
+
 /**
  * Create or update one or more $ENTITIES.
  *
@@ -91,6 +94,7 @@ abstract class AbstractSaveAction extends AbstractAction {
 
   /**
    * @throws \API_Exception
+   * @throws \Civi\API\Exception\UnauthorizedException
    */
   protected function validateValues() {
     $unmatched = [];
@@ -101,6 +105,14 @@ abstract class AbstractSaveAction extends AbstractAction {
     }
     if ($unmatched) {
       throw new \API_Exception("Mandatory values missing from Api4 {$this->getEntityName()}::{$this->getActionName()}: " . implode(", ", $unmatched), "mandatory_missing", ["fields" => $unmatched]);
+    }
+    if ($this->checkPermissions) {
+      foreach ($this->records as $record) {
+        $action = empty($record[$this->idField]) ? 'create' : 'update';
+        if (!CoreUtil::checkAccess($this->getEntityName(), $action, $record)) {
+          throw new UnauthorizedException("ACL check failed");
+        }
+      }
     }
   }
 

--- a/Civi/Api4/Generic/BasicBatchAction.php
+++ b/Civi/Api4/Generic/BasicBatchAction.php
@@ -20,6 +20,8 @@
 namespace Civi\Api4\Generic;
 
 use Civi\API\Exception\NotImplementedException;
+use Civi\API\Exception\UnauthorizedException;
+use Civi\Api4\Utils\CoreUtil;
 
 /**
  * $ACTION one or more $ENTITIES.
@@ -65,6 +67,9 @@ class BasicBatchAction extends AbstractBatchAction {
    */
   public function _run(Result $result) {
     foreach ($this->getBatchRecords() as $item) {
+      if ($this->checkPermissions && !CoreUtil::checkAccess($this->getEntityName(), $this->getActionName(), $item)) {
+        throw new UnauthorizedException("ACL check failed");
+      }
       $result[] = $this->doTask($item);
     }
   }

--- a/Civi/Api4/Generic/BasicUpdateAction.php
+++ b/Civi/Api4/Generic/BasicUpdateAction.php
@@ -20,6 +20,8 @@
 namespace Civi\Api4\Generic;
 
 use Civi\API\Exception\NotImplementedException;
+use Civi\API\Exception\UnauthorizedException;
+use Civi\Api4\Utils\CoreUtil;
 
 /**
  * Update one or more $ENTITY with new values.
@@ -59,7 +61,11 @@ class BasicUpdateAction extends AbstractUpdateAction {
   public function _run(Result $result) {
     $this->formatWriteValues($this->values);
     foreach ($this->getBatchRecords() as $item) {
-      $result[] = $this->writeRecord($this->values + $item);
+      $record = $this->values + $item;
+      if ($this->checkPermissions && !CoreUtil::checkAccess($this->getEntityName(), $this->getActionName(), $record)) {
+        throw new UnauthorizedException("ACL check failed");
+      }
+      $result[] = $this->writeRecord($record);
     }
   }
 

--- a/Civi/Api4/Generic/CheckAccessAction.php
+++ b/Civi/Api4/Generic/CheckAccessAction.php
@@ -1,0 +1,80 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+
+namespace Civi\Api4\Generic;
+
+use Civi\Api4\Utils\CoreUtil;
+
+/**
+ * Check if current user is authorized to perform specified action on a given $ENTITY.
+ *
+ * @method $this setAction(string $action)
+ * @method string getAction()
+ * @method $this setValues(array $values)
+ * @method array getValues()
+ */
+class CheckAccessAction extends AbstractAction {
+
+  /**
+   * @var string
+   * @required
+   */
+  protected $action;
+
+  /**
+   * @var array
+   * @required
+   */
+  protected $values = [];
+
+  /**
+   * @param \Civi\Api4\Generic\Result $result
+   */
+  public function _run(Result $result) {
+    // Prevent circular checks
+    if ($this->action === 'checkAccess') {
+      $granted = TRUE;
+    }
+    else {
+      $granted = CoreUtil::checkAccess($this->getEntityName(), $this->action, $this->values);
+    }
+    $result->exchangeArray([['access' => $granted]]);
+  }
+
+  /**
+   * This action is always allowed
+   *
+   * @return bool
+   */
+  public function isAuthorized() {
+    return TRUE;
+  }
+
+  /**
+   * Add an item to the values array
+   * @param string $fieldName
+   * @param mixed $value
+   * @return $this
+   */
+  public function addValue(string $fieldName, $value) {
+    $this->values[$fieldName] = $value;
+    return $this;
+  }
+
+}

--- a/Civi/Api4/Generic/DAOCreateAction.php
+++ b/Civi/Api4/Generic/DAOCreateAction.php
@@ -33,11 +33,10 @@ class DAOCreateAction extends AbstractCreateAction {
    */
   public function _run(Result $result) {
     $this->formatWriteValues($this->values);
+    $this->fillDefaults($this->values);
     $this->validateValues();
-    $params = $this->values;
-    $this->fillDefaults($params);
-    $items = [$params];
 
+    $items = [$this->values];
     $result->exchangeArray($this->writeObjects($items));
   }
 

--- a/Civi/Api4/Generic/DAODeleteAction.php
+++ b/Civi/Api4/Generic/DAODeleteAction.php
@@ -19,6 +19,9 @@
 
 namespace Civi\Api4\Generic;
 
+use Civi\API\Exception\UnauthorizedException;
+use Civi\Api4\Utils\CoreUtil;
+
 /**
  * Delete one or more $ENTITIES.
  *
@@ -53,6 +56,9 @@ class DAODeleteAction extends AbstractBatchAction {
 
     if ($this->getCheckPermissions()) {
       foreach (array_keys($items) as $key) {
+        if (!CoreUtil::checkAccess($this->getEntityName(), $this->getActionName(), $items[$key])) {
+          throw new UnauthorizedException("ACL check failed");
+        }
         $items[$key]['check_permissions'] = TRUE;
         $this->checkContactPermissions($baoName, $items[$key]);
       }

--- a/Civi/Api4/Generic/DAODeleteAction.php
+++ b/Civi/Api4/Generic/DAODeleteAction.php
@@ -40,6 +40,15 @@ class DAODeleteAction extends AbstractBatchAction {
     }
 
     $items = $this->getBatchRecords();
+
+    if ($this->getCheckPermissions()) {
+      foreach ($items as $key => $item) {
+        if (!CoreUtil::checkAccess($this->getEntityName(), $this->getActionName(), $item)) {
+          throw new UnauthorizedException("ACL check failed");
+        }
+        $items[$key]['check_permissions'] = TRUE;
+      }
+    }
     if ($items) {
       $result->exchangeArray($this->deleteObjects($items));
     }
@@ -53,16 +62,6 @@ class DAODeleteAction extends AbstractBatchAction {
   protected function deleteObjects($items) {
     $ids = [];
     $baoName = $this->getBaoName();
-
-    if ($this->getCheckPermissions()) {
-      foreach (array_keys($items) as $key) {
-        if (!CoreUtil::checkAccess($this->getEntityName(), $this->getActionName(), $items[$key])) {
-          throw new UnauthorizedException("ACL check failed");
-        }
-        $items[$key]['check_permissions'] = TRUE;
-        $this->checkContactPermissions($baoName, $items[$key]);
-      }
-    }
 
     if ($this->getEntityName() !== 'EntityTag' && method_exists($baoName, 'del')) {
       foreach ($items as $item) {

--- a/Civi/Api4/Generic/DAOUpdateAction.php
+++ b/Civi/Api4/Generic/DAOUpdateAction.php
@@ -19,6 +19,9 @@
 
 namespace Civi\Api4\Generic;
 
+use Civi\API\Exception\UnauthorizedException;
+use Civi\Api4\Utils\CoreUtil;
+
 /**
  * Update one or more $ENTITY with new values.
  *
@@ -60,6 +63,9 @@ class DAOUpdateAction extends AbstractUpdateAction {
     // Update a single record by ID unless select requires more than id
     if ($this->getSelect() === ['id'] && count($this->where) === 1 && $this->where[0][0] === 'id' && $this->where[0][1] === '=' && !empty($this->where[0][2])) {
       $this->values['id'] = $this->where[0][2];
+      if ($this->checkPermissions && !CoreUtil::checkAccess($this->getEntityName(), $this->getActionName(), $this->values)) {
+        throw new UnauthorizedException("ACL check failed");
+      }
       $items = [$this->values];
       $result->exchangeArray($this->writeObjects($items));
       return;
@@ -69,6 +75,9 @@ class DAOUpdateAction extends AbstractUpdateAction {
     $items = $this->getBatchRecords();
     foreach ($items as &$item) {
       $item = $this->values + $item;
+      if ($this->checkPermissions && !CoreUtil::checkAccess($this->getEntityName(), $this->getActionName(), $item)) {
+        throw new UnauthorizedException("ACL check failed");
+      }
     }
 
     $result->exchangeArray($this->writeObjects($items));

--- a/Civi/Api4/Generic/Traits/DAOActionTrait.php
+++ b/Civi/Api4/Generic/Traits/DAOActionTrait.php
@@ -136,10 +136,6 @@ trait DAOActionTrait {
         $item['contact_id'] = $entityId;
       }
 
-      if ($this->getCheckPermissions()) {
-        $this->checkContactPermissions($baoName, $item);
-      }
-
       if ($this->getEntityName() === 'Address') {
         $createResult = $baoName::$method($item, $this->fixAddress);
       }
@@ -257,28 +253,6 @@ trait DAOActionTrait {
       \Civi::cache('metadata')->set($cacheKey, $info);
     }
     return isset($info[$fieldName]) ? ['suffix' => $suffix] + $info[$fieldName] : NULL;
-  }
-
-  /**
-   * Check edit/delete permissions for contacts and related entities.
-   *
-   * @param string $baoName
-   * @param array $item
-   *
-   * @throws \Civi\API\Exception\UnauthorizedException
-   */
-  protected function checkContactPermissions($baoName, $item) {
-    if ($baoName === 'CRM_Contact_BAO_Contact' && !empty($item['id'])) {
-      $permission = $this->getActionName() === 'delete' ? \CRM_Core_Permission::DELETE : \CRM_Core_Permission::EDIT;
-      if (!\CRM_Contact_BAO_Contact_Permission::allow($item['id'], $permission)) {
-        throw new \Civi\API\Exception\UnauthorizedException('Permission denied to modify contact record');
-      }
-    }
-    else {
-      // Fixme: decouple from v3
-      require_once 'api/v3/utils.php';
-      _civicrm_api3_check_edit_permissions($baoName, $item);
-    }
   }
 
 }

--- a/Civi/Api4/Utils/CoreUtil.php
+++ b/Civi/Api4/Utils/CoreUtil.php
@@ -175,9 +175,13 @@ class CoreUtil {
       $granted = $granted && $action->addSelect('id')->addWhere('id', '=', $record['id'])->execute()->count();
     }
     else {
-      $baoName = self::getBAOFromApiName($entityName);
       // If entity has a BAO, run the BAO::checkAccess function, which will call the hook
-      if ($baoName && strpos($baoName, '_BAO_')) {
+      $baoName = self::getBAOFromApiName($entityName);
+      // CustomValue also requires the name of the group
+      if ($baoName === 'CRM_Core_BAO_CustomValue') {
+        $granted = \CRM_Core_BAO_CustomValue::checkAccess($actionName, $record, NULL, $granted, substr($entityName, 7));
+      }
+      elseif ($baoName) {
         $granted = $baoName::checkAccess($actionName, $record, NULL, $granted);
       }
       // Otherwise, call the hook directly

--- a/Civi/Api4/Utils/CoreUtil.php
+++ b/Civi/Api4/Utils/CoreUtil.php
@@ -178,7 +178,7 @@ class CoreUtil {
       $baoName = self::getBAOFromApiName($entityName);
       // If entity has a BAO, run the BAO::checkAccess function, which will call the hook
       if ($baoName && strpos($baoName, '_BAO_')) {
-        $baoName::checkAccess($actionName, $record, NULL, $granted);
+        $granted = $baoName::checkAccess($actionName, $record, NULL, $granted);
       }
       // Otherwise, call the hook directly
       else {

--- a/api/v3/Contribution.php
+++ b/api/v3/Contribution.php
@@ -204,23 +204,13 @@ function _civicrm_api3_contribution_create_legacy_support_45(&$params) {
 function civicrm_api3_contribution_delete($params) {
 
   $contributionID = !empty($params['contribution_id']) ? $params['contribution_id'] : $params['id'];
-  // First check contribution financial type
-  $financialType = CRM_Core_DAO::getFieldValue('CRM_Contribute_DAO_Contribution', $contributionID, 'financial_type_id');
-  // Now check permissioned lineitems & permissioned contribution
-  if (!empty($params['check_permissions']) && CRM_Financial_BAO_FinancialType::isACLFinancialTypeStatus() &&
-    (
-      !CRM_Core_Permission::check('delete contributions of type ' . CRM_Contribute_PseudoConstant::financialType($financialType))
-      || !CRM_Financial_BAO_FinancialType::checkPermissionedLineItems($contributionID, 'delete', FALSE)
-    )
-  ) {
+  if (!empty($params['check_permissions']) && !CRM_Contribute_BAO_Contribution::checkAccess('delete', ['id' => $contributionID])) {
     throw new API_Exception('You do not have permission to delete this contribution');
   }
   if (CRM_Contribute_BAO_Contribution::deleteContribution($contributionID)) {
     return civicrm_api3_create_success([$contributionID => 1]);
   }
-  else {
-    throw new API_Exception('Could not delete contribution');
-  }
+  throw new API_Exception('Could not delete contribution');
 }
 
 /**
@@ -671,7 +661,7 @@ function _ipn_process_transaction($params, $contribution, $input, $ids) {
     static $domainFromName;
     static $domainFromEmail;
     if (empty($domainFromEmail) && (empty($params['receipt_from_name']) || empty($params['receipt_from_email']))) {
-      list($domainFromName, $domainFromEmail) = CRM_Core_BAO_Domain::getNameAndEmail(TRUE);
+      [$domainFromName, $domainFromEmail] = CRM_Core_BAO_Domain::getNameAndEmail(TRUE);
     }
     $input['receipt_from_name'] = CRM_Utils_Array::value('receipt_from_name', $params, $domainFromName);
     $input['receipt_from_email'] = CRM_Utils_Array::value('receipt_from_email', $params, $domainFromEmail);

--- a/tests/phpunit/api/v3/ACLPermissionTest.php
+++ b/tests/phpunit/api/v3/ACLPermissionTest.php
@@ -228,9 +228,6 @@ class api_v3_ACLPermissionTest extends CiviUnitTestCase {
       ]);
       $this->assertGreaterThan(0, $results['count']);
     }
-    if ($version == 4) {
-      $this->markTestIncomplete('Skipping entity_id related perms in api4 for now.');
-    }
     $newTag = civicrm_api3('Tag', 'create', [
       'name' => 'Foo123',
     ]);

--- a/tests/phpunit/api/v3/ContactTest.php
+++ b/tests/phpunit/api/v3/ContactTest.php
@@ -3211,7 +3211,12 @@ class api_v3_ContactTest extends CiviUnitTestCase {
 
     $config->userPermissionClass->permissions = ['access CiviCRM'];
     $result = $this->callAPIFailure('contact', 'update', $params);
-    $this->assertEquals('Permission denied to modify contact record', $result['error_message']);
+    if ($version == 3) {
+      $this->assertEquals('Permission denied to modify contact record', $result['error_message']);
+    }
+    else {
+      $this->assertEquals('ACL check failed', $result['error_message']);
+    }
 
     $config->userPermissionClass->permissions = [
       'access CiviCRM',

--- a/tests/phpunit/api/v3/FinancialTypeACLTest.php
+++ b/tests/phpunit/api/v3/FinancialTypeACLTest.php
@@ -291,8 +291,10 @@ class api_v3_FinancialTypeACLTest extends CiviUnitTestCase {
 
   /**
    * Test that acl contributions can be deleted.
+   *
+   * @throws \CRM_Core_Exception
    */
-  public function testDeleteACLContribution() {
+  public function testDeleteACLContribution(): void {
     $this->enableFinancialACLs();
 
     $this->setPermissions([
@@ -313,7 +315,7 @@ class api_v3_FinancialTypeACLTest extends CiviUnitTestCase {
     $this->addFinancialAclPermissions([['delete', 'Donation']]);
     $contribution = $this->callAPISuccess('Contribution', 'delete', $params);
 
-    $this->assertEquals($contribution['count'], 1);
+    $this->assertEquals(1, $contribution['count']);
   }
 
   public function testMembershipTypeACLFinancialTypeACL() {

--- a/tests/phpunit/api/v4/Action/BasicActionsTest.php
+++ b/tests/phpunit/api/v4/Action/BasicActionsTest.php
@@ -260,7 +260,7 @@ class BasicActionsTest extends UnitTestCase {
 
   public function testEmptyAndNullOperators() {
     $records = [
-      [],
+      ['id' => NULL],
       ['color' => '', 'weight' => 0],
       ['color' => 'yellow', 'weight' => 100000000000],
     ];

--- a/tests/phpunit/api/v4/Traits/CheckAccessTrait.php
+++ b/tests/phpunit/api/v4/Traits/CheckAccessTrait.php
@@ -1,0 +1,62 @@
+<?php
+namespace api\v4\Traits;
+
+/**
+ * Define an implementation of `hook_civicrm_checkAccess` in which access-control decisions are
+ * based on a predefined list. For example:
+ *
+ *   $this->setCheckAccessGrants(['Contact::create' => TRUE]);
+ *   Contact::create()->setValues(...)->execute();
+ *
+ * Note: Any class which uses this should implement the `HookInterface` so that the hook is picked up.
+ */
+trait CheckAccessTrait {
+
+  /**
+   * Specify whether to grant access to an entity-action via hook_checkAccess.
+   *
+   * @var array
+   *   Array(string $entityAction => bool $grant).
+   *   TRUE=>Allow. FALSE=>Deny. Undefined=>No preference.
+   */
+  private $checkAccessGrants = [];
+
+  /**
+   * Number of times hook_checkAccess has fired.
+   * @var array
+   */
+  protected $checkAccessCounts = [];
+
+  /**
+   * @param string $entity
+   * @param string $action
+   * @param array $record
+   * @param int|null $contactID
+   * @param bool $granted
+   * @see \CRM_Utils_Hook::checkAccess()
+   */
+  public function hook_civicrm_checkAccess(string $entity, string $action, array $record, ?int $contactID, bool &$granted) {
+    $key = "{$entity}::{$action}";
+    if (isset($this->checkAccessGrants[$key])) {
+      $granted = $this->checkAccessGrants[$key];
+      $this->checkAccessCounts[$key]++;
+    }
+  }
+
+  /**
+   * @param array $list
+   *   Ex: ["Event::delete" => TRUE, "Contribution::delete" => FALSE]
+   */
+  protected function setCheckAccessGrants($list) {
+    $this->checkAccessGrants = $this->checkAccessCounts = [];
+    foreach ($list as $key => $grant) {
+      $this->checkAccessGrants[$key] = $grant;
+      $this->checkAccessCounts[$key] = 0;
+    }
+  }
+
+  protected function resetCheckAccess() {
+    $this->setCheckAccessGrants([]);
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
This combines work done by @eileenmcnaughton in #20035 with WIP from #19837 to make a checkAccess function that works at both the APIv4 and BAO layers. It standardizes on api-style entity & action names, and provides hooks the opportunity to escalate permissions or deny access on a per-record basis.

![image](https://user-images.githubusercontent.com/2874912/111722764-de0ef380-8838-11eb-8097-03045fa33a40.png)