### PR TITLE
[REF] Add strict types to Utils_Mail::Send

### DIFF
--- a/CRM/Core/BAO/ActionSchedule.php
+++ b/CRM/Core/BAO/ActionSchedule.php
@@ -594,7 +594,7 @@ FROM civicrm_action_schedule cas
    * @return array
    *   List of error messages.
    */
-  protected static function sendReminderEmail($tokenRow, $schedule, $toContactID) {
+  protected static function sendReminderEmail($tokenRow, $schedule, $toContactID): array {
     $toEmail = CRM_Contact_BAO_Contact::getPrimaryEmail($toContactID, TRUE);
     if (!$toEmail) {
       return ["email_missing" => "Couldn't find recipient's email address."];
@@ -617,20 +617,20 @@ FROM civicrm_action_schedule cas
       'entity_id' => $schedule->id,
     ];
 
-    if (!$body_html || $tokenRow->context['contact']['preferred_mail_format'] == 'Text' ||
-      $tokenRow->context['contact']['preferred_mail_format'] == 'Both'
+    if (!$body_html || $tokenRow->context['contact']['preferred_mail_format'] === 'Text' ||
+      $tokenRow->context['contact']['preferred_mail_format'] === 'Both'
     ) {
       // render the &amp; entities in text mode, so that the links work
       $mailParams['text'] = str_replace('&amp;', '&', $body_text);
     }
-    if ($body_html && ($tokenRow->context['contact']['preferred_mail_format'] == 'HTML' ||
-        $tokenRow->context['contact']['preferred_mail_format'] == 'Both'
+    if ($body_html && ($tokenRow->context['contact']['preferred_mail_format'] === 'HTML' ||
+        $tokenRow->context['contact']['preferred_mail_format'] === 'Both'
       )
     ) {
       $mailParams['html'] = $body_html;
     }
     $result = CRM_Utils_Mail::send($mailParams);
-    if (!$result || is_a($result, 'PEAR_Error')) {
+    if (!$result) {
       return ['email_fail' => 'Failed to send message'];
     }
 

--- a/CRM/Utils/Mail.php
+++ b/CRM/Utils/Mail.php
@@ -166,7 +166,7 @@ class CRM_Utils_Mail {
    * @return bool
    *   TRUE if a mail was sent, else FALSE.
    */
-  public static function send(&$params) {
+  public static function send(array &$params): bool {
     $defaultReturnPath = CRM_Core_BAO_MailSettings::defaultReturnPath();
     $includeMessageId = CRM_Core_BAO_MailSettings::includeMessageId();
     $emailDomain = CRM_Core_BAO_MailSettings::defaultDomain();
@@ -260,7 +260,7 @@ class CRM_Utils_Mail {
     }
 
     if (!empty($attachments)) {
-      foreach ($attachments as $fileID => $attach) {
+      foreach ($attachments as $attach) {
         $msg->addAttachment(
           $attach['fullPath'],
           $attach['mime_type'],
@@ -277,7 +277,6 @@ class CRM_Utils_Mail {
     $headers = $msg->headers($headers);
 
     $to = [$params['toEmail']];
-    $result = NULL;
     $mailer = \Civi::service('pear_mail');
 
     // CRM-3795, CRM-7355, CRM-7557, CRM-9058, CRM-9887, CRM-12883, CRM-19173 and others ...


### PR DESCRIPTION
Overview
----------------------------------------
[REF] Add strict types to Utils_Mail::Send

Before
----------------------------------------
Function onl returns a bool - but code that calls it handles the possibility of it returning a PEAR_Error, some unused variables

After
----------------------------------------
Function explicitly only returns a bool so the next person won't need to double check the function to be sure they can remove the PEAR error handling

Technical Details
----------------------------------------

Comments
----------------------------------------
