### PR TITLE
dev/core#2573 - Set appropriate default permissions to use api4 CaseActivity

### DIFF
--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -1094,6 +1094,7 @@ class CRM_Core_Permission {
       ],
     ];
     $permissions['case_contact'] = $permissions['case'];
+    $permissions['case_activity'] = $permissions['case'];
 
     $permissions['case_type'] = [
       'default' => ['administer CiviCase'],


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/2573

Before
----------------------------------------
Can't use api4 CaseActivity without administer CiviCRM permission

After
----------------------------------------
Same permissions as Case.

Technical Details
----------------------------------------
I'm not 100% sure this is the right set of permissions. See ticket for some ramblings.

Comments
----------------------------------------
Putting against 5.37 since that's when the class was introduced. (https://github.com/civicrm/civicrm-core/pull/20009)