### PR TITLE
dev/core#2541 Wording change on sched reminders

### DIFF
--- a/CRM/Event/ActionMapping.php
+++ b/CRM/Event/ActionMapping.php
@@ -74,10 +74,10 @@ class CRM_Event_ActionMapping extends \Civi\ActionSchedule\Mapping {
    */
   public function getDateFields() {
     return [
-      'start_date' => ts('Event Start Date'),
-      'end_date' => ts('Event End Date'),
-      'registration_start_date' => ts('Registration Start Date'),
-      'registration_end_date' => ts('Registration End Date'),
+      'start_date' => ts('Event Start'),
+      'end_date' => ts('Event End'),
+      'registration_start_date' => ts('Registration Start'),
+      'registration_end_date' => ts('Registration End'),
     ];
   }
 


### PR DESCRIPTION


Overview
----------------------------------------
I think Lars makes a pretty good case here https://lab.civicrm.org/dev/core/-/issues/2541

Before
----------------------------------------
![lars-image](https://lab.civicrm.org/dev/core/uploads/5841527fcac9d04f62ea81190743bf99/image.png)

After
----------------------------------------
- word date removed
![image](https://user-images.githubusercontent.com/336308/116346400-4b517380-a83e-11eb-9cce-30881c1ef208.png)

Technical Details
----------------------------------------
Read the issue for the case for removing 'date'

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
