### PR TITLE
(REF) CRM_Core_DAO - Simplify getFieldSpec()

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -2722,17 +2722,20 @@ SELECT contact_id
   public function getFieldSpec($fieldName) {
     $fields = $this->fields();
 
-    // Support "unique names" as well as sql names
-    $fieldKey = $fieldName;
-    if (empty($fields[$fieldKey])) {
-      $fieldKeys = $this->fieldKeys();
-      $fieldKey = $fieldKeys[$fieldName] ?? NULL;
+    // Naturally, fields have 1-2 names (eg 'description'/'description'
+    // or 'event_description'/'description'). Use either.
+
+    if (isset($fields[$fieldName])) {
+      return $fields[$fieldName];
     }
-    // If neither worked then this field doesn't exist. Return false.
-    if (empty($fields[$fieldKey])) {
-      return FALSE;
+
+    foreach ($fields as $field) {
+      if ($field['name'] === $fieldName) {
+        return $field;
+      }
     }
-    return $fields[$fieldKey];
+
+    return FALSE;
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
This is a very small cleanup on a helper function.

Before
----------------------------------------

This function is a little more complicated and a little more inefficient than it needs to be... it builds a single-use index (`fieldKeys()`) of all fields and then forgets it.  But building such an index is a full O(n) scan plus O(n) memory allocation - and then a lookup on that list.

After
----------------------------------------

The function is simpler.  It may still do an O(n) scan, but it will stop early on match, and it won't allocate O(n) memory.
