### PR TITLE
Make reCAPTCHA not conditional on paymentprocessor on contribution page

### DIFF
--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -290,7 +290,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
       $this->buildComponentForm($this->_id, $this);
     }
 
-    if (count($this->_paymentProcessors) >= 1 && !$this->get_template_vars("isCaptcha") && \Civi::settings()->get('forceRecaptcha')) {
+    if (!$this->get_template_vars("isCaptcha") && \Civi::settings()->get('forceRecaptcha')) {
       if (!$this->_userID) {
         CRM_Utils_ReCAPTCHA::enableCaptchaOnForm($this);
       }


### PR DESCRIPTION
Overview
----------------------------------------
This is a refactor in preparation for moving the reCAPTCHA code to the new reCAPTCHA extension for the event registration pages.
See https://lab.civicrm.org/dev/core/-/issues/2571

This is a change to simplify the conditions in which reCAPTCHA is enabled on a contribution page as it's currently dependent on there being a paymentprocessor enabled (including paylater).

This is the only place such a check exists (eg. registration pages do not check for paymentprocessor before displaying). As it's still a form for entering user data it seems silly to not display it in this case and this allows us to simplify the code.

I can see use-cases for conditionally enabling on certain forms (eg. specific contribution pages etc.) and eg. only for anonymous users (as is mostly the case but contribution pages don't seem to check for the anonymous user). That sort of thing could easily be implemented in the extension once all the conditionals are moved across there.

Before
----------------------------------------
reCAPTCHA on contribution pages only displayed if there is a payment processor defined.

After
----------------------------------------
reCAPTCHA on contribution pages displayed if enabled.

Technical Details
----------------------------------------
The check relies on checking a protected variable (`$this->_paymentprocessors). There are other public variables we could check to see if there is a paymentprocessor but the check seems unnecessary and looking at the history of the "if" block the condition has gradually been loosened to support manual / pay later etc - eg. see https://github.com/civicrm/civicrm-core/commit/a3d94981bb1e5bd65b83f333cd83634a8413a553

Comments
----------------------------------------
To test configure a contribution page with a free membership (no payments). Before this PR reCAPTCHA would not be shown, after it will.

@seamuslee001 @demeritcowboy Technically this *is* a change in behaviour but seems worth it for the simplification and limited use of "free" contribution pages. It seems more like an accident of history rather than a deliberate design choice.


