### PR TITLE
Contribution.sendconfirmation API3 function should return

### DIFF
--- a/api/v3/Contribution.php
+++ b/api/v3/Contribution.php
@@ -406,6 +406,7 @@ function civicrm_api3_contribution_sendconfirmation($params) {
   ];
   $input = array_intersect_key($params, array_flip($allowedParams));
   CRM_Contribute_BAO_Contribution::sendMail($input, $ids, $params['id']);
+  return [];
 }
 
 /**


### PR DESCRIPTION
Overview
----------------------------------------
Otherwise you get 'cannot interpret return values from function'

Before
----------------------------------------
No return values from function.

After
----------------------------------------
Empty array returned - we could probably look at a more useful result but this "change" prevents errors in API explorer at least.

Technical Details
----------------------------------------


Comments
----------------------------------------
