### PR TITLE
APIv4 - When running validateValues(), fire an event

### DIFF
--- a/CRM/Utils/Array.php
+++ b/CRM/Utils/Array.php
@@ -18,6 +18,31 @@
 class CRM_Utils_Array {
 
   /**
+   * Cast a value to an array.
+   *
+   * This is similar to PHP's `(array)`, but it also converts iterators.
+   *
+   * @param mixed $value
+   * @return array
+   */
+  public static function cast($value) {
+    if (is_array($value)) {
+      return $value;
+    }
+    if ($value instanceof CRM_Utils_LazyArray || $value instanceof ArrayObject) {
+      // iterator_to_array() would work here, but getArrayCopy() doesn't require actual iterations.
+      return $value->getArrayCopy();
+    }
+    if (is_iterable($value)) {
+      return iterator_to_array($value);
+    }
+    if (is_scalar($value)) {
+      return [$value];
+    }
+    throw new \RuntimeException(sprintf("Cannot cast %s to array", gettype($value)));
+  }
+
+  /**
    * Returns $list[$key] if such element exists, or a default value otherwise.
    *
    * If $list is not actually an array at all, then the default value is

--- a/CRM/Utils/LazyArray.php
+++ b/CRM/Utils/LazyArray.php
@@ -1,0 +1,95 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * A lazy-array works much like a regular array or ArrayObject. However, it is
+ * initially empty - and it is only populated if used.
+ */
+class CRM_Utils_LazyArray implements ArrayAccess, IteratorAggregate, Countable {
+
+  /**
+   * A function which generates a list of values.
+   *
+   * @var callable
+   *   function(): iterable
+   */
+  private $func;
+
+  /**
+   * Cached values
+   *
+   * @var array|null
+   */
+  private $cache;
+
+  /**
+   * CRM_Utils_LazyList constructor.
+   *
+   * @param callable $func
+   *   Function which provides a list of values (array/iterator/generator).
+   */
+  public function __construct($func) {
+    $this->func = $func;
+  }
+
+  /**
+   * Determine if the content has been fetched.
+   *
+   * @return bool
+   */
+  public function isLoaded() {
+    return $this->cache !== NULL;
+  }
+
+  public function load($force = FALSE) {
+    if ($this->cache === NULL || $force) {
+      $this->cache = CRM_Utils_Array::cast(call_user_func($this->func));
+    }
+    return $this;
+  }
+
+  public function offsetExists($offset) {
+    return isset($this->load()->cache[$offset]);
+  }
+
+  public function &offsetGet($offset) {
+    return $this->load()->cache[$offset];
+  }
+
+  public function offsetSet($offset, $value) {
+    if ($offset === NULL) {
+      $this->load()->cache[] = $value;
+    }
+    else {
+      $this->load()->cache[$offset] = $value;
+    }
+  }
+
+  public function offsetUnset($offset) {
+    unset($this->load()->cache[$offset]);
+  }
+
+  public function getIterator() {
+    return new ArrayIterator($this->load()->cache);
+  }
+
+  /**
+   * @return array
+   */
+  public function getArrayCopy() {
+    return $this->load()->cache;
+  }
+
+  public function count() {
+    return count($this->load()->cache);
+  }
+
+}

--- a/Civi/Api4/Event/ValidateValuesEvent.php
+++ b/Civi/Api4/Event/ValidateValuesEvent.php
@@ -1,0 +1,157 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+namespace Civi\Api4\Event;
+
+use Civi\Core\Event\GenericHookEvent;
+
+/**
+ * The ValidateValuesEvent ('civi.api4.validate') is emitted when creating or saving an entire record via APIv4.
+ * It is emitted once for every record is updated.
+ *
+ * Example #1: Walk each record and validate some fields
+ *
+ * function(ValidateValuesEvent $e) {
+ *   if ($e->entity !== 'Foozball') return;
+ *   foreach ($e->records as $r => $record) {
+ *     if (strtotime($record['start_time']) < CRM_Utils_Time::time()) {
+ *       $e->addError($r, 'start_time', 'past', ts('Start time has already passed.'));
+ *     }
+ *     if ($record['length'] * $record['width'] * $record['height'] > VOLUME_LIMIT) {
+ *       $e->addError($r, ['length', 'width', 'height'], 'excessive_volume', ts('The record is too big.'));
+ *     }
+ *   }
+ * }
+ *
+ * Example #2: Prohibit recording `Contribution` records on `Student` contacts.
+ *
+ * function(ValidateValuesEvent $e) {
+ *   if ($e->entity !== 'Contribution') return;
+ *   $contactSubTypes = CRM_Utils_SQL_Select::from('civicrm_contact')
+ *     ->where('id IN (#ids)', ['ids' => array_column($e->records, 'contact_id')])
+ *     ->select('id, contact_sub_type')
+ *     ->execute()->fetchMap('id', 'contact_sub_type');
+ *   foreach ($e->records as $r => $record) {
+ *     if ($contactSubTypes[$record['contact_id']] === 'Student') {
+ *       $e->addError($r, 'contact_id', 'student_prohibited', ts('Donations from student records are strictly prohibited.'));
+ *     }
+ *   }
+ * }
+ */
+class ValidateValuesEvent extends GenericHookEvent {
+
+  /**
+   * Type of entity being validated. (APIv4 name).
+   *
+   * @var string
+   *   Ex: 'Membership'
+   */
+  public $entity;
+
+  /**
+   * Action being executed (APIv4 name).
+   *
+   * @var string
+   *   Ex: 'create', 'save', 'update'.
+   */
+  public $action;
+
+  /**
+   * List of updated records.
+   *
+   * The list of `$records` reflects only the list of new values assigned
+   * by this action. It may or may not correspond to an existing row in the database.
+   * It is similar to the `$records` list used by `save()`.
+   *
+   * @var array|\CRM_Utils_LazyArray
+   * @see \Civi\Api4\Generic\AbstractSaveAction::$records
+   */
+  public $records;
+
+  /**
+   * List of error messages.
+   *
+   * @var array
+   *   Array(string $errorName => string $errorMessage)
+   *   Note:
+   */
+  public $errors = [];
+
+  /**
+   * ValidateValuesEvent constructor.
+   *
+   * @param \Civi\Api4\Generic\AbstractAction $apiCall
+   * @param array|\CRM_Utils_LazyArray $records
+   *   List of updates (akin to SaveAction::$records).
+   * @param array|\CRM_Utils_LazyArray $diffs
+   *   List of differences (comparing old values and new values).
+   */
+  public function __construct($apiCall, $records) {
+    $this->entity = $apiCall->getEntityName();
+    $this->action = $apiCall->getActionName();
+    $this->records = $records;
+    $this->errors = [];
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function getHookValues() {
+    return [$this->entity, $this->action, $this->records, &$this->errors];
+  }
+
+  /**
+   * Add an error.
+   *
+   * @param string|int $recordKey
+   *   The validator may work with multiple records. This should identify the specific record.
+   *   Each record is identified by its offset (`$records[$recordKey] === [...the record...]`).
+   * @param string|array $field
+   *   The name of the field which has an error.
+   *   If the error is multi-field (e.g. mismatched password-confirmation), then use an array.
+   *   If the error is independent of any field, then use [].
+   * @param string $name
+   * @param string|NULL $message
+   * @return $this
+   */
+  public function addError($recordKey, $field, string $name, string $message = NULL): self {
+    $this->errors[] = [
+      'record' => $recordKey,
+      'fields' => (array) $field,
+      'name' => $name,
+      'message' => $message ?: ts('Error code (%1)', [1 => $name]),
+    ];
+    return $this;
+  }
+
+  /**
+   * Convert the list of errors an exception.
+   *
+   * @return \API_Exception
+   */
+  public function toException() {
+    // We should probably have a better way to report the errors in a structured/list format.
+    return new \API_Exception(ts('Found %1 error(s) in submitted %2 record(s) of type "%3": %4', [
+      1 => count($this->errors),
+      2 => count(array_unique(array_column($this->errors, 'record'))),
+      3 => $this->entity,
+      4 => implode(', ', array_column($this->errors, 'message')),
+    ]));
+  }
+
+}

--- a/Civi/Api4/Event/ValidateValuesEvent.php
+++ b/Civi/Api4/Event/ValidateValuesEvent.php
@@ -84,6 +84,24 @@ class ValidateValuesEvent extends GenericHookEvent {
   public $records;
 
   /**
+   * Detailed, side-by-side comparison of old and new values.
+   *
+   * This requires loading the list of old values from the database. Consequently,
+   * reading `$diffs` is more expensive than reading `$records`, so you should only use it if
+   * really necessary.
+   *
+   * The list of $diffs may be important if you are enforcing a rule that involves
+   * multiple fields. (Ex: "Validate that the state_id and country_id match.")
+   *
+   * When possible, $records and $diffs will have the same number of items (with corresponding
+   * keys). However, in the case of a batch `update()`, the list of diffs will be longer.
+   *
+   * @var array|\CRM_Utils_LazyArray
+   *   Each item is a record of the form ['old' => $fieldValues, 'new' => $fieldValues]
+   */
+  public $diffs;
+
+  /**
    * List of error messages.
    *
    * @var array
@@ -101,10 +119,11 @@ class ValidateValuesEvent extends GenericHookEvent {
    * @param array|\CRM_Utils_LazyArray $diffs
    *   List of differences (comparing old values and new values).
    */
-  public function __construct($apiCall, $records) {
+  public function __construct($apiCall, $records, $diffs) {
     $this->entity = $apiCall->getEntityName();
     $this->action = $apiCall->getActionName();
     $this->records = $records;
+    $this->diffs = $diffs;
     $this->errors = [];
   }
 

--- a/Civi/Api4/Generic/AbstractBatchAction.php
+++ b/Civi/Api4/Generic/AbstractBatchAction.php
@@ -54,9 +54,23 @@ abstract class AbstractBatchAction extends AbstractQueryAction {
   }
 
   /**
+   * Get a list of records for this batch.
+   *
    * @return array
    */
   protected function getBatchRecords() {
+    return (array) $this->getBatchAction()->execute();
+  }
+
+  /**
+   * Get a query which resolves the list of records for this batch.
+   *
+   * This is similar to `getBatchRecords()`, but you may further refine the
+   * API call (e.g. selecting different fields or data-pages) before executing.
+   *
+   * @return \Civi\Api4\Generic\AbstractGetAction
+   */
+  protected function getBatchAction() {
     $params = [
       'checkPermissions' => $this->checkPermissions,
       'where' => $this->where,
@@ -67,8 +81,7 @@ abstract class AbstractBatchAction extends AbstractQueryAction {
     if (empty($this->reload)) {
       $params['select'] = $this->select;
     }
-
-    return (array) civicrm_api4($this->getEntityName(), 'get', $params);
+    return \Civi\API\Request::create($this->getEntityName(), 'get', ['version' => 4] + $params);
   }
 
   /**

--- a/Civi/Api4/Generic/AbstractCreateAction.php
+++ b/Civi/Api4/Generic/AbstractCreateAction.php
@@ -66,7 +66,9 @@ abstract class AbstractCreateAction extends AbstractAction {
     if ($unmatched) {
       throw new \API_Exception("Mandatory values missing from Api4 {$this->getEntityName()}::{$this->getActionName()}: " . implode(", ", $unmatched), "mandatory_missing", ["fields" => $unmatched]);
     }
-    $e = new ValidateValuesEvent($this, [$this->getValues()]);
+    $e = new ValidateValuesEvent($this, [$this->getValues()], new \CRM_Utils_LazyArray(function () {
+      return [['old' => NULL, 'new' => $this->getValues()]];
+    }));
     \Civi::dispatcher()->dispatch('civi.api4.validate', $e);
     if (!empty($e->errors)) {
       throw $e->toException();

--- a/Civi/Api4/Generic/AbstractUpdateAction.php
+++ b/Civi/Api4/Generic/AbstractUpdateAction.php
@@ -19,6 +19,8 @@
 
 namespace Civi\Api4\Generic;
 
+use Civi\Api4\Event\ValidateValuesEvent;
+
 /**
  * Base class for all `Update` api actions
  *
@@ -74,7 +76,12 @@ abstract class AbstractUpdateAction extends AbstractBatchAction {
    * @throws \API_Exception
    */
   protected function validateValues() {
-    // Placeholder
+    // FIXME: There should be a protocol to report a full list of errors... Perhaps a subclass of API_Exception?
+    $e = new ValidateValuesEvent($this, [$this->values]);
+    \Civi::dispatcher()->dispatch('civi.api4.validate', $e);
+    if (!empty($e->errors)) {
+      throw $e->toException();
+    }
   }
 
 }

--- a/Civi/Api4/Generic/AbstractUpdateAction.php
+++ b/Civi/Api4/Generic/AbstractUpdateAction.php
@@ -77,7 +77,14 @@ abstract class AbstractUpdateAction extends AbstractBatchAction {
    */
   protected function validateValues() {
     // FIXME: There should be a protocol to report a full list of errors... Perhaps a subclass of API_Exception?
-    $e = new ValidateValuesEvent($this, [$this->values]);
+    $e = new ValidateValuesEvent($this, [$this->values], new \CRM_Utils_LazyArray(function () {
+      $existing = $this->getBatchAction()->setSelect(['*'])->execute();
+      $result = [];
+      foreach ($existing as $record) {
+        $result[] = ['old' => $record, 'new' => $this->values];
+      }
+      return $result;
+    }));
     \Civi::dispatcher()->dispatch('civi.api4.validate', $e);
     if (!empty($e->errors)) {
       throw $e->toException();

--- a/Civi/Api4/Generic/AbstractUpdateAction.php
+++ b/Civi/Api4/Generic/AbstractUpdateAction.php
@@ -70,4 +70,11 @@ abstract class AbstractUpdateAction extends AbstractBatchAction {
     return $this;
   }
 
+  /**
+   * @throws \API_Exception
+   */
+  protected function validateValues() {
+    // Placeholder
+  }
+
 }

--- a/Civi/Api4/Generic/BasicUpdateAction.php
+++ b/Civi/Api4/Generic/BasicUpdateAction.php
@@ -58,6 +58,7 @@ class BasicUpdateAction extends AbstractUpdateAction {
    */
   public function _run(Result $result) {
     $this->formatWriteValues($this->values);
+    $this->validateValues();
     foreach ($this->getBatchRecords() as $item) {
       $result[] = $this->writeRecord($this->values + $item);
     }

--- a/Civi/Api4/Generic/DAOUpdateAction.php
+++ b/Civi/Api4/Generic/DAOUpdateAction.php
@@ -61,6 +61,7 @@ class DAOUpdateAction extends AbstractUpdateAction {
     if ($this->getSelect() === ['id'] && count($this->where) === 1 && $this->where[0][0] === 'id' && $this->where[0][1] === '=' && !empty($this->where[0][2])) {
       $this->values['id'] = $this->where[0][2];
       $items = [$this->values];
+      $this->validateValues();
       $result->exchangeArray($this->writeObjects($items));
       return;
     }
@@ -71,6 +72,7 @@ class DAOUpdateAction extends AbstractUpdateAction {
       $item = $this->values + $item;
     }
 
+    $this->validateValues();
     $result->exchangeArray($this->writeObjects($items));
   }
 

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -360,13 +360,20 @@ class Container {
     /** @var CiviEventDispatcher $dispatcher */
     $dispatcher = static::getBootService('dispatcher.boot');
 
+    // Sometimes, you have a generic event ('hook_pre') and wish to fire more targeted aliases ('hook_pre::MyEntity') to allow shorter subscriber lists.
+    $aliasEvent = function($eventName, $fieldName) {
+      return function($e) use ($eventName, $fieldName) {
+        \Civi::dispatcher()->dispatch($eventName . "::" . $e->{$fieldName}, $e);
+      };
+    };
+
     $dispatcher->addListener('civi.core.install', ['\Civi\Core\InstallationCanary', 'check']);
     $dispatcher->addListener('civi.core.install', ['\Civi\Core\DatabaseInitializer', 'initialize']);
     $dispatcher->addListener('civi.core.install', ['\Civi\Core\LocalizationInitializer', 'initialize']);
     $dispatcher->addListener('hook_civicrm_post', ['\CRM_Core_Transaction', 'addPostCommit'], -1000);
-    $dispatcher->addListener('hook_civicrm_pre', ['\Civi\Core\Event\PreEvent', 'dispatchSubevent'], 100);
+    $dispatcher->addListener('hook_civicrm_pre', $aliasEvent('hook_civicrm_pre', 'entity'), 100);
     $dispatcher->addListener('civi.dao.preDelete', ['\CRM_Core_BAO_EntityTag', 'preDeleteOtherEntity']);
-    $dispatcher->addListener('hook_civicrm_post', ['\Civi\Core\Event\PostEvent', 'dispatchSubevent'], 100);
+    $dispatcher->addListener('hook_civicrm_post', $aliasEvent('hook_civicrm_post', 'entity'), 100);
     $dispatcher->addListener('hook_civicrm_post::Activity', ['\Civi\CCase\Events', 'fireCaseChange']);
     $dispatcher->addListener('hook_civicrm_post::Case', ['\Civi\CCase\Events', 'fireCaseChange']);
     $dispatcher->addListener('hook_civicrm_caseChange', ['\Civi\CCase\Events', 'delegateToXmlListeners']);

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -397,6 +397,7 @@ class Container {
     $dispatcher->addListener('hook_civicrm_permissionList', ['CRM_Core_Permission_List', 'findCmsPermissions'], 925);
 
     $dispatcher->addListener('hook_civicrm_triggerInfo', ['\CRM_Contact_BAO_RelationshipCache', 'onHookTriggerInfo']);
+    $dispatcher->addListener('civi.api4.validate', $aliasEvent('civi.api4.validate', 'entity'), 100);
     $dispatcher->addListener('civi.dao.postInsert', ['\CRM_Core_BAO_RecurringEntity', 'triggerInsert']);
     $dispatcher->addListener('civi.dao.postUpdate', ['\CRM_Core_BAO_RecurringEntity', 'triggerUpdate']);
     $dispatcher->addListener('civi.dao.postDelete', ['\CRM_Core_BAO_RecurringEntity', 'triggerDelete']);

--- a/Civi/Core/Event/PostEvent.php
+++ b/Civi/Core/Event/PostEvent.php
@@ -18,17 +18,6 @@ namespace Civi\Core\Event;
 class PostEvent extends GenericHookEvent {
 
   /**
-   * This adapter automatically emits a narrower event.
-   *
-   * For example, `hook_civicrm_pre(Contact, ...)` will also dispatch `hook_civicrm_pre::Contact`.
-   *
-   * @param \Civi\Core\Event\PostEvent $event
-   */
-  public static function dispatchSubevent(PostEvent $event) {
-    \Civi::dispatcher()->dispatch("hook_civicrm_post::" . $event->entity, $event);
-  }
-
-  /**
    * One of: 'create'|'edit'|'delete'
    *
    * @var string

--- a/Civi/Core/Event/PreEvent.php
+++ b/Civi/Core/Event/PreEvent.php
@@ -18,17 +18,6 @@ namespace Civi\Core\Event;
 class PreEvent extends GenericHookEvent {
 
   /**
-   * This adapter automatically emits a narrower event.
-   *
-   * For example, `hook_civicrm_pre(Contact, ...)` will also dispatch `hook_civicrm_pre::Contact`.
-   *
-   * @param \Civi\Core\Event\PreEvent $event
-   */
-  public static function dispatchSubevent(PreEvent $event) {
-    \Civi::dispatcher()->dispatch("hook_civicrm_pre::" . $event->entity, $event);
-  }
-
-  /**
    * One of: 'create'|'edit'|'delete'
    *
    * @var string

--- a/tests/phpunit/CRM/Utils/LazyArrayTest.php
+++ b/tests/phpunit/CRM/Utils/LazyArrayTest.php
@@ -1,0 +1,111 @@
+<?php
+
+/**
+ * Class CRM_Utils_LazyArrayTest
+ * @group headless
+ */
+class CRM_Utils_LazyArrayTest extends CiviUnitTestCase {
+
+  public function testAssoc() {
+    $l = $this->createFruitBasket();
+    $this->assertFalse($l->isLoaded());
+
+    $this->assertEquals('apple', $l['a']);
+    $this->assertEquals('banana', $l['b']);
+    $this->assertTrue($l->isLoaded());
+    $this->assertEquals(3, count($l));
+    $this->assertTrue(isset($l['c']));
+    $this->assertFalse(isset($l['d']));
+
+    $l['a'] = 'apricot';
+    $this->assertEquals('apricot', $l['a']);
+    $this->assertEquals(3, count($l));
+
+    $l['d'] = 'date';
+    $this->assertEquals('date', $l['d']);
+    $this->assertEquals(4, count($l));
+
+    $keys = [];
+    foreach ($l as $key => $value) {
+      $keys[] = $key;
+    }
+    $this->assertEquals(['a', 'b', 'c', 'd'], $keys);
+    $this->assertEquals(['a', 'b', 'c', 'd'], array_keys(CRM_Utils_Array::cast($l)));
+  }
+
+  public function testNumeric() {
+    $l = $this->createSeaRecords();
+    $this->assertFalse($l->isLoaded());
+
+    $this->assertEquals('aegean', $l[0]['name']);
+    $this->assertEquals('caspian', $l[2]['name']);
+    $this->assertTrue($l->isLoaded());
+    $this->assertEquals(3, count($l));
+    $this->assertTrue(isset($l[2]));
+    $this->assertFalse(isset($l[3]));
+
+    $l[2]['name'] = 'coral';
+    $this->assertEquals(['name' => 'coral', 'area' => 371], $l['2']);
+    $this->assertEquals(3, count($l));
+
+    $l[] = ['name' => 'weddell', 'area' => 2800];
+    $this->assertEquals('weddell', $l[3]['name']);
+    $this->assertEquals(4, count($l));
+
+    $keys = [];
+    foreach ($l as $key => $value) {
+      $keys[] = $key;
+    }
+    $this->assertEquals([0, 1, 2, 3], $keys);
+    $this->assertEquals([0, 1, 2, 3], array_keys(CRM_Utils_Array::cast($l)));
+  }
+
+  public function testBasicInspections() {
+    $l = $this->createFruitBasket();
+    $this->assertFalse($l->isLoaded());
+
+    $this->assertTrue($l !== NULL);
+    $this->assertTrue($l instanceof CRM_Utils_LazyArray);
+    $this->assertTrue(is_iterable($l));
+    $this->assertTrue(!is_array($l));
+
+    $this->assertFalse($l->isLoaded());
+
+    $this->assertEquals(3, count($l));
+    $this->assertTrue($l->isLoaded());
+  }
+
+  public function testCopy() {
+    $l = $this->createFruitBasket();
+    $copy = $l->getArrayCopy();
+    $copy['d'] = 'date';
+
+    $this->assertEquals(3, count($l));
+    $this->assertEquals(4, count($copy));
+  }
+
+  /**
+   * @return \CRM_Utils_LazyArray
+   */
+  private function createFruitBasket(): \CRM_Utils_LazyArray {
+    return new CRM_Utils_LazyArray(function () {
+      yield 'a' => 'apple';
+      yield 'b' => 'banana';
+      yield 'c' => 'cherry';
+    });
+  }
+
+  /**
+   * @return \CRM_Utils_LazyArray
+   */
+  private function createSeaRecords(): \CRM_Utils_LazyArray {
+    return new CRM_Utils_LazyArray(function () {
+      return [
+        ['name' => 'aegean', 'area' => 214],
+        ['name' => 'baltic', 'area' => 377],
+        ['name' => 'caspian', 'area' => 371],
+      ];
+    });
+  }
+
+}

--- a/tests/phpunit/api/v4/Entity/ConformanceTest.php
+++ b/tests/phpunit/api/v4/Entity/ConformanceTest.php
@@ -21,6 +21,7 @@ namespace api\v4\Entity;
 
 use Civi\Api4\Entity;
 use api\v4\UnitTestCase;
+use Civi\Api4\Event\ValidateValuesEvent;
 use Civi\Api4\Utils\CoreUtil;
 
 /**
@@ -200,6 +201,13 @@ class ConformanceTest extends UnitTestCase {
    * @return mixed
    */
   protected function checkCreation($entity, $entityClass) {
+    $hookLog = [];
+    $onValidate = function(ValidateValuesEvent $e) use (&$hookLog) {
+      $hookLog[$e->entity][$e->action] = 1 + ($hookLog[$e->entity][$e->action] ?? 0);
+    };
+    \Civi::dispatcher()->addListener('civi.api4.validate', $onValidate);
+    \Civi::dispatcher()->addListener('civi.api4.validate::' . $entity, $onValidate);
+
     $requiredParams = $this->creationParamProvider->getRequired($entity);
     $createResult = $entityClass::create()
       ->setValues($requiredParams)
@@ -211,6 +219,10 @@ class ConformanceTest extends UnitTestCase {
     $id = $createResult['id'];
 
     $this->assertGreaterThanOrEqual(1, $id, "$entity ID not positive");
+
+    $this->assertEquals(2, $hookLog[$entity]['create']);
+    \Civi::dispatcher()->removeListener('civi.api4.validate', $onValidate);
+    \Civi::dispatcher()->removeListener('civi.api4.validate::' . $entity, $onValidate);
 
     return $id;
   }

--- a/tests/phpunit/api/v4/Entity/ValidateValuesTest.php
+++ b/tests/phpunit/api/v4/Entity/ValidateValuesTest.php
@@ -1,0 +1,214 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+namespace api\v4\Entity;
+
+use Civi\Api4\Contact;
+use api\v4\UnitTestCase;
+use Civi\Api4\Event\ValidateValuesEvent;
+use Civi\Test\TransactionalInterface;
+
+/**
+ * Assert that 'validateValues' runs during
+ *
+ * @group headless
+ */
+class ValidateValuesTest extends UnitTestCase implements TransactionalInterface {
+
+  private $lastValidator;
+
+  protected function setUp(): void {
+    $this->lastValidator = NULL;
+    parent::setUp();
+  }
+
+  protected function tearDown(): void {
+    $this->setValidator(NULL);
+    parent::tearDown();
+  }
+
+  /**
+   * Fire ValidateValuesEvent several times - and ensure it conveys the
+   * expected data.
+   *
+   * @throws \API_Exception
+   * @throws \Civi\API\Exception\UnauthorizedException
+   */
+  public function testHookData() {
+    $hookCount = 0;
+
+    // Step 1: `create()` a record for Ms. Alice Alison.
+    $this->setValidator(function (ValidateValuesEvent $e) use (&$hookCount) {
+      $this->assertWellFormedEvent($e);
+      if ($e->entity !== 'Contact') {
+        return;
+      }
+
+      $hookCount++;
+      $this->assertEquals('create', $e->action);
+      $this->assertEquals('Alice', $e->records[0]['first_name']);
+      $this->assertEquals('Alison', $e->records[0]['last_name']);
+
+      $this->assertFalse($e->diffs->isLoaded());
+      $this->assertEquals(1, count($e->diffs));
+      $this->assertEquals(NULL, $e->diffs[0]['old']);
+      $this->assertEquals('Alice', $e->diffs[0]['new']['first_name']);
+      $this->assertEquals('Alison', $e->diffs[0]['new']['last_name']);
+
+    });
+    $created = Contact::create()->setValues([
+      'contact_type' => 'Individual',
+      'first_name' => 'Alice',
+      'last_name' => 'Alison',
+    ])->execute()->single();
+    $this->assertTrue(is_numeric($created['id']));
+    $this->assertEquals(1, $hookCount);
+
+    // Step 2: `save()` a couple records for Ms. Alice Alison and Mr. Bob Bobmom.
+    $this->setValidator(function (ValidateValuesEvent $e) use (&$hookCount) {
+      $this->assertWellFormedEvent($e);
+      if ($e->entity !== 'Contact') {
+        return;
+      }
+
+      $hookCount++;
+      $this->assertEquals('save', $e->action);
+      $this->assertEquals('Alicia', $e->records[0]['first_name']);
+      $this->assertEquals('Bob', $e->records[1]['first_name']);
+
+      $this->assertFalse($e->diffs->isLoaded());
+      $this->assertEquals(2, count($e->diffs));
+      $this->assertEquals('Alice', $e->diffs[0]['old']['first_name']);
+      $this->assertEquals('Alicia', $e->diffs[0]['new']['first_name']);
+      $this->assertEquals(NULL, $e->diffs[1]['old']);
+      $this->assertEquals('Bob', $e->diffs[1]['new']['first_name']);
+
+    });
+    $saved = Contact::save()->setRecords([
+      ['id' => $created['id'], 'first_name' => 'Alicia'],
+      ['contact_type' => 'Individual', 'first_name' => 'Bob', 'last_name' => 'Bobmom'],
+    ])->execute();
+    $this->assertEquals(2, $saved->count());
+    $this->assertEquals(2, $hookCount);
+
+    // Step 3: `update()` a record for Mr. Bob Bobmom
+    $this->setValidator(function (ValidateValuesEvent $e) use (&$hookCount) {
+      $this->assertWellFormedEvent($e);
+      if ($e->entity !== 'Contact') {
+        return;
+      }
+
+      $hookCount++;
+      $this->assertEquals('update', $e->action);
+      $this->assertEquals('Bobby', $e->records[0]['first_name']);
+
+      $this->assertFalse($e->diffs->isLoaded());
+      $this->assertEquals(1, count($e->diffs));
+      $this->assertEquals('Bob', $e->diffs[0]['old']['first_name']);
+      $this->assertEquals('Bobmom', $e->diffs[0]['old']['last_name']);
+      $this->assertEquals('Bobby', $e->diffs[0]['new']['first_name']);
+    });
+    $updated = Contact::update()
+      ->setValues(['first_name' => 'Bobby'])
+      ->addWhere('last_name', '=', 'Bobmom')
+      ->execute();
+    $this->assertEquals(1, $updated->count());
+    $this->assertEquals(3, $hookCount);
+  }
+
+  public function testRaiseError() {
+    $this->setValidator(function (ValidateValuesEvent $e) use (&$hookCount) {
+      $this->assertWellFormedEvent($e);
+      if ($e->entity !== 'Contact') {
+        return;
+      }
+
+      foreach ($e->records as $k => $record) {
+        $e->addError($k, 'first_name', 'not-namey-enough', ts('The first name is not sufficiently namey.'));
+        $e->addError($k, ['first_name', 'last_name'], 'tongue-twister', ts('When the names are put together, they become a tongue twister.'));
+        $e->errors[] = [
+          'record' => $k,
+          'fields' => ['last_name'],
+          'name' => 'misspelled',
+          'message' => ts('I disagree with the spelling of your name.'),
+        ];
+      }
+
+      $hookCount++;
+    });
+
+    try {
+      Contact::create()->setValues([
+        'contact_type' => 'Individual',
+        'first_name' => 'Alice',
+        'last_name' => 'Alison',
+      ])->execute();
+      $this->fail('Expected an exception due to validation error');
+    }
+    catch (\API_Exception $e) {
+      $this->assertEquals(1, $hookCount);
+      $this->assertRegExp(';not sufficiently namey;', $e->getMessage());
+      $this->assertRegExp(';tongue twister;', $e->getMessage());
+      $this->assertRegExp(';disagree with the spelling;', $e->getMessage());
+    }
+  }
+
+  /**
+   * Add/replace the validator.
+   *
+   * @param callable $func
+   */
+  protected function setValidator($func) {
+    $dispatcher = \Civi::dispatcher();
+    if ($this->lastValidator) {
+      $dispatcher->removeListener('civi.api4.validate', $this->lastValidator);
+    }
+    if ($func) {
+      $dispatcher->addListener('civi.api4.validate', $func);
+    }
+    $this->lastValidator = $func;
+  }
+
+  protected function assertWellFormedEvent(ValidateValuesEvent $e) {
+    $this->assertRegExp('/Contact/', $e->entity);
+    $this->assertRegExp('/create|save|update/', $e->action);
+    $this->assertTrue(count($e->records) > 0);
+    foreach ($e->records as $record) {
+      $this->assertWellFormedFields($record);
+    }
+
+    // We want to let the main test do some assertions on the lazy-array, so we'll peek a clone.
+    $peekAtDiffs = clone $e->diffs;
+    $this->assertTrue(count($peekAtDiffs) > 0);
+    foreach ($peekAtDiffs as $diff) {
+      $this->assertTrue(is_array($diff['new']));
+      $this->assertWellFormedFields($diff['new']);
+      if ($diff['old'] !== NULL) {
+        $this->assertTrue(is_array($diff['old']));
+        $this->assertWellFormedFields($diff['old']);
+      }
+    }
+  }
+
+  protected function assertWellFormedFields($record) {
+    foreach ($record as $field => $value) {
+      $this->assertRegExp('/^[a-zA-Z0-9_]+$/', $field);
+    }
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------

This patch introduces an internal event, `civi.api4.validate`, which can be used to introduce more fine-tuned/per-entity validation rules.

Before
----------------------------------------

To validate an entity in APIv4, one would need to override each method (`MyEntity::create()`, `MyEntity::save()`), then override the relevant class and override the `validateValues()` method.

After
----------------------------------------

One may listen to `civi.api4.validate` and add extra validation rules. Here's an example adapted from the docblock:

```php
Civi::dispatcher()->addListener('civi.api4.validate', function(ValidateValuesEvent $e) {
  if ($e->getEntity() !== 'Foozball') return;
  foreach ($e->getRecords() as $r => $record) {
    if (strtotime($record['start_time']) < CRM_Utils_Time::time()) {
      $e->addError($r, 'start_time', 'past', ts('Foozball can only be scheduled in the future. Foozball revisionism is not permitted.'));
    }
    if ($record['length'] * $record['width'] * $record['height'] > VOLUME_LIMIT) {
      $e->addError($r, ['length', 'width', 'height'], 'excessive_volume', ts('The record is too big.'));
    }
  }
});
```

Technical Details
----------------------------------------

As with `hook_civicrm_pre` and `hook_civicrm_post` or Drupal form hooks, this actually dispatches synonymous events (`civi.api4.validate` and `civi.api4.validate::ENTITY_NAME`). For typical/simple cases, this allows to avoid the problem of systemic over-subscription (wherein every listener as to receive every event and then do some conditionals).

There is fairly light test coverage directly in this patch. There is more extensive (but implicit) coverage in a follow-up branch (`master-strings`). Specifically:
* The [Strings](https://github.com/totten/civicrm-core/blob/master-strings/CRM/Core/BAO/Strings.php#L85) entity has a validation listener.
* The [StringsTest](https://github.com/totten/civicrm-core/blob/master-strings/tests/phpunit/api/v4/Entity/StringsTest.php#L56) has several cases where it attempts to send bad data - and the data is rejected based on a validation hook.