### PR TITLE
SearchKit - Pass-thu permission checks from SearchDisplay::run to api.get

### DIFF
--- a/ext/search/Civi/Api4/Action/SearchDisplay/Run.php
+++ b/ext/search/Civi/Api4/Action/SearchDisplay/Run.php
@@ -90,6 +90,7 @@ class Run extends \Civi\Api4\Generic\AbstractAction {
     }
     $entityName = $this->savedSearch['api_entity'];
     $apiParams =& $this->savedSearch['api_params'];
+    $apiParams['checkPermissions'] = $this->checkPermissions;
     $apiParams += ['where' => []];
     $settings = $this->display['settings'];
     $page = NULL;

--- a/ext/search/Civi/Api4/SearchDisplay.php
+++ b/ext/search/Civi/Api4/SearchDisplay.php
@@ -29,4 +29,10 @@ class SearchDisplay extends Generic\DAOEntity {
       ->setCheckPermissions($checkPermissions);
   }
 
+  public static function permissions() {
+    $permissions = parent::permissions();
+    $permissions['run'] = [];
+    return $permissions;
+  }
+
 }

--- a/ext/search/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
+++ b/ext/search/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
@@ -2,13 +2,20 @@
 namespace api\v4\SearchDisplay;
 
 use Civi\Api4\Contact;
+use Civi\Api4\SavedSearch;
+use Civi\Api4\SearchDisplay;
+use Civi\Api4\UFMatch;
 use Civi\Test\HeadlessInterface;
 use Civi\Test\TransactionalInterface;
+
+// FIXME: This shouldn't be needed but the core classLoader doesn't seem present when this file loads
+require_once 'tests/phpunit/CRMTraits/ACL/PermissionTrait.php';
 
 /**
  * @group headless
  */
 class SearchRunTest extends \PHPUnit\Framework\TestCase implements HeadlessInterface, TransactionalInterface {
+  use \CRMTraits_ACL_PermissionTrait;
 
   public function setUpHeadless() {
     // Civi\Test has many helpers, like install(), uninstall(), sql(), and sqlFile().
@@ -100,6 +107,111 @@ class SearchRunTest extends \PHPUnit\Framework\TestCase implements HeadlessInter
     $this->assertCount(2, $result);
     $this->assertEquals('Three', $result[0]['first_name']);
     $this->assertEquals('Two', $result[1]['first_name']);
+  }
+
+  /**
+   * Test running a searchDisplay as a restricted user.
+   */
+  public function testDisplayACLCheck() {
+    $lastName = uniqid(__FUNCTION__);
+    $sampleData = [
+      ['first_name' => 'User', 'last_name' => uniqid('user')],
+      ['first_name' => 'One', 'last_name' => $lastName],
+      ['first_name' => 'Two', 'last_name' => $lastName],
+      ['first_name' => 'Three', 'last_name' => $lastName],
+      ['first_name' => 'Four', 'last_name' => $lastName],
+    ];
+    $sampleData = Contact::save(FALSE)
+      ->setRecords($sampleData)->execute()
+      ->indexBy('first_name')->column('id');
+
+    // Create logged-in user
+    UFMatch::delete(FALSE)
+      ->addWhere('uf_id', '=', 6)
+      ->execute();
+    UFMatch::create(FALSE)->setValues([
+      'contact_id' => $sampleData['User'],
+      'uf_name' => 'superman',
+      'uf_id' => 6,
+    ])->execute();
+
+    $session = \CRM_Core_Session::singleton();
+    $session->set('userID', $sampleData['User']);
+    $hooks = \CRM_Utils_Hook::singleton();
+    \CRM_Core_Config::singleton()->userPermissionClass->permissions = [
+      'access CiviCRM',
+    ];
+
+    $search = SavedSearch::create(FALSE)
+      ->setValues([
+        'name' => uniqid(__FUNCTION__),
+        'api_entity' => 'Contact',
+        'api_params' => [
+          'version' => 4,
+          'select' => ['id', 'first_name', 'last_name'],
+          'where' => [['last_name', '=', $lastName]],
+        ],
+      ])
+      ->addChain('display', SearchDisplay::create()
+        ->setValues([
+          'type' => 'table',
+          'label' => uniqid(__FUNCTION__),
+          'saved_search_id' => '$id',
+          'settings' => [
+            'limit' => 20,
+            'pager' => TRUE,
+            'columns' => [
+              [
+                'key' => 'id',
+                'label' => 'Contact ID',
+                'dataType' => 'Integer',
+                'type' => 'field',
+              ],
+              [
+                'key' => 'first_name',
+                'label' => 'First Name',
+                'dataType' => 'String',
+                'type' => 'field',
+              ],
+              [
+                'key' => 'last_name',
+                'label' => 'Last Name',
+                'dataType' => 'String',
+                'type' => 'field',
+              ],
+            ],
+            'sort' => [
+              ['id', 'ASC'],
+            ],
+          ],
+        ]), 0)
+      ->execute()->first();
+
+    $params = [
+      'return' => 'page:1',
+      'savedSearch' => $search['name'],
+      'display' => $search['display']['name'],
+      'afform' => NULL,
+    ];
+
+    $hooks->setHook('civicrm_aclWhereClause', [$this, 'aclWhereHookNoResults']);
+    $result = civicrm_api4('SearchDisplay', 'run', $params);
+    $this->assertCount(0, $result);
+
+    $this->allowedContactId = $sampleData['Two'];
+    $hooks->setHook('civicrm_aclWhereClause', [$this, 'aclWhereOnlyOne']);
+    $this->cleanupCachedPermissions();
+    $result = civicrm_api4('SearchDisplay', 'run', $params);
+    $this->assertCount(1, $result);
+    $this->assertEquals($sampleData['Two'], $result[0]['id']);
+
+    $hooks->setHook('civicrm_aclWhereClause', [$this, 'aclWhereGreaterThan']);
+    $this->cleanupCachedPermissions();
+    $result = civicrm_api4('SearchDisplay', 'run', $params);
+    $this->assertCount(2, $result);
+    $this->assertEquals($sampleData['Three'], $result[0]['id']);
+    $this->assertEquals($sampleData['Four'], $result[1]['id']);
+
   }
 
 }

--- a/tests/phpunit/CRMTraits/ACL/PermissionTrait.php
+++ b/tests/phpunit/CRMTraits/ACL/PermissionTrait.php
@@ -95,6 +95,21 @@ trait CRMTraits_ACL_PermissionTrait {
   }
 
   /**
+   * Results after the allowedContact are returned.
+   *
+   * @implements CRM_Utils_Hook::aclWhereClause
+   *
+   * @param string $type
+   * @param array $tables
+   * @param array $whereTables
+   * @param int $contactID
+   * @param string $where
+   */
+  public function aclWhereGreaterThan($type, &$tables, &$whereTables, &$contactID, &$where) {
+    $where = " contact_a.id > " . $this->allowedContactId;
+  }
+
+  /**
    * Set up a core ACL.
    *
    * It is recommended that this helper function is accessed through a scenario function.


### PR DESCRIPTION
Overview
----------------------------------------
This fixes a SearchKit regression in which viewing a search display became inaccessable to users without `administer CiviCRM` permission.

Before
----------------------------------------
SearchDisplays used to be available to any user with permission to view the entity being searched on.
Then in 5.36 it regressed due to #19585 and only users with `administer CiviCRM` could view SearchDisplays.

After
----------------------------------------
This restores the original permission model where the API checks permissions on the entity being searched on.

Technical Details
----------------------------------------
The `SearchDisplay::run` action essentially wraps `API.get` for the searched-on entity, so it makes sense to allow open access to the `run` API & then check permissions on the delegated API call.