### PR TITLE
Make send letter function available to searchkit, individual contributions

### DIFF
--- a/CRM/Contribute/Form/Task/TaskTrait.php
+++ b/CRM/Contribute/Form/Task/TaskTrait.php
@@ -144,7 +144,7 @@ trait CRM_Contribute_Form_Task_TaskTrait {
    * @return false
    */
   public function isSingle() {
-    return $this->_single ?? FALSE;
+    return count($this->getIDs()) === 1;
   }
 
 }

--- a/CRM/Contribute/Task.php
+++ b/CRM/Contribute/Task.php
@@ -101,6 +101,11 @@ class CRM_Contribute_Task extends CRM_Core_Task {
           'title' => ts('Thank-you letters - print or email'),
           'class' => 'CRM_Contribute_Form_Task_PDFLetter',
           'result' => FALSE,
+          'url' => 'civicrm/contribute/task?reset=1&task=letter',
+          'key' => 'letter',
+          'name' => ts('Send Letter'),
+          'is_single_mode' => TRUE,
+          'title_single_mode' => ts('Thank-you letter - print or email'),
         ],
         self::PDF_INVOICE => [
           'title' => ts('Invoices - print or email'),

--- a/templates/CRM/Contribute/Form/Task/PDFLetter.tpl
+++ b/templates/CRM/Contribute/Form/Task/PDFLetter.tpl
@@ -21,14 +21,16 @@
     <table class="form-layout-compressed">
       <tr><td class="label-left">{$form.thankyou_update.html} {$form.thankyou_update.label}</td><td></td></tr>
       <tr><td class="label-left">{$form.receipt_update.html} {$form.receipt_update.label}</td><td></td></tr>
-      <tr>
-        <td class="label-left">{$form.group_by.label} {help id="id-contribution-grouping"}</td>
-        <td>{$form.group_by.html}</td>
-      </tr>
-      <tr>
-        <td class="label-left">{$form.group_by_separator.label}</td>
-        <td>{$form.group_by_separator.html}</td>
-      </tr>
+      {if !$single}
+        <tr>
+          <td class="label-left">{$form.group_by.label} {help id="id-contribution-grouping"}</td>
+          <td>{$form.group_by.html}</td>
+        </tr>
+        <tr>
+          <td class="label-left">{$form.group_by_separator.label}</td>
+          <td>{$form.group_by_separator.html}</td>
+        </tr>
+      {/if}
       <tr>
         <td class="label-left">{$form.email_options.label} {help id="id-contribution-email-print"}</td>
         <td>{$form.email_options.html}</td>


### PR DESCRIPTION
Overview
----------------------------------------
Make send letter function available to searchkit, individual contributions

Before
----------------------------------------
Send (thank you) letter function only available from search display results

After
----------------------------------------
Available from search kit & individual contribution rows

Technical Details
----------------------------------------
If there are no contribution tokens this enotice is hit https://github.com/civicrm/civicrm-core/pull/20178 (pre-existing)

@demeritcowboy I thought there was another issue with getSingle but this seemed to work fine so maybe it was ^^

Comments
----------------------------------------
