### PR TITLE
APIv4 - Setting api misc fixes & tests

### DIFF
--- a/CRM/Core/BAO/Setting.php
+++ b/CRM/Core/BAO/Setting.php
@@ -272,13 +272,15 @@ class CRM_Core_BAO_Setting extends CRM_Core_DAO_Setting {
    *   value of the setting to be set
    * @param array $fieldSpec
    *   Metadata for given field (drawn from the xml)
+   * @param bool $convertToSerializedString
+   *   Deprecated mode
    *
    * @return bool
    * @throws \API_Exception
    */
-  public static function validateSetting(&$value, array $fieldSpec) {
+  public static function validateSetting(&$value, array $fieldSpec, $convertToSerializedString = TRUE) {
     // Deprecated guesswork - should use $fieldSpec['serialize']
-    if ($fieldSpec['type'] == 'String' && is_array($value)) {
+    if ($convertToSerializedString && $fieldSpec['type'] == 'String' && is_array($value)) {
       $value = CRM_Core_DAO::VALUE_SEPARATOR . implode(CRM_Core_DAO::VALUE_SEPARATOR, $value) . CRM_Core_DAO::VALUE_SEPARATOR;
     }
     if (empty($fieldSpec['validate_callback'])) {

--- a/CRM/Core/SelectValues.php
+++ b/CRM/Core/SelectValues.php
@@ -437,7 +437,7 @@ class CRM_Core_SelectValues {
    *
    * @throws \CRM_Core_Exception
    */
-  public function taxDisplayOptions() {
+  public static function taxDisplayOptions() {
     return [
       'Do_not_show' => ts('Do not show breakdown, only show total - i.e %1', [
         1 => CRM_Utils_Money::format(120),

--- a/Civi/Api4/Action/Setting/Get.php
+++ b/Civi/Api4/Action/Setting/Get.php
@@ -39,25 +39,31 @@ class Get extends AbstractSettingAction {
   protected function processSettings(Result $result, $settingsBag, $meta, $domain) {
     if ($this->select) {
       foreach ($this->select as $name) {
+        [$name, $suffix] = array_pad(explode(':', $name), 2, NULL);
+        $value = $settingsBag->get($name);
+        if (isset($value) && !empty($meta[$name]['serialize'])) {
+          $value = \CRM_Core_DAO::unSerializeField($value, $meta[$name]['serialize']);
+        }
+        if ($suffix) {
+          $value = $this->matchPseudoconstant($name, $value, 'id', $suffix, $domain);
+        }
         $result[] = [
-          'name' => $name,
-          'value' => $settingsBag->get($name),
+          'name' => $suffix ? "$name:$suffix" : $name,
+          'value' => $value,
           'domain_id' => $domain,
         ];
       }
     }
     else {
       foreach ($settingsBag->all() as $name => $value) {
+        if (isset($value) && !empty($meta[$name]['serialize'])) {
+          $value = \CRM_Core_DAO::unSerializeField($value, $meta[$name]['serialize']);
+        }
         $result[] = [
           'name' => $name,
           'value' => $value,
           'domain_id' => $domain,
         ];
-      }
-    }
-    foreach ($result as &$setting) {
-      if (isset($setting['value']) && !empty($meta[$setting['name']]['serialize'])) {
-        $setting['value'] = \CRM_Core_DAO::unSerializeField($setting['value'], $meta[$setting['name']]['serialize']);
       }
     }
   }

--- a/Civi/Api4/Action/Setting/GetFields.php
+++ b/Civi/Api4/Action/Setting/GetFields.php
@@ -31,6 +31,7 @@ class GetFields extends \Civi\Api4\Generic\BasicGetFieldsAction {
     $names = $this->_itemsToGet('name');
     $filter = $names ? ['name' => $names] : [];
     $settings = \Civi\Core\SettingsMetadata::getMetadata($filter, $this->domainId, $this->loadOptions);
+    $getReadonly = $this->_isFieldSelected('readonly');
     foreach ($settings as $index => $setting) {
       // Unserialize default value
       if (!empty($setting['serialize']) && !empty($setting['default']) && is_string($setting['default'])) {
@@ -38,6 +39,9 @@ class GetFields extends \Civi\Api4\Generic\BasicGetFieldsAction {
       }
       if (!isset($setting['options'])) {
         $setting['options'] = !empty($setting['pseudoconstant']);
+      }
+      if ($getReadonly) {
+        $setting['readonly'] = \Civi::settings()->getMandatory($setting['name']) !== NULL;
       }
       // Filter out deprecated properties
       $settings[$index] = array_intersect_key($setting, array_column($this->fields(), NULL, 'name'));
@@ -86,6 +90,11 @@ class GetFields extends \Civi\Api4\Generic\BasicGetFieldsAction {
       [
         'name' => 'data_type',
         'data_type' => 'Integer',
+      ],
+      [
+        'name' => 'readonly',
+        'data_type' => 'Boolean',
+        'description' => 'True if value is set in code and cannot be overridden.',
       ],
     ];
   }

--- a/Civi/Api4/Generic/BasicGetFieldsAction.php
+++ b/Civi/Api4/Generic/BasicGetFieldsAction.php
@@ -318,6 +318,7 @@ class BasicGetFieldsAction extends BasicGetAction {
       [
         'name' => 'readonly',
         'data_type' => 'Boolean',
+        'description' => 'True for auto-increment, calculated, or otherwise non-editable fields.',
       ],
       [
         'name' => 'output_formatters',

--- a/api/api.php
+++ b/api/api.php
@@ -64,7 +64,7 @@ function civicrm_api4(string $entity, string $action, array $params = [], $index
   $removeIndexField = FALSE;
 
   // If index field is not part of the select query, we add it here and remove it below (except for oddball "Setting" api)
-  if ($indexField && !empty($params['select']) && is_array($params['select']) && $entity !== 'Setting' && !\Civi\Api4\Utils\SelectUtil::isFieldSelected($indexField, $params['select'])) {
+  if ($indexField && !empty($params['select']) && is_array($params['select']) && !($entity === 'Setting' && $action === 'get') && !\Civi\Api4\Utils\SelectUtil::isFieldSelected($indexField, $params['select'])) {
     $params['select'][] = $indexField;
     $removeIndexField = TRUE;
   }

--- a/tests/phpunit/api/v3/SettingTest.php
+++ b/tests/phpunit/api/v3/SettingTest.php
@@ -111,11 +111,9 @@ class api_v3_SettingTest extends CiviUnitTestCase {
 
   /**
    * Test that getfields will filter on group.
-   * @param int $version
-   * @dataProvider versionThreeAndFour
    */
-  public function testGetFieldsGroupFilters($version) {
-    $this->_apiversion = $version;
+  public function testGetFieldsGroupFilters() {
+    $this->_apiversion = 3;
     $params = ['filters' => ['group' => 'multisite']];
     $result = $this->callAPISuccess('setting', 'getfields', $params);
     $this->assertArrayNotHasKey('customCSSURL', $result['values']);
@@ -363,11 +361,11 @@ class api_v3_SettingTest extends CiviUnitTestCase {
     $this->hookClass->setHook('civicrm_alterSettingsFolders', [$this, 'setExtensionMetadata']);
     $data = NULL;
     Civi::cache('settings')->flush();
-    $fields = $this->callAPISuccess('setting', 'getfields', ['filters' => ['group_name' => 'Test Settings']]);
+    $fields = $this->callAPISuccess('setting', 'getfields');
     $this->assertArrayHasKey('test_key', $fields['values']);
     $this->callAPISuccess('setting', 'create', ['test_key' => 'keyset']);
     $this->assertEquals('keyset', Civi::settings()->get('test_key'));
-    $result = $this->callAPISuccess('setting', 'getvalue', ['name' => 'test_key', 'group' => 'Test Settings']);
+    $result = $this->callAPISuccess('setting', 'getvalue', ['name' => 'test_key']);
     $this->assertEquals('keyset', $result);
   }
 

--- a/tests/phpunit/api/v4/Entity/SettingTest.php
+++ b/tests/phpunit/api/v4/Entity/SettingTest.php
@@ -51,10 +51,24 @@ class SettingTest extends UnitTestCase {
   }
 
   public function testSerailizedSetting() {
-    $settings = \Civi\Api4\Setting::get(FALSE)
-      ->addSelect('contact_edit_options')
+    $set = \Civi\Api4\Setting::set(FALSE)
+      ->addValue('contact_edit_options:name', [
+        'CommunicationPreferences',
+        'CustomData',
+      ])
       ->execute();
-    $this->assertTrue(is_array($settings[0]['value']));
+
+    $setting = \Civi\Api4\Setting::get(FALSE)
+      ->addSelect('contact_edit_options')
+      ->execute()->first();
+    $this->assertTrue(is_array($setting['value']));
+    $this->assertTrue(is_numeric($setting['value'][0]));
+
+    $setting = \Civi\Api4\Setting::get(FALSE)
+      ->addSelect('contact_edit_options:label')
+      ->execute()->first();
+    $this->assertEquals(['Communication Preferences', 'Custom Data'], $setting['value']);
+    $this->assertEquals('contact_edit_options:label', $setting['name']);
   }
 
   /**
@@ -76,6 +90,38 @@ class SettingTest extends UnitTestCase {
     }
     $this->assertTrue($stringValues);
     $this->assertTrue($arrayValues);
+  }
+
+  /**
+   * Make sure options load from getFields.
+   */
+  public function testSettingGetFieldsOptions() {
+    $setting = civicrm_api4('Setting', 'getFields', [
+      'select' => ['options'],
+      'loadOptions' => FALSE,
+    ], 'name');
+    $this->assertTrue($setting['contact_edit_options']['options']);
+
+    $setting = civicrm_api4('Setting', 'getFields', [
+      'select' => ['options'],
+      'where' => [['name', '=', 'contact_edit_options']],
+      'loadOptions' => TRUE,
+    ], 'name');
+    $this->assertContains('Custom Data', $setting['contact_edit_options']['options']);
+
+    $setting = civicrm_api4('Setting', 'getFields', [
+      'select' => ['options'],
+      'loadOptions' => ['id', 'name', 'label'],
+    ], 'name');
+    $this->assertTrue(is_array($setting['contact_edit_options']['options'][0]));
+  }
+
+  /**
+   * Ensure settings default values unserialize.
+   */
+  public function testSettingUnserializeDefaults() {
+    $setting = civicrm_api4('Setting', 'getFields', ['where' => [['name', '=', 'contact_view_options']]], 0);
+    $this->assertTrue(is_array($setting['default']));
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes the setting api to correctly handle pseudoconstants & field suffixes

Before
----------------------------------------
Setting pseudoconstants not handled well.

After
----------------------------------------
Works better & covered by tests.
