### PR TITLE
Add deprected warning to apparently unused functions

### DIFF
--- a/CRM/ACL/API.php
+++ b/CRM/ACL/API.php
@@ -40,6 +40,7 @@ class CRM_ACL_API {
    *   true if yes, else false
    */
   public static function check($str, $contactID = NULL) {
+    \CRM_Core_Error::deprecatedWarning(__CLASS__ . '::' . __FUNCTION__ . ' is deprecated.');
     if ($contactID == NULL) {
       $contactID = CRM_Core_Session::getLoggedInContactID();
     }

--- a/CRM/ACL/BAO/ACL.php
+++ b/CRM/ACL/BAO/ACL.php
@@ -190,6 +190,7 @@ SELECT acl.*
    * @return bool
    */
   public static function check($str, $contactID) {
+    \CRM_Core_Error::deprecatedWarning(__CLASS__ . '::' . __FUNCTION__ . ' is deprecated.');
 
     $acls = CRM_ACL_BAO_Cache::build($contactID);
 


### PR DESCRIPTION
Overview
----------------------------------------
This pair of functions do not appear to be called from anywhere. Marking as deprecated for eventual removal.

Technical Details
----------------------------------------
It looks like one check function is only ever called by the other, and the other isn't called from anywhere.

What these functions are supposed to do is unclear.
The code comment appears to be wrong; the variable `$str` is not a permission string but is inserted into a query as `civicrm_acl.object_table`.

Comments
--------------

That's clear as mud to me, but if they're unused we can just get rid of them.

For that matter, the whole `CRM_ACL_API` class makes very little sense to me. It's an internal class, not an api, but it's named API, and it does some obscure things with no documentation.