### PR TITLE
dev/core#2571: Removed Forced Recaptcha function as it called only once

### DIFF
--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -290,7 +290,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
       $this->buildComponentForm($this->_id, $this);
     }
 
-    if (count($this->_paymentProcessors) >= 1 && !$this->get_template_vars("isCaptcha") && $this->hasToAddForcefully()) {
+    if (count($this->_paymentProcessors) >= 1 && !$this->get_template_vars("isCaptcha") && \Civi::settings()->get('forceRecaptcha')) {
       if (!$this->_userID) {
         CRM_Utils_ReCAPTCHA::enableCaptchaOnForm($this);
       }

--- a/ext/recaptcha/CRM/Utils/ReCAPTCHA.php
+++ b/ext/recaptcha/CRM/Utils/ReCAPTCHA.php
@@ -56,13 +56,6 @@ class CRM_Utils_ReCAPTCHA {
   }
 
   /**
-   * Check if reCaptcha has to be added on form forcefully.
-   */
-  public static function hasToAddForcefully() {
-    return (bool) \Civi::settings()->get('forceRecaptcha');
-  }
-
-  /**
    * Add element to form.
    *
    * @param CRM_Core_Form $form


### PR DESCRIPTION
Overview
----------------------------------------
CRM_Utils_ReCAPTCHA::hasToAddForcefully() has been removed and the settings based function used inside it has been used directly as this was used only once in CRM/Contribute/Form/Contribution/Main.php

Before
----------------------------------------
_What is the old user-interface or technical-contract (as appropriate)?_
_For optimal clarity, include a concrete example such as a screenshot, GIF ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)), or code-snippet._

After
----------------------------------------
_What changed? What is new old user-interface or technical-contract?_
_For optimal clarity, include a concrete example such as a screenshot, GIF ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)), or code-snippet._

Technical Details
----------------------------------------
_If the PR involves technical details/changes/considerations which would not be manifest to a casual developer skimming the above sections, please describe the details here._

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
