### PR TITLE
Use disable over readonly

### DIFF
--- a/CRM/Admin/Form/SettingTrait.php
+++ b/CRM/Admin/Form/SettingTrait.php
@@ -177,7 +177,7 @@ trait CRM_Admin_Form_SettingTrait {
 
         //Load input as readonly whose values are overridden in civicrm.settings.php.
         if (Civi::settings()->getMandatory($setting) !== NULL) {
-          $props['html_attributes']['readonly'] = TRUE;
+          $props['html_attributes']['disabled'] = TRUE;
           $this->includesReadOnlyFields = TRUE;
         }
 


### PR DESCRIPTION
Overview
----------------------------------------
Add `$civicrm_setting['CiviCRM Preferences']['logging'] = FALSE;` in civicrm.settings.php, 

Despite it being greyed out I was able to change the setting to Yes and submit the form, where upon logging was enabled. When the form loaded again, it showed as No due to the override, despite logging now being enabled.

Before
----------------------------------------
<img width="1116" alt="Screen Shot 2021-04-30 at 14 18 13" src="https://user-images.githubusercontent.com/2053075/116700690-f721cd00-a9be-11eb-9c2f-3580d11647f3.png">


After
----------------------------------------
<img width="1219" alt="Screen Shot 2021-04-30 at 14 17 54" src="https://user-images.githubusercontent.com/2053075/116701234-95159780-a9bf-11eb-9f01-8da05cc7f5c1.png">

Technical Details
----------------------------------------
The "readonly" attribute is ignored if the value of the type attribute is hidden, range, color, checkbox, radio, file, or a button type (such as button or submit).
