### PR TITLE
dev/core#2571: Add form function of utils/Recaptcha has been altered to avoid checking variable "isCaptcha"

### DIFF
--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -290,7 +290,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
       $this->buildComponentForm($this->_id, $this);
     }
 
-    if (!$this->get_template_vars("isCaptcha") && \Civi::settings()->get('forceRecaptcha')) {
+    if (\Civi::settings()->get('forceRecaptcha')) {
       if (!$this->_userID) {
         CRM_Utils_ReCAPTCHA::enableCaptchaOnForm($this);
       }

--- a/ext/recaptcha/CRM/Utils/ReCAPTCHA.php
+++ b/ext/recaptcha/CRM/Utils/ReCAPTCHA.php
@@ -62,31 +62,33 @@ class CRM_Utils_ReCAPTCHA {
    */
   public static function add(&$form) {
     $error = NULL;
+
+    // If statement has been altered so that we do not need to check !$this->get_template_vars("isCaptcha") in CRM/Contribute/Form/Contribution/Main.php
     if (!function_exists('recaptcha_get_html')) {
       require_once E::path('lib/recaptcha/recaptchalib.php');
-    }
 
-    // Load the Recaptcha api.js over HTTPS
-    $useHTTPS = TRUE;
+      // Load the Recaptcha api.js over HTTPS
+      $useHTTPS = TRUE;
 
-    $html = recaptcha_get_html(\Civi::settings()->get('recaptchaPublicKey'), $error, $useHTTPS);
+      $html = recaptcha_get_html(\Civi::settings()->get('recaptchaPublicKey'), $error, $useHTTPS);
 
-    $form->assign('recaptchaHTML', $html);
-    $form->assign('recaptchaOptions', \Civi::settings()->get('recaptchaOptions'));
-    $form->add(
-      'text',
-      'g-recaptcha-response',
-      'reCaptcha',
-      NULL,
-      TRUE
-    );
-    $form->registerRule('recaptcha', 'callback', 'validate', 'CRM_Utils_ReCAPTCHA');
-    $form->addRule('g-recaptcha-response', E::ts('Please go back and complete the CAPTCHA at the bottom of this form.'), 'recaptcha');
-    if ($form->isSubmitted() && empty($form->_submitValues['g-recaptcha-response'])) {
-      $form->setElementError(
+      $form->assign('recaptchaHTML', $html);
+      $form->assign('recaptchaOptions', \Civi::settings()->get('recaptchaOptions'));
+      $form->add(
+        'text',
         'g-recaptcha-response',
-        E::ts('Please go back and complete the CAPTCHA at the bottom of this form.')
+        'reCaptcha',
+        NULL,
+        TRUE
       );
+      $form->registerRule('recaptcha', 'callback', 'validate', 'CRM_Utils_ReCAPTCHA');
+      $form->addRule('g-recaptcha-response', E::ts('Please go back and complete the CAPTCHA at the bottom of this form.'), 'recaptcha');
+      if ($form->isSubmitted() && empty($form->_submitValues['g-recaptcha-response'])) {
+        $form->setElementError(
+          'g-recaptcha-response',
+          E::ts('Please go back and complete the CAPTCHA at the bottom of this form.')
+        );
+      }
     }
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
To remove `!$this->get_template_vars("isCaptcha")` in https://github.com/civicrm/civicrm-core/blob/191855180797f275646504324de2f3f9dfb64741/CRM/Contribute/Form/Contribution/Main.php#L293, add form function of utils/recaptcha has been altered so that even if `enableCaptchaonForm` is called again (https://github.com/civicrm/civicrm-core/blob/191855180797f275646504324de2f3f9dfb64741/ext/recaptcha/CRM/Utils/ReCAPTCHA.php#L98), we do not add anything to already built HTML of captcha form. 

Before
----------------------------------------
_What is the old user-interface or technical-contract (as appropriate)?_
_For optimal clarity, include a concrete example such as a screenshot, GIF ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)), or code-snippet._

After
----------------------------------------
_What changed? What is new old user-interface or technical-contract?_
_For optimal clarity, include a concrete example such as a screenshot, GIF ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)), or code-snippet._

Technical Details
----------------------------------------
_If the PR involves technical details/changes/considerations which would not be manifest to a casual developer skimming the above sections, please describe the details here._

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
