### PR TITLE
fix capitalization to allow proper access to 'access AJAX API' perm.

### DIFF
--- a/CRM/Api4/Permission.php
+++ b/CRM/Api4/Permission.php
@@ -25,7 +25,7 @@ class CRM_Api4_Permission {
     $config = CRM_Core_Config::singleton();
     $urlPath = explode('/', $_GET[$config->userFrameworkURLVar]);
     $permissions = [
-      ['access CiviCRM', 'access Ajax API'],
+      ['access CiviCRM', 'access AJAX API'],
     ];
     if (!empty($urlPath[3])) {
       $entity = $urlPath[3];

--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -69,24 +69,24 @@ class CRM_Core_Permission {
    * Ex 1: Must have 'access CiviCRM'
    * (string) 'access CiviCRM'
    *
-   *  Ex 2: Must have 'access CiviCRM' and 'access Ajax API'
-   *    ['access CiviCRM', 'access Ajax API']
+   *  Ex 2: Must have 'access CiviCRM' and 'access AJAX API'
+   *    ['access CiviCRM', 'access AJAX API']
    *
-   * Ex 3: Must have 'access CiviCRM' or 'access Ajax API'
+   * Ex 3: Must have 'access CiviCRM' or 'access AJAX API'
    *   [
-   *     ['access CiviCRM', 'access Ajax API'],
+   *     ['access CiviCRM', 'access AJAX API'],
    *   ],
    *
-   * Ex 4: Must have 'access CiviCRM' or 'access Ajax API' AND 'access CiviEvent'
+   * Ex 4: Must have 'access CiviCRM' or 'access AJAX API' AND 'access CiviEvent'
    *   [
-   *     ['access CiviCRM', 'access Ajax API'],
+   *     ['access CiviCRM', 'access AJAX API'],
    *     'access CiviEvent',
    *   ],
    *
    * Note that in permissions.php this is keyed by the action eg.
    *   (access Civi || access AJAX) && (access CiviEvent || access CiviContribute)
    *   'myaction' => [
-   *     ['access CiviCRM', 'access Ajax API'],
+   *     ['access CiviCRM', 'access AJAX API'],
    *     ['access CiviEvent', 'access CiviContribute']
    *   ],
    *


### PR DESCRIPTION
Maybe this is platform dependent? On my dev instance the access AJAX API
permission to the path /civicrm/ajax/api4/X/X is always denied for anon
users because anon users are granted "access AJAX API" yet the check is
done against "access Ajax API".

This only really matters in CRM/Api4/Permission.php but to avoid any
confusion I'm changing it everywhere the string appears.

Overview
----------------------------------------
_A brief description of the pull request. Keep technical jargon to a minimum. Hyperlink relevant discussions._

Before
----------------------------------------
_What is the old user-interface or technical-contract (as appropriate)?_
_For optimal clarity, include a concrete example such as a screenshot, GIF ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)), or code-snippet._

After
----------------------------------------
_What changed? What is new old user-interface or technical-contract?_
_For optimal clarity, include a concrete example such as a screenshot, GIF ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)), or code-snippet._

Technical Details
----------------------------------------
_If the PR involves technical details/changes/considerations which would not be manifest to a casual developer skimming the above sections, please describe the details here._

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
