### PR TITLE
dev/core#2582 Fix PCP and Pledge template urls in message templates t…

### DIFF
--- a/CRM/Upgrade/Incremental/MessageTemplates.php
+++ b/CRM/Upgrade/Incremental/MessageTemplates.php
@@ -239,6 +239,16 @@ class CRM_Upgrade_Incremental_MessageTemplates {
           ['name' => 'petition_confirmation_needed', 'type' => 'html'],
         ],
       ],
+      [
+        'version' => '5.38.alpha1',
+        'upgrade_descriptor' => ts('Fix Pledge and PCP urls to go to the front end site rather than backend site'),
+        'templates' => [
+          ['name' => 'pcp_notify', 'type' => 'html'],
+          ['name' => 'pcp_notify', 'type' => 'text'],
+          ['name' => 'pledge_reminder', 'type' => 'html'],
+          ['name' => 'pledge_reminder', 'type' => 'text'],
+        ],
+      ],
     ];
   }
 

--- a/xml/templates/message_templates/pcp_notify_html.tpl
+++ b/xml/templates/message_templates/pcp_notify_html.tpl
@@ -9,7 +9,7 @@
 {capture assign=headerStyle}colspan="2" style="text-align: left; padding: 4px; border-bottom: 1px solid #999; background-color: #eee;"{/capture}
 {capture assign=labelStyle }style="padding: 4px; border-bottom: 1px solid #999; background-color: #f7f7f7;"{/capture}
 {capture assign=valueStyle }style="padding: 4px; border-bottom: 1px solid #999;"{/capture}
-{capture assign=pcpURL     }{crmURL p="civicrm/pcp/info" q="reset=1&id=`$pcpId`" h=0 a=1}{/capture}
+{capture assign=pcpURL     }{crmURL p="civicrm/pcp/info" q="reset=1&id=`$pcpId`" h=0 a=1 fe=1}{/capture}
 
 <center>
   <table id="crm-event_receipt" style="font-family: Arial, Verdana, sans-serif; text-align: left; width:100%; max-width:700px; padding:0; margin:0; border:0px;">

--- a/xml/templates/message_templates/pcp_notify_text.tpl
+++ b/xml/templates/message_templates/pcp_notify_text.tpl
@@ -5,7 +5,7 @@
 {ts}Action{/ts}: {if $mode EQ 'Update'}{ts}Updated personal campaign page{/ts}{else}{ts}New personal campaign page{/ts}{/if}
 {ts}Personal Campaign Page Title{/ts}: {$pcpTitle}
 {ts}Current Status{/ts}: {$pcpStatus}
-{capture assign=pcpURL}{crmURL p="civicrm/pcp/info" q="reset=1&id=`$pcpId`" h=0 a=1}{/capture}
+{capture assign=pcpURL}{crmURL p="civicrm/pcp/info" q="reset=1&id=`$pcpId`" h=0 a=1 fe=1}{/capture}
 {ts}View Page{/ts}:
 >> {$pcpURL}
 

--- a/xml/templates/message_templates/pledge_reminder_html.tpl
+++ b/xml/templates/message_templates/pledge_reminder_html.tpl
@@ -48,7 +48,7 @@
   <tr>
    <td>
     {if $contribution_page_id}
-     {capture assign=contributionUrl}{crmURL p='civicrm/contribute/transact' q="reset=1&id=`$contribution_page_id`&cid=`$contact.contact_id`&pledgeId=`$pledge_id`&cs=`$checksumValue`" a=true h=0}{/capture}
+     {capture assign=contributionUrl}{crmURL p='civicrm/contribute/transact' q="reset=1&id=`$contribution_page_id`&cid=`$contact.contact_id`&pledgeId=`$pledge_id`&cs=`$checksumValue`" a=true h=0 fe=1}{/capture}
      <p><a href="{$contributionUrl}">{ts}Go to a web page where you can make your payment online{/ts}</a></p>
     {else}
      <p>{ts}Please mail your payment to{/ts}: {$domain.address}</p>

--- a/xml/templates/message_templates/pledge_reminder_text.tpl
+++ b/xml/templates/message_templates/pledge_reminder_text.tpl
@@ -10,7 +10,7 @@
 {ts}Due Date{/ts}: {$scheduled_payment_date|truncate:10:''|crmDate}
 
 {if $contribution_page_id}
-{capture assign=contributionUrl}{crmURL p='civicrm/contribute/transact' q="reset=1&id=`$contribution_page_id`&cid=`$contact.contact_id`&pledgeId=`$pledge_id`&cs=`$checksumValue`" a=true h=0}{/capture}
+{capture assign=contributionUrl}{crmURL p='civicrm/contribute/transact' q="reset=1&id=`$contribution_page_id`&cid=`$contact.contact_id`&pledgeId=`$pledge_id`&cs=`$checksumValue`" a=true h=0 fe=1}{/capture}
 Click this link to go to a web page where you can make your payment online:
 {$contributionUrl}
 {else}


### PR DESCRIPTION
…o go to front end site rather than backend

Overview
----------------------------------------
This fixes a bug in Joomla where by when a user is reminded about their upcoming pledge the link in the notification goes to the backoffice site rather than the frontend site and looks to be the same issue on the PCP url as well

Before
----------------------------------------
Urls go to the back office site

After
----------------------------------------
Urls go to the front end site

ping @demeritcowboy @philmb 

https://lab.civicrm.org/dev/core/-/issues/2582