### PR TITLE
Remove deprecation of order-must-be-pending

### DIFF
--- a/api/v3/Order.php
+++ b/api/v3/Order.php
@@ -74,10 +74,7 @@ function civicrm_api3_order_create($params) {
   civicrm_api3_verify_one_mandatory($params, NULL, ['line_items', 'total_amount']);
   $entity = NULL;
   $entityIds = [];
-  $params['contribution_status_id'] = $params['contribution_status_id'] ?? 'Pending';
-  if ($params['contribution_status_id'] !== 'Pending' && 'Pending' !== CRM_Core_PseudoConstant::getName('CRM_Contribute_BAO_Contribution', 'contribution_status_id', $params['contribution_status_id'])) {
-    CRM_Core_Error::deprecatedFunctionWarning("Creating a Order with a status other than pending is deprecated. Please do not set contribution_status_id, it will default to Pending. You can chain payment creation e.g civicrm_api3('Order', 'create', ['blah' => 'blah', 'contribution_status_id' => 'Pending', 'api.Payment.create => ['total_amount' => 5]]");
-  }
+  $params['contribution_status_id'] = 'Pending';
 
   if (!empty($params['line_items']) && is_array($params['line_items'])) {
     $priceSetID = NULL;


### PR DESCRIPTION

Overview
----------------------------------------
Remove deprecation of order-must-be-pending

Before
----------------------------------------
 We deprecated creating an order with a status other than pending in Aug last year.

After
----------------------------------------
All orders created as pending

Technical Details
----------------------------------------

Comments
----------------------------------------
