### PR TITLE
Improve Permission denied handling in WordPress by re-suing the get_p…

### DIFF
--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -500,11 +500,12 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
 
   /**
    * FIXME: Use CMS-native approach
-   * @throws \CRM_Core_Exception
    */
   public function permissionDenied() {
     status_header(403);
-    throw new CRM_Core_Exception(ts('You do not have permission to access this page.'));
+    $CiviWordPressClass = civi_wp();
+    add_filter('the_content', [$CiviWordPressClass->users, 'get_permission_denied']);
+    return;
   }
 
   /**


### PR DESCRIPTION
…ermission_denied function to output message instead of Exception when permission is denied

Overview
----------------------------------------
This seeks to improve the handling when a user gets a Permission denied error in WordPress

Before
----------------------------------------
Yellow screen / fatal error caused by Exception being thrown

After
----------------------------------------
Page content replaced with a message saying you do not have permission

ping @kcristiano @mattwire @haystack thoughts?