### PR TITLE
[REF] Move ACLPermission Trait into Civi Folder so that it can be acc…

### DIFF
--- a/Civi/Test/ACLPermissionTrait.php
+++ b/Civi/Test/ACLPermissionTrait.php
@@ -9,12 +9,14 @@
  +--------------------------------------------------------------------+
  */
 
+namespace Civi\Test;
+
 /**
- * Trait ACL_Permission_Trait.
+ * Trait Civi\Test\ACLPermissionTrait.
  *
  * Trait for working with ACLs in tests
  */
-trait CRMTraits_ACL_PermissionTrait {
+trait ACLPermissionTrait {
 
   /**
    * ContactID of allowed Contact
@@ -128,7 +130,7 @@ trait CRMTraits_ACL_PermissionTrait {
 
     $permittedRoleID = ($groupAllowedAccess === 'Everyone') ? 0 : $groupAllowedAccess;
     if ($permittedRoleID !== 0) {
-      throw new CRM_Core_Exception('only handling everyone group as yet');
+      throw new \CRM_Core_Exception('only handling everyone group as yet');
     }
 
     foreach ($permissionedEntities as $permissionedEntityID) {
@@ -160,7 +162,7 @@ trait CRMTraits_ACL_PermissionTrait {
     $this->scenarioIDs['Contact']['permitted_contact'] = $this->individualCreate();
     $result = $this->callAPISuccess('GroupContact', 'create', ['group_id' => $this->scenarioIDs['Group']['permitted_group'], 'contact_id' => $this->scenarioIDs['Contact']['permitted_contact'], 'status' => 'Added']);
     $this->scenarioIDs['Contact']['non_permitted_contact'] = $this->individualCreate();
-    CRM_Core_Config::singleton()->userPermissionClass->permissions = [];
+    \CRM_Core_Config::singleton()->userPermissionClass->permissions = [];
     $this->setupCoreACLPermittedAcl([$this->scenarioIDs['Group']['permitted_group']]);
   }
 
@@ -180,7 +182,7 @@ trait CRMTraits_ACL_PermissionTrait {
     $this->quickCleanup(['civicrm_acl_cache', 'civicrm_acl_contact_cache']);
     $this->scenarioIDs['Event']['permitted_event'] = $this->eventCreate()['id'];
     $this->scenarioIDs['Contact']['permitted_contact'] = $this->individualCreate();
-    CRM_Core_Config::singleton()->userPermissionClass->permissions = ['view event info'];
+    \CRM_Core_Config::singleton()->userPermissionClass->permissions = ['view event info'];
     $this->setupCoreACLPermittedAcl([$this->scenarioIDs['Event']['permitted_event']], 'Everyone', 'View', 'Event');
   }
 
@@ -188,10 +190,10 @@ trait CRMTraits_ACL_PermissionTrait {
    * Clean up places where permissions get cached.
    */
   protected function cleanupCachedPermissions() {
-    if (isset(Civi::$statics['CRM_Contact_BAO_Contact_Permission'])) {
-      unset(Civi::$statics['CRM_Contact_BAO_Contact_Permission']);
+    if (isset(\Civi::$statics['CRM_Contact_BAO_Contact_Permission'])) {
+      unset(\Civi::$statics['CRM_Contact_BAO_Contact_Permission']);
     }
-    CRM_Core_DAO::executeQuery('TRUNCATE civicrm_acl_contact_cache');
+    \CRM_Core_DAO::executeQuery('TRUNCATE civicrm_acl_contact_cache');
   }
 
 }

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
@@ -8,14 +8,11 @@ use Civi\Api4\UFMatch;
 use Civi\Test\HeadlessInterface;
 use Civi\Test\TransactionalInterface;
 
-// FIXME: This shouldn't be needed but the core classLoader doesn't seem present when this file loads
-require_once 'tests/phpunit/CRMTraits/ACL/PermissionTrait.php';
-
 /**
  * @group headless
  */
 class SearchRunTest extends \PHPUnit\Framework\TestCase implements HeadlessInterface, TransactionalInterface {
-  use \CRMTraits_ACL_PermissionTrait;
+  use \Civi\Test\ACLPermissionTrait;
 
   public function setUpHeadless() {
     // Civi\Test has many helpers, like install(), uninstall(), sql(), and sqlFile().

--- a/tests/phpunit/CRM/Core/Permission/BaseTest.php
+++ b/tests/phpunit/CRM/Core/Permission/BaseTest.php
@@ -6,7 +6,7 @@
  */
 class CRM_Core_Permission_BaseTest extends CiviUnitTestCase {
 
-  use CRMTraits_ACL_PermissionTrait;
+  use Civi\Test\ACLPermissionTrait;
 
   /**
    * @return array

--- a/tests/phpunit/CRM/Event/BAO/EventPermissionsTest.php
+++ b/tests/phpunit/CRM/Event/BAO/EventPermissionsTest.php
@@ -15,7 +15,7 @@
  */
 class CRM_Event_BAO_EventPermissionsTest extends CiviUnitTestCase {
 
-  use CRMTraits_ACL_PermissionTrait;
+  use Civi\Test\ACLPermissionTrait;
 
   public function setUp(): void {
     parent::setUp();

--- a/tests/phpunit/api/v3/ACLPermissionTest.php
+++ b/tests/phpunit/api/v3/ACLPermissionTest.php
@@ -23,7 +23,7 @@ use Civi\Api4\CustomValue;
  */
 class api_v3_ACLPermissionTest extends CiviUnitTestCase {
 
-  use CRMTraits_ACL_PermissionTrait;
+  use Civi\Test\ACLPermissionTrait;
 
   public $DBResetRequired = FALSE;
   protected $_entity;

--- a/tests/phpunit/api/v3/EntityTagACLTest.php
+++ b/tests/phpunit/api/v3/EntityTagACLTest.php
@@ -26,7 +26,7 @@
  */
 class api_v3_EntityTagACLTest extends CiviUnitTestCase {
 
-  use CRMTraits_ACL_PermissionTrait;
+  use Civi\Test\ACLPermissionTrait;
 
   /**
    * API Version in use.

--- a/tests/phpunit/api/v3/ReportTemplateTest.php
+++ b/tests/phpunit/api/v3/ReportTemplateTest.php
@@ -18,7 +18,7 @@
  */
 class api_v3_ReportTemplateTest extends CiviUnitTestCase {
 
-  use CRMTraits_ACL_PermissionTrait;
+  use Civi\Test\ACLPermissionTrait;
   use CRMTraits_PCP_PCPTestTrait;
   use CRMTraits_Custom_CustomDataTrait;
 


### PR DESCRIPTION
…essed by Extensions

Overview
----------------------------------------
This moves the PermissionTrait from in CRMTraits which doesn't get autoloaded by the Extension test autoloading into the Civi/Test namespace

Before
----------------------------------------
Trait not autoloaded as CRMTraits folder doesn't get autoloaded when booting tests for extensions

After
----------------------------------------
Trait in the Civi/Test namespace and gets autoloaded when booting tests for extensions

pint @eileenmcnaughton @colemanw 