### PR TITLE
Do not error on view contribution recur if not displaying contributions

### DIFF
--- a/CRM/Contribute/Page/ContributionRecur.php
+++ b/CRM/Contribute/Page/ContributionRecur.php
@@ -99,7 +99,7 @@ class CRM_Contribute_Page_ContributionRecur extends CRM_Core_Page {
    */
   public function run() {
     $this->preProcess();
-
+    $this->assign('hasAccessCiviContributePermission', CRM_Core_Permission::check('access CiviContribute'));
     if ($this->isViewContext()) {
       $this->view();
     }

--- a/templates/CRM/Contribute/Page/ContributionRecur.tpl
+++ b/templates/CRM/Contribute/Page/ContributionRecur.tpl
@@ -53,28 +53,29 @@
     <div class="crm-submit-buttons"><a class="button cancel crm-form-submit" href="{crmURL p='civicrm/contact/view' q='action=browse&selectedChild=contribute'}">{ts}Done{/ts}</a></div>
   </div>
 {/if}
-
-<script type="text/javascript">
-  var recurContribID = {$recur.id};
-  var contactID = {$contactId};
-  {literal}
-  CRM.$(function($) {
-    CRM.loadPage(
-            CRM.url(
-                    'civicrm/contribute/contributionrecur-payments',
-                    {
-                      reset: 1,
-                      id: recurContribID,
-                      cid: contactID
-                    },
-                    'back'
-            ),
-            {
-              target : '#recurring-contribution-payments',
-              dialog : false
-            }
-    );
-  });
-  {/literal}
-</script>
+{if $hasAccessCiviContributePermission}
+  <script type="text/javascript">
+    var recurContribID = {$recur.id};
+    var contactID = {$contactId};
+    {literal}
+    CRM.$(function($) {
+      CRM.loadPage(
+              CRM.url(
+                      'civicrm/contribute/contributionrecur-payments',
+                      {
+                        reset: 1,
+                        id: recurContribID,
+                        cid: contactID
+                      },
+                      'back'
+              ),
+              {
+                target : '#recurring-contribution-payments',
+                dialog : false
+              }
+      );
+    });
+    {/literal}
+  </script>
+{/if}
 <div id="recurring-contribution-payments"></div>


### PR DESCRIPTION
Overview
----------------------------------------
A contact with the permissions
- CiviCRM: access Contact Dashboard
- CiviContribute: make online contributions
- CiviCRM: view my contact

But NOT access CiviContribute

Can view their own recurring contribution records - however they get an error because the contribution listing on that page will not display

Before
----------------------------------------
The contribution listing does not display AND there is an error
![image](https://user-images.githubusercontent.com/336308/116839060-ec687180-ac24-11eb-9fe5-3ec9160eab20.png)

After
----------------------------------------
The contribution listing does not display AND there is no error

Technical Details
----------------------------------------
We could do more sophisticated  checks / improve permissioning here but this was something I hit while trying to replicate another issue and I don't think it warrants that degree of thought at this stage

Comments
----------------------------------------
view with w=1 as this is just an IF