### PR TITLE
dev/core#2583 - Fix fatal error on membership renewal

### DIFF
--- a/CRM/Member/Form/MembershipRenewal.php
+++ b/CRM/Member/Form/MembershipRenewal.php
@@ -202,7 +202,7 @@ class CRM_Member_Form_MembershipRenewal extends CRM_Member_Form {
     $defaults['total_amount'] = CRM_Utils_Money::formatLocaleNumericRoundedForDefaultCurrency(CRM_Core_DAO::getFieldValue('CRM_Member_DAO_MembershipType',
       $this->_memType,
       'minimum_fee'
-    ));
+    ) ?? 0);
 
     $defaults['record_contribution'] = 0;
     $defaults['num_terms'] = 1;
@@ -276,7 +276,7 @@ class CRM_Member_Form_MembershipRenewal extends CRM_Member_Form {
 
         //CRM-16950
         $taxAmount = NULL;
-        $totalAmount = $values['minimum_fee'] ?? NULL;
+        $totalAmount = $values['minimum_fee'] ?? 0;
         // @todo - feels a bug - we use taxRate from the form default rather than from the specified type?!?
         if ($this->getTaxRateForFinancialType($values['financial_type_id'])) {
           $taxAmount = ($taxRate / 100) * CRM_Utils_Array::value('minimum_fee', $values);


### PR DESCRIPTION
Overview
----------------------------------------
Backend Membership Renewal returns a fatal error when min fee is empty

Gitlab - https://lab.civicrm.org/dev/core/-/issues/2583

Before
----------------------------------------
To replicate -

- Create Membership Type with no amount value.
- Create a membership on a contact. 
- Renew from the Membership tab. 

![image](https://user-images.githubusercontent.com/5929648/116847288-e0ba8200-ac07-11eb-89ee-25edf2983f27.png)

- Error message when the link is opened in a new window -

![image](https://user-images.githubusercontent.com/5929648/116847302-e9ab5380-ac07-11eb-8652-a8eabf7c7fa0.png)

After
----------------------------------------
Fixed.

Technical Details
----------------------------------------
Return early if the amount is NULL as done in `::format()`.

Comments
----------------------------------------
@eileenmcnaughton 