### PR TITLE
Separates the default language for contacts from the site language

### DIFF
--- a/CRM/Admin/Form/Setting/Localization.php
+++ b/CRM/Admin/Form/Setting/Localization.php
@@ -354,11 +354,13 @@ class CRM_Admin_Form_Setting_Localization extends CRM_Admin_Form_Setting {
    * @return array
    */
   public static function getDefaultLanguageOptions() {
-    return [
+    $availableOptions = [
       '*default*' => ts('Use default site language'),
       'undefined' => ts('Leave undefined'),
       'current_site_language' => ts('Use language in use at the time'),
     ];
+    $availableLanguages = array_merge($availableOptions, CRM_Admin_Form_Setting_Localization::getDefaultLocaleOptions());
+    return $availableLanguages;
   }
 
 }

--- a/CRM/Contact/Form/Edit/CommunicationPreferences.php
+++ b/CRM/Contact/Form/Edit/CommunicationPreferences.php
@@ -144,8 +144,11 @@ class CRM_Contact_Form_Edit_CommunicationPreferences {
 
     // CRM-7119: set preferred_language to default if unset
     if (empty($defaults['preferred_language'])) {
-      $config = CRM_Core_Config::singleton();
-      $defaults['preferred_language'] = $config->lcMessages;
+      if ($form->_action == CRM_Core_Action::ADD) {
+        if (($defContactLanguage = CRM_Core_I18n::getContactDefaultLanguage()) != FALSE) {
+          $defaults['preferred_language'] = $defContactLanguage;
+        }
+      }
     }
 
     if (empty($defaults['communication_style_id'])) {

--- a/CRM/Contact/Form/Inline/CommunicationPreferences.php
+++ b/CRM/Contact/Form/Inline/CommunicationPreferences.php
@@ -44,8 +44,11 @@ class CRM_Contact_Form_Inline_CommunicationPreferences extends CRM_Contact_Form_
 
     // CRM-7119: set preferred_language to default if unset
     if (empty($defaults['preferred_language'])) {
-      $config = CRM_Core_Config::singleton();
-      $defaults['preferred_language'] = $config->lcMessages;
+      if ($form->_action == CRM_Core_Action::ADD) {
+        if (($defContactLanguage = CRM_Core_I18n::getContactDefaultLanguage()) != FALSE) {
+          $defaults['preferred_language'] = $defContactLanguage;
+        }
+      }
     }
 
     // CRM-19135: where CRM_Core_BAO_Contact::getValues() set label as a default value instead of reserved 'value',


### PR DESCRIPTION
Overview
----------------------------------------
This is a PR related to the [issue 2584](https://lab.civicrm.org/dev/core/-/issues/2584)

Before
----------------------------------------
Default language for contacts had 3 options:
* Use default site language
* Leave undefined
* Use language in use at the time

![multil01](https://user-images.githubusercontent.com/14973113/116860920-37b95a80-abfa-11eb-90b6-1dc6ac4ea0ee.png)

After
----------------------------------------
Default language for contacts renders the 3 options above plus all the available languages.

![multil02](https://user-images.githubusercontent.com/14973113/116860943-3e47d200-abfa-11eb-97b8-5c15e14c28ae.png)

Technical Details
----------------------------------------
This PR adds the new languages to the selector and then on the `CommunicationPreferences.php` field examines what is the value of the configuration.

This works properly via the APIv3 as well.
