### PR TITLE
dev/core#1711 - Display SMS segment count when constructing Mass SMS

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -260,6 +260,10 @@
       "smartmenus": {
         "url": "https://github.com/vadikom/smartmenus/archive/1.1.0.zip",
         "ignore": [".gitignore", "Gruntfile.js"]
+      },
+      "sms-counter": {
+        "url": "https://github.com/danxexe/sms-counter/archive/master.zip",
+        "ignore": ["examples"]
       }
     },
     "patches": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "806655f49ee4984e61d0c1bf7bcc0c88",
+    "content-hash": "3d4576d680aea8094656e1d832571507",
     "packages": [
         {
             "name": "adrienrn/php-mimetyper",

--- a/templates/CRM/Contact/Form/Task/SMS.hlp
+++ b/templates/CRM/Contact/Form/Task/SMS.hlp
@@ -42,6 +42,12 @@
 
 {/htxt} 
 
+{htxt id="id-count-text"}
+<p>{ts}A single SMS message is typically 160 characters in length. If you want to send a message that is longer than 160 characters, it is split into multiple segments.{/ts}</p>
+<p>{ts}The cost of sending SMS message is typically <em>per segment</em>.{/ts}</p>
+<p>{ts}Certain characters like emoji or curly quotes can shorten the segment size to 96 characters, increasing the cost per message.{/ts}</p>
+{/htxt}
+
 {htxt id="id-message-text-title"}
 {ts}Rich Text{/ts}
 {/htxt}

--- a/templates/CRM/Contact/Form/Task/SMSCommon.tpl
+++ b/templates/CRM/Contact/Form/Task/SMSCommon.tpl
@@ -9,12 +9,14 @@
 *}
 {*common template for compose sms*}
 
+{crmScript file=bower_components/sms-counter/sms_counter.min.js region=html-header}
+
 <div class="crm-accordion-wrapper crm-plaint_text_sms-accordion ">
 <div class="crm-accordion-header">
   {$form.sms_text_message.label}
   </div><!-- /.crm-accordion-header -->
  <div class="crm-accordion-body">
- <div id='char-count-message'></div>
+ <div><span id="char-count-message"></span> <span id="char-count-help">{help id="id-count-text" tplFile=$tplFile file="CRM/Contact/Form/Task/SMS.hlp"}</span></div>
    <div class="helpIcon" id="helptext">
      <input class="crm-token-selector big" data-field="sms_text_message" />
      {help id="id-token-text" tplFile=$tplFile file="CRM/Contact/Form/Task/SMS.hlp"}
@@ -38,13 +40,16 @@
    <div class="content">{$form.SMSsaveTemplateName.html|crmAddClass:huge}</div>
 </div>
 
+{capture assign="char_count_message"}
+{ts}You can insert up to %1 characters. You have entered %2 characters, requiring %3 segments.{/ts}
+{/capture}
+
 {literal}
 <script type="text/javascript">
-
 {/literal}{if $max_sms_length}{literal}
 maxCharInfoDisplay();
 
-cj('#sms_text_message').bind({
+CRM.$('#sms_text_message').bind({
   change: function() {
    maxLengthMessage();
   },
@@ -55,10 +60,10 @@ cj('#sms_text_message').bind({
 
 function maxLengthMessage()
 {
-   var len = cj('#sms_text_message').val().length;
+   var len = CRM.$('#sms_text_message').val().length;
    var maxLength = {/literal}{$max_sms_length}{literal};
    if (len > maxLength) {
-      cj('#sms_text_message').crmError({/literal}'{ts escape="js"}SMS body exceeding limit of 160 characters{/ts}'{literal});
+      CRM.$('#sms_text_message').crmError({/literal}'{ts escape="js"}SMS body exceeding limit of {$max_sms_length} characters{/ts}'{literal});
       return false;
    }
 return true;
@@ -66,14 +71,16 @@ return true;
 
 function maxCharInfoDisplay(){
    var maxLength = {/literal}{$max_sms_length}{literal};
-   var enteredCharLength = cj('#sms_text_message').val().length;
-   var count = enteredCharLength;
+   var enteredText = SmsCounter.count(CRM.$('#sms_text_message').val());
+   var count = enteredText.length;
+   var segments = enteredText.messages;
 
    if( count < 0 ) {
-      cj('#sms_text_message').val(cj('#sms_text_message').val().substring(0, maxLength));
+      CRM.$('#sms_text_message').val(CRM.$('#sms_text_message').val().substring(0, maxLength));
       count = 0;
    }
-   cj('#char-count-message').text( "You can insert up to " + maxLength + " characters. You have entered " + count + " characters." );
+   var message = "{/literal}{$char_count_message}{literal}"
+   CRM.$('#char-count-message').text(message.replace('%1', maxLength).replace('%2', count).replace('%3', segments));
 }
 {/literal}{/if}{literal}
 


### PR DESCRIPTION
Overview
----------------------------------------
This Pull Request modifies the JS that shows the character count when creating a SMS message so that it also shows how many SMS segments are required to send the message.

Full information regarding the motivation for the change, etc., is [documented in CiviCRM GitLab core issue #1711](https://lab.civicrm.org/dev/core/-/issues/1711). The TLDR is, "SMS delivery costs per segment and people can easily spend much more money than expected because of things like curly quotes".

Before
----------------------------------------
The message displayed immediately above the textfield for entering the SMS message reads:
"You can insert up to <x> characters. You have entered <y> characters."

After
----------------------------------------
The message displayed immediately above the textfield now reads:
"You can insert up to <x> characters. You have entered <y> characters, requiring <z> segments."
A help icon has been added and help text explaining how SMS delivery is charged per-segment, etc.

Technical Details
----------------------------------------
Makes use of [the sms-counter JS library](https://github.com/danxexe/sms-counter) to calculate the required number of segments, specifically, the minified version. The library uses the MIT license and a copy of the license has been included alongside the JS file. The license file includes the copyright information required to satisfy the license.

The other meaningful technical change in this PR is the replacement of `cj` with `CRM.$` [as per this CiviCRM Javascript Standaards documentation](https://docs.civicrm.org/dev/en/latest/standards/javascript/#enclosing-your-code).