### PR TITLE
Api4 Services - Lazy-load subscriber-objects

### DIFF
--- a/CRM/Api4/Services.php
+++ b/CRM/Api4/Services.php
@@ -43,9 +43,10 @@ class CRM_Api4_Services {
     $subscribers = $container->findTaggedServiceIds('event_subscriber');
 
     foreach (array_keys($subscribers) as $subscriber) {
+      $getSubscribedEvents = [$container->findDefinition($subscriber)->getClass(), 'getSubscribedEvents'];
       $dispatcher->addMethodCall(
-        'addSubscriber',
-        [new Reference($subscriber)]
+        'addSubscriberServiceMap',
+        [$subscriber, $getSubscribedEvents()]
       );
     }
 

--- a/Civi/Core/CiviEventDispatcher.php
+++ b/Civi/Core/CiviEventDispatcher.php
@@ -62,6 +62,34 @@ class CiviEventDispatcher extends EventDispatcher {
   }
 
   /**
+   * Adds a series of event listeners from a subscriber object.
+   *
+   * This is particularly useful if you want to register the subscriber without
+   * materializing the subscriber object.
+   *
+   * @param string $subscriber
+   *   Service ID of the subscriber.
+   * @param array $events
+   *   List of events/methods/priorities.
+   * @see \Symfony\Component\EventDispatcher\EventSubscriberInterface::getSubscribedEvents()
+   */
+  public function addSubscriberServiceMap(string $subscriber, array $events) {
+    foreach ($events as $eventName => $params) {
+      if (\is_string($params)) {
+        $this->addListenerService($eventName, [$subscriber, $params]);
+      }
+      elseif (\is_string($params[0])) {
+        $this->addListenerService($eventName, [$subscriber, $params[0]], isset($params[1]) ? $params[1] : 0);
+      }
+      else {
+        foreach ($params as $listener) {
+          $this->addListenerService($eventName, [$subscriber, $listener[0]], isset($listener[1]) ? $listener[1] : 0);
+        }
+      }
+    }
+  }
+
+  /**
    * Adds a service as event listener.
    *
    * This provides partial backwards compatibility with ContainerAwareEventDispatcher.

--- a/Civi/Core/CiviEventDispatcher.php
+++ b/Civi/Core/CiviEventDispatcher.php
@@ -80,13 +80,7 @@ class CiviEventDispatcher extends EventDispatcher {
       throw new \InvalidArgumentException('Expected an array("service", "method") argument');
     }
 
-    $this->addListener($eventName, function($event) use ($callback) {
-      static $svc;
-      if ($svc === NULL) {
-        $svc = \Civi::container()->get($callback[0]);
-      }
-      return call_user_func([$svc, $callback[1]], $event);
-    }, $priority);
+    $this->addListener($eventName, new \Civi\Core\Event\ServiceListener($callback), $priority);
   }
 
   /**

--- a/Civi/Core/Event/ServiceListener.php
+++ b/Civi/Core/Event/ServiceListener.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Civi\Core\Event;
+
+/**
+ * A ServiceListener is a `callable` (supporting "__invoke()") which references
+ * a method of a service-object.
+ *
+ * The following two callables are conceptually similar:
+ *
+ *   (A) addListener('some.event', [Civi::service('foo'), 'doBar']);
+ *   (B) addListener('some.event', new ServiceListener(['foo', 'doBar']));
+ *
+ * The difference is that (A) immediately instantiates the 'foo' service,
+ * whereas (B) instantiates `foo` lazily. (B) is more amenable to serialization,
+ * caching, etc. If you have a long-tail of many services/listeners/etc that
+ * are not required for every page-load, then (B) should perform better.
+ *
+ * @package Civi\Core\Event
+ */
+class ServiceListener {
+
+  /**
+   * @var array
+   *   Ex: ['service_name', 'someMethod']
+   */
+  private $inertCb = NULL;
+
+  /**
+   * @var array|null
+   *   Ex: [$svcObj, 'someMethod']
+   */
+  private $liveCb = NULL;
+
+  /**
+   * @var \Symfony\Component\DependencyInjection\ContainerInterface
+   */
+  private $container = NULL;
+
+  /**
+   * @param array $callback
+   *   Ex: ['service_name', 'someMethod']
+   */
+  public function __construct($callback) {
+    $this->inertCb = $callback;
+  }
+
+  public function __invoke(...$args) {
+    if ($this->liveCb === NULL) {
+      $c = $this->container ?: \Civi::container();
+      $this->liveCb = [$c->get($this->inertCb[0]), $this->inertCb[1]];
+    }
+    return call_user_func_array($this->liveCb, $args);
+  }
+
+  public function __toString() {
+    $class = NULL;
+    if (\Civi\Core\Container::isContainerBooted()) {
+      try {
+        $c = $this->container ?: \Civi::container();
+        $class = $c->findDefinition($this->inertCb[0])->getClass();
+      }
+      catch (Throwable $t) {
+      }
+    }
+    if ($class) {
+      return sprintf('$(%s)->%s() [%s]', $this->inertCb[0], $this->inertCb[1], $class);
+    }
+    else {
+      return sprintf('\$(%s)->%s()', $this->inertCb[0], $this->inertCb[1]);
+    }
+  }
+
+  public function __sleep() {
+    return ['inertCb'];
+  }
+
+  /**
+   * @param \Symfony\Component\DependencyInjection\ContainerInterface $container
+   * @return static
+   */
+  public function setContainer(\Symfony\Component\DependencyInjection\ContainerInterface $container) {
+    $this->container = $container;
+    return $this;
+  }
+
+}

--- a/tests/phpunit/Civi/Core/Event/ServiceListenerTest.php
+++ b/tests/phpunit/Civi/Core/Event/ServiceListenerTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Civi\Core\Event;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+class ServiceListenerTest extends \CiviUnitTestCase {
+
+  public function tearDown(): void {
+    ServiceListenerTestExample::$notes = [];
+    parent::tearDown();
+  }
+
+  public function testDispatch() {
+    $changeMe = $rand = rand(0, 16384);
+
+    $container = new ContainerBuilder();
+    $container->setDefinition('test.svlt', new Definition(ServiceListenerTestExample::class, [$rand]))
+      ->setPublic(TRUE);
+
+    $d = \Civi::dispatcher();
+    $d->addListener('hook_civicrm_svlt', (new ServiceListener(['test.svlt', 'onSvlt']))->setContainer($container));
+
+    // Baseline
+    $this->assertEquals([], ServiceListenerTestExample::$notes);
+    $this->assertEquals($changeMe, $rand);
+
+    // First call - instantiate and run
+    $d->dispatch('hook_civicrm_svlt', GenericHookEvent::create(['foo' => &$changeMe]));
+    $this->assertEquals($changeMe, 1 + $rand);
+    $this->assertEquals(["construct($rand)", "onSvlt($rand)"],
+      ServiceListenerTestExample::$notes);
+
+    // Second call - reuse and run
+    $d->dispatch('hook_civicrm_svlt', GenericHookEvent::create(['foo' => &$changeMe]));
+    $this->assertEquals($changeMe, 2 + $rand);
+    $this->assertEquals(["construct($rand)", "onSvlt($rand)", "onSvlt(" . ($rand + 1) . ")"],
+      ServiceListenerTestExample::$notes);
+  }
+
+}
+
+class ServiceListenerTestExample {
+
+  /**
+   * Free-form list of strings.
+   *
+   * @var array
+   */
+  public static $notes = [];
+
+  public function __construct($rand) {
+    self::$notes[] = "construct($rand)";
+  }
+
+  public function onSvlt(GenericHookEvent $e) {
+    self::$notes[] = "onSvlt({$e->foo})";
+    $e->foo++;
+  }
+
+}


### PR DESCRIPTION
This refines the way in which several [subscribers](https://symfony.com/doc/4.4/event_dispatcher.html#listeners-or-subscribers) (`Civi/Api4/Event/Subscriber/**.php`) are loaded. This makes it safer (from a performance POV) to continue adding more subscribers/listeners without worrying that it will impact the quantity of files/classes/opcodes/SLOC loaded in a typical page-view. To wit: subscribers are only loaded if they are needed.

A good way to visualize the mechanics of this change is to skim `getDispatcherService()` (`[civicrm.compile]/CachedCiviContainer.*.php`) before and after the patch. (Examples included below.)

Before
------

During every page-load, you need to register event-listeners. For subscriber-objects (like `Civi/Api4/Event/Subscriber/**.php`), you get the list of subscriptions by calling `getSubscribedEvents()`.  Therefore, on every page-load, you must load/process the subscriber and calll `getSubscribedEvents()` (regardless of whether the subscriber will actually be used -- on the chance it that *may* be needed).

In `CachedCiviContainer.*.php`, you will see snippets like:

```php
    protected function getDispatcherService()
    {
        ...
        $instance->addSubscriber(${($_ = isset($this->services['Civi_Api4_Event_Subscriber_ActivityPreCreationSubscriber']) ? $this->services['Civi_Api4_Event_Subscriber_ActivityPreCreationSubscriber'] : ($this->services['Civi_Api4_Event_Subscriber_ActivityPreCreationSubscriber'] = new \Civi\Api4\Event\Subscriber\ActivityPreCreationSubscriber())) && false ?: '_'});
        $instance->addSubscriber(${($_ = isset($this->services['Civi_Api4_Event_Subscriber_ActivitySchemaMapSubscriber']) ? $this->services['Civi_Api4_Event_Subscriber_ActivitySchemaMapSubscriber'] : ($this->services['Civi_Api4_Event_Subscriber_ActivitySchemaMapSubscriber'] = new \Civi\Api4\Event\Subscriber\ActivitySchemaMapSubscriber())) && false ?: '_'});
        ...
```

Observe that it instantiates `ActivitySchemaMapSubscriber` then passes the instance to `addSubscriber()`.

After
-----

You only need to instantiate service-objects if (a) you are building a fresh container or (b) you are actually running a relevant event.

This works by calling `getSubscribedEvents()` when building the container. The list of events is cached in the container.

In `CachedCiviContainer.*.php`, you will see snippets like:

```php
    protected function getDispatcherService()
    {
        ...
        $instance->addSubscriberServiceMap('Civi_Api4_Event_Subscriber_ActivityPreCreationSubscriber', ['civi.api.prepare' => 'onApiPrepare']);
        $instance->addSubscriberServiceMap('Civi_Api4_Event_Subscriber_ActivitySchemaMapSubscriber', ['api.schema_map.build' => 'onSchemaBuild']);
        ...
```

Observe that it alludes to `ActivityPreCreationSubscriber` symbolicly but does not need an actual instance.

Comments
-----------------

1. To see that this is equivalent, I used `cv debug:event-dispatcher` before and after the patch. This requires an updated version of `cv`, and the formatting is a little a different, but it does show the same list of listeners.

2. There could be some concern like, "What happens if you're upgrading and have a cached list of subscription events?" Well, note that `CRM_Api4_Services::hook_container` already puts a cached list of subscribers in the container. It already registers the `FileResource`(s). Thus, if a file `Civi/Api4/Event/Subscriber/**.php` changes, it already makes the decision to recompile based on `filemtime()`.

3. There should already be a lot of test-coverage which hits code-paths for these listeners. (If this area is generally non-functional, you should see massive failures.)

4. For `r-run`, I picked an arbitrary subscriber (eg `ActivitySchemaMapSubscriber.php`), then:
   * At the start of the file, add a statement to log whenever the file is read.
     ```php
     file_put_contents('/tmp/parselog.txt', sprintf("%s: %s: %s\n\n",date('Y-m-d H:i:s'), __FILE__, \CRM_Core_Error::formatBacktrace(debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 15))), FILE_APPEND);
     ```
   * In a separate window, run `tail -f /tmp/parselog.txt`.
   * Edit the chosen subscriber (eg `ActivitySchemaMapSubscriber.php`) to add/remove listeners (like `hook_civicrm_alterContent`)
   * Request some Civi page (`curl 'http://dmaster.127.0.0.1.nip.io:8001/civicrm/admin?reset=1'`). It's not important that it actually runs the full page... just that we boot up Civi to look for the page.
   * Alternately repeat the past few steps. Observe thta it only parses the file if there has been a change or if the relevant event(s) actually fire.
