### PR TITLE
dev/core#2588 - Crash when sending to 3+ email recipients with an attachment in 5.36+

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -1176,7 +1176,7 @@ class CRM_Activity_BAO_Activity extends CRM_Activity_DAO_Activity {
       // To minimize storage requirements, only one copy of any file attachments uploaded to CiviCRM is kept,
       // even when multiple contacts will receive separate emails from CiviCRM.
       if (!empty($attachmentFileIds)) {
-        $attachments = array_merge_recursive($attachments, $attachmentFileIds);
+        $attachments = array_replace_recursive($attachments, $attachmentFileIds);
       }
 
       // Create email activity.


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/2588

Tentative fix - I haven't fully tested it but wanted to put it up given the timing.

Before
----------------------------------------
1. Create an email activity (not a mass mailing) to 3 or more people.
2. Add one or more attachments.
3. Send the email.
4. Crashes while sending to the 3rd recipient.

After
----------------------------------------
No crash

Technical Details
----------------------------------------
array_merge_recursive ends up creating an array for the `id` on the 3rd iteration. `$attachmentFileIds` will look something like this on the 2nd and all following iterations:

```php
array(
 'attachFile_1' => array('id' => 46),
 'attachFile_2' => array('id' => 47),
)
```
So there's no merge the first time, and on the 2nd time $attachments doesn't have an id member yet so the merge is fine. But then just before it's merged into $attachments on the 3rd time $attachments looks something like:
```php
array(
  'attachFile_1' => array(
    'uri' => 'something',
    'type' => 'something',
    // ...
    'id' => 46,
  ),
  'attachFile_2' => array(
    'uri' => 'something',
    'type' => 'something',
    // ...
    'id' => 47,
  ),
)
```

so it converts the `id` member into e.g. array(46, 46) because that's what array_merge_recursive does.

Comments
----------------------------------------

