### PR TITLE
Set the smarty variables for mem_status and mem_join_date for back-end membership renewals

### DIFF
--- a/CRM/Member/Form/MembershipRenewal.php
+++ b/CRM/Member/Form/MembershipRenewal.php
@@ -677,6 +677,10 @@ class CRM_Member_Form_MembershipRenewal extends CRM_Member_Form {
       $membership->membership_type_id
     ));
     $this->assign('customValues', $customValues);
+
+    $membership_status = CRM_Member_PseudoConstant::membershipStatus($membership->status_id, NULL, 'label');
+    $this->assign('mem_status', $membership_status);
+    $this->assign('mem_join_date', CRM_Utils_Date::formatDateOnlyLong($membership->join_date));
     $this->assign('mem_start_date', CRM_Utils_Date::formatDateOnlyLong($membership->start_date));
     $this->assign('mem_end_date', CRM_Utils_Date::formatDateOnlyLong($membership->end_date));
     if ($this->_mode) {


### PR DESCRIPTION
Overview
----------------------------------------
Set the smarty variables for mem_status and mem_join_date for back-end membership renewals.

Before
----------------------------------------
mem_status and mem_join_date are not available for back-end membership renewals. Which is problematic when trying to use the mem_status variable to display a "Thanks for renewing!" message or a "Welcome new member" when using the Memberships - Signup and Renewal Receipts (off-line) message template.

After
----------------------------------------
smarty variables for mem_status and mem_join_date are now available.

Technical Details
----------------------------------------


Comments
----------------------------------------
Agileware Ref: CIVICRM-1729