### PR TITLE
Afform - Set default position for contact layout editor

### DIFF
--- a/ext/afform/core/afform.php
+++ b/ext/afform/core/afform.php
@@ -245,7 +245,7 @@ function afform_civicrm_contactSummaryBlocks(&$blocks) {
     ->setSelect(['name', 'title', 'directive_name', 'module_name', 'type', 'type:icon', 'type:label'])
     ->addWhere('contact_summary', '=', 'block')
     ->execute();
-  foreach ($afforms as $afform) {
+  foreach ($afforms as $index => $afform) {
     // Create a group per afform type
     $blocks += [
       "afform_{$afform['type']}" => [
@@ -263,6 +263,7 @@ function afform_civicrm_contactSummaryBlocks(&$blocks) {
         $afform['type:label'],
       ],
       'edit' => 'civicrm/admin/afform#/edit/' . $afform['name'],
+      'system_default' => [0, $index % 2],
     ];
   }
 }


### PR DESCRIPTION
Overview
----------------------------------------
This makes Afform blocks appear in their default positions in the "System Default" layout in Contact Summary Editor 2.0+.

It's backward-compatible with earlier versions of the extension.

Before
----------------------------------------
Afform blocks would appear on the system layout, but the system layout reflected in the Contact Summary Editor did not show them.

After
----------------------------------------
The two layouts match.

Technical Details
---------------------
This new `system_default` block attribute doesn't affect the contact summary itself, it just helps the layout editor show an accurate facsimile of what the system default layout looks like.