### PR TITLE
Activate user when no activation is required

### DIFF
--- a/CRM/Utils/System/Drupal8.php
+++ b/CRM/Utils/System/Drupal8.php
@@ -49,7 +49,7 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
     if ($user_register_conf != 'visitors' && !$user->hasPermission('administer users')) {
       $account->block();
     }
-    elseif ($verify_mail_conf) {
+    else {
       $account->activate();
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
https://chat.civicrm.org/civicrm/pl/pda9f67bofn17decw35jpztf1h

Before
----------------------------------------
Before - there’s no way to create an active user with email validation enabled in Drupal.


After
----------------------------------------
After - any user created on a site that doesn’t require admin approval is active.

Technical Details
----------------------------------------

Comments
----------------------------------------
