### PR TITLE
APIv4 - CiviCase API: Fix openening a case with current user as creator

### DIFF
--- a/Civi/Api4/Action/Address/AddressSaveTrait.php
+++ b/Civi/Api4/Action/Address/AddressSaveTrait.php
@@ -54,7 +54,7 @@ trait AddressSaveTrait {
   /**
    * @inheritDoc
    */
-  protected function writeObjects($items) {
+  protected function writeObjects(&$items) {
     foreach ($items as &$item) {
       if ($this->streetParsing && !empty($item['street_address'])) {
         $item = array_merge($item, \CRM_Core_BAO_Address::parseStreetAddress($item['street_address']));

--- a/Civi/Api4/Action/CiviCase/CiviCaseSaveTrait.php
+++ b/Civi/Api4/Action/CiviCase/CiviCaseSaveTrait.php
@@ -28,7 +28,7 @@ trait CiviCaseSaveTrait {
    * @param array $cases
    * @return array
    */
-  protected function writeObjects($cases) {
+  protected function writeObjects(&$cases) {
     $cases = array_values($cases);
     $result = parent::writeObjects($cases);
 

--- a/Civi/Api4/Action/GroupContact/GroupContactSaveTrait.php
+++ b/Civi/Api4/Action/GroupContact/GroupContactSaveTrait.php
@@ -46,7 +46,7 @@ trait GroupContactSaveTrait {
   /**
    * @inheritDoc
    */
-  protected function writeObjects($items) {
+  protected function writeObjects(&$items) {
     foreach ($items as &$item) {
       $item['method'] = $this->method;
       $item['tracking'] = $this->tracking;

--- a/Civi/Api4/Generic/DAOCreateAction.php
+++ b/Civi/Api4/Generic/DAOCreateAction.php
@@ -36,10 +36,9 @@ class DAOCreateAction extends AbstractCreateAction {
     $this->validateValues();
     $params = $this->values;
     $this->fillDefaults($params);
+    $items = [$params];
 
-    $resultArray = $this->writeObjects([$params]);
-
-    $result->exchangeArray($resultArray);
+    $result->exchangeArray($this->writeObjects($items));
   }
 
   /**

--- a/Civi/Api4/Generic/DAOUpdateAction.php
+++ b/Civi/Api4/Generic/DAOUpdateAction.php
@@ -60,7 +60,8 @@ class DAOUpdateAction extends AbstractUpdateAction {
     // Update a single record by ID unless select requires more than id
     if ($this->getSelect() === ['id'] && count($this->where) === 1 && $this->where[0][0] === 'id' && $this->where[0][1] === '=' && !empty($this->where[0][2])) {
       $this->values['id'] = $this->where[0][2];
-      $result->exchangeArray($this->writeObjects([$this->values]));
+      $items = [$this->values];
+      $result->exchangeArray($this->writeObjects($items));
       return;
     }
 

--- a/Civi/Api4/Generic/Traits/CustomValueActionTrait.php
+++ b/Civi/Api4/Generic/Traits/CustomValueActionTrait.php
@@ -51,7 +51,7 @@ trait CustomValueActionTrait {
   /**
    * @inheritDoc
    */
-  protected function writeObjects($items) {
+  protected function writeObjects(&$items) {
     $fields = $this->entityFields();
     foreach ($items as $idx => $item) {
       FormattingUtil::formatWriteParams($item, $fields);

--- a/Civi/Api4/Generic/Traits/DAOActionTrait.php
+++ b/Civi/Api4/Generic/Traits/DAOActionTrait.php
@@ -103,7 +103,7 @@ trait DAOActionTrait {
    * @throws \API_Exception
    * @throws \CRM_Core_Exception
    */
-  protected function writeObjects($items) {
+  protected function writeObjects(&$items) {
     $baoName = $this->getBaoName();
 
     // Some BAOs are weird and don't support a straightforward "create" method.
@@ -118,7 +118,7 @@ trait DAOActionTrait {
 
     $result = [];
 
-    foreach ($items as $item) {
+    foreach ($items as &$item) {
       $entityId = $item['id'] ?? NULL;
       FormattingUtil::formatWriteParams($item, $this->entityFields());
       $this->formatCustomParams($item, $entityId);

--- a/Civi/Api4/Service/Spec/Provider/CaseCreationSpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/CaseCreationSpecProvider.php
@@ -59,6 +59,16 @@ class CaseCreationSpecProvider implements Generic\SpecProviderInterface {
     $duration->setInputType('Number');
     $duration->setDescription('Open Case activity duration (minutes).');
     $spec->addFieldSpec($duration);
+
+    $defaultStatus = \CRM_Core_DAO::singleValueQuery('SELECT value FROM civicrm_option_value
+      WHERE is_default
+        AND domain_id = ' . \CRM_Core_BAO_Domain::getDomain()->id . '
+        AND option_group_id = (SELECT id FROM civicrm_option_group WHERE name = "case_status")
+      LIMIT 1');
+    if ($defaultStatus) {
+      $status = $spec->getFieldByName('status_id');
+      $status->setDefaultValue((int) $defaultStatus);
+    }
   }
 
   /**

--- a/tests/phpunit/api/v4/DataSets/CaseType.json
+++ b/tests/phpunit/api/v4/DataSets/CaseType.json
@@ -1,0 +1,58 @@
+{
+  "CaseType": [
+    {
+      "name": "test_case_type",
+      "title": "Test Case Type",
+      "definition": {
+        "activityTypes": [
+          {
+            "name": "Open Case",
+            "max_instances": "1"
+          },
+          {
+            "name": "Follow up"
+          }
+        ],
+        "activitySets": [
+          {
+            "name": "standard_timeline",
+            "label": "Standard Timeline",
+            "timeline": 1,
+            "activityTypes": [
+              {
+                "name": "Open Case",
+                "status": "Completed"
+              },
+              {
+                "name": "Follow up",
+                "reference_activity": "Open Case",
+                "reference_offset": "3",
+                "reference_select": "newest"
+              }
+            ]
+          }
+        ],
+        "timelineActivityTypes": [
+          {
+            "name": "Open Case",
+            "status": "Completed"
+          },
+          {
+            "name": "Follow up",
+            "reference_activity": "Open Case",
+            "reference_offset": "3",
+            "reference_select": "newest"
+          }
+        ],
+        "caseRoles": [
+          {
+            "name": "Parent of",
+            "creator": "1",
+            "manager": "1"
+          }
+        ]
+      },
+      "@ref": "test_case_type_1"
+    }
+  ]
+}

--- a/tests/phpunit/api/v4/DataSets/ConformanceTest.json
+++ b/tests/phpunit/api/v4/DataSets/ConformanceTest.json
@@ -13,62 +13,6 @@
       "@ref": "test_contact_2"
     }
   ],
-  "CaseType": [
-    {
-      "name": "test_case_type",
-      "title": "Test Case Type",
-      "definition": {
-        "activityTypes": [
-          {
-            "name": "Open Case",
-            "max_instances": "1"
-          },
-          {
-            "name": "Follow up"
-          }
-        ],
-        "activitySets": [
-          {
-            "name": "standard_timeline",
-            "label": "Standard Timeline",
-            "timeline": 1,
-            "activityTypes": [
-              {
-                "name": "Open Case",
-                "status": "Completed"
-              },
-              {
-                "name": "Follow up",
-                "reference_activity": "Open Case",
-                "reference_offset": "3",
-                "reference_select": "newest"
-              }
-            ]
-          }
-        ],
-        "timelineActivityTypes": [
-          {
-            "name": "Open Case",
-            "status": "Completed"
-          },
-          {
-            "name": "Follow up",
-            "reference_activity": "Open Case",
-            "reference_offset": "3",
-            "reference_select": "newest"
-          }
-        ],
-        "caseRoles": [
-          {
-            "name": "Parent of",
-            "creator": "1",
-            "manager": "1"
-          }
-        ]
-      },
-      "@ref": "test_case_type_1"
-    }
-  ],
   "Case": [
     {
       "case_type_id": "@ref test_case_type_1.id",

--- a/tests/phpunit/api/v4/Entity/CaseTest.php
+++ b/tests/phpunit/api/v4/Entity/CaseTest.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+
+namespace api\v4\Entity;
+
+use Civi\Api4\CiviCase;
+use api\v4\UnitTestCase;
+
+/**
+ * @group headless
+ */
+class CaseTest extends UnitTestCase {
+
+  public function setUp() {
+    parent::setUp();
+    \CRM_Core_BAO_ConfigSetting::enableComponent('CiviCase');
+    $this->loadDataSet('CaseType');
+  }
+
+  public function testCreateUsingLoggedInUser() {
+    $this->createLoggedInUser();
+
+    $contactID = $this->createEntity(['type' => 'Individual'])['id'];
+
+    $result = CiviCase::create(FALSE)
+      ->addValue('case_type_id', $this->getReference('test_case_type_1')['id'])
+      ->addValue('creator_id', 'user_contact_id')
+      ->addValue('status_id', 1)
+      ->addValue('contact_id', $contactID)
+      ->execute()
+      ->first();
+
+  }
+
+}

--- a/tests/phpunit/api/v4/Entity/ConformanceTest.php
+++ b/tests/phpunit/api/v4/Entity/ConformanceTest.php
@@ -53,6 +53,7 @@ class ConformanceTest extends UnitTestCase {
     $this->dropByPrefix('civicrm_value_myfavorite');
     $this->cleanup(['tablesToTruncate' => $tablesToTruncate]);
     $this->setUpOptionCleanup();
+    $this->loadDataSet('CaseType');
     $this->loadDataSet('ConformanceTest');
     $this->creationParamProvider = \Civi::container()->get('test.param_provider');
     parent::setUp();


### PR DESCRIPTION
Overview
----------------------------------------
Fixes APIv4 to be able to open a Case with the current user as creator.

Before
----------------------------------------
Passing `user_contact_id` as the case creator or case contact causes an error.

After
----------------------------------------
Works.

Technical Details
----------------------------------------
The `DAOActionTrait::writeObjects` function was formatting values but not by reference, so the CiviCase `writeObjects` function was using unformatted values to open the case, which would contain the raw string `user_contact_id` instead of the processed value.