### PR TITLE
[REF] Cleanup BAO_ActionSchedule::getlist() signature

### DIFF
--- a/CRM/Admin/Page/ScheduleReminders.php
+++ b/CRM/Admin/Page/ScheduleReminders.php
@@ -126,27 +126,25 @@ class CRM_Admin_Page_ScheduleReminders extends CRM_Core_Page_Basic {
     // Get list of configured reminders
     $reminderList = CRM_Core_BAO_ActionSchedule::getList();
 
-    if (is_array($reminderList)) {
-      // Add action links to each of the reminders
-      foreach ($reminderList as & $format) {
-        $action = array_sum(array_keys($this->links()));
-        if ($format['is_active']) {
-          $action -= CRM_Core_Action::ENABLE;
-        }
-        else {
-          $action -= CRM_Core_Action::DISABLE;
-        }
-        $format['action'] = CRM_Core_Action::formLink(
-          self::links(),
-          $action,
-          ['id' => $format['id']],
-          ts('more'),
-          FALSE,
-          'actionSchedule.manage.action',
-          'ActionSchedule',
-          $format['id']
-        );
+    // Add action links to each of the reminders
+    foreach ($reminderList as & $format) {
+      $action = array_sum(array_keys($this->links()));
+      if ($format['is_active']) {
+        $action -= CRM_Core_Action::ENABLE;
       }
+      else {
+        $action -= CRM_Core_Action::DISABLE;
+      }
+      $format['action'] = CRM_Core_Action::formLink(
+        self::links(),
+        $action,
+        ['id' => $format['id']],
+        ts('more'),
+        FALSE,
+        'actionSchedule.manage.action',
+        'ActionSchedule',
+        $format['id']
+      );
     }
 
     $this->assign('rows', $reminderList);

--- a/CRM/Core/BAO/ActionSchedule.php
+++ b/CRM/Core/BAO/ActionSchedule.php
@@ -102,9 +102,6 @@ class CRM_Core_BAO_ActionSchedule extends CRM_Core_DAO_ActionSchedule {
   /**
    * Retrieve list of Scheduled Reminders.
    *
-   * @param bool $namesOnly
-   *   Return simple list of names.
-   *
    * @param \Civi\ActionSchedule\Mapping|null $filterMapping
    *   Filter by the schedule's mapping type.
    * @param int $filterValue
@@ -114,7 +111,8 @@ class CRM_Core_BAO_ActionSchedule extends CRM_Core_DAO_ActionSchedule {
    *   (reference)   reminder list
    * @throws \CRM_Core_Exception
    */
-  public static function &getList($namesOnly = FALSE, $filterMapping = NULL, $filterValue = NULL) {
+  public static function getList($filterMapping = NULL, $filterValue = NULL): array {
+    $list = [];
     $query = "
 SELECT
        title,

--- a/CRM/Event/Form/ManageEvent/ScheduleReminders.php
+++ b/CRM/Event/Form/ManageEvent/ScheduleReminders.php
@@ -35,32 +35,30 @@ class CRM_Event_Form_ManageEvent_ScheduleReminders extends CRM_Event_Form_Manage
     $mapping = CRM_Utils_Array::first(CRM_Core_BAO_ActionSchedule::getMappings([
       'id' => ($this->_isTemplate ? CRM_Event_ActionMapping::EVENT_TPL_MAPPING_ID : CRM_Event_ActionMapping::EVENT_NAME_MAPPING_ID),
     ]));
-    $reminderList = CRM_Core_BAO_ActionSchedule::getList(FALSE, $mapping, $this->_id);
-    if ($reminderList && is_array($reminderList)) {
-      // Add action links to each of the reminders
-      foreach ($reminderList as & $format) {
-        $action = CRM_Core_Action::UPDATE + CRM_Core_Action::DELETE;
-        if ($format['is_active']) {
-          $action += CRM_Core_Action::DISABLE;
-        }
-        else {
-          $action += CRM_Core_Action::ENABLE;
-        }
-        $scheduleReminder = new CRM_Admin_Page_ScheduleReminders();
-        $links = $scheduleReminder->links();
-        $links[CRM_Core_Action::DELETE]['qs'] .= "&context=event&compId={$this->_id}";
-        $links[CRM_Core_Action::UPDATE]['qs'] .= "&context=event&compId={$this->_id}";
-        $format['action'] = CRM_Core_Action::formLink(
-          $links,
-          $action,
-          ['id' => $format['id']],
-          ts('more'),
-          FALSE,
-          'actionSchedule.manage.action',
-          'ActionSchedule',
-          $this->_id
-        );
+    $reminderList = CRM_Core_BAO_ActionSchedule::getList($mapping, $this->_id);
+    // Add action links to each of the reminders
+    foreach ($reminderList as & $format) {
+      $action = CRM_Core_Action::UPDATE + CRM_Core_Action::DELETE;
+      if ($format['is_active']) {
+        $action += CRM_Core_Action::DISABLE;
       }
+      else {
+        $action += CRM_Core_Action::ENABLE;
+      }
+      $scheduleReminder = new CRM_Admin_Page_ScheduleReminders();
+      $links = $scheduleReminder->links();
+      $links[CRM_Core_Action::DELETE]['qs'] .= "&context=event&compId={$this->_id}";
+      $links[CRM_Core_Action::UPDATE]['qs'] .= "&context=event&compId={$this->_id}";
+      $format['action'] = CRM_Core_Action::formLink(
+        $links,
+        $action,
+        ['id' => $format['id']],
+        ts('more'),
+        FALSE,
+        'actionSchedule.manage.action',
+        'ActionSchedule',
+        $this->_id
+      );
     }
 
     $this->assign('rows', $reminderList);


### PR DESCRIPTION


Overview
----------------------------------------
[REF] Cleanup BAO_ActionSchedule::getlist() signature

Before
----------------------------------------
This is only called from 3 places. Only one passes variables. We have
- php 5.4 support with the & before the function name
- an unused parameter that is never passed in
- either NULL or an array returned. There is handling in 2/3 of the places that call this function for the possibility of it returning NULL which we can remove by always returning an array (view the PR with w=1). The last place is civirules which expects an array and doesn't handle anything else (civirules calls this function but really should be calling the v4 api as it is only doing a db lookup not using the magic in this function)

![image](https://user-images.githubusercontent.com/336308/117232854-211f3780-ae76-11eb-865a-711d3f577f14.png)

After
----------------------------------------
- An array is always returned, handling for something different removed
- no more php 5.4 support
- the unused variable is gone 

Technical Details
----------------------------------------
The place where civirules calls this is unaffected as it does not pass parameters and it already expects an array

Comments
----------------------------------------

