### PR TITLE
[Ref] remove redundant call to clearGroupContactCache

### DIFF
--- a/CRM/Contact/BAO/Group.php
+++ b/CRM/Contact/BAO/Group.php
@@ -472,7 +472,7 @@ class CRM_Contact_BAO_Group extends CRM_Contact_DAO_Group {
       // update group contact cache for all parent groups
       $parentIds = CRM_Contact_BAO_GroupNesting::getParentGroupIds($group->id);
       foreach ($parentIds as $parentId) {
-        CRM_Contact_BAO_GroupContactCache::add($parentId);
+        CRM_Contact_BAO_GroupContactCache::invalidateGroupContactCache($parentId);
       }
     }
 
@@ -486,7 +486,7 @@ class CRM_Contact_BAO_Group extends CRM_Contact_DAO_Group {
     }
 
     self::flushCaches();
-    CRM_Contact_BAO_GroupContactCache::add($group->id);
+    CRM_Contact_BAO_GroupContactCache::invalidateGroupContactCache($group->id);
 
     if (!empty($params['id'])) {
       CRM_Utils_Hook::post('edit', 'Group', $group->id, $group);

--- a/CRM/Contact/BAO/GroupContactCache.php
+++ b/CRM/Contact/BAO/GroupContactCache.php
@@ -149,7 +149,6 @@ AND (
 
     foreach ($groupIDs as $groupID) {
       // first delete the current cache
-      self::clearGroupContactCache($groupID);
       $params = [['group', 'IN', [$groupID], 0, 0]];
       // the below call updates the cache table as a byproduct of the query
       CRM_Contact_BAO_Query::apiQuery($params, ['contact_id'], NULL, NULL, 0, 0, FALSE);

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -85,6 +85,13 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
   static protected $_dbName;
 
   /**
+   * API version in use.
+   *
+   * @var int
+   */
+  protected $_apiversion = 3;
+
+  /**
    * Track tables we have modified during a test.
    *
    * @var array

--- a/tests/phpunit/api/v3/SavedSearchTest.php
+++ b/tests/phpunit/api/v3/SavedSearchTest.php
@@ -34,7 +34,6 @@
  */
 class api_v3_SavedSearchTest extends CiviUnitTestCase {
 
-  protected $_apiversion = 3;
   protected $params;
   protected $id;
   protected $_entity;
@@ -46,7 +45,7 @@ class api_v3_SavedSearchTest extends CiviUnitTestCase {
     // The line below makes it unneccessary to do cleanup after a test,
     // because the transaction of the test will be rolled back.
     // see http://forum.civicrm.org/index.php/topic,35627.0.html
-    $this->useTransaction(TRUE);
+    $this->useTransaction();
 
     $this->_entity = 'SavedSearch';
 
@@ -72,7 +71,7 @@ class api_v3_SavedSearchTest extends CiviUnitTestCase {
     $contactID = $this->createLoggedInUser();
     $result = $this->callAPIAndDocument(
         $this->_entity, 'create', $this->params, __FUNCTION__, __FILE__)['values'];
-    $this->assertEquals(1, count($result));
+    $this->assertCount(1, $result);
     $savedSearch = reset($result);
 
     $this->assertEquals($contactID, $savedSearch['created_id']);
@@ -90,6 +89,8 @@ class api_v3_SavedSearchTest extends CiviUnitTestCase {
   /**
    * Create a saved search, retrieve it again, and check for ID and one of
    * the field values.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function testCreateAndGetSavedSearch(): void {
     // Arrange:
@@ -114,37 +115,13 @@ class api_v3_SavedSearchTest extends CiviUnitTestCase {
   /**
    * Create a saved search, and test whether it can be used for a smart
    * group.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function testCreateSavedSearchWithSmartGroup(): void {
     // First create a volunteer for the default organization
 
-    $result = $this->callAPISuccess('Contact', 'create', [
-      'first_name' => 'Joe',
-      'last_name' => 'Schmoe',
-      'contact_type' => 'Individual',
-      'api.Relationship.create' => [
-        'contact_id_a' => '$value.id',
-        // default organization:
-        'contact_id_b' => 1,
-        // volunteer relationship:
-        'relationship_type_id' => 6,
-        'is_active' => 1,
-      ],
-    ]);
-    $contact_id = $result['id'];
-
-    // Now create our saved search, and chain the creation of a smart group.
-    $params = $this->params;
-    $params['api.Group.create'] = [
-      'name' => 'my_smartgroup',
-      'title' => 'my smartgroup',
-      'description' => 'Volunteers for the default organization',
-      'saved_search_id' => '$value.id',
-      'is_active' => 1,
-      'visibility' => 'User and User Admin Only',
-      'is_hidden' => 0,
-      'is_reserved' => 0,
-    ];
+    [$contact_id, $params] = $this->setupContactInSmartGroup();
 
     $create_result = $this->callAPIAndDocument(
         $this->_entity, 'create', $params, __FUNCTION__, __FILE__);
@@ -153,8 +130,7 @@ class api_v3_SavedSearchTest extends CiviUnitTestCase {
     $group_id = $created_search['api.Group.create']['id'];
 
     // Search for contacts in our new smart group
-    $get_result = $this->callAPISuccess(
-      'Contact', 'get', ['group' => $group_id], __FUNCTION__, __FILE__);
+    $get_result = $this->callAPISuccess('Contact', 'get', ['group' => $group_id]);
 
     // Expect our contact to be there.
     $this->assertEquals(1, $get_result['count']);
@@ -163,47 +139,23 @@ class api_v3_SavedSearchTest extends CiviUnitTestCase {
 
   /**
    * Create a saved search, and test whether it can be used for a smart
-   * group. Also check that when the Group is deleted the associated saved search gets deleted.
+   * group. Also check that when the Group is deleted the associated saved
+   * search gets deleted.
+   *
    * @dataProvider versionThreeAndFour
+   * @throws \CRM_Core_Exception
    */
   public function testSavedSearchIsDeletedWhenSmartGroupIs($apiVersion): void {
     $this->_apiVersion = $apiVersion;
     // First create a volunteer for the default organization
 
-    $result = $this->callAPISuccess('Contact', 'create', [
-      'first_name' => 'Joe',
-      'last_name' => 'Schmoe',
-      'contact_type' => 'Individual',
-      'api.Relationship.create' => [
-        'contact_id_a' => '$value.id',
-        // default organization:
-        'contact_id_b' => 1,
-        // volunteer relationship:
-        'relationship_type_id' => 6,
-        'is_active' => 1,
-      ],
-    ]);
-    $contact_id = $result['id'];
-
-    // Now create our saved search, and chain the creation of a smart group.
-    $params = $this->params;
-    $params['api.Group.create'] = [
-      'name' => 'my_smartgroup',
-      'title' => 'my smartgroup',
-      'description' => 'Volunteers for the default organization',
-      'saved_search_id' => '$value.id',
-      'is_active' => 1,
-      'visibility' => 'User and User Admin Only',
-      'is_hidden' => 0,
-      'is_reserved' => 0,
-    ];
+    [$contact_id, $params] = $this->setupContactInSmartGroup();
 
     $create_result = $this->callAPISuccess($this->_entity, 'create', $params);
 
     $created_search = CRM_Utils_Array::first($create_result['values']);
     $group_id = $created_search['api.Group.create']['id'];
 
-    // Search for contacts in our new smart group
     $get_result = $this->callAPISuccess('Contact', 'get', ['group' => $group_id]);
 
     // Expect our contact to be there.
@@ -215,6 +167,9 @@ class api_v3_SavedSearchTest extends CiviUnitTestCase {
     $this->assertCount(0, $savedSearch['values']);
   }
 
+  /**
+   * @throws \CRM_Core_Exception
+   */
   public function testDeleteSavedSearch(): void {
     // Create saved search, delete it again, and try to get it
     $create_result = $this->callAPISuccess($this->_entity, 'create', $this->params);
@@ -224,6 +179,41 @@ class api_v3_SavedSearchTest extends CiviUnitTestCase {
     $get_result = $this->callAPISuccess($this->_entity, 'get', []);
 
     $this->assertEquals(0, $get_result['count']);
+  }
+
+  /**
+   * @return array
+   * @throws \CRM_Core_Exception
+   */
+  protected function setupContactInSmartGroup(): array {
+    $result = $this->callAPISuccess('Contact', 'create', [
+      'first_name' => 'Joe',
+      'last_name' => 'Schmoe',
+      'contact_type' => 'Individual',
+      'api.Relationship.create' => [
+        'contact_id_a' => '$value.id',
+        // default organization:
+        'contact_id_b' => 1,
+        // volunteer relationship:
+        'relationship_type_id' => 6,
+        'is_active' => 1,
+      ],
+    ]);
+    $contact_id = $result['id'];
+
+    // Now create our saved search, and chain the creation of a smart group.
+    $params = $this->params;
+    $params['api.Group.create'] = [
+      'name' => 'my_smartgroup',
+      'title' => 'my smartgroup',
+      'description' => 'Volunteers for the default organization',
+      'saved_search_id' => '$value.id',
+      'is_active' => 1,
+      'visibility' => 'User and User Admin Only',
+      'is_hidden' => 0,
+      'is_reserved' => 0,
+    ];
+    return [$contact_id, $params];
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
[Ref] remove redundant call to clearGroupContactCache

Before
----------------------------------------
```
 self::clearGroupContactCache($groupID);
```

is called prior to triggering a refresh of the group - the refresh ALSO clears out the cached version of the group

After
----------------------------------------
Line removed & potentially a source of contention. This also stops all parent groups being rebuilt when a child group is updated and invalidates them instead (so they will be rebuilt if required or potentially by cron)

Technical Details
----------------------------------------
This code does a clear on the cache and then calls the api which will eventually
call load(). Load ALSO clears the cache so this seems redundant.

However, there are a couple of places where add() is called from where it might
serve to force the rebuild due to changes to group make up. In general we have switched
to invalidating and letting the rebuild-on-demand do it's thing to allow
things like crons or lack of need for the group to reduce to browser demand.
So, I think that by switching to invalidating rather than rebuilding
we can remove this potentially locky line from GroupContactCache::add()

Comments
----------------------------------------
We should have pretty good test cover on this code