### PR TITLE
dev/core#2593 [REF] Stop passing membership id into recur notify

### DIFF
--- a/CRM/Contribute/BAO/ContributionRecur.php
+++ b/CRM/Contribute/BAO/ContributionRecur.php
@@ -562,8 +562,7 @@ INNER JOIN civicrm_contribution       con ON ( con.id = mp.contribution_id )
       CRM_Contribute_BAO_ContributionPage::recurringNotify(
         $ids['contribution'],
         $isFirstOrLastRecurringPayment,
-        $recur,
-        $autoRenewMembership
+        $recur
       );
     }
   }

--- a/CRM/Core/Payment/AuthorizeNetIPN.php
+++ b/CRM/Core/Payment/AuthorizeNetIPN.php
@@ -89,8 +89,7 @@ class CRM_Core_Payment_AuthorizeNetIPN extends CRM_Core_Payment_BaseIPN {
       if ($isFirstOrLastRecurringPayment) {
         //send recurring Notification email for user
         CRM_Contribute_BAO_ContributionPage::recurringNotify($contributionID, TRUE,
-          $contributionRecur,
-          (bool) $this->getMembershipID($contributionID, $contributionRecur->id)
+          $contributionRecur
         );
       }
 

--- a/CRM/Core/Payment/PayPalIPN.php
+++ b/CRM/Core/Payment/PayPalIPN.php
@@ -346,8 +346,7 @@ class CRM_Core_Payment_PayPalIPN extends CRM_Core_Payment_BaseIPN {
           CRM_Contribute_BAO_ContributionPage::recurringNotify(
             $ids['contribution'],
             $this->getFirstOrLastInSeriesStatus(),
-            $contributionRecur,
-            !empty($ids['membership'])
+            $contributionRecur
           );
         }
         return;

--- a/CRM/Core/Payment/PayPalProIPN.php
+++ b/CRM/Core/Payment/PayPalProIPN.php
@@ -261,8 +261,7 @@ class CRM_Core_Payment_PayPalProIPN extends CRM_Core_Payment_BaseIPN {
       CRM_Contribute_BAO_ContributionPage::recurringNotify(
         $ids['contribution'],
         $subscriptionPaymentStatus,
-        $recur,
-        !empty($ids['membership'])
+        $recur
       );
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#2593 [REF] Stop passing membership id into recur notify

Before
----------------------------------------
The membership id resolves to a boolean template parameter of whether a membership is attached to the relevant
recurring record. The classes that call this function do a lot of work
to determine this so it's better to calculate it in-function and
simplify those classes


After
----------------------------------------
Parameter determined in recurring notifiy

Technical Details
----------------------------------------
@seamuslee001 with this change we should be able to, or be close to able to, remove the call to 
```
      if (!$contribution->loadRelatedObjects($input, $ids)) {
```
From Paypal IPN code - it looks like the only usage of ids after that line would then be to pass ids['participant'] into complete order - that should instead be determined within the complete order function with a simple lookup

Comments
----------------------------------------
There is test cover on the recurring notify function