### PR TITLE
dev/core#2593 [REF] Fix function signature to actually-used variables

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4189,7 +4189,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
    * Moving it out of the BaseIPN class is just the first step.
    *
    * @param array $input
-   * @param array $ids
+   * @param int $recurringContributionID
    * @param int|null $contributionID
    * @param bool $isPostPaymentCreate
    *   Is this being called from the payment.create api. If so the api has taken care of financial entities.
@@ -4201,15 +4201,8 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
    * @throws \CRM_Core_Exception
    * @throws \CiviCRM_API3_Exception
    */
-  public static function completeOrder($input, $ids, $contributionID, $isPostPaymentCreate = FALSE) {
+  public static function completeOrder($input, $recurringContributionID, $contributionID, $isPostPaymentCreate = FALSE) {
     $transaction = new CRM_Core_Transaction();
-    // @todo see if we even need this - it's used further down to create an activity
-    // but the BAO layer should create that - we just need to add a test to cover it & can
-    // maybe remove $ids altogether.
-    $recurringContributionID = $ids['contributionRecur'];
-
-    // Unset ids just to make it clear it's not used again.
-    unset($ids);
 
     $inputContributionWhiteList = [
       'fee_amount',

--- a/CRM/Core/Payment/AuthorizeNetIPN.php
+++ b/CRM/Core/Payment/AuthorizeNetIPN.php
@@ -170,10 +170,7 @@ class CRM_Core_Payment_AuthorizeNetIPN extends CRM_Core_Payment_BaseIPN {
       return FALSE;
     }
 
-    CRM_Contribute_BAO_Contribution::completeOrder($input, [
-      'participant' => NULL,
-      'contributionRecur' => $recur->id,
-    ], $contribution->id ?? NULL);
+    CRM_Contribute_BAO_Contribution::completeOrder($input, $recur->id, $contribution->id ?? NULL);
     return $isFirstOrLastRecurringPayment;
   }
 

--- a/CRM/Core/Payment/BaseIPN.php
+++ b/CRM/Core/Payment/BaseIPN.php
@@ -421,11 +421,7 @@ class CRM_Core_Payment_BaseIPN {
    */
   public function completeTransaction($input, $ids, $objects) {
     CRM_Core_Error::deprecatedFunctionWarning('Use Payment.create api');
-    CRM_Contribute_BAO_Contribution::completeOrder($input, [
-      'related_contact' => $ids['related_contact'] ?? NULL,
-      'participant' => !empty($objects['participant']) ? $objects['participant']->id : NULL,
-      'contributionRecur' => !empty($objects['contributionRecur']) ? $objects['contributionRecur']->id : NULL,
-    ], $objects['contribution']->id ?? NULL);
+    CRM_Contribute_BAO_Contribution::completeOrder($input, !empty($objects['contributionRecur']) ? $objects['contributionRecur']->id : NULL, $objects['contribution']->id ?? NULL);
   }
 
   /**

--- a/CRM/Core/Payment/PayPalIPN.php
+++ b/CRM/Core/Payment/PayPalIPN.php
@@ -224,7 +224,7 @@ class CRM_Core_Payment_PayPalIPN extends CRM_Core_Payment_BaseIPN {
       return;
     }
 
-    CRM_Contribute_BAO_Contribution::completeOrder($input, $ids, $contribution->id ?? NULL);
+    CRM_Contribute_BAO_Contribution::completeOrder($input, $ids['contributionRecur'] ?? NULL, $contribution->id ?? NULL);
   }
 
   /**

--- a/CRM/Core/Payment/PayPalProIPN.php
+++ b/CRM/Core/Payment/PayPalProIPN.php
@@ -350,7 +350,7 @@ class CRM_Core_Payment_PayPalProIPN extends CRM_Core_Payment_BaseIPN {
       return;
     }
 
-    CRM_Contribute_BAO_Contribution::completeOrder($input, $ids, $contribution->id ?? NULL);
+    CRM_Contribute_BAO_Contribution::completeOrder($input, $ids['contributionRecur'] ?? NULL, $contribution->id ?? NULL);
   }
 
   /**

--- a/CRM/Event/Form/Task/Batch.php
+++ b/CRM/Event/Form/Task/Batch.php
@@ -358,11 +358,7 @@ class CRM_Event_Form_Task_Batch extends CRM_Event_Form_Task {
     //complete the contribution.
     // @todo use the api - ie civicrm_api3('Contribution', 'completetransaction', $input);
     // as this method is not preferred / supported.
-    CRM_Contribute_BAO_Contribution::completeOrder($input, [
-      'related_contact' => NULL,
-      'participant' => $params['component_id'],
-      'contributionRecur' => NULL,
-    ], $contribution->id ?? NULL);
+    CRM_Contribute_BAO_Contribution::completeOrder($input, NULL, $contribution->id ?? NULL);
 
     // reset template values before processing next transactions
     $template->clearTemplateVars();

--- a/api/v3/Contribution.php
+++ b/api/v3/Contribution.php
@@ -681,11 +681,9 @@ function _ipn_process_transaction($params, $contribution, $input, $ids) {
   if (!empty($params['payment_instrument_id'])) {
     $input['payment_instrument_id'] = $params['payment_instrument_id'];
   }
-  return CRM_Contribute_BAO_Contribution::completeOrder($input, [
-    'related_contact' => $ids['related_contact'] ?? NULL,
-    'participant' => !empty($objects['participant']) ? $objects['participant']->id : NULL,
-    'contributionRecur' => !empty($objects['contributionRecur']) ? $objects['contributionRecur']->id : NULL,
-  ], $objects['contribution']->id ?? NULL,
+  return CRM_Contribute_BAO_Contribution::completeOrder($input,
+    !empty($objects['contributionRecur']) ? $objects['contributionRecur']->id : NULL,
+   $objects['contribution']->id ?? NULL,
     $params['is_post_payment_create'] ?? NULL);
 }
 


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#2593 [REF] Fix function signature to actually-used variables

Before
----------------------------------------
```$ids``` is received by completeOrder, ```$ids['contributionRecur'] ``` is extracted to ```$contributionRecurID``` and ids is reset

After
----------------------------------------
```$contributionRecurID```  is passed to complete order

Technical Details
----------------------------------------
ids used to hold a whole lotta stuff. Now it just holds contributionRecurID.

This gets rid of ids as a param & just passes contributionRecurID

Note we have made other changes to this signature & it is not called outside of core

Comments
----------------------------------------
@seamuslee001 another piece in removing that line causing you problems
also @mattwire is familiar with this code