### PR TITLE
dev/core#2592 - Create new joined entities instead of trying to replace them in af

### DIFF
--- a/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
@@ -84,10 +84,17 @@ class Submit extends AbstractProcessor {
       $values = self::filterEmptyJoins($joinEntityName, $join);
       // FIXME: Replace/delete should only be done to known contacts
       if ($values) {
-        $api4($joinEntityName, 'replace', [
-          'where' => self::getJoinWhereClause($mainEntityName, $joinEntityName, $entityId),
-          'records' => $values,
-        ]);
+        foreach ($values as $value) {
+          if (array_key_exists('id', $value)) {
+            $api4($joinEntityName, 'replace', [
+              'where' => self::getJoinWhereClause($mainEntityName, $joinEntityName, $entityId),
+              'records' => [$value],
+            ]);
+          } else {
+            $value['contact_id'] = $entityId;
+            $api4($joinEntityName, 'create', [ 'values' => $value ]);
+          }
+        }
       }
       else {
         try {

--- a/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
@@ -90,9 +90,10 @@ class Submit extends AbstractProcessor {
               'where' => self::getJoinWhereClause($mainEntityName, $joinEntityName, $entityId),
               'records' => [$value],
             ]);
-          } else {
+          }
+          else {
             $value['contact_id'] = $entityId;
-            $api4($joinEntityName, 'create', [ 'values' => $value ]);
+            $api4($joinEntityName, 'create', ['values' => $value]);
           }
         }
       }


### PR DESCRIPTION
Overview
----------------------------------------
Afform tries to always simply replace joined entities (e.g. email, phone) when saving. That does not work if the joined entity does not yet exist. This PR makes it either replace or create the joined entity, depending on its previous state.

Before
----------------------------------------
Joined entities were replaced while saving which would fail if they did not yet exist.

After
----------------------------------------
Joined entities will be replaced if they already exist (i.e. they have an `id` set) or will otherwise be created.

Technical Details
----------------------------------------

Comments
----------------------------------------
