### PR TITLE
dev/core#1613 Change event registration button text based on if there are additional participants

### DIFF
--- a/CRM/Event/Form/Registration/Register.php
+++ b/CRM/Event/Form/Registration/Register.php
@@ -378,8 +378,7 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
         $this->add('select', 'additional_participants',
           ts('How many people are you registering?'),
           $additionalOptions,
-          NULL,
-          ['onChange' => "allowParticipant()"]
+          NULL
         );
         $isAdditionalParticipants = TRUE;
       }
@@ -514,7 +513,7 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
         $buttonParams['name'] = ts('Register');
       }
       else {
-        $buttonParams['name'] = ts('Review your registration');
+        $buttonParams['name'] = ts('Review');
         $buttonParams['icon'] = 'fa-chevron-right';
       }
 

--- a/templates/CRM/Event/Form/Registration/Register.tpl
+++ b/templates/CRM/Event/Form/Registration/Register.tpl
@@ -60,10 +60,9 @@
       <div class="crm-public-form-item crm-section additional_participants-section" id="noOfparticipants">
         <div class="label">{$form.additional_participants.label} <span class="crm-marker" title="{ts}This field is required.{/ts}">*</span></div>
         <div class="content">
-          {$form.additional_participants.html}{if $contact_id || $contact_id == NULL}{ts}(including yourself){/ts}{/if}
+          {$form.additional_participants.html}{if $contact_id || $contact_id == NULL}&nbsp;{ts}(including yourself){/ts}{/if}
           <br/>
-          <span
-            class="description">{ts}Fill in your registration information on this page. If you are registering additional people, you will be able to enter their registration information after you complete this page and click &quot;Review your registration&quot;.{/ts}</span>
+          <div class="description" id="additionalParticipantsDescription" style="display: none;">{ts}Fill in your registration information on this page. You will be able to enter the registration information for additional people after you complete this page and click &quot;Continue&quot;.{/ts}</div>
         </div>
         <div class="clear"></div>
       </div>
@@ -167,6 +166,26 @@
     pcpAnonymous();
   {/if}
   {literal}
+
+  CRM.$(function($) {
+    $('#additional_participants').change(function() {
+      toggleAdditionalParticipants();
+      allowParticipant();
+    });
+
+    function toggleAdditionalParticipants() {
+      var submit_button = $("#crm-submit-buttons > button").html();
+      var review_translated = '{/literal}{ts escape="js"}Review{/ts}{literal}';
+      var continue_translated = '{/literal}{ts escape="js"}Continue{/ts}{literal}';
+      if ($('#additional_participants').val()) {
+        $("#additionalParticipantsDescription").show();
+        $("#crm-submit-buttons > button").html(submit_button.replace(review_translated, continue_translated));
+      } else {
+        $("#additionalParticipantsDescription").hide();
+        $("#crm-submit-buttons > button").html(submit_button.replace(continue_translated, review_translated));
+      }
+    }
+  });
 
   function allowParticipant() {
     {/literal}{if $allowGroupOnWaitlist}{literal}


### PR DESCRIPTION
Overview
----------------------------------------
Submit buttons label for event registrations can be confusing. [Discussion here](https://lab.civicrm.org/dev/core/-/issues/1613). This PR simplifies the button label and switches it depending on user selection of additional participants.

Before
----------------------------------------
If additional participants are allowed or confirmation is required for an event registration, the button to go to the next page is labelled "Review your registration". This is not correct in the case where the user selected additional participants, as the next page is the additional participants page, not the review page.

After
----------------------------------------
If additional participants are allowed or confirmation is required, the button to go to the next page is simply labelled "Review". If the user selects additional participants, the button text is changed to "Continue". This is consistent with the additional participants page, where the button to go to the next page is labelled "Continue" as well.

Comments
----------------------------------------
This works, but it does seem a little hacky especially when it comes to translations. If this is just a bad idea, I'm happy to be told that!
See also the [pending PR](https://github.com/civicrm/civicrm-core/pull/20149) that this is added on top of.
Changes one translation string.
