### PR TITLE
dev/events#56 Allow backend (de)registration changes for sold out price set items

### DIFF
--- a/CRM/Event/Form/Registration/Register.php
+++ b/CRM/Event/Form/Registration/Register.php
@@ -650,6 +650,10 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
           if (!empty($optionFullIds) && (count($options) == count($optionFullIds))) {
             $isRequire = FALSE;
           }
+
+          //check if this is a backend registration
+          $isBackEnd = (in_array($className, $formClasses)) ? TRUE : FALSE;
+
           if (!empty($options)) {
             //build the element.
             CRM_Price_BAO_PriceField::addQuickFormElement($form,
@@ -659,7 +663,8 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
               $isRequire,
               NULL,
               $options,
-              $optionFullIds
+              $optionFullIds,
+              $isBackEnd
             );
           }
         }
@@ -765,11 +770,6 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
               $optionFullTotalAmount += CRM_Utils_Array::value('amount', $option);
             }
           }
-          else {
-            if (!empty($defaultPricefieldIds) && in_array($optId, $defaultPricefieldIds)) {
-              unset($optionFullIds[$optId]);
-            }
-          }
         }
         //here option is not full,
         //but we don't want to allow participant to increase
@@ -786,11 +786,6 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
         $option['is_full'] = $isFull;
         $option['db_total_count'] = $dbTotalCount;
         $option['total_option_count'] = $dbTotalCount + $currentTotalCount;
-      }
-
-      //ignore option full for offline registration.
-      if ($className == 'CRM_Event_Form_Participant' || $className === 'CRM_Event_Form_Task_Register') {
-        $optionFullIds = [];
       }
 
       //finally get option ids in.

--- a/CRM/Price/BAO/PriceField.php
+++ b/CRM/Price/BAO/PriceField.php
@@ -241,6 +241,7 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
    *
    * @param null $fieldOptions
    * @param array $freezeOptions
+   * @param bool $isBackEnd
    *
    * @return null
    */
@@ -252,7 +253,8 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
     $useRequired = TRUE,
     $label = NULL,
     $fieldOptions = NULL,
-    $freezeOptions = []
+    $freezeOptions = [],
+    $isBackEnd = NULL
   ) {
 
     $field = new CRM_Price_DAO_PriceField();
@@ -349,9 +351,12 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
 
         // CRM-6902 - Add "max" option for a price set field
         if (in_array($optionKey, $freezeOptions)) {
-          self::freezeIfEnabled($element, $fieldOptions[$optionKey]);
-          // CRM-14696 - Improve display for sold out price set options
-          $element->setLabel($label . '&nbsp;<span class="sold-out-option">' . ts('Sold out') . '</span>');
+          if (!$isBackEnd) {
+            self::freezeIfEnabled($element, $fieldOptions[$optionKey]);
+          }
+          else {
+            $qf->append('sold_out', $optionKey);
+          }
         }
 
         //CRM-10117
@@ -455,7 +460,9 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
         foreach ($element->getElements() as $radioElement) {
           // CRM-6902 - Add "max" option for a price set field
           if (in_array($radioElement->getValue(), $freezeOptions)) {
-            self::freezeIfEnabled($radioElement, $customOption[$radioElement->getValue()]);
+            if (!$isBackEnd) {
+              self::freezeIfEnabled($radioElement, $customOption[$radioElement->getValue()]);
+            }
             // CRM-14696 - Improve display for sold out price set options
             $radioElement->setText('<span class="sold-out-option">' . $radioElement->getText() . '&nbsp;(' . ts('Sold out') . ')</span>');
           }
@@ -498,7 +505,9 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
           }
           // CRM-14696 - Improve display for sold out price set options
           else {
-            $opt['id'] = 'crm_disabled_opt-' . $opt['id'];
+            if (!$isBackEnd) {
+              $opt['id'] = 'crm_disabled_opt-' . $opt['id'];
+            }
             $opt['label'] = $opt['label'] . ' (' . ts('Sold out') . ')';
           }
 
@@ -521,11 +530,6 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
           'data-price-field-values' => json_encode($customOption),
         ]);
 
-        // CRM-6902 - Add "max" option for a price set field
-        $button = substr($qf->controller->getButtonName(), -4);
-        if (!empty($freezeOptions) && $button != 'skip') {
-          $qf->addRule($elementName, ts('Sorry, this option is currently sold out.'), 'regex', "/" . implode('|', $allowedOptions) . "/");
-        }
         break;
 
       case 'CheckBox':
@@ -568,7 +572,9 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
           }
           // CRM-6902 - Add "max" option for a price set field
           if (in_array($opId, $freezeOptions)) {
-            self::freezeIfEnabled($check[$opId], $customOption[$opId]);
+            if (!$isBackEnd) {
+              self::freezeIfEnabled($check[$opId], $customOption[$opId]);
+            }
             // CRM-14696 - Improve display for sold out price set options
             $check[$opId]->setText('<span class="sold-out-option">' . $check[$opId]->getText() . '&nbsp;(' . ts('Sold out') . ')</span>');
           }

--- a/templates/CRM/Price/Form/PriceSet.tpl
+++ b/templates/CRM/Price/Form/PriceSet.tpl
@@ -81,12 +81,12 @@
                       {else}
                         {$option.amount|crmMoney} {$fieldHandle} {$form.$fieldHandle.frozen}
                       {/if}
-                      {if $form.$element_name.frozen EQ 1} ({ts}Sold out{/ts}){/if}
+                      {if $form.$element_name.frozen EQ 1 || $option.id|in_array:$sold_out} ({ts}Sold out{/ts}){/if}
                     {/foreach}
                     </span>
                     {else}
                       {* Not showing amount, but still need to conditionally show Sold out marker *}
-                      {if $form.$element_name.frozen EQ 1}
+                      {if $form.$element_name.frozen EQ 1 || $option.id|in_array:$sold_out}
                         <span class="sold-out-option">({ts}Sold out{/ts})<span>
                       {/if}
                     {/if}


### PR DESCRIPTION
Overview
----------------------------------------
Currently, when editing price set selections for an event registrant, you cannot add or remove sold out items. This PR makes it possible for backend users to add or remove price set selections that are sold out from registrations. It also ensures that all full selections show (Sold out) text, both on the Register Participant form and the Change Selections and Edit Event Registration forms.

Before
----------------------------------------
If a price set selection is sold out, back-end users can add this selection on Events - Register Event Participant, but if they edit a existing registration they cannot either add or subtract from sold out selections as these are disabled/frozen (except for removing select fields, which was possible). Back-end users may add registrants to sold out selections unintentionally, as there is no warning that selections are sold out on the Register Participant Form. Backend users cannot remove registrants from sold out selections, which should clearly be possible. They cannot override price set limits if required to add participants to sold out selections.

Additionally, "Sold out" was shown twice for text fields and sold out was not show on select options if the participant was currently registered for that selection.

Register Participant: Backend user can register participant for sold out selections and they are unmarked
![image](https://user-images.githubusercontent.com/25517556/118904793-cf47ca00-b8d7-11eb-95d5-95ed477ae935.png)

Change Selections: Participant cannot be added or removed from sold out selections, doubled sold out on text field, no sold out on select
![image](https://user-images.githubusercontent.com/25517556/118905235-91977100-b8d8-11eb-9953-a4107610bc0b.png)

Public registration: Text field shows sold out twice.
![image](https://user-images.githubusercontent.com/25517556/118905289-a8d65e80-b8d8-11eb-9905-4d1781043498.png)


After
----------------------------------------
Backend users can register and deregister participants for any price set selection. All price set selections that are sold out are now marked as sold out.

Sold out is only shown after the text field, which is consistent with all other price set fields. Sold out is shown on all relevant select options.

Register participant: Sold out selections are now marked
![image](https://user-images.githubusercontent.com/25517556/118905390-d58a7600-b8d8-11eb-9c4e-0242ebd4a3e3.png)

Change Selections: Participant can be added to or removed from all selections, sold out marked once on text field, sold out marked on select option.
![image](https://user-images.githubusercontent.com/25517556/118905446-f0f58100-b8d8-11eb-9429-271b5bcc0630.png)

Public Registration: Text field shows sold out once. Not other public facing change.
![image](https://user-images.githubusercontent.com/25517556/118905353-c4416980-b8d8-11eb-8efb-9b4e17e42f55.png)

Comments
----------------------------------------
I've removed some now unneeded code that set form rules for selects.

To my eye, the use of bold, italics and regular text in price sets is a bit too much.
![image](https://user-images.githubusercontent.com/25517556/118905706-7b3de500-b8d9-11eb-842f-c5745aa44f6d.png)
It is also inconsistent, as select options that are sold out are not show in italics. My suggestion would be to remove the italics and leave sold out options in regular text. This would be more readable and less of a mishmash.

