### PR TITLE
[Test] Improve cleanup of domain contacts

### DIFF
--- a/tests/phpunit/CRM/Core/BAO/ActionScheduleTest.php
+++ b/tests/phpunit/CRM/Core/BAO/ActionScheduleTest.php
@@ -1753,7 +1753,7 @@ class CRM_Core_BAO_ActionScheduleTest extends CiviUnitTestCase {
       [
         // The next day, send an email.
         'time' => date('Y-m-d H:i:s', strtotime($contact['values'][$contact['id']]['created_date'] . ' +1 day')),
-        'recipients' => [['test-birth_day@example.com']],
+        'recipients' => [['test-birth_day@example.com'], ['fixme.domainemail@example.org'], ['domainemail2@example.org']],
       ],
     ]);
   }
@@ -1777,7 +1777,7 @@ class CRM_Core_BAO_ActionScheduleTest extends CiviUnitTestCase {
       [
         // On the eve of 3 years after they were modified, send an email.
         'time' => date('Y-m-d H:i:s', strtotime($modifiedDate . ' +3 years -1 day')),
-        'recipients' => [['test-birth_day@example.com']],
+        'recipients' => [['test-birth_day@example.com'], ['fixme.domainemail@example.org'], ['domainemail2@example.org']],
       ],
     ]);
   }

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -453,14 +453,30 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
   /**
    * Create default domain contacts for the two domains added during test class.
    * database population.
+   *
+   * @throws \CiviCRM_API3_Exception
    */
-  public function createDomainContacts() {
-    $this->organizationCreate();
-    $this->organizationCreate(['organization_name' => 'Second Domain']);
+  public function createDomainContacts(): void {
+    $this->organizationCreate(['api.Email.create' => ['email' => 'fixme.domainemail@example.org']]);
+    $this->organizationCreate([
+      'organization_name' => 'Second Domain',
+      'api.Email.create' => ['email' => 'domainemail2@example.org'],
+      'api.Address.create' => [
+        'street_address' => '15 Main St',
+        'location_type_id' => 1,
+        'city' => 'Collinsville',
+        'country_id' => 1228,
+        'state_province_id' => 1003,
+        'postal_code' => 6022,
+      ],
+    ]);
   }
 
   /**
    *  Common teardown functions for all unit tests.
+   *
+   * @throws \CiviCRM_API3_Exception
+   * @throws \CRM_Core_Exception
    */
   protected function tearDown(): void {
     $this->_apiversion = 3;
@@ -484,7 +500,7 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
       CRM_Core_Transaction::forceRollbackIfEnabled();
       \Civi\Core\Transaction\Manager::singleton(TRUE);
 
-      $tablesToTruncate = ['civicrm_contact', 'civicrm_uf_match'];
+      $tablesToTruncate = ['civicrm_contact', 'civicrm_uf_match', 'civicrm_email', 'civicrm_address'];
       $this->quickCleanup($tablesToTruncate);
       $this->createDomainContacts();
     }

--- a/tests/phpunit/api/v3/ContactTest.php
+++ b/tests/phpunit/api/v3/ContactTest.php
@@ -3261,7 +3261,7 @@ class api_v3_ContactTest extends CiviUnitTestCase {
       'Bob, Bob :: bob@bob.com',
       'C Bobby, Bobby',
       'H Bobby, Bobby :: bob@h.com',
-      'Second Domain',
+      'Second Domain :: domainemail2@example.org',
       $this->callAPISuccessGetValue('Contact', ['id' => $loggedInContactID, 'return' => 'last_name']) . ', Logged In :: anthony_anderson@civicrm.org',
     ];
     $this->assertEquals(6, $result['count']);
@@ -3309,7 +3309,7 @@ class api_v3_ContactTest extends CiviUnitTestCase {
       'A Bobby, Bobby :: bob@bobby.com',
       'Bob, Bob :: bob@bob.com',
       'C Bobby, Bobby',
-      'Second Domain',
+      'Second Domain :: domainemail2@example.org',
       $this->callAPISuccessGetValue('Contact', ['id' => $loggedInContactID, 'return' => 'last_name']) . ', Logged In :: anthony_anderson@civicrm.org',
     ];
     foreach ($expectedData as $index => $value) {

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -108,6 +108,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
    * Clean up after each test.
    *
    * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
    */
   public function tearDown(): void {
     $this->quickCleanUpFinancialEntities();
@@ -125,6 +126,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
       }
     }
     $this->restoreUFGroupOne();
+    parent::tearDown();
   }
 
   /**

--- a/tests/phpunit/api/v3/DomainTest.php
+++ b/tests/phpunit/api/v3/DomainTest.php
@@ -100,8 +100,10 @@ class api_v3_DomainTest extends CiviUnitTestCase {
 
   /**
    * Test get function with current domain.
+   *
+   * @throws \CRM_Core_Exception
    */
-  public function testGetCurrentDomain() {
+  public function testGetCurrentDomain(): void {
     $params = ['current_domain' => 1];
     $result = $this->callAPISuccess('domain', 'get', $params);
 

--- a/tests/phpunit/api/v3/EntityBatchTest.php
+++ b/tests/phpunit/api/v3/EntityBatchTest.php
@@ -23,11 +23,15 @@ class api_v3_EntityBatchTest extends CiviUnitTestCase {
 
   public $DBResetRequired = FALSE;
 
+  /**
+   * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
+   */
   public function setUp(): void {
     parent::setUp();
-    $this->useTransaction(TRUE);
+    $this->useTransaction();
 
-    $entityParams = ['contact_id' => 1];
+    $entityParams = ['contact_id' => $this->individualCreate()];
 
     $this->_entity = 'EntityBatch';
     $this->_entityID = $this->contributionCreate($entityParams);


### PR DESCRIPTION

Overview
----------------------------------------
This fixes a situation where the domain contact may not have an email if the api_v3_ContributionTest
test is run in combination with certain others. The last test in the suite relies on the
domain contact having an email. 

Before
----------------------------------------
class does not follow practice of tearDown calling parent

After
----------------------------------------
parent::tearDown called. In addition improvements made to createDomainContacts() function to be closer to re-instating them as originally declared

Technical Details
----------------------------------------
This test was not following the practice
of having a tearDown but the tearDown was also flawed in recreating the domain
contacts but not their emails

Comments
----------------------------------------
