### PR TITLE
Make APIv4 Subscribers Public to fix D9 install

### DIFF
--- a/CRM/Api4/Services.php
+++ b/CRM/Api4/Services.php
@@ -94,6 +94,7 @@ class CRM_Api4_Services {
           if ($serviceClass->isInstantiable()) {
             $definition = $container->register(str_replace('\\', '_', $serviceName), $serviceName);
             $definition->addTag($tag);
+            $definition->setPublic(TRUE);
           }
         }
         $container->addResource($resource);


### PR DESCRIPTION
Overview
----------------------------------------
This fixes a failure on the D9 demo install

```
                                                                                                                                                                                                                                                         
  [CiviCRM_API3_Exception]                                                                                                                                                                                                                               
  The "Civi_Api4_Event_Subscriber_PermissionCheckSubscriber" service or alias has been removed or inlined when the container was compiled. You should either make it public, or stop using the container directly and use dependency injection instead.  
                                                                                                                                                                                                                                                         

Exception trace:
 () at /srv/buildkit/build/d9-master/vendor/civicrm/civicrm-core/api/api.php:134
 civicrm_api3() at /srv/buildkit/build/d9-master/vendor/civicrm/civicrm-core/CRM/Core/BAO/Setting.php:253
 CRM_Core_BAO_Setting::validateSettingsInput() at /srv/buildkit/build/d9-master/vendor/civicrm/civicrm-core/Civi/Core/SettingsBag.php:373
 Civi\Core\SettingsBag->setDb() at /srv/buildkit/build/d9-master/vendor/civicrm/civicrm-core/Civi/Core/SettingsBag.php:263
 ```

Before
----------------------------------------
This seems to be a slight regression from https://github.com/civicrm/civicrm-core/commit/a9d469f980abf4fb797a0b2d26868ce3ad442b34 and D9 demo build fails at this point

After
----------------------------------------
D9 Demo build installs CiviCRM correctly

ping @colemanw @totten @eileenmcnaughton 