### PR TITLE
dev/core#2602 - Installer doesn't check mysql version properly

### DIFF
--- a/install/index.php
+++ b/install/index.php
@@ -1070,7 +1070,7 @@ class InstallRequirements {
       }
       else {
         $versionDetails = mysqli_query($this->conn, 'SELECT version() as version')->fetch_assoc();
-        if (version_compare($versionDetails['version'], $min) == -1) {
+        if (version_compare($versionDetails['version'], $version) == -1) {
           $testDetails[2] .= "{$majorHas}.{$minorHas}.";
           $this->error($testDetails);
         }


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/2602

1. Try to install on mariadb 5.5.68 by visiting sites/all/modules/civicrm/install/index.php
2. The requirements checks tell you it's ok even though it should require 5.6.5+

Before
----------------------------------------
Comparing against a non-existent variable. Crashes if you proceed.

After
----------------------------------------
Red message. Can't proceed.

Technical Details
----------------------------------------
When it compares minor versions, it's comparing to `$min` when it should be comparing to `$version` (the variable passed into the function).

Comments
----------------------------------------
I know this is the "legacy" installer, but it's still there and used.
