### PR TITLE
[NFC] Test - fix to use v3 api on postAsserts

### DIFF
--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -501,6 +501,8 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
    * @throws \CRM_Core_Exception
    */
   protected function assertPostConditions() {
+    // Reset to version 3 as not all (e.g payments) work on v4
+    $this->_apiversion = 3;
     if ($this->isLocationTypesOnPostAssert) {
       $this->assertLocationValidity();
     }

--- a/tests/phpunit/api/v3/ACLCachingTest.php
+++ b/tests/phpunit/api/v3/ACLCachingTest.php
@@ -27,6 +27,9 @@ class api_v3_ACLCachingTest extends CiviUnitTestCase {
 
   /**
    * (non-PHPdoc)
+   *
+   * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
    * @see CiviUnitTestCase::tearDown()
    */
   public function tearDown(): void {
@@ -34,13 +37,14 @@ class api_v3_ACLCachingTest extends CiviUnitTestCase {
       'civicrm_activity',
     ];
     $this->quickCleanup($tablesToTruncate, TRUE);
+    parent::tearDown();
   }
 
   /**
    * @param int $version
    * @dataProvider versionThreeAndFour
    */
-  public function testActivityCreateCustomBefore($version) {
+  public function testActivityCreateCustomBefore($version): void {
     $this->_apiversion = $version;
     $values = $this->callAPISuccess('custom_field', 'getoptions', ['field' => 'custom_group_id']);
     $this->assertTrue($values['count'] == 0);
@@ -48,7 +52,7 @@ class api_v3_ACLCachingTest extends CiviUnitTestCase {
     $groupCount = $this->callAPISuccess('custom_group', 'getcount', ['extends' => 'activity']);
     $this->assertEquals($groupCount, 1, 'one group should now exist');
     $values = $this->callAPISuccess('custom_field', 'getoptions', ['field' => 'custom_group_id']);
-    $this->assertTrue($values['count'] == 1, 'check that cached value is not retained for custom_group_id');
+    $this->assertEquals(1, $values['count'], 'check that cached value is not retained for custom_group_id');
   }
 
 }

--- a/tests/phpunit/api/v3/DomainTest.php
+++ b/tests/phpunit/api/v3/DomainTest.php
@@ -76,7 +76,7 @@ class api_v3_DomainTest extends CiviUnitTestCase {
    * Takes no params.
    * Testing mainly for format.
    */
-  public function testGet() {
+  public function testGet(): void {
 
     $params = ['sequential' => 1];
     $result = $this->callAPIAndDocument('domain', 'get', $params, __FUNCTION__, __FILE__);


### PR DESCRIPTION
Overview
----------------------------------------
[NFC] Test - fix to use v3 api on postAsserts

Before
----------------------------------------
When running tests with api version set to v4 the postAssert checks will run using v4 - which winds up being skipped for payment checks

After
----------------------------------------
Revert to v3 api for post assert checks (and tearDown)

Technical Details
----------------------------------------
We want the v4 for the actual tests but we want consistency in post checks & tear down

Comments
----------------------------------------
