### PR TITLE
[NFC] Test - Improve tearDown cleanup of domain contacts

### DIFF
--- a/CRM/Contact/Form/Search/Custom/Group.php
+++ b/CRM/Contact/Form/Search/Custom/Group.php
@@ -184,7 +184,6 @@ class CRM_Contact_Form_Search_Custom_Group extends CRM_Contact_Form_Search_Custo
    * @param bool $justIDs
    *
    * @return string
-   * @throws \Exception
    */
   public function all(
     $offset = 0, $rowcount = 0, $sort = NULL,

--- a/CRM/Core/BAO/ActionSchedule.php
+++ b/CRM/Core/BAO/ActionSchedule.php
@@ -356,7 +356,7 @@ FROM civicrm_action_schedule cas
    * @throws \API_Exception
    * @throws \CRM_Core_Exception
    */
-  public static function processQueue($now = NULL, $params = []) {
+  public static function processQueue($now = NULL, $params = []): void {
     $now = $now ? CRM_Utils_Time::setTime($now) : CRM_Utils_Time::getTime();
 
     $mappings = CRM_Core_BAO_ActionSchedule::getMappings();

--- a/tests/phpunit/CRM/Contact/Form/Search/Custom/GroupTest.php
+++ b/tests/phpunit/CRM/Contact/Form/Search/Custom/GroupTest.php
@@ -28,69 +28,52 @@
  */
 
 /**
- *  Include parent class definition
- */
-
-
-/**
- *  Include class under test
- */
-
-/**
- *  Include form definitions
- */
-
-/**
- *  Include DAO to do queries
- */
-
-/**
- *  Include dataProvider for tests
- */
-
-/**
- *  Test contact custom search functions
+ * Test contact custom search functions
  *
  * @package CiviCRM
  * @group headless
  */
 class CRM_Contact_Form_Search_Custom_GroupTest extends CiviUnitTestCase {
-  protected $_tablesToTruncate = [
-    'civicrm_group_contact',
-    'civicrm_group',
-    'civicrm_saved_search',
-    'civicrm_entity_tag',
-    'civicrm_tag',
-    'civicrm_contact',
-    'civicrm_option_value',
-    'civicrm_option_group',
-  ];
+
+  /**
+   * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
+   */
+  public function tearDown(): void {
+    $this->quickCleanup([
+      'civicrm_group_contact',
+      'civicrm_group',
+      'civicrm_saved_search',
+      'civicrm_entity_tag',
+      'civicrm_tag',
+    ]);
+    parent::tearDown();
+  }
 
   /**
    * @return CRM_Contact_Form_Search_Custom_GroupTestDataProvider
    */
-  public function dataProvider() {
+  public function dataProvider(): CRM_Contact_Form_Search_Custom_GroupTestDataProvider {
     return new CRM_Contact_Form_Search_Custom_GroupTestDataProvider();
   }
 
   /**
-   *  Test CRM_Contact_Form_Search_Custom_Group::count()
+   * Test CRM_Contact_Form_Search_Custom_Group::count().
+   *
    * @dataProvider dataProvider
-   * @param $fv
-   * @param $count
-   * @param $ids
-   * @param $full
-   * @throws \Exception
+   *
+   * @param array $fv
+   * @param int $count
+   *
+   * @throws \CRM_Core_Exception
    */
-  public function testCount($fv, $count, $ids, $full) {
-    $this->quickCleanup($this->_tablesToTruncate);
-
-    $this->loadXMLDataSet(dirname(__FILE__) . '/datasets/group-dataset.xml');
+  public function testCount(array $fv, int $count): void {
+    $this->loadXMLDataSet(__DIR__ . '/datasets/group-dataset.xml');
 
     $obj = new CRM_Contact_Form_Search_Custom_Group($fv);
 
     $sql = $obj->all();
-    $dao = CRM_Core_DAO::executeQuery($sql);
+    CRM_Core_DAO::executeQuery($sql);
 
     /**
      * echo "Count: $count, OBJ: ", $obj->count( ) . "\n";
@@ -110,14 +93,12 @@ class CRM_Contact_Form_Search_Custom_GroupTest extends CiviUnitTestCase {
    * @param $full
    * @throws \Exception
    */
-  public function testAll($fv, $count, $ids, $full) {
-    // Truncate affected tables
-    $this->quickCleanup($this->_tablesToTruncate);
-    $this->loadXMLDataSet(dirname(__FILE__) . '/datasets/group-dataset.xml');
+  public function testAll($fv, $count, $ids, $full): void {
+    $this->loadXMLDataSet(__DIR__ . '/datasets/group-dataset.xml');
 
     $obj = new CRM_Contact_Form_Search_Custom_Group($fv);
     $sql = $obj->all();
-    $this->assertTrue(is_string($sql));
+    $this->assertIsString($sql);
     $dao = CRM_Core_DAO::executeQuery($sql);
     $all = [];
     while ($dao->fetch()) {
@@ -141,10 +122,7 @@ class CRM_Contact_Form_Search_Custom_GroupTest extends CiviUnitTestCase {
    * @throws \Exception
    */
   public function testContactIDs($fv, $count, $ids, $full) {
-    // Truncate affected tables
-    $this->quickCleanup($this->_tablesToTruncate);
-
-    $this->loadXMLDataSet(dirname(__FILE__) . '/datasets/group-dataset.xml');
+    $this->loadXMLDataSet(__DIR__ . '/datasets/group-dataset.xml');
 
     $obj = new CRM_Contact_Form_Search_Custom_Group($fv);
     $sql = $obj->contactIDs();
@@ -163,29 +141,22 @@ class CRM_Contact_Form_Search_Custom_GroupTest extends CiviUnitTestCase {
    *  Test CRM_Contact_Form_Search_Custom_Group::columns()
    *  It returns an array of translated name => keys
    */
-  public function testColumns() {
+  public function testColumns(): void {
     $formValues = [];
     $obj = new CRM_Contact_Form_Search_Custom_Group($formValues);
     $columns = $obj->columns();
-    $this->assertTrue(is_array($columns));
+    $this->assertIsArray($columns);
     foreach ($columns as $key => $value) {
-      $this->assertTrue(is_string($key));
-      $this->assertTrue(is_string($value));
+      $this->assertIsString($key);
+      $this->assertIsString($value);
     }
-  }
-
-  /**
-   *  Test CRM_Contact_Form_Search_Custom_Group::from()
-   * @todo write this test
-   */
-  public function SKIPPED_testFrom() {
   }
 
   /**
    *  Test CRM_Contact_Form_Search_Custom_Group::summary()
    *  It returns NULL
    */
-  public function testSummary() {
+  public function testSummary(): void {
     $formValues = [];
     $obj = new CRM_Contact_Form_Search_Custom_Group($formValues);
     $this->assertNull($obj->summary());
@@ -195,20 +166,18 @@ class CRM_Contact_Form_Search_Custom_GroupTest extends CiviUnitTestCase {
    *  Test CRM_Contact_Form_Search_Custom_Group::templateFile()
    *  Returns the path to the file as a string
    */
-  public function testTemplateFile() {
+  public function testTemplateFile(): void {
     $formValues = [];
     $obj = new CRM_Contact_Form_Search_Custom_Group($formValues);
     $fileName = $obj->templateFile();
-    $this->assertTrue(is_string($fileName));
-    //FIXME: we would need to search the include path to do the following
-    //$this->assertTrue( file_exists( $fileName ) );
+    $this->assertIsString($fileName);
   }
 
   /**
    *  Test CRM_Contact_Form_Search_Custom_Group::where( )
    *  With no arguments it returns '(1)'
    */
-  public function testWhereNoArgs() {
+  public function testWhereNoArgs(): void {
     $formValues = [
       CRM_Core_Form::CB_PREFIX . '17' => TRUE,
       CRM_Core_Form::CB_PREFIX . '23' => TRUE,
@@ -221,30 +190,26 @@ class CRM_Contact_Form_Search_Custom_GroupTest extends CiviUnitTestCase {
    *  Test CRM_Contact_Form_Search_Custom_Group::where( )
    *  With false argument it returns '(1)'
    */
-  public function testWhereFalse() {
+  public function testWhereFalse(): void {
     $formValues = [
       CRM_Core_Form::CB_PREFIX . '17' => TRUE,
       CRM_Core_Form::CB_PREFIX . '23' => TRUE,
     ];
     $obj = new CRM_Contact_Form_Search_Custom_Group($formValues);
-    $this->assertEquals(' (1) ', $obj->where(FALSE),
-      'In line ' . __LINE__
-    );
+    $this->assertEquals(' (1) ', $obj->where(FALSE));
   }
 
   /**
    *  Test CRM_Contact_Form_Search_Custom_Group::where( )
    *  With true argument it returns list of contact IDs
    */
-  public function testWhereTrue() {
+  public function testWhereTrue(): void {
     $formValues = [
       CRM_Core_Form::CB_PREFIX . '17' => TRUE,
       CRM_Core_Form::CB_PREFIX . '23' => TRUE,
     ];
     $obj = new CRM_Contact_Form_Search_Custom_Group($formValues);
-    $this->assertEquals(' (1)  AND contact_a.id IN ( 17, 23 )', $obj->where(TRUE),
-      'In line ' . __LINE__
-    );
+    $this->assertEquals(' (1)  AND contact_a.id IN ( 17, 23 )', $obj->where(TRUE));
   }
 
 }

--- a/tests/phpunit/CRM/Contact/Form/Search/Custom/GroupTestDataProvider.php
+++ b/tests/phpunit/CRM/Contact/Form/Search/Custom/GroupTestDataProvider.php
@@ -54,6 +54,8 @@ class CRM_Contact_Form_Search_Custom_GroupTestDataProvider implements Iterator {
     [
       'fv' => ['excludeGroups' => ['3']],
       'id' => [
+        1,
+        2,
         '9',
         '10',
         '11',
@@ -127,6 +129,8 @@ class CRM_Contact_Form_Search_Custom_GroupTestDataProvider implements Iterator {
     [
       'fv' => ['excludeTags' => ['7']],
       'id' => [
+        1,
+        2,
         '9',
         '10',
         '13',
@@ -253,6 +257,8 @@ class CRM_Contact_Form_Search_Custom_GroupTestDataProvider implements Iterator {
         'excludeGroups' => ['5'],
       ],
       'id' => [
+        1,
+        2,
         '9',
         '11',
         '17',
@@ -266,6 +272,8 @@ class CRM_Contact_Form_Search_Custom_GroupTestDataProvider implements Iterator {
     [
       'fv' => ['includeGroups' => ['6']],
       'id' => [
+        1,
+        2,
         '9',
         '10',
         '11',
@@ -315,10 +323,6 @@ class CRM_Contact_Form_Search_Custom_GroupTestDataProvider implements Iterator {
     ],
   ];
 
-  public function _construct() {
-    $this->i = 0;
-  }
-
   public function rewind() {
     $this->i = 0;
   }
@@ -330,12 +334,22 @@ class CRM_Contact_Form_Search_Custom_GroupTestDataProvider implements Iterator {
     $count = count($this->dataset[$this->i]['id']);
     $ids = $this->dataset[$this->i]['id'];
     $full = [];
-    foreach ($this->dataset[$this->i]['id'] as $key => $value) {
-      $full[] = [
-        'contact_id' => $value,
-        'contact_type' => 'Individual',
-        'sort_name' => "Test Contact $value",
-      ];
+    foreach ($this->dataset[$this->i]['id'] as $value) {
+      if ($value < 3) {
+        // One of the domain contacts...
+        $full[] = [
+          'contact_id' => $value,
+          'contact_type' => 'Organization',
+          'sort_name' => $value === 1 ? 'Unit Test Organization' : 'Second Domain',
+        ];
+      }
+      else {
+        $full[] = [
+          'contact_id' => $value,
+          'contact_type' => 'Individual',
+          'sort_name' => "Test Contact $value",
+        ];
+      }
     }
     return [$this->dataset[$this->i]['fv'], $count, $ids, $full];
   }

--- a/tests/phpunit/CRM/Contact/Form/Search/Custom/SampleTest.php
+++ b/tests/phpunit/CRM/Contact/Form/Search/Custom/SampleTest.php
@@ -29,6 +29,9 @@
  *  Include dataProvider for tests
  */
 
+use Civi\Api4\OptionValue;
+use Civi\Api4\SavedSearch;
+
 /**
  *  Test contact custom search functions
  *
@@ -36,58 +39,81 @@
  * @group headless
  */
 class CRM_Contact_Form_Search_Custom_SampleTest extends CiviUnitTestCase {
-  protected $_tablesToTruncate = [
-    'civicrm_address',
-    'civicrm_saved_search',
-    'civicrm_contact',
-    'civicrm_option_value',
-    'civicrm_option_group',
-  ];
 
   /**
-   * @return CRM_Contact_Form_Search_Custom_SamplTestDataProvider
+   * Set up for test.
+   *
+   * @throws \API_Exception
+   * @throws \Civi\API\Exception\UnauthorizedException
    */
-  public function dataProvider() {
+  public function setUp(): void {
+    parent::setUp();
+    OptionValue::create()->setValues([
+      'option_group_id:name' => 'custom_search',
+      'label' => 'CRM_Contact_Form_Search_Custom_Sample',
+      'value' => 100,
+      'name' => 'CRM_Contact_Form_Search_Custom_Sample',
+      'description' => 'Household Name and State',
+    ])->execute();
+  }
+
+  /**
+   * Post test cleanup.
+   *
+   * @throws \API_Exception
+   * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
+   * @throws \Civi\API\Exception\UnauthorizedException
+   */
+  public function tearDown(): void {
+    $this->quickCleanup([
+      'civicrm_address',
+      'civicrm_saved_search',
+      'civicrm_contact',
+    ]);
+    OptionValue::delete()->addWhere('name', '=', 'CRM_Contact_Form_Search_Custom_Sample')->execute();
+    parent::tearDown();
+  }
+
+  /**
+   * @return \CRM_Contact_Form_Search_Custom_SampleTestDataProvider
+   */
+  public function dataProvider(): CRM_Contact_Form_Search_Custom_SampleTestDataProvider {
     return new CRM_Contact_Form_Search_Custom_SampleTestDataProvider();
   }
 
   /**
    *  Test CRM_Contact_Form_Search_Custom_Sample::count()
+   *
    * @dataProvider dataProvider
-   * @param $fv
-   * @param $count
-   * @param $ids
-   * @param $full
-   * @throws \Exception
+   *
+   * @param array $fv
+   * @param int $count
    */
-  public function testCount($fv, $count, $ids, $full) {
-    $this->quickCleanup($this->_tablesToTruncate);
-
-    $this->loadXMLDataSet(dirname(__FILE__) . '/datasets/sample-dataset.xml');
-
+  public function testCount(array $fv, int $count): void {
+    $this->loadXMLDataSet(__DIR__ . '/datasets/sample-dataset.xml');
     $obj = new CRM_Contact_Form_Search_Custom_Sample($fv);
-
     $this->assertEquals($count, $obj->count());
   }
 
   /**
    *  Test CRM_Contact_Form_Search_Custom_Sample::all()
+   *
    * @dataProvider dataProvider
-   * @param $fv
-   * @param $count
-   * @param $ids
-   * @param $full
-   * @throws \Exception
+   *
+   * @param array $fv
+   * @param int $count
+   * @param array $ids
+   * @param array $full
+   *
+   * @noinspection PhpUnusedParameterInspection
    */
-  public function testAll($fv, $count, $ids, $full) {
-    // Truncate affected tables
-    $this->quickCleanup($this->_tablesToTruncate);
-
-    $this->loadXMLDataSet(dirname(__FILE__) . '/datasets/sample-dataset.xml');
+  public function testAll(array $fv, int $count, array $ids, array $full): void {
+    $this->loadXMLDataSet(__DIR__ . '/datasets/sample-dataset.xml');
 
     $obj = new CRM_Contact_Form_Search_Custom_Sample($fv);
     $sql = $obj->all(0, 0, 'contact_id');
-    $this->assertTrue(is_string($sql));
+    $this->assertIsString($sql);
     $dao = CRM_Core_DAO::executeQuery($sql);
     $all = [];
     while ($dao->fetch()) {
@@ -103,21 +129,21 @@ class CRM_Contact_Form_Search_Custom_SampleTest extends CiviUnitTestCase {
 
   /**
    *  Test CRM_Contact_Form_Search_Custom_Sample::contactIDs()
+   *
    * @dataProvider dataProvider
-   * @param $fv
-   * @param $count
-   * @param $ids
-   * @param $full
-   * @throws \Exception
+   *
+   * @param array $fv
+   * @param int $count
+   * @param array $ids
+   * @param array $full
+   *
+   * @noinspection PhpUnusedParameterInspection
    */
-  public function testContactIDs($fv, $count, $ids, $full) {
-    // Truncate affected tables
-    $this->quickCleanup($this->_tablesToTruncate);
-
-    $this->loadXMLDataSet(dirname(__FILE__) . '/datasets/sample-dataset.xml');
+  public function testContactIDs(array $fv, int $count, array $ids, array $full): void {
+    $this->loadXMLDataSet(__DIR__ . '/datasets/sample-dataset.xml');
     $obj = new CRM_Contact_Form_Search_Custom_Sample($fv);
     $sql = $obj->contactIDs();
-    $this->assertTrue(is_string($sql));
+    $this->assertIsString($sql);
     $dao = CRM_Core_DAO::executeQuery($sql);
     $contacts = [];
     while ($dao->fetch()) {
@@ -132,29 +158,22 @@ class CRM_Contact_Form_Search_Custom_SampleTest extends CiviUnitTestCase {
    *  Test CRM_Contact_Form_Search_Custom_Group::columns()
    *  It returns an array of translated name => keys
    */
-  public function testColumns() {
+  public function testColumns(): void {
     $formValues = [];
     $obj = new CRM_Contact_Form_Search_Custom_Sample($formValues);
     $columns = $obj->columns();
-    $this->assertTrue(is_array($columns));
+    $this->assertIsArray($columns);
     foreach ($columns as $key => $value) {
-      $this->assertTrue(is_string($key));
-      $this->assertTrue(is_string($value));
+      $this->assertIsString($key);
+      $this->assertIsString($value);
     }
-  }
-
-  /**
-   *  Test CRM_Contact_Form_Search_Custom_Group::from()
-   * @todo write this test
-   */
-  public function SKIPPED_testFrom() {
   }
 
   /**
    *  Test CRM_Contact_Form_Search_Custom_Group::summary()
    *  It returns NULL
    */
-  public function testSummary() {
+  public function testSummary(): void {
     $formValues = [];
     $obj = new CRM_Contact_Form_Search_Custom_Group($formValues);
     $this->assertNull($obj->summary());
@@ -164,11 +183,11 @@ class CRM_Contact_Form_Search_Custom_SampleTest extends CiviUnitTestCase {
    *  Test CRM_Contact_Form_Search_Custom_Sample::templateFile()
    *  Returns the path to the file as a string
    */
-  public function testTemplateFile() {
+  public function testTemplateFile(): void {
     $formValues = [];
     $obj = new CRM_Contact_Form_Search_Custom_Group($formValues);
     $fileName = $obj->templateFile();
-    $this->assertTrue(is_string($fileName));
+    $this->assertIsString($fileName);
     //FIXME: we would need to search the include path to do the following
     //$this->assertTrue( file_exists( $fileName ) );
   }
@@ -176,28 +195,31 @@ class CRM_Contact_Form_Search_Custom_SampleTest extends CiviUnitTestCase {
   /**
    *  Test CRM_Contact_Form_Search_Custom_Sample with saved_search_id
    *  With true argument it returns list of contact IDs
+   *
+   * @throws \API_Exception
+   * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
+   * @throws \Civi\API\Exception\UnauthorizedException
    */
-  public function testSavedSearch() {
-    $this->quickCleanup($this->_tablesToTruncate);
-
-    $this->loadXMLDataSet(dirname(__FILE__) . '/datasets/sample-dataset.xml');
+  public function testSavedSearch(): void {
+    $this->loadXMLDataSet(__DIR__ . '/datasets/sample-dataset.xml');
 
     $dataset[1] = ['id' => [12]];
     $dataset[2] = ['id' => [10, 11]];
 
-    $ssdao = CRM_Core_DAO::executeQuery("SELECT * FROM civicrm_saved_search");
-    while ($ssdao->fetch()) {
-      $fv = CRM_Contact_BAO_SavedSearch::getFormValues($ssdao->id);
+    $searches = SavedSearch::get()->addSelect('*')->execute();
+    foreach ($searches as $search) {
+      $fv = CRM_Contact_BAO_SavedSearch::getFormValues($search['id']);
       $obj = new CRM_Contact_Form_Search_Custom_Sample($fv);
       $sql = $obj->contactIDs();
-      $this->assertTrue(is_string($sql));
+      $this->assertIsString($sql);
       $dao = CRM_Core_DAO::executeQuery($sql);
       $contacts = [];
       while ($dao->fetch()) {
         $contacts[] = $dao->contact_id;
       }
       sort($contacts, SORT_NUMERIC);
-      $this->assertEquals($dataset[$ssdao->id]['id'], $contacts);
+      $this->assertEquals($dataset[$search['id']]['id'], $contacts);
     }
   }
 

--- a/tests/phpunit/CRM/Contact/Form/Search/Custom/datasets/group-dataset.xml
+++ b/tests/phpunit/CRM/Contact/Form/Search/Custom/datasets/group-dataset.xml
@@ -429,24 +429,4 @@
         contact_id="28"
         status="Added"
     />
-    <civicrm_option_group
-       id="24"
-       name="custom_search"
-       description="Custom Search"
-       is_reserved="0"
-       is_active="1"
-    />
-    <civicrm_option_value
-       id="153"
-       option_group_id="24"
-       label="CRM_Contact_Form_Search_Custom_Group"
-       value="4"
-       name="CRM_Contact_Form_Search_Custom_Group"
-       filter="0"
-       weight="4"
-       description="Include / Exclude Contacts in a Group / Tag"
-       is_optgroup="0"
-       is_reserved="0"
-       is_active="1"
-    />
 </dataset>

--- a/tests/phpunit/CRM/Contact/Form/Search/Custom/datasets/sample-dataset.xml
+++ b/tests/phpunit/CRM/Contact/Form/Search/Custom/datasets/sample-dataset.xml
@@ -69,24 +69,4 @@
         state_province_id="1031"
         is_primary="1"
     />
-    <civicrm_option_group
-       id="25"
-       name="custom_search"
-       description="Custom Search"
-       is_reserved="0"
-       is_active="1"
-    />
-    <civicrm_option_value
-       id="213"
-       option_group_id="25"
-       label="CRM_Contact_Form_Search_Custom_Sample"
-       value="1"
-       name="CRM_Contact_Form_Search_Custom_Sample"
-       filter="0"
-       weight="1"
-       description="Household Name and State"
-       is_optgroup="0"
-       is_reserved="0"
-       is_active="1"
-    />
-</dataset>
+ </dataset>


### PR DESCRIPTION


Overview
----------------------------------------
[NFC] Test - Improve tearDown cleanup of domain contacts

Before
----------------------------------------
``createDomainContacts`` does not ensure the domain contacts have a from_email

After
----------------------------------------
``createDomainContacts`` does ensure the domain contacts have a from_email

Technical Details
----------------------------------------

Comments
----------------------------------------
Trying to iron out test inconsistencies