### PR TITLE
Change the help text for Message Templates and Scheduled Reminders to include link to CiviCRM Token Documentation page

### DIFF
--- a/templates/CRM/Admin/Form/MessageTemplates.tpl
+++ b/templates/CRM/Admin/Form/MessageTemplates.tpl
@@ -8,128 +8,126 @@
  +--------------------------------------------------------------------+
 *}
 {* this template is used for adding/editing/deleting Message Templates *}
-{capture assign=tokenDocsRepeated}{docURL page="user/common-workflows/tokens-and-mail-merge" text="token documentation"}{/capture}
 
 {if $action neq 8}
-<div class="help">
+  <div class="help">
     {ts}Use this form to add or edit re-usable message templates.{/ts} {help id="id-intro" file="CRM/Admin/Page/MessageTemplates.hlp"}
-</div>
+  </div>
 {/if}
 
 <h3>{if $action eq 1}{ts}New Message Template{/ts}{elseif $action eq 2}{ts}Edit Message Template{/ts}{else}{ts}Delete Message Template{/ts}{/if}</h3>
 
 <div class="crm-block crm-form-block">
-<div class="form-item" id="message_templates">
-{if $action eq 8}
-   <div class="messages status no-popup">
-       {icon icon="fa-info-circle"}{/icon}
-       {ts 1=$msg_title|escape}Do you want to delete the message template '%1'?{/ts}
-   </div>
-{else}
-        <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
-        <table class="form-layout-compressed">
+  <div class="form-item" id="message_templates">
+    {if $action eq 8}
+      <div class="messages status no-popup">
+        {icon icon="fa-info-circle"}{/icon}
+        {ts 1=$msg_title|escape}Do you want to delete the message template '%1'?{/ts}
+      </div>
+    {else}
+      <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
+      <table class="form-layout-compressed">
         <tr>
-            <td class="label-left">{$form.msg_title.label}</td>
-            <td>{$form.msg_title.html}
-                <br /><span class="description html-adjust">{ts}Descriptive title of message - used for template selection.{/ts}</span>
-            </td>
+          <td class="label-left">{$form.msg_title.label}</td>
+          <td>{$form.msg_title.html}
+            <br /><span class="description html-adjust">{ts}Descriptive title of message - used for template selection.{/ts}</span>
+          </td>
         </tr>
         <tr>
-           <td class="label-left">{$form.file_type.label}</td>
-            <td>{$form.file_type.html}
-                <br /><span class="description html-adjust">{ts}Compose a message on-screen for general use in emails or document output, or upload a pre-composed document for mail-merge.{/ts}</span>
-            </td>
+          <td class="label-left">{$form.file_type.label}</td>
+          <td>{$form.file_type.html}
+            <br /><span class="description html-adjust">{ts}Compose a message on-screen for general use in emails or document output, or upload a pre-composed document for mail-merge.{/ts}</span>
+          </td>
         </tr>
         <tr>
-            <td class="label-left">{$form.msg_subject.label}</td>
-            <td>
-              {$form.msg_subject.html|crmAddClass:huge}
-              <input class="crm-token-selector big" data-field="msg_subject" />
-              {help id="id-token-subject" tplFile=$tplFile isAdmin=$isAdmin file="CRM/Contact/Form/Task/Email.hlp"}
-             <br /><span class="description">{ts}Subject for email message.{/ts} {ts 1=$tokenDocsRepeated}Tokens may be included (%1).{/ts}</span>
-            </td>
+          <td class="label-left">{$form.msg_subject.label}</td>
+          <td>
+            {$form.msg_subject.html|crmAddClass:huge}
+            <input class="crm-token-selector big" data-field="msg_subject" />
+            {help id="id-token-subject" tplFile=$tplFile isAdmin=$isAdmin file="CRM/Contact/Form/Task/Email.hlp"}
+          </td>
         </tr>
         <tr>
-            <td class="label-left">{$form.file_id.label}</td>
-            <td>{$form.file_id.html}
-              {if $attachment}
-                 {foreach from=$attachment key=attKey item=attVal}
-                 <div class="crm-attachment-wrapper crm-entity" id="file_{$attVal.fileID}">
-                   <strong><a class="crm-attachment" href="{$attVal.url}">{$attVal.cleanName}</a></strong>
-                   {if $attVal.description}&nbsp;-&nbsp;{$attVal.description}{/if}
-                   {if $attVal.deleteURLArgs}
-                    <a href="#" class="crm-hover-button delete-attachment" data-mimetype="{$attVal.mime_type}" data-filename="{$attVal.cleanName}" data-args="{$attVal.deleteURLArgs}" title="{ts}Delete File{/ts}"><span class="icon delete-icon"></span></a>
-                   {/if}
-                   {include file="CRM/Form/attachmentjs.tpl" context='MessageTemplate'}
-                 {/foreach}
+          <td class="label-left">{$form.file_id.label}</td>
+          <td>{$form.file_id.html}
+            {if $attachment}
+            {foreach from=$attachment key=attKey item=attVal}
+            <div class="crm-attachment-wrapper crm-entity" id="file_{$attVal.fileID}">
+              <strong><a class="crm-attachment" href="{$attVal.url}">{$attVal.cleanName}</a></strong>
+              {if $attVal.description}&nbsp;-&nbsp;{$attVal.description}{/if}
+              {if $attVal.deleteURLArgs}
+                <a href="#" class="crm-hover-button delete-attachment" data-mimetype="{$attVal.mime_type}" data-filename="{$attVal.cleanName}" data-args="{$attVal.deleteURLArgs}" title="{ts}Delete File{/ts}"><span class="icon delete-icon"></span></a>
               {/if}
-                <br /><span class="description html-adjust">{ts}Upload the document in .docx or .odt format.{/ts}</span>
-            </td>
+              {include file="CRM/Form/attachmentjs.tpl" context='MessageTemplate'}
+              {/foreach}
+              {/if}
+              <br /><span class="description html-adjust">{ts}Upload the document in .docx or .odt format.{/ts}</span>
+          </td>
         </tr>
         <tr>
-  </table>
+      </table>
 
       <div id="msg_html_section" class="crm-accordion-wrapper crm-html_email-accordion ">
         <div class="crm-accordion-header">
-            {ts}HTML Format{/ts}
-            {help id="id-message-text" file="CRM/Contact/Form/Task/Email.hlp"}
+          {ts}HTML Format{/ts}
+          {help id="id-message-text" file="CRM/Contact/Form/Task/Email.hlp"}
         </div><!-- /.crm-accordion-header -->
-         <div class="crm-accordion-body">
-           <div class="helpIcon" id="helphtml">
-             <input class="crm-token-selector big" data-field="msg_html" />
-             {help id="id-token-html" tplFile=$tplFile isAdmin=$isAdmin file="CRM/Contact/Form/Task/Email.hlp"}
-           </div>
-                <div class="clear"></div>
-                <div class='html'>
-                    {$form.msg_html.html|crmAddClass:huge}
-                    <div class="description">{ts}An HTML formatted version of this message will be sent to contacts whose Email Format preference is 'HTML' or 'Both'.{/ts} {ts 1=$tokenDocsRepeated}Tokens may be included (%1).{/ts}</div>
-                </div>
+        <div class="crm-accordion-body">
+          <div class="helpIcon" id="helphtml">
+            <input class="crm-token-selector big" data-field="msg_html" />
+            {help id="id-token-html" tplFile=$tplFile isAdmin=$isAdmin file="CRM/Contact/Form/Task/Email.hlp"}
+          </div>
+          <div class="clear"></div>
+          <div class='html'>
+            {$form.msg_html.html|crmAddClass:huge}
+            <div class="description">{ts}An HTML formatted version of this message will be sent to contacts whose Email Format preference is 'HTML' or 'Both'.{/ts}</div>
+          </div>
         </div><!-- /.crm-accordion-body -->
       </div><!-- /.crm-accordion-wrapper -->
 
       <div id="msg_text_section" class="crm-accordion-wrapper crm-plaint_text_email-accordion ">
         <div class="crm-accordion-header">
-                {ts}Plain-Text Format{/ts}
+          {ts}Plain-Text Format{/ts}
         </div><!-- /.crm-accordion-header -->
-            <div class="crm-accordion-body">
-              <div class="helpIcon" id="helptext">
-                <input class="crm-token-selector big" data-field="msg_text" />
-                {help id="id-token-text" tplFile=$tplFile file="CRM/Contact/Form/Task/Email.hlp"}
-              </div>
-              <div class="clear"></div>
-                <div class='text'>
-                    {$form.msg_text.html|crmAddClass:huge}
-                    <div class="description">{ts}Text formatted message.{/ts} {ts 1=$tokenDocsRepeated}Tokens may be included (%1).{/ts}</div>
-                </div>
-            </div><!-- /.crm-accordion-body -->
+        <div class="crm-accordion-body">
+          <div class="helpIcon" id="helptext">
+            <input class="crm-token-selector big" data-field="msg_text" />
+            {help id="id-token-text" tplFile=$tplFile file="CRM/Contact/Form/Task/Email.hlp"}
+          </div>
+          <div class="clear"></div>
+          <div class='text'>
+            {$form.msg_text.html|crmAddClass:huge}
+            <div class="description">{ts}Text formatted message.{/ts}</div>
+          </div>
+        </div><!-- /.crm-accordion-body -->
       </div><!-- /.crm-accordion-wrapper -->
 
       <div id="pdf_format" class="crm-accordion-wrapper crm-html_email-accordion ">
         <div class="crm-accordion-header">
-            {$form.pdf_format_id.label}
+          {$form.pdf_format_id.label}
         </div><!-- /.crm-accordion-header -->
-         <div class="crm-accordion-body">
-                <div class="spacer"></div>
-                <div class='html'>
-                    {$form.pdf_format_id.html}
-                    {help id="id-msg-template" file="CRM/Contact/Form/Task/PDFLetterCommon.hlp"}
-                    <div class="description">{ts}Page format to use when creating PDF files using this template.{/ts}</div>
-                </div>
+        <div class="crm-accordion-body">
+          <div class="spacer"></div>
+          <div class='html'>
+            {$form.pdf_format_id.html}
+            {help id="id-msg-template" file="CRM/Contact/Form/Task/PDFLetterCommon.hlp"}
+            <div class="description">{ts}Page format to use when creating PDF files using this template.{/ts}</div>
+          </div>
         </div><!-- /.crm-accordion-body -->
       </div><!-- /.crm-accordion-wrapper -->
 
-    {if !$workflow_id}
-  <table class="form-layout-compressed">
+      {if !$workflow_id}
+        <table class="form-layout-compressed">
           <tr>
             <td class="label-left">{$form.is_active.label}</td>
             <td>{$form.is_active.html}</td>
           </tr>
-  </table>
+        </table>
+      {/if}
     {/if}
-  {/if}
-  <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
-  <br clear="all" />
-</div>
+    <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
+    <br clear="all" />
+  </div>
 </div> <!-- end of crm-form-block -->
 {include file="CRM/Mailing/Form/InsertTokens.tpl"}
 

--- a/templates/CRM/Contact/Form/Task/Email.hlp
+++ b/templates/CRM/Contact/Form/Task/Email.hlp
@@ -7,6 +7,7 @@
  | and copyright information, see https://civicrm.org/licensing       |
  +--------------------------------------------------------------------+
 *}
+{capture assign=tokentext}{ts}Find out more about CiviCRM Tokens{/ts}{/capture}
 {htxt id="id-from_email-title"}
   {ts}From Address{/ts}
 {/htxt}
@@ -40,6 +41,7 @@
 {/htxt}
 {htxt id="id-token-subject"}
 <p>{ts}Use a token in the Subject when you are sending mail to a number of recipients and want to include their name and / or other values from their contact record automatically in the subject line.{/ts}</p>
+<p>{docURL page="user/common-workflows/tokens-and-mail-merge" text=$tokentext}</p>
 {/htxt}
 
 {htxt id="id-token-text-title"}
@@ -57,6 +59,7 @@
 <p>{ts}Custom tokens (based on custom data) can be added for organizations as well. These tokens will not be displayed in the list of available tokens, but can be added manually. The format is {literal}{contact.custom_12}{/literal} – where 12 is the ID of the custom data field. To find the custom data field ID,
 go Administer > Customize Data & Screens > Custom Fields and click ‘edit’ on the field you want to use. Look at the URL. The last part of the URL will
 be an equal sign and a number (=12). The number (12 in this example) is the id of that custom field.{/ts}</p>
+<p>{docURL page="user/common-workflows/tokens-and-mail-merge" text=$tokentext}</p>
 {/htxt}
 
 {htxt id="id-token-html-title"}
@@ -82,6 +85,7 @@ be an equal sign and a number (=12). The number (12 in this example) is the id o
 <p>{ts}Custom tokens (based on custom data) can be added for organizations as well. These tokens will not be displayed in the list of available tokens, but can be added manually. The format is {literal}{contact.custom_12}{/literal} – where 12 is the ID of the custom data field. To find the custom data field ID,
 go Administer > Customize Data & Screens > Custom Fields and click ‘edit’ on the field you want to use. Look at the URL. The last part of the URL will
 be an equal sign and a number (=12). The number (12 in this example) is the id of that custom field.{/ts}</p>
+<p>{docURL page="user/common-workflows/tokens-and-mail-merge" text=$tokentext}</p>
 {/htxt}
 
 {htxt id="id-message-text-title"}
@@ -90,4 +94,5 @@ be an equal sign and a number (=12). The number (12 in this example) is the id o
 {htxt id="id-message-text"}
 <p>{ts}You can send your email as a simple text-only message, as an HTML formatted message, or both. Text-only messages are sufficient for most email communication - and some recipients may prefer not to receive HTML formatted messages.{/ts}</p>
 <p>{ts}HTML messages have more visual impact, allow you to include images, and may be more readable if you are including links to website pages. However, different email programs may interpret HTML formats differently - so use this option cautiously unless you have a template format that has been tested with different web and desktop email programs.{/ts}</p>
+<p>{docURL page="user/common-workflows/tokens-and-mail-merge" text=$tokentext}</p>
 {/htxt}


### PR DESCRIPTION
Overview
----------------------------------------
Change the help text for Message Templates and Scheduled Reminders to include link to CiviCRM Token Documentation page. Remove the in-line help which is superfluous.

Before
----------------------------------------
There is no link to the documentation for CiviCRM tokens. Instead end users are having to Google to find the CiviCRM documentation for tokens and hitting Stack Exchange, Forums and other sources which may not be correct.

After
----------------------------------------
There is now a link to the CiviCRM Token Documentation page, https://docs.civicrm.org/user/en/latest/common-workflows/tokens-and-mail-merge/
And this is available in multiple help contexts. Users can find the correct documentation easily.

This is what the help pop-up will look like now.

![Screenshot_20210510_152929](https://user-images.githubusercontent.com/58866555/117610096-863f9980-b1a4-11eb-98ed-6cea9b29e7de.png)


Technical Details
----------------------------------------
Added the link in the email help file which is used in Message Templates and Scheduled Reminders

Comments
----------------------------------------

Agileware Ref: CIVICRM-1734
