### PR TITLE
CiviCRM Scheduled Reminders, Subject field missing Token selector - users must copy Token from Body field to Subject

### DIFF
--- a/templates/CRM/Admin/Form/ScheduleReminders.tpl
+++ b/templates/CRM/Admin/Form/ScheduleReminders.tpl
@@ -106,7 +106,11 @@
          </tr>
          <tr class="crm-scheduleReminder-form-block-subject">
             <td class="label">{$form.subject.label}</td>
-            <td>{$form.subject.html}</td>
+            <td>
+              {$form.subject.html|crmAddClass:huge}
+              <input class="crm-token-selector big" data-field="subject" />
+              {help id="id-token-subject" tplFile=$tplFile isAdmin=$isAdmin file="CRM/Contact/Form/Task/Email.hlp"}
+            </td>
          </tr>
        </table>
        {include file="CRM/Contact/Form/Task/EmailCommon.tpl" upload=1 noAttach=1}


### PR DESCRIPTION
Overview
----------------------------------------
CiviCRM Scheduled Reminders, Subject field missing Token selector - users must copy Tokens from Body field to Subject.

Before
----------------------------------------
No Token selector for Subject field, users must copy Tokens from Body field to Subject field. Ugh. :crying_cat_face: 

![Screenshot_20210510_153804](https://user-images.githubusercontent.com/58866555/117610791-a885e700-b1a5-11eb-91b7-c7bf18e78633.png)

After
----------------------------------------
Subject field missing Token selector! Yay! :beers: 

![Screenshot_20210510_153703](https://user-images.githubusercontent.com/58866555/117610719-8c824580-b1a5-11eb-960e-caba12496712.png)


Technical Details
----------------------------------------


Comments
----------------------------------------

Agileware Ref: CIVICRM-1733
