### PR TITLE
Afform - Drag & drop fixes

### DIFF
--- a/ext/afform/admin/ang/afGuiEditor.js
+++ b/ext/afform/admin/ang/afGuiEditor.js
@@ -181,7 +181,7 @@
       $('#af-gui-icon-picker').crmIconPicker();
     });
     // Add css class while dragging
-    $('#crm-container')
+    $(document)
       .on('sortover', function(e) {
         $('.af-gui-container').removeClass('af-gui-dragtarget');
         $(e.target).closest('.af-gui-container').addClass('af-gui-dragtarget');
@@ -192,7 +192,7 @@
       .on('sortstart', '#afGuiEditor', function() {
         $('#afGuiEditor').addClass('af-gui-dragging');
       })
-      .on('sortstop', '#afGuiEditor', function() {
+      .on('sortstop', function() {
         $('.af-gui-dragging').removeClass('af-gui-dragging');
         $('.af-gui-dragtarget').removeClass('af-gui-dragtarget');
       });

--- a/ext/afform/admin/ang/afGuiEditor/afGuiEditor.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiEditor.component.js
@@ -238,13 +238,13 @@
             $target = $(sort.droptarget[0]),
             $item = $(ui.item[0]);
           // Fields cannot be dropped outside their own entity
-          if ($item.is('[af-gui-field]') || $item.has('[af-gui-field]').length) {
+          if ($item.find('af-gui-field').length) {
             if ($source.closest('[data-entity]').attr('data-entity') !== $target.closest('[data-entity]').attr('data-entity')) {
               return sort.cancel();
             }
           }
           // Entity-fieldsets cannot be dropped into other entity-fieldsets
-          if ((sort.model['af-fieldset'] || $item.has('.af-gui-fieldset').length) && $target.closest('.af-gui-fieldset').length) {
+          if ((sort.model['af-fieldset'] || $item.find('.af-gui-fieldset').length) && $target.closest('.af-gui-fieldset').length) {
             return sort.cancel();
           }
         }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes bugs related to dragging and dropping fields in the Afform Admin GUI.

Before
----------------------------------------
Possible to drag fields outside their fieldsets, breaking the UI.

After
----------------------------------------
Fields belonging to an entity constrained to fieldsets of that entity.

Technical Details
----------------------------------------
The drag-drop validation broke when af-gui-field was changed from a directive to a component, as the jQuery was looking for the wrong markup.

Comments
-----------------
Additionally, this attempts to fix a hard-to-reproduce bug where the styling gets stuck in a "dragging" state after something has been dropped.