### PR TITLE
Afform - Fix saving joined entities (email, address, phone, etc)

### DIFF
--- a/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php
@@ -75,11 +75,11 @@ abstract class AbstractProcessor extends \Civi\Api4\Generic\AbstractAction {
     if (self::fieldExists($joinEntityName, 'entity_id')) {
       $params[] = ['entity_id', '=', $mainEntityId];
       if (self::fieldExists($joinEntityName, 'entity_table')) {
-        $params[] = ['entity_table', '=', 'civicrm_' . _civicrm_api_get_entity_name_from_camel($mainEntityName)];
+        $params[] = ['entity_table', '=', 'civicrm_' . \CRM_Core_DAO_AllCoreTables::convertEntityNameToLower($mainEntityName)];
       }
     }
     else {
-      $mainEntityField = _civicrm_api_get_entity_name_from_camel($mainEntityName) . '_id';
+      $mainEntityField = \CRM_Core_DAO_AllCoreTables::convertEntityNameToLower($mainEntityName) . '_id';
       $params[] = [$mainEntityField, '=', $mainEntityId];
     }
     return $params;


### PR DESCRIPTION
Overview
----------------------------------------
Fixes saving emails, phones, websites, addresses, etc when the form is submitted by non-admin users.
https://lab.civicrm.org/dev/core/-/issues/2592

Before
----------------------------------------
Form fails to save email, etc. when submitted by anonymous users.

After
----------------------------------------
Works

Technical Details
----------------------------------------
The `getSecureApi4()` only really works for the main entity. Once that's validated we can disable permission checks to save related entities.