### PR TITLE
Fix delete customgroup using API4 so it removes data table

### DIFF
--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -1251,6 +1251,23 @@ ORDER BY civicrm_custom_group.weight,
   }
 
   /**
+   * Delete a record from supplied params.
+   * API3 calls deleteGroup() which removes the related civicrm_value_X table.
+   * This function does the same for API4.
+   *
+   * @param array $record
+   *   'id' is required.
+   * @return CRM_Core_DAO
+   * @throws CRM_Core_Exception
+   */
+  public static function deleteRecord(array $record) {
+    $table = CRM_Core_DAO::getFieldValue(__CLASS__, $record['id'], 'table_name');
+    $result = parent::deleteRecord($record);
+    CRM_Core_BAO_SchemaHandler::dropTable($table);
+    return $result;
+  }
+
+  /**
    * Set defaults.
    *
    * @param array $groupTree

--- a/tests/phpunit/api/v4/Action/CustomFieldAlterTest.php
+++ b/tests/phpunit/api/v4/Action/CustomFieldAlterTest.php
@@ -162,6 +162,17 @@ class CustomFieldAlterTest extends BaseCustomValueTest {
         ->execute();
     }
 
+    // Check that custom table exists and is then removed when group is deleted
+    $this->assertNotNull(\CRM_Core_DAO::singleValueQuery("SHOW TABLES LIKE '{$customGroup['table_name']}';"));
+
+    CustomField::delete(FALSE)
+      ->addWhere('custom_group_id', '=', $customGroup['id'])
+      ->execute();
+    CustomGroup::delete(FALSE)
+      ->addWhere('id', '=', $customGroup['id'])
+      ->execute();
+    // The table should be gone
+    $this->assertNull(\CRM_Core_DAO::singleValueQuery("SHOW TABLES LIKE '{$customGroup['table_name']}';"));
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
When using API3 CustomGroup.delete the associated data table is also deleted via a special function `deleteGroup()` But with API4 it is not because it's using the generic delete handling. This PR extends that so that the associated data table is deleted when called via API4.

Before
----------------------------------------
Custom group data table not deleted on API4 CustomGroup.delete

After
----------------------------------------
Custom group data table deleted on API4 CustomGroup.delete

Technical Details
----------------------------------------

Comments
----------------------------------------
@colemanw Does this make sense?
