### PR TITLE
dev/core#2601 fix joomla permission regression

### DIFF
--- a/CRM/Core/Permission/Base.php
+++ b/CRM/Core/Permission/Base.php
@@ -393,15 +393,13 @@ class CRM_Core_Permission_Base {
    * in all enabled CiviCRM module extensions.
    *
    * @param bool $descriptions
-   * @param array $permissions
    *
    * @return array
    *   Array of permissions, in the same format as CRM_Core_Permission::getCorePermissions().
    */
-  public function getAllModulePermissions($descriptions = FALSE, &$permissions): array {
-    $newPermissions = [];
-    CRM_Utils_Hook::permission($newPermissions, $permissions);
-    $permissions = array_merge($permissions, $newPermissions);
+  public function getAllModulePermissions($descriptions = FALSE): array {
+    $permissions = [];
+    CRM_Utils_Hook::permission($permissions);
 
     if ($descriptions) {
       foreach ($permissions as $permission => $label) {

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -2025,16 +2025,12 @@ abstract class CRM_Utils_Hook {
    *
    * @param array $newPermissions
    *   Array to be filled with permissions.
-   * @param array $permissions
-   *   Already calculated permissions. These can be altered. Notably an
-   *   extension might want to add it's permissions to 'implied' or to
-   *   remove some permissions.
    *
    * @return null
    *   The return value is ignored
    */
-  public static function permission(&$newPermissions, &$permissions) {
-    return self::singleton()->invoke(['permissions', 'all_permissions'], $newPermissions, $permissions,
+  public static function permission(&$newPermissions) {
+    return self::singleton()->invoke(['permissions'], $newPermissions, self::$_nullObject,
       self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
       'civicrm_permission'
     );


### PR DESCRIPTION
port of #20256 to 5.37

This was a change we ultimately decided to, but forgot to, revert. It gave
extensions the ability to modify already-defined-permissons but
was brought out of scope of the change as it required more
consideration that simply adding the new super duper permission

In the meantime it caused a Joomla! regression
https://lab.civicrm.org/dev/core/-/issues/2601

@eileenmcnaughton @demeritcowboy @colemanw 