### PR TITLE
APIv4 - Save custom fields in bulk

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -888,7 +888,7 @@ class CRM_Core_DAO extends DB_DataObject {
    *
    * @param array $record
    *
-   * @return $this
+   * @return static
    * @throws \CRM_Core_Exception
    */
   public static function writeRecord(array $record): CRM_Core_DAO {
@@ -909,11 +909,26 @@ class CRM_Core_DAO extends DB_DataObject {
   }
 
   /**
+   * Bulk save multiple records
+   *
+   * @param array[] $records
+   * @return static[]
+   * @throws CRM_Core_Exception
+   */
+  public static function writeRecords(array $records) {
+    $results = [];
+    foreach ($records as $record) {
+      $results[] = static::writeRecord($record);
+    }
+    return $results;
+  }
+
+  /**
    * Delete a record from supplied params.
    *
    * @param array $record
    *   'id' is required.
-   * @return CRM_Core_DAO
+   * @return static
    * @throws CRM_Core_Exception
    */
   public static function deleteRecord(array $record) {
@@ -935,6 +950,21 @@ class CRM_Core_DAO extends DB_DataObject {
     CRM_Utils_Hook::post('delete', $entityName, $record['id'], $instance);
 
     return $instance;
+  }
+
+  /**
+   * Bulk delete multiple records.
+   *
+   * @param array[] $records
+   * @return static[]
+   * @throws CRM_Core_Exception
+   */
+  public static function deleteRecords(array $records) {
+    $results = [];
+    foreach ($records as $record) {
+      $results[] = static::deleteRecord($record);
+    }
+    return $results;
   }
 
   /**

--- a/Civi/Api4/Generic/DAODeleteAction.php
+++ b/Civi/Api4/Generic/DAODeleteAction.php
@@ -71,9 +71,8 @@ class DAODeleteAction extends AbstractBatchAction {
       }
     }
     else {
-      foreach ($items as $item) {
-        $baoName::deleteRecord($item);
-        $ids[] = ['id' => $item['id']];
+      foreach ($baoName::deleteRecords($items) as $instance) {
+        $ids[] = ['id' => $instance->id];
       }
     }
     return $ids;


### PR DESCRIPTION
Overview
----------------------------------------
Continues the work started in https://lab.civicrm.org/dev/core/-/issues/1093 toward APIv4 saving in bulk.
This switches APIv4 to using the new bulk method for saving custom fields, and adds a transitional step to allow other BAOs to opt-in to bulk saving and deleting.

Before
----------------------------------------
Custom fields saved one-at-a-time, which is inefficient with all the cache clearing and schema wrangling happening for each one.

After
----------------------------------------
Custom fields saved in bulk. New DAO functions open the door for others to follow suit.

Technical Details
----------------------------------------
This should be a non-disruptive transitional step which does not alter current behavior for any entity other than CustomField.

Eventually I'd like to go through all the BAOs and deprecate their `add`, `create`, and `del` functions and standardize on always using `writeRecords` and `deleteRecords`. But for now, baby step.