### PR TITLE
(REF) dev/core#2601 - Cleanup stale parameter

### DIFF
--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -591,7 +591,7 @@ class CRM_Core_Permission {
     $permissions = self::getCoreAndComponentPermissions($all);
 
     // Add any permissions defined in hook_civicrm_permission implementations.
-    $module_permissions = CRM_Core_Config::singleton()->userPermissionClass->getAllModulePermissions(TRUE, $permissions);
+    $module_permissions = CRM_Core_Config::singleton()->userPermissionClass->getAllModulePermissions(TRUE);
     $permissions = array_merge($permissions, $module_permissions);
     if (!$descriptions) {
       foreach ($permissions as $name => $attr) {


### PR DESCRIPTION
Overview
--------

This cleans up a parameter that became unused/unnecessary following #20256.

History
-------

This revision is a little bouncy. Instead of before/after, here's a history:

* `<= v5.36.x`: `getAllModulePermissions($descriptions = FALSE)`
* `==  v5.37.0`: `getAllModulePermissions($descriptions = FALSE, &$permissions)`
* `>= v5.37.1`: `getAllModulePermissions($descriptions = FALSE)`

I grepped `universe` to confirm that no other repos were using the intermediate signature.

Comments
----------------------------------------

I based this branch on a recent/common ancestor of `5.38`+`master`, so if we want to target 5.38, you can just edit PR in the web UI.