### PR TITLE
Create User Record now hides the Password field and uses the check isUserRegistrationPermitted - which prevents Administrators from setting passwords for new Users

### DIFF
--- a/CRM/Contact/Form/Task/Useradd.php
+++ b/CRM/Contact/Form/Task/Useradd.php
@@ -69,17 +69,22 @@ class CRM_Contact_Form_Task_Useradd extends CRM_Core_Form {
     $element = $this->add('text', 'name', ts('Full Name'), ['class' => 'huge']);
     $element->freeze();
     $this->add('text', 'cms_name', ts('Username'), ['class' => 'huge']);
-    $this->addRule('cms_name', 'Username is required', 'required');
+    $this->addRule('cms_name', ts('Username is required'), 'required');
 
-    if (!$config->userSystem->isUserRegistrationPermitted()) {
+    // For WordPress only, comply with how WordPress sets passwords via magic link
+    // For other CMS, output the password fields
+    if ($config->userFramework !== 'WordPress' || ($config->userFramework === 'WordPress' && !$config->userSystem->isUserRegistrationPermitted())) {
       $this->add('password', 'cms_pass', ts('Password'), ['class' => 'huge']);
       $this->add('password', 'cms_confirm_pass', ts('Confirm Password'), ['class' => 'huge']);
-      $this->addRule('cms_pass', 'Password is required', 'required');
-      $this->addRule(['cms_pass', 'cms_confirm_pass'], 'ERROR: Password mismatch', 'compare');
+      $this->addRule('cms_pass', ts('Password is required'), 'required');
+      $this->addRule([
+        'cms_pass',
+        'cms_confirm_pass',
+      ], ts('Password mismatch'), 'compare');
     }
 
-    $this->add('text', 'email', ts('Email:'), ['class' => 'huge'])->freeze();
-    $this->addRule('email', 'Email is required', 'required');
+    $this->add('text', 'email', ts('Email'), ['class' => 'huge'])->freeze();
+    $this->addRule('email', ts('Email is required'), 'required');
     $this->add('hidden', 'contactID');
 
     //add a rule to check username uniqueness


### PR DESCRIPTION
Overview
----------------------------------------
Create User Record now hides the Password field and uses the check isUserRegistrationPermitted - which prevents Administrators from setting passwords for new Users.

See Gitlab for more deets, https://lab.civicrm.org/dev/core/-/issues/2605

Before
----------------------------------------
Password fields no longer shown. This change was introduced by https://github.com/civicrm/civicrm-core/pull/18982 and
https://github.com/civicrm/civicrm-core/commit/633d512254424bba7c2195da8c62a9d3ff43d1e4

![Screenshot_20210512_161318](https://user-images.githubusercontent.com/58866555/117927331-668fa900-b33d-11eb-9795-cedc25514eba.png)


After
----------------------------------------
Password fields are again shown.

![Screenshot_20210512_161416](https://user-images.githubusercontent.com/58866555/117927321-62fc2200-b33d-11eb-8000-4eb6dcd66608.png)


Technical Details
----------------------------------------


Comments
----------------------------------------
The comment was "Also removes the possibility to set a user-defined password for WordPress users." - this change affects all CMS not just WordPress.

Agileware Ref: CIVICRM-1737