### PR TITLE
dev/core#2606 - Typo in rowCount variable in pager

### DIFF
--- a/CRM/Utils/Pager.php
+++ b/CRM/Utils/Pager.php
@@ -220,7 +220,7 @@ class CRM_Utils_Pager extends Pager_Sliding {
     }
     else {
       if (empty($defaultPageRowCount)) {
-        $rowcount = Civi::settings()->get('default_pager_size');
+        $rowCount = Civi::settings()->get('default_pager_size');
       }
       else {
         $rowCount = $defaultPageRowCount;


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/2606

Typo in letter 'c' makes My Cases dashlet stop working.

From https://github.com/civicrm/civicrm-core/pull/18969

FYI @seamuslee001 