### PR TITLE
Typo when retrieving help_pre textarea attributes for price field

### DIFF
--- a/CRM/Price/Form/Field.php
+++ b/CRM/Price/Form/Field.php
@@ -337,7 +337,7 @@ class CRM_Price_Form_Field extends CRM_Core_Form {
     $this->addRule('options_per_line', ts('must be a numeric value'), 'numeric');
 
     $this->add('textarea', 'help_pre', ts('Pre Field Help'),
-      CRM_Core_DAO::getAttribute('CRM_Price_DAO_PriceField', 'help_post')
+      CRM_Core_DAO::getAttribute('CRM_Price_DAO_PriceField', 'help_pre')
     );
 
     // help post, mask, attributes, javascript ?


### PR DESCRIPTION
Overview
----------------------------------------
Typo in help_pre retrieving html attributes for price field textarea.

It ends up not mattering because both pre and post have array('rows' => 4, 'cols' => 80), so the textarea box looks fine. This is on the form where you create a price field.

From https://github.com/civicrm/civicrm-core/commit/139f5f764cf531ff700d1932250c257bea805281