### PR TITLE
Fix internal formatting of monetary values when handling non-decimal currencies

### DIFF
--- a/CRM/Core/Payment.php
+++ b/CRM/Core/Payment.php
@@ -1166,9 +1166,9 @@ abstract class CRM_Core_Payment {
   protected function getAmount($params = []) {
     if (!CRM_Utils_Rule::numeric($params['amount'])) {
       CRM_Core_Error::deprecatedWarning('Passing Amount value that is not numeric is deprecated please report this in gitlab');
-      return CRM_Utils_Money::formatLocaleNumericRoundedByPrecision(filter_var($params['amount'], FILTER_SANITIZE_NUMBER_FLOAT, FILTER_FLAG_ALLOW_FRACTION), 2);
+      return CRM_Utils_Money::formatUSLocaleNumericRounded(filter_var($params['amount'], FILTER_SANITIZE_NUMBER_FLOAT, FILTER_FLAG_ALLOW_FRACTION), 2);
     }
-    return CRM_Utils_Money::formatLocaleNumericRoundedByPrecision($params['amount'], 2);
+    return CRM_Utils_Money::formatUSLocaleNumericRounded($params['amount'], 2);
   }
 
   /**

--- a/CRM/Utils/Money.php
+++ b/CRM/Utils/Money.php
@@ -194,7 +194,7 @@ class CRM_Utils_Money {
    *
    * @return string
    */
-  protected static function formatUSLocaleNumericRounded($amount, int $numberOfPlaces): string {
+  public static function formatUSLocaleNumericRounded($amount, int $numberOfPlaces): string {
     if (!extension_loaded('intl') || !is_numeric($amount)) {
       // @todo - we should not attempt to format non-numeric strings. For now
       // these will not fail but will give notices on php 7.4


### PR DESCRIPTION
Overview
----------------------------------------

As @mattwire [pointed out on Mattermost](https://chat.civicrm.org/civicrm/pl/zx8emwnzc78fpj3zakz7m11d1c), there is a regression in currency formatting. It arises when processing payments (a) with certain payment processors (e.g. Payflow Pro and iATS) and (b) with currencies that do not use decimal (".") notation.

The problem relates to https://github.com/civicrm/civicrm-core/pull/20074 (esp https://github.com/civicrm/civicrm-core/commit/78b338e07464becd1555a2c7d2d04ac0e4e9180c#diff-3d2a990f0b1960f0b3e6671c645e18033883e6d1eaf535b8d19d085b67dde00bR1171).

Before
----------------------------------------
Currency separators incorrectly applied

After
----------------------------------------
The only reason to format money at this stage is to ensure there are 2 decimal places - we should be sticking with machine (US)  formatting

Technical Details
----------------------------------------

Comments
----------------------------------------
@mattwire @seamuslee001 