### PR TITLE
Give the custom css file a 'name' to make it easier to manipulate in hook_civicrm_alterBundle()

### DIFF
--- a/CRM/Core/Resources/Common.php
+++ b/CRM/Core/Resources/Common.php
@@ -97,7 +97,7 @@ class CRM_Core_Resources_Common {
     $config = CRM_Core_Config::singleton();
     if (!empty($config->customCSSURL)) {
       $customCSSURL = Civi::resources()->addCacheCode($config->customCSSURL);
-      $bundle->addStyleUrl($customCSSURL, 99);
+      $bundle->addStyleUrl($customCSSURL, ['weight' => 99, 'name' => 'civicrm:css/custom.css']);
     }
     if (!Civi::settings()->get('disable_core_css')) {
       $bundle->addStyleFile('civicrm', 'css/civicrm.css', -99);

--- a/tests/phpunit/CRM/Core/Resources/BundleTest.php
+++ b/tests/phpunit/CRM/Core/Resources/BundleTest.php
@@ -72,4 +72,16 @@ class CRM_Core_Resources_BundleTest extends CiviUnitTestCase {
     $this->assertEquals('page-header', $bundle->get('cheese')['region']);
   }
 
+  /**
+   * Test creation of coreStyles bundle
+   */
+  public function testCoreStylesBundle() {
+    $config = CRM_Core_Config::singleton();
+    $config->customCSSURL = "http://example.com/css/custom.css";
+    $bundle = CRM_Core_Resources_Common::createStyleBundle('coreStyles');
+    $this->assertEquals('civicrm:css/civicrm.css', $bundle->get('civicrm:css/civicrm.css')['name']);
+    $this->assertEquals('civicrm:css/crm-i.css', $bundle->get('civicrm:css/crm-i.css')['name']);
+    $this->assertEquals('civicrm:css/custom.css', $bundle->get('civicrm:css/custom.css')['name']);
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Give the custom CSS file a useful 'name' to make it easier to manipulate in the alterBundle hook.

Before
----------------------------------------
In the resources bundle, the custom CSS snippet has a 'name' attribute the same as the path - something like `http://example.org/sites/default/files/civicrm/css/custom.css?r=sdEtX`

After
----------------------------------------
In the resources bundle, the custom CSS snippet has a 'name' attribute of 'civicrm:css/custom.css'. This enables implementations of `hook_civicrm_alterBundle()` to target the custom css file reliably.

Technical Details
----------------------------------------
Nothing

Comments
----------------------------------------
This should not result in any changes other than implementations of `hook_civicrm_alterBundle()`
Has a test.
