### PR TITLE
Afform drag n drop fixes

### DIFF
--- a/ext/afform/admin/ang/afGuiEditor.css
+++ b/ext/afform/admin/ang/afGuiEditor.css
@@ -1,14 +1,11 @@
 #afGuiEditor #afGuiEditor-palette {
   margin-right: 5px;
+  height: 100%;
 }
 
 #afGuiEditor #afGuiEditor-canvas {
   margin-left: 5px;
-}
-
-#afGuiEditor .panel-body {
-  padding: 5px 12px;
-  position: relative;
+  height: 100%;
 }
 
 #afGuiEditor fieldset legend {
@@ -26,13 +23,39 @@
   margin-bottom: 10px;
 }
 
-#afGuiEditor #afGuiEditor-palette-tabs li {
+#afGuiEditor .panel {
+  height: 100%;
+}
+#afGuiEditor .panel-heading {
+  height: 44px;
+  padding: 10px;
+}
+#afGuiEditor .panel-heading ul.nav-tabs {
+  border-bottom: 0 none;
+}
+#afGuiEditor .panel-heading ul.nav-tabs li {
   top: 1px;
 }
-
-#afGuiEditor #afGuiEditor-palette-tabs li > a {
-  padding: 10px 15px;
+#afGuiEditor .panel-heading ul.nav-tabs li.fluid-width-tab {
+  white-space: nowrap;
+  overflow: hidden;
+}
+#afGuiEditor .panel-heading ul.nav-tabs li.active {
+  max-width: 50%;
+}
+#afGuiEditor .panel-heading ul.nav-tabs li > a {
+  padding: 5px 3px 5px 8px;
+  height: 33px;
   font-size: 12px;
+  margin: 0;
+}
+
+#afGuiEditor .panel-body {
+  padding: 5px 12px;
+  position: relative;
+  height: calc(100% - 44px);
+  overflow-y: scroll;
+  overflow-x: hidden;
 }
 
 #afGuiEditor .af-gui-columns {
@@ -49,7 +72,7 @@
 }
 
 #afGuiEditor .crm-editable-enabled,
-#afGuiEditor-palette-tabs > li > a > span {
+#afGuiEditor .panel-heading ul.nav-tabs li > a > span {
   display: inline-block;
   padding: 0 4px !important;
   border: 2px solid transparent !important;
@@ -112,7 +135,7 @@
   left: 0;
   padding-left: 15px;
 }
-#afGuiEditor:not(.af-gui-dragging) #afGuiEditor-canvas:hover .af-gui-bar {
+#afGuiEditor:not(.af-gui-dragging *) #afGuiEditor-canvas:hover .af-gui-bar {
   opacity: 1;
   transition: opacity .2s;
 }
@@ -120,6 +143,16 @@
   background-color: #d7e6ff;
   opacity: 1;
   transition: opacity .1s;
+}
+
+/* Disable menu while dragging */
+body.af-gui-dragging #civicrm-menu {
+  pointer-events: none;
+}
+/* Disable scrollbars while dragging */
+body.af-gui-dragging {
+  overflow-x: hidden;
+  overflow-y: hidden;
 }
 
 #afGuiEditor .af-gui-bar .btn.active {
@@ -143,6 +176,8 @@
   padding: 22px 3px 3px;
   min-height: 40px;
   display: block;
+  margin-bottom: 10px;
+  margin-top: 10px;
 }
 
 #afGuiEditor af-gui-markup,
@@ -160,10 +195,12 @@
 
 #afGuiEditor .af-gui-container-type-fieldset {
   box-shadow: 0 0 5px #bbbbbb;
+  margin-top: 20px;
+  margin-bottom: 20px;
 }
 
 #afGuiEditor .af-gui-container:hover,
-#afGuiEditor.af-gui-dragging .af-gui-container {
+.af-gui-dragging #afGuiEditor .af-gui-container {
   border: 2px dashed #757575;
 }
 #afGuiEditor .af-gui-container.af-gui-dragtarget {
@@ -215,6 +252,20 @@
 #afGuiEditor [ui-sortable] {
   min-height: 60px;
   margin-top: 10px;
+}
+
+#afGuiEditor .ui-sortable-helper {
+  height: 20px !important;
+  opacity: .5;
+  overflow: visible;
+}
+#afGuiEditor .ui-sortable-helper > * {
+  background-color: #d5d5d5;
+}
+#afGuiEditor .ui-sortable-helper .af-gui-palette-item {
+  height: 30px;
+  width: 300px;
+  border: 2px dashed #0071bd;
 }
 
 #afGuiEditor .af-gui-entity-palette-select-list {

--- a/ext/afform/admin/ang/afGuiEditor.css
+++ b/ext/afform/admin/ang/afGuiEditor.css
@@ -175,11 +175,11 @@ body.af-gui-dragging {
   position: relative;
   padding: 22px 3px 3px;
   min-height: 40px;
-  display: block;
   margin-bottom: 10px;
   margin-top: 10px;
 }
 
+#afGuiEditor af-gui-container,
 #afGuiEditor af-gui-markup,
 #afGuiEditor af-gui-field,
 #afGuiEditor af-gui-edit-options {

--- a/ext/afform/admin/ang/afGuiEditor.js
+++ b/ext/afform/admin/ang/afGuiEditor.js
@@ -190,10 +190,10 @@
         $(this).removeClass('af-gui-dragtarget');
       })
       .on('sortstart', '#afGuiEditor', function() {
-        $('#afGuiEditor').addClass('af-gui-dragging');
+        $('body').addClass('af-gui-dragging');
       })
       .on('sortstop', function() {
-        $('.af-gui-dragging').removeClass('af-gui-dragging');
+        $('body').removeClass('af-gui-dragging');
         $('.af-gui-dragtarget').removeClass('af-gui-dragtarget');
       });
   });

--- a/ext/afform/admin/ang/afGuiEditor/afGuiEditor.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiEditor.component.js
@@ -151,6 +151,9 @@
           delete $scope.entities[type + num].loading;
           if (selectTab) {
             editor.selectEntity(type + num);
+            $timeout(function() {
+              editor.scrollToEntity(type + num);
+            });
           }
           $timeout(editor.adjustTabWidths);
         }
@@ -186,6 +189,18 @@
 
       this.getSelectedEntityName = function() {
         return $scope.selectedEntityName;
+      };
+
+      // Scroll an entity's first fieldset into view of the canvas
+      this.scrollToEntity = function(entityName) {
+        var $canvas = $('#afGuiEditor-canvas-body'),
+          $entity = $('.af-gui-container-type-fieldset[data-entity="' + entityName + '"]').first(),
+          // Scrolltop value needed to place entity's fieldset at top of canvas
+          scrollValue = $canvas.scrollTop() + ($entity.offset().top - $canvas.offset().top),
+          // Maximum possible scrollTop (height minus contents height, adjusting for padding)
+          maxScroll = $('#afGuiEditor-canvas-body > *').height() - $canvas.height() + 20;
+        // Exceeding the maximum scrollTop breaks the animation so keep it under the limit
+        $canvas.animate({scrollTop: scrollValue > maxScroll ? maxScroll : scrollValue}, 500);
       };
 
       this.getAfform = function() {

--- a/ext/afform/admin/ang/afGuiEditor/afGuiEditorCanvas.html
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiEditorCanvas.html
@@ -21,11 +21,13 @@
     <ul class="nav nav-tabs">
       <li role="presentation" ng-class="{active: canvasTab === 'layout'}">
         <a href ng-click="canvasTab = 'layout'">
+          <i class="crm-i fa-list-alt"></i>
           <span>{{:: ts('Form Layout') }}</span>
         </a>
       </li>
       <li role="presentation" ng-class="{active: canvasTab === 'markup'}">
         <a href ng-click="canvasTab = 'markup'; updateLayoutHtml()">
+          <i class="crm-i fa-code"></i>
           <span>{{:: ts('Markup') }}</span>
         </a>
       </li>

--- a/ext/afform/admin/ang/afGuiEditor/afGuiEditorPalette.html
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiEditorPalette.html
@@ -1,27 +1,31 @@
 <div id="afGuiEditor-palette-config" class="panel panel-default">
-    <ul id="afGuiEditor-palette-tabs" class="panel-heading nav nav-tabs">
-      <li role="presentation" ng-class="{active: selectedEntityName === null}">
+  <div class="panel-heading">
+    <ul id="afGuiEditor-palette-tabs" class="nav nav-tabs">
+      <li role="presentation" class="fluid-width-tab" ng-class="{active: selectedEntityName === null}" title="{{:: ts('Form Settings') }}">
         <a href ng-click="editor.selectEntity(null)">
+          <i class="crm-i fa-gear"></i>
           <span>{{:: ts('Form Settings') }}</span>
         </a>
       </li>
-      <li role="presentation" ng-repeat="entity in entities" ng-class="{active: selectedEntityName === entity.name}">
+      <li role="presentation" ng-repeat="entity in entities" class="fluid-width-tab" ng-class="{active: selectedEntityName === entity.name}" title="{{ entity.label }}">
         <a href ng-click="editor.selectEntity(entity.name)">
-          <span ng-if="!entity.loading && editor.allowEntityConfig" crm-ui-editable ng-model="entity.label">{{ entity.label }}</span>
-          <span ng-if="!entity.loading && !editor.allowEntityConfig">{{ entity.label }}</span>
+          <i class="crm-i {{:: editor.meta.entities[entity.type].icon }}"></i>
+          <span ng-if="!entity.loading && editor.allowEntityConfig && selectedEntityName === entity.name" crm-ui-editable ng-model="entity.label" ng-change="editor.adjustTabWidths()">{{ entity.label }}</span>
+          <span ng-if="!entity.loading && !(editor.allowEntityConfig && selectedEntityName === entity.name)">{{ entity.label }}</span>
           <i ng-if="entity.loading" class="crm-i fa-spin fa-spinner"></i>
         </a>
       </li>
-      <li role="presentation" ng-repeat="(key, searchDisplay) in editor.meta.searchDisplays" ng-class="{active: selectedEntityName === key}">
+      <li role="presentation" ng-repeat="(key, searchDisplay) in editor.meta.searchDisplays" class="fluid-width-tab" ng-class="{active: selectedEntityName === key}" title="{{ searchDisplay.label }}">
         <a href ng-click="editor.selectEntity(key)">
+          <i class="crm-i {{:: searchDisplay['type:icon'] }}"></i>
           <span>{{ searchDisplay.label }}</span>
         </a>
       </li>
-      <li role="presentation" class="dropdown" ng-if="editor.allowEntityConfig">
-        <a href class="dropdown-toggle" data-toggle="dropdown" title="{{ ts('Add Entity') }}">
-          <span><i class="crm-i fa-plus"></i></span>
+      <li role="presentation" class="dropdown" ng-if="editor.allowEntityConfig" title="{{:: ts('Add Entity') }}">
+        <a href class="dropdown-toggle" data-toggle="dropdown">
+          <i class="crm-i fa-plus"></i>
         </a>
-        <ul class="dropdown-menu">
+        <ul class="dropdown-menu dropdown-menu-right">
           <li ng-repeat="(entityName, entity) in editor.meta.entities" ng-if="entity.defaults">
             <a href ng-click="editor.addEntity(entityName, true)">
               <i class="crm-i {{:: entity.icon }}"></i>
@@ -31,6 +35,7 @@
         </ul>
       </li>
     </ul>
+  </div>
   <div class="panel-body" ng-include="'~/afGuiEditor/config-form.html'" ng-if="selectedEntityName === null"></div>
   <div class="panel-body" ng-repeat="entity in entities" ng-if="selectedEntityName === entity.name">
     <af-gui-entity entity="entity"></af-gui-entity>

--- a/ext/afform/admin/ang/afGuiEditor/afGuiEditorPalette.html
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiEditorPalette.html
@@ -8,7 +8,7 @@
         </a>
       </li>
       <li role="presentation" ng-repeat="entity in entities" class="fluid-width-tab" ng-class="{active: selectedEntityName === entity.name}" title="{{ entity.label }}">
-        <a href ng-click="editor.selectEntity(entity.name)">
+        <a href ng-click="editor.selectEntity(entity.name); editor.scrollToEntity(entity.name);">
           <i class="crm-i {{:: editor.meta.entities[entity.type].icon }}"></i>
           <span ng-if="!entity.loading && editor.allowEntityConfig && selectedEntityName === entity.name" crm-ui-editable ng-model="entity.label" ng-change="editor.adjustTabWidths()">{{ entity.label }}</span>
           <span ng-if="!entity.loading && !(editor.allowEntityConfig && selectedEntityName === entity.name)">{{ entity.label }}</span>

--- a/ext/afform/admin/ang/afGuiEditor/afGuiEntity.html
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiEntity.html
@@ -22,26 +22,26 @@
     <div class="af-gui-entity-palette-select-list">
       <div ng-if="elementList.length">
         <label>{{:: ts('Elements') }}</label>
-        <div ui-sortable="{update: buildPaletteLists, items: '&gt; div:not(.disabled)', connectWith: '[ui-sortable]', placeholder: 'af-gui-dropzone'}" ui-sortable-update="$ctrl.editor.onDrop" ng-model="elementList">
+        <div ui-sortable="$ctrl.editor.getSortableOptions()" ui-sortable-update="buildPaletteLists" ng-model="elementList">
           <div ng-repeat="element in elementList" >
-            {{:: elementTitles[$index] }}
+            <div class="af-gui-palette-item">{{:: elementTitles[$index] }}</div>
           </div>
         </div>
       </div>
       <div ng-if="blockList.length">
         <label>{{:: ts('Blocks') }}</label>
-        <div ui-sortable="{update: buildPaletteLists, items: '&gt; div:not(.disabled)', connectWith: '[data-entity=\'' + $ctrl.entity.name + '\'] &gt; [ui-sortable]', placeholder: 'af-gui-dropzone'}" ui-sortable-update="$ctrl.editor.onDrop" ng-model="blockList">
+        <div ui-sortable="$ctrl.editor.getSortableOptions($ctrl.entity.name)" ui-sortable-update="buildPaletteLists" ng-model="blockList">
           <div ng-repeat="block in blockList" ng-class="{disabled: blockInUse(block)}">
-            {{:: blockTitles[$index] }}
+            <div class="af-gui-palette-item">{{:: blockTitles[$index] }}</div>
           </div>
         </div>
       </div>
       <div ng-repeat="fieldGroup in fieldList">
         <div ng-if="fieldGroup.fields.length">
           <label>{{ fieldGroup.label }}</label>
-          <div ui-sortable="{update: buildPaletteLists, items: '&gt; div:not(.disabled)', connectWith: '[data-entity=\'' + fieldGroup.entityName + '\'] &gt; [ui-sortable]', placeholder: 'af-gui-dropzone'}" ui-sortable-update="$ctrl.editor.onDrop" ng-model="fieldGroup.fields">
+          <div ui-sortable="$ctrl.editor.getSortableOptions(fieldGroup.entityName)" ui-sortable-update="buildPaletteLists" ng-model="fieldGroup.fields">
             <div ng-repeat="field in fieldGroup.fields" ng-class="{disabled: fieldInUse(field.name)}">
-              {{:: getField(fieldGroup.entityType, field.name).label }}
+              <div class="af-gui-palette-item">{{:: getField(fieldGroup.entityType, field.name).label }}</div>
             </div>
           </div>
         </div>

--- a/ext/afform/admin/ang/afGuiEditor/afGuiSearch.html
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiSearch.html
@@ -7,25 +7,25 @@
     <div class="af-gui-entity-palette-select-list">
       <div ng-if="elementList.length">
         <label>{{:: ts('Elements') }}</label>
-        <div ui-sortable="{update: buildPaletteLists, items: '&gt; div:not(.disabled)', connectWith: '[ui-sortable]', placeholder: 'af-gui-dropzone'}" ui-sortable-update="$ctrl.editor.onDrop" ng-model="elementList">
+        <div ui-sortable="$ctrl.editor.getSortableOptions()" ui-sortable-update="buildPaletteLists" ng-model="elementList">
           <div ng-repeat="element in elementList" >
-            {{:: elementTitles[$index] }}
+            <div class="af-gui-palette-item">{{:: elementTitles[$index] }}</div>
           </div>
         </div>
       </div>
       <div ng-if="blockList.length">
         <label>{{:: ts('Blocks') }}</label>
-        <div ui-sortable="{update: buildPaletteLists, items: '&gt; div:not(.disabled)', connectWith: '[ui-sortable]', placeholder: 'af-gui-dropzone'}" ui-sortable-update="$ctrl.editor.onDrop" ng-model="blockList">
+        <div ui-sortable="$ctrl.editor.getSortableOptions()" ui-sortable-update="buildPaletteLists" ng-model="blockList">
           <div ng-repeat="block in blockList" ng-class="{disabled: blockInUse(block)}">
-            {{:: blockTitles[$index] }}
+            <div class="af-gui-palette-item">{{:: blockTitles[$index] }}</div>
           </div>
         </div>
       </div>
       <div ng-if="calcFieldList.length">
         <label>{{:: ts('Calculated Fields') }}</label>
-        <div ui-sortable="{update: buildPaletteLists, items: '&gt; div:not(.disabled)', connectWith: '[ui-sortable]', placeholder: 'af-gui-dropzone'}" ui-sortable-update="$ctrl.editor.onDrop" ng-model="calcFieldList">
+        <div ui-sortable="$ctrl.editor.getSortableOptions()" ui-sortable-update="buildPaletteLists" ng-model="calcFieldList">
           <div ng-repeat="field in calcFieldList" ng-class="{disabled: fieldInUse(field.name)}">
-            {{:: field.defn.label }}
+            <div class="af-gui-palette-item">{{:: field.defn.label }}></div>
           </div>
         </div>
       </div>

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiContainer.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiContainer.component.js
@@ -43,6 +43,8 @@
         connectWith: '[ui-sortable]',
         cancel: 'input,textarea,button,select,option,a,.dropdown-menu',
         placeholder: 'af-gui-dropzone',
+        tolerance: 'pointer',
+        scrollSpeed: 8,
         containment: '#afGuiEditor-canvas-body'
       };
 


### PR DESCRIPTION
Overview
----------------------------------------
This makes a number of adjustments to make the Afform GUI easier to use.

Before
----------------------------------------
- Drag-n-drop was a real drag, large elements couldn't be moved to top or bottom of form
- Long forms could scroll out-of-view of the palette, making it impossible to drag in new fields
- Tabs along top of palette would take up too much space

After
----------------------------------------
Improved dropzones, fixed scrolling while dragging, force palette & canvas to use full screen height, compress tabs to save space.
