### PR TITLE
Afform - hide disabled contact types & entities from disabled components/extensions

### DIFF
--- a/ext/afform/admin/afformEntities/Activity.php
+++ b/ext/afform/admin/afformEntities/Activity.php
@@ -1,6 +1,5 @@
 <?php
 return [
-  'entity' => 'Activity',
   'defaults' => "{'url-autofill': '1'}",
   'boilerplate' => [
     ['#tag' => 'af-field', 'name' => 'subject'],

--- a/ext/afform/admin/afformEntities/Household.php
+++ b/ext/afform/admin/afformEntities/Household.php
@@ -1,7 +1,5 @@
 <?php
 return [
-  'entity' => 'Contact',
-  'contact_type' => 'Household',
   'defaults' => "{
     data: {
       contact_type: 'Household',

--- a/ext/afform/admin/afformEntities/Individual.php
+++ b/ext/afform/admin/afformEntities/Individual.php
@@ -1,7 +1,5 @@
 <?php
 return [
-  'entity' => 'Contact',
-  'contact_type' => 'Individual',
   'defaults' => "{
     data: {
       contact_type: 'Individual',

--- a/ext/afform/admin/afformEntities/Organization.php
+++ b/ext/afform/admin/afformEntities/Organization.php
@@ -1,7 +1,5 @@
 <?php
 return [
-  'entity' => 'Contact',
-  'contact_type' => 'Organization',
   'defaults' => "{
     data: {
       contact_type: 'Organization',


### PR DESCRIPTION
Overview
----------------------------------------
This cleans up and improves Afform's internal entity lookup so it won't show disabled entities.

Before
----------------------------------------
If Households are disabled, they still appear as Afform entities.
If CiviCase is disabled, it appears but with no label or icon (pending addition of Cases to Afform in a separate PR)

After
----------------------------------------
Entities from disabled contact types, extensions and components are hidden from the Afform UI.