### PR TITLE
Fix CKEditor5 link editing in modal dialog

### DIFF
--- a/js/Common.js
+++ b/js/Common.js
@@ -185,7 +185,7 @@ if (!CRM.vars) CRM.vars = {};
 
   // Workaround for https://github.com/ivaynberg/select2/issues/1246
   $.ui.dialog.prototype._allowInteraction = function(e) {
-    return !!$(e.target).closest('.ui-dialog, .ui-datepicker, .select2-drop, .cke_dialog, #civicrm-menu').length;
+    return !!$(e.target).closest('.ui-dialog, .ui-datepicker, .select2-drop, .cke_dialog, .ck-balloon-panel, #civicrm-menu').length;
   };
 
   // Implements jQuery hook.prop


### PR DESCRIPTION
Overview
----------------------------------------
Fixes https://lab.civicrm.org/extensions/ckeditor5/-/issues/4

Before
----------------------------------------
Editing links broken for wysiwyg within popup dialog.

After
----------------------------------------
Fixed.

Technical Details
------------
See https://api.jqueryui.com/dialog/#method-_allowInteraction