### PR TITLE
Switch to non deprecated buildPermissionClause() for contact summary report

### DIFF
--- a/CRM/Report/Form/Contact/Summary.php
+++ b/CRM/Report/Form/Contact/Summary.php
@@ -147,17 +147,10 @@ class CRM_Report_Form_Contact_Summary extends CRM_Report_Form {
   }
 
   public function postProcess() {
-
     $this->beginPostProcess();
-
-    // get the acl clauses built before we assemble the query
-    $this->buildACLClause($this->_aliases['civicrm_contact']);
-
     $sql = $this->buildQuery(TRUE);
-
-    $rows = $graphRows = [];
+    $rows = [];
     $this->buildRows($sql, $rows);
-
     $this->formatDisplay($rows);
     $this->doTemplateAssignment($rows);
     $this->endPostProcess($rows);


### PR DESCRIPTION
Overview
----------------------------------------
Swap deprecated `buildACLClause()` for non-deprecated `buildPermissionClause()`.  On a site using ACLs restricted users were seeing multiple duplicates when refreshing the report - this was caused by the INNER JOIN on the `civicrm_acl_contact_cache` that was being added and is not required.

Before
----------------------------------------
Duplicates for users using ACLs when refreshing the report.

After
----------------------------------------
No duplicates.

Technical Details
----------------------------------------
Described above.

Comments
----------------------------------------

