### PR TITLE
Deprecate passing contribution_status_id to Membership::create

### DIFF
--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -345,6 +345,7 @@ class CRM_Member_BAO_Membership extends CRM_Member_DAO_Membership {
     // Record contribution for this membership and create a MembershipPayment
     // @todo deprecate this.
     if (!empty($params['contribution_status_id'])) {
+      CRM_Core_Error::deprecatedWarning('Use the order api');
       $memInfo = array_merge($params, ['membership_id' => $membership->id]);
       $params['contribution'] = self::recordMembershipContribution($memInfo);
     }


### PR DESCRIPTION
Overview
----------------------------------------
Deprecate passing contribution_status_id to Membership::create

Before
----------------------------------------
Bad practice acted on quietly

After
----------------------------------------
Bad practice acted on noisily

Technical Details
----------------------------------------
I'm fully expecting some test fails first round

Comments
----------------------------------------
