### PR TITLE
Add in Money Service to Civi Facade and clean up Money classes

### DIFF
--- a/CRM/Utils/Number.php
+++ b/CRM/Utils/Number.php
@@ -117,10 +117,7 @@ class CRM_Utils_Number {
    * @throws \Brick\Money\Exception\UnknownCurrencyException
    */
   public static function formatLocaleNumeric(string $amount, $locale = NULL): string {
-    $formatter = new \NumberFormatter($locale ?? CRM_Core_I18n::getLocale(), NumberFormatter::DECIMAL);
-    $formatter->setSymbol(\NumberFormatter::DECIMAL_SEPARATOR_SYMBOL, CRM_Core_Config::singleton()->monetaryDecimalPoint);
-    $formatter->setSymbol(\NumberFormatter::GROUPING_SEPARATOR_SYMBOL, CRM_Core_Config::singleton()->monetaryThousandSeparator);
-    return $formatter->format($amount);
+    return CRM_Utils_Money::formatLocaleNumericRoundedByOptionalPrecision($amount, 9, $locale);
   }
 
 }

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -212,6 +212,11 @@ class Container {
       []
     ))->setPublic(TRUE);
 
+    $container->setDefinition('money', new Definition(
+      '\Civi\Core\Money',
+      [],
+    ))->setPublic(TRUE);
+
     $container->setDefinition('bundle.bootstrap3', new Definition('CRM_Core_Resources_Bundle', ['bootstrap3']))
       ->setFactory('CRM_Core_Resources_Common::createBootstrap3Bundle')->setPublic(TRUE);
 

--- a/Civi/Core/Money.php
+++ b/Civi/Core/Money.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+ namespace Civi\Core;
+
+class Money {
+
+  /**
+   * Get Machine version of Money (en_US locale version used for storing in the database)
+   * @param string $inputMoney
+   * @param int $number_of_palaces = optional number of decimals to return.
+   */
+  public function getMachineMoney(string $inputMoney, int $number_of_palaces = 2): string {
+    return \CRM_Utils_Money::formatUSLocaleNumericRounded($inputMoney, $number_of_palaces);
+  }
+
+  /**
+   * Get Locale version of money
+   * @param string $inputMoney
+   * @param string|null $currency
+   */
+  public function getLocaleFormattedMoney(string $inputMoney, ?string $currency): string {
+    return \CRM_Utils_Money::formatLocaleNumericRoundedByCurrency($inputMoney, $currency);
+  }
+
+}

--- a/tests/phpunit/Civi/Core/MoneyTest.php
+++ b/tests/phpunit/Civi/Core/MoneyTest.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Core;
+
+/**
+ * Class MoneyTest
+ * @package Civi\Core
+ * @group headless
+ */
+class MoneyTest extends \CiviUnitTestCase {
+
+  /**
+   * Money Format cases.
+   */
+  public function machineMoneyTestCases() {
+    $cases = [];
+    $cases[] = ['1234.56', 2, '1,234.56'];
+    $cases[] = ['1234.56', 2, '1,234.56'];
+    $cases[] = ['1234.56789', 2, '1,234.57'];
+    return $cases;
+  }
+
+  /**
+   * @dataProvider machineMoneyTestCases
+   */
+  public function testMachineMoney($inputAmount, $precision, $expectedAmount) {
+    $this->assertEquals($expectedAmount, \Civi::service('money')->getMachineMoney($inputAmount, $precision));
+  }
+
+  /**
+   * Money Locale Format Cases
+   */
+  public function localeMoneyTestCases() {
+    $cases = [];
+    $cases[] = ['1234.56', '.', '1,234.56'];
+    $cases[] = ['1234.56', '.', '1,234.56'];
+    $cases[] = ['1234.56789', '.', '1,234.57'];
+    $cases[] = ['1234.56', ',', '1.234,56'];
+    $cases[] = ['1234.56', ',', '1.234,56'];
+    $cases[] = ['1234.56789', ',', '1.234,57'];
+    return $cases;
+  }
+
+  /**
+   * @dataProvider localeMoneyTestCases
+   */
+  public function testLocaleFormatMoney($inputAmount, $decimalSeparator, $expectedAmount) {
+    if ($decimalSeparator !== '.') {
+      \Civi::settings()->set('monetaryDecimalPoint', $decimalSeparator);
+      \Civi::settings()->set('monetaryThousandSeparator', '.');
+    }
+    $this->assertEquals($expectedAmount, \Civi::service('money')->getLocaleFormattedMoney($inputAmount, 'EUR'));
+    if ($decimalSeparator !== '.') {
+      \Civi::settings()->set('monetaryDecimalPoint', '.');
+      \Civi::settings()->set('monetaryThousandSeparator', ',');
+    }
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
This came up in a recent discussion I was having with EIleen and we figured a better way than just using the CRM_Utils_Money class was if we had an actual Civi Facade for our money formatting. This starts by adding in a function to get the machine formatted money and also locale formatted money. 

This also makes use of @jaapjansma 's use of the DECIMAL_SEPARATOR_SYMBOL and GROUPING_SEPARATOR_SYMBOL in the custom number formatter but moves it into a standardised world. 

Before
----------------------------------------
No Civi Facade for Money formatting

After
----------------------------------------
Civi Facade for money formatting

ping @eileenmcnaughton @totten @mattwire @jitendrapurohit 