### PR TITLE
Fix report buildContactCache to refresh parent groups

### DIFF
--- a/CRM/Contact/BAO/GroupContactCache.php
+++ b/CRM/Contact/BAO/GroupContactCache.php
@@ -731,6 +731,43 @@ AND  civicrm_group_contact.group_id = $groupID ";
   }
 
   /**
+   * Populate a temporary table with group ids and contact ids.
+   *
+   * Do not call this outside of core tested code - it WILL change.
+   *
+   * @param array[int] $groupIDs
+   * @param string $temporaryTable
+   *
+   * @throws \CiviCRM_API3_Exception
+   */
+  public static function populateTemporaryTableWithContactsInGroups(array $groupIDs, string $temporaryTable): void {
+    $groups = civicrm_api3('Group', 'get', [
+      'is_active' => 1,
+      'id' => ['IN' => $groupIDs],
+      'saved_search_id' => ['>' => 0],
+      'return' => 'id',
+    ]);
+    $smartGroups = array_keys($groups['values']);
+
+    $query = "
+       SELECT DISTINCT group_contact.contact_id as contact_id, group_id
+       FROM civicrm_group_contact group_contact
+       WHERE group_contact.group_id IN (" . implode(', ', $groupIDs) . ")
+       AND group_contact.status = 'Added' ";
+
+    if (!empty($smartGroups)) {
+      CRM_Contact_BAO_GroupContactCache::check($smartGroups);
+      $smartGroups = implode(',', $smartGroups);
+      $query .= "
+        UNION DISTINCT
+        SELECT smartgroup_contact.contact_id as contact_id, group_id
+        FROM civicrm_group_contact_cache smartgroup_contact
+        WHERE smartgroup_contact.group_id IN ({$smartGroups}) ";
+    }
+    CRM_Core_DAO::executeQuery('INSERT INTO ' . $temporaryTable . ' ' . $query);
+  }
+
+  /**
    * @param array|null $groupIDs
    * @param int $limit
    *

--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -657,7 +657,7 @@ class CRM_Report_Form extends CRM_Core_Form {
       $this->assign('mode', 'instance');
     }
     elseif (!$this->noController) {
-      list($optionValueID, $optionValue) = CRM_Report_Utils_Report::getValueIDFromUrl();
+      [$optionValueID, $optionValue] = CRM_Report_Utils_Report::getValueIDFromUrl();
       $instanceCount = CRM_Report_Utils_Report::getInstanceCount($optionValue);
       if (($instanceCount > 0) && $optionValueID) {
         $this->assign('instanceUrl',
@@ -3745,6 +3745,8 @@ WHERE cg.extends IN ('" . implode("','", $this->_customGroupExtends) . "') AND
    *
    * This function is called by both the api (tests) and the UI.
    *
+   * @throws \API_Exception
+   * @throws \CRM_Core_Exception
    * @throws \CiviCRM_API3_Exception
    */
   public function buildGroupTempTable(): void {

--- a/tests/phpunit/api/v3/ReportTemplateTest.php
+++ b/tests/phpunit/api/v3/ReportTemplateTest.php
@@ -546,7 +546,7 @@ class api_v3_ReportTemplateTest extends CiviUnitTestCase {
    *
    * @throws \CRM_Core_Exception
    */
-  public function testContributionSummaryWithSmartGroupFilter($template) {
+  public function testContributionSummaryWithSmartGroupFilter(string $template): void {
     $groupID = $this->setUpPopulatedSmartGroup();
     $rows = $this->callAPISuccess('report_template', 'getrows', [
       'report_id' => $template,
@@ -805,7 +805,7 @@ class api_v3_ReportTemplateTest extends CiviUnitTestCase {
    * @throws \CRM_Core_Exception
    */
   public function testContributionSummaryWithSingleContactsInTwoGroups() {
-    list($groupID1, $individualID) = $this->setUpPopulatedGroup(TRUE);
+    [$groupID1, $individualID] = $this->setUpPopulatedGroup(TRUE);
     // create second group and add the individual to it.
     $groupID2 = $this->groupCreate(['name' => 'test_group', 'title' => 'test_title']);
     $this->callAPISuccess('GroupContact', 'create', [


### PR DESCRIPTION
Overview
----------------------------------------
Fix report buildContactCache to refresh parent groups …

Before
----------------------------------------
group contact cache rebuilt for smart groups but not those with children

After
----------------------------------------
Both refreshed

Technical Details
----------------------------------------
 The fix also causes it to call load() on each group directly.
    Previously it was calling check which calls loadAll
    which calls add() which calls the v3 contact api
    which calls the query object, which calls load()
    on each group



Comments
----------------------------------------
build on #20297