### PR TITLE
(dev/release#17) Extension UI - Show developmental icon for alpha/beta-stage extensions

### DIFF
--- a/css/admin.css
+++ b/css/admin.css
@@ -44,15 +44,18 @@
   text-align: center;
 }
 
-#crm-container .crm-extensions-stage {
-  float: right;
+.crm-container .crm-extensions-version {
+  white-space: nowrap;
+}
+.crm-container .crm-extensions-stage {
+  margin-left: 5px;
 }
 
-#crm-container .crm-extensions-stage > .fa-flask {
+.crm-container .crm-extensions-stage.fa-flask {
   color: #eba12d;
 }
 
-#crm-container .crm-extensions-stage > .fa-check-circle {
+.crm-container .crm-extensions-stage.fa-check-circle {
   color: #00994D;
 }
 

--- a/css/admin.css
+++ b/css/admin.css
@@ -44,6 +44,18 @@
   text-align: center;
 }
 
+#crm-container .crm-extensions-stage {
+  float: right;
+}
+
+#crm-container .crm-extensions-stage > .fa-flask {
+  color: #eba12d;
+}
+
+#crm-container .crm-extensions-stage > .fa-check-circle {
+  color: #00994D;
+}
+
 @media screen and (min-width: 480px) {
   #crm-container .admin-section-items {
     column-count: 2;

--- a/templates/CRM/Admin/Page/Extensions/AddNew.tpl
+++ b/templates/CRM/Admin/Page/Extensions/AddNew.tpl
@@ -24,7 +24,7 @@ Depends: CRM/common/enableDisableApi.tpl and CRM/common/jsortable.tpl
           <td class="crm-extensions-label">
               <a class="collapsed" href="#"></a>&nbsp;<strong>{$row.label}</strong><br/>({$row.key})
           </td>
-          <td class="crm-extensions-label">{$row.version}</td>
+          <td class="crm-extensions-version">{$row.version|escape}</td>
           <td class="crm-extensions-description">{$row.type|capitalize}</td>
           <td>{$row.action|replace:'xx':$row.id}</td>
         </tr>

--- a/templates/CRM/Admin/Page/Extensions/AddNew.tpl
+++ b/templates/CRM/Admin/Page/Extensions/AddNew.tpl
@@ -24,7 +24,7 @@ Depends: CRM/common/enableDisableApi.tpl and CRM/common/jsortable.tpl
           <td class="crm-extensions-label">
               <a class="collapsed" href="#"></a>&nbsp;<strong>{$row.label}</strong><br/>({$row.key})
           </td>
-          <td class="crm-extensions-label">{$row.version} {if $row.upgradable}<br/>({$row.upgradeVersion}){/if}</td>
+          <td class="crm-extensions-label">{$row.version}</td>
           <td class="crm-extensions-description">{$row.type|capitalize}</td>
           <td>{$row.action|replace:'xx':$row.id}</td>
         </tr>

--- a/templates/CRM/Admin/Page/Extensions/Main.tpl
+++ b/templates/CRM/Admin/Page/Extensions/Main.tpl
@@ -26,12 +26,12 @@ Depends: CRM/common/enableDisableApi.tpl and CRM/common/jsortable.tpl
                 <div class="crm-extensions-upgrade">{$remoteExtensionRows[$extKey].upgradelink}</div>
               {/if}
           </td>
-          <td class="crm-extensions-label">{$row.statusLabel} {if $row.upgradable}<br/>({ts}Outdated{/ts}){/if}</td>
-          <td class="crm-extensions-label">{$row.version|escape}
+          <td class="crm-extensions-status">{$row.statusLabel} {if $row.upgradable}<br/>({ts}Outdated{/ts}){/if}</td>
+          <td class="crm-extensions-version">{$row.version|escape}
             {if ($row.develStage and $row.develStage != 'stable') or preg_match(";(alpha|beta|dev);", $row.version)}
-              <span class="crm-extensions-stage">{icon icon="fa-flask"}{ts}This is a pre-release version. For more details, see the expanded description.{/ts}{/icon}</span>
-              {else}
-              <span class="crm-extensions-stage">{icon icon="fa-check-circle"}{/icon}</span>
+              {icon icon="fa-flask crm-extensions-stage"}{ts}This is a pre-release version. For more details, see the expanded description.{/ts}{/icon}
+            {else}
+              {icon icon="fa-check-circle crm-extensions-stage"}{ts}This is a stable release version.{/ts}{/icon}
             {/if}
           </td>
           <td class="crm-extensions-description">{$row.type|escape|capitalize}</td>

--- a/templates/CRM/Admin/Page/Extensions/Main.tpl
+++ b/templates/CRM/Admin/Page/Extensions/Main.tpl
@@ -27,7 +27,13 @@ Depends: CRM/common/enableDisableApi.tpl and CRM/common/jsortable.tpl
               {/if}
           </td>
           <td class="crm-extensions-label">{$row.statusLabel} {if $row.upgradable}<br/>({ts}Outdated{/ts}){/if}</td>
-          <td class="crm-extensions-label">{$row.version|escape}</td>
+          <td class="crm-extensions-label">{$row.version|escape}
+            {if ($row.develStage and $row.develStage != 'stable') or preg_match(";(alpha|beta|dev);", $row.version)}
+              <span class="crm-extensions-stage">{icon icon="fa-flask"}{ts}This is a pre-release version. For more details, see the expanded description.{/ts}{/icon}</span>
+              {else}
+              <span class="crm-extensions-stage">{icon icon="fa-check-circle"}{/icon}</span>
+            {/if}
+          </td>
           <td class="crm-extensions-description">{$row.type|escape|capitalize}</td>
           <td>{$row.action|replace:'xx':$row.id}</td>
         </tr>

--- a/templates/CRM/Admin/Page/Extensions/Main.tpl
+++ b/templates/CRM/Admin/Page/Extensions/Main.tpl
@@ -27,7 +27,7 @@ Depends: CRM/common/enableDisableApi.tpl and CRM/common/jsortable.tpl
               {/if}
           </td>
           <td class="crm-extensions-label">{$row.statusLabel} {if $row.upgradable}<br/>({ts}Outdated{/ts}){/if}</td>
-          <td class="crm-extensions-label">{$row.version|escape} {if $row.upgradable}<br/>({$row.upgradeVersion}){/if}</td>
+          <td class="crm-extensions-label">{$row.version|escape}</td>
           <td class="crm-extensions-description">{$row.type|escape|capitalize}</td>
           <td>{$row.action|replace:'xx':$row.id}</td>
         </tr>


### PR DESCRIPTION
Overview
----------------------------------------

Each version of an extensions is published with two fields, `<version>` (e.g.  `1.1`) and `<develStage>` (e.g.  `alpha`).
Confusingly, the two fields sometimes convey redundant information - but not always. A few cases:

* (A) Sometimes a `<version>` as `1.0-alpha1`, `1.2.beta2`, or `2.3dev`. This would make sense if the
developer does formal tagging/releasing for developmental versions. (In this case, you don't really need the
icon - because the version-number tells you.)

* (B) Other times, you might have a `<version>` which simply says `1.0` or `2.0` -- and then supplemental
information where the `<develStage>` says `alpha` or `beta`.  This could make sense if the developmental
version is being continuously updated without formal tags/releases.

* (C) Under dev/release#17, we have another case -- where the core-extensions have version#s which match the
core version# (because they are released together), but the devel-stage of the extension is only
alpha/beta (because the extension is still evolving/optional/not-fully-supported).

Before
----------------------------------------

The "Development Stage" is not specifically indicated. This is OK for (A) but not (B) or (C).

<img width="1015" alt="Screen Shot 2021-05-13 at 11 12 53 PM" src="https://user-images.githubusercontent.com/1336047/118229389-c4f18000-b440-11eb-882e-7fd4ddec0ca9.png">

After
----------------------------------------

There's an icon in the table to signal the development stage. So the stage is indicated in all cases (A,B,C).

<img width="1028" alt="Screen Shot 2021-05-13 at 11 11 59 PM" src="https://user-images.githubusercontent.com/1336047/118229314-a68b8480-b440-11eb-903a-9d2455149992.png">
