### PR TITLE
dev/release#17 - Synchronize version#s for core and core-extensions

### DIFF
--- a/distmaker/core-ext.txt
+++ b/distmaker/core-ext.txt
@@ -1,0 +1,19 @@
+## This is a list of core-extensions stored in the 'ext' folder. These should be included in release
+## workflows, e.g. flagging new versions and building tarballs.
+
+## Note: This file should only be consumed internally (by release/distribution tools).
+## Future versions may change or obsolete the file without notice.
+
+afform
+authx
+contributioncancelactions
+eventcart
+ewaysingle
+financialacls
+flexmailer
+greenwich
+oauth-client
+payflowpro
+recaptcha
+search_kit
+sequentialcreditnotes

--- a/distmaker/dists/common.sh
+++ b/distmaker/dists/common.sh
@@ -118,19 +118,8 @@ function dm_install_coreext() {
 ## Get a list of default/core extension directories (space-delimited)
 ## reldirs=$(dm_core_exts)
 function dm_core_exts() {
-  echo ext/search_kit
-  echo ext/sequentialcreditnotes
-  echo ext/flexmailer
-  echo ext/eventcart
-  echo ext/ewaysingle
-  echo ext/financialacls
-  echo ext/afform
-  echo ext/authx
-  echo ext/greenwich
-  echo ext/contributioncancelactions
-  echo ext/payflowpro
-  echo ext/oauth-client
-  echo ext/recaptcha
+  ## grep to exclude comments and blank lines
+  grep '^[a-zA-Z]' "$DM_SOURCEDIR"/distmaker/core-ext.txt
 }
 
 ## Copy all packages

--- a/ext/afform/admin/info.xml
+++ b/ext/afform/admin/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2020-01-09</releaseDate>
-  <version>0.5</version>
+  <version>5.39.alpha1</version>
   <develStage>alpha</develStage>
   <compatibility>
     <ver>5.23</ver>

--- a/ext/afform/admin/info.xml
+++ b/ext/afform/admin/info.xml
@@ -28,6 +28,6 @@
     <namespace>CRM/AfformAdmin</namespace>
   </civix>
   <classloader>
-    <psr4 prefix="Civi\" path="Civi" />
+    <psr4 prefix="Civi\" path="Civi"/>
   </classloader>
 </extension>

--- a/ext/afform/core/info.xml
+++ b/ext/afform/core/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2020-01-09</releaseDate>
-  <version>0.5</version>
+  <version>5.39.alpha1</version>
   <develStage>alpha</develStage>
   <compatibility>
     <ver>5.23</ver>

--- a/ext/afform/core/info.xml
+++ b/ext/afform/core/info.xml
@@ -28,6 +28,6 @@
     <namespace>CRM/Afform</namespace>
   </civix>
   <classloader>
-    <psr4 prefix="Civi\" path="Civi" />
+    <psr4 prefix="Civi\" path="Civi"/>
   </classloader>
 </extension>

--- a/ext/afform/html/info.xml
+++ b/ext/afform/html/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2020-01-09</releaseDate>
-  <version>0.5</version>
+  <version>5.39.alpha1</version>
   <develStage>alpha</develStage>
   <compatibility>
     <ver>5.23</ver>

--- a/ext/afform/mock/info.xml
+++ b/ext/afform/mock/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2020-01-09</releaseDate>
-  <version>0.5</version>
+  <version>5.39.alpha1</version>
   <tags>
     <tag>mgmt:hidden</tag>
   </tags>

--- a/ext/authx/info.xml
+++ b/ext/authx/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2021-02-11</releaseDate>
-  <version>1.0</version>
+  <version>5.39.alpha1</version>
   <develStage>alpha</develStage>
   <compatibility>
     <ver>5.0</ver>

--- a/ext/contributioncancelactions/info.xml
+++ b/ext/contributioncancelactions/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2020-10-12</releaseDate>
-  <version>1.0</version>
+  <version>5.39.alpha1</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>5.32</ver>

--- a/ext/eventcart/info.xml
+++ b/ext/eventcart/info.xml
@@ -13,7 +13,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2020-08-03</releaseDate>
-  <version>1.0</version>
+  <version>5.39.alpha1</version>
   <tags>
     <tag>mgmt:hidden</tag>
   </tags>

--- a/ext/ewaysingle/info.xml
+++ b/ext/ewaysingle/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2020-10-07</releaseDate>
-  <version>1.0</version>
+  <version>5.39.alpha1</version>
   <tags>
     <tag>mgmt:hidden</tag>
   </tags>

--- a/ext/financialacls/info.xml
+++ b/ext/financialacls/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2020-08-27</releaseDate>
-  <version>1.0</version>
+  <version>5.39.alpha1</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>5.30</ver>

--- a/ext/flexmailer/info.xml
+++ b/ext/flexmailer/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2020-08-05</releaseDate>
-  <version>1.1.2</version>
+  <version>5.39.alpha1</version>
   <develStage>stable</develStage>
   <comments>
     FlexMailer is an email delivery engine which replaces the internal guts

--- a/ext/greenwich/info.xml
+++ b/ext/greenwich/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2020-07-21</releaseDate>
-  <version>1.0</version>
+  <version>5.39.alpha1</version>
   <tags>
     <tag>mgmt:hidden</tag>
   </tags>

--- a/ext/oauth-client/info.xml
+++ b/ext/oauth-client/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2020-10-23</releaseDate>
-  <version>1.0</version>
+  <version>5.39.alpha1</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>5.38</ver>

--- a/ext/oauth-client/info.xml
+++ b/ext/oauth-client/info.xml
@@ -25,7 +25,7 @@
   </requires>
   <comments>This extension provides a framework for oauth support</comments>
   <classloader>
-    <psr0 prefix="CRM_" path="" />
+    <psr0 prefix="CRM_" path=""/>
     <psr4 prefix="Civi\" path="Civi"/>
   </classloader>
   <upgrader>CRM_OAuth_Upgrader</upgrader>

--- a/ext/payflowpro/info.xml
+++ b/ext/payflowpro/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2021-04-13</releaseDate>
-  <version>1.0</version>
+  <version>5.39.alpha1</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>5.0</ver>

--- a/ext/recaptcha/info.xml
+++ b/ext/recaptcha/info.xml
@@ -13,7 +13,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2021-04-03</releaseDate>
-  <version>1.0</version>
+  <version>5.39.alpha1</version>
   <tags>
     <tag>mgmt:hidden</tag>
   </tags>

--- a/ext/search_kit/info.xml
+++ b/ext/search_kit/info.xml
@@ -14,7 +14,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2021-01-06</releaseDate>
-  <version>1.0.beta3</version>
+  <version>5.39.alpha1</version>
   <develStage>beta</develStage>
   <compatibility>
     <ver>5.38</ver>

--- a/ext/search_kit/info.xml
+++ b/ext/search_kit/info.xml
@@ -21,7 +21,7 @@
   </compatibility>
   <comments>This extension is still in beta. Click on the chat link above to discuss development, report problems or ask questions.</comments>
   <classloader>
-    <psr0 prefix="CRM_" path="" />
+    <psr0 prefix="CRM_" path=""/>
     <psr4 prefix="Civi\" path="Civi"/>
   </classloader>
   <upgrader>CRM_Search_Upgrader</upgrader>

--- a/ext/sequentialcreditnotes/info.xml
+++ b/ext/sequentialcreditnotes/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2020-01-28</releaseDate>
-  <version>1.0</version>
+  <version>5.39.alpha1</version>
   <tags>
     <tag>mgmt:hidden</tag>
   </tags>


### PR DESCRIPTION
Overview
----------------------------------------

This simplifies the management of version-numbers for core extensions.

See also: https://lab.civicrm.org/dev/release/-/issues/17

Before
----------------------------------------

Each core-extension has its own version-number. These are often neglected (e.g. not incremented in tandem with the main release).

After
----------------------------------------

Whenever we update the version-number for `civicrm-core`, it will also update the version-numbers for each core extension.

Comments
----------------------------------------

Some core extensions are in an alpha/beta stage. Currently, for a user who browses the list of available extensions, the "Version" column signals this. However, if the version-numbers are sync'd, then this will no longer provide that signal.

A parallel PR (#20302) updates the extension UI so that the `<develStage>` is communicated more effectively.

ping @colemanw 