### PR TITLE
get county fields populated via api call

### DIFF
--- a/api/v3/Profile.php
+++ b/api/v3/Profile.php
@@ -533,6 +533,7 @@ function _civicrm_api3_buildprofile_submitfields($profileID, $optionsBehaviour =
     $hardCodedEntityFields = [
       'state_province' => 'state_province_id',
       'country' => 'country_id',
+      'county' => 'county_id',
       'participant_status' => 'status_id',
       'gender' => 'gender_id',
       'financial_type' => 'financial_type_id',


### PR DESCRIPTION
Ensure that county fields are properly populated when
calling the Profile.getfields api.

Overview
----------------------------------------

The Profile.getfields with `api_action=submit` API helps re-use CiviCRM profiles in other contexts by providing details on all the fields in the profile. Unfortunately, county is left out! This change ensures that the county field is included.

Before
----------------------------------------
When calling the API: `Profile.getfields api_action=submit get_options=all profile_id=NNN` on a profile that includes the county field, the county field is not fully populated.

After
----------------------------------------
After this change, the county field is populated.


Comments
----------------------------------------

This is a tiny change that I hope won't have any nasty repercussions. I know that api3 is being left in the dust, but this teeny fix really helps the remoteform extension live a little longer.
