### PR TITLE
Switch to non deprecated buildPermissionClause() for contact detail report

### DIFF
--- a/CRM/Report/Form/Contact/Detail.php
+++ b/CRM/Report/Form/Contact/Detail.php
@@ -820,15 +820,10 @@ HERESQL;
   }
 
   public function postProcess() {
-
     $this->beginPostProcess();
-
-    // get the acl clauses built before we assemble the query
-    $this->buildACLClause($this->_aliases['civicrm_contact']);
-
     $sql = $this->buildQuery(TRUE);
 
-    $rows = $graphRows = $this->_contactSelected = [];
+    $rows = $this->_contactSelected = [];
     $this->buildRows($sql, $rows);
     foreach ($rows as $key => $val) {
       $rows[$key]['contactID'] = $val['civicrm_contact_id'];


### PR DESCRIPTION
Overview
----------------------------------------
This is the same change that was made for the contact summary report in #20287.

Swap deprecated `buildACLClause()` for non-deprecated `buildPermissionClause()`.

Before
----------------------------------------
Duplicates for users using ACLs when refreshing the report.

After
----------------------------------------
No duplicates.

Technical Details
----------------------------------------
Described above.

Comments
----------------------------------------

