### PR TITLE
(REF) dev/core#2571 - Add helper functions for reCAPTCHA extension

### DIFF
--- a/CRM/Campaign/Form/Petition/Signature.php
+++ b/CRM/Campaign/Form/Petition/Signature.php
@@ -152,6 +152,27 @@ class CRM_Campaign_Form_Petition_Signature extends CRM_Core_Form {
     return $session->get('userID');
   }
 
+  /**
+   * Get the active UFGroups (profiles) on this form
+   * Many forms load one or more UFGroups (profiles).
+   * This provides a standard function to retrieve the IDs of those profiles from the form
+   * so that you can implement things such as "is is_captcha field set on any of the active profiles on this form?"
+   *
+   * NOT SUPPORTED FOR USE OUTSIDE CORE EXTENSIONS - Added for reCAPTCHA core extension.
+   *
+   * @return array
+   */
+  public function getUFGroupIDs() {
+    $ufGroupIDs = [];
+    if (!empty($this->_contactProfileId)) {
+      $ufGroupIDs[] = $this->_contactProfileId;
+    }
+    if (!empty($this->_activityProfileId)) {
+      $ufGroupIDs[] = $this->_activityProfileId;
+    }
+    return $ufGroupIDs;
+  }
+
   public function preProcess() {
     $this->bao = new CRM_Campaign_BAO_Petition();
     $this->_mode = self::MODE_CREATE;

--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -42,6 +42,35 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
   protected $_snippet;
 
   /**
+   * Get the active UFGroups (profiles) on this form
+   * Many forms load one or more UFGroups (profiles).
+   * This provides a standard function to retrieve the IDs of those profiles from the form
+   * so that you can implement things such as "is is_captcha field set on any of the active profiles on this form?"
+   *
+   * NOT SUPPORTED FOR USE OUTSIDE CORE EXTENSIONS - Added for reCAPTCHA core extension.
+   *
+   * @return array
+   */
+  public function getUFGroupIDs() {
+    $ufGroupIDs = [];
+    if (!empty($this->_values['custom_pre_id'])) {
+      $ufGroupIDs[] = $this->_values['custom_pre_id'];
+    }
+    if (!empty($this->_values['custom_post_id'])) {
+      // custom_post_id can be an array (because we can have multiple for events).
+      // It is handled as array for contribution page as well though they don't support multiple profiles.
+      if (!is_array($this->_values['custom_post_id'])) {
+        $ufGroupIDs[] = $this->_values['custom_post_id'];
+      }
+      else {
+        $ufGroupIDs = array_merge($ufGroupIDs, $this->_values['custom_post_id']);
+      }
+    }
+
+    return $ufGroupIDs;
+  }
+
+  /**
    * Set variables up before form is built.
    */
   public function preProcess() {

--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -821,13 +821,6 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
   }
 
   /**
-   * Check if ReCAPTCHA has to be added on Contribution form forcefully.
-   */
-  protected function hasToAddForcefully() {
-    return CRM_Utils_ReCAPTCHA::hasToAddForcefully();
-  }
-
-  /**
    * Add onbehalf/honoree profile fields and native module fields.
    *
    * @param int $id

--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -2751,4 +2751,18 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
     return $this->exportedValues[$fieldName] ?? NULL;
   }
 
+  /**
+   * Get the active UFGroups (profiles) on this form
+   * Many forms load one or more UFGroups (profiles).
+   * This provides a standard function to retrieve the IDs of those profiles from the form
+   * so that you can implement things such as "is is_captcha field set on any of the active profiles on this form?"
+   *
+   * NOT SUPPORTED FOR USE OUTSIDE CORE EXTENSIONS - Added for reCAPTCHA core extension.
+   *
+   * @return array
+   */
+  public function getUFGroupIDs() {
+    return [];
+  }
+
 }

--- a/CRM/Event/Form/Registration/AdditionalParticipant.php
+++ b/CRM/Event/Form/Registration/AdditionalParticipant.php
@@ -28,6 +28,26 @@ class CRM_Event_Form_Registration_AdditionalParticipant extends CRM_Event_Form_R
   public $additionalParticipantId = NULL;
 
   /**
+   * Get the active UFGroups (profiles) on this form
+   * Many forms load one or more UFGroups (profiles).
+   * This provides a standard function to retrieve the IDs of those profiles from the form
+   * so that you can implement things such as "is is_captcha field set on any of the active profiles on this form?"
+   *
+   * NOT SUPPORTED FOR USE OUTSIDE CORE EXTENSIONS - Added for reCAPTCHA core extension.
+   *
+   * @return array
+   */
+  public function getUFGroupIDs() {
+    $ufGroupIDs = [];
+    foreach (['pre', 'post'] as $keys) {
+      if (isset($this->_values['additional_custom_' . $keys . '_id'])) {
+        $ufGroupIDs[] = $this->_values['additional_custom_' . $keys . '_id'];
+      }
+    }
+    return $ufGroupIDs;
+  }
+
+  /**
    * Set variables up before form is built.
    *
    * @return void

--- a/CRM/Event/Form/Registration/Register.php
+++ b/CRM/Event/Form/Registration/Register.php
@@ -129,6 +129,34 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
   }
 
   /**
+   * Get the active UFGroups (profiles) on this form
+   * Many forms load one or more UFGroups (profiles).
+   * This provides a standard function to retrieve the IDs of those profiles from the form
+   * so that you can implement things such as "is is_captcha field set on any of the active profiles on this form?"
+   *
+   * NOT SUPPORTED FOR USE OUTSIDE CORE EXTENSIONS - Added for reCAPTCHA core extension.
+   *
+   * @return array
+   */
+  public function getUFGroupIDs() {
+    $ufGroupIDs = [];
+    if (!empty($this->_values['custom_pre_id'])) {
+      $ufGroupIDs[] = $this->_values['custom_pre_id'];
+    }
+    if (!empty($this->_values['custom_post_id'])) {
+      // custom_post_id can be an array (because we can have multiple for events).
+      // It is handled as array for contribution page as well though they don't support multiple profiles.
+      if (!is_array($this->_values['custom_post_id'])) {
+        $ufGroupIDs[] = $this->_values['custom_post_id'];
+      }
+      else {
+        $ufGroupIDs = array_merge($ufGroupIDs, $this->_values['custom_post_id']);
+      }
+    }
+    return $ufGroupIDs;
+  }
+
+  /**
    * Set variables up before form is built.
    *
    * @throws \CRM_Core_Exception

--- a/CRM/PCP/Form/PCPAccount.php
+++ b/CRM/PCP/Form/PCPAccount.php
@@ -35,6 +35,24 @@ class CRM_PCP_Form_PCPAccount extends CRM_Core_Form {
    */
   public $_single;
 
+  /**
+   * Get the active UFGroups (profiles) on this form
+   * Many forms load one or more UFGroups (profiles).
+   * This provides a standard function to retrieve the IDs of those profiles from the form
+   * so that you can implement things such as "is is_captcha field set on any of the active profiles on this form?"
+   *
+   * NOT SUPPORTED FOR USE OUTSIDE CORE EXTENSIONS - Added for reCAPTCHA core extension.
+   *
+   * @return array
+   */
+  public function getUFGroupIDs() {
+    $ufGroupIDs = [];
+    if (!empty($this->_pageId)) {
+      $ufGroupIDs[] = CRM_PCP_BAO_PCP::getSupporterProfileId($this->_pageId, $this->_component);
+    }
+    return $ufGroupIDs;
+  }
+
   public function preProcess() {
     $session = CRM_Core_Session::singleton();
     $config = CRM_Core_Config::singleton();
@@ -117,21 +135,21 @@ class CRM_PCP_Form_PCPAccount extends CRM_Core_Form {
    * @return void
    */
   public function buildQuickForm() {
-    $id = CRM_PCP_BAO_PCP::getSupporterProfileId($this->_pageId, $this->_component);
-    if (CRM_PCP_BAO_PCP::checkEmailProfile($id)) {
+    $ufGroupID = CRM_PCP_BAO_PCP::getSupporterProfileId($this->_pageId, $this->_component);
+    if (CRM_PCP_BAO_PCP::checkEmailProfile($ufGroupID)) {
       $this->assign('profileDisplay', TRUE);
     }
     $fields = NULL;
     if ($this->_contactID) {
-      if (CRM_Core_BAO_UFGroup::filterUFGroups($id, $this->_contactID)) {
-        $fields = CRM_Core_BAO_UFGroup::getFields($id, FALSE, CRM_Core_Action::ADD);
+      if (CRM_Core_BAO_UFGroup::filterUFGroups($ufGroupID, $this->_contactID)) {
+        $fields = CRM_Core_BAO_UFGroup::getFields($ufGroupID, FALSE, CRM_Core_Action::ADD);
       }
       $this->addFormRule(['CRM_PCP_Form_PCPAccount', 'formRule'], $this);
     }
     else {
-      CRM_Core_BAO_CMSUser::buildForm($this, $id, TRUE);
+      CRM_Core_BAO_CMSUser::buildForm($this, $ufGroupID, TRUE);
 
-      $fields = CRM_Core_BAO_UFGroup::getFields($id, FALSE, CRM_Core_Action::ADD);
+      $fields = CRM_Core_BAO_UFGroup::getFields($ufGroupID, FALSE, CRM_Core_Action::ADD);
     }
 
     if ($fields) {

--- a/CRM/Profile/Form.php
+++ b/CRM/Profile/Form.php
@@ -271,6 +271,34 @@ class CRM_Profile_Form extends CRM_Core_Form {
   }
 
   /**
+   * Get the active UFGroups (profiles) on this form
+   * Many forms load one or more UFGroups (profiles).
+   * This provides a standard function to retrieve the IDs of those profiles from the form
+   * so that you can implement things such as "is is_captcha field set on any of the active profiles on this form?"
+   *
+   * NOT SUPPORTED FOR USE OUTSIDE CORE EXTENSIONS - Added for reCAPTCHA core extension.
+   *
+   * @return array
+   */
+  public function getUFGroupIDs() {
+    if (empty($this->_profileIds)) {
+      $dao = new CRM_Core_DAO_UFGroup();
+      $dao->id = $this->_gid;
+      $this->_profileIds = (array) $dao;
+    }
+    return $this->_profileIds;
+  }
+
+  /**
+   * Are we using the profile in create mode?
+   *
+   * @return bool
+   */
+  public function getIsCreateMode() {
+    return ($this->_mode == self::MODE_CREATE);
+  }
+
+  /**
    * Pre processing work done here.
    *
    * gets session variables for table name, id of entity in table, type of entity and stores them.


### PR DESCRIPTION
Overview
----------------------------------------
There are a few simple checks that are used (inconsistently) on each form that adds a reCAPTCHA:
1. If it has a profile (UFGroup) check if the "add_captcha" flag is set on that group (currently it does this by merging that param into each profile field and then checking that - we simplify that and check the profile directly).
2. If the user is not logged in (anonymous) show the reCAPTCHA.
3. Some pages have additional checks (eg. create mode, forceRecaptcha).

This PR does not make any functional changes. It adds the function `getUFGroupIDs()`, removes unused `hasToAddForcefully()` and adds `getIsCreateMode()` to profile form.

Before
----------------------------------------
Different method required for each form to get a list of UFGroup (profile) IDs.

After
----------------------------------------
Single function `getUFGroupIDs()` can be called on all forms that implement reCAPTCHA and use profiles.

Technical Details
----------------------------------------


Comments
----------------------------------------
You can see how this will be used here: https://github.com/civicrm/civicrm-core/commit/94366a062e24a3f8eb7b8261fc27660922321dd2