### PR TITLE
Deprecate duplicate getLoggedInContactID() function

### DIFF
--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -2243,7 +2243,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
       return (int) $tempID;
     }
 
-    $userID = $this->getLoggedInUserContactID();
+    $userID = CRM_Core_Session::getLoggedInContactID();
 
     if (!is_null($tempID) && $tempID === $userID) {
       CRM_Core_Resources::singleton()->addVars('coreForm', ['contact_id' => (int) $tempID]);
@@ -2283,10 +2283,12 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
 
   /**
    * Get the contact id of the logged in user.
+   * @deprecated
    *
    * @return int|false
    */
   public function getLoggedInUserContactID() {
+    CRM_Core_Error::deprecatedFunctionWarning('CRM_Core_Session::getLoggedInContactID()');
     // check if the user is logged in and has a contact ID
     $session = CRM_Core_Session::singleton();
     return $session->get('userID') ? (int) $session->get('userID') : FALSE;
@@ -2725,7 +2727,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
     if (!$contactID) {
       return FALSE;
     }
-    if ($contactID === $this->getLoggedInUserContactID()) {
+    if ($contactID === CRM_Core_Session::getLoggedInContactID()) {
       return $contactID;
     }
     $userChecksum = CRM_Utils_Request::retrieve('cs', 'String', $this);

--- a/CRM/Core/Session.php
+++ b/CRM/Core/Session.php
@@ -563,7 +563,7 @@ class CRM_Core_Session {
     if (!is_numeric($session->get('userID'))) {
       return NULL;
     }
-    return $session->get('userID');
+    return (int) $session->get('userID');
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
`CRM_Core_Form::getLoggedInUserContactID()` is doing virtually the same thing as `CRM_Core_Session::getLoggedInContactD()` but is only used in 3 places. Deprecate it and use the function on the session class.

Before
----------------------------------------
"Duplicate" function.

After
----------------------------------------
Use standard function

Technical Details
----------------------------------------
Only change here is that we explicitly return an int which the contact ID should always be..

Comments
----------------------------------------
