### PR TITLE
Correct copy-paste error in CustomField schema

### DIFF
--- a/xml/schema/Core/CustomField.xml
+++ b/xml/schema/Core/CustomField.xml
@@ -52,7 +52,7 @@
     <type>varchar</type>
     <title>Custom Field Name</title>
     <length>64</length>
-    <comment>Variable name/programmatic handle for this group.</comment>
+    <comment>Variable name/programmatic handle for this field.</comment>
     <add>3.3</add>
   </field>
   <field>


### PR DESCRIPTION
Before: in API4 explorer and elsewhere, the description for CustomField.name is a verbatim copy of CustomGroup.name -- this is incorrect

After: description correctly refers to "field"