### PR TITLE
Fix form params for testEventPaymentForms

### DIFF
--- a/tests/phpunit/CRM/Financial/Form/PaymentFormsTest.php
+++ b/tests/phpunit/CRM/Financial/Form/PaymentFormsTest.php
@@ -60,7 +60,7 @@ class CRM_Financial_Form_PaymentFormsTest extends CiviUnitTestCase {
     ];
     $genericParams = [
       'credit_card_number' => 4111111111111111,
-      'processor_id' => $processors[0],
+      'payment_processor_id' => $processors[0],
       'cvv2' => '123',
       'credit_card_exp_date' => [
         'M' => '1',


### PR DESCRIPTION
Overview
----------------------------------------
This test should be setting `payment_processor_id` and not `processor_id` for the ID of the payment processor when building the form.

Before
----------------------------------------
Wrong parameter being set.

After
----------------------------------------
Right parameter being set.

Technical Details
----------------------------------------
With the existing eventcart it doesn't actually matter because the parameter is not used but it does matter for https://github.com/civicrm/civicrm-core/pull/17886

Comments
----------------------------------------
