### PR TITLE
Core_DAO - fire links_callback for all entities

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -526,11 +526,14 @@ class CRM_Core_DAO extends DB_DataObject {
   /**
    * Returns list of FK relationships.
    *
-   *
    * @return CRM_Core_Reference_Basic[]
    */
   public static function getReferenceColumns() {
-    return [];
+    if (!isset(Civi::$statics[static::class]['links'])) {
+      Civi::$statics[static::class]['links'] = static::createReferenceColumns(static::class);
+      CRM_Core_DAO_AllCoreTables::invoke(static::class, 'links_callback', Civi::$statics[static::class]['links']);
+    }
+    return Civi::$statics[static::class]['links'];
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
`CRM_Core_DAO` has a fallback `getReferenceColumns` for entities with no foreign key fields. That function was empty, so did not run the callbacks which are called by most other DAOs' `getReferenceColumns`.

Before
----------------------------------------
Fallback function did not call `createReferenceColumns` or fire `links_callback`

After
----------------------------------------
`createReferenceColumns` always called and `links_callback` always fired for any `DAO::getReferenceColumns()`.
