### PR TITLE
Fix case sensitive parameter for call to getCustomFieldTokens

### DIFF
--- a/CRM/Core/SelectValues.php
+++ b/CRM/Core/SelectValues.php
@@ -587,7 +587,7 @@ class CRM_Core_SelectValues {
       //'{contribution.address_id}' => ts('Address ID'),
       '{contribution.check_number}' => ts('Check Number'),
       '{contribution.campaign}' => ts('Contribution Campaign'),
-    ], CRM_Utils_Token::getCustomFieldTokens('contribution', TRUE));
+    ], CRM_Utils_Token::getCustomFieldTokens('Contribution', TRUE));
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Fix case sensitive parameter for call to getCustomFieldTokens.

Before
----------------------------------------
Was getCustomFieldTokens('contribution'...

After
----------------------------------------
Should be getCustomFieldTokens('Contribution'...

Technical Details
----------------------------------------


Comments
----------------------------------------

Agileware Ref: CIVICRM-1732