### PR TITLE
CiviCRM Scheduled Reminders, Event custom fields are not available as tokens

### DIFF
--- a/CRM/Core/SelectValues.php
+++ b/CRM/Core/SelectValues.php
@@ -539,22 +539,28 @@ class CRM_Core_SelectValues {
    * @return array
    */
   public static function eventTokens() {
-    return [
-      '{event.event_id}' => ts('Event ID'),
-      '{event.title}' => ts('Event Title'),
-      '{event.start_date}' => ts('Event Start Date'),
-      '{event.end_date}' => ts('Event End Date'),
-      '{event.event_type}' => ts('Event Type'),
-      '{event.summary}' => ts('Event Summary'),
-      '{event.contact_email}' => ts('Event Contact Email'),
-      '{event.contact_phone}' => ts('Event Contact Phone'),
-      '{event.description}' => ts('Event Description'),
-      '{event.location}' => ts('Event Location'),
-      '{event.fee_amount}' => ts('Event Fees'),
-      '{event.info_url}' => ts('Event Info URL'),
-      '{event.registration_url}' => ts('Event Registration URL'),
-      '{event.balance}' => ts('Event Balance'),
-    ];
+    static $tokens = NULL;
+
+    if (!$tokens) {
+      $tokens = array_merge([
+        '{event.event_id}' => ts('Event ID'),
+        '{event.title}' => ts('Event Title'),
+        '{event.start_date}' => ts('Event Start Date'),
+        '{event.end_date}' => ts('Event End Date'),
+        '{event.event_type}' => ts('Event Type'),
+        '{event.summary}' => ts('Event Summary'),
+        '{event.contact_email}' => ts('Event Contact Email'),
+        '{event.contact_phone}' => ts('Event Contact Phone'),
+        '{event.description}' => ts('Event Description'),
+        '{event.location}' => ts('Event Location'),
+        '{event.fee_amount}' => ts('Event Fees'),
+        '{event.info_url}' => ts('Event Info URL'),
+        '{event.registration_url}' => ts('Event Registration URL'),
+        '{event.balance}' => ts('Event Balance'),
+      ], CRM_Utils_Token::getCustomFieldTokens('Event', TRUE));
+
+    }
+    return $tokens;
   }
 
   /**

--- a/CRM/Event/Tokens.php
+++ b/CRM/Event/Tokens.php
@@ -127,7 +127,7 @@ LEFT JOIN civicrm_phone phone ON phone.id = lb.phone_id
       $row->tokens($entity, $field, $actionSearchResult->$field);
     }
     elseif ($cfID = \CRM_Core_BAO_CustomField::getKeyID($field)) {
-      $row->customToken($entity, $cfID, $actionSearchResult->entity_id);
+      $row->customToken($entity, $cfID, $actionSearchResult->event_id);
     }
     else {
       $row->tokens($entity, $field, '');

--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -1852,7 +1852,7 @@ class CRM_Utils_Token {
    */
   public static function getCustomFieldTokens($entity, $usedForTokenWidget = FALSE) {
     $customTokens = [];
-    $tokenName = $usedForTokenWidget ? "{contribution.custom_%d}" : "custom_%d";
+    $tokenName = $usedForTokenWidget ? '{' . strtolower($entity) . '.custom_%d}' : 'custom_%d';
     foreach (CRM_Core_BAO_CustomField::getFields($entity) as $id => $info) {
       $customTokens[sprintf($tokenName, $id)] = $info['label'];
     }


### PR DESCRIPTION
Overview
----------------------------------------
CiviCRM Scheduled Reminders, Event custom fields are not available as tokens

Before
----------------------------------------
Event custom fields are NOT available as tokens in Scheduled Reminders

After
----------------------------------------
Event custom fields ARE available as tokens in Scheduled Reminders

Technical Details
----------------------------------------

Comments
----------------------------------------
Ping @mattwire 

Agileware Ref: CIVICRM-1730