### PR TITLE
CiviCRM Scheduled Reminders, adds support for Participant fields and Participant Custom Fields as Tokens in Scheduled Reminders

### DIFF
--- a/CRM/Admin/Form/ScheduleReminders.php
+++ b/CRM/Admin/Form/ScheduleReminders.php
@@ -693,6 +693,7 @@ class CRM_Admin_Form_ScheduleReminders extends CRM_Admin_Form {
     $tokens = CRM_Core_SelectValues::contactTokens();
     $tokens = array_merge(CRM_Core_SelectValues::activityTokens(), $tokens);
     $tokens = array_merge(CRM_Core_SelectValues::eventTokens(), $tokens);
+    $tokens = array_merge(CRM_Core_SelectValues::participantTokens(), $tokens);
     $tokens = array_merge(CRM_Core_SelectValues::membershipTokens(), $tokens);
     $tokens = array_merge(CRM_Core_SelectValues::contributionTokens(), $tokens);
     return $tokens;

--- a/CRM/Core/SelectValues.php
+++ b/CRM/Core/SelectValues.php
@@ -682,37 +682,18 @@ class CRM_Core_SelectValues {
   public static function participantTokens() {
     static $tokens = NULL;
     if (!$tokens) {
-      $exportFields = CRM_Event_BAO_Participant::exportableFields();
+      $tokens = array_merge([
+        '{participant.participant_id}' => ts('Participant ID'),
+        '{participant.status}' => ts('Participant Status'),
+        '{participant.role}' => ts('Participant Role'),
+        '{participant.register_date}' => ts('Registration Date'),
+        '{participant.source}' => ts('Source'),
+        '{participant.fee_level}' => ts('Fee Level'),
+        '{participant.fee_amount}' => ts('Fee Amount'),
+        '{participant.is_pay_later}' => ts('Is Pay Later'),
+        '{participant.must_wait}' => ts('On Waiting List'),
+      ], CRM_Utils_Token::getCustomFieldTokens('Participant', TRUE));
 
-      $values = array_merge(array_keys($exportFields));
-      unset($values[0]);
-
-      // skipping some tokens for time being.
-      $skipTokens = [
-        'event_id',
-        'participant_is_pay_later',
-        'participant_is_test',
-        'participant_contact_id',
-        'participant_fee_currency',
-        'participant_campaign_id',
-        'participant_status',
-        'participant_discount_name',
-      ];
-
-      $customFields = CRM_Core_BAO_CustomField::getFields('Participant');
-
-      foreach ($values as $key => $val) {
-        if (in_array($val, $skipTokens)) {
-          continue;
-        }
-        //keys for $tokens should be constant. $token Values are changed for Custom Fields. CRM-3734
-        if ($customFieldId = CRM_Core_BAO_CustomField::getKeyID($val)) {
-          $tokens["{participant.$val}"] = !empty($customFields[$customFieldId]) ? $customFields[$customFieldId]['label'] . " :: " . $customFields[$customFieldId]['groupTitle'] : '';
-        }
-        else {
-          $tokens["{participant.$val}"] = $exportFields[$val]['title'];
-        }
-      }
     }
     return $tokens;
   }

--- a/CRM/Core/SelectValues.php
+++ b/CRM/Core/SelectValues.php
@@ -539,22 +539,28 @@ class CRM_Core_SelectValues {
    * @return array
    */
   public static function eventTokens() {
-    return [
-      '{event.event_id}' => ts('Event ID'),
-      '{event.title}' => ts('Event Title'),
-      '{event.start_date}' => ts('Event Start Date'),
-      '{event.end_date}' => ts('Event End Date'),
-      '{event.event_type}' => ts('Event Type'),
-      '{event.summary}' => ts('Event Summary'),
-      '{event.contact_email}' => ts('Event Contact Email'),
-      '{event.contact_phone}' => ts('Event Contact Phone'),
-      '{event.description}' => ts('Event Description'),
-      '{event.location}' => ts('Event Location'),
-      '{event.fee_amount}' => ts('Event Fees'),
-      '{event.info_url}' => ts('Event Info URL'),
-      '{event.registration_url}' => ts('Event Registration URL'),
-      '{event.balance}' => ts('Event Balance'),
-    ];
+    static $tokens = NULL;
+
+    if (!$tokens) {
+      $tokens = array_merge([
+        '{event.event_id}' => ts('Event ID'),
+        '{event.title}' => ts('Event Title'),
+        '{event.start_date}' => ts('Event Start Date'),
+        '{event.end_date}' => ts('Event End Date'),
+        '{event.event_type}' => ts('Event Type'),
+        '{event.summary}' => ts('Event Summary'),
+        '{event.contact_email}' => ts('Event Contact Email'),
+        '{event.contact_phone}' => ts('Event Contact Phone'),
+        '{event.description}' => ts('Event Description'),
+        '{event.location}' => ts('Event Location'),
+        '{event.fee_amount}' => ts('Event Fees'),
+        '{event.info_url}' => ts('Event Info URL'),
+        '{event.registration_url}' => ts('Event Registration URL'),
+        '{event.balance}' => ts('Event Balance'),
+      ], CRM_Utils_Token::getCustomFieldTokens('Event', TRUE));
+
+    }
+    return $tokens;
   }
 
   /**

--- a/CRM/Event/Participant/Tokens.php
+++ b/CRM/Event/Participant/Tokens.php
@@ -1,0 +1,101 @@
+<?php
+
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * Class CRM_Event_Participant_Tokens
+ *
+ * Generate "participant.*" tokens.
+ *
+ */
+class CRM_Event_Participant_Tokens extends \Civi\Token\AbstractTokenSubscriber {
+
+  /**
+   * Class constructor.
+   */
+  public function __construct() {
+    parent::__construct('participant', array_merge(
+      [
+        'participant_id' => ts('Participant ID'),
+        'status' => ts('Participant Status'),
+        'role' => ts('Participant Role'),
+        'register_date' => ts('Registration Date'),
+        'source' => ts('Source'),
+        'fee_level' => ts('Fee Level'),
+        'fee_amount' => ts('Fee Amount'),
+        'is_pay_later' => ts('Is Pay Later'),
+        'must_wait' => ts('On Waiting List'),
+      ],
+      CRM_Utils_Token::getCustomFieldTokens('Participant')
+    ));
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function checkActive(\Civi\Token\TokenProcessor $processor) {
+    // Extracted from scheduled-reminders code. See the class description.
+    return !empty($processor->context['actionMapping'])
+      && $processor->context['actionMapping']->getEntity() === 'civicrm_participant';
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function evaluateToken(\Civi\Token\TokenRow $row, $entity, $field, $prefetch = NULL) {
+    $actionSearchResult = $row->context['actionSearchResult'];
+
+    if ($field == 'participant_id') {
+      $row->tokens($entity, $field, $actionSearchResult->contact_id);
+    }
+    elseif ($field == 'status') {
+      $row->tokens($entity, $field, \CRM_Event_PseudoConstant::participantStatus($actionSearchResult->status_id, NULL, 'label'));
+    }
+    elseif ($field == 'role') {
+      $role_ids = CRM_Utils_Array::explodePadded($actionSearchResult->role_id);
+      foreach ($role_ids as $role_id) {
+        $roles[] = \CRM_Event_PseudoConstant::participantRole($role_id);
+      }
+      $row->tokens($entity, $field, (!empty($roles)) ? implode(', ', $roles) : '');
+    }
+    elseif ($field == 'register_date') {
+      $row->tokens($entity, $field, \CRM_Utils_Date::customFormat($actionSearchResult->register_date, Civi::settings()
+        ->get('dateformatshortdate')));
+    }
+    elseif ($field == 'source') {
+      $row->tokens($entity, $field, $actionSearchResult->source);
+    }
+    elseif ($field == 'fee_level') {
+      $fee_level_multiple = \CRM_Utils_Array::explodePadded($actionSearchResult->fee_level);
+      foreach ($fee_level_multiple as $fee_level_single) {
+        $fee_levels[] = $fee_level_single;
+      }
+      $row->tokens($entity, $field, (!empty($fee_levels)) ? implode(', ', $fee_levels) : '');
+    }
+    elseif ($field == 'fee_amount') {
+      $row->tokens($entity, $field, \CRM_Utils_Money::format($actionSearchResult->fee_amount));
+    }
+    elseif ($field == 'is_pay_later') {
+      $row->tokens($entity, $field, ($actionSearchResult->is_pay_later == 0) ? '' : ts('You have opted to pay later for this event.'));
+    }
+    elseif ($field == 'must_wait') {
+      $row->tokens($entity, $field, (empty($actionSearchResult->must_wait)) ? '' : ts('You have been added to the WAIT LIST for this event.'));
+    }
+    elseif ($cfID = \CRM_Core_BAO_CustomField::getKeyID($field)) {
+      $row->customToken($entity, $cfID, $actionSearchResult->entity_id);
+    }
+    else {
+      $row->tokens($entity, $field, '');
+    }
+  }
+
+}

--- a/CRM/Event/Tokens.php
+++ b/CRM/Event/Tokens.php
@@ -127,7 +127,7 @@ LEFT JOIN civicrm_phone phone ON phone.id = lb.phone_id
       $row->tokens($entity, $field, $actionSearchResult->$field);
     }
     elseif ($cfID = \CRM_Core_BAO_CustomField::getKeyID($field)) {
-      $row->customToken($entity, $cfID, $actionSearchResult->entity_id);
+      $row->customToken($entity, $cfID, $actionSearchResult->event_id);
     }
     else {
       $row->tokens($entity, $field, '');

--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -1852,7 +1852,7 @@ class CRM_Utils_Token {
    */
   public static function getCustomFieldTokens($entity, $usedForTokenWidget = FALSE) {
     $customTokens = [];
-    $tokenName = $usedForTokenWidget ? "{contribution.custom_%d}" : "custom_%d";
+    $tokenName = $usedForTokenWidget ? '{' . strtolower($entity) . '.custom_%d}' : 'custom_%d';
     foreach (CRM_Core_BAO_CustomField::getFields($entity) as $id => $info) {
       $customTokens[sprintf($tokenName, $id)] = $info['label'];
     }

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -331,7 +331,7 @@ class Container {
       []
     ))->addTag('kernel.event_subscriber')->setPublic(TRUE);
 
-    foreach (['Activity', 'Contribute', 'Event', 'Mailing', 'Member'] as $comp) {
+    foreach (['Activity', 'Contribute', 'Event', 'Event_Participant', 'Mailing', 'Member'] as $comp) {
       $container->setDefinition("crm_" . strtolower($comp) . "_tokens", new Definition(
         "CRM_{$comp}_Tokens",
         []


### PR DESCRIPTION
Overview
----------------------------------------
Adds support for Participant fields and Participant Custom Fields as Tokens in Scheduled Reminders.

Solves this Gitlab Feature Request, Custom Participant tokens not working in scheduled reminders
https://lab.civicrm.org/dev/core/-/issues/348

Before
----------------------------------------
Cannot use Participant fields or Participant Custom Fields as Tokens in Scheduled Reminders, which is sad :cry: 

After
----------------------------------------
Now able to use Participant fields or Participant Custom Fields as Tokens in Scheduled Reminders :grinning: 

Technical Details
----------------------------------------
Includes commits from PR https://github.com/civicrm/civicrm-core/pull/20334 as the two are dependant on a change to the getCustomFieldTokens function.

Comments
----------------------------------------
Ping @mattwire 

Agileware Ref: CIVICRM-1731
