### PR TITLE
SearchKit - Use default_pager_size setting

### DIFF
--- a/ext/search_kit/Civi/Search/Admin.php
+++ b/ext/search_kit/Civi/Search/Admin.php
@@ -32,6 +32,7 @@ class Admin {
       'functions' => \CRM_Api4_Page_Api4Explorer::getSqlFunctions(),
       'displayTypes' => Display::getDisplayTypes(['id', 'name', 'label', 'description', 'icon']),
       'styles' => \CRM_Utils_Array::makeNonAssociative(self::getStyles()),
+      'defaultPagerSize' => \Civi::settings()->get('default_pager_size'),
       'afformEnabled' => $extensions->isActiveModule('afform'),
       'afformAdminEnabled' => $extensions->isActiveModule('afform_admin'),
     ];

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
@@ -13,7 +13,7 @@
       this.DEFAULT_AGGREGATE_FN = 'GROUP_CONCAT';
 
       this.selectedRows = [];
-      this.limit = CRM.cache.get('searchPageSize', 30);
+      this.limit = CRM.crmSearchAdmin.defaultPagerSize;
       this.page = 1;
       this.displayTypes = _.indexBy(CRM.crmSearchAdmin.displayTypes, 'id');
       // After a search this.results is an object of result arrays keyed by page,
@@ -569,8 +569,6 @@
       $scope.onChangeLimit = function() {
         // Refresh only if search has already been run
         if (ctrl.autoSearch || ctrl.results) {
-          // Save page size in localStorage
-          CRM.cache.set('searchPageSize', ctrl.limit);
           ctrl.refreshAll();
         }
       };

--- a/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayList.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayList.component.js
@@ -34,7 +34,7 @@
         if (!ctrl.display.settings) {
           ctrl.display.settings = {
             style: 'ul',
-            limit: 20,
+            limit: CRM.crmSearchAdmin.defaultPagerSize,
             pager: true
           };
         }

--- a/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayTable.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayTable.component.js
@@ -18,7 +18,7 @@
       this.$onInit = function () {
         if (!ctrl.display.settings) {
           ctrl.display.settings = {
-            limit: 20,
+            limit: CRM.crmSearchAdmin.defaultPagerSize,
             pager: true
           };
         }


### PR DESCRIPTION
Overview
----------------------------------------
This makes use of the newly-added `default_pager_size` setting for SearchKit.
See https://lab.civicrm.org/dev/core/-/issues/2187

Before
----------------------------------------
Hard-coded pager size.

After
----------------------------------------
Uses configurable setting.
