### PR TITLE
Generated sql cleanup - only include the licence once in the file

### DIFF
--- a/xml/templates/drop.tpl
+++ b/xml/templates/drop.tpl
@@ -1,4 +1,4 @@
--- +--------------------------------------------------------------------+
+{*suppress license if within a file that already has the license*}{if !$no_license}-- +--------------------------------------------------------------------+
 -- | Copyright CiviCRM LLC. All rights reserved.                        |
 -- |                                                                    |
 -- | This work is published under the GNU AGPLv3 license with some      |
@@ -8,10 +8,11 @@
 --
 -- Generated from {$smarty.template}
 -- {$generated}
---
+--{/if}
 -- /*******************************************************
 -- *
--- * Clean up the existing tables
+-- * Clean up the existing tables{if $no_license} - this section generated from {$smarty.template}
+{/if}
 -- *
 -- *******************************************************/
 

--- a/xml/templates/schema.tpl
+++ b/xml/templates/schema.tpl
@@ -10,7 +10,7 @@
 -- {$generated}
 -- {$database.comment}
 
-{include file="drop.tpl"}
+{include file="drop.tpl" no_license=TRUE}
 
 -- /*******************************************************
 -- *


### PR DESCRIPTION

Overview
----------------------------------------
Generated sql cleanup - only include the licence once in the file

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/118591553-75240780-b7f8-11eb-8f0d-1e74c808d4c8.png)

After
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/118591371-2a09f480-b7f8-11eb-924a-2e7292cdaeca.png)

Technical Details
----------------------------------------
I've separated this from https://github.com/civicrm/civicrm-core/pull/20338
as it might be a little less strait forward

Comments
----------------------------------------
My brain is mush. I cannot spell