### PR TITLE
Fix extraneous white space in generated sql

### DIFF
--- a/xml/templates/drop.tpl
+++ b/xml/templates/drop.tpl
@@ -1,4 +1,4 @@
--- +--------------------------------------------------------------------+
+{*suppress license if within a file that already has the license*}{if !$no_license}-- +--------------------------------------------------------------------+
 -- | Copyright CiviCRM LLC. All rights reserved.                        |
 -- |                                                                    |
 -- | This work is published under the GNU AGPLv3 license with some      |
@@ -8,10 +8,11 @@
 --
 -- Generated from {$smarty.template}
 -- {$generated}
---
+--{/if}
 -- /*******************************************************
 -- *
--- * Clean up the existing tables
+-- * Clean up the existing tables{if $no_license} - this section generated from {$smarty.template}
+{/if}
 -- *
 -- *******************************************************/
 

--- a/xml/templates/schema.tpl
+++ b/xml/templates/schema.tpl
@@ -8,17 +8,17 @@
 --
 -- Generated from {$smarty.template}
 -- {$generated}
--- {$database.comment}
+--{if $database.comment} {$database.comment}{/if}
 
-{include file="drop.tpl"}
+{include file="drop.tpl" no_license=TRUE}
 
 -- /*******************************************************
 -- *
 -- * Create new tables
 -- *
 -- *******************************************************/
-
 {foreach from=$tables item=table}
+
 -- /*******************************************************
 -- *
 -- * {$table.name}
@@ -28,47 +28,28 @@
 {/if}
 -- *
 -- *******************************************************/
-CREATE TABLE `{$table.name}` (
-{assign var='first' value=true}
-
+CREATE TABLE `{$table.name}` ({assign var='first' value=true}
 {foreach from=$table.fields item=field}
-{if ! $first},{/if}
-{assign var='first' value=false}
+{if ! $first},{/if}{assign var='first' value=false}
 
-     `{$field.name}` {$field.sqlType}{if $field.collate} COLLATE {$field.collate}{/if} {if $field.required}{if $field.required == "false"}NULL{else}NOT NULL{/if}{/if} {if $field.autoincrement}AUTO_INCREMENT{/if} {if $field.default|count_characters}DEFAULT {$field.default}{/if} {if $field.comment}COMMENT '{ts escape=sql}{$field.comment}{/ts}'{/if}
-{/foreach} {* table.fields *}
+  `{$field.name}` {$field.sqlType}{if $field.collate} COLLATE {$field.collate}{/if}{if $field.required} {if $field.required == "false"}NULL{else}NOT NULL{/if}{/if}{if $field.autoincrement} AUTO_INCREMENT{/if}{if $field.default|count_characters} DEFAULT {$field.default}{/if}{if $field.comment} COMMENT '{ts escape=sql}{$field.comment}{/ts}'{/if}
+{/foreach}{* table.fields *}{strip}
 
-{if $table.primaryKey}
-{if ! $first},{/if}
-{assign var='first' value=false}
-
-    {assign var='firstIndexField' value=true}
-    PRIMARY KEY ({foreach from=$table.primaryKey.field item=fieldName}{if $firstIndexField}{assign var='firstIndexField' value=false}{else},{/if}`{$fieldName}`{/foreach})
-{/if} {* table.primaryKey *}
-
-{if $table.index}
-  {foreach from=$table.index item=index}
-  {if ! $first},{/if}
-  {assign var='first' value=false}
-  {if $index.unique} UNIQUE{/if} INDEX `{$index.name}`(
-  {assign var='firstIndexField' value=true}
-  {foreach from=$index.field item=fieldName}
-    {if $firstIndexField}{assign var='firstIndexField' value=false}{else}, {/if}{$fieldName}
-  {/foreach}
-)
-{/foreach} {* table.index *}
-{/if} {* table.index *}
-
+{/strip}{if $table.primaryKey}{if !$first},
+{/if}{assign var='first' value=false}{assign var='firstIndexField' value=true}
+  PRIMARY KEY ({foreach from=$table.primaryKey.field item=fieldName}{if $firstIndexField}{assign var='firstIndexField' value=false}{else},{/if}`{$fieldName}`{/foreach}){/if}{* table.primaryKey *}
+{if $table.index}{foreach from=$table.index item=index}{if !$first},
+{/if}{assign var='first' value=false}
+  {if $index.unique}UNIQUE {/if}INDEX `{$index.name}`({assign var='firstIndexField' value=true}{foreach from=$index.field item=fieldName}{strip}
+{/strip}{if $firstIndexField}{assign var='firstIndexField' value=false}{else}, {/if}{$fieldName}{/foreach}){/foreach}{* table.index *}
+{/if}{* table.index *}
 {if $table.foreignKey}
-{foreach from=$table.foreignKey item=foreign}
-{if ! $first},{/if}
-{assign var='first' value=false}
-     {if $mysql eq 'simple'} INDEX FKEY_{$foreign.name} ( `{$foreign.name}` ) , {/if}
-     CONSTRAINT {$foreign.uniqName} FOREIGN KEY (`{$foreign.name}`) REFERENCES `{$foreign.table}`(`{$foreign.key}`) {if $foreign.onDelete}ON DELETE {$foreign.onDelete}{/if}
-{/foreach} {* table.foreignKey *}
-{/if} {* table.foreignKey *}
-
-{* ) {if $mysql eq 'modern' }{$table.attributes}{/if}; *}
-) {if $mysql eq 'modern' } {$table.attributes_modern} {else} {$table.attributes_simple} {/if} ;
-
-{/foreach} {* tables *}
+{foreach from=$table.foreignKey item=foreign}{if ! $first},
+{/if}
+{assign var='first' value=false}{if $mysql eq 'simple'}
+  INDEX FKEY_{$foreign.name} ( `{$foreign.name}` ),{/if}
+  CONSTRAINT {$foreign.uniqName} FOREIGN KEY (`{$foreign.name}`) REFERENCES `{$foreign.table}`(`{$foreign.key}`){if $foreign.onDelete} ON DELETE {$foreign.onDelete}{/if}{/foreach}{* table.foreignKey *}{/if}{strip}
+  {* table.foreignKey *}{/strip}
+)
+{if $mysql eq 'modern' }{$table.attributes_modern}{else}{$table.attributes_simple}{/if};
+{/foreach}{* tables *}


### PR DESCRIPTION
Overview
----------------------------------------
Fix extraneous white space in generated sql - this incorporates #20339  and #20338 and a bunch more change and leaves us with fairly attractive sql at the end. 

Schema.tpl whitespace overhaul

Before
----------------------------------------
If I regenerate sql in search kit I get 

- trailing space when comment is not declared for a db table
- spaces before arguments that don't exist
- extra lines

![image](https://user-images.githubusercontent.com/336308/118598674-8f62e300-b802-11eb-94f0-ea3e1e127fe8.png)


After
----------------------------------------
Schema.tpl less readable but generated sql much better (seems like a fair price IMHO)

![image](https://user-images.githubusercontent.com/336308/118598734-a9042a80-b802-11eb-816e-26ffe880743d.png)

Technical Details
----------------------------------------

Note I tried regenerating civicrm.mysql with this & it looked good - jenkins can
pass judgement too...

I didn't include the regenerated sql in search_kit but I hit what seems to me to be
an unreleated regression in civix - ie search_kit generates
 ROW_FORMAT=DYNAMIC

With my version (lastest from master) of civix I get ENGINE = INNODB but
not the ROW_FORMAT

Comments
----------------------------------------
If https://github.com/totten/civix/pull/202 were merged we possibly would no longer have generated sql files but that got stalled on negotiating feedback 6 months ago & I don't think it should be brought back onto the front burner given other priorities - so this could be short-lived formatting but better to have it now IMHO