### PR TITLE
Fix mandatory keys check fail for value of float 0.0 in a required key in an entity

### DIFF
--- a/api/v3/utils.php
+++ b/api/v3/utils.php
@@ -89,7 +89,7 @@ function civicrm_api3_verify_mandatory($params, $daoName = NULL, $keys = [], $ve
     else {
       // Disallow empty values except for the number zero.
       // TODO: create a utility for this since it's needed in many places.
-      if (!array_key_exists($key, $params) || (empty($params[$key]) && $params[$key] !== 0.0 && $params[$key] !== '0')) {
+      if (!array_key_exists($key, $params) || (empty($params[$key]) && $params[$key] !== 0.0 && $params[$key] !== 0 && $params[$key] !== '0')) {
         $unmatched[] = $key;
       }
     }

--- a/api/v3/utils.php
+++ b/api/v3/utils.php
@@ -89,7 +89,7 @@ function civicrm_api3_verify_mandatory($params, $daoName = NULL, $keys = [], $ve
     else {
       // Disallow empty values except for the number zero.
       // TODO: create a utility for this since it's needed in many places.
-      if (!array_key_exists($key, $params) || (empty($params[$key]) && $params[$key] !== 0 && $params[$key] !== '0')) {
+      if (!array_key_exists($key, $params) || (empty($params[$key]) && $params[$key] !== 0.0 && $params[$key] !== '0')) {
         $unmatched[] = $key;
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes https://lab.civicrm.org/dev/core/-/issues/2071.

The mandatory keys check in function `civicrm_api3_verify_mandatory()` fails erroneously if the key exists but it has the floating-point value of 0.0.

Reproduction steps
----------------------------------------
Using APIv3, create an entity that contains a required key with the floating-point value of 0.0, for example, line_total in a price field element.

Before
----------------------------------------
APIv3 throws a Mandatory key(s) missing from params array: exception.

After
----------------------------------------
Successful creation.

Technical Details
----------------------------------------
In civicrm/api/v3/utils.php, change line 92 from

```
if (!array_key_exists($key, $params) || (empty($params[$key]) && $params[$key] !== 0 && $params[$key] !== '0')) {
```

to 

```
if (!array_key_exists($key, $params) || (empty($params[$key]) && $params[$key] !== 0.0 && $params[$key] !== '0')) {
```

The second version will match on both integer 0 and float 0.0, while the first only matches on integer 0 but not float 0.0.
