### PR TITLE
[REF] Make previously unshared function protected

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -1704,7 +1704,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
           $pending = FALSE;
         }
 
-        [$membership, $renewalMode, $dates] = CRM_Contribute_Form_Contribution_Confirm::legacyProcessMembership(
+        [$membership, $renewalMode, $dates] = self::legacyProcessMembership(
           $contactID, $memType, $isTest,
           date('YmdHis'), $membershipParams['cms_contactID'] ?? NULL,
           $customFieldsFormatted,
@@ -2887,6 +2887,34 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
   }
 
   /**
+   * Temporary function to allow unit tests to access function being refactored away.
+   *
+   * @param int $contactID
+   * @param int $membershipTypeID
+   * @param int $membershipID
+   *
+   * @return array
+   * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
+   */
+  public static function unitTestAccessTolegacyProcessMembership($contactID, $membershipTypeID, $membershipID = NULL) {
+    return self::legacyProcessMembership(
+      $contactID,
+      $membershipTypeID,
+      0,
+      NULL,
+      NULL,
+      NULL,
+      1,
+      $membershipID,
+      NULL,
+      NULL,
+      FALSE,
+      NULL
+    );
+  }
+
+  /**
    * Interim function for processing memberships - this is being refactored out of existence.
    *
    * @param int $contactID
@@ -2909,7 +2937,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
    * @throws \CRM_Core_Exception
    * @throws \CiviCRM_API3_Exception
    */
-  public static function legacyProcessMembership($contactID, $membershipTypeID, $is_test, $changeToday, $modifiedID, $customFieldsFormatted, $numRenewTerms, $membershipID, $pending, $contributionRecurID, $membershipSource, $isPayLater, $memParams = [], $contribution = NULL, $lineItems = []) {
+  protected static function legacyProcessMembership($contactID, $membershipTypeID, $is_test, $changeToday, $modifiedID, $customFieldsFormatted, $numRenewTerms, $membershipID, $pending, $contributionRecurID, $membershipSource, $isPayLater, $memParams = [], $contribution = NULL, $lineItems = []) {
     $renewalMode = $updateStatusId = FALSE;
     $allStatus = CRM_Member_PseudoConstant::membershipStatus();
     $format = '%Y%m%d';

--- a/tests/phpunit/CRM/Contribute/Form/Contribution/ConfirmTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/Contribution/ConfirmTest.php
@@ -20,6 +20,8 @@ class CRM_Contribute_Form_Contribution_ConfirmTest extends CiviUnitTestCase {
 
   /**
    * Clean up DB.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function tearDown(): void {
     $this->quickCleanUpFinancialEntities();
@@ -27,7 +29,7 @@ class CRM_Contribute_Form_Contribution_ConfirmTest extends CiviUnitTestCase {
 
   /**
    * CRM-21200: Test that making online payment for pending contribution
-   * doesn't overwite the contribution details
+   * doesn't overwrite the contribution details
    *
    * @throws \CiviCRM_API3_Exception
    * @throws \CRM_Core_Exception

--- a/tests/phpunit/CRM/Member/BAO/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/BAO/MembershipTest.php
@@ -479,21 +479,9 @@ class CRM_Member_BAO_MembershipTest extends CiviUnitTestCase {
     $config = CRM_Core_Config::singleton();
     $config->keyDisable = TRUE;
 
-    $isTestMembership = 0;
-    [$MembershipRenew] = CRM_Contribute_Form_Contribution_Confirm::legacyProcessMembership(
+    [$MembershipRenew] = CRM_Contribute_Form_Contribution_Confirm::unitTestAccessTolegacyProcessMembership(
       $contactId,
-      $this->_membershipTypeID,
-      $isTestMembership,
-      NULL,
-      NULL,
-      NULL,
-      1,
-      FALSE,
-      NULL,
-      NULL,
-      FALSE,
-      NULL
-    );
+      $this->_membershipTypeID);
     $endDate = date("Y-m-d", strtotime($membership['end_date'] . " +1 year"));
 
     $this->assertDBNotNull('CRM_Member_BAO_MembershipLog',
@@ -549,19 +537,10 @@ class CRM_Member_BAO_MembershipTest extends CiviUnitTestCase {
       'Database checked on membership log record.'
     );
 
-    [$MembershipRenew] = CRM_Contribute_Form_Contribution_Confirm::legacyProcessMembership(
+    [$MembershipRenew] = CRM_Contribute_Form_Contribution_Confirm::unitTestAccessTolegacyProcessMembership(
       $contactId,
       $this->_membershipTypeID,
-      FALSE,
-      FALSE,
-      NULL,
-      NULL,
-      NULL,
-      1,
-      NULL,
-      NULL,
-      NULL,
-      FALSE
+      1
     );
 
     $this->assertDBNotNull('CRM_Member_BAO_MembershipLog',


### PR DESCRIPTION
This clarifies that it is not used outside core - which we
know as it was only just moved here 5187a13c4d0e4278bb9b18f9fb327b2407766dff

Overview
----------------------------------------
[REF] Make previously unshared function protected

Before
----------------------------------------
function public

After
----------------------------------------
Function protected

Technical Details
----------------------------------------

Our functions are fairly ad-hoc about what is protected & what is public - but by making this protected we can make it explict to reviewer's that it is not used from anywhere else - it was only moved here in https://github.com/civicrm/civicrm-core/pull/20313

Comments
----------------------------------------
