### PR TITLE
dev/core#2613 - Replace deprecated function in useradd task

### DIFF
--- a/CRM/Contact/Form/Task/Useradd.php
+++ b/CRM/Contact/Form/Task/Useradd.php
@@ -77,10 +77,7 @@ class CRM_Contact_Form_Task_Useradd extends CRM_Core_Form {
       $this->add('password', 'cms_pass', ts('Password'), ['class' => 'huge']);
       $this->add('password', 'cms_confirm_pass', ts('Confirm Password'), ['class' => 'huge']);
       $this->addRule('cms_pass', ts('Password is required'), 'required');
-      $this->addRule([
-        'cms_pass',
-        'cms_confirm_pass',
-      ], ts('Password mismatch'), 'compare');
+      $this->addFormRule(['CRM_Contact_Form_Task_Useradd', 'passwordMatch']);
     }
 
     $this->add('text', 'email', ts('Email'), ['class' => 'huge'])->freeze();
@@ -138,6 +135,20 @@ class CRM_Contact_Form_Task_Useradd extends CRM_Core_Form {
     $config->userSystem->checkUserNameEmailExists($check_params, $errors);
 
     return empty($errors) ? TRUE : $errors;
+  }
+
+  /**
+   * Validation Rule.
+   *
+   * @param array $params
+   *
+   * @return array|bool
+   */
+  public static function passwordMatch($params) {
+    if ($params['cms_pass'] !== $params['cms_confirm_pass']) {
+      return ['cms_pass' => ts('Password mismatch')];
+    }
+    return TRUE;
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/2613

Before
----------------------------------------
1. Use 5.36 or earlier, or the latest master, and not wordpress.
1. Log in as a user with user creation rights.
1. View a contact.
1. From the actions menu choose Create User Record.
1. Fill it out and save.
1. `Deprecated function: Function create_function() is deprecated...`


After
----------------------------------------
1. No warning.

Technical Details
----------------------------------------
It's deprecated in php 7.2 and will be removed in php 8. This is the only place the quickform 'compare' formrule is used, and it's kind of a weird function, so rather than try to fix it, just use a regular formRule.

Comments
----------------------------------------

