### PR TITLE
SearchKit - Fix menu permission

### DIFF
--- a/ext/search_kit/CRM/Search/Upgrader.php
+++ b/ext/search_kit/CRM/Search/Upgrader.php
@@ -18,6 +18,7 @@ class CRM_Search_Upgrader extends CRM_Search_Upgrader_Base {
       ->addValue('icon', 'crm-i fa-search-plus')
       ->addValue('has_separator', 2)
       ->addValue('weight', 99)
+      ->addValue('permission', 'administer CiviCRM data')
       ->execute();
   }
 
@@ -130,6 +131,16 @@ class CRM_Search_Upgrader extends CRM_Search_Upgrader_Base {
           ->execute();
       }
     }
+    return TRUE;
+  }
+
+  /**
+   * Upgrade 1004 - fix menu permission.
+   * @return bool
+   */
+  public function upgrade_1004() {
+    $this->ctx->log->info('Applying update 1000 - fix menu permission.');
+    CRM_Core_DAO::executeQuery("UPDATE civicrm_navigation SET permission = 'administer CiviCRM data' WHERE url = 'civicrm/admin/search'");
     return TRUE;
   }
 

--- a/ext/search_kit/xml/Menu/search_kit.xml
+++ b/ext/search_kit/xml/Menu/search_kit.xml
@@ -8,6 +8,6 @@
   <item>
     <path>civicrm/admin/search</path>
     <page_callback>CRM_Search_Page_Admin</page_callback>
-    <access_arguments>administer CiviCRM</access_arguments>
+    <access_arguments>administer CiviCRM data</access_arguments>
   </item>
 </menu>


### PR DESCRIPTION
Overview
----------------------------------------
Adjust permission in menubar to match permission on page so that non-permissioned users do not see a non-functional link in the menu.

See https://lab.civicrm.org/dev/core/-/issues/2619

Before
----------------------------------------
Non-admin users see SearchKit menu but when they click on it get "Access Denied"

After
----------------------------------------
Only admin users see SearchKit in menubar.

Technical Details
------------------------
Uses the fairly new 'administer CiviCRM data' permission, which is a sub-permission of 'administer CiviCRM'.