### PR TITLE
Fix Distmaker building by ensuring we are rsyncing from the right folder

### DIFF
--- a/distmaker/dists/common.sh
+++ b/distmaker/dists/common.sh
@@ -110,8 +110,8 @@ function dm_install_coreext() {
   shift
 
   for relext in "$@" ; do
-    [ ! -d "$to/$relext" ] && mkdir -p "$to/$relext"
-    ${DM_RSYNC:-rsync} -avC $excludes_rsync --include=core "$repo/$relext/./" "$to/$relext/./"
+    [ ! -d "$to/ext/$relext" ] && mkdir -p "$to/ext/$relext"
+    ${DM_RSYNC:-rsync} -avC $excludes_rsync --include=core "$repo/ext/$relext/./" "$to/ext/$relext/./"
   done
 }
 


### PR DESCRIPTION
Overview
----------------------------------------
This fixes the following problem with distmaker

```
+ dm_install_coreext /home/publisher/bknix-min/build/cividist/src /home/publisher/bknix-min/build/cividist/out/tmp/civicrm afform authx contributioncancelactions eventcart ewaysingle financialacls flexmailer greenwich oauth-client payflowpro recaptcha search_kit sequentialcreditnotes
+ local repo=/home/publisher/bknix-min/build/cividist/src
+ local to=/home/publisher/bknix-min/build/cividist/out/tmp/civicrm
+ shift
+ shift
+ for relext in "$@"
+ '[' '!' -d /home/publisher/bknix-min/build/cividist/out/tmp/civicrm/afform ']'
+ mkdir -p /home/publisher/bknix-min/build/cividist/out/tmp/civicrm/afform
+ rsync -avC --include=core /home/publisher/bknix-min/build/cividist/src/afform/./ /home/publisher/bknix-min/build/cividist/out/tmp/civicrm/afform/./
sending incremental file list
rsync: change_dir "/home/publisher/bknix-min/build/cividist/src/afform/." failed: No such file or directory (2)
```

Before
----------------------------------------
Distmaker fails

After
----------------------------------------
Distmaker works

ping @totten