### PR TITLE
Testing - Allow tests to auto-subscribe to Symfony events

### DIFF
--- a/Civi/Test/CiviTestListener.php
+++ b/Civi/Test/CiviTestListener.php
@@ -51,6 +51,7 @@ else {
     public function startTest(\PHPUnit\Framework\Test $test) {
       if ($this->isCiviTest($test)) {
         error_reporting(E_ALL);
+        $GLOBALS['CIVICRM_TEST_CASE'] = $test;
       }
 
       if ($test instanceof HeadlessInterface) {
@@ -82,6 +83,7 @@ else {
       }
       \CRM_Utils_Time::resetTime();
       if ($this->isCiviTest($test)) {
+        unset($GLOBALS['CIVICRM_TEST_CASE']);
         error_reporting(E_ALL & ~E_NOTICE);
         $this->errorScope = NULL;
       }

--- a/Civi/Test/CiviTestListenerPHPUnit7.php
+++ b/Civi/Test/CiviTestListenerPHPUnit7.php
@@ -43,6 +43,7 @@ class CiviTestListenerPHPUnit7 implements \PHPUnit\Framework\TestListener {
   public function startTest(\PHPUnit\Framework\Test $test): void {
     if ($this->isCiviTest($test)) {
       error_reporting(E_ALL);
+      $GLOBALS['CIVICRM_TEST_CASE'] = $test;
     }
 
     if ($test instanceof HeadlessInterface) {
@@ -74,6 +75,7 @@ class CiviTestListenerPHPUnit7 implements \PHPUnit\Framework\TestListener {
     }
     \CRM_Utils_Time::resetTime();
     if ($this->isCiviTest($test)) {
+      unset($GLOBALS['CIVICRM_TEST_CASE']);
       error_reporting(E_ALL & ~E_NOTICE);
       $this->errorScope = NULL;
     }

--- a/Civi/Test/HookInterface.php
+++ b/Civi/Test/HookInterface.php
@@ -17,12 +17,29 @@ namespace Civi\Test;
  * }
  * ```
  *
+ * Similarly, to subscribe using Symfony-style listeners, create function with the 'on_' prefix:
+ *
+ * ```
+ * class MyTest extends \PHPUnit_Framework_TestCase implements \Civi\Test\HookInterface {
+ *   public function on_civi_api_authorize(AuthorizeEvent $e) {
+ *     echo "Running civi.api.authorize\n";
+ *   }
+ *   public function on_hook_civicrm_post(GenericHookEvent $e) {
+ *     echo "Running hook_civicrm_post\n";
+ *   }
+ * }
+ * ```
+ *
  * At time of writing, there are a few limitations in how HookInterface is handled
  * by CiviTestListener:
  *
  *  - The test must execute in-process (aka HeadlessInterface; aka CIVICRM_UF==UnitTests).
  *    End-to-end tests (multi-process tests) are not supported.
  *  - Early bootstrap hooks (e.g. hook_civicrm_config) are not supported.
+ *  - This does not support priorities or registering multiple listeners.
+ *
+ * If you need more advanced registration abilities, consider using `Civi::dispatcher()`
+ * or `EventDispatcherInterface`.
  *
  * @see CiviTestListener
  */

--- a/Civi/Test/Legacy/CiviTestListener.php
+++ b/Civi/Test/Legacy/CiviTestListener.php
@@ -41,6 +41,7 @@ class CiviTestListener extends \PHPUnit_Framework_BaseTestListener {
   public function startTest(\PHPUnit_Framework_Test $test) {
     if ($this->isCiviTest($test)) {
       error_reporting(E_ALL);
+      $GLOBALS['CIVICRM_TEST_CASE'] = $test;
     }
 
     if ($test instanceof \Civi\Test\HeadlessInterface) {
@@ -71,6 +72,7 @@ class CiviTestListener extends \PHPUnit_Framework_BaseTestListener {
     }
     \CRM_Utils_Time::resetTime();
     if ($this->isCiviTest($test)) {
+      unset($GLOBALS['CIVICRM_TEST_CASE']);
       error_reporting(E_ALL & ~E_NOTICE);
       $this->errorScope = NULL;
     }

--- a/tests/phpunit/Civi/Test/ExampleHookTest.php
+++ b/tests/phpunit/Civi/Test/ExampleHookTest.php
@@ -2,18 +2,21 @@
 namespace Civi\Test;
 
 use Civi\Angular\Page\Main;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
  * This is an example of a barebones test which uses a hook (based on CiviTestListener).
  *
  * @group headless
  */
-class ExampleHookTest extends \PHPUnit\Framework\TestCase implements HeadlessInterface, HookInterface {
+class ExampleHookTest extends \PHPUnit\Framework\TestCase implements HeadlessInterface, HookInterface, EventSubscriberInterface {
 
   /**
    * @var \CRM_Contact_DAO_Contact
    */
   protected $contact;
+
+  protected $tally;
 
   public function setUpHeadless() {
     return \Civi\Test::headless()->apply();
@@ -25,6 +28,7 @@ class ExampleHookTest extends \PHPUnit\Framework\TestCase implements HeadlessInt
     ]);
     $session = \CRM_Core_Session::singleton();
     $session->set('userID', $this->contact->id);
+    $this->tally = ['civi.api.resolve' => 0, 'civi.api.prepare' => 0];
   }
 
   protected function tearDown(): void {
@@ -32,10 +36,45 @@ class ExampleHookTest extends \PHPUnit\Framework\TestCase implements HeadlessInt
   }
 
   /**
+   * Listen to hook_civicrm_alterContent in traditional hook format.
+   *
    * @see \CRM_Utils_Hook::alterContent
    */
   public function hook_civicrm_alterContent(&$content, $context, $tplName, &$object) {
     $content .= "zzzyyyxxx";
+  }
+
+  /**
+   * Listen to hook_civicrm_alterContent in Symfony event format.
+   *
+   * @see \CRM_Utils_Hook::alterContent
+   */
+  public function on_hook_civicrm_alterContent(\Civi\Core\Event\GenericHookEvent $event) {
+    $event->content .= "111222333";
+  }
+
+  /**
+   * Listen to `civi.api.resolve` in Symfony event format.
+   *
+   * @see \Civi\API\Event\ResolveEvent
+   */
+  public function on_civi_api_resolve(\Civi\API\Event\ResolveEvent $event) {
+    $this->tally['civi.api.resolve']++;
+  }
+
+  public static function getSubscribedEvents() {
+    return [
+      'civi.api.prepare' => ['myCiviApiPrepare', 1234],
+    ];
+  }
+
+  /**
+   * Listen to `civi.api.resolve` in Symfony event format.
+   *
+   * @see \Civi\API\Event\ResolveEvent
+   */
+  public function myCiviApiPrepare(\Civi\API\Event\PrepareEvent $event) {
+    $this->tally['civi.api.prepare']++;
   }
 
   public function testPageOutput() {
@@ -45,6 +84,15 @@ class ExampleHookTest extends \PHPUnit\Framework\TestCase implements HeadlessInt
     $content = ob_get_contents();
     ob_end_clean();
     $this->assertRegExp(';zzzyyyxxx;', $content);
+    $this->assertRegExp(';111222333;', $content);
+  }
+
+  public function testGetFields() {
+    $this->assertEquals(0, $this->tally['civi.api.resolve']);
+    $this->assertEquals(0, $this->tally['civi.api.prepare']);
+    \civicrm_api3('Contact', 'getfields', []);
+    $this->assertTrue($this->tally['civi.api.resolve'] > 0);
+    $this->assertTrue($this->tally['civi.api.prepare'] > 0);
   }
 
 }


### PR DESCRIPTION
Overview
--------

This expands the functionality for automatically registering event-listeners within headless unit-tests,
making it easier to participate in Symfony events.

Before
------

A headless test may implement `HookInterface` and then define methods with the `hook_` prefix. These
are executed in traditional hook style:

```php
public function hook_civicrm_alterContent(&$content, $context, $tplName, &$object) {
```

However, this only works with traditional-style hooks. It is not possible to auto-subscribe to Symfony-style events.

After
-----

Additional notations are supported for Symfony-style events:

(1) A headless test may implement `HookInterface` and then define methods with the `on_` prefix. These
are executed as Symfony-style listeners:

```php
public function on_civi_api_resolve(\Civi\API\Event\ResolveEvent $event);
```

(2) If a headless test has more pick requirements, it may implement `EventDispatcherInterface` and then define `getSubscribedEvents()`, eg

```php
public static function getSubscribedEvents() {
  return ['civi.api.prepare' => ['myCiviApiPrepare', 1234]];
}

public function myCiviApiPrepare(\Civi\API\Event\PrepareEvent $event);
```
