### PR TITLE
[NFC] Add in voids to various setUpBeforeClass and tearDownAfterClass…

### DIFF
--- a/ext/afform/mock/tests/phpunit/api/v4/AfformRoutingTest.php
+++ b/ext/afform/mock/tests/phpunit/api/v4/AfformRoutingTest.php
@@ -8,7 +8,7 @@ class api_v4_AfformRoutingTest extends \PHPUnit\Framework\TestCase implements \C
 
   protected $formName = 'mockPage';
 
-  public static function setUpBeforeClass() {
+  public static function setUpBeforeClass(): void {
     \Civi\Test::e2e()
       ->install(['org.civicrm.afform', 'org.civicrm.afform-mock'])
       ->apply();

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
@@ -22,14 +22,6 @@ class SearchRunTest extends \PHPUnit\Framework\TestCase implements HeadlessInter
       ->apply();
   }
 
-  public function setUp() {
-    parent::setUp();
-  }
-
-  public function tearDown() {
-    parent::tearDown();
-  }
-
   /**
    * Test running a searchDisplay with various filters.
    */

--- a/tests/phpunit/CRM/Utils/QueryFormatterTest.php
+++ b/tests/phpunit/CRM/Utils/QueryFormatterTest.php
@@ -43,7 +43,7 @@ class CRM_Utils_QueryFormatterTest extends CiviUnitTestCase {
     }
   }
 
-  public static function tearDownAfterClass() {
+  public static function tearDownAfterClass(): void {
     CRM_Core_DAO::executeQuery('DROP TABLE IF EXISTS civicrm_fts_example');
     parent::tearDownAfterClass();
   }

--- a/tests/phpunit/Civi/Test/ExampleTransactionalTest.php
+++ b/tests/phpunit/Civi/Test/ExampleTransactionalTest.php
@@ -32,7 +32,7 @@ class ExampleTransactionalTest extends \PHPUnit\Framework\TestCase implements He
   /**
    * In the first test, we make make testDummy1. He exists.
    */
-  public function testDummy1() {
+  public function testDummy1(): void {
     $this->assertTrue(is_numeric(self::$contactIds['testDummy1']) && self::$contactIds['testDummy1'] > 0);
 
     // Still inside transaction. Data exists.
@@ -45,7 +45,7 @@ class ExampleTransactionalTest extends \PHPUnit\Framework\TestCase implements He
    * We previously made testDummy1, but he's been lost (rolled-back).
    * However, testDummy2 now exists.
    */
-  public function testDummy2() {
+  public function testDummy2(): void {
     $this->assertTrue(is_numeric(self::$contactIds['testDummy1']) && self::$contactIds['testDummy1'] > 0);
     $this->assertTrue(is_numeric(self::$contactIds['testDummy2']) && self::$contactIds['testDummy2'] > 0);
 
@@ -66,7 +66,7 @@ class ExampleTransactionalTest extends \PHPUnit\Framework\TestCase implements He
    *
    * @throws \Exception
    */
-  public static function tearDownAfterClass() {
+  public static function tearDownAfterClass(): void {
     if (!is_numeric(self::$contactIds['testDummy1'])) {
       throw new \Exception("Uh oh! The static \$contactIds does not include testDummy1! Did the test fail to execute?");
     }

--- a/tests/phpunit/CiviTest/CiviEndToEndTestCase.php
+++ b/tests/phpunit/CiviTest/CiviEndToEndTestCase.php
@@ -11,7 +11,7 @@
  */
 class CiviEndToEndTestCase extends PHPUnit\Framework\TestCase implements \Civi\Test\EndToEndInterface {
 
-  public static function setUpBeforeClass() {
+  public static function setUpBeforeClass(): void {
     CRM_Core_Config::singleton(1, 1);
     CRM_Utils_System::loadBootStrap(array(
       'name' => $GLOBALS['_CV']['ADMIN_USER'],

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -316,7 +316,7 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
     return TRUE;
   }
 
-  public static function setUpBeforeClass() {
+  public static function setUpBeforeClass(): void {
     static::_populateDB(TRUE);
 
     // also set this global hack

--- a/tests/phpunit/E2E/Cache/CacheTestCase.php
+++ b/tests/phpunit/E2E/Cache/CacheTestCase.php
@@ -18,7 +18,7 @@ abstract class E2E_Cache_CacheTestCase extends \Cache\IntegrationTests\SimpleCac
 
   const MAX_KEY = 255;
 
-  public static function setUpBeforeClass() {
+  public static function setUpBeforeClass(): void {
     CRM_Core_Config::singleton(1, 1);
     CRM_Utils_System::loadBootStrap(array(
       'name' => $GLOBALS['_CV']['ADMIN_USER'],

--- a/tests/phpunit/api/v3/ContributionPageTest.php
+++ b/tests/phpunit/api/v3/ContributionPageTest.php
@@ -1731,10 +1731,6 @@ class api_v3_ContributionPageTest extends CiviUnitTestCase {
     //$this->assertEquals(12, $contribution['values'][1]['api.ContributionRecur.getsingle']['frequency_interval']);
   }
 
-  public static function setUpBeforeClass() {
-    // put stuff here that should happen before all tests in this unit
-  }
-
   /**
    * Create a payment processor instance.
    *

--- a/tests/phpunit/api/v3/PriceSetTest.php
+++ b/tests/phpunit/api/v3/PriceSetTest.php
@@ -129,11 +129,7 @@ class api_v3_PriceSetTest extends CiviUnitTestCase {
     $this->assertEquals(16, $result['values']['is_quick_config']['type']);
   }
 
-  public static function setUpBeforeClass() {
-    // put stuff here that should happen before all tests in this unit
-  }
-
-  public static function tearDownAfterClass() {
+  public static function tearDownAfterClass(): void {
     $tablesToTruncate = [
       'civicrm_contact',
       'civicrm_contribution',


### PR DESCRIPTION
… functions

Overview
----------------------------------------
Title says it all

Before
----------------------------------------
Test classes without voids causes issues on phpunit8

After
----------------------------------------
No issues

ping @eileenmcnaughton 