### PR TITLE
[REF] Useradd contact task - Use OO instead of hardcoding "if Wordpress"

### DIFF
--- a/CRM/Contact/Form/Task/Useradd.php
+++ b/CRM/Contact/Form/Task/Useradd.php
@@ -71,9 +71,9 @@ class CRM_Contact_Form_Task_Useradd extends CRM_Core_Form {
     $this->add('text', 'cms_name', ts('Username'), ['class' => 'huge']);
     $this->addRule('cms_name', ts('Username is required'), 'required');
 
-    // For WordPress only, comply with how WordPress sets passwords via magic link
+    // WordPress may or may not require setting passwords via magic link, depending on its configuration.
     // For other CMS, output the password fields
-    if ($config->userFramework !== 'WordPress' || ($config->userFramework === 'WordPress' && !$config->userSystem->isUserRegistrationPermitted())) {
+    if ($config->userSystem->showPasswordFieldWhenAdminCreatesUser()) {
       $this->add('password', 'cms_pass', ts('Password'), ['class' => 'huge']);
       $this->add('password', 'cms_confirm_pass', ts('Confirm Password'), ['class' => 'huge']);
       $this->addRule('cms_pass', ts('Password is required'), 'required');

--- a/CRM/Utils/System/Base.php
+++ b/CRM/Utils/System/Base.php
@@ -1057,4 +1057,12 @@ abstract class CRM_Utils_System_Base {
   public function invalidateRouteCache() {
   }
 
+  /**
+   * Should the admin be able to set the password when creating a user
+   * or does the CMS want it a different way.
+   */
+  public function showPasswordFieldWhenAdminCreatesUser() {
+    return TRUE;
+  }
+
 }

--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -1462,4 +1462,12 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
     add_action('profile_update', [$civicrm->users, 'update_user']);
   }
 
+  /**
+   * Depending on configuration, either let the admin enter the password
+   * when creating a user or let the user do it via email link.
+   */
+  public function showPasswordFieldWhenAdminCreatesUser() {
+    return !$this->isUserRegistrationPermitted();
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
This should be no change from current - putting it up while it's still in recent memory.

Before
----------------------------------------
1. Log in as a user who can create users in the CMS.
2. Visit a contact record.
3. From the actions dropdown choose Create User Record.
4. On all CMS's except wordpress there'll be a password field.
5. On wordpress it depends if users can register.

After
----------------------------------------
Same

Technical Details
----------------------------------------
Just refactors so that it isn't "if Wordpress" and instead uses the class hierarchy.

Comments
----------------------------------------

