### PR TITLE
[NFC] Add in more voids to unit tests to support PHPUnit8

### DIFF
--- a/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
@@ -133,7 +133,7 @@ class CRM_Contribute_Form_ContributionTest extends CiviUnitTestCase {
    *
    * @throws \CRM_Core_Exception
    */
-  protected function assertPostConditions() {
+  protected function assertPostConditions(): void {
     $this->validateAllPayments();
   }
 

--- a/tests/phpunit/CRM/Event/BAO/AdditionalPaymentTest.php
+++ b/tests/phpunit/CRM/Event/BAO/AdditionalPaymentTest.php
@@ -53,7 +53,7 @@ class CRM_Event_BAO_AdditionalPaymentTest extends CiviUnitTestCase {
    *
    * @throws \CRM_Core_Exception
    */
-  protected function assertPostConditions() {
+  protected function assertPostConditions(): void {
     $this->validateAllPayments();
     $this->validateAllContributions();
   }

--- a/tests/phpunit/CRM/Event/Form/ParticipantTest.php
+++ b/tests/phpunit/CRM/Event/Form/ParticipantTest.php
@@ -28,7 +28,7 @@ class CRM_Event_Form_ParticipantTest extends CiviUnitTestCase {
    *
    * @throws \CRM_Core_Exception
    */
-  protected function assertPostConditions() {
+  protected function assertPostConditions(): void {
     $this->validateAllPayments();
     $this->validateAllContributions();
   }

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -534,7 +534,7 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
    * @throws \API_Exception
    * @throws \CRM_Core_Exception
    */
-  protected function assertPostConditions() {
+  protected function assertPostConditions(): void {
     // Reset to version 3 as not all (e.g payments) work on v4
     $this->_apiversion = 3;
     if ($this->isLocationTypesOnPostAssert) {

--- a/tests/phpunit/api/v4/Entity/CaseTest.php
+++ b/tests/phpunit/api/v4/Entity/CaseTest.php
@@ -27,7 +27,7 @@ use api\v4\UnitTestCase;
  */
 class CaseTest extends UnitTestCase {
 
-  public function setUp() {
+  public function setUp(): void {
     parent::setUp();
     \CRM_Core_BAO_ConfigSetting::enableComponent('CiviCase');
     $this->loadDataSet('CaseType');


### PR DESCRIPTION
Overview
----------------------------------------
This adds more voids in to support phpunit8

Before
----------------------------------------
Some test suites don't start on phpunit8

After
----------------------------------------
Test suites start on phpunit8

ping @eileenmcnaughton 