### PR TITLE
Use PHPUnit8 in main test suites

### DIFF
--- a/tools/scripts/phpunit
+++ b/tools/scripts/phpunit
@@ -15,7 +15,17 @@ $argFilters = [];
 if (PHP_SAPI !== 'cli') {
   die("phpunit can only be run from command line.");
 }
-if (version_compare(PHP_VERSION, '7.1', '>=')) {
+if (version_compare(PHP_VERSION, '7.2', '>=')) {
+  $phpunit = findCommand('phpunit8');
+  $argFilters[] = function ($argv) {
+    $pos = array_search('--tap', $argv);
+    if ($pos !== FALSE) {
+      array_splice($argv, $pos, 1, ['--printer', '\Civi\Test\TAP']);
+    }
+    return $argv;
+  };
+}
+elseif (version_compare(PHP_VERSION, '7.1', '>=')) {
   $phpunit = findCommand('phpunit7');
   $argFilters[] = function ($argv) {
     $pos = array_search('--tap', $argv);


### PR DESCRIPTION
Overview
----------------------------------------
This makes phpunit8 the default test runner for php versions greater than 7.2 for the core test suites

Before
----------------------------------------
PHPUnit7 used as the default

After
----------------------------------------
PHPUnit8 used as default

Technical Details
----------------------------------------
To make this work for Jenkins reasons we need this PR https://github.com/civicrm/civicrm-buildkit/pull/626#issuecomment-846518332 or to upgrade xunit

ping @eileenmcnaughton @totten 