### PR TITLE
Prevent adding duplicate dashlet if present with same name and label

### DIFF
--- a/CRM/Core/BAO/Dashboard.php
+++ b/CRM/Core/BAO/Dashboard.php
@@ -233,9 +233,8 @@ class CRM_Core_BAO_Dashboard extends CRM_Core_DAO_Dashboard {
       $dashlet->domain_id = $params['domain_id'] ?? CRM_Core_Config::domainID();
 
       // Try and find an existing dashlet - it will be updated if found.
-      if (!empty($params['name']) || !empty($params['url'])) {
+      if (!empty($params['name'])) {
         $dashlet->name = $params['name'] ?? NULL;
-        $dashlet->url = $params['url'] ?? NULL;
         $dashlet->find(TRUE);
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------
Steps to replicate:

1. Go to any existing report instance (say 'Activity Details') >>  enable for 'Available for Dashboard' >> Save
2. Then change the 'Limit Dashboard Results' count and save again.
3. Go to homepage, and click  on 'Available Dashlets'


Before
----------------------------------------
There are duplicate dashlets under 'Available Dashlets'

After
----------------------------------------
Updates the existing dashlets. 
