### PR TITLE
[NFC] Fix PHPUnit8 deprecation warnings in the CRM_AllTests suite

### DIFF
--- a/tests/phpunit/CRM/Activity/BAO/ActivityTest.php
+++ b/tests/phpunit/CRM/Activity/BAO/ActivityTest.php
@@ -510,7 +510,7 @@ class CRM_Activity_BAO_ActivityTest extends CiviUnitTestCase {
     $this->checkArrayEquals($expectedFilters, $activityFilter);
     // This should include activities of type Meeting only.
     foreach ($activities['data'] as $value) {
-      $this->assertContains('Meeting', $value['activity_type']);
+      $this->assertStringContainsString('Meeting', $value['activity_type']);
     }
     unset($_GET['activity_type_id']);
 
@@ -525,7 +525,7 @@ class CRM_Activity_BAO_ActivityTest extends CiviUnitTestCase {
     $this->assertEquals(['activity_type_exclude_filter_id' => 1], $activityFilter);
     // None of the activities should be of type Meeting.
     foreach ($activities['data'] as $value) {
-      $this->assertNotContains('Meeting', $value['activity_type']);
+      $this->assertStringNotContainsString('Meeting', $value['activity_type']);
     }
   }
 
@@ -1299,14 +1299,13 @@ $text
   }
 
   /**
-   * @expectedException CRM_Core_Exception
-   * @expectedExceptionMessage You do not have the 'send SMS' permission
    */
   public function testSendSMSWithoutPermission() {
     $dummy = NULL;
     $session = CRM_Core_Session::singleton();
     CRM_Core_Config::singleton()->userPermissionClass->permissions = ['access CiviCRM'];
-
+    $this->expectException(CRM_Core_Exception::class);
+    $this->expectExceptionMessage('You do not have the \'send SMS\' permission');
     CRM_Activity_BAO_Activity::sendSMS(
       $dummy,
       $dummy,

--- a/tests/phpunit/CRM/Activity/Form/ActivityTest.php
+++ b/tests/phpunit/CRM/Activity/Form/ActivityTest.php
@@ -376,7 +376,7 @@ ENDBODY;
 
     // This kind of suffers from the same problem as the old webtests. It's
     // a bit brittle and tied to the UI.
-    $this->assertContains("Hi,<br />\n<br />\nWassup!?!?<br />\n<br />\nLet's check if the output when viewing the form has legible line breaks in the output.<br />\n<br />\nThanks!", $output);
+    $this->assertStringContainsString("Hi,<br />\n<br />\nWassup!?!?<br />\n<br />\nLet's check if the output when viewing the form has legible line breaks in the output.<br />\n<br />\nThanks!", $output);
 
     // Put label back
     $this->callAPISuccess('OptionValue', 'create', [

--- a/tests/phpunit/CRM/Activity/Form/Task/PDFLetterCommonTest.php
+++ b/tests/phpunit/CRM/Activity/Form/Task/PDFLetterCommonTest.php
@@ -39,7 +39,7 @@ class CRM_Activity_Form_Task_PDFLetterCommonTest extends CiviUnitTestCase {
 
     // Check some basic fields
     foreach ($data as $line) {
-      $this->assertContains("\n" . $line[1] . "\n", $output[0]);
+      $this->assertStringContainsString("\n" . $line[1] . "\n", $output[0]);
     }
   }
 

--- a/tests/phpunit/CRM/Case/BAO/CaseTest.php
+++ b/tests/phpunit/CRM/Case/BAO/CaseTest.php
@@ -226,7 +226,7 @@ class CRM_Case_BAO_CaseTest extends CiviUnitTestCase {
     ];
     $sortedActualContactNames = CRM_Utils_Array::collect('sort_name', $cases);
     foreach ($sortedExpectedContactNames as $key => $name) {
-      $this->assertContains($name, $sortedActualContactNames[$key]);
+      $this->assertStringContainsString($name, $sortedActualContactNames[$key]);
     }
   }
 

--- a/tests/phpunit/CRM/Case/Form/SearchTest.php
+++ b/tests/phpunit/CRM/Case/Form/SearchTest.php
@@ -36,7 +36,7 @@ class CRM_Case_Form_SearchTest extends CiviCaseTestCase {
     // as webtests. Mostly what we're doing in this test is checking that it
     // doesn't generate any E_NOTICES/WARNINGS or other errors. But let's do
     // one check.
-    $this->assertContains('<label for="case_id">', $contents);
+    $this->assertStringContainsString('<label for="case_id">', $contents);
   }
 
 }

--- a/tests/phpunit/CRM/Contact/BAO/GroupContactCacheTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/GroupContactCacheTest.php
@@ -424,7 +424,7 @@ class CRM_Contact_BAO_GroupContactCacheTest extends CiviUnitTestCase {
     );
     $key = $query->getGroupCacheTableKeys()[0];
     $expectedWhere = "civicrm_group_contact_cache_{$key}.group_id IN (\"{$group2->id}\")";
-    $this->assertContains($expectedWhere, $query->_whereClause);
+    $this->assertStringContainsString($expectedWhere, $query->_whereClause);
     $this->_assertContactIds($query, "group_id = {$group2->id}");
 
     $params = [['group', '!=', $group->id, 1, 0]];
@@ -437,7 +437,7 @@ class CRM_Contact_BAO_GroupContactCacheTest extends CiviUnitTestCase {
     $key = $query->getGroupCacheTableKeys()[0];
     //Assert if proper where clause is present.
     $expectedWhere = "civicrm_group_contact_{$key}.group_id != {$group->id} AND civicrm_group_contact_cache_{$key}.group_id IS NULL OR  ( civicrm_group_contact_cache_{$key}.contact_id NOT IN (SELECT contact_id FROM civicrm_group_contact_cache cgcc WHERE cgcc.group_id IN ( {$group->id} ) ) )";
-    $this->assertContains($expectedWhere, $query->_whereClause);
+    $this->assertStringContainsString($expectedWhere, $query->_whereClause);
     $this->_assertContactIds($query, "group_id != {$group->id}");
 
     $params = [['group', 'IN', [$group->id, $group2->id], 1, 0]];
@@ -461,7 +461,7 @@ class CRM_Contact_BAO_GroupContactCacheTest extends CiviUnitTestCase {
     );
     $key = $query->getGroupCacheTableKeys()[0];
     $expectedWhere = "civicrm_group_contact_{$key}.group_id NOT IN ( {$group->id} ) AND civicrm_group_contact_cache_{$key}.group_id IS NULL OR  ( civicrm_group_contact_cache_{$key}.contact_id NOT IN (SELECT contact_id FROM civicrm_group_contact_cache cgcc WHERE cgcc.group_id IN ( {$group->id} ) ) )";
-    $this->assertContains($expectedWhere, $query->_whereClause);
+    $this->assertStringContainsString($expectedWhere, $query->_whereClause);
     $this->_assertContactIds($query, "group_id NOT IN ({$group->id})");
     $this->callAPISuccess('group', 'delete', ['id' => $group->id]);
     $this->callAPISuccess('group', 'delete', ['id' => $group2->id]);
@@ -499,14 +499,14 @@ class CRM_Contact_BAO_GroupContactCacheTest extends CiviUnitTestCase {
     $key1 = $query->getGroupCacheTableKeys()[0];
     $key2 = $query->getGroupCacheTableKeys()[1];
     $expectedWhere = 'civicrm_group_contact_cache_' . $key1 . '.group_id IN ("' . $group2->id . '") )  )  AND  (  ( civicrm_group_contact_cache_' . $key2 . '.group_id IN ("' . $group->id . '")';
-    $this->assertContains($expectedWhere, $query->_whereClause);
+    $this->assertStringContainsString($expectedWhere, $query->_whereClause);
     // Check that we have 3 joins to the group contact cache 1 for each of the group where clauses and 1 for the fact we are returning groups in the select.
     $expectedFrom1 = 'LEFT JOIN civicrm_group_contact_cache civicrm_group_contact_cache_' . $key1 . ' ON contact_a.id = civicrm_group_contact_cache_' . $key1 . '.contact_id';
-    $this->assertContains($expectedFrom1, $query->_fromClause);
+    $this->assertStringContainsString($expectedFrom1, $query->_fromClause);
     $expectedFrom2 = 'LEFT JOIN civicrm_group_contact_cache civicrm_group_contact_cache_' . $key2 . ' ON contact_a.id = civicrm_group_contact_cache_' . $key2 . '.contact_id';
-    $this->assertContains($expectedFrom2, $query->_fromClause);
+    $this->assertStringContainsString($expectedFrom2, $query->_fromClause);
     $expectedFrom3 = 'LEFT JOIN civicrm_group_contact_cache ON contact_a.id = civicrm_group_contact_cache.contact_id';
-    $this->assertContains($expectedFrom3, $query->_fromClause);
+    $this->assertStringContainsString($expectedFrom3, $query->_fromClause);
   }
 
   /**

--- a/tests/phpunit/CRM/Contact/BAO/QueryTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/QueryTest.php
@@ -445,39 +445,39 @@ class CRM_Contact_BAO_QueryTest extends CiviUnitTestCase {
    */
   public function testSearchBuilderActivityType() {
     $queryObj = new CRM_Contact_BAO_Query([['activity_type', '=', '3', 1, 0]]);
-    $this->assertContains('WHERE  (  ( civicrm_activity.activity_type_id = 3 )', $queryObj->getSearchSQL());
+    $this->assertStringContainsString('WHERE  (  ( civicrm_activity.activity_type_id = 3 )', $queryObj->getSearchSQL());
     $this->assertEquals('Activity Type = Email', $queryObj->_qill[1][0]);
 
     $queryObj = new CRM_Contact_BAO_Query([['activity_type_id', '=', '3', 1, 0]]);
-    $this->assertContains('WHERE  (  ( civicrm_activity.activity_type_id = 3 )', $queryObj->getSearchSQL());
+    $this->assertStringContainsString('WHERE  (  ( civicrm_activity.activity_type_id = 3 )', $queryObj->getSearchSQL());
     $this->assertEquals('Activity Type ID = Email', $queryObj->_qill[1][0]);
 
     $queryObj = new CRM_Contact_BAO_Query([['activity_status', '=', '3', 1, 0]]);
-    $this->assertContains('WHERE  (  ( civicrm_activity.status_id = 3 )', $queryObj->getSearchSQL());
+    $this->assertStringContainsString('WHERE  (  ( civicrm_activity.status_id = 3 )', $queryObj->getSearchSQL());
     $this->assertEquals('Activity Status = Cancelled', $queryObj->_qill[1][0]);
 
     $queryObj = new CRM_Contact_BAO_Query([['activity_status_id', '=', '3', 1, 0]]);
-    $this->assertContains('WHERE  (  ( civicrm_activity.status_id = 3 )', $queryObj->getSearchSQL());
+    $this->assertStringContainsString('WHERE  (  ( civicrm_activity.status_id = 3 )', $queryObj->getSearchSQL());
     $this->assertEquals('Activity Status = Cancelled', $queryObj->_qill[1][0]);
 
     $queryObj = new CRM_Contact_BAO_Query([['activity_engagement_level', '=', '3', 1, 0]]);
-    $this->assertContains('WHERE  (  ( civicrm_activity.engagement_level = 3 )', $queryObj->getSearchSQL());
+    $this->assertStringContainsString('WHERE  (  ( civicrm_activity.engagement_level = 3 )', $queryObj->getSearchSQL());
     $this->assertEquals('Engagement Index = 3', $queryObj->_qill[1][0]);
 
     $queryObj = new CRM_Contact_BAO_Query([['activity_id', '=', '3', 1, 0]]);
-    $this->assertContains('WHERE  (  ( civicrm_activity.id = 3 )', $queryObj->getSearchSQL());
+    $this->assertStringContainsString('WHERE  (  ( civicrm_activity.id = 3 )', $queryObj->getSearchSQL());
     $this->assertEquals('Activity ID = 3', $queryObj->_qill[1][0]);
 
     $queryObj = new CRM_Contact_BAO_Query([['activity_campaign_id', '=', '3', 1, 0]]);
-    $this->assertContains('WHERE  (  ( civicrm_activity.campaign_id = 3 )', $queryObj->getSearchSQL());
+    $this->assertStringContainsString('WHERE  (  ( civicrm_activity.campaign_id = 3 )', $queryObj->getSearchSQL());
     $this->assertEquals('Campaign ID = 3', $queryObj->_qill[1][0]);
 
     $queryObj = new CRM_Contact_BAO_Query([['activity_priority_id', '=', '3', 1, 0]]);
-    $this->assertContains('WHERE  (  ( civicrm_activity.priority_id = 3 )', $queryObj->getSearchSQL());
+    $this->assertStringContainsString('WHERE  (  ( civicrm_activity.priority_id = 3 )', $queryObj->getSearchSQL());
     $this->assertEquals('Priority = Low', $queryObj->_qill[1][0]);
 
     $queryObj = new CRM_Contact_BAO_Query([['activity_subject', '=', '3', 1, 0]]);
-    $this->assertContains("WHERE  (  ( civicrm_activity.subject = '3' )", $queryObj->getSearchSQL());
+    $this->assertStringContainsString("WHERE  (  ( civicrm_activity.subject = '3' )", $queryObj->getSearchSQL());
     $this->assertEquals("Subject = '3'", $queryObj->_qill[1][0]);
   }
 
@@ -834,7 +834,7 @@ class CRM_Contact_BAO_QueryTest extends CiviUnitTestCase {
       ],
     ];
     $sql = CRM_Contact_BAO_Query::getQuery($params);
-    $this->assertContains('INNER JOIN civicrm_tmp_e', $sql, 'Query appears to use temporary table of compiled relationships?', TRUE);
+    $this->assertStringContainsStringIgnoringCase('INNER JOIN civicrm_tmp_e', $sql, 'Query appears to use temporary table of compiled relationships?');
   }
 
   /**
@@ -845,7 +845,7 @@ class CRM_Contact_BAO_QueryTest extends CiviUnitTestCase {
   public function testRelationshipPermissionClause() {
     $params = [['relation_type_id', 'IN', ['1_b_a'], 0, 0], ['relation_permission', 'IN', [2], 0, 0]];
     $sql = CRM_Contact_BAO_Query::getQuery($params);
-    $this->assertContains('(civicrm_relationship.is_permission_a_b IN (2))', $sql);
+    $this->assertStringContainsString('(civicrm_relationship.is_permission_a_b IN (2))', $sql);
   }
 
   /**

--- a/tests/phpunit/CRM/Contact/Form/Search/Custom/PriceSetTest.php
+++ b/tests/phpunit/CRM/Contact/Form/Search/Custom/PriceSetTest.php
@@ -67,7 +67,7 @@ class CRM_Contact_Form_Search_Custom_PriceSetTest extends CiviUnitTestCase {
     $form = new CRM_Contact_Form_Search_Custom_PriceSet($formValues);
     $sql = $form->all();
     // Assert that we have created a standard temp table
-    $this->assertContains('civicrm_tmp_e_priceset', $sql);
+    $this->assertStringContainsString('civicrm_tmp_e_priceset', $sql);
     // Check that the temp table has been populated.
     $result = CRM_Core_DAO::executeQuery($sql)->fetchAll();
     $this->assertTrue(!empty($result));

--- a/tests/phpunit/CRM/Contact/Form/Task/EmailCommonTest.php
+++ b/tests/phpunit/CRM/Contact/Form/Task/EmailCommonTest.php
@@ -122,7 +122,7 @@ class CRM_Contact_Form_Task_EmailCommonTest extends CiviUnitTestCase {
     $activity = Activity::get(FALSE)->setSelect(['details'])->execute()->first();
     $bccUrl1 = CRM_Utils_System::url('civicrm/contact/view', ['reset' => 1, 'cid' => $bcc1], TRUE);
     $bccUrl2 = CRM_Utils_System::url('civicrm/contact/view', ['reset' => 1, 'cid' => $bcc2], TRUE);
-    $this->assertContains("bcc : <a href='" . $bccUrl1 . "'>Mr. Anthony Anderson II</a>, <a href='" . $bccUrl2 . "'>Mr. Anthony Anderson II</a>", $activity['details']);
+    $this->assertStringContainsString("bcc : <a href='" . $bccUrl1 . "'>Mr. Anthony Anderson II</a>, <a href='" . $bccUrl2 . "'>Mr. Anthony Anderson II</a>", $activity['details']);
     $this->assertEquals([
       [
         'text' => '27 messages were sent successfully. ',

--- a/tests/phpunit/CRM/Contact/Form/Task/PrintMailingLabelTest.php
+++ b/tests/phpunit/CRM/Contact/Form/Task/PrintMailingLabelTest.php
@@ -83,7 +83,7 @@ class CRM_Contact_Form_Task_PrintMailingLabelTest extends CiviUnitTestCase {
 
     foreach ($this->_contactIds as $contactID) {
       // ensure that the address printed in the mailing labe is always primary if 'location_type_id' - none (as Primary) is chosen
-      $this->assertContains($addresses[$contactID]['primary']['street_address'], $rows[$contactID][0]);
+      $this->assertStringContainsString($addresses[$contactID]['primary']['street_address'], $rows[$contactID][0]);
     }
 
     // restore setting

--- a/tests/phpunit/CRM/Contact/Page/View/UserDashboard/GroupContactTest.php
+++ b/tests/phpunit/CRM/Contact/Page/View/UserDashboard/GroupContactTest.php
@@ -158,10 +158,10 @@ class CRM_Contact_Page_View_UserDashboard_GroupContactTest extends CiviUnitTestC
 
     $form = CRM_Core_Smarty::singleton()->get_template_vars('form');
     $group_id_field_html = $form['group_id']['html'];
-    $this->assertContains($publicSmartGroupTitle, $group_id_field_html, "Group '$publicSmartGroupTitle' should be in listed available groups, but is not.");
-    $this->assertContains($publicStdGroupTitle, $group_id_field_html, "Group '$publicStdGroupTitle' should be in listed available groups, but is not.");
-    $this->assertNotContains('* ' . $adminSmartGroupTitle, $group_id_field_html, "Group '$adminSmartGroupTitle' should not be in listed available groups, but is.");
-    $this->assertNotContains($adminStdGroupTitle, $group_id_field_html, "Group '$adminStdGroupTitle' should not be in listed available groups, but is.");
+    $this->assertStringContainsString($publicSmartGroupTitle, $group_id_field_html, "Group '$publicSmartGroupTitle' should be in listed available groups, but is not.");
+    $this->assertStringContainsString($publicStdGroupTitle, $group_id_field_html, "Group '$publicStdGroupTitle' should be in listed available groups, but is not.");
+    $this->assertStringNotContainsString('* ' . $adminSmartGroupTitle, $group_id_field_html, "Group '$adminSmartGroupTitle' should not be in listed available groups, but is.");
+    $this->assertStringNotContainsString($adminStdGroupTitle, $group_id_field_html, "Group '$adminStdGroupTitle' should not be in listed available groups, but is.");
 
     // Add current user to the test groups.
     $publicSmartGroup = $this->callAPISuccess('Contact', 'create', [

--- a/tests/phpunit/CRM/Contact/SelectorTest.php
+++ b/tests/phpunit/CRM/Contact/SelectorTest.php
@@ -66,7 +66,7 @@ class CRM_Contact_SelectorTest extends CiviUnitTestCase {
       $this->assertLike($this->strWrangle($queryString), $this->strWrangle($sql[$index]));
     }
     if (!empty($dataSet['where_contains'])) {
-      $this->assertContains($this->strWrangle(str_replace('@tagid', $tag['id'], $dataSet['where_contains'])), $this->strWrangle($sql[2]));
+      $this->assertStringContainsString($this->strWrangle(str_replace('@tagid', $tag['id'], $dataSet['where_contains'])), $this->strWrangle($sql[2]));
     }
     // Ensure that search builder return individual contact as per criteria
     if ($dataSet['context'] === 'builder') {
@@ -175,7 +175,7 @@ class CRM_Contact_SelectorTest extends CiviUnitTestCase {
     //Check if email column contains (On Hold) string.
     foreach ($rows[$contactID] as $key => $value) {
       if (strpos($key, 'email') !== FALSE) {
-        $this->assertContains("(On Hold)", (string) $value);
+        $this->assertStringContainsString("(On Hold)", (string) $value);
       }
     }
   }

--- a/tests/phpunit/CRM/Contribute/BAO/ContributionPageTest.php
+++ b/tests/phpunit/CRM/Contribute/BAO/ContributionPageTest.php
@@ -47,7 +47,7 @@ class CRM_Contribute_BAO_ContributionPageTest extends CiviUnitTestCase {
     $contributionpage = CRM_Contribute_BAO_ContributionPage::create($params);
 
     $this->assertNotNull($contributionpage->id);
-    $this->assertType('int', $contributionpage->id);
+    $this->assertIsInt($contributionpage->id);
     $this->callAPISuccess('ContributionPage', 'delete', ['id' => $contributionpage->id]);
   }
 

--- a/tests/phpunit/CRM/Contribute/BAO/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/BAO/ContributionTest.php
@@ -305,9 +305,9 @@ class CRM_Contribute_BAO_ContributionTest extends CiviUnitTestCase {
     $this->createLoggedInUserWithFinancialACL();
     $permittedFinancialType = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'financial_type_id', 'Donation');
     $sql = CRM_Contribute_BAO_Contribution::getAnnualQuery([1, 2, 3]);
-    $this->assertContains('SUM(total_amount) as amount,', $sql);
-    $this->assertContains('WHERE b.contact_id IN (1,2,3)', $sql);
-    $this->assertContains('b.financial_type_id IN (' . $permittedFinancialType . ')', $sql);
+    $this->assertStringContainsString('SUM(total_amount) as amount,', $sql);
+    $this->assertStringContainsString('WHERE b.contact_id IN (1,2,3)', $sql);
+    $this->assertStringContainsString('b.financial_type_id IN (' . $permittedFinancialType . ')', $sql);
 
     // Run it to make sure it's not bad sql.
     CRM_Core_DAO::executeQuery($sql);
@@ -337,9 +337,9 @@ class CRM_Contribute_BAO_ContributionTest extends CiviUnitTestCase {
    */
   public function testAnnualQueryWithFinancialACLsDisabled() {
     $sql = CRM_Contribute_BAO_Contribution::getAnnualQuery([1, 2, 3]);
-    $this->assertContains('SUM(total_amount) as amount,', $sql);
-    $this->assertContains('WHERE b.contact_id IN (1,2,3)', $sql);
-    $this->assertNotContains('b.financial_type_id', $sql);
+    $this->assertStringContainsString('SUM(total_amount) as amount,', $sql);
+    $this->assertStringContainsString('WHERE b.contact_id IN (1,2,3)', $sql);
+    $this->assertStringNotContainsString('b.financial_type_id', $sql);
     //$this->assertNotContains('line_item', $sql);
     // Run it to make sure it's not bad sql.
     CRM_Core_DAO::executeQuery($sql);
@@ -351,10 +351,10 @@ class CRM_Contribute_BAO_ContributionTest extends CiviUnitTestCase {
   public function testAnnualQueryWithFinancialHook() {
     $this->hookClass->setHook('civicrm_selectWhereClause', [$this, 'aclIdNoZero']);
     $sql = CRM_Contribute_BAO_Contribution::getAnnualQuery([1, 2, 3]);
-    $this->assertContains('SUM(total_amount) as amount,', $sql);
-    $this->assertContains('WHERE b.contact_id IN (1,2,3)', $sql);
-    $this->assertContains('b.id NOT IN (0)', $sql);
-    $this->assertNotContains('b.financial_type_id', $sql);
+    $this->assertStringContainsString('SUM(total_amount) as amount,', $sql);
+    $this->assertStringContainsString('WHERE b.contact_id IN (1,2,3)', $sql);
+    $this->assertStringContainsString('b.id NOT IN (0)', $sql);
+    $this->assertStringNotContainsString('b.financial_type_id', $sql);
     CRM_Core_DAO::executeQuery($sql);
   }
 

--- a/tests/phpunit/CRM/Contribute/BAO/QueryTest.php
+++ b/tests/phpunit/CRM/Contribute/BAO/QueryTest.php
@@ -39,7 +39,7 @@ class CRM_Contribute_BAO_QueryTest extends CiviUnitTestCase {
     $queryObj = new CRM_Contact_BAO_Query($params);
     $sql = $queryObj->getSearchSQL(0, 0, $sort . ' asc');
     if ($isUseKeySort) {
-      $this->assertContains('field(', $sql);
+      $this->assertStringContainsString('field(', $sql);
     }
     try {
       $resultDAO = CRM_Core_DAO::executeQuery($sql);

--- a/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
@@ -1397,7 +1397,7 @@ Price Field - Price Field 1        1   $ 100.00      $ 100.00
       $form->preProcess();
     }
     catch (CRM_Core_Exception $e) {
-      $this->assertContains("A payment processor configured for this page might be disabled (contact the site administrator for assistance).", $e->getMessage());
+      $this->assertStringContainsString("A payment processor configured for this page might be disabled (contact the site administrator for assistance).", $e->getMessage());
       return;
     }
     $this->fail('Exception was expected');
@@ -1776,7 +1776,7 @@ Price Field - Price Field 1        1   $ 100.00      $ 100.00
 
     // The page contents load later by ajax, so there's just the surrounding
     // html available now, but we can check at least one thing while we're here.
-    $this->assertContains("mainTabContainer", $contents);
+    $this->assertStringContainsString("mainTabContainer", $contents);
   }
 
   /**

--- a/tests/phpunit/CRM/Contribute/Form/Task/InvoiceTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/Task/InvoiceTest.php
@@ -67,14 +67,14 @@ class CRM_Contribute_Form_Task_InvoiceTest extends CiviUnitTestCase {
       $invoiceHTML[current($contributionID)] = CRM_Contribute_Form_Task_Invoice::printPDF($contributionID, $params, $contactIds);
     }
 
-    $this->assertNotContains('Due Date', $invoiceHTML[$result['id']]);
-    $this->assertNotContains('PAYMENT ADVICE', $invoiceHTML[$result['id']]);
-    $this->assertContains('Mr. Anthony Anderson II', $invoiceHTML[$result['id']]);
+    $this->assertStringNotContainsString('Due Date', $invoiceHTML[$result['id']]);
+    $this->assertStringNotContainsString('PAYMENT ADVICE', $invoiceHTML[$result['id']]);
+    $this->assertStringContainsString('Mr. Anthony Anderson II', $invoiceHTML[$result['id']]);
 
-    $this->assertContains('Due Date', $invoiceHTML[$contribution['id']]);
-    $this->assertContains('PAYMENT ADVICE', $invoiceHTML[$contribution['id']]);
+    $this->assertStringContainsString('Due Date', $invoiceHTML[$contribution['id']]);
+    $this->assertStringContainsString('PAYMENT ADVICE', $invoiceHTML[$contribution['id']]);
 
-    $this->assertContains('AMOUNT DUE:</font></b></td>
+    $this->assertStringContainsString('AMOUNT DUE:</font></b></td>
                 <td style="text-align:right;"><b><font size="1">$ 92.00</font></b></td>', $invoiceHTML[$contribution3['id']]);
   }
 
@@ -152,11 +152,11 @@ class CRM_Contribute_Form_Task_InvoiceTest extends CiviUnitTestCase {
     $lineItems = $this->callAPISuccess('LineItem', 'get', ['contribution_id' => $order['id']]);
 
     foreach ($lineItems['values'] as $lineItem) {
-      $this->assertContains("<font size=\"1\">$ {$lineItem['line_total']}</font>", $invoiceHTML);
+      $this->assertStringContainsString("<font size=\"1\">$ {$lineItem['line_total']}</font>", $invoiceHTML);
     }
 
     $totalAmount = $this->formatMoneyInput($order['values'][$order['id']]['total_amount']);
-    $this->assertContains("TOTAL USD</font></b></td>
+    $this->assertStringContainsString("TOTAL USD</font></b></td>
                 <td style=\"text-align:right;\"><font size=\"1\">$ $totalAmount</font>", $invoiceHTML);
 
   }
@@ -190,13 +190,13 @@ class CRM_Contribute_Form_Task_InvoiceTest extends CiviUnitTestCase {
 
     $invoiceHTML = CRM_Contribute_Form_Task_Invoice::printPDF([$contribution['id']], $params, [$this->_individualId]);
 
-    $this->assertNotContains('$', $invoiceHTML);
-    $this->assertNotContains('Amount USD', $invoiceHTML);
-    $this->assertNotContains('TOTAL USD', $invoiceHTML);
-    $this->assertContains('£ 0.00', $invoiceHTML);
-    $this->assertContains('£ 100.00', $invoiceHTML);
-    $this->assertContains('Amount GBP', $invoiceHTML);
-    $this->assertContains('TOTAL GBP', $invoiceHTML);
+    $this->assertStringNotContainsString('$', $invoiceHTML);
+    $this->assertStringNotContainsString('Amount USD', $invoiceHTML);
+    $this->assertStringNotContainsString('TOTAL USD', $invoiceHTML);
+    $this->assertStringContainsString('£ 0.00', $invoiceHTML);
+    $this->assertStringContainsString('£ 100.00', $invoiceHTML);
+    $this->assertStringContainsString('Amount GBP', $invoiceHTML);
+    $this->assertStringContainsString('TOTAL GBP', $invoiceHTML);
 
   }
 

--- a/tests/phpunit/CRM/Contribute/Form/Task/PDFLetterCommonTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/Task/PDFLetterCommonTest.php
@@ -105,7 +105,7 @@ class CRM_Contribute_Form_Task_PDFLetterCommonTest extends CiviUnitTestCase {
       $form->postProcess();
     }
     catch (CRM_Core_Exception_PrematureExitException $e) {
-      $this->assertContains('USD, USD * $ 60.00, $ 70.00 * January 1st, 2021  1:21 PM, February 1st, 2021  2:21 AM', $e->errorData['html']);
+      $this->assertStringContainsString('USD, USD * $ 60.00, $ 70.00 * January 1st, 2021  1:21 PM, February 1st, 2021  2:21 AM', $e->errorData['html']);
     }
   }
 

--- a/tests/phpunit/CRM/Contribute/Selector/SearchTest.php
+++ b/tests/phpunit/CRM/Contribute/Selector/SearchTest.php
@@ -24,7 +24,7 @@ class CRM_Contribute_Selector_SearchTest extends CiviUnitTestCase {
     $searchSelector = new CRM_Contribute_Selector_Search($queryParams, CRM_Core_Action::VIEW);
 
     list($select, $from, $where, $having) = $searchSelector->getQuery()->query();
-    self::assertContains('civicrm_contribution_soft.amount', $select);
+    $this->assertStringContainsString('civicrm_contribution_soft.amount', $select);
   }
 
   /**
@@ -35,7 +35,7 @@ class CRM_Contribute_Selector_SearchTest extends CiviUnitTestCase {
     $searchSelector = new CRM_Contribute_Selector_Search($queryParams, CRM_Core_Action::VIEW);
 
     list($select, $from, $where, $having) = $searchSelector->getQuery()->query();
-    self::assertNotContains('civicrm_contribution_soft.amount', $select);
+    $this->assertStringNotContainsString('civicrm_contribution_soft.amount', $select);
   }
 
 }

--- a/tests/phpunit/CRM/Core/BAO/ActionScheduleTest.php
+++ b/tests/phpunit/CRM/Core/BAO/ActionScheduleTest.php
@@ -1095,7 +1095,7 @@ class CRM_Core_BAO_ActionScheduleTest extends CiviUnitTestCase {
       ->addWhere('source_record_id', '=', $activity->id)
       ->execute();
     foreach ($activities as $activityDetails) {
-      $this->assertContains($activity->subject, $activityDetails['details']);
+      $this->assertStringContainsString($activity->subject, $activityDetails['details']);
     }
   }
 

--- a/tests/phpunit/CRM/Core/BAO/CustomFieldTest.php
+++ b/tests/phpunit/CRM/Core/BAO/CustomFieldTest.php
@@ -977,8 +977,8 @@ class CRM_Core_BAO_CustomFieldTest extends CiviUnitTestCase {
     ])->execute();
     $dao = CRM_Core_DAO::executeQuery(('SHOW CREATE TABLE ' . $customGroup['values'][$customGroup['id']]['table_name']));
     $dao->fetch();
-    $this->assertContains('`test_link_2` varchar(255) COLLATE ' . CRM_Core_BAO_SchemaHandler::getInUseCollation() . ' DEFAULT NULL', $dao->Create_Table);
-    $this->assertContains('KEY `INDEX_my_text` (`my_text`)', $dao->Create_Table);
+    $this->assertStringContainsString('`test_link_2` varchar(255) COLLATE ' . CRM_Core_BAO_SchemaHandler::getInUseCollation() . ' DEFAULT NULL', $dao->Create_Table);
+    $this->assertStringContainsString('KEY `INDEX_my_text` (`my_text`)', $dao->Create_Table);
   }
 
   /**

--- a/tests/phpunit/CRM/Core/BAO/EmailTest.php
+++ b/tests/phpunit/CRM/Core/BAO/EmailTest.php
@@ -186,13 +186,13 @@ class CRM_Core_BAO_EmailTest extends CiviUnitTestCase {
     $this->createLoggedInUser();
     $fromEmails = CRM_Core_BAO_Email::getFromEmail();
     $emails = array_values($fromEmails);
-    $this->assertContains("(preferred)", $emails[0]);
+    $this->assertStringContainsString("(preferred)", $emails[0]);
     Civi::settings()->set("allow_mail_from_logged_in_contact", 0);
     $this->callAPISuccess('system', 'flush', []);
     $fromEmails = CRM_Core_BAO_Email::getFromEmail();
     $emails = array_values($fromEmails);
-    $this->assertNotContains("(preferred)", $emails[0]);
-    $this->assertContains("info@EXAMPLE.ORG", $emails[0]);
+    $this->assertStringNotContainsString("(preferred)", $emails[0]);
+    $this->assertStringContainsString("info@EXAMPLE.ORG", $emails[0]);
     Civi::settings()->set("allow_mail_from_logged_in_contact", 1);
     $this->callAPISuccess('system', 'flush', []);
   }

--- a/tests/phpunit/CRM/Core/BAO/MessageTemplateTest.php
+++ b/tests/phpunit/CRM/Core/BAO/MessageTemplateTest.php
@@ -64,8 +64,8 @@ class CRM_Core_BAO_MessageTemplateTest extends CiviUnitTestCase {
     );
 
     $this->assertEquals('[case #' . $tplParams['idHash'] . '] Test 123', $subject);
-    $this->assertContains('Your Case Role', $message);
-    $this->assertContains('Case ID : 1234', $message);
+    $this->assertStringContainsString('Your Case Role', $message);
+    $this->assertStringContainsString('Case ID : 1234', $message);
   }
 
   /**

--- a/tests/phpunit/CRM/Core/BAO/SchemaHandlerTest.php
+++ b/tests/phpunit/CRM/Core/BAO/SchemaHandlerTest.php
@@ -358,8 +358,8 @@ class CRM_Core_BAO_SchemaHandlerTest extends CiviUnitTestCase {
 
     $create_table = CRM_Core_DAO::executeQuery('SHOW CREATE TABLE civicrm_test_drop_column');
     while ($create_table->fetch()) {
-      $this->assertNotContains('col1', $create_table->Create_Table);
-      $this->assertContains('col2', $create_table->Create_Table);
+      $this->assertStringNotContainsString('col1', $create_table->Create_Table);
+      $this->assertStringContainsString('col2', $create_table->Create_Table);
     }
 
     // drop col2
@@ -368,7 +368,7 @@ class CRM_Core_BAO_SchemaHandlerTest extends CiviUnitTestCase {
 
     $create_table = CRM_Core_DAO::executeQuery('SHOW CREATE TABLE civicrm_test_drop_column');
     while ($create_table->fetch()) {
-      $this->assertNotContains('col2', $create_table->Create_Table);
+      $this->assertStringNotContainsString('col2', $create_table->Create_Table);
     }
   }
 

--- a/tests/phpunit/CRM/Core/ErrorTest.php
+++ b/tests/phpunit/CRM/Core/ErrorTest.php
@@ -104,7 +104,7 @@ class CRM_Core_ErrorTest extends CiviUnitTestCase {
     // The 5 here is a bit arbitrary - on my local the date part is 15 chars (Mar 29 05:29:16) - but we are just checking that
     // there are chars for the date at the start.
     $this->assertTrue(strpos($fileContents, '[info] Mary had a little lamb') > 10);
-    $this->assertContains('[info] Little lamb', $fileContents);
+    $this->assertStringContainsString('[info] Little lamb', $fileContents);
   }
 
 }

--- a/tests/phpunit/CRM/Core/I18n/SchemaTest.php
+++ b/tests/phpunit/CRM/Core/I18n/SchemaTest.php
@@ -109,8 +109,8 @@ class CRM_Core_I18n_SchemaTest extends CiviUnitTestCase {
     $inUseCollation = CRM_Core_BAO_SchemaHandler::getInUseCollation();
     $testCreateTable = CRM_Core_DAO::executeQuery("show create table civicrm_price_set", [], TRUE, NULL, FALSE, FALSE);
     while ($testCreateTable->fetch()) {
-      $this->assertContains("`title_en_US` varchar(255) COLLATE {$inUseCollation} NOT NULL COMMENT 'Displayed title for the Price Set.'", $testCreateTable->Create_Table);
-      $this->assertContains("`help_pre_en_US` text COLLATE {$inUseCollation} COMMENT 'Description and/or help text to display before fields in form.'", $testCreateTable->Create_Table);
+      $this->assertStringContainsString("`title_en_US` varchar(255) COLLATE {$inUseCollation} NOT NULL COMMENT 'Displayed title for the Price Set.'", $testCreateTable->Create_Table);
+      $this->assertStringContainsString("`help_pre_en_US` text COLLATE {$inUseCollation} COMMENT 'Description and/or help text to display before fields in form.'", $testCreateTable->Create_Table);
     }
   }
 

--- a/tests/phpunit/CRM/Core/Payment/BaseIPNTest.php
+++ b/tests/phpunit/CRM/Core/Payment/BaseIPNTest.php
@@ -126,9 +126,9 @@ class CRM_Core_Payment_BaseIPNTest extends CiviUnitTestCase {
     $contribution->id = $this->_contributionId;
     $values = [];
     $msg = $contribution->composeMessageArray($this->input, $this->ids, $values);
-    $this->assertInternalType('array', $msg, 'Message returned as an array in line');
+    $this->assertIsArray($msg, 'Message returned as an array in line');
     $this->assertEquals('Mr. Anthony Anderson II', $msg['to']);
-    $this->assertContains('Membership Type: General', $msg['body']);
+    $this->assertStringContainsString('Membership Type: General', $msg['body']);
   }
 
   /**
@@ -143,7 +143,7 @@ class CRM_Core_Payment_BaseIPNTest extends CiviUnitTestCase {
     $contribution->id = $this->_contributionId;
     $msg = $contribution->composeMessageArray($this->input, $this->ids, $values);
     $this->assertEquals('Mr. Anthony Anderson II', $msg['to']);
-    $this->assertContains('Membership Type: General', $msg['body']);
+    $this->assertStringContainsString('Membership Type: General', $msg['body']);
 
     $this->ids['contact'] = $this->_contactId = $this->individualCreate(['prefix_id' => 'Dr.', 'first_name' => 'Donald', 'last_name' => 'Duck', 'email' => 'the-don@duckville.com']);
     $contribution = $this->callAPISuccess('contribution', 'create', array_merge($this->_contributionParams, ['invoice_id' => 'abc']));
@@ -156,7 +156,7 @@ class CRM_Core_Payment_BaseIPNTest extends CiviUnitTestCase {
     $contribution->id = $this->_contributionId;
     $msg = $contribution->composeMessageArray($this->input, $this->ids, $values);
     $this->assertEquals('Dr. Donald Duck II', $msg['to']);
-    $this->assertContains('Membership Type: Fowl', $msg['body']);
+    $this->assertStringContainsString('Membership Type: Fowl', $msg['body']);
   }
 
   /**
@@ -167,9 +167,9 @@ class CRM_Core_Payment_BaseIPNTest extends CiviUnitTestCase {
     $contribution = new CRM_Contribute_BAO_Contribution();
     $contribution->id = $this->_contributionId;
     $msg = $contribution->composeMessageArray($this->input, $this->ids, $values);
-    $this->assertInternalType('array', $msg, 'Message not returned as an array');
+    $this->assertIsArray($msg, 'Message not returned as an array');
     $this->assertEquals('Mr. Anthony Anderson II', $msg['to']);
-    $this->assertContains('Membership Type: General', $msg['body']);
+    $this->assertStringContainsString('Membership Type: General', $msg['body']);
   }
 
   /**
@@ -181,8 +181,8 @@ class CRM_Core_Payment_BaseIPNTest extends CiviUnitTestCase {
     $contribution->id = $this->_contributionId;
     $contribution->loadRelatedObjects($this->input, $this->ids);
     $msg = $contribution->composeMessageArray($this->input, $this->ids, $values);
-    $this->assertContains('registration has been received and your status has been updated to Attended.', $msg['body']);
-    $this->assertContains('Annual CiviCRM meet', $msg['html']);
+    $this->assertStringContainsString('registration has been received and your status has been updated to Attended.', $msg['body']);
+    $this->assertStringContainsString('Annual CiviCRM meet', $msg['html']);
   }
 
   /**
@@ -193,7 +193,7 @@ class CRM_Core_Payment_BaseIPNTest extends CiviUnitTestCase {
     $contribution->id = $this->_contributionId;
     $msg = $contribution->composeMessageArray($this->input, $this->ids, $values);
     $this->assertEquals('Mr. Anthony Anderson II', $msg['to']);
-    $this->assertContains('Thank you for your registration', $msg['body']);
+    $this->assertStringContainsString('Thank you for your registration', $msg['body']);
   }
 
   /**
@@ -243,7 +243,7 @@ class CRM_Core_Payment_BaseIPNTest extends CiviUnitTestCase {
     $contribution = new CRM_Contribute_BAO_Contribution();
     $contribution->id = $this->_contributionId;
     $msg = $contribution->composeMessageArray($this->input, $this->ids, $values);
-    $this->assertContains('Contribution Information', $msg['html']);
+    $this->assertStringContainsString('Contribution Information', $msg['html']);
   }
 
   public function testThatCancellingEventPaymentWillCancelAllAdditionalPendingParticipantsAndCreateCancellationActivities() {

--- a/tests/phpunit/CRM/Event/Form/Registration/ConfirmTest.php
+++ b/tests/phpunit/CRM/Event/Form/Registration/ConfirmTest.php
@@ -299,19 +299,19 @@ class CRM_Event_Form_Registration_ConfirmTest extends CiviUnitTestCase {
     $this->assertEquals($contribution['total_amount'], 440, 'Invalid Tax amount.');
     $mailSent = $mut->getAllMessages();
     $this->assertCount(3, $mailSent, 'Three mails should have been sent to the 3 participants.');
-    $this->assertContains('contactID:::' . $contribution['contact_id'], $mailSent[0]);
-    $this->assertContains('contactID:::' . ($contribution['contact_id'] + 1), $mailSent[1]);
+    $this->assertStringContainsString('contactID:::' . $contribution['contact_id'], $mailSent[0]);
+    $this->assertStringContainsString('contactID:::' . ($contribution['contact_id'] + 1), $mailSent[1]);
 
     $this->callAPISuccess('Payment', 'create', ['total_amount' => 100, 'payment_type_id' => 'Cash', 'contribution_id' => $contribution['id']]);
     $mailSent = $mut->getAllMessages();
     $this->assertCount(6, $mailSent);
 
-    $this->assertContains('participant_status:::Registered', $mailSent[3]);
-    $this->assertContains('Dear Participant2', $mailSent[3]);
+    $this->assertStringContainsString('participant_status:::Registered', $mailSent[3]);
+    $this->assertStringContainsString('Dear Participant2', $mailSent[3]);
 
-    $this->assertContains('contactID:::' . ($contribution['contact_id'] + 1), $mailSent[3]);
-    $this->assertContains('contactID:::' . ($contribution['contact_id'] + 2), $mailSent[4]);
-    $this->assertContains('contactID:::' . $contribution['contact_id'], $mailSent[5]);
+    $this->assertStringContainsString('contactID:::' . ($contribution['contact_id'] + 1), $mailSent[3]);
+    $this->assertStringContainsString('contactID:::' . ($contribution['contact_id'] + 2), $mailSent[4]);
+    $this->assertStringContainsString('contactID:::' . $contribution['contact_id'], $mailSent[5]);
     $this->revertTemplateToReservedTemplate('event_online_receipt', 'text');
   }
 

--- a/tests/phpunit/CRM/Extension/ManagerTest.php
+++ b/tests/phpunit/CRM/Extension/ManagerTest.php
@@ -25,10 +25,9 @@ class CRM_Extension_ManagerTest extends CiviUnitTestCase {
 
   /**
    * Install an extension with an invalid type name.
-   *
-   * @expectedException CRM_Extension_Exception
    */
   public function testInstallInvalidType() {
+    $this->expectException(CRM_Extension_Exception::class);
     $testingTypeManager = $this->getMockBuilder('CRM_Extension_Manager_Interface')->getMock();
     $testingTypeManager->expects($this->never())
       ->method('onPreInstall');

--- a/tests/phpunit/CRM/Logging/SchemaTest.php
+++ b/tests/phpunit/CRM/Logging/SchemaTest.php
@@ -153,8 +153,8 @@ class CRM_Logging_SchemaTest extends CiviUnitTestCase {
     $log_table = CRM_Core_DAO::executeQuery("SHOW TRIGGERS WHERE `Trigger` LIKE 'civicrm_value_contact_{$customGroup['custom_group_id']}_after_insert%'");
 
     while ($log_table->fetch()) {
-      $this->assertContains('UPDATE civicrm_contact SET modified_date = CURRENT_TIMESTAMP WHERE id = NEW.entity_id;', $log_table->Statement, "Contact modification update should be in the trigger :\n" . $log_table->Statement);
-      $this->assertNotContains('civicrm_mailing', $log_table->Statement, 'Contact field should not update mailing table');
+      $this->assertStringContainsString('UPDATE civicrm_contact SET modified_date = CURRENT_TIMESTAMP WHERE id = NEW.entity_id;', $log_table->Statement, "Contact modification update should be in the trigger :\n" . $log_table->Statement);
+      $this->assertStringNotContainsString('civicrm_mailing', $log_table->Statement, 'Contact field should not update mailing table');
       $this->assertEquals(1, substr_count($log_table->Statement, 'SET modified_date'), 'Modified date should only be updated on one table (here it is contact)');
     }
   }
@@ -224,7 +224,7 @@ class CRM_Logging_SchemaTest extends CiviUnitTestCase {
       $this->assertEquals('civicrm_group', $trigger['table'][0]);
       if ($trigger['event'][0] == 'UPDATE') {
         // civicrm_group.cache_date should be an exception, i.e. not logged
-        $this->assertNotContains(
+        $this->assertStringNotContainsString(
           "IFNULL(OLD.`cache_date`,'') <> IFNULL(NEW.`cache_date`,'')",
           $trigger['sql']
         );

--- a/tests/phpunit/CRM/Mailing/BAO/SpoolTest.php
+++ b/tests/phpunit/CRM/Mailing/BAO/SpoolTest.php
@@ -57,14 +57,14 @@ class CRM_Mailing_BAO_SpoolTest extends CiviUnitTestCase {
     CRM_Utils_Mail::send($params);
 
     $mail = $this->_mut->getMostRecentEmail('raw');
-    $this->assertContains("Subject: $subject", $mail);
-    $this->assertContains(self::$bodytext, $mail);
+    $this->assertStringContainsString("Subject: $subject", $mail);
+    $this->assertStringContainsString(self::$bodytext, $mail);
 
     $mail = $this->_mut->getMostRecentEmail('ezc');
 
     $this->assertEquals($subject, $mail->subject);
-    $this->assertContains($contact_params_1['email'], $mail->from->email, 'From address incorrect.');
-    $this->assertContains($contact_params_2['email'], $mail->to[0]->email, 'Recipient incorrect.');
+    $this->assertStringContainsString($contact_params_1['email'], $mail->from->email, 'From address incorrect.');
+    $this->assertStringContainsString($contact_params_2['email'], $mail->to[0]->email, 'Recipient incorrect.');
 
     $context = new ezcMailPartWalkContext([get_class($this), 'mailWalkCallback']);
     $mail->walkParts($context, $mail);

--- a/tests/phpunit/CRM/Member/Form/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/Form/MembershipTest.php
@@ -188,12 +188,12 @@ class CRM_Member_Form_MembershipTest extends CiviUnitTestCase {
     $files = [];
     $obj = new CRM_Member_Form_Membership();
     $rc = CRM_Member_Form_Membership::formRule($params, $files, $obj);
-    $this->assertType('array', $rc);
+    $this->assertIsArray($rc);
     $this->assertArrayHasKey('membership_type_id', $rc);
 
     $params['membership_type_id'] = [1 => 3];
     $rc = CRM_Member_Form_Membership::formRule($params, $files, $obj);
-    $this->assertType('array', $rc);
+    $this->assertIsArray($rc);
     $this->assertArrayHasKey('join_date', $rc);
   }
 
@@ -217,7 +217,7 @@ class CRM_Member_Form_MembershipTest extends CiviUnitTestCase {
     $files = [];
     $obj = new CRM_Member_Form_Membership();
     $rc = CRM_Member_Form_Membership::formRule($params, $files, $obj);
-    $this->assertType('array', $rc);
+    $this->assertisArray($rc);
     $this->assertTrue(array_key_exists('start_date', $rc));
   }
 
@@ -239,7 +239,7 @@ class CRM_Member_Form_MembershipTest extends CiviUnitTestCase {
     $files = [];
     $obj = new CRM_Member_Form_Membership();
     $rc = CRM_Member_Form_Membership::formRule($params, $files, $obj);
-    $this->assertType('array', $rc);
+    $this->assertIsArray($rc);
     $this->assertTrue(array_key_exists('end_date', $rc));
   }
 
@@ -259,7 +259,7 @@ class CRM_Member_Form_MembershipTest extends CiviUnitTestCase {
     $files = [];
     $obj = new CRM_Member_Form_Membership();
     $rc = $obj::formRule($params, $files, $obj);
-    $this->assertType('array', $rc);
+    $this->assertIsArray($rc);
     $this->assertTrue(array_key_exists('start_date', $rc));
   }
 
@@ -281,7 +281,7 @@ class CRM_Member_Form_MembershipTest extends CiviUnitTestCase {
     $files = [];
     $obj = new CRM_Member_Form_Membership();
     $rc = $obj::formRule($params, $files, $obj);
-    $this->assertType('array', $rc);
+    $this->assertIsArray($rc);
     $this->assertTrue(array_key_exists('status_id', $rc));
   }
 
@@ -301,7 +301,7 @@ class CRM_Member_Form_MembershipTest extends CiviUnitTestCase {
     $files = [];
     $obj = new CRM_Member_Form_Membership();
     $rc = $obj::formRule($params, $files, $obj);
-    $this->assertType('array', $rc);
+    $this->assertIsArray($rc);
     $this->assertTrue(array_key_exists('status_id', $rc));
   }
 
@@ -329,7 +329,7 @@ class CRM_Member_Form_MembershipTest extends CiviUnitTestCase {
     $files = [];
     $membershipForm = new CRM_Member_Form_Membership();
     $validationResponse = CRM_Member_Form_Membership::formRule($params, $files, $membershipForm);
-    $this->assertType('array', $validationResponse);
+    $this->assertIsArray($validationResponse);
     $this->assertEquals('Please enter the Membership override end date.', $validationResponse['status_override_end_date']);
   }
 
@@ -351,7 +351,7 @@ class CRM_Member_Form_MembershipTest extends CiviUnitTestCase {
     $rc = $obj::formRule($params, $files, $obj);
 
     // Should have found no valid membership status.
-    $this->assertType('array', $rc);
+    $this->assertIsArray($rc);
     $this->assertTrue(array_key_exists('_qf_default', $rc));
   }
 

--- a/tests/phpunit/CRM/Member/Form/Task/PDFLetterCommonTest.php
+++ b/tests/phpunit/CRM/Member/Form/Task/PDFLetterCommonTest.php
@@ -84,7 +84,7 @@ class CRM_Member_Form_Task_PDFLetterCommonTest extends CiviUnitTestCase {
     $expected = array_values($expected);
     foreach ($expected as $key => $dateVal) {
       foreach ($tokens as $text => $token) {
-        $this->assertContains($dateVal[$token], $testHTML[$key]);
+        $this->assertStringContainsString($dateVal[$token], $testHTML[$key]);
       }
     }
   }

--- a/tests/phpunit/CRM/Pledge/BAO/PledgePaymentTest.php
+++ b/tests/phpunit/CRM/Pledge/BAO/PledgePaymentTest.php
@@ -457,7 +457,7 @@ class CRM_Pledge_BAO_PledgePaymentTest extends CiviUnitTestCase {
     // The last pledge payment is 8.37 because 12*8.33 = 99.96
     // So CiviCRM automatically creates a larger final pledge to catch the missing cents.
     $last_pp_idx = count($pledgePayments['values']) - 1;
-    $this->assertEquals(8.37, $pledgePayments['values'][$last_pp_idx]['scheduled_amount'], '', 0.01);
+    $this->assertEqualsWithDelta(8.37, $pledgePayments['values'][$last_pp_idx]['scheduled_amount'], 0.01);
 
     // Does all sorts of shenanigans if the amount was not the expected amount,
     // and this is what we really want to test in this function.

--- a/tests/phpunit/CRM/Price/Form/FieldTest.php
+++ b/tests/phpunit/CRM/Price/Form/FieldTest.php
@@ -39,7 +39,7 @@ class CRM_Price_Form_FieldTest extends CiviUnitTestCase {
     $files = [];
 
     $validationResult = $form->formRule($this->publicFieldParams, $files, $form);
-    $this->assertType('array', $validationResult);
+    $this->assertIsArray($validationResult);
     $this->assertTrue(array_key_exists('visibility_id', $validationResult));
   }
 
@@ -53,7 +53,7 @@ class CRM_Price_Form_FieldTest extends CiviUnitTestCase {
     $files = [];
 
     $validationResult = $form->formRule($this->adminFieldParams, $files, $form);
-    $this->assertType('array', $validationResult);
+    $this->assertIsArray($validationResult);
     $this->assertTrue(array_key_exists('visibility_id', $validationResult));
   }
 

--- a/tests/phpunit/CRM/Price/Form/OptionTest.php
+++ b/tests/phpunit/CRM/Price/Form/OptionTest.php
@@ -47,7 +47,7 @@ class CRM_Price_Form_OptionTest extends CiviUnitTestCase {
     $files = [];
 
     $validationResult = $form->formRule($params, $files, $form);
-    $this->assertType('array', $validationResult);
+    $this->assertIsArray($validationResult);
     $this->assertTrue(array_key_exists('visibility_id', $validationResult));
   }
 
@@ -74,7 +74,7 @@ class CRM_Price_Form_OptionTest extends CiviUnitTestCase {
     $files = [];
 
     $validationResult = $form->formRule($params, $files, $form);
-    $this->assertType('array', $validationResult);
+    $this->assertIsArray($validationResult);
     $this->assertTrue(array_key_exists('visibility_id', $validationResult));
   }
 

--- a/tests/phpunit/CRM/Report/Form/Member/DetailTest.php
+++ b/tests/phpunit/CRM/Report/Form/Member/DetailTest.php
@@ -80,10 +80,10 @@ class CRM_Report_Form_Member_DetailTest extends CiviReportTestCase {
     $this->assertCount(2, $results);
     foreach ($results as $result) {
       if ($result['civicrm_contact_id'] == $indContactID1) {
-        $this->assertNotContains('(ended)', $result['civicrm_contribution_recur_autorenew_status_id']);
+        $this->assertStringNotContainsString('(ended)', $result['civicrm_contribution_recur_autorenew_status_id']);
       }
       if ($result['civicrm_contact_id'] == $indContactID2) {
-        $this->assertContains('(ended)', $result['civicrm_contribution_recur_autorenew_status_id']);
+        $this->assertStringContainsString('(ended)', $result['civicrm_contribution_recur_autorenew_status_id']);
       }
     }
 

--- a/tests/phpunit/CRM/UF/Page/ProfileEditorTest.php
+++ b/tests/phpunit/CRM/UF/Page/ProfileEditorTest.php
@@ -53,10 +53,9 @@ class CRM_UF_Page_ProfileEditorTest extends CiviUnitTestCase {
 
   /**
    * Tries to load up the profile schema for a model where there is no corresponding set of fields avaliable.
-   *
-   * @expectedException \CRM_Core_Exception
    */
   public function testGetSchemaWithHooksWithInvalidModel() {
+    $this->expectException(CRM_Core_Exception::class);
     CRM_Utils_Hook::singleton()->setHook('civicrm_alterUFFields', [$this, 'hook_civicrm_alterUFFIelds']);
     $schema = CRM_UF_Page_ProfileEditor::getSchema(['IndividualModel', 'GrantModel', 'PledgeModel']);
   }

--- a/tests/phpunit/CRM/Upgrade/Incremental/BaseTest.php
+++ b/tests/phpunit/CRM/Upgrade/Incremental/BaseTest.php
@@ -29,7 +29,7 @@ class CRM_Upgrade_Incremental_BaseTest extends CiviUnitTestCase {
 
     foreach ($templates as $template) {
       $msg_text = $this->callAPISuccessGetValue('MessageTemplate', ['id' => $template['id'], 'return' => 'msg_text']);
-      $this->assertContains('{assign var="greeting" value="{contact.email_greeting}"}{if $greeting}{$greeting},{/if}', $msg_text);
+      $this->assertStringContainsString('{assign var="greeting" value="{contact.email_greeting}"}{if $greeting}{$greeting},{/if}', $msg_text);
       if ($msg_text !== $originalText) {
         // Reset value for future tests.
         $this->callAPISuccess('MessageTemplate', 'create', ['msg_text' => $originalText, 'id' => $template['id']]);
@@ -59,7 +59,7 @@ class CRM_Upgrade_Incremental_BaseTest extends CiviUnitTestCase {
     foreach ($templates as $template) {
       $msg_text = $this->callAPISuccessGetValue('MessageTemplate', ['id' => $template['id'], 'return' => 'msg_text']);
       if ($template['is_reserved']) {
-        $this->assertContains('{assign var="greeting" value="{contact.email_greeting}"}{if $greeting}{$greeting},{/if}', $msg_text);
+        $this->assertStringContainsString('{assign var="greeting" value="{contact.email_greeting}"}{if $greeting}{$greeting},{/if}', $msg_text);
       }
       else {
         $this->assertEquals('great what a silly sausage you are', $msg_text);

--- a/tests/phpunit/CRM/Utils/SystemTest.php
+++ b/tests/phpunit/CRM/Utils/SystemTest.php
@@ -117,12 +117,12 @@ class CRM_Utils_SystemTest extends CiviUnitTestCase {
     $siteKey = mt_rand();
     $apiKey = mt_rand();
     $restUrl = CRM_Utils_System::externUrl('extern/rest', "entity=Contact&action=get&key=$siteKey&api_key=$apiKey");
-    $this->assertContains('extern/rest.php', $restUrl);
-    $this->assertContains('?', $restUrl);
-    $this->assertContains('entity=Contact', $restUrl);
-    $this->assertContains('action=get', $restUrl);
-    $this->assertContains("key=$siteKey", $restUrl);
-    $this->assertContains("api_key=$apiKey", $restUrl);
+    $this->assertStringContainsString('extern/rest.php', $restUrl);
+    $this->assertStringContainsString('?', $restUrl);
+    $this->assertStringContainsString('entity=Contact', $restUrl);
+    $this->assertStringContainsString('action=get', $restUrl);
+    $this->assertStringContainsString("key=$siteKey", $restUrl);
+    $this->assertStringContainsString("api_key=$apiKey", $restUrl);
   }
 
   /**
@@ -136,8 +136,8 @@ class CRM_Utils_SystemTest extends CiviUnitTestCase {
   public function testAlterExternUrlHook($path, $expected) {
     Civi::dispatcher()->addListener('hook_civicrm_alterExternUrl', [$this, 'hook_civicrm_alterExternUrl']);
     $externUrl = CRM_Utils_System::externUrl($path, $expected['query']);
-    $this->assertContains('path/altered/by/hook', $externUrl, 'Hook failed to alter URL path');
-    $this->assertContains($expected['query'] . '&thisWas=alteredByHook', $externUrl, 'Hook failed to alter URL query');
+    $this->assertStringContainsString('path/altered/by/hook', $externUrl, 'Hook failed to alter URL path');
+    $this->assertStringContainsString($expected['query'] . '&thisWas=alteredByHook', $externUrl, 'Hook failed to alter URL query');
   }
 
   /**

--- a/tests/phpunit/CRMTraits/Page/PageTestTrait.php
+++ b/tests/phpunit/CRMTraits/Page/PageTestTrait.php
@@ -68,7 +68,7 @@ trait CRMTraits_Page_PageTestTrait {
     unset($this->smartyVariables['config']);
     unset($this->smartyVariables['session']);
     foreach ($expectedStrings as $expectedString) {
-      $this->assertContains($expectedString, $this->pageContent, print_r($this->contributions, TRUE) . print_r($this->smartyVariables, TRUE));
+      $this->assertStringContainsString($expectedString, $this->pageContent, print_r($this->contributions, TRUE) . print_r($this->smartyVariables, TRUE));
     }
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
This fixes a number of different deprecation warnings found by PHPUnit8

Before
----------------------------------------
Deprecation warnings emitted
* Using assertContains() with string haystacks is deprecated and will not be supported in PHPUnit 9. Refactor your test to use assertStringContainsString() or assertStringContainsStringIgnoringCase() instead.
* Using assertNotContains() with string haystacks is deprecated and will not be supported in PHPUnit 9. Refactor your test to use assertStringNotContainsString() or assertStringNotContainsStringIgnoringCase() instead.
* The @expectedException, @expectedExceptionCode, @expectedExceptionMessage, and @expectedExceptionMessageRegExp annotations are deprecated. They will be removed in PHPUnit 9. Refactor your test to use expectException(), expectExceptionCode(), expectExceptionMessage(), or expectExceptionMessageMatches() instead.
* assertInternalType() is deprecated and will be removed in PHPUnit 9. Refactor your test to use assertIsArray() instead.

After
----------------------------------------
No warnings

ping @eileenmcnaughton 
