### PR TITLE
If paymentprocessor still uses doTransferCheckout/doDirectPayment trigger deprecated function warning

### DIFF
--- a/CRM/Core/Payment.php
+++ b/CRM/Core/Payment.php
@@ -1378,6 +1378,7 @@ abstract class CRM_Core_Payment {
     }
 
     if ($this->_paymentProcessor['billing_mode'] == 4) {
+      CRM_Core_Error::deprecatedFunctionWarning('doPayment', 'doTransferCheckout');
       $result = $this->doTransferCheckout($params, $component);
       if (is_array($result) && !isset($result['payment_status_id'])) {
         $result['payment_status_id'] = array_search('Pending', $statuses);
@@ -1385,6 +1386,7 @@ abstract class CRM_Core_Payment {
       }
     }
     else {
+      CRM_Core_Error::deprecatedFunctionWarning('doPayment', 'doDirectPayment');
       $result = $this->doDirectPayment($params, $component);
       if (is_array($result) && !isset($result['payment_status_id'])) {
         if (!empty($params['is_recur'])) {


### PR DESCRIPTION
Overview
----------------------------------------
Payment processor should override `doPayment()`. All core processors have now been converted. If not overridden trigger deprecated error before calling deprecated `doTransferCheckout()`/`doDirectPayment()`.

Before
----------------------------------------
No deprecated warning if paymentprocessor implements doTransferCheckout/doDirectPayment.

After
----------------------------------------
Deprecated warning if paymentprocessor implements doTransferCheckout/doDirectPayment.

Technical Details
----------------------------------------
We added deprecated warnings into the actual functions on `CRM_Core_Payment` but these don't normally work because the payment processor extension overrides those functions.

Comments
----------------------------------------

