### PR TITLE
Fix internal group contact cache functions to be protected

### DIFF
--- a/CRM/Contact/BAO/GroupContactCache.php
+++ b/CRM/Contact/BAO/GroupContactCache.php
@@ -190,7 +190,7 @@ AND (
    * @param bool $processed
    *   Whether the cache data was recently modified.
    */
-  public static function updateCacheTime($groupID, $processed) {
+  protected static function updateCacheTime($groupID, $processed) {
     // only update cache entry if we had any values
     if ($processed) {
       // also update the group with cache date information
@@ -216,7 +216,7 @@ WHERE  id IN ( $groupIDs )
    * @param int $groupID
    *
    */
-  public static function clearGroupContactCache($groupID): void {
+  protected static function clearGroupContactCache($groupID): void {
     $transaction = new CRM_Core_Transaction();
     $query = "
     DELETE  g

--- a/tests/phpunit/CRM/Contact/BAO/QueryTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/QueryTest.php
@@ -987,7 +987,7 @@ civicrm_relationship.is_active = 1 AND
     $this->callAPISuccess('GroupContact', 'create', ['group_id' => $groupID, 'contact_id' => $householdID, 'status' => 'Added']);
 
     // Refresh the cache for test purposes. It would be better to alter to alter the GroupContact add function to add contacts to the cache.
-    CRM_Contact_BAO_GroupContactCache::clearGroupContactCache($groupID);
+    CRM_Contact_BAO_GroupContactCache::invalidateGroupContactCache($groupID);
 
     $sql = CRM_Contact_BAO_Query::getQuery(
       [['group', 'IN', [$groupID], 0, 0]],

--- a/tests/phpunit/api/v3/ReportTemplateTest.php
+++ b/tests/phpunit/api/v3/ReportTemplateTest.php
@@ -873,16 +873,18 @@ class api_v3_ReportTemplateTest extends CiviUnitTestCase {
   /**
    * Set up a smart group for testing.
    *
-   * The smart group includes all Households by filter. In addition an individual
-   * is created and hard-added and an individual is created that is not added.
+   * The smart group includes all Households by filter. In addition an
+   * individual is created and hard-added and an individual is created that is
+   * not added.
    *
    * One household is hard-added as well as being in the filter.
    *
-   * This gives us a range of scenarios for testing contacts are included only once
-   * whenever they are hard-added or in the criteria.
+   * This gives us a range of scenarios for testing contacts are included only
+   * once whenever they are hard-added or in the criteria.
    *
    * @return int
    * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
    */
   public function setUpPopulatedSmartGroup(): int {
     $household1ID = $this->householdCreate();
@@ -912,7 +914,7 @@ class api_v3_ReportTemplateTest extends CiviUnitTestCase {
     }
 
     // Refresh the cache for test purposes. It would be better to alter to alter the GroupContact add function to add contacts to the cache.
-    CRM_Contact_BAO_GroupContactCache::clearGroupContactCache($groupID);
+    CRM_Contact_BAO_GroupContactCache::invalidateGroupContactCache($groupID);
     return $groupID;
   }
 
@@ -951,7 +953,7 @@ class api_v3_ReportTemplateTest extends CiviUnitTestCase {
     }
 
     // Refresh the cache for test purposes. It would be better to alter to alter the GroupContact add function to add contacts to the cache.
-    CRM_Contact_BAO_GroupContactCache::clearGroupContactCache($groupID);
+    CRM_Contact_BAO_GroupContactCache::invalidateGroupContactCache($groupID);
 
     if ($returnAddedContact) {
       return [$groupID, $individualID];


### PR DESCRIPTION
These are not in git universe outside of core. In theory the
tests should still work....

Overview
----------------------------------------
Fix internal group contact cache functions to be protected

Before
----------------------------------------
Functions are public - some calls to them in tests but not elsehwere in universe

After
----------------------------------------
protected

Technical Details
----------------------------------------

Comments
----------------------------------------
