### PR TITLE
UserDashboard: Pay now buttons & balance for partial payments

### DIFF
--- a/CRM/Contribute/Page/UserDashboard.php
+++ b/CRM/Contribute/Page/UserDashboard.php
@@ -48,7 +48,10 @@ class CRM_Contribute_Page_UserDashboard extends CRM_Contact_Page_View_UserDashBo
       // This is required for tpl logic. We should move away from hard-code this to adding an array of actions to the row
       // which the tpl can iterate through - this should allow us to cope with competing attempts to add new buttons
       // and allow extensions to assign new ones through the pageRun hook
-      if ('Pending' === CRM_Core_PseudoConstant::getName('CRM_Contribute_BAO_Contribution', 'contribution_status_id', $row['contribution_status_id'])) {
+      $row['balance_amount'] = CRM_Contribute_BAO_Contribution::getContributionBalance($row['contribution_id']);
+      $contributionStatus = CRM_Core_PseudoConstant::getName('CRM_Contribute_BAO_Contribution', 'contribution_status_id', $row['contribution_status_id']);
+
+      if (in_array($contributionStatus, ['Pending', 'Partially paid'])) {
         $row['buttons']['pay'] = [
           'class' => 'button',
           'label' => ts('Pay Now'),

--- a/templates/CRM/Contribute/Page/UserDashboard.tpl
+++ b/templates/CRM/Contribute/Page/UserDashboard.tpl
@@ -18,13 +18,12 @@
                     <th>{ts}Financial Type{/ts}</th>
                     <th>{ts}Received date{/ts}</th>
                     <th>{ts}Receipt Sent{/ts}</th>
+                    <th>{ts}Balance{/ts}</th>
                     <th>{ts}Status{/ts}</th>
                     {if $isIncludeInvoiceLinks}
                       <th></th>
                     {/if}
-                    {foreach from=$row.buttons item=button}
-                      <th></th>
-                    {/foreach}
+                    <th></th>
                 </tr>
 
                 {foreach from=$contribute_rows item=row}
@@ -39,6 +38,7 @@
                         <td>{$row.financial_type}</td>
                         <td>{$row.receive_date|truncate:10:''|crmDate}</td>
                         <td>{$row.receipt_date|truncate:10:''|crmDate}</td>
+                        <td>{$row.balance_amount|crmMoney:$row.currency}</td>
                         <td>{$row.contribution_status}</td>
                         {if $isIncludeInvoiceLinks}
                           <td>
@@ -59,9 +59,11 @@
                             {/if}
                           </td>
                         {/if}
+                        <td>
                         {foreach from=$row.buttons item=button}
-                          <td><a class="{$button.class}" href="{$button.url}"><span class='nowrap'>{$button.label}</span></a></td>
+                          <a class="{$button.class}" href="{$button.url}"><span class='nowrap'>{$button.label}</span></a>
                         {/foreach}
+                        </td>
                     </tr>
                 {/foreach}
             </table>


### PR DESCRIPTION
Overview
----------------------------------------
Enable the 'Pay Now' button for partial paid contributions and display balance due.

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/2195908/119224938-2b416700-bb01-11eb-8154-ae0f9cdff1d8.png)

After
----------------------------------------
![image](https://user-images.githubusercontent.com/2195908/119224912-14027980-bb01-11eb-8430-06e8ee4d6f48.png)

Technical Details
----------------------------------------
_If the PR involves technical details/changes/considerations which would not be manifest to a casual developer skimming the above sections, please describe the details here._

Comments
----------------------------------------
This is a slightly updated version of this one (https://github.com/civicrm/civicrm-core/pull/20376) by @MegaphoneJon 

Which in itself was kind of a follow up of previous work in https://github.com/civicrm/civicrm-core/pull/12319 by @jitendrapurohit 

