### PR TITLE
Add call to validateAllContributions & fix getTotalAmount

### DIFF
--- a/CRM/Financial/BAO/Order.php
+++ b/CRM/Financial/BAO/Order.php
@@ -447,7 +447,7 @@ class CRM_Financial_BAO_Order {
   public function getTotalAmount() :float {
     $amount = 0.0;
     foreach ($this->getLineItems() as $lineItem) {
-      $amount += $lineItem['line_total'] ?? 0.0;
+      $amount += ($lineItem['line_total'] ?? 0.0) + ($lineItem['tax_amount'] ?? 0.0);
     }
     return $amount;
   }

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -3643,7 +3643,7 @@ VALUES
         $taxTotal += (float) ($lineItem['tax_amount'] ?? 0);
       }
       $this->assertEquals($taxTotal, (float) ($contribution['tax_amount'] ?? 0));
-      $this->assertEquals($total, $contribution['total_amount']);
+      $this->assertEquals($total + $taxTotal, $contribution['total_amount']);
     }
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Add call to validateAllContributions & fix getTotalAmount

Before
----------------------------------------
The check in validateAllContributions is checking that the contribution.total_amount = SUM(line_item.line_total) but in fact it should be SUM(line_item.line_total) + SUM(line_item.tax_amount). On fixing that (to allow the check to be added to testCompleteTransactionFeeAmount & pass I found that testSubmitContributionPageWithPriceSetQuantity was failing - however the failure is in the part that is used by the unit tests & the (unused out side of tests ? ) ContributionPage.submit api.

After
----------------------------------------
```$order->getTotalAmount()``` fixed to be SUM(line_item.line_total) + SUM(line_item.tax_amount)

Technical Details
----------------------------------------
I found this trying to extend test cover to allow us to deal with #20357 - it's possible this could be a regression in the back office membership class which does use this function - but I'm unclear about that and am on the fence about putting this against master or the rc

Comments
----------------------------------------

