### PR TITLE
[REF] Minor simplification

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -171,12 +171,7 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution {
 
     // Get Line Items if we don't have them already.
     if (empty($params['line_item'])) {
-      if (isset($params['id'])) {
-        CRM_Price_BAO_LineItem::getLineItemArray($params, [$params['id']]);
-      }
-      else {
-        CRM_Price_BAO_LineItem::getLineItemArray($params);
-      }
+      CRM_Price_BAO_LineItem::getLineItemArray($params, $contributionID ? [$contributionID] : NULL);
     }
 
     if (!isset($params['tax_amount']) && $setPrevContribution && (isset($params['total_amount']) ||

--- a/tests/phpunit/api/v3/ContributionPageTest.php
+++ b/tests/phpunit/api/v3/ContributionPageTest.php
@@ -1824,7 +1824,7 @@ class api_v3_ContributionPageTest extends CiviUnitTestCase {
    *
    * @throws \CRM_Core_Exception
    */
-  public function testSubmitPledgePayment() {
+  public function testSubmitPledgePayment(): void {
     // Need to work on valid financials on this test.
     $this->isValidateFinancialsOnPostAssert = FALSE;
     $this->testSubmitPledgePaymentPaymentProcessorRecurFuturePayment();
@@ -1852,7 +1852,7 @@ class api_v3_ContributionPageTest extends CiviUnitTestCase {
       'pledge_block_id' => $this->_ids['pledge_block_id'],
     ];
     $pledgePayment = $this->callAPISuccess('pledge_payment', 'get', $params);
-    $this->assertEquals($pledgePayment['values'][2]['status_id'], 2);
+    $this->assertEquals(2, $pledgePayment['values'][2]['status_id']);
 
     $this->callAPIAndDocument('contribution_page', 'submit', $submitParams, __FUNCTION__, __FILE__, 'submit contribution page', NULL);
 
@@ -1865,9 +1865,9 @@ class api_v3_ContributionPageTest extends CiviUnitTestCase {
     ]);
 
     $this->assertEquals(100.00, $contribution['total_amount']);
-    $pledgePayment = $this->callAPISuccess('pledge_payment', 'get', $params);
-    $this->assertEquals($pledgePayment['values'][2]['status_id'], 1, 'This pledge payment should have been completed');
-    $this->assertEquals($pledgePayment['values'][2]['contribution_id'], $contribution['id']);
+    $pledgePayment = $this->callAPISuccess('pledge_payment', 'get', $params)['values'];
+    $this->assertEquals(1, $pledgePayment[2]['status_id'], 'This pledge payment should have been completed');
+    $this->assertEquals($contribution['id'], $pledgePayment[2]['contribution_id']);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
[REF] Minor simplification

Before
----------------------------------------
If clause checks if $params['id'] isset & calls the same function slightly differently if it is vs if it isn't

After
----------------------------------------
check removed - $contributionID passed to the function

Technical Details
----------------------------------------
We actually have a unit test that passes FALSE into $params['id'] that does kinda weird stuff here - but basically we either have an id or we don't so we can simplify this. It was probably done that way for old enotice reasons

Comments
----------------------------------------
