### PR TITLE
Fix for dev/core#2624

### DIFF
--- a/CRM/Contribute/BAO/ContributionRecur.php
+++ b/CRM/Contribute/BAO/ContributionRecur.php
@@ -52,7 +52,7 @@ class CRM_Contribute_BAO_ContributionRecur extends CRM_Contribute_DAO_Contributi
         CRM_Price_BAO_LineItem::getLineItemArray($params, [$params['id']], 'contribution_recur');
       }
       else {
-        CRM_Price_BAO_LineItem::getLineItemArray($params, null, 'contribution_recur');
+        CRM_Price_BAO_LineItem::getLineItemArray($params, NULL, 'contribution_recur');
       }
     }
 
@@ -91,7 +91,7 @@ class CRM_Contribute_BAO_ContributionRecur extends CRM_Contribute_DAO_Contributi
 
     // Record line items.
     if (empty($params['skipLineItem'])) {
-      CRM_Price_BAO_LineItem::processPriceSet($recurring->id, CRM_Utils_Array::value('line_item', $params), null, 'civicrm_contribution_recur', $isUpdate);
+      CRM_Price_BAO_LineItem::processPriceSet($recurring->id, CRM_Utils_Array::value('line_item', $params), NULL, 'civicrm_contribution_recur', $isUpdate);
     }
 
     if ($isUpdate) {

--- a/CRM/Contribute/BAO/ContributionRecur.php
+++ b/CRM/Contribute/BAO/ContributionRecur.php
@@ -46,16 +46,6 @@ class CRM_Contribute_BAO_ContributionRecur extends CRM_Contribute_DAO_Contributi
    * @todo move hook calls / extended logic to create - requires changing calls to call create not add
    */
   public static function add(&$params) {
-    // Get Line Items if we don't have them already.
-    if (empty($params['line_item'])) {
-      if (isset($params['id'])) {
-        CRM_Price_BAO_LineItem::getLineItemArray($params, [$params['id']], 'contribution_recur');
-      }
-      else {
-        CRM_Price_BAO_LineItem::getLineItemArray($params, NULL, 'contribution_recur');
-      }
-    }
-
     $isUpdate = !empty($params['id']);
     if ($isUpdate) {
       CRM_Utils_Hook::pre('edit', 'ContributionRecur', $params['id'], $params);
@@ -88,11 +78,6 @@ class CRM_Contribute_BAO_ContributionRecur extends CRM_Contribute_DAO_Contributi
       $recurring->currency = $config->defaultCurrency;
     }
     $recurring->save();
-
-    // Record line items.
-    if (empty($params['skipLineItem'])) {
-      CRM_Price_BAO_LineItem::processPriceSet($recurring->id, CRM_Utils_Array::value('line_item', $params), NULL, 'civicrm_contribution_recur', $isUpdate);
-    }
 
     if ($isUpdate) {
       CRM_Utils_Hook::post('edit', 'ContributionRecur', $recurring->id, $recurring);
@@ -1052,7 +1037,7 @@ INNER JOIN civicrm_contribution       con ON ( con.id = mp.contribution_id )
     // CRM-19309 if more than one then just pass them through:
     elseif (count($lineItems) > 1) {
       foreach ($lineItems as $index => $lineItem) {
-        $lineSets[$index][$lineItem['price_field_id']] = $lineItem;
+        $lineSets[0][$lineItem['price_field_id']] = $lineItem;
       }
     }
     return $lineSets;

--- a/CRM/Contribute/BAO/ContributionRecur.php
+++ b/CRM/Contribute/BAO/ContributionRecur.php
@@ -46,8 +46,7 @@ class CRM_Contribute_BAO_ContributionRecur extends CRM_Contribute_DAO_Contributi
    * @todo move hook calls / extended logic to create - requires changing calls to call create not add
    */
   public static function add(&$params) {
-    $isUpdate = !empty($params['id']);
-    if ($isUpdate) {
+    if (!empty($params['id'])) {
       CRM_Utils_Hook::pre('edit', 'ContributionRecur', $params['id'], $params);
     }
     else {
@@ -79,7 +78,7 @@ class CRM_Contribute_BAO_ContributionRecur extends CRM_Contribute_DAO_Contributi
     }
     $recurring->save();
 
-    if ($isUpdate) {
+    if (!empty($params['id'])) {
       CRM_Utils_Hook::post('edit', 'ContributionRecur', $recurring->id, $recurring);
     }
     else {
@@ -1037,6 +1036,8 @@ INNER JOIN civicrm_contribution       con ON ( con.id = mp.contribution_id )
     // CRM-19309 if more than one then just pass them through:
     elseif (count($lineItems) > 1) {
       foreach ($lineItems as $index => $lineItem) {
+        // we don't need the $index we add all price field ids to the same
+        // index: 0.
         $lineSets[0][$lineItem['price_field_id']] = $lineItem;
       }
     }

--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -1216,9 +1216,6 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     $recurParams['financial_type_id'] = $params['financial_type_id'] ?? NULL;
     $recurParams['currency'] = $params['currency'] ?? NULL;
     $recurParams['payment_instrument_id'] = $params['payment_instrument_id'];
-    if (isset($params['line_item'])) {
-      $recurParams['line_item'] = $params['line_item'];
-    }
 
     // CRM-14354: For an auto-renewing membership with an additional contribution,
     // if separate payments is not enabled, make sure only the membership fee recurs

--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -1216,6 +1216,9 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     $recurParams['financial_type_id'] = $params['financial_type_id'] ?? NULL;
     $recurParams['currency'] = $params['currency'] ?? NULL;
     $recurParams['payment_instrument_id'] = $params['payment_instrument_id'];
+    if (isset($params['line_item'])) {
+      $recurParams['line_item'] = $params['line_item'];
+    }
 
     // CRM-14354: For an auto-renewing membership with an additional contribution,
     // if separate payments is not enabled, make sure only the membership fee recurs

--- a/CRM/Contribute/Page/ContributionRecur.php
+++ b/CRM/Contribute/Page/ContributionRecur.php
@@ -75,31 +75,14 @@ class CRM_Contribute_Page_ContributionRecur extends CRM_Core_Page {
 
     $this->assign('recur', $contributionRecur);
 
-    $lineItems = [];
-    $displayLineItems = FALSE;
+    $this->assign('displayLineItems', FALSE);
     if ($this->getEntityId()) {
-      $lineItems = [CRM_Price_BAO_LineItem::getLineItems($this->getEntityId(), 'contribution_recur', NULL, TRUE, FALSE)];
-      $firstLineItem = reset($lineItems[0]);
-      if (empty($firstLineItem['price_set_id'])) {
-        // CRM-20297 All we care is that it's not QuickConfig, so no price set
-        // is no problem.
-        $displayLineItems = TRUE;
-      }
-      else {
-        try {
-          $priceSet = civicrm_api3('PriceSet', 'getsingle', [
-            'id' => $firstLineItem['price_set_id'],
-            'return' => 'is_quick_config, id',
-          ]);
-          $displayLineItems = !$priceSet['is_quick_config'];
-        }
-        catch (CiviCRM_API3_Exception $e) {
-          throw new CRM_Core_Exception('Cannot find price set by ID');
-        }
+      $templateContribution = CRM_Contribute_BAO_ContributionRecur::getTemplateContribution($this->getEntityId());
+      if (isset($templateContribution['line_item'])) {
+        $this->assign('displayLineItems', TRUE);
+        $this->assign('lineItem', $templateContribution['line_item']);
       }
     }
-    $this->assign('lineItem', $lineItems);
-    $this->assign('displayLineItems', $displayLineItems);
 
     $displayName = CRM_Contact_BAO_Contact::displayName($contributionRecur['contact_id']);
     $this->assign('displayName', $displayName);

--- a/CRM/Contribute/Page/ContributionRecur.php
+++ b/CRM/Contribute/Page/ContributionRecur.php
@@ -75,6 +75,32 @@ class CRM_Contribute_Page_ContributionRecur extends CRM_Core_Page {
 
     $this->assign('recur', $contributionRecur);
 
+    $lineItems = [];
+    $displayLineItems = FALSE;
+    if ($this->getEntityId()) {
+      $lineItems = [CRM_Price_BAO_LineItem::getLineItems($this->getEntityId(), 'contribution_recur', NULL, TRUE, FALSE)];
+      $firstLineItem = reset($lineItems[0]);
+      if (empty($firstLineItem['price_set_id'])) {
+        // CRM-20297 All we care is that it's not QuickConfig, so no price set
+        // is no problem.
+        $displayLineItems = TRUE;
+      }
+      else {
+        try {
+          $priceSet = civicrm_api3('PriceSet', 'getsingle', [
+            'id' => $firstLineItem['price_set_id'],
+            'return' => 'is_quick_config, id',
+          ]);
+          $displayLineItems = !$priceSet['is_quick_config'];
+        }
+        catch (CiviCRM_API3_Exception $e) {
+          throw new CRM_Core_Exception('Cannot find price set by ID');
+        }
+      }
+    }
+    $this->assign('lineItem', $lineItems);
+    $this->assign('displayLineItems', $displayLineItems);
+
     $displayName = CRM_Contact_BAO_Contact::displayName($contributionRecur['contact_id']);
     $this->assign('displayName', $displayName);
 

--- a/templates/CRM/Contribute/Page/ContributionRecur.tpl
+++ b/templates/CRM/Contribute/Page/ContributionRecur.tpl
@@ -20,7 +20,11 @@
         <td class="label">{ts}From{/ts}</td>
         <td class="bold"><a href="{crmURL p='civicrm/contact/view' q="cid=`$recur.contact_id`"}">{$displayName}</a></td>
       </tr>
-      <tr><td class="label">{ts}Amount{/ts}</td><td>{$recur.amount|crmMoney:$recur.currency}{if $is_test} ({ts}test{/ts}){/if}</td></tr>
+      {if $displayLineItems}
+        <tr><td class="label">{ts}Amount{/ts}</td><td>{include file="CRM/Price/Page/LineItem.tpl" context="ContributionRecur" totalAmount=$recur.amount currency=$recur.currency}</td></tr>
+      {else}
+        <tr><td class="label">{ts}Amount{/ts}</td><td>{$recur.amount|crmMoney:$recur.currency}{if $is_test} ({ts}test{/ts}){/if}</td></tr>
+      {/if}
       <tr><td class="label">{ts}Frequency{/ts}</td><td>every {$recur.frequency_interval} {$recur.frequency_unit}</td></tr>
       <tr><td class="label">{ts}Installments{/ts}</td><td>{$recur.installments}</td></tr>
       <tr><td class="label">{ts}Status{/ts}</td><td>{$recur.contribution_status}</td></tr>


### PR DESCRIPTION
Overview
----------------------------------------

Save line items on a recurring contribution.


Before
----------------------------------------

Before when creating a recurring contribution with a price set (through a contribution page) it did not store nor show the line items on the recurring contribution. It did store it at the contribution level. 

![Screenshot_20210524_125323](https://user-images.githubusercontent.com/4126292/119337555-42ae5a80-bc8f-11eb-9851-4975ab94d557.png)

After
----------------------------------------

When creating a recurring contribution with a price set it also saves the line items at the recurring contribution level. 
It also shows this to the user when viewing the recurring contribution. 

![Screenshot_20210524_125301](https://user-images.githubusercontent.com/4126292/119337664-6671a080-bc8f-11eb-91f8-b532eeb87a3a.png)


Comments
----------------------------------------

After this has been merged I can change the code for generating individual contributions and use the line items from the recurring contribution. At the moment the line items are copied from the previous contribution. So functional it works as expected.  However if a recurring contribution could be edited (when a payment processor allows this) then a user should be allowed to edit the line items (payment amount).

See as well this issue: https://lab.civicrm.org/dev/core/-/issues/2624
