### PR TITLE
dev/core#2624  display line items from the template contribution at the view recurring contribution screen.

### DIFF
--- a/CRM/Contribute/Page/ContributionRecur.php
+++ b/CRM/Contribute/Page/ContributionRecur.php
@@ -75,6 +75,17 @@ class CRM_Contribute_Page_ContributionRecur extends CRM_Core_Page {
 
     $this->assign('recur', $contributionRecur);
 
+    $templateContribution = CRM_Contribute_BAO_ContributionRecur::getTemplateContribution($this->getEntityId());
+
+    $lineItems = [];
+    $displayLineItems = FALSE;
+    if (!empty($templateContribution['id'])) {
+      $lineItems = [CRM_Price_BAO_LineItem::getLineItemsByContributionID(($templateContribution['id']))];
+      $displayLineItems = TRUE;
+    }
+    $this->assign('lineItem', $lineItems);
+    $this->assign('displayLineItems', $displayLineItems);
+
     $displayName = CRM_Contact_BAO_Contact::displayName($contributionRecur['contact_id']);
     $this->assign('displayName', $displayName);
 

--- a/templates/CRM/Contribute/Page/ContributionRecur.tpl
+++ b/templates/CRM/Contribute/Page/ContributionRecur.tpl
@@ -20,7 +20,11 @@
         <td class="label">{ts}From{/ts}</td>
         <td class="bold"><a href="{crmURL p='civicrm/contact/view' q="cid=`$recur.contact_id`"}">{$displayName}</a></td>
       </tr>
-      <tr><td class="label">{ts}Amount{/ts}</td><td>{$recur.amount|crmMoney:$recur.currency}{if $is_test} ({ts}test{/ts}){/if}</td></tr>
+      {if $displayLineItems}
+        <tr><td class="label">{ts}Amount{/ts}</td><td>{include file="CRM/Price/Page/LineItem.tpl" context="ContributionRecur" totalAmount=$recur.amount currency=$recur.currency}</td></tr>
+      {else}
+        <tr><td class="label">{ts}Amount{/ts}</td><td>{$recur.amount|crmMoney:$recur.currency}{if $is_test} ({ts}test{/ts}){/if}</td></tr>
+      {/if}
       <tr><td class="label">{ts}Frequency{/ts}</td><td>every {$recur.frequency_interval} {$recur.frequency_unit}</td></tr>
       <tr><td class="label">{ts}Installments{/ts}</td><td>{$recur.installments}</td></tr>
       <tr><td class="label">{ts}Status{/ts}</td><td>{$recur.contribution_status}</td></tr>


### PR DESCRIPTION
Overview
----------------------------------------

This displays the line items from the template contribution at the view recurring contribution screen.

Before
----------------------------------------
![Screenshot_20210524_125323](https://user-images.githubusercontent.com/4126292/119353890-b9555300-bca3-11eb-9f34-f11e360e5450.png)


After
----------------------------------------

![Screenshot_20210524_125301](https://user-images.githubusercontent.com/4126292/119353925-bfe3ca80-bca3-11eb-8e92-740e1cad341a.png)


Technical Details
----------------------------------------

~~This PR fixes also a bug in `CRM_Contribute_BAO_ContributionRecur::reformatLineItemsForRepeatContribution` where the line item array is not build in such a way it can be displayed correctly. (See this comment: https://lab.civicrm.org/dev/core/-/issues/2624#note_59711)~~

The function `CRM_Contribute_BAO_ContributionRecur::getTemplateContribution` also retrieves and formats the line items. However this format is not suitable for displaying. So in the form layer we do another retrieval of of line items and then in the format suitable for displaying. (This code is copied from `CRM/Contribute/Form/ContributionView.php` (See this comment: https://lab.civicrm.org/dev/core/-/issues/2624#note_59711)

Comments
----------------------------------------

See https://lab.civicrm.org/dev/core/-/issues/2624
