### PR TITLE
fix arguments sent to hook_civicrm_check

### DIFF
--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -2546,7 +2546,7 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function check(&$messages, $statusNames = [], $includeDisabled = FALSE) {
-    return self::singleton()->invoke(['messages'],
+    return self::singleton()->invoke(['messages', 'statusNames', 'includeDisabled'],
       $messages, $statusNames, $includeDisabled,
       self::$_nullObject, self::$_nullObject, self::$_nullObject,
       'civicrm_check'


### PR DESCRIPTION
Overview
----------------------------------------
The signature for `hook_civicrm_check` was changed at some point to take three arguments instead of one, per the docs.  However, only one argument is passed to the hook.

Before
----------------------------------------
Error when you defined a `hook_civicrm_check` per the docs:

```
  [Symfony\Component\Debug\Exception\FatalThrowableError]                                                                                                                                                             
  Type error: Too few arguments to function monitoring_civicrm_check(), 1 passed in /mysite.org/vendor/civicrm/civicrm-core/CRM/Utils/Hook.php on line 271 and exactly 3 expected  
```

After
----------------------------------------
All better.

Technical Details
----------------------------------------
Looks like an oversight on #17824.  It should be clear from the line preceding my change what the reason for the change is.