### PR TITLE
Ensure contacts without a name are updated when primary email changes

### DIFF
--- a/CRM/Contact/BAO/Contact/Utils.php
+++ b/CRM/Contact/BAO/Contact/Utils.php
@@ -241,7 +241,7 @@ WHERE  id IN ( $idString )
    */
   public static function createCurrentEmployerRelationship($contactID, $organization, $previousEmployerID = NULL, $newContact = FALSE) {
     //if organization name is passed. CRM-15368,CRM-15547
-    if ($organization && !is_numeric($organization)) {
+    if (!CRM_Utils_System::isNull($organization) && !is_numeric($organization)) {
       $dupeIDs = CRM_Contact_BAO_Contact::getDuplicateContacts(['organization_name' => $organization], 'Organization', 'Unsupervised', [], FALSE);
 
       if (is_array($dupeIDs) && !empty($dupeIDs)) {

--- a/CRM/Contact/Form/Inline/Email.php
+++ b/CRM/Contact/Form/Inline/Email.php
@@ -170,17 +170,9 @@ class CRM_Contact_Form_Inline_Email extends CRM_Contact_Form_Inline {
     }
     CRM_Core_BAO_Block::create('email', $params);
 
-    // If contact has no name, set primary email as display name
-    // TODO: This should be handled in the BAO for the benefit of the api, etc.
+    // Changing email might change a contact's display_name so refresh name block content
     if (!$this->contactHasName) {
-      foreach ($params['email'] as $email) {
-        if ($email['is_primary']) {
-          CRM_Core_DAO::setFieldValue('CRM_Contact_DAO_Contact', $this->_contactId, 'display_name', $email['email']);
-          CRM_Core_DAO::setFieldValue('CRM_Contact_DAO_Contact', $this->_contactId, 'sort_name', $email['email']);
-          $this->ajaxResponse['reloadBlocks'] = ['#crm-contactname-content'];
-          break;
-        }
-      }
+      $this->ajaxResponse['reloadBlocks'] = ['#crm-contactname-content'];
     }
 
     $this->log();

--- a/CRM/Core/BAO/Block.php
+++ b/CRM/Core/BAO/Block.php
@@ -348,7 +348,7 @@ class CRM_Core_BAO_Block {
       $entity = new $class();
       $entity->id = $params['id'];
       $entity->find(TRUE);
-      $contactId = $entity->contact_id;
+      $contactId = $params['contact_id'] = $entity->contact_id;
     }
     // If entity is not associated with contact, concept of is_primary not relevant
     if (!$contactId) {
@@ -397,6 +397,9 @@ class CRM_Core_BAO_Block {
       // primary or return if is already is
       $existingEntities->is_primary = 1;
       $existingEntities->save();
+      if ($class === 'CRM_Core_BAO_Email') {
+        CRM_Core_BAO_Email::updateContactName($contactId, $existingEntities->email);
+      }
     }
   }
 

--- a/Civi/Api4/Service/Spec/Provider/EmailCreationSpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/EmailCreationSpecProvider.php
@@ -30,6 +30,9 @@ class EmailCreationSpecProvider implements Generic\SpecProviderInterface {
     $spec->getFieldByName('email')->setRequired(TRUE);
     $spec->getFieldByName('on_hold')->setRequired(FALSE);
     $spec->getFieldByName('is_bulkmail')->setRequired(FALSE);
+
+    $defaultLocationType = \CRM_Core_BAO_LocationType::getDefault()->id ?? NULL;
+    $spec->getFieldByName('location_type_id')->setDefaultValue($defaultLocationType);
   }
 
   /**

--- a/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php
+++ b/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php
@@ -90,7 +90,7 @@ class AfformAdminMeta {
       'includeCustom' => TRUE,
       'loadOptions' => ['id', 'label'],
       'action' => 'create',
-      'select' => ['name', 'label', 'input_type', 'input_attrs', 'required', 'options', 'help_pre', 'help_post', 'serialize', 'data_type', 'fk_entity'],
+      'select' => ['name', 'label', 'input_type', 'input_attrs', 'required', 'options', 'help_pre', 'help_post', 'serialize', 'data_type', 'fk_entity', 'readonly'],
       'where' => [['input_type', 'IS NOT NULL']],
     ];
     if (in_array($entityName, ['Individual', 'Household', 'Organization'])) {

--- a/ext/afform/admin/ang/afGuiEditor/afGuiEntity.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiEntity.component.js
@@ -72,7 +72,9 @@
 
         function filterFields(fields) {
           return _.transform(fields, function(fieldList, field) {
-            if (!search || _.contains(field.name, search) || _.contains(field.label.toLowerCase(), search)) {
+            if (!field.readonly &&
+              (!search || _.contains(field.name, search) || _.contains(field.label.toLowerCase(), search))
+            ) {
               fieldList.push(fieldDefaults(field));
             }
           }, []);

--- a/ext/afform/core/Civi/Afform/Event/AfformSubmitEvent.php
+++ b/ext/afform/core/Civi/Afform/Event/AfformSubmitEvent.php
@@ -5,15 +5,19 @@ use Civi\Afform\FormDataModel;
 use Civi\Api4\Action\Afform\Submit;
 
 /**
- * Class AfformSubmitEvent
- * @package Civi\Afform\Event
+ * Handle submission of an "<af-form>" entity (or set of entities in the case of `<af-repeat>`).
  *
- * Handle submission of an "<af-form>" entity.
+ * @see Submit::processGenericEntity
+ * which is the default handler of this event, with priority 0.
  *
- * The default handler of this event is `Submit::processGenericEntity`
  * If special processing for an entity type is desired, add a new listener with a higher priority
- * than 0, and either manipulate the $records and allow the default listener to perform the save,
- * or fully process the save and cancel event propagation to bypass `processGenericEntity`.
+ * than 0, and do one of two things:
+ *
+ * 1. Fully process the save, and cancel event propagation to bypass `processGenericEntity`.
+ * 2. Manipulate the $records and allow the default listener to perform the save.
+ *    Setting $record['fields'] = NULL will cancel saving a record, e.g. if the record is not valid.
+ *
+ * @package Civi\Afform\Event
  */
 class AfformSubmitEvent extends AfformBaseEvent {
 
@@ -54,14 +58,14 @@ class AfformSubmitEvent extends AfformBaseEvent {
    * @param array $afform
    * @param \Civi\Afform\FormDataModel $formDataModel
    * @param \Civi\Api4\Action\Afform\Submit $apiRequest
-   * @param array $values
+   * @param array $records
    * @param string $entityType
    * @param string $entityName
    * @param array $entityIds
    */
-  public function __construct(array $afform, FormDataModel $formDataModel, Submit $apiRequest, &$values, string $entityType, string $entityName, array &$entityIds) {
+  public function __construct(array $afform, FormDataModel $formDataModel, Submit $apiRequest, &$records, string $entityType, string $entityName, array &$entityIds) {
     parent::__construct($afform, $formDataModel, $apiRequest);
-    $this->records =& $values;
+    $this->records =& $records;
     $this->entityType = $entityType;
     $this->entityName = $entityName;
     $this->entityIds =& $entityIds;

--- a/ext/afform/core/afform.php
+++ b/ext/afform/core/afform.php
@@ -51,6 +51,7 @@ function afform_civicrm_config(&$config) {
 
   $dispatcher = Civi::dispatcher();
   $dispatcher->addListener(Submit::EVENT_NAME, [Submit::class, 'processGenericEntity'], 0);
+  $dispatcher->addListener(Submit::EVENT_NAME, [Submit::class, 'preprocessContact'], 10);
   $dispatcher->addListener('hook_civicrm_angularModules', ['\Civi\Afform\AngularDependencyMapper', 'autoReq'], -1000);
   $dispatcher->addListener('hook_civicrm_alterAngular', ['\Civi\Afform\AfformMetadataInjector', 'preprocess']);
   $dispatcher->addListener('hook_civicrm_check', ['\Civi\Afform\StatusChecks', 'hook_civicrm_check']);


### PR DESCRIPTION
Overview
----------------------------------------
Contacts with no name use their primary email as `display_name` and `sort_name`.
This ensures that when their primary email is updated, `display_name` and `sort_name` will be updated as well.

Fixes https://lab.civicrm.org/dev/core/-/issues/2622

Before
----------------------------------------
Updating primary email would only update a contact's display/sort name if done through the UI.

After
----------------------------------------
Works in APIv3, APIv4 & Afform, with tests.

Technical Details
----------------------------------------
In some circumstances this may cause an extra query or two, but generally this stuff is cached so it shouldn't be a big problem.