### PR TITLE
Update eventcart test to only test payment form

### DIFF
--- a/tests/phpunit/CRM/Financial/Form/PaymentFormsTest.php
+++ b/tests/phpunit/CRM/Financial/Form/PaymentFormsTest.php
@@ -92,9 +92,14 @@ class CRM_Financial_Form_PaymentFormsTest extends CiviUnitTestCase {
         $form->postProcess();
         $qfKey = $form->controller->_key;
       }
-      $this->callAPISuccessGetSingle('Participant', ['participant_status_id' => 'Registered']);
-      $this->assertRequestValid(['x_city' => 'The+Shire', 'x_state' => 'IL', 'x_amount' => 1.0]);
     }
+    $participant = \Civi\Api4\Participant::get(FALSE)
+      ->addWhere('status_id:name', '=', 'Registered')
+      ->execute()
+      ->first();
+    $this->assertEquals($cart->id, $participant['cart_id']);
+    $this->assertEquals(CRM_Core_PseudoConstant::getKey('CRM_Event_BAO_Participant', 'status_id', 'Registered'), $participant['status_id']);
+    $this->assertRequestValid(['x_city' => 'The+Shire', 'x_state' => 'IL', 'x_amount' => 1.0]);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
There are two forms in the "checkout" phase of the eventcart. One which selects payments and prices and the final one which is the checkout where payment is taken.
The original implementation incorrectly set participants to "registered" on the first form while the refactored version uses Order API and correctly sets them to "Pending in Cart" until payment is taken when they are updated to Registered.

This updates the test to only check the "registered" status on completion of the second checkout (payment) form and will pass with both original and new implementations.

Before
----------------------------------------
Participants set as registered before payment, test validating that happens.

After
----------------------------------------
Test validating that participant is "registered" once payment has been made.

Technical Details
----------------------------------------
Explained above. Test change only.

Comments
----------------------------------------
