### PR TITLE
[REF] Paypal ipn - cleanup references to completion

### DIFF
--- a/tests/phpunit/CRM/Core/Payment/PayPalProIPNTest.php
+++ b/tests/phpunit/CRM/Core/Payment/PayPalProIPNTest.php
@@ -124,14 +124,18 @@ class CRM_Core_Payment_PayPalProIPNTest extends CiviUnitTestCase {
   }
 
   /**
-   * CRM-13743 test IPN edge case where the first transaction fails and the second succeeds.
+   * CRM-13743 test IPN edge case where the first transaction fails and the
+   * second succeeds.
    *
-   * We are checking that the created contribution has the same date as IPN says it should
-   * Note that only one contribution will be created (no evidence of the failed contribution is left)
-   * It seems likely that may change in future & this test will start failing (I point this out in the hope it
-   * will help future debuggers)
+   * We are checking that the created contribution has the same date as IPN
+   * says it should Note that only one contribution will be created (no
+   * evidence of the failed contribution is left) It seems likely that may
+   * change in future & this test will start failing (I point this out in the
+   * hope it will help future debuggers)
+   *
+   * @throws \CRM_Core_Exception
    */
-  public function testIPNPaymentCRM13743() {
+  public function testIPNPaymentCRM13743(): void {
     $this->setupRecurringPaymentProcessorTransaction();
     $firstPaymentParams = $this->getPaypalProRecurTransaction();
     $firstPaymentParams['txn_type'] = 'recurring_payment_failed';


### PR DESCRIPTION
Overview
----------------------------------------
[REF] Paypal ipn - cleanup references to completion 

Before
----------------------------------------
Params passed around

After
----------------------------------------
function used

Technical Details
----------------------------------------
This extracts a function to check if the contribution is completed.

I also rationalised the validation - it was using a combo of recur and first to
validate but on thinking it through I realised all it was saying was
'if we are finalising a pending contribution the amount must match'

I think that's fine even for recur with a change in amount - that seems
to me to be something that happens down the track but we still expect
the very first one to come in with the value it originally
had - if that is NOT true then we probably should just remove the check


Comments
----------------------------------------
Note this leaves a bunch of unused params - I think it's cleaner to remove those once this is merged