### PR TITLE
[REF] Replace deprecated code call

### DIFF
--- a/CRM/Core/Invoke.php
+++ b/CRM/Core/Invoke.php
@@ -365,7 +365,7 @@ class CRM_Core_Invoke {
    *
    * @throws Exception
    */
-  public static function rebuildMenuAndCaches($triggerRebuild = FALSE, $sessionReset = FALSE) {
+  public static function rebuildMenuAndCaches(bool $triggerRebuild = FALSE, bool $sessionReset = FALSE): void {
     $config = CRM_Core_Config::singleton();
     $config->clearModuleList();
 
@@ -393,7 +393,7 @@ class CRM_Core_Invoke {
       $triggerRebuild ||
       CRM_Utils_Request::retrieve('triggerRebuild', 'Boolean', CRM_Core_DAO::$_nullObject, FALSE, 0, 'GET')
     ) {
-      CRM_Core_DAO::triggerRebuild();
+      Civi::service('sql_triggers')->rebuild();
       $config->userSystem->invalidateRouteCache();
     }
     CRM_Core_DAO_AllCoreTables::reinitializeCache(TRUE);


### PR DESCRIPTION
Overview
----------------------------------------
[REF] Replace deprecated code call

Before
----------------------------------------
Deprecated fn call
```
CRM_Core_DAO::triggerRebuild()
```

After
----------------------------------------
```
Civi::service('sql_triggers')->rebuild()
```

Technical Details
----------------------------------------
I hadn't made this change before because the Civi::service() facade means it takes a bit of effort to find the function being called & verify the signature is in fact the same - however I did it this time & it is.

![image](https://user-images.githubusercontent.com/336308/119421009-d2b4d880-bd51-11eb-8f09-d18610883c1f.png)

Perhaps as a follow up we should rip through & do all the others - I'm tempted to perhaps add a comment to say what the actually called function is before each line but I guess in theory the Civi facade is dev-friendly

Also I'm very tempted to rip out the check to the url retrieve - ```   CRM_Utils_Request::retrieve('triggerRebuild', 'Boolean', CRM_Core_DAO::$_nullObject, FALSE, 0, 'GET') ``` = this seems to me like an undocumented feature that was used by devs when developing the triggers but which devs would do in other ways now...

Comments
----------------------------------------
