### PR TITLE
Afform GUI - Fix tab breakage in Shoreditch theme

### DIFF
--- a/ext/afform/admin/ang/afGuiEditor.css
+++ b/ext/afform/admin/ang/afGuiEditor.css
@@ -39,13 +39,15 @@
 }
 #afGuiEditor .panel-heading {
   height: 44px;
-  padding: 10px;
+  padding: 5px 10px 10px 10px;
+  border-bottom: 1px solid #ddd;
 }
 #afGuiEditor .panel-heading ul.nav-tabs {
   border-bottom: 0 none;
+  padding: 0!important;
 }
 #afGuiEditor .panel-heading ul.nav-tabs li {
-  top: 1px;
+  top: 6px;
 }
 #afGuiEditor .panel-heading ul.nav-tabs li.fluid-width-tab {
   white-space: nowrap;
@@ -67,6 +69,7 @@
   height: calc(100% - 44px);
   overflow-y: scroll;
   overflow-x: hidden;
+  border-top: none!important;
 }
 
 #afGuiEditor .af-gui-columns {


### PR DESCRIPTION
Overview
----------------------------------------
Fix layout breakage when using Shoreditch theme.

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/2874912/119512061-fc193880-bd40-11eb-9155-fa1e60196d34.png)


After
----------------------------------------
![image](https://user-images.githubusercontent.com/2874912/119513881-9d54be80-bd42-11eb-8e5c-1fe68160cca3.png)


Comments
----------------------------------------
I dunno why Shoreditch css adds extra padding. Maybe for the API explorer?