### PR TITLE
Remove unused variable on dummy processor

### DIFF
--- a/CRM/Core/Payment/Dummy.php
+++ b/CRM/Core/Payment/Dummy.php
@@ -20,9 +20,8 @@ use Civi\Payment\PropertyBag;
  * Dummy payment processor
  */
 class CRM_Core_Payment_Dummy extends CRM_Core_Payment {
-  protected $_mode;
 
-  protected $_params = [];
+  protected $_mode;
   protected $_doDirectPaymentResult = [];
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Class variable `$_params` is not used

Before
----------------------------------------
Unused class variable

After
----------------------------------------
Gone

Technical Details
----------------------------------------

Comments
----------------------------------------

