### PR TITLE
dev/core#2593 Fix failure to complete contributions when membership deleted

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4234,21 +4234,18 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
       $contributionID = $contributionResult['id'];
     }
 
-    if ($input['component'] == 'contribute') {
-      if ($contributionParams['contribution_status_id'] === $completedContributionStatusID) {
-        self::updateMembershipBasedOnCompletionOfContribution(
-          $contributionID,
-          $input['trxn_date'] ?? date('YmdHis')
-        );
-      }
+    if ($contributionParams['contribution_status_id'] === $completedContributionStatusID) {
+      self::updateMembershipBasedOnCompletionOfContribution(
+        $contributionID,
+        $input['trxn_date'] ?? date('YmdHis')
+      );
     }
-    else {
-      $participantPayment = civicrm_api3('ParticipantPayment', 'get', ['contribution_id' => $contributionID, 'return' => 'participant_id', 'sequential' => 1])['values'];
-      if (!empty($participantPayment) && empty($input['IAmAHorribleNastyBeyondExcusableHackInTheCRMEventFORMTaskClassThatNeedsToBERemoved'])) {
-        $participantParams['id'] = $participantPayment[0]['participant_id'];
-        $participantParams['status_id'] = 'Registered';
-        civicrm_api3('Participant', 'create', $participantParams);
-      }
+
+    $participantPayment = civicrm_api3('ParticipantPayment', 'get', ['contribution_id' => $contributionID, 'return' => 'participant_id', 'sequential' => 1])['values'];
+    if (!empty($participantPayment) && empty($input['IAmAHorribleNastyBeyondExcusableHackInTheCRMEventFORMTaskClassThatNeedsToBERemoved'])) {
+      $participantParams['id'] = $participantPayment[0]['participant_id'];
+      $participantParams['status_id'] = 'Registered';
+      civicrm_api3('Participant', 'create', $participantParams);
     }
 
     $contributionParams['id'] = $contributionID;


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#2593 Fix failure to complete contributions when membership deleted

Before
----------------------------------------
loadRelatedObjects can cause inappropriate fails

After
----------------------------------------
poof

Technical Details
----------------------------------------
includes https://github.com/civicrm/civicrm-core/pull/20423 so that can be rebased out or merged as part of this

Comments
----------------------------------------
@seamuslee001 I put up both the smaller patch & the full & final patch (+ paypal express separately) - once the current 3 are closed this is done