### PR TITLE
core#1590: Disable 'Also include' on participant-based scheduled reminders

### DIFF
--- a/templates/CRM/Admin/Form/ScheduleReminders.tpl
+++ b/templates/CRM/Admin/Form/ScheduleReminders.tpl
@@ -195,8 +195,10 @@
         showHideLimitTo();
       }
 
-      // CRM-14070 Hide limit-to when entity is activity
+      // Magic numbers, sigh. `1` is "Activity", `2`, `3`, and `5` are participant-based.
+      // Can't use labels because of i18n concerns.
       function showHideLimitTo() {
+        // CRM-14070 Hide limit-to when entity is activity
         $('#limit_to', $form).toggle(!($('#entity_0', $form).val() == '1'));
         if ($('#entity_0', $form).val() != '1' || !($('#entity_0').length)) {
           if ($('#limit_to', $form).val() == '') {
@@ -215,6 +217,9 @@
           $('a.limit_to').hide();
           $("label[for='recipient']").text('{/literal}{$recipientLabels.activity}{literal}');
         }
+        // core#1590 Disable "Also include" on participant-based reminders.
+        isParticipantReminder = ["2", "3", "5"].includes($('#entity_0', $form).val());
+        $('#limit_to option[value="0"]').prop('disabled', isParticipantReminder);
       }
 
       $('#recipient', $form).change(populateRecipient);


### PR DESCRIPTION
Overview
----------------------------------------
Scheduled reminders based on events can't have an "Also include" additional recipients, even though it's allowed as an option.  For additional context, see discussion at:
https://github.com/civicrm/civicrm-core/pull/17641
https://lab.civicrm.org/dev/core/-/issues/1590

I've received user complaints that a broken piece of functionality should be disabled, rather than needing to train users not to use it.  This is particularly important here because using this functionality has unexpected results (e.g. sending reminders on long-past events to unrelated users).

Before
----------------------------------------
![Selection_1106](https://user-images.githubusercontent.com/1796012/119574143-3d323c80-bd83-11eb-8463-8944b37417a4.png)


After
----------------------------------------
![Selection_1107](https://user-images.githubusercontent.com/1796012/119574150-402d2d00-bd83-11eb-8316-fc67fcb46e2d.png)

Comments
----------------------------------------
The functionality has been broken since 4.7, when Scheduled Reminders were rewritten.  While previous PRs have mitigated some of the worst side effects of selecting this option, there's no scenario in which the desired effect is achieved.
