### PR TITLE
Test fixes

### DIFF
--- a/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
@@ -1141,7 +1141,7 @@ Price Field - Price Field 1        1   $ 100.00      $ 100.00
       ]
     );
     $this->assertEquals(100, $contribution['total_amount']);
-    $this->assertEquals(NULL, $contribution['tax_amount']);
+    $this->assertEquals(0, (float) $contribution['tax_amount']);
     $this->callAPISuccessGetCount('FinancialTrxn', [], 1);
     $this->callAPISuccessGetCount('FinancialItem', [], 1);
     $lineItem = $this->callAPISuccessGetSingle('LineItem', [

--- a/tests/phpunit/api/v3/ContributionPageTest.php
+++ b/tests/phpunit/api/v3/ContributionPageTest.php
@@ -89,6 +89,7 @@ class api_v3_ContributionPageTest extends CiviUnitTestCase {
     foreach ($this->contactIds as $id) {
       $this->callAPISuccess('contact', 'delete', ['id' => $id]);
     }
+    $this->quickCleanup(['civicrm_system_log']);
     $this->quickCleanUpFinancialEntities();
     parent::tearDown();
   }


### PR DESCRIPTION

Overview
----------------------------------------
Test fixes

This improves cleanup in one class & in another makes it accept tax_amount = 0
rather than requiring it to be NULL. In general it's better for us to return
and save 0 so this makes the test tolerate those changes

Before
----------------------------------------
Test requires tax_amount to be NULL

After
----------------------------------------
Test accepts NULL or 0

Technical Details
----------------------------------------

Comments
----------------------------------------
