### PR TITLE
BAOs, Tests, etal - Support `HookInterface` and `EventSubscriberInterface` for auto-registration

### DIFF
--- a/CRM/Api4/Services.php
+++ b/CRM/Api4/Services.php
@@ -16,7 +16,7 @@
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
 
-
+use Civi\Core\Event\EventScanner;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\Config\FileLocator;
@@ -43,11 +43,8 @@ class CRM_Api4_Services {
     $subscribers = $container->findTaggedServiceIds('event_subscriber');
 
     foreach (array_keys($subscribers) as $subscriber) {
-      $getSubscribedEvents = [$container->findDefinition($subscriber)->getClass(), 'getSubscribedEvents'];
-      $dispatcher->addMethodCall(
-        'addSubscriberServiceMap',
-        [$subscriber, $getSubscribedEvents()]
-      );
+      $listenerMap = EventScanner::findListeners($container->findDefinition($subscriber)->getClass());
+      $dispatcher->addMethodCall('addSubscriberServiceMap', [$subscriber, $listenerMap]);
     }
 
     // add spec providers

--- a/CRM/Contact/BAO/RelationshipCache.php
+++ b/CRM/Contact/BAO/RelationshipCache.php
@@ -69,7 +69,7 @@ class CRM_Contact_BAO_RelationshipCache extends CRM_Contact_DAO_RelationshipCach
    * @param \Civi\Core\Event\GenericHookEvent $e
    * @see \CRM_Utils_Hook::triggerInfo
    */
-  public static function on_hook_civicrm_triggerInfo($e) {
+  public static function on_hook_civicrm_triggerInfo($e): void {
     $relUpdates = self::createInsertUpdateQueries();
     // Use utf8mb4_bin or utf8_bin, depending on what's in use.
     $collation = preg_replace('/^(utf8(?:mb4)?)_.*$/', '$1_bin', CRM_Core_BAO_SchemaHandler::getInUseCollation());

--- a/CRM/Contact/BAO/RelationshipCache.php
+++ b/CRM/Contact/BAO/RelationshipCache.php
@@ -12,7 +12,7 @@
 /**
  * Class CRM_Contact_BAO_RelationshipCache.
  */
-class CRM_Contact_BAO_RelationshipCache extends CRM_Contact_DAO_RelationshipCache {
+class CRM_Contact_BAO_RelationshipCache extends CRM_Contact_DAO_RelationshipCache implements \Civi\Test\HookInterface {
 
   /**
    * The "mappings" array defines the values to put into `civicrm_relationship_cache`
@@ -69,7 +69,7 @@ class CRM_Contact_BAO_RelationshipCache extends CRM_Contact_DAO_RelationshipCach
    * @param \Civi\Core\Event\GenericHookEvent $e
    * @see \CRM_Utils_Hook::triggerInfo
    */
-  public static function onHookTriggerInfo($e) {
+  public static function on_hook_civicrm_triggerInfo($e) {
     $relUpdates = self::createInsertUpdateQueries();
     // Use utf8mb4_bin or utf8_bin, depending on what's in use.
     $collation = preg_replace('/^(utf8(?:mb4)?)_.*$/', '$1_bin', CRM_Core_BAO_SchemaHandler::getInUseCollation());

--- a/CRM/Core/BAO/RecurringEntity.php
+++ b/CRM/Core/BAO/RecurringEntity.php
@@ -20,7 +20,7 @@ use When\When;
 /**
  * Class CRM_Core_BAO_RecurringEntity.
  */
-class CRM_Core_BAO_RecurringEntity extends CRM_Core_DAO_RecurringEntity {
+class CRM_Core_BAO_RecurringEntity extends CRM_Core_DAO_RecurringEntity implements \Symfony\Component\EventDispatcher\EventSubscriberInterface {
 
   const RUNNING = 1;
   public $schedule = [];
@@ -114,6 +114,14 @@ class CRM_Core_BAO_RecurringEntity extends CRM_Core_DAO_RecurringEntity {
   const MODE_THIS_ENTITY_ONLY = 1;
   const MODE_NEXT_ALL_ENTITY = 2;
   const MODE_ALL_ENTITY_IN_SERIES = 3;
+
+  public static function getSubscribedEvents() {
+    return [
+      'civi.dao.postInsert' => 'triggerInsert',
+      'civi.dao.postUpdate' => 'triggerUpdate',
+      'civi.dao.postDelete' => 'triggerDelete',
+    ];
+  }
 
   /**
    * Getter for status.

--- a/CRM/Core/DAO/AllCoreTables.php
+++ b/CRM/Core/DAO/AllCoreTables.php
@@ -277,6 +277,23 @@ class CRM_Core_DAO_AllCoreTables {
   }
 
   /**
+   * Get a list of all extant BAO classes.
+   *
+   * @return array
+   *   Ex: ['Contact' => 'CRM_Contact_BAO_Contact']
+   */
+  public static function getBaoClasses() {
+    $r = [];
+    foreach (\CRM_Core_DAO_AllCoreTables::daoToClass() as $entity => $daoClass) {
+      $baoClass = str_replace('_DAO_', '_BAO_', $daoClass);
+      if (class_exists($baoClass)) {
+        $r[$entity] = $baoClass;
+      }
+    }
+    return $r;
+  }
+
+  /**
    * Get the classname for the table.
    *
    * @param string $tableName

--- a/CRM/Utils/System/UnitTests.php
+++ b/CRM/Utils/System/UnitTests.php
@@ -27,6 +27,15 @@ class CRM_Utils_System_UnitTests extends CRM_Utils_System_Base {
     $this->supports_form_extensions = FALSE;
   }
 
+  public function initialize() {
+    parent::initialize();
+    $test = $GLOBALS['CIVICRM_TEST_CASE'] ?? NULL;
+    if ($test && $test instanceof \Civi\Test\HeadlessInterface) {
+      $listenerMap = \Civi\Core\Event\EventScanner::findListeners($test);
+      \Civi::dispatcher()->addListenerMap($test, $listenerMap);
+    }
+  }
+
   /**
    * @param string $name
    * @param string $value

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -400,7 +400,6 @@ class Container {
     $dispatcher->addListener('hook_civicrm_permissionList', ['CRM_Core_Permission_List', 'findCiviPermissions'], 950);
     $dispatcher->addListener('hook_civicrm_permissionList', ['CRM_Core_Permission_List', 'findCmsPermissions'], 925);
 
-    $dispatcher->addListener('hook_civicrm_triggerInfo', ['\CRM_Contact_BAO_RelationshipCache', 'onHookTriggerInfo']);
     $dispatcher->addListener('civi.dao.postInsert', ['\CRM_Core_BAO_RecurringEntity', 'triggerInsert']);
     $dispatcher->addListener('civi.dao.postUpdate', ['\CRM_Core_BAO_RecurringEntity', 'triggerUpdate']);
     $dispatcher->addListener('civi.dao.postDelete', ['\CRM_Core_BAO_RecurringEntity', 'triggerDelete']);

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -400,9 +400,6 @@ class Container {
     $dispatcher->addListener('hook_civicrm_permissionList', ['CRM_Core_Permission_List', 'findCiviPermissions'], 950);
     $dispatcher->addListener('hook_civicrm_permissionList', ['CRM_Core_Permission_List', 'findCmsPermissions'], 925);
 
-    $dispatcher->addListener('civi.dao.postInsert', ['\CRM_Core_BAO_RecurringEntity', 'triggerInsert']);
-    $dispatcher->addListener('civi.dao.postUpdate', ['\CRM_Core_BAO_RecurringEntity', 'triggerUpdate']);
-    $dispatcher->addListener('civi.dao.postDelete', ['\CRM_Core_BAO_RecurringEntity', 'triggerDelete']);
     $dispatcher->addListener('hook_civicrm_postSave_civicrm_domain', ['\CRM_Core_BAO_Domain', 'onPostSave']);
     $dispatcher->addListener('hook_civicrm_unhandled_exception', [
       'CRM_Core_LegacyErrorHandler',

--- a/Civi/Core/Event/EventPrinter.php
+++ b/Civi/Core/Event/EventPrinter.php
@@ -16,7 +16,7 @@ class EventPrinter {
    * @param mixed $callback
    * @return string
    */
-  public static function formatName($callback) {
+  public static function formatName($callback): string {
     $normalizeNamespace = function($symbol) {
       return $symbol{0} === '\\' ? substr($symbol, 1) : $symbol;
     };

--- a/Civi/Core/Event/EventPrinter.php
+++ b/Civi/Core/Event/EventPrinter.php
@@ -1,0 +1,50 @@
+<?php
+
+
+namespace Civi\Core\Event;
+
+/**
+ * This provides some rarely used debug utilities.
+ *
+ * @package Civi\Core\Event
+ */
+class EventPrinter {
+
+  /**
+   * Prepare a name to identify a callable element.
+   *
+   * @param mixed $callback
+   * @return string
+   */
+  public static function formatName($callback) {
+    $normalizeNamespace = function($symbol) {
+      return $symbol{0} === '\\' ? substr($symbol, 1) : $symbol;
+    };
+    if (is_array($callback)) {
+      [$a, $b] = $callback;
+      if (is_object($a)) {
+        return $normalizeNamespace(get_class($a)) . "->$b(\$e)";
+      }
+      elseif (is_string($a)) {
+        return $normalizeNamespace($a) . "::$b(\$e)";
+      }
+    }
+    elseif (is_string($callback)) {
+      return $normalizeNamespace($callback) . '(\$e)';
+    }
+    elseif ($callback instanceof ServiceListener || $callback instanceof HookStyleListener) {
+      return (string) $callback;
+    }
+    else {
+      try {
+        $f = new \ReflectionFunction($callback);
+        return 'closure<' . $f->getFileName() . '@' . $f->getStartLine() . '>($e)';
+      }
+      catch (\ReflectionException $e) {
+      }
+    }
+
+    return 'unidentified';
+  }
+
+}

--- a/Civi/Core/Event/EventScanner.php
+++ b/Civi/Core/Event/EventScanner.php
@@ -1,0 +1,176 @@
+<?php
+
+namespace Civi\Core\Event;
+
+/**
+ * The `EventScanner` is a utility for scanning a class to see if it has any event-listeners. It may check
+ * for common interfaces and conventions. Example:
+ *
+ * ```
+ * $map = EventScanner::findListeners($someObject);
+ * $dispatcher->addListenerMap($someObject, $map);
+ * ```
+ */
+class EventScanner {
+
+  /**
+   * In-memory cache of the listener-maps found on various classes.
+   *
+   * This cache is a little unusual -- it is geared toward improving unit-tests. Bear in mind:
+   *
+   * - The `EventScanner` is fundamentally scanning class-structure.
+   * - Within a given PHP process, the class-structure cannot change. Therefore, the cached view in `static::$listenerMaps` cannot be stale.
+   * - There are three kinds of PHP processes:
+   *    1. System-flushes -- During this operation, we rebuild the `Container`. This may do some scanning, and the results will be recorded in `Container`.
+   *    2. Ordinary page-loads -- We use the `Container` cache. It shouldn't need any more scans.
+   *    3. Headless unit-tests -- For these, we must frequently tear-down and rebuild a fresh `Container`, often with varying decisions about
+   *       which extensions/services/classes to activate. The container-cache does not operate.
+   *
+   * Here's how `$listenerMaps` plays out in each:
+   *
+   * 1. The `$listenerMaps` is not needed or used.
+   * 2. The `$listenerMaps` (and `EventScanner` generally) is not needed or used.
+   * 3. The `$listenerMaps` is used frequently, preventing redundant scanning.
+   *
+   * A more common approach would be to use `Civi::$statics` or `Civi::cache()`. These would be inappropriate because we want the data to be
+   * preserved across multiple test-runs -- and because the underlying data (PHP class-structure) does not change within a unit-test.
+   *
+   * @var array
+   *   Ex: ['api_v3_SyntaxConformanceTest' => [...listener-names...]]
+   */
+  private static $listenerMaps = [];
+
+  /**
+   * Scan an object or class for event listeners.
+   *
+   * Note: This requires scanning. Consequently, it should not be run in bulk on a regular (runtime) basis. Instead, store
+   * the listener-maps in a cache (e.g. `Container`).
+   *
+   * @param string|object $target
+   *   The object/class which will receive the notifications.
+   *   Use a string (class-name) if the listeners are static methods.
+   *   Use an object-instance if the listeners are regular methods.
+   * @param string|null $self
+   *   If the target $class is focused on a specific entity/form/etc, use the `$self` parameter to specify it.
+   *   This will activate support for `self_{$event}` methods.
+   *   Ex: if '$self' is 'Contact', then 'function self_hook_civicrm_pre()' maps to 'hook_civicrm_pre::Contact'.
+   * @return array
+   *   List of events/listeners. Format is compatible with 'getSubscribedEvents()'.
+   *   Ex: ['some.event' => [['firstFunc'], ['secondFunc']]
+   */
+  public static function findListeners($target, $self = NULL) {
+    $class = is_object($target) ? get_class($target) : $target;
+    $key = "$class::" . ($self ?: '');
+    if (isset(self::$listenerMaps[$key])) {
+      return self::$listenerMaps[$key];
+    }
+
+    $listenerMap = [];
+    // FIXME: Inteface misnomer
+    if (is_subclass_of($class, '\Civi\Test\HookInterface')) {
+      $listenerMap = static::mergeListenerMap($listenerMap, static::findFunctionListeners($class, $self));
+    }
+    if (is_subclass_of($class, '\Symfony\Component\EventDispatcher\EventSubscriberInterface')) {
+      $listenerMap = static::mergeListenerMap($listenerMap, static::normalizeListenerMap($class::getSubscribedEvents()));
+    }
+
+    if (CIVICRM_UF === 'UnitTests') {
+      self::$listenerMaps[$key] = $listenerMap;
+    }
+    return $listenerMap;
+  }
+
+  /**
+   * @param string $class
+   * @param string|null $self
+   *   If the target $class is focused on a specific entity/form/etc, use the `$self` parameter to specify it.
+   *   This will activate support for `self_{$event}` methods.
+   *   Ex: if '$self' is 'Contact', then 'function self_hook_civicrm_pre()' maps to 'hook_civicrm_pre::Contact'.
+   * @return \Generator
+   */
+  protected static function findFunctionListeners($class, $self = NULL) {
+    $listenerMap = [];
+
+    /**
+     * @param string $underscore
+     *   Ex: 'civi_foo_bar', 'hook_civicrm_foo'
+     * @return string
+     *   Ex: 'civi.foo.bar', 'hook_civicrm_foo'
+     */
+    $toEventName = function ($underscore) {
+      if (substr($underscore, 0, 5) === 'hook_') {
+        return $underscore;
+      }
+      else {
+        return str_replace('_', '.', $underscore);
+      }
+    };
+
+    $addListener = function ($event, $func, $priority = 0) use (&$listenerMap) {
+      $listenerMap[$event][] = [$func, $priority];
+    };
+
+    foreach (get_class_methods($class) as $func) {
+      if (preg_match('/^(hook_|on_|self_)/', $func, $m)) {
+        switch ($m[1]) {
+          case 'hook_':
+            $addListener('&' . $func, $func);
+            break;
+
+          case 'on_':
+            $addListener($toEventName(substr($func, 3)), $func);
+            break;
+
+          case 'self_':
+            if ($self === NULL) {
+              throw new \RuntimeException("Cannot add self_*() listeners for $class");
+            }
+            $addListener($toEventName(substr($func, 5)) . '::' . $self, $func);
+            break;
+        }
+      }
+    }
+
+    return $listenerMap;
+  }
+
+  /**
+   * Convert the listeners to a standard flavor.
+   *
+   * @param array $listenerMap
+   *   List of events/listeners. Listeners may be given in singular or plural form.
+   *   Ex: ['some.event' => 'oneListener']
+   *   Ex: ['some.event' => ['oneListener', 100]]
+   *   Ex: ['some.event' => [['firstListener', 100], ['secondListener']]]
+   * @return array
+   *   List of events/listeners. All listeners are described in plural form.
+   *   Ex: ['some.event' => [['firstListener', 100], ['secondListener']]]
+   */
+  protected static function normalizeListenerMap($listenerMap) {
+    $r = [];
+    foreach ($listenerMap as $eventName => $params) {
+      $r[$eventName] = [];
+      if (\is_string($params)) {
+        $r[$eventName][] = [$params];
+      }
+      elseif (\is_string($params[0])) {
+        $r[$eventName][] = $params;
+      }
+      else {
+        $r[$eventName] = array_merge($r[$eventName], $params);
+      }
+    }
+    return $r;
+  }
+
+  protected static function mergeListenerMap($left, $right) {
+    if ($left === []) {
+      return $right;
+    }
+    foreach ($right as $eventName => $listeners) {
+      $left[$eventName] = array_merge($left[$eventName] ?? [], $listeners);
+    }
+    return $left;
+  }
+
+}

--- a/Civi/Core/Event/EventScanner.php
+++ b/Civi/Core/Event/EventScanner.php
@@ -58,7 +58,7 @@ class EventScanner {
    *   List of events/listeners. Format is compatible with 'getSubscribedEvents()'.
    *   Ex: ['some.event' => [['firstFunc'], ['secondFunc']]
    */
-  public static function findListeners($target, $self = NULL) {
+  public static function findListeners($target, $self = NULL): array {
     $class = is_object($target) ? get_class($target) : $target;
     $key = "$class::" . ($self ?: '');
     if (isset(self::$listenerMaps[$key])) {
@@ -86,9 +86,9 @@ class EventScanner {
    *   If the target $class is focused on a specific entity/form/etc, use the `$self` parameter to specify it.
    *   This will activate support for `self_{$event}` methods.
    *   Ex: if '$self' is 'Contact', then 'function self_hook_civicrm_pre()' maps to 'hook_civicrm_pre::Contact'.
-   * @return \Generator
+   * @return array
    */
-  protected static function findFunctionListeners($class, $self = NULL) {
+  protected static function findFunctionListeners(string $class, $self = NULL): array {
     $listenerMap = [];
 
     /**
@@ -137,7 +137,7 @@ class EventScanner {
   /**
    * Convert the listeners to a standard flavor.
    *
-   * @param array $listenerMap
+   * @param iterable $listenerMap
    *   List of events/listeners. Listeners may be given in singular or plural form.
    *   Ex: ['some.event' => 'oneListener']
    *   Ex: ['some.event' => ['oneListener', 100]]
@@ -146,7 +146,7 @@ class EventScanner {
    *   List of events/listeners. All listeners are described in plural form.
    *   Ex: ['some.event' => [['firstListener', 100], ['secondListener']]]
    */
-  protected static function normalizeListenerMap($listenerMap) {
+  protected static function normalizeListenerMap(iterable $listenerMap): array {
     $r = [];
     foreach ($listenerMap as $eventName => $params) {
       $r[$eventName] = [];
@@ -163,7 +163,7 @@ class EventScanner {
     return $r;
   }
 
-  protected static function mergeListenerMap($left, $right) {
+  protected static function mergeListenerMap(array $left, array $right): array {
     if ($left === []) {
       return $right;
     }

--- a/Civi/Core/Event/HookStyleListener.php
+++ b/Civi/Core/Event/HookStyleListener.php
@@ -30,10 +30,11 @@ class HookStyleListener {
   }
 
   public function __invoke(GenericHookEvent $e) {
-    return call_user_func_array($this->callback, $e->getHookValues());
+    $result = call_user_func_array($this->callback, $e->getHookValues());
+    $e->addReturnValues($result);
   }
 
-  public function __toString() {
+  public function __toString(): string {
     $name = EventPrinter::formatName($this->callback);
     return preg_replace('/\(\$?e?\)$/', '(&...)', $name);
   }

--- a/Civi/Core/Event/HookStyleListener.php
+++ b/Civi/Core/Event/HookStyleListener.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Civi\Core\Event;
+
+/**
+ * This is an adapter which allows you to attach hook-style functions directly to the dispatcher.
+ * Example:
+ *
+ * ```php
+ * function listen_to_hook_foo($arg1, &$arg2, $arg3) { ... }
+ * Civi::dispatcher()->addListener('hook_civicrm_foo', new HookStyleListener('listen_to_hook_foo'));
+ * ```
+ *
+ * @package Civi\Core\Event
+ */
+class HookStyleListener {
+
+  /**
+   * @var array
+   *   Ex: ['SomeClass', 'someMethod']
+   */
+  private $callback = NULL;
+
+  /**
+   * @param array $callback
+   *   Ex: ['SomeClass', 'someMethod']
+   */
+  public function __construct($callback) {
+    $this->callback = $callback;
+  }
+
+  public function __invoke(GenericHookEvent $e) {
+    return call_user_func_array($this->callback, $e->getHookValues());
+  }
+
+  public function __toString() {
+    $name = EventPrinter::formatName($this->callback);
+    return preg_replace('/\(\$?e?\)$/', '(&...)', $name);
+  }
+
+}

--- a/Civi/Core/Event/ServiceListener.php
+++ b/Civi/Core/Event/ServiceListener.php
@@ -64,10 +64,10 @@ class ServiceListener {
       }
     }
     if ($class) {
-      return sprintf('$(%s)->%s() [%s]', $this->inertCb[0], $this->inertCb[1], $class);
+      return sprintf('$(%s)->%s($e) [%s]', $this->inertCb[0], $this->inertCb[1], $class);
     }
     else {
-      return sprintf('\$(%s)->%s()', $this->inertCb[0], $this->inertCb[1]);
+      return sprintf('\$(%s)->%s($e)', $this->inertCb[0], $this->inertCb[1]);
     }
   }
 

--- a/Civi/Test/CiviTestListener.php
+++ b/Civi/Test/CiviTestListener.php
@@ -58,12 +58,6 @@ else {
         $this->bootHeadless($test);
       }
 
-      if ($test instanceof HookInterface) {
-        // Note: bootHeadless() indirectly resets any hooks, which means that hook_civicrm_config
-        // is unsubscribable. However, after bootHeadless(), we're free to subscribe to hooks again.
-        $this->registerHooks($test);
-      }
-
       if ($test instanceof TransactionalInterface) {
         $this->tx = new \CRM_Core_Transaction(TRUE);
         $this->tx->rollback();
@@ -115,49 +109,11 @@ else {
     }
 
     /**
-     * @param \Civi\Test\HookInterface $test
-     * @return array
-     *   Array(string $hookName => string $methodName)).
-     */
-    protected function findTestHooks(HookInterface $test) {
-      $class = get_class($test);
-      if (!isset($this->cache[$class])) {
-        $funcs = [];
-        foreach (get_class_methods($class) as $func) {
-          if (preg_match('/^hook_/', $func)) {
-            $funcs[substr($func, 5)] = $func;
-          }
-        }
-        $this->cache[$class] = $funcs;
-      }
-      return $this->cache[$class];
-    }
-
-    /**
      * @param \PHPUnit\Framework\Test $test
      * @return bool
      */
     protected function isCiviTest(\PHPUnit\Framework\Test $test) {
       return $test instanceof HookInterface || $test instanceof HeadlessInterface;
-    }
-
-    /**
-     * Find any hook functions in $test and register them.
-     *
-     * @param \Civi\Test\HookInterface $test
-     */
-    protected function registerHooks(HookInterface $test) {
-      if (CIVICRM_UF !== 'UnitTests') {
-        // This is not ideal -- it's just a side-effect of how hooks and E2E tests work.
-        // We can temporarily subscribe to hooks in-process, but for other processes, it gets messy.
-        throw new \RuntimeException('CiviHookTestInterface requires CIVICRM_UF=UnitTests');
-      }
-      \CRM_Utils_Hook::singleton()->reset();
-      /** @var \CRM_Utils_Hook_UnitTests $hooks */
-      $hooks = \CRM_Utils_Hook::singleton();
-      foreach ($this->findTestHooks($test) as $hook => $func) {
-        $hooks->setHook($hook, [$test, $func]);
-      }
     }
 
     /**

--- a/Civi/Test/CiviTestListener.php
+++ b/Civi/Test/CiviTestListener.php
@@ -51,6 +51,7 @@ else {
     public function startTest(\PHPUnit\Framework\Test $test) {
       if ($this->isCiviTest($test)) {
         error_reporting(E_ALL);
+        $GLOBALS['CIVICRM_TEST_CASE'] = $test;
       }
 
       if ($test instanceof HeadlessInterface) {
@@ -82,6 +83,7 @@ else {
       }
       \CRM_Utils_Time::resetTime();
       if ($this->isCiviTest($test)) {
+        unset($GLOBALS['CIVICRM_TEST_CASE']);
         error_reporting(E_ALL & ~E_NOTICE);
         $this->errorScope = NULL;
       }

--- a/Civi/Test/CiviTestListenerPHPUnit7.php
+++ b/Civi/Test/CiviTestListenerPHPUnit7.php
@@ -50,12 +50,6 @@ class CiviTestListenerPHPUnit7 implements \PHPUnit\Framework\TestListener {
       $this->bootHeadless($test);
     }
 
-    if ($test instanceof HookInterface) {
-      // Note: bootHeadless() indirectly resets any hooks, which means that hook_civicrm_config
-      // is unsubscribable. However, after bootHeadless(), we're free to subscribe to hooks again.
-      $this->registerHooks($test);
-    }
-
     if ($test instanceof TransactionalInterface) {
       $this->tx = new \CRM_Core_Transaction(TRUE);
       $this->tx->rollback();
@@ -106,49 +100,11 @@ class CiviTestListenerPHPUnit7 implements \PHPUnit\Framework\TestListener {
   }
 
   /**
-   * @param \Civi\Test\HookInterface $test
-   * @return array
-   *   Array(string $hookName => string $methodName)).
-   */
-  protected function findTestHooks(HookInterface $test) {
-    $class = get_class($test);
-    if (!isset($this->cache[$class])) {
-      $funcs = [];
-      foreach (get_class_methods($class) as $func) {
-        if (preg_match('/^hook_/', $func)) {
-          $funcs[substr($func, 5)] = $func;
-        }
-      }
-      $this->cache[$class] = $funcs;
-    }
-    return $this->cache[$class];
-  }
-
-  /**
    * @param \PHPUnit\Framework\Test $test
    * @return bool
    */
   protected function isCiviTest(\PHPUnit\Framework\Test $test) {
     return $test instanceof HookInterface || $test instanceof HeadlessInterface;
-  }
-
-  /**
-   * Find any hook functions in $test and register them.
-   *
-   * @param \Civi\Test\HookInterface $test
-   */
-  protected function registerHooks(HookInterface $test) {
-    if (CIVICRM_UF !== 'UnitTests') {
-      // This is not ideal -- it's just a side-effect of how hooks and E2E tests work.
-      // We can temporarily subscribe to hooks in-process, but for other processes, it gets messy.
-      throw new \RuntimeException('CiviHookTestInterface requires CIVICRM_UF=UnitTests');
-    }
-    \CRM_Utils_Hook::singleton()->reset();
-    /** @var \CRM_Utils_Hook_UnitTests $hooks */
-    $hooks = \CRM_Utils_Hook::singleton();
-    foreach ($this->findTestHooks($test) as $hook => $func) {
-      $hooks->setHook($hook, [$test, $func]);
-    }
   }
 
   /**

--- a/Civi/Test/CiviTestListenerPHPUnit7.php
+++ b/Civi/Test/CiviTestListenerPHPUnit7.php
@@ -43,6 +43,7 @@ class CiviTestListenerPHPUnit7 implements \PHPUnit\Framework\TestListener {
   public function startTest(\PHPUnit\Framework\Test $test): void {
     if ($this->isCiviTest($test)) {
       error_reporting(E_ALL);
+      $GLOBALS['CIVICRM_TEST_CASE'] = $test;
     }
 
     if ($test instanceof HeadlessInterface) {
@@ -74,6 +75,7 @@ class CiviTestListenerPHPUnit7 implements \PHPUnit\Framework\TestListener {
     }
     \CRM_Utils_Time::resetTime();
     if ($this->isCiviTest($test)) {
+      unset($GLOBALS['CIVICRM_TEST_CASE']);
       error_reporting(E_ALL & ~E_NOTICE);
       $this->errorScope = NULL;
     }

--- a/Civi/Test/HookInterface.php
+++ b/Civi/Test/HookInterface.php
@@ -21,10 +21,10 @@ namespace Civi\Test;
  *
  * ```
  * class MyTest extends \PHPUnit_Framework_TestCase implements \Civi\Test\HookInterface {
- *   public function on_civi_api_authorize(AuthorizeEvent $e) {
+ *   public function on_civi_api_authorize(AuthorizeEvent $e): void {
  *     echo "Running civi.api.authorize\n";
  *   }
- *   public function on_hook_civicrm_post(GenericHookEvent $e) {
+ *   public function on_hook_civicrm_post(GenericHookEvent $e): void {
  *     echo "Running hook_civicrm_post\n";
  *   }
  * }

--- a/Civi/Test/HookInterface.php
+++ b/Civi/Test/HookInterface.php
@@ -17,12 +17,29 @@ namespace Civi\Test;
  * }
  * ```
  *
+ * Similarly, to subscribe using Symfony-style listeners, create function with the 'on_' prefix:
+ *
+ * ```
+ * class MyTest extends \PHPUnit_Framework_TestCase implements \Civi\Test\HookInterface {
+ *   public function on_civi_api_authorize(AuthorizeEvent $e) {
+ *     echo "Running civi.api.authorize\n";
+ *   }
+ *   public function on_hook_civicrm_post(GenericHookEvent $e) {
+ *     echo "Running hook_civicrm_post\n";
+ *   }
+ * }
+ * ```
+ *
  * At time of writing, there are a few limitations in how HookInterface is handled
  * by CiviTestListener:
  *
  *  - The test must execute in-process (aka HeadlessInterface; aka CIVICRM_UF==UnitTests).
  *    End-to-end tests (multi-process tests) are not supported.
  *  - Early bootstrap hooks (e.g. hook_civicrm_config) are not supported.
+ *  - This does not support priorities or registering multiple listeners.
+ *
+ * If you need more advanced registration abilities, consider using `Civi::dispatcher()`
+ * or `EventDispatcherInterface`.
  *
  * @see CiviTestListener
  */

--- a/Civi/Test/Legacy/CiviTestListener.php
+++ b/Civi/Test/Legacy/CiviTestListener.php
@@ -48,11 +48,6 @@ class CiviTestListener extends \PHPUnit_Framework_BaseTestListener {
       $this->bootHeadless($test);
     }
 
-    if ($test instanceof \Civi\Test\HookInterface) {
-      // Note: bootHeadless() indirectly resets any hooks, which means that hook_civicrm_config
-      // is unsubscribable. However, after bootHeadless(), we're free to subscribe to hooks again.
-      $this->registerHooks($test);
-    }
     if ($test instanceof \Civi\Test\TransactionalInterface) {
       $this->tx = new \CRM_Core_Transaction(TRUE);
       $this->tx->rollback();
@@ -104,49 +99,11 @@ class CiviTestListener extends \PHPUnit_Framework_BaseTestListener {
   }
 
   /**
-   * @param \Civi\Test\HookInterface $test
-   * @return array
-   *   Array(string $hookName => string $methodName)).
-   */
-  protected function findTestHooks(\Civi\Test\HookInterface $test) {
-    $class = get_class($test);
-    if (!isset($this->cache[$class])) {
-      $funcs = [];
-      foreach (get_class_methods($class) as $func) {
-        if (preg_match('/^hook_/', $func)) {
-          $funcs[substr($func, 5)] = $func;
-        }
-      }
-      $this->cache[$class] = $funcs;
-    }
-    return $this->cache[$class];
-  }
-
-  /**
    * @param \PHPUnit_Framework_Test $test
    * @return bool
    */
   protected function isCiviTest(\PHPUnit_Framework_Test $test) {
     return $test instanceof \Civi\Test\HookInterface || $test instanceof \Civi\Test\HeadlessInterface;
-  }
-
-  /**
-   * Find any hook functions in $test and register them.
-   *
-   * @param \Civi\Test\HookInterface $test
-   */
-  protected function registerHooks(\Civi\Test\HookInterface $test) {
-    if (CIVICRM_UF !== 'UnitTests') {
-      // This is not ideal -- it's just a side-effect of how hooks and E2E tests work.
-      // We can temporarily subscribe to hooks in-process, but for other processes, it gets messy.
-      throw new \RuntimeException('CiviHookTestInterface requires CIVICRM_UF=UnitTests');
-    }
-    \CRM_Utils_Hook::singleton()->reset();
-    /** @var \CRM_Utils_Hook_UnitTests $hooks */
-    $hooks = \CRM_Utils_Hook::singleton();
-    foreach ($this->findTestHooks($test) as $hook => $func) {
-      $hooks->setHook($hook, [$test, $func]);
-    }
   }
 
   /**

--- a/Civi/Test/Legacy/CiviTestListener.php
+++ b/Civi/Test/Legacy/CiviTestListener.php
@@ -41,6 +41,7 @@ class CiviTestListener extends \PHPUnit_Framework_BaseTestListener {
   public function startTest(\PHPUnit_Framework_Test $test) {
     if ($this->isCiviTest($test)) {
       error_reporting(E_ALL);
+      $GLOBALS['CIVICRM_TEST_CASE'] = $test;
     }
 
     if ($test instanceof \Civi\Test\HeadlessInterface) {
@@ -71,6 +72,7 @@ class CiviTestListener extends \PHPUnit_Framework_BaseTestListener {
     }
     \CRM_Utils_Time::resetTime();
     if ($this->isCiviTest($test)) {
+      unset($GLOBALS['CIVICRM_TEST_CASE']);
       error_reporting(E_ALL & ~E_NOTICE);
       $this->errorScope = NULL;
     }

--- a/tests/phpunit/Civi/Test/ExampleHookTest.php
+++ b/tests/phpunit/Civi/Test/ExampleHookTest.php
@@ -4,7 +4,16 @@ namespace Civi\Test;
 use Civi\Angular\Page\Main;
 
 /**
- * This is an example of a barebones test which uses a hook (based on CiviTestListener).
+ * This is an example of a barebones test which implements `HookInterface`. Methods are automatically scanned to
+ * find event-listeners based on a naming convention:
+ *
+ * - `function hook_*($arg1, &$arg2, ...)`: Bind to eponymous hook. Receive a list of ordered parameters.
+ * - 'function on_*($event)`: Bind to eponymous Symfony event. Receive an event object.
+ *
+ * The underlying mechanism behind this is:
+ *
+ * - When booting headless Civi, `CRM_Utils_System_UnitTests::initialize()` looks up the active test object.
+ * - It uses `EventScanner` to check the interfaces & methods for any listeners.
  *
  * @group headless
  */
@@ -14,6 +23,8 @@ class ExampleHookTest extends \PHPUnit\Framework\TestCase implements HeadlessInt
    * @var \CRM_Contact_DAO_Contact
    */
   protected $contact;
+
+  protected $tracker;
 
   public function setUpHeadless() {
     return \Civi\Test::headless()->apply();
@@ -25,6 +36,7 @@ class ExampleHookTest extends \PHPUnit\Framework\TestCase implements HeadlessInt
     ]);
     $session = \CRM_Core_Session::singleton();
     $session->set('userID', $this->contact->id);
+    $this->tracker = ['civi.api.resolve' => [], 'civi.api.prepare' => []];
   }
 
   protected function tearDown(): void {
@@ -32,10 +44,39 @@ class ExampleHookTest extends \PHPUnit\Framework\TestCase implements HeadlessInt
   }
 
   /**
+   * Listen to hook_civicrm_alterContent in traditional hook format.
+   *
    * @see \CRM_Utils_Hook::alterContent
    */
   public function hook_civicrm_alterContent(&$content, $context, $tplName, &$object) {
-    $content .= "zzzyyyxxx";
+    $content .= ' ' . __FUNCTION__;
+  }
+
+  /**
+   * Listen to hook_civicrm_alterContent in Symfony event format.
+   *
+   * @see \CRM_Utils_Hook::alterContent
+   */
+  public function on_hook_civicrm_alterContent(\Civi\Core\Event\GenericHookEvent $event) {
+    $event->content .= ' ' . __FUNCTION__;
+  }
+
+  /**
+   * Listen to `civi.api.resolve` in Symfony event format.
+   *
+   * @see \Civi\API\Event\ResolveEvent
+   */
+  public function on_civi_api_resolve(\Civi\API\Event\ResolveEvent $event) {
+    $this->tracker['civi.api.resolve'][__FUNCTION__] = TRUE;
+  }
+
+  /**
+   * Listen to `civi.api.resolve` in Symfony event format.
+   *
+   * @see \Civi\API\Event\PrepareEvent
+   */
+  public function on_civi_api_prepare(\Civi\API\Event\PrepareEvent $event) {
+    $this->tracker['civi.api.prepare'][__FUNCTION__] = TRUE;
   }
 
   public function testPageOutput() {
@@ -44,7 +85,15 @@ class ExampleHookTest extends \PHPUnit\Framework\TestCase implements HeadlessInt
     $p->run();
     $content = ob_get_contents();
     ob_end_clean();
-    $this->assertRegExp(';zzzyyyxxx;', $content);
+    $this->assertRegExp('; hook_civicrm_alterContent on_hook_civicrm_alterContent;', $content);
+  }
+
+  public function testGetFields() {
+    $this->assertEquals([], $this->tracker['civi.api.resolve']);
+    $this->assertEquals([], $this->tracker['civi.api.prepare']);
+    \civicrm_api3('Contact', 'getfields', []);
+    $this->assertEquals(['on_civi_api_resolve' => TRUE], $this->tracker['civi.api.resolve']);
+    $this->assertEquals(['on_civi_api_prepare' => TRUE], $this->tracker['civi.api.prepare']);
   }
 
 }

--- a/tests/phpunit/Civi/Test/ExampleHookTest.php
+++ b/tests/phpunit/Civi/Test/ExampleHookTest.php
@@ -57,7 +57,7 @@ class ExampleHookTest extends \PHPUnit\Framework\TestCase implements HeadlessInt
    *
    * @see \CRM_Utils_Hook::alterContent
    */
-  public function on_hook_civicrm_alterContent(\Civi\Core\Event\GenericHookEvent $event) {
+  public function on_hook_civicrm_alterContent(\Civi\Core\Event\GenericHookEvent $event): void {
     $event->content .= ' ' . __FUNCTION__;
   }
 
@@ -66,7 +66,7 @@ class ExampleHookTest extends \PHPUnit\Framework\TestCase implements HeadlessInt
    *
    * @see \Civi\API\Event\ResolveEvent
    */
-  public function on_civi_api_resolve(\Civi\API\Event\ResolveEvent $event) {
+  public function on_civi_api_resolve(\Civi\API\Event\ResolveEvent $event): void {
     $this->tracker['civi.api.resolve'][__FUNCTION__] = TRUE;
   }
 
@@ -75,7 +75,7 @@ class ExampleHookTest extends \PHPUnit\Framework\TestCase implements HeadlessInt
    *
    * @see \Civi\API\Event\PrepareEvent
    */
-  public function on_civi_api_prepare(\Civi\API\Event\PrepareEvent $event) {
+  public function on_civi_api_prepare(\Civi\API\Event\PrepareEvent $event): void {
     $this->tracker['civi.api.prepare'][__FUNCTION__] = TRUE;
   }
 

--- a/tests/phpunit/Civi/Test/ExampleSubscriberTest.php
+++ b/tests/phpunit/Civi/Test/ExampleSubscriberTest.php
@@ -51,15 +51,15 @@ class ExampleSubscriberTest extends \PHPUnit\Framework\TestCase implements Headl
     ];
   }
 
-  public function myCiviApiResolve(\Civi\API\Event\ResolveEvent $event) {
+  public function myCiviApiResolve(\Civi\API\Event\ResolveEvent $event): void {
     $this->tracker['civi.api.resolve'][__FUNCTION__] = TRUE;
   }
 
-  public function myCiviApiPrepare(\Civi\API\Event\PrepareEvent $event) {
+  public function myCiviApiPrepare(\Civi\API\Event\PrepareEvent $event): void {
     $this->tracker['civi.api.prepare'][__FUNCTION__] = TRUE;
   }
 
-  public function myAlterContentObject(GenericHookEvent $event) {
+  public function myAlterContentObject(GenericHookEvent $event): void {
     $event->content .= ' ' . __FUNCTION__;
   }
 

--- a/tests/phpunit/Civi/Test/ExampleSubscriberTest.php
+++ b/tests/phpunit/Civi/Test/ExampleSubscriberTest.php
@@ -1,0 +1,87 @@
+<?php
+namespace Civi\Test;
+
+use Civi\Angular\Page\Main;
+use Civi\Core\Event\GenericHookEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * This is an example of a barebones test which implements `EventSubscriberInterface`. The method `getSubscribedEvents()` is
+ * used to get a list of listeners.
+ *
+ * The underlying mechanism behind this is:
+ *
+ * - When booting headless Civi, `CRM_Utils_System_UnitTests::initialize()` looks up the active test object.
+ * - It uses `EventScanner` to check the interfaces & methods for any listeners.
+ *
+ * @group headless
+ */
+class ExampleSubscriberTest extends \PHPUnit\Framework\TestCase implements HeadlessInterface, EventSubscriberInterface {
+
+  /**
+   * @var \CRM_Contact_DAO_Contact
+   */
+  protected $contact;
+
+  protected $tracker;
+
+  public function setUpHeadless() {
+    return \Civi\Test::headless()->apply();
+  }
+
+  protected function setUp(): void {
+    $this->contact = \CRM_Core_DAO::createTestObject('CRM_Contact_DAO_Contact', [
+      'contact_type' => 'Individual',
+    ]);
+    $session = \CRM_Core_Session::singleton();
+    $session->set('userID', $this->contact->id);
+    $this->tracker = ['civi.api.resolve' => [], 'civi.api.prepare' => []];
+  }
+
+  protected function tearDown(): void {
+    $this->contact->delete();
+  }
+
+  public static function getSubscribedEvents() {
+    return [
+      'civi.api.resolve' => 'myCiviApiResolve',
+      'civi.api.prepare' => ['myCiviApiPrepare', 1234],
+      'hook_civicrm_alterContent' => ['myAlterContentObject', -7000],
+      '&hook_civicrm_alterContent' => ['myAlterContentParams', -8000],
+    ];
+  }
+
+  public function myCiviApiResolve(\Civi\API\Event\ResolveEvent $event) {
+    $this->tracker['civi.api.resolve'][__FUNCTION__] = TRUE;
+  }
+
+  public function myCiviApiPrepare(\Civi\API\Event\PrepareEvent $event) {
+    $this->tracker['civi.api.prepare'][__FUNCTION__] = TRUE;
+  }
+
+  public function myAlterContentObject(GenericHookEvent $event) {
+    $event->content .= ' ' . __FUNCTION__;
+  }
+
+  public function myAlterContentParams(&$content, $context, $tplName, &$object) {
+    $content .= ' ' . __FUNCTION__;
+  }
+
+  public function testPageOutput() {
+    ob_start();
+    $p = new Main();
+    $p->run();
+    $content = ob_get_contents();
+    ob_end_clean();
+    $this->assertRegExp(';myAlterContentObject myAlterContentParams;', $content);
+  }
+
+  public function testGetFields() {
+    $this->assertEquals([], $this->tracker['civi.api.resolve']);
+    $this->assertEquals([], $this->tracker['civi.api.prepare']);
+    \civicrm_api3('Contact', 'getfields', []);
+    $this->assertEquals(['myCiviApiResolve' => TRUE], $this->tracker['civi.api.resolve']);
+    $this->assertEquals(['myCiviApiPrepare' => TRUE], $this->tracker['civi.api.prepare']);
+  }
+
+}


### PR DESCRIPTION
Overview
--------

This expands the functionality for declaring event-listeners in different classes, making it easier to participate in Symfony events. This expansion applies in two dimensions:

* Allow subscribing in more contexts (unit-tests, APIv4 subscribers, and BAOs)
* Allow subscribing to more types of events (`hook_civicrm_*` and `civi.*`)

The general approach is based on *interface tagging* -- in a supported context (e.g unit-test or BAO), you may mix-in `HookInterface` and/or `EventSubscriberInterface` and then declare your listeners.

Before
------

A headless test may implement `HookInterface` and then define methods with the `hook_` prefix. It will be scanned for methods in the style of:

```php
class ... extends ... implements HookInterface {
  public function hook_civicrm_alterContent(&$content, $context, $tplName, &$object) {}
}
```

However, this only works with traditional hooks. It does not work with Symfony-style events. Additionally, it only works with headless unit-tests -- there is no way to adapt it to other classes.

Separately, if an APIv4 subscriber (`Civi\Api4\Event\Subscriber\*`) implements `EventSubscriberInerface`, it will be scanned for listeners by calling `getSubscribedEvents()`:

```php
class ... extends ... implements EventSubscriberInterface {
  public static function getSubscribedEvents() {
    return ['civi.api.prepare' => 'myCiviApiPrepare'];
  }

  public function myCiviApiPrepare(\Civi\API\Event\PrepareEvent $event) {}
```

After
-----

Declarative registration has been expanded in multiple ways.

(1) Declarative registration can be used on headless unit-tests (as before), APIv4 services (as before), and also on BAOs. All three types of classes support similar declarations (either `HookInterface` or `EventSubscriberInterface`).

(2) If a supported class implements the `HookInterface`, then it may use a  naming-convention to declare listeners. The naming convention now works with all event-types.

```php
class ... extends ... implements HookInterface {
  // Declare hook-style listeners using the `hook_` prefix.
  // This matches existing style.
  public function hook_civicrm_foobar($arg1, &$arg2, ...) {}

  // Declare Symfony-style listeners using the `on_` prefix.
  // This notation works with all events - not just hooks.
  public function on_civi_api_resolve(\Civi\API\Event\ResolveEvent $event) {}

  // Declare Symfony-styles listeners using the `self_` prefix.
  // This implies that we only care about events that target this specific entity.
  public function self_civi_api4_validate(ValidateEvent $event) {}
}
```

(3) If a supported class implements the `EventSubscriberInterface`, then it may use `getSubscribedEvents()` to declare a list of listeners. 

```php
class ... extends ... implements EventSubscriberInterface {
  public static function getSubscribedEvents() {
    return [
      'civi.api.prepare' => ['myCiviApiPrepare', 1234],
      'hook_civicrm_foo' => 'myFoo',
      'hook_civicrm_pre::MyEntity' => 'preMyEntity',
      '&hook_civicrm_alterBar' => 'myAlterBar',
    ];
  }

  public function myCiviApiPrepare(\Civi\API\Event\PrepareEvent $event) {}

  public function myFoo(GenericHookEvent $e) {}

  public function preMyEntity(GenericHookEvent $e) {}

  public function myAlterBar(&$barObject, $barMode, $barShape) {}
}
```

Technical Details
----------------------

This exposes a couple new internal APIs for wiring-up listeners. Given an object or class, you may wire it up with:

```php
// Hook-up listeners based on `static` class-methods
$map = EventScanner::findListeners('\Some\Class\Name');
$dispatcher->addListenerMap('\Some\Class\Name', $map);

// Hook-up listeners based on standard object-methods with a plain-old PHP object
$map = EventScanner::findListeners($someObject);
$dispatcher->addListenerMap($someObject, $map);

// Hook-up listeners based on standard object-methods with a service-object
$map = EventScanner::findListeners('\Some\Class\Name');
$dispatcher->addSubscriberServiceMap('some.service.id', $map);
```

The ideal arrangement is to split those two steps -- run the scan infrequently, store the results in a cache, and use the cache at runtime. For example, this uses the `Container` cache and defers `addListenerMap()` until runtime:

```php
$map = EventScanner::findListeners($target);
$container->getDefinition('dispatcher')->addMethodCall('addListenerMap', [$target, $map]);
```

Other comments
-----------------------

The declarative style of registration has some advantages:

* Declarations can be cached. If you have a broad/sparse event list (e.g. many events, many listeners, but if only a few are ever needed in a typical page-load), then it's more efficient to get the cached listeners (`require_once 'CachedCiviContainer.XXX.php'`) than to imperatively poll each potential listener speculatively (`foreach ($baos as $bao) { require_once '$bao.php'; $bao::initialize(); }`).
* Declarative style is more forgiving about lifecycle-issues. For example,  headless unit-tests may reboot the container multiple times (e.g. during `setUp()`, e.g. when activating an extension temporarily) -- declarative style requires a little less care/knowledge to get the registrations working correctly.
