### PR TITLE
[REF] Upgrade CKEditor to be 4.16.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -170,7 +170,7 @@
         "ignore": [".*", "node_modules", "docs", "Gruntfile.js", "index.html", "package.json", "test"]
       },
       "ckeditor": {
-        "url": "https://github.com/ckeditor/ckeditor-releases/archive/4.14.0.zip"
+        "url": "https://github.com/ckeditor/ckeditor-releases/archive/4.16.1.zip"
       },
       "crossfilter-1.3.x": {
         "url": "https://github.com/crossfilter/crossfilter/archive/1.3.14.zip",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0e39d59009c3d153d1aaa107a411f319",
+    "content-hash": "439af216e22a835897b747b0773da717",
     "packages": [
         {
             "name": "adrienrn/php-mimetyper",


### PR DESCRIPTION
Overview
----------------------------------------
This upgrades CKEditor to 4.16.1

Before
----------------------------------------
CKEditor version 4.14.0 used

After
----------------------------------------
CKEditor version 4.16.1 used

Change log is here https://github.com/ckeditor/ckeditor4/blob/major/CHANGES.md

ping @eileenmcnaughton @colemanw 