### PR TITLE
AfformGui - Fix tabs when cms theme adds extra margin

### DIFF
--- a/ext/afform/admin/ang/afGuiEditor.css
+++ b/ext/afform/admin/ang/afGuiEditor.css
@@ -48,6 +48,7 @@
 }
 #afGuiEditor .panel-heading ul.nav-tabs li {
   top: 6px;
+  margin: 0;
 }
 #afGuiEditor .panel-heading ul.nav-tabs li.fluid-width-tab {
   white-space: nowrap;


### PR DESCRIPTION
Overview
----------------------------------------
Fixes the Afform Gui tabs on certain themes.

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/2874912/119823461-db78ec00-bec2-11eb-8194-f0b0c17de913.png)


After
----------------------------------------
![image](https://user-images.githubusercontent.com/2874912/119823384-bf754a80-bec2-11eb-9de6-2ea27389a3ff.png)


Technical Details
----------------------------------------
Themes like Drupal's 'Garland' add extra margin to `li` elements which interferes with the tab spacing in the Afform GUI.