### PR TITLE
(dev/core#365) Scheduled Reminders - Add effective start and end date to admin UI

### DIFF
--- a/CRM/Admin/Form/ScheduleReminders.php
+++ b/CRM/Admin/Form/ScheduleReminders.php
@@ -216,6 +216,9 @@ class CRM_Admin_Form_ScheduleReminders extends CRM_Admin_Form {
     $this->add('text', 'from_name', ts('From Name'));
     $this->add('text', 'from_email', ts('From Email'));
 
+    $this->add('datepicker', 'effective_start_date', ts('Effective start date'), [], FALSE);
+    $this->add('datepicker', 'effective_end_date', ts('Effective end date'), [], FALSE);
+
     $recipientListingOptions = [];
 
     if ($mappingID) {

--- a/templates/CRM/Admin/Form/ScheduleReminders.tpl
+++ b/templates/CRM/Admin/Form/ScheduleReminders.tpl
@@ -56,11 +56,11 @@
     </tr>
     <tr class="crm-scheduleReminder-effective_start_date">
       <td class="right">{$form.effective_start_date.label}</td>
-      <td colspan="3">{$form.effective_start_date.html} <div class="description">{ts}Earliest date to consider start events from.{/ts}</div></td>
+      <td colspan="3">{$form.effective_start_date.html} <div class="description"></div></td>
     </tr>
     <tr class="crm-scheduleReminder-effective_end_date">
       <td class="right">{$form.effective_end_date.label}</td>
-      <td colspan="3">{$form.effective_end_date.html} <div class="description">{ts}Latest date to consider end events from.{/ts}</div></td>
+      <td colspan="3">{$form.effective_end_date.html} <div class="description"></div></td>
     </tr>
     <tr>
       <td class="label" width="20%">{$form.from_name.label}</td>
@@ -174,22 +174,17 @@
     CRM.$(function($) {
       var $form = $('form.{/literal}{$form.formClass}{literal}'),
         recipientMapping = eval({/literal}{$recipientMapping}{literal});
-  
+
+      updatedEffectiveDateDescription($('#entity_0 option:selected').text(), $('#start_action_date option:selected').text());
+      $('#entity_0, #start_action_date', $form).change(function() {
+       updatedEffectiveDateDescription($('#entity_0 option:selected').text(), $('#start_action_date option:selected').text());
+      });
+
       $('#absolute_date', $form).change(function() {
-        if ($(this).val()) {
-          $('.crm-scheduleReminder-effective_start_date, .crm-scheduleReminder-effective_end_date').hide();
-        }
-        else {
-          $('.crm-scheduleReminder-effective_start_date, .crm-scheduleReminder-effective_end_date').show();
-        }
+        $('.crm-scheduleReminder-effective_start_date, .crm-scheduleReminder-effective_end_date').toggle(($(this).val() === null));
       });
       $('#start_action_offset', $form).change(function() {
-        if ($(this).val()) {
-          $('.crm-scheduleReminder-effective_start_date, .crm-scheduleReminder-effective_end_date').show();
-        }
-        else {
-          $('.crm-scheduleReminder-effective_start_date, .crm-scheduleReminder-effective_end_date').hide();
-        }
+        $('.crm-scheduleReminder-effective_start_date, .crm-scheduleReminder-effective_end_date').toggle(($(this).val() !== null));
       });
 
       $('#absolute_date_display', $form).change(function() {
@@ -205,6 +200,11 @@
 
       loadMsgBox();
       $('#mode', $form).change(loadMsgBox);
+
+      function updatedEffectiveDateDescription(entityText, startActionDateText) {
+        $('.crm-scheduleReminder-effective_start_date .description').text(ts('Earliest %1 %2 to include.', {1: entityText, 2: startActionDateText}));
+        $('.crm-scheduleReminder-effective_end_date .description').text(ts('Earliest %1 %2 to exclude.', {1: entityText, 2: startActionDateText}));
+      }
 
       function populateRecipient() {
         var mappingID = $('#entity_0', $form).val() || $('[name^=mappingID]', $form).val();

--- a/templates/CRM/Admin/Form/ScheduleReminders.tpl
+++ b/templates/CRM/Admin/Form/ScheduleReminders.tpl
@@ -54,6 +54,14 @@
         </table>
      </td>
     </tr>
+    <tr class="crm-scheduleReminder-effective_start_date">
+      <td class="right">{$form.effective_start_date.label}</td>
+      <td colspan="3">{$form.effective_start_date.html} <div class="description">{ts}Earliest date to consider start events from.{/ts}</div></td>
+    </tr>
+    <tr class="crm-scheduleReminder-effective_end_date">
+      <td class="right">{$form.effective_end_date.label}</td>
+      <td colspan="3">{$form.effective_end_date.html} <div class="description">{ts}Latest date to consider end events from.{/ts}</div></td>
+    </tr>
     <tr>
       <td class="label" width="20%">{$form.from_name.label}</td>
       <td>{$form.from_name.html}&nbsp;&nbsp;{help id="id-from_name_email"}</td>
@@ -166,6 +174,23 @@
     CRM.$(function($) {
       var $form = $('form.{/literal}{$form.formClass}{literal}'),
         recipientMapping = eval({/literal}{$recipientMapping}{literal});
+  
+      $('#absolute_date', $form).change(function() {
+        if ($(this).val()) {
+          $('.crm-scheduleReminder-effective_start_date, .crm-scheduleReminder-effective_end_date').hide();
+        }
+        else {
+          $('.crm-scheduleReminder-effective_start_date, .crm-scheduleReminder-effective_end_date').show();
+        }
+      });
+      $('#start_action_offset', $form).change(function() {
+        if ($(this).val()) {
+          $('.crm-scheduleReminder-effective_start_date, .crm-scheduleReminder-effective_end_date').show();
+        }
+        else {
+          $('.crm-scheduleReminder-effective_start_date, .crm-scheduleReminder-effective_end_date').hide();
+        }
+      });
 
       $('#absolute_date_display', $form).change(function() {
         if($(this).val()) {


### PR DESCRIPTION
Overview
----------------------------------------
Added Effective start and end date in Schedule Reminder UI

Before
----------------------------------------
<img width="914" alt="Screenshot 2021-05-27 at 5 51 47 PM" src="https://user-images.githubusercontent.com/3735621/119825182-50284680-bf14-11eb-9f44-ef63eb3a6296.png">

After
----------------------------------------
<img width="896" alt="Screenshot 2021-05-27 at 5 49 23 PM" src="https://user-images.githubusercontent.com/3735621/119825146-49013880-bf14-11eb-888d-1a65050e3bea.png">


Technical Details
----------------------------------------
PR is dependent on https://github.com/civicrm/civicrm-core/pull/19973

Comments
----------------------------------------
ping @eileenmcnaughton 