### PR TITLE
SearchKit - Add static groups and organize main entity selector

### DIFF
--- a/Civi/Api4/ACL.php
+++ b/Civi/Api4/ACL.php
@@ -30,7 +30,7 @@ namespace Civi\Api4;
  *
  * Creating a new ACL requires at minimum an entity table, entity ID and object_table.
  *
- * @searchable false
+ * @searchable none
  * @see https://docs.civicrm.org/user/en/latest/initial-set-up/permissions-and-access-control
  * @package Civi\Api4
  */

--- a/Civi/Api4/ActionSchedule.php
+++ b/Civi/Api4/ActionSchedule.php
@@ -28,7 +28,7 @@ namespace Civi\Api4;
  *
  * Creating a new ActionSchedule requires at minimum a title, mapping_id and entity_value.
  *
- * @searchable false
+ * @searchable none
  * @see https://docs.civicrm.org/user/en/latest/email/scheduled-reminders/
  * @package Civi\Api4
  */

--- a/Civi/Api4/Activity.php
+++ b/Civi/Api4/Activity.php
@@ -30,6 +30,7 @@ namespace Civi\Api4;
  * An activity is a record of some type of interaction with one or more contacts.
  *
  * @see https://docs.civicrm.org/user/en/latest/organising-your-data/activities/
+ * @searchable primary
  * @package Civi\Api4
  */
 class Activity extends Generic\DAOEntity {

--- a/Civi/Api4/Address.php
+++ b/Civi/Api4/Address.php
@@ -30,6 +30,7 @@ namespace Civi\Api4;
  *
  * @ui_join_filters location_type_id
  *
+ * @searchable secondary
  * @package Civi\Api4
  */
 class Address extends Generic\DAOEntity {

--- a/Civi/Api4/Address.php
+++ b/Civi/Api4/Address.php
@@ -22,11 +22,11 @@ namespace Civi\Api4;
 /**
  * Address Entity.
  *
- * This entity holds the address informatiom of a contact. Each contact may hold
+ * This entity holds the address information of a contact. Each contact may hold
  * one or more addresses but must have different location types respectively.
  *
  * Creating a new address requires at minimum a contact's ID and location type ID
- *  and other attributes (although optional) like street address, city, country etc.
+ * and other attributes (although optional) like street address, city, country etc.
  *
  * @ui_join_filters location_type_id
  *

--- a/Civi/Api4/Batch.php
+++ b/Civi/Api4/Batch.php
@@ -22,6 +22,7 @@ namespace Civi\Api4;
 /**
  * Batch entity.
  *
+ * @searchable secondary
  * @see https://docs.civicrm.org/user/en/latest/pledges/everyday-tasks/#batch-entry-of-pledges
  * @package Civi\Api4
  */

--- a/Civi/Api4/Campaign.php
+++ b/Civi/Api4/Campaign.php
@@ -23,6 +23,7 @@ namespace Civi\Api4;
  * Campaign entity.
  *
  * @see https://docs.civicrm.org/user/en/latest/campaign/what-is-civicampaign/
+ * @searchable secondary
  * @package Civi\Api4
  */
 class Campaign extends Generic\DAOEntity {

--- a/Civi/Api4/CiviCase.php
+++ b/Civi/Api4/CiviCase.php
@@ -25,6 +25,7 @@ namespace Civi\Api4;
  * Note that the class for this entity is named "CiviCase" because "Case" is a keyword reserved by php.
  *
  * @see https://docs.civicrm.org/user/en/latest/case-management/what-is-civicase/
+ * @searchable primary
  * @package Civi\Api4
  */
 class CiviCase extends Generic\DAOEntity {

--- a/Civi/Api4/Contact.php
+++ b/Civi/Api4/Contact.php
@@ -28,6 +28,7 @@ namespace Civi\Api4;
  * Creating a new contact requires at minimum a name or email address.
  *
  * @see https://docs.civicrm.org/user/en/latest/organising-your-data/contacts/
+ * @searchable primary
  * @package Civi\Api4
  */
 class Contact extends Generic\DAOEntity {

--- a/Civi/Api4/Contribution.php
+++ b/Civi/Api4/Contribution.php
@@ -15,6 +15,7 @@ namespace Civi\Api4;
 /**
  * Contribution entity.
  *
+ * @searchable primary
  * @package Civi\Api4
  */
 class Contribution extends Generic\DAOEntity {

--- a/Civi/Api4/ContributionPage.php
+++ b/Civi/Api4/ContributionPage.php
@@ -15,6 +15,7 @@ namespace Civi\Api4;
 /**
  * ContributionPage entity.
  *
+ * @searchable secondary
  * @package Civi\Api4
  */
 class ContributionPage extends Generic\DAOEntity {

--- a/Civi/Api4/ContributionRecur.php
+++ b/Civi/Api4/ContributionRecur.php
@@ -15,6 +15,7 @@ namespace Civi\Api4;
 /**
  * ContributionRecur entity.
  *
+ * @searchable secondary
  * @package Civi\Api4
  */
 class ContributionRecur extends Generic\DAOEntity {

--- a/Civi/Api4/ContributionSoft.php
+++ b/Civi/Api4/ContributionSoft.php
@@ -15,6 +15,7 @@ namespace Civi\Api4;
 /**
  * ContributionSoft entity.
  *
+ * @searchable secondary
  * @package Civi\Api4
  */
 class ContributionSoft extends Generic\DAOEntity {

--- a/Civi/Api4/CustomField.php
+++ b/Civi/Api4/CustomField.php
@@ -23,7 +23,7 @@ namespace Civi\Api4;
  * CustomField entity.
  *
  * @see https://docs.civicrm.org/user/en/latest/organising-your-data/creating-custom-fields/
- * @searchable false
+ * @searchable none
  * @package Civi\Api4
  */
 class CustomField extends Generic\DAOEntity {

--- a/Civi/Api4/CustomGroup.php
+++ b/Civi/Api4/CustomGroup.php
@@ -23,7 +23,7 @@ namespace Civi\Api4;
  * CustomGroup entity.
  *
  * @see https://docs.civicrm.org/user/en/latest/organising-your-data/creating-custom-fields/
- * @searchable false
+ * @searchable none
  * @package Civi\Api4
  */
 class CustomGroup extends Generic\DAOEntity {

--- a/Civi/Api4/CustomValue.php
+++ b/Civi/Api4/CustomValue.php
@@ -142,7 +142,7 @@ class CustomValue {
     return [
       'class' => __CLASS__,
       'type' => ['CustomValue'],
-      'searchable' => TRUE,
+      'searchable' => 'secondary',
       'see' => [
         'https://docs.civicrm.org/user/en/latest/organising-your-data/creating-custom-fields/#multiple-record-fieldsets',
         '\Civi\Api4\CustomGroup',

--- a/Civi/Api4/Dashboard.php
+++ b/Civi/Api4/Dashboard.php
@@ -28,7 +28,7 @@ namespace Civi\Api4;
  * Displaying an item to a user is done with the `DashboardContact` entity.
  *
  * @see \Civi\Api4\DashboardContact
- * @searchable false
+ * @searchable none
  * @package Civi\Api4
  */
 class Dashboard extends Generic\DAOEntity {

--- a/Civi/Api4/DashboardContact.php
+++ b/Civi/Api4/DashboardContact.php
@@ -24,7 +24,7 @@ namespace Civi\Api4;
  * This places a dashboard item on a user's home screen.
  *
  * @see \Civi\Api4\Dashboard
- * @searchable false
+ * @searchable none
  * @package Civi\Api4
  */
 class DashboardContact extends Generic\DAOEntity {

--- a/Civi/Api4/Domain.php
+++ b/Civi/Api4/Domain.php
@@ -23,7 +23,7 @@ namespace Civi\Api4;
  * Domains - multisite instances of CiviCRM.
  *
  * @see https://docs.civicrm.org/sysadmin/en/latest/setup/multisite/
- * @searchable false
+ * @searchable none
  * @package Civi\Api4
  */
 class Domain extends Generic\DAOEntity {

--- a/Civi/Api4/Email.php
+++ b/Civi/Api4/Email.php
@@ -26,6 +26,7 @@ namespace Civi\Api4;
  *
  * Creating a new email address requires at minimum a contact's ID and email
  *
+ * @searchable secondary
  * @package Civi\Api4
  */
 class Email extends Generic\DAOEntity {

--- a/Civi/Api4/Entity.php
+++ b/Civi/Api4/Entity.php
@@ -24,6 +24,7 @@ namespace Civi\Api4;
  *
  * @see \Civi\Api4\Generic\AbstractEntity
  *
+ * @searchable none
  * @package Civi\Api4
  */
 class Entity extends Generic\AbstractEntity {
@@ -90,7 +91,12 @@ class Entity extends Generic\AbstractEntity {
         ],
         [
           'name' => 'searchable',
-          'description' => 'Should this entity be selectable in search kit UI',
+          'description' => 'How should this entity be presented in search UIs',
+          'options' => [
+            'primary' => ts('Primary'),
+            'secondary' => ts('Secondary'),
+            'none' => ts('None'),
+          ],
         ],
         [
           'name' => 'paths',

--- a/Civi/Api4/EntityFinancialAccount.php
+++ b/Civi/Api4/EntityFinancialAccount.php
@@ -23,12 +23,23 @@ namespace Civi\Api4;
  *
  * @see https://docs.civicrm.org/dev/en/latest/financial/financialentities/#financial-accounts
  *
- * @bridge entity_id financial_account_id
  * @ui_join_filters account_relationship
  *
  * @package Civi\Api4
  */
 class EntityFinancialAccount extends Generic\DAOEntity {
   use Generic\Traits\EntityBridge;
+
+  /**
+   * @return array
+   */
+  public static function getInfo() {
+    $info = parent::getInfo();
+    $info['bridge'] = [
+      'entity_id' => [],
+      'financial_account_id' => [],
+    ];
+    return $info;
+  }
 
 }

--- a/Civi/Api4/EntityFinancialTrxn.php
+++ b/Civi/Api4/EntityFinancialTrxn.php
@@ -24,11 +24,21 @@ namespace Civi\Api4;
  *
  * @see https://docs.civicrm.org/dev/en/latest/financial/financialentities/
  *
- * @bridge entity_id financial_trxn_id
- *
  * @package Civi\Api4
  */
 class EntityFinancialTrxn extends Generic\DAOEntity {
   use Generic\Traits\EntityBridge;
+
+  /**
+   * @return array
+   */
+  public static function getInfo() {
+    $info = parent::getInfo();
+    $info['bridge'] = [
+      'entity_id' => [],
+      'financial_trxn_id' => [],
+    ];
+    return $info;
+  }
 
 }

--- a/Civi/Api4/Event.php
+++ b/Civi/Api4/Event.php
@@ -24,6 +24,7 @@ namespace Civi\Api4;
  *
  * @see https://docs.civicrm.org/user/en/latest/events/what-is-civievent/
  *
+ * @searchable primary
  * @package Civi\Api4
  */
 class Event extends Generic\DAOEntity {

--- a/Civi/Api4/FinancialAccount.php
+++ b/Civi/Api4/FinancialAccount.php
@@ -25,6 +25,7 @@ namespace Civi\Api4;
  *
  * @see https://docs.civicrm.org/user/en/latest/contributions/key-concepts-and-configurations/#financial-types-financial-accounts-and-accounting-codes
  *
+ * @searchable secondary
  * @package Civi\Api4
  */
 class FinancialAccount extends Generic\DAOEntity {

--- a/Civi/Api4/FinancialTrxn.php
+++ b/Civi/Api4/FinancialTrxn.php
@@ -28,6 +28,7 @@ namespace Civi\Api4;
  *
  * @see https://docs.civicrm.org/dev/en/latest/financial/financialentities/#financial-transactions
  *
+ * @searchable secondary
  * @package Civi\Api4
  */
 class FinancialTrxn extends Generic\DAOEntity {

--- a/Civi/Api4/FinancialType.php
+++ b/Civi/Api4/FinancialType.php
@@ -28,5 +28,6 @@ namespace Civi\Api4;
  * @package Civi\Api4
  */
 class FinancialType extends Generic\DAOEntity {
+  use Generic\Traits\OptionList;
 
 }

--- a/Civi/Api4/Generic/AbstractEntity.php
+++ b/Civi/Api4/Generic/AbstractEntity.php
@@ -151,7 +151,7 @@ abstract class AbstractEntity {
     foreach (ReflectionUtils::getTraits(static::class) as $trait) {
       $info['type'][] = self::stripNamespace($trait);
     }
-    $info['searchable'] = !in_array('OptionList', $info['type']);
+    $info['searchable'] = in_array('OptionList', $info['type'], TRUE) ? 'none' : 'secondary';
     $reflection = new \ReflectionClass(static::class);
     $info = array_merge($info, ReflectionUtils::getCodeDocs($reflection, NULL, ['entity' => $info['name']]));
     unset($info['package'], $info['method']);

--- a/Civi/Api4/Generic/Traits/EntityBridge.php
+++ b/Civi/Api4/Generic/Traits/EntityBridge.php
@@ -23,17 +23,16 @@ trait EntityBridge {
   /**
    * Adds "bridge" info, which should specify an array of two field names from this entity
    *
-   * This automatic function can be overridden by annotating the APIv4 entity like
-   * `@bridge contact_id group_id`
+   * This automatic function can be overridden by adding a getInfo function to the api entity class.
    *
    * @return array
    */
   public static function getInfo() {
     $info = parent::getInfo();
-    if (!empty($info['dao']) && empty($info['bridge'])) {
+    if (!empty($info['dao'])) {
       foreach (($info['dao'])::fields() as $field) {
         if (!empty($field['FKClassName']) || $field['name'] === 'entity_id') {
-          $info['bridge'][] = $field['name'];
+          $info['bridge'][$field['name']] = [];
         }
       }
     }

--- a/Civi/Api4/Generic/Traits/OptionList.php
+++ b/Civi/Api4/Generic/Traits/OptionList.php
@@ -17,7 +17,7 @@ namespace Civi\Api4\Generic\Traits;
  * The options appear in the field metadata for other entities that reference this one via pseudoconstant.
  *
  * Note: At time of writing, this trait does nothing except toggle the searchable flag, (and adds "OptionList" to the "type" in Entity::get() metadata).
- * @searchable false (FYI annotation isn't functional because this is a trait - workaround in AbstractEntity::getInfo)
+ * @searchable none (FYI annotation isn't functional because this is a trait - workaround in AbstractEntity::getInfo)
  */
 trait OptionList {
 

--- a/Civi/Api4/Grant.php
+++ b/Civi/Api4/Grant.php
@@ -25,6 +25,7 @@ namespace Civi\Api4;
  *
  * @see https://docs.civicrm.org/user/en/latest/grants/what-is-civigrant/
  *
+ * @searchable primary
  * @package Civi\Api4
  */
 class Grant extends Generic\DAOEntity {

--- a/Civi/Api4/Group.php
+++ b/Civi/Api4/Group.php
@@ -23,6 +23,7 @@ namespace Civi\Api4;
  *
  * @see https://docs.civicrm.org/user/en/latest/organising-your-data/groups-and-tags/#groups
  *
+ * @searchable secondary
  * @package Civi\Api4
  */
 class Group extends Generic\DAOEntity {

--- a/Civi/Api4/GroupContact.php
+++ b/Civi/Api4/GroupContact.php
@@ -24,9 +24,10 @@ namespace Civi\Api4;
  * A contact can either be "Added" "Removed" or "Pending" in a group.
  * CiviCRM only considers them to be "in" a group if their status is "Added".
  *
+ * @ui_join_filters status
+ *
  * @bridge group_id contact_id
  * @see \Civi\Api4\Group
- * @searchable false
  * @package Civi\Api4
  */
 class GroupContact extends Generic\DAOEntity {

--- a/Civi/Api4/GroupContact.php
+++ b/Civi/Api4/GroupContact.php
@@ -26,7 +26,6 @@ namespace Civi\Api4;
  *
  * @ui_join_filters status
  *
- * @bridge group_id contact_id
  * @see \Civi\Api4\Group
  * @package Civi\Api4
  */
@@ -58,6 +57,18 @@ class GroupContact extends Generic\DAOEntity {
   public static function update($checkPermissions = TRUE) {
     return (new Action\GroupContact\Update(__CLASS__, __FUNCTION__))
       ->setCheckPermissions($checkPermissions);
+  }
+
+  /**
+   * @return array
+   */
+  public static function getInfo() {
+    $info = parent::getInfo();
+    $info['bridge'] = [
+      'group_id' => ['description' => ts('Static (non-smart) group contacts')],
+      'contact_id' => ['description' => ts('Static (non-smart) group contacts')],
+    ];
+    return $info;
   }
 
 }

--- a/Civi/Api4/GroupNesting.php
+++ b/Civi/Api4/GroupNesting.php
@@ -22,7 +22,7 @@ namespace Civi\Api4;
  * GroupNesting entity.
  *
  * @see \Civi\Api4\Group
- * @searchable false
+ * @searchable none
  * @package Civi\Api4
  */
 class GroupNesting extends Generic\DAOEntity {

--- a/Civi/Api4/GroupOrganization.php
+++ b/Civi/Api4/GroupOrganization.php
@@ -23,6 +23,9 @@ namespace Civi\Api4;
  *
  * Relates groups to organizations.
  *
+ * FIXME: For now, excluding this from SearchKit because it's confusingly similar to GroupContact
+ * @searchable false
+ *
  * @see \Civi\Api4\Group
  * @package Civi\Api4
  */

--- a/Civi/Api4/GroupOrganization.php
+++ b/Civi/Api4/GroupOrganization.php
@@ -24,7 +24,7 @@ namespace Civi\Api4;
  * Relates groups to organizations.
  *
  * FIXME: For now, excluding this from SearchKit because it's confusingly similar to GroupContact
- * @searchable false
+ * @searchable none
  *
  * @see \Civi\Api4\Group
  * @package Civi\Api4

--- a/Civi/Api4/IM.php
+++ b/Civi/Api4/IM.php
@@ -22,6 +22,7 @@ namespace Civi\Api4;
 /**
  * IM entity.
  *
+ * @searchable secondary
  * @package Civi\Api4
  */
 class IM extends Generic\DAOEntity {

--- a/Civi/Api4/LineItem.php
+++ b/Civi/Api4/LineItem.php
@@ -21,6 +21,7 @@ namespace Civi\Api4;
 /**
  * LineItem entity.
  *
+ * @searchable secondary
  * @package Civi\Api4
  */
 class LineItem extends Generic\DAOEntity {

--- a/Civi/Api4/LocBlock.php
+++ b/Civi/Api4/LocBlock.php
@@ -17,7 +17,7 @@ namespace Civi\Api4;
  *
  * Links addresses, emails & phones to Events.
  *
- * @searchable false
+ * @searchable none
  * @package Civi\Api4
  */
 class LocBlock extends Generic\DAOEntity {

--- a/Civi/Api4/MailSettings.php
+++ b/Civi/Api4/MailSettings.php
@@ -22,7 +22,7 @@ namespace Civi\Api4;
 /**
  * MailSettings entity.
  *
- * @searchable false
+ * @searchable none
  * @package Civi\Api4
  */
 class MailSettings extends Generic\DAOEntity {

--- a/Civi/Api4/Mapping.php
+++ b/Civi/Api4/Mapping.php
@@ -23,7 +23,7 @@ namespace Civi\Api4;
  *
  * This is a collection of MappingFields, for reuse in import, export, etc.
  *
- * @searchable false
+ * @searchable none
  * @package Civi\Api4
  */
 class Mapping extends Generic\DAOEntity {

--- a/Civi/Api4/MappingField.php
+++ b/Civi/Api4/MappingField.php
@@ -24,7 +24,7 @@ namespace Civi\Api4;
  * This represents one field in a Mapping collection.
  *
  * @see \Civi\Api4\Mapping
- * @searchable false
+ * @searchable none
  * @package Civi\Api4
  */
 class MappingField extends Generic\DAOEntity {

--- a/Civi/Api4/MessageTemplate.php
+++ b/Civi/Api4/MessageTemplate.php
@@ -22,7 +22,7 @@ namespace Civi\Api4;
  * MsgTemplate entity.
  *
  * This is a collection of MsgTemplate, for reuse in import, export, etc.
- * @searchable false
+ * @searchable none
  * @package Civi\Api4
  */
 class MessageTemplate extends Generic\DAOEntity {

--- a/Civi/Api4/Navigation.php
+++ b/Civi/Api4/Navigation.php
@@ -21,7 +21,7 @@ namespace Civi\Api4;
 /**
  * Navigation entity.
  *
- * @searchable false
+ * @searchable none
  * @package Civi\Api4
  */
 class Navigation extends Generic\DAOEntity {

--- a/Civi/Api4/Note.php
+++ b/Civi/Api4/Note.php
@@ -22,6 +22,7 @@ namespace Civi\Api4;
 /**
  * Note entity.
  *
+ * @searchable secondary
  * @package Civi\Api4
  */
 class Note extends Generic\DAOEntity {

--- a/Civi/Api4/OpenID.php
+++ b/Civi/Api4/OpenID.php
@@ -22,6 +22,7 @@ namespace Civi\Api4;
 /**
  * OpenID entity.
  *
+ * @searchable secondary
  * @package Civi\Api4
  */
 class OpenID extends Generic\DAOEntity {

--- a/Civi/Api4/PCPBlock.php
+++ b/Civi/Api4/PCPBlock.php
@@ -21,6 +21,7 @@ namespace Civi\Api4;
 /**
  * PCP Block entity.
  *
+ * @searchable secondary
  * @package Civi\Api4
  */
 class PCPBlock extends Generic\DAOEntity {

--- a/Civi/Api4/Participant.php
+++ b/Civi/Api4/Participant.php
@@ -21,6 +21,7 @@ namespace Civi\Api4;
 /**
  * Participant entity, stores the participation record of a contact in an event.
  *
+ * @searchable primary
  * @package Civi\Api4
  */
 class Participant extends Generic\DAOEntity {

--- a/Civi/Api4/Permission.php
+++ b/Civi/Api4/Permission.php
@@ -25,7 +25,7 @@ namespace Civi\Api4;
  * It may be poorly suited to recursive usage (e.g. permissions defined dynamically
  * on top of permissions!) or during install/uninstall processes.
  *
- * @searchable false
+ * @searchable none
  * @package Civi\Api4
  */
 class Permission extends Generic\AbstractEntity {

--- a/Civi/Api4/Phone.php
+++ b/Civi/Api4/Phone.php
@@ -26,6 +26,7 @@ namespace Civi\Api4;
  *
  * Creating a new phone of a contact, requires at minimum a contact's ID and phone number
  *
+ * @searchable secondary
  * @package Civi\Api4
  */
 class Phone extends Generic\DAOEntity {

--- a/Civi/Api4/PledgePayment.php
+++ b/Civi/Api4/PledgePayment.php
@@ -22,6 +22,7 @@ namespace Civi\Api4;
 /**
  * PledgePayment entity.
  *
+ * @searchable secondary
  * @package Civi\Api4
  */
 class PledgePayment extends Generic\DAOEntity {

--- a/Civi/Api4/PriceField.php
+++ b/Civi/Api4/PriceField.php
@@ -15,6 +15,7 @@ namespace Civi\Api4;
 /**
  * PriceField entity.
  *
+ * @searchable secondary
  * @package Civi\Api4
  */
 class PriceField extends Generic\DAOEntity {

--- a/Civi/Api4/PriceFieldValue.php
+++ b/Civi/Api4/PriceFieldValue.php
@@ -15,6 +15,7 @@ namespace Civi\Api4;
 /**
  * PriceFieldValue entity.
  *
+ * @searchable secondary
  * @package Civi\Api4
  */
 class PriceFieldValue extends Generic\DAOEntity {

--- a/Civi/Api4/PriceSet.php
+++ b/Civi/Api4/PriceSet.php
@@ -15,6 +15,7 @@ namespace Civi\Api4;
 /**
  * PriceSet entity.
  *
+ * @searchable secondary
  * @package Civi\Api4
  */
 class PriceSet extends Generic\DAOEntity {

--- a/Civi/Api4/Query/Api4SelectQuery.php
+++ b/Civi/Api4/Query/Api4SelectQuery.php
@@ -795,7 +795,7 @@ class Api4SelectQuery {
     // Get the 2 bridge reference columns as CRM_Core_Reference_* objects
     $joinRef = $baseRef = NULL;
     foreach ($bridgeDAO::getReferenceColumns() as $ref) {
-      if (in_array($ref->getReferenceKey(), $bridgeFields)) {
+      if (array_key_exists($ref->getReferenceKey(), $bridgeFields)) {
         if (!$joinRef && in_array($joinEntity, $ref->getTargetEntities())) {
           $joinRef = $ref;
         }

--- a/Civi/Api4/Relationship.php
+++ b/Civi/Api4/Relationship.php
@@ -23,7 +23,7 @@ namespace Civi\Api4;
  * Relationship entity.
  *
  * @see https://docs.civicrm.org/user/en/latest/organising-your-data/relationships/
- * @searchable false
+ * @searchable none
  * @package Civi\Api4
  */
 class Relationship extends Generic\DAOEntity {

--- a/Civi/Api4/RelationshipCache.php
+++ b/Civi/Api4/RelationshipCache.php
@@ -23,7 +23,6 @@ namespace Civi\Api4;
  * RelationshipCache - readonly table to facilitate joining and finding contacts by relationship.
  *
  * @see \Civi\Api4\Relationship
- * @bridge near_contact_id far_contact_id
  * @ui_join_filters near_relation
  * @package Civi\Api4
  */
@@ -46,6 +45,18 @@ class RelationshipCache extends Generic\AbstractEntity {
   public static function getFields($checkPermissions = TRUE) {
     return (new Generic\DAOGetFieldsAction(__CLASS__, __FUNCTION__))
       ->setCheckPermissions($checkPermissions);
+  }
+
+  /**
+   * @return array
+   */
+  public static function getInfo() {
+    $info = parent::getInfo();
+    $info['bridge'] = [
+      'near_contact_id' => ['description' => ts('One or more contacts with a relationship to this contact')],
+      'far_contact_id' => ['description' => ts('One or more contacts with a relationship to this contact')],
+    ];
+    return $info;
   }
 
 }

--- a/Civi/Api4/Route.php
+++ b/Civi/Api4/Route.php
@@ -26,7 +26,7 @@ namespace Civi\Api4;
  * Note: this is a read-only api as routes are set via xml files and hooks.
  *
  * @see https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_alterMenu/
- * @searchable false
+ * @searchable none
  * @package Civi\Api4
  */
 class Route extends \Civi\Api4\Generic\AbstractEntity {

--- a/Civi/Api4/SavedSearch.php
+++ b/Civi/Api4/SavedSearch.php
@@ -25,7 +25,7 @@ namespace Civi\Api4;
  * Stores search parameters for populating smart groups with live results.
  *
  * @see https://docs.civicrm.org/user/en/latest/organising-your-data/smart-groups/
- * @searchable false
+ * @searchable none
  * @package Civi\Api4
  */
 class SavedSearch extends Generic\DAOEntity {

--- a/Civi/Api4/Setting.php
+++ b/Civi/Api4/Setting.php
@@ -25,7 +25,7 @@ namespace Civi\Api4;
  * Used to read/write persistent setting data from CiviCRM.
  *
  * @see \Civi\Core\SettingsBag
- * @searchable false
+ * @searchable none
  * @package Civi\Api4
  */
 class Setting extends Generic\AbstractEntity {

--- a/Civi/Api4/StatusPreference.php
+++ b/Civi/Api4/StatusPreference.php
@@ -24,7 +24,7 @@ namespace Civi\Api4;
  *
  * For setting "hush" preferences for system check alerts.
  *
- * @searchable false
+ * @searchable none
  * @package Civi\Api4
  */
 class StatusPreference extends Generic\DAOEntity {

--- a/Civi/Api4/System.php
+++ b/Civi/Api4/System.php
@@ -21,6 +21,7 @@ namespace Civi\Api4;
 /**
  * A collection of system maintenance/diagnostic utilities.
  *
+ * @searchable none
  * @package Civi\Api4
  */
 class System extends Generic\AbstractEntity {

--- a/Civi/Api4/Tag.php
+++ b/Civi/Api4/Tag.php
@@ -26,6 +26,7 @@ namespace Civi\Api4;
  * They are connected to those entities via the EntityTag table.
  *
  * @see https://docs.civicrm.org/user/en/latest/organising-your-data/groups-and-tags/#tags
+ * @searchable secondary
  * @package Civi\Api4
  */
 class Tag extends Generic\DAOEntity {

--- a/Civi/Api4/UFField.php
+++ b/Civi/Api4/UFField.php
@@ -23,7 +23,7 @@ namespace Civi\Api4;
  * UFField entity - aka profile fields.
  *
  * @see \Civi\Api4\UFGroup
- * @searchable false
+ * @searchable none
  * @package Civi\Api4
  */
 class UFField extends Generic\DAOEntity {

--- a/Civi/Api4/UFGroup.php
+++ b/Civi/Api4/UFGroup.php
@@ -23,7 +23,7 @@ namespace Civi\Api4;
  * UFGroup entity - AKA profiles.
  *
  * @see https://docs.civicrm.org/user/en/latest/organising-your-data/profiles/
- * @searchable false
+ * @searchable none
  * @package Civi\Api4
  */
 class UFGroup extends Generic\DAOEntity {

--- a/Civi/Api4/UFJoin.php
+++ b/Civi/Api4/UFJoin.php
@@ -23,7 +23,7 @@ namespace Civi\Api4;
  * UFJoin entity - links profiles to the components/extensions they are used for.
  *
  * @see \Civi\Api4\UFGroup
- * @searchable false
+ * @searchable none
  * @package Civi\Api4
  */
 class UFJoin extends Generic\DAOEntity {

--- a/Civi/Api4/UFMatch.php
+++ b/Civi/Api4/UFMatch.php
@@ -22,7 +22,7 @@ namespace Civi\Api4;
 /**
  * UFMatch entity - links civicrm contacts with users created externally
  *
- * @searchable false
+ * @searchable none
  * @package Civi\Api4
  */
 class UFMatch extends Generic\DAOEntity {

--- a/Civi/Api4/Utils/ReflectionUtils.php
+++ b/Civi/Api4/Utils/ReflectionUtils.php
@@ -98,9 +98,6 @@ class ReflectionUtils {
         elseif ($key == 'searchable') {
           $info[$key] = strtolower($words[0]) !== 'false';
         }
-        elseif ($key == 'bridge') {
-          $info[$key] = $words;
-        }
         elseif ($key == 'param' && $words) {
           $type = $words[0][0] !== '$' ? explode('|', array_shift($words)) : NULL;
           $param = rtrim(array_shift($words), '-:()/');

--- a/Civi/Api4/Utils/ReflectionUtils.php
+++ b/Civi/Api4/Utils/ReflectionUtils.php
@@ -95,9 +95,6 @@ class ReflectionUtils {
         elseif ($key == 'throws' || $key == 'see') {
           $info[$key][] = implode(' ', $words);
         }
-        elseif ($key == 'searchable') {
-          $info[$key] = strtolower($words[0]) !== 'false';
-        }
         elseif ($key == 'param' && $words) {
           $type = $words[0][0] !== '$' ? explode('|', array_shift($words)) : NULL;
           $param = rtrim(array_shift($words), '-:()/');

--- a/Civi/Api4/Website.php
+++ b/Civi/Api4/Website.php
@@ -22,6 +22,7 @@ namespace Civi\Api4;
 /**
  * Website entity.
  *
+ * @searchable secondary
  * @package Civi\Api4
  */
 class Website extends Generic\DAOEntity {

--- a/css/api4-explorer.css
+++ b/css/api4-explorer.css
@@ -152,22 +152,6 @@
   padding: 5px 10px;
 }
 
-/* Collapsible optgroups for select2 */
-div.select2-drop.collapsible-optgroups-enabled .select2-result-with-children:not(.optgroup-expanded) > .select2-result-sub > li.select2-result {
-  display: none;
-}
-div.select2-drop.collapsible-optgroups-enabled .select2-result-with-children > .select2-result-label:before {
-  font-family: FontAwesome;
-  content: "\f0da";
-  display: inline-block;
-  padding-right: 3px;
-  vertical-align: middle;
-  font-weight: normal;
-}
-div.select2-drop.collapsible-optgroups-enabled .select2-result-with-children.optgroup-expanded > .select2-result-label:before {
-  content: "\f0d7";
-}
-
 #bootstrap-theme.api4-explorer-page .form-control.huge {
   width: 25em;
 }

--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -3111,6 +3111,22 @@ tbody.scrollContent tr.alternateRow {
   box-sizing: border-box;
 }
 
+/* Collapsible optgroups for select2 */
+div.select2-drop.collapsible-optgroups-enabled .select2-result-with-children:not(.optgroup-expanded) > .select2-result-sub > li.select2-result {
+  display: none;
+}
+div.select2-drop.collapsible-optgroups-enabled .select2-result-with-children > .select2-result-label:before {
+  font-family: FontAwesome;
+  content: "\f0da";
+  display: inline-block;
+  padding-right: 3px;
+  vertical-align: middle;
+  font-weight: normal;
+}
+div.select2-drop.collapsible-optgroups-enabled .select2-result-with-children.optgroup-expanded > .select2-result-label:before {
+  content: "\f0d7";
+}
+
 span.crm-select-item-color {
   display: inline-block;
   width: .8em;

--- a/ext/afform/core/Civi/Api4/Afform.php
+++ b/ext/afform/core/Civi/Api4/Afform.php
@@ -16,7 +16,7 @@ use Civi\Api4\Generic\BasicBatchAction;
  *      The `prefill` and `submit` actions are used for preparing forms and processing submissions.
  *
  * @see https://lab.civicrm.org/extensions/afform
- * @searchable false
+ * @searchable none
  * @package Civi\Api4
  */
 class Afform extends Generic\AbstractEntity {

--- a/ext/search_kit/Civi/Api4/SearchDisplay.php
+++ b/ext/search_kit/Civi/Api4/SearchDisplay.php
@@ -6,7 +6,7 @@ namespace Civi\Api4;
  *
  * Provided by the Search Kit extension.
  *
- * @searchable false
+ * @searchable none
  * @package Civi\Api4
  */
 class SearchDisplay extends Generic\DAOEntity {

--- a/ext/search_kit/Civi/Search/Admin.php
+++ b/ext/search_kit/Civi/Search/Admin.php
@@ -192,13 +192,15 @@ class Admin {
         $bridge = in_array('EntityBridge', $entity['type']) ? $entity['name'] : NULL;
         foreach ($references as $reference) {
           $keyField = $fields[$reference->getReferenceKey()] ?? NULL;
-          // Exclude any joins that are better represented by pseudoconstants
-          if (is_a($reference, 'CRM_Core_Reference_OptionValue')
-            || !$keyField || !empty($keyField['options'])
+          if (
+            // Sanity check - keyField must exist
+            !$keyField ||
+            // Exclude any joins that are better represented by pseudoconstants
+            is_a($reference, 'CRM_Core_Reference_OptionValue') || (!$bridge && !empty($keyField['options'])) ||
             // Limit bridge joins to just the first
-            || $bridge && array_search($keyField['name'], $entity['bridge']) !== 0
+            ($bridge && array_search($keyField['name'], $entity['bridge']) !== 0) ||
             // Sanity check - table should match
-            || $daoClass::getTableName() !== $reference->getReferenceTable()
+            $daoClass::getTableName() !== $reference->getReferenceTable()
           ) {
             continue;
           }

--- a/ext/search_kit/Civi/Search/Admin.php
+++ b/ext/search_kit/Civi/Search/Admin.php
@@ -190,6 +190,7 @@ class Admin {
         });
         $fields = array_column($entity['fields'], NULL, 'name');
         $bridge = in_array('EntityBridge', $entity['type']) ? $entity['name'] : NULL;
+        $bridgeFields = array_keys($entity['bridge'] ?? []);
         foreach ($references as $reference) {
           $keyField = $fields[$reference->getReferenceKey()] ?? NULL;
           if (
@@ -198,7 +199,7 @@ class Admin {
             // Exclude any joins that are better represented by pseudoconstants
             is_a($reference, 'CRM_Core_Reference_OptionValue') || (!$bridge && !empty($keyField['options'])) ||
             // Limit bridge joins to just the first
-            ($bridge && array_search($keyField['name'], $entity['bridge']) !== 0) ||
+            ($bridge && array_search($keyField['name'], $bridgeFields) !== 0) ||
             // Sanity check - table should match
             $daoClass::getTableName() !== $reference->getReferenceTable()
           ) {
@@ -240,7 +241,7 @@ class Admin {
             // Bridge joins (sanity check - bridge must specify exactly 2 FK fields)
             elseif (count($entity['bridge']) === 2) {
               // Get the other entity being linked through this bridge
-              $baseKey = array_search($reference->getReferenceKey(), $entity['bridge']) ? $entity['bridge'][0] : $entity['bridge'][1];
+              $baseKey = array_search($reference->getReferenceKey(), $bridgeFields) ? $bridgeFields[0] : $bridgeFields[1];
               $baseEntity = $allowedEntities[$fields[$baseKey]['fk_entity']] ?? NULL;
               if (!$baseEntity) {
                 continue;
@@ -251,7 +252,7 @@ class Admin {
               $alias = $baseEntity['name'] . "_{$bridge}_" . $targetEntityName;
               $joins[$baseEntity['name']][] = [
                 'label' => $baseEntity['title'] . ' ' . $targetsTitle,
-                'description' => E::ts('Multiple %1 per %2', [1 => $targetsTitle, 2 => $baseEntity['title']]),
+                'description' => $entity['bridge'][$baseKey]['description'] ?? E::ts('Multiple %1 per %2', [1 => $targetsTitle, 2 => $baseEntity['title']]),
                 'entity' => $targetEntityName,
                 'conditions' => array_merge(
                   [$bridge],
@@ -266,7 +267,7 @@ class Admin {
                 $alias = $targetEntityName . "_{$bridge}_" . $baseEntity['name'];
                 $joins[$targetEntityName][] = [
                   'label' => $targetEntity['title'] . ' ' . $baseEntity['title_plural'],
-                  'description' => E::ts('Multiple %1 per %2', [1 => $baseEntity['title_plural'], 2 => $targetEntity['title']]),
+                  'description' => $entity['bridge'][$reference->getReferenceKey()]['description'] ?? E::ts('Multiple %1 per %2', [1 => $baseEntity['title_plural'], 2 => $targetEntity['title']]),
                   'entity' => $baseEntity['name'],
                   'conditions' => array_merge(
                     [$bridge],

--- a/ext/search_kit/Civi/Search/Admin.php
+++ b/ext/search_kit/Civi/Search/Admin.php
@@ -82,8 +82,8 @@ class Admin {
   public static function getSchema() {
     $schema = [];
     $entities = \Civi\Api4\Entity::get()
-      ->addSelect('name', 'title', 'type', 'title_plural', 'description', 'label_field', 'icon', 'paths', 'dao', 'bridge', 'ui_join_filters')
-      ->addWhere('searchable', '=', TRUE)
+      ->addSelect('name', 'title', 'type', 'title_plural', 'description', 'label_field', 'icon', 'paths', 'dao', 'bridge', 'ui_join_filters', 'searchable')
+      ->addWhere('searchable', '!=', 'none')
       ->addOrderBy('title_plural')
       ->setChain([
         'get' => ['$name', 'getActions', ['where' => [['name', '=', 'get']]], ['params']],

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
@@ -30,12 +30,6 @@
         {k: 'INNER', v: ts('With (required)')},
         {k: 'EXCLUDE', v: ts('Without')},
       ];
-      // Try to create a sensible list of entities one might want to search for,
-      // excluding those whos primary purpose is to provide joins or option lists to other entities
-      var primaryEntities = _.filter(CRM.crmSearchAdmin.schema, function(entity) {
-        return !_.includes(entity.type, 'EntityBridge') && !_.includes(entity.type, 'OptionList');
-      });
-      $scope.entities = formatForSelect2(primaryEntities, 'name', 'title_plural', ['description', 'icon']);
       $scope.getEntity = searchMeta.getEntity;
       $scope.getField = searchMeta.getField;
       this.perm = {
@@ -62,6 +56,19 @@
             }
           });
         }
+
+        var primaryEntities = _.filter(CRM.crmSearchAdmin.schema, function(entity) {
+          return entity.searchable === 'primary' && !_.includes(entity.type, 'EntityBridge');
+        });
+        var secondaryEntities = _.filter(CRM.crmSearchAdmin.schema, function(entity) {
+          return entity.searchable === 'secondary' && !_.includes(entity.type, 'EntityBridge');
+        });
+        $scope.mainEntitySelect = formatForSelect2(primaryEntities, 'name', 'title_plural', ['description', 'icon']);
+        $scope.mainEntitySelect.push({
+          text: ts('More...'),
+          description: ts('Other less-commonly searched entities'),
+          children: formatForSelect2(secondaryEntities, 'name', 'title_plural', ['description', 'icon'])
+        });
 
         $scope.$watchCollection('$ctrl.savedSearch.api_params.select', onChangeSelect);
 

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.html
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.html
@@ -18,7 +18,7 @@
       </div>
       <div class="crm-flex-4 form-inline">
         <label for="crm-search-main-entity">{{:: ts('Search for') }}</label>
-        <input id="crm-search-main-entity" class="form-control huge" ng-model="$ctrl.savedSearch.api_entity" crm-ui-select="::{allowClear: false, data: entities}" ng-disabled="$ctrl.savedSearch.id" />
+        <input id="crm-search-main-entity" class="form-control huge collapsible-optgroups" ng-model="$ctrl.savedSearch.api_entity" crm-ui-select="::{allowClear: false, data: mainEntitySelect}" ng-disabled="$ctrl.savedSearch.id" />
         <div class="btn-group btn-group-md pull-right">
           <button type="button" class="btn" ng-class="{'btn-primary': status === 'unsaved', 'btn-warning': status === 'saving', 'btn-success': status === 'saved'}" ng-disabled="status !== 'unsaved'" ng-click="$ctrl.save()">
             <i class="crm-i" ng-class="{'fa-check': status !== 'saving', 'fa-spin fa-spinner': status === 'saving'}"></i>

--- a/js/Common.js
+++ b/js/Common.js
@@ -474,12 +474,36 @@ if (!CRM.vars) CRM.vars = {};
         };
       }
 
-      // Use description as title for each option
-      $el.on('select2-loaded.crmSelect2', function() {
-        $('.crm-select2-row-description', '#select2-drop').each(function() {
-          $(this).closest('.select2-result-label').attr('title', $(this).text());
+      $el
+        .on('select2-loaded.crmSelect2', function() {
+          // Use description as title for each option
+          $('.crm-select2-row-description', '#select2-drop').each(function() {
+            $(this).closest('.select2-result-label').attr('title', $(this).text());
+          });
+          // Collapsible optgroups should be expanded when searching
+          if ($('#select2-drop.collapsible-optgroups-enabled .select2-search input.select2-input').val()) {
+            $('#select2-drop.collapsible-optgroups-enabled li.select2-result-with-children')
+              .addClass('optgroup-expanded');
+          }
+        })
+        // Handle collapsible optgroups
+        .on('select2-open', function(e) {
+          var isCollapsible = $(e.target).hasClass('collapsible-optgroups');
+          $('#select2-drop')
+            .off('.collapseOptionGroup')
+            .toggleClass('collapsible-optgroups-enabled', isCollapsible);
+          if (isCollapsible) {
+            $('#select2-drop')
+              .on('click.collapseOptionGroup', '.select2-result-with-children > .select2-result-label', function() {
+                $(this).parent().toggleClass('optgroup-expanded');
+              })
+              // If the first item in the list is an optgroup, expand it
+              .find('li.select2-result-with-children:first-child').addClass('optgroup-expanded');
+          }
+        })
+        .on('select2-close', function() {
+          $('#select2-drop').off('.collapseOptionGroup').removeClass('collapsible-optgroups-enabled');
         });
-      });
 
       // Defaults for single-selects
       if ($el.is('select:not([multiple])')) {

--- a/tests/phpunit/api/v4/Entity/ConformanceTest.php
+++ b/tests/phpunit/api/v4/Entity/ConformanceTest.php
@@ -156,6 +156,7 @@ class ConformanceTest extends UnitTestCase {
     $this->assertNotEmpty($info['title_plural']);
     $this->assertNotEmpty($info['type']);
     $this->assertNotEmpty($info['description']);
+    $this->assertContains($info['searchable'], ['primary', 'secondary', 'none']);
     // Bridge must be between exactly 2 entities
     if (in_array('EntityBridge', $info['type'], TRUE)) {
       $this->assertCount(2, $info['bridge']);

--- a/tests/phpunit/api/v4/Entity/ConformanceTest.php
+++ b/tests/phpunit/api/v4/Entity/ConformanceTest.php
@@ -156,6 +156,10 @@ class ConformanceTest extends UnitTestCase {
     $this->assertNotEmpty($info['title_plural']);
     $this->assertNotEmpty($info['type']);
     $this->assertNotEmpty($info['description']);
+    // Bridge must be between exactly 2 entities
+    if (in_array('EntityBridge', $info['type'], TRUE)) {
+      $this->assertCount(2, $info['bridge']);
+    }
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Adds static (non-smart) groups to SearchKit, and organizes main entity selector to be less cluttered, with primary entities up top and the rest within a collapsible optgroup.

Comments
----------------
I started doing the declutter work because selecting a group join is confusing. There are currently 3 ways to join on group (created by, modified by, plus the actual join on GroupContact which is the one 99% people want to use over the other two). That circled my mind back to a previous conversation about basic vs advanced modes, and I thought a collapsible optgroup would help a lot towards that end.
In this PR I didn't get as far as organizing the join selectors, so far the declutter just applies to the main entity selector, but it's a start and this PR is getting quite large, so it'd be good to get it merged and I'll keep at it...
