### PR TITLE
Fix separate payment membership test to create valid financial transa…

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -2055,10 +2055,6 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     $form->controller = new CRM_Contribute_Controller_Contribution();
     $params['invoiceID'] = md5(uniqid(rand(), TRUE));
 
-    // We want to move away from passing in amount as it is calculated by the actually-submitted params.
-    if ($form->getMainContributionAmount($params)) {
-      $params['amount'] = $form->getMainContributionAmount($params);
-    }
     $paramsProcessedForForm = $form->_params = self::getFormParams($params['id'], $params);
 
     $order = new CRM_Financial_BAO_Order();
@@ -2069,7 +2065,10 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
       $order->setOverrideTotalAmount($params['amount']);
     }
     $amount = $order->getTotalAmount();
-    $form->_amount = $params['amount'] = $form->_params['amount'] = $params['amount'] ?? $amount;
+    if ($form->_separateMembershipPayment) {
+      $amount -= $order->getMembershipTotalAmount();
+    }
+    $form->_amount = $params['amount'] = $form->_params['amount'] = $amount;
     // hack these in for test support.
     $form->_fields['billing_first_name'] = 1;
     $form->_fields['billing_last_name'] = 1;

--- a/CRM/Financial/BAO/Order.php
+++ b/CRM/Financial/BAO/Order.php
@@ -470,7 +470,7 @@ class CRM_Financial_BAO_Order {
   }
 
   /**
-   * Get the total tax amount for the order.
+   * Get the total amount for the order.
    *
    * @return float
    *
@@ -479,6 +479,21 @@ class CRM_Financial_BAO_Order {
   public function getTotalAmount() :float {
     $amount = 0.0;
     foreach ($this->getLineItems() as $lineItem) {
+      $amount += ($lineItem['line_total'] ?? 0.0) + ($lineItem['tax_amount'] ?? 0.0);
+    }
+    return $amount;
+  }
+
+  /**
+   * Get the total amount relating to memberships for the order.
+   *
+   * @return float
+   *
+   * @throws \CiviCRM_API3_Exception
+   */
+  public function getMembershipTotalAmount() :float {
+    $amount = 0.0;
+    foreach ($this->getMembershipLineItems() as $lineItem) {
       $amount += ($lineItem['line_total'] ?? 0.0) + ($lineItem['tax_amount'] ?? 0.0);
     }
     return $amount;


### PR DESCRIPTION
Overview
----------------------------------------
Fix separate payment membership test to create valid financial transactions

This fixes the membership submit tests in this class to be submitting price set values that are valid for the form rather than doing weird test-specific overrides.

I also did a lot of standardisation & cleanup 

Before
----------------------------------------
The various tests to submit the contribution page with membershps were forcing amounts through that didn't relate to the actual price set options selected (or not). As a result efforts to ensure line items, tax and payments added up to the total were failing.
I'd already done a big cleanup but still

![image](https://user-images.githubusercontent.com/336308/119925705-1154c800-bfca-11eb-94c4-f69c95ff3a14.png)


After
----------------------------------------
Consistent and valid values used

![image](https://user-images.githubusercontent.com/336308/119925761-2c273c80-bfca-11eb-96be-0114b5d84009.png)

Technical Details
----------------------------------------
There is no actual change to what is tested. The only changes outside tests are really in the test harness - although the order function will be useful if we ever get to cleaning up the rest of that form.

Comments
----------------------------------------
Note the Order class is commented as not supported for use outside of core and all existing uses of it are well covered by tests