### PR TITLE
core#2633 : Cannot remove Group Organisation selection in multisite setup

### DIFF
--- a/CRM/Contact/BAO/Group.php
+++ b/CRM/Contact/BAO/Group.php
@@ -477,12 +477,21 @@ class CRM_Contact_BAO_Group extends CRM_Contact_DAO_Group {
     }
 
     if (!empty($params['organization_id'])) {
-      // dev/core#382 Keeping the id here can cause db errors as it tries to update the wrong record in the Organization table
-      $groupOrg = [
-        'group_id' => $group->id,
-        'organization_id' => $params['organization_id'],
-      ];
-      CRM_Contact_BAO_GroupOrganization::add($groupOrg);
+      if ($params['organization_id'] == 'null') {
+        $groupOrganization = [];
+        CRM_Contact_BAO_GroupOrganization::retrieve($group->id, $groupOrganization);
+        if (!empty($groupOrganization['group_organization'])) {
+          CRM_Contact_BAO_GroupOrganization::deleteGroupOrganization($groupOrganization['group_organization']);
+        }
+      }
+      else {
+        // dev/core#382 Keeping the id here can cause db errors as it tries to update the wrong record in the Organization table
+        $groupOrg = [
+          'group_id' => $group->id,
+          'organization_id' => $params['organization_id'],
+        ];
+        CRM_Contact_BAO_GroupOrganization::add($groupOrg);
+      }
     }
 
     self::flushCaches();

--- a/CRM/Group/Form/Edit.php
+++ b/CRM/Group/Form/Edit.php
@@ -365,6 +365,10 @@ WHERE  title = %1
         'Group'
       );
 
+      if (CRM_Core_Permission::check('administer Multiple Organizations') && CRM_Core_Permission::isMultisiteEnabled()) {
+        $params['organization_id'] = empty($params['organization_id']) ? 'null' : $params['organization_id'];
+      }
+
       $group = CRM_Contact_BAO_Group::create($params);
       // Set the entity id so it is available to postProcess hook consumers
       $this->setEntityId($group->id);


### PR DESCRIPTION
Overview
----------------------------------------
Steps to replicate:

1. Go to any existing or create new group.
2. Select 'Organization' from the drop down and save.
3. Go the setting page of the group and unselect the organisation.


Before
----------------------------------------
Revisit the group setting form and you will find that the organisation selection is not removed.

After
----------------------------------------
Revisit the group setting form and you will find that the organisation selection is removed.

