### PR TITLE
(POC) tests/events/*.php - Enforce general compliance with hook/event signatures

### DIFF
--- a/CRM/Utils/System/UnitTests.php
+++ b/CRM/Utils/System/UnitTests.php
@@ -34,6 +34,7 @@ class CRM_Utils_System_UnitTests extends CRM_Utils_System_Base {
       $listenerMap = \Civi\Core\Event\EventScanner::findListeners($test);
       \Civi::dispatcher()->addListenerMap($test, $listenerMap);
     }
+    \Civi\Test::eventChecker()->addListeners();
   }
 
   /**

--- a/Civi/Test.php
+++ b/Civi/Test.php
@@ -183,6 +183,16 @@ class Test {
   }
 
   /**
+   * @return \Civi\Test\EventChecker
+   */
+  public static function eventChecker() {
+    if (!isset(self::$singletons['eventChecker'])) {
+      self::$singletons['eventChecker'] = new \Civi\Test\EventChecker();
+    }
+    return self::$singletons['eventChecker'];
+  }
+
+  /**
    * Prepare and execute a batch of SQL statements.
    *
    * @param string $query

--- a/Civi/Test/CiviTestListener.php
+++ b/Civi/Test/CiviTestListener.php
@@ -65,9 +65,24 @@ else {
       else {
         $this->tx = NULL;
       }
+
+      if ($this->isCiviTest($test) || $test instanceof \CiviUnitTestCase) {
+        \Civi\Test::eventChecker()->start($test);
+      }
     }
 
     public function endTest(\PHPUnit\Framework\Test $test, $time) {
+      $exception = NULL;
+
+      if ($this->isCiviTest($test) || $test instanceof \CiviUnitTestCase) {
+        try {
+          \Civi\Test::eventChecker()->stop($test);
+        }
+        catch (\Exception $e) {
+          $exception = $e;
+        }
+      }
+
       if ($test instanceof TransactionalInterface) {
         $this->tx->rollback()->commit();
         $this->tx = NULL;
@@ -80,6 +95,10 @@ else {
         unset($GLOBALS['CIVICRM_TEST_CASE']);
         error_reporting(E_ALL & ~E_NOTICE);
         $this->errorScope = NULL;
+      }
+
+      if ($exception) {
+        throw $exception;
       }
     }
 

--- a/Civi/Test/EventCheck.php
+++ b/Civi/Test/EventCheck.php
@@ -1,0 +1,87 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Test;
+
+use PHPUnit\Framework\Assert;
+
+/**
+ * An EventCheck is a fragment of a unit-test -- it is mixed into
+ * various test-scenarios and applies extra assertions.
+ */
+class EventCheck extends Assert {
+
+  /**
+   * @var \PHPUnit\Framework\Test
+   */
+  private $test;
+
+  /**
+   * Determine whether this check should be used during the current test.
+   *
+   * @param \PHPUnit\Framework\Test|NULL $test
+   *
+   * @return bool|string
+   *   FALSE: The check will be completely skipped.
+   *   TRUE: The check will be enabled. However, if the events never
+   *         execute, that is OK. Useful for general compliance-testing.
+   */
+  public function isSupported($test) {
+    return TRUE;
+  }
+
+  /**
+   * @return \PHPUnit\Framework\Test|NULL
+   */
+  public function getTest() {
+    return $this->test;
+  }
+
+  /**
+   * @param \PHPUnit\Framework\Test|NULL $test
+   */
+  public function setTest($test): void {
+    $this->test = $test;
+  }
+
+  /**
+   * Assert that a variable has a given type.
+   *
+   * @param string|string[] $types
+   *   List of types, per `gettype()` or `get_class()`
+   *   Ex: [`array`, `NULL`, `CRM_Core_DAO`]
+   * @param mixed $var
+   *   The variable to check
+   * @param string|NULL $msg
+   */
+  public function assertType($types, $var, $msg = NULL) {
+    $types = (array) $types;
+    if (in_array(gettype($var), $types)) {
+      return;
+    }
+    if (is_object($var)) {
+      foreach ($types as $type) {
+        if ($var instanceof $type) {
+          return;
+        }
+      }
+    }
+    $defactoType = is_object($var) ? get_class($var) : gettype($var);
+    $this->fail(sprintf("Expected one of (%s) but found %s\n%s", implode(' ', $types), $defactoType, $msg));
+  }
+
+  public function setUp() {
+  }
+
+  public function tearDown() {
+  }
+
+}

--- a/Civi/Test/EventChecker.php
+++ b/Civi/Test/EventChecker.php
@@ -1,0 +1,106 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Test;
+
+use Civi\Core\Event\EventScanner;
+
+class EventChecker {
+
+  /**
+   * @var \Civi\Test\EventCheck[]|null
+   */
+  private $allChecks = NULL;
+
+  /**
+   * @var \Civi\Test\EventCheck[]|null
+   */
+  private $activeChecks = NULL;
+
+  /**
+   * @param \PHPUnit\Framework\Test $test
+   *
+   * @return $this
+   */
+  public function start(\PHPUnit\Framework\Test $test) {
+    if ($this->activeChecks === NULL) {
+      $this->activeChecks = [];
+      foreach ($this->findAll() as $template) {
+        /** @var EventCheck $template */
+        if ($template->isSupported($test)) {
+          $checker = clone $template;
+          $checker->setTest($test);
+          $this->activeChecks[] = $checker;
+          $checker->setUp();
+        }
+      }
+    }
+    return $this;
+  }
+
+  /**
+   * @return $this
+   */
+  public function addListeners() {
+    $d = \Civi::dispatcher();
+    foreach ($this->activeChecks ?: [] as $checker) {
+      /** @var EventCheck $checker */
+      $d->addListenerMap($checker, EventScanner::findListeners($checker));
+      // For the moment, KISS. But we may want a counter at some point - to ensure things actually run.
+      //foreach (EventScanner::findListeners($checker) as $event => $listeners) {
+      //  foreach ($listeners as $listener) {
+      //    $d->addListener($event,
+      //      function($args...) use ($listener) {
+      //        $count++;
+      //        $m = $listener[1];
+      //        $checker->$m(...$args);
+      //      },
+      //      $listener[1] ?? 0
+      //    );
+      //  }
+      //}
+    }
+    return $this;
+  }
+
+  /**
+   * @return $this
+   */
+  public function stop() {
+    // NOTE: In test environment, dispatcher will be removed regardless.
+    foreach ($this->activeChecks ?? [] as $checker) {
+      /** @var \Civi\Test\EventCheck $checker */
+      Invasive::call([$checker, 'tearDown']);
+      $checker->setTest(NULL);
+    }
+    $this->activeChecks = NULL;
+    return $this;
+  }
+
+  /**
+   * @return EventCheck[]
+   */
+  protected function findAll() {
+    if ($this->allChecks === NULL) {
+      $all = [];
+      $testDir = \Civi::paths()->getPath('[civicrm.root]/tests/events');
+      $files = \CRM_Utils_File::findFiles($testDir, '*.evch.php', TRUE);
+      sort($files);
+      foreach ($files as $file) {
+        $all[$file] = require $testDir . '/' . $file;
+      }
+      $this->allChecks = $all;
+    }
+
+    return $this->allChecks;
+  }
+
+}

--- a/Civi/Test/Legacy/CiviTestListener.php
+++ b/Civi/Test/Legacy/CiviTestListener.php
@@ -55,9 +55,24 @@ class CiviTestListener extends \PHPUnit_Framework_BaseTestListener {
     else {
       $this->tx = NULL;
     }
+
+    if ($this->isCiviTest($test) || $test instanceof \CiviUnitTestCase) {
+      \Civi\Test::eventChecker()->start($test);
+    }
   }
 
   public function endTest(\PHPUnit_Framework_Test $test, $time) {
+    $exception = NULL;
+
+    if ($this->isCiviTest($test) || $test instanceof \CiviUnitTestCase) {
+      try {
+        \Civi\Test::eventChecker()->stop($test);
+      }
+      catch (\Exception $e) {
+        $exception = $e;
+      }
+    }
+
     if ($test instanceof \Civi\Test\TransactionalInterface) {
       $this->tx->rollback()->commit();
       $this->tx = NULL;
@@ -70,6 +85,10 @@ class CiviTestListener extends \PHPUnit_Framework_BaseTestListener {
       unset($GLOBALS['CIVICRM_TEST_CASE']);
       error_reporting(E_ALL & ~E_NOTICE);
       $this->errorScope = NULL;
+    }
+
+    if ($exception) {
+      throw $exception;
     }
   }
 

--- a/tests/events/civi_region_render.evch.php
+++ b/tests/events/civi_region_render.evch.php
@@ -1,0 +1,33 @@
+<?php
+return new class() extends \Civi\Test\EventCheck implements \Civi\Test\HookInterface {
+
+  private $validSnippetTypes = [
+    'callback',
+    'jquery',
+    'markup',
+    'script',
+    'scriptFile',
+    'scriptUrl',
+    'settings',
+    'style',
+    'styleFile',
+    'styleUrl',
+    'template',
+  ];
+
+  private $validRegion = '/^[A-Z][A-Za-z0-9]*$/';
+
+  /**
+   * Ensure that the hook data is always well-formed.
+   */
+  public function on_civi_region_render(\Civi\Core\Event\GenericHookEvent $e) {
+    $this->assertTrue($e->region instanceof \CRM_Core_Region);
+    /** @var \CRM_Core_Region $region */
+    $region = $e->region;
+    $this->assertRegexp($this->validRegion, $region->_name);
+    foreach ($region->getAll() as $snippet) {
+      $this->assertContains($snippet['type'], $this->validSnippetTypes);
+    }
+  }
+
+};

--- a/tests/events/hook_civicrm_custom.evch.php
+++ b/tests/events/hook_civicrm_custom.evch.php
@@ -1,0 +1,24 @@
+<?php
+return new class() extends \Civi\Test\EventCheck implements \Civi\Test\HookInterface {
+
+  private $validOperations = '/^(create|delete|edit|update|view)$/';
+
+  /**
+   * Ensure that the hook data is always well-formed.
+   *
+   * @see \CRM_Utils_Hook::custom
+   */
+  public function hook_civicrm_custom($op, $groupID, $entityID, &$params) {
+    $msg = "Non-conformant hook_civicrm_custom($op, $groupID, $entityID,...)";
+    $this->assertRegExp($this->validOperations, $op, "$msg: Bad operation");
+    $this->assertTrue(is_numeric($groupID), "$msg: Bad group ID");
+    $this->assertTrue(is_numeric($entityID), "$msg: Bad entity ID");
+    $this->assertTrue(is_array($params), "$msg: Bad params");
+  }
+
+  public function on_hook_civicrm_custom(\Civi\Core\Event\GenericHookEvent $e) {
+    // Ensure that object parameter names are conformant.
+    $this->hook_civicrm_custom($e->op, $e->groupID, $e->entityID, $e->params);
+  }
+
+};

--- a/tests/events/hook_civicrm_post.evch.php
+++ b/tests/events/hook_civicrm_post.evch.php
@@ -1,0 +1,34 @@
+<?php
+return new class() extends \Civi\Test\EventCheck implements \Civi\Test\HookInterface {
+
+  private $validOperations = '/^(create|delete|edit|update|view)$/';
+
+  private $validEntity = '/^[A-Z][A-Za-z0-9]*$/';
+
+  private $paramTypes = [
+    // One would expect 'CRM_Core_DAO' for all invocations, but keep a list of exceptions.
+    '*' => ['NULL', 'CRM_Core_DAO'],
+    'EntityTag' => 'array',
+    'Profile' => 'array',
+    'GroupContact' => ['array'],
+  ];
+
+  /**
+   * Ensure that the hook data is always well-formed.
+   *
+   * @see \CRM_Utils_Hook::post
+   */
+  public function hook_civicrm_post($op, $objectName, $objectId, &$objectRef = NULL) {
+    $msg = "Non-conformant hook_civicrm_post($op, $objectName, $objectId,...)";
+    $this->assertRegExp($this->validOperations, $op, "$msg: Bad operation");
+    $this->assertRegExp($this->validEntity, $objectName, "$msg: Bad object name");
+    $this->assertTrue($objectId === NULL || is_numeric($objectId), "$msg: Bad object ID");
+    $this->assertType($this->paramTypes[$objectName] ?? $this->paramTypes['*'], $objectRef, "$msg: Bad param type");
+  }
+
+  public function on_hook_civicrm_post(\Civi\Core\Event\PostEvent $e) {
+    // Ensure that object parameter names are conformant.
+    $this->hook_civicrm_post($e->action, $e->entity, $e->id, $e->object);
+  }
+
+};

--- a/tests/events/hook_civicrm_pre.evch.php
+++ b/tests/events/hook_civicrm_pre.evch.php
@@ -1,0 +1,32 @@
+<?php
+return new class() extends \Civi\Test\EventCheck implements \Civi\Test\HookInterface {
+
+  private $validOperations = '/^(create|delete|edit|update|view)$/';
+
+  private $validEntity = '/^[A-Z][A-Za-z0-9]*$/';
+
+  private $paramTypes = [
+    // One would expect 'array' for all invocations, but keep a list of exceptions.
+    '*' => ['NULL', 'array'],
+    'Tag' => ['CRM_Core_DAO', 'array'],
+  ];
+
+  /**
+   * Ensure that the hook data is always well-formed.
+   *
+   * @see \CRM_Utils_Hook::pre
+   */
+  public function hook_civicrm_pre($op, $objectName, $id, &$params = []) {
+    $msg = "Non-conformant hook_civicrm_pre($op, $objectName, $id,...)";
+    $this->assertRegExp($this->validOperations, $op, "$msg: Bad operation");
+    $this->assertRegExp($this->validEntity, $objectName, "$msg: Bad object name");
+    $this->assertTrue($id === NULL || is_numeric($id), "$msg: Bad object ID");
+    $this->assertType($this->paramTypes[$objectName] ?? $this->paramTypes['*'], $params, "$msg: Bad param type");
+  }
+
+  public function on_hook_civicrm_pre(\Civi\Core\Event\PreEvent $e) {
+    // Ensure that object parameter names are conformant.
+    $this->hook_civicrm_pre($e->action, $e->entity, $e->id, $e->params);
+  }
+
+};


### PR DESCRIPTION
Overview
----------------------------------------

Introduce a suite of tests (`tests/events/*.php`) which enforce general compliance with hook-signatures. Improve predictability/reliability of hook-data.

~~(Note: This depends on #20427, which is included as `(REVERT)` commit. Consequently, the overall diff looks much longer than it should. Use the list of commits to find more readable snippets.)~~ (*Dependency merged. Patch has been rebased.*)

Before
----------------------------------------

The quality of testing for hooks/events varies widely. While some hooks have thoughtful test-coverage, others have no test-coverage or inadequate coverage.

Consider `hook_civicrm_pre` and `hook_civicrm_post`. Going by documentation and normal practice, the `hook_pre` `$params` should be an `array` of key-value pairs, and the `hook_post` `$objectRef` should be a new DAO object. However, in the case of `GroupContact` (https://lab.civicrm.org/dev/core/-/issues/2585) the hook-data deviates from the documentation... and is even inconsistent with itself. `GroupContact` is particularly tricky but this type of omission is not unique. Understandbly. Given that `hook_civicrm_pre` and `hook_civicrm_post` fire in so many different ways, and that they originated in pre-unit-testing era, it can be daunting to consider writing specific tests for all of them.

After
----------------------------------------

One may write a *general* test which will be used *any time* a hook fires. For example, consider this draft of `tests/events/hook_civicrm_pre.evch.php`:

```php
return new class() extends \Civi\Test\EventCheck implements \Civi\Test\HookInterface {

  private $validOperations = '/^(create|delete|edit|update|view)$/';

  private $validEntity = '/^[A-Z][A-Za-z0-9]*$/';

  /**
   * Ensure that the hook data is always well-formed.
   *
   * @see \CRM_Utils_Hook::pre
   */
  public function hook_civicrm_pre($op, $objectName, $id, &$params = []) {
    $msg = "Non-conformant hook_civicrm_pre($op, $objectName, $id,...)";
    $this->assertRegExp($this->validOperations, $op, "$msg: Bad operation");
    $this->assertRegExp($this->validEntity, $objectName, "$msg: Bad object name");
    $this->assertTrue($id === NULL || is_numeric($id), "$msg: Bad object ID");
    $this->assertTrue(is_array($params));
  }
```

This leverages all the existing scenarios in the core test-suites and ensures that the hook *always* presents data in the expected format (regardless of when or how it's fired).

Comments
----------------------------------------

I did a trial with a small slice of the test-suite locally, and it's identified multiple issues:

* `hook_pre` has inconsistent `$params` when handling `Tag` records
* `hook_pre` has transposed `$op`<=>`$objectName` when handling `UFField` records
* `hook_post` has inconsistent `$objectRef` when handling `EntityTag` records
* `hook_post` has inconsistent `$objectRef` when handling `Profile` records
* `hook_post`has inconsistent `$objectRef` when handling `GroupContact` records

There will probably need to be some mix of cleaning these things and grandfathering these things. For the moment, I added a couple exclusions for some of those. When we get a bigger test run, it'll be interesting to see if those exclusions covered everything or if there's still more.