### PR TITLE
[REF] APIv4 refactoring to support calculated fields

### DIFF
--- a/Civi/Api4/Action/CustomValue/GetFields.php
+++ b/Civi/Api4/Action/CustomValue/GetFields.php
@@ -12,8 +12,6 @@
 
 namespace Civi\Api4\Action\CustomValue;
 
-use Civi\Api4\Service\Spec\SpecFormatter;
-
 /**
  * Get fields for a custom group.
  */
@@ -25,7 +23,7 @@ class GetFields extends \Civi\Api4\Generic\DAOGetFieldsAction {
     /** @var \Civi\Api4\Service\Spec\SpecGatherer $gatherer */
     $gatherer = \Civi::container()->get('spec_gatherer');
     $spec = $gatherer->getSpec('Custom_' . $this->getCustomGroup(), $this->getAction(), $this->includeCustom, $this->values);
-    return SpecFormatter::specToArray($spec->getFields($fields), $this->loadOptions);
+    return $this->specToArray($spec->getFields($fields));
   }
 
   /**

--- a/Civi/Api4/Generic/DAOGetFieldsAction.php
+++ b/Civi/Api4/Generic/DAOGetFieldsAction.php
@@ -19,8 +19,6 @@
 
 namespace Civi\Api4\Generic;
 
-use Civi\Api4\Service\Spec\SpecFormatter;
-
 /**
  * @inheritDoc
  * @method bool getIncludeCustom()
@@ -48,7 +46,7 @@ class DAOGetFieldsAction extends BasicGetFieldsAction {
       $this->includeCustom = strpos(implode('', $fieldsToGet), '.') !== FALSE;
     }
     $spec = $gatherer->getSpec($this->getEntityName(), $this->getAction(), $this->includeCustom, $this->values);
-    $fields = SpecFormatter::specToArray($spec->getFields($fieldsToGet), $this->loadOptions, $this->values);
+    $fields = $this->specToArray($spec->getFields($fieldsToGet));
     foreach ($fieldsToGet ?? [] as $fieldName) {
       if (empty($fields[$fieldName]) && strpos($fieldName, '.') !== FALSE) {
         $fkField = $this->getFkFieldSpec($fieldName, $fields);
@@ -59,6 +57,24 @@ class DAOGetFieldsAction extends BasicGetFieldsAction {
       }
     }
     return $fields;
+  }
+
+  /**
+   * @param \Civi\Api4\Service\Spec\FieldSpec[] $fields
+   *
+   * @return array
+   */
+  protected function specToArray($fields) {
+    $fieldArray = [];
+
+    foreach ($fields as $field) {
+      if ($this->loadOptions) {
+        $field->getOptions($this->values, $this->loadOptions, $this->checkPermissions);
+      }
+      $fieldArray[$field->getName()] = $field->toArray();
+    }
+
+    return $fieldArray;
   }
 
   /**

--- a/Civi/Api4/Service/Spec/CustomFieldSpec.php
+++ b/Civi/Api4/Service/Spec/CustomFieldSpec.php
@@ -23,17 +23,17 @@ class CustomFieldSpec extends FieldSpec {
   /**
    * @var int
    */
-  protected $customFieldId;
+  public $customFieldId;
 
   /**
    * @var int
    */
-  protected $customGroup;
+  public $customGroup;
 
   /**
    * @var string
    */
-  protected $tableName;
+  public $tableName;
 
   /**
    * @inheritDoc

--- a/Civi/Api4/Service/Spec/CustomFieldSpec.php
+++ b/Civi/Api4/Service/Spec/CustomFieldSpec.php
@@ -31,11 +31,6 @@ class CustomFieldSpec extends FieldSpec {
   public $customGroup;
 
   /**
-   * @var string
-   */
-  public $tableName;
-
-  /**
    * @inheritDoc
    */
   public function setDataType($dataType) {
@@ -87,24 +82,6 @@ class CustomFieldSpec extends FieldSpec {
    */
   public function setCustomGroupName($customGroupName) {
     $this->customGroup = $customGroupName;
-
-    return $this;
-  }
-
-  /**
-   * @return string
-   */
-  public function getCustomTableName() {
-    return $this->tableName;
-  }
-
-  /**
-   * @param string $customFieldColumnName
-   *
-   * @return $this
-   */
-  public function setCustomTableName($customFieldColumnName) {
-    $this->tableName = $customFieldColumnName;
 
     return $this;
   }

--- a/Civi/Api4/Service/Spec/FieldSpec.php
+++ b/Civi/Api4/Service/Spec/FieldSpec.php
@@ -66,6 +66,11 @@ class FieldSpec {
   public $options;
 
   /**
+   * @var string
+   */
+  public $tableName;
+
+  /**
    * @var callable
    */
   private $optionsCallback;
@@ -215,6 +220,17 @@ class FieldSpec {
    */
   public function setTitle($title) {
     $this->title = $title;
+
+    return $this;
+  }
+
+  /**
+   * @param string $entity
+   *
+   * @return $this
+   */
+  public function setEntity($entity) {
+    $this->entity = $entity;
 
     return $this;
   }
@@ -444,6 +460,24 @@ class FieldSpec {
    */
   public function setHelpPost($helpPost) {
     $this->helpPost = is_string($helpPost) && strlen($helpPost) ? $helpPost : NULL;
+  }
+
+  /**
+   * @param string $customFieldColumnName
+   *
+   * @return CustomFieldSpec
+   */
+  public function setTableName($customFieldColumnName) {
+    $this->tableName = $customFieldColumnName;
+
+    return $this;
+  }
+
+  /**
+   * @return string
+   */
+  public function getTableName() {
+    return $this->tableName;
   }
 
   /**

--- a/Civi/Api4/Service/Spec/FieldSpec.php
+++ b/Civi/Api4/Service/Spec/FieldSpec.php
@@ -19,108 +19,111 @@
 
 namespace Civi\Api4\Service\Spec;
 
-use Civi\Api4\Utils\CoreUtil;
-
 class FieldSpec {
   /**
    * @var mixed
    */
-  protected $defaultValue;
+  public $defaultValue;
 
   /**
    * @var string
    */
-  protected $name;
+  public $name;
 
   /**
    * @var string
    */
-  protected $label;
+  public $label;
 
   /**
    * @var string
    */
-  protected $title;
+  public $title;
 
   /**
    * @var string
    */
-  protected $entity;
+  public $entity;
 
   /**
    * @var string
    */
-  protected $description;
+  public $description;
 
   /**
    * @var bool
    */
-  protected $required = FALSE;
+  public $required = FALSE;
 
   /**
    * @var bool
    */
-  protected $requiredIf;
+  public $requiredIf;
 
   /**
    * @var array|bool
    */
-  protected $options;
+  public $options;
+
+  /**
+   * @var callable
+   */
+  private $optionsCallback;
 
   /**
    * @var string
    */
-  protected $dataType;
+  public $dataType;
 
   /**
    * @var string
    */
-  protected $inputType;
+  public $inputType;
 
   /**
    * @var array
    */
-  protected $inputAttrs = [];
+  public $inputAttrs = [];
 
   /**
    * @var string
    */
-  protected $fkEntity;
+  public $fkEntity;
 
   /**
    * @var int
    */
-  protected $serialize;
+  public $serialize;
 
   /**
    * @var string
    */
-  protected $helpPre;
+  public $helpPre;
 
   /**
    * @var string
    */
-  protected $helpPost;
+  public $helpPost;
 
   /**
    * @var array
    */
-  protected $permission;
+  public $permission;
 
   /**
    * @var string
    */
-  protected $columnName;
+  public $columnName;
 
   /**
    * @var bool
    */
-  protected $readonly = FALSE;
+  public $readonly = FALSE;
 
   /**
    * @var callable[]
    */
-  protected $outputFormatters = [];
+  public $outputFormatters = [];
 
   /**
    * Aliases for the valid data types
@@ -458,110 +461,19 @@ class FieldSpec {
   /**
    * @param array $values
    * @param array|bool $return
+   * @param bool $checkPermissions
    * @return array
    */
-  public function getOptions($values = [], $return = TRUE) {
-    if (!isset($this->options) || $this->options === TRUE) {
-      $fieldName = $this->getName();
-
-      if ($this instanceof CustomFieldSpec) {
-        // buildOptions relies on the custom_* type of field names
-        $fieldName = sprintf('custom_%d', $this->getCustomFieldId());
-      }
-
-      // BAO::buildOptions returns a single-dimensional list, we call that first because of the hook contract,
-      // @see CRM_Utils_Hook::fieldOptions
-      // We then supplement the data with additional properties if requested.
-      $bao = CoreUtil::getBAOFromApiName($this->getEntity());
-      $optionLabels = $bao::buildOptions($fieldName, NULL, $values);
-
-      if (!is_array($optionLabels) || !$optionLabels) {
-        $this->options = FALSE;
+  public function getOptions($values = [], $return = TRUE, $checkPermissions = TRUE) {
+    if (!isset($this->options)) {
+      if ($this->optionsCallback) {
+        $this->options = ($this->optionsCallback)($this, $values, $return, $checkPermissions);
       }
       else {
-        $this->options = \CRM_Utils_Array::makeNonAssociative($optionLabels, 'id', 'label');
-        if (is_array($return)) {
-          self::addOptionProps($bao, $fieldName, $values, $return);
-        }
+        $this->options = FALSE;
       }
     }
     return $this->options;
-  }
-
-  /**
-   * Augment the 2 values returned by BAO::buildOptions (id, label) with extra properties (name, description, color, icon, etc).
-   *
-   * We start with BAO::buildOptions in order to respect hooks which may be adding/removing items, then we add the extra data.
-   *
-   * @param \CRM_Core_DAO $baoName
-   * @param string $fieldName
-   * @param array $values
-   * @param array $return
-   */
-  private function addOptionProps($baoName, $fieldName, $values, $return) {
-    // FIXME: For now, call the buildOptions function again and then combine the arrays. Not an ideal approach.
-    // TODO: Teach CRM_Core_Pseudoconstant to always load multidimensional option lists so we can get more properties like 'color' and 'icon',
-    // however that might require a change to the hook_civicrm_fieldOptions signature so that's a bit tricky.
-    if (in_array('name', $return)) {
-      $props['name'] = $baoName::buildOptions($fieldName, 'validate', $values);
-    }
-    $return = array_diff($return, ['id', 'name', 'label']);
-    // CRM_Core_Pseudoconstant doesn't know how to fetch extra stuff like icon, description, color, etc., so we have to invent that wheel here...
-    if ($return) {
-      $optionIds = implode(',', array_column($this->options, 'id'));
-      $optionIndex = array_flip(array_column($this->options, 'id'));
-      if ($this instanceof CustomFieldSpec) {
-        $optionGroupId = \CRM_Core_DAO::getFieldValue('CRM_Core_DAO_CustomField', $this->getCustomFieldId(), 'option_group_id');
-      }
-      else {
-        $dao = new $baoName();
-        $fieldSpec = $dao->getFieldSpec($fieldName);
-        $pseudoconstant = $fieldSpec['pseudoconstant'] ?? NULL;
-        $optionGroupName = $pseudoconstant['optionGroupName'] ?? NULL;
-        $optionGroupId = $optionGroupName ? \CRM_Core_DAO::getFieldValue('CRM_Core_DAO_OptionGroup', $optionGroupName, 'id', 'name') : NULL;
-      }
-      if (!empty($optionGroupId)) {
-        $extraStuff = \CRM_Core_BAO_OptionValue::getOptionValuesArray($optionGroupId);
-        $keyColumn = $pseudoconstant['keyColumn'] ?? 'value';
-        foreach ($extraStuff as $item) {
-          if (isset($optionIndex[$item[$keyColumn]])) {
-            foreach ($return as $ret) {
-              // Note: our schema is inconsistent about whether `description` fields allow html,
-              // but it's usually assumed to be plain text, so we strip_tags() to standardize it.
-              $this->options[$optionIndex[$item[$keyColumn]]][$ret] = ($ret === 'description' && isset($item[$ret])) ? strip_tags($item[$ret]) : $item[$ret] ?? NULL;
-            }
-          }
-        }
-      }
-      else {
-        // Fetch the abbr if requested using context: abbreviate
-        if (in_array('abbr', $return)) {
-          $props['abbr'] = $baoName::buildOptions($fieldName, 'abbreviate', $values);
-          $return = array_diff($return, ['abbr']);
-        }
-        // Fetch anything else (color, icon, description)
-        if ($return && !empty($pseudoconstant['table']) && \CRM_Utils_Rule::commaSeparatedIntegers($optionIds)) {
-          $sql = "SELECT * FROM {$pseudoconstant['table']} WHERE id IN (%1)";
-          $query = \CRM_Core_DAO::executeQuery($sql, [1 => [$optionIds, 'CommaSeparatedIntegers']]);
-          while ($query->fetch()) {
-            foreach ($return as $ret) {
-              if (property_exists($query, $ret)) {
-                // Note: our schema is inconsistent about whether `description` fields allow html,
-                // but it's usually assumed to be plain text, so we strip_tags() to standardize it.
-                $this->options[$optionIndex[$query->id]][$ret] = $ret === 'description' ? strip_tags($query->$ret) : $query->$ret;
-              }
-            }
-          }
-        }
-      }
-    }
-    if (isset($props)) {
-      foreach ($this->options as &$option) {
-        foreach ($props as $name => $prop) {
-          $option[$name] = $prop[$option['id']] ?? NULL;
-        }
-      }
-    }
   }
 
   /**
@@ -572,6 +484,23 @@ class FieldSpec {
   public function setOptions($options) {
     $this->options = $options;
     return $this;
+  }
+
+  /**
+   * @param callable $callback
+   *
+   * @return $this
+   */
+  public function setOptionsCallback($callback) {
+    $this->optionsCallback = $callback;
+    return $this;
+  }
+
+  /**
+   * @return callable
+   */
+  public function getOptionsCallback() {
+    return $this->optionsCallback;
   }
 
   /**
@@ -610,16 +539,29 @@ class FieldSpec {
   }
 
   /**
-   * @param array $values
+   * Gets all public variables, converted to snake_case
+   *
    * @return array
    */
-  public function toArray($values = []) {
-    $ret = [];
-    foreach (get_object_vars($this) as $key => $val) {
-      $key = strtolower(preg_replace('/(?=[A-Z])/', '_$0', $key));
-      if (!$values || in_array($key, $values)) {
-        $ret[$key] = $val;
+  public function toArray() {
+    // Anonymous class will only have access to public vars
+    $getter = new class {
+
+      function getPublicVars($object) {
+        return get_object_vars($object);
       }
+
+    };
+
+    // If getOptions was never called, make options a boolean
+    if (!isset($this->options)) {
+      $this->options = isset($this->optionsCallback);
+    }
+
+    $ret = [];
+    foreach ($getter->getPublicVars($this) as $key => $val) {
+      $key = strtolower(preg_replace('/(?=[A-Z])/', '_$0', $key));
+      $ret[$key] = $val;
     }
     return $ret;
   }

--- a/Civi/Api4/Service/Spec/RequestSpec.php
+++ b/Civi/Api4/Service/Spec/RequestSpec.php
@@ -19,6 +19,8 @@
 
 namespace Civi\Api4\Service\Spec;
 
+use Civi\Api4\Utils\CoreUtil;
+
 class RequestSpec {
 
   /**
@@ -32,6 +34,11 @@ class RequestSpec {
   protected $action;
 
   /**
+   * @var string
+   */
+  protected $entityTableName;
+
+  /**
    * @var FieldSpec[]
    */
   protected $fields = [];
@@ -43,9 +50,16 @@ class RequestSpec {
   public function __construct($entity, $action) {
     $this->entity = $entity;
     $this->action = $action;
+    $this->entityTableName = CoreUtil::getTableName($entity);
   }
 
   public function addFieldSpec(FieldSpec $field) {
+    if (!$field->getEntity()) {
+      $field->setEntity($this->entity);
+    }
+    if (!$field->getTableName()) {
+      $field->setTableName($this->entityTableName);
+    }
     $this->fields[] = $field;
   }
 

--- a/Civi/Api4/Service/Spec/SpecFormatter.php
+++ b/Civi/Api4/Service/Spec/SpecFormatter.php
@@ -39,7 +39,7 @@ class SpecFormatter {
         $field->setName($data['custom_group.name'] . '.' . $data['name']);
       }
       else {
-        $field->setCustomTableName($data['custom_group.table_name']);
+        $field->setTableName($data['custom_group.table_name']);
       }
       $field->setColumnName($data['column_name']);
       $field->setCustomFieldId($data['id'] ?? NULL);

--- a/tests/phpunit/api/v4/Action/GetFieldsTest.php
+++ b/tests/phpunit/api/v4/Action/GetFieldsTest.php
@@ -20,11 +20,27 @@
 namespace api\v4\Action;
 
 use api\v4\UnitTestCase;
+use Civi\Api4\Contact;
 
 /**
  * @group headless
  */
 class GetFieldsTest extends UnitTestCase {
+
+  public function testOptionsAreReturned() {
+    $fields = Contact::getFields(FALSE)
+      ->execute()
+      ->indexBy('name');
+    $this->assertTrue($fields['gender_id']['options']);
+    $this->assertFalse($fields['first_name']['options']);
+
+    $fields = Contact::getFields(FALSE)
+      ->setLoadOptions(TRUE)
+      ->execute()
+      ->indexBy('name');
+    $this->assertTrue(is_array($fields['gender_id']['options']));
+    $this->assertFalse($fields['first_name']['options']);
+  }
 
   public function testComponentFields() {
     \CRM_Core_BAO_ConfigSetting::disableComponent('CiviCampaign');

--- a/tests/phpunit/api/v4/Action/GetFieldsTest.php
+++ b/tests/phpunit/api/v4/Action/GetFieldsTest.php
@@ -42,6 +42,14 @@ class GetFieldsTest extends UnitTestCase {
     $this->assertFalse($fields['first_name']['options']);
   }
 
+  public function testTableAndColumnReturned() {
+    $fields = Contact::getFields(FALSE)
+      ->execute()
+      ->indexBy('name');
+    $this->assertEquals('civicrm_contact', $fields['display_name']['table_name']);
+    $this->assertEquals('display_name', $fields['display_name']['column_name']);
+  }
+
   public function testComponentFields() {
     \CRM_Core_BAO_ConfigSetting::disableComponent('CiviCampaign');
     $fields = \Civi\Api4\Event::getFields()

--- a/tests/phpunit/api/v4/Spec/SpecFormatterTest.php
+++ b/tests/phpunit/api/v4/Spec/SpecFormatterTest.php
@@ -20,8 +20,6 @@
 namespace api\v4\Spec;
 
 use Civi\Api4\Service\Spec\CustomFieldSpec;
-use Civi\Api4\Service\Spec\FieldSpec;
-use Civi\Api4\Service\Spec\RequestSpec;
 use Civi\Api4\Service\Spec\SpecFormatter;
 use api\v4\UnitTestCase;
 
@@ -29,16 +27,6 @@ use api\v4\UnitTestCase;
  * @group headless
  */
 class SpecFormatterTest extends UnitTestCase {
-
-  public function testSpecToArray() {
-    $spec = new RequestSpec('Contact', 'get');
-    $fieldName = 'last_name';
-    $field = new FieldSpec($fieldName, 'Contact');
-    $spec->addFieldSpec($field);
-    $arraySpec = SpecFormatter::specToArray($spec->getFields());
-
-    $this->assertEquals('String', $arraySpec[$fieldName]['data_type']);
-  }
 
   /**
    * @dataProvider arrayFieldSpecProvider


### PR DESCRIPTION
Overview
----------------------------------------
This is a code refactor to make it possible to add ad-hoc fields to the api getfields spec.

Before
----------------------------------------
All APIv4 fields correspond to db columns for dao entities for the `get` action.

After
----------------------------------------
It's possible to add other fields. They will be ignored by the get api, so handling will need to be done elsewhere.

Technical Details
----------------------------------------
A big part of this refactor was to move options lookup to a callback function.


