### PR TITLE
[php8-compat] [REF] Fix a couple of functions triggering deprecation notices in php…

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -2011,7 +2011,7 @@ SELECT contact_id
    * @return object
    *   an object of type referenced by daoName
    */
-  public static function commonRetrieveAll($daoName, $fieldIdName = 'id', $fieldId, &$details, $returnProperities = NULL) {
+  public static function commonRetrieveAll($daoName, $fieldIdName, $fieldId, &$details, $returnProperities = NULL) {
     require_once str_replace('_', DIRECTORY_SEPARATOR, $daoName) . ".php";
     $object = new $daoName();
     $object->$fieldIdName = $fieldId;

--- a/CRM/Core/OptionValue.php
+++ b/CRM/Core/OptionValue.php
@@ -251,7 +251,7 @@ class CRM_Core_OptionValue {
    * @return bool
    *   true if object exists
    */
-  public static function optionExists($value, $daoName, $daoID, $optionGroupID, $fieldName = 'name', $domainSpecific) {
+  public static function optionExists($value, $daoName, $daoID, $optionGroupID, $fieldName, $domainSpecific) {
     $object = new $daoName();
     $object->$fieldName = $value;
     $object->option_group_id = $optionGroupID;


### PR DESCRIPTION
…8.0 where by an optional parameter is before required parameters in the function signature

Overview
----------------------------------------
This fixes a couple of deprecation notices found when installing dmaster on a local php8.0 instance 

`PHP Deprecated:  Required parameter $fieldId follows optional parameter $fieldIdName in /home/seamus/buildkit/build/dmaster/web/sites/all/modules/civicrm/CRM/Core/DAO.php on line 2014`

`Deprecated: Required parameter $domainSpecific follows optional parameter $fieldName in /home/seamus/buildkit/build/dmaster/web/sites/all/modules/civicrm/CRM/Core/OptionValue.php on line 254`

Before
----------------------------------------
Deprecation notices emitted in php8.0

After
----------------------------------------
No deprecation notices emitted for these functions in php8.0

ping @eileenmcnaughton @totten @colemanw 