### PR TITLE
[php8-compat] Fix calling method_exist with paremeter that is bool not an object in…

### DIFF
--- a/CRM/Utils/GeocodeProvider.php
+++ b/CRM/Utils/GeocodeProvider.php
@@ -68,7 +68,7 @@ class CRM_Utils_GeocodeProvider {
       // or extend a base class. While we identify and implement a geocoding
       // abstraction library (rather than continue to roll our own), we settle for
       // this check.
-      if (!method_exists($provider, 'format') && $provider !== FALSE) {
+      if ($provider !== FALSE && !method_exists($provider, 'format')) {
         Civi::log()->error('Configured geocoder is invalid, must provide a format method', ['geocode_class' => $provider]);
         $provider = FALSE;
       }


### PR DESCRIPTION
… php8

Overview
----------------------------------------
This fixes an error found when trying to install dmaster on php8.0 where by calling method_exists with a boolean is not acceptable in php8.0, switching the order of the ifs resolves the error

Before
----------------------------------------
Installation fails in php8.0

After
----------------------------------------
Installation works in php8.0

ping @eileenmcnaughton @totten 