### PR TITLE
[php8-compat] Fix Warning Notices when running schema generation

### DIFF
--- a/CRM/Core/CodeGen/Specification.php
+++ b/CRM/Core/CodeGen/Specification.php
@@ -272,7 +272,9 @@ class CRM_Core_CodeGen_Specification {
           $this->getForeignKey($foreignXML, $fields, $foreign, $name);
         }
       }
-      $table['foreignKey'] = &$foreign;
+      if (!empty($foreign)) {
+        $table['foreignKey'] = &$foreign;
+      }
     }
 
     if ($this->value('dynamicForeignKey', $tableXML)) {

--- a/CRM/Core/Smarty/plugins/block.localize.php
+++ b/CRM/Core/Smarty/plugins/block.localize.php
@@ -31,7 +31,7 @@
  *   multilingualized query
  */
 function smarty_block_localize($params, $text, &$smarty) {
-  if (!$smarty->_tpl_vars['multilingual']) {
+  if (!array_key_exists('multilingual', $smarty->_tpl_vars) || !$smarty->_tpl_vars['multilingual']) {
     return $text;
   }
 

--- a/xml/templates/dao.tpl
+++ b/xml/templates/dao.tpl
@@ -89,7 +89,7 @@ class {$table.className} extends CRM_Core_DAO {ldelim}
 
 
 
-{if $table.foreignKey || $table.dynamicForeignKey}
+{if !empty($table.foreignKey) || !empty($table.dynamicForeignKey)}
     /**
      * Returns foreign keys and entity references.
      *
@@ -99,13 +99,16 @@ class {$table.className} extends CRM_Core_DAO {ldelim}
     public static function getReferenceColumns() {ldelim}
       if (!isset(Civi::$statics[__CLASS__]['links'])) {ldelim}
         Civi::$statics[__CLASS__]['links'] = static::createReferenceColumns(__CLASS__);
+{if isset($table.foreignKey)}
 {foreach from=$table.foreignKey item=foreign}
         Civi::$statics[__CLASS__]['links'][] = new CRM_Core_Reference_Basic(self::getTableName(), '{$foreign.name}', '{$foreign.table}', '{$foreign.key}');
 {/foreach}
-
+{/if}
+{if isset($table.dynamicForeignKey)}
 {foreach from=$table.dynamicForeignKey item=foreign}
         Civi::$statics[__CLASS__]['links'][] = new CRM_Core_Reference_Dynamic(self::getTableName(), '{$foreign.idColumn}', NULL, '{$foreign.key|default:'id'}', '{$foreign.typeColumn}');
 {/foreach}
+{/if}
         CRM_Core_DAO_AllCoreTables::invoke(__CLASS__, 'links_callback', Civi::$statics[__CLASS__]['links']);
       {rdelim}
       return Civi::$statics[__CLASS__]['links'];
@@ -139,19 +142,19 @@ class {$table.className} extends CRM_Core_DAO {ldelim}
 {if $field.required}
                                         'required'  => {$field.required|strtoupper},
 {/if} {* field.required *}
-{if $field.length}
+{if isset($field.length)}
                       'maxlength' => {$field.length},
 {/if} {* field.length *}
-{if $field.precision}
+{if isset($field.precision)}
                       'precision'      => array({$field.precision}),
 {/if}
-{if $field.size}
+{if isset($field.size)}
                       'size'      => {$field.size},
 {/if} {* field.size *}
-{if $field.rows}
+{if isset($field.rows)}
                       'rows'      => {$field.rows},
 {/if} {* field.rows *}
-{if $field.cols}
+{if isset($field.cols)}
                       'cols'      => {$field.cols},
 {/if} {* field.cols *}
 
@@ -181,9 +184,9 @@ class {$table.className} extends CRM_Core_DAO {ldelim}
   'entity' => '{$table.entity}',
   'bao' => '{$table.bao}',
   'localizable' => {if $field.localizable}1{else}0{/if},
-  {if $field.localize_context}'localize_context' => '{$field.localize_context}',{/if}
+  {if isset($field.localize_context)}'localize_context' => '{$field.localize_context}',{/if}
 
-{if $field.FKClassName}
+{if isset($field.FKClassName)}
                       'FKClassName' => '{$field.FKClassName}',
 {/if}
 {if !empty($field.component)}
@@ -261,7 +264,7 @@ class {$table.className} extends CRM_Core_DAO {ldelim}
        */
        public static function &import( $prefix = FALSE ) {ldelim}
             $r = CRM_Core_DAO_AllCoreTables::getImports(__CLASS__, '{$table.labelName}', $prefix, array(
-            {if $table.foreignKey}{foreach from=$table.foreignKey item=foreign}
+            {if isset($table.foreignKey)}{foreach from=$table.foreignKey item=foreign}
               {if $foreign.import}'{$foreign.className}',{/if}
             {/foreach}{/if}
             ));
@@ -277,7 +280,7 @@ class {$table.className} extends CRM_Core_DAO {ldelim}
         */
        public static function &export( $prefix = FALSE ) {ldelim}
             $r = CRM_Core_DAO_AllCoreTables::getExports(__CLASS__, '{$table.labelName}', $prefix, array(
-            {if $table.foreignKey}{foreach from=$table.foreignKey item=foreign}
+            {if isset($table.foreignKey)}{foreach from=$table.foreignKey item=foreign}
               {if $foreign.export}'{$foreign.className}',{/if}
             {/foreach}{/if}
             ));

--- a/xml/templates/drop.tpl
+++ b/xml/templates/drop.tpl
@@ -1,4 +1,4 @@
-{*suppress license if within a file that already has the license*}{if !$no_license}-- +--------------------------------------------------------------------+
+{*suppress license if within a file that already has the license*}{if !isset($no_license) or !$no_license}-- +--------------------------------------------------------------------+
 -- | Copyright CiviCRM LLC. All rights reserved.                        |
 -- |                                                                    |
 -- | This work is published under the GNU AGPLv3 license with some      |
@@ -11,7 +11,7 @@
 --{/if}
 -- /*******************************************************
 -- *
--- * Clean up the existing tables{if $no_license} - this section generated from {$smarty.template}
+-- * Clean up the existing tables{if isset($no_license) and $no_license} - this section generated from {$smarty.template}
 {/if}
 -- *
 -- *******************************************************/

--- a/xml/templates/schema.tpl
+++ b/xml/templates/schema.tpl
@@ -32,18 +32,18 @@ CREATE TABLE `{$table.name}` ({assign var='first' value=true}
 {foreach from=$table.fields item=field}
 {if ! $first},{/if}{assign var='first' value=false}
 
-  `{$field.name}` {$field.sqlType}{if $field.collate} COLLATE {$field.collate}{/if}{if $field.required} {if $field.required == "false"}NULL{else}NOT NULL{/if}{/if}{if $field.autoincrement} AUTO_INCREMENT{/if}{if $field.default|count_characters} DEFAULT {$field.default}{/if}{if $field.comment} COMMENT '{ts escape=sql}{$field.comment}{/ts}'{/if}
+  `{$field.name}` {$field.sqlType}{if $field.collate} COLLATE {$field.collate}{/if}{if $field.required} {if $field.required == "false"}NULL{else}NOT NULL{/if}{/if}{if isset($field.autoincrement)} AUTO_INCREMENT{/if}{if $field.default|count_characters} DEFAULT {$field.default}{/if}{if $field.comment} COMMENT '{ts escape=sql}{$field.comment}{/ts}'{/if}
 {/foreach}{* table.fields *}{strip}
 
 {/strip}{if $table.primaryKey}{if !$first},
 {/if}{assign var='first' value=false}{assign var='firstIndexField' value=true}
   PRIMARY KEY ({foreach from=$table.primaryKey.field item=fieldName}{if $firstIndexField}{assign var='firstIndexField' value=false}{else},{/if}`{$fieldName}`{/foreach}){/if}{* table.primaryKey *}
-{if $table.index}{foreach from=$table.index item=index}{if !$first},
+{if !empty($table.index)}{foreach from=$table.index item=index}{if !$first},
 {/if}{assign var='first' value=false}
-  {if $index.unique}UNIQUE {/if}INDEX `{$index.name}`({assign var='firstIndexField' value=true}{foreach from=$index.field item=fieldName}{strip}
+  {if isset($index.unique)}UNIQUE {/if}INDEX `{$index.name}`({assign var='firstIndexField' value=true}{foreach from=$index.field item=fieldName}{strip}
 {/strip}{if $firstIndexField}{assign var='firstIndexField' value=false}{else}, {/if}{$fieldName}{/foreach}){/foreach}{* table.index *}
 {/if}{* table.index *}
-{if $table.foreignKey}
+{if !empty($table.foreignKey)}
 {foreach from=$table.foreignKey item=foreign}{if ! $first},
 {/if}
 {assign var='first' value=false}{if $mysql eq 'simple'}


### PR DESCRIPTION
Overview
----------------------------------------
This fixes a number of warning notices when running `./bin/setup.sh -g` on php8.0 such as `PHP Warning:  Undefined array key "autoincrement"` 

Before
----------------------------------------
Warning notices generated

After
----------------------------------------
No warnings

ping @eileenmcnaughton @colemanw @totten 