### PR TITLE
dev/core#2369 - Change missing image fatal error to 404

### DIFF
--- a/CRM/Contact/Page/ImageFile.php
+++ b/CRM/Contact/Page/ImageFile.php
@@ -52,11 +52,11 @@ class CRM_Contact_Page_ImageFile extends CRM_Core_Page {
         'image/' . ($fileExtension == 'jpg' ? 'jpeg' : $fileExtension),
         $this->ttl
       );
-      CRM_Utils_System::civiExit();
     }
     else {
-      throw new CRM_Core_Exception(ts('Photo does not exist'));
+      header("HTTP/1.0 404 Not Found");
     }
+    CRM_Utils_System::civiExit();
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
A missing profile image results in a unnecessary fatal error

Before
----------------------------------------
Use a profile in order for users to be able to upload a profile image (image url field in contact table). Viewing the field while an image is missing results in a fatal error (user does not notice, it is only logged that way). Being a fatal error the report error extension would also notify us by email each time.

After
----------------------------------------
A missing image url field does not result in a fatal error being logged anymore. The regular 404 rules apply.

Technical Details
----------------------------------------
Removed the lines that would throw the error

Comments
----------------------------------------
The world will be a better place after this commit is merged

Issue can be found over here: https://lab.civicrm.org/dev/core/-/issues/2369
