### PR TITLE
dev/financial#6 Added is template to search screen

### DIFF
--- a/CRM/Contact/Form/Search/Custom/ContribSYBNT.php
+++ b/CRM/Contact/Form/Search/Custom/ContribSYBNT.php
@@ -169,6 +169,7 @@ LEFT JOIN  civicrm_contribution contrib_1 ON contrib_1.contact_id = contact_a.id
            $from
 WHERE      contrib_1.contact_id = contact_a.id
 AND        contrib_1.is_test = 0
+AND        contrib_1.is_template = 0
            $where
 GROUP BY   contact_a.id
            $having
@@ -237,6 +238,7 @@ count(contrib_1.id) AS donation_count
 
     if (!empty($this->start_date_2) || !empty($this->end_date_2)) {
       $clauses[] = "contrib_2.is_test = 0";
+      $clauses[] = "contrib_2.is_template = 0";
 
       if (!empty($this->start_date_2)) {
         $clauses[] = CRM_Core_DAO::composeQuery('contrib_2.receive_date >= %1', [1 => [$this->start_date_2, 'String']]);
@@ -293,7 +295,7 @@ count(contrib_1.id) AS donation_count
 REPLACE   INTO {$this->_xgTableName}
 SELECT   DISTINCT contact_id AS contact_id
 FROM     civicrm_contribution c
-WHERE    c.is_test = 0
+WHERE    c.is_test = 0 AND c.is_template = 0
          $excludeClause
 GROUP BY c.contact_id
          $havingClause
@@ -308,7 +310,7 @@ GROUP BY c.contact_id
 REPLACE  INTO {$this->_xgTableName}
 SELECT   DISTINCT contact_id AS contact_id
 FROM     civicrm_contribution c
-WHERE    c.is_test = 0
+WHERE    c.is_test = 0 AND c.is_template = 0
 AND      c.receive_date < {$this->start_date_1}
 ";
         CRM_Core_DAO::executeQuery($query);

--- a/CRM/Contact/Form/Search/Custom/ContributionAggregate.php
+++ b/CRM/Contact/Form/Search/Custom/ContributionAggregate.php
@@ -198,6 +198,7 @@ civicrm_contact AS contact_a {$this->_aclFrom}
     $clauses = [
       "contrib.contact_id = contact_a.id",
       "contrib.is_test = 0",
+      "contrib.is_template = 0",
       "contrib.contribution_status_id = " . intval($contributionCompletedStatusId),
     ];
 

--- a/CRM/Contact/Form/Search/Custom/EventAggregate.php
+++ b/CRM/Contact/Form/Search/Custom/EventAggregate.php
@@ -214,6 +214,7 @@ class CRM_Contact_Form_Search_Custom_EventAggregate extends CRM_Contact_Form_Sea
 
     $clauses[] = "civicrm_participant.status_id in ( 1 )";
     $clauses[] = "civicrm_contribution.is_test = 0";
+    $clauses[] = "civicrm_contribution.is_template = 0";
     $onLine = CRM_Utils_Array::value('paid_online',
       $this->_formValues
     );

--- a/CRM/Contribute/BAO/Query.php
+++ b/CRM/Contribute/BAO/Query.php
@@ -961,6 +961,7 @@ class CRM_Contribute_BAO_Query extends CRM_Core_BAO_Query {
     $form->addYesNo('contribution_recurring', ts('Contribution is Recurring?'), TRUE);
 
     $form->addYesNo('contribution_test', ts('Contribution is a Test?'), TRUE);
+    $form->addYesNo('is_template', ts('Contribution is Template?'), TRUE);
     // Add field for transaction ID search
     $form->addElement('text', 'contribution_trxn_id', ts("Transaction ID"));
     $form->addElement('text', 'contribution_check_number', ts('Check Number'));
@@ -1029,6 +1030,7 @@ class CRM_Contribute_BAO_Query extends CRM_Core_BAO_Query {
 
     $form->assign('validCiviContribute', TRUE);
     $form->setDefaults(['contribution_test' => 0]);
+    $form->setDefaults(['is_template' => 0]);
 
     CRM_Contribute_BAO_ContributionRecur::recurringContribution($form);
   }

--- a/CRM/Contribute/Selector/Search.php
+++ b/CRM/Contribute/Selector/Search.php
@@ -53,6 +53,7 @@ class CRM_Contribute_Selector_Search extends CRM_Core_Selector_Base implements C
     'contribution_cancel_date',
     'product_name',
     'is_test',
+    'is_template',
     'contribution_recur_id',
     'receipt_date',
     'membership_id',

--- a/templates/CRM/Contact/Form/Search/Advanced.hlp
+++ b/templates/CRM/Contact/Form/Search/Advanced.hlp
@@ -102,7 +102,7 @@
 {/htxt}
 {htxt id="is-template"}
     <p>{ts}Template contributions are used with recurring contribution to generate follow up contributions.{/ts}</p>
-    <p>{ts}You can change the template contribution and the changes will occur as soon as new contribution is generated within the recurring serie.{/ts}</p>
+    <p>{ts}You can change the template contribution and the changes will occur as soon as new contribution is generated within the recurring series.{/ts}</p>
 {/htxt}
 
 {htxt id="processor-id-title"}

--- a/templates/CRM/Contact/Form/Search/Advanced.hlp
+++ b/templates/CRM/Contact/Form/Search/Advanced.hlp
@@ -96,6 +96,15 @@
     <p>{ts}Once you have finished your testing, it is a good idea to clean up by finding your test records and deleting them.{/ts}</p>
 {/htxt}
 
+
+{htxt id="is-template-title"}
+{ts}Template Records{/ts}
+{/htxt}
+{htxt id="is-template"}
+    <p>{ts}Template contributions are used with recurring contribution to generate follow up contributions.{/ts}</p>
+    <p>{ts}You can change the template contribution and the changes will occur as soon as new contribution is generated within the recurring serie.{/ts}</p>
+{/htxt}
+
 {htxt id="processor-id-title"}
 {ts}Processor ID{/ts}
 {/htxt}

--- a/templates/CRM/Contribute/Form/Search/Common.tpl
+++ b/templates/CRM/Contribute/Form/Search/Common.tpl
@@ -110,6 +110,12 @@
           {$form.contribution_recurring.html}
         </td>
       </tr>
+      <tr>
+        <td>{$form.is_template.label} {help id="is-template" file="CRM/Contact/Form/Search/Advanced"}</td>
+        <td>
+          {$form.is_template.html}
+        </td>
+      </tr>
       </tbody>
     </table>
   </td>

--- a/templates/CRM/Contribute/Form/Selector.tpl
+++ b/templates/CRM/Contribute/Form/Selector.tpl
@@ -49,7 +49,11 @@
                &nbsp; {$row.total_amount|crmMoney:$row.currency}
             </a>
           {if $row.amount_level }<br/>({$row.amount_level}){/if}
-          {if $row.contribution_recur_id}<br/>{ts}(Recurring){/ts}{/if}
+          {if $row.contribution_recur_id && $row.is_template}
+            <br/>{ts}(Recurring Template){/ts}
+          {elseif $row.contribution_recur_id }
+            <br/>{ts}(Recurring){/ts}
+          {/if}
         </td>
       {foreach from=$columnHeaders item=column}
         {assign var='columnName' value=$column.field_name}

--- a/tests/phpunit/CRM/Contribute/Form/SearchTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/SearchTest.php
@@ -521,7 +521,7 @@ class CRM_Contribute_Form_SearchTest extends CiviUnitTestCase {
       'contribution_status_id' => 1,
       'contact_id' => $this->ids['Contact']['contactID1'],
       'contribution_recur_id' => $ContributionRecur1['id'],
-      'is_template' => 1
+      'is_template' => 1,
     ]);
     $params = [
       'to_financial_account_id' => 1,

--- a/tests/phpunit/CRM/Contribute/Form/SearchTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/SearchTest.php
@@ -511,6 +511,28 @@ class CRM_Contribute_Form_SearchTest extends CiviUnitTestCase {
       'contribution_status_id' => 5,
       'financial_type_id' => "Donation",
     ]);
+    // Create a template contribution.
+    $TemplateContribution = $this->callAPISuccess('Contribution', 'create', [
+      'financial_type_id' => 'Donation',
+      'total_amount' => 11,
+      'receive_date' => date('Ymd'),
+      'receive_date_time' => NULL,
+      'payment_instrument_id' => 1,
+      'contribution_status_id' => 1,
+      'contact_id' => $this->ids['Contact']['contactID1'],
+      'contribution_recur_id' => $ContributionRecur1['id'],
+      'is_template' => 1
+    ]);
+    $params = [
+      'to_financial_account_id' => 1,
+      'status_id' => 1,
+      'contribution_id' => $TemplateContribution['id'],
+      'payment_instrument_id' => 1,
+      'card_type_id' => 1,
+      'total_amount' => 11,
+    ];
+    CRM_Core_BAO_FinancialTrxn::create($params);
+    // Create a normal contribution
     $Contribution1 = $this->callAPISuccess('Contribution', 'create', [
       'financial_type_id' => 'Donation',
       'total_amount' => 11,
@@ -591,6 +613,13 @@ class CRM_Contribute_Form_SearchTest extends CiviUnitTestCase {
         'expected_count' => 0,
         'expected_contact' => [],
         'expected_qill' => "Recurring Contribution Status = 'Cancelled'",
+      ],
+      // Case 4: Search for contributions with is_template = 1
+      'in_progress_search' => [
+        'form_value' => ['contribution_is_template' => 1],
+        'expected_count' => 1,
+        'expected_contact' => ['Mr. Joe Miller II'],
+        'expected_qill' => "Is a Template Contribution = \"1\"",
       ],
       'trxn_id_search' => [
         'form_value' => ['contribution_recur_trxn_id' => 'a transaction'],


### PR DESCRIPTION
Overview
----------------------------------------

This PR adds a field on the contribution search screen to search for template contributions.
By default this is set to no. 

This PR is part of the work done for https://lab.civicrm.org/dev/financial/-/issues/6

Before
----------------------------------------

There was no way to search for template contributions or to exclude them from the search

After
----------------------------------------

By default template contributions are excluded from the search. Also the user is able to search for them.

In the search result it will also show which contribution is a template and which isn't

![Peek 2021-05-28 11-43](https://user-images.githubusercontent.com/4126292/120172370-41d37680-c203-11eb-9f4e-3397770624cc.gif)

Comments
----------------------------------------

This PR also excludes contributions with `is_template = 1` from various custom searches.

See https://lab.civicrm.org/dev/financial/-/issues/6
And https://lab.civicrm.org/dev/core/-/issues/2624
