### PR TITLE
dev/financial#6 Template contributions on the contact summary

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2430,7 +2430,7 @@ LEFT JOIN  civicrm_contribution contribution ON ( componentPayment.contribution_
       SELECT contribution.id AS id
       FROM civicrm_contribution contribution
       LEFT JOIN civicrm_line_item i ON i.contribution_id = contribution.id AND i.entity_table = 'civicrm_contribution' $liWhere
-      WHERE contribution.is_test = 0 AND contribution.contact_id = {$contactId}
+      WHERE contribution.is_test = 0 AND contribution.is_template != '1' AND contribution.contact_id = {$contactId}
       $additionalWhere
       AND i.id IS NULL";
 
@@ -2438,7 +2438,7 @@ LEFT JOIN  civicrm_contribution contribution ON ( componentPayment.contribution_
       SELECT contribution.id
       FROM civicrm_contribution contribution INNER JOIN civicrm_contribution_soft softContribution
       ON ( contribution.id = softContribution.contribution_id )
-      WHERE contribution.is_test = 0 AND softContribution.contact_id = {$contactId} ";
+      WHERE contribution.is_test = 0 AND contribution.is_template != '1' AND softContribution.contact_id = {$contactId} ";
     $query = "SELECT count( x.id ) count FROM ( ";
     $query .= $contactContributionsSQL;
 

--- a/CRM/Contribute/Form/Search.php
+++ b/CRM/Contribute/Form/Search.php
@@ -258,6 +258,11 @@ class CRM_Contribute_Form_Search extends CRM_Core_Form_Search {
       // @todo - stop changing formValues - respect submitted form values, change a working array.
       $this->_formValues['contribution_test'] = 0;
     }
+    // We don't show template records in summaries or dashboards
+    if (empty($this->_formValues['is_template']) && $this->_force && !empty($this->_context) && ($this->_context === 'dashboard' || $this->_context === 'contribution')) {
+      // @todo - stop changing formValues - respect submitted form values, change a working array.
+      $this->_formValues['is_template'] = 0;
+    }
 
     foreach ([
       'contribution_amount_low',

--- a/CRM/Contribute/Page/Tab.php
+++ b/CRM/Contribute/Page/Tab.php
@@ -58,7 +58,7 @@ class CRM_Contribute_Page_Tab extends CRM_Core_Page {
         'qs' => "reset=1&id=%%crid%%&cid=%%cid%%&context={$context}",
       ],
     ];
-    if (!empty($templateContribution['id'])) {
+    if (!empty($templateContribution['id']) && !empty($templateContribution['is_template'])) {
       // Use constant CRM_Core_Action::PREVIEW as there is no such thing as view template.
       // And reusing view will mangle the actions.
       $links[CRM_Core_Action::PREVIEW] = [

--- a/CRM/Contribute/Page/Tab.php
+++ b/CRM/Contribute/Page/Tab.php
@@ -49,6 +49,7 @@ class CRM_Contribute_Page_Tab extends CRM_Core_Page {
    */
   public static function recurLinks(int $recurID, $context = 'contribution') {
     $paymentProcessorObj = Civi\Payment\System::singleton()->getById(CRM_Contribute_BAO_ContributionRecur::getPaymentProcessorID($recurID));
+    $templateContribution = CRM_Contribute_BAO_ContributionRecur::getTemplateContribution($recurID);
     $links = [
       CRM_Core_Action::VIEW => [
         'name' => ts('View'),
@@ -57,6 +58,16 @@ class CRM_Contribute_Page_Tab extends CRM_Core_Page {
         'qs' => "reset=1&id=%%crid%%&cid=%%cid%%&context={$context}",
       ],
     ];
+    if (!empty($templateContribution['id'])) {
+      // Use constant CRM_Core_Action::PREVIEW as there is no such thing as view template.
+      // And reusing view will mangle the actions.
+      $links[CRM_Core_Action::PREVIEW] = [
+        'name' => ts('View Template'),
+        'title' => ts('View Template Contribution'),
+        'url' => 'civicrm/contact/view/contribution',
+        'qs' => "reset=1&id={$templateContribution['id']}&cid=%%cid%%&action=view&context={$context}",
+      ];
+    }
     if (
       (CRM_Core_Permission::check('edit contributions') || $context !== 'contribution') &&
       ($paymentProcessorObj->supports('ChangeSubscriptionAmount')

--- a/CRM/Contribute/Page/Tab.php
+++ b/CRM/Contribute/Page/Tab.php
@@ -49,7 +49,6 @@ class CRM_Contribute_Page_Tab extends CRM_Core_Page {
    */
   public static function recurLinks(int $recurID, $context = 'contribution') {
     $paymentProcessorObj = Civi\Payment\System::singleton()->getById(CRM_Contribute_BAO_ContributionRecur::getPaymentProcessorID($recurID));
-    $templateContribution = CRM_Contribute_BAO_ContributionRecur::getTemplateContribution($recurID);
     $links = [
       CRM_Core_Action::VIEW => [
         'name' => ts('View'),
@@ -58,16 +57,7 @@ class CRM_Contribute_Page_Tab extends CRM_Core_Page {
         'qs' => "reset=1&id=%%crid%%&cid=%%cid%%&context={$context}",
       ],
     ];
-    if (!empty($templateContribution['id']) && !empty($templateContribution['is_template'])) {
-      // Use constant CRM_Core_Action::PREVIEW as there is no such thing as view template.
-      // And reusing view will mangle the actions.
-      $links[CRM_Core_Action::PREVIEW] = [
-        'name' => ts('View Template'),
-        'title' => ts('View Template Contribution'),
-        'url' => 'civicrm/contact/view/contribution',
-        'qs' => "reset=1&id={$templateContribution['id']}&cid=%%cid%%&action=view&context={$context}",
-      ];
-    }
+
     if (
       (CRM_Core_Permission::check('edit contributions') || $context !== 'contribution') &&
       ($paymentProcessorObj->supports('ChangeSubscriptionAmount')

--- a/CRM/Contribute/Page/Tab.php
+++ b/CRM/Contribute/Page/Tab.php
@@ -57,7 +57,6 @@ class CRM_Contribute_Page_Tab extends CRM_Core_Page {
         'qs' => "reset=1&id=%%crid%%&cid=%%cid%%&context={$context}",
       ],
     ];
-
     if (
       (CRM_Core_Permission::check('edit contributions') || $context !== 'contribution') &&
       ($paymentProcessorObj->supports('ChangeSubscriptionAmount')


### PR DESCRIPTION
Overview
----------------------------------------

This PR does the following

* Exclude contributions with `is_template = 1` from the Contributions tab on the contact summary
* The count on the contribution tab only counts non template contributions.

This PR is part of the work done for https://lab.civicrm.org/dev/financial/-/issues/6


Before
----------------------------------------

All contributions, including the template contributions, where shown on the contributions tab on the contact summary. 

After
----------------------------------------

The template contributions are not shown on the contribution tab.
Also the count on the tab for contributions does only count the non template contributions.


Comments
----------------------------------------

See https://lab.civicrm.org/dev/financial/-/issues/6
And https://lab.civicrm.org/dev/core/-/issues/2624

An alternative PR for creation of template contribution by the user is #20685 
