### PR TITLE
dev/financial#6 creation of a template contribution

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -249,8 +249,8 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution {
 
     // Check whether this is linked to a recurring contribution and whether this is the first contribution.
     // If so we should create the template contribution for the recurring contribution.
-    if (self::isFirstContributionOfRecurringContribution($params, $contribution->id)) {
-      CRM_Contribute_BAO_ContributionRecur::createTemplateContributionFromFirstContribution($params['contribution_recur_id']);
+    if (self::recurringContributionRequiresTemplate($params, $contribution->id)) {
+      CRM_Contribute_BAO_ContributionRecur::ensureTemplateContributionExists($params['contribution_recur_id']);
     }
 
     return $result;
@@ -294,7 +294,7 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution {
    * @throws \API_Exception
    * @throws \Civi\API\Exception\UnauthorizedException
    */
-  public static function isFirstContributionOfRecurringContribution($params, $contribution_id) {
+  public static function recurringContributionRequiresTemplate($params, $contribution_id) {
     if (empty($params['contribution_recur_id'])) {
       // No recurring contribution
       return FALSE;
@@ -324,7 +324,7 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution {
       ->addWhere('contribution_recur_id', '=', $params['contribution_recur_id'])
       ->addWhere('is_test', '=', $recurringContribution['is_test'])
       ->addWhere('is_template', '=', 0)
-      ->addOrderBy('id', 'DESC')
+      ->addOrderBy('receive_date', 'ASC')
       ->setLimit(1)
       ->setSelect(['id'])
       ->execute()

--- a/CRM/Contribute/BAO/ContributionRecur.php
+++ b/CRM/Contribute/BAO/ContributionRecur.php
@@ -443,7 +443,7 @@ INNER JOIN civicrm_contribution       con ON ( con.id = mp.contribution_id )
       ->addWhere('contribution_recur_id', '=', $id)
       ->addWhere('is_test', '=', $recurringContribution['is_test'])
       ->addWhere('is_template', '=', 0)
-      ->addOrderBy('id', 'DESC')
+      ->addOrderBy('receive_date', 'DESC')
       ->setLimit(1)
       ->execute()
       ->first();

--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -1185,6 +1185,15 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     // create an activity record
     if ($contribution) {
       CRM_Activity_BAO_Activity::addActivity($contribution, 'Contribution', $targetContactID, $actParams);
+      if (!empty($contributionParams['contribution_recur_id'])) {
+        // Add the on behalf activity to the template contribution.
+        // We have to do this by looking the template contribution as a DAO object.
+        $templateContribution = CRM_Contribute_BAO_ContributionRecur::getTemplateContribution($contributionParams['contribution_recur_id']);
+        $templateContributionObject = new CRM_Contribute_BAO_Contribution();
+        $templateContributionObject->id = $templateContribution['id'];
+        $templateContributionObject->find(TRUE);
+        CRM_Activity_BAO_Activity::addActivity($templateContributionObject, 'Contribution', $targetContactID, $actParams);
+      }
     }
 
     $transaction->commit();

--- a/tests/phpunit/CRM/Contribute/BAO/ContributionRecurTest.php
+++ b/tests/phpunit/CRM/Contribute/BAO/ContributionRecurTest.php
@@ -167,7 +167,7 @@ class CRM_Contribute_BAO_ContributionRecurTest extends CiviUnitTestCase {
       'contact_id' => $this->individualCreate(),
       'contribution_status_id' => 1,
       'receive_date' => 'yesterday',
-      'is_test' => 0,
+      'is_test' => 1,
     ]);
     $fetchedTemplate = CRM_Contribute_BAO_ContributionRecur::getTemplateContribution($contributionRecur['id']);
     $this->assertNotEquals($testContrib['id'], $fetchedTemplate['id']);

--- a/tests/phpunit/CRM/Contribute/BAO/ContributionRecurTest.php
+++ b/tests/phpunit/CRM/Contribute/BAO/ContributionRecurTest.php
@@ -451,7 +451,7 @@ class CRM_Contribute_BAO_ContributionRecurTest extends CiviUnitTestCase {
     // Third renewal (4th payment).
     $order = $this->callAPISuccess('Contribution', 'repeattransaction', [
       'contribution_recur_id' => $contributionRecurId,
-      'contribution_status_id' => 'Completed'
+      'contribution_status_id' => 'Completed',
     ]);
     $contribution = $this->callAPISuccessGetSingle('Contribution', ['id' => $order['id']]);
     $this->assertEquals(150, $contribution['total_amount']);
@@ -507,7 +507,7 @@ class CRM_Contribute_BAO_ContributionRecurTest extends CiviUnitTestCase {
     // Update the template contribution to total amount 100
     $this->callAPISuccess('Contribution', 'create', [
       'id' => $templateContributionId,
-      'total_amount' => 100
+      'total_amount' => 100,
     ]);
 
     // At this moment Contact 2 is deceased, but we wait until payment is recorded in civi before marking the contact deceased.


### PR DESCRIPTION
Overview
----------------------------------------

When a recurring contribution is created and the first contribution is added then a template contribution is created from this contribution.

This PR is part of the work done for https://lab.civicrm.org/dev/financial/-/issues/6

UI improvements have been done in the following PRs. Ideally those should be merged before this one otherwise we might end up with wrong reports.

* Fix for excluding template contributions from reports: https://github.com/civicrm/civicrm-core/pull/20450
* Fix for searching template contributions: https://github.com/civicrm/civicrm-core/pull/20451
* Fix for excluding template contribution on the contact summary (and add a button to view the template on the recurring contributions tab): https://github.com/civicrm/civicrm-core/pull/20452

Before
----------------------------------------

Not possible to create template contribution

After
----------------------------------------

After a recurring contribution is created a template contribution is created.

Technical Details
----------------------------------------

When a on behalf of contribution is created through a contribution page, an activity is added for this template contribution. 

Comments
----------------------------------------

See https://lab.civicrm.org/dev/financial/-/issues/6
And https://lab.civicrm.org/dev/core/-/issues/2624
