### PR TITLE
SearchKit - Organize ON clause field selectors with joined entity first

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin/compose/criteria.html
+++ b/ext/search_kit/ang/crmSearchAdmin/compose/criteria.html
@@ -9,9 +9,9 @@
             <i class="crm-i fa-trash" aria-hidden="true"></i>
           </button>
         </div>
-        <fieldset class="api4-clause-fieldset">
-          <crm-search-clause clauses="join" format="json" skip="2 + getJoin(join[0]).conditions.length" op="AND" label="{{:: ts('If') }}" fields="fieldsForWhere" ></crm-search-clause>
-        </fieldset>
+        <div class="api4-clause-fieldset">
+          <crm-search-clause clauses="join" format="json" skip="2 + getJoin(join[0]).conditions.length" op="AND" label="{{:: ts('If') }}" hide-label="true" placeholder="ts('Add Condition')" fields="fieldsForJoin(join[0])" ></crm-search-clause>
+        </div>
       </fieldset>
       <fieldset>
         <div class="form-inline">

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchClause.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchClause.component.js
@@ -9,6 +9,8 @@
       op: '@',
       skip: '<',
       label: '@',
+      hideLabel: '@',
+      placeholder: '<',
       deleteGroup: '&'
     },
     templateUrl: '~/crmSearchAdmin/crmSearchClause.html',

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchClause.html
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchClause.html
@@ -1,4 +1,4 @@
-<legend>{{ $ctrl.label || ts('%1 group', {1: $ctrl.conjunctions[$ctrl.op]}) }}</legend>
+<legend ng-if="!$ctrl.hideLabel">{{ $ctrl.label || ts('%1 group', {1: $ctrl.conjunctions[$ctrl.op]}) }}</legend>
 <div class="btn-group btn-group-xs" ng-if=":: $ctrl.hasParent">
   <button type="button" class="btn btn-danger-outline" ng-click="$ctrl.deleteGroup()" title="{{:: ts('Remove group') }}">
     <i class="crm-i fa-trash" aria-hidden="true"></i>
@@ -15,7 +15,7 @@
         </span>
       </div>
       <div ng-if="!$ctrl.conjunctions[clause[0]]" class="api4-input-group">
-        <input class="form-control" ng-model="clause[0]" crm-ui-select="{data: $ctrl.fields, allowClear: true, placeholder: 'Field'}" ng-change="$ctrl.changeClauseField(clause, index)" />
+        <input class="form-control collapsible-optgroups" ng-model="clause[0]" crm-ui-select="{data: $ctrl.fields, allowClear: true, placeholder: 'Field'}" ng-change="$ctrl.changeClauseField(clause, index)" />
         <select class="form-control api4-operator" ng-model="clause[1]" ng-options="o.key as o.value for o in $ctrl.operators" ng-change="$ctrl.changeClauseOperator(clause)" ></select>
         <crm-search-input ng-if="$ctrl.operatorTakesInput(clause[1])" ng-model="clause[2]" field="$ctrl.getField(clause[0])" option-key="$ctrl.getOptionKey(clause[0])" op="clause[1]" format="$ctrl.format" class="form-group"></crm-search-input>
       </div>
@@ -38,5 +38,5 @@
       </ul>
     </div>
   </div>
-  <input class="form-control" ng-model="$ctrl.newClause" ng-change="$ctrl.addClause()" crm-ui-select="{data: $ctrl.fields, placeholder: ts('Select field')}" />
+  <input class="form-control collapsible-optgroups" ng-model="$ctrl.newClause" ng-change="$ctrl.addClause()" crm-ui-select="{data: $ctrl.fields, placeholder: $ctrl.placeholder || ts('Select field')}" />
 </div>


### PR DESCRIPTION
Overview
----------------------------------------
Organize dropdown for selecting ON clause in SearchKit so the joined entity is first in the list, followed by the main entity.

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/2874912/120233523-fbdada80-c223-11eb-9a66-89c6efc076ab.png)


After
----------------------------------------
![image](https://user-images.githubusercontent.com/2874912/120233468-da79ee80-c223-11eb-9a41-aafa68ac9db5.png)
