### PR TITLE
APIv4 - Return id_field as part of Entity.get

### DIFF
--- a/Civi/Api4/Entity.php
+++ b/Civi/Api4/Entity.php
@@ -86,6 +86,10 @@ class Entity extends Generic\AbstractEntity {
           'description' => 'Class name for dao-based entities',
         ],
         [
+          'name' => 'id_field',
+          'description' => 'Name of unique identifier field (e.g. "id")',
+        ],
+        [
           'name' => 'label_field',
           'description' => 'Field to show when displaying a record',
         ],

--- a/Civi/Api4/Generic/AbstractEntity.php
+++ b/Civi/Api4/Generic/AbstractEntity.php
@@ -139,6 +139,7 @@ abstract class AbstractEntity {
       'type' => [self::stripNamespace(get_parent_class(static::class))],
       'paths' => static::getEntityPaths(),
       'class' => static::class,
+      'id_field' => 'id',
     ];
     // Add info for entities with a corresponding DAO
     $dao = \CRM_Core_DAO_AllCoreTables::getFullName($info['name']);

--- a/Civi/Api4/Generic/BasicEntity.php
+++ b/Civi/Api4/Generic/BasicEntity.php
@@ -132,8 +132,17 @@ abstract class BasicEntity extends AbstractEntity {
    * @return BasicReplaceAction
    */
   public static function replace($checkPermissions = TRUE) {
-    return (new BasicReplaceAction(static::getEntityName(), __FUNCTION__))
+    return (new BasicReplaceAction(static::getEntityName(), __FUNCTION__, static::$idField))
       ->setCheckPermissions($checkPermissions);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public static function getInfo() {
+    $info = parent::getInfo();
+    $info['id_field'] = static::$idField;
+    return $info;
   }
 
 }

--- a/ext/afform/core/Civi/Api4/Afform.php
+++ b/ext/afform/core/Civi/Api4/Afform.php
@@ -224,4 +224,13 @@ class Afform extends Generic\AbstractEntity {
     ];
   }
 
+  /**
+   * @inheritDoc
+   */
+  public static function getInfo() {
+    $info = parent::getInfo();
+    $info['id_field'] = 'name';
+    return $info;
+  }
+
 }

--- a/tests/phpunit/api/v4/Mock/Api4/MockBasicEntity.php
+++ b/tests/phpunit/api/v4/Mock/Api4/MockBasicEntity.php
@@ -28,6 +28,8 @@ use api\v4\Mock\MockEntityDataStorage;
  */
 class MockBasicEntity extends Generic\BasicEntity {
 
+  protected static $idField = 'identifier';
+
   protected static $getter = [MockEntityDataStorage::CLASS, 'get'];
   protected static $setter = [MockEntityDataStorage::CLASS, 'write'];
   protected static $deleter = [MockEntityDataStorage::CLASS, 'delete'];
@@ -39,7 +41,7 @@ class MockBasicEntity extends Generic\BasicEntity {
     return (new Generic\BasicGetFieldsAction(__CLASS__, __FUNCTION__, function() {
       return [
         [
-          'name' => 'id',
+          'name' => 'identifier',
           'data_type' => 'Integer',
         ],
         [
@@ -94,9 +96,9 @@ class MockBasicEntity extends Generic\BasicEntity {
    * @return Generic\BasicBatchAction
    */
   public static function batchFrobnicate($checkPermissions = TRUE) {
-    return (new Generic\BasicBatchAction(__CLASS__, __FUNCTION__, ['id', 'number'], function($item) {
+    return (new Generic\BasicBatchAction(__CLASS__, __FUNCTION__, ['identifier', 'number'], function($item) {
       return [
-        'id' => $item['id'],
+        'identifier' => $item['identifier'],
         'frobnication' => $item['number'] * $item['number'],
       ];
     }))->setCheckPermissions($checkPermissions);

--- a/tests/phpunit/api/v4/Mock/MockEntityDataStorage.php
+++ b/tests/phpunit/api/v4/Mock/MockEntityDataStorage.php
@@ -33,18 +33,18 @@ class MockEntityDataStorage {
   }
 
   public static function write($record) {
-    if (empty($record['id'])) {
-      $record['id'] = self::$nextId++;
-      self::$data[$record['id']] = $record;
+    if (empty($record['identifier'])) {
+      $record['identifier'] = self::$nextId++;
+      self::$data[$record['identifier']] = $record;
     }
     else {
-      self::$data[$record['id']] = $record + self::$data[$record['id']];
+      self::$data[$record['identifier']] = $record + self::$data[$record['identifier']];
     }
     return $record;
   }
 
   public static function delete($record) {
-    unset(self::$data[$record['id']]);
+    unset(self::$data[$record['identifier']]);
     return $record;
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Improves APIv4 metadata so it returns the name of the unique identifier field for each entity (usually but not always named "id").

Technical Details
-------------

All entities have a unique identifier field, usually named 'id' but some entities the field is named something else. e.g. Afform uses 'name' as the identifier.

This returns the name of the field as part of `Entity.get`, and it's also available directly from each API class e.g. `Contact::getInfo()`.
