### PR TITLE
  [Ref] Remove function parameter only used from test

### DIFF
--- a/CRM/Logging/Schema.php
+++ b/CRM/Logging/Schema.php
@@ -518,10 +518,8 @@ AND    (TABLE_NAME LIKE 'log_civicrm_%' $nonStandardTableNameString )
 
   /**
    * Fix schema differences.
-   *
-   * @param bool $rebuildTrigger
    */
-  public function fixSchemaDifferencesForAll($rebuildTrigger = FALSE) {
+  public function fixSchemaDifferencesForAll(): void {
     $diffs = [];
     $this->resetTableColumnsCache();
 
@@ -536,10 +534,6 @@ AND    (TABLE_NAME LIKE 'log_civicrm_%' $nonStandardTableNameString )
 
     foreach ($diffs as $table => $cols) {
       $this->fixSchemaDifferencesFor($table, $cols);
-    }
-    if ($rebuildTrigger) {
-      // invoke the meta trigger creation call
-      CRM_Core_DAO::triggerRebuild(NULL, TRUE);
     }
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
  [Ref] Remove function parameter only used from test

Before
----------------------------------------

![image](https://user-images.githubusercontent.com/336308/120274417-eccb5980-c303-11eb-9b5a-78fbf75e01e3.png)

After
----------------------------------------
$rebuildTriggers parameter removed

Technical Details
----------------------------------------
   The test passes a function parameter to rebuild triggers but the only other
    call to this function in the civi-verse doesn't. We shouldn't make this function
    more complex for just the test.


Comments
----------------------------------------
There could be some test caching issues that need re-solving - will see what jenkins says - as this was obviously at least in part there for that