### PR TITLE
[Ref] Remove enableLogging from fixSchemaDifferences

### DIFF
--- a/CRM/Logging/Schema.php
+++ b/CRM/Logging/Schema.php
@@ -272,26 +272,26 @@ AND    (TABLE_NAME LIKE 'log_civicrm_%' $nonStandardTableNameString )
   /**
    * Enable site-wide logging.
    */
-  public function enableLogging() {
-    $this->fixSchemaDifferences(TRUE);
+  public function enableLogging(): void {
+    $this->fixSchemaDifferencesForAll();
+    Civi::service('sql_triggers')->rebuild();
     $this->addReports();
   }
 
   /**
    * Sync log tables and rebuild triggers.
-   *
-   * @param bool $enableLogging : Ensure logging is enabled
    */
-  public function fixSchemaDifferences($enableLogging = FALSE) {
-    $config = CRM_Core_Config::singleton();
-    if ($enableLogging) {
-      $config->logging = TRUE;
-    }
-    if ($config->logging) {
+  public function fixSchemaDifferences(): void {
+    if (Civi::settings()->get('logging')) {
       $this->fixSchemaDifferencesForAll();
     }
-    // invoke the meta trigger creation call
-    CRM_Core_DAO::triggerRebuild(NULL, TRUE);
+    else {
+      // It is unclear if this is needed but it is done during
+      // the above fixSchemaDifferences call and might help
+      // if the static holds older schema info.
+      $this->resetTableColumnsCache();
+    }
+    Civi::service('sql_triggers')->rebuild();
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
[Ref] Remove enableLogging from fixSchemaDifferences

Before
----------------------------------------
input variable enableLogging overrides the config variable

After
----------------------------------------
The config variable is used - this is set by virtue of the setting being set

Technical Details
----------------------------------------
fixSchemaDifferences is only called from Schema->enableLogging(). This is normally
called after the setting for logging has been altered (there is a toggle
value call to onToggle which calls this.

There are some places where enableLogging is called directly - ie
1) unit tests - I have put up
https://github.com/civicrm/civicrm-core/pull/20460 to fix
2) extensions - there are 2 extensions in git universe that call it directly.
However, they ALSO call Civi::settings::set('logging', 1) so the call
to enableLogging is entirely redundant in those extensions


Comments
----------------------------------------
@demeritcowboy one of the 2 extensions that calls this is one of yours - civicaserevisionmigrator - the other is giftaid

![image](https://user-images.githubusercontent.com/336308/120277727-87c63280-c308-11eb-9b16-e9b4d4d40a16.png)
