### PR TITLE
[Ref] Remove extraneous dropTriggers call from disableLogging

### DIFF
--- a/CRM/Logging/Schema.php
+++ b/CRM/Logging/Schema.php
@@ -213,15 +213,8 @@ AND    (TABLE_NAME LIKE 'log_civicrm_%' $nonStandardTableNameString )
   /**
    * Disable logging by dropping the triggers (but keep the log tables intact).
    */
-  public function disableLogging() {
-    $config = CRM_Core_Config::singleton();
-    $config->logging = FALSE;
-
-    $this->dropTriggers();
-
-    // invoke the meta trigger creation call
-    CRM_Core_DAO::triggerRebuild();
-
+  public function disableLogging(): void {
+    Civi::service('sql_triggers')->rebuild();
     $this->deleteReports();
   }
 
@@ -920,7 +913,7 @@ COLS;
    * @param bool $force
    */
   public function triggerInfo(&$info, $tableName = NULL, $force = FALSE) {
-    if (!CRM_Core_Config::singleton()->logging) {
+    if (!Civi::settings()->get('logging')) {
       return;
     }
 


### PR DESCRIPTION


Overview
----------------------------------------
[Ref] Remove extraneous dropTriggers call from disableLogging

Before
----------------------------------------
First the setting is disabled, which fixes the config value, then disableLogging is called, which makes the same change to the config value then dropTriggers is called then rebuildTriggers is called (via the deprecated function) which also calls dropTriggers

After
----------------------------------------
1 - the setting of config->logging is not duplicated - note this function is called directly rather than via the setting in the same places as enableLogging as discussed in #20461 so it should be fully redundant once #20460 is merged 

2 - use non-deprecated method to rebuild triggers - it's the same but a little more annoying as you can't follow it in your IDE and non-deprecated

3 - redundant call to dropTriggers is gone

Technical Details
----------------------------------------
The dropTriggers call is fairly expensive so good to reduce calls to it

Comments
----------------------------------------