### PR TITLE
Don't pass doPayment by reference in Contribution.transact API

### DIFF
--- a/api/v3/Contribution/Transact.php
+++ b/api/v3/Contribution/Transact.php
@@ -58,7 +58,7 @@ function civicrm_api3_contribution_transact($params) {
   $params['invoice_id'] = CRM_Utils_Array::value('invoice_id', $params, md5(uniqid(rand(), TRUE)));
 
   $paymentProcessor = CRM_Financial_BAO_PaymentProcessor::getPayment($params['payment_processor'], $params['payment_processor_mode']);
-  $paymentProcessor['object']->doPayment($params);
+  $params = $paymentProcessor['object']->doPayment($params);
 
   $params['payment_instrument_id'] = $paymentProcessor['object']->getPaymentInstrumentID();
 


### PR DESCRIPTION
Overview
----------------------------------------
API3 `Contribution.transact` is deprecated. However it is the only place in core (and extensions as far as I could see) that uses `doPayment($params)` by reference instead of using the returned params. This fixes that.

Before
----------------------------------------
Uses params from `doPayment($params)` by reference

After
----------------------------------------
Uses params from `$params = doPayment($params)` by return values from function.

Technical Details
----------------------------------------
Technically doPayment() allows params to be passed by reference. That should never have been the case but it is. The only place I can see in core + extensions is here. Changing this makes further steps to control returned parameters easier to implement - https://lab.civicrm.org/dev/financial/-/issues/141

Comments
----------------------------------------

