### PR TITLE
Bump DOMPDF to `~1.0.0`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
   "require": {
     "php": "~7.2",
     "cache/integration-tests": "~0.17.0",
-    "dompdf/dompdf" : "~0.8",
+    "dompdf/dompdf" : "~1.0.0",
     "firebase/php-jwt": ">=3 <6",
     "electrolinux/phpquery": "^0.9.6",
     "symfony/config": "~3.0 || ~4.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2949934973e5f1ae8054ec0a12bfc2b6",
+    "content-hash": "590aac2df1e4ce1d1d144fe806be6630",
     "packages": [
         {
             "name": "adrienrn/php-mimetyper",
@@ -566,16 +566,16 @@
         },
         {
             "name": "dompdf/dompdf",
-            "version": "v0.8.6",
+            "version": "v1.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/dompdf/dompdf.git",
-                "reference": "db91d81866c69a42dad1d2926f61515a1e3f42c5"
+                "reference": "8768448244967a46d6e67b891d30878e0e15d25c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/dompdf/dompdf/zipball/db91d81866c69a42dad1d2926f61515a1e3f42c5",
-                "reference": "db91d81866c69a42dad1d2926f61515a1e3f42c5",
+                "url": "https://api.github.com/repos/dompdf/dompdf/zipball/8768448244967a46d6e67b891d30878e0e15d25c",
+                "reference": "8768448244967a46d6e67b891d30878e0e15d25c",
                 "shasum": ""
             },
             "require": {
@@ -583,11 +583,11 @@
                 "ext-mbstring": "*",
                 "phenx/php-font-lib": "^0.5.2",
                 "phenx/php-svg-lib": "^0.3.3",
-                "php": "^7.1"
+                "php": "^7.1 || ^8.0"
             },
             "require-dev": {
                 "mockery/mockery": "^1.3",
-                "phpunit/phpunit": "^7.5",
+                "phpunit/phpunit": "^7.5 || ^8 || ^9",
                 "squizlabs/php_codesniffer": "^3.5"
             },
             "suggest": {
@@ -630,7 +630,11 @@
             ],
             "description": "DOMPDF is a CSS 2.1 compliant HTML to PDF converter",
             "homepage": "https://github.com/dompdf/dompdf",
-            "time": "2020-08-30T22:54:22+00:00"
+            "support": {
+                "issues": "https://github.com/dompdf/dompdf/issues",
+                "source": "https://github.com/dompdf/dompdf/tree/v1.0.2"
+            },
+            "time": "2021-01-08T14:18:52+00:00"
         },
         {
             "name": "electrolinux/phpquery",


### PR DESCRIPTION
Having reviewed the changelogs and actual changes here https://github.com/dompdf/dompdf/releases and following a run-test on this I can't find any broken functionality as a result of this upgrade.

There are numerous fixes and improvements in this and the next planned version 1.0.3 will further improve SVG handling.

Overview
----------------------------------------
_Update DOMPDF from `~0.8` to `~1.0.0`._

Before
----------------------------------------
_What is the old user-interface or technical-contract (as appropriate)?_
_Using the older `0.8.6` release of DOMPDF._

After
----------------------------------------
_What changed? What is new old user-interface or technical-contract?_
_Using the new `1.0.2` release of DOMPDF._
