### PR TITLE
SearchKit - Update `hook_civicrm_searchKitTasks` signature

### DIFF
--- a/ext/search_kit/search_kit.php
+++ b/ext/search_kit/search_kit.php
@@ -45,11 +45,13 @@ function search_kit_civicrm_managed(&$entities) {
  */
 function search_kit_civicrm_angularModules(&$angularModules) {
   _search_kit_civix_civicrm_angularModules($angularModules);
-  // Fetch all search tasks provided by other modules and add them as crmSearchTasks dependencies
-  $tasks = $dependencies = [];
+  // Fetch all search tasks provided by extensions and add their Angular modules as crmSearchTasks dependencies
+  $tasks = [];
   $null = NULL;
-  CRM_Utils_Hook::singleton()->invoke(['tasks'], $tasks,
-    $null, $null, $null, $null, $null, 'civicrm_searchKitTasks'
+  $checkPermissions = FALSE;
+  \CRM_Utils_Hook::singleton()->invoke(['tasks', 'checkPermissions', 'userId'],
+    $tasks, $checkPermissions, $null,
+    $null, $null, $null, 'civicrm_searchKitTasks'
   );
   foreach ($tasks as $entityTasks) {
     foreach ($entityTasks as $task) {


### PR DESCRIPTION
Overview
----------------------------------------
Update `hook_civicrm_searchKitTasks` signature  to include `checkPermissions` and `userId`.

Before
----------------------------------------
Hook signature has 1 param.

After
----------------------------------------
Hook signature has 3 params.

Notes
----------------------------------------
It's a slightly confusing bit of code due to the dual-purpose nature of the hook - it's used both to gather an array of tasks *and* to get a full list of Angular modules which provide tasks. That's why this hook needs the base-level array and not just the array of tasks for `$this->entity`.
Although it may seem wasteful to have extensions add tasks for all possible entities and then the API discards most of it (all but the ones relevant to `$this->entity`), it's necessary to do it this way so that `search_kit_civicrm_angularModules()` can gather Angular dependencies.