### PR TITLE
Fix Schema calculation of usePrefix to cope with rpow:

### DIFF
--- a/CRM/Logging/Schema.php
+++ b/CRM/Logging/Schema.php
@@ -26,7 +26,13 @@ class CRM_Logging_Schema {
   private $logs = [];
   private $tables = [];
 
+  /**
+   * Name of the database where the logging data is stored.
+   *
+   * @var string
+   */
   private $db;
+
   private $useDBPrefix = TRUE;
 
   private $reports = [
@@ -113,8 +119,7 @@ class CRM_Logging_Schema {
    * Populate $this->tables and $this->logs with current db state.
    */
   public function __construct() {
-    $dao = new CRM_Contact_DAO_Contact();
-    $civiDBName = $dao->_database;
+    $civiDBName = $this->getCiviCRMDatabaseName();
 
     $dao = CRM_Core_DAO::executeQuery("
 SELECT TABLE_NAME
@@ -157,17 +162,8 @@ AND    TABLE_NAME LIKE 'civicrm_%'
     $this->tables = array_keys($this->logTableSpec);
     $nonStandardTableNameString = $this->getNonStandardTableNameFilterString();
 
-    if (defined('CIVICRM_LOGGING_DSN')) {
-      $dsn = CRM_Utils_SQL::autoSwitchDSN(CIVICRM_LOGGING_DSN);
-      $dsn = DB::parseDSN($dsn);
-      $this->useDBPrefix = (CIVICRM_LOGGING_DSN != CIVICRM_DSN);
-    }
-    else {
-      $dsn = CRM_Utils_SQL::autoSwitchDSN(CIVICRM_DSN);
-      $dsn = DB::parseDSN($dsn);
-      $this->useDBPrefix = FALSE;
-    }
-    $this->db = $dsn['database'];
+    $this->db = $this->getDatabaseNameFromDSN(defined('CIVICRM_LOGGING_DSN') ? CIVICRM_LOGGING_DSN : CIVICRM_DSN);
+    $this->useDBPrefix = $this->db !== $civiDBName;
 
     $dao = CRM_Core_DAO::executeQuery("
 SELECT TABLE_NAME
@@ -1062,6 +1058,33 @@ COLS;
       return array_diff($this->tables, array_keys($this->logs));
     }
     return [];
+  }
+
+  /**
+   * Get the name of the database from the dsn string.
+   *
+   * @param string $dsnString
+   *
+   * @return string
+   */
+  protected function getDatabaseNameFromDSN($dsnString): string {
+    $dsn = CRM_Utils_SQL::autoSwitchDSN($dsnString);
+    $dsn = DB::parseDSN($dsn);
+    return $dsn['database'];
+  }
+
+  /**
+   * Get the database name for the CiviCRM connection.
+   *
+   * Note that we want to get it from the database connection,
+   * not the dsn, because there is at least one extension
+   * (https://github.com/totten/rpow) that 'meddles' with
+   * the DSN string.
+   *
+   * @return string
+   */
+  protected function getCiviCRMDatabaseName(): string {
+    return (new CRM_Contact_DAO_Contact())->_database;
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
This fixes the code in the logging schema to calculate $usePrefix based on whether the logging database name matches the civicrm database name, not the whole string. 

$usePrefix is used to determine whether to prepend the database name in the triggers - ie 



Before
----------------------------------------
database name is prepended into the string when rpow is in play

```
CREATE TRIGGER civicrm_activity_after_update ... THEN INSERT INTO `civi_database`.log_civicrm_activity 
```

This would also happen if different db users were used for the 2 databases (I can't think of any reason why they would be) - but the user difference would not flow through in any way.

After
----------------------------------------
```
CREATE TRIGGER civicrm_activity_after_update ... THEN INSERT INTO log_civicrm_activity 
```

Technical Details
----------------------------------------
Getting usePrefix right helps with portability as we avoid hard-coding the database name unless it is necessary.

The previous code was comparing the whole DSN - which will not match when (rpow)[https://github.com/totten/rpow] is in use. However, we are only using it to determine if the db name is the same (we don't write user or db host into the trigger anyway) & comparing just database gives a better result

Comments
----------------------------------------
I don't think a reviewer needs to test this in the rpow context - I think that as long as a reviewer experiences this as no change it's fine 