### PR TITLE
Improve output triggers when logged to file

### DIFF
--- a/CRM/Logging/Schema.php
+++ b/CRM/Logging/Schema.php
@@ -230,7 +230,7 @@ AND    (TABLE_NAME LIKE 'log_civicrm_%' $nonStandardTableNameString )
    *
    * @param string $tableName
    */
-  public function dropTriggers($tableName = NULL) {
+  public function dropTriggers($tableName = NULL): void {
     /** @var \Civi\Core\SqlTriggers $sqlTriggers */
     $sqlTriggers = Civi::service('sql_triggers');
     $dao = new CRM_Core_DAO();
@@ -244,7 +244,7 @@ AND    (TABLE_NAME LIKE 'log_civicrm_%' $nonStandardTableNameString )
 
     // Sort the table names so the sql output is consistent for those sites
     // loading it asynchronously (using the setting 'logging_no_trigger_permission')
-    asort($tableNames);
+    ksort($tableNames);
     foreach ($tableNames as $table) {
       $validName = CRM_Core_DAO::shortenSQLName($table, 48, TRUE);
 


### PR DESCRIPTION
Overview
----------------------------------------
When logging is enabled or disabled with the setting logging_no_trigger_permission set to TRUE the trigger sql is output to a file instead of being run. This is used by wmf & probably no-one else. 

The issue we are having is the output sql has become a bit messy & inconsistent in terms of

1) extraneous db names in it https://github.com/civicrm/civicrm-core/pull/20471
2) the sorting of the tables has somehow changed making a diff tricky
3) duplication - the calculation of triggers to drop happens more than once - resulting in them all being written out once and then being interspersed into the create statements
4) verbosity - the separators are unset & reset after each line.

This cleans it up by
1) see #20471 
2) adding an asort
3) putting all the triggers into an array keyed by the statements (for deduping) and only outputting them on class destruct
4) with them all being written at once we can open and close the delimiters just once


Before
----------------------------------------
`drush cvapi Setting.create logging_no_trigger_permission=1`
`drush cvapi Setting.create logging=1`

The output is to a file in config and log - it is overly verbose

![image](https://user-images.githubusercontent.com/336308/122313943-4ae67680-cf6b-11eb-938a-169d81c9f093.png)

After
----------------------------------------
Per above but logging is less verbose

Technical Details
----------------------------------------

Comments
----------------------------------------
