### PR TITLE
[php8-compat] Fix deprecation error where by required function parame…

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -1265,7 +1265,7 @@ WHERE entity_id =%1 AND entity_table = %2";
    * @throws CRM_Core_Exception
    */
   public static function sendSMS(
-    &$contactDetails = NULL,
+    &$contactDetails,
     &$activityParams,
     &$smsProviderParams = [],
     &$contactIds = NULL,
@@ -1417,7 +1417,7 @@ WHERE entity_id =%1 AND entity_table = %2";
   public static function sendSMSMessage(
     $toID,
     &$tokenText,
-    $smsProviderParams = [],
+    $smsProviderParams,
     $activityID,
     $sourceContactID = NULL
   ) {

--- a/CRM/Batch/BAO/Batch.php
+++ b/CRM/Batch/BAO/Batch.php
@@ -617,7 +617,7 @@ class CRM_Batch_BAO_Batch extends CRM_Batch_DAO_Batch {
    * @param array $batchIds
    * @param $status
    */
-  public static function closeReOpen($batchIds = [], $status) {
+  public static function closeReOpen($batchIds, $status) {
     $batchStatus = CRM_Core_PseudoConstant::get('CRM_Batch_DAO_Batch', 'status_id');
     $params['status_id'] = CRM_Utils_Array::key($status, $batchStatus);
     $session = CRM_Core_Session::singleton();

--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -400,7 +400,7 @@ WHERE cc.contact_id = %1 AND civicrm_case_type.name = '{$caseType}'";
    *
    * @return string
    */
-  public static function getCaseActivityCountQuery($type = 'upcoming', $userID, $condition = NULL) {
+  public static function getCaseActivityCountQuery($type, $userID, $condition = NULL) {
     return sprintf(" SELECT COUNT(*) FROM (%s) temp ", self::getCaseActivityQuery($type, $userID, $condition));
   }
 
@@ -413,7 +413,7 @@ WHERE cc.contact_id = %1 AND civicrm_case_type.name = '{$caseType}'";
    *
    * @return string
    */
-  public static function getCaseActivityQuery($type = 'upcoming', $userID, $condition = NULL, $limit = NULL, $order = NULL) {
+  public static function getCaseActivityQuery($type, $userID, $condition = NULL, $limit = NULL, $order = NULL) {
     $selectClauses = [
       'civicrm_case.id as case_id',
       'civicrm_case.subject as case_subject',
@@ -1258,7 +1258,7 @@ HERESQL;
    *
    * @return bool |array
    */
-  public static function sendActivityCopy($clientId, $activityId, $contacts, $attachments = NULL, $caseId) {
+  public static function sendActivityCopy($clientId, $activityId, $contacts, $attachments, $caseId) {
     if (!$activityId) {
       return FALSE;
     }

--- a/CRM/Contribute/BAO/ContributionPage.php
+++ b/CRM/Contribute/BAO/ContributionPage.php
@@ -831,7 +831,7 @@ LEFT JOIN  civicrm_premiums            ON ( civicrm_premiums.entity_id = civicrm
    *
    * @return array|string
    */
-  public static function formatModuleData($params, $setDefault = FALSE, $module) {
+  public static function formatModuleData($params, $setDefault, $module) {
     $tsLocale = CRM_Core_I18n::getLocale();
     $config = CRM_Core_Config::singleton();
     $json = $jsonDecode = NULL;

--- a/CRM/Core/BAO/Setting.php
+++ b/CRM/Core/BAO/Setting.php
@@ -96,7 +96,7 @@ class CRM_Core_BAO_Setting extends CRM_Core_DAO_Setting {
    *
    * @return array
    */
-  public static function getItems(&$params, $domains = NULL, $settingsToReturn) {
+  public static function getItems(&$params, $domains, $settingsToReturn) {
     $originalDomain = CRM_Core_Config::domainID();
     if (empty($domains)) {
       $domains[] = $originalDomain;

--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -1327,7 +1327,7 @@ ORDER BY   civicrm_email.is_bulkmail DESC
    *
    * @return bool|mixed|null|string
    */
-  private function getTokenData(&$token_a, $html = FALSE, &$contact, &$verp, &$urls, $event_queue_id) {
+  private function getTokenData(&$token_a, $html, &$contact, &$verp, &$urls, $event_queue_id) {
     $type = $token_a['type'];
     $token = $token_a['token'];
     $data = $token;

--- a/CRM/Mailing/Event/BAO/TrackableURLOpen.php
+++ b/CRM/Mailing/Event/BAO/TrackableURLOpen.php
@@ -271,8 +271,8 @@ class CRM_Mailing_Event_BAO_TrackableURLOpen extends CRM_Mailing_Event_DAO_Track
    *   Result set
    */
   public static function &getRows(
-    $mailing_id, $job_id = NULL,
-    $is_distinct = FALSE, $url_id,
+    $mailing_id, $job_id,
+    $is_distinct, $url_id,
     $offset = NULL, $rowCount = NULL, $sort = NULL, $contact_id = NULL
   ) {
 

--- a/CRM/Mailing/Event/BAO/Unsubscribe.php
+++ b/CRM/Mailing/Event/BAO/Unsubscribe.php
@@ -299,7 +299,7 @@ WHERE  email = %2
    * @param int $job
    *   The job ID.
    */
-  public static function send_unsub_response($queue_id, $groups, $is_domain = FALSE, $job) {
+  public static function send_unsub_response($queue_id, $groups, $is_domain, $job) {
     $config = CRM_Core_Config::singleton();
     $domain = CRM_Core_BAO_Domain::getDomain();
     $jobObject = new CRM_Mailing_BAO_MailingJob();

--- a/CRM/Price/BAO/LineItem.php
+++ b/CRM/Price/BAO/LineItem.php
@@ -424,7 +424,7 @@ WHERE li.contribution_id = %1";
    * @param $amount
    * @param array $otherParams
    */
-  public static function syncLineItems($entityId, $entityTable = 'civicrm_contribution', $amount, $otherParams = NULL) {
+  public static function syncLineItems($entityId, $entityTable, $amount, $otherParams = NULL) {
     if (!$entityId || CRM_Utils_System::isNull($amount)) {
       return;
     }


### PR DESCRIPTION
…ter follows an optional function parameter

Overview
----------------------------------------
This aims to fix the following php8 deprecations

```
Deprecated: Required parameter $status follows optional parameter $batchIds in /home/jenkins/bknix-edge/build/build-1/web/sites/all/modules/civicrm/CRM/Batch/BAO/Batch.php on line 620

Deprecated: Required parameter $settingsToReturn follows optional parameter $domains in /home/jenkins/bknix-edge/build/build-1/web/sites/all/modules/civicrm/CRM/Core/BAO/Setting.php on line 99

Deprecated: Required parameter $module follows optional parameter $setDefault in /home/jenkins/bknix-edge/build/build-1/web/sites/all/modules/civicrm/CRM/Contribute/BAO/ContributionPage.php on line 834

Deprecated: Required parameter $userID follows optional parameter $type in /home/jenkins/bknix-edge/build/build-1/web/sites/all/modules/civicrm/CRM/Case/BAO/Case.php on line 403

Deprecated: Required parameter $userID follows optional parameter $type in /home/jenkins/bknix-edge/build/build-1/web/sites/all/modules/civicrm/CRM/Case/BAO/Case.php on line 416

Deprecated: Required parameter $caseId follows optional parameter $attachments in /home/jenkins/bknix-edge/build/build-1/web/sites/all/modules/civicrm/CRM/Case/BAO/Case.php on line 1261

Deprecated: Required parameter $contact follows optional parameter $html in /home/jenkins/bknix-edge/build/build-1/web/sites/all/modules/civicrm/CRM/Mailing/BAO/Mailing.php on line 1330

Deprecated: Required parameter $verp follows optional parameter $html in /home/jenkins/bknix-edge/build/build-1/web/sites/all/modules/civicrm/CRM/Mailing/BAO/Mailing.php on line 1330

Deprecated: Required parameter $urls follows optional parameter $html in /home/jenkins/bknix-edge/build/build-1/web/sites/all/modules/civicrm/CRM/Mailing/BAO/Mailing.php on line 1330

Deprecated: Required parameter $event_queue_id follows optional parameter $html in /home/jenkins/bknix-edge/build/build-1/web/sites/all/modules/civicrm/CRM/Mailing/BAO/Mailing.php on line 1330

Deprecated: Required parameter $url_id follows optional parameter $job_id in /home/jenkins/bknix-edge/build/build-1/web/sites/all/modules/civicrm/CRM/Mailing/Event/BAO/TrackableURLOpen.php on line 273

Deprecated: Required parameter $job follows optional parameter $is_domain in /home/jenkins/bknix-edge/build/build-1/web/sites/all/modules/civicrm/CRM/Mailing/Event/BAO/Unsubscribe.php on line 302

Deprecated: Required parameter $activityParams follows optional parameter $contactDetails in /home/jenkins/bknix-edge/build/build-1/web/sites/all/modules/civicrm/CRM/Activity/BAO/Activity.php on line 1267

Deprecated: Required parameter $activityID follows optional parameter $smsProviderParams in /home/jenkins/bknix-edge/build/build-1/web/sites/all/modules/civicrm/CRM/Activity/BAO/Activity.php on line 1417

Deprecated: Required parameter $amount follows optional parameter $entityTable in /home/jenkins/bknix-edge/build/build-1/web/sites/all/modules/civicrm/CRM/Price/BAO/LineItem.php on line 427
```

Before
----------------------------------------
Deprecations issued in php8

After
----------------------------------------
No deprecations

ping @eileenmcnaughton @totten 