### PR TITLE
[php8-compat][phpunit8][NFC] Fix PHPUnit Warnings and fix a php error on f…

### DIFF
--- a/ext/afform/mock/ang/mockPublicForm.test.php
+++ b/ext/afform/mock/ang/mockPublicForm.test.php
@@ -13,7 +13,7 @@ class MockPublicFormTest extends \Civi\AfformMock\FormTestCase {
     $this->assertContentType('text/html', $r);
     $this->assertStatusCode(200, $r);
     $body = (string) $r->getBody();
-    $this->assertContains('mockPublicForm', $body);
+    $this->assertStringContainsString('mockPublicForm', $body);
   }
 
   public function testPublicCreateAllowed() {

--- a/ext/afform/mock/tests/phpunit/Civi/AfformMock/FormTestCase.php
+++ b/ext/afform/mock/tests/phpunit/Civi/AfformMock/FormTestCase.php
@@ -29,7 +29,7 @@ abstract class FormTestCase extends \PHPUnit\Framework\TestCase implements \Civi
 
   protected $formName = NULL;
 
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     if ($this->formName === NULL && preg_match(';^(.*)\.test\.php$;', basename(static::FILE), $m)) {
@@ -45,7 +45,7 @@ abstract class FormTestCase extends \PHPUnit\Framework\TestCase implements \Civi
     }
   }
 
-  protected function tearDown() {
+  protected function tearDown(): void {
     parent::tearDown();
   }
 

--- a/ext/flexmailer/tests/phpunit/Civi/FlexMailer/MailingPreviewTest.php
+++ b/ext/flexmailer/tests/phpunit/Civi/FlexMailer/MailingPreviewTest.php
@@ -86,15 +86,15 @@ class MailingPreviewTest extends \CiviUnitTestCase {
     $this->assertEquals("[CiviMail Draft] Hello $displayName",
       $previewResult['values']['subject']);
 
-    $this->assertContains("This is $displayName", $previewResult['values']['body_text']);
-    $this->assertContains("civicrm/mailing/optout", $previewResult['values']['body_text']);
-    $this->assertContains("&jid=&qid=&h=fakehash", $previewResult['values']['body_text']);
-    $this->assertContains("subj=(Hello ", $previewResult['values']['body_text']);
+    $this->assertStringContainsString("This is $displayName", $previewResult['values']['body_text']);
+    $this->assertStringContainsString("civicrm/mailing/optout", $previewResult['values']['body_text']);
+    $this->assertStringContainsString("&jid=&qid=&h=fakehash", $previewResult['values']['body_text']);
+    $this->assertStringContainsString("subj=(Hello ", $previewResult['values']['body_text']);
 
-    $this->assertContains("<p>This is $displayName.</p>", $previewResult['values']['body_html']);
-    $this->assertContains("civicrm/mailing/optout", $previewResult['values']['body_html']);
-    $this->assertContains("&amp;jid=&amp;qid=&amp;h=fakehash", $previewResult['values']['body_html']);
-    $this->assertContains("subj=(Hello ", $previewResult['values']['body_html']);
+    $this->assertStringContainsString("<p>This is $displayName.</p>", $previewResult['values']['body_html']);
+    $this->assertStringContainsString("civicrm/mailing/optout", $previewResult['values']['body_html']);
+    $this->assertStringContainsString("&amp;jid=&amp;qid=&amp;h=fakehash", $previewResult['values']['body_html']);
+    $this->assertStringContainsString("subj=(Hello ", $previewResult['values']['body_html']);
 
     $this->assertEquals('flexmailer', $previewResult['values']['_rendered_by_']);
   }
@@ -115,15 +115,15 @@ class MailingPreviewTest extends \CiviUnitTestCase {
     $this->assertEquals("[CiviMail Draft] Hello $displayName",
       $previewResult['values']['subject']);
 
-    $this->assertContains("This is $displayName", $previewResult['values']['body_text']);
-    $this->assertContains("civicrm/mailing/optout", $previewResult['values']['body_text']);
-    $this->assertContains("&jid=&qid=&h=fakehash", $previewResult['values']['body_text']);
-    $this->assertContains("subj=(Hello ", $previewResult['values']['body_text']);
+    $this->assertStringContainsString("This is $displayName", $previewResult['values']['body_text']);
+    $this->assertStringContainsString("civicrm/mailing/optout", $previewResult['values']['body_text']);
+    $this->assertStringContainsString("&jid=&qid=&h=fakehash", $previewResult['values']['body_text']);
+    $this->assertStringContainsString("subj=(Hello ", $previewResult['values']['body_text']);
 
-    $this->assertContains("<p>This is $displayName.</p>", $previewResult['values']['body_html']);
-    $this->assertContains("civicrm/mailing/optout", $previewResult['values']['body_html']);
-    $this->assertContains("&amp;jid=&amp;qid=&amp;h=fakehash", $previewResult['values']['body_html']);
-    $this->assertContains("subj=(Hello ", $previewResult['values']['body_html']);
+    $this->assertStringContainsString("<p>This is $displayName.</p>", $previewResult['values']['body_html']);
+    $this->assertStringContainsString("civicrm/mailing/optout", $previewResult['values']['body_html']);
+    $this->assertStringContainsString("&amp;jid=&amp;qid=&amp;h=fakehash", $previewResult['values']['body_html']);
+    $this->assertStringContainsString("subj=(Hello ", $previewResult['values']['body_html']);
 
     $this->assertEquals('flexmailer', $previewResult['values']['_rendered_by_']);
   }


### PR DESCRIPTION
…unction declaration syntax in core extension tests

Overview
----------------------------------------
This fixes a few phpunit8 warnings generated

```
# Warning Using assertContains() with string haystacks is deprecated and will not be supported in PHPUnit 9. Refactor your test to use assertStringContainsString() or assertStringContainsStringIgnoringCase() instead.
```

This also fixes an error 

```
Fatal error: Declaration of Civi\AfformMock\FormTestCase::setUp() must be compatible with PHPUnit\Framework\TestCase::setUp(): void in /home/jenkins/bknix-edge/build/build-0/web/sites/all/modules/civicrm/ext/afform/mock/tests/phpunit/Civi/AfformMock/FormTestCase.php on line 32
```

Before
----------------------------------------
Warnings issued in phpunit8 and fatal error triggered

After
----------------------------------------
No warnings and no fatal error

ping @eileenmcnaughton @totten @demeritcowboy @colemanw 