### PR TITLE
dev/core#2636 - Authx - Undefined function in drupal 9 

### DIFF
--- a/ext/authx/Civi/Authx/Drupal8.php
+++ b/ext/authx/Civi/Authx/Drupal8.php
@@ -26,7 +26,7 @@ class Drupal8 implements AuthxInterface {
    * @inheritDoc
    */
   public function loginSession($userId) {
-    $user = user_load($userId);
+    $user = \Drupal\user\Entity\User::load($userId);
     user_login_finalize($user);
   }
 
@@ -41,7 +41,7 @@ class Drupal8 implements AuthxInterface {
    * @inheritDoc
    */
   public function loginStateless($userId) {
-    $user = user_load($userId);
+    $user = \Drupal\user\Entity\User::load($userId);
     // In theory, we could use either account_switcher->switchTo() or current_user->setAccount().
     // switchTo() sounds more conscientious, but setAccount() might be a more accurate rendition
     // of "stateless login". At time of writing, there doesn't seem to be a compelling difference.


### PR DESCRIPTION
Overview
----------------------------------------
`user_load() is deprecated in Drupal 8.0.0 and will be removed before Drupal 9.0.0. Use \Drupal\user\Entity\User::load()`

https://lab.civicrm.org/dev/core/-/issues/2636