### PR TITLE
fix missing 'on behalf of' and honoree labels in multilingual

### DIFF
--- a/CRM/Contribute/BAO/ContributionPage.php
+++ b/CRM/Contribute/BAO/ContributionPage.php
@@ -858,17 +858,17 @@ LEFT JOIN  civicrm_premiums            ON ( civicrm_premiums.entity_id = civicrm
     if ($setDefault) {
       $jsonDecode = json_decode($params);
       $jsonDecode = (array) $jsonDecode->$module;
-      if (!$multilingual && !empty($jsonDecode['default'])) {
-        //monolingual state
-        $jsonDecode += (array) $jsonDecode['default'];
-        unset($jsonDecode['default']);
-      }
-      elseif (!empty($jsonDecode[$tsLocale])) {
+      if ($multilingual && !empty($jsonDecode[$tsLocale])) {
         //multilingual state
         foreach ($jsonDecode[$tsLocale] as $column => $value) {
           $jsonDecode[$column] = $value;
         }
         unset($jsonDecode[$tsLocale]);
+      }
+      elseif (!empty($jsonDecode['default'])) {
+        //monolingual state, or an undefined value in multilingual
+        $jsonDecode += (array) $jsonDecode['default'];
+        unset($jsonDecode['default']);
       }
       return $jsonDecode;
     }


### PR DESCRIPTION
https://lab.civicrm.org/dev/translation/-/issues/69

Overview
----------------------------------------
When converting to multilingual, the monolingual strings become the default value in your multilingual installation.  However, these labels are stored differently, and the default is to have no label at all.  It also generated an "undefined index" notice.

Before
----------------------------------------
![Selection_1109](https://user-images.githubusercontent.com/1796012/120539862-075e0b00-c3b6-11eb-8472-0f4cb88717b8.png)


After
----------------------------------------
![Selection_1108](https://user-images.githubusercontent.com/1796012/120539879-0cbb5580-c3b6-11eb-9a87-1476b0b0e793.png)


Technical Details
----------------------------------------
Previously this code read, "if monolingual, do X.  If multilingual and a localized string exists, do Y."

Now it reads, "If multilingual and a localized string exists, do Y.  Otherwise, do X."
