### PR TITLE
[php8-compat][NFC] Ensure that the 2nd parameter of hash_equals is a …

### DIFF
--- a/ext/authx/Civi/Authx/Authenticator.php
+++ b/ext/authx/Civi/Authx/Authenticator.php
@@ -158,7 +158,7 @@ class Authenticator {
 
       // If any one of these passes, then we allow the authentication.
       $passGuard = [];
-      $passGuard[] = in_array('site_key', $useGuards) && defined('CIVICRM_SITE_KEY') && hash_equals(CIVICRM_SITE_KEY, $tgt->siteKey);
+      $passGuard[] = in_array('site_key', $useGuards) && defined('CIVICRM_SITE_KEY') && hash_equals(CIVICRM_SITE_KEY, (string) $tgt->siteKey);
       $passGuard[] = in_array('perm', $useGuards) && isset($perms[$tgt->credType]) && \CRM_Core_Permission::check($perms[$tgt->credType], $tgt->contactId);
       // JWTs are signed by us. We don't need user to prove that they're allowed to use them.
       $passGuard[] = ($tgt->credType === 'jwt');


### PR DESCRIPTION
…string in authx

Overview
----------------------------------------
This fixes the following error when found running unit tests on php8

```
ERROR\n\n The website encountered an unexpected error. Please try again later. \n\nERROR MESSAGE\n\n _TypeError_: hash_equals(): Argument #2 ($user_string) must be of type\nstring, null given in _hash_equals()_ (line _161_ of\n_/home/jenkins/bknix-edge/build/build-1/web/sites/all/modules/civicrm/ext/authx/Civi/Authx/Authenticator.php_)
```

Before
----------------------------------------
Error found in unit tests

After
----------------------------------------
no error

Technical Details
----------------------------------------
A simple cast here should do the trick

ping @eileenmcnaughton @demeritcowboy @totten 