### PR TITLE
[php8-compat][REF] Fix php8 error on undefined constant CIVICRM_DISAB…

### DIFF
--- a/CRM/Core/Resources/Common.php
+++ b/CRM/Core/Resources/Common.php
@@ -241,7 +241,7 @@ class CRM_Core_Resources_Common {
     if (
       $contactID && !CRM_Core_Config::singleton()->userFrameworkFrontend
       && CRM_Core_Permission::check('access CiviCRM')
-      && !@constant('CIVICRM_DISABLE_DEFAULT_MENU')
+      && !CRM_Utils_Constant::value('CIVICRM_DISABLE_DEFAULT_MENU')
       && !CRM_Core_Config::isUpgradeMode()
     ) {
       $position = $settings->get('menubar_position') ?: 'over-cms-menu';


### PR DESCRIPTION
…LE_DEFAULT_MENU

Overview
----------------------------------------
This fixes the following php8 error

```
skip to main content \n\n BUILD-1 [1] \n\nERROR\n\n The website encountered an unexpected error. Please try again later. \n\nERROR MESSAGE\n\n _Error_: Undefined constant \"CIVICRM_DISABLE_DEFAULT_MENU\" in _constant()_\n(line _244_ of\n_/home/jenkins/bknix-edge/build/build-1/web/sites/all/modules/civicrm/CRM/Core/Resources/Common.php_).\n\n\nLinks:\n------\n[1]
```

Before
----------------------------------------
Error on undefined constant

After
----------------------------------------
No error about undefined constant

Technical Details
----------------------------------------
CRM_Utils_Constant::value does a if defined check before trying to access the value of the constant

ping @eileenmcnaughton @totten @colemanw 