### PR TITLE
Clarify types on `hook_custom` and `hook_customPre`

### DIFF
--- a/CRM/Core/BAO/CustomValue.php
+++ b/CRM/Core/BAO/CustomValue.php
@@ -194,7 +194,7 @@ class CRM_Core_BAO_CustomValue extends CRM_Core_DAO {
     $tableName = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_CustomGroup', $customGroupID, 'table_name');
 
     // Retrieve the $entityId so we can pass that to the hook.
-    $entityID = CRM_Core_DAO::singleValueQuery("SELECT entity_id FROM {$tableName} WHERE id = %1", [
+    $entityID = (int) CRM_Core_DAO::singleValueQuery("SELECT entity_id FROM {$tableName} WHERE id = %1", [
       1 => [$customValueID, 'Integer'],
     ]);
 
@@ -203,7 +203,7 @@ class CRM_Core_BAO_CustomValue extends CRM_Core_DAO {
     CRM_Core_DAO::executeQuery($sql);
 
     CRM_Utils_Hook::custom('delete',
-      $customGroupID,
+      (int) $customGroupID,
       $entityID,
       $customValueID
     );

--- a/CRM/Core/BAO/CustomValueTable.php
+++ b/CRM/Core/BAO/CustomValueTable.php
@@ -48,8 +48,7 @@ class CRM_Core_BAO_CustomValueTable {
         $count = 1;
 
         $firstField = reset($fields);
-        $entityID = $firstField['entity_id'];
-        $hookID = $firstField['custom_group_id'];
+        $entityID = (int) $firstField['entity_id'];
         $isMultiple = $firstField['is_multiple'];
         if (array_key_exists('id', $firstField)) {
           $sqlOP = "UPDATE $tableName ";
@@ -64,8 +63,9 @@ class CRM_Core_BAO_CustomValueTable {
           $hookOP = 'create';
         }
 
-        CRM_Utils_Hook::customPre($hookOP,
-          $hookID,
+        CRM_Utils_Hook::customPre(
+          $hookOP,
+          (int) $firstField['custom_group_id'],
           $entityID,
           $fields
         );
@@ -273,7 +273,7 @@ class CRM_Core_BAO_CustomValueTable {
           CRM_Core_DAO::executeQuery($query, $params);
 
           CRM_Utils_Hook::custom($hookOP,
-            $hookID,
+            (int) $firstField['custom_group_id'],
             $entityID,
             $fields
           );

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -517,9 +517,9 @@ abstract class CRM_Utils_Hook {
    *
    * @param string $op
    *   The type of operation being performed.
-   * @param string $groupID
+   * @param int $groupID
    *   The custom group ID.
-   * @param object $entityID
+   * @param int $entityID
    *   The entityID of the row in the custom table.
    * @param array $params
    *   The parameters that were sent into the calling function.
@@ -527,7 +527,7 @@ abstract class CRM_Utils_Hook {
    * @return null
    *   the return value is ignored
    */
-  public static function custom($op, $groupID, $entityID, &$params) {
+  public static function custom(string $op, int $groupID, int $entityID, &$params) {
     return self::singleton()
       ->invoke(['op', 'groupID', 'entityID', 'params'], $op, $groupID, $entityID, $params, self::$_nullObject, self::$_nullObject, 'civicrm_custom');
   }
@@ -537,9 +537,9 @@ abstract class CRM_Utils_Hook {
    *
    * @param string $op
    *   The type of operation being performed.
-   * @param string $groupID
+   * @param int $groupID
    *   The custom group ID.
-   * @param object $entityID
+   * @param int $entityID
    *   The entityID of the row in the custom table.
    * @param array $params
    *   The parameters that were sent into the calling function.
@@ -547,7 +547,7 @@ abstract class CRM_Utils_Hook {
    * @return null
    *   the return value is ignored
    */
-  public static function customPre($op, $groupID, $entityID, &$params) {
+  public static function customPre(string $op, int $groupID, int $entityID, array &$params) {
     return self::singleton()
       ->invoke(['op', 'groupID', 'entityID', 'params'], $op, $groupID, $entityID, $params, self::$_nullObject, self::$_nullObject, 'civicrm_customPre');
   }


### PR DESCRIPTION

Overview
----------------------------------------
Clarify types on custom hooks

The custom & customPre hooks are not called elsewhere in gituniverse
so we can add type hints and fix casting & comments to make it
clearer what the variables are


Before
----------------------------------------
Types unclear & some incorrectly documented

After
----------------------------------------
Casting, hints, correct docs

Technical Details
----------------------------------------

Comments
----------------------------------------
