### PR TITLE
APIv4 - Cleanup getFields, add @internal flag for non-public field attributes

### DIFF
--- a/Civi/Api4/Generic/AbstractAction.php
+++ b/Civi/Api4/Generic/AbstractAction.php
@@ -440,7 +440,8 @@ abstract class AbstractAction implements \ArrayAccess {
         'includeCustom' => FALSE,
       ]);
       $result = new Result();
-      $getFields->_run($result);
+      // Pass TRUE for the private $isInternal param
+      $getFields->_run($result, TRUE);
       $this->_entityFields = (array) $result->indexBy('name');
     }
     return $this->_entityFields;

--- a/Civi/Api4/Service/Spec/FieldSpec.php
+++ b/Civi/Api4/Service/Spec/FieldSpec.php
@@ -128,7 +128,7 @@ class FieldSpec {
   /**
    * @var callable[]
    */
-  public $outputFormatters = [];
+  public $outputFormatters;
 
   /**
    * Aliases for the valid data types
@@ -391,13 +391,6 @@ class FieldSpec {
   }
 
   /**
-   * @return callable[]
-   */
-  public function getOutputFormatters() {
-    return $this->outputFormatters;
-  }
-
-  /**
    * @param callable[] $outputFormatters
    * @return $this
    */
@@ -412,33 +405,22 @@ class FieldSpec {
    * @return $this
    */
   public function addOutputFormatter($outputFormatter) {
+    if (!$this->outputFormatters) {
+      $this->outputFormatters = [];
+    }
     $this->outputFormatters[] = $outputFormatter;
 
     return $this;
   }
 
   /**
-   * @return bool
-   */
-  public function getreadonly() {
-    return $this->readonly;
-  }
-
-  /**
    * @param bool $readonly
    * @return $this
    */
-  public function setreadonly($readonly) {
+  public function setReadonly($readonly) {
     $this->readonly = (bool) $readonly;
 
     return $this;
-  }
-
-  /**
-   * @return string|NULL
-   */
-  public function getHelpPre() {
-    return $this->helpPre;
   }
 
   /**
@@ -446,13 +428,6 @@ class FieldSpec {
    */
   public function setHelpPre($helpPre) {
     $this->helpPre = is_string($helpPre) && strlen($helpPre) ? $helpPre : NULL;
-  }
-
-  /**
-   * @return string|NULL
-   */
-  public function getHelpPost() {
-    return $this->helpPost;
   }
 
   /**
@@ -464,8 +439,7 @@ class FieldSpec {
 
   /**
    * @param string $customFieldColumnName
-   *
-   * @return CustomFieldSpec
+   * @return $this
    */
   public function setTableName($customFieldColumnName) {
     $this->tableName = $customFieldColumnName;
@@ -528,13 +502,6 @@ class FieldSpec {
   public function setOptionsCallback($callback) {
     $this->optionsCallback = $callback;
     return $this;
-  }
-
-  /**
-   * @return callable
-   */
-  public function getOptionsCallback() {
-    return $this->optionsCallback;
   }
 
   /**

--- a/Civi/Api4/Service/Spec/Provider/CustomValueSpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/CustomValueSpecProvider.php
@@ -32,14 +32,14 @@ class CustomValueSpecProvider implements Generic\SpecProviderInterface {
     if ($action !== 'create') {
       $idField = new FieldSpec('id', $spec->getEntity(), 'Integer');
       $idField->setTitle(ts('Custom Value ID'));
-      $idField->setreadonly(TRUE);
+      $idField->setReadonly(TRUE);
       $spec->addFieldSpec($idField);
     }
     $entityField = new FieldSpec('entity_id', $spec->getEntity(), 'Integer');
     $entityField->setTitle(ts('Entity ID'));
     $entityField->setRequired($action === 'create');
     $entityField->setFkEntity('Contact');
-    $entityField->setreadonly(TRUE);
+    $entityField->setReadonly(TRUE);
     $spec->addFieldSpec($entityField);
   }
 

--- a/Civi/Api4/Service/Spec/SpecFormatter.php
+++ b/Civi/Api4/Service/Spec/SpecFormatter.php
@@ -51,7 +51,7 @@ class SpecFormatter {
       if (self::customFieldHasOptions($data)) {
         $field->setOptionsCallback([__CLASS__, 'getOptions']);
       }
-      $field->setreadonly($data['is_view']);
+      $field->setReadonly($data['is_view']);
     }
     else {
       $name = $data['name'] ?? NULL;
@@ -62,7 +62,7 @@ class SpecFormatter {
       if (!empty($data['pseudoconstant'])) {
         $field->setOptionsCallback([__CLASS__, 'getOptions']);
       }
-      $field->setreadonly(!empty($data['readonly']));
+      $field->setReadonly(!empty($data['readonly']));
     }
     $field->setSerialize($data['serialize'] ?? NULL);
     $field->setDefaultValue($data['default'] ?? NULL);

--- a/tests/phpunit/api/v4/Action/GetFieldsTest.php
+++ b/tests/phpunit/api/v4/Action/GetFieldsTest.php
@@ -63,4 +63,20 @@ class GetFieldsTest extends UnitTestCase {
     $this->assertCount(1, $fields);
   }
 
+  public function testInternalPropsAreHidden() {
+    // Public getFields should not contain @internal props
+    $fields = Contact::getFields(FALSE)
+      ->execute()
+      ->getArrayCopy();
+    foreach ($fields as $field) {
+      $this->assertArrayNotHasKey('output_formatters', $field);
+    }
+    // Internal entityFields should contain @internal props
+    $fields = Contact::get(FALSE)
+      ->entityFields();
+    foreach ($fields as $field) {
+      $this->assertArrayHasKey('output_formatters', $field);
+    }
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Cleanup in APIv4 getFields.

Comments
----------------------------------------
This is in preparation for adding more attributes to each field to designate it's type (Field or Filter), the operators it allows and the list of sql callbacks. My main hesitation to adding all that stuff was bloat in the output of api.getFields so this PR adds a `@internal` flag which will give access to those attributes during internal api getFields but hide them from the public api.
