### PR TITLE
[REF][php8-compat] Further fixes where there is a required paramater …

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -3130,7 +3130,7 @@ class CRM_Contact_BAO_Query {
    * @return string WHERE clause component for smart group criteria.
    * @throws \CRM_Core_Exception
    */
-  public function addGroupContactCache($groups, $tableAlias, $joinTable = "contact_a", $op, $joinColumn = 'id') {
+  public function addGroupContactCache($groups, $tableAlias, $joinTable, $op, $joinColumn = 'id') {
     $isNullOp = (strpos($op, 'NULL') !== FALSE);
     $groupsIds = $groups;
 
@@ -5909,7 +5909,7 @@ AND   displayRelType.is_active = 1
     $op,
     $value,
     $grouping,
-    $daoName = NULL,
+    $daoName,
     $field,
     $label,
     $dataType = 'String'

--- a/CRM/Utils/Weight.php
+++ b/CRM/Utils/Weight.php
@@ -280,7 +280,7 @@ class CRM_Utils_Weight {
   public static function &query(
     $queryType,
     $daoName,
-    $fieldValues = NULL,
+    $fieldValues,
     $queryData,
     $additionalWhere = NULL,
     $orderBy = NULL,

--- a/api/v3/Profile.php
+++ b/api/v3/Profile.php
@@ -489,7 +489,7 @@ function _civicrm_api3_profile_getbillingpseudoprofile(&$params) {
  *
  * @return array|void
  */
-function _civicrm_api3_buildprofile_submitfields($profileID, $optionsBehaviour = 1, $is_flush) {
+function _civicrm_api3_buildprofile_submitfields($profileID, $optionsBehaviour, $is_flush) {
   static $profileFields = [];
   if ($is_flush) {
     $profileFields = [];

--- a/tests/phpunit/CiviTest/CiviMailUtils.php
+++ b/tests/phpunit/CiviTest/CiviMailUtils.php
@@ -362,9 +362,9 @@ class CiviMailUtils extends PHPUnit\Framework\TestCase {
    * @param $mail
    * @return mixed
    */
-  public function checkMailForStrings(array $strings, $absentStrings = [], $prefix = '', $mail) {
+  public function checkMailForStrings(array $strings, $absentStrings, $prefix, $mail) {
     foreach ($strings as $string) {
-      $this->_ut->assertContains($string, $mail, "$string .  not found in  $mail  $prefix");
+      $this->_ut->assertStringContainsString($string, $mail, "$string .  not found in  $mail  $prefix");
     }
     foreach ($absentStrings as $string) {
       $this->_ut->assertEmpty(strstr($mail, $string), "$string  incorrectly found in $mail $prefix");


### PR DESCRIPTION
…after an optional paramater

Overview
----------------------------------------
This fixes the following errors:

```
CiviCRM_API3_Exception: Required parameter $op follows optional parameter $joinTable

Deprecated: Required parameter $field follows optional parameter $daoName in /home/jenkins/bknix-edge/build/build-1/web/sites/all/modules/civicrm/CRM/Contact/BAO/Query.php on line 5907
```


Before
----------------------------------------
Errors triggered in php8 unit tests runs

After
----------------------------------------
Less errors

ping @eileenmcnaughton @totten @colemanw 