### PR TITLE
[php8-compat] Fix undefined property on Array Cache class in wordpres…

### DIFF
--- a/CRM/Utils/Cache/ArrayCache.php
+++ b/CRM/Utils/Cache/ArrayCache.php
@@ -122,7 +122,7 @@ class CRM_Utils_Cache_ArrayCache implements CRM_Utils_Cache_Interface {
    * @return int|null
    */
   public function getExpires($key) {
-    return $this->_expires[$key] ?: NULL;
+    return $this->_expires[$key] ?? NULL;
   }
 
 }


### PR DESCRIPTION
…s on PHP8

Overview
----------------------------------------
This fixes the following error when running E2E unit tests on wordpress on php8

```
Undefined property: CRM_Utils_Cache_ArrayCache::$_expires
```

Before
----------------------------------------
Error reported

After
----------------------------------------
no error

ping @eileenmcnaughton @totten 