### PR TITLE
Use line items to look up memberships

### DIFF
--- a/tests/phpunit/CRM/Contribute/BAO/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/BAO/ContributionTest.php
@@ -317,7 +317,7 @@ class CRM_Contribute_BAO_ContributionTest extends CiviUnitTestCase {
   /**
    * Test the annual query returns a correct result when multiple line items are present.
    */
-  public function testAnnualWithMultipleLineItems() {
+  public function testAnnualWithMultipleLineItems(): void {
     $contactID = $this->createLoggedInUserWithFinancialACL();
     $this->createContributionWithTwoLineItemsAgainstPriceSet([
       'contact_id' => $contactID,

--- a/tests/phpunit/CRM/Member/Form/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/Form/MembershipTest.php
@@ -1375,7 +1375,7 @@ Expires: ',
    */
   public function testContributionFormStatusUpdate(): void {
 
-    $this->_contactID = $this->createLoggedInUser();
+    $this->_contactID = $this->ids['Contact']['order'] = $this->createLoggedInUser();
     $this->createContributionAndMembershipOrder();
 
     $params = [

--- a/tests/phpunit/api/v3/ContributionPageTest.php
+++ b/tests/phpunit/api/v3/ContributionPageTest.php
@@ -852,24 +852,11 @@ class api_v3_ContributionPageTest extends CiviUnitTestCase {
       $expectedMembershipStatus = 5;
     }
 
-    $submitParams = [
-      'price_' . $this->_ids['price_field'][0] => reset($this->_ids['price_field_value']),
-      'id' => (int) $this->_ids['contribution_page'],
-      'amount' => 10,
-      'billing_first_name' => 'Billy',
-      'billing_middle_name' => 'Goat',
-      'billing_last_name' => 'Gruff',
-      'email' => 'billy@goat.gruff',
-      'selectMembership' => $this->ids['MembershipType'],
-      'payment_processor_id' => 1,
-      'credit_card_number' => '4111111111111111',
-      'credit_card_type' => 'Visa',
-      'credit_card_exp_date' => ['M' => 9, 'Y' => 2040],
-      'cvv2' => 123,
+    $submitParams = array_merge($this->getSubmitParamsMembership(TRUE), [
       'is_recur' => 1,
       'frequency_interval' => 1,
       'frequency_unit' => $this->params['recur_frequency_unit'],
-    ];
+    ]);
 
     $this->callAPIAndDocument('ContributionPage', 'submit', $submitParams, __FUNCTION__, __FILE__, 'submit contribution page');
     $contribution = $this->callAPISuccess('contribution', 'getsingle', [

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -2794,11 +2794,10 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
    * @throws \CRM_Core_Exception|\CiviCRM_API3_Exception
    */
   public function testContributionOrder() {
-    $this->_contactID = $this->individualCreate();
     $this->createContributionAndMembershipOrder();
     $contribution = $this->callAPISuccess('contribution', 'get')['values'][$this->ids['Contribution'][0]];
     $this->assertEquals('Pending Label**', $contribution['contribution_status']);
-    $membership = $this->callAPISuccessGetSingle('Membership', ['contact_id' => $this->_contactID]);
+    $membership = $this->callAPISuccessGetSingle('Membership', ['contact_id' => $this->ids['Contact']['order']]);
 
     $this->callAPISuccess('Payment', 'create', [
       'contribution_id' => $this->ids['Contribution'][0],

--- a/tests/phpunit/api/v3/MembershipTest.php
+++ b/tests/phpunit/api/v3/MembershipTest.php
@@ -144,7 +144,7 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
    * @throws \CiviCRM_API3_Exception
    */
   public function testActivityForCancelledContribution(): void {
-    $contactId = $this->createLoggedInUser();
+    $contactId = $this->ids['Contact']['order'] = $this->createLoggedInUser();
 
     $this->createContributionAndMembershipOrder();
     $membershipID = $this->callAPISuccessGetValue('MembershipPayment', ['return' => 'id']);


### PR DESCRIPTION

Overview
----------------------------------------
Use line items to look up memberships

Before
----------------------------------------
Checks (deprecated) membership payments

After
----------------------------------------
Checks line items, still checks membership payments & adds them in as a deprecated temporary behaviour

Technical Details
----------------------------------------
This still checks the membership payment but creates some noise if there are validity issues

Comments
----------------------------------------
@seamuslee001 as suggested - note there are many tests you can step through this with - eg in the PaypalIPNTest class