### PR TITLE
[REF][php8-compat] Fix more instances of where there is a required pa…

### DIFF
--- a/CRM/Core/Permission/UnitTests.php
+++ b/CRM/Core/Permission/UnitTests.php
@@ -43,9 +43,8 @@ class CRM_Core_Permission_UnitTests extends CRM_Core_Permission_Base {
     if ($str == CRM_Core_Permission::ALWAYS_ALLOW_PERMISSION) {
       return TRUE;
     }
-
     // return the stubbed permission (defaulting to true if the array is missing)
-    return is_array($this->permissions) ? in_array($str, $this->permissions) : TRUE;
+    return isset($this->permissions) && is_array($this->permissions) ? in_array($str, $this->permissions) : TRUE;
   }
 
   /**

--- a/CRM/Core/Reference/OptionValue.php
+++ b/CRM/Core/Reference/OptionValue.php
@@ -25,7 +25,7 @@ class CRM_Core_Reference_OptionValue extends CRM_Core_Reference_Basic {
    * @param string $targetKey
    * @param null $optionGroupName
    */
-  public function __construct($refTable, $refKey, $targetTable = NULL, $targetKey = 'id', $optionGroupName) {
+  public function __construct($refTable, $refKey, $targetTable, $targetKey, $optionGroupName) {
     parent::__construct($refTable, $refKey, $targetTable, $targetKey, NULL);
     $this->targetOptionGroupName = $optionGroupName;
   }

--- a/CRM/Utils/Pager.php
+++ b/CRM/Utils/Pager.php
@@ -177,7 +177,7 @@ class CRM_Utils_Pager extends Pager_Sliding {
    * @return int
    *   new pageId to display to the user
    */
-  public function getPageID($defaultPageId = 1, &$params) {
+  public function getPageID($defaultPageId, &$params) {
     // POST has higher priority than GET vars
     // else if a value is set that has higher priority and finally the GET var
     $currentPage = $defaultPageId;

--- a/Civi/Payment/PropertyBag.php
+++ b/Civi/Payment/PropertyBag.php
@@ -296,7 +296,7 @@ class PropertyBag implements \ArrayAccess {
    *
    * @return PropertyBag $this object so you can chain set setters.
    */
-  protected function set($prop, $label = 'default', $value) {
+  protected function set($prop, $label, $value) {
     $this->props[$label][$prop] = $value;
     return $this;
   }

--- a/tests/phpunit/CRM/Contact/BAO/RelationshipTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/RelationshipTest.php
@@ -139,7 +139,7 @@ class CRM_Contact_BAO_RelationshipTest extends CiviUnitTestCase {
    *
    * @dataProvider getRelationshipTypeDuplicates
    */
-  public function testRemoveRelationshipTypeDuplicates($relationshipTypeList, $suffix = NULL, $expected, $description) {
+  public function testRemoveRelationshipTypeDuplicates($relationshipTypeList, $suffix, $expected, $description) {
     $result = CRM_Contact_BAO_Relationship::removeRelationshipTypeDuplicates($relationshipTypeList, $suffix);
     $this->assertEquals($expected, $result, "Failure on set '$description'");
   }


### PR DESCRIPTION
…rameter for a function after an optional one and fix an issue where by a NULL function property is treated as not exisiting in php8

Overview
----------------------------------------
Title says it all

Before
----------------------------------------
PHP8 Errors generated in unit tests

After
----------------------------------------
Less PHP8 Errors generated

ping @eileenmcnaughton @totten @demeritcowboy 