### PR TITLE
[REF] Fix Authx tests on Druapl 8/9 by ensuring that we only return a…

### DIFF
--- a/ext/authx/Civi/Authx/Drupal8.php
+++ b/ext/authx/Civi/Authx/Drupal8.php
@@ -54,7 +54,7 @@ class Drupal8 implements AuthxInterface {
    */
   public function getCurrentUserId() {
     $user = \Drupal::currentUser();
-    return $user ? $user->getAccount()->id() : NULL;
+    return $user && $user->getAccount()->id() ? $user->getAccount()->id() : NULL;
   }
 
 }


### PR DESCRIPTION
…n id for the user id if it is greater than 0

Overview
----------------------------------------
This fixes the following test failures https://test.civicrm.org/job/CiviCRM-E2E-Matrix/BKPROF=max,BLDTYPE=drupal9-clean,CIVIVER=master,label=bknix-tmp/lastCompletedBuild/testReport/Civi.Authx/AllFlowsTest/testAnonymous/ on authx by mimicking what we do in the Drupal 7 instance https://github.com/civicrm/civicrm-core/blob/master/ext/authx/Civi/Authx/Drupal.php#L55v

Before
----------------------------------------
Tests fail

After
----------------------------------------
Tests pass on D8/D9

ping @totten @demeritcowboy 