### PR TITLE
dev/core#2486 - Use read-only permissions for FinancialItem API

### DIFF
--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -1136,6 +1136,8 @@ class CRM_Core_Permission {
     ];
     $permissions['line_item'] = $permissions['contribution'];
 
+    $permissions['financial_item'] = $permissions['contribution'];
+
     // Payment permissions
     $permissions['payment'] = [
       'get' => [

--- a/Civi/Api4/FinancialItem.php
+++ b/Civi/Api4/FinancialItem.php
@@ -31,4 +31,18 @@ namespace Civi\Api4;
  */
 class FinancialItem extends Generic\DAOEntity {
 
+  /**
+   * @see \Civi\Api4\Generic\AbstractEntity::permissions()
+   * @return array
+   */
+  public static function permissions() {
+    $permissions = \CRM_Core_Permission::getEntityActionPermissions()['financial_item'] ?? [];
+
+    // Merge permissions for this entity with the defaults
+    return array_merge($permissions, [
+      'create' => [\CRM_Core_Permission::ALWAYS_DENY_PERMISSION],
+      'update' => [\CRM_Core_Permission::ALWAYS_DENY_PERMISSION],
+    ]);
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Add permissions for financial_item entity

Before
----------------------------------------
No permission declared for financial_item

After
----------------------------------------
Financial Item got permissions, and prevent create/update action. 
<img width="501" alt="Screenshot 2021-06-04 at 12 08 19 PM" src="https://user-images.githubusercontent.com/3735621/120757015-a3f6e900-c52d-11eb-9df4-528a16e84ca0.png">

Comments
----------------------------------------

This is a follow-up to #20433.

ping @colemanw @eileenmcnaughton @totten 