### PR TITLE
[php8-compat][NFC] Fix using ZipArchive::open on an empty file

### DIFF
--- a/CRM/Utils/Zip.php
+++ b/CRM/Utils/Zip.php
@@ -116,7 +116,7 @@ class CRM_Utils_Zip {
    */
   public static function createTestZip($zipName, $dirs, $files) {
     $zip = new ZipArchive();
-    $res = $zip->open($zipName, ZipArchive::CREATE);
+    $res = $zip->open($zipName, ZipArchive::OVERWRITE);
     if ($res === TRUE) {
       foreach ($dirs as $dir) {
         if (!$zip->addEmptyDir($dir)) {


### PR DESCRIPTION
Overview
----------------------------------------
This fixes the following deprecation in php8 `ZipArchive::open(): Using empty file as ZipArchive is deprecated`

Before
----------------------------------------
Deprecation issued in php8

After
----------------------------------------
No deprecation issued

ping @eileenmcnaughton @demeritcowboy @totten 