### PR TITLE
Add APIv4 Batch.create spec

### DIFF
--- a/Civi/Api4/Service/Spec/Provider/BatchCreationSpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/BatchCreationSpecProvider.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+
+namespace Civi\Api4\Service\Spec\Provider;
+
+use Civi\Api4\Service\Spec\RequestSpec;
+
+class BatchCreationSpecProvider implements Generic\SpecProviderInterface {
+
+  /**
+   * @inheritDoc
+   */
+  public function modifySpec(RequestSpec $spec) {
+    $spec->getFieldByName('created_id')->setDefaultValue('user_contact_id');
+    $spec->getFieldByName('created_date')->setDefaultValue('now');
+    $spec->getFieldByName('modified_id')->setDefaultValue('user_contact_id');
+    $spec->getFieldByName('modified_date')->setDefaultValue('now');
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function applies($entity, $action) {
+    return $entity === 'Batch' && $action === 'create';
+  }
+
+}

--- a/api/v3/Batch.php
+++ b/api/v3/Batch.php
@@ -37,11 +37,6 @@ function civicrm_api3_batch_create($params) {
  *   Array of parameters determined by getfields.
  */
 function _civicrm_api3_batch_create_spec(&$params) {
-  //@todo - the entity table field looks like it is not actually required & should probably be removed (or a description added if
-  // it is actually required)
-  $params['entity_table']['api.default'] = "civicrm_batch";
-  $params['entity_table']['type'] = CRM_Utils_Type::T_STRING;
-  $params['entity_table']['title'] = 'Batch Entity Table - remove?';
   $params['created_id']['api.default'] = 'user_contact_id';
   $params['created_date']['api.default'] = 'now';
   $params['modified_id']['api.default'] = 'user_contact_id';


### PR DESCRIPTION
Overview
----------------------------------------
Add APIv4 Batch.create spec

Before
----------------------------------------
No default spec for APIv4 Batch.create spec

After
----------------------------------------
Add APIv4 Batch.create spec as declared [here](https://github.com/civicrm/civicrm-core/blob/master/api/v3/Batch.php#L39L53) 


Comments
----------------------------------------
ping @colemanw @eileenmcnaughton @seamuslee001 

I think this was missed in https://github.com/civicrm/civicrm-core/pull/19931 !!!