### PR TITLE
[php8-compat] Fix issue with returning bool from uasort by using the …

### DIFF
--- a/CRM/Core/BAO/Dashboard.php
+++ b/CRM/Core/BAO/Dashboard.php
@@ -96,7 +96,7 @@ class CRM_Core_BAO_Dashboard extends CRM_Core_DAO_Dashboard {
         if (!isset($a['dashboard_contact.weight'])) {
           return 1;
         }
-        return $a['dashboard_contact.weight'] > $b['dashboard_contact.weight'];
+        return $a['dashboard_contact.weight'] <=> $b['dashboard_contact.weight'];
       });
     }
     return Civi::$statics[__CLASS__][__FUNCTION__][$cid] ?? [];

--- a/CRM/Utils/Check.php
+++ b/CRM/Utils/Check.php
@@ -114,7 +114,7 @@ class CRM_Utils_Check {
       return strcmp($a->getName(), $b->getName());
     }
     // The Message constructor guarantees that these will always be integers.
-    return ($aSeverity < $bSeverity);
+    return ($aSeverity <=> $bSeverity);
   }
 
   /**

--- a/api/v3/Profile.php
+++ b/api/v3/Profile.php
@@ -615,7 +615,7 @@ function _civicrm_api3_buildprofile_submitfields($profileID, $optionsBehaviour, 
  * @return bool
  */
 function _civicrm_api3_order_by_weight($a, $b) {
-  return ($b['weight'] ?? 0) < ($a['weight'] ?? 0);
+  return ($b['weight'] ?? 0) < ($a['weight'] ?? 0) ? 1 : -1;
 }
 
 /**


### PR DESCRIPTION
…spaceship operator

Overview
----------------------------------------
This fixes an error in php8

```
uasort(): Returning bool from comparison function is deprecated, return an integer less than, equal to, or greater than zero
```

Before
----------------------------------------
Error shows in php8

After
----------------------------------------
No error

Technical Details
----------------------------------------
As per this https://stackoverflow.com/questions/65382799/what-happened-in-php8-0-0-to-break-usort-intstrlenastrlenb the recommended solution is to use the spaceship <=> operator

ping @eileenmcnaughton @totten @demeritcowboy 