### PR TITLE
[php8-compat] fix Upgrade call back issues by making functions static…

### DIFF
--- a/CRM/Extension/Manager.php
+++ b/CRM/Extension/Manager.php
@@ -382,36 +382,41 @@ class CRM_Extension_Manager {
     $this->addProcess($keys, 'disable');
 
     foreach ($keys as $key) {
-      switch ($origStatuses[$key]) {
-        case self::STATUS_INSTALLED:
-          $this->addProcess([$key], 'disabling');
-          // throws Exception
-          list ($info, $typeManager) = $this->_getInfoTypeHandler($key);
-          $typeManager->onPreDisable($info);
-          $this->_setExtensionActive($info, 0);
-          $typeManager->onPostDisable($info);
-          $this->popProcess([$key]);
-          break;
+      if (isset($origStatuses[$key])) {
+        switch ($origStatuses[$key]) {
+          case self::STATUS_INSTALLED:
+            $this->addProcess([$key], 'disabling');
+            // throws Exception
+            list ($info, $typeManager) = $this->_getInfoTypeHandler($key);
+            $typeManager->onPreDisable($info);
+            $this->_setExtensionActive($info, 0);
+            $typeManager->onPostDisable($info);
+            $this->popProcess([$key]);
+            break;
 
-        case self::STATUS_INSTALLED_MISSING:
-          // throws Exception
-          list ($info, $typeManager) = $this->_getMissingInfoTypeHandler($key);
-          $typeManager->onPreDisable($info);
-          $this->_setExtensionActive($info, 0);
-          $typeManager->onPostDisable($info);
-          break;
+          case self::STATUS_INSTALLED_MISSING:
+            // throws Exception
+            list ($info, $typeManager) = $this->_getMissingInfoTypeHandler($key);
+            $typeManager->onPreDisable($info);
+            $this->_setExtensionActive($info, 0);
+            $typeManager->onPostDisable($info);
+            break;
 
-        case self::STATUS_DISABLED:
-        case self::STATUS_DISABLED_MISSING:
-        case self::STATUS_UNINSTALLED:
-          // ok, nothing to do
-          // Remove the 'disable' process as we're not doing that.
-          $this->popProcess([$key]);
-          break;
+          case self::STATUS_DISABLED:
+          case self::STATUS_DISABLED_MISSING:
+          case self::STATUS_UNINSTALLED:
+            // ok, nothing to do
+            // Remove the 'disable' process as we're not doing that.
+            $this->popProcess([$key]);
+            break;
 
-        case self::STATUS_UNKNOWN:
-        default:
-          throw new CRM_Extension_Exception("Cannot disable unknown extension: $key");
+          case self::STATUS_UNKNOWN:
+          default:
+            throw new CRM_Extension_Exception("Cannot disable unknown extension: $key");
+        }
+      }
+      else {
+        throw new CRM_Extension_Exception("Cannot disable unknown extension: $key");
       }
     }
 

--- a/CRM/Upgrade/Incremental/Base.php
+++ b/CRM/Upgrade/Incremental/Base.php
@@ -268,7 +268,7 @@ class CRM_Upgrade_Incremental_Base {
    *
    * @return bool
    */
-  public function updateSmartGroups($ctx, $actions) {
+  public static function updateSmartGroups($ctx, $actions) {
     $groupUpdateObject = new CRM_Upgrade_Incremental_SmartGroups();
     $groupUpdateObject->updateGroups($actions);
     return TRUE;

--- a/CRM/Upgrade/Incremental/php/FiveSeventeen.php
+++ b/CRM/Upgrade/Incremental/php/FiveSeventeen.php
@@ -104,7 +104,7 @@ class CRM_Upgrade_Incremental_php_FiveSeventeen extends CRM_Upgrade_Incremental_
   /**
    * Update safe file types.
    */
-  public function updateFileTypes() {
+  public static function updateFileTypes() {
     CRM_Core_BAO_OptionValue::ensureOptionValueExists([
       'option_group_id' => 'safe_file_extension',
       'label' => 'pptx',

--- a/CRM/Upgrade/Incremental/php/FiveTwentySeven.php
+++ b/CRM/Upgrade/Incremental/php/FiveTwentySeven.php
@@ -71,7 +71,7 @@ class CRM_Upgrade_Incremental_php_FiveTwentySeven extends CRM_Upgrade_Incrementa
     $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
   }
 
-  public function priceFieldValueLabelRequired($ctx) {
+  public static function priceFieldValueLabelRequired($ctx) {
     $locales = CRM_Core_I18n::getMultilingual();
     if ($locales) {
       foreach ($locales as $locale) {
@@ -86,7 +86,7 @@ class CRM_Upgrade_Incremental_php_FiveTwentySeven extends CRM_Upgrade_Incrementa
     return TRUE;
   }
 
-  public function nameMembershipTypeRequired($ctx) {
+  public static function nameMembershipTypeRequired($ctx) {
     $locales = CRM_Core_I18n::getMultilingual();
     if ($locales) {
       foreach ($locales as $locale) {

--- a/CRM/Upgrade/Incremental/php/FiveTwentySix.php
+++ b/CRM/Upgrade/Incremental/php/FiveTwentySix.php
@@ -81,7 +81,7 @@ class CRM_Upgrade_Incremental_php_FiveTwentySix extends CRM_Upgrade_Incremental_
   /**
    * Update workflow_name based on workflow_id values.
    */
-  public function populateWorkflowName() {
+  public static function populateWorkflowName() {
     CRM_Core_DAO::executeQuery('UPDATE civicrm_msg_template
       LEFT JOIN  civicrm_option_value ov ON ov.id = workflow_id
       SET workflow_name = ov.name'


### PR DESCRIPTION
… and also fixing an issue with an array key not existing when checking obsolete extensions

Overview
----------------------------------------
This fixes call backs in php8 in the upgrade process by making the functions static and also fixing this notice error
```
Undefined array key "com.klangsoft.flexiblejobs" Manager.php:385
```

Before
----------------------------------------
Upgrade Tests fail on php8

After
----------------------------------------
Upgrade tests work on php8

ping @eileenmcnaughton @totten @demeritcowboy 