### PR TITLE
Add ContributionProduct and EntityBatch APIv4 Entity

### DIFF
--- a/Civi/Api4/ContributionProduct.php
+++ b/Civi/Api4/ContributionProduct.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4;
+
+/**
+ * Contribution Product entity.
+ *
+ * @package Civi\Api4
+ */
+class ContributionProduct extends Generic\DAOEntity {
+
+}

--- a/Civi/Api4/EntityBatch.php
+++ b/Civi/Api4/EntityBatch.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+
+namespace Civi\Api4;
+
+/**
+ * EntityBatch entity.
+ *
+ * @searchable none
+ * @package Civi\Api4
+ */
+class EntityBatch extends Generic\DAOEntity {
+
+}

--- a/tests/phpunit/api/v4/DataSets/ConformanceTest.json
+++ b/tests/phpunit/api/v4/DataSets/ConformanceTest.json
@@ -74,5 +74,12 @@
     {
       "payment_processor_type_id:name": "Dummy"
     }
+  ],
+  "Batch": [
+    {
+      "title": "Batch 433397",
+      "name": "Batch_433397",
+      "status_id": "1"
+    }
   ]
 }

--- a/tests/phpunit/api/v4/Entity/ConformanceTest.php
+++ b/tests/phpunit/api/v4/Entity/ConformanceTest.php
@@ -49,6 +49,7 @@ class ConformanceTest extends UnitTestCase {
       'civicrm_group',
       'civicrm_event',
       'civicrm_participant',
+      'civicrm_batch',
     ];
     $this->dropByPrefix('civicrm_value_myfavorite');
     $this->cleanup(['tablesToTruncate' => $tablesToTruncate]);


### PR DESCRIPTION
Overview
----------------------------------------
Add ContributionProduct and EntityBatch APIv4 Entity

Technical Details
----------------------------------------
I want to raise two points: 

1.  Found that the ContributionProduct.product_id is missing foreign key attribute, will add a separate PR to add that. 
2.  Not sure if we need add pseudoconstant property on EntityBatch.entity_table as I am not sure if it contain finite number of table list, right now I can think of civicrm_financial_trxn and civicrm_contact. 


Comments
----------------------------------------
ping @colemanw @eileenmcnaughton @seamuslee001 