### PR TITLE
[php8-compat] Fix issue in APIv3 Where by because product has a colum…

### DIFF
--- a/api/v3/Generic.php
+++ b/api/v3/Generic.php
@@ -511,7 +511,12 @@ function _civicrm_api3_generic_get_metadata_options(&$metadata, $apiRequest, $fi
     return;
   }
 
-  $fieldsToResolve = $apiRequest['params']['options']['get_options'];
+  if (!is_array($apiRequest['params']['options'])) {
+    $fieldsToResolve = [];
+  }
+  else {
+    $fieldsToResolve = $apiRequest['params']['options']['get_options'];
+  }
 
   if (!empty($metadata[$fieldname]['options']) || (!in_array($fieldname, $fieldsToResolve) && !in_array('all', $fieldsToResolve))) {
     return;


### PR DESCRIPTION
…n called options the testCreateSingleValueAlter triggers a cannot access offset of type string on string in php8

Overview
----------------------------------------
This fixes the following error in php8 when running the testCreateSingleValueAlter  for the Product entity

```
TypeError: Cannot access offset of type string on string
/home/seamus/buildkit/build/dmaster/web/sites/all/modules/civicrm/api/v3/Generic.php:514
```

Before
----------------------------------------
Type Error generated in php8

After
----------------------------------------
No Type Error

Technical Details
----------------------------------------
The product table has a column called options which clashes with the apiv3 options in this test in annoying ways

ping @eileenmcnaughton @demeritcowboy @colemanw 