### PR TITLE
Alter property bag to support iteration

### DIFF
--- a/Civi/Payment/PropertyBag.php
+++ b/Civi/Payment/PropertyBag.php
@@ -20,7 +20,7 @@ use CRM_Core_PseudoConstant;
  * This class is also supposed to help with transition away from array key naming nightmares.
  *
  */
-class PropertyBag implements \ArrayAccess {
+class PropertyBag extends \ArrayObject {
 
   protected $props = ['default' => []];
 
@@ -352,6 +352,12 @@ class PropertyBag implements \ArrayAccess {
         $this->offsetSet($key, $value);
       }
     }
+    foreach (self::$propMap as $key => $value) {
+      if ($value === TRUE && !isset($data[$key]) && $this->has($key)) {
+        $data[$key] = $this->get($key, 'default');
+      }
+    }
+    $this->exchangeArray($data);
     $this->setSuppressLegacyWarnings($suppressLegacyWarnings);
   }
 

--- a/Civi/Payment/PropertyBag.php
+++ b/Civi/Payment/PropertyBag.php
@@ -302,7 +302,28 @@ class PropertyBag extends \ArrayObject {
    */
   protected function set($prop, $label, $value) {
     $this->props[$label][$prop] = $value;
+
+    $pseudonyms = $this->getPseudonyms($prop);
+    $data = (array) $this;
+    $data[$prop] = $value;
+    if (!empty($pseudonyms)) {
+      foreach ($pseudonyms as $pseudonym) {
+        $data[$pseudonym] = $value;
+      }
+      $this->exchangeArray($data);
+    }
+
     return $this;
+  }
+
+  protected function getPseudonyms($label) {
+    $pseudonyms = [];
+    foreach (self::$propMap as $key => $preferredKey) {
+      if ($preferredKey === $label) {
+        $pseudonyms[] = $key;
+      }
+    }
+    return $pseudonyms;
   }
 
   /**


### PR DESCRIPTION
This is another alternative to support the authorize.net pattern - I think this is the limits of how tolerant is possible

If you have an array 
```
[
  'amount' => 5,67,
  'is_recur' => TRUE,
];
```

You can cast to propertyBag like this
```
 $params = PropertyBag::cast($params);
```

And the returned array object will return TRUE if you call this function
```
   if (array_key_exists('isRecur', $params)) {
```

If you do

```
   $params = (array) $params;
```

Then the array is 
```
[
  'is_recur' => TRUE,
  'isRecur' => TRUE,
 'amount' => 5.67,
];
```

This option would mean the following would not break
1) iterating through the property bag (a-la Authorize.net)
2) using the array_key_exists function on the property bag

In addition we would be able to say the fix for any of the below is to cast it to an array - because casting the property bag back to an array would provide an array with the preferred keys set along with any known aliases. This only works with casting with this PR although it could be done in the set function too.

This means the following with still break
 1) type hinting - this is not very likely at the doPayment function but it turned out that our custom code passed it off to a function with type hinting & hence it broke. This is also somewhat likely in the alterPaymentProcessor hook and unlikely to be auditable

 2) most other array functions - array_key_exists is the only one that seems to accept array access



Overview
----------------------------------------
_A brief description of the pull request. Keep technical jargon to a minimum. Hyperlink relevant discussions._

Before
----------------------------------------
_What is the old user-interface or technical-contract (as appropriate)?_
_For optimal clarity, include a concrete example such as a screenshot, GIF ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)), or code-snippet._

After
----------------------------------------
_What changed? What is new old user-interface or technical-contract?_
_For optimal clarity, include a concrete example such as a screenshot, GIF ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)), or code-snippet._

Technical Details
----------------------------------------
_If the PR involves technical details/changes/considerations which would not be manifest to a casual developer skimming the above sections, please describe the details here._

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
