### PR TITLE
[php8-compat] Fix some more examples of where required parameters are…

### DIFF
--- a/CRM/Activity/Import/Parser.php
+++ b/CRM/Activity/Import/Parser.php
@@ -58,7 +58,7 @@ abstract class CRM_Activity_Import_Parser extends CRM_Import_Parser {
    */
   public function run(
     array $fileName,
-    $separator = ',',
+    $separator,
     &$mapper,
     $skipColumnHeader = FALSE,
     $mode = self::MODE_PREVIEW,

--- a/CRM/Campaign/Form/Campaign.php
+++ b/CRM/Campaign/Form/Campaign.php
@@ -314,7 +314,7 @@ class CRM_Campaign_Form_Campaign extends CRM_Core_Form {
     }
   }
 
-  public static function submit($params = [], $form) {
+  public static function submit($params, $form) {
     $groups = [];
     if (!empty($params['includeGroups']) && is_array($params['includeGroups'])) {
       foreach ($params['includeGroups'] as $key => $id) {

--- a/CRM/Contribute/Import/Parser.php
+++ b/CRM/Contribute/Import/Parser.php
@@ -118,7 +118,7 @@ abstract class CRM_Contribute_Import_Parser extends CRM_Import_Parser {
    */
   public function run(
     $fileName,
-    $separator = ',',
+    $separator,
     &$mapper,
     $skipColumnHeader = FALSE,
     $mode = self::MODE_PREVIEW,

--- a/CRM/Core/Smarty/plugins/block.localize.php
+++ b/CRM/Core/Smarty/plugins/block.localize.php
@@ -38,7 +38,7 @@ function smarty_block_localize($params, $text, &$smarty) {
   $lines = [];
   foreach ($smarty->_tpl_vars['locales'] as $locale) {
     $line = $text;
-    if ($params['field']) {
+    if (isset($params['field'])) {
       $fields = explode(',', $params['field']);
       foreach ($fields as $field) {
         $field = trim($field);

--- a/CRM/Event/Form/Registration.php
+++ b/CRM/Event/Form/Registration.php
@@ -1100,7 +1100,7 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
    * @param array $optionFullIds
    * @param CRM_Core_Form $form
    */
-  public static function resetElementValue($optionFullIds = [], &$form) {
+  public static function resetElementValue($optionFullIds, &$form) {
     if (!is_array($optionFullIds) ||
       empty($optionFullIds) ||
       !$form->isSubmitted()
@@ -1173,7 +1173,7 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
    * @param array $optionIds
    * @param CRM_Core_Form $form
    */
-  public static function resetSubmittedValue($elementName, $optionIds = [], &$form) {
+  public static function resetSubmittedValue($elementName, $optionIds, &$form) {
     if (empty($elementName) ||
       !$form->elementExists($elementName) ||
       !$form->getSubmitValue($elementName)

--- a/CRM/Event/Import/Parser.php
+++ b/CRM/Event/Import/Parser.php
@@ -60,7 +60,7 @@ abstract class CRM_Event_Import_Parser extends CRM_Import_Parser {
    */
   public function run(
     $fileName,
-    $separator = ',',
+    $separator,
     &$mapper,
     $skipColumnHeader = FALSE,
     $mode = self::MODE_PREVIEW,

--- a/CRM/Member/Import/Parser.php
+++ b/CRM/Member/Import/Parser.php
@@ -61,7 +61,7 @@ abstract class CRM_Member_Import_Parser extends CRM_Import_Parser {
    */
   public function run(
     $fileName,
-    $separator = ',',
+    $separator,
     &$mapper,
     $skipColumnHeader = FALSE,
     $mode = self::MODE_PREVIEW,


### PR DESCRIPTION
… after optional parameters in fucntion declaration

Overview
----------------------------------------
This fixes a few more unit tests caused by issues where by in a function declaration required parameters are after optional ones and also fixes a e-notice in block.localize.php

Before
----------------------------------------
Tests fail

After
----------------------------------------
Tests pass

ping @eileenmcnaughton @demeritcowboy @totten 