### PR TITLE
[php8-compat][REF] Fix some more test failures in php8

### DIFF
--- a/CRM/Campaign/BAO/Petition.php
+++ b/CRM/Campaign/BAO/Petition.php
@@ -576,6 +576,8 @@ AND         tag_id = ( SELECT id FROM civicrm_tag WHERE name = %2 )";
     // tokens then available in msg template as {$petition.title}, etc
     $petitionTokens['title'] = $petitionInfo['title'];
     $petitionTokens['petitionId'] = $params['sid'];
+    $tplParams['survey_id'] = $params['sid'];
+    $tplParams['petitionTitle'] = $petitionInfo['title'];
     $tplParams['petition'] = $petitionTokens;
 
     switch ($sendEmailMode) {

--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -1360,7 +1360,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
     }
 
     // also store lineitem stuff here
-    if ((($this->_lineItem & $this->_action & CRM_Core_Action::ADD) ||
+    if ((($this->_lineItem && $this->_action & CRM_Core_Action::ADD) ||
       ($this->_lineItem && CRM_Core_Action::UPDATE && !$this->_paymentId))
     ) {
       foreach ($this->_contactIds as $num => $contactID) {

--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -945,6 +945,10 @@ DESC limit 1");
 
     if (!empty($formValues['contribution_id'])) {
       $form->assign('contributionID', $formValues['contribution_id']);
+      $form->assign('currency', CRM_Core_DAO::getFieldValue('CRM_Contribute_DAO_Contribution', $formValues['contribution_id'], 'currency'));
+    }
+    else {
+      $form->assign('currency', CRM_Core_Config::singleton()->defaultCurrency);
     }
 
     if (!empty($formValues['contribution_status_id'])) {

--- a/templates/CRM/common/CMSPrint.tpl
+++ b/templates/CRM/common/CMSPrint.tpl
@@ -11,9 +11,9 @@
 {include file="CRM/common/debug.tpl"}
 {/if}
 
-<div id="crm-container" class="crm-container{if $urlIsPublic} crm-public{/if}" lang="{$config->lcMessages|truncate:2:"":true}" xml:lang="{$config->lcMessages|truncate:2:"":true}">
+<div id="crm-container" class="crm-container{if !empty($urlIsPublic)} crm-public{/if}" lang="{$config->lcMessages|truncate:2:"":true}" xml:lang="{$config->lcMessages|truncate:2:"":true}">
 
-{if $breadcrumb}
+{if !empty($breadcrumb)}
   <div class="breadcrumb">
     {foreach from=$breadcrumb item=crumb key=key}
       {if $key != 0}
@@ -24,7 +24,7 @@
   </div>
 {/if}
 
-{if $pageTitle}
+{if !empty($pageTitle)}
   <div class="crm-title">
     <h1 class="title">{if $isDeleted}<del>{/if}{$pageTitle}{if $isDeleted}</del>{/if}</h1>
   </div>
@@ -49,7 +49,7 @@
 </div>
 
 {crmRegion name='page-footer'}
-{if $urlIsPublic}
+{if !empty($urlIsPublic)}
   {include file="CRM/common/publicFooter.tpl"}
 {else}
   {include file="CRM/common/footer.tpl"}

--- a/templates/CRM/common/accesskeys.tpl
+++ b/templates/CRM/common/accesskeys.tpl
@@ -7,7 +7,7 @@
  | and copyright information, see https://civicrm.org/licensing       |
  +--------------------------------------------------------------------+
 *}
-{if not $urlIsPublic}
+{if empty($urlIsPublic)}
   <div class="footer" id="access">
     {capture assign='accessKeysHelpTitle'}{ts}Access Keys{/ts}{/capture}
     {ts}Access Keys:{/ts}

--- a/templates/CRM/common/joomla.tpl
+++ b/templates/CRM/common/joomla.tpl
@@ -11,7 +11,7 @@
 {include file="CRM/common/debug.tpl"}
 {/if}
 
-<div id="crm-container" class="crm-container{if $urlIsPublic} crm-public{/if}" lang="{$config->lcMessages|truncate:2:"":true}" xml:lang="{$config->lcMessages|truncate:2:"":true}">
+<div id="crm-container" class="crm-container{if !empty($urlIsPublic)} crm-public{/if}" lang="{$config->lcMessages|truncate:2:"":true}" xml:lang="{$config->lcMessages|truncate:2:"":true}">
 
 <table border="0" cellpadding="0" cellspacing="0" id="crm-content">
   <tr>
@@ -62,7 +62,7 @@
     </div>
 
     {crmRegion name='page-footer'}
-    {if $urlIsPublic}
+    {if !empty($urlIsPublic)}
       {include file="CRM/common/publicFooter.tpl"}
     {else}
       {include file="CRM/common/footer.tpl"}

--- a/templates/CRM/common/status.tpl
+++ b/templates/CRM/common/status.tpl
@@ -12,7 +12,7 @@
 {if $session->getStatus(false)}
   {assign var="status" value=$session->getStatus(true)}
   {foreach name=statLoop item=statItem from=$status}
-    {if $urlIsPublic}
+    {if !empty($urlIsPublic)}
       {assign var="infoType" value="no-popup `$statItem.type`"}
     {else}
       {assign var="infoType" value=$statItem.type}


### PR DESCRIPTION
Overview
----------------------------------------
This fixes the following test failures on php8

- CRM_Campaign_BAO_PetitionTest::testPetitionEmailWithDomainTokens
Undefined array key "survey_id"
- Civi\Test\ExampleHookTest::testPageOutput
Undefined array key "urlIsPublic"
- CRM_Event_Form_ParticipantTest::testTransferParticipantRegistration
TypeError: Unsupported operand types: array & int

Before
----------------------------------------
Those tests fail on php8

After
----------------------------------------
Those tests pass on php8

ping @eileenmcnaughton @totten @demeritcowboy 