### PR TITLE
[php8-compat][REF] Fix more php8 test failures caused by template issues

### DIFF
--- a/tests/templates/message_templates/event_online_receipt_text.tpl
+++ b/tests/templates/message_templates/event_online_receipt_text.tpl
@@ -14,7 +14,9 @@ participant_status:::{$participant_status}
 {if isset($pricesetFieldsCount)}
 pricesetFieldsCount:::{$pricesetFieldsCount}
 {/if}
+{if !empty($isPrimary)}
 isPrimary:::{$isPrimary}
+{/if}
 {if isset($conference_sessions)}
 conference_sessions:::{$conference_sessions}
 {/if}

--- a/xml/templates/message_templates/contribution_invoice_receipt_html.tpl
+++ b/xml/templates/message_templates/contribution_invoice_receipt_html.tpl
@@ -60,7 +60,7 @@
         </tr>
         <tr>
           <td><font size="1" align="right"> {$country}</font></td>
-          <td><font size="1" align="right">{$source}</font></td>
+          <td><font size="1" align="right">{if !empty($source)}{$source}{/if}</font></td>
           <td valign="top" style="white-space: nowrap"><font size="1" align="right">{if $domain_email}{$domain_email}{/if}</font> </td>
         </tr>
         <tr>

--- a/xml/templates/message_templates/contribution_offline_receipt_html.tpl
+++ b/xml/templates/message_templates/contribution_offline_receipt_html.tpl
@@ -46,12 +46,14 @@
       </td>
      </tr>
      <tr>
-      <td {$labelStyle}>
-       {ts}Financial Type{/ts}
-      </td>
-      <td {$valueStyle}>
-       {$formValues.contributionType_name}
-      </td>
+      {if !empty($formValues.contributionType_name)}
+        <td {$labelStyle}>
+         {ts}Financial Type{/ts}
+        </td>
+        <td {$valueStyle}>
+         {$formValues.contributionType_name}
+        </td>
+      {/if}
      </tr>
 
      {if !empty($lineItem) and empty($is_quick_config)}

--- a/xml/templates/message_templates/contribution_offline_receipt_text.tpl
+++ b/xml/templates/message_templates/contribution_offline_receipt_text.tpl
@@ -9,7 +9,9 @@
 
 ===========================================================
 {ts}Contributor{/ts}: {contact.display_name}
+{if !empty($formValues.contributionType_name)}
 {ts}Financial Type{/ts}: {$formValues.contributionType_name}
+{/if}
 {if $lineItem}
 {foreach from=$lineItem item=value key=priceset}
 ---------------------------------------------------------

--- a/xml/templates/message_templates/event_offline_receipt_html.tpl
+++ b/xml/templates/message_templates/event_offline_receipt_html.tpl
@@ -147,7 +147,7 @@
       {if !empty($lineItem)}
        {foreach from=$lineItem item=value key=priceset}
         {if $value neq 'skip'}
-         {if $isPrimary}
+         {if !empty($isPrimary)}
           {if $lineItem|@count GT 1} {* Header for multi participant registration cases. *}
            <tr>
             <td colspan="2" {$labelStyle}>
@@ -255,10 +255,10 @@
         </td>
        </tr>
       {/if}
-      {if $isPrimary}
+      {if !empty($isPrimary)}
        <tr>
         <td {$labelStyle}>
-        {if $balanceAmount}
+        {if isset($balanceAmount)}
            {ts}Total Paid{/ts}
         {else}
            {ts}Total Amount{/ts}

--- a/xml/templates/message_templates/event_offline_receipt_text.tpl
+++ b/xml/templates/message_templates/event_offline_receipt_text.tpl
@@ -8,7 +8,7 @@
 
 {ts}You have been added to the WAIT LIST for this event.{/ts}
 
-{if $isPrimary}
+{if !empty($isPrimary)}
 {ts}If space becomes available you will receive an email with a link to a web page where you can complete your registration.{/ts}
 
 {/if}
@@ -19,7 +19,7 @@
 
 {ts}Your registration has been submitted.{/ts}
 
-{if $isPrimary}
+{if !empty($isPrimary)}
 {ts}Once your registration has been reviewed, you will receive an email with a link to a web page where you can complete the registration process.{/ts}
 
 {/if}

--- a/xml/templates/message_templates/event_online_receipt_html.tpl
+++ b/xml/templates/message_templates/event_online_receipt_html.tpl
@@ -186,7 +186,7 @@
       {if !empty($lineItem)}
        {foreach from=$lineItem item=value key=priceset}
         {if $value neq 'skip'}
-         {if $isPrimary}
+         {if !empty($isPrimary)}
           {if $lineItem|@count GT 1} {* Header for multi participant registration cases. *}
            <tr>
             <td colspan="2" {$labelStyle}>
@@ -299,7 +299,7 @@
         </td>
        </tr>
       {/if}
-      {if $isPrimary}
+      {if !empty($isPrimary)}
        <tr>
         <td {$labelStyle}>
          {ts}Total Amount{/ts}

--- a/xml/templates/message_templates/event_online_receipt_text.tpl
+++ b/xml/templates/message_templates/event_online_receipt_text.tpl
@@ -24,7 +24,7 @@
 
 {ts}Your registration has been submitted.{/ts}
 
-{if $isPrimary}
+{if !empty($isPrimary)}
 {ts}Once your registration has been reviewed, you will receive an email with a link to a web page where you can complete the registration process.{/ts}
 
 {/if}
@@ -106,7 +106,7 @@ You were registered by: {$payer.name}
 {if !empty($lineItem)}{foreach from=$lineItem item=value key=priceset}
 
 {if $value neq 'skip'}
-{if $isPrimary}
+{if !empty($isPrimary)}
 {if $lineItem|@count GT 1} {* Header for multi participant registration cases. *}
 {ts 1=$priceset+1}Participant %1{/ts} {$part.$priceset.info}
 

--- a/xml/templates/message_templates/event_registration_receipt_html.tpl
+++ b/xml/templates/message_templates/event_registration_receipt_html.tpl
@@ -16,7 +16,7 @@
       </p>
     {else}
       <p>
-        This is being sent to you as a {if $is_refund}confirmation of refund{else}receipt of payment made{/if} for the following workshop, event registration or purchase.
+        This is being sent to you as a {if !empty($is_refund)}confirmation of refund{else}receipt of payment made{/if} for the following workshop, event registration or purchase.
       </p>
     {/if}
 
@@ -24,7 +24,7 @@
       <p>{if isset($pay_later_receipt)}{$pay_later_receipt}{/if}</p>
     {/if}
 
-    <p>Your order number is #{$transaction_id}. {if $line_items && !$is_refund} Information about the workshops will be sent separately to each participant.{/if}
+    <p>Your order number is #{$transaction_id}. {if !empty($line_items) && empty($is_refund)} Information about the workshops will be sent separately to each participant.{/if}
   Here's a summary of your transaction placed on {$transaction_date|date_format:"%D %I:%M %p %Z"}:</p>
 
 {if $billing_name}
@@ -62,7 +62,7 @@
     </tr>
     </table>
 {/if}
-{if $source}
+{if !empty($source)}
     <p>&nbsp;</p>
     {$source}
 {/if}

--- a/xml/templates/message_templates/event_registration_receipt_text.tpl
+++ b/xml/templates/message_templates/event_registration_receipt_text.tpl
@@ -3,14 +3,14 @@
 {if $is_pay_later}
   This is being sent to you as an acknowledgement that you have registered one or more members for the following workshop, event or purchase. Please note, however, that the status of your payment is pending, and the registration for this event will not be completed until your payment is received.
 {else}
-  This is being sent to you as a {if $is_refund}confirmation of refund{else}receipt of payment made{/if} for the following workshop, event registration or purchase.
+  This is being sent to you as a {if !empty($is_refund)}confirmation of refund{else}receipt of payment made{/if} for the following workshop, event registration or purchase.
 {/if}
 
 {if $is_pay_later}
   {if isset($pay_later_receipt)}{$pay_later_receipt}{/if}
 {/if}
 
-  Your order number is #{$transaction_id}. {if $line_items && !$is_refund} Information about the workshops will be sent separately to each participant.{/if}
+  Your order number is #{$transaction_id}. {if !empty($line_items) && empty($is_refund)} Information about the workshops will be sent separately to each participant.{/if}
  Here's a summary of your transaction placed on {$transaction_date|date_format:"%D %I:%M %p %Z"}:
 
 {if $billing_name}
@@ -27,7 +27,7 @@
 {$email}
 {/if}
 
-{if $source}
+{if !empty($source)}
 {$source}
 {/if}
 

--- a/xml/templates/message_templates/membership_offline_receipt_html.tpl
+++ b/xml/templates/message_templates/membership_offline_receipt_html.tpl
@@ -76,7 +76,7 @@
                   {ts}Membership Fee{/ts}
                 </th>
               </tr>
-              {if $formValues.contributionType_name}
+              {if !empty($formValues.contributionType_name)}
                 <tr>
                   <td {$labelStyle}>
                     {ts}Financial Type{/ts}

--- a/xml/templates/message_templates/membership_offline_receipt_text.tpl
+++ b/xml/templates/message_templates/membership_offline_receipt_text.tpl
@@ -24,7 +24,7 @@
 {ts}Membership Fee{/ts}
 
 ===========================================================
-{if $formValues.contributionType_name}
+{if !empty($formValues.contributionType_name)}
 {ts}Financial Type{/ts}: {$formValues.contributionType_name}
 {/if}
 {if !empty($lineItem)}


### PR DESCRIPTION
Overview
----------------------------------------
This adds more fixes for template issues in tests fixing the following test:

- CRM_Financial_Form_PaymentFormsTest::testEventPaymentForms
Undefined array key "is_refund"

Before
----------------------------------------
Test failed on php8

After
----------------------------------------
Test passes on php8

ping @eileenmcnaughton @totten @demeritcowboy 