### PR TITLE
[php8-compat] Fix a couple of test failures caused by the wrong type …

### DIFF
--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -74,7 +74,12 @@ class CRM_Core_BAO_CustomGroup extends CRM_Core_DAO_CustomGroup {
       $extendsChildType = $params['extends_entity_column_value'];
     }
     if (!CRM_Utils_System::isNull($extendsChildType)) {
-      $extendsChildType = implode(CRM_Core_DAO::VALUE_SEPARATOR, $extendsChildType);
+      if (is_array($extendsChildType)) {
+        $extendsChildType = implode(CRM_Core_DAO::VALUE_SEPARATOR, $extendsChildType);
+      }
+      else {
+        throw new Exception('implode(): Invalid arguments passed');
+      }
       if (CRM_Utils_Array::value(0, $extends) == 'Relationship') {
         $extendsChildType = str_replace(['_a_b', '_b_a'], [
           '',

--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -2803,7 +2803,7 @@ SELECT contact_id
             // The first 2 criteria are redundant but are added as they
             // seem like they would
             // be quicker than this 3rd check.
-            && max(array_map('ord', str_split($criterion))) >= 240) {
+            && max(array_map('ord', str_split((string) $criterion))) >= 240) {
             // String contains unsupported emojis.
             // We return a clause that resolves to false as an emoji string by definition cannot be saved.
             // note that if we return just 0 for false if gets lost in empty checks.


### PR DESCRIPTION
…being passed into php functions

Overview
----------------------------------------
This fixes the following two test failures in php8

- api_v3_CustomGroupTest::testCustomGroupExtendsMultipleCreate
TypeError: implode(): Argument #2 ($array) must be of type ?array, string given
- api_v3_ACLPermissionTest::testActivitiesGetMultipleIdsCheckPermissionsLimitedACL with data set "APIv4" (4)
TypeError: str_split(): Argument #1 ($string) must be of type string, array given

Before
----------------------------------------
Those specific tests fail on php8

After
----------------------------------------
Those specific tests pass on php8

ping @eileenmcnaughton @totten @demeritcowboy 