### PR TITLE
[php8-compat] Fix api_v3_PaymentTest failures by putting in more guar…

### DIFF
--- a/xml/templates/message_templates/event_offline_receipt_html.tpl
+++ b/xml/templates/message_templates/event_offline_receipt_html.tpl
@@ -214,6 +214,7 @@
         {/if}
        {/foreach}
        {if !empty($dataArray)}
+        {if isset($totalAmount) and isset($totalTaxAmount)}
         <tr>
          <td {$labelStyle}>
           {ts}Amount Before Tax:{/ts}
@@ -222,6 +223,7 @@
           {$totalAmount-$totalTaxAmount|crmMoney}
          </td>
         </tr>
+        {/if}
         {foreach from=$dataArray item=value key=priceset}
           <tr>
            {if $priceset || $priceset == 0}

--- a/xml/templates/message_templates/event_offline_receipt_text.tpl
+++ b/xml/templates/message_templates/event_offline_receipt_text.tpl
@@ -119,7 +119,9 @@
 {/foreach}
 
 {if !empty($dataArray)}
+{if isset($totalAmount) and isset($totalTaxAmount)}
 {ts}Amount before Tax{/ts}: {$totalAmount-$totalTaxAmount|crmMoney:$currency}
+{/if}
 
 {foreach from=$dataArray item=value key=priceset}
 {if $priceset || $priceset == 0}

--- a/xml/templates/message_templates/event_online_receipt_html.tpl
+++ b/xml/templates/message_templates/event_online_receipt_html.tpl
@@ -257,6 +257,7 @@
         {/if}
        {/foreach}
        {if !empty($dataArray)}
+        {if isset($totalAmount) and isset($totalTaxAmount)}
         <tr>
          <td {$labelStyle}>
           {ts} Amount Before Tax: {/ts}
@@ -265,6 +266,7 @@
           {$totalAmount-$totalTaxAmount|crmMoney}
          </td>
         </tr>
+        {/if}
         {foreach from=$dataArray item=value key=priceset}
          <tr>
           {if $priceset || $priceset == 0}

--- a/xml/templates/message_templates/event_online_receipt_text.tpl
+++ b/xml/templates/message_templates/event_online_receipt_text.tpl
@@ -139,7 +139,9 @@ You were registered by: {$payer.name}
 {""|string_format:"%120s"}
 
 {if !empty($dataArray)}
+{if isset($totalAmount) and isset($totalTaxAmount)}
 {ts}Amount before Tax{/ts}: {$totalAmount-$totalTaxAmount|crmMoney:$currency}
+{/if}
 
 {foreach from=$dataArray item=value key=priceset}
 {if $priceset || $priceset == 0}

--- a/xml/templates/message_templates/membership_offline_receipt_html.tpl
+++ b/xml/templates/message_templates/membership_offline_receipt_html.tpl
@@ -145,6 +145,7 @@
                   </tr>
                 {/foreach}
                 {if !empty($dataArray)}
+                  {if isset($formValues.total_amount) and isset($totalTaxAmount)}
                   <tr>
                     <td {$labelStyle}>
                       {ts}Amount Before Tax:{/ts}
@@ -153,6 +154,7 @@
                       {$formValues.total_amount-$totalTaxAmount|crmMoney}
                     </td>
                   </tr>
+                  {/if}
                   {foreach from=$dataArray item=value key=priceset}
                     <tr>
                       {if $priceset}

--- a/xml/templates/message_templates/payment_or_refund_notification_html.tpl
+++ b/xml/templates/message_templates/payment_or_refund_notification_html.tpl
@@ -71,7 +71,7 @@
         </td>
       </tr>
     {/if}
-    {if $trxn_id}
+    {if !empty($trxn_id)}
       <tr>
         <td {$labelStyle}>
         {ts}Transaction #{/ts}
@@ -81,7 +81,7 @@
         </td>
       </tr>
     {/if}
-    {if $paidBy}
+    {if !empty($paidBy)}
       <tr>
         <td {$labelStyle}>
         {ts}Paid By{/ts}
@@ -91,7 +91,7 @@
         </td>
       </tr>
     {/if}
-    {if $checkNumber}
+    {if !empty($checkNumber)}
       <tr>
         <td {$labelStyle}>
         {ts}Check Number{/ts}
@@ -105,6 +105,7 @@
   <tr>
     <th {$headerStyle}>{ts}Contribution Details{/ts}</th>
   </tr>
+  {if isset($totalAmount)}
   <tr>
     <td {$labelStyle}>
       {ts}Total Fee{/ts}
@@ -113,6 +114,8 @@
       {$totalAmount|crmMoney}
     </td>
   </tr>
+  {/if}
+  {if isset($totalPaid)}
   <tr>
     <td {$labelStyle}>
       {ts}Total Paid{/ts}
@@ -121,6 +124,8 @@
       {$totalPaid|crmMoney}
     </td>
   </tr>
+  {/if}
+  {if isset($amountOwed)}
   <tr>
     <td {$labelStyle}>
       {ts}Balance Owed{/ts}
@@ -129,6 +134,7 @@
       {$amountOwed|crmMoney}
     </td> {* This will be zero after final payment. *}
   </tr>
+  {/if}
   </table>
 
   </td>
@@ -136,7 +142,7 @@
     <tr>
       <td>
   <table style="border: 1px solid #999; margin: 1em 0em 1em; border-collapse: collapse; width:100%;">
-    {if $billingName || $address}
+    {if !empty($billingName) || !empty($address)}
           <tr>
             <th {$headerStyle}>
         {ts}Billing Name and Address{/ts}
@@ -144,12 +150,12 @@
           </tr>
           <tr>
             <td colspan="2" {$valueStyle}>
-        {$billingName}<br />
-        {$address|nl2br}
+        {if !empty($billingName)}{$billingName}{/if}<br />
+        {if !empty($address)}{$address|nl2br}{/if}
             </td>
           </tr>
     {/if}
-    {if $credit_card_number}
+    {if !empty($credit_card_number)}
           <tr>
             <th {$headerStyle}>
         {ts}Credit Card Information{/ts}

--- a/xml/templates/message_templates/payment_or_refund_notification_text.tpl
+++ b/xml/templates/message_templates/payment_or_refund_notification_text.tpl
@@ -31,13 +31,13 @@
 {if $receive_date}
 {ts}Transaction Date{/ts}: {$receive_date|crmDate}
 {/if}
-{if $trxn_id}
+{if !empty($trxn_id)}
 {ts}Transaction #{/ts}: {$trxn_id}
 {/if}
-{if $paidBy}
+{if !empty($paidBy)}
 {ts}Paid By{/ts}: {$paidBy}
 {/if}
-{if $checkNumber}
+{if !empty($checkNumber)}
 {ts}Check Number{/ts}: {$checkNumber}
 {/if}
 
@@ -46,24 +46,33 @@
 {ts}Contribution Details{/ts}
 
 ===============================================================================
+{if isset($totalAmount)}
 {ts}Total Fee{/ts}: {$totalAmount|crmMoney}
+{/if}
+{if isset($totalPaid)}
 {ts}Total Paid{/ts}: {$totalPaid|crmMoney}
+{/if}
+{if isset($amountOwed)}
 {ts}Balance Owed{/ts}: {$amountOwed|crmMoney} {* This will be zero after final payment. *}
+{/if}
 
 
-{if $billingName || $address}
+{if !empty($billingName) || !empty($address)}
 
 ===============================================================================
 
 {ts}Billing Name and Address{/ts}
 
 ===============================================================================
-
+{if !empty($billingName)}
 {$billingName}
+{/if}
+{if !empty($address)}
 {$address}
 {/if}
+{/if}
 
-{if $credit_card_number}
+{if !empty($credit_card_number)}
 ===========================================================
 {ts}Credit Card Information{/ts}
 
@@ -83,15 +92,15 @@
 {$event.event_title}
 {$event.event_start_date|crmDate}{if $event.event_end_date}-{if $event.event_end_date|date_format:"%Y%m%d" == $event.event_start_date|date_format:"%Y%m%d"}{$event.event_end_date|crmDate:0:1}{else}{$event.event_end_date|crmDate}{/if}{/if}
 
-{if $event.participant_role}
+{if !empty($event.participant_role)}
 {ts}Participant Role{/ts}: {$event.participant_role}
 {/if}
 
-{if $isShowLocation}
+{if !empty($isShowLocation)}
 {$location.address.1.display|strip_tags:false}
 {/if}{*End of isShowLocation condition*}
 
-{if $location.phone.1.phone || $location.email.1.email}
+{if !empty($location.phone.1.phone) || !empty($location.email.1.email)}
 
 {ts}Event Contacts:{/ts}
 {foreach from=$location.phone item=phone}


### PR DESCRIPTION
…ds into message templates

Overview
----------------------------------------
This fixes test failures such as 

- api_v3_PaymentTest::testRefundEmailReceipt with data set #0 ('.')
Failure in api call for Payment sendconfirmation:  Undefined array key "participant_role"

Before
----------------------------------------
api_v3_PaymentTest Fails on php8

After
----------------------------------------
api_v3_PaymentTest passes on php8

ping @eileenmcnaughton @totten @demeritcowboy 