### PR TITLE
Test fix up for AdditionalPaymentTest

### DIFF
--- a/tests/phpunit/CRM/Member/Form/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/Form/MembershipTest.php
@@ -1375,7 +1375,7 @@ Expires: ',
    */
   public function testContributionFormStatusUpdate(): void {
 
-    $this->_contactID = $this->createLoggedInUser();
+    $this->_contactID = $this->ids['Contact']['order'] = $this->createLoggedInUser();
     $this->createContributionAndMembershipOrder();
 
     $params = [

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -2794,11 +2794,10 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
    * @throws \CRM_Core_Exception|\CiviCRM_API3_Exception
    */
   public function testContributionOrder() {
-    $this->_contactID = $this->individualCreate();
     $this->createContributionAndMembershipOrder();
     $contribution = $this->callAPISuccess('contribution', 'get')['values'][$this->ids['Contribution'][0]];
     $this->assertEquals('Pending Label**', $contribution['contribution_status']);
-    $membership = $this->callAPISuccessGetSingle('Membership', ['contact_id' => $this->_contactID]);
+    $membership = $this->callAPISuccessGetSingle('Membership', ['contact_id' => $this->ids['Contact']['order']]);
 
     $this->callAPISuccess('Payment', 'create', [
       'contribution_id' => $this->ids['Contribution'][0],

--- a/tests/phpunit/api/v3/MembershipTest.php
+++ b/tests/phpunit/api/v3/MembershipTest.php
@@ -144,7 +144,7 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
    * @throws \CiviCRM_API3_Exception
    */
   public function testActivityForCancelledContribution(): void {
-    $contactId = $this->createLoggedInUser();
+    $contactId = $this->ids['Contact']['order'] = $this->createLoggedInUser();
 
     $this->createContributionAndMembershipOrder();
     $membershipID = $this->callAPISuccessGetValue('MembershipPayment', ['return' => 'id']);


### PR DESCRIPTION

Overview
----------------------------------------
This addresses a poor set up issue where the membership + contribution was being
set up incorrectly &  hence the line items were wrong, along with the ability
to validate the financials. It was blocking https://github.com/civicrm/civicrm-core/pull/20495
along with the efforts to get financial validation on all tests

Before
----------------------------------------
test set up not using order api, not valid 

After
----------------------------------------
Uses order api, valid

Technical Details
----------------------------------------

Comments
----------------------------------------
