### PR TITLE
[REF] Move pcpNotifyOwner to ContributionSoft

### DIFF
--- a/CRM/Contribute/BAO/ContributionSoft.php
+++ b/CRM/Contribute/BAO/ContributionSoft.php
@@ -9,6 +9,8 @@
  +--------------------------------------------------------------------+
  */
 
+use Civi\Api4\Contribution;
+
 /**
  *
  * @package CRM
@@ -588,6 +590,7 @@ class CRM_Contribute_BAO_ContributionSoft extends CRM_Contribute_DAO_Contributio
    *
    * @throws \CRM_Core_Exception
    * @throws \CiviCRM_API3_Exception
+   * @throws \API_Exception
    */
   protected static function processPCP($pcp, $contribution) {
     $pcpId = self::getSoftCreditIds($contribution->id, TRUE);
@@ -609,12 +612,75 @@ class CRM_Contribute_BAO_ContributionSoft extends CRM_Contribute_DAO_Contributio
       $contributionSoft = self::add($softParams);
       //Send notification to owner for PCP
       if ($contributionSoft->pcp_id && empty($pcpId)) {
-        CRM_Contribute_Form_Contribution_Confirm::pcpNotifyOwner($contribution, (array) $contributionSoft);
+        self::pcpNotifyOwner($contribution->id, (array) $contributionSoft);
       }
     }
     //Delete PCP against this contribution and create new on submitted PCP information
     elseif ($pcpId) {
       civicrm_api3('ContributionSoft', 'delete', ['id' => $pcpId]);
+    }
+  }
+
+  /**
+   * Function used to send notification mail to pcp owner.
+   *
+   * @param int $contributionID
+   * @param array $contributionSoft
+   *   Contribution object.
+   *
+   * @throws \API_Exception
+   * @throws \CRM_Core_Exception
+   */
+  public static function pcpNotifyOwner(int $contributionID, array $contributionSoft): void {
+    $params = ['id' => $contributionSoft['pcp_id']];
+    $contribution = Contribution::get(FALSE)
+      ->addWhere('id', '=', $contributionID)
+      ->addSelect('receive_date', 'contact_id')->execute()->first();
+    CRM_Core_DAO::commonRetrieve('CRM_PCP_DAO_PCP', $params, $pcpInfo);
+    $ownerNotifyID = CRM_Core_DAO::getFieldValue('CRM_PCP_DAO_PCPBlock', $pcpInfo['pcp_block_id'], 'owner_notify_id');
+    $ownerNotifyOption = CRM_Core_PseudoConstant::getName('CRM_PCP_DAO_PCPBlock', 'owner_notify_id', $ownerNotifyID);
+
+    if ($ownerNotifyOption !== 'no_notifications' &&
+      (($ownerNotifyOption === 'owner_chooses' &&
+          CRM_Core_DAO::getFieldValue('CRM_PCP_DAO_PCP', $contributionSoft['pcp_id'], 'is_notify')) ||
+        $ownerNotifyOption === 'all_owners')) {
+      $pcpInfoURL = CRM_Utils_System::url('civicrm/pcp/info',
+        "reset=1&id={$contributionSoft['pcp_id']}",
+        TRUE, NULL, FALSE, TRUE
+      );
+      // set email in the template here
+
+      if (CRM_Core_BAO_LocationType::getBilling()) {
+        [$donorName, $email] = CRM_Contact_BAO_Contact_Location::getEmailDetails($contribution['contact_id'],
+          FALSE, CRM_Core_BAO_LocationType::getBilling());
+      }
+      // get primary location email if no email exist( for billing location).
+      if (!$email) {
+        [$donorName, $email] = CRM_Contact_BAO_Contact_Location::getEmailDetails($contribution['contact_id']);
+      }
+      [$ownerName, $ownerEmail] = CRM_Contact_BAO_Contact_Location::getEmailDetails($contributionSoft['contact_id']);
+      $tplParams = [
+        'page_title' => $pcpInfo['title'],
+        'receive_date' => $contribution['receive_date'],
+        'total_amount' => $contributionSoft['amount'],
+        'donors_display_name' => $donorName,
+        'donors_email' => $email,
+        'pcpInfoURL' => $pcpInfoURL,
+        'is_honor_roll_enabled' => $contributionSoft['pcp_display_in_roll'],
+        'currency' => $contributionSoft['currency'],
+      ];
+      $domainValues = CRM_Core_BAO_Domain::getNameAndEmail();
+      $sendTemplateParams = [
+        'groupName' => 'msg_tpl_workflow_contribution',
+        'valueName' => 'pcp_owner_notify',
+        'contactId' => $contributionSoft['contact_id'],
+        'toEmail' => $ownerEmail,
+        'toName' => $ownerName,
+        'from' => "$domainValues[0] <$domainValues[1]>",
+        'tplParams' => $tplParams,
+        'PDFFilename' => 'receipt.pdf',
+      ];
+      CRM_Core_BAO_MessageTemplate::sendTemplate($sendTemplateParams);
     }
   }
 

--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -1389,68 +1389,6 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
   }
 
   /**
-   * Function used to send notification mail to pcp owner.
-   *
-   * This is used by contribution and also event PCPs.
-   *
-   * @param object $contribution
-   * @param array $contributionSoft
-   *   Contribution object.
-   *
-   * @throws \API_Exception
-   * @throws \CRM_Core_Exception
-   */
-  public static function pcpNotifyOwner($contribution, array $contributionSoft) {
-    $params = ['id' => $contributionSoft['pcp_id']];
-    CRM_Core_DAO::commonRetrieve('CRM_PCP_DAO_PCP', $params, $pcpInfo);
-    $ownerNotifyID = CRM_Core_DAO::getFieldValue('CRM_PCP_DAO_PCPBlock', $pcpInfo['pcp_block_id'], 'owner_notify_id');
-    $ownerNotifyOption = CRM_Core_PseudoConstant::getName('CRM_PCP_DAO_PCPBlock', 'owner_notify_id', $ownerNotifyID);
-
-    if ($ownerNotifyOption != 'no_notifications' &&
-        (($ownerNotifyOption == 'owner_chooses' &&
-        CRM_Core_DAO::getFieldValue('CRM_PCP_DAO_PCP', $contributionSoft['pcp_id'], 'is_notify')) ||
-        $ownerNotifyOption == 'all_owners')) {
-      $pcpInfoURL = CRM_Utils_System::url('civicrm/pcp/info',
-        "reset=1&id={$contributionSoft['pcp_id']}",
-        TRUE, NULL, FALSE, TRUE
-      );
-      // set email in the template here
-
-      if (CRM_Core_BAO_LocationType::getBilling()) {
-        [$donorName, $email] = CRM_Contact_BAO_Contact_Location::getEmailDetails($contribution->contact_id,
-          FALSE, CRM_Core_BAO_LocationType::getBilling());
-      }
-      // get primary location email if no email exist( for billing location).
-      if (!$email) {
-        [$donorName, $email] = CRM_Contact_BAO_Contact_Location::getEmailDetails($contribution->contact_id);
-      }
-      [$ownerName, $ownerEmail] = CRM_Contact_BAO_Contact_Location::getEmailDetails($contributionSoft['contact_id']);
-      $tplParams = [
-        'page_title' => $pcpInfo['title'],
-        'receive_date' => $contribution->receive_date,
-        'total_amount' => $contributionSoft['amount'],
-        'donors_display_name' => $donorName,
-        'donors_email' => $email,
-        'pcpInfoURL' => $pcpInfoURL,
-        'is_honor_roll_enabled' => $contributionSoft['pcp_display_in_roll'],
-        'currency' => $contributionSoft['currency'],
-      ];
-      $domainValues = CRM_Core_BAO_Domain::getNameAndEmail();
-      $sendTemplateParams = [
-        'groupName' => 'msg_tpl_workflow_contribution',
-        'valueName' => 'pcp_owner_notify',
-        'contactId' => $contributionSoft['contact_id'],
-        'toEmail' => $ownerEmail,
-        'toName' => $ownerName,
-        'from' => "$domainValues[0] <$domainValues[1]>",
-        'tplParams' => $tplParams,
-        'PDFFilename' => 'receipt.pdf',
-      ];
-      CRM_Core_BAO_MessageTemplate::sendTemplate($sendTemplateParams);
-    }
-  }
-
-  /**
    * Function used to se pcp related defaults / params.
    *
    * This is used by contribution and also event PCPs


### PR DESCRIPTION

Overview
----------------------------------------
[REF] Move pcpNotifyOwner to ContributionSoft

This is cleanup towards https://github.com/civicrm/civicrm-core/pull/19096 in that
it gets the function out of the form layer and also makes it so it does
not require a BAO. 


Before
----------------------------------------
contribution BAO required as a param

After
----------------------------------------
contributionID required as a param

This does add one extra db lookup in some cases but I think
it's pretty low volume and will mean this is not required

https://github.com/civicrm/civicrm-core/pull/19096/files#diff-4c9d0b1abe07057a4eea2b47bc627eecb95face8ed8d86c1c005312a52cca811R4271-R4273

Technical Details
----------------------------------------

A git universe check did not find any other calls to this function

Comments
----------------------------------------

test cover in ```testSubmitWithPCP()```