### PR TITLE
[php8-compat][REF] Fix Date unit tests in php8 by passing in 00 inste…

### DIFF
--- a/CRM/Utils/Date.php
+++ b/CRM/Utils/Date.php
@@ -966,9 +966,9 @@ class CRM_Utils_Date {
    */
   public static function intervalAdd($unit, $interval, $date, $dontCareTime = FALSE) {
     if (is_array($date)) {
-      $hour = $date['H'] ?? NULL;
-      $minute = $date['i'] ?? NULL;
-      $second = $date['s'] ?? NULL;
+      $hour = $date['H'] ?? '00';
+      $minute = $date['i'] ?? '00';
+      $second = $date['s'] ?? '00';
       $month = $date['M'] ?? NULL;
       $day = $date['d'] ?? NULL;
       $year = $date['Y'] ?? NULL;


### PR DESCRIPTION
…ad of null for hours,minutes and seconds

Overview
----------------------------------------
This fixes a test failures such as 

```
CRM_Utils_DateTest::testRelativeEarlierDay
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
 Array (
     'from' => null
-    'to' => '20210605000000'
+    'to' => '20210605003229'
 )
 ```

Before
----------------------------------------
Date test fails in php8

After
----------------------------------------
Date tests pass in php8

Technical Details
----------------------------------------
as per https://www.php.net/manual/en/function.mktime.php#refsect1-function.mktime-changelog the hours, minutes and seconds is now nullable and this means that if null is passed in the current time values for that section is used

ping @eileenmcnaughton @totten @demeritcowboy 