### PR TITLE
[php8-compact][REF] Fix another couple of places where by there are r…

### DIFF
--- a/CRM/Core/Form/RecurringEntity.php
+++ b/CRM/Core/Form/RecurringEntity.php
@@ -321,7 +321,7 @@ class CRM_Core_Form_RecurringEntity {
    *
    * @throws \CiviCRM_API3_Exception
    */
-  public static function postProcess($params = [], $type, $linkedEntities = []) {
+  public static function postProcess($params, $type, $linkedEntities = []) {
     // Check entity_id not present in params take it from class variable
     if (empty($params['entity_id'])) {
       $params['entity_id'] = self::$_entityId;

--- a/CRM/Utils/Mail/Incoming.php
+++ b/CRM/Utils/Mail/Incoming.php
@@ -446,7 +446,7 @@ class CRM_Utils_Mail_Incoming {
    *
    * @return int|null
    */
-  public static function getContactID($email, $name = NULL, $create = TRUE, &$mail) {
+  public static function getContactID($email, $name, $create, &$mail) {
     $dao = CRM_Contact_BAO_Contact::matchContactOnEmail($email, 'Individual');
 
     $contactID = NULL;


### PR DESCRIPTION
…equired variables in php function declaration after optional ones

Overview
----------------------------------------
This fixes the test failure

```
CRM_Utils_Mail_EmailProcessorInboundTest.testFetchActivitiesWithManyAttachments
```

Before
----------------------------------------
PHP8 complains about these functions as they have required parameters after optional parameters

After
----------------------------------------
PHP8 doesn't complain about these functions

ping @eileenmcnaughton @demeritcowboy @totten 