### PR TITLE
[php8-compact][REF] Fix api_v3_PaymentTokenTest to work on php8

### DIFF
--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -2032,7 +2032,7 @@ VALUES
     }
 
     foreach ($params as $key => $value) {
-      if ($key == 'version' || substr($key, 0, 3) == 'api' || !array_key_exists($keys[$key], $result)) {
+      if ($key == 'version' || substr($key, 0, 3) == 'api' || (!array_key_exists($key, $keys) || !array_key_exists($keys[$key], $result))) {
         continue;
       }
       if (in_array($key, $dateFields)) {


### PR DESCRIPTION
Overview
----------------------------------------
This fixes the following test failure on php8

```
api_v3_PaymentTokenTest::testCreatePaymentToken with data set "APIv3" (3)
Undefined array key 0

/home/jenkins/bknix-edge/build/build-0/web/sites/all/modules/civicrm/tests/phpunit/CiviTest/CiviUnitTestCase.php:2035
```

Before
----------------------------------------
That specific test fails on php8

After
----------------------------------------
Test passes on php8

ping @eileenmcnaughton @totten @demeritcowboy 