### PR TITLE
dev/report#67 Fix standalone export classes

### DIFF
--- a/CRM/Export/Controller/Standalone.php
+++ b/CRM/Export/Controller/Standalone.php
@@ -72,7 +72,7 @@ class CRM_Export_Controller_Standalone extends CRM_Core_Controller {
     $className = 'CRM_' . $this->getComponent($this->get('entity')) . '_Task';
     foreach ($className::tasks() as $taskId => $task) {
       $taskForm = (array) $task['class'];
-      if (strpos($taskForm[0], 'CRM_Export_Form_Select') === 0) {
+      if (strpos($taskForm[0], '_Export_Form_Select') !== FALSE) {
         $values['task'] = $taskId;
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------
This fixes an 'access denied' error on standalone export forms, caused by renaming the php classes.

See https://lab.civicrm.org/dev/report/-/issues/67

Before
----------------------------------------
Contact export was working, but trying to export Participants, Grants, etc. from SearchKit would fail.

After
----------------------------------------
All exports should be working now.

Technical Details
----------------------------------------
The bug seems to have been caused by renaming classes in 0a595a2ed9dd4a16ef794e69c8628efea581bbae