### PR TITLE
Introduce civi.api4.authorizeRecord and civi.api4.validate

### DIFF
--- a/CRM/Contact/AccessTrait.php
+++ b/CRM/Contact/AccessTrait.php
@@ -21,13 +21,14 @@
 trait CRM_Contact_AccessTrait {
 
   /**
+   * @param string $entityName
    * @param string $action
    * @param array $record
    * @param int|NULL $userID
    * @return bool
    * @see CRM_Core_DAO::checkAccess
    */
-  public static function _checkAccess(string $action, array $record, $userID) {
+  public static function _checkAccess(string $entityName, string $action, array $record, $userID) {
     $cid = $record['contact_id'] ?? NULL;
     if (!$cid && !empty($record['id'])) {
       $cid = CRM_Core_DAO::getFieldValue(__CLASS__, $record['id'], 'contact_id');

--- a/CRM/Contact/AccessTrait.php
+++ b/CRM/Contact/AccessTrait.php
@@ -1,0 +1,43 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+/**
+ * Trait shared with entities attached to the contact record.
+ */
+trait CRM_Contact_AccessTrait {
+
+  /**
+   * @param string $action
+   * @param array $record
+   * @param int|NULL $userID
+   * @return bool
+   * @see CRM_Core_DAO::checkAccess
+   */
+  public static function _checkAccess(string $action, array $record, $userID) {
+    $cid = $record['contact_id'] ?? NULL;
+    if (!$cid && !empty($record['id'])) {
+      $cid = CRM_Core_DAO::getFieldValue(__CLASS__, $record['id'], 'contact_id');
+    }
+    if (!$cid) {
+      // With no contact id this must be part of an event locblock
+      return in_array(__CLASS__, ['CRM_Core_BAO_Phone', 'CRM_Core_BAO_Email', 'CRM_Core_BAO_Address']) &&
+        CRM_Core_Permission::check('edit all events', $userID);
+    }
+    return CRM_Contact_BAO_Contact::checkAccess($action, ['id' => $cid], $userID);
+  }
+
+}

--- a/CRM/Contact/AccessTrait.php
+++ b/CRM/Contact/AccessTrait.php
@@ -24,11 +24,11 @@ trait CRM_Contact_AccessTrait {
    * @param string $entityName
    * @param string $action
    * @param array $record
-   * @param int|NULL $userID
+   * @param int $userID
    * @return bool
    * @see CRM_Core_DAO::checkAccess
    */
-  public static function _checkAccess(string $entityName, string $action, array $record, $userID) {
+  public static function _checkAccess(string $entityName, string $action, array $record, int $userID) {
     $cid = $record['contact_id'] ?? NULL;
     if (!$cid && !empty($record['id'])) {
       $cid = CRM_Core_DAO::getFieldValue(__CLASS__, $record['id'], 'contact_id');

--- a/CRM/Contact/AccessTrait.php
+++ b/CRM/Contact/AccessTrait.php
@@ -37,7 +37,7 @@ trait CRM_Contact_AccessTrait {
       return in_array(__CLASS__, ['CRM_Core_BAO_Phone', 'CRM_Core_BAO_Email', 'CRM_Core_BAO_Address']) &&
         CRM_Core_Permission::check('edit all events', $userID);
     }
-    return CRM_Contact_BAO_Contact::checkAccess(CRM_Core_Permission::EDIT, ['id' => $cid], $userID);
+    return \Civi\Api4\Utils\CoreUtil::checkAccessDelegated('Contact', 'update', ['id' => $cid], $userID);
   }
 
 }

--- a/CRM/Contact/AccessTrait.php
+++ b/CRM/Contact/AccessTrait.php
@@ -37,7 +37,7 @@ trait CRM_Contact_AccessTrait {
       return in_array(__CLASS__, ['CRM_Core_BAO_Phone', 'CRM_Core_BAO_Email', 'CRM_Core_BAO_Address']) &&
         CRM_Core_Permission::check('edit all events', $userID);
     }
-    return CRM_Contact_BAO_Contact::checkAccess($action, ['id' => $cid], $userID);
+    return CRM_Contact_BAO_Contact::checkAccess(CRM_Core_Permission::EDIT, ['id' => $cid], $userID);
   }
 
 }

--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -3729,13 +3729,14 @@ LEFT JOIN civicrm_address ON ( civicrm_address.contact_id = civicrm_contact.id )
   }
 
   /**
+   * @param string $entityName
    * @param string $action
    * @param array $record
    * @param $userID
    * @return bool
    * @see CRM_Core_DAO::checkAccess
    */
-  public static function _checkAccess(string $action, array $record, $userID): bool {
+  public static function _checkAccess(string $entityName, string $action, array $record, $userID): bool {
     switch ($action) {
       case 'create':
         return CRM_Core_Permission::check('add contacts', $userID);

--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -3728,4 +3728,32 @@ LEFT JOIN civicrm_address ON ( civicrm_address.contact_id = civicrm_contact.id )
     ];
   }
 
+  /**
+   * @param string $action
+   * @param array $record
+   * @param $userID
+   * @return bool
+   * @see CRM_Core_DAO::checkAccess
+   */
+  public static function _checkAccess(string $action, array $record, $userID): bool {
+    switch ($action) {
+      case 'create':
+        return CRM_Core_Permission::check('add contacts', $userID);
+
+      case 'get':
+        $actionType = CRM_Core_Permission::VIEW;
+        break;
+
+      case 'delete':
+        $actionType = CRM_Core_Permission::DELETE;
+        break;
+
+      default:
+        $actionType = CRM_Core_Permission::EDIT;
+        break;
+    }
+
+    return CRM_Contact_BAO_Contact_Permission::allow($record['id'], $actionType, $userID);
+  }
+
 }

--- a/CRM/Core/BAO/Address.php
+++ b/CRM/Core/BAO/Address.php
@@ -19,6 +19,7 @@
  * This is class to handle address related functions.
  */
 class CRM_Core_BAO_Address extends CRM_Core_DAO_Address {
+  use CRM_Contact_AccessTrait;
 
   /**
    * Takes an associative array and creates a address.

--- a/CRM/Core/BAO/CustomValue.php
+++ b/CRM/Core/BAO/CustomValue.php
@@ -224,14 +224,17 @@ class CRM_Core_BAO_CustomValue extends CRM_Core_DAO {
   /**
    * Special checkAccess function for multi-record custom pseudo-entities
    *
+   * @param string $entityName
+   *   Ex: 'Contact' or 'Custom_Foobar'
    * @param string $action
    * @param array $record
-   * @param null $userID
+   * @param int|null $userID
+   *   Contact ID of the active user (whose access we must check). NULL for anonymous.
    * @param bool $granted
-   * @param string $groupName
    * @return bool
    */
-  public static function checkAccess(string $action, array $record, $userID = NULL, $granted = TRUE, $groupName = NULL): bool {
+  public static function checkAccess(string $entityName, string $action, array $record, $userID, $granted = TRUE): bool {
+    $groupName = substr($entityName, 0, 7) === 'Custom_' ? substr($entityName, 7) : NULL;
     if (!$groupName) {
       // $groupName is required but the function signature has to match the parent.
       throw new CRM_Core_Exception('Missing required $groupName in CustomValue::checkAccess');

--- a/CRM/Core/BAO/CustomValue.php
+++ b/CRM/Core/BAO/CustomValue.php
@@ -228,12 +228,12 @@ class CRM_Core_BAO_CustomValue extends CRM_Core_DAO {
    *   Ex: 'Contact' or 'Custom_Foobar'
    * @param string $action
    * @param array $record
-   * @param int|null $userID
-   *   Contact ID of the active user (whose access we must check). NULL for anonymous.
+   * @param int $userID
+   *   Contact ID of the active user (whose access we must check). 0 for anonymous.
    * @return bool
    *   TRUE if granted. FALSE if prohibited. NULL if indeterminate.
    */
-  public static function _checkAccess(string $entityName, string $action, array $record, $userID): ?bool {
+  public static function _checkAccess(string $entityName, string $action, array $record, int $userID): ?bool {
     $groupName = substr($entityName, 0, 7) === 'Custom_' ? substr($entityName, 7) : NULL;
     if (!$groupName) {
       // $groupName is required but the function signature has to match the parent.

--- a/CRM/Core/BAO/CustomValue.php
+++ b/CRM/Core/BAO/CustomValue.php
@@ -230,10 +230,10 @@ class CRM_Core_BAO_CustomValue extends CRM_Core_DAO {
    * @param array $record
    * @param int|null $userID
    *   Contact ID of the active user (whose access we must check). NULL for anonymous.
-   * @param bool $granted
    * @return bool
+   *   TRUE if granted. FALSE if prohibited. NULL if indeterminate.
    */
-  public static function checkAccess(string $entityName, string $action, array $record, $userID, $granted = TRUE): bool {
+  public static function _checkAccess(string $entityName, string $action, array $record, $userID): ?bool {
     $groupName = substr($entityName, 0, 7) === 'Custom_' ? substr($entityName, 7) : NULL;
     if (!$groupName) {
       // $groupName is required but the function signature has to match the parent.
@@ -251,13 +251,7 @@ class CRM_Core_BAO_CustomValue extends CRM_Core_DAO {
       $cid = CRM_Core_DAO::singleValueQuery("SELECT entity_id FROM `$tableName` WHERE id = " . (int) $record['id']);
     }
 
-    // Dispatch to hook
-    $granted = NULL;
-    CRM_Utils_Hook::checkAccess("Custom_$groupName", $action, $record, $userID, $granted);
-    if ($granted === NULL) {
-      $granted = \Civi\Api4\Utils\CoreUtil::checkAccessDelegated('Contact', 'update', ['id' => $cid], $userID);
-    }
-    return $granted;
+    return \Civi\Api4\Utils\CoreUtil::checkAccessDelegated('Contact', 'update', ['id' => $cid], $userID);
   }
 
 }

--- a/CRM/Core/BAO/Email.php
+++ b/CRM/Core/BAO/Email.php
@@ -19,6 +19,7 @@
  * This class contains functions for email handling.
  */
 class CRM_Core_BAO_Email extends CRM_Core_DAO_Email {
+  use CRM_Contact_AccessTrait;
 
   /**
    * Create email address.

--- a/CRM/Core/BAO/EntityTag.php
+++ b/CRM/Core/BAO/EntityTag.php
@@ -16,6 +16,7 @@
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
 class CRM_Core_BAO_EntityTag extends CRM_Core_DAO_EntityTag {
+  use CRM_Core_DynamicFKAccessTrait;
 
   /**
    * Given a contact id, it returns an array of tag id's the contact belongs to.

--- a/CRM/Core/BAO/IM.php
+++ b/CRM/Core/BAO/IM.php
@@ -19,6 +19,7 @@
  * This class contain function for IM handling
  */
 class CRM_Core_BAO_IM extends CRM_Core_DAO_IM {
+  use CRM_Contact_AccessTrait;
 
   /**
    * Create or update IM record.

--- a/CRM/Core/BAO/Note.php
+++ b/CRM/Core/BAO/Note.php
@@ -19,6 +19,7 @@
  * BAO object for crm_note table.
  */
 class CRM_Core_BAO_Note extends CRM_Core_DAO_Note {
+  use CRM_Core_DynamicFKAccessTrait;
 
   /**
    * Const the max number of notes we display at any given time.

--- a/CRM/Core/BAO/OpenID.php
+++ b/CRM/Core/BAO/OpenID.php
@@ -19,6 +19,7 @@
  * This class contains function for Open Id
  */
 class CRM_Core_BAO_OpenID extends CRM_Core_DAO_OpenID {
+  use CRM_Contact_AccessTrait;
 
   /**
    * Create or update OpenID record.

--- a/CRM/Core/BAO/Phone.php
+++ b/CRM/Core/BAO/Phone.php
@@ -19,6 +19,7 @@
  * Class contains functions for phone.
  */
 class CRM_Core_BAO_Phone extends CRM_Core_DAO_Phone {
+  use CRM_Contact_AccessTrait;
 
   /**
    * Create phone object - note that the create function calls 'add' but

--- a/CRM/Core/BAO/UFJoin.php
+++ b/CRM/Core/BAO/UFJoin.php
@@ -175,4 +175,15 @@ class CRM_Core_BAO_UFJoin extends CRM_Core_DAO_UFJoin {
     ];
   }
 
+  /**
+   * Override base method which assumes permissions should be based on entity_table.
+   *
+   * @return array
+   */
+  public function addSelectWhereClause() {
+    $clauses = [];
+    CRM_Utils_Hook::selectWhereClause($this, $clauses);
+    return $clauses;
+  }
+
 }

--- a/CRM/Core/BAO/Website.php
+++ b/CRM/Core/BAO/Website.php
@@ -19,6 +19,7 @@
  * This class contain function for Website handling.
  */
 class CRM_Core_BAO_Website extends CRM_Core_DAO_Website {
+  use CRM_Contact_AccessTrait;
 
   /**
    * Create or update Website record.

--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -3067,7 +3067,6 @@ SELECT contact_id
     ) {
       throw new CRM_Core_Exception('Function checkAccess must be called on a BAO class');
     }
-    $userID = isset($userID) ? (int) $userID : CRM_Core_Session::getLoggedInContactID();
     // Dispatch to protected function _checkAccess in this BAO
     if ($granted && method_exists(static::class, '_checkAccess')) {
       $granted = static::_checkAccess($entityName, $action, $record, $userID);

--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -2993,7 +2993,7 @@ SELECT contact_id
         $clauses[$fieldName] = CRM_Utils_SQL::mergeSubquery('Contact');
       }
       // Clause for an entity_table/entity_id combo
-      if ($fieldName == 'entity_id' && isset($fields['entity_table'])) {
+      if ($fieldName === 'entity_id' && isset($fields['entity_table'])) {
         $relatedClauses = [];
         $relatedEntities = $this->buildOptions('entity_table', 'get');
         foreach ((array) $relatedEntities as $table => $ent) {
@@ -3041,8 +3041,44 @@ SELECT contact_id
   }
 
   /**
+   * Check whether action can be performed on a given record.
+   *
+   * Dispatches to internal BAO function ('static::_checkAccess())` and `hook_civicrm_checkAccess`.
+   *
+   * @param string $action
+   *   APIv4 action name.
+   *   Ex: 'create', 'get', 'delete'
+   * @param array $record
+   *   All (known/loaded) values of individual record being accessed.
+   *   The record should provide an 'id' but may otherwise be incomplete; guard accordingly.
+   * @param int $userID
+   *   Contact ID of the active user (whose access we must check).
+   * @param bool $granted
+   *   Initial value (usually TRUE, but the API might pass FALSE if gatekeeper permissions fail)
+   *
+   * @return bool
+   */
+  public static function checkAccess(string $action, array $record, $userID = NULL, $granted = TRUE): bool {
+    $entityName = CRM_Core_DAO_AllCoreTables::getBriefName(static::class);
+    // Ensure this function was either called on a BAO class or a DAO that has no BAO
+    if (!$entityName ||
+      (!strpos(static::class, '_BAO_') && CRM_Core_DAO_AllCoreTables::getBAOClassName(static::class) !== static::class)
+    ) {
+      throw new CRM_Core_Exception('Function checkAccess must be called on a BAO class');
+    }
+    $userID = isset($userID) ? (int) $userID : CRM_Core_Session::getLoggedInContactID();
+    // Dispatch to protected function _checkAccess in this BAO
+    if ($granted && method_exists(static::class, '_checkAccess')) {
+      $granted = static::_checkAccess($action, $record, $userID);
+    }
+    // Dispatch to hook
+    CRM_Utils_Hook::checkAccess($entityName, $action, $record, $userID, $granted);
+    return $granted;
+  }
+
+  /**
    * ensure database name is 'safe', i.e. only contains word characters (includes underscores)
-   * and dashes, and contains at least one [a-z] case insenstive.
+   * and dashes, and contains at least one [a-z] case insensitive.
    *
    * @param $database
    *

--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -3055,25 +3055,22 @@ SELECT contact_id
    *   The record should provide an 'id' but may otherwise be incomplete; guard accordingly.
    * @param int|null $userID
    *   Contact ID of the active user (whose access we must check). NULL for anonymous.
-   * @param bool $granted
-   *   Initial value (usually TRUE, but the API might pass FALSE if gatekeeper permissions fail)
-   *
    * @return bool
+   *   TRUE if granted. FALSE if prohibited. NULL if indeterminate.
    */
-  public static function checkAccess(string $entityName, string $action, array $record, $userID, $granted = TRUE): bool {
+  public static function checkAccess(string $entityName, string $action, array $record, $userID): ?bool {
     // Ensure this function was either called on a BAO class or a DAO that has no BAO
     if (!$entityName ||
       (!strpos(static::class, '_BAO_') && CRM_Core_DAO_AllCoreTables::getBAOClassName(static::class) !== static::class)
     ) {
       throw new CRM_Core_Exception('Function checkAccess must be called on a BAO class');
     }
-    // Dispatch to protected function _checkAccess in this BAO
-    if ($granted && method_exists(static::class, '_checkAccess')) {
-      $granted = static::_checkAccess($entityName, $action, $record, $userID);
+    if (method_exists(static::class, '_checkAccess')) {
+      return static::_checkAccess($entityName, $action, $record, $userID);
     }
-    // Dispatch to hook
-    CRM_Utils_Hook::checkAccess($entityName, $action, $record, $userID, $granted);
-    return $granted;
+    else {
+      return TRUE;
+    }
   }
 
   /**

--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -3045,21 +3045,22 @@ SELECT contact_id
    *
    * Dispatches to internal BAO function ('static::_checkAccess())` and `hook_civicrm_checkAccess`.
    *
+   * @param string $entityName
+   *   Ex: 'Contact' or 'Custom_Foobar'
    * @param string $action
    *   APIv4 action name.
    *   Ex: 'create', 'get', 'delete'
    * @param array $record
    *   All (known/loaded) values of individual record being accessed.
    *   The record should provide an 'id' but may otherwise be incomplete; guard accordingly.
-   * @param int $userID
-   *   Contact ID of the active user (whose access we must check).
+   * @param int|null $userID
+   *   Contact ID of the active user (whose access we must check). NULL for anonymous.
    * @param bool $granted
    *   Initial value (usually TRUE, but the API might pass FALSE if gatekeeper permissions fail)
    *
    * @return bool
    */
-  public static function checkAccess(string $action, array $record, $userID = NULL, $granted = TRUE): bool {
-    $entityName = CRM_Core_DAO_AllCoreTables::getBriefName(static::class);
+  public static function checkAccess(string $entityName, string $action, array $record, $userID, $granted = TRUE): bool {
     // Ensure this function was either called on a BAO class or a DAO that has no BAO
     if (!$entityName ||
       (!strpos(static::class, '_BAO_') && CRM_Core_DAO_AllCoreTables::getBAOClassName(static::class) !== static::class)
@@ -3069,7 +3070,7 @@ SELECT contact_id
     $userID = isset($userID) ? (int) $userID : CRM_Core_Session::getLoggedInContactID();
     // Dispatch to protected function _checkAccess in this BAO
     if ($granted && method_exists(static::class, '_checkAccess')) {
-      $granted = static::_checkAccess($action, $record, $userID);
+      $granted = static::_checkAccess($entityName, $action, $record, $userID);
     }
     // Dispatch to hook
     CRM_Utils_Hook::checkAccess($entityName, $action, $record, $userID, $granted);

--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -3041,39 +3041,6 @@ SELECT contact_id
   }
 
   /**
-   * Check whether action can be performed on a given record.
-   *
-   * Dispatches to internal BAO function ('static::_checkAccess())` and `hook_civicrm_checkAccess`.
-   *
-   * @param string $entityName
-   *   Ex: 'Contact' or 'Custom_Foobar'
-   * @param string $action
-   *   APIv4 action name.
-   *   Ex: 'create', 'get', 'delete'
-   * @param array $record
-   *   All (known/loaded) values of individual record being accessed.
-   *   The record should provide an 'id' but may otherwise be incomplete; guard accordingly.
-   * @param int|null $userID
-   *   Contact ID of the active user (whose access we must check). NULL for anonymous.
-   * @return bool
-   *   TRUE if granted. FALSE if prohibited. NULL if indeterminate.
-   */
-  public static function checkAccess(string $entityName, string $action, array $record, $userID): ?bool {
-    // Ensure this function was either called on a BAO class or a DAO that has no BAO
-    if (!$entityName ||
-      (!strpos(static::class, '_BAO_') && CRM_Core_DAO_AllCoreTables::getBAOClassName(static::class) !== static::class)
-    ) {
-      throw new CRM_Core_Exception('Function checkAccess must be called on a BAO class');
-    }
-    if (method_exists(static::class, '_checkAccess')) {
-      return static::_checkAccess($entityName, $action, $record, $userID);
-    }
-    else {
-      return TRUE;
-    }
-  }
-
-  /**
    * ensure database name is 'safe', i.e. only contains word characters (includes underscores)
    * and dashes, and contains at least one [a-z] case insensitive.
    *

--- a/CRM/Core/DAO/AllCoreTables.php
+++ b/CRM/Core/DAO/AllCoreTables.php
@@ -203,7 +203,7 @@ class CRM_Core_DAO_AllCoreTables {
    */
   public static function getBAOClassName($daoName) {
     $baoName = str_replace('_DAO_', '_BAO_', $daoName);
-    return class_exists($baoName) ? $baoName : $daoName;
+    return $daoName === $baoName || class_exists($baoName) ? $baoName : $daoName;
   }
 
   /**

--- a/CRM/Core/DynamicFKAccessTrait.php
+++ b/CRM/Core/DynamicFKAccessTrait.php
@@ -24,11 +24,11 @@ trait CRM_Core_DynamicFKAccessTrait {
    * @param string $entityName
    * @param string $action
    * @param array $record
-   * @param int|NULL $userID
+   * @param int $userID
    * @return bool
    * @see CRM_Core_DAO::checkAccess
    */
-  public static function _checkAccess(string $entityName, string $action, array $record, $userID): bool {
+  public static function _checkAccess(string $entityName, string $action, array $record, int $userID): bool {
     $eid = $record['entity_id'] ?? NULL;
     $table = $record['entity_table'] ?? NULL;
     if (!$eid && !empty($record['id'])) {

--- a/CRM/Core/DynamicFKAccessTrait.php
+++ b/CRM/Core/DynamicFKAccessTrait.php
@@ -1,0 +1,46 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+/**
+ * Trait for with entities with an entity_table + entity_id dynamic FK.
+ */
+trait CRM_Core_DynamicFKAccessTrait {
+
+  /**
+   * @param string $action
+   * @param array $record
+   * @param int|NULL $userID
+   * @return bool
+   * @see CRM_Core_DAO::checkAccess
+   */
+  public static function _checkAccess(string $action, array $record, $userID): bool {
+    $eid = $record['entity_id'] ?? NULL;
+    $table = $record['entity_table'] ?? NULL;
+    if (!$eid && !empty($record['id'])) {
+      $eid = CRM_Core_DAO::getFieldValue(__CLASS__, $record['id'], 'entity_id');
+    }
+    if ($eid && !$table && !empty($record['id'])) {
+      $table = CRM_Core_DAO::getFieldValue(__CLASS__, $record['id'], 'entity_table');
+    }
+    if ($eid && $table) {
+      $bao = CRM_Core_DAO_AllCoreTables::getBAOClassName(CRM_Core_DAO_AllCoreTables::getClassForTable($table));
+      return $bao::checkAccess(CRM_Core_Permission::EDIT, ['id' => $eid], $userID);
+    }
+    return TRUE;
+  }
+
+}

--- a/CRM/Core/DynamicFKAccessTrait.php
+++ b/CRM/Core/DynamicFKAccessTrait.php
@@ -37,8 +37,8 @@ trait CRM_Core_DynamicFKAccessTrait {
       $table = CRM_Core_DAO::getFieldValue(__CLASS__, $record['id'], 'entity_table');
     }
     if ($eid && $table) {
-      $bao = CRM_Core_DAO_AllCoreTables::getBAOClassName(CRM_Core_DAO_AllCoreTables::getClassForTable($table));
-      return $bao::checkAccess(CRM_Core_Permission::EDIT, ['id' => $eid], $userID);
+      $targetEntity = CRM_Core_DAO_AllCoreTables::getBriefName(CRM_Core_DAO_AllCoreTables::getClassForTable($table));
+      return \Civi\Api4\Utils\CoreUtil::checkAccessDelegated($targetEntity, 'update', ['id' => $eid], $userID);
     }
     return TRUE;
   }

--- a/CRM/Core/DynamicFKAccessTrait.php
+++ b/CRM/Core/DynamicFKAccessTrait.php
@@ -21,13 +21,14 @@
 trait CRM_Core_DynamicFKAccessTrait {
 
   /**
+   * @param string $entityName
    * @param string $action
    * @param array $record
    * @param int|NULL $userID
    * @return bool
    * @see CRM_Core_DAO::checkAccess
    */
-  public static function _checkAccess(string $action, array $record, $userID): bool {
+  public static function _checkAccess(string $entityName, string $action, array $record, $userID): bool {
     $eid = $record['entity_id'] ?? NULL;
     $table = $record['entity_table'] ?? NULL;
     if (!$eid && !empty($record['id'])) {

--- a/CRM/Financial/BAO/FinancialType.php
+++ b/CRM/Financial/BAO/FinancialType.php
@@ -420,20 +420,20 @@ class CRM_Financial_BAO_FinancialType extends CRM_Financial_DAO_FinancialType {
    * @param string $op
    *   the mode of operation, can be add, view, edit, delete
    * @param bool $force
+   * @param int $contactID
    *
    * @return bool
    */
-  public static function checkPermissionedLineItems($id, $op, $force = TRUE) {
+  public static function checkPermissionedLineItems($id, $op, $force = TRUE, $contactID = NULL) {
     if (!self::isACLFinancialTypeStatus()) {
       return TRUE;
     }
     $lineItems = CRM_Price_BAO_LineItem::getLineItemsByContributionID($id);
     $flag = FALSE;
     foreach ($lineItems as $items) {
-      if (!CRM_Core_Permission::check($op . ' contributions of type ' . CRM_Contribute_PseudoConstant::financialType($items['financial_type_id']))) {
+      if (!CRM_Core_Permission::check($op . ' contributions of type ' . CRM_Contribute_PseudoConstant::financialType($items['financial_type_id']), $contactID)) {
         if ($force) {
           throw new CRM_Core_Exception(ts('You do not have permission to access this page.'));
-          break;
         }
         $flag = FALSE;
         break;

--- a/CRM/Utils/Array.php
+++ b/CRM/Utils/Array.php
@@ -18,6 +18,31 @@
 class CRM_Utils_Array {
 
   /**
+   * Cast a value to an array.
+   *
+   * This is similar to PHP's `(array)`, but it also converts iterators.
+   *
+   * @param mixed $value
+   * @return array
+   */
+  public static function cast($value) {
+    if (is_array($value)) {
+      return $value;
+    }
+    if ($value instanceof CRM_Utils_LazyArray || $value instanceof ArrayObject) {
+      // iterator_to_array() would work here, but getArrayCopy() doesn't require actual iterations.
+      return $value->getArrayCopy();
+    }
+    if (is_iterable($value)) {
+      return iterator_to_array($value);
+    }
+    if (is_scalar($value)) {
+      return [$value];
+    }
+    throw new \RuntimeException(sprintf("Cannot cast %s to array", gettype($value)));
+  }
+
+  /**
    * Returns $list[$key] if such element exists, or a default value otherwise.
    *
    * If $list is not actually an array at all, then the default value is

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -2116,9 +2116,10 @@ abstract class CRM_Utils_Hook {
    *   The record should provide an 'id' but may otherwise be incomplete; guard accordingly.
    * @param int|null $contactID
    *   Contact ID of the active user (whose access we must check).
-   * @param bool $granted
+   * @param bool|null $granted
+   *   TRUE if granted. FALSE if prohibited. NULL if indeterminate.
    */
-  public static function checkAccess(string $entity, string $action, array $record, ?int $contactID, bool &$granted) {
+  public static function checkAccess(string $entity, string $action, array $record, ?int $contactID, ?bool &$granted) {
     self::singleton()->invoke(['entity', 'action', 'record', 'contactID', 'granted'], $entity, $action, $record,
       $contactID, $granted, self::$_nullObject,
       'civicrm_checkAccess'

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -2101,32 +2101,6 @@ abstract class CRM_Utils_Hook {
   }
 
   /**
-   * Check whether the given contact has access to perform the given action.
-   *
-   * If the contact cannot perform the action the
-   *
-   * @param string $entity
-   *   APIv4 entity name.
-   *   Ex: 'Contact', 'Email', 'Event'
-   * @param string $action
-   *   APIv4 action name.
-   *   Ex: 'create', 'get', 'delete'
-   * @param array $record
-   *   All (known/loaded) values of individual record being accessed.
-   *   The record should provide an 'id' but may otherwise be incomplete; guard accordingly.
-   * @param int|null $contactID
-   *   Contact ID of the active user (whose access we must check).
-   * @param bool|null $granted
-   *   TRUE if granted. FALSE if prohibited. NULL if indeterminate.
-   */
-  public static function checkAccess(string $entity, string $action, array $record, ?int $contactID, ?bool &$granted) {
-    self::singleton()->invoke(['entity', 'action', 'record', 'contactID', 'granted'], $entity, $action, $record,
-      $contactID, $granted, self::$_nullObject,
-      'civicrm_checkAccess'
-    );
-  }
-
-  /**
    * Rotate the cryptographic key used in the database.
    *
    * The purpose of this hook is to visit any encrypted values in the database

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -2101,6 +2101,31 @@ abstract class CRM_Utils_Hook {
   }
 
   /**
+   * Check whether the given contact has access to perform the given action.
+   *
+   * If the contact cannot perform the action the
+   *
+   * @param string $entity
+   *   APIv4 entity name.
+   *   Ex: 'Contact', 'Email', 'Event'
+   * @param string $action
+   *   APIv4 action name.
+   *   Ex: 'create', 'get', 'delete'
+   * @param array $record
+   *   All (known/loaded) values of individual record being accessed.
+   *   The record should provide an 'id' but may otherwise be incomplete; guard accordingly.
+   * @param int|null $contactID
+   *   Contact ID of the active user (whose access we must check).
+   * @param bool $granted
+   */
+  public static function checkAccess(string $entity, string $action, array $record, ?int $contactID, bool &$granted) {
+    self::singleton()->invoke(['entity', 'action', 'record', 'contactID', 'granted'], $entity, $action, $record,
+      $contactID, $granted, self::$_nullObject,
+      'civicrm_checkAccess'
+    );
+  }
+
+  /**
    * Rotate the cryptographic key used in the database.
    *
    * The purpose of this hook is to visit any encrypted values in the database

--- a/CRM/Utils/LazyArray.php
+++ b/CRM/Utils/LazyArray.php
@@ -1,0 +1,95 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * A lazy-array works much like a regular array or ArrayObject. However, it is
+ * initially empty - and it is only populated if used.
+ */
+class CRM_Utils_LazyArray implements ArrayAccess, IteratorAggregate, Countable {
+
+  /**
+   * A function which generates a list of values.
+   *
+   * @var callable
+   *   function(): iterable
+   */
+  private $func;
+
+  /**
+   * Cached values
+   *
+   * @var array|null
+   */
+  private $cache;
+
+  /**
+   * CRM_Utils_LazyList constructor.
+   *
+   * @param callable $func
+   *   Function which provides a list of values (array/iterator/generator).
+   */
+  public function __construct($func) {
+    $this->func = $func;
+  }
+
+  /**
+   * Determine if the content has been fetched.
+   *
+   * @return bool
+   */
+  public function isLoaded() {
+    return $this->cache !== NULL;
+  }
+
+  public function load($force = FALSE) {
+    if ($this->cache === NULL || $force) {
+      $this->cache = CRM_Utils_Array::cast(call_user_func($this->func));
+    }
+    return $this;
+  }
+
+  public function offsetExists($offset) {
+    return isset($this->load()->cache[$offset]);
+  }
+
+  public function &offsetGet($offset) {
+    return $this->load()->cache[$offset];
+  }
+
+  public function offsetSet($offset, $value) {
+    if ($offset === NULL) {
+      $this->load()->cache[] = $value;
+    }
+    else {
+      $this->load()->cache[$offset] = $value;
+    }
+  }
+
+  public function offsetUnset($offset) {
+    unset($this->load()->cache[$offset]);
+  }
+
+  public function getIterator() {
+    return new ArrayIterator($this->load()->cache);
+  }
+
+  /**
+   * @return array
+   */
+  public function getArrayCopy() {
+    return $this->load()->cache;
+  }
+
+  public function count() {
+    return count($this->load()->cache);
+  }
+
+}

--- a/Civi/API/Event/AuthorizeEvent.php
+++ b/Civi/API/Event/AuthorizeEvent.php
@@ -22,24 +22,7 @@ namespace Civi\API\Event;
  * Event name: 'civi.api.authorize'
  */
 class AuthorizeEvent extends Event {
-  /**
-   * @var bool
-   */
-  private $authorized = FALSE;
 
-  /**
-   * Mark the request as authorized.
-   */
-  public function authorize() {
-    $this->authorized = TRUE;
-  }
-
-  /**
-   * @return bool
-   *   TRUE if the request has been authorized.
-   */
-  public function isAuthorized() {
-    return $this->authorized;
-  }
+  use AuthorizedTrait;
 
 }

--- a/Civi/API/Event/AuthorizeEvent.php
+++ b/Civi/API/Event/AuthorizeEvent.php
@@ -11,8 +11,11 @@
 
 namespace Civi\API\Event;
 
+use Civi\Api4\Event\ActiveUserTrait;
+
 /**
  * Class AuthorizeEvent
+ *
  * @package Civi\API\Event
  *
  * Determine whether the API request is allowed for the current user.
@@ -24,5 +27,11 @@ namespace Civi\API\Event;
 class AuthorizeEvent extends Event {
 
   use AuthorizedTrait;
+  use ActiveUserTrait;
+
+  public function __construct($apiProvider, $apiRequest, $apiKernel, int $userID) {
+    parent::__construct($apiProvider, $apiRequest, $apiKernel);
+    $this->setUser($userID);
+  }
 
 }

--- a/Civi/API/Event/AuthorizedTrait.php
+++ b/Civi/API/Event/AuthorizedTrait.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Civi\API\Event;
+
+/**
+ * Trait AuthorizedTrait
+ * @package Civi\API\Event
+ */
+trait AuthorizedTrait {
+
+  /**
+   * @var bool|null
+   *   - TRUE: The action is explicitly authorized.
+   *   - FALSE: The action is explicitly prohibited.
+   *   - NULL: The authorization status has not been determined.
+   */
+  private $authorized = NULL;
+
+  /**
+   * Mark the request as authorized.
+   *
+   * @return static
+   */
+  public function authorize() {
+    $this->authorized = TRUE;
+    return $this;
+  }
+
+  /**
+   * @return bool|null
+   *   TRUE if the request has been authorized.
+   */
+  public function isAuthorized(): ?bool {
+    return $this->authorized;
+  }
+
+  /**
+   * Change the authorization status.
+   *
+   * @param bool|null $authorized
+   * @return static
+   */
+  public function setAuthorized(?bool $authorized) {
+    $this->authorized = $authorized;
+    return $this;
+  }
+
+}

--- a/Civi/API/Event/Event.php
+++ b/Civi/API/Event/Event.php
@@ -17,6 +17,8 @@ namespace Civi\API\Event;
  */
 class Event extends \Symfony\Component\EventDispatcher\Event {
 
+  use RequestTrait;
+
   /**
    * @var \Civi\API\Kernel
    */
@@ -29,14 +31,6 @@ class Event extends \Symfony\Component\EventDispatcher\Event {
   protected $apiProvider;
 
   /**
-   * @var array
-   *   The full description of the API request.
-   *
-   * @see \Civi\API\Request::create
-   */
-  protected $apiRequest;
-
-  /**
    * @param \Civi\API\Provider\ProviderInterface $apiProvider
    *   The API responsible for executing the request.
    * @param array $apiRequest
@@ -46,7 +40,7 @@ class Event extends \Symfony\Component\EventDispatcher\Event {
   public function __construct($apiProvider, $apiRequest, $apiKernel) {
     $this->apiKernel = $apiKernel;
     $this->apiProvider = $apiProvider;
-    $this->apiRequest = $apiRequest;
+    $this->setApiRequest($apiRequest);
   }
 
   /**
@@ -63,26 +57,6 @@ class Event extends \Symfony\Component\EventDispatcher\Event {
    */
   public function getApiProvider() {
     return $this->apiProvider;
-  }
-
-  /**
-   * @return array
-   */
-  public function getApiRequest() {
-    return $this->apiRequest;
-  }
-
-  /**
-   * Create a brief string identifying the entity/action. Useful for
-   * pithy matching/switching.
-   *
-   * Ex: if ($e->getApiRequestSig() === '3.contact.get') { ... }
-   *
-   * @return string
-   *   Ex: '3.contact.get'
-   */
-  public function getApiRequestSig() {
-    return mb_strtolower($this->apiRequest['version'] . '.' . $this->apiRequest['entity'] . '.' . $this->apiRequest['action']);
   }
 
 }

--- a/Civi/API/Event/PrepareEvent.php
+++ b/Civi/API/Event/PrepareEvent.php
@@ -26,11 +26,11 @@ class PrepareEvent extends Event {
   /**
    * @param array $apiRequest
    *   The full description of the API request.
-   * @return PrepareEvent
+   * @return static
    */
   public function setApiRequest($apiRequest) {
-    $this->apiRequest = $apiRequest;
-    return $this;
+    // Elevate from 'protected' to 'public'.
+    return parent::setApiRequest($apiRequest);
   }
 
   /**

--- a/Civi/API/Event/RequestTrait.php
+++ b/Civi/API/Event/RequestTrait.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Civi\API\Event;
+
+/**
+ * Trait RequestTrait
+ * @package Civi\API\Event
+ *
+ * Most events emitted by the API subsystem should include information about the active API request.
+ */
+trait RequestTrait {
+
+  /**
+   * @var \Civi\Api4\Generic\AbstractAction|array
+   *   The full description of the API request.
+   *
+   * @see \Civi\API\Request::create
+   */
+  protected $apiRequest;
+
+  /**
+   * @return \Civi\Api4\Generic\AbstractAction|array
+   */
+  public function getApiRequest() {
+    return $this->apiRequest;
+  }
+
+  /**
+   * @param \Civi\Api4\Generic\AbstractAction|array $apiRequest
+   *   The full description of the API request.
+   * @return static
+   */
+  protected function setApiRequest($apiRequest) {
+    $this->apiRequest = $apiRequest;
+    return $this;
+  }
+
+  /**
+   * Create a brief string identifying the entity/action. Useful for
+   * pithy matching/switching.
+   *
+   * Ex: if ($e->getApiRequestSig() === '3.contact.get') { ... }
+   *
+   * @return string
+   *   Ex: '3.contact.get'
+   */
+  public function getApiRequestSig(): string {
+    return mb_strtolower($this->apiRequest['version'] . '.' . $this->apiRequest['entity'] . '.' . $this->apiRequest['action']);
+  }
+
+  /**
+   * @return string
+   *   Ex: 'Contact', 'Activity'
+   */
+  public function getEntityName(): string {
+    return $this->apiRequest['entity'];
+  }
+
+  /**
+   * @return string
+   *   Ex: 'create', 'update'
+   */
+  public function getActionName(): string {
+    return $this->apiRequest['action'];
+  }
+
+}

--- a/Civi/API/Event/ResolveEvent.php
+++ b/Civi/API/Event/ResolveEvent.php
@@ -46,7 +46,8 @@ class ResolveEvent extends Event {
    *   The full description of the API request.
    */
   public function setApiRequest($apiRequest) {
-    $this->apiRequest = $apiRequest;
+    // Elevate from 'protected' to 'public'.
+    return parent::setApiRequest($apiRequest);
   }
 
 }

--- a/Civi/API/Kernel.php
+++ b/Civi/API/Kernel.php
@@ -218,7 +218,7 @@ class Kernel {
    */
   public function authorize($apiProvider, $apiRequest) {
     /** @var \Civi\API\Event\AuthorizeEvent $event */
-    $event = $this->dispatcher->dispatch('civi.api.authorize', new AuthorizeEvent($apiProvider, $apiRequest, $this));
+    $event = $this->dispatcher->dispatch('civi.api.authorize', new AuthorizeEvent($apiProvider, $apiRequest, $this, \CRM_Core_Session::getLoggedInContactID() ?: 0));
     if (!$event->isAuthorized()) {
       throw new \Civi\API\Exception\UnauthorizedException("Authorization failed");
     }

--- a/Civi/Api4/Action/GetActions.php
+++ b/Civi/Api4/Action/GetActions.php
@@ -79,7 +79,7 @@ class GetActions extends BasicGetAction {
     try {
       if (!isset($this->_actions[$actionName]) && (!$this->_actionsToGet || in_array($actionName, $this->_actionsToGet))) {
         $action = \Civi\API\Request::create($this->getEntityName(), $actionName, ['version' => 4]);
-        if (is_object($action) && (!$this->checkPermissions || $action->isAuthorized())) {
+        if (is_object($action) && (!$this->checkPermissions || $action->isAuthorized(\CRM_Core_Session::singleton()->getLoggedInContactID()))) {
           $this->_actions[$actionName] = ['name' => $actionName];
           if ($this->_isFieldSelected('description', 'comment', 'see')) {
             $vars = ['entity' => $this->getEntityName(), 'action' => $actionName];

--- a/Civi/Api4/CustomValue.php
+++ b/Civi/Api4/CustomValue.php
@@ -123,6 +123,13 @@ class CustomValue {
   }
 
   /**
+   * @return \Civi\Api4\Generic\CheckAccessAction
+   */
+  public static function checkAccess($customGroup) {
+    return new Generic\CheckAccessAction("Custom_$customGroup", __FUNCTION__);
+  }
+
+  /**
    * @see \Civi\Api4\Generic\AbstractEntity::permissions()
    * @return array
    */

--- a/Civi/Api4/Event/ActiveUserTrait.php
+++ b/Civi/Api4/Event/ActiveUserTrait.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Civi\Api4\Event;
+
+trait ActiveUserTrait {
+
+  /**
+   * Contact ID of the active/target user (whose access we must check).
+   * 0 for anonymous.
+   *
+   * @var int
+   */
+  private $userID;
+
+  /**
+   * @param int|null $userID
+   *   Contact ID of the active/target user (whose access we must check).
+   *   0 for anonymous.
+   * @return $this
+   */
+  protected function setUser(int $userID) {
+    $loggedInContactID = \CRM_Core_Session::getLoggedInContactID() ?: 0;
+    if ($userID !== $loggedInContactID) {
+      throw new \RuntimeException("The API subsystem does not yet fully support variable user IDs.");
+      // Traditionally, the API events did not emit information about the current user; it was assumed
+      // that the user was the logged-in user. This may be expanded in the future to support some more edge-cases.
+      // For now, the semantics are unchanged - but we've begun reporting the active userID so that
+      // consumers can start adopting it.
+    }
+    $this->userID = $userID;
+    return $this;
+  }
+
+  /**
+   * @return int
+   *   Contact ID of the active/target user (whose access we must check).
+   *   0 for anonymous.
+   */
+  public function getUserID(): int {
+    return $this->userID;
+  }
+
+}

--- a/Civi/Api4/Event/AuthorizeRecordEvent.php
+++ b/Civi/Api4/Event/AuthorizeRecordEvent.php
@@ -1,0 +1,91 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+namespace Civi\Api4\Event;
+
+use Civi\API\Event\AuthorizedTrait;
+use Civi\API\Event\RequestTrait;
+use Civi\Core\Event\GenericHookEvent;
+
+/**
+ * Determine if the a user has access to a given record.
+ *
+ * Event name: 'civi.api4.authorizeRecord'
+ */
+class AuthorizeRecordEvent extends GenericHookEvent {
+
+  use RequestTrait;
+  use AuthorizedTrait;
+
+  /**
+   * All (known/loaded) values of individual record being accessed.
+   * The record should provide an 'id' but may otherwise be incomplete; guard accordingly.
+   *
+   * @var array
+   */
+  private $record;
+
+  /**
+   * Contact ID of the active/target user (whose access we must check).
+   * NULL for anonymous.
+   *
+   * @var int|null
+   */
+  private $userID;
+
+  /**
+   * CheckAccessEvent constructor.
+   *
+   * @param \Civi\Api4\Generic\AbstractAction $apiRequest
+   * @param array $record
+   *   All (known/loaded) values of individual record being accessed.
+   *   The record should provide an 'id' but may otherwise be incomplete; guard accordingly.
+   * @param int|null $userID
+   *   Contact ID of the active/target user (whose access we must check).
+   *   NULL for anonymous.
+   */
+  public function __construct($apiRequest, array $record, ?int $userID) {
+    $this->setApiRequest($apiRequest);
+    $this->record = $record;
+    $this->userID = $userID;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function getHookValues() {
+    return [$this->getApiRequest(), $this->record, &$this->authorized];
+  }
+
+  /**
+   * @return array
+   */
+  public function getRecord(): array {
+    return $this->record;
+  }
+
+  /**
+   * @return int|null
+   *   Contact ID of the active/target user (whose access we must check).
+   *   NULL for anonymous.
+   */
+  public function getUserID(): ?int {
+    return $this->userID;
+  }
+
+}

--- a/Civi/Api4/Event/AuthorizeRecordEvent.php
+++ b/Civi/Api4/Event/AuthorizeRecordEvent.php
@@ -31,6 +31,7 @@ class AuthorizeRecordEvent extends GenericHookEvent {
 
   use RequestTrait;
   use AuthorizedTrait;
+  use ActiveUserTrait;
 
   /**
    * All (known/loaded) values of individual record being accessed.
@@ -41,28 +42,20 @@ class AuthorizeRecordEvent extends GenericHookEvent {
   private $record;
 
   /**
-   * Contact ID of the active/target user (whose access we must check).
-   * NULL for anonymous.
-   *
-   * @var int|null
-   */
-  private $userID;
-
-  /**
    * CheckAccessEvent constructor.
    *
    * @param \Civi\Api4\Generic\AbstractAction $apiRequest
    * @param array $record
    *   All (known/loaded) values of individual record being accessed.
    *   The record should provide an 'id' but may otherwise be incomplete; guard accordingly.
-   * @param int|null $userID
+   * @param int $userID
    *   Contact ID of the active/target user (whose access we must check).
-   *   NULL for anonymous.
+   *   0 for anonymous.
    */
-  public function __construct($apiRequest, array $record, ?int $userID) {
+  public function __construct($apiRequest, array $record, int $userID) {
     $this->setApiRequest($apiRequest);
     $this->record = $record;
-    $this->userID = $userID;
+    $this->setUser($userID);
   }
 
   /**
@@ -77,15 +70,6 @@ class AuthorizeRecordEvent extends GenericHookEvent {
    */
   public function getRecord(): array {
     return $this->record;
-  }
-
-  /**
-   * @return int|null
-   *   Contact ID of the active/target user (whose access we must check).
-   *   NULL for anonymous.
-   */
-  public function getUserID(): ?int {
-    return $this->userID;
   }
 
 }

--- a/Civi/Api4/Event/Subscriber/PermissionCheckSubscriber.php
+++ b/Civi/Api4/Event/Subscriber/PermissionCheckSubscriber.php
@@ -40,7 +40,7 @@ class PermissionCheckSubscriber implements EventSubscriberInterface {
     /* @var \Civi\Api4\Generic\AbstractAction $apiRequest */
     $apiRequest = $event->getApiRequest();
     if ($apiRequest['version'] == 4) {
-      if (!$apiRequest->getCheckPermissions() || $apiRequest->isAuthorized()) {
+      if (!$apiRequest->getCheckPermissions() || $apiRequest->isAuthorized(\CRM_Core_Session::singleton()->getLoggedInContactID())) {
         $event->authorize();
         $event->stopPropagation();
       }

--- a/Civi/Api4/Event/ValidateValuesEvent.php
+++ b/Civi/Api4/Event/ValidateValuesEvent.php
@@ -71,6 +71,24 @@ class ValidateValuesEvent extends GenericHookEvent {
   public $records;
 
   /**
+   * Detailed, side-by-side comparison of old and new values.
+   *
+   * This requires loading the list of old values from the database. Consequently,
+   * reading `$diffs` is more expensive than reading `$records`, so you should only use it if
+   * really necessary.
+   *
+   * The list of $diffs may be important if you are enforcing a rule that involves
+   * multiple fields. (Ex: "Validate that the state_id and country_id match.")
+   *
+   * When possible, $records and $diffs will have the same number of items (with corresponding
+   * keys). However, in the case of a batch `update()`, the list of diffs will be longer.
+   *
+   * @var array|\CRM_Utils_LazyArray
+   *   Each item is a record of the form ['old' => $fieldValues, 'new' => $fieldValues]
+   */
+  public $diffs;
+
+  /**
    * List of error messages.
    *
    * @var array
@@ -85,10 +103,13 @@ class ValidateValuesEvent extends GenericHookEvent {
    * @param \Civi\Api4\Generic\AbstractAction $apiRequest
    * @param array|\CRM_Utils_LazyArray $records
    *   List of updates (akin to SaveAction::$records).
+   * @param array|\CRM_Utils_LazyArray $diffs
+   *   List of differences (comparing old values and new values).
    */
-  public function __construct($apiRequest, $records) {
+  public function __construct($apiRequest, $records, $diffs) {
     $this->setApiRequest($apiRequest);
     $this->records = $records;
+    $this->diffs = $diffs;
     $this->errors = [];
   }
 

--- a/Civi/Api4/Event/ValidateValuesEvent.php
+++ b/Civi/Api4/Event/ValidateValuesEvent.php
@@ -1,0 +1,141 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+namespace Civi\Api4\Event;
+
+use Civi\API\Event\RequestTrait;
+use Civi\Core\Event\GenericHookEvent;
+
+/**
+ * The ValidateValuesEvent ('civi.api4.validate') is emitted when creating or saving an entire record via APIv4.
+ * It is emitted once for every record is updated.
+ *
+ * Example #1: Walk each record and validate some fields
+ *
+ * function(ValidateValuesEvent $e) {
+ *   if ($e->entity !== 'Foozball') return;
+ *   foreach ($e->records as $r => $record) {
+ *     if (strtotime($record['start_time']) < CRM_Utils_Time::time()) {
+ *       $e->addError($r, 'start_time', 'past', ts('Start time has already passed.'));
+ *     }
+ *     if ($record['length'] * $record['width'] * $record['height'] > VOLUME_LIMIT) {
+ *       $e->addError($r, ['length', 'width', 'height'], 'excessive_volume', ts('The record is too big.'));
+ *     }
+ *   }
+ * }
+ *
+ * Example #2: Prohibit recording `Contribution` records on `Student` contacts.
+ *
+ * function(ValidateValuesEvent $e) {
+ *   if ($e->entity !== 'Contribution') return;
+ *   $contactSubTypes = CRM_Utils_SQL_Select::from('civicrm_contact')
+ *     ->where('id IN (#ids)', ['ids' => array_column($e->records, 'contact_id')])
+ *     ->select('id, contact_sub_type')
+ *     ->execute()->fetchMap('id', 'contact_sub_type');
+ *   foreach ($e->records as $r => $record) {
+ *     if ($contactSubTypes[$record['contact_id']] === 'Student') {
+ *       $e->addError($r, 'contact_id', 'student_prohibited', ts('Donations from student records are strictly prohibited.'));
+ *     }
+ *   }
+ * }
+ */
+class ValidateValuesEvent extends GenericHookEvent {
+
+  use RequestTrait;
+
+  /**
+   * List of updated records.
+   *
+   * The list of `$records` reflects only the list of new values assigned
+   * by this action. It may or may not correspond to an existing row in the database.
+   * It is similar to the `$records` list used by `save()`.
+   *
+   * @var array|\CRM_Utils_LazyArray
+   * @see \Civi\Api4\Generic\AbstractSaveAction::$records
+   */
+  public $records;
+
+  /**
+   * List of error messages.
+   *
+   * @var array
+   *   Array(string $errorName => string $errorMessage)
+   *   Note:
+   */
+  public $errors = [];
+
+  /**
+   * ValidateValuesEvent constructor.
+   *
+   * @param \Civi\Api4\Generic\AbstractAction $apiRequest
+   * @param array|\CRM_Utils_LazyArray $records
+   *   List of updates (akin to SaveAction::$records).
+   */
+  public function __construct($apiRequest, $records) {
+    $this->setApiRequest($apiRequest);
+    $this->records = $records;
+    $this->errors = [];
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function getHookValues() {
+    return [$this->getApiRequest(), $this->records, &$this->errors];
+  }
+
+  /**
+   * Add an error.
+   *
+   * @param string|int $recordKey
+   *   The validator may work with multiple records. This should identify the specific record.
+   *   Each record is identified by its offset (`$records[$recordKey] === [...the record...]`).
+   * @param string|array $field
+   *   The name of the field which has an error.
+   *   If the error is multi-field (e.g. mismatched password-confirmation), then use an array.
+   *   If the error is independent of any field, then use [].
+   * @param string $name
+   * @param string|NULL $message
+   * @return $this
+   */
+  public function addError($recordKey, $field, string $name, string $message = NULL): self {
+    $this->errors[] = [
+      'record' => $recordKey,
+      'fields' => (array) $field,
+      'name' => $name,
+      'message' => $message ?: ts('Error code (%1)', [1 => $name]),
+    ];
+    return $this;
+  }
+
+  /**
+   * Convert the list of errors an exception.
+   *
+   * @return \API_Exception
+   */
+  public function toException() {
+    // We should probably have a better way to report the errors in a structured/list format.
+    return new \API_Exception(ts('Found %1 error(s) in submitted %2 record(s) of type "%3": %4', [
+      1 => count($this->errors),
+      2 => count(array_unique(array_column($this->errors, 'record'))),
+      3 => $this->getEntityName(),
+      4 => implode(', ', array_column($this->errors, 'message')),
+    ]));
+  }
+
+}

--- a/Civi/Api4/Generic/AbstractAction.php
+++ b/Civi/Api4/Generic/AbstractAction.php
@@ -389,11 +389,13 @@ abstract class AbstractAction implements \ArrayAccess {
    *
    * This function is called if checkPermissions is set to true.
    *
+   * @param int|null $userID
+   *   Contact ID of the user we are testing, or NULL for the default/active user.
    * @return bool
    */
-  public function isAuthorized() {
+  public function isAuthorized(?int $userID): bool {
     $permissions = $this->getPermissions();
-    return \CRM_Core_Permission::check($permissions);
+    return \CRM_Core_Permission::check($permissions, $userID);
   }
 
   /**

--- a/Civi/Api4/Generic/AbstractAction.php
+++ b/Civi/Api4/Generic/AbstractAction.php
@@ -389,13 +389,12 @@ abstract class AbstractAction implements \ArrayAccess {
    *
    * This function is called if checkPermissions is set to true.
    *
-   * @param int|null $userID
-   *   Contact ID of the user we are testing, or NULL for the default/active user.
    * @return bool
+   * @internal Implement/override in civicrm-core.git only. Signature may evolve.
    */
-  public function isAuthorized(?int $userID): bool {
+  public function isAuthorized(): bool {
     $permissions = $this->getPermissions();
-    return \CRM_Core_Permission::check($permissions, $userID);
+    return \CRM_Core_Permission::check($permissions);
   }
 
   /**

--- a/Civi/Api4/Generic/AbstractBatchAction.php
+++ b/Civi/Api4/Generic/AbstractBatchAction.php
@@ -54,9 +54,23 @@ abstract class AbstractBatchAction extends AbstractQueryAction {
   }
 
   /**
+   * Get a list of records for this batch.
+   *
    * @return array
    */
   protected function getBatchRecords() {
+    return (array) $this->getBatchAction()->execute();
+  }
+
+  /**
+   * Get a query which resolves the list of records for this batch.
+   *
+   * This is similar to `getBatchRecords()`, but you may further refine the
+   * API call (e.g. selecting different fields or data-pages) before executing.
+   *
+   * @return \Civi\Api4\Generic\AbstractGetAction
+   */
+  protected function getBatchAction() {
     $params = [
       'checkPermissions' => $this->checkPermissions,
       'where' => $this->where,
@@ -67,8 +81,7 @@ abstract class AbstractBatchAction extends AbstractQueryAction {
     if (empty($this->reload)) {
       $params['select'] = $this->select;
     }
-
-    return (array) civicrm_api4($this->getEntityName(), 'get', $params);
+    return \Civi\API\Request::create($this->getEntityName(), 'get', ['version' => 4] + $params);
   }
 
   /**

--- a/Civi/Api4/Generic/AbstractCreateAction.php
+++ b/Civi/Api4/Generic/AbstractCreateAction.php
@@ -70,7 +70,7 @@ abstract class AbstractCreateAction extends AbstractAction {
       throw new \API_Exception("Mandatory values missing from Api4 {$this->getEntityName()}::{$this->getActionName()}: " . implode(", ", $unmatched), "mandatory_missing", ["fields" => $unmatched]);
     }
 
-    if ($this->checkPermissions && !CoreUtil::checkAccess($this->getEntityName(), $this->getActionName(), $this->getValues())) {
+    if ($this->checkPermissions && !CoreUtil::checkAccessRecord($this, $this->getValues(), \CRM_Core_Session::getLoggedInContactID())) {
       throw new UnauthorizedException("ACL check failed");
     }
 

--- a/Civi/Api4/Generic/AbstractCreateAction.php
+++ b/Civi/Api4/Generic/AbstractCreateAction.php
@@ -70,7 +70,7 @@ abstract class AbstractCreateAction extends AbstractAction {
       throw new \API_Exception("Mandatory values missing from Api4 {$this->getEntityName()}::{$this->getActionName()}: " . implode(", ", $unmatched), "mandatory_missing", ["fields" => $unmatched]);
     }
 
-    if ($this->checkPermissions && !CoreUtil::checkAccessRecord($this, $this->getValues(), \CRM_Core_Session::getLoggedInContactID())) {
+    if ($this->checkPermissions && !CoreUtil::checkAccessRecord($this, $this->getValues(), \CRM_Core_Session::getLoggedInContactID() ?: 0)) {
       throw new UnauthorizedException("ACL check failed");
     }
 

--- a/Civi/Api4/Generic/AbstractCreateAction.php
+++ b/Civi/Api4/Generic/AbstractCreateAction.php
@@ -66,7 +66,9 @@ abstract class AbstractCreateAction extends AbstractAction {
     if ($unmatched) {
       throw new \API_Exception("Mandatory values missing from Api4 {$this->getEntityName()}::{$this->getActionName()}: " . implode(", ", $unmatched), "mandatory_missing", ["fields" => $unmatched]);
     }
-    $e = new ValidateValuesEvent($this, [$this->getValues()]);
+    $e = new ValidateValuesEvent($this, [$this->getValues()], new \CRM_Utils_LazyArray(function () {
+      return [['old' => NULL, 'new' => $this->getValues()]];
+    }));
     \Civi::dispatcher()->dispatch('civi.api4.validate', $e);
     if (!empty($e->errors)) {
       throw $e->toException();

--- a/Civi/Api4/Generic/AbstractEntity.php
+++ b/Civi/Api4/Generic/AbstractEntity.php
@@ -56,6 +56,13 @@ abstract class AbstractEntity {
   abstract public static function getFields();
 
   /**
+   * @return \Civi\Api4\Generic\CheckAccessAction
+   */
+  public static function checkAccess() {
+    return new CheckAccessAction(self::getEntityName(), __FUNCTION__);
+  }
+
+  /**
    * Returns a list of permissions needed to access the various actions in this api.
    *
    * @return array

--- a/Civi/Api4/Generic/AbstractSaveAction.php
+++ b/Civi/Api4/Generic/AbstractSaveAction.php
@@ -112,7 +112,7 @@ abstract class AbstractSaveAction extends AbstractAction {
     if ($this->checkPermissions) {
       foreach ($this->records as $record) {
         $action = empty($record[$this->idField]) ? 'create' : 'update';
-        if (!CoreUtil::checkAccess($this->getEntityName(), $action, $record)) {
+        if (!CoreUtil::checkAccessDelegated($this->getEntityName(), $action, $record, \CRM_Core_Session::getLoggedInContactID())) {
           throw new UnauthorizedException("ACL check failed");
         }
       }

--- a/Civi/Api4/Generic/AbstractSaveAction.php
+++ b/Civi/Api4/Generic/AbstractSaveAction.php
@@ -112,7 +112,7 @@ abstract class AbstractSaveAction extends AbstractAction {
     if ($this->checkPermissions) {
       foreach ($this->records as $record) {
         $action = empty($record[$this->idField]) ? 'create' : 'update';
-        if (!CoreUtil::checkAccessDelegated($this->getEntityName(), $action, $record, \CRM_Core_Session::getLoggedInContactID())) {
+        if (!CoreUtil::checkAccessDelegated($this->getEntityName(), $action, $record, \CRM_Core_Session::getLoggedInContactID() ?: 0)) {
           throw new UnauthorizedException("ACL check failed");
         }
       }

--- a/Civi/Api4/Generic/AbstractUpdateAction.php
+++ b/Civi/Api4/Generic/AbstractUpdateAction.php
@@ -19,6 +19,8 @@
 
 namespace Civi\Api4\Generic;
 
+use Civi\Api4\Event\ValidateValuesEvent;
+
 /**
  * Base class for all `Update` api actions
  *
@@ -74,7 +76,12 @@ abstract class AbstractUpdateAction extends AbstractBatchAction {
    * @throws \API_Exception
    */
   protected function validateValues() {
-    // Placeholder
+    // FIXME: There should be a protocol to report a full list of errors... Perhaps a subclass of API_Exception?
+    $e = new ValidateValuesEvent($this, [$this->values]);
+    \Civi::dispatcher()->dispatch('civi.api4.validate', $e);
+    if (!empty($e->errors)) {
+      throw $e->toException();
+    }
   }
 
 }

--- a/Civi/Api4/Generic/AbstractUpdateAction.php
+++ b/Civi/Api4/Generic/AbstractUpdateAction.php
@@ -77,7 +77,14 @@ abstract class AbstractUpdateAction extends AbstractBatchAction {
    */
   protected function validateValues() {
     // FIXME: There should be a protocol to report a full list of errors... Perhaps a subclass of API_Exception?
-    $e = new ValidateValuesEvent($this, [$this->values]);
+    $e = new ValidateValuesEvent($this, [$this->values], new \CRM_Utils_LazyArray(function () {
+      $existing = $this->getBatchAction()->setSelect(['*'])->execute();
+      $result = [];
+      foreach ($existing as $record) {
+        $result[] = ['old' => $record, 'new' => $this->values];
+      }
+      return $result;
+    }));
     \Civi::dispatcher()->dispatch('civi.api4.validate', $e);
     if (!empty($e->errors)) {
       throw $e->toException();

--- a/Civi/Api4/Generic/AbstractUpdateAction.php
+++ b/Civi/Api4/Generic/AbstractUpdateAction.php
@@ -70,4 +70,11 @@ abstract class AbstractUpdateAction extends AbstractBatchAction {
     return $this;
   }
 
+  /**
+   * @throws \API_Exception
+   */
+  protected function validateValues() {
+    // Placeholder
+  }
+
 }

--- a/Civi/Api4/Generic/BasicBatchAction.php
+++ b/Civi/Api4/Generic/BasicBatchAction.php
@@ -67,7 +67,7 @@ class BasicBatchAction extends AbstractBatchAction {
    */
   public function _run(Result $result) {
     foreach ($this->getBatchRecords() as $item) {
-      if ($this->checkPermissions && !CoreUtil::checkAccessRecord($this, $item, \CRM_Core_Session::getLoggedInContactID())) {
+      if ($this->checkPermissions && !CoreUtil::checkAccessRecord($this, $item, \CRM_Core_Session::getLoggedInContactID() ?: 0)) {
         throw new UnauthorizedException("ACL check failed");
       }
       $result[] = $this->doTask($item);

--- a/Civi/Api4/Generic/BasicBatchAction.php
+++ b/Civi/Api4/Generic/BasicBatchAction.php
@@ -67,7 +67,7 @@ class BasicBatchAction extends AbstractBatchAction {
    */
   public function _run(Result $result) {
     foreach ($this->getBatchRecords() as $item) {
-      if ($this->checkPermissions && !CoreUtil::checkAccess($this->getEntityName(), $this->getActionName(), $item)) {
+      if ($this->checkPermissions && !CoreUtil::checkAccessRecord($this, $item, \CRM_Core_Session::getLoggedInContactID())) {
         throw new UnauthorizedException("ACL check failed");
       }
       $result[] = $this->doTask($item);

--- a/Civi/Api4/Generic/BasicBatchAction.php
+++ b/Civi/Api4/Generic/BasicBatchAction.php
@@ -20,6 +20,8 @@
 namespace Civi\Api4\Generic;
 
 use Civi\API\Exception\NotImplementedException;
+use Civi\API\Exception\UnauthorizedException;
+use Civi\Api4\Utils\CoreUtil;
 
 /**
  * $ACTION one or more $ENTITIES.
@@ -65,6 +67,9 @@ class BasicBatchAction extends AbstractBatchAction {
    */
   public function _run(Result $result) {
     foreach ($this->getBatchRecords() as $item) {
+      if ($this->checkPermissions && !CoreUtil::checkAccess($this->getEntityName(), $this->getActionName(), $item)) {
+        throw new UnauthorizedException("ACL check failed");
+      }
       $result[] = $this->doTask($item);
     }
   }

--- a/Civi/Api4/Generic/BasicUpdateAction.php
+++ b/Civi/Api4/Generic/BasicUpdateAction.php
@@ -63,7 +63,7 @@ class BasicUpdateAction extends AbstractUpdateAction {
     $this->validateValues();
     foreach ($this->getBatchRecords() as $item) {
       $record = $this->values + $item;
-      if ($this->checkPermissions && !CoreUtil::checkAccessRecord($this, $record, \CRM_Core_Session::getLoggedInContactID())) {
+      if ($this->checkPermissions && !CoreUtil::checkAccessRecord($this, $record, \CRM_Core_Session::getLoggedInContactID() ?: 0)) {
         throw new UnauthorizedException("ACL check failed");
       }
       $result[] = $this->writeRecord($record);

--- a/Civi/Api4/Generic/BasicUpdateAction.php
+++ b/Civi/Api4/Generic/BasicUpdateAction.php
@@ -63,7 +63,7 @@ class BasicUpdateAction extends AbstractUpdateAction {
     $this->validateValues();
     foreach ($this->getBatchRecords() as $item) {
       $record = $this->values + $item;
-      if ($this->checkPermissions && !CoreUtil::checkAccess($this->getEntityName(), $this->getActionName(), $record)) {
+      if ($this->checkPermissions && !CoreUtil::checkAccessRecord($this, $record, \CRM_Core_Session::getLoggedInContactID())) {
         throw new UnauthorizedException("ACL check failed");
       }
       $result[] = $this->writeRecord($record);

--- a/Civi/Api4/Generic/BasicUpdateAction.php
+++ b/Civi/Api4/Generic/BasicUpdateAction.php
@@ -58,6 +58,7 @@ class BasicUpdateAction extends AbstractUpdateAction {
    */
   public function _run(Result $result) {
     $this->formatWriteValues($this->values);
+    $this->validateValues();
     foreach ($this->getBatchRecords() as $item) {
       $result[] = $this->writeRecord($this->values + $item);
     }

--- a/Civi/Api4/Generic/BasicUpdateAction.php
+++ b/Civi/Api4/Generic/BasicUpdateAction.php
@@ -20,6 +20,8 @@
 namespace Civi\Api4\Generic;
 
 use Civi\API\Exception\NotImplementedException;
+use Civi\API\Exception\UnauthorizedException;
+use Civi\Api4\Utils\CoreUtil;
 
 /**
  * Update one or more $ENTITY with new values.
@@ -60,7 +62,11 @@ class BasicUpdateAction extends AbstractUpdateAction {
     $this->formatWriteValues($this->values);
     $this->validateValues();
     foreach ($this->getBatchRecords() as $item) {
-      $result[] = $this->writeRecord($this->values + $item);
+      $record = $this->values + $item;
+      if ($this->checkPermissions && !CoreUtil::checkAccess($this->getEntityName(), $this->getActionName(), $record)) {
+        throw new UnauthorizedException("ACL check failed");
+      }
+      $result[] = $this->writeRecord($record);
     }
   }
 

--- a/Civi/Api4/Generic/CheckAccessAction.php
+++ b/Civi/Api4/Generic/CheckAccessAction.php
@@ -52,7 +52,7 @@ class CheckAccessAction extends AbstractAction {
       $granted = TRUE;
     }
     else {
-      $granted = CoreUtil::checkAccessDelegated($this->getEntityName(), $this->action, $this->values, \CRM_Core_Session::getLoggedInContactID());
+      $granted = CoreUtil::checkAccessDelegated($this->getEntityName(), $this->action, $this->values, \CRM_Core_Session::getLoggedInContactID() ?: 0);
     }
     $result->exchangeArray([['access' => $granted]]);
   }
@@ -62,7 +62,7 @@ class CheckAccessAction extends AbstractAction {
    *
    * @return bool
    */
-  public function isAuthorized(?int $userID): bool {
+  public function isAuthorized(): bool {
     return TRUE;
   }
 

--- a/Civi/Api4/Generic/CheckAccessAction.php
+++ b/Civi/Api4/Generic/CheckAccessAction.php
@@ -1,0 +1,80 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+
+namespace Civi\Api4\Generic;
+
+use Civi\Api4\Utils\CoreUtil;
+
+/**
+ * Check if current user is authorized to perform specified action on a given $ENTITY.
+ *
+ * @method $this setAction(string $action)
+ * @method string getAction()
+ * @method $this setValues(array $values)
+ * @method array getValues()
+ */
+class CheckAccessAction extends AbstractAction {
+
+  /**
+   * @var string
+   * @required
+   */
+  protected $action;
+
+  /**
+   * @var array
+   * @required
+   */
+  protected $values = [];
+
+  /**
+   * @param \Civi\Api4\Generic\Result $result
+   */
+  public function _run(Result $result) {
+    // Prevent circular checks
+    if ($this->action === 'checkAccess') {
+      $granted = TRUE;
+    }
+    else {
+      $granted = CoreUtil::checkAccess($this->getEntityName(), $this->action, $this->values);
+    }
+    $result->exchangeArray([['access' => $granted]]);
+  }
+
+  /**
+   * This action is always allowed
+   *
+   * @return bool
+   */
+  public function isAuthorized() {
+    return TRUE;
+  }
+
+  /**
+   * Add an item to the values array
+   * @param string $fieldName
+   * @param mixed $value
+   * @return $this
+   */
+  public function addValue(string $fieldName, $value) {
+    $this->values[$fieldName] = $value;
+    return $this;
+  }
+
+}

--- a/Civi/Api4/Generic/CheckAccessAction.php
+++ b/Civi/Api4/Generic/CheckAccessAction.php
@@ -62,7 +62,7 @@ class CheckAccessAction extends AbstractAction {
    *
    * @return bool
    */
-  public function isAuthorized() {
+  public function isAuthorized(?int $userID): bool {
     return TRUE;
   }
 

--- a/Civi/Api4/Generic/CheckAccessAction.php
+++ b/Civi/Api4/Generic/CheckAccessAction.php
@@ -52,7 +52,7 @@ class CheckAccessAction extends AbstractAction {
       $granted = TRUE;
     }
     else {
-      $granted = CoreUtil::checkAccess($this->getEntityName(), $this->action, $this->values);
+      $granted = CoreUtil::checkAccessDelegated($this->getEntityName(), $this->action, $this->values, \CRM_Core_Session::getLoggedInContactID());
     }
     $result->exchangeArray([['access' => $granted]]);
   }

--- a/Civi/Api4/Generic/DAOCreateAction.php
+++ b/Civi/Api4/Generic/DAOCreateAction.php
@@ -33,11 +33,10 @@ class DAOCreateAction extends AbstractCreateAction {
    */
   public function _run(Result $result) {
     $this->formatWriteValues($this->values);
+    $this->fillDefaults($this->values);
     $this->validateValues();
-    $params = $this->values;
-    $this->fillDefaults($params);
-    $items = [$params];
 
+    $items = [$this->values];
     $result->exchangeArray($this->writeObjects($items));
   }
 

--- a/Civi/Api4/Generic/DAODeleteAction.php
+++ b/Civi/Api4/Generic/DAODeleteAction.php
@@ -43,7 +43,7 @@ class DAODeleteAction extends AbstractBatchAction {
 
     if ($this->getCheckPermissions()) {
       foreach ($items as $key => $item) {
-        if (!CoreUtil::checkAccess($this->getEntityName(), $this->getActionName(), $item)) {
+        if (!CoreUtil::checkAccessRecord($this, $item, \CRM_Core_Session::getLoggedInContactID())) {
           throw new UnauthorizedException("ACL check failed");
         }
         $items[$key]['check_permissions'] = TRUE;

--- a/Civi/Api4/Generic/DAODeleteAction.php
+++ b/Civi/Api4/Generic/DAODeleteAction.php
@@ -19,6 +19,9 @@
 
 namespace Civi\Api4\Generic;
 
+use Civi\API\Exception\UnauthorizedException;
+use Civi\Api4\Utils\CoreUtil;
+
 /**
  * Delete one or more $ENTITIES.
  *
@@ -53,6 +56,9 @@ class DAODeleteAction extends AbstractBatchAction {
 
     if ($this->getCheckPermissions()) {
       foreach (array_keys($items) as $key) {
+        if (!CoreUtil::checkAccess($this->getEntityName(), $this->getActionName(), $items[$key])) {
+          throw new UnauthorizedException("ACL check failed");
+        }
         $items[$key]['check_permissions'] = TRUE;
         $this->checkContactPermissions($baoName, $items[$key]);
       }

--- a/Civi/Api4/Generic/DAODeleteAction.php
+++ b/Civi/Api4/Generic/DAODeleteAction.php
@@ -40,6 +40,15 @@ class DAODeleteAction extends AbstractBatchAction {
     }
 
     $items = $this->getBatchRecords();
+
+    if ($this->getCheckPermissions()) {
+      foreach ($items as $key => $item) {
+        if (!CoreUtil::checkAccess($this->getEntityName(), $this->getActionName(), $item)) {
+          throw new UnauthorizedException("ACL check failed");
+        }
+        $items[$key]['check_permissions'] = TRUE;
+      }
+    }
     if ($items) {
       $result->exchangeArray($this->deleteObjects($items));
     }
@@ -53,16 +62,6 @@ class DAODeleteAction extends AbstractBatchAction {
   protected function deleteObjects($items) {
     $ids = [];
     $baoName = $this->getBaoName();
-
-    if ($this->getCheckPermissions()) {
-      foreach (array_keys($items) as $key) {
-        if (!CoreUtil::checkAccess($this->getEntityName(), $this->getActionName(), $items[$key])) {
-          throw new UnauthorizedException("ACL check failed");
-        }
-        $items[$key]['check_permissions'] = TRUE;
-        $this->checkContactPermissions($baoName, $items[$key]);
-      }
-    }
 
     if ($this->getEntityName() !== 'EntityTag' && method_exists($baoName, 'del')) {
       foreach ($items as $item) {

--- a/Civi/Api4/Generic/DAODeleteAction.php
+++ b/Civi/Api4/Generic/DAODeleteAction.php
@@ -43,7 +43,7 @@ class DAODeleteAction extends AbstractBatchAction {
 
     if ($this->getCheckPermissions()) {
       foreach ($items as $key => $item) {
-        if (!CoreUtil::checkAccessRecord($this, $item, \CRM_Core_Session::getLoggedInContactID())) {
+        if (!CoreUtil::checkAccessRecord($this, $item, \CRM_Core_Session::getLoggedInContactID() ?: 0)) {
           throw new UnauthorizedException("ACL check failed");
         }
         $items[$key]['check_permissions'] = TRUE;

--- a/Civi/Api4/Generic/DAOUpdateAction.php
+++ b/Civi/Api4/Generic/DAOUpdateAction.php
@@ -63,7 +63,7 @@ class DAOUpdateAction extends AbstractUpdateAction {
     // Update a single record by ID unless select requires more than id
     if ($this->getSelect() === ['id'] && count($this->where) === 1 && $this->where[0][0] === 'id' && $this->where[0][1] === '=' && !empty($this->where[0][2])) {
       $this->values['id'] = $this->where[0][2];
-      if ($this->checkPermissions && !CoreUtil::checkAccess($this->getEntityName(), $this->getActionName(), $this->values)) {
+      if ($this->checkPermissions && !CoreUtil::checkAccessRecord($this, $this->values, \CRM_Core_Session::getLoggedInContactID())) {
         throw new UnauthorizedException("ACL check failed");
       }
       $items = [$this->values];
@@ -76,7 +76,7 @@ class DAOUpdateAction extends AbstractUpdateAction {
     $items = $this->getBatchRecords();
     foreach ($items as &$item) {
       $item = $this->values + $item;
-      if ($this->checkPermissions && !CoreUtil::checkAccess($this->getEntityName(), $this->getActionName(), $item)) {
+      if ($this->checkPermissions && !CoreUtil::checkAccessRecord($this, $item, \CRM_Core_Session::getLoggedInContactID())) {
         throw new UnauthorizedException("ACL check failed");
       }
     }

--- a/Civi/Api4/Generic/DAOUpdateAction.php
+++ b/Civi/Api4/Generic/DAOUpdateAction.php
@@ -19,6 +19,9 @@
 
 namespace Civi\Api4\Generic;
 
+use Civi\API\Exception\UnauthorizedException;
+use Civi\Api4\Utils\CoreUtil;
+
 /**
  * Update one or more $ENTITY with new values.
  *
@@ -60,6 +63,9 @@ class DAOUpdateAction extends AbstractUpdateAction {
     // Update a single record by ID unless select requires more than id
     if ($this->getSelect() === ['id'] && count($this->where) === 1 && $this->where[0][0] === 'id' && $this->where[0][1] === '=' && !empty($this->where[0][2])) {
       $this->values['id'] = $this->where[0][2];
+      if ($this->checkPermissions && !CoreUtil::checkAccess($this->getEntityName(), $this->getActionName(), $this->values)) {
+        throw new UnauthorizedException("ACL check failed");
+      }
       $items = [$this->values];
       $this->validateValues();
       $result->exchangeArray($this->writeObjects($items));
@@ -70,6 +76,9 @@ class DAOUpdateAction extends AbstractUpdateAction {
     $items = $this->getBatchRecords();
     foreach ($items as &$item) {
       $item = $this->values + $item;
+      if ($this->checkPermissions && !CoreUtil::checkAccess($this->getEntityName(), $this->getActionName(), $item)) {
+        throw new UnauthorizedException("ACL check failed");
+      }
     }
 
     $this->validateValues();

--- a/Civi/Api4/Generic/DAOUpdateAction.php
+++ b/Civi/Api4/Generic/DAOUpdateAction.php
@@ -61,6 +61,7 @@ class DAOUpdateAction extends AbstractUpdateAction {
     if ($this->getSelect() === ['id'] && count($this->where) === 1 && $this->where[0][0] === 'id' && $this->where[0][1] === '=' && !empty($this->where[0][2])) {
       $this->values['id'] = $this->where[0][2];
       $items = [$this->values];
+      $this->validateValues();
       $result->exchangeArray($this->writeObjects($items));
       return;
     }
@@ -71,6 +72,7 @@ class DAOUpdateAction extends AbstractUpdateAction {
       $item = $this->values + $item;
     }
 
+    $this->validateValues();
     $result->exchangeArray($this->writeObjects($items));
   }
 

--- a/Civi/Api4/Generic/DAOUpdateAction.php
+++ b/Civi/Api4/Generic/DAOUpdateAction.php
@@ -63,7 +63,7 @@ class DAOUpdateAction extends AbstractUpdateAction {
     // Update a single record by ID unless select requires more than id
     if ($this->getSelect() === ['id'] && count($this->where) === 1 && $this->where[0][0] === 'id' && $this->where[0][1] === '=' && !empty($this->where[0][2])) {
       $this->values['id'] = $this->where[0][2];
-      if ($this->checkPermissions && !CoreUtil::checkAccessRecord($this, $this->values, \CRM_Core_Session::getLoggedInContactID())) {
+      if ($this->checkPermissions && !CoreUtil::checkAccessRecord($this, $this->values, \CRM_Core_Session::getLoggedInContactID() ?: 0)) {
         throw new UnauthorizedException("ACL check failed");
       }
       $items = [$this->values];
@@ -76,7 +76,7 @@ class DAOUpdateAction extends AbstractUpdateAction {
     $items = $this->getBatchRecords();
     foreach ($items as &$item) {
       $item = $this->values + $item;
-      if ($this->checkPermissions && !CoreUtil::checkAccessRecord($this, $item, \CRM_Core_Session::getLoggedInContactID())) {
+      if ($this->checkPermissions && !CoreUtil::checkAccessRecord($this, $item, \CRM_Core_Session::getLoggedInContactID() ?: 0)) {
         throw new UnauthorizedException("ACL check failed");
       }
     }

--- a/Civi/Api4/Generic/Traits/DAOActionTrait.php
+++ b/Civi/Api4/Generic/Traits/DAOActionTrait.php
@@ -136,10 +136,6 @@ trait DAOActionTrait {
         $item['contact_id'] = $entityId;
       }
 
-      if ($this->getCheckPermissions()) {
-        $this->checkContactPermissions($baoName, $item);
-      }
-
       if ($this->getEntityName() === 'Address') {
         $createResult = $baoName::$method($item, $this->fixAddress);
       }
@@ -257,28 +253,6 @@ trait DAOActionTrait {
       \Civi::cache('metadata')->set($cacheKey, $info);
     }
     return isset($info[$fieldName]) ? ['suffix' => $suffix] + $info[$fieldName] : NULL;
-  }
-
-  /**
-   * Check edit/delete permissions for contacts and related entities.
-   *
-   * @param string $baoName
-   * @param array $item
-   *
-   * @throws \Civi\API\Exception\UnauthorizedException
-   */
-  protected function checkContactPermissions($baoName, $item) {
-    if ($baoName === 'CRM_Contact_BAO_Contact' && !empty($item['id'])) {
-      $permission = $this->getActionName() === 'delete' ? \CRM_Core_Permission::DELETE : \CRM_Core_Permission::EDIT;
-      if (!\CRM_Contact_BAO_Contact_Permission::allow($item['id'], $permission)) {
-        throw new \Civi\API\Exception\UnauthorizedException('Permission denied to modify contact record');
-      }
-    }
-    else {
-      // Fixme: decouple from v3
-      require_once 'api/v3/utils.php';
-      _civicrm_api3_check_edit_permissions($baoName, $item);
-    }
   }
 
 }

--- a/Civi/Api4/Service/Spec/Provider/FinancialItemCreationSpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/FinancialItemCreationSpecProvider.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+
+namespace Civi\Api4\Service\Spec\Provider;
+
+use Civi\Api4\Service\Spec\RequestSpec;
+
+class FinancialItemCreationSpecProvider implements Generic\SpecProviderInterface {
+
+  // I'm not sure it makes sense to have a default `entity_table`... actually, I don't even know if it makes
+  // sense to expose `FinancialItem` as a public API, for what that's worth. But it's there, so clearly it does.
+  //  And the ConformanceTests require that you be able to create (and read-back) a record using metadata.
+
+  const DEFAULT_TABLE = 'civicrm_line_item';
+  const DEFAULT_ENTITY = 'LineItem';
+
+  /**
+   * @param \Civi\Api4\Service\Spec\RequestSpec $spec
+   */
+  public function modifySpec(RequestSpec $spec) {
+    $spec->getFieldByName('entity_table')->setRequired(TRUE);
+    $spec->getFieldByName('entity_id')->setRequired(TRUE);
+    $spec->getFieldByName('entity_table')->setDefaultValue(self::DEFAULT_TABLE);
+  }
+
+  /**
+   * @param string $entity
+   * @param string $action
+   *
+   * @return bool
+   */
+  public function applies($entity, $action) {
+    return $entity === 'FinancialItem' && $action === 'create';
+  }
+
+}

--- a/Civi/Api4/Utils/CoreUtil.php
+++ b/Civi/Api4/Utils/CoreUtil.php
@@ -194,4 +194,23 @@ class CoreUtil {
     return $granted;
   }
 
+  /**
+   * If the permissions of record $A are based on record $B, then use `checkAccessDelegated($B...)`
+   * to make see if access to $B is permitted.
+   *
+   * @param string $entityName
+   * @param string $actionName
+   * @param array $record
+   * @param int|null $userID
+   *   Contact ID of the user we are testing, or NULL for the anonymous user.
+   *
+   * @return bool
+   * @throws \API_Exception
+   * @throws \CRM_Core_Exception
+   */
+  public static function checkAccessDelegated(string $entityName, string $actionName, array $record, $userID = NULL) {
+    // FIXME: Move isAuthorized check into here. It's redundant for normal checkAccess().
+    return static::checkAccess($entityName, $actionName, $record, $userID);
+  }
+
 }

--- a/Civi/Api4/Utils/CoreUtil.php
+++ b/Civi/Api4/Utils/CoreUtil.php
@@ -175,9 +175,13 @@ class CoreUtil {
       $granted = $granted && $action->addSelect('id')->addWhere('id', '=', $record['id'])->execute()->count();
     }
     else {
-      $baoName = self::getBAOFromApiName($entityName);
       // If entity has a BAO, run the BAO::checkAccess function, which will call the hook
-      if ($baoName && strpos($baoName, '_BAO_')) {
+      $baoName = self::getBAOFromApiName($entityName);
+      // CustomValue also requires the name of the group
+      if ($baoName === 'CRM_Core_BAO_CustomValue') {
+        $granted = \CRM_Core_BAO_CustomValue::checkAccess($actionName, $record, NULL, $granted, substr($entityName, 7));
+      }
+      elseif ($baoName) {
         $granted = $baoName::checkAccess($actionName, $record, NULL, $granted);
       }
       // Otherwise, call the hook directly

--- a/Civi/Api4/Utils/CoreUtil.php
+++ b/Civi/Api4/Utils/CoreUtil.php
@@ -157,15 +157,15 @@ class CoreUtil {
    *
    * @param \Civi\Api4\Generic\AbstractAction $apiRequest
    * @param array $record
-   * @param int|null $userID
-   *   Contact ID of the user we are testing, or NULL for the anonymous user.
+   * @param int|string $userID
+   *   Contact ID of the user we are testing,. 0 for the anonymous user.
    * @return bool
    * @throws \API_Exception
    * @throws \CRM_Core_Exception
    * @throws \Civi\API\Exception\NotImplementedException
    * @throws \Civi\API\Exception\UnauthorizedException
    */
-  public static function checkAccessRecord(\Civi\Api4\Generic\AbstractAction $apiRequest, array $record, ?int $userID) {
+  public static function checkAccessRecord(\Civi\Api4\Generic\AbstractAction $apiRequest, array $record, int $userID) {
     // For get actions, just run a get and ACLs will be applied to the query.
     // It's a cheap trick and not as efficient as not running the query at all,
     // but BAO::checkAccess doesn't consistently check permissions for the "get" action.
@@ -197,17 +197,17 @@ class CoreUtil {
    * @param string $entityName
    * @param string $actionName
    * @param array $record
-   * @param int|null $userID
-   *   Contact ID of the user we are testing, or NULL for the anonymous user.
+   * @param int $userID
+   *   Contact ID of the user we are testing, or 0 for the anonymous user.
    *
    * @return bool
    * @throws \API_Exception
    * @throws \CRM_Core_Exception
    */
-  public static function checkAccessDelegated(string $entityName, string $actionName, array $record, ?int $userID) {
+  public static function checkAccessDelegated(string $entityName, string $actionName, array $record, int $userID) {
     $apiRequest = Request::create($entityName, $actionName, ['version' => 4]);
     // TODO: Should probably emit civi.api.authorize for checking guardian permission; but in APIv4 with std cfg, this is de-facto equivalent.
-    if (!$apiRequest->isAuthorized($userID)) {
+    if (!$apiRequest->isAuthorized()) {
       return FALSE;
     }
     return static::checkAccessRecord($apiRequest, $record, $userID);

--- a/Civi/Api4/Utils/CoreUtil.php
+++ b/Civi/Api4/Utils/CoreUtil.php
@@ -179,12 +179,8 @@ class CoreUtil {
     else {
       // If entity has a BAO, run the BAO::checkAccess function, which will call the hook
       $baoName = self::getBAOFromApiName($entityName);
-      // CustomValue also requires the name of the group
-      if ($baoName === 'CRM_Core_BAO_CustomValue') {
-        $granted = \CRM_Core_BAO_CustomValue::checkAccess($actionName, $record, $userID, $granted, substr($entityName, 7));
-      }
-      elseif ($baoName) {
-        $granted = $baoName::checkAccess($actionName, $record, $userID, $granted);
+      if ($baoName) {
+        $granted = $baoName::checkAccess($entityName, $actionName, $record, $userID, $granted);
       }
       // Otherwise, call the hook directly
       else {

--- a/Civi/Api4/Utils/CoreUtil.php
+++ b/Civi/Api4/Utils/CoreUtil.php
@@ -178,7 +178,7 @@ class CoreUtil {
       $baoName = self::getBAOFromApiName($entityName);
       // If entity has a BAO, run the BAO::checkAccess function, which will call the hook
       if ($baoName && strpos($baoName, '_BAO_')) {
-        $baoName::checkAccess($actionName, $record, NULL, $granted);
+        $granted = $baoName::checkAccess($actionName, $record, NULL, $granted);
       }
       // Otherwise, call the hook directly
       else {

--- a/Civi/Api4/Utils/CoreUtil.php
+++ b/Civi/Api4/Utils/CoreUtil.php
@@ -166,23 +166,18 @@ class CoreUtil {
    * @throws \Civi\API\Exception\UnauthorizedException
    */
   public static function checkAccessRecord(\Civi\Api4\Generic\AbstractAction $apiRequest, array $record, ?int $userID) {
-    $granted = TRUE;
     // For get actions, just run a get and ACLs will be applied to the query.
     // It's a cheap trick and not as efficient as not running the query at all,
     // but BAO::checkAccess doesn't consistently check permissions for the "get" action.
     if (is_a($apiRequest, '\Civi\Api4\Generic\DAOGetAction')) {
-      $granted = $granted && $apiRequest->addSelect('id')->addWhere('id', '=', $record['id'])->execute()->count();
+      return (bool) $apiRequest->addSelect('id')->addWhere('id', '=', $record['id'])->execute()->count();
     }
-    else {
-      // If entity has a BAO, run the BAO::checkAccess function, which will call the hook
-      $baoName = self::getBAOFromApiName($apiRequest->getEntityName());
-      if ($baoName) {
-        $granted = $baoName::checkAccess($apiRequest->getEntityName(), $apiRequest->getActionName(), $record, $userID, $granted);
-      }
-      // Otherwise, call the hook directly
-      else {
-        \CRM_Utils_Hook::checkAccess($apiRequest->getEntityName(), $apiRequest->getActionName(), $record, $userID, $granted);
-      }
+
+    $granted = NULL;
+    \CRM_Utils_Hook::checkAccess($apiRequest->getEntityName(), $apiRequest->getActionName(), $record, $userID, $granted);
+    $baoName = self::getBAOFromApiName($apiRequest->getEntityName());
+    if ($granted === NULL && $baoName) {
+      $granted = $baoName::checkAccess($apiRequest->getEntityName(), $apiRequest->getActionName(), $record, $userID);
     }
     return $granted;
   }

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -384,6 +384,7 @@ class Container {
     };
 
     $dispatcher->addListener('civi.api4.validate', $aliasMethodEvent('civi.api4.validate', 'getEntityName'), 100);
+    $dispatcher->addListener('civi.api4.authorizeRecord', $aliasMethodEvent('civi.api4.authorizeRecord', 'getEntityName'), 100);
 
     $dispatcher->addListener('civi.core.install', ['\Civi\Core\InstallationCanary', 'check']);
     $dispatcher->addListener('civi.core.install', ['\Civi\Core\DatabaseInitializer', 'initialize']);

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -377,6 +377,13 @@ class Container {
         \Civi::dispatcher()->dispatch($eventName . "::" . $e->{$fieldName}, $e);
       };
     };
+    $aliasMethodEvent = function($eventName, $methodName) {
+      return function($e) use ($eventName, $methodName) {
+        \Civi::dispatcher()->dispatch($eventName . "::" . $e->{$methodName}(), $e);
+      };
+    };
+
+    $dispatcher->addListener('civi.api4.validate', $aliasMethodEvent('civi.api4.validate', 'getEntityName'), 100);
 
     $dispatcher->addListener('civi.core.install', ['\Civi\Core\InstallationCanary', 'check']);
     $dispatcher->addListener('civi.core.install', ['\Civi\Core\DatabaseInitializer', 'initialize']);

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -371,13 +371,20 @@ class Container {
     /** @var CiviEventDispatcher $dispatcher */
     $dispatcher = static::getBootService('dispatcher.boot');
 
+    // Sometimes, you have a generic event ('hook_pre') and wish to fire more targeted aliases ('hook_pre::MyEntity') to allow shorter subscriber lists.
+    $aliasEvent = function($eventName, $fieldName) {
+      return function($e) use ($eventName, $fieldName) {
+        \Civi::dispatcher()->dispatch($eventName . "::" . $e->{$fieldName}, $e);
+      };
+    };
+
     $dispatcher->addListener('civi.core.install', ['\Civi\Core\InstallationCanary', 'check']);
     $dispatcher->addListener('civi.core.install', ['\Civi\Core\DatabaseInitializer', 'initialize']);
     $dispatcher->addListener('civi.core.install', ['\Civi\Core\LocalizationInitializer', 'initialize']);
     $dispatcher->addListener('hook_civicrm_post', ['\CRM_Core_Transaction', 'addPostCommit'], -1000);
-    $dispatcher->addListener('hook_civicrm_pre', ['\Civi\Core\Event\PreEvent', 'dispatchSubevent'], 100);
+    $dispatcher->addListener('hook_civicrm_pre', $aliasEvent('hook_civicrm_pre', 'entity'), 100);
     $dispatcher->addListener('civi.dao.preDelete', ['\CRM_Core_BAO_EntityTag', 'preDeleteOtherEntity']);
-    $dispatcher->addListener('hook_civicrm_post', ['\Civi\Core\Event\PostEvent', 'dispatchSubevent'], 100);
+    $dispatcher->addListener('hook_civicrm_post', $aliasEvent('hook_civicrm_post', 'entity'), 100);
     $dispatcher->addListener('hook_civicrm_post::Activity', ['\Civi\CCase\Events', 'fireCaseChange']);
     $dispatcher->addListener('hook_civicrm_post::Case', ['\Civi\CCase\Events', 'fireCaseChange']);
     $dispatcher->addListener('hook_civicrm_caseChange', ['\Civi\CCase\Events', 'delegateToXmlListeners']);

--- a/Civi/Core/Event/PostEvent.php
+++ b/Civi/Core/Event/PostEvent.php
@@ -18,17 +18,6 @@ namespace Civi\Core\Event;
 class PostEvent extends GenericHookEvent {
 
   /**
-   * This adapter automatically emits a narrower event.
-   *
-   * For example, `hook_civicrm_pre(Contact, ...)` will also dispatch `hook_civicrm_pre::Contact`.
-   *
-   * @param \Civi\Core\Event\PostEvent $event
-   */
-  public static function dispatchSubevent(PostEvent $event) {
-    \Civi::dispatcher()->dispatch("hook_civicrm_post::" . $event->entity, $event);
-  }
-
-  /**
    * One of: 'create'|'edit'|'delete'
    *
    * @var string

--- a/Civi/Core/Event/PreEvent.php
+++ b/Civi/Core/Event/PreEvent.php
@@ -18,17 +18,6 @@ namespace Civi\Core\Event;
 class PreEvent extends GenericHookEvent {
 
   /**
-   * This adapter automatically emits a narrower event.
-   *
-   * For example, `hook_civicrm_pre(Contact, ...)` will also dispatch `hook_civicrm_pre::Contact`.
-   *
-   * @param \Civi\Core\Event\PreEvent $event
-   */
-  public static function dispatchSubevent(PreEvent $event) {
-    \Civi::dispatcher()->dispatch("hook_civicrm_pre::" . $event->entity, $event);
-  }
-
-  /**
    * One of: 'create'|'edit'|'delete'
    *
    * @var string

--- a/api/v3/Contribution.php
+++ b/api/v3/Contribution.php
@@ -204,7 +204,7 @@ function _civicrm_api3_contribution_create_legacy_support_45(&$params) {
 function civicrm_api3_contribution_delete($params) {
 
   $contributionID = !empty($params['contribution_id']) ? $params['contribution_id'] : $params['id'];
-  if (!empty($params['check_permissions']) && !CRM_Contribute_BAO_Contribution::checkAccess('delete', ['id' => $contributionID])) {
+  if (!empty($params['check_permissions']) && !\Civi\Api4\Utils\CoreUtil::checkAccessDelegated('Contribution', 'delete', ['id' => $contributionID], CRM_Core_Session::getLoggedInContactID())) {
     throw new API_Exception('You do not have permission to delete this contribution');
   }
   if (CRM_Contribute_BAO_Contribution::deleteContribution($contributionID)) {

--- a/api/v3/Contribution.php
+++ b/api/v3/Contribution.php
@@ -204,23 +204,13 @@ function _civicrm_api3_contribution_create_legacy_support_45(&$params) {
 function civicrm_api3_contribution_delete($params) {
 
   $contributionID = !empty($params['contribution_id']) ? $params['contribution_id'] : $params['id'];
-  // First check contribution financial type
-  $financialType = CRM_Core_DAO::getFieldValue('CRM_Contribute_DAO_Contribution', $contributionID, 'financial_type_id');
-  // Now check permissioned lineitems & permissioned contribution
-  if (!empty($params['check_permissions']) && CRM_Financial_BAO_FinancialType::isACLFinancialTypeStatus() &&
-    (
-      !CRM_Core_Permission::check('delete contributions of type ' . CRM_Contribute_PseudoConstant::financialType($financialType))
-      || !CRM_Financial_BAO_FinancialType::checkPermissionedLineItems($contributionID, 'delete', FALSE)
-    )
-  ) {
+  if (!empty($params['check_permissions']) && !CRM_Contribute_BAO_Contribution::checkAccess('delete', ['id' => $contributionID])) {
     throw new API_Exception('You do not have permission to delete this contribution');
   }
   if (CRM_Contribute_BAO_Contribution::deleteContribution($contributionID)) {
     return civicrm_api3_create_success([$contributionID => 1]);
   }
-  else {
-    throw new API_Exception('Could not delete contribution');
-  }
+  throw new API_Exception('Could not delete contribution');
 }
 
 /**
@@ -671,7 +661,7 @@ function _ipn_process_transaction($params, $contribution, $input, $ids) {
     static $domainFromName;
     static $domainFromEmail;
     if (empty($domainFromEmail) && (empty($params['receipt_from_name']) || empty($params['receipt_from_email']))) {
-      list($domainFromName, $domainFromEmail) = CRM_Core_BAO_Domain::getNameAndEmail(TRUE);
+      [$domainFromName, $domainFromEmail] = CRM_Core_BAO_Domain::getNameAndEmail(TRUE);
     }
     $input['receipt_from_name'] = CRM_Utils_Array::value('receipt_from_name', $params, $domainFromName);
     $input['receipt_from_email'] = CRM_Utils_Array::value('receipt_from_email', $params, $domainFromEmail);

--- a/api/v3/Contribution.php
+++ b/api/v3/Contribution.php
@@ -204,7 +204,7 @@ function _civicrm_api3_contribution_create_legacy_support_45(&$params) {
 function civicrm_api3_contribution_delete($params) {
 
   $contributionID = !empty($params['contribution_id']) ? $params['contribution_id'] : $params['id'];
-  if (!empty($params['check_permissions']) && !\Civi\Api4\Utils\CoreUtil::checkAccessDelegated('Contribution', 'delete', ['id' => $contributionID], CRM_Core_Session::getLoggedInContactID())) {
+  if (!empty($params['check_permissions']) && !\Civi\Api4\Utils\CoreUtil::checkAccessDelegated('Contribution', 'delete', ['id' => $contributionID], CRM_Core_Session::getLoggedInContactID() ?: 0)) {
     throw new API_Exception('You do not have permission to delete this contribution');
   }
   if (CRM_Contribute_BAO_Contribution::deleteContribution($contributionID)) {

--- a/ext/financialacls/financialacls.php
+++ b/ext/financialacls/financialacls.php
@@ -291,11 +291,11 @@ function financialacls_civicrm_permission(&$permissions) {
  * @param string $action
  * @param array $record
  * @param int|null $contactID
- * @param bool $granted
+ * @param bool|null $granted
  *
  * @throws \CRM_Core_Exception
  */
-function financialacls_civicrm_checkAccess(string $entity, string $action, array $record, ?int $contactID, bool &$granted) {
+function financialacls_civicrm_checkAccess(string $entity, string $action, array $record, ?int $contactID, ?bool &$granted) {
   if (!financialacls_is_acl_limiting_enabled()) {
     return;
   }

--- a/ext/oauth-client/Civi/Api4/Action/OAuthContactToken/OnlyModifyOwnTokensTrait.php
+++ b/ext/oauth-client/Civi/Api4/Action/OAuthContactToken/OnlyModifyOwnTokensTrait.php
@@ -4,14 +4,13 @@ namespace Civi\Api4\Action\OAuthContactToken;
 
 trait OnlyModifyOwnTokensTrait {
 
-  public function isAuthorized(): bool {
-    if (\CRM_Core_Permission::check(['manage all OAuth contact tokens'])) {
+  public function isAuthorized(?int $loggedInContactID): bool {
+    if (\CRM_Core_Permission::check(['manage all OAuth contact tokens'], $loggedInContactID)) {
       return TRUE;
     }
-    if (!\CRM_Core_Permission::check(['manage my OAuth contact tokens'])) {
+    if (!\CRM_Core_Permission::check(['manage my OAuth contact tokens'], $loggedInContactID)) {
       return FALSE;
     }
-    $loggedInContactID = \CRM_Core_Session::singleton()->getLoggedInContactID();
     foreach ($this->where as $clause) {
       [$field, $op, $val] = $clause;
       if ($field !== 'contact_id') {

--- a/ext/oauth-client/Civi/Api4/Action/OAuthContactToken/OnlyModifyOwnTokensTrait.php
+++ b/ext/oauth-client/Civi/Api4/Action/OAuthContactToken/OnlyModifyOwnTokensTrait.php
@@ -4,13 +4,14 @@ namespace Civi\Api4\Action\OAuthContactToken;
 
 trait OnlyModifyOwnTokensTrait {
 
-  public function isAuthorized(?int $loggedInContactID): bool {
-    if (\CRM_Core_Permission::check(['manage all OAuth contact tokens'], $loggedInContactID)) {
+  public function isAuthorized(): bool {
+    if (\CRM_Core_Permission::check(['manage all OAuth contact tokens'])) {
       return TRUE;
     }
-    if (!\CRM_Core_Permission::check(['manage my OAuth contact tokens'], $loggedInContactID)) {
+    if (!\CRM_Core_Permission::check(['manage my OAuth contact tokens'])) {
       return FALSE;
     }
+    $loggedInContactID = \CRM_Core_Session::singleton()->getLoggedInContactID();
     foreach ($this->where as $clause) {
       [$field, $op, $val] = $clause;
       if ($field !== 'contact_id') {

--- a/tests/phpunit/CRM/Utils/LazyArrayTest.php
+++ b/tests/phpunit/CRM/Utils/LazyArrayTest.php
@@ -1,0 +1,111 @@
+<?php
+
+/**
+ * Class CRM_Utils_LazyArrayTest
+ * @group headless
+ */
+class CRM_Utils_LazyArrayTest extends CiviUnitTestCase {
+
+  public function testAssoc() {
+    $l = $this->createFruitBasket();
+    $this->assertFalse($l->isLoaded());
+
+    $this->assertEquals('apple', $l['a']);
+    $this->assertEquals('banana', $l['b']);
+    $this->assertTrue($l->isLoaded());
+    $this->assertEquals(3, count($l));
+    $this->assertTrue(isset($l['c']));
+    $this->assertFalse(isset($l['d']));
+
+    $l['a'] = 'apricot';
+    $this->assertEquals('apricot', $l['a']);
+    $this->assertEquals(3, count($l));
+
+    $l['d'] = 'date';
+    $this->assertEquals('date', $l['d']);
+    $this->assertEquals(4, count($l));
+
+    $keys = [];
+    foreach ($l as $key => $value) {
+      $keys[] = $key;
+    }
+    $this->assertEquals(['a', 'b', 'c', 'd'], $keys);
+    $this->assertEquals(['a', 'b', 'c', 'd'], array_keys(CRM_Utils_Array::cast($l)));
+  }
+
+  public function testNumeric() {
+    $l = $this->createSeaRecords();
+    $this->assertFalse($l->isLoaded());
+
+    $this->assertEquals('aegean', $l[0]['name']);
+    $this->assertEquals('caspian', $l[2]['name']);
+    $this->assertTrue($l->isLoaded());
+    $this->assertEquals(3, count($l));
+    $this->assertTrue(isset($l[2]));
+    $this->assertFalse(isset($l[3]));
+
+    $l[2]['name'] = 'coral';
+    $this->assertEquals(['name' => 'coral', 'area' => 371], $l['2']);
+    $this->assertEquals(3, count($l));
+
+    $l[] = ['name' => 'weddell', 'area' => 2800];
+    $this->assertEquals('weddell', $l[3]['name']);
+    $this->assertEquals(4, count($l));
+
+    $keys = [];
+    foreach ($l as $key => $value) {
+      $keys[] = $key;
+    }
+    $this->assertEquals([0, 1, 2, 3], $keys);
+    $this->assertEquals([0, 1, 2, 3], array_keys(CRM_Utils_Array::cast($l)));
+  }
+
+  public function testBasicInspections() {
+    $l = $this->createFruitBasket();
+    $this->assertFalse($l->isLoaded());
+
+    $this->assertTrue($l !== NULL);
+    $this->assertTrue($l instanceof CRM_Utils_LazyArray);
+    $this->assertTrue(is_iterable($l));
+    $this->assertTrue(!is_array($l));
+
+    $this->assertFalse($l->isLoaded());
+
+    $this->assertEquals(3, count($l));
+    $this->assertTrue($l->isLoaded());
+  }
+
+  public function testCopy() {
+    $l = $this->createFruitBasket();
+    $copy = $l->getArrayCopy();
+    $copy['d'] = 'date';
+
+    $this->assertEquals(3, count($l));
+    $this->assertEquals(4, count($copy));
+  }
+
+  /**
+   * @return \CRM_Utils_LazyArray
+   */
+  private function createFruitBasket(): \CRM_Utils_LazyArray {
+    return new CRM_Utils_LazyArray(function () {
+      yield 'a' => 'apple';
+      yield 'b' => 'banana';
+      yield 'c' => 'cherry';
+    });
+  }
+
+  /**
+   * @return \CRM_Utils_LazyArray
+   */
+  private function createSeaRecords(): \CRM_Utils_LazyArray {
+    return new CRM_Utils_LazyArray(function () {
+      return [
+        ['name' => 'aegean', 'area' => 214],
+        ['name' => 'baltic', 'area' => 377],
+        ['name' => 'caspian', 'area' => 371],
+      ];
+    });
+  }
+
+}

--- a/tests/phpunit/api/v3/ACLPermissionTest.php
+++ b/tests/phpunit/api/v3/ACLPermissionTest.php
@@ -228,9 +228,6 @@ class api_v3_ACLPermissionTest extends CiviUnitTestCase {
       ]);
       $this->assertGreaterThan(0, $results['count']);
     }
-    if ($version == 4) {
-      $this->markTestIncomplete('Skipping entity_id related perms in api4 for now.');
-    }
     $newTag = civicrm_api3('Tag', 'create', [
       'name' => 'Foo123',
     ]);

--- a/tests/phpunit/api/v3/ContactTest.php
+++ b/tests/phpunit/api/v3/ContactTest.php
@@ -3211,7 +3211,12 @@ class api_v3_ContactTest extends CiviUnitTestCase {
 
     $config->userPermissionClass->permissions = ['access CiviCRM'];
     $result = $this->callAPIFailure('contact', 'update', $params);
-    $this->assertEquals('Permission denied to modify contact record', $result['error_message']);
+    if ($version == 3) {
+      $this->assertEquals('Permission denied to modify contact record', $result['error_message']);
+    }
+    else {
+      $this->assertEquals('ACL check failed', $result['error_message']);
+    }
 
     $config->userPermissionClass->permissions = [
       'access CiviCRM',

--- a/tests/phpunit/api/v3/FinancialTypeACLTest.php
+++ b/tests/phpunit/api/v3/FinancialTypeACLTest.php
@@ -291,8 +291,10 @@ class api_v3_FinancialTypeACLTest extends CiviUnitTestCase {
 
   /**
    * Test that acl contributions can be deleted.
+   *
+   * @throws \CRM_Core_Exception
    */
-  public function testDeleteACLContribution() {
+  public function testDeleteACLContribution(): void {
     $this->enableFinancialACLs();
 
     $this->setPermissions([
@@ -313,7 +315,7 @@ class api_v3_FinancialTypeACLTest extends CiviUnitTestCase {
     $this->addFinancialAclPermissions([['delete', 'Donation']]);
     $contribution = $this->callAPISuccess('Contribution', 'delete', $params);
 
-    $this->assertEquals($contribution['count'], 1);
+    $this->assertEquals(1, $contribution['count']);
   }
 
   public function testMembershipTypeACLFinancialTypeACL() {

--- a/tests/phpunit/api/v4/Action/BasicActionsTest.php
+++ b/tests/phpunit/api/v4/Action/BasicActionsTest.php
@@ -260,7 +260,7 @@ class BasicActionsTest extends UnitTestCase {
 
   public function testEmptyAndNullOperators() {
     $records = [
-      [],
+      ['id' => NULL],
       ['color' => '', 'weight' => 0],
       ['color' => 'yellow', 'weight' => 100000000000],
     ];

--- a/tests/phpunit/api/v4/Entity/ConformanceTest.php
+++ b/tests/phpunit/api/v4/Entity/ConformanceTest.php
@@ -19,16 +19,19 @@
 
 namespace api\v4\Entity;
 
+use Civi\API\Exception\UnauthorizedException;
 use Civi\Api4\Entity;
 use api\v4\UnitTestCase;
 use Civi\Api4\Event\ValidateValuesEvent;
 use Civi\Api4\Utils\CoreUtil;
+use Civi\Test\HookInterface;
 
 /**
  * @group headless
  */
-class ConformanceTest extends UnitTestCase {
+class ConformanceTest extends UnitTestCase implements HookInterface {
 
+  use \api\v4\Traits\CheckAccessTrait;
   use \api\v4\Traits\TableDropperTrait;
   use \api\v4\Traits\OptionCleanupTrait {
     setUp as setUpOptionCleanup;
@@ -58,6 +61,7 @@ class ConformanceTest extends UnitTestCase {
     $this->loadDataSet('ConformanceTest');
     $this->creationParamProvider = \Civi::container()->get('test.param_provider');
     parent::setUp();
+    $this->resetCheckAccess();
   }
 
   /**
@@ -137,13 +141,16 @@ class ConformanceTest extends UnitTestCase {
     }
 
     $this->checkFields($entityClass, $entity);
-    $id = $this->checkCreation($entity, $entityClass);
+    $this->checkCreationDenied($entity, $entityClass);
+    $id = $this->checkCreationAllowed($entity, $entityClass);
     $this->checkGet($entityClass, $id, $entity);
+    $this->checkGetAllowed($entityClass, $id, $entity);
     $this->checkGetCount($entityClass, $id, $entity);
     $this->checkUpdateFailsFromCreate($entityClass, $id);
     $this->checkWrongParamType($entityClass);
     $this->checkDeleteWithNoId($entityClass);
-    $this->checkDeletion($entityClass, $id);
+    $this->checkDeletionDenied($entityClass, $id, $entity);
+    $this->checkDeletionAllowed($entityClass, $id, $entity);
     $this->checkPostDelete($entityClass, $id, $entity);
   }
 
@@ -205,31 +212,62 @@ class ConformanceTest extends UnitTestCase {
    *
    * @return mixed
    */
-  protected function checkCreation($entity, $entityClass) {
+  protected function checkCreationAllowed($entity, $entityClass) {
     $hookLog = [];
     $onValidate = function(ValidateValuesEvent $e) use (&$hookLog) {
-      $hookLog[$e->entity][$e->action] = 1 + ($hookLog[$e->entity][$e->action] ?? 0);
+      $hookLog[$e->getEntityName()][$e->getActionName()] = 1 + ($hookLog[$e->getEntityName()][$e->getActionName()] ?? 0);
     };
     \Civi::dispatcher()->addListener('civi.api4.validate', $onValidate);
     \Civi::dispatcher()->addListener('civi.api4.validate::' . $entity, $onValidate);
 
+    $this->setCheckAccessGrants(["{$entity}::create" => TRUE]);
+    $this->assertEquals(0, $this->checkAccessCounts["{$entity}::create"]);
+
     $requiredParams = $this->creationParamProvider->getRequired($entity);
     $createResult = $entityClass::create()
       ->setValues($requiredParams)
-      ->setCheckPermissions(FALSE)
+      ->setCheckPermissions(TRUE)
       ->execute()
       ->first();
 
     $this->assertArrayHasKey('id', $createResult, "create missing ID");
     $id = $createResult['id'];
-
     $this->assertGreaterThanOrEqual(1, $id, "$entity ID not positive");
+    $this->assertEquals(1, $this->checkAccessCounts["{$entity}::create"]);
+    $this->resetCheckAccess();
 
     $this->assertEquals(2, $hookLog[$entity]['create']);
     \Civi::dispatcher()->removeListener('civi.api4.validate', $onValidate);
     \Civi::dispatcher()->removeListener('civi.api4.validate::' . $entity, $onValidate);
 
     return $id;
+  }
+
+  /**
+   * @param string $entity
+   * @param \Civi\Api4\Generic\AbstractEntity|string $entityClass
+   *
+   * @return mixed
+   */
+  protected function checkCreationDenied($entity, $entityClass) {
+    $this->setCheckAccessGrants(["{$entity}::create" => FALSE]);
+    $this->assertEquals(0, $this->checkAccessCounts["{$entity}::create"]);
+
+    $requiredParams = $this->creationParamProvider->getRequired($entity);
+
+    try {
+      $entityClass::create()
+        ->setValues($requiredParams)
+        ->setCheckPermissions(TRUE)
+        ->execute()
+        ->first();
+      $this->fail("{$entityClass}::create() should throw an authorization failure.");
+    }
+    catch (UnauthorizedException $e) {
+      // OK, expected exception
+    }
+    $this->assertEquals(1, $this->checkAccessCounts["{$entity}::create"]);
+    $this->resetCheckAccess();
   }
 
   /**
@@ -265,6 +303,26 @@ class ConformanceTest extends UnitTestCase {
   }
 
   /**
+   * Use a permissioned request for `get()`, with access grnted
+   * via checkAccess event.
+   *
+   * @param \Civi\Api4\Generic\AbstractEntity|string $entityClass
+   * @param int $id
+   * @param string $entity
+   */
+  protected function checkGetAllowed($entityClass, $id, $entity) {
+    $this->setCheckAccessGrants(["{$entity}::get" => TRUE]);
+    $getResult = $entityClass::get()
+      ->addWhere('id', '=', $id)
+      ->execute();
+
+    $errMsg = sprintf('Failed to fetch a %s after creation', $entity);
+    $this->assertEquals($id, $getResult->first()['id'], $errMsg);
+    $this->assertEquals(1, $getResult->count(), $errMsg);
+    $this->resetCheckAccess();
+  }
+
+  /**
    * @param \Civi\Api4\Generic\AbstractEntity|string $entityClass
    * @param int $id
    * @param string $entity
@@ -280,7 +338,6 @@ class ConformanceTest extends UnitTestCase {
     $getResult = $entityClass::get(FALSE)
       ->selectRowCount()
       ->execute();
-    $errMsg = sprintf('%s getCount failed', $entity);
     $this->assertGreaterThanOrEqual(1, $getResult->count(), $errMsg);
   }
 
@@ -317,16 +374,49 @@ class ConformanceTest extends UnitTestCase {
   }
 
   /**
+   * Delete an entity - while having a targeted grant (hook_civirm_checkAccess).
+   *
    * @param \Civi\Api4\Generic\AbstractEntity|string $entityClass
    * @param int $id
+   * @param string $entity
    */
-  protected function checkDeletion($entityClass, $id) {
-    $deleteResult = $entityClass::delete(FALSE)
+  protected function checkDeletionAllowed($entityClass, $id, $entity) {
+    $this->setCheckAccessGrants(["{$entity}::delete" => TRUE]);
+    $this->assertEquals(0, $this->checkAccessCounts["{$entity}::delete"]);
+
+    $deleteResult = $entityClass::delete()
       ->addWhere('id', '=', $id)
       ->execute();
 
     // should get back an array of deleted id
     $this->assertEquals([['id' => $id]], (array) $deleteResult);
+    $this->assertEquals(1, $this->checkAccessCounts["{$entity}::delete"]);
+    $this->resetCheckAccess();
+  }
+
+  /**
+   * Attempt to delete an entity while having explicitly denied permission (hook_civicrm_checkAccess).
+   *
+   * @param \Civi\Api4\Generic\AbstractEntity|string $entityClass
+   * @param int $id
+   * @param string $entity
+   */
+  protected function checkDeletionDenied($entityClass, $id, $entity) {
+    $this->setCheckAccessGrants(["{$entity}::delete" => FALSE]);
+    $this->assertEquals(0, $this->checkAccessCounts["{$entity}::delete"]);
+
+    try {
+      $entityClass::delete()
+        ->addWhere('id', '=', $id)
+        ->execute();
+      $this->fail("{$entity}::delete should throw an authorization failure.");
+    }
+    catch (UnauthorizedException $e) {
+      // OK
+    }
+
+    $this->assertEquals(1, $this->checkAccessCounts["{$entity}::delete"]);
+    $this->resetCheckAccess();
   }
 
   /**

--- a/tests/phpunit/api/v4/Entity/ValidateValuesTest.php
+++ b/tests/phpunit/api/v4/Entity/ValidateValuesTest.php
@@ -1,0 +1,214 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+namespace api\v4\Entity;
+
+use Civi\Api4\Contact;
+use api\v4\UnitTestCase;
+use Civi\Api4\Event\ValidateValuesEvent;
+use Civi\Test\TransactionalInterface;
+
+/**
+ * Assert that 'validateValues' runs during
+ *
+ * @group headless
+ */
+class ValidateValuesTest extends UnitTestCase implements TransactionalInterface {
+
+  private $lastValidator;
+
+  protected function setUp(): void {
+    $this->lastValidator = NULL;
+    parent::setUp();
+  }
+
+  protected function tearDown(): void {
+    $this->setValidator(NULL);
+    parent::tearDown();
+  }
+
+  /**
+   * Fire ValidateValuesEvent several times - and ensure it conveys the
+   * expected data.
+   *
+   * @throws \API_Exception
+   * @throws \Civi\API\Exception\UnauthorizedException
+   */
+  public function testHookData() {
+    $hookCount = 0;
+
+    // Step 1: `create()` a record for Ms. Alice Alison.
+    $this->setValidator(function (ValidateValuesEvent $e) use (&$hookCount) {
+      $this->assertWellFormedEvent($e);
+      if ($e->getEntityName() !== 'Contact') {
+        return;
+      }
+
+      $hookCount++;
+      $this->assertEquals('create', $e->getActionName());
+      $this->assertEquals('Alice', $e->records[0]['first_name']);
+      $this->assertEquals('Alison', $e->records[0]['last_name']);
+
+      $this->assertFalse($e->diffs->isLoaded());
+      $this->assertEquals(1, count($e->diffs));
+      $this->assertEquals(NULL, $e->diffs[0]['old']);
+      $this->assertEquals('Alice', $e->diffs[0]['new']['first_name']);
+      $this->assertEquals('Alison', $e->diffs[0]['new']['last_name']);
+
+    });
+    $created = Contact::create()->setValues([
+      'contact_type' => 'Individual',
+      'first_name' => 'Alice',
+      'last_name' => 'Alison',
+    ])->execute()->single();
+    $this->assertTrue(is_numeric($created['id']));
+    $this->assertEquals(1, $hookCount);
+
+    // Step 2: `save()` a couple records for Ms. Alice Alison and Mr. Bob Bobmom.
+    $this->setValidator(function (ValidateValuesEvent $e) use (&$hookCount) {
+      $this->assertWellFormedEvent($e);
+      if ($e->getEntityName() !== 'Contact') {
+        return;
+      }
+
+      $hookCount++;
+      $this->assertEquals('save', $e->getActionName());
+      $this->assertEquals('Alicia', $e->records[0]['first_name']);
+      $this->assertEquals('Bob', $e->records[1]['first_name']);
+
+      $this->assertFalse($e->diffs->isLoaded());
+      $this->assertEquals(2, count($e->diffs));
+      $this->assertEquals('Alice', $e->diffs[0]['old']['first_name']);
+      $this->assertEquals('Alicia', $e->diffs[0]['new']['first_name']);
+      $this->assertEquals(NULL, $e->diffs[1]['old']);
+      $this->assertEquals('Bob', $e->diffs[1]['new']['first_name']);
+
+    });
+    $saved = Contact::save()->setRecords([
+      ['id' => $created['id'], 'first_name' => 'Alicia'],
+      ['contact_type' => 'Individual', 'first_name' => 'Bob', 'last_name' => 'Bobmom'],
+    ])->execute();
+    $this->assertEquals(2, $saved->count());
+    $this->assertEquals(2, $hookCount);
+
+    // Step 3: `update()` a record for Mr. Bob Bobmom
+    $this->setValidator(function (ValidateValuesEvent $e) use (&$hookCount) {
+      $this->assertWellFormedEvent($e);
+      if ($e->getEntityName() !== 'Contact') {
+        return;
+      }
+
+      $hookCount++;
+      $this->assertEquals('update', $e->getActionName());
+      $this->assertEquals('Bobby', $e->records[0]['first_name']);
+
+      $this->assertFalse($e->diffs->isLoaded());
+      $this->assertEquals(1, count($e->diffs));
+      $this->assertEquals('Bob', $e->diffs[0]['old']['first_name']);
+      $this->assertEquals('Bobmom', $e->diffs[0]['old']['last_name']);
+      $this->assertEquals('Bobby', $e->diffs[0]['new']['first_name']);
+    });
+    $updated = Contact::update()
+      ->setValues(['first_name' => 'Bobby'])
+      ->addWhere('last_name', '=', 'Bobmom')
+      ->execute();
+    $this->assertEquals(1, $updated->count());
+    $this->assertEquals(3, $hookCount);
+  }
+
+  public function testRaiseError() {
+    $this->setValidator(function (ValidateValuesEvent $e) use (&$hookCount) {
+      $this->assertWellFormedEvent($e);
+      if ($e->getEntityName() !== 'Contact') {
+        return;
+      }
+
+      foreach ($e->records as $k => $record) {
+        $e->addError($k, 'first_name', 'not-namey-enough', ts('The first name is not sufficiently namey.'));
+        $e->addError($k, ['first_name', 'last_name'], 'tongue-twister', ts('When the names are put together, they become a tongue twister.'));
+        $e->errors[] = [
+          'record' => $k,
+          'fields' => ['last_name'],
+          'name' => 'misspelled',
+          'message' => ts('I disagree with the spelling of your name.'),
+        ];
+      }
+
+      $hookCount++;
+    });
+
+    try {
+      Contact::create()->setValues([
+        'contact_type' => 'Individual',
+        'first_name' => 'Alice',
+        'last_name' => 'Alison',
+      ])->execute();
+      $this->fail('Expected an exception due to validation error');
+    }
+    catch (\API_Exception $e) {
+      $this->assertEquals(1, $hookCount);
+      $this->assertRegExp(';not sufficiently namey;', $e->getMessage());
+      $this->assertRegExp(';tongue twister;', $e->getMessage());
+      $this->assertRegExp(';disagree with the spelling;', $e->getMessage());
+    }
+  }
+
+  /**
+   * Add/replace the validator.
+   *
+   * @param callable $func
+   */
+  protected function setValidator($func) {
+    $dispatcher = \Civi::dispatcher();
+    if ($this->lastValidator) {
+      $dispatcher->removeListener('civi.api4.validate', $this->lastValidator);
+    }
+    if ($func) {
+      $dispatcher->addListener('civi.api4.validate', $func);
+    }
+    $this->lastValidator = $func;
+  }
+
+  protected function assertWellFormedEvent(ValidateValuesEvent $e) {
+    $this->assertRegExp('/Contact/', $e->getEntityName());
+    $this->assertRegExp('/create|save|update/', $e->getActionName());
+    $this->assertTrue(count($e->records) > 0);
+    foreach ($e->records as $record) {
+      $this->assertWellFormedFields($record);
+    }
+
+    // We want to let the main test do some assertions on the lazy-array, so we'll peek a clone.
+    $peekAtDiffs = clone $e->diffs;
+    $this->assertTrue(count($peekAtDiffs) > 0);
+    foreach ($peekAtDiffs as $diff) {
+      $this->assertTrue(is_array($diff['new']));
+      $this->assertWellFormedFields($diff['new']);
+      if ($diff['old'] !== NULL) {
+        $this->assertTrue(is_array($diff['old']));
+        $this->assertWellFormedFields($diff['old']);
+      }
+    }
+  }
+
+  protected function assertWellFormedFields($record) {
+    foreach ($record as $field => $value) {
+      $this->assertRegExp('/^[a-zA-Z0-9_]+$/', $field);
+    }
+  }
+
+}

--- a/tests/phpunit/api/v4/Service/TestCreationParameterProvider.php
+++ b/tests/phpunit/api/v4/Service/TestCreationParameterProvider.php
@@ -20,6 +20,7 @@
 namespace api\v4\Service;
 
 use Civi\Api4\Service\Spec\FieldSpec;
+use Civi\Api4\Service\Spec\Provider\FinancialItemCreationSpecProvider;
 use Civi\Api4\Service\Spec\SpecGatherer;
 
 class TestCreationParameterProvider {
@@ -82,8 +83,18 @@ class TestCreationParameterProvider {
     elseif ($field->getDefaultValue()) {
       return $field->getDefaultValue();
     }
-    elseif (in_array($field->getName(), ['entity_id', 'contact_id'])) {
+    elseif ($field->getName() === 'contact_id') {
       return $this->getFkID($field, 'Contact');
+    }
+    elseif ($field->getName() === 'entity_id') {
+      // What could possibly go wrong with this?
+      switch ($field->getTableName()) {
+        case 'civicrm_financial_item':
+          return $this->getFkID($field, FinancialItemCreationSpecProvider::DEFAULT_ENTITY);
+
+        default:
+          return $this->getFkID($field, 'Contact');
+      }
     }
 
     $randomValue = $this->getRandomValue($field->getDataType());

--- a/tests/phpunit/api/v4/Traits/CheckAccessTrait.php
+++ b/tests/phpunit/api/v4/Traits/CheckAccessTrait.php
@@ -1,8 +1,10 @@
 <?php
 namespace api\v4\Traits;
 
+use Civi\Api4\Event\AuthorizeRecordEvent;
+
 /**
- * Define an implementation of `hook_civicrm_checkAccess` in which access-control decisions are
+ * Define an implementation of `civi.api4.authorizeRecord` in which access-control decisions are
  * based on a predefined list. For example:
  *
  *   $this->setCheckAccessGrants(['Contact::create' => TRUE]);
@@ -28,17 +30,14 @@ trait CheckAccessTrait {
   protected $checkAccessCounts = [];
 
   /**
-   * @param string $entity
-   * @param string $action
-   * @param array $record
-   * @param int|null $contactID
-   * @param bool $granted
-   * @see \CRM_Utils_Hook::checkAccess()
+   * Listen to 'civi.api4.authorizeRecord'. Override decisions with specified grants.
+   *
+   * @param \Civi\Api4\Event\AuthorizeRecordEvent $e
    */
-  public function hook_civicrm_checkAccess(string $entity, string $action, array $record, ?int $contactID, ?bool &$granted) {
-    $key = "{$entity}::{$action}";
+  public function on_civi_api4_authorizeRecord(AuthorizeRecordEvent $e): void {
+    $key = $e->getEntityName() . '::' . $e->getActionName();
     if (isset($this->checkAccessGrants[$key])) {
-      $granted = $this->checkAccessGrants[$key];
+      $e->setAuthorized($this->checkAccessGrants[$key]);
       $this->checkAccessCounts[$key]++;
     }
   }

--- a/tests/phpunit/api/v4/Traits/CheckAccessTrait.php
+++ b/tests/phpunit/api/v4/Traits/CheckAccessTrait.php
@@ -1,0 +1,62 @@
+<?php
+namespace api\v4\Traits;
+
+/**
+ * Define an implementation of `hook_civicrm_checkAccess` in which access-control decisions are
+ * based on a predefined list. For example:
+ *
+ *   $this->setCheckAccessGrants(['Contact::create' => TRUE]);
+ *   Contact::create()->setValues(...)->execute();
+ *
+ * Note: Any class which uses this should implement the `HookInterface` so that the hook is picked up.
+ */
+trait CheckAccessTrait {
+
+  /**
+   * Specify whether to grant access to an entity-action via hook_checkAccess.
+   *
+   * @var array
+   *   Array(string $entityAction => bool $grant).
+   *   TRUE=>Allow. FALSE=>Deny. Undefined=>No preference.
+   */
+  private $checkAccessGrants = [];
+
+  /**
+   * Number of times hook_checkAccess has fired.
+   * @var array
+   */
+  protected $checkAccessCounts = [];
+
+  /**
+   * @param string $entity
+   * @param string $action
+   * @param array $record
+   * @param int|null $contactID
+   * @param bool $granted
+   * @see \CRM_Utils_Hook::checkAccess()
+   */
+  public function hook_civicrm_checkAccess(string $entity, string $action, array $record, ?int $contactID, bool &$granted) {
+    $key = "{$entity}::{$action}";
+    if (isset($this->checkAccessGrants[$key])) {
+      $granted = $this->checkAccessGrants[$key];
+      $this->checkAccessCounts[$key]++;
+    }
+  }
+
+  /**
+   * @param array $list
+   *   Ex: ["Event::delete" => TRUE, "Contribution::delete" => FALSE]
+   */
+  protected function setCheckAccessGrants($list) {
+    $this->checkAccessGrants = $this->checkAccessCounts = [];
+    foreach ($list as $key => $grant) {
+      $this->checkAccessGrants[$key] = $grant;
+      $this->checkAccessCounts[$key] = 0;
+    }
+  }
+
+  protected function resetCheckAccess() {
+    $this->setCheckAccessGrants([]);
+  }
+
+}

--- a/tests/phpunit/api/v4/Traits/CheckAccessTrait.php
+++ b/tests/phpunit/api/v4/Traits/CheckAccessTrait.php
@@ -35,7 +35,7 @@ trait CheckAccessTrait {
    * @param bool $granted
    * @see \CRM_Utils_Hook::checkAccess()
    */
-  public function hook_civicrm_checkAccess(string $entity, string $action, array $record, ?int $contactID, bool &$granted) {
+  public function hook_civicrm_checkAccess(string $entity, string $action, array $record, ?int $contactID, ?bool &$granted) {
     $key = "{$entity}::{$action}";
     if (isset($this->checkAccessGrants[$key])) {
       $granted = $this->checkAccessGrants[$key];


### PR DESCRIPTION
Overview
----------------------------------------
Combines prior PRs. Refactor so that events use more consistent style (ie `civi.api4.{$TASK}` with alias `civi.api4.{$TASK}::{$ENTITY}`). Description TODO.

_A brief description of the pull request. Keep technical jargon to a minimum. Hyperlink relevant discussions._

Before
----------------------------------------
_What is the old user-interface or technical-contract (as appropriate)?_
_For optimal clarity, include a concrete example such as a screenshot, GIF ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)), or code-snippet._

After
----------------------------------------
_What changed? What is new old user-interface or technical-contract?_
_For optimal clarity, include a concrete example such as a screenshot, GIF ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)), or code-snippet._

Technical Details
----------------------------------------
_If the PR involves technical details/changes/considerations which would not be manifest to a casual developer skimming the above sections, please describe the details here._

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
