### PR TITLE
mailing#96: Warn on invalid mailing options

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -398,6 +398,9 @@ class CRM_Mailing_BAO_Mailing extends CRM_Mailing_DAO_Mailing {
    * @return array
    */
   public static function getLocationFilterAndOrderBy($email_selection_method, $location_type_id) {
+    if ($email_selection_method !== 'automatic' && !$location_type_id) {
+      throw new \CRM_Core_Exception('You set an email Selection Method without specifying a Location Type.  Please go back and change your recipient settings (using the wrench icon next to "Recipients".');
+    }
     $email = CRM_Core_DAO_Email::getTableName();
     // Note: When determining the ORDER that results are returned, it's
     // the record that comes last that counts. That's because we are

--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -399,7 +399,7 @@ class CRM_Mailing_BAO_Mailing extends CRM_Mailing_DAO_Mailing {
    */
   public static function getLocationFilterAndOrderBy($email_selection_method, $location_type_id) {
     if ($email_selection_method !== 'automatic' && !$location_type_id) {
-      throw new \CRM_Core_Exception('You set an email Selection Method without specifying a Location Type.  Please go back and change your recipient settings (using the wrench icon next to "Recipients".');
+      throw new \CRM_Core_Exception(ts('You have selected an email Selection Method without specifying a Location Type. Please go back and change your recipient settings (using the wrench icon next to "Recipients").'));
     }
     $email = CRM_Core_DAO_Email::getTableName();
     // Note: When determining the ORDER that results are returned, it's


### PR DESCRIPTION
https://lab.civicrm.org/dev/mail/-/issues/96

Overview
----------------------------------------
Specifying a "Selection Method" in mailing options (in CiviMail) without specifying a location type gives a DB error.

Steps to replicate (demo server is fine):
* Create a new mailing.
* Click the wrench next to "Recipients".
* Set a *Selection Method* other than "Automatic" but do not touch *Location Type*.
* Attempt to submit the mailing (or press the "X Recipients" to recalculate immediately).
![Selection_1115](https://user-images.githubusercontent.com/1796012/121079282-f17e8a80-c7a7-11eb-9db0-75297f9eab66.png)



Before
----------------------------------------
Unhelpful errors: "Mailing content is out of date, please refresh" or "DB Error: Syntax Error".

After
----------------------------------------
Helpful error: You set an email Selection Method without specifying a Location Type.  Please go back and change your recipient settings (using the wrench icon next to "Recipients".