### PR TITLE
SearchKit - Fix link target selection

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin/displays/colType/field.html
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/colType/field.html
@@ -1,9 +1,9 @@
 <div class="form-inline crm-search-admin-flex-row">
-  <label title="{{ ts('Display as clickable link') }}" >
+  <label title="{{:: ts('Display as clickable link') }}" >
     <input type="checkbox" ng-checked="col.link" ng-click="$ctrl.parent.toggleLink(col)" >
     {{:: ts('Link') }}
   </label>
-  <select class="form-control" ng-model="$ctrl.link.target" ng-if="col.link">
+  <select class="form-control" ng-model="col.link.target" ng-if="col.link">
     <option value>{{:: ts('Open normally') }}</option>
     <option value="_blank">{{:: ts('New tab') }}</option>
     <option value="crm-popup">{{:: ts('Popup dialog') }}</option>

--- a/ext/search_kit/ang/crmSearchDisplay.module.js
+++ b/ext/search_kit/ang/crmSearchDisplay.module.js
@@ -7,7 +7,7 @@
     .factory('searchDisplayUtils', function(crmApi4) {
 
       // Replace tokens keyed to rowData.
-      // If rowMeta is provided, values will be formatted; if omiited, raw values will be provided.
+      // If rowMeta is provided, values will be formatted; if omitted, raw values will be provided.
       function replaceTokens(str, rowData, rowMeta) {
         if (!str) {
           return '';
@@ -30,19 +30,11 @@
         return url;
       }
 
-      // Returns html-escaped display value for a single column in a row
+      // Returns display value for a single column in a row
       function formatDisplayValue(rowData, key, rowMeta) {
         var column = _.findWhere(rowMeta, {key: key}),
-          displayValue = column.rewrite ? replaceTokens(column.rewrite, rowData, rowMeta) : formatRawValue(column, rowData[key]),
-          result = _.escape(displayValue);
-        if (column.link) {
-          var target = '';
-          if (column.link.target) {
-            target = column.link.target === 'crm-popup' ? 'class="crm-popup" ' : 'target="' + column.link.target + '" ';
-          }
-          result = '<a ' + target + 'href="' + _.escape(getUrl(column.link.path, rowData)) + '">' + result + '</a>';
-        }
-        return result;
+          displayValue = column.rewrite ? replaceTokens(column.rewrite, rowData, rowMeta) : formatRawValue(column, rowData[key]);
+        return displayValue;
       }
 
       // Formats raw field value according to data type

--- a/ext/search_kit/ang/crmSearchDisplay/colType/buttons.html
+++ b/ext/search_kit/ang/crmSearchDisplay/colType/buttons.html
@@ -1,5 +1,5 @@
 <span ng-repeat="item in col.links">
-  <a class="btn {{:: col.size }} btn-{{:: item.style }} {{:: item.target }}" target="{{:: item.target }}" href="{{:: displayUtils.getUrl(item.path, row) }}">
+  <a class="btn {{:: col.size }} btn-{{:: item.style }}" target="{{:: item.target }}" href="{{:: displayUtils.getUrl(item.path, row) }}">
     <i ng-if=":: item.icon" class="crm-i {{:: item.icon }}"></i>
     {{:: item.text }}
   </a>

--- a/ext/search_kit/ang/crmSearchDisplay/colType/field.html
+++ b/ext/search_kit/ang/crmSearchDisplay/colType/field.html
@@ -1,2 +1,7 @@
 <crm-search-display-editable row="row" col="col" on-success="$ctrl.refresh(row)" cancel="$ctrl.editing = null;" ng-if="col.editable && $ctrl.editing && $ctrl.editing[0] === rowIndex && $ctrl.editing[1] === col.key"></crm-search-display-editable>
-<span ng-bind-html=":: $ctrl.formatFieldValue(row, col)" ng-class="{'crm-editable-enabled': col.editable && !$ctrl.editing && row[col.editable.id]}" ng-click="col.editable && !$ctrl.editing && ($ctrl.editing = [rowIndex, col.key])"></span>
+<span ng-if="::!col.link" ng-class="{'crm-editable-enabled': col.editable && !$ctrl.editing && row[col.editable.id]}" ng-click="col.editable && !$ctrl.editing && ($ctrl.editing = [rowIndex, col.key])">
+  {{:: $ctrl.formatFieldValue(row, col) }}
+</span>
+<a ng-if="::col.link" target="{{:: col.link.target }}" href="{{:: displayUtils.getUrl(col.link.path, row) }}">
+  {{:: $ctrl.formatFieldValue(row, col) }}
+</a>

--- a/ext/search_kit/ang/crmSearchDisplay/colType/links.html
+++ b/ext/search_kit/ang/crmSearchDisplay/colType/links.html
@@ -1,5 +1,5 @@
 <span ng-repeat="item in col.links">
-  <a class="text-{{:: item.style }} {{:: item.target }}" target="{{:: item.target }}" href="{{:: displayUtils.getUrl(item.path, row) }}">
+  <a class="text-{{:: item.style }}" target="{{:: item.target }}" href="{{:: displayUtils.getUrl(item.path, row) }}">
     <i ng-if=":: item.icon" class="crm-i {{:: item.icon }}"></i>
     {{:: item.text }}
   </a>

--- a/ext/search_kit/ang/crmSearchDisplay/colType/menu.html
+++ b/ext/search_kit/ang/crmSearchDisplay/colType/menu.html
@@ -5,7 +5,7 @@
   </button>
   <ul class="dropdown-menu {{ col.alignment === 'text-right' ? 'dropdown-menu-right' : '' }}" ng-if=":: col.open">
     <li ng-repeat="item in col.links" class="bg-{{:: item.style }}">
-      <a href="{{:: displayUtils.getUrl(item.path, row) }}" class="{{:: item.target }}" target="{{:: item.target }}">
+      <a href="{{:: displayUtils.getUrl(item.path, row) }}" target="{{:: item.target }}">
         <i ng-if=":: item.icon" class="crm-i {{:: item.icon }}"></i>
         {{:: item.text }}
       </a>

--- a/js/crm.ajax.js
+++ b/js/crm.ajax.js
@@ -487,7 +487,7 @@
       if (settings.openInline) {
         settings.autoClose = $el.crmSnippet('isOriginalUrl');
         $(this).off('.openInline').on('click.openInline', settings.openInline, function(e) {
-          if ($(this).is(exclude + ', .crm-popup')) {
+          if ($(this).is(exclude + ', .crm-popup, [target=crm-popup]')) {
             return;
           }
           if ($(this).hasClass('open-inline-noreturn')) {
@@ -594,7 +594,7 @@
 
   $(function($) {
     $('body')
-      .on('click', 'a.crm-popup', CRM.popup)
+      .on('click', 'a.crm-popup, a[target=crm-popup]', CRM.popup)
       // Close unsaved dialog messages
       .on('dialogopen', function(e) {
         $('.alert.unsaved-dialog .ui-notify-cross', '#crm-notification-container').click();


### PR DESCRIPTION
Overview
----------------------------------------
This fixes a recent SearchKit regression which broke the selector for choosing how a link would open (Normal/New Tab/Popup). 

Before
----------------------------------------
Making a selection in this dropdown was ignored by the search display. Links would use default behavior regardless.

![image](https://user-images.githubusercontent.com/2874912/121080069-f3951900-c7a8-11eb-9382-66c3e876d6a3.png)

After
----------------------------------------
Fixed.

Technical Details
----------------------------------------
This also gets some templating logic out of the controller and into the template.
Also simplifies markup needed to open a link in a popup. Now both `class="crm-popup"` and `target="crm-popup"` both work. The target attribute works better for search kit and is more semantic anyway.