### PR TITLE
[php8-compat] Fix Resources Test issue due to undefined array key add…

### DIFF
--- a/CRM/Core/Smarty/plugins/function.crmResURL.php
+++ b/CRM/Core/Smarty/plugins/function.crmResURL.php
@@ -39,5 +39,5 @@ function smarty_function_crmResURL($params, &$smarty) {
   if (!array_key_exists('file', $params)) {
     $params['file'] = NULL;
   }
-  return $res->getUrl($params['ext'], $params['file'], $params['addCacheCode']);
+  return $res->getUrl($params['ext'], $params['file'], $params['addCacheCode'] ?? FALSE);
 }


### PR DESCRIPTION
…CacheCode

Overview
----------------------------------------
This fixes the following test failure

```
CRM_Core_ResourcesTest::testCrmResURL
Undefined array key "addCacheCode"

/home/jenkins/bknix-edge/build/build-0/web/sites/all/modules/civicrm/CRM/Core/Smarty/plugins/function.crmResURL.php:42
```

Before
----------------------------------------
Test fails on php8

After
----------------------------------------
Test passes on php8

ping @eileenmcnaughton @totten @demeritcowboy @colemanw 