### PR TITLE
[php8-compat] Upgrade TCPDF version to support php8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,7 @@
     "symfony/var-dumper": "~3.0 || ~4.4 || ~5.1",
     "psr/log": "~1.0",
     "symfony/finder": "~3.0 || ~4.4",
-    "tecnickcom/tcpdf" : "6.3.*",
+    "tecnickcom/tcpdf" : "6.4.*",
     "totten/ca-config": "~17.05",
     "zetacomponents/base": "1.9.*",
     "zetacomponents/mail": "1.9.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "590aac2df1e4ce1d1d144fe806be6630",
+    "content-hash": "730e40c933b40ec711ba59c7b333400e",
     "packages": [
         {
             "name": "adrienrn/php-mimetyper",
@@ -3493,16 +3493,16 @@
         },
         {
             "name": "tecnickcom/tcpdf",
-            "version": "6.3.5",
+            "version": "6.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/tecnickcom/TCPDF.git",
-                "reference": "19a535eaa7fb1c1cac499109deeb1a7a201b4549"
+                "reference": "5ba838befdb37ef06a16d9f716f35eb03cb1b329"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/tecnickcom/TCPDF/zipball/19a535eaa7fb1c1cac499109deeb1a7a201b4549",
-                "reference": "19a535eaa7fb1c1cac499109deeb1a7a201b4549",
+                "url": "https://api.github.com/repos/tecnickcom/TCPDF/zipball/5ba838befdb37ef06a16d9f716f35eb03cb1b329",
+                "reference": "5ba838befdb37ef06a16d9f716f35eb03cb1b329",
                 "shasum": ""
             },
             "require": {
@@ -3551,7 +3551,17 @@
                 "pdf417",
                 "qrcode"
             ],
-            "time": "2020-02-14T14:20:12+00:00"
+            "support": {
+                "issues": "https://github.com/tecnickcom/TCPDF/issues",
+                "source": "https://github.com/tecnickcom/TCPDF/tree/6.4.1"
+            },
+            "funding": [
+                {
+                    "url": "https://www.paypal.com/cgi-bin/webscr?cmd=_donations&currency_code=GBP&business=paypal@tecnick.com&item_name=donation%20for%20tcpdf%20project",
+                    "type": "custom"
+                }
+            ],
+            "time": "2021-03-27T16:00:33+00:00"
         },
         {
             "name": "togos/gitignore",


### PR DESCRIPTION
Overview
----------------------------------------
This upgrades the TCPDF Library to be compatible with php8

Before
----------------------------------------
TCPDF version not compatible with php8

After
----------------------------------------
TCPDF compatible with php8

Change log is here https://github.com/tecnickcom/TCPDF/blob/main/CHANGELOG.TXT#L2 and nothing jumps out at me as major issue 

ping @demeritcowboy @eileenmcnaughton