### PR TITLE
Sort trigger data before processing

### DIFF
--- a/CRM/Logging/Schema.php
+++ b/CRM/Logging/Schema.php
@@ -242,6 +242,9 @@ AND    (TABLE_NAME LIKE 'log_civicrm_%' $nonStandardTableNameString )
       $tableNames = $this->tables;
     }
 
+    // Sort the table names so the sql output is consistent for those sites
+    // loading it asynchronously (using the setting 'logging_no_trigger_permission')
+    asort($tableNames);
     foreach ($tableNames as $table) {
       $validName = CRM_Core_DAO::shortenSQLName($table, 48, TRUE);
 

--- a/Civi/Core/SqlTriggers.php
+++ b/Civi/Core/SqlTriggers.php
@@ -138,6 +138,10 @@ class SqlTriggers {
       }
     }
 
+    // Sort tables alphabetically in order to output in a consistent order
+    // for sites that like to diff this output over time
+    // (ie. with the logging_no_trigger_permission setting in place).
+    asort($triggers);
     // now spit out the sql
     foreach ($triggers as $tableName => $tables) {
       if ($onlyTableName != NULL && $onlyTableName != $tableName) {


### PR DESCRIPTION
Overview
----------------------------------------
Sort trigger data before processing

At some point these stopped being consistently alpha sorted - which doesn't matter
if you are just letting Civi run the trigger updates but if you output it
and diff it this inconsistency is a problem

Subset of https://github.com/civicrm/civicrm-core/pull/20472
in the hope of getting this merged

https://github.com/civicrm/civicrm-core/pull/20471 also grooms this output for diffing
albeit only in an edge case

Before
----------------------------------------


1. Set the setting logging_no_trigger_permission to 0
2. enable logging
3. the output is not alpha sorted
 

After
----------------------------------------
Per the above but alpha sorted 

Technical Details
----------------------------------------
https://github.com/civicrm/civicrm-core/pull/20472 does a more thorough job of cleaning up the legibility of the output

Comments
----------------------------------------
