### PR TITLE
Fix the populateTempTable to be more direct

### DIFF
--- a/tests/phpunit/api/v3/ReportTemplateTest.php
+++ b/tests/phpunit/api/v3/ReportTemplateTest.php
@@ -537,7 +537,8 @@ class api_v3_ReportTemplateTest extends CiviUnitTestCase {
   }
 
   /**
-   * Test the group filter works on the contribution summary (with a smart group).
+   * Test the group filter works on the contribution summary (with a smart
+   * group).
    *
    * @dataProvider getMembershipAndContributionReportTemplatesForGroupTests
    *
@@ -545,6 +546,7 @@ class api_v3_ReportTemplateTest extends CiviUnitTestCase {
    *   Name of the template to test.
    *
    * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
    */
   public function testContributionSummaryWithSmartGroupFilter(string $template): void {
     $groupID = $this->setUpPopulatedSmartGroup();
@@ -568,8 +570,9 @@ class api_v3_ReportTemplateTest extends CiviUnitTestCase {
    * @param string $template
    *
    * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
    */
-  public function testContributionSummaryWithNotINSmartGroupFilter($template) {
+  public function testContributionSummaryWithNotINSmartGroupFilter($template): void {
     $groupID = $this->setUpPopulatedSmartGroup();
     $rows = $this->callAPISuccess('report_template', 'getrows', [
       'report_id' => 'contribute/summary',

--- a/tests/phpunit/api/v4/Entity/SavedSearchTest.php
+++ b/tests/phpunit/api/v4/Entity/SavedSearchTest.php
@@ -28,7 +28,11 @@ use Civi\Api4\Email;
  */
 class SavedSearchTest extends UnitTestCase {
 
-  public function testContactSmartGroup() {
+  /**
+   * @throws \API_Exception
+   * @throws \Civi\API\Exception\NotImplementedException
+   */
+  public function testContactSmartGroup(): void {
     $in = Contact::create(FALSE)->addValue('first_name', 'yes')->addValue('do_not_phone', TRUE)->execute()->first();
     $out = Contact::create(FALSE)->addValue('first_name', 'no')->addValue('do_not_phone', FALSE)->execute()->first();
 


### PR DESCRIPTION
It's currently using a round-about method to populate the table which goes through
apiv3 and the query object before winding up at the load function
which makes the same 3 calls now being called directly

Overview
----------------------------------------
Fix the populateTempTable to be more direct

Before
----------------------------------------
Process is 
1) ```CRM_Contact_BAO_GroupContactCache::check()``` which calls
2) ```    return self::loadAll($groupIDs);```
3) which calls ```   self::add($processGroupIDs);``` for each group
4) which calls CRM_Contact_BAO_Query::apiQuery for each group
5) which calls load() for each group 
6) which loads the group using

```
 $locks = self::getLocksForRefreshableGroupsTo([$groupID]);
    foreach ($locks as $groupID => $lock) {
      $groupContactsTempTable = CRM_Utils_SQL_TempTable::build()
        ->setCategory('gccache')
        ->setMemory();
      self::buildGroupContactTempTable([$groupID], $groupContactsTempTable);
      self::updateCacheFromTempTable($groupContactsTempTable, [$groupID]);
      $lock->release();
```

After
----------------------------------------
skip steps 1 to 5 - just use the 1 temp table & less inserts (I think it's unlikely that would perform worse & expect less inserts would mean less locking but this doesn't affect many code paths at this stage so if it did then we can revisit)

```
   $groupContactsTempTable = CRM_Utils_SQL_TempTable::build()
        ->setCategory('gccache')
        ->setMemory();
      $locks = self::getLocksForRefreshableGroupsTo($smartGroups);
      self::buildGroupContactTempTable(array_keys($locks), $groupContactsTempTable);
      self::updateCacheFromTempTable($groupContactsTempTable, array_keys($locks));
      foreach ($locks as $lock) {
        $lock->release();
      }

```

Technical Details
----------------------------------------
Note the tests api_v3_ReportTemplateTest as well as the apiv4 tests
cover this function

Comments
----------------------------------------
We have discussed a different (more best effort) way of transferring the data from the temp table to the cache table - this PR comments that stuff in but does not attempt to address it & this is really the end point of this round of cleanup for me for now


@colemanw in the process of this I spotted https://github.com/civicrm/civicrm-core/blob/ccb5836dc64bfa47653a5ed6620d8bec101f6d42/CRM/Contact/BAO/GroupContactCache.php#L654-L659 - wouldn't the filter on saved_search_id filter OUT your parent groups again?