### PR TITLE
[php8-compact] Fix Report tests failing on php8

### DIFF
--- a/templates/CRM/Report/Form.tpl
+++ b/templates/CRM/Report/Form.tpl
@@ -16,7 +16,7 @@
 {elseif $section eq 2}
   <div class="crm-block crm-content-block crm-report-layoutTable-form-block">
     {*include the table layout*}
-    {if !$chartEnabled || !$chartSupported}
+    {if empty($chartEnabled) || empty($chartSupported)}
       {include file="CRM/Report/Form/Layout/Table.tpl"}
     {/if}
   </div>
@@ -39,7 +39,7 @@
 
     {*include the table layout*}
 
-    {if !$chartEnabled || !$chartSupported}
+    {if empty($chartEnabled) || empty($chartSupported)}
       {include file="CRM/Report/Form/Layout/Table.tpl"}
     {/if}
     <br />

--- a/templates/CRM/Report/Form/Layout/Graph.tpl
+++ b/templates/CRM/Report/Form/Layout/Graph.tpl
@@ -9,7 +9,7 @@
 *}
 {assign var=uploadURL value=$config->imageUploadURL|replace:'/persist/contribute/':'/persist/'}
 {* Display weekly,Quarterly,monthly and yearly contributions using pChart (Bar and Pie) *}
-{if $chartEnabled and $chartSupported}
+{if !empty($chartEnabled) and !empty($chartSupported)}
   <div class='crm-chart'>
     {if $outputMode eq 'print' OR $outputMode eq 'pdf'}
       <img src="{$uploadURL|cat:$chartId}.png" />
@@ -19,11 +19,11 @@
   </div>
 {/if}
 
-{if !$printOnly} {* NO print section starts *}
-  {if !$section}
+{if empty($printOnly)} {* NO print section starts *}
+  {if !empty($section)}
     {include file="CRM/common/chart.tpl" divId="chart_$uniqueId"}
   {/if}
-  {if $chartData}
+  {if !empty($chartData)}
     {literal}
     <script type="text/javascript">
        CRM.$(function($) {

--- a/templates/CRM/Report/Form/Layout/Table.tpl
+++ b/templates/CRM/Report/Form/Layout/Table.tpl
@@ -10,7 +10,7 @@
 {if !$rows}
   <p>{ts}None found.{/ts}</p>
 {else}
-    {if $pager and $pager->_response and $pager->_response.numPages > 1}
+    {if !empty($pager) and $pager->_response and $pager->_response.numPages > 1}
         <div class="report-pager">
             {include file="CRM/common/pager.tpl" location="top"}
         </div>
@@ -24,8 +24,8 @@
                 {else}
                     {assign var=class value="class='reports-header'"}
                 {/if}
-                {if !$skip}
-                   {if $header.colspan}
+                {if empty($skip)}
+                   {if !empty($header.colspan)}
                        <th colspan={$header.colspan}>{$header.title|escape}</th>
                       {assign var=skip value=true}
                       {assign var=skipCount value=`$header.colspan`}
@@ -41,7 +41,7 @@
             {/foreach}
         {/capture}
 
-        {if !$sections} {* section headers and sticky headers aren't playing nice yet *}
+        {if empty($sections)} {* section headers and sticky headers aren't playing nice yet *}
             <thead class="sticky">
             <tr>
                 {$tableHeader}
@@ -92,14 +92,14 @@
 
         {foreach from=$rows item=row key=rowid}
            {eval var=$sectionHeaderTemplate}
-            <tr  class="{cycle values="odd-row,even-row"} {$row.class} crm-report" id="crm-report_{$rowid}">
+            <tr  class="{cycle values="odd-row,even-row"} {if !empty($row.class)}{$row.class}{/if} crm-report" id="crm-report_{$rowid}">
                 {foreach from=$columnHeaders item=header key=field}
                     {assign var=fieldLink value=$field|cat:"_link"}
                     {assign var=fieldHover value=$field|cat:"_hover"}
                     {assign var=fieldClass value=$field|cat:"_class"}
                     <td class="crm-report-{$field}{if $header.type eq 1024 OR $header.type eq 1 OR $header.type eq 512} report-contents-right{elseif $row.$field eq 'Subtotal'} report-label{/if}">
                         {if $row.$fieldLink}
-                            <a title="{$row.$fieldHover|escape}" href="{$row.$fieldLink}"  {if $row.$fieldClass} class="{$row.$fieldClass}"{/if}>
+                            <a title="{$row.$fieldHover|escape}" href="{$row.$fieldLink}"  {if !empty($row.$fieldClass)} class="{$row.$fieldClass}"{/if}>
                         {/if}
 
                         {if is_array($row.$field)}
@@ -136,7 +136,7 @@
             </tr>
         {/foreach}
 
-        {if $grandStat}
+        {if !empty($grandStat)}
             {* foreach from=$grandStat item=row*}
             <tr class="total-row">
                 {foreach from=$columnHeaders item=header key=field}
@@ -156,7 +156,7 @@
             {* /foreach*}
         {/if}
     </table>
-    {if $pager and $pager->_response and $pager->_response.numPages > 1}
+    {if !empty($pager) and $pager->_response and $pager->_response.numPages > 1}
         <div class="report-pager">
             {include file="CRM/common/pager.tpl" }
         </div>

--- a/templates/CRM/Report/Form/Statistics.tpl
+++ b/templates/CRM/Report/Form/Statistics.tpl
@@ -7,45 +7,51 @@
  | and copyright information, see https://civicrm.org/licensing       |
  +--------------------------------------------------------------------+
 *}
-{if $top}
+{if !empty($top)}
   {if $printOnly}
     <h1>{$reportTitle}</h1>
     <div id="report-date">{$reportDate}</div>
   {/if}
   {if $statistics}
     <table class="report-layout statistics-table">
-      {foreach from=$statistics.groups item=row}
-        <tr>
-          <th class="statistics" scope="row">{$row.title}</th>
-          <td>{$row.value|escape}</td>
-        </tr>
-      {/foreach}
-      {foreach from=$statistics.filters item=row}
-        <tr>
-          <th class="statistics" scope="row">{$row.title}</th>
-          <td>{$row.value|escape}</td>
-        </tr>
-      {/foreach}
+      {if !empty($statistics.groups)} 
+        {foreach from=$statistics.groups item=row}
+          <tr>
+            <th class="statistics" scope="row">{$row.title}</th>
+            <td>{$row.value|escape}</td>
+          </tr>
+        {/foreach}
+      {/if}
+      {if !empty($statistics.filters)}
+        {foreach from=$statistics.filters item=row}
+          <tr>
+            <th class="statistics" scope="row">{$row.title}</th>
+            <td>{$row.value|escape}</td>
+          </tr>
+        {/foreach}
+      {/if}
     </table>
   {/if}
 {/if}
 
-{if $bottom and $rows and $statistics}
+{if !empty($bottom) and !empty($rows) and !empty($statistics)}
   <table class="report-layout">
-    {foreach from=$statistics.counts item=row}
-      <tr>
-        <th class="statistics" scope="row">{$row.title}</th>
-        <td>
-          {if $row.type eq 1024}
-            {$row.value|crmMoney|escape}
-          {elseif $row.type eq 2}
-            {$row.value|escape}
-          {else}
-            {$row.value|crmNumberFormat|escape}
-          {/if}
+    {if !empty($statistics.counts)}
+      {foreach from=$statistics.counts item=row}
+        <tr>
+          <th class="statistics" scope="row">{$row.title}</th>
+          <td>
+            {if !empty($row.type) and $row.type eq 1024}
+              {$row.value|crmMoney|escape}
+            {elseif !empty($row.type) and $row.type eq 2}
+              {$row.value|escape}
+            {else}
+               {$row.value|crmNumberFormat|escape}
+            {/if}
 
-        </td>
-      </tr>
-    {/foreach}
+          </td>
+        </tr>
+      {/foreach}
+    {/if}
   </table>
 {/if}


### PR DESCRIPTION
Overview
----------------------------------------
This fixes the following test failures on php8

-CRM_Report_Utils_ReportTest::testOutputPrint
Undefined array key "groups"

/home/jenkins/bknix-edge/build/build-0/web/sites/default/files/civicrm/templates_c/en_US/%%1B/1BD/1BD7DE8F%%Statistics.tpl.php:14
-CRM_Report_Utils_ReportTest::testOutputPdf
Undefined array key "groups"

/home/jenkins/bknix-edge/build/build-0/web/sites/default/files/civicrm/templates_c/en_US/%%1B/1BD/1BD7DE8F%%Statistics.tpl.php:14

Before
----------------------------------------
Those report tests fail on php8

After
----------------------------------------
Those report tests pass on php8

ping @eileenmcnaughton @demeritcowboy @totten @colemanw 