### PR TITLE
dev/core#2486 - Use read-only permissions for LineItem, EntityFinancialTrxn and FinancialTrxn APIv4

### DIFF
--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -1167,6 +1167,8 @@ class CRM_Core_Permission {
     ];
     $permissions['contribution_recur'] = $permissions['payment'];
 
+    $permissions['entity_financial_trxn'] = $permissions['payment'];
+
     // Custom field permissions
     $permissions['custom_field'] = [
       'default' => [

--- a/Civi/Api4/EntityFinancialTrxn.php
+++ b/Civi/Api4/EntityFinancialTrxn.php
@@ -41,4 +41,18 @@ class EntityFinancialTrxn extends Generic\DAOEntity {
     return $info;
   }
 
+  /**
+   * @see \Civi\Api4\Generic\AbstractEntity::permissions()
+   * @return array
+   */
+  public static function permissions() {
+    $permissions = \CRM_Core_Permission::getEntityActionPermissions()['entity_financial_trxn'] ?? [];
+
+    // Merge permissions for this entity with the defaults
+    return array_merge($permissions, [
+      'create' => [\CRM_Core_Permission::ALWAYS_DENY_PERMISSION],
+      'update' => [\CRM_Core_Permission::ALWAYS_DENY_PERMISSION],
+    ]);
+  }
+
 }

--- a/Civi/Api4/FinancialTrxn.php
+++ b/Civi/Api4/FinancialTrxn.php
@@ -33,4 +33,18 @@ namespace Civi\Api4;
  */
 class FinancialTrxn extends Generic\DAOEntity {
 
+  /**
+   * @see \Civi\Api4\Generic\AbstractEntity::permissions()
+   * @return array
+   */
+  public static function permissions() {
+    $permissions = \CRM_Core_Permission::getEntityActionPermissions()['payment'] ?? [];
+
+    // Merge permissions for this entity with the defaults
+    return array_merge($permissions, [
+      'create' => [\CRM_Core_Permission::ALWAYS_DENY_PERMISSION],
+      'update' => [\CRM_Core_Permission::ALWAYS_DENY_PERMISSION],
+    ]);
+  }
+
 }

--- a/Civi/Api4/LineItem.php
+++ b/Civi/Api4/LineItem.php
@@ -26,4 +26,18 @@ namespace Civi\Api4;
  */
 class LineItem extends Generic\DAOEntity {
 
+  /**
+   * @see \Civi\Api4\Generic\AbstractEntity::permissions()
+   * @return array
+   */
+  public static function permissions() {
+    $permissions = \CRM_Core_Permission::getEntityActionPermissions()['line_item'] ?? [];
+
+    // Merge permissions for this entity with the defaults
+    return array_merge($permissions, [
+      'create' => [\CRM_Core_Permission::ALWAYS_DENY_PERMISSION],
+      'update' => [\CRM_Core_Permission::ALWAYS_DENY_PERMISSION],
+    ]);
+  }
+
 }

--- a/ext/financialacls/tests/phpunit/Civi/Financialacls/LineItemTest.php
+++ b/ext/financialacls/tests/phpunit/Civi/Financialacls/LineItemTest.php
@@ -61,7 +61,7 @@ class LineItemTest extends BaseTestClass {
     $this->assertCount(2, $lineItems);
     $this->callAPISuccessGetCount('LineItem', ['check_permissions' => TRUE], 1);
 
-    $this->callAPISuccess('LineItem', 'Delete', ['check_permissions' => TRUE, 'id' => $lineItems[0]['id']]);
+    $this->callAPISuccess('LineItem', 'Delete', ['check_permissions' => ($version == 3), 'id' => $lineItems[0]['id']]);
     $this->callAPIFailure('LineItem', 'Delete', ['check_permissions' => TRUE, 'id' => $lineItems[1]['id']]);
     $lineParams = [
       'entity_id' => $order['id'],
@@ -71,14 +71,15 @@ class LineItemTest extends BaseTestClass {
       'price_field_id' => $defaultPriceFieldID,
       'qty' => 1,
       'financial_type_id' => 'Donation',
-      'check_permissions' => FALSE,
+      'check_permissions' => ($version == 3),
     ];
     $line = $this->callAPISuccess('LineItem', 'Create', $lineParams);
     $lineParams['financial_type_id'] = 'Event Fee';
+    $lineParams['check_permissions'] = TRUE;
     $this->callAPIFailure('LineItem', 'Create', $lineParams);
 
     $this->callAPIFailure('LineItem', 'Create', ['id' => $line['id'], 'check_permissions' => TRUE, 'financial_type_id' => 'Event Fee']);
-    $this->callAPISuccess('LineItem', 'Create', ['id' => $line['id'], 'check_permissions' => TRUE, 'financial_type_id' => 'Donation']);
+    $this->callAPISuccess('LineItem', 'Create', ['id' => $line['id'], 'check_permissions' => ($version == 3), 'financial_type_id' => 'Donation']);
   }
 
   /**

--- a/ext/financialacls/tests/phpunit/Civi/Financialacls/LineItemTest.php
+++ b/ext/financialacls/tests/phpunit/Civi/Financialacls/LineItemTest.php
@@ -71,7 +71,7 @@ class LineItemTest extends BaseTestClass {
       'price_field_id' => $defaultPriceFieldID,
       'qty' => 1,
       'financial_type_id' => 'Donation',
-      'check_permissions' => TRUE,
+      'check_permissions' => FALSE,
     ];
     $line = $this->callAPISuccess('LineItem', 'Create', $lineParams);
     $lineParams['financial_type_id'] = 'Event Fee';


### PR DESCRIPTION
Overview
----------------------------------------
Added read-only permissions for LineItem, EntityFinancialTrxn and FinancialTrxn API

Before
----------------------------------------
CRUD actions are available for financial entities in APIv4

After
----------------------------------------
Added read-only permissions for LineItem, EntityFinancialTrxn and FinancialTrxn APIv4

Technical Details
----------------------------------------
The changes only affect APIv4 not APIv3 in order to ensure no breakage in internal code/extensions

Comments
----------------------------------------
This is a followup to https://github.com/civicrm/civicrm-core/pull/20499 

ping @colemanw @eileenmcnaughton @JoeMurray @totten 