### PR TITLE
(REF) dev/core#1744 - Simplify Afform event naming

### DIFF
--- a/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
@@ -10,6 +10,9 @@ use Civi\Afform\Event\AfformSubmitEvent;
  */
 class Submit extends AbstractProcessor {
 
+  /**
+   * @deprecated - You may simply use the event name directly. dev/core#1744
+   */
   const EVENT_NAME = 'civi.afform.submit';
 
   /**
@@ -53,7 +56,7 @@ class Submit extends AbstractProcessor {
       $records = $this->replaceReferences($entityName, $entityValues[$entityName]);
       $this->fillIdFields($records, $entityName);
       $event = new AfformSubmitEvent($this->_afform, $this->_formDataModel, $this, $records, $entityType, $entityName, $this->_entityIds);
-      \Civi::dispatcher()->dispatch(self::EVENT_NAME, $event);
+      \Civi::dispatcher()->dispatch('civi.afform.submit', $event);
     }
 
     // What should I return?

--- a/ext/afform/core/afform.php
+++ b/ext/afform/core/afform.php
@@ -2,7 +2,6 @@
 
 require_once 'afform.civix.php';
 use CRM_Afform_ExtensionUtil as E;
-use Civi\Api4\Action\Afform\Submit;
 
 /**
  * Filter the content of $params to only have supported afform fields.
@@ -50,8 +49,8 @@ function afform_civicrm_config(&$config) {
   Civi::$statics[__FUNCTION__] = 1;
 
   $dispatcher = Civi::dispatcher();
-  $dispatcher->addListener(Submit::EVENT_NAME, [Submit::class, 'processGenericEntity'], 0);
-  $dispatcher->addListener(Submit::EVENT_NAME, [Submit::class, 'preprocessContact'], 10);
+  $dispatcher->addListener('civi.afform.submit', ['\Civi\Api4\Action\Afform\Submit', 'processGenericEntity'], 0);
+  $dispatcher->addListener('civi.afform.submit', ['\Civi\Api4\Action\Afform\Submit', 'preprocessContact'], 10);
   $dispatcher->addListener('hook_civicrm_angularModules', ['\Civi\Afform\AngularDependencyMapper', 'autoReq'], -1000);
   $dispatcher->addListener('hook_civicrm_alterAngular', ['\Civi\Afform\AfformMetadataInjector', 'preprocess']);
   $dispatcher->addListener('hook_civicrm_check', ['\Civi\Afform\StatusChecks', 'hook_civicrm_check']);


### PR DESCRIPTION
Overview
----------------------------------------
This PR replaces the last usage of constants for event names in CiviCRM code base with string literal. 

Before
----------------------------------------
The `ext/afform/core/afform.php` file uses constants for event names.
```diff
-  Civi::dispatcher()->addListener(Submit::EVENT_NAME, [Submit::class, 'processContacts'], 500);                                                                         
-  Civi::dispatcher()->addListener(Submit::EVENT_NAME, [Submit::class, 'processGenericEntity'], -1000);                                                                  
```

After
----------------------------------------
The `ext/afform/core/afform.php` file uses string literal for event names.
```diff
+  Civi::dispatcher()->addListener('civi.afform.submit', ['\Civi\Api4\Action\Afform\Submit', 'processContacts'], 500);                                                   
+  Civi::dispatcher()->addListener('civi.afform.submit', ['\Civi\Api4\Action\Afform\Submit', 'processGenericEntity'], -1000);  
```

Technical Details
----------------------------------------
Since CiviCRM 5.26, the convention was to use string literal for event names and the usage of constants was deprecated according to this issue [dev/core#1744](https://lab.civicrm.org/dev/core/-/issues/1744). This was the last usage of constants for event names in CiviCRM code base.

Comment 
---------------
Also, it addresses the failing deployments for two of our sites with `afform` extension enabled after deploying them on another server e.g. creating dev/staging sites.

I've seen the following error on two sites that had `afform` extension enabled recently:
```php
$ drush cc all
Error: Class "Civi\Api4\Action\Afform\Submit" not found in afform_civicrm_config() (line 52 of civicrm/ext/afform/core/afform.php).
Drush command terminated abnormally due to an unrecoverable error
```
