### PR TITLE
APIv4 - Make the @searchable flag explicit for OptionList type entities.

### DIFF
--- a/Civi/Api4/CaseType.php
+++ b/Civi/Api4/CaseType.php
@@ -25,6 +25,7 @@ namespace Civi\Api4;
  * This contains configuration settings for each type of CiviCase.
  *
  * @see \Civi\Api4\Case
+ * @searchable none
  * @package Civi\Api4
  */
 class CaseType extends Generic\DAOEntity {

--- a/Civi/Api4/ContactType.php
+++ b/Civi/Api4/ContactType.php
@@ -30,6 +30,7 @@ namespace Civi\Api4;
  *
  * @see https://docs.civicrm.org/user/en/latest/organising-your-data/contacts/#contact-subtypes
  * @see \Civi\Api4\Contact
+ * @searchable none
  * @package Civi\Api4
  */
 class ContactType extends Generic\DAOEntity {

--- a/Civi/Api4/Country.php
+++ b/Civi/Api4/Country.php
@@ -21,6 +21,7 @@ namespace Civi\Api4;
 /**
  * Country entity.
  *
+ * @searchable secondary
  * @package Civi\Api4
  */
 class Country extends Generic\DAOEntity {

--- a/Civi/Api4/FinancialType.php
+++ b/Civi/Api4/FinancialType.php
@@ -25,6 +25,7 @@ namespace Civi\Api4;
  *
  * @see https://docs.civicrm.org/user/en/latest/contributions/key-concepts-and-configurations/#financial-types-financial-accounts-and-accounting-codes
  *
+ * @searchable secondary
  * @package Civi\Api4
  */
 class FinancialType extends Generic\DAOEntity {

--- a/Civi/Api4/Generic/AbstractEntity.php
+++ b/Civi/Api4/Generic/AbstractEntity.php
@@ -152,7 +152,9 @@ abstract class AbstractEntity {
     foreach (ReflectionUtils::getTraits(static::class) as $trait) {
       $info['type'][] = self::stripNamespace($trait);
     }
-    $info['searchable'] = in_array('OptionList', $info['type'], TRUE) ? 'none' : 'secondary';
+    // Entities without a @searchable annotation will default to secondary,
+    // which makes them visible in SearchKit but not at the top of the list.
+    $info['searchable'] = 'secondary';
     $reflection = new \ReflectionClass(static::class);
     $info = array_merge($info, ReflectionUtils::getCodeDocs($reflection, NULL, ['entity' => $info['name']]));
     unset($info['package'], $info['method']);

--- a/Civi/Api4/Generic/Traits/OptionList.php
+++ b/Civi/Api4/Generic/Traits/OptionList.php
@@ -16,8 +16,7 @@ namespace Civi\Api4\Generic\Traits;
  *
  * The options appear in the field metadata for other entities that reference this one via pseudoconstant.
  *
- * Note: At time of writing, this trait does nothing except toggle the searchable flag, (and adds "OptionList" to the "type" in Entity::get() metadata).
- * @searchable none (FYI annotation isn't functional because this is a trait - workaround in AbstractEntity::getInfo)
+ * Note: At time of writing, this trait does nothing except add "OptionList" to the "type" in Entity::get() metadata.
  */
 trait OptionList {
 

--- a/Civi/Api4/LocationType.php
+++ b/Civi/Api4/LocationType.php
@@ -15,6 +15,7 @@ namespace Civi\Api4;
 /**
  * LocationType entity.
  *
+ * @searchable none
  * @package Civi\Api4
  */
 class LocationType extends Generic\DAOEntity {

--- a/Civi/Api4/MembershipType.php
+++ b/Civi/Api4/MembershipType.php
@@ -15,6 +15,7 @@ namespace Civi\Api4;
 /**
  * MembershipType entity.
  *
+ * @searchable secondary
  * @package Civi\Api4
  */
 class MembershipType extends Generic\DAOEntity {

--- a/Civi/Api4/OptionGroup.php
+++ b/Civi/Api4/OptionGroup.php
@@ -23,6 +23,7 @@ namespace Civi\Api4;
  * OptionGroup entity.
  *
  * @see \Civi\Api4\OptionValue
+ * @searchable none
  * @package Civi\Api4
  */
 class OptionGroup extends Generic\DAOEntity {

--- a/Civi/Api4/OptionValue.php
+++ b/Civi/Api4/OptionValue.php
@@ -23,6 +23,7 @@ namespace Civi\Api4;
  * OptionValue entity.
  *
  * @see \Civi\Api4\OptionGroup
+ * @searchable none
  * @package Civi\Api4
  */
 class OptionValue extends Generic\DAOEntity {

--- a/Civi/Api4/PaymentProcessor.php
+++ b/Civi/Api4/PaymentProcessor.php
@@ -22,6 +22,7 @@ namespace Civi\Api4;
  *
  * @see https://docs.civicrm.org/sysadmin/en/latest/setup/payment-processors/
  *
+ * @searchable none
  * @package Civi\Api4
  */
 class PaymentProcessor extends Generic\DAOEntity {

--- a/Civi/Api4/PaymentProcessorType.php
+++ b/Civi/Api4/PaymentProcessorType.php
@@ -22,6 +22,7 @@ namespace Civi\Api4;
  *
  * @see \Civi\Api4\PaymentProcessor
  *
+ * @searchable none
  * @package Civi\Api4
  */
 class PaymentProcessorType extends Generic\DAOEntity {

--- a/Civi/Api4/PaymentToken.php
+++ b/Civi/Api4/PaymentToken.php
@@ -22,6 +22,7 @@ namespace Civi\Api4;
  *
  * @see https://docs.civicrm.org/user/en/latest/contributions/payment-processors/#managing-recurring-contributions
  *
+ * @searchable secondary
  * @package Civi\Api4
  */
 class PaymentToken extends Generic\DAOEntity {

--- a/Civi/Api4/RelationshipType.php
+++ b/Civi/Api4/RelationshipType.php
@@ -24,6 +24,7 @@ namespace Civi\Api4;
  *
  * @see \Civi\Api4\Relationship
  *
+ * @searchable secondary
  * @package Civi\Api4
  */
 class RelationshipType extends Generic\DAOEntity {

--- a/Civi/Api4/StateProvince.php
+++ b/Civi/Api4/StateProvince.php
@@ -21,6 +21,7 @@ namespace Civi\Api4;
 /**
  * StateProvince entity.
  *
+ * @searchable secondary
  * @package Civi\Api4
  */
 class StateProvince extends Generic\DAOEntity {


### PR DESCRIPTION
Overview
----------------------------------------
Improves code for categorizing entities for SearchKit, making searchability easier to grok and less magical/mysterious.

Comments
----------------------------------------
When I was first trying to figure out how to categorize entities in SearchKit I came up with this "OptionList" type, which seemed like a good idea at the time. But then I later developed the `@searchable` flag which works much better.
The OptionList trait may or may not be useful in future, maybe we'll just get rid of it if not.
But I think it's better not to couple it with the `@searchable` flag, as that's not exactly the same thing.