### PR TITLE
dev/core#2587 Ignore modified_date when checking for changes during mailing auto-save

### DIFF
--- a/ang/crmMailing/EditMailingCtrl.js
+++ b/ang/crmMailing/EditMailingCtrl.js
@@ -121,7 +121,12 @@
         return true;
       },
       model: function() {
-        return [$scope.mailing, $scope.attachments.getAutosaveSignature()];
+        //modified date is unset so that it gets ignored in comparison
+        //its value is overwritten with the save response from the server and may differ from the local value,
+        //which would result in an unnecessary auto-save
+        var mailing = angular.copy($scope.mailing);
+        mailing.modified_date = undefined;
+        return [mailing, $scope.attachments.getAutosaveSignature()];
       },
       form: function() {
         return $scope.crmMailing;

--- a/ang/crmMailingAB/services.js
+++ b/ang/crmMailingAB/services.js
@@ -51,9 +51,16 @@
 
     angular.extend(CrmMailingAB.prototype, {
       getAutosaveSignature: function() {
+        //modified date is unset so that it gets ignored in comparison
+        //its value is overwritten with the save response from the server and may differ from the local value,
+        //which would result in an unnecessary auto-save
+        var mailings = angular.copy(this.mailings);
+        _.each(mailings, function(mailing) {
+          mailing.modified_date = undefined;
+        });
         return [
           this.ab,
-          this.mailings,
+          mailings,
           this.attachments.a.getAutosaveSignature(),
           this.attachments.b.getAutosaveSignature(),
           this.attachments.c.getAutosaveSignature()


### PR DESCRIPTION
Overview
----------------------------------------
Prevents double auto-save at each modification of a mailing in the mailing editor.
https://lab.civicrm.org/dev/core/-/issues/2587

Before
----------------------------------------
Whenever a mailing or A/B mailing is modified in the editor, the auto-save is triggered twice: once because the mailing was modified, once because after the first save the modified date of the local object does not match the one of the server response (because the server overwrote its value).

After
----------------------------------------
The modified date is ignored in the comparison for the auto-save, so that the second unnecessary save does not happen.

Technical Details
----------------------------------------
The suggestion of the issue on how to implement the fix does not work because the model is not a single object, but a list of objects (mailing(s), optional ab mailing, attachments). The autoSave controller is generic and is agnostic of the structure of the model, so finding and ignoring the modified date could not happen there. This is why instead I chose to edit the model before giving it to the autoSave controller. As far as I can see this affects only the autoSave.

Comments
----------------------------------------
When testing the fix, you may notice that the autoSave still happens twice, **but only for the first time it is triggered**. I found out this is another unrelated bug, due to the schedule date being set to empty string or null depending on whether it comes from initialisation or server response. I didn't chase this bug further.
