### PR TITLE
REF - Cleanup array key checking to use array_key_exists

### DIFF
--- a/CRM/Admin/Form/ContactType.php
+++ b/CRM/Admin/Form/ContactType.php
@@ -89,7 +89,7 @@ class CRM_Admin_Form_ContactType extends CRM_Admin_Form {
 
     $reservedKeyWords = CRM_Core_SelectValues::customGroupExtends();
     //restrict "name" from being a reserved keyword when a new contact subtype is created
-    if (!$self->_id && in_array($contactName, array_keys($reservedKeyWords))) {
+    if (!$self->_id && array_key_exists($contactName, $reservedKeyWords)) {
       $errors['label'] = ts('Contact type names should not use reserved keywords.');
     }
     return empty($errors) ? TRUE : $errors;

--- a/CRM/Admin/Page/MessageTemplates.php
+++ b/CRM/Admin/Page/MessageTemplates.php
@@ -136,7 +136,7 @@ class CRM_Admin_Page_MessageTemplates extends CRM_Core_Page_Basic {
   public function action(&$object, $action, &$values, &$links, $permission, $forceAction = FALSE) {
     if ($object->workflow_id) {
       // do not expose action link for reverting to default if the template did not diverge or we just reverted it now
-      if (!in_array($object->id, array_keys($this->_revertible)) or
+      if (!array_key_exists($object->id, $this->_revertible) or
         ($this->_action & CRM_Core_Action::REVERT and $object->id == $this->_revertedId)
       ) {
         $action &= ~CRM_Core_Action::REVERT;

--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -1076,7 +1076,7 @@ class CRM_Contact_BAO_Query {
           $elementCmpName = 'phone';
         }
 
-        if (in_array($elementCmpName, array_keys($addressCustomFields))) {
+        if (array_key_exists($elementCmpName, $addressCustomFields)) {
           if ($cfID = CRM_Core_BAO_CustomField::getKeyID($elementCmpName)) {
             $addressCustomFieldIds[$cfID][$name] = 1;
           }
@@ -6330,7 +6330,7 @@ AND   displayRelType.is_active = 1
       $value = $formValues[$element] ?? NULL;
       if ($value) {
         if (is_array($value)) {
-          if (in_array($element, array_keys($changeNames))) {
+          if (array_key_exists($element, $changeNames)) {
             unset($formValues[$element]);
             $element = $changeNames[$element];
           }

--- a/CRM/Contact/Form/Search/Advanced.php
+++ b/CRM/Contact/Form/Search/Advanced.php
@@ -84,7 +84,7 @@ class CRM_Contact_Form_Search_Advanced extends CRM_Contact_Form_Search {
 
     $componentPanes = [];
     foreach ($components as $name => $component) {
-      if (in_array($name, array_keys($this->_searchOptions)) &&
+      if (array_key_exists($name, $this->_searchOptions) &&
         $this->_searchOptions[$name] &&
         CRM_Core_Permission::access($component->name)
       ) {

--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -1892,7 +1892,7 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Contact_Import_Parser {
       return array_keys($possibleMatches['values']);
     }
     if ($possibleMatches['count']) {
-      if (in_array($extIDMatch, array_keys($possibleMatches['values']))) {
+      if (array_key_exists($extIDMatch, $possibleMatches['values'])) {
         return [$extIDMatch];
       }
       throw new CRM_Core_Exception(ts(

--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4429,7 +4429,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
       'Chargeback' => 'Chargeback Account is',
     ];
 
-    if (in_array($contributionStatus, array_keys($preferredAccountsRelationships))) {
+    if (array_key_exists($contributionStatus, $preferredAccountsRelationships)) {
       $financialTypeID = !empty($params['financial_type_id']) ? $params['financial_type_id'] : $params['prevContribution']->financial_type_id;
       return CRM_Financial_BAO_FinancialAccount::getFinancialAccountForFinancialTypeByRelationship(
         $financialTypeID,

--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -336,7 +336,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
     }
     if ($customDataType && !is_array($customDataType)) {
 
-      if (in_array($customDataType, CRM_Contact_BAO_ContactType::subTypes())) {
+      if (in_array($customDataType, CRM_Contact_BAO_ContactType::subTypes(), TRUE)) {
         // This is the case when getFieldsForImport() requires fields
         // limited strictly to a subtype.
         $customDataSubType = $customDataType;
@@ -344,7 +344,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
         $onlySubType = TRUE;
       }
 
-      if (in_array($customDataType, array_keys(CRM_Core_SelectValues::customGroupExtends()))) {
+      if (array_key_exists($customDataType, CRM_Core_SelectValues::customGroupExtends())) {
         // this makes the method flexible to support retrieving fields
         // for multiple extends value.
         $customDataType = [$customDataType];
@@ -404,7 +404,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
         if (is_array($customDataType)) {
           $value = NULL;
           foreach ($customDataType as $dataType) {
-            if (in_array($dataType, array_keys(CRM_Core_SelectValues::customGroupExtends()))) {
+            if (array_key_exists($dataType, CRM_Core_SelectValues::customGroupExtends())) {
               if (in_array($dataType, ['Individual', 'Household', 'Organization'])) {
                 $val = "'" . CRM_Utils_Type::escape($dataType, 'String') . "', 'Contact' ";
               }

--- a/CRM/Core/BAO/UFGroup.php
+++ b/CRM/Core/BAO/UFGroup.php
@@ -443,7 +443,7 @@ class CRM_Core_BAO_UFGroup extends CRM_Core_DAO_UFGroup {
 
     $addressCustom = FALSE;
     if (in_array($permissionType, [CRM_Core_Permission::CREATE, CRM_Core_Permission::EDIT]) &&
-      in_array($field->field_name, array_keys($addressCustomFields))
+      array_key_exists($field->field_name, $addressCustomFields)
     ) {
       $addressCustom = TRUE;
       $name = "address_{$name}";

--- a/CRM/Core/I18n/Schema.php
+++ b/CRM/Core/I18n/Schema.php
@@ -461,14 +461,14 @@ class CRM_Core_I18n_Schema {
     $dao->query("DESCRIBE {$table}", FALSE);
     while ($dao->fetch()) {
       // view non-internationalized columns directly
-      if (!in_array($dao->Field, array_keys($columns[$table])) and
+      if (!array_key_exists($dao->Field, $columns[$table]) &&
         !preg_match('/_[a-z][a-z]_[A-Z][A-Z]$/', $dao->Field)
       ) {
         $cols[] = '`' . $dao->Field . '`';
       }
       $tableCols[] = $dao->Field;
     }
-    // view intrernationalized columns through an alias
+    // view internationalized columns through an alias
     foreach ($columns[$table] as $column => $_) {
       if (!$isUpgradeMode) {
         $cols[] = "`{$column}_{$locale}` `{$column}`";

--- a/CRM/Event/Import/Parser/Participant.php
+++ b/CRM/Event/Import/Parser/Participant.php
@@ -201,7 +201,7 @@ class CRM_Event_Import_Parser_Participant extends CRM_Event_Import_Parser {
         $val = explode(',', $val);
         if ($key == 'participant_role_id') {
           foreach ($val as $role) {
-            if (!in_array(trim($role), array_keys($roleIDs))) {
+            if (!array_key_exists(trim($role), $roleIDs)) {
               CRM_Contact_Import_Parser_Contact::addToErrorMsg('Participant Role Id', $errorMessage);
               break;
             }
@@ -219,7 +219,7 @@ class CRM_Event_Import_Parser_Participant extends CRM_Event_Import_Parser {
       elseif ($val && (($key == 'participant_status_id') || ($key == 'participant_status'))) {
         $statusIDs = CRM_Event_PseudoConstant::participantStatus();
         if ($key == 'participant_status_id') {
-          if (!in_array(trim($val), array_keys($statusIDs))) {
+          if (!array_key_exists(trim($val), $statusIDs)) {
             CRM_Contact_Import_Parser_Contact::addToErrorMsg('Participant Status Id', $errorMessage);
             break;
           }

--- a/CRM/Logging/Reverter.php
+++ b/CRM/Logging/Reverter.php
@@ -140,7 +140,7 @@ class CRM_Logging_Reverter {
 
         // custom data tables
 
-        case in_array($table, array_keys($ctypes)):
+        case array_key_exists($table, $ctypes):
           foreach ($row as $id => $changes) {
             $inserts = ['id' => '%1'];
             $updates = [];

--- a/CRM/Price/BAO/PriceField.php
+++ b/CRM/Price/BAO/PriceField.php
@@ -795,7 +795,7 @@ WHERE  id IN (" . implode(',', array_keys($priceFields)) . ')';
             $selectedAmounts[$opId] = $options[$opId]['amount'];
           }
         }
-        elseif (in_array($fields["price_{$fieldId}"], array_keys($options))) {
+        elseif (array_key_exists($fields["price_{$fieldId}"], $options)) {
           $selectedAmounts[$fields["price_{$fieldId}"]] = $options[$fields["price_{$fieldId}"]]['amount'];
         }
       }

--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -2259,7 +2259,7 @@ class CRM_Report_Form extends CRM_Core_Form {
     $relative, $from, $to, $type = NULL, $fromTime = NULL, $toTime = NULL
   ) {
     $clauses = [];
-    if (in_array($relative, array_keys($this->getOperationPair(CRM_Report_Form::OP_DATE)))) {
+    if (array_key_exists($relative, $this->getOperationPair(CRM_Report_Form::OP_DATE))) {
       $sqlOP = $this->getSQLOperator($relative);
       return "( {$fieldName} {$sqlOP} )";
     }

--- a/CRM/Report/Form/Contact/Relationship.php
+++ b/CRM/Report/Form/Contact/Relationship.php
@@ -824,7 +824,7 @@ class CRM_Report_Form_Contact_Relationship extends CRM_Report_Form {
     $fieldName,
     $relative, $from, $to, $type = NULL) {
     $clauses = [];
-    if (in_array($relative, array_keys($this->getOperationPair(CRM_Report_Form::OP_DATE)))) {
+    if (array_key_exists($relative, $this->getOperationPair(CRM_Report_Form::OP_DATE))) {
       return NULL;
     }
 

--- a/api/v3/Contribution.php
+++ b/api/v3/Contribution.php
@@ -51,7 +51,7 @@ function civicrm_api3_contribution_create($params) {
       $op = CRM_Core_Action::UPDATE;
     }
     CRM_Financial_BAO_FinancialType::getAvailableFinancialTypes($types, $op);
-    if (!in_array($params['financial_type_id'], array_keys($types))) {
+    if (!array_key_exists($params['financial_type_id'], $types)) {
       throw new API_Exception('You do not have permission to create this contribution');
     }
   }

--- a/ext/financialacls/financialacls.php
+++ b/ext/financialacls/financialacls.php
@@ -164,7 +164,7 @@ function financialacls_civicrm_pre($op, $objectName, $id, &$params) {
     if (empty($params['financial_type_id'])) {
       $params['financial_type_id'] = CRM_Core_DAO::getFieldValue('CRM_Price_DAO_LineItem', $params['id'], 'financial_type_id');
     }
-    if (!in_array($params['financial_type_id'], array_keys($types))) {
+    if (!array_key_exists($params['financial_type_id'], $types)) {
       throw new API_Exception('You do not have permission to ' . $op . ' this line item');
     }
   }

--- a/tests/phpunit/CRM/Contact/SelectorTest.php
+++ b/tests/phpunit/CRM/Contact/SelectorTest.php
@@ -664,7 +664,7 @@ AND ( 1 ) AND (contact_a.is_deleted = 0)',
       FALSE, FALSE
     );
     //Check if custom table is included in $query->_tables.
-    $this->assertTrue(in_array($cgTableName, array_keys($query->_tables)));
+    $this->assertTrue(array_key_exists($cgTableName, $query->_tables));
     //Assert if from clause joins the custom table.
     $this->assertTrue(strpos($query->_fromClause, $cgTableName) !== FALSE);
     $this->callAPISuccess('CustomField', 'delete', ['id' => $customField['id']]);

--- a/tests/phpunit/CRM/Core/BAO/SchemaHandlerTest.php
+++ b/tests/phpunit/CRM/Core/BAO/SchemaHandlerTest.php
@@ -306,7 +306,7 @@ class CRM_Core_BAO_SchemaHandlerTest extends CiviUnitTestCase {
     //Check if both indices are deleted.
     $indices = CRM_Core_BAO_SchemaHandler::getIndexes($tables);
     foreach ($tables as $index => $tableName) {
-      $this->assertFalse(in_array($index, array_keys($indices[$tableName])));
+      $this->assertFalse(array_key_exists($index, $indices[$tableName]));
     }
     //Drop false index and create again.
     CRM_Core_BAO_SchemaHandler::createMissingIndices($missingIndices);


### PR DESCRIPTION
Overview
----------------------------------------
Code cleanup to simplify checking if an array has a key.

Before
----------------------------------------
` in_array($foo, array_keys($bar))`

After
----------------------------------------
`array_key_exists($foo, $bar)`

Technical Details
----------------------------------------
Aside from pedantry, I made this change (via regex find/replace) because `in_array` contains a dangerous bug - if you don't pass `TRUE` for the 3rd param (strict) then a NULL needle will match any array key, giving false positives. We need to start adding that 3rd param as a safeguard, or, in this case, just not use it at all if there's a better alternative.