### PR TITLE
[NFC] Fix phpunit9 deprecation issues on using assertType instead of …

### DIFF
--- a/tests/phpunit/CRM/Utils/versionCheckTest.php
+++ b/tests/phpunit/CRM/Utils/versionCheckTest.php
@@ -183,8 +183,8 @@ class CRM_Utils_versionCheckTest extends CiviUnitTestCase {
       $this->assertArrayHasKey('PPTypes', $stats);
       $this->assertArrayHasKey('entities', $stats);
       $this->assertArrayHasKey('extensions', $stats);
-      $this->assertType('array', $stats['entities']);
-      $this->assertType('array', $stats['extensions']);
+      $this->assertIsArray($stats['entities']);
+      $this->assertIsArray($stats['extensions']);
 
       // Assert $stats['domain_isoCode'] is correct.
       $this->assertEquals($country['iso_code'], $stats['domain_isoCode']);
@@ -192,7 +192,7 @@ class CRM_Utils_versionCheckTest extends CiviUnitTestCase {
       $entity_names = [];
       foreach ($stats['entities'] as $entity) {
         $entity_names[] = $entity['name'];
-        $this->assertType('int', $entity['size'], "Stats entity {$entity['name']} has integer size?");
+        $this->assertIsInt($entity['size'], "Stats entity {$entity['name']} has integer size?");
       }
 
       $expected_entity_names = [


### PR DESCRIPTION
…more explicit assertIsArray or AssertIsInt

Overview
----------------------------------------
Fixes this warning

ok 3116 - # Warning assertInternalType() is deprecated and will be removed in PHPUnit 9. Refactor your test to use assertIsArray() instead.
assertInternalType() is deprecated and will be removed in PHPUnit 9. Refactor your test to use assertIsInt() instead.

Before
----------------------------------------
Warning issue

After
----------------------------------------
No phpunit warning