### PR TITLE
Fix a few more undefined template vars

### DIFF
--- a/CRM/Core/Block.php
+++ b/CRM/Core/Block.php
@@ -440,6 +440,7 @@ class CRM_Core_Block {
     }
     $value['title'] = $short['title'];
     $value['ref'] = $short['ref'] ?? '';
+    $value['shortCuts'] = [];
     if (!empty($short['shortCuts'])) {
       foreach ($short['shortCuts'] as $shortCut) {
         $value['shortCuts'][] = self::setShortcutValues($shortCut);

--- a/templates/CRM/common/debug.tpl
+++ b/templates/CRM/common/debug.tpl
@@ -8,26 +8,26 @@
  +--------------------------------------------------------------------+
 *}
 <!-- .tpl file invoked: {$tplFile}. Call via form.tpl if we have a form in the page. -->
-{if $smarty.get.smartyDebug}
+{if !empty($smarty.get.smartyDebug)}
 {debug}
 {/if}
 
-{if $smarty.get.sessionReset}
+{if !empty($smarty.get.sessionReset)}
 {$session->reset($smarty.get.sessionReset)}
 {/if}
 
-{if $smarty.get.sessionDebug}
+{if !empty($smarty.get.sessionDebug)}
 {$session->debug($smarty.get.sessionDebug)}
 {/if}
 
-{if $smarty.get.directoryCleanup}
+{if !empty($smarty.get.directoryCleanup)}
 {$config->cleanup($smarty.get.directoryCleanup)}
 {/if}
 
-{if $smarty.get.cacheCleanup}
+{if !empty($smarty.get.cacheCleanup)}
 {$config->clearDBCache()}
 {/if}
 
-{if $smarty.get.configReset}
+{if !empty($smarty.get.configReset)}
 {$config->reset()}
 {/if}


### PR DESCRIPTION




@seamuslee001  

I think we should set this
```
--- a/CRM/Core/Smarty.php
+++ b/CRM/Core/Smarty.php
@@ -70,6 +70,7 @@ class CRM_Core_Smarty extends Smarty {
    */
   public function __construct() {
     parent::__construct();
+    ->debugging = (bool) Civi::settings()->get('debug_enabled');
   }
```
So that devs start seeing and cleaning the up the smarty notice issues now that you have done a big push on them

But we need to fix a few REALLY obvious ones first  - which this covers

