### PR TITLE
Give administer CiviCRM data access to administer custom groups

### DIFF
--- a/CRM/Core/xml/Menu/Admin.xml
+++ b/CRM/Core/xml/Menu/Admin.xml
@@ -7,6 +7,7 @@
      <desc>Configure custom fields to collect and store custom data which is not included in the standard CiviCRM forms.</desc>
      <page_callback>CRM_Custom_Page_Group</page_callback>
      <adminGroup>Customize Data and Screens</adminGroup>
+     <access_arguments>administer CiviCRM data</access_arguments>
      <weight>10</weight>
   </item>
   <item>


### PR DESCRIPTION
Overview
----------------------------------------
Give administer CiviCRM data access to administer custom groups

Before
----------------------------------------
@UshaMakoa  is trying to give the 'administer CiviCRM data' permission & it's not currently permitting access to this screen (must be defaulting to Administer CiviCRM which encompasses 'administer CiviCRM data'


After
----------------------------------------
@UshaMakoa is testing - watch this space....

Technical Details
----------------------------------------

Comments
----------------------------------------
