### PR TITLE
dev/core#2649 - Make 5.39 upgrade more robust

### DIFF
--- a/CRM/Upgrade/Incremental/sql/5.39.alpha1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.39.alpha1.mysql.tpl
@@ -1,6 +1,6 @@
 {* file to handle db changes in 5.39.alpha1 during upgrade *}
 
-CREATE TABLE `civicrm_translation` (
+CREATE TABLE IF NOT EXISTS `civicrm_translation` (
   `id` int unsigned NOT NULL AUTO_INCREMENT COMMENT 'Unique String ID',
   `entity_table` varchar(64) NOT NULL COMMENT 'Table where referenced item is stored',
   `entity_field` varchar(64) NOT NULL COMMENT 'Field where referenced item is stored',
@@ -11,4 +11,4 @@ CREATE TABLE `civicrm_translation` (
   PRIMARY KEY (`id`),
   INDEX `index_entity_lang`(entity_id, entity_table, language)
 )
-ENGINE=InnoDB DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+ENGINE=InnoDB ROW_FORMAT=DYNAMIC;


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/2649

Before
----------------------------------------
* Can't re-run the upgrade step.
* Forces utf8mb4

After
----------------------------------------
Quickie fix

Technical Details
----------------------------------------


Comments
----------------------------------------
I think there's a couple related tickets about how to do this better, for both core and extensions, maybe with a convenience function that does all the right things. This is a quickie fix.
