### PR TITLE
[php8-compact] Fix Test Opening Forms by using toSmarty function get …

### DIFF
--- a/templates/CRM/Contact/Form/Search/Custom/FullText.tpl
+++ b/templates/CRM/Contact/Form/Search/Custom/FullText.tpl
@@ -28,14 +28,22 @@
   </div>
 </div>
 <div class="crm-block crm-content-block">
-{if !$table}{include file="CRM/common/pager.tpl" location="top"}{/if}
+{if empty($table)}{include file="CRM/common/pager.tpl" location="top"}{/if}
 {include file="CRM/common/jsortable.tpl"}
 {if $rowsEmpty}
   {include file="CRM/Contact/Form/Search/Custom/EmptyResults.tpl"}
 {/if}
 
-{assign var=table value=$form.table.value.0}
-{assign var=text  value=$form.text.value}
+{if !empty($form.table.value)}
+  {assign var=table value=$form.table.value.0}
+{else}
+  {assign var=table value=false}
+{/if}
+{if !empty($form.text.value)}
+  {assign var=text  value=$form.text.value}
+{else}
+  {assign var=text value=false}
+{/if}
 {if !empty($summary.Contact) }
   <div class="section">
     {* Search request has returned 1 or more matching rows. Display results. *}

--- a/templates/CRM/Tag/Form/Edit.tpl
+++ b/templates/CRM/Tag/Form/Edit.tpl
@@ -57,7 +57,7 @@
           </tr>
         {/if}
     </table>
-    {else}
+    {elseif $action eq 8}
         <div class="status">{ts 1=$delName}Are you sure you want to delete <b>%1</b>?{/ts}<br />{ts}This tag will be removed from any currently tagged contacts, and users will no longer be able to assign contacts to this tag.{/ts}</div>
     {/if}
     <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>

--- a/templates/CRM/common/jsortable.tpl
+++ b/templates/CRM/common/jsortable.tpl
@@ -151,7 +151,7 @@
 
   //plugin to sort on currency
   cj.fn.dataTableExt.oSort['currency-asc']  = function(a,b) {
-    var symbol = "{/literal}{$defaultCurrencySymbol}{literal}";
+    var symbol = "{/literal}{if isset($defaultCurrencySymbol)}{$defaultCurrencySymbol}{/if}{literal}";
     var x = (a == "-") ? 0 : a.replace( symbol, "" );
     var y = (b == "-") ? 0 : b.replace( symbol, "" );
     x = parseFloat( x );
@@ -160,7 +160,7 @@
   };
 
   cj.fn.dataTableExt.oSort['currency-desc'] = function(a,b) {
-    var symbol = "{/literal}{$defaultCurrencySymbol}{literal}";
+    var symbol = "{/literal}{if isset($defaultCurrencySymbol)}{$defaultCurrencySymbol}{/if}{literal}";
     var x = (a == "-") ? 0 : a.replace( symbol, "" );
     var y = (b == "-") ? 0 : b.replace( symbol, "" );
     x = parseFloat( x );

--- a/tests/phpunit/CRM/Core/FormTest.php
+++ b/tests/phpunit/CRM/Core/FormTest.php
@@ -28,6 +28,7 @@ class CRM_Core_FormTest extends CiviUnitTestCase {
     $form->buildQuickForm();
     $form->setDefaultValues();
     $form->assign('action', $form->_action ?? CRM_Core_Action::UPDATE);
+    $form->assign('form', $form->toSmarty());
     $form->getTemplate()->fetch($form->getTemplateFileName());
   }
 


### PR DESCRIPTION
… assigned to template

Overview
----------------------------------------
This is an alternative to https://github.com/civicrm/civicrm-core/pull/20582 

Before
----------------------------------------
Test CRM_Core_FormTest::testopeningforms fails on php8

After
----------------------------------------
Test passes

Technical Details
----------------------------------------
I think that this might be better than 20582 as its less change and also uses the function used in normal rendering but will leave up to reviewers to decide

ping @colemanw @totten @demeritcowboy 