### PR TITLE
REF dev/core#2571 Move reCAPTCHA code to extension

### DIFF
--- a/CRM/Campaign/Form/Petition/Signature.php
+++ b/CRM/Campaign/Form/Petition/Signature.php
@@ -580,21 +580,12 @@ class CRM_Campaign_Form_Petition_Signature extends CRM_Core_Form {
       if ($fields) {
         $this->assign($name, $fields);
 
-        $addCaptcha = FALSE;
         foreach ($fields as $key => $field) {
           // if state or country in the profile, create map
           list($prefixName, $index) = CRM_Utils_System::explode('-', $key, 2);
 
           CRM_Core_BAO_UFGroup::buildProfile($this, $field, CRM_Profile_Form::MODE_CREATE, $contactID, TRUE);
           $this->_fields[$key] = $field;
-          // CRM-11316 Is ReCAPTCHA enabled for this profile AND is this an anonymous visitor
-          if ($field['add_captcha'] && !$this->_contactId) {
-            $addCaptcha = TRUE;
-          }
-        }
-
-        if ($addCaptcha) {
-          CRM_Utils_ReCAPTCHA::enableCaptchaOnForm($this);
         }
       }
     }

--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -319,12 +319,6 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
       $this->buildComponentForm($this->_id, $this);
     }
 
-    if (\Civi::settings()->get('forceRecaptcha')) {
-      if (!$this->_userID) {
-        CRM_Utils_ReCAPTCHA::enableCaptchaOnForm($this);
-      }
-    }
-
     // Build payment processor form
     CRM_Core_Payment_ProcessorForm::buildQuickForm($this);
 

--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -662,7 +662,6 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
         }
 
         CRM_Core_BAO_Address::checkContactSharedAddressFields($fields, $contactID);
-        $addCaptcha = FALSE;
         // fetch file preview when not submitted yet, like in online contribution Confirm and ThankYou page
         $viewOnlyFileValues = empty($profileContactType) ? [] : [$profileContactType => []];
         foreach ($fields as $key => $field) {
@@ -735,10 +734,6 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
             );
             $this->_fields[$key] = $field;
           }
-          // CRM-11316 Is ReCAPTCHA enabled for this profile AND is this an anonymous visitor
-          if ($field['add_captcha'] && !$this->_userID) {
-            $addCaptcha = TRUE;
-          }
         }
 
         $this->assign($name, $fields);
@@ -748,10 +743,6 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
         }
         elseif (count($viewOnlyFileValues)) {
           $this->assign('viewOnlyFileValues', $viewOnlyFileValues);
-        }
-
-        if ($addCaptcha && !$viewOnly) {
-          CRM_Utils_ReCAPTCHA::enableCaptchaOnForm($this);
         }
       }
     }

--- a/CRM/Event/Form/Registration.php
+++ b/CRM/Event/Form/Registration.php
@@ -533,7 +533,6 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
       $fields = array_diff_key($fields, $fieldsToIgnore);
       CRM_Core_Session::setStatus(ts('Some of the profile fields cannot be configured for this page.'));
     }
-    $addCaptcha = FALSE;
 
     if (!empty($this->_fields)) {
       $fields = @array_diff_assoc($fields, $this->_fields);
@@ -553,19 +552,10 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
         if ($button == 'skip') {
           $field['is_required'] = FALSE;
         }
-        // CRM-11316 Is ReCAPTCHA enabled for this profile AND is this an anonymous visitor
-        elseif ($field['add_captcha'] && !$contactID) {
-          // only add captcha for first page
-          $addCaptcha = TRUE;
-        }
         CRM_Core_BAO_UFGroup::buildProfile($this, $field, CRM_Profile_Form::MODE_CREATE, $contactID, TRUE);
 
         $this->_fields[$key] = $field;
       }
-    }
-
-    if ($addCaptcha) {
-      CRM_Utils_ReCAPTCHA::enableCaptchaOnForm($this);
     }
   }
 

--- a/CRM/Mailing/Form/Subscribe.php
+++ b/CRM/Mailing/Form/Subscribe.php
@@ -105,14 +105,6 @@ ORDER BY title";
       $this->addFormRule(['CRM_Mailing_Form_Subscribe', 'formRule']);
     }
 
-    // CRM-11316 Enable ReCAPTCHA for anonymous visitors
-    $session = CRM_Core_Session::singleton();
-    $contactID = $session->get('userID');
-
-    if (!$contactID) {
-      CRM_Utils_ReCAPTCHA::enableCaptchaOnForm($this);
-    }
-
     $this->addButtons([
       [
         'type' => 'next',

--- a/CRM/PCP/Form/PCPAccount.php
+++ b/CRM/PCP/Form/PCPAccount.php
@@ -181,7 +181,6 @@ class CRM_PCP_Form_PCPAccount extends CRM_Core_Form {
 
     if ($fields) {
       $this->assign('fields', $fields);
-      $addCaptcha = FALSE;
       foreach ($fields as $key => $field) {
         if (isset($field['data_type']) && $field['data_type'] == 'File') {
           // ignore file upload fields
@@ -189,15 +188,6 @@ class CRM_PCP_Form_PCPAccount extends CRM_Core_Form {
         }
         CRM_Core_BAO_UFGroup::buildProfile($this, $field, CRM_Profile_Form::MODE_CREATE);
         $this->_fields[$key] = $field;
-
-        // CRM-11316 Is ReCAPTCHA enabled for this profile AND is this an anonymous visitor
-        if ($field['add_captcha'] && !$this->_contactID) {
-          $addCaptcha = TRUE;
-        }
-      }
-
-      if ($addCaptcha) {
-        CRM_Utils_ReCAPTCHA::enableCaptchaOnForm($this);
       }
     }
 

--- a/ext/recaptcha/README.md
+++ b/ext/recaptcha/README.md
@@ -1,5 +1,27 @@
-# recaptcha
+# ReCAPTCHA
 
 Core extension to extract the reCAPTCHA functionality from CiviCRM core so it can be disabled/replaced.
 
 The extension is licensed under [AGPL-3.0](LICENSE.txt).
+
+
+## Using ReCAPTCHA
+
+There is currently no supported method of adding reCAPTCHA to a non CiviCRM core form.
+
+For supported core forms:
+
+This will check the "standard" conditions for adding to a form which are currently:
+* Do not add if user is logged in.
+
+It will be added immediately before the last `<div class=crm-submit-buttons>` on the form.
+
+## To do
+
+Note that it may be preferred to actually develop a completely new extension with new logic
+for adding one or more methods (such as ReCAPTCHA) for protecting against form abuse.
+That would allow this extension to be disabled, removing all references to ReCAPTCHA from
+CiviCRM Core and potentially offering much simpler logic that can be fully controlled from an
+extension - eg. "Load on all anonymous forms".
+
+#### Develop and document a supported method of adding ReCAPTCHA to your form.

--- a/ext/recaptcha/recaptcha.php
+++ b/ext/recaptcha/recaptcha.php
@@ -117,4 +117,6 @@ function recaptcha_civicrm_buildForm($formName, &$form) {
           'region' => 'page-body',
         ]);
   }
+
+  CRM_Utils_ReCAPTCHA::checkAndAddCaptchaToForm($formName, $form);
 }

--- a/ext/recaptcha/templates/CRM/common/ReCAPTCHA.tpl
+++ b/ext/recaptcha/templates/CRM/common/ReCAPTCHA.tpl
@@ -8,17 +8,26 @@
  +--------------------------------------------------------------------+
 *}
 {if $recaptchaHTML}
-{literal}
-<script type="text/javascript">
-var RecaptchaOptions = {{/literal}{$recaptchaOptions}{literal}};
-</script>
-{/literal}
-<div class="crm-section recaptcha-section">
+  <div class="crm-section recaptcha-section" style="display:none">
     <table class="form-layout-compressed">
-        <tr>
-          <td class="recaptcha_label">&nbsp;</td>
-          <td>{$recaptchaHTML}</td>
-       </tr>
+      <tr>
+        <td class="recaptcha_label">&nbsp;</td>
+        <td>{$recaptchaHTML}</td>
+      </tr>
     </table>
-</div>
+  </div>
+{literal}
+  <script type="text/javascript">
+    var RecaptchaOptions = {{/literal}{$recaptchaOptions}{literal}};
+
+  (function($) {
+    document.addEventListener('DOMContentLoaded', function() {
+      var submitButtons = $('div.crm-submit-buttons').last();
+      var recaptchaSection = $('div.recaptcha-section');
+      submitButtons.before(recaptchaSection);
+      recaptchaSection.show();
+    });
+  }(CRM.$));
+  </script>
+{/literal}
 {/if}

--- a/templates/CRM/Campaign/Form/Petition/Signature.tpl
+++ b/templates/CRM/Campaign/Form/Petition/Signature.tpl
@@ -41,10 +41,6 @@
     {include file="CRM/UF/Form/Block.tpl" fields=$petitionActivityProfile hideFieldset=true}
   </div>
 
-  {if $isCaptcha}
-      {include file='CRM/common/ReCAPTCHA.tpl'}
-  {/if}
-
   <div class="crm-submit-buttons">
     {include file="CRM/common/formButtons.tpl" location="bottom"}
   </div>

--- a/templates/CRM/Contribute/Form/Contribution/Main.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Main.tpl
@@ -296,9 +296,6 @@
       </div>
     {/if}
 
-    {if $isCaptcha}
-      {include file='CRM/common/ReCAPTCHA.tpl'}
-    {/if}
     <div id="crm-submit-buttons" class="crm-submit-buttons">
       {include file="CRM/common/formButtons.tpl" location="bottom"}
     </div>

--- a/templates/CRM/Contribute/Form/PCP/PCPAccount.tpl
+++ b/templates/CRM/Contribute/Form/PCP/PCPAccount.tpl
@@ -23,9 +23,6 @@
 <div class="form-item">
 {include file="CRM/common/CMSUser.tpl"}
 {include file="CRM/UF/Form/Block.tpl" fields=$fields}
-{if $isCaptcha}
-{include file='CRM/common/ReCAPTCHA.tpl'}
-{/if}
 </div>
 <div class="crm-submit-buttons">
 {include file="CRM/common/formButtons.tpl" location="bottom"}

--- a/templates/CRM/Event/Form/Registration/Register.tpl
+++ b/templates/CRM/Event/Form/Registration/Register.tpl
@@ -140,10 +140,6 @@
       {include file="CRM/UF/Form/Block.tpl" fields=$customPost}
     </div>
 
-    {if $isCaptcha}
-      {include file='CRM/common/ReCAPTCHA.tpl'}
-    {/if}
-
     <div id="crm-submit-buttons" class="crm-submit-buttons">
       {include file="CRM/common/formButtons.tpl" location="bottom"}
     </div>

--- a/templates/CRM/Mailing/Form/Subscribe.tpl
+++ b/templates/CRM/Mailing/Form/Subscribe.tpl
@@ -40,8 +40,5 @@
         </td>
     </tr>
 </table>
-{if $isCaptcha}
-  {include file='CRM/common/ReCAPTCHA.tpl'}
-{/if}
 <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
 </div><!-- end crm-block -->

--- a/templates/CRM/PCP/Form/PCPAccount.tpl
+++ b/templates/CRM/PCP/Form/PCPAccount.tpl
@@ -27,9 +27,6 @@
 <div class="form-item crm-block crm-form-block">
 {include file="CRM/common/CMSUser.tpl"}
 {include file="CRM/UF/Form/Block.tpl" fields=$fields}
-{if $isCaptcha}
-{include file='CRM/common/ReCAPTCHA.tpl'}
-{/if}
 
 <div class="crm-submit-buttons">
 {include file="CRM/common/formButtons.tpl" location="bottom"}

--- a/templates/CRM/Profile/Form/Dynamic.tpl
+++ b/templates/CRM/Profile/Form/Dynamic.tpl
@@ -187,11 +187,6 @@
       {/if}{* end of main if field name if *}
     {/foreach}
 
-    {if $isCaptcha && ( $mode eq 8 || $mode eq 4 || $mode eq 1 ) }
-      {include file='CRM/common/ReCAPTCHA.tpl'}
-      <script type="text/javascript">cj('.recaptcha_label').attr('width', '140px');</script>
-    {/if}
-
     {if $field.groupHelpPost}
       <div class="messages help">{$field.groupHelpPost}</div>
     {/if}


### PR DESCRIPTION
Overview
----------------------------------------
This moves reCAPTCHA code to extension for all core forms:

* CRM_Contribute_Form_Contribution_Main - Recaptcha working as expected, both by using forced Recaptcha and using a profile with Recaptcha (for anonymous users).
* CRM_Campaign_Form_Petition_Signature - Recaptcha working as expected (using profile) (For anonymous users).
* CRM_Event_Form_Registration_Register - Getting a Recaptcha using a profile as expected.
* CRM_Mailing_Form_Subscribe - I am getting a recaptcha as an anonymous user after going to ‘https://example.org/civicrm/mailing/subscribe' .
* CRM_PCP_Form_PCPAccount - Since PCP just redirects to Contribution buttons after clicking on donate now, then there is a recaptcha on Contribution page.
* CRM_Profile_Form_Edit - If one of the profiles has recaptcha enabled then it should be displayed.
* CRM_Event_Form_Registration_Register - I am getting a recaptcha only for primary participant (using Profile), For additional participant if I decide to skip, its working fine.

Before
----------------------------------------
reCAPTCHA loaded via core form code.

After
----------------------------------------
reCAPTCHA loaded via extension code.

Technical Details
----------------------------------------
tpl files are still included via core templates at the moment.

Comments
----------------------------------------
@totten @monishdeb @eileenmcnaughton
