### PR TITLE
SearchKit - Show Pledge as a primary entity

### DIFF
--- a/Civi/Api4/Pledge.php
+++ b/Civi/Api4/Pledge.php
@@ -15,6 +15,8 @@ namespace Civi\Api4;
 /**
  * Pledge entity.
  *
+ * @see https://docs.civicrm.org/user/en/latest/pledges/what-is-civipledge/
+ * @searchable primary
  * @package Civi\Api4
  */
 class Pledge extends Generic\DAOEntity {


### PR DESCRIPTION
Overview
----------------------------------------
Show Pledges as a primary entity in SearchKit, since it has its own tab on the contact summary screen.

Before
----------------------------------------
Pledges buried in the "Other" list of secondary entities.

After
----------------------------------------
Pledges in the top list of searchable entities.
![image](https://user-images.githubusercontent.com/2874912/121821156-33567780-cc65-11eb-96d4-b081f1d2505d.png)
