### PR TITLE
[php8-compact]  Fix PDF Letter Test by ensuring that all actual DB fi…

### DIFF
--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -1559,10 +1559,16 @@ class CRM_Utils_Token {
   protected static function _buildContributionTokens() {
     $key = 'contribution';
     if (self::$_tokens[$key] == NULL) {
-      self::$_tokens[$key] = array_keys(array_merge(CRM_Contribute_BAO_Contribution::exportableFields('All'),
-        ['campaign', 'financial_type'],
+      $tokens = array_merge(CRM_Contribute_BAO_Contribution::exportableFields('All'),
+        ['campaign' => [], 'financial_type' => [], 'payment_instrument' => []],
         self::getCustomFieldTokens('Contribution')
-      ));
+      );
+      foreach ($tokens as $token) {
+        if (!empty($token['name'])) {
+          $tokens[$token['name']] = [];
+        }
+      }
+      self::$_tokens[$key] = array_keys($tokens);
     }
   }
 
@@ -1680,7 +1686,6 @@ class CRM_Utils_Token {
       //early return
       return $str;
     }
-    self::_buildContributionTokens();
 
     // here we intersect with the list of pre-configured valid tokens
     // so that we remove anything we do not recognize

--- a/tests/phpunit/CRM/Contribute/Form/Task/PDFLetterCommonTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/Task/PDFLetterCommonTest.php
@@ -49,6 +49,7 @@ class CRM_Contribute_Form_Task_PDFLetterCommonTest extends CiviUnitTestCase {
    * @throws \CiviCRM_API3_Exception
    */
   public function tearDown(): void {
+    CRM_Utils_Token::$_tokens['contribution'] = NULL;
     $this->quickCleanUpFinancialEntities();
     $this->quickCleanup(['civicrm_uf_match', 'civicrm_campaign'], TRUE);
     CRM_Utils_Hook::singleton()->reset();


### PR DESCRIPTION
…elds are in the tokens array and also by resetting the static cache of tokens

Overview
----------------------------------------
This fixes test fail on php8 which seems to be caused by in_array doing things differently in php8 but this fixes by ensuring that all actual db name fields are in the token array

Before
----------------------------------------
Test fail on php8

After
----------------------------------------
Test passes on php8

@eileenmcnaughton This resolves things for me @demeritcowboy @totten 