### PR TITLE
[php8-compact] Fix Session Test errors in php8

### DIFF
--- a/templates/CRM/common/info.tpl
+++ b/templates/CRM/common/info.tpl
@@ -8,10 +8,10 @@
  +--------------------------------------------------------------------+
 *}
 {* Handles display of passed $infoMessage. *}
-{if $infoMessage or $infoTitle}
-  <div class="messages status {$infoType}"{if $infoOptions} data-options='{$infoOptions}'{/if}>
+{if isset($infoMessage) or isset($infoTitle)}
+  <div class="messages status {$infoType|default:''}"{if !empty($infoOptions)} data-options='{$infoOptions}'{/if}>
     {icon icon="fa-info-circle"}{/icon}
-    <span class="msg-title">{$infoTitle}</span>
-    <span class="msg-text">{$infoMessage}</span>
+    <span class="msg-title">{$infoTitle|default:''}</span>
+    <span class="msg-text">{$infoMessage|default:''}</span>
   </div>
 {/if}


### PR DESCRIPTION
Overview
----------------------------------------
This fixes the following test errors on php8

- CRM_Core_SessionTest::testSetStatusWithTitleOnly
Undefined array key "infoMessage"
- CRM_Core_SessionTest::testSetStatusWithBoth
Undefined array key "infoType"
- CRM_Core_SessionTest::testSetStatusWithTextOnly
Undefined array key "infoType"

Before
----------------------------------------
CRM_Core_SessionTest fails on php8

After
----------------------------------------
CRM_Core_SessionTest passes on php8

ping @eileenmcnaughton @totten @colemanw @demeritcowboy 