### PR TITLE
[php8-compact] Fix apiv4 tests in php8 by not incrementing an array

### DIFF
--- a/Civi/Api4/Query/SqlFunction.php
+++ b/Civi/Api4/Query/SqlFunction.php
@@ -97,7 +97,6 @@ abstract class SqlFunction extends SqlExpression {
       $expr = SqlExpression::convert($item, FALSE, $mustBe, $cantBe);
       $this->fields = array_merge($this->fields, $expr->getFields());
       $captured[] = $expr;
-      $captured++;
       // Keep going if we have a comma indicating another expression follows
       if (count($captured) < $limit && substr($arg, 0, 1) === ',') {
         $arg = ltrim(substr($arg, 1));


### PR DESCRIPTION
Overview
----------------------------------------
This fixes the following test failures on php8 (this is an example)

- api\v4\Action\FkJoinTest::testBridgeJoinTags
TypeError: Cannot increment array

/home/jenkins/bknix-edge/build/build-0/web/sites/all/modules/civicrm/Civi/Api4/Query/SqlFunction.php:100

Before
----------------------------------------
APIv4 tests fail on php8

After
----------------------------------------
APIv4 tests pass on php8

ping @colemanw @totten @demeritcowboy 