### PR TITLE
[php8-compact] Fix failing CRM_Core_InvokeTest on php8

### DIFF
--- a/templates/CRM/Contact/Page/DashBoardDashlet.tpl
+++ b/templates/CRM/Contact/Page/DashBoardDashlet.tpl
@@ -9,7 +9,7 @@
 *}
 {include file="CRM/common/chart.tpl"}
 {* Alerts for critical configuration settings. *}
-{$communityMessages}
+{$communityMessages|default:''}
 <div class="clear"></div>
 <div class="crm-block crm-content-block">
 

--- a/templates/CRM/Form/body.tpl
+++ b/templates/CRM/Form/body.tpl
@@ -15,7 +15,7 @@
   <div>{$form.hidden}</div>
 {/if}
 
-{if ($snippet !== 'json') and !$suppressForm and count($form.errors) gt 0}
+{if ($snippet !== 'json') and empty($suppressForm) and count($form.errors) gt 0}
    <div class="messages crm-error">
        <i class="crm-i fa-exclamation-triangle crm-i-red" aria-hidden="true"></i>
      {ts}Please correct the following errors in the form fields below:{/ts}

--- a/templates/CRM/Form/default.tpl
+++ b/templates/CRM/Form/default.tpl
@@ -7,7 +7,7 @@
  | and copyright information, see https://civicrm.org/licensing       |
  +--------------------------------------------------------------------+
 *}
-{if ! $suppressForm}
+{if empty($suppressForm)}
 <form {$form.attributes} >
   {crmRegion name='form-top'}{/crmRegion}
 {/if}
@@ -18,7 +18,7 @@
     {include file=$tplFile}
   {/crmRegion}
 
-{if ! $suppressForm}
+{if empty($suppressForm)}
   {crmRegion name='form-bottom'}{/crmRegion}
 </form>
 {/if}


### PR DESCRIPTION
Overview
----------------------------------------
This fixes the failing test CRM_Core_InvokeTest

- CRM_Core_InvokeTest::testInvokeDashboardForNonAdmin
Undefined array key "suppressForm"

/home/jenkins/bknix-edge/build/build-0/web/sites/default/files/civicrm/templates_c/en_US/%%0C/0CB/0CBEC124%%default.tpl.php:5

Before
----------------------------------------
Test fails on php8

After
----------------------------------------
Test passes on php8

ping @demeritcowboy @colemanw @totten 