### PR TITLE
[php8-compact] Fix failing AuthorizeNetIPN tests on php8

### DIFF
--- a/templates/CRM/Contribute/Form/Contribution/AuthorizeNetARB.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/AuthorizeNetARB.tpl
@@ -7,7 +7,7 @@
  | and copyright information, see https://civicrm.org/licensing       |
  +--------------------------------------------------------------------+
 *}
-{if $subscriptionType eq 'cancel'}
+{if isset($subscriptionType) && $subscriptionType eq 'cancel'}
 <?xml version="1.0" encoding="utf-8"?>
 <ARBCancelSubscriptionRequest xmlns="AnetApi/xml/v1/schema/AnetApiSchema.xsd">
   <merchantAuthentication>
@@ -16,7 +16,7 @@
   </merchantAuthentication>
   <subscriptionId>{$subscriptionId}</subscriptionId>
 </ARBCancelSubscriptionRequest>
-{elseif $subscriptionType eq 'updateBilling'}
+{elseif isset($subscriptionType) && $subscriptionType eq 'updateBilling'}
 <?xml version="1.0" encoding="utf-8"?>
 <ARBUpdateSubscriptionRequest xmlns="AnetApi/xml/v1/schema/AnetApiSchema.xsd">
   <merchantAuthentication>
@@ -42,7 +42,7 @@
     </billTo>
   </subscription>
 </ARBUpdateSubscriptionRequest>
-{elseif $subscriptionType eq 'update'}
+{elseif isset($subscriptionType) && $subscriptionType eq 'update'}
 <?xml version="1.0" encoding="utf-8"?>
 <ARBUpdateSubscriptionRequest xmlns="AnetApi/xml/v1/schema/AnetApiSchema.xsd">
   <merchantAuthentication>


### PR DESCRIPTION
Overview
----------------------------------------
This fixes the failing test 

- CRM_Core_Payment_AuthorizeNetIPNTest::testIPNPaymentRecurNoReceipt
Undefined array key "subscriptionType"

/home/jenkins/bknix-edge/build/build-0/web/sites/default/files/civicrm/templates_c/en_US/%%E7/E76/E76FF25C%%AuthorizeNetARB.tpl.php:5

Before
----------------------------------------
A couple of AuthorizeNetIPN tests fail on php8

After
----------------------------------------
AuthorizeNetIPN tests on php8

ping @eileenmcnaughton @totten @colemanw @demeritcowboy 