### PR TITLE
[php8-compact] Further test fixes for php8

### DIFF
--- a/CRM/Core/Form/Date.php
+++ b/CRM/Core/Form/Date.php
@@ -165,12 +165,12 @@ class CRM_Core_Form_Date {
     &$form,
     $fieldName,
     $selector,
-    $from = '_from',
-    $to = '_to',
-    $fromLabel = 'From:',
-    $required = FALSE,
-    $dateFormat = 'searchDate',
-    $displayTime = FALSE,
+    $from,
+    $to,
+    $fromLabel,
+    $required,
+    $dateFormat,
+    $displayTime,
     $attributes
   ) {
     CRM_Core_Error::deprecatedFunctionWarning('function will be removed');

--- a/templates/CRM/Form/body.tpl
+++ b/templates/CRM/Form/body.tpl
@@ -32,7 +32,7 @@
 {/if}
 
 {* Add all the form elements sent in by the hook  - formerly used by civiDiscount, now deprecated*}
-{if $beginHookFormElements}
+{if !empty($beginHookFormElements)}
   <table class="form-layout-compressed">
   {foreach from=$beginHookFormElements key=dontCare item=hookFormElement}
       <tr><td class="label nowrap">{$form.$hookFormElement.label}</td><td>{$form.$hookFormElement.html}</td></tr>


### PR DESCRIPTION
Overview
----------------------------------------
Fixes the following 2 issues

- CRM_Core_InvokeTest::testInvokeDashboardForNonAdmin
Undefined array key "beginHookFormElements"

/home/jenkins/bknix-edge/build/build-0/web/sites/default/files/civicrm/templates_c/en_US/%%4D/4DC/4DC76B26%%body.tpl.php:36
- CRM_Contact_Import_Form_DataSourceTest::testBuildForm
Required parameter $attributes follows optional parameter $from

/home/jenkins/bknix-edge/build/build-0/web/sites/all/modules/civicrm/CRM/Core/Form/Date.php:164

Before
----------------------------------------
Those 2 tests fail on php8

After
----------------------------------------
Those 2 tests pass on php8

ping @eileenmcnaughton @demeritcowboy @totten @colemanw 