### PR TITLE
Force cleanup of setting value type "checkboxes" when is empty

### DIFF
--- a/CRM/Admin/Form/SettingTrait.php
+++ b/CRM/Admin/Form/SettingTrait.php
@@ -85,8 +85,12 @@ trait CRM_Admin_Form_SettingTrait {
     // Handle quickform hateability just once, right here right now.
     $unsetValues = array_diff_key($this->_settings, $params);
     foreach ($unsetValues as $key => $unsetValue) {
-      if ($this->getQuickFormType($this->getSettingMetadata($key)) === 'CheckBox') {
+      $quickFormType = $this->getQuickFormType($this->getSettingMetadata($key));
+      if ($quickFormType === 'CheckBox') {
         $setValues[$key] = [$key => 0];
+      }
+      elseif ($quickFormType === 'CheckBoxes') {
+        $setValues[$key] = [];
       }
     }
     return $setValues;


### PR DESCRIPTION
Overview
----------------------------------------
When using a custom setting of type `checkboxes`, if there's no checked value in the group, it's not saved empty in the DB

Before
----------------------------------------
Add a custom setting type `checkboxes` in you extension with multiple options, go to to Generic Admin Form, and save any value. Then go back and uncheck all the boxes, the empty value is not saved in the DB, previous value remains.

After
----------------------------------------
Empty value is saved in the DB; if there's no box checked in the Generic Admin Form

Technical Details
----------------------------------------
Looks like the setting type  `checkboxes` is not fully supported in Civi yet, (as a single `checkbox`), probably more PRs coming after this one to add more features to this useful setting type

Comments
---------------------------------------
I haven't found many implementations of custom settings of type `checkboxes` in the community, but it's fully documented as part of settings MetaData in [docs](https://docs.civicrm.org/dev/en/latest/framework/setting/#supported-properties), but still needs some love in the source code to fully work as expected.