### PR TITLE
Added setup pcp page wordpress shortcode

### DIFF
--- a/CRM/Core/Form/ShortCode.php
+++ b/CRM/Core/Form/ShortCode.php
@@ -134,6 +134,7 @@ class CRM_Core_Form_ShortCode extends CRM_Core_Form {
         'options' => [
           'info' => ts('Info Page'),
           'transact' => ts('Contribution Page'),
+          'setup' => ts('Setup a Personal Campaign Page'),
         ],
       ],
       [

--- a/CRM/Core/Form/ShortCode.php
+++ b/CRM/Core/Form/ShortCode.php
@@ -122,6 +122,14 @@ class CRM_Core_Form_ShortCode extends CRM_Core_Form {
     $this->options = [
       [
         'key' => 'action',
+        'components' => ['contribution'],
+        'options' => [
+          'transact' => ts('Contribution Page'),
+          'setup' => ts('Setup a Personal Campaign Page'),
+        ],
+      ],
+      [
+        'key' => 'action',
         'components' => ['event'],
         'options' => [
           'info' => ts('Event Info Page'),
@@ -134,7 +142,6 @@ class CRM_Core_Form_ShortCode extends CRM_Core_Form {
         'options' => [
           'info' => ts('Info Page'),
           'transact' => ts('Contribution Page'),
-          'setup' => ts('Setup a Personal Campaign Page'),
         ],
       ],
       [


### PR DESCRIPTION
Overview
----------------------------------------
This PR has added a shortcode option to setup a PCP similar to other shortcodes present in PCP like info and transact.

Before
----------------------------------------
_What is the old user-interface or technical-contract (as appropriate)?_
_For optimal clarity, include a concrete example such as a screenshot, GIF ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)), or code-snippet._

After
----------------------------------------
_What changed? What is new old user-interface or technical-contract?_
_For optimal clarity, include a concrete example such as a screenshot, GIF ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)), or code-snippet._

Technical Details
----------------------------------------
_If the PR involves technical details/changes/considerations which would not be manifest to a casual developer skimming the above sections, please describe the details here._

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
