### PR TITLE
[php8-compat] Alternate to the alternate for testOpeningForms

### DIFF
--- a/CRM/Contact/Form/Search/Custom/FullText.php
+++ b/CRM/Contact/Form/Search/Custom/FullText.php
@@ -316,6 +316,7 @@ WHERE      t.table_name = 'Activity' AND
     $form->assign('limit', self::LIMIT);
 
     // set form defaults
+    $form->assign('table', '');
     if (!empty($form->_formValues)) {
       $defaults = [];
 

--- a/templates/CRM/Contact/Form/Search/Custom/FullText.tpl
+++ b/templates/CRM/Contact/Form/Search/Custom/FullText.tpl
@@ -34,7 +34,8 @@
   {include file="CRM/Contact/Form/Search/Custom/EmptyResults.tpl"}
 {/if}
 
-{assign var=table value=$form.table.value.0}
+{* @TODO: This is confusing - the variable `table` is already set and used above, and now we set it again to something that is technically different but has the same value, except on a blank form where it doesn't exist, but effectively then is the same value that it already has which is ''. So do we need this line even? *}
+{if (isset($form.table.value.0))}{assign var=table value=$form.table.value.0}{/if}
 {assign var=text  value=$form.text.value}
 {if !empty($summary.Contact) }
   <div class="section">

--- a/templates/CRM/Price/Page/Field.tpl
+++ b/templates/CRM/Price/Page/Field.tpl
@@ -26,7 +26,8 @@
   </div>
 {/if}
 
-{if $action NEQ 8 and $priceField}
+{* priceField is set when e.g. in browse mode *}
+{if $action NEQ 8 and !empty($priceField)}
 <div class="crm-content-block crm-block">
   <div class="action-link">
     {if !$isReserved}

--- a/templates/CRM/Tag/Form/Edit.tpl
+++ b/templates/CRM/Tag/Form/Edit.tpl
@@ -31,7 +31,8 @@
           <td class="label">{$form.used_for.label}</td>
           <td>{$form.used_for.html} <br />
             <span class="description">
-              {if $is_parent}{ts}You can change the types of records which this tag can be used for by editing the 'Parent' tag.{/ts}
+              {* @TODO: I don't think is_parent is ever true because this form is never used for editing a tag itself, and you can't nest tagsets. And when used to add a new child tag, the used_for element doesn't exist. *}
+              {if !empty($is_parent)}{ts}You can change the types of records which this tag can be used for by editing the 'Parent' tag.{/ts}
               {else}{ts}What types of record(s) can this tag be used for?{/ts}
               {/if}
             </span>


### PR DESCRIPTION
Overview
----------------------------------------
Alternate to https://github.com/civicrm/civicrm-core/pull/20583 which was an alternate to https://github.com/civicrm/civicrm-core/pull/20582

The test was always flawed. This updates the test to make it closer to a real simulation so that vars aren't missing.

For the test file itself, because of how github displays the changes it's easier to just look at the new version of the file on its own.