### PR TITLE
[NFC] Fix test failure on MySQL8 because of lack of order in API

### DIFF
--- a/tests/phpunit/api/v3/ContactTest.php
+++ b/tests/phpunit/api/v3/ContactTest.php
@@ -305,7 +305,11 @@ class api_v3_ContactTest extends CiviUnitTestCase {
 
     // get all students and parents
     $result = $this->callAPISuccess('Contact', 'get', ['return' => 'id', 'contact_sub_type' => ['IN' => ['Parent', 'Student']]])['values'];
-    $this->assertEquals([$student['id'], $parent['id']], array_keys($result));
+    // check that we retrieved the student and the parent.
+    // On MySQL 8 this can have different order in the array as there is no specific order set.
+    $this->assertArrayHasKey($student['id'], $result);
+    $this->assertArrayHasKey($parent['id'], $result);
+    $this->assertCount(2, $result);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
This fixes the following test failure on MySQL8 

```
api_v3_ContactTest::testGetMultipleContactSubTypes with data set "APIv3" (3)
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
 Array (
-    0 => 3
-    1 => 4
+    0 => 4
+    1 => 3
 )
```

Before
----------------------------------------
Test fails on MySQL8

After
----------------------------------------
Test Passes on MySQL8

ping @eileenmcnaughton @demeritcowboy @totten @colemanw 