### PR TITLE
[php8-compact] Fix Array to String in formButtons in CRM_Core_FormTest

### DIFF
--- a/templates/CRM/Contact/Form/Search/BasicCriteria.tpl
+++ b/templates/CRM/Contact/Form/Search/BasicCriteria.tpl
@@ -78,7 +78,7 @@
               <div class="clear"></div>
             </div>
         {/if}
-        <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl"}</div>
+        <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
     </div><!-- /.crm-accordion-body -->
     </div><!-- /.crm-accordion-wrapper -->
 </div><!-- /.crm-form-block -->


### PR DESCRIPTION
Overview
----------------------------------------
This fixes the following test error

```
CRM_Core_FormTest::testOpeningForms with data set "Find Contacts" ('civicrm/contact/search?reset=1')
Array to string conversion

/home/jenkins/bknix-edge/build/build-1/web/sites/default/files/civicrm/templates_c/en_US/%%ED/ED7/ED78F5CC%%formButtons.tpl.php:44
```

Before
----------------------------------------
Test fails on php8 due to array to string conversion

After
----------------------------------------
Test passes on php8

ping @demeritcowboy @eileenmcnaughton @totten @colemanw 