### PR TITLE
APIv4 - Make LineItem, EntityFinancialTrxn and FinancialTrxn read-only

### DIFF
--- a/Civi/Api4/EntityFinancialTrxn.php
+++ b/Civi/Api4/EntityFinancialTrxn.php
@@ -29,6 +29,7 @@ namespace Civi\Api4;
  */
 class EntityFinancialTrxn extends Generic\DAOEntity {
   use Generic\Traits\EntityBridge;
+  use Generic\Traits\ReadOnly;
 
   /**
    * @return array

--- a/Civi/Api4/FinancialItem.php
+++ b/Civi/Api4/FinancialItem.php
@@ -30,19 +30,6 @@ namespace Civi\Api4;
  * @package Civi\Api4
  */
 class FinancialItem extends Generic\DAOEntity {
-
-  /**
-   * @see \Civi\Api4\Generic\AbstractEntity::permissions()
-   * @return array
-   */
-  public static function permissions() {
-    $permissions = \CRM_Core_Permission::getEntityActionPermissions()['financial_item'] ?? [];
-
-    // Merge permissions for this entity with the defaults
-    return array_merge($permissions, [
-      'create' => [\CRM_Core_Permission::ALWAYS_DENY_PERMISSION],
-      'update' => [\CRM_Core_Permission::ALWAYS_DENY_PERMISSION],
-    ]);
-  }
+  use Generic\Traits\ReadOnly;
 
 }

--- a/Civi/Api4/FinancialTrxn.php
+++ b/Civi/Api4/FinancialTrxn.php
@@ -32,5 +32,6 @@ namespace Civi\Api4;
  * @package Civi\Api4
  */
 class FinancialTrxn extends Generic\DAOEntity {
+  use Generic\Traits\ReadOnly;
 
 }

--- a/Civi/Api4/Generic/Traits/ReadOnly.php
+++ b/Civi/Api4/Generic/Traits/ReadOnly.php
@@ -1,0 +1,78 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Generic\Traits;
+
+/**
+ * Trait for Entities not intended to be publicly writable.
+ */
+trait ReadOnly {
+
+  /**
+   * Not intended to be used outside CiviCRM core code.
+   *
+   * @inheritDoc
+   * @internal
+   */
+  public static function save($checkPermissions = TRUE) {
+    return parent::save($checkPermissions);
+  }
+
+  /**
+   * Not intended to be used outside CiviCRM core code.
+   *
+   * @inheritDoc
+   * @internal
+   */
+  public static function create($checkPermissions = TRUE) {
+    return parent::create($checkPermissions);
+  }
+
+  /**
+   * Not intended to be used outside CiviCRM core code.
+   *
+   * @inheritDoc
+   * @internal
+   */
+  public static function update($checkPermissions = TRUE) {
+    return parent::update($checkPermissions);
+  }
+
+  /**
+   * Not intended to be used outside CiviCRM core code.
+   *
+   * @inheritDoc
+   * @internal
+   */
+  public static function delete($checkPermissions = TRUE) {
+    return parent::delete($checkPermissions);
+  }
+
+  /**
+   * Not intended to be used outside CiviCRM core code.
+   *
+   * @inheritDoc
+   * @internal
+   */
+  public static function replace($checkPermissions = TRUE) {
+    return parent::replace($checkPermissions);
+  }
+
+  /**
+   * @return array
+   */
+  public static function permissions() {
+    $permissions = parent::permissions();
+    $permissions['create'] = $permissions['update'] = $permissions['delete'] = \CRM_Core_Permission::ALWAYS_DENY_PERMISSION;
+    return $permissions;
+  }
+
+}

--- a/Civi/Api4/LineItem.php
+++ b/Civi/Api4/LineItem.php
@@ -25,5 +25,6 @@ namespace Civi\Api4;
  * @package Civi\Api4
  */
 class LineItem extends Generic\DAOEntity {
+  use Generic\Traits\ReadOnly;
 
 }

--- a/ext/financialacls/tests/phpunit/Civi/Financialacls/LineItemTest.php
+++ b/ext/financialacls/tests/phpunit/Civi/Financialacls/LineItemTest.php
@@ -61,7 +61,7 @@ class LineItemTest extends BaseTestClass {
     $this->assertCount(2, $lineItems);
     $this->callAPISuccessGetCount('LineItem', ['check_permissions' => TRUE], 1);
 
-    $this->callAPISuccess('LineItem', 'Delete', ['check_permissions' => TRUE, 'id' => $lineItems[0]['id']]);
+    $this->callAPISuccess('LineItem', 'Delete', ['check_permissions' => ($version == 3), 'id' => $lineItems[0]['id']]);
     $this->callAPIFailure('LineItem', 'Delete', ['check_permissions' => TRUE, 'id' => $lineItems[1]['id']]);
     $lineParams = [
       'entity_id' => $order['id'],
@@ -71,14 +71,15 @@ class LineItemTest extends BaseTestClass {
       'price_field_id' => $defaultPriceFieldID,
       'qty' => 1,
       'financial_type_id' => 'Donation',
-      'check_permissions' => TRUE,
+      'check_permissions' => ($version == 3),
     ];
     $line = $this->callAPISuccess('LineItem', 'Create', $lineParams);
     $lineParams['financial_type_id'] = 'Event Fee';
+    $lineParams['check_permissions'] = TRUE;
     $this->callAPIFailure('LineItem', 'Create', $lineParams);
 
     $this->callAPIFailure('LineItem', 'Create', ['id' => $line['id'], 'check_permissions' => TRUE, 'financial_type_id' => 'Event Fee']);
-    $this->callAPISuccess('LineItem', 'Create', ['id' => $line['id'], 'check_permissions' => TRUE, 'financial_type_id' => 'Donation']);
+    $this->callAPISuccess('LineItem', 'Create', ['id' => $line['id'], 'check_permissions' => ($version == 3), 'financial_type_id' => 'Donation']);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Alternative to #20550 to restrict use of apis which are not intended to be used outside core code.

Before
-----------
Entities treated like all others with read and write functionality.

After
---------
Write functions hidden from API Explorer and not available unless `checkPermissions = FALSE`.
![image](https://user-images.githubusercontent.com/2874912/122109651-9a9e3400-cdeb-11eb-8773-763d50d11ac4.png)


Technical Details
----------------------------------------
Adds a new ReadOnly trait which annotates write methods as @internal
and sets write permissions to ALWAYS_DENY.

This effectively hides the write actions from the API Explorer,
and restricts use of the write methods to when `checkPermissions = FALSE`.