### PR TITLE
dev/report#68 Fix smart group crash when ordering by aggregated column

### DIFF
--- a/CRM/Contact/BAO/GroupContactCache.php
+++ b/CRM/Contact/BAO/GroupContactCache.php
@@ -530,6 +530,10 @@ ORDER BY   gc.contact_id, g.children
     if (empty($apiParams['having'])) {
       $apiParams['select'] = array_slice($apiParams['select'], 0, 1);
     }
+    // Order is irrelevant unless using limit or offset
+    if (empty($apiParams['limit']) && empty($apiParams['offset'])) {
+      unset($apiParams['orderBy']);
+    }
     /* @var $api \Civi\Api4\Generic\DAOGetAction */
     $api = Request::create($savedSearch['api_entity'], 'get', $apiParams);
     $query = new Api4SelectQuery($api);


### PR DESCRIPTION
Overview
----------------------------------------
Fixes https://lab.civicrm.org/dev/report/-/issues/68

Before
----------------------------------------
SearchKit can crash smart groups when ordering by an aggregated column.

After
----------------------------------------
Fixed.

Technical Details
----------------------------------------
The smart group query removes everything from the SELECT clause, removing calculated fields which may be used by ORDER BY clause.