### PR TITLE
Fix unreleased api change to more logical variant

### DIFF
--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -1168,7 +1168,7 @@ DESC limit 1");
           ]
         );
         $this->ids['Contribution'] = $contribution['id'];
-        $this->setMembershipIDs($contribution['values'][$contribution['id']]['membership_id']);
+        $this->setMembershipIDsFromOrder($contribution);
 
         //create new soft-credit record, CRM-13981
         if ($softParams) {
@@ -1986,6 +1986,19 @@ DESC limit 1");
    */
   protected function getMembershipParamsForType(int $membershipTypeID) {
     return array_merge($this->getFormMembershipParams(), $this->getMembershipParameters()[$membershipTypeID]);
+  }
+
+  /**
+   * @param array $contribution
+   */
+  protected function setMembershipIDsFromOrder(array $contribution): void {
+    $ids = [];
+    foreach ($contribution['values'][$contribution['id']]['line_item'] as $line) {
+      if ($line['entity_table'] ?? '' === 'civicrm_membership') {
+        $ids[] = $line['entity_id'];
+      }
+    }
+    $this->setMembershipIDs($ids);
   }
 
 }

--- a/api/v3/Order.php
+++ b/api/v3/Order.php
@@ -76,9 +76,9 @@ function civicrm_api3_order_create(array $params): array {
   $entity = NULL;
   $entityIds = [];
   $params['contribution_status_id'] = 'Pending';
+  $priceSetID = NULL;
 
   if (!empty($params['line_items']) && is_array($params['line_items'])) {
-    $priceSetID = NULL;
     CRM_Contribute_BAO_Contribution::checkLineItems($params);
     foreach ($params['line_items'] as $lineItems) {
       $entityParams = $lineItems['params'] ?? [];
@@ -149,6 +149,8 @@ function civicrm_api3_order_create(array $params): array {
   }
 
   $contribution = civicrm_api3('Contribution', 'create', $contributionParams);
+  $contribution['values'][$contribution['id']]['line_item'] = $params['line_item'][$priceSetID] ?? [];
+
   // add payments
   if ($entity && !empty($contribution['id'])) {
     foreach ($entityIds as $entityId) {
@@ -161,7 +163,6 @@ function civicrm_api3_order_create(array $params): array {
         $paymentParams += $entityParams;
       }
       elseif ($entity === 'membership') {
-        $contribution['values'][$contribution['id']]['membership_id'][] = $entityId;
         $paymentParams['isSkipLineItem'] = TRUE;
       }
       civicrm_api3($entity . '_payment', 'create', $paymentParams);

--- a/tests/phpunit/CRMTraits/Financial/OrderTrait.php
+++ b/tests/phpunit/CRMTraits/Financial/OrderTrait.php
@@ -127,7 +127,12 @@ trait CRMTraits_Financial_OrderTrait {
     ]);
 
     $this->ids['Contribution'][0] = $order['id'];
-    $this->ids['Membership']['order'] = $order['values'][$order['id']]['membership_id'][0];
+    foreach ($order['values'][$order['id']]['line_item'] as $line) {
+      if (($line['entity_table'] ?? '') === 'civicrm_membership') {
+        $this->ids['Membership']['order'] = $line['entity_id'];
+      }
+    }
+
   }
 
   /**


### PR DESCRIPTION

Overview
----------------------------------------
An unreleased change https://github.com/civicrm/civicrm-core/pull/20077 adds the entity ids for membership to the return values on order api (this was to support the backoffice membership form using order api)

However, on digging into further cleanup I realised that the entity ids are in
the line item array, along with other values which may or may not be useful,
and it's cleaner, more complete and more maintainable to return the line_items.

We should change this in the rc so what is released is consistent with the future


Before
----------------------------------------
Return array includes a key 'entity_ids' that gets the membership id back but is reminiscent of the old 'pass random ids arrays arround' approach

After
----------------------------------------
'line_item' array returned - which includes the entity ids


It requires an extra foreach loop in the calling code but
I don't see that as a downside.

Technical Details
----------------------------------------
Test cover in testSubmitRecur & other tests in CRM_Member_Form_MembershipTest for the only place that accesses this

Comments
----------------------------------------
