### PR TITLE
[NFC] Fix test setup on a couple of tests to make them pass in php8

### DIFF
--- a/tests/phpunit/CRM/Contact/Page/AjaxTest.php
+++ b/tests/phpunit/CRM/Contact/Page/AjaxTest.php
@@ -34,9 +34,8 @@ class CRM_Contact_Page_AjaxTest extends CiviUnitTestCase {
     $_REQUEST['columns'] = [
       [
         'search' => [
-          'value' => [
-            'src' => 'first_name',
-          ],
+          'value' => 'first_name',
+          'regex' => FALSE,
         ],
         'data' => 'src',
       ],

--- a/tests/phpunit/api/v3/ACLPermissionTest.php
+++ b/tests/phpunit/api/v3/ACLPermissionTest.php
@@ -944,8 +944,7 @@ class api_v3_ACLPermissionTest extends CiviUnitTestCase {
     $this->assertEquals(1, $result['count']);
     $this->callAPIFailure('activity', 'getsingle', array_merge($params, [
       'id' => [
-        'IN',
-        [$activity2['id']],
+        'IN' => [$activity2['id']],
       ],
     ]));
   }


### PR DESCRIPTION
Overview
----------------------------------------
This fixes a couple of tests to better match / work so that they pass in php8

Before
----------------------------------------
These tests failed in php8 because of bad test setup

After
----------------------------------------
These tests pass in php8

ping @eileenmcnaughton @demeritcowboy @totten @colemanw