### PR TITLE
Add file_exists check on loading services xml

### DIFF
--- a/CRM/Api4/Services.php
+++ b/CRM/Api4/Services.php
@@ -58,7 +58,9 @@ class CRM_Api4_Services {
       );
     }
 
-    if (defined('CIVICRM_UF') && CIVICRM_UF === 'UnitTests') {
+    if (defined('CIVICRM_UF') && CIVICRM_UF === 'UnitTests'
+      && file_exists('tests/phpunit/api/v4/services.xml')
+    ) {
       $loader->load('tests/phpunit/api/v4/services.xml');
     }
   }


### PR DESCRIPTION

Overview
----------------------------------------
I'm hitting an issue where we run unit tests on our own code base and this is hitting file-not-found

We don't package the tests directory with the tarball so it's not there.

The alternative is to move it to the Civi\test folder if it's important that
it be there for non-core tests

Before
----------------------------------------
Tests fail against file not found when running against tarball

After
----------------------------------------
no fail

Technical Details
----------------------------------------
@totten 

Comments
----------------------------------------
