### PR TITLE
Add test validation for Membership & participant payments

### DIFF
--- a/api/v3/Order.php
+++ b/api/v3/Order.php
@@ -161,11 +161,14 @@ function civicrm_api3_order_create(array $params): array {
       // if entity is pledge then build pledge param
       if ($entity === 'pledge') {
         $paymentParams += $entityParams;
+        // Pledges are not stored as entity_id in the line_item table.
+        CRM_Core_Error::deprecatedWarning('This should be unreachable & tests show it is never tested.');
+        civicrm_api3('PledgePayment', 'create', $paymentParams);
       }
-      elseif ($entity === 'membership') {
-        $paymentParams['isSkipLineItem'] = TRUE;
+      if ($entity === 'participant') {
+        civicrm_api3('ParticipantPayment', 'create', $paymentParams);
       }
-      civicrm_api3($entity . '_payment', 'create', $paymentParams);
+
     }
   }
   return civicrm_api3_create_success($contribution['values'] ?? [], $params, 'Order', 'create');

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -3633,13 +3633,29 @@ VALUES
     foreach ($contributions as $contribution) {
       $lineItems = $this->callAPISuccess('LineItem', 'get', [
         'contribution_id' => $contribution['id'],
-        'return' => ['tax_amount', 'line_total'],
+        'return' => ['tax_amount', 'line_total', 'entity_table', 'entity_id'],
       ])['values'];
       $total = 0;
       $taxTotal = 0;
+      $memberships = [];
+      $participants = [];
       foreach ($lineItems as $lineItem) {
         $total += $lineItem['line_total'];
         $taxTotal += (float) ($lineItem['tax_amount'] ?? 0);
+        if ($lineItem['entity_table'] === 'civicrm_membership') {
+          $memberships[] = $lineItem['entity_id'];
+        }
+        if ($lineItem['entity_table'] === 'civicrm_participant') {
+          $participants[] = $lineItem['entity_id'];
+        }
+      }
+      $membershipPayments = $this->callAPISuccess('MembershipPayment', 'get', ['contribution_id' => $contribution['id'], 'return' => 'membership_id'])['values'];
+      $participantPayments = $this->callAPISuccess('ParticipantPayment', 'get', ['contribution_id' => $contribution['id'], 'return' => 'participant_id'])['values'];
+      $this->assertCount(count($memberships), $membershipPayments);
+      // @todo not working yet.
+      // $this->assertCount(count($participants), $participantPayments);
+      foreach ($membershipPayments as $payment) {
+        $this->assertContains($payment['membership_id'], $memberships);
       }
       $this->assertEquals($taxTotal, (float) ($contribution['tax_amount'] ?? 0));
       $this->assertEquals($total + $taxTotal, $contribution['total_amount']);


### PR DESCRIPTION
Overview
----------------------------------------
Removes redundant line that creates a membership payment in the order api. This is already covered in order api tests but I also extended the validate test cover.

I think the participantPayment.create can go too but I think there are some test issues to address and I am only partially validating participant payments

Before
----------------------------------------
more silly code, less test cover

After
----------------------------------------
Reversed

Technical Details
----------------------------------------
The pledge lines are logically unreachable I believe as I don't believe we ever store the pledge_id in line_item.entity_id and tests indicate they are not reached via tests - https://github.com/civicrm/civicrm-core/pull/20604

Comments
----------------------------------------
