### PR TITLE
[php8-compact] Fix Event Form test for php8 by setting totalAmount in…

### DIFF
--- a/tests/phpunit/CRM/Event/Form/Registration/ConfirmTest.php
+++ b/tests/phpunit/CRM/Event/Form/Registration/ConfirmTest.php
@@ -349,6 +349,7 @@ class CRM_Event_Form_Registration_ConfirmTest extends CiviUnitTestCase {
       'id' => $event['id'],
       'contributeMode' => 'direct',
       'registerByID' => $this->createLoggedInUser(),
+      'totalAmount' => 0,
       'params' => [
         [
           'qfKey' => 'e6eb2903eae63d4c5c6cc70bfdda8741_2801',


### PR DESCRIPTION
… the form params

Overview
----------------------------------------
This fixes the following test failure on php8

```
CRM_Event_Form_Registration_ConfirmTest::testOnlineRegNoPrice
Exception: CRM_Core_Exception: "The system did not record payment details for this payment and so could not process the transaction. Please report this error to the site administrator."
#0 /home/jenkins/bknix-edge/build/build-2/web/sites/all/modules/civicrm/CRM/Event/Form/Registration/Confirm.php(1250): CRM_Event_Form_Registration_Confirm->postProcess()
```

Before
----------------------------------------
Test fails on php8

After
----------------------------------------
Test passes on php8

Technical Details
----------------------------------------
It seems that this was causing an empty string to be set https://github.com/civicrm/civicrm-core/blob/master/CRM/Event/Form/Registration/Confirm.php#L1238 which eventually caused $value['amount'] to get set to an empty string rather than 0 so the test was wrongly winding up in this part of the if https://github.com/civicrm/civicrm-core/blob/master/CRM/Event/Form/Registration/Confirm.php#L522

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
