### PR TITLE
[php8-compact][NFC] Update testGroupClause unit test to work on php8

### DIFF
--- a/tests/phpunit/CRM/Contact/BAO/QueryTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/QueryTest.php
@@ -1007,7 +1007,7 @@ civicrm_relationship.is_active = 1 AND
     $this->assertEquals(3, $dao->N);
     $this->assertFalse(strstr($sql, ' OR '), 'Query does not include or');
     while ($dao->fetch()) {
-      $this->assertTrue(($dao->groups == $groupID || $dao->groups == ',' . $groupID), $dao->groups . ' includes ' . $groupID);
+      $this->assertTrue(($dao->groups == $groupID || $dao->groups == ',' . $groupID || $dao->groups == $groupID . ',' . $groupID), $dao->groups . ' includes ' . $groupID);
     }
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
This fixes the following test failure on php8

```
CRM_Contact_BAO_QueryTest::testGroupClause
1,1 includes 1
Failed asserting that false is true.
```

Before
----------------------------------------
Test fails on php8

After
----------------------------------------
Test passes on php8

ping @eileenmcnaughton @demeritcowboy @totten @colemanw 