### PR TITLE
[php8-compact] Allow for CiviCRM to be installed by 3rd parties using…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
     }
   },
   "require": {
-    "php": "~7.2",
+    "php": "~7.2 || ~8",
     "cache/integration-tests": "~0.17.0",
     "dompdf/dompdf" : "~1.0.0",
     "firebase/php-jwt": ">=3 <6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e7cca2de5a5b2bd54ac4c14b677845ed",
+    "content-hash": "806655f49ee4984e61d0c1bf7bcc0c88",
     "packages": [
         {
             "name": "adrienrn/php-mimetyper",
@@ -4036,7 +4036,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "~7.2",
+        "php": "~7.2 || ~8",
         "ext-intl": "*",
         "ext-json": "*"
     },

--- a/tests/phpunit/CRM/Upgrade/FormTest.php
+++ b/tests/phpunit/CRM/Upgrade/FormTest.php
@@ -18,7 +18,7 @@ class CRM_Upgrade_FormTest extends CiviUnitTestCase {
     $composerJsonRequirePhp = preg_replace(';[~^];', '', $composerJson['require']['php']);
     $actualMajorMinor = preg_replace(';^[\^]*(\d+\.\d+)\..*$;', '\1', $composerJsonRequirePhp);
     $expectMajorMinor = preg_replace(';^(\d+\.\d+)\..*$;', '\1', \CRM_Upgrade_Incremental_General::MIN_INSTALL_PHP_VER);
-    $this->assertEquals($expectMajorMinor, $actualMajorMinor, "The PHP version requirements in CRM_Upgrade_Form ($expectMajorMinor) and composer.json ($actualMajorMinor) should specify same major+minor versions.");
+    $this->assertStringContainsString($expectMajorMinor, $actualMajorMinor, "The PHP version requirements in CRM_Upgrade_Form ($expectMajorMinor) and composer.json ($actualMajorMinor) should specify same major+minor versions.");
   }
 
 }


### PR DESCRIPTION
… composer on php8 systems

Overview
----------------------------------------
This would permit sites running Drupal 9 for example to install / update civicrm if their CLI or similar uses php8

Before
----------------------------------------
Cannot install or update civicrm via composer if php version is > 7.4

After
----------------------------------------
Can install or update civicrm via composer if php versions is > 7.4

I know that we have ~8 test failures still to go but most of those are actual issues not specifically related to php8 but php8 highlights them well. I'm not sure if that should be a blocker to doing this tho.

ping @eileenmcnaughton @totten @demeritcowboy @colemanw @MikeyMJCO 