### PR TITLE
dev/financial#175 - Unable to remove a currency once added

### DIFF
--- a/CRM/Core/OptionGroup.php
+++ b/CRM/Core/OptionGroup.php
@@ -466,6 +466,12 @@ WHERE  v.option_group_id = g.id
    *   the option group ID
    */
   public static function createAssoc($groupName, &$values, &$defaultID, $groupTitle = NULL) {
+    // @TODO: This causes a problem in multilingual
+    // (https://github.com/civicrm/civicrm-core/pull/17228), but is needed in
+    // order to be able to remove currencies once added.
+    if (!CRM_Core_I18n::isMultiLingual()) {
+      self::deleteAssoc($groupName);
+    }
     if (!empty($values)) {
       $group = new CRM_Core_DAO_OptionGroup();
       $group->name = $groupName;
@@ -552,11 +558,8 @@ ORDER BY v.weight
   /**
    * @param string $groupName
    * @param string $operator
-   *
-   * @deprecated
    */
   public static function deleteAssoc($groupName, $operator = "=") {
-    CRM_Core_Error::deprecatedFunctionWarning('unused function');
     $query = "
 DELETE g, v
   FROM civicrm_option_group g,

--- a/tests/phpunit/CRM/Admin/Form/Setting/LocalizationTest.php
+++ b/tests/phpunit/CRM/Admin/Form/Setting/LocalizationTest.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * @group headless
+ */
+class CRM_Admin_Form_Setting_LocalizationTest extends CiviUnitTestCase {
+
+  /**
+   * Test adding and removing a currency.
+   */
+  public function testUpdateCurrencies() {
+    CRM_Admin_Form_Setting_Localization::updateEnabledCurrencies(['USD', 'CAD'], 'USD');
+    CRM_Core_OptionGroup::flushAll();
+    $currencies = array_keys(CRM_Core_OptionGroup::values('currencies_enabled'));
+    $this->assertEquals(['CAD', 'USD'], $currencies, 'Unable to add a currency.');
+
+    // Now try to remove it.
+    CRM_Admin_Form_Setting_Localization::updateEnabledCurrencies(['USD'], 'USD');
+    CRM_Core_OptionGroup::flushAll();
+    $currencies = array_keys(CRM_Core_OptionGroup::values('currencies_enabled'));
+    $this->assertEquals(['USD'], $currencies, 'Unable to remove a currency.');
+
+    // Note in the form there's code to prevent removing the default. The
+    // function we're testing here isn't the full form so we're not testing
+    // that.
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/financial/-/issues/175

Before
----------------------------------------
1. Add a currency on the Localization settings page. Save the form.
2. Go back to the form and remove the currency you added. Save the form.
3. Go back to the form - it's still there!

After
----------------------------------------
Can remove it.

Technical Details
----------------------------------------
In https://github.com/civicrm/civicrm-core/pull/17228 a problem with multilingual was fixed but in the process made the function always additive. This PR doesn't address the multilingual problem and just avoids it by only clearing out the previous values if it's not a multilingual site. So it's a half-fix but I don't know what to do about the multilingual part, and it's no worse than before on those sites.

Comments
----------------------------------------
Has test