### PR TITLE
AngularLoader - Emit warning when setModules method is used.

### DIFF
--- a/Civi/Angular/AngularLoader.php
+++ b/Civi/Angular/AngularLoader.php
@@ -345,11 +345,13 @@ class AngularLoader {
    * Replace all previously set modules.
    *
    * Use with caution, as it can cause conflicts with other extensions who have added modules.
-   *
+   * @internal
+   * @deprecated
    * @param array $modules
    * @return AngularLoader
    */
   public function setModules($modules) {
+    \CRM_Core_Error::deprecatedFunctionWarning('addModules');
     $this->modules = $modules;
     return $this;
   }

--- a/tests/phpunit/Civi/Angular/LoaderTest.php
+++ b/tests/phpunit/Civi/Angular/LoaderTest.php
@@ -47,9 +47,9 @@ class LoaderTest extends \CiviUnitTestCase {
    */
   public function testSettingFactory($module, $expectedSettingCount, $expectedCallbackCount, $expectedPermissions) {
     $loader = new \Civi\Angular\AngularLoader();
-    $loader->setModules([$module]);
+    $loader->addModules([$module]);
     $loader->useApp();
-    // Load triggers a depreaction notice, use @ to suppress it for the test.
+    // Load triggers a deprecation notice, use @ to suppress it for the test.
     @$loader->load();
 
     // Run factory callbacks


### PR DESCRIPTION
Overview
----------------------------------------
Emit warning when extensions do something that could potentially cause problems with other extensions.