### PR TITLE
Show smarty E-notices when in debug mode

### DIFF
--- a/CRM/Core/Smarty.php
+++ b/CRM/Core/Smarty.php
@@ -147,6 +147,10 @@ class CRM_Core_Smarty extends Smarty {
     $this->load_filter('pre', 'resetExtScope');
 
     $this->assign('crmPermissions', new CRM_Core_Smarty_Permissions());
+
+    if ($config->debug) {
+      $this->error_reporting = E_ALL;
+    }
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Shows php notices (e.g. "undefined variable") when the system is in debug mode.

Before
----------------------------------------
Notices always hidden.

After
----------------------------------------
Let the games begin.