### PR TITLE
Remove unreachable code from admin page

### DIFF
--- a/CRM/Admin/Page/Admin.php
+++ b/CRM/Admin/Page/Admin.php
@@ -28,8 +28,6 @@ class CRM_Admin_Page_Admin extends CRM_Core_Page {
   public function run() {
     Civi::resources()->addStyleFile('civicrm', 'css/admin.css');
 
-    $this->assign('registerSite', htmlspecialchars('https://civicrm.org/register-your-site?src=iam&sid=' . CRM_Utils_System::getSiteID()));
-
     $groups = [
       'Customize Data and Screens' => ts('Customize Data and Screens'),
       'Communications' => ts('Communications'),

--- a/templates/CRM/Admin/Page/Admin.tpl
+++ b/templates/CRM/Admin/Page/Admin.tpl
@@ -8,16 +8,6 @@
  +--------------------------------------------------------------------+
 *}
 {* Displays Administer CiviCRM Control Panel *}
-{if $newer_civicrm_version}
-    <div class="messages status no-popup">
-      <table>
-        <tr><td class="tasklist">
-          {ts 1=$registerSite}Have you registered this site at CiviCRM.org? If not, please help strengthen the CiviCRM ecosystem by taking a few minutes to <a href="%1" target="_blank">fill out the site registration form</a>. The information collected will help us prioritize improvements, target our communications and build the community. If you have a technical role for this site, be sure to check "Keep in Touch" to receive technical updates (a low volume mailing list).{/ts}</td>
-        </tr>
-      </table>
-    </div>
-{/if}
-
 <div class="crm-content-block">
 {foreach from=$adminPanel key=groupName item=group}
 <div id="admin-section-{$groupName}">


### PR DESCRIPTION
Overview
----------------------------------------
Removes some template code which was never displayed anywhere.

Before
----------------------------------------
Unreachable code - the variable `$newer_civicrm_version` is never assigned to the template.

After
----------------------------------------
Gone.