### PR TITLE
dev/core#2657 trigger pre hook on LineItem delete

### DIFF
--- a/CRM/Price/BAO/LineItem.php
+++ b/CRM/Price/BAO/LineItem.php
@@ -346,6 +346,11 @@ WHERE li.contribution_id = %1";
       $entityId = [$entityId];
     }
 
+    $params = [];
+    foreach ($entityId as $id) {
+      CRM_Utils_Hook::pre('delete', 'LineItem', $id, $params);
+    }
+
     $query = "DELETE FROM civicrm_line_item where entity_id IN ('" . implode("','", $entityId) . "') AND entity_table = '$entityTable'";
     $dao = CRM_Core_DAO::executeQuery($query);
     return TRUE;


### PR DESCRIPTION
Overview
----------------------------------------
Trigger the pre hook when a line item is deleted.

Before
----------------------------------------
Pre hook is not triggered.

After
----------------------------------------
Pre hook is triggered.

Technical Details
----------------------------------------
The line item delete method (CRM_Price_BAO_LineItem::deleteLineItems()) supports an array of IDs. To retain the expected behavior for the pre hook (which works with a single record at a time), we cycle through the IDs and trigger the hook for each ID separately.