### PR TITLE
[NFC] Fixes an issue in this unit test where we are trying to do an a…

### DIFF
--- a/tests/phpunit/api/v3/AddressTest.php
+++ b/tests/phpunit/api/v3/AddressTest.php
@@ -370,7 +370,7 @@ class api_v3_AddressTest extends CiviUnitTestCase {
       'sequential' => 1,
     ];
     $result = $this->callAPISuccessGetCount('Address', $params, 0);
-    $this->assertEquals(0, $result['count']);
+    $this->assertEquals(0, $result);
   }
 
   /**


### PR DESCRIPTION
…rray acess on an integer

Overview
----------------------------------------
This fixes the following test failure

```
api_v3_AddressTest::testGetAddressLikeFail with data set "APIv3" (3)
Trying to access array offset on value of type int

/home/jenkins/bknix-edge/build/build-2/web/sites/all/modules/civicrm/tests/phpunit/api/v3/AddressTest.php:373
/home/jenkins/bknix-edge/build/build-2/web/sites/all/modules/civicrm/tests/phpunit/CiviTest/CiviUnitTestCase.php:239
/home/jenkins/bknix-edge/extern/phpunit8/phpunit8.phar:671
```

Before
----------------------------------------
Test fails on php8 and warning issued in php7.4

After
----------------------------------------
Test passes on php8 and php7.4