### PR TITLE
[REF] Remove always false if

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -3407,6 +3407,10 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
     $entityID[] = $entityId;
     if (!empty($additionalParticipantId)) {
       $entityID += $additionalParticipantId;
+      // build line item array if necessary
+      if ($additionalParticipantId) {
+        CRM_Price_BAO_LineItem::getLineItemArray($params, $entityID, str_replace('civicrm_', '', $entityTable));
+      }
     }
     // prevContribution appears to mean - original contribution object- ie copy of contribution from before the update started that is being updated
     if (empty($params['prevContribution'])) {
@@ -3414,11 +3418,6 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
     }
 
     $statusId = $params['contribution']->contribution_status_id;
-
-    // build line item array if its not set in $params
-    if (empty($params['line_item']) || $additionalParticipantId) {
-      CRM_Price_BAO_LineItem::getLineItemArray($params, $entityID, str_replace('civicrm_', '', $entityTable), $isRelatedId);
-    }
 
     if ($contributionStatus != 'Failed' &&
       !($contributionStatus == 'Pending' && !$params['contribution']->is_pay_later)


### PR DESCRIPTION

Overview
----------------------------------------
[REF] Remove always false if 

Before
----------------------------------------
recordFinancialAccounts checks is line items is empty - but it never is due to [these lines](https://github.com/civicrm/civicrm-core/blob/efac3dcfd15c0d73422421bfd984710df368e755/CRM/Contribute/BAO/Contribution.php#L174-L177)

After
----------------------------------------
The check for empty is removed, the code is moved into the if that would make it possibly true.

Technical Details
----------------------------------------
We recently added code to ensure line_item is always populated
before this function is called

https://github.com/civicrm/civicrm-core/blob/efac3dcfd15c0d73422421bfd984710df368e755/CRM/Contribute/BAO/Contribution.php#L174-L177

(it is only called from one place in core which is a few lines further down)

So line items is never empty at this point

Comments
----------------------------------------
There is more cleanup that can follow on from this - ie removing more unused stuff - but I wanted to keep this easy to review