### PR TITLE
Fix bug where only one participant registration is completed

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4189,11 +4189,13 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
       );
     }
 
-    $participantPayment = civicrm_api3('ParticipantPayment', 'get', ['contribution_id' => $contributionID, 'return' => 'participant_id', 'sequential' => 1])['values'];
-    if (!empty($participantPayment) && empty($input['IAmAHorribleNastyBeyondExcusableHackInTheCRMEventFORMTaskClassThatNeedsToBERemoved'])) {
-      $participantParams['id'] = $participantPayment[0]['participant_id'];
-      $participantParams['status_id'] = 'Registered';
-      civicrm_api3('Participant', 'create', $participantParams);
+    $participantPayments = civicrm_api3('ParticipantPayment', 'get', ['contribution_id' => $contributionID, 'return' => 'participant_id', 'sequential' => 1])['values'];
+    if (!empty($participantPayments) && empty($input['IAmAHorribleNastyBeyondExcusableHackInTheCRMEventFORMTaskClassThatNeedsToBERemoved'])) {
+      foreach ($participantPayments as $participantPayment) {
+        $participantParams['id'] = $participantPayment['participant_id'];
+        $participantParams['status_id'] = 'Registered';
+        civicrm_api3('Participant', 'create', $participantParams);
+      }
     }
 
     $contributionParams['id'] = $contributionID;
@@ -5337,9 +5339,7 @@ LIMIT 1;";
       'module' => 'CiviEvent',
     ];
 
-    list($custom_pre_id,
-      $custom_post_ids
-      ) = CRM_Core_BAO_UFJoin::getUFGroupIds($ufJoinParams);
+    [$custom_pre_id, $custom_post_ids] = CRM_Core_BAO_UFJoin::getUFGroupIds($ufJoinParams);
 
     $values['custom_pre_id'] = $custom_pre_id;
     $values['custom_post_id'] = $custom_post_ids;

--- a/tests/phpunit/CRMTraits/Financial/OrderTrait.php
+++ b/tests/phpunit/CRMTraits/Financial/OrderTrait.php
@@ -218,7 +218,7 @@ trait CRMTraits_Financial_OrderTrait {
    */
   protected function createEventOrder($orderParams = []) {
     $this->ids['Contribution'][0] = $this->callAPISuccess('Order', 'create', array_merge($this->getParticipantOrderParams(), $orderParams))['id'];
-    $this->ids['Participant'][0] = $this->callAPISuccessGetValue('ParticipantPayment', ['return' => 'participant_id', 'contribution_id' => $this->ids['Contribution'][0]]);
+    $this->ids['Participant'][0] = $this->callAPISuccessGetValue('ParticipantPayment', ['options' => ['limit' => 1], 'return' => 'participant_id', 'contribution_id' => $this->ids['Contribution'][0]]);
   }
 
   /**

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -3534,7 +3534,6 @@ VALUES
    * @throws \CRM_Core_Exception
    */
   protected function getParticipantOrderParams(): array {
-    $this->_contactId = $this->individualCreate();
     $event = $this->eventCreate();
     $this->_eventId = $event['id'];
     $eventParams = [
@@ -3544,23 +3543,13 @@ VALUES
     ];
     $this->callAPISuccess('event', 'create', $eventParams);
     $priceFields = $this->createPriceSet('event', $this->_eventId);
-    $participantParams = [
-      'financial_type_id' => 4,
-      'event_id' => $this->_eventId,
-      'role_id' => 1,
-      'status_id' => 14,
-      'fee_currency' => 'USD',
-      'contact_id' => $this->_contactId,
-    ];
-    $participant = $this->callAPISuccess('Participant', 'create', $participantParams);
     $orderParams = [
       'total_amount' => 300,
       'currency' => 'USD',
-      'contact_id' => $this->_contactId,
+      'contact_id' => $this->individualCreate(),
       'financial_type_id' => 4,
       'contribution_status_id' => 'Pending',
       'contribution_mode' => 'participant',
-      'participant_id' => $participant['id'],
     ];
     foreach ($priceFields['values'] as $key => $priceField) {
       $orderParams['line_items'][] = [
@@ -3577,7 +3566,14 @@ VALUES
             'entity_table' => 'civicrm_participant',
           ],
         ],
-        'params' => $participant,
+        'params' => [
+          'financial_type_id' => 4,
+          'event_id' => $this->_eventId,
+          'role_id' => 1,
+          'status_id' => 14,
+          'fee_currency' => 'USD',
+          'contact_id' => $this->individualCreate(),
+        ],
       ];
     }
     return $orderParams;

--- a/tests/phpunit/api/v3/PaymentTest.php
+++ b/tests/phpunit/api/v3/PaymentTest.php
@@ -497,9 +497,8 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
     $paymentParticipant = [
       'contribution_id' => $contribution['id'],
     ];
-    $participantPayment = $this->callAPISuccess('ParticipantPayment', 'getsingle', $paymentParticipant);
-    $participant = $this->callAPISuccess('participant', 'get', ['id' => $participantPayment['participant_id']]);
-    $this->assertEquals('Registered', $participant['values'][$participant['id']]['participant_status']);
+    $this->callAPISuccessGetCount('ParticipantPayment', $paymentParticipant, 2);
+    $this->callAPISuccessGetCount('Participant', ['status_id' => 'Registered'], 2);
   }
 
   /**
@@ -588,9 +587,8 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
     $paymentParticipant = [
       'contribution_id' => $contribution['id'],
     ];
-    $participantPayment = $this->callAPISuccess('ParticipantPayment', 'getsingle', $paymentParticipant);
-    $participant = $this->callAPISuccess('participant', 'get', ['id' => $participantPayment['participant_id']]);
-    $this->assertEquals('Registered', $participant['values'][$participant['id']]['participant_status']);
+    $this->callAPISuccessGetCount('ParticipantPayment', $paymentParticipant, 2);
+    $this->callAPISuccessGetCount('participant', ['status_id' => 'Registered'], 2);
   }
 
   /**


### PR DESCRIPTION

Overview
----------------------------------------
Fix bug where only one participant registration is completed

This started out as a fix to the test data but it turned out that it was masking a real bug

Before
----------------------------------------
Pending order with 2 participant line items - on Complete contribution only 1 is updated to 'Registered

After
----------------------------------------
Both are, tested

Technical Details
----------------------------------------
Our test data was creating 2 registrations for the same person
for the same event on 2 different line items - this isn't valid
and it doesn't pass heightened strictness tests

Comments
----------------------------------------
@monishdeb can you take a look at this?