### PR TITLE
[php8-compact] Fix APIv4 Group Concat Test by setting dataType to be …

### DIFF
--- a/Civi/Api4/Query/SqlFunctionGROUP_CONCAT.php
+++ b/Civi/Api4/Query/SqlFunctionGROUP_CONCAT.php
@@ -59,6 +59,10 @@ class SqlFunctionGROUP_CONCAT extends SqlFunction {
     // By default, values are split into an array and formatted according to the field's dataType
     if (!$exprArgs[2]['prefix']) {
       $value = explode(\CRM_Core_DAO::VALUE_SEPARATOR, $value);
+      // If the first expression is another sqlFunction then unset $dataType to preserve raw string
+      if ($exprArgs[0]['expr'][0] instanceof SqlFunction) {
+        $dataType = NULL;
+      }
     }
     // If using custom separator, unset $dataType to preserve raw string
     else {


### PR DESCRIPTION
…NULL if the first expression is a SQL Function

Overview
----------------------------------------
This fixes the following test failure on php8

```
api\v4\Action\SqlFunctionTest::testGroupAggregates
Failed asserting that an array contains '1, 122, 100.00'.

/home/jenkins/bknix-edge/build/build-2/web/sites/all/modules/civicrm/tests/phpunit/api/v4/Action/SqlFunctionTest.php:95
/home/jenkins/bknix-edge/extern/phpunit8/phpunit8.phar:671
```

Before
----------------------------------------
Test fails on php8

After
----------------------------------------
Test passes on php8

ping @colemanw 