### PR TITLE
[REF] Follow up clean up - remove contribution_mode

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -3377,7 +3377,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
    * @return null|\CRM_Core_BAO_FinancialTrxn
    */
   public static function recordFinancialAccounts(&$params, $financialTrxnValues = NULL) {
-    $skipRecords = $update = $return = $isRelatedId = FALSE;
+    $skipRecords = $update = $return = FALSE;
     $isUpdate = !empty($params['prevContribution']);
 
     $additionalParticipantId = [];
@@ -3398,10 +3398,6 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
     else {
       $entityId = $params['contribution']->id;
       $entityTable = 'civicrm_contribution';
-    }
-
-    if (CRM_Utils_Array::value('contribution_mode', $params) == 'membership') {
-      $isRelatedId = TRUE;
     }
 
     $entityID[] = $entityId;

--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -1585,9 +1585,6 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
         $params['participant_id'] = $pId;
         $params['skipLineItem'] = 1;
       }
-      elseif ($isRelatedId) {
-        $params['contribution_mode'] = 'membership';
-      }
       $params['line_item'] = $lineItem;
       $params['payment_processor_id'] = $params['payment_processor'] = $this->_paymentProcessor['id'] ?? NULL;
       $params['tax_amount'] = CRM_Utils_Array::value('tax_amount', $submittedValues, CRM_Utils_Array::value('tax_amount', $this->_values));

--- a/api/v3/Order.php
+++ b/api/v3/Order.php
@@ -102,6 +102,7 @@ function civicrm_api3_order_create(array $params): array {
             }
             $entityParams['participant_status_id'] = $entityParams['participant_status_id'] ?? 'Pending from incomplete transaction';
             $entityParams['status_id'] = $entityParams['participant_status_id'];
+            $params['contribution_mode'] = 'participant';
             break;
 
           case 'membership':
@@ -116,7 +117,6 @@ function civicrm_api3_order_create(array $params): array {
         if ($supportedEntity) {
           $entityParams['skipLineItem'] = TRUE;
           $entityResult = civicrm_api3($entity, 'create', $entityParams);
-          $params['contribution_mode'] = $entity;
           $entityIds[] = $params[$entity . '_id'] = $entityResult['id'];
           foreach ($lineItems['line_item'] as &$items) {
             $items['entity_id'] = $entityResult['id'];

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -3509,7 +3509,6 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
       'payment_processor_id' => $this->paymentProcessorID,
       'currency' => 'USD',
       'contribution_page_id' => $this->_ids['contribution_page'],
-      'contribution_mode' => 'membership',
       'source' => 'Membership Signup and Renewal',
     ];
 


### PR DESCRIPTION

Overview
----------------------------------------
Removes legacy parameter

Before
----------------------------------------
'contribution_mode' set to reflect line item 'type' but no longer used for membership

After
----------------------------------------
poof

Technical Details
----------------------------------------
Contribution mode was only set to be used to set isRelatedID
here https://github.com/civicrm/civicrm-core/pull/20653/files#diff-4c9d0b1abe07057a4eea2b47bc627eecb95face8ed8d86c1c005312a52cca811L3420

but we removed that....

Comments
----------------------------------------
@monishdeb can you check this?