### PR TITLE
Fix - changing participant status only when needed

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4190,7 +4190,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
     }
 
     $participantPayment = civicrm_api3('ParticipantPayment', 'get', ['contribution_id' => $contributionID, 'return' => 'participant_id', 'sequential' => 1])['values'];
-    if (!empty($participantPayment) && empty($input['IAmAHorribleNastyBeyondExcusableHackInTheCRMEventFORMTaskClassThatNeedsToBERemoved'])) {
+    if (empty($participantPayment) && !empty($input['IAmAHorribleNastyBeyondExcusableHackInTheCRMEventFORMTaskClassThatNeedsToBERemoved'])) {
       $participantParams['id'] = $participantPayment[0]['participant_id'];
       $participantParams['status_id'] = 'Registered';
       civicrm_api3('Participant', 'create', $participantParams);


### PR DESCRIPTION
Before
----------------------------------------
Completing of participant payment always update participants status to registered

After
----------------------------------------
Participant status is not changed, only create a new participant if no one exists.

Comments
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/2658
