### PR TITLE
dev/core#2604 Apply upstream patch to allow single quotes in return p…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -282,7 +282,8 @@
         "Add in CiviCRM custom error message for CRM-8744": "https://raw.githubusercontent.com/civicrm/civicrm-core/a6a0ff13d2a155ad962529595dceaef728116f96/tools/scripts/composer/patches/net-smtp-patch.patch"
       },
       "zetacomponents/mail": {
-        "CiviCRM Custom Patches for ZetaCompoents mail": "https://raw.githubusercontent.com/civicrm/civicrm-core/9d93748a36c7c5d44422911db1c98fb2f7067b34/tools/scripts/composer/patches/civicrm-custom-patches-zetacompoents-mail.patch"
+        "CiviCRM Custom Patches for ZetaCompoents mail": "https://raw.githubusercontent.com/civicrm/civicrm-core/9d93748a36c7c5d44422911db1c98fb2f7067b34/tools/scripts/composer/patches/civicrm-custom-patches-zetacompoents-mail.patch",
+        "Allow single quotes to be used in return path": "https://github.com/zetacomponents/Mail/pull/86.patch"
       }
     },
     "compile-includes": ["ext/greenwich/composer.compile.json"],

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "730e40c933b40ec711ba59c7b333400e",
+    "content-hash": "e7cca2de5a5b2bd54ac4c14b677845ed",
     "packages": [
         {
             "name": "adrienrn/php-mimetyper",
@@ -3970,11 +3970,6 @@
                 "zetacomponents/unit-test": "*"
             },
             "type": "library",
-            "extra": {
-                "patches_applied": {
-                    "CiviCRM Custom Patches for ZetaCompoents mail": "https://raw.githubusercontent.com/civicrm/civicrm-core/9d93748a36c7c5d44422911db1c98fb2f7067b34/tools/scripts/composer/patches/civicrm-custom-patches-zetacompoents-mail.patch"
-                }
-            },
             "autoload": {
                 "classmap": [
                     "src"
@@ -4027,6 +4022,10 @@
             ],
             "description": "The component allows you construct and/or parse Mail messages conforming to  the mail standard. It has support for attachments, multipart messages and HTML  mail. It also interfaces with SMTP to send mail or IMAP, POP3 or mbox to  retrieve e-mail.",
             "homepage": "https://github.com/zetacomponents",
+            "support": {
+                "issues": "https://github.com/zetacomponents/Mail/issues",
+                "source": "https://github.com/zetacomponents/Mail/tree/1.9.2"
+            },
             "time": "2020-06-13T12:38:26+00:00"
         }
     ],


### PR DESCRIPTION
…atch emails

Overview
----------------------------------------
This applies the patch that has been merged up stream to permit return paths with single quotes to be acceptable

Before
----------------------------------------
Return paths with a single quote in the before the @ part don't work

After
----------------------------------------
They do work now


upstream PR is https://github.com/zetacomponents/Mail/pull/86

ping @eileenmcnaughton @totten 