### PR TITLE
Move determination of priceSetID to the internal order class

### DIFF
--- a/CRM/Member/Form.php
+++ b/CRM/Member/Form.php
@@ -490,6 +490,7 @@ class CRM_Member_Form extends CRM_Contribute_Form_AbstractEditPayment {
    * @param array $formValues
    *
    * @return array
+   * @throws \API_Exception
    */
   protected function setPriceSetParameters(array $formValues): array {
     // process price set and get total amount and line items.
@@ -498,12 +499,9 @@ class CRM_Member_Form extends CRM_Contribute_Form_AbstractEditPayment {
     $priceSetDetails = $this->getPriceSetDetails($formValues);
     $this->_priceSet = $priceSetDetails[$this->_priceSetId];
     $this->order = new CRM_Financial_BAO_Order();
-    $this->order->setPriceSelectionFromUnfilteredInput($formValues);
-    $this->order->setPriceSetID($this->getPriceSetID($formValues));
     $this->order->setForm($this);
-    if ($priceSetDetails[$this->order->getPriceSetID()]['is_quick_config'] && isset($formValues['total_amount'])) {
-      // Amount overrides only permitted on quick config.
-      // Possibly Order object should enforce this...
+    $this->order->setPriceSelectionFromUnfilteredInput($formValues);
+    if (isset($formValues['total_amount'])) {
       $this->order->setOverrideTotalAmount((float) $formValues['total_amount']);
     }
     $this->order->setOverrideFinancialTypeID((int) $formValues['financial_type_id']);

--- a/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
@@ -2120,7 +2120,7 @@ Price Field - Price Field 1        1   $ 100.00      $ 100.00
     ];
 
     $form = new CRM_Contribute_Form_Contribution();
-    $this->assertSame([], $form->formRule($fields, [], $form));
+    $this->assertSame([], $form::formRule($fields, [], $form));
   }
 
   /**


### PR DESCRIPTION

Overview
----------------------------------------
This moves some functionality from the form to where we can start to use if from the order api.

I also added more 'internal' commenting. This is implicitly the case but
I think it would be tempting to use this class and the comments at the top
of the class saying not to could be missed

Before
----------------------------------------
Calculation of price set if from line items on the form

After
----------------------------------------
Moved to the BAO_Order internal helper object

Technical Details
----------------------------------------
Note this object is used from very limited places with very heavy test coverage - notably in the `CRM_Member_Form_MembershipTest` and `CRM_Member_Form_MembershipRenewalTest` - the altered code is in their parent class

Comments
----------------------------------------
