### PR TITLE
Deprecate passing in 'null' for tax

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -186,6 +186,9 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution {
         $lineTotal += (float) ($lineItem['line_total'] ?? 0);
       }
     }
+    if (($params['tax_amount'] ?? '') === 'null') {
+      CRM_Core_Error::deprecatedWarning('tax_amount should be not passed in (preferable) or a float');
+    }
     if (!isset($params['tax_amount']) && $setPrevContribution && (isset($params['total_amount']) ||
      isset($params['financial_type_id']))) {
       $params['tax_amount'] = $taxAmount;

--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -1446,7 +1446,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
         }
         else {
           $lineItems[$itemId]['tax_rate'] = $lineItems[$itemId]['tax_amount'] = "";
-          $submittedValues['tax_amount'] = 'null';
+          $submittedValues['tax_amount'] = 0;
         }
         if ($lineItems[$itemId]['tax_rate']) {
           $lineItems[$itemId]['tax_amount'] = ($lineItems[$itemId]['tax_rate'] / 100) * $lineItems[$itemId]['line_total'];


### PR DESCRIPTION


Overview
----------------------------------------
Deprecate passing in 'null' for tax

Before
----------------------------------------
null is sneakily quiet on php 7.x & throws jenkins for an 8ball on 8.x

After
----------------------------------------
null will not be tolerated

Technical Details
----------------------------------------
This is the source of the php8 test fails -and it's wrong - it should be 0 not null

Comments
----------------------------------------
@seamuslee001 this should drag them out into php7 visibility