### PR TITLE
dev/event#58 Ensure custom data is not saved to template's row

### DIFF
--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -994,6 +994,15 @@ WHERE civicrm_event.is_active = 1
     $copyEvent->save();
 
     if ($blockCopyOfCustomValue) {
+      foreach ($params['custom'] as &$values) {
+        foreach ($values as &$value) {
+          // Ensure we don't copy over the template's id if it is passed in
+          // This is a bit hacky but it's unclear what the
+          // right behaviour is given the whole 'custom'
+          // field is form layer formatting that is reaching the BAO.
+          $value['id'] = NULL;
+        }
+      }
       CRM_Core_BAO_CustomValueTable::store($params['custom'], 'civicrm_event', $copyEvent->id);
     }
 

--- a/Civi/Test/Api3TestTrait.php
+++ b/Civi/Test/Api3TestTrait.php
@@ -228,6 +228,9 @@ trait Api3TestTrait {
     $params += [
       'version' => $this->_apiversion,
     ];
+    if (!empty($this->isGetSafe) && !isset($params['return'])) {
+      $params['return'] = 'id';
+    }
     $result = $this->civicrm_api($entity, 'getsingle', $params);
     if (!is_array($result) || !empty($result['is_error']) || isset($result['values'])) {
       $unfilteredResult = $this->civicrm_api($entity, 'get', ['version' => $this->_apiversion]);

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -163,6 +163,23 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
   protected $isLocationTypesOnPostAssert = TRUE;
 
   /**
+   * Has the test class been verified as 'getsafe'.
+   *
+   * If a class is getsafe it means that where
+   * callApiSuccess is called 'return' is specified or 'return' =>'id'
+   * can be added by that function. This is part of getting away
+   * from open-ended get calls.
+   *
+   * Eventually we want to not be doing these in our test classes & start
+   * to work to not do them in our main code base. Note they mainly
+   * cause issues for activity.get and contact.get as these are where the
+   * too many joins limit is most likely to be hit.
+   *
+   * @var bool
+   */
+  protected $isGetSafe = FALSE;
+
+  /**
    * Class used for hooks during tests.
    *
    * This can be used to test hooks within tests. For example in the ACL_PermissionTrait:


### PR DESCRIPTION

Overview
----------------------------------------
dev/event#58 Ensure custom data is not saved to template's row

Before
----------------------------------------
Create a new set of custom fields (I've been using text, date and select inputs in my tests)
Create a new event template and fill out all necessary inputs (I've also entered something in the title, summary and description).
Create a new event using the newly created template. Enter something in all necessary fields as well as in the custom fields.
Click 'Continue'
Return to 'Info and Settings' - the data entered in the custom fields is gone :/
Open the template in edit mode. The custom data we previously entered in the event is here now

After
----------------------------------------
Saves to event

Technical Details
----------------------------------------
This ensures than when we are copying (implicity a create-new-action) we do not
update an existing row in the custom data table by explicity unsetting the
id in the copy function. This has been bouncey behaviour because
the formatting for form purposes relies on form type formatting and yet
for save purposes it's not really fit for purpose. Although a bit
hacky this approach should be robust & avoids a re-write on the form


Comments
----------------------------------------
