### PR TITLE
Make Order api easier to use for default price set

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -194,7 +194,9 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution {
       $params['tax_amount'] = $taxAmount;
       $params['total_amount'] = $taxAmount + $lineTotal;
     }
-    if (isset($params['tax_amount']) && $params['tax_amount'] != $taxAmount && empty($params['skipLineItem'])) {
+    if (isset($params['tax_amount']) && empty($params['skipLineItem'])
+      && !CRM_Utils_Money::equals($params['tax_amount'], $taxAmount, ($params['currency'] ?? Civi::settings()->get('defaultCurrency')))
+    ) {
       CRM_Core_Error::deprecatedWarning('passing in incorrect tax amounts is deprecated');
     }
 
@@ -4401,9 +4403,6 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
 
     foreach ($params['line_items'] as &$lineItems) {
       foreach ($lineItems['line_item'] as &$item) {
-        if (empty($item['financial_type_id'])) {
-          $item['financial_type_id'] = $params['financial_type_id'];
-        }
         $lineItemAmount += $item['line_total'] + ($item['tax_amount'] ?? 0.00);
       }
     }

--- a/api/v3/Order.php
+++ b/api/v3/Order.php
@@ -76,21 +76,19 @@ function civicrm_api3_order_create(array $params): array {
   $entity = NULL;
   $entityIds = [];
   $params['contribution_status_id'] = 'Pending';
-  $priceSetID = NULL;
+  $order = new CRM_Financial_BAO_Order();
+  $order->setDefaultFinancialTypeID($params['financial_type_id'] ?? NULL);
 
   if (!empty($params['line_items']) && is_array($params['line_items'])) {
     CRM_Contribute_BAO_Contribution::checkLineItems($params);
-    foreach ($params['line_items'] as $lineItems) {
-      $entityParams = $lineItems['params'] ?? [];
-      if (!empty($entityParams) && !empty($lineItems['line_item'])) {
-        $item = reset($lineItems['line_item']);
-        if (!empty($item['membership_type_id'])) {
-          $entity = 'membership';
-        }
-        else {
-          $entity = str_replace('civicrm_', '', $item['entity_table']);
-        }
+    foreach ($params['line_items'] as $index => $lineItems) {
+      foreach ($lineItems['line_item'] as $innerIndex => $lineItem) {
+        $lineIndex = $index . '+' . $innerIndex;
+        $order->setLineItem($lineItem, $lineIndex);
       }
+
+      $entityParams = $lineItems['params'] ?? [];
+      $entity = $order->getLineItemEntity($lineIndex);
 
       if ($entityParams) {
         $supportedEntity = TRUE;
@@ -118,23 +116,20 @@ function civicrm_api3_order_create(array $params): array {
           $entityResult = civicrm_api3($entity, 'create', $entityParams);
           $params['contribution_mode'] = $entity;
           $entityIds[] = $params[$entity . '_id'] = $entityResult['id'];
-          foreach ($lineItems['line_item'] as &$items) {
-            $items['entity_id'] = $entityResult['id'];
+          foreach ($lineItems['line_item'] as $innerIndex => $lineItem) {
+            $lineIndex = $index . '+' . $innerIndex;
+            $order->setLineItemValue('entity_id', $entityResult['id'], $lineIndex);
           }
         }
       }
-
-      if (empty($priceSetID)) {
-        $item = reset($lineItems['line_item']);
-        $priceSetID = (int) civicrm_api3('PriceField', 'getvalue', [
-          'return' => 'price_set_id',
-          'id' => $item['price_field_id'],
-        ]);
-        $params['line_item'][$priceSetID] = [];
-      }
-      $params['line_item'][$priceSetID] = array_merge($params['line_item'][$priceSetID], $lineItems['line_item']);
     }
+    $priceSetID = $order->getPriceSetID();
+    $params['line_item'][$priceSetID] = $order->getLineItems();
   }
+  else {
+    $order->setPriceSetToDefault('contribution');
+  }
+
   $contributionParams = $params;
   // If this is nested we need to set sequential to 0 as sequential handling is done
   // in create_success & id will be miscalculated...
@@ -149,7 +144,7 @@ function civicrm_api3_order_create(array $params): array {
   }
 
   $contribution = civicrm_api3('Contribution', 'create', $contributionParams);
-  $contribution['values'][$contribution['id']]['line_item'] = $params['line_item'][$priceSetID] ?? [];
+  $contribution['values'][$contribution['id']]['line_item'] = $order->getLineItems();
 
   // add payments
   if ($entity && !empty($contribution['id'])) {

--- a/tests/phpunit/CRM/Contribute/BAO/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/BAO/ContributionTest.php
@@ -820,8 +820,6 @@ WHERE eft.entity_id = %1 AND ft.to_financial_account_id <> %2";
         $e->getMessage()
       );
     }
-
-    $this->assertEquals(3, $params['line_items'][0]['line_item'][0]['financial_type_id']);
     $params['total_amount'] = 300;
 
     CRM_Contribute_BAO_Contribution::checkLineItems($params);

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -4345,24 +4345,31 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
       'payment_processor_id' => $this->paymentProcessorID,
     ], $generalParams, $recurParams));
 
-    $this->callAPISuccess('membership', 'create', [
-      'contact_id' => $newContact['id'],
-      'contribution_recur_id' => $contributionRecur['id'],
-      'financial_type_id' => 'Member Dues',
-      'membership_type_id' => $membershipType['id'],
-      'num_terms' => 1,
-      'skipLineItem' => TRUE,
-    ]);
-
-    CRM_Price_BAO_LineItem::getLineItemArray($this->_params, NULL, 'membership', $membershipType['id']);
-    $originalContribution = $this->callAPISuccess('contribution', 'create', array_merge(
+    $originalContribution = $this->callAPISuccess('Order', 'create', array_merge(
       $this->_params,
       [
         'contact_id' => $newContact['id'],
         'contribution_recur_id' => $contributionRecur['id'],
         'financial_type_id' => 'Member Dues',
-        'contribution_status_id' => 1,
+        'api.Payment.create' => ['total_amount' => 100, 'payment_instrument_id' => 'Credit card'],
         'invoice_id' => 2345,
+        'line_items' => [
+          [
+            'line_item' => [
+              [
+                'membership_type_id' => $membershipType['id'],
+                'financial_type_id' => 'Member Dues',
+                'line_total' => $generalParams['total_amount'] ?? 100,
+              ],
+            ],
+            'params' => [
+              'contact_id' => $newContact['id'],
+              'contribution_recur_id' => $contributionRecur['id'],
+              'membership_type_id' => $membershipType['id'],
+              'num_terms' => 1,
+            ],
+          ],
+        ],
       ], $generalParams)
     );
     $lineItem = $this->callAPISuccess('LineItem', 'getsingle', []);


### PR DESCRIPTION
Overview
----------------------------------------
This changes the order api so that it is not necessary to figure out the details
of the default price set when using it to create memberships.

I was [digging into places](https://github.com/civicrm/civicrm-core/pull/20678) where line items are not adequately set by the time they reach the inner workings on Contribution.create and they seem to be mostly coming from the unit tests and it's kinda painful to replace them with order.create when we have to calculate so many fields to use it - this reduces the required parameters when relying on the default price set for memberships


Before
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/122693463-138b0900-d28e-11eb-92c4-fd6ca1f9f89b.png)


After
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/122693384-c018bb00-d28d-11eb-971e-f6cf929547aa.png)

Technical Details
----------------------------------------

Comments
----------------------------------------
