### PR TITLE
Syntax error or access violation on D9 views

### DIFF
--- a/CRM/Admin/Form/Setting/UF.php
+++ b/CRM/Admin/Form/Setting/UF.php
@@ -79,7 +79,7 @@ class CRM_Admin_Form_Setting_UF extends CRM_Admin_Form_Setting {
       $tablePrefixes .= "\n  'default' => '$drupal_prefix',";
       $prefix = "";
       if ($config->dsn != $config->userFrameworkDSN) {
-        $prefix = "`{$dsnArray['database']}`.";
+        $prefix = "{$dsnArray['database']}.";
         if ($config->userFramework === 'Backdrop') {
           $prefix = "{$dsnArray['database']}.";
         }


### PR DESCRIPTION
Overview
----------------------------------------
https://civicrm.stackexchange.com/questions/39830/drupal-9-view-shows-permission-denied-for-civicrm-tables
Before
----------------------------------------
SQLSTATE[42000]: Syntax error or access violation: 1142 SELECT command denied to user 'user'@'10.0.2.97' for table 'civicrm_contact': SELECT "civicrm_contact"."id" AS "id", "users_field_data_civicrm_uf_match"."uid" AS "users_field_data_civicrm_uf_match_uid", "contact_id_civicrm_contact"."id" AS "contact_id_civicrm_contact_id", "member_of_contact_id_civicrm_contact"."id" AS "member_of_contact_id_civicrm_contact_id" FROM {civicrm_contact} "civicrm_contact" INNER JOIN {civicrm_uf_match} "civicrm_uf_match" ON civicrm_contact.id = civicrm_uf_match.contact_id INNER JOIN {users_field_data} "users_field_data_civicrm_uf_match" ON civicrm_uf_match.uf_id = users_field_data_civicrm_uf_match.uid LEFT JOIN {civicrm_membership} "contact_id_civicrm_contact" ON civicrm_contact.id = contact_id_civicrm_contact.contact_id LEFT JOIN {civicrm_membership_type} "member_of_contact_id_civicrm_contact" ON civicrm_contact.id = member_of_contact_id_civicrm_contact.member_of_contact_id WHERE (users_field_data_civicrm_uf_match.uid = :users_field_data_uid) LIMIT 1 OFFSET 0; Array ( [:users_field_data_uid] => 3016 )


After
----------------------------------------
No Error
