### PR TITLE
dev/core#2647 - Deprecated call to non-static CRM_Financial_Form_BatchTransaction::links() 

### DIFF
--- a/CRM/Financial/Page/AJAX.php
+++ b/CRM/Financial/Page/AJAX.php
@@ -371,7 +371,7 @@ class CRM_Financial_Page_AJAX {
           $js = "enableActions('x')";
           $row[$financialItem->id]['check'] = "<input type='checkbox' id='mark_x_" . $financialItem->id . "' name='mark_x_" . $financialItem->id . "' value='1' onclick={$js}></input>";
           $row[$financialItem->id]['action'] = CRM_Core_Action::formLink(
-            CRM_Financial_Form_BatchTransaction::links(),
+            (new CRM_Financial_Form_BatchTransaction())->links(),
             NULL,
             [
               'id' => $financialItem->id,
@@ -389,7 +389,7 @@ class CRM_Financial_Page_AJAX {
           $js = "enableActions('y')";
           $row[$financialItem->id]['check'] = "<input type='checkbox' id='mark_y_" . $financialItem->id . "' name='mark_y_" . $financialItem->id . "' value='1' onclick={$js}></input>";
           $row[$financialItem->id]['action'] = CRM_Core_Action::formLink(
-            CRM_Financial_Page_BatchTransaction::links(),
+            (new CRM_Financial_Page_BatchTransaction())->links(),
             NULL,
             [
               'id' => $financialItem->id,
@@ -427,6 +427,7 @@ class CRM_Financial_Page_AJAX {
       if ($financialItem->contact_id) {
         $row[$financialItem->id]['contact_type'] = CRM_Contact_BAO_Contact_Utils::getImage(!empty($row[$financialItem->id]['contact_sub_type']) ? $row[$financialItem->id]['contact_sub_type'] : CRM_Utils_Array::value('contact_type', $row[$financialItem->id]), FALSE, $financialItem->contact_id);
       }
+      // @todo: Is this right? Shouldn't it be adding to the array as we loop?
       $financialitems = $row;
     }
 

--- a/CRM/Financial/Page/BatchTransaction.php
+++ b/CRM/Financial/Page/BatchTransaction.php
@@ -44,6 +44,14 @@ class CRM_Financial_Page_BatchTransaction extends CRM_Core_Page_Basic {
   /**
    * Get action Links.
    *
+   * @todo:
+   * While this function only references static self::$_links, we can't make
+   * the function static because we need to match CRM_Core_Page_Basic. Possibly
+   * the intent was caching, but there's nothing very time-consuming in here
+   * that needs it so do we even need $_links? The variable is public - a quick
+   * look doesn't seem like it's used on its own, but it's hard to fully check
+   * that.
+   *
    * @return array
    *   (reference) of action links
    */

--- a/tests/phpunit/CRM/Financial/Page/AjaxTest.php
+++ b/tests/phpunit/CRM/Financial/Page/AjaxTest.php
@@ -15,6 +15,15 @@
  */
 class CRM_Financial_Page_AjaxTest extends CiviUnitTestCase {
 
+  public function tearDown(): void {
+    $this->quickCleanUpFinancialEntities();
+    $this->quickCleanUp([
+      'civicrm_entity_batch',
+      'civicrm_batch',
+    ]);
+    parent::tearDown();
+  }
+
   /**
    * Test the ajax function to get financial transactions.
    *
@@ -33,10 +42,34 @@ class CRM_Financial_Page_AjaxTest extends CiviUnitTestCase {
     $_REQUEST['return'] = TRUE;
     $json = CRM_Financial_Page_AJAX::getFinancialTransactionsList();
     $json = str_replace(rtrim(CIVICRM_UF_BASEURL, '/'), 'http://FIX ME', $json);
-    $this->assertEquals($json, '{"sEcho": 1, "iTotalRecords": 1, "iTotalDisplayRecords": 1, "aaData": [ ["","<a href=\"/index.php?q=civicrm/profile/view&amp;reset=1&amp;gid=7&amp;id=3&amp;snippet=4&amp;is_show_email_task=1\" class=\"crm-summary-link\"><div'
+    $this->assertEquals('{"sEcho": 1, "iTotalRecords": 1, "iTotalDisplayRecords": 1, "aaData": [ ["","<a href=\"/index.php?q=civicrm/profile/view&amp;reset=1&amp;gid=7&amp;id=3&amp;snippet=4&amp;is_show_email_task=1\" class=\"crm-summary-link\"><div'
     . ' class=\"icon crm-icon Individual-icon\"></div></a>","<a href=/index.php?q=civicrm/contact/view&amp;reset=1&amp;cid=3>Anderson, Anthony</a>","$ 100.00","12345","' . CRM_Utils_Date::customFormat(date('Ymd')) . ' 12:00 AM","' . CRM_Utils_Date::customFormat(date('Ymd')) . ' 12:00 AM",'
     . '"Credit Card","Completed","Donation","<span><a href=\"/index.php?q=civicrm/contact/view/contribution&amp;reset=1&amp;id=1&amp;cid=3&amp;action=view&amp;context=contribution&amp;'
-    . 'selectedChild=contribute\" class=\"action-item crm-hover-button\" title=\'View Contribution\' >View</a></span>"]] }');
+    . 'selectedChild=contribute\" class=\"action-item crm-hover-button\" title=\'View Contribution\' >View</a></span>"]] }', $json);
+  }
+
+  /**
+   * Test getting open batch.
+   */
+  public function testGetFinancialTransactionsListOpenBatch() {
+    $individualID = $this->individualCreate();
+    $this->contributionCreate(['contact_id' => $individualID, 'trxn_id' => 12345]);
+    $batch = $this->callAPISuccess('Batch', 'create', ['title' => 'test', 'status_id' => 'Open']);
+    CRM_Core_DAO::executeQuery("
+     INSERT INTO civicrm_entity_batch (entity_table, entity_id, batch_id)
+     values('civicrm_financial_trxn', 1, 1)
+   ");
+    $_REQUEST['sEcho'] = 1;
+    $_REQUEST['entityID'] = $batch['id'];
+    $_REQUEST['statusID'] = 1;
+    $_REQUEST['notPresent'] = 1;
+    $_REQUEST['return'] = TRUE;
+    $json = CRM_Financial_Page_AJAX::getFinancialTransactionsList();
+    $json = str_replace(rtrim(CIVICRM_UF_BASEURL, '/'), 'http://FIX ME', $json);
+    $this->assertEquals('{"sEcho": 1, "iTotalRecords": 1, "iTotalDisplayRecords": 1, "aaData": [ ["<input type=\'checkbox\' id=\'mark_x_2\' name=\'mark_x_2\' value=\'1\' onclick=enableActions(\'x\')></input>","<a href=\"/index.php?q=civicrm/profile/view&amp;reset=1&amp;gid=7&amp;id=3&amp;snippet=4&amp;is_show_email_task=1\" class=\"crm-summary-link\"><div'
+    . ' class=\"icon crm-icon Individual-icon\"></div></a>","<a href=/index.php?q=civicrm/contact/view&amp;reset=1&amp;cid=3>Anderson, Anthony</a>","$ 5.00","12345","' . CRM_Utils_Date::customFormat(date('Ymd')) . ' 12:00 AM","' . CRM_Utils_Date::customFormat(date('Ymd')) . ' 12:00 AM",'
+    . '"Credit Card","Completed","Donation","<span><a href=\"/index.php?q=civicrm/contact/view/contribution&amp;reset=1&amp;id=1&amp;cid=3&amp;action=view&amp;context=contribution&amp;'
+    . 'selectedChild=contribute\" class=\"action-item crm-hover-button\" title=\'View Contribution\' >View</a><a href=\"#\" class=\"action-item crm-hover-button disable-action\" title=\'Assign Transaction\' onclick = \"assignRemove( 2,\'assign\' );\">Assign</a></span>"]] }', $json);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/2647

Before
----------------------------------------
1. View an accounting batch.
1. `Non-static method CRM_Financial_Form_BatchTransaction::links() should not be called statically in ...\CRM\Financial\Page\AJAX.php:374`

After
----------------------------------------
1. View an accounting batch.

Technical Details
----------------------------------------
While the called function looks like it should be static, the base class says no, so have just converted calls to non-static which the same caller does later a couple lines down already (line 409).

Comments
----------------------------------------
Has test. If you run it before the change it fails on the same line. The existing test represents something but I'm not sure there's a real spot that calls it like that - I didn't look too hard.
