### PR TITLE
Fix sorting for drop triggers

### DIFF
--- a/CRM/Logging/Schema.php
+++ b/CRM/Logging/Schema.php
@@ -240,7 +240,7 @@ AND    (TABLE_NAME LIKE 'log_civicrm_%' $nonStandardTableNameString )
 
     // Sort the table names so the sql output is consistent for those sites
     // loading it asynchronously (using the setting 'logging_no_trigger_permission')
-    ksort($tableNames);
+    asort($tableNames);
     foreach ($tableNames as $table) {
       $validName = CRM_Core_DAO::shortenSQLName($table, 48, TRUE);
 


### PR DESCRIPTION
Overview
----------------------------------------
Fix sorting for drop triggers - sort was recently change in [my pr](https://github.com/civicrm/civicrm-core/pull/20472/files#diff-38921d05e11c37ba518426a68b4d962a6df048cbfc87f41c0e67dd02dc9c86faL247) but I assumed (incorrectly) it should be the same as [for create](https://github.com/civicrm/civicrm-core/pull/20472/files#diff-9ee8e11340d75f427bd6e3c6d9b3d61f59057bd616ccfa22104169292b52e4a2R152) so I changed both in an outburst of heavyhandedness

Before
----------------------------------------
Create triggers alpha sorted but drop triggers are a random

After
----------------------------------------
Drop triggers sorted too....


Technical Details
----------------------------------------
I added a ksort but it should have been an asort - the createTriggers has an array like
['civicrm_acl'] => [.....]

which suits asort but in this location the array is

[0 => 'civicrm_acl', 1 =>.....

so asort is right

Comments
----------------------------------------
This is unlikely to be noticed by anyone other than wmf