### PR TITLE
Ensure custom group name does not conflict with existing field

### DIFF
--- a/CRM/Core/DAO/AllCoreTables.php
+++ b/CRM/Core/DAO/AllCoreTables.php
@@ -311,13 +311,13 @@ class CRM_Core_DAO_AllCoreTables {
   /**
    * Given a brief-name, determine the full class-name.
    *
-   * @param string $daoName
+   * @param string $briefName
    *   Ex: 'Contact'.
    * @return string|CRM_Core_DAO|NULL
    *   Ex: 'CRM_Contact_DAO_Contact'.
    */
-  public static function getFullName($daoName) {
-    return CRM_Utils_Array::value($daoName, self::daoToClass());
+  public static function getFullName($briefName) {
+    return self::daoToClass()[$briefName] ?? NULL;
   }
 
   /**

--- a/tests/phpunit/CRM/Core/BAO/CustomGroupTest.php
+++ b/tests/phpunit/CRM/Core/BAO/CustomGroupTest.php
@@ -651,4 +651,40 @@ class CRM_Core_BAO_CustomGroupTest extends CiviUnitTestCase {
     $this->assertEquals($extractedGetParams[$fieldName], '2017-06-13');
   }
 
+  /**
+   * @return array
+   */
+  public function getGroupNames(): array {
+    $data = [
+      ['Individual', 'first_name', FALSE],
+      ['Organization', 'first_name', FALSE],
+      ['Contact', 'not_first_name', TRUE],
+      ['Contact', 'gender_id', FALSE],
+      ['Activity', 'activity_type_id', FALSE],
+      ['Campaign', 'activity_type_id', TRUE],
+      ['Campaign', 'campaign_type_id', FALSE],
+    ];
+    // Add descriptive keys to data
+    $dataSet = [];
+    foreach ($data as $item) {
+      $dataSet[$item[0] . '.' . $item[1]] = $item;
+    }
+    return $dataSet;
+  }
+
+  /**
+   * @param string $extends
+   * @param string $name
+   * @param bool $isAllowed
+   * @dataProvider getGroupNames
+   */
+  public function testAllowedGroupNames(string $extends, string $name, bool $isAllowed) {
+    $group = new CRM_Core_DAO_CustomGroup();
+    $group->name = $name;
+    $group->extends = $extends;
+    $expectedName = $isAllowed ? $name : $name . '0';
+    CRM_Core_BAO_CustomGroup::validateCustomGroupName($group);
+    $this->assertEquals($expectedName, $group->name);
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Adds validation when creating a new custom group to prevent name conflicts with existing fields.

Technical Details
----------------------------------------
In APIv4, you access custom fields like `myCustomGroup.my_field`. That works as long as the custom group isn't named something like "contact_type" or "activity_type_id" which would lead to very confusing api calls with unpredictable results.

Comments
----------------------------------------
Validates according to the entity being extended.