### PR TITLE
dev/core#2507 Add in is_deleted field so it can be used in where clau…

### DIFF
--- a/tests/phpunit/api/v4/Query/Api4SelectQueryTest.php
+++ b/tests/phpunit/api/v4/Query/Api4SelectQueryTest.php
@@ -119,4 +119,42 @@ FROM civicrm_pledge a',
     }
   }
 
+  public function testIsDeletedPermission(): void {
+    $contact = $this->createLoggedInUser();
+    \CRM_Core_Config::singleton()->userPermissionClass->permissions = ['access CiviCRM', 'view all contacts'];
+    $api = Request::create('Contact', 'get', [
+      'version' => 4,
+      'checkPermissions' => TRUE,
+      'select' => ['id', 'display_name', 'is_deleted'],
+      'where' => [['first_name', '=', 'phoney']],
+    ]);
+    $query = new Api4SelectQuery($api);
+    $query->run();
+    $api = Request::create('Contact', 'get', [
+      'version' => 4,
+      'checkPermissions' => TRUE,
+      'select' => ['id', 'display_name'],
+      'where' => [['first_name', '=', 'phoney'], ['is_deleted', '=', 0]],
+    ]);
+    $query = new Api4SelectQuery($api);
+    try {
+      $query->run();
+    }
+    catch (\API_Exception $e) {
+      $this->fail('An Exception Should not have been raised');
+    }
+    $api = Request::create('Email', 'get', [
+      'version' => 4,
+      'checkPermissions' => TRUE,
+      'where' => [['contact.first_name', '=', 'phoney'], ['contact_id.is_deleted', '=', 0]],
+    ]);
+    $query = new Api4SelectQuery($api);
+    try {
+      $query->run();
+    }
+    catch (\API_Exception $e) {
+      $this->fail('An Exception Should not have been raised');
+    }
+  }
+
 }


### PR DESCRIPTION
…se in apiv4 get to resolve error reported about is_deleted being an invalid field

Overview
----------------------------------------
This aims to fix the fatal error reported https://lab.civicrm.org/dev/core/-/issues/2507 by manually adding in the is_deleted field to be acceptable fields for use in Where clauses only

Before
----------------------------------------
Fatal error if using is_deleted in an APIv4 where clause for a get if you don't have permission to access deleted contacts

After
----------------------------------------
no fatal error

ping @colemanw @eileenmcnaughton @demeritcowboy @lcdservices 