### PR TITLE
Throw exception when baoName is not found

### DIFF
--- a/Civi/Api4/Generic/DAOGetAction.php
+++ b/Civi/Api4/Generic/DAOGetAction.php
@@ -78,9 +78,17 @@ class DAOGetAction extends AbstractGetAction {
    */
   protected $having = [];
 
+  /**
+   * @throws \API_Exception
+   * @throws \CRM_Core_Exception
+   */
   public function _run(Result $result) {
     // Early return if table doesn't exist yet due to pending upgrade
     $baoName = $this->getBaoName();
+    if (!$baoName) {
+      // In some cases (eg. site spin-up) the code may attempt to call the api before the entity name is registered.
+      throw new \API_Exception("BAO for {$this->getEntityName()} is not available. This could be a load-order issue");
+    }
     if (!$baoName::tableHasBeenAdded()) {
       \Civi::log()->warning("Could not read from {$this->getEntityName()} before table has been added. Upgrade required.", ['civi.tag' => 'upgrade_needed']);
       return;


### PR DESCRIPTION

Overview
----------------------------------------
Throw exception when baoName is not found in v4 api get requests

Before
----------------------------------------
If a race condition arises where the entity is called before it is registered a fatal error results

After
----------------------------------------
In same situation an exception is thrown.

Technical Details
----------------------------------------
An exception is more recoverable than a fatal error.

The specific case I'm hitting at the moment relates to monolog - the
caching of the symfony container means it persists between builds and is
accessed before the extension is installed. However the entity is not
yet registered via entityTypes hook. Interestingly my call to apiv4.getEntities 
does find it to be available. 

Historically I have hit this fatal in other scenarios but I can't recall the details.


Comments
----------------------------------------

