### PR TITLE
Remove deprecated use of format money

### DIFF
--- a/CRM/Contribute/Form/AdditionalInfo.php
+++ b/CRM/Contribute/Form/AdditionalInfo.php
@@ -27,7 +27,7 @@ class CRM_Contribute_Form_AdditionalInfo {
    *
    * @param CRM_Core_Form $form
    */
-  public static function buildPremium(&$form) {
+  public static function buildPremium($form) {
     //premium section
     $form->add('hidden', 'hidden_Premium', 1);
     $sel1 = $sel2 = [];

--- a/templates/CRM/Contribute/Form/AdditionalInfo/Premium.tpl
+++ b/templates/CRM/Contribute/Form/AdditionalInfo/Premium.tpl
@@ -20,7 +20,7 @@
     <table class="form-layout-compressed">
       <tr class="crm-contribution-form-block-min_amount">
         <td class="label">{$form.min_amount.label}</td>
-        <td class="html-adjust">{$form.min_amount.html|crmAddClass:'no-border'|crmMoney:$currency}</td>
+        <td class="html-adjust">{$form.min_amount.html}</td>
       </tr>
     </table>
     <div class="spacer"></div>


### PR DESCRIPTION
Overview
----------------------------------------
Deprecation errors are being logged due to passing the html for min_amount to the money::format funciton. This is a read only field

Removing that call results in a slight loss of formatting but it's broken before AND after on sites with non-US decimarl separators and the field feels obscure enough and is not an input field so my money (guffaw) says no-one will miss the currency symbol. 

It's a bit of work to fix it so it DOES format correctly as js is involved & it has never been reported


Before
----------------------------------------
A deprecation notice is logged due to passing html to Money;;format()

The site default currency is shown but the thousand separators are incorrect.

![image](https://user-images.githubusercontent.com/336308/123044006-3a436e00-d44d-11eb-8fc2-47e753935ee5.png)

After
----------------------------------------
The currency symbol has been sacrificed to get rid of the deprecation notice - the thousand separators are still incorrect

![image](https://user-images.githubusercontent.com/336308/123043822-f81a2c80-d44c-11eb-9f7a-db34050ed7d6.png)

Technical Details
----------------------------------------

Comments
----------------------------------------
