### PR TITLE
APIv4 Explorer - Only apply default limit 25 for "get" action

### DIFF
--- a/ang/api4Explorer/Explorer.js
+++ b/ang/api4Explorer/Explorer.js
@@ -458,7 +458,7 @@
               default:
                 format = 'raw';
             }
-            if (name === 'limit') {
+            if (name === 'limit' && $scope.action === 'get') {
               defaultVal = 25;
             }
             if (name === 'debug') {


### PR DESCRIPTION
Overview
----------------------------------------
The API Explorer sets a default limit of 25 so you don't get an overwhelming result set from a `get` action.

However, for other actions like `getFields` or `getActions`, there is no need for a limit and the default is annoying.

This changes the default to 25 only for get actions, and for others it leaves the default as whatever the API code dictates (usually "0").