### PR TITLE
Backport of 20641 - url fix on payment edit form

### DIFF
--- a/CRM/Financial/Form/PaymentEdit.php
+++ b/CRM/Financial/Form/PaymentEdit.php
@@ -175,7 +175,7 @@ class CRM_Financial_Form_PaymentEdit extends CRM_Core_Form {
     $contactId = CRM_Core_DAO::getFieldValue('CRM_Contribute_DAO_Contribution', $this->getContributionID(), 'contact_id');
     $url = CRM_Utils_System::url(
       "civicrm/contact/view/contribution",
-      "reset=1&action=update&id={" . $this->getContributionID() . "}&cid={$contactId}&context=contribution"
+      "reset=1&action=update&id=" . $this->getContributionID() . "&cid={$contactId}&context=contribution"
     );
     CRM_Core_Session::singleton()->pushUserContext($url);
   }


### PR DESCRIPTION
Overview
----------------------------------------
I missed that this was a recent issue and should have been backported. See #20641.

Comments
----------------------------------------
Note if you're testing that pushUserContext only works in ajax mode, so the redirect doesn't always work anyway, but the url should be the correct url regardless.
