### PR TITLE
APIv4 - Add `@since` annotation to each entity

### DIFF
--- a/Civi/Api4/ACL.php
+++ b/Civi/Api4/ACL.php
@@ -32,6 +32,7 @@ namespace Civi\Api4;
  *
  * @searchable none
  * @see https://docs.civicrm.org/user/en/latest/initial-set-up/permissions-and-access-control
+ * @since 5.19
  * @package Civi\Api4
  */
 class ACL extends Generic\DAOEntity {

--- a/Civi/Api4/ACLEntityRole.php
+++ b/Civi/Api4/ACLEntityRole.php
@@ -23,6 +23,7 @@ namespace Civi\Api4;
  * This api exposes CiviCRM ACLEntityRole.
  *
  * @see https://docs.civicrm.org/user/en/latest/initial-set-up/permissions-and-access-control
+ * @since 5.39
  * @package Civi\Api4
  */
 class ACLEntityRole extends Generic\DAOEntity {

--- a/Civi/Api4/ActionSchedule.php
+++ b/Civi/Api4/ActionSchedule.php
@@ -30,6 +30,7 @@ namespace Civi\Api4;
  *
  * @searchable none
  * @see https://docs.civicrm.org/user/en/latest/email/scheduled-reminders/
+ * @since 5.19
  * @package Civi\Api4
  */
 class ActionSchedule extends Generic\DAOEntity {

--- a/Civi/Api4/Activity.php
+++ b/Civi/Api4/Activity.php
@@ -31,6 +31,7 @@ namespace Civi\Api4;
  *
  * @see https://docs.civicrm.org/user/en/latest/organising-your-data/activities/
  * @searchable primary
+ * @since 5.19
  * @package Civi\Api4
  */
 class Activity extends Generic\DAOEntity {

--- a/Civi/Api4/ActivityContact.php
+++ b/Civi/Api4/ActivityContact.php
@@ -29,6 +29,7 @@ namespace Civi\Api4;
  *
  * @searchable bridge
  * @see \Civi\Api4\Activity
+ * @since 5.19
  * @package Civi\Api4
  */
 class ActivityContact extends Generic\DAOEntity {

--- a/Civi/Api4/Address.php
+++ b/Civi/Api4/Address.php
@@ -31,6 +31,7 @@ namespace Civi\Api4;
  * @ui_join_filters location_type_id
  *
  * @searchable secondary
+ * @since 5.19
  * @package Civi\Api4
  */
 class Address extends Generic\DAOEntity {

--- a/Civi/Api4/Batch.php
+++ b/Civi/Api4/Batch.php
@@ -24,6 +24,7 @@ namespace Civi\Api4;
  *
  * @searchable secondary
  * @see https://docs.civicrm.org/user/en/latest/pledges/everyday-tasks/#batch-entry-of-pledges
+ * @since 5.37
  * @package Civi\Api4
  */
 class Batch extends Generic\DAOEntity {

--- a/Civi/Api4/Campaign.php
+++ b/Civi/Api4/Campaign.php
@@ -24,6 +24,7 @@ namespace Civi\Api4;
  *
  * @see https://docs.civicrm.org/user/en/latest/campaign/what-is-civicampaign/
  * @searchable secondary
+ * @since 5.19
  * @package Civi\Api4
  */
 class Campaign extends Generic\DAOEntity {

--- a/Civi/Api4/CaseActivity.php
+++ b/Civi/Api4/CaseActivity.php
@@ -26,6 +26,7 @@ namespace Civi\Api4;
  *
  * @searchable bridge
  * @see \Civi\Api4\Case
+ * @since 5.37
  * @package Civi\Api4
  */
 class CaseActivity extends Generic\DAOEntity {

--- a/Civi/Api4/CaseContact.php
+++ b/Civi/Api4/CaseContact.php
@@ -26,6 +26,7 @@ namespace Civi\Api4;
  *
  * @searchable bridge
  * @see \Civi\Api4\Case
+ * @since 5.37
  * @package Civi\Api4
  */
 class CaseContact extends Generic\DAOEntity {

--- a/Civi/Api4/CaseType.php
+++ b/Civi/Api4/CaseType.php
@@ -26,6 +26,7 @@ namespace Civi\Api4;
  *
  * @see \Civi\Api4\Case
  * @searchable none
+ * @since 5.37
  * @package Civi\Api4
  */
 class CaseType extends Generic\DAOEntity {

--- a/Civi/Api4/CiviCase.php
+++ b/Civi/Api4/CiviCase.php
@@ -26,6 +26,7 @@ namespace Civi\Api4;
  *
  * @see https://docs.civicrm.org/user/en/latest/case-management/what-is-civicase/
  * @searchable primary
+ * @since 5.37
  * @package Civi\Api4
  */
 class CiviCase extends Generic\DAOEntity {

--- a/Civi/Api4/Contact.php
+++ b/Civi/Api4/Contact.php
@@ -29,6 +29,7 @@ namespace Civi\Api4;
  *
  * @see https://docs.civicrm.org/user/en/latest/organising-your-data/contacts/
  * @searchable primary
+ * @since 5.19
  * @package Civi\Api4
  */
 class Contact extends Generic\DAOEntity {

--- a/Civi/Api4/ContactType.php
+++ b/Civi/Api4/ContactType.php
@@ -31,6 +31,7 @@ namespace Civi\Api4;
  * @see https://docs.civicrm.org/user/en/latest/organising-your-data/contacts/#contact-subtypes
  * @see \Civi\Api4\Contact
  * @searchable none
+ * @since 5.19
  * @package Civi\Api4
  */
 class ContactType extends Generic\DAOEntity {

--- a/Civi/Api4/Contribution.php
+++ b/Civi/Api4/Contribution.php
@@ -16,6 +16,7 @@ namespace Civi\Api4;
  * Contribution entity.
  *
  * @searchable primary
+ * @since 5.19
  * @package Civi\Api4
  */
 class Contribution extends Generic\DAOEntity {

--- a/Civi/Api4/ContributionPage.php
+++ b/Civi/Api4/ContributionPage.php
@@ -16,6 +16,7 @@ namespace Civi\Api4;
  * ContributionPage entity.
  *
  * @searchable secondary
+ * @since 5.19
  * @package Civi\Api4
  */
 class ContributionPage extends Generic\DAOEntity {

--- a/Civi/Api4/ContributionRecur.php
+++ b/Civi/Api4/ContributionRecur.php
@@ -16,6 +16,7 @@ namespace Civi\Api4;
  * ContributionRecur entity.
  *
  * @searchable secondary
+ * @since 5.27
  * @package Civi\Api4
  */
 class ContributionRecur extends Generic\DAOEntity {

--- a/Civi/Api4/ContributionSoft.php
+++ b/Civi/Api4/ContributionSoft.php
@@ -16,6 +16,7 @@ namespace Civi\Api4;
  * ContributionSoft entity.
  *
  * @searchable secondary
+ * @since 5.34
  * @package Civi\Api4
  */
 class ContributionSoft extends Generic\DAOEntity {

--- a/Civi/Api4/Country.php
+++ b/Civi/Api4/Country.php
@@ -22,6 +22,7 @@ namespace Civi\Api4;
  * Country entity.
  *
  * @searchable secondary
+ * @since 5.22
  * @package Civi\Api4
  */
 class Country extends Generic\DAOEntity {

--- a/Civi/Api4/CustomField.php
+++ b/Civi/Api4/CustomField.php
@@ -24,6 +24,7 @@ namespace Civi\Api4;
  *
  * @see https://docs.civicrm.org/user/en/latest/organising-your-data/creating-custom-fields/
  * @searchable none
+ * @since 5.19
  * @package Civi\Api4
  */
 class CustomField extends Generic\DAOEntity {

--- a/Civi/Api4/CustomGroup.php
+++ b/Civi/Api4/CustomGroup.php
@@ -24,6 +24,7 @@ namespace Civi\Api4;
  *
  * @see https://docs.civicrm.org/user/en/latest/organising-your-data/creating-custom-fields/
  * @searchable none
+ * @since 5.19
  * @package Civi\Api4
  */
 class CustomGroup extends Generic\DAOEntity {

--- a/Civi/Api4/Dashboard.php
+++ b/Civi/Api4/Dashboard.php
@@ -29,6 +29,7 @@ namespace Civi\Api4;
  *
  * @see \Civi\Api4\DashboardContact
  * @searchable none
+ * @since 5.25
  * @package Civi\Api4
  */
 class Dashboard extends Generic\DAOEntity {

--- a/Civi/Api4/DashboardContact.php
+++ b/Civi/Api4/DashboardContact.php
@@ -26,6 +26,7 @@ namespace Civi\Api4;
  * @searchable bridge
  * @see \Civi\Api4\Dashboard
  * @searchable none
+ * @since 5.25
  * @package Civi\Api4
  */
 class DashboardContact extends Generic\DAOEntity {

--- a/Civi/Api4/DedupeException.php
+++ b/Civi/Api4/DedupeException.php
@@ -26,6 +26,7 @@ namespace Civi\Api4;
  *
  * @searchable none
  * @see https://docs.civicrm.org/user/en/latest/organising-your-data/contacts/
+ * @since 5.39
  * @package Civi\Api4
  */
 class DedupeException extends Generic\DAOEntity {

--- a/Civi/Api4/DedupeRule.php
+++ b/Civi/Api4/DedupeRule.php
@@ -26,6 +26,7 @@ namespace Civi\Api4;
  *
  * @searchable none
  * @see https://docs.civicrm.org/user/en/latest/organising-your-data/contacts/
+ * @since 5.39
  * @package Civi\Api4
  */
 class DedupeRule extends Generic\DAOEntity {

--- a/Civi/Api4/DedupeRuleGroup.php
+++ b/Civi/Api4/DedupeRuleGroup.php
@@ -26,6 +26,7 @@ namespace Civi\Api4;
  *
  * @searchable none
  * @see https://docs.civicrm.org/user/en/latest/organising-your-data/contacts/
+ * @since 5.39
  * @package Civi\Api4
  */
 class DedupeRuleGroup extends Generic\DAOEntity {

--- a/Civi/Api4/Domain.php
+++ b/Civi/Api4/Domain.php
@@ -24,6 +24,7 @@ namespace Civi\Api4;
  *
  * @see https://docs.civicrm.org/sysadmin/en/latest/setup/multisite/
  * @searchable none
+ * @since 5.19
  * @package Civi\Api4
  */
 class Domain extends Generic\DAOEntity {

--- a/Civi/Api4/Email.php
+++ b/Civi/Api4/Email.php
@@ -27,6 +27,7 @@ namespace Civi\Api4;
  * Creating a new email address requires at minimum a contact's ID and email
  *
  * @searchable secondary
+ * @since 5.19
  * @package Civi\Api4
  */
 class Email extends Generic\DAOEntity {

--- a/Civi/Api4/Entity.php
+++ b/Civi/Api4/Entity.php
@@ -25,6 +25,7 @@ namespace Civi\Api4;
  * @see \Civi\Api4\Generic\AbstractEntity
  *
  * @searchable none
+ * @since 5.19
  * @package Civi\Api4
  */
 class Entity extends Generic\AbstractEntity {
@@ -113,6 +114,11 @@ class Entity extends Generic\AbstractEntity {
           'name' => 'see',
           'data_type' => 'Array',
           'description' => 'Any @see annotations from docblock',
+        ],
+        [
+          'name' => 'since',
+          'data_type' => 'String',
+          'description' => 'Version this API entity was added',
         ],
         [
           'name' => 'bridge',

--- a/Civi/Api4/EntityFinancialAccount.php
+++ b/Civi/Api4/EntityFinancialAccount.php
@@ -26,6 +26,7 @@ namespace Civi\Api4;
  * @ui_join_filters account_relationship
  *
  * @searchable bridge
+ * @since 5.37
  * @package Civi\Api4
  */
 class EntityFinancialAccount extends Generic\DAOEntity {

--- a/Civi/Api4/EntityFinancialTrxn.php
+++ b/Civi/Api4/EntityFinancialTrxn.php
@@ -25,6 +25,7 @@ namespace Civi\Api4;
  * @see https://docs.civicrm.org/dev/en/latest/financial/financialentities/
  *
  * @searchable bridge
+ * @since 5.37
  * @package Civi\Api4
  */
 class EntityFinancialTrxn extends Generic\DAOEntity {

--- a/Civi/Api4/EntityTag.php
+++ b/Civi/Api4/EntityTag.php
@@ -23,6 +23,7 @@ namespace Civi\Api4;
  *
  * @see \Civi\Api4\Tag
  * @searchable bridge
+ * @since 5.19
  * @package Civi\Api4
  */
 class EntityTag extends Generic\DAOEntity {

--- a/Civi/Api4/Event.php
+++ b/Civi/Api4/Event.php
@@ -25,6 +25,7 @@ namespace Civi\Api4;
  * @see https://docs.civicrm.org/user/en/latest/events/what-is-civievent/
  *
  * @searchable primary
+ * @since 5.19
  * @package Civi\Api4
  */
 class Event extends Generic\DAOEntity {

--- a/Civi/Api4/FinancialAccount.php
+++ b/Civi/Api4/FinancialAccount.php
@@ -26,6 +26,7 @@ namespace Civi\Api4;
  * @see https://docs.civicrm.org/user/en/latest/contributions/key-concepts-and-configurations/#financial-types-financial-accounts-and-accounting-codes
  *
  * @searchable secondary
+ * @since 5.34
  * @package Civi\Api4
  */
 class FinancialAccount extends Generic\DAOEntity {

--- a/Civi/Api4/FinancialItem.php
+++ b/Civi/Api4/FinancialItem.php
@@ -26,7 +26,7 @@ namespace Civi\Api4;
  * If your interest is really in payments you should use that api.
  *
  * @see https://docs.civicrm.org/dev/en/latest/financial/financialentities/#financial-items
- *
+ * @since 5.40
  * @package Civi\Api4
  */
 class FinancialItem extends Generic\DAOEntity {

--- a/Civi/Api4/FinancialTrxn.php
+++ b/Civi/Api4/FinancialTrxn.php
@@ -29,6 +29,7 @@ namespace Civi\Api4;
  * @see https://docs.civicrm.org/dev/en/latest/financial/financialentities/#financial-transactions
  *
  * @searchable secondary
+ * @since 5.40
  * @package Civi\Api4
  */
 class FinancialTrxn extends Generic\DAOEntity {

--- a/Civi/Api4/FinancialType.php
+++ b/Civi/Api4/FinancialType.php
@@ -26,6 +26,7 @@ namespace Civi\Api4;
  * @see https://docs.civicrm.org/user/en/latest/contributions/key-concepts-and-configurations/#financial-types-financial-accounts-and-accounting-codes
  *
  * @searchable secondary
+ * @since 5.34
  * @package Civi\Api4
  */
 class FinancialType extends Generic\DAOEntity {

--- a/Civi/Api4/Grant.php
+++ b/Civi/Api4/Grant.php
@@ -26,6 +26,7 @@ namespace Civi\Api4;
  * @see https://docs.civicrm.org/user/en/latest/grants/what-is-civigrant/
  *
  * @searchable primary
+ * @since 5.33
  * @package Civi\Api4
  */
 class Grant extends Generic\DAOEntity {

--- a/Civi/Api4/Group.php
+++ b/Civi/Api4/Group.php
@@ -24,6 +24,7 @@ namespace Civi\Api4;
  * @see https://docs.civicrm.org/user/en/latest/organising-your-data/groups-and-tags/#groups
  *
  * @searchable secondary
+ * @since 5.19
  * @package Civi\Api4
  */
 class Group extends Generic\DAOEntity {

--- a/Civi/Api4/GroupContact.php
+++ b/Civi/Api4/GroupContact.php
@@ -28,6 +28,7 @@ namespace Civi\Api4;
  *
  * @searchable bridge
  * @see \Civi\Api4\Group
+ * @since 5.19
  * @package Civi\Api4
  */
 class GroupContact extends Generic\DAOEntity {

--- a/Civi/Api4/GroupNesting.php
+++ b/Civi/Api4/GroupNesting.php
@@ -23,6 +23,7 @@ namespace Civi\Api4;
  *
  * @see \Civi\Api4\Group
  * @searchable none
+ * @since 5.19
  * @package Civi\Api4
  */
 class GroupNesting extends Generic\DAOEntity {

--- a/Civi/Api4/GroupOrganization.php
+++ b/Civi/Api4/GroupOrganization.php
@@ -27,6 +27,7 @@ namespace Civi\Api4;
  * @searchable none
  *
  * @see \Civi\Api4\Group
+ * @since 5.19
  * @package Civi\Api4
  */
 class GroupOrganization extends Generic\DAOEntity {

--- a/Civi/Api4/IM.php
+++ b/Civi/Api4/IM.php
@@ -23,6 +23,7 @@ namespace Civi\Api4;
  * IM entity.
  *
  * @searchable secondary
+ * @since 5.19
  * @package Civi\Api4
  */
 class IM extends Generic\DAOEntity {

--- a/Civi/Api4/LineItem.php
+++ b/Civi/Api4/LineItem.php
@@ -22,6 +22,7 @@ namespace Civi\Api4;
  * LineItem entity.
  *
  * @searchable secondary
+ * @since 5.31
  * @package Civi\Api4
  */
 class LineItem extends Generic\DAOEntity {

--- a/Civi/Api4/LocBlock.php
+++ b/Civi/Api4/LocBlock.php
@@ -18,6 +18,7 @@ namespace Civi\Api4;
  * Links addresses, emails & phones to Events.
  *
  * @searchable none
+ * @since 5.31
  * @package Civi\Api4
  */
 class LocBlock extends Generic\DAOEntity {

--- a/Civi/Api4/LocationType.php
+++ b/Civi/Api4/LocationType.php
@@ -16,6 +16,7 @@ namespace Civi\Api4;
  * LocationType entity.
  *
  * @searchable none
+ * @since 5.19
  * @package Civi\Api4
  */
 class LocationType extends Generic\DAOEntity {

--- a/Civi/Api4/MailSettings.php
+++ b/Civi/Api4/MailSettings.php
@@ -23,6 +23,7 @@ namespace Civi\Api4;
  * MailSettings entity.
  *
  * @searchable none
+ * @since 5.19
  * @package Civi\Api4
  */
 class MailSettings extends Generic\DAOEntity {

--- a/Civi/Api4/Mapping.php
+++ b/Civi/Api4/Mapping.php
@@ -24,6 +24,7 @@ namespace Civi\Api4;
  * This is a collection of MappingFields, for reuse in import, export, etc.
  *
  * @searchable none
+ * @since 5.19
  * @package Civi\Api4
  */
 class Mapping extends Generic\DAOEntity {

--- a/Civi/Api4/MappingField.php
+++ b/Civi/Api4/MappingField.php
@@ -25,6 +25,7 @@ namespace Civi\Api4;
  *
  * @see \Civi\Api4\Mapping
  * @searchable none
+ * @since 5.19
  * @package Civi\Api4
  */
 class MappingField extends Generic\DAOEntity {

--- a/Civi/Api4/MembershipType.php
+++ b/Civi/Api4/MembershipType.php
@@ -16,6 +16,7 @@ namespace Civi\Api4;
  * MembershipType entity.
  *
  * @searchable secondary
+ * @since 5.27
  * @package Civi\Api4
  */
 class MembershipType extends Generic\DAOEntity {

--- a/Civi/Api4/MessageTemplate.php
+++ b/Civi/Api4/MessageTemplate.php
@@ -23,6 +23,7 @@ namespace Civi\Api4;
  *
  * This is a collection of MsgTemplate, for reuse in import, export, etc.
  * @searchable none
+ * @since 5.26
  * @package Civi\Api4
  */
 class MessageTemplate extends Generic\DAOEntity {

--- a/Civi/Api4/Navigation.php
+++ b/Civi/Api4/Navigation.php
@@ -22,6 +22,7 @@ namespace Civi\Api4;
  * Navigation entity.
  *
  * @searchable none
+ * @since 5.19
  * @package Civi\Api4
  */
 class Navigation extends Generic\DAOEntity {

--- a/Civi/Api4/Note.php
+++ b/Civi/Api4/Note.php
@@ -23,6 +23,7 @@ namespace Civi\Api4;
  * Note entity.
  *
  * @searchable secondary
+ * @since 5.19
  * @package Civi\Api4
  */
 class Note extends Generic\DAOEntity {

--- a/Civi/Api4/OpenID.php
+++ b/Civi/Api4/OpenID.php
@@ -23,6 +23,7 @@ namespace Civi\Api4;
  * OpenID entity.
  *
  * @searchable secondary
+ * @since 5.19
  * @package Civi\Api4
  */
 class OpenID extends Generic\DAOEntity {

--- a/Civi/Api4/OptionGroup.php
+++ b/Civi/Api4/OptionGroup.php
@@ -24,6 +24,7 @@ namespace Civi\Api4;
  *
  * @see \Civi\Api4\OptionValue
  * @searchable none
+ * @since 5.19
  * @package Civi\Api4
  */
 class OptionGroup extends Generic\DAOEntity {

--- a/Civi/Api4/OptionValue.php
+++ b/Civi/Api4/OptionValue.php
@@ -24,6 +24,7 @@ namespace Civi\Api4;
  *
  * @see \Civi\Api4\OptionGroup
  * @searchable none
+ * @since 5.19
  * @package Civi\Api4
  */
 class OptionValue extends Generic\DAOEntity {

--- a/Civi/Api4/PCPBlock.php
+++ b/Civi/Api4/PCPBlock.php
@@ -22,6 +22,7 @@ namespace Civi\Api4;
  * PCP Block entity.
  *
  * @searchable secondary
+ * @since 5.34
  * @package Civi\Api4
  */
 class PCPBlock extends Generic\DAOEntity {

--- a/Civi/Api4/Participant.php
+++ b/Civi/Api4/Participant.php
@@ -22,6 +22,7 @@ namespace Civi\Api4;
  * Participant entity, stores the participation record of a contact in an event.
  *
  * @searchable primary
+ * @since 5.19
  * @package Civi\Api4
  */
 class Participant extends Generic\DAOEntity {

--- a/Civi/Api4/PaymentProcessor.php
+++ b/Civi/Api4/PaymentProcessor.php
@@ -23,6 +23,7 @@ namespace Civi\Api4;
  * @see https://docs.civicrm.org/sysadmin/en/latest/setup/payment-processors/
  *
  * @searchable none
+ * @since 5.23
  * @package Civi\Api4
  */
 class PaymentProcessor extends Generic\DAOEntity {

--- a/Civi/Api4/PaymentProcessorType.php
+++ b/Civi/Api4/PaymentProcessorType.php
@@ -23,6 +23,7 @@ namespace Civi\Api4;
  * @see \Civi\Api4\PaymentProcessor
  *
  * @searchable none
+ * @since 5.23
  * @package Civi\Api4
  */
 class PaymentProcessorType extends Generic\DAOEntity {

--- a/Civi/Api4/PaymentToken.php
+++ b/Civi/Api4/PaymentToken.php
@@ -23,6 +23,7 @@ namespace Civi\Api4;
  * @see https://docs.civicrm.org/user/en/latest/contributions/payment-processors/#managing-recurring-contributions
  *
  * @searchable secondary
+ * @since 5.37
  * @package Civi\Api4
  */
 class PaymentToken extends Generic\DAOEntity {

--- a/Civi/Api4/Permission.php
+++ b/Civi/Api4/Permission.php
@@ -26,6 +26,7 @@ namespace Civi\Api4;
  * on top of permissions!) or during install/uninstall processes.
  *
  * @searchable none
+ * @since 5.34
  * @package Civi\Api4
  */
 class Permission extends Generic\AbstractEntity {

--- a/Civi/Api4/Phone.php
+++ b/Civi/Api4/Phone.php
@@ -27,6 +27,7 @@ namespace Civi\Api4;
  * Creating a new phone of a contact, requires at minimum a contact's ID and phone number
  *
  * @searchable secondary
+ * @since 5.19
  * @package Civi\Api4
  */
 class Phone extends Generic\DAOEntity {

--- a/Civi/Api4/Pledge.php
+++ b/Civi/Api4/Pledge.php
@@ -17,6 +17,7 @@ namespace Civi\Api4;
  *
  * @see https://docs.civicrm.org/user/en/latest/pledges/what-is-civipledge/
  * @searchable primary
+ * @since 5.35
  * @package Civi\Api4
  */
 class Pledge extends Generic\DAOEntity {

--- a/Civi/Api4/PledgePayment.php
+++ b/Civi/Api4/PledgePayment.php
@@ -23,6 +23,7 @@ namespace Civi\Api4;
  * PledgePayment entity.
  *
  * @searchable secondary
+ * @since 5.35
  * @package Civi\Api4
  */
 class PledgePayment extends Generic\DAOEntity {

--- a/Civi/Api4/PriceField.php
+++ b/Civi/Api4/PriceField.php
@@ -16,6 +16,7 @@ namespace Civi\Api4;
  * PriceField entity.
  *
  * @searchable secondary
+ * @since 5.27
  * @package Civi\Api4
  */
 class PriceField extends Generic\DAOEntity {

--- a/Civi/Api4/PriceFieldValue.php
+++ b/Civi/Api4/PriceFieldValue.php
@@ -16,6 +16,7 @@ namespace Civi\Api4;
  * PriceFieldValue entity.
  *
  * @searchable secondary
+ * @since 5.27
  * @package Civi\Api4
  */
 class PriceFieldValue extends Generic\DAOEntity {

--- a/Civi/Api4/PriceSet.php
+++ b/Civi/Api4/PriceSet.php
@@ -16,6 +16,7 @@ namespace Civi\Api4;
  * PriceSet entity.
  *
  * @searchable secondary
+ * @since 5.27
  * @package Civi\Api4
  */
 class PriceSet extends Generic\DAOEntity {

--- a/Civi/Api4/Relationship.php
+++ b/Civi/Api4/Relationship.php
@@ -24,6 +24,7 @@ namespace Civi\Api4;
  *
  * @see https://docs.civicrm.org/user/en/latest/organising-your-data/relationships/
  * @searchable none
+ * @since 5.19
  * @package Civi\Api4
  */
 class Relationship extends Generic\DAOEntity {

--- a/Civi/Api4/RelationshipCache.php
+++ b/Civi/Api4/RelationshipCache.php
@@ -25,6 +25,7 @@ namespace Civi\Api4;
  * @searchable secondary
  * @see \Civi\Api4\Relationship
  * @ui_join_filters near_relation
+ * @since 5.29
  * @package Civi\Api4
  */
 class RelationshipCache extends Generic\AbstractEntity {

--- a/Civi/Api4/RelationshipType.php
+++ b/Civi/Api4/RelationshipType.php
@@ -25,6 +25,7 @@ namespace Civi\Api4;
  * @see \Civi\Api4\Relationship
  *
  * @searchable secondary
+ * @since 5.19
  * @package Civi\Api4
  */
 class RelationshipType extends Generic\DAOEntity {

--- a/Civi/Api4/Route.php
+++ b/Civi/Api4/Route.php
@@ -27,6 +27,7 @@ namespace Civi\Api4;
  *
  * @see https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_alterMenu/
  * @searchable none
+ * @since 5.19
  * @package Civi\Api4
  */
 class Route extends \Civi\Api4\Generic\AbstractEntity {

--- a/Civi/Api4/SavedSearch.php
+++ b/Civi/Api4/SavedSearch.php
@@ -26,6 +26,7 @@ namespace Civi\Api4;
  *
  * @see https://docs.civicrm.org/user/en/latest/organising-your-data/smart-groups/
  * @searchable none
+ * @since 5.24
  * @package Civi\Api4
  */
 class SavedSearch extends Generic\DAOEntity {

--- a/Civi/Api4/Setting.php
+++ b/Civi/Api4/Setting.php
@@ -26,6 +26,7 @@ namespace Civi\Api4;
  *
  * @see \Civi\Core\SettingsBag
  * @searchable none
+ * @since 5.19
  * @package Civi\Api4
  */
 class Setting extends Generic\AbstractEntity {

--- a/Civi/Api4/StateProvince.php
+++ b/Civi/Api4/StateProvince.php
@@ -22,6 +22,7 @@ namespace Civi\Api4;
  * StateProvince entity.
  *
  * @searchable secondary
+ * @since 5.22
  * @package Civi\Api4
  */
 class StateProvince extends Generic\DAOEntity {

--- a/Civi/Api4/StatusPreference.php
+++ b/Civi/Api4/StatusPreference.php
@@ -25,6 +25,7 @@ namespace Civi\Api4;
  * For setting "hush" preferences for system check alerts.
  *
  * @searchable none
+ * @since 5.19
  * @package Civi\Api4
  */
 class StatusPreference extends Generic\DAOEntity {

--- a/Civi/Api4/System.php
+++ b/Civi/Api4/System.php
@@ -22,6 +22,7 @@ namespace Civi\Api4;
  * A collection of system maintenance/diagnostic utilities.
  *
  * @searchable none
+ * @since 5.19
  * @package Civi\Api4
  */
 class System extends Generic\AbstractEntity {

--- a/Civi/Api4/Tag.php
+++ b/Civi/Api4/Tag.php
@@ -27,6 +27,7 @@ namespace Civi\Api4;
  *
  * @see https://docs.civicrm.org/user/en/latest/organising-your-data/groups-and-tags/#tags
  * @searchable secondary
+ * @since 5.19
  * @package Civi\Api4
  */
 class Tag extends Generic\DAOEntity {

--- a/Civi/Api4/Translation.php
+++ b/Civi/Api4/Translation.php
@@ -4,6 +4,7 @@ namespace Civi\Api4;
 /**
  * Attach supplemental translations to strings stored in the database.
  *
+ * @since 5.40
  * @package Civi\Api4
  */
 class Translation extends Generic\DAOEntity {

--- a/Civi/Api4/UFField.php
+++ b/Civi/Api4/UFField.php
@@ -24,6 +24,7 @@ namespace Civi\Api4;
  *
  * @see \Civi\Api4\UFGroup
  * @searchable none
+ * @since 5.19
  * @package Civi\Api4
  */
 class UFField extends Generic\DAOEntity {

--- a/Civi/Api4/UFGroup.php
+++ b/Civi/Api4/UFGroup.php
@@ -24,6 +24,7 @@ namespace Civi\Api4;
  *
  * @see https://docs.civicrm.org/user/en/latest/organising-your-data/profiles/
  * @searchable none
+ * @since 5.19
  * @package Civi\Api4
  */
 class UFGroup extends Generic\DAOEntity {

--- a/Civi/Api4/UFJoin.php
+++ b/Civi/Api4/UFJoin.php
@@ -24,6 +24,7 @@ namespace Civi\Api4;
  *
  * @see \Civi\Api4\UFGroup
  * @searchable none
+ * @since 5.19
  * @package Civi\Api4
  */
 class UFJoin extends Generic\DAOEntity {

--- a/Civi/Api4/UFMatch.php
+++ b/Civi/Api4/UFMatch.php
@@ -23,6 +23,7 @@ namespace Civi\Api4;
  * UFMatch entity - links civicrm contacts with users created externally
  *
  * @searchable none
+ * @since 5.19
  * @package Civi\Api4
  */
 class UFMatch extends Generic\DAOEntity {

--- a/Civi/Api4/Website.php
+++ b/Civi/Api4/Website.php
@@ -23,6 +23,7 @@ namespace Civi\Api4;
  * Website entity.
  *
  * @searchable secondary
+ * @since 5.19
  * @package Civi\Api4
  */
 class Website extends Generic\DAOEntity {

--- a/Civi/Api4/WordReplacement.php
+++ b/Civi/Api4/WordReplacement.php
@@ -25,6 +25,7 @@ namespace Civi\Api4;
  * This entity stores global string replacements for the CiviCRM UI.
  *
  * @searchable secondary
+ * @since 5.39
  * @package Civi\Api4
  */
 class WordReplacement extends Generic\DAOEntity {

--- a/ang/api4Explorer/Explorer.js
+++ b/ang/api4Explorer/Explorer.js
@@ -879,6 +879,7 @@
         description: entityInfo.description,
         comment: entityInfo.comment,
         type: entityInfo.type,
+        since: entityInfo.since,
         see: entityInfo.see
       });
     }

--- a/tests/phpunit/api/v4/Entity/ConformanceTest.php
+++ b/tests/phpunit/api/v4/Entity/ConformanceTest.php
@@ -164,6 +164,7 @@ class ConformanceTest extends UnitTestCase implements HookInterface {
     $this->assertNotEmpty($info['title_plural']);
     $this->assertNotEmpty($info['type']);
     $this->assertNotEmpty($info['description']);
+    $this->assertRegExp(';^\d\.\d\d$;', $info['since']);
     $this->assertContains($info['searchable'], ['primary', 'secondary', 'bridge', 'none']);
     // Bridge must be between exactly 2 entities
     if (in_array('EntityBridge', $info['type'], TRUE)) {


### PR DESCRIPTION
Overview
----------------------------------------
Adds code docs to APIv4 about which version each entity was added.

Before
----------------------------------------
Information missing about when each entity was added to APIv4.

After
----------------------------------------
Available in code docs and displayed in API Explorer.

![image](https://user-images.githubusercontent.com/2874912/123155010-926e7600-d435-11eb-9a89-e5226b2098a1.png)
