### PR TITLE
Fix CRM.api3 calls on Wordpress when basePage is not 'civicrm'

### DIFF
--- a/CRM/Core/Resources/Common.php
+++ b/CRM/Core/Resources/Common.php
@@ -204,6 +204,10 @@ class CRM_Core_Resources_Common {
       "js/wysiwyg/crm.wysiwyg.js",
     ];
 
+    $basePage = $settings->get('wpBasePage');
+    if (empty($basePage)) {
+      $basePage = 'civicrm';
+    }
     // Dynamic localization script
     $items[] = Civi::service('asset_builder')->getUrl('crm-l10n.js', [
       'cid' => $contactID,
@@ -216,6 +220,7 @@ class CRM_Core_Resources_Common {
       'dateInputFormat' => $settings->get('dateInputFormat'),
       'timeInputFormat' => $settings->get('timeInputFormat'),
       'moneyFormat' => CRM_Utils_Money::format(1234.56),
+      'basePage' => $basePage,
     ]);
 
     // add wysiwyg editor

--- a/js/crm.ajax.js
+++ b/js/crm.ajax.js
@@ -25,10 +25,10 @@
     var url,
       frag = path.split('?');
     // Encode url path only if slashes in placeholder were also encoded
-    if (tplURL[mode].indexOf('civicrm/placeholder-url-path') >= 0) {
-      url = tplURL[mode].replace('civicrm/placeholder-url-path', frag[0]);
+    if (tplURL[mode].indexOf(CRM.config.basePage + '/placeholder-url-path') >= 0) {
+      url = tplURL[mode].replace(CRM.config.basePage + '/placeholder-url-path', frag[0]);
     } else {
-      url = tplURL[mode].replace('civicrm%2Fplaceholder-url-path', encodeURIComponent(frag[0]));
+      url = tplURL[mode].replace(CRM.config.basePage + '%2Fplaceholder-url-path', encodeURIComponent(frag[0]));
     }
 
     if (_.isEmpty(query)) {
@@ -65,7 +65,7 @@
   CRM.api4 = function(entity, action, params, index) {
     return new Promise(function(resolve, reject) {
       if (typeof entity === 'string') {
-        $.post(CRM.url('civicrm/ajax/api4/' + entity + '/' + action), {
+        $.post(CRM.url(CRM.config.basePage + '/ajax/api4/' + entity + '/' + action), {
           params: JSON.stringify(params),
           index: index
         })
@@ -76,7 +76,7 @@
             reject(data.responseJSON);
           });
       } else {
-        $.post(CRM.url('civicrm/ajax/api4'), {
+        $.post(CRM.url(CRM.config.basePage + '/ajax/api4'), {
           calls: JSON.stringify(entity)
         })
           .done(function(data) {
@@ -112,7 +112,7 @@
       status = action;
     }
     var ajax = $.ajax({
-      url: CRM.url('civicrm/ajax/rest'),
+      url: CRM.url(CRM.config.basePage + '/ajax/rest'),
       dataType: 'json',
       data: params,
       type: params.action.indexOf('get') === 0 ? 'GET' : 'POST'
@@ -153,7 +153,7 @@
         }
         return settings.success.call(this, result, settings);
       },
-      ajaxURL: 'civicrm/ajax/rest'
+      ajaxURL: CRM.config.basePage + '/ajax/rest'
     };
     action = action.toLowerCase();
     // Default success handler

--- a/templates/CRM/common/l10n.js.tpl
+++ b/templates/CRM/common/l10n.js.tpl
@@ -24,6 +24,7 @@
   CRM.config.ajaxPopupsEnabled = {$ajaxPopupsEnabled|@json_encode};
   CRM.config.allowAlertAutodismissal = {$allowAlertAutodismissal|@json_encode};
   CRM.config.resourceCacheCode = {$resourceCacheCode|@json_encode};
+  CRM.config.basePage = {$basePage|@json_encode}
 
   // Merge entityRef settings
   CRM.config.entityRef = $.extend({ldelim}{rdelim}, {$entityRef|@json_encode}, CRM.config.entityRef || {ldelim}{rdelim});


### PR DESCRIPTION
Overview
----------------------------------------
This was found to be the cause of various "parsererror" messages that Stripe users were getting: https://lab.civicrm.org/extensions/stripe/-/issues/322 The actual issue turns out to be invalid paths for AJAX calls via crm.ajax.js

To reproduce (Wordpress):
1. Create a contribution page with Stripe payment processor (you can also manually run eg. CRM.api3 calls from the console and see the same problem but Stripe js runs a numbers of API calls during submission so easy to reproduce).
2. Set the CiviCRM base page to something other than the standard "civicrm" - eg. "crm".
3. Open the contribution page via the full URL (not clean-url) eg. https://example.org/crm/contribute/transact/?reset=1&id=4&action=preview
4. Fill in the card details and try to submit.

You will see that an AJAX request is made to civicrm/placeholder-url-path which will never work..

Before
----------------------------------------
AJAX/api calls via CRM javascript don't work in some situations on wordpress.

After
----------------------------------------
Base page is passed in and defaults to civicrm. But it will be set to whatever the `wpBasePage` setting is if available and paths in crm.ajax.js are generated using that variable.

Technical Details
----------------------------------------
Explained above - crm.ajax.js assumes in various places that the AJAX path will always be `civicrm/ajax` but that is not true when the wordpress base page is set to something other than `civicrm`. This only applies to frontend URLs.

Comments
----------------------------------------
@haystack @kcristiano Pinging as this is only a problem on wordpress I think!
