### PR TITLE
Fix schema support for composite primary keys

### DIFF
--- a/CRM/Core/CodeGen/Specification.php
+++ b/CRM/Core/CodeGen/Specification.php
@@ -514,7 +514,7 @@ class CRM_Core_CodeGen_Specification {
     if (isset($fields[$name])) {
       $fields[$name]['autoincrement'] = $auto;
     }
-    $fields[$name]['autoincrement'] = $auto;
+
     $primaryKey = [
       'name' => $name,
       'autoincrement' => $auto,


### PR DESCRIPTION
Overview
----------------------------------------
Fix schema support for composite primary keys

Before
----------------------------------------
We support a primaryKey like

```
    <primaryKey>
        <name>contact_timestamp_type</name>
        <field>contact_identifier</field>
        <field>recipient_action_datetime</field>
        <field>event_type</field>
    </primaryKey>
```
but incorrectly add a dummy field for it with just the key 'autoincrement' - by the time it hits the tpl it looks like

```
+        '' => [
+          'name' => '',
+          'type' => ,
+          'where' => 'civicrm_mailing_provider_data.',
+          'table_name' => 'civicrm_mailing_provider_data',
+          'entity' => 'MailingProviderData',
+          'bao' => 'CRM_Omnimail_DAO_MailingProviderData',
+          'localizable' => 0,
+          'add' => NULL,
+        ],
       ];

```

After
----------------------------------------
no dummy key

Technical Details
----------------------------------------
Fixes what looks like an oversight
https://github.com/civicrm/civicrm-core/commit/022785d8d5d4876aa1211b7adc0d7c31e2995fc5#diff-08ba0d294c1f2e5b9d42e4768aa3b30a10e5128809c590f155c5ac0cc9b2f69cL480-L481

An 'if' was added but the uncondition line left in

The result is that if a composite primary field IS defined
per below an entry for it is incorrectly added to the field
array with just autoincrement set.

Comments
----------------------------------------
