### PR TITLE
Add handling for extension tables without id

### DIFF
--- a/Civi/Api4/Query/Api4SelectQuery.php
+++ b/Civi/Api4/Query/Api4SelectQuery.php
@@ -228,6 +228,8 @@ class Api4SelectQuery {
       foreach ($wildFields as $wildField) {
         $pos = array_search($wildField, array_values($select));
         // If the joined_entity.id isn't in the fieldspec already, autoJoinFK will attempt to add the entity.
+        // Note that not every table has an id field - at least not in all extensions.
+        // autoJoinFK will handle this so we can be 'sloppy' here.
         $idField = substr($wildField, 0, strrpos($wildField, '.')) . '.id';
         $this->autoJoinFK($idField);
         $matches = $this->selectMatchingFields($wildField);
@@ -959,6 +961,12 @@ class Api4SelectQuery {
       return;
     }
     $lastLink = array_pop($joinPath);
+    if (!$lastLink) {
+      // This function is called with the 'guessed' $key of 'table.id'. However,
+      // it is possible for extensions to not define id for tables so
+      // we return here rather than call a function on NULL further down.
+      return;
+    }
 
     // Custom field names are already prefixed
     $isCustom = $lastLink instanceof CustomGroupJoinable;


### PR DESCRIPTION


Overview
----------------------------------------
Adds apiv4 handling for extension entities that do not have a contact id

Before
----------------------------------------
Api calls fail when they attempt to join in entities that do not have an id field. In this case the MailingProviderData entity comes from an extension and defines an entity with a composite primary key and no id field. The following results in a fatal error because `$lastLink` is null (here](https://github.com/civicrm/civicrm-core/pull/20706/files#diff-36ab608da0b5718996afd18c10a8c12653c2a1675e81fd3c4dc3e40c2ebb25d2R964) but a few lines later it calls 
`    foreach ($lastLink->getEntityFields() as $fieldObject) `

This is the failing api call - but more complex attempts to define the join fail too because it's a php fatal not an sql error

```
CRM.api4('Contact', 'get', {
  select: ["mailing_provider_data.*", "display_name"],
  join: [["MailingProviderData AS mailing_provider_data", "LEFT"]],
  limit: 25
}).then(function(contacts) {
....
});
```


After
----------------------------------------
All is calm and happy

With this change search kit is able to render the id-less entity


Technical Details
----------------------------------------
If a table does not have an id field this 'guess' at the primary key will result in NULL
being loaded in place of an object and an attempt to call a function on it - which will
result in a fatal error

This adds a check to ensure the function is not called on NULL



Comments
----------------------------------------
@colemanw I couldn't think of a good way to write a unit test on this - I put comments in to try to protect it instead,