### PR TITLE
APIv4 - Don't assume the identifier field for a table is named 'id'

### DIFF
--- a/Civi/Api4/CustomValue.php
+++ b/Civi/Api4/CustomValue.php
@@ -142,6 +142,7 @@ class CustomValue {
       'class' => __CLASS__,
       'type' => ['CustomValue'],
       'searchable' => 'secondary',
+      'id_field' => 'id',
       'see' => [
         'https://docs.civicrm.org/user/en/latest/organising-your-data/creating-custom-fields/#multiple-record-fieldsets',
         '\Civi\Api4\CustomGroup',

--- a/Civi/Api4/Query/Api4SelectQuery.php
+++ b/Civi/Api4/Query/Api4SelectQuery.php
@@ -88,7 +88,7 @@ class Api4SelectQuery {
     $this->api = $apiGet;
 
     // Always select ID of main table unless grouping by something else
-    $id = $this->getIdField($this->getEntity());
+    $id = CoreUtil::getInfoItem($this->getEntity(), 'id_field');
     $this->forceSelectId = !$this->isAggregateQuery() || $this->getGroupBy() === [$id];
 
     // Build field lists
@@ -204,7 +204,7 @@ class Api4SelectQuery {
     }
     else {
       if ($this->forceSelectId) {
-        $id = $this->getIdField($this->getEntity());
+        $id = CoreUtil::getInfoItem($this->getEntity(), 'id_field');
         $select = array_merge([$id], $select);
       }
 
@@ -232,7 +232,7 @@ class Api4SelectQuery {
         // If the joined_entity.id isn't in the fieldspec already, autoJoinFK will attempt to add the entity.
         $fkField = substr($wildField, 0, strrpos($wildField, '.'));
         $fkEntity = $this->getField($fkField)['fk_entity'] ?? NULL;
-        $id = $fkEntity ? $this->getIdField($fkEntity) : 'id';
+        $id = $fkEntity ? CoreUtil::getInfoItem($fkEntity, 'id_field') : 'id';
         $this->autoJoinFK($fkField . ".$id");
         $matches = $this->selectMatchingFields($wildField);
         array_splice($select, $pos, 1, $matches);
@@ -274,14 +274,6 @@ class Api4SelectQuery {
       return in_array($field['type'], ['Field', 'Custom'], TRUE);
     });
     return SelectUtil::getMatchingFields($pattern, array_keys($availableFields));
-  }
-
-  /**
-   * @param $entityName
-   * @return string
-   */
-  private function getIdField($entityName) {
-    return CoreUtil::getApiClass($entityName)::getInfo()['id_field'];
   }
 
   /**

--- a/tests/phpunit/api/v4/Entity/ConformanceTest.php
+++ b/tests/phpunit/api/v4/Entity/ConformanceTest.php
@@ -164,7 +164,8 @@ class ConformanceTest extends UnitTestCase implements HookInterface {
     $this->assertNotEmpty($info['title_plural']);
     $this->assertNotEmpty($info['type']);
     $this->assertNotEmpty($info['description']);
-    $this->assertRegExp(';^\d\.\d\d$;', $info['since']);
+    $this->assertNotEmpty($info['id_field']);
+    $this->assertRegExp(';^\d\.\d+$;', $info['since']);
     $this->assertContains($info['searchable'], ['primary', 'secondary', 'bridge', 'none']);
     // Bridge must be between exactly 2 entities
     if (in_array('EntityBridge', $info['type'], TRUE)) {


### PR DESCRIPTION
Overview
----------------------------------------
Improves APIv4 handling of tables which do not contain a column named `"id"`.

Technical Details
----------------------------------------
APIv4 getInfo() now returns the name of the "id_field" for any entity.
This modifies the selectQuery so that `get` actions rely on that metadata.