### PR TITLE
[REF] - Improve efficiency of APIv4 GetInfo

### DIFF
--- a/Civi/Api4/Generic/AbstractEntity.php
+++ b/Civi/Api4/Generic/AbstractEntity.php
@@ -132,35 +132,41 @@ abstract class AbstractEntity {
    * @return array
    */
   public static function getInfo() {
-    $info = [
-      'name' => static::getEntityName(),
-      'title' => static::getEntityTitle(),
-      'title_plural' => static::getEntityTitle(TRUE),
-      'type' => [self::stripNamespace(get_parent_class(static::class))],
-      'paths' => static::getEntityPaths(),
-      'class' => static::class,
-      'id_field' => 'id',
-      // Entities without a @searchable annotation will default to secondary,
-      // which makes them visible in SearchKit but not at the top of the list.
-      'searchable' => 'secondary',
-    ];
-    // Add info for entities with a corresponding DAO
-    $dao = \CRM_Core_DAO_AllCoreTables::getFullName($info['name']);
-    if ($dao) {
-      $info['paths'] = $dao::getEntityPaths();
-      $info['icon'] = $dao::$_icon;
-      $info['label_field'] = $dao::$_labelField;
-      $info['dao'] = $dao;
+    $cache = \Civi::cache('metadata');
+    $entityName = static::getEntityName();
+    $info = $cache->get("api4.$entityName.info");
+    if (!$info) {
+      $info = [
+        'name' => $entityName,
+        'title' => static::getEntityTitle(),
+        'title_plural' => static::getEntityTitle(TRUE),
+        'type' => [self::stripNamespace(get_parent_class(static::class))],
+        'paths' => static::getEntityPaths(),
+        'class' => static::class,
+        'id_field' => 'id',
+        // Entities without a @searchable annotation will default to secondary,
+        // which makes them visible in SearchKit but not at the top of the list.
+        'searchable' => 'secondary',
+      ];
+      // Add info for entities with a corresponding DAO
+      $dao = \CRM_Core_DAO_AllCoreTables::getFullName($info['name']);
+      if ($dao) {
+        $info['paths'] = $dao::getEntityPaths();
+        $info['icon'] = $dao::$_icon;
+        $info['label_field'] = $dao::$_labelField;
+        $info['dao'] = $dao;
+      }
+      foreach (ReflectionUtils::getTraits(static::class) as $trait) {
+        $info['type'][] = self::stripNamespace($trait);
+      }
+      $reflection = new \ReflectionClass(static::class);
+      $info = array_merge($info, ReflectionUtils::getCodeDocs($reflection, NULL, ['entity' => $info['name']]));
+      if ($dao) {
+        $info['description'] = $dao::getEntityDescription() ?? $info['description'] ?? NULL;
+      }
+      unset($info['package'], $info['method']);
+      $cache->set("api4.$entityName.info", $info);
     }
-    foreach (ReflectionUtils::getTraits(static::class) as $trait) {
-      $info['type'][] = self::stripNamespace($trait);
-    }
-    $reflection = new \ReflectionClass(static::class);
-    $info = array_merge($info, ReflectionUtils::getCodeDocs($reflection, NULL, ['entity' => $info['name']]));
-    if ($dao) {
-      $info['description'] = $dao::getEntityDescription() ?? $info['description'] ?? NULL;
-    }
-    unset($info['package'], $info['method']);
     return $info;
   }
 

--- a/Civi/Api4/Query/Api4SelectQuery.php
+++ b/Civi/Api4/Query/Api4SelectQuery.php
@@ -806,16 +806,13 @@ class Api4SelectQuery {
    * @throws \API_Exception
    */
   private function getBridgeRefs(string $bridgeEntity, string $joinEntity): array {
-    /* @var \Civi\Api4\Generic\DAOEntity $bridgeEntityClass */
-    $bridgeEntityClass = CoreUtil::getApiClass($bridgeEntity);
-    $bridgeInfo = $bridgeEntityClass::getInfo();
-    $bridgeFields = $bridgeInfo['bridge'] ?? [];
+    $bridgeFields = CoreUtil::getInfoItem($bridgeEntity, 'bridge') ?? [];
     // Sanity check - bridge entity should declare exactly 2 FK fields
     if (count($bridgeFields) !== 2) {
       throw new \API_Exception("Illegal bridge entity specified: $bridgeEntity. Expected 2 bridge fields, found " . count($bridgeFields));
     }
     /* @var \CRM_Core_DAO $bridgeDAO */
-    $bridgeDAO = $bridgeInfo['dao'];
+    $bridgeDAO = CoreUtil::getInfoItem($bridgeEntity, 'dao');
     $bridgeTable = $bridgeDAO::getTableName();
 
     // Get the 2 bridge reference columns as CRM_Core_Reference_* objects

--- a/Civi/Api4/Utils/CoreUtil.php
+++ b/Civi/Api4/Utils/CoreUtil.php
@@ -28,7 +28,7 @@ class CoreUtil {
     if ($entityName === 'CustomValue' || strpos($entityName, 'Custom_') === 0) {
       return 'CRM_Core_BAO_CustomValue';
     }
-    $dao = self::getApiClass($entityName)::getInfo()['dao'] ?? NULL;
+    $dao = self::getInfoItem($entityName, 'dao');
     if (!$dao) {
       return NULL;
     }
@@ -50,6 +50,17 @@ class CoreUtil {
     // Because "Case" is a reserved php keyword
     $className = 'Civi\Api4\\' . ($entityName === 'Case' ? 'CiviCase' : $entityName);
     return class_exists($className) ? $className : NULL;
+  }
+
+  /**
+   * Get item from an entity's getInfo array
+   *
+   * @param string $entityName
+   * @param string $keyToReturn
+   * @return mixed
+   */
+  public static function getInfoItem(string $entityName, string $keyToReturn) {
+    return self::getApiClass($entityName)::getInfo()[$keyToReturn] ?? NULL;
   }
 
   /**

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/Run.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/Run.php
@@ -419,9 +419,9 @@ class Run extends \Civi\Api4\Generic\AbstractAction {
    */
   private function getExtraEntityFields(string $entityName): array {
     if (!isset($this->_extraEntityFields[$entityName])) {
-      $info = CoreUtil::getApiClass($entityName)::getInfo();
-      $this->_extraEntityFields[$entityName] = [$info['id_field']];
-      foreach ($info['paths'] ?? [] as $path) {
+      $id = CoreUtil::getInfoItem($entityName, 'id_field');
+      $this->_extraEntityFields[$entityName] = [$id];
+      foreach (CoreUtil::getInfoItem($entityName, 'paths') ?? [] as $path) {
         $matches = [];
         preg_match_all('#\[(\w+)]#', $path, $matches);
         $this->_extraEntityFields[$entityName] = array_unique(array_merge($this->_extraEntityFields[$entityName], $matches[1] ?? []));


### PR DESCRIPTION
Overview
----------------------------------------
This adds a layer of caching to APIv4 entity metadata, along with a couple other improvements.

Technical Details
----------------------------------------
Note that this caches the info returned by the generic function in `AbstractEntity::getInfo()` and some entities override that function, however the overrides generally call the parent and do not perform any expensive computations of their own, so that seems like the best spot to add caching.