### PR TITLE
replace deprecated alias zSize with zCard

### DIFF
--- a/CRM/Core/PrevNextCache/Redis.php
+++ b/CRM/Core/PrevNextCache/Redis.php
@@ -188,7 +188,7 @@ class CRM_Core_PrevNextCache_Redis implements CRM_Core_PrevNextCache_Interface {
 
   public function getCount($cacheKey) {
     $allKey = $this->key($cacheKey, 'all');
-    return $this->redis->zSize($allKey);
+    return $this->redis->zCard($allKey);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Per [this documentation of phpredis](https://github.com/phpredis/phpredis/blob/37a90257d09b4efa75230769cf535484116b2b67/README.markdown#zcard-zsize), "zSize is an alias for zCard and will be removed in future versions of phpredis".

Before
----------------------------------------
Deprecation notices

After
----------------------------------------
Clean(er) logs.