### PR TITLE
Hopefully fix time rollover problem in MessageTemplateTest

### DIFF
--- a/CRM/Contact/BAO/Contact/Utils.php
+++ b/CRM/Contact/BAO/Contact/Utils.php
@@ -177,7 +177,7 @@ WHERE  id IN ( $idString )
     }
 
     if (!$ts) {
-      $ts = time();
+      $ts = CRM_Utils_Time::time();
     }
 
     if (!$live) {

--- a/tests/phpunit/CRM/Core/BAO/MessageTemplateTest.php
+++ b/tests/phpunit/CRM/Core/BAO/MessageTemplateTest.php
@@ -139,6 +139,10 @@ London, 90210
    * @throws \CiviCRM_API3_Exception
    */
   public function testContactTokens(): void {
+    // Freeze the time at the start of the test, so checksums don't suffer from second rollovers.
+    putenv('TIME_FUNC=frozen');
+    CRM_Utils_Time::setTime(date('Y-m-d H:i:s'));
+
     $this->createCustomGroupWithFieldsOfAllTypes([]);
     $tokenData = $this->getAllContactTokens();
     $address = $this->setupContactFromTokeData($tokenData);
@@ -173,6 +177,10 @@ Default Domain Name
     $this->assertEquals($expected_parts[0], $returned_parts[0]);
     $this->assertApproxEquals($expected_parts[1], $returned_parts[1], 2);
     $this->assertEquals($expected_parts[2], $returned_parts[2]);
+
+    // reset time
+    putenv('TIME_FUNC');
+    CRM_Utils_Time::resetTime();
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
This seems to have been coming up frequently lately with it failing intermittently.

Before
----------------------------------------
Failures like this where you can see the timestamp has rolled over one second.
```
-checksum:cs=e8affed2e61e56163f55f9fca86e3dd0_1624645397_168\n
+checksum:cs=cd6cc9538964cccc297dd7d1332e8923_1624645398_168\n
```

After
----------------------------------------
Hopefully fixed.

Technical Details
----------------------------------------
This should be no change in non-test scenarios since Time::time() just returns time().

Comments
----------------------------------------
Is (flakey) test
