### PR TITLE
APIv4 - Fix same-table joins and remove unused code

### DIFF
--- a/tests/phpunit/api/v4/Action/FkJoinTest.php
+++ b/tests/phpunit/api/v4/Action/FkJoinTest.php
@@ -308,7 +308,35 @@ class FkJoinTest extends UnitTestCase {
     $this->assertNull($result[3]['rel.id']);
     $this->assertEquals($cid3, $result[4]['contact.id']);
     $this->assertNull($result[3]['rel.id']);
+  }
 
+  public function testJoinToEmployerId() {
+    $employer = Contact::create(FALSE)
+      ->addValue('contact_type', 'Organization')
+      ->addValue('organization_name', 'TesterCo')
+      ->execute()->first()['id'];
+    $employee = Contact::create(FALSE)
+      ->addValue('employer_id', $employer)
+      ->addValue('first_name', 'TesterMan')
+      ->execute()->first()['id'];
+    $email = Email::create(FALSE)
+      ->addValue('email', 'tester@test.com')
+      ->addValue('contact_id', $employee)
+      ->execute()->first()['id'];
+
+    $contactGet = Contact::get(FALSE)
+      ->addWhere('id', '=', $employee)
+      ->addSelect('employer_id', 'employer_id.display_name')
+      ->execute()->first();
+    $this->assertEquals($employer, $contactGet['employer_id']);
+    $this->assertEquals('TesterCo', $contactGet['employer_id.display_name']);
+
+    $emailGet = Email::get(FALSE)
+      ->addWhere('id', '=', $email)
+      ->addSelect('contact_id.employer_id', 'contact_id.employer_id.display_name')
+      ->execute()->first();
+    $this->assertEquals($employer, $emailGet['contact_id.employer_id']);
+    $this->assertEquals('TesterCo', $emailGet['contact_id.employer_id.display_name']);
   }
 
 }

--- a/tests/phpunit/api/v4/Service/Schema/SchemaMapperTest.php
+++ b/tests/phpunit/api/v4/Service/Schema/SchemaMapperTest.php
@@ -46,34 +46,6 @@ class SchemaMapperTest extends UnitTestCase {
     $this->assertNotEmpty($map->getPath('civicrm_phone', 'location'));
   }
 
-  public function testWillHavePathWithDoubleJump() {
-    $activity = new Table('activity');
-    $activityContact = new Table('activity_contact');
-    $middleLink = new Joinable('activity_contact', 'activity_id');
-    $contactLink = new Joinable('contact', 'id');
-    $activity->addTableLink('id', $middleLink);
-    $activityContact->addTableLink('contact_id', $contactLink);
-
-    $map = new SchemaMap();
-    $map->addTables([$activity, $activityContact]);
-
-    $this->assertNotEmpty($map->getPath('activity', 'contact'));
-  }
-
-  public function testPathWithTripleJoin() {
-    $first = new Table('first');
-    $second = new Table('second');
-    $third = new Table('third');
-    $first->addTableLink('id', new Joinable('second', 'id'));
-    $second->addTableLink('id', new Joinable('third', 'id'));
-    $third->addTableLink('id', new Joinable('fourth', 'id'));
-
-    $map = new SchemaMap();
-    $map->addTables([$first, $second, $third]);
-
-    $this->assertNotEmpty($map->getPath('first', 'fourth'));
-  }
-
   public function testCircularReferenceWillNotBreakIt() {
     $contactTable = new Table('contact');
     $carTable = new Table('car');


### PR DESCRIPTION
Overview
----------------------------------------
This fixes implicit joins between a table and itself, e.g. the Contact.employer_id which links to the Contact table
Also removes alpha code no longer used by APIv4.

Comments
----------------------------------------
Adds a test to ensure the join works across multiple entities.
