### PR TITLE
APIv4 - Emit notices about deprecated join aliases

### DIFF
--- a/CRM/Contact/Form/Task/EmailTrait.php
+++ b/CRM/Contact/Form/Task/EmailTrait.php
@@ -529,11 +529,11 @@ trait CRM_Contact_Form_Task_EmailTrait {
     $emails = Email::get()
       ->addWhere('id', 'IN', $emailIDs)
       ->setCheckPermissions(FALSE)
-      ->setSelect(['contact_id', 'email', 'contact.sort_name', 'contact.display_name'])->execute();
+      ->setSelect(['contact_id', 'email', 'contact_id.sort_name', 'contact_id.display_name'])->execute();
     $emailStrings = [];
     foreach ($emails as $email) {
       $this->contactEmails[$email['id']] = $email;
-      $emailStrings[] = '"' . $email['contact.sort_name'] . '" <' . $email['email'] . '>';
+      $emailStrings[] = '"' . $email['contact_id.sort_name'] . '" <' . $email['email'] . '>';
     }
     return implode(',', $emailStrings);
   }
@@ -552,7 +552,7 @@ trait CRM_Contact_Form_Task_EmailTrait {
     $urls = [];
     foreach ($emailIDs as $email) {
       $contactURL = CRM_Utils_System::url('civicrm/contact/view', ['reset' => 1, 'cid' => $this->contactEmails[$email]['contact_id']], TRUE);
-      $urls[] = "<a href='{$contactURL}'>" . $this->contactEmails[$email]['contact.display_name'] . '</a>';
+      $urls[] = "<a href='{$contactURL}'>" . $this->contactEmails[$email]['contact_id.display_name'] . '</a>';
     }
     return implode(', ', $urls);
   }

--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -1318,13 +1318,13 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution {
       return (bool) ContributionRecur::get(FALSE)->addWhere('id', '=', $recurringContributionID)->addSelect('is_email_receipt')->execute()->first()['is_email_receipt'];
     }
     $contributionPage = Contribution::get(FALSE)
-      ->addSelect('contribution_page.is_email_receipt')
+      ->addSelect('contribution_page_id.is_email_receipt')
       ->addWhere('contribution_page_id', 'IS NOT NULL')
       ->addWhere('id', '=', $contributionID)
       ->execute()->first();
 
     if (!empty($contributionPage)) {
-      return (bool) $contributionPage['contribution_page.is_email_receipt'];
+      return (bool) $contributionPage['contribution_page_id.is_email_receipt'];
     }
     // This would be the case for backoffice (where is_email_receipt is not passed in) or events, where Event::sendMail will filter
     // again anyway.

--- a/CRM/Contribute/BAO/ContributionPage.php
+++ b/CRM/Contribute/BAO/ContributionPage.php
@@ -522,13 +522,13 @@ class CRM_Contribute_BAO_ContributionPage extends CRM_Contribute_DAO_Contributio
         'contribution_page_id',
         'contact_id',
         'contribution_recur_id',
-        'contribution_recur.is_email_receipt',
-        'contribution_page.title',
-        'contribution_page.is_email_receipt',
-        'contribution_page.receipt_from_name',
-        'contribution_page.receipt_from_email',
-        'contribution_page.cc_receipt',
-        'contribution_page.bcc_receipt',
+        'contribution_recur_id.is_email_receipt',
+        'contribution_page_id.title',
+        'contribution_page_id.is_email_receipt',
+        'contribution_page_id.receipt_from_name',
+        'contribution_page_id.receipt_from_email',
+        'contribution_page_id.cc_receipt',
+        'contribution_page_id.bcc_receipt',
       ])
       ->execute()->first();
 
@@ -537,10 +537,10 @@ class CRM_Contribute_BAO_ContributionPage extends CRM_Contribute_DAO_Contributio
       ->addWhere('entity_table', '=', 'civicrm_membership')
       ->addSelect('id')->execute()->first());
 
-    if ($contribution['contribution_recur.is_email_receipt'] || $contribution['contribution_page.is_email_receipt']) {
-      if ($contribution['contribution_page.receipt_from_email']) {
-        $receiptFromName = $contribution['contribution_page.receipt_from_name'];
-        $receiptFromEmail = $contribution['contribution_page.receipt_from_email'];
+    if ($contribution['contribution_recur_id.is_email_receipt'] || $contribution['contribution_page_id.is_email_receipt']) {
+      if ($contribution['contribution_page_id.receipt_from_email']) {
+        $receiptFromName = $contribution['contribution_page_id.receipt_from_name'];
+        $receiptFromEmail = $contribution['contribution_page_id.receipt_from_email'];
       }
       else {
         [$receiptFromName, $receiptFromEmail] = CRM_Core_BAO_Domain::getNameAndEmail();
@@ -570,8 +570,8 @@ class CRM_Contribute_BAO_ContributionPage extends CRM_Contribute_DAO_Contributio
         'toEmail' => $email,
       ];
       //CRM-13811
-      $templatesParams['cc'] = $contribution['contribution_page.cc_receipt'];
-      $templatesParams['bcc'] = $contribution['contribution_page.cc_receipt'];
+      $templatesParams['cc'] = $contribution['contribution_page_id.cc_receipt'];
+      $templatesParams['bcc'] = $contribution['contribution_page_id.cc_receipt'];
       if ($recur->id) {
         // in some cases its just recurringNotify() thats called for the first time and these urls don't get set.
         // like in PaypalPro, & therefore we set it here additionally.

--- a/CRM/Contribute/Form/Task/Invoice.php
+++ b/CRM/Contribute/Form/Task/Invoice.php
@@ -430,13 +430,13 @@ class CRM_Contribute_Form_Task_Invoice extends CRM_Contribute_Form_Task {
         $emails = Email::get()
           ->addWhere('id', 'IN', $emailIDs)
           ->setCheckPermissions(FALSE)
-          ->setSelect(['contact_id', 'email', 'contact.sort_name', 'contact.display_name'])->execute();
+          ->setSelect(['contact_id', 'email', 'contact_id.sort_name', 'contact_id.display_name'])->execute();
         $emailStrings = $contactUrlStrings = [];
         foreach ($emails as $email) {
-          $emailStrings[] = '"' . $email['contact.sort_name'] . '" <' . $email['email'] . '>';
+          $emailStrings[] = '"' . $email['contact_id.sort_name'] . '" <' . $email['email'] . '>';
           // generate the contact url to put in Activity
           $contactURL = CRM_Utils_System::url('civicrm/contact/view', ['reset' => 1, 'force' => 1, 'cid' => $email['contact_id']], TRUE);
-          $contactUrlStrings[] = "<a href='{$contactURL}'>" . $email['contact.display_name'] . '</a>';
+          $contactUrlStrings[] = "<a href='{$contactURL}'>" . $email['contact_id.display_name'] . '</a>';
         }
         $cc_emails = implode(',', $emailStrings);
         $values['cc_receipt'] = $cc_emails;

--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -655,14 +655,14 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
    */
   protected static function getMultiValueCidRefs() {
     $fields = \Civi\Api4\CustomField::get(FALSE)
-      ->addSelect('custom_group.table_name', 'column_name', 'serialize')
+      ->addSelect('custom_group_id.table_name', 'column_name', 'serialize')
       ->addWhere('data_type', '=', 'ContactReference')
       ->addWhere('serialize', 'IS NOT EMPTY')
       ->execute();
 
     $map = [];
     foreach ($fields as $field) {
-      $map[$field['custom_group.table_name']][$field['column_name']] = $field['serialize'];
+      $map[$field['custom_group_id.table_name']][$field['column_name']] = $field['serialize'];
     }
     return $map;
   }

--- a/CRM/Event/Form/ManageEvent/Location.php
+++ b/CRM/Event/Form/ManageEvent/Location.php
@@ -156,7 +156,7 @@ class CRM_Event_Form_ManageEvent_Location extends CRM_Event_Form_ManageEvent {
     if ($this->_id) {
       $this->locationBlock = Event::get()
         ->addWhere('id', '=', $this->_id)
-        ->setSelect(['loc_block.*', 'loc_block_id'])
+        ->setSelect(['loc_block_id.*', 'loc_block_id'])
         ->execute()->first();
       $this->_oldLocBlockId = $this->locationBlock['loc_block_id'];
     }
@@ -249,8 +249,8 @@ class CRM_Event_Form_ManageEvent_Location extends CRM_Event_Form_ManageEvent {
         }
         $params[$block][$index]['location_type_id'] = $defaultLocationTypeID;
         $fieldKey = (int) $index === 1 ? '_id' : '_2_id';
-        if ($isUpdateToExistingLocationBlock && !empty($this->locationBlock['loc_block.' . $block . $fieldKey])) {
-          $params[$block][$index]['id'] = $this->locationBlock['loc_block.' . $block . $fieldKey];
+        if ($isUpdateToExistingLocationBlock && !empty($this->locationBlock['loc_block_id.' . $block . $fieldKey])) {
+          $params[$block][$index]['id'] = $this->locationBlock['loc_block_id.' . $block . $fieldKey];
         }
       }
     }

--- a/CRM/Event/Page/UserDashboard.php
+++ b/CRM/Event/Page/UserDashboard.php
@@ -28,9 +28,9 @@ class CRM_Event_Page_UserDashboard extends CRM_Contact_Page_View_UserDashBoard {
     $event_rows = [];
 
     $participants = \Civi\Api4\Participant::get(FALSE)
-      ->addSelect('id', 'contact_id', 'status_id:name', 'status_id:label', 'event.id', 'event.title', 'event.start_date', 'event.end_date')
+      ->addSelect('id', 'contact_id', 'status_id:name', 'status_id:label', 'event_id', 'event_id.title', 'event_id.start_date', 'event_id.end_date')
       ->addWhere('contact_id', '=', $this->_contactId)
-      ->addOrderBy('event.start_date', 'DESC')
+      ->addOrderBy('event_id.start_date', 'DESC')
       ->execute()
       ->indexBy('id');
 
@@ -39,10 +39,10 @@ class CRM_Event_Page_UserDashboard extends CRM_Contact_Page_View_UserDashBoard {
       $p['participant_id'] = $p['id'];
       $p['status'] = $p['status_id:name'];
       $p['participant_status'] = $p['status_id:label'];
-      $p['event_id'] = $p['event.id'];
-      $p['event_title'] = $p['event.title'];
-      $p['event_start_date'] = $p['event.start_date'];
-      $p['event_end_date'] = $p['event.end_date'];
+      $p['event_id'] = $p['event_id'];
+      $p['event_title'] = $p['event_id.title'];
+      $p['event_start_date'] = $p['event_id.start_date'];
+      $p['event_end_date'] = $p['event_id.end_date'];
 
       $event_rows[] = $p;
     }

--- a/CRM/Financial/BAO/Order.php
+++ b/CRM/Financial/BAO/Order.php
@@ -438,7 +438,7 @@ class CRM_Financial_BAO_Order {
   public function getDefaultPriceField() {
     return PriceField::get(FALSE)
       ->addWhere('name', '=', 'contribution_amount')
-      ->addWhere('price_set.name', '=', 'default_contribution_amount')
+      ->addWhere('price_set_id.name', '=', 'default_contribution_amount')
       ->execute()->first()['id'];
   }
 

--- a/Civi/Api4/Generic/Traits/DAOActionTrait.php
+++ b/Civi/Api4/Generic/Traits/DAOActionTrait.php
@@ -236,7 +236,7 @@ trait DAOActionTrait {
           $field['id'],
           $customParams,
           $value,
-          $field['custom_group.extends'],
+          $field['custom_group_id.extends'],
           // todo check when this is needed
           NULL,
           $entityId,
@@ -270,13 +270,13 @@ trait DAOActionTrait {
     if (!isset($info[$fieldName])) {
       $info = [];
       $fields = CustomField::get(FALSE)
-        ->addSelect('id', 'name', 'html_type', 'data_type', 'custom_group.extends')
-        ->addWhere('custom_group.name', '=', $groupName)
+        ->addSelect('id', 'name', 'html_type', 'data_type', 'custom_group_id.extends')
+        ->addWhere('custom_group_id.name', '=', $groupName)
         ->execute()->indexBy('name');
       foreach ($fields as $name => $field) {
         $field['custom_field_id'] = $field['id'];
         $field['name'] = $groupName . '.' . $name;
-        $field['entity'] = CustomGroupJoinable::getEntityFromExtends($field['custom_group.extends']);
+        $field['entity'] = CustomGroupJoinable::getEntityFromExtends($field['custom_group_id.extends']);
         $info[$name] = $field;
       }
       \Civi::cache('metadata')->set($cacheKey, $info);

--- a/Civi/Api4/Service/Schema/Joinable/CustomGroupJoinable.php
+++ b/Civi/Api4/Service/Schema/Joinable/CustomGroupJoinable.php
@@ -53,11 +53,11 @@ class CustomGroupJoinable extends Joinable {
     $entityFields = (array) \Civi::cache('metadata')->get($cacheKey);
     if (!$entityFields) {
       $fields = CustomField::get(FALSE)
-        ->setSelect(['custom_group.name', 'custom_group.extends', 'custom_group.table_name', 'custom_group.title', '*'])
-        ->addWhere('custom_group.table_name', '=', $this->getTargetTable())
+        ->setSelect(['custom_group_id.name', 'custom_group_id.extends', 'custom_group_id.table_name', 'custom_group_id.title', '*'])
+        ->addWhere('custom_group_id.table_name', '=', $this->getTargetTable())
         ->execute();
       foreach ($fields as $field) {
-        $entityFields[] = \Civi\Api4\Service\Spec\SpecFormatter::arrayToField($field, self::getEntityFromExtends($field['custom_group.extends']));
+        $entityFields[] = \Civi\Api4\Service\Spec\SpecFormatter::arrayToField($field, self::getEntityFromExtends($field['custom_group_id.extends']));
       }
       \Civi::cache('metadata')->set($cacheKey, $entityFields);
     }

--- a/Civi/Api4/Service/Schema/Joiner.php
+++ b/Civi/Api4/Service/Schema/Joiner.php
@@ -70,6 +70,9 @@ class Joiner {
       if ($joinEntity && !$query->checkEntityAccess($joinEntity)) {
         throw new UnauthorizedException('Cannot join to ' . $joinEntity);
       }
+      if ($link->isDeprecated()) {
+        \CRM_Core_Error::deprecatedWarning("Deprecated join alias '$alias' used in APIv4 get. Should be changed to '{$alias}_id'");
+      }
 
       $bao = $joinEntity ? CoreUtil::getBAOFromApiName($joinEntity) : NULL;
       $conditions = $link->getConditionsForJoin($baseTableAlias);

--- a/Civi/Api4/Service/Spec/SpecFormatter.php
+++ b/Civi/Api4/Service/Spec/SpecFormatter.php
@@ -29,16 +29,16 @@ class SpecFormatter {
     if (!empty($data['custom_group_id'])) {
       $field = new CustomFieldSpec($data['name'], $entity, $dataTypeName);
       if (strpos($entity, 'Custom_') !== 0) {
-        $field->setName($data['custom_group.name'] . '.' . $data['name']);
+        $field->setName($data['custom_group_id.name'] . '.' . $data['name']);
       }
       else {
-        $field->setTableName($data['custom_group.table_name']);
+        $field->setTableName($data['custom_group_id.table_name']);
       }
       $field->setColumnName($data['column_name']);
       $field->setCustomFieldId($data['id'] ?? NULL);
-      $field->setCustomGroupName($data['custom_group.name']);
+      $field->setCustomGroupName($data['custom_group_id.name']);
       $field->setTitle($data['label']);
-      $field->setLabel($data['custom_group.title'] . ': ' . $data['label']);
+      $field->setLabel($data['custom_group_id.title'] . ': ' . $data['label']);
       $field->setHelpPre($data['help_pre'] ?? NULL);
       $field->setHelpPost($data['help_post'] ?? NULL);
       if (self::customFieldHasOptions($data)) {

--- a/Civi/Api4/Service/Spec/SpecGatherer.php
+++ b/Civi/Api4/Service/Spec/SpecGatherer.php
@@ -128,9 +128,9 @@ class SpecGatherer {
       $extends = $customInfo['extends'];
     }
     $customFields = CustomField::get(FALSE)
-      ->addWhere('custom_group.extends', 'IN', $extends)
-      ->addWhere('custom_group.is_multiple', '=', '0')
-      ->setSelect(['custom_group.name', 'custom_group.title', '*'])
+      ->addWhere('custom_group_id.extends', 'IN', $extends)
+      ->addWhere('custom_group_id.is_multiple', '=', '0')
+      ->setSelect(['custom_group_id.name', 'custom_group_id.title', '*'])
       ->execute();
 
     foreach ($customFields as $fieldArray) {
@@ -145,8 +145,8 @@ class SpecGatherer {
    */
   private function getCustomGroupFields($customGroup, RequestSpec $specification) {
     $customFields = CustomField::get(FALSE)
-      ->addWhere('custom_group.name', '=', $customGroup)
-      ->setSelect(['custom_group.name', 'custom_group.table_name', 'custom_group.title', '*'])
+      ->addWhere('custom_group_id.name', '=', $customGroup)
+      ->setSelect(['custom_group_id.name', 'custom_group_id.table_name', 'custom_group_id.title', '*'])
       ->execute();
 
     foreach ($customFields as $fieldArray) {

--- a/Civi/Test/Api3TestTrait.php
+++ b/Civi/Test/Api3TestTrait.php
@@ -403,7 +403,7 @@ trait Api3TestTrait {
         // This is a per field hack (bad) but we can't solve everything at once
         // & a cleverer way turned out to be too much for this round.
         // Being in the test class it's tested....
-        $v3Params['option_group.name'] = $v3Params['option_group_id'];
+        $v3Params['option_group_id.name'] = $v3Params['option_group_id'];
         unset($v3Params['option_group_id']);
       }
       if (isset($field['pseudoconstant'], $v3Params[$name]) && $field['type'] === \CRM_Utils_Type::T_INT && !is_numeric($v3Params[$name]) && is_string($v3Params[$name])) {

--- a/Civi/Test/Api3TestTrait.php
+++ b/Civi/Test/Api3TestTrait.php
@@ -322,7 +322,7 @@ trait Api3TestTrait {
       $v4Params['language'] = $language;
     }
     $toRemove = ['option.', 'return', 'api.', 'format.'];
-    $chains = $joins = $custom = [];
+    $chains = $custom = [];
     foreach ($v3Params as $key => $val) {
       foreach ($toRemove as $remove) {
         if (strpos($key, $remove) === 0) {
@@ -425,12 +425,6 @@ trait Api3TestTrait {
           // Ensure id field is returned as v3 always expects it
           if ($v4Entity != 'Setting' && !in_array('id', $v4Params['select'])) {
             $v4Params['select'][] = 'id';
-          }
-          // Convert join syntax
-          foreach ($v4Params['select'] as $idx => $select) {
-            if (strstr($select, '_id.')) {
-              $joins[$select] = $v4Params['select'][$idx] = str_replace('_id.', '.', $select);
-            }
           }
         }
         if ($options['limit'] && $v4Entity != 'Setting') {
@@ -597,10 +591,6 @@ trait Api3TestTrait {
       // Run chains
       foreach ($chains as $key => $params) {
         $result[$index][$key] = $this->runApi4LegacyChain($key, $params, $v4Entity, $row, $sequential);
-      }
-      // Convert join format
-      foreach ($joins as $api3Key => $api4Key) {
-        $result[$index][$api3Key] = $result[$index][$api4Key] ?? NULL;
       }
       // Resolve custom field names
       foreach ($custom as $group => $fields) {

--- a/ext/afform/core/Civi/Afform/AfformMetadataInjector.php
+++ b/ext/afform/core/Civi/Afform/AfformMetadataInjector.php
@@ -28,7 +28,7 @@ class AfformMetadataInjector {
       ->alterHtml(';\\.aff\\.html$;', function($doc, $path) {
         try {
           $module = \Civi::service('angular')->getModule(basename($path, '.aff.html'));
-          $meta = \Civi\Api4\Afform::get()->addWhere('name', '=', $module['_afform'])->setSelect(['join', 'block'])->setCheckPermissions(FALSE)->execute()->first();
+          $meta = \Civi\Api4\Afform::get(FALSE)->addWhere('name', '=', $module['_afform'])->setSelect(['join', 'block'])->execute()->first();
         }
         catch (\Exception $e) {
         }

--- a/ext/oauth-client/tests/phpunit/api/v4/OAuthContactTokenTest.php
+++ b/ext/oauth-client/tests/phpunit/api/v4/OAuthContactTokenTest.php
@@ -228,7 +228,7 @@ class api_v4_OAuthContactTokenTest extends \PHPUnit\Framework\TestCase implement
 
     $this->usePerms(['manage my OAuth contact tokens', 'view my contact']);
     $updateTokensWithLimitedAccess = Civi\Api4\OAuthContactToken::update()
-      ->addWhere('client.guid', '=', $client['guid'])
+      ->addWhere('client_id.guid', '=', $client['guid'])
       ->setValues(['access_token' => 'own-token-revised'])
       ->execute();
     $this->assertCount(1, $updateTokensWithLimitedAccess);
@@ -257,7 +257,7 @@ class api_v4_OAuthContactTokenTest extends \PHPUnit\Framework\TestCase implement
 
     $this->usePerms(['manage my OAuth contact tokens', 'view my contact']);
     $updateTokensForWrongContact = Civi\Api4\OAuthContactToken::update()
-      ->addWhere('contact.id', '=', $notLoggedInContactID)
+      ->addWhere('contact_id.id', '=', $notLoggedInContactID)
       // ^ sneaky way to update a different contact?
       ->setValues(['access_token' => "stranger-token-revised"])
       ->execute();
@@ -271,7 +271,7 @@ class api_v4_OAuthContactTokenTest extends \PHPUnit\Framework\TestCase implement
 
     $this->usePerms(['manage my OAuth contact tokens', 'view all contacts']);
     $deleteTokensWithLimitedAccess = Civi\Api4\OAuthContactToken::delete()
-      ->setWhere([['client.guid', '=', $client['guid']]])
+      ->setWhere([['client_id.guid', '=', $client['guid']]])
       ->execute();
 
     $this->usePerms(['manage my OAuth contact tokens', 'view all contacts']);
@@ -309,7 +309,7 @@ class api_v4_OAuthContactTokenTest extends \PHPUnit\Framework\TestCase implement
 
     $this->usePerms(['manage all OAuth contact tokens', 'view all contacts']);
     $getTokens = Civi\Api4\OAuthContactToken::get()
-      ->addWhere('client.provider', '=', $client['provider'])
+      ->addWhere('client_id.provider', '=', $client['provider'])
       ->addWhere('scopes', 'CONTAINS', 'foo')
       ->execute();
     $this->assertCount(1, $getTokens);
@@ -317,14 +317,14 @@ class api_v4_OAuthContactTokenTest extends \PHPUnit\Framework\TestCase implement
 
     $this->usePerms(['manage all OAuth contact tokens', 'view all contacts']);
     $getTokens = Civi\Api4\OAuthContactToken::get()
-      ->addWhere('client.provider', '=', $client['provider'])
+      ->addWhere('client_id.provider', '=', $client['provider'])
       ->addWhere('scopes', 'CONTAINS', 'nada')
       ->execute();
     $this->assertCount(0, $getTokens);
 
     $this->usePerms(['manage all OAuth contact tokens', 'view all contacts']);
     $getTokens = Civi\Api4\OAuthContactToken::get()
-      ->addWhere('client.provider', '=', 'some-other-provider')
+      ->addWhere('client_id.provider', '=', 'some-other-provider')
       ->addWhere('scopes', 'CONTAINS', 'foo')
       ->execute();
     $this->assertCount(0, $getTokens);

--- a/ext/oauth-client/tests/phpunit/api/v4/OAuthSysTokenTest.php
+++ b/ext/oauth-client/tests/phpunit/api/v4/OAuthSysTokenTest.php
@@ -70,7 +70,7 @@ class api_v4_OAuthSysTokenTest extends \PHPUnit\Framework\TestCase implements He
 
     $usePerms(['manage OAuth client', 'manage OAuth client secrets']);
     $updateToken = Civi\Api4\OAuthSysToken::update()
-      ->setWhere([['client.guid', '=', "example-id-$random"]])
+      ->setWhere([['client_id.guid', '=', "example-id-$random"]])
       ->setValues(['access_token' => "revised-access-token-$random"])
       ->execute();
 
@@ -141,7 +141,7 @@ class api_v4_OAuthSysTokenTest extends \PHPUnit\Framework\TestCase implements He
     $usePerms(['manage OAuth client']);
     try {
       Civi\Api4\OAuthSysToken::update()
-        ->setWhere([['client.guid', '=', "example-id-$random"]])
+        ->setWhere([['client_id.guid', '=', "example-id-$random"]])
         ->setValues(['access_token' => "revised-access-token-$random"])
         ->execute();
       $this->fail('Expected exception - User should not be able to write secret values.');
@@ -191,7 +191,7 @@ class api_v4_OAuthSysTokenTest extends \PHPUnit\Framework\TestCase implements He
 
     $usePerms(['manage OAuth client']);
     $getTokens = Civi\Api4\OAuthSysToken::get()
-      ->addWhere('client.provider', '=', 'test_example_1')
+      ->addWhere('client_id.provider', '=', 'test_example_1')
       ->addWhere('scopes', 'CONTAINS', 'foo')
       ->execute();
     $this->assertEquals(1, count($getTokens));
@@ -199,14 +199,14 @@ class api_v4_OAuthSysTokenTest extends \PHPUnit\Framework\TestCase implements He
 
     $usePerms(['manage OAuth client']);
     $getTokens = Civi\Api4\OAuthSysToken::get()
-      ->addWhere('client.provider', '=', 'test_example_1')
+      ->addWhere('client_id.provider', '=', 'test_example_1')
       ->addWhere('scopes', 'CONTAINS', 'nada')
       ->execute();
     $this->assertEquals(0, count($getTokens));
 
     $usePerms(['manage OAuth client']);
     $getTokens = Civi\Api4\OAuthSysToken::get()
-      ->addWhere('client.provider', '=', 'test_example_2')
+      ->addWhere('client_id.provider', '=', 'test_example_2')
       ->addWhere('scopes', 'CONTAINS', 'foo')
       ->execute();
     $this->assertEquals(0, count($getTokens));

--- a/ext/search_kit/Civi/Search/AfformSearchMetadataInjector.php
+++ b/ext/search_kit/Civi/Search/AfformSearchMetadataInjector.php
@@ -35,19 +35,19 @@ class AfformSearchMetadataInjector {
             if ($searchName && $displayName) {
               $display = \Civi\Api4\SearchDisplay::get(FALSE)
                 ->addWhere('name', '=', $displayName)
-                ->addWhere('saved_search.name', '=', $searchName)
-                ->addSelect('settings', 'saved_search.api_entity', 'saved_search.api_params')
+                ->addWhere('saved_search_id.name', '=', $searchName)
+                ->addSelect('settings', 'saved_search_id.api_entity', 'saved_search_id.api_params')
                 ->execute()->first();
               if ($display) {
                 pq($component)->attr('settings', htmlspecialchars(\CRM_Utils_JS::encode($display['settings'] ?? [])));
-                pq($component)->attr('api-entity', htmlspecialchars($display['saved_search.api_entity']));
+                pq($component)->attr('api-entity', htmlspecialchars($display['saved_search_id.api_entity']));
                 pq($component)->attr('search', htmlspecialchars(\CRM_Utils_JS::encode($searchName)));
                 pq($component)->attr('display', htmlspecialchars(\CRM_Utils_JS::encode($displayName)));
 
                 // Add entity names to the fieldset so that afform can populate field metadata
                 $fieldset = pq($component)->parents('[af-fieldset]');
                 if ($fieldset->length) {
-                  $entityList = array_merge([$display['saved_search.api_entity']], array_column($display['saved_search.api_params']['join'] ?? [], 0));
+                  $entityList = array_merge([$display['saved_search_id.api_entity']], array_column($display['saved_search_id.api_params']['join'] ?? [], 0));
                   $fieldset->attr('api-entities', htmlspecialchars(\CRM_Utils_JS::encode($entityList)));
                 }
               }

--- a/tests/phpunit/CRM/Event/Form/ManageEvent/LocationTest.php
+++ b/tests/phpunit/CRM/Event/Form/ManageEvent/LocationTest.php
@@ -78,10 +78,10 @@ class CRM_Event_Form_ManageEvent_LocationTest extends CiviUnitTestCase {
 
     $locationBlock = Event::get()
       ->addWhere('id', '=', $eventID)
-      ->setSelect(['loc_block.*', 'loc_block_id'])
+      ->setSelect(['loc_block_id.*', 'loc_block_id'])
       ->execute()->first();
 
-    $address = $this->callAPISuccessGetSingle('Address', ['id' => $locationBlock['loc_block.address_id']]);
+    $address = $this->callAPISuccessGetSingle('Address', ['id' => $locationBlock['loc_block_id.address_id']]);
 
     $this->assertEquals([
       'id' => $address['id'],
@@ -101,9 +101,9 @@ class CRM_Event_Form_ManageEvent_LocationTest extends CiviUnitTestCase {
       'manual_geo_code' => '0',
     ], $address);
 
-    $this->callAPISuccessGetSingle('Email', ['id' => $locationBlock['loc_block.email_id'], 'email' => 'john.smith@example.org']);
-    $this->callAPISuccessGetSingle('Phone', ['id' => $locationBlock['loc_block.phone_id'], 'phone' => '303443689']);
-    $this->callAPISuccessGetSingle('Phone', ['id' => $locationBlock['loc_block.phone_2_id'], 'phone' => '9833910234']);
+    $this->callAPISuccessGetSingle('Email', ['id' => $locationBlock['loc_block_id.email_id'], 'email' => 'john.smith@example.org']);
+    $this->callAPISuccessGetSingle('Phone', ['id' => $locationBlock['loc_block_id.phone_id'], 'phone' => '303443689']);
+    $this->callAPISuccessGetSingle('Phone', ['id' => $locationBlock['loc_block_id.phone_2_id'], 'phone' => '9833910234']);
 
     // Cleanup.
     CRM_Core_BAO_Location::deleteLocBlock($locationBlock['loc_block_id']);
@@ -255,12 +255,12 @@ class CRM_Event_Form_ManageEvent_LocationTest extends CiviUnitTestCase {
     $firstEmail = $emails->first();
     $locationBlock = Event::get()
       ->addWhere('id', '=', $eventID)
-      ->setSelect(['loc_block.*', 'loc_block_id'])
+      ->setSelect(['loc_block_id.*', 'loc_block_id'])
       ->execute()->first();
     $this->ids['LocBlock'][0] = $locationBlock['loc_block_id'];
-    $this->assertEquals($firstEmail['id'], $locationBlock['loc_block.email_id']);
+    $this->assertEquals($firstEmail['id'], $locationBlock['loc_block_id.email_id']);
     $secondEmail = $emails->last();
-    $this->assertEquals($secondEmail['id'], $locationBlock['loc_block.email_2_id']);
+    $this->assertEquals($secondEmail['id'], $locationBlock['loc_block_id.email_2_id']);
     return $emails;
   }
 

--- a/tests/phpunit/api/v3/ACLPermissionTest.php
+++ b/tests/phpunit/api/v3/ACLPermissionTest.php
@@ -1077,7 +1077,7 @@ class api_v3_ACLPermissionTest extends CiviUnitTestCase {
     $tag2 = $this->tagCreate(['name' => uniqid('other'), 'created_id' => $other])['id'];
     $this->setPermissions(['access CiviCRM']);
     $this->hookClass->setHook('civicrm_aclWhereClause', [$this, 'aclWhereHookAllResults']);
-    $createdFirstName = $version === 4 ? 'created.first_name' : 'created_id.first_name';
+    $createdFirstName = 'created_id.first_name';
     $result = $this->callAPISuccess('Tag', 'get', [
       'check_permissions' => 1,
       'return' => ['id', $createdFirstName],

--- a/tests/phpunit/api/v4/Action/ContactApiKeyTest.php
+++ b/tests/phpunit/api/v4/Action/ContactApiKeyTest.php
@@ -57,10 +57,10 @@ class ContactApiKeyTest extends \api\v4\UnitTestCase {
 
     // Can also be fetched via join
     $email = Email::get()
-      ->addSelect('contact.api_key')
+      ->addSelect('contact_id.api_key')
       ->addWhere('id', '=', $contact['email']['id'])
       ->execute()->first();
-    $this->assertEquals($key, $email['contact.api_key']);
+    $this->assertEquals($key, $email['contact_id.api_key']);
     $this->assertFalse($isSafe($email), "Should reveal secret details ($key): " . var_export($email, 1));
 
     // Remove permission and we should not see the key
@@ -76,12 +76,12 @@ class ContactApiKeyTest extends \api\v4\UnitTestCase {
 
     // Also not available via join
     $email = Email::get()
-      ->addSelect('contact.api_key')
+      ->addSelect('contact_id.api_key')
       ->addWhere('id', '=', $contact['email']['id'])
       ->setDebug(TRUE)
       ->execute();
-    $this->assertContains('contact.api_key', $email->debug['undefined_fields']);
-    $this->assertArrayNotHasKey('contact.api_key', $email[0]);
+    $this->assertContains('contact_id.api_key', $email->debug['undefined_fields']);
+    $this->assertArrayNotHasKey('contact_id.api_key', $email[0]);
     $this->assertTrue($isSafe($email[0]), "Should NOT reveal secret details ($key): " . var_export($email[0], 1));
 
     $result = Contact::get()
@@ -137,14 +137,14 @@ class ContactApiKeyTest extends \api\v4\UnitTestCase {
     $result = Email::get(FALSE)
       ->addWhere('contact_id', '=', $contact['id'])
       ->addSelect('email')
-      ->addSelect('contact.api_key')
+      ->addSelect('contact_id.api_key')
       ->execute()
       ->first();
     $this->assertFalse($isSafe($result), "Should reveal secret details ($key): " . var_export($result, 1));
 
     $result = Email::get(TRUE)
       ->addWhere('contact_id', '=', $contact['id'])
-      ->addSelect('contact.api_key')
+      ->addSelect('contact_id.api_key')
       ->execute()
       ->first();
     $this->assertTrue($isSafe($result), "Should NOT reveal secret details ($key): " . var_export($result, 1));

--- a/tests/phpunit/api/v4/Action/ContactGetTest.php
+++ b/tests/phpunit/api/v4/Action/ContactGetTest.php
@@ -96,7 +96,7 @@ class ContactGetTest extends \api\v4\UnitTestCase {
       $msg = $e->getMessage();
     }
     $this->assertRegExp(';Expected to find one Contact record;', $msg);
-    $limit1 = Contact::get(FALSE)->setLimit(1)->execute();
+    $limit1 = Contact::get(FALSE)->addWhere('last_name', '=', $last_name)->setLimit(1)->execute();
     $this->assertCount(1, (array) $limit1);
     $this->assertCount(1, $limit1);
     $this->assertTrue(!empty($limit1->single()['sort_name']));

--- a/tests/phpunit/api/v4/Action/FkJoinTest.php
+++ b/tests/phpunit/api/v4/Action/FkJoinTest.php
@@ -107,10 +107,10 @@ class FkJoinTest extends UnitTestCase {
     $contacts = Contact::get(FALSE)
       ->addWhere('id', '=', $this->getReference('test_contact_1')['id'])
       ->addJoin('Address AS address', TRUE, ['id', '=', 'address.contact_id'], ['address.location_type_id', '=', 1])
-      ->addSelect('id', 'address.country.iso_code')
+      ->addSelect('id', 'address.country_id.iso_code')
       ->execute();
     $this->assertCount(1, $contacts);
-    $this->assertEquals('US', $contacts[0]['address.country.iso_code']);
+    $this->assertEquals('US', $contacts[0]['address.country_id.iso_code']);
   }
 
   public function testExcludeJoin() {
@@ -292,8 +292,8 @@ class FkJoinTest extends UnitTestCase {
 
     $result = Activity::get(FALSE)
       ->addSelect('id', 'contact.id', 'rel.id')
-      ->addJoin('Contact', FALSE, 'ActivityContact', ['contact.record_type_id:name', '=', "'Activity Targets'"])
-      ->addJoin('Contact AS rel', FALSE, 'RelationshipCache', ['rel.far_contact_id', '=', 'contact.id'], ['rel.near_relation:name', '=', '"Child of"'])
+      ->addJoin('Contact', 'LEFT', 'ActivityContact', ['contact.record_type_id:name', '=', "'Activity Targets'"])
+      ->addJoin('Contact AS rel', 'LEFT', 'RelationshipCache', ['rel.far_contact_id', '=', 'contact.id'], ['rel.near_relation:name', '=', '"Child of"'])
       ->addWhere('contact.id', 'IN', [$cid1, $cid2, $cid3])
       ->addOrderBy('id')
       ->execute();

--- a/tests/phpunit/api/v4/Action/PseudoconstantTest.php
+++ b/tests/phpunit/api/v4/Action/PseudoconstantTest.php
@@ -234,26 +234,26 @@ class PseudoconstantTest extends BaseCustomValueTest {
       ->execute()->first()['id'];
 
     $emails = Email::get()
-      ->addSelect('location_type_id:name', 'contact.gender_id:label', 'email', 'contact_id')
+      ->addSelect('location_type_id:name', 'contact_id.gender_id:label', 'email', 'contact_id')
       ->addWhere('contact_id', 'IN', [$cid1, $cid2, $cid3])
-      ->addWhere('contact.gender_id:label', 'IN', ['Male', 'Female'])
+      ->addWhere('contact_id.gender_id:label', 'IN', ['Male', 'Female'])
       ->execute()->indexBy('contact_id');
     $this->assertCount(2, $emails);
     $this->assertEquals('Work', $emails[$cid1]['location_type_id:name']);
     $this->assertEquals('Home', $emails[$cid2]['location_type_id:name']);
-    $this->assertEquals('Male', $emails[$cid1]['contact.gender_id:label']);
-    $this->assertEquals('Female', $emails[$cid2]['contact.gender_id:label']);
+    $this->assertEquals('Male', $emails[$cid1]['contact_id.gender_id:label']);
+    $this->assertEquals('Female', $emails[$cid2]['contact_id.gender_id:label']);
 
     $emails = Email::get()
-      ->addSelect('location_type_id:name', 'contact.gender_id:label', 'email', 'contact_id')
+      ->addSelect('location_type_id:name', 'contact_id.gender_id:label', 'email', 'contact_id')
       ->addWhere('contact_id', 'IN', [$cid1, $cid2, $cid3])
       ->addWhere('location_type_id:name', 'IN', ['Home'])
       ->execute()->indexBy('contact_id');
     $this->assertCount(2, $emails);
     $this->assertEquals('Home', $emails[$cid2]['location_type_id:name']);
     $this->assertEquals('Home', $emails[$cid3]['location_type_id:name']);
-    $this->assertEquals('Female', $emails[$cid2]['contact.gender_id:label']);
-    $this->assertNull($emails[$cid3]['contact.gender_id:label']);
+    $this->assertEquals('Female', $emails[$cid2]['contact_id.gender_id:label']);
+    $this->assertNull($emails[$cid3]['contact_id.gender_id:label']);
   }
 
   public function testTagOptions() {

--- a/tests/phpunit/api/v4/Entity/ContactInterchangeTest.php
+++ b/tests/phpunit/api/v4/Entity/ContactInterchangeTest.php
@@ -200,16 +200,16 @@ class ContactInterchangeTest extends UnitTestCase implements TransactionalInterf
   public function readNameByActSubjectJoin_4($cid, $strs) {
     $get = ActivityContact::get()
       ->addWhere('record_type_id:label', '=', 'Activity Source')
-      ->addWhere('activity.subject', '=', $strs['api'])
-      ->addSelect('contact.first_name')
+      ->addWhere('activity_id.subject', '=', $strs['api'])
+      ->addSelect('contact_id.first_name')
       ->execute();
-    return $get->first()['contact.first_name'];
+    return $get->first()['contact_id.first_name'];
   }
 
   public function readNameByActSubjectChain_4($cid, $strs) {
     $get = ActivityContact::get()
       ->addWhere('record_type_id:label', '=', 'Activity Source')
-      ->addWhere('activity.subject', '=', $strs['api'])
+      ->addWhere('activity_id.subject', '=', $strs['api'])
       ->setSelect(['activity_id', 'contact_id'])
       ->setChain([
         'the_contact' => [
@@ -252,16 +252,16 @@ class ContactInterchangeTest extends UnitTestCase implements TransactionalInterf
   public function readNameByActDetailsJoin_4($cid, $strs) {
     $get = ActivityContact::get()
       ->addWhere('record_type_id:label', '=', 'Activity Source')
-      ->addWhere('activity.details', '=', $strs['api'])
-      ->addSelect('contact.first_name')
+      ->addWhere('activity_id.details', '=', $strs['api'])
+      ->addSelect('contact_id.first_name')
       ->execute();
-    return $get->first()['contact.first_name'];
+    return $get->first()['contact_id.first_name'];
   }
 
   public function readNameByActDetailsChain_4($cid, $strs) {
     $get = ActivityContact::get()
       ->addWhere('record_type_id:label', '=', 'Activity Source')
-      ->addWhere('activity.details', '=', $strs['api'])
+      ->addWhere('activity_id.details', '=', $strs['api'])
       ->setSelect(['activity_id', 'contact_id'])
       ->setChain([
         'the_contact' => [

--- a/tests/phpunit/api/v4/Entity/ContactJoinTest.php
+++ b/tests/phpunit/api/v4/Entity/ContactJoinTest.php
@@ -46,23 +46,6 @@ class ContactJoinTest extends UnitTestCase {
     return parent::setUpHeadless();
   }
 
-  public function testContactJoinDeprecated() {
-    $contact = $this->getReference('test_contact_1');
-    $entitiesToTest = ['Address', 'OpenID', 'IM', 'Website', 'Email', 'Phone'];
-
-    foreach ($entitiesToTest as $entity) {
-      $results = civicrm_api4($entity, 'get', [
-        'where' => [['contact_id', '=', $contact['id']]],
-        // Deprecated syntax (new syntax is `contact_id.*` not `contact.*`)
-        'select' => ['contact.*_name', 'contact.id'],
-      ]);
-      foreach ($results as $result) {
-        $this->assertEquals($contact['id'], $result['contact.id']);
-        $this->assertEquals($contact['display_name'], $result['contact.display_name']);
-      }
-    }
-  }
-
   public function testContactJoin() {
     $contact = $this->getReference('test_contact_1');
     $entitiesToTest = ['Address', 'OpenID', 'IM', 'Website', 'Email', 'Phone'];

--- a/tests/phpunit/api/v4/Entity/ContactTypeTest.php
+++ b/tests/phpunit/api/v4/Entity/ContactTypeTest.php
@@ -75,29 +75,29 @@ class ContactTypeTest extends UnitTestCase {
 
     $emails = Email::get(FALSE)
       ->addWhere('contact_id', 'IN', [$indiv, $org, $hh])
-      ->addSelect('id', 'contact_id', 'contact.*', 'contact.prefix_id:label')
+      ->addSelect('id', 'contact_id', 'contact_id.*', 'contact_id.prefix_id:label')
       ->execute()
       ->indexBy('contact_id');
 
-    $this->assertArrayHasKey('contact.first_name', $emails[$indiv]);
-    $this->assertArrayNotHasKey('contact.first_name', $emails[$org]);
-    $this->assertArrayNotHasKey('contact.first_name', $emails[$hh]);
+    $this->assertArrayHasKey('contact_id.first_name', $emails[$indiv]);
+    $this->assertArrayNotHasKey('contact_id.first_name', $emails[$org]);
+    $this->assertArrayNotHasKey('contact_id.first_name', $emails[$hh]);
 
-    $this->assertEquals('Dr.', $emails[$indiv]['contact.prefix_id:label']);
-    $this->assertArrayNotHasKey('contact.prefix_id:label', $emails[$org]);
-    $this->assertArrayNotHasKey('contact.prefix_id:label', $emails[$hh]);
+    $this->assertEquals('Dr.', $emails[$indiv]['contact_id.prefix_id:label']);
+    $this->assertArrayNotHasKey('contact_id.prefix_id:label', $emails[$org]);
+    $this->assertArrayNotHasKey('contact_id.prefix_id:label', $emails[$hh]);
 
-    $this->assertArrayHasKey('contact.organization_name', $emails[$org]);
-    $this->assertArrayNotHasKey('contact.organization_name', $emails[$indiv]);
-    $this->assertArrayNotHasKey('contact.organization_name', $emails[$hh]);
+    $this->assertArrayHasKey('contact_id.organization_name', $emails[$org]);
+    $this->assertArrayNotHasKey('contact_id.organization_name', $emails[$indiv]);
+    $this->assertArrayNotHasKey('contact_id.organization_name', $emails[$hh]);
 
-    $this->assertArrayHasKey('contact.sic_code', $emails[$org]);
-    $this->assertArrayNotHasKey('contact.sic_code', $emails[$indiv]);
-    $this->assertArrayNotHasKey('contact.sic_code', $emails[$hh]);
+    $this->assertArrayHasKey('contact_id.sic_code', $emails[$org]);
+    $this->assertArrayNotHasKey('contact_id.sic_code', $emails[$indiv]);
+    $this->assertArrayNotHasKey('contact_id.sic_code', $emails[$hh]);
 
-    $this->assertArrayHasKey('contact.household_name', $emails[$hh]);
-    $this->assertArrayNotHasKey('contact.household_name', $emails[$org]);
-    $this->assertArrayNotHasKey('contact.household_name', $emails[$indiv]);
+    $this->assertArrayHasKey('contact_id.household_name', $emails[$hh]);
+    $this->assertArrayNotHasKey('contact_id.household_name', $emails[$org]);
+    $this->assertArrayNotHasKey('contact_id.household_name', $emails[$indiv]);
 
   }
 

--- a/tests/phpunit/api/v4/Query/Api4SelectQueryTest.php
+++ b/tests/phpunit/api/v4/Query/Api4SelectQueryTest.php
@@ -54,7 +54,7 @@ class Api4SelectQueryTest extends UnitTestCase {
     $api = Request::create('Phone', 'get', [
       'version' => 4,
       'checkPermissions' => FALSE,
-      'select' => ['id', 'phone', 'contact.display_name', 'contact.first_name'],
+      'select' => ['id', 'phone', 'contact_id.display_name', 'contact_id.first_name'],
       'where' => [['phone', '=', $phoneNum]],
     ]);
     $query = new Api4SelectQuery($api);
@@ -62,7 +62,7 @@ class Api4SelectQueryTest extends UnitTestCase {
 
     $this->assertCount(1, $results);
     $firstResult = array_shift($results);
-    $this->assertEquals($contact['display_name'], $firstResult['contact.display_name']);
+    $this->assertEquals($contact['display_name'], $firstResult['contact_id.display_name']);
   }
 
   /**

--- a/tests/phpunit/api/v4/Query/PermissionCheckTest.php
+++ b/tests/phpunit/api/v4/Query/PermissionCheckTest.php
@@ -91,13 +91,13 @@ class PermissionCheckTest extends UnitTestCase {
       0)
       ->execute()->first();
     $participant = Participant::get()
-      ->addSelect('contact.first_name', 'event.title')
-      ->addWhere('event.id', '=', $event['id'])
+      ->addSelect('contact_id.first_name', 'event_id.title')
+      ->addWhere('event_id.id', '=', $event['id'])
       ->execute()
       ->first();
 
-    $this->assertEquals('ABC123 Event', $participant['event.title']);
-    $this->assertEquals($name, $participant['contact.first_name']);
+    $this->assertEquals('ABC123 Event', $participant['event_id.title']);
+    $this->assertEquals($name, $participant['contact_id.first_name']);
 
     // Remove access to view events
     $config->userPermissionClass->permissions = [
@@ -107,14 +107,14 @@ class PermissionCheckTest extends UnitTestCase {
       'view event participants',
     ];
     $participant = Participant::get()
-      ->addSelect('contact.first_name')
-      ->addSelect('event.title')
+      ->addSelect('contact_id.first_name')
+      ->addSelect('event_id.title')
       ->addWhere('id', '=', $contact['participant']['id'])
       ->execute()
       ->first();
 
-    $this->assertTrue(empty($participant['event.title']));
-    $this->assertEquals($name, $participant['contact.first_name']);
+    $this->assertTrue(empty($participant['event_id.title']));
+    $this->assertEquals($name, $participant['contact_id.first_name']);
 
   }
 

--- a/tests/phpunit/api/v4/Query/SelectQueryMultiJoinTest.php
+++ b/tests/phpunit/api/v4/Query/SelectQueryMultiJoinTest.php
@@ -37,7 +37,7 @@ class SelectQueryMultiJoinTest extends UnitTestCase {
 
   public function testManyToOneSelect() {
     $results = Email::get()
-      ->addSelect('contact.display_name')
+      ->addSelect('contact_id.display_name')
       ->execute()
       ->indexBy('id');
 
@@ -49,7 +49,7 @@ class SelectQueryMultiJoinTest extends UnitTestCase {
     $secondContactEmailIds = [$thirdEmail['id'], $fourthEmail['id']];
 
     foreach ($results as $id => $email) {
-      $displayName = $email['contact.display_name'];
+      $displayName = $email['contact_id.display_name'];
       if (in_array($id, $firstContactEmailIds)) {
         $this->assertEquals('First Contact', $displayName);
       }

--- a/tests/phpunit/api/v4/Spec/SpecFormatterTest.php
+++ b/tests/phpunit/api/v4/Spec/SpecFormatterTest.php
@@ -49,8 +49,8 @@ class SpecFormatterTest extends UnitTestCase {
 
     $data = [
       'custom_group_id' => $customGroupId,
-      'custom_group.name' => 'my_group',
-      'custom_group.title' => 'My Group',
+      'custom_group_id.name' => 'my_group',
+      'custom_group_id.title' => 'My Group',
       'id' => $customFieldId,
       'name' => $name,
       'label' => $name,

--- a/tests/phpunit/api/v4/Utils/SelectUtilTest.php
+++ b/tests/phpunit/api/v4/Utils/SelectUtilTest.php
@@ -40,12 +40,12 @@ class SelectUtilTest extends UnitTestCase {
     'reset_date',
     'signature_text',
     'signature_html',
-    'contact.id',
-    'contact.display_name',
-    'contact.sort_name',
-    'contact.phone.id',
-    'contact.phone.phone',
-    'contact.phone.phone_type_id',
+    'contact_id.id',
+    'contact_id.display_name',
+    'contact_id.sort_name',
+    'contact_id.phone.id',
+    'contact_id.phone.phone',
+    'contact_id.phone.phone_type_id',
   ];
 
   public function getSelectExamples() {
@@ -81,10 +81,10 @@ class SelectUtilTest extends UnitTestCase {
       [['contact_id'], 'con*_id'],
       [['is_primary', 'is_billing', 'is_bulkmail'], 'is_*'],
       [['is_billing', 'is_bulkmail'], 'is_*l*'],
-      [['contact.id', 'contact.display_name', 'contact.sort_name'], 'contact.*'],
-      [['contact.display_name', 'contact.sort_name'], 'contact.*_name'],
-      [['contact.phone.id', 'contact.phone.phone', 'contact.phone.phone_type_id'], 'contact.phone.*'],
-      [['contact.phone.phone', 'contact.phone.phone_type_id'], 'contact.phone.phone*'],
+      [['contact_id.id', 'contact_id.display_name', 'contact_id.sort_name'], 'contact_id.*'],
+      [['contact_id.display_name', 'contact_id.sort_name'], 'contact_id.*_name'],
+      [['contact_id.phone.id', 'contact_id.phone.phone', 'contact_id.phone.phone_type_id'], 'contact_id.phone.*'],
+      [['contact_id.phone.phone', 'contact_id.phone.phone_type_id'], 'contact_id.phone.phone*'],
     ];
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Gives notices from APIv4 to alert developers to update their join syntax if needed.
Switches internal API calls and unit tests to use the non-deprecated syntax.

Old Syntax
----------------------------------------
```php
civicrm_api4('Contact', 'get', [
  'select' => ['employer.display_name'],
]);
```

New Syntax
----------------------------------------
```php
civicrm_api4('Contact', 'get', [
  'select' => ['employer_id.display_name'],
]);
```

Technical Details
----------------------------------------
Now using e.g. `employer` instead of `employer_id` will emit deprecation notice.
The aliases were deprecated a few months ago to reduce ambiguity, as not every FK field ends in "_id".
See #20130