### PR TITLE
Add calling function to deprecatedWarning log message

### DIFF
--- a/CRM/ACL/API.php
+++ b/CRM/ACL/API.php
@@ -38,6 +38,8 @@ class CRM_ACL_API {
    *
    * @return bool
    *   true if yes, else false
+   *
+   * @deprecated
    */
   public static function check($str, $contactID = NULL) {
     \CRM_Core_Error::deprecatedWarning(__CLASS__ . '::' . __FUNCTION__ . ' is deprecated.');

--- a/CRM/ACL/BAO/ACL.php
+++ b/CRM/ACL/BAO/ACL.php
@@ -188,6 +188,8 @@ SELECT acl.*
    * @param int $contactID
    *
    * @return bool
+   *
+   * @deprecated
    */
   public static function check($str, $contactID) {
     \CRM_Core_Error::deprecatedWarning(__CLASS__ . '::' . __FUNCTION__ . ' is deprecated.');

--- a/CRM/Core/Error.php
+++ b/CRM/Core/Error.php
@@ -1039,16 +1039,23 @@ class CRM_Core_Error extends PEAR_ErrorStack {
       $callerClass = $dbt[1]['class'] ?? NULL;
       $oldMethod = "{$callerClass}::{$callerFunction}";
     }
-    self::deprecatedWarning("Deprecated function $oldMethod, use $newMethod.");
+    $message = "Deprecated function $oldMethod, use $newMethod.";
+    Civi::log()->warning($message, ['civi.tag' => 'deprecated']);
+    trigger_error($message, E_USER_DEPRECATED);
   }
 
   /**
    * Output a deprecated notice about a deprecated call path, rather than deprecating a whole function.
+   *
    * @param string $message
    */
   public static function deprecatedWarning($message) {
     // Even though the tag is no longer used within the log() function,
     // \Civi\API\LogObserver instances may still be monitoring it.
+    $dbt = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 3);
+    $callerFunction = $dbt[2]['function'] ?? NULL;
+    $callerClass = $dbt[2]['class'] ?? NULL;
+    $message .= " Caller: {$callerClass}::{$callerFunction}";
     Civi::log()->warning($message, ['civi.tag' => 'deprecated']);
     trigger_error($message, E_USER_DEPRECATED);
   }


### PR DESCRIPTION
Overview
----------------------------------------
When `CRM_Core_Error::deprecatedWarning()` is triggered it's helpful to know where it is called from.

Before
----------------------------------------
No idea what triggered this:
```
 [warning] Attributes passed to CRM_Core_Form::add() are not an array.
Array
(
    [civi.tag] => deprecated
)
```

After
----------------------------------------
Ah, it was triggered by `CRM_Gdpr_SLA_Entity::addField`:
```
 [warning] Attributes passed to CRM_Core_Form::add() are not an array. Caller: CRM_Gdpr_SLA_Entity::addField
Array
(
    [civi.tag] => deprecated
)
```

Technical Details
----------------------------------------
Uses the same code as `deprecatedFunctionWarning()` to get the name of the calling function.

Comments
----------------------------------------
