### PR TITLE
Replace extension key with description in 'Add New' tab

### DIFF
--- a/templates/CRM/Admin/Page/Extensions/AddNew.tpl
+++ b/templates/CRM/Admin/Page/Extensions/AddNew.tpl
@@ -22,7 +22,7 @@ Depends: CRM/common/enableDisableApi.tpl and CRM/common/jsortable.tpl
         {/if}
         <tr id="addnew-row_{$row.file}" class="crm-extensions crm-extensions_{$row.file}">
           <td class="crm-extensions-label">
-              <a class="collapsed" href="#"></a>&nbsp;<strong>{$row.label}</strong><br/>({$row.key})
+            <a class="collapsed" href="#"></a>&nbsp;<strong>{$row.label|escape}</strong><br/>{$row.description|escape}
           </td>
           <td class="crm-extensions-version">{$row.version|escape}</td>
           <td class="crm-extensions-description">{$row.type|capitalize}</td>


### PR DESCRIPTION
Overview
----------------------------------------
This was already changed in the main extension list but got missed on the "Add New" tab.

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/2052161/123607837-248bcb00-d7f6-11eb-8c63-db62ba536e0b.png)

After
----------------------------------------
![image](https://user-images.githubusercontent.com/2052161/123608105-6157c200-d7f6-11eb-9862-f6b689cb7219.png)

Technical Details
----------------------------------------


Comments
----------------------------------------
