### PR TITLE
 dev/core#1711 - small translation improvement

### DIFF
--- a/templates/CRM/Contact/Form/Task/SMSCommon.tpl
+++ b/templates/CRM/Contact/Form/Task/SMSCommon.tpl
@@ -63,7 +63,7 @@ function maxLengthMessage()
    var len = CRM.$('#sms_text_message').val().length;
    var maxLength = {/literal}{$max_sms_length}{literal};
    if (len > maxLength) {
-      CRM.$('#sms_text_message').crmError({/literal}'{ts escape="js"}SMS body exceeding limit of {$max_sms_length} characters{/ts}'{literal});
+      CRM.$('#sms_text_message').crmError({/literal}'{ts escape="js" 1=$max_sms_length}SMS body exceeding limit of %1 characters{/ts}'{literal});
       return false;
    }
 return true;


### PR DESCRIPTION
Overview
----------------------------------------
As per comment https://github.com/civicrm/civicrm-core/pull/20220#discussion_r659725553 the string extractor might not handle it as-written. Changed to use `{ts 1=$x}Aaaaa %1 bbbbbb{/ts}` format.

Works when I try it.