### PR TITLE
APIv4 - Silently ignore non-permissioned fields instead of throwing exceptions

### DIFF
--- a/Civi/Api4/Generic/AbstractAction.php
+++ b/Civi/Api4/Generic/AbstractAction.php
@@ -417,9 +417,7 @@ abstract class AbstractAction implements \ArrayAccess {
    * Returns schema fields for this entity & action.
    *
    * Here we bypass the api wrapper and run the getFields action directly.
-   * This is because we DON'T want the wrapper to check permissions as this is an internal op,
-   * but we DO want permissions to be checked inside the getFields request so e.g. the api_key
-   * field can be conditionally included.
+   * This is because we DON'T want the wrapper to check permissions as this is an internal op.
    * @see \Civi\Api4\Action\Contact\GetFields
    *
    * @throws \API_Exception
@@ -433,7 +431,7 @@ abstract class AbstractAction implements \ArrayAccess {
       }
       $getFields = \Civi\API\Request::create($this->getEntityName(), 'getFields', [
         'version' => 4,
-        'checkPermissions' => $this->checkPermissions,
+        'checkPermissions' => FALSE,
         'action' => $this->getActionName(),
         'where' => [['type', 'IN', $allowedTypes]],
       ]);

--- a/Civi/Api4/Query/SqlField.php
+++ b/Civi/Api4/Query/SqlField.php
@@ -11,6 +11,8 @@
 
 namespace Civi\Api4\Query;
 
+use Civi\API\Exception\UnauthorizedException;
+
 /**
  * Sql column expression
  */
@@ -26,8 +28,11 @@ class SqlField extends SqlExpression {
   }
 
   public function render(array $fieldList): string {
-    if (empty($fieldList[$this->expr])) {
+    if (!isset($fieldList[$this->expr])) {
       throw new \API_Exception("Invalid field '{$this->expr}'");
+    }
+    if ($fieldList[$this->expr] === FALSE) {
+      throw new UnauthorizedException("Unauthorized field '{$this->expr}'");
     }
     return $fieldList[$this->expr]['sql_name'];
   }

--- a/tests/phpunit/api/v4/Action/ContactApiKeyTest.php
+++ b/tests/phpunit/api/v4/Action/ContactApiKeyTest.php
@@ -70,7 +70,7 @@ class ContactApiKeyTest extends \api\v4\UnitTestCase {
       ->addSelect('api_key')
       ->setDebug(TRUE)
       ->execute();
-    $this->assertContains('api_key', $result->debug['undefined_fields']);
+    $this->assertContains('api_key', $result->debug['unauthorized_fields']);
     $this->assertArrayNotHasKey('api_key', $result[0]);
     $this->assertTrue($isSafe($result[0]), "Should NOT reveal secret details ($key): " . var_export($result[0], 1));
 
@@ -80,7 +80,7 @@ class ContactApiKeyTest extends \api\v4\UnitTestCase {
       ->addWhere('id', '=', $contact['email']['id'])
       ->setDebug(TRUE)
       ->execute();
-    $this->assertContains('contact_id.api_key', $email->debug['undefined_fields']);
+    $this->assertContains('contact_id.api_key', $email->debug['unauthorized_fields']);
     $this->assertArrayNotHasKey('contact_id.api_key', $email[0]);
     $this->assertTrue($isSafe($email[0]), "Should NOT reveal secret details ($key): " . var_export($email[0], 1));
 
@@ -90,6 +90,84 @@ class ContactApiKeyTest extends \api\v4\UnitTestCase {
       ->first();
     $this->assertArrayNotHasKey('api_key', $result);
     $this->assertTrue($isSafe($result), "Should NOT reveal secret details ($key): " . var_export($result, 1));
+  }
+
+  public function testApiKeyInWhereAndOrderBy() {
+    \CRM_Core_Config::singleton()->userPermissionClass->permissions = ['access CiviCRM', 'add contacts', 'edit api keys', 'view all contacts', 'edit all contacts'];
+    $keyA = 'a' . \CRM_Utils_String::createRandom(15, \CRM_Utils_String::ALPHANUMERIC);
+    $keyB = 'b' . \CRM_Utils_String::createRandom(15, \CRM_Utils_String::ALPHANUMERIC);
+
+    $firstName = uniqid('name');
+
+    $contactA = Contact::create()
+      ->addValue('first_name', $firstName)
+      ->addValue('last_name', 'KeyA')
+      ->addValue('api_key', $keyA)
+      ->execute()
+      ->first();
+
+    $contactB = Contact::create()
+      ->addValue('first_name', $firstName)
+      ->addValue('last_name', 'KeyB')
+      ->addValue('api_key', $keyB)
+      ->execute()
+      ->first();
+
+    // With sufficient permission we can ORDER BY the key
+    $result = Contact::get()
+      ->addSelect('id')
+      ->addWhere('first_name', '=', $firstName)
+      ->addOrderBy('api_key', 'DESC')
+      ->addOrderBy('id', 'ASC')
+      ->execute();
+    $this->assertEquals($contactB['id'], $result[0]['id']);
+
+    // We can also use the key in WHERE clause
+    $result = Contact::get()
+      ->addSelect('id')
+      ->addWhere('api_key', '=', $keyB)
+      ->execute();
+    $this->assertEquals($contactB['id'], $result->single()['id']);
+
+    // We can also use the key in HAVING clause
+    $result = Contact::get()
+      ->addSelect('id', 'api_key')
+      ->addHaving('api_key', '=', $keyA)
+      ->execute();
+    $this->assertEquals($contactA['id'], $result->single()['id']);
+
+    // Remove permission
+    \CRM_Core_Config::singleton()->userPermissionClass->permissions = ['access CiviCRM', 'view debug output', 'view all contacts'];
+
+    // Assert we cannot ORDER BY the key
+    $result = Contact::get()
+      ->addSelect('id')
+      ->addWhere('first_name', '=', $firstName)
+      ->addOrderBy('api_key', 'DESC')
+      ->addOrderBy('id', 'ASC')
+      ->setDebug(TRUE)
+      ->execute();
+    $this->assertEquals($contactA['id'], $result[0]['id']);
+    $this->assertContains('api_key', $result->debug['unauthorized_fields']);
+
+    // Assert we cannot use the key in WHERE clause
+    $result = Contact::get()
+      ->addSelect('id')
+      ->addWhere('api_key', '=', $keyB)
+      ->setDebug(TRUE)
+      ->execute();
+    $this->assertGreaterThan(1, $result->count());
+    $this->assertContains('api_key', $result->debug['unauthorized_fields']);
+
+    // Assert we cannot use the key in HAVING clause
+    $result = Contact::get()
+      ->addSelect('id', 'api_key')
+      ->addHaving('api_key', '=', $keyA)
+      ->setDebug(TRUE)
+      ->execute();
+    $this->assertGreaterThan(1, $result->count());
+    $this->assertContains('api_key', $result->debug['unauthorized_fields']);
+
   }
 
   public function testCreateWithInsufficientPermissions() {


### PR DESCRIPTION
Overview
----------------------------------------
Fixes API calls to lesser-permissioned users to silently ignore fields the user can't see.

Before
----------------------------------------
Previously the api would throw an exception when the user did not have permission to use a field in the WHERE or HAVING clause.

After
----------------------------------------
Now the unauthorized fields are silently ignored.

Comments
------------
Replaces https://github.com/civicrm/civicrm-core/pull/20695
