### PR TITLE
Error when sorting case roles table by end date

### DIFF
--- a/CRM/Activity/Page/AJAX.php
+++ b/CRM/Activity/Page/AJAX.php
@@ -178,6 +178,7 @@ class CRM_Activity_Page_AJAX {
           $relClient['phone'] = $clientRole['phone'];
           $relClient['email'] = $clientRole['email'];
           $relClient['cid'] = $clientRole['contact_id'];
+          $relClient['end_date'] = '';
           $relClient['source'] = 'contact';
           $caseRelationships[] = $relClient;
         }


### PR DESCRIPTION
Overview
----------------------------------------
This was just added in https://github.com/civicrm/civicrm-core/pull/19737 and rather than keep that PR going forever I decided to just do this as a followup.

Before
----------------------------------------
Depending on your error settings if you try to sort the case roles table on manage case by end date you either get a datatables error or a php warning or silence.

After
----------------------------------------
No error

Technical Details
----------------------------------------
end_date needs to be set for the client too otherwise it's missing when it goes to sort by it a couple lines down.

Comments
----------------------------------------

