### PR TITLE
APIv4 Explorer: show joins for write actions

### DIFF
--- a/CRM/Api4/Page/Api4Explorer.php
+++ b/CRM/Api4/Page/Api4Explorer.php
@@ -40,9 +40,7 @@ class CRM_Api4_Page_Api4Explorer extends CRM_Core_Page {
       'groupOptions' => array_column((array) $groupOptions, 'options', 'name'),
     ];
     Civi::resources()
-      ->addBundle('bootstrap3')
       ->addVars('api4', $vars)
-      ->addPermissions(['access debug output', 'edit groups', 'administer reserved groups'])
       ->addScriptFile('civicrm', 'bower_components/js-yaml/dist/js-yaml.min.js')
       ->addScriptFile('civicrm', 'bower_components/marked/marked.min.js')
       ->addScriptFile('civicrm', 'bower_components/google-code-prettify/bin/prettify.min.js')

--- a/ang/api4Explorer.ang.php
+++ b/ang/api4Explorer.ang.php
@@ -1,5 +1,5 @@
 <?php
-// Autoloader data for Api4 explorer.
+// Autoloader data for Api4 Explorer Angular module.
 return [
   'ext' => 'civicrm',
   'js' => [
@@ -13,5 +13,7 @@ return [
     'ang/api4Explorer',
   ],
   'basePages' => [],
+  'bundles' => ['bootstrap3'],
+  'permissions' => ['access debug output', 'edit groups', 'administer reserved groups'],
   'requires' => ['crmUi', 'crmUtil', 'ngRoute', 'crmRouteBinder', 'ui.sortable', 'api4', 'ngSanitize', 'dialogService', 'checklist-model'],
 ];

--- a/api/v3/Activity.php
+++ b/api/v3/Activity.php
@@ -744,6 +744,8 @@ function _civicrm_api3_activity_getlist_params(&$request) {
     'activity_type_id',
     'subject',
     'source_contact_id',
+    $request['id_field'],
+    $request['label_field'],
   ];
   $request['params']['return'] = array_unique(array_merge($fieldsToReturn, $request['extra']));
   $request['params']['options']['sort'] = 'activity_date_time DESC';

--- a/api/v3/Campaign.php
+++ b/api/v3/Campaign.php
@@ -81,7 +81,15 @@ function civicrm_api3_campaign_delete($params) {
  * @param array $request
  */
 function _civicrm_api3_campaign_getlist_params(&$request) {
-  $fieldsToReturn = ['title', 'campaign_type_id', 'status_id', 'start_date', 'end_date'];
+  $fieldsToReturn = [
+    'title',
+    'campaign_type_id',
+    'status_id',
+    'start_date',
+    'end_date',
+    $request['id_field'],
+    $request['label_field'],
+  ];
   $request['params']['return'] = array_unique(array_merge($fieldsToReturn, $request['extra']));
   if (empty($request['params']['id'])) {
     $request['params']['options']['sort'] = 'start_date DESC, title';

--- a/api/v3/Event.php
+++ b/api/v3/Event.php
@@ -204,7 +204,14 @@ function _civicrm_api3_event_getisfull(&$event, $event_id) {
  * @param array $request
  */
 function _civicrm_api3_event_getlist_params(&$request) {
-  $fieldsToReturn = ['start_date', 'event_type_id', 'title', 'summary'];
+  $fieldsToReturn = [
+    'start_date',
+    'event_type_id',
+    'title',
+    'summary',
+    $request['id_field'],
+    $request['label_field'],
+  ];
   $request['params']['return'] = array_unique(array_merge($fieldsToReturn, $request['extra']));
   $request['params']['options']['sort'] = 'start_date DESC';
   if (empty($request['params']['id'])) {

--- a/api/v3/MembershipType.php
+++ b/api/v3/MembershipType.php
@@ -106,6 +106,7 @@ function _civicrm_api3_membership_type_get_spec(&$params) {
  *   Array of parameters determined by getfields.
  */
 function _civicrm_api3_membership_type_getlist_params(&$request) {
+  _civicrm_api3_generic_getlist_params($request);
   if (!isset($request['params']['is_active']) && empty($request['params']['id'])) {
     $request['params']['is_active'] = 1;
   }

--- a/ext/afform/core/api/v3/Afform.php
+++ b/ext/afform/core/api/v3/Afform.php
@@ -88,7 +88,14 @@ function _civicrm_api3_afform_get_spec(&$fields) {
  *   API request.
  */
 function _civicrm_api3_afform_getlist_params(&$request) {
-  $fieldsToReturn = ['name', 'title', 'type', 'description'];
+  $fieldsToReturn = [
+    'name',
+    'title',
+    'type',
+    'description',
+    $request['id_field'],
+    $request['label_field'],
+  ];
   $request['params']['return'] = array_unique(array_merge($fieldsToReturn, $request['extra']));
 }
 


### PR DESCRIPTION
Overview
----------------------------------------
Displays information about joins for write operations in the API Explorer.
See #20677 for more about the new feature.

Before
----------------------------------------
New feature in API but not in API Explorer.

After
----------------------------------------
Now advertised.

Technical Details
------------------
When testing this I found an edge-case bug in the EntityRef widget which was failing to return an entity's `name` if it was requested as the `id_field`. Fixed in this PR.