### PR TITLE
Enotice fix Remove references to savedFieldMapping in page 2 of the import

### DIFF
--- a/templates/CRM/Activity/Import/Form/MapField.tpl
+++ b/templates/CRM/Activity/Import/Form/MapField.tpl
@@ -16,9 +16,6 @@
 
  <div class="help">
     <p>{ts}Review the values shown below from the first 2 rows of your import file and select the matching CiviCRM database fields from the drop-down lists in the right-hand column. Select '- do not import -' for any columns in the import file that you want ignored.{/ts}</p>
-    {if $savedMapping}
-    <p>{ts}Click 'Load Saved Field Mapping' if data has been previously imported from the same source. You can then select the saved import mapping setup and load it automatically.{/ts}<p>
-    {/if}
     <p>{ts}If you think you may be importing additional data from the same data source, check 'Save this field mapping' at the bottom of the page before continuing. The saved mapping can then be easily reused the next time data is imported.{/ts}</p>
 </div>
 <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>

--- a/templates/CRM/Contact/Import/Form/MapField.tpl
+++ b/templates/CRM/Contact/Import/Form/MapField.tpl
@@ -15,9 +15,6 @@
  {include file="CRM/common/WizardHeader.tpl"}
 <div class="help">
     <p>{ts}Review the values shown below from the first 2 rows of your import file and select the matching CiviCRM database fields from the drop-down lists in the right-hand column. Select '- do not import -' for any columns in the import file that you want ignored.{/ts}</p>
-    {if $savedMapping}
-    <p>{ts}Click 'Load Saved Field Mapping' if data has been previously imported from the same source. You can then select the saved import mapping setup and load it automatically.{/ts}</p>
-    {/if}
     <p>{ts}If you think you may be importing additional data from the same data source, check 'Save this field mapping' at the bottom of the page before continuing. The saved mapping can then be easily reused the next time data is imported.{/ts}</p>
 </div>
 <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>

--- a/templates/CRM/Contribute/Import/Form/MapField.tpl
+++ b/templates/CRM/Contribute/Import/Form/MapField.tpl
@@ -15,9 +15,6 @@
 
  <div class="help">
     <p>{ts}Review the values shown below from the first 2 rows of your import file and select the matching CiviCRM database fields from the drop-down lists in the right-hand column. Select '- do not import -' for any columns in the import file that you want ignored.{/ts}</p>
-    {if $savedMapping}
-    <p>{ts}Click 'Load Saved Field Mapping' if data has been previously imported from the same source. You can then select the saved import mapping setup and load it automatically.{/ts}<p>
-    {/if}
     <p>{ts}If you think you may be importing additional data from the same data source, check 'Save this field mapping' at the bottom of the page before continuing. The saved mapping can then be easily reused the next time data is imported.{/ts}</p>
 </div>
 <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>

--- a/templates/CRM/Event/Import/Form/MapField.tpl
+++ b/templates/CRM/Event/Import/Form/MapField.tpl
@@ -14,9 +14,6 @@
 {include file="CRM/common/WizardHeader.tpl"}
 <div class="help">
     <p>{ts}Review the values shown below from the first 2 rows of your import file and select the matching CiviCRM database fields from the drop-down lists in the right-hand column. Select '- do not import -' for any columns in the import file that you want ignored.{/ts}</p>
-    {if $savedMapping}
-    <p>{ts}Click 'Load Saved Field Mapping' if data has been previously imported from the same source. You can then select the saved import mapping setup and load it automatically.{/ts}<p>
-    {/if}
     <p>{ts}If you think you may be importing additional data from the same data source, check 'Save this field mapping' at the bottom of the page before continuing. The saved mapping can then be easily reused the next time data is imported.{/ts}</p>
 </div>
 

--- a/templates/CRM/Member/Import/Form/MapField.tpl
+++ b/templates/CRM/Member/Import/Form/MapField.tpl
@@ -12,9 +12,6 @@
 {include file="CRM/common/WizardHeader.tpl"}
 <div class="help">
     <p>{ts}Review the values shown below from the first 2 rows of your import file and select the matching CiviCRM database fields from the drop-down lists in the right-hand column. Select '- do not import -' for any columns in the import file that you want ignored.{/ts}</p>
-    {if $savedMapping}
-    <p>{ts}Click 'Load Saved Field Mapping' if data has been previously imported from the same source. You can then select the saved import mapping setup and load it automatically.{/ts}<p>
-    {/if}
     <p>{ts}If you think you may be importing additional data from the same data source, check 'Save this field mapping' at the bottom of the page before continuing. The saved mapping can then be easily reused the next time data is imported.{/ts}</p>
 </div>
 <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>


### PR DESCRIPTION

Overview
----------------------------------------
Enotice fix Remove references to savedFieldMapping in page 2 of the import

Before
----------------------------------------
enotices & extraneous code

After
----------------------------------------
less of both

Technical Details
----------------------------------------
I do not believe this is ever assigned and I also don't think it makes sense
if assigned - the first page 'DataSource.tpl' is the one that displays the
option to load a field mapping. This code applies to the second page and
conditionally displays help text which seems to have stopped being true long ago

ie this is from Datasource.tpl
![image](https://user-images.githubusercontent.com/336308/124050756-4ba10180-da6f-11eb-94b0-67adf9b15bd9.png)

And this is what we see on MapField.tpl - being altered here

![image](https://user-images.githubusercontent.com/336308/124050918-9753ab00-da6f-11eb-9cf9-11eb298e7779.png)


Comments
----------------------------------------
