### PR TITLE
Throw exception rather than fatal

### DIFF
--- a/Civi/Api4/Service/Spec/SpecGatherer.php
+++ b/Civi/Api4/Service/Spec/SpecGatherer.php
@@ -159,10 +159,13 @@ class SpecGatherer {
    * @param string $entityName
    *
    * @return array
+   * @throws \API_Exception
    */
-  private function getDAOFields($entityName) {
+  private function getDAOFields(string $entityName): array {
     $bao = CoreUtil::getBAOFromApiName($entityName);
-
+    if (!$bao) {
+      throw new \API_Exception('Entity not loaded' . $entityName);
+    }
     return $bao::getSupportedFields();
   }
 


### PR DESCRIPTION

Overview
----------------------------------------
Throw exception rather than fatal

Before
----------------------------------------
Fatal error if baoName is not resolved

After
----------------------------------------
Exception thrown in baoName is not resolved

Technical Details
----------------------------------------
This makes it easier to debug if the entityName is not
resolved - in general this is a dev site issue as it is
to do with load order

Comments
----------------------------------------
