### PR TITLE
 APIv4 - Rename id_field to primary_key and make it an array

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -33,6 +33,13 @@ require_once 'CRM/Core/I18n.php';
 class CRM_Core_DAO extends DB_DataObject {
 
   /**
+   * Primary key field(s).
+   *
+   * @var string[]
+   */
+  public static $_primaryKey = ['id'];
+
+  /**
    * How many times has this instance been cloned.
    *
    * @var int

--- a/Civi/Api4/CustomValue.php
+++ b/Civi/Api4/CustomValue.php
@@ -142,7 +142,7 @@ class CustomValue {
       'class' => __CLASS__,
       'type' => ['CustomValue'],
       'searchable' => 'secondary',
-      'id_field' => 'id',
+      'primary_key' => ['id'],
       'see' => [
         'https://docs.civicrm.org/user/en/latest/organising-your-data/creating-custom-fields/#multiple-record-fieldsets',
         '\Civi\Api4\CustomGroup',

--- a/Civi/Api4/Entity.php
+++ b/Civi/Api4/Entity.php
@@ -79,8 +79,9 @@ class Entity extends Generic\AbstractEntity {
           'description' => 'Class name for dao-based entities',
         ],
         [
-          'name' => 'id_field',
-          'description' => 'Name of unique identifier field (e.g. "id")',
+          'name' => 'primary_key',
+          'type' => 'Array',
+          'description' => 'Name of unique identifier field(s) (e.g. [id])',
         ],
         [
           'name' => 'label_field',

--- a/Civi/Api4/Generic/AbstractEntity.php
+++ b/Civi/Api4/Generic/AbstractEntity.php
@@ -143,7 +143,7 @@ abstract class AbstractEntity {
         'type' => [self::stripNamespace(get_parent_class(static::class))],
         'paths' => static::getEntityPaths(),
         'class' => static::class,
-        'id_field' => 'id',
+        'primary_key' => ['id'],
         // Entities without a @searchable annotation will default to secondary,
         // which makes them visible in SearchKit but not at the top of the list.
         'searchable' => 'secondary',

--- a/Civi/Api4/Generic/AbstractEntity.php
+++ b/Civi/Api4/Generic/AbstractEntity.php
@@ -152,6 +152,7 @@ abstract class AbstractEntity {
       $dao = \CRM_Core_DAO_AllCoreTables::getFullName($info['name']);
       if ($dao) {
         $info['paths'] = $dao::getEntityPaths();
+        $info['primary_key'] = $dao::$_primaryKey;
         $info['icon'] = $dao::$_icon;
         $info['label_field'] = $dao::$_labelField;
         $info['dao'] = $dao;

--- a/Civi/Api4/Generic/BasicEntity.php
+++ b/Civi/Api4/Generic/BasicEntity.php
@@ -141,7 +141,7 @@ abstract class BasicEntity extends AbstractEntity {
    */
   public static function getInfo() {
     $info = parent::getInfo();
-    $info['id_field'] = static::$idField;
+    $info['primary_key'] = (array) static::$idField;
     return $info;
   }
 

--- a/Civi/Api4/Query/Api4SelectQuery.php
+++ b/Civi/Api4/Query/Api4SelectQuery.php
@@ -89,8 +89,8 @@ class Api4SelectQuery {
     $this->api = $apiGet;
 
     // Always select ID of main table unless grouping by something else
-    $id = CoreUtil::getInfoItem($this->getEntity(), 'id_field');
-    $this->forceSelectId = !$this->isAggregateQuery() || $this->getGroupBy() === [$id];
+    $keys = CoreUtil::getInfoItem($this->getEntity(), 'primary_key');
+    $this->forceSelectId = !$this->isAggregateQuery() || array_intersect($this->getGroupBy(), $keys);
 
     // Build field lists
     foreach ($this->api->entityFields() as $field) {
@@ -205,8 +205,8 @@ class Api4SelectQuery {
     }
     else {
       if ($this->forceSelectId) {
-        $id = CoreUtil::getInfoItem($this->getEntity(), 'id_field');
-        $select = array_merge([$id], $select);
+        $keys = CoreUtil::getInfoItem($this->getEntity(), 'primary_key');
+        $select = array_merge($keys, $select);
       }
 
       // Expand the superstar 'custom.*' to select all fields in all custom groups
@@ -233,7 +233,7 @@ class Api4SelectQuery {
         // If the joined_entity.id isn't in the fieldspec already, autoJoinFK will attempt to add the entity.
         $fkField = substr($wildField, 0, strrpos($wildField, '.'));
         $fkEntity = $this->getField($fkField)['fk_entity'] ?? NULL;
-        $id = $fkEntity ? CoreUtil::getInfoItem($fkEntity, 'id_field') : 'id';
+        $id = $fkEntity ? CoreUtil::getInfoItem($fkEntity, 'primary_key')[0] : 'id';
         $this->autoJoinFK($fkField . ".$id");
         $matches = $this->selectMatchingFields($wildField);
         array_splice($select, $pos, 1, $matches);

--- a/ext/afform/core/Civi/Api4/Afform.php
+++ b/ext/afform/core/Civi/Api4/Afform.php
@@ -229,7 +229,7 @@ class Afform extends Generic\AbstractEntity {
    */
   public static function getInfo() {
     $info = parent::getInfo();
-    $info['id_field'] = 'name';
+    $info['primary_key'] = ['name'];
     return $info;
   }
 

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/Run.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/Run.php
@@ -419,8 +419,8 @@ class Run extends \Civi\Api4\Generic\AbstractAction {
    */
   private function getExtraEntityFields(string $entityName): array {
     if (!isset($this->_extraEntityFields[$entityName])) {
-      $id = CoreUtil::getInfoItem($entityName, 'id_field');
-      $this->_extraEntityFields[$entityName] = [$id];
+      $id = CoreUtil::getInfoItem($entityName, 'primary_key');
+      $this->_extraEntityFields[$entityName] = $id;
       foreach (CoreUtil::getInfoItem($entityName, 'paths') ?? [] as $path) {
         $matches = [];
         preg_match_all('#\[(\w+)]#', $path, $matches);

--- a/tests/phpunit/api/v4/Action/BasicActionsTest.php
+++ b/tests/phpunit/api/v4/Action/BasicActionsTest.php
@@ -37,7 +37,7 @@ class BasicActionsTest extends UnitTestCase {
   public function testGetInfo() {
     $info = MockBasicEntity::getInfo();
     $this->assertEquals('MockBasicEntity', $info['name']);
-    $this->assertEquals('identifier', $info['id_field']);
+    $this->assertEquals(['identifier'], $info['primary_key']);
   }
 
   public function testCrud() {

--- a/tests/phpunit/api/v4/Entity/ConformanceTest.php
+++ b/tests/phpunit/api/v4/Entity/ConformanceTest.php
@@ -164,7 +164,8 @@ class ConformanceTest extends UnitTestCase implements HookInterface {
     $this->assertNotEmpty($info['title_plural']);
     $this->assertNotEmpty($info['type']);
     $this->assertNotEmpty($info['description']);
-    $this->assertNotEmpty($info['id_field']);
+    $this->assertIsArray($info['primary_key']);
+    $this->assertNotEmpty($info['primary_key']);
     $this->assertRegExp(';^\d\.\d+$;', $info['since']);
     $this->assertContains($info['searchable'], ['primary', 'secondary', 'bridge', 'none']);
     // Bridge must be between exactly 2 entities

--- a/xml/templates/dao.tpl
+++ b/xml/templates/dao.tpl
@@ -24,6 +24,16 @@ class {$table.className} extends CRM_Core_DAO {ldelim}
       */
       public static $_tableName = '{$table.name}';
 
+   {* Only print this variable if it's different than the default in CRM_Core_DAO *}
+   {if count($table.primaryKey.field) !== 1 || $table.primaryKey.field.0 !== 'id'}
+     /**
+      * Primary key field(s).
+      *
+      * @var string[]
+      */
+      public static $_primaryKey = [{if $table.primaryKey.field}'{"', '"|implode:$table.primaryKey.field}'{/if}];
+   {/if}
+
    {if $table.icon}
      /**
       * Icon associated with this entity.


### PR DESCRIPTION
Overview
----------------------------------------
Followup from #20707 - use an array for the identifier field because some tables have multiple primary keys.

Technical Details
--------------
This adds `$_primaryKey = ['id']` to DAOs (in the parent `CRM_Core_DAO` class) and if any entity happens to have a different primary key or set of keys in its schema then GenCode will insert that value into its generated DAO class.

APIv4 will pick up on this value and act appropriately, making use of the primary key data in its queries.