### PR TITLE
Add missing "View Recurring Contribution" link to contribution view

### DIFF
--- a/templates/CRM/Contribute/Form/ContributionView.tpl
+++ b/templates/CRM/Contribute/Form/ContributionView.tpl
@@ -78,7 +78,9 @@
       <td class="label">{ts}Contribution Amount{/ts}</td>
       <td>{include file="CRM/Price/Page/LineItem.tpl" context="Contribution"}
         {if $contribution_recur_id}
-          <strong>{ts}Recurring Contribution{/ts}</strong>
+          <a class="open-inline action-item crm-hover-button" href='{crmURL p="civicrm/contact/view/contributionrecur" q="reset=1&id=`$contribution_recur_id`&cid=`$contact_id`&context=contribution"}'>
+            {ts}View Recurring Contribution{/ts}
+          </a>
           <br/>
           {ts}Installments{/ts}: {if $recur_installments}{$recur_installments}{else}{ts}(ongoing){/ts}{/if}, {ts}Interval{/ts}: {$recur_frequency_interval} {$recur_frequency_unit}(s)
         {/if}
@@ -89,8 +91,8 @@
       <td class="label">{ts}Total Amount{/ts}</td>
       <td><strong>{$total_amount|crmMoney:$currency}</strong>
         {if $contribution_recur_id}
-          <a class="crm-hover-button" href='{crmURL p="civicrm/contact/view/contributionrecur" q="reset=1&id=`$contribution_recur_id`&cid=`$contact_id`&context=contribution"}'>
-            <strong>{ts}Recurring Contribution{/ts}</strong>
+          <a class="open-inline action-item crm-hover-button" href='{crmURL p="civicrm/contact/view/contributionrecur" q="reset=1&id=`$contribution_recur_id`&cid=`$contact_id`&context=contribution"}'>
+            {ts}View Recurring Contribution{/ts}
           </a>
           <br/>
           {ts}Installments{/ts}: {if $recur_installments}{$recur_installments}{else}{ts}(ongoing){/ts}{/if}, {ts}Interval{/ts}: {$recur_frequency_interval} {$recur_frequency_unit}(s)


### PR DESCRIPTION
Overview
----------------------------------------
Add missing "View Recurring Contribution" link to contribution view when displaying line items.

Before
----------------------------------------
Lineitems:
![image](https://user-images.githubusercontent.com/2052161/124267708-8880fd00-db30-11eb-9726-d4518fd6021b.png)

No lineitems:
![image](https://user-images.githubusercontent.com/2052161/124267789-a3ec0800-db30-11eb-8ea8-2b80b71753f8.png)


After
----------------------------------------
Lineitems:
![image](https://user-images.githubusercontent.com/2052161/124267592-5c657c00-db30-11eb-9842-e9f9c155231a.png)

No lineitems:
![image](https://user-images.githubusercontent.com/2052161/124267631-6be4c500-db30-11eb-868f-d1e7458edf09.png)


Technical Details
----------------------------------------

Comments
----------------------------------------
@jaapjansma Would you mind reviewing this one? I found it when reviewing https://github.com/civicrm/civicrm-core/pull/20399