### PR TITLE
Fix invalid defaults for Mailing.update_email_resetdate API

### DIFF
--- a/CRM/Mailing/Event/BAO/Delivered.php
+++ b/CRM/Mailing/Event/BAO/Delivered.php
@@ -263,7 +263,11 @@ class CRM_Mailing_Event_BAO_Delivered extends CRM_Mailing_Event_DAO_Delivered {
    * @param int $maxDays
    *   Consider mailings that were completed not more than $maxDays ago.
    */
-  public static function updateEmailResetDate($minDays = 3, $maxDays = 7) {
+  public static function updateEmailResetDate(int $minDays = 3, int $maxDays = 7) {
+
+    if ($minDays < 0 || $maxDays < 0 || $maxDays <= $minDays) {
+      throw new \InvalidArgumentException("minDays and maxDays must be >=0 and maxDays > minDays");
+    }
 
     $temporaryTable = CRM_Utils_SQL_TempTable::build()
       ->setCategory('mailingemail')

--- a/api/v3/Mailing.php
+++ b/api/v3/Mailing.php
@@ -782,6 +782,18 @@ function civicrm_api3_mailing_stats($params) {
   return civicrm_api3_create_success($stats);
 }
 
+function _civicrm_api3_mailing_update_email_resetdate_spec(&$spec) {
+  $spec['minDays']['title'] = 'Number of days to wait without a bounce to assume successful delivery (default 3)';
+  $spec['minDays']['type'] = CRM_Utils_Type::T_INT;
+  $spec['minDays']['api.default'] = 3;
+  $spec['minDays']['api.required'] = 1;
+
+  $spec['maxDays']['title'] = 'Analyze mailings since this many days ago (default 7)';
+  $spec['maxDays']['type'] = CRM_Utils_Type::T_INT;
+  $spec['maxDays']['api.default'] = 7;
+  $spec['maxDays']['api.required'] = 1;
+}
+
 /**
  * Fix the reset dates on the email record based on when a mail was last delivered.
  *
@@ -793,9 +805,6 @@ function civicrm_api3_mailing_stats($params) {
  * @return array
  */
 function civicrm_api3_mailing_update_email_resetdate($params) {
-  CRM_Mailing_Event_BAO_Delivered::updateEmailResetDate(
-    CRM_Utils_Array::value('minDays', $params, 3),
-    CRM_Utils_Array::value('maxDays', $params, 3)
-  );
+  CRM_Mailing_Event_BAO_Delivered::updateEmailResetDate((int) $params['minDays'], (int) $params['maxDays']);
   return civicrm_api3_create_success();
 }


### PR DESCRIPTION
Overview
----------------------------------------

A suspected typo on defaults meant that api3 `Mailing.update_email_resetdate` never did anything.


Before
----------------------------------------

The minDays and maxDays were set to the same number (3). So refering to a second in time, whereas the comments suggest the defaults would be 3 to 7 days. So the query would never match, unless a mailing completed in that particular moment!


After
----------------------------------------

Made the defaults match the comments: 3, 4 so the query has a chance of working. Also ensured the values are integers.

Comments
----------------------------------------

I can't really see why you'd not want this job running. I only just discovered it today after I experienced the problem that it exists to solve! I'm also not entirely convinced that this daily job is going to work out more efficient than including the logic in the `putEmailOnHold()` code that runs when a bounce is recorded. But I digress.
