### PR TITLE
Make report subtotals work for custom fields

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -3250,6 +3250,7 @@ WHERE cg.extends IN ('" . implode("','", $this->_customGroupExtends) . "') AND
         // let $this->_alterDisplay translate any integer ids to human-readable values.
         $rows[0] = $dao->toArray();
         $this->alterDisplay($rows);
+        $this->alterCustomDataDisplay($rows);
         $row = $rows[0];
 
         // add totals for all permutations of section values


### PR DESCRIPTION
Overview
----------------------------------------
In report, grouping on Alphanumeric custom field gives no total in group header.

To reproduce:
- on contact entity, create a custom field Alphanumeric with a list of value, check "Is this Field Searchable?"
- create a new contact report, and select the field in Sorting with Section "Header / Group By" checked
![ksnip_20210702-145825](https://user-images.githubusercontent.com/372004/124317976-fc79d000-db45-11eb-8261-c53ee61fb3e9.png)


Before
----------------------------------------
![ksnip_20210702-145236](https://user-images.githubusercontent.com/372004/124317469-38606580-db45-11eb-9533-23182aeffd70.png)

After
----------------------------------------
![ksnip_20210702-145033](https://user-images.githubusercontent.com/372004/124318027-0bf91900-db46-11eb-811a-9c63f15cfff1.png)


Technical Details
----------------------------------------
Count is done in smarty based on the label so the value must be converted to the label.

