### PR TITLE
dev/core#2659 Move group cleanup to latest release

### DIFF
--- a/CRM/Upgrade/Incremental/php/FiveThirtyNine.php
+++ b/CRM/Upgrade/Incremental/php/FiveThirtyNine.php
@@ -55,21 +55,77 @@ class CRM_Upgrade_Incremental_php_FiveThirtyNine extends CRM_Upgrade_Incremental
    * (change the x in the function name):
    */
 
-  //  /**
-  //   * Upgrade function.
-  //   *
-  //   * @param string $rev
-  //   */
-  //  public function upgrade_5_0_x($rev) {
-  //    $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
-  //    $this->addTask('Do the foo change', 'taskFoo', ...);
-  //    // Additional tasks here...
-  //    // Note: do not use ts() in the addTask description because it adds unnecessary strings to transifex.
-  //    // The above is an exception because 'Upgrade DB to %1: SQL' is generic & reusable.
-  //  }
+  /**
+   * Upgrade function.
+   *
+   * @param string $rev
+   */
+  public function upgrade_5_39_alpha1($rev) {
+    $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
+    $this->addTask('Update smart groups to rename filters on case_from and case_to to case_start_date and case_end_date', 'updateSmartGroups', [
+      'renameField' => [
+        ['old' => 'case_from_relative', 'new' => 'case_start_date_relative'],
+        ['old' => 'case_from_start_date_high', 'new' => 'case_start_date_high'],
+        ['old' => 'case_from_start_date_low', 'new' => 'case_start_date_low'],
+        ['old' => 'case_to_relative', 'new' => 'case_end_date_relative'],
+        ['old' => 'case_to_end_date_high', 'new' => 'case_end_date_high'],
+        ['old' => 'case_to_end_date_low', 'new' => 'case_end_date_low'],
+        [
+          'old' => 'mailing_date_relative',
+          'new' => 'mailing_job_start_date_relative',
+        ],
+        ['old' => 'mailing_date_high', 'new' => 'mailing_job_start_date_high'],
+        ['old' => 'mailing_date_low', 'new' => 'mailing_job_start_date_low'],
+        [
+          'old' => 'relation_start_date_low',
+          'new' => 'relationship_start_date_low',
+        ],
+        [
+          'old' => 'relation_start_date_high',
+          'new' => 'relationship_start_date_high',
+        ],
+        [
+          'old' => 'relation_start_date_relative',
+          'new' => 'relationship_start_date_relative',
+        ],
+        [
+          'old' => 'relation_end_date_low',
+          'new' => 'relationship_end_date_low',
+        ],
+        [
+          'old' => 'relation_end_date_high',
+          'new' => 'relationship_end_date_high',
+        ],
+        [
+          'old' => 'relation_end_date_relative',
+          'new' => 'relationship_end_date_relative',
+        ],
+        ['old' => 'event_start_date_low', 'new' => 'event_low'],
+        ['old' => 'event_end_date_high', 'new' => 'event_high'],
+      ],
+    ]);
+    $this->addTask('Update smart groups where jcalendar fields have been converted to datepicker', 'updateSmartGroups', [
+      'datepickerConversion' => [
+        'birth_date',
+        'deceased_date',
+        'case_start_date',
+        'case_end_date',
+        'mailing_job_start_date',
+        'relationship_start_date',
+        'relationship_end_date',
+        'event',
+        'relation_active_period_date',
+        'created_date',
+        'modified_date',
+      ],
+    ]);
 
-  // public static function taskFoo(CRM_Queue_TaskContext $ctx, ...) {
-  //   return TRUE;
-  // }
+    $this->addTask('Convert Log date searches to their final names either created date or modified date', 'updateSmartGroups', [
+      'renameLogFields' => [],
+    ]);
+    $this->addTask('Convert Custom data based smart groups from jcalendar to datepicker', 'updateSmartGroups', [
+      'convertCustomSmartGroups' => NULL,
+    ]);
+  }
 
 }

--- a/CRM/Upgrade/Incremental/php/FiveTwenty.php
+++ b/CRM/Upgrade/Incremental/php/FiveTwenty.php
@@ -93,49 +93,7 @@ class CRM_Upgrade_Incremental_php_FiveTwenty extends CRM_Upgrade_Incremental_Bas
     }
     $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
     $this->addTask('Add "Template" contribution status', 'templateStatus');
-    $this->addTask('Update smart groups to rename filters on case_from and case_to to case_start_date and case_end_date', 'updateSmartGroups', [
-      'renameField' => [
-        ['old' => 'case_from_relative', 'new' => 'case_start_date_relative'],
-        ['old' => 'case_from_start_date_high', 'new' => 'case_start_date_high'],
-        ['old' => 'case_from_start_date_low', 'new' => 'case_start_date_low'],
-        ['old' => 'case_to_relative', 'new' => 'case_end_date_relative'],
-        ['old' => 'case_to_end_date_high', 'new' => 'case_end_date_high'],
-        ['old' => 'case_to_end_date_low', 'new' => 'case_end_date_low'],
-        ['old' => 'mailing_date_relative', 'new' => 'mailing_job_start_date_relative'],
-        ['old' => 'mailing_date_high', 'new' => 'mailing_job_start_date_high'],
-        ['old' => 'mailing_date_low', 'new' => 'mailing_job_start_date_low'],
-        ['old' => 'relation_start_date_low', 'new' => 'relationship_start_date_low'],
-        ['old' => 'relation_start_date_high', 'new' => 'relationship_start_date_high'],
-        ['old' => 'relation_start_date_relative', 'new' => 'relationship_start_date_relative'],
-        ['old' => 'relation_end_date_low', 'new' => 'relationship_end_date_low'],
-        ['old' => 'relation_end_date_high', 'new' => 'relationship_end_date_high'],
-        ['old' => 'relation_end_date_relative', 'new' => 'relationship_end_date_relative'],
-        ['old' => 'event_start_date_low', 'new' => 'event_low'],
-        ['old' => 'event_end_date_high', 'new' => 'event_high'],
-      ],
-    ]);
-    $this->addTask('Convert Log date searches to their final names either created date or modified date', 'updateSmartGroups', [
-      'renameLogFields' => [],
-    ]);
-    $this->addTask('Update smart groups where jcalendar fields have been converted to datepicker', 'updateSmartGroups', [
-      'datepickerConversion' => [
-        'birth_date',
-        'deceased_date',
-        'case_start_date',
-        'case_end_date',
-        'mailing_job_start_date',
-        'relationship_start_date',
-        'relationship_end_date',
-        'event',
-        'relation_active_period_date',
-        'created_date',
-        'modified_date',
-      ],
-    ]);
     $this->addTask('Clean up unused table "civicrm_persistent"', 'dropTableIfEmpty', 'civicrm_persistent');
-    $this->addTask('Convert Custom data based smart groups from jcalendar to datepicker', 'updateSmartGroups', [
-      'convertCustomSmartGroups' => NULL,
-    ]);
   }
 
   public static function templateStatus(CRM_Queue_TaskContext $ctx) {


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#2659 Move group cleanup to latest release

Before
----------------------------------------
A site upgrading from pre 5.20 would hit errors trying to process smart group updates due to fields being in the DAO but not yet the table.

After
----------------------------------------
The updates have been moved to 5.39 - after the fields are added

Technical Details
----------------------------------------
These updates will have no impact on sites that have already run them

Comments
----------------------------------------
@demeritcowboy 