### PR TITLE
dev/core#2634 [REF] Move membership date calc from v3 api to BAO

### DIFF
--- a/CRM/Batch/Form/Entry.php
+++ b/CRM/Batch/Form/Entry.php
@@ -846,7 +846,12 @@ class CRM_Batch_Form_Entry extends CRM_Core_Form {
         // end of contribution related section
 
         unset($value['membership_type']);
-
+        $membershipParams = [
+          'start_date' => $value['membership_start_date'] ?? NULL,
+          'end_date' => $value['membership_end_date'] ?? NULL,
+          'join_date' => $value['membership_join_date'] ?? NULL,
+          'campaign_id' => $value['member_campaign_id'] ?? NULL,
+        ];
         $value['is_renew'] = FALSE;
         if (!empty($params['member_option']) && CRM_Utils_Array::value($key, $params['member_option']) == 2) {
 
@@ -873,17 +878,9 @@ class CRM_Batch_Form_Entry extends CRM_Core_Form {
           $this->setCurrentRowMembershipID($membership->id);
         }
         else {
-          $calcDates = CRM_Member_BAO_MembershipType::getDatesForMembershipType($membershipTypeId,
-            $value['membership_join_date'] ?? NULL, $value['membership_start_date'] ?? NULL, $value['membership_end_date'] ?? NULL
-          );
-          $value['join_date'] = $value['membership_join_date'] ?? $calcDates['join_date'];
-          $value['start_date'] = $value['membership_start_date'] ?? $calcDates['start_date'];
-          $value['end_date'] = $value['membership_end_date'] ?? $calcDates['end_date'];
-
-          unset($value['membership_start_date']);
-          unset($value['membership_end_date']);
-          $membership = CRM_Member_BAO_Membership::create($value);
-          $this->setCurrentRowMembershipID($membership->id);
+          // @todo - specify the relevant fields - don't copy all over
+          $membershipParams = array_merge($value, $membershipParams);
+          $membership = CRM_Member_BAO_Membership::create($membershipParams);
         }
 
         //process premiums

--- a/api/v3/Membership.php
+++ b/api/v3/Membership.php
@@ -90,19 +90,9 @@ function civicrm_api3_membership_create($params) {
 
   // Calculate membership dates
   // Fixme: This code belongs in the BAO
-  if (empty($params['id']) || !empty($params['num_terms'])) {
+  if (!empty($params['num_terms'])) {
     // If this is a new membership or we have a specified number of terms calculate membership dates.
-    if (empty($params['id'])) {
-      // This is a new membership, calculate the membership dates.
-      $calcDates = CRM_Member_BAO_MembershipType::getDatesForMembershipType(
-        $params['membership_type_id'],
-        CRM_Utils_Array::value('join_date', $params),
-        CRM_Utils_Array::value('start_date', $params),
-        CRM_Utils_Array::value('end_date', $params),
-        CRM_Utils_Array::value('num_terms', $params, 1)
-      );
-    }
-    else {
+    if (!empty($params['id'])) {
       // This is an existing membership, calculate the membership dates after renewal
       // num_terms is treated as a 'special sauce' for is_renewal but this
       // isn't really helpful for completing pendings.
@@ -112,10 +102,10 @@ function civicrm_api3_membership_create($params) {
         CRM_Utils_Array::value('membership_type_id', $params),
         $params['num_terms']
       );
-    }
-    foreach (['join_date', 'start_date', 'end_date'] as $date) {
-      if (empty($params[$date]) && isset($calcDates[$date])) {
-        $params[$date] = $calcDates[$date];
+      foreach (['join_date', 'start_date', 'end_date'] as $date) {
+        if (empty($params[$date]) && isset($calcDates[$date])) {
+          $params[$date] = $calcDates[$date];
+        }
       }
     }
   }

--- a/tests/phpunit/api/v3/MembershipTest.php
+++ b/tests/phpunit/api/v3/MembershipTest.php
@@ -315,8 +315,10 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
    * Test civicrm_membership_get with params not array.
    *
    * Gets treated as contact_id, memberships expected.
+   *
+   * @throws \CRM_Core_Exception
    */
-  public function testGetInSyntax() {
+  public function testGetInSyntax(): void {
     $this->_membershipID = $this->contactMembershipCreate($this->_params);
     $this->_membershipID2 = $this->contactMembershipCreate($this->_params);
     $this->_membershipID3 = $this->contactMembershipCreate($this->_params);


### PR DESCRIPTION
Overview
----------------------------------------
[REF] Move membership date calc from v3 api to BAO 

Before
----------------------------------------
code to calculated membership dates  for new membership is in the v3 api and in every form that creates memberships

After
----------------------------------------
calculated in the BAO for v3 api & membership batch entry form

Technical Details
----------------------------------------
This moves code to calculate membership dates for new memberships from the
v3 api Membership.create and the batch entry membership form to the membership bao.

I think more cleanup could follow this - in the api most obviously and
the BAO is a bit insane still

This has test cover in the v3 api membership test and in
CRM_Batch_Form_EntryTest

Comments
----------------------------------------
Note this was originally https://github.com/civicrm/civicrm-core/pull/20397 - it's been closed for 6 weeks waiting for me to devote the time to figure out the test failure & I'm going to discuss that here

Basically the failure was because in the BAO there was an assumption that is_override meant 'do not calculate missing dates OR the membership status' whereas the api understood it to mean ' do not calculate membership status'

In the end I settled on the api interpretation because

1) the api is the main way in which Membership.create is interacted with. There are a number of places in core that call the BAO directly but these generally pass in the dates already calculated and I've added pretty extensive coverage I believe.
2) all the evidence I can find is that 'is_override' refers to status, not dates