### PR TITLE
dev/core#2115 Add test cover for membership type page

### DIFF
--- a/ext/financialacls/tests/phpunit/Civi/Financialacls/BaseTestClass.php
+++ b/ext/financialacls/tests/phpunit/Civi/Financialacls/BaseTestClass.php
@@ -45,6 +45,7 @@ class BaseTestClass extends \PHPUnit\Framework\TestCase implements HeadlessInter
     $this->setPermissions([
       'access CiviCRM',
       'access CiviContribute',
+      'access CiviMember',
       'edit contributions',
       'delete in CiviContribute',
       'view contributions of type Donation',

--- a/tests/phpunit/CRM/Member/Page/MembershipTypeTest.php
+++ b/tests/phpunit/CRM/Member/Page/MembershipTypeTest.php
@@ -1,0 +1,50 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *  Test CRM_Member_Form_Membership functions.
+ *
+ * @package   CiviCRM
+ * @group headless
+ */
+class CRM_Member_Page_MembershipTypeTest extends CiviUnitTestCase {
+
+  /**
+   * Test the membership type page loads correctly.
+   */
+  public function testMembershipTypePage(): void {
+    $page = new CRM_Member_Page_MembershipType();
+    $id = $this->membershipTypeCreate(['weight' => 1]);
+    $page->browse();
+    $assigned = CRM_Core_Smarty::singleton()->get_template_vars();
+    $this->assertEquals([
+      $id => [
+        'id' => '1',
+        'domain_id' => '1',
+        'name' => 'General',
+        'membership_type' => 'General',
+        'member_of_contact_id' => '3',
+        'financial_type_id' => '2',
+        'minimum_fee' => '0.000000000',
+        'duration_unit' => 'year',
+        'duration_interval' => '1',
+        'period_type' => 'Rolling',
+        'visibility' => 'Public',
+        'weight' => '1',
+        'auto_renew' => '0',
+        'is_active' => '1',
+        'order' => NULL,
+        'action' => '<span><a href="/index.php?q=civicrm/admin/member/membershipType/add&amp;action=update&amp;id=' . $id . '&amp;reset=1" class="action-item crm-hover-button" title=\'Edit Membership Type\' >Edit</a><a href="#" class="action-item crm-hover-button crm-enable-disable" title=\'Disable Membership Type\' >Disable</a><a href="/index.php?q=civicrm/admin/member/membershipType/add&amp;action=delete&amp;id=1" class="action-item crm-hover-button small-popup" title=\'Delete Membership Type\' >Delete</a></span>',
+      ],
+    ], $assigned['rows']);
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Add test cover for membership type page

Before
----------------------------------------
No test cover so we can't work on switching it to use v4 api / removing financial acl code 

After
----------------------------------------
Cover added for the detail in core & the get call in the extension

Technical Details
----------------------------------------

Comments
----------------------------------------
