### PR TITLE
dev/core#2115 prep - Remove silly if, silly rename

### DIFF
--- a/CRM/Member/Page/MembershipType.php
+++ b/CRM/Member/Page/MembershipType.php
@@ -123,7 +123,6 @@ class CRM_Member_Page_MembershipType extends CRM_Core_Page {
             $value, $relationshipName
           );
         }
-        $membershipType[$dao->id]['maxRelated'] = $membershipType[$dao->id]['max_related'] ?? NULL;
       }
       if (CRM_Financial_BAO_FinancialType::isACLFinancialTypeStatus() && !CRM_Core_Permission::check('edit contributions of type ' . CRM_Contribute_PseudoConstant::financialType($dao->financial_type_id))) {
         unset($links[CRM_Core_Action::UPDATE], $links[CRM_Core_Action::ENABLE], $links[CRM_Core_Action::DISABLE]);
@@ -134,24 +133,22 @@ class CRM_Member_Page_MembershipType extends CRM_Core_Page {
       // form all action links
       $action = array_sum(array_keys($this->links()));
 
-      // update enable/disable links depending on if it is is_reserved or is_active
-      if (!isset($dao->is_reserved)) {
-        if ($dao->is_active) {
-          $action -= CRM_Core_Action::ENABLE;
-        }
-        else {
-          $action -= CRM_Core_Action::DISABLE;
-        }
-        $membershipType[$dao->id]['order'] = $membershipType[$dao->id]['weight'];
-        $membershipType[$dao->id]['action'] = CRM_Core_Action::formLink($links, $action,
-          ['id' => $dao->id],
-          ts('more'),
-          FALSE,
-          'membershipType.manage.action',
-          'MembershipType',
-          $dao->id
-        );
+      // update enable/disable links depending on if it is_active
+      if ($dao->is_active) {
+        $action -= CRM_Core_Action::ENABLE;
       }
+      else {
+        $action -= CRM_Core_Action::DISABLE;
+      }
+      $membershipType[$dao->id]['order'] = $membershipType[$dao->id]['weight'];
+      $membershipType[$dao->id]['action'] = CRM_Core_Action::formLink($links, $action,
+        ['id' => $dao->id],
+        ts('more'),
+        FALSE,
+        'membershipType.manage.action',
+        'MembershipType',
+        $dao->id
+      );
     }
 
     $returnURL = CRM_Utils_System::url('civicrm/admin/member/membershipType', "reset=1&action=browse");

--- a/templates/CRM/Member/Page/MembershipType.tpl
+++ b/templates/CRM/Member/Page/MembershipType.tpl
@@ -45,7 +45,7 @@
           <td class="crmf-duration_interval_unit">{$row.duration_interval} {$row.duration_unit}</td>
           <td class="crmf-auto_renew">{if $row.auto_renew EQ 2}{ts}Required{/ts}{elseif $row.auto_renew EQ 1}{ts}Optional{/ts}{else}{ts}No{/ts}{/if}</td>
           <td class="crmf-relationship_type">{$row.relationshipTypeName}</td>
-          <td class="crmf-max_related" align="right">{$row.maxRelated}</td>
+          <td class="crmf-max_related" align="right">{$row.max_related}</td>
           <td class="crmf-visibility crm-editable" data-type="select">{$row.visibility}</td>
           <td class="nowrap crmf-weight">{$row.weight}</td>
           <td class="crmf-is_active">{if $row.is_active eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>


### PR DESCRIPTION
This removes an if which would only be true if civicrm_membership_type table had the
field is_reserved and it was set to true. Given condition 1 is not met, 2
cannot be met.

Also - we rename max_related to maxRelated for no-good-reason

Overview
----------------------------------------
_A brief description of the pull request. Keep technical jargon to a minimum. Hyperlink relevant discussions._

Before
----------------------------------------
_What is the old user-interface or technical-contract (as appropriate)?_
_For optimal clarity, include a concrete example such as a screenshot, GIF ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)), or code-snippet._

After
----------------------------------------
_What changed? What is new old user-interface or technical-contract?_
_For optimal clarity, include a concrete example such as a screenshot, GIF ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)), or code-snippet._

Technical Details
----------------------------------------
_If the PR involves technical details/changes/considerations which would not be manifest to a casual developer skimming the above sections, please describe the details here._

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
