### PR TITLE
SearchKit - Add ability to join on multi-select ContactRef fields

### DIFF
--- a/Civi/Api4/Generic/Traits/DAOActionTrait.php
+++ b/Civi/Api4/Generic/Traits/DAOActionTrait.php
@@ -224,7 +224,10 @@ trait DAOActionTrait {
           formatCheckBoxField($value, 'custom_' . $field['id'], $this->getEntityName());
         }
 
-        if ($field['data_type'] === 'ContactReference' && !is_numeric($value)) {
+        // Match contact id to strings like "user_contact_id"
+        // FIXME handle arrays for multi-value contact reference fields, etc.
+        if ($field['data_type'] === 'ContactReference' && is_string($value) && !is_numeric($value)) {
+          // FIXME decouple from v3 API
           require_once 'api/v3/utils.php';
           $value = \_civicrm_api3_resolve_contactID($value);
           if ('unknown-user' === $value) {

--- a/Civi/Api4/Service/Schema/Joinable/Joinable.php
+++ b/Civi/Api4/Service/Schema/Joinable/Joinable.php
@@ -71,6 +71,11 @@ class Joinable {
   protected $entity;
 
   /**
+   * @var int
+   */
+  protected $serialize;
+
+  /**
    * @var bool
    */
   protected $deprecated = FALSE;
@@ -232,6 +237,24 @@ class Joinable {
   }
 
   /**
+   * @return int|NULL
+   */
+  public function getSerialize():? int {
+    return $this->serialize;
+  }
+
+  /**
+   * @param int|NULL $serialize
+   *
+   * @return $this
+   */
+  public function setSerialize(?int $serialize) {
+    $this->serialize = $serialize;
+
+    return $this;
+  }
+
+  /**
    * @return int
    */
   public function getJoinType() {
@@ -280,6 +303,14 @@ class Joinable {
     /** @var \Civi\Api4\Service\Spec\SpecGatherer $gatherer */
     $gatherer = \Civi::container()->get('spec_gatherer');
     $spec = $gatherer->getSpec($this->entity, 'get', FALSE);
+    // Serialized fields require a specialized join
+    if ($this->serialize) {
+      foreach ($spec as $field) {
+        // The callback function expects separated values as output
+        $field->setSerialize(\CRM_Core_DAO::SERIALIZE_SEPARATOR_TRIMMED);
+        $field->setSqlRenderer(['Civi\Api4\Query\Api4SelectQuery', 'renderSerializedJoin']);
+      }
+    }
     return $spec;
   }
 

--- a/Civi/Api4/Service/Schema/Joiner.php
+++ b/Civi/Api4/Service/Schema/Joiner.php
@@ -73,6 +73,11 @@ class Joiner {
       if ($link->isDeprecated()) {
         \CRM_Core_Error::deprecatedWarning("Deprecated join alias '$alias' used in APIv4 get. Should be changed to '{$alias}_id'");
       }
+      // Serialized joins are rendered by Api4SelectQuery::renderSerializedJoin
+      if ($link->getSerialize()) {
+        // Virtual join, don't actually add this table
+        break;
+      }
 
       $bao = $joinEntity ? CoreUtil::getBAOFromApiName($joinEntity) : NULL;
       $conditions = $link->getConditionsForJoin($baseTableAlias);

--- a/Civi/Api4/Service/Schema/SchemaMapBuilder.php
+++ b/Civi/Api4/Service/Schema/SchemaMapBuilder.php
@@ -154,7 +154,7 @@ class SchemaMapBuilder {
     }
     $fieldData = \CRM_Utils_SQL_Select::from('civicrm_custom_field f')
       ->join('custom_group', 'INNER JOIN civicrm_custom_group g ON g.id = f.custom_group_id')
-      ->select(['g.name as custom_group_name', 'g.table_name', 'g.is_multiple', 'f.name', 'f.data_type', 'label', 'column_name', 'option_group_id'])
+      ->select(['g.name as custom_group_name', 'g.table_name', 'g.is_multiple', 'f.name', 'f.data_type', 'label', 'column_name', 'option_group_id', 'serialize'])
       ->where('g.extends IN (@entity)', ['@entity' => $customInfo['extends']])
       ->where('g.is_active')
       ->where('f.is_active')
@@ -185,6 +185,9 @@ class SchemaMapBuilder {
 
       if ($fieldData->data_type === 'ContactReference') {
         $joinable = new Joinable('civicrm_contact', 'id', $fieldData->name);
+        if ($fieldData->serialize) {
+          $joinable->setSerialize((int) $fieldData->serialize);
+        }
         $customTable->addTableLink($fieldData->column_name, $joinable);
       }
     }

--- a/ext/search_kit/Civi/Search/Admin.php
+++ b/ext/search_kit/Civi/Search/Admin.php
@@ -124,7 +124,7 @@ class Admin {
     foreach ($schema as &$entity) {
       if ($entity['searchable'] !== 'bridge') {
         foreach (array_reverse($entity['fields'], TRUE) as $index => $field) {
-          if (!empty($field['fk_entity']) && !$field['options'] && empty($field['serialize']) && !empty($schema[$field['fk_entity']]['label_field'])) {
+          if (!empty($field['fk_entity']) && !$field['options'] && !empty($schema[$field['fk_entity']]['label_field'])) {
             $isCustom = strpos($field['name'], '.');
             // Custom fields: append "Contact ID" to original field label
             if ($isCustom) {

--- a/ext/search_kit/ang/crmSearchDisplay/colType/field.html
+++ b/ext/search_kit/ang/crmSearchDisplay/colType/field.html
@@ -2,6 +2,10 @@
 <span ng-if="::!col.link" ng-class="{'crm-editable-enabled': col.editable && !$ctrl.editing && row[col.editable.id]}" ng-click="col.editable && !$ctrl.editing && ($ctrl.editing = [rowIndex, col.key])">
   {{:: $ctrl.formatFieldValue(row, col) }}
 </span>
-<a ng-if="::col.link" target="{{:: col.link.target }}" href="{{:: displayUtils.getUrl(col.link.path, row) }}">
-  {{:: $ctrl.formatFieldValue(row, col) }}
-</a>
+<span ng-if="::col.link">
+  <span ng-repeat="link in $ctrl.getLinks(row, col)">
+    <a target="{{:: col.link.target }}" href="{{:: link.url }}">
+      {{:: link.value }}</a><span ng-if="!$last">,
+    </span>
+  </span>
+</span>

--- a/ext/search_kit/ang/crmSearchDisplayList/crmSearchDisplayList.component.js
+++ b/ext/search_kit/ang/crmSearchDisplayList/crmSearchDisplayList.component.js
@@ -61,6 +61,14 @@
         return searchDisplayUtils.formatDisplayValue(rowData, col.key, ctrl.settings.columns);
       };
 
+      this.getLinks = function(rowData, col) {
+        rowData._links = rowData._links || {};
+        if (!(col.key in rowData._links)) {
+          rowData._links[col.key] = searchDisplayUtils.formatLinks(rowData, col.key, ctrl.settings.columns);
+        }
+        return rowData._links[col.key];
+      };
+
     }
   });
 

--- a/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTable.component.js
+++ b/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTable.component.js
@@ -109,6 +109,14 @@
         return searchDisplayUtils.formatDisplayValue(rowData, col.key, ctrl.settings.columns);
       };
 
+      this.getLinks = function(rowData, col) {
+        rowData._links = rowData._links || {};
+        if (!(col.key in rowData._links)) {
+          rowData._links[col.key] = searchDisplayUtils.formatLinks(rowData, col.key, ctrl.settings.columns);
+        }
+        return rowData._links[col.key];
+      };
+
       $scope.selectAllRows = function() {
         // Deselect all
         if (ctrl.allRowsSelected) {


### PR DESCRIPTION
Overview
----------------------------------------
Improves support for custom contactRef fields in APIv4, SearchKit, and Afform. Makes it possible to save, search for, and filter by serialized (multi-select) custom ContactRef fields.

Before
----------------------------------------
- Bug prevents saving custom contactRef data in APIv4
- Serialized custom contactRef  outputs as numbers rather than display names in SearchKit
- Not possible to create links for serialized contactRef fields in SearchKit
- Bug gave incorrect results when filtering with a multiselect afform contactRef field

After
----------------------------------------
- Saving custom contactRef data in APIv4 fixed, with test
- Serialized custom contactRef  outputs display names in SearchKit
- Possible to create links for serialized contactRef fields in SearchKit
- Fixed filtering with a multiselect afform contactRef field, added test
- Also made it possible to use a text field instead of an autocomplete-select as a contactRef search filter in Afform

Comments
----------------------------------------
This also reverts #20156 as the limitation has been lifted.
