### PR TITLE
APIv4 - Deprecate passing 'id' to basic actions

### DIFF
--- a/Civi/Api4/CustomValue.php
+++ b/Civi/Api4/CustomValue.php
@@ -99,7 +99,7 @@ class CustomValue {
    * @throws \API_Exception
    */
   public static function replace($customGroup, $checkPermissions = TRUE) {
-    return (new Generic\BasicReplaceAction("Custom_$customGroup", __FUNCTION__, ['id', 'entity_id']))
+    return (new Generic\BasicReplaceAction("Custom_$customGroup", __FUNCTION__))
       ->setCheckPermissions($checkPermissions);
   }
 

--- a/Civi/Api4/Generic/AbstractBatchAction.php
+++ b/Civi/Api4/Generic/AbstractBatchAction.php
@@ -12,6 +12,8 @@
 
 namespace Civi\Api4\Generic;
 
+use Civi\Api4\Utils\CoreUtil;
+
 /**
  * Base class for all batch actions (Update, Delete, Replace).
  *
@@ -30,23 +32,6 @@ abstract class AbstractBatchAction extends AbstractQueryAction {
   protected $where = [];
 
   /**
-   * @var array
-   */
-  private $select;
-
-  /**
-   * BatchAction constructor.
-   * @param string $entityName
-   * @param string $actionName
-   * @param string|array $select
-   *   One or more fields to load for each item.
-   */
-  public function __construct($entityName, $actionName, $select = 'id') {
-    $this->select = (array) $select;
-    parent::__construct($entityName, $actionName);
-  }
-
-  /**
    * Get a list of records for this batch.
    *
    * @return array
@@ -56,7 +41,7 @@ abstract class AbstractBatchAction extends AbstractQueryAction {
   }
 
   /**
-   * Get a query which resolves the list of records for this batch.
+   * Get an API action object which resolves the list of records for this batch.
    *
    * This is similar to `getBatchRecords()`, but you may further refine the
    * API call (e.g. selecting different fields or data-pages) before executing.
@@ -72,16 +57,20 @@ abstract class AbstractBatchAction extends AbstractQueryAction {
       'offset' => $this->offset,
     ];
     if (empty($this->reload)) {
-      $params['select'] = $this->select;
+      $params['select'] = $this->getSelect();
     }
     return \Civi\API\Request::create($this->getEntityName(), 'get', ['version' => 4] + $params);
   }
 
   /**
-   * @return array
+   * Determines what fields will be returned by getBatchRecords
+   *
+   * Defaults to an entity's primary key(s), typically ['id']
+   *
+   * @return string[]
    */
   protected function getSelect() {
-    return $this->select;
+    return CoreUtil::getInfoItem($this->getEntityName(), 'primary_key');
   }
 
 }

--- a/Civi/Api4/Generic/BasicBatchAction.php
+++ b/Civi/Api4/Generic/BasicBatchAction.php
@@ -43,13 +43,19 @@ class BasicBatchAction extends AbstractBatchAction {
    *
    * @param string $entityName
    * @param string $actionName
-   * @param string|array $select
-   *   One or more fields to select from each matching item.
    * @param callable $doer
    */
-  public function __construct($entityName, $actionName, $select = 'id', $doer = NULL) {
-    parent::__construct($entityName, $actionName, $select);
+  public function __construct($entityName, $actionName, $doer = NULL) {
+    parent::__construct($entityName, $actionName);
     $this->doer = $doer;
+    // Accept doer as 4th param for now, but emit deprecated warning
+    $this->doer = func_get_args()[3] ?? NULL;
+    if ($this->doer) {
+      \CRM_Core_Error::deprecatedWarning(__CLASS__ . ' constructor received $doer as 4th param; it should be the 3rd as the $select param has been removed');
+    }
+    else {
+      $this->doer = $doer;
+    }
   }
 
   /**

--- a/Civi/Api4/Generic/BasicEntity.php
+++ b/Civi/Api4/Generic/BasicEntity.php
@@ -105,7 +105,7 @@ abstract class BasicEntity extends AbstractEntity {
    * @return BasicSaveAction
    */
   public static function save($checkPermissions = TRUE) {
-    return (new BasicSaveAction(static::getEntityName(), __FUNCTION__, static::$idField, static::$setter))
+    return (new BasicSaveAction(static::getEntityName(), __FUNCTION__, static::$setter))
       ->setCheckPermissions($checkPermissions);
   }
 
@@ -114,7 +114,7 @@ abstract class BasicEntity extends AbstractEntity {
    * @return BasicUpdateAction
    */
   public static function update($checkPermissions = TRUE) {
-    return (new BasicUpdateAction(static::getEntityName(), __FUNCTION__, static::$idField, static::$setter))
+    return (new BasicUpdateAction(static::getEntityName(), __FUNCTION__, static::$setter))
       ->setCheckPermissions($checkPermissions);
   }
 
@@ -123,7 +123,7 @@ abstract class BasicEntity extends AbstractEntity {
    * @return BasicBatchAction
    */
   public static function delete($checkPermissions = TRUE) {
-    return (new BasicBatchAction(static::getEntityName(), __FUNCTION__, static::$idField, static::$deleter))
+    return (new BasicBatchAction(static::getEntityName(), __FUNCTION__, static::$deleter))
       ->setCheckPermissions($checkPermissions);
   }
 
@@ -132,7 +132,7 @@ abstract class BasicEntity extends AbstractEntity {
    * @return BasicReplaceAction
    */
   public static function replace($checkPermissions = TRUE) {
-    return (new BasicReplaceAction(static::getEntityName(), __FUNCTION__, static::$idField))
+    return (new BasicReplaceAction(static::getEntityName(), __FUNCTION__))
       ->setCheckPermissions($checkPermissions);
   }
 

--- a/Civi/Api4/Generic/BasicSaveAction.php
+++ b/Civi/Api4/Generic/BasicSaveAction.php
@@ -30,12 +30,18 @@ class BasicSaveAction extends AbstractSaveAction {
    *
    * @param string $entityName
    * @param string $actionName
-   * @param string $idField
    * @param callable $setter
    */
-  public function __construct($entityName, $actionName, $idField = 'id', $setter = NULL) {
-    parent::__construct($entityName, $actionName, $idField);
-    $this->setter = $setter;
+  public function __construct($entityName, $actionName, $setter = NULL) {
+    parent::__construct($entityName, $actionName);
+    // Accept setter as 4th param for now, but emit deprecated warning
+    $this->setter = func_get_args()[3] ?? NULL;
+    if ($this->setter) {
+      \CRM_Core_Error::deprecatedWarning(__CLASS__ . ' constructor received $setter as 4th param; it should be the 3rd as the $select param has been removed');
+    }
+    else {
+      $this->setter = $setter;
+    }
   }
 
   /**

--- a/Civi/Api4/Generic/BasicUpdateAction.php
+++ b/Civi/Api4/Generic/BasicUpdateAction.php
@@ -13,8 +13,6 @@
 namespace Civi\Api4\Generic;
 
 use Civi\API\Exception\NotImplementedException;
-use Civi\API\Exception\UnauthorizedException;
-use Civi\Api4\Utils\CoreUtil;
 
 /**
  * Update one or more $ENTITY with new values.
@@ -34,33 +32,27 @@ class BasicUpdateAction extends AbstractUpdateAction {
    *
    * @param string $entityName
    * @param string $actionName
-   * @param string|array $select
-   *   One or more fields to select from each matching item.
    * @param callable $setter
    */
-  public function __construct($entityName, $actionName, $select = 'id', $setter = NULL) {
-    parent::__construct($entityName, $actionName, $select);
-    $this->setter = $setter;
+  public function __construct($entityName, $actionName, $setter = NULL) {
+    parent::__construct($entityName, $actionName);
+    // Accept setter as 4th param for now, but emit deprecated warning
+    $this->setter = func_get_args()[3] ?? NULL;
+    if ($this->setter) {
+      \CRM_Core_Error::deprecatedWarning(__CLASS__ . ' constructor received $setter as 4th param; it should be the 3rd as the $select param has been removed');
+    }
+    else {
+      $this->setter = $setter;
+    }
   }
 
   /**
-   * We pass the writeRecord function an array representing one item to update.
-   * We expect to get the same format back.
-   *
-   * @param \Civi\Api4\Generic\Result $result
+   * @param array $items
+   * @return array
    * @throws \API_Exception
-   * @throws \Civi\API\Exception\NotImplementedException
    */
-  public function _run(Result $result) {
-    $this->formatWriteValues($this->values);
-    $this->validateValues();
-    foreach ($this->getBatchRecords() as $item) {
-      $record = $this->values + $item;
-      if ($this->checkPermissions && !CoreUtil::checkAccessRecord($this, $record, \CRM_Core_Session::getLoggedInContactID() ?: 0)) {
-        throw new UnauthorizedException("ACL check failed");
-      }
-      $result[] = $this->writeRecord($record);
-    }
+  protected function updateRecords(array $items): array {
+    return array_map([$this, 'writeRecord'], $items);
   }
 
   /**

--- a/Civi/Api4/Generic/DAOUpdateAction.php
+++ b/Civi/Api4/Generic/DAOUpdateAction.php
@@ -12,70 +12,23 @@
 
 namespace Civi\Api4\Generic;
 
-use Civi\API\Exception\UnauthorizedException;
-use Civi\Api4\Utils\CoreUtil;
-
 /**
  * Update one or more $ENTITY with new values.
  *
- * Use the `where` clause (required) to select them.
+ * Use the `where` clause to bulk update multiple records,
+ * or supply 'id' as a value to update a single record.
  */
 class DAOUpdateAction extends AbstractUpdateAction {
   use Traits\DAOActionTrait;
 
   /**
-   * Criteria for selecting items to update.
-   *
-   * Required if no id is supplied in values.
-   *
-   * @var array
+   * @param array $items
+   * @return array
+   * @throws \API_Exception
+   * @throws \CRM_Core_Exception
    */
-  protected $where = [];
-
-  /**
-   * @inheritDoc
-   */
-  public function _run(Result $result) {
-    $this->formatWriteValues($this->values);
-    // Add ID from values to WHERE clause and check for mismatch
-    if (!empty($this->values['id'])) {
-      $wheres = array_column($this->where, NULL, 0);
-      if (!isset($wheres['id'])) {
-        $this->addWhere('id', '=', $this->values['id']);
-      }
-      elseif (!($wheres['id'][1] === '=' && $wheres['id'][2] == $this->values['id'])) {
-        throw new \Exception("Cannot update the id of an existing " . $this->getEntityName() . '.');
-      }
-    }
-
-    // Require WHERE if we didn't get an ID from values
-    if (!$this->where) {
-      throw new \API_Exception('Parameter "where" is required unless an id is supplied in values.');
-    }
-
-    // Update a single record by ID unless select requires more than id
-    if ($this->getSelect() === ['id'] && count($this->where) === 1 && $this->where[0][0] === 'id' && $this->where[0][1] === '=' && !empty($this->where[0][2])) {
-      $this->values['id'] = $this->where[0][2];
-      if ($this->checkPermissions && !CoreUtil::checkAccessRecord($this, $this->values, \CRM_Core_Session::getLoggedInContactID() ?: 0)) {
-        throw new UnauthorizedException("ACL check failed");
-      }
-      $items = [$this->values];
-      $this->validateValues();
-      $result->exchangeArray($this->writeObjects($items));
-      return;
-    }
-
-    // Batch update 1 or more records based on WHERE clause
-    $items = $this->getBatchRecords();
-    foreach ($items as &$item) {
-      $item = $this->values + $item;
-      if ($this->checkPermissions && !CoreUtil::checkAccessRecord($this, $item, \CRM_Core_Session::getLoggedInContactID() ?: 0)) {
-        throw new UnauthorizedException("ACL check failed");
-      }
-    }
-
-    $this->validateValues();
-    $result->exchangeArray($this->writeObjects($items));
+  protected function updateRecords(array $items): array {
+    return $this->writeObjects($items);
   }
 
 }

--- a/Civi/Api4/Generic/Traits/CustomValueActionTrait.php
+++ b/Civi/Api4/Generic/Traits/CustomValueActionTrait.php
@@ -24,7 +24,7 @@ trait CustomValueActionTrait {
 
   public function __construct($customGroup, $actionName) {
     $this->customGroup = $customGroup;
-    parent::__construct('CustomValue', $actionName, ['id', 'entity_id']);
+    parent::__construct('CustomValue', $actionName);
   }
 
   /**

--- a/ext/afform/core/Civi/Api4/Afform.php
+++ b/ext/afform/core/Civi/Api4/Afform.php
@@ -44,7 +44,7 @@ class Afform extends Generic\AbstractEntity {
    * @return Action\Afform\Update
    */
   public static function update($checkPermissions = TRUE) {
-    return (new Action\Afform\Update('Afform', __FUNCTION__, 'name'))
+    return (new Action\Afform\Update('Afform', __FUNCTION__))
       ->setCheckPermissions($checkPermissions);
   }
 
@@ -53,7 +53,7 @@ class Afform extends Generic\AbstractEntity {
    * @return Action\Afform\Save
    */
   public static function save($checkPermissions = TRUE) {
-    return (new Action\Afform\Save('Afform', __FUNCTION__, 'name'))
+    return (new Action\Afform\Save('Afform', __FUNCTION__))
       ->setCheckPermissions($checkPermissions);
   }
 
@@ -89,7 +89,7 @@ class Afform extends Generic\AbstractEntity {
    * @return Generic\BasicBatchAction
    */
   public static function revert($checkPermissions = TRUE) {
-    return (new BasicBatchAction('Afform', __FUNCTION__, ['name'], function($item, BasicBatchAction $action) {
+    return (new BasicBatchAction('Afform', __FUNCTION__, function($item, BasicBatchAction $action) {
       $scanner = \Civi::service('afform_scanner');
       $files = [
         \CRM_Afform_AfformScanner::METADATA_FILE,

--- a/tests/phpunit/api/v4/Action/BasicActionsTest.php
+++ b/tests/phpunit/api/v4/Action/BasicActionsTest.php
@@ -48,18 +48,26 @@ class BasicActionsTest extends UnitTestCase {
     $result = MockBasicEntity::get()->execute();
     $this->assertCount(1, $result);
 
-    $id2 = MockBasicEntity::create()->addValue('foo', 'two')->execute()->first()['identifier'];
+    $id2 = MockBasicEntity::create()
+      ->addValue('foo', 'two')
+      ->addValue('group:label', 'First')
+      ->execute()->first()['identifier'];
 
     $result = MockBasicEntity::get()->selectRowCount()->execute();
     $this->assertEquals(2, $result->count());
 
+    // Updating a single record should support identifier either in the values or the where clause
+    // Test both styles of update
     MockBasicEntity::update()->addWhere('identifier', '=', $id2)->addValue('foo', 'new')->execute();
+    MockBasicEntity::update()->addValue('identifier', $id2)->addValue('color', 'red')->execute();
 
     $result = MockBasicEntity::get()->addOrderBy('identifier', 'DESC')->setLimit(1)->execute();
     // The object's count() method will account for all results, ignoring limit, while the array results are limited
     $this->assertCount(2, $result);
     $this->assertCount(1, (array) $result);
     $this->assertEquals('new', $result->first()['foo']);
+    $this->assertEquals('red', $result->first()['color']);
+    $this->assertEquals('one', $result->first()['group']);
 
     $result = MockBasicEntity::save()
       ->addRecord(['identifier' => $id1, 'foo' => 'one updated', 'weight' => '5'])
@@ -252,7 +260,7 @@ class BasicActionsTest extends UnitTestCase {
     }
 
     $result = MockBasicEntity::get()
-      ->addSelect('*e', 'weig*ht')
+      ->addSelect('s*e', 'weig*ht')
       ->execute()
       ->first();
     $this->assertEquals(['shape', 'size', 'weight'], array_keys($result));

--- a/tests/phpunit/api/v4/Mock/Api4/Action/MockBasicEntity/BatchFrobnicate.php
+++ b/tests/phpunit/api/v4/Mock/Api4/Action/MockBasicEntity/BatchFrobnicate.php
@@ -10,20 +10,29 @@
  +--------------------------------------------------------------------+
  */
 
-namespace Civi\Api4\Action\CustomValue;
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+
+namespace Civi\Api4\Action\MockBasicEntity;
 
 /**
- * Update one or more records with new values. Use the where clause to select them.
+ * This class demonstrates how the getRecords method of Basic\Get can be overridden.
  */
-class Update extends \Civi\Api4\Generic\DAOUpdateAction {
-  use \Civi\Api4\Generic\Traits\CustomValueActionTrait;
+class BatchFrobnicate extends \Civi\Api4\Generic\BasicBatchAction {
 
-  /**
-   * Ensure entity_id is returned by getBatchRecords()
-   * @return string[]
-   */
+  protected function doTask($item) {
+    return [
+      'identifier' => $item['identifier'],
+      'frobnication' => $item['number'] * $item['number'],
+    ];
+  }
+
   protected function getSelect() {
-    return ['id', 'entity_id'];
+    return ['identifier', 'number'];
   }
 
 }

--- a/tests/phpunit/api/v4/Mock/Api4/MockBasicEntity.php
+++ b/tests/phpunit/api/v4/Mock/Api4/MockBasicEntity.php
@@ -96,12 +96,8 @@ class MockBasicEntity extends Generic\BasicEntity {
    * @return Generic\BasicBatchAction
    */
   public static function batchFrobnicate($checkPermissions = TRUE) {
-    return (new Generic\BasicBatchAction(__CLASS__, __FUNCTION__, ['identifier', 'number'], function($item) {
-      return [
-        'identifier' => $item['identifier'],
-        'frobnication' => $item['number'] * $item['number'],
-      ];
-    }))->setCheckPermissions($checkPermissions);
+    return (new Action\MockBasicEntity\BatchFrobnicate(__CLASS__, __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Refactors some of the APIv4 internals to make better use of the new `primary_key` info.

Before
----------------------------------------
Basic action classes require 'id' to be passed in.
Duplicated code between `DAOUpdate` and `BasicUpdate` actions. 

After
----------------------------------------
They can figure it out using entity metadata.

Technical Details
----------------------------------------
The primary_key is now known for every entity so the basic action classes can get it using `getInfo()`.

This accepts the old constructor arguments for backward-compatibility, for now.