### PR TITLE
Fix super recent api regression

### DIFF
--- a/Civi/Api4/Query/Api4SelectQuery.php
+++ b/Civi/Api4/Query/Api4SelectQuery.php
@@ -205,7 +205,7 @@ class Api4SelectQuery {
     }
     else {
       if ($this->forceSelectId) {
-        $keys = CoreUtil::getInfoItem($this->getEntity(), 'primary_key');
+        $keys = (array) CoreUtil::getInfoItem($this->getEntity(), 'primary_key');
         $select = array_merge($keys, $select);
       }
 


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a fatal caused by a very recently merged patch

Before
----------------------------------------
```
      $contactDashboards = (array) DashboardContact::get(FALSE)
        ->addSelect('column_no', 'is_active', 'dashboard_id', 'weight', 'contact_id')
        ->addWhere('contact_id', '=', $cid)
        ->addOrderBy('weight')
        ->execute()->indexBy('dashboard_id');
```

results in a fatal (from BAO_Dashboard)

After
----------------------------------------
Works

Technical Details
----------------------------------------
The altered line was returning null & the next line was turning $select into a null when it tried to array_merge it

Comments
----------------------------------------
@colemanw this seems like such a blatant error I can only assume different php versions work differently & this would show up on matrix even though it passed PR tests
