### PR TITLE
dev/translation#38 Fix hard fail when creating new custom groups/cust…

### DIFF
--- a/CRM/Utils/SQL.php
+++ b/CRM/Utils/SQL.php
@@ -124,6 +124,25 @@ class CRM_Utils_SQL {
   }
 
   /**
+   * Disable STRICT_TRANS_TABLE SQL Mode
+   *
+   * @return bool
+   */
+  public static function disableStrictTransTable() {
+    $sqlModes = self::getSqlModes();
+
+    if (!empty($sqlModes) && in_array('STRICT_TRANS_TABLES', $sqlModes)) {
+      if ($key = array_search('STRICT_TRANS_TABLES', $sqlModes)) {
+        unset($sqlModes[$key]);
+        CRM_Core_DAO::executeQuery("SET SESSION sql_mode = '" . implode(',', $sqlModes) . "'");
+      }
+      return TRUE;
+    }
+
+    return FALSE;
+  }
+
+  /**
    * CHeck if ONLY_FULL_GROUP_BY is in the global sql_modes
    * @return bool
    */


### PR DESCRIPTION
…om fields or new option values in multilingual mode on stock mariadb engines

Overview
----------------------------------------
This is an alternate fix to #20753, this aims to work around the bug in MariaDB that causes hard fails

Before
----------------------------------------
Creating new Custom Group / Custom Field in MariaDB with a multilingual instance causes hard fails

After
----------------------------------------
No Hard fails 

ping @MegaphoneJon @mlutfy @samuelsov 