### PR TITLE
smarty notice - case dashboard when no upcoming/recent cases

### DIFF
--- a/CRM/Case/Page/DashBoard.php
+++ b/CRM/Case/Page/DashBoard.php
@@ -72,12 +72,8 @@ class CRM_Case_Page_DashBoard extends CRM_Core_Page {
     $recent = CRM_Case_BAO_Case::getCases($allCases, ['type' => 'recent'], 'dashboard', TRUE);
 
     $this->assign('casesSummary', $summary);
-    if (!empty($upcoming)) {
-      $this->assign('upcomingCases', TRUE);
-    }
-    if (!empty($recent)) {
-      $this->assign('recentCases', TRUE);
-    }
+    $this->assign('upcomingCases', !empty($upcoming));
+    $this->assign('recentCases', !empty($recent));
 
     $controller = new CRM_Core_Controller_Simple('CRM_Case_Form_Search',
       ts('Case'), CRM_Core_Action::BROWSE,


### PR DESCRIPTION
Overview
----------------------------------------
1. Enable civicase but do not create a case.
2. Visit the case dashboard.

Before
----------------------------------------
`Notice: Undefined index: upcomingCases in include() (line 88 of .../templates_c/en_US/%%13/137/137BFF47%%DashBoard.tpl.php).`
`Notice: Undefined index: recentCases in include() (line 109 of .../templates_c/en_US/%%13/137/137BFF47%%DashBoard.tpl.php).`

After
----------------------------------------


Technical Details
----------------------------------------
You might also see this if there are cases, but you're logged in as someone who doesn't have access to any of the upcoming/recent cases.

Comments
----------------------------------------

