### PR TITLE
smarty notice - title is only set for a list of existing report instances

### DIFF
--- a/templates/CRM/Report/Page/InstanceList.tpl
+++ b/templates/CRM/Report/Page/InstanceList.tpl
@@ -22,7 +22,7 @@
       {foreach from=$list item=rows key=report}
         <div class="crm-accordion-wrapper crm-accordion_{$report}-accordion ">
           <div class="crm-accordion-header">
-            {if $title}{$title}{elseif $report EQ 'Contribute'}{ts}Contribution Reports{/ts}{else}{ts}{$report} Reports{/ts}{/if}</a>
+            {if isset($title)}{$title}{elseif $report EQ 'Contribute'}{ts}Contribution Reports{/ts}{else}{ts 1=$report}%1 Reports{/ts}{/if}</a>
           </div><!-- /.crm-accordion-header -->
           <div class="crm-accordion-body">
             <div id="{$report}" class="boxBlock">


### PR DESCRIPTION
Overview
----------------------------------------
Under Reports, visit any of the links, e.g. Contact Reports.

Before
----------------------------------------
`Notice: Undefined index: title in ...\templates_c\en_US\%%93\93C\93C94F9B%%InstanceList.tpl.php on line 7`

Note depending on your error settings it might appear in the accordion header not the usual drupal red error box area.

After
----------------------------------------


Technical Details
----------------------------------------
The title var is only set when you are viewing a list of existing instances created from a given template.

Also wrong use of `ts` placeholder.

There's an existing weird hack for Contribute, but I'm leaving that alone.

Comments
----------------------------------------

