### PR TITLE
smarty notice - confirm_message is usually irrelevant in report listings

### DIFF
--- a/templates/CRM/Report/Page/InstanceList.tpl
+++ b/templates/CRM/Report/Page/InstanceList.tpl
@@ -37,7 +37,7 @@
                       <ul class="panel">
                         {foreach from=$row.actions item=action key=action_name}
                           <li><a href="{$action.url}" class="{$action_name} action-item crm-hover-button small-popup"
-                          {if $action.confirm_message}onclick="return window.confirm({$action.confirm_message|json_encode|htmlspecialchars})"{/if}
+                          {if !empty($action.confirm_message)}onclick="return window.confirm({$action.confirm_message|json_encode|htmlspecialchars})"{/if}
                           title="{$action.label|escape}">{$action.label}</a></li>
                         {/foreach}
                       </ul>


### PR DESCRIPTION
Overview
----------------------------------------
Under Reports, visit any of the links, e.g. Contact Reports.

Before
----------------------------------------
`Notice: Undefined index: confirm_message in include() (line 11 of ...\templates_c\en_US\%%93\93C\93C94F9B%%InstanceList.tpl.php).`

After
----------------------------------------

Technical Details
----------------------------------------
confirm_message is usually only relevant for delete actions or some custom actions

Comments
----------------------------------------
Technically '0' is a valid string even if not a good message. I waffled a bit over whether to use isset, but which would then include the empty string.
