### PR TITLE
[NFC] Cleanup Custom Groups and associated tables in api v4 unit test…

### DIFF
--- a/tests/phpunit/api/v4/Action/BasicCustomFieldTest.php
+++ b/tests/phpunit/api/v4/Action/BasicCustomFieldTest.php
@@ -38,7 +38,7 @@ class BasicCustomFieldTest extends BaseCustomValueTest {
       ->execute()
       ->first();
 
-    CustomField::create(FALSE)
+    $customField = CustomField::create(FALSE)
       ->addValue('label', 'FavColor')
       ->addValue('custom_group_id', $customGroup['id'])
       ->addValue('html_type', 'Text')
@@ -81,12 +81,14 @@ class BasicCustomFieldTest extends BaseCustomValueTest {
       ->first();
 
     $this->assertEquals('Blue', $contact['MyIndividualFields.FavColor']);
+    CustomField::delete(FALSE)->addWhere('id', '=', $customField[0]['id'])->execute();
+    CustomGroup::delete(FALSE)->addWhere('id', '=', $customGroup['id'])->execute();
   }
 
   public function testWithTwoFields() {
 
     // First custom set
-    CustomGroup::create(FALSE)
+    $customGroup1 = CustomGroup::create(FALSE)
       ->addValue('name', 'MyContactFields')
       ->addValue('extends', 'Contact')
       ->addChain('field1', CustomField::create()
@@ -102,7 +104,7 @@ class BasicCustomFieldTest extends BaseCustomValueTest {
       ->execute();
 
     // Second custom set
-    CustomGroup::create(FALSE)
+    $customGroup2 = CustomGroup::create(FALSE)
       ->addValue('name', 'MyContactFields2')
       ->addValue('extends', 'Contact')
       ->addChain('field1', CustomField::create()
@@ -222,6 +224,14 @@ class BasicCustomFieldTest extends BaseCustomValueTest {
 
     $this->assertNotContains($contactId1, array_keys((array) $search));
     $this->assertNotContains($contactId2, array_keys((array) $search));
+    CustomField::get()
+      ->addChain('delete', CustomField::delete()
+        ->addWhere('id', '=', '$id'))
+      ->execute();
+    CustomGroup::get()
+      ->addChain('delete', CustomGroup::delete()
+        ->addWhere('id', '=', '$id'))
+      ->execute();
   }
 
   public function testRelationshipCacheCustomFields() {
@@ -233,7 +243,7 @@ class BasicCustomFieldTest extends BaseCustomValueTest {
       ->execute()
       ->first();
 
-    CustomField::create(FALSE)
+    $customField = CustomField::create(FALSE)
       ->addValue('label', 'PetName')
       ->addValue('custom_group_id', $customGroup['id'])
       ->addValue('html_type', 'Text')
@@ -268,6 +278,8 @@ class BasicCustomFieldTest extends BaseCustomValueTest {
 
     $this->assertCount(2, $results);
     $this->assertEquals('Buddy', $results[0]["$cgName.PetName"]);
+    CustomField::delete(FALSE)->addWhere('id', '=', $customField[0]['id'])->execute();
+    CustomGroup::delete(FALSE)->addWhere('id', '=', $customGroup['id'])->execute();
   }
 
 }

--- a/tests/phpunit/api/v4/Action/CreateCustomValueTest.php
+++ b/tests/phpunit/api/v4/Action/CreateCustomValueTest.php
@@ -71,6 +71,8 @@ class CreateCustomValueTest extends BaseCustomValueTest {
     $createdOptionValues = array_combine($values, $labels);
 
     $this->assertEquals($optionValues, $createdOptionValues);
+    CustomField::delete(FALSE)->addWhere('id', '=', $customField['id'])->execute();
+    CustomGroup::delete(FALSE)->addWhere('id', '=', $customGroup['id'])->execute();
   }
 
 }

--- a/tests/phpunit/api/v4/Action/CreateWithOptionGroupTest.php
+++ b/tests/phpunit/api/v4/Action/CreateWithOptionGroupTest.php
@@ -42,39 +42,39 @@ class CreateWithOptionGroupTest extends BaseCustomValueTest {
     $colorField = uniqid('colora');
     $foodField = uniqid('fooda');
 
-    $customGroupId = CustomGroup::create(FALSE)
+    $customGroup1Id = CustomGroup::create(FALSE)
       ->addValue('name', $group)
       ->addValue('extends', 'Contact')
       ->execute()
       ->first()['id'];
 
-    CustomField::create(FALSE)
+    $customField1 = CustomField::create(FALSE)
       ->addValue('label', $colorField)
       ->addValue('name', $colorField)
       ->addValue('option_values', ['r' => 'Red', 'g' => 'Green', 'b' => 'Blue'])
-      ->addValue('custom_group_id', $customGroupId)
+      ->addValue('custom_group_id', $customGroup1Id)
       ->addValue('html_type', 'Select')
       ->addValue('data_type', 'String')
       ->execute();
 
-    CustomField::create(FALSE)
+    $customField2 = CustomField::create(FALSE)
       ->addValue('label', $foodField)
       ->addValue('name', $foodField)
       ->addValue('option_values', ['1' => 'Corn', '2' => 'Potatoes', '3' => 'Cheese'])
-      ->addValue('custom_group_id', $customGroupId)
+      ->addValue('custom_group_id', $customGroup1Id)
       ->addValue('html_type', 'Select')
       ->addValue('data_type', 'String')
       ->execute();
 
-    $customGroupId = CustomGroup::create(FALSE)
+    $customGroup2Id = CustomGroup::create(FALSE)
       ->addValue('name', 'FinancialStuff')
       ->addValue('extends', 'Contact')
       ->execute()
       ->first()['id'];
 
-    CustomField::create(FALSE)
+    $customField3 = CustomField::create(FALSE)
       ->addValue('label', 'Salary')
-      ->addValue('custom_group_id', $customGroupId)
+      ->addValue('custom_group_id', $customGroup2Id)
       ->addValue('html_type', 'Number')
       ->addValue('data_type', 'Money')
       ->execute();
@@ -101,6 +101,11 @@ class CreateWithOptionGroupTest extends BaseCustomValueTest {
     $this->assertEquals('Red', $result["$group.$colorField:label"]);
     $this->assertEquals('Corn', $result["$group.$foodField:label"]);
     $this->assertEquals(50000, $result['FinancialStuff.Salary']);
+    CustomField::delete(FALSE)->addWhere('id', '=', $customField1[0]['id'])->execute();
+    CustomField::delete(FALSE)->addWhere('id', '=', $customField2[0]['id'])->execute();
+    CustomField::delete(FALSE)->addWhere('id', '=', $customField3[0]['id'])->execute();
+    CustomGroup::delete(FALSE)->addWhere('id', '=', $customGroup1Id)->execute();
+    CustomGroup::delete(FALSE)->addWhere('id', '=', $customGroup2Id)->execute();
   }
 
   public function testWithCustomDataForMultipleContacts() {
@@ -108,39 +113,39 @@ class CreateWithOptionGroupTest extends BaseCustomValueTest {
     $colorField = uniqid('colorb');
     $foodField = uniqid('foodb');
 
-    $customGroupId = CustomGroup::create(FALSE)
+    $customGroup1Id = CustomGroup::create(FALSE)
       ->addValue('name', $group)
       ->addValue('extends', 'Contact')
       ->execute()
       ->first()['id'];
 
-    CustomField::create(FALSE)
+    $customField1 = CustomField::create(FALSE)
       ->addValue('label', $colorField)
       ->addValue('name', $colorField)
       ->addValue('option_values', ['r' => 'Red', 'g' => 'Green', 'b' => 'Blue'])
-      ->addValue('custom_group_id', $customGroupId)
+      ->addValue('custom_group_id', $customGroup1Id)
       ->addValue('html_type', 'Select')
       ->addValue('data_type', 'String')
       ->execute();
 
-    CustomField::create(FALSE)
+    $customField2 = CustomField::create(FALSE)
       ->addValue('label', $foodField)
       ->addValue('name', $foodField)
       ->addValue('option_values', ['1' => 'Corn', '2' => 'Potatoes', '3' => 'Cheese'])
-      ->addValue('custom_group_id', $customGroupId)
+      ->addValue('custom_group_id', $customGroup1Id)
       ->addValue('html_type', 'Select')
       ->addValue('data_type', 'String')
       ->execute();
 
-    $customGroupId = CustomGroup::create(FALSE)
+    $customGroup2Id = CustomGroup::create(FALSE)
       ->addValue('name', 'FinancialStuff')
       ->addValue('extends', 'Contact')
       ->execute()
       ->first()['id'];
 
-    CustomField::create(FALSE)
+    $customField3 = CustomField::create(FALSE)
       ->addValue('label', 'Salary')
-      ->addValue('custom_group_id', $customGroupId)
+      ->addValue('custom_group_id', $customGroup2Id)
       ->addValue('html_type', 'Number')
       ->addValue('data_type', 'Money')
       ->execute();
@@ -182,6 +187,11 @@ class CreateWithOptionGroupTest extends BaseCustomValueTest {
     $this->assertEquals('Blue', $blueCheese["$group.$colorField:label"]);
     $this->assertEquals('Cheese', $blueCheese["$group.$foodField:label"]);
     $this->assertEquals(500000, $blueCheese['FinancialStuff.Salary']);
+    CustomField::delete(FALSE)->addWhere('id', '=', $customField1[0]['id'])->execute();
+    CustomField::delete(FALSE)->addWhere('id', '=', $customField2[0]['id'])->execute();
+    CustomField::delete(FALSE)->addWhere('id', '=', $customField3[0]['id'])->execute();
+    CustomGroup::delete(FALSE)->addWhere('id', '=', $customGroup1Id)->execute();
+    CustomGroup::delete(FALSE)->addWhere('id', '=', $customGroup2Id)->execute();
   }
 
 }

--- a/tests/phpunit/api/v4/Action/CustomContactRefTest.php
+++ b/tests/phpunit/api/v4/Action/CustomContactRefTest.php
@@ -36,7 +36,7 @@ class CustomContactRefTest extends BaseCustomValueTest {
       ->execute()
       ->first();
 
-    CustomField::create(FALSE)
+    $customField = CustomField::create(FALSE)
       ->addValue('label', 'FavPerson')
       ->addValue('custom_group_id', $customGroup['id'])
       ->addValue('html_type', 'Autocomplete-Select')
@@ -68,6 +68,8 @@ class CustomContactRefTest extends BaseCustomValueTest {
 
     $this->assertEquals('Favorite', $contact['MyContactRef.FavPerson.first_name']);
     $this->assertEquals('Person', $contact['MyContactRef.FavPerson.last_name']);
+    CustomField::delete(FALSE)->addWhere('id', '=', $customField[0]['id'])->execute();
+    CustomGroup::delete(FALSE)->addWhere('id', '=', $customGroup['id'])->execute();
   }
 
   public function testCurrentUser() {
@@ -79,7 +81,7 @@ class CustomContactRefTest extends BaseCustomValueTest {
       ->execute()
       ->first();
 
-    CustomField::create(FALSE)
+    $customField = CustomField::create(FALSE)
       ->addValue('label', 'FavPerson')
       ->addValue('custom_group_id', $customGroup['id'])
       ->addValue('html_type', 'Autocomplete-Select')
@@ -102,6 +104,8 @@ class CustomContactRefTest extends BaseCustomValueTest {
       ->first();
 
     $this->assertEquals($currentUser, $contact['MyContactRef.FavPerson']);
+    CustomField::delete(FALSE)->addWhere('id', '=', $customField[0]['id'])->execute();
+    CustomGroup::delete(FALSE)->addWhere('id', '=', $customGroup['id'])->execute();
   }
 
 }

--- a/tests/phpunit/api/v4/Action/CustomValuePerformanceTest.php
+++ b/tests/phpunit/api/v4/Action/CustomValuePerformanceTest.php
@@ -42,7 +42,7 @@ class CustomValuePerformanceTest extends BaseCustomValueTest {
       ->execute()
       ->first()['id'];
 
-    CustomField::create(FALSE)
+    $customField1 = CustomField::create(FALSE)
       ->addValue('label', 'FavColor')
       ->addValue('custom_group_id', $customGroupId)
       ->addValue('options', ['r' => 'Red', 'g' => 'Green', 'b' => 'Blue'])
@@ -50,21 +50,21 @@ class CustomValuePerformanceTest extends BaseCustomValueTest {
       ->addValue('data_type', 'String')
       ->execute();
 
-    CustomField::create(FALSE)
+    $CustomField2 = CustomField::create(FALSE)
       ->addValue('label', 'FavAnimal')
       ->addValue('custom_group_id', $customGroupId)
       ->addValue('html_type', 'Text')
       ->addValue('data_type', 'String')
       ->execute();
 
-    CustomField::create(FALSE)
+    $customField3 = CustomField::create(FALSE)
       ->addValue('label', 'FavLetter')
       ->addValue('custom_group_id', $customGroupId)
       ->addValue('html_type', 'Text')
       ->addValue('data_type', 'String')
       ->execute();
 
-    CustomField::create(FALSE)
+    $customField4 = CustomField::create(FALSE)
       ->addValue('label', 'FavFood')
       ->addValue('custom_group_id', $customGroupId)
       ->addValue('html_type', 'Text')
@@ -100,6 +100,11 @@ class CustomValuePerformanceTest extends BaseCustomValueTest {
     // FIXME: This count is artificially high due to the line
     // $this->entity = Tables::getBriefName(Tables::getClassForTable($targetTable));
     // In class Joinable. TODO: Investigate why.
+    CustomField::delete(FALSE)->addWhere('id', '=', $customField1[0]['id'])->execute();
+    CustomField::delete(FALSE)->addWhere('id', '=', $customField2[0]['id'])->execute();
+    CustomField::delete(FALSE)->addWhere('id', '=', $customField3[0]['id'])->execute();
+    CustomField::delete(FALSE)->addWhere('id', '=', $customField4[0]['id'])->execute();
+    CustomGroup::delete(FALSE)->addWhere('id', '=', $customGroupId)->execute();
   }
 
 }

--- a/tests/phpunit/api/v4/Action/CustomValueTest.php
+++ b/tests/phpunit/api/v4/Action/CustomValueTest.php
@@ -249,6 +249,10 @@ class CustomValueTest extends BaseCustomValueTest {
     $result = CustomValue::get($group)->execute();
     // check that there are no custom values present
     $this->assertEquals(0, count($result));
+    CustomField::delete(FALSE)->addWhere('id', '=', $textField['id'])->execute();
+    CustomField::delete(FALSE)->addWhere('id', '=', $multiField['id'])->execute();
+    CustomField::delete(FALSE)->addWhere('id', '=', $colorField['id'])->execute();
+    CustomGroup::delete(FALSE)->addWhere('id', '=', $customGroup['id'])->execute();
   }
 
 }

--- a/tests/phpunit/api/v4/Action/ExtendFromIndividualTest.php
+++ b/tests/phpunit/api/v4/Action/ExtendFromIndividualTest.php
@@ -37,7 +37,7 @@ class ExtendFromIndividualTest extends BaseCustomValueTest {
       ->execute()
       ->first();
 
-    CustomField::create(FALSE)
+    $customField = CustomField::create(FALSE)
       ->addValue('label', 'FavColor')
       ->addValue('custom_group_id', $customGroup['id'])
       ->addValue('html_type', 'Text')
@@ -60,6 +60,8 @@ class ExtendFromIndividualTest extends BaseCustomValueTest {
       ->first();
 
     $this->assertEquals('Red', $contact['MyContactFields.FavColor']);
+    CustomField::delete(FALSE)->addWhere('id', '=', $customField[0]['id'])->execute();
+    CustomGroup::delete(FALSE)->addWhere('id', '=', $customGroup['id'])->execute();
   }
 
 }

--- a/tests/phpunit/api/v4/Action/FkJoinTest.php
+++ b/tests/phpunit/api/v4/Action/FkJoinTest.php
@@ -224,6 +224,11 @@ class FkJoinTest extends UnitTestCase {
     $this->assertEquals(2, (int) $reverse[$tag1]['contacts']);
     $this->assertEquals(1, (int) $reverse[$tag2]['contacts']);
     $this->assertEquals(1, (int) $reverse[$tag3]['contacts']);
+    EntityTag::get(FALSE)
+      ->addWhere('entity_id', 'IN', [$cid1, $cid2, $cid3])
+      ->addChain('delete', Tag::delete(FALSE)
+        ->addWhere('id', '=', '$tag_id'))
+      ->execute();
   }
 
   public function testBridgeJoinRelationshipContactActivity() {
@@ -308,6 +313,7 @@ class FkJoinTest extends UnitTestCase {
     $this->assertNull($result[3]['rel.id']);
     $this->assertEquals($cid3, $result[4]['contact.id']);
     $this->assertNull($result[3]['rel.id']);
+    Relationship::delete()->addWhere('contact_id_b', 'IN', [$cid1, $cid2])->execute();
   }
 
   public function testJoinToEmployerId() {

--- a/tests/phpunit/api/v4/Action/PseudoconstantTest.php
+++ b/tests/phpunit/api/v4/Action/PseudoconstantTest.php
@@ -215,6 +215,9 @@ class PseudoconstantTest extends BaseCustomValueTest {
       ->addOrderBy('myPseudoconstantTest.Technicolor:label', 'DESC')
       ->execute()->first()['id'];
     $this->assertEquals($cid1, $result);
+    $customGroup = CustomGroup::get(FALSE)->addWhere('name', '=', 'myPseudoconstantTest')->execute()->first();
+    CustomField::delete(FALSE)->addWhere('custom_group_id', '=', $customGroup['id'])->execute();
+    CustomGroup::delete(FALSE)->addWhere('id', '=', $customGroup['id'])->execute();
   }
 
   public function testJoinOptions() {

--- a/tests/phpunit/api/v4/Action/ReplaceTest.php
+++ b/tests/phpunit/api/v4/Action/ReplaceTest.php
@@ -111,14 +111,14 @@ class ReplaceTest extends UnitTestCase {
       ->execute()
       ->first();
 
-    CustomField::create()
+    $customField1 = CustomField::create()
       ->addValue('label', 'Custom1')
       ->addValue('custom_group_id', $customGroup['id'])
       ->addValue('html_type', 'String')
       ->addValue('data_type', 'String')
       ->execute();
 
-    CustomField::create(FALSE)
+    $customField2 = CustomField::create(FALSE)
       ->addValue('label', 'Custom2')
       ->addValue('custom_group_id', $customGroup['id'])
       ->addValue('html_type', 'String')
@@ -181,6 +181,9 @@ class ReplaceTest extends UnitTestCase {
     $this->assertEquals('new two', $newRecords->last()['Custom2']);
     $this->assertEquals('changed one', $newRecords[$cid1Records[0]['id']]['Custom1']);
     $this->assertEquals('changed two', $newRecords[$cid1Records[0]['id']]['Custom2']);
+    CustomField::delete(FALSE)->addWhere('id', '=', $customField1[0]['id'])->execute();
+    CustomField::delete(FALSE)->addWhere('id', '=', $customField2[0]['id'])->execute();
+    CustomGroup::delete(FALSE)->addWhere('id', '=', $customGroup['id'])->execute();
   }
 
 }

--- a/tests/phpunit/api/v4/Action/UpdateCustomValueTest.php
+++ b/tests/phpunit/api/v4/Action/UpdateCustomValueTest.php
@@ -37,7 +37,7 @@ class UpdateCustomValueTest extends BaseCustomValueTest {
       ->execute()
       ->first();
 
-    CustomField::create(FALSE)
+    $customField = CustomField::create(FALSE)
       ->addValue('label', 'FavColor')
       ->addValue('custom_group_id', $customGroup['id'])
       ->addValue('html_type', 'Text')
@@ -64,6 +64,8 @@ class UpdateCustomValueTest extends BaseCustomValueTest {
 
     $this->assertEquals(1, count($result));
     $this->assertContains('Blue', $result);
+    CustomField::delete(FALSE)->addWhere('id', '=', $customField[0]['id'])->execute();
+    CustomGroup::delete(FALSE)->addWhere('id', '=', $customGroup['id'])->execute();
   }
 
 }

--- a/tests/phpunit/api/v4/Entity/CaseTest.php
+++ b/tests/phpunit/api/v4/Entity/CaseTest.php
@@ -28,6 +28,14 @@ use api\v4\UnitTestCase;
 class CaseTest extends UnitTestCase {
 
   public function setUp(): void {
+    $this->cleanup([
+      'tablesToTruncate' => [
+        'civicrm_case',
+        'civicrm_case_activity',
+        'civicrm_case_contact',
+        'civicrm_case_type',
+      ],
+    ]);
     parent::setUp();
     \CRM_Core_BAO_ConfigSetting::enableComponent('CiviCase');
     $this->loadDataSet('CaseType');

--- a/tests/phpunit/api/v4/Spec/SpecGathererTest.php
+++ b/tests/phpunit/api/v4/Spec/SpecGathererTest.php
@@ -105,6 +105,8 @@ class SpecGathererTest extends UnitTestCase {
     $options = array_column($customField->getOptions([], ['id', 'name', 'label']), NULL, 'id');
     $this->assertEquals('Green', $options['g']['name']);
     $this->assertEquals('Pink', $options['p']['label']);
+    CustomField::delete(FALSE)->addWhere('custom_group_id', '=', $customGroupId)->execute();
+    CustomGroup::delete(FALSE)->addWhere('id', '=', $customGroupId)->execute();
   }
 
 }

--- a/tests/phpunit/api/v4/Utils/CoreUtilTest.php
+++ b/tests/phpunit/api/v4/Utils/CoreUtilTest.php
@@ -49,6 +49,8 @@ class CoreUtilTest extends UnitTestCase {
 
     $this->assertEquals('Custom_' . $multiGroup['name'], CoreUtil::getApiNameFromTableName($multiGroup['table_name']));
     $this->assertEquals($multiGroup['table_name'], CoreUtil::getTableName('Custom_' . $multiGroup['name']));
+    CustomGroup::delete(FALSE)->addWhere('id', '=', $singleGroup['id'])->execute();
+    CustomGroup::delete(FALSE)->addWhere('id', '=', $multiGroup['id'])->execute();
   }
 
   public function testGetApiClass() {
@@ -70,7 +72,8 @@ class CoreUtilTest extends UnitTestCase {
       ->execute()->first();
 
     $this->assertEquals('Civi\Api4\CustomValue', CoreUtil::getApiClass('Custom_' . $multiGroup['name']));
-
+    CustomGroup::delete(FALSE)->addWhere('id', '=', $singleGroup['id'])->execute();
+    CustomGroup::delete(FALSE)->addWhere('id', '=', $multiGroup['id'])->execute();
   }
 
 }


### PR DESCRIPTION
…s so that multiple runs can be performed

Overview
----------------------------------------
This cleans up various Custom Groups/Custom Fields 

Before
----------------------------------------
Tests leave created custom value tables around

After
----------------------------------------
Tests cleaned up custom value tables

ping @eileenmcnaughton @colemanw @totten 