### PR TITLE
Fix test set up to user Order api

### DIFF
--- a/api/v3/Order.php
+++ b/api/v3/Order.php
@@ -107,9 +107,13 @@ function civicrm_api3_order_create(array $params): array {
 
           case 'membership':
             $entityParams['status_id'] = 'Pending';
+            if (!empty($params['contribution_recur_id'])) {
+              $entityParams['contribution_recur_id'] = $params['contribution_recur_id'];
+            }
             $entityParams['skipLineItem'] = TRUE;
             $entityResult = civicrm_api3('Membership', 'create', $entityParams);
             break;
+
         }
 
         foreach ($lineItems['line_item'] as $innerIndex => $lineItem) {

--- a/tests/phpunit/CRM/Core/Payment/PayPalIPNTest.php
+++ b/tests/phpunit/CRM/Core/Payment/PayPalIPNTest.php
@@ -24,6 +24,16 @@ class CRM_Core_Payment_PayPalIPNTest extends CiviUnitTestCase {
   protected $_customFieldID;
 
   /**
+   * Should financials be checked after the test but before tear down.
+   *
+   * Ideally all tests (or at least all that call any financial api calls ) should do this but there
+   * are some test data issues and some real bugs currently blockinng.
+   *
+   * @var bool
+   */
+  protected $isValidateFinancialsOnPostAssert = TRUE;
+
+  /**
    * Set up function.
    */
   public function setUp(): void {


### PR DESCRIPTION
Note this includes the order api ensuring that the contribution_recur_id is passed through to
any created memberships

Overview
----------------------------------------
Fix test set up to user Order api 

Before
----------------------------------------
Test uses mishmash set up

After
----------------------------------------
Test uses api

Technical Details
----------------------------------------

Comments
----------------------------------------
