### PR TITLE
Forward Mailing: remove duplicate buttons, cancel button

### DIFF
--- a/CRM/Mailing/Form/ForwardMailing.php
+++ b/CRM/Mailing/Form/ForwardMailing.php
@@ -75,10 +75,6 @@ class CRM_Mailing_Form_ForwardMailing extends CRM_Core_Form {
         'name' => ts('Forward'),
         'isDefault' => TRUE,
       ],
-      [
-        'type' => 'cancel',
-        'name' => ts('Cancel'),
-      ],
     ]);
   }
 

--- a/templates/CRM/Mailing/Form/ForwardMailing.tpl
+++ b/templates/CRM/Mailing/Form/ForwardMailing.tpl
@@ -8,8 +8,6 @@
  +--------------------------------------------------------------------+
 *}
 <div class="crm-block crm-mailing-forward-form-block">
-<br />
-<div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div><br />
 <table class="form-layout">
 <tr class="crm-mailing-forward-form-block-fromEmail"><td class="label">From</td><td>{$fromEmail}</td></tr>
 <tr><td colspan="2">{ts}Please enter up to 5 email addresses to receive the mailing.{/ts}</td></tr>


### PR DESCRIPTION
Overview
----------------------------------------

When a user wishes to forward a mailing (if the token is used, which I suspect few people do), the interface looks kind of weird, with lots of buttons.

This patch does a bit of cleanup.

Before
----------------------------------------

![mail-forward-before](https://user-images.githubusercontent.com/254741/124632488-61893a80-de52-11eb-88fc-9eeeae1a88a2.png)


After
----------------------------------------

![mail-forward-after2-2021-07-06_12-02](https://user-images.githubusercontent.com/254741/124632503-66e68500-de52-11eb-9654-fd556480f4d9.png)


Comments
----------------------------------------

I know that CiviCRM likes displaying buttons both at the top and bottom, and I think that this is silly.

Also, most public forms do not display buttons at the top.

Finally, I removed the "cancel" button because it's pretty easily and frustrating to accidentally click "Cancel" after taking the time to enter all that info. Most people know how to use a back button, and other forms, such as Contribution forms, do not have a cancel button.