### PR TITLE
Fixes getTemplateContribution to use a more reliable way to load line items

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2497,7 +2497,6 @@ LEFT JOIN  civicrm_contribution contribution ON ( componentPayment.contribution_
    *   The count is out on how correct related entities wind up in this case.
    */
   protected static function repeatTransaction(array $input, array $contributionParams) {
-
     $templateContribution = CRM_Contribute_BAO_ContributionRecur::getTemplateContribution(
       (int) $contributionParams['contribution_recur_id'],
       array_filter([

--- a/CRM/Contribute/BAO/ContributionRecur.php
+++ b/CRM/Contribute/BAO/ContributionRecur.php
@@ -453,16 +453,25 @@ INNER JOIN civicrm_contribution       con ON ( con.id = mp.contribution_id )
     }
     if ($templateContributions->count()) {
       $templateContribution = $templateContributions->first();
-      $lineItems = CRM_Price_BAO_LineItem::getLineItemsByContributionID($templateContribution['id']);
+      $order = new CRM_Financial_BAO_Order();
+      $order->setTemplateContributionID($templateContribution['id']);
+      $order->setOverrideFinancialTypeID($overrides['financial_type_id'] ?? NULL);
+      $order->setOverridableFinancialTypeID($templateContribution['financial_type_id']);
+      $order->setOverrideTotalAmount($overrides['total_amount'] ?? NULL);
+      $order->setIsPermitOverrideFinancialTypeForMultipleLines(FALSE);
+      $lineItems = $order->getLineItems();
       // We only permit the financial type to be overridden for single line items.
       // Otherwise we need to figure out a whole lot of extra complexity.
       // It's not UI-possible to alter financial_type_id for recurring contributions
       // with more than one line item.
+      // The handling of the line items is managed in BAO_Order so this
+      // is whether we should override on the contribution. Arguably the 2 should
+      // be decoupled.
       if (count($lineItems) > 1 && isset($overrides['financial_type_id'])) {
         unset($overrides['financial_type_id']);
       }
       $result = array_merge($templateContribution, $overrides);
-      $result['line_item'] = self::reformatLineItemsForRepeatContribution($result['total_amount'], $result['financial_type_id'], $lineItems, (array) $templateContribution);
+      $result['line_item'][$order->getPriceSetID()] = $lineItems;
       // If the template contribution was made on-behalf then add the
       // relevant values to ensure the activity reflects that.
       $relatedContact = CRM_Contribute_BAO_Contribution::getOnbehalfIds($result['id']);
@@ -991,55 +1000,6 @@ INNER JOIN civicrm_contribution       con ON ( con.id = mp.contribution_id )
         return $allProcessors;
     }
     return CRM_Core_PseudoConstant::get(__CLASS__, $fieldName, $params, $context);
-  }
-
-  /**
-   * Reformat line items for getTemplateContribution / repeat contribution.
-   *
-   * This is an extraction and may be subject to further cleanup.
-   *
-   * @param float $total_amount
-   * @param int $financial_type_id
-   * @param array $lineItems
-   * @param array $originalContribution
-   *
-   * @return array
-   */
-  protected static function reformatLineItemsForRepeatContribution($total_amount, $financial_type_id, array $lineItems, array $originalContribution): array {
-    $lineSets = [];
-    if (count($lineItems) == 1) {
-      foreach ($lineItems as $index => $lineItem) {
-        if ($lineItem['financial_type_id'] != $originalContribution['financial_type_id']) {
-          // CRM-20685, Repeattransaction produces incorrect Financial Type ID (in specific circumstance) - if number of lineItems = 1, So this conditional will set the financial_type_id as the original if line_item and contribution comes with different data.
-          $financial_type_id = $lineItem['financial_type_id'];
-        }
-        if ($financial_type_id) {
-          // CRM-17718 allow for possibility of changed financial type ID having been set prior to calling this.
-          $lineItem['financial_type_id'] = $financial_type_id;
-        }
-        $taxAmountMatches = FALSE;
-        if ((!empty($lineItem['tax_amount']) && ($lineItem['line_total'] + $lineItem['tax_amount']) == $total_amount)) {
-          $taxAmountMatches = TRUE;
-        }
-        if ($lineItem['line_total'] != $total_amount && !$taxAmountMatches) {
-          // We are dealing with a changed amount! Per CRM-16397 we can work out what to do with these
-          // if there is only one line item, and the UI should prevent this situation for those with more than one.
-          $lineItem['line_total'] = $total_amount;
-          $lineItem['unit_price'] = round($total_amount / $lineItem['qty'], 2);
-        }
-        $priceField = new CRM_Price_DAO_PriceField();
-        $priceField->id = $lineItem['price_field_id'];
-        $priceField->find(TRUE);
-        $lineSets[$priceField->price_set_id][$lineItem['price_field_id']] = $lineItem;
-      }
-    }
-    // CRM-19309 if more than one then just pass them through:
-    elseif (count($lineItems) > 1) {
-      foreach ($lineItems as $index => $lineItem) {
-        $lineSets[$index][$lineItem['price_field_id']] = $lineItem;
-      }
-    }
-    return $lineSets;
   }
 
 }

--- a/tests/phpunit/CRM/Contribute/BAO/ContributionRecurTest.php
+++ b/tests/phpunit/CRM/Contribute/BAO/ContributionRecurTest.php
@@ -218,7 +218,6 @@ class CRM_Contribute_BAO_ContributionRecurTest extends CiviUnitTestCase {
    * Test that is_template contribution is used where available
    *
    * @throws \API_Exception
-   * @throws \CRM_Core_Exception
    * @throws \CiviCRM_API3_Exception
    * @throws \Civi\API\Exception\UnauthorizedException
    */

--- a/tests/phpunit/CRM/Core/Payment/PayPalIPNTest.php
+++ b/tests/phpunit/CRM/Core/Payment/PayPalIPNTest.php
@@ -129,7 +129,7 @@ class CRM_Core_Payment_PayPalIPNTest extends CiviUnitTestCase {
     $this->assertEquals(1, $contribution1['contribution_status_id']);
     $this->assertEquals('8XA571746W2698126', $contribution1['trxn_id']);
     // source gets set by processor
-    $this->assertTrue(substr($contribution1['contribution_source'], 0, 20) === 'Online Contribution:');
+    $this->assertEquals('Online Contribution:', substr($contribution1['contribution_source'], 0, 20));
     $contributionRecur = $this->callAPISuccess('contribution_recur', 'getsingle', ['id' => $this->_contributionRecurID]);
     $this->assertEquals(5, $contributionRecur['contribution_status_id']);
     $paypalIPN = new CRM_Core_Payment_PayPalIPN($this->getPaypalRecurSubsequentTransaction());
@@ -207,7 +207,7 @@ class CRM_Core_Payment_PayPalIPNTest extends CiviUnitTestCase {
    * @throws \CRM_Core_Exception
    * @throws \CiviCRM_API3_Exception
    */
-  public function testIPNPaymentInputMembershipRecurSuccess() {
+  public function testIPNPaymentInputMembershipRecurSuccess(): void {
     $durationUnit = 'year';
     $this->setupMembershipRecurringPaymentProcessorTransaction(['duration_unit' => $durationUnit, 'frequency_unit' => $durationUnit]);
     $membershipPayment = $this->callAPISuccessGetSingle('membership_payment', []);

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -2558,11 +2558,9 @@ VALUES
       'total_amount' => '200',
       'invoice_id' => $this->_invoiceID,
       'financial_type_id' => 'Donation',
-      'contribution_status_id' => 'Pending',
       'contact_id' => $this->_contactID,
       'contribution_page_id' => $this->_contributionPageID,
       'payment_processor_id' => $this->_paymentProcessorID,
-      'is_test' => 0,
       'receive_date' => '2019-07-25 07:34:23',
       'skipCleanMoney' => TRUE,
       'amount_level' => 'expensive',
@@ -2818,11 +2816,9 @@ VALUES
     $paramsSet['financial_type_id'] = 'Event Fee';
     $paramsSet['extends'] = 1;
     $priceSet = $this->callAPISuccess('price_set', 'create', $paramsSet);
-    $priceSetId = $priceSet['id'];
-    //Checking for priceset added in the table.
-    $this->assertDBCompareValue('CRM_Price_BAO_PriceSet', $priceSetId, 'title',
-      'id', $paramsSet['title'], 'Check DB for created priceset'
-    );
+    if ($componentId) {
+      CRM_Price_BAO_PriceSet::addTo('civicrm_' . $component, $componentId, $priceSet['id']);
+    }
     $paramsField = array_merge([
       'label' => 'Price Field',
       'name' => CRM_Utils_String::titleToVar('Price Field'),
@@ -2842,9 +2838,6 @@ VALUES
     ], $priceFieldOptions);
 
     $priceField = CRM_Price_BAO_PriceField::create($paramsField);
-    if ($componentId) {
-      CRM_Price_BAO_PriceSet::addTo('civicrm_' . $component, $componentId, $priceSetId);
-    }
     return $this->callAPISuccess('PriceFieldValue', 'get', ['price_field_id' => $priceField->id]);
   }
 

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -2410,19 +2410,21 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
     ];
     $lineItem1 = $this->callAPISuccess('line_item', 'get', array_merge($lineItemParams, [
       'entity_id' => $originalContribution['id'],
-    ]));
+      'options' => ['sort' => 'qty'],
+    ]))['values'];
     $lineItem2 = $this->callAPISuccess('line_item', 'get', array_merge($lineItemParams, [
       'entity_id' => $originalContribution['id'] + 1,
-    ]));
+      'options' => ['sort' => 'qty'],
+    ]))['values'];
 
     // unset id and entity_id for all of them to be able to compare the lineItems:
-    unset($lineItem1['values'][0]['id'], $lineItem1['values'][0]['entity_id']);
-    unset($lineItem2['values'][0]['id'], $lineItem2['values'][0]['entity_id']);
-    $this->assertEquals($lineItem1['values'][0], $lineItem2['values'][0]);
+    unset($lineItem1[0]['id'], $lineItem1[0]['entity_id']);
+    unset($lineItem2[0]['id'], $lineItem2[0]['entity_id']);
+    $this->assertEquals($lineItem1[0], $lineItem2[0]);
 
-    unset($lineItem1['values'][1]['id'], $lineItem1['values'][1]['entity_id']);
-    unset($lineItem2['values'][1]['id'], $lineItem2['values'][1]['entity_id']);
-    $this->assertEquals($lineItem1['values'][1], $lineItem2['values'][1]);
+    unset($lineItem1[1]['id'], $lineItem1[1]['entity_id']);
+    unset($lineItem2[1]['id'], $lineItem2[1]['entity_id']);
+    $this->assertEquals($lineItem1[1], $lineItem2[1]);
 
     // CRM-19309 so in future we also want to:
     // check that financial_line_items have been created for entity_id 3 and 4;
@@ -2892,9 +2894,9 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
     ]);
     $lineItem1 = $this->callAPISuccess('line_item', 'get', array_merge($lineItemParams, [
       'entity_id' => $originalContribution['id'],
-    ]));
+    ]))['values'][0];
     $expectedLineItem = array_merge(
-      $lineItem1['values'][0], [
+      $lineItem1, [
         'line_total' => '100.00',
         'unit_price' => '100.00',
         'financial_type_id' => 2,
@@ -3001,7 +3003,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
    *
    * @throws \CRM_Core_Exception
    */
-  public function testRepeatTransactionUpdatedFinancialTypeAndNotEquals() {
+  public function testRepeatTransactionUpdatedFinancialTypeAndNotEquals(): void {
     $originalContribution = $this->setUpRecurringContribution([], ['financial_type_id' => 2]);
     // This will made the trick to get the not equals behaviour.
     $this->callAPISuccess('line_item', 'create', ['id' => 1, 'financial_type_id' => 4]);


### PR DESCRIPTION
Overview
----------------------------------------
Fixes getTemplateContribution to use a more reliable way to load line items

 My efforts to add testing a 'deprecate weird stuff' have identified an odd and fragile
flow for the line items in getTemplateContribution. It calls
getLineItemsByContributionID which, as it turns out, substitues the
actual entity table with 'civicrm_contribution'.
    
Then [this line of weird handling](https://github.com/civicrm/civicrm-core/pull/20775/files#diff-a16d4d7449cf5f3a0616d1d282a32f27ab6d3f7d2726d076c02ad1d4d655af41R393) swoops in and saves the day.
    
This PR switches us to something cleaner than just loads the line items (with v4 LineItem.get) and
    no weird handling


Before
----------------------------------------
Line items loaded in correctly & then fixed later

After
----------------------------------------
Line items loaded correctly

Technical Details
----------------------------------------
This relies on a couple of fixes that I'll rebase out of the PR once merged #20079 and on top of that https://github.com/civicrm/civicrm-core/pull/20780

Comments
----------------------------------------

