### PR TITLE
Fix BaseIPN test to (mostly) pass invalid financials checks

### DIFF
--- a/api/v3/Order.php
+++ b/api/v3/Order.php
@@ -144,7 +144,7 @@ function civicrm_api3_order_create(array $params): array {
   }
 
   $contribution = civicrm_api3('Contribution', 'create', $contributionParams);
-  $contribution['values'][$contribution['id']]['line_item'] = $order->getLineItems();
+  $contribution['values'][$contribution['id']]['line_item'] = array_values($order->getLineItems());
 
   // add payments
   if ($entity && !empty($contribution['id'])) {

--- a/tests/phpunit/CRM/Event/BAO/ChangeFeeSelectionTest.php
+++ b/tests/phpunit/CRM/Event/BAO/ChangeFeeSelectionTest.php
@@ -276,6 +276,9 @@ class CRM_Event_BAO_ChangeFeeSelectionTest extends CiviUnitTestCase {
    * @throws \CiviCRM_API3_Exception
    */
   public function testCRM19273() {
+    // When a line item is 'resurrected' the financial_items attached to it are wrong.
+    // We have to skip validatePayments until fixed.
+    $this->isValidateFinancialsOnPostAssert = FALSE;
     $this->registerParticipantAndPay();
 
     $priceSetParams['price_' . $this->priceSetFieldID] = $this->cheapFeeValueID;

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -26,6 +26,7 @@
  *   <http://www.gnu.org/licenses/>.
  */
 
+use Civi\Api4\Contribution;
 use Civi\Api4\CustomField;
 use Civi\Api4\CustomGroup;
 use Civi\Api4\OptionGroup;
@@ -151,7 +152,7 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
    * Should financials be checked after the test but before tear down.
    *
    * Ideally all tests (or at least all that call any financial api calls ) should do this but there
-   * are some test data issues and some real bugs currently blockinng.
+   * are some test data issues and some real bugs currently blocking.
    *
    * @var bool
    */
@@ -3639,10 +3640,10 @@ VALUES
   /**
    * Validate all created contributions.
    *
-   * @throws \CRM_Core_Exception
+   * @throws \API_Exception
    */
   protected function validateAllContributions(): void {
-    $contributions = $this->callAPISuccess('Contribution', 'get', ['return' => ['tax_amount', 'total_amount']])['values'];
+    $contributions = Contribution::get(FALSE)->setSelect(['total_amount', 'tax_amount'])->execute();
     foreach ($contributions as $contribution) {
       $lineItems = $this->callAPISuccess('LineItem', 'get', [
         'contribution_id' => $contribution['id'],

--- a/tests/phpunit/api/v3/SyntaxConformanceTest.php
+++ b/tests/phpunit/api/v3/SyntaxConformanceTest.php
@@ -25,6 +25,16 @@ class api_v3_SyntaxConformanceTest extends CiviUnitTestCase {
   protected $_apiversion = 3;
 
   /**
+   * Do not check financial entities in this test class.
+   *
+   * The class uses lots of crud to do things by-passing
+   * BAO logic & entities are often not valid as a result.
+   *
+   * @var bool
+   */
+  protected $isValidateFinancialsOnPostAssert = FALSE;
+
+  /**
    * @var array
    * e.g. $this->deletes['CRM_Contact_DAO_Contact'][] = $contactID;
    */


### PR DESCRIPTION
Overview
----------------------------------------
Fix BaseIPN test to (mostly) pass invalid financials checks

Before
----------------------------------------
Base IPN tests faile when we try to enable checks to ensure all financial entites are valid at the end of the test

After
----------------------------------------
All but one test pass - I've marked that one to be skipped, along with SyntaxConformance (which will never task) and another one which needs a lot of thought to fix. 

Technical Details
----------------------------------------
The immediate goal is to switch from marking which tests DO pass these checks to marking which don't (this is like the rising lid policy we used when getting tests compliant with e-notices

Comments
----------------------------------------
