### PR TITLE
crmMonaco - Multiple updates. Toward message-template editing.

### DIFF
--- a/CRM/Utils/JS.php
+++ b/CRM/Utils/JS.php
@@ -109,6 +109,10 @@ class CRM_Utils_JS {
    * @return string
    */
   public static function stripComments($script) {
+    // This function is a little naive, and some expressions may trip it up. Opt-out if anything smells fishy.
+    if (preg_match(';`\r?\n//;', $script)) {
+      return $script;
+    }
     return preg_replace("#^\\s*//[^\n]*$(?:\r\n|\n)?#m", "", $script);
   }
 

--- a/ang/crmMonaco.js
+++ b/ang/crmMonaco.js
@@ -94,4 +94,19 @@
     };
   });
 
+  angular.module('crmMonaco').directive('crmMonacoInsertRx', function() {
+    return {
+      require: 'crmMonaco',
+      link: function(scope, element, attrs, crmMonaco) {
+        scope.$on(attrs.crmMonacoInsertRx, function(e, tokenName) {
+          var editor = crmMonaco.editor;
+          var id = { major: 1, minor: 1 };
+          var op = {identifier: id, range: editor.getSelection(), text: tokenName, forceMoveMarkers: true};
+          editor.executeEdits("tokens", [op]);
+          editor.focus();
+        });
+      }
+    };
+  });
+
 })(angular, CRM.$, CRM._);

--- a/ang/crmMonaco.js
+++ b/ang/crmMonaco.js
@@ -7,9 +7,13 @@
   angular.module('crmMonaco').directive('crmMonaco', function($timeout, $parse) {
     return {
       restrict: 'AE',
-      require: 'ngModel',
+      require: ['ngModel', 'crmMonaco'],
       template: '<div class="crm-monaco-container"></div>',
-      link: function($scope, $el, $attr, ngModel) {
+      controller: function() {
+        this.editor = null; // Filled in by link().
+      },
+      link: function($scope, $el, $attr, controllers) {
+        var ngModel = controllers[0], crmMonaco = controllers[1];
         var heightPct = 0.70;
         var editor;
         require.config({paths: CRM.crmMonaco.paths});
@@ -78,9 +82,12 @@
           editor.onDidFocusEditorWidget(bodyScrollSuspend);
           editor.onDidBlurEditorWidget(bodyScrollRestore);
 
+          crmMonaco.editor = editor;
+
           $scope.$on('$destroy', function () {
             bodyScrollRestore();
             if (editor) editor.dispose();
+            delete crmMonaco.editor;
           });
         });
       }

--- a/ang/crmMonaco.js
+++ b/ang/crmMonaco.js
@@ -41,6 +41,9 @@
             }
           });
 
+          heightPct = options.crmHeightPct || heightPct;
+          delete options.crmHeightPct;
+
           var editorEl = $el.find('.crm-monaco-container');
           editorEl.css({height: Math.round(heightPct * $(window).height())});
           editor = monaco.editor.create(editorEl[0], options);

--- a/composer.json
+++ b/composer.json
@@ -216,7 +216,7 @@
         "ignore": [".*", "*.json", "*.md", "Makefile", "*/*"]
       },
       "monaco-editor": {
-        "url": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.16.2.tgz",
+        "url": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.25.2.tgz",
         "path": "bower_components/monaco-editor",
         "ignore": ["dev", "esm"]
       },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3d4576d680aea8094656e1d832571507",
+    "content-hash": "ea837c7aee5b94c6cbc1df32c5b3aa70",
     "packages": [
         {
             "name": "adrienrn/php-mimetyper",
@@ -3042,20 +3042,6 @@
                 "polyfill",
                 "portable"
             ],
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-05-12T16:14:59+00:00"
         },
         {
@@ -3114,20 +3100,6 @@
                 "polyfill",
                 "portable",
                 "shim"
-            ],
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
             ],
             "time": "2020-05-12T16:47:27+00:00"
         },
@@ -3190,20 +3162,6 @@
                 "polyfill",
                 "portable",
                 "shim"
-            ],
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
             ],
             "time": "2020-05-12T16:47:27+00:00"
         },
@@ -3332,20 +3290,6 @@
                 "polyfill",
                 "portable",
                 "shim"
-            ],
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
             ],
             "time": "2020-05-12T16:47:27+00:00"
         },
@@ -3970,6 +3914,12 @@
                 "zetacomponents/unit-test": "*"
             },
             "type": "library",
+            "extra": {
+                "patches_applied": {
+                    "CiviCRM Custom Patches for ZetaCompoents mail": "https://raw.githubusercontent.com/civicrm/civicrm-core/9d93748a36c7c5d44422911db1c98fb2f7067b34/tools/scripts/composer/patches/civicrm-custom-patches-zetacompoents-mail.patch",
+                    "Allow single quotes to be used in return path": "https://github.com/zetacomponents/Mail/pull/86.patch"
+                }
+            },
             "autoload": {
                 "classmap": [
                     "src"
@@ -4022,10 +3972,6 @@
             ],
             "description": "The component allows you construct and/or parse Mail messages conforming to  the mail standard. It has support for attachments, multipart messages and HTML  mail. It also interfaces with SMTP to send mail or IMAP, POP3 or mbox to  retrieve e-mail.",
             "homepage": "https://github.com/zetacomponents",
-            "support": {
-                "issues": "https://github.com/zetacomponents/Mail/issues",
-                "source": "https://github.com/zetacomponents/Mail/tree/1.9.2"
-            },
             "time": "2020-06-13T12:38:26+00:00"
         }
     ],
@@ -4044,5 +3990,5 @@
     "platform-overrides": {
         "php": "7.2"
     },
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "1.1.0"
 }

--- a/tests/phpunit/CRM/Utils/JSTest.php
+++ b/tests/phpunit/CRM/Utils/JSTest.php
@@ -177,6 +177,12 @@ class CRM_Utils_JSTest extends CiviUnitTestCase {
       "alert('//# sourceMappingURL=../foo/bar/baz.js');\n//zoop\na();",
       "alert('//# sourceMappingURL=../foo/bar/baz.js');\na();",
     ];
+    $cases[] = [
+      // Quoted code-template which includes comment on newline. The '//' is part of the string.
+      // Ex: bower_components/monaco-editor/min/vs/loader.js @ ~v0.25
+      "var tpl=`\r\n//quoted comment`;",
+      "var tpl=`\r\n//quoted comment`;",
+    ];
     return $cases;
   }
 


### PR DESCRIPTION
Overview
----------------------------------------

This is a small batch of updates for the [Monaco](https://microsoft.github.io/monaco-editor/index.html)-Angular adapter (`crmMonaco`), moving towards [improved editing of message templates](https://lab.civicrm.org/dev/mail/-/issues/83).

ping @eileenmcnaughton @colemanw @seamuslee001 

Before
----------------------------------------

* The height of a Monaco widget is hard-coded at 70% of viewport.
* If you have an "Insert Token" picker, it cannot add tokens into a Monaco editor.
* It is impossible to mix-in any directive or controller logic which interacts with Monaco's `editor` API.
* The included version of Monaco is 0.16.2.

After
----------------------------------------

* The height of Monaco widgets may be adjusted via the `heightPct` option. (For example, the `msg_subject` widget can be 15% of view-port while the `msg_html` widget can be 50%.)
* If you have an "Insert Token" picker, it can add tokens into a Monaco editor. (This uses `crm-monaco-insert-rx` which is similar to `crm-ui-insert-rx`, except that it receives broadcasts for Monaco instead of `textarea`/`input`.)
* You can create new directives which use Monaco's `editor` API (as in `crm-monaco-insert-rx`).
* The included version of Monaco is 0.25.2.
 
Comments
----------------------------------------

For `r-run`ning to check for regressions, try `afform_admin` -- note that the HTML rendition of the form is presented via Monaco, and it should still work as before.

Several of these updates can be seen in the WIP extension `msgtplui`, e.g. https://github.com/totten/msgtplui/blob/34693479354966381c46f1921ed464ac5c9b94a4/ang/msgtplui/EditContent.html#L18-L20. (Note, though, that this may require other patches. [This branch](https://github.com/totten/civicrm-core/tree/master-msgtpl-ui) integrates tangential requirements.)

