### PR TITLE
CRM_Utils_Array - Implement pathUnset() method

### DIFF
--- a/CRM/Utils/Array.php
+++ b/CRM/Utils/Array.php
@@ -1059,6 +1059,40 @@ class CRM_Utils_Array {
   }
 
   /**
+   * Remove a key from an array.
+   *
+   * This is a helper for when the calling function does not know how many layers deep
+   * the path array is so cannot easily check.
+   *
+   * @param array $values
+   * @param array $path
+   * @param bool $cleanup
+   *   If removed item leaves behind an empty array, should you remove the empty array?
+   * @return bool
+   *   TRUE if anything has been removed. FALSE if no changes were required.
+   */
+  public static function pathUnset(&$values, $path, $cleanup = FALSE) {
+    if (count($path) === 1) {
+      if (isset($values[$path[0]])) {
+        unset($values[$path[0]]);
+        return TRUE;
+      }
+      else {
+        return FALSE;
+      }
+    }
+    else {
+      $next = array_shift($path);
+      $r = static::pathUnset($values[$next], $path, $cleanup);
+      if ($cleanup && $values[$next] === []) {
+        $r = TRUE;
+        unset($values[$next]);
+      }
+      return $r;
+    }
+  }
+
+  /**
    * Set a single value in an array tree.
    *
    * @param array $values

--- a/tests/phpunit/CRM/Utils/ArrayTest.php
+++ b/tests/phpunit/CRM/Utils/ArrayTest.php
@@ -133,6 +133,10 @@ class CRM_Utils_ArrayTest extends CiviUnitTestCase {
       'two' => [
         'half' => 2,
       ],
+      'three' => [
+        'first-third' => '1/3',
+        'second-third' => '2/3',
+      ],
     ];
     $this->assertEquals('1', CRM_Utils_Array::pathGet($arr, ['one']));
     $this->assertEquals('2', CRM_Utils_Array::pathGet($arr, ['two', 'half']));
@@ -140,6 +144,19 @@ class CRM_Utils_ArrayTest extends CiviUnitTestCase {
     CRM_Utils_Array::pathSet($arr, ['zoo', 'half'], '3');
     $this->assertEquals(3, CRM_Utils_Array::pathGet($arr, ['zoo', 'half']));
     $this->assertEquals(3, $arr['zoo']['half']);
+
+    $arrCopy = $arr;
+    $this->assertEquals(FALSE, CRM_Utils_Array::pathUnset($arr, ['does-not-exist']));
+    $this->assertEquals($arrCopy, $arr);
+
+    $this->assertEquals(TRUE, CRM_Utils_Array::pathUnset($arr, ['two', 'half'], FALSE));
+    $this->assertEquals([], $arr['two']);
+    $this->assertTrue(array_key_exists('two', $arr));
+
+    CRM_Utils_Array::pathUnset($arr, ['three', 'first-third'], TRUE);
+    $this->assertEquals(['second-third' => '2/3'], $arr['three']);
+    CRM_Utils_Array::pathUnset($arr, ['three', 'second-third'], TRUE);
+    $this->assertFalse(array_key_exists('three', $arr));
   }
 
   public function getSortExamples() {


### PR DESCRIPTION
Overview
----------------------------------------

Add a helper function, `pathUnset()`, which removes an item from an array-tree. This complements existing helper functions `pathGet()`, `pathIsset()`, and `pathSet()` (which read and write values in an array-tree).

Technical Details
----------------------------------------

For example, suppose you have this array:

```php
$arr = [
  'one' => '1',
  'two' => [
    'half' => 2,
  ],
  'three' => [
    'first-third' => '1/3',
    'second-third' => '2/3',
  ],
];
```

You may interact with the item `three`.`first-third` by calling:

```php
CRM_Utils_Array::pathGet($arr, ['three', 'first-third']); // Returns string "1/3"
CRM_Utils_Array::pathIsset($arr, ['three', 'first-third']); // Returns bool "true"
CRM_Utils_Array::pathSet($arr, ['three', 'first-third'], "Revival!"); // Updates the item
CRM_Utils_Array::pathUnset($arr, ['three', 'first-third']); // Removes the item
```

