### PR TITLE
CRM_Utils_Array::asColumns() - Add helper to rotate a matrix (from rows to columns)

### DIFF
--- a/CRM/Utils/Array.php
+++ b/CRM/Utils/Array.php
@@ -984,6 +984,34 @@ class CRM_Utils_Array {
   }
 
   /**
+   * Rotate a matrix, converting from row-oriented array to a column-oriented array.
+   *
+   * @param iterable $rows
+   *   Ex: [['a'=>10,'b'=>'11'], ['a'=>20,'b'=>21]]
+   *   Formula: [scalar $rowId => [scalar $colId => mixed $value]]
+   * @param bool $unique
+   *   Only return unique values.
+   * @return array
+   *   Ex: ['a'=>[10,20], 'b'=>[11,21]]
+   *   Formula: [scalar $colId => [scalar $rowId => mixed $value]]
+   *   Note: In unique mode, the $rowId is not meaningful.
+   */
+  public static function asColumns(iterable $rows, bool $unique = FALSE) {
+    $columns = [];
+    foreach ($rows as $rowKey => $row) {
+      foreach ($row as $columnKey => $value) {
+        if (FALSE === $unique) {
+          $columns[$columnKey][$rowKey] = $value;
+        }
+        elseif (!in_array($value, $columns[$columnKey] ?? [])) {
+          $columns[$columnKey][] = $value;
+        }
+      }
+    }
+    return $columns;
+  }
+
+  /**
    * Rewrite the keys in an array.
    *
    * @param array $array

--- a/tests/phpunit/CRM/Utils/ArrayTest.php
+++ b/tests/phpunit/CRM/Utils/ArrayTest.php
@@ -6,6 +6,37 @@
  */
 class CRM_Utils_ArrayTest extends CiviUnitTestCase {
 
+  public function testAsColumns() {
+    $rowsNum = [
+      ['a' => 10, 'b' => 11],
+      ['a' => 20, 'b' => 21],
+      ['a' => 20, 'b' => 29],
+    ];
+
+    $rowsAssoc = [
+      '!' => ['a' => 10, 'b' => 11],
+      '@' => ['a' => 20, 'b' => 21],
+      '#' => ['a' => 20, 'b' => 29],
+    ];
+
+    $this->assertEquals(
+      ['a' => [10, 20, 20], 'b' => [11, 21, 29]],
+      CRM_Utils_Array::asColumns($rowsNum)
+    );
+    $this->assertEquals(
+      ['a' => [10, 20], 'b' => [11, 21, 29]],
+      CRM_Utils_Array::asColumns($rowsNum, TRUE)
+    );
+    $this->assertEquals(
+      ['a' => ['!' => 10, '@' => 20, '#' => 20], 'b' => ['!' => 11, '@' => 21, '#' => 29]],
+      CRM_Utils_Array::asColumns($rowsAssoc)
+    );
+    $this->assertEquals(
+      ['a' => [10, 20], 'b' => [11, 21, 29]],
+      CRM_Utils_Array::asColumns($rowsAssoc, TRUE)
+    );
+  }
+
   public function testIndexArray() {
     $inputs = [];
     $inputs[] = [


### PR DESCRIPTION
Overview
----------------------------------------
Add a helper function, `asColumns()`, which rotates an array-matrix -- converting from a row-orientation to a column-orientation.

Before
----------------------------------------

Helper does not exist.

After
----------------------------------------

Helper exists.

Technical Details
----------------------------------------

Suppose you have this data:

```php
$alphabetByLetter = [
          // English column     // Greek column
  'a' => ['english' => 'eh',    'greek' => 'alpha'],
  'b' => ['english' => 'bee',   'greek' => 'beta' ],
];
// Assert: $rows['b']['greek'] == 'beta'
```

Then you rotate it, getting the data in columnar form:

```php
$alphabetByLang = CRM_Utils_Array::asColumns($alphabetByLetter);
```

The resulting data is shaped like:

```php
$alphabetByLang = [
                // "A" column      // "B" column
  'english' => ['a' =>'eh',        'b' => 'bee' ],
  'greek'   => ['a' =>'alpha',     'b' => 'beta'],
];
// Assert: $rows['greek']['b'] == 'beta'
```

