### PR TITLE
(REF) crmUi - Support onCrmUiSelect for using select2 as a picklist

### DIFF
--- a/ang/crmUi.js
+++ b/ang/crmUi.js
@@ -633,6 +633,22 @@
       };
     })
 
+    // Use a select2 widget as a pick-list. Instead of updating ngModel, the select2 widget will fire an event.
+    // This similar to ngModel+ngChange, except that value is never stored in a model. It is only fired in the event.
+    // usage: <select crm-ui-select='{...}' on-crm-ui-select="alert("User picked this item: " + selection)"></select>
+    .directive('onCrmUiSelect', function ($parse) {
+      return {
+        priority: 10,
+        link: function (scope, element, attrs) {
+          element.on('select2-selecting', function(e) {
+            e.preventDefault();
+            element.select2('close').select2('val', '');
+            scope.$parent.$eval(attrs.onCrmUiSelect, {selection: e.val});
+          });
+        }
+      };
+    })
+
     // Render a crmEntityRef widget
     // usage: <input crm-entityref="{entity: 'Contact', select: {allowClear:true}}" ng-model="myobj.field" />
     .directive('crmEntityref', function ($parse, $timeout) {


### PR DESCRIPTION
Overview
----------------------------------------

Add an Angular directive to enrich the behavior of `crm-ui-select` - firing an event immediately after selecting a value (`on-crm-ui-select`).

```html
<input class="form-control pull-right crm-action-menu fa-code"
  crm-ui-select="{placeholder: ts('Tokens'), data: $ctrl.myTokenList, width: '12em', dropdownAutoWidth: true}"
  on-crm-ui-select="$ctrl.insertMyToken(selection)"
  />
```

It may help to consider an example use-case. The `crmMailingToken` widget presents a pick-list of available tokens:

<img width="1074" alt="Screen Shot 2021-07-06 at 5 41 24 PM" src="https://user-images.githubusercontent.com/1336047/124683414-ce67f900-de81-11eb-8bf1-5cfdfe67568e.png">

After picking a token, it closes the list and executes some code based on the selected value (*adding the selected token to the body of the text editor*).

However, the `crmMailingToken` implementation is specific to CiviMail. This patch  aims to support message-template-editing for [dev/mail#83](https://lab.civicrm.org/dev/mail/-/issues/83). The behavior of the widget should be similar, but other key details (like the list of available tokens - and the visual placement of the token widget) can differ.

Before
----------------------------------------

If you want to implement a select2 pick list, your options are:

* Use `crm-mailing-token`. But this only supports CiviMail tokens specifically.
* Copy/paste all of `crm-mailing-token` and then edit in several ways.
* Create a `<select>` widget with `crm-ui-select`, `ng-model`, and `ng-change`. However, this has problematic behavioral quirks, and it also requires defining a superfluous model-field in the scope (which then has to be reset periodically). 

After
----------------------------------------

One may use the existing `crm-ui-select` directive and combine it with `on-crm-ui-select`, as in:

```html
<input class="form-control pull-right crm-action-menu fa-code"
  crm-ui-select="{placeholder: ts('Tokens'), data: $ctrl.myTokenList, width: '12em', dropdownAutoWidth: true}"
  on-crm-ui-select="$ctrl.insertMyToken(selection)"
  />
```

Comments
----------------------------------------

For a live example, see the WIP extension msgtplui, e.g. https://github.com/totten/msgtplui/blob/34693479354966381c46f1921ed464ac5c9b94a4/ang/msgtplui/EditContent.html#L8-L14. (Note, though, that this may require other patches. [This branch](https://github.com/totten/civicrm-core/tree/master-msgtpl-ui) integrates tangential requirements.)

It may make sense at some point to phase-out `crmMailingToken`, but that is a different scope of work from enhancing `crmUiSelect`/`onCrmUiSelect`.