### PR TITLE
Handle participant payment create in line item

### DIFF
--- a/CRM/Price/BAO/LineItem.php
+++ b/CRM/Price/BAO/LineItem.php
@@ -72,6 +72,15 @@ class CRM_Price_BAO_LineItem extends CRM_Price_DAO_LineItem {
         civicrm_api3('MembershipPayment', 'create', $membershipPaymentParams);
       }
     }
+    if ($lineItemBAO->entity_table === 'civicrm_participant' && $lineItemBAO->contribution_id && $lineItemBAO->entity_id) {
+      $participantPaymentParams = [
+        'participant_id' => $lineItemBAO->entity_id,
+        'contribution_id' => $lineItemBAO->contribution_id,
+      ];
+      if (!civicrm_api3('ParticipantPayment', 'getcount', $participantPaymentParams)) {
+        civicrm_api3('ParticipantPayment', 'create', $participantPaymentParams);
+      }
+    }
 
     if ($id) {
       // CRM-21281: Restore entity reference in case the post hook needs it

--- a/api/v3/Order.php
+++ b/api/v3/Order.php
@@ -160,10 +160,6 @@ function civicrm_api3_order_create(array $params): array {
         CRM_Core_Error::deprecatedWarning('This should be unreachable & tests show it is never tested.');
         civicrm_api3('PledgePayment', 'create', $paymentParams);
       }
-      if ($entity === 'participant') {
-        civicrm_api3('ParticipantPayment', 'create', $paymentParams);
-      }
-
     }
   }
   return civicrm_api3_create_success($contribution['values'] ?? [], $params, 'Order', 'create');


### PR DESCRIPTION


Overview
----------------------------------------
Handling participant payments the same way as membership payments - ie ensure they exist when the line item is created

Before
----------------------------------------
Done for membership payment in the line item bao but not participant payments

After
----------------------------------------
ALso for participant payments

Technical Details
----------------------------------------
Note the BAO handles the scenario where it already exists 

Comments
----------------------------------------
@monishdeb this is pulled out from https://github.com/civicrm/civicrm-core/pull/20650 - the test in there shows it works but it  needs https://github.com/civicrm/civicrm-core/pull/20670 merged first