### PR TITLE
smarty notices - New case screen - Case.hlp

### DIFF
--- a/templates/CRM/Case/Form/Case.hlp
+++ b/templates/CRM/Case/Form/Case.hlp
@@ -16,7 +16,7 @@
   {ts}Details{/ts}
 {/htxt}
 {htxt id="id-details"}
-{if $params.activityTypeFile EQ 'OpenCase'}
+{if !empty($params.activityTypeFile) && $params.activityTypeFile EQ 'OpenCase'}
     <ul>
     <li>{ts}Introduce yourself and your role within our organization.{/ts}</li>
     <li>{ts}&quot;All of the information that you provide to us or any of our representatives and service providers will be held in strictest confidence. It will not be used for any purpose other than to help you, and for any other purpose that you authorize in writing, or which is required by law.&quot;{/ts}</li>
@@ -34,7 +34,7 @@
   {ts}Title{/ts}
 {/htxt}
 {htxt id="id-activity_subject"}
-{if $params.activityTypeFile EQ 'OpenCase'}
+{if !empty($params.activityTypeFile) && $params.activityTypeFile EQ 'OpenCase'}
   {ts}Provide a one-line summary of what this case is about.{/ts}
 {/if}
 {/htxt}
@@ -43,7 +43,7 @@
   {ts}Case Type{/ts}
 {/htxt}
 {htxt id="id-case_type"}
-{if $params.activityTypeFile EQ 'OpenCase'}
+{if !empty($params.activityTypeFile) && $params.activityTypeFile EQ 'OpenCase'}
   {ts}Offer the appropriate service from the list. If the service requires coordination, contact the Director.{/ts}
 {/if}
 {/htxt}


### PR DESCRIPTION
Overview
----------------------------------------
1. Go to create a new case
2. Smarty notices

Before
----------------------------------------
Notice: Undefined index: params in include() (line 11 of blah/0FA1A004%%Case.hlp.php

After
----------------------------------------


Technical Details
----------------------------------------
$params is sometimes legitimately missing, e.g. the way the access keys help bubble works it calls this file but without $params, or if you have the fulltext search drupal block enabled.

Comments
----------------------------------------
There are a couple side issues with this help bubble but am leaving out for now:
1. The title of the `subject` help is just the generic "Title" - it should probably be "Subject".
2. Do any of these help bubbles make sense on this page in the generic case? You can override them so it conveniently provides a pre-made spot to insert your own text and maybe people are doing that so I'm hesitant to just remove them, but maybe the default text could be something more generic.