### PR TITLE
APIv4 - Fix pseudoconstant matching reliability across joins

### DIFF
--- a/Civi/Api4/Generic/AbstractAction.php
+++ b/Civi/Api4/Generic/AbstractAction.php
@@ -494,6 +494,7 @@ abstract class AbstractAction implements \ArrayAccess {
         if ($field) {
           $optionFields[$fieldName] = [
             'val' => $record[$expr],
+            'expr' => $expr,
             'field' => $field,
             'suffix' => substr($expr, $suffix + 1),
             'depends' => $field['input_attrs']['control_field'] ?? NULL,
@@ -508,7 +509,7 @@ abstract class AbstractAction implements \ArrayAccess {
     });
     // Replace pseudoconstants. Note this is a reverse lookup as we are evaluating input not output.
     foreach ($optionFields as $fieldName => $info) {
-      $options = FormattingUtil::getPseudoconstantList($info['field'], $info['suffix'], $record, 'create');
+      $options = FormattingUtil::getPseudoconstantList($info['field'], $info['expr'], $record, 'create');
       $record[$fieldName] = FormattingUtil::replacePseudoconstant($options, $info['val'], TRUE);
     }
   }

--- a/Civi/Api4/Generic/Traits/DAOActionTrait.php
+++ b/Civi/Api4/Generic/Traits/DAOActionTrait.php
@@ -215,7 +215,7 @@ trait DAOActionTrait {
       if (NULL !== $value) {
 
         if ($field['suffix']) {
-          $options = FormattingUtil::getPseudoconstantList($field, $field['suffix'], $params, $this->getActionName());
+          $options = FormattingUtil::getPseudoconstantList($field, $name, $params, $this->getActionName());
           $value = FormattingUtil::replacePseudoconstant($options, $value, TRUE);
         }
 
@@ -266,8 +266,8 @@ trait DAOActionTrait {
     if (strpos($fieldExpr, '.') === FALSE) {
       return NULL;
     }
-    list($groupName, $fieldName) = explode('.', $fieldExpr);
-    list($fieldName, $suffix) = array_pad(explode(':', $fieldName), 2, NULL);
+    [$groupName, $fieldName] = explode('.', $fieldExpr);
+    [$fieldName, $suffix] = array_pad(explode(':', $fieldName), 2, NULL);
     $cacheKey = "APIv4_Custom_Fields-$groupName";
     $info = \Civi::cache('metadata')->get($cacheKey);
     if (!isset($info[$fieldName])) {

--- a/Civi/Api4/Query/Api4SelectQuery.php
+++ b/Civi/Api4/Query/Api4SelectQuery.php
@@ -319,7 +319,7 @@ class Api4SelectQuery {
         $suffix = strstr($item, ':');
         if ($suffix && $expr->getType() === 'SqlField') {
           $field = $this->getField($item);
-          $options = FormattingUtil::getPseudoconstantList($field, substr($suffix, 1));
+          $options = FormattingUtil::getPseudoconstantList($field, $item);
           if ($options) {
             asort($options);
             $column = "FIELD($column,'" . implode("','", array_keys($options)) . "')";


### PR DESCRIPTION
Overview
----------------------------------------
Fixes an obscure bug in APIv4 and adds a test.

Before
----------------------------------------
Doing api.get for an organization and joining on an individual would fail to correctly retrieve the individual's contact_sub_type

After
----------------------------------------
Works, test added

Technical Details
----------------------------------------
The getPseudoconstantList() function passes an array of params to core BAO::buildOptions, that list needs to be transformed to match the prefix on the field, in case that field belongs to a joined entity rather than the main entity.