### PR TITLE
CiviEvent: Fix waitlist warning

### DIFF
--- a/templates/CRM/Price/Form/ParticipantCount.tpl
+++ b/templates/CRM/Price/Form/ParticipantCount.tpl
@@ -23,7 +23,7 @@
 
     function pricesetParticipantCount( ) {
 
-      cj("input,#priceset select,#priceset").each(function () {
+      CRM.$('input','#priceset','select','#priceset').each(function () {
 
         if ( cj(this).attr('price') ) {
             switch( cj(this).attr('type') ) {
@@ -170,7 +170,7 @@
     var optionPart = option[1].split(optionSep);
   if ( optionPart[1] ) {
       addCount    = parseInt( optionPart[1] );
-      var textval = parseInt( cj(object).attr('value') );
+      var textval = parseInt( CRM.$(object).val() );
       var curval  = textval * addCount;
         if ( textval >= 0 ) {
       pPartiCount    = pPartiCount + curval - parseInt(pPartiRef[ele]);


### PR DESCRIPTION
Overview
----------------------------------------
If you try to purchase more tickets for an event than are available, you used to receive a warning, but now you don't.

### Steps to replicate:
* Set up an event with a max participants, a waitlist, and a price set.
* Try to purchase more tickets than are available.
* The warning should appear immediately at the top of the page, before you submit.

Before
----------------------------------------
No warning.

After
----------------------------------------
"This event has only `x` space(s) left. If you continue and register more than `x` people (including yourself ), the whole group will be wait listed. Or, you can reduce the number of people you are registering to `x` to avoid being put on the waiting list."

Technical Details
----------------------------------------
`attr('value')` worked prior to jQuery 1.6, but it selects the attribute (the initial value) and not the current value.

Additionally, the jQuery selector that found the priceset inputs was set up incorrectly, and was finding all inputs/selects on the page, not just those inside the priceset div. 
