### PR TITLE
Enotice fix on extensions page

### DIFF
--- a/templates/CRM/Admin/Page/ExtensionDetails.tpl
+++ b/templates/CRM/Admin/Page/ExtensionDetails.tpl
@@ -7,9 +7,9 @@
         <td>
           {foreach from=$extension.authors item=author}
             {capture assign=authorDetails}
-              {if $author.role}{$author.role|escape};{/if}
-              {if $author.email}<a href="mailto:{$author.email|escape}">{$author.email|escape}</a>;{/if}
-              {if $author.homepage}<a href="{$author.homepage|escape}">{$author.homepage|escape}</a>;{/if}
+              {if !empty($author.role)}{$author.role|escape};{/if}
+              {if !empty($author.email)}<a href="mailto:{$author.email|escape}">{$author.email|escape}</a>;{/if}
+              {if !empty($author.homepage)}<a href="{$author.homepage|escape}">{$author.homepage|escape}</a>;{/if}
             {/capture}
             {$author.name|escape} {if $authorDetails}({$authorDetails|trim:'; '}){/if}<br/>
           {/foreach}

--- a/templates/CRM/Admin/Page/Extensions/Main.tpl
+++ b/templates/CRM/Admin/Page/Extensions/Main.tpl
@@ -19,14 +19,14 @@ Depends: CRM/common/enableDisableApi.tpl and CRM/common/jsortable.tpl
       </thead>
       <tbody>
         {foreach from=$localExtensionRows key=extKey item=row}
-        <tr id="extension-{$row.file|escape}" class="crm-entity crm-extension-{$row.file|escape}{if $row.status eq 'disabled'} disabled{/if}{if $row.status eq 'installed-missing' or $row.status eq 'disabled-missing'} extension-missing{/if}{if $row.upgradable} extension-upgradable{elseif $row.status eq 'installed'} extension-installed{/if}">
+        <tr id="extension-{$row.file|escape}" class="crm-entity crm-extension-{$row.file|escape}{if $row.status eq 'disabled'} disabled{/if}{if $row.status eq 'installed-missing' or $row.status eq 'disabled-missing'} extension-missing{/if}{if $row.status eq 'installed'} extension-installed{/if}">
           <td class="crm-extensions-label">
               <a class="collapsed" href="#"></a>&nbsp;<strong>{$row.label|escape}</strong><br/>{$row.description|escape}
-              {if $extAddNewEnabled && $remoteExtensionRows[$extKey] && $remoteExtensionRows[$extKey].upgradelink}
+              {if $extAddNewEnabled && !empty($remoteExtensionRows[$extKey]) && $remoteExtensionRows[$extKey].upgradelink}
                 <div class="crm-extensions-upgrade">{$remoteExtensionRows[$extKey].upgradelink}</div>
               {/if}
           </td>
-          <td class="crm-extensions-status">{$row.statusLabel} {if $row.upgradable}<br/>({ts}Outdated{/ts}){/if}</td>
+          <td class="crm-extensions-status">{$row.statusLabel} </td>
           <td class="crm-extensions-version">{$row.version|escape}
             {if ($row.develStage and $row.develStage != 'stable') or preg_match(";(alpha|beta|dev);", $row.version)}
               {icon icon="fa-flask crm-extensions-stage"}{ts}This is a pre-release version. For more details, see the expanded description.{/ts}{/icon}


### PR DESCRIPTION
Overview
----------------------------------------
Enotice fix on extensions page

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/124830842-902c2000-dfce-11eb-883b-0a766b35a4d4.png)

After
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/124830855-93bfa700-dfce-11eb-90f6-6e988906ea51.png)

Technical Details
----------------------------------------
I dug around and I think upgradable is an obsolete row value - I couldn't find where it
was set - including when I marked an extension as an older version in info.xml


Comments
----------------------------------------
@totten this is one of a bunch of notices on that page - I'm wondering if you would recognise some of the fields as dated if you looked (also I think it's OK for there to be notices if they are fields we think really should be filled in in the info.xml)

![image](https://user-images.githubusercontent.com/336308/124830967-b8b41a00-dfce-11eb-9447-d8cc5a3df467.png)
