### PR TITLE
SearchKit - Remove automatic filter from address

### DIFF
--- a/Civi/Api4/Address.php
+++ b/Civi/Api4/Address.php
@@ -19,8 +19,6 @@ namespace Civi\Api4;
  * Creating a new address requires at minimum a contact's ID and location type ID
  * and other attributes (although optional) like street address, city, country etc.
  *
- * @ui_join_filters location_type_id
- *
  * @searchable secondary
  * @since 5.19
  * @package Civi\Api4


### PR DESCRIPTION
Overview
----------------------------------------
Usability fix for SearchKit - don't automatically add "Location Type" to the search when joining with Address.

Before
----------------------------------------
When creating a search, adding "With Address" will auto add a filter which may be more confusing than helpful.

After
----------------------------------------
Filiter not added automatically; still can be added manually.

Comments
----------------------------------------
This is consistent with other location entities like Email, IM, Phone, etc. which do not auto-add any filters.

Discovered while testing #20746
