### PR TITLE
Wordpress Profile User Creation Sign On

### DIFF
--- a/CRM/ACL/API.php
+++ b/CRM/ACL/API.php
@@ -38,6 +38,8 @@ class CRM_ACL_API {
    *
    * @return bool
    *   true if yes, else false
+   *
+   * @deprecated
    */
   public static function check($str, $contactID = NULL) {
     \CRM_Core_Error::deprecatedWarning(__CLASS__ . '::' . __FUNCTION__ . ' is deprecated.');

--- a/CRM/ACL/BAO/ACL.php
+++ b/CRM/ACL/BAO/ACL.php
@@ -188,6 +188,8 @@ SELECT acl.*
    * @param int $contactID
    *
    * @return bool
+   *
+   * @deprecated
    */
   public static function check($str, $contactID) {
     \CRM_Core_Error::deprecatedWarning(__CLASS__ . '::' . __FUNCTION__ . ' is deprecated.');

--- a/CRM/Core/Error.php
+++ b/CRM/Core/Error.php
@@ -1039,16 +1039,23 @@ class CRM_Core_Error extends PEAR_ErrorStack {
       $callerClass = $dbt[1]['class'] ?? NULL;
       $oldMethod = "{$callerClass}::{$callerFunction}";
     }
-    self::deprecatedWarning("Deprecated function $oldMethod, use $newMethod.");
+    $message = "Deprecated function $oldMethod, use $newMethod.";
+    Civi::log()->warning($message, ['civi.tag' => 'deprecated']);
+    trigger_error($message, E_USER_DEPRECATED);
   }
 
   /**
    * Output a deprecated notice about a deprecated call path, rather than deprecating a whole function.
+   *
    * @param string $message
    */
   public static function deprecatedWarning($message) {
     // Even though the tag is no longer used within the log() function,
     // \Civi\API\LogObserver instances may still be monitoring it.
+    $dbt = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 3);
+    $callerFunction = $dbt[2]['function'] ?? NULL;
+    $callerClass = $dbt[2]['class'] ?? NULL;
+    $message .= " Caller: {$callerClass}::{$callerFunction}";
     Civi::log()->warning($message, ['civi.tag' => 'deprecated']);
     trigger_error($message, E_USER_DEPRECATED);
   }

--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -1468,4 +1468,12 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
     add_action('profile_update', [$civicrm->users, 'update_user']);
   }
 
+  /**
+   * Depending on configuration, either let the admin enter the password
+   * when creating a user or let the user do it via email link.
+   */
+  public function showPasswordFieldWhenAdminCreatesUser() {
+    return !$this->isUserRegistrationPermitted();
+  }
+
 }

--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -922,7 +922,10 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
     if (!current_user_can('create_users')) {
       $creds = [];
       $creds['user_login'] = $params['cms_name'];
+      $creds['user_password'] = $user_data['user_pass'];
       $creds['remember'] = TRUE;
+
+      // @todo handle a wp_signon failure
       wp_signon($creds, FALSE);
     }
 
@@ -1460,14 +1463,6 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
     // Re-add current CiviCRM plugin filters.
     add_action('user_register', [$civicrm->users, 'update_user']);
     add_action('profile_update', [$civicrm->users, 'update_user']);
-  }
-
-  /**
-   * Depending on configuration, either let the admin enter the password
-   * when creating a user or let the user do it via email link.
-   */
-  public function showPasswordFieldWhenAdminCreatesUser() {
-    return !$this->isUserRegistrationPermitted();
   }
 
 }

--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -924,7 +924,10 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
       $creds['user_login'] = $params['cms_name'];
       $creds['user_password'] = $user_data['user_pass'];
       $creds['remember'] = TRUE;
+<<<<<<< HEAD
 
+=======
+>>>>>>> add password to wp_signon
       // @todo handle a wp_signon failure
       wp_signon($creds, FALSE);
     }

--- a/Civi/Api4/CustomValue.php
+++ b/Civi/Api4/CustomValue.php
@@ -99,7 +99,7 @@ class CustomValue {
    * @throws \API_Exception
    */
   public static function replace($customGroup, $checkPermissions = TRUE) {
-    return (new Generic\BasicReplaceAction("Custom_$customGroup", __FUNCTION__, ['id', 'entity_id']))
+    return (new Generic\BasicReplaceAction("Custom_$customGroup", __FUNCTION__))
       ->setCheckPermissions($checkPermissions);
   }
 

--- a/Civi/Api4/Generic/AbstractBatchAction.php
+++ b/Civi/Api4/Generic/AbstractBatchAction.php
@@ -12,6 +12,8 @@
 
 namespace Civi\Api4\Generic;
 
+use Civi\Api4\Utils\CoreUtil;
+
 /**
  * Base class for all batch actions (Update, Delete, Replace).
  *
@@ -30,23 +32,6 @@ abstract class AbstractBatchAction extends AbstractQueryAction {
   protected $where = [];
 
   /**
-   * @var array
-   */
-  private $select;
-
-  /**
-   * BatchAction constructor.
-   * @param string $entityName
-   * @param string $actionName
-   * @param string|array $select
-   *   One or more fields to load for each item.
-   */
-  public function __construct($entityName, $actionName, $select = 'id') {
-    $this->select = (array) $select;
-    parent::__construct($entityName, $actionName);
-  }
-
-  /**
    * Get a list of records for this batch.
    *
    * @return array
@@ -56,7 +41,7 @@ abstract class AbstractBatchAction extends AbstractQueryAction {
   }
 
   /**
-   * Get a query which resolves the list of records for this batch.
+   * Get an API action object which resolves the list of records for this batch.
    *
    * This is similar to `getBatchRecords()`, but you may further refine the
    * API call (e.g. selecting different fields or data-pages) before executing.
@@ -72,16 +57,20 @@ abstract class AbstractBatchAction extends AbstractQueryAction {
       'offset' => $this->offset,
     ];
     if (empty($this->reload)) {
-      $params['select'] = $this->select;
+      $params['select'] = $this->getSelect();
     }
     return \Civi\API\Request::create($this->getEntityName(), 'get', ['version' => 4] + $params);
   }
 
   /**
-   * @return array
+   * Determines what fields will be returned by getBatchRecords
+   *
+   * Defaults to an entity's primary key(s), typically ['id']
+   *
+   * @return string[]
    */
   protected function getSelect() {
-    return $this->select;
+    return CoreUtil::getInfoItem($this->getEntityName(), 'primary_key');
   }
 
 }

--- a/Civi/Api4/Generic/BasicBatchAction.php
+++ b/Civi/Api4/Generic/BasicBatchAction.php
@@ -43,13 +43,19 @@ class BasicBatchAction extends AbstractBatchAction {
    *
    * @param string $entityName
    * @param string $actionName
-   * @param string|array $select
-   *   One or more fields to select from each matching item.
    * @param callable $doer
    */
-  public function __construct($entityName, $actionName, $select = 'id', $doer = NULL) {
-    parent::__construct($entityName, $actionName, $select);
+  public function __construct($entityName, $actionName, $doer = NULL) {
+    parent::__construct($entityName, $actionName);
     $this->doer = $doer;
+    // Accept doer as 4th param for now, but emit deprecated warning
+    $this->doer = func_get_args()[3] ?? NULL;
+    if ($this->doer) {
+      \CRM_Core_Error::deprecatedWarning(__CLASS__ . ' constructor received $doer as 4th param; it should be the 3rd as the $select param has been removed');
+    }
+    else {
+      $this->doer = $doer;
+    }
   }
 
   /**

--- a/Civi/Api4/Generic/BasicEntity.php
+++ b/Civi/Api4/Generic/BasicEntity.php
@@ -105,7 +105,7 @@ abstract class BasicEntity extends AbstractEntity {
    * @return BasicSaveAction
    */
   public static function save($checkPermissions = TRUE) {
-    return (new BasicSaveAction(static::getEntityName(), __FUNCTION__, static::$idField, static::$setter))
+    return (new BasicSaveAction(static::getEntityName(), __FUNCTION__, static::$setter))
       ->setCheckPermissions($checkPermissions);
   }
 
@@ -114,7 +114,7 @@ abstract class BasicEntity extends AbstractEntity {
    * @return BasicUpdateAction
    */
   public static function update($checkPermissions = TRUE) {
-    return (new BasicUpdateAction(static::getEntityName(), __FUNCTION__, static::$idField, static::$setter))
+    return (new BasicUpdateAction(static::getEntityName(), __FUNCTION__, static::$setter))
       ->setCheckPermissions($checkPermissions);
   }
 
@@ -123,7 +123,7 @@ abstract class BasicEntity extends AbstractEntity {
    * @return BasicBatchAction
    */
   public static function delete($checkPermissions = TRUE) {
-    return (new BasicBatchAction(static::getEntityName(), __FUNCTION__, static::$idField, static::$deleter))
+    return (new BasicBatchAction(static::getEntityName(), __FUNCTION__, static::$deleter))
       ->setCheckPermissions($checkPermissions);
   }
 
@@ -132,7 +132,7 @@ abstract class BasicEntity extends AbstractEntity {
    * @return BasicReplaceAction
    */
   public static function replace($checkPermissions = TRUE) {
-    return (new BasicReplaceAction(static::getEntityName(), __FUNCTION__, static::$idField))
+    return (new BasicReplaceAction(static::getEntityName(), __FUNCTION__))
       ->setCheckPermissions($checkPermissions);
   }
 

--- a/Civi/Api4/Generic/BasicSaveAction.php
+++ b/Civi/Api4/Generic/BasicSaveAction.php
@@ -30,12 +30,18 @@ class BasicSaveAction extends AbstractSaveAction {
    *
    * @param string $entityName
    * @param string $actionName
-   * @param string $idField
    * @param callable $setter
    */
-  public function __construct($entityName, $actionName, $idField = 'id', $setter = NULL) {
-    parent::__construct($entityName, $actionName, $idField);
-    $this->setter = $setter;
+  public function __construct($entityName, $actionName, $setter = NULL) {
+    parent::__construct($entityName, $actionName);
+    // Accept setter as 4th param for now, but emit deprecated warning
+    $this->setter = func_get_args()[3] ?? NULL;
+    if ($this->setter) {
+      \CRM_Core_Error::deprecatedWarning(__CLASS__ . ' constructor received $setter as 4th param; it should be the 3rd as the $select param has been removed');
+    }
+    else {
+      $this->setter = $setter;
+    }
   }
 
   /**

--- a/Civi/Api4/Generic/BasicUpdateAction.php
+++ b/Civi/Api4/Generic/BasicUpdateAction.php
@@ -13,8 +13,6 @@
 namespace Civi\Api4\Generic;
 
 use Civi\API\Exception\NotImplementedException;
-use Civi\API\Exception\UnauthorizedException;
-use Civi\Api4\Utils\CoreUtil;
 
 /**
  * Update one or more $ENTITY with new values.
@@ -34,33 +32,27 @@ class BasicUpdateAction extends AbstractUpdateAction {
    *
    * @param string $entityName
    * @param string $actionName
-   * @param string|array $select
-   *   One or more fields to select from each matching item.
    * @param callable $setter
    */
-  public function __construct($entityName, $actionName, $select = 'id', $setter = NULL) {
-    parent::__construct($entityName, $actionName, $select);
-    $this->setter = $setter;
+  public function __construct($entityName, $actionName, $setter = NULL) {
+    parent::__construct($entityName, $actionName);
+    // Accept setter as 4th param for now, but emit deprecated warning
+    $this->setter = func_get_args()[3] ?? NULL;
+    if ($this->setter) {
+      \CRM_Core_Error::deprecatedWarning(__CLASS__ . ' constructor received $setter as 4th param; it should be the 3rd as the $select param has been removed');
+    }
+    else {
+      $this->setter = $setter;
+    }
   }
 
   /**
-   * We pass the writeRecord function an array representing one item to update.
-   * We expect to get the same format back.
-   *
-   * @param \Civi\Api4\Generic\Result $result
+   * @param array $items
+   * @return array
    * @throws \API_Exception
-   * @throws \Civi\API\Exception\NotImplementedException
    */
-  public function _run(Result $result) {
-    $this->formatWriteValues($this->values);
-    $this->validateValues();
-    foreach ($this->getBatchRecords() as $item) {
-      $record = $this->values + $item;
-      if ($this->checkPermissions && !CoreUtil::checkAccessRecord($this, $record, \CRM_Core_Session::getLoggedInContactID() ?: 0)) {
-        throw new UnauthorizedException("ACL check failed");
-      }
-      $result[] = $this->writeRecord($record);
-    }
+  protected function updateRecords(array $items): array {
+    return array_map([$this, 'writeRecord'], $items);
   }
 
   /**

--- a/Civi/Api4/Generic/DAOUpdateAction.php
+++ b/Civi/Api4/Generic/DAOUpdateAction.php
@@ -12,70 +12,23 @@
 
 namespace Civi\Api4\Generic;
 
-use Civi\API\Exception\UnauthorizedException;
-use Civi\Api4\Utils\CoreUtil;
-
 /**
  * Update one or more $ENTITY with new values.
  *
- * Use the `where` clause (required) to select them.
+ * Use the `where` clause to bulk update multiple records,
+ * or supply 'id' as a value to update a single record.
  */
 class DAOUpdateAction extends AbstractUpdateAction {
   use Traits\DAOActionTrait;
 
   /**
-   * Criteria for selecting items to update.
-   *
-   * Required if no id is supplied in values.
-   *
-   * @var array
+   * @param array $items
+   * @return array
+   * @throws \API_Exception
+   * @throws \CRM_Core_Exception
    */
-  protected $where = [];
-
-  /**
-   * @inheritDoc
-   */
-  public function _run(Result $result) {
-    $this->formatWriteValues($this->values);
-    // Add ID from values to WHERE clause and check for mismatch
-    if (!empty($this->values['id'])) {
-      $wheres = array_column($this->where, NULL, 0);
-      if (!isset($wheres['id'])) {
-        $this->addWhere('id', '=', $this->values['id']);
-      }
-      elseif (!($wheres['id'][1] === '=' && $wheres['id'][2] == $this->values['id'])) {
-        throw new \Exception("Cannot update the id of an existing " . $this->getEntityName() . '.');
-      }
-    }
-
-    // Require WHERE if we didn't get an ID from values
-    if (!$this->where) {
-      throw new \API_Exception('Parameter "where" is required unless an id is supplied in values.');
-    }
-
-    // Update a single record by ID unless select requires more than id
-    if ($this->getSelect() === ['id'] && count($this->where) === 1 && $this->where[0][0] === 'id' && $this->where[0][1] === '=' && !empty($this->where[0][2])) {
-      $this->values['id'] = $this->where[0][2];
-      if ($this->checkPermissions && !CoreUtil::checkAccessRecord($this, $this->values, \CRM_Core_Session::getLoggedInContactID() ?: 0)) {
-        throw new UnauthorizedException("ACL check failed");
-      }
-      $items = [$this->values];
-      $this->validateValues();
-      $result->exchangeArray($this->writeObjects($items));
-      return;
-    }
-
-    // Batch update 1 or more records based on WHERE clause
-    $items = $this->getBatchRecords();
-    foreach ($items as &$item) {
-      $item = $this->values + $item;
-      if ($this->checkPermissions && !CoreUtil::checkAccessRecord($this, $item, \CRM_Core_Session::getLoggedInContactID() ?: 0)) {
-        throw new UnauthorizedException("ACL check failed");
-      }
-    }
-
-    $this->validateValues();
-    $result->exchangeArray($this->writeObjects($items));
+  protected function updateRecords(array $items): array {
+    return $this->writeObjects($items);
   }
 
 }

--- a/Civi/Api4/Generic/Traits/CustomValueActionTrait.php
+++ b/Civi/Api4/Generic/Traits/CustomValueActionTrait.php
@@ -24,7 +24,7 @@ trait CustomValueActionTrait {
 
   public function __construct($customGroup, $actionName) {
     $this->customGroup = $customGroup;
-    parent::__construct('CustomValue', $actionName, ['id', 'entity_id']);
+    parent::__construct('CustomValue', $actionName);
   }
 
   /**

--- a/ext/afform/core/Civi/Api4/Afform.php
+++ b/ext/afform/core/Civi/Api4/Afform.php
@@ -44,7 +44,7 @@ class Afform extends Generic\AbstractEntity {
    * @return Action\Afform\Update
    */
   public static function update($checkPermissions = TRUE) {
-    return (new Action\Afform\Update('Afform', __FUNCTION__, 'name'))
+    return (new Action\Afform\Update('Afform', __FUNCTION__))
       ->setCheckPermissions($checkPermissions);
   }
 
@@ -53,7 +53,7 @@ class Afform extends Generic\AbstractEntity {
    * @return Action\Afform\Save
    */
   public static function save($checkPermissions = TRUE) {
-    return (new Action\Afform\Save('Afform', __FUNCTION__, 'name'))
+    return (new Action\Afform\Save('Afform', __FUNCTION__))
       ->setCheckPermissions($checkPermissions);
   }
 
@@ -89,7 +89,7 @@ class Afform extends Generic\AbstractEntity {
    * @return Generic\BasicBatchAction
    */
   public static function revert($checkPermissions = TRUE) {
-    return (new BasicBatchAction('Afform', __FUNCTION__, ['name'], function($item, BasicBatchAction $action) {
+    return (new BasicBatchAction('Afform', __FUNCTION__, function($item, BasicBatchAction $action) {
       $scanner = \Civi::service('afform_scanner');
       $files = [
         \CRM_Afform_AfformScanner::METADATA_FILE,

--- a/templates/CRM/Report/Form.tpl
+++ b/templates/CRM/Report/Form.tpl
@@ -49,7 +49,7 @@
     {include file="CRM/Report/Form/ErrorMessage.tpl"}
   </div>
 {/if}
-{if $outputMode == 'print'}
+{if !empty($outputMode) && $outputMode == 'print'}
   <script type="text/javascript">
     window.print();
   </script>

--- a/templates/CRM/Report/Form/Actions.tpl
+++ b/templates/CRM/Report/Form/Actions.tpl
@@ -7,7 +7,7 @@
  | and copyright information, see https://civicrm.org/licensing       |
  +--------------------------------------------------------------------+
 *}
-{if !$printOnly} {* NO print section starts *}
+{if empty($printOnly)} {* NO print section starts *}
 
   {* build the print pdf buttons *}
     <div class="crm-tasks">
@@ -19,7 +19,7 @@
             <table class="form-layout-compressed">
               <tr>
                 {include file="CRM/common/tasks.tpl" location="botton"}
-                {if $instanceUrl}
+                {if !empty($instanceUrl)}
                   <td>&nbsp;&nbsp;<i class="crm-i fa-chevron-right" aria-hidden="true"></i> <a href="{$instanceUrl}">{ts}Existing report(s) from this template{/ts}</a></td>
                 {/if}
               </tr>
@@ -27,13 +27,13 @@
           </td>
           <td>
             <table class="form-layout-compressed" align="right">
-              {if $chartSupported}
+              {if !empty($chartSupported)}
                 <tr>
                   <td>{$form.charts.html|crmAddClass:big}</td>
                   <td align="right">{$form.$chart.html}</td>
                 </tr>
               {/if}
-              {if $form.groups}
+              {if !empty($form.groups)}
                 <tr>
                   <td>
                     {$form.groups.html}{$form.$group.html}
@@ -71,7 +71,7 @@
       // Disable print/pdf output of charts
       $('select[name=charts]', 'form.crm-report-form').change(function() {
         var viewType = $(this).val(),
-          flashChartType = '{/literal}{if $chartType}{$chartType}{else}{/if}{literal}';
+          flashChartType = '{/literal}{if !empty($chartType)}{$chartType}{else}{/if}{literal}';
         $('#_qf_Summary_submit_pdf, #_qf_Summary_submit_print').prop('disabled', (viewType && flashChartType != viewType));
       });
     });

--- a/templates/CRM/Report/Form/Criteria.tpl
+++ b/templates/CRM/Report/Form/Criteria.tpl
@@ -24,7 +24,7 @@
   {foreach from=$table item=field key=fieldName}
     {literal}var val = "dnc";{/literal}
     {assign var=fieldOp     value=$fieldName|cat:"_op"}
-    {if !($field.operatorType & 4) && !$field.no_display && $form.$fieldOp.html}
+    {if !(!empty($field.operatorType) && $field.operatorType & 4) && empty($field.no_display) && !empty($form.$fieldOp.html)}
       {literal}var val = document.getElementById("{/literal}{$fieldOp}{literal}").value;{/literal}
     {/if}
     {literal}showHideMaxMinVal( "{/literal}{$fieldName}{literal}", val );{/literal}
@@ -52,7 +52,7 @@
     $('.crm-report-criteria-groupby input:checkbox').click(function() {
       $('#fields_' + this.id.substr(10)).prop('checked', this.checked);
     });
-    {/literal}{if $displayToggleGroupByFields}{literal}
+    {/literal}{if !empty($displayToggleGroupByFields)}{literal}
       $('.crm-report-criteria-field input:checkbox').click(function() {
         $('#group_bys_' + this.id.substr(7)).prop('checked', this.checked);
       });

--- a/templates/CRM/Report/Form/ErrorMessage.tpl
+++ b/templates/CRM/Report/Form/ErrorMessage.tpl
@@ -7,7 +7,7 @@
  | and copyright information, see https://civicrm.org/licensing       |
  +--------------------------------------------------------------------+
 *}
-{if $outputMode eq 'html' && !$rows}
+{if !empty($outputMode) && $outputMode eq 'html' && empty($rows)}
   <div class="messages status no-popup">
     {icon icon="fa-info-circle"}{/icon} {ts}None found.{/ts}
   </div>

--- a/templates/CRM/Report/Form/Fields.tpl
+++ b/templates/CRM/Report/Form/Fields.tpl
@@ -7,8 +7,8 @@
  | and copyright information, see https://civicrm.org/licensing       |
  +--------------------------------------------------------------------+
 *}
-{if !$printOnly} {* NO print section starts *}
-  {if $criteriaForm}
+{if empty($printOnly)} {* NO print section starts *}
+  {if !empty($criteriaForm)}
     <div class="crm-report-criteria"> {* criteria section starts *}
       <div id="mainTabContainer">
         {*tab navigation bar*}
@@ -18,7 +18,7 @@
               <a title="{$tab.title|escape}" href="#report-tab-{$tab.div_label}">{$tab.title}</a>
             </li>
           {/foreach}
-          {if $instanceForm OR $instanceFormError}
+          {if !empty($instanceForm) OR !empty($instanceFormError)}
             <li id="tab_settings" class="ui-corner-all">
               <a title="{ts}Title and Format{/ts}" href="#report-tab-format">{ts}Title and Format{/ts}</a>
             </li>
@@ -35,7 +35,7 @@
         {include file="CRM/Report/Form/Criteria.tpl"}
 
         {*settings*}
-        {if $instanceForm OR $instanceFormError}
+        {if !empty($instanceForm) OR !empty($instanceFormError)}
           {include file="CRM/Report/Form/Tabs/Instance.tpl"}
         {/if}
       </div> {* end mainTabContainer *}
@@ -51,7 +51,7 @@
     CRM.$(function($) {
       var tabSettings = {
         collapsible: true,
-        active: {/literal}{if $rows}false{else}0{/if}{literal}
+        active: {/literal}{if !empty($rows)}false{else}0{/if}{literal}
       };
       // If a tab contains an error, open it
       if ($('.civireport-criteria .crm-error', '#mainTabContainer').length) {

--- a/templates/CRM/Report/Form/Grant/Statistics.tpl
+++ b/templates/CRM/Report/Form/Grant/Statistics.tpl
@@ -24,7 +24,7 @@
         {*include the graph*}
         {include file="CRM/Report/Form/Layout/Graph.tpl"}
 
-    {if $printOnly}
+    {if !empty($printOnly)}
         <h1>{$reportTitle}</h1>
         <div id="report-date">{$reportDate}</div>
     {/if}

--- a/templates/CRM/Report/Form/Layout/Table.tpl
+++ b/templates/CRM/Report/Form/Layout/Table.tpl
@@ -7,7 +7,7 @@
  | and copyright information, see https://civicrm.org/licensing       |
  +--------------------------------------------------------------------+
 *}
-{if !$rows}
+{if empty($rows)}
   <p>{ts}None found.{/ts}</p>
 {else}
     {if !empty($pager) and $pager->_response and $pager->_response.numPages > 1}
@@ -98,7 +98,7 @@
                     {assign var=fieldHover value=$field|cat:"_hover"}
                     {assign var=fieldClass value=$field|cat:"_class"}
                     <td class="crm-report-{$field}{if $header.type eq 1024 OR $header.type eq 1 OR $header.type eq 512} report-contents-right{elseif $row.$field eq 'Subtotal'} report-label{/if}">
-                        {if $row.$fieldLink}
+                        {if !empty($row.$fieldLink)}
                             <a title="{$row.$fieldHover|escape}" href="{$row.$fieldLink}"  {if !empty($row.$fieldClass)} class="{$row.$fieldClass}"{/if}>
                         {/if}
 
@@ -130,7 +130,7 @@
                             {$row.$field}
                         {/if}
 
-                        {if $row.$fieldLink}</a>{/if}
+                        {if !empty($row.$fieldLink)}</a>{/if}
                     </td>
                 {/foreach}
             </tr>

--- a/templates/CRM/Report/Form/Statistics.tpl
+++ b/templates/CRM/Report/Form/Statistics.tpl
@@ -8,13 +8,13 @@
  +--------------------------------------------------------------------+
 *}
 {if !empty($top)}
-  {if $printOnly}
+  {if !empty($printOnly)}
     <h1>{$reportTitle}</h1>
-    <div id="report-date">{$reportDate}</div>
+    <div id="report-date">{if !empty($reportDate)}{$reportDate}{/if}</div>
   {/if}
-  {if $statistics}
+  {if !empty($statistics)}
     <table class="report-layout statistics-table">
-      {if !empty($statistics.groups)} 
+      {if !empty($statistics.groups)}
         {foreach from=$statistics.groups item=row}
           <tr>
             <th class="statistics" scope="row">{$row.title}</th>

--- a/templates/CRM/Report/Form/Tabs/FieldSelection.tpl
+++ b/templates/CRM/Report/Form/Tabs/FieldSelection.tpl
@@ -12,7 +12,7 @@
     {foreach from=$colGroups item=grpFields key=dnc}
       {assign  var="count" value="0"}
       {* Wrap custom field sets in collapsed accordion pane. *}
-      {if $grpFields.use_accordian_for_field_selection}
+      {if !empty($grpFields.use_accordian_for_field_selection)}
         <div class="crm-accordion-wrapper crm-accordion collapsed">
         <div class="crm-accordion-header">
           {$grpFields.group_title}
@@ -33,7 +33,7 @@
           {/if}
         </tr>
       </table>
-      {if $grpFields.use_accordian_for_field_selection}
+      {if !empty($grpFields.use_accordian_for_field_selection)}
         </div><!-- /.crm-accordion-body -->
         </div><!-- /.crm-accordion-wrapper -->
       {/if}

--- a/templates/CRM/Report/Form/Tabs/Filters.tpl
+++ b/templates/CRM/Report/Form/Tabs/Filters.tpl
@@ -14,7 +14,7 @@
       {foreach from=$filters item=table key=tableName}
         {assign  var="filterCount" value=$table|@count}
         {* Wrap custom field sets in collapsed accordion pane. *}
-        {if $filterGroups.$tableName.group_title and $filterCount gte 1}
+        {if !empty($filterGroups.$tableName.group_title) and $filterCount gte 1}
           {* we should close table that contains other filter elements before we start building custom group accordion
            *}
           {if $counter eq 1}
@@ -33,23 +33,26 @@
                 {assign var=filterVal   value=$fieldName|cat:"_value"}
                 {assign var=filterMin   value=$fieldName|cat:"_min"}
                 {assign var=filterMax   value=$fieldName|cat:"_max"}
-                {if $field.operatorType & 4}
+                {if !empty($field.operatorType) && $field.operatorType & 4}
                   <tr class="report-contents crm-report crm-report-criteria-filter crm-report-criteria-filter-{$tableName}">
-                    <td class="label report-contents">{$field.title}</td>
-                      {include file="CRM/Core/DatePickerRangeWrapper.tpl" fieldName=$fieldName hideRelativeLabel=1, from='_from' to='_to'}
+                    <td class="label report-contents">{if !empty($field.title)}{$field.title}{/if}</td>
+                      {include file="CRM/Core/DatePickerRangeWrapper.tpl" fieldName=$fieldName hideRelativeLabel=1 from='_from' to='_to'}
                   </tr>
                 {elseif $form.$fieldOp.html}
-                  <tr class="report-contents crm-report crm-report-criteria-filter crm-report-criteria-filter-{$tableName}" {if $field.no_display} style="display: none;"{/if}>
-                    <td class="label report-contents">{$field.title}</td>
+                  <tr class="report-contents crm-report crm-report-criteria-filter crm-report-criteria-filter-{$tableName}" {if !empty($field.no_display)} style="display: none;"{/if}>
+                    <td class="label report-contents">{if !empty($field.title)}{$field.title}{/if}</td>
                     <td class="report-contents">{$form.$fieldOp.html}</td>
                     <td>
                       <span id="{$filterVal}_cell">{$form.$filterVal.label}&nbsp;{$form.$filterVal.html}</span>
-                      <span id="{$filterMin}_max_cell">{$form.$filterMin.label}&nbsp;{$form.$filterMin.html}&nbsp;&nbsp;{$form.$filterMax.label}&nbsp;{$form.$filterMax.html}</span>
+                      <span id="{$filterMin}_max_cell">
+                        {if !empty($form.$filterMin)}{$form.$filterMin.label}&nbsp;{$form.$filterMin.html}&nbsp;&nbsp;{/if}
+                        {if !empty($form.$filterMax)}{$form.$filterMax.label}&nbsp;{$form.$filterMax.html}{/if}
+                      </span>
                     </td>
                   </tr>
                 {/if}
         {/foreach}
-        {if $filterGroups.$tableName.group_title}
+        {if !empty($filterGroups.$tableName.group_title)}
               </table>
             </div><!-- /.crm-accordion-body -->
           </div><!-- /.crm-accordion-wrapper -->

--- a/templates/CRM/Report/Form/Tabs/Instance.tpl
+++ b/templates/CRM/Report/Form/Tabs/Instance.tpl
@@ -58,19 +58,23 @@
       <td class="report-label">{$form.parent_id.label} {help id="id-parent" file="CRM/Admin/Form/Navigation.hlp"}</td>
       <td>{$form.parent_id.html|crmAddClass:huge}</td>
     </tr>
+    {if !empty($form.drilldown_id)}
     <tr class="crm-report-instanceForm-form-block-drilldown">
       <td class="report-label">{$form.drilldown_id.label}</td>
       <td>{$form.drilldown_id.html}</td>
     </tr>
+    {/if}
     {if $config->userFramework neq 'Joomla'}
       <tr class="crm-report-instanceForm-form-block-permission">
         <td class="report-label" width="20%">{$form.permission.label} {help id="id-report_perms" file="CRM/Report/Form/Tabs/Settings.hlp"}</td>
         <td>{$form.permission.html|crmAddClass:huge}</td>
       </tr>
+      {if !empty($form.grouprole)}
       <tr class="crm-report-instanceForm-form-block-role">
         <td class="report-label" width="20%">{$form.grouprole.label}</td>
         <td>{$form.grouprole.html|crmAddClass:huge}</td>
       </tr>
+      {/if}
     {/if}
     <tr class="crm-report-instanceForm-form-block-add-to-my-reports">
       <td class="report-label">{$form.add_to_my_reports.label} {help id="id-add_to_my_reports" file="CRM/Report/Form/Tabs/Settings.hlp"}</td>
@@ -119,7 +123,7 @@
   });
 </script>
 {/literal}
-{if $is_navigation}
+{if !empty($is_navigation)}
   <script type="text/javascript">
     document.getElementById('is_navigation').checked = true;
     showHideByValue('is_navigation','','navigation_menu','table-row','radio',false);

--- a/templates/CRM/Report/Page/InstanceList.tpl
+++ b/templates/CRM/Report/Page/InstanceList.tpl
@@ -9,10 +9,10 @@
 *}
 {strip}
   <div class="action-link">
-    {if $templateUrl}
+    {if !empty($templateUrl)}
       <a href="{$templateUrl}" class="button"><span><i class="crm-i fa-plus-circle" aria-hidden="true"></i> {$newButton}</span></a>
     {/if}
-    {if $reportUrl}
+    {if !empty($reportUrl)}
       <a href="{$reportUrl}" class="button"><span>{ts}View All Reports{/ts}</span></a>
     {/if}
   </div>
@@ -53,10 +53,10 @@
     </div>
 
     <div class="action-link">
-      {if $templateUrl}
+      {if !empty($templateUrl)}
         <a href="{$templateUrl}" class="button"><span><i class="crm-i fa-plus-circle" aria-hidden="true"></i> {$newButton}</span></a>
       {/if}
-      {if $reportUrl}
+      {if !empty($reportUrl)}
         <a href="{$reportUrl}" class="button"><span>{ts}View All Reports{/ts}</span></a>
       {/if}
     </div>
@@ -65,11 +65,11 @@
     <div class="crm-content-block">
       <div class="messages status no-popup">
         {icon icon="fa-info-circle"}{/icon}
-        {if $myReports}
+        {if !empty($myReports)}
           {ts}You do not have any private reports. To add a report to this section, edit the Report Settings for a report and set 'Add to My Reports' to Yes.{/ts} &nbsp;
         {else}
           {ts 1=$compName}No %1 reports have been created.{/ts} &nbsp;
-          {if $templateUrl}
+          {if !empty($templateUrl)}
             {ts 1=$templateUrl}You can create reports by selecting from the <a href="%1">list of report templates here.</a>{/ts}
           {else}
             {ts}Contact your site administrator for help creating reports.{/ts}

--- a/templates/CRM/Report/Page/TemplateList.tpl
+++ b/templates/CRM/Report/Page/TemplateList.tpl
@@ -28,7 +28,7 @@
                   <tr id="row_{counter}" class="crm-report-templateList">
                     <td class="crm-report-templateList-title" style="width:35%;">
                       <a href="{$row.url}" title="{ts}Create report from this template{/ts}"><i class="crm-i fa-chevron-right" aria-hidden="true"></i> <strong>{$row.title}</strong></a>
-                      {if $row.instanceUrl}
+                      {if !empty($row.instanceUrl)}
                         <div style="font-size:10px;text-align:right;margin-top:3px;">
                           <a href="{$row.instanceUrl}">{ts}Existing Report(s){/ts}</a>
                         </div>

--- a/tests/phpunit/api/v4/Action/BasicActionsTest.php
+++ b/tests/phpunit/api/v4/Action/BasicActionsTest.php
@@ -48,18 +48,26 @@ class BasicActionsTest extends UnitTestCase {
     $result = MockBasicEntity::get()->execute();
     $this->assertCount(1, $result);
 
-    $id2 = MockBasicEntity::create()->addValue('foo', 'two')->execute()->first()['identifier'];
+    $id2 = MockBasicEntity::create()
+      ->addValue('foo', 'two')
+      ->addValue('group:label', 'First')
+      ->execute()->first()['identifier'];
 
     $result = MockBasicEntity::get()->selectRowCount()->execute();
     $this->assertEquals(2, $result->count());
 
+    // Updating a single record should support identifier either in the values or the where clause
+    // Test both styles of update
     MockBasicEntity::update()->addWhere('identifier', '=', $id2)->addValue('foo', 'new')->execute();
+    MockBasicEntity::update()->addValue('identifier', $id2)->addValue('color', 'red')->execute();
 
     $result = MockBasicEntity::get()->addOrderBy('identifier', 'DESC')->setLimit(1)->execute();
     // The object's count() method will account for all results, ignoring limit, while the array results are limited
     $this->assertCount(2, $result);
     $this->assertCount(1, (array) $result);
     $this->assertEquals('new', $result->first()['foo']);
+    $this->assertEquals('red', $result->first()['color']);
+    $this->assertEquals('one', $result->first()['group']);
 
     $result = MockBasicEntity::save()
       ->addRecord(['identifier' => $id1, 'foo' => 'one updated', 'weight' => '5'])
@@ -252,7 +260,7 @@ class BasicActionsTest extends UnitTestCase {
     }
 
     $result = MockBasicEntity::get()
-      ->addSelect('*e', 'weig*ht')
+      ->addSelect('s*e', 'weig*ht')
       ->execute()
       ->first();
     $this->assertEquals(['shape', 'size', 'weight'], array_keys($result));

--- a/tests/phpunit/api/v4/Mock/Api4/Action/MockBasicEntity/BatchFrobnicate.php
+++ b/tests/phpunit/api/v4/Mock/Api4/Action/MockBasicEntity/BatchFrobnicate.php
@@ -10,20 +10,29 @@
  +--------------------------------------------------------------------+
  */
 
-namespace Civi\Api4\Action\CustomValue;
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+
+namespace Civi\Api4\Action\MockBasicEntity;
 
 /**
- * Update one or more records with new values. Use the where clause to select them.
+ * This class demonstrates how the getRecords method of Basic\Get can be overridden.
  */
-class Update extends \Civi\Api4\Generic\DAOUpdateAction {
-  use \Civi\Api4\Generic\Traits\CustomValueActionTrait;
+class BatchFrobnicate extends \Civi\Api4\Generic\BasicBatchAction {
 
-  /**
-   * Ensure entity_id is returned by getBatchRecords()
-   * @return string[]
-   */
+  protected function doTask($item) {
+    return [
+      'identifier' => $item['identifier'],
+      'frobnication' => $item['number'] * $item['number'],
+    ];
+  }
+
   protected function getSelect() {
-    return ['id', 'entity_id'];
+    return ['identifier', 'number'];
   }
 
 }

--- a/tests/phpunit/api/v4/Mock/Api4/MockBasicEntity.php
+++ b/tests/phpunit/api/v4/Mock/Api4/MockBasicEntity.php
@@ -96,12 +96,8 @@ class MockBasicEntity extends Generic\BasicEntity {
    * @return Generic\BasicBatchAction
    */
   public static function batchFrobnicate($checkPermissions = TRUE) {
-    return (new Generic\BasicBatchAction(__CLASS__, __FUNCTION__, ['identifier', 'number'], function($item) {
-      return [
-        'identifier' => $item['identifier'],
-        'frobnication' => $item['number'] * $item['number'],
-      ];
-    }))->setCheckPermissions($checkPermissions);
+    return (new Action\MockBasicEntity\BatchFrobnicate(__CLASS__, __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
User is not signed in automatically when submitting a profile form with user creation on Wordpress. This was previously the behavior and I believe the intended behavior.

Before
----------------------------------------
User is not log on profile submission.

After
----------------------------------------
User is logged in on profile submission.

Technical Details
----------------------------------------
No password is passed to the `wp_signon` method in the `CRM_Utils_System_WordPress::createUser` method. This is required by this method to authenticate the user (I believe). The password is known at the time of form submission so it is added to the credentials array.

Currently, the `wp_signon` method is return a `WP_Error` object with the error message `The password field is empty.`

Comments
----------------------------------------
It looks like this change was made in the pull request https://github.com/civicrm/civicrm-core/pull/18982 by @mlutfy with an update by @christianwach at https://github.com/civicrm/civicrm-core/pull/20057. There was good discussion by @mlutfy @kcristiano @braders @christianwach. Maybe there is a configuration difference between my Wordpress install and a standard install causing this behavior?
