### PR TITLE
Wordpress Profile User Creation Sign On (v2)

### DIFF
--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -922,7 +922,10 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
     if (!current_user_can('create_users')) {
       $creds = [];
       $creds['user_login'] = $params['cms_name'];
+      $creds['user_password'] = $user_data['user_pass'];
       $creds['remember'] = TRUE;
+
+      // @todo handle a wp_signon failure
       wp_signon($creds, FALSE);
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
User is not signed in automatically when submitting a profile form with user creation on Wordpress. This was previously the behavior and I believe the intended behavior.

Before
----------------------------------------
User is not log on profile submission.

After
----------------------------------------
User is logged in on profile submission.

Technical Details
----------------------------------------
No password is passed to the `wp_signon` method in the `CRM_Utils_System_WordPress::createUser` method. This is required by this method to authenticate the user (I believe). The password is known at the time of form submission so it is added to the credentials array.

Currently, the `wp_signon` method is return a `WP_Error` object with the error message `The password field is empty.`

Comments
----------------------------------------
It looks like this change was made in the pull request https://github.com/civicrm/civicrm-core/pull/18982 by @mlutfy with an update by @christianwach at https://github.com/civicrm/civicrm-core/pull/20057. There was good discussion by @mlutfy @kcristiano @braders @christianwach. Maybe there is a configuration difference between my Wordpress install and a standard install causing this behavior?
