### PR TITLE
AssetBuilderTest - Raise threshold for timeout

### DIFF
--- a/tests/phpunit/E2E/Core/AssetBuilderTest.php
+++ b/tests/phpunit/E2E/Core/AssetBuilderTest.php
@@ -164,7 +164,7 @@ class AssetBuilderTest extends \CiviEndToEndTestCase {
     $url = \Civi::service('asset_builder')->getUrl('invalid.json');
     try {
       $guzzleClient = new \GuzzleHttp\Client();
-      $guzzleResponse = $guzzleClient->request('GET', $url, array('timeout' => 1));
+      $guzzleResponse = $guzzleClient->request('GET', $url, array('timeout' => 2));
       $this->fail('Expecting ClientException... but it was not thrown!');
     }
     catch (\GuzzleHttp\Exception\ClientException $e) {


### PR DESCRIPTION
Overview
--------

Raise the threshold before abandoning execution of this E2E test.

Technical Details
------------------

This aims to mitigate flaky failures like the following:

Example failure: https://test.civicrm.org/job/CiviCRM-Core-Matrix/BKPROF=max,CIVIVER=5.39,SUITES=phpunit-e2e,label=bknix-tmp/9766/testReport/junit/E2E.Core/AssetBuilderTest/testInvalid/

```
E2E\Core\AssetBuilderTest::testInvalid
GuzzleHttp\Exception\ConnectException: cURL error 28: Operation timed out after 1001 milliseconds with 0 bytes received (see https://curl.haxx.se/libcurl/c/libcurl-errors.html)

/home/jenkins/bknix-max/build/build-0/web/sites/all/modules/civicrm/vendor/guzzlehttp/guzzle/src/Handler/CurlFactory.php:200
/home/jenkins/bknix-max/build/build-0/web/sites/all/modules/civicrm/vendor/guzzlehttp/guzzle/src/Handler/CurlFactory.php:155
/home/jenkins/bknix-max/build/build-0/web/sites/all/modules/civicrm/vendor/guzzlehttp/guzzle/src/Handler/CurlFactory.php:105
/home/jenkins/bknix-max/build/build-0/web/sites/all/modules/civicrm/vendor/guzzlehttp/guzzle/src/Handler/CurlHandler.php:43
/home/jenkins/bknix-max/build/build-0/web/sites/all/modules/civicrm/vendor/guzzlehttp/guzzle/src/Handler/Proxy.php:28
/home/jenkins/bknix-max/build/build-0/web/sites/all/modules/civicrm/vendor/guzzlehttp/guzzle/src/Handler/Proxy.php:51
/home/jenkins/bknix-max/build/build-0/web/sites/all/modules/civicrm/vendor/guzzlehttp/guzzle/src/PrepareBodyMiddleware.php:37
/home/jenkins/bknix-max/build/build-0/web/sites/all/modules/civicrm/vendor/guzzlehttp/guzzle/src/Middleware.php:29
/home/jenkins/bknix-max/build/build-0/web/sites/all/modules/civicrm/vendor/guzzlehttp/guzzle/src/RedirectMiddleware.php:70
/home/jenkins/bknix-max/build/build-0/web/sites/all/modules/civicrm/vendor/guzzlehttp/guzzle/src/Middleware.php:59
/home/jenkins/bknix-max/build/build-0/web/sites/all/modules/civicrm/vendor/guzzlehttp/guzzle/src/HandlerStack.php:71
/home/jenkins/bknix-max/build/build-0/web/sites/all/modules/civicrm/vendor/guzzlehttp/guzzle/src/Client.php:351
/home/jenkins/bknix-max/build/build-0/web/sites/all/modules/civicrm/vendor/guzzlehttp/guzzle/src/Client.php:162
/home/jenkins/bknix-max/build/build-0/web/sites/all/modules/civicrm/vendor/guzzlehttp/guzzle/src/Client.php:182
/home/jenkins/bknix-max/build/build-0/web/sites/all/modules/civicrm/tests/phpunit/E2E/Core/AssetBuilderTest.php:167
/home/jenkins/bknix-max/extern/phpunit8/phpunit8.phar:671
```

