### PR TITLE
APIv4 - Fix dumb typo breaking color lookup

### DIFF
--- a/CRM/Core/OptionValue.php
+++ b/CRM/Core/OptionValue.php
@@ -457,7 +457,7 @@ FROM
         'is_active' => $dao->is_active,
         'is_default' => $dao->is_default,
         'icon' => $dao->icon,
-        'color' => $dao->icon,
+        'color' => $dao->color,
       ];
     }
     return $values;


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a dumb typo which caused the afform type selector to look funny.

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/2874912/125006786-edef5500-e02c-11eb-9ce2-43090ff1a333.png)

After
----------------------------------------
![image](https://user-images.githubusercontent.com/2874912/125006709-c13b3d80-e02c-11eb-812c-ec48b7de2372.png)
