### PR TITLE
[REF] Add in APIv4 Product Entity and Fix APIv4 Syntax Conformance te…

### DIFF
--- a/Civi/Api4/ContributionProduct.php
+++ b/Civi/Api4/ContributionProduct.php
@@ -15,6 +15,7 @@ namespace Civi\Api4;
 /**
  * Contribution Product entity.
  *
+ * @since 5.41
  * @package Civi\Api4
  */
 class ContributionProduct extends Generic\DAOEntity {

--- a/Civi/Api4/Product.php
+++ b/Civi/Api4/Product.php
@@ -10,22 +10,14 @@
  +--------------------------------------------------------------------+
  */
 
-/**
- *
- * @package CRM
- * @copyright CiviCRM LLC https://civicrm.org/licensing
- */
-
-
 namespace Civi\Api4;
 
 /**
- * EntityBatch entity.
+ * Product entity.
  *
  * @since 5.41
- * @searchable none
  * @package Civi\Api4
  */
-class EntityBatch extends Generic\DAOEntity {
+class Product extends Generic\DAOEntity {
 
 }

--- a/tests/phpunit/api/v4/DataSets/ConformanceTest.json
+++ b/tests/phpunit/api/v4/DataSets/ConformanceTest.json
@@ -81,5 +81,14 @@
       "name": "Batch_433397",
       "status_id": "1"
     }
+  ],
+  "Product": [
+    {
+      "name": "Test Product",
+      "price": "10.00",
+      "sku": "Test SKU",
+      "financial_type_id:name": "Donation",
+      "min_contribution": "10.00"
+    }
   ]
 }

--- a/tests/phpunit/api/v4/Entity/ConformanceTest.php
+++ b/tests/phpunit/api/v4/Entity/ConformanceTest.php
@@ -54,6 +54,7 @@ class ConformanceTest extends UnitTestCase implements HookInterface {
       'civicrm_event',
       'civicrm_participant',
       'civicrm_batch',
+      'civicrm_product',
     ];
     $this->dropByPrefix('civicrm_value_myfavorite');
     $this->cleanup(['tablesToTruncate' => $tablesToTruncate]);


### PR DESCRIPTION
…st failures on ContributionProduct and EntityBatch APIs

Overview
----------------------------------------
This adds in an APIv4 Entity for Product to assist in fixing the following 2 test failures

```
api\v4\Entity\ConformanceTest::testConformance with data set "ContributionProduct" ('ContributionProduct')
Undefined index: since

/home/jenkins/bknix-max/build/build-0/web/sites/all/modules/civicrm/tests/phpunit/api/v4/Entity/ConformanceTest.php:170
/home/jenkins/bknix-max/build/build-0/web/sites/all/modules/civicrm/tests/phpunit/api/v4/Entity/ConformanceTest.php:136
/home/jenkins/bknix-max/extern/phpunit8/phpunit8.phar:671

api\v4\Entity\ConformanceTest::testConformance with data set "EntityBatch" ('EntityBatch')
Undefined index: since

/home/jenkins/bknix-max/build/build-0/web/sites/all/modules/civicrm/tests/phpunit/api/v4/Entity/ConformanceTest.php:170
/home/jenkins/bknix-max/build/build-0/web/sites/all/modules/civicrm/tests/phpunit/api/v4/Entity/ConformanceTest.php:136
/home/jenkins/bknix-max/extern/phpunit8/phpunit8.phar:671
```

Before
----------------------------------------
Tests fail and no APIv4 Product Entity

After
----------------------------------------
Tests pass and there is a v4 Product Entity

ping @monishdeb @colemanw @eileenmcnaughton @demeritcowboy 