### PR TITLE
dev/core#2684 Fix filters tpl in civi reports to permit more than one  table in a grouping

### DIFF
--- a/templates/CRM/Report/Form/Tabs/Filters.tpl
+++ b/templates/CRM/Report/Form/Tabs/Filters.tpl
@@ -8,27 +8,21 @@
  +--------------------------------------------------------------------+
 *}
 
-  <div id="report-tab-set-filters" class="civireport-criteria">
-    <table class="report-layout">
+<div id="report-tab-set-filters" class="civireport-criteria">
+  <div class="report-layout">
       {assign var="counter" value=1}
-      {foreach from=$filters item=table key=tableName}
-        {assign  var="filterCount" value=$table|@count}
+      {foreach from=$filterGroups item=filterGroup}
         {* Wrap custom field sets in collapsed accordion pane. *}
-        {if !empty($filterGroups.$tableName.group_title) and $filterCount gte 1}
-          {* we should close table that contains other filter elements before we start building custom group accordion
-           *}
-          {if $counter eq 1}
-    </table>
-            {assign var="counter" value=0}
-          {/if}
+        {if $filterGroup.use_accordion_for_field_selection}
           <div class="crm-accordion-wrapper crm-accordion collapsed">
             <div class="crm-accordion-header">
-              {$filterGroups.$tableName.group_title}
+              {$filterGroup.group_title}
             </div><!-- /.crm-accordion-header -->
             <div class="crm-accordion-body">
-              <table class="report-layout">
         {/if}
-        {foreach from=$table item=field key=fieldName}
+        <table class="report-layout">
+        {foreach from=$filterGroup.tables item=table key=tableName}
+          {foreach from=$table item=field key=fieldName}
                 {assign var=fieldOp     value=$fieldName|cat:"_op"}
                 {assign var=filterVal   value=$fieldName|cat:"_value"}
                 {assign var=filterMin   value=$fieldName|cat:"_min"}
@@ -51,17 +45,13 @@
                     </td>
                   </tr>
                 {/if}
+          {/foreach}
         {/foreach}
-        {if !empty($filterGroups.$tableName.group_title)}
-              </table>
+        </table>
+        {if $filterGroup.use_accordion_for_field_selection}
             </div><!-- /.crm-accordion-body -->
           </div><!-- /.crm-accordion-wrapper -->
-          {assign var=closed value="1"} {*-- ie table tags are closed-- *}
-        {else}
-          {assign var=closed     value="0"} {*-- ie table tags are not closed-- *}
         {/if}
       {/foreach}
-    {if $closed eq 0 }
-      </table>
-    {/if}
   </div>
+</div>


### PR DESCRIPTION
Overview
----------------------------------------
This fixes the handling of 'grouping' in civireport table definition to do what it was seemingly intended to do - but didn't


Before
----------------------------------------
If you attempt to assign more than one table to the same 'Grouping' in the report you wind up with duplicate accordians rather than one accordian with one header & both tables in it . You can also wind up with broken html in some cases

![repeat](https://lab.civicrm.org/dev/core/uploads/666557d6e2606a320e59005aa277ed58/image.png)

After
----------------------------------------
In this example the Contact, phone and email tables are all grouped as 'contact'. Note the PR doesn't make this change to any core reports - but this PR in extended reports uses it https://github.com/eileenmcnaughton/nz.co.fuzion.extendedreport/pull/490

![better](https://lab.civicrm.org/dev/core/uploads/dee00592372f10fa1f62a3faed0d4d4c/image.png) -

Technical Details
----------------------------------------
In 'classic' CiviCRM fashion we were assigning an array of 'filterGroupings' and separately an array or filters and trying to cross reference them in the tpl layer to figure out when to open and close the accordians. This switched to only using the 'filterGroupings' array and adding the values from the 'filters' array into that array at the php layer - leaving a single iteration at the tpl layer

Comments
----------------------------------------

To test this make the below changes - note I'm not including this change or any change that actually changes output in this patch (and I don't necessarily see us changing any core reports) - but by applying the patch it can be seen the filters can be directed to go in an accordion

![image](https://user-images.githubusercontent.com/336308/125255298-64eb5d00-e34f-11eb-8bc4-14b8b35a756a.png)



```
--- a/CRM/Report/Form/Contribute/Detail.php
+++ b/CRM/Report/Form/Contribute/Detail.php
@@ -77,6 +77,8 @@ class CRM_Report_Form_Contribute_Detail extends CRM_Report_Form {
         'fields_required' => ['id'],
         'filters_defaults' => ['is_deleted' => 0],
         'no_field_disambiguation' => TRUE,
+        'grouping' => 'contact-fields',
+        'group_title' => ts('Contact fields'),
       ]),
       [
:
         'filters_defaults' => ['is_deleted' => 0],
         'no_field_disambiguation' => TRUE,
+        'grouping' => 'contact-fields',
+        'group_title' => ts('Contact fields'),
       ]),
       [
         'civicrm_email' => [
:
         'filters_defaults' => ['is_deleted' => 0],
         'no_field_disambiguation' => TRUE,
+        'grouping' => 'contact-fields',
+        'group_title' => ts('Contact fields'),
       ]),
       [
         'civicrm_email' => [
@@ -253,7 +255,8 @@ class CRM_Report_Form_Contribute_Detail extends CRM_Report_Form {
:
         'filters_defaults' => ['is_deleted' => 0],
         'no_field_disambiguation' => TRUE,
+        'grouping' => 'contact-fields',
+        'group_title' => ts('Contact fields'),
       ]),
       [
         'civicrm_email' => [
@@ -253,7 +255,8 @@ class CRM_Report_Form_Contribute_Detail extends CRM_Report_Form {
               'title' => ts('Contribution'),
:
         'filters_defaults' => ['is_deleted' => 0],
         'no_field_disambiguation' => TRUE,
+        'grouping' => 'contact-fields',
+        'group_title' => ts('Contact fields'),
       ]),
       [
         'civicrm_email' => [
@@ -253,7 +255,8 @@ class CRM_Report_Form_Contribute_Detail extends CRM_Report_Form {
               'title' => ts('Contribution'),
             ],
:
         'filters_defaults' => ['is_deleted' => 0],
         'no_field_disambiguation' => TRUE,
+        'grouping' => 'contact-fields',
+        'group_title' => ts('Contact fields'),
       ]),
       [
         'civicrm_email' => [
@@ -253,7 +255,8 @@ class CRM_Report_Form_Contribute_Detail extends CRM_Report_Form {
               'title' => ts('Contribution'),
             ],
           ],
:
         'filters_defaults' => ['is_deleted' => 0],
         'no_field_disambiguation' => TRUE,
+        'grouping' => 'contact-fields',
+        'group_title' => ts('Contact fields'),
       ]),
       [
         'civicrm_email' => [
@@ -253,7 +255,8 @@ class CRM_Report_Form_Contribute_Detail extends CRM_Report_Form {
               'title' => ts('Contribution'),
             ],
           ],
-          'grouping' => 'contri-fields',
:
         'filters_defaults' => ['is_deleted' => 0],
         'no_field_disambiguation' => TRUE,
+        'grouping' => 'contact-fields',
+        'group_title' => ts('Contact fields'),
       ]),
       [
         'civicrm_email' => [
@@ -253,7 +255,8 @@ class CRM_Report_Form_Contribute_Detail extends CRM_Report_Form {
               'title' => ts('Contribution'),
             ],
           ],
-          'grouping' => 'contri-fields',
+          'grouping' => 'contribution-fields',
+          'group_title' => ts('Contribution fields')
         ],
         'civicrm_contribution_soft' => [
           'dao' => 'CRM_Contribute_DAO_ContributionSoft',
@@ -276,9 +279,11 @@ class CRM_Report_Form_Contribute_Detail extends CRM_Report_Form {
               'title' => ts('Soft Credit'),
             ],
           ],
+          'grouping' => 'contribution-fields',
         ],
         'civicrm_financial_trxn' => [
           'dao' => 'CRM_Financial_DAO_FinancialTrxn',
+          'grouping' => 'contribution-fields',
           'fields' => [
             'card_type_id' => [
               'title' => ts('Credit Card Type'),
@@ -296,7 +301,7 @@ class CRM_Report_Form_Contribute_Detail extends CRM_Report_Form {
         ],
         'civicrm_batch' => [
           'dao' => 'CRM_Batch_DAO_EntityBatch',
-          'grouping' => 'contri-fields',
+          'grouping' => 'contribution-fields',
           'fields' => [
             'batch_id' => [
               'name' => 'batch_id',
@@ -316,6 +321,7 @@ class CRM_Report_Form_Contribute_Detail extends CRM_Report_Form {
         'civicrm_contribution_ordinality' => [
           'dao' => 'CRM_Contribute_DAO_Contribution',
           'alias' => 'cordinality',
+          'grouping' => 'contribution-fields',
           'filters' => [
             'ordinality' => [
               'title' => ts('Contribution Ordinality'),
@@ -330,6 +336,7 @@ class CRM_Report_Form_Contribute_Detail extends CRM_Report_Form {
         ],
         'civicrm_note' => [
           'dao' => 'CRM_Core_DAO_Note',
+          'grouping' => 'contribution-fields',
           'fields' => [
             'contribution_note' => [
               'name' => 'note',
@@ -347,6 +354,7 @@ class CRM_Report_Form_Contribute_Detail extends CRM_Report_Form {
         ],
         'civicrm_pledge_payment' => [
           'dao' => 'CRM_Pledge_DAO_PledgePayment',
+          'grouping' => 'contribution-fields',
           'fields' => [
             'pledge_id' => [
               'title' => ts('Pledge ID'),
@@ -360,7 +368,7 @@ class CRM_Report_Form_Contribute_Detail extends CRM_Report_Form {
           ],
         ],
       ],
-      $this->getColumns('Address')
+      $this->getColumns('Address', ['grouping' => 'contact-fields'])
     );
     // The tests test for this variation of the sort_name field. Don't argue with the tests :-).
     $this->_columns['civicrm_contact']['fields']['sort_name']['title'] = ts('Donor Name');

```