### PR TITLE
Mark afform extensions as beta

### DIFF
--- a/ext/afform/admin/info.xml
+++ b/ext/afform/admin/info.xml
@@ -16,7 +16,7 @@
   </urls>
   <releaseDate>2020-01-09</releaseDate>
   <version>5.41.alpha1</version>
-  <develStage>alpha</develStage>
+  <develStage>beta</develStage>
   <compatibility>
     <ver>5.23</ver>
   </compatibility>

--- a/ext/afform/core/info.xml
+++ b/ext/afform/core/info.xml
@@ -16,7 +16,7 @@
   </urls>
   <releaseDate>2020-01-09</releaseDate>
   <version>5.41.alpha1</version>
-  <develStage>alpha</develStage>
+  <develStage>beta</develStage>
   <compatibility>
     <ver>5.23</ver>
   </compatibility>


### PR DESCRIPTION
Overview
----------------------------------------
This will show the Afform Core and Admin extensions as beta instead of alpha.
