### PR TITLE
[REF] Update Product Create to use hooks and also switch the manage p…

### DIFF
--- a/CRM/Contribute/BAO/Product.php
+++ b/CRM/Contribute/BAO/Product.php
@@ -79,6 +79,7 @@ class CRM_Contribute_BAO_Product extends CRM_Contribute_DAO_Product {
    */
   public static function create($params) {
     $id = $params['id'] ?? NULL;
+    $op = !empty($id) ? 'edit' : 'create';
     if (empty($id)) {
       $defaultParams = [
         'id' => $id,
@@ -90,7 +91,7 @@ class CRM_Contribute_BAO_Product extends CRM_Contribute_DAO_Product {
       ];
       $params = array_merge($defaultParams, $params);
     }
-
+    CRM_Utils_Hook::pre($op, 'Product', $id, $params);
     // Modify the submitted values for 'image' and 'thumbnail' so that we use
     // local URLs for these images when possible.
     if (isset($params['image'])) {
@@ -104,6 +105,7 @@ class CRM_Contribute_BAO_Product extends CRM_Contribute_DAO_Product {
     $premium = new CRM_Contribute_DAO_Product();
     $premium->copyValues($params);
     $premium->save();
+    CRM_Utils_Hook::post($op, 'Product', $id, $premium);
     return $premium;
   }
 

--- a/CRM/Contribute/Form/ManagePremiums.php
+++ b/CRM/Contribute/Form/ManagePremiums.php
@@ -15,6 +15,8 @@
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
 
+use Civi\Api4\Product;
+
 /**
  * This class generates form components for Premiums.
  */
@@ -35,8 +37,7 @@ class CRM_Contribute_Form_ManagePremiums extends CRM_Contribute_Form {
   public function setDefaultValues() {
     $defaults = parent::setDefaultValues();
     if ($this->_id) {
-      $params = ['id' => $this->_id];
-      CRM_Contribute_BAO_Product::retrieve($params, $tempDefaults);
+      $tempDefaults = Product::get()->addWhere('id', '=', $this->_id)->execute()->first();
       if (isset($tempDefaults['image']) && isset($tempDefaults['thumbnail'])) {
         $defaults['imageUrl'] = $tempDefaults['image'];
         $defaults['thumbnailUrl'] = $tempDefaults['thumbnail'];
@@ -291,10 +292,10 @@ class CRM_Contribute_Form_ManagePremiums extends CRM_Contribute_Form {
     $this->_processImages($params);
 
     // Save the premium product to database
-    $premium = CRM_Contribute_BAO_Product::create($params);
+    $premium = Product::save()->addRecord($params)->execute()->first();
 
     CRM_Core_Session::setStatus(
-      ts("The Premium '%1' has been saved.", [1 => $premium->name]),
+      ts("The Premium '%1' has been saved.", [1 => $premium['name']]),
       ts('Saved'), 'success');
   }
 

--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -1135,6 +1135,7 @@ class CRM_Core_Permission {
       ],
     ];
     $permissions['line_item'] = $permissions['contribution'];
+    $permissions['product'] = $permissions['contribution'];
 
     $permissions['financial_item'] = $permissions['contribution'];
 


### PR DESCRIPTION
…roduct/premium page to use APIv4 Product Entity

Overview
----------------------------------------
This updates the Product create BAO to trigger pre/post hooks and also to update the Manage Product forms to use the newly added v4 API entity

Before
----------------------------------------
No hooks triggered and DAO used

After
----------------------------------------
Hooks triggered and APIv4 Entity used

ping @colemanw @demeritcowboy @eileenmcnaughton @totten 