### PR TITLE
Remove a couple of instances of 'contribution_mode' from tests

### DIFF
--- a/tests/phpunit/CRM/Contribute/BAO/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/BAO/ContributionTest.php
@@ -739,7 +739,6 @@ WHERE eft.entity_id = %1 AND ft.to_financial_account_id <> %2";
       'contact_id' => $this->_contactId,
       'financial_type_id' => 4,
       'contribution_status_id' => 'Pending',
-      'contribution_mode' => 'participant',
       'participant_id' => $participant->id,
       'sequential' => TRUE,
       'api.Payment.create' => ['total_amount' => 150],

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -3555,7 +3555,6 @@ VALUES
       'contact_id' => $this->individualCreate(),
       'financial_type_id' => 4,
       'contribution_status_id' => 'Pending',
-      'contribution_mode' => 'participant',
     ];
     foreach ($priceFields['values'] as $key => $priceField) {
       $orderParams['line_items'][] = [


### PR DESCRIPTION

Overview
----------------------------------------
Remove a couple of instances of 'contribution_mode' from tests

This should not be required - we should pass in correct line items....


Before
----------------------------------------
contribution_mode set on tests to participant

After
----------------------------------------
rely on line items being set

Technical Details
----------------------------------------
We just added some extra teardown checks - so if this passes tests we can be fairly confident it was doing nothing

Comments
----------------------------------------
