### PR TITLE
CustomGroup - change admin permission to 'administer CiviCRM data'

### DIFF
--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -211,8 +211,6 @@ class CRM_Core_Permission {
    * @return bool
    */
   public static function customGroupAdmin() {
-    $admin = FALSE;
-
     // check if user has all powerful permission
     // or administer civicrm permission (CRM-1905)
     if (self::check('access all custom data')) {
@@ -226,7 +224,7 @@ class CRM_Core_Permission {
       return TRUE;
     }
 
-    if (self::check('administer CiviCRM')) {
+    if (self::check('administer CiviCRM data')) {
       return TRUE;
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
Fine-tunes the permissions needed to access all custom data. 

Before
----------------------------------------
Users with `"administer CiviCRM"` could access all custom data.

After
----------------------------------------
Users with `"administer CiviCRM"` can still access all custom data, but now users with `'administer CiviCRM data'` can do so as well.

Technical Details
----------------------------------------
This permission is a subset of 'administer CiviCRM' and is more precise, allowing finer-grained admin permissions.