### PR TITLE
fixes core#2687: regression on group rebuild scheduled job

### DIFF
--- a/CRM/Contact/BAO/GroupContactCache.php
+++ b/CRM/Contact/BAO/GroupContactCache.php
@@ -129,6 +129,8 @@ AND (
       $groupIDs = (array) $groupIDs;
     }
 
+    // Treat the default help text in Scheduled Jobs as equivalent to no limit.
+    $limit = (int) $limit;
     $processGroupIDs = self::getGroupsNeedingRefreshing($groupIDs, $limit);
 
     if (!empty($processGroupIDs)) {


### PR DESCRIPTION
Overview
----------------------------------------
Cron fails if you have "Rebuild Smart Group Cache" enabled in the default configuration.  Detailed replication steps on the ticket: https://lab.civicrm.org/dev/core/-/issues/2687

Before
----------------------------------------
Cron fails (specifically, `job.rebuild_group` fails).

After
----------------------------------------
Cron succeeds.

Comments
----------------------------------------
This is a side effect of a refactoring in https://github.com/civicrm/civicrm-core/pull/20373.
