### PR TITLE
Resolve dev/rc#13 by permitting civi.setupui events to be dispatched …

### DIFF
--- a/setup/src/Setup.php
+++ b/setup/src/Setup.php
@@ -71,7 +71,11 @@ class Setup {
     self::$instance->model = new \Civi\Setup\Model();
     self::$instance->model->setValues($modelValues);
     self::$instance->dispatcher = new CiviEventDispatcher();
-    self::$instance->dispatcher->setDispatchPolicy(['/^civi\.setup\./' => 'run', '/./' => 'fail']);
+    self::$instance->dispatcher->setDispatchPolicy([
+      '/^civi\.setup\./' => 'run',
+      '/^civi\.setupui\./' => 'run',
+      '/./' => 'fail',
+    ]);
     self::$instance->log = $log ? $log : new NullLogger();
 
     $pluginDir = dirname(__DIR__) . '/plugins';


### PR DESCRIPTION
…during install

Overview
----------------------------------------
This fixes  https://lab.civicrm.org/dev/rc/-/issues/13 by permitting civi.setupui.x events to fire during the Civi Setup routine

Before
----------------------------------------
any civi.setupui.x hooks failed to fire properly causing fatal error on wordpress install

After
----------------------------------------
No fatal error because civi.setupui.x hooks fire

ping @totten @demeritcowboy @kcristiano @mlutfy 