### PR TITLE
Smarty notices - Missing type on logging civireport

### DIFF
--- a/CRM/Logging/ReportDetail.php
+++ b/CRM/Logging/ReportDetail.php
@@ -103,9 +103,9 @@ class CRM_Logging_ReportDetail extends CRM_Report_Form {
     }
 
     $this->_columnHeaders = [
-      'field' => ['title' => ts('Field')],
-      'from' => ['title' => ts('Changed From')],
-      'to' => ['title' => ts('Changed To')],
+      'field' => ['title' => ts('Field'), 'type' => CRM_Utils_Type::T_STRING],
+      'from' => ['title' => ts('Changed From'), 'type' => CRM_Utils_Type::T_STRING],
+      'to' => ['title' => ts('Changed To'), 'type' => CRM_Utils_Type::T_STRING],
     ];
   }
 

--- a/templates/CRM/Logging/ReportDetail.tpl
+++ b/templates/CRM/Logging/ReportDetail.tpl
@@ -9,6 +9,7 @@
 *}
 <div class="crm-block crm-content-block crm-report-form-block">
   {if $rows}
+    {* todo: Is `raw` ever assigned to the template and why would it make a difference as to whether this div is present? The revert confirmation is handled (awkwardly) lower down by javascript $revertConfirm *}
     {if $raw}
       <div class="status">
         <dl>


### PR DESCRIPTION
Overview
----------------------------------------
1. Turn on logging at admin - system settings misc
2. Edit a contact and change something.
3. Visit the change log tab on that contact.
4. Click where it says "Update" to see the detail report.


Before
----------------------------------------
Notice: Undefined index: type in include() (line 23 of .../sites/default/files/civicrm/templates_c/en_US/%%F5/F54/F5478576%%Table.tpl.php).

After
----------------------------------------
Still a couple other notices but they are more interesting so leaving for the moment.

Technical Details
----------------------------------------


Comments
----------------------------------------

