### PR TITLE
dev/core#2691 - On logging detail civireport show words instead of numbers

### DIFF
--- a/CRM/Logging/Differ.php
+++ b/CRM/Logging/Differ.php
@@ -290,6 +290,7 @@ WHERE lt.log_conn_id = %1
           'activity_type_id' => CRM_Core_PseudoConstant::activityType(TRUE, TRUE, FALSE, 'label', TRUE),
           'case_type_id' => CRM_Case_PseudoConstant::caseType('title', FALSE),
           'priority_id' => CRM_Core_PseudoConstant::get('CRM_Activity_DAO_Activity', 'priority_id'),
+          'record_type_id' => CRM_Activity_BAO_ActivityContact::buildOptions('record_type_id', 'get'),
         ];
 
         // for columns that appear in more than 1 table


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/2691

1. Turn on logging at admin - system settings - misc
2. Do something like edit an activity.
3. Go to the Contact Logging Summary report.
4. Drill down on the detail for that change.

Before
----------------------------------------
Something like this

![Untitled](https://user-images.githubusercontent.com/2967821/125650142-6a5371cf-5eb5-478a-affe-7cd7e3dffa24.gif)


After
----------------------------------------
Something like this

![Untitled2](https://user-images.githubusercontent.com/2967821/125650190-46ff3717-fc81-4710-ae39-b790a64f2226.gif)


Technical Details
----------------------------------------
I'm also looking at changing the contact id to a name but it looks a bit harder so leaving out for now. Is there an api4 thing available that can take a table/field and convert it to the DAO labelField's value? Or at least get close.

Comments
----------------------------------------

