### PR TITLE
Issue #899: don't show PCPs where the events or contribution pages are disabled or past the end date

### DIFF
--- a/CRM/PCP/BAO/PCP.php
+++ b/CRM/PCP/BAO/PCP.php
@@ -89,8 +89,12 @@ WHERE  civicrm_pcp.contact_id = civicrm_contact.id
    */
   public static function getPcpDashboardInfo($contactId) {
     $query = '
-SELECT pcp.*, block.is_tellfriend_enabled FROM civicrm_pcp pcp
+SELECT pcp.*, block.is_tellfriend_enabled,
+COALESCE(cp.end_date, event.end_date) as end_date
+FROM civicrm_pcp pcp
 LEFT JOIN civicrm_pcp_block block ON block.id = pcp.pcp_block_id
+LEFT OUTER JOIN civicrm_contribution_page cp ON (cp.id = pcp.page_id AND pcp.page_type = "contribute")
+LEFT OUTER JOIN civicrm_event event ON (event.id = pcp.page_id AND pcp.page_type = "event")
 WHERE pcp.is_active = 1
   AND pcp.contact_id = %1
 ORDER BY page_type, page_id';
@@ -140,6 +144,7 @@ ORDER BY page_type, page_id';
         'pcpId' => $pcpInfoDao->id,
         'pcpTitle' => $pcpInfoDao->title,
         'pcpStatus' => CRM_Core_PseudoConstant::getLabel('CRM_PCP_BAO_PCP', 'status_id', $pcpInfoDao->status_id),
+        'end_date' => $pcpInfoDao->end_date,
         'action' => $action,
         'class' => $class,
       ];
@@ -158,12 +163,19 @@ AND target_entity_id NOT IN ( " . implode(',', $entityIds) . ") )";
     }
 
     $query = "
-SELECT *
+SELECT block.*,
+COALESCE(cp.end_date, event.end_date) as end_date
 FROM civicrm_pcp_block block
-LEFT JOIN civicrm_pcp pcp ON pcp.pcp_block_id = block.id
+LEFT OUTER JOIN civicrm_contribution_page cp ON (cp.id = block.target_entity_id AND block.target_entity_type = 'contribute')
+LEFT OUTER JOIN civicrm_event event ON (event.id = block.target_entity_id AND block.target_entity_type = 'event')
 WHERE block.is_active = 1
 {$clause}
-GROUP BY block.id, pcp.id
+  AND (cp.is_active = 1 OR event.is_active = 1)
+  AND (
+    (block.target_entity_type = 'contribute' AND (cp.end_date >= DATE_FORMAT(NOW(), '%Y-%m-%d %H:%i:%s') OR cp.end_date IS NULL))
+    OR
+    (block.target_entity_type = 'event' AND (event.end_date >= DATE_FORMAT(NOW(), '%Y-%m-%d %H:%i:%s') OR event.end_date IS NULL)))
+GROUP BY block.id, block.target_entity_id
 ORDER BY target_entity_type, target_entity_id
 ";
     $pcpBlockDao = CRM_Core_DAO::executeQuery($query);
@@ -184,7 +196,9 @@ ORDER BY target_entity_type, target_entity_id
       if ($pageTitle) {
         $pcpBlock[] = [
           'pageId' => $pcpBlockDao->target_entity_id,
+          'pageComponent' => $pcpBlockDao->target_entity_type,
           'pageTitle' => $pageTitle,
+          'end_date' => $pcpBlockDao->end_date,
           'action' => $action,
         ];
       }

--- a/templates/CRM/Contribute/Page/PcpUserDashboard.tpl
+++ b/templates/CRM/Contribute/Page/PcpUserDashboard.tpl
@@ -49,10 +49,10 @@
 {strip}
 {if $pcpInfo} {* Change layout and text if they already have a PCP. *}
     <br />
-    <div class="float-right" style="width: 65%">
+    <div>
     <div>{ts}Create a Personal Campaign Page for another campaign:{/ts}</div>
 {else}
-    <div style="width: 65%">
+    <div>
     <div class="label">{ts}Become a supporter by creating a Personal Campaign Page:{/ts}</div>
 {/if}
 <table class="selector">
@@ -64,7 +64,7 @@
 
   {foreach from=$pcpBlock item=row}
   <tr class="{cycle values="odd-row,even-row"}">
-    <td>{if $row.component eq 'contribute'}<a href="{crmURL p='civicrm/contribute/transact' q="id=`$row.pageId`&reset=1"}" title="{ts}View campaign page{/ts}">{else}<a href="{crmURL p='civicrm/event/register' q="id=`$row.pageId`&reset=1"}" title="{ts}View campaign page{/ts}">{/if}{$row.pageTitle}</a></td>
+    <td>{if $row.pageComponent eq 'contribute'}<a href="{crmURL p='civicrm/contribute/transact' q="id=`$row.pageId`&reset=1"}" title="{ts}View campaign page{/ts}">{else}<a href="{crmURL p='civicrm/event/register' q="id=`$row.pageId`&reset=1"}" title="{ts}View campaign page{/ts}">{/if}{$row.pageTitle}</a></td>
         <td>{if $row.end_date}{$row.end_date|truncate:10:''|crmDate}{else}({ts}ongoing{/ts}){/if}</td>
     <td>{$row.action|replace:'xx':$row.pageId}</td>
   </tr>

--- a/tests/phpunit/CRM/PCP/BAO/PCPTest.php
+++ b/tests/phpunit/CRM/PCP/BAO/PCPTest.php
@@ -95,6 +95,13 @@ class CRM_PCP_BAO_PCPTest extends CiviUnitTestCase {
   public function testGetPcpDashboardInfo() {
     $block = CRM_PCP_BAO_PCPBlock::create($this->pcpBlockParams());
     $contactID = $this->individualCreate();
+    $submitParams = [
+      'id' => 1,
+      'financial_type_id' => 1,
+      'start_date' => date('Y-m-d 00:00:00'),
+      'end_date' => date('Y-m-d 00:00:00', strtotime('+8 weeks')),
+    ];
+    $contributionUpdate = $this->callAPISuccess('ContributionPage', 'create', $submitParams);
     $contributionPage = $this->callAPISuccessGetSingle('ContributionPage', []);
     $this->callAPISuccess('Pcp', 'create', ['contact_id' => $contactID, 'title' => 'pcp', 'page_id' => $contributionPage['id'], 'pcp_block_id' => $block->id, 'is_active' => TRUE, 'status_id' => 'Approved']);
     $this->assertEquals([
@@ -103,10 +110,11 @@ class CRM_PCP_BAO_PCPTest extends CiviUnitTestCase {
         [
           'pageTitle' => $contributionPage['title'],
           'action' => '<span><a href="/index.php?q=civicrm/pcp/info&amp;action=update&amp;reset=1&amp;id=' . $contributionPage['id'] . '&amp;component=contribute" class="action-item crm-hover-button" title=\'Configure\' >Edit Your Page</a><a href="/index.php?q=civicrm/friend&amp;eid=1&amp;blockId=1&amp;reset=1&amp;pcomponent=pcp&amp;component=contribute" class="action-item crm-hover-button" title=\'Tell Friends\' >Tell Friends</a></span><span class=\'btn-slide crm-hover-button\'>more<ul class=\'panel\'><li><a href="/index.php?q=civicrm/pcp/info&amp;reset=1&amp;id=1&amp;component=contribute" class="action-item crm-hover-button" title=\'URL for this Page\' >URL for this Page</a></li><li><a href="/index.php?q=civicrm/pcp/info&amp;action=browse&amp;reset=1&amp;id=1&amp;component=contribute" class="action-item crm-hover-button" title=\'Update Contact Information\' >Update Contact Information</a></li><li><a href="/index.php?q=civicrm/pcp&amp;action=disable&amp;reset=1&amp;id=1&amp;component=contribute" class="action-item crm-hover-button" title=\'Disable\' >Disable</a></li><li><a href="/index.php?q=civicrm/pcp&amp;action=delete&amp;reset=1&amp;id=1&amp;component=contribute" class="action-item crm-hover-button small-popup" title=\'Delete\' onclick = "return confirm(\'Are you sure you want to delete this Personal Campaign Page?\nThis action cannot be undone.\');">Delete</a></li></ul></span>',
-          'pcpId' => 1,
+          'pcpId' => '1',
           'pcpTitle' => 'pcp',
           'pcpStatus' => 'Approved',
           'class' => '',
+          'end_date' => date('Y-m-d 00:00:00', strtotime('+8 weeks')),
         ],
       ],
     ], CRM_PCP_BAO_PCP::getPcpDashboardInfo($contactID));


### PR DESCRIPTION
Fixes https://lab.civicrm.org/dev/core/-/issues/899

Overview
----------------------------------------
This will only show PCP links on the user dashboard if the event or contribution page is active, or if either is before the end date, if set.

Before
----------------------------------------
See https://lab.civicrm.org/dev/core/-/issues/899. If an event or contribution page is disabled the PCP links still show. They also show for events and contribution pages that are past their end date, if set.

The link was also broken if it was a contribution page.

After
----------------------------------------
This will only show PCP links on the user dashboard if the event or contribution page is active, or if either is before the end date, if set. 

It also fixes the link to the event or contribution.

Technical Details
----------------------------------------
Adds joins to contribution pages or events so it can add more conditions.