### PR TITLE
CKEditor - Fix .tpl insertion on every form

### DIFF
--- a/ext/ckeditor4/ckeditor4.php
+++ b/ext/ckeditor4/ckeditor4.php
@@ -156,10 +156,10 @@ function ckeditor4_civicrm_buildForm($formName, $form) {
         'value' => 1,
       ]
     );
+    CRM_Core_Region::instance('form-bottom')->add([
+      'template' => 'CRM/Admin/Form/Preferences/Ckeditor.tpl',
+    ]);
   }
-  CRM_Core_Region::instance('form-bottom')->add([
-    'template' => 'CRM/Admin/Form/Preferences/Ckeditor.tpl',
-  ]);
 }
 
 function ckeditor4_civicrm_coreResourceList(&$list, $region) {


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a regression caused by the CKEditor extension where a tpl would place javascript on every form; it was only intended for the Display Preferences admin form.

Before
----------------------------------------
Undefined index errors and possible javascript errors on every form.

After
----------------------------------------
Fixed.