### PR TITLE
Remove deprecated code

### DIFF
--- a/CRM/Admin/Form/ScheduleReminders.php
+++ b/CRM/Admin/Form/ScheduleReminders.php
@@ -59,7 +59,7 @@ class CRM_Admin_Form_ScheduleReminders extends CRM_Admin_Form {
 
     if ($isEvent) {
       $this->setComponentID(CRM_Utils_Request::retrieve('compId', 'Integer', $this));
-      if (!CRM_Event_BAO_Event::checkPermission($this->getComponentID(), CRM_Core_Permission::EDIT)) {
+      if (!CRM_Event_BAO_Event::checkPermission((int) $this->getComponentID(), CRM_Core_Permission::EDIT)) {
         throw new CRM_Core_Exception(ts('You do not have permission to access this page.'));
       }
     }

--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -2045,12 +2045,7 @@ WHERE  ce.loc_block_id = $locBlockId";
    *   Whether the user has permission for this event (or if eventId=NULL an array of permissions)
    * @throws \CiviCRM_API3_Exception
    */
-  public static function checkPermission($eventId = NULL, $permissionType = CRM_Core_Permission::VIEW) {
-    if (empty($eventId)) {
-      CRM_Core_Error::deprecatedFunctionWarning('CRM_Event_BAO_Event::getAllPermissions');
-      return self::getAllPermissions();
-    }
-
+  public static function checkPermission(int $eventId, $permissionType = CRM_Core_Permission::VIEW) {
     switch ($permissionType) {
       case CRM_Core_Permission::EDIT:
         // We also set the cached "view" permission to TRUE if "edit" is TRUE

--- a/CRM/Event/Form/ManageEvent/Delete.php
+++ b/CRM/Event/Form/ManageEvent/Delete.php
@@ -43,7 +43,7 @@ class CRM_Event_Form_ManageEvent_Delete extends CRM_Event_Form_ManageEvent {
       $this->_title = CRM_Core_DAO::getFieldValue('CRM_Event_DAO_Event', $this->_id, 'title');
     }
 
-    if (!CRM_Event_BAO_Event::checkPermission($this->_id, CRM_Core_Permission::DELETE)) {
+    if (!CRM_Event_BAO_Event::checkPermission((int) $this->_id, CRM_Core_Permission::DELETE)) {
       CRM_Core_Error::statusBounce(ts('You do not have permission to access this page.'));
     }
   }


### PR DESCRIPTION

Overview
----------------------------------------
We deprecated NOT passing an id into the function in 2018 - this removes

Note I double checked - if you pass in '2' to a strict casting of int
it accepts it and casts to int

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/125702667-bcf313af-a409-4e17-a505-150638445626.png)


After
----------------------------------------
poof

Technical Details
----------------------------------------

Comments
----------------------------------------
