### PR TITLE
Remove never-true-if

### DIFF
--- a/CRM/Core/Payment/AuthorizeNetIPN.php
+++ b/CRM/Core/Payment/AuthorizeNetIPN.php
@@ -158,13 +158,6 @@ class CRM_Core_Payment_AuthorizeNetIPN extends CRM_Core_Payment_BaseIPN {
       return FALSE;
     }
 
-    // check if contribution is already completed, if so we ignore this ipn
-    if ($contribution->contribution_status_id == 1) {
-      CRM_Core_Error::debug_log_message("Returning since contribution has already been handled.");
-      echo 'Success: Contribution has already been handled<p>';
-      return FALSE;
-    }
-
     CRM_Contribute_BAO_Contribution::completeOrder($input, $recur->id, $contribution->id ?? NULL);
     return $isFirstOrLastRecurringPayment;
   }


### PR DESCRIPTION
This code is in the recur() function. the lines immediately before this function is called (it is only called from one place) ensure contribution->contribution_status_id
is unset if it is 1 - meaning this if can never be true
