### PR TITLE
Add ts() function within CRM_Core_Error::statusBounce() method

### DIFF
--- a/CRM/Batch/Form/Entry.php
+++ b/CRM/Batch/Form/Entry.php
@@ -314,7 +314,7 @@ class CRM_Batch_Form_Entry extends CRM_Core_Form {
     $offset = 50;
     if ((count($this->_elementIndex) + $offset) > ini_get("max_input_vars")) {
       // Avoiding 'ts' for obscure messages.
-      CRM_Core_Error::statusBounce('Batch size is too large. Increase value of php.ini setting "max_input_vars" (current val = ' . ini_get("max_input_vars") . ')');
+      CRM_Core_Error::statusBounce(ts('Batch size is too large. Increase value of php.ini setting "max_input_vars" (current val = %1)', [1 => ini_get("max_input_vars")]));
     }
 
     $this->assign('fields', $this->_fields);

--- a/CRM/Campaign/Form/Petition/Signature.php
+++ b/CRM/Campaign/Form/Petition/Signature.php
@@ -182,7 +182,7 @@ class CRM_Campaign_Form_Petition_Signature extends CRM_Core_Form {
 
     //some sanity checks
     if (!$this->_surveyId) {
-      CRM_Core_Error::statusBounce('Petition id is not valid. (it needs a "sid" in the url).');
+      CRM_Core_Error::statusBounce(ts('Petition id is not valid. (it needs a "sid" in the url).'));
       return;
     }
     //check petition is valid and active
@@ -190,10 +190,10 @@ class CRM_Campaign_Form_Petition_Signature extends CRM_Core_Form {
     $this->petition = [];
     CRM_Campaign_BAO_Survey::retrieve($params, $this->petition);
     if (empty($this->petition)) {
-      CRM_Core_Error::statusBounce('Petition doesn\'t exist.');
+      CRM_Core_Error::statusBounce(ts('Petition doesn\'t exist.'));
     }
     if ($this->petition['is_active'] == 0) {
-      CRM_Core_Error::statusBounce('Petition is no longer active.');
+      CRM_Core_Error::statusBounce(ts('Petition is no longer active.'));
     }
 
     //get userID from session
@@ -219,7 +219,7 @@ class CRM_Campaign_Form_Petition_Signature extends CRM_Core_Form {
       $this->_contactProfileFields = CRM_Core_BAO_UFGroup::getFields($this->_contactProfileId, FALSE, CRM_Core_Action::ADD);
     }
     if (!isset($this->_contactProfileFields['email-Primary'])) {
-      CRM_Core_Error::statusBounce('The contact profile needs to contain the primary email address field');
+      CRM_Core_Error::statusBounce(ts('The contact profile needs to contain the primary email address field'));
     }
 
     $ufJoinParams['weight'] = 1;

--- a/CRM/Case/Form/Activity/ChangeCaseStartDate.php
+++ b/CRM/Case/Form/Activity/ChangeCaseStartDate.php
@@ -128,7 +128,7 @@ class CRM_Case_Form_Activity_ChangeCaseStartDate {
       !$caseId ||
       !$caseType
     ) {
-      CRM_Core_Error::statusBounce('Required parameter missing for ChangeCaseType - end post processing');
+      CRM_Core_Error::statusBounce(ts('Required parameter missing for ChangeCaseType - end post processing'));
     }
 
     $config = CRM_Core_Config::singleton();
@@ -199,7 +199,7 @@ class CRM_Case_Form_Activity_ChangeCaseStartDate {
 
       $newActivity = CRM_Activity_BAO_Activity::create($openCaseParams);
       if (is_a($newActivity, 'CRM_Core_Error')) {
-        CRM_Core_Error::statusBounce('Unable to update Open Case activity');
+        CRM_Core_Error::statusBounce(ts('Unable to update Open Case activity'));
       }
       else {
         // Create linkage to case

--- a/CRM/Case/Form/Activity/ChangeCaseType.php
+++ b/CRM/Case/Form/Activity/ChangeCaseType.php
@@ -134,7 +134,7 @@ class CRM_Case_Form_Activity_ChangeCaseType {
       !$params['case_type_id'] ||
       !$caseType
     ) {
-      CRM_Core_Error::statusBounce('Required parameter missing for ChangeCaseType - end post processing');
+      CRM_Core_Error::statusBounce(ts('Required parameter missing for ChangeCaseType - end post processing'));
     }
 
     $params['status_id'] = CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_status_id', 'Completed');

--- a/CRM/Case/Form/Activity/OpenCase.php
+++ b/CRM/Case/Form/Activity/OpenCase.php
@@ -260,18 +260,18 @@ class CRM_Case_Form_Activity_OpenCase {
     $isMultiClient = $xmlProcessorProcess->getAllowMultipleCaseClients();
 
     if (!$isMultiClient && !$form->_currentlyViewedContactId) {
-      CRM_Core_Error::statusBounce('Required parameter missing for OpenCase - end post processing');
+      CRM_Core_Error::statusBounce(ts('Required parameter missing for OpenCase - end post processing'));
     }
 
     if (!$form->_currentUserId || !$params['case_id'] || !$params['case_type']) {
-      CRM_Core_Error::statusBounce('Required parameter missing for OpenCase - end post processing');
+      CRM_Core_Error::statusBounce(ts('Required parameter missing for OpenCase - end post processing'));
     }
 
     // 1. create case-contact
     if ($isMultiClient && $form->_context == 'standalone') {
       foreach ($params['client_id'] as $cliId) {
         if (empty($cliId)) {
-          CRM_Core_Error::statusBounce('client_id cannot be empty for OpenCase - end post processing');
+          CRM_Core_Error::statusBounce(ts('client_id cannot be empty for OpenCase - end post processing'));
         }
         $contactParams = [
           'case_id' => $params['case_id'],

--- a/CRM/Case/Page/Tab.php
+++ b/CRM/Case/Page/Tab.php
@@ -63,7 +63,7 @@ class CRM_Case_Page_Tab extends CRM_Core_Page {
     }
     else {
       if ($this->_action & CRM_Core_Action::VIEW) {
-        CRM_Core_Error::statusBounce('Contact Id is required for view action.');
+        CRM_Core_Error::statusBounce(ts('Contact Id is required for view action.'));
       }
     }
 

--- a/CRM/Contact/Form/Search/Custom.php
+++ b/CRM/Contact/Form/Search/Custom.php
@@ -37,7 +37,7 @@ class CRM_Contact_Form_Search_Custom extends CRM_Contact_Form_Search {
       ) = CRM_Contact_BAO_SearchCustom::details($csID, $ssID, $gID);
 
     if (!$this->_customSearchID) {
-      CRM_Core_Error::statusbounce('Could not get details for custom search.');
+      CRM_Core_Error::statusbounce(ts('Could not get details for custom search.'));
     }
 
     // stash this as a hidden element so we can potentially go there if the session

--- a/CRM/Contribute/Form/CancelSubscription.php
+++ b/CRM/Contribute/Form/CancelSubscription.php
@@ -89,7 +89,7 @@ class CRM_Contribute_Form_CancelSubscription extends CRM_Contribute_Form_Contrib
       (!$this->_crid && !$this->_coid && !$this->_mid) ||
       (!$this->getSubscriptionDetails())
     ) {
-      CRM_Core_Error::statusBounce('Required information missing.');
+      CRM_Core_Error::statusBounce(ts('Required information missing.'));
     }
 
     $this->assign('cancelRecurDetailText', $this->_paymentProcessorObj->getText('cancelRecurDetailText', $cancelRecurTextParams));

--- a/CRM/Contribute/Page/ContributionRecur.php
+++ b/CRM/Contribute/Page/ContributionRecur.php
@@ -38,7 +38,7 @@ class CRM_Contribute_Page_ContributionRecur extends CRM_Core_Page {
    */
   public function view() {
     if (empty($this->getEntityId())) {
-      CRM_Core_Error::statusBounce('Recurring contribution not found');
+      CRM_Core_Error::statusBounce(ts('Recurring contribution not found'));
     }
 
     try {
@@ -47,7 +47,7 @@ class CRM_Contribute_Page_ContributionRecur extends CRM_Core_Page {
       ]);
     }
     catch (Exception $e) {
-      CRM_Core_Error::statusBounce('Recurring contribution not found (ID: ' . $this->getEntityId());
+      CRM_Core_Error::statusBounce(ts('Recurring contribution not found (ID: %1', [1 => $this->getEntityId()]));
     }
 
     $contributionRecur['payment_processor'] = CRM_Financial_BAO_PaymentProcessor::getPaymentProcessorName(

--- a/CRM/Contribute/Page/ContributionRecur.php
+++ b/CRM/Contribute/Page/ContributionRecur.php
@@ -47,7 +47,7 @@ class CRM_Contribute_Page_ContributionRecur extends CRM_Core_Page {
       ]);
     }
     catch (Exception $e) {
-      CRM_Core_Error::statusBounce(ts('Recurring contribution not found (ID: %1', [1 => $this->getEntityId()]));
+      CRM_Core_Error::statusBounce(ts('Recurring contribution not found (ID: %1)', [1 => $this->getEntityId()]));
     }
 
     $contributionRecur['payment_processor'] = CRM_Financial_BAO_PaymentProcessor::getPaymentProcessorName(

--- a/CRM/Core/Form/RecurringEntity.php
+++ b/CRM/Core/Form/RecurringEntity.php
@@ -424,7 +424,7 @@ class CRM_Core_Form_RecurringEntity {
                   ]
                 );
                 if ($result['error']) {
-                  CRM_Core_Error::statusBounce('Error creating recurring list');
+                  CRM_Core_Error::statusBounce(ts('Error creating recurring list'));
                 }
               }
             }
@@ -440,7 +440,7 @@ class CRM_Core_Form_RecurringEntity {
                   ]
                 );
                 if ($result['error']) {
-                  CRM_Core_Error::statusBounce('Error creating recurring list');
+                  CRM_Core_Error::statusBounce(ts('Error creating recurring list'));
                 }
               }
             }

--- a/CRM/Core/Invoke.php
+++ b/CRM/Core/Invoke.php
@@ -103,7 +103,7 @@ class CRM_Core_Invoke {
         return CRM_Utils_System::redirect();
       }
       else {
-        CRM_Core_Error::statusBounce('You do not have permission to execute this url');
+        CRM_Core_Error::statusBounce(ts('You do not have permission to execute this url'));
       }
     }
   }

--- a/CRM/Core/Page/File.php
+++ b/CRM/Core/Page/File.php
@@ -38,7 +38,7 @@ class CRM_Core_Page_File extends CRM_Core_Page {
     if (empty($fileName)) {
       $hash = CRM_Utils_Request::retrieve('fcs', 'Alphanumeric', $this);
       if (!CRM_Core_BAO_File::validateFileHash($hash, $entityId, $fileId)) {
-        CRM_Core_Error::statusBounce('URL for file is not valid');
+        CRM_Core_Error::statusBounce(ts('URL for file is not valid'));
       }
 
       list($path, $mimeType) = CRM_Core_BAO_File::path($fileId, $entityId);
@@ -52,7 +52,7 @@ class CRM_Core_Page_File extends CRM_Core_Page {
     }
 
     if (!$path) {
-      CRM_Core_Error::statusBounce('Could not retrieve the file');
+      CRM_Core_Error::statusBounce(ts('Could not retrieve the file'));
     }
 
     if (empty($mimeType)) {
@@ -71,7 +71,7 @@ class CRM_Core_Page_File extends CRM_Core_Page {
 
     $buffer = file_get_contents($path);
     if (!$buffer) {
-      CRM_Core_Error::statusBounce('The file is either empty or you do not have permission to retrieve the file');
+      CRM_Core_Error::statusBounce(ts('The file is either empty or you do not have permission to retrieve the file'));
     }
 
     if ($action & CRM_Core_Action::DELETE) {

--- a/CRM/Core/Page/Redirect.php
+++ b/CRM/Core/Page/Redirect.php
@@ -38,7 +38,7 @@ class CRM_Core_Page_Redirect extends CRM_Core_Page {
    */
   public static function createUrl($requestPath, $requestArgs, $pageArgs, $absolute) {
     if (empty($pageArgs['url'])) {
-      CRM_Core_Error::statusBounce('This page is configured as a redirect, but it does not have a target.');
+      CRM_Core_Error::statusBounce(ts('This page is configured as a redirect, but it does not have a target.'));
     }
 
     $vars = [];

--- a/CRM/Event/Form/Task/Batch.php
+++ b/CRM/Event/Form/Task/Batch.php
@@ -80,7 +80,7 @@ class CRM_Event_Form_Task_Batch extends CRM_Event_Form_Task {
   public function buildQuickForm() {
     $ufGroupId = $this->get('ufGroupId');
     if (!$ufGroupId) {
-      CRM_Core_Error::statusBounce('ufGroupId is missing');
+      CRM_Core_Error::statusBounce(ts('ufGroupId is missing'));
     }
 
     $this->_title = ts('Update multiple participants') . ' - ' . CRM_Core_BAO_UFGroup::getTitle($ufGroupId);

--- a/CRM/Event/Page/ParticipantListing.php
+++ b/CRM/Event/Page/ParticipantListing.php
@@ -27,7 +27,7 @@ class CRM_Event_Page_ParticipantListing extends CRM_Core_Page {
   public function preProcess() {
     $this->_id = CRM_Utils_Request::retrieve('id', 'Integer', $this, TRUE);
 
-    // ensure that there is a particpant type for this
+    // ensure that there is a participant type for this
     $this->_participantListingID = CRM_Core_DAO::getFieldValue('CRM_Event_DAO_Event',
       $this->_id,
       'participant_listing_id'
@@ -75,7 +75,7 @@ class CRM_Event_Page_ParticipantListing extends CRM_Core_Page {
       ) . '.php';
     $error = include_once $classFile;
     if ($error == FALSE) {
-      CRM_Core_Error::statusBounce(ts('Participant listing code file: %1 does not exist. Please verify your custom particpant listing settings in CiviCRM administrative panel.', [1 => $classFile]));
+      CRM_Core_Error::statusBounce(ts('Participant listing code file: %1 does not exist. Please verify your custom participant listing settings in CiviCRM administrative panel.', [1 => $classFile]));
     }
 
     $participantListingClass = new $className();

--- a/CRM/Event/Page/ParticipantListing.php
+++ b/CRM/Event/Page/ParticipantListing.php
@@ -75,7 +75,7 @@ class CRM_Event_Page_ParticipantListing extends CRM_Core_Page {
       ) . '.php';
     $error = include_once $classFile;
     if ($error == FALSE) {
-      CRM_Core_Error::statusBounce('Participant listing code file: ' . $classFile . ' does not exist. Please verify your custom particpant listing settings in CiviCRM administrative panel.');
+      CRM_Core_Error::statusBounce(ts('Participant listing code file: %1 does not exist. Please verify your custom particpant listing settings in CiviCRM administrative panel.', [1 => $classFile]));
     }
 
     $participantListingClass = new $className();

--- a/CRM/Financial/Page/FinancialTypeAccount.php
+++ b/CRM/Financial/Page/FinancialTypeAccount.php
@@ -166,7 +166,7 @@ class CRM_Financial_Page_FinancialTypeAccount extends CRM_Core_Page {
       $this->assign('financialTypeTitle', $this->_title);
     }
     else {
-      CRM_Core_Error::statusBounce('No Financial Accounts found for the Financial Type');
+      CRM_Core_Error::statusBounce(ts('No Financial Accounts found for the Financial Type'));
     }
   }
 

--- a/CRM/Member/Form/Task/Batch.php
+++ b/CRM/Member/Form/Task/Batch.php
@@ -74,7 +74,7 @@ class CRM_Member_Form_Task_Batch extends CRM_Member_Form_Task {
     $ufGroupId = $this->get('ufGroupId');
 
     if (!$ufGroupId) {
-      CRM_Core_Error::statusBounce('ufGroupId is missing');
+      CRM_Core_Error::statusBounce(ts('ufGroupId is missing'));
     }
     $this->_title = ts('Update multiple memberships') . ' - ' . CRM_Core_BAO_UFGroup::getTitle($ufGroupId);
     CRM_Utils_System::setTitle($this->_title);

--- a/CRM/Profile/Page/Listings.php
+++ b/CRM/Profile/Page/Listings.php
@@ -281,7 +281,7 @@ class CRM_Profile_Page_Listings extends CRM_Core_Page {
       $ufgroupDAO = new CRM_Core_DAO_UFGroup();
       $ufgroupDAO->id = $this->_gid;
       if (!$ufgroupDAO->find(TRUE)) {
-        CRM_Core_Error::statusBounce('Unable to find matching UF Group');
+        CRM_Core_Error::statusBounce(ts('Unable to find matching UF Group'));
       }
     }
 

--- a/CRM/Queue/Page/Runner.php
+++ b/CRM/Queue/Page/Runner.php
@@ -36,7 +36,7 @@ class CRM_Queue_Page_Runner extends CRM_Core_Page {
     $qrid = CRM_Utils_Request::retrieve('qrid', 'String', $this, TRUE);
     $runner = CRM_Queue_Runner::instance($qrid);
     if (!is_object($runner)) {
-      CRM_Core_Error::statusBounce('Queue runner must be configured before execution.');
+      CRM_Core_Error::statusBounce(ts('Queue runner must be configured before execution.'));
     }
 
     CRM_Utils_System::setTitle($runner->title);

--- a/CRM/Report/Page/Instance.php
+++ b/CRM/Report/Page/Instance.php
@@ -44,7 +44,7 @@ class CRM_Report_Page_Instance extends CRM_Core_Page {
     $optionVal = CRM_Report_Utils_Report::getValueFromUrl($instanceId);
     $templateInfo = CRM_Core_OptionGroup::getRowValues('report_template', "{$optionVal}", 'value');
     if (empty($templateInfo)) {
-      CRM_Core_Error::statusBounce('You have tried to access a report that does not exist.');
+      CRM_Core_Error::statusBounce(ts('You have tried to access a report that does not exist.'));
     }
 
     $extKey = strpos($templateInfo['name'], '.');

--- a/CRM/Report/Page/Options.php
+++ b/CRM/Report/Page/Options.php
@@ -63,7 +63,7 @@ class CRM_Report_Page_Options extends CRM_Core_Page_Basic {
       self::$_gId = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_OptionGroup', self::$_gName, 'id', 'name');
     }
     else {
-      CRM_Core_Error::statusBounce('Unable to determine the Option Group');
+      CRM_Core_Error::statusBounce(ts('Unable to determine the Option Group'));
     }
 
     self::$_GName = ucwords(str_replace('_', ' ', self::$_gName));


### PR DESCRIPTION
Overview
----------------------------------------
I couldn't translate *you have tried to access a report that does not exist* text.

Before
----------------------------------------
Some texts within *CRM_Core_Error::statusBounce()* method don't have translation function.

After
----------------------------------------
All *CRM_Core_Error::statusBounce()* methods have translation function `ts()`.
