### PR TITLE
Add hook for validating checksum

### DIFF
--- a/CRM/Contact/BAO/Contact/Utils.php
+++ b/CRM/Contact/BAO/Contact/Utils.php
@@ -202,6 +202,12 @@ WHERE  id IN ( $idString )
    * @throws \CRM_Core_Exception
    */
   public static function validChecksum($contactID, $inputCheck) {
+    // Allow a hook to invalidate checksums
+    $invalid = FALSE;
+    CRM_Utils_Hook::invalidateChecksum($contactID, $inputCheck, $invalid);
+    if ($invalid) {
+      return FALSE;
+    }
 
     $input = CRM_Utils_System::explode('_', $inputCheck, 3);
 

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -2835,4 +2835,23 @@ abstract class CRM_Utils_Hook {
     );
   }
 
+  /**
+   * Allows an extension to override the checksum validation.
+   * For example you may want to invalidate checksums that were sent out/forwarded by mistake. You could also
+   * intercept and redirect to a different page in this case - eg. to say "sorry, you tried to use a compromised
+   * checksum".
+   *
+   * @param int $contactID
+   * @param string $checksum
+   * @param bool $invalid
+   *   Leave this at FALSE to allow the core code to perform validation. Set to TRUE to invalidate
+   */
+  public static function invalidateChecksum($contactID, $checksum, &$invalid) {
+    return self::singleton()->invoke(
+      ['contactID', 'checksum', 'invalid'],
+      $contactID, $checksum, $invalid, self::$_nullObject, self::$_nullObject,
+      self::$_nullObject, 'civicrm_invalidateChecksum'
+    );
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Checksums are not stored anywhere in the database (they are calculated at time of creation and time of use). This causes problems because there is no way to "invalidate" a checksum that was made available by mistake (eg. hardcoded in an email).

This PR proposes adding a hook that can be called to override/modify the checksum validation.

Before
----------------------------------------
No way to override checksum validation.

After
----------------------------------------
Can be overridden via hook - eg. 
```php
function example_civicrm_invalidateChecksum($contactID, $checksum, &$invalid) {
  // These checksums sent out hardcoded via mailing on 14th July (valid for 30 days)
  if (in_array($checksum, ['fdsfsdfdsf_sfsd_123', 'fsa34f30fsfs_sf34f_123'])) {
    $invalid = TRUE;
    \Civi::log()->warning('Invalidated checksum was used: ' . $checksum . ' for contact ID ' . $contactID);
    // Optionally trigger a redirect to another page explaining why it was invalid
    // CRM_Utils_System::redirect('https://example.org/invalidchecksumlandingpage');
  }
}
```

Technical Details
----------------------------------------


Comments
----------------------------------------
@seamuslee001 @petednz @demeritcowboy What do you think?