### PR TITLE
Only process financial records when relevant

### DIFF
--- a/tests/phpunit/CRM/Batch/BAO/BatchTest.php
+++ b/tests/phpunit/CRM/Batch/BAO/BatchTest.php
@@ -106,7 +106,7 @@ class CRM_Batch_BAO_BatchTest extends CiviUnitTestCase {
     $params['contribution_payment_instrument_id']
       = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'payment_instrument_id', 'Check');
     $result = CRM_Batch_BAO_Batch::getBatchFinancialItems($entityId, $returnvalues, $notPresent, $params, TRUE)->fetchAll();
-    $this->assertEquals(count($result), 1, 'In line' . __LINE__);
+    $this->assertCount(1, $result);
     $this->assertEquals($result[0]['payment_method'], CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'payment_instrument_id', 'Check'), 'In line' . __LINE__);
     $params['financial_type_id'] = implode(',', [
       CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'financial_type_id', 'Donation'),


### PR DESCRIPTION
This is a step towards making the financials more sensible. If we avoid calling them
for updates that do not involve financial change (e.g changing the receipt date)

Overview
----------------------------------------
_A brief description of the pull request. Keep technical jargon to a minimum. Hyperlink relevant discussions._

Before
----------------------------------------
_What is the old user-interface or technical-contract (as appropriate)?_
_For optimal clarity, include a concrete example such as a screenshot, GIF ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)), or code-snippet._

After
----------------------------------------
_What changed? What is new old user-interface or technical-contract?_
_For optimal clarity, include a concrete example such as a screenshot, GIF ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)), or code-snippet._

Technical Details
----------------------------------------
_If the PR involves technical details/changes/considerations which would not be manifest to a casual developer skimming the above sections, please describe the details here._

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
