### PR TITLE
dev/core#2719 [REF] Remove some legacy references to contribution_invoice_settings

### DIFF
--- a/CRM/Admin/Form/Preferences/Display.php
+++ b/CRM/Admin/Form/Preferences/Display.php
@@ -47,8 +47,7 @@ class CRM_Admin_Form_Preferences_Display extends CRM_Admin_Form_Preferences {
   public function buildQuickForm() {
 
     //changes for freezing the invoices/credit notes checkbox if invoicing is uncheck
-    $invoiceSettings = Civi::settings()->get('contribution_invoice_settings');
-    $this->assign('invoicing', CRM_Invoicing_Utils::isInvoicingEnabled());
+    $this->assign('invoicing', Civi::settings()->get('invoicing'));
 
     $this->addElement(
       'xbutton',

--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -1668,9 +1668,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
    * @param array $lineItem
    */
   protected function invoicingPostProcessHook($submittedValues, $action, $lineItem) {
-
-    $invoiceSettings = Civi::settings()->get('contribution_invoice_settings');
-    if (empty($invoiceSettings['invoicing'])) {
+    if (!Civi::settings()->get('invoicing')) {
       return;
     }
     $taxRate = [];

--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -1105,9 +1105,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
 
       $contribution = CRM_Contribute_BAO_Contribution::add($contributionParams);
 
-      $invoiceSettings = Civi::settings()->get('contribution_invoice_settings');
-      $invoicing = $invoiceSettings['invoicing'] ?? NULL;
-      if ($invoicing) {
+      if (Civi::settings()->get('invoicing')) {
         $dataArray = [];
         // @todo - interrogate the line items passed in on the params array.
         // No reason to assume line items will be set on the form.

--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -1477,8 +1477,6 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
         if ($this->_isPaidEvent) {
           // fix amount for each of participants ( for bulk mode )
           $eventAmount = [];
-          $invoiceSettings = Civi::settings()->get('contribution_invoice_settings');
-          $invoicing = $invoiceSettings['invoicing'] ?? NULL;
           $totalTaxAmount = 0;
 
           //add dataArray in the receipts in ADD and UPDATE condition
@@ -1489,7 +1487,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
           elseif ($this->_action & CRM_Core_Action::UPDATE) {
             $line = $this->_values['line_items'];
           }
-          if ($invoicing) {
+          if (Civi::settings()->get('invoicing')) {
             foreach ($line as $key => $value) {
               if (isset($value['tax_amount'])) {
                 $totalTaxAmount += $value['tax_amount'];

--- a/CRM/Financial/BAO/FinancialType.php
+++ b/CRM/Financial/BAO/FinancialType.php
@@ -476,17 +476,7 @@ class CRM_Financial_BAO_FinancialType extends CRM_Financial_DAO_FinancialType {
    * @return bool
    */
   public static function isACLFinancialTypeStatus() {
-    if (!isset(\Civi::$statics[__CLASS__]['is_acl_enabled'])) {
-      \Civi::$statics[__CLASS__]['is_acl_enabled'] = FALSE;
-      $realSetting = \Civi::$statics[__CLASS__]['is_acl_enabled'] = Civi::settings()->get('acl_financial_type');
-      if (!$realSetting) {
-        $contributeSettings = Civi::settings()->get('contribution_invoice_settings');
-        if (!empty($contributeSettings['acl_financial_type'])) {
-          \Civi::$statics[__CLASS__]['is_acl_enabled'] = TRUE;
-        }
-      }
-    }
-    return \Civi::$statics[__CLASS__]['is_acl_enabled'];
+    return Civi::settings()->get('acl_financial_type');
   }
 
 }

--- a/CRM/Invoicing/Utils.php
+++ b/CRM/Invoicing/Utils.php
@@ -55,11 +55,7 @@ class CRM_Invoicing_Utils {
    * We check both here. But will deprecate the latter in time.
    */
   public static function isInvoicingEnabled() {
-    if (Civi::settings()->get('invoicing')) {
-      return TRUE;
-    }
-    $invoiceSettings = Civi::settings()->get('contribution_invoice_settings');
-    return $invoiceSettings['invoicing'] ?? NULL;
+    return Civi::settings()->get('invoicing');
   }
 
   /**


### PR DESCRIPTION

Overview
----------------------------------------
[REF] Remove some legacy references to contribution_invoice_settings

Before
----------------------------------------
```
  $invoiceSettings = Civi::settings()->get('contribution_invoice_settings');
  $invoicing = $invoiceSettings['invoicing'];

```

After
----------------------------------------
```
$invoicing = Civi::settings()->get('invoicing')
```
Technical Details
----------------------------------------
These subkeys are now settings in their own right & can be accessed directly. The Settings code handles
inconsistencies so we don't need to


Comments
----------------------------------------
