### PR TITLE
Fix v4 api to do custom field delete in tearDown

### DIFF
--- a/tests/phpunit/api/v4/Action/BaseCustomValueTest.php
+++ b/tests/phpunit/api/v4/Action/BaseCustomValueTest.php
@@ -21,6 +21,7 @@ namespace api\v4\Action;
 
 use api\v4\UnitTestCase;
 use api\v4\Traits\TableDropperTrait;
+use Civi\Api4\CustomGroup;
 
 abstract class BaseCustomValueTest extends UnitTestCase {
 
@@ -34,15 +35,16 @@ abstract class BaseCustomValueTest extends UnitTestCase {
    */
   public function setUp(): void {
     $this->setUpOptionCleanup();
-    $cleanup_params = [
-      'tablesToTruncate' => [
-        'civicrm_custom_group',
-        'civicrm_custom_field',
-      ],
-    ];
+  }
 
-    $this->dropByPrefix('civicrm_value_my');
-    $this->cleanup($cleanup_params);
+  /**
+   * Delete all created options groups.
+   *
+   * @throws \API_Exception
+   */
+  public function tearDown(): void {
+    CustomGroup::delete(FALSE)->addWhere('id', '>', 0)->execute();
+    parent::tearDown();
   }
 
 }

--- a/tests/phpunit/api/v4/Action/BasicCustomFieldTest.php
+++ b/tests/phpunit/api/v4/Action/BasicCustomFieldTest.php
@@ -30,8 +30,10 @@ use Civi\Api4\RelationshipCache;
  */
 class BasicCustomFieldTest extends BaseCustomValueTest {
 
-  public function testWithSingleField() {
-
+  /**
+   * @throws \API_Exception
+   */
+  public function testWithSingleField(): void {
     $customGroup = CustomGroup::create(FALSE)
       ->addValue('name', 'MyIndividualFields')
       ->addValue('extends', 'Individual')


### PR DESCRIPTION


Overview
----------------------------------------
Fix v4 api to do custom field delete in tearDown

Before
----------------------------------------
Cleanup done before rather than after tests

After
----------------------------------------
Cleanup done in the tearDown where it should be

Technical Details
----------------------------------------
This existing efforts are wrong because
1) the delete has to go in the tearDown not the clean up in order to run after the test passes or fails
2) it is rigid about the custom group table name - which
will get us into problems as the name can be set and we
should be ensuring that it can in our tests

Comments
----------------------------------------