### PR TITLE
(REF) Civi/Schema - Extract MagicGetterSetterTrait. Add test coverage.

### DIFF
--- a/Civi/Api4/Generic/AbstractAction.php
+++ b/Civi/Api4/Generic/AbstractAction.php
@@ -14,7 +14,6 @@ namespace Civi\Api4\Generic;
 use Civi\Api4\Utils\CoreUtil;
 use Civi\Api4\Utils\FormattingUtil;
 use Civi\Api4\Utils\ReflectionUtils;
-use Civi\Schema\Traits\MagicGetterSetterTrait;
 
 /**
  * Base class for all api actions.
@@ -36,7 +35,7 @@ use Civi\Schema\Traits\MagicGetterSetterTrait;
  */
 abstract class AbstractAction implements \ArrayAccess {
 
-  use MagicGetterSetterTrait;
+  use \Civi\Schema\Traits\MagicGetterSetterTrait;
 
   /**
    * Api version number; cannot be changed.

--- a/Civi/Schema/Traits/MagicGetterSetterTrait.php
+++ b/Civi/Schema/Traits/MagicGetterSetterTrait.php
@@ -1,0 +1,96 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Schema\Traits;
+
+/**
+ * Automatically define getter/setter methods for public and protected fields.
+ *
+ * BASIC USAGE
+ *
+ * - Choose a class
+ * - Add the trait (`use MagicGetterSetterTrait;`).
+ * - Add a public or protected property  (`protected $fooBar;`).
+ * - When using the class, you may now call `setFooBar($value)` and `getFooBar()`.
+ *
+ * TIPS AND TRICKS
+ *
+ * - To provide better hints/DX in IDEs, you may add the `@method` notations
+ *   to the class docblock. There are several examples of this in APIv4
+ *   (see e.g. `AbstractAction.php` or `AbstractQueryAction.php`).
+ * - When/if you need to customize the behavior of a getter/setter, then simply
+ *   add your own method. This takes precedence over magic mehods.
+ * - If a field name begins with `_`, then it will be excluded.
+ *
+ * @package Civi\Schema\Traits
+ */
+trait MagicGetterSetterTrait {
+
+  /**
+   * Magic function to provide getters/setters.
+   *
+   * @param string $method
+   * @param array $arguments
+   * @return static|mixed
+   * @throws \CRM_Core_Exception
+   */
+  public function __call($method, $arguments) {
+    $mode = substr($method, 0, 3);
+    $prop = lcfirst(substr($method, 3));
+    $props = static::getMagicProperties();
+    if (isset($props[$prop])) {
+      switch ($mode) {
+        case 'get':
+          return $this->$prop;
+
+        case 'set':
+          $this->$prop = $arguments[0];
+          return $this;
+      }
+    }
+
+    throw new \CRM_Core_Exception(sprintf('Unknown method: %s::%s()', static::CLASS, $method));
+  }
+
+  /**
+   * Get a list of class properties for which magic methods are supported.
+   *
+   * @return array
+   *   List of supported properties, keyed by property name.
+   *   Array(string $propertyName => bool $true).
+   */
+  protected static function getMagicProperties(): array {
+    // Thread-local cache of class metadata. This is strictly readonly and immutable, and it should ideally be reused across varied test-functions.
+    static $cache = [];
+
+    if (!isset($cache[static::CLASS])) {
+      try {
+        $clazz = new \ReflectionClass(static::CLASS);
+      }
+      catch (\ReflectionException $e) {
+        // This shouldn't happen. Cast to RuntimeException so that we don't have a million `@throws` statements.
+        throw new \RuntimeException(sprintf("Class %s cannot reflect upon itself.", static::CLASS));
+      }
+
+      $fields = [];
+      foreach ($clazz->getProperties(\ReflectionProperty::IS_PROTECTED | \ReflectionProperty::IS_PUBLIC) as $property) {
+        $name = $property->getName();
+        if (!$property->isStatic() && $name[0] !== '_') {
+          $fields[$name] = TRUE;
+        }
+      }
+      unset($clazz);
+      $cache[static::CLASS] = $fields;
+    }
+    return $cache[static::CLASS];
+  }
+
+}

--- a/tests/phpunit/Civi/Schema/MagicGetterSetterTest.php
+++ b/tests/phpunit/Civi/Schema/MagicGetterSetterTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Civi\Schema;
+
+use Civi\Schema\Traits\MagicGetterSetterTrait;
+
+class MagicGetterSetterTest extends \CiviUnitTestCase {
+
+  public function createExample() {
+    return new class() {
+
+      use MagicGetterSetterTrait;
+
+      protected $protectedField;
+      public $publicField;
+      protected $_obscureProtectedField;
+      public $_obscurePublicField;
+      protected $overriddenProtectedField;
+      protected $set;
+      protected $get;
+
+      /**
+       * @return mixed
+       */
+      public function getOverriddenProtectedField() {
+        return $this->overriddenProtectedField . '_and_get';
+      }
+
+      /**
+       * @param mixed $overriddenProtectedField
+       * @return $this
+       */
+      public function setOverriddenProtectedField($overriddenProtectedField) {
+        $this->overriddenProtectedField = $overriddenProtectedField . '_and_set';
+        return $this;
+      }
+
+    };
+  }
+
+  public function testExample() {
+    $ex = $this->createExample();
+    $this->assertEquals(NULL, $ex->setProtectedField(NULL)->getProtectedField());
+    $this->assertEquals('apple', $ex->setProtectedField('apple')->getProtectedField());
+    $this->assertEquals('banana', $ex->setPublicField('banana')->getPublicField());
+    $this->assertEquals('cherry', $ex->setSet('cherry')->getSet());
+    $this->assertEquals('date', $ex->setGet('date')->getGet());
+    $this->assertEquals('base_and_set_and_get', $ex->setOverriddenProtectedField('base')->getOverriddenProtectedField());
+
+    $nonMethods = [
+      'goozfraba',
+
+      // Typos
+      'seProtectedField',
+      'geProtectedField',
+      'istProtectedField',
+
+      // Obscure fields
+      'set_obscureProtectedField',
+      'get_obscureProtectedField',
+      'is_obscureProtectedField',
+      'setObscureProtectedField',
+      'getObscureProtectedField',
+      'isObscureProtectedField',
+      'set_obscurePublicField',
+      'get_obscurePublicField',
+      'is_obscurePublicField',
+      'setObscurePublicField',
+      'getObscurePublicField',
+      'isObscurePublicField',
+
+      // Funny substrings
+      'i',
+      'g',
+      's',
+      'set',
+      'get',
+      'is',
+      'istanbul',
+      'getter',
+      'setter',
+    ];
+    foreach ($nonMethods as $nonMethod) {
+      try {
+        $ex->{$nonMethod}();
+        $this->fail("Method $nonMethod() should raise exception.");
+      }
+      catch (\CRM_Core_Exception $e) {
+        $message = $e->getMessage();
+        $this->assertRegExp('/Unknown method.*::' . $nonMethod . '()/', $message);
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------

Creates a trait,  `MagicGetterSetterTrait` ~~`FluentGetterSetterTrait`~~, which captures the magic getter/setter behavior from APIv4's `AbstractAction` class. This makes it easier to implement similar behavior in other classes, and it ensures that certain rules (like handling of `_`) are standardized.

For example:

```php
class Foo {
  use MagicGetterSetterTrait;

  protected $bar;
}

$foo = new Foo();
$foo->setBar(100);
echo $foo->getBar();
```

Before
----------------------------------------

* `AbstractAction` implements `__call()` (to handle `getFoo()` and `setFoo()`) and does scanning/filtering of the property-list.

After
----------------------------------------

* `AbstractAction` uses `MagicGetterSetterTrait`. 
* `MagicGetterSetterTrait` implements `__call()` (to handle `getFoo()` and `setFoo()`)and does scanning/filtering of the property-list.
* There's a test for `MagicGetterSetterTrait` which touches on the naming and string-manipulation.
 
Comment
----------------------------------------

The methods `AbstractAction::getParams()` (*public*) and the `MagicGetterSetterTrait::getMagicProperties()` (*private*) may sound similar, but they differ:

* `getParams()`  returns all of the *parameter data*. In effect, it converts `$this` from an object to an `array` (but filtered by the property-list). 
* `getMagicProperties()` only returns the property-list.

(*Updated description to reflect name change: `FluentGetterSetterTrait` => `MagicGetterSetterTrait`)