### PR TITLE
CRM_Utils_Array::pathMove - Add helper to move an item within array tree

### DIFF
--- a/CRM/Utils/Array.php
+++ b/CRM/Utils/Array.php
@@ -1143,6 +1143,31 @@ class CRM_Utils_Array {
   }
 
   /**
+   * Move an item in an array-tree (if it exists).
+   *
+   * @param array $values
+   *   Data-tree
+   * @param string[] $src
+   *   Old path for the existing item
+   * @param string[] $dest
+   *   New path
+   * @param bool $cleanup
+   * @return int
+   *   Number of items moved (0 or 1).
+   */
+  public static function pathMove(&$values, $src, $dest, $cleanup = FALSE) {
+    if (!static::pathIsset($values, $src)) {
+      return 0;
+    }
+    else {
+      $value = static::pathGet($values, $src);
+      static::pathSet($values, $dest, $value);
+      static::pathUnset($values, $src, $cleanup);
+      return 1;
+    }
+  }
+
+  /**
    * Convert a simple dictionary into separate key+value records.
    *
    * @param array $array

--- a/tests/phpunit/CRM/Utils/ArrayTest.php
+++ b/tests/phpunit/CRM/Utils/ArrayTest.php
@@ -159,7 +159,7 @@ class CRM_Utils_ArrayTest extends CiviUnitTestCase {
   }
 
   public function testGetSetPathParts() {
-    $arr = [
+    $arr = $arrOrig = [
       'one' => '1',
       'two' => [
         'half' => 2,
@@ -188,6 +188,23 @@ class CRM_Utils_ArrayTest extends CiviUnitTestCase {
     $this->assertEquals(['second-third' => '2/3'], $arr['three']);
     CRM_Utils_Array::pathUnset($arr, ['three', 'second-third'], TRUE);
     $this->assertFalse(array_key_exists('three', $arr));
+
+    // pathMove(): Change location of an item
+    $arr = $arrOrig;
+    $this->assertEquals(2, $arr['two']['half']);
+    $this->assertTrue(!isset($arr['verb']['double']['half']));
+    $this->assertEquals(1, CRM_Utils_Array::pathMove($arr, ['two'], ['verb', 'double']));
+    $this->assertEquals(2, $arr['verb']['double']['half']);
+    $this->assertTrue(!isset($arr['two']['half']));
+
+    // pathMove(): If item doesn't exist, return 0.
+    $arr = $arrOrig;
+    $this->assertTrue(!isset($arr['not-a-src']));
+    $this->assertTrue(!isset($arr['not-a-dest']));
+    $this->assertEquals(0, CRM_Utils_Array::pathMove($arr, ['not-a-src'], ['not-a-dest']));
+    $this->assertTrue(!isset($arr['not-a-src']));
+    $this->assertTrue(!isset($arr['not-a-dest']));
+
   }
 
   public function getSortExamples() {


### PR DESCRIPTION
Overview
----------------------------------------

Adds a helper function to move items within an array tree, e.g.

```php
$foodStuffs = [
  'fruits' => [
    'apple' => ['sweet' => TRUE],
  ],
  'veggies' => [
    'tomato' => ['sweet' => FALSE],
  ],
];

// Ruhroh. Tomato had a culinary classification, but we need botanical classification!
CRM_Utils_Array::pathMove($foodStuffs, ['veggies','tomato'], ['fruits', 'tomato']);
// Assert: $foodStuffs['veggies']['tomato'] ==> undefined
// Assert: $foodStuffs['fruits']['tomato'] ==> ['sweet' => FALSE]
```
