### PR TITLE
[Ref] Remove never-passed parameter

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -3376,12 +3376,10 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
    *   Contribution object, line item array and params for trxn.
    *
    *
-   * @param array $financialTrxnValues
-   *
    * @return null|\CRM_Core_BAO_FinancialTrxn
    */
-  public static function recordFinancialAccounts(&$params, $financialTrxnValues = NULL) {
-    $skipRecords = $update = $return = FALSE;
+  public static function recordFinancialAccounts(&$params) {
+    $skipRecords = $return = FALSE;
     $isUpdate = !empty($params['prevContribution']);
 
     $additionalParticipantId = [];
@@ -3491,10 +3489,6 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
         $trxnParams['payment_processor_id'] = $params['payment_processor'];
       }
 
-      // consider external values passed for recording transaction entry
-      if (!empty($financialTrxnValues)) {
-        $trxnParams = array_merge($trxnParams, $financialTrxnValues);
-      }
       if (empty($trxnParams['payment_processor_id'])) {
         unset($trxnParams['payment_processor_id']);
       }


### PR DESCRIPTION


Overview
----------------------------------------
this function is called from only one place & it does not pass in financialTrxnValues

![image](https://user-images.githubusercontent.com/336308/125899287-b7d7e0b2-b494-4d39-9757-4dadf95b3318.png)

Before
----------------------------------------
Extra, unused parameter in the signature

After
----------------------------------------
poor

Technical Details
----------------------------------------

Comments
----------------------------------------
