### PR TITLE
dev/core#2715 [REF] Start the process of moving financial processing to own class

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -1141,7 +1141,7 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution {
         $receiveDate = CRM_Utils_Date::isoToMysql($params['contribution']->receive_date);
       }
 
-      $financialAccount = self::getFinancialAccountForStatusChangeTrxn($params, CRM_Utils_Array::value('financial_account_id', $prevFinancialItem));
+      $financialAccount = CRM_Contribute_BAO_FinancialProcessor::getFinancialAccountForStatusChangeTrxn($params, CRM_Utils_Array::value('financial_account_id', $prevFinancialItem));
 
       $currency = $params['prevContribution']->currency;
       if ($params['contribution']->currency) {
@@ -4383,37 +4383,6 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
       ];
       self::createProportionalFinancialEntries($entityParams, $lineItems, $ftIds, $taxItems);
     }
-  }
-
-  /**
-   * Get the financial account for the item associated with the new transaction.
-   *
-   * @param array $params
-   * @param int $default
-   *
-   * @return int
-   */
-  public static function getFinancialAccountForStatusChangeTrxn($params, $default) {
-
-    if (!empty($params['financial_account_id'])) {
-      return $params['financial_account_id'];
-    }
-
-    $contributionStatus = CRM_Contribute_PseudoConstant::contributionStatus($params['contribution_status_id'], 'name');
-    $preferredAccountsRelationships = [
-      'Refunded' => 'Credit/Contra Revenue Account is',
-      'Chargeback' => 'Chargeback Account is',
-    ];
-
-    if (array_key_exists($contributionStatus, $preferredAccountsRelationships)) {
-      $financialTypeID = !empty($params['financial_type_id']) ? $params['financial_type_id'] : $params['prevContribution']->financial_type_id;
-      return CRM_Financial_BAO_FinancialAccount::getFinancialAccountForFinancialTypeByRelationship(
-        $financialTypeID,
-        $preferredAccountsRelationships[$contributionStatus]
-      );
-    }
-
-    return $default;
   }
 
   /**

--- a/CRM/Contribute/BAO/FinancialProcessor.php
+++ b/CRM/Contribute/BAO/FinancialProcessor.php
@@ -1,0 +1,54 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * Class for handling processing of financial records.
+ *
+ * This is a place to extract the financial record processing code to
+ * in order to clean it up.
+ *
+ * @internal core use only.
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+class CRM_Contribute_BAO_FinancialProcessor {
+
+  /**
+   * Get the financial account for the item associated with the new transaction.
+   *
+   * @param array $params
+   * @param int $default
+   *
+   * @return int
+   */
+  public static function getFinancialAccountForStatusChangeTrxn($params, $default) {
+    if (!empty($params['financial_account_id'])) {
+      return $params['financial_account_id'];
+    }
+
+    $contributionStatus = CRM_Contribute_PseudoConstant::contributionStatus($params['contribution_status_id'], 'name');
+    $preferredAccountsRelationships = [
+      'Refunded' => 'Credit/Contra Revenue Account is',
+      'Chargeback' => 'Chargeback Account is',
+    ];
+
+    if (array_key_exists($contributionStatus, $preferredAccountsRelationships)) {
+      $financialTypeID = !empty($params['financial_type_id']) ? $params['financial_type_id'] : $params['prevContribution']->financial_type_id;
+      return CRM_Financial_BAO_FinancialAccount::getFinancialAccountForFinancialTypeByRelationship(
+        $financialTypeID,
+        $preferredAccountsRelationships[$contributionStatus]
+      );
+    }
+    return $default;
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
[REF] Start the process of moving financial processing to own class

This starts the process of moving the functions used to process financial records to their own class

Once we have moved them over (& unwravelled all the 'self' references) it will be easier to clean them up
and use methods rather than param passing

Before
----------------------------------------
Function on one class

After
----------------------------------------
On another, less cluttered class

Technical Details
----------------------------------------
Not called from elsewhere

![image](https://user-images.githubusercontent.com/336308/125901177-2c302a7e-7752-44f0-913a-aa617bcd7038.png)

Comments
----------------------------------------
We don't need to do universe checks on these deep financial processing functions - we've been really clear that people shouldn't call them directly and they have changed many times

These are also heavily tested functions