### PR TITLE
(REF) APIv4 FieldSpec - Extract various traits (Civi\Schema\Traits\*)

### DIFF
--- a/Civi/Api4/Service/Spec/FieldSpec.php
+++ b/Civi/Api4/Service/Spec/FieldSpec.php
@@ -15,6 +15,7 @@ namespace Civi\Api4\Service\Spec;
 use Civi\Schema\Traits\BasicSpecTrait;
 use Civi\Schema\Traits\DataTypeSpecTrait;
 use Civi\Schema\Traits\GuiSpecTrait;
+use Civi\Schema\Traits\OptionsSpecTrait;
 use Civi\Schema\Traits\SqlSpecTrait;
 
 class FieldSpec {
@@ -24,6 +25,9 @@ class FieldSpec {
 
   // DataTypeSpecTrait: dataType, serialize, fkEntity
   use DataTypeSpecTrait;
+
+  // OptionsSpecTrait: options, optionsCallback
+  use OptionsSpecTrait;
 
   // GuiSpecTrait: label, inputType, inputAttrs, helpPre, helpPost
   use GuiSpecTrait;
@@ -55,16 +59,6 @@ class FieldSpec {
    * @var bool
    */
   public $requiredIf;
-
-  /**
-   * @var array|bool
-   */
-  public $options;
-
-  /**
-   * @var callable
-   */
-  private $optionsCallback;
 
   /**
    * @var array
@@ -220,44 +214,6 @@ class FieldSpec {
   public function setReadonly($readonly) {
     $this->readonly = (bool) $readonly;
 
-    return $this;
-  }
-
-  /**
-   * @param array $values
-   * @param array|bool $return
-   * @param bool $checkPermissions
-   * @return array
-   */
-  public function getOptions($values = [], $return = TRUE, $checkPermissions = TRUE) {
-    if (!isset($this->options)) {
-      if ($this->optionsCallback) {
-        $this->options = ($this->optionsCallback)($this, $values, $return, $checkPermissions);
-      }
-      else {
-        $this->options = FALSE;
-      }
-    }
-    return $this->options;
-  }
-
-  /**
-   * @param array|bool $options
-   *
-   * @return $this
-   */
-  public function setOptions($options) {
-    $this->options = $options;
-    return $this;
-  }
-
-  /**
-   * @param callable $callback
-   *
-   * @return $this
-   */
-  public function setOptionsCallback($callback) {
-    $this->optionsCallback = $callback;
     return $this;
   }
 

--- a/Civi/Api4/Service/Spec/FieldSpec.php
+++ b/Civi/Api4/Service/Spec/FieldSpec.php
@@ -12,7 +12,14 @@
 
 namespace Civi\Api4\Service\Spec;
 
+use Civi\Schema\Traits\BasicSpecTrait;
+
 class FieldSpec {
+
+  // BasicSpecTrait: name, title, description
+  use BasicSpecTrait;
+
+
   /**
    * @var mixed
    */
@@ -21,17 +28,7 @@ class FieldSpec {
   /**
    * @var string
    */
-  public $name;
-
-  /**
-   * @var string
-   */
   public $label;
-
-  /**
-   * @var string
-   */
-  public $title;
 
   /**
    * @var string
@@ -42,11 +39,6 @@ class FieldSpec {
    * @var string
    */
   public $entity;
-
-  /**
-   * @var string
-   */
-  public $description;
 
   /**
    * @var bool
@@ -187,24 +179,6 @@ class FieldSpec {
   /**
    * @return string
    */
-  public function getName() {
-    return $this->name;
-  }
-
-  /**
-   * @param string $name
-   *
-   * @return $this
-   */
-  public function setName($name) {
-    $this->name = $name;
-
-    return $this;
-  }
-
-  /**
-   * @return string
-   */
   public function getLabel() {
     return $this->label;
   }
@@ -216,24 +190,6 @@ class FieldSpec {
    */
   public function setLabel($label) {
     $this->label = $label;
-
-    return $this;
-  }
-
-  /**
-   * @return string
-   */
-  public function getTitle() {
-    return $this->title;
-  }
-
-  /**
-   * @param string $title
-   *
-   * @return $this
-   */
-  public function setTitle($title) {
-    $this->title = $title;
 
     return $this;
   }
@@ -254,24 +210,6 @@ class FieldSpec {
    */
   public function getEntity() {
     return $this->entity;
-  }
-
-  /**
-   * @return string
-   */
-  public function getDescription() {
-    return $this->description;
-  }
-
-  /**
-   * @param string $description
-   *
-   * @return $this
-   */
-  public function setDescription($description) {
-    $this->description = $description;
-
-    return $this;
   }
 
   /**

--- a/Civi/Api4/Service/Spec/FieldSpec.php
+++ b/Civi/Api4/Service/Spec/FieldSpec.php
@@ -14,6 +14,7 @@ namespace Civi\Api4\Service\Spec;
 
 use Civi\Schema\Traits\BasicSpecTrait;
 use Civi\Schema\Traits\GuiSpecTrait;
+use Civi\Schema\Traits\SqlSpecTrait;
 
 class FieldSpec {
 
@@ -22,6 +23,9 @@ class FieldSpec {
 
   // GuiSpecTrait: label, inputType, inputAttrs, helpPre, helpPost
   use GuiSpecTrait;
+
+  // SqlSpecTrait tableName, columnName, operators, sqlFilters
+  use SqlSpecTrait;
 
   /**
    * @var mixed
@@ -54,11 +58,6 @@ class FieldSpec {
   public $options;
 
   /**
-   * @var string
-   */
-  public $tableName;
-
-  /**
    * @var callable
    */
   private $optionsCallback;
@@ -67,11 +66,6 @@ class FieldSpec {
    * @var string
    */
   public $dataType;
-
-  /**
-   * @var string[]
-   */
-  public $operators;
 
   /**
    * @var string
@@ -89,11 +83,6 @@ class FieldSpec {
   public $permission;
 
   /**
-   * @var string
-   */
-  public $columnName;
-
-  /**
    * @var bool
    */
   public $readonly = FALSE;
@@ -102,17 +91,6 @@ class FieldSpec {
    * @var callable[]
    */
   public $outputFormatters;
-
-  /**
-   * @var callable
-   */
-  public $sqlRenderer;
-
-  /**
-   * @var callable[]
-   */
-  public $sqlFilters;
-
 
   /**
    * Aliases for the valid data types
@@ -269,16 +247,6 @@ class FieldSpec {
   }
 
   /**
-   * @param string[] $operators
-   * @return $this
-   */
-  public function setOperators($operators) {
-    $this->operators = $operators;
-
-    return $this;
-  }
-
-  /**
    * @param callable[] $outputFormatters
    * @return $this
    */
@@ -302,39 +270,6 @@ class FieldSpec {
   }
 
   /**
-   * @param callable $sqlRenderer
-   * @return $this
-   */
-  public function setSqlRenderer($sqlRenderer) {
-    $this->sqlRenderer = $sqlRenderer;
-
-    return $this;
-  }
-
-  /**
-   * @param callable[] $sqlFilters
-   * @return $this
-   */
-  public function setSqlFilters($sqlFilters) {
-    $this->sqlFilters = $sqlFilters;
-
-    return $this;
-  }
-
-  /**
-   * @param callable $sqlFilter
-   * @return $this
-   */
-  public function addSqlFilter($sqlFilter) {
-    if (!$this->sqlFilters) {
-      $this->sqlFilters = [];
-    }
-    $this->sqlFilters[] = $sqlFilter;
-
-    return $this;
-  }
-
-  /**
    * @param string $type
    * @return $this
    */
@@ -352,23 +287,6 @@ class FieldSpec {
     $this->readonly = (bool) $readonly;
 
     return $this;
-  }
-
-  /**
-   * @param string $tableName
-   * @return $this
-   */
-  public function setTableName($tableName) {
-    $this->tableName = $tableName;
-
-    return $this;
-  }
-
-  /**
-   * @return string
-   */
-  public function getTableName() {
-    return $this->tableName;
   }
 
   /**
@@ -436,23 +354,6 @@ class FieldSpec {
   public function setFkEntity($fkEntity) {
     $this->fkEntity = $fkEntity;
 
-    return $this;
-  }
-
-  /**
-   * @return string|NULL
-   */
-  public function getColumnName(): ?string {
-    return $this->columnName;
-  }
-
-  /**
-   * @param string|null $columnName
-   *
-   * @return $this
-   */
-  public function setColumnName(?string $columnName) {
-    $this->columnName = $columnName;
     return $this;
   }
 

--- a/Civi/Api4/Service/Spec/FieldSpec.php
+++ b/Civi/Api4/Service/Spec/FieldSpec.php
@@ -12,6 +12,7 @@
 
 namespace Civi\Api4\Service\Spec;
 
+use Civi\Schema\Traits\ArrayFormatTrait;
 use Civi\Schema\Traits\BasicSpecTrait;
 use Civi\Schema\Traits\DataTypeSpecTrait;
 use Civi\Schema\Traits\GuiSpecTrait;
@@ -34,6 +35,9 @@ class FieldSpec {
 
   // SqlSpecTrait tableName, columnName, operators, sqlFilters
   use SqlSpecTrait;
+
+  // ArrayFormatTrait: toArray():array, loadArray($array)
+  use ArrayFormatTrait;
 
   /**
    * @var mixed
@@ -215,34 +219,6 @@ class FieldSpec {
     $this->readonly = (bool) $readonly;
 
     return $this;
-  }
-
-  /**
-   * Gets all public variables, converted to snake_case
-   *
-   * @return array
-   */
-  public function toArray() {
-    // Anonymous class will only have access to public vars
-    $getter = new class {
-
-      function getPublicVars($object) {
-        return get_object_vars($object);
-      }
-
-    };
-
-    // If getOptions was never called, make options a boolean
-    if (!isset($this->options)) {
-      $this->options = isset($this->optionsCallback);
-    }
-
-    $ret = [];
-    foreach ($getter->getPublicVars($this) as $key => $val) {
-      $key = strtolower(preg_replace('/(?=[A-Z])/', '_$0', $key));
-      $ret[$key] = $val;
-    }
-    return $ret;
   }
 
 }

--- a/Civi/Api4/Service/Spec/FieldSpec.php
+++ b/Civi/Api4/Service/Spec/FieldSpec.php
@@ -13,22 +13,20 @@
 namespace Civi\Api4\Service\Spec;
 
 use Civi\Schema\Traits\BasicSpecTrait;
+use Civi\Schema\Traits\GuiSpecTrait;
 
 class FieldSpec {
 
   // BasicSpecTrait: name, title, description
   use BasicSpecTrait;
 
+  // GuiSpecTrait: label, inputType, inputAttrs, helpPre, helpPost
+  use GuiSpecTrait;
 
   /**
    * @var mixed
    */
   public $defaultValue;
-
-  /**
-   * @var string
-   */
-  public $label;
 
   /**
    * @var string
@@ -71,16 +69,6 @@ class FieldSpec {
   public $dataType;
 
   /**
-   * @var string
-   */
-  public $inputType;
-
-  /**
-   * @var array
-   */
-  public $inputAttrs = [];
-
-  /**
    * @var string[]
    */
   public $operators;
@@ -94,16 +82,6 @@ class FieldSpec {
    * @var int
    */
   public $serialize;
-
-  /**
-   * @var string
-   */
-  public $helpPre;
-
-  /**
-   * @var string
-   */
-  public $helpPost;
 
   /**
    * @var array
@@ -172,24 +150,6 @@ class FieldSpec {
    */
   public function setDefaultValue($defaultValue) {
     $this->defaultValue = $defaultValue;
-
-    return $this;
-  }
-
-  /**
-   * @return string
-   */
-  public function getLabel() {
-    return $this->label;
-  }
-
-  /**
-   * @param string $label
-   *
-   * @return $this
-   */
-  public function setLabel($label) {
-    $this->label = $label;
 
     return $this;
   }
@@ -309,40 +269,6 @@ class FieldSpec {
   }
 
   /**
-   * @return string
-   */
-  public function getInputType() {
-    return $this->inputType;
-  }
-
-  /**
-   * @param string $inputType
-   * @return $this
-   */
-  public function setInputType($inputType) {
-    $this->inputType = $inputType;
-
-    return $this;
-  }
-
-  /**
-   * @return array
-   */
-  public function getInputAttrs() {
-    return $this->inputAttrs;
-  }
-
-  /**
-   * @param array $inputAttrs
-   * @return $this
-   */
-  public function setInputAttrs($inputAttrs) {
-    $this->inputAttrs = $inputAttrs;
-
-    return $this;
-  }
-
-  /**
    * @param string[] $operators
    * @return $this
    */
@@ -426,20 +352,6 @@ class FieldSpec {
     $this->readonly = (bool) $readonly;
 
     return $this;
-  }
-
-  /**
-   * @param string|NULL $helpPre
-   */
-  public function setHelpPre($helpPre) {
-    $this->helpPre = is_string($helpPre) && strlen($helpPre) ? $helpPre : NULL;
-  }
-
-  /**
-   * @param string|NULL $helpPost
-   */
-  public function setHelpPost($helpPost) {
-    $this->helpPost = is_string($helpPost) && strlen($helpPost) ? $helpPost : NULL;
   }
 
   /**

--- a/Civi/Api4/Service/Spec/FieldSpec.php
+++ b/Civi/Api4/Service/Spec/FieldSpec.php
@@ -45,6 +45,11 @@ class FieldSpec {
   public $defaultValue;
 
   /**
+   * Meta-type indicating how this field was defined/implemented.
+   *
+   * Ex: 'Field' (normal/standard DB field), 'Custom' (auxiliary DB field),
+   * 'Filter' (read-oriented filter option), 'Extra' (special/programmatic field).
+   *
    * @var string
    */
   public $type = 'Extra';

--- a/Civi/Api4/Service/Spec/FieldSpec.php
+++ b/Civi/Api4/Service/Spec/FieldSpec.php
@@ -13,6 +13,7 @@
 namespace Civi\Api4\Service\Spec;
 
 use Civi\Schema\Traits\BasicSpecTrait;
+use Civi\Schema\Traits\DataTypeSpecTrait;
 use Civi\Schema\Traits\GuiSpecTrait;
 use Civi\Schema\Traits\SqlSpecTrait;
 
@@ -20,6 +21,9 @@ class FieldSpec {
 
   // BasicSpecTrait: name, title, description
   use BasicSpecTrait;
+
+  // DataTypeSpecTrait: dataType, serialize, fkEntity
+  use DataTypeSpecTrait;
 
   // GuiSpecTrait: label, inputType, inputAttrs, helpPre, helpPost
   use GuiSpecTrait;
@@ -63,21 +67,6 @@ class FieldSpec {
   private $optionsCallback;
 
   /**
-   * @var string
-   */
-  public $dataType;
-
-  /**
-   * @var string
-   */
-  public $fkEntity;
-
-  /**
-   * @var int
-   */
-  public $serialize;
-
-  /**
    * @var array
    */
   public $permission;
@@ -91,17 +80,6 @@ class FieldSpec {
    * @var callable[]
    */
   public $outputFormatters;
-
-  /**
-   * Aliases for the valid data types
-   *
-   * @var array
-   */
-  public static $typeAliases = [
-    'Int' => 'Integer',
-    'Link' => 'Url',
-    'Memo' => 'Text',
-  ];
 
   /**
    * @param string $name
@@ -187,50 +165,6 @@ class FieldSpec {
   }
 
   /**
-   * @return string
-   */
-  public function getDataType() {
-    return $this->dataType;
-  }
-
-  /**
-   * @param $dataType
-   *
-   * @return $this
-   * @throws \Exception
-   */
-  public function setDataType($dataType) {
-    if (array_key_exists($dataType, self::$typeAliases)) {
-      $dataType = self::$typeAliases[$dataType];
-    }
-
-    if (!in_array($dataType, $this->getValidDataTypes())) {
-      throw new \Exception(sprintf('Invalid data type "%s', $dataType));
-    }
-
-    $this->dataType = $dataType;
-
-    return $this;
-  }
-
-  /**
-   * @return int
-   */
-  public function getSerialize() {
-    return $this->serialize;
-  }
-
-  /**
-   * @param int|null $serialize
-   * @return $this
-   */
-  public function setSerialize($serialize) {
-    $this->serialize = $serialize;
-
-    return $this;
-  }
-
-  /**
    * @param array $permission
    * @return $this
    */
@@ -290,18 +224,6 @@ class FieldSpec {
   }
 
   /**
-   * Add valid types that are not not part of \CRM_Utils_Type::dataTypes
-   *
-   * @return array
-   */
-  private function getValidDataTypes() {
-    $extraTypes = ['Boolean', 'Text', 'Float', 'Url', 'Array', 'Blob', 'Mediumblob'];
-    $extraTypes = array_combine($extraTypes, $extraTypes);
-
-    return array_merge(\CRM_Utils_Type::dataTypes(), $extraTypes);
-  }
-
-  /**
    * @param array $values
    * @param array|bool $return
    * @param bool $checkPermissions
@@ -336,24 +258,6 @@ class FieldSpec {
    */
   public function setOptionsCallback($callback) {
     $this->optionsCallback = $callback;
-    return $this;
-  }
-
-  /**
-   * @return string
-   */
-  public function getFkEntity() {
-    return $this->fkEntity;
-  }
-
-  /**
-   * @param string $fkEntity
-   *
-   * @return $this
-   */
-  public function setFkEntity($fkEntity) {
-    $this->fkEntity = $fkEntity;
-
     return $this;
   }
 

--- a/Civi/Schema/Traits/ArrayFormatTrait.php
+++ b/Civi/Schema/Traits/ArrayFormatTrait.php
@@ -1,0 +1,76 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Schema\Traits;
+
+/**
+ *
+ *
+ * @package Civi\Schema\Traits
+ */
+trait ArrayFormatTrait {
+
+  /**
+   * Gets all public variables, converted to snake_case
+   *
+   * @return array
+   */
+  public function toArray() {
+    // Anonymous class will only have access to public vars
+    $getter = new class {
+
+      function getPublicVars($object) {
+        return get_object_vars($object);
+      }
+
+    };
+
+    // If getOptions was never called, make options a boolean
+    if (property_exists($this, 'options') && !isset($this->options)) {
+      $this->options = isset($this->optionsCallback);
+    }
+
+    $ret = [];
+    foreach ($getter->getPublicVars($this) as $key => $val) {
+      $key = strtolower(preg_replace('/(?=[A-Z])/', '_$0', $key));
+      $ret[$key] = $val;
+    }
+    return $ret;
+  }
+
+  /**
+   * Populate this field-spec using values from an array.
+   *
+   * @param iterable $values
+   *   List of public variables, expressed in snake_case.
+   *   Ex: ['title' => 'Color', 'default_value' => '#f00']
+   * @param  bool $strict
+   *   In strict mode, properties are only accepted if they are formally defined on the current class.
+   * @return $this
+   */
+  public function loadArray(iterable $values, bool $strict = FALSE) {
+    foreach ($values as $key => $value) {
+      $field = \CRM_Utils_String::convertStringToCamel($key, FALSE);
+      $setter = 'set' . ucfirst($field);
+      if ($strict && !property_exists($this, $field) && !method_exists($this, $setter) && $value !== NULL) {
+        throw new \CRM_Core_Exception(sprintf('Cannot assign field (%s::%s aka %s)', get_class($this), $field, $key));
+      }
+      if (is_callable([$this, $setter])) {
+        $this->{$setter}($value);
+      }
+      else {
+        $this->{$field} = $value;
+      }
+    }
+    return $this;
+  }
+
+}

--- a/Civi/Schema/Traits/BasicSpecTrait.php
+++ b/Civi/Schema/Traits/BasicSpecTrait.php
@@ -1,0 +1,102 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Schema\Traits;
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+trait BasicSpecTrait {
+
+  /**
+   * Symbolic name of the field.
+   *
+   * Ex: 'first_name'
+   *
+   * @var string
+   */
+  public $name;
+
+  /**
+   * Backend-facing label. Shown in API, exports, and other configuration
+   * systems.
+   *
+   * If this field is presented to an administrator (e.g. when configuring a
+   * screen or configuring process-automation), how the field be entitled?
+   *
+   * Ex: ts('First Name')
+   *
+   * @var string
+   */
+  public $title;
+
+  /**
+   * Explanation of the purpose of the field.
+   *
+   * @var string
+   */
+  public $description;
+
+  /**
+   * @return string
+   */
+  public function getName() {
+    return $this->name;
+  }
+
+  /**
+   * @param string $name
+   *
+   * @return $this
+   */
+  public function setName($name) {
+    $this->name = $name;
+
+    return $this;
+  }
+
+  /**
+   * @return string
+   */
+  public function getTitle() {
+    return $this->title;
+  }
+
+  /**
+   * @param string $title
+   *
+   * @return $this
+   */
+  public function setTitle($title) {
+    $this->title = $title;
+    return $this;
+  }
+
+  /**
+   * @return string
+   */
+  public function getDescription() {
+    return $this->description;
+  }
+
+  /**
+   * @param string $description
+   *
+   * @return $this
+   */
+  public function setDescription($description) {
+    $this->description = $description;
+    return $this;
+  }
+
+}

--- a/Civi/Schema/Traits/DataTypeSpecTrait.php
+++ b/Civi/Schema/Traits/DataTypeSpecTrait.php
@@ -1,0 +1,142 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Schema\Traits;
+
+/**
+ * Describe what values are allowed to be stored in this field.
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+trait DataTypeSpecTrait {
+
+  /**
+   * The type of data stored in this field.
+   *
+   * Ex: 'Integer', 'Boolean', 'Float', 'String', 'Text', 'Blob'
+   *
+   * @var string
+   */
+  public $dataType;
+
+  /**
+   * @var int
+   * @see CRM_Core_DAO::SERIALIZE_SEPARATOR_BOOKEND,
+   *   CRM_Core_DAO::SERIALIZE_JSON, etc
+   */
+  public $serialize;
+
+  /**
+   * @var string
+   */
+  public $fkEntity;
+
+  /**
+   * Aliases for the valid data types
+   *
+   * @var array
+   */
+  public static $typeAliases = [
+    'Int' => 'Integer',
+    'Link' => 'Url',
+    'Memo' => 'Text',
+  ];
+
+  /**
+   * @return string
+   */
+  public function getDataType() {
+    return $this->dataType;
+  }
+
+  /**
+   * @param $dataType
+   *
+   * @return $this
+   * @throws \Exception
+   */
+  public function setDataType($dataType) {
+    if (array_key_exists($dataType, self::$typeAliases)) {
+      $dataType = self::$typeAliases[$dataType];
+    }
+
+    if (!in_array($dataType, $this->getValidDataTypes())) {
+      throw new \Exception(sprintf('Invalid data type "%s', $dataType));
+    }
+
+    $this->dataType = $dataType;
+
+    return $this;
+  }
+
+  /**
+   * @return string
+   */
+  public function getFkEntity() {
+    return $this->fkEntity;
+  }
+
+  /**
+   * @param string $fkEntity
+   *
+   * @return $this
+   */
+  public function setFkEntity($fkEntity) {
+    $this->fkEntity = $fkEntity;
+
+    return $this;
+  }
+
+  /**
+   * @return int
+   */
+  public function getSerialize() {
+    return $this->serialize;
+  }
+
+  /**
+   * @param int|string|null $serialize
+   * @return $this
+   */
+  public function setSerialize($serialize) {
+    if (is_string($serialize)) {
+      $const = 'CRM_Core_DAO::SERIALIZE_' . $serialize;
+      if (defined($const)) {
+        $serialize = constant($const);
+      }
+    }
+    $this->serialize = $serialize;
+    return $this;
+  }
+
+  /**
+   * Add valid types that are not not part of \CRM_Utils_Type::dataTypes
+   *
+   * @return array
+   */
+  protected function getValidDataTypes() {
+    $extraTypes = [
+      'Boolean',
+      'Text',
+      'Float',
+      'Url',
+      'Array',
+      'Blob',
+      'Mediumblob',
+    ];
+    $extraTypes = array_combine($extraTypes, $extraTypes);
+
+    return array_merge(\CRM_Utils_Type::dataTypes(), $extraTypes);
+  }
+
+}

--- a/Civi/Schema/Traits/GuiSpecTrait.php
+++ b/Civi/Schema/Traits/GuiSpecTrait.php
@@ -1,0 +1,120 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Schema\Traits;
+
+/**
+ * If a field will be presented in GUIs (e.g. data-entry fields or
+ * data-columns), then use GuiSpecTrait to describe its typical/default appearance..
+ *
+ * @package Civi\Schema\Traits
+ */
+trait GuiSpecTrait {
+
+  /**
+   * User-facing label, shown on most forms and displays
+   *
+   * Default label to use when presenting this field to an end-user (e.g.
+   * on a data-entry form or a data-column view).
+   *
+   * @var string
+   */
+  public $label;
+
+  /**
+   * Default widget to use when presenting this field.
+   *
+   * @var string
+   *   Ex: 'RichTextEditor'
+   */
+  public $inputType;
+
+  /**
+   * @var array
+   */
+  public $inputAttrs = [];
+
+  /**
+   * @var string
+   */
+  public $helpPre;
+
+  /**
+   * @var string
+   */
+  public $helpPost;
+
+  /**
+   * @return string
+   */
+  public function getLabel() {
+    return $this->label;
+  }
+
+  /**
+   * @return string
+   */
+  public function getInputType() {
+    return $this->inputType;
+  }
+
+  /**
+   * @param string $inputType
+   *
+   * @return $this
+   */
+  public function setInputType($inputType) {
+    $this->inputType = $inputType;
+    return $this;
+  }
+
+  /**
+   * @return array
+   */
+  public function getInputAttrs() {
+    return $this->inputAttrs;
+  }
+
+  /**
+   * @param array $inputAttrs
+   *
+   * @return $this
+   */
+  public function setInputAttrs($inputAttrs) {
+    $this->inputAttrs = $inputAttrs;
+    return $this;
+  }
+
+  /**
+   * @param string $label
+   *
+   * @return $this
+   */
+  public function setLabel($label) {
+    $this->label = $label;
+    return $this;
+  }
+
+  /**
+   * @param string|NULL $helpPre
+   */
+  public function setHelpPre($helpPre) {
+    $this->helpPre = is_string($helpPre) && strlen($helpPre) ? $helpPre : NULL;
+  }
+
+  /**
+   * @param string|NULL $helpPost
+   */
+  public function setHelpPost($helpPost) {
+    $this->helpPost = is_string($helpPost) && strlen($helpPost) ? $helpPost : NULL;
+  }
+
+}

--- a/Civi/Schema/Traits/OptionsSpecTrait.php
+++ b/Civi/Schema/Traits/OptionsSpecTrait.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Schema\Traits;
+
+/**
+ * Describe what values are allowed to be stored in this field.
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+trait OptionsSpecTrait {
+
+  /**
+   * @var array|bool
+   */
+  public $options;
+
+  /**
+   * @var callable
+   */
+  private $optionsCallback;
+
+  /**
+   * @param array $values
+   * @param array|bool $return
+   * @param bool $checkPermissions
+   *
+   * @return array
+   */
+  public function getOptions($values = [], $return = TRUE, $checkPermissions = TRUE) {
+    if (!isset($this->options)) {
+      if ($this->optionsCallback) {
+        $this->options = ($this->optionsCallback)($this, $values, $return, $checkPermissions);
+      }
+      else {
+        $this->options = FALSE;
+      }
+    }
+    return $this->options;
+  }
+
+  /**
+   * @param array|bool $options
+   *
+   * @return $this
+   */
+  public function setOptions($options) {
+    $this->options = $options;
+    return $this;
+  }
+
+  /**
+   * @param callable $callback
+   *
+   * @return $this
+   */
+  public function setOptionsCallback($callback) {
+    $this->optionsCallback = $callback;
+    return $this;
+  }
+
+}

--- a/Civi/Schema/Traits/PhpDataTypeSpecTrait.php
+++ b/Civi/Schema/Traits/PhpDataTypeSpecTrait.php
@@ -1,0 +1,88 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Schema\Traits;
+
+/**
+ * Describe what values are allowed to be stored in this field.
+ *
+ * This trait is used to track a PHP-style field which is mapped ot a entity-style field.
+ * Thus, it has both PHP's `@var` (`$type`) and entity's `@dataType` (`$dataType`).
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+trait PhpDataTypeSpecTrait {
+
+  // DataTypeSpecTrait: dataType, serialize, fkEntity
+  use DataTypeSpecTrait;
+
+  /**
+   * The PHP
+   *
+   * @var string[]
+   */
+  public $type;
+
+  /**
+   * @param string|string[] $type
+   * @return $this
+   * @throws \Exception
+   */
+  public function setType($type) {
+    $type = (array) $type;
+    if (property_exists(static::CLASS, 'required') && preg_grep('/null/i', $type)) {
+      $this->required = FALSE;
+    }
+    $type = preg_grep('/null/i', $type, PREG_GREP_INVERT);
+    // If there is one `@var` type, then attempt to infer the `dataType` and `serialize` type.
+    if (count($type) === 1) {
+      switch ($type[0]) {
+        case 'string[]':
+        case 'int[]':
+        case 'bool[]':
+        case 'array':
+          $autoDataType = 'Blob';
+          $autoSerialize = \CRM_Core_DAO::SERIALIZE_JSON;
+          break;
+
+        case 'string':
+        case 'int':
+          $autoDataType = ucfirst($type[0]);
+          $autoSerialize = NULL;
+          break;
+
+        case 'bool':
+          $autoDataType = 'Boolean';
+          $autoSerialize = NULL;
+          break;
+      }
+
+      if ($this->dataType === NULL) {
+        $this->setDataType($autoDataType);
+      }
+      if ($this->serialize === NULL) {
+        $this->setSerialize($autoSerialize);
+      }
+    }
+    $this->type = $type;
+    return $this;
+  }
+
+  /**
+   * @return string[]
+   */
+  public function getType(): array {
+    return $this->type;
+  }
+
+}

--- a/Civi/Schema/Traits/SqlSpecTrait.php
+++ b/Civi/Schema/Traits/SqlSpecTrait.php
@@ -1,0 +1,133 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Schema\Traits;
+
+/**
+ * If a field is specifically stored in the database, then use SqlSpecTrait
+ * to describe how to read/write the field.
+ *
+ * @package Civi\Schema\Traits
+ */
+trait SqlSpecTrait {
+
+  /**
+   * SQL table which stores this field.
+   *
+   * @var string
+   */
+  public $tableName;
+
+  /**
+   * SQL column which stores this field.
+   *
+   * @var string
+   */
+  public $columnName;
+
+  /**
+   * If set, limits the operators that can be used on this field for "get"
+   * actions.
+   *
+   * @var string[]
+   */
+  public $operators;
+
+  /**
+   * @var callable
+   */
+  public $sqlRenderer;
+
+  /**
+   * Some fields use a callback to generate their SQL (for reading/searching).
+   *
+   * @var callable[]
+   */
+  public $sqlFilters;
+
+  /**
+   * @param string $tableName
+   *
+   * @return $this
+   */
+  public function setTableName($tableName) {
+    $this->tableName = $tableName;
+    return $this;
+  }
+
+  /**
+   * @return string
+   */
+  public function getTableName() {
+    return $this->tableName;
+  }
+
+  /**
+   * @return string|NULL
+   */
+  public function getColumnName(): ?string {
+    return $this->columnName;
+  }
+
+  /**
+   * @param string|null $columnName
+   *
+   * @return $this
+   */
+  public function setColumnName(?string $columnName) {
+    $this->columnName = $columnName;
+    return $this;
+  }
+
+  /**
+   * @param string[] $operators
+   *
+   * @return $this
+   */
+  public function setOperators($operators) {
+    $this->operators = $operators;
+    return $this;
+  }
+
+  /**
+   * @param callable $sqlRenderer
+   * @return $this
+   */
+  public function setSqlRenderer($sqlRenderer) {
+    $this->sqlRenderer = $sqlRenderer;
+    return $this;
+  }
+
+  /**
+   * @param callable[] $sqlFilters
+   *
+   * @return $this
+   */
+  public function setSqlFilters($sqlFilters) {
+    $this->sqlFilters = $sqlFilters;
+    return $this;
+  }
+
+  /**
+   * @param callable $sqlFilter
+   *
+   * @return $this
+   */
+  public function addSqlFilter($sqlFilter) {
+    if (!$this->sqlFilters) {
+      $this->sqlFilters = [];
+    }
+    $this->sqlFilters[] = $sqlFilter;
+
+    return $this;
+  }
+
+}

--- a/tests/phpunit/api/v4/Entity/ConformanceTest.php
+++ b/tests/phpunit/api/v4/Entity/ConformanceTest.php
@@ -23,6 +23,8 @@ use Civi\API\Exception\UnauthorizedException;
 use Civi\Api4\Entity;
 use api\v4\UnitTestCase;
 use Civi\Api4\Event\ValidateValuesEvent;
+use Civi\Api4\Service\Spec\CustomFieldSpec;
+use Civi\Api4\Service\Spec\FieldSpec;
 use Civi\Api4\Utils\CoreUtil;
 use Civi\Test\HookInterface;
 
@@ -193,6 +195,19 @@ class ConformanceTest extends UnitTestCase implements HookInterface {
 
     $this->assertArrayHasKey('data_type', $fields['id'], $errMsg);
     $this->assertEquals('Integer', $fields['id']['data_type']);
+
+    // Ensure that the getFields (FieldSpec) format is generally consistent.
+    foreach ($fields as $field) {
+      $isNotNull = function($v) {
+        return $v !== NULL;
+      };
+      $class = empty($field['custom_field_id']) ? FieldSpec::class : CustomFieldSpec::class;
+      $spec = (new $class($field['name'], $field['entity']))->loadArray($field, TRUE);
+      $this->assertEquals(
+        array_filter($field, $isNotNull),
+        array_filter($spec->toArray(), $isNotNull)
+      );
+    }
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------

There are currently several different schemas floating around (e.g.  for APIv3-fields, APIv4-fields, DAO-fields, and settings).  These schemas have a mix of fields which are:

1. The same (e.g. `name`, `title`, `description`). 
    * We should ensure that these continue working the same in various schemas.
2. Different in essential ways (e.g. SQL-mapped fields have `table_name` and `column_name`;  setting-fields have `group_name`).
    * We should ensure that these can continue to be separate from each other.
3. Different in non-essential ways (e.g. `help_text` vs `help_pre`/`help_post`; `html` vs `input_type`/`input_attrs`).
    * In the short-term, we should avoid further drift. In the long-term, we may want to refactor/consolidate.

Since these mixable sets of fields, it makes sense to track/document/audit them as traits.

Before
----------------------------------------

`Civi/Api4/Service/Spec/FieldSpec.php` has long list of metadata fields.

After
----------------------------------------

A majority of the metadata fields have been split-off into separate traits (`Civi\Schema\Traits\*`).  If you need to model a new schema, you can re-use these traits -- ensuring that the names/types/descriptions match-up.  They are:

* `BasicSpecTrait` - Basic identification for the field. (Name, title, description)
* `DataTypeSpecTrait` - Describe the type of data stored in a field. (Data-type, serialize, fk-entity)
* `OptionsSpecTrait` - Describe allowed options. (Options, options-callback)
* `GuiSpecTrait` - Describe how to display the field in a user-facing GUI. (Label, input-type, input-attrs, help)
* `SqlSpecTrait` - Describe how to the field maps into SQL. (Table-name, column-name, sql-operators, sql-filters)
* `ArrayFormatTrait` - Translate the spec into an array-format. (eg `$field->defaultValue` vs `$field['default_value']`)

Comments
----------------------------------------

This PR is a step toward introducing another schema for describing workflow message-template fields. However, that schema left as a separate issue.

Not sure there's a whole lot of QA'ing that makes sense beyond existing tests.

I did expand coverage a bit in `ConformanceTest` - this basically ensures that APIv4's `getFields` and the class-model in `FieldSpec` remain true to each other.