### PR TITLE
SearchKit - Fix pager count return value

### DIFF
--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/Run.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/Run.php
@@ -113,7 +113,7 @@ class Run extends \Civi\Api4\Generic\AbstractAction {
         if (empty($apiParams['having'])) {
           $apiParams['select'] = [];
         }
-        if (!in_array($this->return, $apiParams)) {
+        if (!in_array($this->return, $apiParams['select'], TRUE)) {
           $apiParams['select'][] = $this->return;
         }
         unset($apiParams['orderBy'], $apiParams['limit']);


### PR DESCRIPTION
Overview
----------------------------------------
Fixes inefficient pager count which was returning all values instead of just the count

Before
----------------------------------------
Pager count api call returns count plus every value from every record.

After
----------------------------------------
Returns just the count

Comments
---------------------
It was a silly mistake