### PR TITLE
Fix onCrmUiSelect to use current scope and apply to the digest cycle

### DIFF
--- a/ang/crmUi.js
+++ b/ang/crmUi.js
@@ -636,14 +636,16 @@
     // Use a select2 widget as a pick-list. Instead of updating ngModel, the select2 widget will fire an event.
     // This similar to ngModel+ngChange, except that value is never stored in a model. It is only fired in the event.
     // usage: <select crm-ui-select='{...}' on-crm-ui-select="alert("User picked this item: " + selection)"></select>
-    .directive('onCrmUiSelect', function ($parse) {
+    .directive('onCrmUiSelect', function () {
       return {
         priority: 10,
         link: function (scope, element, attrs) {
           element.on('select2-selecting', function(e) {
             e.preventDefault();
             element.select2('close').select2('val', '');
-            scope.$parent.$eval(attrs.onCrmUiSelect, {selection: e.val});
+            scope.$apply(function() {
+              scope.$eval(attrs.onCrmUiSelect, {selection: e.val});
+            });
           });
         }
       };


### PR DESCRIPTION
Overview
----------------------------------------
Fixes the new `onCrmUiSelect` directive introduced in #20789

Before
----------------------------------------
Operates outside of current scope and outside the digest cycle.

After
----------------------------------------
Works as expected.