### PR TITLE
SearchKit - Support all fields as tokens

### DIFF
--- a/ang/api4Explorer/Explorer.js
+++ b/ang/api4Explorer/Explorer.js
@@ -142,11 +142,14 @@
           if (join.bridge) {
             var bridgeFields = _.cloneDeep(entityFields(join.bridge)),
               bridgeEntity = getEntity(join.bridge),
-              joinFieldNames = _.pluck(joinFields, 'name');
+              joinFieldNames = _.pluck(joinFields, 'name'),
+              // Check if this is a symmetric bridge e.g. RelationshipCache joins Contact to Contact
+              bridgePair = _.keys(bridgeEntity.bridge),
+              symmetric = getField(bridgePair[0], join.bridge).entity === getField(bridgePair[1], join.bridge).entity;
             _.each(bridgeFields, function(field) {
               if (
                 // Only include bridge fields that link back to the original entity
-                (!bridgeEntity.bridge[field.name] || field.fk_entity !== join.entity) &&
+                (!bridgeEntity.bridge[field.name] || field.fk_entity !== join.entity || symmetric) &&
                 // Exclude fields with the same name as those in the original entity
                 !_.includes(joinFieldNames, field.name)
               ) {

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/Run.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/Run.php
@@ -366,6 +366,7 @@ class Run extends \Civi\Api4\Generic\AbstractAction {
       $possibleTokens .= ($column['rewrite'] ?? '') . ($column['link']['path'] ?? '');
       if (!empty($column['links'])) {
         $possibleTokens .= implode('', array_column($column['links'], 'path'));
+        $possibleTokens .= implode('', array_column($column['links'], 'text'));
       }
 
       // Select value fields for in-place editing

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminLinkGroup.html
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminLinkGroup.html
@@ -27,8 +27,9 @@
           <option value="crm-popup">{{:: ts('Popup dialog') }}</option>
         </select>
       </td>
-      <td>
+      <td class="form-inline">
         <input type="text" class="form-control" ng-model="item.text">
+        <crm-search-admin-token-select model="item" field="text" suffix=":label"></crm-search-admin-token-select>
       </td>
       <td class="form-inline">
         <crm-search-admin-link-select api-entity="$ctrl.apiEntity" api-params="$ctrl.apiParams" link="item" links="$ctrl.links" on-change="$ctrl.onChangeLink(item, before, after)"></crm-search-admin-link-select>

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminLinkSelect.html
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminLinkSelect.html
@@ -17,4 +17,4 @@
     </ul>
   </div>
 </div>
-<crm-search-admin-token-select ng-if="!$ctrl.getLink($ctrl.link.path)" api-entity="$ctrl.apiEntity" api-params="$ctrl.apiParams" model="$ctrl.link" field="path"></crm-search-admin-token-select>
+<crm-search-admin-token-select ng-if="!$ctrl.getLink($ctrl.link.path)" model="$ctrl.link" field="path"></crm-search-admin-token-select>

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminTokenSelect.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminTokenSelect.component.js
@@ -3,47 +3,34 @@
 
   angular.module('crmSearchAdmin').component('crmSearchAdminTokenSelect', {
     bindings: {
-      apiEntity: '<',
-      apiParams: '<',
       model: '<',
-      field: '@'
+      field: '@',
+      suffix: '@'
+    },
+    require: {
+      admin: '^crmSearchAdmin'
     },
     templateUrl: '~/crmSearchAdmin/crmSearchAdminTokenSelect.html',
     controller: function ($scope, $element, searchMeta) {
       var ts = $scope.ts = CRM.ts('org.civicrm.search_kit'),
         ctrl = this;
 
-      this.initTokens = function() {
-        ctrl.tokens = ctrl.tokens || getTokens();
-      };
-
       this.insertToken = function(key) {
-        ctrl.model[ctrl.field] = (ctrl.model[ctrl.field] || '') + ctrl.tokens[key].token;
+        ctrl.model[ctrl.field] = (ctrl.model[ctrl.field] || '') + '[' + key + ']';
       };
 
-      function getTokens() {
-        var tokens = {
-          id: {
-            token: '[id]',
-            label: searchMeta.getField('id', ctrl.apiEntity).label
-          }
+      this.getTokens = function() {
+        var allFields = ctrl.admin.getAllFields(ctrl.suffix || '', ['Field', 'Custom', 'Extra']);
+        _.eachRight(ctrl.admin.savedSearch.api_params.select, function(fieldName) {
+          allFields.unshift({
+            id: fieldName,
+            text: searchMeta.getDefaultLabel(fieldName)
+          });
+        });
+        return {
+          results: allFields
         };
-        _.each(ctrl.apiParams.join, function(joinParams) {
-          var info = searchMeta.parseExpr(joinParams[0].split(' AS ')[1] + '.id');
-          tokens[info.alias] = {
-            token: '[' + info.alias + ']',
-            label: info.field ? info.field.label : info.alias
-          };
-        });
-        _.each(ctrl.apiParams.select, function(expr) {
-          var info = searchMeta.parseExpr(expr);
-          tokens[info.alias] = {
-            token: '[' + info.alias + ']',
-            label: info.field ? info.field.label : info.alias
-          };
-        });
-        return tokens;
-      }
+      };
 
     }
   });

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminTokenSelect.html
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminTokenSelect.html
@@ -1,10 +1,6 @@
-<div class="btn-group btn-group-xs">
-  <button type="button" class="btn btn-default-outline dropdown-toggle" ng-click="$ctrl.initTokens()" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-    {{:: ts('Tokens') }} <span class="caret"></span>
-  </button>
-  <ul class="dropdown-menu dropdown-menu-right">
-    <li ng-repeat="(id, token) in $ctrl.tokens" >
-      <a href ng-click="$ctrl.insertToken(id)">{{ token.label }}</a>
-    </li>
-  </ul>
-</div>
+<span title="{{:: ts('Insert Tokens') }}">
+  <input class="form-control crm-action-menu fa-code collapsible-optgroups"
+         crm-ui-select="{placeholder: ' ', data: $ctrl.getTokens, width: '52px', containerCss: {minWidth: '52px'}, dropdownCss: {width: '250px'}}"
+         on-crm-ui-select="$ctrl.insertToken(selection)"
+  />
+</span>

--- a/ext/search_kit/ang/crmSearchAdmin/displays/colType/field.html
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/colType/field.html
@@ -17,7 +17,7 @@
     {{:: ts('Tooltip') }}
   </label>
   <input class="form-control crm-flex-1" type="text" ng-model="col.title" ng-if="col.title" ng-model-options="{updateOn: 'blur'}" />
-  <crm-search-admin-token-select ng-if="col.title" api-entity="$ctrl.apiEntity" api-params="$ctrl.apiParams" model="col" field="title"></crm-search-admin-token-select>
+  <crm-search-admin-token-select ng-if="col.title" model="col" field="title" suffix=":label"></crm-search-admin-token-select>
 </div>
 <div class="form-inline crm-search-admin-flex-row">
   <label title="{{ ts('Change the contents of this field, or combine multiple field values.') }}">
@@ -25,7 +25,7 @@
     {{:: ts('Rewrite') }}
   </label>
   <input type="text" class="form-control crm-flex-1" ng-if="col.rewrite" ng-model="col.rewrite" ng-model-options="{updateOn: 'blur'}">
-  <crm-search-admin-token-select ng-if="col.rewrite" api-entity="$ctrl.apiEntity" api-params="$ctrl.apiParams" model="col" field="rewrite"></crm-search-admin-token-select>
+  <crm-search-admin-token-select ng-if="col.rewrite" model="col" field="rewrite" suffix=":label"></crm-search-admin-token-select>
 </div>
 <div class="form-inline">
   <label ng-if="$ctrl.parent.isEditable(col)" title="{{:: ts('Users will be able to click to edit this field.') }}">

--- a/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayList.html
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayList.html
@@ -49,7 +49,7 @@
           {{:: ts('Label') }}
         </label>
         <input ng-if="col.label" class="form-control crm-flex-1" type="text" ng-model="col.label" ng-model-options="{updateOn: 'blur'}">
-        <crm-search-admin-token-select ng-if="col.label" api-entity="$ctrl.apiEntity" api-params="$ctrl.apiParams" model="col" field="label"></crm-search-admin-token-select>
+        <crm-search-admin-token-select ng-if="col.label" model="col" field="label" suffix=":label"></crm-search-admin-token-select>
       </div>
       <div class="form-inline" ng-if="col.label">
         <label style="visibility: hidden"><input type="checkbox" disabled></label><!--To indent by 1 checkbox-width-->

--- a/ext/search_kit/ang/crmSearchDisplay/colType/buttons.html
+++ b/ext/search_kit/ang/crmSearchDisplay/colType/buttons.html
@@ -1,6 +1,6 @@
 <span ng-repeat="item in col.links">
   <a class="btn {{:: col.size }} btn-{{:: item.style }}" target="{{:: item.target }}" href="{{:: displayUtils.getUrl(item.path, row) }}">
     <i ng-if=":: item.icon" class="crm-i {{:: item.icon }}"></i>
-    {{:: item.text }}
+    {{:: $ctrl.replaceTokens(item.text, row) }}
   </a>
 </span>

--- a/ext/search_kit/ang/crmSearchDisplay/colType/links.html
+++ b/ext/search_kit/ang/crmSearchDisplay/colType/links.html
@@ -1,6 +1,6 @@
 <span ng-repeat="item in col.links">
   <a class="text-{{:: item.style }}" target="{{:: item.target }}" href="{{:: displayUtils.getUrl(item.path, row) }}">
     <i ng-if=":: item.icon" class="crm-i {{:: item.icon }}"></i>
-    {{:: item.text }}
+    {{:: $ctrl.replaceTokens(item.text, row) }}
   </a>
 </span>

--- a/ext/search_kit/ang/crmSearchDisplay/colType/menu.html
+++ b/ext/search_kit/ang/crmSearchDisplay/colType/menu.html
@@ -7,7 +7,7 @@
     <li ng-repeat="item in col.links" class="bg-{{:: item.style }}">
       <a href="{{:: displayUtils.getUrl(item.path, row) }}" target="{{:: item.target }}">
         <i ng-if=":: item.icon" class="crm-i {{:: item.icon }}"></i>
-        {{:: item.text }}
+        {{:: $ctrl.replaceTokens(item.text, row) }}
       </a>
     </li>
   </ul>

--- a/ext/search_kit/ang/crmSearchDisplayList/crmSearchDisplayList.component.js
+++ b/ext/search_kit/ang/crmSearchDisplayList/crmSearchDisplayList.component.js
@@ -61,6 +61,10 @@
         return searchDisplayUtils.formatDisplayValue(rowData, col.key, ctrl.settings.columns);
       };
 
+      this.replaceTokens = function(value, row, raw) {
+        return searchDisplayUtils.replaceTokens(value, row, raw ? null : ctrl.settings.columns);
+      };
+
       this.getLinks = function(rowData, col) {
         rowData._links = rowData._links || {};
         if (!(col.key in rowData._links)) {

--- a/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTable.component.js
+++ b/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTable.component.js
@@ -109,6 +109,10 @@
         return searchDisplayUtils.formatDisplayValue(rowData, col.key, ctrl.settings.columns);
       };
 
+      this.replaceTokens = function(value, row, raw) {
+        return searchDisplayUtils.replaceTokens(value, row, raw ? null : ctrl.settings.columns);
+      };
+
       this.getLinks = function(rowData, col) {
         rowData._links = rowData._links || {};
         if (!(col.key in rowData._links)) {


### PR DESCRIPTION
Overview
----------------------------------------
Improves SearchDisplay support for tokens (in link URLs, list labels, and rewritten fields).

Before
----------------------------------------
Only fields present in the SELECT clause could be tokens. And the selector didn't do a good job of differentiating the fields of multiple entities e.g. a search for Contact with Related Contacts would look like this:

![image](https://user-images.githubusercontent.com/2874912/125998437-6f7613b3-310d-43ca-b4a0-4320aeb6be32.png)

After
----------------------------------------
Any field can be used as a token.
The `SearchDisplay::Run` API will add any fields used as tokens to the SELECT automatically.

![image](https://user-images.githubusercontent.com/2874912/125998301-65d7eb59-fcb9-4c16-8d7d-a17649fcbcaa.png)

Comments
----------------------------------------
The new token selector depends on #20879 (merged).