### PR TITLE
don't allow multiple currencies in a batch

### DIFF
--- a/CRM/Batch/BAO/Batch.php
+++ b/CRM/Batch/BAO/Batch.php
@@ -329,16 +329,7 @@ class CRM_Batch_BAO_Batch extends CRM_Batch_DAO_Batch {
         $values['id']
       );
       // CRM-21205
-      $values['currency'] = CRM_Core_DAO::singleValueQuery("
-        SELECT GROUP_CONCAT(DISTINCT ft.currency)
-        FROM  civicrm_batch batch
-        JOIN civicrm_entity_batch eb
-          ON batch.id = eb.batch_id
-        JOIN civicrm_financial_trxn ft
-          ON eb.entity_id = ft.id
-        WHERE batch.id = %1
-        GROUP BY batch.id
-      ", [1 => [$values['id'], 'Positive']]);
+      $values['currency'] = CRM_Batch_BAO_EntityBatch::getBatchCurrency($values['id']);
       $results[$values['id']] = $values;
     }
 

--- a/CRM/Batch/BAO/EntityBatch.php
+++ b/CRM/Batch/BAO/EntityBatch.php
@@ -23,6 +23,35 @@ class CRM_Batch_BAO_EntityBatch extends CRM_Batch_DAO_EntityBatch {
    * @return CRM_Batch_DAO_EntityBatch
    */
   public static function create($params) {
+    // Only write the EntityBatch record if the financial trxn and batch match on currency and payment instrument.
+    $batchId = $params['batch_id'] ?? NULL;
+    $entityId = $params['entity_id'] ?? NULL;
+    // Not having a batch ID and entity ID is only acceptable on an update.
+    if (!$batchId) {
+      $existingEntityBatch = \Civi\Api4\EntityBatch::get(FALSE)
+        ->addSelect('id', '=', $params['id'])
+        ->execute()
+        ->first();
+      $batchId = $existingEntityBatch['batch_id'] ?? NULL;
+      $entityId = $existingEntityBatch['entity_id'] ?? NULL;
+    }
+    // There should never be a legitimate case where a record has an ID but no batch ID but SyntaxConformanceTest says otherwise.
+    if ($batchId) {
+      $batchCurrency = self::getBatchCurrency($batchId);
+      $batchPID = (int) CRM_Core_DAO::getFieldValue('CRM_Batch_DAO_Batch', $batchId, 'payment_instrument_id');
+      $trxn = \Civi\Api4\FinancialTrxn::get(FALSE)
+        ->addSelect('currency', 'payment_instrument_id')
+        ->addWhere('id', '=', $entityId)
+        ->execute()
+        ->first();
+      if ($batchCurrency && $batchCurrency !== $trxn['currency']) {
+        throw new \CRM_Core_Exception(ts('You can not add items of two different currencies to a single contribution batch.'));
+      }
+      if ($batchPID && $trxn && $batchPID !== $trxn['payment_instrument_id']) {
+        $paymentInstrument = CRM_Core_PseudoConstant::getLabel('CRM_Batch_BAO_Batch', 'payment_instrument_id', $batchPID);
+        throw new \CRM_Core_Exception(ts('This batch is configured to include only transactions using %1 payment method. If you want to include other transactions, please edit the batch first and modify the Payment Method.', [1 => $paymentInstrument]));
+      }
+    }
     return self::writeRecord($params);
   }
 
@@ -37,6 +66,30 @@ class CRM_Batch_BAO_EntityBatch extends CRM_Batch_DAO_EntityBatch {
       $params = ['id' => $params];
     }
     return self::deleteRecord($params);
+  }
+
+  /**
+   * Get the currency associated with a batch (if any).
+   *
+   * @param int $batchId
+   *
+   */
+  public static function getBatchCurrency($batchId) : ?string {
+    $sql = "SELECT DISTINCT ft.currency
+      FROM  civicrm_batch batch
+      JOIN civicrm_entity_batch eb
+        ON batch.id = eb.batch_id
+      JOIN civicrm_financial_trxn ft
+        ON eb.entity_id = ft.id
+      WHERE batch.id = %1";
+    $dao = CRM_Core_DAO::executeQuery($sql, [1 => [$batchId, 'Positive']]);
+    if ($dao->N === 0) {
+      return NULL;
+    }
+    else {
+      $dao->fetch();
+      return $dao->currency;
+    }
   }
 
 }


### PR DESCRIPTION
https://lab.civicrm.org/dev/financial/-/issues/89

Overview
----------------------------------------
Adding multiple currencies to a batch results in dataTables errors when viewing a list of batches.

#### Steps to replicate
* Enable at least two currencies.
* Create two contributions of different currencies.
* Create a new accounting batch.
* Add both contributions to the batch.
* Close the batch.
* Go to **Contributions menu » Accounting Batches » Closed Batches**.

Before
----------------------------------------
dataTables error.

After
----------------------------------------
No dataTables error - but more importantly - you are no longer allowed to add a contribution that doesn't match the currency of existing transactions in the batch.

Comments
----------------------------------------
When I went to make this change, I saw a lot of code quality issues and ended up doing a fair amount of refactoring in the process:
* I extracted the SQL that gets a batch currency to its own method.
* The old SQL handled the possibility of multiple currencies, but in a way that generated an error.  Since multiple currencies are no longer possible, I simplified the SQL.
* The validation specifying that the trxn's payment instrument must match the batch was being done at the AJAX level, and precluded other validations. I moved "payment instrument" validation to the BAO (alongside the new "currency" validation) and implemented exceptions.  This also reduced the copy/paste between `CRM_Financial_Page_AJAX::assignRemove()` and `CRM_Financial_Page_AJAX::bulkAssignRemove()`.

@JoeMurray you had this ticket assigned to yourself so I imagine you have some interest in this.