### PR TITLE
SearchKit - Add links to view/edit/delete relationships

### DIFF
--- a/Civi/Api4/RelationshipCache.php
+++ b/Civi/Api4/RelationshipCache.php
@@ -45,6 +45,7 @@ class RelationshipCache extends Generic\AbstractEntity {
    */
   public static function getInfo() {
     $info = parent::getInfo();
+    $info['bridge_title'] = ts('Relationship');
     $info['bridge'] = [
       'near_contact_id' => ['description' => ts('One or more contacts with a relationship to this contact')],
       'far_contact_id' => ['description' => ts('One or more contacts with a relationship to this contact')],

--- a/ext/search_kit/Civi/Search/Admin.php
+++ b/ext/search_kit/Civi/Search/Admin.php
@@ -82,7 +82,7 @@ class Admin {
   public static function getSchema() {
     $schema = [];
     $entities = \Civi\Api4\Entity::get()
-      ->addSelect('name', 'title', 'type', 'primary_key', 'title_plural', 'description', 'label_field', 'icon', 'paths', 'dao', 'bridge', 'ui_join_filters', 'searchable')
+      ->addSelect('name', 'title', 'title_plural', 'bridge_title', 'type', 'primary_key', 'description', 'label_field', 'icon', 'paths', 'dao', 'bridge', 'ui_join_filters', 'searchable')
       ->addWhere('searchable', '!=', 'none')
       ->addOrderBy('title_plural')
       ->setChain([

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminDisplay.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminDisplay.component.js
@@ -264,12 +264,20 @@
         // Links to explicitly joined entities
         _.each(ctrl.savedSearch.api_params.join, function(joinClause) {
           var join = searchMeta.getJoin(joinClause[0]),
-            joinEntity = searchMeta.getEntity(join.entity);
+            joinEntity = searchMeta.getEntity(join.entity),
+            bridgeEntity = _.isString(joinClause[2]) ? searchMeta.getEntity(joinClause[2]) : null;
           _.each(joinEntity.paths, function(path) {
             var link = _.cloneDeep(path);
             link.path = link.path.replace(/\[/g, '[' + join.alias + '.');
             link.join = join.alias;
             addTitle(link, join.label);
+            links.push(link);
+          });
+          _.each(bridgeEntity && bridgeEntity.paths, function(path) {
+            var link = _.cloneDeep(path);
+            link.path = link.path.replace(/\[/g, '[' + join.alias + '.');
+            link.join = join.alias;
+            addTitle(link, join.label + (bridgeEntity.bridge_title ? ' ' + bridgeEntity.bridge_title : ''));
             links.push(link);
           });
         });


### PR DESCRIPTION
Overview
----------------------------------------
Adds links to view/edit/delete the relationship when joining on related contacts.

Before
----------------------------------------
Links available to view/edit/delete the related contact, but not the relationship itself.

After
----------------------------------------
![image](https://user-images.githubusercontent.com/2874912/126020572-f3e2d801-990d-47e4-a7f1-7231d3d5326e.png)



Comments
----------------------------------------
The phrasing of the link labels is cumbersome, I know, but it had to be a) clear which base contact (there could be many) and which relationship (ditto), and b) metadata-based and c) translatable.

To fully function, this PR depends on #20883 and #20880