### PR TITLE
dev/core#2666 - Don't repeatedly log about crm-l10n.js during upgrade

### DIFF
--- a/Civi/Core/AssetBuilder.php
+++ b/Civi/Core/AssetBuilder.php
@@ -195,7 +195,10 @@ class AssetBuilder {
       }
       catch (UnknownAssetException $e) {
         // unexpected error, log and continue
-        \Civi::log()->error('Unexpected error while rendering a file in the AssetBuilder: ' . $e->getMessage(), ['exception' => $e]);
+        // except during upgrade since this repeatedly logs about l10n for each individual upgrade task
+        if ($e->getMessage() !== 'Unrecognized asset name: crm-l10n.js' || !\CRM_Core_Config::isUpgradeMode()) {
+          \Civi::log()->error('Unexpected error while rendering a file in the AssetBuilder: ' . $e->getMessage(), ['exception' => $e]);
+        }
       }
     }
     return $fileName;


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/2666

Before
----------------------------------------
For each individual task in the upgrade, there's an exception dump also logged for crm-l10n.js and it seems to be meaningless.

After
----------------------------------------
Just the upgrade steps logged.

Technical Details
----------------------------------------
I've put it against 5.40 since it seems to have come from https://github.com/civicrm/civicrm-core/pull/20121 which was in May. Before that, l10n.js wasn't generated by the asset builder so it didn't come up.

Comments
----------------------------------------
The inability to generate the file doesn't seem to affect upgrades on non-english sites. They still work as normal.

Note this may only be an issue for the UI upgrader. You may not see it if using `cv`.

An alternate is at https://github.com/civicrm/civicrm-core/pull/20890