### PR TITLE
[REF] Add in smarty modifier to replcae the upper smarty modifier to …

### DIFF
--- a/CRM/Core/Smarty/plugins/modifier.crmUpper.php
+++ b/CRM/Core/Smarty/plugins/modifier.crmUpper.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+/**
+ * Upper case a string but use the multibyte strtoupper function to better handle accents / umlaut
+ *
+ * @param string $string the string to upper case
+ *
+ * @return string
+ */
+function smarty_modifier_crmUpper($string): string {
+  return mb_strtoupper($string);
+}

--- a/templates/CRM/Event/Form/Participant.tpl
+++ b/templates/CRM/Event/Form/Participant.tpl
@@ -28,7 +28,7 @@
     <div class="view-content">
       {if !empty($participantMode)}
         <div class="help">
-          {ts 1=$displayName 2=$participantMode|upper}Use this form to submit an event registration on behalf of %1. <strong>A %2 transaction will be submitted</strong> using the selected payment processor.{/ts}
+          {ts 1=$displayName 2=$participantMode|crmUpper}Use this form to submit an event registration on behalf of %1. <strong>A %2 transaction will be submitted</strong> using the selected payment processor.{/ts}
         </div>
       {/if}
       <div id="eventFullMsg" class="messages status no-popup" style="display:none;"></div>

--- a/templates/CRM/Report/Form/Contact/Detail.tpl
+++ b/templates/CRM/Report/Form/Contact/Detail.tpl
@@ -110,7 +110,7 @@
                             {assign var=componentContactId value=$row.contactID}
                             {foreach from=$columnHeadersComponent item=pheader key=component}
                                 {if $componentRows.$componentContactId.$component}
-                                    <h3>{$component|replace:'_civireport':''|upper}</h3>
+                                    <h3>{$component|replace:'_civireport':''|crmUpper}</h3>
                           <table class="report-layout crm-report_{$component}">
                               {*add space before headers*}
                             <tr>


### PR DESCRIPTION
…better handle umlouts / accents

Overview
----------------------------------------
This creates a smarty modifier plugin to replace the standard smarty upper one but to be better for multibyte strings such as those with accents/umoults

Before
----------------------------------------
Only upper case plugin is a smarty one that doesn't handle multibyte strings well

After
----------------------------------------
CiviCRM Smarty plugin avaliable for upper casing string with multibyte support

ping @demeritcowboy @Anatoleallain @mlutfy 

see also https://github.com/civicrm/civicrm-packages/pull/325 and https://civicrm.stackexchange.com/questions/39967/upper-case-in-name-with-accents