### PR TITLE
APIv4 - Fix and add tests for comparison SQL functions

### DIFF
--- a/Civi/Api4/Query/SqlFunctionABS.php
+++ b/Civi/Api4/Query/SqlFunctionABS.php
@@ -20,7 +20,6 @@ class SqlFunctionABS extends SqlFunction {
 
   protected static $params = [
     [
-      'expr' => 1,
       'optional' => FALSE,
       'must_be' => ['SqlField', 'SqlNumber'],
     ],

--- a/Civi/Api4/Query/SqlFunctionAVG.php
+++ b/Civi/Api4/Query/SqlFunctionAVG.php
@@ -21,7 +21,6 @@ class SqlFunctionAVG extends SqlFunction {
   protected static $params = [
     [
       'prefix' => ['', 'DISTINCT', 'ALL'],
-      'expr' => 1,
       'must_be' => ['SqlField'],
     ],
   ];

--- a/Civi/Api4/Query/SqlFunctionCOALESCE.php
+++ b/Civi/Api4/Query/SqlFunctionCOALESCE.php
@@ -20,7 +20,7 @@ class SqlFunctionCOALESCE extends SqlFunction {
 
   protected static $params = [
     [
-      'expr' => 99,
+      'max_expr' => 99,
       'optional' => FALSE,
     ],
   ];

--- a/Civi/Api4/Query/SqlFunctionCOALESCE.php
+++ b/Civi/Api4/Query/SqlFunctionCOALESCE.php
@@ -32,4 +32,17 @@ class SqlFunctionCOALESCE extends SqlFunction {
     return ts('Coalesce');
   }
 
+  /**
+   * Prevent reformatting
+   *
+   * @see \Civi\Api4\Utils\FormattingUtil::formatOutputValues
+   * @param string $value
+   * @param string $dataType
+   * @return string|array
+   */
+  public function formatOutputValue($value, &$dataType) {
+    $dataType = NULL;
+    return $value;
+  }
+
 }

--- a/Civi/Api4/Query/SqlFunctionCONCAT.php
+++ b/Civi/Api4/Query/SqlFunctionCONCAT.php
@@ -20,7 +20,7 @@ class SqlFunctionCONCAT extends SqlFunction {
 
   protected static $params = [
     [
-      'expr' => 99,
+      'max_expr' => 99,
       'optional' => FALSE,
       'must_be' => ['SqlField', 'SqlString'],
     ],

--- a/Civi/Api4/Query/SqlFunctionCOUNT.php
+++ b/Civi/Api4/Query/SqlFunctionCOUNT.php
@@ -21,7 +21,7 @@ class SqlFunctionCOUNT extends SqlFunction {
   protected static $params = [
     [
       'prefix' => ['', 'DISTINCT', 'ALL'],
-      'expr' => 1,
+      'max_expr' => 1,
       'must_be' => ['SqlField', 'SqlWild'],
       'cant_be' => [],
     ],

--- a/Civi/Api4/Query/SqlFunctionCOUNT.php
+++ b/Civi/Api4/Query/SqlFunctionCOUNT.php
@@ -28,7 +28,7 @@ class SqlFunctionCOUNT extends SqlFunction {
   ];
 
   /**
-   * Reformat result as array if using default separator
+   * Reformat result as integer
    *
    * @see \Civi\Api4\Utils\FormattingUtil::formatOutputValues
    * @param string $value

--- a/Civi/Api4/Query/SqlFunctionGREATEST.php
+++ b/Civi/Api4/Query/SqlFunctionGREATEST.php
@@ -22,7 +22,7 @@ class SqlFunctionGREATEST extends SqlFunction {
 
   protected static $params = [
     [
-      'expr' => 99,
+      'max_expr' => 99,
       'optional' => FALSE,
     ],
   ];

--- a/Civi/Api4/Query/SqlFunctionGROUP_CONCAT.php
+++ b/Civi/Api4/Query/SqlFunctionGROUP_CONCAT.php
@@ -23,20 +23,20 @@ class SqlFunctionGROUP_CONCAT extends SqlFunction {
   protected static $params = [
     [
       'prefix' => ['', 'DISTINCT', 'ALL'],
-      'expr' => 1,
+      'max_expr' => 1,
       'must_be' => ['SqlField', 'sqlFunction'],
       'optional' => FALSE,
     ],
     [
       'prefix' => ['ORDER BY'],
-      'expr' => 1,
+      'max_expr' => 1,
       'suffix' => ['', 'ASC', 'DESC'],
       'must_be' => ['SqlField'],
       'optional' => TRUE,
     ],
     [
       'prefix' => ['SEPARATOR'],
-      'expr' => 1,
+      'max_expr' => 1,
       'must_be' => ['SqlString'],
       'optional' => TRUE,
       // @see self::formatOutput()

--- a/Civi/Api4/Query/SqlFunctionIF.php
+++ b/Civi/Api4/Query/SqlFunctionIF.php
@@ -20,7 +20,8 @@ class SqlFunctionIF extends SqlFunction {
 
   protected static $params = [
     [
-      'expr' => 3,
+      'min_expr' => 3,
+      'max_expr' => 3,
       'optional' => FALSE,
     ],
   ];

--- a/Civi/Api4/Query/SqlFunctionIF.php
+++ b/Civi/Api4/Query/SqlFunctionIF.php
@@ -14,15 +14,13 @@ namespace Civi\Api4\Query;
 /**
  * Sql function
  */
-class SqlFunctionNULLIF extends SqlFunction {
-
-  public $supportsExpansion = TRUE;
+class SqlFunctionIF extends SqlFunction {
 
   protected static $category = self::CATEGORY_COMPARISON;
 
   protected static $params = [
     [
-      'expr' => 2,
+      'expr' => 3,
       'optional' => FALSE,
     ],
   ];
@@ -31,7 +29,20 @@ class SqlFunctionNULLIF extends SqlFunction {
    * @return string
    */
   public static function getTitle(): string {
-    return ts('Null if');
+    return ts('If');
+  }
+
+  /**
+   * Prevent formatting based on first field
+   *
+   * @see \Civi\Api4\Utils\FormattingUtil::formatOutputValues
+   * @param string $value
+   * @param string $dataType
+   * @return string|array
+   */
+  public function formatOutputValue($value, &$dataType) {
+    $dataType = NULL;
+    return $value;
   }
 
 }

--- a/Civi/Api4/Query/SqlFunctionISNULL.php
+++ b/Civi/Api4/Query/SqlFunctionISNULL.php
@@ -32,4 +32,18 @@ class SqlFunctionISNULL extends SqlFunction {
     return ts('Is null');
   }
 
+  /**
+   * Reformat result as boolean
+   *
+   * @see \Civi\Api4\Utils\FormattingUtil::formatOutputValues
+   * @param string $value
+   * @param string $dataType
+   * @return string|array
+   */
+  public function formatOutputValue($value, &$dataType) {
+    // Value is always TRUE or FALSE
+    $dataType = 'Boolean';
+    return $value;
+  }
+
 }

--- a/Civi/Api4/Query/SqlFunctionISNULL.php
+++ b/Civi/Api4/Query/SqlFunctionISNULL.php
@@ -20,7 +20,6 @@ class SqlFunctionISNULL extends SqlFunction {
 
   protected static $params = [
     [
-      'expr' => 1,
       'optional' => FALSE,
     ],
   ];

--- a/Civi/Api4/Query/SqlFunctionLEAST.php
+++ b/Civi/Api4/Query/SqlFunctionLEAST.php
@@ -22,7 +22,7 @@ class SqlFunctionLEAST extends SqlFunction {
 
   protected static $params = [
     [
-      'expr' => 99,
+      'max_expr' => 99,
       'optional' => FALSE,
     ],
   ];

--- a/Civi/Api4/Query/SqlFunctionLOWER.php
+++ b/Civi/Api4/Query/SqlFunctionLOWER.php
@@ -20,7 +20,6 @@ class SqlFunctionLOWER extends SqlFunction {
 
   protected static $params = [
     [
-      'expr' => 1,
       'optional' => FALSE,
       'must_be' => ['SqlField', 'SqlString'],
     ],

--- a/Civi/Api4/Query/SqlFunctionMAX.php
+++ b/Civi/Api4/Query/SqlFunctionMAX.php
@@ -23,7 +23,6 @@ class SqlFunctionMAX extends SqlFunction {
   protected static $params = [
     [
       'prefix' => ['', 'DISTINCT', 'ALL'],
-      'expr' => 1,
       'must_be' => ['SqlField'],
     ],
   ];

--- a/Civi/Api4/Query/SqlFunctionMIN.php
+++ b/Civi/Api4/Query/SqlFunctionMIN.php
@@ -23,7 +23,6 @@ class SqlFunctionMIN extends SqlFunction {
   protected static $params = [
     [
       'prefix' => ['', 'DISTINCT', 'ALL'],
-      'expr' => 1,
       'must_be' => ['SqlField'],
     ],
   ];

--- a/Civi/Api4/Query/SqlFunctionNULLIF.php
+++ b/Civi/Api4/Query/SqlFunctionNULLIF.php
@@ -22,7 +22,8 @@ class SqlFunctionNULLIF extends SqlFunction {
 
   protected static $params = [
     [
-      'expr' => 2,
+      'min_expr' => 2,
+      'max_expr' => 2,
       'optional' => FALSE,
     ],
   ];

--- a/Civi/Api4/Query/SqlFunctionREPLACE.php
+++ b/Civi/Api4/Query/SqlFunctionREPLACE.php
@@ -20,17 +20,14 @@ class SqlFunctionREPLACE extends SqlFunction {
 
   protected static $params = [
     [
-      'expr' => 1,
       'optional' => FALSE,
       'must_be' => ['SqlField', 'SqlString'],
     ],
     [
-      'expr' => 1,
       'optional' => FALSE,
       'must_be' => ['SqlField', 'SqlString'],
     ],
     [
-      'expr' => 1,
       'optional' => FALSE,
       'must_be' => ['SqlField', 'SqlString'],
     ],

--- a/Civi/Api4/Query/SqlFunctionROUND.php
+++ b/Civi/Api4/Query/SqlFunctionROUND.php
@@ -20,12 +20,10 @@ class SqlFunctionROUND extends SqlFunction {
 
   protected static $params = [
     [
-      'expr' => 1,
       'optional' => FALSE,
       'must_be' => ['SqlField', 'SqlNumber'],
     ],
     [
-      'expr' => 1,
       'optional' => TRUE,
       'must_be' => ['SqlNumber'],
     ],

--- a/Civi/Api4/Query/SqlFunctionSUM.php
+++ b/Civi/Api4/Query/SqlFunctionSUM.php
@@ -21,7 +21,6 @@ class SqlFunctionSUM extends SqlFunction {
   protected static $params = [
     [
       'prefix' => ['', 'DISTINCT', 'ALL'],
-      'expr' => 1,
       'must_be' => ['SqlField'],
     ],
   ];

--- a/Civi/Api4/Query/SqlFunctionUPPER.php
+++ b/Civi/Api4/Query/SqlFunctionUPPER.php
@@ -20,7 +20,6 @@ class SqlFunctionUPPER extends SqlFunction {
 
   protected static $params = [
     [
-      'expr' => 1,
       'optional' => FALSE,
       'must_be' => ['SqlField', 'SqlString'],
     ],

--- a/tests/phpunit/api/v4/Action/SqlFunctionTest.php
+++ b/tests/phpunit/api/v4/Action/SqlFunctionTest.php
@@ -20,6 +20,7 @@
 namespace api\v4\Action;
 
 use api\v4\UnitTestCase;
+use Civi\Api4\Activity;
 use Civi\Api4\Contact;
 use Civi\Api4\Contribution;
 
@@ -129,6 +130,50 @@ class SqlFunctionTest extends UnitTestCase {
     $this->assertEquals(100, $result[0]['MIN:total_amount']);
     $this->assertEquals(2, $result[0]['count']);
     $this->assertEquals(1, $result[1]['count']);
+  }
+
+  public function testComparisonFunctions() {
+    $cid = Contact::create(FALSE)
+      ->addValue('first_name', 'hello')
+      ->execute()->first()['id'];
+    $sampleData = [
+      ['subject' => 'abc', 'activity_type_id:name' => 'Meeting', 'source_contact_id' => $cid, 'duration' => 123, 'location' => 'abc'],
+      ['subject' => 'xyz', 'activity_type_id:name' => 'Meeting', 'source_contact_id' => $cid, 'location' => 'abc', 'is_deleted' => 1],
+      ['subject' => 'def', 'activity_type_id:name' => 'Meeting', 'source_contact_id' => $cid, 'duration' => 456, 'location' => 'abc'],
+    ];
+    $aids = Activity::save(FALSE)
+      ->setRecords($sampleData)
+      ->execute()->column('id');
+
+    $result = Activity::get(FALSE)
+      ->addWhere('id', 'IN', $aids)
+      ->addSelect('IF(is_deleted, "Trash", "No Trash") AS trashed')
+      ->addSelect('NULLIF(subject, location) AS subject_is_location')
+      ->addSelect('NULLIF(duration, 456) AS duration_not_456')
+      ->addSelect('COALESCE(duration, location) AS duration_or_location')
+      ->addSelect('GREATEST(duration, 0200) AS duration_or_200')
+      ->addSelect('LEAST(duration, 300) AS 300_or_duration')
+      ->addSelect('ISNULL(duration) AS duration_isnull')
+      ->addOrderBy('id')
+      ->execute()->indexBy('id');
+
+    $this->assertCount(3, $result);
+    $this->assertEquals('No Trash', $result[$aids[0]]['trashed']);
+    $this->assertEquals('Trash', $result[$aids[1]]['trashed']);
+    $this->assertEquals('No Trash', $result[$aids[2]]['trashed']);
+    $this->assertEquals(NULL, $result[$aids[0]]['subject_is_location']);
+    $this->assertEquals('xyz', $result[$aids[1]]['subject_is_location']);
+    $this->assertEquals('def', $result[$aids[2]]['subject_is_location']);
+    $this->assertEquals(123, $result[$aids[0]]['duration_not_456']);
+    $this->assertEquals(NULL, $result[$aids[1]]['duration_not_456']);
+    $this->assertEquals(NULL, $result[$aids[2]]['duration_not_456']);
+    $this->assertEquals('123', $result[$aids[0]]['duration_or_location']);
+    $this->assertEquals('abc', $result[$aids[1]]['duration_or_location']);
+    $this->assertEquals(123, $result[$aids[0]]['300_or_duration']);
+    $this->assertEquals(300, $result[$aids[2]]['300_or_duration']);
+    $this->assertEquals(FALSE, $result[$aids[0]]['duration_isnull']);
+    $this->assertEquals(TRUE, $result[$aids[1]]['duration_isnull']);
+    $this->assertEquals(FALSE, $result[$aids[2]]['duration_isnull']);
   }
 
 }

--- a/tests/phpunit/api/v4/Action/SqlFunctionTest.php
+++ b/tests/phpunit/api/v4/Action/SqlFunctionTest.php
@@ -34,7 +34,8 @@ class SqlFunctionTest extends UnitTestCase {
     $this->assertArrayHasKey('SUM', $functions);
     $this->assertArrayNotHasKey('', $functions);
     $this->assertArrayNotHasKey('SqlFunction', $functions);
-    $this->assertEquals(1, $functions['MAX']['params'][0]['expr']);
+    $this->assertEquals(1, $functions['MAX']['params'][0]['min_expr']);
+    $this->assertEquals(1, $functions['MAX']['params'][0]['max_expr']);
   }
 
   public function testGroupAggregates() {
@@ -174,6 +175,28 @@ class SqlFunctionTest extends UnitTestCase {
     $this->assertEquals(FALSE, $result[$aids[0]]['duration_isnull']);
     $this->assertEquals(TRUE, $result[$aids[1]]['duration_isnull']);
     $this->assertEquals(FALSE, $result[$aids[2]]['duration_isnull']);
+  }
+
+  public function testIncorrectNumberOfArguments() {
+    try {
+      Activity::get(FALSE)
+        ->addSelect('IF(is_deleted) AS whoops')
+        ->execute();
+      $this->fail('Api should have thrown exception');
+    }
+    catch (\API_Exception $e) {
+      $this->assertEquals('Incorrect number of arguments for SQL function IF', $e->getMessage());
+    }
+
+    try {
+      Activity::get(FALSE)
+        ->addSelect('NULLIF(is_deleted, 1, 2) AS whoops')
+        ->execute();
+      $this->fail('Api should have thrown exception');
+    }
+    catch (\API_Exception $e) {
+      $this->assertEquals('Incorrect number of arguments for SQL function NULLIF', $e->getMessage());
+    }
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Improves support for comparison functions in APIv4

Before
----------------------------------------
Functions exist but no tests

After
----------------------------------------
Tests added which revealed some bugs. Now fixed.
Also added validation for the number of args passed to sql functions, with a test.
