### PR TITLE
APIv4 - Better handling of output value using GROUP_CONCAT

### DIFF
--- a/Civi/Api4/Query/SqlFunctionCONCAT.php
+++ b/Civi/Api4/Query/SqlFunctionCONCAT.php
@@ -33,4 +33,17 @@ class SqlFunctionCONCAT extends SqlFunction {
     return ts('Combine');
   }
 
+  /**
+   * Prevent reformatting of result
+   *
+   * @see \Civi\Api4\Utils\FormattingUtil::formatOutputValues
+   * @param string $value
+   * @param string $dataType
+   * @return string|array
+   */
+  public function formatOutputValue($value, &$dataType) {
+    $dataType = NULL;
+    return $value;
+  }
+
 }

--- a/Civi/Api4/Query/SqlFunctionGROUP_CONCAT.php
+++ b/Civi/Api4/Query/SqlFunctionGROUP_CONCAT.php
@@ -59,9 +59,9 @@ class SqlFunctionGROUP_CONCAT extends SqlFunction {
     // By default, values are split into an array and formatted according to the field's dataType
     if (!$exprArgs[2]['prefix']) {
       $value = explode(\CRM_Core_DAO::VALUE_SEPARATOR, $value);
-      // If the first expression is another sqlFunction then unset $dataType to preserve raw string
-      if ($exprArgs[0]['expr'][0] instanceof SqlFunction) {
-        $dataType = NULL;
+      // If the first expression is another sqlFunction, allow it to control the dataType
+      if ($exprArgs[0]['expr'][0] instanceof SqlFunction && is_callable([$exprArgs[0]['expr'][0], 'formatOutputValue'])) {
+        $exprArgs[0]['expr'][0]->formatOutputValue(NULL, $dataType);
       }
     }
     // If using custom separator, unset $dataType to preserve raw string


### PR DESCRIPTION
Overview
----------------------------------------
Followup to #20655 to improve output formatting of the GROUP_CONCAT sql function in APIv4

Before
----------------------------------------
Output formatting disabled if function nested within function

After
----------------------------------------
Output formatting controlled by the inner function
