### PR TITLE
[REF] Refactor SearchKit displays to inherit traits from a common base

### DIFF
--- a/ext/search_kit/ang/crmSearchDisplay/Pager.html
+++ b/ext/search_kit/ang/crmSearchDisplay/Pager.html
@@ -4,7 +4,7 @@
       boundary-links="true"
       total-items="$ctrl.rowCount"
       ng-model="$ctrl.page"
-      ng-change="$ctrl.getResults()"
+      ng-change="getResults()"
       items-per-page="$ctrl.settings.limit"
       max-size="6"
       force-ellipses="true"

--- a/ext/search_kit/ang/crmSearchDisplay/colType/buttons.html
+++ b/ext/search_kit/ang/crmSearchDisplay/colType/buttons.html
@@ -1,5 +1,5 @@
 <span ng-repeat="item in col.links">
-  <a class="btn {{:: col.size }} btn-{{:: item.style }}" target="{{:: item.target }}" href="{{:: displayUtils.getUrl(item.path, row) }}">
+  <a class="btn {{:: col.size }} btn-{{:: item.style }}" target="{{:: item.target }}" href="{{:: $ctrl.getUrl(item.path, row) }}">
     <i ng-if=":: item.icon" class="crm-i {{:: item.icon }}"></i>
     {{:: $ctrl.replaceTokens(item.text, row) }}
   </a>

--- a/ext/search_kit/ang/crmSearchDisplay/colType/links.html
+++ b/ext/search_kit/ang/crmSearchDisplay/colType/links.html
@@ -1,5 +1,5 @@
 <span ng-repeat="item in col.links">
-  <a class="text-{{:: item.style }}" target="{{:: item.target }}" href="{{:: displayUtils.getUrl(item.path, row) }}">
+  <a class="text-{{:: item.style }}" target="{{:: item.target }}" href="{{:: $ctrl.getUrl(item.path, row) }}">
     <i ng-if=":: item.icon" class="crm-i {{:: item.icon }}"></i>
     {{:: $ctrl.replaceTokens(item.text, row) }}
   </a>

--- a/ext/search_kit/ang/crmSearchDisplay/colType/menu.html
+++ b/ext/search_kit/ang/crmSearchDisplay/colType/menu.html
@@ -5,7 +5,7 @@
   </button>
   <ul class="dropdown-menu {{ col.alignment === 'text-right' ? 'dropdown-menu-right' : '' }}" ng-if=":: col.open">
     <li ng-repeat="item in col.links" class="bg-{{:: item.style }}">
-      <a href="{{:: displayUtils.getUrl(item.path, row) }}" target="{{:: item.target }}">
+      <a href="{{:: $ctrl.getUrl(item.path, row) }}" target="{{:: item.target }}">
         <i ng-if=":: item.icon" class="crm-i {{:: item.icon }}"></i>
         {{:: $ctrl.replaceTokens(item.text, row) }}
       </a>

--- a/ext/search_kit/ang/crmSearchDisplayList/crmSearchDisplayList.component.js
+++ b/ext/search_kit/ang/crmSearchDisplayList/crmSearchDisplayList.component.js
@@ -14,63 +14,18 @@
       afFieldset: '?^^afFieldset'
     },
     templateUrl: '~/crmSearchDisplayList/crmSearchDisplayList.html',
-    controller: function($scope, $element, crmApi4, searchDisplayUtils) {
+    controller: function($scope, $element, searchDisplayBaseTrait) {
       var ts = $scope.ts = CRM.ts('org.civicrm.search_kit'),
-        ctrl = this;
-
-      this.page = 1;
-      this.rowCount = null;
+        // Mix in properties of searchDisplayBaseTrait
+        ctrl = angular.extend(this, searchDisplayBaseTrait);
 
       this.$onInit = function() {
-        this.sort = this.settings.sort ? _.cloneDeep(this.settings.sort) : [];
-        $scope.displayUtils = searchDisplayUtils;
-
-        // If search is embedded in contact summary tab, display count in tab-header
-        var contactTab = $element.closest('.crm-contact-page .ui-tabs-panel').attr('id');
-        if (contactTab) {
-          var unwatchCount = $scope.$watch('$ctrl.rowCount', function(rowCount) {
-            if (typeof rowCount === 'number') {
-              unwatchCount();
-              CRM.tabHeader.updateCount(contactTab.replace('contact-', '#tab_'), rowCount);
-            }
-          });
-        }
-
-        if (this.afFieldset) {
-          $scope.$watch(this.afFieldset.getFieldData, onChangeFilters, true);
-        }
-        $scope.$watch('$ctrl.filters', onChangeFilters, true);
+        this.initializeDisplay($scope, $element);
       };
-
-      this.getResults = _.debounce(function() {
-        searchDisplayUtils.getResults(ctrl);
-      }, 100);
 
       // Refresh current page
       this.refresh = function(row) {
-        searchDisplayUtils.getResults(ctrl);
-      };
-
-      function onChangeFilters() {
-        ctrl.page = 1;
-        ctrl.rowCount = null;
         ctrl.getResults();
-      }
-
-      this.formatFieldValue = function(rowData, col) {
-        return searchDisplayUtils.formatDisplayValue(rowData, col.key, ctrl.settings.columns);
-      };
-
-      this.replaceTokens = function(value, row, raw) {
-        return searchDisplayUtils.replaceTokens(value, row, raw ? null : ctrl.settings.columns);
-      };
-
-      this.getLinks = function(rowData, col) {
-        rowData._links = rowData._links || {};
-        if (!(col.key in rowData._links)) {
-          rowData._links[col.key] = searchDisplayUtils.formatLinks(rowData, col.key, ctrl.settings.columns);
-        }
-        return rowData._links[col.key];
       };
 
     }

--- a/ext/search_kit/ang/crmSearchDisplayList/crmSearchDisplayListItems.html
+++ b/ext/search_kit/ang/crmSearchDisplayList/crmSearchDisplayListItems.html
@@ -1,7 +1,7 @@
 <li ng-repeat="(rowIndex, row) in $ctrl.results">
-  <div ng-repeat="col in $ctrl.settings.columns" title="{{:: displayUtils.replaceTokens(col.title, row, $ctrl.settings.columns) }}" class="{{:: col.break ? '' : 'crm-inline-block' }}">
+  <div ng-repeat="col in $ctrl.settings.columns" title="{{:: $ctrl.replaceTokens(col.title, row) }}" class="{{:: col.break ? '' : 'crm-inline-block' }}">
     <label ng-if=":: col.label && (col.type !== 'field' || col.forceLabel || row[col.key])">
-      {{:: displayUtils.replaceTokens(col.label, row, $ctrl.settings.columns) }}
+      {{:: $ctrl.replaceTokens(col.label, row) }}
     </label>
     <span ng-include="'~/crmSearchDisplay/colType/' + col.type + '.html'"></span>
   </div>

--- a/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTable.html
+++ b/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTable.html
@@ -1,6 +1,6 @@
 <div class="crm-search-display crm-search-display-table">
   <div class="form-inline" ng-if="$ctrl.settings.actions">
-    <crm-search-tasks entity="$ctrl.apiEntity" ids="$ctrl.selectedRows" refresh="$ctrl.getResults()"></crm-search-tasks>
+    <crm-search-tasks entity="$ctrl.apiEntity" ids="$ctrl.selectedRows" refresh="getResults()"></crm-search-tasks>
   </div>
   <table>
     <thead>
@@ -19,7 +19,7 @@
         <td ng-if=":: $ctrl.settings.actions">
           <input type="checkbox" ng-checked="isRowSelected(row)" ng-click="selectRow(row)" ng-disabled="!(!loadingAllRows && row.id)">
         </td>
-        <td ng-repeat="col in $ctrl.settings.columns" ng-include="'~/crmSearchDisplay/colType/' + col.type + '.html'" title="{{:: displayUtils.replaceTokens(col.title, row, $ctrl.settings.columns) }}" class="{{:: col.alignment }}">
+        <td ng-repeat="col in $ctrl.settings.columns" ng-include="'~/crmSearchDisplay/colType/' + col.type + '.html'" title="{{:: $ctrl.replaceTokens(col.title, row) }}" class="{{:: col.alignment }}">
         </td>
         <td></td>
       </tr>


### PR DESCRIPTION
Overview
----------------------------------------
This refactors the search display code to share common properties & methods using a trait.

Before
----------------------------------------
A lot of code duplication across similar classes.

After
----------------------------------------
Much cleaner.

Technical Details
----------------------------------------
I had always wanted to figure out some way to do class inheritance in Angular but no amount of googling turned up anything useful.
I finally figured out a simple way to do it - the trait is declared with `.factory()`, added with service injection, and mixed in with `angular.extend()`. The result is very similar to PHP Traits.

Check this out: https://gist.github.com/colemanw/a3814f4bb77d1039316512a224fd3444