### PR TITLE
[NFC/Unit test] dev/core#2699 - Fix intermittent api4 test (part 1)

### DIFF
--- a/tests/phpunit/api/v4/Action/BaseCustomValueTest.php
+++ b/tests/phpunit/api/v4/Action/BaseCustomValueTest.php
@@ -31,6 +31,11 @@ abstract class BaseCustomValueTest extends UnitTestCase {
    * @throws \API_Exception
    */
   public function tearDown(): void {
+    $optgroups = CustomField::get(FALSE)->addSelect('option_group_id')->addWhere('option_group_id', 'IS NOT NULL')->execute();
+    foreach ($optgroups as $optgroup) {
+      \Civi\Api4\OptionValue::delete(FALSE)->addWhere('option_group_id', '=', $optgroup['option_group_id'])->execute();
+      \Civi\Api4\OptionGroup::delete(FALSE)->addWhere('id', '=', $optgroup['option_group_id'])->execute();
+    }
     CustomField::delete(FALSE)->addWhere('id', '>', 0)->execute();
     CustomGroup::delete(FALSE)->addWhere('id', '>', 0)->execute();
     parent::tearDown();


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/2699

api.v4.Action.CreateWithOptionGroupTest.testWithCustomDataForMultipleContacts intermittently fails with DB Error: already exists

Before
----------------------------------------
Intermittent fails

After
----------------------------------------
Not intermittent fails. I think the full cause still needs to be addressed, but this seems safe to add in whether more is done or not. 

Technical Details
----------------------------------------
1. The test doesn't clean up the option groups/values.
2. This wasn't as big a problem with this test before 5.40 because a change was made in 5.40 to always create a dummy option group for new custom fields, even for types that don't have option groups. I haven't put this against 5.40 because I'd need to backport some more things, and maybe the whole concept of autocreating groups still needs more so just doing the minimum safe thing right now.
3. It only comes up intermittently because the option group name is based on timestamp, and in a unit test sometimes it's so fast that the timestamp hasn't advanced between tests, so it has a duplicate name.

Comments
----------------------------------------
Is test.

If you want to verify that this fixes it every time, you can apply this patch to freeze time:

```patch
diff --git a/CRM/Core/BAO/CustomField.php b/CRM/Core/BAO/CustomField.php
index ba06f71973..9ace7168ed 100644
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -2014,7 +2014,8 @@ WHERE  id IN ( %1, %2 )
       ) {
         // first create an option group for this custom group
         $optionGroup = new CRM_Core_DAO_OptionGroup();
-        $optionGroup->name = "{$params['column_name']}_" . date('YmdHis');
+        echo \CRM_Utils_Time::date('YmdHis') . "\n";
+        $optionGroup->name = "{$params['column_name']}_" . CRM_Utils_Time::date('YmdHis');
         $optionGroup->title = $params['label'];
         $optionGroup->is_active = 1;
         // Don't set reserved as it's not a built-in option group and may be useful for other custom fields.
diff --git a/tests/phpunit/api/v4/Action/CreateWithOptionGroupTest.php b/tests/phpunit/api/v4/Action/CreateWithOptionGroupTest.php
index dc778fe31d..307ea543a4 100644
--- a/tests/phpunit/api/v4/Action/CreateWithOptionGroupTest.php
+++ b/tests/phpunit/api/v4/Action/CreateWithOptionGroupTest.php
@@ -29,6 +29,11 @@ use Civi\Api4\Contact;
 class CreateWithOptionGroupTest extends BaseCustomValueTest {

   public function testGetWithCustomData() {
+    putenv('TIME_FUNC=frozen');
+    $d = date('Y-m-d H:i:s');
+    putenv("testGetWithCustomData=$d");
+    \CRM_Utils_Time::setTime($d);
+    echo \CRM_Utils_Time::date('YmdHis') . "\n";
     $group = uniqid('fava');
     $colorField = uniqid('colora');
     $foodField = uniqid('fooda');
@@ -95,6 +100,9 @@ class CreateWithOptionGroupTest extends BaseCustomValueTest {
   }

   public function testWithCustomDataForMultipleContacts() {
+    putenv('TIME_FUNC=frozen');
+    $d = getenv('testGetWithCustomData');
+    \CRM_Utils_Time::setTime($d);
     $group = uniqid('favb');
     $colorField = uniqid('colorb');
     $foodField = uniqid('foodb');
@@ -173,6 +181,9 @@ class CreateWithOptionGroupTest extends BaseCustomValueTest {
     $this->assertEquals('Blue', $blueCheese["$group.$colorField:label"]);
     $this->assertEquals('Cheese', $blueCheese["$group.$foodField:label"]);
     $this->assertEquals(500000, $blueCheese['FinancialStuff.Salary']);
+
+    putenv('TIME_FUNC');
+    \CRM_Utils_Time::resetTime();
   }

 }
```