### PR TITLE
Display configured currency on PCPPage instead of default

### DIFF
--- a/CRM/PCP/Page/PCPInfo.php
+++ b/CRM/PCP/Page/PCPInfo.php
@@ -57,6 +57,7 @@ class CRM_PCP_Page_PCPInfo extends CRM_Core_Page {
 
     CRM_Utils_System::setTitle($pcpInfo['title']);
     $this->assign('pcp', $pcpInfo);
+    $this->assign('currency', $pcpInfo['currency']);
 
     $pcpStatus = CRM_Core_OptionGroup::values("pcp_status");
     $approvedId = CRM_Core_PseudoConstant::getKey('CRM_PCP_BAO_PCP', 'status_id', 'Approved');

--- a/templates/CRM/PCP/Page/PCPInfo.tpl
+++ b/templates/CRM/PCP/Page/PCPInfo.tpl
@@ -50,7 +50,7 @@
       {if $pcp.is_thermometer}
       <div class="thermometer-wrapper">
           <div class="pcp-amount-goal">
-            {ts}Goal{/ts} <span class="goal-amount crmMoney">{$pcp.goal_amount|crmMoney}</span>
+            {ts}Goal{/ts} <span class="goal-amount crmMoney">{$pcp.goal_amount|crmMoney:$currency}</span>
         </div>
         <div class="thermometer-fill-wrapper">
             <div style="height: {$achieved}%;" class="thermometer-fill">
@@ -58,7 +58,7 @@
             </div><!-- /.thermometer-fill -->
         </div><!-- /.thermometer-fill-wrapper -->
         <div class="pcp-amount-raised">
-             <span class="raised-amount crmMoney">{$total|crmMoney}</span> {ts}raised{/ts}
+             <span class="raised-amount crmMoney">{$total|crmMoney:$currency}</span> {ts}raised{/ts}
         </div>
     </div>
       {/if}


### PR DESCRIPTION
Overview
----------------------------------------
Show correct currency for PCP page.

Before
----------------------------------------
Default currency in CiviCRM shown

After
----------------------------------------
Actual currency configured for contribution/pcp page shown:
![image](https://user-images.githubusercontent.com/2052161/126236210-2935e786-47e4-4e50-9aec-14fe39d3dd97.png)

Technical Details
----------------------------------------


Comments
----------------------------------------
