### PR TITLE
Fix databaseSupportsUTF8MB4

### DIFF
--- a/CRM/Core/BAO/SchemaHandler.php
+++ b/CRM/Core/BAO/SchemaHandler.php
@@ -920,7 +920,7 @@ MODIFY      {$columnName} varchar( $length )
    */
   public static function databaseSupportsUTF8MB4(): bool {
     if (!isset(\Civi::$statics[__CLASS__][__FUNCTION__])) {
-      \Civi::$statics[__CLASS__][__FUNCTION__] = stripos(self::getInUseCollation(), 'utf8mb4') === TRUE;
+      \Civi::$statics[__CLASS__][__FUNCTION__] = stripos(self::getInUseCollation(), 'utf8mb4') === 0;
     }
     return \Civi::$statics[__CLASS__][__FUNCTION__];
   }

--- a/tests/phpunit/api/v3/ContactTest.php
+++ b/tests/phpunit/api/v3/ContactTest.php
@@ -5194,29 +5194,13 @@ class api_v3_ContactTest extends CiviUnitTestCase {
    *
    * By default our DBs are not 🦉 compliant. This test will age
    * out when we are.
-   *
-   * @throws \CRM_Core_Exception
    */
   public function testEmojiInWhereClause(): void {
-    $schemaNeedsAlter = CRM_Core_BAO_SchemaHandler::databaseSupportsUTF8MB4();
-    if ($schemaNeedsAlter) {
-      CRM_Core_DAO::executeQuery("
-        ALTER TABLE civicrm_contact MODIFY COLUMN
-        `first_name` VARCHAR(64) CHARACTER SET utf8 COLLATE utf8_unicode_ci DEFAULT NULL COMMENT 'First Name.',
-        CHARSET utf8
-      ");
-    }
     $this->callAPISuccess('Contact', 'get', [
       'debug' => 1,
       'first_name' => '🦉Claire',
+      'version' => 4,
     ]);
-    if ($schemaNeedsAlter) {
-      CRM_Core_DAO::executeQuery("
-        ALTER TABLE civicrm_contact MODIFY COLUMN
-        `first_name` VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT 'First Name.',
-        CHARSET utf8mb4
-      ");
-    }
   }
 
   /**


### PR DESCRIPTION

Overview
----------------------------------------
Fix databaseSupportsUTF8MB4

Before
----------------------------------------
``databaseSupportsUTF8MB4`` always returns false

After
----------------------------------------
Only returns false when false

Technical Details
----------------------------------------
This function has been wrong since it was added

Comments
----------------------------------------
stripos returns 0 on success, not true.
