### PR TITLE
Add test & fix for failing OR clause in apv4

### DIFF
--- a/Civi/Api4/Query/Api4SelectQuery.php
+++ b/Civi/Api4/Query/Api4SelectQuery.php
@@ -396,7 +396,7 @@ class Api4SelectQuery {
           foreach ($clause[1] as $subclause) {
             $sql_subclauses[] = $this->treeWalkClauses($subclause, $type, $depth + 1);
           }
-          return '(' . implode("\n" . $clause[0], $sql_subclauses) . ')';
+          return '(' . implode("\n" . $clause[0] . ' ', $sql_subclauses) . ')';
         }
 
       case 'NOT':

--- a/tests/phpunit/api/v4/Action/ContactGetTest.php
+++ b/tests/phpunit/api/v4/Action/ContactGetTest.php
@@ -259,4 +259,14 @@ class ContactGetTest extends \api\v4\UnitTestCase {
     $this->assertEquals(['Student'], $result['Contact_RelationshipCache_Contact_01.contact_sub_type:label']);
   }
 
+  /**
+   * @throws \API_Exception
+   */
+  public function testOrClause(): void {
+    Contact::get()
+      ->addClause('OR', ['first_name', '=', '🚂'], ['last_name', '=', '🚂'])
+      ->setCheckPermissions(FALSE)
+      ->execute();
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Add test & fix for failing OR clause in apv4

Before
----------------------------------------
When an apiv4 query checks 2 different fields for a value with an emoji in it we get a mysql fail because the OR is missing a space - e.g

```

    Contact::get()
      ->addClause('OR', ['first_name', '=', '🚂'], ['last_name', '=', '🚂'])
      ->setCheckPermissions(FALSE)
      ->execute();
```

After
----------------------------------------
Works

Technical Details
----------------------------------------
This fails because when the field is being concatenated like
```
`a`.`first_name`='x' OR`a`.`last_name`='x'
```

The lack of a space between OR and `a` is fugly but it
is parsed by mysql. 

However, when a utf8mb4 string is used and the code decides (incorrectly without #20905 )
that the database does not support utf8mb4 then it replaces the criteria with `0 = 1`

The missing space between OR  and 0 then becomes a fatal error

`0 = 1 OR0 = 1`

Comments
----------------------------------------
@colemanw 