### PR TITLE
dev/core#2691 - On logging detail civireport show words instead of numbers (part 2)

### DIFF
--- a/CRM/Logging/ReportDetail.php
+++ b/CRM/Logging/ReportDetail.php
@@ -215,11 +215,24 @@ class CRM_Logging_ReportDetail extends CRM_Report_Form {
           $to = implode(', ', array_filter($tos));
         }
 
+        $tableDAOClass = CRM_Core_DAO_AllCoreTables::getClassForTable($table);
+        if (!empty($tableDAOClass)) {
+          $tableDAOFields = (new $tableDAOClass())->fields();
+          // If this field is a foreign key, then we can later use the foreign
+          // class to translate the id into something more useful for display.
+          $fkClassName = $tableDAOFields[$field]['FKClassName'] ?? NULL;
+        }
         if (isset($values[$field][$from])) {
           $from = $values[$field][$from];
         }
+        elseif (!empty($from) && !empty($fkClassName)) {
+          $from = $this->convertForeignKeyValuesToLabels($fkClassName, $field, $from);
+        }
         if (isset($values[$field][$to])) {
           $to = $values[$field][$to];
+        }
+        elseif (!empty($to) && !empty($fkClassName)) {
+          $to = $this->convertForeignKeyValuesToLabels($fkClassName, $field, $to);
         }
         if (isset($titles[$field])) {
           $field = $titles[$field];
@@ -447,6 +460,28 @@ class CRM_Logging_ReportDetail extends CRM_Report_Form {
       $this->dblimit = $rowCount;
       $this->dboffset = $offset;
     }
+  }
+
+  /**
+   * Given a key value that we know is a foreign key to another table, return
+   * what the DAO thinks is the "label" for the foreign entity. For example
+   * if it's referencing a contact then return the contact name, or if it's an
+   * activity then return the activity subject.
+   * If it's the type of DAO that doesn't have such a thing, just echo back
+   * what we were given.
+   *
+   * @param string $fkClassName
+   * @param string $field
+   * @param int $keyval
+   * @return string
+   */
+  private function convertForeignKeyValuesToLabels(string $fkClassName, string $field, int $keyval): string {
+    if (property_exists($fkClassName, '_labelField')) {
+      $labelValue = CRM_Core_DAO::getFieldValue($fkClassName, $keyval, $fkClassName::$_labelField);
+      // Not sure if this should use ts - there's not a lot of context (`%1 (id: %2)`) - and also the similar field labels above don't use ts.
+      return "{$labelValue} (id: {$keyval})";
+    }
+    return (string) $keyval;
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/2691

This is a followup to https://github.com/civicrm/civicrm-core/pull/20844 which only addressed activity record type. This addresses foreign keys, displaying more useful words instead of the foreign key id, e.g. `fk activity_id => activity subject`  or  `fk contact_id => display_name`.

1. Turn on logging at admin - system settings - misc
1. Do something like edit an activity.
1. Go to the Contact Logging Summary report.
1. Drill down on the detail for that change. (Note for activities it will usually say action = Delete, because at the moment the report is only showing activity_contact records not activity records, and civi often does a delete+insert to make an update. I'm only mentioning this because you might be looking for the word Update in the report and not seeing it, but that's separate from making numbers into words.)


Before
----------------------------------------
Something like this

<img width="630" alt="Untitled" src="https://user-images.githubusercontent.com/2967821/126332129-93342fe7-472e-4215-88e4-4f015e4f2c13.png">


After
----------------------------------------
Something like this:

<img width="500" alt="Untitled2" src="https://user-images.githubusercontent.com/2967821/126332236-e53f2be3-f983-4b37-b858-68fc5c669b10.png">


Technical Details
----------------------------------------
There's metadata available that says if a field is a foreign key and then on the foreign class there's metadata that tells you what would be meaningful to display as a label for that record. So this looks up that label. I'm not sure if there's already an api4 function available that takes a table+field and gets it for you.

For the test I had to work around something that only comes up in tests where logging will always have the same connection id throughout the entire run, whereas in real life on different page requests there'll be a different connection id corresponding to each change. The logging detail report relies on the connection id to tell what db records were associated with a change, so if I don't artificially fiddle with it then it thinks everything that has happened since the start is all one big change.

Comments
----------------------------------------
