### PR TITLE
APIv4 - Fix calculated fields in bridge entities

### DIFF
--- a/Civi/Api4/Query/Api4SelectQuery.php
+++ b/Civi/Api4/Query/Api4SelectQuery.php
@@ -903,14 +903,16 @@ class Api4SelectQuery {
     $bridgeFkFields = [$joinRef->getReferenceKey(), $joinRef->getTypeColumn(), $baseRef->getReferenceKey(), $baseRef->getTypeColumn()];
     $bridgeEntityClass = CoreUtil::getApiClass($bridgeEntity);
     foreach ($bridgeEntityClass::get($this->getCheckPermissions())->entityFields() as $name => $field) {
-      if ($field['type'] !== 'Field' || $name === 'id' || ($side === 'INNER' && in_array($name, $bridgeFkFields, TRUE))) {
+      if ($name === 'id' || ($side === 'INNER' && in_array($name, $bridgeFkFields, TRUE))) {
         continue;
       }
       // For INNER joins, these fields get a sql alias pointing to the bridge entity,
       // but an api alias pretending they belong to the join entity.
       $field['sql_name'] = '`' . ($side === 'LEFT' ? $alias : $bridgeAlias) . '`.`' . $field['column_name'] . '`';
       $this->addSpecField($alias . '.' . $name, $field);
-      $fakeFields[$field['column_name']] = '`' . $bridgeAlias . '`.`' . $field['column_name'] . '`';
+      if ($field['type'] === 'Field') {
+        $fakeFields[$field['column_name']] = '`' . $bridgeAlias . '`.`' . $field['column_name'] . '`';
+      }
     }
     return $fakeFields;
   }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a crash-inducing bug in the use of calculated fields on a bridge entity, such as `RelationshipCache.is_current` which prevented this in SearchKit:
![image](https://user-images.githubusercontent.com/2874912/126373802-8bba2dba-eadd-4b8b-8934-7df11a93d351.png)


Before
----------------------------------------
Test fails, search crashes

After
----------------------------------------
Test passes, search works

Technical Details
----------------------------------------
It's complicated, trust the unit tests.