### PR TITLE
Greenwich - fix select2 font size

### DIFF
--- a/ext/greenwich/scss/_tweaks.scss
+++ b/ext/greenwich/scss/_tweaks.scss
@@ -20,3 +20,8 @@ label input[type=checkbox]:not(:checked) + * {
 input[type="search"]::-webkit-search-cancel-button {
   -webkit-appearance: searchfield-cancel-button;
 }
+/* civicrm.css makes this too big */
+.select2-container .select2-choice > .select2-chosen {
+  font-size: inherit;
+  font-weight: normal;
+}


### PR DESCRIPTION
Overview
----------------------------------------
Fixes the font size & weight of Select2 elements in bootstrap themes. Especially noticeable when adding a new column to searchkit as of #20910 :

Before
-----------------------------
![image](https://user-images.githubusercontent.com/2874912/126415429-afb7a538-68f2-4264-be11-9d09609709c2.png)

After
----------------------
![image](https://user-images.githubusercontent.com/2874912/126415289-caef3c4a-e514-4abb-b2bd-74533f502372.png)
