### PR TITLE
Capitalization Fix

### DIFF
--- a/Civi/Api4/Query/SqlFunctionGROUP_CONCAT.php
+++ b/Civi/Api4/Query/SqlFunctionGROUP_CONCAT.php
@@ -24,7 +24,7 @@ class SqlFunctionGROUP_CONCAT extends SqlFunction {
     [
       'prefix' => ['', 'DISTINCT', 'ALL'],
       'max_expr' => 1,
-      'must_be' => ['SqlField', 'sqlFunction'],
+      'must_be' => ['SqlField', 'SqlFunction'],
       'optional' => FALSE,
     ],
     [


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a mis-capitalized class-name.

Technical Details
----------------------------------------
This is covered by the `SqlFunctionTest::testGroupAggregates`. It passes before and after on Linux, but I suspect on Windows it would have failed before this change.
