### PR TITLE
dev/core#2709 Enable logging for custom data tables with non-standard names

### DIFF
--- a/CRM/Logging/Schema.php
+++ b/CRM/Logging/Schema.php
@@ -131,6 +131,15 @@ AND    TABLE_NAME LIKE 'civicrm_%'
     while ($dao->fetch()) {
       $this->tables[] = $dao->TABLE_NAME;
     }
+    // Get any non standard table names used for custom groups.
+    // include these BEFORE the hook is called.
+    $customFieldDAO = CRM_Core_DAO::executeQuery("
+      SELECT DISTINCT table_name as TABLE_NAME FROM civicrm_custom_group
+      where table_name NOT LIKE 'civicrm_%';
+    ");
+    while ($customFieldDAO->fetch()) {
+      $this->tables[] = $customFieldDAO->TABLE_NAME;
+    }
 
     // do not log temp import, cache, menu and log tables
     $this->tables = preg_grep('/^civicrm_import_job_/', $this->tables, PREG_GREP_INVERT);

--- a/tests/phpunit/CRMTraits/Custom/CustomDataTrait.php
+++ b/tests/phpunit/CRMTraits/Custom/CustomDataTrait.php
@@ -91,12 +91,11 @@ trait CRMTraits_Custom_CustomDataTrait {
    * @param array $fieldParams
    *
    * @throws \API_Exception
-   * @throws \CRM_Core_Exception
    */
-  public function createCustomGroupWithFieldOfType($groupParams = [], $customFieldType = 'text', $identifier = NULL, $fieldParams = []): void {
+  public function createCustomGroupWithFieldOfType(array $groupParams = [], string $customFieldType = 'text', ?string $identifier = NULL, array $fieldParams = []): void {
     $supported = ['text', 'select', 'date', 'checkbox', 'int', 'contact_reference', 'radio', 'multi_country'];
     if (!in_array($customFieldType, $supported, TRUE)) {
-      throw new CRM_Core_Exception('we have not yet extracted other custom field types from createCustomFieldsOfAllTypes, Use consistent syntax when you do');
+      $this->fail('we have not yet extracted other custom field types from createCustomFieldsOfAllTypes, Use consistent syntax when you do');
     }
     $groupParams['title'] = empty($groupParams['title']) ? $identifier . 'Group with field ' . $customFieldType : $groupParams['title'];
     $groupParams['name'] = $identifier ?? 'Custom Group';

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -1870,16 +1870,7 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
       throw new \CRM_Core_Exception("CiviUnitTestCase: quickCleanup() is not compatible with useTransaction()");
     }
     if ($dropCustomValueTables) {
-
-      CustomField::get(FALSE)->setSelect(['option_group_id', 'custom_group_id'])
-        ->addChain('delete_options', OptionGroup::delete()
-          ->addWhere('id', '=', '$option_group_id')
-        )
-        ->addChain('delete_fields', CustomField::delete()
-          ->addWhere('id', '=', '$id')
-        )->execute();
-
-      CustomGroup::delete(FALSE)->addWhere('id', '>', 0)->execute();
+      $this->cleanupCustomGroups();
       // Reset autoincrement too.
       $tablesToTruncate[] = 'civicrm_custom_group';
       $tablesToTruncate[] = 'civicrm_custom_field';
@@ -3876,6 +3867,23 @@ WHERE a1.is_primary = 0
       'Case Coordinator is',
       'Supervised by',
     ])->execute();
+  }
+
+  /**
+   * Delete any existing custom data groups.
+   *
+   * @throws \API_Exception
+   */
+  protected function cleanupCustomGroups(): void {
+    CustomField::get(FALSE)->setSelect(['option_group_id', 'custom_group_id'])
+      ->addChain('delete_options', OptionGroup::delete()
+        ->addWhere('id', '=', '$option_group_id')
+      )
+      ->addChain('delete_fields', CustomField::delete()
+        ->addWhere('id', '=', '$id')
+      )->execute();
+
+    CustomGroup::delete(FALSE)->addWhere('id', '>', 0)->execute();
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#2709 Enable logging for custom data tables with non-standard names

Before
----------------------------------------
When a custom group is created and the table_name is specified as 'something random' and then logging is enabled, logging is not enabled for the table

After
----------------------------------------
Logging behaviour follows normal standards. As with any other table the hook can be used to opt the table out of logging 

Technical Details
----------------------------------------
One line change + comments + test

Comments
----------------------------------------
