### PR TITLE
dev/core#2710 Cannot disable contact type/sub-type

### DIFF
--- a/templates/CRM/Admin/Page/ContactType.tpl
+++ b/templates/CRM/Admin/Page/ContactType.tpl
@@ -32,7 +32,7 @@
     </tr>
     </thead>
     {foreach from=$rows item=row}
-      <tr id="contact_type-{$row.id}" data-action="setvalue" class="{cycle values="odd-row,even-row"} {if !empty($row.class)}{$row.class}{/if} crm-contactType crm-entity {if NOT $row.is_active} disabled{/if}">
+      <tr id="contact_type-{$row.id}" data-action="create" class="{cycle values="odd-row,even-row"} {if !empty($row.class)}{$row.class}{/if} crm-contactType crm-entity {if NOT $row.is_active} disabled{/if}">
         <td class="crm-contactType-label crm-editable" data-field="label">{ts}{$row.label}{/ts}</td>
         <td class="crm-contactType-parent">{if $row.parent}{ts}{$row.parent_label}{/ts}{else}{ts}(built-in){/ts}{/if}</td>
         <td class="crm-contactType-description crm-editable" data-field="description" data-type="textarea">{$row.description}</td>


### PR DESCRIPTION
Overview
----------------------------------------
Steps to replicate: 

1. Click on Administer -> Customize Data and Screens -> Contact Types.
2. Disable any contact type or sub-type
3. Doesn't affect, page refreshes but the disabled contact sub-type is still active

Before
----------------------------------------
![after](https://user-images.githubusercontent.com/3735621/126446325-ddc610ac-7ef6-41ca-afb9-04b580a4ca08.gif)


After
----------------------------------------
![after](https://user-images.githubusercontent.com/3735621/126446518-ec15bc86-0836-4962-b8bf-06ff59ad93fd.gif)


Comments
----------------------------------------
ping @colemanw @eileenmcnaughton @seamuslee001 