### PR TITLE
Add check to see if these indices are actually removed + call the function which should

### DIFF
--- a/tests/phpunit/CRM/Core/InnoDBIndexerTest.php
+++ b/tests/phpunit/CRM/Core/InnoDBIndexerTest.php
@@ -6,18 +6,31 @@
  */
 class CRM_Core_InnoDBIndexerTest extends CiviUnitTestCase {
 
-  public function tearDown(): void {
-    // May or may not cleanup well if there's a bug in the indexer.
-    // This is better than nothing -- and better than duplicating the
-    // cleanup logic.
-    $idx = new CRM_Core_InnoDBIndexer(FALSE, []);
-    $idx->fixSchemaDifferences();
+  /**
+   * Indices to be created or removed.
+   *
+   * @var array
+   */
+  protected $indices = [];
 
+  /**
+   * @throws \API_Exception
+   * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
+   */
+  public function tearDown(): void {
+    $idx = new CRM_Core_InnoDBIndexer(FALSE, []);
+    foreach (array_keys($this->indices) as $table) {
+      foreach ($idx->dropIndexSql($table) as $sql) {
+        CRM_Core_DAO::executeQuery($sql);
+      }
+    }
+    $this->assertFullTextIndexesNotPresent();
     parent::tearDown();
   }
 
-  public function testHasDeclaredIndex() {
-    $idx = new CRM_Core_InnoDBIndexer(TRUE, [
+  public function testHasDeclaredIndex(): void {
+    $this->indices = [
       'civicrm_contact' => [
         ['first_name', 'last_name'],
         ['foo'],
@@ -25,7 +38,8 @@ class CRM_Core_InnoDBIndexerTest extends CiviUnitTestCase {
       'civicrm_email' => [
         ['whiz'],
       ],
-    ]);
+    ];
+    $idx = new CRM_Core_InnoDBIndexer(TRUE, $this->indices);
 
     $this->assertTrue($idx->hasDeclaredIndex('civicrm_contact', ['first_name', 'last_name']));
     $this->assertTrue($idx->hasDeclaredIndex('civicrm_contact', ['last_name', 'first_name']));
@@ -44,17 +58,18 @@ class CRM_Core_InnoDBIndexerTest extends CiviUnitTestCase {
   /**
    * When disabled, there is no FTS index, so queries that rely on FTS index fail.
    */
-  public function testDisabled() {
-    $idx = new CRM_Core_InnoDBIndexer(FALSE, [
+  public function testDisabled(): void {
+    $this->indices = [
       'civicrm_contact' => [
         ['first_name', 'last_name'],
       ],
-    ]);
+    ];
+    $idx = new CRM_Core_InnoDBIndexer(FALSE, $this->indices);
     $idx->fixSchemaDifferences();
 
     try {
       CRM_Core_DAO::executeQuery('SELECT id FROM civicrm_contact WHERE MATCH(first_name,last_name) AGAINST ("joe")');
-      $this->fail("Missed expected exception");
+      $this->fail('Missed expected exception');
     }
     catch (Exception $e) {
       $this->assertTrue(TRUE, 'Received expected exception');
@@ -64,27 +79,26 @@ class CRM_Core_InnoDBIndexerTest extends CiviUnitTestCase {
   /**
    * When enabled, the FTS index is created, so queries that rely on FTS work.
    */
-  public function testEnabled() {
-    if (!$this->supportsFts()) {
-      $this->markTestSkipped("Local installation of InnoDB does not support FTS.");
-      return;
-    }
-
-    $idx = new CRM_Core_InnoDBIndexer(TRUE, [
+  public function testEnabled(): void {
+    $this->indices = [
       'civicrm_contact' => [
         ['first_name', 'last_name'],
       ],
-    ]);
+    ];
+    $idx = new CRM_Core_InnoDBIndexer(TRUE, $this->indices);
     $idx->fixSchemaDifferences();
-
     CRM_Core_DAO::executeQuery('SELECT id FROM civicrm_contact WHERE MATCH(first_name,last_name) AGAINST ("joe")');
   }
 
   /**
-   * @return mixed
+   * Assert that all indices have been removed.
    */
-  public function supportsFts() {
-    return version_compare(CRM_Core_DAO::singleValueQuery('SELECT VERSION()'), '5.6.0', '>=');
+  protected function assertFullTextIndexesNotPresent(): void {
+    $this->assertEmpty(CRM_Core_DAO::singleValueQuery("
+  SELECT GROUP_CONCAT(CONCAT(table_name, ' ', index_name))
+  FROM information_Schema.STATISTICS
+  WHERE table_schema = '" . CRM_Core_DAO::getDatabaseName() . "'
+    AND index_type = 'FULLTEXT'"), 'Full text indices should have been removed');
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
This builds on https://github.com/civicrm/civicrm-core/pull/20912 which demonstrates the indexes are not cleaned up and adds an extra layer of fix which causes it to actually call the function in a way which SHOULD cleanup the indexes. On my local they are still failing to clean up - I am running MariabDB 10.4 - but it is unknown what jenkins will think as the function *may* work on jenkins

Before
----------------------------------------
We know the full text index is not being removed - we don't know if it would be if the cleanup called the right function

After
----------------------------------------
We will know whether the actual function works on the version of mysql jenkins runs

Technical Details
----------------------------------------

Comments
----------------------------------------

This is probably pretty edge functionality & could have been broken for a decade but it's impacting other tests