### PR TITLE
dev/drupal#161 - (not just drupal) Can't install sample data using UI installer

### DIFF
--- a/install/civicrm.php
+++ b/install/civicrm.php
@@ -89,7 +89,7 @@ function civicrm_main(&$config) {
   civicrm_source($dsn, $sqlPath . DIRECTORY_SEPARATOR . 'civicrm.mysql');
 
   if (!empty($config['loadGenerated'])) {
-    civicrm_source($dsn, $sqlPath . DIRECTORY_SEPARATOR . 'civicrm_generated.mysql', TRUE);
+    civicrm_source($dsn, $sqlPath . DIRECTORY_SEPARATOR . 'civicrm_generated.mysql');
   }
   else {
     if (isset($config['seedLanguage'])


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/drupal/-/issues/161

Using the original UI installer (e.g. sites/all/modules/civicrm/install/index.php), the sample data can no longer be installed.

Affects 5.39+

Before
----------------------------------------
Cannot execute INSERT INTO `civicrm_acl` (`id`, `name`, `deny`, `entity_table`, `entity_id`, `operation`, `object_table`, `object_id`, `acl_table`, `acl_id`, `is_active`) VALUES: DB Error: syntax error

After
----------------------------------------
ok

Technical Details
----------------------------------------
The legacy installer has a lineMode parameter which is a bit mysterious, and the newer civicrm-setup [explicitly does not implement it](https://github.com/civicrm/civicrm-core/blob/d34ef1270a91affb1bac8927ae2cf606143d6852/setup/src/Setup/DbUtil.php#L212) and notes that it is [weird](https://github.com/civicrm/civicrm-core/blob/d34ef1270a91affb1bac8927ae2cf606143d6852/setup/src/Setup/DbUtil.php#L178).

It runs fine without the lineMode parameter, same as using `cv core:install` etc.

My regen script broke this when it started splitting the file into multiple lines.

Comments
----------------------------------------

