### PR TITLE
Fix 'includes tax' translation for PriceSet Checkbox fields

### DIFF
--- a/CRM/Price/BAO/PriceField.php
+++ b/CRM/Price/BAO/PriceField.php
@@ -387,17 +387,7 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
               $postHelpText = '<span class="crm-price-amount-help-post-separator">:&nbsp;</span><span class="crm-price-amount-help-post description">' . $opt['help_post'] . '</span>';
             }
             if (isset($taxAmount) && $invoicing) {
-              if ($displayOpt == 'Do_not_show') {
-                $opt['label'] = '<span class="crm-price-amount-label">' . $opt['label'] . '</span>' . '<span class="crm-price-amount-amount">' . CRM_Utils_Money::format($opt[$valueFieldName] + $taxAmount) . '</span>';
-              }
-              elseif ($displayOpt == 'Inclusive') {
-                $opt['label'] = '<span class="crm-price-amount-label">' . $opt['label'] . '</span>' . '<span class="crm-price-amount-amount">' . CRM_Utils_Money::format($opt[$valueFieldName] + $taxAmount) . '</span>';
-                $opt['label'] .= '<span class="crm-price-amount-tax"> (includes ' . $taxTerm . ' of ' . CRM_Utils_Money::format($opt['tax_amount']) . ')</span>';
-              }
-              else {
-                $opt['label'] = '<span class="crm-price-amount-label">' . $opt['label'] . '</span>' . '<span class="crm-price-amount-amount">' . CRM_Utils_Money::format($opt[$valueFieldName]) . '</span>';
-                $opt['label'] .= '<span class="crm-price-amount-tax"> + ' . CRM_Utils_Money::format($opt['tax_amount']) . ' ' . $taxTerm . '</span>';
-              }
+              $opt['label'] = '<span class="crm-price-amount-label">' . $opt['label'] . '</span>' . self::getTaxLabel($opt, $valueFieldName, $displayOpt, $taxTerm);
             }
             else {
               $opt['label'] = '<span class="crm-price-amount-label">' . $opt['label'] . '</span>' . '<span class="crm-price-amount-amount">' . CRM_Utils_Money::format($opt[$valueFieldName]) . '</span>';
@@ -848,7 +838,7 @@ WHERE  id IN (" . implode(',', array_keys($priceFields)) . ')';
     }
     elseif ($displayOpt == 'Inclusive') {
       $label = CRM_Utils_Money::format($opt[$valueFieldName] + $opt['tax_amount']);
-      $label .= '<span class="crm-price-amount-tax"> (includes ' . $taxTerm . ' of ' . CRM_Utils_Money::format($opt['tax_amount']) . ')</span>';
+      $label .= '<span class="crm-price-amount-tax"> ' . ts('(includes %1 of %2)', [1 => $taxTerm, 2 => CRM_Utils_Money::format($opt['tax_amount'])]) . '</span>';
     }
     else {
       $label = CRM_Utils_Money::format($opt[$valueFieldName]);


### PR DESCRIPTION
Overview
----------------------------------------

Fixes the translation of the "includes tax-term of 123$" in PriceSet CheckBox fields.

Bug reported by Maria on the [translation channel](https://chat.civicrm.org/civicrm/pl/7r6m9dwku7868khj55h81c4miw).

Before
----------------------------------------

Here you can see that the first option is correctly translated ("incluant"), but not for the checkboxes:

![civi-tax-before-2021-07-21_08-35](https://user-images.githubusercontent.com/254741/126490327-48204b19-225f-42d2-97fa-9aea61f339ce.png)

After
----------------------------------------

Now all fields translate correctly:

![civi-tax-after-2021-07-21_08-44](https://user-images.githubusercontent.com/254741/126490468-325f3167-ddd4-435a-aa02-76f61d3d71f8.png)

(I also tested radio-buttons, because I did a bit of unrelated code cleanup)

Comments
----------------------------------------

I think Jeff Bezos should pay taxes too.