### PR TITLE
Improve accessibility for price fields of the type select by adding the price field label to the placeholder.

### DIFF
--- a/CRM/Price/BAO/PriceField.php
+++ b/CRM/Price/BAO/PriceField.php
@@ -525,13 +525,12 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
         else {
           $visibility_id = self::getVisibilityOptionID('public');
         }
-        $element = &$qf->add('select', $elementName, $label,
-          [
-            '' => ts('- select -'),
-          ] + $selectOption,
-          $useRequired && $field->is_required,
-          ['price' => json_encode($priceVal), 'class' => 'crm-select2', 'data-price-field-values' => json_encode($customOption)]
-        );
+        $element = &$qf->add('select', $elementName, $label, $selectOption, $useRequired && $field->is_required, [
+          'placeholder' => ts('- select %1 -', [1 => $label]),
+          'price' => json_encode($priceVal),
+          'class' => 'crm-select2',
+          'data-price-field-values' => json_encode($customOption),
+        ]);
 
         // CRM-6902 - Add "max" option for a price set field
         $button = substr($qf->controller->getButtonName(), -4);


### PR DESCRIPTION
Overview
----------------------------------------
Due to limitations in Select2, screen readers don't read the labels of Select2 fields. As a stopgap, this adds the price field label to the placeholder text for price fields of the type select. The placeholder text is read by the screenreader.

Before
----------------------------------------
When using a price field of the type select on an event registration or contribution form the placeholder text was "- select -". 

For example if the price field label was "Shirt Size" the place holder would be "- select -".

After
----------------------------------------
When using a price field of the type select on an event registration or contribution form the placeholder text is "- select $priceFieldLabel -".

For example if the price field label is "Shirt Size" the place holder would be "- select Shirt Size -".

Comments
----------------------------------------
Continues work outlined in https://github.com/civicrm/civicrm-core/pull/17675
