### PR TITLE
dev/wordpress#109 fix bug when is_monetary is not checked

### DIFF
--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -336,7 +336,6 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
       $this->assignBillingType();
 
       // check for is_monetary status
-      $isMonetary = $this->_values['is_monetary'] ?? NULL;
       $isPayLater = $this->_values['is_pay_later'] ?? NULL;
       if (!empty($this->_ccid)) {
         $this->_values['financial_type_id'] = CRM_Core_DAO::getFieldValue('CRM_Contribute_DAO_Contribution',
@@ -352,14 +351,12 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
         $this->setPayLaterLabel($this->_values['pay_later_text']);
       }
 
-      if ($isMonetary) {
-        $this->_paymentProcessorIDs = array_filter(explode(
-          CRM_Core_DAO::VALUE_SEPARATOR,
-          CRM_Utils_Array::value('payment_processor', $this->_values)
-        ));
+      $this->_paymentProcessorIDs = array_filter(explode(
+        CRM_Core_DAO::VALUE_SEPARATOR,
+        CRM_Utils_Array::value('payment_processor', $this->_values)
+      ));
 
-        $this->assignPaymentProcessor($isPayLater);
-      }
+      $this->assignPaymentProcessor($isPayLater);
 
       // get price info
       // CRM-5095


### PR DESCRIPTION
Overview
----------------------------------------
This ensures the paymentProcessor is consistenly on the form regardless of is_monetary being checked

https://lab.civicrm.org/dev/wordpress/-/issues/109 highlights that it has been 'required'
even though we don't understand what it means. This removes that brittleness which we can't
'justify' from a logic point of view


Before
----------------------------------------
Fatal error if execute real-time monetary transactions is unchecked

![image](https://user-images.githubusercontent.com/336308/126550522-7e7db71d-d305-4261-9497-1079c83c4f92.png)

After
----------------------------------------
poof

Technical Details
----------------------------------------
This fatal error would date back to Dec last year (when a type hint was added to the function ) but has not been reported until now - probably because users, like the code, mostly ignore that checkbox - but we should be tolerant given we don't know why it exists

The code comments indicate that this was thought to be unreachable  & given the breakage was not picked up for 6 months I suspect we can remove it

![image](https://user-images.githubusercontent.com/336308/126550927-8e69a501-1544-4af9-b02c-be9db1f27707.png)


Comments
----------------------------------------
