### PR TITLE
Enable range search for money fields in search kit + afform

### DIFF
--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
@@ -67,7 +67,7 @@
             // Multiselects cannot use range search
             !ctrl.getDefn().input_attrs.multiple &&
             // DataType & inputType must make sense for a range
-            _.includes(['Date', 'Timestamp', 'Integer', 'Float'], ctrl.getDefn().data_type) &&
+            _.includes(['Date', 'Timestamp', 'Integer', 'Float', 'Money'], ctrl.getDefn().data_type) &&
             _.includes(['Date', 'Number', 'Select'], $scope.getProp('input_type'))
         ));
       };


### PR DESCRIPTION

Overview
----------------------------------------
Allow total_amount to be exposed for searching by range


Before
----------------------------------------
search range not available for money fields

After
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/126561326-afa53c9b-5ff1-4f23-a2d0-de72dd82b448.png)

Technical Details
----------------------------------------
You have to change the type from 'text' to 'number' - which feels like the wrong default (since searching is only available for number) - this doesn't seem to be the case for 'Contribution ID' which defaults to number - I suspect there must be another list like this somewhere of types

Comments
----------------------------------------
@colemanw
