### PR TITLE
dev/core#2705 - wrap email message lines

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -1232,11 +1232,11 @@ ORDER BY   civicrm_email.is_bulkmail DESC
     }
 
     if (!empty($mailParams['text'])) {
-      $message->setTxtBody($mailParams['text']);
+      $message->setTxtBody(CRM_Utils_Mail::wrapEmailText($mailParams['text']));
     }
 
     if (!empty($mailParams['html'])) {
-      $message->setHTMLBody($mailParams['html']);
+      $message->setHTMLBody(CRM_Utils_Mail::wrapEmailText($mailParams['html']));
     }
 
     if (!empty($mailParams['attachments'])) {

--- a/CRM/Utils/Mail.php
+++ b/CRM/Utils/Mail.php
@@ -189,10 +189,10 @@ class CRM_Utils_Mail {
 
     // wrap lines - https://lab.civicrm.org/dev/core/-/issues/2705
     if (!is_null($textMessage)) {
-        $textMessage = self::wrapEmailText($textMessage);
+      $textMessage = self::wrapEmailText($textMessage);
     }
     if (!is_null($htmlMessage)) {
-        $htmlMessage = self::wrapEmailText($htmlMessage);
+      $htmlMessage = self::wrapEmailText($htmlMessage);
     }
 
     // CRM-6224
@@ -610,7 +610,7 @@ class CRM_Utils_Mail {
    * @see https://civicrm.stackexchange.com/questions/39172/line-wrapping-breaking-lines-longer-than-998-characters-in-civicrm-civimail
    */
   public static function wrapEmailText($text) {
-      return wordwrap($text, 990);
+    return wordwrap($text, 990);
   }
 
 }

--- a/CRM/Utils/Mail.php
+++ b/CRM/Utils/Mail.php
@@ -586,4 +586,23 @@ class CRM_Utils_Mail {
     return $from;
   }
 
+  /**
+   * Wrap the too long lines.
+   * The SMTP protocol only allows 1000 chars per line (998 +\r\n).
+   * In the linked issue the suggestion for the wrapping was 990, so that
+   * this value is used as the width parameter of the wordwrap.
+   *
+   * @param string $text
+   *   The email message string.
+   * @return string
+   *   The wrapped email string.
+   *
+   * @see https://datatracker.ietf.org/doc/html/rfc2822#section-2.1.1
+   * @see https://lab.civicrm.org/dev/core/-/issues/2705
+   * @see https://civicrm.stackexchange.com/questions/39172/line-wrapping-breaking-lines-longer-than-998-characters-in-civicrm-civimail
+   */
+  public static function wrapEmailText($text) {
+      return wordwrap($text, 990);
+  }
+
 }

--- a/CRM/Utils/Mail.php
+++ b/CRM/Utils/Mail.php
@@ -187,6 +187,14 @@ class CRM_Utils_Mail {
     $htmlMessage = $params['html'] ?? NULL;
     $attachments = $params['attachments'] ?? NULL;
 
+    // wrap lines - https://lab.civicrm.org/dev/core/-/issues/2705
+    if (!is_null($textMessage)) {
+        $textMessage = self::wrapEmailText($textMessage);
+    }
+    if (!is_null($htmlMessage)) {
+        $htmlMessage = self::wrapEmailText($htmlMessage);
+    }
+
     // CRM-6224
     if (trim(CRM_Utils_String::htmlToText($htmlMessage)) == '') {
       $htmlMessage = FALSE;

--- a/ext/flexmailer/src/Listener/HookAdapter.php
+++ b/ext/flexmailer/src/Listener/HookAdapter.php
@@ -29,6 +29,12 @@ class HookAdapter extends BaseListener {
       $mailParams = $task->getMailParams();
       if ($mailParams) {
         \CRM_Utils_Hook::alterMailParams($mailParams, 'flexmailer');
+        if (!empty($mailParams['text'])) {
+          $mailParams['text'] = CRM_Utils_Mail::wrapEmailText($mailParams['text']);
+        }
+        if (!empty($mailParams['html'])) {
+          $mailParams['html'] = CRM_Utils_Mail::wrapEmailText($mailParams['html']);
+        }
         $task->setMailParams($mailParams);
       }
     }

--- a/ext/flexmailer/src/Listener/HookAdapter.php
+++ b/ext/flexmailer/src/Listener/HookAdapter.php
@@ -30,10 +30,10 @@ class HookAdapter extends BaseListener {
       if ($mailParams) {
         \CRM_Utils_Hook::alterMailParams($mailParams, 'flexmailer');
         if (!empty($mailParams['text'])) {
-          $mailParams['text'] = CRM_Utils_Mail::wrapEmailText($mailParams['text']);
+          $mailParams['text'] = \CRM_Utils_Mail::wrapEmailText($mailParams['text']);
         }
         if (!empty($mailParams['html'])) {
-          $mailParams['html'] = CRM_Utils_Mail::wrapEmailText($mailParams['html']);
+          $mailParams['html'] = \CRM_Utils_Mail::wrapEmailText($mailParams['html']);
         }
         $task->setMailParams($mailParams);
       }


### PR DESCRIPTION
Overview
----------------------------------------
Patch for [CORE-2705](https://lab.civicrm.org/dev/core/-/issues/2705).
Wrap long lines that could cause invalid DKIM signatures.

Before
----------------------------------------
If you send an email with lines longer than 1000 characters, the lines are not wrapped.

After
----------------------------------------
The lines in the email are wrapped after 990 characters.

Technical Details
----------------------------------------
The wordwrap functionality has been called after the alterMailParams hook has been executed, to prevent the overwrite with the hook. This functionality has been added after every alterMailParam hook call except when the context is messageTemplate, because that hook is called before the tokens are applied.

Comments
----------------------------------------
I'm not familiar with the flexmailer and the hook is also triggered from there with the flexmailer context. I'm not sure that I put the wrapping logic into the right place. If you could point me to the relevant documentation, that would be welcome.