### PR TITLE
[NFC] Typo in parameter for lybunt test

### DIFF
--- a/tests/phpunit/api/v3/ReportTemplateTest.php
+++ b/tests/phpunit/api/v3/ReportTemplateTest.php
@@ -538,7 +538,7 @@ class api_v3_ReportTemplateTest extends CiviUnitTestCase {
       'yid_value' => 2015,
       'yid_op' => 'fiscal',
       'options' => ['metadata' => ['sql']],
-      'fields' => ['first_name'],
+      'fields' => ['first_name' => 1],
       'order_bys' => [
         [
           'column' => 'last_year_total_amount',


### PR DESCRIPTION
Overview
----------------------------------------
Parameter is wrong for the field list. It doesn't change the test since it was returning the rows and all the required fields, just wasn't _also_ returning this field, but the field itself is never used.