### PR TITLE
dev/core#2717 Simplify batch membership renewal

### DIFF
--- a/CRM/Batch/Form/Entry.php
+++ b/CRM/Batch/Form/Entry.php
@@ -820,12 +820,7 @@ class CRM_Batch_Form_Entry extends CRM_Core_Form {
         }
         // end of contribution related section
 
-        $membershipParams = [
-          'start_date' => $value['membership_start_date'] ?? NULL,
-          'end_date' => $value['membership_end_date'] ?? NULL,
-          'join_date' => $value['membership_join_date'] ?? NULL,
-          'campaign_id' => $value['member_campaign_id'] ?? NULL,
-        ];
+        $membershipParams = $this->getMembershipParams();
 
         if ($this->currentRowIsRenew()) {
           // The following parameter setting may be obsolete.
@@ -1205,6 +1200,20 @@ class CRM_Batch_Form_Entry extends CRM_Core_Form {
       CRM_Member_BAO_Membership::fixMembershipStatusBeforeRenew($this->currentRowExistingMembership);
     }
     return $this->currentRowExistingMembership;
+  }
+
+  /**
+   * Get the params as related to the membership entity.
+   *
+   * @return array
+   */
+  private function getMembershipParams(): array {
+    return [
+      'start_date' => $this->currentRow['membership_start_date'] ?? NULL,
+      'end_date' => $this->currentRow['membership_end_date'] ?? NULL,
+      'join_date' => $this->currentRow['membership_join_date'] ?? NULL,
+      'campaign_id' => $this->currentRow['member_campaign_id'] ?? NULL,
+    ];
   }
 
 }

--- a/CRM/Batch/Form/Entry.php
+++ b/CRM/Batch/Form/Entry.php
@@ -836,8 +836,7 @@ class CRM_Batch_Form_Entry extends CRM_Core_Form {
             'start_date' => $value['membership_start_date'] ?? NULL,
           ];
           $membershipSource = $value['source'] ?? NULL;
-          $membership = $this->legacyProcessMembership(
-            $value['contact_id'], $value['membership_type_id'],
+          $membership = $this->legacyProcessMembership($value['membership_type_id'],
             $value['custom'], $membershipSource, ['campaign_id' => $value['member_campaign_id'] ?? NULL], $formDates
           );
 
@@ -1005,7 +1004,6 @@ class CRM_Batch_Form_Entry extends CRM_Core_Form {
   }
 
   /**
-   * @param int $contactID
    * @param int $membershipTypeID
    * @param $customFieldsFormatted
    * @param $membershipSource
@@ -1018,15 +1016,12 @@ class CRM_Batch_Form_Entry extends CRM_Core_Form {
    * @throws \CRM_Core_Exception
    * @throws \CiviCRM_API3_Exception
    */
-  protected function legacyProcessMembership($contactID, $membershipTypeID, $customFieldsFormatted, $membershipSource, $memParams = [], $formDates = []): CRM_Member_DAO_Membership {
+  protected function legacyProcessMembership($membershipTypeID, $customFieldsFormatted, $membershipSource, $memParams = [], $formDates = []): CRM_Member_DAO_Membership {
     $updateStatusId = FALSE;
     $changeToday = NULL;
     $is_test = FALSE;
     $numRenewTerms = 1;
-    $allStatus = CRM_Member_PseudoConstant::membershipStatus();
     $format = '%Y%m%d';
-    $statusFormat = '%Y-%m-%d';
-    $membershipTypeDetails = CRM_Member_BAO_MembershipType::getMembershipType($membershipTypeID);
     $ids = [];
     $isPayLater = NULL;
     $currentMembership = $this->getCurrentMembership();


### PR DESCRIPTION
Overview
----------------------------------------
Simplify batch membership renewal

This builds off https://github.com/civicrm/civicrm-core/pull/20882 and makes the assumption that we only need 2 code paths in this form

1) form option is_renew chosen AND a current membership exists => then use the renew code
2) form option is renew not chosen or no current membership exists => then use the create code.

It removes handling for the (hopefully already unreachable and / or broken)
- form option is_renew chose and no membership exists 
- for option is_renew chosen but only cancelled or pending memberships exist 

Before
----------------------------------------
A lot of code that was relevant to obscure pathways on the online contribution form (that doesn't have a separate 'new membership' process

After
----------------------------------------
poof

Technical Details
----------------------------------------
@monishdeb @kcristiano @jitendrapurohit  this is a  bit of a bigger change to the batch membership form from a required r-run POV - I'm hoping one of you can help on it

Comments
----------------------------------------
