### PR TITLE
Don't crash when all action tasks are disabled

### DIFF
--- a/CRM/Activity/Task.php
+++ b/CRM/Activity/Task.php
@@ -124,16 +124,17 @@ class CRM_Activity_Task extends CRM_Core_Task {
    *   set of tasks that are valid for the user
    */
   public static function permissionedTaskTitles($permission, $params = []) {
+    $tasks = [];
     if ($permission == CRM_Core_Permission::EDIT) {
       $tasks = self::taskTitles();
     }
     else {
-      $tasks = [
-        self::TASK_EXPORT => self::$_tasks[self::TASK_EXPORT]['title'],
-      ];
+      if (!empty(self::$_tasks[self::TASK_EXPORT]['title'])) {
+        $tasks[self::TASK_EXPORT] = self::$_tasks[self::TASK_EXPORT]['title'];
+      }
 
-      //CRM-4418,
-      if (CRM_Core_Permission::check('delete activities')) {
+      if (CRM_Core_Permission::check('delete activities')
+        && (!empty(self::$_tasks[self::TASK_DELETE]['title']))) {
         $tasks[self::TASK_DELETE] = self::$_tasks[self::TASK_DELETE]['title'];
       }
     }
@@ -156,11 +157,7 @@ class CRM_Activity_Task extends CRM_Core_Task {
       // make the print task by default
       $value = self::TASK_PRINT;
     }
-
-    return [
-      self::$_tasks[$value]['class'],
-      self::$_tasks[$value]['result'],
-    ];
+    return parent::getTask($value);
   }
 
 }

--- a/CRM/Campaign/Task.php
+++ b/CRM/Campaign/Task.php
@@ -112,11 +112,7 @@ class CRM_Campaign_Task extends CRM_Core_Task {
       // Set the interview task as default
       $value = self::INTERVIEW;
     }
-
-    return [
-      self::$_tasks[$value]['class'],
-      self::$_tasks[$value]['result'],
-    ];
+    return parent::getTask($value);
   }
 
 }

--- a/CRM/Case/Task.php
+++ b/CRM/Case/Task.php
@@ -102,6 +102,7 @@ class CRM_Case_Task extends CRM_Core_Task {
    *   set of tasks that are valid for the user
    */
   public static function permissionedTaskTitles($permission, $params = []) {
+    $tasks = [];
     if (($permission == CRM_Core_Permission::EDIT)
       || CRM_Core_Permission::check('access all cases and activities')
       || CRM_Core_Permission::check('access my cases and activities')
@@ -109,11 +110,12 @@ class CRM_Case_Task extends CRM_Core_Task {
       $tasks = self::taskTitles();
     }
     else {
-      $tasks = [
-        self::TASK_EXPORT => self::$_tasks[self::TASK_EXPORT]['title'],
-      ];
-      //CRM-4418,
-      if (CRM_Core_Permission::check('delete in CiviCase')) {
+      if (!empty(self::$_tasks[self::TASK_EXPORT]['title'])) {
+        $tasks[self::TASK_EXPORT] = self::$_tasks[self::TASK_EXPORT]['title'];
+      }
+
+      if (CRM_Core_Permission::check('delete in CiviCase')
+        && (!empty(self::$_tasks[self::TASK_DELETE]['title']))) {
         $tasks[self::TASK_DELETE] = self::$_tasks[self::TASK_DELETE]['title'];
       }
     }
@@ -136,11 +138,7 @@ class CRM_Case_Task extends CRM_Core_Task {
       // make the print task by default
       $value = self::TASK_PRINT;
     }
-
-    return [
-      self::$_tasks[$value]['class'],
-      self::$_tasks[$value]['result'],
-    ];
+    return parent::getTask($value);
   }
 
 }

--- a/CRM/Contact/StateMachine/Search.php
+++ b/CRM/Contact/StateMachine/Search.php
@@ -50,13 +50,15 @@ class CRM_Contact_StateMachine_Search extends CRM_Core_StateMachine {
       list($task, $result) = $this->taskName($controller, 'Basic');
     }
     $this->_task = $task;
-    if (is_array($task)) {
-      foreach ($task as $t) {
-        $this->_pages[$t] = NULL;
+    if (isset($task)) {
+      if (is_array($task)) {
+        foreach ($task as $t) {
+          $this->_pages[$t] = NULL;
+        }
       }
-    }
-    else {
-      $this->_pages[$task] = NULL;
+      else {
+        $this->_pages[$task] = NULL;
+      }
     }
 
     if ($result) {

--- a/CRM/Contact/Task.php
+++ b/CRM/Contact/Task.php
@@ -283,8 +283,11 @@ class CRM_Contact_Task extends CRM_Core_Task {
     $tasks = [];
     if ($params['deletedContacts']) {
       if (CRM_Core_Permission::check('access deleted contacts')) {
-        $tasks[self::RESTORE] = self::$_tasks[self::RESTORE]['title'];
-        if (CRM_Core_Permission::check('delete contacts')) {
+        if (!empty(self::$_tasks[self::RESTORE]['title'])) {
+          $tasks[self::RESTORE] = self::$_tasks[self::RESTORE]['title'];
+        }
+        if (CRM_Core_Permission::check('delete contacts')
+          && !empty(self::$_tasks[self::DELETE_PERMANENTLY]['title'])) {
           $tasks[self::DELETE_PERMANENTLY] = self::$_tasks[self::DELETE_PERMANENTLY]['title'];
         }
       }
@@ -293,13 +296,10 @@ class CRM_Contact_Task extends CRM_Core_Task {
       $tasks = self::taskTitles();
     }
     else {
-      $tasks = [
-        self::TASK_EXPORT => self::$_tasks[self::TASK_EXPORT]['title'],
-        self::TASK_EMAIL => self::$_tasks[self::TASK_EMAIL]['title'],
-        self::LABEL_CONTACTS => self::$_tasks[self::LABEL_CONTACTS]['title'],
-      ];
-
       foreach ([
+        self::TASK_EXPORT,
+        self::TASK_EMAIL,
+        self::LABEL_CONTACTS,
         self::MAP_CONTACTS,
         self::CREATE_MAILING,
         self::TASK_SMS,

--- a/CRM/Contribute/Task.php
+++ b/CRM/Contribute/Task.php
@@ -186,14 +186,19 @@ class CRM_Contribute_Task extends CRM_Core_Task {
       $tasks = self::taskTitles();
     }
     else {
-      $tasks = [
-        self::TASK_EXPORT => self::$_tasks[self::TASK_EXPORT]['title'],
-        self::TASK_EMAIL => self::$_tasks[self::TASK_EMAIL]['title'],
-        self::PDF_RECEIPT => self::$_tasks[self::PDF_RECEIPT]['title'],
-      ];
+      foreach ([
+        self::TASK_EXPORT,
+        self::TASK_EMAIL,
+        self::PDF_RECEIPT,
+      ] as $task) {
+        if (isset(self::$_tasks[$task])
+          && !empty(self::$_tasks[$task]['title'])) {
+          $tasks[$task] = self::$_tasks[$task]['title'];
+        }
+      }
 
-      //CRM-4418,
-      if (CRM_Core_Permission::check('delete in CiviContribute')) {
+      if (CRM_Core_Permission::check('delete in CiviContribute')
+        && !empty(self::$_tasks[self::TASK_DELETE]['title'])) {
         $tasks[self::TASK_DELETE] = self::$_tasks[self::TASK_DELETE]['title'];
       }
     }

--- a/CRM/Core/Task.php
+++ b/CRM/Core/Task.php
@@ -159,10 +159,13 @@ abstract class CRM_Core_Task {
       // Children can specify a default task (eg. print), pick another if it is not valid.
       $value = key(self::$_tasks);
     }
-    return [
-      CRM_Utils_Array::value('class', self::$_tasks[$value]),
-      CRM_Utils_Array::value('result', self::$_tasks[$value]),
-    ];
+    if (isset(self::$_tasks[$value])) {
+      return [
+        self::$_tasks[$value]['class'],
+        self::$_tasks[$value]['result'] ?? FALSE,
+      ];
+    }
+    return [NULL, NULL];
   }
 
   /**

--- a/CRM/Event/Task.php
+++ b/CRM/Event/Task.php
@@ -144,19 +144,25 @@ class CRM_Event_Task extends CRM_Core_Task {
    *   set of tasks that are valid for the user
    */
   public static function permissionedTaskTitles($permission, $params = []) {
+    $tasks = [];
     if (($permission == CRM_Core_Permission::EDIT)
       || CRM_Core_Permission::check('edit event participants')
     ) {
       $tasks = self::taskTitles();
     }
     else {
-      $tasks = [
-        self::TASK_EXPORT => self::$_tasks[self::TASK_EXPORT]['title'],
-        self::TASK_EMAIL => self::$_tasks[self::TASK_EMAIL]['title'],
-      ];
+      foreach ([
+        self::TASK_EXPORT,
+        self::TASK_EMAIL,
+      ] as $task) {
+        if (isset(self::$_tasks[$task]) &&
+          !empty(self::$_tasks[$task]['title'])) {
+          $tasks[$task] = self::$_tasks[$task]['title'];
+        }
+      }
 
-      //CRM-4418,
-      if (CRM_Core_Permission::check('delete in CiviEvent')) {
+      if (CRM_Core_Permission::check('delete in CiviEvent')
+        && !empty(self::$_tasks[self::TASK_DELETE]['title'])) {
         $tasks[self::TASK_DELETE] = self::$_tasks[self::TASK_DELETE]['title'];
       }
     }

--- a/CRM/Grant/Task.php
+++ b/CRM/Grant/Task.php
@@ -88,17 +88,19 @@ class CRM_Grant_Task extends CRM_Core_Task {
    *   set of tasks that are valid for the user
    */
   public static function permissionedTaskTitles($permission, $params = []) {
+    $tasks = [];
     if (($permission == CRM_Core_Permission::EDIT)
       || CRM_Core_Permission::check('edit grants')
     ) {
       $tasks = self::taskTitles();
     }
     else {
-      $tasks = [
-        self::TASK_EXPORT => self::$_tasks[self::TASK_EXPORT]['title'],
-      ];
-      //CRM-4418,
-      if (CRM_Core_Permission::check('delete in CiviGrant')) {
+      if (!empty(self::$_tasks[self::TASK_EXPORT]['title'])) {
+        $tasks[self::TASK_EXPORT] = self::$_tasks[self::TASK_EXPORT]['title'];
+      }
+
+      if (CRM_Core_Permission::check('delete in CiviGrant')
+        && !empty(self::$_tasks[self::TASK_DELETE]['title'])) {
         $tasks[self::TASK_DELETE] = self::$_tasks[self::TASK_DELETE]['title'];
       }
     }

--- a/CRM/Mailing/Task.php
+++ b/CRM/Mailing/Task.php
@@ -79,11 +79,7 @@ class CRM_Mailing_Task extends CRM_Core_Task {
       // make the print task by default
       $value = self::TASK_PRINT;
     }
-
-    return [
-      self::$_tasks[$value]['class'],
-      self::$_tasks[$value]['result'],
-    ];
+    return parent::getTask($value);
   }
 
 }

--- a/CRM/Member/Task.php
+++ b/CRM/Member/Task.php
@@ -135,18 +135,25 @@ class CRM_Member_Task extends CRM_Core_Task {
    *   set of tasks that are valid for the user
    */
   public static function permissionedTaskTitles($permission, $params = []) {
+    $tasks = [];
     if (($permission == CRM_Core_Permission::EDIT)
       || CRM_Core_Permission::check('edit memberships')
     ) {
       $tasks = self::taskTitles();
     }
     else {
-      $tasks = [
-        self::TASK_EXPORT => self::$_tasks[self::TASK_EXPORT]['title'],
-        self::TASK_EMAIL => self::$_tasks[self::TASK_EMAIL]['title'],
-      ];
-      //CRM-4418,
-      if (CRM_Core_Permission::check('delete in CiviMember')) {
+      foreach ([
+        self::TASK_EXPORT,
+        self::TASK_EMAIL,
+      ] as $task) {
+        if (isset(self::$_tasks[$task]) &&
+          !empty(self::$_tasks[$task]['title'])) {
+          $tasks[$task] = self::$_tasks[$task]['title'];
+        }
+      }
+
+      if (CRM_Core_Permission::check('delete in CiviMember')
+        && !empty(self::$_tasks[self::TASK_DELETE]['title'])) {
         $tasks[self::TASK_DELETE] = self::$_tasks[self::TASK_DELETE]['title'];
       }
     }

--- a/CRM/Pledge/Task.php
+++ b/CRM/Pledge/Task.php
@@ -74,17 +74,19 @@ class CRM_Pledge_Task extends CRM_Core_Task {
    *   set of tasks that are valid for the user
    */
   public static function permissionedTaskTitles($permission, $params = []) {
+    $tasks = [];
     if (($permission == CRM_Core_Permission::EDIT)
       || CRM_Core_Permission::check('edit pledges')
     ) {
       $tasks = self::taskTitles();
     }
     else {
-      $tasks = [
-        self::TASK_EXPORT => self::$_tasks[self::TASK_EXPORT]['title'],
-      ];
-      //CRM-4418,
-      if (CRM_Core_Permission::check('delete in CiviPledge')) {
+      if (!empty(self::$_tasks[self::TASK_EXPORT]['title'])) {
+        $tasks[self::TASK_EXPORT] = self::$_tasks[self::TASK_EXPORT]['title'];
+      }
+
+      if (CRM_Core_Permission::check('delete in CiviPledge')
+        && !empty(self::$_tasks[self::TASK_DELETE]['title'])) {
         $tasks[self::TASK_DELETE] = self::$_tasks[self::TASK_DELETE]['title'];
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------
This was found following release 1.2 of [exportpermissions](https://github.com/progressivetech/net.ourpowerbase.exportpermission) extension which supports disabling export/print/pdf/labels tasks. It turns out that disabling all of these can cause the advanced search to fail because some "modules" do not have any search tasks - see https://github.com/progressivetech/net.ourpowerbase.exportpermission/issues/6.

Specifically Activities and Mailings trigger a "Network error" because when there are no tasks defined a "null" page gets added which then triggers a `require_once('.php')` here https://github.com/civicrm/civicrm-core/blob/master/CRM/Core/Controller.php#L452 because `$className` is not defined.

Before
----------------------------------------
When a search task has no actions (eg. Activity, Mailings) and it is expanded in Advanced Search it crashes.

After
----------------------------------------
All tasks can be disabled and everything continues working!

Technical Details
----------------------------------------
Explained above. Most of the task code changes here are fixing PHP notices - the change in CRM/Contact/StateMachine/Search.php is what stops the crash.

Comments
----------------------------------------
