### PR TITLE
[NFC] Remove exceptions from comments

### DIFF
--- a/Civi/Test/ContactTestTrait.php
+++ b/Civi/Test/ContactTestTrait.php
@@ -23,7 +23,6 @@ trait ContactTestTrait {
    *
    * @return int
    *   Contact ID of the created user.
-   * @throws \CiviCRM_API3_Exception
    */
   public function createLoggedInUser(): int {
     $params = [
@@ -77,10 +76,8 @@ trait ContactTestTrait {
    *
    * @return int
    *   id of Individual created
-   *
-   * @throws \CiviCRM_API3_Exception
    */
-  public function individualCreate($params = [], $seq = 0, $random = FALSE): int {
+  public function individualCreate(array $params = [], $seq = 0, $random = FALSE): int {
     $params = array_merge($this->sampleContact('Individual', $seq, $random), $params);
     return $this->_contactCreate($params);
   }


### PR DESCRIPTION

Overview
----------------------------------------
[NFC] Remove exceptions from comments

callApiSuccess now uses fail rather than throwing an exception so
we don't need these here


Before
----------------------------------------
Extraneous exception declaration

After
----------------------------------------
poof

Technical Details
----------------------------------------

Comments
----------------------------------------
