### PR TITLE
Test, enotice fixes, handling for permissions key for Member_Tasks

### DIFF
--- a/CRM/Core/Task.php
+++ b/CRM/Core/Task.php
@@ -166,6 +166,51 @@ abstract class CRM_Core_Task {
   }
 
   /**
+   * Filter tasks based on the permission key, if available.
+   *
+   * @param array $tasks
+   * @param bool $hasEditContactPermission
+   *   Does the user have permission to edit the given contact. Required where
+   *   permission to edit the user is required in conjunction with permission
+   *   to do the task.
+   *
+   * @return array
+   */
+  protected static function getTasksFilteredByPermission(array $tasks, bool $hasEditContactPermission): array {
+    foreach ($tasks as $index => $task) {
+      // requires_edit_contact_permission is a (hopefully transient way) of denoting which
+      // tasks need 'edit this contact' on top of the membership permission.
+      if (!empty($task['requires_edit_contact_permission']) && !$hasEditContactPermission) {
+        unset($tasks[$index]);
+      }
+      elseif (!empty($task['permissions']) && !CRM_Core_Permission::check($task['permissions'])) {
+        unset($tasks[$index]);
+      }
+    }
+    return $tasks;
+  }
+
+  /**
+   * Get task tiles filtered by any declared permissions.
+   *
+   * @param array $tasks
+   * @param bool $hasEditContactPermission
+   *   Does the user have permission to edit the given contact. Required where
+   *   permission to edit the user is required in conjunction with permission
+   *   to do the task.
+   *
+   * @return array
+   */
+  protected static function getTitlesFilteredByPermission(array $tasks, bool $hasEditContactPermission): array {
+    $availableTasks = self::getTasksFilteredByPermission($tasks, $hasEditContactPermission);
+    $return = [];
+    foreach ($availableTasks as $key => $details) {
+      $return[$key] = $details['title'];
+    }
+    return $return;
+  }
+
+  /**
    * Function to return the task information on basis of provided task's form name
    *
    * @param string $className

--- a/tests/phpunit/CRM/Member/TaskTest.php
+++ b/tests/phpunit/CRM/Member/TaskTest.php
@@ -1,0 +1,64 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * Class CRM_Member_BAO_MembershipTest
+ * @group headless
+ */
+class CRM_Member_TaskTest extends CiviUnitTestCase {
+
+  use Civi\Test\ACLPermissionTrait;
+
+  /**
+   * Test tiles are correctly filtered on permissions.
+   */
+  public function testPermissionedTiles(): void {
+    $this->createLoggedInUser();
+
+    CRM_Member_Task::tasks();
+    \CRM_Core_Config::singleton()->userPermissionClass->permissions = ['view memberships'];
+    $tasks = CRM_Member_Task::permissionedTaskTitles(CRM_Core_Permission::VIEW);
+    $this->assertEquals([8 => 'Export members', 5 => 'Print selected rows'], $tasks);
+
+    \CRM_Core_Config::singleton()->userPermissionClass->permissions = ['delete in CiviMember', 'view memberships'];
+    $tasks = CRM_Member_Task::permissionedTaskTitles(CRM_Core_Permission::VIEW);
+    $this->assertEquals([8 => 'Export members', 5 => 'Print selected rows', 4 => 'Delete memberships'], $tasks);
+
+    \CRM_Core_Config::singleton()->userPermissionClass->permissions = ['edit memberships'];
+    $tasks = CRM_Member_Task::permissionedTaskTitles(CRM_Core_Permission::VIEW);
+    $this->assertEquals([8 => 'Export members', 5 => 'Print selected rows'], $tasks);
+
+    \CRM_Core_Config::singleton()->userPermissionClass->permissions = ['edit memberships'];
+    $tasks = CRM_Member_Task::permissionedTaskTitles(CRM_Core_Permission::EDIT);
+    $this->assertEquals([
+      8 => 'Export members',
+      5 => 'Print selected rows',
+      9 => 'Email - send now (to 50 or less)',
+      201 => 'Mailing labels - print',
+      3 => 'Print/merge document for memberships',
+      6 => 'Update multiple memberships',
+    ], $tasks);
+
+    \CRM_Core_Config::singleton()->userPermissionClass->permissions = ['edit memberships', 'delete in CiviMember', 'edit groups'];
+    $tasks = CRM_Member_Task::permissionedTaskTitles(CRM_Core_Permission::EDIT);
+    $this->assertEquals([
+      8 => 'Export members',
+      5 => 'Print selected rows',
+      9 => 'Email - send now (to 50 or less)',
+      201 => 'Mailing labels - print',
+      3 => 'Print/merge document for memberships',
+      6 => 'Update multiple memberships',
+      4 => 'Delete memberships',
+      12 => 'Group - create smart group',
+    ], $tasks);
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Alternate potential approach to the enotice portion of https://github.com/civicrm/civicrm-core/pull/20940

This approach adds support for permissions using a syntax like the [summary actions hook](https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_summaryActions/) when defining a task - ie

```
$task['blah'] => [
  'permissions' => ['edit memberships'],
];

$task['blah2'] => [
  'permissions' => [['edit memberships', 'view memberships]],
];

```
If we get to the point where it is consistent we can document it as an alternative for extensions (although they may still choose to stick with 'unset') when working with the [search tasks hook](https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_searchTasks/)

The last place where we provide task (I hope) is [searchKitTasks](https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_searchKitTasks/) which kinda leverages search tasks


Before
----------------------------------------
No tests on the function, enotices when tasks are unset, confusing code with lots of setting & unsetting and no 'source of knowledge' - ie consistent metadata.

After
----------------------------------------
A more metadata based approach, potential for more cleanup / integration with `parent:permissionedTaskTitles`

![image](https://user-images.githubusercontent.com/336308/126859343-d28fb74c-a0fa-4f7c-8e4d-9bba197c8cdf.png)

Technical Details
----------------------------------------
It took me quite a while to figure out what the EDIT_PERMISSION actually meant and I didn't have any good ideas for how to handle it other than extending test cover and documentation and marking the metadata parameter as 'possibly temporary'

Comments
----------------------------------------
@mattwire potential alternate approach to the enotices in the PR you put up.
@colemanw note the permissions key would potentially be one hooks could set in search kit too - although as I mention they ALSO have the option to unset based on more complex conditions