### PR TITLE
Check for no action task so we don't add an undefined page

### DIFF
--- a/CRM/Contact/StateMachine/Search.php
+++ b/CRM/Contact/StateMachine/Search.php
@@ -50,13 +50,15 @@ class CRM_Contact_StateMachine_Search extends CRM_Core_StateMachine {
       list($task, $result) = $this->taskName($controller, 'Basic');
     }
     $this->_task = $task;
-    if (is_array($task)) {
-      foreach ($task as $t) {
-        $this->_pages[$t] = NULL;
+    if (isset($task)) {
+      if (is_array($task)) {
+        foreach ($task as $t) {
+          $this->_pages[$t] = NULL;
+        }
       }
-    }
-    else {
-      $this->_pages[$task] = NULL;
+      else {
+        $this->_pages[$task] = NULL;
+      }
     }
 
     if ($result) {


### PR DESCRIPTION
Overview
----------------------------------------
Partial from https://github.com/civicrm/civicrm-core/pull/20940 which contains the actual fix for the crash (there's a lot of PHP notice fixes there too but the actual fix is a small change so extracted here for ease of review).

This was found following release 1.2 of [exportpermissions](https://github.com/progressivetech/net.ourpowerbase.exportpermission) extension which supports disabling export/print/pdf/labels tasks. It turns out that disabling all of these can cause the advanced search to fail because some "modules" do not have any search tasks - see https://github.com/progressivetech/net.ourpowerbase.exportpermission/issues/6.

Specifically Activities and Mailings trigger a "Network error" when you click the accordion to expand the search criteria because when there are no tasks defined a "null" page gets added which then triggers a `require_once('.php')` here https://github.com/civicrm/civicrm-core/blob/master/CRM/Core/Controller.php#L452 because `$className` is not defined.

Before
----------------------------------------
When a search task has no actions (eg. Activity, Mailings) and it is expanded in Advanced Search it crashes.

After
----------------------------------------
All tasks can be disabled and everything continues working!

Technical Details
----------------------------------------


Comments
----------------------------------------
