### PR TITLE
Fix error message when unable to delete ManagedEntity

### DIFF
--- a/CRM/Core/ManagedEntities.php
+++ b/CRM/Core/ManagedEntities.php
@@ -367,6 +367,9 @@ class CRM_Core_ManagedEntities {
       if ((bool) $check['count']) {
         $result = civicrm_api($dao->entity_type, 'delete', $params);
         if ($result['is_error']) {
+          if (isset($dao->name)) {
+            $params['name'] = $dao->name;
+          }
           $this->onApiError($dao->entity_type, 'delete', $params, $result);
         }
       }
@@ -482,7 +485,7 @@ class CRM_Core_ManagedEntities {
       'result' => $result,
     ]);
     throw new Exception('API error: ' . $result['error_message'] . ' on ' . $entity . '.' . $action
-      . !empty($params['name']) ? '( entity name ' . $params['name'] . ')' : ''
+      . (!empty($params['name']) ? '( entity name ' . $params['name'] . ')' : '')
     );
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Error message was effectively being overwritten because of missing brackets when generating message. In this case I added a new paymentprocessortype via ManagedEntity and then rolled the extension back to a previous version that did not include that managed entity. That triggered the error message.

Before
----------------------------------------
Exception: "( entity name )"

After
----------------------------------------
Exception "API error: Could not delete payment processor type on payment_processor_type.delete( entity name Authorize.Net (Accept.js))"

Technical Details
----------------------------------------
An extra set of brackets was needed.

Comments
----------------------------------------

