### PR TITLE
dev/core#2704 SearchKit - Add support for SQL functions

### DIFF
--- a/CRM/Api4/Page/Api4Explorer.php
+++ b/CRM/Api4/Page/Api4Explorer.php
@@ -61,6 +61,7 @@ class CRM_Api4_Page_Api4Explorer extends CRM_Core_Page {
             'title' => $className::getTitle(),
             'params' => $className::getParams(),
             'category' => $className::getCategory(),
+            'dataType' => $className::getDataType(),
           ];
         }
       }

--- a/Civi/Api4/Query/SqlFunction.php
+++ b/Civi/Api4/Query/SqlFunction.php
@@ -19,11 +19,6 @@ namespace Civi\Api4\Query;
 abstract class SqlFunction extends SqlExpression {
 
   /**
-   * @var array
-   */
-  protected static $params = [];
-
-  /**
    * @var array[]
    */
   protected $args = [];
@@ -224,9 +219,9 @@ abstract class SqlFunction extends SqlExpression {
    * Get the param metadata for this sql function.
    * @return array
    */
-  public static function getParams(): array {
+  final public static function getParams(): array {
     $params = [];
-    foreach (static::$params as $param) {
+    foreach (static::params() as $param) {
       // Merge in defaults to ensure each param has these properties
       $params[] = $param + [
         'prefix' => [],
@@ -241,6 +236,8 @@ abstract class SqlFunction extends SqlExpression {
     }
     return $params;
   }
+
+  abstract protected static function params(): array;
 
   /**
    * Get the arguments passed to this sql function instance.

--- a/Civi/Api4/Query/SqlFunction.php
+++ b/Civi/Api4/Query/SqlFunction.php
@@ -30,6 +30,13 @@ abstract class SqlFunction extends SqlExpression {
    */
   protected static $category;
 
+  /**
+   * Data type output by this function
+   *
+   * @var string
+   */
+  protected static $dataType;
+
   const CATEGORY_AGGREGATE = 'aggregate',
     CATEGORY_COMPARISON = 'comparison',
     CATEGORY_DATE = 'date',
@@ -76,6 +83,21 @@ abstract class SqlFunction extends SqlExpression {
         $this->args[$idx]['suffix'] = (array) $this->captureKeyword(array_keys($param['flag_after']), $arg);
       }
     }
+  }
+
+  /**
+   * Change $dataType according to output of function
+   *
+   * @see \Civi\Api4\Utils\FormattingUtil::formatOutputValues
+   * @param string $value
+   * @param string $dataType
+   * @return string
+   */
+  public function formatOutputValue($value, &$dataType) {
+    if (static::$dataType) {
+      $dataType = static::$dataType;
+    }
+    return $value;
   }
 
   /**
@@ -264,6 +286,13 @@ abstract class SqlFunction extends SqlExpression {
    */
   public static function getCategory(): string {
     return static::$category;
+  }
+
+  /**
+   * @return string|NULL
+   */
+  public static function getDataType():? string {
+    return static::$dataType;
   }
 
   /**

--- a/Civi/Api4/Query/SqlFunctionABS.php
+++ b/Civi/Api4/Query/SqlFunctionABS.php
@@ -18,12 +18,14 @@ class SqlFunctionABS extends SqlFunction {
 
   protected static $category = self::CATEGORY_MATH;
 
-  protected static $params = [
-    [
-      'optional' => FALSE,
-      'must_be' => ['SqlField', 'SqlNumber'],
-    ],
-  ];
+  protected static function params(): array {
+    return [
+      [
+        'optional' => FALSE,
+        'must_be' => ['SqlField', 'SqlNumber'],
+      ],
+    ];
+  }
 
   /**
    * @return string

--- a/Civi/Api4/Query/SqlFunctionAVG.php
+++ b/Civi/Api4/Query/SqlFunctionAVG.php
@@ -18,12 +18,14 @@ class SqlFunctionAVG extends SqlFunction {
 
   protected static $category = self::CATEGORY_AGGREGATE;
 
-  protected static $params = [
-    [
-      'prefix' => ['', 'DISTINCT', 'ALL'],
-      'must_be' => ['SqlField'],
-    ],
-  ];
+  protected static function params(): array {
+    return [
+      [
+        'prefix' => ['', 'DISTINCT', 'ALL'],
+        'must_be' => ['SqlField'],
+      ],
+    ];
+  }
 
   /**
    * @return string

--- a/Civi/Api4/Query/SqlFunctionAVG.php
+++ b/Civi/Api4/Query/SqlFunctionAVG.php
@@ -21,7 +21,7 @@ class SqlFunctionAVG extends SqlFunction {
   protected static function params(): array {
     return [
       [
-        'prefix' => ['', 'DISTINCT', 'ALL'],
+        'flag_before' => ['DISTINCT' => ts('Distinct')],
         'must_be' => ['SqlField'],
       ],
     ];

--- a/Civi/Api4/Query/SqlFunctionCOALESCE.php
+++ b/Civi/Api4/Query/SqlFunctionCOALESCE.php
@@ -18,12 +18,14 @@ class SqlFunctionCOALESCE extends SqlFunction {
 
   protected static $category = self::CATEGORY_COMPARISON;
 
-  protected static $params = [
-    [
-      'max_expr' => 99,
-      'optional' => FALSE,
-    ],
-  ];
+  protected static function params(): array {
+    return [
+      [
+        'max_expr' => 99,
+        'optional' => FALSE,
+      ],
+    ];
+  }
 
   /**
    * @return string

--- a/Civi/Api4/Query/SqlFunctionCOALESCE.php
+++ b/Civi/Api4/Query/SqlFunctionCOALESCE.php
@@ -18,6 +18,8 @@ class SqlFunctionCOALESCE extends SqlFunction {
 
   protected static $category = self::CATEGORY_COMPARISON;
 
+  protected static $dataType = 'String';
+
   protected static function params(): array {
     return [
       [
@@ -32,19 +34,6 @@ class SqlFunctionCOALESCE extends SqlFunction {
    */
   public static function getTitle(): string {
     return ts('Coalesce');
-  }
-
-  /**
-   * Prevent reformatting
-   *
-   * @see \Civi\Api4\Utils\FormattingUtil::formatOutputValues
-   * @param string $value
-   * @param string $dataType
-   * @return string|array
-   */
-  public function formatOutputValue($value, &$dataType) {
-    $dataType = NULL;
-    return $value;
   }
 
 }

--- a/Civi/Api4/Query/SqlFunctionCONCAT.php
+++ b/Civi/Api4/Query/SqlFunctionCONCAT.php
@@ -18,6 +18,8 @@ class SqlFunctionCONCAT extends SqlFunction {
 
   protected static $category = self::CATEGORY_STRING;
 
+  protected static $dataType = 'String';
+
   protected static function params(): array {
     return [
       [
@@ -33,19 +35,6 @@ class SqlFunctionCONCAT extends SqlFunction {
    */
   public static function getTitle(): string {
     return ts('Combine');
-  }
-
-  /**
-   * Prevent reformatting of result
-   *
-   * @see \Civi\Api4\Utils\FormattingUtil::formatOutputValues
-   * @param string $value
-   * @param string $dataType
-   * @return string|array
-   */
-  public function formatOutputValue($value, &$dataType) {
-    $dataType = NULL;
-    return $value;
   }
 
 }

--- a/Civi/Api4/Query/SqlFunctionCONCAT.php
+++ b/Civi/Api4/Query/SqlFunctionCONCAT.php
@@ -18,13 +18,15 @@ class SqlFunctionCONCAT extends SqlFunction {
 
   protected static $category = self::CATEGORY_STRING;
 
-  protected static $params = [
-    [
-      'max_expr' => 99,
-      'optional' => FALSE,
-      'must_be' => ['SqlField', 'SqlString'],
-    ],
-  ];
+  protected static function params(): array {
+    return [
+      [
+        'max_expr' => 99,
+        'optional' => FALSE,
+        'must_be' => ['SqlField', 'SqlString'],
+      ],
+    ];
+  }
 
   /**
    * @return string

--- a/Civi/Api4/Query/SqlFunctionCOUNT.php
+++ b/Civi/Api4/Query/SqlFunctionCOUNT.php
@@ -21,7 +21,7 @@ class SqlFunctionCOUNT extends SqlFunction {
   protected static function params(): array {
     return [
       [
-        'prefix' => ['', 'DISTINCT', 'ALL'],
+        'flag_before' => ['DISTINCT' => ts('Distinct')],
         'max_expr' => 1,
         'must_be' => ['SqlField', 'SqlWild'],
         'cant_be' => [],

--- a/Civi/Api4/Query/SqlFunctionCOUNT.php
+++ b/Civi/Api4/Query/SqlFunctionCOUNT.php
@@ -18,14 +18,16 @@ class SqlFunctionCOUNT extends SqlFunction {
 
   protected static $category = self::CATEGORY_AGGREGATE;
 
-  protected static $params = [
-    [
-      'prefix' => ['', 'DISTINCT', 'ALL'],
-      'max_expr' => 1,
-      'must_be' => ['SqlField', 'SqlWild'],
-      'cant_be' => [],
-    ],
-  ];
+  protected static function params(): array {
+    return [
+      [
+        'prefix' => ['', 'DISTINCT', 'ALL'],
+        'max_expr' => 1,
+        'must_be' => ['SqlField', 'SqlWild'],
+        'cant_be' => [],
+      ],
+    ];
+  }
 
   /**
    * Reformat result as integer

--- a/Civi/Api4/Query/SqlFunctionCOUNT.php
+++ b/Civi/Api4/Query/SqlFunctionCOUNT.php
@@ -18,6 +18,8 @@ class SqlFunctionCOUNT extends SqlFunction {
 
   protected static $category = self::CATEGORY_AGGREGATE;
 
+  protected static $dataType = 'Integer';
+
   protected static function params(): array {
     return [
       [
@@ -27,20 +29,6 @@ class SqlFunctionCOUNT extends SqlFunction {
         'cant_be' => [],
       ],
     ];
-  }
-
-  /**
-   * Reformat result as integer
-   *
-   * @see \Civi\Api4\Utils\FormattingUtil::formatOutputValues
-   * @param string $value
-   * @param string $dataType
-   * @return string|array
-   */
-  public function formatOutputValue($value, &$dataType) {
-    // Count is always an integer
-    $dataType = 'Integer';
-    return (int) $value;
   }
 
   /**

--- a/Civi/Api4/Query/SqlFunctionCURDATE.php
+++ b/Civi/Api4/Query/SqlFunctionCURDATE.php
@@ -18,6 +18,10 @@ class SqlFunctionCURDATE extends SqlFunction {
 
   protected static $category = self::CATEGORY_DATE;
 
+  protected static function params(): array {
+    return [];
+  }
+
   /**
    * @return string
    */

--- a/Civi/Api4/Query/SqlFunctionDATE.php
+++ b/Civi/Api4/Query/SqlFunctionDATE.php
@@ -1,0 +1,50 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Query;
+
+/**
+ * Sql function
+ */
+class SqlFunctionDATE extends SqlFunction {
+
+  protected static $category = self::CATEGORY_DATE;
+
+  protected static function params(): array {
+    return [
+      [
+        'max_expr' => 1,
+        'optional' => FALSE,
+      ],
+    ];
+  }
+
+  /**
+   * @return string
+   */
+  public static function getTitle(): string {
+    return ts('Date Only');
+  }
+
+  /**
+   * Ensure is processed as type Date
+   *
+   * @see \Civi\Api4\Utils\FormattingUtil::formatOutputValues
+   * @param string $value
+   * @param string $dataType
+   * @return string|array
+   */
+  public function formatOutputValue($value, &$dataType) {
+    $dataType = 'Date';
+    return $value;
+  }
+
+}

--- a/Civi/Api4/Query/SqlFunctionDATE.php
+++ b/Civi/Api4/Query/SqlFunctionDATE.php
@@ -18,6 +18,8 @@ class SqlFunctionDATE extends SqlFunction {
 
   protected static $category = self::CATEGORY_DATE;
 
+  protected static $dataType = 'Date';
+
   protected static function params(): array {
     return [
       [
@@ -32,19 +34,6 @@ class SqlFunctionDATE extends SqlFunction {
    */
   public static function getTitle(): string {
     return ts('Date Only');
-  }
-
-  /**
-   * Ensure is processed as type Date
-   *
-   * @see \Civi\Api4\Utils\FormattingUtil::formatOutputValues
-   * @param string $value
-   * @param string $dataType
-   * @return string|array
-   */
-  public function formatOutputValue($value, &$dataType) {
-    $dataType = 'Date';
-    return $value;
   }
 
 }

--- a/Civi/Api4/Query/SqlFunctionGREATEST.php
+++ b/Civi/Api4/Query/SqlFunctionGREATEST.php
@@ -20,12 +20,14 @@ class SqlFunctionGREATEST extends SqlFunction {
 
   protected static $category = self::CATEGORY_COMPARISON;
 
-  protected static $params = [
-    [
-      'max_expr' => 99,
-      'optional' => FALSE,
-    ],
-  ];
+  protected static function params(): array {
+    return [
+      [
+        'max_expr' => 99,
+        'optional' => FALSE,
+      ],
+    ];
+  }
 
   /**
    * @return string

--- a/Civi/Api4/Query/SqlFunctionGROUP_CONCAT.php
+++ b/Civi/Api4/Query/SqlFunctionGROUP_CONCAT.php
@@ -62,13 +62,13 @@ class SqlFunctionGROUP_CONCAT extends SqlFunction {
     if (isset($exprArgs[2]['expr'][0]->expr) && $exprArgs[2]['expr'][0]->expr === \CRM_Core_DAO::VALUE_SEPARATOR) {
       $value = explode(\CRM_Core_DAO::VALUE_SEPARATOR, $value);
       // If the first expression is another sqlFunction, allow it to control the dataType
-      if ($exprArgs[0]['expr'][0] instanceof SqlFunction && is_callable([$exprArgs[0]['expr'][0], 'formatOutputValue'])) {
+      if ($exprArgs[0]['expr'][0] instanceof SqlFunction) {
         $exprArgs[0]['expr'][0]->formatOutputValue(NULL, $dataType);
       }
     }
-    // If using custom separator, unset $dataType to preserve raw string
+    // If using custom separator, preserve raw string
     else {
-      $dataType = NULL;
+      $dataType = 'String';
     }
     return $value;
   }

--- a/Civi/Api4/Query/SqlFunctionGROUP_CONCAT.php
+++ b/Civi/Api4/Query/SqlFunctionGROUP_CONCAT.php
@@ -23,20 +23,20 @@ class SqlFunctionGROUP_CONCAT extends SqlFunction {
   protected static function params(): array {
     return [
       [
-        'prefix' => ['', 'DISTINCT', 'ALL'],
+        'flag_before' => ['DISTINCT' => ts('Distinct')],
         'max_expr' => 1,
         'must_be' => ['SqlField', 'SqlFunction'],
         'optional' => FALSE,
       ],
       [
-        'prefix' => ['ORDER BY'],
+        'prefix' => 'ORDER BY',
         'max_expr' => 1,
-        'suffix' => ['', 'ASC', 'DESC'],
+        'flag_after' => ['ASC' => ts('Ascending'), 'DESC' => ts('Descending')],
         'must_be' => ['SqlField'],
         'optional' => TRUE,
       ],
       [
-        'prefix' => ['SEPARATOR'],
+        'prefix' => 'SEPARATOR',
         'max_expr' => 1,
         'must_be' => ['SqlString'],
         'optional' => TRUE,
@@ -59,7 +59,7 @@ class SqlFunctionGROUP_CONCAT extends SqlFunction {
   public function formatOutputValue($value, &$dataType) {
     $exprArgs = $this->getArgs();
     // By default, values are split into an array and formatted according to the field's dataType
-    if (!$exprArgs[2]['prefix']) {
+    if (isset($exprArgs[2]['expr'][0]->expr) && $exprArgs[2]['expr'][0]->expr === \CRM_Core_DAO::VALUE_SEPARATOR) {
       $value = explode(\CRM_Core_DAO::VALUE_SEPARATOR, $value);
       // If the first expression is another sqlFunction, allow it to control the dataType
       if ($exprArgs[0]['expr'][0] instanceof SqlFunction && is_callable([$exprArgs[0]['expr'][0], 'formatOutputValue'])) {

--- a/Civi/Api4/Query/SqlFunctionGROUP_CONCAT.php
+++ b/Civi/Api4/Query/SqlFunctionGROUP_CONCAT.php
@@ -20,31 +20,33 @@ class SqlFunctionGROUP_CONCAT extends SqlFunction {
 
   protected static $category = self::CATEGORY_AGGREGATE;
 
-  protected static $params = [
-    [
-      'prefix' => ['', 'DISTINCT', 'ALL'],
-      'max_expr' => 1,
-      'must_be' => ['SqlField', 'SqlFunction'],
-      'optional' => FALSE,
-    ],
-    [
-      'prefix' => ['ORDER BY'],
-      'max_expr' => 1,
-      'suffix' => ['', 'ASC', 'DESC'],
-      'must_be' => ['SqlField'],
-      'optional' => TRUE,
-    ],
-    [
-      'prefix' => ['SEPARATOR'],
-      'max_expr' => 1,
-      'must_be' => ['SqlString'],
-      'optional' => TRUE,
-      // @see self::formatOutput()
-      'api_default' => [
-        'expr' => ['"' . \CRM_Core_DAO::VALUE_SEPARATOR . '"'],
+  protected static function params(): array {
+    return [
+      [
+        'prefix' => ['', 'DISTINCT', 'ALL'],
+        'max_expr' => 1,
+        'must_be' => ['SqlField', 'SqlFunction'],
+        'optional' => FALSE,
       ],
-    ],
-  ];
+      [
+        'prefix' => ['ORDER BY'],
+        'max_expr' => 1,
+        'suffix' => ['', 'ASC', 'DESC'],
+        'must_be' => ['SqlField'],
+        'optional' => TRUE,
+      ],
+      [
+        'prefix' => ['SEPARATOR'],
+        'max_expr' => 1,
+        'must_be' => ['SqlString'],
+        'optional' => TRUE,
+        // @see self::formatOutput()
+        'api_default' => [
+          'expr' => ['"' . \CRM_Core_DAO::VALUE_SEPARATOR . '"'],
+        ],
+      ],
+    ];
+  }
 
   /**
    * Reformat result as array if using default separator

--- a/Civi/Api4/Query/SqlFunctionIF.php
+++ b/Civi/Api4/Query/SqlFunctionIF.php
@@ -18,6 +18,8 @@ class SqlFunctionIF extends SqlFunction {
 
   protected static $category = self::CATEGORY_COMPARISON;
 
+  protected static $dataType = 'String';
+
   protected static function params(): array {
     return [
       [
@@ -33,19 +35,6 @@ class SqlFunctionIF extends SqlFunction {
    */
   public static function getTitle(): string {
     return ts('If');
-  }
-
-  /**
-   * Prevent formatting based on first field
-   *
-   * @see \Civi\Api4\Utils\FormattingUtil::formatOutputValues
-   * @param string $value
-   * @param string $dataType
-   * @return string|array
-   */
-  public function formatOutputValue($value, &$dataType) {
-    $dataType = NULL;
-    return $value;
   }
 
 }

--- a/Civi/Api4/Query/SqlFunctionIF.php
+++ b/Civi/Api4/Query/SqlFunctionIF.php
@@ -18,13 +18,15 @@ class SqlFunctionIF extends SqlFunction {
 
   protected static $category = self::CATEGORY_COMPARISON;
 
-  protected static $params = [
-    [
-      'min_expr' => 3,
-      'max_expr' => 3,
-      'optional' => FALSE,
-    ],
-  ];
+  protected static function params(): array {
+    return [
+      [
+        'min_expr' => 3,
+        'max_expr' => 3,
+        'optional' => FALSE,
+      ],
+    ];
+  }
 
   /**
    * @return string

--- a/Civi/Api4/Query/SqlFunctionISNULL.php
+++ b/Civi/Api4/Query/SqlFunctionISNULL.php
@@ -18,11 +18,13 @@ class SqlFunctionISNULL extends SqlFunction {
 
   protected static $category = self::CATEGORY_COMPARISON;
 
-  protected static $params = [
-    [
-      'optional' => FALSE,
-    ],
-  ];
+  protected static function params(): array {
+    return [
+      [
+        'optional' => FALSE,
+      ],
+    ];
+  }
 
   /**
    * @return string

--- a/Civi/Api4/Query/SqlFunctionISNULL.php
+++ b/Civi/Api4/Query/SqlFunctionISNULL.php
@@ -18,6 +18,8 @@ class SqlFunctionISNULL extends SqlFunction {
 
   protected static $category = self::CATEGORY_COMPARISON;
 
+  protected static $dataType = 'Boolean';
+
   protected static function params(): array {
     return [
       [
@@ -31,20 +33,6 @@ class SqlFunctionISNULL extends SqlFunction {
    */
   public static function getTitle(): string {
     return ts('Is null');
-  }
-
-  /**
-   * Reformat result as boolean
-   *
-   * @see \Civi\Api4\Utils\FormattingUtil::formatOutputValues
-   * @param string $value
-   * @param string $dataType
-   * @return string|array
-   */
-  public function formatOutputValue($value, &$dataType) {
-    // Value is always TRUE or FALSE
-    $dataType = 'Boolean';
-    return $value;
   }
 
 }

--- a/Civi/Api4/Query/SqlFunctionLEAST.php
+++ b/Civi/Api4/Query/SqlFunctionLEAST.php
@@ -20,12 +20,14 @@ class SqlFunctionLEAST extends SqlFunction {
 
   protected static $category = self::CATEGORY_COMPARISON;
 
-  protected static $params = [
-    [
-      'max_expr' => 99,
-      'optional' => FALSE,
-    ],
-  ];
+  protected static function params(): array {
+    return [
+      [
+        'max_expr' => 99,
+        'optional' => FALSE,
+      ],
+    ];
+  }
 
   /**
    * @return string

--- a/Civi/Api4/Query/SqlFunctionLOWER.php
+++ b/Civi/Api4/Query/SqlFunctionLOWER.php
@@ -18,12 +18,14 @@ class SqlFunctionLOWER extends SqlFunction {
 
   protected static $category = self::CATEGORY_STRING;
 
-  protected static $params = [
-    [
-      'optional' => FALSE,
-      'must_be' => ['SqlField', 'SqlString'],
-    ],
-  ];
+  protected static function params(): array {
+    return [
+      [
+        'optional' => FALSE,
+        'must_be' => ['SqlField', 'SqlString'],
+      ],
+    ];
+  }
 
   /**
    * @return string

--- a/Civi/Api4/Query/SqlFunctionMAX.php
+++ b/Civi/Api4/Query/SqlFunctionMAX.php
@@ -23,7 +23,7 @@ class SqlFunctionMAX extends SqlFunction {
   protected static function params(): array {
     return [
       [
-        'prefix' => ['', 'DISTINCT', 'ALL'],
+        'flag_before' => ['DISTINCT' => ts('Distinct')],
         'must_be' => ['SqlField'],
       ],
     ];

--- a/Civi/Api4/Query/SqlFunctionMAX.php
+++ b/Civi/Api4/Query/SqlFunctionMAX.php
@@ -20,12 +20,14 @@ class SqlFunctionMAX extends SqlFunction {
 
   protected static $category = self::CATEGORY_AGGREGATE;
 
-  protected static $params = [
-    [
-      'prefix' => ['', 'DISTINCT', 'ALL'],
-      'must_be' => ['SqlField'],
-    ],
-  ];
+  protected static function params(): array {
+    return [
+      [
+        'prefix' => ['', 'DISTINCT', 'ALL'],
+        'must_be' => ['SqlField'],
+      ],
+    ];
+  }
 
   /**
    * @return string

--- a/Civi/Api4/Query/SqlFunctionMIN.php
+++ b/Civi/Api4/Query/SqlFunctionMIN.php
@@ -23,7 +23,7 @@ class SqlFunctionMIN extends SqlFunction {
   protected static function params(): array {
     return [
       [
-        'prefix' => ['', 'DISTINCT', 'ALL'],
+        'flag_before' => ['DISTINCT' => ts('Distinct')],
         'must_be' => ['SqlField'],
       ],
     ];

--- a/Civi/Api4/Query/SqlFunctionMIN.php
+++ b/Civi/Api4/Query/SqlFunctionMIN.php
@@ -20,12 +20,14 @@ class SqlFunctionMIN extends SqlFunction {
 
   protected static $category = self::CATEGORY_AGGREGATE;
 
-  protected static $params = [
-    [
-      'prefix' => ['', 'DISTINCT', 'ALL'],
-      'must_be' => ['SqlField'],
-    ],
-  ];
+  protected static function params(): array {
+    return [
+      [
+        'prefix' => ['', 'DISTINCT', 'ALL'],
+        'must_be' => ['SqlField'],
+      ],
+    ];
+  }
 
   /**
    * @return string

--- a/Civi/Api4/Query/SqlFunctionNULLIF.php
+++ b/Civi/Api4/Query/SqlFunctionNULLIF.php
@@ -20,13 +20,15 @@ class SqlFunctionNULLIF extends SqlFunction {
 
   protected static $category = self::CATEGORY_COMPARISON;
 
-  protected static $params = [
-    [
-      'min_expr' => 2,
-      'max_expr' => 2,
-      'optional' => FALSE,
-    ],
-  ];
+  protected static function params(): array {
+    return [
+      [
+        'min_expr' => 2,
+        'max_expr' => 2,
+        'optional' => FALSE,
+      ],
+    ];
+  }
 
   /**
    * @return string

--- a/Civi/Api4/Query/SqlFunctionREPLACE.php
+++ b/Civi/Api4/Query/SqlFunctionREPLACE.php
@@ -21,14 +21,8 @@ class SqlFunctionREPLACE extends SqlFunction {
   protected static function params(): array {
     return [
       [
-        'optional' => FALSE,
-        'must_be' => ['SqlField', 'SqlString'],
-      ],
-      [
-        'optional' => FALSE,
-        'must_be' => ['SqlField', 'SqlString'],
-      ],
-      [
+        'min_expr' => 3,
+        'max_expr' => 3,
         'optional' => FALSE,
         'must_be' => ['SqlField', 'SqlString'],
       ],

--- a/Civi/Api4/Query/SqlFunctionREPLACE.php
+++ b/Civi/Api4/Query/SqlFunctionREPLACE.php
@@ -18,20 +18,22 @@ class SqlFunctionREPLACE extends SqlFunction {
 
   protected static $category = self::CATEGORY_STRING;
 
-  protected static $params = [
-    [
-      'optional' => FALSE,
-      'must_be' => ['SqlField', 'SqlString'],
-    ],
-    [
-      'optional' => FALSE,
-      'must_be' => ['SqlField', 'SqlString'],
-    ],
-    [
-      'optional' => FALSE,
-      'must_be' => ['SqlField', 'SqlString'],
-    ],
-  ];
+  protected static function params(): array {
+    return [
+      [
+        'optional' => FALSE,
+        'must_be' => ['SqlField', 'SqlString'],
+      ],
+      [
+        'optional' => FALSE,
+        'must_be' => ['SqlField', 'SqlString'],
+      ],
+      [
+        'optional' => FALSE,
+        'must_be' => ['SqlField', 'SqlString'],
+      ],
+    ];
+  }
 
   /**
    * @return string

--- a/Civi/Api4/Query/SqlFunctionROUND.php
+++ b/Civi/Api4/Query/SqlFunctionROUND.php
@@ -18,16 +18,18 @@ class SqlFunctionROUND extends SqlFunction {
 
   protected static $category = self::CATEGORY_MATH;
 
-  protected static $params = [
-    [
-      'optional' => FALSE,
-      'must_be' => ['SqlField', 'SqlNumber'],
-    ],
-    [
-      'optional' => TRUE,
-      'must_be' => ['SqlNumber'],
-    ],
-  ];
+  protected static function params(): array {
+    return [
+      [
+        'optional' => FALSE,
+        'must_be' => ['SqlField', 'SqlNumber'],
+      ],
+      [
+        'optional' => TRUE,
+        'must_be' => ['SqlNumber'],
+      ],
+    ];
+  }
 
   /**
    * @return string

--- a/Civi/Api4/Query/SqlFunctionSUM.php
+++ b/Civi/Api4/Query/SqlFunctionSUM.php
@@ -18,12 +18,14 @@ class SqlFunctionSUM extends SqlFunction {
 
   protected static $category = self::CATEGORY_AGGREGATE;
 
-  protected static $params = [
-    [
-      'prefix' => ['', 'DISTINCT', 'ALL'],
-      'must_be' => ['SqlField'],
-    ],
-  ];
+  protected static function params(): array {
+    return [
+      [
+        'prefix' => ['', 'DISTINCT', 'ALL'],
+        'must_be' => ['SqlField'],
+      ],
+    ];
+  }
 
   /**
    * @return string

--- a/Civi/Api4/Query/SqlFunctionSUM.php
+++ b/Civi/Api4/Query/SqlFunctionSUM.php
@@ -21,7 +21,7 @@ class SqlFunctionSUM extends SqlFunction {
   protected static function params(): array {
     return [
       [
-        'prefix' => ['', 'DISTINCT', 'ALL'],
+        'flag_before' => ['DISTINCT' => ts('Distinct')],
         'must_be' => ['SqlField'],
       ],
     ];

--- a/Civi/Api4/Query/SqlFunctionTIME.php
+++ b/Civi/Api4/Query/SqlFunctionTIME.php
@@ -1,0 +1,50 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Query;
+
+/**
+ * Sql function
+ */
+class SqlFunctionTIME extends SqlFunction {
+
+  protected static $category = self::CATEGORY_DATE;
+
+  protected static function params(): array {
+    return [
+      [
+        'max_expr' => 1,
+        'optional' => FALSE,
+      ],
+    ];
+  }
+
+  /**
+   * @return string
+   */
+  public static function getTitle(): string {
+    return ts('Time Only');
+  }
+
+  /**
+   * Prevent reformatting
+   *
+   * @see \Civi\Api4\Utils\FormattingUtil::formatOutputValues
+   * @param string $value
+   * @param string $dataType
+   * @return string|array
+   */
+  public function formatOutputValue($value, &$dataType) {
+    $dataType = NULL;
+    return $value;
+  }
+
+}

--- a/Civi/Api4/Query/SqlFunctionTIME.php
+++ b/Civi/Api4/Query/SqlFunctionTIME.php
@@ -18,6 +18,8 @@ class SqlFunctionTIME extends SqlFunction {
 
   protected static $category = self::CATEGORY_DATE;
 
+  protected static $dataType = 'Time';
+
   protected static function params(): array {
     return [
       [
@@ -32,19 +34,6 @@ class SqlFunctionTIME extends SqlFunction {
    */
   public static function getTitle(): string {
     return ts('Time Only');
-  }
-
-  /**
-   * Prevent reformatting
-   *
-   * @see \Civi\Api4\Utils\FormattingUtil::formatOutputValues
-   * @param string $value
-   * @param string $dataType
-   * @return string|array
-   */
-  public function formatOutputValue($value, &$dataType) {
-    $dataType = NULL;
-    return $value;
   }
 
 }

--- a/Civi/Api4/Query/SqlFunctionUPPER.php
+++ b/Civi/Api4/Query/SqlFunctionUPPER.php
@@ -18,12 +18,14 @@ class SqlFunctionUPPER extends SqlFunction {
 
   protected static $category = self::CATEGORY_STRING;
 
-  protected static $params = [
-    [
-      'optional' => FALSE,
-      'must_be' => ['SqlField', 'SqlString'],
-    ],
-  ];
+  protected static function params(): array {
+    return [
+      [
+        'optional' => FALSE,
+        'must_be' => ['SqlField', 'SqlString'],
+      ],
+    ];
+  }
 
   /**
    * @return string

--- a/Civi/Api4/Query/SqlFunctionYEAR.php
+++ b/Civi/Api4/Query/SqlFunctionYEAR.php
@@ -18,6 +18,8 @@ class SqlFunctionYEAR extends SqlFunction {
 
   protected static $category = self::CATEGORY_DATE;
 
+  protected static $dataType = 'Integer';
+
   protected static function params(): array {
     return [
       [
@@ -32,19 +34,6 @@ class SqlFunctionYEAR extends SqlFunction {
    */
   public static function getTitle(): string {
     return ts('Year Only');
-  }
-
-  /**
-   * Prevent reformatting
-   *
-   * @see \Civi\Api4\Utils\FormattingUtil::formatOutputValues
-   * @param string $value
-   * @param string $dataType
-   * @return string|array
-   */
-  public function formatOutputValue($value, &$dataType) {
-    $dataType = NULL;
-    return $value;
   }
 
 }

--- a/Civi/Api4/Query/SqlFunctionYEAR.php
+++ b/Civi/Api4/Query/SqlFunctionYEAR.php
@@ -1,0 +1,50 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Query;
+
+/**
+ * Sql function
+ */
+class SqlFunctionYEAR extends SqlFunction {
+
+  protected static $category = self::CATEGORY_DATE;
+
+  protected static function params(): array {
+    return [
+      [
+        'max_expr' => 1,
+        'optional' => FALSE,
+      ],
+    ];
+  }
+
+  /**
+   * @return string
+   */
+  public static function getTitle(): string {
+    return ts('Year Only');
+  }
+
+  /**
+   * Prevent reformatting
+   *
+   * @see \Civi\Api4\Utils\FormattingUtil::formatOutputValues
+   * @param string $value
+   * @param string $dataType
+   * @return string|array
+   */
+  public function formatOutputValue($value, &$dataType) {
+    $dataType = NULL;
+    return $value;
+  }
+
+}

--- a/Civi/Api4/Utils/FormattingUtil.php
+++ b/Civi/Api4/Utils/FormattingUtil.php
@@ -200,12 +200,9 @@ class FormattingUtil {
         $fieldName = \CRM_Utils_Array::first($fieldExpr->getFields());
         $field = $fieldName && isset($fields[$fieldName]) ? $fields[$fieldName] : NULL;
         $dataType = $field['data_type'] ?? ($fieldName == 'id' ? 'Integer' : NULL);
-        // If Sql Function e.g. GROUP_CONCAT or COUNT wants to do its own formatting, apply
+        // Allow Sql Functions to do special formatting and/or alter the $dataType
         if (method_exists($fieldExpr, 'formatOutputValue') && is_string($value)) {
           $result[$key] = $value = $fieldExpr->formatOutputValue($value, $dataType);
-        }
-        if (!$field) {
-          continue;
         }
         if (!empty($field['output_formatters'])) {
           self::applyFormatters($result, $fieldName, $field, $value);

--- a/ext/search_kit/ang/crmSearchAdmin/compose/criteria.html
+++ b/ext/search_kit/ang/crmSearchAdmin/compose/criteria.html
@@ -35,11 +35,14 @@
                crm-ui-select="{placeholder: ts('Group By'), data: fieldsForGroupBy, dropdownCss: {width: '300px'}}"
                on-crm-ui-select="$ctrl.addParam('groupBy', selection)" >
       </div>
-      <fieldset id="crm-search-build-group-aggregate" ng-if="$ctrl.savedSearch.api_params.groupBy.length" class="crm-collapsible collapsed">
-        <legend class="collapsible-title">{{:: ts('Aggregate fields') }}</legend>
-        <div>
-          <fieldset ng-repeat="col in $ctrl.savedSearch.api_params.select" ng-if="$ctrl.canAggregate(col)">
-            <crm-search-function expr="$ctrl.savedSearch.api_params.select[$index]" cat="'aggregate'"></crm-search-function>
+      <fieldset id="crm-search-build-functions">
+        <legend ng-click="controls.showFunctions = !controls.showFunctions">
+          <i class="crm-i fa-caret-{{ !controls.showFunctions ? 'right' : 'down' }}"></i>
+          {{:: ts('Field Transformations') }}
+        </legend>
+        <div ng-if="!!controls.showFunctions">
+          <fieldset ng-repeat="col in $ctrl.savedSearch.api_params.select">
+            <crm-search-function expr="$ctrl.savedSearch.api_params.select[$index]"></crm-search-function>
           </fieldset>
         </div>
       </fieldset>

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
@@ -659,8 +659,9 @@
         if (ctrl.savedSearch.api_params.groupBy.indexOf(info.path) > -1) {
           return false;
         }
-        // If the entity this column belongs to is being grouped by id, then also no
-        return ctrl.savedSearch.api_params.groupBy.indexOf(info.prefix + 'id') < 0;
+        // If the entity this column belongs to is being grouped by primary key, then also no
+        var idField = searchMeta.getEntity(info.field.entity).primary_key[0];
+        return ctrl.savedSearch.api_params.groupBy.indexOf(info.prefix + idField) < 0;
       };
 
       $scope.formatResult = function(row, col) {

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
@@ -660,9 +660,6 @@
       $scope.formatResult = function(row, col) {
         var info = searchMeta.parseExpr(col),
           value = row[info.alias];
-        if (info.fn && info.fn.name === 'COUNT') {
-          return value;
-        }
         return formatFieldValue(row, info, value);
       };
 
@@ -697,7 +694,7 @@
       }
 
       function formatFieldValue(row, info, value, index) {
-        var type = info.field.data_type,
+        var type = (info.fn && info.fn.dataType) || info.field.data_type,
           result = value,
           link;
         if (_.isArray(value)) {

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminDisplay.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminDisplay.component.js
@@ -184,7 +184,7 @@
           values.label = searchMeta.getDefaultLabel(fieldExpr);
         }
         if (defaults.dataType) {
-          values.dataType = (info.fn && info.fn.name === 'COUNT') ? 'Integer' : info.field && info.field.data_type;
+          values.dataType = (info.fn && info.fn.dataType) || (info.field && info.field.data_type);
         }
         return values;
       }

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchFunction.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchFunction.component.js
@@ -24,7 +24,7 @@
       $scope.$watch('$ctrl.expr', function(expr) {
         var fieldInfo = searchMeta.parseExpr(expr);
         ctrl.path = fieldInfo.path + fieldInfo.suffix;
-        ctrl.field = fieldInfo.field;
+        ctrl.field = [fieldInfo.field];
         ctrl.fn = !fieldInfo.fn ? '' : fieldInfo.fn.name;
         ctrl.modifier = fieldInfo.modifier || null;
         initFunction();
@@ -42,6 +42,7 @@
         }
       }
 
+      // On-demand options for dropdown function selector
       this.getFunctions = function() {
         var allowedTypes = [], functions = [];
         if (ctrl.expr && ctrl.field) {
@@ -49,17 +50,26 @@
             allowedTypes.push('aggregate');
           } else {
             allowedTypes.push('comparison', 'string');
-            if (_.includes(['Integer', 'Float', 'Date', 'Timestamp'], ctrl.field.data_type)) {
+            if (_.includes(['Integer', 'Float', 'Date', 'Timestamp'], ctrl.field[0].data_type)) {
               allowedTypes.push('math');
             }
-            if (_.includes(['Date', 'Timestamp'], ctrl.field.data_type)) {
+            if (_.includes(['Date', 'Timestamp'], ctrl.field[0].data_type)) {
               allowedTypes.push('date');
             }
           }
-          _.each(allowedTypes, function (type) {
+          _.each(allowedTypes, function(type) {
+            var allowedFunctions = _.filter(CRM.crmSearchAdmin.functions, function(fn) {
+              return fn.category === type &&
+                fn.params.length &&
+                // For now, only support functions that take a single field
+                fn.params[0].min_expr === 1 &&
+                fn.params[0].max_expr === 1 &&
+                !_.includes(fn.params[0].cant_be, 'SqlField') &&
+                (!fn.params[0].must_be.length || _.includes(fn.params[0].must_be, 'SqlField'));
+            });
             functions.push({
               text: allTypes[type],
-              children: formatForSelect2(_.where(CRM.crmSearchAdmin.functions, {category: type}), 'name', 'title')
+              children: formatForSelect2(allowedFunctions, 'name', 'title')
             });
           });
         }

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchFunction.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchFunction.component.js
@@ -23,17 +23,23 @@
 
       function initFunction() {
         ctrl.fnInfo = _.find(CRM.crmSearchAdmin.functions, {name: ctrl.fn});
-        if (ctrl.fnInfo && _.includes(ctrl.fnInfo.params[0].prefix, 'DISTINCT')) {
-          ctrl.modifierAllowed = true;
+        if (ctrl.fnInfo && ctrl.fnInfo.params[0] && !_.isEmpty(ctrl.fnInfo.params[0].flag_before)) {
+          ctrl.modifierName = _.keys(ctrl.fnInfo.params[0].flag_before)[0];
+          ctrl.modifierLabel = ctrl.fnInfo.params[0].flag_before[ctrl.modifierName];
         }
         else {
-          ctrl.modifierAllowed = false;
+          ctrl.modifierName = null;
           ctrl.modifier = null;
         }
       }
 
       this.selectFunction = function() {
         initFunction();
+        ctrl.writeExpr();
+      };
+
+      this.toggleModifier = function() {
+        ctrl.modifier = ctrl.modifier ? null : ctrl. modifierName;
         ctrl.writeExpr();
       };
 

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchFunction.html
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchFunction.html
@@ -1,6 +1,6 @@
 <div class="form-inline">
   <label>{{ $ctrl.field.label }}:</label>
-  <input class="form-control" style="width: 15em;" ng-model="$ctrl.fn" crm-ui-select="{data: $ctrl.functions, placeholder: ts('Select')}" ng-change="$ctrl.selectFunction()">
+  <input class="form-control" style="width: 15em;" ng-model="$ctrl.fn" crm-ui-select="{data: $ctrl.getFunctions, placeholder: ts('Select')}" ng-change="$ctrl.selectFunction()">
   <label ng-if="$ctrl.modifierName">
     <input type="checkbox" ng-checked="!!$ctrl.modifier" ng-click="$ctrl.toggleModifier()">
     {{ $ctrl.modifierLabel }}

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchFunction.html
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchFunction.html
@@ -1,5 +1,5 @@
 <div class="form-inline">
-  <label>{{ $ctrl.field.label }}:</label>
+  <label>{{ $ctrl.field[0].label }}:</label>
   <input class="form-control" style="width: 15em;" ng-model="$ctrl.fn" crm-ui-select="{data: $ctrl.getFunctions, placeholder: ts('Select')}" ng-change="$ctrl.selectFunction()">
   <label ng-if="$ctrl.modifierName">
     <input type="checkbox" ng-checked="!!$ctrl.modifier" ng-click="$ctrl.toggleModifier()">

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchFunction.html
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchFunction.html
@@ -1,8 +1,8 @@
 <div class="form-inline">
   <label>{{ $ctrl.field.label }}:</label>
   <input class="form-control" style="width: 15em;" ng-model="$ctrl.fn" crm-ui-select="{data: $ctrl.functions, placeholder: ts('Select')}" ng-change="$ctrl.selectFunction()">
-  <label ng-if="$ctrl.modifierAllowed">
-    <input type="checkbox" ng-model="$ctrl.modifier" ng-change="$ctrl.writeExpr()" ng-true-value="'DISTINCT'" ng-false-value="null">
-    {{ ts('Distinct') }}
+  <label ng-if="$ctrl.modifierName">
+    <input type="checkbox" ng-checked="!!$ctrl.modifier" ng-click="$ctrl.toggleModifier()">
+    {{ $ctrl.modifierLabel }}
   </label>
 </div>

--- a/ext/search_kit/css/crmSearchAdmin.css
+++ b/ext/search_kit/css/crmSearchAdmin.css
@@ -112,6 +112,10 @@
   min-height: 3.5em;
 }
 
+#bootstrap-theme.crm-search legend[ng-click] {
+  cursor: pointer;
+}
+
 #bootstrap-theme.crm-search .api4-input-group {
   display: inline-block;
 }

--- a/tests/phpunit/api/v4/Query/SqlExpressionParserTest.php
+++ b/tests/phpunit/api/v4/Query/SqlExpressionParserTest.php
@@ -44,16 +44,16 @@ class SqlExpressionParserTest extends UnitTestCase {
   public function testAggregateFuncitons($fnName) {
     $className = 'Civi\Api4\Query\SqlFunction' . $fnName;
     $params = $className::getParams();
-    $this->assertNotEmpty($params[0]['prefix']);
-    $this->assertEmpty($params[0]['suffix']);
+    $this->assertNotEmpty($params[0]['flag_before']);
+    $this->assertEmpty($params[0]['flag_after']);
 
     $sqlFn = new $className($fnName . '(total)');
     $this->assertEquals($fnName, $sqlFn->getName());
     $this->assertEquals(['total'], $sqlFn->getFields());
     $args = $sqlFn->getArgs();
     $this->assertCount(1, $args);
-    $this->assertNull($args[0]['prefix']);
-    $this->assertNull($args[0]['suffix']);
+    $this->assertEmpty($args[0]['prefix']);
+    $this->assertEmpty($args[0]['suffix']);
     $this->assertTrue(is_a($args[0]['expr'][0], 'Civi\Api4\Query\SqlField'));
 
     $sqlFn = SqlExpression::convert($fnName . '(DISTINCT stuff)');
@@ -63,8 +63,8 @@ class SqlExpressionParserTest extends UnitTestCase {
     $this->assertEquals(['stuff'], $sqlFn->getFields());
     $args = $sqlFn->getArgs();
     $this->assertCount(1, $args);
-    $this->assertEquals('DISTINCT', $args[0]['prefix']);
-    $this->assertNull($args[0]['suffix']);
+    $this->assertEquals('DISTINCT', $args[0]['prefix'][0]);
+    $this->assertEmpty($args[0]['suffix']);
     $this->assertTrue(is_a($args[0]['expr'][0], 'Civi\Api4\Query\SqlField'));
 
     try {
@@ -72,8 +72,8 @@ class SqlExpressionParserTest extends UnitTestCase {
       if ($fnName === 'COUNT') {
         $args = $sqlFn->getArgs();
         $this->assertCount(1, $args);
-        $this->assertNull($args[0]['prefix']);
-        $this->assertNull($args[0]['suffix']);
+        $this->assertEmpty($args[0]['prefix']);
+        $this->assertEmpty($args[0]['suffix']);
         $this->assertTrue(is_a($args[0]['expr'][0], 'Civi\Api4\Query\SqlWild'));
       }
       else {


### PR DESCRIPTION
Overview
----------------------------------------
Support SQL functions in the SearchKit UI

See https://lab.civicrm.org/dev/core/-/issues/2704

Before
----------------------------------------
Only aggregate functions supported

After
----------------------------------------
More functions work

Comments
----------------------------------------
For now it's limited to functions that take a single field as input.