### PR TITLE
Smarty notices on logging detail report

### DIFF
--- a/CRM/Logging/ReportDetail.php
+++ b/CRM/Logging/ReportDetail.php
@@ -275,6 +275,7 @@ class CRM_Logging_ReportDetail extends CRM_Report_Form {
     }
     $this->assign('revertURL', CRM_Report_Utils_Report::getNextUrl($this->detail, "$q&revert=1", FALSE, TRUE));
     $this->assign('revertConfirm', ts('Are you sure you want to revert all changes?'));
+    $this->assign('sections', []);
   }
 
   /**

--- a/templates/CRM/Logging/ReportDetail.tpl
+++ b/templates/CRM/Logging/ReportDetail.tpl
@@ -9,21 +9,10 @@
 *}
 <div class="crm-block crm-content-block crm-report-form-block">
   {if $rows}
-    {* todo: Is `raw` ever assigned to the template and why would it make a difference as to whether this div is present? The revert confirmation is handled (awkwardly) lower down by javascript $revertConfirm *}
-    {if $raw}
-      <div class="status">
-        <dl>
-          <dt>{icon icon="fa-info-circle"}{/icon}</dt>
-          <dd>
-            {ts}WARNING: Are you sure you want to revert the below changes?{/ts}
-          </dd>
-        </dl>
-      </div>
-    {/if}
     <p>{ts 1=$whom_url 2=$whom_name|escape 3=$who_url 4=$who_name|escape 5=$log_date}Change to <a href='%1'>%2</a> made by <a href='%3'>%4</a> on %5:{/ts}</p>
     {if $layout eq 'overlay'}
       {include file="CRM/Report/Form/Layout/Overlay.tpl"}
-    {elseif !$chartEnabled || !$chartSupported}
+    {else}
       {include file="CRM/Report/Form/Layout/Table.tpl"}
     {/if}
   {else}
@@ -34,7 +23,7 @@
   {if $layout neq 'overlay'}
   <div class="action-link">
       <a href="{$backURL}"   class="button"><span><i class="crm-i fa-chevron-left" aria-hidden="true"></i> {ts}Back to Logging Summary{/ts}</span></a>
-      <a href="{$revertURL}" class="button" onclick="return confirm('{$revertConfirm}');"><span><i class="crm-i fa-undo" aria-hidden="true"></i> {ts}Revert These Changes{/ts}</span></a>
+      <a href="{$revertURL}" class="button" onclick="return confirm('{$revertConfirm|escape:'javascript'}');"><span><i class="crm-i fa-undo" aria-hidden="true"></i> {ts}Revert These Changes{/ts}</span></a>
   </div>
   {/if}
 </div>


### PR DESCRIPTION
Overview
----------------------------------------
1. Turn on logging at System Settings - Misc
2. Update a contact.
3. View the contact logging summary.
4. Click where it says Update to view the detail report.

Before
----------------------------------------
Notice: Undefined index: chartEnabled in include() (line 24 of ...\templates_c\en_US\%%33\33E\33ED58CB%%ReportDetail.tpl.php).
Notice: Undefined index: sections in include() (line 61 of ...\templates_c\en_US\%%F5\F54\F5478576%%Table.tpl.php).
Notice: Undefined index: raw in ...\templates_c\en_US\%%33\33E\33ED58CB%%ReportDetail.tpl.php on line 7

After
----------------------------------------


Technical Details
----------------------------------------
For the $raw one I removed the whole `$raw` block which isn't doing anything and is handled by javascript $revertConfirm lower down. You can manually add raw=1 in the url to change what the table displays, but that isn't connected to this $raw anymore - it looks like it used to be where the way the revert button worked was to reload the page, thus displaying this div: https://github.com/civicrm/civicrm-svn/commit/c6871f184fc5e511e3dd612da6257f18f28e573b, although it looks like maybe it never worked.

The chartEnabled / chartSupported is meaningless for this report, and even if it meant something, there's nothing in this template at the moment to display it (e.g. by including Graph.tpl).

Comments
----------------------------------------

