### PR TITLE
Smarty warning about pager location on all CiviReports

### DIFF
--- a/templates/CRM/Report/Form/Layout/Table.tpl
+++ b/templates/CRM/Report/Form/Layout/Table.tpl
@@ -158,7 +158,7 @@
     </table>
     {if !empty($pager) and $pager->_response and $pager->_response.numPages > 1}
         <div class="report-pager">
-            {include file="CRM/common/pager.tpl" }
+            {include file="CRM/common/pager.tpl" location="bottom"}
         </div>
     {/if}
 {/if}


### PR DESCRIPTION
Overview
----------------------------------------
Go to any civireport that has at least 50 rows, like Constituent Summary.

Before
----------------------------------------
Notice: Undefined index: location in include() (line 9 of ...\templates_c\en_US\%%8D\8D7\8D7E85BC%%pager.tpl.php).

Also note that the "Rows per page" filter normally present on pagers at the bottom is missing.

After
----------------------------------------
No notice.
The rows per page filter is present now, but note anything you put in it gets ignored, but that's a different issue.

Technical Details
----------------------------------------


Comments
----------------------------------------

