### PR TITLE
Check for "NULL" page in addPages so we don't crash when calling require_once

### DIFF
--- a/CRM/Core/Controller.php
+++ b/CRM/Core/Controller.php
@@ -433,6 +433,11 @@ class CRM_Core_Controller extends HTML_QuickForm_Controller {
   public function addPages(&$stateMachine, $action = CRM_Core_Action::NONE) {
     $pages = $stateMachine->getPages();
     foreach ($pages as $name => $value) {
+      if (empty($name)) {
+        // An "empty" page can happen eg. when triggered from a StateMachine/Search class
+        //   when there are no SearchTasks defined.
+        continue;
+      }
       $className = CRM_Utils_Array::value('className', $value, $name);
       $title = $value['title'] ?? NULL;
       $options = $value['options'] ?? NULL;


### PR DESCRIPTION
Overview
----------------------------------------
Replacement for #20945. It seems the "NULL page" problem affects all `StateMachine/Search` classes if there are no tasks.

![image](https://user-images.githubusercontent.com/2052161/126908820-a197db57-35b6-4098-a890-3dec95e23fe2.png)

Before
----------------------------------------
If a null page is defined (because there were no tasks) require_once tries to open a file named ".php".

After
----------------------------------------
A null page is ignored.

Technical Details
----------------------------------------
The approach in #20945 is technically cleaner but requires changes in a lot of (statemachine) classes and as we've identified the tasks functionality really needs reworking/improving - see eg. https://github.com/civicrm/civicrm-core/pull/20944
This PR provides a simple, clearly commented change that is easy to maintain / remove in future if no longer required and won't cause any problems (because a "null" page could never work).

Comments
----------------------------------------
