### PR TITLE
Activity tasks - don't add invalid tasks

### DIFF
--- a/CRM/Activity/StateMachine/Search.php
+++ b/CRM/Activity/StateMachine/Search.php
@@ -35,16 +35,10 @@ class CRM_Activity_StateMachine_Search extends CRM_Core_StateMachine {
     $this->_pages = [];
 
     $this->_pages['CRM_Activity_Form_Search'] = NULL;
-    list($task, $result) = $this->taskName($controller, 'Search');
+    list($task) = $this->taskName($controller, 'Search');
     $this->_task = $task;
-
-    if (is_array($task)) {
-      foreach ($task as $t) {
-        $this->_pages[$t] = NULL;
-      }
-    }
-    else {
-      $this->_pages[$task] = NULL;
+    foreach ($task as $t) {
+      $this->_pages[$t] = NULL;
     }
 
     $this->addSequentialPages($this->_pages, $action);
@@ -63,7 +57,7 @@ class CRM_Activity_StateMachine_Search extends CRM_Core_StateMachine {
    * @return array
    *   the name of the form that will handle the task
    */
-  public function taskName($controller, $formName = 'Search') {
+  protected function taskName($controller, $formName = 'Search') {
     // total hack, check POST vars and then session to determine stuff
     $value = $_POST['task'] ?? NULL;
     if (!isset($value)) {

--- a/CRM/Activity/Task.php
+++ b/CRM/Activity/Task.php
@@ -156,11 +156,10 @@ class CRM_Activity_Task extends CRM_Core_Task {
       // make the print task by default
       $value = self::TASK_PRINT;
     }
-
-    return [
-      self::$_tasks[$value]['class'],
-      self::$_tasks[$value]['result'],
-    ];
+    if (isset(self::$_tasks[$value])) {
+      return [[self::$_tasks[$value]['class']], self::$_tasks[$value]['result']];
+    }
+    return [[], NULL];
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Alternate to  #20945

The differences is  #20945 permits invalid data to be in `$this->_pages` at [this line](https://github.com/civicrm/civicrm-core/pull/20951/files#diff-c9474800befc5f4a294f8e39a38947465c7cb906cf24e0afe6f9274885008598R44) and then 'fixes' `addSequentialPages` to not crash on that bad data, whereas this fixes  `$this->_pages` to only include valid values.

This keeps the grouchiness in the generic controller
to warn us of other mistakes.


Before
----------------------------------------
Per #20945

After
----------------------------------------
Fixed for activity search (including one of the enotices)

Technical Details
----------------------------------------

The only other place Activity::getTask is called from is here & it will also cope with having a consistent array returned - but we would have to deprecate rather than remove non-array handling in that function

![image](https://user-images.githubusercontent.com/336308/126915838-6b244209-a705-4818-a8ef-05d4a085bdc6.png)


I made `taskName` protected

You can see how in universe all instances are called from `$this`

![image](https://user-images.githubusercontent.com/336308/126915547-54cc49d3-8e35-44ed-ab73-9920e545afbd.png)

![image](https://user-images.githubusercontent.com/336308/126915586-482ef65c-eb7a-47dd-a7c0-6f92420ce2f0.png)


![image](https://user-images.githubusercontent.com/336308/126915560-2952f292-a1be-4596-80c8-70e14f750e4a.png)

and that this class is not extended 

![image](https://user-images.githubusercontent.com/336308/126915644-632411d0-c82d-404f-ad18-962a5f1f572d.png)



Comments
----------------------------------------
