### PR TITLE
dev/core#2721 [REF] start unravelling the way we retrieve the saved search

### DIFF
--- a/CRM/Contact/BAO/GroupContactCache.php
+++ b/CRM/Contact/BAO/GroupContactCache.php
@@ -13,6 +13,7 @@ use Civi\API\Request;
 use Civi\Api4\Group;
 use Civi\Api4\Query\Api4SelectQuery;
 use Civi\Api4\Query\SqlExpression;
+use Civi\Api4\SavedSearch;
 
 /**
  *
@@ -796,7 +797,10 @@ ORDER BY   gc.contact_id, g.children
    */
   protected static function insertGroupContactsIntoTempTable(string $tempTableName, int $groupID, ?int $savedSearchID, ?string $children): void {
     if ($savedSearchID) {
-      $ssParams = CRM_Contact_BAO_SavedSearch::getSearchParams($savedSearchID);
+      $savedSearch = SavedSearch::get(FALSE)
+        ->addWhere('id', '=', $savedSearchID)
+        ->execute()
+        ->first();
 
       $excludeClause = "NOT IN (
                         SELECT contact_id FROM civicrm_group_contact
@@ -804,10 +808,22 @@ ORDER BY   gc.contact_id, g.children
                         AND civicrm_group_contact.group_id = $groupID )";
       $addSelect = "$groupID AS group_id";
 
-      if (!empty($ssParams['api_entity'])) {
-        $sql = self::getApiSQL($ssParams, $addSelect, $excludeClause);
+      if (!empty($savedSearch['api_entity'])) {
+        $sql = self::getApiSQL($savedSearch, $addSelect, $excludeClause);
       }
       else {
+        $fv = CRM_Contact_BAO_SavedSearch::getFormValues($savedSearchID);
+        //check if the saved search has mapping id
+        if ($savedSearch['mapping_id']) {
+          $ssParams = CRM_Core_BAO_Mapping::formattedFields($fv);
+        }
+        elseif (!empty($fv['customSearchID'])) {
+          $ssParams = $fv;
+        }
+        else {
+          $ssParams = CRM_Contact_BAO_Query::convertFormValues($fv);
+        }
+
         // CRM-7021 rectify params to what proximity search expects if there is a value for prox_distance
         if (!empty($ssParams)) {
           CRM_Contact_BAO_ProximityQuery::fixInputParams($ssParams);


### PR DESCRIPTION

Overview
----------------------------------------
dev/core#2721 [REF] start unravelling the way we retrieve the saved search

Before
----------------------------------------
We want to get to the point of passing out a consistent $savedSearch array to the 3 sql functions - but it is already inconsistent when it is retrieved into this function

After
----------------------------------------
Retrieved consistently. Wrangling closer to where it is used (but still needs some sorting)

Technical Details
----------------------------------------
We have 3 types of saved searches
- search kit
- legacy core searches
- legacy custom searches

The only information these 3 need to load is the savedSearch details and
the group ID (to add in the add & exclude). The wrangling of the params should
happen in the getSql functions - which we can think about being in a listener once
they have standard inputs & outputs. However, to get to that point
we want to standardise those inputs & outputs. This removes
only point of randomness - ie savedSearch has a consistent value & the wrangling
of what is in it is pushed closer to the relevant functions

Comments
----------------------------------------
