### PR TITLE
Fix test to use valid financials

### DIFF
--- a/Civi/Test/ContactTestTrait.php
+++ b/Civi/Test/ContactTestTrait.php
@@ -54,8 +54,6 @@ trait ContactTestTrait {
    *
    * @return int
    *   id of Organisation created
-   *
-   * @throws \CiviCRM_API3_Exception
    */
   public function organizationCreate($params = [], $seq = 0): int {
     if (!$params) {

--- a/tests/phpunit/CRM/Contribute/BAO/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/BAO/ContributionTest.php
@@ -21,6 +21,13 @@ class CRM_Contribute_BAO_ContributionTest extends CiviUnitTestCase {
   use CRMTraits_Financial_PriceSetTrait;
 
   /**
+   * Should financials be checked after the test but before tear down.
+   *
+   * @var bool
+   */
+  protected $isValidateFinancialsOnPostAssert = TRUE;
+
+  /**
    * Clean up after tests.
    */
   public function tearDown(): void {
@@ -666,7 +673,9 @@ WHERE eft.entity_id = %1 AND ft.to_financial_account_id <> %2";
    * @throws \CRM_Core_Exception
    * @throws \CiviCRM_API3_Exception
    */
-  public function testAssignProportionalLineItems() {
+  public function testAssignProportionalLineItems(): void {
+    // This test doesn't seem to manage financials properly, possibly by design
+    $this->isValidateFinancialsOnPostAssert = FALSE;
     $contribution = $this->addParticipantWithContribution();
     // Delete existing financial_trxns. This is because we are testing a code flow we
     // want to deprecate & remove & the test relies on bad data asa starting point.

--- a/tests/phpunit/CRM/Event/Form/ParticipantTest.php
+++ b/tests/phpunit/CRM/Event/Form/ParticipantTest.php
@@ -21,18 +21,13 @@ class CRM_Event_Form_ParticipantTest extends CiviUnitTestCase {
     parent::setUp();
   }
 
+
   /**
-   * CHeck that all tests that have created payments have created them with the right financial entities.
+   * Should financials be checked after the test but before tear down.
    *
-   * Ideally this would be on CiviUnitTestCase but many classes would still fail. Also, it might
-   * be good if it only ran on tests that created at least one contribution.
-   *
-   * @throws \CRM_Core_Exception
+   * @var bool
    */
-  protected function assertPostConditions(): void {
-    $this->validateAllPayments();
-    $this->validateAllContributions();
-  }
+  protected $isValidateFinancialsOnPostAssert = TRUE;
 
   /**
    * Initial test of submit function.

--- a/tests/phpunit/CRM/Event/Form/ParticipantTest.php
+++ b/tests/phpunit/CRM/Event/Form/ParticipantTest.php
@@ -21,7 +21,6 @@ class CRM_Event_Form_ParticipantTest extends CiviUnitTestCase {
     parent::setUp();
   }
 
-
   /**
    * Should financials be checked after the test but before tear down.
    *

--- a/tests/phpunit/CRM/Event/Form/Registration/ConfirmTest.php
+++ b/tests/phpunit/CRM/Event/Form/Registration/ConfirmTest.php
@@ -10,6 +10,17 @@ class CRM_Event_Form_Registration_ConfirmTest extends CiviUnitTestCase {
 
   use CRMTraits_Profile_ProfileTrait;
 
+
+  /**
+   * Should financials be checked after the test but before tear down.
+   *
+   * Ideally all tests (or at least all that call any financial api calls ) should do this but there
+   * are some test data issues and some real bugs currently blocking.
+   *
+   * @var bool
+   */
+  protected $isValidateFinancialsOnPostAssert = TRUE;
+
   public function setUp(): void {
     $this->useTransaction(TRUE);
     parent::setUp();
@@ -95,6 +106,8 @@ class CRM_Event_Form_Registration_ConfirmTest extends CiviUnitTestCase {
    * @dataProvider getThousandSeparators
    */
   public function testPaidSubmit($thousandSeparator) {
+    // @todo - figure out why this doesn't pass validate financials
+    $this->isValidateFinancialsOnPostAssert = FALSE;
     $this->setCurrencySeparators($thousandSeparator);
     $mut = new CiviMailUtils($this);
     $paymentProcessorID = $this->processorCreate();
@@ -222,6 +235,8 @@ class CRM_Event_Form_Registration_ConfirmTest extends CiviUnitTestCase {
    * @throws \Exception
    */
   public function testTaxMultipleParticipant() {
+    // @todo - figure out why this doesn't pass validate financials
+    $this->isValidateFinancialsOnPostAssert = FALSE;
     $mut = new CiviMailUtils($this);
     $params = ['is_monetary' => 1, 'financial_type_id' => 1];
     $event = $this->eventCreate($params);

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -486,7 +486,6 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
    * Create default domain contacts for the two domains added during test class.
    * database population.
    *
-   * @throws \CiviCRM_API3_Exception
    * @throws \API_Exception
    */
   public function createDomainContacts(): void {

--- a/tests/phpunit/api/v3/ACLPermissionTest.php
+++ b/tests/phpunit/api/v3/ACLPermissionTest.php
@@ -25,6 +25,16 @@ class api_v3_ACLPermissionTest extends CiviUnitTestCase {
 
   use Civi\Test\ACLPermissionTrait;
 
+  /**
+   * Should financials be checked after the test but before tear down.
+   *
+   * The setup methodology in this class bypasses valid financial creation
+   * so we don't check.
+   *
+   * @var bool
+   */
+  protected $isValidateFinancialsOnPostAssert = FALSE;
+
   public $DBResetRequired = FALSE;
   protected $_entity;
 

--- a/tests/phpunit/api/v3/LineItemTest.php
+++ b/tests/phpunit/api/v3/LineItemTest.php
@@ -20,6 +20,13 @@ class api_v3_LineItemTest extends CiviUnitTestCase {
   protected $_entity = 'line_item';
 
   /**
+   * Should financials be checked after the test but before tear down.
+   *
+   * @var bool
+   */
+  protected $isValidateFinancialsOnPostAssert = TRUE;
+
+  /**
    * Prepare for test.
    *
    * @throws \CRM_Core_Exception
@@ -143,7 +150,9 @@ class api_v3_LineItemTest extends CiviUnitTestCase {
    *
    * @throws \CRM_Core_Exception
    */
-  public function testDeleteLineItem($version): void {
+  public function testDeleteLineItem(int $version): void {
+    // Deleting line items does not leave valid financial data.
+    $this->isValidateFinancialsOnPostAssert = FALSE;
     $this->_apiversion = $version;
     $getParams = [
       'entity_table' => 'civicrm_contribution',

--- a/tests/phpunit/api/v3/MembershipPaymentTest.php
+++ b/tests/phpunit/api/v3/MembershipPaymentTest.php
@@ -23,6 +23,17 @@ class api_v3_MembershipPaymentTest extends CiviUnitTestCase {
   protected $_membershipStatusID;
   protected $_contribution = [];
 
+  /**
+   * Should financials be checked after the test but before tear down.
+   *
+   * This test class is opted out as this method should not be called outside
+   * of the LineItem::create function and the test is artificial & not creating
+   * valid financials.
+   *
+   * @var bool
+   */
+  protected $isValidateFinancialsOnPostAssert = FALSE;
+
   public function setUp(): void {
     parent::setUp();
     $this->useTransaction(TRUE);

--- a/tests/phpunit/api/v3/ProfileTest.php
+++ b/tests/phpunit/api/v3/ProfileTest.php
@@ -542,6 +542,8 @@ class api_v3_ProfileTest extends CiviUnitTestCase {
    * @throws \CiviCRM_API3_Exception
    */
   public function testProfileSubmitMembershipBatch(): void {
+    // @todo - figure out why this doesn't pass validate financials
+    $this->isValidateFinancialsOnPostAssert = FALSE;
     $this->_contactID = $this->individualCreate();
     $this->callAPISuccess('profile', 'submit', [
       'profile_id' => 'membership_batch_entry',


### PR DESCRIPTION
Overview
----------------------------------------
Fix test to use valid financials

Before
----------------------------------------
Creates contributions and then line items, resulting in invalid financial data in the test set up

After
----------------------------------------
uses order api

Technical Details
----------------------------------------

Comments
----------------------------------------
