### PR TITLE
Smarty notices for New Activity / New Case for tags for attachments

### DIFF
--- a/templates/CRM/Case/Form/Case.tpl
+++ b/templates/CRM/Case/Form/Case.tpl
@@ -90,7 +90,7 @@
     </tr>
 {/if}
 
-{if $form.tag.html}
+{if !empty($form.tag.html)}
     <tr class="crm-case-form-block-tag">
       <td class="label">{$form.tag.label}</td>
       <td class="view-value"><div class="crm-select-container">{$form.tag.html}</div>

--- a/templates/CRM/Form/attachment.tpl
+++ b/templates/CRM/Form/attachment.tpl
@@ -51,13 +51,13 @@
             <div class="description">{ts}Browse to the <strong>file</strong> you want to upload.{/ts}{if $maxAttachments GT 1} {ts 1=$maxAttachments}You can have a maximum of %1 attachment(s).{/ts}{/if} {ts 1=$config->maxFileSize}Each file must be less than %1M in size. You can also add a short description.{/ts}</div>
           </td>
         </tr>
-        {if $form.tag_1.html}
+        {if !empty($form.tag_1.html)}
           <tr>
             <td class="label">{$form.tag_1.label}</td>
             <td><div class="crm-select-container crm-attachment-tags">{$form.tag_1.html}</div></td>
           </tr>
         {/if}
-        {if $tagsetInfo.file}
+        {if !empty($tagsetInfo.file)}
           <tr>{include file="CRM/common/Tagset.tpl" tagsetType='file' tableLayout=true tagsetElementName="file_taglist_1"}</tr>
         {/if}
         {section name=attachLoop start=2 loop=$numAttachments+1}
@@ -70,11 +70,13 @@
                 <td class="label">{$form.attachFile_1.label}</td>
                 <td>{$form.$attachName.html}&nbsp;{$form.$attachDesc.html}<a href="#" class="crm-hover-button crm-clear-attachment" style="visibility: hidden;" title="{ts}Clear{/ts}"><i class="crm-i fa-times" aria-hidden="true"></i></a></td>
             </tr>
+            {if !empty($form.$tagElement.html)}
             <tr>
               <td class="label">{$form.$tagElement.label}</td>
               <td><div class="crm-select-container crm-attachment-tags">{$form.$tagElement.html}</div></td>
             </tr>
-            {if $tagsetInfo.file}
+            {/if}
+            {if !empty($tagsetInfo.file)}
               <tr>{include file="CRM/common/Tagset.tpl" tagsetType='file' tableLayout=true tagsetElementName="file_taglist_$index"}</tr>
             {/if}
         {/section}


### PR DESCRIPTION
Overview
----------------------------------------
1. Don't create any tags for attachments.
2. Create a regular activity, or create a new case.
3. Smarty notices - the exact set of notices depends on whether you have any tags for other types or not.

Before
----------------------------------------
Something like
```
    Notice: Undefined index: tag_1 in include() (line 60 of .../templates_c/en_US/%%3F/3F9/3F9B0555%%attachment.tpl.php).
    Notice: Undefined index: tagsetInfo in include() (line 68 of .../templates_c/en_US/%%3F/3F9/3F9B0555%%attachment.tpl.php).
    Notice: Undefined index: tag_2 in include() (line 116 of .../templates_c/en_US/%%3F/3F9/3F9B0555%%attachment.tpl.php).
    Notice: Undefined index: tag_2 in include() (line 118 of .../templates_c/en_US/%%3F/3F9/3F9B0555%%attachment.tpl.php).
    Notice: Undefined index: tagsetInfo in include() (line 121 of .../templates_c/en_US/%%3F/3F9/3F9B0555%%attachment.tpl.php).
    Notice: Undefined index: tag_3 in include() (line 116 of .../templates_c/en_US/%%3F/3F9/3F9B0555%%attachment.tpl.php).
    Notice: Undefined index: tag_3 in include() (line 118 of .../templates_c/en_US/%%3F/3F9/3F9B0555%%attachment.tpl.php).
    Notice: Undefined index: tagsetInfo in include() (line 121 of .../templates_c/en_US/%%3F/3F9/3F9B0555%%attachment.tpl.php).
    Notice: Undefined index: tag in include() (line 108 of .../templates_c/en_US/%%E8/E8E/E8EBFB02%%Case.tpl.php).
```

After
----------------------------------------
There are still some others depending on your config, but this covers the stock install for attachments.

Technical Details
----------------------------------------
They can be legitimately missing because it's reasonable not to display a tag select widget if you don't have any tags for the type defined.

Comments
----------------------------------------

