### PR TITLE
Case Dashboard: fix labels on my/all radio buttons, and simplify label text

### DIFF
--- a/templates/CRM/Case/Page/DashBoard.tpl
+++ b/templates/CRM/Case/Page/DashBoard.tpl
@@ -26,12 +26,12 @@
         {if $myCases}
           {* check for access all cases and activities *}
           {if call_user_func(array('CRM_Core_Permission','check'), 'access all cases and activities')}
-            <div><input name="allupcoming" type="radio" class="radio" onClick='window.location.replace("{crmURL p="civicrm/case" q="reset=1&all=1"}")' value="1"><span>{ts}All Cases with Upcoming Activities{/ts}</span></input></div>
-            <div><input name="allupcoming" checked type="radio" class="radio" onClick='window.location.replace("{crmURL p="civicrm/case" q="reset=1&all=0"}")' value="0"><span>{ts}My Cases with Upcoming Activities{/ts}</span></input></div>
+            <div><input name="allupcoming" id="allupcoming-all" type="radio" class="radio" onClick='window.location.replace("{crmURL p="civicrm/case" q="reset=1&all=1"}")' value="1"><label for="allupcoming-all">{ts}All Cases{/ts}</label></div>
+            <div><input name="allupcoming" id="allupcoming-my" checked type="radio" class="radio" onClick='window.location.replace("{crmURL p="civicrm/case" q="reset=1&all=0"}")' value="0"><label for="allupcoming-my">{ts}My Cases{/ts}</label></div>
           {/if}
         {else}
-          <div><input name="allupcoming" checked type="radio" class="radio" onClick='window.location.replace("{crmURL p="civicrm/case" q="reset=1&all=1"}")' value="1"><span>{ts}All Cases with Upcoming Activities{/ts}</span></input></div>
-          <div><input name="allupcoming" type="radio" class="radio" onClick='window.location.replace("{crmURL p="civicrm/case" q="reset=1&all=0"}")' value="0"><span>{ts}My Cases with Upcoming Activities{/ts}</span></input></div>
+          <div><input name="allupcoming" id="allupcoming-all" checked type="radio" class="radio" onClick='window.location.replace("{crmURL p="civicrm/case" q="reset=1&all=1"}")' value="1"><label for="allupcoming-all">{ts}All Cases with Upcoming Activities{/ts}</label></div>
+          <div><input name="allupcoming" id="allupcoming-my" type="radio" class="radio" onClick='window.location.replace("{crmURL p="civicrm/case" q="reset=1&all=0"}")' value="0"><label for="allupcoming-my">{ts}My Cases with Upcoming Activities{/ts}</label></div>
         {/if}
       </div>
     </div>


### PR DESCRIPTION
Overview
----------------------------------------

The Case dashboard has a radio button to toggle between "My Cases" and "All Case".

Except they are not named that way, nor do they behave like most radio buttons. What you might read below might surprise you. Or not. (/clickbait)

Before
----------------------------------------

![civicase-before-2021-07-26_15-14](https://user-images.githubusercontent.com/254741/127046077-2367384a-002a-4368-b19d-1842aaf40135.png)

* The toggle does indeed toggle the filters on the lists of "Upcoming Activities", but it's very verbose, and I think most people can figure it out. Not to mention that the listings do have a title that says "My Cases with Upcoming Activities" (or "All Cases with upcoming activities). Most users do not read text unless they really to, so shorter is usually better.
* When we click the text of the radio, it does not select the option. One must precisely click on the round thing.

After
----------------------------------------

![civicase-after-2021-07-26_15-14](https://user-images.githubusercontent.com/254741/127046278-db98d2b2-1f71-4c38-8264-d6be1de9ed0b.png)

- text is clickable
- label is shorter

Comments
----------------------------------------

cc @demeritcowboy