### PR TITLE
Cast to float when setting overrideTotalAmount - regression in master

### DIFF
--- a/CRM/Batch/Form/Entry.php
+++ b/CRM/Batch/Form/Entry.php
@@ -808,7 +808,7 @@ class CRM_Batch_Form_Entry extends CRM_Core_Form {
         $order = new CRM_Financial_BAO_Order();
         // We use the override total amount because we are dealing with a
         // possibly tax_inclusive total, which is assumed for the override total.
-        $order->setOverrideTotalAmount($value['total_amount']);
+        $order->setOverrideTotalAmount((float) $value['total_amount']);
         $order->setLineItem([
           'membership_type_id' => $value['membership_type_id'],
           'financial_type_id' => $value['financial_type_id'],

--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -921,7 +921,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
     $order = new CRM_Financial_BAO_Order();
     $order->setPriceSelectionFromUnfilteredInput($fields);
     if (isset($fields['total_amount'])) {
-      $order->setOverrideTotalAmount($fields['total_amount']);
+      $order->setOverrideTotalAmount((float) $fields['total_amount']);
     }
     $lineItems = $order->getLineItems();
     try {

--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -2000,7 +2000,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     $order->setPriceSelectionFromUnfilteredInput($params);
     if (isset($params['amount']) && !CRM_Contribute_BAO_ContributionPage::getIsMembershipPayment($form->_id)) {
       // @todo deprecate receiving amount, calculate on the form.
-      $order->setOverrideTotalAmount($params['amount']);
+      $order->setOverrideTotalAmount((float) $params['amount']);
     }
     $amount = $order->getTotalAmount();
     if ($form->_separateMembershipPayment) {


### PR DESCRIPTION

Overview
----------------------------------------
Cast to float when setting overrideTotalAmount

Before
----------------------------------------
 submitting a new contribution and leaving total_amount empty
causes a fatal before it can get to the validation error - back office contribution form

![image](https://user-images.githubusercontent.com/336308/127125788-2e0da84f-0bf0-45f5-978f-9fd01fdae14a.png)


After
----------------------------------------
Cast to float 

Technical Details
----------------------------------------

Comments
----------------------------------------

