### PR TITLE
dev/core#2726 - Set ssl option when using DSN with SSL

### DIFF
--- a/CRM/Utils/File.php
+++ b/CRM/Utils/File.php
@@ -327,7 +327,8 @@ class CRM_Utils_File {
       require_once 'DB.php';
       $dsn = CRM_Utils_SQL::autoSwitchDSN($dsn);
       try {
-        $db = DB::connect($dsn);
+        $options = CRM_Utils_SQL::isSSLDSN($dsn) ? ['ssl' => TRUE] : [];
+        $db = DB::connect($dsn, $options);
       }
       catch (Exception $e) {
         die("Cannot open $dsn: " . $e->getMessage());


### PR DESCRIPTION
Overview
----------------------------------------
Refer to issue https://lab.civicrm.org/dev/core/-/issues/2726.

`DB::connect()` function requires an options array that define `ssl=true` for mysqli to connect to the CiviCRM database over ssl connection.

This PR adds logic to check if DSN is using SSL then pass the option `ssl=true` 

Before
----------------------------------------

Exception was thrown when using DSN with SSL to connect the database.

`Cannot open mysqli://user:password@local:3306/civicrm_db?new_link=true&ca=%2Fetc%2Fmysql%2Fdatabase-certificate.pem: DB Error: connect failed`

After
----------------------------------------

No error is thrown when using DSN with SSL.
