### PR TITLE
Fix Membership.create in BAO to respect passed in status_id

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4721,19 +4721,23 @@ LIMIT 1;";
         );
         $dates['join_date'] = $currentMembership['join_date'];
       }
+      if ('Pending' === CRM_Core_PseudoConstant::getName('CRM_Member_BAO_Membership', 'status_id', $membership['status_id'])) {
+        $membershipParams['skipStatusCal'] = '';
+      }
+      else {
+        //get the status for membership.
+        $calcStatus = CRM_Member_BAO_MembershipStatus::getMembershipStatusByDate($dates['start_date'],
+          $dates['end_date'],
+          $dates['join_date'],
+          'now',
+         TRUE,
+          $membershipParams['membership_type_id'],
+          $membershipParams
+        );
 
-      //get the status for membership.
-      $calcStatus = CRM_Member_BAO_MembershipStatus::getMembershipStatusByDate($dates['start_date'],
-        $dates['end_date'],
-        $dates['join_date'],
-        'now',
-        TRUE,
-        $membershipParams['membership_type_id'],
-        $membershipParams
-      );
-
-      unset($dates['end_date']);
-      $membershipParams['status_id'] = CRM_Utils_Array::value('id', $calcStatus, 'New');
+        unset($dates['end_date']);
+        $membershipParams['status_id'] = CRM_Utils_Array::value('id', $calcStatus, 'New');
+      }
       //we might be renewing membership,
       //so make status override false.
       $membershipParams['is_override'] = FALSE;

--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -301,7 +301,7 @@ class CRM_Member_BAO_Membership extends CRM_Member_DAO_Membership {
         $excludeIsAdmin = TRUE;
       }
 
-      if (empty($params['is_override'])) {
+      if (empty($params['status_id']) && empty($params['is_override'])) {
         $calcStatus = CRM_Member_BAO_MembershipStatus::getMembershipStatusByDate($params['start_date'], $params['end_date'], $params['join_date'],
           'now', $excludeIsAdmin, $params['membership_type_id'] ?? NULL, $params
         );

--- a/Civi/Test/ContactTestTrait.php
+++ b/Civi/Test/ContactTestTrait.php
@@ -77,7 +77,8 @@ trait ContactTestTrait {
    */
   public function individualCreate(array $params = [], $seq = 0, $random = FALSE): int {
     $params = array_merge($this->sampleContact('Individual', $seq, $random), $params);
-    return $this->_contactCreate($params);
+    $this->ids['Contact']['individual_' . $seq] = $this->_contactCreate($params);
+    return $this->ids['Contact']['individual_' . $seq];
   }
 
   /**

--- a/api/v3/Order.php
+++ b/api/v3/Order.php
@@ -139,7 +139,9 @@ function civicrm_api3_order_create(array $params): array {
     }
 
     if ($entityParams['entity'] === 'membership') {
-      $entityParams['status_id'] = 'Pending';
+      if (empty($entityParams['id'])) {
+        $entityParams['status_id'] = 'Pending';
+      }
       if (!empty($params['contribution_recur_id'])) {
         $entityParams['contribution_recur_id'] = $params['contribution_recur_id'];
       }

--- a/tests/phpunit/CRM/Export/BAO/ExportTest.php
+++ b/tests/phpunit/CRM/Export/BAO/ExportTest.php
@@ -204,6 +204,7 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
    *
    * @throws \CRM_Core_Exception
    * @throws \League\Csv\Exception
+   * @throws \API_Exception
    */
   public function testExportComponentsMembership(): void {
     $this->setUpMembershipExportData();
@@ -305,7 +306,7 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
       'Membership Start Date' => $membership['start_date'],
       'Membership Expiration Date' => $membership['end_date'],
       'Source' => 'Payment',
-      'Membership Status' => 'New',
+      'Membership Status' => 'Pending',
       'Membership ID' => '2',
       'Primary Member ID' => '',
       'Max Related' => '',
@@ -420,7 +421,7 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
    * Set up some data for us to do testing on.
    *
    * @throws \CRM_Core_Exception
-   * @throws \CiviCRM_API3_Exception
+   * @throws \API_Exception
    */
   public function setUpMembershipExportData(): void {
     $this->setUpContactExportData();
@@ -472,9 +473,6 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
 
   /**
    * Set up some data for us to do testing on.
-   *
-   * @throws \CRM_Core_Exception
-   * @throws \CiviCRM_API3_Exception
    */
   public function setUpContactExportData(): void {
     $this->contactIDs[] = $contactA = $this->individualCreate(['gender_id' => 'Female']);

--- a/tests/phpunit/CRM/Member/Selector/SearchTest.php
+++ b/tests/phpunit/CRM/Member/Selector/SearchTest.php
@@ -19,9 +19,9 @@ class CRM_Member_Selector_SearchTest extends CiviUnitTestCase {
   /**
    * Test results from getRows.
    *
-   * @throws \CRM_Core_Exception
+   * @throws \API_Exception
    */
-  public function testSelectorGetRows() {
+  public function testSelectorGetRows(): void {
     $this->_contactID = $this->individualCreate();
     $this->_invoiceID = 1234;
     $this->_contributionPageID = NULL;
@@ -44,7 +44,7 @@ class CRM_Member_Selector_SearchTest extends CiviUnitTestCase {
       'membership_source' => 'Payment',
       'member_is_test' => '0',
       'owner_membership_id' => NULL,
-      'membership_status' => 'New',
+      'membership_status' => 'Pending',
       'member_campaign_id' => NULL,
       'campaign' => NULL,
       'campaign_id' => NULL,

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -514,7 +514,6 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
   /**
    *  Common teardown functions for all unit tests.
    *
-   * @throws \CiviCRM_API3_Exception
    * @throws \CRM_Core_Exception
    * @throws \API_Exception
    */
@@ -712,8 +711,6 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
    * @param string $name
    *
    * @return mixed
-   *
-   * @throws \CRM_Core_Exception
    */
   public function membershipStatusCreate($name = 'test member status') {
     $params['name'] = $name;
@@ -825,7 +822,6 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
    * @param array $params
    *
    * @return mixed
-   * @throws \CRM_Core_Exception
    */
   public function paymentProcessorAuthorizeNetCreate($params = []) {
     $params = array_merge([
@@ -3169,7 +3165,7 @@ VALUES
   public function createPriceSetWithPage($entity = NULL, $params = []) {
     $membershipTypeID = $this->membershipTypeCreate(['name' => 'Special']);
     $contributionPageResult = $this->callAPISuccess('contribution_page', 'create', [
-      'title' => "Test Contribution Page",
+      'title' => 'Test Contribution Page',
       'financial_type_id' => 1,
       'currency' => 'NZD',
       'goal_amount' => 50,

--- a/tests/phpunit/api/v3/MembershipStatusTest.php
+++ b/tests/phpunit/api/v3/MembershipStatusTest.php
@@ -37,9 +37,7 @@ class api_v3_MembershipStatusTest extends CiviUnitTestCase {
    * @throws \CRM_Core_Exception
    */
   public function tearDown(): void {
-    $this->membershipStatusDelete($this->_membershipStatusID);
-    $this->membershipTypeDelete(['id' => $this->_membershipTypeID]);
-    $this->contactDelete($this->_contactID);
+    $this->quickCleanUpFinancialEntities();
     parent::tearDown();
   }
 
@@ -77,17 +75,17 @@ class api_v3_MembershipStatusTest extends CiviUnitTestCase {
     $this->assertEquals(1, $result['count'], "Check only 1 retrieved " . __LINE__);
   }
 
-  public function testCreateDuplicateName() {
+  public function testCreateDuplicateName(): void {
     $params = ['name' => 'name'];
-    $result = $this->callAPISuccess('membership_status', 'create', $params);
-    $result = $this->callAPIFailure('membership_status', 'create', $params,
+    $this->callAPISuccess('MembershipStatus', 'create', $params);
+    $this->callAPIFailure('MembershipStatus', 'create', $params,
       'A membership status with this name already exists.'
     );
   }
 
-  public function testCreateWithMissingRequired() {
+  public function testCreateWithMissingRequired(): void {
     $params = ['title' => 'Does not make sense'];
-    $this->callAPIFailure('membership_status', 'create', $params, 'Mandatory key(s) missing from params array: name');
+    $this->callAPIFailure('MembershipStatus', 'create', $params, 'Mandatory key(s) missing from params array: name');
   }
 
   public function testCreate() {
@@ -112,10 +110,9 @@ class api_v3_MembershipStatusTest extends CiviUnitTestCase {
       'id' => $id,
       'name' => 'renamed',
     ];
-    $result = $this->callAPISuccess('membership_status', 'create', $newParams);
-    $result = $this->callAPISuccess('membership_status', 'get', ['id' => $id]);
+    $this->callAPISuccess('MembershipStatus', 'create', $newParams);
+    $result = $this->callAPISuccess('MembershipStatus', 'get', ['id' => $id]);
     $this->assertEquals('renamed', $result['values'][$id]['name']);
-    $this->membershipStatusDelete($result['id']);
   }
 
   ///////////////// civicrm_membership_status_delete methods
@@ -123,8 +120,8 @@ class api_v3_MembershipStatusTest extends CiviUnitTestCase {
   /**
    * Attempt (and fail) to delete membership status without an parameters.
    */
-  public function testDeleteEmptyParams() {
-    $result = $this->callAPIFailure('membership_status', 'delete', []);
+  public function testDeleteEmptyParams(): void {
+    $this->callAPIFailure('membership_status', 'delete', []);
   }
 
   public function testDeleteWithMissingRequired() {
@@ -162,7 +159,7 @@ class api_v3_MembershipStatusTest extends CiviUnitTestCase {
   /**
    * Test that trying to delete membership status while membership still exists creates error.
    */
-  public function testDeleteWithMembershipError() {
+  public function testDeleteWithMembershipError(): void {
     $membershipStatusID = $this->membershipStatusCreate();
     $this->_contactID = $this->individualCreate();
     $this->_entity = 'membership';
@@ -177,18 +174,18 @@ class api_v3_MembershipStatusTest extends CiviUnitTestCase {
       'status_id' => $membershipStatusID,
     ];
 
-    $result = $this->callAPISuccess('membership', 'create', $params);
+    $result = $this->callAPISuccess('Membership', 'create', $params);
     $membershipID = $result['id'];
 
     $params = [
       'id' => $membershipStatusID,
     ];
-    $result = $this->callAPIFailure('membership_status', 'delete', $params);
+    $this->callAPIFailure('MembershipStatus', 'delete', $params);
 
     $this->callAPISuccess('Membership', 'Delete', [
       'id' => $membershipID,
     ]);
-    $result = $this->callAPISuccess('membership_status', 'delete', $params);
+    $this->callAPISuccess('membership_status', 'delete', $params);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Fix Membership.create in BAO to respect passed in status_id 

Before
----------------------------------------
- Membership::create overwrites passed in status_id 
- Order create forces membership status id for new memberships (good) and renewals (bad) 

After
----------------------------------------
'status_id' respected if it reaches create, renewals not reset to pending

Technical Details
----------------------------------------
I didn't touch the handling of status_id when I fixed the handling of dates because it caused tests to fail - however, it appears the tests were incorrect. The failure was in the setup and they were creating Memberships with a 'grace' status before the payment was received. So, I did another round of fixing the tests

Comments
----------------------------------------
@monishdeb I'd really like your help to get this merged before the rc is cut as @artfulrobot has been having issues around this & also because I think there are a few membership bao changes that should ideally be in the same release.