### PR TITLE
Add upgrade routine to remove old action schedule token

### DIFF
--- a/CRM/Contribute/Tokens.php
+++ b/CRM/Contribute/Tokens.php
@@ -78,7 +78,6 @@ class CRM_Contribute_Tokens extends AbstractTokenSubscriber {
       'id' => 'contribution_id',
       'payment_instrument' => 'payment_instrument_id',
       'source' => 'contribution_source',
-      'status' => 'contribution_status_id',
       'type' => 'financial_type_id',
       'cancel_date' => 'contribution_cancel_date',
     ];
@@ -129,10 +128,6 @@ class CRM_Contribute_Tokens extends AbstractTokenSubscriber {
     $tokens['id'] = ts('Contribution ID');
     $tokens['payment_instrument'] = ts('Payment Instrument');
     $tokens['source'] = ts('Contribution Source');
-    // Per https://lab.civicrm.org/dev/core/-/issues/2650
-    // the intent is to deprecate this field in favour of
-    // {contribution.contribution_status_id:label}
-    $tokens['status'] = ts('Contribution Status');
     $tokens['type'] = ts('Financial Type');
     $tokens = array_merge($tokens, $this->getPseudoTokens(), CRM_Utils_Token::getCustomFieldTokens('Contribution'));
     parent::__construct('contribution', $tokens);
@@ -196,9 +191,6 @@ class CRM_Contribute_Tokens extends AbstractTokenSubscriber {
       $row->tokens($entity, $field, $this->getPseudoValue($split[0], $split[1], $actionSearchResult->{"contrib_$split[0]"} ?? NULL));
     }
     elseif (in_array($field, array_keys($this->getBasicTokens()))) {
-      // For now we just ensure that the label fields do not override the
-      // id field here.
-      // Later we will add support for contribution_status_id:label
       $row->tokens($entity, $field, $fieldValue);
     }
     else {

--- a/CRM/Upgrade/Incremental/Base.php
+++ b/CRM/Upgrade/Incremental/Base.php
@@ -249,6 +249,22 @@ class CRM_Upgrade_Incremental_Base {
   }
 
   /**
+   * Updated a message token within a template.
+   *
+   * @param CRM_Queue_TaskContext $ctx
+   * @param string $old
+   * @param string $new
+   * @param $version
+   *
+   * @return bool
+   */
+  public static function updateActionScheduleToken($ctx, string $old, string $new, $version):bool {
+    $messageObj = new CRM_Upgrade_Incremental_MessageTemplates($version);
+    $messageObj->replaceTokenInActionSchedule($old, $new);
+    return TRUE;
+  }
+
+  /**
    * Re-save any valid values from contribute settings into the normal setting
    * format.
    *

--- a/CRM/Upgrade/Incremental/MessageTemplates.php
+++ b/CRM/Upgrade/Incremental/MessageTemplates.php
@@ -290,6 +290,23 @@ class CRM_Upgrade_Incremental_MessageTemplates {
   }
 
   /**
+   * Replace a token with the new preferred option.
+   *
+   * @param string $old
+   * @param string $new
+   */
+  public function replaceTokenInActionSchedule(string $old, string $new): void {
+    $oldToken = '{' . $old . '}';
+    $newToken = '{' . $new . '}';
+    CRM_Core_DAO::executeQuery("UPDATE civicrm_action_schedule
+      SET
+        body_text = REPLACE(body_text, '$oldToken', '$newToken'),
+        subject = REPLACE(subject, '$oldToken', '$newToken'),
+        body_html = REPLACE(body_html, '$oldToken', '$newToken')
+    ");
+  }
+
+  /**
    * Get warnings for users if the replaced string is still present.
    *
    * This might be the case when used in an IF and for now we will recommend

--- a/CRM/Upgrade/Incremental/php/FiveFortyOne.php
+++ b/CRM/Upgrade/Incremental/php/FiveFortyOne.php
@@ -65,6 +65,12 @@ class CRM_Upgrade_Incremental_php_FiveFortyOne extends CRM_Upgrade_Incremental_B
   public function upgrade_5_41_alpha1($rev) {
     $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
     $this->addTask('Install legacy custom search extension', 'installCustomSearches');
+    $this->addTask('Replace legacy displayName smarty token in Invoice workflow template',
+      'updateMessageToken', 'contribution_invoice_receipt', '$display_name', 'contact.display_name', $rev
+    );
+    $this->addTask('Replace contribution status token in action schedule',
+      'updateActionScheduleToken', 'contribution.status', 'contribution.contribution_status_id:label', $rev
+    );
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Add upgrade routine to remove old action schedule token - which is no longer of use post https://github.com/civicrm/civicrm-core/pull/20961 which ensures standardised alternatives exist

This adds a routing to swap out the action schedule tokens on upgrade.

Given the token is completely invisible in the UI it's unlikely it is in use anywhere but
rather than just remove it from Contribute_Tokens this adds the upgrade
routine to remove this token, and others


Before
----------------------------------------
`{contribution.status} ` token is part of Contribution token processor - but not exposed in the UI & this token processor does not 'listen to anything other than scheduled reminders so we can be comfortable that if we remove it from scheduled reminders in the DB we can also remove from the class

After
----------------------------------------
poof

Technical Details
----------------------------------------
Note that in the similar upgrade for message templates I added an message for when the string wasn't cleaned up but that applied to smarty but not to 'token tokens' - ie we can't be sure that swapping out `{$displayName}` gets everything because `{if $displayName...` is valid but `{contribution.status}` will always be exactly that

Comments
----------------------------------------
