### PR TITLE
New membership: fix tax amount translation

### DIFF
--- a/templates/CRM/Member/Form/Membership.tpl
+++ b/templates/CRM/Member/Form/Membership.tpl
@@ -302,9 +302,7 @@
         var taxAmount = (membershipType['tax_rate']/100)*taxExclusiveAmount;
         taxAmount = isNaN (taxAmount) ? 0:taxAmount;
         cj("#total_amount").val(CRM.formatMoney(taxExclusiveAmount + taxAmount, true));
-
-        var taxMessage = taxAmount > 0 ? 'Includes '+taxTerm+' amount of '+currency+' '+taxAmount:'';
-        cj('.totaltaxAmount').html(taxMessage);
+        cj('.totaltaxAmount').html(allMemberships[membershipTypeID]['tax_message']);
       }
 
 


### PR DESCRIPTION
Overview
----------------------------------------

When taxes are applied to memberships, the "includes X tax amount" is not translated.

To reproduce:

- Administer > CiviContribute > CiviContribute Settings, and "Enable taxes & invoices"
- Administer > CiviContribute > Financial Accounts, and add a new Financial Account, "is tax", and set a tax % (I called my tax the "Cat Tax", and I use 14.975 as the tax rate, because that's the silly tax rate in Quebec, and it's really useful to create rounding bugs).
- Administer > CiviContribute > Financial Types, and assign the tax account to the "Member Dues" FT
- Administer > Localization > Languages: set the language to French (or some other language)

Now go to a contact record, and add a membership (screenshots below):

Before
----------------------------------------

![member-tax-translation-2021-07-30_10-40](https://user-images.githubusercontent.com/254741/127670212-95ef693f-b69c-43c3-a721-5d4ada06fb01.png)

After
----------------------------------------

This is a different result, but since we are fetching the data from `allMembershipInfo`, it means that extensions such as [taxcalculator](https://lab.civicrm.org/extensions/taxcalculator) can override the output:

![taxcalculator-2021-07-30_10-48](https://user-images.githubusercontent.com/254741/127670798-010e9429-62d6-4920-8658-bc65c82641a8.png)

Technical Details
----------------------------------------

This PR merely copy-pastes from `templates/CRM/Member/Form/MembershipRenewal.tpl`, which has lots of copy-pasted code, but I was too afraid to refactor, because it has some subtle changes between the two.