### PR TITLE
PHP E_NOTICE during upgrade

### DIFF
--- a/CRM/Queue/Service.php
+++ b/CRM/Queue/Service.php
@@ -117,7 +117,7 @@ class CRM_Queue_Service {
    * @return CRM_Queue_Queue
    */
   public function load($queueSpec) {
-    if (is_object($this->queues[$queueSpec['name']])) {
+    if (is_object($this->queues[$queueSpec['name']] ?? NULL)) {
       return $this->queues[$queueSpec['name']];
     }
     $queue = $this->instantiateQueueObject($queueSpec);


### PR DESCRIPTION
Overview
----------------------------------------
For me this only shows up the apache log for some reason. I think it's always been there.

Before
----------------------------------------
Undefined index: CRM_Upgrade in ...\\CRM\\Queue\\Service.php on line 120, referer: http://site/civicrm/upgrade/queue/runner?reset=1&qrid=CRM_Upgrade

After
----------------------------------------


Technical Details
----------------------------------------
The queue object simply hasn't been set yet on the first hit since that happens a few lines down.

Comments
----------------------------------------

