### PR TITLE
Deprecate db_token back to the only function that calls it

### DIFF
--- a/Civi/Token/TokenRow.php
+++ b/Civi/Token/TokenRow.php
@@ -201,6 +201,7 @@ class TokenRow {
    * @throws \CRM_Core_Exception
    */
   public function dbToken($tokenEntity, $tokenField, $baoName, $baoField, $fieldValue) {
+    \CRM_Core_Error::deprecatedWarning('to be removed');
     if ($fieldValue === NULL || $fieldValue === '') {
       return $this->tokens($tokenEntity, $tokenField, '');
     }


### PR DESCRIPTION
Overview
----------------------------------------
I realised that in the whole git universe only this function calls db_token. The code in
db_token partially duplicates this code and this code is doing work to 'avoid' the stuff db_token
does. I also think the logic of how to direct db token to format the fields belongs in this
function, the signature of db_token is not quite right and the pseudoconstant stuff is wrong.

All in all I think melding this back into it's only calling function and then coming up
with the right shared function makes more sense

Before
----------------------------------------
only one function ever calls $row->db_token & functionality is duplicated between them & in some cases $row-evaluate token is working to avoid db_token

After
----------------------------------------
One of the 2 calls to it is copied & pasted. The other is still calling the deprecated function but I'm planning to upgrade those alias tokens out of existance - although we probably need https://github.com/civicrm/civicrm-core/pull/20978 to pass before this will

Technical Details
----------------------------------------

Comments
----------------------------------------
