### PR TITLE
Fix membership tests to do valid financials

### DIFF
--- a/tests/phpunit/CRM/Member/Form/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/Form/MembershipTest.php
@@ -29,7 +29,6 @@ use Civi\Api4\MembershipType;
 class CRM_Member_Form_MembershipTest extends CiviUnitTestCase {
 
   use CRMTraits_Financial_OrderTrait;
-  use CRMTraits_Financial_PriceSetTrait;
 
   /**
    * @var int


### PR DESCRIPTION

Overview
----------------------------------------
Fix membership tests to do valid financials

Before
----------------------------------------
The order was not being set up correctly for multiple memberships, hence invalid financials.

After
----------------------------------------
Valid setup, valid financial checking extended to the class

Technical Details
----------------------------------------

We don't actually support having more than one instance of a price_field in the
same price set at this point (I kinda feel we should see if we can when we get to
the afform order form but this is just fixing tests to current reality

Comments
----------------------------------------
I added a skip + todo for the other test in the class not passing valid financials as it is a 'real bug' not a test setup issue