### PR TITLE
Upgrade message is scrunched up next to the previous sentence

### DIFF
--- a/CRM/Upgrade/Incremental/php/FiveFortyOne.php
+++ b/CRM/Upgrade/Incremental/php/FiveFortyOne.php
@@ -44,7 +44,7 @@ class CRM_Upgrade_Incremental_php_FiveFortyOne extends CRM_Upgrade_Incremental_B
    */
   public function setPostUpgradeMessage(&$postUpgradeMessage, $rev) {
     $templateUpgrader = new CRM_Upgrade_Incremental_MessageTemplates($rev);
-    $postUpgradeMessage .= $templateUpgrader->getMessageTemplateWarning('contribution_invoice_receipt', '$display_name', 'contact.display_name');
+    $postUpgradeMessage .= '<ul><li>' . htmlspecialchars($templateUpgrader->getMessageTemplateWarning('contribution_invoice_receipt', '$display_name', 'contact.display_name')) . '</li></ul>';
     // Example: Generate a post-upgrade message.
     // if ($rev == '5.12.34') {
     //   $postUpgradeMessage .= '<br /><br />' . ts("By default, CiviCRM now disables the ability to import directly from SQL. To use this feature, you must explicitly grant permission 'import SQL datasource'.");


### PR DESCRIPTION
Overview
----------------------------------------
Recently added upgrade message doesn't leave any space before it.

Before
----------------------------------------
<img width="513" alt="before" src="https://user-images.githubusercontent.com/2967821/127746128-5feb7f55-d5d1-4cc6-9ce3-8314f6b7a8ba.png">


After
----------------------------------------
<img width="501" alt="after" src="https://user-images.githubusercontent.com/2967821/127746133-1c836b4e-0437-4e55-83da-71f71f0c89e9.png">


Technical Details
----------------------------------------


Comments
----------------------------------------

