### PR TITLE
Fix case export from searchKit

### DIFF
--- a/CRM/Export/StateMachine/Standalone.php
+++ b/CRM/Export/StateMachine/Standalone.php
@@ -28,10 +28,20 @@ class CRM_Export_StateMachine_Standalone extends CRM_Core_StateMachine {
 
     $entityMap = ['Contribution' => 'Contribute', 'Membership' => 'Member', 'Participant' => 'Event'];
     $entity = $entityMap[$entity] ?? $entity;
-    $this->_pages = [
-      'CRM_' . $entity . '_Export_Form_Select' => NULL,
-      'CRM_' . $entity . '_Export_Form_Map' => NULL,
-    ];
+    switch ($entity) {
+      case 'Case':
+        $this->_pages = [
+          'CRM_Export_Form_Select_Case' => NULL,
+          'CRM_Export_Form_Map' => NULL,
+        ];
+        break;
+
+      default:
+        $this->_pages = [
+          'CRM_' . $entity . '_Export_Form_Select' => NULL,
+          'CRM_' . $entity . '_Export_Form_Map' => NULL,
+        ];
+    }
 
     $this->addSequentialPages($this->_pages, $action);
   }


### PR DESCRIPTION
Overview
----------------------------------------
Create a "Cases" view in SearchKit. Run a search and then click "Export Cases".

Before
----------------------------------------
Export Cases triggers 500 internal server error

After
----------------------------------------
Export Cases opens export forms and allows you to export the case fields.

Technical Details
----------------------------------------
Case export classes do not follow "standard" naming convention so tries to require files that do not exist.

Comments
----------------------------------------
@colemanw @eileenmcnaughton I imagine this could be fixed another way by renaming case classes etc. but I have no idea what impact that would have!