### PR TITLE
Fix mailing task when there are no tasks

### DIFF
--- a/CRM/Mailing/Task.php
+++ b/CRM/Mailing/Task.php
@@ -80,10 +80,10 @@ class CRM_Mailing_Task extends CRM_Core_Task {
       $value = self::TASK_PRINT;
     }
 
-    return [
-      self::$_tasks[$value]['class'],
-      self::$_tasks[$value]['result'],
-    ];
+    if (isset(self::$_tasks[$value])) {
+      return [[self::$_tasks[$value]['class']], self::$_tasks[$value]['result']];
+    }
+    return [[], NULL];
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Same fix for mailings as we did for activities here https://github.com/civicrm/civicrm-core/pull/20951

Before
----------------------------------------
Expanding "Mailings" on advanced search gives network error if there are no mailing action tasks.

After
----------------------------------------
Expanding "Mailings" on advanced search works if there are no mailing action tasks.

Technical Details
----------------------------------------

Comments
----------------------------------------
@eileenmcnaughton 
