### PR TITLE
dev/core#2719 [REF] Remove a couple more (tested) references to legacy contribution_invoice_settings

### DIFF
--- a/CRM/Batch/Form/Entry.php
+++ b/CRM/Batch/Form/Entry.php
@@ -942,7 +942,7 @@ class CRM_Batch_Form_Entry extends CRM_Core_Form {
         'toName' => $form->_contributorDisplayName,
         'toEmail' => $form->_contributorEmail,
         'PDFFilename' => ts('receipt') . '.pdf',
-        'isEmailPdf' => Civi::settings()->get('invoicing') && Civi::settings()->get('invoice_is_email_pdf'),
+        'isEmailPdf' => Civi::settings()->get('invoice_is_email_pdf'),
         'contributionId' => $this->getCurrentRowContributionID(),
         'isTest' => (bool) ($form->_action & CRM_Core_Action::PREVIEW),
       ]

--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -5164,14 +5164,11 @@ LIMIT 1;";
    *
    * @param int $contributionID
    *
-   * @return string
+   * @return string|null
    */
-  public static function getInvoiceNumber($contributionID) {
-    if ($invoicePrefix = self::checkContributeSettings('invoice_prefix')) {
-      return $invoicePrefix . $contributionID;
-    }
-
-    return NULL;
+  public static function getInvoiceNumber(int $contributionID): ?string {
+    $invoicePrefix = Civi::settings()->get('invoice_prefix');
+    return $invoicePrefix ? $invoicePrefix . $contributionID : NULL;
   }
 
   /**

--- a/CRM/Contribute/BAO/ContributionPage.php
+++ b/CRM/Contribute/BAO/ContributionPage.php
@@ -440,7 +440,7 @@ class CRM_Contribute_BAO_ContributionPage extends CRM_Contribute_DAO_Contributio
         $sendTemplateParams['cc'] = $values['cc_receipt'] ?? NULL;
         $sendTemplateParams['bcc'] = $values['bcc_receipt'] ?? NULL;
         //send email with pdf invoice
-        if (Civi::settings()->get('invoicing') && Civi::settings()->get('invoice_is_email_pdf')) {
+        if (Civi::settings()->get('invoice_is_email_pdf')) {
           $sendTemplateParams['isEmailPdf'] = TRUE;
           $sendTemplateParams['contributionId'] = $values['contribution_id'];
         }

--- a/CRM/Contribute/Form/AdditionalInfo.php
+++ b/CRM/Contribute/Form/AdditionalInfo.php
@@ -432,7 +432,7 @@ class CRM_Contribute_Form_AdditionalInfo {
         'toEmail' => $contributorEmail,
         'isTest' => $form->_mode == 'test',
         'PDFFilename' => ts('receipt') . '.pdf',
-        'isEmailPdf' => Civi::settings()->get('invoicing') && Civi::settings()->get('invoice_is_email_pdf'),
+        'isEmailPdf' => Civi::settings()->get('invoice_is_email_pdf'),
       ]
     );
 

--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -1242,7 +1242,7 @@ WHERE civicrm_event.is_active = 1
             $values['event']
           );
 
-          if (Civi::settings()->get('invoicing') && Civi::settings()->get('invoice_is_email_pdf') && !empty($values['contributionId'])) {
+          if (Civi::settings()->get('invoice_is_email_pdf') && !empty($values['contributionId'])) {
             $sendTemplateParams['isEmailPdf'] = TRUE;
             $sendTemplateParams['contributionId'] = $values['contributionId'];
           }

--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -1546,7 +1546,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
         );
         $prefixValue = Civi::settings()->get('contribution_invoice_settings');
         $invoicing = $prefixValue['invoicing'] ?? NULL;
-        if (!empty($taxAmt) && (isset($invoicing) && Civi::settings()->get('invoice_is_email_pdf'))) {
+        if (Civi::settings()->get('invoice_is_email_pdf')) {
           $sendTemplateParams['isEmailPdf'] = TRUE;
           $sendTemplateParams['contributionId'] = $contributionId;
         }

--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -1546,7 +1546,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
         );
         $prefixValue = Civi::settings()->get('contribution_invoice_settings');
         $invoicing = $prefixValue['invoicing'] ?? NULL;
-        if (!empty($taxAmt) && (isset($invoicing) && isset($prefixValue['is_email_pdf']))) {
+        if (!empty($taxAmt) && (isset($invoicing) && Civi::settings()->get('invoice_is_email_pdf'))) {
           $sendTemplateParams['isEmailPdf'] = TRUE;
           $sendTemplateParams['contributionId'] = $contributionId;
         }

--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -993,7 +993,7 @@ DESC limit 1");
         'toName' => $form->_contributorDisplayName,
         'toEmail' => $form->_contributorEmail,
         'PDFFilename' => ts('receipt') . '.pdf',
-        'isEmailPdf' => Civi::settings()->get('invoicing') && Civi::settings()->get('invoice_is_email_pdf'),
+        'isEmailPdf' => Civi::settings()->get('invoice_is_email_pdf'),
         'contributionId' => $formValues['contribution_id'],
         'isTest' => (bool) ($form->_action & CRM_Core_Action::PREVIEW),
       ]

--- a/tests/phpunit/CRM/Core/Payment/PayPalIPNTest.php
+++ b/tests/phpunit/CRM/Core/Payment/PayPalIPNTest.php
@@ -65,7 +65,7 @@ class CRM_Core_Payment_PayPalIPNTest extends CiviUnitTestCase {
    *
    * @throws \CRM_Core_Exception
    */
-  public function testInvoiceSentOnIPNPaymentSuccess() {
+  public function testInvoiceSentOnIPNPaymentSuccess(): void {
     $this->enableTaxAndInvoicing();
 
     $pendingStatusID = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Pending');

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -3095,10 +3095,8 @@ VALUES
 
   /**
    * Enable Tax and Invoicing
-   *
-   * @throws \CRM_Core_Exception
    */
-  protected function disableTaxAndInvoicing(): \Civi\Core\SettingsBag {
+  protected function disableTaxAndInvoicing(): void {
     $accounts = $this->callAPISuccess('EntityFinancialAccount', 'get', ['account_relationship' => 'Sales Tax Account is'])['values'];
     foreach ($accounts as $account) {
       $this->callAPISuccess('EntityFinancialAccount', 'delete', ['id' => $account['id']]);
@@ -3108,7 +3106,8 @@ VALUES
     if (!empty(\Civi::$statics['CRM_Core_PseudoConstant']) && isset(\Civi::$statics['CRM_Core_PseudoConstant']['taxRates'])) {
       unset(\Civi::$statics['CRM_Core_PseudoConstant']['taxRates']);
     }
-    return Civi::settings()->set('invoicing', FALSE);
+    Civi::settings()->set('invoice_is_email_pdf', FALSE);
+    Civi::settings()->set('invoicing', FALSE);
   }
 
   /**

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -3073,24 +3073,24 @@ VALUES
    * Enable Tax and Invoicing
    *
    * @param array $params
-   *
-   * @return \Civi\Core\SettingsBag
    */
-  protected function enableTaxAndInvoicing($params = []) {
+  protected function enableTaxAndInvoicing(array $params = []): void {
     // Enable component contribute setting
     $contributeSetting = array_merge($params,
       [
         'invoicing' => 1,
         'invoice_prefix' => 'INV_',
-        'due_date' => 10,
-        'due_date_period' => 'days',
-        'notes' => '',
-        'is_email_pdf' => 1,
+        'invoice_due_date' => 10,
+        'invoice_due_date_period' => 'days',
+        'invoice_notes' => '',
+        'invoice_is_email_pdf' => 1,
         'tax_term' => 'Sales Tax',
         'tax_display_settings' => 'Inclusive',
       ]
     );
-    return Civi::settings()->set('contribution_invoice_settings', $contributeSetting);
+    foreach ($contributeSetting as $setting => $value) {
+      Civi::settings()->set($setting, $value);
+    }
   }
 
   /**

--- a/tests/phpunit/api/v3/ContributionPageTest.php
+++ b/tests/phpunit/api/v3/ContributionPageTest.php
@@ -52,8 +52,6 @@ class api_v3_ContributionPageTest extends CiviUnitTestCase {
 
   /**
    * Setup for test.
-   *
-   * @throws \CiviCRM_API3_Exception
    */
   public function setUp(): void {
     parent::setUp();
@@ -113,7 +111,6 @@ class api_v3_ContributionPageTest extends CiviUnitTestCase {
    * @param int $version
    *
    * @dataProvider versionThreeAndFour
-   * @throws \CRM_Core_Exception
    */
   public function testGetBasicContributionPage(int $version): void {
     $this->_apiversion = $version;
@@ -129,8 +126,6 @@ class api_v3_ContributionPageTest extends CiviUnitTestCase {
 
   /**
    * Test get with amount as a parameter.
-   *
-   * @throws \CRM_Core_Exception
    */
   public function testGetContributionPageByAmount(): void {
     $createResult = $this->callAPISuccess($this->_entity, 'create', $this->params);
@@ -1702,11 +1697,13 @@ class api_v3_ContributionPageTest extends CiviUnitTestCase {
    * Contribution total = 3723.05
    *  made up of  tax 337.55
    *          non tax 3385.5
+   *
    * @param string $thousandSeparator
    *   punctuation used to refer to thousands.
    *
-   * @dataProvider getThousandSeparators
+   * @throws \API_Exception
    * @throws \CRM_Core_Exception
+   * @dataProvider getThousandSeparators
    */
   public function testSubmitContributionPageWithPriceSetQuantity(string $thousandSeparator): void {
     $this->setCurrencySeparators($thousandSeparator);


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#2719 [REF] Remove a couple more (tested) references to legacy contribution_invoice_settings

Before
----------------------------------------
Settings accessed by legacy contribution_invoice_settings wrapper

After
----------------------------------------
Settings accessed correctly

Technical Details
----------------------------------------
Fixes some test fails in https://github.com/civicrm/civicrm-core/pull/20970

Comments
----------------------------------------
