### PR TITLE
Deprecate db_token back to the only function that calls it

### DIFF
--- a/CRM/Contribute/Tokens.php
+++ b/CRM/Contribute/Tokens.php
@@ -48,6 +48,7 @@ class CRM_Contribute_Tokens extends AbstractTokenSubscriber {
 
   /**
    * Get a list of tokens whose name and title match the DB fields.
+   *
    * @return array
    */
   protected function getPassthruTokens(): array {
@@ -99,11 +100,12 @@ class CRM_Contribute_Tokens extends AbstractTokenSubscriber {
   }
 
   /**
-   * Get pseudoTokens - it tokens that reflect the name or label of a pseudoconstant.
-   *
-   * @internal - this function will likely be made protected soon.
+   * Get pseudoTokens - it tokens that reflect the name or label of a
+   * pseudoconstant.
    *
    * @return array
+   * @internal - this function will likely be made protected soon.
+   *
    */
   public function getPseudoTokens(): array {
     $return = [];
@@ -194,7 +196,43 @@ class CRM_Contribute_Tokens extends AbstractTokenSubscriber {
       $row->tokens($entity, $field, $fieldValue);
     }
     else {
-      $row->dbToken($entity, $field, 'CRM_Contribute_BAO_Contribution', $field, $fieldValue);
+      // This section is copied & pasted & can be cleaned up later.
+      // most if probably already done in this functions
+      $tokenEntity = $entity;
+      $tokenField = $field;
+      $baoName = $this->getBAOName();
+      $baoField = $field;
+      if ($fieldValue === NULL || $fieldValue === '') {
+        return $row->tokens($tokenEntity, $tokenField, '');
+      }
+
+      $fields = $baoName::fields();
+      if (!empty($fields[$baoField]['pseudoconstant'])) {
+        $options = $baoName::buildOptions($baoField, 'get');
+        return $row->format('text/plain')
+          ->tokens($tokenEntity, $tokenField, $options[$fieldValue]);
+      }
+
+      switch ($fields[$baoField]['type']) {
+        case \CRM_Utils_Type::T_DATE + \CRM_Utils_Type::T_TIME:
+          return $row->format('text/plain')
+            ->tokens($tokenEntity, $tokenField, \CRM_Utils_Date::customFormat($fieldValue));
+
+        case \CRM_Utils_Type::T_MONEY:
+          // Is this something you should ever use? Seems like you need more context
+          // to know which currency to use.
+          return $row->format('text/plain')
+            ->tokens($tokenEntity, $tokenField, \CRM_Utils_Money::format($fieldValue));
+
+        case \CRM_Utils_Type::T_STRING:
+        case \CRM_Utils_Type::T_BOOLEAN:
+        case \CRM_Utils_Type::T_INT:
+        case \CRM_Utils_Type::T_TEXT:
+          return $row->format('text/plain')
+            ->tokens($tokenEntity, $tokenField, $fieldValue);
+
+      }
+      throw new \CRM_Core_Exception("Cannot format token for field '$baoField' in '$baoName'");
     }
   }
 

--- a/Civi/Token/TokenRow.php
+++ b/Civi/Token/TokenRow.php
@@ -192,6 +192,8 @@ class TokenRow {
   /**
    * Update the value of a token. Apply formatting based on DB schema.
    *
+   * @deprecated
+   *
    * @param string $tokenEntity
    * @param string $tokenField
    * @param string $baoName


### PR DESCRIPTION
Overview
----------------------------------------
Deprecate db_token back to the only function that calls it

I realised that in the whole git universe only this function calls db_token. The code in
db_token partially duplicates this code and this code is doing work to 'avoid' the stuff db_token
does. I also think the logic of how to direct db token to format the fields belongs in this
function, the signature of db_token is not quite right and the pseudoconstant stuff is wrong.

All in all I think melding this back into it's only calling function and then coming up
with the right shared function makes more sense


Before
----------------------------------------
db_token is called from 2 places in the same function - one of those places only exists because of the vagaries of db_token (it uses aliased field titles to access the metadata) and the other has been increasingly side stepped by the rest of the code in the function to do the same things db_token does

After
----------------------------------------
Code copied back to replace one of the calls, opening the door for  the rest of the function to be simplified

Technical Details
----------------------------------------
The end result is that db_token will be noisily deprecated but it is quietly deprecated until the other call to it is removed

Comments
----------------------------------------
Note there is no test added with this PR but the follow up PRs have test cover for this 