### PR TITLE
Do not generate a notice when a vcard is downloaded with a non-primary email or non-primary phone number

### DIFF
--- a/CRM/Contact/Page/View/Vcard.php
+++ b/CRM/Contact/Page/View/Vcard.php
@@ -127,7 +127,7 @@ class CRM_Contact_Page_View_Vcard extends CRM_Contact_Page_View {
         if ($vcardName) {
           $vcard->addParam('TYPE', $vcardName);
         }
-        if ($phone['is_primary']) {
+        if (!empty($phone['is_primary'])) {
           $vcard->addParam('TYPE', 'PREF');
         }
       }
@@ -140,7 +140,7 @@ class CRM_Contact_Page_View_Vcard extends CRM_Contact_Page_View {
         if ($vcardName) {
           $vcard->addParam('TYPE', $vcardName);
         }
-        if ($email['is_primary']) {
+        if (!empty($email['is_primary'])) {
           $vcard->addParam('TYPE', 'PREF');
         }
       }


### PR DESCRIPTION
To reproduce
----------------------------------------
* Configure your CiviCRM, so that notices are shown.
* Select a contact with two phone numbers or two emails (that makes one of them non-primary).
* Select the action (1) vcard (2)
![vcard](https://user-images.githubusercontent.com/14834891/127871760-06b9c44f-7dac-4142-a913-b9c32f91097d.png)
* Now a vcard is downloaded on your local disk.
* Refresh your screen

Before
----------------------------------------
A notice is shown
![notice](https://user-images.githubusercontent.com/14834891/127871958-637abc39-c53c-473c-9e12-3449309feb0e.png)

After
----------------------------------------
No notice is shown

Technical Details
----------------------------------------
`$phone['is_primary']` is replaced by `!empty($phone['is_primary'])`. The same trick is already used in other parts of the code e.g. job_title, so the code did become more consistent.
