### PR TITLE
Fix upgrade message when nothing was changed

### DIFF
--- a/CRM/Upgrade/Incremental/php/FiveFortyOne.php
+++ b/CRM/Upgrade/Incremental/php/FiveFortyOne.php
@@ -44,7 +44,10 @@ class CRM_Upgrade_Incremental_php_FiveFortyOne extends CRM_Upgrade_Incremental_B
    */
   public function setPostUpgradeMessage(&$postUpgradeMessage, $rev) {
     $templateUpgrader = new CRM_Upgrade_Incremental_MessageTemplates($rev);
-    $postUpgradeMessage .= '<ul><li>' . htmlspecialchars($templateUpgrader->getMessageTemplateWarning('contribution_invoice_receipt', '$display_name', 'contact.display_name')) . '</li></ul>';
+    $upgradeMessage = $templateUpgrader->getMessageTemplateWarning('contribution_invoice_receipt', '$display_name', 'contact.display_name');
+    if (!empty($upgradeMessage)) {
+      $postUpgradeMessage .= '<ul><li>' . htmlspecialchars($upgradeMessage) . '</li></ul>';
+    }
     // Example: Generate a post-upgrade message.
     // if ($rev == '5.12.34') {
     //   $postUpgradeMessage .= '<br /><br />' . ts("By default, CiviCRM now disables the ability to import directly from SQL. To use this feature, you must explicitly grant permission 'import SQL datasource'.");


### PR DESCRIPTION
Overview
----------------------------------------
In https://github.com/civicrm/civicrm-core/pull/20986 I didn't take into account what happens if you don't have {$display_name} in your template, or if you're re-running the upgrade and it was already changed.

Before
----------------------------------------
You just see a bullet item but it has no words.

After
----------------------------------------
Cleaner

Technical Details
----------------------------------------
The string returned from the function is blank if nothing will be changing, so don't put a blank string in a bullet list.

Comments
----------------------------------------

