### PR TITLE
Ensure advanced search displaying related contacts works consitently

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -5836,10 +5836,7 @@ AND   displayRelType.is_active = 1
       else {
         $from .= $qcache['from'];
       }
-      if (!strlen($where)) {
-        $where = " WHERE 1 ";
-      }
-      $where .= $qcache['where'];
+      $where = $qcache['where'];
       if (!empty($this->_tables['civicrm_case'])) {
         // Change the join on CiviCRM case so that it joins on the right contac from the relationship.
         $from = str_replace("ON civicrm_case_contact.contact_id = contact_a.id", "ON civicrm_case_contact.contact_id = transform_temp.contact_id", $from);

--- a/tests/phpunit/CRM/Contact/BAO/QueryTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/QueryTest.php
@@ -1317,4 +1317,53 @@ civicrm_relationship.is_active = 1 AND
     $this->assertEquals('World Region = Middle East and North Africa', $query->_qill[0][0]);
   }
 
+  /**
+   * Tests the advanced search query by searching on related contacts and contact type same time.
+   *
+   * Preparation:
+   *   Create an individual contact Contact A
+   *   Create an organization contact Contact B
+   *   Create an "Employer of" relationship between them. 
+   *
+   * Searching:
+   *   Go to advanced search
+   *   Click on View contact as related contact
+   *   Select Employee of as relationship type
+   *   Select "Organization" as contact type 
+   *
+   * Expected results
+   *   We expect to find contact A.
+   *
+   * @throws \Exception
+   */
+  public function testAdvancedSearchWithDisplayRelationshipsAndContactType() {
+    // Preperation
+    $employeeRelationshipTypeId = civicrm_api3('RelationshipType', 'getvalue', ['return' => 'id', 'name_a_b' => 'Employee of']);
+    $indContactID = $this->individualCreate(['first_name' => 'John', 'last_name' => 'Smith']);
+    $orgContactID = $this->organizationCreate(['contact_type' => 'Organization', 'organization_name' => 'Healthy Planet Fund']);
+    civicrm_api3('Relationship', 'create', ['contact_id_a' => $indContactID, 'contact_id_b' => $orgContactID, 'relationship_type_id' => $employeeRelationshipTypeId]);
+
+    // Search setup
+    $formValues = ['display_relationship_type' => $employeeRelationshipTypeId . '_a_b', 'contact_type' => 'Organization'];
+    $params = CRM_Contact_BAO_Query::convertFormValues($formValues, 0, FALSE, NULL, []);
+    $isDeleted = FALSE;
+    $selector = new CRM_Contact_Selector(
+      'CRM_Contact_Selector',
+      $formValues,
+      $params,
+      NULL,
+      CRM_Core_Action::NONE,
+      NULL,
+      FALSE,
+      'advanced'
+    );
+    $queryObject = $selector->getQueryObject();
+    $sql = $queryObject->query(FALSE, FALSE, FALSE, $isDeleted);
+    // Run the search
+    $rows = CRM_Core_DAO::executeQuery(implode(' ', $sql))->fetchAll();
+    // Check expected results.
+    $this->assertCount(1, $rows);
+    $this->assertEquals('John', $rows[0]['first_name']);
+    $this->assertEquals('Smith', $rows[0]['last_name']);
+  }
 }

--- a/tests/phpunit/CRM/Contact/BAO/QueryTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/QueryTest.php
@@ -1323,13 +1323,13 @@ civicrm_relationship.is_active = 1 AND
    * Preparation:
    *   Create an individual contact Contact A
    *   Create an organization contact Contact B
-   *   Create an "Employer of" relationship between them. 
+   *   Create an "Employer of" relationship between them.
    *
    * Searching:
    *   Go to advanced search
    *   Click on View contact as related contact
    *   Select Employee of as relationship type
-   *   Select "Organization" as contact type 
+   *   Select "Organization" as contact type
    *
    * Expected results
    *   We expect to find contact A.
@@ -1366,4 +1366,5 @@ civicrm_relationship.is_active = 1 AND
     $this->assertEquals('John', $rows[0]['first_name']);
     $this->assertEquals('Smith', $rows[0]['last_name']);
   }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
An advanced search, in which contacts are display as related contacts, fails to find any results under certain conditions. See: https://lab.civicrm.org/dev/core/-/issues/2707

Before
----------------------------------------

1 Click Search -> Advanced Search
2. Under "Display results as" choose "Related Contacts" and choose "Employee of" as the relationship type.
3. Then select "Organization" as the contact type.

I expect this to display all individuaul contacts that have a Employee of Relationship to an organization. Instead, I get no results.

It seems that the search is looking for all related contacts that have their contact type set to Organization, instead of all related contacts with an employer that is an organization.

After
----------------------------------------
When conducting a search to find individual contacts that have an Employee of Relationship to an organization using the "Display Results as" functionality, the expected contacts are displayed.

Technical Details
----------------------------------------

A [recent commit](https://github.com/civicrm/civicrm-core/commit/4f4fb809a77#diff-ea0c7e154d37aced347680a3590e42d88e9b857e761e79039a506daa88e2827eR5840) changed how the WHERE clause is generated when searching for related contacts.

By fixing one part of that commit, we seem to have the intended functionality.

Comments
----------------------------------------
I have not fully tested to ensure that the functionality of the original commit is preserved with this change.