### PR TITLE
Rename legacy token for contribution id to match sched reminder tokens

### DIFF
--- a/CRM/Core/SelectValues.php
+++ b/CRM/Core/SelectValues.php
@@ -564,7 +564,7 @@ class CRM_Core_SelectValues {
    */
   public static function contributionTokens() {
     return array_merge([
-      '{contribution.contribution_id}' => ts('Contribution ID'),
+      '{contribution.id}' => ts('Contribution ID'),
       '{contribution.total_amount}' => ts('Total Amount'),
       '{contribution.fee_amount}' => ts('Fee Amount'),
       '{contribution.net_amount}' => ts('Net Amount'),

--- a/tests/phpunit/CRM/Contribute/ActionMapping/ByTypeTest.php
+++ b/tests/phpunit/CRM/Contribute/ActionMapping/ByTypeTest.php
@@ -264,6 +264,8 @@ class CRM_Contribute_ActionMapping_ByTypeTest extends \Civi\ActionSchedule\Abstr
       contribution status id = {contribution.contribution_status_id}
       new style status = {contribution.contribution_status_id:name}
       new style label = {contribution.contribution_status_id:label}
+      id {contribution.id}
+      contribution_id {contribution.contribution_id} - not valid for action schedule
     ';
     $this->schedule->save();
     $this->callAPISuccess('job', 'send_reminder', []);
@@ -273,6 +275,8 @@ class CRM_Contribute_ActionMapping_ByTypeTest extends \Civi\ActionSchedule\Abstr
       'contribution status id = 1',
       'new style status = Completed',
       'new style label = Completed Label**',
+      'id ' . $this->ids['Contribution']['alice'],
+      'id  - not valid for action schedule',
     ];
     $this->mut->checkMailLog($expected);
 
@@ -291,11 +295,13 @@ class CRM_Contribute_ActionMapping_ByTypeTest extends \Civi\ActionSchedule\Abstr
       'receive_date = February 1st, 2015 12:00 AM',
       'new style status = Completed',
       'contribution status id = 1',
+      'id ' . $this->ids['Contribution']['alice'],
+      'contribution_id ' . $this->ids['Contribution']['alice'],
     ];
     foreach ($expected as $string) {
       $this->assertStringContainsString($string, $contributionDetails[$this->contacts['alice']['id']]['html']);
     }
-    $tokens = ['contribution_status_id', 'contribution_status_id:name', 'contribution_status_id:label'];
+    $tokens = ['id', 'contribution_status_id', 'contribution_status_id:name', 'contribution_status_id:label'];
     $processor = new CRM_Contribute_Tokens();
     foreach ($tokens as $token) {
       $this->assertEquals(CRM_Core_SelectValues::contributionTokens()['{contribution.' . $token . '}'], $processor->tokenNames[$token]);


### PR DESCRIPTION

Overview
----------------------------------------
Rename legacy token for contribution id to match sched reminder tokens

Before
----------------------------------------
When choosing a token for contribution id from the widget {contribution.contribution_id} is inserted. This works from send letter but not from scheduled reminders

After
----------------------------------------
When choosing a token for contribution id from the widget {contribution.id} is inserted - this works from both places

Screenshots are the tokens and output from send letter (scheduled reminders is unchanged other than the addition of test cover by this PR)

![image](https://user-images.githubusercontent.com/336308/127922849-eeef4068-5171-4d9c-8b63-aa4017eabdec.png)

![image](https://user-images.githubusercontent.com/336308/127922918-171f4f79-aa6c-43ee-a666-cd251b53652b.png)



Technical Details
----------------------------------------
In this case it turns out

1) the token being advertised by scheduled reminders is more correct ('id')
2) the legacy method resolves either 'id' or 'contribution_id' and
3) changing the advertised token from 'contribution.contribution_id' to contribution.id
does not cause contribution_id to stop working

So in summary - the advertised token was working in 'send letter' but not
in scheduled reminders. And changing which is advertised doesn't stop
the other from working in send letter


Comments
----------------------------------------
