### PR TITLE
Switch contribution action schedule tokens to use advertised tokens for cancel_date & source

### DIFF
--- a/CRM/Upgrade/Incremental/php/FiveFortyOne.php
+++ b/CRM/Upgrade/Incremental/php/FiveFortyOne.php
@@ -74,6 +74,12 @@ class CRM_Upgrade_Incremental_php_FiveFortyOne extends CRM_Upgrade_Incremental_B
     $this->addTask('Replace contribution status token in action schedule',
       'updateActionScheduleToken', 'contribution.status', 'contribution.contribution_status_id:label', $rev
     );
+    $this->addTask('Replace contribution cancel_date token in action schedule',
+      'updateActionScheduleToken', 'contribution.contribution_cancel_date', 'contribution.cancel_date', $rev
+    );
+    $this->addTask('Replace contribution source token in action schedule',
+      'updateActionScheduleToken', 'contribution.contribution_source', 'contribution.source', $rev
+    );
   }
 
   /**

--- a/tests/phpunit/CRM/Contribute/ActionMapping/ByTypeTest.php
+++ b/tests/phpunit/CRM/Contribute/ActionMapping/ByTypeTest.php
@@ -150,7 +150,7 @@ class CRM_Contribute_ActionMapping_ByTypeTest extends \Civi\ActionSchedule\Abstr
   /**
    * Create a contribution record for Alice with type "Member Dues".
    */
-  public function addAliceDues() {
+  public function addAliceDues(): void {
     $this->ids['Contribution']['alice'] = $this->callAPISuccess('Contribution', 'create', [
       'contact_id' => $this->contacts['alice']['id'],
       'receive_date' => date('Ymd', strtotime($this->targetDate)),
@@ -160,6 +160,8 @@ class CRM_Contribute_ActionMapping_ByTypeTest extends \Civi\ActionSchedule\Abstr
       'fee_amount' => '5',
       'net_amount' => '95',
       'source' => 'SSF',
+      // Having a cancel date is a bit artificial here but we can test it....
+      'cancel_date' => '2021-08-09',
       'contribution_status_id' => 1,
       'soft_credit' => [
         '1' => [
@@ -266,7 +268,8 @@ class CRM_Contribute_ActionMapping_ByTypeTest extends \Civi\ActionSchedule\Abstr
       new style label = {contribution.contribution_status_id:label}
       id {contribution.id}
       contribution_id {contribution.contribution_id} - not valid for action schedule
-    ';
+      cancel date {contribution.cancel_date}
+      source {contribution.source}';
     $this->schedule->save();
     $this->callAPISuccess('job', 'send_reminder', []);
     $expected = [
@@ -277,6 +280,8 @@ class CRM_Contribute_ActionMapping_ByTypeTest extends \Civi\ActionSchedule\Abstr
       'new style label = Completed Label**',
       'id ' . $this->ids['Contribution']['alice'],
       'id  - not valid for action schedule',
+      'cancel date August 9th, 2021 12:00 AM',
+      'source SSF',
     ];
     $this->mut->checkMailLog($expected);
 


### PR DESCRIPTION
Overview
----------------------------------------
Scheduled reminders was working with the incorrect and not advertised variants - this
switches over and upgrades ( a bit precautionary since the removed ones were not in the widget)

Before
----------------------------------------
Tokens in the widget work for letters but not scheduled reminders

![image](https://user-images.githubusercontent.com/336308/127924372-9c393d51-631d-4a8d-ba04-2654cab8c6a8.png)

After
----------------------------------------
Tokens in the widget work for both, upgrade script removes references to the old ones

Technical Details
----------------------------------------
PR incorporates 2 other PRs that can be re-based out

Comments
----------------------------------------
