### PR TITLE
 Reconcile and upgrade tokens for payment instrument, financial type

### DIFF
--- a/CRM/Core/SelectValues.php
+++ b/CRM/Core/SelectValues.php
@@ -562,15 +562,19 @@ class CRM_Core_SelectValues {
    *
    * @return array
    */
-  public static function contributionTokens() {
-    return array_merge([
+  public static function contributionTokens(): array {
+    $tokens = [];
+    $processor = new CRM_Contribute_Tokens();
+    foreach (array_merge($processor->getPseudoTokens(), $processor->getBasicTokens()) as $token => $title) {
+      $tokens['{contribution.' . $token . '}'] = $title;
+    }
+    return array_merge($tokens, [
       '{contribution.id}' => ts('Contribution ID'),
       '{contribution.total_amount}' => ts('Total Amount'),
       '{contribution.fee_amount}' => ts('Fee Amount'),
       '{contribution.net_amount}' => ts('Net Amount'),
       '{contribution.non_deductible_amount}' => ts('Non-deductible Amount'),
       '{contribution.receive_date}' => ts('Contribution Date Received'),
-      '{contribution.payment_instrument}' => ts('Payment Method'),
       '{contribution.trxn_id}' => ts('Transaction ID'),
       '{contribution.invoice_id}' => ts('Invoice ID'),
       '{contribution.currency}' => ts('Currency'),
@@ -580,13 +584,6 @@ class CRM_Core_SelectValues {
       '{contribution.thankyou_date}' => ts('Thank You Date'),
       '{contribution.contribution_source}' => ts('Contribution Source'),
       '{contribution.amount_level}' => ts('Amount Level'),
-      //'{contribution.contribution_recur_id}' => ts('Contribution Recurring ID'),
-      //'{contribution.honor_contact_id}' => ts('Honor Contact ID'),
-      '{contribution.contribution_status_id}' => ts('Contribution Status ID'),
-      '{contribution.contribution_status_id:label}' => ts('Contribution Status'),
-      '{contribution.contribution_status_id:name}' => ts('Machine name') . ': ' . ts('Contribution Status'),
-      //'{contribution.honor_type_id}' => ts('Honor Type ID'),
-      //'{contribution.address_id}' => ts('Address ID'),
       '{contribution.check_number}' => ts('Check Number'),
       '{contribution.campaign}' => ts('Contribution Campaign'),
     ], CRM_Utils_Token::getCustomFieldTokens('Contribution', TRUE));

--- a/CRM/Upgrade/Incremental/php/FiveFortyOne.php
+++ b/CRM/Upgrade/Incremental/php/FiveFortyOne.php
@@ -80,6 +80,12 @@ class CRM_Upgrade_Incremental_php_FiveFortyOne extends CRM_Upgrade_Incremental_B
     $this->addTask('Replace contribution source token in action schedule',
       'updateActionScheduleToken', 'contribution.contribution_source', 'contribution.source', $rev
     );
+    $this->addTask('Replace contribution type token in action schedule',
+      'updateActionScheduleToken', 'contribution.type', 'contribution.financial_type_id:label', $rev
+    );
+    $this->addTask('Replace contribution payment instrument token in action schedule',
+      'updateActionScheduleToken', 'contribution.payment_instrument', 'contribution.payment_instrument_id:label', $rev
+    );
   }
 
   /**

--- a/tests/phpunit/CRM/Contribute/ActionMapping/ByTypeTest.php
+++ b/tests/phpunit/CRM/Contribute/ActionMapping/ByTypeTest.php
@@ -269,7 +269,14 @@ class CRM_Contribute_ActionMapping_ByTypeTest extends \Civi\ActionSchedule\Abstr
       id {contribution.id}
       contribution_id {contribution.contribution_id} - not valid for action schedule
       cancel date {contribution.cancel_date}
-      source {contribution.source}';
+      source {contribution.source}
+      financial type id = {contribution.financial_type_id}
+      financial type name = {contribution.financial_type_id:name}
+      financial type label = {contribution.financial_type_id:label}
+      payment instrument id = {contribution.payment_instrument_id}
+      payment instrument name = {contribution.payment_instrument_id:name}
+      payment instrument label = {contribution.payment_instrument_id:label}';
+
     $this->schedule->save();
     $this->callAPISuccess('job', 'send_reminder', []);
     $expected = [
@@ -282,6 +289,12 @@ class CRM_Contribute_ActionMapping_ByTypeTest extends \Civi\ActionSchedule\Abstr
       'id  - not valid for action schedule',
       'cancel date August 9th, 2021 12:00 AM',
       'source SSF',
+      'financial type id = 1',
+      'financial type name = Donation',
+      'financial type label = Donation',
+      'payment instrument id = 4',
+      'payment instrument name = Check',
+      'payment instrument label = Check',
     ];
     $this->mut->checkMailLog($expected);
 
@@ -302,11 +315,28 @@ class CRM_Contribute_ActionMapping_ByTypeTest extends \Civi\ActionSchedule\Abstr
       'contribution status id = 1',
       'id ' . $this->ids['Contribution']['alice'],
       'contribution_id ' . $this->ids['Contribution']['alice'],
+      'financial type id = 1',
+      'financial type name = Donation',
+      'financial type label = Donation',
+      'payment instrument id = 4',
+      'payment instrument name = Check',
+      'payment instrument label = Check',
     ];
     foreach ($expected as $string) {
       $this->assertStringContainsString($string, $contributionDetails[$this->contacts['alice']['id']]['html']);
     }
-    $tokens = ['id', 'contribution_status_id', 'contribution_status_id:name', 'contribution_status_id:label'];
+    $tokens = [
+      'id',
+      'payment_instrument_id',
+      'payment_instrument_id:name',
+      'payment_instrument_id:label',
+      'financial_type_id',
+      'financial_type_id:name',
+      'financial_type_id:label',
+      'contribution_status_id',
+      'contribution_status_id:name',
+      'contribution_status_id:label',
+    ];
     $processor = new CRM_Contribute_Tokens();
     foreach ($tokens as $token) {
       $this->assertEquals(CRM_Core_SelectValues::contributionTokens()['{contribution.' . $token . '}'], $processor->tokenNames[$token]);


### PR DESCRIPTION
Overview
----------------------------------------
This switches the last 2 'alias' tokens from Contribute_Tokens to the preferred format,
adds tests & upgrade and switches the advertised tokens. I tested & the token
removed from the sent letter collection still works

Before
----------------------------------------
Scheduled reminders handles 
{contribution.type} = financial type label. This is not advertised
{contribution.payment_instrument} = payment instrument label. This is advertised

After
----------------------------------------
The following work in 'send letter' - only the first 3 are advertised / work in send letter. The legacy ones are upgraded out of scheduled reminders. I didn't do anything upgrade related for send letter since I'm not cleaning up that code & they didn't break but I think we would just do a replace on all of message templates when / if we do

![image](https://user-images.githubusercontent.com/336308/127928015-37280cbf-43f1-4d71-bae0-7f53ea39ea58.png)

![image](https://user-images.githubusercontent.com/336308/127928289-b4f77360-9389-42c2-812e-6f9dc748df7d.png)



Technical Details
----------------------------------------
This switches the last 2 'alias' tokens from Contribute_Tokens to the preferred format,
adds tests & upgrade and switches the advertised tokens. I tested & the token
removed from the sent letter collection still works


Comments
----------------------------------------
