### PR TITLE
[REF] Fix utf8mb4 test in APIv4 and re-enable the altering of databas…

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -5668,7 +5668,10 @@ civicrm_relationship.start_date > {$today}
           }
           throw new CRM_Core_Exception(ts('Failed to interpret input for search'));
         }
-
+        $emojiWhere = CRM_Utils_SQL::handleEmojiInQuery($value);
+        if ($emojiWhere === '0 = 1') {
+          $value = $emojiWhere;
+        }
         $value = CRM_Utils_Type::escape($value, $dataType);
         // if we don't have a dataType we should assume
         if ($dataType == 'String' || $dataType == 'Text') {

--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -2881,20 +2881,9 @@ SELECT contact_id
    */
   public static function createSQLFilter($fieldName, $filter, $type = NULL, $alias = NULL, $returnSanitisedArray = FALSE) {
     foreach ($filter as $operator => $criteria) {
-      if (!CRM_Core_BAO_SchemaHandler::databaseSupportsUTF8MB4()) {
-        foreach ((array) $criteria as $criterion) {
-          if (!empty($criterion) && !is_numeric($criterion)
-            // The first 2 criteria are redundant but are added as they
-            // seem like they would
-            // be quicker than this 3rd check.
-            && max(array_map('ord', str_split($criterion))) >= 240) {
-            // String contains unsupported emojis.
-            // We return a clause that resolves to false as an emoji string by definition cannot be saved.
-            // note that if we return just 0 for false if gets lost in empty checks.
-            // https://stackoverflow.com/questions/16496554/can-php-detect-4-byte-encoded-utf8-chars
-            return '0 = 1';
-          }
-        }
+      $emojiFilter = CRM_Utils_SQL::handleEmojiInQuery($criteria);
+      if ($emojiFilter === '0 = 1') {
+        return $emojiFilter;
       }
 
       if (in_array($operator, self::acceptedSQLOperators(), TRUE)) {

--- a/CRM/Utils/SQL.php
+++ b/CRM/Utils/SQL.php
@@ -203,4 +203,30 @@ class CRM_Utils_SQL {
     return $dsn;
   }
 
+  /**
+   * Filter out Emojis in where clause if the database (determined by checking the create table for civicrm_contact)
+   * cannot support emojis
+   * @param mixed $criteria - filter criteria to check
+   *
+   * @return bool|string
+   */
+  public static function handleEmojiInQuery($criteria) {
+    if (!CRM_Core_BAO_SchemaHandler::databaseSupportsUTF8MB4()) {
+      foreach ((array) $criteria as $criterion) {
+        if (!empty($criterion) && !is_numeric($criterion)
+          // The first 2 criteria are redundant but are added as they
+          // seem like they would
+          // be quicker than this 3rd check.
+          && max(array_map('ord', str_split($criterion))) >= 240) {
+          // String contains unsupported emojis.
+          // We return a clause that resolves to false as an emoji string by definition cannot be saved.
+          // note that if we return just 0 for false if gets lost in empty checks.
+          // https://stackoverflow.com/questions/16496554/can-php-detect-4-byte-encoded-utf8-chars
+          return '0 = 1';
+        }
+      }
+      return TRUE;
+    }
+  }
+
 }

--- a/tests/phpunit/api/v3/ContactTest.php
+++ b/tests/phpunit/api/v3/ContactTest.php
@@ -5196,11 +5196,27 @@ class api_v3_ContactTest extends CiviUnitTestCase {
    * out when we are.
    */
   public function testEmojiInWhereClause(): void {
+    $schemaNeedsAlter = \CRM_Core_BAO_SchemaHandler::databaseSupportsUTF8MB4();
+    if ($schemaNeedsAlter) {
+      CRM_Core_DAO::executeQuery("
+        ALTER TABLE civicrm_contact MODIFY COLUMN
+        `first_name` VARCHAR(64) CHARACTER SET utf8 COLLATE utf8_unicode_ci DEFAULT NULL COMMENT 'First Name.',
+        CHARSET utf8 COLLATE utf8_unicode_ci
+      ");
+      Civi::$statics['CRM_Core_BAO_SchemaHandler'] = [];
+    }
     $this->callAPISuccess('Contact', 'get', [
       'debug' => 1,
       'first_name' => '🦉Claire',
-      'version' => 4,
     ]);
+    if ($schemaNeedsAlter) {
+      CRM_Core_DAO::executeQuery("
+        ALTER TABLE civicrm_contact MODIFY COLUMN
+        `first_name` VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT 'First Name.',
+        CHARSET utf8mb4 COLLATE utf8mb4_unicode_ci
+      ");
+      Civi::$statics['CRM_Core_BAO_SchemaHandler'] = [];
+    }
   }
 
   /**

--- a/tests/phpunit/api/v4/Action/ContactGetTest.php
+++ b/tests/phpunit/api/v4/Action/ContactGetTest.php
@@ -117,8 +117,9 @@ class ContactGetTest extends \api\v4\UnitTestCase {
       \CRM_Core_DAO::executeQuery("
         ALTER TABLE civicrm_contact MODIFY COLUMN
         `first_name` VARCHAR(64) CHARACTER SET utf8 COLLATE utf8_unicode_ci DEFAULT NULL COMMENT 'First Name.',
-        CHARSET utf8
+        CHARSET utf8 COLLATE utf8_unicode_ci
       ");
+      \Civi::$statics['CRM_Core_BAO_SchemaHandler'] = [];
     }
     \Civi::$statics['CRM_Core_BAO_SchemaHandler'] = [];
     Contact::get()
@@ -129,7 +130,7 @@ class ContactGetTest extends \api\v4\UnitTestCase {
       \CRM_Core_DAO::executeQuery("
         ALTER TABLE civicrm_contact MODIFY COLUMN
         `first_name` VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT 'First Name.',
-        CHARSET utf8mb4
+        CHARSET utf8mb4 COLLATE utf8mb4_unicode_ci
       ");
     }
   }


### PR DESCRIPTION
…e in the v3 version of the test and fix handling for first name field

Overview
----------------------------------------
This is a follow on to https://github.com/civicrm/civicrm-core/pull/20905 which improves the APIv3 version of the test to do the faking of the database to test the re-writing of the query. It also properly fixes the handling for the v3 unit test.

Before
----------------------------------------
APIv4 unit test fails

After
----------------------------------------
V4 and V3 unit tests pass in a similar manner

ping @demeritcowboy @eileenmcnaughton 
