### PR TITLE
Smarty warnings on Manage Case

### DIFF
--- a/CRM/Case/Form/CaseView.php
+++ b/CRM/Case/Form/CaseView.php
@@ -353,9 +353,7 @@ class CRM_Case_Form_CaseView extends CRM_Core_Form {
     );
 
     $hookCaseSummary = CRM_Utils_Hook::caseSummary($this->_caseID);
-    if (is_array($hookCaseSummary)) {
-      $this->assign('hookCaseSummary', $hookCaseSummary);
-    }
+    $this->assign('hookCaseSummary', is_array($hookCaseSummary) ? $hookCaseSummary : NULL);
 
     $allTags = CRM_Core_BAO_Tag::getColorTags('civicrm_case');
 

--- a/templates/CRM/Case/Form/CaseView.tpl
+++ b/templates/CRM/Case/Form/CaseView.tpl
@@ -178,7 +178,7 @@
             <th data-data="phone">{ts}Phone{/ts}</th>
             <th data-data="email">{ts}Email{/ts}</th>
             <th data-data="end_date">{ts}End Date{/ts}</th>
-            {if $relId neq 'client' and $hasAccessToAllCases}
+            {if $hasAccessToAllCases}
               <th data-data="actions" data-orderable="false">{ts}Actions{/ts}</th>
             {/if}
           </tr>


### PR DESCRIPTION
Overview
----------------------------------------
Some smarty warnings on Manage Case.

Before
----------------------------------------
* Notice: Undefined index: hookCaseSummary in include() (line 112 of .../templates_c/en_US/%%64/643/643EC55F%%CaseView.tpl.php).
* Notice: Undefined index: relId in include() (line 231 of .../templates_c/en_US/%%64/643/643EC55F%%CaseView.tpl.php).


After
----------------------------------------
There's still some more if you have other config like tags, but these are the stock ones.

Technical Details
----------------------------------------
$relId is mildly interesting. I think it was a mistake when it was added here https://github.com/civicrm/civicrm-svn/commit/8733a55c221b0890fa8bcb010826bf597a5483ee#diff-32e9cc54f42fb47188c658534516a573994fca84ba72f41a11f21261b412f610R174 (it doesn't autoexpand - search the page for CaseView.tpl and then click on Load Diff). Even if the variable were being used in scope, it doesn't make sense to compare $relId to 'client' in the table header because it's a per-row variable (look just down below that at line 179). They probably just copy/pasted from line 190.

Comments
----------------------------------------

