### PR TITLE
Use template variable to add or remove swap button.

### DIFF
--- a/CRM/Activity/Form/Activity.php
+++ b/CRM/Activity/Form/Activity.php
@@ -570,6 +570,7 @@ class CRM_Activity_Form_Activity extends CRM_Contact_Form_Task {
       $count = count(is_array($defaults['target_contact_id']) ? $defaults['target_contact_id'] : explode(',', $defaults['target_contact_id']));
       if ($count > 50) {
         $this->freeze(['target_contact_id']);
+        $this->assign('disable_swap_button', TRUE);
       }
     }
 

--- a/templates/CRM/Activity/Form/Activity.tpl
+++ b/templates/CRM/Activity/Form/Activity.tpl
@@ -78,7 +78,7 @@
       <td>
         {$form.assignee_contact_id.html}
         {if $action neq 4}
-          {if !$form.target_contact_id.frozen}
+          {if empty($disable_swap_button)}
             <a href="#" class="crm-hover-button" id="swap_target_assignee" title="{ts}Swap Target and Assignee Contacts{/ts}" style="position:relative; bottom: 1em;">
               <i class="crm-i fa-random" aria-hidden="true"></i>
             </a>


### PR DESCRIPTION
Overview
----------------------------------------
Use template variable to add or remove swap button.

Before
----------------------------------------
Rendering of 'swap button' ![swap](https://lab.civicrm.org/extensions/assignee/uploads/a77498411bbd29893201802446584c9e/image.png)

on activity form driven by whether or not the activity assignee field is frozen

![full form](https://lab.civicrm.org/extensions/assignee/uploads/4ada7fe872e6b60ee068101ce9649a2e/image.png)


After
----------------------------------------
Presence rendered by a template variable

Technical Details
----------------------------------------
In combination with email notifications this button can be dangerous - ie an accidental click and
a donor rather than a staff member gets the email.

My thinking is to disable this via the activity assignee extension,
https://lab.civicrm.org/extensions/assignee/-/issues/2 - but it's cleaner for
an extension to intervene by setting a smarty variable than using javascript
to remove the button and I feel like it makes more sense for the form to
assign 'instruction variables' than for the decision to freeze to
also have 'hidden' effects further down

This doesn't wind up being any more supported than the js but it will be easier for us to write a unit test within the extension to ensure it doesn't quietly stop working 

Comments
----------------------------------------
