### PR TITLE
Afform - support default values for fields

### DIFF
--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -3231,7 +3231,7 @@ span.crm-select-item-color {
   top: 4px;
 }
 .crm-container ul.crm-checkbox-list li label {
-  display: block;
+  display: block !important;
   padding: 2px 0 2px 22px;
   margin: 0;
   word-break: break-all;

--- a/ext/afform/admin/ang/afGuiEditor.css
+++ b/ext/afform/admin/ang/afGuiEditor.css
@@ -133,16 +133,18 @@
   text-align: right;
 }
 
-#afGuiEditor .af-gui-bar {
+#afGuiEditor-canvas .af-gui-bar {
   height: 22px;
   width: 100%;
-  opacity: 0;
   transition: opacity .2s;
   position:relative;
   font-family: "Courier New", Courier, monospace;
   font-size: 12px;
 }
-#afGuiEditor [ui-sortable] .af-gui-bar {
+#afGuiEditor-canvas:not(.af-gui-menu-open) .af-gui-bar {
+  opacity: 0;
+}
+#afGuiEditor-canvas [ui-sortable] .af-gui-bar {
   cursor: move;
   background-color: #f2f2f2;
   position: absolute;
@@ -154,7 +156,7 @@
   opacity: 1;
   transition: opacity .2s;
 }
-#afGuiEditor-canvas .af-gui-dragtarget > .af-gui-bar {
+#afGuiEditor #afGuiEditor-canvas .af-gui-dragtarget > .af-gui-bar {
   background-color: #d7e6ff;
   opacity: 1;
   transition: opacity .1s;
@@ -218,7 +220,7 @@ body.af-gui-dragging {
   margin-bottom: 20px;
 }
 
-#afGuiEditor .af-gui-container:hover,
+#afGuiEditor-canvas:not(.af-gui-menu-open) .af-gui-container:hover,
 .af-gui-dragging #afGuiEditor .af-gui-container {
   border: 2px dashed #757575;
 }
@@ -455,9 +457,6 @@ body.af-gui-dragging {
 #afGuiEditor .af-gui-field-input-type-select .input-group .dropdown-menu {
   width: 100%;
   right: 0;
-}
-#afGuiEditor .af-gui-field-input-type-select .input-group .dropdown-menu a {
-  cursor: default;
 }
 
 #afGuiEditor .af-gui-text-h1 {

--- a/ext/afform/admin/ang/afGuiEditor.js
+++ b/ext/afform/admin/ang/afGuiEditor.js
@@ -210,11 +210,13 @@
           .on('show.bs.dropdown', function() {
             $scope.$apply(function() {
               $scope.menu.open = true;
+              element.closest('#afGuiEditor-canvas').addClass('af-gui-menu-open');
             });
           })
           .on('hidden.bs.dropdown', function() {
             $scope.$apply(function() {
               $scope.menu.open = false;
+              element.closest('#afGuiEditor-canvas').removeClass('af-gui-menu-open');
             });
           });
       }

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiField-menu.html
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiField-menu.html
@@ -7,25 +7,36 @@
   </div>
 </li>
 <li>
-  <a href ng-click="toggleRequired(); $event.stopPropagation();" title="{{:: ts('Require this field') }}">
+  <a href ng-click="toggleRequired(); $event.stopPropagation(); $event.target.blur();" title="{{:: ts('Require this field') }}">
     <i class="crm-i fa-{{ getProp('required') ? 'check-' : '' }}square-o"></i>
     {{:: ts('Required') }}
   </a>
 </li>
 <li>
-  <a href ng-click="toggleLabel(); $event.stopPropagation();" title="{{:: ts('Show field label') }}">
+  <a href ng-click="toggleDefaultValue(); $event.stopPropagation(); $event.target.blur();" title="{{:: ts('Pre-fill this field with a value') }}">
+    <i class="crm-i fa-{{ $ctrl.hasDefaultValue ? 'check-' : '' }}square-o"></i>
+    {{:: ts('Default value') }}
+  </a>
+</li>
+<li ng-if="$ctrl.hasDefaultValue">
+  <div ng-click="$event.stopPropagation()" class="af-gui-field-select-in-dropdown form-inline">
+    <input class="form-control" af-gui-field-value="$ctrl.fieldDefn" ng-model="getSet('afform_default')" ng-model-options="{getterSetter: true}" >
+  </div>
+</li>
+<li>
+  <a href ng-click="toggleLabel(); $event.stopPropagation(); $event.target.blur();" title="{{:: ts('Show field label') }}">
     <i class="crm-i fa-{{ $ctrl.node.defn.label === false ? '' : 'check-' }}square-o"></i>
     {{:: ts('Label') }}
   </a>
 </li>
 <li>
-  <a href ng-click="toggleHelp('pre'); $event.stopPropagation();" title="{{:: ts('Show help text above this field') }}">
+  <a href ng-click="toggleHelp('pre'); $event.stopPropagation(); $event.target.blur();" title="{{:: ts('Show help text above this field') }}">
     <i class="crm-i fa-{{ propIsset('help_pre') ? 'check-' : '' }}square-o"></i>
     {{:: ts('Pre help text') }}
   </a>
 </li>
 <li>
-  <a href ng-click="toggleHelp('post'); $event.stopPropagation();" title="{{:: ts('Show help text below this field') }}">
+  <a href ng-click="toggleHelp('post'); $event.stopPropagation(); $event.target.blur();" title="{{:: ts('Show help text below this field') }}">
     <i class="crm-i fa-{{ propIsset('help_post') ? 'check-' : '' }}square-o" ></i>
     {{:: ts('Post help text') }}
   </a>

--- a/ext/afform/admin/ang/afGuiEditor/inputType/CheckBox.html
+++ b/ext/afform/admin/ang/afGuiEditor/inputType/CheckBox.html
@@ -1,6 +1,6 @@
-<ul class="crm-checkbox-list" ng-if="$ctrl.getOptions()">
+<ul class="crm-checkbox-list" ng-if="$ctrl.getOptions()" title="{{:: ts('Set default value') }}">
   <li ng-repeat="opt in $ctrl.getOptions()" >
-    <input type="checkbox" disabled >
+    <input type="checkbox" ng-checked="defaultValueContains(opt.id)" ng-click="toggleDefaultValueItem(opt.id)" >
     <label>{{ opt.label }}</label>
   </li>
 </ul>

--- a/ext/afform/admin/ang/afGuiEditor/inputType/Radio.html
+++ b/ext/afform/admin/ang/afGuiEditor/inputType/Radio.html
@@ -1,6 +1,6 @@
-<div class="form-inline">
+<div class="form-inline" title="{{:: ts('Set default value') }}">
   <label ng-repeat="opt in $ctrl.getOptions()" class="radio" >
-    <input class="crm-form-radio" type="radio" disabled />
+    <input class="crm-form-radio" type="radio" ng-checked="defaultValueContains(opt.id)" ng-click="toggleDefaultValueItem(opt.id)" >
     {{ opt.label }}
   </label>
 </div>

--- a/ext/afform/admin/ang/afGuiEditor/inputType/Select.html
+++ b/ext/afform/admin/ang/afGuiEditor/inputType/Select.html
@@ -5,9 +5,12 @@
       <input autocomplete="off" class="form-control" placeholder="{{:: ts('Select') }}" title="{{:: ts('Click to add placeholder text') }}" ng-model="getSet('input_attrs.placeholder' + i)" ng-model-options="{getterSetter: true}" type="text" />
       <div class="input-group-btn" af-gui-menu>
         <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><i class="crm-i fa-caret-down"></i></button>
-        <ul class="dropdown-menu" ng-if="menu.open">
+        <ul class="dropdown-menu" ng-if="menu.open" title="{{:: ts('Set default value') }}">
           <li ng-repeat="opt in $ctrl.getOptions()" >
-            <a href>{{ opt.label }}</a>
+            <a href ng-click="toggleDefaultValueItem(opt.id); $event.stopPropagation(); $event.target.blur();">
+              <i class="crm-i fa-{{defaultValueContains(opt.id) ? 'check-' : ''}}circle-o"></i>
+              {{ opt.label }}
+            </a>
           </li>
         </ul>
       </div>

--- a/ext/afform/core/ang/af/afField.component.js
+++ b/ext/afform/core/ang/af/afField.component.js
@@ -12,7 +12,7 @@
       fieldName: '@name',
       defn: '='
     },
-    controller: function($scope, $element, crmApi4) {
+    controller: function($scope, $element, crmApi4, $timeout) {
       var ts = $scope.ts = CRM.ts('org.civicrm.afform'),
         ctrl = this,
         boolOptions = [{id: true, label: ts('Yes')}, {id: false, label: ts('No')}],
@@ -83,6 +83,14 @@
                   ctrl.defn.options = data.options;
                 });
             }
+          });
+        }
+
+        // Set default value
+        if (ctrl.defn.afform_default) {
+          // Wait for parent controllers to initialize
+          $timeout(function() {
+            $scope.dataProvider.getFieldData()[ctrl.fieldName] = ctrl.defn.afform_default;
           });
         }
 


### PR DESCRIPTION
Overview
----------------------------------------
Allow default values for fields per https://lab.civicrm.org/dev/core/-/issues/2734

Before
----------------------------------------
Not possible to configure default values for Afform fields.

After
----------------------------------------
![image](https://user-images.githubusercontent.com/2874912/128112860-e9e3e6bd-2961-4626-b950-a9c24fef2126.png)


Technical Details
----------------------------------------
This adds an `"afform_default"` property to the field definition.
It does not use the `"default_value"` property from getFields because that's more to do with Civi's schema and often not appropriate for a form.