### PR TITLE
dev/core#2121 Ability to change pdf filename before downloading

### DIFF
--- a/CRM/Contact/Form/Task/PDFLetterCommon.php
+++ b/CRM/Contact/Form/Task/PDFLetterCommon.php
@@ -232,9 +232,9 @@ class CRM_Contact_Form_Task_PDFLetterCommon extends CRM_Core_Form_Task_PDFLetter
       $fileName = CRM_Utils_String::munge($form->getSubmittedValue('subject'), '_', 200);
     }
     else {
-      $fileName = "CiviLetter";
+      $fileName = 'CiviLetter';
     }
-    $fileName = self::isLiveMode($form) ? $fileName : $fileName . "_preview";
+    $fileName = self::isLiveMode($form) ? $fileName : $fileName . '_preview';
 
     return $fileName;
   }

--- a/CRM/Contact/Form/Task/PDFLetterCommon.php
+++ b/CRM/Contact/Form/Task/PDFLetterCommon.php
@@ -178,8 +178,10 @@ class CRM_Contact_Form_Task_PDFLetterCommon extends CRM_Core_Form_Task_PDFLetter
     $mimeType = self::getMimeType($type);
     // ^^ Useful side-effect: consistently throws error for unrecognized types.
 
+    $fileName = self::getFileName($form);
+    $fileName = "$fileName.$type";
+
     if ($type == 'pdf') {
-      $fileName = "CiviLetter.$type";
       CRM_Utils_PDF_Utils::html2pdf($html, $fileName, FALSE, $formValues);
     }
     elseif (!empty($formValues['document_file_path'])) {
@@ -187,7 +189,6 @@ class CRM_Contact_Form_Task_PDFLetterCommon extends CRM_Core_Form_Task_PDFLetter
       CRM_Utils_PDF_Document::printDocuments($html, $fileName, $type, $zip);
     }
     else {
-      $fileName = "CiviLetter.$type";
       CRM_Utils_PDF_Document::html2doc($html, $fileName, $formValues);
     }
 
@@ -213,6 +214,29 @@ class CRM_Contact_Form_Task_PDFLetterCommon extends CRM_Core_Form_Task_PDFLetter
     $form->postProcessHook();
 
     CRM_Utils_System::civiExit();
+  }
+
+  /**
+   * Returns the filename for the pdf by striping off unwanted characters and limits the length to 200 characters.
+   *
+   * @param CRM_Core_Form $form
+   *
+   * @return string
+   *   The name of the file.
+   */
+  private static function getFileName(CRM_Core_Form $form) {
+    if (!empty($form->getSubmittedValue('pdf_file_name'))) {
+      $fileName = CRM_Utils_String::munge($form->getSubmittedValue('pdf_file_name'), '_', 200);
+    }
+    elseif (!empty($form->getSubmittedValue('subject'))) {
+      $fileName = CRM_Utils_String::munge($form->getSubmittedValue('subject'), '_', 200);
+    }
+    else {
+      $fileName = "CiviLetter";
+    }
+    $fileName = self::isLiveMode($form) ? $fileName : $fileName . "_preview";
+
+    return $fileName;
   }
 
   /**

--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -2744,7 +2744,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
    *
    * @return mixed|null
    */
-  protected function getSubmittedValue(string $fieldName) {
+  public function getSubmittedValue(string $fieldName) {
     if (empty($this->exportedValues)) {
       $this->exportedValues = $this->controller->exportValues($this->_name);
     }

--- a/CRM/Core/Form/Task/PDFLetterCommon.php
+++ b/CRM/Core/Form/Task/PDFLetterCommon.php
@@ -53,6 +53,10 @@ class CRM_Core_Form_Task_PDFLetterCommon {
       FALSE
     );
 
+    // Added for core#2121,
+    // To support sending a custom pdf filename before downloading.
+    $form->addElement('hidden', 'pdf_file_name', []);
+
     $form->addSelect('format_id', [
       'label' => ts('Select Format'),
       'placeholder' => ts('Default'),

--- a/tests/phpunit/CRM/Contact/Form/Task/PDFLetterCommonTest.php
+++ b/tests/phpunit/CRM/Contact/Form/Task/PDFLetterCommonTest.php
@@ -1,0 +1,119 @@
+<?php
+
+/*
++--------------------------------------------------------------------+
+| Copyright CiviCRM LLC. All rights reserved.                        |
+|                                                                    |
+| This work is published under the GNU AGPLv3 license with some      |
+| permitted exceptions and without any warranty. For full license    |
+| and copyright information, see https://civicrm.org/licensing       |
++--------------------------------------------------------------------+
+ */
+
+/**
+ * Test class for CRM_Contact_Form_Task_PDFLetterCommon.
+ *
+ * @group headless
+ */
+class CRM_Contact_Form_Task_PDFLetterCommonTest extends CiviUnitTestCase {
+
+  /**
+   * Contact ID.
+   *
+   * @var int
+   */
+  protected $contactId;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->contactId = $this->createLoggedInUser();
+  }
+
+  /**
+   * Test the pdf filename is assigned as expected.
+   *
+   * @param string|null $pdfFileName
+   *   Value for pdf_file_name param.
+   * @param string|null $activitySubject
+   *   Value of the subject of the activity.
+   * @param bool|null $isLiveMode
+   *   TRUE when the form is in live mode, NULL when it is a preview.
+   * @param string $expectedFilename
+   *   Expected filename assigned to the pdf.
+   *
+   * @dataProvider getFilenameCases
+   */
+  public function testFilenameIsAssigned(?string $pdfFileName, ?string $activitySubject, ?bool $isLiveMode, string $expectedFilename): void {
+    $_REQUEST['cid'] = $this->contactId;
+    $form = $this->getFormObject('CRM_Contact_Form_Task_PDF', [
+      'pdf_file_name' => $pdfFileName,
+      'subject' => $activitySubject,
+      '_contactIds' => [],
+      'document_type' => 'pdf',
+      'buttons' => [
+        '_qf_PDF_upload' => $isLiveMode,
+      ],
+    ]);
+    $fileNameAssigned = NULL;
+    $form->preProcess();
+    try {
+      $form->postProcess();
+    }
+    catch (CRM_Core_Exception_PrematureExitException $e) {
+      $fileNameAssigned = $e->errorData['fileName'];
+    }
+
+    $this->assertEquals($expectedFilename, $fileNameAssigned);
+  }
+
+  /**
+   * DataProvider for testFilenameIsAssigned.
+   *
+   * @return array
+   *   Array with the test information.
+   */
+  public function getFilenameCases(): array {
+    return [
+      [
+        'FilenameInParam',
+        'FilenameInActivitySubject',
+        NULL,
+        'FilenameInParam_preview',
+      ],
+      [
+        'FilenameInParam',
+        'FilenameInActivitySubject',
+        TRUE,
+        'FilenameInParam',
+      ],
+      [
+        NULL,
+        'FilenameInActivitySubject',
+        NULL,
+        'FilenameInActivitySubject_preview',
+      ],
+      [
+        NULL,
+        'FilenameInActivitySubject',
+        TRUE,
+        'FilenameInActivitySubject',
+      ],
+      [
+        NULL,
+        NULL,
+        NULL,
+        'CiviLetter_preview',
+      ],
+      [
+        NULL,
+        NULL,
+        TRUE,
+        'CiviLetter',
+      ],
+    ];
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
This is a continuation of https://github.com/civicrm/civicrm-core/pull/18938.

For Print/Merge Activities, the pdf filename was always downloaded with the name `CiviLetter.pdf`. So in this PR, we are allowing the filename to be customised.

By default the Subject of the Activity will be considered as the file name.
If No Subject is available, then existing `CiviLetter` will still be used.
Also any 3rd party extensions can customise the name even further by submitting the form with `pdf_file_name` hidden field added.

Before
----------------------------------------
The filename was always CiviLetter.pdf.

After
----------------------------------------
![98368463-30edc880-2059-11eb-96b3-b0d6947e585f](https://user-images.githubusercontent.com/5058867/128133195-99880efb-756c-4761-8ff2-2d0516aad188.gif)

Technical Details
----------------------------------------
In `CRM/Core/Form/Task/PDFLetterCommon.php`, a new hidden field `pdf_file_name` is added, using which the pdf filename can be customised by any 3rd party extensions. 

In `CRM/Contact/Form/Task/PDFLetterCommon.php`, added logic to apply the `pdf_file_name` filed values as pdf file name, if its not present then Activity Subject will be considered, and if that is also not present, the previous `CiviLetter` string will be used as PDF file name.
