### PR TITLE
enable paging if contact has more then 50 grants.

### DIFF
--- a/templates/CRM/Grant/Form/Selector.tpl
+++ b/templates/CRM/Grant/Form/Selector.tpl
@@ -64,6 +64,6 @@
 
 
 
-{if $context EQ 'Search'}
+{if $context EQ 'Search' or $context EQ 'grant'}
     {include file="CRM/common/pager.tpl" location="bottom"}
 {/if}


### PR DESCRIPTION
Overview
----------------------------------------
Ensure that if a contact has more then 50 grants, you can access all of the grants by clicking on the "Grants" tab from their contact record.

Before
----------------------------------------
When you click on a contact, and then click the "Grants" tab, we expect to see all of the grants assigned to them.

Instead, we only see the first 50 grants assigned. If there are more then 50, we cannot click to the next page.

![no-pagination-for-grants](https://user-images.githubusercontent.com/4511942/128228005-2d954efc-8b3c-4472-9685-9fff5411b6e1.png)

Note - 56 grants. If you tediously count, you should find only 50 grants listed.

After
----------------------------------------

After this change, there is a pagination set of links at the bottom, allowing you to see the additional 6 grants.

![fixed-pagination-for-grants](https://user-images.githubusercontent.com/4511942/128228148-b5045058-4a89-4c6f-bd04-cac02fcce518.png)

Technical Details
----------------------------------------
I'm not 100% sure this is the right fix. I see that other entities (activities for example) have a different method for pagination, using javascript Maybe this PR should be rejected in favor of doing in that way? 

The template I modified seems to be used for Search results, the Grants Dashboard and the Grants Tab. The existing code only shows pagination for the Search results and it shows it at the top and bottom of the page.

I choose to show it at the bottom of the page for either Search or the Grants tab, but keep the top pagination links as they are. I'm not sure that's the right decision either - open to feedback!

The dashboard clearly says: these are the most recent grants. So, I don't think it needs pagination.
