### PR TITLE
[NFC] Fix APIv4 Utf8mb4 test to ensure no mixed collation errors

### DIFF
--- a/tests/phpunit/api/v4/Action/ContactGetTest.php
+++ b/tests/phpunit/api/v4/Action/ContactGetTest.php
@@ -120,6 +120,7 @@ class ContactGetTest extends \api\v4\UnitTestCase {
         CHARSET utf8
       ");
     }
+    \Civi::$statics['CRM_Core_BAO_SchemaHandler'] = [];
     Contact::get()
       ->setDebug(TRUE)
       ->addWhere('first_name', '=', '🦉Claire')


### PR DESCRIPTION
Overview
----------------------------------------
This is pulled out of https://github.com/civicrm/civicrm-core/pull/21001 and should fix the error in the core matrix test

Before
----------------------------------------
Core matrix test fails

After
----------------------------------------
Core matrix test runs passs

ping @eileenmcnaughton 