### PR TITLE
dev/core#2739 - Fix contribution tasks using wrong IDs

### DIFF
--- a/CRM/Contribute/Form/Task/TaskTrait.php
+++ b/CRM/Contribute/Form/Task/TaskTrait.php
@@ -114,7 +114,9 @@ trait CRM_Contribute_Form_Task_TaskTrait {
    * @throws \CRM_Core_Exception
    */
   protected function calculateIDS() {
-    if ($this->controller->get('id')) {
+    // contact search forms use the id property to store the selected uf_group_id
+    // rather than entity (contribution) IDs, so don't use the property in that case
+    if (!$this->controller instanceof CRM_Contact_Controller_Search && $this->controller->get('id')) {
       return explode(',', $this->controller->get('id'));
     }
     $ids = $this->getSelectedIDs($this->getSearchFormValues());


### PR DESCRIPTION
Overview
----------------------------------------
This fixes an issue where contribution tasks may perform actions on unrelated contribution IDs when they're called via contact search forms.

https://github.com/greenpeace-cee/civicrm-core/commit/6645ca8e24c6951ee7bc9e479637cae51ae017be

