### PR TITLE
dev/core#2728 - ReCAPTCHA - Consistently present link to settings

### DIFF
--- a/ext/recaptcha/recaptcha.php
+++ b/ext/recaptcha/recaptcha.php
@@ -127,7 +127,7 @@ function recaptcha_civicrm_entityTypes(&$entityTypes) {
  * Implements hook_civicrm_navigationMenu().
  */
 function recaptcha_civicrm_navigationMenu(&$menu) {
-  _recaptcha_civix_insert_navigation_menu($menu, 'Administer/Customize Data and Screens', [
+  _recaptcha_civix_insert_navigation_menu($menu, 'Administer/System Settings', [
     'label' => E::ts('reCAPTCHA Settings'),
     'name' => 'recaptcha_settings',
     'url' => 'civicrm/admin/setting/recaptcha',

--- a/ext/recaptcha/xml/Menu/recaptcha.xml
+++ b/ext/recaptcha/xml/Menu/recaptcha.xml
@@ -3,7 +3,9 @@
   <item>
     <path>civicrm/admin/setting/recaptcha</path>
     <title>reCAPTCHA Settings</title>
+    <desc>Configure anti-abuse/bot-prevention service</desc>
     <page_callback>CRM_Admin_Form_Generic</page_callback>
     <access_arguments>administer CiviCRM</access_arguments>
+    <adminGroup>System Settings</adminGroup>
   </item>
 </menu>


### PR DESCRIPTION
Overview
------------

See also: https://lab.civicrm.org/dev/core/-/issues/2728

Before
------

"ReCAPTCHA Settings" appears in "Customize Data and Screens" in the nav-menu, and it is missing in the `civicrm/admin` dashboard.

After
-----

"ReCAPTCHA Settings" appears "System Settings" for both the nav-menu and the `civicrm/admin` dashboard.

Comments
-----------

This page collects API credentials for connecting to a remote service. It is less akin to "Custom Fields", "Tags", or "Contact Types" and more akin to "Outbound Email" or "Mapping and Geocoding". Additionally, its old location was also under "System Settings".