### PR TITLE
Fix bulk adding custom fields with logging on

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -154,7 +154,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
 
       $tableName = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_CustomGroup', $customField->custom_group_id, 'table_name');
       $sql[$tableName][] = $fieldSQL;
-      $addedColumns[$tableName][] = $customField->name;
+      $addedColumns[$tableName][] = $customField->column_name;
       $customFields[$index] = $customField;
     }
 


### PR DESCRIPTION

Overview
----------------------------------------
Fixes a SQL error when adding fields to logging tables after bulk saving new CustomFields

To replicate: on a wmff build, turn logging on, check out
https://gerrit.wikimedia.org/r/c/wikimedia/fundraising/crm/+/709873
and run drush update-custom-fields

Before
----------------------------------------
SQL syntax error message and new field not added to logging table

After
----------------------------------------
No error message, field added to logging table

Technical Details
----------------------------------------
This code is only triggered in the 'bulk' writeRecords codepath,
not in the createField codepath which is used for creating custom
fields via the UI. By sending the 'name' instead of the 'column_name'
the _getColumnQuery's grep was not finding anything matching in the
main table create statement
https://github.com/civicrm/civicrm-core/blob/master/CRM/Logging/Schema.php#L520

