### PR TITLE
[REGRESSION] Fix CRM.url to not encode hash on WP

### DIFF
--- a/js/crm.ajax.js
+++ b/js/crm.ajax.js
@@ -22,8 +22,12 @@
       mode = CRM.config && CRM.config.isFrontend ? 'front' : 'back';
     }
     query = query || '';
-    var url,
-      frag = path.split('?');
+    var url, frag, hash = '';
+    if (path.indexOf('#') > -1) {
+      hash = '#' + path.split('#')[1];
+      path = path.split('#')[0];
+    }
+    frag = path.split('?');
     // Encode url path only if slashes in placeholder were also encoded
     if (tplURL[mode].indexOf('civicrm/placeholder-url-path') >= 0) {
       url = tplURL[mode].replace('civicrm/placeholder-url-path', frag[0]);
@@ -39,7 +43,7 @@
     if (frag[1]) {
       url += (url.indexOf('?') < 0 ? '?' : '&') + frag[1];
     }
-    return url;
+    return url + hash;
   };
 
   $.fn.crmURL = function () {


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a regression where the link to edit a SavedSearch from Afform is broken on WP.

Before
----------------------------------------
This link doesn't work on WP, due to a url encoding issue in `CRM.url()`:

![image](https://user-images.githubusercontent.com/2874912/128277541-b002478a-a3ef-4c73-b64e-318b8b49e309.png)


After
----------------------------------------
Fixed.

Technical Details
----------------------------------------
This regressed in 7cf0b338862c282d3ffb68188825c91c982a73a6