### PR TITLE
dev/event#62 - Expose all price fields to backend form (5.39)

### DIFF
--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -1662,7 +1662,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
 
       //retrieve custom information
       $form->_values = [];
-      CRM_Event_Form_Registration::initEventFee($form, $event['id']);
+      CRM_Event_Form_Registration::initEventFee($form, $event['id'], FALSE);
       CRM_Event_Form_Registration_Register::buildAmount($form, TRUE, $form->_discountId);
       $lineItem = [];
       $invoiceSettings = Civi::settings()->get('contribution_invoice_settings');

--- a/CRM/Price/BAO/PriceSet.php
+++ b/CRM/Price/BAO/PriceSet.php
@@ -456,11 +456,11 @@ WHERE     cpf.price_set_id = %1";
     $where = "
 WHERE price_set_id = %1
 AND is_active = 1
-AND ( active_on IS NULL OR active_on <= {$currentTime} )
 ";
     $dateSelect = '';
     if ($doNotIncludeExpiredFields) {
       $dateSelect = "
+AND ( active_on IS NULL OR active_on <= {$currentTime} )
 AND ( expire_on IS NULL OR expire_on >= {$currentTime} )
 ";
     }


### PR DESCRIPTION
Overview
----------------------------------------
Expose all price fields, regardless of active/expire dates, to the backend registration form.

(Backport of @lcdservices's https://github.com/civicrm/civicrm-core/pull/20972 to 5.39)

Before
----------------------------------------
Only price fields that are in the current date range are exposed.

After
----------------------------------------
All fields are exposed.

Technical Details
----------------------------------------
See detailed explanation here: https://lab.civicrm.org/dev/event/-/issues/62