### PR TITLE
token comparison

### DIFF
--- a/tests/phpunit/CRM/Contribute/ActionMapping/ByTypeTest.php
+++ b/tests/phpunit/CRM/Contribute/ActionMapping/ByTypeTest.php
@@ -354,6 +354,11 @@ class CRM_Contribute_ActionMapping_ByTypeTest extends \Civi\ActionSchedule\Abstr
       'contribution_status_id:label',
     ];
     $processor = new CRM_Contribute_Tokens();
+    $legacyTokens = [];
+    foreach (CRM_Core_SelectValues::contributionTokens() as $token => $label) {
+      $legacyTokens[substr($token, 14, -1)] = $label;
+    }
+    $this->assertEquals($legacyTokens, $processor->tokenNames);
     foreach ($tokens as $token) {
       $this->assertEquals(CRM_Core_SelectValues::contributionTokens()['{contribution.' . $token . '}'], $processor->tokenNames[$token]);
     }

--- a/tests/phpunit/CRM/Contribute/ActionMapping/ByTypeTest.php
+++ b/tests/phpunit/CRM/Contribute/ActionMapping/ByTypeTest.php
@@ -9,6 +9,8 @@
  +--------------------------------------------------------------------+
  */
 
+use Civi\Api4\Contribution;
+
 /**
  * Class CRM_Contribute_ActionMapping_ByTypeTest
  * @group ActionSchedule
@@ -355,9 +357,19 @@ class CRM_Contribute_ActionMapping_ByTypeTest extends \Civi\ActionSchedule\Abstr
     ];
     $processor = new CRM_Contribute_Tokens();
     $legacyTokens = [];
+    $realLegacyTokens = [];
     foreach (CRM_Core_SelectValues::contributionTokens() as $token => $label) {
       $legacyTokens[substr($token, 14, -1)] = $label;
+      if (strpos($token, ':') === FALSE) {
+        $realLegacyTokens[substr($token, 14, -1)] = $label;
+      }
     }
+    $fields = (array) Contribution::getFields()->addSelect('name', 'title')->execute()->indexBy('name');
+    $allFields = [];
+    foreach ($fields as $field) {
+      $allFields[$field['name']] = $field['title'];
+    }
+    $this->assertEquals($realLegacyTokens, $allFields);
     $this->assertEquals($legacyTokens, $processor->tokenNames);
     foreach ($tokens as $token) {
       $this->assertEquals(CRM_Core_SelectValues::contributionTokens()['{contribution.' . $token . '}'], $processor->tokenNames[$token]);


### PR DESCRIPTION
This adds comparison of the 2 sets of supported tokens - includes the MOP PR but it's just a couple of lines on a test - this is open for now just to give visibility


![image](https://user-images.githubusercontent.com/336308/128432600-92940691-8b70-4912-91ce-063390e026bd.png)
