### PR TITLE
Reconcile contribution amount tokens

### DIFF
--- a/CRM/Core/EntityTokens.php
+++ b/CRM/Core/EntityTokens.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+use Civi\Token\AbstractTokenSubscriber;
+use Civi\Token\TokenRow;
+
+/**
+ * Class CRM_Core_EntityTokens
+ *
+ * Parent class for generic entity token functionality.
+ *
+ * WARNING - this class is highly likely to be temporary and
+ * to be consolidated with the TokenTrait and / or the
+ * AbstractTokenSubscriber in future. It is being used to clarify
+ * functionality but should NOT be used from outside of core tested code.
+ */
+class CRM_Core_EntityTokens extends AbstractTokenSubscriber {
+
+  /**
+   * This is required for the parent - it will be filled out.
+   *
+   * @inheritDoc
+   */
+  public function evaluateToken(TokenRow $row, $entity, $field, $prefetch = NULL) {
+  }
+
+  /**
+   * Is the given field a date field.
+   *
+   * @param string $fieldName
+   *
+   * @return bool
+   */
+  public function isDateField(string $fieldName): bool {
+    return $this->getFieldMetadata()[$fieldName]['type'] === (\CRM_Utils_Type::T_DATE + \CRM_Utils_Type::T_TIME);
+  }
+
+  /**
+   * Is the given field a date field.
+   *
+   * @param string $fieldName
+   *
+   * @return bool
+   */
+  public function isMoneyField(string $fieldName): bool {
+    return $this->getFieldMetadata()[$fieldName]['type'] === (\CRM_Utils_Type::T_MONEY);
+  }
+
+  /**
+   * Get the metadata for the available fields.
+   *
+   * @return array
+   */
+  protected function getFieldMetadata(): array {
+    if (empty($this->fieldMetadata)) {
+      $baoName = $this->getBAOName();
+
+      $fields = (array) $baoName::fields();
+      // re-index by real field name. I originally wanted to use apiv4
+      // getfields - but it returns different stuff for 'type' and
+      // does not return 'pseudoconstant' as a key so for now...
+      foreach ($fields as $details) {
+        $this->fieldMetadata[$details['name']] = $details;
+      }
+    }
+    return $this->fieldMetadata;
+  }
+
+}

--- a/Civi/Token/TokenRow.php
+++ b/Civi/Token/TokenRow.php
@@ -201,6 +201,7 @@ class TokenRow {
    * @throws \CRM_Core_Exception
    */
   public function dbToken($tokenEntity, $tokenField, $baoName, $baoField, $fieldValue) {
+    \CRM_Core_Error::deprecatedFunctionWarning('no alternative');
     if ($fieldValue === NULL || $fieldValue === '') {
       return $this->tokens($tokenEntity, $tokenField, '');
     }

--- a/tests/phpunit/CRM/Contribute/ActionMapping/ByTypeTest.php
+++ b/tests/phpunit/CRM/Contribute/ActionMapping/ByTypeTest.php
@@ -155,6 +155,7 @@ class CRM_Contribute_ActionMapping_ByTypeTest extends \Civi\ActionSchedule\Abstr
       'contact_id' => $this->contacts['alice']['id'],
       'receive_date' => date('Ymd', strtotime($this->targetDate)),
       'total_amount' => '100',
+      'currency' => 'EUR',
       'financial_type_id' => 1,
       'non_deductible_amount' => '10',
       'fee_amount' => '5',
@@ -276,7 +277,11 @@ class CRM_Contribute_ActionMapping_ByTypeTest extends \Civi\ActionSchedule\Abstr
       financial type label = {contribution.financial_type_id:label}
       payment instrument id = {contribution.payment_instrument_id}
       payment instrument name = {contribution.payment_instrument_id:name}
-      payment instrument label = {contribution.payment_instrument_id:label}';
+      payment instrument label = {contribution.payment_instrument_id:label}
+      non_deductible_amount = {contribution.non_deductible_amount}
+      total_amount = {contribution.total_amount}
+      net_amount = {contribution.net_amount}
+      fee_amount = {contribution.fee_amount}';
 
     $this->schedule->save();
     $this->callAPISuccess('job', 'send_reminder', []);
@@ -296,6 +301,10 @@ class CRM_Contribute_ActionMapping_ByTypeTest extends \Civi\ActionSchedule\Abstr
       'payment instrument id = 4',
       'payment instrument name = Check',
       'payment instrument label = Check',
+      'non_deductible_amount = € 10.00',
+      'total_amount = € 100.00',
+      'net_amount = € 95.00',
+      'fee_amount = € 5.00',
     ];
     $this->mut->checkMailLog($expected);
 
@@ -324,6 +333,10 @@ class CRM_Contribute_ActionMapping_ByTypeTest extends \Civi\ActionSchedule\Abstr
       'payment instrument label = Check',
       'legacy source SSF',
       'source SSF',
+      'non_deductible_amount = € 10.00',
+      'total_amount = € 100.00',
+      'net_amount = € 95.00',
+      'fee_amount = € 5.00',
     ];
     foreach ($expected as $string) {
       $this->assertStringContainsString($string, $contributionDetails[$this->contacts['alice']['id']]['html']);


### PR DESCRIPTION

Overview
----------------------------------------
Reconcile contribution amount tokens

Before
----------------------------------------
non_deductible_amount identified in https://github.com/civicrm/civicrm-core/pull/21034 as being present in the legacy token provider but not the token processor / scheduled reminders

After
----------------------------------------
Rendered & tested in both

Technical Details
----------------------------------------


PR also moves the metadata functions to a parent class - this class might wind up
being a temporary class as there are 3 other contenders for where this functionality
should go - the TokenTrait, the abstractProvider or the tokenRow class. The intent
is not to make that decision yet - just to provide visual clarity about
what is generic

Note - I've figured out how to switch over to v4 api for this but will do that in a separate PR


Comments
----------------------------------------
