### PR TITLE
Fix advertised token for source

### DIFF
--- a/CRM/Core/SelectValues.php
+++ b/CRM/Core/SelectValues.php
@@ -582,7 +582,7 @@ class CRM_Core_SelectValues {
       '{contribution.cancel_reason}' => ts('Contribution Cancel Reason'),
       '{contribution.receipt_date}' => ts('Receipt Date'),
       '{contribution.thankyou_date}' => ts('Thank You Date'),
-      '{contribution.contribution_source}' => ts('Contribution Source'),
+      '{contribution.source}' => ts('Contribution Source'),
       '{contribution.amount_level}' => ts('Amount Level'),
       '{contribution.check_number}' => ts('Check Number'),
       '{contribution.campaign}' => ts('Contribution Campaign'),

--- a/tests/phpunit/CRM/Contribute/ActionMapping/ByTypeTest.php
+++ b/tests/phpunit/CRM/Contribute/ActionMapping/ByTypeTest.php
@@ -270,6 +270,7 @@ class CRM_Contribute_ActionMapping_ByTypeTest extends \Civi\ActionSchedule\Abstr
       contribution_id {contribution.contribution_id} - not valid for action schedule
       cancel date {contribution.cancel_date}
       source {contribution.source}
+      legacy source {contribution.contribution_source}
       financial type id = {contribution.financial_type_id}
       financial type name = {contribution.financial_type_id:name}
       financial type label = {contribution.financial_type_id:label}
@@ -321,6 +322,8 @@ class CRM_Contribute_ActionMapping_ByTypeTest extends \Civi\ActionSchedule\Abstr
       'payment instrument id = 4',
       'payment instrument name = Check',
       'payment instrument label = Check',
+      'legacy source SSF',
+      'source SSF',
     ];
     foreach ($expected as $string) {
       $this->assertStringContainsString($string, $contributionDetails[$this->contacts['alice']['id']]['html']);


### PR DESCRIPTION
Overview
----------------------------------------
Fix advertised token for source

Before
----------------------------------------
Advertised token is {contribution.contribution_source}
Preferred token is {contribution.source}
- only the preferred works in action schedules
- both work for send letter action

After
----------------------------------------
Preferred is advertised, tests prove functionality is not affected (scheduled reminders were already tests so tests added to the legacy token flow)

Technical Details
----------------------------------------

Comments
----------------------------------------
