### PR TITLE
Reconcile tokens misnamed or missing on legacy class

### DIFF
--- a/CRM/Core/EntityTokens.php
+++ b/CRM/Core/EntityTokens.php
@@ -62,6 +62,15 @@ class CRM_Core_EntityTokens extends AbstractTokenSubscriber {
   }
 
   /**
+   * Get all the tokens supported by this processor.
+   *
+   * @return array|string[]
+   */
+  public function getAllTokens(): array {
+    return array_merge($this->getBasicTokens(), $this->getPseudoTokens(), CRM_Utils_Token::getCustomFieldTokens('Contribution'));
+  }
+
+  /**
    * Is the given field a date field.
    *
    * @param string $fieldName

--- a/CRM/Core/SelectValues.php
+++ b/CRM/Core/SelectValues.php
@@ -565,27 +565,16 @@ class CRM_Core_SelectValues {
   public static function contributionTokens(): array {
     $tokens = [];
     $processor = new CRM_Contribute_Tokens();
-    foreach (array_merge($processor->getPseudoTokens(), $processor->getBasicTokens()) as $token => $title) {
+    foreach ($processor->getAllTokens() as $token => $title) {
       $tokens['{contribution.' . $token . '}'] = $title;
     }
     return array_merge($tokens, [
-      '{contribution.id}' => ts('Contribution ID'),
-      '{contribution.total_amount}' => ts('Total Amount'),
-      '{contribution.fee_amount}' => ts('Fee Amount'),
-      '{contribution.net_amount}' => ts('Net Amount'),
-      '{contribution.non_deductible_amount}' => ts('Non-deductible Amount'),
-      '{contribution.receive_date}' => ts('Contribution Date Received'),
-      '{contribution.trxn_id}' => ts('Transaction ID'),
-      '{contribution.invoice_id}' => ts('Invoice ID'),
-      '{contribution.currency}' => ts('Currency'),
-      '{contribution.cancel_date}' => ts('Contribution Cancel Date'),
       '{contribution.cancel_reason}' => ts('Contribution Cancel Reason'),
-      '{contribution.receipt_date}' => ts('Receipt Date'),
-      '{contribution.thankyou_date}' => ts('Thank You Date'),
-      '{contribution.source}' => ts('Contribution Source'),
       '{contribution.amount_level}' => ts('Amount Level'),
       '{contribution.check_number}' => ts('Check Number'),
       '{contribution.campaign}' => ts('Contribution Campaign'),
+      // @todo - we shouldn't need to include custom fields here -
+      // remove, with test.
     ], CRM_Utils_Token::getCustomFieldTokens('Contribution', TRUE));
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Reconcile tokens misnamed or missing on legacy class

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/128451261-2daa400a-25e7-43a9-9b71-a13b2c5519d5.png)

After
----------------------------------------
Titles are resolved and only the fields in this class but not the token processor are still discrepancies.

Note a by product of this is adding tax_amount to the advertised tokens -there are tests on the other currency fields and the pattern should be the same so I don't think fixing the test setup to a with-tax config is worth doing for this

![image](https://user-images.githubusercontent.com/336308/128451749-b584d6c7-a965-4c97-b232-a6b898812705.png)

Technical Details
----------------------------------------
Screenshot of the value of `$tokens` right before the removed lines - showing they are now covered

![image](https://user-images.githubusercontent.com/336308/128451503-913574ec-dbcf-4cea-b303-a3cf4ff284d0.png)

Comments
----------------------------------------
