### PR TITLE
Enotice fix

### DIFF
--- a/templates/CRM/Mailing/Form/Search.tpl
+++ b/templates/CRM/Mailing/Form/Search.tpl
@@ -43,7 +43,7 @@
     </tr>
 
     {* language *}
-    {if $form.language}
+    {if !empty($form.language)}
       <tr>
         <td>{$form.language.label} {help id="id-language"}<br />
           {$form.language.html|crmAddClass:big}


### PR DESCRIPTION
Overview
----------------------------------------
Enotice fix

Before
----------------------------------------
Now you see it

After
----------------------------------------
Now you don't

Technical Details
----------------------------------------
`$language` is conditionally assigned to the form

![image](https://user-images.githubusercontent.com/336308/128466549-98daa07a-b32a-4282-a2ab-b1563cf70099.png)

Comments
----------------------------------------
