### PR TITLE
[REF] Use OO when determining what to suggest for settings.php prefixes for drupal/backdrop views, instead of scattered "if cms =="

### DIFF
--- a/CRM/Admin/Form/Setting/UF.php
+++ b/CRM/Admin/Form/Setting/UF.php
@@ -67,8 +67,8 @@ class CRM_Admin_Form_Setting_UF extends CRM_Admin_Form_Setting {
         $config->dsn != $config->userFrameworkDSN || !empty($drupal_prefix)
       )
     ) {
-      $dsn = CRM_Utils_SQL::autoSwitchDSN($config->dsn);
-      $dsnArray = DB::parseDSN($dsn);
+
+      $dsnArray = DB::parseDSN(CRM_Utils_SQL::autoSwitchDSN($config->dsn));
       $tableNames = CRM_Core_DAO::getTableNames();
       asort($tableNames);
       $tablePrefixes = '$databases[\'default\'][\'default\'][\'prefix\']= [';
@@ -77,13 +77,7 @@ class CRM_Admin_Form_Setting_UF extends CRM_Admin_Form_Setting {
       }
       // add default prefix: the drupal database prefix
       $tablePrefixes .= "\n  'default' => '$drupal_prefix',";
-      $prefix = "";
-      if ($config->dsn != $config->userFrameworkDSN) {
-        $prefix = "`{$dsnArray['database']}`.";
-        if ($config->userFramework === 'Backdrop') {
-          $prefix = "{$dsnArray['database']}.";
-        }
-      }
+      $prefix = $config->userSystem->getCRMDatabasePrefix();
       foreach ($tableNames as $tableName) {
         $tablePrefixes .= "\n  '" . str_pad($tableName . "'", 41) . " => '{$prefix}',";
       }

--- a/CRM/Utils/System/Backdrop.php
+++ b/CRM/Utils/System/Backdrop.php
@@ -1056,4 +1056,16 @@ AND    u.status = 1
     return ['ufAccessURL' => url('admin/config/people/permissions')];
   }
 
+  /**
+   * Get the CRM database as a 'prefix'.
+   *
+   * This returns a string that can be prepended to a query to include a CRM table.
+   *
+   * However, this string should contain backticks, or not, in accordance with the
+   * CMS's drupal views expectations, if any.
+   */
+  public function getCRMDatabasePrefix(): string {
+    return str_replace(parent::getCRMDatabasePrefix(), '`', '');
+  }
+
 }

--- a/CRM/Utils/System/Base.php
+++ b/CRM/Utils/System/Base.php
@@ -1052,6 +1052,23 @@ abstract class CRM_Utils_System_Base {
   }
 
   /**
+   * Get the CRM database as a 'prefix'.
+   *
+   * This returns a string that can be prepended to a query to include a CRM table.
+   *
+   * However, this string should contain backticks, or not, in accordance with the
+   * CMS's drupal views expectations, if any.
+   */
+  public function getCRMDatabasePrefix(): string {
+    $crmDatabase = DB::parseDSN(CRM_Core_Config::singleton()->dsn)['database'];
+    $cmsDatabase = DB::parseDSN(CRM_Core_Config::singleton()->userFrameworkDSN)['database'];
+    if ($crmDatabase === $cmsDatabase) {
+      return '';
+    }
+    return "`$crmDatabase`.";
+  }
+
+  /**
    * Invalidates the cache of dynamic routes and forces a rebuild.
    */
   public function invalidateRouteCache() {


### PR DESCRIPTION

Overview
----------------------------------------
I took a look at https://github.com/civicrm/civicrm-core/pull/20682 and it seemed clear that
in it's current state it would fix one CMS (d9) & break another (d7). This is
an alternate that will hopefully be non-breaky


Before
----------------------------------------
See #20682 

After
----------------------------------------
fixed - hopefully without breaking anything else

Technical Details
----------------------------------------
The discussion by @demeritcowboy @homotechsual @demeritcowboy @seamuslee001 seems to indicate this would be a be a safer approach

Comments
----------------------------------------
ping @pradpnayak 