### PR TITLE
SearchKit - Fix permission to access task list

### DIFF
--- a/ext/search_kit/Civi/Api4/SearchDisplay.php
+++ b/ext/search_kit/Civi/Api4/SearchDisplay.php
@@ -32,6 +32,8 @@ class SearchDisplay extends Generic\DAOEntity {
   public static function permissions() {
     $permissions = parent::permissions();
     $permissions['default'] = ['administer CiviCRM data'];
+    $permissions['getSearchTasks'] = ['access CiviCRM'];
+    // Permission for run action is checked internally
     $permissions['run'] = [];
     return $permissions;
   }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a regression preventing access to the tasks menu in search displays for non-admin users.

Before
----------------------------------------
For non-admin users, the task menu just spins:

![image](https://user-images.githubusercontent.com/2874912/128532009-8dae5ea0-54ed-49c0-b4ea-6096be49b004.png)

After
----------------------------------------
Task menu shows for all users with "access CiviCRM"

Technical Details
----------------------------------------
This regressed in 06ea32c, as a new api action was added but permissions were not declared.