### PR TITLE
[Ref] cleanup alterActionSchedule

### DIFF
--- a/CRM/Contribute/Tokens.php
+++ b/CRM/Contribute/Tokens.php
@@ -125,7 +125,7 @@ class CRM_Contribute_Tokens extends CRM_Core_EntityTokens {
    */
   public function checkActive(TokenProcessor $processor) {
     return !empty($processor->context['actionMapping'])
-      && $processor->context['actionMapping']->getEntity() === 'civicrm_contribution';
+      && $processor->context['actionMapping']->getEntity() === $this->getExtendableTableName();
   }
 
   /**
@@ -134,17 +134,11 @@ class CRM_Contribute_Tokens extends CRM_Core_EntityTokens {
    * @param \Civi\ActionSchedule\Event\MailingQueryEvent $e
    */
   public function alterActionScheduleQuery(MailingQueryEvent $e): void {
-    if ($e->mapping->getEntity() !== 'civicrm_contribution') {
+    if ($e->mapping->getEntity() !== $this->getExtendableTableName()) {
       return;
     }
-
-    $fields = $this->getFieldMetadata();
-    foreach (array_keys($this->getBasicTokens()) as $token) {
-      $e->query->select('e.' . $fields[$token]['name'] . ' AS ' . $this->getEntityAlias() . $token);
-    }
-    foreach (array_keys($this->getPseudoTokens()) as $token) {
-      $split = explode(':', $token);
-      $e->query->select('e.' . $fields[$split[0]]['name'] . ' AS ' . $this->getEntityAlias() . $split[0]);
+    foreach ($this->getReturnFields() as $token) {
+      $e->query->select('e.' . $token . ' AS ' . $this->getEntityAlias() . $token);
     }
   }
 

--- a/CRM/Core/EntityTokens.php
+++ b/CRM/Core/EntityTokens.php
@@ -55,10 +55,30 @@ class CRM_Core_EntityTokens extends AbstractTokenSubscriber {
   }
 
   /**
+   * Get the name of the table this token class can extend.
+   *
+   * The default is based on the entity but some token classes,
+   * specifically the event class, latch on to other tables - ie
+   * the participant table.
+   */
+  public function getExtendableTableName(): string {
+    return CRM_Core_DAO_AllCoreTables::getTableForEntityName($this->getApiEntityName());
+  }
+
+  /**
    * Get the relevant bao name.
    */
   public function getBAOName(): string {
     return CRM_Core_DAO_AllCoreTables::getFullName($this->getApiEntityName());
+  }
+
+  /**
+   * Get an array of fields to be requested.
+   *
+   * @return string[]
+   */
+  public function getReturnFields(): array {
+    return array_keys($this->getBasicTokens());
   }
 
   /**


### PR DESCRIPTION

Overview
----------------------------------------
[Ref] cleanup alterActionSchedule

Before
----------------------------------------
More code

After
----------------------------------------
Less ... but since I pre-added really solid testing on this function  we can be sure that a green light means it wasn't missed

Technical Details
----------------------------------------
We can simplify this function now as basicFields is keyed by the real field name and
all pseudofields are already in basicFields.

tests in `testTokenRendering` cover both pseudo & non pseudo fields

Comments
----------------------------------------
