### PR TITLE
 dev/core#2747 REF] Move all the generic functions to the parent

### DIFF
--- a/CRM/Contribute/Tokens.php
+++ b/CRM/Contribute/Tokens.php
@@ -147,23 +147,21 @@ class CRM_Contribute_Tokens extends CRM_Core_EntityTokens {
    * @throws \CRM_Core_Exception
    */
   public function evaluateToken(TokenRow $row, $entity, $field, $prefetch = NULL) {
-    $actionSearchResult = $row->context['actionSearchResult'];
-    $aliasedField = $this->getEntityAlias() . $field;
-    $fieldValue = $actionSearchResult->{$aliasedField} ?? NULL;
+    $fieldValue = $this->getFieldValue($row, $field);
 
     if ($this->isPseudoField($field)) {
       $split = explode(':', $field);
-      return $row->tokens($entity, $field, $this->getPseudoValue($split[0], $split[1], $actionSearchResult->{"contrib_$split[0]"} ?? NULL));
+      return $row->tokens($entity, $field, $this->getPseudoValue($split[0], $split[1], $this->getFieldValue($row, $split[0])));
     }
     if ($this->isMoneyField($field)) {
       return $row->format('text/plain')->tokens($entity, $field,
-        \CRM_Utils_Money::format($fieldValue, $actionSearchResult->contrib_currency));
+        \CRM_Utils_Money::format($fieldValue, $this->getFieldValue($row, 'currency')));
     }
     if ($this->isDateField($field)) {
       return $row->format('text/plain')->tokens($entity, $field, \CRM_Utils_Date::customFormat($fieldValue));
     }
     if ($this->isCustomField($field)) {
-      $row->customToken($entity, \CRM_Core_BAO_CustomField::getKeyID($field), $actionSearchResult->entity_id);
+      $row->customToken($entity, \CRM_Core_BAO_CustomField::getKeyID($field), $this->getFieldValue($row, 'id'));
     }
     else {
       $row->format('text/plain')->tokens($entity, $field, (string) $fieldValue);

--- a/CRM/Contribute/Tokens.php
+++ b/CRM/Contribute/Tokens.php
@@ -10,10 +10,6 @@
  +--------------------------------------------------------------------+
  */
 
-use Civi\ActionSchedule\Event\MailingQueryEvent;
-use Civi\Token\TokenProcessor;
-use Civi\Token\TokenRow;
-
 /**
  * Class CRM_Contribute_Tokens
  *
@@ -49,13 +45,6 @@ class CRM_Contribute_Tokens extends CRM_Core_EntityTokens {
   protected function getApiEntityName(): string {
     return 'Contribution';
   }
-
-  /**
-   * Metadata about the entity fields.
-   *
-   * @var array
-   */
-  protected $fieldMetadata = [];
 
   /**
    * Get a list of tokens for the entity for which access is permitted to.
@@ -106,66 +95,6 @@ class CRM_Contribute_Tokens extends CRM_Core_EntityTokens {
       $return[$fieldName] = $this->getFieldMetadata()[$fieldName]['title'];
     }
     return $return;
-  }
-
-  /**
-   * Class constructor.
-   */
-  public function __construct() {
-    $tokens = $this->getAllTokens();
-    parent::__construct('contribution', $tokens);
-  }
-
-  /**
-   * Check if the token processor is active.
-   *
-   * @param \Civi\Token\TokenProcessor $processor
-   *
-   * @return bool
-   */
-  public function checkActive(TokenProcessor $processor) {
-    return !empty($processor->context['actionMapping'])
-      && $processor->context['actionMapping']->getEntity() === $this->getExtendableTableName();
-  }
-
-  /**
-   * Alter action schedule query.
-   *
-   * @param \Civi\ActionSchedule\Event\MailingQueryEvent $e
-   */
-  public function alterActionScheduleQuery(MailingQueryEvent $e): void {
-    if ($e->mapping->getEntity() !== $this->getExtendableTableName()) {
-      return;
-    }
-    foreach ($this->getReturnFields() as $token) {
-      $e->query->select('e.' . $token . ' AS ' . $this->getEntityAlias() . $token);
-    }
-  }
-
-  /**
-   * @inheritDoc
-   * @throws \CRM_Core_Exception
-   */
-  public function evaluateToken(TokenRow $row, $entity, $field, $prefetch = NULL) {
-    $fieldValue = $this->getFieldValue($row, $field);
-
-    if ($this->isPseudoField($field)) {
-      $split = explode(':', $field);
-      return $row->tokens($entity, $field, $this->getPseudoValue($split[0], $split[1], $this->getFieldValue($row, $split[0])));
-    }
-    if ($this->isMoneyField($field)) {
-      return $row->format('text/plain')->tokens($entity, $field,
-        \CRM_Utils_Money::format($fieldValue, $this->getFieldValue($row, 'currency')));
-    }
-    if ($this->isDateField($field)) {
-      return $row->format('text/plain')->tokens($entity, $field, \CRM_Utils_Date::customFormat($fieldValue));
-    }
-    if ($this->isCustomField($field)) {
-      $row->customToken($entity, \CRM_Core_BAO_CustomField::getKeyID($field), $this->getFieldValue($row, 'id'));
-    }
-    else {
-      $row->format('text/plain')->tokens($entity, $field, (string) $fieldValue);
-    }
   }
 
 }

--- a/CRM/Core/EntityTokens.php
+++ b/CRM/Core/EntityTokens.php
@@ -212,4 +212,15 @@ class CRM_Core_EntityTokens extends AbstractTokenSubscriber {
     return (string) $fieldValue;
   }
 
+  /**
+   * @param \Civi\Token\TokenRow $row
+   * @param string $field
+   * @return string|int
+   */
+  protected function getFieldValue(TokenRow $row, string $field) {
+    $actionSearchResult = $row->context['actionSearchResult'];
+    $aliasedField = $this->getEntityAlias() . $field;
+    return $actionSearchResult->{$aliasedField} ?? NULL;
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
 [REF] Move all the generic functions to the parent

Before
----------------------------------------
Both entity specific & generic functions on the specific class

After
----------------------------------------
All generic functions moved to parent

Technical Details
----------------------------------------
This is for clarity, note that I need agreement on
https://lab.civicrm.org/dev/core/-/issues/2745
to decide whether to keep 'getExposedFields' or not - hence
that is not moved at this stage

Comments
----------------------------------------
