### PR TITLE
dev/core#2747 Add listening & test for contribution tokens processor

### DIFF
--- a/CRM/Contribute/Tokens.php
+++ b/CRM/Contribute/Tokens.php
@@ -23,13 +23,6 @@ class CRM_Contribute_Tokens extends CRM_Core_EntityTokens {
   /**
    * @return string
    */
-  protected function getEntityName(): string {
-    return 'contribution';
-  }
-
-  /**
-   * @return string
-   */
   protected function getEntityAlias(): string {
     return 'contrib_';
   }

--- a/CRM/Core/EntityTokens.php
+++ b/CRM/Core/EntityTokens.php
@@ -10,10 +10,12 @@
  +--------------------------------------------------------------------+
  */
 
+use Civi\Api4\Generic\Result;
 use Civi\Token\AbstractTokenSubscriber;
 use Civi\Token\TokenRow;
 use Civi\ActionSchedule\Event\MailingQueryEvent;
 use Civi\Token\TokenProcessor;
+use Civi\Token\Event\TokenValueEvent;
 
 /**
  * Class CRM_Core_EntityTokens
@@ -32,25 +34,62 @@ class CRM_Core_EntityTokens extends AbstractTokenSubscriber {
    * @throws \CRM_Core_Exception
    */
   public function evaluateToken(TokenRow $row, $entity, $field, $prefetch = NULL) {
-    $fieldValue = $this->getFieldValue($row, $field);
+    $prefetchedValues = $this->getPrefetchedValuesForRow((array) $prefetch, $row);
+    $fieldValue = $this->getFieldValue($row, $field, $prefetchedValues);
 
     if ($this->isPseudoField($field)) {
       $split = explode(':', $field);
-      return $row->tokens($entity, $field, $this->getPseudoValue($split[0], $split[1], $this->getFieldValue($row, $split[0])));
+      return $row->tokens($entity, $field, $this->getPseudoValue($split[0], $split[1], $this->getFieldValue($row, $split[0], $prefetchedValues)));
     }
     if ($this->isMoneyField($field)) {
       return $row->format('text/plain')->tokens($entity, $field,
-        \CRM_Utils_Money::format($fieldValue, $this->getFieldValue($row, 'currency')));
+        \CRM_Utils_Money::format($fieldValue, $this->getFieldValue($row, 'currency', $prefetchedValues)));
     }
     if ($this->isDateField($field)) {
       return $row->format('text/plain')->tokens($entity, $field, \CRM_Utils_Date::customFormat($fieldValue));
     }
     if ($this->isCustomField($field)) {
-      $row->customToken($entity, \CRM_Core_BAO_CustomField::getKeyID($field), $this->getFieldValue($row, 'id'));
+      $row->customToken($entity, \CRM_Core_BAO_CustomField::getKeyID($field), $this->getFieldValue($row, 'id', $prefetchedValues));
     }
     else {
       $row->format('text/plain')->tokens($entity, $field, (string) $fieldValue);
     }
+  }
+
+  /**
+   * @param \Civi\Token\Event\TokenValueEvent $e
+   *
+   * @return null|array
+   *
+   * @throws \API_Exception
+   * @throws \Civi\API\Exception\UnauthorizedException
+   */
+  public function prefetch(TokenValueEvent $e): ?array {
+    // Find all the entity IDs
+    $entityIDs = $e->getTokenProcessor()->getContextValues($this->getEntityIDField());
+
+    if (!empty($entityIDs)) {
+      return [$this->getEntityName() => $this->getEntities($entityIDs)];
+    }
+    return NULL;
+  }
+
+  /**
+   * Get the
+   *
+   * @param array $ids
+   *
+   * @return \Civi\Api4\Generic\Result
+   * @throws \API_Exception
+   */
+  public function getEntities(array $ids): Result {
+    return civicrm_api4($this->getApiEntityName(), 'get', [
+      'checkPermissions' => FALSE,
+      // Note custom fields are not yet added - I need to
+      // re-do the unit tests to support custom fields first.
+      'select' => $this->getReturnFields(),
+      'where' => [['id', 'IN', $ids]],
+    ], 'id');
   }
 
   /**
@@ -67,6 +106,23 @@ class CRM_Core_EntityTokens extends AbstractTokenSubscriber {
    */
   protected function getApiEntityName(): string {
     return '';
+  }
+
+  /**
+   * @return string
+   */
+  protected function getEntityName(): string {
+    return CRM_Core_DAO_AllCoreTables::convertEntityNameToLower($this->getApiEntityName());
+  }
+
+  /**
+   * Get the name of the field that will provide the id for this entity.
+   *
+   * For example 'contributionId'
+   * @return string
+   */
+  protected function getEntityIDField(): string {
+    return $this->getEntityName() . 'Id';
   }
 
   /**
@@ -242,12 +298,14 @@ class CRM_Core_EntityTokens extends AbstractTokenSubscriber {
   /**
    * @param \Civi\Token\TokenRow $row
    * @param string $field
-   * @return string|int
+   * @param array $prefetchedValues
+   *
+   * @return string|int|null
    */
-  protected function getFieldValue(TokenRow $row, string $field) {
+  protected function getFieldValue(TokenRow $row, string $field, $prefetchedValues) {
     $actionSearchResult = $row->context['actionSearchResult'];
     $aliasedField = $this->getEntityAlias() . $field;
-    return $actionSearchResult->{$aliasedField} ?? NULL;
+    return $actionSearchResult->{$aliasedField} ?? ($prefetchedValues[$field] ?? NULL);
   }
 
   /**
@@ -265,9 +323,10 @@ class CRM_Core_EntityTokens extends AbstractTokenSubscriber {
    *
    * @return bool
    */
-  public function checkActive(TokenProcessor $processor) {
-    return !empty($processor->context['actionMapping'])
-      && $processor->context['actionMapping']->getEntity() === $this->getExtendableTableName();
+  public function checkActive(TokenProcessor $processor): bool {
+    return (!empty($processor->context['actionMapping'])
+        && $processor->context['actionMapping']->getEntity() === $this->getExtendableTableName())
+      || $processor->getContextValues($this->getEntityIDField());
   }
 
   /**
@@ -282,6 +341,28 @@ class CRM_Core_EntityTokens extends AbstractTokenSubscriber {
     foreach ($this->getReturnFields() as $token) {
       $e->query->select('e.' . $token . ' AS ' . $this->getEntityAlias() . $token);
     }
+  }
+
+  /**
+   * Get any values pre-fetched for the row.
+   *
+   * @param array $prefetch
+   * @param \Civi\Token\TokenRow $row
+   *
+   * @return array
+   */
+  protected function getPrefetchedValuesForRow(array $prefetch, TokenRow $row): array {
+    $id = $this->getEntityIDFromRow($row);
+    return $prefetch[$this->getEntityName()][$id] ?? [];
+  }
+
+  /**
+   * @param \Civi\Token\TokenRow $row
+   *
+   * @return int|null
+   */
+  protected function getEntityIDFromRow(TokenRow $row): ?int {
+    return $row->context[$this->getEntityIDField()];
   }
 
 }

--- a/tests/phpunit/CRM/Contribute/ActionMapping/ByTypeTest.php
+++ b/tests/phpunit/CRM/Contribute/ActionMapping/ByTypeTest.php
@@ -9,6 +9,8 @@
  +--------------------------------------------------------------------+
  */
 
+use Civi\Token\TokenProcessor;
+
 /**
  * Class CRM_Contribute_ActionMapping_ByTypeTest
  * @group ActionSchedule
@@ -307,6 +309,21 @@ class CRM_Contribute_ActionMapping_ByTypeTest extends \Civi\ActionSchedule\Abstr
       'fee_amount = € 5.00',
     ];
     $this->mut->checkMailLog($expected);
+
+    $tokenProcessor = new TokenProcessor(\Civi::dispatcher(), [
+      'controller' => get_class(),
+      'smarty' => FALSE,
+      'contributionId' => $this->ids['Contribution']['alice'],
+      'contactId' => $this->contacts['alice']['id'],
+    ]);
+    $tokenProcessor->addRow([]);
+    $tokenProcessor->addMessage('html', $this->schedule->body_text, 'text/plain');
+    $tokenProcessor->evaluate();
+    foreach ($tokenProcessor->getRows() as $row) {
+      foreach ($expected as $value) {
+        $this->assertStringContainsString($value, $row->render('html'));
+      }
+    }
 
     $messageToken = CRM_Utils_Token::getTokens($this->schedule->body_text);
 


### PR DESCRIPTION
Overview
----------------------------------------
This covers step 9 in https://lab.civicrm.org/dev/core/-/issues/2747 - add listening & tests to the listening for the contribution token processor 

Only https://github.com/civicrm/civicrm-core/pull/21058/commits/0e3ad0d0ac5bc8fb7b06228f11ac056bfca09256 truly belongs to this PR - the other 2 are preliminary cleanup & can be rebased out if the separate PRs are merged

Before
----------------------------------------
Contribution token processor only accessible via scheduled reminders

After
----------------------------------------
Accessible and tested via

```
    $tokenProcessor = new TokenProcessor(\Civi::dispatcher(), [
      'controller' => get_class(),
      'smarty' => FALSE,
      'contributionId' => $this->ids['Contribution']['alice'],
      'contactId' => $this->contacts['alice']['id'],
    ]);
    $tokenProcessor->addRow([

    ]);
    $tokenProcessor->addMessage('html', $this->schedule->body_text, 'text/plain');
    $tokenProcessor->evaluate();
```

Technical Details
----------------------------------------
@totten per our discussion today - this is the minimum version to get it listening & tested & pushes out of scope all the stuff in other open PRs that was confusing me & blocking me on this side of things (which in itself was fairly trivial). This incorporates 2 cleanup prs & it's probably good if I can get them merged & rebased out.

There is one big gap - custom fields when using pre-fetch - I decided to leave them out of scope because I have a problem with the unit test - namely it's in a class relying on transaction rollback for cleanup - which will break if I start creating tables within the test - I need to figure out a restructure on that. I'm comfortable I can do that before the rc is cut if we get this merged (if I don't it's still OK in that only-developer-exposed functionality is incomplete)

Comments
----------------------------------------
Steps remaining after this PR from 
https://lab.civicrm.org/dev/core/-/issues/2747

- custom fields + test per above
- determine whether the final token list is appropriate #2745
- message template access
