### PR TITLE
dev/core#2748 Remove unused token assigns

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2983,14 +2983,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
     // and this function should assign them (assigning null if not set).
     // the way the pcpParams & honor Params section works is a baby-step towards this.
     $template = CRM_Core_Smarty::singleton();
-    $template->assign('first_name', $this->_relatedObjects['contact']->first_name);
-    $template->assign('last_name', $this->_relatedObjects['contact']->last_name);
-    $template->assign('displayName', $this->_relatedObjects['contact']->display_name);
     $template->assign('billingName', $values['billingName']);
-
-    // For some unit tests contribution cannot contain paymentProcessor information
-    $billingMode = empty($this->_relatedObjects['paymentProcessor']) ? CRM_Core_Payment::BILLING_MODE_NOTIFY : $this->_relatedObjects['paymentProcessor']['billing_mode'];
-    $template->assign('contributeMode', CRM_Core_SelectValues::contributeMode()[$billingMode] ?? NULL);
 
     //assign honor information to receipt message
     $softRecord = CRM_Contribute_BAO_ContributionSoft::getSoftContribution($this->id);

--- a/CRM/Upgrade/Incremental/php/FiveFortyThree.php
+++ b/CRM/Upgrade/Incremental/php/FiveFortyThree.php
@@ -60,9 +60,19 @@ class CRM_Upgrade_Incremental_php_FiveFortyThree extends CRM_Upgrade_Incremental
    *
    * @param string $rev
    */
-  public function upgrade_5_43_alpha1($rev) {
+  public function upgrade_5_43_alpha1(string $rev): void {
     $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
     $this->addTask('Fix DB Collation if needed on the relatonship cache table', 'fixRelationshipCacheTableCollation');
+
+    $this->addTask('Replace legacy displayName smarty token in Online contribution workflow template',
+      'updateMessageToken', 'contribution_online_receipt', '$displayName', 'contact.display_name', $rev
+    );
+    $this->addTask('Replace legacy first_name smarty token in Online contribution workflow template',
+      'updateMessageToken', 'contribution_online_receipt', '$first_name', 'contact.first_name', $rev
+    );
+    $this->addTask('Replace legacy last_name smarty token in Online contribution workflow template',
+      'updateMessageToken', 'contribution_online_receipt', '$last_name', 'contact.last_name', $rev
+    );
   }
 
   public static function fixRelationshipCacheTableCollation():bool {

--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -1952,6 +1952,12 @@ class CRM_Utils_Token {
         'contribution_invoice_receipt' => [
           '$display_name' => 'contact.display_name',
         ],
+        'contribution_online_receipt' => [
+          '$contributeMode' => 'no longer available / relevant',
+          '$first_name' => 'contact.first_name',
+          '$last_name' => 'contact.last_name',
+          '$displayName' => 'contact.display_name',
+        ],
       ],
     ];
   }

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -2072,9 +2072,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
       'currency:::USD',
       'receive_date:::' . date('Ymd', strtotime($contribution['receive_date'])),
       "receipt_date:::\n",
-      'contributeMode:::notify',
       'title:::Contribution',
-      'displayName:::Mr. Anthony Anderson II',
       'contributionStatus:::Completed',
     ]);
     $mut->stop();
@@ -2112,9 +2110,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
       'currency:::EUR',
       'receive_date:::' . date('Ymd', strtotime($contribution['receive_date'])),
       "receipt_date:::\n",
-      'contributeMode:::notify',
       'title:::Contribution',
-      'displayName:::Mr. Anthony Anderson II',
       'contributionStatus:::Completed',
     ]);
     $mut->stop();
@@ -2150,7 +2146,6 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
       'is_pay_later:::1',
       'email:::anthony_anderson@civicrm.org',
       'pay_later_receipt:::This is a pay later receipt',
-      'displayName:::Mr. Anthony Anderson II',
       'contributionPageId:::' . $contributionPageID,
       'title:::Test Contribution Page',
       'amount:::100',
@@ -3185,9 +3180,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
       'currency:::USD',
       'receive_date:::' . date('Ymd', strtotime($receive_date)),
       'receipt_date:::' . date('Ymd'),
-      'contributeMode:::notify',
       'title:::Contribution',
-      'displayName:::Mr. Anthony Anderson II',
       'trxn_id:::kazam',
       'contactID:::' . $this->_params['contact_id'],
       'contributionID:::' . $contribution['id'],

--- a/tests/templates/message_templates/contribution_online_receipt_html.tpl
+++ b/tests/templates/message_templates/contribution_online_receipt_html.tpl
@@ -9,7 +9,6 @@
   receipt_text:::{$receipt_text}
   {/if}
   is_pay_later:::{$is_pay_later}
-  displayName:::{$displayName}
   financialTypeId:::{$financialTypeId}
   financialTypeName:::{$financialTypeName}
   contactID:::{$contactID}
@@ -51,9 +50,6 @@
   {/if}
   {if isset($is_recur)}
   is_recur:::{$is_recur}
-  {/if}
-  {if isset($contributeMode)}
-  contributeMode:::{$contributeMode}
   {/if}
   {if isset($trxn_id)}
   trxn_id:::{$trxn_id}


### PR DESCRIPTION
Overview
----------------------------------------
Per https://lab.civicrm.org/dev/core/-/issues/2748 - this removes some no-longer-used token assigns & adds an upgrade message in case people have templates still referring to them

Before
----------------------------------------
We assign $first_name, $last_name, $displayName $contributeMode to the template but they have not been in the shipped templates for a long time - there is a preferred alternative (token) for the first 3 

After
----------------------------------------
Assigns removed, system checks will warn

Technical Details
----------------------------------------
These variables are coming from the dreaded `loadRelatedObjects` function  and in turn from `loadRelatedEntitiesByID` - which we hope to decommission

Comments
----------------------------------------
