### PR TITLE
dev/core#2730 - Replace fopen call in CRM_Utils_File::isIncludable with one that doesn't need error-supression to avoid problems in php8

### DIFF
--- a/CRM/Utils/File.php
+++ b/CRM/Utils/File.php
@@ -415,14 +415,11 @@ class CRM_Utils_File {
    *   whether the file can be include()d or require()d
    */
   public static function isIncludable($name) {
-    $x = @fopen($name, 'r', TRUE);
-    if ($x) {
-      fclose($x);
-      return TRUE;
-    }
-    else {
+    $full_filepath = stream_resolve_include_path($name);
+    if ($full_filepath === FALSE) {
       return FALSE;
     }
+    return is_readable($full_filepath);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/2730

Before
----------------------------------------
One (extreme) way to see the before situation is https://github.com/civicrm/civicrm-core/pull/21064. Lots of stuff like:

`Failure in api call for UFGroup create:  fopen(api/v3/UFGroup/Getfields.php):  failed to open stream: No such file or directory'`

While this is an E_WARNING and doesn't change anything in normal usage in php 8, what does change in php 8 is when you have an error handler that takes the incoming `$errno` and acts when it has a value of E_WARNING. In php 7, errno is always set to 0 when the error_supression (`@`) operator is used. In php 8 it passes the actual value in.
(There are other changes, like it also changes the value of error_reporting(), but that doesn't apply to this specifically).

After
----------------------------------------
Quiet

Technical Details
----------------------------------------
This should be an equivalent call but at the time the function was written it's possible not all sites had a high enough php version. There's more in the lab ticket if interested.

Comments
----------------------------------------
Has test, which passed before on the current code so is at least a partial check that there's some equivalence: https://test.civicrm.org/job/CiviCRM-Core-PR/42883/
