### PR TITLE
Remove unused assignment

### DIFF
--- a/CRM/Contact/Form/Task/EmailCommon.php
+++ b/CRM/Contact/Form/Task/EmailCommon.php
@@ -76,28 +76,16 @@ class CRM_Contact_Form_Task_EmailCommon {
    *
    * @param array $fields
    *   The input form values.
-   * @param array $dontCare
-   * @param array $self
-   *   Additional values form 'this'.
    *
    * @return bool|array
    *   true if no errors, else array of errors
    */
-  public static function formRule($fields, $dontCare, $self) {
+  public static function formRule(array $fields) {
     $errors = [];
-    $template = CRM_Core_Smarty::singleton();
-
-    if (isset($fields['html_message'])) {
-      $htmlMessage = str_replace(["\n", "\r"], ' ', $fields['html_message']);
-      $htmlMessage = str_replace('"', '\"', $htmlMessage);
-      $template->assign('htmlContent', $htmlMessage);
-    }
-
     //Added for CRM-1393
     if (!empty($fields['saveTemplate']) && empty($fields['saveTemplateName'])) {
-      $errors['saveTemplateName'] = ts("Enter name to save message template");
+      $errors['saveTemplateName'] = ts('Enter name to save message template');
     }
-
     return empty($errors) ? TRUE : $errors;
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Remove unused assignment

Before
----------------------------------------
A template assignment 'htmlContent' is done in the wrong place (`formRule` function) - a bit of a search shows that this is not used in any of the email or pdf classes that access the function 
 
After
----------------------------------------
poof

Technical Details
----------------------------------------
I thought I'd finish decommissioning this old class & start to fix the pdf classes to use a trait like the email classes do - but when I looked at this function it seemed odd & on further digging I couldn't find a reason for the oddness - maybe @demeritcowboy  can?

Comments
----------------------------------------
