### PR TITLE
Move make-sure-single-set out of shared function

### DIFF
--- a/CRM/Contact/Form/Task/EmailCommon.php
+++ b/CRM/Contact/Form/Task/EmailCommon.php
@@ -31,11 +31,6 @@ class CRM_Contact_Form_Task_EmailCommon {
    * @throws \CiviCRM_API3_Exception
    */
   public static function preProcessFromAddress(&$form, $bounce = TRUE) {
-    if (!isset($form->_single)) {
-      // @todo ensure this is already set.
-      $form->_single = FALSE;
-    }
-
     $form->_emails = [];
 
     // @TODO remove these line and to it somewhere more appropriate. Currently some classes (e.g Case

--- a/CRM/Contact/Form/Task/EmailTrait.php
+++ b/CRM/Contact/Form/Task/EmailTrait.php
@@ -30,8 +30,6 @@ trait CRM_Contact_Form_Task_EmailTrait {
    */
   public $_single = FALSE;
 
-  public $_noEmails = FALSE;
-
   /**
    * All the existing templates in the system.
    *

--- a/CRM/Contact/Form/Task/PDFLetterCommon.php
+++ b/CRM/Contact/Form/Task/PDFLetterCommon.php
@@ -42,6 +42,10 @@ class CRM_Contact_Form_Task_PDFLetterCommon extends CRM_Core_Form_Task_PDFLetter
    * @param CRM_Core_Form $form
    */
   public static function preProcess(&$form) {
+    if (!isset($form->_single)) {
+      // @todo ensure this is already set.
+      $form->_single = FALSE;
+    }
     CRM_Contact_Form_Task_EmailCommon::preProcessFromAddress($form);
     $messageText = [];
     $messageSubject = [];


### PR DESCRIPTION
Overview
----------------------------------------
3 places in the code call this - in 2 _single is declared on the class as false
& hence don't need this - ergo it is only being done for the one remaining place
so it's not shared it's just a helper for that code & we should return it

Before
----------------------------------------
2/3 of the non-test places that call this set $_single (I also removed the unused var in the screenshot) so it doesn't make sense in the shared function
![image](https://user-images.githubusercontent.com/336308/128621861-f63cb894-9de7-46b6-9c55-0352d1de67bf.png)


![image](https://user-images.githubusercontent.com/336308/128621801-40885d75-6936-46ee-9bc2-772bfa596f71.png)

![image](https://user-images.githubusercontent.com/336308/128621813-d63bb901-de3f-4ee5-99c9-37ce63697249.png)


After
----------------------------------------
Out of the shared function, into the class that might need it - that class is not an OOO class or trait so it's harder to tell

Technical Details
----------------------------------------

Comments
----------------------------------------
