### PR TITLE
[Ref] Clarify what parameters are passed in

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2079,26 +2079,22 @@ LEFT JOIN  civicrm_contribution contribution ON ( componentPayment.contribution_
    *
    */
   public static function transitionComponents($params) {
+    $contributionStatus = CRM_Core_PseudoConstant::getName('CRM_Contribute_BAO_Contribution', 'contribution_status_id', $params['contribution_status_id']);
+    $previousStatus = CRM_Core_PseudoConstant::getName('CRM_Contribute_BAO_Contribution', 'contribution_status_id', $params['previous_contribution_status_id']);
     // @todo fix the one place that calls this function to use Payment.create
     // remove this.
     // get minimum required values.
-    $contactId = $params['contact_id'] ?? NULL;
-    $componentId = $params['component_id'] ?? NULL;
-    $componentName = $params['componentName'] ?? NULL;
-    $contributionId = $params['contribution_id'] ?? NULL;
-    $contributionStatusId = $params['contribution_status_id'] ?? NULL;
+    $contactId = NULL;
+    $componentId = NULL;
+    $componentName = NULL;
+    $contributionId = $params['contribution_id'];
+    $contributionStatusId = $params['contribution_status_id'];
 
     // if we already processed contribution object pass previous status id.
-    $previousContriStatusId = $params['previous_contribution_status_id'] ?? NULL;
-
-    $contributionStatuses = CRM_Contribute_PseudoConstant::contributionStatus(NULL, 'name');
+    $previousContriStatusId = $params['previous_contribution_status_id'];
 
     // we process only ( Completed, Cancelled, or Failed ) contributions.
-    if (!$contributionId ||
-      !in_array($contributionStatusId, [
-        array_search('Completed', $contributionStatuses),
-      ])
-    ) {
+    if (!$contributionId || $contributionStatus !== 'Completed') {
       return;
     }
 
@@ -2170,11 +2166,11 @@ LEFT JOIN  civicrm_contribution contribution ON ( componentPayment.contribution_
         'status_id'
       );
     }
-    if ($contributionStatusId == array_search('Completed', $contributionStatuses)) {
+    if ($contributionStatus === 'Completed') {
 
       // only pending contribution related object processed.
       if ($previousContriStatusId &&
-        !in_array($contributionStatuses[$previousContriStatusId], [
+        !in_array($previousStatus, [
           'Pending',
           'Partially paid',
         ])
@@ -2183,7 +2179,7 @@ LEFT JOIN  civicrm_contribution contribution ON ( componentPayment.contribution_
         return;
       }
       elseif (!$previousContriStatusId &&
-        !in_array($contributionStatuses[$contribution->contribution_status_id], [
+        !in_array($contributionStatus, [
           'Pending',
           'Partially paid',
         ])


### PR DESCRIPTION
Overview
----------------------------------------
[Ref] Clarify what parameters are passed in

this function is called from 2 places with 4 keys in the array always set & no others


Before
----------------------------------------
It's not clear in the function that these 3 values will always be NULL

```
$contactId = $params['contact_id'] ?? NULL;
$componentId = $params['component_id'] ?? NULL;
$componentName = $params['componentName'] ?? NULL;
```
Or that the keys will always be present for 

```
 $contributionId = $params['contribution_id'] ?? NULL;
 $contributionStatusId = $params['contribution_status_id'] ?? NULL;
 $previousContriStatusId = $params['previous_contribution_status_id'];
```
which means that any changes around the assumptions for those keys will require a reviewer to do a grep. 

After
----------------------------------------
By tightening the setting of values from these keys we make it so a reviewer of future cleanups won't need to look outside this function to check the values coming in. 

Also assigning the name to values makes the if clauses more legible - which will make it easier to point out the chunks of this code are unreachable in follow ups :-)

Technical Details
----------------------------------------
These are the 2 places that call the function and in both places exactly the same 4 keys are set

![image](https://user-images.githubusercontent.com/336308/128622558-f15ed26c-0dd3-4f4d-b6df-10ac98cbfe6b.png)

![image](https://user-images.githubusercontent.com/336308/128622617-eb5207bc-60d5-4f70-aaf7-d77afcfbc163.png)

![image](https://user-images.githubusercontent.com/336308/128622625-75084777-3412-414a-9249-3096a715e715.png)


Comments
----------------------------------------
Obviously it's a given that external code should not be calling this function - in universe I find no examples (I do find a couple of references to a function that used to exist and used to call this function & I logged an issue against the relevant extension) 

![image](https://user-images.githubusercontent.com/336308/128622688-e5725da7-7f72-435d-88ea-a5e18fa708c1.png)
