### PR TITLE
financial#121: Support modifying Soft Credit permissions via hook

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2444,7 +2444,8 @@ LEFT JOIN  civicrm_contribution contribution ON ( componentPayment.contribution_
       SELECT contribution.id
       FROM civicrm_contribution contribution INNER JOIN civicrm_contribution_soft softContribution
       ON ( contribution.id = softContribution.contribution_id )
-      WHERE contribution.is_test = 0 AND contribution.is_template != '1' AND softContribution.contact_id = {$contactId} ";
+      WHERE contribution.is_test = 0 AND contribution.is_template != '1' AND softContribution.contact_id = {$contactId}
+      $additionalWhere ";
     $query = "SELECT count( x.id ) count FROM ( ";
     $query .= $contactContributionsSQL;
 

--- a/CRM/Contribute/BAO/ContributionSoft.php
+++ b/CRM/Contribute/BAO/ContributionSoft.php
@@ -207,45 +207,33 @@ class CRM_Contribute_BAO_ContributionSoft extends CRM_Contribute_DAO_Contributio
    */
   public static function getSoftContributionTotals($contact_id, $isTest = 0) {
 
-    $whereClause = "AND cc.cancel_date IS NULL";
+    $contributionSofts = \Civi\Api4\ContributionSoft::get()
+      ->addSelect('currency', 'SUM(amount) AS SUM_amount', 'AVG(amount) AS AVG_amount', 'COUNT(id) AS COUNT_id')
+      ->setGroupBy([
+        'currency',
+      ])
+      ->addWhere('contact_id', '=', $contact_id)
+      ->addWhere('contribution_id.is_test', '=', $isTest);
 
-    $query = "
-    SELECT SUM(amount) as amount, AVG(total_amount) as average, cc.currency
-    FROM civicrm_contribution_soft  ccs
-      LEFT JOIN civicrm_contribution cc ON ccs.contribution_id = cc.id
-    WHERE cc.is_test = %2 AND ccs.contact_id = %1 {$whereClause}
-    GROUP BY currency";
-
-    $params = [
-      1 => [$contact_id, 'Integer'],
-      2 => [$isTest, 'Integer'],
-    ];
-
-    $cs = CRM_Core_DAO::executeQuery($query, $params);
+    $contributionSoftsNoCancel = $contributionSofts->addWhere('contribution_id.cancel_date', 'IS NULL')->execute();
+    $contributionSoftsYesCancel = $contributionSofts->addWhere('contribution_id.cancel_date', 'IS NOT NULL')->execute();
 
     $count = $countCancelled = 0;
     $amount = $average = $cancelAmount = [];
 
-    while ($cs->fetch()) {
-      if ($cs->amount > 0) {
-        $count++;
-        $amount[] = CRM_Utils_Money::format($cs->amount, $cs->currency);
-        $average[] = CRM_Utils_Money::format($cs->average, $cs->currency);
-      }
+    foreach ($contributionSoftsNoCancel as $csByCurrency) {
+      $count += $csByCurrency['COUNT_id'];
+      $amount[] = CRM_Utils_Money::format($csByCurrency['SUM_amount'], $csByCurrency['currency']);
+      $average[] = CRM_Utils_Money::format($csByCurrency['AVG_amount'], $csByCurrency['currency']);
     }
 
     //to get cancel amount
-    $cancelAmountWhereClause = "AND cc.cancel_date IS NOT NULL";
-    $query = str_replace($whereClause, $cancelAmountWhereClause, $query);
-    $cancelAmountSQL = CRM_Core_DAO::executeQuery($query, $params);
-    while ($cancelAmountSQL->fetch()) {
-      if ($cancelAmountSQL->amount > 0) {
-        $countCancelled++;
-        $cancelAmount[] = CRM_Utils_Money::format($cancelAmountSQL->amount, $cancelAmountSQL->currency);
-      }
+    foreach ($contributionSoftsYesCancel as $csByCurrency) {
+      $countCancelled += $csByCurrency['COUNT_id'];
+      $amount[] = CRM_Utils_Money::format($csByCurrency['SUM_amount'], $csByCurrency['currency']);
     }
 
-    if ($count > 0 || $countCancelled > 0) {
+    if ($contributionSoftsNoCancel->rowCount || $contributionSoftsYesCancel->rowCount) {
       return [
         $count,
         $countCancelled,
@@ -410,6 +398,15 @@ class CRM_Contribute_BAO_ContributionSoft extends CRM_Contribute_DAO_Contributio
    * @return array
    */
   public static function getSoftContributionList($contact_id, $filter = NULL, $isTest = 0, &$dTParams = NULL) {
+    // This is necessary for dataTables sorting.
+    $dataTableMapping = [
+      'sct_label' => 'soft_credit_type_id:label',
+      'contributor_name' => 'contact.sort_name',
+      'financial_type' => 'contribution_id.financial_type_id:label',
+      'contribution_status' => 'contribution_id.contribution_status_id:label',
+      'receive_date' => 'contribution.receive_date',
+      'pcp_title' => 'pcp_id.title',
+    ];
     $config = CRM_Core_Config::singleton();
     $links = [
       CRM_Core_Action::VIEW => [
@@ -419,91 +416,57 @@ class CRM_Contribute_BAO_ContributionSoft extends CRM_Contribute_DAO_Contributio
         'title' => ts('View related contribution'),
       ],
     ];
-    $orderBy = 'cc.receive_date DESC';
-    if (!empty($dTParams['sort'])) {
-      $orderBy = $dTParams['sort'];
-    }
-    $limit = '';
+
+    $contributionSofts = \Civi\Api4\ContributionSoft::get()
+      ->addSelect('*', 'contribution.receive_date', 'contact.id', 'contact.display_name', 'soft_credit_type_id:label', 'contribution_id.contribution_status_id:label', 'contribution_id.financial_type_id:label', 'pcp_id.title')
+      ->addJoin('Contact AS contact', 'LEFT', ['contact.id', '=', 'contribution.contact_id'])
+      ->addWhere('contact_id', '=', $contact_id)
+      ->addWhere('contribution_id.is_test', '=', $isTest);
+
     if (!empty($dTParams['rowCount']) && $dTParams['rowCount'] > 0) {
-      $limit = " LIMIT {$dTParams['offset']}, {$dTParams['rowCount']} ";
-    }
-    $softOgId = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_OptionGroup', 'soft_credit_type', 'id', 'name');
-    $statusOgId = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_OptionGroup', 'contribution_status', 'id', 'name');
-
-    $query = '
-    SELECT SQL_CALC_FOUND_ROWS ccs.id, ccs.amount as amount,
-           ccs.contribution_id,
-           ccs.pcp_id,
-           ccs.pcp_display_in_roll,
-           ccs.pcp_roll_nickname,
-           ccs.pcp_personal_note,
-           ccs.soft_credit_type_id,
-           sov.label as sct_label,
-           cc.receive_date,
-           cc.contact_id as contributor_id,
-           cc.contribution_status_id as contribution_status_id,
-           cov.label as contribution_status,
-           cp.title as pcp_title,
-           cc.currency,
-           contact.display_name as contributor_name,
-           cct.name as financial_type
-    FROM civicrm_contribution_soft ccs
-      LEFT JOIN civicrm_contribution cc
-            ON ccs.contribution_id = cc.id
-      LEFT JOIN civicrm_pcp cp
-            ON ccs.pcp_id = cp.id
-      LEFT JOIN civicrm_contact contact ON
-      ccs.contribution_id = cc.id AND cc.contact_id = contact.id
-      LEFT JOIN civicrm_financial_type cct ON cc.financial_type_id = cct.id
-      LEFT JOIN civicrm_option_value sov ON sov.option_group_id = %3 AND ccs.soft_credit_type_id = sov.value
-      LEFT JOIN civicrm_option_value cov ON cov.option_group_id = %4 AND cc.contribution_status_id = cov.value
-    ';
-
-    $where = "
-      WHERE cc.is_test = %2 AND ccs.contact_id = %1";
-    if ($filter) {
-      $where .= $filter;
+      $contributionSofts
+        ->setLimit($dTParams['rowCount'])
+        ->setOffset($dTParams['offset'] ?? 0);
     }
 
-    $query .= "{$where} ORDER BY {$orderBy} {$limit}";
+    if (!empty($dTParams['sort'])) {
+      [$sortField, $direction] = explode(' ', $dTParams['sort']);
+      $contributionSofts->addOrderBy($dataTableMapping[$sortField] ?: $sortField, strtoupper($direction));
+    }
+    else {
+      $contributionSofts->addOrderBy('contribution_id.receive_date', 'DESC');
+    }
+    $contributionSofts = $contributionSofts->execute();
 
-    $params = [
-      1 => [$contact_id, 'Integer'],
-      2 => [$isTest, 'Integer'],
-      3 => [$softOgId, 'Integer'],
-      4 => [$statusOgId, 'Integer'],
-    ];
-    $cs = CRM_Core_DAO::executeQuery($query, $params);
-
-    $dTParams['total'] = CRM_Core_DAO::singleValueQuery('SELECT FOUND_ROWS()');
+    $dTParams['total'] = $contributionSofts->rowCount;
     $result = [];
-    while ($cs->fetch()) {
-      $result[$cs->id]['amount'] = CRM_Utils_Money::format($cs->amount, $cs->currency);
-      $result[$cs->id]['currency'] = $cs->currency;
-      $result[$cs->id]['contributor_id'] = $cs->contributor_id;
-      $result[$cs->id]['contribution_id'] = $cs->contribution_id;
-      $result[$cs->id]['contributor_name'] = CRM_Utils_System::href(
-        $cs->contributor_name,
+    foreach ($contributionSofts as $cs) {
+      $result[$cs['id']]['amount'] = CRM_Utils_Money::format($cs['amount'], $cs['currency']);
+      $result[$cs['id']]['currency'] = $cs['currency'];
+      $result[$cs['id']]['contributor_id'] = $cs['contribution_id.contact_id'];
+      $result[$cs['id']]['contribution_id'] = $cs['contribution_id'];
+      $result[$cs['id']]['contributor_name'] = CRM_Utils_System::href(
+        $cs['contact.display_name'],
         'civicrm/contact/view',
-        "reset=1&cid={$cs->contributor_id}"
+        "reset=1&cid={$cs['contact.id']}"
       );
-      $result[$cs->id]['financial_type'] = $cs->financial_type;
-      $result[$cs->id]['receive_date'] = CRM_Utils_Date::customFormat($cs->receive_date, $config->dateformatDatetime);
-      $result[$cs->id]['pcp_id'] = $cs->pcp_id;
-      $result[$cs->id]['pcp_title'] = ($cs->pcp_title) ? $cs->pcp_title : 'n/a';
-      $result[$cs->id]['pcp_display_in_roll'] = $cs->pcp_display_in_roll;
-      $result[$cs->id]['pcp_roll_nickname'] = $cs->pcp_roll_nickname;
-      $result[$cs->id]['pcp_personal_note'] = $cs->pcp_personal_note;
-      $result[$cs->id]['contribution_status'] = $cs->contribution_status;
-      $result[$cs->id]['sct_label'] = $cs->sct_label;
+      $result[$cs['id']]['financial_type'] = $cs['contribution_id.financial_type_id:label'];
+      $result[$cs['id']]['receive_date'] = CRM_Utils_Date::customFormat($cs['contribution.receive_date'], $config->dateformatDatetime);
+      $result[$cs['id']]['pcp_id'] = $cs['pcp_id'];
+      $result[$cs['id']]['pcp_title'] = ($cs['pcp_id.title']) ?: 'n/a';
+      $result[$cs['id']]['pcp_display_in_roll'] = $cs['pcp_display_in_roll'];
+      $result[$cs['id']]['pcp_roll_nickname'] = $cs['pcp_roll_nickname'];
+      $result[$cs['id']]['pcp_personal_note'] = $cs['pcp_personal_note'];
+      $result[$cs['id']]['contribution_status'] = $cs['contribution_id.contribution_status_id:label'];
+      $result[$cs['id']]['sct_label'] = $cs['soft_credit_type_id:label'];
       $replace = [
-        'contributionid' => $cs->contribution_id,
-        'contactId' => $cs->contributor_id,
+        'contributionid' => $cs['contribution_id'],
+        'contactId' => $cs['contact.id'],
       ];
-      $result[$cs->id]['links'] = CRM_Core_Action::formLink($links, NULL, $replace);
+      $result[$cs['id']]['links'] = CRM_Core_Action::formLink($links, NULL, $replace);
 
       if ($isTest) {
-        $result[$cs->id]['contribution_status'] = CRM_Core_TestEntity::appendTestText($result[$cs->id]['contribution_status']);
+        $result[$cs['id']]['contribution_status'] = CRM_Core_TestEntity::appendTestText($result[$cs['id']]['contribution_status']);
       }
     }
     return $result;
@@ -684,6 +647,15 @@ class CRM_Contribute_BAO_ContributionSoft extends CRM_Contribute_DAO_Contributio
       ];
       CRM_Core_BAO_MessageTemplate::sendTemplate($sendTemplateParams);
     }
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function addSelectWhereClause() {
+    $clauses['contribution_id'] = CRM_Utils_SQL::mergeSubquery('Contribution');
+    CRM_Utils_Hook::selectWhereClause($this, $clauses);
+    return $clauses;
   }
 
 }

--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -1137,6 +1137,7 @@ class CRM_Core_Permission {
     $permissions['line_item'] = $permissions['contribution'];
 
     $permissions['financial_item'] = $permissions['contribution'];
+    $permissions['contribution_soft'] = $permissions['contribution'];
 
     // Payment permissions
     $permissions['payment'] = [

--- a/Civi/Api4/PCP.php
+++ b/Civi/Api4/PCP.php
@@ -1,0 +1,22 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+namespace Civi\Api4;
+
+/**
+ * PCP entity.
+ *
+ * @searchable secondary
+ * @since 5.42
+ * @package Civi\Api4
+ */
+class PCP extends Generic\DAOEntity {
+
+}

--- a/tests/phpunit/CRM/Contribute/BAO/ContributionSoftTest.php
+++ b/tests/phpunit/CRM/Contribute/BAO/ContributionSoftTest.php
@@ -1,0 +1,140 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * Class CRM_Contribute_BAO_ContributionTest
+ * @group headless
+ */
+class CRM_Contribute_BAO_ContributionSoftTest extends CiviUnitTestCase {
+
+  use CRMTraits_Financial_FinancialACLTrait;
+
+  /**
+   * Clean up after tests.
+   */
+  public function tearDown() : void {
+    $this->quickCleanUpFinancialEntities();
+    parent::tearDown();
+  }
+
+  /**
+   * Creates two donor contacts and one soft creditee contact.
+   * Creates a contribution for each donor contact, soft crediting the creditee.
+   * The contributions have different financial types ("Donation" and "Campaign Contribution")
+   * to facilitate testing ACLs.
+   * @return array
+   */
+  protected function createTwoSoftCredits() {
+    $donorId = $this->individualCreate();
+    $donorId2 = $this->individualCreate();
+    $crediteeId = $this->individualCreate();
+    $contributionId = $this->contributionCreate(['financial_type_id' => 'Donation', 'contact_id' => $donorId]);
+    $contributionId2 = $this->contributionCreate(['financial_type_id' => 'Campaign Contribution', 'contact_id' => $donorId2]);
+
+    $params = [
+      'contribution_id' => $contributionId,
+      'amount' => 100,
+      'contact_id' => $crediteeId,
+    ];
+    CRM_Contribute_BAO_ContributionSoft::add($params);
+
+    $params2 = [
+      'contribution_id' => $contributionId2,
+      'amount' => 200,
+      'contact_id' => $crediteeId,
+    ];
+    CRM_Contribute_BAO_ContributionSoft::add($params2);
+    return [$donorId, $donorId2, $crediteeId, $contributionId, $contributionId2];
+  }
+
+  /**
+   * Test add method
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testAdd() {
+    $donorId = $this->individualCreate();
+    $contributionId = $this->contributionCreate(['receive_date' => '2018-01-02', 'contact_id' => $donorId]);
+    $crediteeId = $this->individualCreate();
+
+    $params = [
+      'contribution_id' => $contributionId,
+      'amount' => 100,
+      'contact_id' => $crediteeId,
+    ];
+
+    $contributionSoft = CRM_Contribute_BAO_ContributionSoft::add($params);
+    $this->assertEquals($params['amount'], $contributionSoft->amount);
+    $this->assertEquals($crediteeId, $contributionSoft->contact_id);
+  }
+
+  /**
+   * Test getSoftContributionList method.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testGetSoftContributionList() {
+    list($donorId, $donorId2, $crediteeId, $contributionId, $contributionId2) = $this->createTwoSoftCredits();
+    $list = CRM_Contribute_BAO_ContributionSoft::getSoftContributionList($crediteeId);
+    $this->assertEquals('$ 100.00', $list[1]['amount']);
+    $this->assertEquals('Donation', $list[1]['financial_type']);
+    $this->assertEquals($donorId, $list[1]['contributor_id']);
+    $this->assertEquals($contributionId, $list[1]['contribution_id']);
+    $this->assertEquals('$ 200.00', $list[2]['amount']);
+    $this->assertEquals('Campaign Contribution', $list[2]['financial_type']);
+    $this->assertEquals($donorId2, $list[2]['contributor_id']);
+    $this->assertEquals($contributionId2, $list[2]['contribution_id']);
+
+    // And again, with ACLs enabled.
+    $this->enableFinancialACLs();
+    $this->setPermissions([
+      'access CiviCRM',
+      'access CiviContribute',
+      'edit contributions',
+      'view contributions of type Campaign Contribution',
+    ]);
+
+    $list = CRM_Contribute_BAO_ContributionSoft::getSoftContributionList($crediteeId);
+    $this->assertArrayNotHasKey(1, $list);
+    $this->assertEquals('$ 200.00', $list[2]['amount']);
+    $this->assertEquals('Campaign Contribution', $list[2]['financial_type']);
+    $this->assertEquals($donorId2, $list[2]['contributor_id']);
+    $this->assertEquals($contributionId2, $list[2]['contribution_id']);
+  }
+
+  /**
+   * Test getSoftContributionTotals method.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testGetSoftContributionTotals() {
+    list($donorId, $donorId2, $crediteeId, $contributionId, $contributionId2) = $this->createTwoSoftCredits();
+    $totals = CRM_Contribute_BAO_ContributionSoft::getSoftContributionTotals($crediteeId);
+    $this->assertEquals('$ 300.00', $totals[2], 'test total of completed soft credits');
+    $this->assertEquals('$ 150.00', $totals[3], 'test average of completed soft credits');
+    $this->assertEquals('', $totals[4], 'test count of cancelled soft credits');
+
+    // And again, with ACLs enabled.
+    $this->enableFinancialACLs();
+    $this->setPermissions([
+      'access CiviCRM',
+      'access CiviContribute',
+      'edit contributions',
+      'view contributions of type Campaign Contribution',
+    ]);
+
+    $totals = CRM_Contribute_BAO_ContributionSoft::getSoftContributionTotals($crediteeId);
+    $this->assertEquals('$ 200.00', $totals[2], 'test total of completed soft credits');
+    $this->assertEquals('$ 200.00', $totals[3], 'test average of completed soft credits');
+    $this->assertEquals('', $totals[4], 'test count of cancelled soft credits');
+  }
+
+}


### PR DESCRIPTION
https://lab.civicrm.org/dev/financial/-/issues/121

Overview
----------------------------------------
Soft Credit permissions are:
* ill-defined (require "Administer CiviCRM" via API4);
* unmodifiable (notably via Financial ACL extension);
* untested.

Before
----------------------------------------
See above.

After
----------------------------------------
Soft credits have proper permissions and can be updated, and tests are in place.

Technical Details
----------------------------------------
Mainly this involved replacing SQL statements with API4.  Cleaner, and gave us permissions for free.

I also added a `selectWhereClause()` to ensure Soft Credits followed the permissioning of their corresponding contributions.

To display PCP page in the Soft Credit datatable, I needed to add PCP to API4. I imagine may need to be broken out.  Let me know.


Comments
----------------------------------------
* I tried tackling this a year ago and gave up because of API permissions; API4 solves that for me.
* This fixes a bug in the soft credit summary - it said "total soft credits" but then did a GROUP BY on currency, so almost always said 1.
* Tests aside, this reduces the LOC.