### PR TITLE
[Ref] Move rule to email trait

### DIFF
--- a/CRM/Contact/Form/Task/EmailCommon.php
+++ b/CRM/Contact/Form/Task/EmailCommon.php
@@ -81,6 +81,7 @@ class CRM_Contact_Form_Task_EmailCommon {
    *   true if no errors, else array of errors
    */
   public static function formRule(array $fields) {
+    CRM_Core_Error::deprecatedFunctionWarning('no replacement');
     $errors = [];
     //Added for CRM-1393
     if (!empty($fields['saveTemplate']) && empty($fields['saveTemplateName'])) {

--- a/CRM/Contact/Form/Task/EmailTrait.php
+++ b/CRM/Contact/Form/Task/EmailTrait.php
@@ -331,7 +331,7 @@ trait CRM_Contact_Form_Task_EmailTrait {
     //Added for CRM-15984: Add campaign field
     CRM_Campaign_BAO_Campaign::addCampaign($this);
 
-    $this->addFormRule(['CRM_Contact_Form_Task_EmailCommon', 'formRule'], $this);
+    $this->addFormRule([__CLASS__, 'saveTemplateFormRule'], $this);
     CRM_Core_Resources::singleton()->addScriptFile('civicrm', 'templates/CRM/Contact/Form/Task/EmailCommon.js', 0, 'html-header');
   }
 
@@ -642,6 +642,24 @@ trait CRM_Contact_Form_Task_EmailTrait {
       }
     }
     return $followupStatus;
+  }
+
+  /**
+   * Form rule.
+   *
+   * @param array $fields
+   *   The input form values.
+   *
+   * @return bool|array
+   *   true if no errors, else array of errors
+   */
+  public static function saveTemplateFormRule(array $fields) {
+    $errors = [];
+    //Added for CRM-1393
+    if (!empty($fields['saveTemplate']) && empty($fields['saveTemplateName'])) {
+      $errors['saveTemplateName'] = ts('Enter name to save message template');
+    }
+    return empty($errors) ? TRUE : $errors;
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
[Ref] Move rule to email trait

This is part of dis-establishing EmailCommon - the function is not called from elsewhere

UPDATE - I found a place in 'universe' - so I deprecated instead of removing


Before
----------------------------------------
Function on deprecated class, only used from the trait

After
----------------------------------------
Function on the trait

Technical Details
----------------------------------------
A universe search shows it is not used other than here

![image](https://user-images.githubusercontent.com/336308/128648758-89de8924-8f47-403b-9a06-50a7283473ac.png)

Comments
----------------------------------------
