### PR TITLE
APIv4 - Support multiple implicit joins to the same table

### DIFF
--- a/Civi/Api4/Query/Api4SelectQuery.php
+++ b/Civi/Api4/Query/Api4SelectQuery.php
@@ -47,6 +47,18 @@ class Api4SelectQuery {
   protected $joins = [];
 
   /**
+   * Used to keep track of implicit join table aliases
+   * @var array
+   */
+  protected $joinTree = [];
+
+  /**
+   * Used to create a unique table alias for each implicit join
+   * @var int
+   */
+  protected $autoJoinSuffix = 0;
+
+  /**
    * @var array[]
    */
   protected $apiFieldSpec;
@@ -598,7 +610,7 @@ class Api4SelectQuery {
     // Prevent (most) redundant acl sub clauses if they have already been applied to the main entity.
     // FIXME: Currently this only works 1 level deep, but tracking through multiple joins would increase complexity
     // and just doing it for the first join takes care of most acl clause deduping.
-    if (count($stack) === 1 && in_array($stack[0], $this->aclFields, TRUE)) {
+    if (count($stack) === 1 && in_array(reset($stack), $this->aclFields, TRUE)) {
       return [];
     }
     $clauses = $baoName::getSelectWhereClause($tableAlias);
@@ -970,49 +982,97 @@ class Api4SelectQuery {
    * Joins a path and adds all fields in the joined entity to apiFieldSpec
    *
    * @param $key
-   * @throws \API_Exception
-   * @throws \Exception
    */
   protected function autoJoinFK($key) {
     if (isset($this->apiFieldSpec[$key])) {
       return;
     }
-
-    $pathArray = explode('.', $key);
-
     /** @var \Civi\Api4\Service\Schema\Joiner $joiner */
     $joiner = \Civi::container()->get('joiner');
+
+    $pathArray = explode('.', $key);
     // The last item in the path is the field name. We don't care about that; we'll add all fields from the joined entity.
     array_pop($pathArray);
 
+    $baseTableAlias = $this::MAIN_TABLE_ALIAS;
+
+    // If the first item is the name of an explicit join, use it as the base & shift it off the path
+    $explicitJoin = $this->getExplicitJoin($pathArray[0]);
+    if ($explicitJoin) {
+      $baseTableAlias = array_shift($pathArray);
+    }
+
+    // Ensure joinTree array contains base table
+    $this->joinTree[$baseTableAlias]['#table_alias'] = $baseTableAlias;
+    $this->joinTree[$baseTableAlias]['#path'] = $explicitJoin ? $baseTableAlias . '.' : '';
+    // During iteration this variable will refer to the current position in the tree
+    $joinTreeNode =& $this->joinTree[$baseTableAlias];
+
     try {
-      $joinPath = $joiner->autoJoin($this, $pathArray);
+      $joinPath = $joiner->getPath($explicitJoin['table'] ?? $this->getFrom(), $pathArray);
     }
     catch (\Exception $e) {
+      // Because the select clause silently ignores unknown fields, this function shouldn't throw exceptions
       return;
     }
-    $lastLink = array_pop($joinPath);
-    $previousLink = array_pop($joinPath);
 
-    // Custom field names are already prefixed
-    $isCustom = $lastLink instanceof CustomGroupJoinable;
-    if ($isCustom) {
-      array_pop($pathArray);
-    }
-    $prefix = $pathArray ? implode('.', $pathArray) . '.' : '';
-    // Cache field info for retrieval by $this->getField()
-    foreach ($lastLink->getEntityFields() as $fieldObject) {
-      $fieldArray = $fieldObject->toArray();
-      // Set sql name of field, using column name for real joins
-      if (!$lastLink->getSerialize()) {
-        $fieldArray['sql_name'] = '`' . $lastLink->getAlias() . '`.`' . $fieldArray['column_name'] . '`';
+    foreach ($joinPath as $joinName => $link) {
+      if (!isset($joinTreeNode[$joinName])) {
+        $target = $link->getTargetTable();
+        $tableAlias = $link->getAlias() . '_' . ++$this->autoJoinSuffix;
+        $isCustom = $link instanceof CustomGroupJoinable;
+
+        $joinTreeNode[$joinName] = [
+          '#table_alias' => $tableAlias,
+          '#path' => $joinTreeNode['#path'] . $joinName . '.',
+        ];
+        $joinEntity = CoreUtil::getApiNameFromTableName($target);
+
+        if ($joinEntity && !$this->checkEntityAccess($joinEntity)) {
+          return;
+        }
+        if ($this->getCheckPermissions() && $isCustom) {
+          // Check access to custom group
+          $groupId = \CRM_Core_DAO::getFieldValue('CRM_Core_DAO_CustomGroup', $link->getTargetTable(), 'id', 'table_name');
+          if (!\CRM_Core_BAO_CustomGroup::checkGroupAccess($groupId, \CRM_Core_Permission::VIEW)) {
+            return;
+          }
+        }
+        if ($link->isDeprecated()) {
+          $deprecatedAlias = $link->getAlias();
+          \CRM_Core_Error::deprecatedWarning("Deprecated join alias '$deprecatedAlias' used in APIv4 get. Should be changed to '{$deprecatedAlias}_id'");
+        }
+        $virtualField = $link->getSerialize();
+
+        // Cache field info for retrieval by $this->getField()
+        foreach ($link->getEntityFields() as $fieldObject) {
+          $fieldArray = $fieldObject->toArray();
+          // Set sql name of field, using column name for real joins
+          if (!$virtualField) {
+            $fieldArray['sql_name'] = '`' . $tableAlias . '`.`' . $fieldArray['column_name'] . '`';
+          }
+          // For virtual joins on serialized fields, the callback function will need the sql name of the serialized field
+          // @see self::renderSerializedJoin()
+          else {
+            $fieldArray['sql_name'] = '`' . $joinTreeNode['#table_alias'] . '`.`' . $link->getBaseColumn() . '`';
+          }
+          // Custom fields will already have the group name prefixed
+          $fieldName = $isCustom ? explode('.', $fieldArray['name'])[1] : $fieldArray['name'];
+          $this->addSpecField($joinTreeNode[$joinName]['#path'] . $fieldName, $fieldArray);
+        }
+
+        // Serialized joins are rendered by this::renderSerializedJoin. Don't add their tables.
+        if (!$virtualField) {
+          $bao = $joinEntity ? CoreUtil::getBAOFromApiName($joinEntity) : NULL;
+          $conditions = $link->getConditionsForJoin($joinTreeNode['#table_alias'], $tableAlias);
+          if ($bao) {
+            $conditions = array_merge($conditions, $this->getAclClause($tableAlias, $bao, $joinPath));
+          }
+          $this->join('LEFT', $target, $tableAlias, $conditions);
+        }
+
       }
-      // For virtual joins on serialized fields, the callback function will need the sql name of the serialized field
-      // @see self::renderSerializedJoin()
-      else {
-        $fieldArray['sql_name'] = '`' . $previousLink->getAlias() . '`.`' . $lastLink->getBaseColumn() . '`';
-      }
-      $this->addSpecField($prefix . $fieldArray['name'], $fieldArray);
+      $joinTreeNode =& $joinTreeNode[$joinName];
     }
   }
 

--- a/Civi/Api4/Service/Schema/Joinable/Joinable.php
+++ b/Civi/Api4/Service/Schema/Joinable/Joinable.php
@@ -97,17 +97,17 @@ class Joinable {
   /**
    * Gets conditions required when joining to a base table
    *
-   * @param string|null $baseTableAlias
-   *   Name of the base table, if aliased.
+   * @param string $baseTableAlias
+   * @param string $tableAlias
    *
    * @return array
    */
-  public function getConditionsForJoin($baseTableAlias = NULL) {
+  public function getConditionsForJoin(string $baseTableAlias, string $tableAlias) {
     $baseCondition = sprintf(
       '%s.%s =  %s.%s',
-      $baseTableAlias ?: $this->baseTable,
+      $baseTableAlias,
       $this->baseColumn,
-      $this->getAlias(),
+      $tableAlias,
       $this->targetColumn
     );
 

--- a/Civi/Api4/Service/Schema/Joiner.php
+++ b/Civi/Api4/Service/Schema/Joiner.php
@@ -106,23 +106,22 @@ class Joiner {
    * @param array $joinPath
    *
    * @return \Civi\Api4\Service\Schema\Joinable\Joinable[]
-   * @throws \Exception
+   * @throws \API_Exception
    */
   protected function getPath(string $baseTable, array $joinPath) {
     $cacheKey = sprintf('%s.%s', $baseTable, implode('.', $joinPath));
     if (!isset($this->cache[$cacheKey])) {
       $fullPath = [];
 
-      foreach ($joinPath as $key => $targetAlias) {
-        $links = $this->schemaMap->getPath($baseTable, $targetAlias);
+      foreach ($joinPath as $targetAlias) {
+        $link = $this->schemaMap->getLink($baseTable, $targetAlias);
 
-        if (empty($links)) {
-          throw new \Exception(sprintf('Cannot join %s to %s', $baseTable, $targetAlias));
+        if (!$link) {
+          throw new \API_Exception(sprintf('Cannot join %s to %s', $baseTable, $targetAlias));
         }
         else {
-          $fullPath = array_merge($fullPath, $links);
-          $lastLink = end($links);
-          $baseTable = $lastLink->getTargetTable();
+          $fullPath[] = $link;
+          $baseTable = $link->getTargetTable();
         }
       }
 

--- a/Civi/Api4/Service/Schema/SchemaMap.php
+++ b/Civi/Api4/Service/Schema/SchemaMap.php
@@ -14,8 +14,6 @@ namespace Civi\Api4\Service\Schema;
 
 class SchemaMap {
 
-  const MAX_JOIN_DEPTH = 3;
-
   /**
    * @var Table[]
    */
@@ -25,20 +23,23 @@ class SchemaMap {
    * @param $baseTableName
    * @param $targetTableAlias
    *
-   * @return \Civi\Api4\Service\Schema\Joinable\Joinable[]
-   *   Array of links to the target table, empty if no path found
+   * @return \Civi\Api4\Service\Schema\Joinable\Joinable|NULL
+   *   Link to the target table
+   * @throws \API_Exception
    */
-  public function getPath($baseTableName, $targetTableAlias) {
+  public function getLink($baseTableName, $targetTableAlias): ?Joinable\Joinable {
     $table = $this->getTableByName($baseTableName);
-    $path = [];
 
     if (!$table) {
-      return $path;
+      throw new \API_Exception("Table $baseTableName not found");
     }
 
-    $this->findPaths($table, $targetTableAlias, $path);
-
-    return $path;
+    foreach ($table->getTableLinks() as $link) {
+      if ($link->getAlias() === $targetTableAlias) {
+        return $link;
+      }
+    }
+    return NULL;
   }
 
   /**
@@ -84,24 +85,6 @@ class SchemaMap {
   public function addTables(array $tables) {
     foreach ($tables as $table) {
       $this->addTable($table);
-    }
-  }
-
-  /**
-   * Traverse the schema looking for a path
-   *
-   * @param Table $table
-   *   The current table to base fromm
-   * @param string $target
-   *   The target joinable table alias
-   * @param \Civi\Api4\Service\Schema\Joinable\Joinable[] $path
-   *   (By-reference) The possible paths to the target table
-   */
-  private function findPaths(Table $table, $target, &$path) {
-    foreach ($table->getTableLinks() as $link) {
-      if ($link->getAlias() === $target) {
-        $path[] = $link;
-      }
     }
   }
 

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -3451,7 +3451,6 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
     //Assert only three activities are created.
     $activityNames = (array) ActivityContact::get(FALSE)
       ->addWhere('contact_id', '=', $this->_ids['contact'])
-      ->addSelect('activity.*')
       ->addSelect('activity_id.activity_type_id:name')->execute()->indexBy('activity_id.activity_type_id:name');
     $this->assertArrayHasKey('Contribution', $activityNames);
     $this->assertArrayHasKey('Membership Signup', $activityNames);

--- a/tests/phpunit/api/v4/Service/Schema/SchemaMapperTest.php
+++ b/tests/phpunit/api/v4/Service/Schema/SchemaMapperTest.php
@@ -31,7 +31,13 @@ class SchemaMapperTest extends UnitTestCase {
 
   public function testWillHaveNoPathWithNoTables() {
     $map = new SchemaMap();
-    $this->assertEmpty($map->getPath('foo', 'bar'));
+    try {
+      $map->getLink('foo', 'bar');
+    }
+    catch (\API_Exception $e) {
+      $exception = $e;
+    }
+    $this->assertStringContainsString('not found', $exception->getMessage());
   }
 
   public function testWillHavePathWithSingleJump() {
@@ -43,7 +49,7 @@ class SchemaMapperTest extends UnitTestCase {
     $map = new SchemaMap();
     $map->addTables([$phoneTable, $locationTable]);
 
-    $this->assertNotEmpty($map->getPath('civicrm_phone', 'location'));
+    $this->assertNotEmpty($map->getLink('civicrm_phone', 'location'));
   }
 
   public function testCircularReferenceWillNotBreakIt() {
@@ -57,7 +63,7 @@ class SchemaMapperTest extends UnitTestCase {
     $map = new SchemaMap();
     $map->addTables([$contactTable, $carTable]);
 
-    $this->assertEmpty($map->getPath('contact', 'foo'));
+    $this->assertEmpty($map->getLink('contact', 'foo'));
   }
 
   public function testCannotGoOverJoinLimit() {
@@ -73,7 +79,7 @@ class SchemaMapperTest extends UnitTestCase {
     $map = new SchemaMap();
     $map->addTables([$first, $second, $third, $fourth]);
 
-    $this->assertEmpty($map->getPath('first', 'fifth'));
+    $this->assertEmpty($map->getLink('first', 'fifth'));
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Supports multiple implicit joins to the same table in APIv4 & SearchKit.

Fixes https://lab.civicrm.org/dev/report/-/issues/73

Before
--------------------
APIv4 always used the name of the table with no sql alias when adding an implicit join, meaning it could only be added once.

After
--------------
Creates a unique alias for each instance of an implicit join, allowing the same table to be joined multiple times.
