### PR TITLE
APIv4 - Throw exception instead of munging illegal join aliases

### DIFF
--- a/Civi/Api4/Query/Api4SelectQuery.php
+++ b/Civi/Api4/Query/Api4SelectQuery.php
@@ -680,7 +680,10 @@ class Api4SelectQuery {
         continue;
       }
       // Ensure alias is a safe string, and supply default if not given
-      $alias = $alias ? \CRM_Utils_String::munge($alias, '_', 256) : strtolower($entity);
+      $alias = $alias ?: strtolower($entity);
+      if ($alias === self::MAIN_TABLE_ALIAS || !preg_match('/^[-\w]{1,256}$/', $alias)) {
+        throw new \API_Exception('Illegal join alias: "' . $alias . '"');
+      }
       // First item in the array is a boolean indicating if the join is required (aka INNER or LEFT).
       // The rest are join conditions.
       $side = array_shift($join);


### PR DESCRIPTION
Overview
----------------------------------------
Improves APIv4 validation of explicit join aliases.

Before
----------------------------------------
Incorrect aliases would be silently "fixed".

After
----------------------------------------
Exception thrown.

Technical Details
----------------------------------------
The problem with "fixing" an illegal join alias is that it's then mysterious what the correct alias will be, leading to bugs when the incorrect alias gets used throughout the rest of the api params.

Throwing an exception seems like a better way to ensure developers are alerted to the error.