### PR TITLE
MessageTemplate::sendTemplate() - Accept `array $messageTemplate` and `array $tokenContext`

### DIFF
--- a/CRM/Core/BAO/MessageTemplate.php
+++ b/CRM/Core/BAO/MessageTemplate.php
@@ -383,12 +383,14 @@ class CRM_Core_BAO_MessageTemplate extends CRM_Core_DAO_MessageTemplate {
       'messageTemplateID' => NULL,
       // content of the message template
       // Ex: ['msg_subject' => 'Hello {contact.display_name}', 'msg_html' => '...', 'msg_text' => '...']
+      // INTERNAL: 'messageTemplate' is currently only intended for use within civicrm-core only. For downstream usage, future updates will provide comparable public APIs.
       'messageTemplate' => NULL,
       // contact id if contact tokens are to be replaced
       'contactId' => NULL,
       // additional template params (other than the ones already set in the template singleton)
       'tplParams' => [],
       // additional token params (passed to the TokenProcessor)
+      // INTERNAL: 'tokenContext' is currently only intended for use within civicrm-core only. For downstream usage, future updates will provide comparable public APIs.
       'tokenContext' => [],
       // the From: header
       'from' => NULL,


### PR DESCRIPTION
Overview
----------------------------------------

The method `MessageTemplate::sendTemplate()` accepts various template-options and data-model options, then it renders  the corresponding template and (optionally) sends an email.

This is an extracted portion of https://github.com/civicrm/civicrm-core/pull/20975 which contributes toward https://lab.civicrm.org/dev/mail/-/issues/83. For dev/mail#83, we need more robust rendering/previewing APIs. Building those APIs on top of ensures a consistent rendering pipeline (e.g. where hooks fire consistently). However, this requires more flexibility in `sendTemplate`. this PR adds a few options (with test coverage) to make it a more useful building block.

ping @eileenmcnaughton 

Before
----------------------------------------

* Templates may be loaded by either `messageTemplateID` (int) or `valueName` (string) .
* Token data may be generated for `contactId` (int).

After
----------------------------------------

* Templates may be additionally be specified by `messageTemplate` (array), e.g. `["msg_subject" => "Hello", "msg_html" => "World"]`
* Token data may be generated for any supported entity via `tokenContext` (array), e.g. `["contactId"=>123,"activityId"=>456]`

