### PR TITLE
Remove no longer used variable in Email.tpl / smarty warning

### DIFF
--- a/templates/CRM/Contact/Form/Task/Email.tpl
+++ b/templates/CRM/Contact/Form/Task/Email.tpl
@@ -124,8 +124,7 @@ CRM.$(function($) {
   }
 
   {/literal}
-  var toContact = {if $toContact}{$toContact}{else}''{/if},
-    ccContact = {if $ccContact}{$ccContact}{else}''{/if};
+  var toContact = {if $toContact}{$toContact}{else}''{/if};
   {literal}
   emailSelect('#to', toContact);
 });


### PR DESCRIPTION
Overview
----------------------------------------
Oddly this smarty warning is a bit quieter than others. It comes up when making a new email activity.

Before
----------------------------------------
Undefined index: ccContact

After
----------------------------------------


Technical Details
----------------------------------------
Code has been moved around a lot on these forms. At some point the way cc/bcc works was changed, but this is left over and is no longer assigned to the template.

Comments
----------------------------------------
It's difficult to reproduce the error visually. I had to run a step debugger with it set to stop on everything.