### PR TITLE
[Ref] Move id fetching to the classes

### DIFF
--- a/CRM/Contribute/Form/Task/Email.php
+++ b/CRM/Contribute/Form/Task/Email.php
@@ -22,6 +22,17 @@ class CRM_Contribute_Form_Task_Email extends CRM_Contribute_Form_Task {
   use CRM_Contact_Form_Task_EmailTrait;
 
   /**
+   * Get selected contribution IDs.
+   *
+   * @return array
+   *
+   * @throws \CRM_Core_Exception
+   */
+  protected function getContributionIDs(): array {
+    return $this->getIDs();
+  }
+
+  /**
    * List available tokens for this form.
    *
    * @return array


### PR DESCRIPTION
Overview
----------------------------------------
[Ref] Move id fetching to the classes

Before
----------------------------------------
Shared class tries to retrieve contributionIDs, caseId from properties - it shouldn't need to know about them

After
----------------------------------------
For contribution it's moved to the contribution class - but case leaves me with questions - so I though I'd open this & ask Dave - @demeritcowboy - do you think the handling for _caseId rightly belongs on `CRM_Activity_Form_Task_Email`

Technical Details
----------------------------------------

Comments
----------------------------------------

