### PR TITLE
Token Parser - Allow tokens with multiple dots (eg {contribution.contribution_recur_id.amount})

### DIFF
--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -182,16 +182,16 @@ class CRM_Utils_Token {
   }
 
   /**
-   * Get< the regex for token replacement
+   * Get the regex for token replacement
    *
    * @param string $token_type
    *   A string indicating the the type of token to be used in the expression.
    *
    * @return string
-   *   regular expression sutiable for using in preg_replace
+   *   regular expression suitable for using in preg_replace
    */
-  private static function tokenRegex($token_type) {
-    return '/(?<!\{|\\\\)\{' . $token_type . '\.([\w]+:?\w*(\-[\w\s]+)?)\}(?!\})/';
+  private static function tokenRegex(string $token_type) {
+    return '/(?<!\{|\\\\)\{' . $token_type . '\.([\w]+(:|\.)?\w*(\-[\w\s]+)?)\}(?!\})/';
   }
 
   /**
@@ -1102,7 +1102,7 @@ class CRM_Utils_Token {
   public static function getTokens($string) {
     $matches = [];
     $tokens = [];
-    preg_match_all('/(?<!\{|\\\\)\{(\w+\.\w+:?\w*)\}(?!\})/',
+    preg_match_all('/(?<!\{|\\\\)\{(\w+\.\w+(:|.)?\w*)\}(?!\})/',
       $string,
       $matches,
       PREG_PATTERN_ORDER
@@ -1110,12 +1110,15 @@ class CRM_Utils_Token {
 
     if ($matches[1]) {
       foreach ($matches[1] as $token) {
-        [$type, $name] = preg_split('/\./', $token, 2);
+        $parts = explode('.', $token, 3);
+        $type = $parts[0];
+        $name = $parts[1];
+        $suffix = !empty($parts[2]) ? ('.' . $parts[2]) : '';
         if ($name && $type) {
           if (!isset($tokens[$type])) {
             $tokens[$type] = [];
           }
-          $tokens[$type][] = $name;
+          $tokens[$type][] = $name . $suffix;
         }
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------

Adjust the naming/parsing rules for Civi-style tokens. Tokens may include dots and colons

```
{contribution.campaign_id}
{contribution.campaign_id.name}
{contribution.campaign_id.title}
{contribution.campaign_id:name}
{contribution.campaign_id:label}
```

(*Patch extracted from larger work on specific tokens. Description rewritten to focus on the change to the parser.*)

Before
----------------------------------------

Civi tokens may look like: `{foo.bar}`, `{foo.bar:whiz}` (*recent addition*)

After
----------------------------------------

Civi tokens may look like: `{foo.bar}`, `{foo.bar:whiz}`, and `{foo.bar.whiz}` (*new here*)

Comment
----------------------------------------

Civi supports a hybrid Token-Smarty notation. Any changes in the token-notation require some thought on the interaction with Smarty notations. Fortunately, this change seems consistent with existing dividing line -- these distinctions are still valid:

* Civi tokens do not have a dollar-sign (*distinguishes token `{foo.bar}` and Smarty `{$foo.bar}`, a value expression*)
* Civi tokens do not have spaces (*distinguishes token `{foo.bar}` and Smarty `{foo bar}`, a block with parameters*)
* Civi tokens have at least one dot (*distinguishes token `{foo.bar}` and Smarty `{fooBar}`, a block with no parameters*)
