### PR TITLE
Fix the check to see if the financialAclExtension is installed

### DIFF
--- a/CRM/Upgrade/Incremental/General.php
+++ b/CRM/Upgrade/Incremental/General.php
@@ -122,8 +122,8 @@ class CRM_Upgrade_Incremental_General {
     }
 
     $ftAclSetting = Civi::settings()->get('acl_financial_type');
-    $financialAclExtension = civicrm_api3('extension', 'get', ['key' => 'biz.jmaconsulting.financialaclreport']);
-    if ($ftAclSetting && (($financialAclExtension['count'] == 1 && $financialAclExtension['status'] != 'Installed') || $financialAclExtension['count'] !== 1)) {
+    $financialAclExtension = civicrm_api3('extension', 'get', ['key' => 'biz.jmaconsulting.financialaclreport', 'sequential' => 1]);
+    if ($ftAclSetting && (($financialAclExtension['count'] == 1 && $financialAclExtension['values'][0]['status'] != 'Installed') || $financialAclExtension['count'] !== 1)) {
       $preUpgradeMessage .= '<br />' . ts('CiviCRM will in the future require the extension %1 for CiviCRM Reports to work correctly with the Financial Type ACLs. The extension can be downloaded <a href="%2">here</a>', [
         1 => 'biz.jmaconsulting.financialaclreport',
         2 => 'https://github.com/JMAConsulting/biz.jmaconsulting.financialaclreport',


### PR DESCRIPTION
Overview
----------------------------------------
This PR fixes a small mistake in the incremental upgrader.

Before
----------------------------------------
The reference to the key/value pair that determines if an extension is installed [is incorrect](https://github.com/civicrm/civicrm-core/blob/master/CRM/Upgrade/Incremental/General.php#L126): `$financialAclExtension['status']`.

After
----------------------------------------
The reference is fixed: `$financialAclExtension['values'][0]['status']`.

Comments
----------------------------------------
I don't know how to test this to be honest but I have used the API3 Explorer to confirm the data model for results return from `civicrm_api3('extension', 'get', ...)` calls is such that the `status` key definitely sits within the array underneath the `values` key. It is not at the same level of the object as the `count` key.
