### PR TITLE
(dev/core#2673) Email Tokens - Custom tokens in `subject` block similar tokens in `body`

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -1059,7 +1059,7 @@ class CRM_Activity_BAO_Activity extends CRM_Activity_DAO_Activity {
     $subjectToken = CRM_Utils_Token::getTokens($subject);
     $messageToken = CRM_Utils_Token::getTokens($text);
     $messageToken = array_merge($messageToken, CRM_Utils_Token::getTokens($html));
-    $allTokens = array_merge($messageToken, $subjectToken);
+    $allTokens = CRM_Utils_Array::crmArrayMerge($messageToken, $subjectToken);
 
     if (!$from) {
       $from = "$fromDisplayName <$fromEmail>";


### PR DESCRIPTION
Overview
----------------------------------------

In an email, a token from an extension in a subject will inhibits the same token group in the email body.

Original ticket and proposed fix here: https://github.com/twomice/com.joineryhq.reltoken/issues/15 and https://lab.civicrm.org/dev/core/-/issues/2673

Before
----------------------------------------
In an email, if I put a custom token {custom.name} in the subject and another custom token in the email body and then send the email, I will only receive the value of the {custom.name} that's in the subject. The other custom token in the email body will be blank. Example:

```
Subject: {custom.name}

Email Body
Name: {custom.name}
Age: {custom.age}
Gender: {custom.gender}
```
In the email, the `{custom.name}` is populated in subject and in body, but tokens `{custom.age}` and `{custom.gender}` are blank in body, even if they actually have values.

After
----------------------------------------
Tokens in body are correctly populated regardless of which tokens are used in the subject.

Technical Details
----------------------------------------
See ticket OP for technical analysis.

Comments
----------------------------------------
[none]
