### PR TITLE
Upgrade angular-file-uploader to v2.6.1

### DIFF
--- a/ang/angularFileUpload.ang.php
+++ b/ang/angularFileUpload.ang.php
@@ -2,5 +2,5 @@
 // This file declares an Angular module which can be autoloaded
 return [
   'ext' => 'civicrm',
-  'js' => ['bower_components/angular-file-upload/angular-file-upload.min.js'],
+  'js' => ['bower_components/angular-file-upload/dist/angular-file-upload.min.js'],
 ];

--- a/composer.json
+++ b/composer.json
@@ -136,8 +136,8 @@
         "url": "https://github.com/angular-ui/bootstrap-bower/archive/2.5.0.zip"
       },
       "angular-file-upload": {
-        "url": "https://github.com/nervgh/angular-file-upload/archive/v1.1.6.zip",
-        "ignore": ["examples"]
+        "url": "https://github.com/nervgh/angular-file-upload/archive/2.6.1.zip",
+        "ignore": ["examples", "src"]
       },
       "angular-jquery-dialog-service": {
         "url": "https://github.com/totten/angular-jquery-dialog-service/archive/v0.8.0-civicrm-1.0.zip"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "58272f5bca4104f5bab01213016da6e7",
+    "content-hash": "127a1f748210d2bbea50645b5c0b2663",
     "packages": [
         {
             "name": "adrienrn/php-mimetyper",

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -36,7 +36,7 @@ module.exports = function(config) {
       'js/crm.datepicker.js',
       'bower_components/angular/angular.js',
       angularTempFile,
-      'bower_components/angular-file-upload/angular-file-upload.js',
+      'bower_components/angular-file-upload/dist/angular-file-upload.js',
       'bower_components/angular-jquery-dialog-service/dialog-service.js',
       'bower_components/angular-route/angular-route.js',
       'bower_components/angular-mocks/angular-mocks.js',


### PR DESCRIPTION
Overview
----------------------------------------
Upgrades an Angular plugin that is only used by the CiviCase extension, in preparation for also using it in Afform.

Before
----------------------------------------
AngularFileUploader v1.1.6

After
----------------------------------------
AngularFileUploader v2.6.1

Technical Details
----------------------------------------
I couldn't find any release notes about breaking changes, and I tested the CiviCase extension and the drag-n-drop file uploads work fine before and after.

![image](https://user-images.githubusercontent.com/2874912/128927479-18da4369-3e7d-4bd2-8e91-4a5e95ad067a.png)

