### PR TITLE
Fix search display access for non-admin users

### DIFF
--- a/Civi/Api4/SavedSearch.php
+++ b/Civi/Api4/SavedSearch.php
@@ -22,4 +22,10 @@ namespace Civi\Api4;
  */
 class SavedSearch extends Generic\DAOEntity {
 
+  public static function permissions() {
+    $permissions = parent::permissions();
+    $permissions['get'] = ['access CiviCRM'];
+    return $permissions;
+  }
+
 }

--- a/ext/search_kit/Civi/Api4/SearchDisplay.php
+++ b/ext/search_kit/Civi/Api4/SearchDisplay.php
@@ -32,6 +32,7 @@ class SearchDisplay extends Generic\DAOEntity {
   public static function permissions() {
     $permissions = parent::permissions();
     $permissions['default'] = ['administer CiviCRM data'];
+    $permissions['get'] = ['access CiviCRM'];
     $permissions['getSearchTasks'] = ['access CiviCRM'];
     // Permission for run action is checked internally
     $permissions['run'] = [];

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
@@ -464,7 +464,7 @@ class SearchRunTest extends \PHPUnit\Framework\TestCase implements HeadlessInter
     }
     $this->assertStringContainsString('failed', $error);
 
-    $config->userPermissionClass->permissions = ['administer CiviCRM data'];
+    $config->userPermissionClass->permissions = ['access CiviCRM', 'administer CiviCRM data'];
 
     // Admins can edit the search and the display
     SavedSearch::update()->addWhere('name', '=', $searchName)


### PR DESCRIPTION
Overview
----------------------------------------
Non-admin users should be allowed to view any search display that doesn't have permission checks disabled;
for those displays that disable permission checks, non-admins will only be able to view it if embedded in an afform.

Fixes dev/core#2737

Before
----------------------------------------
Permission checks too strict

After
----------------------------------------
Permission checks just right
