### PR TITLE
APIv4 - Silently ignore errors in CoreUtil::getInfoItem()

### DIFF
--- a/Civi/Api4/Utils/CoreUtil.php
+++ b/Civi/Api4/Utils/CoreUtil.php
@@ -60,7 +60,8 @@ class CoreUtil {
    * @return mixed
    */
   public static function getInfoItem(string $entityName, string $keyToReturn) {
-    return self::getApiClass($entityName)::getInfo()[$keyToReturn] ?? NULL;
+    $className = self::getApiClass($entityName);
+    return $className ? $className::getInfo()[$keyToReturn] ?? NULL : NULL;
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Fixes dev/core#2751

Before
----------------------------------------
Crash described in https://lab.civicrm.org/dev/core/-/issues/2751

After
----------------------------------------
No crash