### PR TITLE
Scheduled Reminders - Pass locale through to TokenProcessor

### DIFF
--- a/CRM/Core/BAO/ActionSchedule.php
+++ b/CRM/Core/BAO/ActionSchedule.php
@@ -271,7 +271,7 @@ FROM civicrm_action_schedule cas
         // switch language if necessary
         if ($multilingual) {
           $preferred_language = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Contact', $dao->contactID, 'preferred_language');
-          CRM_Core_BAO_ActionSchedule::setCommunicationLanguage($actionSchedule->communication_language, $preferred_language);
+          CRM_Core_I18n::singleton()->setLocale(CRM_Core_BAO_ActionSchedule::pickLocale($actionSchedule->communication_language, $preferred_language));
         }
 
         $errors = [];
@@ -401,10 +401,11 @@ FROM civicrm_action_schedule cas
   }
 
   /**
-   * @param $communication_language
-   * @param $preferred_language
+   * @param string|null $communication_language
+   * @param string|null $preferred_language
+   * @return string
    */
-  public static function setCommunicationLanguage($communication_language, $preferred_language) {
+  public static function pickLocale($communication_language, $preferred_language) {
     $currentLocale = CRM_Core_I18n::getLocale();
     $language = $currentLocale;
 
@@ -425,8 +426,7 @@ FROM civicrm_action_schedule cas
     }
 
     // change the language
-    $i18n = CRM_Core_I18n::singleton();
-    $i18n->setLocale($language);
+    return $language;
   }
 
   /**

--- a/CRM/Core/BAO/ActionSchedule.php
+++ b/CRM/Core/BAO/ActionSchedule.php
@@ -282,6 +282,9 @@ FROM civicrm_action_schedule cas
           }
 
           foreach ($tokenProcessor->evaluate()->getRows() as $tokenRow) {
+            // It's possible, eg, that sendReminderEmail fires Hook::alterMailParams() and that some listener use ts().
+            $swapLocale = empty($row->context['locale']) ? NULL : \CRM_Utils_AutoClean::swapLocale($row->context['locale']);
+
             if ($actionSchedule->mode === 'SMS' || $actionSchedule->mode === 'User_Preference') {
               CRM_Utils_Array::extend($errors, self::sendReminderSms($tokenRow, $actionSchedule, $dao->contactID));
             }
@@ -294,6 +297,8 @@ FROM civicrm_action_schedule cas
               $caseID = empty($dao->case_id) ? NULL : $dao->case_id;
               CRM_Core_BAO_ActionSchedule::createMailingActivity($tokenRow, $mapping, $dao->contactID, $dao->entityID, $caseID);
             }
+
+            unset($swapLocale);
           }
         }
         catch (\Civi\Token\TokenException $e) {

--- a/CRM/Utils/AutoClean.php
+++ b/CRM/Utils/AutoClean.php
@@ -49,6 +49,26 @@ class CRM_Utils_AutoClean {
   }
 
   /**
+   * Temporarily set the active locale. Cleanup locale when the autoclean handle disappears.
+   *
+   * @param string|null $newLocale
+   *   Ex: 'fr_CA'
+   * @return \CRM_Utils_AutoClean|null
+   */
+  public static function swapLocale(?string $newLocale) {
+    $oldLocale = $GLOBALS['tsLocale'] ?? NULL;
+    if ($oldLocale === $newLocale) {
+      return NULL;
+    }
+
+    $i18n = \CRM_Core_I18n::singleton();
+    $i18n->setLocale($newLocale);
+    return static::with(function() use ($i18n, $oldLocale) {
+      $i18n->setLocale($oldLocale);
+    });
+  }
+
+  /**
    * Temporarily swap values using callback functions, and cleanup
    * when the current context shuts down.
    *

--- a/Civi/Token/TokenCompatSubscriber.php
+++ b/Civi/Token/TokenCompatSubscriber.php
@@ -51,6 +51,10 @@ class TokenCompatSubscriber implements EventSubscriberInterface {
       if (empty($row->context['contactId'])) {
         continue;
       }
+
+      unset($swapLocale);
+      $swapLocale = empty($row->context['locale']) ? NULL : \CRM_Utils_AutoClean::swapLocale($row->context['locale']);
+
       /** @var int $contactId */
       $contactId = $row->context['contactId'];
       if (empty($row->context['contact'])) {

--- a/Civi/Token/TokenProcessor.php
+++ b/Civi/Token/TokenProcessor.php
@@ -55,6 +55,7 @@ class TokenProcessor {
    *     automatically from contactId.)
    *   - actionSchedule: DAO, the rule which triggered the mailing
    *     [for CRM_Core_BAO_ActionScheduler].
+   *   - locale: string, the name of a locale (eg 'fr_CA') to use for {ts} strings in the view.
    *   - schema: array, a list of fields that will be provided for each row.
    *     This is automatically populated with any general context
    *     keys, but you may need to add extra keys for token-row data.
@@ -350,6 +351,8 @@ class TokenProcessor {
     if (!is_object($row)) {
       $row = $this->getRow($row);
     }
+
+    $swapLocale = empty($row->context['locale']) ? NULL : \CRM_Utils_AutoClean::swapLocale($row->context['locale']);
 
     $message = $this->getMessage($name);
     $row->fill($message['format']);


### PR DESCRIPTION
Overview
----------------------------------------

Update the mechanism by which Scheduled Reminders (`ActionSchedule`) activate the appropriate locale. 

In a subsequent PR, this will allow significant simplification/maintainability improvements for the `CRM_*_Tokens` adapters. 

Before
----------------------------------------

The `ActionSchedule` controller calls `I18n->setLocale()` directly. It then creates a separate `TokenProcessor` for each recipient and runs the full `TokenProcessor` routine.

After
----------------------------------------

The `ActionSchedule` controller does not call `I18n->setLocale()` directly. Instead, it passes the `locale` to the `TokenProcessor`. At key moments (while handling each recipient/message), it will switch the active locale.

Technical Details
----------------------------------------

There are a couple ways for a translated string to get into a scheduled-reminder -- most likely by way of Smarty expression (`{ts}...{/ts}`). There are a couple `hook_civicrm_tokenValues` consumers in `universe` which call `ts()`. At a stretch, it's hypothetically possible that `hook_civircm_alterMail` might inject a translated string. This patch should give the same outcomes in all those cases.
