### PR TITLE
CRM_Core_Component - Remove unused code

### DIFF
--- a/CRM/Core/Component.php
+++ b/CRM/Core/Component.php
@@ -204,24 +204,6 @@ class CRM_Core_Component {
   }
 
   /**
-   * @return array
-   */
-  public static function &menu() {
-    $info = self::_info();
-    $items = [];
-    foreach ($info as $name => $comp) {
-      $mnu = $comp->getMenuObject();
-
-      $ret = $mnu->permissioned();
-      $items = array_merge($items, $ret);
-
-      $ret = $mnu->main($task);
-      $items = array_merge($items, $ret);
-    }
-    return $items;
-  }
-
-  /**
    * @param string $componentName
    *
    * @return mixed
@@ -230,9 +212,6 @@ class CRM_Core_Component {
     $info = self::_info();
     if (!empty($info[$componentName])) {
       return $info[$componentName]->componentID;
-    }
-    else {
-      return;
     }
   }
 

--- a/CRM/Core/Component/Info.php
+++ b/CRM/Core/Component/Info.php
@@ -221,20 +221,7 @@ abstract class CRM_Core_Component_Info {
    */
   public function isEnabled() {
     $config = CRM_Core_Config::singleton();
-    if (in_array($this->info['name'], $config->enableComponents)) {
-      return TRUE;
-    }
-    return FALSE;
-  }
-
-  /**
-   * Provides component's menu definition object.
-   *
-   * @return mixed
-   *   component's menu definition object
-   */
-  public function getMenuObject() {
-    return $this->_instantiate(self::COMPONENT_MENU_CLASS);
+    return in_array($this->info['name'], $config->enableComponents, TRUE);
   }
 
   /**
@@ -352,7 +339,6 @@ abstract class CRM_Core_Component_Info {
    */
   private function _instantiate($cl) {
     $className = $this->namespace . '_' . $cl;
-    require_once str_replace('_', DIRECTORY_SEPARATOR, $className) . '.php';
     return new $className();
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Removes unused or redundant code.

Before
----------------------------------------
Unused functions which reference non-existent variables or constants.

After
----------------------------------------
Gone.

Technical Details
----------------------------------------
`getMenuObject()` references non-existent `COMPONENT_MENU_CLASS`, and is only ever called by `&menu()`, which is unused (if it were ever used it would crash because it references non-existent variable `$task`).