### PR TITLE
Upgrade Pear/DB package to be version 1.11.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -83,7 +83,7 @@
     "brick/money": "~0.4",
     "ext-intl": "*",
     "pear/mail_mime": "~1.10",
-    "pear/db": "1.10",
+    "pear/db": "1.11",
     "civicrm/composer-compile-lib": "~0.3 || ~1.0",
     "ext-json": "*"
   },
@@ -274,7 +274,7 @@
         "PHP7.4 Fix for array access using {} instead of []": "https://raw.githubusercontent.com/civicrm/civicrm-core/fe45bdfc4f3e3d3deb27e3d853cdbc7f616620a9/tools/scripts/composer/patches/php74_array_access_fix_phpquery.patch"
       },
       "pear/db": {
-        "Apply CiviCRM Customisations for the pear:db package": "https://raw.githubusercontent.com/civicrm/civicrm-core/a48a43c2b5f6d694fff1cfb99d522c5d9e2459a0/tools/scripts/composer/pear_db_civicrm_changes.patch"
+        "Apply CiviCRM Customisations for the pear:db package": "https://raw.githubusercontent.com/civicrm/civicrm-core/2ad420c394/tools/scripts/composer/pear_db_civicrm_changes.patch"
       },
       "pear/mail": {
         "Apply CiviCRM Customisations for CRM-1367 and CRM-5946": "https://raw.githubusercontent.com/civicrm/civicrm-core/36319938a5bf26c1e7e2110a26a65db6a5979268/tools/scripts/composer/patches/pear-mail.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ea837c7aee5b94c6cbc1df32c5b3aa70",
+    "content-hash": "58272f5bca4104f5bab01213016da6e7",
     "packages": [
         {
             "name": "adrienrn/php-mimetyper",
@@ -1450,27 +1450,22 @@
         },
         {
             "name": "pear/db",
-            "version": "v1.10.0",
+            "version": "v1.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pear/DB.git",
-                "reference": "e158c3a48246b67cd8c95856ffbb93de4ef380fe"
+                "reference": "7e4f33dcecd99595df982ef8f56c1d7c2bbeaa21"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pear/DB/zipball/e158c3a48246b67cd8c95856ffbb93de4ef380fe",
-                "reference": "e158c3a48246b67cd8c95856ffbb93de4ef380fe",
+                "url": "https://api.github.com/repos/pear/DB/zipball/7e4f33dcecd99595df982ef8f56c1d7c2bbeaa21",
+                "reference": "7e4f33dcecd99595df982ef8f56c1d7c2bbeaa21",
                 "shasum": ""
             },
             "require": {
                 "pear/pear-core-minimal": "*"
             },
             "type": "library",
-            "extra": {
-                "patches_applied": {
-                    "Apply CiviCRM Customisations for the pear:db package": "https://raw.githubusercontent.com/civicrm/civicrm-core/a48a43c2b5f6d694fff1cfb99d522c5d9e2459a0/tools/scripts/composer/pear_db_civicrm_changes.patch"
-                }
-            },
             "autoload": {
                 "psr-0": {
                     "DB": "./"
@@ -1481,7 +1476,7 @@
                 "./"
             ],
             "license": [
-                "PHP License v3.01"
+                "PHP-3.01"
             ],
             "authors": [
                 {
@@ -1506,7 +1501,11 @@
                 }
             ],
             "description": "More info available on: http://pear.php.net/package/DB",
-            "time": "2020-04-19T19:45:59+00:00"
+            "support": {
+                "issues": "http://pear.php.net/bugs/search.php?cmd=display&package_name[]=DB",
+                "source": "https://github.com/pear/DB"
+            },
+            "time": "2021-08-11T00:24:34+00:00"
         },
         {
             "name": "pear/log",
@@ -3990,5 +3989,5 @@
     "platform-overrides": {
         "php": "7.2"
     },
-    "plugin-api-version": "1.1.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/tools/scripts/composer/pear_db_civicrm_changes.patch
+++ b/tools/scripts/composer/pear_db_civicrm_changes.patch
@@ -1,0 +1,158 @@
+diff -ruN DB/common.php DB/common.php
+--- DB/common.php	2020-04-20 05:45:59.000000000 +1000
++++ DB/common.php	2020-08-01 14:46:53.146175149 +1000
+@@ -147,7 +147,7 @@
+      */
+     function __construct()
+     {
+-        $this->PEAR('DB_Error');
++        parent::__construct('DB_Error');
+     }
+
+     // }}}
+@@ -1150,7 +1147,22 @@
+      */
+     function modifyQuery($query)
+     {
+-        return $query;
++        // CRM-20445 Add query dispatcher to allow query modification.
++        // This section of code may run hundreds or thousands of times in a given request.
++        // Consequently, it is micro-optimized to use single lookup in typical case.
++        if (!isset(Civi::$statics['db_common_dispatcher'])) {
++            if (class_exists('Civi\Core\Container') && \Civi\Core\Container::isContainerBooted()) {
++                Civi::$statics['db_common_dispatcher'] = Civi\Core\Container::singleton()->get('dispatcher');
++            }
++            else {
++                return $query;
++            }
++        }
++
++        $e = new \Civi\Core\Event\QueryEvent($query);
++        Civi::$statics['db_common_dispatcher']->dispatch('civi.db.query', $e);
++        // CRM-20445 ends.
++        return $e->query;
+     }
+ 
+     // }}}
+@@ -1882,7 +1894,7 @@
+      *
+      * @see PEAR_Error
+      */
+-    function &raiseError($code = DB_ERROR, $mode = null, $options = null,
++    function raiseError($code = DB_ERROR, $mode = null, $options = null,
+                          $userinfo = null, $nativecode = null, $dummy1 = null,
+                          $dummy2 = null)
+     {
+@@ -2255,6 +2267,20 @@
+     }
+ 
+     // }}}
++    // {{{ lastInsertId()
++
++   /**
++    * Get the most recently inserted Id
++    *
++    * @throws RuntimeException
++    */
++    function lastInsertId()
++    {
++        throw new \RuntimeException("Not implemented: " . get_class($this) . '::lastInsertId');
++    }
++
++    // }}}
++
+ }
+ 
+ /*
+diff -ruN DB/mysqli.php DB/mysqli.php
+--- DB/mysqli.php	2020-04-20 05:45:59.000000000 +1000
++++ DB/mysqli.php	2020-08-01 14:51:11.871272253 +1000
+@@ -314,7 +317,8 @@
+                     $dsn['password'],
+                     $dsn['database'],
+                     $dsn['port'],
+-                    $dsn['socket']))
++                    $dsn['socket'],
++                    MYSQLI_CLIENT_SSL))
+             {
+                 $this->connection = $init;
+             }
+@@ -1087,6 +1091,14 @@
+     }
+ 
+     // }}}
++    // {{{ lastInsertId()
++
++    function lastInsertId()
++    {
++        return mysqli_insert_id($this->connection);
++    }
++
++    // }}}
+ 
+ }
+ 
+diff -ruN DB/mysql.php DB/mysql.php
+--- DB/mysql.php	2020-04-20 05:45:59.000000000 +1000
++++ DB/mysql.php	2020-08-01 14:48:58.276132870 +1000
+@@ -1021,6 +1024,14 @@
+     }
+ 
+     // }}}
++    // {{{ lastInsertId()
++
++    function lastInsertId()
++    {
++        return mysql_insert_id($this->connection);
++    }
++
++    // }}}
+ 
+ }
+ 
+diff -ruN DB/storage.php DB/storage.php
+--- DB/storage.php   2020-04-20 05:45:59.000000000 +1000
++++ DB/storage.php       2020-08-01 15:24:40.814621336 +1000
+@@ -96,7 +96,7 @@
+      */
+     function __construct($table, $keycolumn, &$dbh, $validator = null)
+     {
+-        $this->PEAR('DB_Error');
++        parent::__construct('DB_Error');
+         $this->_table = $table;
+         $this->_keycolumn = $keycolumn;
+         $this->_dbh = $dbh;
+diff -ruN DB.php DB.php
+--- DB.php	2020-04-20 05:45:59.000000000 +1000
++++ DB.php	2020-08-01 14:43:45.338870953 +1000
+@@ -641,8 +646,12 @@
+                 . 'CREATE|DROP|'
+                 . 'LOAD DATA|SELECT .* INTO .* FROM|COPY|'
+                 . 'ALTER|GRANT|REVOKE|'
++                // CRM_Core_Transaction Tests fail without the following line.
++                . 'SAVEPOINT|ROLLBACK|'
+                 . 'LOCK|UNLOCK';
+-        if (preg_match('/^\s*"?(' . $manips . ')\s+/i', $query)) {
++        // First strip any leading comments
++        $queryString = (substr($query, 0, 2) === '/*') ? substr($query, strpos($query, '*/') + 2) : $query;
++        if (preg_match('/^\s*"?(' . $manips . ')\s+/i', $queryString)) {
+             return true;
+         }
+         return false;
+@@ -744,6 +754,16 @@
+      */
+     public static function parseDSN($dsn)
+     {
++
++        if (defined('DB_DSN_MODE') && DB_DSN_MODE === 'auto') {
++            if (extension_loaded('mysqli')) {
++                $dsn = preg_replace('/^mysql:/', 'mysqli:', $dsn);
++            }
++            else {
++                $dsn = preg_replace('/^mysqli:/', 'mysql:', $dsn);
++            }
++        }
++
+         $parsed = array(
+             'phptype'  => false,
+             'dbsyntax' => false,


### PR DESCRIPTION
Overview
----------------------------------------
Pear DB has been updated to include this patch https://github.com/pear/DB/pull/11/files of CiviCRM's and this upgrades the version we install and updates the patch to be compatible with the new version

Before
----------------------------------------
Pear DB version 1.10.0 used

After
----------------------------------------
Pear DB version 1.11.0 used

Plenty of unit tests cover this so if jenkins is happy we should be as well IMO