### PR TITLE
ActionSchedule - Pass real batches into TokenProcessor. Simplify CRM_Activity_Tokens.

### DIFF
--- a/CRM/Activity/Tokens.php
+++ b/CRM/Activity/Tokens.php
@@ -84,6 +84,7 @@ class CRM_Activity_Tokens extends AbstractTokenSubscriber {
     // Multiple revisions of the activity.
     // Q: Could we simplify & move the extra AND clauses into `where(...)`?
     $e->query->param('casEntityJoinExpr', 'e.id = reminder.entity_id AND e.is_current_revision = 1 AND e.is_deleted = 0');
+    $e->query->select('e.id AS tokenContext_' . $this->getEntityContextSchema());
   }
 
   /**
@@ -91,9 +92,7 @@ class CRM_Activity_Tokens extends AbstractTokenSubscriber {
    */
   public function prefetch(TokenValueEvent $e) {
     // Find all the entity IDs
-    $entityIds
-      = $e->getTokenProcessor()->getContextValues('actionSearchResult', 'entityID')
-      + $e->getTokenProcessor()->getContextValues($this->getEntityContextSchema());
+    $entityIds = $e->getTokenProcessor()->getContextValues($this->getEntityContextSchema());
 
     if (!$entityIds) {
       return NULL;
@@ -144,8 +143,7 @@ class CRM_Activity_Tokens extends AbstractTokenSubscriber {
       'activity_id' => 'id',
     ];
 
-    // Get ActivityID either from actionSearchResult (for scheduled reminders) if exists
-    $activityId = $row->context['actionSearchResult']->entityID ?? $row->context[$this->getEntityContextSchema()];
+    $activityId = $row->context[$this->getEntityContextSchema()];
 
     $activity = $prefetch['activity'][$activityId];
 

--- a/CRM/Core/BAO/ActionSchedule.php
+++ b/CRM/Core/BAO/ActionSchedule.php
@@ -269,40 +269,35 @@ FROM civicrm_action_schedule cas
       $multilingual = CRM_Core_I18n::isMultilingual();
       while ($dao->fetch()) {
         $errors = [];
-        try {
-          $tokenProcessor = self::createTokenProcessor($actionSchedule, $mapping);
-          $row = $tokenProcessor->addRow()
-            ->context('contactId', $dao->contactID)
-            ->context('actionSearchResult', (object) $dao->toArray());
+        $tokenProcessor = self::createTokenProcessor($actionSchedule, $mapping);
+        $row = $tokenProcessor->addRow()
+          ->context('contactId', $dao->contactID)
+          ->context('actionSearchResult', (object) $dao->toArray());
 
-          // switch language if necessary
-          if ($multilingual) {
-            $preferred_language = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Contact', $dao->contactID, 'preferred_language');
-            $row->context('locale', CRM_Core_BAO_ActionSchedule::pickLocale($actionSchedule->communication_language, $preferred_language));
-          }
-
-          foreach ($tokenProcessor->evaluate()->getRows() as $tokenRow) {
-            // It's possible, eg, that sendReminderEmail fires Hook::alterMailParams() and that some listener use ts().
-            $swapLocale = empty($row->context['locale']) ? NULL : \CRM_Utils_AutoClean::swapLocale($row->context['locale']);
-
-            if ($actionSchedule->mode === 'SMS' || $actionSchedule->mode === 'User_Preference') {
-              CRM_Utils_Array::extend($errors, self::sendReminderSms($tokenRow, $actionSchedule, $dao->contactID));
-            }
-
-            if ($actionSchedule->mode === 'Email' || $actionSchedule->mode === 'User_Preference') {
-              CRM_Utils_Array::extend($errors, self::sendReminderEmail($tokenRow, $actionSchedule, $dao->contactID));
-            }
-            // insert activity log record if needed
-            if ($actionSchedule->record_activity && empty($errors)) {
-              $caseID = empty($dao->case_id) ? NULL : $dao->case_id;
-              CRM_Core_BAO_ActionSchedule::createMailingActivity($tokenRow, $mapping, $dao->contactID, $dao->entityID, $caseID);
-            }
-
-            unset($swapLocale);
-          }
+        // switch language if necessary
+        if ($multilingual) {
+          $preferred_language = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Contact', $dao->contactID, 'preferred_language');
+          $row->context('locale', CRM_Core_BAO_ActionSchedule::pickLocale($actionSchedule->communication_language, $preferred_language));
         }
-        catch (\Civi\Token\TokenException $e) {
-          $errors['token_exception'] = $e->getMessage();
+
+        foreach ($tokenProcessor->evaluate()->getRows() as $tokenRow) {
+          // It's possible, eg, that sendReminderEmail fires Hook::alterMailParams() and that some listener use ts().
+          $swapLocale = empty($row->context['locale']) ? NULL : \CRM_Utils_AutoClean::swapLocale($row->context['locale']);
+
+          if ($actionSchedule->mode === 'SMS' || $actionSchedule->mode === 'User_Preference') {
+            CRM_Utils_Array::extend($errors, self::sendReminderSms($tokenRow, $actionSchedule, $dao->contactID));
+          }
+
+          if ($actionSchedule->mode === 'Email' || $actionSchedule->mode === 'User_Preference') {
+            CRM_Utils_Array::extend($errors, self::sendReminderEmail($tokenRow, $actionSchedule, $dao->contactID));
+          }
+          // insert activity log record if needed
+          if ($actionSchedule->record_activity && empty($errors)) {
+            $caseID = empty($dao->case_id) ? NULL : $dao->case_id;
+            CRM_Core_BAO_ActionSchedule::createMailingActivity($tokenRow, $mapping, $dao->contactID, $dao->entityID, $caseID);
+          }
+
+          unset($swapLocale);
         }
 
         // update action log record

--- a/CRM/Core/BAO/ActionSchedule.php
+++ b/CRM/Core/BAO/ActionSchedule.php
@@ -267,9 +267,8 @@ FROM civicrm_action_schedule cas
       );
 
       $multilingual = CRM_Core_I18n::isMultilingual();
+      $tokenProcessor = self::createTokenProcessor($actionSchedule, $mapping);
       while ($dao->fetch()) {
-        $errors = [];
-        $tokenProcessor = self::createTokenProcessor($actionSchedule, $mapping);
         $row = $tokenProcessor->addRow()
           ->context('contactId', $dao->contactID)
           ->context('actionSearchResult', (object) $dao->toArray());
@@ -279,26 +278,30 @@ FROM civicrm_action_schedule cas
           $preferred_language = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Contact', $dao->contactID, 'preferred_language');
           $row->context('locale', CRM_Core_BAO_ActionSchedule::pickLocale($actionSchedule->communication_language, $preferred_language));
         }
+      }
 
-        foreach ($tokenProcessor->evaluate()->getRows() as $tokenRow) {
-          // It's possible, eg, that sendReminderEmail fires Hook::alterMailParams() and that some listener use ts().
-          $swapLocale = empty($row->context['locale']) ? NULL : \CRM_Utils_AutoClean::swapLocale($row->context['locale']);
+      $tokenProcessor->evaluate();
+      foreach ($tokenProcessor->getRows() as $tokenRow) {
+        $dao = $tokenRow->context['actionSearchResult'];
+        $errors = [];
 
-          if ($actionSchedule->mode === 'SMS' || $actionSchedule->mode === 'User_Preference') {
-            CRM_Utils_Array::extend($errors, self::sendReminderSms($tokenRow, $actionSchedule, $dao->contactID));
-          }
+        // It's possible, eg, that sendReminderEmail fires Hook::alterMailParams() and that some listener use ts().
+        $swapLocale = empty($row->context['locale']) ? NULL : \CRM_Utils_AutoClean::swapLocale($row->context['locale']);
 
-          if ($actionSchedule->mode === 'Email' || $actionSchedule->mode === 'User_Preference') {
-            CRM_Utils_Array::extend($errors, self::sendReminderEmail($tokenRow, $actionSchedule, $dao->contactID));
-          }
-          // insert activity log record if needed
-          if ($actionSchedule->record_activity && empty($errors)) {
-            $caseID = empty($dao->case_id) ? NULL : $dao->case_id;
-            CRM_Core_BAO_ActionSchedule::createMailingActivity($tokenRow, $mapping, $dao->contactID, $dao->entityID, $caseID);
-          }
-
-          unset($swapLocale);
+        if ($actionSchedule->mode === 'SMS' || $actionSchedule->mode === 'User_Preference') {
+          CRM_Utils_Array::extend($errors, self::sendReminderSms($tokenRow, $actionSchedule, $dao->contactID));
         }
+
+        if ($actionSchedule->mode === 'Email' || $actionSchedule->mode === 'User_Preference') {
+          CRM_Utils_Array::extend($errors, self::sendReminderEmail($tokenRow, $actionSchedule, $dao->contactID));
+        }
+        // insert activity log record if needed
+        if ($actionSchedule->record_activity && empty($errors)) {
+          $caseID = empty($dao->case_id) ? NULL : $dao->case_id;
+          CRM_Core_BAO_ActionSchedule::createMailingActivity($tokenRow, $mapping, $dao->contactID, $dao->entityID, $caseID);
+        }
+
+        unset($swapLocale);
 
         // update action log record
         $logParams = [

--- a/CRM/Core/BAO/ActionSchedule.php
+++ b/CRM/Core/BAO/ActionSchedule.php
@@ -278,6 +278,15 @@ FROM civicrm_action_schedule cas
           $preferred_language = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Contact', $dao->contactID, 'preferred_language');
           $row->context('locale', CRM_Core_BAO_ActionSchedule::pickLocale($actionSchedule->communication_language, $preferred_language));
         }
+
+        foreach ($dao->toArray() as $key => $value) {
+          if (preg_match('/^tokenContext_(.*)/', $key, $m)) {
+            if (!in_array($m[1], $tokenProcessor->context['schema'])) {
+              $tokenProcessor->context['schema'][] = $m[1];
+            }
+            $row->context($m[1], $value);
+          }
+        }
       }
 
       $tokenProcessor->evaluate();

--- a/Civi/Token/TokenProcessor.php
+++ b/Civi/Token/TokenProcessor.php
@@ -256,7 +256,7 @@ class TokenProcessor {
    *   Each row is presented with a fluent, OOP facade.
    */
   public function getRows() {
-    return new TokenRowIterator($this, new \ArrayIterator($this->rowContexts));
+    return new TokenRowIterator($this, new \ArrayIterator($this->rowContexts ?: []));
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------

When sending scheduled reminders, the method `ActionSchedule::sendMailings()` fetches a batch of pending reminders then composes+delivers a message for each. This PR changes the batch mechanics with an aim toward future simplifications in `CRM_*_Tokens`.

(Depends: #21085. Extracted from #21079.)

Before
----------------------------------------

For *each item in the batch*, it makes a *new and separate* instance of `TokenProcessor`.  This means that the `TokenProcessor` only sees one pending reminder at a time. Thus, a method like `CRM_Activity_Tokens::prefetch()` can only prefetch one record at a time. In the context of scheduled reminders, `prefetch()` cannot meaningfully fetch batched data.

(*This is why several variants of `CRM_*_Tokens` implement duplicate data-loads. eg One general-purpose data-load uses `$context['activityId']`+`prefetch()`; but an auxiliary data-load is needed for ActionSchedules.  It uses `$context['actionSearchResult']`+`alterActionScheduleQuery()`.*)

After
----------------------------------------

It creates one `TokenProcessor` and adds multiple rows (one row for each pending reminder).  This means a method like `CRM_Activity_Tokens::prefetch()` can see a full batch. In the context of scheduled reminders, `TokenProcessor` can meaningfully fetch batched data.

(*This means that we don't need duplicate data-loads. The variants based on `$context['actionSearchResult']`+`alterActionScheduleQuery()` can become redundant.*)

Comments
----------------------------------------

To demonstrate that the change works, the PR also updates `CRM_Activity_Tokens` to rely on the new mechanics and to pare-down `actionSearchResult`.

There is a fair amount of test-coverage for scheduled-reminders and tokens in `CRM_Core_BAO_ActionScheduleTest` and `CRM_Activity_ActionMappingTest`. The correctness of the PR mostly rests on the existing tests.