### PR TITLE
Scheduled Reminders UI - Show more activity tokens in admin GUI

### DIFF
--- a/CRM/Admin/Form/ScheduleReminders.php
+++ b/CRM/Admin/Form/ScheduleReminders.php
@@ -695,8 +695,14 @@ class CRM_Admin_Form_ScheduleReminders extends CRM_Admin_Form {
    * @return array
    */
   public function listTokens() {
-    $tokens = CRM_Core_SelectValues::contactTokens();
-    $tokens = array_merge(CRM_Core_SelectValues::activityTokens(), $tokens);
+    $tokenProcessor = new \Civi\Token\TokenProcessor(\Civi::dispatcher(), [
+      'controller' => get_class(),
+      'smarty' => FALSE,
+      'schema' => ['activityId'],
+    ]);
+    $tokens = $tokenProcessor->listTokens();
+
+    $tokens = array_merge(CRM_Core_SelectValues::contactTokens(), $tokens);
     $tokens = array_merge(CRM_Core_SelectValues::eventTokens(), $tokens);
     $tokens = array_merge(CRM_Core_SelectValues::membershipTokens(), $tokens);
     $tokens = array_merge(CRM_Core_SelectValues::contributionTokens(), $tokens);


### PR DESCRIPTION
Overview
----------------------------------------

In "Administer => Communications => Scheduled Reminders", this updates the token-picker  to include a more complete list of activity tokens.

This is extracted from @mattwire's branch in #16983.

Before
----------------------------------------
<img width="743" alt="Screen Shot 2021-08-10 at 9 18 25 PM" src="https://user-images.githubusercontent.com/1336047/128969051-67f70b69-0fa5-4b5c-8b29-c29d10cdb991.png">

After
----------------------------------------

<img width="745" alt="Screen Shot 2021-08-10 at 9 19 00 PM" src="https://user-images.githubusercontent.com/1336047/128969053-03dade20-1029-416e-bb9c-7587cda16cd9.png">

