### PR TITLE
Respect http_timeout core setting for Guzzle HTTP requests

### DIFF
--- a/CRM/Utils/Address/USPS.php
+++ b/CRM/Utils/Address/USPS.php
@@ -74,6 +74,7 @@ class CRM_Utils_Address_USPS {
         'API' => 'Verify',
         'XML' => $XMLQuery,
       ],
+      'timeout' => \Civi::settings()->get('http_timeout'),
     ]);
 
     $session = CRM_Core_Session::singleton();

--- a/CRM/Utils/Geocode/Google.php
+++ b/CRM/Utils/Geocode/Google.php
@@ -106,7 +106,7 @@ class CRM_Utils_Geocode_Google {
     $query = 'https://' . self::$_server . self::$_uri . $add;
 
     $client = new GuzzleHttp\Client();
-    $request = $client->request('GET', $query);
+    $request = $client->request('GET', $query, ['timeout' => \Civi::settings()->get('http_timeout')]);
     $string = $request->getBody();
 
     libxml_use_internal_errors(TRUE);

--- a/ext/recaptcha/lib/recaptcha/recaptchalib.php
+++ b/ext/recaptcha/lib/recaptcha/recaptchalib.php
@@ -67,7 +67,7 @@ function _recaptcha_qsencode ($data) {
 function _recaptcha_http_post($host, $path, $data) {
   $client = new Client();
   try {
-    $response = $client->request('POST', $host . '/' . $path, ['query' => $data]);
+    $response = $client->request('POST', $host . '/' . $path, ['query' => $data, 'timeout' => \Civi::settings()->get('http_timeout')]);
   }
   catch (Exception $e) {
     return '';


### PR DESCRIPTION
Overview
----------------------------------------
CiviCRM core has a `http_timeout` setting but USPS, Google geocode and recaptcha is not respecting that timeout and using guzzle default which is 0 (unlimited wait).

Before
----------------------------------------
Guzzle HTTP requests not respecting core `http_timeout` setting.

After
----------------------------------------
Guzzle HTTP requests respecting core `http_timeout` setting (default 5).

Technical Details
----------------------------------------

Comments
----------------------------------------

