### PR TITLE
Switch extension downloader and extensions feed to use Guzzle HTTP library

### DIFF
--- a/CRM/Extension/Browser.php
+++ b/CRM/Extension/Browser.php
@@ -41,6 +41,25 @@ class CRM_Extension_Browser {
   const CHECK_TIMEOUT = 5;
 
   /**
+   * @var GuzzleHttp\Client
+   */
+  protected $guzzleClient;
+
+  /**
+   * @return \GuzzleHttp\Client
+   */
+  public function getGuzzleClient(): \GuzzleHttp\Client {
+    return $this->guzzleClient ?? new \GuzzleHttp\Client();
+  }
+
+  /**
+   * @param \GuzzleHttp\Client $guzzleClient
+   */
+  public function setGuzzleClient(\GuzzleHttp\Client $guzzleClient) {
+    $this->guzzleClient = $guzzleClient;
+  }
+
+  /**
    * @param string $repoUrl
    *   URL of the remote repository.
    * @param string $indexPath
@@ -230,7 +249,7 @@ class CRM_Extension_Browser {
     $filename = $this->cacheDir . DIRECTORY_SEPARATOR . self::CACHE_JSON_FILE . '.' . md5($this->getRepositoryUrl());
     $url = $this->getRepositoryUrl() . $this->indexPath;
 
-    $client = new GuzzleHttp\Client();
+    $client = $this->getGuzzleClient();
     $response = $client->request('GET', $url, ['sink' => $filename, 'timeout' => \Civi::settings()->get('http_timeout')]);
     restore_error_handler();
 

--- a/CRM/Extension/Downloader.php
+++ b/CRM/Extension/Downloader.php
@@ -16,6 +16,26 @@
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
 class CRM_Extension_Downloader {
+
+  /**
+   * @var GuzzleHttp\Client
+   */
+  protected $guzzleClient;
+
+  /**
+   * @return \GuzzleHttp\Client
+   */
+  public function getGuzzleClient(): \GuzzleHttp\Client {
+    return $this->guzzleClient ?? new \GuzzleHttp\Client();
+  }
+
+  /**
+   * @param \GuzzleHttp\Client $guzzleClient
+   */
+  public function setGuzzleClient(\GuzzleHttp\Client $guzzleClient) {
+    $this->guzzleClient = $guzzleClient;
+  }
+
   /**
    * @var CRM_Extension_Container_Basic
    * The place where downloaded extensions are ultimately stored
@@ -136,7 +156,7 @@ class CRM_Extension_Downloader {
    *   Whether the download was successful.
    */
   public function fetch($remoteFile, $localFile) {
-    $client = new GuzzleHttp\Client();
+    $client = $this->getGuzzleClient();
     $response = $client->request('GET', $remoteFile, ['sink' => $localFile, 'timeout' => \Civi::settings()->get('http_timeout')]);
     if ($response->getStatusCode() === 200) {
       return TRUE;

--- a/CRM/Extension/Downloader.php
+++ b/CRM/Extension/Downloader.php
@@ -136,14 +136,12 @@ class CRM_Extension_Downloader {
    *   Whether the download was successful.
    */
   public function fetch($remoteFile, $localFile) {
-    $result = CRM_Utils_HttpClient::singleton()->fetch($remoteFile, $localFile);
-    switch ($result) {
-      case CRM_Utils_HttpClient::STATUS_OK:
-        return TRUE;
-
-      default:
-        return FALSE;
+    $client = new GuzzleHttp\Client();
+    $response = $client->request('GET', $remoteFile, ['sink' => $localFile, 'timeout' => \Civi::settings()->get('http_timeout')]);
+    if ($response->getStatusCode() === 200) {
+      return TRUE;
     }
+    return FALSE;
   }
 
   /**

--- a/tests/phpunit/CRM/Extension/BrowserTest.php
+++ b/tests/phpunit/CRM/Extension/BrowserTest.php
@@ -6,32 +6,62 @@
  */
 class CRM_Extension_BrowserTest extends CiviUnitTestCase {
 
+  use \Civi\Test\GuzzleTestTrait;
+
+  /**
+   * @var CRM_Extension_Browser
+   */
+  protected $browser;
+
+  /**
+   * Get the expected response from browser extension.
+   *
+   * @return array
+   */
+  protected function getExpectedResponse() {
+    return [
+      '{"test.crm.extension.browsertest.a":"<extension key=\'test.crm.extension.browsertest.a\' type=\'report\'>\n  <file>main<\/file>\n  <name>test_crm_extension_browsertest_a<\/name>\n  <description>Brought to you by the letter \"A\"<\/description>\n  <version>0.1<\/version>\n  <downloadUrl>http:\/\/example.com\/test.crm.extension.browsertest.a-0.1.zip<\/downloadUrl>\n  <typeInfo>\n    <reportUrl>test\/extension\/browsertest\/a<\/reportUrl>\n    <component>CiviContribute<\/component>\n  <\/typeInfo>\n<\/extension>\n","test.crm.extension.browsertest.b":"<extension key=\'test.crm.extension.browsertest.b\' type=\'module\'>\n  <file>moduletest<\/file>\n  <name>test_crm_extension_browsertest_b<\/name>\n  <version>1.2<\/version>\n  <downloadUrl>http:\/\/example.com\/test.crm.extension.browsertest.b-1.2.zip<\/downloadUrl>\n  <description>Brought to you by the letter \"B\"<\/description>\n<\/extension>\n"}',
+    ];
+  }
+
+  /**
+   * Add a mock handler to the extension browser for testing.
+   *
+   */
+  protected function setupMockHandler() {
+    $responses = $this->getExpectedResponse();
+    $this->createMockHandler($responses);
+    $this->setUpClientWithHistoryContainer();
+    $this->browser->setGuzzleClient($this->getGuzzleClient());
+  }
+
   public function testDisabled() {
-    $browser = new CRM_Extension_Browser(FALSE, '/index.html', 'file:///itd/oesn/tmat/ter');
-    $this->assertEquals(FALSE, $browser->isEnabled());
-    $this->assertEquals([], $browser->checkRequirements());
-    $this->assertEquals([], $browser->getExtensions());
+    $this->browser = new CRM_Extension_Browser(FALSE, '/index.html', 'file:///itd/oesn/tmat/ter');
+    $this->assertEquals(FALSE, $this->browser->isEnabled());
+    $this->assertEquals([], $this->browser->checkRequirements());
+    $this->assertEquals([], $this->browser->getExtensions());
   }
 
   public function testCheckRequirements_BadCachedir_false() {
-    $browser = new CRM_Extension_Browser('file://' . dirname(__FILE__) . '/dataset/good-repository', NULL, FALSE);
-    $this->assertEquals(TRUE, $browser->isEnabled());
-    $reqs = $browser->checkRequirements();
+    $this->browser = new CRM_Extension_Browser('file://' . dirname(__FILE__) . '/dataset/good-repository', NULL, FALSE);
+    $this->assertEquals(TRUE, $this->browser->isEnabled());
+    $reqs = $this->browser->checkRequirements();
     $this->assertEquals(1, count($reqs));
   }
 
   public function testCheckRequirements_BadCachedir_nonexistent() {
-    $browser = new CRM_Extension_Browser('file://' . dirname(__FILE__) . '/dataset/good-repository', NULL, '/tot/all/yin/v/alid');
-    $this->assertEquals(TRUE, $browser->isEnabled());
-    $reqs = $browser->checkRequirements();
+    $this->browser = new CRM_Extension_Browser('file://' . dirname(__FILE__) . '/dataset/good-repository', NULL, '/tot/all/yin/v/alid');
+    $this->assertEquals(TRUE, $this->browser->isEnabled());
+    $reqs = $this->browser->checkRequirements();
     $this->assertEquals(1, count($reqs));
   }
 
   public function testGetExtensions_good() {
-    $browser = new CRM_Extension_Browser('file://' . dirname(__FILE__) . '/dataset/good-repository', NULL, $this->createTempDir('ext-cache-'));
-    $this->assertEquals(TRUE, $browser->isEnabled());
-    $this->assertEquals([], $browser->checkRequirements());
-    $exts = $browser->getExtensions();
+    $this->browser = new CRM_Extension_Browser('file://' . dirname(__FILE__) . '/dataset/good-repository', NULL, $this->createTempDir('ext-cache-'));
+    $this->assertEquals(TRUE, $this->browser->isEnabled());
+    $this->assertEquals([], $this->browser->checkRequirements());
+    $this->setupMockHandler();
+    $exts = $this->browser->getExtensions();
     $keys = array_keys($exts);
     sort($keys);
     $this->assertEquals(['test.crm.extension.browsertest.a', 'test.crm.extension.browsertest.b'], $keys);
@@ -42,21 +72,21 @@ class CRM_Extension_BrowserTest extends CiviUnitTestCase {
   }
 
   public function testGetExtension_good() {
-    $browser = new CRM_Extension_Browser('file://' . dirname(__FILE__) . '/dataset/good-repository', NULL, $this->createTempDir('ext-cache-'));
-    $this->assertEquals(TRUE, $browser->isEnabled());
-    $this->assertEquals([], $browser->checkRequirements());
-
-    $info = $browser->getExtension('test.crm.extension.browsertest.b');
+    $this->browser = new CRM_Extension_Browser('file://' . dirname(__FILE__) . '/dataset/good-repository', NULL, $this->createTempDir('ext-cache-'));
+    $this->assertEquals(TRUE, $this->browser->isEnabled());
+    $this->assertEquals([], $this->browser->checkRequirements());
+    $this->setupMockHandler();
+    $info = $this->browser->getExtension('test.crm.extension.browsertest.b');
     $this->assertEquals('module', $info->type);
     $this->assertEquals('http://example.com/test.crm.extension.browsertest.b-1.2.zip', $info->downloadUrl);
   }
 
   public function testGetExtension_nonexistent() {
-    $browser = new CRM_Extension_Browser('file://' . dirname(__FILE__) . '/dataset/good-repository', NULL, $this->createTempDir('ext-cache-'));
-    $this->assertEquals(TRUE, $browser->isEnabled());
-    $this->assertEquals([], $browser->checkRequirements());
-
-    $info = $browser->getExtension('test.crm.extension.browsertest.nonexistent');
+    $this->browser = new CRM_Extension_Browser('file://' . dirname(__FILE__) . '/dataset/good-repository', NULL, $this->createTempDir('ext-cache-'));
+    $this->assertEquals(TRUE, $this->browser->isEnabled());
+    $this->assertEquals([], $this->browser->checkRequirements());
+    $this->setupMockHandler();
+    $info = $this->browser->getExtension('test.crm.extension.browsertest.nonexistent');
     $this->assertEquals(NULL, $info);
   }
 

--- a/tests/phpunit/api/v3/ExtensionTest.php
+++ b/tests/phpunit/api/v3/ExtensionTest.php
@@ -22,9 +22,10 @@
  */
 class api_v3_ExtensionTest extends CiviUnitTestCase {
 
+  use \Civi\Test\GuzzleTestTrait;
+
   public function setUp(): void {
-    $url = 'file://' . dirname(dirname(dirname(dirname(__FILE__)))) . '/mock/extension_browser_results';
-    Civi::settings()->set('ext_repo_url', $url);
+    Civi::settings()->set('ext_repo_url', 'http://localhost:9999/fake-repo');
   }
 
   public function tearDown(): void {
@@ -35,10 +36,18 @@ class api_v3_ExtensionTest extends CiviUnitTestCase {
    * Test getremote.
    */
   public function testGetremote() {
+    $testsDir = dirname(dirname(dirname(dirname(__FILE__))));
+    $this->createMockHandler([file_get_contents($testsDir . '/mock/extension_browser_results/single')]);
+    $this->setUpClientWithHistoryContainer();
+    CRM_Extension_System::singleton()->getBrowser()->setGuzzleClient($this->getGuzzleClient());
+    CRM_Extension_System::singleton()->getBrowser()->refresh();
+
     $result = $this->callAPISuccess('extension', 'getremote', []);
     $this->assertEquals('org.civicrm.module.cividiscount', $result['values'][0]['key']);
     $this->assertEquals('module', $result['values'][0]['type']);
     $this->assertEquals('CiviDiscount', $result['values'][0]['name']);
+
+    $this->assertEquals(['http://localhost:9999/fake-repo/single'], $this->getRequestUrls());
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Switch extension download and extensions feed to use Guzzle HTTP library.

This fixes some situations (eg. shared servers with open_basedir restrictions in effect) where zip file was not downloaded properly and extension could not be updated.
It also means that we are no longer using our custom `CRM_Utils_HttpClient::fetch()` function from within civicrm core.

Before
----------------------------------------
Using civicrm core function `CRM_Utils_HttpClient::fetch()` which uses cURL internally.

After
----------------------------------------
Using guzzle HTTP library which has been shipped with core for a long time now.

Fixes some situations (eg. shared servers with open_basedir restrictions in effect) where zip file was not downloaded properly and extension could not be updated.

Technical Details
----------------------------------------
Simple change, following existing code examples within civicrm core.

Comments
----------------------------------------

