### PR TITLE
dev/core#2743 fix api v3 to not unnecessarily load options

### DIFF
--- a/api/v3/utils.php
+++ b/api/v3/utils.php
@@ -2078,9 +2078,14 @@ function _civicrm_api3_validate_integer(&$params, $fieldName, &$fieldInfo, $enti
         $fieldValue = NULL;
       }
     }
-    if (!empty($fieldInfo['pseudoconstant']) || !empty($fieldInfo['options']) || $fieldName === 'campaign_id') {
+    if (
+    (!empty($fieldInfo['pseudoconstant']) || !empty($fieldInfo['options']) || $fieldName === 'campaign_id')
+     // if it is already numeric AND it is an FK field we don't need to validate because
+     // sql will do that for us on insert (this also saves a big lookup)
+     && (!is_numeric($fieldValue) || empty($fieldInfo['FKClassName']))
+    ) {
       $additional_lookup_params = [];
-      if (strtolower($entity) == 'address' && $fieldName == 'state_province_id') {
+      if (strtolower($entity) === 'address' && $fieldName == 'state_province_id') {
         $country_id = _civicrm_api3_resolve_country_id($params);
         if (!empty($country_id)) {
           $additional_lookup_params = ['country_id' => $country_id];

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -1204,10 +1204,10 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
    * In the interests of removing financial type / contribution type checks from
    * legacy format function lets test that the api is doing this for us
    */
-  public function testCreateInvalidFinancialType() {
+  public function testCreateInvalidFinancialType(): void {
     $params = $this->_params;
     $params['financial_type_id'] = 99999;
-    $this->callAPIFailure($this->entity, 'create', $params, "'99999' is not a valid option for field financial_type_id");
+    $this->callAPIFailure($this->entity, 'create', $params);
   }
 
   /**

--- a/tests/phpunit/api/v3/MembershipTest.php
+++ b/tests/phpunit/api/v3/MembershipTest.php
@@ -915,23 +915,6 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
     );
   }
 
-  public function testMembershipCreateWithInvalidStatus() {
-    $params = $this->_params;
-    $params['status_id'] = 999;
-    $this->callAPIFailure('membership', 'create', $params,
-      "'999' is not a valid option for field status_id"
-    );
-  }
-
-  public function testMembershipCreateWithInvalidType() {
-    $params = $this->_params;
-    $params['membership_type_id'] = 999;
-
-    $this->callAPIFailure('membership', 'create', $params,
-      "'999' is not a valid option for field membership_type_id"
-    );
-  }
-
   /**
    * Check with complete array + custom field
    * Note that the test is written on purpose without any


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#2743 fix api v3 to not unnecessarily load options

Before
----------------------------------------
Campaign options loaded for verification even when its already an int

After
----------------------------------------
Only loaded if needed

Technical Details
----------------------------------------
We don't need to validate if already numeric

Comments
----------------------------------------
@colemanw this is actually very similar to @pfigel's hack & I think it makes sense for the rc 