### PR TITLE
dev/core#2749 remove exception when no payment processor configured when no payment processor configured

### DIFF
--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -848,9 +848,6 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
       // It's not clear why we set this on the form.
       $this->set('paymentProcessors', $this->_paymentProcessors);
     }
-    else {
-      throw new CRM_Core_Exception(ts('A payment processor configured for this page might be disabled (contact the site administrator for assistance).'));
-    }
   }
 
   /**

--- a/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
@@ -1371,10 +1371,10 @@ Price Field - Price Field 1        1   $ 100.00      $ 100.00
    * @throws \CRM_Core_Exception
    * @throws \CRM_Contribute_Exception_InactiveContributionPageException
    */
-  public function testContributionBasePreProcess() {
+  public function testContributionBasePreProcess(): void {
     //Create contribution page with only pay later enabled.
     $params = [
-      'title' => "Test Contribution Page",
+      'title' => 'Test Contribution Page',
       'financial_type_id' => 1,
       'currency' => 'NZD',
       'goal_amount' => 100,
@@ -1387,7 +1387,7 @@ Price Field - Price Field 1        1   $ 100.00      $ 100.00
       'receipt_from_name' => 'Ego Freud',
     ];
 
-    $page1 = $this->callAPISuccess("contribution_page", 'create', $params);
+    $page1 = $this->callAPISuccess('ContributionPage', 'create', $params);
 
     //Execute CRM_Contribute_Form_ContributionBase preProcess
     //and check the assignment of payment processors
@@ -1397,25 +1397,18 @@ Price Field - Price Field 1        1   $ 100.00      $ 100.00
     $_REQUEST['id'] = $page1['id'];
 
     $form->preProcess();
-    $this->assertEquals($form->_paymentProcessor['name'], 'pay_later');
+    $this->assertEquals('pay_later', $form->_paymentProcessor['name']);
 
     //Disable all the payment processor for the contribution page.
     $params['is_pay_later'] = 0;
-    $page2 = $this->callAPISuccess("contribution_page", 'create', $params);
+    $page2 = $this->callAPISuccess('ContributionPage', 'create', $params);
 
     //Assert an exception is thrown on loading the contribution page.
     $form = new CRM_Contribute_Form_ContributionBase();
     $form->controller = new CRM_Core_Controller();
     $_REQUEST['id'] = $page2['id'];
     $form->set('id', $page2['id']);
-    try {
-      $form->preProcess();
-    }
-    catch (CRM_Core_Exception $e) {
-      $this->assertStringContainsString("A payment processor configured for this page might be disabled (contact the site administrator for assistance).", $e->getMessage());
-      return;
-    }
-    $this->fail('Exception was expected');
+    $form->preProcess();
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#2749 remove exception when no payment processor configured when no payment processor configured

Before
----------------------------------------
Regression - contribution page will not load for free events with exception about no processors

After
----------------------------------------
Exception removed - potentially less information if the contribution page is misconfigured - but on the flip side it's a little less easy to misconfigure than it was before the change that caused this regression

Technical Details
----------------------------------------

This is an attempt to fix a regression https://lab.civicrm.org/dev/core/-/issues/2749
when there are legitimately no payment processors assigned to a page.

I feel like the configuration screens are adequate to enforce this & having an exception like
this in the assign function is the wrong place.

The original issue is that the is_monetary box was not checked & hence the
processor wasn't assigned. This felt like asking users to understand that
a payment method when money options are configured

Comments
----------------------------------------
@MegaphoneJon 