### PR TITLE
dev/user-interface#37 Reinstate jQueryUI visible focus effect in quicksearch

### DIFF
--- a/js/crm.menubar.js
+++ b/js/crm.menubar.js
@@ -314,6 +314,12 @@
             });
           },
           focus: function (event, ui) {
+            // This is when an item is 'focussed' by keyboard up/down or mouse hover.
+            // It is not the same as actually having focus, i.e. it is not :focus
+            var lis = $(event.currentTarget).find('li[data-cid="' + ui.item.value + '"]');
+            lis.children('div').addClass('ui-state-active');
+            lis.siblings().children('div').removeClass('ui-state-active');
+            // Returning false leaves the user-entered text as it was.
             return false;
           },
           select: function (event, ui) {
@@ -340,6 +346,7 @@
         .autocomplete( "instance" )._renderItem = function( ul, item ) {
           var uiMenuItemWrapper = $("<div class='ui-menu-item-uiMenuItemWrapper'>");
           if (item.value == 0) {
+            // "No results"
             uiMenuItemWrapper.text(item.label);
           }
           else {
@@ -359,7 +366,7 @@
               }));
           }
 
-          return $( "<li class='ui-menu-item'>" )
+          return $( "<li class='ui-menu-item' data-cid=" + item.value + ">" )
             .append(uiMenuItemWrapper)
             .appendTo( ul );
         };


### PR DESCRIPTION
… issue 37

Overview
----------------------------------------

Fixes the issue at https://lab.civicrm.org/dev/user-interface/-/issues/37



Before
----------------------------------------

Pressing keyboard up/down in quicksearch results made no visible changes


After
----------------------------------------

Pressing keyboard up/down in quicksearch results visually shows the 'focussed' item.


Technical Details
----------------------------------------

Adds the ui-state-active class to the element that jQueryUI says has 'focus'


Comments
----------------------------------------

Fixes regression brought in by https://github.com/civicrm/civicrm-core/pull/19779

