### PR TITLE
dev/user-interface#38 Contact Edit: Only display signatures if contact has a CMS account

### DIFF
--- a/CRM/Contact/Form/Edit/Email.php
+++ b/CRM/Contact/Form/Edit/Email.php
@@ -81,14 +81,19 @@ class CRM_Contact_Form_Edit_Email {
       $form->addElement('radio', "email[$blockId][is_primary]", '', '', '1', $js);
 
       if (CRM_Utils_System::getClassName($form) == 'CRM_Contact_Form_Contact') {
-
-        $form->add('textarea', "email[$blockId][signature_text]", ts('Signature (Text)'),
-          ['rows' => 2, 'cols' => 40]
-        );
-
-        $form->add('wysiwyg', "email[$blockId][signature_html]", ts('Signature (HTML)'),
-          ['rows' => 2, 'cols' => 40]
-        );
+        // Only display the signature fields if this contact has a CMS account
+        // because they can only send email if they have access to the CRM
+        if (!empty($form->_contactId)) {
+          $ufID = CRM_Core_BAO_UFMatch::getUFId($form->_contactId);
+          if ($ufID) {
+            $form->add('textarea', "email[$blockId][signature_text]", ts('Signature (Text)'),
+              ['rows' => 2, 'cols' => 40]
+            );
+            $form->add('wysiwyg', "email[$blockId][signature_html]", ts('Signature (HTML)'),
+              ['rows' => 2, 'cols' => 40]
+            );
+          }
+        }
       }
     }
   }

--- a/templates/CRM/Contact/Form/Edit/Email.tpl
+++ b/templates/CRM/Contact/Form/Edit/Email.tpl
@@ -26,8 +26,8 @@
 
 <tr id="Email_Block_{$blockId}">
   <td>{$form.email.$blockId.email.html|crmAddClass:email}&nbsp;{$form.email.$blockId.location_type_id.html}
-    <div class="clear"></div>
-    {if $className eq 'CRM_Contact_Form_Contact'}
+    {if $className eq 'CRM_Contact_Form_Contact' and !empty($form.email.$blockId.signature_html.html)}
+      <div class="clear"></div>
       <div class="email-signature crm-collapsible collapsed">
         <div class="collapsible-title">
           {ts}Signature{/ts}


### PR DESCRIPTION
Overview
----------------------------------------

* Gitlab discussion: https://lab.civicrm.org/dev/user-interface/-/issues/38
* User-interface discussion: https://chat.civicrm.org/civicrm/pl/ptjc1t6qxp8tzkgyrgyzgmdpqy (1 thumbs-up) :)

When editing a contact, we have an option to add an email signature which is then used when sending emails from CiviCRM (via Contact > Actions > Email).

It looks something like this:

![image](https://user-images.githubusercontent.com/254741/129205442-2dd71a3d-76dd-4789-9252-5c95c19a6de0.png)

Expanding the signature block displays a WYSIWYG and text field to enter an email signature.

This small link is easy to ignore by experienced CiviCRM users, but pretty overwhelming to new CiviCRM users. Not only does expanding explode the UI in a pretty scary way, it's also in an area of CiviCRM that is very overwhelming (location type, On Hold, Mass Mail?, Primary?, Delete).

Before
----------------------------------------

Email signature is always displayed:

![image](https://user-images.githubusercontent.com/254741/129205442-2dd71a3d-76dd-4789-9252-5c95c19a6de0.png)

After
----------------------------------------

Email signature is only displayed if the Contact displayed has a CMS account.

![ui38-nosig-2021-08-12_09-32](https://user-images.githubusercontent.com/254741/129205679-2650fb1a-1392-4ad3-8905-19faaeeaad85.png)

If the contact has a CMS account, the signature works the same as before:

![image](https://user-images.githubusercontent.com/254741/129205791-6072cfdb-ac36-451e-bd87-d80b62720454.png)


Comments
----------------------------------------

There was Gitlab discussion that the email signature does not really belong here at all (and I agree), but that's a bigger change and requires more reflexion about the concept of user preferences.