### PR TITLE
dev/core#2634 Add v4 Membership api, access it via order

### DIFF
--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -339,70 +339,80 @@ class CRM_Member_BAO_Membership extends CRM_Member_DAO_Membership {
     }
 
     $params['membership_id'] = $membership->id;
-    // @todo further cleanup required to remove use of $ids['contribution'] from here
-    if (isset($ids['membership'])) {
-      $contributionID = CRM_Core_DAO::getFieldValue('CRM_Member_DAO_MembershipPayment',
-        $membership->id,
-        'contribution_id',
-        'membership_id'
-      );
-      // @todo this is a temporary step to removing $ids['contribution'] completely
-      if (empty($params['contribution_id']) && !empty($contributionID)) {
-        $params['contribution_id'] = $contributionID;
+    // For api v4 we skip all of this stuff. There is an expectation that v4 users either use
+    // the order api, or handle any financial / related processing themselves.
+    // Note that the processing below is fairly intertwined with core usage and in some places
+    // problematic or to be removed.
+    // Note the choice of 'version' as a parameter is to make it
+    // unavailable through apiv3.
+    // once we are rid of direct calls to the BAO::create from core
+    // we will deprecate this stuff into the v3 api.
+    if (($params['version'] ?? 0) !== 4) {
+      // @todo further cleanup required to remove use of $ids['contribution'] from here
+      if (isset($ids['membership'])) {
+        $contributionID = CRM_Core_DAO::getFieldValue('CRM_Member_DAO_MembershipPayment',
+          $membership->id,
+          'contribution_id',
+          'membership_id'
+        );
+        // @todo this is a temporary step to removing $ids['contribution'] completely
+        if (empty($params['contribution_id']) && !empty($contributionID)) {
+          $params['contribution_id'] = $contributionID;
+        }
       }
-    }
 
-    // This code ensures a line item is created but it is recommended you pass in 'skipLineItem' or 'line_item'
-    if (empty($params['line_item']) && !empty($params['membership_type_id']) && empty($params['skipLineItem'])) {
-      CRM_Price_BAO_LineItem::getLineItemArray($params, NULL, 'membership', $params['membership_type_id']);
-    }
-    $params['skipLineItem'] = TRUE;
-
-    // Record contribution for this membership and create a MembershipPayment
-    // @todo deprecate this.
-    if (!empty($params['contribution_status_id'])) {
-      $memInfo = array_merge($params, ['membership_id' => $membership->id]);
-      $params['contribution'] = self::recordMembershipContribution($memInfo);
-    }
-
-    // If the membership has no associated contribution then we ensure
-    // the line items are 'correct' here. This is a lazy legacy
-    // hack whereby they are deleted and recreated
-    if (empty($contributionID)) {
-      if (!empty($params['lineItems'])) {
-        $params['line_item'] = $params['lineItems'];
+      // This code ensures a line item is created but it is recommended you pass in 'skipLineItem' or 'line_item'
+      if (empty($params['line_item']) && !empty($params['membership_type_id']) && empty($params['skipLineItem'])) {
+        CRM_Price_BAO_LineItem::getLineItemArray($params, NULL, 'membership', $params['membership_type_id']);
       }
-      // do cleanup line items if membership edit the Membership type.
-      if (!empty($ids['membership'])) {
-        CRM_Price_BAO_LineItem::deleteLineItems($ids['membership'], 'civicrm_membership');
-      }
-      // @todo - we should ONLY do the below if a contribution is created. Let's
-      // get some deprecation notices in here & see where it's hit & work to eliminate.
-      // This could happen if there is no contribution or we are in one of many
-      // weird and wonderful flows. This is scary code. Keep adding tests.
-      if (!empty($params['line_item']) && empty($params['contribution_id'])) {
+      $params['skipLineItem'] = TRUE;
 
-        foreach ($params['line_item'] as $priceSetId => $lineItems) {
-          foreach ($lineItems as $lineIndex => $lineItem) {
-            $lineMembershipType = $lineItem['membership_type_id'] ?? NULL;
-            if (!empty($params['contribution'])) {
-              $params['line_item'][$priceSetId][$lineIndex]['contribution_id'] = $params['contribution']->id;
-            }
-            if ($lineMembershipType && $lineMembershipType == ($params['membership_type_id'] ?? NULL)) {
-              $params['line_item'][$priceSetId][$lineIndex]['entity_id'] = $membership->id;
-              $params['line_item'][$priceSetId][$lineIndex]['entity_table'] = 'civicrm_membership';
-            }
-            elseif (!$lineMembershipType && !empty($params['contribution'])) {
-              $params['line_item'][$priceSetId][$lineIndex]['entity_id'] = $params['contribution']->id;
-              $params['line_item'][$priceSetId][$lineIndex]['entity_table'] = 'civicrm_contribution';
+      // Record contribution for this membership and create a MembershipPayment
+      // @todo deprecate this.
+      if (!empty($params['contribution_status_id'])) {
+        $memInfo = array_merge($params, ['membership_id' => $membership->id]);
+        $params['contribution'] = self::recordMembershipContribution($memInfo);
+      }
+
+      // If the membership has no associated contribution then we ensure
+      // the line items are 'correct' here. This is a lazy legacy
+      // hack whereby they are deleted and recreated
+      if (empty($contributionID)) {
+        if (!empty($params['lineItems'])) {
+          $params['line_item'] = $params['lineItems'];
+        }
+        // do cleanup line items if membership edit the Membership type.
+        if (!empty($ids['membership'])) {
+          CRM_Price_BAO_LineItem::deleteLineItems($ids['membership'], 'civicrm_membership');
+        }
+        // @todo - we should ONLY do the below if a contribution is created. Let's
+        // get some deprecation notices in here & see where it's hit & work to eliminate.
+        // This could happen if there is no contribution or we are in one of many
+        // weird and wonderful flows. This is scary code. Keep adding tests.
+        if (!empty($params['line_item']) && empty($params['contribution_id'])) {
+
+          foreach ($params['line_item'] as $priceSetId => $lineItems) {
+            foreach ($lineItems as $lineIndex => $lineItem) {
+              $lineMembershipType = $lineItem['membership_type_id'] ?? NULL;
+              if (!empty($params['contribution'])) {
+                $params['line_item'][$priceSetId][$lineIndex]['contribution_id'] = $params['contribution']->id;
+              }
+              if ($lineMembershipType && $lineMembershipType == ($params['membership_type_id'] ?? NULL)) {
+                $params['line_item'][$priceSetId][$lineIndex]['entity_id'] = $membership->id;
+                $params['line_item'][$priceSetId][$lineIndex]['entity_table'] = 'civicrm_membership';
+              }
+              elseif (!$lineMembershipType && !empty($params['contribution'])) {
+                $params['line_item'][$priceSetId][$lineIndex]['entity_id'] = $params['contribution']->id;
+                $params['line_item'][$priceSetId][$lineIndex]['entity_table'] = 'civicrm_contribution';
+              }
             }
           }
+          CRM_Price_BAO_LineItem::processPriceSet(
+            $membership->id,
+            $params['line_item'],
+            $params['contribution'] ?? NULL
+          );
         }
-        CRM_Price_BAO_LineItem::processPriceSet(
-          $membership->id,
-          $params['line_item'],
-          $params['contribution'] ?? NULL
-        );
       }
     }
 

--- a/Civi/Api4/Membership.php
+++ b/Civi/Api4/Membership.php
@@ -1,0 +1,23 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+namespace Civi\Api4;
+
+/**
+ * Membership entity.
+ *
+ * @searchable primary
+ * @since 5.42
+ * @package Civi\Api4
+ */
+class Membership extends Generic\DAOEntity {
+  use Generic\Traits\OptionList;
+
+}

--- a/Civi/Api4/MembershipBlock.php
+++ b/Civi/Api4/MembershipBlock.php
@@ -1,0 +1,23 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+namespace Civi\Api4;
+
+/**
+ * MembershipBlock entity.
+ *
+ * @searchable secondary
+ * @since 5.42
+ * @package Civi\Api4
+ */
+class MembershipBlock extends Generic\DAOEntity {
+  use Generic\Traits\OptionList;
+
+}

--- a/Civi/Api4/MembershipStatus.php
+++ b/Civi/Api4/MembershipStatus.php
@@ -1,0 +1,23 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+namespace Civi\Api4;
+
+/**
+ * MembershipStatus entity.
+ *
+ * @searchable secondary
+ * @since 5.42
+ * @package Civi\Api4
+ */
+class MembershipStatus extends Generic\DAOEntity {
+  use Generic\Traits\OptionList;
+
+}

--- a/Civi/Api4/Service/Spec/Provider/MembershipCreationSpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/MembershipCreationSpecProvider.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Service\Spec\Provider;
+
+use Civi\Api4\Service\Spec\FieldSpec;
+use Civi\Api4\Service\Spec\RequestSpec;
+
+class MembershipCreationSpecProvider implements Generic\SpecProviderInterface {
+
+  /**
+   * @param \Civi\Api4\Service\Spec\RequestSpec $spec
+   */
+  public function modifySpec(RequestSpec $spec): void {
+    $spec->getFieldByName('status_id')->setRequired(FALSE);
+    // This is a bit of dark-magic - the membership BAO code is particularly
+    // nasty. It has a lot of logic in it that does not belong there in
+    // terms of our current expectations. Removing it is difficult
+    // so the plan is that new api v4 membership.create users will either
+    // use the Order api flow when financial code should kick in. Otherwise
+    // the crud flow will bypass all the financial processing in membership.create.
+    // The use of the 'version' parameter to drive this is to be sure that
+    // we know the bypass will not affect the v3 api to the extent
+    // it cannot be reached by the v3 api at all (in time we can move some
+    // of the code we are deprecating into the v3 api, to die of natural deprecation).
+    $spec->addFieldSpec(new FieldSpec('version', 'Membership', 'Integer'));
+    $spec->getFieldByName('version')->setDefaultValue(4)->setRequired(TRUE);
+  }
+
+  /**
+   * When does this apply.
+   *
+   * @param string $entity
+   * @param string $action
+   *
+   * @return bool
+   */
+  public function applies($entity, $action): bool {
+    return $entity === 'Membership' && $action === 'create';
+  }
+
+}

--- a/tests/phpunit/CRM/Core/Payment/PayPalIPNTest.php
+++ b/tests/phpunit/CRM/Core/Payment/PayPalIPNTest.php
@@ -156,12 +156,14 @@ class CRM_Core_Payment_PayPalIPNTest extends CiviUnitTestCase {
   }
 
   /**
-   * Test IPN response updates contribution_recur & contribution for first & second contribution.
+   * Test IPN response updates contribution_recur & contribution for first &
+   * second contribution.
    *
    * @throws \CRM_Core_Exception
    * @throws \CiviCRM_API3_Exception
+   * @throws \API_Exception
    */
-  public function testIPNPaymentMembershipRecurSuccess() {
+  public function testIPNPaymentMembershipRecurSuccess(): void {
     $durationUnit = 'year';
     $this->setupMembershipRecurringPaymentProcessorTransaction(['duration_unit' => $durationUnit, 'frequency_unit' => $durationUnit]);
     $this->callAPISuccessGetSingle('membership_payment', []);

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -669,9 +669,8 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
    * @param array $params
    *
    * @return int
-   * @throws \CRM_Core_Exception
    */
-  public function contactMembershipCreate($params) {
+  public function contactMembershipCreate(array $params): int {
     $params = array_merge([
       'join_date' => '2007-01-21',
       'start_date' => '2007-01-21',

--- a/tests/phpunit/api/v3/MembershipTest.php
+++ b/tests/phpunit/api/v3/MembershipTest.php
@@ -965,9 +965,11 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
   /**
    * Test civicrm_contact_memberships_create with membership id (edit
    * membership).
-   * success expected.
+   *
+   * @dataProvider versionThreeAndFour
    */
-  public function testMembershipCreateWithId() {
+  public function testMembershipCreateWithId($version): void {
+    $this->_apiversion = $version;
     $membershipID = $this->contactMembershipCreate($this->_params);
     $params = [
       'id' => $membershipID,

--- a/tests/phpunit/api/v4/DataSets/ConformanceTest.json
+++ b/tests/phpunit/api/v4/DataSets/ConformanceTest.json
@@ -90,5 +90,26 @@
       "financial_type_id:name": "Donation",
       "min_contribution": "10.00"
     }
+  ],
+  "MembershipType": [
+    {
+      "name": "General",
+      "period_type" : "fixed",
+      "financial_type_id:name": "Donation",
+      "duration_unit" : "month",
+      "member_of_contact_id" : "@ref test_contact_1.id"
+    }
+  ],
+  "ContributionPage": [
+    {
+      "name": "General"
+    }
+  ],
+  "Membership": [
+    {
+      "membership_type_id:name": "General",
+      "contact_id" : "@ref test_contact_1.id",
+      "status_id:name" : "Pending"
+    }
   ]
 }


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#2634 Add v4 Membership api, access it via order

Before
----------------------------------------
Membership  v4 api unavailable

After
----------------------------------------
Additional api 
Membership
MembershipStatus
~~MembershipLog~~ (failed delete test - not sure why but pushed out of scope)
MembershipBlock

Technical Details
----------------------------------------
Per https://lab.civicrm.org/dev/core/-/issues/2634 the Membership.create BAO does a whole lotta stuff 
to do with line items and related contributions that is only sometimes appropriate. 

The agreed plan for v4 api is to bypass all of that stuff - specifically when called from v4 api (so we are not just adding a param that could be also accessed via v3 api but one which is explicitly linked to v4 api. This means we know that in future we can start to move some more of the awful stuff into the v3 api layer later)

So when calling membership.create through v4 api there should be 2 options

1) call it via order api. Order api handles all financials & line items
2) call it directly via v4. No handling of financials or line items is done & calling code is responsible.

Note that this PR doesn't quite nail 2 in that version is not (yet) being passed in from the Membership apiv4 class. I acknowledge this is a bit of a non-standard pattern (expecting version in the BAO layer) but this is a particularly nasty BAO create function. In the medium term we probably want to deprecate NOT passing in version - ie calling the BAO layer without going through either api - so that we can start to sort 'all the stuff' between 'this can die when v3 api does' & 'yeah this actually makes sense'

Also there is a jenkins battle.

Comments
----------------------------------------
The BAO changes are mostly whitespace as an IF is added