### PR TITLE
delocalize total amount before passing to setOverrideTotal

### DIFF
--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -921,7 +921,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
     $order = new CRM_Financial_BAO_Order();
     $order->setPriceSelectionFromUnfilteredInput($fields);
     if (isset($fields['total_amount'])) {
-      $order->setOverrideTotalAmount((float) $fields['total_amount']);
+      $order->setOverrideTotalAmount((float) CRM_Utils_Rule::cleanMoney($fields['total_amount']));
     }
     $lineItems = $order->getLineItems();
     try {


### PR DESCRIPTION
Overview
----------------------------------------
A value is being passed to `CRM_Financial_BAO_Order->setOverrideTotalAmount`, which accepts a `float`, before it is delocalized.

Before
----------------------------------------
Values truncated to the amount before the thousands separator - in USD.  Other currencies I'm sure fail in their own weird and wonderful ways.

After
----------------------------------------
No more crash.

Technical Details
----------------------------------------
`CRM_Utils_Rule::cleanMoney()`.