### PR TITLE
[REF] Upgrade CKEditor to 4.16.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -170,7 +170,7 @@
         "ignore": [".*", "node_modules", "docs", "Gruntfile.js", "index.html", "package.json", "test"]
       },
       "ckeditor": {
-        "url": "https://github.com/ckeditor/ckeditor-releases/archive/4.16.1.zip"
+        "url": "https://github.com/ckeditor/ckeditor-releases/archive/4.16.2.zip"
       },
       "crossfilter-1.3.x": {
         "url": "https://github.com/crossfilter/crossfilter/archive/1.3.14.zip",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ea837c7aee5b94c6cbc1df32c5b3aa70",
+    "content-hash": "aceccd69415b5fd67668ed7c0c870c39",
     "packages": [
         {
             "name": "adrienrn/php-mimetyper",
@@ -3990,5 +3990,5 @@
     "platform-overrides": {
         "php": "7.2"
     },
-    "plugin-api-version": "1.1.0"
+    "plugin-api-version": "2.1.0"
 }


### PR DESCRIPTION
Overview
----------------------------------------
This upgrades CKEditor to 4.16.2 due to https://ckeditor.com/blog/ckeditor-4.16.2-with-browser-improvements-and-security-fixes/

Before
----------------------------------------
CKeditor 4.16.1 used 

After
----------------------------------------
CKEditor 4.16.2 used

ping @eileenmcnaughton @colemanw 