### PR TITLE
(REF) ReflectionUtils - Add findStandardProperties() and findMethodHelpers()

### DIFF
--- a/Civi/Api4/Utils/ReflectionUtils.php
+++ b/Civi/Api4/Utils/ReflectionUtils.php
@@ -157,4 +157,49 @@ class ReflectionUtils {
     return $traits;
   }
 
+  /**
+   * Get a list of standard properties which can be written+read by outside callers.
+   *
+   * @param string $class
+   */
+  public static function findStandardProperties($class): iterable {
+    try {
+      /** @var \ReflectionClass $clazz */
+      $clazz = new \ReflectionClass($class);
+
+      yield from [];
+      foreach ($clazz->getProperties(\ReflectionProperty::IS_PROTECTED | \ReflectionProperty::IS_PUBLIC) as $property) {
+        if (!$property->isStatic() && $property->getName()[0] !== '_') {
+          yield $property;
+        }
+      }
+    }
+    catch (\ReflectionException $e) {
+      throw new \RuntimeException(sprintf("Cannot inspect class %s.", $class));
+    }
+  }
+
+  /**
+   * Find any methods in this class which match the given prefix.
+   *
+   * @param string $class
+   * @param string $prefix
+   */
+  public static function findMethodHelpers($class, string $prefix): iterable {
+    try {
+      /** @var \ReflectionClass $clazz */
+      $clazz = new \ReflectionClass($class);
+
+      yield from [];
+      foreach ($clazz->getMethods(\ReflectionMethod::IS_PUBLIC | \ReflectionMethod::IS_PROTECTED) as $m) {
+        if (\CRM_Utils_String::startsWith($m->getName(), $prefix)) {
+          yield $m;
+        }
+      }
+    }
+    catch (\ReflectionException $e) {
+      throw new \RuntimeException(sprintf("Cannot inspect class %s.", $class));
+    }
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------

Small refactoring. Add some internal utilities for scanning members.

Technical Details
----------------------------------------

* Extract `findStandardProperties()` from `MagicGetterSetterTrait::getMagicProperties()`. Move to `ReflectionUtils`. This splits responsibility for scanning (`ReflectionUtils::findStandardProperties()`) and caching (`MagicGetterSetterTrait::getMagicProperties()`). 
* Add a similar function for scanning method names by prefix (`findMethodHelpers()`).

There's a little expansion of test-coverage for `MagicGetterSetterTrait` here to ensure that the cleaner (&-based) cache code works. Additionally, the tests in #20975 will provide more implicit coverage.