### PR TITLE
MessageTemplate - Add renderTemplate(). Deprecate renderMessageTemplate().

### DIFF
--- a/CRM/Core/BAO/MessageTemplate.php
+++ b/CRM/Core/BAO/MessageTemplate.php
@@ -365,6 +365,37 @@ class CRM_Core_BAO_MessageTemplate extends CRM_Core_DAO_MessageTemplate {
   }
 
   /**
+   * Render a message template.
+   *
+   * This method is very similar to `sendTemplate()` - accepting most of the same arguments
+   * and emitting similar hooks. However, it specifically precludes the possibility of
+   * sending a message. It only renders.
+   *
+   * @param $params
+   *  Mixed render parameters. See sendTemplate() for more details.
+   * @return array
+   *   Rendered message, consistent of 'subject', 'text', 'html'
+   *   Ex: ['subject' => 'Hello Bob', 'text' => 'It\'s been so long since we sent you an automated notification!']
+   * @throws \API_Exception
+   * @throws \CRM_Core_Exception
+   * @see sendTemplate()
+   */
+  public static function renderTemplate($params) {
+    $forbidden = ['from', 'toName', 'toEmail', 'cc', 'bcc', 'replyTo'];
+    $intersect = array_intersect($forbidden, array_keys($params));
+    if (!empty($intersect)) {
+      throw new \CRM_Core_Exception(sprintf("renderTemplate() received forbidden fields (%s)",
+        implode(',', $intersect)));
+    }
+
+    $mailContent = [];
+    // sendTemplate has had an obscure feature - if you omit `toEmail`, then it merely renders.
+    // At some point, we may want to invert the relation between renderTemplate/sendTemplate, but for now this is a smaller patch.
+    [$sent, $mailContent['subject'], $mailContent['text'], $mailContent['html']] = static::sendTemplate($params);
+    return $mailContent;
+  }
+
+  /**
    * Send an email from the specified template based on an array of params.
    *
    * @param array $params
@@ -583,9 +614,17 @@ class CRM_Core_BAO_MessageTemplate extends CRM_Core_DAO_MessageTemplate {
   /**
    * Render the message template, resolving tokens and smarty tokens.
    *
-   * As with all BAO methods this should not be called directly outside
-   * of tested core code and is highly likely to change.
+   * This method has been deprecated in favor of two alternatives:
+   *  - Use CRM_Core_BAO_MessageTemplate::renderTemplate() if you want a high-level
+   *    trial-run of sendTemplate(). This will use the loaders, filters, hooks, etc
+   *    but stop short of delivery.
+   *  - Use CRM_Core_TokenSmarty::render() if you want a low-level utility to
+   *    render a template with the hybrid Token-Smarty template format.
    *
+   * @internal
+   * @deprecated
+   * @see CRM_Core_BAO_MessageTemplate::renderTemplate()
+   * @see CRM_Core_TokenSmarty::render()
    * @param array $mailContent
    * @param bool $disableSmarty
    * @param int|NULL $contactID

--- a/tests/phpunit/CRM/Core/BAO/MessageTemplateTest.php
+++ b/tests/phpunit/CRM/Core/BAO/MessageTemplateTest.php
@@ -22,6 +22,29 @@ class CRM_Core_BAO_MessageTemplateTest extends CiviUnitTestCase {
     parent::tearDown();
   }
 
+  public function testRenderTemplate() {
+    $contactId = $this->individualCreate([
+      'first_name' => 'Abba',
+      'last_name' => 'Baab',
+      'prefix_id' => NULL,
+      'suffix_id' => NULL,
+    ]);
+    $rendered = CRM_Core_BAO_MessageTemplate::renderTemplate([
+      'valueName' => 'case_activity',
+      'tokenContext' => [
+        'contactId' => $contactId,
+      ],
+      'messageTemplate' => [
+        'msg_subject' => 'Hello testRenderTemplate {contact.display_name}!',
+        'msg_text' => 'Hello testRenderTemplate {contact.display_name}!',
+        'msg_html' => '<p>Hello testRenderTemplate {contact.display_name}!</p>',
+      ],
+    ]);
+    $this->assertEquals('Hello testRenderTemplate Abba Baab!', $rendered['subject']);
+    $this->assertEquals('Hello testRenderTemplate Abba Baab!', $rendered['text']);
+    $this->assertStringContainsString('<p>Hello testRenderTemplate Abba Baab!</p>', $rendered['html']);
+  }
+
   public function testSendTemplate_RenderMode_OpenTemplate() {
     $contactId = $this->individualCreate([
       'first_name' => 'Abba',


### PR DESCRIPTION
Overview
----------------------------------------

This deprecates one recent/internal helper, `CRM_Core_BAO_MessageTemplate::renderMessageTemplate()`. As alternatives, use `CRM_Core_BAO_MessageTemplate::renderTemplate()` or `CRM_Core_TokenSmarty::render()`.

Before
----------------------------------------

```php
// Internal APIs
CRM_Core_BAO_MessageTemplate::sendTemplate(array $params): array;
CRM_Core_BAO_MessageTemplate::renderMessageTemplate(array $mailContent, bool $disableSmarty, $contactID,
                                                    array $smartyAssigns, array $tokenContext = []): array;
```

After
----------------------------------------

```php
// Internal APIs
CRM_Core_BAO_MessageTemplate::sendTemplate(array $params): array;
CRM_Core_BAO_MessageTemplate::renderTemplate(array $params): array;
CRM_Core_TokenSmarty::render(array $messages, array $tokenContext, array $smartyContext): array;
```

Use `CRM_Core_TokenSmarty::render()` if you want a low-level utility to render a template with the hybrid Token-Smarty template format. This function was recently extracted (#20870), so it is functionally the same. (The remaining bits in `renderMessageTemplate` merely juggle the names for `smarty/disableSmarty` and `contactID/contactId`).
 would be appropriate if you need to use the same notation (Token-Smarty) but with a different process (template-loading/validation/hooks).

Use `CRM_Core_BAO_MessageTemplate::renderTemplate()` if you want a high-level trial-run of `sendTemplate()`. This is a new function with broader scope, and it is better suited to generating preview-GUI. The `renderTemplate($params)` and `sendTemplate($params)` use the same list of options+behaviors for template-loading, data-loading, data-validation, and hooks (`Hook::alterMailContent`, `Hook::alterMailParams`), etc.  (This function is a pre-req for #20975.)
