### PR TITLE
Replace deprecated calls to `renderMessageTemplate()`

### DIFF
--- a/CRM/Contribute/Form/Task/PDFLetter.php
+++ b/CRM/Contribute/Form/Task/PDFLetter.php
@@ -545,8 +545,12 @@ class CRM_Contribute_Form_Task_PDFLetter extends CRM_Contribute_Form_Task {
       // no change to normal behaviour to avoid risk of breakage
       $tokenHtml = CRM_Utils_Token::replaceContributionTokens($html_message, $contribution, TRUE, $messageToken);
     }
-    $useSmarty = (defined('CIVICRM_MAIL_SMARTY') && CIVICRM_MAIL_SMARTY);
-    return CRM_Core_BAO_MessageTemplate::renderMessageTemplate(['text' => '', 'html' => $tokenHtml, 'subject' => ''], !$useSmarty, $contact['contact_id'], ['contact' => $contact])['html'];
+    $tokenContext = [
+      'smarty' => (defined('CIVICRM_MAIL_SMARTY') && CIVICRM_MAIL_SMARTY),
+      'contactId' => $contact['contact_id'],
+    ];
+    $smarty = ['contact' => $contact];
+    return CRM_Core_TokenSmarty::render(['html' => $tokenHtml], $tokenContext, $smarty)['html'];
   }
 
 }

--- a/CRM/SMS/Form/Upload.php
+++ b/CRM/SMS/Form/Upload.php
@@ -338,7 +338,10 @@ class CRM_SMS_Form_Upload extends CRM_Core_Form {
       $dummy_mail = new CRM_Mailing_BAO_Mailing();
       $mess = "body_text";
       $dummy_mail->$mess = $str;
-      $str = CRM_Core_BAO_MessageTemplate::renderMessageTemplate(['text' => $str, 'html' => '', 'subject' => ''], TRUE, CRM_Core_Session::getLoggedInContactID(), [])['text'];
+      $str = CRM_Core_TokenSmarty::render(['text' => $str], [
+        'smarty' => FALSE,
+        'contactId' => CRM_Core_Session::getLoggedInContactID(),
+      ])['text'];
       $tokens = $dummy_mail->getTokens();
 
       $str = CRM_Utils_Token::replaceSubscribeInviteTokens($str);


### PR DESCRIPTION
Overview
----------------------------------------

Replace deprecated calls to `renderMessageTemplate()`.

Follow-up to #21115

Before
----------------------------------------

Calls to `renderMessageTemplate()`

After
----------------------------------------

Calls to `TokenSmarty::render()` and `renderTemplate()`.

Comments
----------------------------------------

This merits some `r-run` on the PDF and SMS bits.