### PR TITLE
Add handling for error at smarty level

### DIFF
--- a/Civi/Token/TokenCompatSubscriber.php
+++ b/Civi/Token/TokenCompatSubscriber.php
@@ -131,8 +131,16 @@ class TokenCompatSubscriber implements EventSubscriberInterface {
 
     if ($useSmarty) {
       $smarty = \CRM_Core_Smarty::singleton();
-      $e->string = $smarty->fetch("string:" . $e->string);
+      set_error_handler([$this, 'handleSmartyError'], E_USER_ERROR);
+      $e->string = $smarty->fetch('string:' . $e->string);
+      restore_error_handler();
     }
+  }
+
+  public function handleSmartyError($errno, $errstr, $errfile, $errline) {
+    $event = new \Civi\Core\Event\SmartyErrorEvent($errno, $errstr);
+    \Civi::dispatcher()->dispatch('civi.smarty.error', $event);
+    throw new \CRM_Core_Exception('message was not parsed');
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
This is the fix for https://github.com/civicrm/civicrm-packages/pull/313 that avoids hacking
an external package and is more careful.

In testing it turns out that an enotice triggers a smarty error - so this escalates only E_USER_ERROR

I tested 2 strings in the online contribution message template (& used the option to send receipt from contribution search results)

![image](https://user-images.githubusercontent.com/336308/129335041-e913371a-0e9a-4a2a-860a-80db65d04d38.png)

Before
----------------------------------------

An enotice (works fine)
```{$b} {if 1}h{else}y{/if}```

Invalid smarty
```{$b} {if 1h{else}y{/if}```

Invalid style code
```
<style type="text/css">body {
        margin: 0;
        padding: 0;
    }
</style>
```
Scenario 1 = no issue

Scenario 2

![image](https://user-images.githubusercontent.com/336308/129335197-74dc7e86-e24e-4250-857d-778ee09b303d.png)

Scenario 3 - succeeds with no issue - not this means the error is swallowed but that may cause problems on real live sites


After
----------------------------------------
Enotice works fine.

Scenario 2 & 3 = civi error

(debug back trace disabled) 
![image](https://user-images.githubusercontent.com/336308/129334163-a610a26b-0bf6-43bd-b9a6-9d2235d9f24b.png)

Technical Details
----------------------------------------
Note I suspect this should be moved to the smartyRender class now if we use it 

Comments
----------------------------------------
@totten testing suggests care is needed since if this line permits E_NOTICE then E_NOTICE is escalated

Setting E_ERROR ignores the weird tag situation ie 
```
 $handler = set_error_handler([$this, 'handleSmartyError'], E_ERROR);


```

I think E_USER_ERROR is right