### PR TITLE
fix crmValidate() not loading on event registration pages

### DIFF
--- a/templates/CRM/Form/validate.tpl
+++ b/templates/CRM/Form/validate.tpl
@@ -9,7 +9,7 @@
 *}
 {* Initialize jQuery validate on a form *}
 {* Extra params and functions may be added to the CRM.validate object before this template is loaded *}
-{if empty($crm_form_validate_included) and isset($smarty.get.snippet) and $smarty.get.snippet neq 'json' and !empty($form) and !empty($form.formClass)}
+{if empty($crm_form_validate_included) and ((isset($smarty.get.snippet) and $smarty.get.snippet neq 'json') or !isset($smarty.get.snippet)) and !empty($form) and !empty($form.formClass)}
   {assign var=crm_form_validate_included value=1}
   {literal}
   <script type="text/javascript">


### PR DESCRIPTION
Overview
----------------------------------------
There is a logic error in https://github.com/civicrm/civicrm-core/pull/20543 that prevents the CiviCRM-specific client-side validation loading on event registration pages (and probably elsewhere).

Before
----------------------------------------
`crmValidate()` not loading.

After
----------------------------------------
`crmValidate()` loading.

Comments
----------------------------------------
My understanding if #20543 is:
* It's a refactor in that it's not intended to have any noticeable effect;
* The goal is to ensure that we're not attempting to access uninitialized variables, array elements, etc.

I think this fix satisfies both.