### PR TITLE
 dev/core#2745 - Contribution Tokens - Support 'contributionId'

### DIFF
--- a/CRM/Contribute/Tokens.php
+++ b/CRM/Contribute/Tokens.php
@@ -23,13 +23,6 @@ class CRM_Contribute_Tokens extends CRM_Core_EntityTokens {
   /**
    * @return string
    */
-  protected function getEntityName(): string {
-    return 'contribution';
-  }
-
-  /**
-   * @return string
-   */
   protected function getEntityAlias(): string {
     return 'contrib_';
   }
@@ -44,64 +37,6 @@ class CRM_Contribute_Tokens extends CRM_Core_EntityTokens {
    */
   protected function getApiEntityName(): string {
     return 'Contribution';
-  }
-
-  /**
-   * Get a list of tokens for the entity for which access is permitted to.
-   *
-   * This list is historical and we need to question whether we
-   * should filter out any fields (other than those fields, like api_key
-   * on the contact entity) with permissions defined.
-   *
-   * @return array
-   */
-  protected function getExposedFields(): array {
-    $fields = [
-      'contribution_page_id',
-      'source',
-      'id',
-      'receive_date',
-      'total_amount',
-      'fee_amount',
-      'net_amount',
-      'non_deductible_amount',
-      'trxn_id',
-      'invoice_id',
-      'currency',
-      'cancel_date',
-      'receipt_date',
-      'thankyou_date',
-      'tax_amount',
-      'contribution_status_id',
-      'financial_type_id',
-      'payment_instrument_id',
-      'cancel_reason',
-      'amount_level',
-      'check_number',
-    ];
-    if (CRM_Campaign_BAO_Campaign::isCampaignEnable()) {
-      $fields[] = 'campaign_id';
-    }
-    return $fields;
-  }
-
-  /**
-   * Get tokens supporting the syntax we are migrating to.
-   *
-   * In general these are tokens that were not previously supported
-   * so we can add them in the preferred way or that we have
-   * undertaken some, as yet to be written, db update.
-   *
-   * See https://lab.civicrm.org/dev/core/-/issues/2650
-   *
-   * @return string[]
-   */
-  public function getBasicTokens(): array {
-    $return = [];
-    foreach ($this->getExposedFields() as $fieldName) {
-      $return[$fieldName] = $this->getFieldMetadata()[$fieldName]['title'];
-    }
-    return $return;
   }
 
 }

--- a/CRM/Contribute/Tokens.php
+++ b/CRM/Contribute/Tokens.php
@@ -39,4 +39,11 @@ class CRM_Contribute_Tokens extends CRM_Core_EntityTokens {
     return 'Contribution';
   }
 
+  /**
+   * @return array
+   */
+  public function getCurrencyFieldName() {
+    return ['currency'];
+  }
+
 }

--- a/tests/phpunit/CRM/Contribute/ActionMapping/ByTypeTest.php
+++ b/tests/phpunit/CRM/Contribute/ActionMapping/ByTypeTest.php
@@ -10,6 +10,7 @@
  */
 
 use Civi\Api4\Contribution;
+use Civi\Token\TokenProcessor;
 
 /**
  * Class CRM_Contribute_ActionMapping_ByTypeTest
@@ -319,6 +320,22 @@ class CRM_Contribute_ActionMapping_ByTypeTest extends \Civi\ActionSchedule\Abstr
       'campaign label = Campaign',
     ];
     $this->mut->checkMailLog($expected);
+
+    $tokenProcessor = new TokenProcessor(\Civi::dispatcher(), [
+      'controller' => get_class(),
+      'smarty' => FALSE,
+      'schema' => ['contributionId'],
+      'contributionId' => $this->ids['Contribution']['alice'],
+      'contactId' => $this->contacts['alice']['id'],
+    ]);
+    $tokenProcessor->addRow([]);
+    $tokenProcessor->addMessage('html', $this->schedule->body_text, 'text/plain');
+    $tokenProcessor->evaluate();
+    foreach ($tokenProcessor->getRows() as $row) {
+      foreach ($expected as $value) {
+        $this->assertStringContainsString($value, $row->render('html'));
+      }
+    }
 
     $messageToken = CRM_Utils_Token::getTokens($this->schedule->body_text);
 

--- a/tests/phpunit/CRM/Contribute/ActionMapping/ByTypeTest.php
+++ b/tests/phpunit/CRM/Contribute/ActionMapping/ByTypeTest.php
@@ -255,6 +255,7 @@ class CRM_Contribute_ActionMapping_ByTypeTest extends \Civi\ActionSchedule\Abstr
    * legacy processor function. Once this is true we can expose the listener on the
    * token processor for contribution and call it internally from the legacy code.
    *
+   * @throws \API_Exception
    * @throws \CiviCRM_API3_Exception
    */
   public function testTokenRendering(): void {
@@ -381,7 +382,9 @@ class CRM_Contribute_ActionMapping_ByTypeTest extends \Civi\ActionSchedule\Abstr
     foreach ($fields as $field) {
       $allFields[$field['name']] = $field['title'];
     }
-    // $this->assertEquals($realLegacyTokens, $allFields);
+    // contact ID is skipped.
+    unset($allFields['contact_id']);
+    $this->assertEquals($allFields, $realLegacyTokens);
     $this->assertEquals($legacyTokens, $processor->tokenNames);
     foreach ($tokens as $token) {
       $this->assertEquals(CRM_Core_SelectValues::contributionTokens()['{contribution.' . $token . '}'], $processor->tokenNames[$token]);

--- a/tests/phpunit/CRM/Contribute/BAO/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/BAO/ContributionTest.php
@@ -1304,7 +1304,8 @@ WHERE eft.entity_id = %1 AND ft.to_financial_account_id <> %2";
 
   /**
    * Test for replaceContributionTokens.
-   *   This function tests whether the contribution tokens are replaced with
+   *
+   * This function tests whether the contribution tokens are replaced with
    * values from contribution.
    *
    * @throws \CiviCRM_API3_Exception


### PR DESCRIPTION
Overview
----------------------------------------
This salvages the useful part (the test) from https://github.com/civicrm/civicrm-core/pull/21058 - it should fail for now but once #21109 is merged I'll rebase out that & we'll be left with the (still failing) test that will cover contribution tokens once they are listening properly - @totten had ideas on how to make it listen in https://github.com/civicrm/civicrm-core/pull/21079 - I'm also going to close that one as it needs to be re-worked to pass this test once #21109 is merged - but at this stage it's mostly full of stuff that is not relevant now

Before
----------------------------------------
