### PR TITLE
dev/core#1618 Trigger a reconciliation of logging tables after Extens…

### DIFF
--- a/CRM/Extension/Upgrades.php
+++ b/CRM/Extension/Upgrades.php
@@ -69,7 +69,25 @@ class CRM_Extension_Upgrades {
 
     CRM_Utils_Hook::upgrade('enqueue', $queue);
 
+    // dev/core#1618 When Extension Upgrades are run reconcile log tables
+    $task = new CRM_Queue_Task(
+      [__CLASS__, 'upgradeLogTables'],
+      [],
+      ts('Update log tables')
+    );
+    // Set weight low so that it will be run last.
+    $queue->createItem($task, -2);
+
     return $queue;
+  }
+
+  /**
+   * Update log tables following execution of extension upgrades
+   */
+  public static function upgradeLogTables() {
+    $logging = new CRM_Logging_Schema();
+    $logging->fixSchemaDifferences();
+    return TRUE;
   }
 
   /**


### PR DESCRIPTION
…ion upgrades have been done to ensure any new columns are correctly added to logging tables as well

Overview
----------------------------------------
This adds in a step to the extensions upgrade queue running job so that log tables are updated when the extension upgrades are run

Before
----------------------------------------
1. Install 5.39
2. Enable detailed logging
3. Install Search Kit
4. Upgrade CiviCRM to 5.40
5. Run Extension Upgrdae
6. Error because acl_bypass is not a field

After
----------------------------------------
No error

ping @demeritcowboy @colemanw @jaapjansma 