### PR TITLE
dev/core#2757 test to demonstrate contact delete actions not called for v4 api

### DIFF
--- a/tests/phpunit/api/v3/RelationshipTest.php
+++ b/tests/phpunit/api/v3/RelationshipTest.php
@@ -1357,8 +1357,10 @@ class api_v3_RelationshipTest extends CiviUnitTestCase {
     ]);
     $this->callAPISuccessGetCount('membership', ['contact_id' => $this->_cId_a_2], 0);
 
+    $this->_apiversion = 4;
     // Deleting the organization should cause the related membership to be deleted.
-    $this->callAPISuccess('contact', 'delete', ['id' => $this->_cId_b]);
+    $this->callAPISuccess('Contact', 'delete', ['id' => $this->_cId_b]);
+    $this->_apiversion = 3;
     $this->callAPISuccessGetCount('membership', ['contact_id' => $this->_cId_a], 0);
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Per https://lab.civicrm.org/dev/core/-/issues/2757 it turns out that our tests were hiding the fact that calling Contact.delete using v4 api wasn't calling the right delete BAO actions (in this case deleting  inherited memberships).

This PR just demonstrates this in a unit test

Before
----------------------------------------

After
----------------------------------------

Technical Details
----------------------------------------
@colemanw I *thought* we had addressed this ?

Comments
----------------------------------------
