### PR TITLE
(dev/mail#83) Workflow Messages - Introduce class contracts

### DIFF
--- a/CRM/Core/BAO/MessageTemplate.php
+++ b/CRM/Core/BAO/MessageTemplate.php
@@ -408,24 +408,34 @@ class CRM_Core_BAO_MessageTemplate extends CRM_Core_DAO_MessageTemplate {
    * @throws \API_Exception
    */
   public static function sendTemplate($params) {
-    $defaults = [
+    $modelDefaults = [
       // instance of WorkflowMessageInterface, containing a list of data to provide to the message-template
       'model' => NULL,
-      // option value name of the template
+      // Symbolic name of the workflow step. Matches the option-value-name of the template.
       'valueName' => NULL,
-      // ID of the template
-      'messageTemplateID' => NULL,
-      // content of the message template
-      // Ex: ['msg_subject' => 'Hello {contact.display_name}', 'msg_html' => '...', 'msg_text' => '...']
-      // INTERNAL: 'messageTemplate' is currently only intended for use within civicrm-core only. For downstream usage, future updates will provide comparable public APIs.
-      'messageTemplate' => NULL,
-      // contact id if contact tokens are to be replaced
-      'contactId' => NULL,
       // additional template params (other than the ones already set in the template singleton)
       'tplParams' => [],
       // additional token params (passed to the TokenProcessor)
       // INTERNAL: 'tokenContext' is currently only intended for use within civicrm-core only. For downstream usage, future updates will provide comparable public APIs.
       'tokenContext' => [],
+      // properties to import directly to the model object
+      'modelProps' => NULL,
+      // contact id if contact tokens are to be replaced; alias for tokenContext.contactId
+      'contactId' => NULL,
+    ];
+    $viewDefaults = [
+      // ID of the specific template to load
+      'messageTemplateID' => NULL,
+      // content of the message template
+      // Ex: ['msg_subject' => 'Hello {contact.display_name}', 'msg_html' => '...', 'msg_text' => '...']
+      // INTERNAL: 'messageTemplate' is currently only intended for use within civicrm-core only. For downstream usage, future updates will provide comparable public APIs.
+      'messageTemplate' => NULL,
+      // whether this is a test email (and hence should include the test banner)
+      'isTest' => FALSE,
+      // Disable Smarty?
+      'disableSmarty' => FALSE,
+    ];
+    $envelopeDefaults = [
       // the From: header
       'from' => NULL,
       // the recipient’s name
@@ -440,12 +450,8 @@ class CRM_Core_BAO_MessageTemplate extends CRM_Core_DAO_MessageTemplate {
       'replyTo' => NULL,
       // email attachments
       'attachments' => NULL,
-      // whether this is a test email (and hence should include the test banner)
-      'isTest' => FALSE,
       // filename of optional PDF version to add as attachment (do not include path)
       'PDFFilename' => NULL,
-      // Disable Smarty?
-      'disableSmarty' => FALSE,
     ];
 
     // Allow WorkflowMessage to run any filters/mappings/cleanups.
@@ -455,7 +461,7 @@ class CRM_Core_BAO_MessageTemplate extends CRM_Core_DAO_MessageTemplate {
     // Subsequent hooks use $params. Retaining the $params['model'] might be nice - but don't do it unless you figure out how to ensure data-consistency (eg $params['tplParams'] <=> $params['model']).
     // If you want to expose the model via hook, consider interjecting a new Hook::alterWorkflowMessage($model) between `importAll()` and `exportAll()`.
 
-    $params = array_merge($defaults, $params);
+    $params = array_merge($modelDefaults, $viewDefaults, $envelopeDefaults, $params);
 
     CRM_Utils_Hook::alterMailParams($params, 'messageTemplate');
     if (!is_int($params['messageTemplateID']) && !is_null($params['messageTemplateID'])) {
@@ -499,6 +505,7 @@ class CRM_Core_BAO_MessageTemplate extends CRM_Core_DAO_MessageTemplate {
 
       $config = CRM_Core_Config::singleton();
       if (isset($params['isEmailPdf']) && $params['isEmailPdf'] == 1) {
+        // FIXME: $params['contributionId'] is not modeled in the parameter list. When is it supplied? Should probably move to tokenContext.contributionId.
         $pdfHtml = CRM_Contribute_BAO_ContributionPage::addInvoicePdfToEmail($params['contributionId'], $params['contactId']);
         if (empty($params['attachments'])) {
           $params['attachments'] = [];

--- a/Civi/WorkflowMessage/Exception/WorkflowMessageException.php
+++ b/Civi/WorkflowMessage/Exception/WorkflowMessageException.php
@@ -1,0 +1,18 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+namespace Civi\WorkflowMessage\Exception;
+
+/**
+ * An error encountered while evaluating a workflow-message-template.
+ */
+class WorkflowMessageException extends \CRM_Core_Exception {
+
+}

--- a/Civi/WorkflowMessage/FieldSpec.php
+++ b/Civi/WorkflowMessage/FieldSpec.php
@@ -1,0 +1,98 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\WorkflowMessage;
+
+use Civi\Schema\Traits\ArrayFormatTrait;
+use Civi\Schema\Traits\BasicSpecTrait;
+use Civi\Schema\Traits\PhpDataTypeSpecTrait;
+use Civi\Schema\Traits\OptionsSpecTrait;
+
+class FieldSpec {
+
+  // BasicSpecTrait: name, title, description
+  use BasicSpecTrait;
+
+  // PhpDataTypeSpecTrait: type, dataType, serialize, fkEntity
+  use PhpDataTypeSpecTrait;
+
+  // OptionsSpecTrait: options, optionsCallback
+  use OptionsSpecTrait;
+
+  // ArrayFormatTrait: toArray():array, loadArray($array)
+  use ArrayFormatTrait;
+
+  /**
+   * @var bool|null
+   */
+  public $required;
+
+  /**
+   * Allow this property to be used in alternative scopes, such as Smarty and TokenProcessor.
+   *
+   * @var array|null
+   *   Ex: ['Smarty' => 'smarty_name']
+   */
+  public $scope;
+
+  /**
+   * @return bool
+   */
+  public function isRequired(): ?bool {
+    return $this->required;
+  }
+
+  /**
+   * @param bool|null $required
+   * @return $this
+   */
+  public function setRequired(?bool $required) {
+    $this->required = $required;
+    return $this;
+  }
+
+  /**
+   * @return array|NULL
+   */
+  public function getScope(): ?array {
+    return $this->scope;
+  }
+
+  /**
+   * Enable export/import in alternative scopes.
+   *
+   * @param string|array|NULL $scope
+   *   Ex: 'tplParams'
+   *   Ex: 'tplParams as foo_bar'
+   *   Ex: 'tplParams as contact_id, TokenProcessor as contactId'
+   *   Ex: ['tplParams' => 'foo_bar']
+   * @return $this
+   */
+  public function setScope($scope) {
+    if (is_array($scope)) {
+      $this->scope = $scope;
+    }
+    else {
+      $parts = explode(',', $scope);
+      $this->scope = [];
+      foreach ($parts as $part) {
+        if (preg_match('/^\s*(\S+) as (\S+)\s*$/', $part, $m)) {
+          $this->scope[trim($m[1])] = trim($m[2]);
+        }
+        else {
+          $this->scope[trim($part)] = $this->getName();
+        }
+      }
+    }
+    return $this;
+  }
+
+}

--- a/Civi/WorkflowMessage/GenericWorkflowMessage.php
+++ b/Civi/WorkflowMessage/GenericWorkflowMessage.php
@@ -13,6 +13,7 @@
 namespace Civi\WorkflowMessage;
 
 use Civi\Schema\Traits\MagicGetterSetterTrait;
+use Civi\WorkflowMessage\Traits\AddressingTrait;
 use Civi\WorkflowMessage\Traits\FinalHelperTrait;
 use Civi\WorkflowMessage\Traits\ReflectiveWorkflowTrait;
 
@@ -35,6 +36,9 @@ class GenericWorkflowMessage implements WorkflowMessageInterface {
 
   // Implement assertValid(), renderTemplate(), sendTemplate() - Sugary stub methods that delegate to real APIs.
   use FinalHelperTrait;
+
+  // Implement setTo(), setReplyTo(), etc
+  use AddressingTrait;
 
   /**
    * WorkflowMessage constructor.

--- a/Civi/WorkflowMessage/GenericWorkflowMessage.php
+++ b/Civi/WorkflowMessage/GenericWorkflowMessage.php
@@ -13,6 +13,7 @@
 namespace Civi\WorkflowMessage;
 
 use Civi\Schema\Traits\MagicGetterSetterTrait;
+use Civi\WorkflowMessage\Traits\FinalHelperTrait;
 use Civi\WorkflowMessage\Traits\ReflectiveWorkflowTrait;
 
 /**
@@ -29,6 +30,9 @@ class GenericWorkflowMessage implements WorkflowMessageInterface {
 
   // Implement __call() - Public and protected properties are automatically given a default getter/setter. These may be overridden/customized.
   use MagicGetterSetterTrait;
+
+  // Implement assertValid(), renderTemplate(), sendTemplate() - Sugary stub methods that delegate to real APIs.
+  use FinalHelperTrait;
 
   /**
    * WorkflowMessage constructor.

--- a/Civi/WorkflowMessage/GenericWorkflowMessage.php
+++ b/Civi/WorkflowMessage/GenericWorkflowMessage.php
@@ -21,6 +21,8 @@ use Civi\WorkflowMessage\Traits\ReflectiveWorkflowTrait;
  *
  * @method $this setContactId(int|null $contactId)
  * @method int|null getContactId()
+ * @method $this setContact(array|null $contact)
+ * @method array|null getContact()
  */
 class GenericWorkflowMessage implements WorkflowMessageInterface {
 
@@ -49,9 +51,41 @@ class GenericWorkflowMessage implements WorkflowMessageInterface {
   /**
    * The contact receiving this message.
    *
-   * @var int
+   * @var int|null
    * @scope tokenContext
+   * @fkEntity Contact
    */
   protected $contactId;
+
+  /**
+   * @var array|null
+   * @scope tokenContext
+   */
+  protected $contact;
+
+  /**
+   * Must provide either 'int $contactId' or 'array $contact'
+   *
+   * @param array $errors
+   * @see ReflectiveWorkflowTrait::validate()
+   */
+  protected function validateExtra_contact(array &$errors) {
+    if (empty($this->contactId) && empty($this->contact['id'])) {
+      $errors[] = [
+        'severity' => 'error',
+        'fields' => ['contactId', 'contact'],
+        'name' => 'missingContact',
+        'message' => ts('Message template requires one of these fields (%1)', ['contactId, contact']),
+      ];
+    }
+    if (!empty($this->contactId) && !empty($this->contact)) {
+      $errors[] = [
+        'severity' => 'warning',
+        'fields' => ['contactId', 'contact'],
+        'name' => 'missingContact',
+        'message' => ts('Passing both (%1) may lead to ambiguous behavior.', ['contactId, contact']),
+      ];
+    }
+  }
 
 }

--- a/Civi/WorkflowMessage/GenericWorkflowMessage.php
+++ b/Civi/WorkflowMessage/GenericWorkflowMessage.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\WorkflowMessage;
+
+use Civi\Schema\Traits\MagicGetterSetterTrait;
+use Civi\WorkflowMessage\Traits\ReflectiveWorkflowTrait;
+
+/**
+ * Generic base-class for describing the inputs for a workflow email template.
+ *
+ * @method $this setContactId(int|null $contactId)
+ * @method int|null getContactId()
+ */
+class GenericWorkflowMessage implements WorkflowMessageInterface {
+
+  // Implement getFields(), import(), export(), validate() - All methods based on inspecting class properties (`ReflectionClass`).
+  // Define stub methods exportExtraTokenContext(), exportExtraTplParams(), etc.
+  use ReflectiveWorkflowTrait;
+
+  // Implement __call() - Public and protected properties are automatically given a default getter/setter. These may be overridden/customized.
+  use MagicGetterSetterTrait;
+
+  /**
+   * WorkflowMessage constructor.
+   *
+   * @param array $imports
+   *   List of values to import.
+   *   Ex: ['tplParams' => [...tplValues...], 'tokenContext' => [...tokenData...]]
+   *   Ex: ['modelProps' => [...classProperties...]]
+   */
+  public function __construct(array $imports = []) {
+    WorkflowMessage::importAll($this, $imports);
+  }
+
+  /**
+   * The contact receiving this message.
+   *
+   * @var int
+   * @scope tokenContext
+   */
+  protected $contactId;
+
+}

--- a/Civi/WorkflowMessage/Traits/AddressingTrait.php
+++ b/Civi/WorkflowMessage/Traits/AddressingTrait.php
@@ -1,0 +1,336 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\WorkflowMessage\Traits;
+
+const ADDRESS_STORAGE_FMT = 'rfc822';
+const ADDRESS_EXPORT_FMT = 'rfc822';
+
+/**
+ * Define the $to, $from, $replyTo, $cc, and $bcc fields to a WorkflowMessage class.
+ *
+ * Email addresses may be get or set in any of these formats:
+ *
+ * - rfc822 (string): RFC822-style, e.g. 'Full Name <user@example.com>'
+ * - record (array): Pair of name+email, e.g. ['name' => 'Full Name', 'email' => 'user@example.com']
+ * - records: (array) List of records, keyed sequentially.
+ */
+trait AddressingTrait {
+
+  /**
+   * The primary email recipient (single address).
+   *
+   * @var string|null
+   *   Ex: '"Foo Bar" <foo.bar@example.com>'
+   *   Ex: ['name' => "Foo Bar", "email" => "foo.bar@example.com"]
+   *
+   * The "To:" address is mapped to the "envelope" scope. The existing
+   * envelope format treats this as a pair of fields [toName,toEmail].
+   * Consequently, we only support one "To:" address, and it uses a
+   * special import/export method.
+   */
+  protected $to;
+
+  /**
+   * The email sender (single address).
+   *
+   * @var string|null
+   *   Ex: '"Foo Bar" <foo.bar@example.com>'
+   * @scope envelope
+   */
+  protected $from;
+
+  /**
+   * The email sender's Reply-To (single address).
+   *
+   * @var string|null
+   *   Ex: '"Foo Bar" <foo.bar@example.com>'
+   * @scope envelope
+   */
+  protected $replyTo;
+
+  /**
+   * Additional recipients (multiple addresses).
+   *
+   * @var string|null
+   *   Ex: '"Foo Bar" <foo.bar@example.com>, "Whiz Bang" <whiz.bang@example.com>'
+   *   Ex: [['name' => 'Foo Bar', 'email' => 'foo.bar@example.com'], ['name' => 'Whiz Bang', 'email' => 'whiz.bang@example.com']]
+   * @scope envelope
+   */
+  protected $cc;
+
+  /**
+   * Additional recipients (multiple addresses).
+   *
+   * @var string|null
+   *   Ex: '"Foo Bar" <foo.bar@example.com>, "Whiz Bang" <whiz.bang@example.com>'
+   *   Ex: [['name' => 'Foo Bar', 'email' => 'foo.bar@example.com'], ['name' => 'Whiz Bang', 'email' => 'whiz.bang@example.com']]
+   * @scope envelope
+   */
+  protected $bcc;
+
+  /**
+   * Get the list of "To:" addresses.
+   *
+   * Note: This returns only
+   *
+   * @param string $format
+   *   Ex: 'rfc822', 'records', 'record'
+   * @return array|string
+   *   Ex: '"Foo Bar" <foo.bar@example.com>'
+   *   Ex: ['name' => 'Foo Bar', 'email' => 'foo.bar@example.com']
+   */
+  public function getTo($format = ADDRESS_EXPORT_FMT) {
+    return $this->formatAddress($format, $this->to);
+  }
+
+  /**
+   * Get the "From:" address.
+   *
+   * @param string $format
+   *   Ex: 'rfc822', 'records', 'record'
+   * @return array|string
+   *   The "From" address. If none set, this will be empty ([]).
+   *   Ex: '"Foo Bar" <foo.bar@example.com>'
+   *   Ex: ['name' => 'Foo Bar', 'email' => 'foo.bar@example.com']
+   */
+  public function getFrom($format = ADDRESS_EXPORT_FMT) {
+    return $this->formatAddress($format, $this->from);
+  }
+
+  /**
+   * Get the "Reply-To:" address.
+   *
+   * @param string $format
+   *   Ex: 'rfc822', 'records', 'record'
+   * @return array|string
+   *   The "From" address. If none set, this will be empty ([]).
+   *   Ex: '"Foo Bar" <foo.bar@example.com>'
+   *   Ex: ['name' => 'Foo Bar', 'email' => 'foo.bar@example.com']
+   */
+  public function getReplyTo($format = ADDRESS_EXPORT_FMT) {
+    return $this->formatAddress($format, $this->replyTo);
+  }
+
+  /**
+   * Get the list of "Cc:" addresses.
+   *
+   * @param string $format
+   *   Ex: 'rfc822', 'records', 'record'
+   * @return array|string
+   *   List of addresses.
+   *   Ex: 'First <first@example.com>, second@example.com'
+   *   Ex: [['name' => 'First', 'email' => 'first@example.com'], ['email' => 'second@example.com']]
+   */
+  public function getCc($format = ADDRESS_EXPORT_FMT) {
+    return $this->formatAddress($format, $this->cc);
+  }
+
+  /**
+   * Get the list of "Bcc:" addresses.
+   *
+   * @param string $format
+   *   Ex: 'rfc822', 'records', 'record'
+   * @return array|string
+   *   List of addresses.
+   *   Ex: 'First <first@example.com>, second@example.com'
+   *   Ex: [['name' => 'First', 'email' => 'first@example.com'], ['email' => 'second@example.com']]
+   */
+  public function getBcc($format = ADDRESS_EXPORT_FMT) {
+    return $this->formatAddress($format, $this->bcc);
+  }
+
+  /**
+   * @param string|array $address
+   *   Ex: '"Foo Bar" <foo.bar@example.com>'
+   *   Ex: ['name' => "Foo Bar", "email" => "foo.bar@example.com"]
+   * @return $this
+   */
+  public function setFrom($address) {
+    $this->from = $this->formatAddress(ADDRESS_STORAGE_FMT, $address);
+    return $this;
+  }
+
+  /**
+   * @param string|array $address
+   *   Ex: '"Foo Bar" <foo.bar@example.com>'
+   *   Ex: ['name' => "Foo Bar", "email" => "foo.bar@example.com"]
+   * @return $this
+   */
+  public function setTo($address) {
+    $this->to = $this->formatAddress(ADDRESS_STORAGE_FMT, $address);
+    return $this;
+  }
+
+  /**
+   * @param string|array $address
+   *   Ex: '"Foo Bar" <foo.bar@example.com>'
+   *   Ex: ['name' => "Foo Bar", "email" => "foo.bar@example.com"]
+   * @return $this
+   */
+  public function setReplyTo($address) {
+    $this->replyTo = $this->formatAddress(ADDRESS_STORAGE_FMT, $address);
+    return $this;
+  }
+
+  /**
+   * Set the "CC:" list.
+   *
+   * @param string|array $address
+   *   Ex: '"Foo Bar" <foo.bar@example.com>'
+   *   Ex: ['name' => "Foo Bar", "email" => "foo.bar@example.com"]
+   *   Ex: [['email' => 'first@example.com'], ['email' => 'second@example.com']]
+   * @return $this
+   */
+  public function setCc($address) {
+    $this->cc = $this->formatAddress(ADDRESS_STORAGE_FMT, $address);
+    return $this;
+  }
+
+  /**
+   * Set the "BCC:" list.
+   *
+   * @param string|array $address
+   *   Ex: '"Foo Bar" <foo.bar@example.com>'
+   *   Ex: ['name' => "Foo Bar", "email" => "foo.bar@example.com"]
+   *   Ex: [['email' => 'first@example.com'], ['email' => 'second@example.com']]
+   * @return $this
+   */
+  public function setBcc($address) {
+    $this->bcc = $this->formatAddress(ADDRESS_STORAGE_FMT, $address);
+    return $this;
+  }
+
+  /**
+   * Add another "CC:" address.
+   *
+   * @param string|array $address
+   *   Ex: '"Foo Bar" <foo.bar@example.com>'
+   *   Ex: ['name' => "Foo Bar", "email" => "foo.bar@example.com"]
+   *   Ex: [['email' => 'first@example.com'], ['email' => 'second@example.com']]
+   * @return $this
+   */
+  public function addCc($address) {
+    return $this->setCc(array_merge(
+      $this->getCc('records'),
+      $this->formatAddress('records', $address)
+    ));
+  }
+
+  /**
+   * Add another "BCC:" address.
+   *
+   * @param string|array $address
+   *   Ex: '"Foo Bar" <foo.bar@example.com>'
+   *   Ex: ['name' => "Foo Bar", "email" => "foo.bar@example.com"]
+   *   Ex: [['email' => 'first@example.com'], ['email' => 'second@example.com']]
+   * @return $this
+   */
+  public function addBcc($address) {
+    return $this->setBcc(array_merge(
+      $this->getBcc('records'),
+      $this->formatAddress('records', $address)
+    ));
+  }
+
+  /**
+   * Plugin to `WorkflowMessageInterface::import()` and handle toEmail/toName.
+   *
+   * @param array $values
+   * @see \Civi\WorkflowMessage\Traits\ReflectiveWorkflowTrait::import
+   */
+  protected function importExtraEnvelope_toAddress(array &$values): void {
+    if (array_key_exists('toEmail', $values) || array_key_exists('toName', $values)) {
+      $this->setTo(['name' => $values['toName'] ?? NULL, 'email' => $values['toEmail'] ?? NULL]);
+      unset($values['toName']);
+      unset($values['toEmail']);
+    }
+  }
+
+  /**
+   * Plugin to `WorkflowMessageInterface::export()` and handle toEmail/toName.
+   *
+   * @param array $values
+   * @see \Civi\WorkflowMessage\Traits\ReflectiveWorkflowTrait::export
+   */
+  protected function exportExtraEnvelope_toAddress(array &$values): void {
+    $addr = $this->getTo('record');
+    $values['toName'] = $addr['name'] ?? NULL;
+    $values['toEmail'] = $addr['email'] ?? NULL;
+  }
+
+  /**
+   * Convert an address to the desired format.
+   *
+   * @param string $newFormat
+   *   Ex: 'rfc822', 'records', 'record'
+   * @param array|string $mixed
+   * @return array|string|null
+   */
+  private function formatAddress($newFormat, $mixed) {
+    if ($mixed === NULL) {
+      return NULL;
+    }
+
+    $oldFormat = is_string($mixed) ? 'rfc822' : (array_key_exists('email', $mixed) ? 'record' : 'records');
+    if ($oldFormat === $newFormat) {
+      return $mixed;
+    }
+
+    $recordToObj = function (?array $record) {
+      return new \ezcMailAddress($record['email'], $record['name'] ?? '');
+    };
+    $objToRecord = function (?\ezcMailAddress $addr) {
+      return is_null($addr) ? NULL : ['email' => $addr->email, 'name' => $addr->name];
+    };
+
+    // Convert $mixed to intermediate format (ezcMailAddress[] $objects) and then to final format.
+
+    /** @var \ezcMailAddress[] $objects */
+
+    switch ($oldFormat) {
+      case 'rfc822':
+        $objects = \ezcMailTools::parseEmailAddresses($mixed);
+        break;
+
+      case 'record':
+        $objects = [$recordToObj($mixed)];
+        break;
+
+      case 'records':
+        $objects = array_map($recordToObj, $mixed);
+        break;
+
+      default:
+        throw new \RuntimeException("Unrecognized source format: $oldFormat");
+    }
+
+    switch ($newFormat) {
+      case 'rfc822':
+        // We use `implode(map(composeEmailAddress))` instead of `composeEmailAddresses` because the latter has header-line-wrapping.
+        return implode(', ', array_map(['ezcMailTools', 'composeEmailAddress'], $objects));
+
+      case 'record':
+        if (count($objects) > 1) {
+          throw new \RuntimeException("Cannot convert email addresses to record format. Too many addresses.");
+        }
+        return $objToRecord($objects[0] ?? NULL);
+
+      case 'records':
+        return array_map($objToRecord, $objects);
+
+      default:
+        throw new \RuntimeException("Unrecognized output format: $newFormat");
+    }
+  }
+
+}

--- a/Civi/WorkflowMessage/Traits/FinalHelperTrait.php
+++ b/Civi/WorkflowMessage/Traits/FinalHelperTrait.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\WorkflowMessage\Traits;
+
+/**
+ * Define a series of high-level, non-extensible helpers for WorkflowMessages,
+ * such as `renderTemplate()` or `sendTemplate()`.
+ *
+ * These helpers are convenient because it should be common to take a WorkflowMessage
+ * instance and pass it to a template. However, WorkflowMessage is the data-model
+ * for content of a message -- templating is outside the purview of WorkflowMessage.
+ * Consequently, there should not be any substantial templating logic here. Instead,
+ * these helpers MUST ONLY delegate out to a canonical renderer.
+ */
+trait FinalHelperTrait {
+
+  /**
+   * @see \Civi\WorkflowMessage\WorkflowMessageInterface::export()
+   * @see \Civi\WorkflowMessage\Traits\ReflectiveWorkflowTrait::export()
+   */
+  abstract public function export(string $format = NULL): ?array;
+
+  /**
+   * @see \Civi\WorkflowMessage\WorkflowMessageInterface::validate()
+   * @see \Civi\WorkflowMessage\Traits\ReflectiveWorkflowTrait::validate()
+   */
+  abstract public function validate(): array;
+
+  /**
+   * @see \Civi\WorkflowMessage\WorkflowMessageInterface::assertValid()
+   */
+  final public function assertValid($strict = FALSE) {
+    $validations = $this->validate();
+    if (!$strict) {
+      $validations = array_filter($validations, function ($validation) {
+        return $validation['severity'] === 'error';
+      });
+    }
+    if (!empty($validations)) {
+      throw new \CRM_Core_Exception(sprintf("Found %d validation error(s) in %s.", count($validations), get_class($this)));
+    }
+    return $this;
+  }
+
+  /**
+   * @see \Civi\WorkflowMessage\WorkflowMessageInterface::renderTemplate()
+   */
+  final public function renderTemplate(array $params = []): array {
+    $params['model'] = $this;
+    return \CRM_Core_BAO_MessageTemplate::renderTemplate($params);
+  }
+
+  /**
+   * @see \Civi\WorkflowMessage\WorkflowMessageInterface::sendTemplate()
+   */
+  final public function sendTemplate(array $params = []): array {
+    return \CRM_Core_BAO_MessageTemplate::sendTemplate($params + ['model' => $this]);
+  }
+
+  ///**
+  // * Get the list of available tokens.
+  // *
+  // * @return array
+  // *   Ex: ['contact.first_name' => ['entity' => 'contact', 'field' => 'first_name', 'label' => ts('Last Name')]]
+  // *   Array(string $dottedName => array('entity'=>string, 'field'=>string, 'label'=>string)).
+  // */
+  //final public function getTokens(): array {
+  //  $tp = new TokenProcessor(\Civi::dispatcher(), [
+  //    'controller' => static::CLASS,
+  //  ]);
+  //  $tp->addRow($this->export('tokenContext'));
+  //  return $tp->getTokens();
+  //}
+
+}

--- a/Civi/WorkflowMessage/Traits/ReflectiveWorkflowTrait.php
+++ b/Civi/WorkflowMessage/Traits/ReflectiveWorkflowTrait.php
@@ -1,0 +1,306 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\WorkflowMessage\Traits;
+
+use Civi\Api4\Utils\ReflectionUtils;
+
+/**
+ * The ReflectiveWorkflowTrait makes it easier to define
+ * workflow-messages using conventional PHP class-modeling. Thus:
+ *
+ * - As general rule, you define all inputs+outputs as PHP properties.
+ * - All key WorkflowMessage methods (getFields, import, export, validate)
+ *   are based reflection (inspecting types/annotations of the PHP properties).
+ * - Most common tasks can be done with annotations on the properties such
+ *   as `@var` and `@scope`.
+ * - If you need special behaviors (e.g. outputting derived data to the
+ *   Smarty context automatically), then you may override certain methods
+ *   (e.g. exportExtra*(), importExtra*()).
+ *
+ * Here are few important annotations:
+ *
+ * - `@var` - Specify the PHP type for the data. (Use '|' to list multiple permitted types.)
+ *   Ex: `@var string|bool`
+ * - `@scope` - Share data with another subsystem, such as the token-processor (`tokenContext`)
+ *   or Smarty (`tplParams`).
+ *   (By default, the property will have the same name in the other context, but)
+ *   Ex: `@scope tplParams`
+ *   Ex: `@scope tplParams as contact_id, tokenContext as contactId`
+ */
+trait ReflectiveWorkflowTrait {
+
+  /**
+   * The extras are an open-ended list of fields that will be passed-through to
+   * tpl, tokenContext, etc. This is the storage of last-resort for imported
+   * values that cannot be stored by other means.
+   *
+   * @var array
+   *   Ex: ['tplParams' => ['assigned_value' => 'A', 'other_value' => 'B']]
+   */
+  protected $_extras = [];
+
+  /**
+   * @inheritDoc
+   * @see \Civi\WorkflowMessage\WorkflowMessageInterface::getFields()
+   */
+  public function getFields(): array {
+    // Thread-local cache of class metadata. Class metadata is immutable at runtime, so this is strictly write-once. It should ideally be reused across varied test-functions.
+    static $caches = [];
+    $cache =& $caches[static::CLASS];
+    if ($cache === NULL) {
+      $cache = [];
+      foreach (ReflectionUtils::findStandardProperties(static::CLASS) as $property) {
+        /** @var \ReflectionProperty $property */
+        $parsed = ReflectionUtils::getCodeDocs($property, 'Property');
+        $field = new \Civi\WorkflowMessage\FieldSpec();
+        $field->setName($property->getName())->loadArray($parsed);
+        $cache[$field->getName()] = $field;
+      }
+    }
+    return $cache;
+  }
+
+  protected function getFieldsByFormat($format): ?array {
+    switch ($format) {
+      case 'modelProps':
+        return $this->getFields();
+
+      case 'envelope':
+      case 'tplParams':
+      case 'tokenContext':
+        $matches = [];
+        foreach ($this->getFields() as $field) {
+          /** @var \Civi\WorkflowMessage\FieldSpec $field */
+          if (isset($field->getScope()[$format])) {
+            $key = $field->getScope()[$format];
+            $matches[$key] = $field;
+          }
+        }
+        return $matches;
+
+      default:
+        return NULL;
+    }
+  }
+
+  /**
+   * @inheritDoc
+   * @see \Civi\WorkflowMessage\WorkflowMessageInterface::export()
+   */
+  public function export(string $format = NULL): ?array {
+    switch ($format) {
+      case 'modelProps':
+      case 'envelope':
+      case 'tokenContext':
+      case 'tplParams':
+        $values = $this->_extras[$format] ?? [];
+        $fieldsByFormat = $this->getFieldsByFormat($format);
+        foreach ($fieldsByFormat as $key => $field) {
+          /** @var \Civi\WorkflowMessage\FieldSpec $field */
+          $getter = 'get' . ucfirst($field->getName());
+          \CRM_Utils_Array::pathSet($values, explode('.', $key), $this->$getter());
+        }
+
+        $methods = ReflectionUtils::findMethodHelpers(static::CLASS, 'exportExtra' . ucfirst($format));
+        foreach ($methods as $method) {
+          $this->{$method->getName()}(...[&$values]);
+        }
+        return $values;
+
+      default:
+        return NULL;
+    }
+  }
+
+  /**
+   * @inheritDoc
+   * @see \Civi\WorkflowMessage\WorkflowMessageInterface::import()
+   */
+  public function import(string $format, array $values) {
+    $MISSING = new \stdClass();
+
+    switch ($format) {
+      case 'modelProps':
+      case 'envelope':
+      case 'tokenContext':
+      case 'tplParams':
+        $fields = $this->getFieldsByFormat($format);
+        foreach ($fields as $key => $field) {
+          /** @var \Civi\WorkflowMessage\FieldSpec $field */
+          $path = explode('.', $key);
+          $value = \CRM_Utils_Array::pathGet($values, $path, $MISSING);
+          if ($value !== $MISSING) {
+            $setter = 'set' . ucfirst($field->getName());
+            $this->$setter($value);
+            \CRM_Utils_Array::pathUnset($values, $path, TRUE);
+          }
+        }
+
+        $methods = ReflectionUtils::findMethodHelpers(static::CLASS, 'importExtra' . ucfirst($format));
+        foreach ($methods as $method) {
+          $this->{$method->getName()}($values);
+        }
+
+        if ($format !== 'modelProps' && !empty($values)) {
+          $this->_extras[$format] = array_merge($this->_extras[$format] ?? [], $values);
+          $values = [];
+        }
+        break;
+
+    }
+
+    return $this;
+  }
+
+  /**
+   * Determine if the data for this workflow message is complete/well-formed.
+   *
+   * @return array
+   *   A list of errors and warnings. Each record defines
+   *   - severity: string, 'error' or 'warning'
+   *   - fields: string[], list of fields implicated in the error
+   *   - name: string, symbolic name of the error/warning
+   *   - message: string, printable message describing the problem
+   * @see \Civi\WorkflowMessage\WorkflowMessageInterface::validate()
+   */
+  public function validate(): array {
+    $props = $this->export('modelProps');
+    $fields = $this->getFields();
+
+    $errors = [];
+    foreach ($fields as $fieldName => $fieldSpec) {
+      /** @var \Civi\WorkflowMessage\FieldSpec $fieldSpec */
+      $fieldValue = $props[$fieldName] ?? NULL;
+      if (!$fieldSpec->isRequired() && $fieldValue === NULL) {
+        continue;
+      }
+      if (!\CRM_Utils_Type::validatePhpType($fieldValue, $fieldSpec->getType(), FALSE)) {
+        $errors[] = [
+          'severity' => 'error',
+          'fields' => [$fieldName],
+          'name' => 'wrong_type',
+          'message' => ts('Field should have type %1.', [1 => implode('|', $fieldSpec->getType())]),
+        ];
+      }
+      if ($fieldSpec->isRequired() && ($fieldValue === NULL || $fieldValue === '')) {
+        $errors[] = [
+          'severity' => 'error',
+          'fields' => [$fieldName],
+          'name' => 'required',
+          'message' => ts('Missing required field %1.', [1 => $fieldName]),
+        ];
+      }
+    }
+
+    $methods = ReflectionUtils::findMethodHelpers(static::CLASS, 'validateExtra');
+    foreach ($methods as $method) {
+      $this->{$method->getName()}($errors);
+    }
+
+    return $errors;
+  }
+
+  // All of the methods below are empty placeholders. They may be overridden to customize behavior.
+
+  /**
+   * Get a list of key-value pairs to include the array-coded version of the class.
+   *
+   * @param array $export
+   *   Modifiable list of export-values.
+   */
+  protected function exportExtraModelProps(array &$export): void {
+  }
+
+  /**
+   * Get a list of key-value pairs to add to the token-context.
+   *
+   * @param array $export
+   *   Modifiable list of export-values.
+   */
+  protected function exportExtraTokenContext(array &$export): void {
+    $export['controller'] = static::CLASS;
+  }
+
+  /**
+   * Get a list of key-value pairs to include the Smarty template context.
+   *
+   * Values returned here will override any defaults.
+   *
+   * @param array $export
+   *   Modifiable list of export-values.
+   */
+  protected function exportExtraTplParams(array &$export): void {
+  }
+
+  /**
+   * Get a list of key-value pairs to include the Smarty template context.
+   *
+   * @param array $export
+   *   Modifiable list of export-values.
+   */
+  protected function exportExtraEnvelope(array &$export): void {
+    if ($wfName = \CRM_Utils_Constant::value(static::CLASS . '::WORKFLOW')) {
+      $export['valueName'] = $wfName;
+    }
+    if ($wfGroup = \CRM_Utils_Constant::value(static::CLASS . '::GROUP')) {
+      $export['groupName'] = $wfGroup;
+    }
+  }
+
+  /**
+   * Given an import-array (in the class-format), pull out any interesting values.
+   *
+   * @param array $values
+   *   List of import-values. Optionally, unset values that you have handled or blocked.
+   */
+  protected function importExtraModelProps(array &$values): void {
+  }
+
+  /**
+   * Given an import-array (in the token-context-format), pull out any interesting values.
+   *
+   * @param array $values
+   *   List of import-values. Optionally, unset values that you have handled or blocked.
+   */
+  protected function importExtraTokenContext(array &$values): void {
+  }
+
+  /**
+   * Given an import-array (in the tpl-format), pull out any interesting values.
+   *
+   * @param array $values
+   *   List of import-values. Optionally, unset values that you have handled or blocked.
+   */
+  protected function importExtraTplParams(array &$values): void {
+  }
+
+  /**
+   * Given an import-array (in the envelope-format), pull out any interesting values.
+   *
+   * @param array $values
+   *   List of import-values. Optionally, unset values that you have handled or blocked.
+   */
+  protected function importExtraEnvelope(array &$values): void {
+    if ($wfName = \CRM_Utils_Constant::value(static::CLASS . '::WORKFLOW')) {
+      if (isset($values['valueName']) && $wfName === $values['valueName']) {
+        unset($values['valueName']);
+      }
+    }
+    if ($wfGroup = \CRM_Utils_Constant::value(static::CLASS . '::GROUP')) {
+      if (isset($values['groupName']) && $wfGroup === $values['groupName']) {
+        unset($values['groupName']);
+      }
+    }
+  }
+
+}

--- a/Civi/WorkflowMessage/WorkflowMessage.php
+++ b/Civi/WorkflowMessage/WorkflowMessage.php
@@ -1,0 +1,173 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\WorkflowMessage;
+
+use Civi\WorkflowMessage\Exception\WorkflowMessageException;
+
+/**
+ * A WorkflowMessage describes the inputs to an automated email messages.
+ *
+ * These classes may be instantiated by either class-name or workflow-name.
+ *
+ * Ex: $msgWf = new \CRM_Foo_WorkflowMessage_MyAlert(['tplParams' => [...tplValues...]]);
+ * Ex: $msgWf = new \CRM_Foo_WorkflowMessage_MyAlert(['modelProps' => [...classProperties...]]);
+ * Ex: $msgWf = WorkflowMessage::create('my_alert_name', ['tplParams' => [...tplValues...]]);
+ * Ex: $msgWf = WorkflowMessage::create('my_alert_name', ['modelProps' => [...classProperties...]]);
+ *
+ * Instantiating by class-name will provide better hinting and inspection.
+ * However, some workflows may not have specific classes at the time of writing.
+ * Instantiating by workflow-name will work regardless of whether there is a specific class.
+ */
+class WorkflowMessage {
+
+  /**
+   * Create a new instance of the workflow-message context.
+   *
+   * @param string $wfName
+   *   Name of the workflow.
+   *   Ex: 'case_activity'
+   * @param array $imports
+   *   List of data to use when populating the message.
+   *
+   *   The parameters may be given in a mix of formats. This mix reflects two modes of operation:
+   *
+   *   - (Informal/Generic) Traditionally, workflow-messages did not have formal parameters. Instead,
+   *     they relied on a mix of un(der)documented/unverifiable inputs -- supplied as a mix of Smarty
+   *     assignments, token-data, and sendTemplate() params.
+   *   - (Formal) More recently, workflow-messages could be defined with a PHP class that lists the
+   *     inputs explicitly.
+   *
+   *   You may supply inputs using these keys:
+   *
+   *   - `tplParams` (array): Smarty data. These values go to `$smarty->assign()`.
+   *   - `tokenContext` (array): Token-processing data. These values go to `$tokenProcessor->context`.
+   *   - `envelope` (array): Email delivery data. These values go to `sendTemplate(...)`
+   *   - `modelProps` (array): Formal parameters defined by a class.
+   *
+   *   Informal workflow-messages ONLY support 'tplParams', 'tokenContext', and/or 'envelope'.
+   *   Formal workflow-messages accept any format.
+   *
+   * @return \Civi\WorkflowMessage\WorkflowMessageInterface
+   *   If there is a workflow-message class, then it will return an instance of that class.
+   *   Otherwise, it will return an instance of `GenericWorkflowMessage`.
+   * @throws \Civi\WorkflowMessage\Exception\WorkflowMessageException
+   */
+  public static function create(string $wfName, array $imports = []) {
+    $classMap = static::getWorkflowNameClassMap();
+    $class = $classMap[$wfName] ?? 'Civi\WorkflowMessage\GenericWorkflowMessage';
+    $imports['envelope']['valueName'] = $wfName;
+    $model = new $class();
+    static::importAll($model, $imports);
+    return $model;
+  }
+
+  /**
+   * Import a batch of params, updating the $model.
+   *
+   * @param \Civi\WorkflowMessage\WorkflowMessageInterface $model
+   * @param array $params
+   *   List of parameters, per MessageTemplate::sendTemplate().
+   *   Ex: Initialize using adhoc data:
+   *       ['tplParams' => [...], 'tokenContext' => [...]]
+   *   Ex: Initialize using properties of the class-model
+   *       ['modelProps' => [...]]
+   * @return \Civi\WorkflowMessage\WorkflowMessageInterface
+   *   The updated model.
+   * @throws \Civi\WorkflowMessage\Exception\WorkflowMessageException
+   */
+  public static function importAll(WorkflowMessageInterface $model, array $params) {
+    // The $params format is defined to match the traditional format of CRM_Core_BAO_MessageTemplate::sendTemplate().
+    // At the top level, it is an "envelope", but it also has keys for other sections.
+    if (isset($params['model'])) {
+      if ($params['model'] !== $model) {
+        throw new WorkflowMessageException(sprintf("%s: Cannot apply mismatched model", get_class($model)));
+      }
+      unset($params['model']);
+    }
+
+    \CRM_Utils_Array::pathMove($params, ['contactId'], ['tokenContext', 'contactId']);
+
+    // Core#644 - handle Email ID passed as "From".
+    if (isset($params['from'])) {
+      $params['from'] = \CRM_Utils_Mail::formatFromAddress($params['from']);
+    }
+
+    if (isset($params['tplParams'])) {
+      $model->import('tplParams', $params['tplParams']);
+      unset($params['tplParams']);
+    }
+    if (isset($params['tokenContext'])) {
+      $model->import('tokenContext', $params['tokenContext']);
+      unset($params['tokenContext']);
+    }
+    if (isset($params['modelProps'])) {
+      $model->import('modelProps', $params['modelProps']);
+      unset($params['modelProps']);
+    }
+    if (isset($params['envelope'])) {
+      $model->import('envelope', $params['envelope']);
+      unset($params['envelope']);
+    }
+    $model->import('envelope', $params);
+    return $model;
+  }
+
+  /**
+   * @param \Civi\WorkflowMessage\WorkflowMessageInterface $model
+   * @return array
+   *   List of parameters, per MessageTemplate::sendTemplate().
+   *   Ex: ['tplParams' => [...], 'tokenContext' => [...]]
+   */
+  public static function exportAll(WorkflowMessageInterface $model): array {
+    // The format is defined to match the traditional format of CRM_Core_BAO_MessageTemplate::sendTemplate().
+    // At the top level, it is an "envelope", but it also has keys for other sections.
+    $values = $model->export('envelope');
+    $values['tplParams'] = $model->export('tplParams');
+    $values['tokenContext'] = $model->export('tokenContext');
+    if (isset($values['tokenContext']['contactId'])) {
+      $values['contactId'] = $values['tokenContext']['contactId'];
+    }
+    return $values;
+  }
+
+  /**
+   * @return array
+   *   Array(string $workflowName => string $className).
+   *   Ex: ["case_activity" => "CRM_Case_WorkflowMessage_CaseActivity"]
+   * @internal
+   */
+  public static function getWorkflowNameClassMap() {
+    $cache = \Civi::cache('long');
+    $cacheKey = 'WorkflowMessage-' . __FUNCTION__;
+    $map = $cache->get($cacheKey);
+    if ($map === NULL) {
+      $map = [];
+      $map['generic'] = GenericWorkflowMessage::class;
+      $baseDirs = explode(PATH_SEPARATOR, get_include_path());
+      foreach ($baseDirs as $baseDir) {
+        $baseDir = \CRM_Utils_File::addTrailingSlash($baseDir);
+        $glob = (array) glob($baseDir . 'CRM/*/WorkflowMessage/*.php');
+        $glob = preg_grep('/\.ex\.php$/', $glob, PREG_GREP_INVERT);
+        foreach ($glob as $file) {
+          $class = strtr(preg_replace('/\.php$/', '', \CRM_Utils_File::relativize($file, $baseDir)), ['/' => '_', '\\' => '_']);
+          if (class_exists($class) && (new \ReflectionClass($class))->implementsInterface(WorkflowMessageInterface::class)) {
+            $map[$class::WORKFLOW] = $class;
+          }
+        }
+      }
+      $cache->set($cacheKey, $map);
+    }
+    return $map;
+  }
+
+}

--- a/Civi/WorkflowMessage/WorkflowMessageInterface.php
+++ b/Civi/WorkflowMessage/WorkflowMessageInterface.php
@@ -56,4 +56,59 @@ interface WorkflowMessageInterface {
    */
   public function validate(): array;
 
+  // These additional methods are sugar-coating - they're part of the interface to
+  // make it easier to work with, but implementers should not differentiate themselves
+  // using this methods. Instead, use FinalHelperTrait as a thin implementation.
+
+  /**
+   * Assert that the current message data is valid/sufficient.
+   *
+   * TIP: Do not implement directly. Use FinalHelperTrait.
+   *
+   * @param bool $strict
+   *   If TRUE, then warnings will raise exceptions.
+   *   If FALSE, then only errors will raise exceptions.
+   * @return $this
+   * @throws \CRM_Core_Exception
+   */
+  public function assertValid($strict = FALSE);
+
+  /**
+   * Render a message template.
+   *
+   * TIP: Do not implement directly. Use FinalHelperTrait.
+   *
+   * @param array $params
+   *   Options for loading the message template.
+   *   If none given, the default for this workflow will be loaded.
+   *   Ex: ['messageTemplate' => ['msg_subject' => 'Hello {contact.first_name}']]
+   *   Ex: ['messageTemplateID' => 123]
+   * @return array
+   *   Rendered message, consistent of 'subject', 'text', 'html'
+   *   Ex: ['subject' => 'Hello Bob', 'text' => 'It\'s been so long since we sent you an automated notification!']
+   * @see \CRM_Core_BAO_MessageTemplate::renderTemplate()
+   */
+  public function renderTemplate(array $params = []): array;
+
+  /**
+   * Send an email using a message template.
+   *
+   * TIP: Do not implement directly. Use FinalHelperTrait.
+   *
+   * @param array $params
+   *   List of extra parameters to pass to `sendTemplate()`. Ex:
+   *   - from
+   *   - toName
+   *   - toEmail
+   *   - cc
+   *   - bcc
+   *   - replyTo
+   *   - isTest
+   *
+   * @return array
+   *   Array of four parameters: a boolean whether the email was sent, and the subject, text and HTML templates
+   * @see \CRM_Core_BAO_MessageTemplate::sendTemplate()
+   */
+  public function sendTemplate(array $params = []): array;
+
 }

--- a/Civi/WorkflowMessage/WorkflowMessageInterface.php
+++ b/Civi/WorkflowMessage/WorkflowMessageInterface.php
@@ -1,0 +1,59 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\WorkflowMessage;
+
+interface WorkflowMessageInterface {
+
+  /**
+   * @return \Civi\WorkflowMessage\FieldSpec[]
+   *   A list of field-specs that are used in the given format, keyed by their name in that format.
+   *   If the implementation does not understand a specific format, return NULL.
+   */
+  public function getFields(): array;
+
+  /**
+   * @param string $format
+   *   Ex: 'tplParams', 'tokenContext', 'modelProps', 'envelope'
+   * @return array|null
+   *   A list of field-values that are used in the given format, keyed by their name in that format.
+   *   If the implementation does not understand a specific format, return NULL.
+   * @see \Civi\WorkflowMessage\Traits\ReflectiveWorkflowTrait::export()
+   */
+  public function export(string $format = NULL): ?array;
+
+  /**
+   * Import values from some scope.
+   *
+   * Ex: $message->import('tplParams', ['sm_art_stuff' => 123]);
+   *
+   * @param string $format
+   *   Ex: 'tplParams', 'tokenContext', 'modelProps', 'envelope'
+   * @param array $values
+   *
+   * @return $this
+   * @see \Civi\WorkflowMessage\Traits\ReflectiveWorkflowTrait::import()
+   */
+  public function import(string $format, array $values);
+
+  /**
+   * Determine if the data for this workflow message is complete/well-formed.
+   *
+   * @return array
+   *   A list of errors and warnings. Each record defines
+   *   - severity: string, 'error' or 'warning'
+   *   - fields: string[], list of fields implicated in the error
+   *   - name: string, symbolic name of the error/warning
+   *   - message: string, printable message describing the problem
+   */
+  public function validate(): array;
+
+}

--- a/tests/phpunit/Civi/WorkflowMessage/ExampleWorkflowMessageTest.php
+++ b/tests/phpunit/Civi/WorkflowMessage/ExampleWorkflowMessageTest.php
@@ -1,0 +1,262 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\WorkflowMessage;
+
+use Civi\Test\Invasive;
+
+/**
+ * Test the WorkflowMessage class
+ *
+ * @group headless
+ */
+class ExampleWorkflowMessageTest extends \CiviUnitTestCase {
+
+  protected function setUp(): void {
+    $this->useTransaction();
+    parent::setUp();
+  }
+
+  /**
+   * @return \Civi\WorkflowMessage\WorkflowMessageInterface
+   */
+  protected static function createExample() {
+    return new class() extends GenericWorkflowMessage {
+
+      const WORKFLOW = 'my_example_wf';
+
+      const GROUP = 'my_example_grp';
+
+      /**
+       * @var string
+       * @scope tplParams as my_public_string
+       */
+      public $myPublicString;
+
+      /**
+       * @var int
+       * @scope tplParams as my_int
+       */
+      protected $myProtectedInt;
+
+      /**
+       * @var string[]
+       */
+      protected $implicitStringArray;
+
+      /**
+       * @var string[]
+       * @dataType Text
+       * @serialize COMMA
+       */
+      protected $explicitStringArray;
+
+      /**
+       * @var int
+       * @scope tplParams as some.deep.thing
+       * @required
+       */
+      protected $deepValue;
+
+      protected function exportExtraTplParams(array &$export): void {
+        $export['some_extra_tpl_stuff'] = 100;
+      }
+
+    };
+  }
+
+  public function testValidateFail() {
+    /** @var \Civi\WorkflowMessage\WorkflowMessageInterface $ex */
+    $ex = static::createExample();
+    $ex->import('modelProps', [
+      'myPublicString' => 'ok',
+      'implicitStringArray' => 'single',
+      'myProtectedInt' => 'two',
+      'deepValue' => NULL,
+    ]);
+    $errors = $ex->validate();
+    $expected = [];
+    $expected[] = ['severity' => 'error', 'fields' => ['contactId', 'contact'], 'name' => 'missingContact', 'message' => 'Message template requires one of these fields (contactId, contact)'];
+    $expected[] = ['severity' => 'error', 'fields' => ['implicitStringArray'], 'name' => 'wrong_type', 'message' => 'Field should have type string[].'];
+    $expected[] = ['severity' => 'error', 'fields' => ['myProtectedInt'], 'name' => 'wrong_type', 'message' => 'Field should have type int.'];
+    $expected[] = ['severity' => 'error', 'fields' => ['deepValue'], 'name' => 'wrong_type', 'message' => 'Field should have type int.'];
+    $expected[] = ['severity' => 'error', 'fields' => ['deepValue'], 'name' => 'required', 'message' => 'Missing required field deepValue.'];
+
+    $cmp = function($a, $b) {
+      if ($v = strnatcmp($a['message'], $b['message'])) {
+        return $v;
+      }
+      return strnatcmp(implode(',', $a['fields']), implode(',', $b['fields']));
+    };
+    usort($errors, $cmp);
+    usort($expected, $cmp);
+    $this->assertEquals($expected, $errors);
+  }
+
+  public function testValidatePass() {
+    /** @var \Civi\WorkflowMessage\WorkflowMessageInterface $ex */
+    $ex = static::createExample();
+    $ex->import('modelProps', [
+      'contactId' => $this->individualCreate(),
+      'myPublicString' => 'ok',
+      'implicitStringArray' => ['single'],
+      'myProtectedInt' => 2,
+      'deepValue' => 34,
+    ]);
+    $errors = $ex->validate();
+    $expected = [];
+    $this->assertEquals($expected, $errors);
+  }
+
+  /**
+   * Assert that "getFields()" provides metadata from properties/docblocks.
+   */
+  public function testGetFields() {
+    /** @var \Civi\WorkflowMessage\WorkflowMessageInterface $ex */
+    $ex = static::createExample();
+    $fields = $ex->getFields();
+    /** @var \Civi\WorkflowMessage\FieldSpec $field */
+
+    $field = $fields['myPublicString'];
+    $this->assertEquals(['string'], $field->getType());
+    $this->assertEquals('String', $field->getDataType());
+    $this->assertEquals(NULL, $field->getSerialize());
+
+    $field = $fields['implicitStringArray'];
+    $this->assertEquals(['string[]'], $field->getType());
+    $this->assertEquals('Blob', $field->getDataType());
+    $this->assertEquals(\CRM_Core_DAO::SERIALIZE_JSON, $field->getSerialize());
+
+    $field = $fields['explicitStringArray'];
+    $this->assertEquals(['string[]'], $field->getType());
+    $this->assertEquals('Text', $field->getDataType());
+    $this->assertEquals(\CRM_Core_DAO::SERIALIZE_COMMA, $field->getSerialize());
+
+    $field = $fields['myProtectedInt'];
+    $this->assertEquals(['int'], $field->getType());
+    $this->assertEquals('Integer', $field->getDataType());
+    $this->assertEquals(NULL, $field->getSerialize());
+  }
+
+  /**
+   * Assert that getters/setters work on class fields.
+   */
+  public function testGetSetClassFields() {
+    /** @var \Civi\WorkflowMessage\WorkflowMessageInterface $ex */
+    $ex = static::createExample();
+
+    $ex->setmyProtectedInt(5);
+    $this->assertEquals(5, $ex->getmyProtectedInt());
+    $this->assertEquals(5, Invasive::get([$ex, 'myProtectedInt']));
+
+    $ex->setMyPublicString('hello');
+    $this->assertEquals('hello', $ex->getMyPublicString());
+    $this->assertEquals('hello', $ex->myPublicString);
+  }
+
+  /**
+   * Assert that import()/export() work on standard fields.
+   */
+  public function testImportExportStandardField() {
+    /** @var \Civi\WorkflowMessage\WorkflowMessageInterface $ex */
+    $ex = static::createExample();
+
+    $ex->import('tplParams', [
+      'my_public_string' => 'hello world',
+      'my_int' => 10,
+      'some' => ['deep' => ['thing' => 20]],
+    ]);
+
+    $this->assertEquals('hello world', $ex->getMyPublicString());
+    $this->assertEquals(10, $ex->getMyProtectedInt());
+    $this->assertEquals(20, $ex->getDeepValue());
+
+    $ex->myPublicString .= ' and stuff';
+    $ex->setDeepValue(22);
+
+    $tpl = $ex->export('tplParams');
+    $this->assertEquals('hello world and stuff', $tpl['my_public_string']);
+    $this->assertEquals(10, $tpl['my_int']);
+    $this->assertEquals(22, $tpl['some']['deep']['thing']);
+    $this->assertEquals(100, $tpl['some_extra_tpl_stuff']);
+
+    $envelope = $ex->export('envelope');
+    $this->assertEquals('my_example_wf', $envelope['valueName']);
+    $this->assertEquals('my_example_grp', $envelope['groupName']);
+  }
+
+  /**
+   * Assert that unrecognized fields are preserved in the round-trip from import=>export.
+   */
+  public function testImportExportExtraField() {
+    /** @var \Civi\WorkflowMessage\WorkflowMessageInterface $ex */
+    $ex = static::createExample();
+
+    $ex->import('tplParams', [
+      'my.st!er_y' => ['is not mentioned anywhere'],
+    ]);
+
+    $tpl = $ex->export('tplParams');
+    $this->assertEquals(['is not mentioned anywhere'], $tpl['my.st!er_y']);
+  }
+
+  /**
+   * Assert that
+   */
+  public function testImportExportUnmappedField() {
+    /** @var \Civi\WorkflowMessage\WorkflowMessageInterface $ex */
+    $ex = static::createExample();
+
+    $ex->import('tplParams', [
+      'implicitStringArray' => ['is not mapped between class and tpl'],
+    ]);
+
+    $this->assertEquals(NULL, $ex->getimplicitStringArray());
+    $ex->setimplicitStringArray(['this is the real class field']);
+
+    $tpl = $ex->export('tplParams');
+    $this->assertEquals(['is not mapped between class and tpl'], $tpl['implicitStringArray']);
+
+    $classData = $ex->export('modelProps');
+    $this->assertEquals(['this is the real class field'], $classData['implicitStringArray']);
+  }
+
+  /**
+   * Create an impromptu instance of  `WorkflowMessage` for a new/unknown workflow.
+   */
+  public function testImpromptuImportExport() {
+    /** @var \Civi\WorkflowMessage\WorkflowMessageInterface $ex */
+    $ex = WorkflowMessage::create('some_impromptu_wf', [
+      'envelope' => ['from' => 'foo@example.com'],
+      'tokenContext' => ['contactId' => 123],
+      'tplParams' => [
+        'myImpromputInt' => 456,
+        'impromptu_smarty_data' => ['is not mentioned anywhere'],
+      ],
+    ]);
+    $this->assertTrue($ex instanceof GenericWorkflowMessage);
+
+    $tpl = $ex->export('tplParams');
+    $this->assertEquals(456, $tpl['myImpromputInt']);
+    $this->assertEquals(['is not mentioned anywhere'], $tpl['impromptu_smarty_data']);
+    $this->assertTrue(!isset($tpl['valueName']));
+
+    $envelope = $ex->export('envelope');
+    $this->assertEquals('some_impromptu_wf', $envelope['valueName']);
+    $this->assertEquals('foo@example.com', $envelope['from']);
+    $this->assertTrue(!isset($envelope['myProtectedInt']));
+
+    $tokenCtx = $ex->export('tokenContext');
+    $this->assertEquals(123, $tokenCtx['contactId']);
+    $this->assertTrue(!isset($envelope['myProtectedInt']));
+  }
+
+}

--- a/tests/phpunit/Civi/WorkflowMessage/FieldSpecTest.php
+++ b/tests/phpunit/Civi/WorkflowMessage/FieldSpecTest.php
@@ -1,0 +1,61 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\WorkflowMessage;
+
+/**
+ * @group headless
+ */
+class FieldSpecTest extends \CiviUnitTestCase {
+
+  protected function setUp(): void {
+    $this->useTransaction();
+    parent::setUp();
+  }
+
+  public function getScopeExamples() {
+    // When the naming convention is more established, one might improve readability by inlining these constants.
+    $tpl = 'tplParams';
+    $tok = 'tokenContext';
+
+    $exs = [];
+    $exs[] = [$tpl, [$tpl => 'foo']];
+    $exs[] = ["$tpl as foo.bar", [$tpl => 'foo.bar']];
+    $exs[] = ["$tpl, $tok", [$tpl => 'foo', $tok => 'foo']];
+    $exs[] = ["$tok, $tpl as foo.bar", [$tok => 'foo', $tpl => 'foo.bar']];
+    $exs[] = ["$tok as fooBar, $tpl", [$tok => 'fooBar', $tpl => 'foo']];
+    return $exs;
+  }
+
+  /**
+   * Test that the setScope()/getScope() normalization works.
+   *
+   * @param mixed $input
+   *   The value to pass into `setScope()`
+   * @param array $expect
+   *   The resulting value to expect from `getScope()`.
+   * @dataProvider getScopeExamples
+   */
+  public function testSetScope($input, $expect) {
+    $f = new FieldSpec();
+    $f->setName('foo');
+
+    // Check that the inputs are translated
+    $f->setScope($input);
+    $getScope = $f->getScope();
+    $this->assertEquals($expect, $getScope);
+
+    // The output of translation should be stable/convergent.
+    $f->setScope($getScope);
+    $this->assertEquals($expect, $f->getScope());
+  }
+
+}

--- a/tests/phpunit/Civi/WorkflowMessage/Traits/AddressingTraitTest.php
+++ b/tests/phpunit/Civi/WorkflowMessage/Traits/AddressingTraitTest.php
@@ -1,0 +1,215 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\WorkflowMessage\Traits;
+
+use Civi\WorkflowMessage\GenericWorkflowMessage;
+
+class AddressingTraitTest extends \CiviUnitTestCase {
+
+  protected function setUp(): void {
+    $this->useTransaction();
+    parent::setUp();
+  }
+
+  /**
+   * @return \Civi\WorkflowMessage\GenericWorkflowMessage
+   */
+  protected static function createExample() {
+    return new class() extends GenericWorkflowMessage {
+
+      const WORKFLOW = 'ex_address_wf';
+
+      const GROUP = 'ex_address_grp';
+    };
+  }
+
+  /**
+   * Set email addresses using fluent methods (setTo(), setCc(), etc).
+   */
+  public function testFluentSetup() {
+    $wfm = $this->createExample()
+      // Setters support array or string inputs. All address fields support the same formats.
+      ->setTo(['name' => 'Foo', 'email' => 'foo@example.com'])
+      ->setReplyTo('Nobody <nobody@example.com>')
+      ->setCc([['email' => 'cc1@example.com'], ['name' => 'Bob', 'email' => 'cc2@example.com']]);
+
+    $this->assertEquals(['email' => 'nobody@example.com', 'name' => 'Nobody'], $wfm->getReplyTo('record'));
+
+    $export = $wfm->export('envelope');
+
+    $this->assertEquals('Foo', $export['toName']);
+    $this->assertEquals('foo@example.com', $export['toEmail']);
+    $this->assertEquals('cc1@example.com, Bob <cc2@example.com>', $export['cc']);
+    $this->assertEquals('Nobody <nobody@example.com>', $export['replyTo']);
+  }
+
+  /**
+   * Set email addresses using fluent methods (setTo(), setCc(), etc).
+   */
+  public function testFluentAdder() {
+    $wfm = $this->createExample()
+      // Setters support array or string inputs. All address fields support the same formats.
+      ->setCc([['email' => 'cc1@example.com'], ['name' => 'Bob', 'email' => 'cc2@example.com']])
+      ->addCc('"Third" <cc3@example.com>')
+      ->addCc(['email' => 'cc4@example.com', 'name' => 'Fourth\'s']);
+
+    $this->assertEquals('cc1@example.com, Bob <cc2@example.com>, Third <cc3@example.com>, "Fourth\'s" <cc4@example.com>', $wfm->getCc('rfc822'));
+  }
+
+  /**
+   * Set email addresses using model-properties.
+   */
+  public function testModelPropsSetup() {
+    $wfm = $this->createExample()
+      ->import('modelProps', [
+        // modelProps support array or string inputs. All address fields support the same formats.
+        'to' => ['name' => 'Foo', 'email' => 'foo@example.com'],
+        'replyTo' => 'Nobody <nobody@example.com>',
+        'cc' => [['email' => 'cc1@example.com'], ['name' => 'Bob', 'email' => 'cc2@example.com']],
+      ]);
+
+    $this->assertEquals(['email' => 'nobody@example.com', 'name' => 'Nobody'], $wfm->getReplyTo('record'));
+
+    $export = $wfm->export('envelope');
+
+    $this->assertEquals('Foo', $export['toName']);
+    $this->assertEquals('foo@example.com', $export['toEmail']);
+    $this->assertEquals('cc1@example.com, Bob <cc2@example.com>', $export['cc']);
+    $this->assertEquals('Nobody <nobody@example.com>', $export['replyTo']);
+  }
+
+  /**
+   * Set email addresses using sendTemplate()'s envelope format.
+   */
+  public function testEnvelopeSetup() {
+    $ex = $this->createExample();
+
+    $envelopeArray = [
+      'toName' => "It's Me",
+      'toEmail' => 'me@example.com',
+      'from' => '<from@example.com>',
+      'replyTo' => '"Reply To Me" <replyto@example.com>',
+      'cc' => 'cc1@example.com, <cc2@example.com>, "Third" <cc3@example.com>',
+    ];
+
+    $ex->import('envelope', $envelopeArray);
+    $this->assertEquals(['name' => "It's Me", 'email' => 'me@example.com'], $ex->getTo('record'));
+    $this->assertEquals(['name' => NULL, 'email' => 'from@example.com'], $ex->getFrom('record'));
+    $this->assertEquals(['name' => 'Reply To Me', 'email' => 'replyto@example.com'], $ex->getReplyTo('record'));
+    $this->assertEquals([
+      ['name' => NULL, 'email' => 'cc1@example.com'],
+      ['name' => NULL, 'email' => 'cc2@example.com'],
+      ['name' => 'Third', 'email' => 'cc3@example.com'],
+    ], $ex->getCc('records'));
+
+    $actualExport = $ex->export('envelope');
+    foreach ($envelopeArray as $key => $value) {
+      $this->assertEquals($value, $actualExport[$key], "Key '$key' should match");
+    }
+  }
+
+  public function testSingularValues() {
+    $ex = $this->createExample();
+
+    $singularFields = ['to', 'from', 'replyTo', 'cc', 'bcc'];
+
+    $singularExamples = [];
+    $singularExamples[] = [
+      'rfc822' => 'Foo Bar <foo@example.com>',
+      'record' => ['name' => 'Foo Bar', 'email' => 'foo@example.com'],
+      'records' => [['name' => 'Foo Bar', 'email' => 'foo@example.com']],
+    ];
+    $singularExamples[] = [
+      'rfc822' => 'foo@example.com',
+      'record' => ['name' => NULL, 'email' => 'foo@example.com'],
+      'records' => [['name' => NULL, 'email' => 'foo@example.com']],
+    ];
+
+    $this->assertNotEmpty($singularFields);
+    foreach ($singularFields as $field) {
+      $setter = 'set' . ucfirst($field);
+      $getter = 'get' . ucfirst($field);
+
+      $this->assertNotEmpty($singularExamples);
+      foreach ($singularExamples as $equivalenceSet) {
+        $this->assertNotEmpty($equivalenceSet);
+        foreach (array_keys($equivalenceSet) as $inFormat) {
+          foreach (array_keys($equivalenceSet) as $outFormat) {
+            $ex->{$setter}(NULL);
+            $this->assertEquals(NULL, $ex->{$getter}(), "Field ($field) should start at empty");
+
+            $ex->{$setter}($equivalenceSet[$inFormat]);
+            $this->assertEquals($equivalenceSet[$outFormat], $ex->{$getter}($outFormat), "Field ($field) should return equivalent result (method=setter, in=$inFormat, out=$outFormat)");
+
+            if ($field !== 'to') {
+              $export = $ex->export('envelope');
+              $this->assertEquals($equivalenceSet['rfc822'], $export[$field], 'export() always produces header format');
+
+              $ex->{$setter}(NULL);
+              $this->assertEquals(NULL, $ex->{$getter}(), "Field ($field) should start at empty");
+
+              $ex->import('envelope', [$field => $equivalenceSet[$inFormat]]);
+              $this->assertEquals($equivalenceSet[$outFormat], $ex->{$getter}($outFormat), "Field ($field) should return equivalent result (method=import, in=$inFormat, out=$outFormat)");
+            }
+          }
+        }
+      }
+    }
+  }
+
+  public function testPluralValues() {
+    $ex = $this->createExample();
+
+    $pluralFields = ['cc', 'bcc'];
+
+    $pluralExamples = [];
+    $pluralExamples[] = [
+      'rfc822' => 'First <first@example.com>, "Second\'s Name" <second@example.com>, third@example.com',
+      'records' => [
+        ['name' => 'First', 'email' => 'first@example.com'],
+        ['name' => "Second's Name", 'email' => 'second@example.com'],
+        ['name' => NULL, 'email' => 'third@example.com'],
+      ],
+    ];
+    $pluralExamples[] = [
+      'rfc822' => '',
+      'records' => [],
+    ];
+
+    $this->assertNotEmpty($pluralFields);
+    foreach ($pluralFields as $field) {
+      $setter = 'set' . ucfirst($field);
+      $getter = 'get' . ucfirst($field);
+
+      $this->assertNotEmpty($pluralExamples);
+      foreach ($pluralExamples as $equivalenceSet) {
+        $this->assertNotEmpty($equivalenceSet);
+        foreach (array_keys($equivalenceSet) as $inFormat) {
+          foreach (array_keys($equivalenceSet) as $outFormat) {
+            $ex->{$setter}(NULL);
+            $this->assertEquals(NULL, $ex->{$getter}(), "Field ($field) should start at empty");
+
+            $ex->{$setter}($equivalenceSet[$inFormat]);
+            $this->assertEquals($equivalenceSet[$outFormat], $ex->{$getter}($outFormat), "Field ($field) should return equivalent result (method=setter, in=$inFormat, out=$outFormat)");
+
+            $ex->{$setter}(NULL);
+            $this->assertEquals(NULL, $ex->{$getter}(), "Field ($field) should start at empty");
+
+            $ex->import('envelope', [$field => $equivalenceSet[$inFormat]]);
+            $this->assertEquals($equivalenceSet[$outFormat], $ex->{$getter}($outFormat), "Field ($field) should return equivalent result (method=import, in=$inFormat, out=$outFormat)");
+          }
+        }
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------

A *workflow message* is an automatic, standardized email sent as part of some workflow - for example, sending a receipt for an online donation, sending a reminder for membership renewal, or sending an update about an on-going case. The content of a *workflow message* can be customized to communicate details that are important to each user-organization. However, there are usability challenges when working them. This PR introduces a mechanism for *describing* and *validating* workflow messages -- which will enable richer APIs and UIs.

Corresponding MR for developer docs:

* Gitlab: https://lab.civicrm.org/documentation/docs/dev/-/merge_requests/962
* Preview: https://think.hm/docs/dev/framework/message/

Background
----------------------------------------

CiviCRM currently tracks *message templates* (`civicrm_msg_template`). Some are "System workflow message templates", and others are "User-driven message templates". This PR focuses on "System workflow message templates" - which are distinguished by the fields `workflow_name` and `workflow_id`. System processes will search on this `workflow_*` property and then compose/deliver automated messages.

Every workflow is a little different, e.g.

* A receipt letter for an online donation might reference the completed `Contribution`, and
* A reminder for a membership renewal might reference the existing `Membership` and point out how to make a new `Contribution`, and
* A case update might reference a new `Activity` and key `Case` properties.

These form different *contracts*. Consider the membership renewal example:

* __Administrative User / Message Author__: When editing the Membership renewal message, the author may incorporate information about the `Membership` (e.g. its pricing; its original start date; its last contribution; its expiration date) and member's contact information (e.g. first name, lastname, email).
* __Developer / System Automator__: When trigger a new email, they must supply corresponding information (such as the `Membership` and `Contact` record).

Understanding this contract is important to tasks like:

* Editing a message template ("What data can I reference?")
* Previewing a message template ("What example data must I supply?")
* Editing code which triggers the email ("What real data must I supply?")

The "Before" and "After" consider the shape of this contract.

Before
----------------------------------------

The contract is informal, but there are some common elements:

* All (almost all?) have support for `{contact.*}` tokens
* All (almost all?) have some mix of bespoke Smarty variables (e.g. `{$contributionMode}`)
* Some may support other tokens (`{contribution.*}`, `{activity.*}`)

Messages are most often generated by way of `CRM_Core_BAO_MessageTemplate::sendTemplate()`.

```php
CRM_Core_BAO_MessageTemplate::sendTemplate([
  'groupName' => 'msg_tpl_workflow_mygrp',
  'valueName' => 'mymsg',
  'contactId' => 100,
  'tplParams' => [
    'someTitle' => 'Hello world',
    'senderMessage' => 'The sun is a mass of incandescent gas.',
  ],
  'from' => '"Sender Name" <sender@example.com>',
  'toName' => 'Recipient Name',
  'toEmail' => 'recip@example.com',
]);
```

Following recent revisions, you can take this a bit further - setting the `tokenContext` can enable tokens like `{contribution.*}`, `{activity.*}`, eg

```php
CRM_Core_BAO_MessageTemplate::sendTemplate([
  ...
  'tokenContext' => [
    'contributionId' => 200,
    'membershipId' => 300,
  ],
  ...
]);
```

However, there is no metadata for this message. For example, if you are an administrator (or an admin GUI developer), you would need to determine that `mymsg` defines `tplParams` (`someTitle`, `senderMessage`) as well as `tokenContext` (`contributionId`, `membershipId`).  This, in turn, determines what token expressions are valid (e.g. `{contribution.total_amount}`). But we lack metadata, so the admin GUI cannot present this information.

After
----------------------------------------

The contract is explicit. The example above could be declared as:

```php
class CRM_Mysubsystem_WorkflowMessage_MyMsg extends GenericWorkflowMessage {
  const GROUP = 'msg_tpl_workflow_mygrp';
  const WORKFLOW = 'mymsg';

  /**
   * @var int
   * @fkEntity Contribution
   * @scope tokenContext
   * @required
   */
  protected $contributionId;

  /**
   * @var int
   * @fkEntity Membership
   * @scope tokenContext
   * @required
   */
  protected $membershipId;

  /**
   * @var string
   * @scope tplParams
   */
  protected $someTitle;

  /**
   * @var string
   * @scope tplParams
   * @required
   */
  protected $senderMessage;
}
```

This message can still be sent in the same as in "Before". Additionally, it supports OOP usage:

```php
$msg = new CRM_Mysubsystem_WorkflowMessage_MyMsg(); // Use a specific class, or
$msg = WorkflowMessage:create('mymsg'); // Use the workflow name
```

which can be inspected:

```php
$fields = $msg->getFields();
```

Or use OOP interface to fill, validate, render, and/or send the message.

```php
$msg->setTo(['name' => 'Recip Name', 'email' => 'recip@example.com'])
  ->setFrom(['name' => 'Sender Name', 'email' => 'sender@example.com'])
  ->setSomeTitle('Hello world')
  ->setSenderMessage('The sun is a mass of incandescent gas.')
  ->setContactId(100)
  ->setContributionId(200);

$errors = $msg->validate();
$msg->assertValid();
$rendered = $msg->renderTemplate();
$sent = $msg->sendTemplate();
```

Under the hood, these are the same processes as `sendTemplate()`. It is fairly flexible about accepting data via fluent getter/setter methods - or via array. The class has various extension points (`validate()`, `validateExtra*`, `importExtra*()`, `exportExtra*()`) which can be used to control/migrate/phase-in/phase-out elements of each contract.

Comments
------------------------

If you peek ahead into #20975, there are APIv4 mechanisms for finding/loading examples, getting the list of fields, and rendering previews. 

Using a *PHP class* to model this information isn't strictly necessary - you could theoretically model fields with XML or JSON. Using the class gives us several more mechanisms for refactoring (e.g. setter/getter methods, import/export methods). Additionally, this allows us to reuse the class-parsing/annotation mechanisms from APIv4.

Class models are static (*use the fields we define!*). The traditional method `sendTemplate(['tplParams'=>[...], 'tokenContext'=>[...], ...])` is more dynamic (*add any random thing*). IMHO, that's mostly a good thing (*more predictability*), but there may be edge-cases were dynamic fields are important. That is still possible - dynamic fields work with `$msg->import('tplParams', [...$dynamicFields..])` and `$msg->export('tplParams')`. Any unrecognized fields are simply passed through. This make it amenable to progressive enhancement (where you incrementally declare important fields).