### PR TITLE
Use convenience function for one-off token evaluations to avoid too-long filenames and possible privacy issues

### DIFF
--- a/Civi/Token/TokenCompatSubscriber.php
+++ b/Civi/Token/TokenCompatSubscriber.php
@@ -130,8 +130,7 @@ class TokenCompatSubscriber implements EventSubscriberInterface {
     }
 
     if ($useSmarty) {
-      $smarty = \CRM_Core_Smarty::singleton();
-      $e->string = $smarty->fetch("string:" . $e->string);
+      $e->string = \CRM_Utils_String::parseOneOffStringThroughSmarty($e->string);
     }
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Addresses conversation at https://github.com/civicrm/civicrm-core/pull/21064#issuecomment-895192218 and uses same idea as in https://github.com/civicrm/civicrm-core/pull/16733

Before
----------------------------------------
Filename like this, that also possibly unnecessarily caches personal info.

 `templates_c/en_US//%%27/27E/27EEDEE2%%string%3A%0A++++++first+name+%3D+Alice%0A++++++receive_date+%3D+February+1st%2C+2015+12%3A00+AM%0A++++++contribution+status+id+%3D+1%0A++++++new+style+status+%3D+Completed%0A++++++new+style+label+%3D+Completed+Label%2A%2A%0A++++++id+1%0A++++++contribution_id++-+not+valid+for+action+schedule%0A++++++cancel+date+August+9th%2C+2021+12%3A00+AM%0A++++++source+SSF%0A++++++legacy+source+%0A++++++financial+type+id+%3D+1%0A++++++financial+type+name+%3D+Donation%0A++++++financial+type+label+%3D+Donation%0A++++++payment+instrument+id+%3D+4%0A++++++payment+instrument+name+%3D+Check%0A++++++payment+instrument+label+%3D+Check%0A++++++non_deductible_amount+%3D+%E2%82%AC+10.00%0A++++++total_amount+%3D+%E2%82%AC+100.00%0A++++++net_amount+%3D+%E2%82%AC+95.00%0A++++++fee_amount+%3D+%E2%82%AC+5.00.php` 


After
----------------------------------------
Filename looks something like `eval+var%3D%24smartySingleUseString.php`

Technical Details
----------------------------------------


Comments
----------------------------------------
Has test in the sense it came up during a form of stress-testing with the tests and at least one of them calls this.
