### PR TITLE
APIv4 - Remove ineffective security check

### DIFF
--- a/CRM/Api4/Page/AJAX.php
+++ b/CRM/Api4/Page/AJAX.php
@@ -21,27 +21,6 @@ class CRM_Api4_Page_AJAX extends CRM_Core_Page {
    * Handler for api4 ajax requests
    */
   public function run() {
-    $config = CRM_Core_Config::singleton();
-    if (!$config->debug && (!array_key_exists('HTTP_X_REQUESTED_WITH', $_SERVER) ||
-        $_SERVER['HTTP_X_REQUESTED_WITH'] != "XMLHttpRequest"
-      )
-    ) {
-      $response = [
-        'error_code' => 401,
-        'error_message' => "SECURITY ALERT: Ajax requests can only be issued by javascript clients, eg. CRM.api4().",
-      ];
-      Civi::log()->debug("SECURITY ALERT: Ajax requests can only be issued by javascript clients, eg. CRM.api4().",
-        [
-          'IP' => $_SERVER['REMOTE_ADDR'],
-          'level' => 'security',
-          'referer' => $_SERVER['HTTP_REFERER'],
-          'reason' => 'CSRF suspected',
-        ]
-      );
-      CRM_Utils_System::setHttpHeader('Content-Type', 'application/json');
-      echo json_encode($response);
-      CRM_Utils_System::civiExit();
-    }
     if ($_SERVER['REQUEST_METHOD'] == 'GET' &&
       strtolower(substr($this->urlPath[4], 0, 3)) != 'get') {
       $response = [


### PR DESCRIPTION
Overview
----------------------------------------
Removes an ineffective security check which was not doing anything but getting in the way of some ajax clients.

Before
----------------------------------------
Ineffective check attempting ensure the ajax api was called via ajax.

After
----------------------------------------
Good riddance.

Technical Details
----------------------------------------
This conditional acted like it was performing a security check, but it was not.
`HTTP_X_REQUESTED_WITH` headers can be set to anything by the client, and is therefore not a security check at all. But it does interfere with ajax file uploads.

Comments
----------------------------------------
This is blocking work on Afform file uploads.