### PR TITLE
[REF] Fix e-notice in APIv3 Profile Test on PHP8

### DIFF
--- a/api/v3/Profile.php
+++ b/api/v3/Profile.php
@@ -604,6 +604,7 @@ function _civicrm_api3_buildprofile_submitfields($profileID, $optionsBehaviour, 
        */
     }
   }
+  $profileFields[$profileID] = $profileFields[$profileID] ?? [];
   uasort($profileFields[$profileID], "_civicrm_api3_order_by_weight");
   return $profileFields[$profileID];
 }


### PR DESCRIPTION
Overview
----------------------------------------
This fixes an e-notice error on php 8 unit tests on 5.40, 5.41, master branches

Before
----------------------------------------
Test e-notice

```
api_v3_ProfileTest::testProfileSubmitInvalidProfileId
TypeError: uasort(): Argument #1 ($array) must be of type array, null given

/home/jenkins/bknix-edge/build/build-0/web/sites/all/modules/civicrm/api/v3/Profile.php:607
```

After
----------------------------------------
Test passes on php8

ping @eileenmcnaughton @totten 