### PR TITLE
dev/core#2745 - Contribution Tokens - Support 'contributionId'

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -5150,11 +5150,7 @@ LIMIT 1;";
     }
     if (!empty($messageToken['contribution'])) {
       $processor = new CRM_Contribute_Tokens();
-      $pseudoFields = array_keys($processor->getPseudoTokens());
-      foreach ($pseudoFields as $pseudoField) {
-        $split = explode(':', $pseudoField);
-        $result['values'][$id][$pseudoField] = $processor->getPseudoValue($split[0], $split[1], $result['values'][$id][$split[0]] ?? '');
-      }
+      $result['values'][$id] = array_merge($result['values'][$id], $processor->getPseudoValues($id));
     }
     return $result;
   }

--- a/CRM/Contribute/Tokens.php
+++ b/CRM/Contribute/Tokens.php
@@ -28,13 +28,6 @@ class CRM_Contribute_Tokens extends CRM_Core_EntityTokens {
   }
 
   /**
-   * @return string
-   */
-  protected function getEntityAlias(): string {
-    return 'contrib_';
-  }
-
-  /**
    * Get the entity name for api v4 calls.
    *
    * In practice this IS just ucfirst($this->GetEntityName)
@@ -47,15 +40,16 @@ class CRM_Contribute_Tokens extends CRM_Core_EntityTokens {
   }
 
   /**
-   * Get a list of tokens for the entity for which access is permitted to.
+   * Get a list of tokens which are loaded via APIv4.
    *
    * This list is historical and we need to question whether we
    * should filter out any fields (other than those fields, like api_key
    * on the contact entity) with permissions defined.
    *
    * @return array
+   *   Ex: ['foo', 'bar_id', 'bar_id:name', 'bar_id:label']
    */
-  protected function getExposedFields(): array {
+  protected function getApiTokens(): array {
     $fields = [
       'contribution_page_id',
       'source',
@@ -73,35 +67,58 @@ class CRM_Contribute_Tokens extends CRM_Core_EntityTokens {
       'thankyou_date',
       'tax_amount',
       'contribution_status_id',
+      'contribution_status_id:name',
+      'contribution_status_id:label',
       'financial_type_id',
+      'financial_type_id:name',
+      'financial_type_id:label',
       'payment_instrument_id',
+      'payment_instrument_id:name',
+      'payment_instrument_id:label',
       'cancel_reason',
       'amount_level',
       'check_number',
     ];
     if (CRM_Campaign_BAO_Campaign::isCampaignEnable()) {
       $fields[] = 'campaign_id';
+      $fields[] = 'campaign_id.name';
+      $fields[] = 'campaign_id.title';
     }
+
     return $fields;
   }
 
-  /**
-   * Get tokens supporting the syntax we are migrating to.
-   *
-   * In general these are tokens that were not previously supported
-   * so we can add them in the preferred way or that we have
-   * undertaken some, as yet to be written, db update.
-   *
-   * See https://lab.civicrm.org/dev/core/-/issues/2650
-   *
-   * @return string[]
-   */
-  public function getBasicTokens(): array {
-    $return = [];
-    foreach ($this->getExposedFields() as $fieldName) {
-      $return[$fieldName] = $this->getFieldMetadata()[$fieldName]['title'];
+  public function getAliasTokens(): array {
+    $aliases = [];
+    if (CRM_Campaign_BAO_Campaign::isCampaignEnable()) {
+      // Unit-tests are written to use these funny tokens - but they're not valid in APIv4.
+      $aliases['campaign'] = 'campaign_id.name';
+      $aliases['campaign_id:name'] = 'campaign_id.name';
+      $aliases['campaign_id:label'] = 'campaign_id.title';
     }
-    return $return;
+    return $aliases;
+  }
+
+  public function getPrefetchFields(\Civi\Token\Event\TokenValueEvent $e): array {
+    $result = parent::getPrefetchFields($e);
+
+    // Always prefetch 'civicrm_contribution.currency' in case we need to format other fields (fee_amount, total_amount, etc).
+    $result[] = 'currency';
+
+    return array_unique($result);
+  }
+
+  public function evaluateToken(\Civi\Token\TokenRow $row, $entity, $field, $prefetch = NULL) {
+    $values = $prefetch[$row->context[$this->getEntityIDField()]];
+
+    // Any monetary fields in a `Contribution` (`fee_amount`, `total_amount`, etc) should be formatted in matching `currency`.
+    // This formatting rule would be nonsensical in any other entity.
+    if ($this->isApiFieldType($field, 'Money')) {
+      return $row->format('text/plain')->tokens($entity, $field,
+        \CRM_Utils_Money::format($values[$field], $values['currency']));
+    }
+
+    return parent::evaluateToken($row, $entity, $field, $prefetch);
   }
 
 }

--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -1567,6 +1567,7 @@ class CRM_Utils_Token {
       $tokens = array_merge(CRM_Contribute_BAO_Contribution::exportableFields('All'),
         ['campaign' => [], 'financial_type' => [], 'payment_instrument' => []],
         self::getCustomFieldTokens('Contribution'),
+        $processor->getAliasTokens(),
         $processor->getPseudoTokens()
       );
       foreach ($tokens as $token) {

--- a/Civi/Token/TokenRow.php
+++ b/Civi/Token/TokenRow.php
@@ -233,6 +233,27 @@ class TokenRow {
   }
 
   /**
+   * Copy a token, including any/all available formats.
+   *
+   * @param string $src
+   *   Ex: 'contact.foo_bar'
+   * @param string $dest
+   *   Ex: 'contact.whiz_bang'
+   * @return TokenRow
+   */
+  public function copyToken($src, $dest) {
+    [$srcEntity, $srcField] = explode('.', $src, 2);
+    [$destEntity, $destField] = explode('.', $dest, 2);
+    $rv = &$this->tokenProcessor->rowValues;
+    foreach (array_keys($rv[$this->tokenRow]) as $format) {
+      if (isset($rv[$this->tokenRow][$format][$srcEntity][$srcField])) {
+        $rv[$this->tokenRow][$format][$destEntity][$destField] = $rv[$this->tokenRow][$format][$srcEntity][$srcField];
+      }
+    }
+    return $this;
+  }
+
+  /**
    * Auto-convert between different formats
    *
    * @param string $format

--- a/tests/phpunit/CRM/Contribute/ActionMapping/ByTypeTest.php
+++ b/tests/phpunit/CRM/Contribute/ActionMapping/ByTypeTest.php
@@ -10,6 +10,7 @@
  */
 
 use Civi\Api4\Contribution;
+use Civi\Token\TokenProcessor;
 
 /**
  * Class CRM_Contribute_ActionMapping_ByTypeTest
@@ -318,6 +319,21 @@ class CRM_Contribute_ActionMapping_ByTypeTest extends \Civi\ActionSchedule\Abstr
       'campaign label = Campaign',
     ];
     $this->mut->checkMailLog($expected);
+
+    $tokenProcessor = new TokenProcessor(\Civi::dispatcher(), [
+      'controller' => get_class(),
+      'smarty' => FALSE,
+      'contributionId' => $this->ids['Contribution']['alice'],
+      'contactId' => $this->contacts['alice']['id'],
+    ]);
+    $tokenProcessor->addRow([]);
+    $tokenProcessor->addMessage('html', $this->schedule->body_text, 'text/plain');
+    $tokenProcessor->evaluate();
+    foreach ($tokenProcessor->getRows() as $row) {
+      foreach ($expected as $value) {
+        $this->assertStringContainsString($value, $row->render('html'));
+      }
+    }
 
     $messageToken = CRM_Utils_Token::getTokens($this->schedule->body_text);
 


### PR DESCRIPTION
Overview
----------------------------------------

Change the way that CiviContribute tokens are loaded.

Refresh of #21079 which mixes in  #21134.

ping @eileenmcnaughton 

Before
----------------------------------------

`CRM_Contribution_Tokens` prefetches token data via `alterActionScheduleQuery()`. 

After
----------------------------------------

`CRM_Contribution_Tokens` prefetches token data via `prefetch()` and `civicrm_api4()`. This uses the `$tokenRow->context['contributionId']` values, which means that:

* You can use this in non-Scheduled-Reminder code.
* The Scheduled-Reminder queries become simpler


