### PR TITLE
[NFC] Update testCaseActivityCopyTemplate to provide variable that would usually be present

### DIFF
--- a/tests/phpunit/CRM/Core/BAO/MessageTemplateTest.php
+++ b/tests/phpunit/CRM/Core/BAO/MessageTemplateTest.php
@@ -177,6 +177,7 @@ class CRM_Core_BAO_MessageTemplateTest extends CiviUnitTestCase {
       ],
       'activitySubject' => 'Test 123',
       'idHash' => substr(sha1(CIVICRM_SITE_KEY . '1234'), 0, 7),
+      'contact' => ['role' => 'Sand grain counter'],
     ];
 
     [, $subject, $message] = CRM_Core_BAO_MessageTemplate::sendTemplate(
@@ -192,7 +193,7 @@ class CRM_Core_BAO_MessageTemplateTest extends CiviUnitTestCase {
     );
 
     $this->assertEquals('[case #' . $tplParams['idHash'] . '] Test 123', $subject);
-    $this->assertStringContainsString('Your Case Role', $message);
+    $this->assertStringContainsString('Your Case Role(s) : Sand grain counter', $message);
     $this->assertStringContainsString('Case ID : 1234', $message);
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Usually the `contact` variable would be filled.

Before
----------------------------------------
Not filled.

After
----------------------------------------
Has something in it.

Technical Details
----------------------------------------
For the bigger picture I'm a little conflicted on what to think about the `|default` smarty modifier. If interested see https://github.com/civicrm/civicrm-core/pull/21064#issuecomment-898896861.

Comments
----------------------------------------
Is test
