### PR TITLE
[REF] Fix e-notice in APIv3 Profile Test on PHP8

### DIFF
--- a/api/v3/Profile.php
+++ b/api/v3/Profile.php
@@ -604,6 +604,7 @@ function _civicrm_api3_buildprofile_submitfields($profileID, $optionsBehaviour, 
        */
     }
   }
+  $profileFields[$profileID] = $profileFields[$profileID] ?? [];
   uasort($profileFields[$profileID], "_civicrm_api3_order_by_weight");
   return $profileFields[$profileID];
 }


### PR DESCRIPTION
Remove e-notice issue found by dave d

Overview
----------------------------------------
Backport of #21143 to 5.40 given that https://github.com/civicrm/civicrm-core/pull/21099 has also been backported to 5.40

@eileenmcnaughton 