### PR TITLE
dev/core#2717 Use order api for new membership create in batch

### DIFF
--- a/CRM/Financial/BAO/Order.php
+++ b/CRM/Financial/BAO/Order.php
@@ -1059,6 +1059,26 @@ class CRM_Financial_BAO_Order {
   }
 
   /**
+   * Get the constructed line items formatted for the v3 Order api.
+   *
+   * @return array
+   *
+   * @internal core tested code only.
+   *
+   * @throws \CiviCRM_API3_Exception
+   */
+  public function getLineItemForV3OrderApi(): array {
+    $lineItems = [];
+    foreach ($this->getLineItems() as $key => $line) {
+      $lineItems[] = [
+        'line_item' => [$line['price_field_value_id'] => $line],
+        'params' => $this->entityParameters[$key] ?? [],
+      ];
+    }
+    return $lineItems;
+  }
+
+  /**
    * @return array
    * @throws \API_Exception
    * @throws \Civi\API\Exception\UnauthorizedException

--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -289,9 +289,9 @@ class CRM_Member_BAO_Membership extends CRM_Member_DAO_Membership {
       else {
         $calcDates = [];
       }
-      $params['start_date'] = $params['start_date'] ?? ($calcDates['start_date'] ?? 'null');
-      $params['end_date'] = $params['end_date'] ?? ($calcDates['end_date'] ?? 'null');
-      $params['join_date'] = $params['join_date'] ?? ($calcDates['join_date'] ?? 'null');
+      $params['start_date'] = empty($params['start_date']) ? ($calcDates['start_date'] ?? 'null') : $params['start_date'];
+      $params['end_date'] = empty($params['end_date']) ? ($calcDates['end_date'] ?? 'null') : $params['end_date'];
+      $params['join_date'] = empty($params['join_date']) ? ($calcDates['join_date'] ?? 'null') : $params['join_date'];
 
       //fix for CRM-3570, during import exclude the statuses those having is_admin = 1
       $excludeIsAdmin = $params['exclude_is_admin'] ?? FALSE;

--- a/tests/phpunit/CRM/Batch/Form/EntryTest.php
+++ b/tests/phpunit/CRM/Batch/Form/EntryTest.php
@@ -201,6 +201,7 @@ class CRM_Batch_Form_EntryTest extends CiviUnitTestCase {
     //check start dates #1 should default to 1 Jan this year, #2 should be as entered
     $this->assertEquals(date('Y-m-d', strtotime('first day of January 2013')), $memberships[1]['start_date']);
     $this->assertEquals('2013-02-03', $memberships[2]['start_date']);
+    $this->assertEquals('2013-12-31', $memberships[2]['end_date']);
 
     //check start dates #1 should default to 1 Jan this year, #2 should be as entered
     $this->assertEquals(date('Y-m-d', strtotime('last day of December 2013')), $memberships[1]['end_date']);
@@ -346,8 +347,7 @@ class CRM_Batch_Form_EntryTest extends CiviUnitTestCase {
           'financial_type' => 2,
           'total_amount' => $this->formatMoneyInput(1500),
           'receive_date' => '2013-07-17',
-          'receive_date_time' => NULL,
-          'payment_instrument' => NULL,
+          'payment_instrument' => 1,
           'trxn_id' => 'TX102',
           'check_number' => NULL,
           'contribution_status_id' => 1,
@@ -362,8 +362,7 @@ class CRM_Batch_Form_EntryTest extends CiviUnitTestCase {
           'financial_type' => 2,
           'total_amount' => $this->formatMoneyInput(1500),
           'receive_date' => '2013-07-17',
-          'receive_date_time' => NULL,
-          'payment_instrument' => NULL,
+          'payment_instrument' => 1,
           'trxn_id' => 'TX103',
           'check_number' => NULL,
           'contribution_status_id' => 1,


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#2717 Use order api for new membership create in batch

Before
----------------------------------------
Batch membership create calls membership bao directly

After
----------------------------------------
As with the back office membership form it calls the order api

Technical Details
----------------------------------------
@kcristiano this is really how I think the code should wind up looking for this flow (although the renew flow still needs more work.) It really does surface the setting of the end date though as the order flow expectst that all 3 dates will be set when it is in pending status. I have fixed it to that in the BAO - but it does mean it's not possible to avoid setting it if I do it this way.

I guess I could only pass in date fields if they are populated - which would cause the BAO to otherwise set them, That might be where I end up as I *think* we can treat the failure to set end_date as a bug.

Comments
----------------------------------------
