### PR TITLE
[NFC] Update CRM_Core_RegionTest so it doesn't need the error-suppression operator

### DIFF
--- a/tests/phpunit/CRM/Core/RegionTest.php
+++ b/tests/phpunit/CRM/Core/RegionTest.php
@@ -23,7 +23,12 @@ class CRM_Core_RegionTest extends CiviUnitTestCase {
    * @return \CRM_Core_Resources_CollectionInterface
    */
   public function createEmptyCollection() {
-    @++Civi::$statics['CRM_Core_RegionTestId'];
+    if (empty(Civi::$statics['CRM_Core_RegionTestId'])) {
+      Civi::$statics['CRM_Core_RegionTestId'] = 1;
+    }
+    else {
+      ++Civi::$statics['CRM_Core_RegionTestId'];
+    }
     $r = new CRM_Core_Region('region_' . Civi::$statics['CRM_Core_RegionTestId']);
     $r->filter(function($snippet) {
       return $snippet['name'] !== 'default';


### PR DESCRIPTION
Overview
----------------------------------------
It doesn't need to be this clever in a test. The operator can potentially cause problems with error-handlers in php 8.

See https://github.com/civicrm/civicrm-core/pull/21064