### PR TITLE
dev/translation#71 getFullMonthNames: do not rely on the OS for translation

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -1361,20 +1361,8 @@ class CRM_Report_Form extends CRM_Core_Form {
               !is_array($field['options']) || empty($field['options'])
             ) {
               // If there's no option list for this filter, define one.
-              $field['options'] = [
-                1 => ts('January'),
-                2 => ts('February'),
-                3 => ts('March'),
-                4 => ts('April'),
-                5 => ts('May'),
-                6 => ts('June'),
-                7 => ts('July'),
-                8 => ts('August'),
-                9 => ts('September'),
-                10 => ts('October'),
-                11 => ts('November'),
-                12 => ts('December'),
-              ];
+              $field['options'] = CRM_Utils_Date::getFullMonthNames();
+
               // Add this option list to this column _columns. This is
               // required so that filter statistics show properly.
               $this->_columns[$table]['filters'][$fieldName]['options'] = $field['options'];

--- a/CRM/Utils/Date.php
+++ b/CRM/Utils/Date.php
@@ -237,16 +237,27 @@ class CRM_Utils_Date {
    *
    */
   public static function &getFullMonthNames() {
-    static $fullMonthNames;
-    if (!isset($fullMonthNames)) {
-
-      // set LC_TIME and build the arrays from locale-provided names
-      CRM_Core_I18n::setLcTime();
-      for ($i = 1; $i <= 12; $i++) {
-        $fullMonthNames[$i] = strftime('%B', mktime(0, 0, 0, $i, 10, 1970));
-      }
+    if (empty(\Civi::$statics[__CLASS__]['fullMonthNames'])) {
+      // Not relying on strftime because it depends on the operating system
+      // and most people will not have a non-US locale configured out of the box
+      // Ignoring other date names for now, since less visible by default
+      \Civi::$statics[__CLASS__]['fullMonthNames'] = [
+        1 => ts('January'),
+        2 => ts('February'),
+        3 => ts('March'),
+        4 => ts('April'),
+        5 => ts('May'),
+        6 => ts('June'),
+        7 => ts('July'),
+        8 => ts('August'),
+        9 => ts('September'),
+        10 => ts('October'),
+        11 => ts('November'),
+        12 => ts('December'),
+      ];
     }
-    return $fullMonthNames;
+
+    return \Civi::$statics[__CLASS__]['fullMonthNames'];
   }
 
   /**


### PR DESCRIPTION
https://lab.civicrm.org/dev/translation/-/issues/71

Overview
----------------------------------------

This kind of question comes up from time to time:
https://civicrm.stackexchange.com/questions/35468/date-in-english-even-when-page-is-set-to-french/40170

>   "The date is always uses English month and day names regardless of the interface language. How do I fix this?"

The main issue is because currently translating the month name relies on the operating system. The non-English locale must be enabled so that strftime outputs the correct month name (ex: "janvier" not "January").

Most people somewhat control their hosting environment, and can enable it once they know how, but since the default CiviCRM date format uses %B (full month name), it gives a bad first impression. Considering we already have those strings in Transifex, it would be easy to just hardcode the list of months and translate using 'ts'.

Before
----------------------------------------

Month names are not translated unless a root does `dpkg-reconfigure locales` and enables the correct `xx_YY.utf8` and then restarts fpm or apache. Or a few hours of fiddling on Docker images.

After
----------------------------------------

Month names are translated out of the box.

Technical Details
----------------------------------------

Relies on Transifex translations (using `ts`) instead of `strftime`.

Comments
----------------------------------------

I did not bother for now with month abbreviations and other names in `CRM_Utils_Date`, because they are not used out of the box and would require adding more strings to Transifex.

![image](https://user-images.githubusercontent.com/254741/129592129-cabdd157-ee39-4571-9680-c674807bbbf1.png)
