### PR TITLE
dev/core#2486 APIv4 - Add File entity

### DIFF
--- a/Civi/Api4/File.php
+++ b/Civi/Api4/File.php
@@ -1,0 +1,22 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+namespace Civi\Api4;
+
+/**
+ * File entity.
+ *
+ * @searchable none
+ * @since 5.41
+ * @package Civi\Api4
+ */
+class File extends Generic\DAOEntity {
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Adds a simple API for Files

Technical Details
----------------------------------------
Because custom file fields declare an FK to `civicrm_file`, it's useful to have an api for the FK entity. And this fixes some SearchKit errors reported when an entity contains custom File fields.