### PR TITLE
SearchKit - Misc bulk action bug fixes

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin/resultsTable/crmSearchAdminResultsTable.html
+++ b/ext/search_kit/ang/crmSearchAdmin/resultsTable/crmSearchAdminResultsTable.html
@@ -2,7 +2,7 @@
   <div ng-include="'~/crmSearchAdmin/resultsTable/debug.html'"></div>
   <div class="form-inline">
     <div class="btn-group" ng-include="'~/crmSearchDisplay/SearchButton.html'"></div>
-    <crm-search-tasks entity="$ctrl.apiEntity" ids="$ctrl.selectedRows" refresh="$ctrl.getResults()"></crm-search-tasks>
+    <crm-search-tasks entity="$ctrl.apiEntity" ids="$ctrl.selectedRows" refresh="$ctrl.refreshAfterTask()"></crm-search-tasks>
   </div>
   <table>
     <thead>

--- a/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTable.html
+++ b/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTable.html
@@ -1,7 +1,7 @@
 <div class="crm-search-display crm-search-display-table">
   <div class="form-inline">
     <div class="btn-group" ng-include="'~/crmSearchDisplay/SearchButton.html'" ng-if="$ctrl.settings.button"></div>
-    <crm-search-tasks ng-if="$ctrl.settings.actions" entity="$ctrl.apiEntity" ids="$ctrl.selectedRows" refresh="$ctrl.getResults()"></crm-search-tasks>
+    <crm-search-tasks ng-if="$ctrl.settings.actions" entity="$ctrl.apiEntity" ids="$ctrl.selectedRows" refresh="$ctrl.refreshAfterTask()"></crm-search-tasks>
   </div>
   <table>
     <thead>

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchInput/crmSearchInput.component.js
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchInput/crmSearchInput.component.js
@@ -21,7 +21,7 @@
         }
         // If no search operator this is an input for e.g. the bulk update action
         // Return `true` if the field is multi-valued, else `null`
-        return ctrl.field.serialize || ctrl.field.data_type === 'Array' ? true : null;
+        return ctrl.field && (ctrl.field.serialize || ctrl.field.data_type === 'Array') ? true : null;
       };
 
       this.$onInit = function() {

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchInput/crmSearchInputVal.component.js
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchInput/crmSearchInputVal.component.js
@@ -85,28 +85,29 @@
       };
 
       this.getTemplate = function() {
+        var field = ctrl.field || {};
 
-        if (ctrl.field.input_type === 'Date') {
+        if (field.input_type === 'Date') {
           return '~/crmSearchTasks/crmSearchInput/date.html';
         }
 
-        if (ctrl.field.data_type === 'Boolean') {
+        if (field.data_type === 'Boolean') {
           return '~/crmSearchTasks/crmSearchInput/boolean.html';
         }
 
-        if (ctrl.field.options) {
+        if (field.options) {
           return '~/crmSearchTasks/crmSearchInput/select.html';
         }
 
-        if (ctrl.field.fk_entity || ctrl.field.name === 'id') {
+        if (field.fk_entity || field.name === 'id') {
           return '~/crmSearchTasks/crmSearchInput/entityRef.html';
         }
 
-        if (ctrl.field.data_type === 'Integer') {
+        if (field.data_type === 'Integer') {
           return '~/crmSearchTasks/crmSearchInput/integer.html';
         }
 
-        if (ctrl.field.data_type === 'Float') {
+        if (field.data_type === 'Float') {
           return '~/crmSearchTasks/crmSearchInput/float.html';
         }
 
@@ -114,7 +115,8 @@
       };
 
       this.getFieldOptions = function() {
-        return {results: formatForSelect2(ctrl.field.options, ctrl.optionKey || 'id', 'label', ['description', 'color', 'icon'])};
+        var field = ctrl.field || {};
+        return {results: formatForSelect2(field.options || [], ctrl.optionKey || 'id', 'label', ['description', 'color', 'icon'])};
       };
 
     }

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchTaskUpdate.ctrl.js
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchTaskUpdate.ctrl.js
@@ -13,7 +13,7 @@
 
     crmApi4(model.entity, 'getFields', {
       action: 'update',
-      select: ['name', 'label', 'description', 'data_type', 'serialize', 'options', 'fk_entity'],
+      select: ['name', 'label', 'description', 'input_type', 'data_type', 'serialize', 'options', 'fk_entity'],
       loadOptions: ['id', 'name', 'label', 'description', 'color', 'icon'],
       where: [["readonly", "=", false]],
     }).then(function(fields) {

--- a/ext/search_kit/ang/crmSearchTasks/traits/searchDisplayTasksTrait.service.js
+++ b/ext/search_kit/ang/crmSearchTasks/traits/searchDisplayTasksTrait.service.js
@@ -52,6 +52,12 @@
         return this.allRowsSelected || _.includes(this.selectedRows, row.id);
       },
 
+      refreshAfterTask: function() {
+        this.selectedRows.length = 0;
+        this.allRowsSelected = false;
+        this.runSearch();
+      },
+
       // Overwrite empty onChangeFilters array from searchDisplayBaseTrait
       onChangeFilters: [function() {
         // Reset selection when filters are changed


### PR DESCRIPTION
Overview
----------------------------------------
Minor bug fixes in SearchKit bulk actions.

Before
----------------------------------------
- Deleting one or more records with the bulk delete action would still leave them selected, leading to a confusing message about e.g. "2 Contacts selected" even when they were gone: 
![image](https://user-images.githubusercontent.com/2874912/129621122-f6336d67-cbbf-4101-9402-fa347c70066c.png)
- Choosing a date field, e.g. "Birth Date" from the bulk update dialog would show it as a text input rather than date: 
![image](https://user-images.githubusercontent.com/2874912/129621286-b42b59c5-17f0-495c-8c1b-0a1a8c95573a.png)
- Clearing a field (by pressing the **x** in the Select2) would cause javascript errors in the console: 
![image](https://user-images.githubusercontent.com/2874912/129621435-fb0fe763-3a30-40bc-91ea-ebac8a91b124.png)


After
----------------------------------------
All better :adhesive_bandage: 
