### PR TITLE
[Ref] remove unused variable

### DIFF
--- a/CRM/Core/DAO/AllCoreTables.php
+++ b/CRM/Core/DAO/AllCoreTables.php
@@ -366,11 +366,9 @@ class CRM_Core_DAO_AllCoreTables {
 
   /**
    * Reinitialise cache.
-   *
-   * @param bool $fresh
    */
-  public static function reinitializeCache($fresh = FALSE) {
-    self::init($fresh);
+  public static function reinitializeCache() {
+    self::init(TRUE);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
This function is only called from one place in universe & that one place 

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/129670287-798cee76-d643-4b76-b51a-10efa01873e0.png)


After
----------------------------------------
the var is gone

Technical Details
----------------------------------------
It doesn't make sense to call this with FALSE because you might as well just call init ....

Comments
----------------------------------------

