### PR TITLE
release-notes/5.40.2.md - Add reference to Gitlab issue

### DIFF
--- a/release-notes/5.40.2.md
+++ b/release-notes/5.40.2.md
@@ -21,7 +21,7 @@ Released August 17, 2021
 ## <a name="bugs"></a>Bugs resolved
 
 * **_APIv3_: Fix performance regression when processing `Campaign`-affiliated data ([dev/core#2743](https://lab.civicrm.org/dev/core/-/issues/2743): [#21099](https://github.com/civicrm/civicrm-core/pull/21099), [#21143](https://github.com/civicrm/civicrm-core/pull/21143))**
-* **_CiviContribute_: setOverrideTotal() receives malformatted quantities ([#21107](https://github.com/civicrm/civicrm-core/pull/21107))**
+* **_CiviContribute_: Fix support for editing contribution amount with "," ([dev/core#2756](https://lab.civicrm.org/dev/core/-/issues/2756): [#21107](https://github.com/civicrm/civicrm-core/pull/21107))**
 * **_CiviEvent, et al_: Fix loading of form validation utility ([#21124](https://github.com/civicrm/civicrm-core/pull/21124))**
 * **_CiviMember_: Fix handling of free memberships ([dev/core#2749](https://lab.civicrm.org/dev/core/-/issues/2749): [#21100](https://github.com/civicrm/civicrm-core/pull/21100))**
 * **_CiviMember_: Fix error in batch update ([#21151](https://github.com/civicrm/civicrm-core/pull/21151))**
@@ -34,8 +34,8 @@ This release was developed by the following authors and reviewers:
 
 Wikimedia Foundation - Eileen McNaughton; timo.kabsch; SYSTOPIA Organisationsberatung -
 Björn Endres; Megaphone Technology Consulting - Jon Goldberg; JMA Consulting - Seamus Lee;
-Greenpeace Central and Eastern Europe - Patrick Figel; Dave D; Coop SymbioTIC - Mathieu
-Lutfy; CiviCRM - Coleman Watts, Tim Otten; Artful Robot - Rich Lott
+Greenpeace Central and Eastern Europe - Patrick Figel; Digitalcourage - Detlev Sieber;  Dave D;
+Coop SymbioTIC - Mathieu Lutfy; CiviCRM - Coleman Watts, Tim Otten; Artful Robot - Rich Lott
 
 ## <a name="feedback"></a>Feedback
 


### PR DESCRIPTION
The Gitlab issue provides a clearer explanation of the problem.

Note: None of the PRs had referenced the Gitlab issue, so the link didn't make it into the first pass of release notes.
