### PR TITLE
dev/core#2763 cache clearing fix

### DIFF
--- a/CRM/Core/Config.php
+++ b/CRM/Core/Config.php
@@ -278,6 +278,8 @@ class CRM_Core_Config extends CRM_Core_Config_MagicMerge {
     // clear all caches
     self::clearDBCache();
     Civi::cache('session')->clear();
+    Civi::cache('metadata')->clear();
+    CRM_Core_DAO_AllCoreTables::reinitializeCache();
     CRM_Utils_System::flushCache();
 
     if ($sessionReset) {

--- a/CRM/Core/DAO/AllCoreTables.php
+++ b/CRM/Core/DAO/AllCoreTables.php
@@ -366,11 +366,9 @@ class CRM_Core_DAO_AllCoreTables {
 
   /**
    * Reinitialise cache.
-   *
-   * @param bool $fresh
    */
-  public static function reinitializeCache($fresh = FALSE) {
-    self::init($fresh);
+  public static function reinitializeCache() {
+    self::init(TRUE);
   }
 
   /**

--- a/CRM/Core/Invoke.php
+++ b/CRM/Core/Invoke.php
@@ -399,7 +399,7 @@ class CRM_Core_Invoke {
       // For example - when uninstalling an extension. We already set "triggerRebuild" to true for these operations.
       $config->userSystem->invalidateRouteCache();
     }
-    CRM_Core_DAO_AllCoreTables::reinitializeCache(TRUE);
+    CRM_Core_DAO_AllCoreTables::reinitializeCache();
     CRM_Core_ManagedEntities::singleton(TRUE)->reconcile();
   }
 

--- a/CRM/Core/Invoke.php
+++ b/CRM/Core/Invoke.php
@@ -399,7 +399,7 @@ class CRM_Core_Invoke {
       // For example - when uninstalling an extension. We already set "triggerRebuild" to true for these operations.
       $config->userSystem->invalidateRouteCache();
     }
-    CRM_Core_DAO_AllCoreTables::reinitializeCache();
+
     CRM_Core_ManagedEntities::singleton(TRUE)->reconcile();
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Fatal error on installing extensions - conditions apply

Before
----------------------------------------
Fatal error when running `civibuild create wmff` (this ships with buildkit)

After
----------------------------------------
works

Technical Details
----------------------------------------
This is a load order thing.

What I'm seeing is that when enabling extensions there is an extension in the mix which calls api v4 to get the default for a setting. This triggers a caching process for the v4 info - seemingly before the DAO is available -presumably settings are loaded before the entityTypes hook is called. This results in the info for v4 api entity being stored in `Civi::cache('metadata')` with NULL for the `'dao'` value.



Later when `rebuildMenuAndCaches` was called the dao cache in allCoreTables is cleared but the api info cache wasn't.

This puts the clearing of the metadata cache in there next to the clearing of the metadata stored in `allCoreTables`.

I moved the metadata setting earlier in the function (into 
```   // also cleanup all caches
    $config->cleanupCaches($sessionReset || CRM_Utils_Request::retrieve('sessionReset', 'Boolean', CRM_Core_DAO::$_nullObject, FALSE, 0, 'GET'));
```
which is probably the most arguable part of this change. That is how I tested it & the most important part is that they are together - however - I *think* it makes sense to move this to the cacheClear function both because it IS clearing caches and because it will then call hook::entityTypes BEFORE it calls settings and menu rebuild hooks - which *should* help with this work around I found in dataprocessor

```
/**
 * Implements hook_civicrm_alterMenu().
 *
 * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_alterMenu/
 */
function dataprocessor_civicrm_alterMenu(&$items) {
  // This hook is called BEFORE civicrm_entityTypes so DataProcessor API calls will fail with missing BAO in
  //   some cases (eg. running cv flush from cli)
  // So we manually run it here before calling alterMenu function
  $entityTypes = [];
  _dataprocessor_civix_civicrm_entityTypes($entityTypes);
  foreach ($entityTypes as $entityType) {
    CRM_Core_DAO_AllCoreTables::registerEntityType(
      $entityType['name'],
      $entityType['class'],
      $entityType['table'],
      $entityType['fields_callback'] ?? NULL,
      $entityType['links_callback'] ?? NULL
    );
```

backtrace for the loading of the api info WITHOUT dao info

![image](https://user-images.githubusercontent.com/336308/129687728-be9a78c0-cc2e-4ebb-8e33-2bab6ec909c9.png)

Comments
----------------------------------------
