### PR TITLE
dev/core#2758 - Fix contribution activity campaign propagation

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -538,8 +538,7 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution {
         ['activity_type_id:name', '=', 'Contribution'],
       ])->execute()->first();
 
-      $campaignParams = isset($params['campaign_id']) ? ['campaign_id' => ($params['campaign_id'] ?? NULL)] : [];
-      $activityParams = array_merge([
+      $activityParams = [
         'activity_type_id:name' => 'Contribution',
         'source_record_id' => $contribution->id,
         'activity_date_time' => $contribution->receive_date,
@@ -547,8 +546,9 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution {
         'status_id:name' => $isCompleted ? 'Completed' : 'Scheduled',
         'skipRecentView' => TRUE,
         'subject' => CRM_Activity_BAO_Activity::getActivitySubject($contribution),
+        'campaign_id' => $contribution->campaign_id,
         'id' => $existingActivity['id'] ?? NULL,
-      ], $campaignParams);
+      ];
       if (!$activityParams['id']) {
         $activityParams['source_contact_id'] = (int) ($params['source_contact_id'] ?? (CRM_Core_Session::getLoggedInContactID() ?: $contribution->contact_id));
         $activityParams['target_contact_id'] = ($activityParams['source_contact_id'] === (int) $contribution->contact_id) ? [] : [$contribution->contact_id];


### PR DESCRIPTION
Overview
----------------------------------------
This fixes an issue where contribution campaigns may not be propagated to the corresponding contribution activity when the request that triggers activity creation does not explicitly set the `campaign_id` parameter.

Before
----------------------------------------
Contribution activity campaign is not set sometimes.

After
----------------------------------------
Contribution activity campaign matches contribution campaign.
