### PR TITLE
closes core#2770: Dedupe by website

### DIFF
--- a/CRM/Dedupe/BAO/DedupeRule.php
+++ b/CRM/Dedupe/BAO/DedupeRule.php
@@ -91,6 +91,7 @@ class CRM_Dedupe_BAO_DedupeRule extends CRM_Dedupe_DAO_DedupeRule {
       case 'civicrm_im':
       case 'civicrm_openid':
       case 'civicrm_phone':
+      case 'civicrm_website':
         $id = 'contact_id';
         break;
 

--- a/CRM/Dedupe/BAO/DedupeRuleGroup.php
+++ b/CRM/Dedupe/BAO/DedupeRuleGroup.php
@@ -84,6 +84,7 @@ class CRM_Dedupe_BAO_DedupeRuleGroup extends CRM_Dedupe_DAO_DedupeRuleGroup {
         'civicrm_note',
         'civicrm_openid',
         'civicrm_phone',
+        'civicrm_website',
       ];
 
       foreach (['Individual', 'Organization', 'Household'] as $ctype) {

--- a/tests/phpunit/CRM/Dedupe/BAO/RuleGroupTest.php
+++ b/tests/phpunit/CRM/Dedupe/BAO/RuleGroupTest.php
@@ -93,6 +93,10 @@ class CRM_Dedupe_BAO_RuleGroupTest extends CiviUnitTestCase {
           'phone_numeric' => 'Phone',
           'phone_ext' => 'Phone Extension',
         ],
+      'civicrm_website' =>
+        [
+          'url' => 'Website',
+        ],
     ], $fields);
   }
 


### PR DESCRIPTION
https://lab.civicrm.org/dev/core/-/issues/2770

Overview
----------------------------------------
I have imports of records with Facebook etc. profiles, which are imported as websites of type "Facebook".  However, there's currently no option to dedupe by Facebook profile.

Before
----------------------------------------
"Website" not available as a criterium to dedupe by.

After
----------------------------------------
"Website" is available.

Technical Details
----------------------------------------
It's almost identical to dedupe by OpenID, and so requires almost no code at all.