### PR TITLE
dev/core#2769 use php email validation not hacked & bad quickform function

### DIFF
--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -347,6 +347,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
       'settingPath',
       'autocomplete',
       'validContact',
+      'email',
     ];
 
     foreach ($rules as $rule) {

--- a/tests/phpunit/CRM/Utils/RuleTest.php
+++ b/tests/phpunit/CRM/Utils/RuleTest.php
@@ -306,7 +306,8 @@ class CRM_Utils_RuleTest extends CiviUnitTestCase {
   }
 
   /**
-   * Test cvvs
+   * Test cvvs.
+   *
    * @return array
    */
   public static function cvvs(): array {
@@ -341,6 +342,32 @@ class CRM_Utils_RuleTest extends CiviUnitTestCase {
    */
   public function testCvvRule($cvv, $type, $expected): void {
     $this->assertEquals($expected, CRM_Utils_Rule::cvv($cvv, $type));
+  }
+
+  /**
+   * Test CVV rule
+   *
+   * @param string $email
+   * @param bool $expected expected outcome of the rule validation
+   *
+   * @dataProvider emails
+   */
+  public function testEmailRule(string $email, bool $expected): void {
+    $this->assertEquals($expected, CRM_Utils_Rule::email($email));
+  }
+
+  /**
+   * Test emails.
+   *
+   * @return array
+   */
+  public static function emails(): array {
+    $cases = [];
+    $cases['name.-o-.i.10@example.com'] = ['name.-o-.i.10@example.com', TRUE];
+    $cases['test@ēxāmplē.co.nz'] = ['test@ēxāmplē.co.nz', TRUE];
+    $cases['test@localhost'] = ['test@localhost', TRUE];
+    $cases['test@ēxāmplē.co'] = ['test@exāmple', FALSE];
+    return $cases;
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#2769 use php email validation not hacked qf

Before
----------------------------------------
Cannot save email `name.-o-.i.10@example.com` through back office contact edit screen (& others based on where this rule is in place)

After
----------------------------------------
It saves, but an obviously wrong email doesn't

Technical Details
----------------------------------------
Per https://lab.civicrm.org/dev/core/-/issues/2769 we have had problems over the years with
quickform's email validation and we now have a hacked version that is
problematic from a maintenance pov & also doesn't work
with the string I have just encountered: name.-o-.i.10@example.com
(which I am told is valid and which passes the php filter).

We already have an email rule which calls a php native function
which is better maintained than our layers of hacks. This
PR registers our email rule - which overrides the quickform
one. If we merge this we can revert quickform back to
unhacked which will improve debugging
and maintenance (although it's actually bypassed
now with this change)


Comments
----------------------------------------
