### PR TITLE
dev/core#2758 - Fix contribution activity campaign propagation ...more

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -546,7 +546,7 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution {
         'status_id:name' => $isCompleted ? 'Completed' : 'Scheduled',
         'skipRecentView' => TRUE,
         'subject' => CRM_Activity_BAO_Activity::getActivitySubject($contribution),
-        'campaign_id' => $contribution->campaign_id,
+        'campaign_id' => !is_numeric($contribution->campaign_id) ? NULL : $contribution->campaign_id,
         'id' => $existingActivity['id'] ?? NULL,
       ];
       if (!$activityParams['id']) {


### PR DESCRIPTION

Overview
----------------------------------------
Fixes master-only regression https://github.com/civicrm/civicrm-core/pull/21167

Before
----------------------------------------
Can't create a membership with no campaign on back office membership form

After
----------------------------------------
Can

Technical Details
----------------------------------------
In this scenarion `$contribution->campaign_id` is `'null'` when it reaches this line & hence it fails

Comments
----------------------------------------
@pfigel 

@kcristiano fyi since you are likely to hit this if you pull from master with #21167 merged
