### PR TITLE
SearchKit - Add placeholder to token select

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminTokenSelect.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminTokenSelect.component.js
@@ -15,6 +15,13 @@
       var ts = $scope.ts = CRM.ts('org.civicrm.search_kit'),
         ctrl = this;
 
+      this.$onInit = function() {
+        // Because this widget is so small, some placeholder text is helpful once it's open
+        $element.on('select2-open', function() {
+          $('#select2-drop > .select2-search > input').attr('placeholder', ts('Insert Token'));
+        });
+      };
+
       this.insertToken = function(key) {
         ctrl.model[ctrl.field] = (ctrl.model[ctrl.field] || '') + '[' + key + ']';
       };
@@ -30,6 +37,17 @@
         return {
           results: allFields
         };
+      };
+
+      this.tokenSelectSettings = {
+        data: this.getTokens,
+        // The crm-action-menu icon doesn't show without a placeholder
+        placeholder: ' ',
+        // Make this widget very compact
+        width: '52px',
+        containerCss: {minWidth: '52px'},
+        // Make the dropdown wider than the widget
+        dropdownCss: {width: '250px'}
       };
 
     }

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminTokenSelect.html
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminTokenSelect.html
@@ -1,6 +1,6 @@
-<span title="{{:: ts('Insert Tokens') }}">
+<span title="{{:: ts('Insert Token') }}">
   <input class="form-control crm-action-menu fa-code collapsible-optgroups"
-         crm-ui-select="{placeholder: ' ', data: $ctrl.getTokens, width: '52px', containerCss: {minWidth: '52px'}, dropdownCss: {width: '250px'}}"
+         crm-ui-select="$ctrl.tokenSelectSettings"
          on-crm-ui-select="$ctrl.insertToken(selection)"
   />
 </span>


### PR DESCRIPTION
Overview
----------------------------------------
Minor code cleanup and placeholder addition to the token selector.
Because the widget is so small, a placeholder is nice to tell the user what it does.

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/2874912/129825037-aa1cc56c-0d7d-474f-a8aa-17ac54b339d8.png)

After
----------------------------------------
![image](https://user-images.githubusercontent.com/2874912/129824984-bcc80bdf-80de-47f3-8991-63c6d2764aaa.png)

