### PR TITLE
Log details of mailing error and don't display details to end user

### DIFF
--- a/CRM/Utils/Mail.php
+++ b/CRM/Utils/Mail.php
@@ -305,14 +305,16 @@ class CRM_Utils_Mail {
         $result = $mailer->send($to, $headers, $message);
       }
       catch (Exception $e) {
-        CRM_Core_Session::setStatus($e->getMessage(), ts('Mailing Error'), 'error');
+        \Civi::log()->error('Mailing error: ' . $e->getMessage());
+        CRM_Core_Session::setStatus(ts('Unable to send email. Please report this message to the site administrator'), ts('Mailing Error'), 'error');
         return FALSE;
       }
       if (is_a($result, 'PEAR_Error')) {
         $message = self::errorMessage($mailer, $result);
         // append error message in case multiple calls are being made to
         // this method in the course of sending a batch of messages.
-        CRM_Core_Session::setStatus($message, ts('Mailing Error'), 'error');
+        \Civi::log()->error('Mailing error: ' . $message);
+        CRM_Core_Session::setStatus(ts('Unable to send email. Please report this message to the site administrator'), ts('Mailing Error'), 'error');
         return FALSE;
       }
       // CRM-10699

--- a/tests/phpunit/CRM/Utils/MailTest.php
+++ b/tests/phpunit/CRM/Utils/MailTest.php
@@ -69,7 +69,7 @@ class CRM_Utils_MailTest extends CiviUnitTestCase {
     ]);
 
     $this->assertFalse(CRM_Utils_Mail::send($params));
-    $this->assertEquals('You shall not pass', CRM_Core_Session::singleton()->getStatus()[0]['text']);
+    $this->assertEquals('Unable to send email. Please report this message to the site administrator', CRM_Core_Session::singleton()->getStatus()[0]['text']);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Found when using the sparkpost extension and an error from sparkpost causes a failure to send the email. The CiviCRM mail library logs the message to the user session and it is then displayed - this is problematic because there could be sensitive information returned in the error message. Additionally there is no indication that an error occurred in the CiviCRM log files.

Before
----------------------------------------
Error message from mailer is displayed to end-user who is trying to unsubscribe:

![image](https://user-images.githubusercontent.com/2052161/129910177-26974645-6469-44db-81bb-cf929469ce24.png)

After
----------------------------------------
Simple error message displayed to end-user with no sensitive information. Detail recorded as error in CiviCRM log:

![image](https://user-images.githubusercontent.com/2052161/129910551-c6bd7bdf-ac99-485f-80ed-fbbc503b2f74.png)

Technical Details
----------------------------------------
`CRM_Core_Session::setStatus()` will display the message to any user who has an active session (eg. when following an unsubscribe link in an email). When certain mailing libraries are using this results in far too much detailed information being displayed to the end-user and not recorded in the logs.

Comments
----------------------------------------
@mlutfy @seamuslee001 
