### PR TITLE
Mailing Unsubscribe Form: Show if email is already unsubscribed

### DIFF
--- a/CRM/Mailing/Form/Unsubscribe.php
+++ b/CRM/Mailing/Form/Unsubscribe.php
@@ -48,6 +48,7 @@ class CRM_Mailing_Form_Unsubscribe extends CRM_Core_Form {
     $this->_job_id = $job_id = CRM_Utils_Request::retrieve('jid', 'Integer', $this);
     $this->_queue_id = $queue_id = CRM_Utils_Request::retrieve('qid', 'Integer', $this);
     $this->_hash = $hash = CRM_Utils_Request::retrieve('h', 'String', $this);
+    $isConfirm = CRM_Utils_Request::retrieveValue('confirm', 'Boolean', FALSE, FALSE, 'GET');
 
     if (!$job_id || !$queue_id || !$hash) {
       throw new CRM_Core_Exception(ts('Missing Parameters'));
@@ -74,8 +75,8 @@ class CRM_Mailing_Form_Unsubscribe extends CRM_Core_Form {
         $groupExist = TRUE;
       }
     }
-    if (!$groupExist) {
-      $statusMsg = ts('%1 has been unsubscribed.', [1 => $email]);
+    if (!$groupExist && !$isConfirm) {
+      $statusMsg = ts('%1 has already been unsubscribed.', [1 => $email]);
       CRM_Core_Session::setStatus($statusMsg, '', 'error');
     }
     $this->assign('groupExist', $groupExist);
@@ -112,7 +113,7 @@ class CRM_Mailing_Form_Unsubscribe extends CRM_Core_Form {
       CRM_Mailing_Event_BAO_Unsubscribe::send_unsub_response($this->_queue_id, $groups, FALSE, $this->_job_id);
     }
 
-    $statusMsg = ts('%1 is unsubscribed.', [1 => CRM_Utils_String::maskEmail($this->_email)]);
+    $statusMsg = ts('%1 has been unsubscribed successfully.', [1 => $this->_email]);
     CRM_Core_Session::setStatus($statusMsg, '', 'success');
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
This cleans up messaging on the unsubscribe form so it is clearer (at least in english) what the current status is.

user@example.org is unsubscribed > user@example.org has been unsubscribed successfully
user@example.org has been unsubscribed > user@example.org has already been unsubscribed

Before
----------------------------------------
Click link in email:

Unsubscribe form shown.

Click unsubscribe:
Message is `user@example.org is unsubscribed`

Click link in email again:

Message is `user@example.org has been unsubscribed.`

After
----------------------------------------
Click link in email:
![image](https://user-images.githubusercontent.com/2052161/129920549-c3ee348d-a5a0-4ac8-8b00-e97adfb45331.png)

Click unsubscribe:
![image](https://user-images.githubusercontent.com/2052161/129920610-db419978-678e-4fa2-8cb2-3d1cf58842c1.png)
*Note: ignore the mailing error - that's related to #21173 and the confirmation message here is now clearer because the unsubscribe WAS successful but the email confirming that unsubscribe failed to send.

Message is `user@example.org has been unsubscribed successfully.`

Click link in email again:
![image](https://user-images.githubusercontent.com/2052161/129920902-f314e067-7ca0-48dc-a9dd-dfed9cb7b5d6.png)

Message is `user@example.org has already been unsubscribed.`

Technical Details
----------------------------------------


Comments
----------------------------------------

