### PR TITLE
Remove requirement to enter email address on unsubscribe

### DIFF
--- a/CRM/Admin/Form/Preferences/Mailing.php
+++ b/CRM/Admin/Form/Preferences/Mailing.php
@@ -16,7 +16,7 @@
  */
 
 /**
- * This class generates form components for the maling component preferences.
+ * This class generates form components for the mailing component preferences.
  */
 class CRM_Admin_Form_Preferences_Mailing extends CRM_Admin_Form_Preferences {
 

--- a/CRM/Mailing/Form/Unsubscribe.php
+++ b/CRM/Mailing/Form/Unsubscribe.php
@@ -24,18 +24,32 @@ class CRM_Mailing_Form_Unsubscribe extends CRM_Core_Form {
    */
   public $submitOnce = TRUE;
 
+  /**
+   * @var int
+   */
+  private $_job_id;
+
+  /**
+   * @var int
+   */
+  private $_queue_id;
+
+  /**
+   * @var string
+   */
+  private $_hash;
+
+  /**
+   * @var string
+   */
+  private $_email;
+
   public function preProcess() {
-
-    $this->_type = 'unsubscribe';
-
     $this->_job_id = $job_id = CRM_Utils_Request::retrieve('jid', 'Integer', $this);
     $this->_queue_id = $queue_id = CRM_Utils_Request::retrieve('qid', 'Integer', $this);
     $this->_hash = $hash = CRM_Utils_Request::retrieve('h', 'String', $this);
 
-    if (!$job_id ||
-      !$queue_id ||
-      !$hash
-    ) {
+    if (!$job_id || !$queue_id || !$hash) {
       throw new CRM_Core_Exception(ts('Missing Parameters'));
     }
 
@@ -55,27 +69,21 @@ class CRM_Mailing_Form_Unsubscribe extends CRM_Core_Form {
     $groups = CRM_Mailing_Event_BAO_Unsubscribe::unsub_from_mailing($job_id, $queue_id, $hash, TRUE);
     $this->assign('groups', $groups);
     $groupExist = NULL;
-    foreach ($groups as $key => $value) {
+    foreach ($groups as $value) {
       if ($value) {
         $groupExist = TRUE;
       }
     }
     if (!$groupExist) {
-      $statusMsg = ts('%1 has been unsubscribed.',
-        [1 => $email]
-      );
+      $statusMsg = ts('%1 has been unsubscribed.', [1 => $email]);
       CRM_Core_Session::setStatus($statusMsg, '', 'error');
     }
     $this->assign('groupExist', $groupExist);
-
   }
 
   public function buildQuickForm() {
     CRM_Utils_System::addHTMLHead('<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">');
     $this->setTitle(ts('Unsubscribe Confirmation'));
-
-    $this->add('text', 'email_confirm', ts('Verify email address to unsubscribe:'));
-    $this->addRule('email_confirm', ts('Email address is required to unsubscribe.'), 'required');
 
     $buttons = [
       [
@@ -93,42 +101,19 @@ class CRM_Mailing_Form_Unsubscribe extends CRM_Core_Form {
   }
 
   public function postProcess() {
-    $values = $this->exportValues();
-
-    // check if EmailTyped matches Email address
-    $result = CRM_Utils_String::compareStr($this->_email, $values['email_confirm'], TRUE);
-    $job_id = $this->_job_id;
-    $queue_id = $this->_queue_id;
-    $hash = $this->_hash;
-
-    $confirmURL = CRM_Utils_System::url("civicrm/mailing/{$this->_type}", "reset=1&jid={$job_id}&qid={$queue_id}&h={$hash}&confirm=1");
+    $confirmURL = CRM_Utils_System::url("civicrm/mailing/unsubscribe", "reset=1&jid={$this->_job_id}&qid={$this->_queue_id}&h={$this->_hash}&confirm=1");
     $this->assign('confirmURL', $confirmURL);
-    $session = CRM_Core_Session::singleton();
-    $session->pushUserContext($confirmURL);
+    CRM_Core_Session::singleton()->pushUserContext($confirmURL);
 
-    if ($result == TRUE) {
-      // Email address verified
-      $groups = CRM_Mailing_Event_BAO_Unsubscribe::unsub_from_mailing($job_id, $queue_id, $hash);
+    // Email address verified
+    $groups = CRM_Mailing_Event_BAO_Unsubscribe::unsub_from_mailing($this->_job_id, $this->_queue_id, $this->_hash);
 
-      if (count($groups)) {
-        CRM_Mailing_Event_BAO_Unsubscribe::send_unsub_response($queue_id, $groups, FALSE, $job_id);
-      }
-
-      $statusMsg = ts('%1 is unsubscribed.',
-        [1 => $values['email_confirm']]
-      );
-
-      CRM_Core_Session::setStatus($statusMsg, '', 'success');
+    if (count($groups)) {
+      CRM_Mailing_Event_BAO_Unsubscribe::send_unsub_response($this->_queue_id, $groups, FALSE, $this->_job_id);
     }
-    elseif ($result == FALSE) {
-      // Email address not verified
-      $statusMsg = ts('%1 is not associated with this unsubscribe request.',
-        [1 => $values['email_confirm']]
-      );
 
-      CRM_Core_Session::setStatus($statusMsg, '', 'error');
-
-    }
+    $statusMsg = ts('%1 is unsubscribed.', [1 => CRM_Utils_String::maskEmail($this->_email)]);
+    CRM_Core_Session::setStatus($statusMsg, '', 'success');
   }
 
 }

--- a/templates/CRM/Mailing/Form/Unsubscribe.tpl
+++ b/templates/CRM/Mailing/Form/Unsubscribe.tpl
@@ -24,15 +24,10 @@
     <div class="crm-block crm-form-block crm-miscellaneous-form-block">
       <p>{ts}You are requesting to unsubscribe this email address:{/ts}</p>
       <h3>{$email_masked}</h3>
-      <p>{ts}If this is not your email address, there is no need to do anything. You have <i><b>not</b></i> been added to any mailing lists. If this is your email address and you <i><b>wish to unsubscribe</b></i> please enter your email address below for verification purposes:{/ts}</p>
-      <table class="form-layout">
-        <tbody>
-          <tr>
-            <td class="label">{$form.email_confirm.label}</td>
-            <td class="content">{$form.email_confirm.html}</td>
-          </tr>
-        </tbody>
-      </table>
+      <p>
+        {ts}If this is not your email address, there is no need to do anything. You have <strong>not</strong> been added to any mailing lists.{/ts}
+        {ts}If this is your email address and you <strong>wish to unsubscribe</strong> please click the <strong>Unsubscribe</strong> button to confirm.{/ts}
+      </p>
       <div class="crm-submit-buttons">
         {include file="CRM/common/formButtons.tpl" location="bottom"}
       </div>


### PR DESCRIPTION
Overview
----------------------------------------
I find it very annoying when I have to do additional work to actually unsubscribe from a mailing list - especially when doing so via a device without a keyboard! Most list unsubscribe forms don't require you to enter any details these days and usually just ask you to confirm.

**_Following discussion this PR is now updated to remove the requirement to enter email address instead of adding a setting_**

You are not asked to re-enter your email address on unsubscribe.

Before
----------------------------------------
You must enter your email address correctly in the text box:
![image](https://user-images.githubusercontent.com/2052161/129952112-b7fa4bf1-88f1-43df-a71e-2ca87d3dfc87.png)

After
----------------------------------------
You just need to read the form and click "Unsubscribe":
![image](https://user-images.githubusercontent.com/2052161/129952211-41159387-a163-4568-9f1e-2f61113596ff.png)

Technical Details
----------------------------------------

Comments
----------------------------------------

