### PR TITLE
dev/core#2752 Allow financial_trxns to be viewed

### DIFF
--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -1145,6 +1145,7 @@ class CRM_Core_Permission {
     $permissions['financial_type']['get'] = $permissions['contribution']['get'];
     $permissions['entity_financial_account']['get'] = $permissions['contribution']['get'];
     $permissions['financial_account']['get'] = $permissions['contribution']['get'];
+    $permissions['financial_trxn']['get'] = $permissions['contribution']['get'];
 
     // Payment permissions
     $permissions['payment'] = [


### PR DESCRIPTION


Overview
----------------------------------------
Per https://lab.civicrm.org/dev/core/-/issues/2752 this allows non admins to
see payment details in search for contributions they can see.
I only added for 'get' because I didn't want to loosen 'delete'
(in particular) and this was the minimum extra to achieve
search access

Before
----------------------------------------
User with 'access civicontribute' can see payment details in core screens but not search kit

![image](https://user-images.githubusercontent.com/336308/129973638-b6494593-cf2f-4b8b-b1e7-3aa68e97606c.png)

After
----------------------------------------
Search details show in search kit

![image](https://user-images.githubusercontent.com/336308/129973679-91768246-fcc6-4257-ad1b-b891671badff.png)

Technical Details
----------------------------------------
The behaviour has changed a bit over recent releases - on earlier code you get errors rather than missing fields. Missing fields is nicer :-)

Comments
----------------------------------------
