### PR TITLE
Add tested ACL filtering to FinancialType entity

### DIFF
--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -1138,6 +1138,8 @@ class CRM_Core_Permission {
 
     $permissions['financial_item'] = $permissions['contribution'];
     $permissions['financial_trxn']['get'] = $permissions['contribution']['get'];
+    $permissions['financial_type']['get'] = $permissions['contribution']['get'];
+    $permissions['entity_financial_account']['get'] = $permissions['contribution']['get'];
 
     // Payment permissions
     $permissions['payment'] = [

--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -1137,6 +1137,7 @@ class CRM_Core_Permission {
     $permissions['line_item'] = $permissions['contribution'];
 
     $permissions['financial_item'] = $permissions['contribution'];
+    $permissions['financial_trxn']['get'] = $permissions['contribution']['get'];
 
     // Payment permissions
     $permissions['payment'] = [

--- a/ext/financialacls/financialacls.php
+++ b/ext/financialacls/financialacls.php
@@ -202,18 +202,29 @@ function financialacls_civicrm_selectWhereClause($entity, &$clauses) {
     case 'LineItem':
     case 'MembershipType':
     case 'ContributionRecur':
-      $types = [];
-      CRM_Financial_BAO_FinancialType::getAvailableFinancialTypes($types);
-      if ($types) {
-        $clauses['financial_type_id'] = 'IN (' . implode(',', array_keys($types)) . ')';
-      }
-      else {
-        $clauses['financial_type_id'] = '= 0';
-      }
+      $clauses['financial_type_id'] = _financialacls_civicrm_get_clause();
+      break;
+
+    case 'FinancialType':
+      $clauses['id'] = _financialacls_civicrm_get_clause();
       break;
 
   }
 
+}
+
+/**
+ * Get the clause to limit available types.
+ *
+ * @return string
+ */
+function _financialacls_civicrm_get_clause(): string {
+  $types = [];
+  CRM_Financial_BAO_FinancialType::getAvailableFinancialTypes($types);
+  if ($types) {
+    return 'IN (' . implode(',', array_keys($types)) . ')';
+  }
+  return '= 0';
 }
 
 /**

--- a/ext/financialacls/tests/phpunit/Civi/Financialacls/FinancialTypeTest.php
+++ b/ext/financialacls/tests/phpunit/Civi/Financialacls/FinancialTypeTest.php
@@ -62,4 +62,15 @@ class FinancialTypeTest extends BaseTestClass {
     ], $permissions['administer CiviCRM Financial Types']);
   }
 
+  /**
+   * Test income financial types are acl filtered.
+   */
+  public function testGetIncomeFinancialType(): void {
+    $types = \CRM_Financial_BAO_FinancialType::getIncomeFinancialType();
+    $this->assertCount(4, $types);
+    $this->setupLoggedInUserWithLimitedFinancialTypeAccess();
+    $type = \CRM_Financial_BAO_FinancialType::getIncomeFinancialType();
+    $this->assertEquals([1 => 'Donation'], $type);
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Add tested ACL filtering to FinancialType entity

Before
----------------------------------------
Administer civicrm required to access financial type entity

After
----------------------------------------
Access Civi Contribution required for get + access to the type if acls enabled

Technical Details
----------------------------------------
Without this search kit borks for non adminstrators when pulling in financial type data or payment data

Comments
----------------------------------------
