### PR TITLE
Allow CiviCRM to create CMS user accounts when CMS has public registrations disabled

### DIFF
--- a/CRM/Core/BAO/CMSUser.php
+++ b/CRM/Core/BAO/CMSUser.php
@@ -62,23 +62,10 @@ class CRM_Core_BAO_CMSUser {
    * @param bool $emailPresent
    *   True if the profile field has email(primary).
    * @param \const|int $action
-   *
-   * @return FALSE|void
-   *   WTF
-   *
    */
   public static function buildForm(&$form, $gid, $emailPresent, $action = CRM_Core_Action::NONE) {
     $config = CRM_Core_Config::singleton();
     $showCMS = FALSE;
-
-    $isDrupal = $config->userSystem->is_drupal;
-    $isJoomla = ucfirst($config->userFramework) == 'Joomla';
-    $isWordPress = $config->userFramework == 'WordPress';
-
-    if (!$config->userSystem->isUserRegistrationPermitted()) {
-      // Do not build form if CMS is not configured to allow creating users.
-      return FALSE;
-    }
 
     if ($gid) {
       $isCMSUser = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_UFGroup', $gid, 'is_cms_user');

--- a/CRM/Utils/System/Backdrop.php
+++ b/CRM/Utils/System/Backdrop.php
@@ -402,16 +402,6 @@ AND    u.status = 1
   /**
    * @inheritDoc
    */
-  public function isUserRegistrationPermitted() {
-    if (config_get('system.core', 'user_register') == 'admin_only') {
-      return FALSE;
-    }
-    return TRUE;
-  }
-
-  /**
-   * @inheritDoc
-   */
   public function isPasswordUserGenerated() {
     if (config_get('system.core', 'user_email_verification') == TRUE) {
       return FALSE;

--- a/CRM/Utils/System/Base.php
+++ b/CRM/Utils/System/Base.php
@@ -446,7 +446,7 @@ abstract class CRM_Utils_System_Base {
    * @return bool
    */
   public function isUserRegistrationPermitted() {
-    return FALSE;
+    return TRUE;
   }
 
   /**

--- a/CRM/Utils/System/Drupal8.php
+++ b/CRM/Utils/System/Drupal8.php
@@ -491,16 +491,6 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
   /**
    * @inheritDoc
    */
-  public function isUserRegistrationPermitted() {
-    if (\Drupal::config('user.settings')->get('register') == 'admin_only') {
-      return FALSE;
-    }
-    return TRUE;
-  }
-
-  /**
-   * @inheritDoc
-   */
   public function isPasswordUserGenerated() {
     if (\Drupal::config('user.settings')->get('verify_mail') == TRUE) {
       return FALSE;

--- a/CRM/Utils/System/DrupalBase.php
+++ b/CRM/Utils/System/DrupalBase.php
@@ -389,16 +389,6 @@ abstract class CRM_Utils_System_DrupalBase extends CRM_Utils_System_Base {
   /**
    * @inheritDoc
    */
-  public function isUserRegistrationPermitted() {
-    if (!variable_get('user_register', TRUE)) {
-      return FALSE;
-    }
-    return TRUE;
-  }
-
-  /**
-   * @inheritDoc
-   */
   public function isPasswordUserGenerated() {
     if (variable_get('user_email_verification', TRUE)) {
       return FALSE;

--- a/CRM/Utils/System/Joomla.php
+++ b/CRM/Utils/System/Joomla.php
@@ -618,17 +618,6 @@ class CRM_Utils_System_Joomla extends CRM_Utils_System_Base {
   /**
    * @inheritDoc
    */
-  public function isUserRegistrationPermitted() {
-    $userParams = JComponentHelper::getParams('com_users');
-    if (!$userParams->get('allowUserRegistration')) {
-      return FALSE;
-    }
-    return TRUE;
-  }
-
-  /**
-   * @inheritDoc
-   */
   public function isPasswordUserGenerated() {
     return TRUE;
   }

--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -1006,16 +1006,6 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
   /**
    * @inheritDoc
    */
-  public function isUserRegistrationPermitted() {
-    if (!get_option('users_can_register')) {
-      return FALSE;
-    }
-    return TRUE;
-  }
-
-  /**
-   * @inheritDoc
-   */
   public function isPasswordUserGenerated() {
     return FALSE;
   }


### PR DESCRIPTION
Allow CiviCRM to create CMS user accounts when CMS has public registrations disabled

Overview
----------------------------------------

Changes the decision to enforce the CMS new user account option and allows CiviCRM to create CMS user accounts, even when CMS has public registrations disabled. See discussion https://lab.civicrm.org/dev/core/-/issues/2765

Before
----------------------------------------
If CMS has public registrations disabled, then the CiviCRM Profile, User account registration option was displayed but had no affect. It was not possible to create a CMS user. For this option to work, the CMS had to have public registrations enabled.

After
----------------------------------------
The CiviCRM Profile, User account registration option works and is not affected by the CMS public registration option.

Technical Details
----------------------------------------
None

Comments
----------------------------------------
See discussion https://lab.civicrm.org/dev/core/-/issues/2765

Agileware Ref: CIVICRM-1809