### PR TITLE
dev/core#2772 - Don't crash for custom fields of type int that are multi-select

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -1653,7 +1653,9 @@ SELECT $columnName
       'table_name' => $tableName,
       'column_name' => $columnName,
       'file_id' => $fileID,
+      // is_multiple refers to the custom group, serialize refers to the field.
       'is_multiple' => $customFields[$customFieldId]['is_multiple'],
+      'serialize' => $customFields[$customFieldId]['serialize'],
     ];
 
     //we need to sort so that custom fields are created in the order of entry

--- a/CRM/Core/BAO/CustomValueTable.php
+++ b/CRM/Core/BAO/CustomValueTable.php
@@ -228,7 +228,7 @@ class CRM_Core_BAO_CustomValueTable {
             // would be 'String' for a concatenated set of integers.
             // However, the god-forsaken timestamp hack also needs to be kept
             // if value is NULL.
-            $params[$count] = [$value, ($value && $field['is_multiple']) ? 'String' : $type];
+            $params[$count] = [$value, ($value && $field['serialize']) ? 'String' : $type];
             $count++;
           }
 
@@ -360,7 +360,10 @@ class CRM_Core_BAO_CustomValueTable {
           'custom_group_id' => $customValue['custom_group_id'],
           'table_name' => $customValue['table_name'],
           'column_name' => $customValue['column_name'],
-          'is_multiple' => $customValue['is_multiple'] ?? NULL,
+          // is_multiple refers to the custom group, serialize refers to the field.
+          // @todo is_multiple can be null - does that mean anything different from 0?
+          'is_multiple' => $customValue['is_multiple'] ?? CRM_Core_DAO::getFieldValue('CRM_Core_DAO_CustomGroup', $customValue['custom_group_id'], 'is_multiple'),
+          'serialize' => $customValue['serialize'] ?? (int) CRM_Core_DAO::getFieldValue('CRM_Core_DAO_CustomField', $customValue['custom_field_id'], 'serialize'),
           'file_id' => $customValue['file_id'],
         ];
 
@@ -590,7 +593,8 @@ SELECT cg.table_name  as table_name ,
        cf.column_name as column_name,
        cf.id          as cf_id      ,
        cf.html_type   as html_type  ,
-       cf.data_type   as data_type
+       cf.data_type   as data_type  ,
+       cf.serialize   as serialize
 FROM   civicrm_custom_group cg,
        civicrm_custom_field cf
 WHERE  cf.custom_group_id = cg.id
@@ -648,6 +652,7 @@ AND    cf.id IN ( $fieldIDList )
           'table_name' => $dao->table_name,
           'column_name' => $dao->column_name,
           'is_multiple' => $dao->is_multiple,
+          'serialize' => $dao->serialize,
           'extends' => $dao->extends,
         ];
 

--- a/tests/phpunit/CRM/Core/BAO/CustomValueTableTest.php
+++ b/tests/phpunit/CRM/Core/BAO/CustomValueTableTest.php
@@ -180,6 +180,52 @@ class CRM_Core_BAO_CustomValueTableTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test store function for multiselect int.
+   */
+  public function testStoreMultiSelectInt() {
+    $contactID = $this->individualCreate();
+    $customGroup = $this->customGroupCreate();
+    $fields = [
+      'custom_group_id' => $customGroup['id'],
+      'data_type' => 'Int',
+      'html_type' => 'Multi-Select',
+      'option_values' => [
+        1 => 'choice1',
+        2 => 'choice2',
+      ],
+      'default_value' => '',
+    ];
+
+    $customField = $this->customFieldCreate($fields);
+
+    $params = [
+      [
+        $customField['id'] => [
+          'value' => CRM_Core_DAO::VALUE_SEPARATOR . '1' . CRM_Core_DAO::VALUE_SEPARATOR . '2' . CRM_Core_DAO::VALUE_SEPARATOR,
+          'type' => 'Int',
+          'custom_field_id' => $customField['id'],
+          'custom_group_id' => $customGroup['id'],
+          'table_name' => $customGroup['values'][$customGroup['id']]['table_name'],
+          'column_name' => $customField['values'][$customField['id']]['column_name'],
+          'file_id' => '',
+        ],
+      ],
+    ];
+
+    CRM_Core_BAO_CustomValueTable::store($params, 'civicrm_contact', $contactID);
+
+    $customData = \Civi\Api4\Contact::get(FALSE)
+      ->addSelect('new_custom_group.Custom_Field')
+      ->addWhere('id', '=', $contactID)
+      ->execute()->first();
+    $this->assertEquals([1, 2], $customData['new_custom_group.Custom_Field']);
+
+    $this->customFieldDelete($customField['id']);
+    $this->customGroupDelete($customGroup['id']);
+    $this->contactDelete($contactID);
+  }
+
+  /**
    * Test getEntityValues function for stored value.
    */
   public function testGetEntityValues() {


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/2772

Can't save a record that has a value entered into a custom field of type int which is a dropdown multi-select.

Before
----------------------------------------
1. Create a custom field of type int.
1. Make it a dropdown.
1. Check the box for multiselect.
1. Create a record and fill in a selection for the custom field.
1. Save.

CRM_Core_Exception: One of parameters (value: ☐1☐) is not of the type Timestamp in .../CRM/Core/DAO.php on line 1713

After
----------------------------------------
Saves.

Technical Details
----------------------------------------
is_multiple is for the custom_group and whether it can have multiple instances of the group.
serialize is for the field and specifies multi-select.

Comments
----------------------------------------
This same issue was supposedly fixed in 5.35 (https://lab.civicrm.org/dev/core/-/issues/2423), but I've tested 5.35.2 and it doesn't work there either.