### PR TITLE
dev/financial#180 Switch to expecting total_amount to be tax inclusive (always)

### DIFF
--- a/CRM/Financial/BAO/Order.php
+++ b/CRM/Financial/BAO/Order.php
@@ -941,7 +941,15 @@ class CRM_Financial_BAO_Order {
       $this->addTotalsToLineBasedOnOverrideTotal((int) $lineItem['financial_type_id'], $lineItem);
     }
     elseif (isset($lineItem['line_total_inclusive'])) {
-      $lineItem = $this->alterLineItemForTax($this->getTaxRate($lineItem['financial_type_id']), $lineItem, $lineItem['line_total_inclusive']);
+      if (isset($lineItem['tax_amount_override'])) {
+        // @todo deprecate this - work with Karin to make sure she is not using order api in
+        // a way that deprecating this causes problems.
+        $lineItem['tax_amount'] = $lineItem['tax_amount_override'];
+        $lineItem['line_total'] = $lineItem['line_total_inclusive'] - $lineItem['tax_amount'];
+      }
+      else {
+        $lineItem = $this->alterLineItemForTax($this->getTaxRate($lineItem['financial_type_id']), $lineItem, $lineItem['line_total_inclusive']);
+      }
     }
     else {
       $lineItem['tax_amount'] = ($this->getTaxRate($lineItem['financial_type_id']) / 100) * $lineItem['line_total'];

--- a/CRM/Price/BAO/LineItem.php
+++ b/CRM/Price/BAO/LineItem.php
@@ -516,17 +516,20 @@ WHERE li.contribution_id = %1";
           }
           $financialType = $values['financial_type_id'];
         }
+        $taxRates = CRM_Core_PseudoConstant::getTaxRates();
+        $taxRate = $taxRates[$financialType] ?? 0;
+        $taxAmount = ($taxRate / 100) * $totalAmount / (1 + ($taxRate / 100));
         $lineItem = [
           'price_field_id' => $values['priceFieldID'],
           'price_field_value_id' => $values['priceFieldValueID'],
           'label' => $values['label'],
           'qty' => 1,
-          'unit_price' => $totalAmount,
-          'line_total' => $totalAmount,
+          'unit_price' => $totalAmount - $taxAmount,
+          'line_total' => $totalAmount - $taxAmount,
           'financial_type_id' => $financialType,
           'membership_type_id' => $values['membership_type_id'],
+          'tax_amount' => $taxAmount,
         ];
-        $lineItem['tax_amount'] = self::getTaxAmountForLineItem($lineItem);
         $params['line_item'][$values['setID']][$values['priceFieldID']] = $lineItem;
         break;
       }

--- a/api/v3/Order.php
+++ b/api/v3/Order.php
@@ -102,9 +102,9 @@ function civicrm_api3_order_create(array $params): array {
     $order->setPriceSetToDefault('contribution');
     $order->setLineItem([
       // Historically total_amount in this case could be tax
-      // inclusive if tax is also supplied.
+      // inclusive if tax is also supplied - as of 5.41 it always is.
       // This is inconsistent with the contribution api....
-      'line_total' => ((float) $params['total_amount'] - (float) ($params['tax_amount'] ?? 0)),
+      'line_total_inclusive' => (float) $params['total_amount'],
       'financial_type_id' => (int) $params['financial_type_id'],
     ], 0);
   }

--- a/api/v3/Order.php
+++ b/api/v3/Order.php
@@ -106,6 +106,8 @@ function civicrm_api3_order_create(array $params): array {
       // This is inconsistent with the contribution api....
       'line_total_inclusive' => (float) $params['total_amount'],
       'financial_type_id' => (int) $params['financial_type_id'],
+      // This is expected to be temporary - but need to work with Karin before we start deprecating
+      'tax_amount_override' => isset($params['tax_amount']) ? (float) $params['tax_amount'] : NULL,
     ], 0);
   }
   // Only check the amount if line items are set because that is what we have historically
@@ -118,6 +120,7 @@ function civicrm_api3_order_create(array $params): array {
     }
   }
   $params['total_amount'] = $order->getTotalAmount();
+  $params['tax_amount'] = $order->getTotalTaxAmount();
 
   foreach ($order->getEntitiesToCreate() as $entityParams) {
     if ($entityParams['entity'] === 'participant') {

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -29,6 +29,7 @@
 use Civi\Api4\Contribution;
 use Civi\Api4\CustomField;
 use Civi\Api4\CustomGroup;
+use Civi\Api4\FinancialType;
 use Civi\Api4\LineItem;
 use Civi\Api4\OptionGroup;
 use Civi\Api4\RelationshipType;
@@ -1926,6 +1927,9 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
     $this->restoreDefaultPriceSetConfig();
     $this->disableTaxAndInvoicing();
     $this->setCurrencySeparators(',');
+    FinancialType::delete(FALSE)->addWhere(
+      'name', 'NOT IN', ['Donation' , 'Member Dues', 'Campaign Contribution', 'Event Fee']
+    )->execute();
     CRM_Core_PseudoConstant::flush('taxRates');
     System::singleton()->flushProcessors();
     // @fixme this parameter is leaking - it should not be defined as a class static

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -2286,10 +2286,10 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
       'sequential' => 1,
     ]);
     $contributionPostPayment = $this->callAPISuccessGetSingle('Contribution', ['id' => $contributionID, 'return' => ['tax_amount', 'fee_amount', 'net_amount']]);
-    $this->assertEquals(5, $contributionPrePayment['tax_amount']);
-    $this->assertEquals(5, $contributionPostPayment['tax_amount']);
+    $this->assertEquals(4.76, $contributionPrePayment['tax_amount']);
+    $this->assertEquals(4.76, $contributionPostPayment['tax_amount']);
     $this->assertEquals('6.00', $contributionPostPayment['fee_amount']);
-    $this->assertEquals('99.00', $contributionPostPayment['net_amount']);
+    $this->assertEquals('94.00', $contributionPostPayment['net_amount']);
     $this->validateAllContributions();
     $this->validateAllPayments();
   }
@@ -4785,8 +4785,8 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
     //Assert line item records.
     $lineItems = $this->callAPISuccess('LineItem', 'get', ['sequential' => 1])['values'];
     foreach ($lineItems as $lineItem) {
-      $this->assertEquals($lineItem['unit_price'], $this->_params['total_amount']);
-      $this->assertEquals($lineItem['line_total'], $this->_params['total_amount']);
+      $this->assertEquals($lineItem['unit_price'] + $lineItem['tax_amount'], $this->_params['total_amount']);
+      $this->assertEquals($lineItem['line_total'] + $lineItem['tax_amount'], $this->_params['total_amount']);
     }
     $this->callAPISuccessGetCount('Contribution', [], 2);
   }

--- a/tests/phpunit/api/v3/OrderTest.php
+++ b/tests/phpunit/api/v3/OrderTest.php
@@ -489,6 +489,24 @@ class api_v3_OrderTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test order api treats amount as inclusive when line items not set.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testAPIOrderTax(): void {
+    $this->enableTaxAndInvoicing();
+    $this->createFinancialTypeWithSalesTax();
+    $order = $this->callAPISuccess('Order', 'create', [
+      'total_amount' => 10,
+      'financial_type_id' => 'Test taxable financial Type',
+      'contact_id' => $this->individualCreate(),
+      'sequential' => 1,
+    ])['values'][0];
+    $this->assertEquals(10, $order['total_amount']);
+    $this->assertEquals(0.47619047619048, $order['tax_amount']);
+  }
+
+  /**
    * Test cancel order api
    *
    * @throws \CRM_Core_Exception
@@ -591,7 +609,6 @@ class api_v3_OrderTest extends CiviUnitTestCase {
       'receive_date' => '2018-01-01',
       'total_amount' => 36.75,
       'financial_type_id' => $this->_financialTypeId,
-      'contribution_status_id' => 'Pending',
       'tax_amount' => 1.75,
       'line_items' => [
         0 => [


### PR DESCRIPTION
My expectation is this will fix for @karing but cause a test to fail - which should help find the
inconsistency

My feeling looking at this is that perhaps historically (at the bao level possibly) it was treated as inclusive if tax_amount is provided & not otherwise.

If my theory is correct I think we could go back to doing that but throw a deprecation notice is tax_amount is provided

note that total_amount is ignored when line items are provided

I'm open to considering a new 'total_amount_inclusive' param - which would be either /or with total_amount (probably throw an exception if both are provided) - that would be in master I guess & I'm not sure whether it's manageable at the moment (ie the reason for wanting to pass in inclusive is to get the rounding right but I don't know how ready the code is for that)

Overview
----------------------------------------
dev/financial#180 Switch to expecting total_amount to be tax inclusive (always)


Before
----------------------------------------
total_amount is treated as tax exclusive when tax_amount is passed in

After
----------------------------------------
- total_amount is IGNORED in favour of using the line items if they are passed in (unchanged)
- if passed in then it is always treated as inclusive
 
In all cases tax_amount is calculated within the order api, based on the financial types & the total amounts passed in (at a line item level or at the api level)

Technical Details
----------------------------------------
This handling has a confusing history and to be honest I thought I'd figured out what would be a no-change behaviour until @KarinG started sleuthing.

I guess what we need to do is 

1) agree the above
2) update docs to make it clear
3) email the dev list

Comments
----------------------------------------
