### PR TITLE
dev/core#2771 test for error on deprecated syntax

### DIFF
--- a/tests/phpunit/api/v3/EmailTest.php
+++ b/tests/phpunit/api/v3/EmailTest.php
@@ -44,6 +44,18 @@ class api_v3_EmailTest extends CiviUnitTestCase {
     ];
   }
 
+  public function testBrokeStuff() {
+    // Check for existing....
+    $matches = Civi\Api4\Email::get(FALSE)
+      ->addWhere('contact.first_name', '=', 'Peter')
+      ->addWhere('contact.last_name', '=', '')
+      ->addWhere('contact.is_deleted', '=', 0)
+      ->addWhere('contact.is_deceased', '=', 0)
+      ->addWhere('email', '=', '')
+      ->addWhere('is_primary', '=', TRUE)
+      ->setSelect(['contact_id'])->execute();
+  }
+
   /**
    * Test create email.
    *


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#2771 test for error on deprecated syntax

Before
----------------------------------------
the big silence

After
----------------------------------------
Look it's a test

Technical Details
----------------------------------------
@colemanw it turns out that, as with the other issue, it's an error handling issue - the lines in the screenshot are swallowing the deprecation message & giving a misleading message

I think it's fine for tests to fail on deprecation errors - but the error should be clear to the person.

I also think, on balance, that 5.41 might be a little too soon to add this level of noisiness to the syntax switch  - but we could also mitigate that by writing up the changes & the reason for the changes in the dev digest & perhaps in dev docs

![image](https://user-images.githubusercontent.com/336308/130162697-a619242e-ca15-4e65-b250-7217ca9b02a3.png)

![image](https://user-images.githubusercontent.com/336308/130162962-906fb079-58d6-4d2a-bddc-f354af8d06e5.png)

Comments
----------------------------------------

