### PR TITLE
dev/rc#14 handle api calls post schema change

### DIFF
--- a/api/v3/utils.php
+++ b/api/v3/utils.php
@@ -2059,6 +2059,10 @@ function _civicrm_api3_swap_out_aliases(&$apiRequest, $fields) {
  */
 function _civicrm_api3_validate_integer(&$params, $fieldName, &$fieldInfo, $entity) {
   list($fieldValue, $op) = _civicrm_api3_field_value_check($params, $fieldName);
+  if ($fieldName === 'auto_renew' && $fieldValue === TRUE) {
+    // https://lab.civicrm.org/dev/rc/-/issues/14
+    $fieldValue = 1;
+  }
   if (strpos($op, 'NULL') !== FALSE || strpos($op, 'EMPTY') !== FALSE) {
     return;
   }

--- a/tests/phpunit/api/v3/MembershipTypeTest.php
+++ b/tests/phpunit/api/v3/MembershipTypeTest.php
@@ -185,6 +185,24 @@ class api_v3_MembershipTypeTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test that auto renew = TRUE still works post schema change.
+   *
+   * https://lab.civicrm.org/dev/rc/-/issues/14
+   */
+  public function testCreateMembershipTypeAutoRenewBool(): void {
+    $this->callAPISuccess('MembershipType', 'create', [
+      'member_of_contact_id' => 1,
+      'financial_type_id' => 'Member Dues',
+      'duration_unit' => 'year',
+      'duration_interval' => 1,
+      'period_type' => 'rolling',
+      'minimum_fee' => 1,
+      'name' => 'gen',
+      'auto_renew' => TRUE,
+    ]);
+  }
+
+  /**
    * Test update.
    *
    * @dataProvider versionThreeAndFour


### PR DESCRIPTION
Overview
----------------------------------------
dev/rc#14 handle api calls post schema change

Before
----------------------------------------
Calling v3 api MembershipType.create with `'auto_renew' => TRUE` works on 5.40 but fails on 5.41

After
----------------------------------------
Also works on 5.41 - unsure about v4 api, I suspect it doesn't

Technical Details
----------------------------------------
The schema oddly had auto_renew as a boolean although as a TINYINT it could actually record all 3 valid values (0, 1 or 2). A fix to the schema in 5.41 caused this to start failing - at least in tests

This adds hack-handling for the v3 api but I'm undecided about v4 api. I haven't tested, suspect there would also be an issue. However the relative rarity of MembershipType.create being called outside of tests is mitigating

![failing](https://lab.civicrm.org/dev/rc/uploads/3e5094abf8edf2e13d1ccd6ab5711271/image.png)

Comments
----------------------------------------

@colemanw @KarinG 
