### PR TITLE
dev/core#2774 : Sort by date column on multirecord field listing section on profile edit mode doesn't work

### DIFF
--- a/CRM/Profile/Page/MultipleRecordFieldsListing.php
+++ b/CRM/Profile/Page/MultipleRecordFieldsListing.php
@@ -307,7 +307,12 @@ class CRM_Profile_Page_MultipleRecordFieldsListing extends CRM_Core_Page_Basic {
               $customValue = &$val;
               if (!empty($dateFields) && array_key_exists($fieldId, $dateFields)) {
                 // formatted date capture value capture
-                $dateFieldsVals[$fieldId][$recId] = CRM_Core_BAO_CustomField::displayValue($customValue, $fieldId);
+                if ($this->_pageViewType == 'profileDataView') {
+                  $dateFieldsVals[$fieldId][$recId] = CRM_Utils_Date::processDate($result[$recId][$fieldId], NULL, FALSE, 'YmdHis');
+                }
+                else {
+                  $dateFieldsVals[$fieldId][$recId] = CRM_Core_BAO_CustomField::displayValue($customValue, $fieldId);
+                }
 
                 //set date and time format
                 switch ($timeFormat) {

--- a/templates/CRM/Profile/Page/MultipleRecordFieldsListing.tpl
+++ b/templates/CRM/Profile/Page/MultipleRecordFieldsListing.tpl
@@ -75,7 +75,7 @@
               {foreach from=$records key=recId item=rows}
                 <tr class="{cycle values="odd-row,even-row"}">
                   {foreach from=$headers key=hrecId item=head}
-                    <td {crmAttributes a=$attributes.$hrecId.$recId}>{$rows.$hrecId}</td>
+                    <td {if !empty($dateFieldsVals.$hrecId)}data-order="{$dateFieldsVals.$hrecId.$recId|crmDate:'%Y-%m-%d'}"{/if} {crmAttributes a=$attributes.$hrecId.$recId}>{$rows.$hrecId}</td>
                   {/foreach}
                   <td>{$rows.action}</td>
                   {foreach from=$dateFieldsVals key=fid item=rec}


### PR DESCRIPTION
Overview
----------------------------------------
1. create a multi-record custom data set for contacts
2. create a date field of format mm/dd/yyyy. it may be beneficial to create another text field for reference.
3. Configure a profile using those multi-record custom data field
4. Go to profile edit mode and add some data to a contact record. For the date field, select some values across multiple years.
5. Try sorting by the date on the frontend profile form in edit mode

Before
----------------------------------------
![before](https://user-images.githubusercontent.com/3735621/130192832-265fd749-4b9b-4c1a-9cbc-e4d30ece13e6.gif)


After
----------------------------------------
![after](https://user-images.githubusercontent.com/3735621/130192853-6c9d2321-3b96-4510-acc2-5eb79267666c.gif)


Comments
----------------------------------------
ping @lcdservices @seamuslee001 @eileenmcnaughton 