### PR TITLE
dev/core#2777 - Fix js break on reminder form

### DIFF
--- a/templates/CRM/Contact/Form/Task/SMSCommon.tpl
+++ b/templates/CRM/Contact/Form/Task/SMSCommon.tpl
@@ -9,8 +9,6 @@
 *}
 {*common template for compose sms*}
 
-{crmScript file=bower_components/sms-counter/sms_counter.min.js region=html-header}
-
 <div class="crm-accordion-wrapper crm-plaint_text_sms-accordion ">
 <div class="crm-accordion-header">
   {$form.sms_text_message.label}
@@ -47,41 +45,43 @@
 {literal}
 <script type="text/javascript">
 {/literal}{if $max_sms_length}{literal}
-maxCharInfoDisplay();
+CRM.loadScript(CRM.config.resourceBase + 'bower_components/sms-counter/sms_counter.min.js').done(function () {
+  maxCharInfoDisplay();
 
-CRM.$('#sms_text_message').bind({
-  change: function() {
-   maxLengthMessage();
-  },
-  keyup:  function() {
-   maxCharInfoDisplay();
+  CRM.$('#sms_text_message').bind({
+    change: function() {
+    maxLengthMessage();
+    },
+    keyup:  function() {
+    maxCharInfoDisplay();
+    }
+  });
+
+  function maxLengthMessage()
+  {
+    var len = CRM.$('#sms_text_message').val().length;
+    var maxLength = {/literal}{$max_sms_length}{literal};
+    if (len > maxLength) {
+        CRM.$('#sms_text_message').crmError({/literal}'{ts escape="js" 1=$max_sms_length}SMS body exceeding limit of %1 characters{/ts}'{literal});
+        return false;
+    }
+  return true;
+  }
+
+  function maxCharInfoDisplay(){
+    var maxLength = {/literal}{$max_sms_length}{literal};
+    var enteredText = SmsCounter.count(CRM.$('#sms_text_message').val());
+    var count = enteredText.length;
+    var segments = enteredText.messages;
+
+    if( count < 0 ) {
+        CRM.$('#sms_text_message').val(CRM.$('#sms_text_message').val().substring(0, maxLength));
+        count = 0;
+    }
+    var message = "{/literal}{$char_count_message}{literal}"
+    CRM.$('#char-count-message').text(message.replace('%1', maxLength).replace('%2', count).replace('%3', segments));
   }
 });
-
-function maxLengthMessage()
-{
-   var len = CRM.$('#sms_text_message').val().length;
-   var maxLength = {/literal}{$max_sms_length}{literal};
-   if (len > maxLength) {
-      CRM.$('#sms_text_message').crmError({/literal}'{ts escape="js" 1=$max_sms_length}SMS body exceeding limit of %1 characters{/ts}'{literal});
-      return false;
-   }
-return true;
-}
-
-function maxCharInfoDisplay(){
-   var maxLength = {/literal}{$max_sms_length}{literal};
-   var enteredText = SmsCounter.count(CRM.$('#sms_text_message').val());
-   var count = enteredText.length;
-   var segments = enteredText.messages;
-
-   if( count < 0 ) {
-      CRM.$('#sms_text_message').val(CRM.$('#sms_text_message').val().substring(0, maxLength));
-      count = 0;
-   }
-   var message = "{/literal}{$char_count_message}{literal}"
-   CRM.$('#char-count-message').text(message.replace('%1', maxLength).replace('%2', count).replace('%3', segments));
-}
 {/literal}{/if}{literal}
 
 </script>


### PR DESCRIPTION
Overview
----------------------------------------
Fix js break on Reminder form.

Before
----------------------------------------
To replicate -

- Add an SMS provider on https://dmaster.demo.civicrm.org/civicrm/admin/sms/provider?reset=1 by installing twilio.
- Open Reminder form in AJAX popup.

- The form looks borked (title & CKEditor missing).

![image](https://user-images.githubusercontent.com/5929648/130229829-13925df5-bff0-4f34-ae8c-03b95fdf6a36.png)

Console error -

![image](https://user-images.githubusercontent.com/5929648/130229787-9afda726-2612-4212-8fbc-93243b50244c.png)

which seems to be related to this change - https://github.com/civicrm/civicrm-core/pull/20220

After
----------------------------------------
![image](https://user-images.githubusercontent.com/5929648/130229704-9772122f-2d60-464b-ac20-62dff7559e4e.png)

Technical Details
----------------------------------------
Replace smarty crmScript with loadScript function. 

Comments
----------------------------------------
Gitlab - https://lab.civicrm.org/dev/core/-/issues/2777