### PR TITLE
REF Switch to CRM_Core_Form::setTitle() instead of CRM_Utils_System::setTitle() part 1

### DIFF
--- a/CRM/ACL/Form/WordPress/Permissions.php
+++ b/CRM/ACL/Form/WordPress/Permissions.php
@@ -30,7 +30,7 @@ class CRM_ACL_Form_WordPress_Permissions extends CRM_Core_Form {
    */
   public function buildQuickForm() {
 
-    CRM_Utils_System::setTitle('WordPress Access Control');
+    $this->setTitle('WordPress Access Control');
 
     // Get the core permissions array
     $permissionsArray = self::getPermissionArray();

--- a/CRM/Activity/Form/Activity.php
+++ b/CRM/Activity/Form/Activity.php
@@ -1243,10 +1243,10 @@ class CRM_Activity_Form_Activity extends CRM_Contact_Form_Task {
           if (CRM_Contact_BAO_Contact::checkDomainContact($this->_currentlyViewedContactId)) {
             $displayName .= ' (' . ts('default organization') . ')';
           }
-          CRM_Utils_System::setTitle($displayName . ' - ' . $activityTypeDisplayLabel);
+          $this->setTitle($displayName . ' - ' . $activityTypeDisplayLabel);
         }
         else {
-          CRM_Utils_System::setTitle(ts('%1 Activity', [1 => $activityTypeDisplayLabel]));
+          $this->setTitle(ts('%1 Activity', [1 => $activityTypeDisplayLabel]));
         }
       }
     }

--- a/CRM/Activity/Form/Task/Batch.php
+++ b/CRM/Activity/Form/Task/Batch.php
@@ -90,7 +90,7 @@ class CRM_Activity_Form_Task_Batch extends CRM_Activity_Form_Task {
       throw new CRM_Core_Exception('The profile id is missing');
     }
     $this->_title = ts('Update multiple activities') . ' - ' . CRM_Core_BAO_UFGroup::getTitle($ufGroupId);
-    CRM_Utils_System::setTitle($this->_title);
+    $this->setTitle($this->_title);
 
     $this->addDefaultButtons(ts('Save'));
     $this->_fields = [];

--- a/CRM/Activity/Form/Task/FileOnCase.php
+++ b/CRM/Activity/Form/Task/FileOnCase.php
@@ -52,7 +52,7 @@ class CRM_Activity_Form_Task_FileOnCase extends CRM_Activity_Form_Task {
     $session = CRM_Core_Session::singleton();
     $this->_userContext = $session->readUserContext();
 
-    CRM_Utils_System::setTitle(ts('File on Case'));
+    $this->setTitle(ts('File on Case'));
   }
 
   /**

--- a/CRM/Activity/Form/Task/PickOption.php
+++ b/CRM/Activity/Form/Task/PickOption.php
@@ -60,7 +60,7 @@ class CRM_Activity_Form_Task_PickOption extends CRM_Activity_Form_Task {
     $session = CRM_Core_Session::singleton();
     $this->_userContext = $session->readUserContext();
 
-    CRM_Utils_System::setTitle(ts('Send Email to Contacts'));
+    $this->setTitle(ts('Send Email to Contacts'));
 
     $validate = FALSE;
     //validations

--- a/CRM/Activity/Form/Task/PickProfile.php
+++ b/CRM/Activity/Form/Task/PickProfile.php
@@ -54,7 +54,7 @@ class CRM_Activity_Form_Task_PickProfile extends CRM_Activity_Form_Task {
     $session = CRM_Core_Session::singleton();
     $this->_userContext = $session->readUserContext();
 
-    CRM_Utils_System::setTitle(ts('Update multiple activities'));
+    $this->setTitle(ts('Update multiple activities'));
 
     $validate = FALSE;
     // Validations.

--- a/CRM/Admin/Form/Job.php
+++ b/CRM/Admin/Form/Job.php
@@ -31,7 +31,7 @@ class CRM_Admin_Form_Job extends CRM_Admin_Form {
     parent::preProcess();
     $this->setContext();
 
-    CRM_Utils_System::setTitle(ts('Manage - Scheduled Jobs'));
+    $this->setTitle(ts('Manage - Scheduled Jobs'));
 
     if ($this->_id) {
       $refreshURL = CRM_Utils_System::url('civicrm/admin/job',

--- a/CRM/Admin/Form/MessageTemplates.php
+++ b/CRM/Admin/Form/MessageTemplates.php
@@ -213,7 +213,7 @@ class CRM_Admin_Form_MessageTemplates extends CRM_Core_Form {
 
     if ($this->_action & CRM_Core_Action::VIEW) {
       $this->freeze();
-      CRM_Utils_System::setTitle(ts('View System Default Message Template'));
+      $this->setTitle(ts('View System Default Message Template'));
     }
   }
 

--- a/CRM/Admin/Form/OptionGroup.php
+++ b/CRM/Admin/Form/OptionGroup.php
@@ -40,7 +40,7 @@ class CRM_Admin_Form_OptionGroup extends CRM_Admin_Form {
     if ($this->_action & CRM_Core_Action::DELETE) {
       return;
     }
-    CRM_Utils_System::setTitle(ts('Dropdown Options'));
+    $this->setTitle(ts('Dropdown Options'));
 
     $this->applyFilter('__ALL__', 'trim');
 

--- a/CRM/Admin/Form/Setting/Case.php
+++ b/CRM/Admin/Form/Setting/Case.php
@@ -32,7 +32,7 @@ class CRM_Admin_Form_Setting_Case extends CRM_Admin_Form_Setting {
    * Build the form object.
    */
   public function buildQuickForm() {
-    CRM_Utils_System::setTitle(ts('Settings - CiviCase'));
+    $this->setTitle(ts('Settings - CiviCase'));
     parent::buildQuickForm();
   }
 

--- a/CRM/Admin/Form/Setting/Date.php
+++ b/CRM/Admin/Form/Setting/Date.php
@@ -38,7 +38,7 @@ class CRM_Admin_Form_Setting_Date extends CRM_Admin_Form_Setting {
    * Build the form object.
    */
   public function buildQuickForm() {
-    CRM_Utils_System::setTitle(ts('Settings - Date'));
+    $this->setTitle(ts('Settings - Date'));
 
     parent::buildQuickForm();
   }

--- a/CRM/Admin/Form/Setting/Debugging.php
+++ b/CRM/Admin/Form/Setting/Debugging.php
@@ -32,7 +32,7 @@ class CRM_Admin_Form_Setting_Debugging extends CRM_Admin_Form_Setting {
    * Build the form object.
    */
   public function buildQuickForm() {
-    CRM_Utils_System::setTitle(ts(' Settings - Debugging and Error Handling '));
+    $this->setTitle(ts(' Settings - Debugging and Error Handling '));
     if (CRM_Core_Config::singleton()->userSystem->supports_UF_Logging == '1') {
       $this->_settings['userFrameworkLogging'] = CRM_Core_BAO_Setting::DEVELOPER_PREFERENCES_NAME;
     }

--- a/CRM/Admin/Form/Setting/Localization.php
+++ b/CRM/Admin/Form/Setting/Localization.php
@@ -45,7 +45,7 @@ class CRM_Admin_Form_Setting_Localization extends CRM_Admin_Form_Setting {
   public function buildQuickForm() {
     $config = CRM_Core_Config::singleton();
 
-    CRM_Utils_System::setTitle(ts('Settings - Localization'));
+    $this->setTitle(ts('Settings - Localization'));
 
     $warningTitle = json_encode(ts("Warning"));
     $defaultLocaleOptions = CRM_Admin_Form_Setting_Localization::getDefaultLocaleOptions();

--- a/CRM/Admin/Form/Setting/Mail.php
+++ b/CRM/Admin/Form/Setting/Mail.php
@@ -35,7 +35,7 @@ class CRM_Admin_Form_Setting_Mail extends CRM_Admin_Form_Setting {
    * Build the form object.
    */
   public function buildQuickForm() {
-    CRM_Utils_System::setTitle(ts('Settings - CiviMail'));
+    $this->setTitle(ts('Settings - CiviMail'));
     $this->addFormRule(['CRM_Admin_Form_Setting_Mail', 'formRule']);
     parent::buildQuickForm();
   }

--- a/CRM/Admin/Form/Setting/Mapping.php
+++ b/CRM/Admin/Form/Setting/Mapping.php
@@ -31,7 +31,7 @@ class CRM_Admin_Form_Setting_Mapping extends CRM_Admin_Form_Setting {
    * Build the form object.
    */
   public function buildQuickForm() {
-    CRM_Utils_System::setTitle(ts('Settings - Mapping and Geocoding Providers'));
+    $this->setTitle(ts('Settings - Mapping and Geocoding Providers'));
     parent::buildQuickForm();
   }
 

--- a/CRM/Admin/Form/Setting/Miscellaneous.php
+++ b/CRM/Admin/Form/Setting/Miscellaneous.php
@@ -65,7 +65,7 @@ class CRM_Admin_Form_Setting_Miscellaneous extends CRM_Admin_Form_Setting {
    * Build the form object.
    */
   public function buildQuickForm() {
-    CRM_Utils_System::setTitle(ts('Misc (Undelete, PDFs, Limits, Logging, etc.)'));
+    $this->setTitle(ts('Misc (Undelete, PDFs, Limits, Logging, etc.)'));
 
     $this->assign('validTriggerPermission', CRM_Core_DAO::checkTriggerViewPermission(FALSE));
     // dev/core#1812 Assign multilingual status.

--- a/CRM/Admin/Form/Setting/Path.php
+++ b/CRM/Admin/Form/Setting/Path.php
@@ -35,7 +35,7 @@ class CRM_Admin_Form_Setting_Path extends CRM_Admin_Form_Setting {
    * @throws \CRM_Core_Exception
    */
   public function buildQuickForm() {
-    CRM_Utils_System::setTitle(ts('Settings - Upload Directories'));
+    $this->setTitle(ts('Settings - Upload Directories'));
     parent::buildQuickForm();
 
     $directories = [

--- a/CRM/Admin/Form/Setting/Search.php
+++ b/CRM/Admin/Form/Setting/Search.php
@@ -42,7 +42,7 @@ class CRM_Admin_Form_Setting_Search extends CRM_Admin_Form_Setting {
    * Build the form object.
    */
   public function buildQuickForm() {
-    CRM_Utils_System::setTitle(ts('Settings - Search Preferences'));
+    $this->setTitle(ts('Settings - Search Preferences'));
 
     parent::buildQuickForm();
 

--- a/CRM/Admin/Form/Setting/Smtp.php
+++ b/CRM/Admin/Form/Setting/Smtp.php
@@ -47,7 +47,7 @@ class CRM_Admin_Form_Setting_Smtp extends CRM_Admin_Form_Setting {
     ];
     $this->addRadio('outBound_option', ts('Select Mailer'), $outBoundOption, $props['outBound_option'] ?? []);
 
-    CRM_Utils_System::setTitle(ts('Settings - Outbound Mail'));
+    $this->setTitle(ts('Settings - Outbound Mail'));
     $this->add('text', 'sendmail_path', ts('Sendmail Path'));
     $this->add('text', 'sendmail_args', ts('Sendmail Argument'));
     $this->add('text', 'smtpServer', ts('SMTP Server'), CRM_Utils_Array::value('smtpServer', $props));

--- a/CRM/Admin/Form/Setting/UF.php
+++ b/CRM/Admin/Form/Setting/UF.php
@@ -36,7 +36,7 @@ class CRM_Admin_Form_Setting_UF extends CRM_Admin_Form_Setting {
       $this->_settings['wpBasePage'] = CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME;
     }
 
-    CRM_Utils_System::setTitle(
+    $this->setTitle(
       ts('Settings - %1 Integration', [1 => $this->_uf])
     );
 

--- a/CRM/Admin/Form/Setting/UpdateConfigBackend.php
+++ b/CRM/Admin/Form/Setting/UpdateConfigBackend.php
@@ -24,7 +24,7 @@ class CRM_Admin_Form_Setting_UpdateConfigBackend extends CRM_Admin_Form_Setting 
    * Build the form object.
    */
   public function buildQuickForm() {
-    CRM_Utils_System::setTitle(ts('Settings - Cleanup Caches and Update Paths'));
+    $this->setTitle(ts('Settings - Cleanup Caches and Update Paths'));
 
     $this->addButtons([
       [

--- a/CRM/Admin/Form/Setting/Url.php
+++ b/CRM/Admin/Form/Setting/Url.php
@@ -32,7 +32,7 @@ class CRM_Admin_Form_Setting_Url extends CRM_Admin_Form_Setting {
    * Build the form object.
    */
   public function buildQuickForm() {
-    CRM_Utils_System::setTitle(ts('Settings - Resource URLs'));
+    $this->setTitle(ts('Settings - Resource URLs'));
     $settingFields = civicrm_api('setting', 'getfields', [
       'version' => 3,
     ]);

--- a/CRM/Batch/Form/Entry.php
+++ b/CRM/Batch/Form/Entry.php
@@ -231,13 +231,13 @@ class CRM_Batch_Form_Entry extends CRM_Core_Form {
     $batchTypes = CRM_Core_PseudoConstant::get('CRM_Batch_DAO_Batch', 'type_id', ['flip' => 1], 'validate');
     // get the profile information
     if ($this->_batchInfo['type_id'] == $batchTypes['Contribution']) {
-      CRM_Utils_System::setTitle(ts('Batch Data Entry for Contributions'));
+      $this->setTitle(ts('Batch Data Entry for Contributions'));
     }
     elseif ($this->_batchInfo['type_id'] == $batchTypes['Membership']) {
-      CRM_Utils_System::setTitle(ts('Batch Data Entry for Memberships'));
+      $this->setTitle(ts('Batch Data Entry for Memberships'));
     }
     elseif ($this->_batchInfo['type_id'] == $batchTypes['Pledge Payment']) {
-      CRM_Utils_System::setTitle(ts('Batch Data Entry for Pledge Payments'));
+      $this->setTitle(ts('Batch Data Entry for Pledge Payments'));
     }
 
     $this->_fields = CRM_Core_BAO_UFGroup::getFields($this->_profileId, FALSE, CRM_Core_Action::VIEW);

--- a/CRM/Campaign/Form/Campaign.php
+++ b/CRM/Campaign/Form/Campaign.php
@@ -75,7 +75,7 @@ class CRM_Campaign_Form_Campaign extends CRM_Core_Form {
       $title = ts('Delete Campaign');
     }
     if ($title) {
-      CRM_Utils_System::setTitle($title);
+      $this->setTitle($title);
     }
 
     $session = CRM_Core_Session::singleton();

--- a/CRM/Campaign/Form/Gotv.php
+++ b/CRM/Campaign/Form/Gotv.php
@@ -72,7 +72,7 @@ class CRM_Campaign_Form_Gotv extends CRM_Core_Form {
     }
 
     //set the form title.
-    CRM_Utils_System::setTitle(ts('GOTV (Voter Tracking)'));
+    $this->setTitle(ts('GOTV (Voter Tracking)'));
   }
 
   /**

--- a/CRM/Campaign/Form/Petition.php
+++ b/CRM/Campaign/Form/Petition.php
@@ -57,10 +57,10 @@ class CRM_Campaign_Form_Petition extends CRM_Core_Form {
       $this->_surveyId = CRM_Utils_Request::retrieve('id', 'Positive', $this, TRUE);
 
       if ($this->_action & CRM_Core_Action::UPDATE) {
-        CRM_Utils_System::setTitle(ts('Edit Survey'));
+        $this->setTitle(ts('Edit Survey'));
       }
       else {
-        CRM_Utils_System::setTitle(ts('Delete Survey'));
+        $this->setTitle(ts('Delete Survey'));
       }
     }
 
@@ -89,10 +89,10 @@ class CRM_Campaign_Form_Petition extends CRM_Core_Form {
       $this->_surveyId = CRM_Utils_Request::retrieve('id', 'Positive', $this, TRUE);
 
       if ($this->_action & CRM_Core_Action::UPDATE) {
-        CRM_Utils_System::setTitle(ts('Edit Petition'));
+        $this->setTitle(ts('Edit Petition'));
       }
       else {
-        CRM_Utils_System::setTitle(ts('Delete Petition'));
+        $this->setTitle(ts('Delete Petition'));
       }
     }
 

--- a/CRM/Campaign/Form/Petition/Signature.php
+++ b/CRM/Campaign/Form/Petition/Signature.php
@@ -230,7 +230,7 @@ class CRM_Campaign_Form_Petition_Signature extends CRM_Core_Form {
     }
 
     $this->setDefaultValues();
-    CRM_Utils_System::setTitle($this->petition['title']);
+    $this->setTitle($this->petition['title']);
   }
 
   /**

--- a/CRM/Campaign/Form/Search.php
+++ b/CRM/Campaign/Form/Search.php
@@ -144,7 +144,7 @@ class CRM_Campaign_Form_Search extends CRM_Core_Form_Search {
     }
 
     //set the form title.
-    CRM_Utils_System::setTitle(ts('Find Respondents To %1', array(1 => ucfirst($this->_operation))));
+    $this->setTitle(ts('Find Respondents To %1', array(1 => ucfirst($this->_operation))));
   }
 
   /**

--- a/CRM/Campaign/Form/Search/Campaign.php
+++ b/CRM/Campaign/Form/Search/Campaign.php
@@ -54,7 +54,7 @@ class CRM_Campaign_Form_Search_Campaign extends CRM_Core_Form {
     $this->assign('suppressForm', TRUE);
 
     //set the form title.
-    CRM_Utils_System::setTitle(ts('Find Campaigns'));
+    $this->setTitle(ts('Find Campaigns'));
   }
 
   /**

--- a/CRM/Campaign/Form/Search/Petition.php
+++ b/CRM/Campaign/Form/Search/Petition.php
@@ -44,7 +44,7 @@ class CRM_Campaign_Form_Search_Petition extends CRM_Core_Form {
     $this->assign('suppressForm', TRUE);
 
     //set the form title.
-    CRM_Utils_System::setTitle(ts('Find Petition'));
+    $this->setTitle(ts('Find Petition'));
   }
 
   /**

--- a/CRM/Campaign/Form/Search/Survey.php
+++ b/CRM/Campaign/Form/Search/Survey.php
@@ -45,7 +45,7 @@ class CRM_Campaign_Form_Search_Survey extends CRM_Core_Form {
     $this->assign('suppressForm', TRUE);
 
     //set the form title.
-    CRM_Utils_System::setTitle(ts('Find Survey'));
+    $this->setTitle(ts('Find Survey'));
   }
 
   /**

--- a/CRM/Campaign/Form/Survey.php
+++ b/CRM/Campaign/Form/Survey.php
@@ -72,7 +72,7 @@ class CRM_Campaign_Form_Survey extends CRM_Core_Form {
       CRM_Campaign_BAO_Survey::retrieve($params, $surveyInfo);
       $this->_surveyTitle = $surveyInfo['title'];
       $this->assign('surveyTitle', $this->_surveyTitle);
-      CRM_Utils_System::setTitle(ts('Configure Survey - %1', [1 => $this->_surveyTitle]));
+      $this->setTitle(ts('Configure Survey - %1', [1 => $this->_surveyTitle]));
     }
 
     $this->assign('action', $this->_action);

--- a/CRM/Campaign/Form/Survey/Delete.php
+++ b/CRM/Campaign/Form/Survey/Delete.php
@@ -47,7 +47,7 @@ class CRM_Campaign_Form_Survey_Delete extends CRM_Core_Form {
     CRM_Campaign_BAO_Survey::retrieve($params, $surveyInfo);
     $this->_surveyTitle = $surveyInfo['title'];
     $this->assign('surveyTitle', $this->_surveyTitle);
-    CRM_Utils_System::setTitle(ts('Delete Survey') . ' - ' . $this->_surveyTitle);
+    $this->setTitle(ts('Delete Survey') . ' - ' . $this->_surveyTitle);
   }
 
   /**

--- a/CRM/Campaign/Form/Survey/Main.php
+++ b/CRM/Campaign/Form/Survey/Main.php
@@ -47,7 +47,7 @@ class CRM_Campaign_Form_Survey_Main extends CRM_Campaign_Form_Survey {
     $this->_action = CRM_Utils_Request::retrieve('action', 'String', $this);
 
     if ($this->_action & CRM_Core_Action::UPDATE) {
-      CRM_Utils_System::setTitle(ts('Configure Survey') . ' - ' . $this->_surveyTitle);
+      $this->setTitle(ts('Configure Survey') . ' - ' . $this->_surveyTitle);
     }
 
     // Add custom data to form

--- a/CRM/Campaign/Form/Task/Interview.php
+++ b/CRM/Campaign/Form/Task/Interview.php
@@ -235,7 +235,7 @@ WHERE {$clause}
     //set the title.
     $this->_surveyTypeId = $this->_surveyValues['activity_type_id'] ?? NULL;
     $surveyTypeLabel = CRM_Core_PseudoConstant::getLabel('CRM_Activity_BAO_Activity', 'activity_type_id', $this->_surveyTypeId);
-    CRM_Utils_System::setTitle(ts('Record %1 Responses', [1 => $surveyTypeLabel]));
+    $this->setTitle(ts('Record %1 Responses', [1 => $surveyTypeLabel]));
   }
 
   public function validateIds() {

--- a/CRM/Campaign/Form/Task/Release.php
+++ b/CRM/Campaign/Form/Task/Release.php
@@ -109,7 +109,7 @@ class CRM_Campaign_Form_Task_Release extends CRM_Campaign_Form_Task {
     }
 
     //set the title.
-    CRM_Utils_System::setTitle(ts('Release Respondents'));
+    $this->setTitle(ts('Release Respondents'));
   }
 
   /**

--- a/CRM/Campaign/Form/Task/Reserve.php
+++ b/CRM/Campaign/Form/Task/Reserve.php
@@ -99,7 +99,7 @@ class CRM_Campaign_Form_Task_Reserve extends CRM_Campaign_Form_Task {
     }
 
     //set the title.
-    CRM_Utils_System::setTitle(ts('Reserve Respondents'));
+    $this->setTitle(ts('Reserve Respondents'));
   }
 
   public function validateSurvey() {


### PR DESCRIPTION
Overview
----------------------------------------
Follows on from some work that @eileenmcnaughton started in 2019. Forms should use `$this->setTitle()` instead of `CRM_Utils_System::setTitle()` because it allows you to use `$this->getTitle()` on a form to get the title of the form that the user will see.

Before
----------------------------------------
Calls to `CRM_Utils_System::setTitle()`

After
----------------------------------------
Calls to `$this->setTitle()`

Technical Details
----------------------------------------
As can be observed `CRM_Core_Form::setTitle()` calls `CRM_Utils_System::setTitle()` internally after setting `$this->_title` showing that this function is a drop-in replacement. There are just over 200 instances that need converting and (for ease of review) I've only included the first 43 here.
I would suggest that `r-run` testing could be done with a few forms only instead of all of them - what needs to be verified is that it is a form that inherits from CRM_Core_Form (and not eg. a Page).

Comments
----------------------------------------
There are 4 commits in total that would complete this change and I'll follow up with the others - see https://github.com/civicrm/civicrm-core/compare/master...mattwire:settitle?expand=1
