### PR TITLE
APIv4 - Properly show deprecated joins in unit tests (fixes dev/core#2771)

### DIFF
--- a/Civi/Api4/Query/Api4SelectQuery.php
+++ b/Civi/Api4/Query/Api4SelectQuery.php
@@ -988,7 +988,7 @@ class Api4SelectQuery {
     try {
       $joinPath = $joiner->autoJoin($this, $pathArray);
     }
-    catch (\Exception $e) {
+    catch (\API_Exception $e) {
       return;
     }
     $lastLink = array_pop($joinPath);

--- a/Civi/Api4/Service/Schema/Joiner.php
+++ b/Civi/Api4/Service/Schema/Joiner.php
@@ -106,7 +106,7 @@ class Joiner {
    * @param array $joinPath
    *
    * @return \Civi\Api4\Service\Schema\Joinable\Joinable[]
-   * @throws \Exception
+   * @throws \API_Exception
    */
   protected function getPath(string $baseTable, array $joinPath) {
     $cacheKey = sprintf('%s.%s', $baseTable, implode('.', $joinPath));
@@ -117,7 +117,7 @@ class Joiner {
         $links = $this->schemaMap->getPath($baseTable, $targetAlias);
 
         if (empty($links)) {
-          throw new \Exception(sprintf('Cannot join %s to %s', $baseTable, $targetAlias));
+          throw new \API_Exception(sprintf('Cannot join %s to %s', $baseTable, $targetAlias));
         }
         else {
           $fullPath = array_merge($fullPath, $links);

--- a/tests/phpunit/api/v4/Action/FkJoinTest.php
+++ b/tests/phpunit/api/v4/Action/FkJoinTest.php
@@ -374,4 +374,22 @@ class FkJoinTest extends UnitTestCase {
     $this->assertEquals('TesterCo', $emailGet['contact_id.employer_id.display_name']);
   }
 
+  public function testDeprecatedJoins() {
+    $message = '';
+    try {
+      \Civi\Api4\Email::get(FALSE)
+        ->addWhere('contact.first_name', '=', 'Peter')
+        ->addWhere('contact.last_name', '=', '')
+        ->addWhere('contact.is_deleted', '=', 0)
+        ->addWhere('contact.is_deceased', '=', 0)
+        ->addWhere('email', '=', '')
+        ->addWhere('is_primary', '=', TRUE)
+        ->setSelect(['contact_id'])->execute();
+    }
+    catch (\Exception $e) {
+      $message = $e->getMessage();
+    }
+    $this->assertStringContainsString("Deprecated join alias 'contact' used in APIv4 get. Should be changed to 'contact_id'", $message);
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Replacement for #21188

See https://lab.civicrm.org/dev/core/-/issues/2771