### PR TITLE
APIv4 - Add unit test for deprecated joins (dev/core#2771)

### DIFF
--- a/Civi/Api4/Query/Api4SelectQuery.php
+++ b/Civi/Api4/Query/Api4SelectQuery.php
@@ -1014,7 +1014,7 @@ class Api4SelectQuery {
     try {
       $joinPath = $joiner->getPath($explicitJoin['table'] ?? $this->getFrom(), $pathArray);
     }
-    catch (\Exception $e) {
+    catch (\API_Exception $e) {
       // Because the select clause silently ignores unknown fields, this function shouldn't throw exceptions
       return;
     }

--- a/tests/phpunit/api/v4/Action/FkJoinTest.php
+++ b/tests/phpunit/api/v4/Action/FkJoinTest.php
@@ -408,4 +408,22 @@ class FkJoinTest extends UnitTestCase {
     $this->assertEquals('TesterCo', $emailGet['contact_id.employer_id.display_name']);
   }
 
+  public function testDeprecatedJoins() {
+    $message = '';
+    try {
+      \Civi\Api4\Email::get(FALSE)
+        ->addWhere('contact.first_name', '=', 'Peter')
+        ->addWhere('contact.last_name', '=', '')
+        ->addWhere('contact.is_deleted', '=', 0)
+        ->addWhere('contact.is_deceased', '=', 0)
+        ->addWhere('email', '=', '')
+        ->addWhere('is_primary', '=', TRUE)
+        ->setSelect(['contact_id'])->execute();
+    }
+    catch (\Exception $e) {
+      $message = $e->getMessage();
+    }
+    $this->assertStringContainsString("Deprecated join alias 'contact' used in APIv4 get. Should be changed to 'contact_id'", $message);
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Unlike #21195 on 5.41, this test passed on `master` without any changes, due to some internal API refactoring that had already been done.

I did however switch the `catch` to a more specific exception for good measure.

See https://lab.civicrm.org/dev/core/-/issues/2771