### PR TITLE
dev/report#72 Advanced Search: relationships to case not correctly filtered

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -5839,10 +5839,14 @@ AND   displayRelType.is_active = 1
       else {
         $from .= $qcache['from'];
       }
+      $originalWhere = $where;
       $where = $qcache['where'];
       if (!empty($this->_tables['civicrm_case'])) {
         // Change the join on CiviCRM case so that it joins on the right contac from the relationship.
         $from = str_replace("ON civicrm_case_contact.contact_id = contact_a.id", "ON civicrm_case_contact.contact_id = transform_temp.contact_id", $from);
+        $originalWhere = str_replace("AND civicrm_case_contact.contact_id = contact_a.id", "AND civicrm_case_contact.contact_id = transform_temp.contact_id", $originalWhere);
+        $originalWhere = str_replace("WHERE ", "AND ", $originalWhere);
+        $where .= $originalWhere;
         $where .= " AND displayRelType.case_id = civicrm_case_contact.case_id ";
       }
       if (!empty($this->_permissionFromClause) && !stripos($from, 'aclContactCache')) {

--- a/tests/phpunit/CRM/Case/BAO/QueryTest.php
+++ b/tests/phpunit/CRM/Case/BAO/QueryTest.php
@@ -139,6 +139,66 @@ class CRM_Case_BAO_QueryTest extends CiviCaseTestCase {
    *
    * @throws \Exception
    */
+  public function testAdvancedSearchWithDisplayRelationshipsAndCaseType() {
+    // Preperation
+    $benefitRelationshipTypeId = civicrm_api3('RelationshipType', 'getvalue', ['return' => 'id', 'name_a_b' => 'Benefits Specialist is']);
+    $clientContactID = $this->individualCreate(['first_name' => 'John', 'last_name' => 'Smith']);
+    $benefitSpecialist1 = $this->individualCreate(['Individual', 'first_name' => 'Alexa', 'last_name' => 'Clarke']);
+    $benefitSpecialist2 = $this->individualCreate(['Individual', 'first_name' => 'Sandra', 'last_name' => 'Johnson']);
+    $housingSupportCase = $this->createCase($clientContactID, NULL, ['case_type' => 'housing_support', 'case_type_id' => 1]);
+    $adultDayCareReferralCase = $this->createCase($clientContactID, NULL, ['case_type' => 'adult_day_care_referral', 'case_type_id' => 2]);
+    civicrm_api3('Relationship', 'create', ['contact_id_a' => $clientContactID, 'contact_id_b' => $benefitSpecialist1, 'relationship_type_id' => $benefitRelationshipTypeId, 'case_id' => $housingSupportCase->id]);
+    civicrm_api3('Relationship', 'create', ['contact_id_a' => $clientContactID, 'contact_id_b' => $benefitSpecialist2, 'relationship_type_id' => $benefitRelationshipTypeId, 'case_id' => $adultDayCareReferralCase->id]);
+
+    // Search setup
+    $formValues = ['display_relationship_type' => $benefitRelationshipTypeId . '_b_a', 'case_type_id' => 1];
+    $params = CRM_Contact_BAO_Query::convertFormValues($formValues, 0, FALSE, NULL, []);
+    $isDeleted = in_array(['deleted_contacts', '=', 1, 0, 0], $params);
+    $selector = new CRM_Contact_Selector(
+      'CRM_Contact_Selector',
+      $formValues,
+      $params,
+      NULL,
+      CRM_Core_Action::NONE,
+      NULL,
+      FALSE,
+      'advanced'
+    );
+    $queryObject = $selector->getQueryObject();
+    $sql = $queryObject->query(FALSE, FALSE, FALSE, $isDeleted);
+    // Run the search
+    $rows = CRM_Core_DAO::executeQuery(implode(' ', $sql))->fetchAll();
+    // Check expected results.
+    $this->assertCount(1, $rows);
+    $this->assertEquals('Alexa', $rows[0]['first_name']);
+    $this->assertEquals('Clarke', $rows[0]['last_name']);
+  }
+
+
+
+  /**
+   * Tests the advanced search query by searching on related contacts and case type at the same time.
+   *
+   * Preparation:
+   *   Create a contact Contact A
+   *   Create another contact Contact B
+   *   Create a third contact Contact C
+   *   Create a case of type Housing Support for Contact A
+   *   On the case assign the role Benefit specialist is to Contact B
+   *   Create a second case of type Adult day care referral
+   *   On the case assign the role Benefit specialist is to Contact C
+   *
+   * Searching:
+   *   Go to advanced search
+   *   Click on View contact as related contact
+   *   Select Benefit Specialist as relationship type
+   *   Go to tab cases and select Housing Support as case type
+   *
+   * Expected results
+   *   We expect to find contact B and not C.
+   *
+   * @throws \Exception
+   */
   public function testAdvancedSearchWithDisplayRelationshipsAndCaseType(): void {
     $this->markTestIncomplete('temporarily disabled as https://github.com/civicrm/civicrm-core/pull/20002 reverted for now');
     $benefitRelationshipTypeId = $this->callAPISuccess('RelationshipType', 'getvalue', ['return' => 'id', 'name_a_b' => 'Benefits Specialist is']);


### PR DESCRIPTION
Overview
----------------------------------------
When doing an advanced search with case parameters set and displaying related contacts. Gives all clients of all the found cases which have this relationship. What we would expect is that related contact is linked to the found cases. 

Steps to reproduce
--------------------------

Preparation:
1. Create a contact **Contact A**
2. Create another contact **Contact B**
3. Create a third contact **Contact C**
4. Create a case of type **Housing Support** for **Contact A**
5. On the case assign the role **Benefit specialist is** to **Contact B**
6. Create a second case of type **Adult day care referral**
7. On the case assign the role **Benefit specialist is** to **Contact C**

Searching:
1. Go to advanced search
2. Click on **View contact as related contact**
3. Select **Benefit Specialist** as relationship type
4. Go to tab cases and select **Housing Support** as case type

Expected results
-----------------------

I expected to see only Contact B as that one has a relationship on the case **Housing Support**.

Actual results
-------------------

I see both Contact B and Contact C.

Comments
----------------------------------------

This is a reworked PR because the original PR got reverted. 

See also the discussion of a similar related topic: https://lab.civicrm.org/dev/report/-/issues/53
See also https://lab.civicrm.org/dev/report/-/issues/72
