### PR TITLE
[REF] Cleanup BAO::del() functions with unnecessary FK checks (dev/core#2757)

### DIFF
--- a/CRM/Contribute/BAO/Product.php
+++ b/CRM/Contribute/BAO/Product.php
@@ -111,20 +111,11 @@ class CRM_Contribute_BAO_Product extends CRM_Contribute_DAO_Product {
    * Delete premium Types.
    *
    * @param int $productID
-   *
+   * @deprecated
    * @throws \CRM_Core_Exception
    */
   public static function del($productID) {
-    //check dependencies
-    $premiumsProduct = new CRM_Contribute_DAO_PremiumsProduct();
-    $premiumsProduct->product_id = $productID;
-    if ($premiumsProduct->find(TRUE)) {
-      throw new CRM_Core_Exception('Cannot delete a Premium that is linked to a Contribution page');
-    }
-    // delete product
-    $premium = new CRM_Contribute_DAO_Product();
-    $premium->id = $productID;
-    $premium->delete();
+    static::deleteRecord(['id' => $productID]);
   }
 
 }

--- a/CRM/Core/BAO/Tag.php
+++ b/CRM/Core/BAO/Tag.php
@@ -349,31 +349,11 @@ class CRM_Core_BAO_Tag extends CRM_Core_DAO_Tag {
    * Delete the tag.
    *
    * @param int $id
-   *   Tag id.
-   *
+   * @deprecated
    * @return bool
    */
   public static function del($id) {
-    // since this is a destructive operation, lets make sure
-    // id is a positive number
-    CRM_Utils_Type::validate($id, 'Positive');
-
-    // delete all crm_entity_tag records with the selected tag id
-    $entityTag = new CRM_Core_DAO_EntityTag();
-    $entityTag->tag_id = $id;
-    $entityTag->delete();
-
-    // delete from tag table
-    $tag = new CRM_Core_DAO_Tag();
-    $tag->id = $id;
-
-    CRM_Utils_Hook::pre('delete', 'Tag', $id, $tag);
-
-    if ($tag->delete()) {
-      CRM_Utils_Hook::post('delete', 'Tag', $id, $tag);
-      return TRUE;
-    }
-    return FALSE;
+    return (bool) static::deleteRecord(['id' => $id]);
   }
 
   /**

--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -957,6 +957,7 @@ class CRM_Core_DAO extends DB_DataObject {
     if (empty($record['id'])) {
       throw new CRM_Core_Exception("Cannot delete {$entityName} with no id.");
     }
+    CRM_Utils_Type::validate($record['id'], 'Positive');
 
     CRM_Utils_Hook::pre('delete', $entityName, $record['id'], $record);
     $instance = new $className();


### PR DESCRIPTION
Overview
----------------------------------------
Broken off from a larger cleanup PR #21200. These are the non-no-brainers which a reviewer should double-check for accuracy.

Before
----------------------------------------
These were using PHP to enforce key constraints better taken care of by MySQL.

After
----------------------------------------
Just leave it to MySQL to do its thing with foreign key checks and deprecate the functions in favor of generics.

Comments
---------
A reviewer should note that `civicrm_entity_tag` uses `ON DELETE CASCADE`, making the php function here redundant. And `PremiumsProduct` does NOT cascade, again making this php function redundant.