### PR TITLE
[REF] Deprecate unnecessary del() functions

### DIFF
--- a/CRM/ACL/BAO/ACLEntityRole.php
+++ b/CRM/ACL/BAO/ACLEntityRole.php
@@ -69,10 +69,10 @@ class CRM_ACL_BAO_ACLEntityRole extends CRM_ACL_DAO_ACLEntityRole {
    *
    * @param int $entityRoleId
    *   ID of the EntityRole record to be deleted.
-   *
+   * @deprecated
    */
   public static function del($entityRoleId) {
-    return parent::deleteRecord(['id' => $entityRoleId]);
+    return self::deleteRecord(['id' => $entityRoleId]);
   }
 
 }

--- a/CRM/Badge/BAO/Layout.php
+++ b/CRM/Badge/BAO/Layout.php
@@ -106,13 +106,10 @@ class CRM_Badge_BAO_Layout extends CRM_Core_DAO_PrintLabel {
    * Delete name labels.
    *
    * @param int $printLabelId
-   *   ID of the name label to be deleted.
-   *
+   * @deprecated
    */
   public static function del($printLabelId) {
-    $printLabel = new CRM_Core_DAO_PrintLabel();
-    $printLabel->id = $printLabelId;
-    $printLabel->delete();
+    self::deleteRecord(['id' => $printLabelId]);
   }
 
   /**

--- a/CRM/Campaign/BAO/Campaign.php
+++ b/CRM/Campaign/BAO/Campaign.php
@@ -77,24 +77,18 @@ class CRM_Campaign_BAO_Campaign extends CRM_Campaign_DAO_Campaign {
    * Delete the campaign.
    *
    * @param int $id
-   *   Id of the campaign.
    *
-   * @return bool|mixed
+   * @deprecated
+   * @return bool|int
    */
   public static function del($id) {
-    if (!$id) {
+    try {
+      self::deleteRecord(['id' => $id]);
+    }
+    catch (CRM_Core_Exception $e) {
       return FALSE;
     }
-
-    CRM_Utils_Hook::pre('delete', 'Campaign', $id);
-
-    $dao = new CRM_Campaign_DAO_Campaign();
-    $dao->id = $id;
-    $result = $dao->delete();
-
-    CRM_Utils_Hook::post('delete', 'Campaign', $id, $dao);
-
-    return $result;
+    return 1;
   }
 
   /**

--- a/CRM/Core/BAO/ActionSchedule.php
+++ b/CRM/Core/BAO/ActionSchedule.php
@@ -213,20 +213,11 @@ FROM civicrm_action_schedule cas
    * Delete a Reminder.
    *
    * @param int $id
-   *   ID of the Reminder to be deleted.
-   *
+   * @deprecated
    * @throws CRM_Core_Exception
    */
   public static function del($id) {
-    if ($id) {
-      $dao = new CRM_Core_DAO_ActionSchedule();
-      $dao->id = $id;
-      if ($dao->find(TRUE)) {
-        $dao->delete();
-        return;
-      }
-    }
-    throw new CRM_Core_Exception(ts('Invalid value passed to delete function.'));
+    self::deleteRecord(['id' => $id]);
   }
 
   /**

--- a/CRM/Core/BAO/EntityTag.php
+++ b/CRM/Core/BAO/EntityTag.php
@@ -96,7 +96,8 @@ class CRM_Core_BAO_EntityTag extends CRM_Core_DAO_EntityTag {
    * Delete the tag for a contact.
    *
    * @param array $params
-   *   (reference ) an assoc array of name/value pairs.
+   *
+   * WARNING: Nonstandard params searches by tag_id rather than id!
    */
   public static function del(&$params) {
     //invoke pre hook

--- a/CRM/Core/BAO/Job.php
+++ b/CRM/Core/BAO/Job.php
@@ -85,25 +85,14 @@ class CRM_Core_BAO_Job extends CRM_Core_DAO_Job {
    * Function  to delete scheduled job.
    *
    * @param $jobID
-   *   ID of the job to be deleted.
    *
    * @return bool|null
+   * @deprecated
    * @throws CRM_Core_Exception
    */
   public static function del($jobID) {
-    if (!$jobID) {
-      throw new CRM_Core_Exception(ts('Invalid value passed to delete function.'));
-    }
-
-    $dao = new CRM_Core_DAO_Job();
-    $dao->id = $jobID;
-    if (!$dao->find(TRUE)) {
-      return NULL;
-    }
-
-    if ($dao->delete()) {
-      return TRUE;
-    }
+    self::deleteRecord(['id' => $jobID]);
+    return TRUE;
   }
 
   /**

--- a/CRM/Core/BAO/UFField.php
+++ b/CRM/Core/BAO/UFField.php
@@ -157,17 +157,11 @@ class CRM_Core_BAO_UFField extends CRM_Core_DAO_UFField {
    * Delete the profile Field.
    *
    * @param int $id
-   *   Field Id.
-   *
+   * @deprecated
    * @return bool
-   *
    */
   public static function del($id) {
-    //delete  field field
-    $field = new CRM_Core_DAO_UFField();
-    $field->id = $id;
-    $field->delete();
-    return TRUE;
+    return (bool) self::deleteRecord(['id' => $id]);
   }
 
   /**

--- a/CRM/Mailing/BAO/MailingJob.php
+++ b/CRM/Mailing/BAO/MailingJob.php
@@ -1117,20 +1117,11 @@ AND    record_type_id = $targetRecordID
    * Delete the mailing job.
    *
    * @param int $id
-   *   Mailing Job id.
-   *
-   * @return mixed
+   * @deprecated
+   * @return bool
    */
   public static function del($id) {
-    CRM_Utils_Hook::pre('delete', 'MailingJob', $id);
-
-    $jobDAO = new CRM_Mailing_BAO_MailingJob();
-    $jobDAO->id = $id;
-    $result = $jobDAO->delete();
-
-    CRM_Utils_Hook::post('delete', 'MailingJob', $jobDAO->id, $jobDAO);
-
-    return $result;
+    return (bool) self::deleteRecord(['id' => $id]);
   }
 
 }

--- a/CRM/Member/BAO/MembershipBlock.php
+++ b/CRM/Member/BAO/MembershipBlock.php
@@ -37,18 +37,11 @@ class CRM_Member_BAO_MembershipBlock extends CRM_Member_DAO_MembershipBlock {
    * Delete membership Blocks.
    *
    * @param int $id
-   *
+   * @deprecated
    * @return bool
    */
   public static function del($id) {
-    $dao = new CRM_Member_DAO_MembershipBlock();
-    $dao->id = $id;
-    $result = FALSE;
-    if ($dao->find(TRUE)) {
-      $dao->delete();
-      $result = TRUE;
-    }
-    return $result;
+    return (bool) self::deleteRecord(['id' => $id]);
   }
 
 }

--- a/CRM/Member/BAO/MembershipPayment.php
+++ b/CRM/Member/BAO/MembershipPayment.php
@@ -84,18 +84,11 @@ class CRM_Member_BAO_MembershipPayment extends CRM_Member_DAO_MembershipPayment 
    * Delete membership Payments.
    *
    * @param int $id
-   *
+   * @deprecated
    * @return bool
    */
   public static function del($id) {
-    $dao = new CRM_Member_DAO_MembershipPayment();
-    $dao->id = $id;
-    $result = FALSE;
-    if ($dao->find(TRUE)) {
-      $dao->delete();
-      $result = TRUE;
-    }
-    return $result;
+    return (bool) self::deleteRecord(['id' => $id]);
   }
 
 }

--- a/CRM/Pledge/BAO/PledgePayment.php
+++ b/CRM/Pledge/BAO/PledgePayment.php
@@ -203,27 +203,11 @@ WHERE     pledge_id = %1
    * Delete pledge payment.
    *
    * @param int $id
-   *
-   * @return int
-   *   pledge payment id
+   * @deprecated
+   * @return bool
    */
   public static function del($id) {
-    $payment = new CRM_Pledge_DAO_PledgePayment();
-    $payment->id = $id;
-    if ($payment->find()) {
-      $payment->fetch();
-
-      CRM_Utils_Hook::pre('delete', 'PledgePayment', $id, $payment);
-
-      $result = $payment->delete();
-
-      CRM_Utils_Hook::post('delete', 'PledgePayment', $id, $payment);
-
-      return $result;
-    }
-    else {
-      return FALSE;
-    }
+    return (bool) self::deleteRecord(['id' => $id]);
   }
 
   /**

--- a/CRM/Price/BAO/PriceFieldValue.php
+++ b/CRM/Price/BAO/PriceFieldValue.php
@@ -217,19 +217,12 @@ class CRM_Price_BAO_PriceFieldValue extends CRM_Price_DAO_PriceFieldValue {
    * Delete the value.
    *
    * @param int $id
-   *   Id.
    *
+   * @deprecated
    * @return bool
-   *
    */
   public static function del($id) {
-    if (!$id) {
-      return FALSE;
-    }
-
-    $fieldValueDAO = new CRM_Price_DAO_PriceFieldValue();
-    $fieldValueDAO->id = $id;
-    return $fieldValueDAO->delete();
+    return (bool) self::deleteRecord(['id' => $id]);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
This moves us toward a standard delete function for APIv4, by cleaning up and deprecating all the `BAO::del()` functions which do nothing special.

Before
----------------------------------------
Generic functions implemented copy/paste style.

After
----------------------------------------
Deprecated in favor of a single, tested generic function.
