### PR TITLE
[REF] dev/core#2757 Move acl delete logic to an event listener

### DIFF
--- a/CRM/ACL/BAO/ACL.php
+++ b/CRM/ACL/BAO/ACL.php
@@ -18,7 +18,7 @@
 /**
  *  Access Control List
  */
-class CRM_ACL_BAO_ACL extends CRM_ACL_DAO_ACL {
+class CRM_ACL_BAO_ACL extends CRM_ACL_DAO_ACL implements \Civi\Test\HookInterface {
 
   /**
    * Available operations for  pseudoconstant.
@@ -433,16 +433,21 @@ SELECT g.*
    * Delete ACL records.
    *
    * @param int $aclId
-   *   ID of the ACL record to be deleted.
-   *
+   * @deprecated
    */
   public static function del($aclId) {
-    // delete all entries from the acl cache
-    CRM_ACL_BAO_Cache::resetCache();
+    self::deleteRecord(['id' => $aclId]);
+  }
 
-    $acl = new CRM_ACL_DAO_ACL();
-    $acl->id = $aclId;
-    $acl->delete();
+  /**
+   * Event fired before an action is taken on an ACL record.
+   * @param \Civi\Core\Event\PreEvent $event
+   */
+  public static function self_hook_civicrm_pre(\Civi\Core\Event\PreEvent $event) {
+    // Reset cache when deleting an ACL record
+    if ($event->action === 'delete') {
+      CRM_ACL_BAO_Cache::resetCache();
+    }
   }
 
   /**

--- a/Civi/Core/Event/EventScanner.php
+++ b/Civi/Core/Event/EventScanner.php
@@ -53,7 +53,7 @@ class EventScanner {
    * @param string|null $self
    *   If the target $class is focused on a specific entity/form/etc, use the `$self` parameter to specify it.
    *   This will activate support for `self_{$event}` methods.
-   *   Ex: if '$self' is 'Contact', then 'function self_hook_civicrm_pre()' maps to 'hook_civicrm_pre::Contact'.
+   *   Ex: if '$self' is 'Contact', then 'function self_hook_civicrm_pre()' maps to 'on_hook_civicrm_pre::Contact'.
    * @return array
    *   List of events/listeners. Format is compatible with 'getSubscribedEvents()'.
    *   Ex: ['some.event' => [['firstFunc'], ['secondFunc']]


### PR DESCRIPTION
Overview
----------------------------------------
This demonstrates how `DAO::del()` functions can be eliminated when they contain business logic that needs to be retained.

Before
----------------------------------------
`del()` function contains business logic needed during delete, but the generic function `deleteRecords()` does not.

After
----------------------------------------
Business logic happens when either function is called. `del()` deprecated in favor of `deleteRecords()`.

Comments
----------------------------------------
This uses `HookInterface` to listen for `hook_civicrm_pre`.