### PR TITLE
Switch to CRM_Core_Form::setTitle() instead of CRM_Utils_System::setTitle() part 2

### DIFF
--- a/CRM/Case/Form/ActivityToCase.php
+++ b/CRM/Case/Form/ActivityToCase.php
@@ -37,11 +37,11 @@ class CRM_Case_Form_ActivityToCase extends CRM_Core_Form {
 
     switch (CRM_Utils_Request::retrieve('fileOnCaseAction', 'String')) {
       case 'move':
-        CRM_Utils_System::setTitle(ts('Move to Case'));
+        $this->setTitle(ts('Move to Case'));
         break;
 
       case 'copy':
-        CRM_Utils_System::setTitle(ts('Copy to Case'));
+        $this->setTitle(ts('Copy to Case'));
         break;
 
     }

--- a/CRM/Case/Form/ActivityView.php
+++ b/CRM/Case/Form/ActivityView.php
@@ -83,7 +83,7 @@ class CRM_Case_Form_ActivityView extends CRM_Core_Form {
     }
 
     if ($revs) {
-      CRM_Utils_System::setTitle(ts('Activity Revision History'));
+      $this->setTitle(ts('Activity Revision History'));
       $this->assign('revs', $revs);
       $this->assign('result', $viewPriorActivities);
       $this->assign('subject', $activitySubject);

--- a/CRM/Case/Form/Case.php
+++ b/CRM/Case/Form/Case.php
@@ -164,7 +164,7 @@ class CRM_Case_Form_Case extends CRM_Core_Form {
 
     $details = CRM_Case_PseudoConstant::caseActivityType(FALSE);
 
-    CRM_Utils_System::setTitle($details[$this->_activityTypeId]['label']);
+    $this->setTitle($details[$this->_activityTypeId]['label']);
     $this->assign('activityType', $details[$this->_activityTypeId]['label']);
     $this->assign('activityTypeDescription', $details[$this->_activityTypeId]['description']);
 

--- a/CRM/Case/Form/CaseView.php
+++ b/CRM/Case/Form/CaseView.php
@@ -46,7 +46,7 @@ class CRM_Case_Form_CaseView extends CRM_Core_Form {
       }
       $this->assign('relatedCases', $relatedCases);
       $this->assign('showRelatedCases', TRUE);
-      CRM_Utils_System::setTitle(ts('Related Cases'));
+      $this->setTitle(ts('Related Cases'));
       return;
     }
 
@@ -103,7 +103,7 @@ class CRM_Case_Form_CaseView extends CRM_Core_Form {
     $displayName = CRM_Contact_BAO_Contact::displayName($this->_contactID);
     $this->assign('displayName', $displayName);
 
-    CRM_Utils_System::setTitle($displayName . ' - ' . $caseType);
+    $this->setTitle($displayName . ' - ' . $caseType);
 
     $recentOther = [];
     if (CRM_Core_Permission::checkActionPermission('CiviCase', CRM_Core_Action::DELETE)) {

--- a/CRM/Case/Form/CustomData.php
+++ b/CRM/Case/Form/CustomData.php
@@ -60,7 +60,7 @@ class CRM_Case_Form_CustomData extends CRM_Core_Form {
     // Array contains only one item
     foreach ($groupTree as $groupValues) {
       $this->_customTitle = $groupValues['title'];
-      CRM_Utils_System::setTitle(ts('Edit %1', [1 => $groupValues['title']]));
+      $this->setTitle(ts('Edit %1', [1 => $groupValues['title']]));
     }
 
     $this->_defaults = [];

--- a/CRM/Contact/Form/Contact.php
+++ b/CRM/Contact/Form/Contact.php
@@ -180,7 +180,7 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
       );
       $typeLabel = implode(' / ', $typeLabel);
 
-      CRM_Utils_System::setTitle(ts('New %1', [1 => $typeLabel]));
+      $this->setTitle(ts('New %1', [1 => $typeLabel]));
       $session->pushUserContext(CRM_Utils_System::url('civicrm/dashboard', 'reset=1'));
       $this->_contactId = NULL;
     }
@@ -221,7 +221,7 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
         }
 
         // omitting contactImage from title for now since the summary overlay css doesn't work outside of our crm-container
-        CRM_Utils_System::setTitle($displayName);
+        $this->setTitle($displayName);
         $context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this);
         $qfKey = CRM_Utils_Request::retrieve('key', 'String', $this);
 

--- a/CRM/Contact/Form/CustomData.php
+++ b/CRM/Contact/Form/CustomData.php
@@ -112,15 +112,15 @@ class CRM_Contact_Form_CustomData extends CRM_Core_Form {
         $groupTitle = CRM_Core_BAO_CustomGroup::getTitle($this->_groupID);
         switch ($mode) {
           case 'add':
-            CRM_Utils_System::setTitle(ts('Add %1', [1 => $groupTitle]));
+            $this->setTitle(ts('Add %1', [1 => $groupTitle]));
             break;
 
           case 'edit':
-            CRM_Utils_System::setTitle(ts('Edit %1', [1 => $groupTitle]));
+            $this->setTitle(ts('Edit %1', [1 => $groupTitle]));
             break;
 
           case 'copy':
-            CRM_Utils_System::setTitle(ts('Copy %1', [1 => $groupTitle]));
+            $this->setTitle(ts('Copy %1', [1 => $groupTitle]));
             break;
         }
 
@@ -138,7 +138,7 @@ class CRM_Contact_Form_CustomData extends CRM_Core_Form {
     $this->assign('contact_type', $this->_contactType);
     $this->assign('contact_subtype', $this->_contactSubType);
     list($displayName, $contactImage) = CRM_Contact_BAO_Contact::getDisplayAndImage($this->_tableID);
-    CRM_Utils_System::setTitle($displayName, $contactImage . ' ' . $displayName);
+    $this->setTitle($displayName, $contactImage . ' ' . $displayName);
 
     // when custom data is included in this page
     if (!empty($_POST['hidden_custom'])) {

--- a/CRM/Contact/Form/Domain.php
+++ b/CRM/Contact/Form/Domain.php
@@ -71,7 +71,7 @@ class CRM_Contact_Form_Domain extends CRM_Core_Form {
   }
 
   public function preProcess() {
-    CRM_Utils_System::setTitle(ts('Organization Address and Contact Info'));
+    $this->setTitle(ts('Organization Address and Contact Info'));
     $breadCrumbPath = CRM_Utils_System::url('civicrm/admin', 'reset=1');
     CRM_Utils_System::appendBreadCrumb(ts('Administer CiviCRM'), $breadCrumbPath);
     $session = CRM_Core_Session::singleton();

--- a/CRM/Contact/Form/Merge.php
+++ b/CRM/Contact/Form/Merge.php
@@ -248,7 +248,7 @@ class CRM_Contact_Form_Merge extends CRM_Core_Form {
 
   public function buildQuickForm() {
     $this->unsavedChangesWarn = FALSE;
-    CRM_Utils_System::setTitle(ts('Merge %1 contacts', [1 => $this->_contactType]));
+    $this->setTitle(ts('Merge %1 contacts', [1 => $this->_contactType]));
     $buttons = [];
 
     $buttons[] = [

--- a/CRM/Contact/Form/RelatedContact.php
+++ b/CRM/Contact/Form/RelatedContact.php
@@ -74,7 +74,7 @@ class CRM_Contact_Form_RelatedContact extends CRM_Core_Form {
       }
 
       list($displayName, $contactImage) = CRM_Contact_BAO_Contact::getDisplayAndImage($this->_contactId);
-      CRM_Utils_System::setTitle($displayName, $contactImage . ' ' . $displayName);
+      $this->setTitle($displayName, $contactImage . ' ' . $displayName);
     }
     else {
       CRM_Core_Error::statusBounce(ts('Could not get a contact_id and/or contact_type'));

--- a/CRM/Contact/Form/Relationship.php
+++ b/CRM/Contact/Form/Relationship.php
@@ -139,19 +139,19 @@ class CRM_Contact_Form_Relationship extends CRM_Core_Form {
     // Set page title based on action
     switch ($this->_action) {
       case CRM_Core_Action::VIEW:
-        CRM_Utils_System::setTitle(ts('View Relationship for %1', [1 => $this->_display_name_a]));
+        $this->setTitle(ts('View Relationship for %1', [1 => $this->_display_name_a]));
         break;
 
       case CRM_Core_Action::ADD:
-        CRM_Utils_System::setTitle(ts('Add Relationship for %1', [1 => $this->_display_name_a]));
+        $this->setTitle(ts('Add Relationship for %1', [1 => $this->_display_name_a]));
         break;
 
       case CRM_Core_Action::UPDATE:
-        CRM_Utils_System::setTitle(ts('Edit Relationship for %1', [1 => $this->_display_name_a]));
+        $this->setTitle(ts('Edit Relationship for %1', [1 => $this->_display_name_a]));
         break;
 
       case CRM_Core_Action::DELETE:
-        CRM_Utils_System::setTitle(ts('Delete Relationship for %1', [1 => $this->_display_name_a]));
+        $this->setTitle(ts('Delete Relationship for %1', [1 => $this->_display_name_a]));
         break;
     }
 

--- a/CRM/Contact/Form/Search.php
+++ b/CRM/Contact/Form/Search.php
@@ -436,7 +436,7 @@ class CRM_Contact_Form_Search extends CRM_Core_Form_Search {
         }
 
         // Set dynamic page title for 'Show Members of Group'
-        CRM_Utils_System::setTitle(ts('Contacts in Group: %1', [1 => $this->_group[$this->_groupID]]));
+        $this->setTitle(ts('Contacts in Group: %1', [1 => $this->_group[$this->_groupID]]));
       }
 
       $group_contact_status = [];
@@ -464,7 +464,7 @@ class CRM_Contact_Form_Search extends CRM_Core_Form_Search {
       }
 
       // Set dynamic page title for 'Add Members Group'
-      CRM_Utils_System::setTitle(ts('Add to Group: %1', [1 => $this->_group[$this->_amtgID]]));
+      $this->setTitle(ts('Add to Group: %1', [1 => $this->_group[$this->_amtgID]]));
       // also set the group title and freeze the action task with Add Members to Group
       $groupValues = ['id' => $this->_amtgID, 'title' => $this->_group[$this->_amtgID]];
       $this->assign_by_ref('group', $groupValues);

--- a/CRM/Contact/Form/Task/AddToGroup.php
+++ b/CRM/Contact/Form/Task/AddToGroup.php
@@ -115,10 +115,10 @@ class CRM_Contact_Form_Task_AddToGroup extends CRM_Contact_Form_Task {
 
     // Set dynamic page title for 'Add Members Group (confirm)'
     if ($this->_id) {
-      CRM_Utils_System::setTitle(ts('Add Contacts: %1', [1 => $this->_title]));
+      $this->setTitle(ts('Add Contacts: %1', [1 => $this->_title]));
     }
     else {
-      CRM_Utils_System::setTitle(ts('Add Contacts to A Group'));
+      $this->setTitle(ts('Add Contacts to A Group'));
     }
 
     $this->addDefaultButtons(ts('Add to Group'));

--- a/CRM/Contact/Form/Task/AddToParentClass.php
+++ b/CRM/Contact/Form/Task/AddToParentClass.php
@@ -30,7 +30,7 @@ class CRM_Contact_Form_Task_AddToParentClass extends CRM_Contact_Form_Task {
 
   public function buildQuickForm() {
     $contactType = $this->get('contactType');
-    CRM_Utils_System::setTitle(ts('Add Contacts to %1', [1 => $contactType]));
+    $this->setTitle(ts('Add Contacts to %1', [1 => $contactType]));
     $this->addElement('text', 'name', ts('Find Target %1', [1 => $contactType]));
 
     $this->add('select',

--- a/CRM/Contact/Form/Task/Batch.php
+++ b/CRM/Contact/Form/Task/Batch.php
@@ -69,7 +69,7 @@ class CRM_Contact_Form_Task_Batch extends CRM_Contact_Form_Task {
       CRM_Core_Error::statusBounce(ts('ufGroupId is missing'));
     }
     $this->_title = ts('Update multiple contacts') . ' - ' . CRM_Core_BAO_UFGroup::getTitle($ufGroupId);
-    CRM_Utils_System::setTitle($this->_title);
+    $this->setTitle($this->_title);
 
     $this->addDefaultButtons(ts('Save'));
     $this->_fields = CRM_Core_BAO_UFGroup::getFields($ufGroupId, FALSE, CRM_Core_Action::VIEW);

--- a/CRM/Contact/Form/Task/Delete.php
+++ b/CRM/Contact/Form/Task/Delete.php
@@ -63,7 +63,7 @@ class CRM_Contact_Form_Task_Delete extends CRM_Contact_Form_Task {
     $this->assign('restore', $this->_restore);
 
     if ($this->_restore) {
-      CRM_Utils_System::setTitle(ts('Restore Contact'));
+      $this->setTitle(ts('Restore Contact'));
     }
 
     if ($cid) {

--- a/CRM/Contact/Form/Task/Email.php
+++ b/CRM/Contact/Form/Task/Email.php
@@ -58,10 +58,10 @@ class CRM_Contact_Form_Task_Email extends CRM_Contact_Form_Task {
         $displayName[] = CRM_Contact_BAO_Contact::displayName($val);
       }
 
-      CRM_Utils_System::setTitle(implode(',', $displayName) . ' - ' . ts('Email'));
+      $this->setTitle(implode(',', $displayName) . ' - ' . ts('Email'));
     }
     else {
-      CRM_Utils_System::setTitle(ts('New Email'));
+      $this->setTitle(ts('New Email'));
     }
     if ($this->_context === 'search') {
       $this->_single = TRUE;

--- a/CRM/Contact/Form/Task/Label.php
+++ b/CRM/Contact/Form/Task/Label.php
@@ -41,7 +41,7 @@ class CRM_Contact_Form_Task_Label extends CRM_Contact_Form_Task {
    * @param CRM_Core_Form $form
    */
   public static function buildLabelForm($form) {
-    CRM_Utils_System::setTitle(ts('Make Mailing Labels'));
+    $form->setTitle(ts('Make Mailing Labels'));
 
     //add select for label
     $label = CRM_Core_BAO_LabelFormat::getList(TRUE);

--- a/CRM/Contact/Form/Task/Map.php
+++ b/CRM/Contact/Form/Task/Map.php
@@ -125,7 +125,7 @@ class CRM_Contact_Form_Task_Map extends CRM_Contact_Form_Task {
   public static function createMapXML($ids, $locationId, &$page, $addBreadCrumb, $type = 'Contact') {
     $config = CRM_Core_Config::singleton();
 
-    CRM_Utils_System::setTitle(ts('Map Location(s)'));
+    $this->setTitle(ts('Map Location(s)'));
     $page->assign('query', 'CiviCRM Search Query');
     $page->assign('mapProvider', $config->mapProvider);
     $page->assign('mapKey', urlencode($config->mapAPIKey));

--- a/CRM/Contact/Form/Task/PDFLetterCommon.php
+++ b/CRM/Contact/Form/Task/PDFLetterCommon.php
@@ -68,7 +68,10 @@ class CRM_Contact_Form_Task_PDFLetterCommon extends CRM_Core_Form_Task_PDFLetter
     $form->_contactIds = explode(',', $cid);
     // put contact display name in title for single contact mode
     if (count($form->_contactIds) === 1) {
-      CRM_Utils_System::setTitle(ts('Print/Merge Document for %1', [1 => CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Contact', $cid, 'display_name')]));
+      $form->setTitle(
+        ts('Print/Merge Document for %1',
+        [1 => CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Contact', $cid, 'display_name')])
+      );
     }
   }
 

--- a/CRM/Contact/Form/Task/PickProfile.php
+++ b/CRM/Contact/Form/Task/PickProfile.php
@@ -80,7 +80,7 @@ class CRM_Contact_Form_Task_PickProfile extends CRM_Contact_Form_Task {
    * Build the form object.
    */
   public function buildQuickForm() {
-    CRM_Utils_System::setTitle(ts('Update multiple contacts'));
+    $this->setTitle(ts('Update multiple contacts'));
 
     foreach ($this->_contactIds as $id) {
       $this->_contactTypes = CRM_Contact_BAO_Contact::getContactTypes($id);

--- a/CRM/Contact/Form/Task/RemoveFromGroup.php
+++ b/CRM/Contact/Form/Task/RemoveFromGroup.php
@@ -30,7 +30,7 @@ class CRM_Contact_Form_Task_RemoveFromGroup extends CRM_Contact_Form_Task {
     $group = ['' => ts('- select group -')] + CRM_Core_PseudoConstant::nestedGroup();
     $groupElement = $this->add('select', 'group_id', ts('Select Group'), $group, TRUE, ['class' => 'crm-select2 huge']);
 
-    CRM_Utils_System::setTitle(ts('Remove Contacts from Group'));
+    $this->setTitle(ts('Remove Contacts from Group'));
     $this->addDefaultButtons(ts('Remove from Group'));
   }
 

--- a/CRM/Contact/Form/Task/Useradd.php
+++ b/CRM/Contact/Form/Task/Useradd.php
@@ -43,7 +43,7 @@ class CRM_Contact_Form_Task_Useradd extends CRM_Core_Form {
     $contact = CRM_Contact_BAO_Contact::retrieve($params, $defaults, $ids);
     $this->_displayName = $contact->display_name;
     $this->_email = $contact->email;
-    CRM_Utils_System::setTitle(ts('Create User Record for %1', [1 => $this->_displayName]));
+    $this->setTitle(ts('Create User Record for %1', [1 => $this->_displayName]));
   }
 
   /**

--- a/CRM/Contribute/Form/AdditionalPayment.php
+++ b/CRM/Contribute/Form/AdditionalPayment.php
@@ -76,7 +76,7 @@ class CRM_Contribute_Form_AdditionalPayment extends CRM_Contribute_Form_Abstract
 
     if ($this->_view == 'transaction' && ($this->_action & CRM_Core_Action::BROWSE)) {
       $title = $this->assignPaymentInfoBlock();
-      CRM_Utils_System::setTitle($title);
+      $this->setTitle($title);
       return;
     }
     if ($this->_component == 'event') {

--- a/CRM/Contribute/Form/CancelSubscription.php
+++ b/CRM/Contribute/Form/CancelSubscription.php
@@ -97,7 +97,7 @@ class CRM_Contribute_Form_CancelSubscription extends CRM_Contribute_Form_Contrib
     // handle context redirection
     CRM_Contribute_BAO_ContributionRecur::setSubscriptionContext();
 
-    CRM_Utils_System::setTitle($this->_mid ? ts('Cancel Auto-renewal') : ts('Cancel Recurring Contribution'));
+    $this->setTitle($this->_mid ? ts('Cancel Auto-renewal') : ts('Cancel Recurring Contribution'));
     $this->assign('mode', $this->_mode);
 
     if ($this->isSelfService()) {

--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -301,7 +301,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
     if ($this->_mode && $this->_id) {
       $this->_payNow = TRUE;
       $this->assign('payNow', $this->_payNow);
-      CRM_Utils_System::setTitle(ts('Pay with Credit Card'));
+      $this->setTitle(ts('Pay with Credit Card'));
     }
     elseif (!empty($this->_values['is_template'])) {
       $this->setPageTitle(ts('Template Contribution'));

--- a/CRM/Contribute/Form/Contribution/ThankYou.php
+++ b/CRM/Contribute/Form/Contribution/ThankYou.php
@@ -48,7 +48,7 @@ class CRM_Contribute_Form_Contribution_ThankYou extends CRM_Contribute_Form_Cont
     $this->assign('thankyou_footer', CRM_Utils_Array::value('thankyou_footer', $this->_values));
     $this->assign('max_reminders', CRM_Utils_Array::value('max_reminders', $this->_values));
     $this->assign('initial_reminder_day', CRM_Utils_Array::value('initial_reminder_day', $this->_values));
-    CRM_Utils_System::setTitle(CRM_Utils_Array::value('thankyou_title', $this->_values));
+    $this->setTitle(CRM_Utils_Array::value('thankyou_title', $this->_values));
     // Make the contributionPageID available to the template
     $this->assign('contributionPageID', $this->_id);
     $this->assign('isShare', $this->_values['is_share']);

--- a/CRM/Contribute/Form/ContributionPage/Settings.php
+++ b/CRM/Contribute/Form/ContributionPage/Settings.php
@@ -41,7 +41,7 @@ class CRM_Contribute_Form_ContributionPage_Settings extends CRM_Contribute_Form_
         $this->_id,
         'title'
       );
-      CRM_Utils_System::setTitle(ts('Title and Settings') . " ($title)");
+      $this->setTitle(ts('Title and Settings') . " ($title)");
 
       foreach (['on_behalf', 'soft_credit'] as $module) {
         $ufJoinDAO = new CRM_Core_DAO_UFJoin();

--- a/CRM/Contribute/Form/ContributionView.php
+++ b/CRM/Contribute/Form/ContributionView.php
@@ -172,10 +172,10 @@ class CRM_Contribute_Form_ContributionView extends CRM_Core_Form {
     }
 
     if (empty($values['is_template'])) {
-      CRM_Utils_System::setTitle(ts('View Contribution from') . ' ' . $displayName);
+      $this->setTitle(ts('View Contribution from') . ' ' . $displayName);
     }
     else {
-      CRM_Utils_System::setTitle(ts('View Template Contribution from') . ' ' . $displayName);
+      $this->setTitle(ts('View Template Contribution from') . ' ' . $displayName);
     }
 
     // add viewed contribution to recent items list

--- a/CRM/Contribute/Form/Task/Batch.php
+++ b/CRM/Contribute/Form/Task/Batch.php
@@ -72,7 +72,7 @@ class CRM_Contribute_Form_Task_Batch extends CRM_Contribute_Form_Task {
       throw new CRM_Core_Exception('ufGroupId is missing');
     }
     $this->_title = ts('Update multiple contributions') . ' - ' . CRM_Core_BAO_UFGroup::getTitle($ufGroupId);
-    CRM_Utils_System::setTitle($this->_title);
+    $this->setTitle($this->_title);
 
     $this->addDefaultButtons(ts('Save'));
     $this->_fields = [];

--- a/CRM/Contribute/Form/Task/Invoice.php
+++ b/CRM/Contribute/Form/Task/Invoice.php
@@ -123,10 +123,10 @@ class CRM_Contribute_Form_Task_Invoice extends CRM_Contribute_Form_Task {
 
     CRM_Contact_Form_Task_EmailCommon::preProcessFromAddress($this);
     if ($this->_selectedOutput == 'email') {
-      CRM_Utils_System::setTitle(ts('Email Invoice'));
+      $this->setTitle(ts('Email Invoice'));
     }
     else {
-      CRM_Utils_System::setTitle(ts('Print Contribution Invoice'));
+      $this->setTitle(ts('Print Contribution Invoice'));
     }
   }
 

--- a/CRM/Contribute/Form/Task/PDF.php
+++ b/CRM/Contribute/Form/Task/PDF.php
@@ -65,7 +65,7 @@ AND    {$this->_componentClause}";
     // we have all the contribution ids, so now we get the contact ids
     parent::setContactIDs();
     CRM_Utils_System::appendBreadCrumb($breadCrumb);
-    CRM_Utils_System::setTitle(ts('Print Contribution Receipts'));
+    $this->setTitle(ts('Print Contribution Receipts'));
     // Ajax submit would interfere with pdf file download
     $this->preventAjaxSubmit();
   }

--- a/CRM/Contribute/Form/Task/PickProfile.php
+++ b/CRM/Contribute/Form/Task/PickProfile.php
@@ -48,7 +48,7 @@ class CRM_Contribute_Form_Task_PickProfile extends CRM_Contribute_Form_Task {
     $session = CRM_Core_Session::singleton();
     $this->_userContext = $session->readUserContext();
 
-    CRM_Utils_System::setTitle(ts('Update multiple contributions'));
+    $this->setTitle(ts('Update multiple contributions'));
 
     $validate = FALSE;
     //validations

--- a/CRM/Contribute/Form/UpdateSubscription.php
+++ b/CRM/Contribute/Form/UpdateSubscription.php
@@ -115,7 +115,7 @@ class CRM_Contribute_Form_UpdateSubscription extends CRM_Contribute_Form_Contrib
       [$this->_donorDisplayName, $this->_donorEmail] = CRM_Contact_BAO_Contact::getContactDetails($this->_subscriptionDetails->contact_id);
     }
 
-    CRM_Utils_System::setTitle(ts('Update Recurring Contribution'));
+    $this->setTitle(ts('Update Recurring Contribution'));
 
     // Handle context redirection.
     CRM_Contribute_BAO_ContributionRecur::setSubscriptionContext();


### PR DESCRIPTION
Overview
----------------------------------------
Follows on from some work that @eileenmcnaughton started in 2019. Forms should use `$this->setTitle()` instead of `CRM_Utils_System::setTitle()` because it allows you to use `$this->getTitle()` on a form to get the title of the form that the user will see.

Before
----------------------------------------
Calls to `CRM_Utils_System::setTitle()`

After
----------------------------------------
Calls to `$this->setTitle()`

Technical Details
----------------------------------------
As can be observed `CRM_Core_Form::setTitle()` calls `CRM_Utils_System::setTitle()` internally after setting `$this->_title` showing that this function is a drop-in replacement. There are just over 200 instances that need converting and (for ease of review) this is the next 34.
I would suggest that `r-run` testing could be done with a few forms only instead of all of them - what needs to be verified is that it is a form that inherits from CRM_Core_Form (and not eg. a Page).

Comments
----------------------------------------
There are 4 commits in total that would complete this change and I'll follow up with the others - see https://github.com/civicrm/civicrm-core/compare/master...mattwire:settitle?expand=1
