### PR TITLE
[REF] CRM_Utils_Recent - Use hook listener to delete items

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -217,15 +217,6 @@ class CRM_Activity_BAO_Activity extends CRM_Activity_DAO_Activity {
       self::logActivityAction($activity, $logMsg);
     }
 
-    // delete the recently created Activity
-    if ($result) {
-      $activityRecent = [
-        'id' => $activity->id,
-        'type' => 'Activity',
-      ];
-      CRM_Utils_Recent::del($activityRecent);
-    }
-
     $transaction->commit();
     if (isset($activity)) {
       // CRM-8708

--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -217,12 +217,6 @@ WHERE civicrm_case.id = %1";
 
       CRM_Utils_Hook::post('delete', 'Case', $caseId, $case);
 
-      // remove case from recent items.
-      $caseRecent = [
-        'id' => $caseId,
-        'type' => 'Case',
-      ];
-      CRM_Utils_Recent::del($caseRecent);
       return TRUE;
     }
 

--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -1063,7 +1063,7 @@ WHERE     civicrm_contact.id = " . CRM_Utils_Type::escape($id, 'Integer');
     }
 
     //delete the contact id from recently view
-    CRM_Utils_Recent::delContact($id);
+    CRM_Utils_Recent::del(['contact_id' => $id]);
     self::updateContactCache($id, empty($restore));
 
     // delete any prevnext/dupe cache entry

--- a/CRM/Contact/BAO/Group.php
+++ b/CRM/Contact/BAO/Group.php
@@ -116,13 +116,6 @@ class CRM_Contact_BAO_Group extends CRM_Contact_DAO_Group {
     $transaction->commit();
 
     CRM_Utils_Hook::post('delete', 'Group', $id, $group);
-
-    // delete the recently created Group
-    $groupRecent = [
-      'id' => $id,
-      'type' => 'Group',
-    ];
-    CRM_Utils_Recent::del($groupRecent);
   }
 
   /**

--- a/CRM/Contact/BAO/Relationship.php
+++ b/CRM/Contact/BAO/Relationship.php
@@ -744,13 +744,6 @@ class CRM_Contact_BAO_Relationship extends CRM_Contact_DAO_Relationship {
 
     CRM_Utils_Hook::post('delete', 'Relationship', $id, $relationship);
 
-    // delete the recently created Relationship
-    $relationshipRecent = [
-      'id' => $id,
-      'type' => 'Relationship',
-    ];
-    CRM_Utils_Recent::del($relationshipRecent);
-
     return $relationship;
   }
 

--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -1530,13 +1530,6 @@ INNER JOIN  civicrm_contact contact ON ( contact.id = c.contact_id )
 
     CRM_Utils_Hook::post('delete', 'Contribution', $dao->id, $dao);
 
-    // delete the recently created Contribution
-    $contributionRecent = [
-      'id' => $id,
-      'type' => 'Contribution',
-    ];
-    CRM_Utils_Recent::del($contributionRecent);
-
     return $results;
   }
 

--- a/CRM/Event/BAO/Participant.php
+++ b/CRM/Event/BAO/Participant.php
@@ -876,14 +876,6 @@ WHERE  civicrm_participant.id = {$participantId}
 
     CRM_Utils_Hook::post('delete', 'Participant', $participant->id, $participant);
 
-    // delete the recently created Participant
-    $participantRecent = [
-      'id' => $id,
-      'type' => 'Participant',
-    ];
-
-    CRM_Utils_Recent::del($participantRecent);
-
     return $participant;
   }
 

--- a/CRM/Grant/BAO/Grant.php
+++ b/CRM/Grant/BAO/Grant.php
@@ -259,13 +259,6 @@ class CRM_Grant_BAO_Grant extends CRM_Grant_DAO_Grant {
 
     $grant->find();
 
-    // delete the recently created Grant
-    $grantRecent = [
-      'id' => $id,
-      'type' => 'Grant',
-    ];
-    CRM_Utils_Recent::del($grantRecent);
-
     if ($grant->fetch()) {
       $results = $grant->delete();
       CRM_Utils_Hook::post('delete', 'Grant', $grant->id, $grant);

--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -673,13 +673,6 @@ INNER JOIN  civicrm_membership_type type ON ( type.id = membership.membership_ty
 
     CRM_Utils_Hook::post('delete', 'Membership', $membership->id, $membership);
 
-    // delete the recently created Membership
-    $membershipRecent = [
-      'id' => $membershipId,
-      'type' => 'Membership',
-    ];
-    CRM_Utils_Recent::del($membershipRecent);
-
     return $results;
   }
 

--- a/CRM/Pledge/BAO/Pledge.php
+++ b/CRM/Pledge/BAO/Pledge.php
@@ -314,13 +314,6 @@ class CRM_Pledge_BAO_Pledge extends CRM_Pledge_DAO_Pledge {
 
     CRM_Utils_Hook::post('delete', 'Pledge', $dao->id, $dao);
 
-    // delete the recently created Pledge
-    $pledgeRecent = [
-      'id' => $id,
-      'type' => 'Pledge',
-    ];
-    CRM_Utils_Recent::del($pledgeRecent);
-
     return $results;
   }
 

--- a/CRM/Utils/Recent.php
+++ b/CRM/Utils/Recent.php
@@ -90,22 +90,13 @@ class CRM_Utils_Recent {
     $contactName,
     $others = []
   ) {
-    self::initialize();
-
+    // Abort if this entity type is not supported
     if (!self::isProviderEnabled($type)) {
       return;
     }
 
-    $session = CRM_Core_Session::singleton();
-
-    // make sure item is not already present in list
-    for ($i = 0; $i < count(self::$_recent); $i++) {
-      if (self::$_recent[$i]['type'] === $type && self::$_recent[$i]['id'] == $id) {
-        // delete item from array
-        array_splice(self::$_recent, $i, 1);
-        break;
-      }
-    }
+    // Ensure item is not already present in list
+    self::removeItems(['id' => $id, 'type' => $type]);
 
     if (!is_array($others)) {
       $others = [];
@@ -127,12 +118,14 @@ class CRM_Utils_Recent {
       ]
     );
 
-    if (count(self::$_recent) > self::$_maxItems) {
+    // Keep the list trimmed to max length
+    while (count(self::$_recent) > self::$_maxItems) {
       array_pop(self::$_recent);
     }
 
     CRM_Utils_Hook::recent(self::$_recent);
 
+    $session = CRM_Core_Session::singleton();
     $session->set(self::STORE_NAME, self::$_recent);
   }
 
@@ -151,27 +144,30 @@ class CRM_Utils_Recent {
   }
 
   /**
-   * Delete an item from the recent stack.
-   *
-   * @param array $recentItem
-   *   Array of the recent Item to be removed.
+   * Remove items from the array that match given props
+   * @param array $props
    */
-  public static function del($recentItem) {
+  private static function removeItems(array $props) {
     self::initialize();
-    $tempRecent = self::$_recent;
 
-    self::$_recent = [];
-
-    // make sure item is not already present in list
-    for ($i = 0; $i < count($tempRecent); $i++) {
-      if (!($tempRecent[$i]['id'] == $recentItem['id'] &&
-        $tempRecent[$i]['type'] == $recentItem['type']
-      )
-      ) {
-        self::$_recent[] = $tempRecent[$i];
+    self::$_recent = array_filter(self::$_recent, function($item) use ($props) {
+      foreach ($props as $key => $val) {
+        if (isset($item[$key]) && $item[$key] == $val) {
+          return FALSE;
+        }
       }
-    }
+      return TRUE;
+    });
+  }
 
+  /**
+   * Delete item(s) from the recently-viewed list.
+   *
+   * @param array $removeItem
+   *   Item to be removed.
+   */
+  public static function del($removeItem) {
+    self::removeItems($removeItem);
     CRM_Utils_Hook::recent(self::$_recent);
     $session = CRM_Core_Session::singleton();
     $session->set(self::STORE_NAME, self::$_recent);
@@ -181,27 +177,11 @@ class CRM_Utils_Recent {
    * Delete an item from the recent stack.
    *
    * @param string $id
-   *   Contact id that had to be removed.
+   * @deprecated
    */
   public static function delContact($id) {
-    self::initialize();
-
-    $tempRecent = self::$_recent;
-
-    self::$_recent = [];
-
-    // rebuild recent.
-    for ($i = 0; $i < count($tempRecent); $i++) {
-      // don't include deleted contact in recent.
-      if (CRM_Utils_Array::value('contact_id', $tempRecent[$i]) == $id) {
-        continue;
-      }
-      self::$_recent[] = $tempRecent[$i];
-    }
-
-    CRM_Utils_Hook::recent(self::$_recent);
-    $session = CRM_Core_Session::singleton();
-    $session->set(self::STORE_NAME, self::$_recent);
+    CRM_Core_Error::deprecatedFunctionWarning('del');
+    self::del(['contact_id' => $id]);
   }
 
   /**

--- a/CRM/Utils/Recent.php
+++ b/CRM/Utils/Recent.php
@@ -137,6 +137,20 @@ class CRM_Utils_Recent {
   }
 
   /**
+   * Callback for hook_civicrm_post().
+   * @param \Civi\Core\Event\PostEvent $event
+   */
+  public static function on_hook_civicrm_post(\Civi\Core\Event\PostEvent $event) {
+    if ($event->action === 'delete' && $event->id && CRM_Core_Session::getLoggedInContactID()) {
+      // Is this an entity that might be in the recent items list?
+      $providersPermitted = Civi::settings()->get('recentItemsProviders') ?: array_keys(self::getProviders());
+      if (in_array($event->entity, $providersPermitted)) {
+        self::del(['id' => $event->id, 'type' => $event->entity]);
+      }
+    }
+  }
+
+  /**
    * Delete an item from the recent stack.
    *
    * @param array $recentItem

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -406,6 +406,8 @@ class Container {
     $dispatcher->addListener('hook_civicrm_coreResourceList', ['\CRM_Utils_System', 'appendCoreResources']);
     $dispatcher->addListener('hook_civicrm_getAssetUrl', ['\CRM_Utils_System', 'alterAssetUrl']);
     $dispatcher->addListener('hook_civicrm_alterExternUrl', ['\CRM_Utils_System', 'migrateExternUrl'], 1000);
+    // Not a BAO class so it can't implement hookInterface
+    $dispatcher->addListener('hook_civicrm_post', ['CRM_Utils_Recent', 'on_hook_civicrm_post']);
     $dispatcher->addListener('hook_civicrm_permissionList', ['CRM_Core_Permission_List', 'findConstPermissions'], 975);
     $dispatcher->addListener('hook_civicrm_permissionList', ['CRM_Core_Permission_List', 'findCiviPermissions'], 950);
     $dispatcher->addListener('hook_civicrm_permissionList', ['CRM_Core_Permission_List', 'findCmsPermissions'], 925);

--- a/tests/phpunit/api/v4/Action/RecentItemsTest.php
+++ b/tests/phpunit/api/v4/Action/RecentItemsTest.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+
+namespace api\v4\Action;
+
+use api\v4\UnitTestCase;
+use Civi\Api4\Activity;
+
+/**
+ * @group headless
+ */
+class RecentItemsTest extends UnitTestCase {
+
+  /**
+   * This locks in a fix to ensure that if a user doesn't have permission to view the is_deleted field that doesn't hard fail if that field happens to be in an APIv4 call.
+   */
+  public function testIsDeletedPermission(): void {
+    $cid = $this->createLoggedInUser();
+
+    $aid = Activity::create(FALSE)
+      ->addValue('activity_type_id:name', 'Meeting')
+      ->addValue('source_contact_id', $cid)
+      ->addValue('subject', 'Hello recent!')
+      ->execute()->first()['id'];
+
+    $this->assertEquals(1, $this->getRecentItemCount(['type' => 'Activity', 'id' => $aid]));
+
+    Activity::delete(FALSE)->addWhere('id', '=', $aid)->execute();
+
+    $this->assertEquals(0, $this->getRecentItemCount(['type' => 'Activity', 'id' => $aid]));
+  }
+
+  private function getRecentItemCount($props) {
+    $count = 0;
+    foreach (\CRM_Utils_Recent::get() as $item) {
+      foreach ($props as $key => $val) {
+        if (($item[$key] ?? NULL) != $val) {
+          continue 2;
+        }
+      }
+      ++$count;
+    }
+    return $count;
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Simplifies a bunch of delete functions by de-coupling BAOs from the Recent Items menu/sidebar.

Before
----------------------------------------
BAO functions responsible for deleting their own items from the Recent menu/sidebar.

After
----------------------------------------
Recent items delete themselves.

Technical Details
----------------------------------------
This is toward [dev/core#2757](https://lab.civicrm.org/dev/core/-/issues/2757)

Comments
----------------------------------------
All that's missing is `Note` which has a weird `del()` function. That's addressed in #21208
