### PR TITLE
[NFC] CRM_Extension_Manager_ModuleTest - use ?? instead of error-suppression operator

### DIFF
--- a/tests/phpunit/CRM/Extension/Manager/ModuleTest.php
+++ b/tests/phpunit/CRM/Extension/Manager/ModuleTest.php
@@ -225,8 +225,8 @@ class CRM_Extension_Manager_ModuleTest extends CiviUnitTestCase {
   public function assertHookCounts($module, $counts) {
     global $_test_extension_manager_moduletest_counts;
     foreach ($counts as $key => $expected) {
-      $actual = @$_test_extension_manager_moduletest_counts[$module][$key];
-      $this->assertEquals($expected, $actual,
+      $actual = $_test_extension_manager_moduletest_counts[$module][$key] ?? 0;
+      $this->assertSame($expected, $actual,
         sprintf('Expected %d call(s) to hook_civicrm_%s -- found %d', $expected, $key, $actual)
       );
     }


### PR DESCRIPTION
Overview
----------------------------------------
Can potentially cause problems in php 8 with certain error handlers.
Note also that assertEquals() treats `0` and `null` as equal, so have tightened it up by using assertSame.
Addresses test fails in https://github.com/civicrm/civicrm-core/pull/21064:

```
not ok 1926 - Error: CRM_Extension_Manager_ModuleTest::testInstallDisableUninstall
not ok 1927 - Failure: CRM_Extension_Manager_ModuleTest::testInstallDisableEnable
  ---
  message: Failed asserting that true matches expected false.
  severity: fail
  data:
    got: true
    expected: false
  ...
  not ok 1928 - Error: CRM_Extension_Manager_ModuleTest::testInstall_DirtyRemove_Disable_Uninstall
not ok 1929 - Error: CRM_Extension_Manager_ModuleTest::testInstall_DirtyRemove_Disable_Restore
```