### PR TITLE
[REF] APIv4 Notes - Ensure child notes are deleted with parent, and hooks are called

### DIFF
--- a/CRM/Contact/Page/View/Note.php
+++ b/CRM/Contact/Page/View/Note.php
@@ -158,7 +158,7 @@ class CRM_Contact_Page_View_Note extends CRM_Core_Page {
     $session->pushUserContext($url);
 
     if (CRM_Utils_Request::retrieve('confirmed', 'Boolean')) {
-      CRM_Core_BAO_Note::del($this->_id);
+      $this->delete();
       CRM_Utils_System::redirect($url);
     }
 
@@ -233,10 +233,12 @@ class CRM_Contact_Page_View_Note extends CRM_Core_Page {
   }
 
   /**
-   * Delete the note object from the db.
+   * Delete the note object from the db and set a status msg.
    */
   public function delete() {
-    CRM_Core_BAO_Note::del($this->_id);
+    CRM_Core_BAO_Note::deleteRecord(['id' => $this->_id]);
+    $status = ts('Selected Note has been deleted successfully.');
+    CRM_Core_Session::setStatus($status, ts('Deleted'), 'success');
   }
 
   /**

--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -1518,7 +1518,7 @@ INNER JOIN  civicrm_contact contact ON ( contact.id = c.contact_id )
     $note = CRM_Core_BAO_Note::getNote($id, 'civicrm_contribution');
     $noteId = key($note);
     if ($noteId) {
-      CRM_Core_BAO_Note::del($noteId, FALSE);
+      CRM_Core_BAO_Note::deleteRecord(['id' => $noteId]);
     }
 
     $dao = new CRM_Contribute_DAO_Contribution();

--- a/CRM/Contribute/Form/AdditionalInfo.php
+++ b/CRM/Contribute/Form/AdditionalInfo.php
@@ -231,7 +231,9 @@ class CRM_Contribute_Form_AdditionalInfo {
    */
   public static function processNote($params, $contactID, $contributionID, $contributionNoteID = NULL) {
     if (CRM_Utils_System::isNull($params['note']) && $contributionNoteID) {
-      CRM_Core_BAO_Note::del($contributionNoteID);
+      CRM_Core_BAO_Note::deleteRecord(['id' => $contributionNoteID]);
+      $status = ts('Selected Note has been deleted successfully.');
+      CRM_Core_Session::setStatus($status, ts('Deleted'), 'success');
       return;
     }
     //process note

--- a/CRM/Event/BAO/Participant.php
+++ b/CRM/Event/BAO/Participant.php
@@ -242,7 +242,7 @@ class CRM_Event_BAO_Participant extends CRM_Event_DAO_Participant {
         CRM_Core_BAO_Note::add($noteParams, $noteIDs);
       }
       elseif ($noteId && $hasNoteField) {
-        CRM_Core_BAO_Note::del($noteId, FALSE);
+        CRM_Core_BAO_Note::deleteRecord(['id' => $noteId]);
       }
     }
 
@@ -867,7 +867,7 @@ WHERE  civicrm_participant.id = {$participantId}
     $note = CRM_Core_BAO_Note::getNote($id, 'civicrm_participant');
     $noteId = key($note);
     if ($noteId) {
-      CRM_Core_BAO_Note::del($noteId, FALSE);
+      CRM_Core_BAO_Note::deleteRecord(['id' => $noteId]);
     }
 
     $participant->delete();

--- a/CRM/Note/Form/Note.php
+++ b/CRM/Note/Form/Note.php
@@ -173,7 +173,9 @@ class CRM_Note_Form_Note extends CRM_Core_Form {
     }
 
     if ($this->_action & CRM_Core_Action::DELETE) {
-      CRM_Core_BAO_Note::del($this->_id);
+      CRM_Core_BAO_Note::deleteRecord(['id' => $this->_id]);
+      $status = ts('Selected Note has been deleted successfully.');
+      CRM_Core_Session::setStatus($status, ts('Deleted'), 'success');
       return;
     }
 

--- a/api/v3/Note.php
+++ b/api/v3/Note.php
@@ -57,8 +57,8 @@ function _civicrm_api3_note_create_spec(&$params) {
  * @return array
  */
 function civicrm_api3_note_delete($params) {
-  $result = new CRM_Core_BAO_Note();
-  return $result->del($params['id']) ? civicrm_api3_create_success() : civicrm_api3_create_error('Error while deleting Note');
+  $result = CRM_Core_BAO_Note::deleteRecord($params);
+  return $result ? civicrm_api3_create_success() : civicrm_api3_create_error('Error while deleting Note');
 }
 
 /**

--- a/tests/phpunit/api/v4/Entity/NoteTest.php
+++ b/tests/phpunit/api/v4/Entity/NoteTest.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+namespace api\v4\Entity;
+
+use api\v4\UnitTestCase;
+use Civi\Api4\Note;
+use Civi\Test\TransactionalInterface;
+
+/**
+ * @group headless
+ */
+class NoteTest extends UnitTestCase implements TransactionalInterface {
+
+  public function testDeleteWithChildren() {
+    $c1 = $this->createEntity(['type' => 'Individual']);
+
+    $text = uniqid(__FUNCTION__, TRUE);
+
+    // Create 2 top-level notes.
+    $notes = Note::save(FALSE)
+      ->setRecords([['note' => $text], ['note' => $text]])
+      ->setDefaults([
+        'entity_id' => $c1['id'],
+        'entity_table' => 'civicrm_contact',
+      ])->execute();
+
+    // Add 2 children of the first note.
+    $children = Note::save(FALSE)
+      ->setRecords([['note' => $text], ['note' => $text]])
+      ->setDefaults([
+        'entity_id' => $notes->first()['id'],
+        'entity_table' => 'civicrm_note',
+      ])->execute();
+
+    // Add 2 children of the first child.
+    $grandChildren = Note::save(FALSE)
+      ->setRecords([['note' => $text], ['note' => $text]])
+      ->setDefaults([
+        'entity_id' => $children->first()['id'],
+        'entity_table' => 'civicrm_note',
+      ])->execute();
+
+    // We just created 2 top-level notes and 4 children. Ensure we have a total of 6.
+    $existing = Note::get(FALSE)
+      ->addWhere('note', '=', $text)
+      ->execute();
+    $this->assertCount(6, $existing);
+
+    // Delete parent
+    Note::delete(FALSE)
+      ->addWhere('id', '=', $notes->first()['id'])
+      ->execute();
+
+    // Should have deleted 1 parent + 4 child-notes, for a new total of 1 remaining.
+    $existing = Note::get(FALSE)
+      ->addWhere('note', '=', $text)
+      ->execute();
+    $this->assertCount(1, $existing);
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Note BAO refactoring related to work on dev/core#2757
Companion to #21204

Before
----------------------------------------
- When deleting a parent group via APIv4, child groups would not be deleted.
- Hooks never called when deleting a note (by any means)

After
----------------------------------------
- When deleting a parent group via APIv4, child groups are deleted.
- Hooks always called when deleting a note (even outside the api)
