### PR TITLE
Remove unused, duplicate functions getEntitiesByTag

### DIFF
--- a/CRM/Campaign/BAO/Petition.php
+++ b/CRM/Campaign/BAO/Petition.php
@@ -449,27 +449,6 @@ AND         tag_id = ( SELECT id FROM civicrm_tag WHERE name = %2 )";
   }
 
   /**
-   * This function returns all entities assigned to a specific tag.
-   *
-   * @param object $tag
-   *   An object of a tag.
-   *
-   * @return array
-   *   array of contact ids
-   */
-  public function getEntitiesByTag($tag) {
-    $contactIds = [];
-    $entityTagDAO = new CRM_Core_DAO_EntityTag();
-    $entityTagDAO->tag_id = $tag['id'];
-    $entityTagDAO->find();
-
-    while ($entityTagDAO->fetch()) {
-      $contactIds[] = $entityTagDAO->entity_id;
-    }
-    return $contactIds;
-  }
-
-  /**
    * Check if contact has signed this petition.
    *
    * @param int $surveyId

--- a/CRM/Core/BAO/EntityTag.php
+++ b/CRM/Core/BAO/EntityTag.php
@@ -291,26 +291,6 @@ class CRM_Core_BAO_EntityTag extends CRM_Core_DAO_EntityTag {
   }
 
   /**
-   * This function returns all entities assigned to a specific tag.
-   *
-   * @param object $tag
-   *   An object of a tag.
-   *
-   * @return array
-   *   array of entity ids
-   */
-  public function getEntitiesByTag($tag) {
-    $entityIds = [];
-    $entityTagDAO = new CRM_Core_DAO_EntityTag();
-    $entityTagDAO->tag_id = $tag->id;
-    $entityTagDAO->find();
-    while ($entityTagDAO->fetch()) {
-      $entityIds[] = $entityTagDAO->entity_id;
-    }
-    return $entityIds;
-  }
-
-  /**
    * Get contact tags.
    *
    * @param int $contactID


### PR DESCRIPTION
Overview
----------------------------------------
Removes an unused function as well as its evil twin.

Technical Details
----------------------------------------
According to https://issues.civicrm.org/jira/browse/CRM-13156, `CRM_Core_BAO_EntityTag::getEntitiesByTag()` was only ever used in the v2 API, which no longer exists.
The real mystery is why someone thought it was a good idea to copy/paste the function into CiviPetition. Seems pretty random.