### PR TITLE
[REF] Deprecate 2 del() functions in favor of generics and hooks (dev/core#2757)

### DIFF
--- a/CRM/Campaign/BAO/Survey.php
+++ b/CRM/Campaign/BAO/Survey.php
@@ -18,7 +18,7 @@
 /**
  * Class CRM_Campaign_BAO_Survey.
  */
-class CRM_Campaign_BAO_Survey extends CRM_Campaign_DAO_Survey {
+class CRM_Campaign_BAO_Survey extends CRM_Campaign_DAO_Survey implements Civi\Test\HookInterface {
 
   /**
    * Retrieve DB object based on input parameters.
@@ -366,24 +366,31 @@ SELECT  survey.id    as id,
   }
 
   /**
-   * Delete the survey.
+   * Delete a survey.
    *
    * @param int $id
-   *   Survey id.
-   *
+   * @deprecated
    * @return mixed|null
    */
   public static function del($id) {
     if (!$id) {
       return NULL;
     }
-    $reportId = CRM_Campaign_BAO_Survey::getReportID($id);
-    if ($reportId) {
-      CRM_Report_BAO_ReportInstance::del($reportId);
+    self::deleteRecord(['id' => $id]);
+    return 1;
+  }
+
+  /**
+   * Event fired prior to modifying a Survey.
+   * @param \Civi\Core\Event\PreEvent $event
+   */
+  public static function self_hook_civicrm_pre(\Civi\Core\Event\PreEvent $event) {
+    if ($event->action === 'delete' && $event->id) {
+      $reportId = self::getReportID($event->id);
+      if ($reportId) {
+        CRM_Report_BAO_ReportInstance::deleteRecord(['id' => $reportId]);
+      }
     }
-    $dao = new CRM_Campaign_DAO_Survey();
-    $dao->id = $id;
-    return $dao->delete();
   }
 
   /**

--- a/CRM/Report/BAO/ReportInstance.php
+++ b/CRM/Report/BAO/ReportInstance.php
@@ -14,7 +14,7 @@
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
-class CRM_Report_BAO_ReportInstance extends CRM_Report_DAO_ReportInstance {
+class CRM_Report_BAO_ReportInstance extends CRM_Report_DAO_ReportInstance implements Civi\Test\HookInterface {
 
   /**
    * Takes an associative array and creates an instance object.
@@ -219,22 +219,27 @@ class CRM_Report_BAO_ReportInstance extends CRM_Report_DAO_ReportInstance {
    * Delete the instance of the Report.
    *
    * @param int $id
-   *
+   * @deprecated
    * @return mixed
-   *   $results no of deleted Instance on success, false otherwise
    */
   public static function del($id = NULL) {
-    $navId = CRM_Core_DAO::getFieldValue('CRM_Report_DAO_ReportInstance', $id, 'navigation_id', 'id');
-    $dao = new CRM_Report_DAO_ReportInstance();
-    $dao->id = $id;
-    $result = $dao->delete();
+    self::deleteRecord(['id' => $id]);
+    return 1;
+  }
 
-    // Delete navigation if exists.
-    if ($navId) {
-      CRM_Core_BAO_Navigation::processDelete($navId);
-      CRM_Core_BAO_Navigation::resetNavigation();
+  /**
+   * Event fired prior to modifying a ReportInstance.
+   * @param \Civi\Core\Event\PreEvent $event
+   */
+  public static function self_hook_civicrm_pre(\Civi\Core\Event\PreEvent $event) {
+    if ($event->action === 'delete' && $event->id) {
+      // When deleting a report, also delete from navigation menu
+      $navId = CRM_Core_DAO::getFieldValue('CRM_Report_DAO_ReportInstance', $event->id, 'navigation_id');
+      if ($navId) {
+        CRM_Core_BAO_Navigation::processDelete($navId);
+        CRM_Core_BAO_Navigation::resetNavigation();
+      }
     }
-    return $result;
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Part of ongoing work to internally use hook callbacks instead of putting the logic inside `BAO::del()` functions.

