### PR TITLE
[REF] Move Email, Address, etc. is_primary handling on delete to a hook (dev/core#2757) 

### DIFF
--- a/CRM/Core/BAO/Address.php
+++ b/CRM/Core/BAO/Address.php
@@ -1210,12 +1210,14 @@ SELECT is_primary,
   /**
    * Call common delete function.
    *
-   * @param int $id
+   * @see \CRM_Contact_BAO_Contact::on_hook_civicrm_post
    *
+   * @param int $id
+   * @deprecated
    * @return bool
    */
   public static function del($id) {
-    return CRM_Contact_BAO_Contact::deleteObjectWithPrimary('Address', $id);
+    return (bool) self::deleteRecord(['id' => $id]);
   }
 
   /**

--- a/CRM/Core/BAO/IM.php
+++ b/CRM/Core/BAO/IM.php
@@ -158,12 +158,14 @@ ORDER BY cim.is_primary DESC, im_id ASC ";
   /**
    * Call common delete function.
    *
-   * @param int $id
+   * @see \CRM_Contact_BAO_Contact::on_hook_civicrm_post
    *
+   * @param int $id
+   * @deprecated
    * @return bool
    */
   public static function del($id) {
-    return CRM_Contact_BAO_Contact::deleteObjectWithPrimary('IM', $id);
+    return (bool) self::deleteRecord(['id' => $id]);
   }
 
 }

--- a/CRM/Core/BAO/OpenID.php
+++ b/CRM/Core/BAO/OpenID.php
@@ -121,12 +121,14 @@ ORDER BY
   /**
    * Call common delete function.
    *
-   * @param int $id
+   * @see \CRM_Contact_BAO_Contact::on_hook_civicrm_post
    *
+   * @param int $id
+   * @deprecated
    * @return bool
    */
   public static function del($id) {
-    return CRM_Contact_BAO_Contact::deleteObjectWithPrimary('OpenID', $id);
+    return (bool) self::deleteRecord(['id' => $id]);
   }
 
 }

--- a/CRM/Core/BAO/Phone.php
+++ b/CRM/Core/BAO/Phone.php
@@ -234,12 +234,14 @@ ORDER BY ph.is_primary DESC, phone_id ASC ";
   /**
    * Call common delete function.
    *
-   * @param int $id
+   * @see \CRM_Contact_BAO_Contact::on_hook_civicrm_post
    *
+   * @param int $id
+   * @deprecated
    * @return bool
    */
   public static function del($id) {
-    return CRM_Contact_BAO_Contact::deleteObjectWithPrimary('Phone', $id);
+    return (bool) self::deleteRecord(['id' => $id]);
   }
 
 }

--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -962,9 +962,14 @@ class CRM_Core_DAO extends DB_DataObject {
     CRM_Utils_Hook::pre('delete', $entityName, $record['id'], $record);
     $instance = new $className();
     $instance->id = $record['id'];
-    if (!$instance->delete()) {
+    // Load complete object for the sake of hook_civicrm_post, below
+    $instance->find(TRUE);
+    if (!$instance || !$instance->delete()) {
       throw new CRM_Core_Exception("Could not delete {$entityName} id {$record['id']}");
     }
+    // For other operations this hook is passed an incomplete object and hook listeners can load if needed.
+    // But that's not possible with delete because it's gone from the database by the time this hook is called.
+    // So in this case the object has been pre-loaded so hook listeners have access to the complete record.
     CRM_Utils_Hook::post('delete', $entityName, $record['id'], $instance);
 
     return $instance;

--- a/tests/phpunit/api/v4/Entity/AddressTest.php
+++ b/tests/phpunit/api/v4/Entity/AddressTest.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+namespace api\v4\Entity;
+
+use api\v4\UnitTestCase;
+use Civi\Api4\Address;
+use Civi\Api4\Contact;
+use Civi\Test\TransactionalInterface;
+
+/**
+ * Test Address functionality
+ *
+ * @group headless
+ */
+class AddressTest extends UnitTestCase implements TransactionalInterface {
+
+  /**
+   * Check that 2 addresses for the same contact can't both be primary
+   */
+  public function testPrimary() {
+    $cid = Contact::create(FALSE)->addValue('first_name', uniqid())->execute()->single()['id'];
+
+    $a1 = Address::create(FALSE)
+      ->addValue('is_primary', TRUE)
+      ->addValue('contact_id', $cid)
+      ->addValue('location_type_id', 1)
+      ->addValue('city', 'Somewhere')
+      ->execute();
+
+    $a2 = Address::create(FALSE)
+      ->addValue('is_primary', TRUE)
+      ->addValue('contact_id', $cid)
+      ->addValue('location_type_id', 2)
+      ->addValue('city', 'Elsewhere')
+      ->execute();
+
+    $addresses = Address::get(FALSE)
+      ->addWhere('contact_id', '=', $cid)
+      ->addOrderBy('id')
+      ->execute();
+
+    $this->assertFalse($addresses[0]['is_primary']);
+    $this->assertTrue($addresses[1]['is_primary']);
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Part of ongoing refactoring work for dev/core#2757

Before
----------------------------------------
Post-delete logic to handle `is_primary` in a delegated function.

After
----------------------------------------
Post-delete logic moved to a hook listener.
