### PR TITLE
dev/financial#180 Fix line item calculation regression on line items (incorrectly treating as exclusive)

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -192,7 +192,6 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution {
     if (!isset($params['tax_amount']) && $setPrevContribution && (isset($params['total_amount']) ||
      isset($params['financial_type_id']))) {
       $params['tax_amount'] = $taxAmount;
-      $params['total_amount'] = $taxAmount + $lineTotal;
     }
     if (isset($params['tax_amount']) && empty($params['skipLineItem'])
       && !CRM_Utils_Money::equals($params['tax_amount'], $taxAmount, ($params['currency'] ?? Civi::settings()->get('defaultCurrency')))

--- a/CRM/Price/BAO/LineItem.php
+++ b/CRM/Price/BAO/LineItem.php
@@ -516,17 +516,20 @@ WHERE li.contribution_id = %1";
           }
           $financialType = $values['financial_type_id'];
         }
+        $taxRates = CRM_Core_PseudoConstant::getTaxRates();
+        $taxRate = $taxRates[$financialType] ?? 0;
+        $taxAmount = ($taxRate / 100) * $totalAmount / (1 + ($taxRate / 100));
         $lineItem = [
           'price_field_id' => $values['priceFieldID'],
           'price_field_value_id' => $values['priceFieldValueID'],
           'label' => $values['label'],
           'qty' => 1,
-          'unit_price' => $totalAmount,
-          'line_total' => $totalAmount,
+          'unit_price' => $totalAmount - $taxAmount,
+          'line_total' => $totalAmount - $taxAmount,
           'financial_type_id' => $financialType,
           'membership_type_id' => $values['membership_type_id'],
+          'tax_amount' => $taxAmount,
         ];
-        $lineItem['tax_amount'] = self::getTaxAmountForLineItem($lineItem);
         $params['line_item'][$values['setID']][$values['priceFieldID']] = $lineItem;
         break;
       }

--- a/api/v3/Contribution.php
+++ b/api/v3/Contribution.php
@@ -70,6 +70,18 @@ function civicrm_api3_contribution_create($params) {
       throw new API_Exception($error['financial_type_id']);
     }
   }
+  if (!isset($params['tax_amount']) && empty($params['line_item'])
+    && empty($params['skipLineItem'])
+    && empty($params['id'])
+  ) {
+    $taxRates = CRM_Core_PseudoConstant::getTaxRates();
+    $taxRate = $taxRates[$params['financial_type_id']] ?? 0;
+    if ($taxRate) {
+      // Be afraid - historically if a contribution was tax then the passed in amount is EXCLUSIVE
+      $params['tax_amount'] = $params['total_amount'] * ($taxRate / 100);
+      $params['total_amount'] += $params['tax_amount'];
+    }
+  }
   _civicrm_api3_contribution_create_legacy_support_45($params);
 
   return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params, 'Contribution');

--- a/tests/phpunit/api/v3/TaxContributionPageTest.php
+++ b/tests/phpunit/api/v3/TaxContributionPageTest.php
@@ -392,7 +392,7 @@ class api_v3_TaxContributionPageTest extends CiviUnitTestCase {
     ]);
 
     $this->assertEquals('300.00', $lineItems);
-    $this->assertEquals('320.00', $this->_getFinancialTrxnAmount($contribution['id']));
+    $this->assertEquals('300.00', $this->_getFinancialTrxnAmount($contribution['id']));
     $this->assertEquals('320.00', $this->_getFinancialItemAmount($contribution['id']));
   }
 


### PR DESCRIPTION
Overview
=======================
Fixes a 5.41 regression where total amount was assumed to be exclusive when generating line items and calculating tax when it  is only sometimes exclusive


Before 
======================
Total amount is assumed to be tax-exclusive in all scenarios and line items calculated on that assumption

After 
=======================
Total amount is assumed to be inclusive in the bao - the edge case where it is exclusive historically and tested to be so is moved to contribution.create api

Technical Details
=======================

A [recent fix](https://github.com/civicrm/civicrm-core/commit/e967ce8fe2b58b94e2163dde395542e55599da13#diff-a16d4d7449cf5f3a0616d1d282a32f27ab6d3f7d2726d076c02ad1d4d655af41R512) added tax_amount calculations to getLineItems and used that amount to calculate the tax amount. 

However, in accordance with `api_v3_TaxContributionPageTest` I reached the conclusion that the 'normal behaviour' was to [treat the passed in amount as inclusive](https://github.com/civicrm/civicrm-core/commit/e967ce8fe2b58b94e2163dde395542e55599da13#diff-4c9d0b1abe07057a4eea2b47bc627eecb95face8ed8d86c1c005312a52cca811L4026-L4035). In fact that is historically the case ONLY [IF tax_amount is not passed in](https://github.com/civicrm/civicrm-core/commit/e967ce8fe2b58b94e2163dde395542e55599da13#diff-4c9d0b1abe07057a4eea2b47bc627eecb95face8ed8d86c1c005312a52cca811R187) - and it seems that it most commonly IS passed in. 

This moves the weird handling to the v3 contribution api. The intention is that v4 contribution api and order api will always assume that it is inclusive - although we can discuss adding the flexibility to define exclusive instead from the order api.

Note that when line_item (e.g as core forms do) is passed the bug is not hit -  the focus really is on the contribution.create api when it is allowing the BAO to calculate the line items.

Comments
=======================

@KarinG @mattwire @monishdeb @jitendrapurohit @christianwach this is the fix for the original sin - I think with this merged it will fix Contribution.api to 'do the right thing' when tax_amount is passed in. The fix for the order api becomes pretty simple at that point https://github.com/civicrm/civicrm-core/pull/21230/commits/05d1bbaade730155b18c419be5a090c2b5d2f220

However, I'm still expecting some tests that were altered AFTER the bug was introduced to fail with this or the order fix - just because the tests are wrong I think. 