### PR TITLE
[NFC] CRM_Utils_SystemTest - Call to Uri->withPath() using deprecated format

### DIFF
--- a/tests/phpunit/CRM/Utils/SystemTest.php
+++ b/tests/phpunit/CRM/Utils/SystemTest.php
@@ -136,7 +136,7 @@ class CRM_Utils_SystemTest extends CiviUnitTestCase {
   public function testAlterExternUrlHook($path, $expected) {
     Civi::dispatcher()->addListener('hook_civicrm_alterExternUrl', [$this, 'hook_civicrm_alterExternUrl']);
     $externUrl = CRM_Utils_System::externUrl($path, $expected['query']);
-    $this->assertStringContainsString('path/altered/by/hook', $externUrl, 'Hook failed to alter URL path');
+    $this->assertStringContainsString('/path/altered/by/hook', $externUrl, 'Hook failed to alter URL path');
     $this->assertStringContainsString($expected['query'] . '&thisWas=alteredByHook', $externUrl, 'Hook failed to alter URL query');
   }
 
@@ -154,7 +154,7 @@ class CRM_Utils_SystemTest extends CiviUnitTestCase {
     $this->assertTrue($event->hasField('fragment'));
     $this->assertTrue($event->hasField('absolute'));
     $this->assertTrue($event->hasField('isSSL'));
-    $event->url = $event->url->withPath('path/altered/by/hook');
+    $event->url = $event->url->withPath('/path/altered/by/hook');
     $event->url = $event->url->withQuery($event->query . '&thisWas=alteredByHook');
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Addresses test fails in https://github.com/civicrm/civicrm-core/pull/21064.

Before
----------------------------------------
CRM_Utils_SystemTest::testAlterExternUrlHook with data set 0 ('extern/url', array('extern/url', 'u=1&qid=1'))
Exception: The path of a URI with an authority must start with a slash "/" or be empty. Automagically fixing the URI by adding a leading slash to the path is deprecated since version 1.4 and will throw an exception instead.

CRM_Utils_SystemTest::testAlterExternUrlHook with data set 1 ('extern/open', array('extern/open', 'q=1'))
Exception: The path of a URI with an authority must start with a slash "/" or be empty. Automagically fixing the URI by adding a leading slash to the path is deprecated since version 1.4 and will throw an exception instead.

After
----------------------------------------


Technical Details
----------------------------------------
Guzzle uses the same "technique" (I'm trying to use a nice word) as drupal 8 that was the reason we didn't see any of the deprecations, even in logs on dev sites, until people started using drupal 9 and it hard-crashed. You only see these if you're using a special error handler: https://github.com/guzzle/psr7/blob/1.6.1/src/Uri.php#L751

Comments
----------------------------------------

