### PR TITLE
Alternate to 20131 - Avoid crash during import for blank lines in a one-column csv file

### DIFF
--- a/CRM/Import/DataSource/CSV.php
+++ b/CRM/Import/DataSource/CSV.php
@@ -214,6 +214,10 @@ class CRM_Import_DataSource_CSV extends CRM_Import_DataSource {
       if (count($row) != $numColumns) {
         continue;
       }
+      // A blank line will be array(0 => NULL)
+      if ($row === [NULL]) {
+        continue;
+      }
 
       if (!$first) {
         $sql .= ', ';

--- a/tests/phpunit/CRM/Import/DataSource/blankLineAtEnd.csv
+++ b/tests/phpunit/CRM/Import/DataSource/blankLineAtEnd.csv
@@ -1,0 +1,3 @@
+email
+yogi@yellowstone.park
+


### PR DESCRIPTION
Overview
----------------------------------------
Alternate to https://github.com/civicrm/civicrm-core/pull/20131

Importing a one-column csv file that has blank lines in it will crash

Before
----------------------------------------
1. Create a file with just, e.g. email, in it. It should only have one column.
2. Add one or more blank lines at the end.
3. Go to contact import and import it.
4. Crash with TypeError: Argument 1 passed to CRM_Import_DataSource_CSV::trimNonBreakingSpaces() must be of the type string, null given in CRM_Import_DataSource_CSV::trimNonBreakingSpaces() (line 259 of .../CRM/Import/DataSource/CSV.php)
5. Unit test fails with same error.

After
----------------------------------------
Blank line is skipped. Test passes.

Technical Details
----------------------------------------
A blank line is read by fgetcsv as `array(0 => NULL)`. When there's more than one expected column this gets skipped by some column-count checking already in the import code. When there's only one column, this ends up calling a function that's not expecting null. If the line is blank, don't even need to bother.

Comments
----------------------------------------
Has test.
