### PR TITLE
SearchKit - Allow tokens in menu button text

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin/displays/colType/menu.html
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/colType/menu.html
@@ -27,6 +27,7 @@
       <span crm-ui-editable ng-model="col.text">{{ col.text }}</span>
     </button>
   </div>
+  <crm-search-admin-token-select model="col" field="text" suffix=":label"></crm-search-admin-token-select>
 </div>
 <hr>
 <crm-search-admin-link-group links="$ctrl.parent.getLinks()" group="col.links" api-entity="$ctrl.apiEntity" api-params="$ctrl.apiParams"></crm-search-admin-link-group>

--- a/ext/search_kit/ang/crmSearchDisplay/colType/menu.html
+++ b/ext/search_kit/ang/crmSearchDisplay/colType/menu.html
@@ -1,7 +1,7 @@
 <div class="btn-group">
   <button type="button" class="dropdown-toggle {{:: col.size }} btn-{{:: col.style }}" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" ng-click="col.open = true">
     <i ng-if=":: col.icon" class="crm-i {{:: col.icon }}"></i>
-    {{:: col.text }}
+    {{:: $ctrl.replaceTokens(col.text, row) }}
   </button>
   <ul class="dropdown-menu {{ col.alignment === 'text-right' ? 'dropdown-menu-right' : '' }}" ng-if=":: col.open">
     <li ng-repeat="item in col.links" class="bg-{{:: item.style }}">


### PR DESCRIPTION
Overview
----------------------------------------
Allows button text for a dropdown menu element to be customized with tokens:
![Screenshot from 2021-08-22 15-37-34](https://user-images.githubusercontent.com/2874912/130367908-62dcae4a-f19e-4aca-aea7-f49751208d05.png)
