### PR TITLE
Change the default PDF file name from "CiviLetter.pdf" to use the Activity Subject, if available

### DIFF
--- a/CRM/Contribute/Form/Task/PDFLetter.php
+++ b/CRM/Contribute/Form/Task/PDFLetter.php
@@ -241,13 +241,19 @@ class CRM_Contribute_Form_Task_PDFLetter extends CRM_Contribute_Form_Task {
 
     //CRM-19761
     if (!empty($html)) {
-      $type = $this->getSubmittedValue('document_type');
-
-      if ($type === 'pdf') {
-        CRM_Utils_PDF_Utils::html2pdf($html, "CiviLetter.pdf", FALSE, $formValues);
+      // Set the filename for the PDF using the Activity Subject, if defined. Remove unwanted characters and limit the length to 200 characters.
+      if (!empty($formValues['subject'])) {
+        $fileName = CRM_Utils_File::makeFilenameWithUnicode($formValues['subject'], '_', 200);
       }
       else {
-        CRM_Utils_PDF_Document::html2doc($html, "CiviLetter.$type", $formValues);
+        $fileName = 'CiviLetter';
+      }
+
+      if ($this->getSubmittedValue('document_type') === 'pdf') {
+        CRM_Utils_PDF_Utils::html2pdf($html, $fileName . '.pdf', FALSE, $formValues);
+      }
+      else {
+        CRM_Utils_PDF_Document::html2doc($html, $fileName . '.' . $this->getSubmittedValue('document_type'), $formValues);
       }
     }
 

--- a/CRM/Core/Form/Task/PDFLetterCommon.php
+++ b/CRM/Core/Form/Task/PDFLetterCommon.php
@@ -376,11 +376,20 @@ class CRM_Core_Form_Task_PDFLetterCommon {
    * @param array $html
    */
   protected static function outputFromHtml($formValues, array $html) {
-    if ($formValues['document_type'] === 'pdf') {
-      CRM_Utils_PDF_Utils::html2pdf($html, 'CiviLetter.pdf', FALSE, $formValues);
+
+    // Set the filename for the PDF using the Activity Subject, if defined. Remove unwanted characters and limit the length to 200 characters.
+    if (!empty($formValues['subject'])) {
+      $fileName = CRM_Utils_File::makeFilenameWithUnicode($formValues['subject'], '_', 200);
     }
     else {
-      CRM_Utils_PDF_Document::html2doc($html, 'CiviLetter.' . $formValues['document_type'], $formValues);
+      $fileName = 'CiviLetter';
+    }
+
+    if ($formValues['document_type'] === 'pdf') {
+      CRM_Utils_PDF_Utils::html2pdf($html, $fileName . '.pdf', FALSE, $formValues);
+    }
+    else {
+      CRM_Utils_PDF_Document::html2doc($html, $fileName . '.' . $formValues['document_type'], $formValues);
     }
   }
 

--- a/CRM/Member/Form/Task/PDFLetterCommon.php
+++ b/CRM/Member/Form/Task/PDFLetterCommon.php
@@ -33,7 +33,15 @@ class CRM_Member_Form_Task_PDFLetterCommon extends CRM_Contact_Form_Task_PDFLett
       );
     self::createActivities($form, $html_message, $contactIDs, $formValues['subject'], CRM_Utils_Array::value('campaign_id', $formValues));
 
-    CRM_Utils_PDF_Utils::html2pdf($html, "CiviLetter.pdf", FALSE, $formValues);
+    // Set the filename for the PDF using the Activity Subject, if defined. Remove unwanted characters and limit the length to 200 characters.
+    if (!empty($form->getSubmittedValue('subject'))) {
+      $fileName = CRM_Utils_File::makeFilenameWithUnicode($form->getSubmittedValue('subject'), '_', 200) . '.pdf';
+    }
+    else {
+      $fileName = 'CiviLetter.pdf';
+    }
+
+    CRM_Utils_PDF_Utils::html2pdf($html, $fileName, FALSE, $formValues);
 
     $form->postProcessHook();
 
@@ -41,7 +49,7 @@ class CRM_Member_Form_Task_PDFLetterCommon extends CRM_Contact_Form_Task_PDFLett
   }
 
   /**
-   * Generate htmlfor pdf letters.
+   * Generate html for pdf letters.
    *
    * @param array $membershipIDs
    * @param array $returnProperties


### PR DESCRIPTION
Change the default PDF file name from "CiviLetter.pdf" to use the Activity Subject, if available

Overview
----------------------------------------
Continues the change initiated by PR #21006

Before
----------------------------------------
Some other actions in CiviCRM which generate PDFs still use the old 'CiviLetter.pdf' file name.

After
----------------------------------------
PDF will use Activity Subject as the file name, if it has been set. Otherwise will fall back to 'CiviLetter.pdf'. 

Technical Details
----------------------------------------
Continues PR #21006

Comments
----------------------------------------

Agileware Ref: CIVICRM-1812
