### PR TITLE
Change PDF file name from "civicrmContributionReceipt.pdf" to use the standard "receipt.pdf" file name

### DIFF
--- a/CRM/Contribute/Form/Task/PDF.php
+++ b/CRM/Contribute/Form/Task/PDF.php
@@ -193,7 +193,7 @@ AND    {$this->_componentClause}";
 
     if ($elements['createPdf']) {
       CRM_Utils_PDF_Utils::html2pdf($message,
-        'civicrmContributionReceipt.pdf',
+        'receipt.pdf',
         FALSE,
         $elements['params']['pdf_format_id']
       );


### PR DESCRIPTION
Change PDF file name from "civicrmContributionReceipt.pdf" to use the standard "receipt.pdf" file name

Overview
----------------------------------------
Change PDF file name from "civicrmContributionReceipt.pdf" to use the standard "receipt.pdf" file name

Before
----------------------------------------
This is the only place that CiviCRM creates a file called "civicrmContributionReceipt.pdf" for a receipt.

After
----------------------------------------
Uses the standard "receipt.pdf" file name.

Technical Details
----------------------------------------
Continues work of https://github.com/civicrm/civicrm-core/pull/21220 and https://github.com/civicrm/civicrm-core/pull/21006

Comments
----------------------------------------
Agileware Ref: CIVICRM-1813
