### PR TITLE
Fixes dev/core#2778 - Fatal error on dedupe screen

### DIFF
--- a/CRM/Contact/Page/AJAX.php
+++ b/CRM/Contact/Page/AJAX.php
@@ -578,8 +578,8 @@ LIMIT {$offset}, {$rowCount}
       'src_email' => 'ce2.email',
       'dst_postcode' => 'ca1.postal_code',
       'src_postcode' => 'ca2.postal_code',
-      'dst_street' => 'ca1.street',
-      'src_street' => 'ca2.street',
+      'dst_street' => 'ca1.street_address',
+      'src_street' => 'ca2.street_address',
     ];
 
     foreach ($mappings as $key => $dbName) {


### PR DESCRIPTION
Overview
----------------------------------------
Error when using search in 'Find and Merge Duplicate Contacts' page

Before
----------------------------------------
Searching on the dedupe screen returns an error -

![image](https://user-images.githubusercontent.com/5929648/130447428-3fc7d878-1065-4f9c-9090-a350d27a678d.png)


After
----------------------------------------
Fixed.

Technical Details
----------------------------------------
Incorrect column name.

Comments
----------------------------------------
Gitlab - https://lab.civicrm.org/dev/core/-/issues/2778