### PR TITLE
dev/core#2779 - Specify row fields to fetch in Api4 OAuthSysToken.Refresh 

### DIFF
--- a/ext/oauth-client/Civi/Api4/Action/OAuthSysToken/Refresh.php
+++ b/ext/oauth-client/Civi/Api4/Action/OAuthSysToken/Refresh.php
@@ -38,10 +38,15 @@ class Refresh extends BasicBatchAction {
 
   private $syncFields = ['access_token', 'refresh_token', 'expires', 'token_type'];
   private $writeFields = ['access_token', 'refresh_token', 'expires', 'token_type', 'raw'];
+  private $selectFields = ['id', 'client_id', 'access_token', 'refresh_token', 'expires', 'token_type', 'raw'];
   private $providers = [];
 
   public function __construct($entityName, $actionName) {
-    parent::__construct($entityName, $actionName, '*');
+    parent::__construct($entityName, $actionName);
+  }
+
+  protected function getSelect() {
+    return $this->selectFields;
   }
 
   protected function doTask($row) {


### PR DESCRIPTION
Overview
----------------------------------------
Fix for https://lab.civicrm.org/dev/core/-/issues/2779

Before
----------------------------------------
Api4 action implementation was broken by this update to underlying BasicBatchAction class interface https://lab.civicrm.org/dev/core/-/commit/29ab318b684a79f4cdedde2bf0417775d4be5523

After
----------------------------------------
Previous functionality restored

Technical Details
----------------------------------------
The required fields from the OAuthSysToken table for the batch action are now explicitly specified using getSelect() method. Previously it fetched all using a wildcard "*" but I don't think this is possible any more. If the method needed additional fields they would need to be added to the selectFields array

