### PR TITLE
Afform - fix contact source field & field defaults

### DIFF
--- a/ext/afform/admin/ang/afGuiEditor/afGuiEditor.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiEditor.component.js
@@ -120,7 +120,7 @@
         while (!!$scope.entities[type + num]) {
           num++;
         }
-        $scope.entities[type + num] = backfillEntityDefaults(_.assign($parse(meta.defaults)($scope), {
+        $scope.entities[type + num] = backfillEntityDefaults(_.assign($parse(meta.defaults)(editor), {
           '#tag': 'af-entity',
           type: meta.entity,
           name: type + num,
@@ -331,7 +331,7 @@
       $scope.$watch('editor.afform.title', function(newTitle, oldTitle) {
         if (typeof oldTitle === 'string') {
           _.each($scope.entities, function(entity) {
-            if (entity.data && entity.data.source === oldTitle) {
+            if (entity.data && 'source' in entity.data && (entity.data.source || '') === oldTitle) {
               entity.data.source = newTitle;
             }
           });

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
@@ -236,11 +236,13 @@
       };
 
       $scope.defaultValueContains = function(val) {
+        val = '' + val;
         var defaultVal = getSet('afform_default');
         return defaultVal === val || (_.isArray(defaultVal) && _.includes(defaultVal, val));
       };
 
       $scope.toggleDefaultValueItem = function(val) {
+        val = '' + val;
         if (defaultValueShouldBeArray()) {
           if (!_.isArray(getSet('afform_default'))) {
             ctrl.node.defn.afform_default = [];

--- a/ext/afform/admin/ang/afGuiEditor/inputType/Select.html
+++ b/ext/afform/admin/ang/afGuiEditor/inputType/Select.html
@@ -6,6 +6,9 @@
       <div class="input-group-btn" af-gui-menu>
         <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><i class="crm-i fa-caret-down"></i></button>
         <ul class="dropdown-menu" ng-if="menu.open" title="{{:: ts('Set default value') }}">
+          <li class="disabled">
+            <a><strong>{{:: ts('Default Value:') }}</strong></a>
+          </li>
           <li ng-repeat="opt in $ctrl.getOptions()" >
             <a href ng-click="toggleDefaultValueItem(opt.id); $event.stopPropagation(); $event.target.blur();">
               <i class="crm-i fa-{{defaultValueContains(opt.id) ? 'check-' : ''}}circle-o"></i>


### PR DESCRIPTION
Overview
----------------------------------------
2 minor Afform bugfixes:

1. Contact source is supposed to take its default from the afform title but was broken
2. Field defaults were saving incorrectly for some fields

Before
----------------------------------------
Adding a contact to a form would get a blank value for Source.
Fields defaults with numeric keys (e.g. location type id) were saving as integers instead of strings.

After
----------------------------------------
Source stays in sync with the Afform title unless manually edited.
Fields defaults set correctly, plus added a helpful "Default Value" title to the dropdown:
![Screenshot from 2021-08-23 16-25-24](https://user-images.githubusercontent.com/2874912/130514631-f2933050-dfd0-4b1e-9b0b-ebea749d7bb4.png)
