### PR TITLE
FIx order api regression

### DIFF
--- a/api/v3/Order.php
+++ b/api/v3/Order.php
@@ -100,13 +100,8 @@ function civicrm_api3_order_create(array $params): array {
   }
   else {
     $order->setPriceSetToDefault('contribution');
-    $order->setLineItem([
-      // Historically total_amount in this case could be tax
-      // inclusive if tax is also supplied.
-      // This is inconsistent with the contribution api....
-      'line_total' => ((float) $params['total_amount'] - (float) ($params['tax_amount'] ?? 0)),
-      'financial_type_id' => (int) $params['financial_type_id'],
-    ], 0);
+    $order->setOverrideTotalAmount((float) $params['total_amount']);
+    $order->setLineItem([], 0);
   }
   // Only check the amount if line items are set because that is what we have historically
   // done and total amount is historically only inclusive of tax_amount IF
@@ -118,6 +113,11 @@ function civicrm_api3_order_create(array $params): array {
     }
   }
   $params['total_amount'] = $order->getTotalAmount();
+  if (!isset($params['tax_amount'])) {
+    // @todo always calculate tax amount - left for now
+    // for webform
+    $params['tax_amount'] = $order->getTotalTaxAmount();
+  }
 
   foreach ($order->getEntitiesToCreate() as $entityParams) {
     if ($entityParams['entity'] === 'participant') {

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -2266,8 +2266,9 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
    * @param string $thousandSeparator
    *   punctuation used to refer to thousands.
    *
-   * @dataProvider getThousandSeparators
+   * @throws \API_Exception
    * @throws \CRM_Core_Exception
+   * @dataProvider getThousandSeparators
    */
   public function testCheckTaxAmount(string $thousandSeparator): void {
     $this->setCurrencySeparators($thousandSeparator);
@@ -2286,10 +2287,10 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
       'sequential' => 1,
     ]);
     $contributionPostPayment = $this->callAPISuccessGetSingle('Contribution', ['id' => $contributionID, 'return' => ['tax_amount', 'fee_amount', 'net_amount']]);
-    $this->assertEquals(5, $contributionPrePayment['tax_amount']);
-    $this->assertEquals(5, $contributionPostPayment['tax_amount']);
+    $this->assertEquals(4.76, $contributionPrePayment['tax_amount']);
+    $this->assertEquals(4.76, $contributionPostPayment['tax_amount']);
     $this->assertEquals('6.00', $contributionPostPayment['fee_amount']);
-    $this->assertEquals('99.00', $contributionPostPayment['net_amount']);
+    $this->assertEquals('94.00', $contributionPostPayment['net_amount']);
     $this->validateAllContributions();
     $this->validateAllPayments();
   }
@@ -4768,6 +4769,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
 
   /**
    * Test Repeat Transaction Contribution with Tax amount.
+   *
    * https://lab.civicrm.org/dev/core/issues/806
    *
    * @throws \CRM_Core_Exception
@@ -4792,7 +4794,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
       'contribution_status_id' => 'Completed',
       'trxn_id' => 'test',
     ]);
-    $payments = $this->callAPISuccess('Contribution', 'get', ['sequential' => 1])['values'];
+    $payments = $this->callAPISuccess('Contribution', 'get', ['sequential' => 1, 'return' => ['total_amount', 'tax_amount']])['values'];
     //Assert if first payment and repeated payment has the same contribution amount.
     $this->assertEquals($payments[0]['total_amount'], $payments[1]['total_amount']);
     $this->callAPISuccessGetCount('Contribution', [], 2);
@@ -4800,8 +4802,9 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
     //Assert line item records.
     $lineItems = $this->callAPISuccess('LineItem', 'get', ['sequential' => 1])['values'];
     foreach ($lineItems as $lineItem) {
-      $this->assertEquals($lineItem['unit_price'], $this->_params['total_amount']);
-      $this->assertEquals($lineItem['line_total'], $this->_params['total_amount']);
+      $taxExclusiveAmount = $payments[0]['total_amount'] - $payments[0]['tax_amount'];
+      $this->assertEquals($lineItem['unit_price'], $taxExclusiveAmount);
+      $this->assertEquals($lineItem['line_total'], $taxExclusiveAmount);
     }
     $this->callAPISuccessGetCount('Contribution', [], 2);
   }


### PR DESCRIPTION
Overview
----------------------------------------
Builds on  https://github.com/civicrm/civicrm-core/pull/21212 to fix order api - note the failing tests were converted to use order api after this bug was introduced from my analysis & the tests need to be fixed 

Before
---------------------------------------
total_amount treated as exclusive in order api

After
----------------------------------------
Treated as inclusive

Technical Details
----------------------------------------
@monishdeb @jitendrapurohit @KarinG this causes test fails but note the tests were altered after this bug was introduced - eg.

https://github.com/civicrm/civicrm-core/commit/53c8b1bebcbb6b0d974f57ba17615d3adf364ab5#diff-f854cc50e25729d771411105b2ea81397cc1946abb90e79be703a3ec5c6e5bb6R2291 and see the long write up on the test

The repeat transaction one was also altered in the set up function - here https://github.com/civicrm/civicrm-core/commit/4d86769f2aebfa8c1b76649de970e85c25ab2898#diff-f854cc50e25729d771411105b2ea81397cc1946abb90e79be703a3ec5c6e5bb6R4418 

Comments
----------------------------------------
@monishdeb @jitendrapurohit if you conclude that I'm right in thinking the tests are recently altered & wrong I'll update them to make this pass

Note these are the failing tests - but I think the bottom one is no longer

![image](https://user-images.githubusercontent.com/336308/130652688-3b76e081-3ba8-4ed9-b215-1a293f9d643a.png)
