### PR TITLE
APIv4 - Use correct BAO delete function (fixes dev/core#2757)

### DIFF
--- a/CRM/Core/BAO/EntityTag.php
+++ b/CRM/Core/BAO/EntityTag.php
@@ -96,7 +96,7 @@ class CRM_Core_BAO_EntityTag extends CRM_Core_DAO_EntityTag {
    * Delete the tag for a contact.
    *
    * @param array $params
-   *
+   * @deprecated
    * WARNING: Nonstandard params searches by tag_id rather than id!
    */
   public static function del(&$params) {

--- a/Civi/Api4/Action/Contact/Delete.php
+++ b/Civi/Api4/Action/Contact/Delete.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Action\Contact;
+
+/**
+ * Deletes a contact, by default moving to trash. Set `useTrash = FALSE` for permanent deletion.
+ * @inheritDoc
+ */
+class Delete extends \Civi\Api4\Generic\DAODeleteAction {
+  use \Civi\Api4\Generic\Traits\SoftDelete;
+
+  /**
+   * @param $items
+   * @return array
+   * @throws \API_Exception
+   */
+  protected function deleteObjects($items) {
+    foreach ($items as $item) {
+      if (!\CRM_Contact_BAO_Contact::deleteContact($item['id'], FALSE, !$this->useTrash, $this->checkPermissions)) {
+        throw new \API_Exception("Could not delete {$this->getEntityName()} id {$item['id']}");
+      }
+      $ids[] = ['id' => $item['id']];
+    }
+    return $ids;
+  }
+
+}

--- a/Civi/Api4/Contact.php
+++ b/Civi/Api4/Contact.php
@@ -28,6 +28,15 @@ class Contact extends Generic\DAOEntity {
 
   /**
    * @param bool $checkPermissions
+   * @return Action\Contact\Delete
+   */
+  public static function delete($checkPermissions = TRUE) {
+    return (new Action\Contact\Delete(__CLASS__, __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
+  }
+
+  /**
+   * @param bool $checkPermissions
    * @return Action\Contact\GetChecksum
    */
   public static function getChecksum($checkPermissions = TRUE) {

--- a/Civi/Api4/Generic/DAODeleteAction.php
+++ b/Civi/Api4/Generic/DAODeleteAction.php
@@ -14,6 +14,7 @@ namespace Civi\Api4\Generic;
 
 use Civi\API\Exception\UnauthorizedException;
 use Civi\Api4\Utils\CoreUtil;
+use Civi\Api4\Utils\ReflectionUtils;
 
 /**
  * Delete one or more $ENTITIES.
@@ -56,7 +57,8 @@ class DAODeleteAction extends AbstractBatchAction {
     $ids = [];
     $baoName = $this->getBaoName();
 
-    if ($this->getEntityName() !== 'EntityTag' && method_exists($baoName, 'del')) {
+    // Use BAO::del() method if it is not deprecated
+    if (method_exists($baoName, 'del') && !ReflectionUtils::isMethodDeprecated($baoName, 'del')) {
       foreach ($items as $item) {
         $args = [$item['id']];
         $bao = call_user_func_array([$baoName, 'del'], $args);

--- a/Civi/Api4/Generic/Traits/SoftDelete.php
+++ b/Civi/Api4/Generic/Traits/SoftDelete.php
@@ -1,0 +1,27 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Generic\Traits;
+
+/**
+ * This trait is used by entities with a "move to trash" option.
+ * @method $this setUseTrash(bool $useTrash) Pass FALSE to force delete and bypass trash
+ * @method bool getUseTrash()
+ */
+trait SoftDelete {
+
+  /**
+   * Should $ENTITY be moved to the trash instead of permanently deleted?
+   * @var bool
+   */
+  protected $useTrash = TRUE;
+
+}

--- a/Civi/Api4/Utils/ReflectionUtils.php
+++ b/Civi/Api4/Utils/ReflectionUtils.php
@@ -180,6 +180,20 @@ class ReflectionUtils {
   }
 
   /**
+   * Check if a class method is deprecated
+   *
+   * @param string $className
+   * @param string $methodName
+   * @return bool
+   * @throws \ReflectionException
+   */
+  public static function isMethodDeprecated(string $className, string $methodName): bool {
+    $reflection = new \ReflectionClass($className);
+    $docBlock = $reflection->getMethod($methodName)->getDocComment();
+    return strpos($docBlock, "@deprecated") !== FALSE;
+  }
+
+  /**
    * Find any methods in this class which match the given prefix.
    *
    * @param string $class

--- a/Civi/Test/Api3TestTrait.php
+++ b/Civi/Test/Api3TestTrait.php
@@ -510,6 +510,10 @@ trait Api3TestTrait {
       }
     }
 
+    if (isset($actionInfo[0]['params']['useTrash'])) {
+      $v4Params['useTrash'] = empty($v3Params['skip_undelete']);
+    }
+
     // Build where clause for 'getcount', 'getsingle', 'getvalue', 'get' & 'replace'
     if ($v4Action == 'get' || $v3Action == 'replace') {
       foreach ($v3Params as $key => $val) {

--- a/tests/phpunit/api/v4/Entity/ConformanceTest.php
+++ b/tests/phpunit/api/v4/Entity/ConformanceTest.php
@@ -424,10 +424,15 @@ class ConformanceTest extends UnitTestCase implements HookInterface {
     $this->assertEquals(0, $this->checkAccessCounts["{$entity}::delete"]);
     $isReadOnly = $this->isReadOnly($entityClass);
 
-    $deleteResult = $entityClass::delete()
+    $deleteAction = $entityClass::delete()
       ->setCheckPermissions(!$isReadOnly)
-      ->addWhere('id', '=', $id)
-      ->execute();
+      ->addWhere('id', '=', $id);
+
+    if (property_exists($deleteAction, 'useTrash')) {
+      $deleteAction->setUseTrash(FALSE);
+    }
+
+    $deleteResult = $deleteAction->execute();
 
     // should get back an array of deleted id
     $this->assertEquals([['id' => $id]], (array) $deleteResult);

--- a/tests/phpunit/api/v4/Mock/MockV4ReflectionGrandchild.php
+++ b/tests/phpunit/api/v4/Mock/MockV4ReflectionGrandchild.php
@@ -31,4 +31,21 @@ namespace api\v4\Mock;
  */
 class MockV4ReflectionGrandchild extends MockV4ReflectionChild {
 
+  /**
+   * Function marked deprecated
+   * @see \api\v4\Utils\ReflectionUtilsTest::testIsMethodDeprecated
+   * @deprecated
+   */
+  public static function deprecatedFn() {
+
+  }
+
+  /**
+   * Function not marked deprecated
+   * @see \api\v4\Utils\ReflectionUtilsTest::testIsMethodDeprecated
+   */
+  public static function nonDeprecatedFn() {
+
+  }
+
 }

--- a/tests/phpunit/api/v4/Utils/ReflectionUtilsTest.php
+++ b/tests/phpunit/api/v4/Utils/ReflectionUtilsTest.php
@@ -109,4 +109,10 @@ This is the base class.';
     $this->assertEquals($expected, ReflectionUtils::parseDocBlock($input));
   }
 
+  public function testIsMethodDeprecated() {
+    $mockClass = 'api\v4\Mock\MockV4ReflectionGrandchild';
+    $this->assertTrue(ReflectionUtils::isMethodDeprecated($mockClass, 'deprecatedFn'));
+    $this->assertFalse(ReflectionUtils::isMethodDeprecated($mockClass, 'nonDeprecatedFn'));
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes the contact delete bug noted in  [dev/core#2757](https://lab.civicrm.org/dev/core/-/issues/2757) and gives us a way to noisy-deprecate `BAO::del()` functions without tripping up APIv4 tests.
