### PR TITLE
Resolve dev/core#2768 Reinstate code into APIv4 that handled magic fu…

### DIFF
--- a/Civi/Api4/Generic/AbstractAction.php
+++ b/Civi/Api4/Generic/AbstractAction.php
@@ -192,6 +192,33 @@ abstract class AbstractAction implements \ArrayAccess {
   }
 
   /**
+   * Magic function to provide automatic getter/setter for params.
+   *
+   * @param $name
+   * @param $arguments
+   * @return static|mixed
+   * @throws \API_Exception
+   */
+  public function __call($name, $arguments) {
+    $param = lcfirst(substr($name, 3));
+    if (!$param || $param[0] == '_') {
+      throw new \API_Exception('Unknown api parameter: ' . $name);
+    }
+    $mode = substr($name, 0, 3);
+    if ($this->paramExists($param)) {
+      switch ($mode) {
+        case 'get':
+          return $this->$param;
+
+        case 'set':
+          $this->$param = $arguments[0];
+          return $this;
+      }
+    }
+    throw new \API_Exception('Unknown api parameter: ' . $name);
+  }
+
+  /**
    * Invoke api call.
    *
    * At this point all the params have been sent in and we initiate the api call & return the result.

--- a/tests/phpunit/api/v4/Action/AbstractActionFunctionTest.php
+++ b/tests/phpunit/api/v4/Action/AbstractActionFunctionTest.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+namespace api\v4\Action;
+
+use api\v4\UnitTestCase;
+
+/**
+ * @group headless
+ */
+class AbstractActionFunctionTest extends UnitTestCase {
+
+  public function testUndefinedParamException(): void {
+    $this->expectException('API_Exception');
+    $this->expectExceptionMessage('Unknown api parameter: getLanguage');
+    \Civi\Api4\System::flush(FALSE)->getLanguage();
+  }
+
+}


### PR DESCRIPTION
…nctions

Overview
----------------------------------------
This aims to resolve https://lab.civicrm.org/dev/core/-/issues/2768 by putting back in the code for the magic function call that was copied across to the trait

Before
----------------------------------------
Cannot use setLangauge on an abstract action

After
----------------------------------------
can

ping @eileenmcnaughton @totten @colemanw 