### PR TITLE
Fix test to actually pass valid data

### DIFF
--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -3586,6 +3586,21 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
     //Update it to Failed.
     $form->_params['id'] = $contribution['id'];
     $form->_params['contribution_status_id'] = 4;
+    // We now have 2 line items of $20 each.
+    // form params['total_amount'] is set to $20 but
+    // now that we have 2 line items of $20 it should be $40
+    // this is an artificial test scenario.
+    // but we need to ensure it is valid enough to
+    // pass validation checks. Note the way these lines are created
+    // above is wrong wrong wrong - but the rc is not the place to fix.
+    // Also note that this test has historically created incorrect
+    // financial data. The financials check was enabled on it
+    // AFTER the code we are honing was merged.
+    // so it used to tolerate incorrect financials, then it started
+    // re-calculating them (correctly in this artificial scenario - but not for tax scenarios)
+    // but as of 5.41 it is 'accepting' the total_amount
+    // so we should pass in a correct one.
+    $form->_params['total_amount'] = 40;
 
     $form->testSubmit($form->_params, CRM_Core_Action::UPDATE);
     //Existing membership should not get updated to expired.


### PR DESCRIPTION


Overview
----------------------------------------
Fix test that was passing invalid data

Before
----------------------------------------
The test winds up with 2 artificially created line items of $20 each but passes in a contribution.total_amount of $20. The correct amount is of course $40

After
----------------------------------------
$40 passed in

Technical Details
----------------------------------------
This test should pass before and after the change. The history is
- until 5.41 it passed in the wrong data. The sum of the line items did not add up to the total_amount and so we marked this test as having invalid financials so the validFinancials check would never run
- in 5.41 we started calculating the total_amount off the line items. That meant the total_amount was ignored and valid financials were created, so the check was enabled.
- However, in 5.41 there is a bug and the fix for that requires us to be more limited in calculating the total amount - which results in this creating invalid financials because we are passing in invalid information. But then the test fails because of the new check. 


This updates the data passed in to be correct to remove the confusion of it doing something wrong, that it has always done wrong but which is now visible due to the extra test cover.

Here is the line item creation

```
   $this->callAPISuccess('line_item', 'create', [
      'entity_id' => $contribution['id'],
      'entity_table' => 'civicrm_contribution',
      'contribution_id' => $contribution['id'],
      'price_field_id' => $this->_ids['price_field'][0],
      'qty' => 1,
      'unit_price' => 20,
      'line_total' => 20,
      'financial_type_id' => 1,
      'price_field_value_id' => $this->_ids['price_field_value']['cont'],
    ]);
    $this->callAPISuccess('line_item', 'create', [
      'entity_id' => $this->_ids['membership'],
      'entity_table' => 'civicrm_membership',
      'contribution_id' => $contribution['id'],
      'price_field_id' => $this->_ids['price_field'][0],
      'qty' => 1,
      'unit_price' => 20,
      'line_total' => 20,
      'financial_type_id' => 1,
      'price_field_value_id' => $this->_ids['price_field_value'][0],
      'membership_type_id' => $this->_ids['membership_type'],
    ]);
```

Comments
----------------------------------------
@seamuslee001 @monishdeb I think getting this merged will help reduce confusion around the regression fix


