### PR TITLE
[NFC] - Replace deprecated function in AngularLoaderTest

### DIFF
--- a/tests/phpunit/Civi/Angular/LoaderTest.php
+++ b/tests/phpunit/Civi/Angular/LoaderTest.php
@@ -46,11 +46,16 @@ class LoaderTest extends \CiviUnitTestCase {
    * @param $expectedPermissions
    */
   public function testSettingFactory($module, $expectedSettingCount, $expectedCallbackCount, $expectedPermissions) {
-    $loader = new \Civi\Angular\AngularLoader();
+    $loader = \Civi::service('angularjs.loader');
     $loader->addModules([$module]);
     $loader->useApp();
-    // Load triggers a deprecation notice, use @ to suppress it for the test.
-    @$loader->load();
+
+    // Load angular resources.
+    //
+    // It seems like calling something like
+    //   \CRM_Core_Region::instance('html-header')->render('');
+    // would be more realistic but then the test fails. Maybe a future todo.
+    \Civi::dispatcher()->dispatch('civi.region.render', \Civi\Core\Event\GenericHookEvent::create(['region' => \CRM_Core_Region::instance('html-header')]));
 
     // Run factory callbacks
     $actual = \Civi::resources()->getSettings();


### PR DESCRIPTION
Overview
----------------------------------------
Addresses test fail in https://github.com/civicrm/civicrm-core/pull/21064

Before
----------------------------------------
Deprecated function AngularLoader->load()

After
----------------------------------------


Technical Details
----------------------------------------
Deprecation not coming up in regular test runs because the `@` was hiding it.

Comments
----------------------------------------
Is test.