### PR TITLE
CiviCRM Mailing, function unsub_from_mailing has spelling error, "experiement" impacts A/B Mailing unsubscribes

### DIFF
--- a/CRM/Mailing/Event/BAO/Unsubscribe.php
+++ b/CRM/Mailing/Event/BAO/Unsubscribe.php
@@ -132,7 +132,7 @@ WHERE  email = %2
     $relevant_mailing_id = $mailing_id;
 
     // Special case for AB Tests:
-    if (in_array($mailing_type, ['experiement', 'winner'])) {
+    if (in_array($mailing_type, ['experiment', 'winner'])) {
       // The mailing belongs to an AB test.
       // See if we can find an AB test where this is variant B.
       $mailing_id_a = CRM_Core_DAO::getFieldValue('CRM_Mailing_DAO_MailingAB', mailing_id, 'mailing_id_a', 'mailing_id_b');


### PR DESCRIPTION
CiviCRM Mailing, function unsub_from_mailing has spelling error, "experiement" impacts A/B Mailing unsubscribes

Overview
----------------------------------------
Spelling mistake in string comparison causes logic to never evaluate.

Before
----------------------------------------
Logic checks for mailing type "experiement"

After
----------------------------------------
Logic now checks for mailing type "experiment"

Technical Details
----------------------------------------
Looks like this was introduced in https://github.com/civicrm/civicrm-core/pull/15815


Comments
----------------------------------------
Would be ideal if Jenkins could at least raise a warning for spelling mistakes like this.

Agileware Ref: CIVICRM-1816
