### PR TITLE
5.41 to master

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -192,7 +192,6 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution {
     if (!isset($params['tax_amount']) && $setPrevContribution && (isset($params['total_amount']) ||
      isset($params['financial_type_id']))) {
       $params['tax_amount'] = $taxAmount;
-      $params['total_amount'] = $taxAmount + $lineTotal;
     }
     if (isset($params['tax_amount']) && empty($params['skipLineItem'])
       && !CRM_Utils_Money::equals($params['tax_amount'], $taxAmount, ($params['currency'] ?? Civi::settings()->get('defaultCurrency')))

--- a/CRM/Price/BAO/LineItem.php
+++ b/CRM/Price/BAO/LineItem.php
@@ -516,17 +516,20 @@ WHERE li.contribution_id = %1";
           }
           $financialType = $values['financial_type_id'];
         }
+        $taxRates = CRM_Core_PseudoConstant::getTaxRates();
+        $taxRate = $taxRates[$financialType] ?? 0;
+        $taxAmount = ($taxRate / 100) * $totalAmount / (1 + ($taxRate / 100));
         $lineItem = [
           'price_field_id' => $values['priceFieldID'],
           'price_field_value_id' => $values['priceFieldValueID'],
           'label' => $values['label'],
           'qty' => 1,
-          'unit_price' => $totalAmount,
-          'line_total' => $totalAmount,
+          'unit_price' => $totalAmount - $taxAmount,
+          'line_total' => $totalAmount - $taxAmount,
           'financial_type_id' => $financialType,
           'membership_type_id' => $values['membership_type_id'],
+          'tax_amount' => $taxAmount,
         ];
-        $lineItem['tax_amount'] = self::getTaxAmountForLineItem($lineItem);
         $params['line_item'][$values['setID']][$values['priceFieldID']] = $lineItem;
         break;
       }

--- a/api/v3/Contribution.php
+++ b/api/v3/Contribution.php
@@ -70,6 +70,18 @@ function civicrm_api3_contribution_create($params) {
       throw new API_Exception($error['financial_type_id']);
     }
   }
+  if (!isset($params['tax_amount']) && empty($params['line_item'])
+    && empty($params['skipLineItem'])
+    && empty($params['id'])
+  ) {
+    $taxRates = CRM_Core_PseudoConstant::getTaxRates();
+    $taxRate = $taxRates[$params['financial_type_id']] ?? 0;
+    if ($taxRate) {
+      // Be afraid - historically if a contribution was tax then the passed in amount is EXCLUSIVE
+      $params['tax_amount'] = $params['total_amount'] * ($taxRate / 100);
+      $params['total_amount'] += $params['tax_amount'];
+    }
+  }
   _civicrm_api3_contribution_create_legacy_support_45($params);
 
   return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params, 'Contribution');

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -3538,21 +3538,6 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
     //Update it to Failed.
     $form->_params['id'] = $this->getContributionID('second');
     $form->_params['contribution_status_id'] = 4;
-    // We now have 2 line items of $20 each.
-    // form params['total_amount'] is set to $20 but
-    // now that we have 2 line items of $20 it should be $40
-    // this is an artificial test scenario.
-    // but we need to ensure it is valid enough to
-    // pass validation checks. Note the way these lines are created
-    // above is wrong wrong wrong - but the rc is not the place to fix.
-    // Also note that this test has historically created incorrect
-    // financial data. The financials check was enabled on it
-    // AFTER the code we are honing was merged.
-    // so it used to tolerate incorrect financials, then it started
-    // re-calculating them (correctly in this artificial scenario - but not for tax scenarios)
-    // but as of 5.41 it is 'accepting' the total_amount
-    // so we should pass in a correct one.
-    $form->_params['total_amount'] = 40;
 
     $form->testSubmit($form->_params, CRM_Core_Action::UPDATE);
     //Existing membership should not get updated to expired.

--- a/tests/phpunit/api/v3/TaxContributionPageTest.php
+++ b/tests/phpunit/api/v3/TaxContributionPageTest.php
@@ -392,7 +392,7 @@ class api_v3_TaxContributionPageTest extends CiviUnitTestCase {
     ]);
 
     $this->assertEquals('300.00', $lineItems);
-    $this->assertEquals('320.00', $this->_getFinancialTrxnAmount($contribution['id']));
+    $this->assertEquals('300.00', $this->_getFinancialTrxnAmount($contribution['id']));
     $this->assertEquals('320.00', $this->_getFinancialItemAmount($contribution['id']));
   }
 


### PR DESCRIPTION
Merge 5.41 to master

A straight up-merge https://github.com/civicrm/civicrm-core/pull/21242 is failing on the test change we made in 5.41 to get the tests to pass. The test setup for this test is materially different in master than 5.41 (it doesn't just create random line items) so we can revert https://github.com/civicrm/civicrm-core/commit/11736aba4778a4beaf40a1ccaf93ebed9e01a9fd when up-merging