### PR TITLE
BasicPageLoadTest - Add basic E2E test which requests every nav-menu item

### DIFF
--- a/CRM/Utils/HTMLTidy.php
+++ b/CRM/Utils/HTMLTidy.php
@@ -1,0 +1,54 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+class CRM_Utils_HTMLTidy {
+
+  /**
+   * Validate that a document is well-formed.
+   *
+   * @param string $html
+   *   HTML document
+   * @return string[]
+   *   List of validation messages.
+   */
+  public static function validate(string $html): array {
+    $tidy = new \tidy();
+    $tidy->parseString($html, [
+      'drop-empty-elements' => FALSE,
+      'markup' => FALSE,
+      'new-blocklevel-tags' => 'crm-angular-js',
+      'new-empty-tags' => '',
+      'new-inline-tags' => '',
+      'new-pre-tags' => '',
+    ], 'utf8');
+    $errs = $tidy->errorBuffer ? explode("\n", $tidy->errorBuffer) : [];
+    return preg_grep(static::getIgnoredErrors(), $errs, PREG_GREP_INVERT);
+  }
+
+  protected static function getIgnoredErrors() {
+    if (!isset(\Civi::$statics[__CLASS__][__FUNCTION__])) {
+      $pats = [
+        // We're loosey goosey about where to place <script>.
+        '\<script\> isn\'t allowed in \<table\>',
+        // This should probably be fixed - but not sure how.
+        'nested emphasis \<label\>',
+      ];
+      \Civi::$statics[__CLASS__][__FUNCTION__] = ';(' . implode('|', $pats) . ');';
+    }
+    return \Civi::$statics[__CLASS__][__FUNCTION__];
+  }
+
+}

--- a/Civi/Test/HttpTestTrait.php
+++ b/Civi/Test/HttpTestTrait.php
@@ -34,11 +34,20 @@ trait HttpTestTrait {
   /**
    * Create an HTTP client suitable for simulating AJAX requests.
    *
+   * The client may include some mix of these middlewares:
+   *
+   * @see \CRM_Utils_GuzzleMiddleware::authx()
+   * @see \CRM_Utils_GuzzleMiddleware::url()
+   * @see \CRM_Utils_GuzzleMiddleware::curlLog()
+   * @see Middleware::history()
+   * @see Middleware::log()
+   *
    * @param array $options
    * @return \GuzzleHttp\Client
    */
   protected function createGuzzle($options = []) {
     $handler = HandlerStack::create();
+    $handler->unshift(\CRM_Utils_GuzzleMiddleware::authx(), 'civi_authx');
     $handler->unshift(\CRM_Utils_GuzzleMiddleware::url(), 'civi_url');
     $handler->push(Middleware::history($this->httpHistory), 'history');
 

--- a/templates/CRM/Activity/Form/Activity.tpl
+++ b/templates/CRM/Activity/Form/Activity.tpl
@@ -126,7 +126,7 @@
     <td class="label">{$form.duration.label}</td>
     <td class="view-value">
       {$form.duration.html}
-      {if $action neq 4}<span class="description">{ts}minutes{/ts}{/if}
+      {if $action neq 4}<span class="description">{ts}minutes{/ts}</span>{/if}
     </td>
   </tr>
   <tr class="crm-activity-form-block-status_id">

--- a/templates/CRM/common/notifications.tpl
+++ b/templates/CRM/common/notifications.tpl
@@ -1,4 +1,4 @@
-<div id="crm-notification-container" role="alert" aria-live="assertive" aria-atomic=”true” style="display:none">
+<div id="crm-notification-container" role="alert" aria-live="assertive" aria-atomic="true" style="display:none">
   <div id="crm-notification-alert" class="#{ldelim}type{rdelim}">
     <div class="icon ui-notify-close" title="{ts}close{/ts}"> </div>
     <a class="ui-notify-cross ui-notify-close" href="#" title="{ts}close{/ts}">x</a>

--- a/tests/phpunit/E2E/Core/BasicPageLoadTest.php
+++ b/tests/phpunit/E2E/Core/BasicPageLoadTest.php
@@ -1,0 +1,167 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace E2E\Core;
+
+use Civi\Test\Invasive;
+use GuzzleHttp\Client;
+
+/**
+ * Walk through a list of common pages. Perform a full E2E request for the page,
+ * ensure that each returns a well-formed response (eg HTTP 200). Each request must run as a specific
+ * user (eg `ADMIN_USER` or `DEMO_USER`).
+ *
+ * When running this test, you may set some environment variables to influence it:
+ *
+ * - DEBUG=1: Output summary information for each HTTP request
+ * - DEBUG=2: Output detailed information for each HTTP request
+ * - PAGE_REGEX=';civicrm/activity;': Only test URLs that match the regex
+ * - PAGE_LIMIT=100: Only test up to $x URLs.
+ *
+ * For example, you might run this command:
+ *
+ *   PAGE_REGEX=';civicrm/activity;' PAGE_LIMIT=3 DEBUG=1 phpunit7 tests/phpunit/E2E/Core/PageSmokeTest.php
+ *
+ * As part of the DEBUG output, it will provide the "curl log". You can copy-paste these
+ * curl commands ot repeat the request.
+ *
+ * @package E2E\Core
+ * @group e2e
+ */
+class BasicPageLoadTest extends \CiviEndToEndTestCase {
+
+  use \Civi\Test\HttpTestTrait;
+
+  const AUTH_TTL = 60 * 15;
+
+  const IGNORE_URL_REGEX = ';civicrm(/|%2F)logout;';
+
+  public static function setUpBeforeClass(): void {
+    parent::setUpBeforeClass();
+    if (!\CRM_Extension_System::singleton()->getMapper()->isActiveModule('authx')) {
+      \civicrm_api3('Extension', 'install', ['key' => 'authx']);
+    }
+  }
+
+  protected function setUp(): void {
+    parent::setUp();
+  }
+
+  public function testAdminPages() {
+    $http = $this->createGuzzle(['cookies' => new \GuzzleHttp\Cookie\CookieJar()]);
+    $http->post('civicrm/authx/login', ['authx_user' => $GLOBALS['_CV']['ADMIN_USER']]);
+
+    $urls = $this->parseNavUrls(json_decode($http->get('route://civicrm/ajax/navmenu')->getBody(), TRUE));
+    $this->assertGreaterThan(100, count($urls), 'If fewer than 100 menu items are found, then something must be wrong with fetching the menu.');
+    $urls = $this->filterTestUrls($urls);
+
+    // Assert that URLs returned decent results. We want a full list of failed/erroneous pages.
+    $fmtArr = function($arr) {
+      $buf = '';
+      foreach ($arr as $k => $v) {
+        $buf .= sprintf("# URL: %s\n%s\n\n", $k, trim($v));
+      }
+      return $buf;
+    };
+    $actualValidations = $this->validateUrls($http, $urls);
+    $expectValidations = array_fill_keys($urls, 'ok');
+    $this->assertEquals($fmtArr($expectValidations), $fmtArr($actualValidations));
+  }
+
+  private function validateUrls(Client $http, array $urls): array {
+    $matchHeader = function ($response, $header, $type) {
+      return !empty(preg_grep($type, $response->getHeader($header)));
+    };
+
+    $result = [];
+    foreach ($urls as $url) {
+      $response = $http->get($url);
+      $errs = [];
+      if ($response->getStatusCode() != 200) {
+        $errs[] = 'Error: HTTP ' . $response->getStatusCode();
+      }
+      elseif ($matchHeader($response, 'Content-Type', ';text/html;')) {
+        $errs = array_merge($errs, static::checkResponseHtmlBasicParse((string) $response->getBody()));
+        $errs = array_merge($errs, \CRM_Utils_HTMLTidy::validate((string) $response->getBody()));
+      }
+      else {
+        $errs[] = "Unrecognized response type: " . json_encode($response->getHeader('Content-Type'));
+      }
+      $result[$url] = empty($errs) ? 'ok' : implode("\n", $errs);
+    }
+    return $result;
+  }
+
+  /**
+   * Given a menu-tree, extract a list of URLs from the navigation menu.
+   *
+   * @param array $menuData
+   *   See `civicrm/ajax/navmenu`
+   * @return array
+   *   List of absolute URLs.
+   */
+  private function parseNavUrls(array $menuData): array {
+    $internalBase = parse_url(CIVICRM_UF_BASEURL, PHP_URL_SCHEME) . '://'
+      . parse_url(CIVICRM_UF_BASEURL, PHP_URL_HOST)
+      . (($port = parse_url(CIVICRM_UF_BASEURL, PHP_URL_PORT)) ? ":$port" : '');
+
+    \CRM_Utils_Array::flatten($menuData['menu'], $flatMenu);
+    $urls = array_filter($flatMenu, function($key) {
+      return preg_match('/\.url$/', $key);
+    }, ARRAY_FILTER_USE_KEY);
+
+    $urls = array_map(['CRM_Utils_String', 'unstupifyUrl'], $urls);
+
+    $urls = array_map(function($value) use ($internalBase) {
+      return ($value[0] === '/' ? $internalBase : '') . $value;
+    }, $urls);
+
+    $urls = preg_grep('/' . preg_quote($internalBase, '/') . '/', $urls);
+
+    $urls = array_unique($urls);
+    sort($urls);
+    return $urls;
+  }
+
+  public static function checkResponseHtmlBasicParse(string $body): array {
+    $oldLibXMLErrors = libxml_use_internal_errors();
+    try {
+      libxml_use_internal_errors(TRUE);
+      $doc = new \DOMDocument();
+      if (!$doc->loadHTML($body)) {
+        return [Invasive::call(['CRM_Utils_XML', 'formatErrors'], [libxml_get_errors()])];
+      }
+      // $doc->validate() sounds good but doesn't seem to work.
+    }
+    finally {
+      libxml_use_internal_errors($oldLibXMLErrors);
+    }
+    return [];
+  }
+
+  /**
+   * Apply any optional runtime filters. These can be used to focus on a specific set of pages.
+   *
+   * @param string[] $urls
+   * @return string[]
+   */
+  private function filterTestUrls(array $urls): array {
+    $urls = preg_grep(self::IGNORE_URL_REGEX, $urls, PREG_GREP_INVERT);
+    if (getenv('PAGE_REGEX')) {
+      $urls = preg_grep(getenv('PAGE_REGEX'), $urls);
+    }
+    if (getenv('PAGE_LIMIT')) {
+      $urls = array_slice(array_values($urls), 0, getenv('PAGE_LIMIT'));
+    }
+    return $urls;
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------

This test doesn't ensure that every page works correctly.  It merely ensures that every page sends a well-formed response.  This should flag obvious crashes.

Marked as "Draft". Just want to see what happens. It will likely fail because (a) the `tidy` PECL is needed and (b) there are a number of small/random HTML quality issues.

Depends: https://github.com/civicrm/civicrm-buildkit/pull/646

Before
----------------------------------------

Test does not exist.

After
----------------------------------------

Example output when requesting a malformed page:

<img width="1649" alt="Screen Shot 2021-08-24 at 6 20 13 PM" src="https://user-images.githubusercontent.com/1336047/130710697-8af8d236-997e-4551-a37b-f087ade0ba94.png">


Technical Details
----------------------------------------
_If the PR involves technical details/changes/considerations which would not be manifest to a casual developer skimming the above sections, please describe the details here._

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
