### PR TITLE
CiviCRM Scheduled Reminders, Effective Start Date and Effective End Date are incorrectly evaluated if these fields contain a value '0000-00-00 00:00:00'

### DIFF
--- a/Civi/ActionSchedule/RecipientBuilder.php
+++ b/Civi/ActionSchedule/RecipientBuilder.php
@@ -409,10 +409,10 @@ class RecipientBuilder {
       else {
         $startDateClauses[] = "DATE_SUB(!casNow, INTERVAL 1 DAY ) <= {$date}";
       }
-      if (!empty($actionSchedule->effective_start_date)) {
+      if (!empty($actionSchedule->effective_start_date) && $actionSchedule->effective_start_date !== '0000-00-00 00:00:00') {
         $startDateClauses[] = "'{$actionSchedule->effective_start_date}' <= {$date}";
       }
-      if (!empty($actionSchedule->effective_end_date)) {
+      if (!empty($actionSchedule->effective_end_date) && $actionSchedule->effective_end_date !== '0000-00-00 00:00:00') {
         $startDateClauses[] = "'{$actionSchedule->effective_end_date}' > {$date}";
       }
     }


### PR DESCRIPTION
CiviCRM Scheduled Reminders, Effective Start Date and Effective End Date are incorrectly evaluated if these fields contain a value '0000-00-00 00:00:00'. See Gitlab, https://lab.civicrm.org/dev/core/-/issues/2787

Overview
----------------------------------------
See Gitlab, https://lab.civicrm.org/dev/core/-/issues/2787

Before
----------------------------------------
Scheduled Reminder is **NOT sent** when either the Effective Start Date or Effective End Date have a value of  '0000-00-00 00:00:00'.

After
----------------------------------------
Scheduled Reminder **IS sent** when either the Effective Start Date or Effective End Date have a value of  '0000-00-00 00:00:00'.

Technical Details
----------------------------------------

Comments
----------------------------------------
This problem relates to this PR https://github.com/civicrm/civicrm-core/pull/19973

Agileware Ref: CIVICRM-1820 
