### PR TITLE
Afform - selectable location type for address, email, etc

### DIFF
--- a/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php
+++ b/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php
@@ -2,6 +2,7 @@
 
 namespace Civi\AfformAdmin;
 
+use Civi\Api4\Entity;
 use Civi\Api4\Utils\CoreUtil;
 use CRM_AfformAdmin_ExtensionUtil as E;
 
@@ -67,17 +68,32 @@ class AfformAdminMeta {
     }
     $info = \Civi\Api4\Entity::get(FALSE)
       ->addWhere('name', '=', $entityName)
-      ->addSelect('title', 'icon')
       ->execute()->first();
     if (!$info) {
       // Disabled contact type or nonexistent api entity
       return NULL;
     }
-    return [
-      'entity' => $entityName,
+    return self::entityToAfformMeta($info);
+  }
+
+  /**
+   * Converts info from API.Entity.get to an array of afform entity metadata
+   * @param array $info
+   * @return array
+   */
+  private static function entityToAfformMeta(array $info): array {
+    $meta = [
+      'entity' => $info['name'],
       'label' => $info['title'],
       'icon' => $info['icon'],
     ];
+    // Custom entities are always type 'join'
+    if (in_array('CustomValue', $info['type'], TRUE)) {
+      $meta['type'] = 'join';
+      $max = (int) \CRM_Core_DAO::getFieldValue('CRM_Core_DAO_CustomGroup', substr($info['name'], 7), 'max_multiple', 'name');
+      $meta['repeat_max'] = $max ?: NULL;
+    }
+    return $meta;
   }
 
   /**
@@ -140,9 +156,16 @@ class AfformAdminMeta {
           'icon' => 'fa-pencil-square-o',
           'fields' => [],
         ],
-        'Contact' => self::getApiEntity('Contact'),
       ],
     ];
+
+    // Explicitly load Contact and Custom entities because they do not have afformEntity files
+    $entities = Entity::get(TRUE)
+      ->addClause('OR', ['name', '=', 'Contact'], ['type', 'CONTAINS', 'CustomValue'])
+      ->execute()->indexBy('name');
+    foreach ($entities as $name => $entity) {
+      $data['entities'][$name] = self::entityToAfformMeta($entity);
+    }
 
     $contactTypes = \CRM_Contact_BAO_ContactType::basicTypeInfo();
 

--- a/ext/afform/admin/Civi/Api4/Action/Afform/LoadAdminData.php
+++ b/ext/afform/admin/Civi/Api4/Action/Afform/LoadAdminData.php
@@ -237,7 +237,7 @@ class LoadAdminData extends \Civi\Api4\Generic\AbstractAction {
     }
     if ($entities) {
       $blockInfo = Afform::get($this->checkPermissions)
-        ->addSelect('name', 'title', 'entity_type', 'join_entity', 'directive_name', 'repeat')
+        ->addSelect('name', 'title', 'entity_type', 'join_entity', 'directive_name')
         ->setWhere($where)
         ->addWhere('type', '=', 'block')
         ->addWhere('entity_type', 'IN', $entities)

--- a/ext/afform/admin/afformEntities/Activity.php
+++ b/ext/afform/admin/afformEntities/Activity.php
@@ -1,5 +1,6 @@
 <?php
 return [
+  'type' => 'primary',
   'defaults' => "{
     data: {
       source_contact_id: 'user_contact_id',

--- a/ext/afform/admin/afformEntities/Address.php
+++ b/ext/afform/admin/afformEntities/Address.php
@@ -1,0 +1,5 @@
+<?php
+return [
+  'type' => 'join',
+  'repeat_max' => NULL,
+];

--- a/ext/afform/admin/afformEntities/Address.php
+++ b/ext/afform/admin/afformEntities/Address.php
@@ -2,4 +2,5 @@
 return [
   'type' => 'join',
   'repeat_max' => NULL,
+  'unique_fields' => ['is_primary', 'location_type_id'],
 ];

--- a/ext/afform/admin/afformEntities/Email.php
+++ b/ext/afform/admin/afformEntities/Email.php
@@ -1,0 +1,5 @@
+<?php
+return [
+  'type' => 'join',
+  'repeat_max' => NULL,
+];

--- a/ext/afform/admin/afformEntities/Email.php
+++ b/ext/afform/admin/afformEntities/Email.php
@@ -2,4 +2,5 @@
 return [
   'type' => 'join',
   'repeat_max' => NULL,
+  'unique_fields' => ['is_primary', 'location_type_id'],
 ];

--- a/ext/afform/admin/afformEntities/Household.php
+++ b/ext/afform/admin/afformEntities/Household.php
@@ -1,5 +1,6 @@
 <?php
 return [
+  'type' => 'primary',
   'defaults' => "{
     data: {
       contact_type: 'Household',

--- a/ext/afform/admin/afformEntities/IM.php
+++ b/ext/afform/admin/afformEntities/IM.php
@@ -1,0 +1,5 @@
+<?php
+return [
+  'type' => 'join',
+  'repeat_max' => NULL,
+];

--- a/ext/afform/admin/afformEntities/IM.php
+++ b/ext/afform/admin/afformEntities/IM.php
@@ -2,4 +2,5 @@
 return [
   'type' => 'join',
   'repeat_max' => NULL,
+  'unique_fields' => ['is_primary', 'location_type_id'],
 ];

--- a/ext/afform/admin/afformEntities/Individual.php
+++ b/ext/afform/admin/afformEntities/Individual.php
@@ -1,5 +1,6 @@
 <?php
 return [
+  'type' => 'primary',
   'defaults' => "{
     data: {
       contact_type: 'Individual',

--- a/ext/afform/admin/afformEntities/Organization.php
+++ b/ext/afform/admin/afformEntities/Organization.php
@@ -1,5 +1,6 @@
 <?php
 return [
+  'type' => 'primary',
   'defaults' => "{
     data: {
       contact_type: 'Organization',

--- a/ext/afform/admin/afformEntities/Phone.php
+++ b/ext/afform/admin/afformEntities/Phone.php
@@ -1,0 +1,5 @@
+<?php
+return [
+  'type' => 'join',
+  'repeat_max' => NULL,
+];

--- a/ext/afform/admin/afformEntities/Phone.php
+++ b/ext/afform/admin/afformEntities/Phone.php
@@ -2,4 +2,5 @@
 return [
   'type' => 'join',
   'repeat_max' => NULL,
+  'unique_fields' => ['is_primary', 'location_type_id'],
 ];

--- a/ext/afform/admin/afformEntities/Website.php
+++ b/ext/afform/admin/afformEntities/Website.php
@@ -1,0 +1,5 @@
+<?php
+return [
+  'type' => 'join',
+  'repeat_max' => NULL,
+];

--- a/ext/afform/admin/afformEntities/Website.php
+++ b/ext/afform/admin/afformEntities/Website.php
@@ -2,4 +2,5 @@
 return [
   'type' => 'join',
   'repeat_max' => NULL,
+  'unique_fields' => ['website_type_id'],
 ];

--- a/ext/afform/admin/ang/afAdmin/afAdminList.controller.js
+++ b/ext/afform/admin/ang/afAdmin/afAdminList.controller.js
@@ -58,7 +58,7 @@
 
       if (ctrl.tab === 'form') {
         _.each(CRM.afGuiEditor.entities, function(entity, name) {
-          if (entity.defaults) {
+          if (entity.type === 'primary') {
             links.push({
               url: '#create/form/' + name,
               label: entity.label,

--- a/ext/afform/admin/ang/afGuiEditor.css
+++ b/ext/afform/admin/ang/afGuiEditor.css
@@ -260,13 +260,14 @@ body.af-gui-dragging {
   opacity: 1;
   transition: opacity 0s;
 }
-#afGuiEditor #afGuiEditor-canvas .af-entity-selected > .af-gui-bar > .form-inline > button > span,
+/* Fix button colors when bar is highlighted */
+#afGuiEditor #afGuiEditor-canvas .af-entity-selected > .af-gui-bar > .form-inline > .btn-group > .btn-group > button > span,
 #afGuiEditor #afGuiEditor-canvas .af-entity-selected > .af-gui-bar > .form-inline > span {
   color: white;
 }
-#afGuiEditor #afGuiEditor-canvas .af-entity-selected > .af-gui-bar > .form-inline > button:hover > span,
-#afGuiEditor #afGuiEditor-canvas .af-entity-selected > .af-gui-bar > .open > button > span,
-#afGuiEditor #afGuiEditor-canvas .af-entity-selected > .af-gui-bar > .form-inline > button:focus > span {
+#afGuiEditor #afGuiEditor-canvas .af-entity-selected > .af-gui-bar > .form-inline > .btn-group > .btn-group > button:hover > span,
+#afGuiEditor #afGuiEditor-canvas .af-entity-selected > .af-gui-bar > .form-inline > .btn-group > .btn-group > button[aria-expanded=true] > span,
+#afGuiEditor #afGuiEditor-canvas .af-entity-selected > .af-gui-bar > .form-inline > .btn-group > .btn-group > button:focus > span {
   color: #0071bd;
 }
 

--- a/ext/afform/admin/ang/afGuiEditor/afGuiContainerMultiToggle.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiContainerMultiToggle.component.js
@@ -1,0 +1,115 @@
+// https://civicrm.org/licensing
+(function(angular, $, _) {
+  "use strict";
+
+  // Menu item to control the border property of a node
+  angular.module('afGuiEditor').component('afGuiContainerMultiToggle', {
+    templateUrl: '~/afGuiEditor/afGuiContainerMultiToggle.html',
+    bindings: {
+      entity: '<'
+    },
+    require: {
+      container: '^^afGuiContainer'
+    },
+    controller: function($scope, afGui) {
+      var ts = $scope.ts = CRM.ts('org.civicrm.afform_admin'),
+        ctrl = this;
+      this.menuItems = [];
+      this.uniqueFields = {};
+
+      this.$onInit = function() {
+        this.menuItems.push({
+          key: 'repeat',
+          label: ts('Multiple')
+        });
+        _.each(afGui.getEntity(this.entity).unique_fields, function(fieldName) {
+          var field = ctrl.uniqueFields[fieldName] = afGui.getField(ctrl.entity, fieldName);
+          ctrl.menuItems.push({});
+          if (field.options) {
+            _.each(field.options, function(option) {
+              ctrl.menuItems.push({
+                field: fieldName,
+                key: option.id,
+                label: option.label
+              });
+            });
+          } else {
+            ctrl.menuItems.push({
+              field: fieldName,
+              key: true,
+              label: field.label
+            });
+          }
+        });
+      };
+
+      this.isMulti = function() {
+        return 'af-repeat' in ctrl.container.node;
+      };
+
+      this.isSelected = function(item) {
+        if (!item.field && item.key === 'repeat') {
+          return ctrl.isMulti();
+        }
+        if (ctrl.container.node.data) {
+          var field = ctrl.uniqueFields[item.field];
+          if (field.options) {
+            return ctrl.container.node.data[item.field] === item.key;
+          }
+          return ctrl.container.node.data[item.field];
+        }
+        return false;
+      };
+
+      this.selectOption = function(item) {
+        if (!item.field && item.key === 'repeat') {
+          return ctrl.container.toggleRepeat();
+        }
+        if (ctrl.isMulti()) {
+          ctrl.container.toggleRepeat();
+        }
+        var field = ctrl.uniqueFields[item.field];
+        ctrl.container.node.data = ctrl.container.node.data || {};
+        if (field.options) {
+          if (ctrl.container.node.data[item.field] === item.key) {
+            delete ctrl.container.node.data[item.field];
+          } else {
+            ctrl.container.node.data = {};
+            ctrl.container.node.data[item.field] = item.key;
+            ctrl.container.removeField(item.field);
+          }
+        } else if (ctrl.container.node.data[item.field]) {
+          delete ctrl.container.node.data[item.field];
+        } else {
+          ctrl.container.node.data = {};
+          ctrl.container.node.data[item.field] = true;
+          ctrl.container.removeField(item.field);
+        }
+        if (_.isEmpty(ctrl.container.node.data)) {
+          delete ctrl.container.node.data;
+        }
+      };
+
+      this.getButtonText = function() {
+        if (ctrl.isMulti()) {
+          return ts('Multiple');
+        }
+        var output = ts('Single');
+        _.each(ctrl.container.node.data, function(val, fieldName) {
+          if (val && (fieldName in ctrl.uniqueFields)) {
+            var field = ctrl.uniqueFields[fieldName];
+            if (field.options) {
+              output = _.result(_.findWhere(field.options, {id: val}), 'label');
+            } else {
+              output = field.label;
+            }
+            return false;
+          }
+        });
+        return output;
+      };
+
+    }
+  });
+
+})(angular, CRM.$, CRM._);

--- a/ext/afform/admin/ang/afGuiEditor/afGuiContainerMultiToggle.html
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiContainerMultiToggle.html
@@ -1,0 +1,14 @@
+<button type="button" class="btn btn-default btn-xs dropdown-toggle" data-toggle="dropdown" title="{{:: ts('Toggle multi or single block') }}">
+  <span>
+    <i class="crm-i fa-{{ $ctrl.isMulti() ? 'repeat' : 'dot-circle-o' }}"></i>
+    {{ $ctrl.getButtonText() }}
+  </span>
+</button>
+<ul class="dropdown-menu dropdown-menu-right">
+  <li ng-repeat="item in $ctrl.menuItems" class="{{ item.key ? '' : 'divider' }}">
+    <a href ng-if="item.key" ng-click="$ctrl.selectOption(item)">
+      <i class="crm-i fa-{{ $ctrl.isSelected(item) ? 'check-' : '' }}circle-o"></i>
+      {{:: item.label }}
+    </a>
+  </li>
+</ul>

--- a/ext/afform/admin/ang/afGuiEditor/afGuiEntity.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiEntity.component.js
@@ -99,14 +99,17 @@
           ) {
             var item = {"#tag": block.join_entity ? "div" : directive};
             if (block.join_entity) {
+              var joinEntity = afGui.getEntity(block.join_entity);
+              // Skip adding block if entity does not exist
+              if (!joinEntity) {
+                return;
+              }
               item['af-join'] = block.join_entity;
               item['#children'] = [{"#tag": directive}];
-            }
-            if (block.repeat) {
               item['af-repeat'] = ts('Add');
               item.min = '1';
-              if (typeof block.repeat === 'number') {
-                item.max = '' + block.repeat;
+              if (typeof joinEntity.repeat_max === 'number') {
+                item.max = '' + joinEntity.repeat_max;
               }
             }
             $scope.blockList.push(item);

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiContainer-menu.html
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiContainer-menu.html
@@ -16,7 +16,7 @@
     </label>
     <span ng-style="{visibility: $ctrl.node['af-repeat'] || $ctrl.node['af-repeat'] === '' ? 'visible' : 'hidden'}">
       <input type="number" class="form-control" ng-model="getSetMin" ng-model-options="{getterSetter: true}" placeholder="{{:: ts('min') }}" min="0" step="1" />
-      - <input type="number" class="form-control" ng-model="getSetMax" ng-model-options="{getterSetter: true}" placeholder="{{:: ts('max') }}" min="2" step="1" />
+      - <input type="number" class="form-control" ng-model="getSetMax" ng-model-options="{getterSetter: true}" placeholder="{{:: ts('max') }}" min="2" max="{{:: getRepeatMax() }}" step="1" />
     </span>
   </div>
 </li>

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiContainer-menu.html
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiContainer-menu.html
@@ -10,7 +10,7 @@
 </li>
 <li ng-if="isRepeatable()" ng-click="$event.stopPropagation()">
   <div class="af-gui-field-select-in-dropdown form-inline">
-    <label ng-click="toggleRepeat()">
+    <label ng-click="$ctrl.toggleRepeat()">
       <i class="crm-i fa-{{ $ctrl.node['af-repeat'] || $ctrl.node['af-repeat'] === '' ? 'check-' : '' }}square-o"></i>
       {{:: ts('Repeat') }}
     </label>

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiContainer.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiContainer.component.js
@@ -88,6 +88,7 @@
         }
       };
 
+      // Sets min value for af-repeat as a string, returns it as an int
       $scope.getSetMin = function(val) {
         if (arguments.length) {
           if (ctrl.node.max && val > parseInt(ctrl.node.max, 10)) {
@@ -103,6 +104,7 @@
         return ctrl.node.min ? parseInt(ctrl.node.min, 10) : null;
       };
 
+      // Sets max value for af-repeat as a string, returns it as an int
       $scope.getSetMax = function(val) {
         if (arguments.length) {
           if (ctrl.node.min && val && val < parseInt(ctrl.node.min, 10)) {
@@ -116,6 +118,16 @@
           }
         }
         return ctrl.node.max ? parseInt(ctrl.node.max, 10) : null;
+      };
+
+      // Returns the maximum number of repeats allowed if this is a joined entity with a limit
+      // Value comes from civicrm_custom_group.max_multiple for custom entities,
+      // or from afformEntity php file for core entities.
+      $scope.getRepeatMax = function() {
+        if (ctrl.join) {
+          return afGui.getEntity(ctrl.join).repeat_max || '';
+        }
+        return '';
       };
 
       $scope.pickAddIcon = function() {

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiContainer.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiContainer.component.js
@@ -76,7 +76,7 @@
         return ctrl.node['af-fieldset'] || (block.directive && afGui.meta.blocks[block.directive].repeat) || ctrl.join;
       };
 
-      $scope.toggleRepeat = function() {
+      this.toggleRepeat = function() {
         if ('af-repeat' in ctrl.node) {
           delete ctrl.node.max;
           delete ctrl.node.min;
@@ -85,6 +85,7 @@
         } else {
           ctrl.node.min = '1';
           ctrl.node['af-repeat'] = ts('Add');
+          delete ctrl.node.data;
         }
       };
 
@@ -125,7 +126,7 @@
       // or from afformEntity php file for core entities.
       $scope.getRepeatMax = function() {
         if (ctrl.join) {
-          return afGui.getEntity(ctrl.join).repeat_max || '';
+          return ctrl.getJoinEntity().repeat_max || '';
         }
         return '';
       };
@@ -290,8 +291,19 @@
         afGui.removeRecursive($scope.getSetChildren(), {$$hashKey: element.$$hashKey});
       };
 
+      this.removeField = function(fieldName) {
+        afGui.removeRecursive($scope.getSetChildren(), {'#tag': 'af-field', name: fieldName});
+      };
+
       this.getEntityName = function() {
         return ctrl.entityName ? ctrl.entityName.split('-join-')[0] : null;
+      };
+
+      this.getJoinEntity = function() {
+        if (!ctrl.join) {
+          return null;
+        }
+        return afGui.getEntity(ctrl.join);
       };
 
       // Returns the primary entity type for this container e.g. "Contact"

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiContainer.html
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiContainer.html
@@ -1,5 +1,5 @@
 <div class="af-gui-bar" ng-if="$ctrl.node['#tag']" ng-click="selectEntity()" >
-  <div ng-if="!$ctrl.loading" class="form-inline" af-gui-menu>
+  <div ng-if="!$ctrl.loading" class="form-inline">
     <span ng-if="$ctrl.getNodeType($ctrl.node) == 'fieldset'">{{ $ctrl.editor.getEntity($ctrl.entityName).label }}</span>
     <span ng-if="block">{{ $ctrl.join ? ts($ctrl.join) + ':' : ts('Block:') }}</span>
     <span ng-if="!block">{{ tags[$ctrl.node['#tag']] }}</span>
@@ -8,10 +8,15 @@
       <option ng-value="option.id" ng-repeat="option in block.options track by option.id">{{ option.text }}</option>
     </select>
     <button type="button" class="btn btn-default btn-xs" ng-if="block && !block.layout" ng-click="saveBlock()">{{:: ts('Save...') }}</button>
-    <button type="button" class="btn btn-default btn-xs dropdown-toggle af-gui-add-element-button pull-right" data-toggle="dropdown" title="{{:: ts('Configure') }}">
-      <span><i class="crm-i fa-gear"></i></span>
-    </button>
-    <ul class="dropdown-menu dropdown-menu-right" ng-if="menu.open" ng-include="'~/afGuiEditor/elements/afGuiContainer-menu.html'"></ul>
+    <div class="btn-group pull-right">
+      <af-gui-container-multi-toggle ng-if="!ctrl.loading && ($ctrl.join || $ctrl.node['af-repeat'])" entity="$ctrl.getFieldEntityType()" class="btn-group"></af-gui-container-multi-toggle>
+      <div class="btn-group" af-gui-menu>
+        <button type="button" class="btn btn-default btn-xs dropdown-toggle af-gui-add-element-button" data-toggle="dropdown" title="{{:: ts('Configure') }}">
+          <span><i class="crm-i fa-gear"></i></span>
+        </button>
+        <ul class="dropdown-menu dropdown-menu-right" ng-if="menu.open" ng-include="'~/afGuiEditor/elements/afGuiContainer-menu.html'"></ul>
+      </div>
+    </div>
   </div>
   <div ng-if="$ctrl.loading"><i class="crm-i fa-spin fa-spinner"></i></div>
 </div>

--- a/ext/afform/core/CRM/Afform/ArrayHtml.php
+++ b/ext/afform/core/CRM/Afform/ArrayHtml.php
@@ -23,12 +23,12 @@ class CRM_Afform_ArrayHtml {
     '*' => [
       '*' => 'text',
       'af-fieldset' => 'text',
+      'data' => 'js',
     ],
     'af-entity' => [
       '#selfClose' => TRUE,
       'name' => 'text',
       'type' => 'text',
-      'data' => 'js',
       'security' => 'text',
       'actions' => 'js',
     ],

--- a/ext/afform/core/Civi/Api4/Action/Afform/Get.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/Get.php
@@ -135,7 +135,6 @@ class Get extends \Civi\Api4\Generic\BasicGetAction {
         'permission' => 'access CiviCRM',
         'join_entity' => 'Custom_' . $custom['name'],
         'entity_type' => $custom['extends'],
-        'repeat' => $custom['max_multiple'] ?: TRUE,
         'has_base' => TRUE,
       ];
       if ($getLayout) {

--- a/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
@@ -38,9 +38,11 @@ class Submit extends AbstractProcessor {
         foreach ($values['joins'] as $joinEntity => &$joinValues) {
           // Enforce the limit set by join[max]
           $joinValues = array_slice($joinValues, 0, $entity['joins'][$joinEntity]['max'] ?? NULL);
-          // Only accept values from join fields on the form
           foreach ($joinValues as $index => $vals) {
+            // Only accept values from join fields on the form
             $joinValues[$index] = array_intersect_key($vals, $entity['joins'][$joinEntity]['fields'] ?? []);
+            // Merge in pre-set data
+            $joinValues[$index] = array_merge($joinValues[$index], $entity['joins'][$joinEntity]['data'] ?? []);
           }
         }
         $entityValues[$entityName][] = $values;

--- a/ext/afform/core/Civi/Api4/Afform.php
+++ b/ext/afform/core/Civi/Api4/Afform.php
@@ -179,10 +179,6 @@ class Afform extends Generic\AbstractEntity {
           ],
         ],
         [
-          'name' => 'repeat',
-          'data_type' => 'Mixed',
-        ],
-        [
           'name' => 'server_route',
         ],
         [

--- a/ext/afform/core/ang/afblockContactAddress.aff.json
+++ b/ext/afform/core/ang/afblockContactAddress.aff.json
@@ -2,6 +2,5 @@
   "title": "Contact Address(es)",
   "type": "block",
   "entity_type": "Contact",
-  "join_entity": "Address",
-  "repeat": true
+  "join_entity": "Address"
 }

--- a/ext/afform/core/ang/afblockContactEmail.aff.json
+++ b/ext/afform/core/ang/afblockContactEmail.aff.json
@@ -2,6 +2,5 @@
   "title": "Contact Email(s)",
   "type": "block",
   "entity_type": "Contact",
-  "join_entity": "Email",
-  "repeat": true
+  "join_entity": "Email"
 }

--- a/ext/afform/core/ang/afblockContactIM.aff.json
+++ b/ext/afform/core/ang/afblockContactIM.aff.json
@@ -2,6 +2,5 @@
   "title": "Contact IM(s)",
   "type": "block",
   "entity_type": "Contact",
-  "join_entity": "IM",
-  "repeat": true
+  "join_entity": "IM"
 }

--- a/ext/afform/core/ang/afblockContactPhone.aff.json
+++ b/ext/afform/core/ang/afblockContactPhone.aff.json
@@ -2,6 +2,5 @@
   "title": "Contact Phone(s)",
   "type": "block",
   "entity_type": "Contact",
-  "join_entity": "Phone",
-  "repeat": true
+  "join_entity": "Phone"
 }

--- a/ext/afform/core/ang/afblockContactWebsite.aff.json
+++ b/ext/afform/core/ang/afblockContactWebsite.aff.json
@@ -2,6 +2,5 @@
   "title": "Contact Website(s)",
   "type": "block",
   "entity_type": "Contact",
-  "join_entity": "Website",
-  "repeat": true
+  "join_entity": "Website"
 }

--- a/ext/afform/mock/tests/phpunit/api/v4/AfformCustomFieldUsageTest.php
+++ b/ext/afform/mock/tests/phpunit/api/v4/AfformCustomFieldUsageTest.php
@@ -53,7 +53,6 @@ EOHTML;
       ->setLayoutFormat('shallow')
       ->setFormatWhitespace(TRUE)
       ->execute()->single();
-    $this->assertEquals(2, $block['repeat']);
     $this->assertEquals('afblock-custom-my-things', $block['directive_name']);
     $this->assertEquals('my_text', $block['layout'][0]['name']);
     $this->assertEquals('my_friend', $block['layout'][1]['name']);


### PR DESCRIPTION
Overview
----------------------------------------
Makes it possible to select a single location type for an address, email, phone etc. block instead of having the field on the form.

See https://lab.civicrm.org/dev/core/-/issues/2703

Before
----------------------------------------
Location type must be selected on the form.

After
----------------------------------------
The admin can make a block either repeatable, primary, or a specific location type. All options are mutually exclusive.

![Screenshot from 2021-08-25 15-44-59](https://user-images.githubusercontent.com/2874912/130854911-d0498e24-427e-46fe-bc06-368927b8475f.png)

Technical Details
----------------------------------------
This also improves the metadata for entities by creating an entity definition file for the join entities, and specifying each entity as type "primary" or "join".

Comments
--------------------
So far this still only supports one block per join per contact. So it's not yet possible to e.g. create 2 email blocks for home & work. Use the repeat option for that.