### PR TITLE
Fix invalid parameter giving E_WARNING

### DIFF
--- a/CRM/Core/Form/Task/PDFLetterCommon.php
+++ b/CRM/Core/Form/Task/PDFLetterCommon.php
@@ -55,7 +55,7 @@ class CRM_Core_Form_Task_PDFLetterCommon {
 
     // Added for core#2121,
     // To support sending a custom pdf filename before downloading.
-    $form->addElement('hidden', 'pdf_file_name', []);
+    $form->addElement('hidden', 'pdf_file_name');
 
     $form->addSelect('format_id', [
       'label' => ts('Select Format'),


### PR DESCRIPTION
Overview
----------------------------------------
The third param for a quickform hidden element needs to be null not an empty array if not passing in anything.

Before
----------------------------------------
1. Search for contacts.
2. Choose print/merge document 
3. Warning: htmlspecialchars() expects parameter 1 to be string, array given in HTML_Common->_getAttrString() (line 144 of ...civicrm/packages/HTML/Common.php).

After
----------------------------------------


Technical Details
----------------------------------------


Comments
----------------------------------------
This was just added yesterday
