### PR TITLE
HttpTestTrait - Allow one to easily authenticate subrequests

### DIFF
--- a/Civi/Test/HttpTestTrait.php
+++ b/Civi/Test/HttpTestTrait.php
@@ -34,11 +34,20 @@ trait HttpTestTrait {
   /**
    * Create an HTTP client suitable for simulating AJAX requests.
    *
+   * The client may include some mix of these middlewares:
+   *
+   * @see \CRM_Utils_GuzzleMiddleware::authx()
+   * @see \CRM_Utils_GuzzleMiddleware::url()
+   * @see \CRM_Utils_GuzzleMiddleware::curlLog()
+   * @see Middleware::history()
+   * @see Middleware::log()
+   *
    * @param array $options
    * @return \GuzzleHttp\Client
    */
   protected function createGuzzle($options = []) {
     $handler = HandlerStack::create();
+    $handler->unshift(\CRM_Utils_GuzzleMiddleware::authx(), 'civi_authx');
     $handler->unshift(\CRM_Utils_GuzzleMiddleware::url(), 'civi_url');
     $handler->push(Middleware::history($this->httpHistory), 'history');
 


### PR DESCRIPTION
Overview
----------------------------------------

Update `HttpTestTrait` to make it is easier for E2E tests to send authenticated requests on behalf of different users/contacts. 

Step towards #21249

Before
----------------------------------------

The test writer must determine a specific credential (e.g. username+password or api_key or JWT) and send it as part of the request.

After
----------------------------------------

The test writer may pass the option `authx_user` or `authx_contact_id` to Guzzle. This will be converted to a JWT so that the HTTP call includes authentication credentials. A few examples:

```php
// Add JWT credentials to every Guzzle request.
$http = $this->createGuzzle([
  'authx_user' =>  $GLOBALS['_CV']['DEMO_USER'],
]);
$response = $http->get('route://civicrm/dashboard');

// Add JWT credentials to a single request.
$http = $this->createGuzzle();
$response = $http->get('route://civicrm/dashboard', [
  'authx_user' =>  $GLOBALS['_CV']['ADMIN_USER'],
]);

// Perform a stateful login via JWT.
$http = $this->createGuzzle(['cookies' => new CookieJar()]);
$response = $http->get('route://civicrm/authx/login', [
  'authx_contact_id' => 100,
]);
```

Full list of options:

- `authx_ttl` (int): Seconds of validity for JWT's
- `authx_host` (string): Only send tokens for the given host. (Default per `CIVICRM_UF_BASEURL`)
- `authx_contact_id` (int): The CiviCRM contact to authenticate with
- `authx_user` (string): The CMS user to authenticate with
- `authx_flow` (string): How to format the auth token. One of: 'param', 'xheader', 'header'.
