### PR TITLE
[NFC] Do not generate a result cache file when running legacycustomse…

### DIFF
--- a/ext/legacycustomsearches/phpunit.xml.dist
+++ b/ext/legacycustomsearches/phpunit.xml.dist
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<phpunit backupGlobals="false" backupStaticAttributes="false" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" bootstrap="tests/phpunit/bootstrap.php">
+<phpunit backupGlobals="false" backupStaticAttributes="false" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" bootstrap="tests/phpunit/bootstrap.php" cacheResult="false">
   <testsuites>
     <testsuite name="Legacy custom searches">
       <directory>./tests/phpunit</directory>


### PR DESCRIPTION
…arches phpunit tests

Overview
----------------------------------------
This adds in a configuration setting so that when the unit tests for this extension are run in phpunit8 and above  a result cache file isn't created

Before
----------------------------------------
Result cache file is created in phpunit8 and above

After
----------------------------------------
No Result cache file

ping @eileenmcnaughton 
