### PR TITLE
(dev/translation#70) Multilingual - Fix loading multiple translations within same page-view (OptionValues, ContactTypes)

### DIFF
--- a/CRM/Contact/BAO/ContactType.php
+++ b/CRM/Contact/BAO/ContactType.php
@@ -863,7 +863,10 @@ WHERE ($subtypeClause)";
    * @throws \API_Exception
    */
   protected static function getAllContactTypes() {
-    if (!Civi::cache('contactTypes')->has('all')) {
+    $cache = Civi::cache('contactTypes');
+    $cacheKey = 'all_' . $GLOBALS['tsLocale'];
+    $contactTypes = $cache->get($cacheKey);
+    if ($contactTypes === NULL) {
       $contactTypes = (array) ContactType::get(FALSE)
         ->setSelect(['id', 'name', 'label', 'description', 'is_active', 'is_reserved', 'image_URL', 'parent_id', 'parent_id:name', 'parent_id:label'])
         ->execute()->indexBy('name');
@@ -873,9 +876,8 @@ WHERE ($subtypeClause)";
         $contactTypes[$id]['parent_label'] = $contactType['parent_id:label'];
         unset($contactTypes[$id]['parent_id:name'], $contactTypes[$id]['parent_id:label']);
       }
-      Civi::cache('contactTypes')->set('all', $contactTypes);
+      $cache->set($cacheKey, $contactTypes);
     }
-    $contactTypes = Civi::cache('contactTypes')->get('all');
     return $contactTypes;
   }
 

--- a/CRM/Core/OptionGroup.php
+++ b/CRM/Core/OptionGroup.php
@@ -107,10 +107,10 @@ class CRM_Core_OptionGroup {
   ) {
     $cache = CRM_Utils_Cache::singleton();
     if (in_array($name, self::$_domainIDGroups)) {
-      $cacheKey = self::createCacheKey($name, $flip, $grouping, $localize, $condition, $labelColumnName, $onlyActive, $keyColumnName, $orderBy, CRM_Core_Config::domainID());
+      $cacheKey = self::createCacheKey($name, CRM_Core_I18n::getLocale(), $flip, $grouping, $localize, $condition, $labelColumnName, $onlyActive, $keyColumnName, $orderBy, CRM_Core_Config::domainID());
     }
     else {
-      $cacheKey = self::createCacheKey($name, $flip, $grouping, $localize, $condition, $labelColumnName, $onlyActive, $keyColumnName, $orderBy);
+      $cacheKey = self::createCacheKey($name, CRM_Core_I18n::getLocale(), $flip, $grouping, $localize, $condition, $labelColumnName, $onlyActive, $keyColumnName, $orderBy);
     }
 
     if (!$fresh) {
@@ -181,7 +181,7 @@ WHERE  v.option_group_id = g.id
    * @param string $keyColumnName
    */
   protected static function flushValues($name, $flip, $grouping, $localize, $condition, $labelColumnName, $onlyActive, $keyColumnName = 'value') {
-    $cacheKey = self::createCacheKey($name, $flip, $grouping, $localize, $condition, $labelColumnName, $onlyActive, $keyColumnName);
+    $cacheKey = self::createCacheKey($name, CRM_Core_I18n::getLocale(), $flip, $grouping, $localize, $condition, $labelColumnName, $onlyActive, $keyColumnName);
     $cache = CRM_Utils_Cache::singleton();
     $cache->delete($cacheKey);
     unset(self::$_cache[$cacheKey]);
@@ -219,7 +219,7 @@ WHERE  v.option_group_id = g.id
    * @void
    */
   public static function &valuesByID($id, $flip = FALSE, $grouping = FALSE, $localize = FALSE, $labelColumnName = 'label', $onlyActive = TRUE, $fresh = FALSE) {
-    $cacheKey = self::createCacheKey($id, $flip, $grouping, $localize, $labelColumnName, $onlyActive);
+    $cacheKey = self::createCacheKey($id, CRM_Core_I18n::getLocale(), $flip, $grouping, $localize, $labelColumnName, $onlyActive);
 
     $cache = CRM_Utils_Cache::singleton();
     if (!$fresh) {

--- a/tests/phpunit/CRM/Core/I18n/LocaleTest.php
+++ b/tests/phpunit/CRM/Core/I18n/LocaleTest.php
@@ -82,6 +82,18 @@ class CRM_Core_I18n_LocaleTest extends CiviUnitTestCase {
       }
     }
 
+    \CRM_Core_DAO::executeQuery('UPDATE civicrm_option_value SET label_fr_CA = \'Planifié\' WHERE name = \'Scheduled\'',
+      [], TRUE, NULL, FALSE, FALSE);
+
+    // If you switch back and forth among these languages, labels should follow suit.
+    for ($trial = 0; $trial < 3; $trial++) {
+      \CRM_Core_I18n::singleton()->setLocale('en_US');
+      $this->assertEquals('Scheduled', \CRM_Core_PseudoConstant::getLabel("CRM_Activity_BAO_Activity", "status_id", 1));
+
+      \CRM_Core_I18n::singleton()->setLocale('fr_CA');
+      $this->assertEquals('Planifié', \CRM_Core_PseudoConstant::getLabel("CRM_Activity_BAO_Activity", "status_id", 1));
+    }
+
     CRM_Core_I18n::singleton()->setLocale('en_US');
     CRM_Core_I18n_Schema::makeSinglelingual('en_US');
     Civi::$statics['CRM_Core_I18n']['singleton'] = [];


### PR DESCRIPTION
Overview
----------------------------------------

Suppose you have a multilingual site where some of the option-labels have been translated (e.g. the `OptionValue` for "Scheduled"  could be "Planifié", "Programado", "Geplant").

Suppose you are running some batch/background operations which involve multiple locales.

The operation may need to lookup the labels within different locales.

```php
CRM_Core_I18n::singleton()->setLocale("fr_FR"); 
$av=CRM_Core_PseudoConstant::getLabel("CRM_Activity_BAO_Activity", "status_id", 1);
$al=CRM_Core_OptionGroup::values("activity_status");

CRM_Core_I18n::singleton()->setLocale("es_MX");
$bv=CRM_Core_PseudoConstant::getLabel("CRM_Activity_BAO_Activity", "status_id", 1); 
$bl=CRM_Core_OptionGroup::values("activity_status");;

return [$av, $al, $bv, $bl];
```

NOTE: I added in the fix for a related bug for `ContactType`s (https://lab.civicrm.org/dev/translation/-/issues/70) because the issue and the `r-run` process are both very similar.

Before
----------------------------------------

The first lookup (in `fr_FR`) creates a cache line which clashes with the second lookup (in `es_MX`).

After
----------------------------------------

The two lookups hit different caches.

Comments 
----------------------------------------

CC @eileenmcnaughton @mlutfy 

It's hard to be certain, but I feel like the existence of this bug would indicate that tokens like `{activity.status}` would not have been localized for scheduled-reminder recipients with different locales.