### PR TITLE
Remove deprecated isDevelopment() function

### DIFF
--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -1866,32 +1866,6 @@ class CRM_Utils_System {
   }
 
   /**
-   * @deprecated
-   * Determine whether this system is deployed using version control.
-   *
-   * Normally sites would tune their php error settings to prevent deprecation
-   * notices appearing on a live site. However, on some systems the user
-   * does not have control over this setting. Sites with version-controlled
-   * deployments are unlikely to be in a situation where they cannot alter their
-   * php error level reporting so we can trust that the are able to set them
-   * to suppress deprecation / php error level warnings if appropriate but
-   * in order to phase in deprecation warnings we originally chose not to
-   * show them on sites who might not be able to set their error_level in
-   * a way that is appropriate to their site.
-   *
-   * @return bool
-   */
-  public static function isDevelopment() {
-    CRM_Core_Error::deprecatedWarning('isDevelopment() is deprecated. Set your php error_reporting or MySQL settings appropriately instead.');
-    static $cache = NULL;
-    if ($cache === NULL) {
-      global $civicrm_root;
-      $cache = file_exists("{$civicrm_root}/.svn") || file_exists("{$civicrm_root}/.git");
-    }
-    return $cache;
-  }
-
-  /**
    * Is in upgrade mode.
    *
    * @return bool


### PR DESCRIPTION
Overview
----------------------------------------
`CRM_Utils_System::isDevelopment()` marked as deprecated and unused since 11 Jan 2021.

Before
----------------------------------------
Deprecated function.

After
----------------------------------------
Gone.

Technical Details
----------------------------------------


Comments
----------------------------------------
