### PR TITLE
Tidies Joomla 4 integration (menu, padding) after final release

### DIFF
--- a/css/joomla.css
+++ b/css/joomla.css
@@ -417,3 +417,21 @@ body.admin.com_civicrm.layout-default .crm-container .crm-dashlet {
 body.admin.com_civicrm.layout-default .crm-container .content {
 	padding: inherit; /* overrides J4 padding */
 }
+
+/* J4 Modals */
+
+body.admin.com_civicrm.layout-default .crm-container.ui-dialog.ui-resizable {
+	z-index: 1021;
+}
+
+body.admin.com_civicrm.layout-default .ui-widget-overlay {
+	z-index: 1;
+}
+
+body.admin.com_civicrm.layout-default .crm-container .modal-dialog {
+	max-width: inherit;
+	padding: 0;
+	margin: 0;
+	overflow: scroll;
+	pointer-events: all;
+}

--- a/css/joomla.css
+++ b/css/joomla.css
@@ -414,6 +414,10 @@ body.admin.com_civicrm.layout-default .crm-container .crm-dashlet {
 	max-width: 50vw; /* fixes over-wide news dashlet */ 
 }
 
+body.admin.com_civicrm.layout-default .crm-container .content {
+	padding: inherit; /* overrides J4 padding */
+}
+
 /* J4 Modals */
 
 body.admin.com_civicrm.layout-default .crm-container.ui-dialog.ui-resizable {

--- a/css/joomla.css
+++ b/css/joomla.css
@@ -414,10 +414,6 @@ body.admin.com_civicrm.layout-default .crm-container .crm-dashlet {
 	max-width: 50vw; /* fixes over-wide news dashlet */ 
 }
 
-body.admin.com_civicrm.layout-default .crm-container .content {
-	padding: inherit; /* overrides J4 padding */
-}
-
 /* J4 Modals */
 
 body.admin.com_civicrm.layout-default .crm-container.ui-dialog.ui-resizable {
@@ -435,3 +431,4 @@ body.admin.com_civicrm.layout-default .crm-container .modal-dialog {
 	overflow: scroll;
 	pointer-events: all;
 }
+

--- a/css/joomla.css
+++ b/css/joomla.css
@@ -402,14 +402,18 @@ body.ui-dialog-open #status {
 
 /* Joomla 4 */
 
-body.admin.com_civicrm.layout-default #content > .row > .col-md-12 {
+body.admin.com_civicrm.layout-default #content {
 	padding: 0;
 }
 
-body.admin.com_civicrm.layout-default #subhead {
+body.admin.com_civicrm.layout-default #subhead-container {
 	display: none;
 }
 
 body.admin.com_civicrm.layout-default .crm-container .crm-dashlet {
 	max-width: 50vw; /* fixes over-wide news dashlet */ 
+}
+
+body.admin.com_civicrm.layout-default .crm-container .content {
+	padding: inherit; /* overrides J4 padding */
 }

--- a/css/menubar-joomla.css
+++ b/css/menubar-joomla.css
@@ -42,7 +42,7 @@ body.admin.com_civicrm.layout-default #crm-qsearch label {
   }
 
   body.crm-menubar-below-cms-menu.layout-default > #civicrm-menu-nav #civicrm-menu {
-    top: 70px;
+    top: calc($menubarHeight + 26px);
     z-index: 1000;
     position: absolute;
 	  border-top: 1px solid #aaa;
@@ -60,23 +60,14 @@ body.admin.com_civicrm.layout-default #crm-qsearch label {
 @media (max-width: $breakMin) {
 
   body.com_civicrm.layout-default #header {
-    min-height: 45px;
-    padding: 10px 0;
     margin-bottom: $menubarHeight;
   }
 
   body.admin.com_civicrm.layout-default #civicrm-menu-nav {
-    margin-top: 45px;
+    margin-top: calc($menubarHeight + 14px);
     background: #1b1b1b;
     z-index: 1000;
     height: $menubarHeight;
     border-top: 1px solid #aaa;
   }
 }
-
-@media (max-width: 575px) {
-
-  body.admin.com_civicrm.layout-default #civicrm-menu-nav {
-  	margin-top: 77px;
-  }
-}	

--- a/css/menubar-joomla.css
+++ b/css/menubar-joomla.css
@@ -43,7 +43,7 @@ body.admin.com_civicrm.layout-default #crm-qsearch label {
 
   body.crm-menubar-below-cms-menu.layout-default > #civicrm-menu-nav #civicrm-menu {
     top: calc($menubarHeight + 26px);
-    z-index: 1000;
+    z-index: 10000;
     position: absolute;
 	  border-top: 1px solid #aaa;
   }


### PR DESCRIPTION
Overview
----------------------------------------
The final admin template for the Joomla 4 made some changes; this PR fixes the menubar being half-hidden at small viewports and misplaced at large, and removes some excess padding and empty region.

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/1175967/131035720-7064aeda-4eaf-4ea8-8cb6-3edbfca58336.png)
![image](https://user-images.githubusercontent.com/1175967/131035838-756b14d4-452a-459b-8a05-819872e5bcaa.png)

After
----------------------------------------
![image](https://user-images.githubusercontent.com/1175967/131035119-3fbd0ab8-34f8-45dd-95a6-36f7d74fa811.png)
![image](https://user-images.githubusercontent.com/1175967/131035601-e16d6bba-06b0-4b65-bc16-e25bb0639d2c.png)

Technical Details
----------------------------------------
The changes should impact Joomla 4 not Joomla 3.x, as the selectors are namespaced. While changing parts of the CSS related to the menubar height, I also adjusted them to reference $menubarHeight (taken here to be 40px).


Sidenote
----------------------------------------
I did see some other smaller issues with J4 but which aren't as quick fixes, so making a note of them here for future reference.
 - dropdown items at mobile viewports are max-widthed too narrow; no quick fix without using !important as the width is set inline;
 - the dropdown in the recent items sidebar list is oddly aligned; needs a bit of investigating in other CMSs as it's hard to see how J4 is causing this;
  - it's tempting to hide the sidebar at narrow viewports as it takes up half the screen or more, but that probably needs some discussion, also would be useful for J3 (and WordPress.