### PR TITLE
REF Don't check if id is set in ContributionView form - it's required

### DIFF
--- a/CRM/Contribute/Form/ContributionView.php
+++ b/CRM/Contribute/Form/ContributionView.php
@@ -25,6 +25,9 @@ class CRM_Contribute_Form_ContributionView extends CRM_Core_Form {
    */
   public function preProcess() {
     $id = $this->get('id');
+    if (empty($id)) {
+      throw new CRM_Core_Exception('Contribution ID is required');
+    }
     $params = ['id' => $id];
     $context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this);
     $this->assign('context', $context);
@@ -96,13 +99,11 @@ class CRM_Contribute_Form_ContributionView extends CRM_Core_Form {
     CRM_Core_BAO_CustomGroup::buildCustomDataView($this, $groupTree, FALSE, NULL, NULL, NULL, $id);
 
     $premiumId = NULL;
-    if ($id) {
-      $dao = new CRM_Contribute_DAO_ContributionProduct();
-      $dao->contribution_id = $id;
-      if ($dao->find(TRUE)) {
-        $premiumId = $dao->id;
-        $productID = $dao->product_id;
-      }
+    $dao = new CRM_Contribute_DAO_ContributionProduct();
+    $dao->contribution_id = $id;
+    if ($dao->find(TRUE)) {
+      $premiumId = $dao->id;
+      $productID = $dao->product_id;
     }
 
     if ($premiumId) {
@@ -139,27 +140,23 @@ class CRM_Contribute_Form_ContributionView extends CRM_Core_Form {
       $this->assign($name, $value);
     }
 
-    $lineItems = [];
-    $displayLineItems = FALSE;
-    if ($id) {
-      $lineItems = [CRM_Price_BAO_LineItem::getLineItemsByContributionID(($id))];
-      $firstLineItem = reset($lineItems[0]);
-      if (empty($firstLineItem['price_set_id'])) {
-        // CRM-20297 All we care is that it's not QuickConfig, so no price set
-        // is no problem.
-        $displayLineItems = TRUE;
+    $lineItems = [CRM_Price_BAO_LineItem::getLineItemsByContributionID(($id))];
+    $firstLineItem = reset($lineItems[0]);
+    if (empty($firstLineItem['price_set_id'])) {
+      // CRM-20297 All we care is that it's not QuickConfig, so no price set
+      // is no problem.
+      $displayLineItems = TRUE;
+    }
+    else {
+      try {
+        $priceSet = civicrm_api3('PriceSet', 'getsingle', [
+          'id' => $firstLineItem['price_set_id'],
+          'return' => 'is_quick_config, id',
+        ]);
+        $displayLineItems = !$priceSet['is_quick_config'];
       }
-      else {
-        try {
-          $priceSet = civicrm_api3('PriceSet', 'getsingle', [
-            'id' => $firstLineItem['price_set_id'],
-            'return' => 'is_quick_config, id',
-          ]);
-          $displayLineItems = !$priceSet['is_quick_config'];
-        }
-        catch (CiviCRM_API3_Exception $e) {
-          throw new CRM_Core_Exception('Cannot find price set by ID');
-        }
+      catch (CiviCRM_API3_Exception $e) {
+        throw new CRM_Core_Exception('Cannot find price set by ID');
       }
     }
     $this->assign('lineItem', $lineItems);
@@ -177,7 +174,7 @@ class CRM_Contribute_Form_ContributionView extends CRM_Core_Form {
     }
 
     // assign values to the template
-    $this->assign($values);
+    $this->assignVariables($values, array_keys($values));
     $invoicing = CRM_Invoicing_Utils::isInvoicingEnabled();
     $this->assign('invoicing', $invoicing);
     $this->assign('isDeferred', Civi::settings()->get('deferred_revenue_enabled'));


### PR DESCRIPTION
Overview
----------------------------------------
Following on from work by @jaapjansma around template contributions I'm looking to simplify the contribution view so it always displays "lineitems" - see https://github.com/civicrm/civicrm-core/compare/master...mattwire:contributionviewlineitems?expand=1

However, as a pre-requisite to that I found that `$id` is a required parameter to `preProcess()` but `if ($id)` is being used in some places in the function. This cleans that up, making it clear that `$id` is required and not doing additional checks to see if `$id` is set.

Before
----------------------------------------
Unnecessary checks. Unclear if `$id` is required without checking functions where it is a param.

After
----------------------------------------
`$id` is clearly always required.

Technical Details
----------------------------------------


Comments
----------------------------------------
Review with `w=1` in URL to hide whitespace changes.
