### PR TITLE
Fix token deprecation to be a check not an upgrade notice

### DIFF
--- a/CRM/Upgrade/Incremental/MessageTemplates.php
+++ b/CRM/Upgrade/Incremental/MessageTemplates.php
@@ -307,38 +307,6 @@ class CRM_Upgrade_Incremental_MessageTemplates {
   }
 
   /**
-   * Get warnings for users if the replaced string is still present.
-   *
-   * This might be the case when used in an IF and for now we will recommend
-   * manual intervention.
-   *
-   * @param string $workflowName
-   * @param string $old
-   * @param string $new
-   *
-   * @return string
-   */
-  public function getMessageTemplateWarning(string $workflowName, string $old, string $new) {
-    if (CRM_Core_DAO::singleValueQuery("
-      SELECT COUNT(*)
-      FROM civicrm_msg_template
-      WHERE workflow_name = '$workflowName'
-      AND (
-        msg_html LIKE '%$old%'
-        OR msg_subject LIKE '%$old%'
-        OR civicrm_msg_template.msg_text LIKE '%$old%'
-      )
-    ")) {
-      return ts('Please review your %1 message template and remove references to the token %2 as it has been replaced by %3', [
-        1 => $workflowName,
-        2 => '{' . $old . '}',
-        3 => '{' . $new . '}',
-      ]);
-    }
-    return '';
-  }
-
-  /**
    * Get the upgrade messages.
    */
   public function getUpgradeMessages() {

--- a/CRM/Upgrade/Incremental/php/FiveFortyOne.php
+++ b/CRM/Upgrade/Incremental/php/FiveFortyOne.php
@@ -42,16 +42,10 @@ class CRM_Upgrade_Incremental_php_FiveFortyOne extends CRM_Upgrade_Incremental_B
    * @param string $rev
    *   an intermediate version; note that setPostUpgradeMessage is called repeatedly with different $revs.
    */
-  public function setPostUpgradeMessage(&$postUpgradeMessage, $rev) {
-    $templateUpgrader = new CRM_Upgrade_Incremental_MessageTemplates($rev);
-    $upgradeMessage = $templateUpgrader->getMessageTemplateWarning('contribution_invoice_receipt', '$display_name', 'contact.display_name');
-    if (!empty($upgradeMessage)) {
-      $postUpgradeMessage .= '<ul><li>' . htmlspecialchars($upgradeMessage) . '</li></ul>';
+  public function setPostUpgradeMessage(&$postUpgradeMessage, $rev): void {
+    if ($rev === '5.41.alpha1') {
+      $postUpgradeMessage .= '<br /><br />' . ts('A token has been updated in the %1 template. Check the system checks page to see if any action is required.', [1 => 'invoice']);
     }
-    // Example: Generate a post-upgrade message.
-    // if ($rev == '5.12.34') {
-    //   $postUpgradeMessage .= '<br /><br />' . ts("By default, CiviCRM now disables the ability to import directly from SQL. To use this feature, you must explicitly grant permission 'import SQL datasource'.");
-    // }
   }
 
   /*

--- a/CRM/Utils/Check/Component/Tokens.php
+++ b/CRM/Utils/Check/Component/Tokens.php
@@ -1,0 +1,63 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+class CRM_Utils_Check_Component_Tokens extends CRM_Utils_Check_Component {
+
+  /**
+   * Check that deprecated and / or tokens no longer exist/
+   *
+   * @return CRM_Utils_Check_Message[]
+   */
+  public function checkTokens(): array {
+    $changes = CRM_Utils_Token::getTokenDeprecations();
+    $messages = $problems = [];
+    foreach ($changes['WorkFlowMessageTemplates'] as $workflowName => $workflowChanges) {
+      foreach ($workflowChanges as $old => $new) {
+        if (CRM_Core_DAO::singleValueQuery("
+          SELECT COUNT(*)
+          FROM civicrm_msg_template
+          WHERE workflow_name = '$workflowName'
+          AND (
+            msg_html LIKE '%$old%'
+            OR msg_subject LIKE '%$old%'
+            OR civicrm_msg_template.msg_text LIKE '%$old%'
+          )
+        ")) {
+          $problems[] = ts('Please review your %1 message template and remove references to the token %2 as it has been replaced by %3', [
+            1 => $workflowName,
+            2 => '{' . $old . '}',
+            3 => '{' . $new . '}',
+          ]);
+        }
+      }
+    }
+    if (!empty($problems)) {
+      $messages[] = new CRM_Utils_Check_Message(
+        __FUNCTION__ . md5(implode(',', $problems)),
+        '<p>' .
+        ts('You are using tokens that have been removed or deprecated.') .
+        '</p>' .
+        '<ul><li>' .
+        implode('</li><li>', $problems) .
+        '</li></ul></p>',
+        ts('Outdated tokens in use'),
+        \Psr\Log\LogLevel::WARNING
+      );
+    }
+    return $messages;
+  }
+
+}

--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -1930,4 +1930,19 @@ class CRM_Utils_Token {
     return $value;
   }
 
+  /**
+   * Get token deprecation information.
+   *
+   * @return array
+   */
+  public static function getTokenDeprecations(): array {
+    return [
+      'WorkFlowMessageTemplates' => [
+        'contribution_invoice_receipt' => [
+          '$display_name' => 'contact.display_name',
+        ],
+      ],
+    ];
+  }
+
 }

--- a/tests/phpunit/CRM/Upgrade/Incremental/BaseTest.php
+++ b/tests/phpunit/CRM/Upgrade/Incremental/BaseTest.php
@@ -51,8 +51,9 @@ class CRM_Upgrade_Incremental_BaseTest extends CiviUnitTestCase {
       'workflow_name', '=', 'contribution_invoice_receipt'
     )->execute();
     $upgrader = new CRM_Upgrade_Incremental_MessageTemplates('5.41.0');
-    $messages = $upgrader->getMessageTemplateWarning('contribution_invoice_receipt', '$display_name', 'contact.display_name');
-    $this->assertEquals('Please review your contribution_invoice_receipt message template and remove references to the token {$display_name} as it has been replaced by {contact.display_name}', $messages);
+    $check = new CRM_Utils_Check_Component_Tokens();
+    $message = $check->checkTokens()[0];
+    $this->assertEquals('<p>You are using tokens that have been removed or deprecated.</p><ul><li>Please review your contribution_invoice_receipt message template and remove references to the token {$display_name} as it has been replaced by {contact.display_name}</li></ul></p>', $message->getMessage());
     $upgrader->replaceTokenInTemplate('contribution_invoice_receipt', '$display_name', 'contact.display_name');
     $templates = MessageTemplate::get()->addSelect('msg_html')
       ->addWhere(
@@ -61,8 +62,8 @@ class CRM_Upgrade_Incremental_BaseTest extends CiviUnitTestCase {
     foreach ($templates as $template) {
       $this->assertEquals('{contact.display_name}', $template['msg_html']);
     }
-    $messages = $upgrader->getMessageTemplateWarning('contribution_invoice_receipt', '$display_name', 'contact.display_name');
-    $this->assertEquals('', $messages);
+    $messages = $check->checkTokens();
+    $this->assertEmpty($messages);
     $this->revertTemplateToReservedTemplate('contribution_invoice_receipt');
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Fix token deprecation to be a check not an upgrade notice 

Before
----------------------------------------
When a token is replaced & deprecated the upgrade script does a basic replacement - eg {$display_name} is replaced
by {contact.display_name) but then it tells the user to do the same replacement - even though it has been done.

The notification was intended to kick in in more complex scenarions like `{if $display_name === 'Bridget Jones'}Please diarise this{/if}` but was showing even in the simple, handled, scenarios

After
----------------------------------------
The upgrade notice is generic - the detail is provided by the system status check

![image](https://user-images.githubusercontent.com/336308/131056623-00de83f1-2009-413f-acfd-16435dbad4de.png)

Technical Details
----------------------------------------
It turns out the upgrade notice is calculated before the upgrade action runs
- this means that currently the upgrade notice is displayed even though
manual intervention will only be required in edge cases (since the
upgrade replaces the most common usage and it would require the
presence of an if or something like that for it to still exist).

Comments
----------------------------------------
This is the simplest version of this I could do since it only has one token to deal with - once we get over to master I'll rework this in conjunction with #21059