### PR TITLE
[REF] dev/core#2790 towards pdf task trait

### DIFF
--- a/CRM/Activity/Form/Task/PDF.php
+++ b/CRM/Activity/Form/Task/PDF.php
@@ -9,6 +9,8 @@
  +--------------------------------------------------------------------+
  */
 
+use Civi\Token\TokenProcessor;
+
 /**
  * This class provides the functionality to create PDF/Word letters for activities.
  */
@@ -19,9 +21,9 @@ class CRM_Activity_Form_Task_PDF extends CRM_Activity_Form_Task {
   /**
    * Build all the data structures needed to build the form.
    */
-  public function preProcess() {
+  public function preProcess(): void {
     parent::preProcess();
-    CRM_Activity_Form_Task_PDFLetterCommon::preProcess($this);
+    $this->setTitle('Print/Merge Document');
   }
 
   /**
@@ -35,14 +37,23 @@ class CRM_Activity_Form_Task_PDF extends CRM_Activity_Form_Task {
     // for them to block pdf.
     // @todo debug & fix....
     $this->add('select', 'document_type', ts('Document Type'), ['pdf' => ts('Portable Document Format (.pdf)')]);
-
   }
 
   /**
    * Process the form after the input has been submitted and validated.
    */
   public function postProcess() {
-    CRM_Activity_Form_Task_PDFLetterCommon::postProcess($this);
+    $form = $this;
+    $activityIds = $form->_activityHolderIds;
+    $formValues = $form->controller->exportValues($form->getName());
+    $html_message = CRM_Core_Form_Task_PDFLetterCommon::processTemplate($formValues);
+
+    // Do the rest in another function to make testing easier
+    $form->createDocument($activityIds, $html_message, $formValues);
+
+    $form->postProcessHook();
+
+    CRM_Utils_System::civiExit(1);
   }
 
   /**
@@ -51,7 +62,90 @@ class CRM_Activity_Form_Task_PDF extends CRM_Activity_Form_Task {
    * @return array
    */
   public function listTokens() {
-    return CRM_Activity_Form_Task_PDFLetterCommon::listTokens();
+    return $this->createTokenProcessor()->listTokens();
+  }
+
+  /**
+   * Create a token processor
+   *
+   * @return \Civi\Token\TokenProcessor
+   */
+  public function createTokenProcessor() {
+    return new TokenProcessor(\Civi::dispatcher(), [
+      'controller' => get_class(),
+      'smarty' => FALSE,
+      'schema' => ['activityId'],
+    ]);
+  }
+
+  /**
+   * Produce the document from the activities
+   * This uses the new token processor
+   *
+   * @param  array $activityIds  array of activity ids
+   * @param  string $html_message message text with tokens
+   * @param  array $formValues   formValues from the form
+   *
+   * @return array
+   */
+  public function createDocument($activityIds, $html_message, $formValues) {
+    $tp = $this->createTokenProcessor();
+    $tp->addMessage('body_html', $html_message, 'text/html');
+
+    foreach ($activityIds as $activityId) {
+      $tp->addRow()->context('activityId', $activityId);
+    }
+    $tp->evaluate();
+
+    return $this->renderFromRows($tp->getRows(), 'body_html', $formValues);
+  }
+
+  /**
+   * Render html from rows
+   *
+   * @param $rows
+   * @param string $msgPart
+   *   The name registered with the TokenProcessor
+   * @param array $formValues
+   *   The values submitted through the form
+   *
+   * @return string
+   *   If formValues['is_unit_test'] is true, otherwise outputs document to browser
+   */
+  public function renderFromRows($rows, $msgPart, $formValues) {
+    $html = [];
+    foreach ($rows as $row) {
+      $html[] = $row->render($msgPart);
+    }
+
+    if (!empty($formValues['is_unit_test'])) {
+      return $html;
+    }
+
+    if (!empty($html)) {
+      $this->outputFromHtml($formValues, $html);
+    }
+  }
+
+  /**
+   * Output the pdf or word document from the generated html.
+   *
+   * @param array $formValues
+   * @param array $html
+   */
+  protected function outputFromHtml($formValues, array $html) {
+    if (!empty($formValues['subject'])) {
+      $fileName = CRM_Utils_File::makeFilenameWithUnicode($formValues['subject'], '_', 200);
+    }
+    else {
+      $fileName = 'CiviLetter';
+    }
+    if ($formValues['document_type'] === 'pdf') {
+      CRM_Utils_PDF_Utils::html2pdf($html, $fileName . '.pdf', FALSE, $formValues);
+    }
+    else {
+      CRM_Utils_PDF_Document::html2doc($html, $fileName . '.' . $formValues['document_type'], $formValues);
+    }
   }
 
 }

--- a/CRM/Activity/Form/Task/PDFLetterCommon.php
+++ b/CRM/Activity/Form/Task/PDFLetterCommon.php
@@ -15,6 +15,7 @@ use Civi\Token\TokenProcessor;
  * This class provides the common functionality for creating PDF letter for
  * activities.
  *
+ * @deprecated
  */
 class CRM_Activity_Form_Task_PDFLetterCommon extends CRM_Core_Form_Task_PDFLetterCommon {
 
@@ -26,12 +27,13 @@ class CRM_Activity_Form_Task_PDFLetterCommon extends CRM_Core_Form_Task_PDFLette
    * @return void
    */
   public static function postProcess(&$form) {
+    CRM_Core_Error::deprecatedFunctionWarning('no alternative');
     $activityIds = $form->_activityHolderIds;
     $formValues = $form->controller->exportValues($form->getName());
-    $html_message = self::processTemplate($formValues);
+    $html_message = CRM_Core_Form_Task_PDFLetterCommon::processTemplate($formValues);
 
     // Do the rest in another function to make testing easier
-    self::createDocument($activityIds, $html_message, $formValues);
+    $form->createDocument($activityIds, $html_message, $formValues);
 
     $form->postProcessHook();
 
@@ -46,9 +48,12 @@ class CRM_Activity_Form_Task_PDFLetterCommon extends CRM_Core_Form_Task_PDFLette
    * @param  string $html_message message text with tokens
    * @param  array $formValues   formValues from the form
    *
+   * @deprecated
+   *
    * @return string
    */
   public static function createDocument($activityIds, $html_message, $formValues) {
+    CRM_Core_Error::deprecatedFunctionWarning('no alternative');
     $tp = self::createTokenProcessor();
     $tp->addMessage('body_html', $html_message, 'text/html');
 
@@ -63,9 +68,12 @@ class CRM_Activity_Form_Task_PDFLetterCommon extends CRM_Core_Form_Task_PDFLette
   /**
    * Create a token processor
    *
+   * @deprecated
+   *
    * @return \Civi\Token\TokenProcessor
    */
   public static function createTokenProcessor() {
+    CRM_Core_Error::deprecatedFunctionWarning('no alternative');
     return new TokenProcessor(\Civi::dispatcher(), [
       'controller' => get_class(),
       'smarty' => FALSE,

--- a/CRM/Core/Form/Task/PDFLetterCommon.php
+++ b/CRM/Core/Form/Task/PDFLetterCommon.php
@@ -346,10 +346,13 @@ class CRM_Core_Form_Task_PDFLetterCommon {
    * @param array $formValues
    *   The values submitted through the form
    *
+   * @deprecated
+   *
    * @return array
    *   If formValues['is_unit_test'] is true, otherwise outputs document to browser
    */
   public static function renderFromRows($rows, $msgPart, $formValues) {
+    CRM_Core_Error::deprecatedFunctionWarning('no alternative');
     $html = [];
     foreach ($rows as $row) {
       $html[] = $row->render($msgPart);
@@ -367,8 +370,11 @@ class CRM_Core_Form_Task_PDFLetterCommon {
   /**
    * List the available tokens
    * @return array of token name => label
+   *
+   * @deprecated
    */
   public static function listTokens() {
+    CRM_Core_Error::deprecatedFunctionWarning('no alternative');
     $class = get_called_class();
     if (method_exists($class, 'createTokenProcessor')) {
       return $class::createTokenProcessor()->listTokens();
@@ -378,11 +384,13 @@ class CRM_Core_Form_Task_PDFLetterCommon {
   /**
    * Output the pdf or word document from the generated html.
    *
+   * @deprecated
+   *
    * @param array $formValues
    * @param array $html
    */
   protected static function outputFromHtml($formValues, array $html) {
-
+    CRM_Core_Error::deprecatedFunctionWarning('no alternative');
     // Set the filename for the PDF using the Activity Subject, if defined. Remove unwanted characters and limit the length to 200 characters.
     if (!empty($formValues['subject'])) {
       $fileName = CRM_Utils_File::makeFilenameWithUnicode($formValues['subject'], '_', 200);
@@ -390,7 +398,6 @@ class CRM_Core_Form_Task_PDFLetterCommon {
     else {
       $fileName = 'CiviLetter';
     }
-
     if ($formValues['document_type'] === 'pdf') {
       CRM_Utils_PDF_Utils::html2pdf($html, $fileName . '.pdf', FALSE, $formValues);
     }

--- a/tests/phpunit/CRM/Activity/Form/Task/PDFLetterCommonTest.php
+++ b/tests/phpunit/CRM/Activity/Form/Task/PDFLetterCommonTest.php
@@ -35,7 +35,8 @@ class CRM_Activity_Form_Task_PDFLetterCommonTest extends CiviUnitTestCase {
       ['Activity ID: {activity.activity_id}', 'Activity ID: ' . $activity['id']],
     ];
     $html_message = "\n" . implode("\n", CRM_Utils_Array::collect('0', $data)) . "\n";
-    $output = CRM_Activity_Form_Task_PDFLetterCommon::createDocument([$activity['id']], $html_message, ['is_unit_test' => TRUE]);
+    $form = $this->getFormObject('CRM_Activity_Form_Task_PDF');
+    $output = $form->createDocument([$activity['id']], $html_message, ['is_unit_test' => TRUE]);
 
     // Check some basic fields
     foreach ($data as $line) {
@@ -58,7 +59,8 @@ class CRM_Activity_Form_Task_PDFLetterCommonTest extends CiviUnitTestCase {
 
     $html_message = "Custom: {activity.$cf}";
     $activityIds = CRM_Utils_Array::collect('id', $activities);
-    $output = CRM_Activity_Form_Task_PDFLetterCommon::createDocument($activityIds, $html_message, ['is_unit_test' => TRUE]);
+    $form = $this->getFormObject('CRM_Activity_Form_Task_PDF');
+    $output = $form->createDocument($activityIds, $html_message, ['is_unit_test' => TRUE]);
     // Should have one row of output per activity
     $this->assertCount(count($activities), $output);
 
@@ -89,7 +91,8 @@ class CRM_Activity_Form_Task_PDFLetterCommonTest extends CiviUnitTestCase {
       ['Target Count: {activity.targets_count}', "Target Count: 1"],
     ];
     $html_message = "\n" . implode("\n", CRM_Utils_Array::collect('0', $data)) . "\n";
-    $output = CRM_Activity_Form_Task_PDFLetterCommon::createDocument([$activity['id']], $html_message, ['is_unit_test' => TRUE]);
+    $form = $this->getFormObject('CRM_Activity_Form_Task_PDF');
+    $output = $form->createDocument([$activity['id']], $html_message, ['is_unit_test' => TRUE]);
 
     foreach ($data as $line) {
       $this->assertContains("\n" . $line[1] . "\n", $output[0]);
@@ -103,7 +106,8 @@ class CRM_Activity_Form_Task_PDFLetterCommonTest extends CiviUnitTestCase {
   public function testCreateDocumentUnknownTokens(): void {
     $activity = $this->activityCreate();
     $html_message = 'Unknown token: {activity.something_unknown}';
-    $output = CRM_Activity_Form_Task_PDFLetterCommon::createDocument([$activity['id']], $html_message, ['is_unit_test' => TRUE]);
+    $form = $this->getFormObject('CRM_Activity_Form_Task_PDF');
+    $output = $form->createDocument([$activity['id']], $html_message, ['is_unit_test' => TRUE]);
     // Unknown tokens should be left alone
     $this->assertEquals($html_message, $output[0]);
   }


### PR DESCRIPTION
Overview
----------------------------------------
Deprecate CRM_Activity_Form_Task_PDFLetterCommon

https://lab.civicrm.org/dev/core/-/issues/2790


Before
----------------------------------------
3 classes in play to render the activity pdf form - as a quasi OO

After
----------------------------------------
Down to 2

Technical Details
----------------------------------------

This gets us to having 2 classes rather than 3 that manage the activityPDF task
functionality.

CRM_Activity_Form_Task_PDFLetterCommon doesn't really add anything from a structure POV
but it does make it more confusing. There are also functions on the parent
that are only used by this class - which makes switching to a trait
harder. This untangles that part.

Note that once we have the trait (& some more token cleanup done) we will be well placed
to share some of these functions so that they are actually used by more than one class

Comments
----------------------------------------

