### PR TITLE
Simplify ContributionView form. Always display "lineitems"

### DIFF
--- a/CRM/Contribute/Form/ContributionView.php
+++ b/CRM/Contribute/Form/ContributionView.php
@@ -141,26 +141,7 @@ class CRM_Contribute_Form_ContributionView extends CRM_Core_Form {
     }
 
     $lineItems = [CRM_Price_BAO_LineItem::getLineItemsByContributionID(($id))];
-    $firstLineItem = reset($lineItems[0]);
-    if (empty($firstLineItem['price_set_id'])) {
-      // CRM-20297 All we care is that it's not QuickConfig, so no price set
-      // is no problem.
-      $displayLineItems = TRUE;
-    }
-    else {
-      try {
-        $priceSet = civicrm_api3('PriceSet', 'getsingle', [
-          'id' => $firstLineItem['price_set_id'],
-          'return' => 'is_quick_config, id',
-        ]);
-        $displayLineItems = !$priceSet['is_quick_config'];
-      }
-      catch (CiviCRM_API3_Exception $e) {
-        throw new CRM_Core_Exception('Cannot find price set by ID');
-      }
-    }
     $this->assign('lineItem', $lineItems);
-    $this->assign('displayLineItems', $displayLineItems);
     $values['totalAmount'] = $values['total_amount'];
     $this->assign('displayLineItemFinancialType', TRUE);
 

--- a/templates/CRM/Contribute/Form/ContributionView.tpl
+++ b/templates/CRM/Contribute/Form/ContributionView.tpl
@@ -75,33 +75,18 @@
     <td>{if $receive_date}{$receive_date|crmDate}{else}({ts}not available{/ts}){/if}</td>
   </tr>
   {/if}
-  {if $displayLineItems}
-    <tr>
-      <td class="label">{ts}Contribution Amount{/ts}</td>
-      <td>{include file="CRM/Price/Page/LineItem.tpl" context="Contribution"}
+  <tr>
+    <td class="label">{ts}Contribution Amount{/ts}</td>
+    <td>{include file="CRM/Price/Page/LineItem.tpl" context="Contribution"}
         {if $contribution_recur_id}
           <a class="open-inline action-item crm-hover-button" href='{crmURL p="civicrm/contact/view/contributionrecur" q="reset=1&id=`$contribution_recur_id`&cid=`$contact_id`&context=contribution"}'>
-            {ts}View Recurring Contribution{/ts}
+              {ts}View Recurring Contribution{/ts}
           </a>
           <br/>
-          {ts}Installments{/ts}: {if $recur_installments}{$recur_installments}{else}{ts}(ongoing){/ts}{/if}, {ts}Interval{/ts}: {$recur_frequency_interval} {$recur_frequency_unit}(s)
+            {ts}Installments{/ts}: {if $recur_installments}{$recur_installments}{else}{ts}(ongoing){/ts}{/if}, {ts}Interval{/ts}: {$recur_frequency_interval} {$recur_frequency_unit}(s)
         {/if}
-      </td>
-    </tr>
-  {else}
-    <tr>
-      <td class="label">{ts}Total Amount{/ts}</td>
-      <td><strong>{$total_amount|crmMoney:$currency}</strong>
-        {if $contribution_recur_id}
-          <a class="open-inline action-item crm-hover-button" href='{crmURL p="civicrm/contact/view/contributionrecur" q="reset=1&id=`$contribution_recur_id`&cid=`$contact_id`&context=contribution"}'>
-            {ts}View Recurring Contribution{/ts}
-          </a>
-          <br/>
-          {ts}Installments{/ts}: {if $recur_installments}{$recur_installments}{else}{ts}(ongoing){/ts}{/if}, {ts}Interval{/ts}: {$recur_frequency_interval} {$recur_frequency_unit}(s)
-        {/if}
-      </td>
-    </tr>
-  {/if}
+    </td>
+  </tr>
   {if $invoicing && $tax_amount}
     <tr>
       <td class="label">{ts 1=$taxTerm}Total %1 Amount{/ts}</td>


### PR DESCRIPTION
Overview
----------------------------------------
If we are using "quickconfig" the form does not display lineitems. Quickconfig is when adding amounts via a contributionpage without a priceset but it is still using pricesets/lineitems internally so there are always lineitems.

This was identified during @jaapjansma work on template contributions and I believe the reason for the two ways to display is just historical - ie. one was there already and when lineitems/quickconfig came along the other got added on but without removing the old way. This is quite a common source of confusion because it causes the detail of a contribution to be displayed in a different way.

Before
----------------------------------------
Two ways that "lineitems" can be shown.

![image](https://user-images.githubusercontent.com/2052161/131106496-fa964e7b-e2c5-4bbb-8ded-9bade1522e9e.png)

After
----------------------------------------
Just one standard way. Simpler form.

![image](https://user-images.githubusercontent.com/2052161/131106678-54a8f7f0-c287-448b-a46d-4bf4f132547c.png)

Technical Details
----------------------------------------


Comments
----------------------------------------
