### PR TITLE
Fixes unusable modals in Joomla 4

### DIFF
--- a/css/joomla.css
+++ b/css/joomla.css
@@ -413,3 +413,22 @@ body.admin.com_civicrm.layout-default #subhead {
 body.admin.com_civicrm.layout-default .crm-container .crm-dashlet {
 	max-width: 50vw; /* fixes over-wide news dashlet */ 
 }
+
+/* J4 Modals */
+
+body.admin.com_civicrm.layout-default .crm-container.ui-dialog.ui-resizable {
+	z-index: 1021;
+}
+
+body.admin.com_civicrm.layout-default .ui-widget-overlay {
+	z-index: 1;
+}
+
+body.admin.com_civicrm.layout-default .crm-container .modal-dialog {
+	max-width: inherit;
+	padding: 0;
+	margin: 0;
+	overflow: scroll;
+	pointer-events: all;
+}
+


### PR DESCRIPTION
Overview
----------------------------------------
As described here: https://lab.civicrm.org/dev/joomla/-/issues/19 - J4 Civi modals had a number of issues making them unusable. For admin/backend Civi pages, this puts the tinted overlay behind the modal and brings the modal in front of the menubar. It makes the modal clickable, removes the narrow width and ensures scrolling.

Before
----------------------------------------
<img width="1638" alt="image" src="https://user-images.githubusercontent.com/1175967/131116313-28379b34-81db-44c6-bd1f-fdb117ca2f2d.png">

After
----------------------------------------
<img width="1623" alt="image" src="https://user-images.githubusercontent.com/1175967/131116198-de768e21-107c-4dbc-9ee3-5cad38d60fb6.png">

Technical Details
----------------------------------------
Namespaced to only target Joomla 4 admin template.