### PR TITLE
dev/core#2786 Ensure non-English installs have a default financial type for membership default price set

### DIFF
--- a/xml/templates/civicrm_data.tpl
+++ b/xml/templates/civicrm_data.tpl
@@ -1746,10 +1746,9 @@ VALUES
 
 -- CRM-9714
 
-SELECT @financial_type_id := max(id) FROM `civicrm_financial_type` WHERE `name` = 'Member Dues';
 INSERT INTO `civicrm_price_set` ( `name`, `title`, `is_active`, `extends`, `is_quick_config`, `financial_type_id`, `is_reserved` )
 VALUES ( 'default_contribution_amount', 'Contribution Amount', '1', '2', '1', NULL,1),
-( 'default_membership_type_amount', 'Membership Amount', '1', '3', '1', @financial_type_id,1);
+( 'default_membership_type_amount', 'Membership Amount', '1', '3', '1', @financial_type_id_md,1);
 
 SELECT @setID := max(id) FROM civicrm_price_set WHERE name = 'default_contribution_amount' AND extends = 2 AND is_quick_config = 1 ;
 


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#2786 Ensure non-English installs have a default financial type for membership default price set

Before
----------------------------------------
Per analysis from @demeritcowboy  on https://lab.civicrm.org/dev/core/-/issues/2786 - international installs may be missing price_set.financial_type_id for the default membershp price set

After
----------------------------------------
Should be fixed

Technical Details
----------------------------------------

Comments
----------------------------------------
