### PR TITLE
Fix for new prefetch key

### DIFF
--- a/CRM/Core/EntityTokens.php
+++ b/CRM/Core/EntityTokens.php
@@ -196,8 +196,9 @@ class CRM_Core_EntityTokens extends AbstractTokenSubscriber {
     $return = [];
     foreach (array_keys($this->getBasicTokens()) as $fieldName) {
       if ($this->isAddPseudoTokens($fieldName)) {
-        $return[$fieldName . ':label'] = $this->fieldMetadata[$fieldName]['input_attrs']['label'];
-        $return[$fieldName . ':name'] = ts('Machine name') . ': ' . $this->fieldMetadata[$fieldName]['input_attrs']['label'];
+        $fieldLabel = $this->fieldMetadata[$fieldName]['input_attrs']['label'] ?? $this->fieldMetadata[$fieldName]['label'];
+        $return[$fieldName . ':label'] = $fieldLabel;
+        $return[$fieldName . ':name'] = ts('Machine name') . ': ' . $fieldLabel;
       }
     }
     return $return;
@@ -229,7 +230,7 @@ class CRM_Core_EntityTokens extends AbstractTokenSubscriber {
       // v4 style custom tokens - but medium term this IF will probably go.
       return FALSE;
     }
-    return (bool) $this->getFieldMetadata()[$fieldName]['options'];
+    return (bool) ($this->getFieldMetadata()[$fieldName]['options'] || !empty($this->getFieldMetadata()[$fieldName]['suffixes']));
   }
 
   /**

--- a/Civi/Api4/Service/Spec/SpecFormatter.php
+++ b/Civi/Api4/Service/Spec/SpecFormatter.php
@@ -61,7 +61,7 @@ class SpecFormatter {
       $field->setLabel($data['html']['label'] ?? NULL);
       if (!empty($data['pseudoconstant'])) {
         // Do not load options if 'prefetch' is explicitly FALSE
-        if ($data['pseudoconstant']['prefetch'] ?? TRUE) {
+        if (!isset($data['pseudoconstant']['prefetch']) || $data['pseudoconstant']['prefetch'] === FALSE) {
           $field->setOptionsCallback([__CLASS__, 'getOptions']);
         }
         // These suffixes are always supported if a field has options

--- a/tests/phpunit/api/v4/Action/GetFieldsTest.php
+++ b/tests/phpunit/api/v4/Action/GetFieldsTest.php
@@ -20,6 +20,7 @@
 namespace api\v4\Action;
 
 use api\v4\UnitTestCase;
+use Civi\Api4\Campaign;
 use Civi\Api4\Contact;
 use Civi\Api4\Contribution;
 
@@ -82,6 +83,7 @@ class GetFieldsTest extends UnitTestCase {
   public function testPreloadFalse() {
     \CRM_Core_BAO_ConfigSetting::enableComponent('CiviContribute');
     \CRM_Core_BAO_ConfigSetting::enableComponent('CiviCampaign');
+    Campaign::create()->setValues(['name' => 'Big Campaign', 'title' => 'Biggie'])->execute();
     // The campaign_id field has preload = false in the schema,
     // Which means the options will NOT load but suffixes are still available
     $fields = Contribution::getFields(FALSE)


### PR DESCRIPTION



Overview
----------------------------------------
Fixes a bug in
https://github.com/civicrm/civicrm-core/pull/21184
which was masked in the test by the lack of campaigns to load.

Before
----------------------------------------
Options still loaded when 'prefetch' is set to FALSE

After
----------------------------------------
Options not loaded

Technical Details
----------------------------------------
The ?? operator handles FALSE differently to the ?: operator
so this was casting FALSE to TRUE

Comments
----------------------------------------
@colemanw 
