### PR TITLE
[REF] dev/core#2790 move buildForm to pdfTrait

### DIFF
--- a/CRM/Activity/Form/Task/PDF.php
+++ b/CRM/Activity/Form/Task/PDF.php
@@ -26,9 +26,11 @@ class CRM_Activity_Form_Task_PDF extends CRM_Activity_Form_Task {
 
   /**
    * Build the form object.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function buildQuickForm() {
-    CRM_Activity_Form_Task_PDFLetterCommon::buildQuickForm($this);
+    $this->addPDFElementsToForm();
     // Remove types other than pdf as they are not working (have never worked) and don't want fix
     // for them to block pdf.
     // @todo debug & fix....

--- a/CRM/Case/Form/Task/PDF.php
+++ b/CRM/Case/Form/Task/PDF.php
@@ -44,13 +44,6 @@ class CRM_Case_Form_Task_PDF extends CRM_Case_Form_Task {
   }
 
   /**
-   * Build the form object.
-   */
-  public function buildQuickForm() {
-    CRM_Contact_Form_Task_PDFLetterCommon::buildQuickForm($this);
-  }
-
-  /**
    * Process the form after the input has been submitted and validated.
    */
   public function postProcess() {

--- a/CRM/Contact/Form/Task/PDF.php
+++ b/CRM/Contact/Form/Task/PDF.php
@@ -89,7 +89,7 @@ class CRM_Contact_Form_Task_PDF extends CRM_Contact_Form_Task {
   public function buildQuickForm() {
     //enable form element
     $this->assign('suppressForm', FALSE);
-    CRM_Contact_Form_Task_PDFLetterCommon::buildQuickForm($this);
+    $this->addPDFElementsToForm();
   }
 
   /**

--- a/CRM/Contact/Form/Task/PDFTrait.php
+++ b/CRM/Contact/Form/Task/PDFTrait.php
@@ -38,4 +38,149 @@ trait CRM_Contact_Form_Task_PDFTrait {
     return $defaultFormat;
   }
 
+  /**
+   * Build the form object.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function buildQuickForm(): void {
+    $this->addPDFElementsToForm();
+  }
+
+  /**
+   * Build the form object.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function addPDFElementsToForm(): void {
+    $form = $this;
+    // This form outputs a file so should never be submitted via ajax
+    $form->preventAjaxSubmit();
+
+    //Added for CRM-12682: Add activity subject and campaign fields
+    CRM_Campaign_BAO_Campaign::addCampaign($form);
+    $form->add(
+      'text',
+      'subject',
+      ts('Activity Subject'),
+      ['size' => 45, 'maxlength' => 255],
+      FALSE
+    );
+
+    // Added for core#2121,
+    // To support sending a custom pdf filename before downloading.
+    $form->addElement('hidden', 'pdf_file_name');
+
+    $form->addSelect('format_id', [
+      'label' => ts('Select Format'),
+      'placeholder' => ts('Default'),
+      'entity' => 'message_template',
+      'field' => 'pdf_format_id',
+      'option_url' => 'civicrm/admin/pdfFormats',
+    ]);
+    $form->add(
+      'select',
+      'paper_size',
+      ts('Paper Size'),
+      [0 => ts('- default -')] + CRM_Core_BAO_PaperSize::getList(TRUE),
+      FALSE,
+      ['onChange' => "selectPaper( this.value ); showUpdateFormatChkBox();"]
+    );
+    $form->add(
+      'select',
+      'orientation',
+      ts('Orientation'),
+      CRM_Core_BAO_PdfFormat::getPageOrientations(),
+      FALSE,
+      ['onChange' => "updatePaperDimensions(); showUpdateFormatChkBox();"]
+    );
+    $form->add(
+      'select',
+      'metric',
+      ts('Unit of Measure'),
+      CRM_Core_BAO_PdfFormat::getUnits(),
+      FALSE,
+      ['onChange' => "selectMetric( this.value );"]
+    );
+    $form->add(
+      'text',
+      'margin_left',
+      ts('Left Margin'),
+      ['size' => 8, 'maxlength' => 8, 'onkeyup' => "showUpdateFormatChkBox();"],
+      TRUE
+    );
+    $form->add(
+      'text',
+      'margin_right',
+      ts('Right Margin'),
+      ['size' => 8, 'maxlength' => 8, 'onkeyup' => "showUpdateFormatChkBox();"],
+      TRUE
+    );
+    $form->add(
+      'text',
+      'margin_top',
+      ts('Top Margin'),
+      ['size' => 8, 'maxlength' => 8, 'onkeyup' => "showUpdateFormatChkBox();"],
+      TRUE
+    );
+    $form->add(
+      'text',
+      'margin_bottom',
+      ts('Bottom Margin'),
+      ['size' => 8, 'maxlength' => 8, 'onkeyup' => "showUpdateFormatChkBox();"],
+      TRUE
+    );
+
+    $config = CRM_Core_Config::singleton();
+    /** CRM-15883 Suppressing Stationery path field until we switch from DOMPDF to a library that supports it.
+     * if ($config->wkhtmltopdfPath == FALSE) {
+     * $form->add(
+     * 'text',
+     * 'stationery',
+     * ts('Stationery (relative path to PDF you wish to use as the background)'),
+     * array('size' => 25, 'maxlength' => 900, 'onkeyup' => "showUpdateFormatChkBox();"),
+     * FALSE
+     * );
+     * }
+     */
+    $form->add('checkbox', 'bind_format', ts('Always use this Page Format with the selected Template'));
+    $form->add('checkbox', 'update_format', ts('Update Page Format (this will affect all templates that use this format)'));
+
+    $form->assign('useThisPageFormat', ts('Always use this Page Format with the new template?'));
+    $form->assign('useSelectedPageFormat', ts('Should the new template always use the selected Page Format?'));
+    $form->assign('totalSelectedContacts', !is_null($form->_contactIds) ? count($form->_contactIds) : 0);
+
+    $form->add('select', 'document_type', ts('Document Type'), CRM_Core_SelectValues::documentFormat());
+
+    $documentTypes = implode(',', CRM_Core_SelectValues::documentApplicationType());
+    $form->addElement('file', "document_file", 'Upload Document', 'size=30 maxlength=255 accept="' . $documentTypes . '"');
+    $form->addUploadElement("document_file");
+
+    CRM_Mailing_BAO_Mailing::commonCompose($form);
+
+    $buttons = [];
+    if ($form->get('action') != CRM_Core_Action::VIEW) {
+      $buttons[] = [
+        'type' => 'upload',
+        'name' => ts('Download Document'),
+        'isDefault' => TRUE,
+        'icon' => 'fa-download',
+      ];
+      $buttons[] = [
+        'type' => 'submit',
+        'name' => ts('Preview'),
+        'subName' => 'preview',
+        'icon' => 'fa-search',
+        'isDefault' => FALSE,
+      ];
+    }
+    $buttons[] = [
+      'type' => 'cancel',
+      'name' => $form->get('action') == CRM_Core_Action::VIEW ? ts('Done') : ts('Cancel'),
+    ];
+    $form->addButtons($buttons);
+
+    $form->addFormRule(['CRM_Core_Form_Task_PDFLetterCommon', 'formRule'], $form);
+  }
+
 }

--- a/CRM/Contribute/Form/Task/PDFLetter.php
+++ b/CRM/Contribute/Form/Task/PDFLetter.php
@@ -71,6 +71,8 @@ class CRM_Contribute_Form_Task_PDFLetter extends CRM_Contribute_Form_Task {
 
   /**
    * Build the form object.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function buildQuickForm() {
     //enable form element
@@ -82,7 +84,7 @@ class CRM_Contribute_Form_Task_PDFLetter extends CRM_Contribute_Form_Task {
 
     // Contribute PDF tasks allow you to email as well, so we need to add email address to those forms
     $this->add('select', 'from_email_address', ts('From Email Address'), $this->_fromEmails, TRUE);
-    CRM_Core_Form_Task_PDFLetterCommon::buildQuickForm($this);
+    $this->addPDFElementsToForm();
 
     // specific need for contributions
     $this->add('static', 'more_options_header', NULL, ts('Thank-you Letter Options'));

--- a/CRM/Core/Form/Task/PDFLetterCommon.php
+++ b/CRM/Core/Form/Task/PDFLetterCommon.php
@@ -36,10 +36,13 @@ class CRM_Core_Form_Task_PDFLetterCommon {
   /**
    * Build the form object.
    *
+   * @deprecated
+   *
    * @var CRM_Core_Form $form
    * @throws \CRM_Core_Exception
    */
   public static function buildQuickForm(&$form) {
+    CRM_Core_Error::deprecatedFunctionWarning('no supported alternative for non-core code');
     // This form outputs a file so should never be submitted via ajax
     $form->preventAjaxSubmit();
 

--- a/CRM/Event/Form/Task/PDF.php
+++ b/CRM/Event/Form/Task/PDF.php
@@ -56,13 +56,6 @@ class CRM_Event_Form_Task_PDF extends CRM_Event_Form_Task {
   }
 
   /**
-   * Build the form object.
-   */
-  public function buildQuickForm() {
-    CRM_Contact_Form_Task_PDFLetterCommon::buildQuickForm($this);
-  }
-
-  /**
    * Process the form after the input has been submitted and validated.
    */
   public function postProcess() {

--- a/CRM/Member/Form/Task/PDFLetter.php
+++ b/CRM/Member/Form/Task/PDFLetter.php
@@ -21,6 +21,8 @@
  */
 class CRM_Member_Form_Task_PDFLetter extends CRM_Member_Form_Task {
 
+  use CRM_Contact_Form_Task_PDFTrait;
+
   /**
    * All the existing templates in the system.
    *
@@ -49,11 +51,12 @@ class CRM_Member_Form_Task_PDFLetter extends CRM_Member_Form_Task {
    *
    *
    * @return void
+   * @throws \CRM_Core_Exception
    */
   public function buildQuickForm() {
     //enable form element
     $this->assign('suppressForm', FALSE);
-    CRM_Contact_Form_Task_PDFLetterCommon::buildQuickForm($this);
+    $this->addPDFElementsToForm();
   }
 
   /**


### PR DESCRIPTION


Overview
----------------------------------------
[REF] dev/core#2790 move buildForm to pdfTrait

Before
----------------------------------------
Function is on static class that is under deprecation

After
----------------------------------------
Function moved to a trait

Technical Details
----------------------------------------
This moves the buildForm function over the pdfTrait

I note that some of the functions have

I wonder if they all should  - I suspect so

Comments
----------------------------------------
