### PR TITLE
[NFC] Fix APIv4 Conformance tests on php8

### DIFF
--- a/tests/phpunit/api/v4/DataSets/ConformanceTest.json
+++ b/tests/phpunit/api/v4/DataSets/ConformanceTest.json
@@ -105,6 +105,29 @@
       "name": "General"
     }
   ],
+  "MembershipType": [
+    {
+      "domain_id": "1",
+      "name": "General",
+      "description": "Regular annual membership.",
+      "member_of_contact_id": "1",
+      "financial_type_id": "2",
+      "minimum_fee": "100.000000000",
+      "duration_unit": "year",
+      "duration_interval": "2",
+      "period_type": "rolling",
+      "relationship_type_id": [
+        "7"
+      ],
+      "relationship_direction": [
+        "b_a"
+      ],
+      "visibility": "Public",
+      "weight": "1",
+      "auto_renew": "0",
+      "is_active": "1"
+    }
+  ],
   "Membership": [
     {
       "membership_type_id:name": "General",


### PR DESCRIPTION
Overview
----------------------------------------
This aims to fix the following test failure when the conformance tests are run on php8

```
api\v4\Entity\ConformanceTest::testConformance with data set "ACL" ('ACL')
Trying to access array offset on value of type null

/home/jenkins/bknix-max/build/build-0/web/sites/all/modules/civicrm/CRM/Member/BAO/MembershipType.php:393
/home/jenkins/bknix-max/build/build-0/web/sites/all/modules/civicrm/CRM/Member/BAO/Membership.php:286
```

Before
----------------------------------------
Conformance tests fail on php8 as no MembershipType is present in the database

After
----------------------------------------
Tests pass

ping @eileenmcnaughton 