### PR TITLE
[REF] dev/core#2790 Deprecate CRM/Member/Form/Task/PDFLetterCommon

### DIFF
--- a/CRM/Member/Form/Task/PDFLetter.php
+++ b/CRM/Member/Form/Task/PDFLetter.php
@@ -67,9 +67,96 @@ class CRM_Member_Form_Task_PDFLetter extends CRM_Member_Form_Task {
     $this->setContactIDs();
     $skipOnHold = $this->skipOnHold ?? FALSE;
     $skipDeceased = $this->skipDeceased ?? TRUE;
-    CRM_Member_Form_Task_PDFLetterCommon::postProcessMembers(
+    self::postProcessMembers(
       $this, $this->_memberIds, $skipOnHold, $skipDeceased, $this->_contactIds
     );
+  }
+
+  /**
+   * Process the form after the input has been submitted and validated.
+   * @todo this is horrible copy & paste code because there is so much risk of breakage
+   * in fixing the existing pdfLetter classes to be suitably generic
+   *
+   * @param CRM_Core_Form $form
+   * @param $membershipIDs
+   * @param $skipOnHold
+   * @param $skipDeceased
+   * @param $contactIDs
+   */
+  public static function postProcessMembers(&$form, $membershipIDs, $skipOnHold, $skipDeceased, $contactIDs) {
+    $formValues = $form->controller->exportValues($form->getName());
+    list($formValues, $categories, $html_message, $messageToken, $returnProperties) = CRM_Contact_Form_Task_PDFLetterCommon::processMessageTemplate($formValues);
+
+    $html
+      = self::generateHTML(
+      $membershipIDs,
+      $returnProperties,
+      $skipOnHold,
+      $skipDeceased,
+      $messageToken,
+      $html_message,
+      $categories
+    );
+    CRM_Contact_Form_Task_PDFLetterCommon::createActivities($form, $html_message, $contactIDs, $formValues['subject'], CRM_Utils_Array::value('campaign_id', $formValues));
+
+    // Set the filename for the PDF using the Activity Subject, if defined. Remove unwanted characters and limit the length to 200 characters.
+    if (!empty($form->getSubmittedValue('subject'))) {
+      $fileName = CRM_Utils_File::makeFilenameWithUnicode($form->getSubmittedValue('subject'), '_', 200) . '.pdf';
+    }
+    else {
+      $fileName = 'CiviLetter.pdf';
+    }
+
+    CRM_Utils_PDF_Utils::html2pdf($html, $fileName, FALSE, $formValues);
+
+    $form->postProcessHook();
+
+    CRM_Utils_System::civiExit();
+  }
+
+  /**
+   * Generate html for pdf letters.
+   *
+   * @param array $membershipIDs
+   * @param array $returnProperties
+   * @param bool $skipOnHold
+   * @param bool $skipDeceased
+   * @param array $messageToken
+   * @param $html_message
+   * @param $categories
+   *
+   * @return array
+   */
+  public static function generateHTML($membershipIDs, $returnProperties, $skipOnHold, $skipDeceased, $messageToken, $html_message, $categories) {
+    $memberships = CRM_Utils_Token::getMembershipTokenDetails($membershipIDs);
+    $html = [];
+
+    foreach ($membershipIDs as $membershipID) {
+      $membership = $memberships[$membershipID];
+      // get contact information
+      $contactId = $membership['contact_id'];
+      $params = ['contact_id' => $contactId];
+      //getTokenDetails is much like calling the api contact.get function - but - with some minor
+      // special handlings. It precedes the existence of the api
+      list($contacts) = CRM_Utils_Token::getTokenDetails(
+        $params,
+        $returnProperties,
+        $skipOnHold,
+        $skipDeceased,
+        NULL,
+        $messageToken,
+        'CRM_Contribution_Form_Task_PDFLetterCommon'
+      );
+
+      $tokenHtml = CRM_Utils_Token::replaceContactTokens($html_message, $contacts[$contactId], TRUE, $messageToken);
+      $tokenHtml = CRM_Utils_Token::replaceEntityTokens('membership', $membership, $tokenHtml, $messageToken);
+      $tokenHtml = CRM_Utils_Token::replaceHookTokens($tokenHtml, $contacts[$contactId], $categories, TRUE);
+      $tokenHtml = CRM_Utils_Token::parseThroughSmarty($tokenHtml, $contacts[$contactId]);
+
+      $html[] = $tokenHtml;
+
+    }
+    return $html;
   }
 
   /**

--- a/CRM/Member/Form/Task/PDFLetterCommon.php
+++ b/CRM/Member/Form/Task/PDFLetterCommon.php
@@ -3,6 +3,8 @@
 /**
  * This class provides the common functionality for creating PDF letter for
  * members
+ *
+ * @deprecated
  */
 class CRM_Member_Form_Task_PDFLetterCommon extends CRM_Contact_Form_Task_PDFLetterCommon {
 
@@ -11,6 +13,8 @@ class CRM_Member_Form_Task_PDFLetterCommon extends CRM_Contact_Form_Task_PDFLett
    * @todo this is horrible copy & paste code because there is so much risk of breakage
    * in fixing the existing pdfLetter classes to be suitably generic
    *
+   * @deprecated
+   *
    * @param CRM_Core_Form $form
    * @param $membershipIDs
    * @param $skipOnHold
@@ -18,8 +22,9 @@ class CRM_Member_Form_Task_PDFLetterCommon extends CRM_Contact_Form_Task_PDFLett
    * @param $contactIDs
    */
   public static function postProcessMembers(&$form, $membershipIDs, $skipOnHold, $skipDeceased, $contactIDs) {
+    CRM_Core_Error::deprecatedFunctionWarning('no alternative');
     $formValues = $form->controller->exportValues($form->getName());
-    list($formValues, $categories, $html_message, $messageToken, $returnProperties) = self::processMessageTemplate($formValues);
+    list($formValues, $categories, $html_message, $messageToken, $returnProperties) = CRM_Contact_Form_Task_PDFLetterCommon::processMessageTemplate($formValues);
 
     $html
       = self::generateHTML(
@@ -31,7 +36,7 @@ class CRM_Member_Form_Task_PDFLetterCommon extends CRM_Contact_Form_Task_PDFLett
         $html_message,
         $categories
       );
-    self::createActivities($form, $html_message, $contactIDs, $formValues['subject'], CRM_Utils_Array::value('campaign_id', $formValues));
+    CRM_Contact_Form_Task_PDFLetterCommon::createActivities($form, $html_message, $contactIDs, $formValues['subject'], CRM_Utils_Array::value('campaign_id', $formValues));
 
     // Set the filename for the PDF using the Activity Subject, if defined. Remove unwanted characters and limit the length to 200 characters.
     if (!empty($form->getSubmittedValue('subject'))) {
@@ -59,9 +64,12 @@ class CRM_Member_Form_Task_PDFLetterCommon extends CRM_Contact_Form_Task_PDFLett
    * @param $html_message
    * @param $categories
    *
+   * @deprecated
+   *
    * @return array
    */
   public static function generateHTML($membershipIDs, $returnProperties, $skipOnHold, $skipDeceased, $messageToken, $html_message, $categories) {
+    CRM_Core_Error::deprecatedFunctionWarning('no alternative');
     $memberships = CRM_Utils_Token::getMembershipTokenDetails($membershipIDs);
     $html = [];
 

--- a/tests/phpunit/CRM/Member/Form/Task/PDFLetterCommonTest.php
+++ b/tests/phpunit/CRM/Member/Form/Task/PDFLetterCommonTest.php
@@ -71,7 +71,7 @@ class CRM_Member_Form_Task_PDFLetterCommonTest extends CiviUnitTestCase {
       }
     }
     $messageToken = CRM_Utils_Token::getTokens($htmlMessage);
-    $testHTML = CRM_Member_Form_Task_PDFLetterCommon::generateHTML($membershipIds,
+    $testHTML = CRM_Member_Form_Task_PDFLetter::generateHTML($membershipIds,
       $returnProperties,
       NULL,
       NULL,


### PR DESCRIPTION


Overview
----------------------------------------
[REF] dev/core#2790 Deprecate CRM/Member/Form/Task/PDFLetterCommon

Before
----------------------------------------
Functionality spread across 3 classes

After
----------------------------------------
Spread across 2

Technical Details
----------------------------------------
This gets rid of the pseudo oo model on this class
and gets us to only having 2 classes in play

We are moving towards a trait

Comments
----------------------------------------