### PR TITLE
[REF] dev/core#2790 Pre process cleanup on pdf tasks

### DIFF
--- a/CRM/Contact/Form/Task/PDFLetterCommon.php
+++ b/CRM/Contact/Form/Task/PDFLetterCommon.php
@@ -42,22 +42,8 @@ class CRM_Contact_Form_Task_PDFLetterCommon extends CRM_Core_Form_Task_PDFLetter
    * @param CRM_Core_Form $form
    */
   public static function preProcess(&$form) {
-    if (!isset($form->_single)) {
-      // @todo ensure this is already set.
-      $form->_single = FALSE;
-    }
-    $form->_emails = [];
-
-    // @TODO remove these line and to it somewhere more appropriate. Currently some classes (e.g Case
-    // are having to re-write contactIds afterwards due to this inappropriate variable setting
-    // If we don't have any contact IDs, use the logged in contact ID
-    $form->_contactIds = $form->_contactIds ?: [CRM_Core_Session::getLoggedInContactID()];
-
-    $fromEmailValues = CRM_Core_BAO_Email::getFromEmail();
-
-    $form->_emails = $fromEmailValues;
     $defaults = [];
-    $form->_fromEmails = $fromEmailValues;
+    $form->_fromEmails = CRM_Core_BAO_Email::getFromEmail();
     if (is_numeric(key($form->_fromEmails))) {
       $emailID = (int) key($form->_fromEmails);
       $defaults = CRM_Core_BAO_Email::getEmailSignatureDefaults($emailID);
@@ -66,19 +52,7 @@ class CRM_Contact_Form_Task_PDFLetterCommon extends CRM_Core_Form_Task_PDFLetter
       $defaults['from_email_address'] = current(CRM_Core_BAO_Domain::getNameAndEmail(FALSE, TRUE));
     }
     $form->setDefaults($defaults);
-    $messageText = [];
-    $messageSubject = [];
-    $dao = new CRM_Core_BAO_MessageTemplate();
-    $dao->is_active = 1;
-    $dao->find();
-    while ($dao->fetch()) {
-      $messageText[$dao->id] = $dao->msg_text;
-      $messageSubject[$dao->id] = $dao->msg_subject;
-    }
-
-    $form->assign('message', $messageText);
-    $form->assign('messageSubject', $messageSubject);
-    parent::preProcess($form);
+    $form->setTitle('Print/Merge Document');
   }
 
   /**

--- a/tests/phpunit/CRM/Contact/Form/Task/PDFLetterCommonTest.php
+++ b/tests/phpunit/CRM/Contact/Form/Task/PDFLetterCommonTest.php
@@ -47,25 +47,19 @@ class CRM_Contact_Form_Task_PDFLetterCommonTest extends CiviUnitTestCase {
    * @dataProvider getFilenameCases
    */
   public function testFilenameIsAssigned(?string $pdfFileName, ?string $activitySubject, ?bool $isLiveMode, string $expectedFilename): void {
+    // @todo - remove this cid - it helps direct the form controller but is
+    // pretty cludgey.
     $_REQUEST['cid'] = $this->contactId;
     $form = $this->getFormObject('CRM_Contact_Form_Task_PDF', [
       'pdf_file_name' => $pdfFileName,
       'subject' => $activitySubject,
-      '_contactIds' => [],
       'document_type' => 'pdf',
       'buttons' => [
         '_qf_PDF_upload' => $isLiveMode,
       ],
     ]);
-    $fileNameAssigned = NULL;
-    $form->preProcess();
-    try {
-      $form->postProcess();
-    }
-    catch (CRM_Core_Exception_PrematureExitException $e) {
-      $fileNameAssigned = $e->errorData['fileName'];
-    }
-
+    $form->_contactIds = [$this->contactId];
+    $fileNameAssigned = $this->submitForm($form)['fileName'];
     $this->assertEquals($expectedFilename, $fileNameAssigned);
   }
 
@@ -114,6 +108,23 @@ class CRM_Contact_Form_Task_PDFLetterCommonTest extends CiviUnitTestCase {
         'CiviLetter',
       ],
     ];
+  }
+
+  /**
+   * @param \CRM_Core_Form $form
+   *
+   * @return int|mixed
+   */
+  protected function submitForm(CRM_Core_Form $form) {
+    $form->preProcess();
+    try {
+      $form->postProcess();
+    }
+    catch (CRM_Core_Exception_PrematureExitException $e) {
+      return $e->errorData;
+
+    }
+    $this->fail('line should be unreachable');
   }
 
 }

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -3336,7 +3336,6 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
    * @param string $pageName
    *
    * @return \CRM_Core_Form
-   * @throws \CRM_Core_Exception
    */
   public function getFormObject($class, $formValues = [], $pageName = '') {
     $_POST = $formValues;


### PR DESCRIPTION
Overview
----------------------------------------
[REF] Pre process cleanup on pdf tasks

Before
----------------------------------------
Three variables are set on the class that were originally set because of shared code but don't seem to make sense

1) `$form->_single` - this was presumably an enotice fix - if any enotices re-emerge we can fix the right way - by setting a property on the form
2) `$form->_contactIds` - I believe this was added to support the invoice form - it doesn't make sense to default to writing a letter to your self
3) `$form->_emails` - this is used in the emails classes but not the pdf classes on searching

After
----------------------------------------
Poof


Technical Details
----------------------------------------

Comments
----------------------------------------
@demeritcowboy this is the clean up I thought needed to be done.... With this done I'll move the preProcess to the trait & move the default setting into it's own function or, more likely, into the setDefaults function already on the trait