### PR TITLE
[REF] Do not set input['line_item'] pointlessly

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2459,7 +2459,7 @@ LEFT JOIN  civicrm_contribution contribution ON ( componentPayment.contribution_
         // array_filter with strlen filters out NULL, '' and FALSE but not 0.
       ], 'strlen')
     );
-    $input['line_item'] = $contributionParams['line_item'] = $templateContribution['line_item'];
+    $contributionParams['line_item'] = $templateContribution['line_item'];
     $contributionParams['status_id'] = 'Pending';
 
     foreach (['contact_id', 'campaign_id', 'financial_type_id', 'currency', 'source', 'amount_level', 'address_id', 'on_behalf', 'source_contact_id', 'tax_amount', 'contribution_page_id', 'total_amount'] as $fieldName) {


### PR DESCRIPTION
Overview
----------------------------------------
[REF] Do not set input['line_item'] pointlessly

Before
----------------------------------------
key set but never used

After
----------------------------------------
not set

Technical Details
----------------------------------------
`$input` is only used once more after this - to handle the possibility of 'membershipID' being set - which should probably also go - but that is another story

Comments
----------------------------------------
