### PR TITLE
[REF] Improve Custom data insert performance when using the copyCusto…

### DIFF
--- a/CRM/Core/BAO/Address.php
+++ b/CRM/Core/BAO/Address.php
@@ -104,7 +104,7 @@ class CRM_Core_BAO_Address extends CRM_Core_DAO_Address {
       // call the function to sync shared address and create relationships
       // if address is already shared, share master_id with all children and update relationships accordingly
       // (prevent chaining 2) CRM-21214
-      self::processSharedAddress($address->id, $params);
+      self::processSharedAddress($address->id, $params, $hook);
 
       // lets call the post hook only after we've done all the follow on processing
       CRM_Utils_Hook::post($hook, 'Address', $address->id, $address);
@@ -956,8 +956,9 @@ SELECT is_primary,
    *   Address id.
    * @param array $params
    *   Associated array of address params.
+   * @param string $parentOperation Operation being taken on the parent entity.
    */
-  public static function processSharedAddress($addressId, $params) {
+  public static function processSharedAddress($addressId, $params, $parentOperation = NULL) {
     $query = 'SELECT id, contact_id FROM civicrm_address WHERE master_id = %1';
     $dao = CRM_Core_DAO::executeQuery($query, [1 => [$addressId, 'Integer']]);
 
@@ -996,7 +997,7 @@ SELECT is_primary,
       $addressDAO->copyValues($params);
       $addressDAO->id = $dao->id;
       $addressDAO->save();
-      $addressDAO->copyCustomFields($addressId, $addressDAO->id);
+      $addressDAO->copyCustomFields($addressId, $addressDAO->id, $parentOperation);
     }
   }
 

--- a/CRM/Core/BAO/CustomValueTable.php
+++ b/CRM/Core/BAO/CustomValueTable.php
@@ -396,15 +396,16 @@ class CRM_Core_BAO_CustomValueTable {
    * @param $entityTable
    * @param int $entityID
    * @param $customFieldExtends
+   * @param $parentOperation
    */
-  public static function postProcess(&$params, $entityTable, $entityID, $customFieldExtends) {
+  public static function postProcess(&$params, $entityTable, $entityID, $customFieldExtends, $parentOperation = NULL) {
     $customData = CRM_Core_BAO_CustomField::postProcess($params,
       $entityID,
       $customFieldExtends
     );
 
     if (!empty($customData)) {
-      self::store($customData, $entityTable, $entityID);
+      self::store($customData, $entityTable, $entityID, $parentOperation);
     }
   }
 

--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -1971,8 +1971,9 @@ LIKE %1
    *
    * @param int $entityID
    * @param int $newEntityID
+   * @param string $parentOperation
    */
-  public function copyCustomFields($entityID, $newEntityID) {
+  public function copyCustomFields($entityID, $newEntityID, $parentOperation = NULL) {
     $entity = CRM_Core_DAO_AllCoreTables::getBriefName(get_class($this));
     $tableName = CRM_Core_DAO_AllCoreTables::getTableForClass(get_class($this));
     // Obtain custom values for the old entity.
@@ -2010,7 +2011,7 @@ LIKE %1
       }
 
       // Save Custom Fields for new Entity.
-      CRM_Core_BAO_CustomValueTable::postProcess($customParams, $tableName, $newEntityID, $entity, 'create');
+      CRM_Core_BAO_CustomValueTable::postProcess($customParams, $tableName, $newEntityID, $entity, $parentOperation ?? 'create');
     }
 
     // copy activity attachments ( if any )

--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -1975,7 +1975,7 @@ LIKE %1
   public function copyCustomFields($entityID, $newEntityID) {
     $entity = CRM_Core_DAO_AllCoreTables::getBriefName(get_class($this));
     $tableName = CRM_Core_DAO_AllCoreTables::getTableForClass(get_class($this));
-    // Obtain custom values for old event
+    // Obtain custom values for the old entity.
     $customParams = $htmlType = [];
     $customValues = CRM_Core_BAO_CustomValueTable::getEntityValues($entityID, $entity);
 
@@ -2009,8 +2009,8 @@ LIKE %1
         }
       }
 
-      // Save Custom Fields for new Event
-      CRM_Core_BAO_CustomValueTable::postProcess($customParams, $tableName, $newEntityID, $entity);
+      // Save Custom Fields for new Entity.
+      CRM_Core_BAO_CustomValueTable::postProcess($customParams, $tableName, $newEntityID, $entity, 'create');
     }
 
     // copy activity attachments ( if any )

--- a/tests/phpunit/CRM/Contribute/BAO/ContributionRecurTest.php
+++ b/tests/phpunit/CRM/Contribute/BAO/ContributionRecurTest.php
@@ -294,6 +294,8 @@ class CRM_Contribute_BAO_ContributionRecurTest extends CiviUnitTestCase {
     $templateContribution = $templateContribution->first();
     $this->assertNotNull($templateContribution['template.field']);
     $this->assertEquals('Second and most recent Contribution', $templateContribution['template.field']);
+    $this->callAPISuccess('CustomField', 'delete', ['id' => $custom_field['id']]);
+    $this->callAPISuccess('CustomGroup', 'delete', ['id' => $custom_group['id']]);
   }
 
   /**


### PR DESCRIPTION
…mFields

Overview
----------------------------------------
This is a follow up to https://github.com/civicrm/civicrm-core/pull/20924 and https://github.com/civicrm/civicrm-core/pull/14605, This ensures that when the ::store() function on CustomValueTable is eventually called the $parentOperation is set to create which it should be from the copyCustomFields function because we are inherently creating a new entity here.

Before
----------------------------------------
Possible deadlock when creating an address with a master_id due to the on duplicate key statement

After
----------------------------------------
less Deadlocks from creating an address with master_id

ping @eileenmcnaughton @monishdeb @JoeMurray @jaapjansma @mattwire 