### PR TITLE
[NFC] Fix undefined array key when running CRM unit test suite in php8

### DIFF
--- a/tests/phpunit/CRM/Core/BAO/ActionScheduleTest.php
+++ b/tests/phpunit/CRM/Core/BAO/ActionScheduleTest.php
@@ -961,7 +961,15 @@ class CRM_Core_BAO_ActionScheduleTest extends CiviUnitTestCase {
 
     // In this example, we test activity tokens
     $activityTokens = '{activity.subject};;{activity.details};;{activity.activity_date_time}';
-    $activity = $this->fixtures['phonecall'];
+    $activity = [
+      'status_id' => 1,
+      'activity_type_id' => 2,
+      'activity_date_time' => '20120615100000',
+      'is_current_revision' => 1,
+      'is_deleted' => 0,
+      'subject' => 'Phone call',
+      'details' => 'A phone call about a bear',
+    ];
     $activityTokensExpected = "Phone call;;A phone call about a bear;;June 15th, 2012 10:00 AM";
     $cases[4] = [
       // Schedule definition.


### PR DESCRIPTION
Overview
----------------------------------------
This fixes an error when running the CRM Test suite 

```
Warning: Undefined array key "phonecall" in /home/jenkins/bknix-edge/build/build-1/web/sites/all/modules/civicrm/tests/phpunit/CRM/Core/BAO/ActionScheduleTest.php on line 96
```

Before
----------------------------------------
Undefined array key warning when running CRM_AllTests in php8

After
----------------------------------------
No error

Technical Details
----------------------------------------
The problem here is that this function is used as a dataprovider for other tests and the dataprovider is evaluated prior to the setUp functions which is where $this->fixtures is set
 
ping @eileenmcnaughton @mattwire @demeritcowboy 