### PR TITLE
Fix Searchkit "Add" columns button UI

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin/displays/common/addColMenu.html
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/common/addColMenu.html
@@ -1,4 +1,4 @@
-<button type="button" class="btn dropdown-toggle btn-default-outline" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+<button type="button" class="btn dropdown-toggle btn-secondary-outline" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
   <i class="crm-i fa-plus"></i>
   {{:: ts('Add') }} <span class="caret"></span>
 </button>


### PR DESCRIPTION
Overview
----------------------------------------
In Search Kit, the Add Columns Button UI has been fixed. Previously it was not visible when using with Shoreditch.
In Response to https://github.com/civicrm/org.civicrm.shoreditch/issues/512.

Before
----------------------------------------
**With Shoreditch**
![2021-08-30 at 1 44 PM](https://user-images.githubusercontent.com/5058867/131308221-5294aa9e-a22a-4654-812d-3951e7d46ae5.png)

**Without Shoreditch**
![2021-08-30 at 1 45 PM](https://user-images.githubusercontent.com/5058867/131308313-977e5128-5e17-4f74-b5f0-c9afed41d3da.png)

After
----------------------------------------
**With Shoreditch**
![2021-08-30 at 1 43 PM](https://user-images.githubusercontent.com/5058867/131308077-7fffe4e5-277c-4297-9a66-d4a1fe61ffa0.png)

**Without Shoreditch**
![2021-08-30 at 1 44 PM](https://user-images.githubusercontent.com/5058867/131308147-5862ef87-3ba1-444d-b538-d2b72e583ad4.png)


Technical Details
----------------------------------------
Previously `btn-default-outline` was used for the button, which is not correct, because with that class, the Border and Font Color are white. In this case, we need a darker color, since the background is set to white https://github.com/civicrm/civicrm-core/blob/master/ext/search_kit/css/crmSearchAdmin.css#L72.
