### PR TITLE
 dev/core#2732 SearchKit - Move field formatting from client-side to server-side 

### DIFF
--- a/Civi/Api4/Query/SqlExpression.php
+++ b/Civi/Api4/Query/SqlExpression.php
@@ -46,6 +46,13 @@ abstract class SqlExpression {
   public $supportsExpansion = FALSE;
 
   /**
+   * Data type output by this expression
+   *
+   * @var string
+   */
+  protected static $dataType;
+
+  /**
    * SqlFunction constructor.
    * @param string $expr
    * @param string|null $alias
@@ -164,6 +171,13 @@ abstract class SqlExpression {
   public function getType(): string {
     $className = get_class($this);
     return substr($className, strrpos($className, '\\') + 1);
+  }
+
+  /**
+   * @return string|NULL
+   */
+  public static function getDataType():? string {
+    return static::$dataType;
   }
 
 }

--- a/Civi/Api4/Query/SqlFunction.php
+++ b/Civi/Api4/Query/SqlFunction.php
@@ -30,13 +30,6 @@ abstract class SqlFunction extends SqlExpression {
    */
   protected static $category;
 
-  /**
-   * Data type output by this function
-   *
-   * @var string
-   */
-  protected static $dataType;
-
   const CATEGORY_AGGREGATE = 'aggregate',
     CATEGORY_COMPARISON = 'comparison',
     CATEGORY_DATE = 'date',
@@ -286,13 +279,6 @@ abstract class SqlFunction extends SqlExpression {
    */
   public static function getCategory(): string {
     return static::$category;
-  }
-
-  /**
-   * @return string|NULL
-   */
-  public static function getDataType():? string {
-    return static::$dataType;
   }
 
   /**

--- a/Civi/Api4/Query/SqlFunctionLOWER.php
+++ b/Civi/Api4/Query/SqlFunctionLOWER.php
@@ -16,6 +16,8 @@ namespace Civi\Api4\Query;
  */
 class SqlFunctionLOWER extends SqlFunction {
 
+  protected static $dataType = 'String';
+
   protected static $category = self::CATEGORY_STRING;
 
   protected static function params(): array {

--- a/Civi/Api4/Query/SqlFunctionUPPER.php
+++ b/Civi/Api4/Query/SqlFunctionUPPER.php
@@ -16,6 +16,8 @@ namespace Civi\Api4\Query;
  */
 class SqlFunctionUPPER extends SqlFunction {
 
+  protected static $dataType = 'String';
+
   protected static $category = self::CATEGORY_STRING;
 
   protected static function params(): array {

--- a/Civi/Api4/Query/SqlNumber.php
+++ b/Civi/Api4/Query/SqlNumber.php
@@ -16,6 +16,8 @@ namespace Civi\Api4\Query;
  */
 class SqlNumber extends SqlExpression {
 
+  protected static $dataType = 'Float';
+
   protected function initialize() {
     \CRM_Utils_Type::validate($this->expr, 'Float');
   }

--- a/Civi/Api4/Query/SqlString.php
+++ b/Civi/Api4/Query/SqlString.php
@@ -16,6 +16,8 @@ namespace Civi\Api4\Query;
  */
 class SqlString extends SqlExpression {
 
+  protected static $dataType = 'String';
+
   protected function initialize() {
     // Remove surrounding quotes
     $str = substr($this->expr, 1, -1);

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
@@ -1,0 +1,343 @@
+<?php
+
+namespace Civi\Api4\Action\SearchDisplay;
+
+use Civi\API\Exception\UnauthorizedException;
+use Civi\Api4\SavedSearch;
+use Civi\Api4\SearchDisplay;
+use Civi\Api4\Utils\CoreUtil;
+
+/**
+ * Base class for running a search.
+ *
+ * @package Civi\Api4\Action\SearchDisplay
+ */
+abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
+
+  /**
+   * Either the name of the savedSearch or an array containing the savedSearch definition (for preview mode)
+   * @var string|array
+   * @required
+   */
+  protected $savedSearch;
+
+  /**
+   * Either the name of the display or an array containing the display definition (for preview mode)
+   * @var string|array
+   * @required
+   */
+  protected $display;
+
+  /**
+   * Array of fields to use for ordering the results
+   * @var array
+   */
+  protected $sort = [];
+
+  /**
+   * Search conditions that will be automatically added to the WHERE or HAVING clauses
+   * @var array
+   */
+  protected $filters = [];
+
+  /**
+   * Name of Afform, if this display is embedded (used for permissioning)
+   * @var string
+   */
+  protected $afform;
+
+  /**
+   * @var \Civi\Api4\Query\Api4SelectQuery
+   */
+  private $_selectQuery;
+
+  /**
+   * @var array
+   */
+  private $_afform;
+
+  /**
+   * @param \Civi\Api4\Generic\Result $result
+   * @throws UnauthorizedException
+   * @throws \API_Exception
+   */
+  public function _run(\Civi\Api4\Generic\Result $result) {
+    // Only administrators can use this in unsecured "preview mode"
+    if (!(is_string($this->savedSearch) && is_string($this->display)) && $this->checkPermissions && !\CRM_Core_Permission::check('administer CiviCRM data')) {
+      throw new UnauthorizedException('Access denied');
+    }
+    if (is_string($this->savedSearch)) {
+      $this->savedSearch = SavedSearch::get(FALSE)
+        ->addWhere('name', '=', $this->savedSearch)
+        ->execute()->first();
+    }
+    if (is_string($this->display) && !empty($this->savedSearch['id'])) {
+      $this->display = SearchDisplay::get(FALSE)
+        ->setSelect(['*', 'type:name'])
+        ->addWhere('name', '=', $this->display)
+        ->addWhere('saved_search_id', '=', $this->savedSearch['id'])
+        ->execute()->first();
+    }
+    if (!$this->savedSearch || !$this->display) {
+      throw new \API_Exception("Error: SearchDisplay not found.");
+    }
+    // Displays with acl_bypass must be embedded on an afform which the user has access to
+    if (
+      $this->checkPermissions && !empty($this->display['acl_bypass']) &&
+      !\CRM_Core_Permission::check('all CiviCRM permissions and ACLs') && !$this->loadAfform()
+    ) {
+      throw new UnauthorizedException('Access denied');
+    }
+
+    $this->savedSearch['api_params'] += ['where' => []];
+    $this->savedSearch['api_params']['checkPermissions'] = empty($this->display['acl_bypass']);
+
+    $this->processResult($result);
+  }
+
+  abstract protected function processResult(\Civi\Api4\Generic\Result $result);
+
+  /**
+   * Returns field definition for a given field or NULL if not found
+   * @param $fieldName
+   * @return array|null
+   */
+  protected function getField($fieldName) {
+    if (!$this->_selectQuery) {
+      $api = \Civi\API\Request::create($this->savedSearch['api_entity'], 'get', $this->savedSearch['api_params']);
+      $this->_selectQuery = new \Civi\Api4\Query\Api4SelectQuery($api);
+    }
+    return $this->_selectQuery->getField($fieldName, FALSE);
+  }
+
+  /**
+   * Applies supplied filters to the where clause
+   */
+  protected function applyFilters() {
+    // Ignore empty strings
+    $filters = array_filter($this->filters, [$this, 'hasValue']);
+    if (!$filters) {
+      return;
+    }
+
+    // Process all filters that are included in SELECT clause or are allowed by the Afform.
+    $allowedFilters = array_merge($this->getSelectAliases(), $this->getAfformFilters());
+    foreach ($filters as $fieldName => $value) {
+      if (in_array($fieldName, $allowedFilters, TRUE)) {
+        $this->applyFilter($fieldName, $value);
+      }
+    }
+  }
+
+  /**
+   * Returns an array of field names or aliases + allowed suffixes from the SELECT clause
+   * @return string[]
+   */
+  protected function getSelectAliases() {
+    $result = [];
+    $selectAliases = array_map(function($select) {
+      return array_slice(explode(' AS ', $select), -1)[0];
+    }, $this->savedSearch['api_params']['select']);
+    foreach ($selectAliases as $alias) {
+      [$alias] = explode(':', $alias);
+      $result[] = $alias;
+      foreach (['name', 'label', 'abbr'] as $allowedSuffix) {
+        $result[] = $alias . ':' . $allowedSuffix;
+      }
+    }
+    return $result;
+  }
+
+  /**
+   * @param string $fieldName
+   * @param mixed $value
+   */
+  private function applyFilter(string $fieldName, $value) {
+    // Global setting determines if % wildcard should be added to both sides (default) or only the end of a search string
+    $prefixWithWildcard = \Civi::settings()->get('includeWildCardInName');
+
+    $field = $this->getField($fieldName);
+    // If field is not found it must be an aggregated column & belongs in the HAVING clause.
+    if (!$field) {
+      $this->savedSearch['api_params']['having'] = $this->savedSearch['api_params']['having'] ?? [];
+      $clause =& $this->savedSearch['api_params']['having'];
+    }
+    // If field belongs to an EXCLUDE join, it should be added as a join condition
+    else {
+      $prefix = strpos($fieldName, '.') ? explode('.', $fieldName)[0] : NULL;
+      foreach ($this->savedSearch['api_params']['join'] ?? [] as $idx => $join) {
+        if (($join[1] ?? 'LEFT') === 'EXCLUDE' && (explode(' AS ', $join[0])[1] ?? '') === $prefix) {
+          $clause =& $this->savedSearch['api_params']['join'][$idx];
+        }
+      }
+    }
+    // Default: add filter to WHERE clause
+    if (!isset($clause)) {
+      $clause =& $this->savedSearch['api_params']['where'];
+    }
+
+    $dataType = $field['data_type'] ?? NULL;
+
+    // Array is either associative `OP => VAL` or sequential `IN (...)`
+    if (is_array($value)) {
+      $value = array_filter($value, [$this, 'hasValue']);
+      // If array does not contain operators as keys, assume array of values
+      if (array_diff_key($value, array_flip(CoreUtil::getOperators()))) {
+        // Use IN for regular fields
+        if (empty($field['serialize'])) {
+          $clause[] = [$fieldName, 'IN', $value];
+        }
+        // Use an OR group of CONTAINS for array fields
+        else {
+          $orGroup = [];
+          foreach ($value as $val) {
+            $orGroup[] = [$fieldName, 'CONTAINS', $val];
+          }
+          $clause[] = ['OR', $orGroup];
+        }
+      }
+      // Operator => Value array
+      else {
+        foreach ($value as $operator => $val) {
+          $clause[] = [$fieldName, $operator, $val];
+        }
+      }
+    }
+    elseif (!empty($field['serialize'])) {
+      $clause[] = [$fieldName, 'CONTAINS', $value];
+    }
+    elseif (!empty($field['options']) || in_array($dataType, ['Integer', 'Boolean', 'Date', 'Timestamp'])) {
+      $clause[] = [$fieldName, '=', $value];
+    }
+    elseif ($prefixWithWildcard) {
+      $clause[] = [$fieldName, 'CONTAINS', $value];
+    }
+    else {
+      $clause[] = [$fieldName, 'LIKE', $value . '%'];
+    }
+  }
+
+  /**
+   * Transforms the SORT param (which is expected to be an array of arrays)
+   * to the ORDER BY clause (which is an associative array of [field => DIR]
+   *
+   * @return array
+   */
+  protected function getOrderByFromSort() {
+    $defaultSort = $this->display['settings']['sort'] ?? [];
+    $currentSort = $this->sort;
+
+    // Validate that requested sort fields are part of the SELECT
+    foreach ($this->sort as $item) {
+      if (!in_array($item[0], $this->getSelectAliases())) {
+        $currentSort = NULL;
+      }
+    }
+
+    $orderBy = [];
+    foreach ($currentSort ?: $defaultSort as $item) {
+      $orderBy[$item[0]] = $item[1];
+    }
+    return $orderBy;
+  }
+
+  /**
+   * Adds additional fields to the select clause required to render the display
+   *
+   * @param array $apiParams
+   */
+  protected function augmentSelectClause(&$apiParams): void {
+    $possibleTokens = '';
+    foreach ($this->display['settings']['columns'] ?? [] as $column) {
+      // Collect display values in which a token is allowed
+      $possibleTokens .= ($column['rewrite'] ?? '') . ($column['link']['path'] ?? '');
+      if (!empty($column['links'])) {
+        $possibleTokens .= implode('', array_column($column['links'], 'path'));
+        $possibleTokens .= implode('', array_column($column['links'], 'text'));
+      }
+
+      // Select value fields for in-place editing
+      if (isset($column['editable']['value']) && !in_array($column['editable']['value'], $apiParams['select'])) {
+        $apiParams['select'][] = $column['editable']['value'];
+      }
+    }
+    // Add fields referenced via token
+    $tokens = [];
+    preg_match_all('/\\[([^]]+)\\]/', $possibleTokens, $tokens);
+    $apiParams['select'] = array_unique(array_merge($apiParams['select'], $tokens[1]));
+  }
+
+  /**
+   * Checks if a filter contains a non-empty value
+   *
+   * "Empty" search values are [], '', and NULL.
+   * Also recursively checks arrays to ensure they contain at least one non-empty value.
+   *
+   * @param $value
+   * @return bool
+   */
+  private function hasValue($value) {
+    return $value !== '' && $value !== NULL && (!is_array($value) || array_filter($value, [$this, 'hasValue']));
+  }
+
+  /**
+   * Returns a list of filter fields and directive filters
+   *
+   * Automatically applies directive filters
+   *
+   * @return array
+   */
+  private function getAfformFilters() {
+    $afform = $this->loadAfform();
+    if (!$afform) {
+      return [];
+    }
+    // Get afform field filters
+    $filterKeys = array_column(\CRM_Utils_Array::findAll(
+      $afform['layout'] ?? [],
+      ['#tag' => 'af-field']
+    ), 'name');
+    // Get filters passed into search display directive from Afform markup
+    $filterAttr = $afform['searchDisplay']['filters'] ?? NULL;
+    if ($filterAttr && is_string($filterAttr) && $filterAttr[0] === '{') {
+      foreach (\CRM_Utils_JS::decode($filterAttr) as $filterKey => $filterVal) {
+        $filterKeys[] = $filterKey;
+        // Automatically apply filters from the markup if they have a value
+        // (if it's a javascript variable it will have come back from decode() as NULL and we'll ignore it).
+        if ($this->hasValue($filterVal)) {
+          $this->applyFilter($filterKey, $filterVal);
+        }
+      }
+    }
+    return $filterKeys;
+  }
+
+  /**
+   * Return afform with name specified in api call.
+   *
+   * Verifies the searchDisplay is embedded in the afform and the user has permission to view it.
+   *
+   * @return array|false|null
+   */
+  private function loadAfform() {
+    // Only attempt to load afform once.
+    if ($this->afform && !isset($this->_afform)) {
+      $this->_afform = FALSE;
+      // Permission checks are enabled in this api call to ensure the user has permission to view the form
+      $afform = \Civi\Api4\Afform::get()
+        ->addWhere('name', '=', $this->afform)
+        ->setLayoutFormat('shallow')
+        ->execute()->first();
+      // Validate that the afform contains this search display
+      $afform['searchDisplay'] = \CRM_Utils_Array::findAll(
+          $afform['layout'] ?? [],
+          ['#tag' => "{$this->display['type:name']}", 'display-name' => $this->display['name']]
+        )[0] ?? NULL;
+      if ($afform['searchDisplay']) {
+        $this->_afform = $afform;
+      }
+    }
+    return $this->_afform;
+  }
+
+}

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/Run.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/Run.php
@@ -59,10 +59,17 @@ class Run extends AbstractRunAction {
     $this->applyFilters();
 
     $apiResult = civicrm_api4($entityName, 'get', $apiParams);
-
+    // Copy over meta properties to this result
     $result->rowCount = $apiResult->rowCount;
-    $result->exchangeArray($apiResult->getArrayCopy());
     $result->debug = $apiResult->debug;
+
+    if ($this->return === 'row_count' || $this->return === 'id') {
+      $result->exchangeArray($apiResult->getArrayCopy());
+    }
+    else {
+      $result->exchangeArray($this->formatResult($apiResult));
+    }
+
   }
 
 }

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/Run.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/Run.php
@@ -2,43 +2,12 @@
 
 namespace Civi\Api4\Action\SearchDisplay;
 
-use Civi\API\Exception\UnauthorizedException;
-use Civi\Api4\SavedSearch;
-use Civi\Api4\SearchDisplay;
-use Civi\Api4\Utils\CoreUtil;
-
 /**
  * Load the results for rendering a SearchDisplay.
  *
  * @package Civi\Api4\Action\SearchDisplay
  */
-class Run extends \Civi\Api4\Generic\AbstractAction {
-
-  /**
-   * Either the name of the savedSearch or an array containing the savedSearch definition (for preview mode)
-   * @var string|array
-   * @required
-   */
-  protected $savedSearch;
-
-  /**
-   * Either the name of the display or an array containing the display definition (for preview mode)
-   * @var string|array
-   * @required
-   */
-  protected $display;
-
-  /**
-   * Array of fields to use for ordering the results
-   * @var array
-   */
-  protected $sort = [];
-
-  /**
-   * Number of results to return
-   * @var int
-   */
-  protected $limit;
+class Run extends AbstractRunAction {
 
   /**
    * Should this api call return a page of results or the row_count or the ids
@@ -48,68 +17,18 @@ class Run extends \Civi\Api4\Generic\AbstractAction {
   protected $return;
 
   /**
-   * Search conditions that will be automatically added to the WHERE or HAVING clauses
-   * @var array
+   * Number of results to return
+   * @var int
    */
-  protected $filters = [];
-
-  /**
-   * Name of Afform, if this display is embedded (used for permissioning)
-   * @var string
-   */
-  protected $afform;
-
-  /**
-   * @var \Civi\Api4\Query\Api4SelectQuery
-   */
-  private $_selectQuery;
-
-  /**
-   * @var array
-   */
-  private $_afform;
-
-  /**
-   * @var array
-   */
-  private $_extraEntityFields = [];
+  protected $limit;
 
   /**
    * @param \Civi\Api4\Generic\Result $result
-   * @throws UnauthorizedException
    * @throws \API_Exception
    */
-  public function _run(\Civi\Api4\Generic\Result $result) {
-    // Only administrators can use this in unsecured "preview mode"
-    if (!(is_string($this->savedSearch) && is_string($this->display)) && $this->checkPermissions && !\CRM_Core_Permission::check('administer CiviCRM data')) {
-      throw new UnauthorizedException('Access denied');
-    }
-    if (is_string($this->savedSearch)) {
-      $this->savedSearch = SavedSearch::get(FALSE)
-        ->addWhere('name', '=', $this->savedSearch)
-        ->execute()->first();
-    }
-    if (is_string($this->display) && !empty($this->savedSearch['id'])) {
-      $this->display = SearchDisplay::get(FALSE)
-        ->setSelect(['*', 'type:name'])
-        ->addWhere('name', '=', $this->display)
-        ->addWhere('saved_search_id', '=', $this->savedSearch['id'])
-        ->execute()->first();
-    }
-    if (!$this->savedSearch || !$this->display) {
-      throw new \API_Exception("Error: SearchDisplay not found.");
-    }
-    // Displays with acl_bypass must be embedded on an afform which the user has access to
-    if (
-      $this->checkPermissions && !empty($this->display['acl_bypass']) &&
-      !\CRM_Core_Permission::check('all CiviCRM permissions and ACLs') && !$this->loadAfform()
-    ) {
-      throw new UnauthorizedException('Access denied');
-    }
+  protected function processResult(\Civi\Api4\Generic\Result $result) {
     $entityName = $this->savedSearch['api_entity'];
     $apiParams =& $this->savedSearch['api_params'];
-    $apiParams['checkPermissions'] = empty($this->display['acl_bypass']);
-    $apiParams += ['where' => []];
     $settings = $this->display['settings'];
     $page = NULL;
 
@@ -144,249 +63,6 @@ class Run extends \Civi\Api4\Generic\AbstractAction {
     $result->rowCount = $apiResult->rowCount;
     $result->exchangeArray($apiResult->getArrayCopy());
     $result->debug = $apiResult->debug;
-  }
-
-  /**
-   * Checks if a filter contains a non-empty value
-   *
-   * "Empty" search values are [], '', and NULL.
-   * Also recursively checks arrays to ensure they contain at least one non-empty value.
-   *
-   * @param $value
-   * @return bool
-   */
-  private function hasValue($value) {
-    return $value !== '' && $value !== NULL && (!is_array($value) || array_filter($value, [$this, 'hasValue']));
-  }
-
-  /**
-   * Applies supplied filters to the where clause
-   */
-  private function applyFilters() {
-    // Ignore empty strings
-    $filters = array_filter($this->filters, [$this, 'hasValue']);
-    if (!$filters) {
-      return;
-    }
-
-    // Process all filters that are included in SELECT clause or are allowed by the Afform.
-    $allowedFilters = array_merge($this->getSelectAliases(), $this->getAfformFilters());
-    foreach ($filters as $fieldName => $value) {
-      if (in_array($fieldName, $allowedFilters, TRUE)) {
-        $this->applyFilter($fieldName, $value);
-      }
-    }
-  }
-
-  /**
-   * @param string $fieldName
-   * @param mixed $value
-   */
-  private function applyFilter(string $fieldName, $value) {
-    // Global setting determines if % wildcard should be added to both sides (default) or only the end of a search string
-    $prefixWithWildcard = \Civi::settings()->get('includeWildCardInName');
-
-    $field = $this->getField($fieldName);
-    // If field is not found it must be an aggregated column & belongs in the HAVING clause.
-    if (!$field) {
-      $this->savedSearch['api_params']['having'] = $this->savedSearch['api_params']['having'] ?? [];
-      $clause =& $this->savedSearch['api_params']['having'];
-    }
-    // If field belongs to an EXCLUDE join, it should be added as a join condition
-    else {
-      $prefix = strpos($fieldName, '.') ? explode('.', $fieldName)[0] : NULL;
-      foreach ($this->savedSearch['api_params']['join'] ?? [] as $idx => $join) {
-        if (($join[1] ?? 'LEFT') === 'EXCLUDE' && (explode(' AS ', $join[0])[1] ?? '') === $prefix) {
-          $clause =& $this->savedSearch['api_params']['join'][$idx];
-        }
-      }
-    }
-    // Default: add filter to WHERE clause
-    if (!isset($clause)) {
-      $clause =& $this->savedSearch['api_params']['where'];
-    }
-
-    $dataType = $field['data_type'] ?? NULL;
-
-    // Array is either associative `OP => VAL` or sequential `IN (...)`
-    if (is_array($value)) {
-      $value = array_filter($value, [$this, 'hasValue']);
-      // If array does not contain operators as keys, assume array of values
-      if (array_diff_key($value, array_flip(CoreUtil::getOperators()))) {
-        // Use IN for regular fields
-        if (empty($field['serialize'])) {
-          $clause[] = [$fieldName, 'IN', $value];
-        }
-        // Use an OR group of CONTAINS for array fields
-        else {
-          $orGroup = [];
-          foreach ($value as $val) {
-            $orGroup[] = [$fieldName, 'CONTAINS', $val];
-          }
-          $clause[] = ['OR', $orGroup];
-        }
-      }
-      // Operator => Value array
-      else {
-        foreach ($value as $operator => $val) {
-          $clause[] = [$fieldName, $operator, $val];
-        }
-      }
-    }
-    elseif (!empty($field['serialize'])) {
-      $clause[] = [$fieldName, 'CONTAINS', $value];
-    }
-    elseif (!empty($field['options']) || in_array($dataType, ['Integer', 'Boolean', 'Date', 'Timestamp'])) {
-      $clause[] = [$fieldName, '=', $value];
-    }
-    elseif ($prefixWithWildcard) {
-      $clause[] = [$fieldName, 'CONTAINS', $value];
-    }
-    else {
-      $clause[] = [$fieldName, 'LIKE', $value . '%'];
-    }
-  }
-
-  /**
-   * Transforms the SORT param (which is expected to be an array of arrays)
-   * to the ORDER BY clause (which is an associative array of [field => DIR]
-   *
-   * @return array
-   */
-  private function getOrderByFromSort() {
-    $defaultSort = $this->display['settings']['sort'] ?? [];
-    $currentSort = $this->sort;
-
-    // Validate that requested sort fields are part of the SELECT
-    foreach ($this->sort as $item) {
-      if (!in_array($item[0], $this->getSelectAliases())) {
-        $currentSort = NULL;
-      }
-    }
-
-    $orderBy = [];
-    foreach ($currentSort ?: $defaultSort as $item) {
-      $orderBy[$item[0]] = $item[1];
-    }
-    return $orderBy;
-  }
-
-  /**
-   * Returns an array of field names or aliases + allowed suffixes from the SELECT clause
-   * @return string[]
-   */
-  private function getSelectAliases() {
-    $result = [];
-    $selectAliases = array_map(function($select) {
-      return array_slice(explode(' AS ', $select), -1)[0];
-    }, $this->savedSearch['api_params']['select']);
-    foreach ($selectAliases as $alias) {
-      [$alias] = explode(':', $alias);
-      $result[] = $alias;
-      foreach (['name', 'label', 'abbr'] as $allowedSuffix) {
-        $result[] = $alias . ':' . $allowedSuffix;
-      }
-    }
-    return $result;
-  }
-
-  /**
-   * Returns field definition for a given field or NULL if not found
-   * @param $fieldName
-   * @return array|null
-   */
-  private function getField($fieldName) {
-    if (!$this->_selectQuery) {
-      $api = \Civi\API\Request::create($this->savedSearch['api_entity'], 'get', $this->savedSearch['api_params']);
-      $this->_selectQuery = new \Civi\Api4\Query\Api4SelectQuery($api);
-    }
-    return $this->_selectQuery->getField($fieldName, FALSE);
-  }
-
-  /**
-   * Returns a list of filter fields and directive filters
-   *
-   * Automatically applies directive filters
-   *
-   * @return array
-   */
-  private function getAfformFilters() {
-    $afform = $this->loadAfform();
-    if (!$afform) {
-      return [];
-    }
-    // Get afform field filters
-    $filterKeys = array_column(\CRM_Utils_Array::findAll(
-      $afform['layout'] ?? [],
-      ['#tag' => 'af-field']
-    ), 'name');
-    // Get filters passed into search display directive from Afform markup
-    $filterAttr = $afform['searchDisplay']['filters'] ?? NULL;
-    if ($filterAttr && is_string($filterAttr) && $filterAttr[0] === '{') {
-      foreach (\CRM_Utils_JS::decode($filterAttr) as $filterKey => $filterVal) {
-        $filterKeys[] = $filterKey;
-        // Automatically apply filters from the markup if they have a value
-        // (if it's a javascript variable it will have come back from decode() as NULL and we'll ignore it).
-        if ($this->hasValue($filterVal)) {
-          $this->applyFilter($filterKey, $filterVal);
-        }
-      }
-    }
-    return $filterKeys;
-  }
-
-  /**
-   * Return afform with name specified in api call.
-   *
-   * Verifies the searchDisplay is embedded in the afform and the user has permission to view it.
-   *
-   * @return array|false|null
-   */
-  private function loadAfform() {
-    // Only attempt to load afform once.
-    if ($this->afform && !isset($this->_afform)) {
-      $this->_afform = FALSE;
-      // Permission checks are enabled in this api call to ensure the user has permission to view the form
-      $afform = \Civi\Api4\Afform::get()
-        ->addWhere('name', '=', $this->afform)
-        ->setLayoutFormat('shallow')
-        ->execute()->first();
-      // Validate that the afform contains this search display
-      $afform['searchDisplay'] = \CRM_Utils_Array::findAll(
-        $afform['layout'] ?? [],
-        ['#tag' => "{$this->display['type:name']}", 'display-name' => $this->display['name']]
-      )[0] ?? NULL;
-      if ($afform['searchDisplay']) {
-        $this->_afform = $afform;
-      }
-    }
-    return $this->_afform;
-  }
-
-  /**
-   * Adds additional fields to the select clause required to render the display
-   *
-   * @param array $apiParams
-   */
-  private function augmentSelectClause(&$apiParams): void {
-    $possibleTokens = '';
-    foreach ($this->display['settings']['columns'] ?? [] as $column) {
-      // Collect display values in which a token is allowed
-      $possibleTokens .= ($column['rewrite'] ?? '') . ($column['link']['path'] ?? '');
-      if (!empty($column['links'])) {
-        $possibleTokens .= implode('', array_column($column['links'], 'path'));
-        $possibleTokens .= implode('', array_column($column['links'], 'text'));
-      }
-
-      // Select value fields for in-place editing
-      if (isset($column['editable']['value']) && !in_array($column['editable']['value'], $apiParams['select'])) {
-        $apiParams['select'][] = $column['editable']['value'];
-      }
-    }
-    // Add fields referenced via token
-    $tokens = [];
-    preg_match_all('/\\[([^]]+)\\]/', $possibleTokens, $tokens);
-    $apiParams['select'] = array_unique(array_merge($apiParams['select'], $tokens[1]));
   }
 
 }

--- a/ext/search_kit/Civi/Api4/SearchDisplay.php
+++ b/ext/search_kit/Civi/Api4/SearchDisplay.php
@@ -29,6 +29,15 @@ class SearchDisplay extends Generic\DAOEntity {
       ->setCheckPermissions($checkPermissions);
   }
 
+  /**
+   * @param bool $checkPermissions
+   * @return Action\SearchDisplay\Run
+   */
+  public static function download($checkPermissions = TRUE) {
+    return (new Action\SearchDisplay\Download(__CLASS__, __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
+  }
+
   public static function permissions() {
     $permissions = parent::permissions();
     $permissions['default'] = ['administer CiviCRM data'];

--- a/ext/search_kit/ang/crmSearchDisplay/colType/field.html
+++ b/ext/search_kit/ang/crmSearchDisplay/colType/field.html
@@ -6,7 +6,7 @@
   <span ng-repeat="link in $ctrl.getLinks(row, col)">
     <a target="{{:: col.link.target }}" href="{{:: link.url }}">
       <span ng-if=":: col.image && $ctrl.formatFieldValue(row, col).length">
-        <img ng-src="{{:: $ctrl.formatFieldValue(row, col) }}" alt="{{:: $ctrl.replaceTokens(col.image.alt, row, $ctrl.settings.columns) }}" height="{{:: col.image.height }}" width="{{:: col.image.width }}"/>
+        <img ng-src="{{:: $ctrl.formatFieldValue(row, col) }}" alt="{{:: $ctrl.replaceTokens(col.image.alt, row) }}" height="{{:: col.image.height }}" width="{{:: col.image.width }}"/>
       </span>
       {{:: link.value }}</a><span ng-if="!$last">,
     </span>

--- a/ext/search_kit/ang/crmSearchDisplay/crmSearchDisplayEditable.component.js
+++ b/ext/search_kit/ang/crmSearchDisplay/crmSearchDisplayEditable.component.js
@@ -19,8 +19,8 @@
 
       this.$onInit = function() {
         col = this.col;
-        this.value = _.cloneDeep(this.row[col.editable.value]);
-        initialValue = _.cloneDeep(this.row[col.editable.value]);
+        this.value = _.cloneDeep(this.row[col.editable.value].raw);
+        initialValue = _.cloneDeep(this.row[col.editable.value].raw);
 
         this.field = {
           data_type: col.dataType,
@@ -54,7 +54,7 @@
           ctrl.cancel();
           return;
         }
-        var values = {id: ctrl.row[col.editable.id]};
+        var values = {id: ctrl.row[col.editable.id].raw};
         values[col.editable.name] = ctrl.value;
         $('input', $element).attr('disabled', true);
         crmStatus({}, crmApi4(col.editable.entity, 'update', {

--- a/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
+++ b/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
@@ -6,15 +6,14 @@
     var ts = CRM.ts('org.civicrm.search_kit');
 
     // Replace tokens keyed to rowData.
-    // If rowMeta is provided, values will be formatted; if omitted, raw values will be provided.
-    function replaceTokens(str, rowData, rowMeta, index) {
+    // Pass view=true to replace with view value, otherwise raw value is used.
+    function replaceTokens(str, rowData, view, index) {
       if (!str) {
         return '';
       }
       _.each(rowData, function(value, key) {
         if (str.indexOf('[' + key + ']') >= 0) {
-          var column = rowMeta && _.findWhere(rowMeta, {key: key}),
-            val = column ? formatRawValue(column, value) : value,
+          var val = view ? value.view : value.raw,
             replacement = angular.isArray(val) ? val[index || 0] : val;
           str = str.replace(new RegExp(_.escapeRegExp('[' + key + ']', 'g')), replacement);
         }
@@ -23,7 +22,7 @@
     }
 
     function getUrl(link, rowData, index) {
-      var url = replaceTokens(link, rowData, null, index);
+      var url = replaceTokens(link, rowData, false, index);
       if (url.slice(0, 1) !== '/' && url.slice(0, 4) !== 'http') {
         url = CRM.url(url);
       }
@@ -33,14 +32,14 @@
     // Returns display value for a single column in a row
     function formatDisplayValue(rowData, key, columns) {
       var column = _.findWhere(columns, {key: key}),
-        displayValue = column.rewrite ? replaceTokens(column.rewrite, rowData, columns) : formatRawValue(column, rowData[key]);
+        displayValue = column.rewrite ? replaceTokens(column.rewrite, rowData, columns) : getValue(rowData[key], 'view');
       return angular.isArray(displayValue) ? displayValue.join(', ') : displayValue;
     }
 
     // Returns value and url for a column formatted as link(s)
     function formatLinks(rowData, key, columns) {
       var column = _.findWhere(columns, {key: key}),
-        value = column.image ? '' : formatRawValue(column, rowData[key]),
+        value = column.image ? '' : getValue(rowData[key], 'view'),
         values = angular.isArray(value) ? value : [value],
         links = [];
       _.each(values, function(value, index) {
@@ -52,25 +51,9 @@
       return links;
     }
 
-    // Formats raw field value according to data type
-    function formatRawValue(column, value) {
-      var type = column && column.dataType,
-        result = value;
-      if (_.isArray(value)) {
-        return _.map(value, function(val) {
-          return formatRawValue(column, val);
-        });
-      }
-      if (value && (type === 'Date' || type === 'Timestamp') && /^\d{4}-\d{2}-\d{2}/.test(value)) {
-        result = CRM.utils.formatDate(value, null, type === 'Timestamp');
-      }
-      else if (type === 'Boolean' && typeof value === 'boolean') {
-        result = value ? ts('Yes') : ts('No');
-      }
-      else if (type === 'Money' && typeof value === 'number') {
-        result = CRM.formatMoney(value);
-      }
-      return result;
+    // Get value from column data, specify either 'raw' or 'view'
+    function getValue(data, ret) {
+      return (data || {})[ret];
     }
 
     // Return a base trait shared by all search display controllers

--- a/ext/search_kit/ang/crmSearchTasks/traits/searchDisplayTasksTrait.service.js
+++ b/ext/search_kit/ang/crmSearchTasks/traits/searchDisplayTasksTrait.service.js
@@ -23,7 +23,7 @@
         // Select all
         ctrl.allRowsSelected = true;
         if (ctrl.page === 1 && ctrl.results.length < ctrl.limit) {
-          ctrl.selectedRows = _.pluck(ctrl.results, 'id');
+          ctrl.selectedRows = _.pluck(_.pluck(ctrl.results, 'id'), 'raw');
           return;
         }
         // If more than one page of results, use ajax to fetch all ids
@@ -37,9 +37,9 @@
 
       // Toggle row selection
       selectRow: function(row) {
-        var index = this.selectedRows.indexOf(row.id);
+        var index = this.selectedRows.indexOf(row.id.raw);
         if (index < 0) {
-          this.selectedRows.push(row.id);
+          this.selectedRows.push(row.id.raw);
           this.allRowsSelected = (this.rowCount === this.selectedRows.length);
         } else {
           this.allRowsSelected = false;
@@ -49,7 +49,7 @@
 
       // @return bool
       isRowSelected: function(row) {
-        return this.allRowsSelected || _.includes(this.selectedRows, row.id);
+        return this.allRowsSelected || _.includes(this.selectedRows, row.id.raw);
       },
 
       refreshAfterTask: function() {
@@ -69,8 +69,8 @@
       onPostRun: [function(results, status, editedRow) {
         if (editedRow && status === 'success') {
           // If edited row disappears (because edits cause it to not meet search criteria), deselect it
-          var index = this.selectedRows.indexOf(editedRow.id);
-          if (index > -1 && !_.findWhere(results, {id: editedRow.id})) {
+          var index = this.selectedRows.indexOf(editedRow.id.raw);
+          if (index > -1 && !_.findWhere(results, {id: editedRow.id.raw})) {
             this.selectedRows.splice(index, 1);
           }
         }


### PR DESCRIPTION
Overview
----------------------------------------
Refactoring work toward a SearchKit direct export feature.

https://lab.civicrm.org/dev/core/-/issues/2732

Before
----------------------------------------
Field formatting (e.g. date format) done in javascript.

After
----------------------------------------
Field formatting done on the server

Technical Details
----------
Formattig field values server-side allows the view values to be reused in exports.
It also opens the door for more complex formatting to happen on the server, if needed.


https://lab.civicrm.org/documentation/docs/user-en/-/merge_requests/495