### PR TITLE
[NFC] Fix UpdateSubscriptionTest on php8 by creating a Payment Processor

### DIFF
--- a/tests/phpunit/CRM/Contribute/Form/UpdateSubscriptionTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/UpdateSubscriptionTest.php
@@ -71,12 +71,13 @@ class CRM_Contribute_Form_UpdateSubscriptionTest extends CiviUnitTestCase {
    *
    */
   public function addContribution(): void {
+    $this->paymentProcessorId = $this->processorCreate();
     $this->callAPISuccess('Order', 'create', [
       'contact_id' => $this->getContactID(),
       'contribution_recur_id' => $this->getContributionRecurID(),
       'financial_type_id' => 'Donation',
       'total_amount' => 10,
-      'api.Payment.create' => ['total_amount' => 10],
+      'api.Payment.create' => ['total_amount' => 10, 'payment_processor_id' => $this->paymentProcessorId],
     ]);
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
This fixes the following the following test error on php8

```
CRM_Contribute_Form_UpdateSubscriptionTest::testMail
Failure in api call for Order create:  Error in call to Payment_create : Undefined array key "updateSubscriptionBillingUrl"
#0 /home/jenkins/bknix-edge/build/build-2/web/sites/all/modules/civicrm/CRM/Financial/BAO/Payment.php(189): civicrm_api3('Contribu
```

Before
----------------------------------------
Test fails on php8

After
----------------------------------------
Test passes on php8

ping @eileenmcnaughton 