### PR TITLE
Use realpath with WordPress to prevent excessive log entries

### DIFF
--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -98,7 +98,12 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
           'url' => $upload_dir['baseurl'] . '/civicrm/',
         ];
 
-        if ($old['path'] === $new['path']) {
+        // If the path to the WordPress installation includes symlinks,
+        // the old and new paths can hold different names for the same folder
+        $oldRealpath = realpath($old['path']);
+        $newRealpath = realpath($new['path']);
+
+        if ($oldRealpath !== false && $oldRealpath === $newRealpath) {
            return $new;
         }
 


### PR DESCRIPTION
If the path to the WordPress installation contains symlinks, the old and new methods can return different names for the same folder.  This resulted in filling the log with warnings to set the location in the CiviCRM settings file.  Expanding the symlinks with realpath before comparing avoids the extra log messages.  We have to check for false as realpath returns false if the path does not exist.