### PR TITLE
dev/core#2807 - Contribution thank-you letters give Undefined index: contribution when you don't use any contribution tokens

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -5158,13 +5158,13 @@ LIMIT 1;";
       return [];
     }
     $result = civicrm_api3('Contribution', 'get', ['id' => $id]);
-    // lab.c.o mail#46 - show labels, not values, for custom fields with option values.
-    foreach ($result['values'][$id] as $fieldName => $fieldValue) {
-      if (strpos($fieldName, 'custom_') === 0 && array_search($fieldName, $messageToken['contribution']) !== FALSE) {
-        $result['values'][$id][$fieldName] = CRM_Core_BAO_CustomField::displayValue($result['values'][$id][$fieldName], $fieldName);
-      }
-    }
     if (!empty($messageToken['contribution'])) {
+      // lab.c.o mail#46 - show labels, not values, for custom fields with option values.
+      foreach ($result['values'][$id] as $fieldName => $fieldValue) {
+        if (strpos($fieldName, 'custom_') === 0 && array_search($fieldName, $messageToken['contribution']) !== FALSE) {
+          $result['values'][$id][$fieldName] = CRM_Core_BAO_CustomField::displayValue($result['values'][$id][$fieldName], $fieldName);
+        }
+      }
       $processor = new CRM_Contribute_Tokens();
       $pseudoFields = array_keys($processor->getPseudoTokens());
       foreach ($pseudoFields as $pseudoField) {


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/2807

Before
----------------------------------------
1. Search for contributions.
1. From actions choose thank-you letter.
1. Don't use any contribution tokens in the message.
1. Submit.
1. Depending on how your site is set up you may need to now visit another page to see the red warnings.

After
----------------------------------------


Technical Details
----------------------------------------
The loop was moved out of the `if` in https://github.com/civicrm/civicrm-core/commit/9b3cb77dca4db85658e62b2b1b7f2d24958a9714 but I can't see a reason why?

Comments
----------------------------------------
Affects 5.41+