### PR TITLE
SearchKit - Fix pager count and add 'None Found' text in empty tables

### DIFF
--- a/ext/search_kit/ang/crmSearchDisplay/Pager.html
+++ b/ext/search_kit/ang/crmSearchDisplay/Pager.html
@@ -30,7 +30,7 @@
       <label for="crm-search-results-page-size" >
         {{:: ts('Page Size') }}
       </label>
-      <input class="form-control" id="crm-search-results-page-size" type="number" ng-model="$ctrl.limit" min="10" step="10" ng-change="onChangeLimit()">
+      <input class="form-control" id="crm-search-results-page-size" type="number" ng-model="$ctrl.limit" min="10" step="10">
     </div>
   </div>
 </div>

--- a/ext/search_kit/ang/crmSearchDisplay/SearchButton.html
+++ b/ext/search_kit/ang/crmSearchDisplay/SearchButton.html
@@ -1,4 +1,4 @@
-<button type="button" class="btn btn-primary" ng-click="$ctrl.getResults()" ng-disabled="$ctrl.loading">
+<button type="button" class="btn btn-primary" ng-click="$ctrl.onClickSearchButton()" ng-disabled="$ctrl.loading">
   <i ng-if="$ctrl.loading" class="crm-i fa-spin fa-spinner"></i>
   <i ng-if="!$ctrl.loading" class="crm-i fa-search"></i>
   {{:: $ctrl.settings.button }}

--- a/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
+++ b/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
@@ -131,6 +131,12 @@
         };
       },
 
+      onClickSearchButton: function() {
+        this.rowCount = null;
+        this.page = 1;
+        this.getResults();
+      },
+
       // Call SearchDisplay.run and update ctrl.results and ctrl.rowCount
       runSearch: function(editedRow) {
         var ctrl = this,

--- a/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTableBody.html
+++ b/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTableBody.html
@@ -4,5 +4,11 @@
   </td>
   <td ng-repeat="col in $ctrl.settings.columns" ng-include="'~/crmSearchDisplay/colType/' + col.type + '.html'" title="{{:: $ctrl.replaceTokens(col.title, row) }}" class="{{:: col.alignment }}">
   </td>
-  <td></td>
+</tr>
+<tr ng-if="$ctrl.rowCount === 0">
+  <td colspan="{{ $ctrl.settings.columns.length + 2 }}">
+    <p class="alert alert-info text-center">
+      {{:: ts('None Found') }}
+    </p>
+  </td>
 </tr>


### PR DESCRIPTION
Overview
----------------------------------------
Adds "None Found" text to empty results, and fix a bug when clicking the Search button does not update the pager count.
![Screenshot from 2021-08-31 17-26-17](https://user-images.githubusercontent.com/2874912/131578527-8029fa70-f3d1-4790-911c-2a80c63f0883.png)


Before
----------------------------------------
Clicking the "Search" button in search kit after updating search criteria does not update the pager count.

After
----------------------------------------
Pager count stays up-to-date with search results, and "None Found" shown to visually distinguish an empty table from waiting to load results.