### PR TITLE
[REF] dev/core#2790 deprecate preProcessSingle

### DIFF
--- a/CRM/Contact/Form/Task/PDF.php
+++ b/CRM/Contact/Form/Task/PDF.php
@@ -58,10 +58,11 @@ class CRM_Contact_Form_Task_PDF extends CRM_Contact_Form_Task {
       // in search context 'id' is the default profile id for search display
       // CRM-11227
       $this->_activityId = CRM_Utils_Request::retrieve('id', 'Positive', $this, FALSE);
-    }
-
-    if ($cid) {
-      CRM_Contact_Form_Task_PDFLetterCommon::preProcessSingle($this, $cid);
+      $this->_contactIds = explode(',', $cid);
+      // put contact display name in title for single contact mode
+      if (count($this->_contactIds) === 1) {
+        CRM_Utils_System::setTitle(ts('Print/Merge Document for %1', [1 => CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Contact', $cid, 'display_name')]));
+      }
       $this->_single = TRUE;
     }
     else {
@@ -85,6 +86,8 @@ class CRM_Contact_Form_Task_PDF extends CRM_Contact_Form_Task {
 
   /**
    * Build the form object.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function buildQuickForm() {
     //enable form element

--- a/CRM/Contact/Form/Task/PDFLetterCommon.php
+++ b/CRM/Contact/Form/Task/PDFLetterCommon.php
@@ -59,10 +59,12 @@ class CRM_Contact_Form_Task_PDFLetterCommon extends CRM_Core_Form_Task_PDFLetter
   }
 
   /**
+   * @deprecated
    * @param CRM_Core_Form $form
    * @param int $cid
    */
   public static function preProcessSingle(&$form, $cid) {
+    CRM_Core_Error::deprecatedFunctionWarning('no alternative');
     $form->_contactIds = explode(',', $cid);
     // put contact display name in title for single contact mode
     if (count($form->_contactIds) === 1) {


### PR DESCRIPTION

Overview
----------------------------------------
[REF] dev/core#2790 deprecate preProcessSingle

Before
----------------------------------------
Function is on another class, function name doesn't give much information about what it is doing so it just adds complexity

After
----------------------------------------
Code brought 'back into the fold'

Technical Details
----------------------------------------
This is only called from here & is short & can just be part of the main function.

Comments
----------------------------------------
@demeritcowboy another fairly simple one