### PR TITLE
[REF] dev/core#2790 dev/core#2814 Start migration to MessageTemplate::render

### DIFF
--- a/CRM/Contact/Form/Task/PDFLetterCommon.php
+++ b/CRM/Contact/Form/Task/PDFLetterCommon.php
@@ -149,19 +149,16 @@ class CRM_Contact_Form_Task_PDFLetterCommon extends CRM_Core_Form_Task_PDFLetter
         continue;
       }
 
-      $tokenHtml = CRM_Utils_Token::replaceContactTokens($html_message, $contact[$contactId], TRUE, $messageToken);
-
+      $tokenHtml = $html_message;
       if ($caseId) {
         $tokenHtml = CRM_Utils_Token::replaceCaseTokens($caseId, $tokenHtml, $messageToken);
       }
-      $tokenHtml = CRM_Utils_Token::replaceHookTokens($tokenHtml, $contact[$contactId], $categories, TRUE);
-
-      if (defined('CIVICRM_MAIL_SMARTY') && CIVICRM_MAIL_SMARTY) {
-        $smarty = CRM_Core_Smarty::singleton();
-        // also add the contact tokens to the template
-        $smarty->assign_by_ref('contact', $contact);
-        $tokenHtml = $smarty->fetch("string:$tokenHtml");
-      }
+      $tokenHtml = CRM_Core_BAO_MessageTemplate::renderTemplate([
+        'contactId' => $contactId,
+        'messageTemplate' => ['msg_html' => $tokenHtml],
+        'tplParams' => ['contact' => $contact],
+        'disableSmarty' => (!defined('CIVICRM_MAIL_SMARTY') || !CIVICRM_MAIL_SMARTY),
+      ])['html'];
 
       $html[] = $tokenHtml;
     }
@@ -181,7 +178,7 @@ class CRM_Contact_Form_Task_PDFLetterCommon extends CRM_Core_Form_Task_PDFLetter
     $fileName = self::getFileName($form);
     $fileName = "$fileName.$type";
 
-    if ($type == 'pdf') {
+    if ($type === 'pdf') {
       CRM_Utils_PDF_Utils::html2pdf($html, $fileName, FALSE, $formValues);
     }
     elseif (!empty($formValues['document_file_path'])) {


### PR DESCRIPTION
Overview
----------------------------------------
[REF] dev/core#2790 Start migration to MessageTemplate::render

Before
----------------------------------------
long chunk of copy & paste used to replace most functions

After
----------------------------------------
`MessageTemplate::render` function used

Technical Details
----------------------------------------
- the test cover should mean we can switch to using the api once the api is available if this is merged first
- I've left the case tokens for later - hence they are before the smarty handling
- we know the contact tokens have been reconciled
- I want to remove this chunk as a follow up - https://github.com/civicrm/civicrm-core/blob/758b39a42cecc318aeb045dd1daa3d05356f44df/CRM/Contact/Form/Task/PDFLetterCommon.php#L138-L150 - however it is still achieving 2 things for now 
  1)  possibly maybe filtering out deceased & on hold - I have my doubts but havent tested yet - that should be done before the rendering starts IMHO
   2) retrieving the contact to assign to the template IF smarty is enabled
- @totten - this last point throws up a variant of what we have been discussing -  an annoying variant - note I don't see it as blocking on merging this - just something for next PR

Comments
----------------------------------------
