### PR TITLE
dev/core#2806 Fix accidental exposure of v4 tokens

### DIFF
--- a/CRM/Core/EntityTokens.php
+++ b/CRM/Core/EntityTokens.php
@@ -321,7 +321,12 @@ class CRM_Core_EntityTokens extends AbstractTokenSubscriber {
   public function getBasicTokens(): array {
     $return = [];
     foreach ($this->getExposedFields() as $fieldName) {
-      $return[$fieldName] = $this->getFieldMetadata()[$fieldName]['title'];
+      // Custom fields are still added v3 style - we want to keep v4 naming 'unpoluted'
+      // for now to allow us to consider how to handle names vs labels vs values
+      // and other raw vs not raw options.
+      if ($this->getFieldMetadata()[$fieldName]['type'] !== 'Custom') {
+        $return[$fieldName] = $this->getFieldMetadata()[$fieldName]['title'];
+      }
     }
     return $return;
   }


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#2806 Fix accidental exposure of v4 tokens

Before
----------------------------------------
In master (only) tokens were being displayed like '`{contribution.Partner.name'} ` referring to custom fields. Long term we want this more portable format but we are not ready to define it yet

After
----------------------------------------
Extraneous tokens removed

Technical Details
----------------------------------------
@demeritcowboy I haven't added a test here because I'm working on tests for this stuff in `CRM_Utils_TokenConsistencyTest` but I already have an open test against this class - https://github.com/civicrm/civicrm-core/pull/21327/files - unfortunately that one didn't pick it up because  contribution recur doesn't 'normally' have custom data - but I do intend to add more tests for this stuff in that class . The class I did the original contribution tokens test in unfortunately uses rollback which doesn't play nice with custom fields so I 'moved'


Comments
----------------------------------------

