### PR TITLE
Scheduled Job Hook Use pass by reference for Job manager

### DIFF
--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -2030,7 +2030,7 @@ abstract class CRM_Utils_Hook {
    * @return null
    *   The return value is ignored.
    */
-  public static function cron($jobManager) {
+  public static function cron(&$jobManager) {
     return self::singleton()->invoke(['jobManager'],
       $jobManager, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
       'civicrm_cron'


### PR DESCRIPTION
Overview
----------------------------------------
Use pass by reference

Before
----------------------------------------
`cron` hook is called before iterating all jobs.
```php
CRM_Utils_Hook::cron($this);
foreach ($this->jobs as $job) {
  if ($job->is_active) {
    if ($job->needsRunning()) {
      $this->executeJob($job);
    }
  }
}
```
If, We want to add, modify, disable or skip certain job through hook ,  we are not able to update the main object and pass updated object to main caller object ( Hook changes not get reflected).

After
----------------------------------------
We can update the object.

