### PR TITLE
[NFC/Unit test] Update flaky test CRM_Utils_TokenConsistencyTest::testCaseTokenConsistency

### DIFF
--- a/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
+++ b/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
@@ -74,8 +74,8 @@ July 26th, 2021
 case details
 Ongoing
 No
-' . $this->case['modified_date'] . '
 ' . $this->case['created_date'] . '
+' . $this->case['modified_date'] . '
 ';
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Avoid flaky test because created and modified are backwards which might have a split-second difference between them, e.g. https://test.civicrm.org/job/CiviCRM-Core-PR/43516/testReport/junit/(root)/CRM_Utils_TokenConsistencyTest/testCaseTokenConsistency/

```
CRM_Utils_TokenConsistencyTest::testCaseTokenConsistency
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
 Ongoing\n
 No\n
 2021-09-01 02:36:47\n
-2021-09-01 02:36:47\n
+2021-09-01 02:36:48\n
 '

/home/jenkins/bknix-dfl/build/core-21328-7rs5q/web/sites/all/modules/civicrm/tests/phpunit/CRM/Utils/TokenConsistencyTest.php:57
```