### PR TITLE
SearchKit - Add links to admin table and refresh after popups

### DIFF
--- a/ext/search_kit/Civi/Search/Admin.php
+++ b/ext/search_kit/Civi/Search/Admin.php
@@ -68,6 +68,7 @@ class Admin {
     return [
       'default' => E::ts('Default'),
       'primary' => E::ts('Primary'),
+      'secondary' => E::ts('Secondary'),
       'success' => E::ts('Success'),
       'info' => E::ts('Info'),
       'warning' => E::ts('Warning'),

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
@@ -583,19 +583,26 @@
           switch (link.action) {
             case 'view':
               link.title = ts('View %1', {1: entityName});
+              link.icon = 'fa-external-link';
+              link.style = 'default';
               break;
 
             case 'update':
               link.title = ts('Edit %1', {1: entityName});
+              link.icon = 'fa-pencil';
+              link.style = 'default';
               break;
 
             case 'delete':
               link.title = ts('Delete %1', {1: entityName});
+              link.icon = 'fa-trash';
+              link.style = 'danger';
               break;
           }
         }
 
         // Links to main entity
+        // @return {Array}
         var mainEntity = searchMeta.getEntity(ctrl.savedSearch.api_entity),
           links = _.cloneDeep(mainEntity.paths || []);
         _.each(links, function(link) {

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminLinkGroup.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminLinkGroup.component.js
@@ -31,18 +31,6 @@
         }
       };
 
-      var defaultIcons = {
-        view: 'fa-external-link',
-        update: 'fa-pencil',
-        delete: 'fa-trash'
-      };
-
-      var defaultStyles = {
-        view: 'primary',
-        update: 'warning',
-        delete: 'danger'
-      };
-
       $scope.pickIcon = function(index) {
         searchMeta.pickIcon().then(function(icon) {
           ctrl.group[index].icon = icon;
@@ -53,9 +41,9 @@
         var link = ctrl.getLink(path);
         ctrl.group.push({
           path: path,
-          style: link && defaultStyles[link.action] || 'default',
+          style: link && link.style || 'default',
           text: link ? link.title : ts('Link'),
-          icon: link && defaultIcons[link.action] || 'fa-external-link'
+          icon: link && link.icon || 'fa-external-link'
         });
       };
 

--- a/ext/search_kit/ang/crmSearchAdmin/displays/colType/menu.html
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/colType/menu.html
@@ -12,12 +12,13 @@
     {{:: ts('Style') }}
   </label>
   <select id="crm-search-admin-col-style-{{$index}}" class="form-control" ng-model="col.style">
-    <option ng-repeat="opt in $ctrl.parent.styles" value="{{ opt.key }}">{{ opt.value }}</option>
+    <option ng-repeat="opt in $ctrl.parent.styles" value="{{:: opt.key }}">{{:: opt.value }}</option>
+    <option ng-repeat="opt in $ctrl.parent.styles" value="{{:: opt.key + '-outline' }}">{{:: opt.value + ' ' + ts('Outline') }}</option>
   </select>
 </div>
 <div class="form-inline">
   <label>
-    {{:: ts('Menu Text/Icon') }}
+    {{:: ts('Menu Icon/Text') }}
   </label>
   <div class="btn-group">
     <button type="button" class="btn btn-{{ col.style + ' ' + col.size }}">

--- a/ext/search_kit/ang/crmSearchAdmin/resultsTable/crmSearchAdminResultsTable.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/resultsTable/crmSearchAdminResultsTable.component.js
@@ -10,7 +10,7 @@
       crmSearchAdmin: '^crmSearchAdmin'
     },
     templateUrl: '~/crmSearchAdmin/resultsTable/crmSearchAdminResultsTable.html',
-    controller: function($scope, searchMeta, searchDisplayBaseTrait, searchDisplayTasksTrait, searchDisplaySortableTrait) {
+    controller: function($scope, $element, searchMeta, searchDisplayBaseTrait, searchDisplayTasksTrait, searchDisplaySortableTrait) {
       var ts = $scope.ts = CRM.ts('org.civicrm.search_kit'),
         // Mix in traits to this controller
         ctrl = angular.extend(this, searchDisplayBaseTrait, searchDisplayTasksTrait, searchDisplaySortableTrait);
@@ -49,6 +49,25 @@
             })
           }
         };
+        if (links.length) {
+          ctrl.display.settings.columns.push({
+            text: '',
+            icon: 'fa-bars',
+            type: 'menu',
+            size: 'btn-xs',
+            style: 'secondary-outline',
+            alignment: 'text-right',
+            links: _.transform(links, function(links, link) {
+              links.push({
+                path: link.path,
+                text: link.title,
+                icon: link.icon,
+                style: link.style,
+                target: link.action === 'view' ? '_blank' : 'crm-popup'
+              });
+            })
+          });
+        }
         ctrl.debug = {
           apiParams: JSON.stringify(ctrl.search.api_params, null, 2)
         };
@@ -57,7 +76,7 @@
 
       this.$onInit = function() {
         buildSettings();
-        this.initializeDisplay($scope, $());
+        this.initializeDisplay($scope, $element);
         $scope.$watch('$ctrl.search.api_entity', buildSettings);
         $scope.$watch('$ctrl.search.api_params', buildSettings, true);
       };

--- a/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
+++ b/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
@@ -90,6 +90,8 @@
           });
         }
 
+        $element.on('crmPopupFormSuccess', this.getResults);
+
         function onChangeFilters() {
           ctrl.page = 1;
           ctrl.rowCount = null;


### PR DESCRIPTION
Overview
----------------------------------------
Adds quick-action links to the admin results table.

![Screenshot from 2021-09-01 15-42-22](https://user-images.githubusercontent.com/2874912/131733974-8720c4ea-5b6a-42f4-a13b-7612d9c60fb1.png)

Technical Details
--------------
Adds optional outline button styles which look better IMO.
Also fixes a bug where editing or deleting a contact in a popup wasn't refreshing the search results.