### PR TITLE
[REF] Fix Page Hook test on php8 by putting in guard into customDataB…

### DIFF
--- a/templates/CRM/common/customDataBlock.tpl
+++ b/templates/CRM/common/customDataBlock.tpl
@@ -7,7 +7,7 @@
   <script type="text/javascript">
     CRM.$(function($) {
       {/literal}
-      {if $customDataSubType}
+      {if !empty($customDataSubType)}
         CRM.buildCustomData('{$customDataType}', {$customDataSubType}, false, false, false, false, false, {$cid});
       {else}
         CRM.buildCustomData('{$customDataType}', false, false, false, false, false, false, {$cid});


### PR DESCRIPTION
…lock around the SubType variable

Overview
----------------------------------------
CRM_Core_Page_HookTest fails on php8 due to an e-notice

Before
----------------------------------------
Test fails

```
CRM_Core_Page_HookTest::testFormsCallBuildFormOnce
Undefined array key "customDataSubType"

/home/jenkins/bknix-edge/build/build-0/web/sites/default/files/civicrm/templates_c/en_US/%%9F/9F8/9F828591%%customDataBlock.tpl.php:18
/home/jenkins/bknix-edge/build/build-0/web/sites/all/modules/civicrm/packages/Smarty/Smarty.class.php:1914
/home/jenkins/bknix-edge/build/build-0/web/sites/default/files/civicrm/templates_c/en_US/%%4C/4C5/4C5F7411%%EntityForm.tpl.php:36
/home/jenkins/bknix-edge/build/build-0/web/sites/all/modules/civicrm/packages/Smarty/Smarty.class.php:1914
/home/jenkins/bknix-edge/build/build-0/web/sites/default/files/civicrm/templates_c/en_US/%%7A/7AF/7AF88B87%%RelationshipType.tpl.php:6
```

After
----------------------------------------
Test passes on php8

ping @eileenmcnaughton @demeritcowboy 