### PR TITLE
[NFC] Fix E-notice in Afform unit tests

### DIFF
--- a/ext/afform/core/Civi/Api4/Action/Afform/Get.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/Get.php
@@ -56,7 +56,7 @@ class Get extends \Civi\Api4\Generic\BasicGetAction {
       // Skip if afform does not exist or is not of requested type(s)
       if (
         (!$record && !isset($values[$name])) ||
-        ($getTypes && !in_array($record['type'], $getTypes, TRUE))
+        ($getTypes && isset($record['type']) && !in_array($record['type'], $getTypes, TRUE))
       ) {
         continue;
       }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes the following e-notice in Afform unit tests

```
api_v4_AfformFileUploadTest::testSubmitFile
Trying to access array offset on value of type null

/home/jenkins/bknix-max/build/build-0/web/sites/all/modules/civicrm/ext/afform/core/Civi/Api4/Action/Afform/Get.php:59
```

Before
----------------------------------------
E-notice exists in tests on php7.4 and up

After
----------------------------------------
No E-notice

ping @colemanw 