### PR TITLE
dev/core#2812 Fix issue where having a processor configured with a se…

### DIFF
--- a/CRM/Core/ClassLoader.php
+++ b/CRM/Core/ClassLoader.php
@@ -133,6 +133,8 @@ class CRM_Core_ClassLoader {
       '.',
       $civicrm_base_path,
       $packages_path,
+      // dev/core#2812 Ensure that the database upgrade script can run if dataprocessor extension is enabled. It relies on the legacy custom searches which have been moved into this extension
+      implode(DIRECTORY_SEPARATOR, [$civicrm_base_path, 'ext', 'legacycustomsearches']),
     ];
     $include_paths = implode(PATH_SEPARATOR, $include_paths);
     set_include_path($include_paths . PATH_SEPARATOR . get_include_path());


### PR DESCRIPTION
…arch output casues WSOD not allowing for access to upgrade screen

Overview
----------------------------------------
This fixes a problem with the dataprocessor extension being enabled after deploying the 5.41 code base and before upgrade step causing a WSOD due to the reliance on the legacy custom search classes

Before
----------------------------------------
1. Set up demo wordpress site
2. Install CIvi 5.40
3. Install Dataprocessor extension
4. create a sample dataprocessor that uses Contact as the source and has a field of Contact ID and outputs a Dashlet and a Search / Report.
5. Attach Dashlet on dashboard
6. Deploy the CIvi 5.41 codebase
WSOD and cannot even access the UI upgrade screen

After
----------------------------------------
No WSOD

Technical Details
----------------------------------------
The problem seems to be that there is some heavy dependency on the base custom search class in dataprovider which is causing issues pre db upgrade step

ping @eileenmcnaughton @agileware-justin @totten 

Comments
----------------------------------------

This was originally submitted for 5.42-RC as https://github.com/civicrm/civicrm-core/pull/21347