### PR TITLE
Remove requirement to enter email address on Opt Out

### DIFF
--- a/CRM/Admin/Form/Preferences/Mailing.php
+++ b/CRM/Admin/Form/Preferences/Mailing.php
@@ -16,7 +16,7 @@
  */
 
 /**
- * This class generates form components for the maling component preferences.
+ * This class generates form components for the mailing component preferences.
  */
 class CRM_Admin_Form_Preferences_Mailing extends CRM_Admin_Form_Preferences {
 

--- a/CRM/Mailing/Form/Optout.php
+++ b/CRM/Mailing/Form/Optout.php
@@ -16,18 +16,40 @@
  */
 class CRM_Mailing_Form_Optout extends CRM_Core_Form {
 
+  /**
+   * Prevent people double-submitting the form (e.g. by double-clicking).
+   * https://lab.civicrm.org/dev/core/-/issues/1773
+   *
+   * @var bool
+   */
+  public $submitOnce = TRUE;
+
+  /**
+   * @var int
+   */
+  private $_job_id;
+
+  /**
+   * @var int
+   */
+  private $_queue_id;
+
+  /**
+   * @var string
+   */
+  private $_hash;
+
+  /**
+   * @var string
+   */
+  private $_email;
+
   public function preProcess() {
-
-    $this->_type = 'optout';
-
     $this->_job_id = $job_id = CRM_Utils_Request::retrieve('jid', 'Integer', $this);
     $this->_queue_id = $queue_id = CRM_Utils_Request::retrieve('qid', 'Integer', $this);
     $this->_hash = $hash = CRM_Utils_Request::retrieve('h', 'String', $this);
 
-    if (!$job_id ||
-      !$queue_id ||
-      !$hash
-    ) {
+    if (!$job_id || !$queue_id || !$hash) {
       throw new CRM_Core_Exception(ts("Missing input parameters"));
     }
 
@@ -49,9 +71,6 @@ class CRM_Mailing_Form_Optout extends CRM_Core_Form {
     CRM_Utils_System::addHTMLHead('<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">');
     $this->setTitle(ts('Opt Out Confirmation'));
 
-    $this->add('text', 'email_confirm', ts('Verify email address to opt out:'));
-    $this->addRule('email_confirm', ts('Email address is required to opt out.'), 'required');
-
     $buttons = [
       [
         'type' => 'next',
@@ -68,42 +87,17 @@ class CRM_Mailing_Form_Optout extends CRM_Core_Form {
   }
 
   public function postProcess() {
-
-    $values = $this->exportValues();
-
-    // check if EmailTyped matches Email address
-    $result = CRM_Utils_String::compareStr($this->_email, $values['email_confirm'], TRUE);
-
-    $job_id = $this->_job_id;
-    $queue_id = $this->_queue_id;
-    $hash = $this->_hash;
-
-    $confirmURL = CRM_Utils_System::url("civicrm/mailing/{$this->_type}", "reset=1&jid={$job_id}&qid={$queue_id}&h={$hash}&confirm=1");
+    $confirmURL = CRM_Utils_System::url("civicrm/mailing/optout", "reset=1&jid={$this->_job_id}&qid={$this->_queue_id}&h={$this->_hash}&confirm=1");
     $this->assign('confirmURL', $confirmURL);
-    $session = CRM_Core_Session::singleton();
-    $session->pushUserContext($confirmURL);
+    CRM_Core_Session::singleton()->pushUserContext($confirmURL);
 
-    if ($result == TRUE) {
-      // Email address verified
-      if (CRM_Mailing_Event_BAO_Unsubscribe::unsub_from_domain($job_id, $queue_id, $hash)) {
-        CRM_Mailing_Event_BAO_Unsubscribe::send_unsub_response($queue_id, NULL, TRUE, $job_id);
-      }
-
-      $statusMsg = ts('%1 opt out confirmed.',
-        [1 => $values['email_confirm']]
-      );
-
-      CRM_Core_Session::setStatus($statusMsg, '', 'success');
-    }
-    elseif ($result == FALSE) {
-      // Email address not verified
-      $statusMsg = ts('%1 is not associated with this opt out request.',
-        [1 => $values['email_confirm']]
-      );
-
-      CRM_Core_Session::setStatus($statusMsg, '', 'error');
+    // Email address verified
+    if (CRM_Mailing_Event_BAO_Unsubscribe::unsub_from_domain($this->_job_id, $this->_queue_id, $this->_hash)) {
+      CRM_Mailing_Event_BAO_Unsubscribe::send_unsub_response($this->_queue_id, NULL, TRUE, $this->_job_id);
     }
 
+    $statusMsg = ts('%1 opt out confirmed.', [1 => CRM_Utils_String::maskEmail($this->_email)]);
+    CRM_Core_Session::setStatus($statusMsg, '', 'success');
   }
 
 }

--- a/CRM/Mailing/Form/Unsubscribe.php
+++ b/CRM/Mailing/Form/Unsubscribe.php
@@ -24,18 +24,32 @@ class CRM_Mailing_Form_Unsubscribe extends CRM_Core_Form {
    */
   public $submitOnce = TRUE;
 
+  /**
+   * @var int
+   */
+  private $_job_id;
+
+  /**
+   * @var int
+   */
+  private $_queue_id;
+
+  /**
+   * @var string
+   */
+  private $_hash;
+
+  /**
+   * @var string
+   */
+  private $_email;
+
   public function preProcess() {
-
-    $this->_type = 'unsubscribe';
-
     $this->_job_id = $job_id = CRM_Utils_Request::retrieve('jid', 'Integer', $this);
     $this->_queue_id = $queue_id = CRM_Utils_Request::retrieve('qid', 'Integer', $this);
     $this->_hash = $hash = CRM_Utils_Request::retrieve('h', 'String', $this);
 
-    if (!$job_id ||
-      !$queue_id ||
-      !$hash
-    ) {
+    if (!$job_id || !$queue_id || !$hash) {
       throw new CRM_Core_Exception(ts('Missing Parameters'));
     }
 
@@ -55,27 +69,21 @@ class CRM_Mailing_Form_Unsubscribe extends CRM_Core_Form {
     $groups = CRM_Mailing_Event_BAO_Unsubscribe::unsub_from_mailing($job_id, $queue_id, $hash, TRUE);
     $this->assign('groups', $groups);
     $groupExist = NULL;
-    foreach ($groups as $key => $value) {
+    foreach ($groups as $value) {
       if ($value) {
         $groupExist = TRUE;
       }
     }
     if (!$groupExist) {
-      $statusMsg = ts('%1 has been unsubscribed.',
-        [1 => $email]
-      );
+      $statusMsg = ts('%1 has been unsubscribed.', [1 => $email]);
       CRM_Core_Session::setStatus($statusMsg, '', 'error');
     }
     $this->assign('groupExist', $groupExist);
-
   }
 
   public function buildQuickForm() {
     CRM_Utils_System::addHTMLHead('<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">');
     $this->setTitle(ts('Unsubscribe Confirmation'));
-
-    $this->add('text', 'email_confirm', ts('Verify email address to unsubscribe:'));
-    $this->addRule('email_confirm', ts('Email address is required to unsubscribe.'), 'required');
 
     $buttons = [
       [
@@ -93,42 +101,19 @@ class CRM_Mailing_Form_Unsubscribe extends CRM_Core_Form {
   }
 
   public function postProcess() {
-    $values = $this->exportValues();
-
-    // check if EmailTyped matches Email address
-    $result = CRM_Utils_String::compareStr($this->_email, $values['email_confirm'], TRUE);
-    $job_id = $this->_job_id;
-    $queue_id = $this->_queue_id;
-    $hash = $this->_hash;
-
-    $confirmURL = CRM_Utils_System::url("civicrm/mailing/{$this->_type}", "reset=1&jid={$job_id}&qid={$queue_id}&h={$hash}&confirm=1");
+    $confirmURL = CRM_Utils_System::url("civicrm/mailing/unsubscribe", "reset=1&jid={$this->_job_id}&qid={$this->_queue_id}&h={$this->_hash}&confirm=1");
     $this->assign('confirmURL', $confirmURL);
-    $session = CRM_Core_Session::singleton();
-    $session->pushUserContext($confirmURL);
+    CRM_Core_Session::singleton()->pushUserContext($confirmURL);
 
-    if ($result == TRUE) {
-      // Email address verified
-      $groups = CRM_Mailing_Event_BAO_Unsubscribe::unsub_from_mailing($job_id, $queue_id, $hash);
+    // Email address verified
+    $groups = CRM_Mailing_Event_BAO_Unsubscribe::unsub_from_mailing($this->_job_id, $this->_queue_id, $this->_hash);
 
-      if (count($groups)) {
-        CRM_Mailing_Event_BAO_Unsubscribe::send_unsub_response($queue_id, $groups, FALSE, $job_id);
-      }
-
-      $statusMsg = ts('%1 is unsubscribed.',
-        [1 => $values['email_confirm']]
-      );
-
-      CRM_Core_Session::setStatus($statusMsg, '', 'success');
+    if (count($groups)) {
+      CRM_Mailing_Event_BAO_Unsubscribe::send_unsub_response($this->_queue_id, $groups, FALSE, $this->_job_id);
     }
-    elseif ($result == FALSE) {
-      // Email address not verified
-      $statusMsg = ts('%1 is not associated with this unsubscribe request.',
-        [1 => $values['email_confirm']]
-      );
 
-      CRM_Core_Session::setStatus($statusMsg, '', 'error');
-
-    }
+    $statusMsg = ts('%1 is unsubscribed.', [1 => CRM_Utils_String::maskEmail($this->_email)]);
+    CRM_Core_Session::setStatus($statusMsg, '', 'success');
   }
 
 }

--- a/templates/CRM/Mailing/Form/Optout.tpl
+++ b/templates/CRM/Mailing/Form/Optout.tpl
@@ -9,25 +9,18 @@
 *}
 
 <div class="crm-block crm-form-block crm-miscellaneous-form-block">
+  <p>{ts}You are requesting to opt out this email address from all mailing lists:{/ts}</p>
+  <h3>{$email_masked}</h3>
 
-    <p>{ts}You are requesting to opt out this email address from all mailing lists:{/ts}</p>
-    <h3>{$email_masked}</h3>
-
-    <p>{ts}If this is not your email address, there is no need to do anything. You have <i><b>not</b></i> been added to any mailing lists. If this is your email address and you <i><b>wish to opt out</b></i> please enter your email address below for verification purposes:{/ts}</p>
-
-    <table class="form-layout">
-      <tbody>
-      <tr>
-        <td class="label">{$form.email_confirm.label}</td>
-        <td class="content">{$form.email_confirm.html}
-      </tr>
-      </tbody>
-    </table>
+  <p>
+      {ts}If this is not your email address, there is no need to do anything. You have <strong>not</strong> been added to any mailing lists.{/ts}
+      {ts}If this is your email address and you <strong>wish to opt out</strong> please click the <strong>Opt Out</strong> button to confirm.{/ts}
+  </p>
 
   <div class="crm-submit-buttons">
-    {include file="CRM/common/formButtons.tpl" location="bottom"}
+      {include file="CRM/common/formButtons.tpl" location="bottom"}
   </div>
 
-<br/>
+  <br/>
 </div>
 

--- a/templates/CRM/Mailing/Form/Unsubscribe.tpl
+++ b/templates/CRM/Mailing/Form/Unsubscribe.tpl
@@ -24,15 +24,10 @@
     <div class="crm-block crm-form-block crm-miscellaneous-form-block">
       <p>{ts}You are requesting to unsubscribe this email address:{/ts}</p>
       <h3>{$email_masked}</h3>
-      <p>{ts}If this is not your email address, there is no need to do anything. You have <i><b>not</b></i> been added to any mailing lists. If this is your email address and you <i><b>wish to unsubscribe</b></i> please enter your email address below for verification purposes:{/ts}</p>
-      <table class="form-layout">
-        <tbody>
-          <tr>
-            <td class="label">{$form.email_confirm.label}</td>
-            <td class="content">{$form.email_confirm.html}</td>
-          </tr>
-        </tbody>
-      </table>
+      <p>
+        {ts}If this is not your email address, there is no need to do anything. You have <strong>not</strong> been added to any mailing lists.{/ts}
+        {ts}If this is your email address and you <strong>wish to unsubscribe</strong> please click the <strong>Unsubscribe</strong> button to confirm.{/ts}
+      </p>
       <div class="crm-submit-buttons">
         {include file="CRM/common/formButtons.tpl" location="bottom"}
       </div>


### PR DESCRIPTION
Overview
----------------------------------------
Follow up to #21175. This makes the same change for the Opt Out form.

Note that the forms for unsubscribe and opt-out are very similar so we *could* create a shared parent class. But they are also simple forms (simpler now the verify email has been removed) so I don't think that's necessary yet! I've cleaned up the code here to so the two forms more or less match internally.

Before
----------------------------------------
Have to type email address to confirm opt-out.

After
----------------------------------------
Just read and click "Opt Out" to conform opt-out.

Technical Details
----------------------------------------

Comments
----------------------------------------
@mlutfy 
