### PR TITLE
Switch to CRM_Core_Form::setTitle() instead of CRM_Utils_System::setTitle() part 3

### DIFF
--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -2419,20 +2419,20 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
   public function setPageTitle($entityLabel) {
     switch ($this->_action) {
       case CRM_Core_Action::ADD:
-        CRM_Utils_System::setTitle(ts('New %1', [1 => $entityLabel]));
+        $this->setTitle(ts('New %1', [1 => $entityLabel]));
         break;
 
       case CRM_Core_Action::UPDATE:
-        CRM_Utils_System::setTitle(ts('Edit %1', [1 => $entityLabel]));
+        $this->setTitle(ts('Edit %1', [1 => $entityLabel]));
         break;
 
       case CRM_Core_Action::VIEW:
       case CRM_Core_Action::PREVIEW:
-        CRM_Utils_System::setTitle(ts('View %1', [1 => $entityLabel]));
+        $this->setTitle(ts('View %1', [1 => $entityLabel]));
         break;
 
       case CRM_Core_Action::DELETE:
-        CRM_Utils_System::setTitle(ts('Delete %1', [1 => $entityLabel]));
+        $this->setTitle(ts('Delete %1', [1 => $entityLabel]));
         break;
     }
   }

--- a/CRM/Core/Form/Task/Batch.php
+++ b/CRM/Core/Form/Task/Batch.php
@@ -89,7 +89,7 @@ class CRM_Core_Form_Task_Batch extends CRM_Core_Form_Task {
       throw new InvalidArgumentException('ufGroupId is missing');
     }
     $this->_title = ts("Update multiple %1s", [1 => $this::$entityShortname]) . ' - ' . CRM_Core_BAO_UFGroup::getTitle($ufGroupId);
-    CRM_Utils_System::setTitle($this->_title);
+    $this->setTitle($this->_title);
 
     $this->addDefaultButtons(ts('Save'));
     $this->_fields = CRM_Core_BAO_UFGroup::getFields($ufGroupId, FALSE, CRM_Core_Action::VIEW);

--- a/CRM/Core/Form/Task/PDFLetterCommon.php
+++ b/CRM/Core/Form/Task/PDFLetterCommon.php
@@ -30,7 +30,7 @@ class CRM_Core_Form_Task_PDFLetterCommon {
    * @var CRM_Core_Form $form
    */
   public static function preProcess(&$form) {
-    CRM_Utils_System::setTitle('Print/Merge Document');
+    $form->setTitle('Print/Merge Document');
   }
 
   /**

--- a/CRM/Core/Form/Task/PickProfile.php
+++ b/CRM/Core/Form/Task/PickProfile.php
@@ -65,7 +65,7 @@ abstract class CRM_Core_Form_Task_PickProfile extends CRM_Core_Form_Task {
     $session = CRM_Core_Session::singleton();
     $this->_userContext = $session->readUserContext();
 
-    CRM_Utils_System::setTitle(ts('Update multiple ' . $this::$entityShortname . 's'));
+    $this->setTitle(ts('Update multiple ' . $this::$entityShortname . 's'));
 
     // validations
     if (count($this->_entityIds) > $this->_maxEntities) {

--- a/CRM/Core/I18n/Form.php
+++ b/CRM/Core/I18n/Form.php
@@ -80,7 +80,7 @@ class CRM_Core_I18n_Form extends CRM_Core_Form {
 
     $this->addDefaultButtons(ts('Save'), 'next', NULL);
 
-    CRM_Utils_System::setTitle(ts('Languages'));
+    $this->setTitle(ts('Languages'));
 
     $this->assign('locales', $this->_locales);
     $this->assign('field', $field);

--- a/CRM/Custom/Form/DeleteField.php
+++ b/CRM/Custom/Form/DeleteField.php
@@ -49,7 +49,7 @@ class CRM_Custom_Form_DeleteField extends CRM_Core_Form {
 
     $this->_title = $defaults['label'] ?? NULL;
     $this->assign('title', $this->_title);
-    CRM_Utils_System::setTitle(ts('Delete %1', [1 => $this->_title]));
+    $this->setTitle(ts('Delete %1', [1 => $this->_title]));
   }
 
   /**

--- a/CRM/Custom/Form/DeleteGroup.php
+++ b/CRM/Custom/Form/DeleteGroup.php
@@ -60,7 +60,7 @@ class CRM_Custom_Form_DeleteGroup extends CRM_Core_Form {
     }
     $this->assign('title', $this->_title);
 
-    CRM_Utils_System::setTitle(ts('Confirm Custom Group Delete'));
+    $this->setTitle(ts('Confirm Custom Group Delete'));
   }
 
   /**

--- a/CRM/Custom/Form/Field.php
+++ b/CRM/Custom/Form/Field.php
@@ -191,7 +191,7 @@ class CRM_Custom_Form_Field extends CRM_Core_Form {
   public function buildQuickForm() {
     if ($this->_gid) {
       $this->_title = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_CustomGroup', $this->_gid, 'title');
-      CRM_Utils_System::setTitle($this->_title . ' - ' . ($this->_id ? ts('Edit Field') : ts('New Field')));
+      $this->setTitle($this->_title . ' - ' . ($this->_id ? ts('Edit Field') : ts('New Field')));
       $this->assign('gid', $this->_gid);
     }
 

--- a/CRM/Custom/Form/Group.php
+++ b/CRM/Custom/Form/Group.php
@@ -59,14 +59,14 @@ class CRM_Custom_Form_Group extends CRM_Core_Form {
     // setting title for html page
     if ($this->_action == CRM_Core_Action::UPDATE) {
       $title = CRM_Core_BAO_CustomGroup::getTitle($this->_id);
-      CRM_Utils_System::setTitle(ts('Edit %1', [1 => $title]));
+      $this->setTitle(ts('Edit %1', [1 => $title]));
     }
     elseif ($this->_action == CRM_Core_Action::VIEW) {
       $title = CRM_Core_BAO_CustomGroup::getTitle($this->_id);
-      CRM_Utils_System::setTitle(ts('Preview %1', [1 => $title]));
+      $this->setTitle(ts('Preview %1', [1 => $title]));
     }
     else {
-      CRM_Utils_System::setTitle(ts('New Custom Field Set'));
+      $this->setTitle(ts('New Custom Field Set'));
     }
 
     if (isset($this->_id)) {

--- a/CRM/Custom/Form/MoveField.php
+++ b/CRM/Custom/Form/MoveField.php
@@ -76,7 +76,7 @@ class CRM_Custom_Form_MoveField extends CRM_Core_Form {
       'label'
     );
 
-    CRM_Utils_System::setTitle(ts('Custom Field Move: %1',
+    $this->setTitle(ts('Custom Field Move: %1',
       [1 => $this->_srcFieldLabel]
     ));
 

--- a/CRM/Event/Form/ParticipantFeeSelection.php
+++ b/CRM/Event/Form/ParticipantFeeSelection.php
@@ -95,7 +95,7 @@ class CRM_Event_Form_ParticipantFeeSelection extends CRM_Core_Form {
 
     $title = ts("Change selections for %1", [1 => $this->_contributorDisplayName]);
     if ($title) {
-      CRM_Utils_System::setTitle($title);
+      $this->setTitle($title);
     }
   }
 

--- a/CRM/Event/Form/ParticipantView.php
+++ b/CRM/Event/Form/ParticipantView.php
@@ -207,7 +207,7 @@ class CRM_Event_Form_ParticipantView extends CRM_Core_Form {
     }
     $this->assign('displayName', $displayName);
     // omitting contactImage from title for now since the summary overlay css doesn't work outside of our crm-container
-    CRM_Utils_System::setTitle(ts('View Event Registration for') . ' ' . $displayName);
+    $this->setTitle(ts('View Event Registration for') . ' ' . $displayName);
 
     $roleId = $values[$participantID]['role_id'] ?? NULL;
     $title = $displayName . ' (' . CRM_Utils_Array::value($roleId, $participantRoles) . ' - ' . $eventTitle . ')';

--- a/CRM/Event/Form/Registration/AdditionalParticipant.php
+++ b/CRM/Event/Form/Registration/AdditionalParticipant.php
@@ -72,7 +72,7 @@ class CRM_Event_Form_Registration_AdditionalParticipant extends CRM_Event_Form_R
     if ($skipCount) {
       $this->assign('skipCount', $skipCount);
     }
-    CRM_Utils_System::setTitle(ts('Register Participant %1 of %2', [1 => $participantCnt, 2 => $participantTot]));
+    $this->setTitle(ts('Register Participant %1 of %2', [1 => $participantCnt, 2 => $participantTot]));
 
     //CRM-4320, hack to check last participant.
     $this->_lastParticipant = FALSE;

--- a/CRM/Event/Form/Registration/Confirm.php
+++ b/CRM/Event/Form/Registration/Confirm.php
@@ -87,7 +87,7 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
     }
 
     if (isset($this->_values['event']['confirm_title'])) {
-      CRM_Utils_System::setTitle($this->_values['event']['confirm_title']);
+      $this->setTitle($this->_values['event']['confirm_title']);
     }
 
     // Personal campaign page

--- a/CRM/Event/Form/Registration/ThankYou.php
+++ b/CRM/Event/Form/Registration/ThankYou.php
@@ -46,7 +46,7 @@ class CRM_Event_Form_Registration_ThankYou extends CRM_Event_Form_Registration {
 
     CRM_Event_Form_Registration_Confirm::assignProfiles($this);
 
-    CRM_Utils_System::setTitle(CRM_Utils_Array::value('thankyou_title', $this->_values['event']));
+    $this->setTitle(CRM_Utils_Array::value('thankyou_title', $this->_values['event']));
   }
 
   /**

--- a/CRM/Event/Form/Task/AddToGroup.php
+++ b/CRM/Event/Form/Task/AddToGroup.php
@@ -120,10 +120,10 @@ class CRM_Event_Form_Task_AddToGroup extends CRM_Event_Form_Task {
 
     // Set dynamic page title for 'Add Members Group (confirm)'
     if ($this->_id) {
-      CRM_Utils_System::setTitle(ts('Add Contacts: %1', [1 => $this->_title]));
+      $this->setTitle(ts('Add Contacts: %1', [1 => $this->_title]));
     }
     else {
-      CRM_Utils_System::setTitle(ts('Add Contacts to A Group'));
+      $this->setTitle(ts('Add Contacts to A Group'));
     }
 
     $this->addDefaultButtons(ts('Add to Group'));

--- a/CRM/Event/Form/Task/Badge.php
+++ b/CRM/Event/Form/Task/Badge.php
@@ -67,7 +67,7 @@ class CRM_Event_Form_Task_Badge extends CRM_Event_Form_Task {
    * Build the form object.
    */
   public function buildQuickForm() {
-    CRM_Utils_System::setTitle(ts('Make Name Badges'));
+    $this->setTitle(ts('Make Name Badges'));
 
     // Ajax submit would interfere with file download
     $this->preventAjaxSubmit();

--- a/CRM/Event/Form/Task/Batch.php
+++ b/CRM/Event/Form/Task/Batch.php
@@ -84,7 +84,7 @@ class CRM_Event_Form_Task_Batch extends CRM_Event_Form_Task {
     }
 
     $this->_title = ts('Update multiple participants') . ' - ' . CRM_Core_BAO_UFGroup::getTitle($ufGroupId);
-    CRM_Utils_System::setTitle($this->_title);
+    $this->setTitle($this->_title);
     $this->addDefaultButtons(ts('Save'));
 
     $this->_fields = CRM_Core_BAO_UFGroup::getFields($ufGroupId, FALSE, CRM_Core_Action::VIEW);

--- a/CRM/Event/Form/Task/Cancel.php
+++ b/CRM/Event/Form/Task/Cancel.php
@@ -46,7 +46,7 @@ class CRM_Event_Form_Task_Cancel extends CRM_Event_Form_Task {
    * @return void
    */
   public function buildQuickForm() {
-    CRM_Utils_System::setTitle(ts('Cancel Registration for Event Participation'));
+    $this->setTitle(ts('Cancel Registration for Event Participation'));
     $session = CRM_Core_Session::singleton();
     $this->addDefaultButtons(ts('Cancel Registrations'), 'done');
   }

--- a/CRM/Event/Form/Task/PickProfile.php
+++ b/CRM/Event/Form/Task/PickProfile.php
@@ -51,7 +51,7 @@ class CRM_Event_Form_Task_PickProfile extends CRM_Event_Form_Task {
     $session = CRM_Core_Session::singleton();
     $this->_userContext = $session->readUserContext();
 
-    CRM_Utils_System::setTitle(ts('Update multiple participants'));
+    $this->setTitle(ts('Update multiple participants'));
 
     $validate = FALSE;
     //validations

--- a/CRM/Event/Form/Task/SaveSearch.php
+++ b/CRM/Event/Form/Task/SaveSearch.php
@@ -48,7 +48,7 @@ class CRM_Event_Form_Task_SaveSearch extends CRM_Event_Form_Task {
    * @return void
    */
   public function buildQuickForm() {
-    CRM_Utils_System::setTitle(ts('Smart Group'));
+    $this->setTitle(ts('Smart Group'));
     // get the qill
     $query = new CRM_Event_BAO_Query($this->get('formValues'));
     $qill = $query->qill();

--- a/CRM/Financial/Form/BatchTransaction.php
+++ b/CRM/Financial/Form/BatchTransaction.php
@@ -53,7 +53,7 @@ class CRM_Financial_Form_BatchTransaction extends CRM_Contribute_Form_Search {
       $this->assign('validStatus', $validStatus);
       $this->_values = civicrm_api3('Batch', 'getSingle', ['id' => self::$_entityID]);
       $batchTitle = CRM_Core_DAO::getFieldValue('CRM_Batch_BAO_Batch', self::$_entityID, 'title');
-      CRM_Utils_System::setTitle(ts('Accounting Batch - %1', [1 => $batchTitle]));
+      $this->setTitle(ts('Accounting Batch - %1', [1 => $batchTitle]));
 
       $columnHeaders = [
         'created_by' => ts('Created By'),

--- a/CRM/Financial/Form/FinancialBatch.php
+++ b/CRM/Financial/Form/FinancialBatch.php
@@ -62,7 +62,7 @@ class CRM_Financial_Form_FinancialBatch extends CRM_Contribute_Form {
     $this->setPageTitle(ts('Financial Batch'));
     if (!empty($this->_id)) {
       $this->_title = CRM_Core_DAO::getFieldValue('CRM_Batch_DAO_Batch', $this->_id, 'title');
-      CRM_Utils_System::setTitle($this->_title . ' - ' . ts('Accounting Batch'));
+      $this->setTitle($this->_title . ' - ' . ts('Accounting Batch'));
       $this->assign('batchTitle', $this->_title);
       $contactID = CRM_Core_DAO::getFieldValue('CRM_Batch_DAO_Batch', $this->_id, 'created_id');
       $contactName = CRM_Contact_BAO_Contact::displayName($contactID);

--- a/CRM/Financial/Form/FinancialTypeAccount.php
+++ b/CRM/Financial/Form/FinancialTypeAccount.php
@@ -64,7 +64,7 @@ class CRM_Financial_Form_FinancialTypeAccount extends CRM_Core_Form {
     $this->_BAOName = 'CRM_Financial_BAO_FinancialTypeAccount';
     if ($this->_aid && ($this->_action & CRM_Core_Action::ADD)) {
       $this->_title = CRM_Core_DAO::getFieldValue('CRM_Financial_DAO_FinancialType', $this->_aid, 'name');
-      CRM_Utils_System::setTitle($this->_title . ' - ' . ts('Financial Accounts'));
+      $this->setTitle($this->_title . ' - ' . ts('Financial Accounts'));
 
       $session = CRM_Core_Session::singleton();
       $session->pushUserContext($url);
@@ -85,7 +85,7 @@ class CRM_Financial_Form_FinancialTypeAccount extends CRM_Core_Form {
     if ($this->_id) {
       $financialAccount = CRM_Core_DAO::getFieldValue('CRM_Financial_DAO_EntityFinancialAccount', $this->_id, 'financial_account_id');
       $fieldTitle = CRM_Core_DAO::getFieldValue('CRM_Financial_DAO_FinancialAccount', $financialAccount, 'name');
-      CRM_Utils_System::setTitle($fieldTitle . ' - ' . ts('Financial Type Accounts'));
+      $this->setTitle($fieldTitle . ' - ' . ts('Financial Type Accounts'));
     }
 
     $breadCrumb = [

--- a/CRM/Financial/Form/PaymentEdit.php
+++ b/CRM/Financial/Form/PaymentEdit.php
@@ -84,7 +84,7 @@ class CRM_Financial_Form_PaymentEdit extends CRM_Core_Form {
    * Build quickForm.
    */
   public function buildQuickForm() {
-    CRM_Utils_System::setTitle(ts('Update Payment details'));
+    $this->setTitle(ts('Update Payment details'));
 
     $paymentFields = $this->getPaymentFields();
     $this->assign('paymentFields', $paymentFields);

--- a/CRM/Friend/Form.php
+++ b/CRM/Friend/Form.php
@@ -140,7 +140,7 @@ class CRM_Friend_Form extends CRM_Core_Form {
     $defaults['entity_table'] = $this->_entityTable;
 
     CRM_Friend_BAO_Friend::getValues($defaults);
-    CRM_Utils_System::setTitle(CRM_Utils_Array::value('title', $defaults));
+    $this->setTitle(CRM_Utils_Array::value('title', $defaults));
 
     $this->assign('title', CRM_Utils_Array::value('title', $defaults));
     $this->assign('intro', CRM_Utils_Array::value('intro', $defaults));
@@ -302,7 +302,7 @@ class CRM_Friend_Form extends CRM_Core_Form {
       }
     }
 
-    CRM_Utils_System::setTitle($defaults['thankyou_title']);
+    $this->setTitle($defaults['thankyou_title']);
     $this->assign('thankYouText', $defaults['thankyou_text']);
   }
 

--- a/CRM/Group/Form/Edit.php
+++ b/CRM/Group/Form/Edit.php
@@ -122,7 +122,7 @@ class CRM_Group_Form_Edit extends CRM_Core_Form {
         catch (CRM_Core_Exception $e) {
           // If the group is borked the query might fail but delete should be possible.
         }
-        CRM_Utils_System::setTitle(ts('Confirm Group Delete'));
+        $this->setTitle(ts('Confirm Group Delete'));
       }
       if ($this->_groupValues['is_reserved'] == 1 && !CRM_Core_Permission::check('administer reserved groups')) {
         CRM_Core_Error::statusBounce(ts("You do not have sufficient permission to delete this reserved group."));
@@ -151,7 +151,7 @@ class CRM_Group_Form_Edit extends CRM_Core_Form {
 
         $this->assign_by_ref('group', $groupValues);
 
-        CRM_Utils_System::setTitle(ts('Group Settings: %1', array(1 => $this->_title)));
+        $this->setTitle(ts('Group Settings: %1', array(1 => $this->_title)));
       }
       $session = CRM_Core_Session::singleton();
       $session->pushUserContext(CRM_Utils_System::url('civicrm/group', 'reset=1'));

--- a/CRM/Mailing/Form/Approve.php
+++ b/CRM/Mailing/Form/Approve.php
@@ -73,7 +73,7 @@ class CRM_Mailing_Form_Approve extends CRM_Core_Form {
    */
   public function buildQuickform() {
     $title = ts('Approve/Reject Mailing') . " - {$this->_mailing->name}";
-    CRM_Utils_System::setTitle($title);
+    $this->setTitle($title);
 
     $this->addElement('textarea', 'approval_note', ts('Approve/Reject Note'));
 

--- a/CRM/Mailing/Form/ForwardMailing.php
+++ b/CRM/Mailing/Form/ForwardMailing.php
@@ -46,7 +46,7 @@ class CRM_Mailing_Form_ForwardMailing extends CRM_Core_Form {
     // Show the subject instead of the name here, since it's being
     // displayed to external contacts/users.
 
-    CRM_Utils_System::setTitle(ts('Forward Mailing: %1', [1 => $mailing->subject]));
+    $this->setTitle(ts('Forward Mailing: %1', [1 => $mailing->subject]));
 
     $this->set('queue_id', $queue_id);
     $this->set('job_id', $job_id);

--- a/CRM/Mailing/Form/Optout.php
+++ b/CRM/Mailing/Form/Optout.php
@@ -47,7 +47,7 @@ class CRM_Mailing_Form_Optout extends CRM_Core_Form {
 
   public function buildQuickForm() {
     CRM_Utils_System::addHTMLHead('<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">');
-    CRM_Utils_System::setTitle(ts('Opt Out Confirmation'));
+    $this->setTitle(ts('Opt Out Confirmation'));
 
     $this->add('text', 'email_confirm', ts('Verify email address to opt out:'));
     $this->addRule('email_confirm', ts('Email address is required to opt out.'), 'required');

--- a/CRM/Mailing/Form/Subscribe.php
+++ b/CRM/Mailing/Form/Subscribe.php
@@ -43,7 +43,7 @@ SELECT   title, frontend_title, description, frontend_description
       $dao = CRM_Core_DAO::executeQuery($query);
       if ($dao->fetch()) {
         $this->assign('groupName', !empty($dao->frontend_title) ? $dao->frontend_title : $dao->title);
-        CRM_Utils_System::setTitle(ts('Subscribe to Mailing List - %1', [1 => !empty($dao->frontend_title) ? $dao->frontend_title : $dao->title]));
+        $this->setTitle(ts('Subscribe to Mailing List - %1', [1 => !empty($dao->frontend_title) ? $dao->frontend_title : $dao->title]));
       }
       else {
         CRM_Core_Error::statusBounce("The specified group is not configured for this action OR The group doesn't exist.");
@@ -53,7 +53,7 @@ SELECT   title, frontend_title, description, frontend_description
     }
     else {
       $this->assign('single', FALSE);
-      CRM_Utils_System::setTitle(ts('Mailing List Subscription'));
+      $this->setTitle(ts('Mailing List Subscription'));
     }
   }
 

--- a/CRM/Mailing/Form/Unsubscribe.php
+++ b/CRM/Mailing/Form/Unsubscribe.php
@@ -72,7 +72,7 @@ class CRM_Mailing_Form_Unsubscribe extends CRM_Core_Form {
 
   public function buildQuickForm() {
     CRM_Utils_System::addHTMLHead('<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">');
-    CRM_Utils_System::setTitle(ts('Unsubscribe Confirmation'));
+    $this->setTitle(ts('Unsubscribe Confirmation'));
 
     $this->add('text', 'email_confirm', ts('Verify email address to unsubscribe:'));
     $this->addRule('email_confirm', ts('Email address is required to unsubscribe.'), 'required');


### PR DESCRIPTION
Overview
----------------------------------------
Follows on from some work that @eileenmcnaughton started in 2019. Forms should use `$this->setTitle()` instead of `CRM_Utils_System::setTitle()` because it allows you to use `$this->getTitle()` on a form to get the title of the form that the user will see.

Before
----------------------------------------
Calls to `CRM_Utils_System::setTitle()`

After
----------------------------------------
Calls to `$this->setTitle()`

Technical Details
----------------------------------------
As can be observed `CRM_Core_Form::setTitle()` calls `CRM_Utils_System::setTitle()` internally after setting `$this->_title` showing that this function is a drop-in replacement. There are just over 200 instances that need converting and (for ease of review) this is the next 43.
I would suggest that `r-run` testing could be done with a few forms only instead of all of them - what needs to be verified is that it is a form that inherits from CRM_Core_Form (and not eg. a Page).

Comments
----------------------------------------
There are 4 commits in total that would complete this change and I'll follow up with the others - see https://github.com/civicrm/civicrm-core/compare/master...mattwire:settitle?expand=1
