### PR TITLE
[REF] Extract code to get the from address for a recurring contribution.

### DIFF
--- a/CRM/Contribute/BAO/ContributionRecur.php
+++ b/CRM/Contribute/BAO/ContributionRecur.php
@@ -1085,4 +1085,32 @@ INNER JOIN civicrm_contribution       con ON ( con.id = mp.contribution_id )
     return CRM_Core_PseudoConstant::get(__CLASS__, $fieldName, $params, $context);
   }
 
+  /**
+   * Get the from address to use for the recurring contribution.
+   *
+   * This uses the contribution page id, if there is one, or the default domain one.
+   *
+   * @param int $id
+   *   Recurring contribution ID.
+   *
+   * @internal
+   *
+   * @return string
+   * @throws \API_Exception
+   * @throws \CRM_Core_Exception
+   */
+  public static function getRecurFromAddress(int $id): string {
+    $details = Contribution::get(FALSE)
+      ->addWhere('contribution_recur_id', '=', $id)
+      ->addWhere('contribution_page_id', 'IS NOT NULL')
+      ->addSelect('contribution_page_id.receipt_from_name', 'contribution_page_id.receipt_from_email')
+      ->addOrderBy('receive_date', 'DESC')
+      ->execute()->first();
+    if (empty($details['contribution_page_id.receipt_from_email'])) {
+      $domainValues = CRM_Core_BAO_Domain::getNameAndEmail();
+      return "$domainValues[0] <$domainValues[1]>";
+    }
+    return '"' . $details['contribution_page_id.receipt_from_name'] . '" <' . $details['contribution_page_id.receipt_from_email'] . '>';
+  }
+
 }

--- a/tests/phpunit/CRM/Contribute/Form/UpdateSubscriptionTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/UpdateSubscriptionTest.php
@@ -17,7 +17,7 @@ class CRM_Contribute_Form_UpdateSubscriptionTest extends CiviUnitTestCase {
   /**
    * Test the mail sent on update.
    *
-   * @throws \CRM_Core_Exception
+   * @throws \CRM_Core_Exception|\API_Exception
    */
   public function testMail(): void {
     $mut = new CiviMailUtils($this, TRUE);
@@ -44,14 +44,14 @@ class CRM_Contribute_Form_UpdateSubscriptionTest extends CiviUnitTestCase {
   public function getExpectedMailStrings(): array {
     return [
       'MIME-Version: 1.0',
-      'From: FIXME <info@EXAMPLE.ORG>',
+      'From: "Bob" <bob@example.org>',
       'To: Anthony Anderson <anthony_anderson@civicrm.org>',
       'Subject: Recurring Contribution Update Notification - Mr. Anthony Anderson II',
-      'Return-Path: info@EXAMPLE.ORG',
+      'Return-Path: bob@example.org',
       'Dear Anthony,',
       'Your recurring contribution has been updated as requested:',
       'Recurring contribution is for $ 10.00, every 1 month(s) for 12 installments.',
-      'If you have questions please contact us at FIXME <info@EXAMPLE.ORG>.',
+      'If you have questions please contact us at "Bob" <bob@example.org>.',
     ];
   }
 
@@ -77,7 +77,12 @@ class CRM_Contribute_Form_UpdateSubscriptionTest extends CiviUnitTestCase {
       'contribution_recur_id' => $this->getContributionRecurID(),
       'financial_type_id' => 'Donation',
       'total_amount' => 10,
-      'api.Payment.create' => ['total_amount' => 10, 'payment_processor_id' => $this->paymentProcessorId],
+      'contribution_page_id' => $this->getContributionPageID(),
+      'api.Payment.create' => [
+        'total_amount' => 10,
+        'payment_processor_id' => $this->paymentProcessorId,
+        'is_send_contribution_notification' => FALSE,
+      ],
     ]);
   }
 
@@ -97,6 +102,22 @@ class CRM_Contribute_Form_UpdateSubscriptionTest extends CiviUnitTestCase {
       ])['id'];
     }
     return $this->ids['ContributionRecur'][0];
+  }
+
+  /**
+   * Get a contribution page id.
+   *
+   * @return int
+   */
+  public function getContributionPageID(): int {
+    if (!isset($this->ids['ContributionPage'][0])) {
+      $this->ids['ContributionPage'][0] = $this->callAPISuccess('ContributionPage', 'create', [
+        'receipt_from_name' => 'Bob',
+        'receipt_from_email' => 'bob@example.org',
+        'financial_type_id' => 'Donation',
+      ])['id'];
+    }
+    return $this->ids['ContributionPage'][0];
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
[REF] Extract code to get the from address for a recurring contribution.

Before
----------------------------------------
Long code block

After
----------------------------------------
spiffing new function

Technical Details
----------------------------------------
This makes the retrieval generally available, since is it part of the data model,
rather than tied to the form. It could possibly be a token, or at least retrievable on
the recurring edit workflow template - but that is beyond the scope of this

Note that in some cases this could result in an extra query but in others it might make the query quicker. I don't think an extra query in a form post process is a biggie (deep in the BAO it could be)


This parameter is specifically covered in the test I pre-added but I updated the test so that it was using the more 'complicted' variant - ie retrieving from a contribution page

Comments
----------------------------------------
@seamuslee001 are you able to MOP this - I think it's pretty straight forward & will make code conversations easier if we get rid of this noise