### PR TITLE
Remove testing hack

### DIFF
--- a/CRM/Contribute/Form/Task/PDFLetter.php
+++ b/CRM/Contribute/Form/Task/PDFLetter.php
@@ -130,6 +130,7 @@ class CRM_Contribute_Form_Task_PDFLetter extends CRM_Contribute_Form_Task {
    * Process the form after the input has been submitted and validated.
    *
    * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
    */
   public function postProcess() {
     $formValues = $this->controller->exportValues($this->getName());
@@ -233,10 +234,6 @@ class CRM_Contribute_Form_Task_PDFLetter extends CRM_Contribute_Form_Task {
     $contactIds = array_keys($contacts);
     CRM_Contact_Form_Task_PDFLetterCommon::createActivities($this, $html_message, $contactIds, CRM_Utils_Array::value('subject', $formValues, ts('Thank you letter')), CRM_Utils_Array::value('campaign_id', $formValues), $contactHtml);
     $html = array_diff_key($html, $emailedHtml);
-
-    if (!empty($formValues['is_unit_test'])) {
-      return $html;
-    }
 
     //CRM-19761
     if (!empty($html)) {

--- a/CRM/Utils/PDF/Document.php
+++ b/CRM/Utils/PDF/Document.php
@@ -68,6 +68,15 @@ class CRM_Utils_PDF_Document {
       'marginBottom' => self::toTwip(CRM_Core_BAO_PdfFormat::getValue('margin_bottom', $format), $metric),
       'marginLeft' => self::toTwip(CRM_Core_BAO_PdfFormat::getValue('margin_left', $format), $metric),
     ];
+    if (CIVICRM_UF === 'UnitTests' && headers_sent()) {
+      // Streaming content will 'die' in unit tests unless ob_start()
+      // has been called.
+      throw new CRM_Core_Exception_PrematureExitException('_html2doc called', [
+        'html' => $pages,
+        'fileName' => $fileName,
+        'pageStyle' => $pageStyle,
+      ]);
+    }
 
     $ext = pathinfo($fileName, PATHINFO_EXTENSION);
 


### PR DESCRIPTION
Overview
----------------------------------------
Remove testing hack

Before
----------------------------------------
A long long time ago... the best way we had to get pdf output was a hack like the 'is_unit_test' but in New York we came up with 'PrematureExitExceptions` - nothing to do with the spammers you know & love - but this test was still stuck in the dark ages

After
----------------------------------------
Welcome to the modern world

Technical Details
----------------------------------------
We'll always have Brooklyn

Comments
----------------------------------------
