### PR TITLE
SearchKit - Add 'array' option to download API and add test

### DIFF
--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/Download.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/Download.php
@@ -7,19 +7,24 @@ use League\Csv\Writer;
 /**
  * Download the results of a SearchDisplay as a spreadsheet.
  *
- * Note: unlike other APIs this action directly outputs a file.
+ * Note: unlike other APIs this action will directly output a file
+ * if 'format' is set to anything other than 'array'.
  *
  * @package Civi\Api4\Action\SearchDisplay
  */
 class Download extends AbstractRunAction {
 
   /**
-   * Requested file format
+   * Requested file format.
+   *
+   * 'array' will return a normal api result, with table headers as the first row.
+   * 'csv', etc. will directly output a file to the browser.
+   *
    * @var string
    * @required
-   * @options csv
+   * @options array,csv
    */
-  protected $format;
+  protected $format = 'array';
 
   /**
    * @param \Civi\Api4\Generic\Result $result
@@ -60,6 +65,17 @@ class Download extends AbstractRunAction {
     $fileName = \CRM_Utils_File::makeFilenameWithUnicode($this->display['label']) . '.' . $this->format;
 
     switch ($this->format) {
+      case 'array':
+        $result[] = $columns;
+        foreach ($rows as $data) {
+          $row = [];
+          foreach ($columns as $col) {
+            $row[] = $this->formatColumnValue($col, $data);
+          }
+          $result[] = $row;
+        }
+        return;
+
       case 'csv':
         $this->outputCSV($rows, $columns, $fileName);
         break;

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchDownloadTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchDownloadTest.php
@@ -19,6 +19,65 @@ class SearchDownloadTest extends \PHPUnit\Framework\TestCase implements Headless
   }
 
   /**
+   * Test downloading array format.
+   */
+  public function testDownloadArray() {
+    $lastName = uniqid(__FUNCTION__);
+    $sampleData = [
+      ['first_name' => 'One', 'last_name' => $lastName],
+      ['first_name' => 'Two', 'last_name' => $lastName],
+      ['first_name' => 'Three', 'last_name' => $lastName],
+      ['first_name' => 'Four', 'last_name' => $lastName],
+    ];
+    Contact::save(FALSE)->setRecords($sampleData)->execute();
+
+    $params = [
+      'checkPermissions' => FALSE,
+      'format' => 'array',
+      'savedSearch' => [
+        'api_entity' => 'Contact',
+        'api_params' => [
+          'version' => 4,
+          'select' => ['last_name'],
+          'where' => [],
+        ],
+      ],
+      'display' => [
+        'type' => 'table',
+        'label' => '',
+        'settings' => [
+          'limit' => 2,
+          'actions' => TRUE,
+          'pager' => [],
+          'columns' => [
+            [
+              'key' => 'last_name',
+              'label' => 'First Last',
+              'dataType' => 'String',
+              'type' => 'field',
+              'rewrite' => '[first_name] [last_name]',
+            ],
+          ],
+          'sort' => [
+            ['id', 'ASC'],
+          ],
+        ],
+      ],
+      'filters' => ['last_name' => $lastName],
+      'afform' => NULL,
+    ];
+
+    $download = (array) civicrm_api4('SearchDisplay', 'download', $params);
+    $header = array_shift($download);
+
+    $this->assertEquals('First Last', $header[0]['label']);
+
+    foreach ($download as $rowNum => $data) {
+      $this->assertEquals($sampleData[$rowNum]['first_name'] . ' ' . $lastName, $data[0]);
+    }
+  }
+
+  /**
    * Test downloading CSV format.
    *
    * Must run in separate process to capture direct output to browser


### PR DESCRIPTION
Overview
----------------------------------------
This adds a new option to the SearchKit "Download" api to return a normal array result, which makes testing easier.

Before
----------------------------------------
Download api would directly output a file to the browser. No working unit test.

After
----------------------------------------
New option to not directly output file. Unit test works.
