### PR TITLE
dev/core#2814 Fix profile edit to use messagetemplate:render

### DIFF
--- a/tests/phpunit/CRM/Profile/Form/EditTest.php
+++ b/tests/phpunit/CRM/Profile/Form/EditTest.php
@@ -1,0 +1,49 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+use Civi\Api4\UFJoin;
+
+/**
+ * Test class for CRM_Price_BAO_PriceSet.
+ * @group headless
+ */
+class CRM_Profile_Form_EditTest extends CiviUnitTestCase {
+
+  public function tearDown(): void {
+    $this->quickCleanup(['civicrm_uf_field', 'civicrm_uf_group']);
+    parent::tearDown();
+  }
+
+  /**
+   * Test the url on the profile edit form renders tokens
+   *
+   * @throws \API_Exception
+   */
+  public function testProfileUrl(): void {
+    $profileID = Civi\Api4\UFGroup::create(FALSE)->setValues([
+      'post_URL' => 'civicrm/{contact.display_name}',
+      'title' => 'title',
+    ])->execute()->first()['id'];
+    UFJoin::create(FALSE)->setValues([
+      'module' => 'Profile',
+      'uf_group_id' => $profileID,
+    ])->execute();
+    $this->uFFieldCreate(['uf_group_id' => $profileID]);
+    $id = $this->individualCreate();
+    $form = $this->getFormObject('CRM_Profile_Form_Edit');
+    $form->set('gid', $profileID);
+    $form->set('id', $id);
+    $form->buildForm();
+    $form->postProcess();
+    $this->assertEquals('civicrm/Mr. Anthony Anderson II', CRM_Core_Session::singleton()->popUserContext());
+  }
+
+}


### PR DESCRIPTION

Overview
----------------------------------------
dev/core#2814 Fix profile edit to use messagetemplate:render

Before
----------------------------------------
Weird & wonderful way of resolving the tokens, no test

After
----------------------------------------
Test, uses `renderTemplate`

```
 $url = CRM_Core_BAO_MessageTemplate::renderTemplate([
        'messageTemplate' => ['msg_text' => $this->_postURL],
        'contactId' => $this->_id,
        'disableSmarty' => TRUE,
      ])['text'];
```

Technical Details
----------------------------------------
If the api were merged I would have used that - but this adds the test & when can test converting
to the api when it is merged. It gets the hard lifting of this conversion out of the way

- note I put the notes below on the gitlab but thought I'd copy them here too

As of a 6 months ago, or so, we had resolved all differences between using the token processor and replaceContactTokens to ....replaceContactTokens.
We don't quite have the api yet but when complete it is pretty much a drop in replacement for `renderTemplate`

Calling renderTemplate directly is supported provided

1) it is only done from core and
2) there is test cover for each instance

We don't have that many places left so I'm going to push through & replace them.
The last place in core is the token processor itself. I intend to cut that dependency last & duplicate the code in some way onto the processor.
While not supported from outside of core replaceContactTokens IS called from a number of places. We are also firming up the new token api so I don't want to 'hustle' people to change their code until it's bedded in so I propose to deprecate quietly at this stage (@deprecated on the function but don't make it 'noisy' for a few more months)


Comments
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/2814