### PR TITLE
[REF] dev/core#2790 Move pdf getFileName functionality to the trait

### DIFF
--- a/CRM/Activity/Form/Task/PDF.php
+++ b/CRM/Activity/Form/Task/PDF.php
@@ -134,12 +134,7 @@ class CRM_Activity_Form_Task_PDF extends CRM_Activity_Form_Task {
    * @param array $html
    */
   protected function outputFromHtml($formValues, array $html) {
-    if (!empty($formValues['subject'])) {
-      $fileName = CRM_Utils_File::makeFilenameWithUnicode($formValues['subject'], '_', 200);
-    }
-    else {
-      $fileName = 'CiviLetter';
-    }
+    $fileName = $this->getFileName();
     if ($formValues['document_type'] === 'pdf') {
       CRM_Utils_PDF_Utils::html2pdf($html, $fileName . '.pdf', FALSE, $formValues);
     }

--- a/CRM/Contact/Form/Task/PDFLetterCommon.php
+++ b/CRM/Contact/Form/Task/PDFLetterCommon.php
@@ -183,10 +183,9 @@ class CRM_Contact_Form_Task_PDFLetterCommon extends CRM_Core_Form_Task_PDFLetter
     $mimeType = self::getMimeType($type);
     // ^^ Useful side-effect: consistently throws error for unrecognized types.
 
-    $fileName = self::getFileName($form);
-    $fileName = "$fileName.$type";
+    $fileName = method_exists($form, 'getFileName') ? ($form->getFileName() . '.' . $type) : 'CiviLetter.' . $type;
 
-    if ($type == 'pdf') {
+    if ($type === 'pdf') {
       CRM_Utils_PDF_Utils::html2pdf($html, $fileName, FALSE, $formValues);
     }
     elseif (!empty($formValues['document_file_path'])) {
@@ -219,29 +218,6 @@ class CRM_Contact_Form_Task_PDFLetterCommon extends CRM_Core_Form_Task_PDFLetter
     $form->postProcessHook();
 
     CRM_Utils_System::civiExit();
-  }
-
-  /**
-   * Returns the filename for the pdf by striping off unwanted characters and limits the length to 200 characters.
-   *
-   * @param CRM_Core_Form $form
-   *
-   * @return string
-   *   The name of the file.
-   */
-  private static function getFileName(CRM_Core_Form $form) {
-    if (!empty($form->getSubmittedValue('pdf_file_name'))) {
-      $fileName = CRM_Utils_File::makeFilenameWithUnicode($form->getSubmittedValue('pdf_file_name'), '_', 200);
-    }
-    elseif (!empty($form->getSubmittedValue('subject'))) {
-      $fileName = CRM_Utils_File::makeFilenameWithUnicode($form->getSubmittedValue('subject'), '_', 200);
-    }
-    else {
-      $fileName = 'CiviLetter';
-    }
-    $fileName = self::isLiveMode($form) ? $fileName : $fileName . '_preview';
-
-    return $fileName;
   }
 
   /**

--- a/CRM/Contact/Form/Task/PDFTrait.php
+++ b/CRM/Contact/Form/Task/PDFTrait.php
@@ -201,4 +201,41 @@ trait CRM_Contact_Form_Task_PDFTrait {
     $form->setTitle('Print/Merge Document');
   }
 
+  /**
+   * Returns the filename for the pdf by striping off unwanted characters and limits the length to 200 characters.
+   *
+   * @return string
+   *   The name of the file.
+   */
+  public function getFileName(): string {
+    if (!empty($this->getSubmittedValue('pdf_file_name'))) {
+      $fileName = CRM_Utils_File::makeFilenameWithUnicode($this->getSubmittedValue('pdf_file_name'), '_', 200);
+    }
+    elseif (!empty($this->getSubmittedValue('subject'))) {
+      $fileName = CRM_Utils_File::makeFilenameWithUnicode($this->getSubmittedValue('subject'), '_', 200);
+    }
+    else {
+      $fileName = 'CiviLetter';
+    }
+    return $this->isLiveMode() ? $fileName : $fileName . '_preview';
+  }
+
+  /**
+   * Is the form in live mode (as opposed to being run as a preview).
+   *
+   * Returns true if the user has clicked the Download Document button on a
+   * Print/Merge Document (PDF Letter) search task form, or false if the Preview
+   * button was clicked.
+   *
+   * @return bool
+   *   TRUE if the Download Document button was clicked (also defaults to TRUE
+   *     if the form controller does not exist), else FALSE
+   */
+  protected function isLiveMode(): bool {
+    // CRM-21255 - Hrm, CiviCase 4+5 seem to report buttons differently...
+    $buttonName = $this->controller->getButtonName();
+    $c = $this->controller->container();
+    return ($buttonName === '_qf_PDF_upload') || isset($c['values']['PDF']['buttons']['_qf_PDF_upload']);
+  }
+
 }

--- a/CRM/Contribute/Form/Task/PDFLetter.php
+++ b/CRM/Contribute/Form/Task/PDFLetter.php
@@ -237,14 +237,7 @@ class CRM_Contribute_Form_Task_PDFLetter extends CRM_Contribute_Form_Task {
 
     //CRM-19761
     if (!empty($html)) {
-      // Set the filename for the PDF using the Activity Subject, if defined. Remove unwanted characters and limit the length to 200 characters.
-      if (!empty($formValues['subject'])) {
-        $fileName = CRM_Utils_File::makeFilenameWithUnicode($formValues['subject'], '_', 200);
-      }
-      else {
-        $fileName = 'CiviLetter';
-      }
-
+      $fileName = $this->getFileName();
       if ($this->getSubmittedValue('document_type') === 'pdf') {
         CRM_Utils_PDF_Utils::html2pdf($html, $fileName . '.pdf', FALSE, $formValues);
       }

--- a/CRM/Member/Form/Task/PDFLetter.php
+++ b/CRM/Member/Form/Task/PDFLetter.php
@@ -102,16 +102,7 @@ class CRM_Member_Form_Task_PDFLetter extends CRM_Member_Form_Task {
       $categories
     );
     CRM_Contact_Form_Task_PDFLetterCommon::createActivities($form, $html_message, $contactIDs, $formValues['subject'], CRM_Utils_Array::value('campaign_id', $formValues));
-
-    // Set the filename for the PDF using the Activity Subject, if defined. Remove unwanted characters and limit the length to 200 characters.
-    if (!empty($form->getSubmittedValue('subject'))) {
-      $fileName = CRM_Utils_File::makeFilenameWithUnicode($form->getSubmittedValue('subject'), '_', 200) . '.pdf';
-    }
-    else {
-      $fileName = 'CiviLetter.pdf';
-    }
-
-    CRM_Utils_PDF_Utils::html2pdf($html, $fileName, FALSE, $formValues);
+    CRM_Utils_PDF_Utils::html2pdf($html, $this->getFileName() . '.pdf', FALSE, $formValues);
 
     $form->postProcessHook();
 

--- a/tests/phpunit/CRM/Utils/TokenTest.php
+++ b/tests/phpunit/CRM/Utils/TokenTest.php
@@ -152,10 +152,8 @@ class CRM_Utils_TokenTest extends CiviUnitTestCase {
    *   and makes sure that greeting + contact tokens are replaced.
    * This is a good example to copy/expand when creating additional tests for token processor
    *   in "real" situations.
-   *
-   * @throws \CRM_Core_Exception
    */
-  public function testTokenProcessor() {
+  public function testTokenProcessor(): void {
     $params['contact_id'] = $this->individualCreate();
 
     // Prepare the processor and general context.


### PR DESCRIPTION

Overview
----------------------------------------
[REF] dev/core#2790 Move getFileName functionality to the trait

Before
----------------------------------------
New `getFileName` function in multiple places

After
----------------------------------------
One shared place for core code

Technical Details
----------------------------------------
This moves the recently added functionality to standardise the file name to PDFTrait

For code not using the trait (naughty extensions that are using core code in unsupported ways)
the functionality will be the same as prior versions.

(note extensions should just copy & paste the code they want from core into their extensions
if they want code that is not part of a supported interface
rather than call core functions - it's not 'DRY' if it's not supported).

Comments
----------------------------------------
