### PR TITLE
dev/core#2814 migrate export processor to use MessageRender

### DIFF
--- a/tests/phpunit/CRM/Export/BAO/ExportTest.php
+++ b/tests/phpunit/CRM/Export/BAO/ExportTest.php
@@ -97,7 +97,7 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
     }
     if ($this->processor && $this->processor->getTemporaryTable()) {
       // delete the export temp table
-      CRM_Core_DAO::executeQuery("DROP TABLE IF EXISTS " . $this->processor->getTemporaryTable());
+      CRM_Core_DAO::executeQuery('DROP TABLE IF EXISTS ' . $this->processor->getTemporaryTable());
     }
     parent::tearDown();
   }


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#2814 migrate export processor to use MessageRender

Before
----------------------------------------
`replaceContactTokens` used

After
----------------------------------------
`MessageRender` used

Technical Details
----------------------------------------
Note that test cover is in `CRM_Export_BAO_ExportTest`

I used  `testMergeSameAddressGreetingOptions` to step through it
as that specifically covers this change. In this case the cover is tightly correlated enough to make an r-run redundant

Comments
----------------------------------------

https://lab.civicrm.org/dev/core/-/issues/2814