### PR TITLE
Switch to CRM_Core_Form::setTitle() instead of CRM_Utils_System::setTitle() part 4

### DIFF
--- a/CRM/Member/Form/MembershipRenewal.php
+++ b/CRM/Member/Form/MembershipRenewal.php
@@ -162,7 +162,7 @@ class CRM_Member_Form_MembershipRenewal extends CRM_Member_Form {
       CRM_Custom_Form_CustomData::setDefaultValues($this);
     }
 
-    CRM_Utils_System::setTitle(ts('Renew Membership'));
+    $this->setTitle(ts('Renew Membership'));
 
     parent::preProcess();
   }

--- a/CRM/Member/Form/MembershipView.php
+++ b/CRM/Member/Form/MembershipView.php
@@ -341,7 +341,7 @@ SELECT r.id, c.id as cid, c.display_name as name, c.job_title as comment,
       }
 
       // omitting contactImage from title for now since the summary overlay css doesn't work outside crm-container
-      CRM_Utils_System::setTitle(ts('View Membership for') . ' ' . $displayName);
+      $this->setTitle(ts('View Membership for') . ' ' . $displayName);
 
       // add viewed membership to recent items list
       $recentTitle = $displayName . ' - ' . ts('Membership Type:') . ' ' . $values['membership_type'];

--- a/CRM/Member/Form/Task/Batch.php
+++ b/CRM/Member/Form/Task/Batch.php
@@ -77,7 +77,7 @@ class CRM_Member_Form_Task_Batch extends CRM_Member_Form_Task {
       CRM_Core_Error::statusBounce(ts('ufGroupId is missing'));
     }
     $this->_title = ts('Update multiple memberships') . ' - ' . CRM_Core_BAO_UFGroup::getTitle($ufGroupId);
-    CRM_Utils_System::setTitle($this->_title);
+    $this->setTitle($this->_title);
 
     $this->addDefaultButtons(ts('Save'));
     $this->_fields = [];

--- a/CRM/Member/Form/Task/PickProfile.php
+++ b/CRM/Member/Form/Task/PickProfile.php
@@ -50,7 +50,7 @@ class CRM_Member_Form_Task_PickProfile extends CRM_Member_Form_Task {
     $session = CRM_Core_Session::singleton();
     $this->_userContext = $session->readUserContext();
 
-    CRM_Utils_System::setTitle(ts('Update multiple memberships'));
+    $this->setTitle(ts('Update multiple memberships'));
 
     $validate = FALSE;
     //validations

--- a/CRM/PCP/Form/Campaign.php
+++ b/CRM/PCP/Form/Campaign.php
@@ -44,7 +44,7 @@ class CRM_PCP_Form_Campaign extends CRM_Core_Form {
       $title = ts('Edit Your Personal Campaign Page');
     }
 
-    CRM_Utils_System::setTitle($title);
+    $this->setTitle($title);
     parent::preProcess();
   }
 

--- a/CRM/PCP/Form/Event.php
+++ b/CRM/PCP/Form/Event.php
@@ -42,7 +42,7 @@ class CRM_PCP_Form_Event extends CRM_Event_Form_ManageEvent {
     $defaults = [];
     if (isset($this->_id)) {
       $title = CRM_Core_DAO::getFieldValue('CRM_Event_DAO_Event', $this->_id, 'title');
-      CRM_Utils_System::setTitle(ts('Personal Campaign Page Settings (%1)', [1 => $title]));
+      $this->setTitle(ts('Personal Campaign Page Settings (%1)', [1 => $title]));
 
       $params = ['entity_id' => $this->_id, 'entity_table' => 'civicrm_event'];
       CRM_Core_DAO::commonRetrieve('CRM_PCP_DAO_PCPBlock', $params, $defaults);

--- a/CRM/PCP/Form/PCPAccount.php
+++ b/CRM/PCP/Form/PCPAccount.php
@@ -100,7 +100,7 @@ class CRM_PCP_Form_PCPAccount extends CRM_Core_Form {
     $this->assign('pcpComponent', $this->_component);
 
     if ($this->_single) {
-      CRM_Utils_System::setTitle(ts('Update Contact Information'));
+      $this->setTitle(ts('Update Contact Information'));
     }
   }
 

--- a/CRM/Pledge/Form/Payment.php
+++ b/CRM/Pledge/Form/Payment.php
@@ -54,7 +54,7 @@ class CRM_Pledge_Form_Payment extends CRM_Core_Form {
 
     $this->_id = CRM_Utils_Request::retrieve('ppId', 'Positive', $this);
 
-    CRM_Utils_System::setTitle(ts('Edit Scheduled Pledge Payment'));
+    $this->setTitle(ts('Edit Scheduled Pledge Payment'));
   }
 
   /**

--- a/CRM/Pledge/Form/PledgeView.php
+++ b/CRM/Pledge/Form/PledgeView.php
@@ -99,7 +99,7 @@ class CRM_Pledge_Form_PledgeView extends CRM_Core_Form {
       $displayName .= ' (' . ts('default organization') . ')';
     }
     // omitting contactImage from title for now since the summary overlay css doesn't work outside of our crm-container
-    CRM_Utils_System::setTitle(ts('View Pledge by') . ' ' . $displayName);
+    $this->setTitle(ts('View Pledge by') . ' ' . $displayName);
 
     // do check for campaigns
     if ($campaignId = CRM_Utils_Array::value('campaign_id', $values)) {

--- a/CRM/Price/Form/DeleteField.php
+++ b/CRM/Price/Form/DeleteField.php
@@ -50,7 +50,7 @@ class CRM_Price_Form_DeleteField extends CRM_Core_Form {
 
     $this->assign('title', $this->_title);
 
-    CRM_Utils_System::setTitle(ts('Confirm Price Field Delete'));
+    $this->setTitle(ts('Confirm Price Field Delete'));
   }
 
   /**

--- a/CRM/Price/Form/Set.php
+++ b/CRM/Price/Form/Set.php
@@ -108,7 +108,7 @@ class CRM_Price_Form_Set extends CRM_Core_Form {
     elseif ($this->_action & CRM_Core_Action::VIEW) {
       $title = ts('Preview %1', [1 => $title]);
     }
-    CRM_Utils_System::setTitle($title);
+    $this->setTitle($title);
 
     $url = CRM_Utils_System::url('civicrm/admin/price', 'reset=1');
     $breadCrumb = [

--- a/CRM/Report/Form/Register.php
+++ b/CRM/Report/Form/Register.php
@@ -22,7 +22,7 @@ class CRM_Report_Form_Register extends CRM_Core_Form {
     $this->_action = CRM_Utils_Request::retrieve('action', 'String', $this, FALSE);
     $this->_id = CRM_Utils_Request::retrieve('id', 'String', $this, FALSE);
 
-    CRM_Utils_System::setTitle(ts('Report Template'));
+    $this->setTitle(ts('Report Template'));
 
     if ($this->_action & CRM_Core_Action::DELETE) {
       return;

--- a/CRM/UF/Form/Group.php
+++ b/CRM/UF/Form/Group.php
@@ -124,7 +124,7 @@ class CRM_UF_Form_Group extends CRM_Core_Form {
 
     // setting title for html page
     if ($this->_action & CRM_Core_Action::UPDATE) {
-      CRM_Utils_System::setTitle(ts('Profile Settings') . " - $title");
+      $this->setTitle(ts('Profile Settings') . " - $title");
     }
     elseif ($this->_action & (CRM_Core_Action::DISABLE | CRM_Core_Action::DELETE)) {
       $ufGroup['module'] = implode(' , ', CRM_Core_BAO_UFGroup::getUFJoinRecord($this->_id, TRUE));
@@ -149,7 +149,7 @@ class CRM_UF_Form_Group extends CRM_Core_Form {
       $this->assign('message', $message);
     }
     else {
-      CRM_Utils_System::setTitle(ts('New CiviCRM Profile'));
+      $this->setTitle(ts('New CiviCRM Profile'));
     }
   }
 

--- a/CRM/Upgrade/Form.php
+++ b/CRM/Upgrade/Form.php
@@ -187,7 +187,7 @@ class CRM_Upgrade_Form extends CRM_Core_Form {
   }
 
   public function preProcess() {
-    CRM_Utils_System::setTitle($this->getTitle());
+    $this->setTitle($this->getTitle());
     if (!$this->verifyPreDBState($errorMessage)) {
       if (!isset($errorMessage)) {
         $errorMessage = 'pre-condition failed for current upgrade step';

--- a/tests/extensions/test.extension.manager.searchtest/main.php
+++ b/tests/extensions/test.extension.manager.searchtest/main.php
@@ -22,7 +22,7 @@ class test_extension_manager_searchtest extends CRM_Contact_Form_Search_Custom_B
    * @return void
    */
   public function buildForm(&$form) {
-    CRM_Utils_System::setTitle(ts('My Search Title'));
+    $form->setTitle(ts('My Search Title'));
 
     $form->add('text',
       'household_name',


### PR DESCRIPTION
Overview
----------------------------------------
Follows on from some work that @eileenmcnaughton started in 2019. Forms should use `$this->setTitle()` instead of `CRM_Utils_System::setTitle()` because it allows you to use `$this->getTitle()` on a form to get the title of the form that the user will see.

Before
----------------------------------------
Calls to `CRM_Utils_System::setTitle()`

After
----------------------------------------
Calls to `$this->setTitle()`

Technical Details
----------------------------------------
As can be observed `CRM_Core_Form::setTitle()` calls `CRM_Utils_System::setTitle()` internally after setting `$this->_title` showing that this function is a drop-in replacement. There are just over 200 instances that need converting and (for ease of review) this is the final 43.
I would suggest that `r-run` testing could be done with a few forms only instead of all of them - what needs to be verified is that it is a form that inherits from CRM_Core_Form (and not eg. a Page).

Comments
----------------------------------------
This is the final one
