### PR TITLE
[NFC/Unit test] - Fix secondary issue with case token consistency test

### DIFF
--- a/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
+++ b/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
@@ -130,19 +130,27 @@ No
    */
   protected function getCaseID(): int {
     if (!isset($this->case)) {
-      $this->case = $this->callAPISuccess('Case', 'create', [
+      $case_id = $this->callAPISuccess('Case', 'create', [
         'case_type_id' => 'housing_support',
         'activity_subject' => 'Case Subject',
         'client_id' => $this->getContactID(),
         'status_id' => 1,
         'subject' => 'Case Subject',
         'start_date' => '2021-07-23 15:39:20',
+        // Note end_date is inconsistent with status Ongoing but for the
+        // purposes of testing tokens is ok. Creating it with status Resolved
+        // then ignores our known fixed end date.
         'end_date' => '2021-07-26 18:07:20',
         'medium_id' => 2,
         'details' => 'case details',
         'activity_details' => 'blah blah',
         'sequential' => 1,
-      ])['values'][0];
+      ])['id'];
+      // Need to retrieve the case again because modified date might be updated a
+      // split-second later than the original return value because of activity
+      // triggers when the timeline is populated. The returned array from create
+      // is determined before that happens.
+      $this->case = $this->callAPISuccess('Case', 'getsingle', ['id' => $case_id]);
     }
     return $this->case['id'];
   }


### PR DESCRIPTION
Overview
----------------------------------------
Intermittently failing test

Before
----------------------------------------
e.g.

```
CRM_Utils_TokenConsistencyTest::testCaseTokenConsistency
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
 Ongoing\n
 No\n
 2021-09-04 06:22:17\n
-2021-09-04 06:22:17\n
+2021-09-04 06:22:18\n
 '
```

After
----------------------------------------


Technical Details
----------------------------------------
api3 case create calls CRM_Case_BAO_Case::create to create the Case record, and stores it in $caseBAO. It then calls the xmlprocessor to populate the timeline, which via activity triggers updates case.modified_date. Then it returns the $caseBAO from before that as the api result. If there's a split-second delay then $caseBAO['modified_date'] won't match the latest modified_date, which is what the evaluated token uses.

Comments
----------------------------------------
Is test
