### PR TITLE
Fix test to test trait not deprecated function

### DIFF
--- a/tests/phpunit/CRM/Contact/Form/Task/EmailCommonTest.php
+++ b/tests/phpunit/CRM/Contact/Form/Task/EmailCommonTest.php
@@ -107,8 +107,8 @@ class CRM_Contact_Form_Task_EmailCommonTest extends CiviUnitTestCase {
     // This rule somehow disappears if there's a form-related test before us,
     // so register it again. See packages/HTML/QuickForm/file.php.
     $form->registerRule('maxfilesize', 'callback', '_ruleCheckMaxFileSize', 'HTML_QuickForm_file');
-    CRM_Contact_Form_Task_EmailCommon::preProcessFromAddress($form);
-    $form->buildQuickForm();
+    $form->isSearchContext = FALSE;
+    $form->buildForm();
     $form->submit(array_merge($form->_defaultValues, [
       'from_email_address' => $loggedInEmail['id'],
       'subject' => 'Really interesting stuff',


### PR DESCRIPTION
Overview
----------------------------------------
Fix test to test trait not deprecated function

Before
----------------------------------------
Test testing the deprecated function - not the one in use

After
----------------------------------------
calling `buildForm` calls the version on the trait

Technical Details
----------------------------------------
It's time to fully deprecate the old `EmailCommon` class

Comments
----------------------------------------
