### PR TITLE
Fix event custom field tokens in scheduled reminders

### DIFF
--- a/CRM/Event/Tokens.php
+++ b/CRM/Event/Tokens.php
@@ -127,7 +127,7 @@ LEFT JOIN civicrm_phone phone ON phone.id = lb.phone_id
       $row->tokens($entity, $field, $actionSearchResult->$field);
     }
     elseif ($cfID = \CRM_Core_BAO_CustomField::getKeyID($field)) {
-      $row->customToken($entity, $cfID, $actionSearchResult->entity_id);
+      $row->customToken($entity, $cfID, $actionSearchResult->event_id);
     }
     else {
       $row->tokens($entity, $field, '');


### PR DESCRIPTION
Overview
----------------------------------------
Fix for rendering Event custom field tokens like {event.custom_123} in scheduled reminders for events

Before
----------------------------------------
The token processor looks up the value for the custom field using participant id rather than event id.

Generally this will be out of range and so the Scheduled Reminder job fails with `Finished execution of Send Scheduled Reminders with result: Failure, Error message: Expected one Event but found 0`

[I suppose it's possible it might hit a custom value from a random event in the co-incidence that participant_id matches some other event_id.]

After
----------------------------------------
{event.custom_123} tokens work as expected.

Technical Details
----------------------------------------
The line looks like a generalised look up for custom fields on $entity ( which is relevant when repeated in e.g. https://github.com/civicrm/civicrm-core/blob/41c0455e1936ff809f39283a1ff547768b241521/CRM/Member/Tokens.php#L88 ) but I'm fairly confident in this context $entity is always 'Event' .

Comments
----------------------------------------
Looks like there are ambitious plans for TokenProcessor more generally, but hopeful this tiny fix could be useful in the interim.
