### PR TITLE
Update use of CRM_Utils_System::setTitle() for legacycustomsearches

### DIFF
--- a/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/ActivitySearch.php
+++ b/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/ActivitySearch.php
@@ -391,18 +391,6 @@ ORDER BY contact_a.sort_name';
   }
 
   /**
-   * @param $title
-   */
-  public function setTitle($title) {
-    if ($title) {
-      CRM_Utils_System::setTitle($title);
-    }
-    else {
-      CRM_Utils_System::setTitle(ts('Search'));
-    }
-  }
-
-  /**
    * @return null
    */
   public function summary() {

--- a/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/Base.php
+++ b/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/Base.php
@@ -23,6 +23,12 @@ class CRM_Contact_Form_Search_Custom_Base {
   protected $_stateID;
 
   /**
+   * The title of this form
+   * @var string
+   */
+  protected $_title = NULL;
+
+  /**
    * Class constructor.
    *
    * @param array $formValues
@@ -228,17 +234,17 @@ class CRM_Contact_Form_Search_Custom_Base {
   }
 
   /**
-   * Set the title.
+   * Setter function for title.
    *
    * @param string $title
+   *   The title of the form.
    */
   public function setTitle($title) {
-    if ($title) {
-      CRM_Utils_System::setTitle($title);
+    if (empty($title)) {
+      $title = ts('Search');
     }
-    else {
-      CRM_Utils_System::setTitle(ts('Search'));
-    }
+    $this->_title = $title;
+    CRM_Utils_System::setTitle($title);
   }
 
   /**

--- a/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/ContribSYBNT.php
+++ b/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/ContribSYBNT.php
@@ -366,18 +366,6 @@ AND      c.receive_date < {$this->start_date_1}
   }
 
   /**
-   * @param $title
-   */
-  public function setTitle($title) {
-    if ($title) {
-      CRM_Utils_System::setTitle($title);
-    }
-    else {
-      CRM_Utils_System::setTitle(ts('Search'));
-    }
-  }
-
-  /**
    * @param string $tableAlias
    */
   public function buildACLClause($tableAlias = 'contact') {

--- a/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/ContributionAggregate.php
+++ b/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/ContributionAggregate.php
@@ -321,18 +321,6 @@ civicrm_contact AS contact_a {$this->_aclFrom}
   }
 
   /**
-   * @param $title
-   */
-  public function setTitle($title) {
-    if ($title) {
-      CRM_Utils_System::setTitle($title);
-    }
-    else {
-      CRM_Utils_System::setTitle(ts('Search'));
-    }
-  }
-
-  /**
    * @return null
    */
   public function summary() {

--- a/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/DateAdded.php
+++ b/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/DateAdded.php
@@ -362,18 +362,6 @@ class CRM_Contact_Form_Search_Custom_DateAdded extends CRM_Contact_Form_Search_C
   }
 
   /**
-   * @param $title
-   */
-  public function setTitle($title) {
-    if ($title) {
-      CRM_Utils_System::setTitle($title);
-    }
-    else {
-      CRM_Utils_System::setTitle(ts('Search'));
-    }
-  }
-
-  /**
    * @return mixed
    */
   public function count() {

--- a/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/EventAggregate.php
+++ b/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/EventAggregate.php
@@ -336,18 +336,6 @@ class CRM_Contact_Form_Search_Custom_EventAggregate extends CRM_Contact_Form_Sea
   }
 
   /**
-   * @param $title
-   */
-  public function setTitle($title) {
-    if ($title) {
-      CRM_Utils_System::setTitle($title);
-    }
-    else {
-      CRM_Utils_System::setTitle(ts('Search'));
-    }
-  }
-
-  /**
    * @param string $tableAlias
    */
   public function buildACLClause($tableAlias = 'contact') {

--- a/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/FullText.php
+++ b/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/FullText.php
@@ -520,15 +520,6 @@ FROM   {$this->_tableName} contact_a
   }
 
   /**
-   * @param $title
-   */
-  public function setTitle($title) {
-    if ($title) {
-      CRM_Utils_System::setTitle($title);
-    }
-  }
-
-  /**
    * @param int|array $limit
    * @return string
    *   SQL

--- a/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/Group.php
+++ b/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/Group.php
@@ -653,20 +653,6 @@ WHERE  gcc.group_id = {$ssGroup->id}
   }
 
   /**
-   * Set title on search.
-   *
-   * @param string $title
-   */
-  public function setTitle($title) {
-    if ($title) {
-      CRM_Utils_System::setTitle($title);
-    }
-    else {
-      CRM_Utils_System::setTitle(ts('Search'));
-    }
-  }
-
-  /**
    * Build ACL clause.
    *
    * @param string $tableAlias

--- a/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/PriceSet.php
+++ b/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/PriceSet.php
@@ -333,12 +333,10 @@ INNER JOIN {$this->_tableName} tempTable ON ( tempTable.contact_id = contact_a.i
    * @param $title
    */
   public function setTitle($title) {
-    if ($title) {
-      CRM_Utils_System::setTitle($title);
+    if (empty($title)) {
+      $title = ts('Export Price Set Info for an Event');
     }
-    else {
-      CRM_Utils_System::setTitle(ts('Export Price Set Info for an Event'));
-    }
+    parent::setTitle($title);
   }
 
   /**

--- a/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/Proximity.php
+++ b/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/Proximity.php
@@ -271,18 +271,6 @@ class CRM_Contact_Form_Search_Custom_Proximity extends CRM_Contact_Form_Search_C
   }
 
   /**
-   * @param $title
-   */
-  public function setTitle($title) {
-    if ($title) {
-      CRM_Utils_System::setTitle($title);
-    }
-    else {
-      CRM_Utils_System::setTitle(ts('Search'));
-    }
-  }
-
-  /**
    * Validate form input.
    *
    * @param array $fields

--- a/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/RandomSegment.php
+++ b/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/RandomSegment.php
@@ -333,18 +333,6 @@ class CRM_Contact_Form_Search_Custom_RandomSegment extends CRM_Contact_Form_Sear
   }
 
   /**
-   * @param $title
-   */
-  public function setTitle($title) {
-    if ($title) {
-      CRM_Utils_System::setTitle($title);
-    }
-    else {
-      CRM_Utils_System::setTitle(ts('Search'));
-    }
-  }
-
-  /**
    * @return mixed
    */
 

--- a/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/Sample.php
+++ b/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/Sample.php
@@ -207,18 +207,6 @@ LEFT JOIN civicrm_state_province state_province ON state_province.id = address.s
   }
 
   /**
-   * @param $title
-   */
-  public function setTitle($title) {
-    if ($title) {
-      CRM_Utils_System::setTitle($title);
-    }
-    else {
-      CRM_Utils_System::setTitle(ts('Search'));
-    }
-  }
-
-  /**
    * @param string $tableAlias
    */
   public function buildACLClause($tableAlias = 'contact') {

--- a/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/TagContributions.php
+++ b/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/TagContributions.php
@@ -237,18 +237,6 @@ WHERE  $where
   }
 
   /**
-   * @param $title
-   */
-  public function setTitle($title) {
-    if ($title) {
-      CRM_Utils_System::setTitle($title);
-    }
-    else {
-      CRM_Utils_System::setTitle(ts('Search'));
-    }
-  }
-
-  /**
    * @return null
    */
   public function summary() {

--- a/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/ZipCodeRange.php
+++ b/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/ZipCodeRange.php
@@ -189,18 +189,6 @@ LEFT JOIN civicrm_email   email   ON ( email.contact_id = contact_a.id AND
   }
 
   /**
-   * @param $title
-   */
-  public function setTitle($title) {
-    if ($title) {
-      CRM_Utils_System::setTitle($title);
-    }
-    else {
-      CRM_Utils_System::setTitle(ts('Search'));
-    }
-  }
-
-  /**
    * @param string $tableAlias
    */
   public function buildACLClause($tableAlias = 'contact') {


### PR DESCRIPTION
Overview
----------------------------------------
Follows on from some work that @eileenmcnaughton started in 2019. Forms should use `$this->setTitle()` instead of `CRM_Utils_System::setTitle()` because it allows you to use `$this->getTitle()` on a form to get the title of the form that the user will see.

Before
----------------------------------------
Calls to `CRM_Utils_System::setTitle()` via child functions that are identical to parent function.

After
----------------------------------------
Calls to `$this->setTitle()` calls parent function directly which sets the title in the same way as `CRM_Core_Form` even though we don't inherit from `CRM_Core_Form` here.

Technical Details
----------------------------------------


Comments
----------------------------------------
