### PR TITLE
SearchKit - enable tags for Saved Searches

### DIFF
--- a/ext/search_kit/Civi/Search/Admin.php
+++ b/ext/search_kit/Civi/Search/Admin.php
@@ -11,6 +11,7 @@
 
 namespace Civi\Search;
 
+use Civi\Api4\Tag;
 use CRM_Search_ExtensionUtil as E;
 
 /**
@@ -35,6 +36,10 @@ class Admin {
       'defaultPagerSize' => \Civi::settings()->get('default_pager_size'),
       'afformEnabled' => $extensions->isActiveModule('afform'),
       'afformAdminEnabled' => $extensions->isActiveModule('afform_admin'),
+      'tags' => Tag::get()
+        ->addSelect('id', 'name', 'color', 'is_selectable', 'description')
+        ->addWhere('used_for', 'CONTAINS', 'civicrm_saved_search')
+        ->execute(),
     ];
   }
 

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminTags.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminTags.component.js
@@ -1,0 +1,84 @@
+(function(angular, $, _) {
+  "use strict";
+
+  angular.module('crmSearchAdmin').component('crmSearchAdminTags', {
+    bindings: {
+      tagIds: '<',
+      savedSearchId: '<'
+    },
+    templateUrl: '~/crmSearchAdmin/crmSearchAdminTags.html',
+    controller: function ($scope, $element, crmApi4, crmStatus) {
+      var ts = $scope.ts = CRM.ts('org.civicrm.search_kit'),
+        ctrl = this;
+      this.allTags = CRM.crmSearchAdmin.tags;
+
+      function reset() {
+        ctrl.menuOpen = false;
+        ctrl.search = '';
+      }
+
+      this.$onInit = function() {
+        ctrl.tagIds = ctrl.tagIds || [];
+        reset();
+        $element.on('hidden.bs.dropdown', function() {
+          $scope.$apply(reset);
+        });
+      };
+
+      this.openMenu = function() {
+        ctrl.menuOpen = true;
+        ctrl.color = getRandomColor();
+      };
+
+      this.getTag = function(id) {
+        return _.findWhere(ctrl.allTags, {id: id});
+      };
+
+      this.hasTag = function(tag) {
+        return _.includes(ctrl.tagIds, tag.id);
+      };
+
+      this.getStyle = function(id) {
+        var tag = ctrl.getTag(id);
+        if (tag && tag.color) {
+          return 'background-color: ' + tag.color + '; color: ' + CRM.utils.colorContrast(tag.color);
+        }
+        return '';
+      };
+
+      this.toggleTag = function(tag) {
+        if (ctrl.hasTag(tag)) {
+          _.remove(ctrl.tagIds, function(id) {return id === tag.id;});
+          if (ctrl.savedSearchId) {
+            crmStatus({}, crmApi4('EntityTag', 'delete', {
+              where: [['entity_id', '=', ctrl.savedSearchId], ['tag_id', '=', tag.id], ['entity_table', '=', 'civicrm_saved_search']]
+            }));
+          }
+        } else {
+          ctrl.tagIds.push(tag.id);
+          if (ctrl.savedSearchId) {
+            crmStatus({}, crmApi4('EntityTag', 'create', {
+              values: {entity_id: ctrl.savedSearchId, tag_id: tag.id, entity_table: 'civicrm_saved_search'}
+            }));
+          }
+        }
+      };
+
+      this.makeTag = function(name) {
+        crmApi4('Tag', 'create', {
+          values: {name: name, color: ctrl.color, is_selectable: true, used_for: ['civicrm_saved_search']}
+        }, 0).then(function(tag) {
+          ctrl.allTags.push(tag);
+          ctrl.toggleTag(tag);
+        });
+      };
+
+      // TODO: Use https://github.com/davidmerfield/randomColor
+      function getRandomColor() {
+        return '#' + Math.floor(Math.random()*16777215).toString(16);
+      }
+
+    }
+  });
+
+})(angular, CRM.$, CRM._);

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminTags.html
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminTags.html
@@ -1,0 +1,29 @@
+<button type="button" class="btn dropdown-toggle" ng-click="$ctrl.openMenu()" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+  <i class="crm-i fa-tag"></i>
+  <span class="crm-search-admin-tags-btn-label">{{:: ts('Tags') }}</span>
+  <span class="caret"></span>
+</button>
+<ul class="dropdown-menu" ng-if="$ctrl.menuOpen">
+  <li>
+    <div class="form-inline" ng-click="$event.stopPropagation()">
+      <input type="search" placeholder="{{:: ts('Add tag...') }}" ng-model="$ctrl.search">
+    </div>
+  </li>
+  <li ng-if="$ctrl.search.length > 1">
+    <div class="form-inline">
+      <label ng-click="$ctrl.makeTag($ctrl.search)">{{:: ts('Create Tag') }}</label>
+      <input type="color" ng-model="$ctrl.color">
+      <a href ng-click="$ctrl.makeTag($ctrl.search)">{{ $ctrl.search }}</a>
+    </div>
+  </li>
+  <li ng-repeat="tag in $ctrl.allTags | filter:{name: $ctrl.search, is_selectable: true}">
+    <a href ng-click="$ctrl.toggleTag(tag)">
+      <i class="crm-i fa-check" style="visibility: {{ $ctrl.hasTag(tag) ? 'visible' : 'hidden' }}"></i>
+      <span class="crm-search-admin-tag-color" style="background-color: {{:: tag.color }}"></span>
+      {{:: tag.name }}
+    </a>
+  </li>
+</ul>
+<span class="badge" ng-repeat="id in $ctrl.tagIds" style="{{:: $ctrl.getStyle(id) }}">
+  {{:: $ctrl.getTag(id).name }}
+</span>

--- a/ext/search_kit/ang/crmSearchAdmin/searchListing/crmSearchAdminSearchListing.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/searchListing/crmSearchAdminSearchListing.component.js
@@ -28,6 +28,8 @@
             'api_params',
             'created_date',
             'modified_date',
+            'DATE(created_date) AS date_created',
+            'DATE(modified_date) AS date_modified',
             'GROUP_CONCAT(display.name ORDER BY display.id) AS display_name',
             'GROUP_CONCAT(display.label ORDER BY display.id) AS display_label',
             'GROUP_CONCAT(display.type:icon ORDER BY display.id) AS display_icon',
@@ -96,13 +98,13 @@
               }),
               searchMeta.fieldToColumn('created_date', {
                 label: ts('Created'),
-                dataType: 'Date',
-                rewrite: ts('%1 by %2', {1: '[created_date]', 2: '[created_id.display_name]'})
+                title: '[created_date]',
+                rewrite: ts('%1 by %2', {1: '[date_created]', 2: '[created_id.display_name]'})
               }),
               searchMeta.fieldToColumn('modified_date', {
                 label: ts('Last Modified'),
-                dataType: 'Date',
-                rewrite: ts('%1 by %2', {1: '[modified_date]', 2: '[modified_id.display_name]'})
+                title: '[modified_date]',
+                rewrite: ts('%1 by %2', {1: '[date_modified]', 2: '[modified_id.display_name]'})
               }),
               {
                 type: 'include',

--- a/ext/search_kit/ang/crmSearchAdmin/searchListing/crmSearchAdminSearchListing.html
+++ b/ext/search_kit/ang/crmSearchAdmin/searchListing/crmSearchAdminSearchListing.html
@@ -1,8 +1,9 @@
 <div id="bootstrap-theme" class="crm-search">
   <h1 crm-page-title>{{:: ts('Saved Searches') }}</h1>
   <div class="form-inline">
-    <label for="search-list-filter">{{:: ts('Filter') }}</label>
-    <input class="form-control" type="search" id="search-list-filter" ng-model="$ctrl.filters.label" placeholder="&#xf002">
+    <input class="form-control" type="search" id="search-list-filter" ng-model="$ctrl.filters.label" placeholder="{{:: ts('Filter by label...') }}">
+    <input class="form-control collapsible-optgroups" ng-model="$ctrl.filters.api_entity" ng-list crm-ui-select="{multiple: true, data: $ctrl.entitySelect, placeholder: ts('Filter by entity...')}">
+    <input class="form-control" ng-model="$ctrl.filters.tags" ng-list crm-ui-select="{multiple: true, data: $ctrl.getTags, placeholder: ts('Filter by tags...')}">
     <a class="btn btn-primary pull-right" href="#/create/Contact/">
       <i class="crm-i fa-plus"></i>
       {{:: ts('New Search') }}

--- a/ext/search_kit/ang/crmSearchAdmin/searchListing/tags.html
+++ b/ext/search_kit/ang/crmSearchAdmin/searchListing/tags.html
@@ -1,0 +1,1 @@
+<crm-search-admin-tags tag-ids="row.tag_id.raw" saved-search-id="row.id.raw" class="btn-group btn-group-xs"></crm-search-admin-tags>

--- a/ext/search_kit/ang/crmSearchAdmin/tabs.html
+++ b/ext/search_kit/ang/crmSearchAdmin/tabs.html
@@ -1,3 +1,6 @@
+<li>
+  <crm-search-admin-tags tag-ids="$ctrl.savedSearch.tag_id" class="btn-group btn-group-sm"></crm-search-admin-tags>
+</li>
 <li role="presentation" ng-class="{active: controls.tab === 'compose'}">
   <a href ng-click="selectTab('compose')">
     <i class="crm-i fa-gears"></i>

--- a/ext/search_kit/css/crmSearchAdmin.css
+++ b/ext/search_kit/css/crmSearchAdmin.css
@@ -211,16 +211,39 @@
 #bootstrap-theme tbody .crm-search-admin-icon-col {
   text-align: center;
 }
+#bootstrap-theme .crm-search-admin-tag-color {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border: 1px solid lightgrey;
+  border-radius: 5px;
+}
 
-#bootstrap-theme input[type=search]::placeholder {
-  font-family: FontAwesome;
-  text-align: right;
+#bootstrap-theme crm-search-admin-tags.btn-group-xs .crm-search-admin-tags-btn-label {
+  display: none;
 }
-#bootstrap-theme input[type=search]:-ms-input-placeholder {
-  font-family: FontAwesome;
-  text-align: right;
+
+#bootstrap-theme .dropdown-menu li .form-inline {
+  padding: 2px 19px 2px 21px;
+  clear: both;
+  font-weight: 400;
+  line-height: 1.5384615385;
+  color: #4d4d69;
+  white-space: nowrap;
 }
-#bootstrap-theme input[type=search]::-ms-input-placeholder {
-  font-family: FontAwesome;
-  text-align: right;
+
+#bootstrap-theme .dropdown-menu li > * > label {
+  font-weight: normal;
+  cursor: pointer;
+}
+
+#bootstrap-theme .dropdown-menu li .form-inline > select {
+  max-width: 120px;
+  padding-left: 5px;
+  padding-right: 5px;
+}
+
+#bootstrap-theme li .form-inline input[type=color] {
+  width: 30px;
+  padding: 2px 4px;
 }

--- a/ext/search_kit/managed/TagUsedFor.mgd.php
+++ b/ext/search_kit/managed/TagUsedFor.mgd.php
@@ -1,0 +1,15 @@
+<?php
+// Adds option group for SearchDisplay.type
+
+return [
+  [
+    'name' => 'SavedSearch:tag_used_for',
+    'entity' => 'OptionValue',
+    'params' => [
+      'option_group_id' => 'tag_used_for',
+      'value' => 'civicrm_saved_search',
+      'name' => 'SavedSearch',
+      'label' => ts('Saved Searches'),
+    ],
+  ],
+];


### PR DESCRIPTION
Overview
----------------------------------------
Allows saved searches to be tagged, for categorization in SearchKit.

![Screenshot from 2021-09-05 18-13-34](https://user-images.githubusercontent.com/2874912/132142857-ba2942e5-a8a4-4269-aa7d-d65ab61a1925.png)

Comments
----------------------------------------
The tag widget I made in Angular was inspired by the "Labels" dropdown in GitHub in which the search box serves a double-purpose with a "create new tag" option.