### PR TITLE
dev/core#2814 Fix activity:sendSMS to use renderTemplate

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -1327,8 +1327,7 @@ WHERE entity_id =%1 AND entity_table = %2";
         unset($tokenDetails["{$contactId}"]['phone_type_id']);
         $contact = array_merge($contact, $tokenDetails["{$contactId}"]);
       }
-      $tokenText = CRM_Utils_Token::replaceContactTokens($text, $contact, FALSE, $messageToken, FALSE, FALSE);
-      $tokenText = CRM_Utils_Token::replaceHookTokens($tokenText, $contact, $categories, FALSE, FALSE);
+      $tokenText = CRM_Core_BAO_MessageTemplate::renderTemplate(['messageTemplate' => ['msg_text' => $text], 'contactId' => $contactId, 'disableSmarty' => TRUE])['text'];
 
       // Only send if the phone is of type mobile
       if ($contact['phone_type_id'] == CRM_Core_PseudoConstant::getKey('CRM_Core_BAO_Phone', 'phone_type_id', 'Mobile')) {

--- a/tests/phpunit/CiviTest/CiviTestSMSProvider.php
+++ b/tests/phpunit/CiviTest/CiviTestSMSProvider.php
@@ -13,7 +13,7 @@
   * Test SMS provider to allow for testing
   */
 class CiviTestSMSProvider extends CRM_SMS_Provider {
-  protected $_providerInfo = [];
+  protected $sentMessage;
   protected $_id = 0;
   static private $_singleton = [];
 
@@ -44,6 +44,16 @@ class CiviTestSMSProvider extends CRM_SMS_Provider {
   }
 
   public function send($recipients, $header, $message, $dncID = NULL) {
+    $this->sentMessage = $message;
+  }
+
+  /**
+   * Get the message that was sent.
+   *
+   * @return string
+   */
+  public function getSentMessage(): string {
+    return $this->sentMessage;
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#2814 Fix activity:sendSMS to use renderTemplate

Before
----------------------------------------
`replaceContactTokens` used

After
----------------------------------------
`MessageTemplate::render` used

Technical Details
----------------------------------------
This adds a test to ensure the token is replaced

Comments
----------------------------------------
@colemanw 