### PR TITLE
dev/core#2814 Fix membership pdf to use renderTemplate

### DIFF
--- a/CRM/Member/Form/Task/PDFLetter.php
+++ b/CRM/Member/Form/Task/PDFLetter.php
@@ -154,12 +154,8 @@ class CRM_Member_Form_Task_PDFLetter extends CRM_Member_Form_Task {
         'CRM_Contribution_Form_Task_PDFLetterCommon'
       );
 
-      $tokenHtml = CRM_Utils_Token::replaceContactTokens($html_message, $contacts[$contactId], TRUE, $messageToken);
-      $tokenHtml = CRM_Utils_Token::replaceEntityTokens('membership', $membership, $tokenHtml, $messageToken);
-      $tokenHtml = CRM_Utils_Token::replaceHookTokens($tokenHtml, $contacts[$contactId], $categories, TRUE);
-      $tokenHtml = CRM_Utils_Token::parseThroughSmarty($tokenHtml, $contacts[$contactId]);
-
-      $html[] = $tokenHtml;
+      $tokenHtml = CRM_Utils_Token::replaceEntityTokens('membership', $membership, $html_message, $messageToken);
+      $html[] = CRM_Core_BAO_MessageTemplate::renderTemplate(['messageTemplate' => ['msg_html' => $tokenHtml], 'contactId' => $contactId])['html'];
 
     }
     return $html;

--- a/CRM/Member/Form/Task/PDFLetterCommon.php
+++ b/CRM/Member/Form/Task/PDFLetterCommon.php
@@ -90,12 +90,8 @@ class CRM_Member_Form_Task_PDFLetterCommon extends CRM_Contact_Form_Task_PDFLett
         'CRM_Contribution_Form_Task_PDFLetterCommon'
       );
 
-      $tokenHtml = CRM_Utils_Token::replaceContactTokens($html_message, $contacts[$contactId], TRUE, $messageToken);
-      $tokenHtml = CRM_Utils_Token::replaceEntityTokens('membership', $membership, $tokenHtml, $messageToken);
-      $tokenHtml = CRM_Utils_Token::replaceHookTokens($tokenHtml, $contacts[$contactId], $categories, TRUE);
-      $tokenHtml = CRM_Utils_Token::parseThroughSmarty($tokenHtml, $contacts[$contactId]);
-
-      $html[] = $tokenHtml;
+      $tokenHtml = CRM_Utils_Token::replaceEntityTokens('membership', $membership, $html_message, $messageToken);
+      $html[] = CRM_Core_BAO_MessageTemplate::renderTemplate(['messageTemplate' => ['msg_html' => $tokenHtml], 'contactId' => $contactId])['html'];
 
     }
     return $html;

--- a/tests/phpunit/CRM/Member/Form/Task/PDFLetterCommonTest.php
+++ b/tests/phpunit/CRM/Member/Form/Task/PDFLetterCommonTest.php
@@ -84,6 +84,7 @@ class CRM_Member_Form_Task_PDFLetterCommonTest extends CiviUnitTestCase {
     // Assert all membership tokens are replaced correctly.
     $expected = array_values($expected);
     foreach ($expected as $key => $dateVal) {
+      $this->assertStringContainsString('Anthony', $testHTML[$key]);
       foreach ($tokens as $text => $token) {
         $this->assertStringContainsString($dateVal[$token], $testHTML[$key]);
       }
@@ -107,6 +108,7 @@ class CRM_Member_Form_Task_PDFLetterCommonTest extends CiviUnitTestCase {
     foreach ($tokens as $key => $val) {
       $html .= "<p>{$key} - {membership.{$val}}</p>";
     }
+    $html .= '{contact.first_name}';
     return [$tokens, $html];
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#2814 Fix membership pdf to use renderTemplate

Before
----------------------------------------
legacy function used

After
----------------------------------------
renderTemplate used

Technical Details
----------------------------------------
One of these functions is actually a deprecated copy of the other - I've updated both even one is probably unused & will be removed over time

Comments
----------------------------------------

