### PR TITLE
dev/core#2817 towards deprecating legacy `replaceCaseTokens`

### DIFF
--- a/CRM/Core/SelectValues.php
+++ b/CRM/Core/SelectValues.php
@@ -699,9 +699,18 @@ class CRM_Core_SelectValues {
   public static function caseTokens($caseTypeId = NULL) {
     static $tokens = NULL;
     if (!$tokens) {
-      foreach (CRM_Case_BAO_Case::fields() as $field) {
-        $tokens["{case.{$field['name']}}"] = $field['title'];
-      }
+      $tokens = [
+        '{case.id}' => 'Case ID',
+        '{case.case_type_id:label}' => 'Case Type',
+        '{case.subject}' => 'Case Subject',
+        '{case.start_date}' => 'Case Start Date',
+        '{case.end_date}' => 'Case End Date',
+        '{case.details}' => 'Details',
+        '{case.status_id:label}' => 'Case Status',
+        '{case.is_deleted}' => 'Case is in the Trash',
+        '{case.created_date}' => 'Created Date',
+        '{case.modified_date}' => 'Modified Date',
+      ];
 
       $customFields = CRM_Core_BAO_CustomField::getFields('Case', FALSE, FALSE, $caseTypeId);
       foreach ($customFields as $id => $field) {

--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -1616,7 +1616,12 @@ class CRM_Utils_Token {
     $fn = is_callable(['CRM_Utils_Token', $fn]) ? $fn : 'getApiTokenReplacement';
     // since we already know the tokens lets just use them & do str_replace which is faster & simpler than preg_replace
     foreach ($knownTokens[$entity] as $token) {
-      $replacement = self::$fn($entity, $token, $entityArray);
+      // We are now supporting the syntax case_type_id:label
+      // so strip anything after the ':'
+      // (we aren't supporting 'name' at this stage, so we can assume 'label'
+      // test cover in TokenConsistencyTest.
+      $parts = explode(':', $token);
+      $replacement = self::$fn($entity, $parts[0], $entityArray);
       if ($escapeSmarty) {
         $replacement = self::tokenEscapeSmarty($replacement);
       }

--- a/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
+++ b/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
@@ -58,6 +58,10 @@ class CRM_Utils_TokenConsistencyTest extends CiviUnitTestCase {
     // Now do the same without passing in 'knownTokens'
     $tokenHtml = CRM_Utils_Token::replaceCaseTokens($caseID, implode("\n", array_keys($this->getCaseTokens())));
     $this->assertEquals($this->getExpectedCaseTokenOutput(), $tokenHtml);
+
+    // And check our deprecated tokens still work.
+    $tokenHtml = CRM_Utils_Token::replaceCaseTokens($caseID, '{case.case_type_id} {case.status_id}');
+    $this->assertEquals('Housing Support Ongoing', $tokenHtml);
   }
 
   /**
@@ -110,12 +114,12 @@ No
   public function getCaseTokens(): array {
     return [
       '{case.id}' => 'Case ID',
-      '{case.case_type_id}' => 'Case Type ID',
+      '{case.case_type_id:label}' => 'Case Type',
       '{case.subject}' => 'Case Subject',
       '{case.start_date}' => 'Case Start Date',
       '{case.end_date}' => 'Case End Date',
       '{case.details}' => 'Details',
-      '{case.status_id}' => 'Case Status',
+      '{case.status_id:label}' => 'Case Status',
       '{case.is_deleted}' => 'Case is in the Trash',
       '{case.created_date}' => 'Created Date',
       '{case.modified_date}' => 'Modified Date',


### PR DESCRIPTION


Overview
----------------------------------------
dev/core#2817 towards deprecating legacy

This adds support for the syntax

{case.status_id:label} which what we agreed as a preferred syntax
to disambiguate the demands for labels vs ids vs machine names in
various implementations.

The new (preferred) label is advertised - but the old
one still works



Before
----------------------------------------
`{case.status_id}` renders (e.g.) 'Ongoing'
`{case.case_type_id}` renders (e.g 'Housing Support')

After
----------------------------------------
The unambiguous versions work & are supported. The ambiguous ones also still work - but in the token processor variant they will render the DB value

`{case.status_id}` renders (e.g.) 'Ongoing'
`{case.status_id:label}` renders (e.g.) 'Ongoing'
`{case.case_type_id}` renders (e.g 'Housing Support')
`{case.case_type_id:label}` renders (e.g 'Housing Support')

Technical Details
----------------------------------------
See https://lab.civicrm.org/dev/core/-/issues/2817 for next steps

Comments
----------------------------------------
