### PR TITLE
dev/core#2817 Block submission of pdf with text including token format that is ambiguous with the processor

### DIFF
--- a/CRM/Contact/Form/Task/EmailTrait.php
+++ b/CRM/Contact/Form/Task/EmailTrait.php
@@ -352,6 +352,7 @@ trait CRM_Contact_Form_Task_EmailTrait {
     CRM_Campaign_BAO_Campaign::addCampaign($this);
 
     $this->addFormRule([__CLASS__, 'saveTemplateFormRule'], $this);
+    $this->addFormRule([__CLASS__, 'deprecatedTokensFormRule'], $this);
     CRM_Core_Resources::singleton()->addScriptFile('civicrm', 'templates/CRM/Contact/Form/Task/EmailCommon.js', 0, 'html-header');
   }
 
@@ -681,6 +682,27 @@ trait CRM_Contact_Form_Task_EmailTrait {
       $errors['saveTemplateName'] = ts('Enter name to save message template');
     }
     return empty($errors) ? TRUE : $errors;
+  }
+
+  /**
+   * Prevent submission of deprecated tokens.
+   *
+   * @param array $fields
+   *
+   * @return bool|string[]
+   */
+  public static function deprecatedTokensFormRule(array $fields) {
+    $deprecatedTokens = [
+      '{case.status_id}' => '{case.status_id:label}',
+      '{case.case_type_id}' => '{case.case_type_id:label}',
+    ];
+    $tokenErrors = [];
+    foreach ($deprecatedTokens as $token => $replacement) {
+      if (strpos($fields['html_message'], $token) !== FALSE) {
+        $tokenErrors[] = ts('Token %1 is no longer supported - use %2 instead', [$token, $replacement]);
+      }
+    }
+    return empty($tokenErrors) ? TRUE : ['html_message' => implode('<br>', $tokenErrors)];
   }
 
   /**

--- a/CRM/Core/Form/Task/PDFLetterCommon.php
+++ b/CRM/Core/Form/Task/PDFLetterCommon.php
@@ -198,7 +198,19 @@ class CRM_Core_Form_Task_PDFLetterCommon {
    */
   public static function formRule($fields, $files, $self) {
     $errors = [];
-    $template = CRM_Core_Smarty::singleton();
+    $deprecatedTokens = [
+      '{case.status_id}' => '{case.status_id:label}',
+      '{case.case_type_id}' => '{case.case_type_id:label}',
+    ];
+    $tokenErrors = [];
+    foreach ($deprecatedTokens as $token => $replacement) {
+      if (strpos($fields['html_message'], $token) !== FALSE) {
+        $tokenErrors[] = ts('Token %1 is no longer supported - use %2 instead', [$token, $replacement]);
+      }
+    }
+    if (!empty($tokenErrors)) {
+      $errors['html_message'] = implode('<br>', $tokenErrors);
+    }
 
     // If user uploads non-document file other than odt/docx
     if (empty($fields['template']) &&


### PR DESCRIPTION
Overview
----------------------------------------
Block submission with token format that is ambiguous with the processor

Before
----------------------------------------
When we add case tokens via the processor it will render a number for `{case.case_type_id}` so we want to ensure the values submitted on this form use the syntax `{case.case_type_id:label}`. Tokens selected from the token selector will be in tht syntax from https://github.com/civicrm/civicrm-core/pull/21380 - but they might be getting it from somewhere else so we want to prevent submit of these tokens on this form in advance of switching to the processor

After
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/132185400-89774807-1d1b-4160-9c74-571764bd179b.png)

Technical Details
----------------------------------------
Not in this PR - but we should probably also do an upgrade in message templates - the only question is whether we add a WHERE clause - I'm leaning to 'no'

 https://lab.civicrm.org/dev/core/-/issues/2817 for steps

Comments
----------------------------------------