### PR TITLE
Don't specify character set for civicrm_relationship_cache table

### DIFF
--- a/CRM/Upgrade/Incremental/sql/5.29.alpha1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.29.alpha1.mysql.tpl
@@ -27,7 +27,7 @@ CREATE TABLE `civicrm_relationship_cache` (
      CONSTRAINT FK_civicrm_relationship_cache_relationship_type_id FOREIGN KEY (`relationship_type_id`) REFERENCES `civicrm_relationship_type`(`id`) ON DELETE CASCADE,
      CONSTRAINT FK_civicrm_relationship_cache_near_contact_id FOREIGN KEY (`near_contact_id`) REFERENCES `civicrm_contact`(`id`) ON DELETE CASCADE,
      CONSTRAINT FK_civicrm_relationship_cache_far_contact_id FOREIGN KEY (`far_contact_id`) REFERENCES `civicrm_contact`(`id`) ON DELETE CASCADE
-)  ENGINE=InnoDB DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci;
+)  ENGINE=InnoDB;
 
 -- Fix missing resubscribeUrl token. There doesn't seem to be any precedent
 -- for doing an upgrade for these, since the last update was in 2009 when


### PR DESCRIPTION
Overview
----------------------------------------
The upgrader in 5.29 specified utf8 for character set. It should not be specified as it should use the database default (eg. utf8mb4).

How did I find this? Keep finding `civicrm_relationship_cache` set to utf8 on client databases when everything else is utf8mb4.

Before
----------------------------------------
Hardcoded to utf8

After
----------------------------------------
Uses database default (eg. utf8mb4)

Technical Details
----------------------------------------


Comments
----------------------------------------
I don't think a new table was added to core for a long time and then this was added in 5.29. I'd like to fix the upgrader step even though it won't affect many (ie. they've probably already run the upgrade or will install new) because it leaves a bad example or how to create a new table in core.
 
