### PR TITLE
dev/core#2817 Add CaseToken processor

### DIFF
--- a/CRM/Case/Tokens.php
+++ b/CRM/Case/Tokens.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * Class CRM_Case_Tokens
+ *
+ * Generate "case.*" tokens.
+ */
+class CRM_Case_Tokens extends CRM_Core_EntityTokens {
+
+  /**
+   * Get the entity name for api v4 calls.
+   *
+   * @return string
+   */
+  protected function getApiEntityName(): string {
+    return 'Case';
+  }
+
+}

--- a/CRM/Contribute/RecurTokens.php
+++ b/CRM/Contribute/RecurTokens.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * Class CRM_Contribute_RecurTokens
+ *
+ * Generate "contribution_recur.*" tokens.
+ */
+class CRM_Contribute_RecurTokens extends CRM_Core_EntityTokens {
+
+  /**
+   * Get the entity name for api v4 calls.
+   *
+   * @return string
+   */
+  protected function getApiEntityName(): string {
+    return 'ContributionRecur';
+  }
+
+  /**
+   * @return array
+   */
+  public function getCurrencyFieldName(): array {
+    return ['currency'];
+  }
+
+}

--- a/CRM/Core/EntityTokens.php
+++ b/CRM/Core/EntityTokens.php
@@ -383,7 +383,10 @@ class CRM_Core_EntityTokens extends AbstractTokenSubscriber {
    * @return string[]
    */
   public function getSkippedFields(): array {
-    $fields = ['contact_id'];
+    // tags is offered in 'case' & is one of the only fields that is
+    // 'not a real field' offered up by case - seems like an oddity
+    // we should skip at the top level for now.
+    $fields = ['contact_id', 'tags'];
     if (!CRM_Campaign_BAO_Campaign::isCampaignEnable()) {
       $fields[] = 'campaign_id';
     }

--- a/CRM/Core/SelectValues.php
+++ b/CRM/Core/SelectValues.php
@@ -707,7 +707,7 @@ class CRM_Core_SelectValues {
         '{case.end_date}' => 'Case End Date',
         '{case.details}' => 'Details',
         '{case.status_id:label}' => 'Case Status',
-        '{case.is_deleted}' => 'Case is in the Trash',
+        '{case.is_deleted:label}' => 'Case is in the Trash',
         '{case.created_date}' => 'Created Date',
         '{case.modified_date}' => 'Modified Date',
       ];

--- a/CRM/Upgrade/Incremental/php/FiveFortyThree.php
+++ b/CRM/Upgrade/Incremental/php/FiveFortyThree.php
@@ -26,9 +26,9 @@ class CRM_Upgrade_Incremental_php_FiveFortyThree extends CRM_Upgrade_Incremental
    */
   public function setPreUpgradeMessage(&$preUpgradeMessage, $rev, $currentVer = NULL) {
     // Example: Generate a pre-upgrade message.
-    // if ($rev == '5.12.34') {
-    //   $preUpgradeMessage .= '<p>' . ts('A new permission, "%1", has been added. This permission is now used to control access to the Manage Tags screen.', array(1 => ts('manage tags'))) . '</p>';
-    // }
+    if ($rev === '5.43.alpha1' && !empty(CRM_Core_Component::getEnabledComponents()['CiviCase'])) {
+      $preUpgradeMessage .= '<p>' . ts('Minor changes have been made to how the tokens to render case.is_deleted, case.created_date and case.modified_date. See https://docs.civicrm.org/sysadmin/en/latest/upgrade/version-specific/ for more') . '</p>';
+    }
   }
 
   /**

--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -1633,7 +1633,7 @@ class CRM_Utils_Token {
       return implode(', ', $ret);
     }
     // Format date fields
-    elseif ($entityArray[$token] && $fieldType == CRM_Utils_Type::T_DATE) {
+    elseif ($entityArray[$token] && in_array($fieldType, [CRM_Utils_Type::T_DATE, CRM_Utils_Type::T_TIMESTAMP, (CRM_Utils_Type::T_DATE + CRM_Utils_Type::T_TIME)])) {
       return CRM_Utils_Date::customFormat($entityArray[$token]);
     }
     return implode(', ', (array) $entityArray[$token]);
@@ -1829,7 +1829,7 @@ class CRM_Utils_Token {
     $customTokens = [];
     $tokenName = $usedForTokenWidget ? "{contribution.custom_%d}" : "custom_%d";
     foreach (CRM_Core_BAO_CustomField::getFields($entity) as $id => $info) {
-      $customTokens[sprintf($tokenName, $id)] = $info['label'];
+      $customTokens[sprintf($tokenName, $id)] = $info['label'] . ' :: ' . $info['groupTitle'];
     }
 
     return $customTokens;

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -323,16 +323,20 @@ class Container {
       []
     ))->addTag('kernel.event_subscriber')->setPublic(TRUE);
     $container->setDefinition("crm_mailing_action_tokens", new Definition(
-      "CRM_Mailing_ActionTokens",
+      'CRM_Mailing_ActionTokens',
       []
     ))->addTag('kernel.event_subscriber')->setPublic(TRUE);
 
     foreach (['Activity', 'Contribute', 'Event', 'Mailing', 'Member'] as $comp) {
-      $container->setDefinition("crm_" . strtolower($comp) . "_tokens", new Definition(
+      $container->setDefinition('crm_' . strtolower($comp) . '_tokens', new Definition(
         "CRM_{$comp}_Tokens",
         []
       ))->addTag('kernel.event_subscriber')->setPublic(TRUE);
     }
+    $container->setDefinition('crm_contribution_recur_tokens', new Definition(
+      'CRM_Contribute_RecurTokens',
+      []
+    ))->addTag('kernel.event_subscriber')->setPublic(TRUE);
 
     $dispatcherDefn = $container->getDefinition('dispatcher');
     foreach (\CRM_Core_DAO_AllCoreTables::getBaoClasses() as $baoEntity => $baoClass) {

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -327,7 +327,7 @@ class Container {
       []
     ))->addTag('kernel.event_subscriber')->setPublic(TRUE);
 
-    foreach (['Activity', 'Contribute', 'Event', 'Mailing', 'Member'] as $comp) {
+    foreach (['Activity', 'Contribute', 'Event', 'Mailing', 'Member', 'Case'] as $comp) {
       $container->setDefinition('crm_' . strtolower($comp) . '_tokens', new Definition(
         "CRM_{$comp}_Tokens",
         []

--- a/tests/phpunit/CRM/Contribute/ActionMapping/ByTypeTest.php
+++ b/tests/phpunit/CRM/Contribute/ActionMapping/ByTypeTest.php
@@ -397,7 +397,9 @@ class CRM_Contribute_ActionMapping_ByTypeTest extends \Civi\ActionSchedule\Abstr
     $fields = (array) Contribution::getFields()->addSelect('name', 'title')->execute()->indexBy('name');
     $allFields = [];
     foreach ($fields as $field) {
-      $allFields[$field['name']] = $field['title'];
+      if (!in_array($field['name'], ['is_test', 'is_pay_later', 'is_template'], TRUE)) {
+        $allFields[$field['name']] = $field['title'];
+      }
     }
     // contact ID is skipped.
     unset($allFields['contact_id']);

--- a/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
+++ b/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
@@ -62,15 +62,41 @@ class CRM_Utils_TokenConsistencyTest extends CiviUnitTestCase {
     $tokens = CRM_Core_SelectValues::caseTokens();
     $this->assertEquals($this->getCaseTokens(), $tokens);
     $caseID = $this->getCaseID();
-    $tokenHtml = CRM_Utils_Token::replaceCaseTokens($caseID, implode("\n", array_keys($this->getCaseTokens())), ['case' => $this->getCaseTokenKeys()]);
+    $tokenString = implode("\n", array_keys($this->getCaseTokens()));
+    $tokenHtml = CRM_Utils_Token::replaceCaseTokens($caseID, $tokenString, ['case' => $this->getCaseTokenKeys()]);
     $this->assertEquals($this->getExpectedCaseTokenOutput(), $tokenHtml);
     // Now do the same without passing in 'knownTokens'
-    $tokenHtml = CRM_Utils_Token::replaceCaseTokens($caseID, implode("\n", array_keys($this->getCaseTokens())));
+    $tokenHtml = CRM_Utils_Token::replaceCaseTokens($caseID, $tokenString);
     $this->assertEquals($this->getExpectedCaseTokenOutput(), $tokenHtml);
 
     // And check our deprecated tokens still work.
     $tokenHtml = CRM_Utils_Token::replaceCaseTokens($caseID, '{case.case_type_id} {case.status_id}');
     $this->assertEquals('Housing Support Ongoing', $tokenHtml);
+
+    $additionalTokensFromProcessor = [
+      '{case.case_type_id}' => 'Case Type ID',
+      '{case.status_id}' => 'Case Status',
+      '{case.case_type_id:name}' => 'Machine name: Case Type',
+      '{case.status_id:name}' => 'Machine name: Case Status',
+    ];
+    $expectedTokens = array_merge($this->getCaseTokens(), $additionalTokensFromProcessor);
+
+    $tokenProcessor = new TokenProcessor(\Civi::dispatcher(), [
+      'controller' => __CLASS__,
+      'smarty' => FALSE,
+      'schema' => ['caseId'],
+    ]);
+    $this->assertEquals($expectedTokens, $tokenProcessor->listTokens());
+    $tokenProcessor->addRow([
+      'caseId' => $this->getCaseID(),
+    ]);
+    $tokenProcessor->addMessage('html', $tokenString, 'text/plain');
+
+    $tokenProcessor->evaluate();
+    foreach ($tokenProcessor->getRows() as $row) {
+      $text = $row->render('html');
+    }
+    $this->assertEquals($this->getExpectedCaseTokenOutput(), $text);
   }
 
   /**
@@ -87,8 +113,8 @@ July 26th, 2021
 case details
 Ongoing
 No
-' . $this->case['created_date'] . '
-' . $this->case['modified_date'] . '
+' . CRM_Utils_Date::customFormat($this->case['created_date']) . '
+' . CRM_Utils_Date::customFormat($this->case['modified_date']) . '
 ';
   }
 
@@ -129,7 +155,7 @@ No
       '{case.end_date}' => 'Case End Date',
       '{case.details}' => 'Details',
       '{case.status_id:label}' => 'Case Status',
-      '{case.is_deleted}' => 'Case is in the Trash',
+      '{case.is_deleted:label}' => 'Case is in the Trash',
       '{case.created_date}' => 'Created Date',
       '{case.modified_date}' => 'Modified Date',
       '{case.custom_1}' => 'Enter text here :: Group with field text',

--- a/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
+++ b/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
@@ -9,6 +9,8 @@
  +--------------------------------------------------------------------+
  */
 
+use Civi\Token\TokenProcessor;
+
 /**
  * CRM_Utils_TokenConsistencyTest
  *
@@ -28,6 +30,13 @@ class CRM_Utils_TokenConsistencyTest extends CiviUnitTestCase {
    * @var array
    */
   protected $case;
+
+  /**
+   * Recurring contribution.
+   *
+   * @var array
+   */
+  protected $contributionRecur;
 
   /**
    * Post test cleanup.
@@ -157,6 +166,169 @@ No
       $this->case = $this->callAPISuccess('Case', 'getsingle', ['id' => $case_id]);
     }
     return $this->case['id'];
+  }
+
+  /**
+   * Test that contribution recur tokens are consistently rendered.
+   */
+  public function testContributionRecurTokenConsistency(): void {
+    $this->createLoggedInUser();
+    $tokenProcessor = new TokenProcessor(\Civi::dispatcher(), [
+      'controller' => __CLASS__,
+      'smarty' => FALSE,
+      'schema' => ['contribution_recurId'],
+    ]);
+    $this->assertEquals($this->getContributionRecurTokens(), $tokenProcessor->listTokens());
+    $tokenString = implode("\n", array_keys($this->getContributionRecurTokens()));
+
+    $tokenProcessor->addMessage('html', $tokenString, 'text/plain');
+    $tokenProcessor->addRow(['contribution_recurId' => $this->getContributionRecurID()]);
+    $tokenProcessor->evaluate();
+    $this->assertEquals($this->getExpectedContributionRecurTokenOutPut(), $tokenProcessor->getRow(0)->render('html'));
+  }
+
+  /**
+   * Get the contribution recur tokens keyed by the token.
+   *
+   * e.g {contribution_recur.id}
+   *
+   * @return array
+   */
+  protected function getContributionRecurTokens(): array {
+    $return = [];
+    foreach ($this->getContributionRecurTokensByField() as $key => $value) {
+      $return['{contribution_recur.' . $key . '}'] = $value;
+    }
+    return $return;
+  }
+
+  protected function getContributionRecurTokensByField(): array {
+    return [
+      'id' => 'Recurring Contribution ID',
+      'amount' => 'Amount',
+      'currency' => 'Currency',
+      'frequency_unit' => 'Frequency Unit',
+      'frequency_interval' => 'Interval (number of units)',
+      'installments' => 'Number of Installments',
+      'start_date' => 'Start Date',
+      'create_date' => 'Created Date',
+      'modified_date' => 'Modified Date',
+      'cancel_date' => 'Cancel Date',
+      'cancel_reason' => 'Cancellation Reason',
+      'end_date' => 'Recurring Contribution End Date',
+      'processor_id' => 'Processor ID',
+      'payment_token_id' => 'Payment Token ID',
+      'trxn_id' => 'Transaction ID',
+      'invoice_id' => 'Invoice ID',
+      'contribution_status_id' => 'Status',
+      'is_test' => 'Test',
+      'cycle_day' => 'Cycle Day',
+      'next_sched_contribution_date' => 'Next Scheduled Contribution Date',
+      'failure_count' => 'Number of Failures',
+      'failure_retry_date' => 'Retry Failed Attempt Date',
+      'auto_renew' => 'Auto Renew',
+      'payment_processor_id' => 'Payment Processor ID',
+      'financial_type_id' => 'Financial Type ID',
+      'payment_instrument_id' => 'Payment Method',
+      'is_email_receipt' => 'Send email Receipt?',
+      'frequency_unit:label' => 'Frequency Unit',
+      'frequency_unit:name' => 'Machine name: Frequency Unit',
+      'contribution_status_id:label' => 'Status',
+      'contribution_status_id:name' => 'Machine name: Status',
+      'payment_processor_id:label' => 'Payment Processor',
+      'payment_processor_id:name' => 'Machine name: Payment Processor',
+      'financial_type_id:label' => 'Financial Type',
+      'financial_type_id:name' => 'Machine name: Financial Type',
+      'payment_instrument_id:label' => 'Payment Method',
+      'payment_instrument_id:name' => 'Machine name: Payment Method',
+    ];
+  }
+
+  /**
+   * Get contributionRecur ID.
+   *
+   * @return int
+   */
+  protected function getContributionRecurID(): int {
+    if (!isset($this->contributionRecur)) {
+      $paymentProcessorID = $this->processorCreate();
+      $this->contributionRecur = $this->callAPISuccess('ContributionRecur', 'create', [
+        'contact_id' => $this->getContactID(),
+        'status_id' => 1,
+        'is_email_receipt' => 1,
+        'start_date' => '2021-07-23 15:39:20',
+        'end_date' => '2021-07-26 18:07:20',
+        'cancel_date' => '2021-08-19 09:12:45',
+        'cancel_reason' => 'Because',
+        'amount' => 5990.99,
+        'currency' => 'EUR',
+        'frequency_unit' => 'year',
+        'frequency_interval' => 2,
+        'installments' => 24,
+        'payment_instrument_id' => 'Check',
+        'financial_type_id' => 'Member dues',
+        'processor_id' => 'abc',
+        'payment_processor_id' => $paymentProcessorID,
+        'trxn_id' => 123,
+        'invoice_id' => 'inv123',
+        'sequential' => 1,
+        'failure_retry_date' => '2020-01-03',
+        'auto_renew' => 1,
+        'cycle_day' => '15',
+        'is_test' => TRUE,
+        'payment_token_id' => $this->callAPISuccess('PaymentToken', 'create', [
+          'contact_id' => $this->getContactID(),
+          'token' => 456,
+          'payment_processor_id' => $paymentProcessorID,
+        ])['id'],
+      ])['values'][0];
+    }
+    return $this->contributionRecur['id'];
+  }
+
+  /**
+   * Get rendered output for contribution tokens.
+   *
+   * @return string
+   */
+  protected function getExpectedContributionRecurTokenOutPut(): string {
+    return $this->getContributionRecurID() . '
+€ 5,990.99
+EUR
+year
+2
+24
+July 23rd, 2021  3:39 PM
+' . CRM_Utils_Date::customFormat($this->contributionRecur['create_date']) . '
+' . CRM_Utils_Date::customFormat($this->contributionRecur['modified_date']) . '
+August 19th, 2021  9:12 AM
+Because
+July 26th, 2021  6:07 PM
+abc
+1
+123
+inv123
+2
+1
+15
+
+0
+January 3rd, 2020 12:00 AM
+1
+1
+2
+4
+1
+year
+year
+Pending Label**
+Pending
+Dummy
+Dummy
+Member Dues
+Member Dues
+Check
+Check';
   }
 
 }

--- a/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
+++ b/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
@@ -221,16 +221,16 @@ No
       'trxn_id' => 'Transaction ID',
       'invoice_id' => 'Invoice ID',
       'contribution_status_id' => 'Status',
-      'is_test' => 'Test',
+      'is_test:label' => 'Test',
       'cycle_day' => 'Cycle Day',
       'next_sched_contribution_date' => 'Next Scheduled Contribution Date',
       'failure_count' => 'Number of Failures',
       'failure_retry_date' => 'Retry Failed Attempt Date',
-      'auto_renew' => 'Auto Renew',
+      'auto_renew:label' => 'Auto Renew',
       'payment_processor_id' => 'Payment Processor ID',
       'financial_type_id' => 'Financial Type ID',
       'payment_instrument_id' => 'Payment Method',
-      'is_email_receipt' => 'Send email Receipt?',
+      'is_email_receipt:label' => 'Send email Receipt?',
       'frequency_unit:label' => 'Frequency Unit',
       'frequency_unit:name' => 'Machine name: Frequency Unit',
       'contribution_status_id:label' => 'Status',
@@ -309,22 +309,22 @@ abc
 123
 inv123
 2
-1
+Yes
 15
 
 0
 January 3rd, 2020 12:00 AM
-1
+Yes
 1
 2
 4
-1
+Yes
 year
 year
 Pending Label**
 Pending
-Dummy
-Dummy
+Dummy (test)
+Dummy (test)
 Member Dues
 Member Dues
 Check


### PR DESCRIPTION
This should be step 4 in https://lab.civicrm.org/dev/core/-/issues/2817 - it incorporates 1-3 which are also in separate PRs & should be mergeable 

This shows a discrepancy on date field handling however

- on the left the dates are formatted for the date fields (end_date, start_date) but not for created_date, modified_date. On the right they are formatted for both.  I'm inclined to think the left is an oversight & these are kinda obscure tokens but maybe we need an extension for those who Do want raw? We could move the other legacy tokens in there too from `replaceCaseTokens` - pondering

- Also on the left we have 'No' for the Boolean & FALSE on the right. I'm thinking that on the right is an oversight (since it is newer code) and we should fix the token processor to render a string for bool

UPDATE - I think we should stop providing 'is_deleted' as a token - that would punt on the boolean question & I don't think it makes sense (it is there by oversight IMHO)

![image](https://user-images.githubusercontent.com/336308/132194921-2b8ae3b2-5764-465a-ac28-21d52d67f17f.png)

It's also worth noting the function is only reachable from the send email & pdf search actions