### PR TITLE
dev/core#2814 remove replaceGreetingTokens from token Compat

### DIFF
--- a/Civi/Token/TokenCompatSubscriber.php
+++ b/Civi/Token/TokenCompatSubscriber.php
@@ -70,8 +70,7 @@ class TokenCompatSubscriber implements EventSubscriberInterface {
     $e->getTokenProcessor()->context['hookTokenCategories'] = \CRM_Utils_Token::getTokenCategories();
 
     $messageTokens = $e->getTokenProcessor()->getMessageTokens();
-    $returnProperties = array_fill_keys($messageTokens['contact'] ?? [], 1);
-    $returnProperties = array_merge(\CRM_Contact_BAO_Query::defaultReturnProperties(), $returnProperties);
+    $returnProperties = $this->getReturnFields($messageTokens['contact']);
 
     foreach ($e->getRows() as $row) {
       if (empty($row->context['contactId'])) {
@@ -148,8 +147,7 @@ class TokenCompatSubscriber implements EventSubscriberInterface {
     $e->string = \CRM_Utils_Token::replaceDomainTokens($e->string, $domain, $isHtml, $e->message['tokens'], $useSmarty);
 
     if (!empty($e->context['contact'])) {
-      \CRM_Utils_Token::replaceGreetingTokens($e->string, $e->context['contact'], $e->context['contact']['contact_id'], NULL, $useSmarty);
-      $e->string = \CRM_Utils_Token::replaceContactTokens($e->string, $e->context['contact'], $isHtml, $e->message['tokens'], TRUE, $useSmarty);
+      $e->string = \CRM_Utils_Token::replaceContactTokens($e->string, $e->context['contact'], $isHtml, $e->message['tokens'], FALSE, $useSmarty);
 
       // FIXME: This may depend on $contact being merged with hook values.
       $e->string = \CRM_Utils_Token::replaceHookTokens($e->string, $e->context['contact'], $e->context['hookTokenCategories'], $isHtml, $useSmarty);
@@ -170,6 +168,17 @@ class TokenCompatSubscriber implements EventSubscriberInterface {
         \CRM_Core_Smarty::singleton()->popScope();
       }
     }
+  }
+
+  /**
+   * @param $contact1
+   *
+   * @return array|int[]
+   */
+  protected function getReturnFields($contact1): array {
+    $returnProperties = array_fill_keys($contact1 ?? [], 1);
+    $returnProperties = array_merge(\CRM_Contact_BAO_Query::defaultReturnProperties(), $returnProperties);
+    return $returnProperties;
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#2814 remove replaceGreetingTokens from token Compat

Before
----------------------------------------
`replaceGreetingTokens` is the only remaining place (outside `tokenCompatSubscriber`) that calls `replaceContactTokens` but can't be switched to call the provider as it would be circular

After
----------------------------------------
call to `replaceGreetingTokens` removed as the next line seems to replace the greeting tokens just fine without it

Technical Details
----------------------------------------
The relevant test is `BAO_ActionScheduleTest:testMailer` but this is deeply brain hurty stuff so we might need some brain power to confirm this line is not required

It seems the 'contact' object has retrieved the greetings as part of the v3 api get call - so the circularity may outlive this change

A better change might be to switch to using the v4 api (we have good test cover & it would be more reliable going forwards) and see if we can render the greeting to a string ie
`
$str = '{contact.email_greeting}'
`

is converted to 

`
$str = '{contact.first_name}{ }{contact.last_name}';
`

before resolving - it could add a db lookup if we don't already have email_greeting_id but we likely already have that.

But THEN AGAIN - email_greeting appears to be fairly reliably cached to 'email_greeting_display' on SAVE so - why not just use the db on get .... erm ... like we do later on

https://github.com/civicrm/civicrm-core/blob/c30d0e4dbe0237b6dcf3ad0f6decbc4e023f11f3/Civi/Token/TokenCompatSubscriber.php#L93-L96

Comments
----------------------------------------
As you can see I'm still mentally working through this