### PR TITLE
[REF] Add in upgrade step to align the relationship cache table colla…

### DIFF
--- a/tests/phpunit/CRM/Upgrade/Incremental/BaseTest.php
+++ b/tests/phpunit/CRM/Upgrade/Incremental/BaseTest.php
@@ -738,4 +738,14 @@ class CRM_Upgrade_Incremental_BaseTest extends CiviUnitTestCase {
     $this->callAPISuccess('ContactType', 'delete', ['id' => $contactType['id']]);
   }
 
+  public function testUpdateRelationshipCacheTable() {
+    CRM_Core_DAO::executeQuery("ALTER TABLE civicrm_relationship_cache DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci");
+    CRM_Upgrade_Incremental_php_FiveFortyThree::fixRelationshipCacheTableCollation();
+    $contactTableCollation = CRM_Core_BAO_SchemaHandler::getInUseCollation();
+    $dao = CRM_Core_DAO::executeQuery('SHOW TABLE STATUS LIKE \'civicrm_relationship_cache\'');
+    $dao->fetch();
+    $relationshipCacheCollation = $dao->Collation;
+    $this->assertEquals($contactTableCollation, $relationshipCacheCollation);
+  }
+
 }


### PR DESCRIPTION
…tion and charset with the other tables

Overview
----------------------------------------
This is a follow on from #21382 that found that the collation and charset of the relationship cache table may not match the other tables in the database for civicrm

Before
----------------------------------------
Table set to utf8 by upgrader

After
----------------------------------------
table collation changed to match that of the civicrm_contact table

ping @eileenmcnaughton @mattwire @demeritcowboy 