### PR TITLE
[NFC] Add in type hints to template upgrade functions

### DIFF
--- a/CRM/Upgrade/Incremental/php/Template.php
+++ b/CRM/Upgrade/Incremental/php/Template.php
@@ -30,7 +30,7 @@ class CRM_Upgrade_Incremental_php_<?php echo $camelNumber; ?> extends CRM_Upgrad
    *   a version number, e.g. '4.4.alpha1', '4.4.beta3', '4.4.0'.
    * @param null $currentVer
    */
-  public function setPreUpgradeMessage(&$preUpgradeMessage, $rev, $currentVer = NULL) {
+  public function setPreUpgradeMessage(&$preUpgradeMessage, $rev, $currentVer = NULL): void {
     // Example: Generate a pre-upgrade message.
     // if ($rev == '5.12.34') {
     //   $preUpgradeMessage .= '<p>' . ts('A new permission, "%1", has been added. This permission is now used to control access to the Manage Tags screen.', array(1 => ts('manage tags'))) . '</p>';
@@ -48,7 +48,7 @@ class CRM_Upgrade_Incremental_php_<?php echo $camelNumber; ?> extends CRM_Upgrad
    * @param string $rev
    *   an intermediate version; note that setPostUpgradeMessage is called repeatedly with different $revs.
    */
-  public function setPostUpgradeMessage(&$postUpgradeMessage, $rev) {
+  public function setPostUpgradeMessage(&$postUpgradeMessage, $rev): void {
     // Example: Generate a post-upgrade message.
     // if ($rev == '5.12.34') {
     //   $postUpgradeMessage .= '<br /><br />' . ts("By default, CiviCRM now disables the ability to import directly from SQL. To use this feature, you must explicitly grant permission 'import SQL datasource'.");
@@ -66,7 +66,7 @@ class CRM_Upgrade_Incremental_php_<?php echo $camelNumber; ?> extends CRM_Upgrad
   //   *
   //   * @param string $rev
   //   */
-  //  public function upgrade_5_0_x($rev) {
+  //  public function upgrade_5_0_x($rev): void {
   //    $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
   //    $this->addTask('Do the foo change', 'taskFoo', ...);
   //    // Additional tasks here...
@@ -74,7 +74,7 @@ class CRM_Upgrade_Incremental_php_<?php echo $camelNumber; ?> extends CRM_Upgrad
   //    // The above is an exception because 'Upgrade DB to %1: SQL' is generic & reusable.
   //  }
 
-  // public static function taskFoo(CRM_Queue_TaskContext $ctx, ...) {
+  // public static function taskFoo(CRM_Queue_TaskContext $ctx, ...): bool {
   //   return TRUE;
   // }
 


### PR DESCRIPTION
Overview
----------------------------------------
This adds some type hints to various template functions in the boilerplate step upgrade php function

Before
----------------------------------------
No return type hints

After
----------------------------------------
Type hints

ping @eileenmcnaughton @totten 