### PR TITLE
WIP - Extend events to disable confirmation screen for paid events

### DIFF
--- a/CRM/Event/Form/ManageEvent/Registration.php
+++ b/CRM/Event/Form/ManageEvent/Registration.php
@@ -377,12 +377,7 @@ class CRM_Event_Form_ManageEvent_Registration extends CRM_Event_Form_ManageEvent
    */
   public function buildConfirmationBlock(&$form) {
     $attributes = CRM_Core_DAO::getAttribute('CRM_Event_DAO_Event');
-    // CRM-11182 - Optional confirmation page for free events
-    $is_monetary = CRM_Core_DAO::getFieldValue('CRM_Event_DAO_Event', $form->_id, 'is_monetary');
-    $form->assign('is_monetary', $is_monetary);
-    if ($is_monetary == "0") {
-      $form->addYesNo('is_confirm_enabled', ts('Use a confirmation screen?'), NULL, NULL, ['onclick' => "return showHideByValue('is_confirm_enabled','','confirm_screen_settings','block','radio',false);"]);
-    }
+    $form->addYesNo('is_confirm_enabled', ts('Use a confirmation screen?'), NULL, NULL, ['onclick' => "return showHideByValue('is_confirm_enabled','','confirm_screen_settings','block','radio',false);"]);
     $form->add('text', 'confirm_title', ts('Title'), $attributes['confirm_title']);
     $form->add('wysiwyg', 'confirm_text', ts('Introductory Text'), $attributes['confirm_text'] + ['class' => 'collapsed', 'preset' => 'civievent']);
     $form->add('wysiwyg', 'confirm_footer_text', ts('Footer Text'), $attributes['confirm_text'] + ['class' => 'collapsed', 'preset' => 'civievent']);
@@ -782,7 +777,7 @@ class CRM_Event_Form_ManageEvent_Registration extends CRM_Event_Form_ManageEvent
     // format params
     $params['is_online_registration'] = CRM_Utils_Array::value('is_online_registration', $params, FALSE);
     // CRM-11182
-    $params['is_confirm_enabled'] = CRM_Utils_Array::value('is_confirm_enabled', $params, FALSE);
+    $params['is_confirm_enabled'] = CRM_Utils_Array::value('is_confirm_enabled', $params, TRUE);
     $params['is_multiple_registrations'] = CRM_Utils_Array::value('is_multiple_registrations', $params, FALSE);
     $params['allow_same_participant_emails'] = CRM_Utils_Array::value('allow_same_participant_emails', $params, FALSE);
     $params['requires_approval'] = CRM_Utils_Array::value('requires_approval', $params, FALSE);

--- a/CRM/Event/Form/Registration/Register.php
+++ b/CRM/Event/Form/Registration/Register.php
@@ -508,7 +508,6 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
       ];
       if (
         !$this->_values['event']['is_multiple_registrations']
-        && !$this->_values['event']['is_monetary']
         && !$this->_values['event']['is_confirm_enabled']
       ) {
         $buttonParams['name'] = ts('Register');
@@ -1148,6 +1147,9 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
         // The concept of contributeMode is deprecated - but still needs removal from the message templates.
         $this->set('contributeMode', 'notify');
       }
+      if (empty($this->_values['event']['is_confirm_enabled']) && empty($params['additional_participants'])) {
+        $this->skipToThankYouPage();
+      }
     }
     else {
       $params['description'] = ts('Online Event Registration') . ' ' . $this->_values['event']['title'];
@@ -1170,6 +1172,31 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
       $statusMsg = ts('Registration information for participant 1 has been saved.');
       CRM_Core_Session::setStatus($statusMsg, ts('Saved'), 'success');
     }
+  }
+
+  /**
+   * Process confirm function and pass browser to the thank you page.
+   */
+  protected function skipToThankYouPage() {
+    // call the post process hook for the main page before we switch to confirm
+    $this->postProcessHook();
+
+    // build the confirm page
+    $confirmForm = &$this->controller->_pages['Confirm'];
+    $confirmForm->preProcess();
+    $confirmForm->buildQuickForm();
+
+    // the confirmation page is valid
+    $data = &$this->controller->container();
+    $data['valid']['Confirm'] = 1;
+
+    // confirm the contribution
+    // mainProcess calls the hook also
+    $confirmForm->mainProcess();
+    $qfKey = $this->controller->_key;
+
+    // redirect to thank you page
+    CRM_Utils_System::redirect(CRM_Utils_System::url('civicrm/event/register', "_qf_ThankYou_display=1&qfKey=$qfKey", TRUE, NULL, FALSE));
   }
 
   /**

--- a/templates/CRM/Event/Form/ManageEvent/Registration.tpl
+++ b/templates/CRM/Event/Form/ManageEvent/Registration.tpl
@@ -225,7 +225,7 @@
       <tr class="crm-event-manage-registration-form-block-is_confirm_enabled">
         <td scope="row" class="label" width="20%">{$form.is_confirm_enabled.label}</td>
         <td>{$form.is_confirm_enabled.html}
-          <div class="description">{ts}Optionally hide the confirmation screen for free events.{/ts}</div>
+          <div class="description">{ts}Optionally hide the confirmation screen for events.{/ts}</div>
         </td>
       </tr>
     </table>


### PR DESCRIPTION
Overview
----------------------------------------
Extend event to disable confirmation screen for paid events

Before
----------------------------------------
Disable confirmation screen was only available for free events.

After
----------------------------------------
The confirmation screen can be disabled for paid events too.

![image](https://user-images.githubusercontent.com/5929648/132349060-f32c71d0-819b-4c77-b22b-7608928651e7.png)

For additional participants, the confirmation screen is still forced during registration.

Comments
----------------------------------------
Gitlab - https://lab.civicrm.org/dev/core/-/issues/2382

Have not done initial testing yet so tagging as wip to check build pass. 

I think we need to test this with Paypal, stripe and other processors to ensure correct navigation of pages. I've only tested it with dummy and pay later payments for now.