### PR TITLE
Fix Upgrade step to ensure all fields are converted correctly as well

### DIFF
--- a/CRM/Upgrade/Incremental/php/FiveFortyThree.php
+++ b/CRM/Upgrade/Incremental/php/FiveFortyThree.php
@@ -75,7 +75,7 @@ class CRM_Upgrade_Incremental_php_FiveFortyThree extends CRM_Upgrade_Incremental
       $characterSet = 'utf8mb4';
     }
     if ($contactTableCollation !== $relationshipCacheCollation) {
-      CRM_Core_DAO::executeQuery('ALTER TABLE civicrm_relationship_cache ENGINE=InnoDB DEFAULT CHARACTER SET ' . $characterSet . ' COLLATE ' . $contactTableCollation);
+      CRM_Core_BAO_SchemaHandler::migrateUtf8mb4(($characterSet === 'utf8mb4' ? FALSE : TRUE), ['%civicrm_relationship_cache%']);
     }
     return TRUE;
   }


### PR DESCRIPTION
Overview
----------------------------------------
As per Dave D's comment on https://github.com/civicrm/civicrm-core/pull/21389 the upgrade step didn't properly capture fields but also not the logging tables if present as well. So using the utf8mb4 conversion function resolves that for us

Before
----------------------------------------
Fields stuck in utf8 when should be utf8mb4 if appropriate

After
----------------------------------------
Fields correct collation for the table

ping @demeritcowboy @mattwire @eileenmcnaughton 