### PR TITLE
SearchKit - Support bootstrap styles in search display tables

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayTable.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayTable.component.js
@@ -15,13 +15,34 @@
       var ts = $scope.ts = CRM.ts('org.civicrm.search_kit'),
         ctrl = this;
 
+      this.tableClasses = [
+        {name: 'table', label: ts('Row Borders')},
+        {name: 'table-bordered', label: ts('Column Borders')},
+        {name: 'table-striped', label: ts('Even/Odd Stripes')}
+      ];
+
+      // Check if array conatains item
+      this.includes = _.includes;
+
+      // Add or remove an item from an array
+      this.toggle = function(collection, item) {
+        if (_.includes(collection, item)) {
+          _.pull(collection, item);
+        } else {
+          collection.push(item);
+        }
+      };
+
       this.$onInit = function () {
         if (!ctrl.display.settings) {
           ctrl.display.settings = {
             limit: CRM.crmSearchAdmin.defaultPagerSize,
+            classes: ['table'],
             pager: {}
           };
         }
+        // Displays created prior to 5.43 may not have this property
+        ctrl.display.settings.classes = ctrl.display.settings.classes || [];
         ctrl.parent.initColumns({label: true});
       };
 

--- a/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayTable.html
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayTable.html
@@ -9,6 +9,15 @@
     </div>
     <div class="form-group" ng-include="'~/crmSearchAdmin/displays/common/searchButtonConfig.html'"></div>
   </div>
+  <div class="form-inline">
+    <label>{{:: ts('Table Style') }}</label>
+    <div class="checkbox-inline form-control" ng-repeat="style in $ctrl.tableClasses">
+      <label>
+        <input type="checkbox" ng-checked="$ctrl.includes($ctrl.display.settings.classes, style.name)" ng-click="$ctrl.toggle($ctrl.display.settings.classes, style.name)">
+        <span>{{:: style.label }}</span>
+      </label>
+    </div>
+  </div>
   <search-admin-pager-config display="$ctrl.display"></search-admin-pager-config>
 </fieldset>
 <fieldset class="crm-search-admin-edit-columns-wrapper">

--- a/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTable.html
+++ b/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTable.html
@@ -3,7 +3,7 @@
     <div class="btn-group" ng-include="'~/crmSearchDisplay/SearchButton.html'" ng-if="$ctrl.settings.button"></div>
     <crm-search-tasks ng-if="$ctrl.settings.actions" entity="$ctrl.apiEntity" ids="$ctrl.selectedRows" search="$ctrl.search" display="$ctrl.display" display-controller="$ctrl" refresh="$ctrl.refreshAfterTask()"></crm-search-tasks>
   </div>
-  <table>
+  <table class="{{:: $ctrl.settings.classes.join(' ') }}">
     <thead>
       <tr>
         <th class="crm-search-result-select" ng-if=":: $ctrl.settings.actions">


### PR DESCRIPTION
Overview
----------------------------------------
Enables optional bootstrap styling of table displays.

Before
----------------------------------------
Tables plain white with no borders or background.

After
----------------------------------------
![Screenshot from 2021-09-07 19-35-32](https://user-images.githubusercontent.com/2874912/132423357-2454f742-1275-4e11-bddd-36e18c5d47a7.png)

