### PR TITLE
dev/core#2823 Restructure determination of required actions.

### DIFF
--- a/CRM/Core/ManagedEntities.php
+++ b/CRM/Core/ManagedEntities.php
@@ -75,7 +75,6 @@ class CRM_Core_ManagedEntities {
    */
   public function __construct(array $modules) {
     $this->moduleIndex = $this->createModuleIndex($modules);
-    $this->loadDeclarations();
   }
 
   /**
@@ -125,7 +124,7 @@ class CRM_Core_ManagedEntities {
     if (CRM_Core_Config::singleton()->isUpgradeMode() && !$ignoreUpgradeMode) {
       return;
     }
-
+    $this->loadDeclarations();
     if ($error = $this->validate($this->getDeclarations())) {
       throw new CRM_Core_Exception($error);
     }

--- a/CRM/Core/ManagedEntities.php
+++ b/CRM/Core/ManagedEntities.php
@@ -1,5 +1,7 @@
 <?php
 
+use Civi\Api4\Managed;
+
 /**
  * The ManagedEntities system allows modules to add records to the database
  * declaratively.  Those records will be automatically inserted, updated,
@@ -25,6 +27,13 @@ class CRM_Core_ManagedEntities {
    *   Array($status => array($name => CRM_Core_Module)).
    */
   protected $moduleIndex;
+
+  /**
+   * Actions arising from the managed entities.
+   *
+   * @var array
+   */
+  protected $managedActions = [];
 
   /**
    * @var array
@@ -72,6 +81,8 @@ class CRM_Core_ManagedEntities {
   /**
    * Read a managed entity using APIv3.
    *
+   * @deprecated
+   *
    * @param string $moduleName
    *   The name of the module which declared entity.
    * @param string $name
@@ -114,9 +125,11 @@ class CRM_Core_ManagedEntities {
     if (CRM_Core_Config::singleton()->isUpgradeMode() && !$ignoreUpgradeMode) {
       return;
     }
+
     if ($error = $this->validate($this->getDeclarations())) {
       throw new CRM_Core_Exception($error);
     }
+    $this->loadManagedEntityActions();
     $this->reconcileEnabledModules();
     $this->reconcileDisabledModules();
     $this->reconcileUnknownModules();
@@ -136,7 +149,7 @@ class CRM_Core_ManagedEntities {
     $decls = $this->createDeclarationIndex($this->moduleIndex, $this->getDeclarations());
     foreach ($decls as $moduleName => $todos) {
       if ($this->isModuleEnabled($moduleName)) {
-        $this->reconcileEnabledModule($this->moduleIndex[TRUE][$moduleName], $todos);
+        $this->reconcileEnabledModule($moduleName);
       }
     }
   }
@@ -145,31 +158,85 @@ class CRM_Core_ManagedEntities {
    * For one enabled module, add new entities, update existing entities,
    * and remove orphaned (stale) entities.
    *
-   * @param \CRM_Core_Module $module
-   * @param array $todos
-   *   List of entities currently declared by this module.
-   *   array(string $name => array $entityDef).
+   * @param string $module
    */
-  public function reconcileEnabledModule(CRM_Core_Module $module, $todos) {
-    $dao = new CRM_Core_DAO_Managed();
-    $dao->module = $module->name;
-    $dao->find();
-    while ($dao->fetch()) {
-      if (isset($todos[$dao->name]) && $todos[$dao->name]) {
-        // update existing entity; remove from $todos
-        $this->updateExistingEntity($dao, $todos[$dao->name]);
-        unset($todos[$dao->name]);
-      }
-      else {
-        // remove stale entity; not in $todos
-        $this->removeStaleEntity($dao);
-      }
+  public function reconcileEnabledModule(string $module): void {
+    foreach ($this->getManagedEntitiesToUpdate(['module' => $module]) as $todo) {
+      $dao = new CRM_Core_DAO_Managed();
+      $dao->module = $todo['module'];
+      $dao->name = $todo['name'];
+      $dao->entity_type = $todo['entity_type'];
+      $dao->entity_id = $todo['entity_id'];
+      $dao->id = $todo['id'];
+      $this->updateExistingEntity($dao, $todo);
     }
 
-    // create new entities from leftover $todos
-    foreach ($todos as $name => $todo) {
+    foreach ($this->getManagedEntitiesToDelete(['module' => $module]) as $todo) {
+      $dao = new CRM_Core_DAO_Managed();
+      $dao->module = $todo['module'];
+      $dao->name = $todo['name'];
+      $dao->entity_type = $todo['entity_type'];
+      $dao->id = $todo['id'];
+      $dao->cleanup = $todo['cleanup'];
+      $dao->entity_id = $todo['entity_id'];
+      $this->removeStaleEntity($dao);
+    }
+    foreach ($this->getManagedEntitiesToCreate(['module' => $module]) as $todo) {
       $this->insertNewEntity($todo);
     }
+  }
+
+  /**
+   * Get the managed entities to be created.
+   *
+   * @param array $filters
+   *
+   * @return array
+   */
+  protected function getManagedEntitiesToCreate(array $filters = []): array {
+    return $this->getManagedEntities(array_merge($filters, ['managed_action' => 'create']));
+  }
+
+  /**
+   * Get the managed entities to be created.
+   *
+   * @param array $filters
+   *
+   * @return array
+   */
+  protected function getManagedEntitiesToUpdate(array $filters = []): array {
+    return $this->getManagedEntities(array_merge($filters, ['managed_action' => 'update']));
+  }
+
+  /**
+   * Get the managed entities to be deleted.
+   *
+   * @param array $filters
+   *
+   * @return array
+   */
+  protected function getManagedEntitiesToDelete(array $filters = []): array {
+    return $this->getManagedEntities(array_merge($filters, ['managed_action' => 'delete']));
+  }
+
+  /**
+   * Get the managed entities that fit the criteria.
+   *
+   * @param array $filters
+   *
+   * @return array
+   */
+  protected function getManagedEntities(array $filters = []): array {
+    $return = [];
+    foreach ($this->managedActions as $actionKey => $action) {
+      foreach ($filters as $filterKey => $filterValue) {
+        if ($action[$filterKey] !== $filterValue) {
+          continue 2;
+        }
+      }
+      $return[$actionKey] = $action;
+    }
+    return $return;
   }
 
   /**
@@ -223,15 +290,15 @@ class CRM_Core_ManagedEntities {
    *   Entity specification (per hook_civicrm_managedEntities).
    */
   protected function insertNewEntity($todo) {
-    $result = civicrm_api($todo['entity'], 'create', $todo['params']);
+    $result = civicrm_api($todo['entity_type'], 'create', $todo['params']);
     if (!empty($result['is_error'])) {
-      $this->onApiError($todo['entity'], 'create', $todo['params'], $result);
+      $this->onApiError($todo['entity_type'], 'create', $todo['params'], $result);
     }
 
     $dao = new CRM_Core_DAO_Managed();
     $dao->module = $todo['module'];
     $dao->name = $todo['name'];
-    $dao->entity_type = $todo['entity'];
+    $dao->entity_type = $todo['entity_type'];
     // A fatal error will result if there is no valid id but if
     // this is v4 api we might need to access it via ->first().
     $dao->entity_id = $result['id'] ?? $result->first()['id'];
@@ -314,7 +381,7 @@ class CRM_Core_ManagedEntities {
    * Remove a stale entity (if policy allows).
    *
    * @param CRM_Core_DAO_Managed $dao
-   * @throws Exception
+   * @throws CRM_Core_Exception
    */
   protected function removeStaleEntity($dao) {
     $policy = empty($dao->cleanup) ? 'always' : $dao->cleanup;
@@ -342,7 +409,7 @@ class CRM_Core_ManagedEntities {
         break;
 
       default:
-        throw new \Exception('Unrecognized cleanup policy: ' . $policy);
+        throw new CRM_Core_Exception('Unrecognized cleanup policy: ' . $policy);
     }
 
     if ($doDelete) {
@@ -533,6 +600,36 @@ class CRM_Core_ManagedEntities {
     }
     CRM_Utils_Hook::managed($this->declarations);
     $this->declarations = $this->cleanDeclarations($this->declarations);
+  }
+
+  protected function loadManagedEntityActions(): void {
+    $managedEntities = Managed::get(FALSE)->addSelect('*')->execute();
+    foreach ($managedEntities as $managedEntity) {
+      $key = "{$managedEntity['module']}_{$managedEntity['name']}_{$managedEntity['entity_type']}";
+      // Set to 'delete' - it will be overwritten below if it is to be updated.
+      $action = 'delete';
+      $this->managedActions[$key] = array_merge($managedEntity, ['managed_action' => $action]);
+    }
+    foreach ($this->declarations as $declaration) {
+      $key = "{$declaration['module']}_{$declaration['name']}_{$declaration['entity']}";
+      if (isset($this->managedActions[$key])) {
+        $this->managedActions[$key]['params'] = $declaration['params'];
+        $this->managedActions[$key]['managed_action'] = 'update';
+        $this->managedActions[$key]['cleanup'] = $declaration['cleanup'] ?? NULL;
+        $this->managedActions[$key]['update'] = $declaration['update'] ?? 'always';
+      }
+      else {
+        $this->managedActions[$key] = [
+          'module' => $declaration['module'],
+          'name' => $declaration['name'],
+          'entity_type' => $declaration['entity'],
+          'managed_action' => 'create',
+          'params' => $declaration['params'],
+          'cleanup' => $declaration['cleanup'] ?? NULL,
+          'update' => $declaration['update'] ?? 'always',
+        ];
+      }
+    }
   }
 
 }

--- a/CRM/Core/ManagedEntities.php
+++ b/CRM/Core/ManagedEntities.php
@@ -138,10 +138,8 @@ class CRM_Core_ManagedEntities {
   /**
    * For all enabled modules, add new entities, update
    * existing entities, and remove orphaned (stale) entities.
-   *
-   * @throws Exception
    */
-  public function reconcileEnabledModules() {
+  protected function reconcileEnabledModules(): void {
     // Note: any thing currently declared is necessarily from
     // an active module -- because we got it from a hook!
 
@@ -160,7 +158,7 @@ class CRM_Core_ManagedEntities {
    *
    * @param string $module
    */
-  public function reconcileEnabledModule(string $module): void {
+  protected function reconcileEnabledModule(string $module): void {
     foreach ($this->getManagedEntitiesToUpdate(['module' => $module]) as $todo) {
       $dao = new CRM_Core_DAO_Managed();
       $dao->module = $todo['module'];
@@ -242,7 +240,7 @@ class CRM_Core_ManagedEntities {
   /**
    * For all disabled modules, disable any managed entities.
    */
-  public function reconcileDisabledModules() {
+  protected function reconcileDisabledModules() {
     if (empty($this->moduleIndex[FALSE])) {
       return;
     }
@@ -262,7 +260,7 @@ class CRM_Core_ManagedEntities {
    * Remove any orphaned (stale) entities that are linked to
    * unknown modules.
    */
-  public function reconcileUnknownModules() {
+  protected function reconcileUnknownModules() {
     $knownModules = [];
     if (array_key_exists(0, $this->moduleIndex) && is_array($this->moduleIndex[0])) {
       $knownModules = array_merge($knownModules, array_keys($this->moduleIndex[0]));
@@ -313,7 +311,7 @@ class CRM_Core_ManagedEntities {
    * @param array $todo
    *   Entity specification (per hook_civicrm_managedEntities).
    */
-  public function updateExistingEntity($dao, $todo) {
+  protected function updateExistingEntity($dao, $todo) {
     $policy = CRM_Utils_Array::value('update', $todo, 'always');
     $doUpdate = ($policy === 'always');
 


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#2823 Restructure determination of required actions.
This builds on top of the 2 cleanups in the other open PRs #21399 & #21440 to build an array of actions for the reconcile enable in the constructor & adds functions to retreive those. It is a part-way refactor

Before
----------------------------------------
The determination  of actions to take & the doing of the actions is interwoven

After
----------------------------------------
The determination happens in the constructor. The doing happens in 'reconcile'

Technical Details
----------------------------------------
The code that calls the action-actions
is still pretty cludgey - but the intent is that
we would stop passing the dao object into those
action-action functions in the near future.

Comments
----------------------------------------
