### PR TITLE
(dev/drupal#163) Session erroneously getting set to NULL on change

### DIFF
--- a/CRM/Core/Session.php
+++ b/CRM/Core/Session.php
@@ -42,13 +42,6 @@ class CRM_Core_Session {
   protected $_session = NULL;
 
   /**
-   * Current php Session ID : needed to detect if the session is changed
-   *
-   * @var string
-   */
-  protected $sessionID;
-
-  /**
    * We only need one instance of this object. So we use the singleton
    * pattern and cache the instance in this variable
    *
@@ -128,10 +121,9 @@ class CRM_Core_Session {
    *   Is this a read operation, in this case, the session will not be touched.
    */
   public function initialize($isRead = FALSE) {
-    // remove $_SESSION reference if session is changed
-    if (($sid = session_id()) !== $this->sessionID) {
-      $this->_session = NULL;
-      $this->sessionID = $sid;
+    // reset $this->_session in case if it is no longer a reference to $_SESSION;
+    if (isset($_SESSION) && isset($this->_session) && $_SESSION !== $this->_session) {
+      unset($this->_session);
     }
     // lets initialize the _session variable just before we need it
     // hopefully any bootstrapping code will actually load the session from the CMS
@@ -171,9 +163,9 @@ class CRM_Core_Session {
       unset($this->_session[$this->_key]);
     }
     else {
-      $this->_session = [];
+      $this->_session[$this->_key] = [];
+      unset($this->_session);
     }
-
   }
 
   /**


### PR DESCRIPTION
Session erroneously getting set to NULL on change (Drupal user login)

Overview
----------------------------------------
In some cases (ie drupal login / user impersonation (masquerade) / login with externalAuth...), the session id change and CiviCRM remove all the data from $_SESSION, included data out of 'CiviCRM' scope.

Before
----------------------------------------
- Session values set before sign in are lost once authenticated. (tested with Drupal 9)
- Signing in using an external auth provider does not work (tested on Drupal 9 with CAS module).

After
----------------------------------------
 - Session values out of 'CiviCRM' scope are remains. (D7 8 9)
 - Signing in works correctly with external provider (CAS). (D7 8 9)
 - Masquerading still works. (tested D7 8 9)

Technical Details
----------------------------------------
This issue is a consequence of previous PR from (dev/drupal#98) that managed to fix CRM_Core_Session::_session reference issue. When masquerading with Drupal 7, the $_SESSION change and the CRM_Core_Session::_session doesn't refer the new $_SESSION array.
This PR purposes are:
 - Ensures that session values ​​outside of "CiviCRM" scope are not removed by CiviCRM.
 - Ensures that CRM_Core_Session::_session is still a valid reference to $_SESSION.
