### PR TITLE
SearchKit & Afform - Use Bootstrap table styles on admin screens

### DIFF
--- a/ext/afform/admin/ang/afAdmin/afAdminList.html
+++ b/ext/afform/admin/ang/afAdmin/afAdminList.html
@@ -34,7 +34,7 @@
     </div>
   </div>
 
-  <table>
+  <table class="table table-striped">
     <thead>
     <tr>
       <th title="{{:: ts('Click to sort') }}" ng-click="$ctrl.sortBy('title')">

--- a/ext/search_kit/ang/crmSearchAdmin/resultsTable/crmSearchAdminResultsTable.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/resultsTable/crmSearchAdminResultsTable.component.js
@@ -34,6 +34,7 @@
             limit: CRM.crmSearchAdmin.defaultPagerSize,
             pager: {show_count: true, expose_limit: true},
             actions: true,
+            classes: ['table', 'table-striped'],
             button: ts('Search'),
             columns: _.transform(ctrl.search.api_params.select, function(columns, fieldExpr) {
               var column = {label: true},

--- a/ext/search_kit/ang/crmSearchAdmin/resultsTable/crmSearchAdminResultsTable.html
+++ b/ext/search_kit/ang/crmSearchAdmin/resultsTable/crmSearchAdminResultsTable.html
@@ -4,7 +4,7 @@
     <div class="btn-group" ng-include="'~/crmSearchDisplay/SearchButton.html'"></div>
     <crm-search-tasks entity="$ctrl.apiEntity" ids="$ctrl.selectedRows" search="$ctrl.search" display="$ctrl.display" display-controller="$ctrl" refresh="$ctrl.refreshAfterTask()"></crm-search-tasks>
   </div>
-  <table>
+  <table class="{{:: $ctrl.settings.classes.join(' ') }}">
     <thead>
       <tr ng-model="$ctrl.search.api_params.select" ui-sortable="sortableColumnOptions">
         <th class="crm-search-result-select" ng-if=":: $ctrl.settings.actions">

--- a/ext/search_kit/ang/crmSearchAdmin/searchListing/crmSearchAdminSearchListing.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/searchListing/crmSearchAdminSearchListing.component.js
@@ -96,6 +96,7 @@
             limit: CRM.crmSearchAdmin.defaultPagerSize,
             pager: {show_count: true, expose_limit: true},
             actions: false,
+            classes: ['table', 'table-striped'],
             sort: [['modified_date', 'DESC']],
             columns: [
               searchMeta.fieldToColumn('label', {


### PR DESCRIPTION
Overview
----------------------------------------
As a follow-up from #21397 this applies Bootstrap table styles to admin tables in SearchKit and Afform.

Before
----------------------------------------
![Screenshot from 2021-09-08 10-38-32](https://user-images.githubusercontent.com/2874912/132530598-6908a35c-e47e-4b2b-a18f-ac12cb3bfd67.png)
![Screenshot from 2021-09-08 10-38-50](https://user-images.githubusercontent.com/2874912/132530579-6c00dcae-2cdc-465f-8ab4-816ce3cf1936.png)


After
----------------------------------------
![Screenshot from 2021-09-08 10-38-05](https://user-images.githubusercontent.com/2874912/132530613-0532422b-eb15-4e70-af04-f48d3a5b2cb3.png)
![Screenshot from 2021-09-08 10-36-37](https://user-images.githubusercontent.com/2874912/132530624-5dfc1910-c86f-499d-a6ae-6e4fade7016f.png)


Technical Details
----------------------------------------
Adds css class "table table-striped" to admin tables
