### PR TITLE
Experimental: Invalidate and do not flush group contact cache

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -394,7 +394,10 @@ class CRM_Contact_BAO_Contact extends CRM_Contact_DAO_Contact {
       'name'
     );
 
-    CRM_Contact_BAO_Contact_Utils::clearContactCaches();
+    CRM_ACL_BAO_Cache::opportunisticCacheFlush();
+    // We used to call CRM_Contact_BAO_GroupContactCache::opportunisticCacheFlush() here but we only need to
+    // invalidate the ones that contained this contact ID. They will be rebuilt when required.
+    CRM_Contact_BAO_GroupContactCache::invalidateGroupContactCacheByContactID($contact->id);
 
     if ($invokeHooks) {
       if ($isEdit) {

--- a/CRM/Contact/BAO/GroupContactCache.php
+++ b/CRM/Contact/BAO/GroupContactCache.php
@@ -517,6 +517,18 @@ ORDER BY   gc.contact_id, g.children
   }
 
   /**
+   * Invalidates the smart group cache for all groups containing contact ID
+   * @param int $contactID - Groups containing this contactID will be invalidated
+   */
+  public static function invalidateGroupContactCacheByContactID(int $contactID): void {
+    CRM_Core_DAO::executeQuery('UPDATE civicrm_group
+      SET cache_date = NULL
+      WHERE id IN (SELECT distinct group_id FROM civicrm_group_contact_cache WHERE contact_id = %1)', [
+        1 => [$contactID, 'Positive'],
+      ]);
+  }
+
+  /**
    * @param array $savedSearch
    * @param int $groupID
    *


### PR DESCRIPTION
Overview
----------------------------------------
I'm struggling to see why we ever need to actually trigger an opportunistic flush of the group contact cache. As long as the cache is invalidated then it should be built on demand.
Any performance impact would seem mitigated by the fact that an opportunistic flush can happen on almost any request, whereas the cache rebuild would only happen on a request that actually requires it! So the actual user who needs to query the cache may seem some slowdown but the poor user who just wanted to check his email address won't get any slowdown.

After this there are only two places that call `CRM_Contact_BAO_Contact_Utils::clearContactCaches()` (cli.class.php and import preview).

Before
----------------------------------------
Cache flush may occur when we only need to invalidate the cache and don't need to actually use it.

After
----------------------------------------
Cache flush only occurs when we actually need to access it.

Technical Details
----------------------------------------
`CRM_Contact_BAO_GroupContactCache::flushCaches()` clears out entries from expired cached groups and then clears the cache date. But clearing the expired cache and *updating* the cache date is done when we rebuild the cache so why do it twice?

Comments
----------------------------------------
@eileenmcnaughton Be interested in your thoughts here? I've not tested this on a real site yet but I can't get my head around *why* we would ever want to proactively clear the cache rather than just invalidate it. I don't think there is anywhere that tries to access the group contact cache without `load()`ing it first.