### PR TITLE
Remove duplicate global declaration in civicrm.settings.php template

### DIFF
--- a/templates/CRM/common/civicrm.settings.php.template
+++ b/templates/CRM/common/civicrm.settings.php.template
@@ -176,8 +176,6 @@ if (!defined('CIVICRM_LOGGING_DSN')) {
  *
  */
 
-global $civicrm_root;
-
 $civicrm_root = '%%crmRoot%%';
 if (!defined('CIVICRM_TEMPLATE_COMPILEDIR')) {
   define( 'CIVICRM_TEMPLATE_COMPILEDIR', '%%templateCompileDir%%');


### PR DESCRIPTION
Overview
----------------------------------------
Got duplicated [here](https://github.com/civicrm/civicrm-core/commit/f553d1eac3d3bd329fd85d0a2abf7b3acf2a7023#diff-6f64563f7e1018b992faf7184464d74f33fc44e0e3bf4371c6056ff3a62b39adR31) when it was moved to the top of the file.

Before
----------------------------------------
Harmless but appears twice.

After
----------------------------------------


Technical Details
----------------------------------------


Comments
----------------------------------------

