### PR TITLE
Smarty warning about missing contact subtype on New Individual

### DIFF
--- a/templates/CRM/Contact/Form/Edit/Individual.tpl
+++ b/templates/CRM/Contact/Form/Edit/Individual.tpl
@@ -8,16 +8,6 @@
  +--------------------------------------------------------------------+
 *}
 {* tpl for building Individual related fields *}
-<script type="text/javascript">
-{literal}
-CRM.$(function($) {
-  if ($('#contact_sub_type *').length == 0) {//if they aren't any subtype we don't offer the option
-    $('#contact_sub_type').parent().hide();
-  }
-});
-</script>
-{/literal}
-
 <table class="form-layout-compressed">
   <tr>
     {if $form.prefix_id}
@@ -71,9 +61,11 @@ CRM.$(function($) {
       {$form.nick_name.label}<br />
       {$form.nick_name.html}
     </td>
+    {if !empty($form.contact_sub_type)}
     <td>
       {$form.contact_sub_type.label}<br />
       {$form.contact_sub_type.html}
     </td>
+    {/if}
   </tr>
 </table>


### PR DESCRIPTION
Overview
----------------------------------------
It's not unusual to have zero contact subtypes defined.

Before
----------------------------------------
Turn on Enable Debugging.

Notice: Trying to access array offset on value of type null in include() (line 89 of ...\templates_c\en_US\%%FD\FD4\FD4493C8%%Individual.tpl.php).
Notice: Undefined index: contact_sub_type in include() (line 91 of ...\templates_c\en_US\%%FD\FD4\FD4493C8%%Individual.tpl.php).
Notice: Trying to access array offset on value of type null in include() (line 91 of ...\templates_c\en_US\%%FD\FD4\FD4493C8%%Individual.tpl.php).
Notice: Undefined index: prefix in include() (line 11 of ...\templates_c\en_US\%%B2\B2F\B2F0EF90%%ContactReference.tpl.php).


After
----------------------------------------


Technical Details
----------------------------------------
The field gets skipped over here: https://github.com/civicrm/civicrm-core/blob/a77bc9dc991f0cad7800617c9fb8a2f4457d41b3/CRM/Contact/Form/Contact.php#L775

And I can't see any other reason for the javascript since the field doesn't exist for it to act on.

Comments
----------------------------------------

