### PR TITLE
SearchKit - Fix aggregated joins

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
@@ -613,9 +613,12 @@
         _.each(ctrl.savedSearch.api_params.join, function(joinClause) {
           var join = searchMeta.getJoin(joinClause[0]),
             joinEntity = searchMeta.getEntity(join.entity),
+            primaryKey = joinEntity.primary_key[0],
+            isAggregate = ctrl.canAggregate(join.alias + '.' + primaryKey),
             bridgeEntity = _.isString(joinClause[2]) ? searchMeta.getEntity(joinClause[2]) : null;
           _.each(joinEntity.paths, function(path) {
             var link = _.cloneDeep(path);
+            link.isAggregate = isAggregate;
             link.path = link.path.replace(/\[/g, '[' + join.alias + '.');
             link.join = join.alias;
             addTitle(link, join.label);

--- a/ext/search_kit/ang/crmSearchAdmin/resultsTable/crmSearchAdminResultsTable.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/resultsTable/crmSearchAdminResultsTable.component.js
@@ -58,13 +58,15 @@
             style: 'secondary-outline',
             alignment: 'text-right',
             links: _.transform(links, function(links, link) {
-              links.push({
-                path: link.path,
-                text: link.title,
-                icon: link.icon,
-                style: link.style,
-                target: link.action === 'view' ? '_blank' : 'crm-popup'
-              });
+              if (!link.isAggregate) {
+                links.push({
+                  path: link.path,
+                  text: link.title,
+                  icon: link.icon,
+                  style: link.style,
+                  target: link.action === 'view' ? '_blank' : 'crm-popup'
+                });
+              }
             })
           });
         }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a bug where adding an aggregated join will cause invalid SQL.

Before
----------------------------------------
The following search will crash:
SEARCH FOR: Activities
WITH (optional): Activity Contacts
GROUP BY: Activity ID

After
----------------------------------------
Search runs without error.

Comments
---------------
When merging this forward, the first commit is already in `master` and can be skipped over if git complains.