### PR TITLE
[REF] Duplicate back greeting tokens

### DIFF
--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -1431,7 +1431,7 @@ class CRM_Utils_Token {
    * @param array $contactDetails
    * @param array $greetingTokens
    */
-  private static function removeNullContactTokens(&$tokenString, $contactDetails, &$greetingTokens) {
+  public static function removeNullContactTokens(&$tokenString, $contactDetails, &$greetingTokens) {
 
     // Only applies to contact tokens
     if (!array_key_exists('contact', $greetingTokens)) {


### PR DESCRIPTION
Overview
----------------------------------------
[REF] Duplicate back greeting tokens

Before
----------------------------------------
Dry (ahem)

After
----------------------------------------
Wet

Technical Details
----------------------------------------
@totten I often find it helpful to copy back a function that is shared but for reasons lost in time to the calling function in order to unravel what is going on (Copy back & then clean up - knowing it can be cleaned up without impacting on the original function).

 I had a go at doing that for the `replaceGreetingTokens` and I think it rather highlights the extent to which `replaceGreetingTokens` is actually doing the same thing as the `TokenCompat` class with the exception that it keeps checking the string to see if it still has tokens to replace. So where a hook token replacement is happening I would expect htat to be called once in `replaceGreetingTokens` and then again in the main `render` flow.


(We don't need to merge this - I find it a useful interim step making changes like this but it does require acceptance of 'it's gonna get worse before it gets messier)

Comments
----------------------------------------
This is what the full function looks like with this merged - you can see a lot of it could be extracted out & shared with `evaluate`

```
   if (!empty($e->context['contact'])) {
      // check if there are any tokens
      $greetingTokens = \CRM_Utils_Token::getTokens($e->string);

      if (!empty($greetingTokens)) {
        // first use the existing contact object for token replacement
        if (!empty($e->context['contact'])) {
          $e->string = \CRM_Utils_Token::replaceContactTokens($e->string, $e->context['contact'], TRUE, $greetingTokens, TRUE, $useSmarty);
        }

        \CRM_Utils_Token::removeNullContactTokens($e->string, $e->context['contact'], $greetingTokens);
        // check if there are any unevaluated tokens
        $greetingTokens = \CRM_Utils_Token::getTokens($e->string);

        // $greetingTokens not empty, means there are few tokens which are not
        // evaluated, like custom data etc
        // so retrieve it from database
        if (!empty($greetingTokens) && array_key_exists('contact', $greetingTokens)) {
          $greetingsReturnProperties = array_flip(\CRM_Utils_Array::value('contact', $greetingTokens));
          $greetingsReturnProperties = array_fill_keys(array_keys($greetingsReturnProperties), 1);
          $contactParams = ['contact_id' => $e->context['contact']['contact_id']];

          $greetingDetails = \CRM_Utils_Token::getTokenDetails($contactParams,
            $greetingsReturnProperties,
            FALSE, FALSE, NULL,
            $greetingTokens,
            NULL
          );

          // again replace tokens
          $e->string = \CRM_Utils_Token::replaceContactTokens($e->string,
            $greetingDetails,
            TRUE,
            $greetingTokens,
            TRUE,
            $useSmarty
          );
        }

        // check if there are still any unevaluated tokens
        $remainingTokens = \CRM_Utils_Token::getTokens($e->string);

        // $greetingTokens not empty, there are customized or hook tokens to replace
        if (!empty($remainingTokens)) {
          // Fill the return properties array
          $greetingTokens = $remainingTokens;
          reset($greetingTokens);
          $greetingsReturnProperties = [];
          foreach ($greetingTokens as $value) {
            $props = array_flip($value);
            $props = array_fill_keys(array_keys($props), 1);
            $greetingsReturnProperties = $greetingsReturnProperties + $props;
          }
          $contactParams = ['contact_id' => $e->context['contact']['contact_id']];
          $greetingDetails = \CRM_Utils_Token::getTokenDetails($contactParams,
            $greetingsReturnProperties,
            FALSE, FALSE, NULL,
            $greetingTokens,
            NULL
          );
          // Prepare variables for calling replaceHookTokens
          $categories = array_keys($greetingTokens);
          [$contact] = $greetingDetails;
          // Replace tokens defined in Hooks.
          $e->string = \CRM_Utils_Token::replaceHookTokens($e->string, $contact[$e->context['contact']['contact_id']], $categories);
        }
      }

      $e->string = \CRM_Utils_Token::replaceContactTokens($e->string, $e->context['contact'], $isHtml, $e->message['tokens'], TRUE, $useSmarty);

      // FIXME: This may depend on $contact being merged with hook values.
      $e->string = \CRM_Utils_Token::replaceHookTokens($e->string, $e->context['contact'], $e->context['hookTokenCategories'], $isHtml, $useSmarty);
    }

```