### PR TITLE
dev/core#2814 Remove redundant call to `replaceContactTokens`

### DIFF
--- a/Civi/Token/TokenCompatSubscriber.php
+++ b/Civi/Token/TokenCompatSubscriber.php
@@ -143,10 +143,6 @@ class TokenCompatSubscriber implements EventSubscriberInterface {
 
     if (!empty($e->context['contact'])) {
       \CRM_Utils_Token::replaceGreetingTokens($e->string, $e->context['contact'], $e->context['contact']['contact_id'], NULL, $useSmarty);
-      $e->string = \CRM_Utils_Token::replaceContactTokens($e->string, $e->context['contact'], $isHtml, $e->message['tokens'], TRUE, $useSmarty);
-
-      // FIXME: This may depend on $contact being merged with hook values.
-      $e->string = \CRM_Utils_Token::replaceHookTokens($e->string, $e->context['contact'], $e->context['hookTokenCategories'], $isHtml, $useSmarty);
     }
 
     if ($useSmarty) {


### PR DESCRIPTION
Overview
----------------------------------------
Remove redundant call

Before
----------------------------------------
`replaceContactTokens` called in `replaceGreetingTokens` and after it too

After
----------------------------------------
poof

Technical Details
----------------------------------------
See https://github.com/civicrm/civicrm-core/pull/21413 for what it looks like if we copy `replaceGreetingTokens` back into the `TokenCompatSubscriber` ready to clean it up - it becomes clear this call is already happening and this is a duplicate

(the same appears to be true of the hook call).

Logically no contact tokens remain by the time we get to this point - `replaceGreetingTokens` actually replaces any contact or hook tokens in the provided string - and test cover is very solid

Comments
----------------------------------------
