### PR TITLE
[REF] Extract function to getDomainTokens

### DIFF
--- a/tests/phpunit/CRM/Core/BAO/MessageTemplateTest.php
+++ b/tests/phpunit/CRM/Core/BAO/MessageTemplateTest.php
@@ -201,6 +201,7 @@ class CRM_Core_BAO_MessageTemplateTest extends CiviUnitTestCase {
    * Test rendering of domain tokens.
    *
    * @throws \CRM_Core_Exception
+   * @throws \API_Exception
    */
   public function testDomainTokens(): void {
     $values = $this->getDomainTokenData();


### PR DESCRIPTION




Overview
----------------------------------------
[REF] Extract function to getDomainTokens

Before
----------------------------------------
The caching & code for replace domain tokens is just weird

After
----------------------------------------
A cached array is returned..... 

Technical Details
----------------------------------------
Test cover in `BAO_MessageTemplateTest.testDomainTokens`

This caches the whole token set by domain+locale+html rather than just part.

Open questions
1) where should this go  - on the BAO_Domain class?
Or on a token processor class (eventually it would only be
called from a token processor class)
2) does it make sense to pass `$html` in - I left it there for now but I think the token processor would expect to handle that itself

Comments
----------------------------------------