### PR TITLE
Follow up on removing contributeMode from templates

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2713,11 +2713,6 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
       $template->assign('cancelSubscriptionUrl', $paymentObject->subscriptionURL($entityID, $entity, 'cancel'));
       $template->assign('updateSubscriptionBillingUrl', $paymentObject->subscriptionURL($entityID, $entity, 'billing'));
       $template->assign('updateSubscriptionUrl', $paymentObject->subscriptionURL($entityID, $entity, 'update'));
-
-      if ($this->_relatedObjects['paymentProcessor']['billing_mode'] & CRM_Core_Payment::BILLING_MODE_FORM) {
-        //direct mode showing billing block, so use directIPN for temporary
-        $template->assign('contributeMode', 'directIPN');
-      }
     }
     // todo remove strtolower - check consistency
     if (strtolower($this->_component) === 'event') {


### PR DESCRIPTION


Overview
----------------------------------------
Follow up on removing contributeMode from templates

Before
----------------------------------------
`$contributeMode` still being assigned in another place

After
----------------------------------------
poof

Technical Details
----------------------------------------
Per https://github.com/civicrm/civicrm-core/pull/21059
its a really long time since this was in the stock templates

Comments
----------------------------------------
@demeritcowboy 