### PR TITLE
SearchKit - Fix display of links in aggregated columns

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
@@ -300,7 +300,7 @@
           if (ctrl.canAggregate(col)) {
             // Ensure all non-grouped columns are aggregated if using GROUP BY
             if (!info.fn || info.fn.category !== 'aggregate') {
-              ctrl.savedSearch.api_params.select[pos] = ctrl.DEFAULT_AGGREGATE_FN + '(DISTINCT ' + fieldExpr + ') AS ' + ctrl.DEFAULT_AGGREGATE_FN + '_DISTINCT_' + fieldExpr.replace(/[.:]/g, '_');
+              ctrl.savedSearch.api_params.select[pos] = ctrl.DEFAULT_AGGREGATE_FN + '(DISTINCT ' + fieldExpr + ') AS ' + ctrl.DEFAULT_AGGREGATE_FN + '_' + fieldExpr.replace(/[.:]/g, '_');
             }
           } else {
             // Remove aggregate functions when no grouping
@@ -620,11 +620,12 @@
             joinEntity = searchMeta.getEntity(join.entity),
             primaryKey = joinEntity.primary_key[0],
             isAggregate = ctrl.canAggregate(join.alias + '.' + primaryKey),
+            joinPrefix = (isAggregate ? 'GROUP_CONCAT_' : '') + join.alias + '.',
             bridgeEntity = _.isString(joinClause[2]) ? searchMeta.getEntity(joinClause[2]) : null;
           _.each(joinEntity.paths, function(path) {
             var link = _.cloneDeep(path);
             link.isAggregate = isAggregate;
-            link.path = link.path.replace(/\[/g, '[' + join.alias + '.');
+            link.path = link.path.replace(/\[/g, '[' + joinPrefix).replace(/[.:]/g, '_');
             link.join = join.alias;
             addTitle(link, join.label);
             links.push(link);

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminDisplay.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminDisplay.component.js
@@ -181,6 +181,14 @@
         return !col.image && !col.rewrite && !col.link && !info.fn && info.field && !info.field.readonly;
       };
 
+      // Aggregate functions (COUNT, AVG, MAX) cannot display as links, except for GROUP_CONCAT
+      // which gets special treatment in APIv4 to convert it to an array.
+      this.canBeLink = function(col) {
+        var expr = ctrl.getExprFromSelect(col.key),
+          info = searchMeta.parseExpr(expr);
+        return !info.fn || info.fn.category !== 'aggregate' || info.fn.name === 'GROUP_CONCAT';
+      };
+
       this.toggleLink = function(column) {
         if (column.link) {
           ctrl.onChangeLink(column, column.link.path, '');

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchFunction.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchFunction.component.js
@@ -87,7 +87,7 @@
 
       // Make a sql-friendly alias for this expression
       function makeAlias() {
-        return (ctrl.fn + '_' + (ctrl.modifier ? ctrl.modifier + '_' : '') + ctrl.path).replace(/[.:]/g, '_');
+        return (ctrl.fn + '_' + ctrl.path).replace(/[.:]/g, '_');
       }
 
       this.writeExpr = function() {

--- a/ext/search_kit/ang/crmSearchAdmin/displays/colType/field.html
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/colType/field.html
@@ -1,4 +1,4 @@
-<div class="form-inline crm-search-admin-flex-row">
+<div class="form-inline crm-search-admin-flex-row" ng-if=":: $ctrl.parent.canBeLink(col)">
   <label title="{{:: ts('Display as clickable link') }}" >
     <input type="checkbox" ng-checked="col.link" ng-click="$ctrl.parent.toggleLink(col)" >
     {{:: ts('Link') }}

--- a/ext/search_kit/ang/crmSearchAdmin/resultsTable/crmSearchAdminResultsTable.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/resultsTable/crmSearchAdminResultsTable.component.js
@@ -19,7 +19,7 @@
       function getViewLink(fieldExpr, links) {
         var info = searchMeta.parseExpr(fieldExpr),
           entity = searchMeta.getEntity(info.field.entity);
-        if (!info.fn && entity && info.field.fieldName === entity.label_field) {
+        if (entity && info.field.fieldName === entity.label_field) {
           var joinEntity = searchMeta.getJoinEntity(info);
           return _.find(links, {join: joinEntity, action: 'view'});
         }

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchAfformTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchAfformTest.php
@@ -35,7 +35,7 @@ class SearchAfformTest extends \PHPUnit\Framework\TestCase implements HeadlessIn
           'select' => [
             'id',
             'display_name',
-            'GROUP_CONCAT(DISTINCT Contact_Email_contact_id_01.email) AS GROUP_CONCAT_DISTINCT_Contact_Email_contact_id_01_email',
+            'GROUP_CONCAT(DISTINCT Contact_Email_contact_id_01.email) AS GROUP_CONCAT_Contact_Email_contact_id_01_email',
           ],
           'orderBy' => [],
           'where' => [
@@ -77,7 +77,7 @@ class SearchAfformTest extends \PHPUnit\Framework\TestCase implements HeadlessIn
               'type' => 'field',
             ],
             [
-              'key' => 'GROUP_CONCAT_DISTINCT_Contact_Email_contact_id_01_email',
+              'key' => 'GROUP_CONCAT_Contact_Email_contact_id_01_email',
               'label' => 'Emails',
               'dataType' => 'String',
               'type' => 'field',


### PR DESCRIPTION
Overview
----------------------------------------
Fixes an error caused by trying to make an aggregated column into a link.

Before
----------------------------------------
- Create search for Activities
- Add LEFT join for Activity Contacts
- Run search, notice that contact display name column is not shown as links
- Create a display, notice that configuring the contact display name column as links will cause an error

After
----------------------------------------
Same as above, links work correctly. Also prevents you from adding links when using any aggregate function other than `GROUP_CONCAT` since it's the only one that can show each aggregated item individually.

Technical Details
----------------------------------------
This gives special treatment to the `GROUP_CONCAT` function in SearchKit to match the special treatment it gets in APIv4 (exploding it into an array).