### PR TITLE
Smarty notices on Find Activities results page

### DIFF
--- a/templates/CRM/Activity/Form/Selector.tpl
+++ b/templates/CRM/Activity/Form/Selector.tpl
@@ -21,10 +21,12 @@
        {/if}
        {foreach from=$columnHeaders item=header}
           <th scope="col">
-          {if $header.sort}
+          {if isset($header.sort)}
             {assign var='key' value=$header.sort}
-            {$sort->_response.$key.link}
-          {else}
+            {if !empty($sort)}
+              {$sort->_response.$key.link}
+            {/if}
+          {elseif isset($header.name)}
             {$header.name}
           {/if}
           </th>
@@ -52,22 +54,20 @@
       {/if}
     </td>
 
-  <td>{$row.activity_subject}</td>
+  <td>{if isset($row.activity_subject)}{$row.activity_subject|purify}{/if}</td>
 
     <td>
     {if !$row.source_contact_id}
       <em>n/a</em>
-    {elseif $contactId NEQ $row.source_contact_id}
-      <a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=`$row.source_contact_id`"}" title="{ts}View contact{/ts}">{$row.source_contact_name}</a>
     {else}
-      {$row.source_contact_name}
+      <a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=`$row.source_contact_id`"}" title="{ts}View contact{/ts}">{$row.source_contact_name|purify}</a>
     {/if}
     </td>
 
     <td>
     {if $row.mailingId}
       <a href="{$row.mailingId}" title="{ts}View Mailing Report{/ts}">{$row.recipients}</a>
-    {elseif $row.recipients}
+    {elseif isset($row.recipients)}
       {$row.recipients}
     {elseif !$row.target_contact_name}
       <em>n/a</em>


### PR DESCRIPTION
Overview
----------------------------------------
1. Enable Debugging.
1. Go to Find Activities
1. Click Search.

Before
----------------------------------------
An enormous number of smarty notices. In particular there are several repeated for every row in the output.

After
----------------------------------------
Still an enormous number of smarty notices.

Technical Details
----------------------------------------
I've left out the one about `id` for the moment (line 107). I'm not sure `id` is ever set, and I'm not sure where the concept of replacing 'xx' with an id at output time gets set up to begin with. It might be left over from something older.

Comments
----------------------------------------

