### PR TITLE
SearchKit - Support custom fields in bridge join entities

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
@@ -475,7 +475,7 @@
           // Add extra searchable fields from bridge entity
           if (join && join.bridge) {
             addFields(_.filter(searchMeta.getEntity(join.bridge).fields, function(field) {
-              return (field.name !== 'id' && field.name !== 'entity_id' && field.name !== 'entity_table' && !field.fk_entity && !_.includes(field.name, '.'));
+              return (field.name !== 'id' && field.name !== 'entity_id' && field.name !== 'entity_table' && !field.fk_entity);
             }));
           }
 


### PR DESCRIPTION
Overview
----------------------------------------
Makes it possible to use relationship custom data throughout Search Kit.

Before
----------------------------------------
Joining "Contact Related Contacts" in SearchKit would not allow display of relationship custom fields.

After
----------------------------------------
![Screenshot from 2021-09-09 18-10-43](https://user-images.githubusercontent.com/2874912/132769194-fdff0057-4488-4396-aef4-6c119075ebdd.png)


Technical Details
----------------------------------------
This fixes bridge joins in APIv4 to allow selecting custom fields that belong to the bridge entity
as if they were part of the joined entity. This was already working for core fields.