### PR TITLE
Remove error handling for core error being returned

### DIFF
--- a/Civi/Token/TokenCompatSubscriber.php
+++ b/Civi/Token/TokenCompatSubscriber.php
@@ -94,11 +94,6 @@ class TokenCompatSubscriber implements EventSubscriberInterface {
         $contact['email_greeting'] = $contact['email_greeting_display'] ?? '';
         $contact['postal_greeting'] = $contact['postal_greeting_display'] ?? '';
         $contact['addressee'] = $contact['address_display'] ?? '';
-        if (!$contact || is_a($contact, 'CRM_Core_Error')) {
-          // FIXME: Need to differentiate errors which kill the batch vs the individual row.
-          \Civi::log()->debug('Failed to generate token data. Invalid contact ID: ' . $row->context['contactId']);
-          continue;
-        }
 
         //update value of custom field token
         if (!empty($messageTokens['contact'])) {


### PR DESCRIPTION
This would be throwing an exception - also it isn't an error situation

Overview
----------------------------------------
Remove error handling for core error being returned

Before
----------------------------------------
Handling for returned CRM_COre_Error

After
----------------------------------------
poof

Technical Details
----------------------------------------
Remove error handling for core error being returned

Comments
----------------------------------------
We have lots of places like this but there are very few functions that actually return core errors these days.... history 
