### PR TITLE
Replace expensive query with cheaper one

### DIFF
--- a/tests/phpunit/CRM/Core/BAO/MessageTemplateTest.php
+++ b/tests/phpunit/CRM/Core/BAO/MessageTemplateTest.php
@@ -45,7 +45,41 @@ class CRM_Core_BAO_MessageTemplateTest extends CiviUnitTestCase {
     $this->assertStringContainsString('<p>Hello testRenderTemplate Abba Baab!</p>', $rendered['html']);
   }
 
-  public function testSendTemplate_RenderMode_OpenTemplate() {
+  /**
+   * Check detection of contact's preferred mail.
+   *
+   * - ie if text then no html output is sent.
+   *
+   * @throws \API_Exception
+   * @throws \CRM_Core_Exception
+   */
+  public function testSendTemplateNoHtml(): void {
+    $contactId = $this->individualCreate([
+      'preferred_mail_format' => 'Text',
+      'first_name' => 'Mary',
+      'email' => 'mary_anderson@civicrm.org',
+    ]);
+    $mut = new CiviMailUtils($this, TRUE);
+    CRM_Core_BAO_MessageTemplate::sendTemplate(
+      [
+        'contactId' => $contactId,
+        'from' => 'admin@example.com',
+        'toEmail' => 'mary_anderson@civicrm.org',
+        'messageTemplate' => [
+          'msg_subject' => 'My subject',
+          'msg_text' => 'My text',
+          'msg_html' => 'My html',
+        ],
+      ]
+    );
+    $mut->checkMailLog(['My text', 'My subject'], ['My html']);
+  }
+
+  /**
+   * @throws \API_Exception
+   * @throws \CRM_Core_Exception
+   */
+  public function testSendTemplate_RenderMode_OpenTemplate(): void {
     $contactId = $this->individualCreate([
       'first_name' => 'Abba',
       'last_name' => 'Baab',


### PR DESCRIPTION

Overview
----------------------------------------
Replace expensive query with cheaper one

Before
----------------------------------------
call so `apiQuery` - retrieves all fields across several tables

After
----------------------------------------
Apiv4 field - retrieves 1 field

Technical Details
----------------------------------------
Rather than retrieve everything with a legacy function, just get what we want....

Note I commented on how silly I think it is but no change to outcome


Comments
----------------------------------------
