### PR TITLE
TokenProcessor - Allow basic filter/modifier expressions

### DIFF
--- a/Civi/Token/TokenProcessor.php
+++ b/Civi/Token/TokenProcessor.php
@@ -384,6 +384,9 @@ class TokenProcessor {
 
 class TokenRowIterator extends \IteratorIterator {
 
+  /**
+   * @var \Civi\Token\TokenProcessor
+   */
   protected $tokenProcessor;
 
   /**


### PR DESCRIPTION
Overview
---------

This demonstrates how to extend `TokenProcessor` to support rendering token-expressions with filters/modifiers.

ping @eileenmcnaughton @mattwire 

Before
------

`Hello {foo.bar}`

After
-----

`Hello {foo.bar|upper}` and `Hello {foo.bar|lower}`

Technical Details
-----------------

This only supports tokens that supply values through `civi.token.eval` (ie `$row->token(...key-value...)`).  At the time of this commit, most `{contact.*}` tokens still use `TokenCompatSubscriber::onRender()` to hack-in their values and won't work until they switch over.

The regex which recognizes the filter is pretty tight (eg accepting `|upper` or `|lower` but not `|myfunc:"yadda yadda"`).  This can be relaxed somewhat by a subsequent change, but I'd say such a change has a burden to demonstrate safety/interoparbility when running in Token-Smarty format.  (e.g.  demonstrate that matching of open/close symbols works correctly).
