### PR TITLE
flushCaches should respect permitCacheFlushMode. Also flush caches which have a NULL cache_date

### DIFF
--- a/CRM/Contact/BAO/GroupContactCache.php
+++ b/CRM/Contact/BAO/GroupContactCache.php
@@ -259,19 +259,32 @@ WHERE  id IN ( $groupIDs )
       // Someone else is kindly doing the refresh for us right now.
       return;
     }
+
+    // Get the list of expired smart groups that may need flushing
     $params = [1 => [self::getCacheInvalidDateTime(), 'String']];
-    $groupsDAO = CRM_Core_DAO::executeQuery("SELECT id FROM civicrm_group WHERE cache_date <= %1", $params);
+    $groupsThatMayNeedToBeFlushedSQL = "SELECT id FROM civicrm_group WHERE (saved_search_id IS NOT NULL OR children <> '') AND (cache_date <= %1 OR cache_date IS NULL)";
+    $groupsDAO = CRM_Core_DAO::executeQuery($groupsThatMayNeedToBeFlushedSQL, $params);
     $expiredGroups = [];
     while ($groupsDAO->fetch()) {
       $expiredGroups[] = $groupsDAO->id;
     }
-    if (!empty($expiredGroups)) {
-      $expiredGroups = implode(',', $expiredGroups);
-      CRM_Core_DAO::executeQuery("DELETE FROM civicrm_group_contact_cache WHERE group_id IN ({$expiredGroups})");
+    if (empty($expiredGroups)) {
+      // There are no expired smart groups to flush
+      return;
+    }
+
+    $expiredGroupsCSV = implode(',', $expiredGroups);
+    $flushSQLParams = [1 => [$expiredGroupsCSV, 'CommaSeparatedIntegers']];
+    // Now check if we actually have any entries in the smart groups to flush
+    $groupsHaveEntriesToFlushSQL = 'SELECT group_id FROM civicrm_group_contact_cache gc WHERE group_id IN (%1) LIMIT 1';
+    $groupsHaveEntriesToFlush = (bool) CRM_Core_DAO::singleValueQuery($groupsHaveEntriesToFlushSQL, $flushSQLParams);
+
+    if ($groupsHaveEntriesToFlush) {
+      CRM_Core_DAO::executeQuery("DELETE FROM civicrm_group_contact_cache WHERE group_id IN (%1)", [1 => [$expiredGroupsCSV, 'CommaSeparatedIntegers']]);
 
       // Clear these out without resetting them because we are not building caches here, only clearing them,
       // so the state is 'as if they had never been built'.
-      CRM_Core_DAO::executeQuery("UPDATE civicrm_group SET cache_date = NULL WHERE id IN ({$expiredGroups})");
+      CRM_Core_DAO::executeQuery("UPDATE civicrm_group SET cache_date = NULL WHERE id IN (%1)", [1 => [$expiredGroupsCSV, 'CommaSeparatedIntegers']]);
     }
     $lock->release();
   }

--- a/tests/phpunit/api/v3/ContactTest.php
+++ b/tests/phpunit/api/v3/ContactTest.php
@@ -146,9 +146,11 @@ class api_v3_ContactTest extends CiviUnitTestCase {
    * @throws \CRM_Core_Exception
    */
   public function testCreateIndividualNoCacheClear(): void {
-
     $contact = $this->callAPISuccess('contact', 'create', $this->_params);
-    $groupID = $this->groupCreate();
+
+    $smartGroupParams = ['form_values' => ['contact_type' => ['IN' => ['Household']]]];
+    $savedSearch = CRM_Contact_BAO_SavedSearch::create($smartGroupParams);
+    $groupID = $this->groupCreate(['saved_search_id' => $savedSearch->id]);
 
     $this->putGroupContactCacheInClearableState($groupID, $contact);
 


### PR DESCRIPTION
Overview
----------------------------------------
Found via experimental #21384.

There is an option to prevent cache flushes `CRM_Core_Config::isPermitCacheFlushMode()` (currently only used by the importer) but it's only respected if we flush caches via the `CRM_Contact_BAO_Contact_Utils::clearContactCaches()` function which is bypassed by both opportunistic and deterministic (group contact) cache flushes. This means it's quite likely caches will be flushed anyway probably triggering deadlocks.

A group contact cache can have a NULL cache date if (1) it's never been built, (2) it's been invalidated but not flushed. But `flushCaches()` will only clear cache entries for groups which have an expired cache date.

Before
----------------------------------------
Group contact cache flushed even if `CRM_Core_Config::isPermitCacheFlushMode()` returns FALSE when opportunistic/deterministic cache flush is triggered.

Group contact cache not cleared if it has a NULL cache date.

After
----------------------------------------
Group contact cache not flushed if `CRM_Core_Config::isPermitCacheFlushMode()` returns FALSE when opportunistic/deterministic cache flush is triggered.

Group contact cache cleared if it has an expired *or* NULL cache date.

Technical Details
----------------------------------------
#21384 fails cache tests because the tests are testing things in a very specific way which is not necessarily how the cache *should* work. Looking into improving those tests identified the two issues in this PR which make fixing those tests much easier and should make the group contact cache more consistent as well as reduce deadlocks (during import at least).

Comments
----------------------------------------
@eileenmcnaughton 
