### PR TITLE
avoid back trace when importing preferred communication method

### DIFF
--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -621,6 +621,12 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Contact_Import_Parser {
         ->setLoadOptions(TRUE)
         ->execute()->indexBy('name');
       foreach ($fields as $fieldName => $fieldSpec) {
+        if (isset($formatted[$fieldName]) && is_array($formatted[$fieldName])) {
+          // If we have an array at this stage, it's probably a multi-select
+          // field that has already been parsed properly into the value that
+          // should be inserted into the database.
+          continue;
+        }
         if (!empty($formatted[$fieldName])
           && empty($fieldSpec['options'][$formatted[$fieldName]])) {
           $formatted[$fieldName] = array_search($formatted[$fieldName], $fieldSpec['options'], TRUE) ?? $formatted[$fieldName];

--- a/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
+++ b/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
@@ -851,6 +851,45 @@ class CRM_Contact_Import_Parser_ContactTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test importing fields with various options.
+   *
+   * Ensure we can import multiple preferred_communication_methods, single
+   * gender, and single preferred language using both labels and values.
+   *
+   * @throws \CRM_Core_Exception @throws \CiviCRM_API3_Exception
+   */
+  public function testImportFieldsWithVariousOptions() {
+    $processor = new CRM_Import_ImportProcessor();
+    $processor->setContactType('Individual');
+    $processor->setMappingFields(
+      [
+        ['name' => 'first_name'],
+        ['name' => 'last_name'],
+        ['name' => 'preferred_communication_method'],
+        ['name' => 'gender_id'],
+        ['name' => 'preferred_language'],
+      ],
+    );
+    $importer = $processor->getImporterObject();
+    $fields = ['Ima', 'Texter', "SMS,Phone", "Female", "Danish"];
+    $importer->import(CRM_Import_Parser::DUPLICATE_NOCHECK, $fields);
+    $contact = $this->callAPISuccessGetSingle('Contact', ['last_name' => 'Texter']);
+
+    $this->assertEquals([4, 1], $contact['preferred_communication_method'], "Import multiple preferred communication methods using labels.");
+    $this->assertEquals(1, $contact['gender_id'], "Import gender with label.");
+    $this->assertEquals('da_DK', $contact['preferred_language'], "Import preferred language with label.");
+
+    $importer = $processor->getImporterObject();
+    $fields = ['Ima', 'Texter', "4,1", "1", "da_DK"];
+    $importer->import(CRM_Import_Parser::DUPLICATE_NOCHECK, $fields);
+    $contact = $this->callAPISuccessGetSingle('Contact', ['last_name' => 'Texter']);
+
+    $this->assertEquals([4, 1], $contact['preferred_communication_method'], "Import multiple preferred communication methods using values.");
+    $this->assertEquals(1, $contact['gender_id'], "Import gender with id.");
+    $this->assertEquals('da_DK', $contact['preferred_language'], "Import preferred language with value.");
+  }
+
+  /**
    * Run the import parser.
    *
    * @param array $originalValues

--- a/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
+++ b/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
@@ -868,7 +868,7 @@ class CRM_Contact_Import_Parser_ContactTest extends CiviUnitTestCase {
         ['name' => 'preferred_communication_method'],
         ['name' => 'gender_id'],
         ['name' => 'preferred_language'],
-      ],
+      ]
     );
     $importer = $processor->getImporterObject();
     $fields = ['Ima', 'Texter', "SMS,Phone", "Female", "Danish"];


### PR DESCRIPTION

Overview
----------------------------------------

When importing a contact with preferred communication method set, I get:

CiviCRM_API3_Exception: "'' is not a valid option for field preferred_communication_method"

The problem surfaced after upgrading from 5.33 to 5.39.

I traced it back to this code and can fix it with this simple change.

The problem with the original code is that `$formatted[$fieldName]` is an
array with the key set to the chosen value and the value set to 1. So, the array_search always fails since the key it's looking for is an array, not a string.

I think the line:

`&& empty($fieldSpec['options'][$formatted[$fieldName]])) {`

Is also not quite right but not sure how to change it.

Before
----------------------------------------

Importing a contact with preferred communication method set results in:

'' is not a valid option for field preferred_communication_method

After
----------------------------------------

The contact record is imported.

Technical Details
----------------------------------------
The problem may have been introduced via cdfa6649f87d29341cc680e5d42991b23283a238.

Comments
----------------------------------------

I don't think this fix is quite there yet but would love to get some feedback.

Also, in this particular use case, the label for the SMS option has been changed to "Text message" but I don't think that has an impact on this issue.
