### PR TITLE
dev/core#2828 - Make up for message template text version update from 5.20 that never happened

### DIFF
--- a/CRM/Upgrade/Incremental/MessageTemplates.php
+++ b/CRM/Upgrade/Incremental/MessageTemplates.php
@@ -249,6 +249,13 @@ class CRM_Upgrade_Incremental_MessageTemplates {
           ['name' => 'pledge_reminder', 'type' => 'text'],
         ],
       ],
+      [
+        'version' => '5.43.alpha1',
+        'upgrade_descriptor' => ts('Missed text version from 5.20'),
+        'templates' => [
+          ['name' => 'contribution_online_receipt', 'type' => 'text'],
+        ],
+      ],
     ];
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/2828

Before
----------------------------------------
If the site was installed before 5.20 you will still have the old contribution_online_receipt message template text version in the db even after upgrading to 5.43.

After
----------------------------------------
Replaced in the db.

Technical Details
----------------------------------------
It seems it was missed in 5.20. See lab ticket

Comments
----------------------------------------
I don't think it's worth backporting since it's just the text version, and somebody would have noticed a problem by now.
