### PR TITLE
SearchKit - Add pseudo-fields for row number and current user

### DIFF
--- a/ext/search_kit/Civi/Search/Admin.php
+++ b/ext/search_kit/Civi/Search/Admin.php
@@ -11,6 +11,7 @@
 
 namespace Civi\Search;
 
+use Civi\Api4\Action\SearchDisplay\AbstractRunAction;
 use Civi\Api4\Tag;
 use CRM_Search_ExtensionUtil as E;
 
@@ -29,6 +30,7 @@ class Admin {
     return [
       'schema' => self::addImplicitFKFields($schema),
       'joins' => self::getJoins($schema),
+      'pseudoFields' => AbstractRunAction::getPseudoFields(),
       'operators' => \CRM_Utils_Array::makeNonAssociative(self::getOperators()),
       'functions' => \CRM_Api4_Page_Api4Explorer::getSqlFunctions(),
       'displayTypes' => Display::getDisplayTypes(['id', 'name', 'label', 'description', 'icon']),

--- a/ext/search_kit/ang/crmSearchAdmin.module.js
+++ b/ext/search_kit/ang/crmSearchAdmin.module.js
@@ -193,6 +193,9 @@
         if (defaults.label === true) {
           values.label = getDefaultLabel(fieldExpr);
         }
+        if (defaults.sortable) {
+          values.sortable = (info.field.type === 'Field');
+        }
         return values;
       }
       return {

--- a/ext/search_kit/ang/crmSearchAdmin.module.js
+++ b/ext/search_kit/ang/crmSearchAdmin.module.js
@@ -137,6 +137,10 @@
         if (!field && join && join.bridge) {
           field = _.find(getEntity(join.bridge).fields, {name: name});
         }
+        // Might be a pseudoField
+        if (!field) {
+          field = _.cloneDeep(_.find(CRM.crmSearchAdmin.pseudoFields, {name: name}));
+        }
         if (field) {
           field.baseEntity = entityName;
           return {field: field, join: join};

--- a/ext/search_kit/ang/crmSearchAdmin/compose.html
+++ b/ext/search_kit/ang/crmSearchAdmin/compose.html
@@ -41,7 +41,7 @@
           {{:: ts('Field Transformations') }}
         </legend>
         <div ng-if="!!controls.showFunctions">
-          <fieldset ng-repeat="col in $ctrl.savedSearch.api_params.select">
+          <fieldset ng-repeat="col in $ctrl.savedSearch.api_params.select" ng-if="!$ctrl.isPseudoField(col)">
             <crm-search-function expr="$ctrl.savedSearch.api_params.select[$index]"></crm-search-function>
           </fieldset>
         </div>

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminTokenSelect.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminTokenSelect.component.js
@@ -27,7 +27,7 @@
       };
 
       this.getTokens = function() {
-        var allFields = ctrl.admin.getAllFields(ctrl.suffix || '', ['Field', 'Custom', 'Extra']);
+        var allFields = ctrl.admin.getAllFields(ctrl.suffix || '', ['Field', 'Custom', 'Extra', 'Pseudo']);
         _.eachRight(ctrl.admin.savedSearch.api_params.select, function(fieldName) {
           allFields.unshift({
             id: fieldName,

--- a/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayTable.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayTable.component.js
@@ -43,7 +43,7 @@
         }
         // Displays created prior to 5.43 may not have this property
         ctrl.display.settings.classes = ctrl.display.settings.classes || [];
-        ctrl.parent.initColumns({label: true});
+        ctrl.parent.initColumns({label: true, sortable: true});
       };
 
     }

--- a/ext/search_kit/ang/crmSearchAdmin/resultsTable/crmSearchAdminResultsTable.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/resultsTable/crmSearchAdminResultsTable.component.js
@@ -37,7 +37,7 @@
             classes: ['table', 'table-striped'],
             button: ts('Search'),
             columns: _.transform(ctrl.search.api_params.select, function(columns, fieldExpr) {
-              var column = {label: true},
+              var column = {label: true, sortable: true},
                 link = getViewLink(fieldExpr, links);
               if (link) {
                 column.title = link.title;

--- a/ext/search_kit/ang/crmSearchAdmin/resultsTable/crmSearchAdminResultsTable.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/resultsTable/crmSearchAdminResultsTable.component.js
@@ -111,7 +111,7 @@
       };
 
       $scope.fieldsForSelect = function() {
-        return {results: ctrl.crmSearchAdmin.getAllFields(':label', ['Field', 'Custom', 'Extra'], function(key) {
+        return {results: ctrl.crmSearchAdmin.getAllFields(':label', ['Field', 'Custom', 'Extra', 'Pseudo'], function(key) {
             return _.contains(ctrl.search.api_params.select, key);
           })
         };

--- a/ext/search_kit/ang/crmSearchAdmin/resultsTable/crmSearchAdminResultsTable.html
+++ b/ext/search_kit/ang/crmSearchAdmin/resultsTable/crmSearchAdminResultsTable.html
@@ -11,7 +11,7 @@
           <input type="checkbox" ng-disabled="$ctrl.loading || !$ctrl.results.length" ng-checked="$ctrl.allRowsSelected" ng-click="$ctrl.selectAllRows()" >
         </th>
         <th ng-repeat="item in $ctrl.search.api_params.select" ng-click="$ctrl.setSort($ctrl.settings.columns[$index], $event)" title="{{$index || !$ctrl.crmSearchAdmin.groupExists ? ts('Drag to reorder columns, click to sort results (shift-click to sort by multiple).') : ts('Column reserved for smart group.')}}">
-          <i class="crm-i {{ $ctrl.getSort($ctrl.settings.columns[$index]) }}"></i>
+          <i ng-if=":: $ctrl.isSortable($ctrl.settings.columns[$index])" class="crm-i {{ $ctrl.getSort($ctrl.settings.columns[$index]) }}"></i>
           <span ng-class="{'crm-draggable': $index || !$ctrl.crmSearchAdmin.groupExists}">{{ $ctrl.settings.columns[$index].label }}</span>
           <span ng-switch="$index || !$ctrl.crmSearchAdmin.groupExists ? 'sortable' : 'locked'">
             <i ng-switch-when="locked" class="crm-i fa-lock" aria-hidden="true"></i>

--- a/ext/search_kit/ang/crmSearchAdmin/resultsTable/crmSearchAdminResultsTable.html
+++ b/ext/search_kit/ang/crmSearchAdmin/resultsTable/crmSearchAdminResultsTable.html
@@ -19,7 +19,7 @@
           </span>
         </th>
         <th class="form-inline text-right">
-          <input class="form-control crm-action-menu fa-plus"
+          <input class="form-control crm-action-menu fa-plus collapsible-optgroups"
                  crm-ui-select="::{data: fieldsForSelect, placeholder: ts('Add'), width: '80px', containerCss: {minWidth: '80px'}, dropdownCss: {width: '300px'}}"
                  on-crm-ui-select="addColumn(selection)" >
         </th>

--- a/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplaySortableTrait.service.js
+++ b/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplaySortableTrait.service.js
@@ -10,6 +10,10 @@
 
       sort: [],
 
+      isSortable: function(col) {
+        return col.type === 'field' && col.sortable !== false;
+      },
+
       getSort: function(col) {
         var dir = _.reduce(this.sort, function(dir, item) {
           return item[0] === col.key ? item[1] : dir;
@@ -21,7 +25,7 @@
       },
 
       setSort: function(col, $event) {
-        if (col.type !== 'field') {
+        if (!this.isSortable(col)) {
           return;
         }
         var dir = this.getSort(col) === 'fa-sort-asc' ? 'DESC' : 'ASC';

--- a/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTable.html
+++ b/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTable.html
@@ -9,8 +9,8 @@
         <th class="crm-search-result-select" ng-if=":: $ctrl.settings.actions">
           <input type="checkbox" ng-disabled="$ctrl.loading || !$ctrl.results.length" ng-checked="$ctrl.allRowsSelected" ng-click="$ctrl.selectAllRows()" >
         </th>
-        <th ng-repeat="col in $ctrl.settings.columns" ng-click="$ctrl.setSort(col, $event)" title="{{:: col.type === 'field' ? ts('Click to sort results (shift-click to sort by multiple).') : '' }}">
-          <i ng-if=":: col.type === 'field'" class="crm-i {{ $ctrl.getSort(col) }}"></i>
+        <th ng-repeat="col in $ctrl.settings.columns" ng-click="$ctrl.setSort(col, $event)" title="{{:: $ctrl.isSortable(col) ? ts('Click to sort results (shift-click to sort by multiple).') : '' }}">
+          <i ng-if=":: $ctrl.isSortable(col)" class="crm-i {{ $ctrl.getSort(col) }}"></i>
           <span>{{:: col.label }}</span>
         </th>
       </tr>


### PR DESCRIPTION
Overview
----------------------------------------
Makes a couple calculated fields available for use as columns or tokens in SearchKit.

Before
----------------------------------------
No option to display current user or row number in columns or tokens

After
----------------------------------------
New columns available:
![Screenshot from 2021-09-11 11-02-15](https://user-images.githubusercontent.com/2874912/132952181-ed4444b7-16fd-427d-935c-deb019727c06.png)


New fields also work as tokens:
![Screenshot from 2021-09-11 10-59-44](https://user-images.githubusercontent.com/2874912/132952151-33d6b902-b90c-4a17-8cac-9e63ee387e10.png)

