### PR TITLE
Afform - gracefully handle missing html files

### DIFF
--- a/ext/afform/core/Civi/Afform/AngularDependencyMapper.php
+++ b/ext/afform/core/Civi/Afform/AngularDependencyMapper.php
@@ -49,6 +49,10 @@ class AngularDependencyMapper {
       $jFile = $scanner->findFilePath($formName, 'aff.json');
       $hFile = $scanner->findFilePath($formName, 'aff.html');
 
+      if (!$hFile) {
+        \Civi::log()->warning("Missing html file for Afform: '$jFile'");
+        continue;
+      }
       $jStat = stat($jFile);
       $hStat = stat($hFile);
 


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a fatal error when an Afform `.aff.json` file exists without a corresponding `.aff.html` file.

Before
----------------------------------------
Every Civi page looks like this if an afform is missing its `.html` file:

![Screenshot from 2021-09-11 12-15-34](https://user-images.githubusercontent.com/2874912/132954328-42a918ce-50fe-449e-8b4a-39a69fc01eb4.png)

After
----------------------------------------
Logs a warning without affecting runtime.
