### PR TITLE
dev/core#2829 - unit test for nonempty dashboard

### DIFF
--- a/tests/phpunit/CRM/Core/InvokeTest.php
+++ b/tests/phpunit/CRM/Core/InvokeTest.php
@@ -30,4 +30,25 @@ class CRM_Core_InvokeTest extends CiviUnitTestCase {
     ob_end_clean();
   }
 
+  /**
+   * Test dashboard with something actually on it.
+   */
+  public function testInvokeDashboardWithGettingStartedDashlet(): void {
+    $user_id = $this->createLoggedInUser();
+    $this->callAPISuccess('DashboardContact', 'create', [
+      'dashboard_id' => 2,
+      'contact_id' => $user_id,
+    ]);
+
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = ['access CiviCRM'];
+
+    $_SERVER['REQUEST_URI'] = 'civicrm/dashboard?reset=1';
+    $_GET['q'] = 'civicrm/dashboard';
+
+    $item = CRM_Core_Invoke::getItem(['civicrm/dashboard?reset=1']);
+    ob_start();
+    CRM_Core_Invoke::runItem($item);
+    ob_end_clean();
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/2829

Test demonstrating dashboard fail.

My only question is whether `$explicitJoin['bridge']` [in Api4SelectQuery](https://github.com/civicrm/civicrm-core/blob/741ebf1f3d6095b7cd8e1a6b6a55c19e8047646b/Civi/Api4/Query/Api4SelectQuery.php#L1033) is expected to always be set or whether it's ok that it's missing. I'm thinking the latter.

Before
----------------------------------------
_What is the old user-interface or technical-contract (as appropriate)?_
_For optimal clarity, include a concrete example such as a screenshot, GIF ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)), or code-snippet._

After
----------------------------------------
_What changed? What is new old user-interface or technical-contract?_
_For optimal clarity, include a concrete example such as a screenshot, GIF ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)), or code-snippet._

Technical Details
----------------------------------------
_If the PR involves technical details/changes/considerations which would not be manifest to a casual developer skimming the above sections, please describe the details here._

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
