### PR TITLE
Authx: README: add note about CMS permissions

### DIFF
--- a/ext/authx/README.md
+++ b/ext/authx/README.md
@@ -124,3 +124,6 @@ $ cv ev 'Civi::settings()->set("authx_header_cred", ["pass","jwt"]);'
 $ curl 'https://demouser:demopass@example.org/civicrm/authx/id'
 {"contact_id":203,"user_id":"2"}
 ```
+
+The "AuthX: Authenticate to services with password" CiviCRM permission must
+also be granted for the role associated to the user.


### PR DESCRIPTION
Overview
----------------------------------------

Clarify the example in the Authx README.

Comments
----------------------------------------

I was playing around with the Authx extension and was wondering why is was failing, until I realized this from reading the code.