### PR TITLE
dev/core#2829 - "Trying to access array offset on value of type null" on dashboard

### DIFF
--- a/Civi/Api4/Query/Api4SelectQuery.php
+++ b/Civi/Api4/Query/Api4SelectQuery.php
@@ -1030,7 +1030,7 @@ class Api4SelectQuery {
       $joinPath = $joiner->getPath($explicitJoin['table'] ?? $this->getFrom(), $pathArray);
     }
     catch (\API_Exception $e) {
-      if ($explicitJoin['bridge']) {
+      if (!empty($explicitJoin['bridge'])) {
         // Try looking up custom field in bridge entity instead
         try {
           $useBridgeTable = TRUE;


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/2829

1. Use php 7.4+
1. Visit dashboard

Before
----------------------------------------
Trying to access array offset on value of type null

After
----------------------------------------


Technical Details
----------------------------------------
I think it's expected that the 'bridge' member might not ever get set for some tables.

Comments
----------------------------------------
Unit test is at https://github.com/civicrm/civicrm-core/pull/21437
