### PR TITLE
[NFC/Unit test] - Fix test fail on php 7.4 CRM_Core_BAO_MessageTemplateTest::testCaseActivityCopyTemplate

### DIFF
--- a/tests/phpunit/CRM/Core/BAO/MessageTemplateTest.php
+++ b/tests/phpunit/CRM/Core/BAO/MessageTemplateTest.php
@@ -214,14 +214,16 @@ class CRM_Core_BAO_MessageTemplateTest extends CiviUnitTestCase {
       'contact' => ['role' => 'Sand grain counter'],
     ];
 
+    $toContact = $this->callAPISuccess('Contact', 'getsingle', ['id' => $contact_id]);
+
     [, $subject, $message] = CRM_Core_BAO_MessageTemplate::sendTemplate(
       [
         'valueName' => 'case_activity',
         'contactId' => $contact_id,
         'tplParams' => $tplParams,
         'from' => 'admin@example.com',
-        'toName' => 'Demo',
-        'toEmail' => 'admin@example.com',
+        'toName' => $toContact['display_name'],
+        'toEmail' => $toContact['email'],
         'attachments' => NULL,
       ]
     );


### PR DESCRIPTION
Overview
----------------------------------------
https://test.civicrm.org/job/CiviCRM-Core-Matrix/10039/BKPROF=max,CIVIVER=master,SUITES=phpunit-crm,label=bknix-tmp/testReport/junit/(root)/CRM_Core_BAO_MessageTemplateTest/testCaseActivityCopyTemplate/

CRM_Core_BAO_MessageTemplateTest::testCaseActivityCopyTemplate
Trying to access array offset on value of type null

/home/jenkins/bknix-max/build/build-1/web/sites/all/modules/civicrm/CRM/Core/BAO/MessageTemplate.php:378
/home/jenkins/bknix-max/build/build-1/web/sites/all/modules/civicrm/tests/phpunit/CRM/Core/BAO/MessageTemplateTest.php:219

Technical Details
----------------------------------------
The change in https://github.com/civicrm/civicrm-core/pull/21426 assumes the recipient is an existing contact. In normal usage this is reasonable for this function, but this test uses an arbitrary toEmail that doesn't belong to a real contact.

Comments
----------------------------------------

