### PR TITLE
SearchKit - Fix deleting search displays

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
@@ -99,6 +99,7 @@
         } else if (params.id) {
           apiCalls.deleteGroup = ['Group', 'delete', {where: [['saved_search_id', '=', params.id]]}];
         }
+        _.remove(params.displays, {trashed: true});
         if (params.displays && params.displays.length) {
           chain.displays = ['SearchDisplay', 'replace', {where: [['saved_search_id', '=', '$id']], records: params.displays}];
         } else if (params.id) {


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a regression where search displays cannot be deleted from the UI.

Before
----------------------------------------
1. Click "Edit" on a saved search with at least one display
2. Click the trash icon next to a display
3. Click save
4. Note the display has not been deleted

After
----------------------------------------
Fixed

Comments
----------------------------------------
IDK when this regressed or if it was always broken but it's a simple fix.