### PR TITLE
[wip] dev/core#2788 list case tokens via one method

### DIFF
--- a/CRM/Core/SelectValues.php
+++ b/CRM/Core/SelectValues.php
@@ -630,28 +630,9 @@ class CRM_Core_SelectValues {
    * @param int $caseTypeId
    * @return array
    */
-  public static function caseTokens($caseTypeId = NULL) {
-    static $tokens = NULL;
-    if (!$tokens) {
-      $tokens = [
-        '{case.id}' => 'Case ID',
-        '{case.case_type_id:label}' => 'Case Type',
-        '{case.subject}' => 'Case Subject',
-        '{case.start_date}' => 'Case Start Date',
-        '{case.end_date}' => 'Case End Date',
-        '{case.details}' => 'Details',
-        '{case.status_id:label}' => 'Case Status',
-        '{case.is_deleted:label}' => 'Case is in the Trash',
-        '{case.created_date}' => 'Created Date',
-        '{case.modified_date}' => 'Modified Date',
-      ];
-
-      $customFields = CRM_Core_BAO_CustomField::getFields('Case', FALSE, FALSE, $caseTypeId);
-      foreach ($customFields as $id => $field) {
-        $tokens["{case.custom_$id}"] = "{$field['label']} :: {$field['groupTitle']}";
-      }
-    }
-    return $tokens;
+  public static function caseTokens($caseTypeId = NULL): array {
+    $tokenProcessor = new TokenProcessor(Civi::dispatcher(), ['schema' => ['caseId']]);
+    return $tokenProcessor->listTokens();
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#2817 list case tokens via one method

Before
----------------------------------------
2 different functions to list case tokens

After
----------------------------------------
They do the same thing

Technical Details
----------------------------------------
@demeritcowboy I think this is the missing bit for what you were talking about.

However, there are 2 pieces to resolve before this is mergeable

1) your comment about order of group & field in the token code (or it could be out of scope)
2) - this change currently removes the filtering by case type id - I have to check if it is ever passed in to determine if we need to resolve that pre-merge (looking)

Comments
----------------------------------------
