### PR TITLE
dev/core#2817 Remove last core calls to `replaceCaseTokens`

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -1131,18 +1131,13 @@ class CRM_Activity_BAO_Activity extends CRM_Activity_DAO_Activity {
       $tokenText = in_array($values['preferred_mail_format'], ['Both', 'Text'], TRUE) ? $text : '';
       $tokenHtml = in_array($values['preferred_mail_format'], ['Both', 'HTML'], TRUE) ? $html : '';
 
-      if ($caseId) {
-        $tokenSubject = CRM_Utils_Token::replaceCaseTokens($caseId, $tokenSubject, $subjectToken, $escapeSmarty);
-        $tokenText = CRM_Utils_Token::replaceCaseTokens($caseId, $tokenText, $messageToken, $escapeSmarty);
-        $tokenHtml = CRM_Utils_Token::replaceCaseTokens($caseId, $tokenHtml, $messageToken, $escapeSmarty);
-      }
-
       $renderedTemplate = CRM_Core_BAO_MessageTemplate::renderTemplate([
         'messageTemplate' => [
           'msg_text' => $tokenText,
           'msg_html' => $tokenHtml,
           'msg_subject' => $tokenSubject,
         ],
+        'tokenContext' => $caseId ? ['caseId' => $caseId] : [],
         'contactId' => $contactId,
         'disableSmarty' => !CRM_Utils_Constant::value('CIVICRM_MAIL_SMARTY'),
         'tplParams' => ['contact' => $values],

--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -1586,6 +1586,8 @@ class CRM_Utils_Token {
   }
 
   /**
+   * @deprecated
+   *
    * @param int $caseId
    * @param string $str
    * @param array $knownTokens

--- a/tests/phpunit/CRM/Contact/Form/Task/EmailCommonTest.php
+++ b/tests/phpunit/CRM/Contact/Form/Task/EmailCommonTest.php
@@ -67,7 +67,7 @@ class CRM_Contact_Form_Task_EmailCommonTest extends CiviUnitTestCase {
    * @throws \CiviCRM_API3_Exception
    * @throws \Civi\API\Exception\UnauthorizedException
    */
-  public function testPostProcessWithSignature() {
+  public function testPostProcessWithSignature(): void {
     $mut = new CiviMailUtils($this, TRUE);
     $bcc1 = $this->individualCreate(['email' => 'bcc1@example.com']);
     $bcc2 = $this->individualCreate(['email' => 'bcc2@example.com']);


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#2817 Remove last core calls to `replaceCaseTokens`

Before
----------------------------------------
still calling `replaceCaseTokens` from email send

After
----------------------------------------
No core calls to `replaceCaseTokens` once this & https://github.com/civicrm/civicrm-core/pull/21445 are merged

Technical Details
----------------------------------------

Comments
----------------------------------------
