### PR TITLE
dev/core#2814 TokenCompatSubscriber - Evaluate tokens during "civi.token.eval" phase

### DIFF
--- a/CRM/Core/BAO/ActionSchedule.php
+++ b/CRM/Core/BAO/ActionSchedule.php
@@ -615,15 +615,15 @@ FROM civicrm_action_schedule cas
     $mailParams = [
       'groupName' => 'Scheduled Reminder Sender',
       'from' => self::pickFromEmail($schedule),
-      'toName' => $tokenRow->context['contact']['display_name'],
+      'toName' => $tokenRow->render('toName'),
       'toEmail' => $toEmail,
       'subject' => $tokenRow->render('subject'),
       'entity' => 'action_schedule',
       'entity_id' => $schedule->id,
     ];
 
-    if (!$body_html || $tokenRow->context['contact']['preferred_mail_format'] === 'Text' ||
-      $tokenRow->context['contact']['preferred_mail_format'] === 'Both'
+    $preferredMailFormat = $tokenRow->render('preferred_mail_format');
+    if (!$body_html ||  $preferredMailFormat === 'Text' || $preferredMailFormat === 'Both'
     ) {
       // render the &amp; entities in text mode, so that the links work
       $mailParams['text'] = str_replace('&amp;', '&', $body_text);
@@ -658,6 +658,10 @@ FROM civicrm_action_schedule cas
     $tp->addMessage('body_html', $schedule->body_html, 'text/html');
     $tp->addMessage('sms_body_text', $schedule->sms_body_text, 'text/plain');
     $tp->addMessage('subject', $schedule->subject, 'text/plain');
+    // These 2 are not 'real' tokens - but it tells the processor to load them.
+    $tp->addMessage('toName', '{contact.display_name}', 'text/plain');
+    $tp->addMessage('preferred_mail_format', '{contact.preferred_mail_format}', 'text/plain');
+
     return $tp;
   }
 

--- a/Civi/Token/TokenCompatSubscriber.php
+++ b/Civi/Token/TokenCompatSubscriber.php
@@ -288,7 +288,7 @@ class TokenCompatSubscriber implements EventSubscriberInterface {
       );
       foreach ($hookTokens as $hookToken) {
         foreach ($messageTokens[$hookToken] as $tokenName) {
-          $row->format('text/plain')->tokens($hookToken, $tokenName, $contactArray[$row->context['contactId']][$tokenName] ?? '');
+          $row->tokens($hookToken, $tokenName, $contactArray[$row->context['contactId']]["{$hookToken}.{$tokenName}"] ?? '');
         }
       }
     }

--- a/Civi/Token/TokenCompatSubscriber.php
+++ b/Civi/Token/TokenCompatSubscriber.php
@@ -288,7 +288,7 @@ class TokenCompatSubscriber implements EventSubscriberInterface {
       );
       foreach ($hookTokens as $hookToken) {
         foreach ($messageTokens[$hookToken] as $tokenName) {
-          $row->tokens($hookToken, $tokenName, $contactArray[$row->context['contactId']]["{$hookToken}.{$tokenName}"] ?? '');
+          $row->format('text/html')->tokens($hookToken, $tokenName, $contactArray[$row->context['contactId']]["{$hookToken}.{$tokenName}"] ?? '');
         }
       }
     }

--- a/Civi/Token/TokenCompatSubscriber.php
+++ b/Civi/Token/TokenCompatSubscriber.php
@@ -30,6 +30,7 @@ class TokenCompatSubscriber implements EventSubscriberInterface {
     return [
       'civi.token.eval' => [
         ['setupSmartyAliases', 1000],
+        ['evaluateLegacyHookTokens', 500],
         ['onEvaluate'],
       ],
       'civi.token.render' => 'onRender',
@@ -243,6 +244,57 @@ class TokenCompatSubscriber implements EventSubscriberInterface {
   }
 
   /**
+   * Load token data from legacy hooks.
+   *
+   * While our goal is for people to move towards implementing
+   * toke processors the old-style hooks can extend contact
+   * token data.
+   *
+   * When that is happening we need to load the full contact record
+   * to send to the hooks (not great for performance but the
+   * fix is to move away from implementing legacy style hooks).
+   *
+   * Consistent with prior behaviour we only load the contact it it
+   * is already loaded. In that scenario we also load any extra fields
+   * that might be wanted for the contact tokens.
+   *
+   * @param \Civi\Token\Event\TokenValueEvent $e
+   * @throws TokenException
+   */
+  public function evaluateLegacyHookTokens(TokenValueEvent $e): void {
+    $messageTokens = $e->getTokenProcessor()->getMessageTokens();
+    $hookTokens = array_intersect(\CRM_Utils_Token::getTokenCategories(), array_keys($messageTokens));
+    if (empty($hookTokens)) {
+      return;
+    }
+    foreach ($e->getRows() as $row) {
+      if (empty($row->context['contactId'])) {
+        continue;
+      }
+      unset($swapLocale);
+      $swapLocale = empty($row->context['locale']) ? NULL : \CRM_Utils_AutoClean::swapLocale($row->context['locale']);
+      if (empty($row->context['contact'])) {
+        // If we don't have the contact already load it now, getting full
+        // details for hooks and anything the contact token resolution might
+        // want later.
+        $row->context['contact'] = $this->getContact($row->context['contactId'], $messageTokens['contact'] ?? [], TRUE);
+      }
+      $contactArray = [$row->context['contactId'] => $row->context['contact']];
+      \CRM_Utils_Hook::tokenValues($contactArray,
+        [$row->context['contactId']],
+        empty($row->context['mailingJobId']) ? NULL : $row->context['mailingJobId'],
+        $messageTokens,
+        $row->context['controller']
+      );
+      foreach ($hookTokens as $hookToken) {
+        foreach ($messageTokens[$hookToken] as $tokenName) {
+          $row->format('text/plain')->tokens($hookToken, $tokenName, $contactArray[$row->context['contactId']][$tokenName] ?? '');
+        }
+      }
+    }
+  }
+
+  /**
    * Load token data.
    *
    * @param \Civi\Token\Event\TokenValueEvent $e
@@ -255,7 +307,7 @@ class TokenCompatSubscriber implements EventSubscriberInterface {
 
     $e->getTokenProcessor()->context['hookTokenCategories'] = \CRM_Utils_Token::getTokenCategories();
 
-    $messageTokens = $e->getTokenProcessor()->getMessageTokens();
+    $messageTokens = $e->getTokenProcessor()->getMessageTokens()['contact'] ?? [];
 
     foreach ($e->getRows() as $row) {
       if (empty($row->context['contactId'])) {
@@ -268,23 +320,10 @@ class TokenCompatSubscriber implements EventSubscriberInterface {
       /** @var int $contactId */
       $contactId = $row->context['contactId'];
       if (empty($row->context['contact'])) {
-        $contact = $this->getContact($contactId, $messageTokens['contact'] ?? [], TRUE);
+        $contact = $this->getContact($contactId, $messageTokens);
       }
       else {
         $contact = $row->context['contact'];
-      }
-
-      $contactArray = [$contactId => $contact];
-      \CRM_Utils_Hook::tokenValues($contactArray,
-        [$contactId],
-        empty($row->context['mailingJobId']) ? NULL : $row->context['mailingJobId'],
-        $messageTokens,
-        $row->context['controller']
-      );
-
-      // merge the custom tokens in the $contact array
-      if (!empty($contactArray[$contactId])) {
-        $contact = array_merge($contact, $contactArray[$contactId]);
       }
       $row->context('contact', $contact);
     }

--- a/tests/phpunit/CRM/Core/BAO/MessageTemplateTest.php
+++ b/tests/phpunit/CRM/Core/BAO/MessageTemplateTest.php
@@ -339,6 +339,7 @@ London, 90210
     // work in combination.
     $tokenString = '{$pre_assigned_smarty}{$passed_smarty}
 {domain.name}
+{important_stuff.favourite_emoticon}
 ';
     foreach (array_keys($tokenData) as $key) {
       $tokenString .= "{$key}:{contact.{$key}}\n";
@@ -356,6 +357,7 @@ London, 90210
     ]);
     $expected = 'weewhoa
 Default Domain Name
+emo
 ';
     $expected .= $this->getExpectedContactOutput($address['id'], $tokenData, $messageContent['html']);
     $this->assertEquals($expected, $messageContent['html']);
@@ -455,7 +457,12 @@ Default Domain Name
     ];
   }
 
-  public function getAdvertisedTokens() {
+  /**
+   * Get the tokens we expect to see advertised.
+   *
+   * @return string[]
+   */
+  public function getAdvertisedTokens(): array {
     return [
       '{contact.contact_type}' => 'Contact Type',
       '{contact.do_not_email}' => 'Do Not Email',

--- a/tests/phpunit/CRM/Core/BAO/MessageTemplateTest.php
+++ b/tests/phpunit/CRM/Core/BAO/MessageTemplateTest.php
@@ -384,7 +384,7 @@ emo
    */
   public function hookTokenValues(array &$details): void {
     foreach ($details as $index => $detail) {
-      $details[$index]['favourite_emoticon'] = 'emo';
+      $details[$index]['important_stuff.favourite_emoticon'] = 'emo';
     }
   }
 


### PR DESCRIPTION

Overview
----------------------------------------
dev/core#2814 Fix tokenCompatSubscriber to conditionally evaluate legacy hook tokens

Before
----------------------------------------
legacy hook tokens evaluated in render

After
----------------------------------------
legacy hook tokens loaded in evaluate

Technical Details
----------------------------------------
As discussed the tokens should be loaded in evaluate and the token processor class should handle the rendering - but currently that is not how it is working. This adds a function to evaluate for legacy hooks that runs before the main contact evaluate function. It loads the contact with all 'returnProperties' if hooks are to be called - because that is what they expect....

But if we get as far as the main evaluate and the contact isn't loaded we just load the values we actually need for tokens

It is pretty hard finding the right size chunk for this - it would be sensible to ask why I didn't go that bit further and fix the contact tokens to follow the same pattern. OTOH this might be so big it just stalls. I did create https://github.com/civicrm/civicrm-core/pull/21450 in order to potentially address the 'too big' - if it seems to not go far enough then IMHO the solution is to see it as a process

Comments
----------------------------------------
Test cover is excellent on this code by now
