### PR TITLE
Fixed issue with sending from do-not-reply@domain address

### DIFF
--- a/CRM/Mailing/Event/BAO/Confirm.php
+++ b/CRM/Mailing/Event/BAO/Confirm.php
@@ -87,7 +87,7 @@ class CRM_Mailing_Event_BAO_Confirm extends CRM_Mailing_Event_DAO_Confirm {
     $config = CRM_Core_Config::singleton();
 
     $domain = CRM_Core_BAO_Domain::getDomain();
-    list($domainEmailName, $_) = CRM_Core_BAO_Domain::getNameAndEmail();
+    list($domainEmailName, $domainEmailAddress) = CRM_Core_BAO_Domain::getNameAndEmail();
 
     list($display_name, $email) = CRM_Contact_BAO_Contact_Location::getEmailDetails($se->contact_id);
 
@@ -125,7 +125,7 @@ class CRM_Mailing_Event_BAO_Confirm extends CRM_Mailing_Event_DAO_Confirm {
     $mailParams = [
       'groupName' => 'Mailing Event ' . $component->component_type,
       'subject' => $component->subject,
-      'from' => "\"$domainEmailName\" <" . CRM_Core_BAO_Domain::getNoReplyEmailAddress() . '>',
+      'from' => "\"{$domainEmailName}\" <{$domainEmailAddress}>",
       'toEmail' => $email,
       'toName' => $display_name,
       'replyTo' => CRM_Core_BAO_Domain::getNoReplyEmailAddress(),

--- a/CRM/Mailing/Event/BAO/Reply.php
+++ b/CRM/Mailing/Event/BAO/Reply.php
@@ -228,12 +228,12 @@ class CRM_Mailing_Event_BAO_Reply extends CRM_Mailing_Event_DAO_Reply {
     $component->find(TRUE);
 
     $domain = CRM_Core_BAO_Domain::getDomain();
-    list($domainEmailName, $_) = CRM_Core_BAO_Domain::getNameAndEmail();
+    list($domainEmailName, $domainEmailAddress) = CRM_Core_BAO_Domain::getNameAndEmail();
 
     $params = [
       'subject' => $component->subject,
       'toEmail' => $to,
-      'from' => "\"$domainEmailName\" <" . CRM_Core_BAO_Domain::getNoReplyEmailAddress() . '>',
+      'from' => "\"{$domainEmailName}\" <{$domainEmailAddress}>",
       'replyTo' => CRM_Core_BAO_Domain::getNoReplyEmailAddress(),
       'returnPath' => CRM_Core_BAO_Domain::getNoReplyEmailAddress(),
     ];

--- a/CRM/Mailing/Event/BAO/Resubscribe.php
+++ b/CRM/Mailing/Event/BAO/Resubscribe.php
@@ -249,7 +249,7 @@ class CRM_Mailing_Event_BAO_Resubscribe {
 
     $params = [
       'subject' => $component->subject,
-      'from' => "\"$domainEmailName\" <" . CRM_Core_BAO_Domain::getNoReplyEmailAddress() . '>',
+      'from' => "\"{$domainEmailName}\" <{$domainEmailAddress}>",
       'toEmail' => $eq->email,
       'replyTo' => CRM_Core_BAO_Domain::getNoReplyEmailAddress(),
       'returnPath' => CRM_Core_BAO_Domain::getNoReplyEmailAddress(),

--- a/CRM/Mailing/Event/BAO/Unsubscribe.php
+++ b/CRM/Mailing/Event/BAO/Unsubscribe.php
@@ -384,7 +384,7 @@ WHERE  email = %2
 
     $params = [
       'subject' => $component->subject,
-      'from' => "\"$domainEmailName\" <" . CRM_Core_BAO_Domain::getNoReplyEmailAddress() . '>',
+      'from' => "\"{$domainEmailName}\" <{$domainEmailAddress}>",
       'toEmail' => $eq->email,
       'replyTo' => CRM_Core_BAO_Domain::getNoReplyEmailAddress(),
       'returnPath' => CRM_Core_BAO_Domain::getNoReplyEmailAddress(),


### PR DESCRIPTION
Fixed issue with sending from do-not-reply@domain address resulting in fatal errors because an invalid from address was used. 

Overview
----------------------------------------

When confirming a group description another e-mail is send with a from e-mail address do-not-reply@domain.com when the mail account is not allowed to send on behalf of this e-mail address a fatal error is shown. 
This PR sets the from address to the default domain e-mail address and leaves the reply to to do-not-reply@domain.com so when a user press reply on this e-mail it goes to the do-not-reply address.

Before
----------------------------------------

When it is not possible to send from do-not-reply@domain.com it might result in an error like below:

![ccve](https://user-images.githubusercontent.com/4126292/133118682-bdff0679-8c45-46be-afdd-e0063091978b.png)



After
----------------------------------------

The from e-mail address used is the default domain from e-mail address. The reply-to is still do-not-reply so the fatal error is gone.

Comments
----------------------------------------

See this issue: https://lab.civicrm.org/dev/core/-/issues/645
