### PR TITLE
dev/core#2835 - Activity export broken in 5.41

### DIFF
--- a/CRM/Activity/Task.php
+++ b/CRM/Activity/Task.php
@@ -157,7 +157,7 @@ class CRM_Activity_Task extends CRM_Core_Task {
       $value = self::TASK_PRINT;
     }
     if (isset(self::$_tasks[$value])) {
-      return [[self::$_tasks[$value]['class']], self::$_tasks[$value]['result']];
+      return [(array) self::$_tasks[$value]['class'], self::$_tasks[$value]['result']];
     }
     return [[], NULL];
   }

--- a/tests/phpunit/CRM/Activity/Form/SearchTest.php
+++ b/tests/phpunit/CRM/Activity/Form/SearchTest.php
@@ -120,4 +120,45 @@ class CRM_Activity_Form_SearchTest extends CiviUnitTestCase {
     ];
   }
 
+  /**
+   * This just checks there's no errors. It doesn't perform any tasks.
+   * It's a little bit like choosing an action from the dropdown.
+   * @dataProvider taskControllerProvider
+   * @param int $task
+   */
+  public function testTaskController(int $task) {
+    // It gets the task from the POST var
+    $oldtask = $_POST['task'] ?? NULL;
+    $_POST['task'] = $task;
+
+    // yes it's the string 'null'
+    new CRM_Activity_Controller_Search('Find Activities', TRUE, 'null');
+
+    // clean up
+    if (is_null($oldtask)) {
+      unset($_POST['task']);
+    }
+    else {
+      $_POST['task'] = $oldtask;
+    }
+  }
+
+  /**
+   * dataprovider for testTaskController
+   * @return array
+   */
+  public function taskControllerProvider(): array {
+    return [
+      [CRM_Activity_Task::TASK_DELETE],
+      [CRM_Activity_Task::TASK_PRINT],
+      [CRM_Activity_Task::TASK_EXPORT],
+      [CRM_Activity_Task::BATCH_UPDATE],
+      [CRM_Activity_Task::TASK_EMAIL],
+      [CRM_Activity_Task::PDF_LETTER],
+      [CRM_Activity_Task::TASK_SMS],
+      [CRM_Activity_Task::TAG_ADD],
+      [CRM_Activity_Task::TAG_REMOVE],
+    ];
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/2835

Before
----------------------------------------
1. Find Activities
1. Select a couple and from the dropdown choose export.
1. You're now on a different screen, not the export screen - which screen seems to depend where you were before.
1. Warning: Illegal offset type in CRM_Activity_StateMachine_Search->__construct() (line 41 of ...\CRM\Activity\StateMachine\Search.php).

After
----------------------------------------
Works

Technical Details
----------------------------------------
This seems intended to be a cast to array not a nested array:

https://github.com/civicrm/civicrm-core/commit/20eb1cf7378ec801d5520eba9de5952075918f6c#diff-0118f13b1d17a95ba175eca5956f83bcf00341a38d4fa9741f275ff44e8252b3R160

Comments
----------------------------------------
Before the patch the unit test fails for EXPORT, EMAIL, and BATCH.
