### PR TITLE
Ensure TokenSmary::render returns an array

### DIFF
--- a/CRM/Core/TokenSmarty.php
+++ b/CRM/Core/TokenSmarty.php
@@ -41,6 +41,7 @@ class CRM_Core_TokenSmarty {
    * @internal
    */
   public static function render(array $messages, array $tokenContext = [], array $smartyAssigns = []): array {
+    $result = [];
     $tokenContextDefaults = [
       'controller' => __CLASS__,
       'smarty' => TRUE,


### PR DESCRIPTION

Overview
----------------------------------------
Ensure TokenSmary::render returns an array

Before
----------------------------------------
error (due to type hint) if messages are empty

After
----------------------------------------
If there are no messages it should return an empty array

Technical Details
----------------------------------------

Comments
----------------------------------------
