### PR TITLE
dev/core#2650 dev/core#2832 add support & testing for preferred token format

### DIFF
--- a/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
+++ b/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
@@ -374,6 +374,23 @@ Check';
     $messageToken = CRM_Utils_Token::getTokens($tokenString);
     $tokenHtml = CRM_Utils_Token::replaceEntityTokens('membership', $memberships[$this->getMembershipID()], $tokenString, $messageToken);
     $this->assertEquals($this->getExpectedMembershipTokenOutput(), $tokenHtml);
+
+    // Now compare with scheduled reminder
+    $mut = new CiviMailUtils($this);
+    CRM_Utils_Time::setTime('2007-01-22 15:00:00');
+    $this->callAPISuccess('action_schedule', 'create', [
+      'title' => 'job',
+      'subject' => 'job',
+      'entity_value' => 1,
+      'mapping_id' => 4,
+      'start_action_date' => 'membership_join_date',
+      'start_action_offset' => 1,
+      'start_action_condition' => 'after',
+      'start_action_unit' => 'day',
+      'body_html' => $tokenString,
+    ]);
+    $this->callAPISuccess('job', 'send_reminder', []);
+    $mut->checkMailLog([$this->getExpectedMembershipTokenOutput()]);
   }
 
   /**


### PR DESCRIPTION

Overview
----------------------------------------
dev/core#2650 add support & testing for preferred token format

This fixes the membership token processor to support the preferred
token format style in scheduled reminders
and adds test cover

Before
----------------------------------------
Limited test cover of tokens in membership scheduled reminder
Preferred tokens don't work - ie `{membership.status_id:label}` and `{membership.membership_type_id:label}`

After
----------------------------------------
Test cover & preferred tokens work. Switched to use the `EntityTokens` parent per the other classes to the minimum extent required to get the tests to pass - further consolidation will be in follow up PRs 

Technical Details
----------------------------------------

Next step is to upgrade the old tokens out of the scheduled reminders
and remove support for them. For the legacy token handler
it is just used from one place from core so we can add a rule
to prevent them from being 'requested' & switch them
off the legacy method.

Note the token processor is not 'listening' yet - it's only accessed from Scheduled reminders at the moment

Comments
----------------------------------------
The test cover in this is more thorough than pre-existing tests
but here is a list of them

api_v3_JobTest.testCallSendReminderSuccessMoreThanDefaultLimit
api_v3_JobTest.testCallSendReminderLimitToSMS
api_v3_JobTest.testCallSendReminderLimitToSMSWithDeletedProvider
CRM_Core_BAO_ActionScheduleTest.testMembershipDateMatch
CRM_Core_BAO_ActionScheduleTest.testMembershipJoinDateNonMatch
CRM_Core_BAO_ActionScheduleTest.testMembershipEndDateRepeat
CRM_Core_BAO_ActionScheduleTest.testMembershipEndDateRepeatChangedEndDate_CRM_15376
CRM_Core_BAO_ActionScheduleTest.testMembershipEndDateMatch
CRM_Core_BAO_ActionScheduleTest.testMultipleMembershipEndDateMatch
CRM_Core_BAO_ActionScheduleTest.testMembershipEndDateNoMatch
CRM_Core_BAO_ActionScheduleTest.testMembershipLimitToNone
CRM_Core_BAO_ActionScheduleTest.testMembershipWithReferenceDate
CRM_Core_BAO_ActionScheduleTest.testMembershipOnMultipleReminder
CRM_Core_BAO_ActionScheduleTest.testRepetitionFrequencyUnit
CRM_Core_BAO_ActionScheduleTest.testInheritedMembershipPermissions
CRM_Core_BAO_ActionScheduleTest.testMembershipScheduleWithAbsoluteDate