### PR TITLE
[Ref] Cleanup on SelectValues::contributeTokens

### DIFF
--- a/CRM/Core/EntityTokens.php
+++ b/CRM/Core/EntityTokens.php
@@ -122,8 +122,9 @@ class CRM_Core_EntityTokens extends AbstractTokenSubscriber {
    * Get all the tokens supported by this processor.
    *
    * @return array|string[]
+   * @throws \API_Exception
    */
-  public function getAllTokens(): array {
+  protected function getAllTokens(): array {
     $basicTokens = $this->getBasicTokens();
     foreach (array_keys($basicTokens) as $fieldName) {
       // The goal is to be able to render more complete tokens

--- a/CRM/Core/SelectValues.php
+++ b/CRM/Core/SelectValues.php
@@ -560,17 +560,13 @@ class CRM_Core_SelectValues {
   }
 
   /**
-   * Different type of Event Tokens.
+   * Different type of Contribution Tokens.
    *
    * @return array
    */
   public static function contributionTokens(): array {
-    $tokens = [];
-    $processor = new CRM_Contribute_Tokens();
-    foreach ($processor->getAllTokens() as $token => $title) {
-      $tokens['{contribution.' . $token . '}'] = $title;
-    }
-    return $tokens;
+    $tokenProcessor = new TokenProcessor(Civi::dispatcher(), ['schema' => ['contributionId']]);
+    return $tokenProcessor->listTokens();
   }
 
   /**


### PR DESCRIPTION

Overview
----------------------------------------
[Ref] Cleanup on SelectValues::contributeTokens

This has 100% test cover in the ByTypeTest::testTokenRendering test

Before
----------------------------------------
6 lines of code

After
----------------------------------------
2

Technical Details
----------------------------------------
Now that the Contribute token processor class is 'listening' we can do this simplification

The change means we no longer need the recently-added function
to be public & hence it is switched to protected.

Note this is the same as the equivalent contactTokens function

Comments
----------------------------------------
