### PR TITLE
dev/core#2833 Fix Contact Type change on Backend Membership Credit Ca…

### DIFF
--- a/CRM/Contribute/Form/AbstractEditPayment.php
+++ b/CRM/Contribute/Form/AbstractEditPayment.php
@@ -634,9 +634,10 @@ WHERE  contribution_id = {$id}
       }
       //here we are setting up the billing contact - if different from the member they are already created
       // but they will get billing details assigned
+      $addressParams['contact_id'] = $this->_contributorContactID;
       CRM_Contact_BAO_Contact::createProfileContact($addressParams, $fields,
         $this->_contributorContactID, NULL, NULL,
-        CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Contact', $this->_contactID, 'contact_type')
+        CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Contact', $this->_contributorContactID, 'contact_type')
       );
     }
 

--- a/tests/phpunit/CRM/Member/Form/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/Form/MembershipTest.php
@@ -1332,6 +1332,7 @@ Expires: ',
     // register for both of these memberships via backoffice membership form submission
     $params = [
       'cid' => $contactId,
+      'contact_id' => $contactId,
       'join_date' => date('Y-m-d'),
       'start_date' => '',
       'end_date' => '',


### PR DESCRIPTION
Overview
----------------------------------------

**Individual** Contact get changed to **Organization**


Reproduction steps
----------------------------------------
1. Individual Contact must have an Existing Membership Record (may be with **Expired** Status) 
1. Choose Renew with Credit card action
1. select **Record Payment from a Different Contact?** checkbox and choose Organisation Contact for field **Payment From**
1. Keep Billing Name and Address of Individual Contact (Used Dummy Processor for testing).

Now, click on 'Renew' Button.

Individual Contact 'Contact Type' get changed from **Individual** to **Organization**

Same issue with  **Submit Credit Card Membership** functionality.


Current behaviour
----------------------------------------
Contact Type Changes from **Individual** to **Organization**

Expected behaviour
----------------------------------------
Contact type should not change.

Environment information
----------------------------------------
Able to re-create issue on https://dmaster.demo.civicrm.org (5.43.alpha1)
Same issue exist on 5.21 version also. So its not a new issue.