### PR TITLE
flushCaches should respect permitCacheFlushMode

### DIFF
--- a/CRM/Contact/BAO/GroupContactCache.php
+++ b/CRM/Contact/BAO/GroupContactCache.php
@@ -248,6 +248,10 @@ WHERE  id IN ( $groupIDs )
    * clear.
    */
   protected static function flushCaches() {
+    if (!CRM_Core_Config::isPermitCacheFlushMode()) {
+      return;
+    }
+
     try {
       $lock = self::getLockForRefresh();
     }


### PR DESCRIPTION
Overview
----------------------------------------
There is an option to prevent cache flushes `CRM_Core_Config::isPermitCacheFlushMode()` (currently only used by the importer) but it's only respected if we flush caches via the `CRM_Contact_BAO_Contact_Utils::clearContactCaches()` function which is bypassed by both opportunistic and deterministic (group contact) cache flushes. This means it's quite likely caches will be flushed anyway probably triggering deadlocks.

Before
----------------------------------------
Group contact cache flushed even if `CRM_Core_Config::isPermitCacheFlushMode()` returns FALSE when opportunistic/deterministic cache flush is triggered.

After
----------------------------------------
Group contact cache not flushed if `CRM_Core_Config::isPermitCacheFlushMode()` returns FALSE when opportunistic/deterministic cache flush is triggered.

Technical Details
----------------------------------------

Comments
----------------------------------------
@eileenmcnaughton 
