### PR TITLE
Fix display of subscription frequency on 'Update Subscription' form

### DIFF
--- a/CRM/Contribute/Form/UpdateSubscription.php
+++ b/CRM/Contribute/Form/UpdateSubscription.php
@@ -84,6 +84,8 @@ class CRM_Contribute_Form_UpdateSubscription extends CRM_Contribute_Form_Contrib
     }
 
     $this->assign('self_service', $this->isSelfService());
+    $this->assign('recur_frequency_interval', $this->_subscriptionDetails->frequency_interval);
+    $this->assign('recur_frequency_unit', $this->_subscriptionDetails->frequency_unit);
 
     $this->editableScheduleFields = $this->_paymentProcessorObj->getEditableRecurringScheduleFields();
 

--- a/templates/CRM/Contribute/Form/UpdateSubscription.tpl
+++ b/templates/CRM/Contribute/Form/UpdateSubscription.tpl
@@ -22,7 +22,7 @@
   <table class="form-layout">
     <tr>
       <td class="label">{$form.amount.label}</td>
-      <td>{$form.currency.html|crmAddClass:eight}&nbsp;{$form.amount.html|crmAddClass:eight} ({ts}every{/ts} {$frequency_interval} {$frequency_unit})</td>
+      <td>{$form.currency.html|crmAddClass:eight}&nbsp;{$form.amount.html|crmAddClass:eight} ({ts}every{/ts} {$recur_frequency_interval} {$recur_frequency_unit})</td>
     </tr>
     <tr><td class="label">{$form.installments.label}</td><td>{$form.installments.html}<br />
           <span class="description">{ts}Total number of payments to be made. Set this to 0 if this is an open-ended commitment i.e. no set end date.{/ts}</span></td></tr>


### PR DESCRIPTION
Overview
----------------------------------------
Frequency unit/interval was not displayed.

Before
----------------------------------------
Frequency unit/interval was not displayed.

![Captura de ecrã de 2021-09-14 14-12-58](https://user-images.githubusercontent.com/2052161/133263994-26a8e452-203d-43a7-99e6-781ef47b37e6.png)


After
----------------------------------------
Frequency unit/interval is displayed.

![Captura de ecrã de 2021-09-14 14-11-44](https://user-images.githubusercontent.com/2052161/133263871-86e91076-f275-432d-b692-64b10f4cbe86.png)

Technical Details
----------------------------------------
Values were not assigned to template (note I chose `recur_` because that matches an assign used later for sending a receipt).

Comments
----------------------------------------
@jaapjansma Are you able to review?
