### PR TITLE
dev/financial#6 Fix creating of template contribution when it has custom data

### DIFF
--- a/CRM/Contribute/BAO/ContributionRecur.php
+++ b/CRM/Contribute/BAO/ContributionRecur.php
@@ -435,6 +435,7 @@ INNER JOIN civicrm_contribution       con ON ( con.id = mp.contribution_id )
 
     // Retrieve the most recently added contribution
     $mostRecentContribution = Contribution::get(FALSE)
+      ->addSelect('custom.*', 'id', 'contact_id', 'campaign_id', 'financial_type_id', 'currency', 'source', 'amount_level', 'address_id', 'on_behalf', 'source_contact_id', 'tax_amount', 'contribution_page_id', 'total_amount', 'is_test')
       ->addWhere('contribution_recur_id', '=', $id)
       ->addWhere('is_template', '=', 0)
       // we need this line otherwise the is test contribution don't work.
@@ -461,26 +462,21 @@ INNER JOIN civicrm_contribution       con ON ( con.id = mp.contribution_id )
     // relevant values to ensure the activity reflects that.
     $relatedContact = CRM_Contribute_BAO_Contribution::getOnbehalfIds($mostRecentContribution['id']);
 
-    $templateContributionParams = [];
-    $templateContributionParams['is_test'] = $mostRecentContribution['is_test'];
+    $templateContributionParams = $mostRecentContribution;
+    unset($templateContributionParams['id']);
     $templateContributionParams['is_template'] = '1';
+    $templateContributionParams['contribution_status_id:name'] = 'Template';
     $templateContributionParams['skipRecentView'] = TRUE;
     $templateContributionParams['contribution_recur_id'] = $id;
-    $templateContributionParams['line_item'] = $mostRecentContribution['line_item'];
-    $templateContributionParams['status_id'] = 'Template';
-    foreach (['contact_id', 'campaign_id', 'financial_type_id', 'currency', 'source', 'amount_level', 'address_id', 'on_behalf', 'source_contact_id', 'tax_amount', 'contribution_page_id', 'total_amount'] as $fieldName) {
-      if (isset($mostRecentContribution[$fieldName])) {
-        $templateContributionParams[$fieldName] = $mostRecentContribution[$fieldName];
-      }
-    }
     if (!empty($relatedContact['individual_id'])) {
       $templateContributionParams['on_behalf'] = TRUE;
       $templateContributionParams['source_contact_id'] = $relatedContact['individual_id'];
     }
     $templateContributionParams['source'] = $templateContributionParams['source'] ?? ts('Recurring contribution');
-    $templateContribution = civicrm_api3('Contribution', 'create', $templateContributionParams);
-    $temporaryObject = new CRM_Contribute_BAO_Contribution();
-    $temporaryObject->copyCustomFields($mostRecentContribution['id'], $templateContribution['id']);
+    $templateContribution = Contribution::create(FALSE)
+      ->setValues($templateContributionParams)
+      ->execute()
+      ->first();
     // Add new soft credit against current $contribution.
     CRM_Contribute_BAO_ContributionRecur::addrecurSoftCredit($templateContributionParams['contribution_recur_id'], $templateContribution['id']);
     return $templateContribution['id'];


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/financial/-/issues/6

---
UPDATE: The original issue seems to be fixed between 5.44-5.45 - CiviCRM no longer crashes with a "data already exists" DB error. BUT it still doesn't do the right thing because any hook that tries to insert custom data on create gets ignored and the original values are used instead.
I've updated the test to demonstrate that a hook *can* insert custom data on a "Contribution.create" and the inserted data will end up in the database and not the copied custom data from the original.

*It is good practise to insert entity+custom data in the same API call and this PR changes that to be the case, also uses API4 for a bit more modern-ness.*

---

If there is an extension installed that automatically calculates custom data for a contribution on "create" this can cause CiviCRM to crash because:

Before
----------------------------------------
1. API3 Contribution.create runs and creates the new contribution (without custom data being copied) and triggers hooks.
2. Hooks fire (in this case ukgiftaid extension calculates and inserts it's custom data for new contribution).
3. `$contribution->copyCustomFields()` runs which then triggers a database exception because the data already exists.

After
----------------------------------------
1. API4 Contribution.create runs and creates the new contribution with copied custom data and triggers hooks.
2. Hooks fire (in this case ukgiftaid extension calculates and inserts it's custom data for new contribution).

Technical Details
----------------------------------------
Explained above.

Comments
----------------------------------------
@jaapjansma Are you able to review this one? It is a bug with the template contribution create.
