### PR TITLE
dev/financial#6 Update the recurring contribution when we edit the template contribution

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -23,7 +23,7 @@ use Civi\Api4\PledgePayment;
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
-class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution {
+class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution implements Civi\Test\HookInterface {
 
   /**
    * Static field for all the contribution information that we can potentially import
@@ -605,6 +605,16 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution {
     }
 
     return $contribution;
+  }
+
+  /**
+   * Event fired after modifying a contribution.
+   * @param \Civi\Core\Event\PostEvent $event
+   */
+  public static function self_hook_civicrm_post(\Civi\Core\Event\PostEvent $event) {
+    if ($event->action === 'edit') {
+      CRM_Contribute_BAO_ContributionRecur::updateOnTemplateUpdated($event->object);
+    }
   }
 
   /**

--- a/CRM/Contribute/Form/UpdateSubscription.php
+++ b/CRM/Contribute/Form/UpdateSubscription.php
@@ -151,9 +151,17 @@ class CRM_Contribute_Form_UpdateSubscription extends CRM_Contribute_Form_Contrib
     if (count($lineItems) > 1) {
       $amtAttr += ['readonly' => TRUE];
     }
-    $this->addMoney('amount', ts('Recurring Contribution Amount'), TRUE, $amtAttr,
+    $amountField = $this->addMoney('amount', ts('Recurring Contribution Amount'), TRUE, $amtAttr,
       TRUE, 'currency', $this->_subscriptionDetails->currency, TRUE
     );
+
+    // The amount on the recurring contribution should not be updated directly. If we update the amount using a template contribution the recurring contribution
+    //   will be updated automatically.
+    $paymentProcessorObj = Civi\Payment\System::singleton()->getById(CRM_Contribute_BAO_ContributionRecur::getPaymentProcessorID($this->contributionRecurID));
+    $templateContribution = CRM_Contribute_BAO_ContributionRecur::getTemplateContribution($this->contributionRecurID);
+    if (!empty($templateContribution['id']) && $paymentProcessorObj->supportsEditRecurringContribution()) {
+      $amountField->freeze();
+    }
 
     $this->add('text', 'installments', ts('Number of Installments'), ['size' => 20], FALSE);
 

--- a/templates/CRM/Contribute/Form/UpdateSubscription.tpl
+++ b/templates/CRM/Contribute/Form/UpdateSubscription.tpl
@@ -19,6 +19,12 @@
     </div>
   {/if}
   <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
+  {if $form.amount.frozen}
+  <div class="help">
+    {icon icon="fa-info-circle"}{/icon}
+    {ts}To change the amount you need to edit the template contribution. Click on "View Template" and then "Edit" from the list of recurring contributions{/ts}
+  </div>
+  {/if}
   <table class="form-layout">
     <tr>
       <td class="label">{$form.amount.label}</td>


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/financial/-/issues/6

When we update a template contribution we are specifying what the *next* contribution should be. As the recurring contribution represents the "contract" or "subscription" we need to update the amount to match the new amount on the template.

The "amount" field on the recurring contribution should probably (eventually) be deprecated because it's duplicating information we already have elsewhere in more detail.

As the template contribution is used to configure the next payment the recurring contribution should match that expectation.

If we can update the amount via the template contribution we disable updating via the "Edit recurring contribution" form because it will be updated automatically in the other direction.

Before
----------------------------------------
Recurring contribution amount not update to match template.

After
----------------------------------------
Recurring contribution amount updated to match template.

![Captura de ecrã de 2021-09-14 16-49-17](https://user-images.githubusercontent.com/2052161/133290947-32eb0a2c-103a-4d0c-9acd-b6ca80401c4c.png)

Technical Details
----------------------------------------
This is implemented using the "new" hook style interface that @colemanw added recently. If a template contribution is updated the associated recurring contribution is updated to match the new amount/currency.

Comments
----------------------------------------
@jaapjansma 
