### PR TITLE
fixes core#2318: fix cancel button when sending an individual email

### DIFF
--- a/CRM/Contact/Form/Task/EmailTrait.php
+++ b/CRM/Contact/Form/Task/EmailTrait.php
@@ -297,11 +297,8 @@ trait CRM_Contact_Form_Task_EmailTrait {
 
       $session = CRM_Core_Session::singleton();
       $session->replaceUserContext($url);
-      $this->addDefaultButtons(ts('Send Email'), 'upload', 'cancel');
     }
-    else {
-      $this->addDefaultButtons(ts('Send Email'), 'upload');
-    }
+    $this->addDefaultButtons(ts('Send Email'), 'upload', 'cancel');
 
     $fields = [
       'followup_assignee_contact_id' => [


### PR DESCRIPTION
Overview
----------------------------------------
You can't cancel a non-CiviMail email.  Screencast is present on [core#2318](https://lab.civicrm.org/dev/core/-/issues/2318) and written replication steps on [core#2815](https://lab.civicrm.org/dev/core/-/issues/2815)