### PR TITLE
dev/core#2650 upgrade membership tokens to the new format

### DIFF
--- a/CRM/Core/Form/Task/PDFLetterCommon.php
+++ b/CRM/Core/Form/Task/PDFLetterCommon.php
@@ -201,6 +201,8 @@ class CRM_Core_Form_Task_PDFLetterCommon {
     $deprecatedTokens = [
       '{case.status_id}' => '{case.status_id:label}',
       '{case.case_type_id}' => '{case.case_type_id:label}',
+      '{membership.status}' => '{membership.status_id:label}',
+      '{membership.type}' => '{membership.membership_type_id:label}',
     ];
     $tokenErrors = [];
     foreach ($deprecatedTokens as $token => $replacement) {

--- a/CRM/Core/SelectValues.php
+++ b/CRM/Core/SelectValues.php
@@ -523,11 +523,11 @@ class CRM_Core_SelectValues {
    *
    * @return array
    */
-  public static function membershipTokens() {
+  public static function membershipTokens(): array {
     return [
       '{membership.id}' => ts('Membership ID'),
-      '{membership.status}' => ts('Membership Status'),
-      '{membership.type}' => ts('Membership Type'),
+      '{membership.status_id:label}' => ts('Membership Status'),
+      '{membership.membership_type_id:label}' => ts('Membership Type'),
       '{membership.start_date}' => ts('Membership Start Date'),
       '{membership.join_date}' => ts('Membership Join Date'),
       '{membership.end_date}' => ts('Membership End Date'),

--- a/CRM/Member/Tokens.php
+++ b/CRM/Member/Tokens.php
@@ -46,8 +46,6 @@ class CRM_Member_Tokens extends CRM_Core_EntityTokens {
         'join_date' => ts('Membership Join Date'),
         'start_date' => ts('Membership Start Date'),
         'end_date' => ts('Membership End Date'),
-        'status' => ts('Membership Status'),
-        'type' => ts('Membership Type'),
         'status_id:label' => ts('Membership Status'),
         'membership_type_id:label' => ts('Membership Type'),
       ],
@@ -77,9 +75,8 @@ class CRM_Member_Tokens extends CRM_Core_EntityTokens {
     // FIXME: `select('e.*')` seems too broad.
     $e->query
       ->select('e.*')
-      ->select('mt.minimum_fee as fee, e.id as id , e.join_date, e.start_date, e.end_date, membership_type_id as Membership__membership_type_id, status_id as Membership__status_id, ms.name as status, mt.name as type')
-      ->join('mt', '!casMailingJoinType civicrm_membership_type mt ON e.membership_type_id = mt.id')
-      ->join('ms', '!casMailingJoinType civicrm_membership_status ms ON e.status_id = ms.id');
+      ->select('mt.minimum_fee as fee, e.id as id , e.join_date, e.start_date, e.end_date, membership_type_id as Membership__membership_type_id, status_id as Membership__status_id')
+      ->join('mt', '!casMailingJoinType civicrm_membership_type mt ON e.membership_type_id = mt.id');
   }
 
   /**

--- a/CRM/Upgrade/Incremental/php/FiveFortyThree.php
+++ b/CRM/Upgrade/Incremental/php/FiveFortyThree.php
@@ -68,6 +68,12 @@ class CRM_Upgrade_Incremental_php_FiveFortyThree extends CRM_Upgrade_Incremental
     $this->addTask('Replace legacy last_name smarty token in Online contribution workflow template',
       'updateMessageToken', 'contribution_online_receipt', '$last_name', 'contact.last_name', $rev
     );
+    $this->addTask('Replace membership status token in action schedule',
+      'updateActionScheduleToken', 'membership.status', 'membership.status_id:label', $rev
+    );
+    $this->addTask('Replace membership type token in action schedule',
+      'updateActionScheduleToken', 'membership.type', 'membership.membership_type_id:label', $rev
+    );
   }
 
   /**

--- a/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
+++ b/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
@@ -401,8 +401,8 @@ Check';
   public function getMembershipTokens(): array {
     return [
       '{membership.id}' => 'Membership ID',
-      '{membership.status}' => 'Membership Status',
-      '{membership.type}' => 'Membership Type',
+      '{membership.status_id:label}' => 'Membership Status',
+      '{membership.membership_type_id:label}' => 'Membership Type',
       '{membership.start_date}' => 'Membership Start Date',
       '{membership.join_date}' => 'Membership Join Date',
       '{membership.end_date}' => 'Membership End Date',


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#2650 upgrade membership tokens to the new format 

Before
----------------------------------------
Non standard format tokens : `{membership.type}` `{membership.status}` only used in
- scheduled reminders  
- membership pdf letters 

After
----------------------------------------
- scheduled reminders  - fixed by upgrade
- membership pdf letters - added validation to prevent submit with them

Technical Details
----------------------------------------
_If the PR involves technical details/changes/considerations which would not be manifest to a casual developer skimming the above sections, please describe the details here._

Comments
----------------------------------------
I've added to docs

https://lab.civicrm.org/-/ide/project/documentation/docs/sysadmin/tree/case/-/docs/upgrade/version-specific.md/
