### PR TITLE
dev/core#2790 Move pdf postProcess function to the trait

### DIFF
--- a/CRM/Case/Form/Task/PDF.php
+++ b/CRM/Case/Form/Task/PDF.php
@@ -44,13 +44,6 @@ class CRM_Case_Form_Task_PDF extends CRM_Case_Form_Task {
   }
 
   /**
-   * Process the form after the input has been submitted and validated.
-   */
-  public function postProcess() {
-    CRM_Contact_Form_Task_PDFLetterCommon::postProcess($this);
-  }
-
-  /**
    * List available tokens for this form.
    *
    * @return array

--- a/CRM/Contact/Form/Task/PDF.php
+++ b/CRM/Contact/Form/Task/PDF.php
@@ -96,13 +96,6 @@ class CRM_Contact_Form_Task_PDF extends CRM_Contact_Form_Task {
   }
 
   /**
-   * Process the form after the input has been submitted and validated.
-   */
-  public function postProcess() {
-    CRM_Contact_Form_Task_PDFLetterCommon::postProcess($this);
-  }
-
-  /**
    * List available tokens for this form.
    *
    * @return array

--- a/CRM/Contact/Form/Task/PDFLetterCommon.php
+++ b/CRM/Contact/Form/Task/PDFLetterCommon.php
@@ -113,8 +113,11 @@ class CRM_Contact_Form_Task_PDFLetterCommon extends CRM_Core_Form_Task_PDFLetter
    * @throws \CRM_Core_Exception
    * @throws \CiviCRM_API3_Exception
    * @throws \API_Exception
+   *
+   * @deprecated
    */
   public static function postProcess(&$form): void {
+    CRM_Core_Error::deprecatedFunctionWarning('no alternative');
     $formValues = $form->controller->exportValues($form->getName());
     [$formValues, $categories, $html_message, $messageToken, $returnProperties] = self::processMessageTemplate($formValues);
     $html = $activityIds = [];
@@ -207,8 +210,11 @@ class CRM_Contact_Form_Task_PDFLetterCommon extends CRM_Core_Form_Task_PDFLetter
    *   and use-case.
    *
    * @throws CRM_Core_Exception
+   *
+   * @deprecated
    */
   public static function createActivities($form, $html_message, $contactIds, $subject, $campaign_id, $perContactHtml = []) {
+    CRM_Core_Error::deprecatedFunctionWarning('no alternative');
 
     $activityParams = [
       'subject' => $subject,
@@ -278,6 +284,8 @@ class CRM_Contact_Form_Task_PDFLetterCommon extends CRM_Core_Form_Task_PDFLetter
    * @param string $type
    * @return string
    * @throws \CRM_Core_Exception
+   *
+   * @deprecated
    */
   private static function getMimeType($type) {
     $mimeTypes = [
@@ -320,6 +328,8 @@ class CRM_Contact_Form_Task_PDFLetterCommon extends CRM_Core_Form_Task_PDFLetter
    * @return bool
    *   TRUE if the Download Document button was clicked (also defaults to TRUE
    *     if the form controller does not exist), else FALSE
+   *
+   * @deprecated
    */
   protected static function isLiveMode($form) {
     // CRM-21255 - Hrm, CiviCase 4+5 seem to report buttons differently...

--- a/CRM/Contribute/Form/Task/PDFLetter.php
+++ b/CRM/Contribute/Form/Task/PDFLetter.php
@@ -232,7 +232,7 @@ class CRM_Contribute_Form_Task_PDFLetter extends CRM_Contribute_Form_Task {
     }
 
     $contactIds = array_keys($contacts);
-    CRM_Contact_Form_Task_PDFLetterCommon::createActivities($this, $html_message, $contactIds, CRM_Utils_Array::value('subject', $formValues, ts('Thank you letter')), CRM_Utils_Array::value('campaign_id', $formValues), $contactHtml);
+    $this->createActivities($this, $html_message, $contactIds, CRM_Utils_Array::value('subject', $formValues, ts('Thank you letter')), CRM_Utils_Array::value('campaign_id', $formValues), $contactHtml);
     $html = array_diff_key($html, $emailedHtml);
 
     //CRM-19761

--- a/CRM/Event/Form/Task/PDF.php
+++ b/CRM/Event/Form/Task/PDF.php
@@ -56,13 +56,6 @@ class CRM_Event_Form_Task_PDF extends CRM_Event_Form_Task {
   }
 
   /**
-   * Process the form after the input has been submitted and validated.
-   */
-  public function postProcess() {
-    CRM_Contact_Form_Task_PDFLetterCommon::postProcess($this);
-  }
-
-  /**
    * List available tokens for this form.
    *
    * @return array

--- a/CRM/Member/Form/Task/PDFLetter.php
+++ b/CRM/Member/Form/Task/PDFLetter.php
@@ -97,7 +97,7 @@ class CRM_Member_Form_Task_PDFLetter extends CRM_Member_Form_Task {
       $messageToken,
       $html_message
     );
-    CRM_Contact_Form_Task_PDFLetterCommon::createActivities($form, $html_message, $contactIDs, $formValues['subject'], CRM_Utils_Array::value('campaign_id', $formValues));
+    $form->createActivities($form, $html_message, $contactIDs, $formValues['subject'], CRM_Utils_Array::value('campaign_id', $formValues));
     CRM_Utils_PDF_Utils::html2pdf($html, $this->getFileName() . '.pdf', FALSE, $formValues);
 
     $form->postProcessHook();


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#2790 Move pdf postProcess function to the trait

Before
----------------------------------------
Functionality on the pdfCommon status class

After
----------------------------------------
Functionality in the trait

Technical Details
----------------------------------------
This just leaves the `processMessageTemplate` function to bring over


Comments
----------------------------------------
@demeritcowboy once it's all on the trait I'll figure out that liveMode regression you logged

I also put up https://github.com/civicrm/civicrm-core/pull/21478 that takes this & goes that last little stretch....