### PR TITLE
dev/core#2790 Move rest of pdfCommon functionality to the trait

### DIFF
--- a/CRM/Activity/Form/Task/PDF.php
+++ b/CRM/Activity/Form/Task/PDF.php
@@ -46,7 +46,7 @@ class CRM_Activity_Form_Task_PDF extends CRM_Activity_Form_Task {
     $form = $this;
     $activityIds = $form->_activityHolderIds;
     $formValues = $form->controller->exportValues($form->getName());
-    $html_message = CRM_Core_Form_Task_PDFLetterCommon::processTemplate($formValues);
+    $html_message = $this->processTemplate($formValues);
 
     // Do the rest in another function to make testing easier
     $form->createDocument($activityIds, $html_message, $formValues);

--- a/CRM/Contact/Form/Task/PDFLetterCommon.php
+++ b/CRM/Contact/Form/Task/PDFLetterCommon.php
@@ -83,8 +83,12 @@ class CRM_Contact_Form_Task_PDFLetterCommon extends CRM_Core_Form_Task_PDFLetter
    *
    * @return array
    *   [$categories, $html_message, $messageToken, $returnProperties]
+   *
+   * @deprecated
    */
   public static function processMessageTemplate($formValues) {
+    CRM_Core_Error::deprecatedFunctionWarning('no alternative');
+
     $html_message = self::processTemplate($formValues);
 
     $categories = self::getTokenCategories();
@@ -304,6 +308,8 @@ class CRM_Contact_Form_Task_PDFLetterCommon extends CRM_Core_Form_Task_PDFLetter
 
   /**
    * Get the categories required for rendering tokens.
+   *
+   * @deprecated
    *
    * @return array
    */

--- a/CRM/Contribute/Form/Task/PDFLetter.php
+++ b/CRM/Contribute/Form/Task/PDFLetter.php
@@ -134,7 +134,7 @@ class CRM_Contribute_Form_Task_PDFLetter extends CRM_Contribute_Form_Task {
    */
   public function postProcess() {
     $formValues = $this->controller->exportValues($this->getName());
-    [$formValues, $categories, $html_message, $messageToken, $returnProperties] = CRM_Contact_Form_Task_PDFLetterCommon::processMessageTemplate($formValues);
+    [$formValues, $html_message, $messageToken, $returnProperties] = $this->processMessageTemplate($formValues);
     $isPDF = FALSE;
     $emailParams = [];
     if (!empty($formValues['email_options'])) {

--- a/CRM/Core/Form/Task/PDFLetterCommon.php
+++ b/CRM/Core/Form/Task/PDFLetterCommon.php
@@ -23,13 +23,19 @@
  * The intention is that common functionality can be moved here and the other
  * classes cleaned up.
  * Keep old-style token handling out of this class.
+ *
+ * @deprecated
  */
 class CRM_Core_Form_Task_PDFLetterCommon {
 
   /**
    * @var CRM_Core_Form $form
+   *
+   * @deprecated
    */
   public static function preProcess(&$form) {
+    CRM_Core_Error::deprecatedFunctionWarning('no alternative');
+
     $form->setTitle('Print/Merge Document');
   }
 
@@ -247,11 +253,15 @@ class CRM_Core_Form_Task_PDFLetterCommon {
    *
    * @return string $html_message
    *
+   * @deprecated
+   *
    * @throws \CRM_Core_Exception
    * @throws \CiviCRM_API3_Exception
    * @throws \Civi\API\Exception\UnauthorizedException
    */
   public static function processTemplate(&$formValues) {
+    CRM_Core_Error::deprecatedFunctionWarning('no alternative');
+
     $html_message = $formValues['html_message'] ?? NULL;
 
     // process message template
@@ -309,6 +319,8 @@ class CRM_Core_Form_Task_PDFLetterCommon {
   }
 
   /**
+   * @deprecated
+   *
    * @param $message
    */
   public static function formatMessage(&$message) {

--- a/CRM/Member/Form/Task/PDFLetter.php
+++ b/CRM/Member/Form/Task/PDFLetter.php
@@ -89,7 +89,7 @@ class CRM_Member_Form_Task_PDFLetter extends CRM_Member_Form_Task {
   public function postProcessMembers($membershipIDs, $skipOnHold, $skipDeceased, $contactIDs) {
     $form = $this;
     $formValues = $form->controller->exportValues($form->getName());
-    [$formValues, $categories, $html_message, $messageToken, $returnProperties] = CRM_Contact_Form_Task_PDFLetterCommon::processMessageTemplate($formValues);
+    [$formValues, $html_message, $messageToken, $returnProperties] = $this->processMessageTemplate($formValues);
 
     $html
       = $this->generateHTML(

--- a/tests/phpunit/CRM/Contact/Form/Task/PrintDocumentTest.php
+++ b/tests/phpunit/CRM/Contact/Form/Task/PrintDocumentTest.php
@@ -10,7 +10,7 @@
  */
 
  /**
-  * Test class for CRM_Contact_Form_Task_PDFLetterCommon.
+  * Test class for CRM_Contact_Form_Task_PDF.
   * @group headless
   */
 class CRM_Contact_Form_Task_PrintDocumentTest extends CiviUnitTestCase {
@@ -51,8 +51,12 @@ class CRM_Contact_Form_Task_PrintDocumentTest extends CiviUnitTestCase {
    */
   public function _testDocumentContent($formValues, $type) {
     $html = [];
-    $form = new CRM_Contact_Form_Task_PDFLetterCommon();
-    list($formValues, $categories, $html_message, $messageToken, $returnProperties) = $form->processMessageTemplate($formValues);
+    /* @var CRM_Contact_Form_Task_PDF $form */
+    $form = $this->getFormObject('CRM_Contact_Form_Task_PDF', [], NULL, [
+      'radio_ts' => 'ts_sel',
+      'task' => CRM_Member_Task::PDF_LETTER,
+    ]);
+    list($formValues, $html_message, $messageToken, $returnProperties) = $form->processMessageTemplate($formValues);
     list($html_message, $zip) = CRM_Utils_PDF_Document::unzipDoc($formValues['document_file_path'], $formValues['document_type']);
 
     foreach ($this->_contactIds as $item => $contactId) {

--- a/tests/phpunit/CRM/Contribute/Form/Task/PDFLetterCommonTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/Task/PDFLetterCommonTest.php
@@ -394,7 +394,7 @@ campaign : Big one
     $this->mut = new CiviMailUtils($this, TRUE);
     $this->_individualId = $this->individualCreate();
     $this->_individualId2 = $this->individualCreate();
-    $htmlMessage = "{aggregate.rendered_token}";
+    $htmlMessage = '{aggregate.rendered_token}';
     $formValues = [
       'group_by' => 'contact_id',
       'html_message' => $htmlMessage,
@@ -505,9 +505,8 @@ campaign : Big one
     $this->assertEquals($html[2], $activities['values'][1]['details']);
     // Checking it is not called multiple times.
     // once for each contact create + once for the activities.
-    // & once for the token processor, for now.
     // By calling the cached function we can get this down to 1
-    $this->assertEquals(4, $this->hookTokensCalled);
+    $this->assertEquals(3, $this->hookTokensCalled);
     $this->mut->checkAllMailLog($html);
 
   }


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#2790 Move rest of pdfCommon functionality to the trait

Before
----------------------------------------
Functionality on the static PDFCommon

After
----------------------------------------
Moved to the trait

Technical Details
----------------------------------------
After this only the form rule is used from the shared class. I will leave that a bit longer as I have another PR that is adding deprecations to it open but from this I can switch to cleaning it up

Comments
----------------------------------------
Includes https://github.com/civicrm/civicrm-core/pull/21478