### PR TITLE
(dev/mail#83) ExampleDataLoader - Multiple fixes for quirky examples

### DIFF
--- a/Civi/Test/ExampleDataLoader.php
+++ b/Civi/Test/ExampleDataLoader.php
@@ -64,10 +64,7 @@ class ExampleDataLoader {
       return NULL;
     }
 
-    if ($example['file']) {
-      include_once $example['file'];
-    }
-    $obj = new $example['class']();
+    $obj = $this->createObj($example['file'], $example['class']);
     $obj->build($example);
     return $example;
   }
@@ -91,8 +88,7 @@ class ExampleDataLoader {
 
     $all = [];
     foreach ($classes as $file => $class) {
-      require_once $file;
-      $obj = new $class();
+      $obj = $this->createObj($file, $class);
       $offset = 0;
       foreach ($obj->getExamples() as $example) {
         $example['file'] = $file;
@@ -130,6 +126,17 @@ class ExampleDataLoader {
       }
     }
     return $r;
+  }
+
+  private function createObj(?string $file, ?string $class): ExampleDataInterface {
+    if ($file) {
+      include_once $file;
+    }
+    if (!class_exists($class)) {
+      throw new \CRM_Core_Exception("Failed to read example (class '{$class}' in file '{$file}')");
+    }
+
+    return new $class();
   }
 
 }

--- a/tests/phpunit/CRM/Case/WorkflowMessage/CaseActivity/CaseAdhocExample.ex.php
+++ b/tests/phpunit/CRM/Case/WorkflowMessage/CaseActivity/CaseAdhocExample.ex.php
@@ -6,6 +6,9 @@ class CRM_Case_WorkflowMessage_CaseActivity_CaseAdhocExample extends \Civi\Workf
    * @inheritDoc
    */
   public function getExamples(): iterable {
+    if (!class_exists($this->wfClass)) {
+      return []; /* CaseActivity WfMsg is temporarily in tests/phpunit, so it's not reliably loadable.  Temp work-around. */
+    }
     yield [
       'name' => "workflow/{$this->wfName}/{$this->exName}",
       'title' => ts('Case Activity (Adhoc-style example)'),

--- a/tests/phpunit/CRM/Case/WorkflowMessage/CaseActivity/CaseModelExample.ex.php
+++ b/tests/phpunit/CRM/Case/WorkflowMessage/CaseActivity/CaseModelExample.ex.php
@@ -5,6 +5,9 @@ class CRM_Case_WorkflowMessage_CaseActivity_CaseModelExample extends \Civi\Workf
    * @inheritDoc
    */
   public function getExamples(): iterable {
+    if (!class_exists($this->wfClass)) {
+      return []; /* CaseActivity WfMsg is temporarily in tests/phpunit, so it's not reliably loadable.  Temp work-around. */
+    }
     yield [
       'name' => "workflow/{$this->wfName}/{$this->exName}",
       'title' => ts('Case Activity (Class-style example)'),


### PR DESCRIPTION
Overview
----------------------------------------

This is a follow-up to #21338. Toward the end, based on request, some of the classes had been moved from `./CRM` to `./tests/phpunit/CRM`. This has created some bonkers edge-cases (e.g. the case-activity example-data works normally in test-env, but it causes errors/failures at runtime).

This preserves the weird arrangement but makes it less breaky.

ping @eileenmcnaughton

Before
----------------------------------------

* `ExampleDataLoader` reported inconsistent (and slightly opaque) errors if the file-name/class-name mapping had any quirks.
* If any example data-sets exist under `tests/phpunit`, then they are scanned in any environment / at any time - but they can only be `include`d in the test-env. They raise errors in a regular web-env.
* Specifically, CaseActivity example-data is scanned by regular web-env consumer -- but it is not useful because the required business-class is weirdly/temporarily placed under `tests/phpunit`.

After
----------------------------------------

* `ExampleDataLoader` reports better (and more consistent) errors.
* Example data defined under `tests/phpunit` can be both scanned and loaded.
* Specifically, CaseActivity example-data will only load if the corresponding `CaseActivity` msg-class is valid.

