### PR TITLE
SearchKit - Fix links to non-aggregage join fields

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
@@ -620,13 +620,16 @@
           var join = searchMeta.getJoin(joinClause[0]),
             joinEntity = searchMeta.getEntity(join.entity),
             primaryKey = joinEntity.primary_key[0],
+            // Links for aggregate columns get aggregated using GROUP_CONCAT
             isAggregate = ctrl.canAggregate(join.alias + '.' + primaryKey),
-            joinPrefix = (isAggregate ? 'GROUP_CONCAT_' : '') + join.alias + '.',
+            joinPrefix = (isAggregate ? ctrl.DEFAULT_AGGREGATE_FN + '_' : '') + join.alias + '.',
             bridgeEntity = _.isString(joinClause[2]) ? searchMeta.getEntity(joinClause[2]) : null;
           _.each(joinEntity.paths, function(path) {
             var link = _.cloneDeep(path);
-            link.isAggregate = isAggregate;
-            link.path = link.path.replace(/\[/g, '[' + joinPrefix).replace(/[.:]/g, '_');
+            link.path = link.path.replace(/\[/g, '[' + joinPrefix);
+            if (isAggregate) {
+              link.path = link.path.replace(/[.:]/g, '_');
+            }
             link.join = join.alias;
             addTitle(link, join.label);
             links.push(link);


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a regression introduced by #21420

Before
----------------------------------------
Create a search for contacts with related contacts. Observe link to the related contact in the results column is broken.

After
----------------------------------------
Link fixed.
