### PR TITLE
Ensure we don't get previously set honoree values in receipts

### DIFF
--- a/CRM/Contribute/BAO/ContributionPage.php
+++ b/CRM/Contribute/BAO/ContributionPage.php
@@ -325,6 +325,10 @@ class CRM_Contribute_BAO_ContributionPage extends CRM_Contribute_DAO_Contributio
         }
         list($values['customPost_grouptitle'], $values['customPost']) = self::getProfileNameAndFields($postID, $userID, $params['custom_post_id']);
       }
+      // Assign honoree values for the receipt. But first, stop any leaks from
+      // previously assigned values.
+      $template->assign('honoreeProfile', []);
+      $template->assign('honorName', NULL);
       if (isset($values['honor'])) {
         $honorValues = $values['honor'];
         $template->_values = ['honoree_profile_id' => $values['honoree_profile_id']];


### PR DESCRIPTION
Overview
----------------------------------------
When processing a series of recurring contributions, the honoree info from previously processed contributions show up in the receipts of contributions processed later.

@adixon @KarinG - We encountered this bug with a group using Iats - and it may impact Iats more then other payment processors because Iats processes recurring contributions in single run rather then via individual webhook calls.

Before
----------------------------------------

When running a series of recurring contributions, if a contribution includes an honoree (soft credit), then that honoree will show up in all subsequent receipts that do not specify an honoree.

Here's what the first (correct) receipt looks like:

![correct-receipt](https://user-images.githubusercontent.com/4511942/133467244-87ffaa39-7e7d-4de7-9389-cee774f2ce30.png)

And a later (incorrect) receipt might look like this:

![incorrect-receipt](https://user-images.githubusercontent.com/4511942/133467420-619ca3b2-f5cc-45e1-9fb7-51f3b6124210.png)

After
----------------------------------------

By manualling clearing the variable, the incrrect data does not show up.

Technical Details
----------------------------------------

This behavior and fix are tested against 5.39. I'm sure I should submit a test to lock it in, but am a bit overwhelmed by all the moving parts of setting up the recurring contribution, checking the email etc.


