### PR TITLE
Add unique class to price field template

### DIFF
--- a/templates/CRM/Price/Form/PriceSet.tpl
+++ b/templates/CRM/Price/Form/PriceSet.tpl
@@ -29,7 +29,7 @@
         {* Skip 'Admin' visibility price fields WHEN this tpl is used in online registration unless user has administer CiviCRM permission. *}
         {if $element.visibility EQ 'public' || ($element.visibility EQ 'admin' && $adminFld EQ true) || $context eq 'standalone' || $context eq 'advanced' || $context eq 'search' || $context eq 'participant' || $context eq 'dashboard' || $action eq 1024}
             {if $element.help_pre}<span class="content description">{$element.help_pre}</span><br />{/if}
-            <div class="crm-section {$element.name}-section">
+            <div class="crm-section {$element.name}-section crm-price-field-id-{$field_id}">
             {if ($element.html_type eq 'CheckBox' || $element.html_type == 'Radio') && $element.options_per_line}
               {assign var="element_name" value="price_"|cat:$field_id}
               <div class="label">{$form.$element_name.label}</div>


### PR DESCRIPTION
Motivation
----------------------------------------
Currently, classes are assigned to price fields based on the 'name' of the price field, eg:

![image](https://user-images.githubusercontent.com/5212601/133475972-91ca9a87-2c11-4237-a0d0-62d121550467.png)

However:
- this is clunky to reference in CSS
- when a price set is 'copied' - the price fields are copied along with it, and they keep the same 'name' as the original, eg:

![image](https://user-images.githubusercontent.com/5212601/133476739-92552687-f40b-425d-b27e-b664a2d317eb.png)

... this can have the unintended consequence of customisations to one price field being cloned, and applying to the clone as well!

Solution
----------------------------------------

We don't want to change the current behaviour, as it might break peoples' templates and customisations.

However, let's add a new class to price fields, which includes the ID of the price field. This will make it easier to target them in CSS, and give them truly 'unique' names.

See the screenshots above, you can see the new classes 'crm-price-field-id-xxxx'

Technical Details
----------------------------------------

Minor template change to add a new css class in what seemed like a consistent format.
