### PR TITLE
(dev/mail#83) EntityTokens - Allow using mocked data

### DIFF
--- a/CRM/Core/EntityTokens.php
+++ b/CRM/Core/EntityTokens.php
@@ -293,6 +293,11 @@ class CRM_Core_EntityTokens extends AbstractTokenSubscriber {
    * @return string|int
    */
   protected function getFieldValue(TokenRow $row, string $field) {
+    $entityName = $this->getEntityName();
+    if (isset($row->context[$entityName][$field])) {
+      return $row->context[$entityName][$field];
+    }
+
     $actionSearchResult = $row->context['actionSearchResult'];
     $aliasedField = $this->getEntityAlias() . $field;
     if (isset($actionSearchResult->{$aliasedField})) {


### PR DESCRIPTION
Overview
----------------------------------------

This updates the wiring for certain token-providers (`{contribution.*}`, `{contribution_recur.*}`, etc) to follow a data-mocking pattern available to `{contact.*}` tokens. 

This is a step toward more responsive previewing/experimentation when editing message-templates.

Before
----------------------------------------

Tokens are generally based on entity-id as input, eg

```php
$proc->addRow([
  'contactId' => 123, 
  'contributionId' => 456, 
]);
```

The `{contact.*}` entity allows mocking or overriding specific data values, eg 

```php
$proc->addRow([
  'contactId' => 123, 
  'contact' => ['display_name' => 'Fake Name', ...],
  'contributionId' => 456, 
]);
```

However, this doesn't work with other entities.

After
----------------------------------------

Any entity based on `CRM_Core_EntityTokens` will support similar mocking/overriding, eg 

```php
$proc->addRow([
  'contactId' => 123, 
  'contact' => ['display_name' => 'Fake Name', ...],
  'contributionId' => 456, 
  'contribution' => ['net_amount' => 3211.23, 'invoice_id' => '888-999', ...],
]);
```
