### PR TITLE
SearchKit - Fix search display pager when using default pager settings

### DIFF
--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/Run.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/Run.php
@@ -45,7 +45,7 @@ class Run extends AbstractRunAction {
         break;
 
       default:
-        if (!empty($settings['pager']) && preg_match('/^page:\d+$/', $this->return)) {
+        if (($settings['pager'] ?? FALSE) !== FALSE && preg_match('/^page:\d+$/', $this->return)) {
           $page = explode(':', $this->return)[1];
         }
         $limit = !empty($settings['pager']['expose_limit']) && $this->limit ? $this->limit : NULL;


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a regression where the pager stopped working in Search Displays.
Regression was caused by #21069

Before
----------------------------------------
Create a new search display. Leave the pager settings at their default.
In the preview, notice that paging past page 1 still shows page 1 results.

After
----------------------------------------
Pager shows correct results for each page.