### PR TITLE
Fix activity tokens

### DIFF
--- a/CRM/Core/TokenTrait.php
+++ b/CRM/Core/TokenTrait.php
@@ -58,17 +58,15 @@ trait CRM_Core_TokenTrait {
 
   /**
    * Find the fields that we need to get to construct the tokens requested.
-   * @param  array $activeTokens list of active tokens
+   *
    * @return array         list of fields needed to generate those tokens
    */
-  public function getReturnFields($activeTokens) {
+  public function getReturnFields(): array {
     // Make sure we always return something
     $fields = ['id'];
 
-    $tokensInUse = array_intersect(
-      $activeTokens,
-      array_merge(array_keys(self::getBasicTokens()), array_keys(self::getCustomFieldTokens()))
-    );
+    $tokensInUse =
+      array_merge(array_keys(self::getBasicTokens()), array_keys(self::getCustomFieldTokens()));
     foreach ($tokensInUse as $token) {
       if (isset(self::$fieldMapping[$token])) {
         $fields = array_merge($fields, self::$fieldMapping[$token]);


### PR DESCRIPTION


Overview
----------------------------------------
Fix activity tokens 

Before
----------------------------------------
In testing for another PR @demeritcowboy and I were finding not all advertised tokens were being resolved 

After
----------------------------------------
Working, test cover extended, still passes action schedule token tests.

Technical Details
----------------------------------------
I wasn't gonna touch these until the end since my plan was to get comprehensive test cover in place
and migrate the ambigous tokens to the new style before figuring out the 'final look' of whatever
combo of parent class/ trait we use - but it turns out there is some active breakage.

This is not intended to be the 'final word' but just 'enough to get it working again & supported
the preferred tokens'

It leaves out of scope a final cleanup pass and
the reconcilliation between the trait & parent class
and any decisions about any finalised interface.

Existing tokens still work but new-style are advertised with this

This is the block I've been testing with - I also tried `{activity.location}`
```

Subject: {activity.subject}
Date: {activity.activity_date_time}
Duration: {activity.duration}
Location: {activity.location}
Details: {activity.details}
Status ID: {activity.status_id}
(legacy) Status: {activity.status}
Status: {activity.status_id:label}
Activity Type ID: {activity.activity_type_id}
(legacy) Activity Type: {activity.activity_type}
Activity Type: {activity.activity_type_id:label}
Activity ID: {activity.activity_id}
(legacy) Activity ID: {activity.id}

(just weird) Case ID: {activity.case_id}
```

Comments
----------------------------------------
Tests cover the changes to tokens and
testActivityDateTimeMatchRepeatableSchedule covers the schedule rendering

Note that if this is merged I'll action the updates to scheduled reminders, docs, and the form rules for pdf & email but I won't add any noise / break the legacy style tokens as there is higher risk this class is being used outside of core. At some point we can
