### PR TITLE
dev/core#2554 Remove code to assign contact to the template in sendEmail

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -1056,37 +1056,6 @@ class CRM_Activity_BAO_Activity extends CRM_Activity_DAO_Activity {
       $from = "$fromDisplayName <$fromEmail>";
     }
 
-    $returnProperties = [];
-    if (isset($messageToken['contact'])) {
-      foreach ($messageToken['contact'] as $key => $value) {
-        $returnProperties[$value] = 1;
-      }
-    }
-
-    if (isset($subjectToken['contact'])) {
-      foreach ($subjectToken['contact'] as $key => $value) {
-        if (!isset($returnProperties[$value])) {
-          $returnProperties[$value] = 1;
-        }
-      }
-    }
-
-    // get token details for contacts, call only if tokens are used
-    $details = [];
-    if (!empty($returnProperties) || !empty($tokens) || !empty($allTokens)) {
-      list($details) = CRM_Utils_Token::getTokenDetails(
-        $contactIds,
-        $returnProperties,
-        NULL, NULL, FALSE,
-        $allTokens,
-        'CRM_Activity_BAO_Activity'
-      );
-    }
-
-    $tokens = [];
-    CRM_Utils_Hook::tokens($tokens);
-    $categories = array_keys($tokens);
-
     $escapeSmarty = FALSE;
     if (defined('CIVICRM_MAIL_SMARTY') && CIVICRM_MAIL_SMARTY) {
       $smarty = CRM_Core_Smarty::singleton();
@@ -1120,13 +1089,6 @@ class CRM_Activity_BAO_Activity extends CRM_Activity_DAO_Activity {
         $html = $contributionDetails[$contactId]['html'];
       }
 
-      if (!empty($details) && is_array($details["{$contactId}"])) {
-        // unset email from details since it always returns primary email address
-        unset($details["{$contactId}"]['email']);
-        unset($details["{$contactId}"]['email_id']);
-        $values = array_merge($values, $details["{$contactId}"]);
-      }
-
       $tokenSubject = $subject;
       $tokenText = in_array($values['preferred_mail_format'], ['Both', 'Text'], TRUE) ? $text : '';
       $tokenHtml = in_array($values['preferred_mail_format'], ['Both', 'HTML'], TRUE) ? $html : '';
@@ -1140,7 +1102,6 @@ class CRM_Activity_BAO_Activity extends CRM_Activity_DAO_Activity {
         'tokenContext' => $caseId ? ['caseId' => $caseId] : [],
         'contactId' => $contactId,
         'disableSmarty' => !CRM_Utils_Constant::value('CIVICRM_MAIL_SMARTY'),
-        'tplParams' => ['contact' => $values],
       ]);
 
       $sent = FALSE;


### PR DESCRIPTION
Overview
----------------------------------------
Remove code to assign contact to the template in sendEmail 

Same logic as https://github.com/civicrm/civicrm-core/pull/21475

Before
----------------------------------------
Code does a lot of work to generate the variable `$contact` which is assigned to the template & usable IF CIVICRM_MAIL_Smarty is defined & true

After
----------------------------------------
Code removed - if sites really want this the can install https://github.com/eileenmcnaughton/legacytokenhelper
However, in my analysis for that I decided it was basically useless as only the requested tokens would be added to the assigned `$contact` object


Technical Details
----------------------------------------
@demeritcowboy 

Comments
----------------------------------------
Docs https://lab.civicrm.org/documentation/docs/sysadmin/-/merge_requests/318