### PR TITLE
Fixes dev/core#2840 bug in recent items sidebar/menu

### DIFF
--- a/CRM/Utils/Recent.php
+++ b/CRM/Utils/Recent.php
@@ -152,11 +152,11 @@ class CRM_Utils_Recent {
 
     self::$_recent = array_filter(self::$_recent, function($item) use ($props) {
       foreach ($props as $key => $val) {
-        if (isset($item[$key]) && $item[$key] == $val) {
-          return FALSE;
+        if (isset($item[$key]) && $item[$key] != $val) {
+          return TRUE;
         }
       }
-      return TRUE;
+      return FALSE;
     });
   }
 

--- a/tests/phpunit/api/v4/Action/RecentItemsTest.php
+++ b/tests/phpunit/api/v4/Action/RecentItemsTest.php
@@ -30,21 +30,32 @@ class RecentItemsTest extends UnitTestCase {
   public function testAddDeleteActivity(): void {
     $cid = $this->createLoggedInUser();
 
-    $aid = Activity::create(FALSE)
+    $aid1 = Activity::create(FALSE)
       ->addValue('activity_type_id:name', 'Meeting')
       ->addValue('source_contact_id', $cid)
       ->addValue('subject', 'Hello recent!')
       ->execute()->first()['id'];
-
-    $this->assertEquals(1, $this->getRecentItemCount(['type' => 'Activity', 'id' => $aid]));
-
+    $this->assertEquals(1, $this->getRecentItemCount(['type' => 'Activity', 'id' => $aid1]));
     $this->assertStringContainsString('Hello recent!', \CRM_Utils_Recent::get()[0]['title']);
 
-    Activity::delete(FALSE)->addWhere('id', '=', $aid)->execute();
+    $aid2 = Activity::create(FALSE)
+      ->addValue('activity_type_id:name', 'Meeting')
+      ->addValue('source_contact_id', $cid)
+      ->addValue('subject', 'Goodbye recent!')
+      ->execute()->first()['id'];
+    $this->assertEquals(1, $this->getRecentItemCount(['type' => 'Activity', 'id' => $aid2]));
+    $this->assertStringContainsString('Goodbye recent!', \CRM_Utils_Recent::get()[0]['title']);
 
-    $this->assertEquals(0, $this->getRecentItemCount(['type' => 'Activity', 'id' => $aid]));
+    Activity::delete(FALSE)->addWhere('id', '=', $aid1)->execute();
+
+    $this->assertEquals(0, $this->getRecentItemCount(['type' => 'Activity', 'id' => $aid1]));
+    $this->assertEquals(1, $this->getRecentItemCount(['type' => 'Activity', 'id' => $aid2]));
   }
 
+  /**
+   * @param array $props
+   * @return int
+   */
   private function getRecentItemCount($props) {
     $count = 0;
     foreach (\CRM_Utils_Recent::get() as $item) {


### PR DESCRIPTION
Overview
----------------------------------------
Fixes regression documented in https://lab.civicrm.org/dev/core/-/issues/2840

Before
----------------------------------------
Browse multiple contacts or other entities - the recent items list only contains the last one and no others

After
----------------------------------------
Recent items contains the correct number of items.
