### PR TITLE
dev/core#2839 Fix addition of _preview to filename

### DIFF
--- a/CRM/Contact/Form/Task/PDFTrait.php
+++ b/CRM/Contact/Form/Task/PDFTrait.php
@@ -158,26 +158,7 @@ trait CRM_Contact_Form_Task_PDFTrait {
 
     CRM_Mailing_BAO_Mailing::commonCompose($form);
 
-    $buttons = [];
-    if ($form->get('action') != CRM_Core_Action::VIEW) {
-      $buttons[] = [
-        'type' => 'upload',
-        'name' => ts('Download Document'),
-        'isDefault' => TRUE,
-        'icon' => 'fa-download',
-      ];
-      $buttons[] = [
-        'type' => 'submit',
-        'name' => ts('Preview'),
-        'subName' => 'preview',
-        'icon' => 'fa-search',
-        'isDefault' => FALSE,
-      ];
-    }
-    $buttons[] = [
-      'type' => 'cancel',
-      'name' => $form->get('action') == CRM_Core_Action::VIEW ? ts('Done') : ts('Cancel'),
-    ];
+    $buttons = $this->getButtons($form);
     $form->addButtons($buttons);
 
     $form->addFormRule(['CRM_Core_Form_Task_PDFLetterCommon', 'formRule'], $form);
@@ -232,10 +213,7 @@ trait CRM_Contact_Form_Task_PDFTrait {
    *     if the form controller does not exist), else FALSE
    */
   protected function isLiveMode(): bool {
-    // CRM-21255 - Hrm, CiviCase 4+5 seem to report buttons differently...
-    $buttonName = $this->controller->getButtonName();
-    $c = $this->controller->container();
-    return ($buttonName === '_qf_PDF_upload') || isset($c['values']['PDF']['buttons']['_qf_PDF_upload']);
+    return strpos($this->controller->getButtonName(), '_preview') === FALSE;
   }
 
   /**
@@ -559,6 +537,44 @@ trait CRM_Contact_Form_Task_PDFTrait {
       $m = implode($newLineOperators['br']['oper'], $messages);
     }
     $message = implode($newLineOperators['p']['oper'], $htmlMsg);
+  }
+
+  /**
+   * Get the buttons to display.
+   *
+   * @return array
+   */
+  protected function getButtons(): array {
+    $buttons = [];
+    if (!$this->isFormInViewMode()) {
+      $buttons[] = [
+        'type' => 'upload',
+        'name' => $this->getMainSubmitButtonName(),
+        'isDefault' => TRUE,
+        'icon' => 'fa-download',
+      ];
+      $buttons[] = [
+        'type' => 'submit',
+        'name' => ts('Preview'),
+        'subName' => 'preview',
+        'icon' => 'fa-search',
+        'isDefault' => FALSE,
+      ];
+    }
+    $buttons[] = [
+      'type' => 'cancel',
+      'name' => $this->isFormInViewMode() ? ts('Done') : ts('Cancel'),
+    ];
+    return $buttons;
+  }
+
+  /**
+   * Get the name for the main submit button.
+   *
+   * @return string
+   */
+  protected function getMainSubmitButtonName(): string {
+    return ts('Download Document');
   }
 
 }

--- a/tests/phpunit/CRM/Contact/Form/Task/PDFLetterCommonTest.php
+++ b/tests/phpunit/CRM/Contact/Form/Task/PDFLetterCommonTest.php
@@ -136,9 +136,7 @@ class CRM_Contact_Form_Task_PDFLetterCommonTest extends CiviUnitTestCase {
       'pdf_file_name' => 'pdf_file_name',
       'subject' => 'subject',
       'document_type' => 'pdf',
-      'buttons' => [
-        '_qf_PDF_upload' => $isLiveMode,
-      ],
+      '_qf_button_name' => ('_qf_PDF_upload' . (!$isLiveMode ? '_preview' : '')),
     ], $formValues));
     $form->_contactIds = $contactIDs;
     return $form;

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -3369,6 +3369,9 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
     if ($searchFormValues) {
       $_SESSION['_' . $form->controller->_name . '_container']['values']['Search'] = $searchFormValues;
     }
+    if (isset($formValues['_qf_button_name'])) {
+      $_SESSION['_' . $form->controller->_name . '_container']['_qf_button_name'] = $formValues['_qf_button_name'];
+    }
     return $form;
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#2839 Fix addition of _preview to filename

Note this also standardises the buttons with the other forms meaning that
1) the button is now 'download document' not 'make thank you letters and [UPDATE - the button name stayed the same in the end - see discussion]
2) the preview buttons is now available

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/133544645-8c429d27-8648-4b32-a88a-7ec7b07055b6.png)

After
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/133544609-a93d24f5-e115-4b81-b8a1-6bafc236b689.png)

Technical Details
----------------------------------------
The preview buttons doesn't create activities or update the thank you date/ receipt date

Comments
----------------------------------------
@agh1 @kcristiano @jusfreeman @Stoob - standardising the button name & adding the preview is a little easier to code cleanly than not doing so (but not critical to solving this issue) and it seems like an improvement to me - but if you think it's likely to be contentious I'll just fix the actual regression

Also note I removed the 'special handling' from this old ticket https://issues.civicrm.org/jira/browse/CRM-21255 - that I think is now un-needed

