### PR TITLE
dev/core#2814 TokenCompatSubscriber - evaluate contact tokens during civi.token.eval phase

### DIFF
--- a/Civi/Token/TokenCompatSubscriber.php
+++ b/Civi/Token/TokenCompatSubscriber.php
@@ -310,7 +310,7 @@ class TokenCompatSubscriber implements EventSubscriberInterface {
     $this->fieldMetadata = (array) civicrm_api4('Contact', 'getfields', ['checkPermissions' => FALSE], 'name');
 
     foreach ($e->getRows() as $row) {
-      if (empty($row->context['contactId'])) {
+      if (empty($row->context['contactId']) && empty($row->context['contact'])) {
         continue;
       }
 
@@ -344,8 +344,7 @@ class TokenCompatSubscriber implements EventSubscriberInterface {
           $row->format('text/plain')->tokens('contact', $token, '');
         }
         elseif ($token === 'signature_html') {
-          $text = html_entity_decode($row->context['contact'][$token]);
-          $row->format('text/html')->tokens('contact', $token, $value);
+          $row->format('text/html')->tokens('contact', $token, html_entity_decode($row->context['contact'][$token]));
         }
         else {
           $row->format('text/html')

--- a/Civi/Token/TokenProcessor.php
+++ b/Civi/Token/TokenProcessor.php
@@ -383,7 +383,7 @@ class TokenProcessor {
     // Regex examples: '{foo.bar}', '{foo.bar|whiz}'
     // Regex counter-examples: '{foobar}', '{foo bar}', '{$foo.bar}', '{$foo.bar|whiz}', '{foo.bar|whiz{bang}}'
     // Key observations: Civi tokens MUST have a `.` and MUST NOT have a `$`. Civi filters MUST NOT have `{}`s or `$`s.
-    $tokRegex = '([\w]+)\.([\w:]+)';
+    $tokRegex = '([\w]+)\.([\w:\.]+)';
     $filterRegex = '(\w+)';
     $event->string = preg_replace_callback(";\{$tokRegex(?:\|$filterRegex)?\};", $getToken, $message['string']);
     $this->dispatcher->dispatch('civi.token.render', $event);

--- a/tests/phpunit/CRM/Core/BAO/MessageTemplateTest.php
+++ b/tests/phpunit/CRM/Core/BAO/MessageTemplateTest.php
@@ -360,6 +360,16 @@ emo
 ';
     $expected .= $this->getExpectedContactOutput($address['id'], $tokenData, $messageContent['html']);
     $this->assertEquals($expected, $messageContent['html']);
+    $textDifferences = [
+      '<p>',
+      '</p>',
+      '<a href="http://civicrm.org" ',
+      'target="_blank">',
+      '</a>',
+    ];
+    foreach ($textDifferences as $html) {
+      $expected = str_replace($html, '', $expected);
+    }
     $this->assertEquals($expected, $messageContent['text']);
     $checksum_position = strpos($messageContent['subject'], 'cs=');
     $this->assertTrue($checksum_position !== FALSE);
@@ -773,7 +783,7 @@ phone_type:Mobile
 email:anthony_anderson@civicrm.org
 on_hold:
 signature_text:Yours sincerely
-signature_html:&lt;p&gt;Yours&lt;/p&gt;
+signature_html:<p>Yours</p>
 im_provider:1
 im:IM Screen Name
 openid:OpenID

--- a/tests/phpunit/CRM/Core/BAO/MessageTemplateTest.php
+++ b/tests/phpunit/CRM/Core/BAO/MessageTemplateTest.php
@@ -768,7 +768,7 @@ state_province:TX
 country:United States
 phone:123-456
 phone_ext:77
-phone_type_id:
+phone_type_id:2
 phone_type:Mobile
 email:anthony_anderson@civicrm.org
 on_hold:

--- a/tests/phpunit/CRM/Core/FormTest.php
+++ b/tests/phpunit/CRM/Core/FormTest.php
@@ -62,7 +62,7 @@ class CRM_Core_FormTest extends CiviUnitTestCase {
     ];
   }
 
-  public function testNewPriceField() {
+  public function testNewPriceField(): void {
     $this->createLoggedInUser();
 
     $priceSetId = $this->callAPISuccess('PriceSet', 'create', [


### PR DESCRIPTION
Overview
----------------------------------------
Same as https://github.com/civicrm/civicrm-core/pull/21449 but for contact tokens

Let's let the tests have at it first

There are a few contact tokens for which the existing  behavior is awkward/unappealing. These are changed. 

Before
----------------------------------------

* Token-evaluation is confusingly performed during the `civi.token.render` phase.
* The following tokens have awkward/unappealing behavior:
    * `{contact.signature_html}`: Returned HTML content, regardless of whether the email format was text or html.
    * `{contact.custom_9}` (*where the field is a url*) : Returned an `<a>` tag, regardless of whether the email format was text or html.

After
----------------------------------------
* Token-evaluation moved to `civi.token.eval` phase - note this results in some html being rendered as 'real ' html not encoded - but I think that is right
* The awkward tokens now behave as follows:
    * `{contact.signature_html}`: Return flagged HTML content. For HTML-format email, this still yields HTML content. But for text-format email, it converts to plain-text (decode-entities/strip-tags).
    * `{contact.custom_9}` (*where the field is a url*) : Returns an `<a>` tag for HTML. Omits the `<a>` tag for text.

Technical Details
----------------------------------------
I hack-handled all the discrepancies except the listed ones ^^

Comments
----------------------------------------

