### PR TITLE
SearchKit - Exclude custom fields from ON clause selector

### DIFF
--- a/Civi/Api4/Service/Spec/SpecFormatter.php
+++ b/Civi/Api4/Service/Spec/SpecFormatter.php
@@ -32,6 +32,8 @@ class SpecFormatter {
         $field->setName($data['custom_group_id.name'] . '.' . $data['name']);
       }
       else {
+        // Fields belonging to custom entities are treated as normal; type = Field instead of Custom
+        $field->setType('Field');
         $field->setTableName($data['custom_group_id.table_name']);
       }
       $field->setColumnName($data['column_name']);

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
@@ -423,9 +423,10 @@
       };
 
       function getFieldsForJoin(joinEntity) {
-        return {results: ctrl.getAllFields(':name', ['Field', 'Custom'], null, joinEntity)};
+        return {results: ctrl.getAllFields(':name', ['Field'], null, joinEntity)};
       }
 
+      // @return {function}
       $scope.fieldsForJoin = function(joinEntity) {
         if (!fieldsForJoinGetters[joinEntity]) {
           fieldsForJoinGetters[joinEntity] = _.wrap(joinEntity, getFieldsForJoin);

--- a/tests/phpunit/api/v4/Action/CustomValueTest.php
+++ b/tests/phpunit/api/v4/Action/CustomValueTest.php
@@ -84,7 +84,7 @@ class CustomValueTest extends BaseCustomValueTest {
     $expectedResult = [
       [
         'custom_group' => $group,
-        'type' => 'Custom',
+        'type' => 'Field',
         'name' => $colorFieldName,
         'title' => $colorFieldName,
         'entity' => "Custom_$group",
@@ -97,7 +97,7 @@ class CustomValueTest extends BaseCustomValueTest {
       ],
       [
         'custom_group' => $group,
-        'type' => 'Custom',
+        'type' => 'Field',
         'name' => $multiFieldName,
         'title' => $multiFieldName,
         'entity' => "Custom_$group",
@@ -110,7 +110,7 @@ class CustomValueTest extends BaseCustomValueTest {
       ],
       [
         'custom_group' => $group,
-        'type' => 'Custom',
+        'type' => 'Field',
         'name' => $textFieldName,
         'title' => $textFieldName,
         'entity' => "Custom_$group",


### PR DESCRIPTION
Overview
----------------------------------------
Custom fields cannot as-yet be added to an ON clause in APIv4 because they do not belong to the tables being joined.

This removes the tripping hazard from the UI, by making custom fields unavailable to select in an ON clause.

Before
----------------------------------------
Possible to add custom fields to ON clause in SearchKit, which crashes the SQL query.

After
----------------------------------------
Removed.

Comments
---------------
This problem was noticed while testing #21424 - it was noted that custom fields for bridge entities don't work in the ON clause. Further testing showed that custom fields for *any* entity don't work in the ON clause, so I thought it best to remove them from the selector completely.