### PR TITLE
[NFC] [test] minor cleanup in test

### DIFF
--- a/tests/phpunit/CRMTraits/Financial/OrderTrait.php
+++ b/tests/phpunit/CRMTraits/Financial/OrderTrait.php
@@ -28,7 +28,6 @@ trait CRMTraits_Financial_OrderTrait {
   public function createRepeatMembershipOrder(): void {
     $this->createExtraneousContribution();
     $this->ids['contact'][0] = $this->individualCreate();
-    $this->ids['membership_type'][0] = $this->membershipTypeCreate();
 
     $contributionRecur = $this->callAPISuccess('ContributionRecur', 'create', array_merge([
       'contact_id' => $this->_contactID,
@@ -59,7 +58,7 @@ trait CRMTraits_Financial_OrderTrait {
         [
           'params' => [
             'contact_id' => $this->ids['contact'][0],
-            'membership_type_id' => $this->ids['membership_type'][0],
+            'membership_type_id:name' => 'General',
             'contribution_recur_id' => $contributionRecur['id'],
             'source' => 'Payment',
           ],

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -2582,7 +2582,7 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
    * @param array $recurParams (Optional)
    * @param array $contributionParams (Optional)
    */
-  public function setupRecurringPaymentProcessorTransaction($recurParams = [], $contributionParams = []): void {
+  public function setupRecurringPaymentProcessorTransaction(array $recurParams = [], array $contributionParams = []): void {
     $this->ids['campaign'][0] = $this->callAPISuccess('Campaign', 'create', ['title' => 'get the money'])['id'];
     $contributionParams = array_merge([
       'total_amount' => '200',


### PR DESCRIPTION

Overview
----------------------------------------
[NFC] [test] minor cleanup in test

Before
----------------------------------------
This function in the order trait creates a membership

After
----------------------------------------
switches to using `restoreMembershipTypes` rather than creating a membership.


Technical Details
----------------------------------------
`restoreMembershipTypes` would ideally be in `tearDown` to get us back to a known membership
set but there is fallout

Comments
----------------------------------------
