### PR TITLE
Add sort functionality to event summary report

### DIFF
--- a/CRM/Report/Form/Event/Summary.php
+++ b/CRM/Report/Form/Event/Summary.php
@@ -85,6 +85,23 @@ class CRM_Report_Form_Event_Summary extends CRM_Report_Form {
             'operatorType' => CRM_Report_Form::OP_DATE,
           ],
         ],
+        'order_bys' => [
+          'event_start_date' => [
+            'title' => ts('Event Start Date'),
+            'default' => '1',
+            'default_weight' => '0',
+            'default_order' => 'DESC',
+          ],
+          'event_end_date' => [
+            'title' => ts('Event End Date'),
+          ],
+          'max_participants' => [
+            'title' => ts('Capacity'),
+          ],
+          'title' => [
+            'title' => ts('Event Title'),
+          ],
+        ],
       ],
     ];
     $this->_currencyColumn = 'civicrm_participant_fee_currency';


### PR DESCRIPTION
Before
----------------------------------------
No sorting tab on the 'Event summary' report. No way to configure sort columns.

After
----------------------------------------
Added sorting functionality, defaulted to 'event start date' descending. This is a required field for events, so will always be populated.

![image](https://user-images.githubusercontent.com/5212601/133595109-25083bf1-cf3a-4910-bf42-31e483670c7a.png)


Technical Details
----------------------------------------
Simple additions to report setup arrays, in line with other reports.
