### PR TITLE
Fixes dev/drupal#164 scss compile error

### DIFF
--- a/ext/greenwich/scss/_greenwich.scss
+++ b/ext/greenwich/scss/_greenwich.scss
@@ -566,7 +566,7 @@ $popover-arrow-color: $popover-bg;
 //** Popover outer arrow width
 $popover-arrow-outer-width: ($popover-arrow-width + 1);
 //** Popover outer arrow color
-$popover-arrow-outer-color: fadein($popover-border-color, 5%);
+$popover-arrow-outer-color: fade_in($popover-border-color, 0.05);
 //** Popover outer arrow fallback color
 $popover-arrow-outer-fallback-color: darken($popover-fallback-border-color, 20%);
 


### PR DESCRIPTION
Overview
----------------------------------------
Fixes bug reported in https://lab.civicrm.org/dev/drupal/-/issues/164

Before
----------------------------------------
Composer install crashes with fatal error when compiling Greenwich scss.

After
----------------------------------------
No error.