### PR TITLE
Add support for CiviCRM date formats in crmDate

### DIFF
--- a/CRM/Core/Smarty/plugins/modifier.crmDate.php
+++ b/CRM/Core/Smarty/plugins/modifier.crmDate.php
@@ -21,14 +21,36 @@
  * @param string $dateString
  *   Date which needs to converted to human readable format.
  *
- * @param null $dateFormat
+ * @param string|null $dateFormat
+ *   A string per https://www.php.net/manual/en/function.strftime.php or
+ *   one of our configured formats name - eg
+ *    - dateformatDatetime
+ *    - dateformatFull
+ *    - dateformatPartial
+ *    - dateformatTime
+ *    - dateformatYear
+ *    - dateformatFinancialBatch
+ *    - dateformatshortdate
+ *
  * @param bool $onlyTime
  *
  * @return string
  *   human readable date format | invalid date message
  */
-function smarty_modifier_crmDate($dateString, $dateFormat = NULL, $onlyTime = FALSE) {
+function smarty_modifier_crmDate($dateString, ?string $dateFormat = NULL, bool $onlyTime = FALSE): string {
   if ($dateString) {
+    $configuredFormats = [
+      'Datetime',
+      'Full',
+      'Partial',
+      'Time',
+      'Year',
+      'FinancialBatch',
+      'shortdate',
+    ];
+    if (in_array($dateFormat, $configuredFormats, TRUE)) {
+      $dateFormat = Civi::settings()->get('dateformat' . $dateFormat);
+    }
     // this check needs to be type sensitive
     // CRM-3689, CRM-2441
     if ($dateFormat === 0) {

--- a/tests/phpunit/CRM/Core/TokenSmartyTest.php
+++ b/tests/phpunit/CRM/Core/TokenSmartyTest.php
@@ -56,7 +56,7 @@ class CRM_Core_TokenSmartyTest extends CiviUnitTestCase {
   /**
    * A template that specifically opts out of Smarty.
    */
-  public function testDisableSmarty() {
+  public function testDisableSmarty(): void {
     $rendered = CRM_Core_TokenSmarty::render(
       ['msg_subject' => 'First name is {contact.first_name}. ExtraFoo is {$extra.foo}.'],
       ['contactId' => $this->contactId, 'smarty' => FALSE],
@@ -66,9 +66,39 @@ class CRM_Core_TokenSmartyTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test smarty rendered dates using the setting short name.
+   *
+   * @param string $format
+   * @param string $expected
+   *
+   * @dataProvider getDateFormats
+   */
+  public function testSmartySettingDates(string $format, string $expected = ''): void {
+    $date = '2010-09-19 13:34:45';
+    CRM_Core_Smarty::singleton()->assign('date', $date);
+    $string = '{$date|crmDate:' . $format . '}';
+    $this->assertEquals($expected, CRM_Utils_String::parseOneOffStringThroughSmarty($string));
+  }
+
+  /**
+   * Get date formats to test.
+   */
+  public function getDateFormats(): array {
+    return [
+      ['Full', 'September 19th, 2010'],
+      ['Datetime', 'September 19th, 2010  1:34 PM'],
+      ['Partial', 'September 2010'],
+      ['Time', ' 1:34 PM'],
+      ['Year', '2010'],
+      ['FinancialBatch', '09/19/2010'],
+      ['shortdate', '09/19/2010'],
+    ];
+  }
+
+  /**
    * Someone malicious gives cutesy expressions (via token-content) that tries to provoke extra evaluation.
    */
-  public function testCutesyTokenData() {
+  public function testCutesyTokenData(): void {
     $cutesyContactId = $this->individualCreate([
       'first_name' => '{$extra.foo}{contact.last_name}',
       'last_name' => 'Roberts',
@@ -84,7 +114,7 @@ class CRM_Core_TokenSmartyTest extends CiviUnitTestCase {
   /**
    * Someone malicious gives cutesy expressions (via Smarty-content) that tries to provoke extra evaluation.
    */
-  public function testCutesySmartyData() {
+  public function testCutesySmartyData(): void {
     $rendered = CRM_Core_TokenSmarty::render(
       ['msg_subject' => 'First name is {contact.first_name}. ExtraFoo is {$extra.foo}.'],
       ['contactId' => $this->contactId],
@@ -96,7 +126,7 @@ class CRM_Core_TokenSmartyTest extends CiviUnitTestCase {
   /**
    * The same tokens are used in multiple parts of the template - without redundant evaluation.
    */
-  public function testDataLoadCount() {
+  public function testDataLoadCount(): void {
     // Define a token `{counter.i}` which increments whenever tokens are evaluated.
     Civi::dispatcher()->addListener('civi.token.eval', function (\Civi\Token\Event\TokenValueEvent $e) {
       static $i;


### PR DESCRIPTION
Overview
----------------------------------------
Add support for CiviCRM date formats in crmDate

Before
----------------------------------------
Smarty can parse a date like

`{$date|crmDate:%b}`

But it cannot get the dates configured for the site

After
----------------------------------------
`{$date|crmDate:shortdate}`
`{$date|crmDate:Datetime}`
`{$date|crmDate:Partial}`
`{$date|crmDate:Year}`
`{$date|crmDate:FinancialBatch}`
`{$date|crmDate:Time}`
`{$date|crmDate:Full}`

e.g
```
   return [
      ['Full', 'September 19th, 2010'],
      ['Datetime', 'September 19th, 2010  1:34 PM'],
      ['Partial', 'September 2010'],
      ['Time', ' 1:34 PM'],
      ['Year', '2010'],
      ['FinancialBatch', '09/19/2010'],
      ['shortdate', '09/19/2010'],
    ];
```

Technical Details
----------------------------------------

Comments
----------------------------------------
@totten this is good from the smarty pov.

I had an idea that I would separate out date tokens & add 'now'' to that for adding tests for use in token processor (& add that)