### PR TITLE
dev/core#2820: Deduping produces bad results after a rule change

### DIFF
--- a/CRM/Contact/Form/DedupeRules.php
+++ b/CRM/Contact/Form/DedupeRules.php
@@ -298,7 +298,7 @@ UPDATE civicrm_dedupe_rule_group
 
     //need to clear cache of deduped contacts
     //based on the previous rule
-    $cacheKey = "merge {$this->_contactType}_{$this->_rgid}_%";
+    $cacheKey = "merge_{$this->_contactType}_{$this->_rgid}_%";
 
     CRM_Core_BAO_PrevNextCache::deleteItem(NULL, $cacheKey);
 


### PR DESCRIPTION
Overview
----------------------------------------
When a dedupe rule is changed, the results appear to be cached.

Reproduction steps
----------------------------------------
1. Create a dedupe rule on 'Last Name' weight 5, 'First Name' weight 5, threshold 5.
1. Run a dedupe search with this rule - should show contacts with either first or last matching names
1. Edit the dedupe rule, change the threshold to 10.
1. Run a dedupe search with this rule

Before
----------------------------------------
Shows previous results - those with first or last matching names.  Click the 'Threshold' box and note scores of 5 - below the specified threshold of 10.

After
----------------------------------------
Should only list contacts with matching first and last names where threshold score is 10.


Technical Details
----------------------------------------
Regression is caused by https://github.com/civicrm/civicrm-core/commit/9d2f6d53cdd5f06b15dbdaa844c4dbca1a5292cb#diff-fe60c89ebe94bbd40114d135459371cc53708db1f2952ade6c0ce9b3468c4dabR2038 this change and affecting since 5.3.0

Fixed by correcting the cache key which is used to fetch and delete the cache of previous dedupe rule.

Comments
----------------------------------------
ping @eileenmcnaughton @aydun 