### PR TITLE
dev/core#2816: New contribution can't be saved when validation fails …

### DIFF
--- a/CRM/Contribute/Form/AdditionalInfo.php
+++ b/CRM/Contribute/Form/AdditionalInfo.php
@@ -190,10 +190,16 @@ class CRM_Contribute_Form_AdditionalInfo {
     if (!empty($options[$selectedProductID])) {
       $dao->product_option = $options[$selectedProductID][$selectedProductOptionID];
     }
-    if ($premiumID) {
+
+    // This IF condition codeblock does the following:
+    // 1. If premium is present then get previous contribution-product mapping record (if any) based on contribtuion ID.
+    //   If found and the product chosen doesn't matches with old done, then delete or else set the ID for update
+    // 2. If no product is chosen theb delete the previous contribution-product mapping record based on contribtuion ID.
+    if ($premiumID || empty($selectedProductID)) {
       $ContributionProduct = new CRM_Contribute_DAO_ContributionProduct();
-      $ContributionProduct->id = $premiumID;
+      $ContributionProduct->contribution_id = $contributionID;
       $ContributionProduct->find(TRUE);
+      // here $selectedProductID can be 0 in case one unselect the premium product on backoffice update form
       if ($ContributionProduct->product_id == $selectedProductID) {
         $dao->id = $premiumID;
       }
@@ -203,7 +209,11 @@ class CRM_Contribute_Form_AdditionalInfo {
       }
     }
 
-    $dao->save();
+    // only add/update contribution product when a product is selected
+    if (!empty($selectedProductID)) {
+      $dao->save();
+    }
+
     //CRM-11106
     if ($premiumID == NULL || $isDeleted) {
       $premiumParams = [


### PR DESCRIPTION
Overview
----------------------------------------
Steps to replicate: 

1. Define a premium product.
1. Contributions - New Contribution
1. Fill out the contact and the amount, but forget, let's say, the financial type.
1. Click save.
1. Ok it warns you and reloads the form.
1. Now pick Donation.
1. Click save.

Before
----------------------------------------
![before](https://user-images.githubusercontent.com/3735621/133768066-1db93dd6-4c56-4b2c-bb40-0c8e0aa5cc48.gif)

After
----------------------------------------
![after](https://user-images.githubusercontent.com/3735621/133768100-56d11fe1-e01c-4b32-820e-1f10de5e6948.gif)


Technical Details
----------------------------------------
Regression is caused in 'New Contribution' backoffice form from 5.40 onward, when civicrm_contribution_product.product_id is set as a foreignkey of civicrm_product.id [here](https://github.com/civicrm/civicrm-core/commit/930c05e087ba98388489bc80c638acfab3f4597c). As a result the previously code used to insert product_id = 0 for back office contribution and now it ends up in a DB error due to nonexistent product_id = 0. Rest assured  this doesn't break CiviCRM upgrade from 5.40 onward because of this DELETE SQL [here](https://github.com/civicrm/civicrm-core/blob/master/CRM/Upgrade/Incremental/php/FiveForty.php#L95) which also delete entries with non-existent product_ids. 

As per the fix is concern, I am not in support of changing the placeholder `- select -` value to '' from 0, because 0 serves as an indicator on the backoffice contribution edit screen, when one removes the previous product selection.  

Comments
----------------------------------------
ping @eileenmcnaughton @seamuslee001 @colemanw  