### PR TITLE
Fix issues with case sorting/searching from case dashboard

### DIFF
--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -416,6 +416,8 @@ WHERE cc.contact_id = %1 AND civicrm_case_type.name = '{$caseType}'";
       "GROUP_CONCAT(DISTINCT IF(case_relationship.contact_id_b = $userID, case_relation_type.label_a_b, case_relation_type.label_b_a) SEPARATOR ', ') as case_role",
       't_act.activity_date_time as activity_date_time',
       't_act.id as activity_id',
+      'case_status.label AS case_status',
+      'civicrm_case_type.title AS case_type',
     ];
 
     $query = CRM_Contact_BAO_Query::appendAnyValueToSelect($selectClauses, 'case_id');
@@ -424,6 +426,11 @@ WHERE cc.contact_id = %1 AND civicrm_case_type.name = '{$caseType}'";
       FROM civicrm_case
         INNER JOIN civicrm_case_contact ON civicrm_case.id = civicrm_case_contact.case_id
         INNER JOIN civicrm_contact ON civicrm_case_contact.contact_id = civicrm_contact.id
+        LEFT JOIN civicrm_case_type ON civicrm_case.case_type_id = civicrm_case_type.id
+        LEFT JOIN civicrm_option_group option_group_case_status ON ( option_group_case_status.name = 'case_status' )
+        LEFT JOIN civicrm_option_value case_status ON ( civicrm_case.status_id = case_status.value
+          AND option_group_case_status.id = case_status.option_group_id )
+
 HERESQL;
 
     // 'upcoming' and 'recent' show the next scheduled and most recent

--- a/CRM/Case/Selector/Search.php
+++ b/CRM/Case/Selector/Search.php
@@ -354,7 +354,7 @@ class CRM_Case_Selector_Search extends CRM_Core_Selector_Base {
       $rows[$result->case_id] = $row;
     }
 
-    //retrive the scheduled & recent Activity type and date for selector
+    //retrieve the scheduled & recent Activity type and date for selector
     if (!empty($scheduledInfo)) {
       $schdeduledActivity = CRM_Case_BAO_Case::getNextScheduledActivity($scheduledInfo, 'upcoming');
       foreach ($schdeduledActivity as $key => $value) {
@@ -417,12 +417,12 @@ class CRM_Case_Selector_Search extends CRM_Core_Selector_Base {
         ],
         [
           'name' => ts('Most Recent'),
-          'sort' => 'case_recent_activity_date',
+          // @fixme: Triggers DB error field not found on "Find Cases": 'sort' => 'case_recent_activity_date',
           'direction' => CRM_Utils_Sort::DONTCARE,
         ],
         [
           'name' => ts('Next Sched.'),
-          'sort' => 'case_scheduled_activity_date',
+          // @fixme: Triggers DB error field not found on "Find Cases": 'sort' => 'case_scheduled_activity_date',
           'direction' => CRM_Utils_Sort::DONTCARE,
         ],
         ['name' => ts('Actions')],


### PR DESCRIPTION
Overview
----------------------------------------
* Fixes https://lab.civicrm.org/dev/core/-/issues/1624: Case Dashboard/Dashlet gives datatables error if sort by type or status:
Now works!

* "Fixes" https://lab.civicrm.org/dev/core/-/issues/2319: Network error when trying to sort results by 'Next Scheduled date':
Disables sorting on most recent / next scheduled. This is better than before where it allows you to sort but then triggers a DB error whenever you try. It looks more complex to actually make the sort work because of the complexity of the query and dependencies internally in CiviCRM.

Before
----------------------------------------
500 / network error when sorting by status/type.

After
----------------------------------------
Sorting/searching works without error.

Technical Details
----------------------------------------
See lab issues

Comments
----------------------------------------
@demeritcowboy 
