### PR TITLE
Fix PropertyBag setRecurInstallments to accept 0

### DIFF
--- a/Civi/Payment/PropertyBag.php
+++ b/Civi/Payment/PropertyBag.php
@@ -1037,7 +1037,10 @@ class PropertyBag implements \ArrayAccess {
    */
   public function setRecurInstallments($recurInstallments, $label = 'default') {
     // Counts zero as positive which is ok - means no installments
-    if (!\CRM_Utils_Type::validate($recurInstallments, 'Positive')) {
+    try {
+      \CRM_Utils_Type::validate($recurInstallments, 'Positive');
+    }
+    catch (\CRM_Core_Exception $e) {
       throw new InvalidArgumentException('recurInstallments must be 0 or a positive integer');
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
Installments were added to `\Civi\Payment\PropertyBag` in https://github.com/civicrm/civicrm-core/pull/20023 but the setter does not work for the value "0" because of a mistake in the validation code.

Before
----------------------------------------
`setRecurInstallments(0)` does not work.

After
----------------------------------------
`setRecurInstallments(0)` works.

Technical Details
----------------------------------------
`!($result)` is treated as FALSE when we don't want to treat 0 as FALSE.

Comments
----------------------------------------
