### PR TITLE
dev/core#2832 Switch membership pdf to use token processor

### DIFF
--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -1276,6 +1276,8 @@ class CRM_Utils_Token {
    * Get Membership Token Details.
    * @param array $membershipIDs
    *   Array of membership IDS.
+   *
+   * @deprecated
    */
   public static function getMembershipTokenDetails($membershipIDs) {
     $memberships = civicrm_api3('membership', 'get', [

--- a/tests/phpunit/CRM/Member/Form/Task/PDFLetterTest.php
+++ b/tests/phpunit/CRM/Member/Form/Task/PDFLetterTest.php
@@ -60,8 +60,8 @@ class CRM_Member_Form_Task_PDFLetterTest extends CiviUnitTestCase {
       $params = array_merge($params,
         [
           'fee' => '100.00',
-          'type' => 'General',
-          'status' => 'New',
+          'membership_type_id:label' => 'General',
+          'status_id:label' => 'New',
         ]
       );
 
@@ -105,8 +105,8 @@ class CRM_Member_Form_Task_PDFLetterTest extends CiviUnitTestCase {
   public static function getSampleHTML() {
     $tokens = [
       'Test Fee' => 'fee',
-      'Test Type' => 'type',
-      'Test Status' => 'status',
+      'Test Type' => 'membership_type_id:label',
+      'Test Status' => 'status_id:label',
       'Test Join Date' => 'join_date',
       'Test Start Date' => 'start_date',
       'Test End Date' => 'end_date',


### PR DESCRIPTION

Overview
----------------------------------------
dev/core#2832 Switch membership pdf to use token processor

Replaces final instances of `replaceEntityTokens`

https://lab.civicrm.org/dev/core/-/issues/2832

Before
----------------------------------------
legacy function used for membership tokens

After
----------------------------------------
token processor used

Technical Details
----------------------------------------
Test cover in tests/phpunit/CRM/Member/Form/Task/PDFLetterTest.php

Note that the alterations to that test are for token changes previously documented here and for which we added a rule to prevent them being submitted

Also note that I updated the deprecated class with the same change in order to make it easier to see the function is no longer used

https://lab.civicrm.org/documentation/docs/sysadmin/-/merge_requests/318

Comments
----------------------------------------
