### PR TITLE
dev/core#2851 Remove calls to replaceContributionTokens in contribution pdf letter task

### DIFF
--- a/CRM/Contribute/Form/Task/PDFLetter.php
+++ b/CRM/Contribute/Form/Task/PDFLetter.php
@@ -546,19 +546,19 @@ class CRM_Contribute_Form_Task_PDFLetter extends CRM_Contribute_Form_Task {
    * @return string
    */
   protected function resolveTokens(string $html_message, $contact, $contribution, $messageToken, $grouped, $separator, $contributions): string {
-    if ($grouped) {
-      $tokenHtml = CRM_Utils_Token::replaceMultipleContributionTokens($separator, $html_message, $contributions, $messageToken);
-    }
-    else {
-      // no change to normal behaviour to avoid risk of breakage
-      $tokenHtml = CRM_Utils_Token::replaceContributionTokens($html_message, $contribution, TRUE, $messageToken);
-    }
     $tokenContext = [
       'smarty' => (defined('CIVICRM_MAIL_SMARTY') && CIVICRM_MAIL_SMARTY),
       'contactId' => $contact['contact_id'],
     ];
+    if ($grouped) {
+      $html_message = CRM_Utils_Token::replaceMultipleContributionTokens($separator, $html_message, $contributions, $messageToken);
+    }
+    else {
+      $tokenContext['schema'] = ['contributionId'];
+      $tokenContext['contributionId'] = $contribution['id'];
+    }
     $smarty = ['contact' => $contact];
-    return CRM_Core_TokenSmarty::render(['html' => $tokenHtml], $tokenContext, $smarty)['html'];
+    return CRM_Core_TokenSmarty::render(['html' => $html_message], $tokenContext, $smarty)['html'];
   }
 
 }

--- a/Civi/Token/TokenRow.php
+++ b/Civi/Token/TokenRow.php
@@ -186,7 +186,7 @@ class TokenRow {
       $fieldValue = \CRM_Core_BAO_CustomField::displayValue($fieldValue, $customFieldID);
     }
 
-    return $this->tokens($entity, $customFieldName, $fieldValue);
+    return $this->format('text/html')->tokens($entity, $customFieldName, $fieldValue);
   }
 
   /**

--- a/tests/phpunit/CRM/Contribute/Form/Task/PDFLetterCommonTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/Task/PDFLetterCommonTest.php
@@ -297,19 +297,19 @@ class CRM_Contribute_Form_Task_PDFLetterCommonTest extends CiviUnitTestCase {
   <body>
     <div id="crm-container">
 id : 1
-total_amount : € 9,999.99
-fee_amount : € 1,111.11
-net_amount : € 7,777.78
-non_deductible_amount : € 2,222.22
+total_amount : &euro; 9,999.99
+fee_amount : &euro; 1,111.11
+net_amount : &euro; 7,777.78
+non_deductible_amount : &euro; 2,222.22
 receive_date : July 20th, 2018 12:00 AM
 payment_instrument_id:label : Check
 trxn_id : 1234
 invoice_id : 568
 currency : EUR
-cancel_date : 2019-12-30 00:00:00
+cancel_date : December 30th, 2019 12:00 AM
 cancel_reason : Contribution Cancel Reason
 receipt_date : October 30th, 2019 12:00 AM
-thankyou_date : 2019-11-30 00:00:00
+thankyou_date : November 30th, 2019 12:00 AM
 source : Contribution Source
 amount_level : Amount Level
 contribution_status_id : 2

--- a/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
+++ b/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
@@ -470,8 +470,8 @@ event description
 Emerald City, Maine 90210
 
 $ 50.00
-' . CRM_Utils_System::url('civicrm/event/info', NULL, TRUE) . '&amp;reset=1&amp;id=1
-' . CRM_Utils_System::url('civicrm/event/register', NULL, TRUE) . '&amp;reset=1&amp;id=1
+' . CRM_Utils_System::url('civicrm/event/info', NULL, TRUE) . '&reset=1&id=1
+' . CRM_Utils_System::url('civicrm/event/register', NULL, TRUE) . '&reset=1&id=1
 
 my field';
   }


### PR DESCRIPTION
Overview
----------------------------------------
Remove calls to replaceContributionTokens in pdf letter task (for non-grouped contributions)

Before
----------------------------------------
Legacy method used to resolve contribution tokens in contribution pdf letter task

After
----------------------------------------
Token processor used - legacy style still used for 'multiple contribution tokens' - but I have a plan for that

Technical Details
----------------------------------------


Note the output of cancel_date & thankyou_date is now date style - I've updated the upgrade notes for this. I expect wanting non-formatted (or these tokens at all) would be pretty edge https://lab.civicrm.org/-/ide/project/documentation/docs/sysadmin/tree/case/-/


Comments
----------------------------------------
This builds on https://github.com/civicrm/civicrm-core/pull/21525 which also makes minor token changes (added to the same docs PR) - for those we are changing the token syntax not the output so we can block the old syntax & advertise the new