### PR TITLE
dev/core#2851 Block use of legacy style contribution tokens

### DIFF
--- a/CRM/Contact/Form/Task/EmailTrait.php
+++ b/CRM/Contact/Form/Task/EmailTrait.php
@@ -692,6 +692,10 @@ trait CRM_Contact_Form_Task_EmailTrait {
     $deprecatedTokens = [
       '{case.status_id}' => '{case.status_id:label}',
       '{case.case_type_id}' => '{case.case_type_id:label}',
+      '{contribution.campaign}' => '{contribution.campaign_id:label}',
+      '{contribution.payment_instrument}' => '{contribution.payment_instrument_id:label}',
+      '{contribution.contribution_id}' => '{contribution.id}',
+      '{contribution.contribution_source}' => '{contribution.source}',
     ];
     $tokenErrors = [];
     foreach ($deprecatedTokens as $token => $replacement) {

--- a/CRM/Core/Form/Task/PDFLetterCommon.php
+++ b/CRM/Core/Form/Task/PDFLetterCommon.php
@@ -209,6 +209,10 @@ class CRM_Core_Form_Task_PDFLetterCommon {
       '{case.case_type_id}' => '{case.case_type_id:label}',
       '{membership.status}' => '{membership.status_id:label}',
       '{membership.type}' => '{membership.membership_type_id:label}',
+      '{contribution.campaign}' => '{contribution.campaign_id:label}',
+      '{contribution.payment_instrument}' => '{contribution.payment_instrument_id:label}',
+      '{contribution.contribution_id}' => '{contribution.id}',
+      '{contribution.contribution_source}' => '{contribution.source}',
     ];
     $tokenErrors = [];
     foreach ($deprecatedTokens as $token => $replacement) {

--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -1777,7 +1777,7 @@ class CRM_Utils_Token {
    * @return mixed|string
    * @throws \CRM_Core_Exception
    */
-  public static function getContributionTokenReplacement($token, &$contribution, $html = FALSE, $escapeSmarty = FALSE) {
+  public static function getContributionTokenReplacement($token, $contribution, $html = FALSE, $escapeSmarty = FALSE) {
     self::_buildContributionTokens();
 
     switch ($token) {
@@ -1796,6 +1796,10 @@ class CRM_Utils_Token {
         $value = CRM_Utils_Array::retrieveValueRecursive($contribution, $token);
         $config = CRM_Core_Config::singleton();
         $value = CRM_Utils_Date::customFormat($value, $config->dateformatDatetime);
+        break;
+
+      case 'source':
+        $value = CRM_Utils_Array::retrieveValueRecursive($contribution, 'contribution_source');
         break;
 
       default:

--- a/tests/phpunit/CRM/Contribute/Form/Task/PDFLetterCommonTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/Task/PDFLetterCommonTest.php
@@ -265,7 +265,6 @@ class CRM_Contribute_Form_Task_PDFLetterCommonTest extends CiviUnitTestCase {
    * @throws \API_Exception
    * @throws \CRM_Core_Exception
    * @throws \CiviCRM_API3_Exception
-   * @throws \Civi\API\Exception\UnauthorizedException
    */
   public function testAllContributionTokens(): void {
     $this->createLoggedInUser();
@@ -281,7 +280,7 @@ class CRM_Contribute_Form_Task_PDFLetterCommonTest extends CiviUnitTestCase {
     }
     /* @var $form CRM_Contribute_Form_Task_PDFLetter */
     $form = $this->getFormObject('CRM_Contribute_Form_Task_PDFLetter', $formValues);
-    $form->setContributionIds([$this->createContribution(array_merge(['campaign_id' => $tokens['campaign']], $tokens))]);
+    $form->setContributionIds([$this->createContribution(array_merge(['campaign_id' => $tokens['campaign_id:label']], $tokens))]);
     try {
       $form->postProcess();
     }
@@ -297,13 +296,13 @@ class CRM_Contribute_Form_Task_PDFLetterCommonTest extends CiviUnitTestCase {
 ' . "    \n" . '  </head>
   <body>
     <div id="crm-container">
-contribution_id : 1
+id : 1
 total_amount : € 9,999.99
 fee_amount : € 1,111.11
 net_amount : € 7,777.78
 non_deductible_amount : € 2,222.22
 receive_date : July 20th, 2018 12:00 AM
-payment_instrument : Check
+payment_instrument_id:label : Check
 trxn_id : 1234
 invoice_id : 568
 currency : EUR
@@ -311,11 +310,11 @@ cancel_date : 2019-12-30 00:00:00
 cancel_reason : Contribution Cancel Reason
 receipt_date : October 30th, 2019 12:00 AM
 thankyou_date : 2019-11-30 00:00:00
-contribution_source : Contribution Source
+source : Contribution Source
 amount_level : Amount Level
 contribution_status_id : 2
 check_number : 6789
-campaign : Big one
+campaign_id:label : Big one
 ' . $this->getCustomFieldName('text') . ' : Bobsled
 ' . $this->getCustomFieldName('select_string') . ' : Red
 ' . $this->getCustomFieldName('select_date') . ' : 01/20/2021 12:00AM
@@ -337,17 +336,16 @@ campaign : Big one
    * Get all the tokens available to contributions.
    *
    * @return array
-   * @throws \CiviCRM_API3_Exception
    */
   public function getAllContributionTokens(): array {
     return [
-      'contribution_id' => '',
+      'id' => '',
       'total_amount' => '9999.99',
       'fee_amount' => '1111.11',
       'net_amount' => '7777.78',
       'non_deductible_amount' => '2222.22',
       'receive_date' => '2018-07-20',
-      'payment_instrument' => 'Check',
+      'payment_instrument_id:label' => 'Check',
       'trxn_id' => '1234',
       'invoice_id' => '568',
       'currency' => 'EUR',
@@ -355,11 +353,11 @@ campaign : Big one
       'cancel_reason' => 'Contribution Cancel Reason',
       'receipt_date' => '2019-10-30',
       'thankyou_date' => '2019-11-30',
-      'contribution_source' => 'Contribution Source',
+      'source' => 'Contribution Source',
       'amount_level' => 'Amount Level',
       'contribution_status_id' => 'Pending',
       'check_number' => '6789',
-      'campaign' => 'Big one',
+      'campaign_id:label' => 'Big one',
       $this->getCustomFieldName('text') => 'Bobsled',
       $this->getCustomFieldName('select_string') => 'R',
       $this->getCustomFieldName('select_date') => '2021-01-20',
@@ -373,7 +371,6 @@ campaign : Big one
       $this->getCustomFieldName('boolean') => TRUE,
       $this->getCustomFieldName('checkbox') => 'P',
       $this->getCustomFieldName('contact_reference') => $this->individualCreate(['first_name' => 'Spider', 'last_name' => 'Man']),
-
     ];
   }
 
@@ -675,6 +672,7 @@ value=$contact_aggregate+$contribution.total_amount}
       'contact_id' => $this->individualCreate(),
       'total_amount' => 100,
       'financial_type_id' => 'Donation',
+      'source' => 'Contribution Source',
     ], $contributionParams);
     return $this->callAPISuccess('Contribution', 'create', $contributionParams)['id'];
   }


### PR DESCRIPTION
Overview
----------------------------------------
Block use of legacy style contribution tokens

`ReplaceContributionTokens` is only used from the pdf letter and email tasks and this prepares us to swap those places to the token processor by preventing people from attempting to submit the old style tokens from those screens (which also allows us to stop testing them & switch to testing the new style)

This puts them in the validation rule to prevent form submission with them
and switches the test over to the preferred / advertised tokens

Before
----------------------------------------
Legacy tokens are not 'advertised' on the pdf / email forms but text with them can still be submitted and it will still render

|Old| New|
|----|----|
|{contribution.campaign}|{contribution.campaign_id:label}|
|{contribution.contribution_id}|{contribution.id}|
|{contribution.contribution_source}|{contribution.source}|
|{contribution.payment_instrument}|{contribution.payment_instrument:label}|

After
----------------------------------------
Form validation fails on the pdf & email tasks for contributions if the legacy tokens are included

Technical Details
----------------------------------------
Preparation for switching to the token processor

https://github.com/civicrm/civicrm-core/pull/21524

Comments
----------------------------------------

Docs https://lab.civicrm.org/-/ide/project/documentation/docs/sysadmin/tree/case/-/docs/upgrade/version-specific.md/
