### PR TITLE
WIP Multiple fixes/improvements to \Civi\Payment\PropertyBag

### DIFF
--- a/Civi/Payment/PropertyBag.php
+++ b/Civi/Payment/PropertyBag.php
@@ -184,13 +184,16 @@ class PropertyBag implements \ArrayAccess {
       }
     }
 
+    // These lines are here (and not in try block) because the catch must only
+    // catch the case when the prop is custom.
+    $getter = 'get' . ucfirst($prop);
     if (!$this->getSuppressLegacyWarnings()) {
       CRM_Core_Error::deprecatedFunctionWarning(
         "get" . ucfirst($offset) . "()",
         "PropertyBag array access for core property '$offset'"
       );
     }
-    return $this->get($prop, 'default');
+    return $this->$getter('default');
   }
 
   /**
@@ -753,6 +756,9 @@ class PropertyBag implements \ArrayAccess {
    * @return string
    */
   public function getDescription($label = 'default') {
+    if (!$this->has('description')) {
+      return '';
+    }
     return $this->get('description', $label);
   }
 
@@ -840,6 +846,9 @@ class PropertyBag implements \ArrayAccess {
    * @return string|null
    */
   public function getInvoiceID($label = 'default') {
+    if (!$this->has('invoiceID')) {
+      $this->set('invoiceID', $label, md5(uniqid(mt_rand(), TRUE)));
+    }
     return $this->get('invoiceID', $label);
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
* Map additional legacy params to propertyBag standard params.
* Add in `billingStateProvince` and getter/setter which is required for full billingAddress coverage.
* Ensure that property "getter" is used instead of generic getter (so we don't skip special handling eg. default for `getIsRecur()`).
* For billing address fields make sure we actually return the "new"/propertyBag name if we have a legacy property.
* Add default for non "essential" property `description` = ''
* Add default for `invoiceID` - generate per CiviCRM core if not defined - makes invoiceID generation consistent if using propertyBag for payment and does not rely on calling code to make sure it has been generated. Calling code can generate if it wants to.

Before
----------------------------------------
Missing functionality and some bugs

After
----------------------------------------
More functionality and less bugs

Technical Details
----------------------------------------


Comments
----------------------------------------
