### PR TITLE
SearchKit - Support multiple arguments to field transformations aka SQL functions

### DIFF
--- a/CRM/Api4/Page/Api4Explorer.php
+++ b/CRM/Api4/Page/Api4Explorer.php
@@ -59,6 +59,7 @@ class CRM_Api4_Page_Api4Explorer extends CRM_Core_Page {
           $fns[] = [
             'name' => $className::getName(),
             'title' => $className::getTitle(),
+            'description' => $className::getDescription(),
             'params' => $className::getParams(),
             'category' => $className::getCategory(),
             'dataType' => $className::getDataType(),

--- a/Civi/Api4/Query/SqlExpression.php
+++ b/Civi/Api4/Query/SqlExpression.php
@@ -73,11 +73,10 @@ abstract class SqlExpression {
    * @param string $expression
    * @param bool $parseAlias
    * @param array $mustBe
-   * @param array $cantBe
    * @return SqlExpression
    * @throws \API_Exception
    */
-  public static function convert(string $expression, $parseAlias = FALSE, $mustBe = [], $cantBe = ['SqlWild']) {
+  public static function convert(string $expression, $parseAlias = FALSE, $mustBe = []) {
     $as = $parseAlias ? strrpos($expression, ' AS ') : FALSE;
     $expr = $as ? substr($expression, 0, $as) : $expression;
     $alias = $as ? \CRM_Utils_String::munge(substr($expression, $as + 4), '_', 256) : NULL;
@@ -114,11 +113,6 @@ abstract class SqlExpression {
       throw new \API_Exception('Unable to parse sql expression: ' . $expression);
     }
     $sqlExpression = new $className($expr, $alias);
-    foreach ($cantBe as $cant) {
-      if (is_a($sqlExpression, __NAMESPACE__ . '\\' . $cant)) {
-        throw new \API_Exception('Illegal sql expression.');
-      }
-    }
     if ($mustBe) {
       foreach ($mustBe as $must) {
         if (is_a($sqlExpression, __NAMESPACE__ . '\\' . $must)) {

--- a/Civi/Api4/Query/SqlFunction.php
+++ b/Civi/Api4/Query/SqlFunction.php
@@ -283,4 +283,9 @@ abstract class SqlFunction extends SqlExpression {
    */
   abstract public static function getTitle(): string;
 
+  /**
+   * @return string
+   */
+  abstract public static function getDescription(): string;
+
 }

--- a/Civi/Api4/Query/SqlFunction.php
+++ b/Civi/Api4/Query/SqlFunction.php
@@ -67,7 +67,7 @@ abstract class SqlFunction extends SqlExpression {
         'suffix' => [],
       ];
       if ($param['max_expr'] && (!$param['name'] || $param['name'] === $prefix)) {
-        $exprs = $this->captureExpressions($arg, $param['must_be'], $param['cant_be']);
+        $exprs = $this->captureExpressions($arg, $param['must_be']);
         if (count($exprs) < $param['min_expr'] || count($exprs) > $param['max_expr']) {
           throw new \API_Exception('Incorrect number of arguments for SQL function ' . static::getName());
         }
@@ -116,17 +116,16 @@ abstract class SqlFunction extends SqlExpression {
    *
    * @param string $arg
    * @param array $mustBe
-   * @param array $cantBe
    * @return array
    * @throws \API_Exception
    */
-  private function captureExpressions(&$arg, $mustBe, $cantBe) {
+  private function captureExpressions(&$arg, $mustBe) {
     $captured = [];
     $arg = ltrim($arg);
     while ($arg) {
       $item = $this->captureExpression($arg);
       $arg = ltrim(substr($arg, strlen($item)));
-      $expr = SqlExpression::convert($item, FALSE, $mustBe, $cantBe);
+      $expr = SqlExpression::convert($item, FALSE, $mustBe);
       $this->fields = array_merge($this->fields, $expr->getFields());
       $captured[] = $expr;
       // Keep going if we have a comma indicating another expression follows
@@ -253,8 +252,7 @@ abstract class SqlFunction extends SqlExpression {
         'flag_before' => [],
         'flag_after' => [],
         'optional' => FALSE,
-        'must_be' => [],
-        'cant_be' => ['SqlWild'],
+        'must_be' => ['SqlField', 'SqlFunction', 'SqlString', 'SqlNumber', 'SqlNull'],
         'api_default' => NULL,
       ];
     }

--- a/Civi/Api4/Query/SqlFunction.php
+++ b/Civi/Api4/Query/SqlFunction.php
@@ -147,7 +147,6 @@ abstract class SqlFunction extends SqlExpression {
    * @return string
    */
   private function captureExpression($arg) {
-    $chars = str_split($arg);
     $isEscaped = $quote = NULL;
     $item = '';
     $quotes = ['"', "'"];
@@ -155,7 +154,7 @@ abstract class SqlFunction extends SqlExpression {
       ')' => '(',
     ];
     $enclosures = array_fill_keys($brackets, 0);
-    foreach ($chars as $index => $char) {
+    foreach (str_split($arg) as $char) {
       if (!$isEscaped && in_array($char, $quotes, TRUE)) {
         // Open quotes - we'll ignore everything inside
         if (!$quote) {

--- a/Civi/Api4/Query/SqlFunctionABS.php
+++ b/Civi/Api4/Query/SqlFunctionABS.php
@@ -31,7 +31,14 @@ class SqlFunctionABS extends SqlFunction {
    * @return string
    */
   public static function getTitle(): string {
-    return ts('Absolute');
+    return ts('Absolute value');
+  }
+
+  /**
+   * @return string
+   */
+  public static function getDescription(): string {
+    return ts('The positive value of a number.');
   }
 
 }

--- a/Civi/Api4/Query/SqlFunctionAVG.php
+++ b/Civi/Api4/Query/SqlFunctionAVG.php
@@ -34,4 +34,11 @@ class SqlFunctionAVG extends SqlFunction {
     return ts('Average');
   }
 
+  /**
+   * @return string
+   */
+  public static function getDescription(): string {
+    return ts('The mean of all values in the grouping.');
+  }
+
 }

--- a/Civi/Api4/Query/SqlFunctionBINARY.php
+++ b/Civi/Api4/Query/SqlFunctionBINARY.php
@@ -34,4 +34,11 @@ class SqlFunctionBINARY extends SqlFunction {
     return ts('Binary');
   }
 
+  /**
+   * @return string
+   */
+  public static function getDescription(): string {
+    return ts('Case-sensitive string treatment.');
+  }
+
 }

--- a/Civi/Api4/Query/SqlFunctionCOALESCE.php
+++ b/Civi/Api4/Query/SqlFunctionCOALESCE.php
@@ -36,4 +36,11 @@ class SqlFunctionCOALESCE extends SqlFunction {
     return ts('Coalesce');
   }
 
+  /**
+   * @return string
+   */
+  public static function getDescription(): string {
+    return ts('The first value that is not null.');
+  }
+
 }

--- a/Civi/Api4/Query/SqlFunctionCONCAT.php
+++ b/Civi/Api4/Query/SqlFunctionCONCAT.php
@@ -34,7 +34,14 @@ class SqlFunctionCONCAT extends SqlFunction {
    * @return string
    */
   public static function getTitle(): string {
-    return ts('Combine');
+    return ts('Combine text');
+  }
+
+  /**
+   * @return string
+   */
+  public static function getDescription(): string {
+    return ts('Multiple values concatenated into a single string.');
   }
 
 }

--- a/Civi/Api4/Query/SqlFunctionCOUNT.php
+++ b/Civi/Api4/Query/SqlFunctionCOUNT.php
@@ -26,7 +26,6 @@ class SqlFunctionCOUNT extends SqlFunction {
         'flag_before' => ['DISTINCT' => ts('Distinct')],
         'max_expr' => 1,
         'must_be' => ['SqlField', 'SqlWild'],
-        'cant_be' => [],
       ],
     ];
   }

--- a/Civi/Api4/Query/SqlFunctionCOUNT.php
+++ b/Civi/Api4/Query/SqlFunctionCOUNT.php
@@ -38,4 +38,11 @@ class SqlFunctionCOUNT extends SqlFunction {
     return ts('Count');
   }
 
+  /**
+   * @return string
+   */
+  public static function getDescription(): string {
+    return ts('The number of items in the grouping.');
+  }
+
 }

--- a/Civi/Api4/Query/SqlFunctionCURDATE.php
+++ b/Civi/Api4/Query/SqlFunctionCURDATE.php
@@ -29,4 +29,11 @@ class SqlFunctionCURDATE extends SqlFunction {
     return ts('Now');
   }
 
+  /**
+   * @return string
+   */
+  public static function getDescription(): string {
+    return ts('The current date.');
+  }
+
 }

--- a/Civi/Api4/Query/SqlFunctionDATE.php
+++ b/Civi/Api4/Query/SqlFunctionDATE.php
@@ -33,7 +33,14 @@ class SqlFunctionDATE extends SqlFunction {
    * @return string
    */
   public static function getTitle(): string {
-    return ts('Date Only');
+    return ts('Date only');
+  }
+
+  /**
+   * @return string
+   */
+  public static function getDescription(): string {
+    return ts('Only the date portion of a date/time.');
   }
 
 }

--- a/Civi/Api4/Query/SqlFunctionGREATEST.php
+++ b/Civi/Api4/Query/SqlFunctionGREATEST.php
@@ -36,4 +36,11 @@ class SqlFunctionGREATEST extends SqlFunction {
     return ts('Greatest');
   }
 
+  /**
+   * @return string
+   */
+  public static function getDescription(): string {
+    return ts('The largest of all provided values.');
+  }
+
 }

--- a/Civi/Api4/Query/SqlFunctionGREATEST.php
+++ b/Civi/Api4/Query/SqlFunctionGREATEST.php
@@ -24,6 +24,7 @@ class SqlFunctionGREATEST extends SqlFunction {
     return [
       [
         'max_expr' => 99,
+        'min_expr' => 2,
         'optional' => FALSE,
       ],
     ];

--- a/Civi/Api4/Query/SqlFunctionGROUP_CONCAT.php
+++ b/Civi/Api4/Query/SqlFunctionGROUP_CONCAT.php
@@ -80,4 +80,11 @@ class SqlFunctionGROUP_CONCAT extends SqlFunction {
     return ts('List');
   }
 
+  /**
+   * @return string
+   */
+  public static function getDescription(): string {
+    return ts('All values in the grouping.');
+  }
+
 }

--- a/Civi/Api4/Query/SqlFunctionGROUP_CONCAT.php
+++ b/Civi/Api4/Query/SqlFunctionGROUP_CONCAT.php
@@ -29,14 +29,14 @@ class SqlFunctionGROUP_CONCAT extends SqlFunction {
         'optional' => FALSE,
       ],
       [
-        'prefix' => 'ORDER BY',
+        'name' => 'ORDER BY',
         'max_expr' => 1,
         'flag_after' => ['ASC' => ts('Ascending'), 'DESC' => ts('Descending')],
         'must_be' => ['SqlField'],
         'optional' => TRUE,
       ],
       [
-        'prefix' => 'SEPARATOR',
+        'name' => 'SEPARATOR',
         'max_expr' => 1,
         'must_be' => ['SqlString'],
         'optional' => TRUE,

--- a/Civi/Api4/Query/SqlFunctionIF.php
+++ b/Civi/Api4/Query/SqlFunctionIF.php
@@ -34,7 +34,14 @@ class SqlFunctionIF extends SqlFunction {
    * @return string
    */
   public static function getTitle(): string {
-    return ts('If');
+    return ts('If/Else');
+  }
+
+  /**
+   * @return string
+   */
+  public static function getDescription(): string {
+    return ts('If the field is empty, the first value, otherwise the second.');
   }
 
 }

--- a/Civi/Api4/Query/SqlFunctionISNULL.php
+++ b/Civi/Api4/Query/SqlFunctionISNULL.php
@@ -35,4 +35,11 @@ class SqlFunctionISNULL extends SqlFunction {
     return ts('Is null');
   }
 
+  /**
+   * @return string
+   */
+  public static function getDescription(): string {
+    return ts('TRUE if the value is NULL, otherwise FALSE.');
+  }
+
 }

--- a/Civi/Api4/Query/SqlFunctionLEAST.php
+++ b/Civi/Api4/Query/SqlFunctionLEAST.php
@@ -36,4 +36,11 @@ class SqlFunctionLEAST extends SqlFunction {
     return ts('Least');
   }
 
+  /**
+   * @return string
+   */
+  public static function getDescription(): string {
+    return ts('The smallest of all provided values.');
+  }
+
 }

--- a/Civi/Api4/Query/SqlFunctionLEAST.php
+++ b/Civi/Api4/Query/SqlFunctionLEAST.php
@@ -24,6 +24,7 @@ class SqlFunctionLEAST extends SqlFunction {
     return [
       [
         'max_expr' => 99,
+        'min_expr' => 2,
         'optional' => FALSE,
       ],
     ];

--- a/Civi/Api4/Query/SqlFunctionLOWER.php
+++ b/Civi/Api4/Query/SqlFunctionLOWER.php
@@ -36,4 +36,11 @@ class SqlFunctionLOWER extends SqlFunction {
     return ts('Lowercase');
   }
 
+  /**
+   * @return string
+   */
+  public static function getDescription(): string {
+    return ts('Lowercase version of text.');
+  }
+
 }

--- a/Civi/Api4/Query/SqlFunctionMAX.php
+++ b/Civi/Api4/Query/SqlFunctionMAX.php
@@ -36,4 +36,11 @@ class SqlFunctionMAX extends SqlFunction {
     return ts('Max');
   }
 
+  /**
+   * @return string
+   */
+  public static function getDescription(): string {
+    return ts('The largest value in the grouping.');
+  }
+
 }

--- a/Civi/Api4/Query/SqlFunctionMIN.php
+++ b/Civi/Api4/Query/SqlFunctionMIN.php
@@ -36,4 +36,11 @@ class SqlFunctionMIN extends SqlFunction {
     return ts('Min');
   }
 
+  /**
+   * @return string
+   */
+  public static function getDescription(): string {
+    return ts('The smallest value in the grouping.');
+  }
+
 }

--- a/Civi/Api4/Query/SqlFunctionNULLIF.php
+++ b/Civi/Api4/Query/SqlFunctionNULLIF.php
@@ -34,7 +34,14 @@ class SqlFunctionNULLIF extends SqlFunction {
    * @return string
    */
   public static function getTitle(): string {
-    return ts('Null if');
+    return ts('Unequal');
+  }
+
+  /**
+   * @return string
+   */
+  public static function getDescription(): string {
+    return ts('The first value, only if it is not equal to the second.');
   }
 
 }

--- a/Civi/Api4/Query/SqlFunctionRAND.php
+++ b/Civi/Api4/Query/SqlFunctionRAND.php
@@ -26,7 +26,14 @@ class SqlFunctionRAND extends SqlFunction {
    * @return string
    */
   public static function getTitle(): string {
-    return ts('Random Number');
+    return ts('Random number');
+  }
+
+  /**
+   * @return string
+   */
+  public static function getDescription(): string {
+    return ts('Generates a random number between 0 and 1.');
   }
 
 }

--- a/Civi/Api4/Query/SqlFunctionREPLACE.php
+++ b/Civi/Api4/Query/SqlFunctionREPLACE.php
@@ -24,7 +24,7 @@ class SqlFunctionREPLACE extends SqlFunction {
         'min_expr' => 3,
         'max_expr' => 3,
         'optional' => FALSE,
-        'must_be' => ['SqlField', 'SqlString'],
+        'must_be' => ['SqlString', 'SqlField'],
       ],
     ];
   }
@@ -33,7 +33,14 @@ class SqlFunctionREPLACE extends SqlFunction {
    * @return string
    */
   public static function getTitle(): string {
-    return ts('Replace');
+    return ts('Replace text');
+  }
+
+  /**
+   * @return string
+   */
+  public static function getDescription(): string {
+    return ts('Substitutes one value for another in the text.');
   }
 
 }

--- a/Civi/Api4/Query/SqlFunctionROUND.php
+++ b/Civi/Api4/Query/SqlFunctionROUND.php
@@ -22,11 +22,9 @@ class SqlFunctionROUND extends SqlFunction {
     return [
       [
         'optional' => FALSE,
-        'must_be' => ['SqlField', 'SqlNumber'],
-      ],
-      [
-        'optional' => TRUE,
-        'must_be' => ['SqlNumber'],
+        'min_expr' => 1,
+        'max_expr' => 2,
+        'must_be' => ['SqlNumber', 'SqlField'],
       ],
     ];
   }
@@ -36,6 +34,13 @@ class SqlFunctionROUND extends SqlFunction {
    */
   public static function getTitle(): string {
     return ts('Round');
+  }
+
+  /**
+   * @return string
+   */
+  public static function getDescription(): string {
+    return ts('Number rounded to specified number of decimal places.');
   }
 
 }

--- a/Civi/Api4/Query/SqlFunctionSUM.php
+++ b/Civi/Api4/Query/SqlFunctionSUM.php
@@ -34,4 +34,11 @@ class SqlFunctionSUM extends SqlFunction {
     return ts('Sum');
   }
 
+  /**
+   * @return string
+   */
+  public static function getDescription(): string {
+    return ts('The sum of all values in the grouping.');
+  }
+
 }

--- a/Civi/Api4/Query/SqlFunctionTIME.php
+++ b/Civi/Api4/Query/SqlFunctionTIME.php
@@ -33,7 +33,14 @@ class SqlFunctionTIME extends SqlFunction {
    * @return string
    */
   public static function getTitle(): string {
-    return ts('Time Only');
+    return ts('Time only');
+  }
+
+  /**
+   * @return string
+   */
+  public static function getDescription(): string {
+    return ts('Only the time portaion of a date/time.');
   }
 
 }

--- a/Civi/Api4/Query/SqlFunctionUPPER.php
+++ b/Civi/Api4/Query/SqlFunctionUPPER.php
@@ -36,4 +36,11 @@ class SqlFunctionUPPER extends SqlFunction {
     return ts('Uppercase');
   }
 
+  /**
+   * @return string
+   */
+  public static function getDescription(): string {
+    return ts('Uppercase version of text.');
+  }
+
 }

--- a/Civi/Api4/Query/SqlFunctionYEAR.php
+++ b/Civi/Api4/Query/SqlFunctionYEAR.php
@@ -36,4 +36,11 @@ class SqlFunctionYEAR extends SqlFunction {
     return ts('Year Only');
   }
 
+  /**
+   * @return string
+   */
+  public static function getDescription(): string {
+    return ts('Only the year of a date.');
+  }
+
 }

--- a/ang/api4Explorer/Explorer.js
+++ b/ang/api4Explorer/Explorer.js
@@ -456,8 +456,8 @@
             children: _.transform(CRM.vars.api4.functions, function(result, fn) {
               result.push({
                 id: fn.name + '() AS ' + fn.name.toLowerCase(),
-                text: fn.name + '()',
-                description: fn.name + '(' + describeSqlFn(fn.params) + ')'
+                description: fn.description,
+                text: fn.name + '(' + describeSqlFn(fn.params) + ')'
               });
             })
           };
@@ -607,16 +607,19 @@
       var desc = ' ';
       _.each(params, function(param) {
         desc += ' ';
-        if (param.prefix) {
-          desc += _.filter(param.prefix).join('|') + ' ';
+        if (param.name) {
+          desc += param.name + ' ';
         }
-        if (param.expr === 1) {
+        if (!_.isEmpty(param.flag_before)) {
+          desc += '[' + _.filter(param.name ? [param.name] : _.keys(param.flag_before)).join('|') + '] ';
+        }
+        if (param.max_expr === 1) {
           desc += 'expr ';
-        } else if (param.expr > 1) {
+        } else if (param.max_expr > 1) {
           desc += 'expr, ... ';
         }
-        if (param.suffix) {
-          desc += ' ' + _.filter(param.suffix).join('|') + ' ';
+        if (!_.isEmpty(param.flag_after)) {
+          desc += ' [' + _.filter(param.flag_after).join('|') + '] ';
         }
       });
       return desc.replace(/[ ]+/g, ' ');

--- a/ext/afform/admin/Civi/Api4/Action/Afform/LoadAdminData.php
+++ b/ext/afform/admin/Civi/Api4/Action/Afform/LoadAdminData.php
@@ -273,9 +273,12 @@ class LoadAdminData extends \Civi\Api4\Generic\AbstractAction {
     foreach ($apiParams['select'] ?? [] as $select) {
       if (strstr($select, ' AS ')) {
         $expr = SqlExpression::convert($select, TRUE);
-        $field = $expr->getFields() ? $selectQuery->getField($expr->getFields()[0]) : NULL;
-        $joinName = explode('.', $expr->getFields()[0] ?? '')[0];
-        $label = $expr::getTitle() . ': ' . (isset($joinMap[$joinName]) ? $joinMap[$joinName] . ' ' : '') . $field['title'];
+        $label = $expr::getTitle();
+        foreach ($expr->getFields() as $num => $fieldName) {
+          $field = $selectQuery->getField($fieldName);
+          $joinName = explode('.', $fieldName)[0];
+          $label .= ($num ? ', ' : ': ') . (isset($joinMap[$joinName]) ? $joinMap[$joinName] . ' ' : '') . $field['title'];
+        }
         $calcFields[] = [
           '#tag' => 'af-field',
           'name' => $expr->getAlias(),

--- a/ext/search_kit/ang/crmSearchAdmin/compose.html
+++ b/ext/search_kit/ang/crmSearchAdmin/compose.html
@@ -35,17 +35,6 @@
                crm-ui-select="{placeholder: ts('Group By'), data: fieldsForGroupBy, dropdownCss: {width: '300px'}}"
                on-crm-ui-select="$ctrl.addParam('groupBy', selection)" >
       </div>
-      <fieldset id="crm-search-build-functions">
-        <legend ng-click="controls.showFunctions = !controls.showFunctions">
-          <i class="crm-i fa-caret-{{ !controls.showFunctions ? 'right' : 'down' }}"></i>
-          {{:: ts('Field Transformations') }}
-        </legend>
-        <div ng-if="!!controls.showFunctions">
-          <fieldset ng-repeat="col in $ctrl.savedSearch.api_params.select" ng-if="!$ctrl.isPseudoField(col)">
-            <crm-search-function expr="$ctrl.savedSearch.api_params.select[$index]"></crm-search-function>
-          </fieldset>
-        </div>
-      </fieldset>
     </fieldset>
   </div>
   <div class="crm-search-criteria-column">
@@ -57,3 +46,15 @@
     </fieldset>
   </div>
 </div>
+<fieldset id="crm-search-build-functions">
+  <legend ng-click="controls.showFunctions = !controls.showFunctions">
+    <i class="crm-i fa-caret-{{ !controls.showFunctions ? 'right' : 'down' }}"></i>
+    {{:: ts('Field Transformations') }}
+  </legend>
+  <div ng-if="!!controls.showFunctions">
+    <!-- Must use track by $index with an array of primitives, and manually refresh this loop when indexes change -->
+    <fieldset ng-repeat="col in $ctrl.savedSearch.api_params.select track by $index" ng-if="!$ctrl.isPseudoField(col)">
+      <crm-search-function expr="$ctrl.savedSearch.api_params.select[$index]"></crm-search-function>
+    </fieldset>
+  </div>
+</fieldset>

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
@@ -297,7 +297,7 @@
       function reconcileAggregateColumns() {
         _.each(ctrl.savedSearch.api_params.select, function(col, pos) {
           var info = searchMeta.parseExpr(col),
-            fieldExpr = info.path + info.suffix;
+            fieldExpr = (_.findWhere(info.args, {type: 'field'}) || {}).value;
           if (ctrl.canAggregate(col)) {
             // Ensure all non-grouped columns are aggregated if using GROUP BY
             if (!info.fn || info.fn.category !== 'aggregate') {
@@ -405,14 +405,18 @@
         if (!ctrl.savedSearch.api_params.groupBy.length) {
           return false;
         }
-        var info = searchMeta.parseExpr(col);
+        var arg = _.findWhere(searchMeta.parseExpr(col).args, {type: 'field'}) || {};
+        // If the column is not a database field, no
+        if (!arg.field || !arg.field.entity || arg.field.type !== 'Field') {
+          return false;
+        }
         // If the column is used for a groupBy, no
-        if (ctrl.savedSearch.api_params.groupBy.indexOf(info.path) > -1) {
+        if (ctrl.savedSearch.api_params.groupBy.indexOf(arg.path) > -1) {
           return false;
         }
         // If the entity this column belongs to is being grouped by primary key, then also no
-        var idField = searchMeta.getEntity(info.field.entity).primary_key[0];
-        return ctrl.savedSearch.api_params.groupBy.indexOf(info.prefix + idField) < 0;
+        var idField = searchMeta.getEntity(arg.field.entity).primary_key[0];
+        return ctrl.savedSearch.api_params.groupBy.indexOf(arg.prefix + idField) < 0;
       };
 
       $scope.fieldsForGroupBy = function() {
@@ -534,7 +538,7 @@
           var item = {
             id: info.alias,
             text: ctrl.getFieldLabel(name),
-            description: info.field && info.field.description
+            description: info.fn ? info.fn.description : info.args[0].field && info.args[0].field.description
           };
           if (disabledIf(item.id)) {
             item.disabled = true;
@@ -662,10 +666,10 @@
         // Links to implicit joins
         _.each(ctrl.savedSearch.api_params.select, function(fieldName) {
           if (!_.includes(fieldName, ' AS ')) {
-            var info = searchMeta.parseExpr(fieldName);
+            var info = searchMeta.parseExpr(fieldName).args[0];
             if (info.field && !info.suffix && !info.fn && info.field.type === 'Field' && (info.field.fk_entity || info.field.name !== info.field.fieldName)) {
               var idFieldName = info.field.fk_entity ? fieldName : fieldName.substr(0, fieldName.lastIndexOf('.')),
-                idField = searchMeta.parseExpr(idFieldName).field;
+                idField = searchMeta.parseExpr(idFieldName).args[0].field;
               if (!ctrl.canAggregate(idFieldName)) {
                 var joinEntity = searchMeta.getEntity(idField.fk_entity),
                   label = (idField.join ? idField.join.label + ': ' : '') + (idField.input_attrs && idField.input_attrs.label || idField.label);

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
@@ -383,7 +383,15 @@
 
       // Deletes an item from an array param
       this.clearParam = function(name, idx) {
+        if (name === 'select') {
+          // Function selectors use `ng-repeat` with `track by $index` so must be refreshed when splicing the array
+          ctrl.hideFuncitons();
+        }
         ctrl.savedSearch.api_params[name].splice(idx, 1);
+      };
+
+      this.hideFuncitons = function() {
+        $scope.controls.showFunctions = false;
       };
 
       function onChangeSelect(newSelect, oldSelect) {

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminDisplay.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminDisplay.component.js
@@ -158,19 +158,25 @@
         }
 
         var info = searchMeta.parseExpr(col.key),
+          field = info.args[0] && info.args[0].field,
           value = col.key.split(':')[0];
+        if (!field || info.fn) {
+          delete col.editable;
+          return;
+        }
         // If field is an implicit join, use the original fk field
-        if (info.field.name !== info.field.fieldName) {
+        if (field.name !== field.fieldName) {
           value = value.substr(0, value.lastIndexOf('.'));
           info = searchMeta.parseExpr(value);
+          field = info.args[0].field;
         }
         col.editable = {
-          entity: info.field.baseEntity,
-          options: !!info.field.options,
-          serialize: !!info.field.serialize,
-          fk_entity: info.field.fk_entity,
+          entity: field.baseEntity,
+          options: !!field.options,
+          serialize: !!field.serialize,
+          fk_entity: field.fk_entity,
           id: info.prefix + 'id',
-          name: info.field.name,
+          name: field.name,
           value: value
         };
       };
@@ -178,7 +184,7 @@
       this.isEditable = function(col) {
         var expr = ctrl.getExprFromSelect(col.key),
           info = searchMeta.parseExpr(expr);
-        return !col.image && !col.rewrite && !col.link && !info.fn && info.field && !info.field.readonly;
+        return !col.image && !col.rewrite && !col.link && !info.fn && info.args[0] && info.args[0].field && !info.args[0].field.readonly;
       };
 
       // Aggregate functions (COUNT, AVG, MAX) cannot display as links, except for GROUP_CONCAT

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchClause.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchClause.component.js
@@ -63,14 +63,14 @@
 
       this.getField = function(expr) {
         if (!meta[expr]) {
-          meta[expr] = searchMeta.parseExpr(expr);
+          meta[expr] = searchMeta.parseExpr(expr).args[0];
         }
         return meta[expr].field;
       };
 
       this.getOptionKey = function(expr) {
         if (!meta[expr]) {
-          meta[expr] = searchMeta.parseExpr(expr);
+          meta[expr] = _.findWhere(searchMeta.parseExpr(expr).args, {type: 'field'});
         }
         return meta[expr].suffix ? meta[expr].suffix.slice(1) : 'id';
       };

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchFunction.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchFunction.component.js
@@ -21,39 +21,57 @@
         string: ts('Text')
       };
 
-      $scope.$watch('$ctrl.expr', function(expr) {
-        var fieldInfo = searchMeta.parseExpr(expr);
-        ctrl.path = fieldInfo.path + fieldInfo.suffix;
-        ctrl.field = [fieldInfo.field];
-        ctrl.fn = !fieldInfo.fn ? '' : fieldInfo.fn.name;
-        ctrl.modifier = fieldInfo.modifier || null;
+      this.exprTypes = {
+        SqlField: {label: ts('Field'), type: 'field'},
+        SqlString: {label: ts('Text'), type: 'string'},
+        SqlNumber: {label: ts('Number'), type: 'number'},
+      };
+
+      this.$onInit = function() {
+        var info = searchMeta.parseExpr(ctrl.expr);
+        ctrl.args = info.args;
+        ctrl.fn = info.fn;
+        ctrl.fnName = !info.fn ? '' : info.fn.name;
         initFunction();
-      });
+      };
+
+      this.addArg = function(exprType) {
+        exprType = exprType || ctrl.fn.params[0].must_be[0];
+        ctrl.args.push({
+          type: ctrl.exprTypes[exprType].type,
+          value: exprType === 'SqlNumber' ? 0 : ''
+        });
+      };
 
       function initFunction() {
-        ctrl.fnInfo = _.find(CRM.crmSearchAdmin.functions, {name: ctrl.fn});
-        if (ctrl.fnInfo && ctrl.fnInfo.params[0] && !_.isEmpty(ctrl.fnInfo.params[0].flag_before)) {
-          ctrl.modifierName = _.keys(ctrl.fnInfo.params[0].flag_before)[0];
-          ctrl.modifierLabel = ctrl.fnInfo.params[0].flag_before[ctrl.modifierName];
+        if (!ctrl.fn) {
+          return;
+        }
+        if (ctrl.fn && ctrl.fn.params[0] && !_.isEmpty(ctrl.fn.params[0].flag_before)) {
+          ctrl.modifierName = _.keys(ctrl.fn.params[0].flag_before)[0];
+          ctrl.modifierLabel = ctrl.fn.params[0].flag_before[ctrl.modifierName];
         }
         else {
           ctrl.modifierName = null;
           ctrl.modifier = null;
+        }
+        while (ctrl.args.length < ctrl.fn.params[0].min_expr) {
+          ctrl.addArg();
         }
       }
 
       // On-demand options for dropdown function selector
       this.getFunctions = function() {
         var allowedTypes = [], functions = [];
-        if (ctrl.expr && ctrl.field) {
+        if (ctrl.expr && ctrl.args[0] && ctrl.args[0].field) {
           if (ctrl.crmSearchAdmin.canAggregate(ctrl.expr)) {
             allowedTypes.push('aggregate');
           } else {
             allowedTypes.push('comparison', 'string');
-            if (_.includes(['Integer', 'Float', 'Date', 'Timestamp'], ctrl.field[0].data_type)) {
+            if (_.includes(['Integer', 'Float', 'Date', 'Timestamp'], ctrl.args[0].field.data_type)) {
               allowedTypes.push('math');
             }
-            if (_.includes(['Date', 'Timestamp'], ctrl.field[0].data_type)) {
+            if (_.includes(['Date', 'Timestamp'], ctrl.args[0].field.data_type)) {
               allowedTypes.push('date');
             }
           }
@@ -61,11 +79,8 @@
             var allowedFunctions = _.filter(CRM.crmSearchAdmin.functions, function(fn) {
               return fn.category === type &&
                 fn.params.length &&
-                // For now, only support functions that take a single field
-                fn.params[0].min_expr === 1 &&
-                fn.params[0].max_expr === 1 &&
-                !_.includes(fn.params[0].cant_be, 'SqlField') &&
-                (!fn.params[0].must_be.length || _.includes(fn.params[0].must_be, 'SqlField'));
+                fn.params[0].min_expr > 0 &&
+                _.includes(fn.params[0].must_be, 'SqlField');
             });
             functions.push({
               text: allTypes[type],
@@ -76,22 +91,50 @@
         return {results: functions};
       };
 
+      this.getFields = function() {
+        return {
+          results: ctrl.crmSearchAdmin.getAllFields(':label', ['Field', 'Custom', 'Extra'])
+        };
+      };
+
       this.selectFunction = function() {
+        ctrl.fn = _.find(CRM.crmSearchAdmin.functions, {name: ctrl.fnName});
+        ctrl.args.length = 1;
+        initFunction();
         ctrl.writeExpr();
       };
 
       this.toggleModifier = function() {
-        ctrl.modifier = ctrl.modifier ? null : ctrl. modifierName;
+        ctrl.modifier = ctrl.modifier ? null : ctrl.modifierName;
+        ctrl.writeExpr();
+      };
+
+      this.changeArg = function(index) {
+        var val = ctrl.args[index].value;
+        // Delete empty value
+        if (!val && ctrl.args.length > ctrl.fn.params[0].min_expr) {
+          ctrl.args.splice(index, 1);
+        }
         ctrl.writeExpr();
       };
 
       // Make a sql-friendly alias for this expression
       function makeAlias() {
-        return (ctrl.fn + '_' + ctrl.path).replace(/[.:]/g, '_');
+        var args = _.pluck(_.filter(_.filter(ctrl.args, 'value'), {type: 'field'}), 'value');
+        return (ctrl.fnName + '_' + args.join('_')).replace(/[.:]/g, '_');
       }
 
       this.writeExpr = function() {
-        ctrl.expr = ctrl.fn ? (ctrl.fn + '(' + (ctrl.modifier ? ctrl.modifier + ' ' : '') + ctrl.path + ') AS ' + makeAlias()) : ctrl.path;
+        if (ctrl.fnName) {
+          var args = _.transform(ctrl.args, function(args, arg) {
+            if (arg.value) {
+              args.push(arg.type === 'string' ? JSON.stringify(arg.value) : arg.value);
+            }
+          });
+          ctrl.expr = ctrl.fnName + '(' + (ctrl.modifier ? ctrl.modifier + ' ' : '') + args.join(', ') + ') AS ' + makeAlias();
+        } else {
+          ctrl.expr = ctrl.args[0].value;
+        }
       };
     }
   });

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchFunction.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchFunction.component.js
@@ -69,7 +69,7 @@
             });
             functions.push({
               text: allTypes[type],
-              children: formatForSelect2(allowedFunctions, 'name', 'title')
+              children: formatForSelect2(allowedFunctions, 'name', 'title', ['description'])
             });
           });
         }

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchFunction.html
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchFunction.html
@@ -1,8 +1,25 @@
 <div class="form-inline">
-  <label>{{ $ctrl.field[0].label }}:</label>
-  <input class="form-control" style="width: 15em;" ng-model="$ctrl.fn" crm-ui-select="{data: $ctrl.getFunctions, placeholder: ts('Select')}" ng-change="$ctrl.selectFunction()">
+  <input class="form-control" style="width: 15em;" ng-model="$ctrl.fnName" crm-ui-select="{data: $ctrl.getFunctions, placeholder: ts('Function')}" ng-change="$ctrl.selectFunction()">
+  <label>{{ $ctrl.args[0].field.label }}</label>
   <label ng-if="$ctrl.modifierName">
     <input type="checkbox" ng-checked="!!$ctrl.modifier" ng-click="$ctrl.toggleModifier()">
     {{ $ctrl.modifierLabel }}
   </label>
+  <div class="form-group" ng-repeat="arg in $ctrl.args" ng-if="$index">
+    <span ng-switch="arg.type">
+      <input ng-switch-when="number" class="form-control" type="number" ng-model="arg.value" ng-change="$ctrl.changeArg($index)" ng-model-options="{updateOn: 'blur'}">
+      <input ng-switch-when="string" class="form-control" ng-model="arg.value" ng-change="$ctrl.changeArg($index)" ng-model-options="{updateOn: 'blur'}">
+      <input ng-switch-default class="form-control" ng-model="arg.value" crm-ui-select="{data: $ctrl.getFields, placeholder: ts('Field')}" ng-change="$ctrl.changeArg($index)">
+    </span>
+  </div>
+  <div class="btn-group" ng-if="$ctrl.args.length < $ctrl.fn.params[0].max_expr">
+    <button type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+      <i class="crm-i fa-plus"></i> <span class="caret"></span>
+    </button>
+    <ul class="dropdown-menu">
+      <li ng-repeat="(name, type) in $ctrl.exprTypes" ng-show="$ctrl.fn.params[0].must_be.indexOf(name) >= 0">
+        <a href ng-click="$ctrl.addArg(name)">{{ type.label }}</a>
+      </li>
+    </ul>
+  </div>
 </div>

--- a/ext/search_kit/ang/crmSearchAdmin/resultsTable/crmSearchAdminResultsTable.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/resultsTable/crmSearchAdminResultsTable.component.js
@@ -18,8 +18,9 @@
       // Output user-facing name/label fields as a link, if possible
       function getViewLink(fieldExpr, links) {
         var info = searchMeta.parseExpr(fieldExpr),
-          entity = searchMeta.getEntity(info.field.entity);
-        if (entity && info.field.fieldName === entity.label_field) {
+          firstField = _.findWhere(info.args, {type: 'field'}),
+          entity = firstField && searchMeta.getEntity(firstField.field.entity);
+        if (entity && firstField.field.fieldName === entity.label_field) {
           var joinEntity = searchMeta.getJoinEntity(info);
           return _.find(links, {join: joinEntity, action: 'view'});
         }

--- a/ext/search_kit/ang/crmSearchAdmin/resultsTable/crmSearchAdminResultsTable.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/resultsTable/crmSearchAdminResultsTable.component.js
@@ -108,6 +108,8 @@
           if (!ui.item.sortable.dropindex && ctrl.crmSearchAdmin.groupExists) {
             ui.item.sortable.cancel();
           }
+          // Function selectors use `ng-repeat` with `track by $index` so must be refreshed when rearranging the array
+          ctrl.crmSearchAdmin.hideFuncitons();
         }
       };
 


### PR DESCRIPTION
Overview
----------------------------------------
Enhances the SearchKit UI to allow multiple fields to be acted upon at once in a function.

Before
----------------------------------------
Field transformations only work on a single field

After
----------------------------------------
Multiple inputs can be acted upon, e.g. GREATEST or LEAST of multiple fields, or concatenating multiple fields with static strings.

Comments
----------------------------------------
Note: SQL functions still don't work with pseudoconstants. That's a known issue.
