### PR TITLE
dev/core#2843 push new link to the end

### DIFF
--- a/CRM/Contribute/Page/Tab.php
+++ b/CRM/Contribute/Page/Tab.php
@@ -59,16 +59,6 @@ class CRM_Contribute_Page_Tab extends CRM_Core_Page {
     ];
 
     $templateContribution = CRM_Contribute_BAO_ContributionRecur::getTemplateContribution($recurID);
-    if (!empty($templateContribution['id']) && $paymentProcessorObj->supportsEditRecurringContribution()) {
-      // Use constant CRM_Core_Action::PREVIEW as there is no such thing as view template.
-      // And reusing view will mangle the actions.
-      $links[CRM_Core_Action::PREVIEW] = [
-        'name' => ts('View Template'),
-        'title' => ts('View Template Contribution'),
-        'url' => 'civicrm/contact/view/contribution',
-        'qs' => "reset=1&id={$templateContribution['id']}&cid=%%cid%%&action=view&context={$context}&force_create_template=1",
-      ];
-    }
     if (
       (CRM_Core_Permission::check('edit contributions') || $context !== 'contribution') &&
       ($paymentProcessorObj->supports('ChangeSubscriptionAmount')
@@ -100,6 +90,16 @@ class CRM_Contribute_Page_Tab extends CRM_Core_Page {
         'title' => ts('Change Billing Details'),
         'url' => 'civicrm/contribute/updatebilling',
         'qs' => "reset=1&crid=%%crid%%&cid=%%cid%%&context={$context}",
+      ];
+    }
+    if (!empty($templateContribution['id']) && $paymentProcessorObj->supportsEditRecurringContribution()) {
+      // Use constant CRM_Core_Action::PREVIEW as there is no such thing as view template.
+      // And reusing view will mangle the actions.
+      $links[CRM_Core_Action::PREVIEW] = [
+        'name' => ts('View Template'),
+        'title' => ts('View Template Contribution'),
+        'url' => 'civicrm/contact/view/contribution',
+        'qs' => "reset=1&id={$templateContribution['id']}&cid=%%cid%%&action=view&context={$context}&force_create_template=1",
       ];
     }
 


### PR DESCRIPTION

Overview
----------------------------------------
dev/core#2843 push new link to the end
As discussed in https://lab.civicrm.org/dev/core/-/issues/2843
this makes the UI change less for users & reduces confusion


Before
----------------------------------------
New 'view template' action for recurrings has moved the ones the users are used to seeing out of view

After
----------------------------------------
The new one is at the end 

Technical Details
----------------------------------------

Comments
----------------------------------------
Agreed in the gitlab