### PR TITLE
Convert event badges to use token processor

### DIFF
--- a/CRM/Core/EntityTokens.php
+++ b/CRM/Core/EntityTokens.php
@@ -40,6 +40,10 @@ class CRM_Core_EntityTokens extends AbstractTokenSubscriber {
   public function evaluateToken(TokenRow $row, $entity, $field, $prefetch = NULL) {
     $this->prefetch = (array) $prefetch;
     $fieldValue = $this->getFieldValue($row, $field);
+    if (is_array($fieldValue)) {
+      // eg. role_id for participant would be an array here.
+      $fieldValue = implode(',', $fieldValue);
+    }
 
     if ($this->isPseudoField($field)) {
       if (!empty($fieldValue)) {

--- a/CRM/Core/SelectValues.php
+++ b/CRM/Core/SelectValues.php
@@ -594,18 +594,16 @@ class CRM_Core_SelectValues {
    */
   public static function participantTokens(): array {
     $tokens = [
-      '{participant.participant_status_id}' => 'Status ID',
-      '{participant.participant_role_id}' => 'Participant Role (ID)',
-      '{participant.participant_register_date}' => 'Register date',
-      '{participant.participant_source}' => 'Participant Source',
-      '{participant.participant_fee_level}' => 'Fee level',
-      '{participant.participant_fee_amount}' => 'Fee Amount',
-      '{participant.participant_registered_by_id}' => 'Registered By Participant ID',
+      '{participant.status_id}' => 'Status ID',
+      '{participant.role_id}' => 'Participant Role (ID)',
+      '{participant.register_date}' => 'Register date',
+      '{participant.source}' => 'Participant Source',
+      '{participant.fee_level}' => 'Fee level',
+      '{participant.fee_amount}' => 'Fee Amount',
+      '{participant.registered_by_id}' => 'Registered By Participant ID',
       '{participant.transferred_to_contact_id}' => 'Transferred to Contact ID',
-      '{participant.participant_role}' => 'Participant Role (label)',
+      '{participant.role_id:label}' => 'Participant Role (label)',
       '{participant.fee_label}' => 'Fee Label',
-      '{participant.default_role_id}' => 'Default Role',
-      '{participant.template_title}' => 'Event Template Title',
     ];
     $customFields = CRM_Core_BAO_CustomField::getFields('Participant');
 

--- a/CRM/Event/ParticipantTokens.php
+++ b/CRM/Event/ParticipantTokens.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * Class CRM_Event_ParticipantTokens
+ *
+ * Generate "participant.*" tokens.
+ */
+class CRM_Event_ParticipantTokens extends CRM_Core_EntityTokens {
+
+  /**
+   * Get the entity name for api v4 calls.
+   *
+   * @return string
+   */
+  protected function getApiEntityName(): string {
+    return 'Participant';
+  }
+
+  /**
+   * @return array
+   */
+  public function getCurrencyFieldName(): array {
+    return ['fee_currency'];
+  }
+
+}

--- a/CRM/Upgrade/Incremental/php/FiveFortyThree.php
+++ b/CRM/Upgrade/Incremental/php/FiveFortyThree.php
@@ -83,6 +83,31 @@ class CRM_Upgrade_Incremental_php_FiveFortyThree extends CRM_Upgrade_Incremental
     $this->addTask('Replace duplicate event end date token in event badges',
       'updatePrintLabelToken', 'participant.event_end_date', 'event.end_date', $rev
     );
+    $this->addTask('Update participant status id token in event badges',
+      'updatePrintLabelToken', 'participant.participant_status_id', 'participant.status_id', $rev
+    );
+    $this->addTask('Update participant role id token in event badges',
+      'updatePrintLabelToken', 'participant.participant_role_id', 'participant.role_id', $rev
+    );
+    $this->addTask('Update participant role label token in event badges',
+      'updatePrintLabelToken', 'participant.participant_role', 'participant.role_id:label', $rev
+    );
+    $this->addTask('Update participant register date token in event badges',
+      'updatePrintLabelToken', 'participant.participant_register_date', 'participant.register_date', $rev
+    );
+    $this->addTask('Update participant source token in event badges',
+      'updatePrintLabelToken', 'participant.participant_source', 'participant.source', $rev
+    );
+    $this->addTask('Update participant fee level token in event badges',
+      'updatePrintLabelToken', 'participant.participant_fee_level', 'participant.fee_level', $rev
+    );
+    $this->addTask('Update participant fee amount token in event badges',
+      'updatePrintLabelToken', 'participant.participant_fee_amount', 'participant.fee_amount', $rev
+    );
+    $this->addTask('Update participant registered by id token in event badges',
+      'updatePrintLabelToken', 'participant.participant_registered_by_id', 'participant.registered_by_id', $rev
+    );
+
   }
 
   /**

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -333,6 +333,10 @@ class Container {
         []
       ))->addTag('kernel.event_subscriber')->setPublic(TRUE);
     }
+    $container->setDefinition('crm_participant_tokens', new Definition(
+      'CRM_Event_ParticipantTokens',
+      []
+    ))->addTag('kernel.event_subscriber')->setPublic(TRUE);
     $container->setDefinition('crm_contribution_recur_tokens', new Definition(
       'CRM_Contribute_RecurTokens',
       []

--- a/tests/phpunit/CRM/Event/Form/Task/BadgeTest.php
+++ b/tests/phpunit/CRM/Event/Form/Task/BadgeTest.php
@@ -84,27 +84,24 @@ class CRM_Event_Form_Task_BadgeTest extends CiviUnitTestCase {
    * @return string[]
    */
   protected function getAvailableTokens(): array {
-    $tokens = [
+    return [
       '{event.title}' => 'Annual CiviCRM meet',
       '{contact.display_name}' => 'Mr. Anthony Anderson II',
       '{contact.current_employer}' => 'Default Organization',
       '{event.start_date}' => 'October 21st',
-      '{participant.participant_status_id}' => 2,
-      '{participant.participant_role_id}' => 1,
-      '{participant.participant_register_date}' => 'February 19th',
-      '{participant.participant_source}' => 'Wimbeldon',
-      '{participant.participant_fee_level}' => 'low',
-      '{participant.participant_fee_amount}' => NULL,
-      '{participant.participant_registered_by_id}' => NULL,
+      '{participant.status_id}' => 2,
+      '{participant.role_id}' => 1,
+      '{participant.register_date}' => 'February 19th, 2007 12:00 AM',
+      '{participant.source}' => 'Wimbeldon',
+      '{participant.fee_level}' => 'low',
+      '{participant.fee_amount}' => NULL,
+      '{participant.registered_by_id}' => NULL,
       '{participant.transferred_to_contact_id}' => NULL,
-      '{participant.participant_role}' => 'Attendee',
+      '{participant.role_id:label}' => 'Attendee',
       '{participant.fee_label}' => NULL,
-      '{participant.default_role_id}' => 1,
-      '{participant.template_title}' => NULL,
       '{event.end_date}' => 'October 23rd',
       '{event.id}' => 1,
     ];
-    return $tokens;
   }
 
 }

--- a/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
+++ b/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
@@ -483,18 +483,16 @@ December 21st, 2007
    */
   public function getParticipantTokens(): array {
     return [
-      '{participant.participant_status_id}' => 'Status ID',
-      '{participant.participant_role_id}' => 'Participant Role (ID)',
-      '{participant.participant_register_date}' => 'Register date',
-      '{participant.participant_source}' => 'Participant Source',
-      '{participant.participant_fee_level}' => 'Fee level',
-      '{participant.participant_fee_amount}' => 'Fee Amount',
-      '{participant.participant_registered_by_id}' => 'Registered By Participant ID',
+      '{participant.status_id}' => 'Status ID',
+      '{participant.role_id}' => 'Participant Role (ID)',
+      '{participant.register_date}' => 'Register date',
+      '{participant.source}' => 'Participant Source',
+      '{participant.fee_level}' => 'Fee level',
+      '{participant.fee_amount}' => 'Fee Amount',
+      '{participant.registered_by_id}' => 'Registered By Participant ID',
       '{participant.transferred_to_contact_id}' => 'Transferred to Contact ID',
-      '{participant.participant_role}' => 'Participant Role (label)',
+      '{participant.role_id:label}' => 'Participant Role (label)',
       '{participant.fee_label}' => 'Fee Label',
-      '{participant.default_role_id}' => 'Default Role',
-      '{participant.template_title}' => 'Event Template Title',
       '{participant.' . $this->getCustomFieldName('text') . '}' => 'Enter text here :: Group with field text',
     ];
   }


### PR DESCRIPTION
Overview
----------------------------------------
Convert event badges to use token processor
    
This adds the token processor class for participants and
switches the one place where we currently resolve participant
tokens to use it.
    
In the process I upgrade the badge tokens with a syntax change and
drop a few more that are actually
    
a) weird / seemingly accidentally exposed and
b) not really part of the participant entity
    
ie event template title & default role id

And I also the 'registered_date' token to regress to a less-good format. I've documented that [here](https://lab.civicrm.org/-/ide/project/documentation/docs/sysadmin/tree/case/-/docs/upgrade/version-specific.md/) and given that the use case for it seems sketchy and we have a plan in play for more flexible date formatting I think that's an OK trade off for this standardisation.
    
    

Before
----------------------------------------
Badges have their own special way of rendering participant & contact tokens

After
----------------------------------------
The token processor is used - note this just leaves the event tokens being extra specially rendered

Technical Details
----------------------------------------
With participant tokens we have been fortunate not
to let a non-standard implementation go out
so it's only the event badges which are
a bit obscure / less used / less likely to be
blindly used. I have added token replacement
but I think it will be all very edge case


Builds on https://github.com/civicrm/civicrm-core/pull/21520

Comments
----------------------------------------
https://lab.civicrm.org/-/ide/project/documentation/docs/sysadmin/tree/case/-/docs/upgrade/version-specific.md/