### PR TITLE
Add {domain.now}, supporting |crmDate

### DIFF
--- a/CRM/Core/DomainTokens.php
+++ b/CRM/Core/DomainTokens.php
@@ -57,7 +57,8 @@ class CRM_Core_DomainTokens extends AbstractTokenSubscriber {
    */
   public function evaluateToken(TokenRow $row, $entity, $field, $prefetch = NULL): void {
     if ($field === 'now') {
-      $row->format('text/html')->tokens($entity, $field, new DateTime());
+      $nowObj = (new \DateTime())->setTimestamp(\CRM_Utils_Time::time());
+      $row->format('text/html')->tokens($entity, $field, $nowObj);
       return;
     }
     $row->format('text/html')->tokens($entity, $field, self::getDomainTokenValues()[$field]);

--- a/CRM/Core/DomainTokens.php
+++ b/CRM/Core/DomainTokens.php
@@ -47,6 +47,7 @@ class CRM_Core_DomainTokens extends AbstractTokenSubscriber {
       'email' => ts('Domain (organization) email'),
       'id' => ts('Domain ID'),
       'description' => ts('Domain Description'),
+      'now' => ts('Current time/date'),
     ];
   }
 
@@ -55,6 +56,10 @@ class CRM_Core_DomainTokens extends AbstractTokenSubscriber {
    * @throws \CRM_Core_Exception
    */
   public function evaluateToken(TokenRow $row, $entity, $field, $prefetch = NULL): void {
+    if ($field === 'now') {
+      $row->format('text/html')->tokens($entity, $field, new DateTime());
+      return;
+    }
     $row->format('text/html')->tokens($entity, $field, self::getDomainTokenValues()[$field]);
     $row->format('text/plain')->tokens($entity, $field, self::getDomainTokenValues(NULL, FALSE)[$field]);
   }

--- a/Civi/Token/TokenProcessor.php
+++ b/Civi/Token/TokenProcessor.php
@@ -430,7 +430,7 @@ class TokenProcessor {
         if ($value instanceof \DateTime) {
           // @todo cludgey.
           require_once 'CRM/Core/Smarty/plugins/modifier.crmDate.php';
-          return \smarty_modifier_crmDate($value->format('Y-m-d H:i:s'));
+          return \smarty_modifier_crmDate($value->format('Y-m-d H:i:s'), $filter[1] ?? NULL);
         }
 
       default:

--- a/Civi/Token/TokenRow.php
+++ b/Civi/Token/TokenRow.php
@@ -283,15 +283,18 @@ class TokenRow {
         // HTML => Plain.
         foreach ($htmlTokens as $entity => $values) {
           foreach ($values as $field => $value) {
+            if (!$value instanceof \DateTime) {
+              $value = html_entity_decode(strip_tags($value));
+            }
             if (!isset($textTokens[$entity][$field])) {
-              $textTokens[$entity][$field] = html_entity_decode(strip_tags($value));
+              $textTokens[$entity][$field] = $value;
             }
           }
         }
         break;
 
       default:
-        throw new \RuntimeException("Invalid format");
+        throw new \RuntimeException('Invalid format');
     }
 
     return $this;

--- a/tests/phpunit/CRM/Core/TokenSmartyTest.php
+++ b/tests/phpunit/CRM/Core/TokenSmartyTest.php
@@ -32,6 +32,26 @@ class CRM_Core_TokenSmartyTest extends CiviUnitTestCase {
       ['extra' => ['foo' => 'foobar']]
     );
     $this->assertEquals('First name is Bob. ExtraFoo is foobar.', $rendered['msg_subject']);
+
+    try {
+      $modifiers = [
+        '|crmDate:"shortdate"' => '02/01/2020',
+        '|crmDate:"%B %Y"' => 'February 2020',
+        '|crmDate' => 'February 1st, 2020  3:04 AM',
+      ];
+      foreach ($modifiers as $modifier => $expected) {
+        CRM_Utils_Time::setTime('2020-02-01 03:04:05');
+        $rendered = CRM_Core_TokenSmarty::render(
+          ['msg_subject' => "Now is the token, {domain.now$modifier}! No, now is the smarty-pants, {\$extra.now$modifier}!"],
+          ['contactId' => $this->contactId],
+          ['extra' => ['now' => '2020-02-01 03:04:05']]
+        );
+        $this->assertEquals("Now is the token, $expected! No, now is the smarty-pants, $expected!", $rendered['msg_subject']);
+      }
+    }
+    finally {
+      \CRM_Utils_Time::resetTime();
+    }
   }
 
   /**

--- a/tests/phpunit/CRM/Core/TokenSmartyTest.php
+++ b/tests/phpunit/CRM/Core/TokenSmartyTest.php
@@ -58,6 +58,9 @@ class CRM_Core_TokenSmartyTest extends CiviUnitTestCase {
    * A template which uses token-data as part of a Smarty expression.
    */
   public function testTokenInSmarty() {
+    \CRM_Utils_Time::setTime('2022-04-08 16:32:04');
+    $resetTime = \CRM_Utils_AutoClean::with(['CRM_Utils_Time', 'resetTime']);
+
     $rendered = CRM_Core_TokenSmarty::render(
       ['msg_html' => '<p>{assign var="greeting" value="{contact.email_greeting}"}Greeting: {$greeting}!</p>'],
       ['contactId' => $this->contactId],
@@ -71,6 +74,20 @@ class CRM_Core_TokenSmartyTest extends CiviUnitTestCase {
       []
     );
     $this->assertEquals('<p>Yes CID</p>', $rendered['msg_html']);
+
+    $rendered = CRM_Core_TokenSmarty::render(
+      ['msg_html' => '<p>{assign var="greeting" value="hey yo {contact.first_name|upper} {contact.last_name|upper} circa {domain.now|crmDate:"%m/%Y"}"}My Greeting: {$greeting}!</p>'],
+      ['contactId' => $this->contactId],
+      []
+    );
+    $this->assertEquals('<p>My Greeting: hey yo BOB ROBERTS circa 04/2022!</p>', $rendered['msg_html']);
+
+    $rendered = CRM_Core_TokenSmarty::render(
+      ['msg_html' => '<p>{assign var="greeting" value="hey yo {contact.first_name} {contact.last_name|upper} circa {domain.now|crmDate:"shortdate"}"}My Greeting: {$greeting|capitalize}!</p>'],
+      ['contactId' => $this->contactId],
+      []
+    );
+    $this->assertEquals('<p>My Greeting: Hey Yo Bob ROBERTS Circa 04/08/2022!</p>', $rendered['msg_html']);
   }
 
   /**

--- a/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
+++ b/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
@@ -509,7 +509,7 @@ December 21st, 2007
     ]);
     $tokens['{domain.id}'] = 'Domain ID';
     $tokens['{domain.description}'] = 'Domain Description';
-    $tokens['domain.now'] = 'Current time/date';
+    $tokens['{domain.now}'] = 'Current time/date';
     $this->assertEquals($tokens, $tokenProcessor->listTokens());
   }
 

--- a/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
+++ b/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
@@ -520,20 +520,23 @@ December 21st, 2007
   public function testDomainNow(): void {
     putenv('TIME_FUNC=frozen');
     CRM_Utils_Time::setTime('2021-09-18 23:58:00');
-    $resolved = CRM_Core_BAO_MessageTemplate::renderTemplate([
-      'messageTemplate' => [
-        'msg_text' => '{domain.now|crmDate:short}',
-      ],
-    ])['text'];
-    $this->assertEquals('September 18th, 2021 11:58 PM', $resolved);
+    $modifiers = [
+      'shortdate' => '09/18/2021',
+    ];
+    foreach ($modifiers as $filter => $expected) {
+      $resolved = CRM_Core_BAO_MessageTemplate::renderTemplate([
+        'messageTemplate' => [
+          'msg_text' => '{domain.now|crmDate:' . $filter . '}',
+        ],
+      ])['text'];
+      $this->assertEquals('09/18/2021', $resolved);
+    }
     $resolved = CRM_Core_BAO_MessageTemplate::renderTemplate([
       'messageTemplate' => [
         'msg_text' => '{domain.now}',
       ],
     ])['text'];
     $this->assertEquals('September 18th, 2021 11:58 PM', $resolved);
-
-    $b1 = 1;
   }
 
   /**

--- a/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
+++ b/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
@@ -519,7 +519,7 @@ December 21st, 2007
    */
   public function testDomainNow(): void {
     putenv('TIME_FUNC=frozen');
-    CRM_Utils_Time::setTime('2021-21-18 11:58:00');
+    CRM_Utils_Time::setTime('2021-09-18 23:58:00');
     $resolved = CRM_Core_BAO_MessageTemplate::renderTemplate([
       'messageTemplate' => [
         'msg_text' => '{domain.now|crmDate:short}',

--- a/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
+++ b/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
@@ -522,14 +522,15 @@ December 21st, 2007
     CRM_Utils_Time::setTime('2021-09-18 23:58:00');
     $modifiers = [
       'shortdate' => '09/18/2021',
+      '%B %Y' => 'September 2021',
     ];
     foreach ($modifiers as $filter => $expected) {
       $resolved = CRM_Core_BAO_MessageTemplate::renderTemplate([
         'messageTemplate' => [
-          'msg_text' => '{domain.now|crmDate:' . $filter . '}',
+          'msg_text' => '{domain.now|crmDate:"' . $filter . '"}',
         ],
       ])['text'];
-      $this->assertEquals('09/18/2021', $resolved);
+      $this->assertEquals($expected, $resolved);
     }
     $resolved = CRM_Core_BAO_MessageTemplate::renderTemplate([
       'messageTemplate' => [
@@ -537,6 +538,19 @@ December 21st, 2007
       ],
     ])['text'];
     $this->assertEquals('September 18th, 2021 11:58 PM', $resolved);
+
+    // This example is malformed - no quotes
+    try {
+      $resolved = CRM_Core_BAO_MessageTemplate::renderTemplate([
+        'messageTemplate' => [
+          'msg_text' => '{domain.now|crmDate:shortdate}',
+        ],
+      ])['text'];
+      $this->fail("Expected unquoted parameter to fail");
+    }
+    catch (\CRM_Core_Exception $e) {
+      $this->assertRegExp(';Malformed token param;', $e->getMessage());
+    }
   }
 
   /**

--- a/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
+++ b/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
@@ -509,7 +509,31 @@ December 21st, 2007
     ]);
     $tokens['{domain.id}'] = 'Domain ID';
     $tokens['{domain.description}'] = 'Domain Description';
+    $tokens['domain.now'] = 'Current time/date';
     $this->assertEquals($tokens, $tokenProcessor->listTokens());
+  }
+
+  /**
+   * @throws \API_Exception
+   * @throws \CRM_Core_Exception
+   */
+  public function testDomainNow(): void {
+    putenv('TIME_FUNC=frozen');
+    CRM_Utils_Time::setTime('2021-21-18 11:58:00');
+    $resolved = CRM_Core_BAO_MessageTemplate::renderTemplate([
+      'messageTemplate' => [
+        'msg_text' => '{domain.now|crmDate:short}',
+      ],
+    ])['text'];
+    $this->assertEquals('September 18th, 2021 11:58 PM', $resolved);
+    $resolved = CRM_Core_BAO_MessageTemplate::renderTemplate([
+      'messageTemplate' => [
+        'msg_text' => '{domain.now}',
+      ],
+    ])['text'];
+    $this->assertEquals('September 18th, 2021 11:58 PM', $resolved);
+
+    $b1 = 1;
   }
 
   /**
@@ -525,6 +549,7 @@ December 21st, 2007
       '{domain.email}' => 'Domain (organization) email',
       '{domain.id}' => ts('Domain ID'),
       '{domain.description}' => ts('Domain Description'),
+      '{domain.now}' => 'Current time/date',
     ];
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Add new `{domain.now}` token - this provides the current date. 

It also supports formatting and provides a mechanism for other dates to follow  - ie the following work based on the formats configured in the date settings page.  

|Token|example output|
|-----|-----|
|{domain.now}| September 18th, 2021 11:58 PM|
|{domain.now&#124;crmDate:"Datetime"} | September 18th, 2021 11:58 PM|
|{domain.now&#124;crmDate:"shortdate"}|  09/18/2021|
|{domain.now&#124;crmDate:"Full"}|September 19th, 2010|
|{domain.now&#124;crmDate:"Partial"}|September 19th, 2010|
|{domain.now&#124;crmDate:"Time"}|1:34 PM|
|{domain.now&#124;crmDate:"Year"}|2010|
|{domain.now&#124;crmDate:"FinancialBatch"}| 09/19/2010|
|{domain.now&#124;crmDate:"%B %Y"}| September 202|

Before
----------------------------------------
^^ not available

After
----------------------------------------
and now it is


Technical Details
----------------------------------------

This expands the range of what is considered a valid token-filter. The filters may now accept string-parameters, as in `|crmDate:"first":"second":"third"`.

`crmDate` works if the token-value is defined as a `\DateTime` object (which I will do on the main entities as a follow up)


https://lab.civicrm.org/documentation/docs/user-en/-/merge_requests/498