### PR TITLE
SearchKit - Fix in-place edit of relationships and dates

### DIFF
--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
@@ -380,6 +380,7 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
       // Select value fields for in-place editing
       if (isset($column['editable']['value'])) {
         $additions[] = $column['editable']['value'];
+        $additions[] = $column['editable']['id'];
       }
     }
     // Add fields referenced via token

--- a/ext/search_kit/Civi/Search/Admin.php
+++ b/ext/search_kit/Civi/Search/Admin.php
@@ -118,6 +118,13 @@ class Admin {
         ]);
         foreach ($getFields as $field) {
           $field['fieldName'] = $field['name'];
+          // Hack for RelationshipCache to make Relationship fields editable
+          if ($entity['name'] === 'RelationshipCache') {
+            $entity['primary_key'] = ['relationship_id'];
+            if (in_array($field['name'], ['is_active', 'start_date', 'end_date'])) {
+              $field['readonly'] = FALSE;
+            }
+          }
           $entity['fields'][] = $field;
         }
         $params = $entity['get'][0];

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminDisplay.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminDisplay.component.js
@@ -158,25 +158,28 @@
         }
 
         var info = searchMeta.parseExpr(col.key),
-          field = info.args[0] && info.args[0].field,
+          arg = _.findWhere(info.args, {type: 'field'}) || {},
           value = col.key.split(':')[0];
-        if (!field || info.fn) {
+        if (!arg.field || info.fn) {
           delete col.editable;
           return;
         }
         // If field is an implicit join, use the original fk field
-        if (field.name !== field.fieldName) {
+        if (arg.field.name !== arg.field.fieldName) {
           value = value.substr(0, value.lastIndexOf('.'));
           info = searchMeta.parseExpr(value);
-          field = info.args[0].field;
+          arg = info.args[0];
         }
         col.editable = {
-          entity: field.baseEntity,
-          options: !!field.options,
-          serialize: !!field.serialize,
-          fk_entity: field.fk_entity,
-          id: info.prefix + 'id',
-          name: field.name,
+          // Hack to support editing relationships
+          entity: arg.field.entity.replace('RelationshipCache', 'Relationship'),
+          input_type: arg.field.input_type,
+          data_type: arg.field.data_type,
+          options: !!arg.field.options,
+          serialize: !!arg.field.serialize,
+          fk_entity: arg.field.fk_entity,
+          id: arg.prefix + searchMeta.getEntity(arg.field.entity).primary_key[0],
+          name: arg.field.name,
           value: value
         };
       };

--- a/ext/search_kit/ang/crmSearchDisplay/crmSearchDisplayEditable.component.js
+++ b/ext/search_kit/ang/crmSearchDisplay/crmSearchDisplayEditable.component.js
@@ -23,7 +23,8 @@
         initialValue = _.cloneDeep(this.row[col.editable.value].raw);
 
         this.field = {
-          data_type: col.dataType,
+          data_type: col.editable.data_type,
+          input_type: col.editable.input_type,
           name: col.editable.name,
           options: col.editable.options,
           fk_entity: col.editable.fk_entity,


### PR DESCRIPTION
Overview
----------------------------------------
Makes relationship fields in-place editable on SearchKit, and fixes in-place editing of dates.

Before
----------------------------------------
Date fields were not rendering correctly, and relationships could not be edited due to the read-only nature of the relationshipCache table.

After
----------------------------------------
Relationship start date, end date, is_active, and custom fields can be edited in-place on search displays.

Technical Details
----------------------------------------
No fields in the RelationshipCache table are editable directly, so this tricks SearchKit into thinking they belong to the Relationship entity.

Comments
----------------------------------------
Also fixes a couple bugs related to in-place editing caused by the refactoring done in #21528
