### PR TITLE
Use the processor function to get event tokens

### DIFF
--- a/CRM/Core/SelectValues.php
+++ b/CRM/Core/SelectValues.php
@@ -550,7 +550,7 @@ class CRM_Core_SelectValues {
       '{event.contact_phone}' => ts('Event Contact Phone'),
       '{event.description}' => ts('Event Description'),
       '{event.location}' => ts('Event Location'),
-      '{event.fee_amount}' => ts('Event Fees'),
+      '{event.fee_amount}' => ts('Event Fee'),
       '{event.info_url}' => ts('Event Info URL'),
       '{event.registration_url}' => ts('Event Registration URL'),
       '{event.balance}' => ts('Event Balance'),

--- a/CRM/Core/SelectValues.php
+++ b/CRM/Core/SelectValues.php
@@ -536,25 +536,19 @@ class CRM_Core_SelectValues {
   /**
    * Different type of Event Tokens.
    *
+   * @deprecated
+   *
    * @return array
    */
-  public static function eventTokens() {
-    return [
-      '{event.event_id}' => ts('Event ID'),
-      '{event.title}' => ts('Event Title'),
-      '{event.start_date}' => ts('Event Start Date'),
-      '{event.end_date}' => ts('Event End Date'),
-      '{event.event_type}' => ts('Event Type'),
-      '{event.summary}' => ts('Event Summary'),
-      '{event.contact_email}' => ts('Event Contact Email'),
-      '{event.contact_phone}' => ts('Event Contact Phone'),
-      '{event.description}' => ts('Event Description'),
-      '{event.location}' => ts('Event Location'),
-      '{event.fee_amount}' => ts('Event Fee'),
-      '{event.info_url}' => ts('Event Info URL'),
-      '{event.registration_url}' => ts('Event Registration URL'),
-      '{event.balance}' => ts('Event Balance'),
-    ];
+  public static function eventTokens(): array {
+    $tokenProcessor = new TokenProcessor(Civi::dispatcher(), ['schema' => ['eventId']]);
+    $allTokens = $tokenProcessor->listTokens();
+    foreach (array_keys($allTokens) as $token) {
+      if (strpos($token, '{domain.') === 0) {
+        unset($allTokens[$token]);
+      }
+    }
+    return $allTokens;
   }
 
   /**

--- a/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
+++ b/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
@@ -535,4 +535,42 @@ December 21st, 2007
     ];
   }
 
+  /**
+   * Test that domain tokens are consistently rendered.
+   */
+  public function testEventTokenConsistency(): void {
+    $tokens = CRM_Core_SelectValues::eventTokens();
+    $this->assertEquals($this->getEventTokens(), $tokens);
+    $tokenProcessor = new TokenProcessor(\Civi::dispatcher(), [
+      'controller' => __CLASS__,
+      'smarty' => FALSE,
+      'schema' => ['eventId'],
+    ]);
+    $this->assertEquals(array_merge($tokens, $this->getDomainTokens()), $tokenProcessor->listTokens());
+  }
+
+  /**
+   * Get expected event tokens.
+   *
+   * @return string[]
+   */
+  protected function getEventTokens(): array {
+    return [
+      '{event.event_id}' => 'Event ID',
+      '{event.title}' => 'Event Title',
+      '{event.start_date}' => 'Event Start Date',
+      '{event.end_date}' => 'Event End Date',
+      '{event.event_type}' => 'Event Type',
+      '{event.summary}' => 'Event Summary',
+      '{event.contact_email}' => 'Event Contact Email',
+      '{event.contact_phone}' => 'Event Contact Phone',
+      '{event.description}' => 'Event Description',
+      '{event.location}' => 'Event Location',
+      '{event.fee_amount}' => 'Event Fee',
+      '{event.info_url}' => 'Event Info URL',
+      '{event.registration_url}' => 'Event Registration URL',
+      '{event.balance}' => 'Event Balance',
+    ];
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Use the procesor function to get event tokens

Before
----------------------------------------
2 different functions to get event tokens

After
----------------------------------------
the deprecated one calls the 'to keep' one

Technical Details
----------------------------------------
The tests in this PR are separately here https://github.com/civicrm/civicrm-core/pull/21536 to show it passes before and after

Event tokens are only rendered from scheduled reminders - which gives us the space to fix these up - eg. fee amount & balance belong on the participant class & the id token should be `{event.id}` or `{participant.event_id}`

Comments
----------------------------------------
This fixes the issue with event tokens not being advertised as a 'by product'

Once https://github.com/civicrm/civicrm-core/pull/21530 is merged I will tackle the token outputs 