### PR TITLE
Deprecate civicrm_contribution_recur.trxn_id

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -1231,9 +1231,8 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     $recurParams['contribution_status_id'] = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Pending');
     $recurParams['payment_processor_id'] = $params['payment_processor_id'] ?? NULL;
     $recurParams['is_email_receipt'] = (bool) ($params['is_email_receipt'] ?? FALSE);
-    // we need to add a unique trxn_id to avoid a unique key error
-    // in paypal IPN we reset this when paypal sends us the real trxn id, CRM-2991
-    $recurParams['trxn_id'] = $params['trxn_id'] ?? $params['invoiceID'];
+    // We set trxn_id=invoiceID specifically for paypal IPN. It is reset this when paypal sends us the real trxn id, CRM-2991
+    $recurParams['processor_id'] = $recurParams['trxn_id'] = ($params['trxn_id'] ?? $params['invoiceID']);
     $recurParams['financial_type_id'] = $contributionType->id;
 
     $campaignId = $params['campaign_id'] ?? $form->_values['campaign_id'] ?? NULL;

--- a/CRM/Contribute/Page/ContributionRecur.php
+++ b/CRM/Contribute/Page/ContributionRecur.php
@@ -74,6 +74,9 @@ class CRM_Contribute_Page_ContributionRecur extends CRM_Core_Page {
       NULL, TRUE, NULL, FALSE, CRM_Core_Permission::VIEW);
     CRM_Core_BAO_CustomGroup::buildCustomDataView($this, $groupTree, FALSE, NULL, NULL, NULL, $contributionRecur['id']);
 
+    if (isset($contributionRecur['trxn_id']) && ($contributionRecur['processor_id'] === $contributionRecur['trxn_id'])) {
+      unset($contributionRecur['trxn_id']);
+    }
     $this->assign('recur', $contributionRecur);
 
     $templateContribution = CRM_Contribute_BAO_ContributionRecur::getTemplateContribution($this->getEntityId());

--- a/CRM/Upgrade/Incremental/sql/5.48.alpha1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.48.alpha1.mysql.tpl
@@ -1,1 +1,5 @@
 {* file to handle db changes in 5.48.alpha1 during upgrade *}
+
+{* https://github.com/civicrm/civicrm-core/pull/21539 Deprecate civicrm_contribution_recur.trxn_id *}
+ALTER TABLE `civicrm_contribution_recur` MODIFY `processor_id` varchar(255) DEFAULT NULL COMMENT 'May store an identifier used to link this recurring contribution record to a third party payment processor\'s system';
+ALTER TABLE `civicrm_contribution_recur` MODIFY `trxn_id` varchar(255) DEFAULT NULL COMMENT 'unique transaction id (deprecated - use processor_id)';

--- a/xml/schema/Contribute/ContributionRecur.xml
+++ b/xml/schema/Contribute/ContributionRecur.xml
@@ -229,7 +229,7 @@
     <title>Transaction ID</title>
     <type>varchar</type>
     <length>255</length>
-    <comment>unique transaction id. may be processor id, bank id + trans id, or account number + check number... depending on payment_method</comment>
+    <comment>unique transaction id (deprecated - use processor_id)</comment>
     <add>1.6</add>
     <html>
       <type>Text</type>


### PR DESCRIPTION
Overview
----------------------------------------
See discussion on https://lab.civicrm.org/dev/financial/-/issues/57

The `civicrm_contribution_recur` table has both `trxn_id` and `processor_id`. Various parts of the core code *require* that you use `processor_id` (eg. UpdateBilling/UpdateSubscription historically it was the only value passed that could be used to identify the recurring contribution).

I'm not aware of any payment processor that actually uses both - it's basically impossible to do so because of the way core has handled them - and those that *do* rely on one of those fields generally copy the same value into both to make sure  - eg. https://lab.civicrm.org/extensions/gocardless/-/blob/main/CRM/GoCardlessUtils.php#L389

Before
----------------------------------------
Not clear which parameter should be used.

After
----------------------------------------
Clearer..

Technical Details
----------------------------------------


Comments
----------------------------------------

