### PR TITLE
Replace "Print Invoice" and "Print Invoice and Credit Note" buttons with label "Download Invoice" and "Download Invoice and Credit Note"

### DIFF
--- a/templates/CRM/Contribute/Form/ContributionView.tpl
+++ b/templates/CRM/Contribute/Form/ContributionView.tpl
@@ -38,11 +38,11 @@
     {if $invoicing && empty($is_template)}
       <div class="css_right">
         <a class="button no-popup" href="{crmURL p='civicrm/contribute/invoice' q=$pdfUrlParams}">
-          <i class="crm-i fa-print" aria-hidden="true"></i>
+          <i class="crm-i fa-download" aria-hidden="true"></i>
         {if $contribution_status != 'Refunded' && $contribution_status != 'Cancelled' }
-          {ts}Print Invoice{/ts}</a>
+          {ts}Download Invoice{/ts}</a>
         {else}
-          {ts}Print Invoice and Credit Note{/ts}</a>
+          {ts}Download Invoice and Credit Note{/ts}</a>
         {/if}
         <a class="button" href="{crmURL p='civicrm/contribute/invoice/email' q=$emailUrlParams}">
           <i class="crm-i fa-paper-plane" aria-hidden="true"></i>

--- a/templates/CRM/Contribute/Page/UserDashboard.tpl
+++ b/templates/CRM/Contribute/Page/UserDashboard.tpl
@@ -49,11 +49,11 @@
                             {if call_user_func(array('CRM_Core_Permission','check'), 'view my invoices') OR call_user_func(array('CRM_Core_Permission','check'), 'access CiviContribute')}
                                 <a class="button no-popup nowrap"
                                    href="{crmURL p='civicrm/contribute/invoice' q=$urlParams}">
-                                    <i class="crm-i fa-print" aria-hidden="true"></i>
+                                    <i class="crm-i fa-download" aria-hidden="true"></i>
                                     {if empty($row.contribution_status_name) || (!empty($row.contribution_status_name) && $row.contribution_status_name != 'Refunded' && $row.contribution_status_name != 'Cancelled') }
-                                        <span>{ts}Print Invoice{/ts}</span>
+                                        <span>{ts}Download Invoice{/ts}</span>
                                     {else}
-                                        <span>{ts}Print Invoice and Credit Note{/ts}</span>
+                                        <span>{ts}Download Invoice and Credit Note{/ts}</span>
                                     {/if}
                                 </a>
                             {/if}

--- a/tests/phpunit/CRM/Contact/Page/View/UserDashBoardTest.php
+++ b/tests/phpunit/CRM/Contact/Page/View/UserDashBoardTest.php
@@ -114,7 +114,7 @@ class CRM_Contact_Page_View_UserDashBoardTest extends CiviUnitTestCase {
     $expectedStrings = [
       'Your Contribution(s)',
       '<table class="selector"><tr class="columnheader"><th>Total Amount</th><th>Financial Type</th><th>Received date</th><th>Receipt Sent</th><th>Balance</th><th>Status</th><th></th>',
-      '<td>Completed</td><td><a class="button no-popup nowrap"href="/index.php?q=civicrm/contribute/invoice&amp;reset=1&amp;id=1&amp;cid=' . $this->contactID . '"><i class="crm-i fa-print" aria-hidden="true"></i><span>Print Invoice</span></a></td></tr><tr id=\'rowid2\'',
+      '<td>Completed</td><td><a class="button no-popup nowrap"href="/index.php?q=civicrm/contribute/invoice&amp;reset=1&amp;id=1&amp;cid=' . $this->contactID . '"><i class="crm-i fa-download" aria-hidden="true"></i><span>Download Invoice</span></a></td></tr><tr id=\'rowid2\'',
       'Pay Now',
     ];
 


### PR DESCRIPTION
Replace "Print Invoice" and "Print Invoice and Credit Note" buttons with label "Download Invoice" and "Download Invoice and Credit Note"

Overview
----------------------------------------

This button does not send the downloaded PDF to a printer, nor does it open a "printer friendly" page and then show the print dialog. Instead, this button just downloads a PDF and so should be labelled as such.

Before
----------------------------------------

Clicking Print Invoice button does not print the invoice.

![print-invoice](https://user-images.githubusercontent.com/58866555/133949052-2e7407a5-d33a-4335-b88b-7cb25eb087a1.png)

After
----------------------------------------

Clicking Download Invoice button does download the invoice.

![Screenshot_20210920_114448](https://user-images.githubusercontent.com/58866555/133950473-6d9aa6b7-879c-4a11-8a41-f4487f80e80f.png)

Technical Details
----------------------------------------
Replaced FA Print icon with Download icon too.

Comments
----------------------------------------

Agileware Ref: CIVIBLD-279
