### PR TITLE
Test tearDown fixes

### DIFF
--- a/tests/phpunit/CRM/Activity/BAO/ActivityTest.php
+++ b/tests/phpunit/CRM/Activity/BAO/ActivityTest.php
@@ -40,6 +40,8 @@ class CRM_Activity_BAO_ActivityTest extends CiviUnitTestCase {
       'civicrm_uf_match',
       'civicrm_campaign',
       'civicrm_email',
+      'civicrm_file',
+      'civicrm_entity_file',
     ];
     $this->quickCleanup($tablesToTruncate);
     $this->cleanUpAfterACLs();

--- a/tests/phpunit/CRM/Batch/BAO/BatchTest.php
+++ b/tests/phpunit/CRM/Batch/BAO/BatchTest.php
@@ -35,10 +35,11 @@ class CRM_Batch_BAO_BatchTest extends CiviUnitTestCase {
    * Cleanup after test.
    *
    * @throws \CRM_Core_Exception
+   * @throws \API_Exception
    */
   public function tearDown(): void {
-    parent::tearDown();
     $this->quickCleanup(['civicrm_batch']);
+    parent::tearDown();
   }
 
   /**

--- a/tests/phpunit/CRM/Case/BAO/CaseTest.php
+++ b/tests/phpunit/CRM/Case/BAO/CaseTest.php
@@ -18,6 +18,8 @@ class CRM_Case_BAO_CaseTest extends CiviUnitTestCase {
       'civicrm_case_contact',
       'civicrm_case_activity',
       'civicrm_case_type',
+      'civicrm_file',
+      'civicrm_entity_file',
       'civicrm_activity_contact',
       'civicrm_managed',
       'civicrm_relationship',
@@ -37,7 +39,7 @@ class CRM_Case_BAO_CaseTest extends CiviUnitTestCase {
   /**
    * Make sure that the latest case activity works accurately.
    */
-  public function testCaseActivity() {
+  public function testCaseActivity(): void {
     $userID = $this->createLoggedInUser();
 
     $addTimeline = civicrm_api3('Case', 'addtimeline', [
@@ -57,8 +59,8 @@ class CRM_Case_BAO_CaseTest extends CiviUnitTestCase {
   }
 
   protected function tearDown(): void {
-    parent::tearDown();
     $this->quickCleanup($this->tablesToTruncate, TRUE);
+    parent::tearDown();
   }
 
   public function testAddCaseToContact() {

--- a/tests/phpunit/CRM/Contribute/Form/Contribution/MainTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/Contribution/MainTest.php
@@ -23,6 +23,7 @@ class CRM_Contribute_Form_Contribution_MainTest extends CiviUnitTestCase {
    */
   public function tearDown(): void {
     $this->quickCleanUpFinancialEntities();
+    parent::tearDown();
   }
 
   /**

--- a/tests/phpunit/CRM/Contribute/Form/Contribution/ThankYouTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/Contribution/ThankYouTest.php
@@ -20,9 +20,12 @@ class CRM_Contribute_Form_Contribution_ThankYouTest extends CiviUnitTestCase {
 
   /**
    * Clean up DB.
+   *
+   * @throws \CRM_Core_Exception|\API_Exception
    */
   public function tearDown(): void {
     $this->quickCleanUpFinancialEntities();
+    parent::tearDown();
   }
 
   /**

--- a/tests/phpunit/CRM/Contribute/Form/Task/InvoiceTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/Task/InvoiceTest.php
@@ -27,6 +27,7 @@ class CRM_Contribute_Form_Task_InvoiceTest extends CiviUnitTestCase {
     $this->quickCleanUpFinancialEntities();
     $this->revertTemplateToReservedTemplate('contribution_invoice_receipt');
     CRM_Utils_Hook::singleton()->reset();
+    parent::tearDown();
   }
 
   /**

--- a/tests/phpunit/CRM/Core/BAO/CustomValueTableTest.php
+++ b/tests/phpunit/CRM/Core/BAO/CustomValueTableTest.php
@@ -6,6 +6,11 @@
  */
 class CRM_Core_BAO_CustomValueTableTest extends CiviUnitTestCase {
 
+  public function tearDown(): void {
+    $this->quickCleanup(['civicrm_file', 'civicrm_entity_file'], TRUE);
+    parent::tearDown();
+  }
+
   /**
    * Test store function for country.
    */
@@ -35,10 +40,6 @@ class CRM_Core_BAO_CustomValueTableTest extends CiviUnitTestCase {
     ];
 
     CRM_Core_BAO_CustomValueTable::store($params, 'civicrm_contact', $contactID);
-
-    $this->customFieldDelete($customField['id']);
-    $this->customGroupDelete($customGroup['id']);
-    $this->contactDelete($contactID);
   }
 
   /**
@@ -70,16 +71,12 @@ class CRM_Core_BAO_CustomValueTableTest extends CiviUnitTestCase {
     ];
 
     CRM_Core_BAO_CustomValueTable::store($params, 'civicrm_contact', $contactID);
-
-    $this->customFieldDelete($customField['id']);
-    $this->customGroupDelete($customGroup['id']);
-    $this->contactDelete($contactID);
   }
 
   /**
    * Test store function for state province.
    */
-  public function testStoreStateProvince() {
+  public function testStoreStateProvince(): void {
     $contactID = $this->individualCreate();
     $customGroup = $this->customGroupCreate();
     $fields = [
@@ -104,16 +101,12 @@ class CRM_Core_BAO_CustomValueTableTest extends CiviUnitTestCase {
     ];
 
     CRM_Core_BAO_CustomValueTable::store($params, 'civicrm_contact', $contactID);
-
-    $this->customFieldDelete($customField['id']);
-    $this->customGroupDelete($customGroup['id']);
-    $this->contactDelete($contactID);
   }
 
   /**
    * Test store function for date.
    */
-  public function testStoreDate() {
+  public function testStoreDate(): void {
     $params = [];
     $contactID = $this->individualCreate();
     $customGroup = $this->customGroupCreate();
@@ -139,16 +132,12 @@ class CRM_Core_BAO_CustomValueTableTest extends CiviUnitTestCase {
     ];
 
     CRM_Core_BAO_CustomValueTable::store($params, 'civicrm_contact', $contactID);
-
-    $this->customFieldDelete($customField['id']);
-    $this->customGroupDelete($customGroup['id']);
-    $this->contactDelete($contactID);
   }
 
   /**
    * Test store function for rich text editor.
    */
-  public function testStoreRichTextEditor() {
+  public function testStoreRichTextEditor(): void {
     $params = [];
     $contactID = $this->individualCreate();
     $customGroup = $this->customGroupCreate();
@@ -173,16 +162,14 @@ class CRM_Core_BAO_CustomValueTableTest extends CiviUnitTestCase {
     ];
 
     CRM_Core_BAO_CustomValueTable::store($params, 'civicrm_contact', $contactID);
-
-    $this->customFieldDelete($customField['id']);
-    $this->customGroupDelete($customGroup['id']);
-    $this->contactDelete($contactID);
   }
 
   /**
    * Test store function for multiselect int.
+   *
+   * @throws \API_Exception
    */
-  public function testStoreMultiSelectInt() {
+  public function testStoreMultiSelectInt(): void {
     $contactID = $this->individualCreate();
     $customGroup = $this->customGroupCreate();
     $fields = [
@@ -219,17 +206,12 @@ class CRM_Core_BAO_CustomValueTableTest extends CiviUnitTestCase {
       ->addWhere('id', '=', $contactID)
       ->execute()->first();
     $this->assertEquals([1, 2], $customData['new_custom_group.Custom_Field']);
-
-    $this->customFieldDelete($customField['id']);
-    $this->customGroupDelete($customGroup['id']);
-    $this->contactDelete($contactID);
   }
 
   /**
    * Test getEntityValues function for stored value.
    */
-  public function testGetEntityValues() {
-
+  public function testGetEntityValues(): void {
     $params = [];
     $contactID = $this->individualCreate();
     $customGroup = $this->customGroupCreate(['extends' => 'Individual']);
@@ -257,16 +239,12 @@ class CRM_Core_BAO_CustomValueTableTest extends CiviUnitTestCase {
 
     $entityValues = CRM_Core_BAO_CustomValueTable::getEntityValues($contactID, 'Individual');
 
-    $this->assertEquals($entityValues[$customField['id']], '<p><strong>This is a <u>test</u></p>',
+    $this->assertEquals('<p><strong>This is a <u>test</u></p>', $entityValues[$customField['id']],
       'Checking same for returned value.'
     );
-    $this->customFieldDelete($customField['id']);
-    $this->customGroupDelete($customGroup['id']);
-    $this->contactDelete($contactID);
   }
 
-  public function testCustomGroupMultiple() {
-    $params = [];
+  public function testCustomGroupMultiple(): void {
     $contactID = $this->individualCreate();
     $customGroup = $this->customGroupCreate();
 
@@ -292,10 +270,6 @@ class CRM_Core_BAO_CustomValueTableTest extends CiviUnitTestCase {
 
     $this->assertEquals($params['custom_' . $customField['id'] . '_-1'], $result['custom_' . $customField['id']]);
     $this->assertEquals($params['entityID'], $result['entityID']);
-
-    $this->customFieldDelete($customField['id']);
-    $this->customGroupDelete($customGroup['id']);
-    $this->contactDelete($contactID);
   }
 
 }

--- a/tests/phpunit/CRM/Utils/Mail/EmailProcessorInboundTest.php
+++ b/tests/phpunit/CRM/Utils/Mail/EmailProcessorInboundTest.php
@@ -35,6 +35,7 @@ class CRM_Utils_Mail_EmailProcessorInboundTest extends CiviUnitTestCase {
     $this->callAPISuccess('MailSettings', 'delete', [
       'id' => $this->mailSettingsId,
     ]);
+    $this->quickCleanup(['civicrm_file', 'civicrm_entity_file']);
     parent::tearDown();
   }
 

--- a/tests/phpunit/api/v3/ContactTest.php
+++ b/tests/phpunit/api/v3/ContactTest.php
@@ -90,6 +90,8 @@ class api_v3_ContactTest extends CiviUnitTestCase {
       'civicrm_website',
       'civicrm_relationship',
       'civicrm_uf_match',
+      'civicrm_file',
+      'civicrm_entity_file',
       'civicrm_phone',
       'civicrm_address',
       'civicrm_acl_contact_cache',


### PR DESCRIPTION

Overview
----------------------------------------
Test tearDown fixes

Before
----------------------------------------
Can't figure out what is leaving 'civicrm_file' & 'civicrm_entity_file' records behind

After
----------------------------------------
Have tracked down some ...

Technical Details
----------------------------------------
Fixes places where parent:tearDown not called and civicrm_file &
civicrm_entity_file not truncated

Also note - increasing use of fail() rather than allowing
exceptions to bubble up in test functions in order
to not let tearDown be such a distraction & require annotation


Comments
----------------------------------------

