### PR TITLE
Add test and fix for API4 failing to decode strings stored as HTML

### DIFF
--- a/Civi/Api4/Generic/Traits/DAOActionTrait.php
+++ b/Civi/Api4/Generic/Traits/DAOActionTrait.php
@@ -149,6 +149,7 @@ trait DAOActionTrait {
       }
 
       $result[] = $this->baoToArray($createResult, $item);
+      \CRM_Utils_API_HTMLInputCoder::singleton()->decodeRows($result);
     }
 
     // Use bulk `writeRecords` method if the BAO doesn't have a create or add method

--- a/tests/phpunit/api/v4/Action/ResultTest.php
+++ b/tests/phpunit/api/v4/Action/ResultTest.php
@@ -34,4 +34,37 @@ class ResultTest extends UnitTestCase {
     $this->assertTrue(is_array(json_decode($json)));
   }
 
+  /**
+   * Knowing that the db layer HTML-encodes strings, we want to test
+   * that this ugliness is hidden from us as users of the API.
+   *
+   * @see https://issues.civicrm.org/jira/browse/CRM-11532
+   * @see https://lab.civicrm.org/dev/core/-/issues/1328
+   */
+  public function testNoDataCorruptionThroughEncoding() {
+
+    $original = 'hello < you';
+    $result = Contact::create(FALSE)
+      ->setValues(['display_name' => $original])
+      ->execute()->first();
+    $this->assertEquals($original, $result['display_name'],
+      "The value returned from Contact.create is different to the value sent."
+    );
+
+    $result = Contact::update(FALSE)
+      ->addWhere('id', '=', $result['id'])
+      ->setValues(['display_name' => $original])
+      ->execute()->first();
+    $this->assertEquals($original, $result['display_name'],
+      "The value returned from Contact.update is different to the value sent."
+    );
+
+    $result = Contact::get(FALSE)
+      ->addWhere('id', '=', $result['id'])
+      ->execute()->first();
+    $this->assertEquals($original, $result['display_name'],
+      "The value returned from Contact.get is different to the value sent."
+    );
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------

See
https://chat.civicrm.org/civicrm/pl/yw3u69gi1jnjuek6q8c1s7iq7c


Before
----------------------------------------

Calling an API DAO create or update with a string returns  htmlspecialchars(string) instead of the same string as you wanted to store.

This was not picked up by tests.


After
----------------------------------------

Same, but this is picked up by tests.

Technical Details
----------------------------------------

Note that .get actions seem to work OK.
