### PR TITLE
Missed message template updates from 5.39/5.40

### DIFF
--- a/CRM/Upgrade/Incremental/MessageTemplates.php
+++ b/CRM/Upgrade/Incremental/MessageTemplates.php
@@ -251,9 +251,12 @@ class CRM_Upgrade_Incremental_MessageTemplates {
       ],
       [
         'version' => '5.43.alpha1',
-        'upgrade_descriptor' => ts('Missed text version from 5.20'),
+        'upgrade_descriptor' => ts('Missed templates from earlier versions'),
         'templates' => [
           ['name' => 'contribution_online_receipt', 'type' => 'text'],
+          ['name' => 'case_activity', 'type' => 'html'],
+          ['name' => 'case_activity', 'type' => 'text'],
+          ['name' => 'case_activity', 'type' => 'subject'],
         ],
       ],
     ];


### PR DESCRIPTION
Overview
----------------------------------------
These were missed when they were updated in 5.39/5.40 so people will still have the old templates in their db.

I haven't put it against 5.42 because there were no functional changes and it's mostly about php 8 compatibility.