### PR TITLE
APIv4 - Add support for sql equations

### DIFF
--- a/Civi/Api4/Query/SqlEquation.php
+++ b/Civi/Api4/Query/SqlEquation.php
@@ -1,0 +1,109 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Query;
+
+/**
+ * Numeric sql expression
+ */
+class SqlEquation extends SqlExpression {
+
+  /**
+   * @var array
+   */
+  protected $args = [];
+
+  /**
+   * @var string[]
+   */
+  public static $arithmeticOperators = [
+    '+',
+    '-',
+    '*',
+    '/',
+  ];
+
+  /**
+   * @var string[]
+   */
+  public static $comparisonOperators = [
+    '<=',
+    '>=',
+    '<',
+    '>',
+    '=',
+    '!=',
+    '<=>',
+    'IS NOT',
+    'IS',
+    'BETWEEN',
+    'AND',
+  ];
+
+  protected function initialize() {
+    $arg = trim(substr($this->expr, strpos($this->expr, '(') + 1, -1));
+    $permitted = ['SqlField', 'SqlString', 'SqlNumber', 'SqlNull'];
+    $operators = array_merge(self::$arithmeticOperators, self::$comparisonOperators);
+    while (strlen($arg)) {
+      $this->args = array_merge($this->args, $this->captureExpressions($arg, $permitted, FALSE));
+      $op = $this->captureKeyword($operators, $arg);
+      if ($op) {
+        $this->args[] = $op;
+      }
+    }
+  }
+
+  /**
+   * Render the expression for insertion into the sql query
+   *
+   * @param array $fieldList
+   * @return string
+   */
+  public function render(array $fieldList): string {
+    $output = [];
+    foreach ($this->args as $arg) {
+      $output[] = is_string($arg) ? $arg : $arg->render($fieldList);
+    }
+    return '(' . implode(' ', $output) . ')';
+  }
+
+  /**
+   * Returns the alias to use for SELECT AS.
+   *
+   * @return string
+   */
+  public function getAlias(): string {
+    return $this->alias ?? \CRM_Utils_String::munge(trim($this->expr, ' ()'), '_', 256);
+  }
+
+  /**
+   * Change $dataType according to operator used in equation
+   *
+   * @see \Civi\Api4\Utils\FormattingUtil::formatOutputValues
+   * @param string $value
+   * @param string $dataType
+   * @return string
+   */
+  public function formatOutputValue($value, &$dataType) {
+    foreach (self::$comparisonOperators as $op) {
+      if (strpos($this->expr, " $op ")) {
+        $dataType = 'Boolean';
+      }
+    }
+    foreach (self::$arithmeticOperators as $op) {
+      if (strpos($this->expr, " $op ")) {
+        $dataType = 'Float';
+      }
+    }
+    return $value;
+  }
+
+}

--- a/Civi/Api4/Query/SqlExpression.php
+++ b/Civi/Api4/Query/SqlExpression.php
@@ -83,8 +83,12 @@ abstract class SqlExpression {
     $bracketPos = strpos($expr, '(');
     $firstChar = substr($expr, 0, 1);
     $lastChar = substr($expr, -1);
+    // Statement surrounded by brackets is an equation
+    if ($firstChar === '(' && $lastChar === ')') {
+      $className = 'SqlEquation';
+    }
     // If there are brackets but not the first character, we have a function
-    if ($bracketPos && $lastChar === ')') {
+    elseif ($bracketPos && $lastChar === ')') {
       $fnName = substr($expr, 0, $bracketPos);
       if ($fnName !== strtoupper($fnName)) {
         throw new \API_Exception('Sql function must be uppercase.');
@@ -172,6 +176,99 @@ abstract class SqlExpression {
    */
   public static function getDataType():? string {
     return static::$dataType;
+  }
+
+  /**
+   * Shift a keyword off the beginning of the argument string and return it.
+   *
+   * @param array $keywords
+   *   Whitelist of keywords
+   * @param string $arg
+   * @return mixed|null
+   */
+  protected function captureKeyword($keywords, &$arg) {
+    foreach ($keywords as $key) {
+      if (strpos($arg, $key . ' ') === 0) {
+        $arg = ltrim(substr($arg, strlen($key)));
+        return $key;
+      }
+    }
+    return NULL;
+  }
+
+  /**
+   * Shifts 0 or more expressions off the argument string and returns them
+   *
+   * @param string $arg
+   * @param array $mustBe
+   * @param bool $multi
+   * @return SqlExpression[]
+   * @throws \API_Exception
+   */
+  protected function captureExpressions(string &$arg, array $mustBe, bool $multi) {
+    $captured = [];
+    $arg = ltrim($arg);
+    while ($arg) {
+      $item = $this->captureExpression($arg);
+      $arg = ltrim(substr($arg, strlen($item)));
+      $expr = self::convert($item, FALSE, $mustBe);
+      $this->fields = array_merge($this->fields, $expr->getFields());
+      $captured[] = $expr;
+      // Keep going if we have a comma indicating another expression follows
+      if ($multi && substr($arg, 0, 1) === ',') {
+        $arg = ltrim(substr($arg, 1));
+      }
+      else {
+        break;
+      }
+    }
+    return $captured;
+  }
+
+  /**
+   * Scans the beginning of a string for an expression; stops when it hits delimiter
+   *
+   * @param $arg
+   * @return string
+   */
+  protected function captureExpression($arg) {
+    $isEscaped = $quote = NULL;
+    $item = '';
+    $quotes = ['"', "'"];
+    $brackets = [
+      ')' => '(',
+    ];
+    $enclosures = array_fill_keys($brackets, 0);
+    foreach (str_split($arg) as $char) {
+      if (!$isEscaped && in_array($char, $quotes, TRUE)) {
+        // Open quotes - we'll ignore everything inside
+        if (!$quote) {
+          $quote = $char;
+        }
+        // Close quotes
+        elseif ($char === $quote) {
+          $quote = NULL;
+        }
+      }
+      if (!$quote) {
+        // Delineates end of expression
+        if (($char == ',' || $char == ' ') && !array_filter($enclosures)) {
+          return $item;
+        }
+        // Open brackets - we'll ignore delineators inside
+        if (isset($enclosures[$char])) {
+          $enclosures[$char]++;
+        }
+        // Close brackets
+        if (isset($brackets[$char]) && $enclosures[$brackets[$char]]) {
+          $enclosures[$brackets[$char]]--;
+        }
+      }
+      $item .= $char;
+      // We are escaping the next char if this is a backslash not preceded by an odd number of backslashes
+      $isEscaped = $char === '\\' && ((strlen($item) - strlen(rtrim($item, '\\'))) % 2);
+    }
+    return $item;
   }
 
 }

--- a/Civi/Api4/Query/SqlFunctionIF.php
+++ b/Civi/Api4/Query/SqlFunctionIF.php
@@ -26,6 +26,7 @@ class SqlFunctionIF extends SqlFunction {
         'min_expr' => 3,
         'max_expr' => 3,
         'optional' => FALSE,
+        'must_be' => ['SqlEquation', 'SqlField', 'SqlFunction', 'SqlString', 'SqlNumber', 'SqlNull'],
         'ui_defaults' => [
           ['type' => 'SqlField', 'placeholder' => ts('If')],
           ['type' => 'SqlField', 'placeholder' => ts('Then')],

--- a/tests/phpunit/api/v4/Action/SqlExpressionTest.php
+++ b/tests/phpunit/api/v4/Action/SqlExpressionTest.php
@@ -21,6 +21,7 @@ namespace api\v4\Action;
 
 use api\v4\UnitTestCase;
 use Civi\Api4\Contact;
+use Civi\Api4\Email;
 
 /**
  * @group headless
@@ -93,6 +94,33 @@ class SqlExpressionTest extends UnitTestCase {
     Contact::get()
       ->addSelect('55 AS ok_alias')
       ->execute();
+  }
+
+  public function testSelectEquations() {
+    $contact = Contact::create(FALSE)->addValue('first_name', 'bob')
+      ->addChain('email', Email::create()->setValues(['email' => 'hello@example.com', 'contact_id' => '$id']))
+      ->execute()->first();
+    $result = Email::get(FALSE)
+      ->setSelect([
+        'IF((contact_id.first_name = "bob"), "Yes", "No") AS is_bob',
+        'IF((contact_id.first_name != "fred"), "No", "Yes") AS is_fred',
+        '(5 * 11)',
+        '(5 > 11) AS five_greater_eleven',
+        '(5 <= 11) AS five_less_eleven',
+        '(1 BETWEEN 0 AND contact_id) AS is_between',
+        '(illegal * stuff) AS illegal_stuff',
+      ])
+      ->addWhere('contact_id', '=', $contact['id'])
+      ->setLimit(1)
+      ->execute()
+      ->first();
+    $this->assertEquals('Yes', $result['is_bob']);
+    $this->assertEquals('No', $result['is_fred']);
+    $this->assertEquals('55', $result['5_11']);
+    $this->assertFalse($result['five_greater_eleven']);
+    $this->assertTrue($result['five_less_eleven']);
+    $this->assertTrue($result['is_between']);
+    $this->assertArrayNotHasKey('illegal_stuff', $result);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Allows equations e.g. `(1 + 1)` as sql expressions in the query.

Before
----------------------------------------
Not supported

After
----------------------------------------
Arithmetic and comparison operators supported as standalone equations. For example:

```
Contribution::get()
  ->addSelect('(total_amount - non_deductible_amount) AS deductible_amount')
  ->addSelect('(receive_date < thankyou_date) AS non_same_day_thanks')
  ->addSelect('IF((total_amount > 1000), 'Big', 'Small') AS my_opinion')
``` 

Technical Details
----------------------------------------
Expressions must be surrounded by parentheses with whitespace around the operators, e.g. `(5 + 5)` not `5+5`.

Comments
----------------------------------------
This is a POC for the sake of enhancing SearchKit. If this PR is merged then I'll work on a UI for it.

The diff looks big but most of it is just moving some functions to the parent class for reusability.
