### PR TITLE
[Ref] Extend email trait test, process more sanely

### DIFF
--- a/CRM/Contact/Form/Task/EmailTrait.php
+++ b/CRM/Contact/Form/Task/EmailTrait.php
@@ -138,24 +138,6 @@ trait CRM_Contact_Form_Task_EmailTrait {
     // are having to re-write contactIds afterwards due to this inappropriate variable setting
     // If we don't have any contact IDs, use the logged in contact ID
     $form->_contactIds = $form->_contactIds ?: [CRM_Core_Session::getLoggedInContactID()];
-
-    $fromEmailValues = CRM_Core_BAO_Email::getFromEmail();
-
-    if (empty($fromEmailValues)) {
-      CRM_Core_Error::statusBounce(ts('Your user record does not have a valid email address and no from addresses have been configured.'));
-    }
-
-    $form->_emails = $fromEmailValues;
-    $defaults = [];
-    $form->_fromEmails = $fromEmailValues;
-    if (is_numeric(key($form->_fromEmails))) {
-      $emailID = (int) key($form->_fromEmails);
-      $defaults = CRM_Core_BAO_Email::getEmailSignatureDefaults($emailID);
-    }
-    if (!Civi::settings()->get('allow_mail_from_logged_in_contact')) {
-      $defaults['from_email_address'] = current(CRM_Core_BAO_Domain::getNameAndEmail(FALSE, TRUE));
-    }
-    $form->setDefaults($defaults);
   }
 
   /**
@@ -269,7 +251,7 @@ trait CRM_Contact_Form_Task_EmailTrait {
 
     $this->add('text', 'subject', ts('Subject'), ['size' => 50, 'maxlength' => 254], TRUE);
 
-    $this->add('select', 'from_email_address', ts('From'), $this->_fromEmails, TRUE);
+    $this->add('select', 'from_email_address', ts('From'), $this->getFromEmails(), TRUE);
 
     CRM_Mailing_BAO_Mailing::commonCompose($this);
 
@@ -354,6 +336,27 @@ trait CRM_Contact_Form_Task_EmailTrait {
   }
 
   /**
+   * Set relevant default values.
+   *
+   * @return array
+   *
+   * @throws \API_Exception
+   * @throws \CRM_Core_Exception
+   */
+  public function setDefaultValues(): array {
+    $defaults = parent::setDefaultValues();
+    $fromEmails = $this->getFromEmails();
+    if (is_numeric(key($fromEmails))) {
+      $emailID = (int) key($fromEmails);
+      $defaults = CRM_Core_BAO_Email::getEmailSignatureDefaults($emailID);
+    }
+    if (!Civi::settings()->get('allow_mail_from_logged_in_contact')) {
+      $defaults['from_email_address'] = current(CRM_Core_BAO_Domain::getNameAndEmail(FALSE, TRUE));
+    }
+    return $defaults;
+  }
+
+  /**
    * Process the form after the input has been submitted and validated.
    *
    * @throws \CRM_Core_Exception
@@ -375,7 +378,7 @@ trait CRM_Contact_Form_Task_EmailTrait {
    * @param int $count
    *  The number of emails the user is attempting to send
    */
-  protected function bounceIfSimpleMailLimitExceeded($count) {
+  protected function bounceIfSimpleMailLimitExceeded($count): void {
     $limit = Civi::settings()->get('simple_mail_limit');
     if ($count > $limit) {
       CRM_Core_Error::statusBounce(ts('Please do not use this task to send a lot of emails (greater than %1). Many countries have legal requirements when sending bulk emails and the CiviMail framework has opt out functionality and domain tokens to help meet these.',
@@ -396,7 +399,7 @@ trait CRM_Contact_Form_Task_EmailTrait {
    * @throws \Civi\API\Exception\UnauthorizedException
    * @throws \API_Exception
    */
-  public function submit($formValues) {
+  public function submit($formValues): void {
     $this->saveMessageTemplate($formValues);
 
     $from = $formValues['from_email_address'] ?? NULL;
@@ -724,6 +727,18 @@ trait CRM_Contact_Form_Task_EmailTrait {
       return (int) $caseID;
     }
     return NULL;
+  }
+
+  /**
+   * @return array
+   */
+  protected function getFromEmails(): array {
+    $fromEmailValues = CRM_Core_BAO_Email::getFromEmail();
+
+    if (empty($fromEmailValues)) {
+      CRM_Core_Error::statusBounce(ts('Your user record does not have a valid email address and no from addresses have been configured.'));
+    }
+    return $fromEmailValues;
   }
 
 }

--- a/tests/phpunit/CRM/Contribute/Form/Task/EmailTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/Task/EmailTest.php
@@ -46,15 +46,26 @@ class CRM_Contribute_Form_Task_EmailTest extends CiviUnitTestCase {
     ]);
     $contribution1 = $this->contributionCreate(['contact_id' => $contact2]);
     $contribution2 = $this->contributionCreate(['total_amount' => 999, 'contact_id' => $contact1]);
-    $form = $this->getFormObject('CRM_Contribute_Form_Task_Email', ['cc_id' => '', 'bcc_id' => ''], [], [
+    $form = $this->getFormObject('CRM_Contribute_Form_Task_Email', [
+      'cc_id' => '',
+      'bcc_id' => '',
+      'to' => implode(',', [
+        $contact1 . '::teresajensen-nielsen65@spamalot.co.in',
+        $contact2 . '::bob@example.com',
+      ]),
+      'subject' => '{contact.display_name}',
+      'text_message' => '{contribution.total_amount}',
+      'html_message' => '{domain.name}',
+    ], [], [
       'radio_ts' => 'ts_sel',
-      'task' => CRM_Contribute_Task::TASK_EMAIL,
+      'task' => CRM_Core_Task::TASK_EMAIL,
       'mark_x_' . $contribution1 => 1,
       'mark_x_' . $contribution2 => 1,
     ]);
     $form->set('cid', $contact1 . ',' . $contact2);
     $form->buildForm();
     $this->assertEquals('<br/><br/>--Benny, Benny', $form->_defaultValues['html_message']);
+    $form->postProcess();
   }
 
 }

--- a/tests/phpunit/CRM/Contribute/Form/Task/EmailTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/Task/EmailTest.php
@@ -1,0 +1,60 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *  Test Email task.
+ *
+ * @package CiviCRM_APIv3
+ * @subpackage API_Contribution
+ * @group headless
+ */
+class CRM_Contribute_Form_Task_EmailTest extends CiviUnitTestCase {
+
+  /**
+   * Clean up after each test.
+   *
+   * @throws \CRM_Core_Exception
+   * @throws \API_Exception
+   */
+  public function tearDown(): void {
+    $this->quickCleanUpFinancialEntities();
+    parent::tearDown();
+  }
+
+  /**
+   * Test that email tokens are rendered.
+   */
+  public function testEmailTokens(): void {
+    Civi::settings()->set('max_attachments', 0);
+    $contact1 = $this->individualCreate();
+    $contact2 = $this->individualCreate();
+    $userID = $this->createLoggedInUser();
+    Civi::settings()->set('allow_mail_from_logged_in_contact', TRUE);
+    $this->callAPISuccess('Email', 'create', [
+      'contact_id' => $userID,
+      'email' => 'benny_jetts@example.com',
+      'signature_html' => 'Benny, Benny',
+      'is_primary' => 1,
+    ]);
+    $contribution1 = $this->contributionCreate(['contact_id' => $contact2]);
+    $contribution2 = $this->contributionCreate(['total_amount' => 999, 'contact_id' => $contact1]);
+    $form = $this->getFormObject('CRM_Contribute_Form_Task_Email', ['cc_id' => '', 'bcc_id' => ''], [], [
+      'radio_ts' => 'ts_sel',
+      'task' => CRM_Contribute_Task::TASK_EMAIL,
+      'mark_x_' . $contribution1 => 1,
+      'mark_x_' . $contribution2 => 1,
+    ]);
+    $form->set('cid', $contact1 . ',' . $contact2);
+    $form->buildForm();
+    $this->assertEquals('<br/><br/>--Benny, Benny', $form->_defaultValues['html_message']);
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
[Ref] Extend email trait test, process more sanely


Builds on https://github.com/civicrm/civicrm-core/pull/21540 which is already a bit of a crazy battle!

Before
----------------------------------------
Weird process retrieves email addresses from the submitted 'to' values in the buildForm

After
----------------------------------------
Moved to the `postProcess` - now testable

Technical Details
----------------------------------------
This is an artefact of the way the email tasks used to all pass `$form` to a static function - it would up 'doing stuff where it could' in `buildForm` not in a sane place. This now uses `getSubmittedValues` - the same could be extended to the other weird loading stuff later on

Comments
----------------------------------------