### PR TITLE
[REF] Remove illusion of looping

### DIFF
--- a/CRM/Contact/Form/Task/PDFTrait.php
+++ b/CRM/Contact/Form/Task/PDFTrait.php
@@ -449,7 +449,8 @@ trait CRM_Contact_Form_Task_PDFTrait {
       CRM_Core_DAO::executeQuery($query);
 
       $documentInfo = CRM_Core_BAO_File::getEntityFile('civicrm_msg_template', $formValues['template']);
-      foreach ((array) $documentInfo as $info) {
+      if ($documentInfo) {
+        $info = reset($documentInfo);
         [$html_message, $formValues['document_type']] = CRM_Utils_PDF_Document::docReader($info['fullPath'], $info['mime_type']);
         $formValues['document_file_path'] = $info['fullPath'];
       }


### PR DESCRIPTION
Overview
----------------------------------------
[REF] Remove illusion of looping

This foreach actually only copes with 1 value. Making that clearer makes it more readable

Before
----------------------------------------
It loops through the attachments if any but only uses the 'last one'

After
----------------------------------------
It explicitly only grabs the first one

Technical Details
----------------------------------------
If the data model only copes with 1 then I don't think first vs last is material - the reality is it works with up to 1 attachment & clarifying that now means we don't have to later....

Most of this handling seems to be because it could be NULL rather than an array

This functionality appears to be about allowing an attachment to be  the message template - ie upload a doc as a template rather than save a message template - so more than 1 file makes no sense

Comments
----------------------------------------