### PR TITLE
dev/core#2493 Add support for money laundry in `getSubmittedValue`

### DIFF
--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -71,6 +71,16 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
   public $_action;
 
   /**
+   * Monetary fields that may be submitted.
+   *
+   * Any fields in this list will be converted to non-localised format
+   * if retrieved by `getSubmittedValue`
+   *
+   * @var array
+   */
+  protected $submittableMoneyFields = [];
+
+  /**
    * Available payment processors.
    *
    * As part of trying to consolidate various payment pages we store processors here & have functions
@@ -2746,7 +2756,11 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
     if (empty($this->exportedValues)) {
       $this->exportedValues = $this->controller->exportValues($this->_name);
     }
-    return $this->exportedValues[$fieldName] ?? NULL;
+    $value = $this->exportedValues[$fieldName] ?? NULL;
+    if (in_array($fieldName, $this->submittableMoneyFields, TRUE)) {
+      return CRM_Utils_Rule::cleanMoney($value);
+    }
+    return $value;
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
This ensures that any money fields retrieved by  `getSubmittedValue` are
in a machine usable format.

https://lab.civicrm.org/dev/core/-/issues/2493#note_65321

Before
----------------------------------------
You might clean the money fields post submit but if you then access them using our increasingly-preferred helper you'll get the unclean version

After
----------------------------------------
The helper will launder your money

Technical Details
----------------------------------------

We've been switching to this function rather than 'passing around arrays'
but we need to ensure this function is returning clean money to
prevent regressions.

Comments
----------------------------------------
This relies on `submittableMoneyFields` being defined - which is fairly uniformly true in back office forms but needs work in front end forms