### PR TITLE
Solve escape-on-output with this one weird trick

### DIFF
--- a/tests/phpunit/CRM/Core/DAOTest.php
+++ b/tests/phpunit/CRM/Core/DAOTest.php
@@ -598,4 +598,41 @@ class CRM_Core_DAOTest extends CiviUnitTestCase {
     $this->assertNull($dao->expired_date);
   }
 
+  public function testHtmlEscapeInput() {
+    $contact = new CRM_Contact_DAO_Contact();
+    $contact->contact_type = 'Individual';
+    $contact->first_name = 'Greater > Than';
+    $contact->last_name = 'Less < Than';
+    $contact->middle_name = '&';
+    $contact->save();
+
+    $legacyQueryGet = CRM_Core_DAO::executeQuery('SELECT * FROM civicrm_contact WHERE id = ' . $contact->id);
+    $legacyQueryGet->fetch();
+    $this->assertEquals('Greater &gt; Than', $legacyQueryGet->first_name);
+    $this->assertEquals('Less &lt; Than', $legacyQueryGet->last_name);
+    $this->assertEquals('&', $legacyQueryGet->middle_name);
+
+    $legacyDaoGet = new CRM_Contact_DAO_Contact();
+    $legacyDaoGet->id = $contact->id;
+    $legacyDaoGet->find(TRUE);
+    $this->assertEquals('Greater &gt; Than', $legacyDaoGet->first_name);
+    $this->assertEquals('Less &lt; Than', $legacyDaoGet->last_name);
+    $this->assertEquals('&', $legacyDaoGet->middle_name);
+
+    $queryGet = CRM_Core_DAO::executeQuery('SELECT * FROM civicrm_contact WHERE id = ' . $contact->id);
+    $queryGet->setLegacyCrmMode(FALSE);
+    $queryGet->fetch();
+    $this->assertEquals('Greater > Than', $queryGet->first_name);
+    $this->assertEquals('Less < Than', $queryGet->last_name);
+    $this->assertEquals('&', $queryGet->middle_name);
+
+    $daoGet = new CRM_Contact_DAO_Contact();
+    $daoGet->id = $contact->id;
+    $daoGet->setLegacyCrmMode(FALSE);
+    $daoGet->find(TRUE);
+    $this->assertEquals('Greater > Than', $daoGet->first_name);
+    $this->assertEquals('Less < Than', $daoGet->last_name);
+    $this->assertEquals('&', $daoGet->middle_name);
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Experimental/POC which adds a test for https://github.com/civicrm/civicrm-packages/pull/333
The goal is to transition CiviCRM from an escape-on-input to an escape-on-output data model
See https://lab.civicrm.org/dev/core/-/issues/1328

Before
----------------------------------------
Strings stored html-encoded in the database from the form-layer and the api-layer, then decoded by the API.

After
----------------------------------------
This POC shows that strings can be stored unescaped in the database and then converted to the expected format when loaded either from the DAO or from an ad-hoc SELECT query.

Technical Details
----------------------------------------
Escape-on-input currently happens from 3 places:
- APIv3 create/update
- APIv4 create/update/save
- The form layer, specifically `HTML_QuickForm::exportValues()`

Note: the existing code does not escape every html character, only `<` and `>`.

While reading existing code I noted some inconsistencies in the current model (escape-on-input):
- Escaping from the form layer happens for inputs of type text/textarea that are not on the skipFields list
- Escaping from the API layer happens for *any* field not on the skipFields list - input type is not checked
- A potential gotcha is that any data saved via direct query or direct `$dao->save()` will not be automatically escaped (unless the data passes through the form layer)

Given the above, it would be difficult to predict exactly what data in the database is already html-escaped, but I think it would be relatively safe to do a bulk upgrade (using batches of course) to un-escape every text field not on the skipFields list. Probably with a few additional caveats such as the field cannot be serialized with php-based serialization, the field cannot be a foreign-key, or have a pseudoconstant.

I also think we should tweak the [new legacy escape-on-output code](https://github.com/civicrm/civicrm-packages/pull/333) to take the above into consideration and narrow down the fields it will return escaped.

Comments
----------------------------------------
I hope the clickbait title gets everyone's attention :)
