### PR TITLE
Stop testing for gender_id output that was described as 'legacy' years ago

### DIFF
--- a/tests/phpunit/CRM/Core/BAO/ActionScheduleTest.php
+++ b/tests/phpunit/CRM/Core/BAO/ActionScheduleTest.php
@@ -880,8 +880,6 @@ class CRM_Core_BAO_ActionScheduleTest extends CiviUnitTestCase {
       '{contact.display_name}',
       // funny legacy contact token
       '{contact.gender}',
-      // funny legacy contact token
-      '{contact.gender_id}',
       // domain token
       '{domain.name}',
       // action-scheduler token
@@ -896,7 +894,7 @@ class CRM_Core_BAO_ActionScheduleTest extends CiviUnitTestCase {
     ]);
     // Note: The behavior of domain-tokens on a scheduled reminder is undefined. All we
     // can really do is check that it has something.
-    $someTokensExpected = 'Churmondleia Ōtākou;;Female;;Female;;[a-zA-Z0-9 ]+;;Phone Call';
+    $someTokensExpected = 'Churmondleia Ōtākou;;Female;;[a-zA-Z0-9 ]+;;Phone Call';
     $manyTokensExpected = sprintf('%s;;Dear Churmondleia;;%s', $someTokensExpected, '{contactCustomTokenValue}');
 
     // In this example, we use a lot of tokens cutting across multiple components.


### PR DESCRIPTION
Overview
----------------------------------------
Stop testing for gender_id output that was described as 'legacy' years ago

Before
----------------------------------------
The widget advertises `{contact.gender}`  but `{contact.gender_id}` is a hidden token. Both are non-standardness

We have test coverage locking in this non-standardness for both

After
----------------------------------------
We stop testing the non-standard hidden token & allow it to stop returning the label & revert back to the id or 'whatever' since it's not an 'official' token

[Documention is here](https://lab.civicrm.org/-/ide/project/documentation/docs/sysadmin/tree/case/-/docs/upgrade/version-specific.md/) for this token changing (the change is in a follow up PR but I wanted to get this merged to expose this decision & simplify that PR but taking the decision out of it) -  along with other edge case tokens being altered. By making this a 'thing' in 5.43 we can give people the notice to check & test.

Technical Details
----------------------------------------
`{contact.gender_id}` has not been 'advertised' in the widget for years, if ever - last commit was in 2019 it was an array formatting commit

Comments
----------------------------------------
@colemanw @seamuslee001 
