### PR TITLE
CiviReport - avoid error in test environments when using built-in php web server

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -626,6 +626,10 @@ class CRM_Report_Form extends CRM_Core_Form {
 
       // set qfkey so that pager picks it up and use it in the "Next > Last >>" links.
       // FIXME: Note setting it in $_GET doesn't work, since pager generates link based on QUERY_STRING
+      if (!isset($_SERVER['QUERY_STRING'])) {
+        // in php 7.4 can do this with less lines with ??=
+        $_SERVER['QUERY_STRING'] = '';
+      }
       $_SERVER['QUERY_STRING'] .= "&qfKey={$this->controller->_key}";
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
Admittedly this is not something that comes up in core, but is a straightforward "if variable doesn't exist yet don't try to append to it".

Before
----------------------------------------
Error: $_SERVER['QUERY_STRING'] undefined 

After
----------------------------------------


Technical Details
----------------------------------------
Came up during https://lab.civicrm.org/extensions/cdntaxreceipts/-/merge_requests/153#note_65360 where it seems in apache `$_SERVER['QUERY_STRING']` is always at least set to '', whereas in php's built-in web server it might not exist.

The point being in different web server environments you can't assume $_SERVER array members already exist.

Comments
----------------------------------------
I've labelled "Has Test" in the sense that the above noted unit test is intended to be a regularly run test just not as part of the core tests. And that's how this came up. Feel free to remove.
