### PR TITLE
Do not send email notification to the user if `notify` is not set in the params

### DIFF
--- a/CRM/Utils/System/Drupal8.php
+++ b/CRM/Utils/System/Drupal8.php
@@ -82,10 +82,11 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
     //      self-registers.
     //    - 'register_pending_approval': Welcome message, user pending admin
     //      approval.
-    // @Todo: Should we only send off emails if $params['notify'] is set?
     switch (TRUE) {
       case $user_register_conf == 'admin_only' || $user->isAuthenticated():
-        _user_mail_notify('register_admin_created', $account);
+        if (!empty($params['notify'])) {
+          _user_mail_notify('register_admin_created', $account);
+        }
         break;
 
       case $user_register_conf == 'visitors':


### PR DESCRIPTION
Overview
----------------------------------------
Do not send email notification to the user if `notify` is not set in the params

Before
----------------------------------------
Create User sends email notification even if `$params['notify']` is set to FALSE.

After
----------------------------------------
Email is sent only if `$params['notify'] = true;`

Technical Details
-----------------------------------------

Spotted a ToDo comment in D8 file - 

>@Todo: Should we only send off emails if $params['notify'] is set?

which i think is yes, since we have the same implementation in D7 and Backdrop - https://github.com/civicrm/civicrm-core/blob/master/CRM/Utils/System/Drupal.php#L40