### PR TITLE
dev/core#2851 Fix send email task contribution tokens to the processor

### DIFF
--- a/CRM/Contact/Form/Task/EmailTrait.php
+++ b/CRM/Contact/Form/Task/EmailTrait.php
@@ -690,6 +690,11 @@ trait CRM_Contact_Form_Task_EmailTrait {
   /**
    * Prevent submission of deprecated tokens.
    *
+   * Note this rule can be removed after a transition period.
+   * It's mostly to help to ensure users don't get missing tokens
+   * or unexpected output after the 5.43 upgrade until any
+   * old templates have aged out.
+   *
    * @param array $fields
    *
    * @return bool|string[]
@@ -702,6 +707,10 @@ trait CRM_Contact_Form_Task_EmailTrait {
       '{contribution.payment_instrument}' => '{contribution.payment_instrument_id:label}',
       '{contribution.contribution_id}' => '{contribution.id}',
       '{contribution.contribution_source}' => '{contribution.source}',
+      '{contribution.contribution_status}' => '{contribution.contribution_status_id:label}',
+      '{contribution.contribution_cancel_date}' => '{contribution.cancel_date}',
+      '{contribution.type}' => '{contribution.financial_type_id:label}',
+      '{contribution.contribution_page_id}' => '{contribution.contribution_page_id:label}',
     ];
     $tokenErrors = [];
     foreach ($deprecatedTokens as $token => $replacement) {


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#2851 Fix send email task contribution tokens to the processor

Before
----------------------------------------
Contribution tokens for email trait rendered using the legacy `replaceContributionTokens` function

After
----------------------------------------
Token processor used

Technical Details
----------------------------------------
Note that this means the legacy tokens need to go from here. We upgraded them out of the scheduled reminders in 5.41 & this update blocks them from email task submission

```
  '{contribution.contribution_source}' => '{contribution.source}',
  '{contribution.contribution.status}' => 
  '{contribution.contribution_status_id:label}',
  '{contribution.contribution_cancel_date}', '{contribution.cancel_date}',
  '{contribution.type}' => '{contribution.financial_type_id:label}',
  '{contribution.payment_instrument}', '{contribution.payment_instrument_id:label}',
  '{contribution.contribution_page_id}', '{contribution.contribution_page_id:label}',
 ```

Also note - the behaviour is weird - if you select 2 contributions from the same person they get 1 email & tokens from the second contribution are used but not the first. This puts in a test that 'locks it in' & keeps the behaviour but it might be worth further discussion

Comments
----------------------------------------
I've updated the docs here

https://lab.civicrm.org/-/ide/project/documentation/docs/sysadmin/tree/case/-/docs/upgrade/version-specific.md/

Some of the token replacements were likely never available from this screen (scheduled reminders only) but I have listed all the replacements since it seems clearer in one place