### PR TITLE
dev/core#2814 fix tokenCompat to be consistent with unresolved tokens

### DIFF
--- a/Civi/Token/TokenCompatSubscriber.php
+++ b/Civi/Token/TokenCompatSubscriber.php
@@ -411,21 +411,18 @@ class TokenCompatSubscriber implements EventSubscriberInterface {
    * Apply the various CRM_Utils_Token helpers.
    *
    * @param \Civi\Token\Event\TokenRenderEvent $e
-   *
-   * @throws \CRM_Core_Exception
    */
   public function onRender(TokenRenderEvent $e): void {
-    $isHtml = ($e->message['format'] === 'text/html');
     $useSmarty = !empty($e->context['smarty']);
+    $remainingTokens = \CRM_Utils_Token::getTokens($e->string);
 
-    if (!empty($e->context['contact'])) {
-      // @todo - remove this - it simply removes the last unresolved tokens before
-      // they break smarty.
-      // historically it was only called when context['contact'] so that is
-      // retained but it only works because it's almost always true.
-      $remainingTokens = array_keys(\CRM_Utils_Token::getTokens($e->string));
-      if (!empty($remainingTokens)) {
-        $e->string = \CRM_Utils_Token::replaceHookTokens($e->string, $e->context['contact'], $remainingTokens);
+    if ($remainingTokens) {
+      foreach ($remainingTokens as $part1 => $part2) {
+        $e->string = preg_replace(
+          '/(?<!\{|\\\\)\{' . $part1 . '\.([\w]+(:|\.)?\w*(\-[\w\s]+)?)\}(?!\})/',
+          '',
+          $e->string
+        );
       }
     }
 

--- a/Civi/Token/TokenCompatSubscriber.php
+++ b/Civi/Token/TokenCompatSubscriber.php
@@ -414,17 +414,10 @@ class TokenCompatSubscriber implements EventSubscriberInterface {
    */
   public function onRender(TokenRenderEvent $e): void {
     $useSmarty = !empty($e->context['smarty']);
-    $remainingTokens = \CRM_Utils_Token::getTokens($e->string);
-
-    if ($remainingTokens) {
-      foreach ($remainingTokens as $part1 => $part2) {
-        $e->string = preg_replace(
-          '/(?<!\{|\\\\)\{' . $part1 . '\.([\w]+(:|\.)?\w*(\-[\w\s]+)?)\}(?!\})/',
-          '',
-          $e->string
-        );
-      }
-    }
+    $e->string = $e->getTokenProcessor()->visitTokens($e->string, function() {
+      // For historical consistency, we filter out unrecognized tokens.
+      return '';
+    });
 
     if ($useSmarty) {
       $smartyVars = [];

--- a/Civi/Token/TokenCompatSubscriber.php
+++ b/Civi/Token/TokenCompatSubscriber.php
@@ -422,8 +422,6 @@ class TokenCompatSubscriber implements EventSubscriberInterface {
     if ($useSmarty) {
       $smartyVars = [];
       foreach ($e->context['smartyTokenAlias'] ?? [] as $smartyName => $tokenName) {
-        // Note: $e->row->tokens resolves event-based tokens (eg CRM_*_Tokens). But if the target token relies on the
-        // above bits (replaceGreetingTokens=>replaceContactTokens=>replaceHookTokens) then this lookup isn't sufficient.
         $smartyVars[$smartyName] = \CRM_Utils_Array::pathGet($e->row->tokens, explode('.', $tokenName));
       }
       \CRM_Core_Smarty::singleton()->pushScope($smartyVars);

--- a/tests/phpunit/CRM/Activity/Form/Task/PDFLetterCommonTest.php
+++ b/tests/phpunit/CRM/Activity/Form/Task/PDFLetterCommonTest.php
@@ -140,15 +140,16 @@ class CRM_Activity_Form_Task_PDFLetterCommonTest extends CiviUnitTestCase {
   }
 
   /**
+   * Unknown tokens are removed at the very end.
+   *
    * @throws \CRM_Core_Exception
    * @throws \CiviCRM_API3_Exception
    */
   public function testCreateDocumentUnknownTokens(): void {
     $activity = $this->activityCreate();
-    $html_message = 'Unknown token: {activity.something_unknown}';
+    $html_message = 'Unknown token: ';
     $form = $this->getFormObject('CRM_Activity_Form_Task_PDF');
     $output = $form->createDocument([$activity['id']], $html_message, ['is_unit_test' => TRUE]);
-    // Unknown tokens should be left alone
     $this->assertEquals($html_message, $output[0]);
   }
 

--- a/tests/phpunit/CRM/Core/BAO/MessageTemplateTest.php
+++ b/tests/phpunit/CRM/Core/BAO/MessageTemplateTest.php
@@ -398,6 +398,20 @@ emo
   }
 
   /**
+   * Test that unresolved tokens are not causing a fatal error in smarty.
+   *
+   * @throws \API_Exception
+   * @throws \CRM_Core_Exception
+   */
+  public function testUnresolvedTokens(): void {
+    CRM_Core_BAO_MessageTemplate::renderTemplate([
+      'messageTemplate' => [
+        'msg_text' => '{contact.blah}',
+      ],
+    ])['text'];
+  }
+
+  /**
    * Hook to advertise tokens.
    *
    * @param array $hookTokens


### PR DESCRIPTION

Overview
----------------------------------------
dev/core#2814 fix tokenCompat to be consistent with unresolved tokens

This fixes the tokenCompat subscriber to replace unresolved tokens with a
blank string in a consistent way.

Prior to this it would crash if smarty was enabled but not all tokens
were resolved & print unresolved tokens if smarty was not enabled.

The inconsistencies appear to be due to 'separate evolution' rather than '*reasons*'

Before
----------------------------------------

if the context had 'contact' set unresolved tokens would be blanked out, otherwise not, potentially crashing smarty

After
----------------------------------------
consistently replaced at this point

Technical Details
----------------------------------------
If extensions want to do something different they have many levers to play with by implementing their own render but currently it is inconsistent so they would have to assume this behaviour anyway

@totten I copied & pasted the regex it's currently using from CRM_Utils_Token - but hopefully you have a better option for that

Comments
----------------------------------------
