### PR TITLE
CRM_Utils_Date - Month and day names should match active locale

### DIFF
--- a/CRM/Utils/Date.php
+++ b/CRM/Utils/Date.php
@@ -160,8 +160,10 @@ class CRM_Utils_Date {
    *
    */
   public static function getAbbrWeekdayNames() {
-    static $days = [];
+    $key = 'abbrDays_' . \CRM_Core_I18n::getLocale();
+    $days = &\Civi::$statics[__CLASS__][$key];
     if (!$days) {
+      $days = [];
       // First day of the week
       $firstDay = Civi::settings()->get('weekBegins');
 
@@ -189,8 +191,10 @@ class CRM_Utils_Date {
    *
    */
   public static function getFullWeekdayNames() {
-    static $days = [];
+    $key = 'fullDays_' . \CRM_Core_I18n::getLocale();
+    $days = &\Civi::$statics[__CLASS__][$key];
     if (!$days) {
+      $days = [];
       // First day of the week
       $firstDay = Civi::settings()->get('weekBegins');
 
@@ -214,7 +218,8 @@ class CRM_Utils_Date {
    *
    */
   public static function &getAbbrMonthNames($month = FALSE) {
-    static $abbrMonthNames;
+    $key = 'abbrMonthNames_' . \CRM_Core_I18n::getLocale();
+    $abbrMonthNames = &\Civi::$statics[__CLASS__][$key];
     if (!isset($abbrMonthNames)) {
 
       // set LC_TIME and build the arrays from locale-provided names
@@ -237,11 +242,12 @@ class CRM_Utils_Date {
    *
    */
   public static function &getFullMonthNames() {
-    if (empty(\Civi::$statics[__CLASS__]['fullMonthNames'])) {
+    $key = 'fullMonthNames_' . \CRM_Core_I18n::getLocale();
+    if (empty(\Civi::$statics[__CLASS__][$key])) {
       // Not relying on strftime because it depends on the operating system
       // and most people will not have a non-US locale configured out of the box
       // Ignoring other date names for now, since less visible by default
-      \Civi::$statics[__CLASS__]['fullMonthNames'] = [
+      \Civi::$statics[__CLASS__][$key] = [
         1 => ts('January'),
         2 => ts('February'),
         3 => ts('March'),
@@ -257,7 +263,7 @@ class CRM_Utils_Date {
       ];
     }
 
-    return \Civi::$statics[__CLASS__]['fullMonthNames'];
+    return \Civi::$statics[__CLASS__][$key];
   }
 
   /**

--- a/tests/phpunit/CRM/Utils/DateTest.php
+++ b/tests/phpunit/CRM/Utils/DateTest.php
@@ -306,4 +306,22 @@ class CRM_Utils_DateTest extends CiviUnitTestCase {
     ], $date);
   }
 
+  public function testLocalizeConsts() {
+    $expect['en_US'] = ['Jan', 'Tue', 'March', 'Thursday'];
+    $expect['fr_FR'] = ['janv.', 'mar.', 'Mars', 'jeudi'];
+    $expect['es_MX'] = ['ene', 'mar', 'Marzo', 'jueves'];
+
+    foreach ($expect as $lang => $expectNames) {
+      $useLocale = CRM_Utils_AutoClean::swapLocale($lang);
+      $actualNames = [
+        CRM_Utils_Date::getAbbrMonthNames()[1],
+        CRM_Utils_Date::getAbbrWeekdayNames()[2],
+        CRM_Utils_Date::getFullMonthNames()[3],
+        CRM_Utils_Date::getFullWeekdayNames()[4],
+      ];
+      $this->assertEquals($expectNames, $actualNames, "Check temporal names in $lang");
+      unset($useLocale);
+    }
+  }
+
 }

--- a/tests/phpunit/Civi/Token/TokenProcessorTest.php
+++ b/tests/phpunit/Civi/Token/TokenProcessorTest.php
@@ -171,20 +171,23 @@ class TokenProcessorTest extends \CiviUnitTestCase {
   }
 
   public function testRenderLocalizedSmarty() {
+    \CRM_Utils_Time::setTime('2022-04-08 16:32:04');
+    $resetTime = \CRM_Utils_AutoClean::with(['CRM_Utils_Time', 'resetTime']);
+    $this->dispatcher->addSubscriber(new \CRM_Core_DomainTokens());
     $this->dispatcher->addSubscriber(new TokenCompatSubscriber());
     $p = new TokenProcessor($this->dispatcher, [
       'controller' => __CLASS__,
       'smarty' => TRUE,
     ]);
-    $p->addMessage('text', '{ts}Yes{/ts} {ts}No{/ts}', 'text/plain');
+    $p->addMessage('text', '{ts}Yes{/ts} {ts}No{/ts} {domain.now|crmDate:"%B"}', 'text/plain');
     $p->addRow([]);
     $p->addRow(['locale' => 'fr_FR']);
     $p->addRow(['locale' => 'es_MX']);
 
     $expectText = [
-      'Yes No',
-      'Oui Non',
-      'Sí No',
+      'Yes No April',
+      'Oui Non Avril',
+      'Sí No Abril',
     ];
 
     $rowCount = 0;


### PR DESCRIPTION
Overview
----------------------------------------

(*Note: Some of the unit-tests in this patch depend on items from #21531. The PR will look a lot smaller after merge+rebase.*)

This fixes a cache-bug in `CRM_Utils_Date` which prevents dates from being localized, as in a scenario like:

```php
CRM_Core_I18n::singleton()->setLocale('es_MX');
echo CRM_Utils_Date::customFormat(... '...%B...' ...);
CRM_Core_I18n::singleton()->setLocale('fr_FR');
echo CRM_Utils_Date::customFormat(... '...%B...' ...);
```

Before
----------------------------------------

The first time that it translates a month name (`%B`), `CRM_Utils_Date` stores a cache of all month names. This is shared by all locales. Thus, a French-speaking user may wind up seeing dates with Spanish names.

After
----------------------------------------

The cache of month names and date names is split (per-locale).

Technical Details
----------------------------------------

I included a lower-level test to show the various caches are locale-friendly - as well as a higher-level test to show that dates are localized when composing batch-messages for different people in different locales.