### PR TITLE
Fixes dev/core#2852 - Add is_primary as a default SearchKit filter

### DIFF
--- a/Civi/Api4/Address.php
+++ b/Civi/Api4/Address.php
@@ -19,6 +19,8 @@ namespace Civi\Api4;
  * Creating a new address requires at minimum a contact's ID and location type ID
  * and other attributes (although optional) like street address, city, country etc.
  *
+ * @ui_join_filters is_primary
+ *
  * @searchable secondary
  * @since 5.19
  * @package Civi\Api4

--- a/Civi/Api4/Email.php
+++ b/Civi/Api4/Email.php
@@ -17,6 +17,8 @@ namespace Civi\Api4;
  *
  * Creating a new email address requires at minimum a contact's ID and email
  *
+ * @ui_join_filters is_primary
+ *
  * @searchable secondary
  * @since 5.19
  * @package Civi\Api4

--- a/Civi/Api4/IM.php
+++ b/Civi/Api4/IM.php
@@ -13,6 +13,8 @@ namespace Civi\Api4;
 /**
  * IM entity.
  *
+ * @ui_join_filters is_primary
+ *
  * @searchable secondary
  * @since 5.19
  * @package Civi\Api4

--- a/Civi/Api4/Phone.php
+++ b/Civi/Api4/Phone.php
@@ -17,6 +17,8 @@ namespace Civi\Api4;
  *
  * Creating a new phone of a contact, requires at minimum a contact's ID and phone number
  *
+ * @ui_join_filters is_primary
+ *
  * @searchable secondary
  * @since 5.19
  * @package Civi\Api4

--- a/ext/search_kit/Civi/Search/Admin.php
+++ b/ext/search_kit/Civi/Search/Admin.php
@@ -355,13 +355,20 @@ class Admin {
     foreach ($entities as $entity) {
       foreach ($entity['ui_join_filters'] ?? [] as $fieldName) {
         $field = civicrm_api4($entity['name'], 'getFields', [
-          'select' => ['options'],
+          'select' => ['options', 'data_type'],
           'where' => [['name', '=', $fieldName]],
           'loadOptions' => ['name'],
         ])->first();
-        $value = isset($field['options'][0]) ? json_encode($field['options'][0]['name']) : '';
+        $value = '';
+        if ($field['data_type'] === 'Boolean') {
+          $value = TRUE;
+        }
+        elseif (isset($field['options'][0])) {
+          $fieldName .= ':name';
+          $value = json_encode($field['options'][0]['name']);
+        }
         $conditions[] = [
-          $alias . '.' . $fieldName . ($value ? ':name' : ''),
+          $alias . '.' . $fieldName,
           '=',
           $value,
         ];


### PR DESCRIPTION
Overview
----------------------------------------
When joining Contacts to emails, addresses, phones and IMs this will
automatically add is_primary=1 as a default search criteria.

See https://lab.civicrm.org/dev/core/-/issues/2852

Before
----------------------------------------
No default ON clause set

After
----------------------------------------
![Screenshot from 2021-09-22 10-49-50](https://user-images.githubusercontent.com/2874912/134366776-d69c3600-4e7d-4532-bef5-c97efae2cbdb.png)
