### PR TITLE
UFMatch - E_NOTICE when nonexistent uf_id

### DIFF
--- a/CRM/Core/BAO/UFMatch.php
+++ b/CRM/Core/BAO/UFMatch.php
@@ -624,13 +624,12 @@ AND    domain_id    = %4
       return [];
     }
 
-    static $ufValues;
-    if ($ufID && !isset($ufValues[$ufID])) {
+    if (!isset(Civi::$statics[__CLASS__][__FUNCTION__][$ufID])) {
       $ufmatch = new CRM_Core_DAO_UFMatch();
       $ufmatch->uf_id = $ufID;
       $ufmatch->domain_id = CRM_Core_Config::domainID();
       if ($ufmatch->find(TRUE)) {
-        $ufValues[$ufID] = [
+        Civi::$statics[__CLASS__][__FUNCTION__][$ufID] = [
           'uf_id' => $ufmatch->uf_id,
           'uf_name' => $ufmatch->uf_name,
           'contact_id' => $ufmatch->contact_id,
@@ -638,7 +637,7 @@ AND    domain_id    = %4
         ];
       }
     }
-    return $ufValues[$ufID];
+    return Civi::$statics[__CLASS__][__FUNCTION__][$ufID] ?? NULL;
   }
 
   /**

--- a/tests/phpunit/CRM/Core/BAO/UFMatchTest.php
+++ b/tests/phpunit/CRM/Core/BAO/UFMatchTest.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * Class CRM_Core_BAO_UFMatchTest
+ * @group headless
+ */
+class CRM_Core_BAO_UFMatchTest extends CiviUnitTestCase {
+
+  /**
+   * Don't crash if the uf_id doesn't exist
+   */
+  public function testGetUFValuesWithNonexistentUFId() {
+    $max_id = (int) CRM_Core_DAO::singleValueQuery('SELECT MAX(uf_id) FROM civicrm_uf_match');
+    $dontcrash = CRM_Core_BAO_UFMatch::getUFValues($max_id + 1);
+    $this->assertNull($dontcrash);
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Calling CRM_Core_BAO_UFMatch::getUFValues with a nonexistent uf_id gives an E_NOTICE.

Before
----------------------------------------
E_NOTICE

After
----------------------------------------
No notice.
Also use civi::statics.

Technical Details
----------------------------------------
The main thing is it calls `return $ufValues[$ufID];` without checking if it actually did set it.

Comments
----------------------------------------

