### PR TITLE
ensure recur options are present on backend cc contribution form.

### DIFF
--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -572,24 +572,23 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
     }
 
     $this->payment_instrument_id = CRM_Utils_Array::value('payment_instrument_id', $defaults, $this->getDefaultPaymentInstrumentId());
-    if (CRM_Core_Payment_Form::buildPaymentForm($this, $this->_paymentProcessor, FALSE, TRUE, $this->payment_instrument_id) == TRUE) {
-      if (!empty($this->_recurPaymentProcessors)) {
-        $buildRecurBlock = TRUE;
-        if ($this->_ppID) {
-          // ppID denotes a pledge payment.
-          foreach ($this->_paymentProcessors as $processor) {
-            if (!empty($processor['is_recur']) && !empty($processor['object']) && $processor['object']->supports('recurContributionsForPledges')) {
-              $buildRecurBlock = TRUE;
-              break;
-            }
-            $buildRecurBlock = FALSE;
+    CRM_Core_Payment_Form::buildPaymentForm($this, $this->_paymentProcessor, FALSE, TRUE, $this->payment_instrument_id);
+    if (!empty($this->_recurPaymentProcessors)) {
+      $buildRecurBlock = TRUE;
+      if ($this->_ppID) {
+        // ppID denotes a pledge payment.
+        foreach ($this->_paymentProcessors as $processor) {
+          if (!empty($processor['is_recur']) && !empty($processor['object']) && $processor['object']->supports('recurContributionsForPledges')) {
+            $buildRecurBlock = TRUE;
+            break;
           }
+          $buildRecurBlock = FALSE;
         }
-        if ($buildRecurBlock) {
-          CRM_Contribute_Form_Contribution_Main::buildRecur($this);
-          $this->setDefaults(['is_recur' => 0]);
-          $this->assign('buildRecurBlock', TRUE);
-        }
+      }
+      if ($buildRecurBlock) {
+        CRM_Contribute_Form_Contribution_Main::buildRecur($this);
+        $this->setDefaults(['is_recur' => 0]);
+        $this->assign('buildRecurBlock', TRUE);
       }
     }
     $this->addPaymentProcessorSelect(FALSE, $buildRecurBlock);

--- a/CRM/Core/Payment/Form.php
+++ b/CRM/Core/Payment/Form.php
@@ -222,13 +222,12 @@ class CRM_Core_Payment_Form {
     }
 
     if (!empty($processor['object']) && $processor['object']->buildForm($form)) {
-      return NULL;
+      return;
     }
 
     self::setPaymentFieldsByProcessor($form, $processor, $billing_profile_id, $isBackOffice, $paymentInstrumentID);
     self::addCommonFields($form, $form->_paymentFields);
     self::addRules($form, $form->_paymentFields);
-    return (!empty($form->_paymentFields));
   }
 
   /**

--- a/CRM/Core/Payment/Form.php
+++ b/CRM/Core/Payment/Form.php
@@ -211,8 +211,6 @@ class CRM_Core_Payment_Form {
    *   entering details but once again the issue is not back office but 'another user'.
    * @param int $paymentInstrumentID
    *   Payment instrument ID.
-   *
-   * @return bool
    */
   public static function buildPaymentForm(&$form, $processor, $billing_profile_id, $isBackOffice, $paymentInstrumentID = NULL) {
     //if the form has address fields assign to the template so the js can decide what billing fields to show


### PR DESCRIPTION
Overview
----------------------------------------
CiviCRM seems to be adding an extra check to see if the given payment processor has any credit card fields before including the recur option on the backend contribution page. But some processors, like Stripe, insert the fields via javascript. It should be enough to just test for the existence of a payment processor that supports recur to run the block.

Before
----------------------------------------

When using the stripe payment processor via the backend, there is no option to set a recurring contribution.

![before-fix-no-recur](https://user-images.githubusercontent.com/4511942/134397587-fa849061-fe52-4de2-ab84-161a743ead8e.png)



After
----------------------------------------

After applying the patch, it appears:

![after-fix-recur](https://user-images.githubusercontent.com/4511942/134397627-d1cd29bb-31b5-4e52-8a85-61d2f6ccbb96.png)


Technical Details
----------------------------------------

Messing with this kind of code is somewhat terrying. And... I really don't know why this check was put there in the first place.

Also tagging @mattwire - as far as I can tell, the ability to add recurring contributions via the back end has not been possible for a while, but I'm honestly not sure. This discovery came up somewhat randomly for us.

Also, despite the complicated looking diff, the only non-white space change introduced is to remove this if clause:

` if (CRM_Core_Payment_Form::buildPaymentForm($this, $this->_paymentProcessor, FALSE, TRUE, $this->payment_instrument_id) == TRUE)`

Instead, we simply rely on `if (!empty($this->_recurPaymentProcessors)) {` to determine whether or not to include the recur block.