### PR TITLE
dev/core#2856 - Token "filter" can be null so filter[0] doesn't exist

### DIFF
--- a/Civi/Token/TokenProcessor.php
+++ b/Civi/Token/TokenProcessor.php
@@ -432,7 +432,7 @@ class TokenProcessor {
       $filter = ['crmDate'];
     }
 
-    switch ($filter[0]) {
+    switch ($filter[0] ?? NULL) {
       case NULL:
         return $value;
 


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/2856

Before
----------------------------------------
filter can be null so can't access filter[0]

After
----------------------------------------


Technical Details
----------------------------------------
Based on the lines above it's expected that filter can be null, but this will silence unexpected null-ness so not sure it's desirable. I haven't been able to keep up with the volume of token changes.

Comments
----------------------------------------
I was going to write a test but there's a slew of tests already failing on MAX, and how I noticed this was via non-core test that was working yesterday but was now failing.

FYI @eileenmcnaughton @totten 
