### PR TITLE
Add billingStateProvince and standardized property names

### DIFF
--- a/Civi/Payment/PropertyBag.php
+++ b/Civi/Payment/PropertyBag.php
@@ -26,13 +26,23 @@ class PropertyBag implements \ArrayAccess {
 
   protected static $propMap = [
     'amount'                      => TRUE,
+    'total_amount'                => 'amount',
     'billingStreetAddress'        => TRUE,
+    'billing_street_address'      => 'billingStreetAddress',
+    'street_address'              => 'billingStreetAddress',
     'billingSupplementalAddress1' => TRUE,
     'billingSupplementalAddress2' => TRUE,
     'billingSupplementalAddress3' => TRUE,
     'billingCity'                 => TRUE,
+    'billing_city'                => 'billingCity',
+    'city'                        => 'billingCity',
     'billingPostalCode'           => TRUE,
+    'billing_postal_code'         => 'billingPostalCode',
+    'postal_code'                 => 'billingPostalCode',
     'billingCounty'               => TRUE,
+    'billingStateProvince'        => TRUE,
+    'billing_state_province'      => 'billingStateProvince',
+    'state_province'              => 'billingStateProvince',
     'billingCountry'              => TRUE,
     'contactID'                   => TRUE,
     'contact_id'                  => 'contactID',
@@ -264,7 +274,7 @@ class PropertyBag implements \ArrayAccess {
     if ($newName === NULL) {
       if ($silent) {
         // Only for use by offsetExists
-        return;
+        return NULL;
       }
       throw new \InvalidArgumentException("Unknown property '$prop'.");
     }
@@ -300,7 +310,7 @@ class PropertyBag implements \ArrayAccess {
    *
    * @return PropertyBag $this object so you can chain set setters.
    */
-  protected function set($prop, $label, $value) {
+  protected function set($prop, $label = 'default', $value) {
     $this->props[$label][$prop] = $value;
     return $this;
   }
@@ -589,6 +599,27 @@ class PropertyBag implements \ArrayAccess {
    */
   public function setBillingCounty($input, $label = 'default') {
     return $this->set('billingCounty', $label, (string) $input);
+  }
+
+  /**
+   * BillingStateProvince getter.
+   *
+   * @return string
+   */
+  public function getBillingStateProvince($label = 'default') {
+    return $this->get('billingStateProvince', $label);
+  }
+
+  /**
+   * BillingStateProvince setter.
+   *
+   * Nb. we can't validate this unless we have the country ID too, so we don't.
+   *
+   * @param string $input
+   * @param string $label e.g. 'default'
+   */
+  public function setBillingStateProvince($input, $label = 'default') {
+    return $this->set('billingStateProvince', $label, (string) $input);
   }
 
   /**

--- a/Civi/Payment/PropertyBag.php
+++ b/Civi/Payment/PropertyBag.php
@@ -268,7 +268,12 @@ class PropertyBag implements \ArrayAccess {
     if ($newName === NULL && substr($prop, -2) === '-' . \CRM_Core_BAO_LocationType::getBilling()
       && isset(static::$propMap[substr($prop, 0, -2)])
     ) {
-      $newName = substr($prop, 0, -2);
+      $billingAddressProp = substr($prop, 0, -2);
+      $newName = static::$propMap[$billingAddressProp] ?? NULL;
+      if ($newName === TRUE) {
+        // Good, modern name.
+        return $billingAddressProp;
+      }
     }
 
     if ($newName === NULL) {

--- a/tests/phpunit/Civi/Payment/PropertyBagTest.php
+++ b/tests/phpunit/Civi/Payment/PropertyBagTest.php
@@ -409,9 +409,10 @@ class PropertyBagTest extends \PHPUnit\Framework\TestCase implements HeadlessInt
   }
 
   /**
-   *
    * Data provider for testOtherParams
+   * $prop, $legacy_names, $valid_values, $invalid_values
    *
+   * return array
    */
   public function otherParamsDataProvider() {
     $valid_bools = [['0' , FALSE], ['', FALSE], [0, FALSE], [FALSE, FALSE], [TRUE, TRUE], [1, TRUE], ['1', TRUE]];
@@ -420,13 +421,14 @@ class PropertyBagTest extends \PHPUnit\Framework\TestCase implements HeadlessInt
     $valid_ints = [[123, 123], ['123', 123]];
     $invalid_ints = [-1, 0, NULL, ''];
     return [
-      ['billingStreetAddress', [], $valid_strings_inc_null, []],
+      ['billingStreetAddress', ['billing_street_address', 'street_address', 'billing_street_address-5'], $valid_strings_inc_null, []],
       ['billingSupplementalAddress1', [], $valid_strings_inc_null, []],
       ['billingSupplementalAddress2', [], $valid_strings_inc_null, []],
       ['billingSupplementalAddress3', [], $valid_strings_inc_null, []],
-      ['billingCity', [], $valid_strings_inc_null, []],
-      ['billingPostalCode', [], $valid_strings_inc_null, []],
+      ['billingCity', ['billing_city', 'city', 'billing_city-5'], $valid_strings_inc_null, []],
+      ['billingPostalCode', ['billing_postal_code', 'postal_code', 'billing_postal_code-5'], $valid_strings_inc_null, []],
       ['billingCounty', [], $valid_strings_inc_null, []],
+      ['billingStateProvince', ['billing_state_province', 'state_province', 'billing_state_province-5'], $valid_strings_inc_null, []],
       ['billingCountry', [], [['GB', 'GB'], ['NZ', 'NZ']], ['XX', '', NULL, 0]],
       ['contributionID', ['contribution_id'], $valid_ints, $invalid_ints],
       ['contributionRecurID', ['contribution_recur_id'], $valid_ints, $invalid_ints],


### PR DESCRIPTION
Overview
----------------------------------------
Extracted from https://github.com/civicrm/civicrm-core/pull/21527. These are the simple bits that have been approved by @artfulrobot 

- Add in billingStateProvince and getter/setter which is required for full billingAddress coverage.
- Map additional legacy params to propertyBag standard params.

Before
----------------------------------------

After
----------------------------------------


Technical Details
----------------------------------------


Comments
----------------------------------------

