### PR TITLE
Extend token date handling to 'most' date fields

### DIFF
--- a/CRM/Core/EntityTokens.php
+++ b/CRM/Core/EntityTokens.php
@@ -63,7 +63,13 @@ class CRM_Core_EntityTokens extends AbstractTokenSubscriber {
         \CRM_Utils_Money::format($fieldValue, $this->getCurrency($row)));
     }
     if ($this->isDateField($field)) {
-      return $row->format('text/plain')->tokens($entity, $field, \CRM_Utils_Date::customFormat($fieldValue));
+      try {
+        return $row->format('text/plain')
+          ->tokens($entity, $field, new DateTime($fieldValue));
+      }
+      catch (Exception $e) {
+        Civi::log()->info('invalid date token');
+      }
     }
     $row->format('text/plain')->tokens($entity, $field, (string) $fieldValue);
   }

--- a/Civi/Token/TokenProcessor.php
+++ b/Civi/Token/TokenProcessor.php
@@ -452,6 +452,10 @@ class TokenProcessor {
 
     if ($value instanceof \DateTime && $filter === NULL) {
       $filter = ['crmDate'];
+      if ($value->format('His') === '000000') {
+        // if time is 'midnight' default to just date.
+        $filter[1] = 'Full';
+      }
     }
 
     switch ($filter[0] ?? NULL) {

--- a/Civi/Token/TokenRow.php
+++ b/Civi/Token/TokenRow.php
@@ -272,7 +272,7 @@ class TokenRow {
                 $htmlTokens[$entity][$field] = \CRM_Utils_String::purifyHTML($value);
               }
               else {
-                $htmlTokens[$entity][$field] = htmlentities($value);
+                $htmlTokens[$entity][$field] = is_object($value) ? $value : htmlentities($value);
               }
             }
           }

--- a/tests/phpunit/CRM/Activity/Form/Task/PDFLetterCommonTest.php
+++ b/tests/phpunit/CRM/Activity/Form/Task/PDFLetterCommonTest.php
@@ -29,7 +29,7 @@ class CRM_Activity_Form_Task_PDFLetterCommonTest extends CiviUnitTestCase {
     $activity = $this->activityCreate(['campaign_id' => $this->campaignCreate()]);
     $data = [
       ['Subject: {activity.subject}', 'Subject: Discussion on warm beer'],
-      ['Date: {activity.activity_date_time}', 'Date: ' . CRM_Utils_Date::customFormat(date('Ymd')) . ' 12:00 AM'],
+      ['Date: {activity.activity_date_time}', 'Date: ' . CRM_Utils_Date::customFormat(date('Ymd'))],
       ['Duration: {activity.duration}', 'Duration: 90'],
       ['Location: {activity.location}', 'Location: Baker Street'],
       ['Details: {activity.details}', 'Details: Lets schedule a meeting'],
@@ -127,17 +127,17 @@ class CRM_Activity_Form_Task_PDFLetterCommonTest extends CiviUnitTestCase {
     $this->markTestIncomplete('special tokens not yet merged - see https://github.com/civicrm/civicrm-core/pull/12012');
     $activity = $this->activityCreate();
     $data = [
-      ['Source First Name: {activity.source_first_name}', "Source First Name: Anthony"],
-      ['Target N First Name: {activity.target_N_first_name}', "Target N First Name: Julia"],
-      ['Target 0 First Name: {activity.target_0_first_name}', "Target 0 First Name: Julia"],
-      ['Target 1 First Name: {activity.target_1_first_name}', "Target 1 First Name: Julia"],
-      ['Target 2 First Name: {activity.target_2_first_name}', "Target 2 First Name: "],
-      ['Assignee N First Name: {activity.target_N_first_name}', "Assignee N First Name: Julia"],
-      ['Assignee 0 First Name: {activity.target_0_first_name}', "Assignee 0 First Name: Julia"],
-      ['Assignee 1 First Name: {activity.target_1_first_name}', "Assignee 1 First Name: Julia"],
-      ['Assignee 2 First Name: {activity.target_2_first_name}', "Assignee 2 First Name: "],
-      ['Assignee Count: {activity.assignees_count}', "Assignee Count: 1"],
-      ['Target Count: {activity.targets_count}', "Target Count: 1"],
+      ['Source First Name: {activity.source_first_name}', 'Source First Name: Anthony'],
+      ['Target N First Name: {activity.target_N_first_name}', 'Target N First Name: Julia'],
+      ['Target 0 First Name: {activity.target_0_first_name}', 'Target 0 First Name: Julia'],
+      ['Target 1 First Name: {activity.target_1_first_name}', 'Target 1 First Name: Julia'],
+      ['Target 2 First Name: {activity.target_2_first_name}', 'Target 2 First Name: '],
+      ['Assignee N First Name: {activity.target_N_first_name}', 'Assignee N First Name: Julia'],
+      ['Assignee 0 First Name: {activity.target_0_first_name}', 'Assignee 0 First Name: Julia'],
+      ['Assignee 1 First Name: {activity.target_1_first_name}', 'Assignee 1 First Name: Julia'],
+      ['Assignee 2 First Name: {activity.target_2_first_name}', 'Assignee 2 First Name: '],
+      ['Assignee Count: {activity.assignees_count}', 'Assignee Count: 1'],
+      ['Target Count: {activity.targets_count}', 'Target Count: 1'],
     ];
     $html_message = "\n" . implode("\n", CRM_Utils_Array::collect('0', $data)) . "\n";
     $form = $this->getFormObject('CRM_Activity_Form_Task_PDF');

--- a/tests/phpunit/CRM/Contribute/ActionMapping/ByTypeTest.php
+++ b/tests/phpunit/CRM/Contribute/ActionMapping/ByTypeTest.php
@@ -297,13 +297,13 @@ class CRM_Contribute_ActionMapping_ByTypeTest extends \Civi\ActionSchedule\Abstr
     $this->callAPISuccess('job', 'send_reminder', []);
     $expected = [
       'first name = Alice',
-      'receive_date = February 1st, 2015 12:00 AM',
+      'receive_date = February 1st, 2015',
       'contribution status id = 1',
       'new style status = Completed',
       'new style label = Completed Label**',
       'id ' . $this->ids['Contribution']['alice'],
       'id  - not valid for action schedule',
-      'cancel date August 9th, 2021 12:00 AM',
+      'cancel date August 9th, 2021',
       'source SSF',
       'financial type id = 1',
       'financial type name = Donation',
@@ -349,7 +349,7 @@ class CRM_Contribute_ActionMapping_ByTypeTest extends \Civi\ActionSchedule\Abstr
       TRUE
     );
     $expected = [
-      'receive_date = February 1st, 2015 12:00 AM',
+      'receive_date = February 1st, 2015',
       'new style status = Completed',
       'contribution status id = 1',
       'id ' . $this->ids['Contribution']['alice'],

--- a/tests/phpunit/CRM/Event/Form/Task/BadgeTest.php
+++ b/tests/phpunit/CRM/Event/Form/Task/BadgeTest.php
@@ -91,7 +91,7 @@ class CRM_Event_Form_Task_BadgeTest extends CiviUnitTestCase {
       '{event.start_date}' => 'October 21st',
       '{participant.status_id}' => 2,
       '{participant.role_id}' => 1,
-      '{participant.register_date}' => 'February 19th, 2007 12:00 AM',
+      '{participant.register_date}' => 'February 19th, 2007',
       '{participant.source}' => 'Wimbeldon',
       '{participant.fee_level}' => 'low',
       '{participant.fee_amount}' => NULL,

--- a/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
+++ b/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
@@ -288,6 +288,7 @@ No
         'start_date' => '2021-07-23 15:39:20',
         'end_date' => '2021-07-26 18:07:20',
         'cancel_date' => '2021-08-19 09:12:45',
+        'next_sched_contribution_date' => '2021-09-08',
         'cancel_reason' => 'Because',
         'amount' => 5990.99,
         'currency' => 'EUR',
@@ -340,9 +341,9 @@ inv123
 2
 Yes
 15
-
+September 8th, 2021
 0
-January 3rd, 2020 12:00 AM
+January 3rd, 2020
 Yes
 1
 2
@@ -602,6 +603,8 @@ December 21st, 2007
 
   /**
    * Test that domain tokens are consistently rendered.
+   *
+   * @throws \API_Exception
    */
   public function testEventTokenConsistency(): void {
     $mut = new CiviMailUtils($this);


### PR DESCRIPTION


Overview
----------------------------------------
Extend token date handling to 'most' date fields

Before
----------------------------------------
Only `{domain.now}` supports date formatting

After
----------------------------------------
Date tokens from contribution, contribution recur, participant, activity also support them

Technical Details
----------------------------------------

If this passes it has lots ot test cover to 'prove' notchange (good since we aren't adding any formatting) - but if it doesn't it will prove I haven't lost my marbles (seems unlikely that I haven't but giving definitive answers to questions like that is what unit tests are for)

Comments
----------------------------------------
