### PR TITLE
SearchKit - A random stable genius

### DIFF
--- a/Civi/Api4/Query/SqlFunction.php
+++ b/Civi/Api4/Query/SqlFunction.php
@@ -68,7 +68,10 @@ abstract class SqlFunction extends SqlExpression {
       ];
       if ($param['max_expr'] && (!$param['name'] || $param['name'] === $prefix)) {
         $exprs = $this->captureExpressions($arg, $param['must_be'], TRUE);
-        if (count($exprs) < $param['min_expr'] || count($exprs) > $param['max_expr']) {
+        if (
+          (count($exprs) < $param['min_expr'] || count($exprs) > $param['max_expr']) &&
+          !(!$exprs && $param['optional'])
+        ) {
           throw new \API_Exception('Incorrect number of arguments for SQL function ' . static::getName());
         }
         $this->args[$idx]['expr'] = $exprs;

--- a/Civi/Api4/Query/SqlFunctionRAND.php
+++ b/Civi/Api4/Query/SqlFunctionRAND.php
@@ -19,7 +19,12 @@ class SqlFunctionRAND extends SqlFunction {
   protected static $category = self::CATEGORY_MATH;
 
   protected static function params(): array {
-    return [];
+    return [
+      [
+        'optional' => TRUE,
+        'must_be' => ['SqlNumber'],
+      ],
+    ];
   }
 
   /**

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
@@ -349,6 +349,10 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
 
     $orderBy = [];
     foreach ($currentSort ?: $defaultSort as $item) {
+      // Apply seed to random sorting
+      if ($item[0] === 'RAND()' && isset($this->seed)) {
+        $item[0] = 'RAND(' . $this->seed . ')';
+      }
       $orderBy[$item[0]] = $item[1];
     }
     return $orderBy;

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/Run.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/Run.php
@@ -23,6 +23,14 @@ class Run extends AbstractRunAction {
   protected $limit;
 
   /**
+   * Integer used as a seed when ordering by RAND().
+   * This keeps the order stable enough to use a pager with random sorting.
+   *
+   * @var int
+   */
+  protected $seed;
+
+  /**
    * @param \Civi\Api4\Generic\Result $result
    * @throws \API_Exception
    */

--- a/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
+++ b/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
@@ -4,7 +4,8 @@
   // Trait provides base methods and properties common to all search display types
   angular.module('crmSearchDisplay').factory('searchDisplayBaseTrait', function(crmApi4) {
     var ts = CRM.ts('org.civicrm.search_kit'),
-      runCount = 0;
+      runCount = 0,
+      seed = Date.now();
 
     // Replace tokens keyed to rowData.
     // Pass view=true to replace with view value, otherwise raw value is used.
@@ -73,6 +74,7 @@
         var ctrl = this;
         this.limit = this.settings.limit;
         this.sort = this.settings.sort ? _.cloneDeep(this.settings.sort) : [];
+        this.seed = Date.now();
 
         this.getResults = _.debounce(function() {
           $scope.$apply(function() {
@@ -129,6 +131,7 @@
           display: this.display,
           sort: this.sort,
           limit: this.limit,
+          seed: this.seed,
           filters: _.assign({}, (this.afFieldset ? this.afFieldset.getFieldData() : {}), this.filters),
           afform: this.afFieldset ? this.afFieldset.getFormName() : null
         };


### PR DESCRIPTION
Overview
----------------------------------------
Allows the pager, edit-in-place, and bulk updates to work properly with random sorting.

Before
----------------------------------------
You can do this, but it will cause strange behavior with the pager and inline/bulk updates. Results will appear randomly on each page, making the pager unusable, and a record will "disappear" immediately after inline-editing because it gets shuffled to a different spot.

![Screenshot from 2021-09-23 10-07-41](https://user-images.githubusercontent.com/2874912/134522545-e438be57-ae06-4986-ba42-0234b96d49eb.png)


After
----------------------------------------
Works as expected.

Technical Details
----------------------------------------
Without a seed, `ORDER BY RAND()` will reshuffle the results every time, whereas searchkit expects a stable order. 

The solution is to generate a seed on the client-side when the display initializes, and re-use it every time results are fetched. This keeps the order stable, only reshuffling when the browser reloads the page.