### PR TITLE
Suppresses error logging on every page load when open_basedir restriction in effect: File(/CRM/Core/Smarty/plugins/) is not within the allowed path(s)

### DIFF
--- a/CRM/Core/Smarty.php
+++ b/CRM/Core/Smarty.php
@@ -98,7 +98,7 @@ class CRM_Core_Smarty extends Smarty {
     $this->use_sub_dirs = TRUE;
 
     $customPluginsDir = NULL;
-    if (isset($config->customPHPPathDir)) {
+    if (!empty($config->customPHPPathDir) || $config->customPHPPathDir === '0') {
       $customPluginsDir
         = $config->customPHPPathDir . DIRECTORY_SEPARATOR .
         'CRM' . DIRECTORY_SEPARATOR .


### PR DESCRIPTION
Suppresses error logging on every page load when open_basedir restriction in effect: File(/CRM/Core/Smarty/plugins/) is not within the allowed path(s)

Overview
----------------------------------------
Error log can be spammed on every CivICRM page load by PHP warnings about non-fatal reasons the directories can't be opened, for example:

> Got error 'PHP message: PHP Warning:  file_exists(): open_basedir restriction in effect. File(/CRM/Core/Smarty/plugins/) is not within the allowed path(s): (/var/www/vhosts/canetoadwhackers.org.au/:/tmp/) in /var/www/vhosts/canetoadwhackers.org.au/httpdocs/wp-content/plugins/civicrm/civicrm/CRM/Core/Smarty.php on line 114'

Before
----------------------------------------
Many useless log messages.

After
----------------------------------------
Less useless log messages.

Technical Details
----------------------------------------
Follows same approach as https://github.com/civicrm/civicrm-core/pull/11086

Comments
----------------------------------------

Agileware Ref: CIVICRM-1804