### PR TITLE
(Option 1 Targeted) Fix error log spam PHP message: PHP Warning: is_dir(): open_basedir restriction in effect. File ... is not within the allowed path(s)

### DIFF
--- a/Civi/API/Provider/MagicFunctionProvider.php
+++ b/Civi/API/Provider/MagicFunctionProvider.php
@@ -103,7 +103,7 @@ class MagicFunctionProvider implements EventSubscriberInterface, ProviderInterfa
     foreach ($include_dirs as $include_dir) {
       $api_dir = implode(DIRECTORY_SEPARATOR,
         [$include_dir, 'api', 'v' . $version]);
-      if (!is_dir($api_dir)) {
+      if (!@is_dir($api_dir)) {
         continue;
       }
       $iterator = new \DirectoryIterator($api_dir);
@@ -119,7 +119,7 @@ class MagicFunctionProvider implements EventSubscriberInterface, ProviderInterfa
 
         // Check for entities with standalone action files (eg "api/v3/MyEntity/MyAction.php").
         $action_dir = $api_dir . DIRECTORY_SEPARATOR . $file;
-        if (preg_match('/^[A-Z][A-Za-z0-9]*$/', $file) && is_dir($action_dir)) {
+        if (preg_match('/^[A-Z][A-Za-z0-9]*$/', $file) && @is_dir($action_dir)) {
           if (count(glob("$action_dir/[A-Z]*.php")) > 0) {
             $entities[] = $file;
           }
@@ -281,7 +281,7 @@ class MagicFunctionProvider implements EventSubscriberInterface, ProviderInterfa
       foreach ([$camelName, 'Generic'] as $name) {
         $action_dir = implode(DIRECTORY_SEPARATOR,
           [$include_dir, 'api', "v${version}", $name]);
-        if (!is_dir($action_dir)) {
+        if (!@is_dir($action_dir)) {
           continue;
         }
 


### PR DESCRIPTION
Fix error log spam PHP message: PHP Warning: is_dir(): open_basedir restriction in effect. File ... is not within the allowed path(s).

This is Option 1 of two possible approaches to solving this problem. This PR is a targeted approach. Option 2 is here, #21592

Overview
----------------------------------------
Fix error log spam PHP message: PHP Warning: is_dir(): open_basedir restriction in effect. File ... is not within the allowed path(s)

Before
----------------------------------------
Error message logged repeatedly when using CiviCRM backend. PHP message: PHP Warning: is_dir(): open_basedir restriction in effect. File ... is not within the allowed path(s)

After
----------------------------------------
No more error messages logged.

Technical Details
----------------------------------------
Same approach as #11086

Comments
----------------------------------------
Related to #21589

Agileware Ref: CIVICRM-1651 
