### PR TITLE
(Option 2 Find/Replace) Fix error log spam PHP message: PHP Warning: is_dir(): open_basedir restriction in effect. File ... is not within the allowed path(s)

### DIFF
--- a/CRM/Admin/Page/APIExplorer.php
+++ b/CRM/Admin/Page/APIExplorer.php
@@ -63,7 +63,7 @@ class CRM_Admin_Page_APIExplorer extends CRM_Core_Page {
     $paths = self::uniquePaths();
     foreach ($paths as $path) {
       $dir = \CRM_Utils_File::addTrailingSlash($path) . 'api' . DIRECTORY_SEPARATOR . 'v3' . DIRECTORY_SEPARATOR . 'examples';
-      if (is_dir($dir)) {
+      if (@is_dir($dir)) {
         foreach (scandir($dir) as $item) {
           if ($item && strpos($item, '.') === FALSE && array_search($item, $examples) === FALSE) {
             $examples[] = $item;
@@ -96,7 +96,7 @@ class CRM_Admin_Page_APIExplorer extends CRM_Core_Page {
       $paths = self::uniquePaths();
       foreach ($paths as $path) {
         $dir = \CRM_Utils_File::addTrailingSlash($path) . 'api' . DIRECTORY_SEPARATOR . 'v3' . DIRECTORY_SEPARATOR . 'examples' . DIRECTORY_SEPARATOR . $_GET['entity'];
-        if (is_dir($dir)) {
+        if (@is_dir($dir)) {
           foreach (scandir($dir) as $item) {
             $item = str_replace('.ex.php', '', $item);
             if ($item && strpos($item, '.') === FALSE) {

--- a/CRM/Api4/Services.php
+++ b/CRM/Api4/Services.php
@@ -79,7 +79,7 @@ class CRM_Api4_Services {
     );
     foreach ($locations as $location) {
       $path = \CRM_Utils_File::addTrailingSlash(dirname($location)) . str_replace('\\', DIRECTORY_SEPARATOR, $namespace);
-      if (!file_exists($path) || !is_dir($path)) {
+      if (!file_exists($path) || !@is_dir($path)) {
         $resource = new \Symfony\Component\Config\Resource\FileExistenceResource($path);
         $container->addResource($resource);
       }

--- a/CRM/Contact/Import/Form/DataSource.php
+++ b/CRM/Contact/Import/Form/DataSource.php
@@ -223,7 +223,7 @@ class CRM_Contact_Import_Form_DataSource extends CRM_Core_Form {
     global $civicrm_root;
     $dataSourceDir = $civicrm_root . DIRECTORY_SEPARATOR . 'CRM' . DIRECTORY_SEPARATOR . 'Import' . DIRECTORY_SEPARATOR . 'DataSource' . DIRECTORY_SEPARATOR;
     $dataSources = [];
-    if (!is_dir($dataSourceDir)) {
+    if (!@is_dir($dataSourceDir)) {
       $this->invalidConfig("Import DataSource directory $dataSourceDir does not exist");
     }
     if (!$dataSourceHandle = opendir($dataSourceDir)) {

--- a/CRM/Core/CodeGen/Util/File.php
+++ b/CRM/Core/CodeGen/Util/File.php
@@ -10,7 +10,7 @@ class CRM_Core_CodeGen_Util_File {
    * @param int $perm
    */
   public static function createDir($dir, $perm = 0755) {
-    if (!is_dir($dir)) {
+    if (!@is_dir($dir)) {
       mkdir($dir, $perm, TRUE);
     }
   }

--- a/CRM/Core/Component.php
+++ b/CRM/Core/Component.php
@@ -399,7 +399,7 @@ class CRM_Core_Component {
   public static function getComponentsFromFile($crmFolderDir) {
     $components = [];
     //traverse CRM folder and check for Info file
-    if (is_dir($crmFolderDir) && $dir = opendir($crmFolderDir)) {
+    if (@is_dir($crmFolderDir) && $dir = opendir($crmFolderDir)) {
       while ($subDir = readdir($dir)) {
         // skip the extensions diretory since it has an Info.php file also
         if ($subDir == 'Extension') {

--- a/CRM/Core/Config.php
+++ b/CRM/Core/Config.php
@@ -166,7 +166,7 @@ class CRM_Core_Config extends CRM_Core_Config_MagicMerge {
       $this->configAndLogDir,
       $this->customFileUploadDir,
     ] as $dir) {
-      if ($dir && is_dir($dir)) {
+      if ($dir && @is_dir($dir)) {
         CRM_Utils_File::restrictAccess($dir);
       }
     }

--- a/CRM/Core/Config/MagicMerge.php
+++ b/CRM/Core/Config/MagicMerge.php
@@ -242,7 +242,7 @@ class CRM_Core_Config_MagicMerge {
         if ($value) {
           $value = CRM_Utils_File::addTrailingSlash($value);
           if (isset($this->map[$k][2]) && in_array('mkdir', $this->map[$k][2])) {
-            if (!is_dir($value) && !CRM_Utils_File::createDir($value, FALSE)) {
+            if (!@is_dir($value) && !CRM_Utils_File::createDir($value, FALSE)) {
               CRM_Core_Session::setStatus(ts('Failed to make directory (%1) at "%2". Please update the settings or file permissions.', [
                 1 => $k,
                 2 => $value,

--- a/CRM/Core/I18n.php
+++ b/CRM/Core/I18n.php
@@ -199,7 +199,7 @@ class CRM_Core_I18n {
 
       // check which ones are available; add them to $all if not there already
       $codes = [];
-      if (is_dir(CRM_Core_I18n::getResourceDir()) && $dir = opendir(CRM_Core_I18n::getResourceDir())) {
+      if (@is_dir(CRM_Core_I18n::getResourceDir()) && $dir = opendir(CRM_Core_I18n::getResourceDir())) {
         while ($filename = readdir($dir)) {
           if (preg_match('/^[a-z][a-z]_[A-Z][A-Z]$/', $filename)) {
             $codes[] = $filename;

--- a/CRM/Core/Page/QUnit.php
+++ b/CRM/Core/Page/QUnit.php
@@ -32,7 +32,7 @@ class CRM_Core_Page_QUnit extends CRM_Core_Page {
     }
 
     $path = CRM_Extension_System::singleton()->getMapper()->keyToBasePath($ext);
-    if (!is_dir("$path/tests/qunit/$suite")) {
+    if (!@is_dir("$path/tests/qunit/$suite")) {
       throw new CRM_Core_Exception("Failed to locate test suite");
     }
 

--- a/CRM/Extension/Browser.php
+++ b/CRM/Extension/Browser.php
@@ -52,7 +52,7 @@ class CRM_Extension_Browser {
     $this->repoUrl = $repoUrl;
     $this->cacheDir = $cacheDir;
     $this->indexPath = empty($indexPath) ? self::SINGLE_FILE_PATH : $indexPath;
-    if ($cacheDir && !file_exists($cacheDir) && is_dir(dirname($cacheDir)) && is_writable(dirname($cacheDir))) {
+    if ($cacheDir && !file_exists($cacheDir) && @is_dir(dirname($cacheDir)) && is_writable(dirname($cacheDir))) {
       CRM_Utils_File::createDir($cacheDir, FALSE);
     }
   }
@@ -99,7 +99,7 @@ class CRM_Extension_Browser {
 
     $errors = [];
 
-    if (!$this->cacheDir || !is_dir($this->cacheDir) || !is_writable($this->cacheDir)) {
+    if (!$this->cacheDir || !@is_dir($this->cacheDir) || !is_writable($this->cacheDir)) {
       $civicrmDestination = urlencode(CRM_Utils_System::url('civicrm/admin/extensions', 'reset=1'));
       $url = CRM_Utils_System::url('civicrm/admin/setting/path', "reset=1&civicrmDestination=${civicrmDestination}");
       $errors[] = array(

--- a/CRM/Extension/Container/Basic.php
+++ b/CRM/Extension/Container/Basic.php
@@ -102,7 +102,7 @@ class CRM_Extension_Container_Basic implements CRM_Extension_Container_Interface
   public function checkRequirements() {
     $errors = [];
 
-    if (empty($this->baseDir) || !is_dir($this->baseDir)) {
+    if (empty($this->baseDir) || !@is_dir($this->baseDir)) {
       $errors[] = [
         'title' => ts('Invalid Base Directory'),
         'message' => ts('An extension container has been defined with a blank directory.'),

--- a/CRM/Extension/Container/Default.php
+++ b/CRM/Extension/Container/Default.php
@@ -30,7 +30,7 @@ class CRM_Extension_Container_Default extends CRM_Extension_Container_Basic {
 
     // In current configuration, we don't construct the default container
     // unless baseDir is set, so this error condition is more theoretical.
-    if (empty($this->baseDir) || !is_dir($this->baseDir)) {
+    if (empty($this->baseDir) || !@is_dir($this->baseDir)) {
       $civicrmDestination = urlencode(CRM_Utils_System::url('civicrm/admin/extensions', 'reset=1'));
       $url = CRM_Utils_System::url('civicrm/admin/setting/path', "reset=1&civicrmDestination=${civicrmDestination}");
       $errors[] = array(

--- a/CRM/Extension/Downloader.php
+++ b/CRM/Extension/Downloader.php
@@ -51,7 +51,7 @@ class CRM_Extension_Downloader {
   public function checkRequirements($extensionInfo = NULL) {
     $errors = [];
 
-    if (!$this->containerDir || !is_dir($this->containerDir) || !is_writable($this->containerDir)) {
+    if (!$this->containerDir || !@is_dir($this->containerDir) || !is_writable($this->containerDir)) {
       $civicrmDestination = urlencode(CRM_Utils_System::url('civicrm/admin/extensions', 'reset=1'));
       $url = CRM_Utils_System::url('civicrm/admin/setting/path', "reset=1&civicrmDestination=${civicrmDestination}");
       $errors[] = array(
@@ -166,7 +166,7 @@ class CRM_Extension_Downloader {
         return FALSE;
       }
       $extractedZipPath = $this->tmpDir . DIRECTORY_SEPARATOR . $zipSubDir;
-      if (is_dir($extractedZipPath)) {
+      if (@is_dir($extractedZipPath)) {
         if (!CRM_Utils_File::cleanDir($extractedZipPath, TRUE, FALSE)) {
           CRM_Core_Session::setStatus(ts('Unable to extract the extension: %1 cannot be cleared', array(1 => $extractedZipPath)), ts('Installation Error'), 'error');
           return FALSE;

--- a/CRM/Extension/Manager.php
+++ b/CRM/Extension/Manager.php
@@ -537,7 +537,7 @@ class CRM_Extension_Manager {
       while ($dao->fetch()) {
         try {
           $path = $this->fullContainer->getPath($dao->full_name);
-          $codeExists = !empty($path) && is_dir($path);
+          $codeExists = !empty($path) && @is_dir($path);
         }
         catch (CRM_Extension_Exception $e) {
           $codeExists = FALSE;

--- a/CRM/Extension/System.php
+++ b/CRM/Extension/System.php
@@ -129,7 +129,7 @@ class CRM_Extension_System {
       // At time of writing, D6, D7, and WP support cmsRootPath() but J does not
       if (NULL !== $this->parameters['cmsRootPath']) {
         $vendorPath = $this->parameters['cmsRootPath'] . DIRECTORY_SEPARATOR . 'vendor';
-        if (is_dir($vendorPath)) {
+        if (@is_dir($vendorPath)) {
           $containers['cmsvendor'] = new CRM_Extension_Container_Basic(
             $vendorPath,
             CRM_Utils_File::addTrailingSlash($this->parameters['userFrameworkBaseURL'], '/') . 'vendor',

--- a/CRM/Upgrade/Form.php
+++ b/CRM/Upgrade/Form.php
@@ -605,7 +605,7 @@ SET    version = '$version'
     $files = $source->findOrphanedFiles();
     $errors = [];
     foreach ($files as $file) {
-      if (is_dir($file['path'])) {
+      if (@is_dir($file['path'])) {
         @rmdir($file['path']);
       }
       else {

--- a/CRM/Utils/Check/Component/Env.php
+++ b/CRM/Utils/Check/Component/Env.php
@@ -542,7 +542,7 @@ class CRM_Utils_Check_Component_Env extends CRM_Utils_Check_Component {
       return $messages;
     }
 
-    if (!is_dir($basedir)) {
+    if (!@is_dir($basedir)) {
       $messages[] = new CRM_Utils_Check_Message(
         __FUNCTION__,
         ts('Your extensions directory path points to %1, which is not a directory.  Please check your file system.',

--- a/CRM/Utils/Check/Component/Security.php
+++ b/CRM/Utils/Check/Component/Security.php
@@ -302,7 +302,7 @@ class CRM_Utils_Check_Component_Security extends CRM_Utils_Check_Component {
    * @return bool
    */
   public function isBrowsable($dir, $url) {
-    if (empty($dir) || empty($url) || !is_dir($dir)) {
+    if (empty($dir) || empty($url) || !@is_dir($dir)) {
       return FALSE;
     }
 
@@ -337,7 +337,7 @@ class CRM_Utils_Check_Component_Security extends CRM_Utils_Check_Component {
    */
   public function isDirAccessible($dir, $url) {
     $url = rtrim($url, '/');
-    if (empty($dir) || empty($url) || !is_dir($dir)) {
+    if (empty($dir) || empty($url) || !@is_dir($dir)) {
       return FALSE;
     }
 

--- a/CRM/Utils/File.php
+++ b/CRM/Utils/File.php
@@ -92,7 +92,7 @@ class CRM_Utils_File {
    *   FALSE: Creation failed.
    */
   public static function createDir($path, $abort = TRUE) {
-    if (is_dir($path) || empty($path)) {
+    if (@is_dir($path) || empty($path)) {
       return NULL;
     }
 
@@ -133,7 +133,7 @@ class CRM_Utils_File {
         if (!in_array($sibling, $exceptions)) {
           $object = $target . DIRECTORY_SEPARATOR . $sibling;
 
-          if (is_dir($object)) {
+          if (@is_dir($object)) {
             CRM_Utils_File::cleanDir($object, $rmdir, $verbose);
           }
           elseif (is_file($object)) {
@@ -190,7 +190,7 @@ class CRM_Utils_File {
       @mkdir($destination);
       while (FALSE !== ($file = readdir($dh))) {
         if (($file != '.') && ($file != '..')) {
-          if (is_dir($source . DIRECTORY_SEPARATOR . $file)) {
+          if (@is_dir($source . DIRECTORY_SEPARATOR . $file)) {
             CRM_Utils_File::copyDir($source . DIRECTORY_SEPARATOR . $file, $destination . DIRECTORY_SEPARATOR . $file);
           }
           else {
@@ -528,7 +528,7 @@ class CRM_Utils_File {
     // note: empty value for $dir can play havoc, since that might result in putting '.htaccess' to root dir
     // of site, causing site to stop functioning.
     // FIXME: we should do more checks here -
-    if (!empty($dir) && is_dir($dir)) {
+    if (!empty($dir) && @is_dir($dir)) {
       $htaccess = <<<HTACCESS
 <Files "*">
 # Apache 2.2
@@ -559,7 +559,7 @@ HTACCESS;
    * @param $publicDir
    */
   public static function restrictBrowsing($publicDir) {
-    if (!is_dir($publicDir) || !is_writable($publicDir)) {
+    if (!@is_dir($publicDir) || !is_writable($publicDir)) {
       return;
     }
 
@@ -572,7 +572,7 @@ HTACCESS;
     // child dirs
     $dir = new RecursiveDirectoryIterator($publicDir);
     foreach ($dir as $name => $object) {
-      if (is_dir($name) && $name != '..') {
+      if (@is_dir($name) && $name != '..') {
         $nobrowse = realpath($name) . '/index.html';
         if (!file_exists($nobrowse)) {
           @file_put_contents($nobrowse, '');
@@ -742,7 +742,7 @@ HTACCESS;
    * @return array(string)
    */
   public static function findFiles($dir, $pattern, $relative = FALSE) {
-    if (!is_dir($dir) || !is_readable($dir)) {
+    if (!@is_dir($dir) || !is_readable($dir)) {
       return [];
     }
     // Which dirs should we exclude from our searches?
@@ -760,7 +760,7 @@ HTACCESS;
       $matches = glob("$subdir/$pattern");
       if (is_array($matches)) {
         foreach ($matches as $match) {
-          if (!is_dir($match)) {
+          if (!@is_dir($match)) {
             $result[] = $relative ? CRM_Utils_File::relativize($match, "$dir/") : $match;
           }
         }
@@ -777,7 +777,7 @@ HTACCESS;
             $entry !== '.'
             && $entry !== '..'
             && (empty($excludeDirsPattern) || !preg_match($excludeDirsPattern, $path))
-            && is_dir($path)
+            && @is_dir($path)
             && is_readable($path)
           ) {
             $todos[] = $path;
@@ -834,7 +834,7 @@ HTACCESS;
    *   TRUE on success
    */
   public static function replaceDir($fromDir, $toDir, $verbose = FALSE) {
-    if (is_dir($toDir)) {
+    if (@is_dir($toDir)) {
       if (!self::cleanDir($toDir, TRUE, $verbose)) {
         return FALSE;
       }

--- a/CRM/Utils/Mail/EmailProcessor.php
+++ b/CRM/Utils/Mail/EmailProcessor.php
@@ -54,7 +54,7 @@ class CRM_Utils_Mail_EmailProcessor {
    */
   public static function cleanupDir($dir, $age = 5184000) {
     // return early if we can’t read/write the dir
-    if (!is_writable($dir) or !is_readable($dir) or !is_dir($dir)) {
+    if (!is_writable($dir) or !is_readable($dir) or !@is_dir($dir)) {
       return;
     }
 
@@ -69,7 +69,7 @@ class CRM_Utils_Mail_EmailProcessor {
       }
 
       // it’s an old file/dir, so delete/recurse
-      is_dir("$dir/$file") ? self::cleanupDir("$dir/$file", $age) : unlink("$dir/$file");
+      @is_dir("$dir/$file") ? self::cleanupDir("$dir/$file", $age) : unlink("$dir/$file");
     }
   }
 

--- a/CRM/Utils/Rule.php
+++ b/CRM/Utils/Rule.php
@@ -874,7 +874,7 @@ class CRM_Utils_Rule {
    * @return bool
    */
   public static function settingPath($path) {
-    return is_dir(Civi::paths()->getPath($path));
+    return @is_dir(Civi::paths()->getPath($path));
   }
 
   /**

--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -1756,7 +1756,7 @@ class CRM_Utils_System {
     $inc_dirs = explode(PATH_SEPARATOR, get_include_path());
     foreach ($inc_dirs as $inc_dir) {
       $target_dir = $inc_dir . DIRECTORY_SEPARATOR . $relpath;
-      if (is_dir($target_dir)) {
+      if (@is_dir($target_dir)) {
         $cur_list = scandir($target_dir);
         foreach ($cur_list as $fname) {
           if ($fname != '.' && $fname != '..') {

--- a/Civi/API/Provider/MagicFunctionProvider.php
+++ b/Civi/API/Provider/MagicFunctionProvider.php
@@ -103,7 +103,7 @@ class MagicFunctionProvider implements EventSubscriberInterface, ProviderInterfa
     foreach ($include_dirs as $include_dir) {
       $api_dir = implode(DIRECTORY_SEPARATOR,
         [$include_dir, 'api', 'v' . $version]);
-      if (!is_dir($api_dir)) {
+      if (!@is_dir($api_dir)) {
         continue;
       }
       $iterator = new \DirectoryIterator($api_dir);
@@ -119,7 +119,7 @@ class MagicFunctionProvider implements EventSubscriberInterface, ProviderInterfa
 
         // Check for entities with standalone action files (eg "api/v3/MyEntity/MyAction.php").
         $action_dir = $api_dir . DIRECTORY_SEPARATOR . $file;
-        if (preg_match('/^[A-Z][A-Za-z0-9]*$/', $file) && is_dir($action_dir)) {
+        if (preg_match('/^[A-Z][A-Za-z0-9]*$/', $file) && @is_dir($action_dir)) {
           if (count(glob("$action_dir/[A-Z]*.php")) > 0) {
             $entities[] = $file;
           }
@@ -281,7 +281,7 @@ class MagicFunctionProvider implements EventSubscriberInterface, ProviderInterfa
       foreach ([$camelName, 'Generic'] as $name) {
         $action_dir = implode(DIRECTORY_SEPARATOR,
           [$include_dir, 'api', "v${version}", $name]);
-        if (!is_dir($action_dir)) {
+        if (!@is_dir($action_dir)) {
           continue;
         }
 

--- a/Civi/Api4/Action/Entity/Get.php
+++ b/Civi/Api4/Action/Entity/Get.php
@@ -89,7 +89,7 @@ class Get extends \Civi\Api4\Generic\BasicGetAction {
       );
       foreach ($locations as $location) {
         $dir = \CRM_Utils_File::addTrailingSlash(dirname($location)) . 'Civi/Api4';
-        if (is_dir($dir)) {
+        if (@is_dir($dir)) {
           foreach (glob("$dir/*.php") as $file) {
             $className = 'Civi\Api4\\' . basename($file, '.php');
             if (is_a($className, 'Civi\Api4\Generic\AbstractEntity', TRUE)) {

--- a/Civi/Api4/Action/GetActions.php
+++ b/Civi/Api4/Action/GetActions.php
@@ -60,7 +60,7 @@ class GetActions extends BasicGetAction {
    */
   private function scanDir($dir, $nameSpace) {
     $dir .= str_replace('\\', '/', $nameSpace);
-    if (is_dir($dir)) {
+    if (@is_dir($dir)) {
       foreach (glob("$dir/*.php") as $file) {
         $actionName = basename($file, '.php');
         $actionClass = new \ReflectionClass($nameSpace . '\\' . $actionName);

--- a/Civi/CiUtil/PHPUnitScanner.php
+++ b/Civi/CiUtil/PHPUnitScanner.php
@@ -37,7 +37,7 @@ class PHPUnitScanner {
     $finder = new Finder();
 
     foreach ($paths as $path) {
-      if (is_dir($path)) {
+      if (@is_dir($path)) {
         foreach ($finder->files()->in($paths)->name('*Test.php') as $file) {
           $testClass = self::_findTestClasses((string) $file);
           if (count($testClass) == 1) {

--- a/Civi/Core/Paths.php
+++ b/Civi/Core/Paths.php
@@ -84,7 +84,7 @@ class Paths {
       ->register('civicrm.l10n', function () {
         $dir = defined('CIVICRM_L10N_BASEDIR') ? CIVICRM_L10N_BASEDIR : \Civi::paths()->getPath('[civicrm.private]/l10n');
         return [
-          'path' => is_dir($dir) ? $dir : \Civi::paths()->getPath('[civicrm.root]/l10n'),
+          'path' => @is_dir($dir) ? $dir : \Civi::paths()->getPath('[civicrm.root]/l10n'),
         ];
       })
       ->register('cms', function () {

--- a/Civi/Core/SettingsMetadata.php
+++ b/Civi/Core/SettingsMetadata.php
@@ -87,7 +87,7 @@ class SettingsMetadata {
     $loadedFolders = [];
     foreach ($metaDataFolders as $metaDataFolder) {
       $realFolder = realpath($metaDataFolder);
-      if (is_dir($realFolder) && !isset($loadedFolders[$realFolder])) {
+      if (@is_dir($realFolder) && !isset($loadedFolders[$realFolder])) {
         $loadedFolders[$realFolder] = TRUE;
         $settingsMetadata = $settingsMetadata + self::loadSettingsMetadata($metaDataFolder);
       }

--- a/Civi/Test/Api3DocTrait.php
+++ b/Civi/Test/Api3DocTrait.php
@@ -120,7 +120,7 @@ trait Api3DocTrait {
 
     global $civicrm_root;
     if (file_exists($civicrm_root . '/tests/templates/documentFunction.tpl')) {
-      if (!is_dir($civicrm_root . "/api/v3/examples/$entity")) {
+      if (!@is_dir($civicrm_root . "/api/v3/examples/$entity")) {
         mkdir($civicrm_root . "/api/v3/examples/$entity");
       }
       $f = fopen($civicrm_root . "/api/v3/examples/$entity/$exampleName.ex.php", "w+b");

--- a/bin/givi
+++ b/bin/givi
@@ -215,7 +215,7 @@ class Givi {
 
     // Filter branch list based on what repos actually exist
     foreach (array_keys($this->repos) as $repo) {
-      if (!is_dir($this->repos[$repo])) {
+      if (!@is_dir($this->repos[$repo])) {
         unset($this->repos[$repo]);
       }
     }

--- a/distmaker/utils/joomlaxml.php
+++ b/distmaker/utils/joomlaxml.php
@@ -27,7 +27,7 @@ generateJoomlaConfig($version);
  * @internal param \mode $peram for that directory
  */
 function createDir($dir, $perm = 0755) {
-  if (!is_dir($dir)) {
+  if (!@is_dir($dir)) {
     echo "Outdir: $dir\n";
     mkdir($dir, $perm, TRUE);
   }

--- a/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php
+++ b/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php
@@ -180,7 +180,7 @@ class AfformAdminMeta {
     // Scan all extensions for entities & input types
     foreach (\CRM_Extension_System::singleton()->getMapper()->getActiveModuleFiles() as $ext) {
       $dir = \CRM_Utils_File::addTrailingSlash(dirname($ext['filePath']));
-      if (is_dir($dir)) {
+      if (@is_dir($dir)) {
         // Scan for entities
         foreach (glob($dir . 'afformEntities/*.php') as $file) {
           $entityInfo = include $file;

--- a/ext/afform/admin/afform_admin.civix.php
+++ b/ext/afform/admin/afform_admin.civix.php
@@ -267,7 +267,7 @@ function _afform_admin_civix_civicrm_managed(&$entities) {
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_caseTypes
  */
 function _afform_admin_civix_civicrm_caseTypes(&$caseTypes) {
-  if (!is_dir(__DIR__ . '/xml/case')) {
+  if (!@is_dir(__DIR__ . '/xml/case')) {
     return;
   }
 
@@ -295,7 +295,7 @@ function _afform_admin_civix_civicrm_caseTypes(&$caseTypes) {
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_angularModules
  */
 function _afform_admin_civix_civicrm_angularModules(&$angularModules) {
-  if (!is_dir(__DIR__ . '/ang')) {
+  if (!@is_dir(__DIR__ . '/ang')) {
     return;
   }
 
@@ -436,7 +436,7 @@ function _afform_admin_civix_fixNavigationMenuItems(&$nodes, &$maxNavID, $parent
  */
 function _afform_admin_civix_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
   $settingsDir = __DIR__ . DIRECTORY_SEPARATOR . 'settings';
-  if (!in_array($settingsDir, $metaDataFolders) && is_dir($settingsDir)) {
+  if (!in_array($settingsDir, $metaDataFolders) && @is_dir($settingsDir)) {
     $metaDataFolders[] = $settingsDir;
   }
 }

--- a/ext/afform/core/afform.civix.php
+++ b/ext/afform/core/afform.civix.php
@@ -267,7 +267,7 @@ function _afform_civix_civicrm_managed(&$entities) {
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_caseTypes
  */
 function _afform_civix_civicrm_caseTypes(&$caseTypes) {
-  if (!is_dir(__DIR__ . '/xml/case')) {
+  if (!@is_dir(__DIR__ . '/xml/case')) {
     return;
   }
 
@@ -295,7 +295,7 @@ function _afform_civix_civicrm_caseTypes(&$caseTypes) {
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_angularModules
  */
 function _afform_civix_civicrm_angularModules(&$angularModules) {
-  if (!is_dir(__DIR__ . '/ang')) {
+  if (!@is_dir(__DIR__ . '/ang')) {
     return;
   }
 
@@ -436,7 +436,7 @@ function _afform_civix_fixNavigationMenuItems(&$nodes, &$maxNavID, $parentID) {
  */
 function _afform_civix_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
   $settingsDir = __DIR__ . DIRECTORY_SEPARATOR . 'settings';
-  if (!in_array($settingsDir, $metaDataFolders) && is_dir($settingsDir)) {
+  if (!in_array($settingsDir, $metaDataFolders) && @is_dir($settingsDir)) {
     $metaDataFolders[] = $settingsDir;
   }
 }

--- a/ext/afform/html/afform_html.civix.php
+++ b/ext/afform/html/afform_html.civix.php
@@ -267,7 +267,7 @@ function _afform_html_civix_civicrm_managed(&$entities) {
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_caseTypes
  */
 function _afform_html_civix_civicrm_caseTypes(&$caseTypes) {
-  if (!is_dir(__DIR__ . '/xml/case')) {
+  if (!@is_dir(__DIR__ . '/xml/case')) {
     return;
   }
 
@@ -295,7 +295,7 @@ function _afform_html_civix_civicrm_caseTypes(&$caseTypes) {
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_angularModules
  */
 function _afform_html_civix_civicrm_angularModules(&$angularModules) {
-  if (!is_dir(__DIR__ . '/ang')) {
+  if (!@is_dir(__DIR__ . '/ang')) {
     return;
   }
 
@@ -436,7 +436,7 @@ function _afform_html_civix_fixNavigationMenuItems(&$nodes, &$maxNavID, $parentI
  */
 function _afform_html_civix_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
   $settingsDir = __DIR__ . DIRECTORY_SEPARATOR . 'settings';
-  if (!in_array($settingsDir, $metaDataFolders) && is_dir($settingsDir)) {
+  if (!in_array($settingsDir, $metaDataFolders) && @is_dir($settingsDir)) {
     $metaDataFolders[] = $settingsDir;
   }
 }

--- a/ext/afform/html/bin/add-zip-regex.php
+++ b/ext/afform/html/bin/add-zip-regex.php
@@ -26,7 +26,7 @@ foreach ($files as $file) {
   }
   $file = preg_replace(':^\./:', '', $file);
   $internalName = preg_replace($argv[2], $argv[3], $file);
-  if (file_exists($file) && is_dir($file)) {
+  if (file_exists($file) && @is_dir($file)) {
     $zip->addEmptyDir($internalName);
   }
   else {

--- a/ext/afform/mock/afform_mock.civix.php
+++ b/ext/afform/mock/afform_mock.civix.php
@@ -267,7 +267,7 @@ function _afform_mock_civix_civicrm_managed(&$entities) {
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_caseTypes
  */
 function _afform_mock_civix_civicrm_caseTypes(&$caseTypes) {
-  if (!is_dir(__DIR__ . '/xml/case')) {
+  if (!@is_dir(__DIR__ . '/xml/case')) {
     return;
   }
 
@@ -295,7 +295,7 @@ function _afform_mock_civix_civicrm_caseTypes(&$caseTypes) {
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_angularModules
  */
 function _afform_mock_civix_civicrm_angularModules(&$angularModules) {
-  if (!is_dir(__DIR__ . '/ang')) {
+  if (!@is_dir(__DIR__ . '/ang')) {
     return;
   }
 
@@ -436,7 +436,7 @@ function _afform_mock_civix_fixNavigationMenuItems(&$nodes, &$maxNavID, $parentI
  */
 function _afform_mock_civix_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
   $settingsDir = __DIR__ . DIRECTORY_SEPARATOR . 'settings';
-  if (!in_array($settingsDir, $metaDataFolders) && is_dir($settingsDir)) {
+  if (!in_array($settingsDir, $metaDataFolders) && @is_dir($settingsDir)) {
     $metaDataFolders[] = $settingsDir;
   }
 }

--- a/ext/afform/mock/tests/phpunit/api/v4/AfformFileUploadTest.php
+++ b/ext/afform/mock/tests/phpunit/api/v4/AfformFileUploadTest.php
@@ -149,7 +149,7 @@ EOHTML;
    */
   protected function mockUploadFile() {
     $tmpDir = sys_get_temp_dir();
-    $this->assertTrue($tmpDir && is_dir($tmpDir), 'Tmp dir must exist: ' . $tmpDir);
+    $this->assertTrue($tmpDir && @is_dir($tmpDir), 'Tmp dir must exist: ' . $tmpDir);
     $fileName = uniqid() . '.txt';
     $filePath = $tmpDir . '/' . $fileName;
     file_put_contents($filePath, 'Hello');

--- a/ext/authx/authx.civix.php
+++ b/ext/authx/authx.civix.php
@@ -238,7 +238,7 @@ function _authx_civix_find_files($dir, $pattern) {
   while (!empty($todos)) {
     $subdir = array_shift($todos);
     foreach (_authx_civix_glob("$subdir/$pattern") as $match) {
-      if (!is_dir($match)) {
+      if (!@is_dir($match)) {
         $result[] = $match;
       }
     }
@@ -247,7 +247,7 @@ function _authx_civix_find_files($dir, $pattern) {
         $path = $subdir . DIRECTORY_SEPARATOR . $entry;
         if ($entry[0] == '.') {
         }
-        elseif (is_dir($path)) {
+        elseif (@is_dir($path)) {
           $todos[] = $path;
         }
       }
@@ -291,7 +291,7 @@ function _authx_civix_civicrm_managed(&$entities) {
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_caseTypes
  */
 function _authx_civix_civicrm_caseTypes(&$caseTypes) {
-  if (!is_dir(__DIR__ . '/xml/case')) {
+  if (!@is_dir(__DIR__ . '/xml/case')) {
     return;
   }
 
@@ -319,7 +319,7 @@ function _authx_civix_civicrm_caseTypes(&$caseTypes) {
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_angularModules
  */
 function _authx_civix_civicrm_angularModules(&$angularModules) {
-  if (!is_dir(__DIR__ . '/ang')) {
+  if (!@is_dir(__DIR__ . '/ang')) {
     return;
   }
 
@@ -460,7 +460,7 @@ function _authx_civix_fixNavigationMenuItems(&$nodes, &$maxNavID, $parentID) {
  */
 function _authx_civix_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
   $settingsDir = __DIR__ . DIRECTORY_SEPARATOR . 'settings';
-  if (!in_array($settingsDir, $metaDataFolders) && is_dir($settingsDir)) {
+  if (!in_array($settingsDir, $metaDataFolders) && @is_dir($settingsDir)) {
     $metaDataFolders[] = $settingsDir;
   }
 }

--- a/ext/ckeditor4/CRM/Ckeditor4/Form/CKEditorConfig.php
+++ b/ext/ckeditor4/CRM/Ckeditor4/Form/CKEditorConfig.php
@@ -211,7 +211,7 @@ class CRM_Ckeditor4_Form_CKEditorConfig extends CRM_Core_Form {
           'text' => ucfirst($name),
           'icon' => NULL,
         ];
-        if (is_dir($dir . "icons")) {
+        if (@is_dir($dir . "icons")) {
           if (is_file($dir . "icons/$name.png")) {
             $plugins[$name]['icon'] = "bower_components/ckeditor/plugins/$name/icons/$name.png";
           }
@@ -311,7 +311,7 @@ class CRM_Ckeditor4_Form_CKEditorConfig extends CRM_Core_Form {
     if (!self::getConfigFile()) {
       $config = self::fileHeader() . "CKEDITOR.editorConfig = function( config ) {\n\tconfig.allowedContent = true;\n};\n";
       // Make sure directories exist
-      if (!is_dir(Civi::paths()->getPath('[civicrm.files]/persist'))) {
+      if (!@is_dir(Civi::paths()->getPath('[civicrm.files]/persist'))) {
         mkdir(Civi::paths()->getPath('[civicrm.files]/persist'));
       }
       $newFileName = Civi::paths()->getPath(self::CONFIG_FILEPATH . 'default.js');

--- a/ext/ckeditor4/ckeditor4.civix.php
+++ b/ext/ckeditor4/ckeditor4.civix.php
@@ -267,7 +267,7 @@ function _ckeditor4_civix_civicrm_managed(&$entities) {
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_caseTypes
  */
 function _ckeditor4_civix_civicrm_caseTypes(&$caseTypes) {
-  if (!is_dir(__DIR__ . '/xml/case')) {
+  if (!@is_dir(__DIR__ . '/xml/case')) {
     return;
   }
 
@@ -295,7 +295,7 @@ function _ckeditor4_civix_civicrm_caseTypes(&$caseTypes) {
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_angularModules
  */
 function _ckeditor4_civix_civicrm_angularModules(&$angularModules) {
-  if (!is_dir(__DIR__ . '/ang')) {
+  if (!@is_dir(__DIR__ . '/ang')) {
     return;
   }
 
@@ -436,7 +436,7 @@ function _ckeditor4_civix_fixNavigationMenuItems(&$nodes, &$maxNavID, $parentID)
  */
 function _ckeditor4_civix_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
   $settingsDir = __DIR__ . DIRECTORY_SEPARATOR . 'settings';
-  if (!in_array($settingsDir, $metaDataFolders) && is_dir($settingsDir)) {
+  if (!in_array($settingsDir, $metaDataFolders) && @is_dir($settingsDir)) {
     $metaDataFolders[] = $settingsDir;
   }
 }

--- a/ext/contributioncancelactions/contributioncancelactions.civix.php
+++ b/ext/contributioncancelactions/contributioncancelactions.civix.php
@@ -238,7 +238,7 @@ function _contributioncancelactions_civix_find_files($dir, $pattern) {
   while (!empty($todos)) {
     $subdir = array_shift($todos);
     foreach (_contributioncancelactions_civix_glob("$subdir/$pattern") as $match) {
-      if (!is_dir($match)) {
+      if (!@is_dir($match)) {
         $result[] = $match;
       }
     }
@@ -247,7 +247,7 @@ function _contributioncancelactions_civix_find_files($dir, $pattern) {
         $path = $subdir . DIRECTORY_SEPARATOR . $entry;
         if ($entry[0] == '.') {
         }
-        elseif (is_dir($path)) {
+        elseif (@is_dir($path)) {
           $todos[] = $path;
         }
       }
@@ -291,7 +291,7 @@ function _contributioncancelactions_civix_civicrm_managed(&$entities) {
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_caseTypes
  */
 function _contributioncancelactions_civix_civicrm_caseTypes(&$caseTypes) {
-  if (!is_dir(__DIR__ . '/xml/case')) {
+  if (!@is_dir(__DIR__ . '/xml/case')) {
     return;
   }
 
@@ -319,7 +319,7 @@ function _contributioncancelactions_civix_civicrm_caseTypes(&$caseTypes) {
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_angularModules
  */
 function _contributioncancelactions_civix_civicrm_angularModules(&$angularModules) {
-  if (!is_dir(__DIR__ . '/ang')) {
+  if (!@is_dir(__DIR__ . '/ang')) {
     return;
   }
 
@@ -460,7 +460,7 @@ function _contributioncancelactions_civix_fixNavigationMenuItems(&$nodes, &$maxN
  */
 function _contributioncancelactions_civix_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
   $settingsDir = __DIR__ . DIRECTORY_SEPARATOR . 'settings';
-  if (!in_array($settingsDir, $metaDataFolders) && is_dir($settingsDir)) {
+  if (!in_array($settingsDir, $metaDataFolders) && @is_dir($settingsDir)) {
     $metaDataFolders[] = $settingsDir;
   }
 }

--- a/ext/eventcart/eventcart.civix.php
+++ b/ext/eventcart/eventcart.civix.php
@@ -238,7 +238,7 @@ function _eventcart_civix_find_files($dir, $pattern) {
   while (!empty($todos)) {
     $subdir = array_shift($todos);
     foreach (_eventcart_civix_glob("$subdir/$pattern") as $match) {
-      if (!is_dir($match)) {
+      if (!@is_dir($match)) {
         $result[] = $match;
       }
     }
@@ -247,7 +247,7 @@ function _eventcart_civix_find_files($dir, $pattern) {
         $path = $subdir . DIRECTORY_SEPARATOR . $entry;
         if ($entry[0] == '.') {
         }
-        elseif (is_dir($path)) {
+        elseif (@is_dir($path)) {
           $todos[] = $path;
         }
       }
@@ -291,7 +291,7 @@ function _eventcart_civix_civicrm_managed(&$entities) {
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_caseTypes
  */
 function _eventcart_civix_civicrm_caseTypes(&$caseTypes) {
-  if (!is_dir(__DIR__ . '/xml/case')) {
+  if (!@is_dir(__DIR__ . '/xml/case')) {
     return;
   }
 
@@ -319,7 +319,7 @@ function _eventcart_civix_civicrm_caseTypes(&$caseTypes) {
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_angularModules
  */
 function _eventcart_civix_civicrm_angularModules(&$angularModules) {
-  if (!is_dir(__DIR__ . '/ang')) {
+  if (!@is_dir(__DIR__ . '/ang')) {
     return;
   }
 
@@ -460,7 +460,7 @@ function _eventcart_civix_fixNavigationMenuItems(&$nodes, &$maxNavID, $parentID)
  */
 function _eventcart_civix_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
   $settingsDir = __DIR__ . DIRECTORY_SEPARATOR . 'settings';
-  if (!in_array($settingsDir, $metaDataFolders) && is_dir($settingsDir)) {
+  if (!in_array($settingsDir, $metaDataFolders) && @is_dir($settingsDir)) {
     $metaDataFolders[] = $settingsDir;
   }
 }

--- a/ext/ewaysingle/ewaysingle.civix.php
+++ b/ext/ewaysingle/ewaysingle.civix.php
@@ -238,7 +238,7 @@ function _ewaysingle_civix_find_files($dir, $pattern) {
   while (!empty($todos)) {
     $subdir = array_shift($todos);
     foreach (_ewaysingle_civix_glob("$subdir/$pattern") as $match) {
-      if (!is_dir($match)) {
+      if (!@is_dir($match)) {
         $result[] = $match;
       }
     }
@@ -247,7 +247,7 @@ function _ewaysingle_civix_find_files($dir, $pattern) {
         $path = $subdir . DIRECTORY_SEPARATOR . $entry;
         if ($entry[0] == '.') {
         }
-        elseif (is_dir($path)) {
+        elseif (@is_dir($path)) {
           $todos[] = $path;
         }
       }
@@ -291,7 +291,7 @@ function _ewaysingle_civix_civicrm_managed(&$entities) {
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_caseTypes
  */
 function _ewaysingle_civix_civicrm_caseTypes(&$caseTypes) {
-  if (!is_dir(__DIR__ . '/xml/case')) {
+  if (!@is_dir(__DIR__ . '/xml/case')) {
     return;
   }
 
@@ -319,7 +319,7 @@ function _ewaysingle_civix_civicrm_caseTypes(&$caseTypes) {
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_angularModules
  */
 function _ewaysingle_civix_civicrm_angularModules(&$angularModules) {
-  if (!is_dir(__DIR__ . '/ang')) {
+  if (!@is_dir(__DIR__ . '/ang')) {
     return;
   }
 
@@ -460,7 +460,7 @@ function _ewaysingle_civix_fixNavigationMenuItems(&$nodes, &$maxNavID, $parentID
  */
 function _ewaysingle_civix_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
   $settingsDir = __DIR__ . DIRECTORY_SEPARATOR . 'settings';
-  if (!in_array($settingsDir, $metaDataFolders) && is_dir($settingsDir)) {
+  if (!in_array($settingsDir, $metaDataFolders) && @is_dir($settingsDir)) {
     $metaDataFolders[] = $settingsDir;
   }
 }

--- a/ext/financialacls/financialacls.civix.php
+++ b/ext/financialacls/financialacls.civix.php
@@ -238,7 +238,7 @@ function _financialacls_civix_find_files($dir, $pattern) {
   while (!empty($todos)) {
     $subdir = array_shift($todos);
     foreach (_financialacls_civix_glob("$subdir/$pattern") as $match) {
-      if (!is_dir($match)) {
+      if (!@is_dir($match)) {
         $result[] = $match;
       }
     }
@@ -247,7 +247,7 @@ function _financialacls_civix_find_files($dir, $pattern) {
         $path = $subdir . DIRECTORY_SEPARATOR . $entry;
         if ($entry[0] == '.') {
         }
-        elseif (is_dir($path)) {
+        elseif (@is_dir($path)) {
           $todos[] = $path;
         }
       }
@@ -291,7 +291,7 @@ function _financialacls_civix_civicrm_managed(&$entities) {
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_caseTypes
  */
 function _financialacls_civix_civicrm_caseTypes(&$caseTypes) {
-  if (!is_dir(__DIR__ . '/xml/case')) {
+  if (!@is_dir(__DIR__ . '/xml/case')) {
     return;
   }
 
@@ -319,7 +319,7 @@ function _financialacls_civix_civicrm_caseTypes(&$caseTypes) {
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_angularModules
  */
 function _financialacls_civix_civicrm_angularModules(&$angularModules) {
-  if (!is_dir(__DIR__ . '/ang')) {
+  if (!@is_dir(__DIR__ . '/ang')) {
     return;
   }
 
@@ -460,7 +460,7 @@ function _financialacls_civix_fixNavigationMenuItems(&$nodes, &$maxNavID, $paren
  */
 function _financialacls_civix_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
   $settingsDir = __DIR__ . DIRECTORY_SEPARATOR . 'settings';
-  if (!in_array($settingsDir, $metaDataFolders) && is_dir($settingsDir)) {
+  if (!in_array($settingsDir, $metaDataFolders) && @is_dir($settingsDir)) {
     $metaDataFolders[] = $settingsDir;
   }
 }

--- a/ext/flexmailer/flexmailer.civix.php
+++ b/ext/flexmailer/flexmailer.civix.php
@@ -238,7 +238,7 @@ function _flexmailer_civix_find_files($dir, $pattern) {
   while (!empty($todos)) {
     $subdir = array_shift($todos);
     foreach (_flexmailer_civix_glob("$subdir/$pattern") as $match) {
-      if (!is_dir($match)) {
+      if (!@is_dir($match)) {
         $result[] = $match;
       }
     }
@@ -247,7 +247,7 @@ function _flexmailer_civix_find_files($dir, $pattern) {
         $path = $subdir . DIRECTORY_SEPARATOR . $entry;
         if ($entry[0] == '.') {
         }
-        elseif (is_dir($path)) {
+        elseif (@is_dir($path)) {
           $todos[] = $path;
         }
       }
@@ -291,7 +291,7 @@ function _flexmailer_civix_civicrm_managed(&$entities) {
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_caseTypes
  */
 function _flexmailer_civix_civicrm_caseTypes(&$caseTypes) {
-  if (!is_dir(__DIR__ . '/xml/case')) {
+  if (!@is_dir(__DIR__ . '/xml/case')) {
     return;
   }
 
@@ -319,7 +319,7 @@ function _flexmailer_civix_civicrm_caseTypes(&$caseTypes) {
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_angularModules
  */
 function _flexmailer_civix_civicrm_angularModules(&$angularModules) {
-  if (!is_dir(__DIR__ . '/ang')) {
+  if (!@is_dir(__DIR__ . '/ang')) {
     return;
   }
 
@@ -460,7 +460,7 @@ function _flexmailer_civix_fixNavigationMenuItems(&$nodes, &$maxNavID, $parentID
  */
 function _flexmailer_civix_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
   $settingsDir = __DIR__ . DIRECTORY_SEPARATOR . 'settings';
-  if (!in_array($settingsDir, $metaDataFolders) && is_dir($settingsDir)) {
+  if (!in_array($settingsDir, $metaDataFolders) && @is_dir($settingsDir)) {
     $metaDataFolders[] = $settingsDir;
   }
 }

--- a/ext/greenwich/greenwich.civix.php
+++ b/ext/greenwich/greenwich.civix.php
@@ -238,7 +238,7 @@ function _greenwich_civix_find_files($dir, $pattern) {
   while (!empty($todos)) {
     $subdir = array_shift($todos);
     foreach (_greenwich_civix_glob("$subdir/$pattern") as $match) {
-      if (!is_dir($match)) {
+      if (!@is_dir($match)) {
         $result[] = $match;
       }
     }
@@ -247,7 +247,7 @@ function _greenwich_civix_find_files($dir, $pattern) {
         $path = $subdir . DIRECTORY_SEPARATOR . $entry;
         if ($entry[0] == '.') {
         }
-        elseif (is_dir($path)) {
+        elseif (@is_dir($path)) {
           $todos[] = $path;
         }
       }
@@ -291,7 +291,7 @@ function _greenwich_civix_civicrm_managed(&$entities) {
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_caseTypes
  */
 function _greenwich_civix_civicrm_caseTypes(&$caseTypes) {
-  if (!is_dir(__DIR__ . '/xml/case')) {
+  if (!@is_dir(__DIR__ . '/xml/case')) {
     return;
   }
 
@@ -319,7 +319,7 @@ function _greenwich_civix_civicrm_caseTypes(&$caseTypes) {
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_angularModules
  */
 function _greenwich_civix_civicrm_angularModules(&$angularModules) {
-  if (!is_dir(__DIR__ . '/ang')) {
+  if (!@is_dir(__DIR__ . '/ang')) {
     return;
   }
 
@@ -460,7 +460,7 @@ function _greenwich_civix_fixNavigationMenuItems(&$nodes, &$maxNavID, $parentID)
  */
 function _greenwich_civix_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
   $settingsDir = __DIR__ . DIRECTORY_SEPARATOR . 'settings';
-  if (!in_array($settingsDir, $metaDataFolders) && is_dir($settingsDir)) {
+  if (!in_array($settingsDir, $metaDataFolders) && @is_dir($settingsDir)) {
     $metaDataFolders[] = $settingsDir;
   }
 }

--- a/ext/legacycustomsearches/legacycustomsearches.civix.php
+++ b/ext/legacycustomsearches/legacycustomsearches.civix.php
@@ -267,7 +267,7 @@ function _legacycustomsearches_civix_civicrm_managed(&$entities) {
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_caseTypes
  */
 function _legacycustomsearches_civix_civicrm_caseTypes(&$caseTypes) {
-  if (!is_dir(__DIR__ . '/xml/case')) {
+  if (!@is_dir(__DIR__ . '/xml/case')) {
     return;
   }
 
@@ -295,7 +295,7 @@ function _legacycustomsearches_civix_civicrm_caseTypes(&$caseTypes) {
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_angularModules
  */
 function _legacycustomsearches_civix_civicrm_angularModules(&$angularModules) {
-  if (!is_dir(__DIR__ . '/ang')) {
+  if (!@is_dir(__DIR__ . '/ang')) {
     return;
   }
 
@@ -436,7 +436,7 @@ function _legacycustomsearches_civix_fixNavigationMenuItems(&$nodes, &$maxNavID,
  */
 function _legacycustomsearches_civix_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
   $settingsDir = __DIR__ . DIRECTORY_SEPARATOR . 'settings';
-  if (!in_array($settingsDir, $metaDataFolders) && is_dir($settingsDir)) {
+  if (!in_array($settingsDir, $metaDataFolders) && @is_dir($settingsDir)) {
     $metaDataFolders[] = $settingsDir;
   }
 }

--- a/ext/oauth-client/oauth_client.civix.php
+++ b/ext/oauth-client/oauth_client.civix.php
@@ -267,7 +267,7 @@ function _oauth_client_civix_civicrm_managed(&$entities) {
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_caseTypes
  */
 function _oauth_client_civix_civicrm_caseTypes(&$caseTypes) {
-  if (!is_dir(__DIR__ . '/xml/case')) {
+  if (!@is_dir(__DIR__ . '/xml/case')) {
     return;
   }
 
@@ -295,7 +295,7 @@ function _oauth_client_civix_civicrm_caseTypes(&$caseTypes) {
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_angularModules
  */
 function _oauth_client_civix_civicrm_angularModules(&$angularModules) {
-  if (!is_dir(__DIR__ . '/ang')) {
+  if (!@is_dir(__DIR__ . '/ang')) {
     return;
   }
 
@@ -436,7 +436,7 @@ function _oauth_client_civix_fixNavigationMenuItems(&$nodes, &$maxNavID, $parent
  */
 function _oauth_client_civix_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
   $settingsDir = __DIR__ . DIRECTORY_SEPARATOR . 'settings';
-  if (!in_array($settingsDir, $metaDataFolders) && is_dir($settingsDir)) {
+  if (!in_array($settingsDir, $metaDataFolders) && @is_dir($settingsDir)) {
     $metaDataFolders[] = $settingsDir;
   }
 }

--- a/ext/payflowpro/payflowpro.civix.php
+++ b/ext/payflowpro/payflowpro.civix.php
@@ -238,7 +238,7 @@ function _payflowpro_civix_find_files($dir, $pattern) {
   while (!empty($todos)) {
     $subdir = array_shift($todos);
     foreach (_payflowpro_civix_glob("$subdir/$pattern") as $match) {
-      if (!is_dir($match)) {
+      if (!@is_dir($match)) {
         $result[] = $match;
       }
     }
@@ -247,7 +247,7 @@ function _payflowpro_civix_find_files($dir, $pattern) {
         $path = $subdir . DIRECTORY_SEPARATOR . $entry;
         if ($entry[0] == '.') {
         }
-        elseif (is_dir($path)) {
+        elseif (@is_dir($path)) {
           $todos[] = $path;
         }
       }
@@ -291,7 +291,7 @@ function _payflowpro_civix_civicrm_managed(&$entities) {
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_caseTypes
  */
 function _payflowpro_civix_civicrm_caseTypes(&$caseTypes) {
-  if (!is_dir(__DIR__ . '/xml/case')) {
+  if (!@is_dir(__DIR__ . '/xml/case')) {
     return;
   }
 
@@ -319,7 +319,7 @@ function _payflowpro_civix_civicrm_caseTypes(&$caseTypes) {
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_angularModules
  */
 function _payflowpro_civix_civicrm_angularModules(&$angularModules) {
-  if (!is_dir(__DIR__ . '/ang')) {
+  if (!@is_dir(__DIR__ . '/ang')) {
     return;
   }
 
@@ -460,7 +460,7 @@ function _payflowpro_civix_fixNavigationMenuItems(&$nodes, &$maxNavID, $parentID
  */
 function _payflowpro_civix_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
   $settingsDir = __DIR__ . DIRECTORY_SEPARATOR . 'settings';
-  if (!in_array($settingsDir, $metaDataFolders) && is_dir($settingsDir)) {
+  if (!in_array($settingsDir, $metaDataFolders) && @is_dir($settingsDir)) {
     $metaDataFolders[] = $settingsDir;
   }
 }

--- a/ext/recaptcha/recaptcha.civix.php
+++ b/ext/recaptcha/recaptcha.civix.php
@@ -238,7 +238,7 @@ function _recaptcha_civix_find_files($dir, $pattern) {
   while (!empty($todos)) {
     $subdir = array_shift($todos);
     foreach (_recaptcha_civix_glob("$subdir/$pattern") as $match) {
-      if (!is_dir($match)) {
+      if (!@is_dir($match)) {
         $result[] = $match;
       }
     }
@@ -247,7 +247,7 @@ function _recaptcha_civix_find_files($dir, $pattern) {
         $path = $subdir . DIRECTORY_SEPARATOR . $entry;
         if ($entry[0] == '.') {
         }
-        elseif (is_dir($path)) {
+        elseif (@is_dir($path)) {
           $todos[] = $path;
         }
       }
@@ -291,7 +291,7 @@ function _recaptcha_civix_civicrm_managed(&$entities) {
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_caseTypes
  */
 function _recaptcha_civix_civicrm_caseTypes(&$caseTypes) {
-  if (!is_dir(__DIR__ . '/xml/case')) {
+  if (!@is_dir(__DIR__ . '/xml/case')) {
     return;
   }
 
@@ -319,7 +319,7 @@ function _recaptcha_civix_civicrm_caseTypes(&$caseTypes) {
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_angularModules
  */
 function _recaptcha_civix_civicrm_angularModules(&$angularModules) {
-  if (!is_dir(__DIR__ . '/ang')) {
+  if (!@is_dir(__DIR__ . '/ang')) {
     return;
   }
 
@@ -460,7 +460,7 @@ function _recaptcha_civix_fixNavigationMenuItems(&$nodes, &$maxNavID, $parentID)
  */
 function _recaptcha_civix_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
   $settingsDir = __DIR__ . DIRECTORY_SEPARATOR . 'settings';
-  if (!in_array($settingsDir, $metaDataFolders) && is_dir($settingsDir)) {
+  if (!in_array($settingsDir, $metaDataFolders) && @is_dir($settingsDir)) {
     $metaDataFolders[] = $settingsDir;
   }
 }

--- a/ext/search_kit/search_kit.civix.php
+++ b/ext/search_kit/search_kit.civix.php
@@ -267,7 +267,7 @@ function _search_kit_civix_civicrm_managed(&$entities) {
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_caseTypes
  */
 function _search_kit_civix_civicrm_caseTypes(&$caseTypes) {
-  if (!is_dir(__DIR__ . '/xml/case')) {
+  if (!@is_dir(__DIR__ . '/xml/case')) {
     return;
   }
 
@@ -295,7 +295,7 @@ function _search_kit_civix_civicrm_caseTypes(&$caseTypes) {
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_angularModules
  */
 function _search_kit_civix_civicrm_angularModules(&$angularModules) {
-  if (!is_dir(__DIR__ . '/ang')) {
+  if (!@is_dir(__DIR__ . '/ang')) {
     return;
   }
 
@@ -436,7 +436,7 @@ function _search_kit_civix_fixNavigationMenuItems(&$nodes, &$maxNavID, $parentID
  */
 function _search_kit_civix_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
   $settingsDir = __DIR__ . DIRECTORY_SEPARATOR . 'settings';
-  if (!in_array($settingsDir, $metaDataFolders) && is_dir($settingsDir)) {
+  if (!in_array($settingsDir, $metaDataFolders) && @is_dir($settingsDir)) {
     $metaDataFolders[] = $settingsDir;
   }
 }

--- a/ext/sequentialcreditnotes/sequentialcreditnotes.civix.php
+++ b/ext/sequentialcreditnotes/sequentialcreditnotes.civix.php
@@ -237,7 +237,7 @@ function _sequentialcreditnotes_civix_find_files($dir, $pattern) {
   while (!empty($todos)) {
     $subdir = array_shift($todos);
     foreach (_sequentialcreditnotes_civix_glob("$subdir/$pattern") as $match) {
-      if (!is_dir($match)) {
+      if (!@is_dir($match)) {
         $result[] = $match;
       }
     }
@@ -246,7 +246,7 @@ function _sequentialcreditnotes_civix_find_files($dir, $pattern) {
         $path = $subdir . DIRECTORY_SEPARATOR . $entry;
         if ($entry[0] == '.') {
         }
-        elseif (is_dir($path)) {
+        elseif (@is_dir($path)) {
           $todos[] = $path;
         }
       }
@@ -290,7 +290,7 @@ function _sequentialcreditnotes_civix_civicrm_managed(&$entities) {
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_caseTypes
  */
 function _sequentialcreditnotes_civix_civicrm_caseTypes(&$caseTypes) {
-  if (!is_dir(__DIR__ . '/xml/case')) {
+  if (!@is_dir(__DIR__ . '/xml/case')) {
     return;
   }
 
@@ -318,7 +318,7 @@ function _sequentialcreditnotes_civix_civicrm_caseTypes(&$caseTypes) {
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_angularModules
  */
 function _sequentialcreditnotes_civix_civicrm_angularModules(&$angularModules) {
-  if (!is_dir(__DIR__ . '/ang')) {
+  if (!@is_dir(__DIR__ . '/ang')) {
     return;
   }
 
@@ -459,7 +459,7 @@ function _sequentialcreditnotes_civix_fixNavigationMenuItems(&$nodes, &$maxNavID
  */
 function _sequentialcreditnotes_civix_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
   $settingsDir = __DIR__ . DIRECTORY_SEPARATOR;
-  if (!in_array($settingsDir, $metaDataFolders) && is_dir($settingsDir)) {
+  if (!in_array($settingsDir, $metaDataFolders) && @is_dir($settingsDir)) {
     $metaDataFolders[] = $settingsDir;
   }
 }

--- a/install/civicrm.php
+++ b/install/civicrm.php
@@ -29,18 +29,18 @@ function civicrm_setup($filesDirectory) {
   $sqlPath = $crmPath . DIRECTORY_SEPARATOR . 'sql';
   $tplPath = $crmPath . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 'CRM' . DIRECTORY_SEPARATOR . 'common' . DIRECTORY_SEPARATOR;
 
-  if (!is_dir($filesDirectory)) {
+  if (!@is_dir($filesDirectory)) {
     mkdir($filesDirectory, 0777);
     chmod($filesDirectory, 0777);
   }
 
   $scratchDir = $filesDirectory . DIRECTORY_SEPARATOR . 'civicrm';
-  if (!is_dir($scratchDir)) {
+  if (!@is_dir($scratchDir)) {
     mkdir($scratchDir, 0777);
   }
 
   $compileDir = $scratchDir . DIRECTORY_SEPARATOR . 'templates_c' . DIRECTORY_SEPARATOR;
-  if (!is_dir($compileDir)) {
+  if (!@is_dir($compileDir)) {
     mkdir($compileDir, 0777);
   }
   $compileDir = addslashes($compileDir);

--- a/tests/phpunit/CRM/Mailing/MailStoreTest.php
+++ b/tests/phpunit/CRM/Mailing/MailStoreTest.php
@@ -16,7 +16,7 @@ class CRM_Mailing_MailStoreTest extends \CiviUnitTestCase {
 
   public function tearDown(): void {
     parent::tearDown();
-    if (is_dir($this->workDir)) {
+    if (@is_dir($this->workDir)) {
       CRM_Utils_File::cleanDir($this->workDir);
     }
   }

--- a/tests/phpunit/Civi/Angular/ManagerTest.php
+++ b/tests/phpunit/Civi/Angular/ManagerTest.php
@@ -71,7 +71,7 @@ class ManagerTest extends \CiviUnitTestCase {
       if (isset($module['partials'])) {
         $this->assertTrue(is_array($module['partials']));
         foreach ((array) $module['partials'] as $basedir) {
-          $this->assertTrue(is_dir($this->res->getPath($module['ext']) . '/' . $basedir));
+          $this->assertTrue(@is_dir($this->res->getPath($module['ext']) . '/' . $basedir));
           $counts['partials']++;
         }
       }

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -2185,7 +2185,7 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
       return;
     }
     foreach ($this->tempDirs as $tempDir) {
-      if (is_dir($tempDir)) {
+      if (@is_dir($tempDir)) {
         CRM_Utils_File::cleanDir($tempDir, TRUE, FALSE);
       }
     }

--- a/tests/phpunit/E2E/Core/PathUrlTest.php
+++ b/tests/phpunit/E2E/Core/PathUrlTest.php
@@ -59,7 +59,7 @@ class PathUrlTest extends \CiviEndToEndTestCase {
 
     foreach (array_merge($pathOnly, $pathAndUrl) as $var) {
       $path = \Civi::paths()->getVariable($var, 'path');
-      $this->assertTrue(file_exists($path) && is_dir($path), "The path for $var should be a valid directory.");
+      $this->assertTrue(file_exists($path) && @is_dir($path), "The path for $var should be a valid directory.");
     }
 
     foreach (array_merge($urlOnly, $pathAndUrl) as $var) {

--- a/tests/phpunit/api/v3/AttachmentTest.php
+++ b/tests/phpunit/api/v3/AttachmentTest.php
@@ -693,7 +693,7 @@ class api_v3_AttachmentTest extends CiviUnitTestCase {
    */
   protected function tmpFile($name) {
     $tmpDir = sys_get_temp_dir();
-    $this->assertTrue($tmpDir && is_dir($tmpDir), 'Tmp dir must exist: ' . $tmpDir);
+    $this->assertTrue($tmpDir && @is_dir($tmpDir), 'Tmp dir must exist: ' . $tmpDir);
     return $tmpDir . '/' . self::getFilePrefix() . $name;
   }
 

--- a/tools/extensions/org.civicrm.angularex/angularex.civix.php
+++ b/tools/extensions/org.civicrm.angularex/angularex.civix.php
@@ -237,7 +237,7 @@ function _angularex_civix_find_files($dir, $pattern) {
   while (!empty($todos)) {
     $subdir = array_shift($todos);
     foreach (_angularex_civix_glob("$subdir/$pattern") as $match) {
-      if (!is_dir($match)) {
+      if (!@is_dir($match)) {
         $result[] = $match;
       }
     }
@@ -246,7 +246,7 @@ function _angularex_civix_find_files($dir, $pattern) {
         $path = $subdir . DIRECTORY_SEPARATOR . $entry;
         if ($entry{0} == '.') {
         }
-        elseif (is_dir($path)) {
+        elseif (@is_dir($path)) {
           $todos[] = $path;
         }
       }
@@ -289,7 +289,7 @@ function _angularex_civix_civicrm_managed(&$entities) {
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_caseTypes
  */
 function _angularex_civix_civicrm_caseTypes(&$caseTypes) {
-  if (!is_dir(__DIR__ . '/xml/case')) {
+  if (!@is_dir(__DIR__ . '/xml/case')) {
     return;
   }
 
@@ -317,7 +317,7 @@ function _angularex_civix_civicrm_caseTypes(&$caseTypes) {
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_angularModules
  */
 function _angularex_civix_civicrm_angularModules(&$angularModules) {
-  if (!is_dir(__DIR__ . '/ang')) {
+  if (!@is_dir(__DIR__ . '/ang')) {
     return;
   }
 
@@ -458,7 +458,7 @@ function _angularex_civix_fixNavigationMenuItems(&$nodes, &$maxNavID, $parentID)
  */
 function _angularex_civix_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
   $settingsDir = __DIR__ . DIRECTORY_SEPARATOR . 'settings';
-  if (!in_array($settingsDir, $metaDataFolders) && is_dir($settingsDir)) {
+  if (!in_array($settingsDir, $metaDataFolders) && @is_dir($settingsDir)) {
     $metaDataFolders[] = $settingsDir;
   }
 }

--- a/tools/scripts/phpunit
+++ b/tools/scripts/phpunit
@@ -86,7 +86,7 @@ putenv("CIVICRM_UF=$CIVICRM_UF");
 // Transition: Make sure we use phpunit code from PATH, not
 // civicrm-packages.  This will be unnecessary once civicrm-packages is
 // updated.
-if (is_dir('packages/PHPUnit/')) {
+if (@is_dir('packages/PHPUnit/')) {
   if (!rename('packages/PHPUnit', 'packages/PHPUnit.bak')) {
     echo "Failed to move aside stale copy of PHPUnit.\n";
     exit(1);


### PR DESCRIPTION
Overview
----------------------------------------
Fix error log spam PHP message: PHP Warning: is_dir(): open_basedir restriction in effect. File ... is not within the allowed path(s).

This is Option 2 of two possible approaches to solving this problem. This PR is a broader approach. Option 1 is here #21591

Before
----------------------------------------
Error message logged repeatedly when using CiviCRM backend. PHP message: PHP Warning: is_dir(): open_basedir restriction in effect. File ... is not within the allowed path(s)

After
----------------------------------------
No more error messages logged.

Technical Details
----------------------------------------
Same approach as #11086

Comments
----------------------------------------
May break other things, hopefully tests will pick that up.

Related to #21589

Agileware Ref: CIVICRM-1651
