### PR TITLE
When using APIv3 Explorer, PHP logs error message: Warning: is_dir(): open_basedir restriction in effect

### DIFF
--- a/CRM/Admin/Page/APIExplorer.php
+++ b/CRM/Admin/Page/APIExplorer.php
@@ -63,7 +63,7 @@ class CRM_Admin_Page_APIExplorer extends CRM_Core_Page {
     $paths = self::uniquePaths();
     foreach ($paths as $path) {
       $dir = \CRM_Utils_File::addTrailingSlash($path) . 'api' . DIRECTORY_SEPARATOR . 'v3' . DIRECTORY_SEPARATOR . 'examples';
-      if (is_dir($dir)) {
+      if (@is_dir($dir)) {
         foreach (scandir($dir) as $item) {
           if ($item && strpos($item, '.') === FALSE && array_search($item, $examples) === FALSE) {
             $examples[] = $item;
@@ -96,7 +96,7 @@ class CRM_Admin_Page_APIExplorer extends CRM_Core_Page {
       $paths = self::uniquePaths();
       foreach ($paths as $path) {
         $dir = \CRM_Utils_File::addTrailingSlash($path) . 'api' . DIRECTORY_SEPARATOR . 'v3' . DIRECTORY_SEPARATOR . 'examples' . DIRECTORY_SEPARATOR . $_GET['entity'];
-        if (is_dir($dir)) {
+        if (@is_dir($dir)) {
           foreach (scandir($dir) as $item) {
             $item = str_replace('.ex.php', '', $item);
             if ($item && strpos($item, '.') === FALSE) {


### PR DESCRIPTION
Overview
----------------------------------------
When using APIv3 Explorer, PHP logs error message: Warning: is_dir(): open_basedir restriction in effect

Before
----------------------------------------
When using APIv3 Explorer, PHP logs error message: Warning: is_dir(): open_basedir restriction in effect

After
----------------------------------------
No more PHP error messages logged when using APIv3 Explorer.

Technical Details
----------------------------------------


Comments
----------------------------------------
Relates to #21591 and #21589
Can also be replaced by #21592 

Agileware Ref: CIVICRM-1717
