### PR TITLE
Remove all references to safe_mode, DEPRECATED as of PHP 5.3.0 and REMOVED as of PHP 5.4.0

### DIFF
--- a/CRM/Activity/Import/Controller.php
+++ b/CRM/Activity/Import/Controller.php
@@ -26,10 +26,7 @@ class CRM_Activity_Import_Controller extends CRM_Core_Controller {
   public function __construct($title = NULL, $action = CRM_Core_Action::NONE, $modal = TRUE) {
     parent::__construct($title, $modal);
 
-    // lets get around the time limit issue if possible, CRM-2113
-    if (!ini_get('safe_mode')) {
-      set_time_limit(0);
-    }
+    set_time_limit(0);
 
     $this->_stateMachine = new CRM_Import_StateMachine($this, $action);
 

--- a/CRM/Contact/Import/Controller.php
+++ b/CRM/Contact/Import/Controller.php
@@ -26,10 +26,7 @@ class CRM_Contact_Import_Controller extends CRM_Core_Controller {
   public function __construct($title = NULL, $action = CRM_Core_Action::NONE, $modal = TRUE) {
     parent::__construct($title, $modal);
 
-    // lets get around the time limit issue if possible, CRM-2113
-    if (!ini_get('safe_mode')) {
-      set_time_limit(0);
-    }
+    set_time_limit(0);
 
     $this->_stateMachine = new CRM_Import_StateMachine($this, $action);
 

--- a/CRM/Contribute/Import/Controller.php
+++ b/CRM/Contribute/Import/Controller.php
@@ -26,10 +26,7 @@ class CRM_Contribute_Import_Controller extends CRM_Core_Controller {
   public function __construct($title = NULL, $action = CRM_Core_Action::NONE, $modal = TRUE) {
     parent::__construct($title, $modal);
 
-    // lets get around the time limit issue if possible, CRM-2113
-    if (!ini_get('safe_mode')) {
-      set_time_limit(0);
-    }
+    set_time_limit(0);
 
     $this->_stateMachine = new CRM_Import_StateMachine($this, $action);
 

--- a/CRM/Core/Payment/Elavon.php
+++ b/CRM/Core/Payment/Elavon.php
@@ -157,7 +157,7 @@ class CRM_Core_Payment_Elavon extends CRM_Core_Payment {
     // set this for debugging -look for output in apache error log
     //curl_setopt ($ch,CURLOPT_VERBOSE,1 );
     // ensures any Location headers are followed
-    if (ini_get('open_basedir') == '' && ini_get('safe_mode') == 'Off') {
+    if (ini_get('open_basedir') == '') {
       curl_setopt($ch, CURLOPT_FOLLOWLOCATION, 1);
     }
 

--- a/CRM/Core/Payment/FirstData.php
+++ b/CRM/Core/Payment/FirstData.php
@@ -222,7 +222,7 @@ class CRM_Core_Payment_FirstData extends CRM_Core_Payment {
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
     curl_setopt($ch, CURLOPT_TIMEOUT, 36000);
     // ensures any Location headers are followed
-    if (ini_get('open_basedir') == '' && ini_get('safe_mode') == 'Off') {
+    if (ini_get('open_basedir') == '') {
       curl_setopt($ch, CURLOPT_FOLLOWLOCATION, 1);
     }
 

--- a/CRM/Core/Smarty.php
+++ b/CRM/Core/Smarty.php
@@ -95,13 +95,7 @@ class CRM_Core_Smarty extends Smarty {
       exit();
     }
 
-    //Check for safe mode CRM-2207
-    if (ini_get('safe_mode')) {
-      $this->use_sub_dirs = FALSE;
-    }
-    else {
-      $this->use_sub_dirs = TRUE;
-    }
+    $this->use_sub_dirs = TRUE;
 
     $customPluginsDir = NULL;
     if (isset($config->customPHPPathDir)) {

--- a/CRM/Custom/Import/Controller.php
+++ b/CRM/Custom/Import/Controller.php
@@ -15,10 +15,7 @@ class CRM_Custom_Import_Controller extends CRM_Core_Controller {
   public function __construct($title = NULL, $action = CRM_Core_Action::NONE, $modal = TRUE) {
     parent::__construct($title, $modal);
 
-    // lets get around the time limit issue if possible, CRM-2113
-    if (!ini_get('safe_mode')) {
-      set_time_limit(0);
-    }
+    set_time_limit(0);
 
     $this->_stateMachine = new CRM_Import_StateMachine($this, $action);
 

--- a/CRM/Event/Import/Controller.php
+++ b/CRM/Event/Import/Controller.php
@@ -26,10 +26,7 @@ class CRM_Event_Import_Controller extends CRM_Core_Controller {
   public function __construct($title = NULL, $action = CRM_Core_Action::NONE, $modal = TRUE) {
     parent::__construct($title, $modal);
 
-    // lets get around the time limit issue if possible, CRM-2113
-    if (!ini_get('safe_mode')) {
-      set_time_limit(0);
-    }
+    set_time_limit(0);
 
     $this->_stateMachine = new CRM_Import_StateMachine($this, $action);
 

--- a/CRM/Member/Import/Controller.php
+++ b/CRM/Member/Import/Controller.php
@@ -26,10 +26,7 @@ class CRM_Member_Import_Controller extends CRM_Core_Controller {
   public function __construct($title = NULL, $action = CRM_Core_Action::NONE, $modal = TRUE) {
     parent::__construct($title, $modal);
 
-    // lets get around the time limit issue if possible, CRM-2113
-    if (!ini_get('safe_mode')) {
-      set_time_limit(0);
-    }
+    set_time_limit(0);
 
     $this->_stateMachine = new CRM_Import_StateMachine($this, $action);
 

--- a/CRM/Upgrade/Headless.php
+++ b/CRM/Upgrade/Headless.php
@@ -25,10 +25,7 @@ class CRM_Upgrade_Headless {
    *   - message: string, HTML-ish blob
    */
   public function run($enablePrint = TRUE) {
-    // lets get around the time limit issue if possible for upgrades
-    if (!ini_get('safe_mode')) {
-      set_time_limit(0);
-    }
+    set_time_limit(0);
 
     $upgrade = new CRM_Upgrade_Form();
     list($currentVer, $latestVer) = $upgrade->getUpgradeVersions();

--- a/CRM/Upgrade/Page/Upgrade.php
+++ b/CRM/Upgrade/Page/Upgrade.php
@@ -29,10 +29,7 @@ class CRM_Upgrade_Page_Upgrade extends CRM_Core_Page {
    * @throws \Exception
    */
   public function run() {
-    // lets get around the time limit issue if possible for upgrades
-    if (!ini_get('safe_mode')) {
-      set_time_limit(0);
-    }
+    set_time_limit(0);
 
     Civi::resources()->addStyleFile('civicrm', 'css/admin.css');
 

--- a/CRM/Utils/HttpClient.php
+++ b/CRM/Utils/HttpClient.php
@@ -201,7 +201,7 @@ class CRM_Utils_HttpClient {
    * @return bool
    */
   public function isRedirectSupported() {
-    return (ini_get('open_basedir') == '') && (ini_get('safe_mode') == 'Off' || ini_get('safe_mode') == '' || ini_get('safe_mode') === FALSE);
+    return (ini_get('open_basedir') == '');
   }
 
 }

--- a/api/v3/System/ini-whitelist.txt
+++ b/api/v3/System/ini-whitelist.txt
@@ -180,7 +180,6 @@ register_long_arrays
 report_memleaks
 report_zend_debug
 request_order
-safe_mode
 # Omit: safe_mode_allowed_env_vars
 # Omit: safe_mode_exec_dir
 safe_mode_gid

--- a/bin/ContributionProcessor.php
+++ b/bin/ContributionProcessor.php
@@ -545,10 +545,7 @@ CRM_Core_Error::debug_log_message('ContributionProcessor.php');
 $lock = Civi::lockManager()->acquire('worker.contribute.CiviContributeProcessor');
 
 if ($lock->isAcquired()) {
-  // try to unset any time limits
-  if (!ini_get('safe_mode')) {
-    set_time_limit(0);
-  }
+  set_time_limit(0);
 
   CiviContributeProcessor::process();
 }

--- a/ext/payflowpro/tests/phpunit/bootstrap.php
+++ b/ext/payflowpro/tests/phpunit/bootstrap.php
@@ -1,7 +1,6 @@
 <?php
 
 ini_set('memory_limit', '2G');
-ini_set('safe_mode', 0);
 // phpcs:disable
 eval(cv('php:boot --level=classloader', 'phpcode'));
 // phpcs:enable

--- a/ext/search_kit/tests/phpunit/bootstrap.php
+++ b/ext/search_kit/tests/phpunit/bootstrap.php
@@ -1,7 +1,6 @@
 <?php
 
 ini_set('memory_limit', '2G');
-ini_set('safe_mode', 0);
 // phpcs:disable
 eval(cv('php:boot --level=classloader', 'phpcode'));
 // phpcs:enable


### PR DESCRIPTION
Overview
----------------------------------------
Remove all references to safe_mode, DEPRECATED as of PHP 5.3.0 and REMOVED as of PHP 5.4.0

Before
----------------------------------------
safe_mode checked.

After
----------------------------------------
safe_mode checks removed.

Technical Details
----------------------------------------
Removed other references to safe_mode as well.

Comments
----------------------------------------
Agileware Ref: CIVICRM-1844]
