### PR TITLE
Find Activities Search, the default search option of "With" criteria excludes Activities by default. Confuses End Users when 0 results are returned when criteria appears to be correct.

### DIFF
--- a/CRM/Activity/BAO/Query.php
+++ b/CRM/Activity/BAO/Query.php
@@ -450,7 +450,7 @@ class CRM_Activity_BAO_Query {
       1 => ts('Added by'),
     ];
     $form->addRadio('activity_role', NULL, $activityRoles, ['allowClear' => TRUE]);
-    $form->setDefaults(['activity_role' => 3]);
+
     $activityStatus = CRM_Core_PseudoConstant::get('CRM_Activity_DAO_Activity', 'status_id', [
       'flip' => 1,
       'labelColumn' => 'name',


### PR DESCRIPTION
Overview
----------------------------------------
Find Activities Search, the **default search option** of "With" criteria excludes Activities by default and confuses end users when 0 results are returned.

End users feel less confident using the system as a result and are annoyed by having a default option which is wrong.

![Screenshot_20200917_133714](https://user-images.githubusercontent.com/58866555/134624620-2d4d0c7c-6ee6-4d88-86a8-390d234ff72e.png)


Before
----------------------------------------
Using the default search option "With" criteria, no Activities are returned in the search results.

After
----------------------------------------
When "With" criteria is not set, Activities are returned in the search results.

Technical Details
----------------------------------------

Comments
----------------------------------------
Agileware Ref: CIVICRM-1563
