### PR TITLE
Find Activities Search, default search option for Activity Status will exclude Activities by default which do not have a status of Scheduled or Completed. Confuses and frustrates End Users.

### DIFF
--- a/CRM/Activity/BAO/Query.php
+++ b/CRM/Activity/BAO/Query.php
@@ -461,7 +461,6 @@ class CRM_Activity_BAO_Query {
     if (!empty($ssID) && !empty($form->_formValues['activity_status_id'])) {
       $status = $form->_formValues['activity_status_id'];
     }
-    $form->setDefaults(['activity_status_id' => $status]);
 
     $form->addElement('text', 'activity_text', ts('Activity Text'), CRM_Core_DAO::getAttribute('CRM_Contact_DAO_Contact', 'sort_name'));
 


### PR DESCRIPTION
Overview
----------------------------------------
Find Activities Search, default search option for Activity Status will exclude Activities by default which do not have a status of Scheduled or Completed. This confuses end users when Activities that have different statuses are not shown in search results.

End users feel less confident using the system as a result and are annoyed by having a default option which is wrong.

Before
----------------------------------------
Using the default search option "Activity Status" criteria, no Activities are returned in the search results.

After
----------------------------------------
When "Activity Status" criteria is not set, Activities are returned in the search results.

Technical Details
----------------------------------------

Comments
----------------------------------------
Relates to #21595

Agileware Ref: CIVICRM-1845
