### PR TITLE
CRM-19236 - Fix Flexmailer extension to support unicode urls

### DIFF
--- a/ext/flexmailer/src/ClickTracker/HtmlClickTracker.php
+++ b/ext/flexmailer/src/ClickTracker/HtmlClickTracker.php
@@ -51,9 +51,9 @@ class HtmlClickTracker implements ClickTrackerInterface {
 
     // Find anything like href="..." or href='...' inside a tag.
     $tmp = preg_replace_callback(
-      ';(\<a[^>]*href *= *")([^">]+)(");i', $callback, $html);
+      ';(\<a[^>]*href *= *")([^">]+)(");iu', $callback, $html);
     return preg_replace_callback(
-      ';(\<a[^>]*href *= *\')([^\'>]+)(\');i', $callback, $tmp);
+      ';(\<a[^>]*href *= *\')([^\'>]+)(\');iu', $callback, $tmp);
   }
 
   //  /**

--- a/ext/flexmailer/src/ClickTracker/TextClickTracker.php
+++ b/ext/flexmailer/src/ClickTracker/TextClickTracker.php
@@ -37,7 +37,7 @@ class TextClickTracker implements ClickTrackerInterface {
     };
     // Find any HTTP(S) URLs in the text.
     // return preg_replace_callback('/\b(?:(?:https?):\/\/|www\.|ftp\.)[-A-Z0-9+&@#\/%=~_|$?!:,.]*[A-Z0-9+&@#\/%=~_|$]/i', $callback, $tex
-    return preg_replace_callback('/\b(?:(?:https?):\/\/)[-A-Z0-9+&@#\/%=~_|$?!:,.{}\[\];]*[A-Z0-9+&@#\/%=~_|${}\[\];]/i',
+    return preg_replace_callback('/\b(?:(?:https?):\/\/)[\w+&@#\/%=~_|$?!:,.{}\[\];]*[\w+&@#\/%=~_|${}\[\];]/iu',
       $callback, $text);
   }
 

--- a/ext/flexmailer/tests/phpunit/Civi/FlexMailer/ClickTrackerTest.php
+++ b/ext/flexmailer/tests/phpunit/Civi/FlexMailer/ClickTrackerTest.php
@@ -29,15 +29,15 @@ class ClickTrackerTest extends \PHPUnit\Framework\TestCase implements HeadlessIn
     // Mock the getTrackerURL call; we don't need to test creating a row in a table.
     // If you want this to work without runkit, then either (a) make the dummy rows or (b) switch this to a hook/event that is runtime-configurable.
     require_once 'CRM/Mailing/BAO/TrackableURL.php';
-    runkit7_method_rename('\CRM_Mailing_BAO_TrackableURL', 'getBasicTrackerURL', 'orig_getBasicTrackerURL');
-    runkit7_method_add('\CRM_Mailing_BAO_TrackableURL', 'getBasicTrackerURL', '$a, $b, $c', 'return \'http://example.com/extern?u=1&qid=1\';', RUNKIT7_ACC_STATIC | RUNKIT7_ACC_PRIVATE);
+    \runkit7_method_rename('\CRM_Mailing_BAO_TrackableURL', 'getBasicTrackerURL', 'orig_getBasicTrackerURL');
+    \runkit7_method_add('\CRM_Mailing_BAO_TrackableURL', 'getBasicTrackerURL', '$a, $b, $c', 'return \'http://example.com/extern?u=1&qid=1\';', RUNKIT7_ACC_STATIC | RUNKIT7_ACC_PRIVATE);
     parent::setUp();
   }
 
   public function tearDown(): void {
     // Reset the class.
-    runkit7_method_remove('\CRM_Mailing_BAO_TrackableURL', 'getBasicTrackerURL');
-    runkit7_method_rename('\CRM_Mailing_BAO_TrackableURL', 'orig_getBasicTrackerURL', 'getBasicTrackerURL');
+    \runkit7_method_remove('\CRM_Mailing_BAO_TrackableURL', 'getBasicTrackerURL');
+    \runkit7_method_rename('\CRM_Mailing_BAO_TrackableURL', 'orig_getBasicTrackerURL', 'getBasicTrackerURL');
     parent::tearDown();
   }
 
@@ -135,6 +135,20 @@ class ClickTrackerTest extends \PHPUnit\Framework\TestCase implements HeadlessIn
     $msg = 'See this: https://example.com/{some.path}';
     $result = $filter->filterContent($msg, 1, 1);
     $this->assertEquals('See this: https://example.com/{some.path}', $result);
+  }
+
+  public function testLinkWithUnicode(): void {
+    $filter = new TextClickTracker();
+    $msg = 'See this: https://civińcrm.org';
+    $result = $filter->filterContent($msg, 1, 1);
+    $this->assertEquals('See this: http://example.com/extern?u=1&qid=1', $result);
+  }
+
+  public function testHtmlLinkWithUnicode(): void {
+    $filter = new HtmlClickTracker();
+    $msg = '<p><a href="https://civińcrm.org">See This</a></p>';
+    $result = $filter->filterContent($msg, 1, 1);
+    $this->assertEquals('<p><a href="http://example.com/extern?u=1&amp;qid=1" rel=\'nofollow\'>See This</a></p>', $result);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
This updates flexmailer click tracking to support unicode urls

Before
----------------------------------------
Unicode urls don't work in flexmailer

After
----------------------------------------
Unicode urls work in flexmailer

Technical Details
----------------------------------------
see previous PRs https://github.com/civicrm/civicrm-core/pull/8900 https://github.com/civicrm/civicrm-core/pull/8904

ping @eileenmcnaughton @totten 