### PR TITLE
Find Activities Search, default search option for Activity Text is set to "both" in the code, but should actually be set to 6 which is the value for "both"

### DIFF
--- a/CRM/Activity/BAO/Query.php
+++ b/CRM/Activity/BAO/Query.php
@@ -466,7 +466,7 @@ class CRM_Activity_BAO_Query {
     $form->addElement('text', 'activity_text', ts('Activity Text'), CRM_Core_DAO::getAttribute('CRM_Contact_DAO_Contact', 'sort_name'));
 
     $form->addRadio('activity_option', '', CRM_Core_SelectValues::activityTextOptions());
-    $form->setDefaults(['activity_option' => 'both']);
+    $form->setDefaults(['activity_option' => 6]);
 
     $form->addYesNo('activity_test', ts('Activity is a Test?'));
     $activity_tags = CRM_Core_BAO_Tag::getColorTags('civicrm_activity');


### PR DESCRIPTION
Overview
----------------------------------------
Find Activities Search, default search option for Activity Text is set to "both" in the code, but should actually be set to 6 which is the value for "both". As a result "both" is not set by default.

![Screenshot_20200917_133714](https://user-images.githubusercontent.com/58866555/134626422-2d9a86b2-bc0e-4cde-9720-db425a0cd50d.png)

Before
----------------------------------------
"both" is not set by default.

After
----------------------------------------
Now "both" is set by default.

Technical Details
----------------------------------------
Just a bug in the code.

Comments
----------------------------------------
Agileware Ref: CIVICRM-1846