### PR TITLE
(dev/core#2638) Civi::format() - Add helper for formatting

### DIFF
--- a/Civi.php
+++ b/Civi.php
@@ -1,5 +1,7 @@
 <?php
 
+use Civi\Core\Format;
+
 /**
  * Class Civi
  *
@@ -101,6 +103,15 @@ class Civi {
    */
   public static function paths() {
     return \Civi\Core\Container::getBootService('paths');
+  }
+
+  /**
+   * Obtain the formatting object.
+   *
+   * @return \Civi\Core\Format
+   */
+  public static function format(): Format {
+    return new Civi\Core\Format();
   }
 
   /**

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -213,6 +213,11 @@ class Container {
       []
     ))->setPublic(TRUE);
 
+    $container->setDefinition('format', new Definition(
+      '\Civi\Core\Format',
+      []
+    ))->setPublic(TRUE);
+
     $container->setDefinition('bundle.bootstrap3', new Definition('CRM_Core_Resources_Bundle', ['bootstrap3']))
       ->setFactory('CRM_Core_Resources_Common::createBootstrap3Bundle')->setPublic(TRUE);
 

--- a/Civi/Core/Format.php
+++ b/Civi/Core/Format.php
@@ -1,0 +1,184 @@
+<?php
+
+namespace Civi\Core;
+
+use Brick\Money\Currency;
+use Brick\Money\Money;
+use Brick\Math\RoundingMode;
+use Civi;
+use CRM_Core_Config;
+use CRM_Core_I18n;
+use CRM_Utils_Constant;
+use NumberFormatter;
+use Brick\Money\Context\AutoContext;
+
+/**
+ * Class Paths
+ * @package Civi\Core
+ *
+ * This class provides standardised formatting
+ */
+class Format {
+
+  /**
+   * Get formatted money
+   *
+   * @param string $amount
+   * @param string|null $currency
+   *   Currency, defaults to site currency if not provided.
+   * @param string|null $locale
+   *
+   * @return string
+   *
+   * @noinspection PhpDocMissingThrowsInspection
+   * @noinspection PhpUnhandledExceptionInspection
+   */
+  public function money(string $amount, ?string $currency = NULL, ?string $locale = NULL): string {
+    if (!$currency) {
+      $currency = Civi::settings()->get('defaultCurrency');
+    }
+    if (!isset($locale)) {
+      $locale = CRM_Core_I18n::getLocale();
+    }
+    $money = Money::of($amount, $currency, NULL, RoundingMode::HALF_UP);
+    $formatter = $this->getMoneyFormatter($currency, $locale);
+    return $money->formatWith($formatter);
+  }
+
+  /**
+   * Get a formatted number.
+   *
+   * @param string|int|float|Money $amount
+   *   Amount in a machine money format.
+   * @param string|null $locale
+   * @param array $attributes
+   *   Additional values supported by NumberFormatter
+   *   https://www.php.net/manual/en/class.numberformatter.php
+   *   By default this will set it to round to 8 places and not
+   *   add any padding.
+   *
+   * @return string
+   */
+  public function number($amount, ?string $locale = NULL, array $attributes = [
+    NumberFormatter::MIN_FRACTION_DIGITS => 0,
+    NumberFormatter::MAX_FRACTION_DIGITS => 8,
+  ]): string {
+    $formatter = $this->getMoneyFormatter(NULL, $locale, NumberFormatter::DECIMAL, $attributes);
+    return $formatter->format($amount);
+  }
+
+  /**
+   * Get a number formatted with rounding expectations derived from the currency.
+   *
+   * @param string|float|int $amount
+   * @param string $currency
+   * @param $locale
+   *
+   * @return string
+   *
+   * @noinspection PhpDocMissingThrowsInspection
+   * @noinspection PhpUnhandledExceptionInspection
+   */
+  public function moneyNumber($amount, string $currency, $locale): string {
+    $formatter = $this->getMoneyFormatter($currency, $locale, NumberFormatter::DECIMAL);
+    $money = Money::of($amount, $currency, NULL, RoundingMode::HALF_UP);
+    return $money->formatWith($formatter);
+  }
+
+  /**
+   * Get a money value with formatting but not rounding.
+   *
+   * @param string|float|int $amount
+   * @param string|null $currency
+   * @param string|null $locale
+   *
+   * @return string
+   *
+   * @noinspection PhpDocMissingThrowsInspection
+   * @noinspection PhpUnhandledExceptionInspection
+   */
+  public function moneyLong($amount, ?string $currency, ?string $locale): string {
+    $formatter = $this->getMoneyFormatter($currency, $locale, NumberFormatter::CURRENCY, [
+      NumberFormatter::MAX_FRACTION_DIGITS => 9,
+    ]);
+    $money = Money::of($amount, $currency, new AutoContext());
+    return $money->formatWith($formatter);
+  }
+
+  /**
+   * Get a number with minimum decimal places based on the currency but no rounding.
+   *
+   * @param string|float|int $amount
+   * @param string|null $currency
+   * @param string|null $locale
+   *
+   * @return string
+   *
+   * @noinspection PhpDocMissingThrowsInspection
+   * @noinspection PhpUnhandledExceptionInspection
+   */
+  public function moneyNumberLong($amount, ?string $currency, ?string $locale): string {
+    $formatter = $this->getMoneyFormatter($currency, $locale, NumberFormatter::DECIMAL, [
+      NumberFormatter::MAX_FRACTION_DIGITS => 9,
+    ]);
+    $money = Money::of($amount, $currency, new AutoContext());
+    return $money->formatWith($formatter);
+  }
+
+  /**
+   * Should we use the configured thousand & decimal separators.
+   *
+   * The goal is to phase this into being FALSE - but for now
+   * we are looking at how to manage an 'opt in'
+   */
+  protected function isUseSeparatorSettings(): bool {
+    return !CRM_Utils_Constant::value('IGNORE_SEPARATOR_CONFIG');
+  }
+
+  /**
+   * Get the money formatter for when we are using configured thousand separators.
+   *
+   * Our intent is to phase out these settings in favour of deriving them from the locale.
+   *
+   * @param string|null $currency
+   * @param string|null $locale
+   * @param int $style
+   *   See https://www.php.net/manual/en/class.numberformatter.php#intl.numberformatter-constants
+   * @param array $attributes
+   *   See https://www.php.net/manual/en/class.numberformatter.php#intl.numberformatter-constants.unumberformatattribute
+   *
+   * @return \NumberFormatter
+   *
+   * @noinspection PhpDocMissingThrowsInspection
+   * @noinspection PhpUnhandledExceptionInspection
+   */
+  public function getMoneyFormatter(?string $currency = NULL, ?string $locale = NULL, int $style = NumberFormatter::CURRENCY, array $attributes = []): NumberFormatter {
+    if (!$currency) {
+      $currency = Civi::settings()->get('defaultCurrency');
+    }
+    $cacheKey = __CLASS__ . $currency . '_' . $locale . '_' . $style . (!empty($attributes) ? md5(json_encode($attributes)) : '');
+    if (!isset(\Civi::$statics[$cacheKey])) {
+      $formatter = new NumberFormatter($locale, $style);
+
+      if (!isset($attributes[NumberFormatter::MIN_FRACTION_DIGITS])) {
+        $attributes[NumberFormatter::MIN_FRACTION_DIGITS] = Currency::of($currency)
+          ->getDefaultFractionDigits();
+      }
+      if (!isset($attributes[NumberFormatter::MAX_FRACTION_DIGITS])) {
+        $attributes[NumberFormatter::MAX_FRACTION_DIGITS] = Currency::of($currency)
+          ->getDefaultFractionDigits();
+      }
+
+      foreach ($attributes as $attribute => $value) {
+        $formatter->setAttribute($attribute, $value);
+      }
+      if ($locale === CRM_Core_I18n::getLocale() && $this->isUseSeparatorSettings()) {
+        $formatter->setSymbol(NumberFormatter::MONETARY_GROUPING_SEPARATOR_SYMBOL, CRM_Core_Config::singleton()->monetaryThousandSeparator);
+        $formatter->setSymbol(NumberFormatter::MONETARY_SEPARATOR_SYMBOL, CRM_Core_Config::singleton()->monetaryDecimalPoint);
+      }
+      \Civi::$statics[$cacheKey] = $formatter;
+    }
+    return \Civi::$statics[$cacheKey];
+  }
+
+}

--- a/tests/phpunit/Civi/Core/FormatTest.php
+++ b/tests/phpunit/Civi/Core/FormatTest.php
@@ -1,0 +1,228 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Core;
+
+use Civi;
+use CiviUnitTestCase;
+
+/**
+ * Class MoneyTest
+ *
+ * @package Civi\Core
+ * @group headless
+ */
+class FormatTest extends CiviUnitTestCase {
+
+  /**
+   * Money Locale Format Cases
+   */
+  public function localeMoneyTestCases(): array {
+    $cases = [];
+    $cases['en_US_USD'] = [
+      [
+        'amount' => '1234.56',
+        'locale' => 'en_US',
+        'currency' => 'USD',
+        'money' => '$1,234.56',
+        'money_number' => '1,234.56',
+        'money_number_long' => '1,234.56',
+        'number' => '1,234.56',
+        'money_long' => '$1,234.56',
+      ],
+    ];
+    $cases['en_US_USD_long'] = [
+      [
+        'amount' => '1234.56700',
+        'locale' => 'en_US',
+        'currency' => 'USD',
+        'money' => '$1,234.57',
+        'money_number' => '1,234.57',
+        'money_number_long' => '1,234.567',
+        'number' => '1,234.567',
+        'money_long' => '$1,234.567',
+      ],
+    ];
+    $cases['en_US_USD_pad'] = [
+      [
+        'amount' => '1234.50',
+        'locale' => 'en_US',
+        'currency' => 'USD',
+        'money' => '$1,234.50',
+        'money_number' => '1,234.50',
+        'money_number_long' => '1,234.50',
+        'number' => '1,234.5',
+        'money_long' => '$1,234.50',
+      ],
+    ];
+    $cases['en_US_EUR'] = [
+      [
+        'amount' => '1234.56',
+        'locale' => 'en_US',
+        'currency' => 'EUR',
+        'money' => '€1,234.56',
+        'money_number' => '1,234.56',
+        'number' => '1,234.56',
+        'money_long' => '€1,234.56',
+        'money_number_long' => '1,234.56',
+      ],
+    ];
+    $cases['en_US_EUR_long'] = [
+      [
+        'amount' => '1234.56700',
+        'locale' => 'en_US',
+        'currency' => 'EUR',
+        'money' => '€1,234.57',
+        'money_number' => '1,234.57',
+        'number' => '1,234.567',
+        'money_long' => '€1,234.567',
+        'money_number_long' => '1,234.567',
+      ],
+    ];
+    $cases['en_US_EUR_pad'] = [
+      [
+        'amount' => '1234.5',
+        'locale' => 'en_US',
+        'currency' => 'EUR',
+        'money' => '€1,234.50',
+        'money_number' => '1,234.50',
+        'number' => '1,234.5',
+        'money_long' => '€1,234.50',
+        'money_number_long' => '1,234.50',
+      ],
+    ];
+    $cases['fr_FR_EUR'] = [
+      [
+        'amount' => '1234.56',
+        'locale' => 'fr_FR',
+        'currency' => 'EUR',
+        'money' => '1 234,56 €',
+        'money_number' => '1 234,56',
+        'number' => '1 234,56',
+        'money_long' => '1 234,56 €',
+        'money_number_long' => '1 234,56',
+      ],
+    ];
+    $cases['fr_FR_EUR_long'] = [
+      [
+        'amount' => '1234.56700',
+        'locale' => 'fr_FR',
+        'currency' => 'EUR',
+        'money' => '1 234,57 €',
+        'money_number' => '1 234,57',
+        'number' => '1 234,567',
+        'money_long' => '1 234,567 €',
+        'money_number_long' => '1 234,567',
+      ],
+    ];
+    $cases['fr_FR_EUR_pad'] = [
+      [
+        'amount' => '1234.50',
+        'locale' => 'fr_FR',
+        'currency' => 'EUR',
+        'money' => '1 234,50 €',
+        'money_number' => '1 234,50',
+        'number' => '1 234,5',
+        'money_long' => '1 234,50 €',
+        'money_number_long' => '1 234,50',
+      ],
+    ];
+    $cases['ar_AE_KWD'] = [
+      [
+        'amount' => '1234.56',
+        'locale' => 'ar_AE',
+        'currency' => 'KWD',
+        'money' => '١٬٢٣٤٫٥٦٠ د.ك.‏',
+        'money_number' => '١٬٢٣٤٫٥٦٠',
+        'number' => '١٬٢٣٤٫٥٦',
+        'money_long' => '١٬٢٣٤٫٥٦٠ د.ك.‏',
+        'money_number_long' => '١٬٢٣٤٫٥٦٠',
+      ],
+    ];
+    $cases['ar_AE_KWD_long'] = [
+      [
+        'amount' => '1234.56710',
+        'locale' => 'ar_AE',
+        'currency' => 'KWD',
+        'money' => '١٬٢٣٤٫٥٦٧ د.ك.‏',
+        'money_number' => '١٬٢٣٤٫٥٦٧',
+        'number' => '١٬٢٣٤٫٥٦٧١',
+        'money_long' => '١٬٢٣٤٫٥٦٧١ د.ك.‏',
+        'money_number_long' => '١٬٢٣٤٫٥٦٧١',
+      ],
+    ];
+    $cases['ar_AE_KWD_pad'] = [
+      [
+        'amount' => '1234.56',
+        'locale' => 'ar_AE',
+        'currency' => 'KWD',
+        'money' => '١٬٢٣٤٫٥٦٠ د.ك.‏',
+        'money_number' => '١٬٢٣٤٫٥٦٠',
+        'number' => '١٬٢٣٤٫٥٦',
+        'money_long' => '١٬٢٣٤٫٥٦٠ د.ك.‏',
+        'money_number_long' => '١٬٢٣٤٫٥٦٠',
+      ],
+    ];
+    $cases['en_US_KWD'] = [
+      [
+        'amount' => '1234.56',
+        'locale' => 'fr_FR',
+        'currency' => 'KWD',
+        'money' => '1 234,560 KWD',
+        'money_number' => '1 234,560',
+        'number' => '1 234,56',
+        'money_long' => '1 234,560 KWD',
+        'money_number_long' => '1 234,560',
+      ],
+    ];
+    $cases['en_US_KWD_long'] = [
+      [
+        'amount' => '1234.5678000',
+        'locale' => 'fr_FR',
+        'currency' => 'KWD',
+        'money' => '1 234,568 KWD',
+        'money_number' => '1 234,568',
+        'number' => '1 234,5678',
+        'money_long' => '1 234,5678 KWD',
+        'money_number_long' => '1 234,5678',
+      ],
+    ];
+    $cases['en_US_KWD_pad'] = [
+      [
+        'amount' => '1234.5',
+        'locale' => 'fr_FR',
+        'currency' => 'KWD',
+        'money' => '1 234,500 KWD',
+        'money_number' => '1 234,500',
+        'number' => '1 234,5',
+        'money_long' => '1 234,500 KWD',
+        'money_number_long' => '1 234,500',
+      ],
+    ];
+    return $cases;
+  }
+
+  /**
+   * @dataProvider localeMoneyTestCases
+   *
+   * @param array $testData
+   */
+  public function testMoneyAndNumbers(array $testData): void {
+    $this->assertEquals($testData['money'], Civi::format()->money($testData['amount'], $testData['currency'], $testData['locale']));
+    $this->assertEquals($testData['money_number'], Civi::format()->moneyNumber($testData['amount'], $testData['currency'], $testData['locale']));
+    $this->assertEquals($testData['number'], Civi::format()->number($testData['amount'], $testData['locale']));
+    $this->assertEquals($testData['money_long'], Civi::format()->moneyLong($testData['amount'], $testData['currency'], $testData['locale']));
+    $this->assertEquals($testData['money_number_long'], Civi::format()->moneyNumberLong($testData['amount'], $testData['currency'], $testData['locale']));
+
+  }
+
+}

--- a/tests/phpunit/Civi/Core/FormatTest.php
+++ b/tests/phpunit/Civi/Core/FormatTest.php
@@ -184,7 +184,7 @@ class FormatTest extends CiviUnitTestCase {
         'money_number_long' => '1 234,560',
       ],
     ];
-    $cases['en_US_KWD_long'] = [
+    $cases['fr_FR_KWD_long'] = [
       [
         'amount' => '1234.5678000',
         'locale' => 'fr_FR',


### PR DESCRIPTION
Overview
----------------------------------------
Adds a helper class for formatting.  - although many sites have used the core utils class.

This attempts to provide a consistent formatting interface via `\Civi::format()` for  numbers and money.

Dates were originally included too but I pulled them out because once we add in timezone to the dates it adds quite a burden in terms of writing more tests which I wanted to push out to a follow up

IMPORTANT - in the end I bypassed our existing money functions & wrote the functions I thought we should have. However, I did not that there is a change in formatting from `$ 1.00` to `$1.00` - both look equally 'correct' to me & I wasn't of the opinion we should bend over backwards to force the former if php is suggesting the latter is 'the standard'. 

Before
----------------------------------------
Previously we have not had an official supported way to format values using CiviCRM functions. The existing functions have had gaps / confusion / bad parameter choices.

After
----------------------------------------
|Function|For|
|---|---|
|`Civi::format()->number()`|formating to a localised number|
|`Civi::format()->money()`|formating to a localised money output|
|`Civi::format()->moneylong()`|formating to money based in currency-specific minimum rounding)|
|`Civi::format()->moneyNumber()`|formating to a number based on money rounding(e.g for data input)|
|`Civi::format()->moneyNumberLong()`|formating to a number based on minimum padding for the currency (e.g for data input)|
|`Civi::format()->getMoneyFormatter()`|gets the money formatter object, allowing the calling code to manipulate further|


**Details**

All money functions take the following parameters

|Parameter|details|
|---|---|
|`$amount`| an amount. This should be already using `.` to denote decimal places|
|`$currency`| currency - defaults to site default|
|`$locale`| either NULL or the locale for format in eg `fr_FR`|

Note that 

1) as with our existing basic `money::format()` functions the default behaviour for the basic `Civi::format()->money()` function is to round the number to the number of decimal places appropriate to the currency.
2)  `Civi::format()->moneyLong()` pads the money to the number of decimal places appropriate to the currency but does not round.
3)  `Civi::format()->moneyNumber()` as ` `Civi::format()->moneyNumberLong()` do the same as above but do not add currency symbols (equivalent to the '$onlyNumber` parameters that litter our existing code.
 

`Civi::format()->number()` takes the following

|Parameter|details|
|---|---|
|`$amount`| an amount. This should be already using `.` to denote decimal places|
|`$locale`| either NULL or the locale for format in eg `fr_FR`|
|`$attributes`|an array of values that are passed to the number formatter. By default this specifies max decimal places as 9, like our db fields|

`Civi::format()->getMoneyFormatter()` provides flexibility to combine our defaults with more bespoke use-cases.

|Parameter|details|
|---|---|
|`$currency`| defaults to site currency if null|
|`$locale`| either NULL or the locale for format in eg `fr_FR`|
|`$style`| see https://www.php.net/manual/en/class.numberformatter.php#intl.numberformatter-constants
|`$attributes`|an array of values that are passed to the number formatter. By default this specifies max decimal places as 9, like our db fields|


Technical Details
----------------------------------------

**numbers & money**
I added support for a define `IGNORE_SEPARATOR_CONFIG` for early adopters to always ignore the thousand separators. We have discussed settings & such like to migrate it in but if we don't get to that this round it would be good to have 'something'

**Rounding**

From past efforts (regressions!) we have learnt that we generally want to ensure we have sensible defaults for both padding and rounding. The functions in this PR

12.1    => 12.10
12.10  => 12.10
12.89000 => 12.89
- kinda mostly
12.89340 => 12.89
- but in 'long' situations
12.89340 => 12.8934

The scope of this PR was originally more ambitious but the challenge of the above caused me to drop the rest out of scope for manageability reasons but the original plan (& following discussion was to also add)

Originally  included but moved out of scope of this PR
|Function|For|
|`Civi::format()->machineDate()`|formating to a machine friendly date- no longer in this PR|
|`Civi::format()->machineNumber()`|formating to a machine friendly number- no longer in this PR|
|`Civi::format()->machineMoney()`|formating to a machine friendly number with the rounding based on the currency- no longer in this PR|


|`Civi::format()->date()`|formating to a localised date - no longer in this PR|

** date formatting**
`dateFormat` supports the same values as smarty `crmDate` (with the exception of the obsolete `$onlyTime` & hence that has been fixed to call this
`timezone` is new / not supported elsewhere
`Civi::format()->date()` takes the following

|Parameter|details|
|---|---|
|`$date`| a date string, such as can be interpretted by `strtotime`, defaults to 'now', in the timezone of the php session|
|`$dateFormat`| either a string reference to a date setting such as 'Year' or a strftime string, defaults to 'dateformat' setting [see](https://lab.civicrm.org/documentation/docs/user-en/-/merge_requests/498/diffs)|
|`$timezone|timezone to output in - eg. 'Asia/Paciic'|

As per the intent was to add `machineMoney` etc functions that 'deformat' - the scope of these grew when we talked about these fully reversing the format functions - since our existing functions don't deal with that. My reading suggests this would be the way to go https://www.php.net/manual/en/numberformatter.parsecurrency.php

Comments
----------------------------------------
Most recent related discussion 
https://github.com/civicrm/civicrm-core/pull/20296

Gap - tests on timezone. edge cases in tests



@mattwire @jaapjansma @seamuslee001 @totten - this builds on previous discussions -  it switches us from having a 'money' class as per some discussions to a 'format' class. I found that reframing really helpful in terms of trying to get to the nub of how 'number' interacts with money - basically 'number' is money without the currency and with different rounding assumptions