### PR TITLE
dev/core#2861 Saved search loading fix

### DIFF
--- a/CRM/Contact/BAO/GroupContactCache.php
+++ b/CRM/Contact/BAO/GroupContactCache.php
@@ -835,7 +835,7 @@ ORDER BY   gc.contact_id, g.children
       if ($savedSearch['api_entity']) {
         $sql = self::getApiSQL($savedSearch, $groupID);
       }
-      elseif (!empty($savedSearch['form_values']['customSearchID'])) {
+      elseif (!empty($savedSearch['search_custom_id'])) {
         $sql = self::getCustomSearchSQL($savedSearch, $groupID);
       }
       else {

--- a/Civi/Api4/Service/Spec/Provider/ContactGetSpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/ContactGetSpecProvider.php
@@ -58,7 +58,7 @@ class ContactGetSpecProvider implements Generic\SpecProviderInterface {
     $tempTable = \CRM_Utils_SQL_TempTable::build();
     $tempTable->createWithColumns('contact_id INT');
     $tableName = $tempTable->getName();
-    \CRM_Contact_BAO_GroupContactCache::populateTemporaryTableWithContactsInGroups($value, $tableName);
+    \CRM_Contact_BAO_GroupContactCache::populateTemporaryTableWithContactsInGroups((array) $value, $tableName);
     // SQL optimization - use INNER JOIN if the base table is Contact & this clause is not nested
     if ($fieldAlias === '`a`.`id`' && $operator === "IN" && !$depth) {
       $query->getQuery()->join($tableName, "INNER JOIN `$tableName` ON $fieldAlias = `$tableName`.contact_id");

--- a/tests/phpunit/CRM/Contact/Form/Search/Custom/datasets/group-dataset.xml
+++ b/tests/phpunit/CRM/Contact/Form/Search/Custom/datasets/group-dataset.xml
@@ -295,10 +295,12 @@
     />
     <civicrm_saved_search
         id="1"
+        search_custom_id="4"
         form_values='a:9:{s:5:"qfKey";s:32:"0123456789abcdef0123456789abcdef";s:13:"includeGroups";a:1:{i:0;s:1:"3";}s:13:"excludeGroups";a:0:{}s:11:"includeTags";a:0:{}s:11:"excludeTags";a:0:{}s:4:"task";s:2:"14";s:8:"radio_ts";s:6:"ts_all";s:14:"customSearchID";s:1:"4";s:17:"customSearchClass";s:36:"CRM_Contact_Form_Search_Custom_Group";}'
     />
     <civicrm_saved_search
         id="2"
+        search_custom_id="4"
         form_values='a:9:{s:5:"qfKey";s:32:"0123456789abcdef0123456789abcdef";s:13:"includeGroups";a:0:{}s:13:"excludeGroups";a:1:{i:0;s:1:"3";}s:11:"includeTags";a:0:{}s:11:"excludeTags";a:0:{}s:4:"task";s:2:"14";s:8:"radio_ts";s:6:"ts_all";s:14:"customSearchID";s:1:"4";s:17:"customSearchClass";s:36:"CRM_Contact_Form_Search_Custom_Group";}'
     />
     <civicrm_group


### PR DESCRIPTION
Overview
----------------------------------------
Fixes custom search regression per https://lab.civicrm.org/dev/core/-/issues/2861

Before
----------------------------------------
Group contact cache contains *all* !!! contacts for custom searches

After
----------------------------------------
Fixed

Technical Details
----------------------------------------
Once this is merged up to master I want to do the following extra
1) add a hook to get the sql for a saved search
2) add a call to this from legacycustomsearches
3) lock it in with tests....

Comments
----------------------------------------
