### PR TITLE
 Add upgrade to replace legacy contribution tokens from message templates

### DIFF
--- a/CRM/Upgrade/Incremental/Base.php
+++ b/CRM/Upgrade/Incremental/Base.php
@@ -264,7 +264,12 @@ class CRM_Upgrade_Incremental_Base {
    */
   public static function updateMessageToken($ctx, string $workflowName, string $old, string $new, $version):bool {
     $messageObj = new CRM_Upgrade_Incremental_MessageTemplates($version);
-    $messageObj->replaceTokenInTemplate($workflowName, $old, $new);
+    if (!empty($workflowName)) {
+      $messageObj->replaceTokenInTemplate($workflowName, $old, $new);
+    }
+    else {
+      $messageObj->replaceTokenInMessageTemplates($old, $new);
+    }
     return TRUE;
   }
 

--- a/CRM/Upgrade/Incremental/MessageTemplates.php
+++ b/CRM/Upgrade/Incremental/MessageTemplates.php
@@ -300,6 +300,24 @@ class CRM_Upgrade_Incremental_MessageTemplates {
   }
 
   /**
+   * Replace a token with the new preferred option in non-workflow templates.
+   *
+   * @param string $old
+   * @param string $new
+   */
+  public function replaceTokenInMessageTemplates(string $old, string $new): void {
+    $oldToken = '{' . $old . '}';
+    $newToken = '{' . $new . '}';
+    CRM_Core_DAO::executeQuery("UPDATE civicrm_msg_template
+      SET
+        msg_text = REPLACE(msg_text, '$oldToken', '$newToken'),
+        msg_subject = REPLACE(msg_subject, '$oldToken', '$newToken'),
+        msg_html = REPLACE(msg_html, '$oldToken', '$newToken')
+      WHERE workflow_name IS NULL
+    ");
+  }
+
+  /**
    * Replace a token with the new preferred option.
    *
    * @param string $old

--- a/CRM/Upgrade/Incremental/php/FiveFortyThree.php
+++ b/CRM/Upgrade/Incremental/php/FiveFortyThree.php
@@ -107,7 +107,12 @@ class CRM_Upgrade_Incremental_php_FiveFortyThree extends CRM_Upgrade_Incremental
     $this->addTask('Update participant registered by id token in event badges',
       'updatePrintLabelToken', 'participant.participant_registered_by_id', 'participant.registered_by_id', $rev
     );
-
+    $this->addTask('Update contribution status token in saved message templates',
+      'updateMessageToken', '', 'contribution.contribution_status', 'contribution.contribution_status_id:label', $rev
+    );
+    $this->addTask('Update campaign token in saved message templates',
+      'updateMessageToken', '', 'contribution.campaign', 'contribution.campaign_id:label', $rev
+    );
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Add upgrade to replace legacy contribution tokens from message templates

Before
----------------------------------------
People with saved templates with the old values would need to manually fix them before using them to create a pdf of send an email

After
----------------------------------------
DB updated automatically

Technical Details
----------------------------------------
Under legacy token replacement these 4 work
contribution.contribution_status
contribution.contribution_status_id:label
contribution.campaign
contribution.campaign_id:label

But only the label ones work with the processor. This upgrades the
old ones our of the message templates table

Comments
----------------------------------------
@demeritcowboy 
