### PR TITLE
Afform - Accept default field values from the url

### DIFF
--- a/ext/afform/core/ang/af/afField.component.js
+++ b/ext/afform/core/ang/af/afField.component.js
@@ -12,7 +12,7 @@
       fieldName: '@name',
       defn: '='
     },
-    controller: function($scope, $element, crmApi4, $timeout) {
+    controller: function($scope, $element, crmApi4, $timeout, $location) {
       var ts = $scope.ts = CRM.ts('org.civicrm.afform'),
         ctrl = this,
         boolOptions = [{id: true, label: ts('Yes')}, {id: false, label: ts('No')}],
@@ -86,13 +86,26 @@
           });
         }
 
-        // Set default value
-        if (ctrl.defn.afform_default) {
-          // Wait for parent controllers to initialize
-          $timeout(function() {
+        // Wait for parent controllers to initialize
+        $timeout(function() {
+          // Unique field name = entity_name index . join . field_name
+          var entityName = ctrl.afFieldset.getName(),
+            joinEntity = ctrl.afJoin ? ctrl.afJoin.entity : null,
+            uniquePrefix = '',
+            urlArgs = $location.search();
+          if (entityName) {
+            var index = ctrl.getEntityIndex();
+            uniquePrefix = entityName + (index ? index + 1 : '') + (joinEntity ? '.' + joinEntity : '') + '.';
+          }
+          // Set default value based on url
+          if (urlArgs && urlArgs[uniquePrefix + ctrl.fieldName]) {
+            $scope.dataProvider.getFieldData()[ctrl.fieldName] = urlArgs[uniquePrefix + ctrl.fieldName];
+          }
+          // Set default value based on field defn
+          else if (ctrl.defn.afform_default) {
             $scope.dataProvider.getFieldData()[ctrl.fieldName] = ctrl.defn.afform_default;
-          });
-        }
+          }
+        });
 
       };
 


### PR DESCRIPTION
Overview
----------------------------------------
Allows default field values to be set from the url.
![image](https://user-images.githubusercontent.com/2874912/134737680-73cc9314-2366-499b-aabf-383c1bfc4215.png)


Technical Details
----------------------------------------
On a submission-type form, the args will be prefixed with their entity names, e.g. `civicrm/my-afform#?Individual.first_name=Bob`

On a search form the args don't need a prefix and just use the name of the field.