### PR TITLE
[REF] Return the sendEmail function to it's owner

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -979,7 +979,7 @@ class CRM_Activity_BAO_Activity extends CRM_Activity_DAO_Activity {
   }
 
   /**
-   * Send the message to all the contacts.
+   * DO NOT USE THIS FUNCTION - DEPRECATED.
    *
    * Also insert a contact activity in each contacts record.
    *
@@ -1012,6 +1012,8 @@ class CRM_Activity_BAO_Activity extends CRM_Activity_DAO_Activity {
    *   bool $sent FIXME: this only indicates the status of the last email sent.
    *   array $activityIds The activity ids created, one per "To" recipient.
    *
+   * @deprecated
+   *
    * @throws \API_Exception
    * @throws \CRM_Core_Exception
    */
@@ -1032,6 +1034,10 @@ class CRM_Activity_BAO_Activity extends CRM_Activity_DAO_Activity {
     $campaignId = NULL,
     $caseId = NULL
   ) {
+    // @todo add noisy deprecation.
+    // This function is no longer called from core.
+    // I just left off the noisy deprecation for now as there
+    // are already a lot of other noisy deprecation points in 5.43.
     // get the contact details of logged in contact, which we set as from email
     if ($userID == NULL) {
       $userID = CRM_Core_Session::getLoggedInContactID();
@@ -1142,10 +1148,12 @@ class CRM_Activity_BAO_Activity extends CRM_Activity_DAO_Activity {
    * @param array $attachments
    *   Attachments.
    *
+   * @internal
+   *
    * @return array
    *   Array of attachment key versus file Id.
    */
-  private static function getAttachmentFileIds($activityID, $attachments) {
+  public static function getAttachmentFileIds($activityID, $attachments) {
     $queryParams = [1 => [$activityID, 'Positive'], 2 => [CRM_Activity_DAO_Activity::getTableName(), 'String']];
     $query = "SELECT file_id, uri FROM civicrm_entity_file INNER JOIN civicrm_file ON civicrm_entity_file.file_id = civicrm_file.id
 WHERE entity_id =%1 AND entity_table = %2";

--- a/CRM/Core/BAO/File.php
+++ b/CRM/Core/BAO/File.php
@@ -570,8 +570,8 @@ AND       CEF.entity_id    = %2";
 
         CRM_Utils_File::formatFile($formValues, $attachName, $extraParams);
 
-        // set the formatted attachment attributes to $params, later used by
-        // CRM_Activity_BAO_Activity::sendEmail(...) to send mail with desired attachments
+        // set the formatted attachment attributes to $params, later used
+        // to send mail with desired attachments
         if (!empty($formValues[$attachName])) {
           $params[$attachName] = $formValues[$attachName];
         }

--- a/tests/phpunit/CRM/Activity/BAO/ActivityTest.php
+++ b/tests/phpunit/CRM/Activity/BAO/ActivityTest.php
@@ -1261,8 +1261,10 @@ class CRM_Activity_BAO_ActivityTest extends CiviUnitTestCase {
     $text = __FUNCTION__ . ' text {contact.display_name} {case.case_type_id:label}';
     $userID = $loggedInUser;
 
+    /* @var CRM_Contact_Form_Task_Email $form */
+    $form = $this->getFormObject('CRM_Contact_Form_Task_Email');
     $mut = new CiviMailUtils($this, TRUE);
-    [$sent, $activity_ids] = CRM_Activity_BAO_Activity::sendEmail(
+    [$sent, $activity_ids] = $form->sendEmail(
       $contactDetails,
       $subject,
       $text,
@@ -1375,9 +1377,10 @@ class CRM_Activity_BAO_ActivityTest extends CiviUnitTestCase {
     $subject = __FUNCTION__ . ' subject';
     $html = __FUNCTION__ . ' html';
     $text = __FUNCTION__ . ' text';
-
+    /* @var CRM_Contact_Form_Task_Email $form */
+    $form = $this->getFormObject('CRM_Contact_Form_Task_Email');
     $mut = new CiviMailUtils($this, TRUE);
-    [$sent, $activity_ids] = CRM_Activity_BAO_Activity::sendEmail(
+    [$sent, $activity_ids] = $form->sendEmail(
       $contactDetails,
       $subject,
       $text,
@@ -1441,8 +1444,10 @@ $text
     $html = __FUNCTION__ . ' html';
     $text = __FUNCTION__ . ' text';
     $userID = $loggedInUser;
+    /* @var CRM_Contact_Form_Task_Email $form */
+    $form = $this->getFormObject('CRM_Contact_Form_Task_Email');
 
-    [$sent, $activity_ids] = $email_result = CRM_Activity_BAO_Activity::sendEmail(
+    [$sent, $activity_ids] = $email_result = $form->sendEmail(
       $contactDetails,
       $subject,
       $text,
@@ -1701,7 +1706,9 @@ $text
     $text = __FUNCTION__ . ' text';
 
     $mut = new CiviMailUtils($this, TRUE);
-    [$sent, $activity_ids] = $email_result = CRM_Activity_BAO_Activity::sendEmail(
+    /* @var CRM_Contact_Form_Task_Email $form */
+    $form = $this->getFormObject('CRM_Contact_Form_Task_Email');
+    [$sent, $activity_ids] = $form->sendEmail(
       $contact['values'],
       $subject,
       $text,
@@ -1750,7 +1757,9 @@ $text
     $text = __FUNCTION__ . ' text' . '{contact.display_name}';
     $userID = $loggedInUser;
 
-    CRM_Activity_BAO_Activity::sendEmail(
+    /* @var CRM_Contact_Form_Task_Email $form */
+    $form = $this->getFormObject('CRM_Contact_Form_Task_Email');
+    $form->sendEmail(
       $contact['values'],
       $subject,
       $text,


### PR DESCRIPTION
Overview
----------------------------------------
[REF] Return the sendEmail function to it's owner

Before
----------------------------------------
Function to send emails from the Email task is on the activity BAO - giving the illusion of being centralised, re-usable code

After
----------------------------------------
The function on the BAO is deprecated. The real function now lives on the email trait, permitting us to clean up the inputs & outputs in follow ups

Technical Details
----------------------------------------
This sendEmail function is only called from one place in core and it is not 'generally useful' having
an awful parameter set. This PR moves it back to the class that 'owns' it - which will
allow us to undo all the work of building up that parameter set
and make it possible to support tokens for other entities than those already mangled in.

I would normally add a noisy deprecation notice once a function becomes unused in
core but since that has been done to the pdf task this release I've left this
deprecation a bit quieter for now.

Note that I cleaned up the tokens handled here before deprecating so we
could get rid of those calls fully

Under the OO structure it becomes easier to add the missing token options
- membership & participant - but the business of 'one email per person, &
just grab the tokens from the last entity' is messing with
my head a bit. That's the next bit....

Comments
----------------------------------------
@demeritcowboy @seamuslee001  @colemanw this one really is a straight copy so should be easy to confirm