### PR TITLE
Afform - fix loading embedded blocks

### DIFF
--- a/ext/afform/admin/Civi/Api4/Action/Afform/LoadAdminData.php
+++ b/ext/afform/admin/Civi/Api4/Action/Afform/LoadAdminData.php
@@ -116,6 +116,7 @@ class LoadAdminData extends \Civi\Api4\Generic\AbstractAction {
         if (!isset($info['blocks'][$blockTag])) {
           // Load full contents of block used on the form, then recurse into it
           $embeddedForm = Afform::get($this->checkPermissions)
+            ->addSelect('*', 'directive_name')
             ->setFormatWhitespace(TRUE)
             ->setLayoutFormat('shallow')
             ->addWhere('directive_name', '=', $blockTag)


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a regression in master where content from embedded blocks would not show up in the Editor gui.

Before
----------------------------------------
Click "new afform" from the admin UI. The form layout is missing the "first name" "middle name" and "last name" fields.

After
----------------------------------------
Fixed.

Technical Details
---------
Regressed due to 60a6221505ce7914efb615df14ae664a04a7773f