### PR TITLE
issue 1699: respect membership is_override when contribution is changed

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2067,7 +2067,7 @@ LEFT JOIN  civicrm_contribution contribution ON ( componentPayment.contribution_
 
     if (is_array($memberships)) {
       foreach ($memberships as $membership) {
-        if ($membership) {
+        if ($membership && CRM_Member_StatusOverrideTypes::isNo($membership->is_override)) {
           $format = '%Y%m%d';
 
           //CRM-4523

--- a/CRM/Member/StatusOverrideTypes.php
+++ b/CRM/Member/StatusOverrideTypes.php
@@ -65,7 +65,7 @@ class CRM_Member_StatusOverrideTypes {
    * @return bool
    */
   public static function isOverridden($overrideType) {
-    if ($overrideType == self::NO) {
+    if (self::isNo($overrideType)) {
       return FALSE;
     }
 
@@ -73,11 +73,11 @@ class CRM_Member_StatusOverrideTypes {
   }
 
   public static function isNo($overrideType) {
-    if ($overrideType != self::NO) {
-      return FALSE;
+    if (empty($overrideType) || $overrideType == self::NO) {
+      return TRUE;
     }
 
-    return TRUE;
+    return FALSE;
   }
 
   public static function isPermanent($overrideType) {


### PR DESCRIPTION
Overview
----------------------------------------
Respects is_override when contribution is changed. See issue dev/core#1699

Before
----------------------------------------
When you change a contribution, the code in CRM/Contribute/BAO/Contribution.php neglects the is_override flag of memberships.

After
----------------------------------------
Respects is_override when contribution is changed. 

Technical Details
----------------------------------------
Skips the membership when the override flag is set.


