### PR TITLE
Use HTMLPurifier from composer instead of packages

### DIFF
--- a/CRM/Core/ClassLoader.php
+++ b/CRM/Core/ClassLoader.php
@@ -119,7 +119,6 @@ class CRM_Core_ClassLoader {
     // TODO Remove this autoloader. For civicrm-core and civicrm-packages, the composer autoloader works fine.
     // Extensions rely on include_path-based autoloading
     spl_autoload_register([$this, 'loadClass'], TRUE, $prepend);
-    $this->initHtmlPurifier($prepend);
 
     $this->_registered = TRUE;
     // The ClassLoader runs before the classes are available. Approximate Civi::paths()->get('[civicrm.packages]').
@@ -138,60 +137,6 @@ class CRM_Core_ClassLoader {
     set_include_path($include_paths . PATH_SEPARATOR . get_include_path());
     // @todo Why do we need to load this again?
     $this->requireComposerAutoload();
-  }
-
-  /**
-   * Initialize HTML purifier class.
-   *
-   * @param string $prepend
-   */
-  public function initHtmlPurifier($prepend) {
-    if (class_exists('HTMLPurifier_Bootstrap')) {
-      // HTMLPurifier is already initialized, e.g. by the Drupal module.
-      return;
-    }
-
-    $htmlPurifierPath = $this->getHtmlPurifierPath();
-
-    if (FALSE === $htmlPurifierPath) {
-      // No HTMLPurifier available, e.g. during installation.
-      return;
-    }
-    require_once $htmlPurifierPath;
-    spl_autoload_register(['HTMLPurifier_Bootstrap', 'autoload'], TRUE, $prepend);
-  }
-
-  /**
-   * @return string|false
-   *   Path to the file where the class HTMLPurifier_Bootstrap is defined, or
-   *   FALSE, if such a file does not exist.
-   */
-  private function getHtmlPurifierPath() {
-    if (function_exists('libraries_get_path')
-      && ($path = libraries_get_path('htmlpurifier'))
-      && file_exists($file = $path . '/library/HTMLPurifier/Bootstrap.php')
-    ) {
-      // We are in Drupal 7, and the HTMLPurifier module is installed.
-      // Use Drupal's HTMLPurifier path, to avoid conflicts.
-      // @todo Verify that we are really in Drupal 7, and not in some other
-      // environment that happens to provide a 'libraries_get_path()' function.
-      return $file;
-    }
-
-    // we do this to prevent a autoloader errors with joomla / 3rd party packages
-    // Use absolute path, since we don't know the content of include_path yet.
-    // CRM-11304
-    if (isset($GLOBALS['civicrm_paths']['civicrm.packages']['path'])) {
-      $file = rtrim($GLOBALS['civicrm_paths']['civicrm.packages']['path'], DIRECTORY_SEPARATOR) . '/IDS/vendors/htmlpurifier/HTMLPurifier/Bootstrap.php';
-    }
-    else {
-      $file = dirname(__FILE__) . '/../../packages/IDS/vendors/htmlpurifier/HTMLPurifier/Bootstrap.php';
-    }
-    if (file_exists($file)) {
-      return $file;
-    }
-
-    return FALSE;
   }
 
   /**

--- a/CRM/Core/IDS.php
+++ b/CRM/Core/IDS.php
@@ -110,7 +110,8 @@ class CRM_Core_IDS {
         'filter_type' => 'xml',
         'filter_path' => "{$pkgs}/IDS/default_filter.xml",
         'tmp_path' => $tmpDir,
-        'HTML_Purifier_Path' => $pkgs . '/IDS/vendors/htmlpurifier/HTMLPurifier.auto.php',
+        // Ignored, uses autoloader
+        'HTML_Purifier_Path' => TRUE,
         'HTML_Purifier_Cache' => $tmpDir,
         'scan_keys' => '',
         'exceptions' => ['__utmz', '__utmc'],

--- a/composer.json
+++ b/composer.json
@@ -85,7 +85,8 @@
     "pear/mail_mime": "~1.10",
     "pear/db": "1.11",
     "civicrm/composer-compile-lib": "~0.3 || ~1.0",
-    "ext-json": "*"
+    "ext-json": "*",
+    "ezyang/htmlpurifier": "^4.13"
   },
   "scripts": {
     "post-install-cmd": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "96460a970b8f56a147890c6704c01d60",
+    "content-hash": "33f820fbbb88a8cbf7cf43f773af1773",
     "packages": [
         {
             "name": "adrienrn/php-mimetyper",
@@ -680,6 +680,60 @@
             "description": "phpQuery is a server-side, chainable, CSS3 selector driven Document Object Model (DOM) API based on jQuery JavaScript Library",
             "homepage": "http://code.google.com/p/phpquery/",
             "time": "2013-03-21T12:39:33+00:00"
+        },
+        {
+            "name": "ezyang/htmlpurifier",
+            "version": "v4.13.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ezyang/htmlpurifier.git",
+                "reference": "08e27c97e4c6ed02f37c5b2b20488046c8d90d75"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ezyang/htmlpurifier/zipball/08e27c97e4c6ed02f37c5b2b20488046c8d90d75",
+                "reference": "08e27c97e4c6ed02f37c5b2b20488046c8d90d75",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.2"
+            },
+            "require-dev": {
+                "simpletest/simpletest": "dev-master#72de02a7b80c6bb8864ef9bf66d41d2f58f826bd"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "HTMLPurifier": "library/"
+                },
+                "files": [
+                    "library/HTMLPurifier.composer.php"
+                ],
+                "exclude-from-classmap": [
+                    "/library/HTMLPurifier/Language/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-2.1-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Edward Z. Yang",
+                    "email": "admin@htmlpurifier.org",
+                    "homepage": "http://ezyang.com"
+                }
+            ],
+            "description": "Standards compliant HTML filter written in PHP",
+            "homepage": "http://htmlpurifier.org/",
+            "keywords": [
+                "html"
+            ],
+            "support": {
+                "issues": "https://github.com/ezyang/htmlpurifier/issues",
+                "source": "https://github.com/ezyang/htmlpurifier/tree/master"
+            },
+            "time": "2020-06-29T00:56:53+00:00"
         },
         {
             "name": "firebase/php-jwt",


### PR DESCRIPTION
Overview
----------------------------------------
A triad of PRs to switch to autoloading `HTMLPurifier` with Composer instead of including it in `packages/IDS`

- CiviCRM Core PR (this one) adds the entry in Composer and removes the code for finding a path to the php files (now done by the autoloader)
- [CiviCRM Drupal 7 PR](https://github.com/civicrm/civicrm-drupal/pull/649) adds the workaround for preventing conflicts if the class is included in Libraries
- [CiviCRM Packages PR](https://github.com/civicrm/civicrm-packages/pull/334) removes the `HTMLPurifier` package, as well as the code to load it via `require_once`

See https://lab.civicrm.org/dev/core/issues/976

Before
----------------------------------------
- The `HTMLPurifier` classes were located in `packages/IDS`, and loading had to be done manually.
- The IDS class in packages expected a `HTML_Purifier_Path` string to be passed when initializing it, and it would `require_once` that value.
- A special hack in `CRM_Core_ClassLoader` mitigated conflicts when a Drupal7 module had already provided its own copy of `HTMLPurifier`.

After
----------------------------------------
- `HTMLPurifier` classes included by Composer, which sets up its own autoloader.
- IDS patched to ignore `HTML_Purifier_Path` and not `require_once`.
- `CRM_Core_ClassLoader` special handling of  `HTMLPurifier` removed.
- CMS-specific hacks removed from `CRM_Core_ClassLoader` and moved to the Drupal 7 `civicrm.module` file.

Technical Details
----------------------------------------
Most of the hacks and special handling are now moot because the Composer autoloader does most of the work. The Drupal 7 hack seems worth keeping, but not in Core, so I moved it to the drupal7 repo.

Comments
----------------------------------------
This new triad replaces #21432 
