### PR TITLE
Fix membership transition by switching to Payment.create

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4167,18 +4167,21 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
   }
 
   /**
-   * Update the memberships associated with a contribution if it has been completed.
+   * Update the memberships associated with a contribution if it has been
+   * completed.
    *
-   * Note that the way in which $memberships are loaded as objects is pretty messy & I think we could just
-   * load them in this function. Code clean up would compensate for any minor performance implication.
+   * Note that the way in which $memberships are loaded as objects is pretty
+   * messy & I think we could just load them in this function. Code clean up
+   * would compensate for any minor performance implication.
    *
    * @param int $contributionID
    * @param string $changeDate
    *
    * @throws \CRM_Core_Exception
    * @throws \CiviCRM_API3_Exception
+   * @throws \API_Exception
    */
-  public static function updateMembershipBasedOnCompletionOfContribution($contributionID, $changeDate) {
+  public static function updateMembershipBasedOnCompletionOfContribution(int $contributionID, $changeDate) {
     $memberships = self::getRelatedMemberships((int) $contributionID);
     foreach ($memberships as $membership) {
       $membershipParams = [

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -3472,8 +3472,6 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
     /* @var CRM_Contribute_Form_Contribution $form */
     $form = $this->getFormObject('CRM_Contribute_Form_Contribution', [
       'total_amount' => 20,
-      'net_amount' => 20,
-      'fee_amount' => 0,
       'financial_type_id' => 1,
       'contact_id' => $this->_individualId,
       'contribution_status_id' => 1,

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -3457,8 +3457,11 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
    */
   public function testPendingToCompleteContribution(): void {
     $this->createPriceSetWithPage('membership');
-    $this->setUpPendingContribution($this->_ids['price_field_value'][0]);
-    $this->callAPISuccess('membership', 'getsingle', ['id' => $this->_ids['membership']]);
+    $this->setUpPendingContribution($this->_ids['price_field_value'][0], '', [], [], [
+      'start_date' => 'yesterday',
+      'join_date' => 'yesterday',
+    ]);
+    $this->callAPISuccess('Membership', 'getsingle', ['id' => $this->_ids['membership']]);
     // Case 1: Assert that Membership Signup Activity is created on Pending to Completed Contribution via backoffice
     $activity = $this->callAPISuccess('Activity', 'get', [
       'activity_type_id' => 'Membership Signup',
@@ -3466,7 +3469,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
       'status_id' => 'Scheduled',
     ]);
     $this->assertEquals(1, $activity['count']);
-    $_REQUEST['id'] = $this->getContributionID();
+    $_REQUEST['id'] = $this->getContributionID('');
     $_REQUEST['action'] = 'update';
     // change pending contribution to completed
     /* @var CRM_Contribute_Form_Contribution $form */
@@ -3507,7 +3510,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
     // 2.b Contribution activity created to record successful payment
     $activity = $this->callAPISuccess('Activity', 'get', [
       'activity_type_id' => 'Contribution',
-      'source_record_id' => $this->getContributionID(),
+      'source_record_id' => $this->getContributionID(''),
       'status_id' => 'Completed',
     ]);
     $this->assertEquals(1, $activity['count']);


### PR DESCRIPTION
Overview
----------------------------------------
Alternative to https://github.com/civicrm/civicrm-core/pull/21616

Before
----------------------------------------
deprecated transitionComponents function used - it doesn't respect override

After
----------------------------------------
Payment.create is used

Technical Details
----------------------------------------
I'm expecting test fails here - I switched to using 'getSubmittedValue' which is cleaner but requires the tests to be fixed to be more like the real flow

Comments
----------------------------------------
@AlainBenbassat still some work to do on this - but does it fix the problem?