### PR TITLE
Test cleanup

### DIFF
--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -1493,7 +1493,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
     }
     $this->assign('lineItem', !empty($lineItem) && !$isQuickConfig ? $lineItem : FALSE);
 
-    $isEmpty = array_keys(array_flip($submittedValues['soft_credit_contact_id']));
+    $isEmpty = array_keys(array_flip($submittedValues['soft_credit_contact_id'] ?? []));
     if ($this->_id && count($isEmpty) == 1 && key($isEmpty) == NULL) {
       civicrm_api3('ContributionSoft', 'get', ['contribution_id' => $this->_id, 'pcp_id' => ['IS NULL' => 1], 'api.ContributionSoft.delete' => 1]);
     }


### PR DESCRIPTION

Overview
----------------------------------------
Test cleanup

Before
----------------------------------------
We use the 'artificial' submit function

After
----------------------------------------
We call `postProcess`

Technical Details
----------------------------------------
This switches us to a less hacky way to interact with the form in some of the tests.

Our helpers now support us interacting with the forms in a way that better mimics
the real flow & allows us to call 'postProcess'

It also means the tests won't fail if we start using `getSubmittedValue`

Comments
----------------------------------------
