### PR TITLE
Remove handling for empty required field

### DIFF
--- a/CRM/Contact/Form/Task/EmailTrait.php
+++ b/CRM/Contact/Form/Task/EmailTrait.php
@@ -406,7 +406,7 @@ trait CRM_Contact_Form_Task_EmailTrait {
   public function submit($formValues): void {
     $this->saveMessageTemplate($formValues);
 
-    $from = $formValues['from_email_address'] ?? NULL;
+    $from = $formValues['from_email_address'];
     // dev/core#357 User Emails are keyed by their id so that the Signature is able to be added
     // If we have had a contact email used here the value returned from the line above will be the
     // numerical key where as $from for use in the sendEmail in Activity needs to be of format of "To Name" <toemailaddress>
@@ -790,7 +790,7 @@ trait CRM_Contact_Form_Task_EmailTrait {
    *   The subject of the message.
    * @param $text
    * @param $html
-   * @param string|null $from
+   * @param string $from
    * @param array|null $attachments
    *   The array of attachments if any.
    * @param string|null $cc
@@ -820,7 +820,7 @@ trait CRM_Contact_Form_Task_EmailTrait {
     $subject,
     $text,
     $html,
-    $from = NULL,
+    $from,
     $attachments = NULL,
     $cc = NULL,
     $bcc = NULL,
@@ -831,18 +831,6 @@ trait CRM_Contact_Form_Task_EmailTrait {
   ) {
 
     $userID = CRM_Core_Session::getLoggedInContactID();
-
-    [$fromDisplayName, $fromEmail, $fromDoNotEmail] = CRM_Contact_BAO_Contact::getContactDetails($userID);
-    if (!$fromEmail) {
-      return [count($contactDetails), 0, count($contactDetails)];
-    }
-    if (!trim($fromDisplayName)) {
-      $fromDisplayName = $fromEmail;
-    }
-
-    if (!$from) {
-      $from = "$fromDisplayName <$fromEmail>";
-    }
 
     $contributionDetails = [];
     if (!empty($contributionIds)) {

--- a/tests/phpunit/CRM/Contribute/Form/Task/EmailTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/Task/EmailTest.php
@@ -39,12 +39,12 @@ class CRM_Contribute_Form_Task_EmailTest extends CiviUnitTestCase {
     $userID = $this->createLoggedInUser();
     $mut = new CiviMailUtils($this);
     Civi::settings()->set('allow_mail_from_logged_in_contact', TRUE);
-    $this->callAPISuccess('Email', 'create', [
+    $emailID = $this->callAPISuccess('Email', 'create', [
       'contact_id' => $userID,
       'email' => 'benny_jetts@example.com',
       'signature_html' => 'Benny, Benny',
       'is_primary' => 1,
-    ]);
+    ])['id'];
     $contribution1 = $this->contributionCreate(['contact_id' => $contact2, 'invoice_number' => 'soy']);
     $contribution2 = $this->contributionCreate(['total_amount' => 999, 'contact_id' => $contact1, 'invoice_number' => 'saucy']);
     $contribution3 = $this->contributionCreate(['total_amount' => 999, 'contact_id' => $contact1, 'invoice_number' => 'ranch']);
@@ -58,6 +58,7 @@ class CRM_Contribute_Form_Task_EmailTest extends CiviUnitTestCase {
       'subject' => '{contact.display_name} {contribution.total_amount}',
       'text_message' => '{contribution.financial_type_id:label} {contribution.invoice_number}',
       'html_message' => '{domain.name}',
+      'from_email_address' => $emailID,
     ], [], [
       'radio_ts' => 'ts_sel',
       'task' => CRM_Core_Task::TASK_EMAIL,


### PR DESCRIPTION

Overview
----------------------------------------
From is a required field - remove code to handle it being empty

Before
----------------------------------------
From is required - but the code still does a lot of work in case it's empty

![image](https://user-images.githubusercontent.com/336308/134793002-4bc4d2dc-c79f-4bec-a123-7dc6aa10e6c2.png)

After
----------------------------------------
poof

Technical Details
----------------------------------------
The function that the extra code was in was used from other places ... once upon a time but not now

Comments
----------------------------------------
