### PR TITLE
dev/core#2629 show only contribution statuses on contribution form

### DIFF
--- a/CRM/Contribute/BAO/Contribution/Utils.php
+++ b/CRM/Contribute/BAO/Contribution/Utils.php
@@ -208,13 +208,13 @@ LIMIT 1
    * Get contribution statuses by entity e.g. contribution, membership or 'participant'
    *
    * @param string $usedFor
-   * @param int $id
+   * @param string $name
    *   Contribution ID
    *
    * @return array
    *   Array of contribution statuses in array('status id' => 'label') format
    */
-  public static function getContributionStatuses($usedFor = 'contribution', $id = NULL) {
+  public static function getContributionStatuses($usedFor = 'contribution', $name = NULL) {
     if ($usedFor === 'pledge') {
       $statusNames = CRM_Pledge_BAO_Pledge::buildOptions('status_id', 'validate');
     }
@@ -232,7 +232,7 @@ LIMIT 1
       'Template',
     ];
     // on create fetch statuses on basis of component
-    if (!$id) {
+    if (!$name) {
       $statusNamesToUnset = array_merge($statusNamesToUnset, [
         'Refunded',
         'Chargeback',
@@ -266,8 +266,7 @@ LIMIT 1
       }
     }
     else {
-      $contributionStatus = CRM_Core_DAO::getFieldValue('CRM_Contribute_DAO_Contribution', $id, 'contribution_status_id');
-      $name = $statusNames[$contributionStatus] ?? NULL;
+
       switch ($name) {
         case 'Completed':
           // [CRM-17498] Removing unsupported status change options.


### PR DESCRIPTION


Overview
----------------------------------------
dev/core#2629 show only contribution statuses on contribution form

Before
----------------------------------------
Whoa - that code is crazy-confusing

After
----------------------------------------
Makes a bit more sense

Technical Details
----------------------------------------
This arose from digging into
https://lab.civicrm.org/dev/core/-/issues/2629
but I think it's a tangent....

The function that looks to find out what contribution statuses to expose passes in the 'component' - but there is no reason the component should be relevant to the contribution status on the contribution edit screen. Note that I think this relates to when we used to overload the contribution_status_id option value for multiple entities

I'm not seeing this as changing anything other than code complexity

@monishdeb can you check this?

Comments
---------------------------------------