### PR TITLE
Setting::getItem - use deprecatedWarning instead of just logging

### DIFF
--- a/CRM/Core/BAO/Setting.php
+++ b/CRM/Core/BAO/Setting.php
@@ -75,13 +75,13 @@ class CRM_Core_BAO_Setting extends CRM_Core_DAO_Setting {
     $manager = \Civi::service('settings_manager');
     $settings = ($contactID === NULL) ? $manager->getBagByDomain($domainID) : $manager->getBagByContact($domainID, $contactID);
     if ($name === NULL) {
-      CRM_Core_Error::debug_log_message("Deprecated: Group='$group'. Name should be provided.\n");
+      CRM_Core_Error::deprecatedWarning("Deprecated: Group='$group'. Name should be provided.\n");
     }
     if ($componentID !== NULL) {
-      CRM_Core_Error::debug_log_message("Deprecated: Group='$group'. Name='$name'. Component should be omitted\n");
+      CRM_Core_Error::deprecatedWarning("Deprecated: Group='$group'. Name='$name'. Component should be omitted\n");
     }
     if ($defaultValue !== NULL) {
-      CRM_Core_Error::debug_log_message("Deprecated: Group='$group'. Name='$name'. Defaults should come from metadata\n");
+      CRM_Core_Error::deprecatedWarning("Deprecated: Group='$group'. Name='$name'. Defaults should come from metadata\n");
     }
     return $name ? $settings->get($name) : $settings->all();
   }

--- a/tests/phpunit/CRM/Core/BAO/SettingTest.php
+++ b/tests/phpunit/CRM/Core/BAO/SettingTest.php
@@ -121,39 +121,23 @@ class CRM_Core_BAO_SettingTest extends CiviUnitTestCase {
     global $civicrm_setting;
     $civicrm_setting[CRM_Core_BAO_Setting::DIRECTORY_PREFERENCES_NAME]['imageUploadDir'] = '/test/override';
     Civi::service('settings_manager')->useMandatory();
-    $value = CRM_Core_BAO_Setting::getItem(CRM_Core_BAO_Setting::DIRECTORY_PREFERENCES_NAME, 'imageUploadDir');
+    $value = Civi::settings()->get('imageUploadDir');
     $this->assertEquals('/test/override', $value);
+
+    $civicrm_setting['domain']['customCSSURL'] = 'http://test.test/overridedomain';
+    Civi::service('settings_manager')->useMandatory();
+    $value = Civi::settings()->get('customCSSURL');
+    $this->assertEquals('http://test.test/overridedomain', $value);
 
     // CRM-14974 test suite
     $civicrm_setting['Test Preferences']['overrideSetting'] = '/test/override';
     Civi::service('settings_manager')->useMandatory();
-    $values = CRM_Core_BAO_Setting::getItem('Test Preferences');
-    $this->assertEquals('/test/override', $values['overrideSetting']);
-    Civi::settings()->set('databaseSetting', '/test/database');
-    $values = CRM_Core_BAO_Setting::getItem('Test Preferences');
-    $this->assertEquals('/test/override', $values['overrideSetting']);
-    $this->assertEquals('/test/database', $values['databaseSetting']);
-    $civicrm_setting['Test Preferences']['databaseSetting'] = '/test/dataride';
-    Civi::service('settings_manager')->useMandatory();
-    $values = CRM_Core_BAO_Setting::getItem('Test Preferences');
-    $this->assertEquals('/test/override', $values['overrideSetting']);
-    $this->assertEquals('/test/dataride', $values['databaseSetting']);
+    $value = Civi::settings()->get('overrideSetting');
+    $this->assertEquals('/test/override', $value);
     // CRM-14974 tear down
     unset($civicrm_setting['Test Preferences']);
-    $query = "DELETE FROM civicrm_setting WHERE name IN ('overrideSetting', 'databaseSetting');";
+    $query = "DELETE FROM civicrm_setting WHERE name = 'overrideSetting'";
     CRM_Core_DAO::executeQuery($query);
-  }
-
-  /**
-   * Ensure that overrides in $civicrm_setting apply when
-   * using getItem($group).
-   */
-  public function testGetItemGroup_Override() {
-    global $civicrm_setting;
-    $civicrm_setting[CRM_Core_BAO_Setting::DIRECTORY_PREFERENCES_NAME]['imageUploadDir'] = '/test/override';
-    Civi::service('settings_manager')->useMandatory();
-    $values = CRM_Core_BAO_Setting::getItem(CRM_Core_BAO_Setting::DIRECTORY_PREFERENCES_NAME);
-    $this->assertEquals('/test/override', $values['imageUploadDir']);
   }
 
   public function testDefaults() {


### PR DESCRIPTION
Overview
----------------------------------------
I don't think this will change anything in core, but let's see if anything comes up in tests.