### PR TITLE
SearchKit - Style buttons for compatability with Shoreditch theme

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminLinkSelect.html
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminLinkSelect.html
@@ -1,10 +1,10 @@
 <div class="crm-flex-1 input-group" >
   <input type="text" class="form-control" ng-if="!$ctrl.getLink($ctrl.link.path)" ng-model="$ctrl.link.path" ng-model-options="{updateOn: 'blur'}" ng-change="$ctrl.onChange({before: 'civicrm/', after: $ctrl.link.path})">
   <div class="input-group-btn" style="{{ $ctrl.getLink($ctrl.link.path) ? '' : 'width:27px' }}">
-    <button type="button" class="btn btn-default-outline dropdown-toggle" style="min-width: 200px; text-align: left;" ng-if="$ctrl.getLink($ctrl.link.path)" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+    <button type="button" class="btn btn-sm btn-secondary-outline dropdown-toggle" style="min-width: 200px; text-align: left;" ng-if="$ctrl.getLink($ctrl.link.path)" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
       {{ $ctrl.getLink($ctrl.link.path).title }}
     </button>
-    <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+    <button type="button" class="btn btn-sm btn-secondary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
       <span class="caret"></span>
     </button>
     <ul class="dropdown-menu {{ $ctrl.getLink($ctrl.link.path) ? '' : 'dropdown-menu-right' }}" style="min-width: 223px;">

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminTags.html
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminTags.html
@@ -1,4 +1,4 @@
-<button type="button" class="btn dropdown-toggle" ng-click="$ctrl.openMenu()" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+<button type="button" class="btn btn-secondary dropdown-toggle" ng-click="$ctrl.openMenu()" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
   <i class="crm-i fa-tag"></i>
   <span class="crm-search-admin-tags-btn-label">{{:: ts('Tags') }}</span>
   <span class="caret"></span>

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchFunction.html
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchFunction.html
@@ -18,7 +18,7 @@
     </span>
   </div>
   <div class="btn-group" ng-if="$ctrl.canAddArg()">
-    <button type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+    <button type="button" class="btn btn-sm btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
       <i class="crm-i fa-plus"></i> <span class="caret"></span>
     </button>
     <ul class="dropdown-menu">

--- a/ext/search_kit/ang/crmSearchAdmin/displays/common/searchButtonConfig.html
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/common/searchButtonConfig.html
@@ -1,10 +1,10 @@
 <div class="input-group">
   <div class="input-group-btn" title="{{:: ts('Should the search be run immediately, or wait for the user to click a button?') }}">
-    <button type="button" class="btn btn-outline-default" ng-click="$ctrl.display.settings.button = null" ng-class="{active: !$ctrl.display.settings.button}">
+    <button type="button" class="btn btn-secondary-outline btn-sm" ng-click="$ctrl.display.settings.button = null" ng-class="{active: !$ctrl.display.settings.button}">
       <i class="crm-i fa-{{ $ctrl.display.settings.button ? '' : 'check-' }}circle-o"></i>
       {{:: ts('Auto-Run') }}
     </button>
-    <button type="button" class="btn btn-outline-default" ng-click="$ctrl.display.settings.button = ts('Search')" ng-class="{active: $ctrl.display.settings.button}">
+    <button type="button" class="btn btn-secondary-outline btn-sm" ng-click="$ctrl.display.settings.button = ts('Search')" ng-class="{active: $ctrl.display.settings.button}">
       <i class="crm-i fa-{{ !$ctrl.display.settings.button ? '' : 'check-' }}circle-o"></i>
       {{:: ts('Search Button') }}
     </button>


### PR DESCRIPTION
Overview
----------------------------------------
This adjusts a few css classes to reach a reasonable compromise between Shoreditch and Greenwich, so that nothing looks "broken" in either theme.

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/2874912/134823604-7d71b411-560e-41e9-aa93-116fd6875b88.png)

After
----------------------------------------
![image](https://user-images.githubusercontent.com/2874912/134823566-52f7485f-329d-45c1-9726-f6f982285913.png)
