### PR TITLE
Fix dev/core#2867 - APIv4 Entity.get to return class name by default

### DIFF
--- a/Civi/Api4/Entity.php
+++ b/Civi/Api4/Entity.php
@@ -113,6 +113,11 @@ class Entity extends Generic\AbstractEntity {
           'description' => 'Version this API entity was added',
         ],
         [
+          'name' => 'class',
+          'data_type' => 'String',
+          'description' => 'PHP class name',
+        ],
+        [
           'name' => 'bridge',
           'data_type' => 'Array',
           'description' => 'Connecting fields for EntityBridge types',


### PR DESCRIPTION
Overview
----------------------------------------
Fixes the APIv4 Explorer PHP OOP output to include the correct class name.

See https://lab.civicrm.org/dev/core/-/issues/2867

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/2874912/134827268-51499bd0-6c52-499d-b7ec-d2bd33f52b9e.png)


After
----------------------------------------
![image](https://user-images.githubusercontent.com/2874912/134827254-3799829d-6cb3-4e78-a6f1-4fb326879f51.png)
Technical Details
----------------------------------------
Ad-hoc entities (which includes the Entity entity) now default to not return any fields not declared in GetFields as of 60a6221.
This field was accidentally left out.