### PR TITLE
TypeError: Argument 1 passed to CRM_Import_DataSource_CSV::trimNonBreakingSpaces() must be of the type string, null given in CRM_Import_DataSource_CSV::trimNonBreakingSpaces

### DIFF
--- a/CRM/Import/DataSource/CSV.php
+++ b/CRM/Import/DataSource/CSV.php
@@ -260,7 +260,7 @@ class CRM_Import_DataSource_CSV extends CRM_Import_DataSource {
    * @param string $string
    * @return string The trimmed string
    */
-  public static function trimNonBreakingSpaces(string $string): string {
+  public static function trimNonBreakingSpaces($string): string {
     $encoding = mb_detect_encoding($string, NULL, TRUE);
     if ($encoding === FALSE) {
       // This could mean a couple things. One is that the string is


### PR DESCRIPTION
Overview
----------------------------------------
When performing a Contact Import, if the supplied CSV file has multiple blank lines at the end of the file, then the import will abort and an error shown:
`TypeError: Argument 1 passed to CRM_Import_DataSource_CSV::trimNonBreakingSpaces() must be of the type string, null given in CRM_Import_DataSource_CSV::trimNonBreakingSpaces`

See Gitlab for more details and example CSVs, https://lab.civicrm.org/dev/core/-/issues/2868

Confirmed in CiviCRM 5.40.4 and CiviCRM 5.41.2

Before
----------------------------------------
Contact Import feature cannot be used to import CSV.

After
----------------------------------------
Contact Import feature can import CSV.

Technical Details
----------------------------------------

Comments
----------------------------------------
Agileware Ref: CIVICRM-1847
