### PR TITLE
PoC: Return contact ID when logged in via checksum

### DIFF
--- a/CRM/Core/Session.php
+++ b/CRM/Core/Session.php
@@ -555,12 +555,25 @@ class CRM_Core_Session {
   /**
    * Retrieve contact id of the logged in user.
    *
+   * @param bool $returnChecksumContactID
+   *   Whether to return a contact ID if we are "logged in" via checksum.
+   *
    * @return int|null
    *   contact ID of logged in user
    */
-  public static function getLoggedInContactID() {
+  public static function getLoggedInContactID(bool $returnChecksumContactID = FALSE) {
     $session = CRM_Core_Session::singleton();
     if (!is_numeric($session->get('userID'))) {
+      if ($returnChecksumContactID && !empty($_REQUEST['cs'])) {
+        // If user is accessing via a "checksum" link validate that and return their contact ID.
+        $userChecksum = CRM_Utils_Request::retrieveValue('cs', 'String');
+        $checksumCID = CRM_Utils_Request::retrieveValue('cid', 'Positive');
+        $validUser = CRM_Contact_BAO_Contact_Utils::validChecksum($checksumCID, $userChecksum);
+
+        if ($validUser) {
+          return (int) $checksumCID;
+        }
+      }
       return NULL;
     }
     return (int) $session->get('userID');


### PR DESCRIPTION
Overview
----------------------------------------
`CRM_Core_Session::getLoggedInContactID()` returns NULL when a contact is "logged in" via a checksum link. This doesn't really make sense because they can do everything that they would have been able to do if "logged in" via a normal session.

I've seen a lot of code that makes the assumption that 
```
if (CRM_Core_Session::getLoggedInContactID() === NULL) {
  // do anonymous user stuff
}
```

Inspired by the new loginsecurity extension by @mlutfy 

Before
----------------------------------------
`getLoggedInContactID()` doesn't always do what you expect (if logged in via checksum).

After
----------------------------------------
Default behaviour is not changed. It is explicit because the parameter makes it clear that you will not get the checksum Contact ID unless you specifically request that behaviour.

Technical Details
----------------------------------------


Comments
----------------------------------------

