### PR TITLE
Afform - ensure default value data type matches input type

### DIFF
--- a/ext/afform/core/ang/af/afField.component.js
+++ b/ext/afform/core/ang/af/afField.component.js
@@ -99,15 +99,35 @@
           }
           // Set default value based on url
           if (urlArgs && urlArgs[uniquePrefix + ctrl.fieldName]) {
-            $scope.dataProvider.getFieldData()[ctrl.fieldName] = urlArgs[uniquePrefix + ctrl.fieldName];
+            setValue(urlArgs[uniquePrefix + ctrl.fieldName]);
           }
           // Set default value based on field defn
           else if (ctrl.defn.afform_default) {
-            $scope.dataProvider.getFieldData()[ctrl.fieldName] = ctrl.defn.afform_default;
+            setValue(ctrl.defn.afform_default);
           }
         });
-
       };
+
+      // Set default value; ensure data type matches input type
+      function setValue(value) {
+        if (ctrl.defn.input_type === 'Number' && ctrl.defn.search_range) {
+          if (!_.isPlainObject(value)) {
+            value = {
+              '>=': +(('' + value).split('-')[0] || 0),
+              '<=': +(('' + value).split('-')[1] || 0),
+            };
+          }
+        } else if (ctrl.defn.input_type === 'Number') {
+          value = +value;
+        } else if (ctrl.defn.search_range && !_.isPlainObject(value)) {
+          value = {
+            '>=': ('' + value).split('-')[0],
+            '<=': ('' + value).split('-')[1] || '',
+          };
+        }
+
+        $scope.dataProvider.getFieldData()[ctrl.fieldName] = value;
+      }
 
       // Get the repeat index of the entity fieldset (not the join)
       ctrl.getEntityIndex = function() {


### PR DESCRIPTION
Overview
----------------------------------------
Followup to #21606 
Fixes mismatch between default value from the URL (which is always a string) and inputs for other types of values - numbers and search ranges.

Before
----------------------------------------
Url args don't seem to populate for number fields or range inputs.

After
----------------------------------------
Number fields work as expected. Range fields can be passed through the url with high and low values separated by `-` like `/civicrm/test-form#?my_number_field=123-456`

Screenshot is with #21645 

![image](https://user-images.githubusercontent.com/2874912/134958784-f692a26d-a207-44aa-a11a-7925eaff22d1.png)