### PR TITLE
show processed token in greeting dropdown

### DIFF
--- a/CRM/Contact/Form/Edit/CommunicationPreferences.php
+++ b/CRM/Contact/Form/Edit/CommunicationPreferences.php
@@ -82,8 +82,30 @@ class CRM_Contact_Form_Edit_CommunicationPreferences {
         'greeting_type' => $greeting,
       ];
 
-      //add addressee in Contact form
+      // Add addressee in Contact form.
       $greetingTokens = CRM_Core_PseudoConstant::greeting($filter);
+
+      // Instead of showing smarty token with/o conditional logic in Drop down
+      // list, show processed token (Only in Contact Edit mode).
+      // Get Description of each greeting.
+      $greetingTokensDescription = CRM_Core_PseudoConstant::greeting($filter, 'description');
+      if ($form->_contactId) {
+        $renderedGreetingTokens = CRM_Core_TokenSmarty::render($greetingTokens,
+          [
+            'contactId' => $form->_contactId,
+          ]
+        );
+        foreach ($greetingTokens as $key => &$emailGreetingString) {
+          if ($emailGreetingString) {
+            $emailGreetingString = $renderedGreetingTokens[$key];
+            $emailGreetingString = CRM_Core_DAO::escapeString(CRM_Utils_String::stripSpaces($emailGreetingString));
+            if (!empty($greetingTokensDescription[$key])) {
+              // Append description to processed greeting.
+              $emailGreetingString .= ' ( ' . $greetingTokensDescription[$key] . ' )';
+            }
+          }
+        }
+      }
       if (!empty($greetingTokens)) {
         $form->addElement('select', $fields['field'], $fields['label'],
           [

--- a/templates/CRM/Admin/Form/Options.tpl
+++ b/templates/CRM/Admin/Form/Options.tpl
@@ -99,9 +99,11 @@
                 <td>{$form.description.html}<br />
             {if $gName eq 'activity_type'}
                <span class="description">{ts}Description is included at the top of the activity edit and view pages for this type of activity.{/ts}</span>
+            {elseif $gName eq 'email_greeting' || $gName eq 'postal_greeting' || $gName eq  'addressee'}
+                <span class="description">{ts}Description will be appended to processed greeting.{/ts}</span>
+            {/if}
                 </td>
               </tr>
-            {/if}
         {/if}
         {if $gName eq 'participant_status'}
               <tr class="crm-admin-options-form-block-visibility_id">


### PR DESCRIPTION
Overview
----------------------------------------
For Greeting we show Dear with some contact token as configured in greeting back-end section. Some time to generate custom greeting, we need to write smarty code with conditional logic capture smarty function. On Contact Summary page, same smarty code shown in greeting drop down list.

So instead of showing smarty code we can show processed greeting in drop drown list and user don't have check logic written for each greeting block. Description will shown in bracket if present in-front of each processed greeting.

Before
----------------------------------------
Tokens were displayed with conditional logic if present ...
<img width="966" alt="Screenshot 2021-09-27 at 7 16 43 PM" src="https://user-images.githubusercontent.com/377735/134947991-3c208316-da64-4d7e-8f5b-e6ec4b299dcf.png">


After
----------------------------------------
Token get Processed and processed token output get shown.

<img width="573" alt="Screenshot 2021-09-27 at 7 16 20 PM" src="https://user-images.githubusercontent.com/377735/134948088-14615f4a-bdf2-483a-9a14-6d856fb0e808.png">


Back-end configuration of Addressee Token:
<img width="999" alt="Screenshot 2021-09-27 at 9 00 46 PM" src="https://user-images.githubusercontent.com/377735/134948157-5b5a64ad-dc7a-4bae-825c-a73f6120b245.png">


Comments
----------------------------------------
I did submitted Same PR few year back with similar changes but failed in user testing:
https://github.com/civicrm/civicrm-core/pull/10480

Relevant Ticket link on JIRA  : https://issues.civicrm.org/jira/browse/CRM-20695

