### PR TITLE
Afform - Use search display name as field prefix for url-based field defaults

### DIFF
--- a/ext/afform/core/ang/af/afField.component.js
+++ b/ext/afform/core/ang/af/afField.component.js
@@ -97,9 +97,13 @@
             var index = ctrl.getEntityIndex();
             uniquePrefix = entityName + (index ? index + 1 : '') + (joinEntity ? '.' + joinEntity : '') + '.';
           }
-          // Set default value based on url
+          // Set default value from url with uniquePrefix + fieldName
           if (urlArgs && urlArgs[uniquePrefix + ctrl.fieldName]) {
             setValue(urlArgs[uniquePrefix + ctrl.fieldName]);
+          }
+          // Set default value from url with fieldName only
+          else if (urlArgs && urlArgs[ctrl.fieldName]) {
+            $scope.dataProvider.getFieldData()[ctrl.fieldName] = urlArgs[ctrl.fieldName];
           }
           // Set default value based on field defn
           else if (ctrl.defn.afform_default) {

--- a/ext/afform/core/ang/af/afFieldset.directive.js
+++ b/ext/afform/core/ang/af/afFieldset.directive.js
@@ -11,15 +11,18 @@
         var self = ctrls[0];
         self.afFormCtrl = ctrls[1];
       },
-      controller: function($scope) {
+      controller: function($scope, $element) {
         var ctrl = this,
           localData = [];
 
         this.getData = function() {
           return ctrl.afFormCtrl ? ctrl.afFormCtrl.getData(ctrl.modelName) : localData;
         };
+        // Get name of afform entity or search display
         this.getName = function() {
-          return this.modelName;
+          return this.modelName ||
+            // If there is no Afform entity, get the name of embedded search display
+            $element.find('[search-name][display-name]').attr('display-name');
         };
         this.getEntityType = function() {
           return this.afFormCtrl.getEntity(this.modelName).type;


### PR DESCRIPTION
Overview
------------------
Followup from #21606 
Makes field prefix optional for Afform url-based defaults, and uses search display name as prefix for search forms.

Before
----------------------------------------
Regular forms (e.g. with a submit button) would require the entity name as a prefix in url args, e.g. `#?Individual1.first_name=Bob` but search forms would not use a prefix.

After
----------------------------------------
Search forms use the name of the search display as prefix, but prefix is now optional (screenshot is with #21643):

![image](https://user-images.githubusercontent.com/2874912/134958784-f692a26d-a207-44aa-a11a-7925eaff22d1.png)


Technical Details
----------------------------------------
There is only one URL bar, but potentially lots of Afforms on a page, so using a prefix is generally a good idea, but not required as of this PR.

For input forms, either of these will work:
-  `#?first_name=Bob`
-  `#?Individual1.first_name=Bob`

For search forms, the display name is used as the field prefix (and range values are separated with a dash). Either of these will work:
-  `#?total_amount=500-1000`
-  `#?MySearchDisplay.total_amount=500-1000`

Note that this assumes the main search entity is Contribution. For joins, the name of the join is required e.g. `#?Contribution_Contact.first_name=Bob`