### PR TITLE
fixes core#2874 - Search Builder on State/Province with Primary and IN

### DIFF
--- a/CRM/Core/BAO/Mapping.php
+++ b/CRM/Core/BAO/Mapping.php
@@ -1051,7 +1051,7 @@ class CRM_Core_BAO_Mapping extends CRM_Core_DAO_Mapping {
           // CRM-19081 Fix legacy StateProvince Field Values.
           // These derive from smart groups created using search builder under older
           // CiviCRM versions.
-          if (!is_numeric($value) && $fldName == 'state_province') {
+          if ($fldName == 'state_province' && !is_numeric($value) && !is_array($value)) {
             $value = CRM_Core_PseudoConstant::getKey('CRM_Core_BAO_Address', 'state_province_id', $value);
           }
 

--- a/tests/phpunit/CRM/Contact/BAO/SavedSearchDataSets/primary_multiple_state_province.sql
+++ b/tests/phpunit/CRM/Contact/BAO/SavedSearchDataSets/primary_multiple_state_province.sql
@@ -1,0 +1,7 @@
+INSERT INTO civicrm_mapping (id,name,description,mapping_type_id) Values
+(114, NULL, NULL, NULL);
+INSERT INTO `civicrm_mapping_field` (`id`, `mapping_id`, `name`, `contact_type`, `column_number`, `location_type_id`, `phone_type_id`, `im_provider_id`, `relationship_type_id`, `relationship_direction`, `grouping`, `operator`, `value`, `website_type_id`) VALUES
+(2846, 114, 'state_province', 'Contact', 0, NULL, NULL, NULL, NULL, NULL, 1, 'IN', '1501,2704', NULL);
+INSERT INTO `civicrm_saved_search` (`id`, `form_values`, `mapping_id`, `search_custom_id`) VALUES
+(333, 'a:5:{s:6:"mapper";a:1:{i:1;a:1:{i:0;a:3:{i:0;s:7:"Contact";i:1;s:14:"state_province";i:2;s:1:" ";}}}s:8:"operator";a:1:{i:1;a:1:{i:0;s:2:"IN";}}s:5:"value";a:1:{i:1;a:1:{i:0;s:9:"1501,2074";}}s:8:"radio_ts";s:6:"ts_all";s:4:"task";s:0:"";}', '114', NULL);
+INSERT INTO `civicrm_group` (`id`, `name`, `title`, `description`, `source`, `saved_search_id`, `is_active`, `visibility`) VALUES (98, 'core_2874', 'Core 2874 test group', NULL, NULL, 333, 1, 'User and User Admin Only');


### PR DESCRIPTION
https://lab.civicrm.org/dev/core/-/issues/2874

Overview
----------------------------------------
Using Search Builder with a field of "State/Province", a location type of "Primary" and an operator of "IN" causes a validation error.  Full replication steps, before/after, etc. are on https://lab.civicrm.org/dev/core/-/issues/2874.

Technical Details
----------------------------------------
This is a fix to PR #8890, which fixed the case where the Search Builder could be passed a string for a `state_province` value, but didn't consider the case where it's passed an array.
