### PR TITLE
[REF] Copy another email trait function back to the trait

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -1389,6 +1389,8 @@ WHERE entity_id =%1 AND entity_table = %2";
   }
 
   /**
+   * DO Not use this function. Under deprecation, no active core use.
+   *
    * Send the message to a specific contact.
    *
    * @param string $from
@@ -1410,6 +1412,8 @@ WHERE entity_id =%1 AND entity_table = %2";
    *
    * @return bool
    *   TRUE if successful else FALSE.
+   *
+   * @deprecated
    */
   public static function sendMessage(
     $from,


### PR DESCRIPTION

Overview
----------------------------------------
[REF] Copy another email trait function back to the trait

Before
----------------------------------------
Hard to clean up inputs & outputs as it is on the BAO

After
----------------------------------------
Clear that the function belongs to the task

Technical Details
----------------------------------------
The only core use for this function is via the task & the signature is cludgey
This copies it back & deprecates the no-longer-in-use code

Comments
----------------------------------------
