### PR TITLE
Remove call to the dreaded replaceMultipleContributionTokens

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4858,6 +4858,8 @@ LIMIT 1;";
   }
 
   /**
+   * Do not use - unused in core.
+   *
    * Function to replace contribution tokens.
    *
    * @param array $contributionIds
@@ -4873,6 +4875,8 @@ LIMIT 1;";
    * @param array $messageToken
    *
    * @param bool $escapeSmarty
+   *
+   * @deprecated
    *
    * @return array
    * @throws \CiviCRM_API3_Exception

--- a/CRM/Contribute/Form/Task/PDFLetter.php
+++ b/CRM/Contribute/Form/Task/PDFLetter.php
@@ -546,19 +546,19 @@ class CRM_Contribute_Form_Task_PDFLetter extends CRM_Contribute_Form_Task {
    * @return string
    */
   protected function resolveTokens(string $html_message, $contact, $contribution, $messageToken, $grouped, $separator, $contributions): string {
-    if ($grouped) {
-      $tokenHtml = CRM_Utils_Token::replaceMultipleContributionTokens($separator, $html_message, $contributions, $messageToken);
-    }
-    else {
-      // no change to normal behaviour to avoid risk of breakage
-      $tokenHtml = CRM_Utils_Token::replaceContributionTokens($html_message, $contribution, TRUE, $messageToken);
-    }
     $tokenContext = [
       'smarty' => (defined('CIVICRM_MAIL_SMARTY') && CIVICRM_MAIL_SMARTY),
       'contactId' => $contact['contact_id'],
     ];
+    if ($grouped) {
+      $html_message = CRM_Utils_Token::replaceMultipleContributionTokens($separator, $html_message, $contributions, $messageToken);
+    }
+    else {
+      $tokenContext['schema'] = ['contributionId'];
+      $tokenContext['contributionId'] = $contribution['id'];
+    }
     $smarty = ['contact' => $contact];
-    return CRM_Core_TokenSmarty::render(['html' => $tokenHtml], $tokenContext, $smarty)['html'];
+    return CRM_Core_TokenSmarty::render(['html' => $html_message], $tokenContext, $smarty)['html'];
   }
 
 }

--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -1636,6 +1636,8 @@ class CRM_Utils_Token {
   }
 
   /**
+   * Do not use - unused in core.
+   *
    * Replace Contribution tokens in html.
    *
    * @param string $str
@@ -1643,6 +1645,8 @@ class CRM_Utils_Token {
    * @param bool|string $html
    * @param string $knownTokens
    * @param bool|string $escapeSmarty
+   *
+   * @deprecated
    *
    * @return mixed
    */
@@ -1685,9 +1689,12 @@ class CRM_Utils_Token {
    * @param array $contributions
    * @param array $knownTokens
    *
+   * @deprecated
+   *
    * @return string
    */
   public static function replaceMultipleContributionTokens(string $separator, string $str, array $contributions, array $knownTokens): string {
+    CRM_Core_Error::deprecatedFunctionWarning('no alternative');
     foreach ($knownTokens['contribution'] ?? [] as $token) {
       $resolvedTokens = [];
       foreach ($contributions as $contribution) {
@@ -1778,10 +1785,14 @@ class CRM_Utils_Token {
   }
 
   /**
+   * Do not use - unused in core.
+   *
    * @param $token
    * @param $contribution
    * @param bool $html
    * @param bool $escapeSmarty
+   *
+   * @deprecated
    *
    * @return mixed|string
    * @throws \CRM_Core_Exception

--- a/Civi/Token/TokenRow.php
+++ b/Civi/Token/TokenRow.php
@@ -186,7 +186,7 @@ class TokenRow {
       $fieldValue = \CRM_Core_BAO_CustomField::displayValue($fieldValue, $customFieldID);
     }
 
-    return $this->tokens($entity, $customFieldName, $fieldValue);
+    return $this->format('text/html')->tokens($entity, $customFieldName, $fieldValue);
   }
 
   /**

--- a/tests/phpunit/CRM/Contribute/Form/Task/PDFLetterCommonTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/Task/PDFLetterCommonTest.php
@@ -297,19 +297,19 @@ class CRM_Contribute_Form_Task_PDFLetterCommonTest extends CiviUnitTestCase {
   <body>
     <div id="crm-container">
 id : 1
-total_amount : € 9,999.99
-fee_amount : € 1,111.11
-net_amount : € 7,777.78
-non_deductible_amount : € 2,222.22
+total_amount : &euro; 9,999.99
+fee_amount : &euro; 1,111.11
+net_amount : &euro; 7,777.78
+non_deductible_amount : &euro; 2,222.22
 receive_date : July 20th, 2018 12:00 AM
 payment_instrument_id:label : Check
 trxn_id : 1234
 invoice_id : 568
 currency : EUR
-cancel_date : 2019-12-30 00:00:00
+cancel_date : December 30th, 2019 12:00 AM
 cancel_reason : Contribution Cancel Reason
 receipt_date : October 30th, 2019 12:00 AM
-thankyou_date : 2019-11-30 00:00:00
+thankyou_date : November 30th, 2019 12:00 AM
 source : Contribution Source
 amount_level : Amount Level
 contribution_status_id : 2

--- a/tests/phpunit/CRM/Contribute/Form/Task/PDFLetterCommonTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/Task/PDFLetterCommonTest.php
@@ -48,7 +48,6 @@ class CRM_Contribute_Form_Task_PDFLetterCommonTest extends CiviUnitTestCase {
    * @throws \CRM_Core_Exception
    */
   public function tearDown(): void {
-    CRM_Utils_Token::$_tokens['contribution'] = NULL;
     $this->quickCleanUpFinancialEntities();
     $this->quickCleanup(['civicrm_uf_match', 'civicrm_campaign'], TRUE);
     CRM_Utils_Hook::singleton()->reset();
@@ -78,6 +77,7 @@ class CRM_Contribute_Form_Task_PDFLetterCommonTest extends CiviUnitTestCase {
       'receive_date' => '2021-02-01 2:21',
       'currency' => 'USD',
     ])['id'];
+    /* @var CRM_Contribute_Form_Task_PDFLetter $form */
     $form = $this->getFormObject('CRM_Contribute_Form_Task_PDFLetter', [
       'campaign_id' => '',
       'subject' => '',
@@ -139,7 +139,7 @@ class CRM_Contribute_Form_Task_PDFLetterCommonTest extends CiviUnitTestCase {
       'total_amount' => 6,
       'campaign_id' => $this->campaignCreate(['title' => $campaignTitle], FALSE),
       'financial_type_id' => 'Donation',
-      $customFieldKey => 'Text_' . substr(sha1(rand()), 0, 7),
+      $customFieldKey => 'Text_',
     ];
     $contributionIDs = $returnProperties = [];
     $result = $this->callAPISuccess('Contribution', 'create', $params);
@@ -301,15 +301,15 @@ total_amount : &euro; 9,999.99
 fee_amount : &euro; 1,111.11
 net_amount : &euro; 7,777.78
 non_deductible_amount : &euro; 2,222.22
-receive_date : July 20th, 2018 12:00 AM
+receive_date : July 20th, 2018
 payment_instrument_id:label : Check
 trxn_id : 1234
 invoice_id : 568
 currency : EUR
-cancel_date : December 30th, 2019 12:00 AM
+cancel_date : December 30th, 2019
 cancel_reason : Contribution Cancel Reason
-receipt_date : October 30th, 2019 12:00 AM
-thankyou_date : November 30th, 2019 12:00 AM
+receipt_date : October 30th, 2019
+thankyou_date : November 30th, 2019
 source : Contribution Source
 amount_level : Amount Level
 contribution_status_id : 2


### PR DESCRIPTION
Overview
----------------------------------------
Remove call to the dreaded replaceMultipleContributionTokens

Before
----------------------------------------
The horror the horror

After
----------------------------------------
Awful - but not calling legacy functions

Technical Details
----------------------------------------
This builds on https://github.com/civicrm/civicrm-core/pull/21524 to remove the last core usage of `replaceContributionTokens`

Comments
----------------------------------------
@demeritcowboy I worked up the courage to tackle it https://docs.civicrm.org/user/en/latest/contributions/manual-receipts-and-thank-yous/#grouped-contribution-thank-you-letters

The test I worked with is `testGroupedThankYous` but there is another in that class