### PR TITLE
[REF] stop passing form into createActivities

### DIFF
--- a/CRM/Contact/Form/Task/PDFTrait.php
+++ b/CRM/Contact/Form/Task/PDFTrait.php
@@ -84,7 +84,7 @@ trait CRM_Contact_Form_Task_PDFTrait {
       ts('Paper Size'),
       [0 => ts('- default -')] + CRM_Core_BAO_PaperSize::getList(TRUE),
       FALSE,
-      ['onChange' => "selectPaper( this.value ); showUpdateFormatChkBox();"]
+      ['onChange' => 'selectPaper( this.value ); showUpdateFormatChkBox();']
     );
     $form->add(
       'select',
@@ -92,7 +92,7 @@ trait CRM_Contact_Form_Task_PDFTrait {
       ts('Orientation'),
       CRM_Core_BAO_PdfFormat::getPageOrientations(),
       FALSE,
-      ['onChange' => "updatePaperDimensions(); showUpdateFormatChkBox();"]
+      ['onChange' => 'updatePaperDimensions(); showUpdateFormatChkBox();']
     );
     $form->add(
       'select',
@@ -225,13 +225,13 @@ trait CRM_Contact_Form_Task_PDFTrait {
    */
   public function postProcess(): void {
     $form = $this;
-    $formValues = $form->controller->exportValues($form->getName());
-    [$formValues, $html_message, $messageToken, $returnProperties] = $this->processMessageTemplate($formValues);
+    $formValues = $this->controller->exportValues($this->getName());
+    [$formValues, $html_message] = $this->processMessageTemplate($formValues);
     $html = $activityIds = [];
 
     // CRM-16725 Skip creation of activities if user is previewing their PDF letter(s)
     if ($this->isLiveMode()) {
-      $activityIds = $this->createActivities($form, $html_message, $form->_contactIds, $formValues['subject'], CRM_Utils_Array::value('campaign_id', $formValues));
+      $activityIds = $this->createActivities($html_message, $form->_contactIds, $formValues['subject'], CRM_Utils_Array::value('campaign_id', $formValues));
     }
 
     if (!empty($formValues['document_file_path'])) {
@@ -257,7 +257,7 @@ trait CRM_Contact_Form_Task_PDFTrait {
     $tee = NULL;
     if ($this->isLiveMode() && Civi::settings()->get('recordGeneratedLetters') === 'combined-attached') {
       if (count($activityIds) !== 1) {
-        throw new CRM_Core_Exception("When recordGeneratedLetters=combined-attached, there should only be one activity.");
+        throw new CRM_Core_Exception('When recordGeneratedLetters=combined-attached, there should only be one activity.');
       }
       $tee = CRM_Utils_ConsoleTee::create()->start();
     }
@@ -326,7 +326,6 @@ trait CRM_Contact_Form_Task_PDFTrait {
   }
 
   /**
-   * @param CRM_Core_Form $form
    * @param string $html_message
    * @param array $contactIds
    * @param string $subject
@@ -340,8 +339,8 @@ trait CRM_Contact_Form_Task_PDFTrait {
    *
    * @throws CRM_Core_Exception
    */
-  public function createActivities($form, $html_message, $contactIds, $subject, $campaign_id, $perContactHtml = []) {
-
+  protected function createActivities($html_message, $contactIds, $subject, $campaign_id, $perContactHtml = []) {
+    $form = $this;
     $activityParams = [
       'subject' => $subject,
       'campaign_id' => $campaign_id,

--- a/CRM/Contribute/Form/Task/PDFLetter.php
+++ b/CRM/Contribute/Form/Task/PDFLetter.php
@@ -235,7 +235,7 @@ class CRM_Contribute_Form_Task_PDFLetter extends CRM_Contribute_Form_Task {
     $contactIds = array_keys($contacts);
     // CRM-16725 Skip creation of activities if user is previewing their PDF letter(s)
     if ($this->isLiveMode()) {
-      $this->createActivities($this, $html_message, $contactIds, CRM_Utils_Array::value('subject', $formValues, ts('Thank you letter')), CRM_Utils_Array::value('campaign_id', $formValues), $contactHtml);
+      $this->createActivities($html_message, $contactIds, CRM_Utils_Array::value('subject', $formValues, ts('Thank you letter')), CRM_Utils_Array::value('campaign_id', $formValues), $contactHtml);
     }
     $html = array_diff_key($html, $emailedHtml);
 

--- a/CRM/Member/Form/Task/PDFLetter.php
+++ b/CRM/Member/Form/Task/PDFLetter.php
@@ -97,7 +97,7 @@ class CRM_Member_Form_Task_PDFLetter extends CRM_Member_Form_Task {
       $messageToken,
       $html_message
     );
-    $form->createActivities($form, $html_message, $contactIDs, $formValues['subject'], CRM_Utils_Array::value('campaign_id', $formValues));
+    $form->createActivities($html_message, $contactIDs, $formValues['subject'], CRM_Utils_Array::value('campaign_id', $formValues));
     CRM_Utils_PDF_Utils::html2pdf($html, $this->getFileName() . '.pdf', FALSE, $formValues);
 
     $form->postProcessHook();


### PR DESCRIPTION

Overview
----------------------------------------
[REF] stop passing form into createActivities

Very minor cleanup

Before
----------------------------------------
Function has been spun off from the (now deprecated) static function, but `$form` is still being passed in

After
----------------------------------------
protected, no form parameter 

Technical Details
----------------------------------------
This function is now an OO function - so we can make it protected & stop passing form in

![image](https://user-images.githubusercontent.com/336308/135072514-789a2357-0e91-4dfb-b125-a5fd7d77bd02.png)


Comments
----------------------------------------
