### PR TITLE
Move case schema bit to case class

### DIFF
--- a/CRM/Activity/Page/AJAX.php
+++ b/CRM/Activity/Page/AJAX.php
@@ -217,7 +217,7 @@ class CRM_Activity_Page_AJAX {
       }
       // email column links/icon
       if ($row['email']) {
-        $row['email'] = '<a class="crm-hover-button crm-popup" href="' . CRM_Utils_System::url('civicrm/activity/email/add', 'reset=1&action=add&atype=3&cid=' . $row['cid']) . '&caseid=' . $caseID . '" title="' . ts('Send an Email') . '"><i class="crm-i fa-envelope" aria-hidden="true"></i></a>';
+        $row['email'] = '<a class="crm-hover-button crm-popup" href="' . CRM_Utils_System::url('civicrm/case/email/add', 'reset=1&action=add&atype=3&cid=' . $row['cid']) . '&caseid=' . $caseID . '" title="' . ts('Send an Email') . '"><i class="crm-i fa-envelope" aria-hidden="true"></i></a>';
       }
 
       // view end date if set

--- a/CRM/Case/Form/CaseView.php
+++ b/CRM/Case/Form/CaseView.php
@@ -251,7 +251,7 @@ class CRM_Case_Form_CaseView extends CRM_Core_Form {
     $activityLinks = ['' => ts('Add Activity')];
     foreach ($aTypes as $type => $label) {
       if ($type == $emailActivityType) {
-        $url = CRM_Utils_System::url('civicrm/activity/email/add',
+        $url = CRM_Utils_System::url('civicrm/case/email/add',
           "action=add&context=standalone&reset=1&caseid={$this->_caseID}&atype=$type",
           FALSE, NULL, FALSE
         );

--- a/CRM/Case/Form/Task.php
+++ b/CRM/Case/Form/Task.php
@@ -20,6 +20,28 @@
 class CRM_Case_Form_Task extends CRM_Core_Form_Task {
 
   /**
+   * Case ID.
+   *
+   * Even though there may be more than one case ID only one can be used
+   * in tokens - this is it!
+   *
+   * Case id comes in from caseid in the url.
+   *
+   * @var int caseID.
+   */
+  protected $caseID;
+
+  /**
+   * Case IDs.
+   *
+   * In some cases an activity might be filed on multiple cases.
+   *
+   * Case ids come in from caseid in the url (it can be comma separated)
+   * @var []int caseID.
+   */
+  protected $caseIDs;
+
+  /**
    * Must be set to entity table name (eg. civicrm_participant) by child class
    * @var string
    */
@@ -84,6 +106,90 @@ class CRM_Case_Form_Task extends CRM_Core_Form_Task {
    */
   public function getEntityAliasField() {
     return 'case_id';
+  }
+
+  /**
+   * Get the (first) case id. This is
+   *
+   * @return int
+   */
+  protected function getCaseID(): ?int {
+    if (!isset($this->caseID)) {
+      $this->caseID = $this->getCaseIDS()[0];
+    }
+    return $this->caseID;
+  }
+
+  /**
+   * Get case IDs.
+   *
+   * These are used for filing on a case.
+   *
+   * @return array
+   *
+   * @throws \CRM_Core_Exception
+   */
+  protected function getCaseIDS(): array {
+    if (!isset($this->caseIDS)) {
+      $this->caseIDS = explode(',', CRM_Utils_Request::retrieve('caseid', 'CommaSeparatedIntegers', $this));
+    }
+    return $this->caseIDs;
+  }
+
+  /**
+   * Get the schema for which tokens should be listed.
+   */
+  protected function getTokenSchema(): array {
+    return ['caseId'];
+  }
+
+  /**
+   * Get the subject for the message.
+   *
+   * The case handling should possibly be on the case form.....
+   *
+   * @param string $subject
+   *
+   * @return string
+   * @throws \CRM_Core_Exception
+   */
+  protected function getSubject(string $subject):string {
+    // CRM-5916: prepend case id hash to CiviCase-originating emails’ subjects
+    if ($this->getCaseID()) {
+      $hash = substr(sha1(CIVICRM_SITE_KEY . $this->getCaseID()), 0, 7);
+      $subject = "[case #$hash] $subject";
+    }
+    return $subject;
+  }
+
+  /**
+   * Get the schema for token rendering.
+   *
+   * Contact is included by default.
+   *
+   * e.g return ['contributionId' => 3]
+   *
+   * @param int $contactID
+   *
+   * @return array
+   */
+  protected function getTokenContext(int $contactID): array {
+    $caseId = $this->getCaseID($contactID);
+    return $caseId ? ['caseId' => $caseId] : [];
+  }
+
+  /**
+   * Get the url to redirect the user to.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  protected function getRedirectURL(): string {
+    $firstContactID = CRM_Core_DAO::getFieldValue('CRM_Case_DAO_CaseContact', $this->getCaseID(),
+      'contact_id', 'case_id'
+    );
+    return CRM_Utils_System::url('civicrm/contact/view/case',
+      "&reset=1&action=view&cid={$firstContactID}&id=" . $this->getCaseID()
+    );
   }
 
 }

--- a/CRM/Case/Form/Task/Email.php
+++ b/CRM/Case/Form/Task/Email.php
@@ -1,0 +1,24 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+/**
+ * This class provides the functionality to email a group of contacts.
+ */
+class CRM_Case_Form_Task_Email extends CRM_Case_Form_Task {
+  use CRM_Contact_Form_Task_EmailTrait;
+
+}

--- a/CRM/Case/xml/Menu/Case.xml
+++ b/CRM/Case/xml/Menu/Case.xml
@@ -135,4 +135,10 @@
     <path>civicrm/ajax/get-cases</path>
     <page_callback>CRM_Case_Page_AJAX::getCases</page_callback>
   </item>
+  <item>
+    <path>civicrm/case/email/add</path>
+    <path_arguments>action=add</path_arguments>
+    <title>Email</title>
+    <page_callback>CRM_Case_Form_Task_Email</page_callback>
+  </item>
 </menu>

--- a/CRM/Contact/Form/Task/Email.php
+++ b/CRM/Contact/Form/Task/Email.php
@@ -32,7 +32,6 @@ class CRM_Contact_Form_Task_Email extends CRM_Contact_Form_Task {
     // @todo - more of the handling in this function should be move to the trait. Notably the title part is
     //  not set on other forms that share the trait.
     // store case id if present
-    $this->_caseId = CRM_Utils_Request::retrieve('caseid', 'String', $this, FALSE);
     $this->_context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this);
 
     $cid = CRM_Utils_Request::retrieve('cid', 'String', $this, FALSE);
@@ -81,23 +80,5 @@ class CRM_Contact_Form_Task_Email extends CRM_Contact_Form_Task {
    * @todo move some code from preProcess into here.
    */
   public function setContactIDs() {}
-
-  /**
-   * List available tokens for this form.
-   *
-   * @return array
-   * @throws \CRM_Core_Exception
-   */
-  public function listTokens() {
-    $tokens = CRM_Core_SelectValues::contactTokens();
-
-    if (isset($this->_caseId) || isset($this->_caseIds)) {
-      // For a single case, list tokens relevant for only that case type
-      $caseTypeId = isset($this->_caseId) ? CRM_Core_DAO::getFieldValue('CRM_Case_DAO_Case', $this->_caseId, 'case_type_id') : NULL;
-      $tokens += CRM_Core_SelectValues::caseTokens($caseTypeId);
-    }
-
-    return $tokens;
-  }
 
 }

--- a/CRM/Contact/Form/Task/PDFTrait.php
+++ b/CRM/Contact/Form/Task/PDFTrait.php
@@ -239,15 +239,10 @@ trait CRM_Contact_Form_Task_PDFTrait {
     }
 
     foreach ($form->_contactIds as $item => $contactId) {
-      $caseId = $form->getVar('_caseId');
-      if (empty($caseId) && !empty($form->_caseIds[$item])) {
-        $caseId = $form->_caseIds[$item];
-      }
-
       $tokenHtml = CRM_Core_BAO_MessageTemplate::renderTemplate([
         'contactId' => $contactId,
         'messageTemplate' => ['msg_html' => $html_message],
-        'tokenContext' => $caseId ? ['caseId' => $caseId] : [],
+        'tokenContext' => $this->getTokenContext($contactId),
         'disableSmarty' => (!defined('CIVICRM_MAIL_SMARTY') || !CIVICRM_MAIL_SMARTY),
       ])['html'];
 

--- a/CRM/Core/Form/Task.php
+++ b/CRM/Core/Form/Task.php
@@ -338,4 +338,19 @@ SELECT contact_id
     return $this::$entityShortname . '_id';
   }
 
+  /**
+   * Get the schema for token rendering.
+   *
+   * Contact is included by default.
+   *
+   * e.g return ['contributionId' => 3]
+   *
+   * @param int $contactID
+   *
+   * @return array
+   */
+  protected function getTokenContext(int $contactID): array {
+    return [];
+  }
+
 }

--- a/templates/CRM/Case/Form/CaseView.tpl
+++ b/templates/CRM/Case/Form/CaseView.tpl
@@ -45,7 +45,7 @@
             {foreach from=$caseRoles.client item=client}
               <tr class="crm-case-caseview-display_name">
                 <td class="label-left bold" style="padding: 0px; border: none;">
-                  <a href="{crmURL p='civicrm/contact/view' q="action=view&reset=1&cid=`$client.contact_id`"}" title="{ts}View contact record{/ts}">{$client.display_name}</a>{if $client.email}{crmAPI var='email_type_id' entity='OptionValue' action='getsingle' return="value" name="Email" option_group_id="activity_type"}<span class="crm-case-caseview-email"><a class="crm-hover-button crm-popup" href="{crmURL p='civicrm/activity/email/add' q="reset=1&action=add&atype=`$email_type_id.value`&cid=`$client.contact_id`&caseid=`$caseId`"}" title="{ts 1=$client.email|escape}Email: %1{/ts}"><i class="crm-i fa-envelope" aria-hidden="true"></i></a></span>{/if}
+                  <a href="{crmURL p='civicrm/contact/view' q="action=view&reset=1&cid=`$client.contact_id`"}" title="{ts}View contact record{/ts}">{$client.display_name}</a>{if $client.email}{crmAPI var='email_type_id' entity='OptionValue' action='getsingle' return="value" name="Email" option_group_id="activity_type"}<span class="crm-case-caseview-email"><a class="crm-hover-button crm-popup" href="{crmURL p='civicrm/case/email/add' q="reset=1&action=add&atype=`$email_type_id.value`&cid=`$client.contact_id`&caseid=`$caseId`"}" title="{ts 1=$client.email|escape}Email: %1{/ts}"><i class="crm-i fa-envelope" aria-hidden="true"></i></a></span>{/if}
                 </td>
               </tr>
               {if $client.phone}

--- a/tests/phpunit/CRM/Contact/Form/Task/PDFLetterCommonTest.php
+++ b/tests/phpunit/CRM/Contact/Form/Task/PDFLetterCommonTest.php
@@ -126,13 +126,13 @@ class CRM_Contact_Form_Task_PDFLetterCommonTest extends CiviUnitTestCase {
    * @param array $contactIDs
    * @param bool|null $isLiveMode
    *
-   * @return \CRM_Contact_Form_Task_PDF
+   * @return \CRM_Case_Form_Task_PDF
    */
-  protected function getPDFForm(array $formValues, array $contactIDs, ?bool $isLiveMode = TRUE): CRM_Contact_Form_Task_PDF {
+  protected function getPDFForm(array $formValues, array $contactIDs, ?bool $isLiveMode = TRUE): CRM_Case_Form_Task_PDF {
     // pretty cludgey.
     $_REQUEST['cid'] = $contactIDs[0];
     /* @var CRM_Contact_Form_Task_PDF $form */
-    $form = $this->getFormObject('CRM_Contact_Form_Task_PDF', array_merge([
+    $form = $this->getFormObject('CRM_Case_Form_Task_PDF', array_merge([
       'pdf_file_name' => 'pdf_file_name',
       'subject' => 'subject',
       'document_type' => 'pdf',


### PR DESCRIPTION
Overview
----------------------------------------
Move case schema bit to case class

@demeritcowboy I've put this up  but mostly for input at this stage - 
there are a couple things I can't figure out.... 

1) - basically how `$item` works in `!empty($form->_caseIds[$item])) {` / how it relates to contact IDs and
2) how does the email task get accessed for cases - I recall I tried to do something simlar there before but there isn't actually an 'email' action from a case search (not knowing how to r-run is  an issue :-)

The goal is to push `getTokenContext(int $contactID):`function up to where it can be accessed by both email & pdf tasks & can be entity-specific


Before
----------------------------------------

After
----------------------------------------

Technical Details
----------------------------------------

Comments
----------------------------------------
