### PR TITLE
MessageTemplate - Deprecate `valueName`. Emphasize `workflow`. Consolidate converters. 

### DIFF
--- a/CRM/Core/BAO/MessageTemplate.php
+++ b/CRM/Core/BAO/MessageTemplate.php
@@ -324,22 +324,35 @@ class CRM_Core_BAO_MessageTemplate extends CRM_Core_DAO_MessageTemplate {
       'PDFFilename' => NULL,
     ];
 
+    // Some params have been deprecated/renamed. Synchronize old<=>new params. We periodically resync after exchanging data with other parties.
+    $sync = function () use (&$params, $modelDefaults, $viewDefaults) {
+      CRM_Utils_Array::pathSync($params, ['workflow'], ['valueName']);
+      CRM_Utils_Array::pathSync($params, ['tokenContext', 'contactId'], ['contactId']);
+      CRM_Utils_Array::pathSync($params, ['tokenContext', 'smarty'], ['disableSmarty'], function ($v, bool $isCanon) {
+        return !$v;
+      });
+
+      // Core#644 - handle Email ID passed as "From".
+      if (isset($params['from'])) {
+        $params['from'] = \CRM_Utils_Mail::formatFromAddress($params['from']);
+      }
+    };
+    $sync();
+
     // Allow WorkflowMessage to run any filters/mappings/cleanups.
-    $model = $params['model'] ?? WorkflowMessage::create($params['valueName'] ?? 'UNKNOWN');
+    $model = $params['model'] ?? WorkflowMessage::create($params['workflow'] ?? 'UNKNOWN');
     $params = WorkflowMessage::exportAll(WorkflowMessage::importAll($model, $params));
     unset($params['model']);
     // Subsequent hooks use $params. Retaining the $params['model'] might be nice - but don't do it unless you figure out how to ensure data-consistency (eg $params['tplParams'] <=> $params['model']).
     // If you want to expose the model via hook, consider interjecting a new Hook::alterWorkflowMessage($model) between `importAll()` and `exportAll()`.
 
+    $sync();
     $params = array_merge($modelDefaults, $viewDefaults, $envelopeDefaults, $params);
 
     CRM_Utils_Hook::alterMailParams($params, 'messageTemplate');
     $mailContent = self::loadTemplate((string) $params['valueName'], $params['isTest'], $params['messageTemplateID'] ?? NULL, $params['groupName'] ?? '', $params['messageTemplate'], $params['subject'] ?? NULL);
 
-    $params['tokenContext'] = array_merge([
-      'smarty' => (bool) !$params['disableSmarty'],
-      'contactId' => $params['contactId'],
-    ], $params['tokenContext']);
+    $sync();
     $rendered = CRM_Core_TokenSmarty::render(CRM_Utils_Array::subset($mailContent, ['text', 'html', 'subject']), $params['tokenContext'], $params['tplParams']);
     if (isset($rendered['subject'])) {
       $rendered['subject'] = trim(preg_replace('/[\r\n]+/', ' ', $rendered['subject']));

--- a/CRM/Utils/Array.php
+++ b/CRM/Utils/Array.php
@@ -1168,6 +1168,38 @@ class CRM_Utils_Array {
   }
 
   /**
+   * Attempt to synchronize or fill aliased items.
+   *
+   * If $canonPath is set, copy to $altPath; or...
+   * If $altPath is set, copy to $canonPath.
+   *
+   * @param array $params
+   *   Data-tree
+   * @param string[] $canonPath
+   *   Preferred path
+   * @param string[] $altPath
+   *   Old/alternate/deprecated path.
+   * @param callable|null $filter
+   *   Optional function to filter the value as it passes through (canonPath=>altPath or altPath=>canonPath).
+   *   function(mixed $v, bool $isCanon): mixed
+   */
+  public static function pathSync(&$params, $canonPath, $altPath, ?callable $filter = NULL) {
+    $MISSING = new \stdClass();
+
+    $v = static::pathGet($params, $canonPath, $MISSING);
+    if ($v !== $MISSING) {
+      static::pathSet($params, $altPath, $filter ? $filter($v, TRUE) : $v);
+      return;
+    }
+
+    $v = static::pathGet($params, $altPath, $MISSING);
+    if ($v !== $MISSING) {
+      static::pathSet($params, $canonPath, $filter ? $filter($v, FALSE) : $v);
+      return;
+    }
+  }
+
+  /**
    * Convert a simple dictionary into separate key+value records.
    *
    * @param array $array

--- a/Civi/WorkflowMessage/Traits/ReflectiveWorkflowTrait.php
+++ b/Civi/WorkflowMessage/Traits/ReflectiveWorkflowTrait.php
@@ -250,7 +250,7 @@ trait ReflectiveWorkflowTrait {
    */
   protected function exportExtraEnvelope(array &$export): void {
     if ($wfName = \CRM_Utils_Constant::value(static::CLASS . '::WORKFLOW')) {
-      $export['valueName'] = $wfName;
+      $export['workflow'] = $wfName;
     }
     if ($wfGroup = \CRM_Utils_Constant::value(static::CLASS . '::GROUP')) {
       $export['groupName'] = $wfGroup;
@@ -292,8 +292,8 @@ trait ReflectiveWorkflowTrait {
    */
   protected function importExtraEnvelope(array &$values): void {
     if ($wfName = \CRM_Utils_Constant::value(static::CLASS . '::WORKFLOW')) {
-      if (isset($values['valueName']) && $wfName === $values['valueName']) {
-        unset($values['valueName']);
+      if (isset($values['workflow']) && $wfName === $values['workflow']) {
+        unset($values['workflow']);
       }
     }
     if ($wfGroup = \CRM_Utils_Constant::value(static::CLASS . '::GROUP')) {

--- a/Civi/WorkflowMessage/WorkflowMessage.php
+++ b/Civi/WorkflowMessage/WorkflowMessage.php
@@ -66,7 +66,7 @@ class WorkflowMessage {
   public static function create(string $wfName, array $imports = []) {
     $classMap = static::getWorkflowNameClassMap();
     $class = $classMap[$wfName] ?? 'Civi\WorkflowMessage\GenericWorkflowMessage';
-    $imports['envelope']['valueName'] = $wfName;
+    $imports['envelope']['workflow'] = $wfName;
     $model = new $class();
     static::importAll($model, $imports);
     return $model;
@@ -95,7 +95,6 @@ class WorkflowMessage {
       }
       unset($params['model']);
     }
-
 
     if (isset($params['tplParams'])) {
       $model->import('tplParams', $params['tplParams']);

--- a/Civi/WorkflowMessage/WorkflowMessage.php
+++ b/Civi/WorkflowMessage/WorkflowMessage.php
@@ -96,12 +96,6 @@ class WorkflowMessage {
       unset($params['model']);
     }
 
-    \CRM_Utils_Array::pathMove($params, ['contactId'], ['tokenContext', 'contactId']);
-
-    // Core#644 - handle Email ID passed as "From".
-    if (isset($params['from'])) {
-      $params['from'] = \CRM_Utils_Mail::formatFromAddress($params['from']);
-    }
 
     if (isset($params['tplParams'])) {
       $model->import('tplParams', $params['tplParams']);

--- a/tests/events/hook_civicrm_alterMailParams.evch.php
+++ b/tests/events/hook_civicrm_alterMailParams.evch.php
@@ -115,8 +115,10 @@ return new class() extends \Civi\Test\EventCheck implements \Civi\Test\HookInter
     $this->assertEquals([], $unknownKeys, "$msg: Unrecognized keys: " . implode(', ', $unknownKeys) . "\n$dump");
 
     foreach ($params as $key => $value) {
-      $this->assertType($paramSpecs[$key]['type'], $value, "$msg: Bad data-type found in param ($key)\n$dump");
-      if (isset($paramSpecs[$key]['regex'])) {
+      if (isset($paramSpecs[$key]['type'])) {
+        $this->assertType($paramSpecs[$key]['type'], $value, "$msg: Bad data-type found in param ($key)\n$dump");
+      }
+      if (isset($paramSpecs[$key]['regex']) && $value !== NULL) {
         $this->assertRegExp($paramSpecs[$key]['regex'], $value, "Parameter [$key => $value] should match regex ({$paramSpecs[$key]['regex']})");
       }
     }

--- a/tests/events/hook_civicrm_alterMailParams.evch.php
+++ b/tests/events/hook_civicrm_alterMailParams.evch.php
@@ -46,6 +46,11 @@ return new class() extends \Civi\Test\EventCheck implements \Civi\Test\HookInter
     'tokenContext' => ['type' => 'array', 'for' => 'messageTemplate'],
     'tplParams' => ['type' => 'array', 'for' => 'messageTemplate'],
     'contactId' => ['type' => 'int|NULL', 'for' => 'messageTemplate' /* deprecated in favor of tokenContext[contactId] */],
+    'workflow' => [
+      'regex' => '/^([a-zA-Z_]+)$/',
+      'type' => 'string',
+      'for' => 'messageTemplate',
+    ],
     'valueName' => [
       'regex' => '/^([a-zA-Z_]+)$/',
       'type' => 'string',
@@ -124,7 +129,11 @@ return new class() extends \Civi\Test\EventCheck implements \Civi\Test\HookInter
     }
 
     if ($context === 'messageTemplate') {
-      $this->assertTrue(!empty($params['valueName']), "$msg: Message templates must always specify the name of the workflow step\n$dump");
+      $this->assertTrue(!empty($params['workflow']), "$msg: Message templates must always specify a symbolic name of the step/task\n$dump");
+      if (isset($params['valueName'])) {
+        // This doesn't require that valueName be supplied - but if it is supplied, it must match the workflow name.
+        $this->assertEquals($params['workflow'], $params['valueName'], "$msg: If given, workflow and valueName must match\n$dump");
+      }
       $this->assertEquals($params['contactId'] ?? NULL, $params['tokenContext']['contactId'] ?? NULL, "$msg: contactId moved to tokenContext, but legacy value should be equivalent\n$dump");
 
       // This assertion is surprising -- yet true. We should perhaps check if it was true in past releases...

--- a/tests/phpunit/Civi/WorkflowMessage/ExampleWorkflowMessageTest.php
+++ b/tests/phpunit/Civi/WorkflowMessage/ExampleWorkflowMessageTest.php
@@ -33,7 +33,11 @@ class ExampleWorkflowMessageTest extends \CiviUnitTestCase {
 
       const WORKFLOW = 'my_example_wf';
 
-      const GROUP = 'my_example_grp';
+      /**
+       * Use this to provide interop with old-style `groupName`.
+       * @deprecated
+       */
+      const GROUP = 'msg_old_style_grp';
 
       /**
        * @var string
@@ -189,8 +193,8 @@ class ExampleWorkflowMessageTest extends \CiviUnitTestCase {
     $this->assertEquals(100, $tpl['some_extra_tpl_stuff']);
 
     $envelope = $ex->export('envelope');
-    $this->assertEquals('my_example_wf', $envelope['valueName']);
-    $this->assertEquals('my_example_grp', $envelope['groupName']);
+    $this->assertEquals('my_example_wf', $envelope['workflow']);
+    $this->assertEquals('msg_old_style_grp', $envelope['groupName']);
   }
 
   /**
@@ -247,10 +251,10 @@ class ExampleWorkflowMessageTest extends \CiviUnitTestCase {
     $tpl = $ex->export('tplParams');
     $this->assertEquals(456, $tpl['myImpromputInt']);
     $this->assertEquals(['is not mentioned anywhere'], $tpl['impromptu_smarty_data']);
-    $this->assertTrue(!isset($tpl['valueName']));
+    $this->assertTrue(!isset($tpl['workflow']));
 
     $envelope = $ex->export('envelope');
-    $this->assertEquals('some_impromptu_wf', $envelope['valueName']);
+    $this->assertEquals('some_impromptu_wf', $envelope['workflow']);
     $this->assertEquals('foo@example.com', $envelope['from']);
     $this->assertTrue(!isset($envelope['myProtectedInt']));
 
@@ -267,7 +271,7 @@ class ExampleWorkflowMessageTest extends \CiviUnitTestCase {
     $ex = $this->createExample()->setContactId($cid);
     \Civi::dispatcher()->addListener('hook_civicrm_alterMailParams', function($e) use (&$hookCount) {
       $hookCount++;
-      $this->assertEquals('my_example_wf', $e->params['valueName'], 'ExampleWorkflow::WORKFLOW should propagate to params[valueName]');
+      $this->assertEquals('my_example_wf', $e->params['workflow'], 'ExampleWorkflow::WORKFLOW should propagate to params[workflow]');
     });
     $this->assertEquals(0, $hookCount);
     $rendered = $ex->renderTemplate([
@@ -289,7 +293,7 @@ class ExampleWorkflowMessageTest extends \CiviUnitTestCase {
     ]);
     \Civi::dispatcher()->addListener('hook_civicrm_alterMailParams', function($e) use (&$hookCount) {
       $hookCount++;
-      $this->assertEquals('some_impromptu_wf', $e->params['valueName'], 'Adhoc name should propagate to params[workflow]');
+      $this->assertEquals('some_impromptu_wf', $e->params['workflow'], 'Adhoc name should propagate to params[workflow]');
     });
     $this->assertEquals(0, $hookCount);
     $rendered = $ex->renderTemplate([
@@ -318,7 +322,7 @@ class ExampleWorkflowMessageTest extends \CiviUnitTestCase {
 
     \Civi::dispatcher()->addListener('hook_civicrm_alterMailParams', function($e) use (&$hookCount) {
       $hookCount++;
-      $this->assertEquals('petition_sign', $e->params['valueName']);
+      $this->assertEquals('petition_sign', $e->params['workflow']);
     });
     $this->assertEquals(0, $hookCount);
     $rendered = $ex->renderTemplate();

--- a/tests/phpunit/Civi/WorkflowMessage/ExampleWorkflowMessageTest.php
+++ b/tests/phpunit/Civi/WorkflowMessage/ExampleWorkflowMessageTest.php
@@ -259,22 +259,50 @@ class ExampleWorkflowMessageTest extends \CiviUnitTestCase {
     $this->assertTrue(!isset($envelope['myProtectedInt']));
   }
 
+  public function testExampleRender() {
+    $hookCount = 0;
+    $rand = rand(0, 1000);
+    $cid = $this->individualCreate(['first_name' => 'Foo', 'last_name' => 'Bar' . $rand, 'prefix_id' => NULL, 'suffix_id' => NULL]);
+    /** @var \Civi\WorkflowMessage\GenericWorkflowMessage $ex */
+    $ex = $this->createExample()->setContactId($cid);
+    \Civi::dispatcher()->addListener('hook_civicrm_alterMailParams', function($e) use (&$hookCount) {
+      $hookCount++;
+      $this->assertEquals('my_example_wf', $e->params['valueName'], 'ExampleWorkflow::WORKFLOW should propagate to params[valueName]');
+    });
+    $this->assertEquals(0, $hookCount);
+    $rendered = $ex->renderTemplate([
+      'messageTemplate' => [
+        'msg_subject' => 'Hello {contact.display_name}',
+      ],
+    ]);
+    $this->assertEquals(1, $hookCount);
+    $this->assertEquals('Hello Foo Bar' . $rand, $rendered['subject']);
+  }
+
   public function testImpromptuRender() {
+    $hookCount = 0;
     $rand = rand(0, 1000);
     $cid = $this->individualCreate(['first_name' => 'Foo', 'last_name' => 'Bar' . $rand, 'prefix_id' => NULL, 'suffix_id' => NULL]);
     /** @var \Civi\WorkflowMessage\GenericWorkflowMessage $ex */
     $ex = WorkflowMessage::create('some_impromptu_wf', [
       'tokenContext' => ['contactId' => $cid],
     ]);
+    \Civi::dispatcher()->addListener('hook_civicrm_alterMailParams', function($e) use (&$hookCount) {
+      $hookCount++;
+      $this->assertEquals('some_impromptu_wf', $e->params['valueName'], 'Adhoc name should propagate to params[workflow]');
+    });
+    $this->assertEquals(0, $hookCount);
     $rendered = $ex->renderTemplate([
       'messageTemplate' => [
         'msg_subject' => 'Hello {contact.display_name}',
       ],
     ]);
+    $this->assertEquals(1, $hookCount);
     $this->assertEquals('Hello Foo Bar' . $rand, $rendered['subject']);
   }
 
   public function testRenderStoredTemplate() {
+    $hookCount = 0;
     $rand = rand(0, 1000);
     $cid = $this->individualCreate(['first_name' => 'Foo', 'last_name' => 'Bar' . $rand, 'prefix_id' => NULL, 'suffix_id' => NULL]);
     /** @var \Civi\WorkflowMessage\GenericWorkflowMessage $ex */
@@ -287,7 +315,14 @@ class ExampleWorkflowMessageTest extends \CiviUnitTestCase {
         'survey_id' => NULL,
       ],
     ]);
+
+    \Civi::dispatcher()->addListener('hook_civicrm_alterMailParams', function($e) use (&$hookCount) {
+      $hookCount++;
+      $this->assertEquals('petition_sign', $e->params['valueName']);
+    });
+    $this->assertEquals(0, $hookCount);
     $rendered = $ex->renderTemplate();
+    $this->assertEquals(1, $hookCount);
     $this->assertStringContainsString('Foo Bar' . $rand, $rendered['subject']);
     $this->assertStringContainsString('Thank you for signing The Fake Petition', $rendered['html']);
     $this->assertStringContainsString('Thank you for signing The Fake Petition', $rendered['text']);


### PR DESCRIPTION
Overview
----------------------------------------

`CRM_Core_BAO_MessageTemplate::sendTemplate()` and `::renderTemplate()` accept an argument called `valueName`. The the option has grown misleading -- if message templates will no longer be identified by `OptionValue` per se. Of course, the content is still important as it identifies the workflow step (a la `civicrm_msg_template.workflow_name` `WorkflowMessage::WORKFLOW`).

The primary change of this branch is to deprecate `valueName` in favor of `workflow`. Additionally, it does some cleanup for other fields that went through a similar change.

Before
----------------------------------------

* The fields `contactId` and `disableSmarty` are translated to `tokenContext.contactId` and `tokenContext.smarty`. However, these translations are sprinkled around.
* `sendTemplate()` and `renderTemplate()` use `valueName`
* `WorkflowMessage` and `hook_alterMailParams` use the same params as ^^ -- so they use `valueName`

After
----------------------------------------

* The translations for `valueName`, `contactId`, and `disableSmarty` all work the same way - and they've each been boiled down to 1-line call (`CRM_Utils_Array::pathSync()`) 
* `sendTemplate()` and `renderTemplate()` use `workflow` (with alias support for `valueName`)
* `WorkflowMessage` and `hook_alterMailParams` use the same params  as ^^ -- so they use `workflow` (with alias support for `valueName`)

Comments
----------------------------------------

It's tempting to add an extra warning at the start of `renderTemplateRaw()`, although this would make the patch a longer (ie we'll get test-failures for old callers - and need to update each).

```php
if ($badGuys = array_intersect(array_keys($params), ['valueName', 'disableSmarty', 'contactId'])) {
  \CRM_Core_Error::deprecatedWarning("renderTemplate() received deprecated option(s): " . implode(', ', $badGuys));
}
```
