### PR TITLE
[REF] Move getCustomFieldTokens to the tokens class, annotate more deprecations

### DIFF
--- a/CRM/Core/TokenTrait.php
+++ b/CRM/Core/TokenTrait.php
@@ -84,7 +84,10 @@ trait CRM_Core_TokenTrait {
    */
   protected function getCustomFieldTokens(): array {
     if (!isset($this->customFieldTokens)) {
-      $this->customFieldTokens = \CRM_Utils_Token::getCustomFieldTokens(ucfirst($this->getEntityName()));
+      $this->customFieldTokens = [];
+      foreach (CRM_Core_BAO_CustomField::getFields(ucfirst($this->getEntityName())) as $id => $info) {
+        $this->customFieldTokens['custom_' . $id] = $info['label'] . ' :: ' . $info['groupTitle'];
+      }
     }
     return $this->customFieldTokens;
   }

--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -1561,6 +1561,10 @@ class CRM_Utils_Token {
   }
 
   /**
+   * Do not use.
+   *
+   * @deprecated
+   *
    * Replace tokens for an entity.
    * @param string $entity
    * @param array $entityArray
@@ -1872,6 +1876,8 @@ class CRM_Utils_Token {
 
   /**
    * Get all custom field tokens of $entity
+   *
+   * @deprecated
    *
    * @param string $entity
    * @return array


### PR DESCRIPTION

Overview
----------------------------------------
Move getCustomFieldTokens to the tokens class, annotate more deprecations

This deprecates (quietly) another function on CRM_Utils_Token. It's a pretty small function -
the sort you'd just copy & paste if you wanted to use outside of core but
I didn't add noise. 

Before
----------------------------------------
`CRM_Utils_Token` being called for a 3 line function, only used in token classes, to get custom tokens

After
----------------------------------------
Duplicated onto the class, deprecated (still called from the `TokenTrait` but from a function that is itself a candidate for removal - once we've checked universe. The only class that uses the trait has good test cover)

Technical Details
----------------------------------------
The only core place that still calls this is the tokenTrait
- which is 'used' by activity tokens - and I haven't started to think about
whether that class actually needs the `_N_` handling that it uses the tokenTrait
to possibly support (my recollection is that functionality is not enabled)

Anyway - I'm leaving that question for later because I'm not sure if the token
trait is used outside of core or how our final interface will look

Comments
----------------------------------------
