### PR TITLE
 dev/core#348 Participant tokens on scheduled reminders

### DIFF
--- a/CRM/Admin/Form/ScheduleReminders.php
+++ b/CRM/Admin/Form/ScheduleReminders.php
@@ -698,7 +698,7 @@ class CRM_Admin_Form_ScheduleReminders extends CRM_Admin_Form {
     $tokenProcessor = new \Civi\Token\TokenProcessor(\Civi::dispatcher(), [
       'controller' => get_class(),
       'smarty' => FALSE,
-      'schema' => ['activityId'],
+      'schema' => ['activityId', 'participantId'],
     ]);
     $tokens = $tokenProcessor->listTokens();
 

--- a/CRM/Contact/Form/Task/EmailTrait.php
+++ b/CRM/Contact/Form/Task/EmailTrait.php
@@ -511,7 +511,7 @@ trait CRM_Contact_Form_Task_EmailTrait {
    *
    * @return array
    */
-  public function listTokens() {
+  public function listTokens(): array {
     return CRM_Core_SelectValues::contactTokens();
   }
 

--- a/CRM/Core/SelectValues.php
+++ b/CRM/Core/SelectValues.php
@@ -590,28 +590,19 @@ class CRM_Core_SelectValues {
   /**
    * Different type of Participant Tokens.
    *
+   * @deprecated
+   *
    * @return array
    */
   public static function participantTokens(): array {
-    $tokens = [
-      '{participant.status_id}' => 'Status ID',
-      '{participant.role_id}' => 'Participant Role (ID)',
-      '{participant.register_date}' => 'Register date',
-      '{participant.source}' => 'Participant Source',
-      '{participant.fee_level}' => 'Fee level',
-      '{participant.fee_amount}' => 'Fee Amount',
-      '{participant.registered_by_id}' => 'Registered By Participant ID',
-      '{participant.transferred_to_contact_id}' => 'Transferred to Contact ID',
-      '{participant.role_id:label}' => 'Participant Role (label)',
-      '{participant.fee_label}' => 'Fee Label',
-    ];
-    $customFields = CRM_Core_BAO_CustomField::getFields('Participant');
-
-    foreach ($customFields as $customField) {
-      $tokens['{participant.custom_' . $customField['id'] . '}'] = $customField['label'] . " :: " . $customField['groupTitle'];
+    $tokenProcessor = new TokenProcessor(Civi::dispatcher(), ['schema' => ['participantId']]);
+    $allTokens = $tokenProcessor->listTokens();
+    foreach (array_keys($allTokens) as $token) {
+      if (strpos($token, '{domain.') === 0) {
+        unset($allTokens[$token]);
+      }
     }
-
-    return $tokens;
+    return $allTokens;
   }
 
   /**

--- a/CRM/Event/ParticipantTokens.php
+++ b/CRM/Event/ParticipantTokens.php
@@ -10,12 +10,21 @@
  +--------------------------------------------------------------------+
  */
 
+use Civi\Token\TokenRow;
+
 /**
  * Class CRM_Event_ParticipantTokens
  *
  * Generate "participant.*" tokens.
  */
 class CRM_Event_ParticipantTokens extends CRM_Core_EntityTokens {
+
+  public static function getSubscribedEvents() {
+    $events = parent::getSubscribedEvents();
+    // Set the weight so it runs before event tokens.
+    $events['civi.token.eval'] = ['evaluateTokens', 400];
+    return $events;
+  }
 
   /**
    * Get the entity name for api v4 calls.
@@ -31,6 +40,60 @@ class CRM_Event_ParticipantTokens extends CRM_Core_EntityTokens {
    */
   public function getCurrencyFieldName(): array {
     return ['fee_currency'];
+  }
+
+  /**
+   * Get any tokens with custom calculation.
+   */
+  public function getBespokeTokens(): array {
+    return ['balance' => ts('Event Balance')];
+  }
+
+  /**
+   * @inheritDoc
+   * @throws \CiviCRM_API3_Exception
+   */
+  public function evaluateToken(TokenRow $row, $entity, $field, $prefetch = NULL) {
+    $this->prefetch = (array) $prefetch;
+    if (empty($row->context['eventId'])) {
+      $row->context['eventId'] = $this->getFieldValue($row, 'event_id');
+    }
+    if ($field === 'balance') {
+      // @todo - is this really a good idea to call this & potentially get the
+      // balance of the contribution attached to 'registered_by_id'
+      $info = \CRM_Contribute_BAO_Contribution::getPaymentInfo($this->getFieldValue($row, 'id'), 'event');
+      $balancePay = $info['balance'] ?? NULL;
+      $balancePay = \CRM_Utils_Money::format($balancePay);
+      $row->tokens($entity, $field, $balancePay);
+      return;
+    }
+    parent::evaluateToken($row, $entity, $field, $prefetch);
+  }
+
+  /**
+   * Do not show event id in the UI as event.id will also be available.
+   *
+   * Discount id is probably a bit esoteric.
+   *
+   * @return string[]
+   */
+  protected function getHiddenTokens(): array {
+    return ['event_id', 'discount_id'];
+  }
+
+  /**
+   * Get entity fields that should not be exposed as tokens.
+   *
+   * @return string[]
+   */
+  public function getSkippedFields(): array {
+    $fields = parent::getSkippedFields();
+    // Never add these 2 fields - may not be a stable part of the schema.
+    // This field is on it's way out of core.
+    $fields[] = 'cart_id';
+    // this will probably get schema changed out of the table at some point.
+    $fields[] = 'is_pay_later';
+    return $fields;
   }
 
 }

--- a/CRM/Upgrade/Incremental/php/FiveFortyThree.php
+++ b/CRM/Upgrade/Incremental/php/FiveFortyThree.php
@@ -74,6 +74,21 @@ class CRM_Upgrade_Incremental_php_FiveFortyThree extends CRM_Upgrade_Incremental
     $this->addTask('Replace membership type token in action schedule',
       'updateActionScheduleToken', 'membership.type', 'membership.membership_type_id:label', $rev
     );
+    $this->addTask('Replace event fee amount token in action schedule',
+      'updateActionScheduleToken', 'event.fee_amount', 'participant.fee_amount', $rev
+    );
+    $this->addTask('Replace event type token in action schedule',
+      'updateActionScheduleToken', 'event.event_type_id', 'participant.event_type_id:label', $rev
+    );
+    $this->addTask('Replace event balance in action schedule',
+      'updateActionScheduleToken', 'event.balance', 'participant.balance', $rev
+    );
+    $this->addTask('Replace event fee amount in action schedule',
+      'updateActionScheduleToken', 'event.fee_amount', 'participant.fee_amount', $rev
+    );
+    $this->addTask('Replace event event_id in action schedule',
+      'updateActionScheduleToken', 'event.event_id', 'event.id', $rev
+    );
     $this->addTask('Replace duplicate event title token in event badges',
       'updatePrintLabelToken', 'participant.event_title', 'event.title', $rev
     );


### PR DESCRIPTION
Overview
----------------------------------------
This PR adds support for participant tokens in scheduled reminders

Before
----------------------------------------
Only event tokens were available. The query to add them was convoluted and had an unindexed join

After
----------------------------------------
Participant tokens are available...

Technical Details
----------------------------------------
I followed the domain model for events & cached the accessed events to an array. We know from the fact people never noticed the bad join that this isn't being used for high volume :-) But, it seems unlikely to me that, due to the time based nature of events, people would be sending to thousands of events in one hit and, even if they were, it's not a UI action & anyimpact of a huge array is likely to be in the realm of 'annoying in browser' rather than slows the job down (I doubt that it would slow it down anyway as browser lag is usually from initially building a large array not loading to it as required

Also note that event needs to listen to 'participant' AND 'event' - I put the handling for the former in the participant class.

Now that I've gotten to this point I realise how hard I was working around a function on the abstract subscriber class & I have some ideas for a cleanup to follow on

Comments
----------------------------------------
@magnolia61 some progress - I've gotten tests to pass locally but need to run through this again in the morning - will see if any thing else fails...

It *should* be testable - but back out quickly if you hit issues as it could be broken