### PR TITLE
[REF] Remove unnecessary parameters from function

### DIFF
--- a/CRM/Contact/Form/Task/PDFTrait.php
+++ b/CRM/Contact/Form/Task/PDFTrait.php
@@ -410,7 +410,7 @@ trait CRM_Contact_Form_Task_PDFTrait {
    * @throws \CiviCRM_API3_Exception
    * @throws \Civi\API\Exception\UnauthorizedException
    */
-  public function processTemplate(&$formValues) {
+  public function processTemplate(&$formValues): ?string {
     $html_message = $formValues['html_message'] ?? NULL;
 
     // process message template
@@ -484,16 +484,7 @@ trait CRM_Contact_Form_Task_PDFTrait {
     //from particular letter line, CRM-6798
     $this->formatMessage($html_message);
 
-    $messageToken = CRM_Utils_Token::getTokens($html_message);
-
-    $returnProperties = [];
-    if (isset($messageToken['contact'])) {
-      foreach ($messageToken['contact'] as $key => $value) {
-        $returnProperties[$value] = 1;
-      }
-    }
-
-    return [$formValues, $html_message, $messageToken, $returnProperties];
+    return [$formValues, $html_message];
   }
 
   /**

--- a/CRM/Member/Form/Task/PDFLetter.php
+++ b/CRM/Member/Form/Task/PDFLetter.php
@@ -91,8 +91,8 @@ class CRM_Member_Form_Task_PDFLetter extends CRM_Member_Form_Task {
   public function postProcessMembers($membershipIDs, $skipOnHold, $skipDeceased, $contactIDs) {
     $form = $this;
     $formValues = $form->controller->exportValues($form->getName());
-    [$formValues, $html_message, $messageToken, $returnProperties] = $this->processMessageTemplate($formValues);
-
+    [$formValues, $html_message] = $this->processMessageTemplate($formValues);
+    $messageToken = CRM_Utils_Token::getTokens($html_message);
     $html
       = $this->generateHTML(
       $membershipIDs,

--- a/tests/phpunit/CRM/Contact/Form/Task/PrintDocumentTest.php
+++ b/tests/phpunit/CRM/Contact/Form/Task/PrintDocumentTest.php
@@ -56,7 +56,7 @@ class CRM_Contact_Form_Task_PrintDocumentTest extends CiviUnitTestCase {
       'radio_ts' => 'ts_sel',
       'task' => CRM_Member_Task::PDF_LETTER,
     ]);
-    list($formValues, $html_message, $messageToken, $returnProperties) = $form->processMessageTemplate($formValues);
+    list($formValues) = $form->processMessageTemplate($formValues);
     list($html_message, $zip) = CRM_Utils_PDF_Document::unzipDoc($formValues['document_file_path'], $formValues['document_type']);
 
     foreach ($this->_contactIds as $item => $contactId) {


### PR DESCRIPTION
Overview
----------------------------------------
Remove unnecessary parameters from function

Before
----------------------------------------
`$returnProperties` & `$messageToken` unused (although `$messageToken` is not fully eliminated from Membership pdf in this pr)

After
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/135261524-a3598b35-37fe-4660-99db-e99732730dcd.png)

Technical Details
----------------------------------------
Recently extracted function, cannot be used elsewhere

Comments
----------------------------------------
