### PR TITLE
[REF] Use getSubmittedValue rather than passed values

### DIFF
--- a/CRM/Contact/Form/Task/PDFTrait.php
+++ b/CRM/Contact/Form/Task/PDFTrait.php
@@ -414,7 +414,7 @@ trait CRM_Contact_Form_Task_PDFTrait {
     $html_message = $formValues['html_message'] ?? NULL;
 
     // process message template
-    if (!empty($formValues['saveTemplate']) || !empty($formValues['updateTemplate'])) {
+    if (!empty($this->getSubmittedValue('saveTemplate')) || !empty($formValues['updateTemplate'])) {
       $messageTemplate = [
         'msg_text' => NULL,
         'msg_html' => $formValues['html_message'],
@@ -426,8 +426,8 @@ trait CRM_Contact_Form_Task_PDFTrait {
       if (!empty($formValues['bind_format']) && $formValues['format_id']) {
         $messageTemplate['pdf_format_id'] = $formValues['format_id'];
       }
-      if (!empty($formValues['saveTemplate'])) {
-        $messageTemplate['msg_title'] = $formValues['saveTemplateName'];
+      if ($this->getSubmittedValue('saveTemplate')) {
+        $messageTemplate['msg_title'] = $this->getSubmittedValue('saveTemplateName');
         CRM_Core_BAO_MessageTemplate::add($messageTemplate);
       }
 


### PR DESCRIPTION
Overview
----------------------------------------
Use getSubmittedValue rather than passed values

Before
----------------------------------------
When arrays of values are passed around it is 
a) hard to know whether they are what was submitted or somehow altered and 
b) hard to move to another place in the code (see a)

After
----------------------------------------
`getSubmittedValue` used. We added this earlier this year & it's actually quite transformational

Technical Details
----------------------------------------

Comments
----------------------------------------

tests pass so yay