### PR TITLE
fixes event#64: Send event confirmation to submitted email address

### DIFF
--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -1108,9 +1108,9 @@ WHERE civicrm_event.is_active = 1
 
     if ($values['event']['is_email_confirm'] || $returnMessageText) {
       list($displayName, $email) = CRM_Contact_BAO_Contact_Location::getEmailDetails($contactID);
-
+      $notifyEmail = CRM_Utils_Array::valueByRegexKey('/^email-/', $participantParams) ?? $email;
       //send email only when email is present
-      if (isset($email) || $returnMessageText) {
+      if (isset($notifyEmail) || $returnMessageText) {
         $preProfileID = $values['custom_pre_id'] ?? NULL;
         $postProfileID = $values['custom_post_id'] ?? NULL;
 
@@ -1153,7 +1153,7 @@ WHERE civicrm_event.is_active = 1
           $customPostTitles = NULL;
         }
         $tplParams = array_merge($values, $participantParams, [
-          'email' => $email,
+          'email' => $notifyEmail,
           'confirm_email_text' => $values['event']['confirm_email_text'] ?? NULL,
           'isShowLocation' => $values['event']['is_show_location'] ?? NULL,
           // The concept of contributeMode is deprecated.
@@ -1233,7 +1233,7 @@ WHERE civicrm_event.is_active = 1
         else {
           $sendTemplateParams['from'] = CRM_Utils_Array::value('confirm_from_name', $values['event']) . " <" . CRM_Utils_Array::value('confirm_from_email', $values['event']) . ">";
           $sendTemplateParams['toName'] = $displayName;
-          $sendTemplateParams['toEmail'] = $email;
+          $sendTemplateParams['toEmail'] = $notifyEmail;
           $sendTemplateParams['autoSubmitted'] = TRUE;
           $sendTemplateParams['cc'] = CRM_Utils_Array::value('cc_confirm',
             $values['event']

--- a/CRM/Event/Form/Registration/ThankYou.php
+++ b/CRM/Event/Form/Registration/ThankYou.php
@@ -73,7 +73,10 @@ class CRM_Event_Form_Registration_ThankYou extends CRM_Event_Form_Registration {
     // Assign the email address from a contact id lookup as in CRM_Event_BAO_Event->sendMail()
     $primaryContactId = $this->get('primaryContactId');
     if ($primaryContactId) {
-      list($displayName, $email) = CRM_Contact_BAO_Contact_Location::getEmailDetails($primaryContactId);
+      $email = CRM_Utils_Array::valueByRegexKey('/^email-/', current($this->_params));
+      if (!$email) {
+        $email = CRM_Contact_BAO_Contact::getPrimaryEmail($primaryContactId);
+      }
       $this->assign('email', $email);
     }
     $this->assignToTemplate();

--- a/tests/phpunit/CRM/Event/Form/Registration/ConfirmTest.php
+++ b/tests/phpunit/CRM/Event/Form/Registration/ConfirmTest.php
@@ -595,4 +595,72 @@ class CRM_Event_Form_Registration_ConfirmTest extends CiviUnitTestCase {
     $this->submitWithNote($event, $contact_id);
   }
 
+  /**
+   * event#64 - ensure we send to the submitted email, not the primary email when they differ.
+   *
+   * @throws \Exception
+   */
+  public function testSubmitNonPrimaryEmail(): void {
+    $event = $this->eventCreate();
+    $mut = new CiviMailUtils($this, TRUE);
+    $cid = $this->createLoggedInUser();
+    CRM_Event_Form_Registration_Confirm::testSubmit([
+      'id' => $event['id'],
+      'contributeMode' => 'direct',
+      'registerByID' => $cid,
+      'params' => [
+        [
+          'qfKey' => 'e6eb2903eae63d4c5c6cc70bfdda8741_2801',
+          'entryURL' => 'http://dmaster.local/civicrm/event/register?reset=1&amp;id=3',
+          'first_name' => 'k',
+          'last_name' => 'p',
+          'email-Other' => 'nonprimaryemail@example.com',
+          'hidden_processor' => '1',
+          'credit_card_number' => '4111111111111111',
+          'cvv2' => '123',
+          'credit_card_exp_date' => [
+            'M' => '1',
+            'Y' => '2019',
+          ],
+          'credit_card_type' => 'Visa',
+          'billing_first_name' => 'p',
+          'billing_middle_name' => '',
+          'billing_last_name' => 'p',
+          'billing_street_address-5' => 'p',
+          'billing_city-5' => 'p',
+          'billing_state_province_id-5' => '1061',
+          'billing_postal_code-5' => '7',
+          'billing_country_id-5' => '1228',
+          'priceSetId' => '6',
+          'price_7' => [
+            13 => 1,
+          ],
+          'payment_processor_id' => '1',
+          'bypass_payment' => '',
+          'MAX_FILE_SIZE' => '33554432',
+          'is_primary' => 1,
+          'is_pay_later' => 0,
+          'campaign_id' => NULL,
+          'defaultRole' => 1,
+          'participant_role_id' => '1',
+          'currencyID' => 'USD',
+          'amount_level' => 'Tiny-tots (ages 5-8) - 1',
+          'amount' => '800.00',
+          'tax_amount' => NULL,
+          'year' => '2019',
+          'month' => '1',
+          'ip_address' => '127.0.0.1',
+          'invoiceID' => '57adc34957a29171948e8643ce906332',
+          'button' => '_qf_Register_upload',
+          'billing_state_province-5' => 'AP',
+          'billing_country-5' => 'US',
+        ],
+      ],
+    ]);
+
+    $mut->checkMailLog(['nonprimaryemail@example.com']);
+    $mut->stop();
+    $mut->clearMessages();
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
An event registration that's submitted with an email that differs from the (existing) contact's primary email will go to the primary email.  It should go to the submitted email.

Before
----------------------------------------
Event registration confirmations go to the existing primary email.

After
----------------------------------------
Event registration confirmations go to the email submitted.

Technical Details
----------------------------------------
My last line isn't necessary - the Manage Event screen won't allow you to enable email confirmations if we don't ask for an email, so it should always be present.  But who knows what those extension writers get up to?