### PR TITLE
Remove workflow_id reference

### DIFF
--- a/CRM/Admin/Form/MessageTemplates.php
+++ b/CRM/Admin/Form/MessageTemplates.php
@@ -110,7 +110,7 @@ class CRM_Admin_Form_MessageTemplates extends CRM_Core_Form {
     else {
       $this->_workflow_id = $this->_values['workflow_id'] ?? NULL;
       $this->checkUserPermission($this->_workflow_id);
-      $this->assign('workflow_id', $this->_workflow_id);
+      $this->assign('isWorkflow', (bool) ($this->_values['workflow_id'] ?? NULL));
 
       if ($this->_workflow_id) {
         $selectedChild = 'workflow';

--- a/CRM/Admin/Page/MessageTemplates.php
+++ b/CRM/Admin/Page/MessageTemplates.php
@@ -51,7 +51,7 @@ class CRM_Admin_Page_MessageTemplates extends CRM_Core_Page_Basic {
     $sql = '
             SELECT diverted.id, orig.id orig_id
             FROM civicrm_msg_template diverted JOIN civicrm_msg_template orig ON (
-                diverted.workflow_id = orig.workflow_id AND
+                diverted.workflow_name = orig.workflow_name AND
                 orig.is_reserved = 1                    AND (
                     diverted.msg_subject != orig.msg_subject OR
                     diverted.msg_text    != orig.msg_text    OR
@@ -134,7 +134,7 @@ class CRM_Admin_Page_MessageTemplates extends CRM_Core_Page_Basic {
    * @param bool $forceAction
    */
   public function action(&$object, $action, &$values, &$links, $permission, $forceAction = FALSE) {
-    if ($object->workflow_id) {
+    if ($object->workflow_name) {
       // do not expose action link for reverting to default if the template did not diverge or we just reverted it now
       if (!array_key_exists($object->id, $this->_revertible) or
         ($this->_action & CRM_Core_Action::REVERT and $object->id == $this->_revertedId)
@@ -145,7 +145,7 @@ class CRM_Admin_Page_MessageTemplates extends CRM_Core_Page_Basic {
 
       // default workflow templates shouldn’t be deletable
       // workflow templates shouldn’t have disable/enable actions (at least for CiviCRM 3.1)
-      if ($object->workflow_id) {
+      if ($object->workflow_name) {
         $action &= ~CRM_Core_Action::DISABLE;
         $action &= ~CRM_Core_Action::DELETE;
       }

--- a/CRM/Core/BAO/MessageTemplate.php
+++ b/CRM/Core/BAO/MessageTemplate.php
@@ -230,7 +230,7 @@ class CRM_Core_BAO_MessageTemplate extends CRM_Core_DAO_MessageTemplate {
     }
 
     $orig = new CRM_Core_BAO_MessageTemplate();
-    $orig->workflow_id = $diverted->workflow_id;
+    $orig->workflow_name = $diverted->workflow_name;
     $orig->is_reserved = 1;
     $orig->find(1);
 

--- a/CRM/Mailing/Info.php
+++ b/CRM/Mailing/Info.php
@@ -68,15 +68,15 @@ class CRM_Mailing_Info extends CRM_Core_Component_Info {
 
     $emailAdd = civicrm_api3('Email', 'get', [
       'sequential' => 1,
-      'return' => "email",
+      'return' => 'email',
       'contact_id' => $contactID,
     ]);
 
     $mesTemplate = civicrm_api3('MessageTemplate', 'get', $params + [
       'sequential' => 1,
       'is_active' => 1,
-      'return' => ["id", "msg_title"],
-      'workflow_id' => ['IS NULL' => ""],
+      'return' => ['id', 'msg_title'],
+      'workflow_name' => ['IS NULL' => ''],
     ]);
     $mailTokens = civicrm_api3('Mailing', 'gettokens', [
       'entity' => ['contact', 'mailing'],

--- a/ang/crmMailing/Templates.js
+++ b/ang/crmMailing/Templates.js
@@ -72,8 +72,8 @@
                     }
 
                     rcpAjaxState.page_i = page_num - rcpAjaxState.page_n;
-                    var filterParams = { is_active: 1, workflow_id: { "IS NULL": 1 } };
-                    
+                    var filterParams = { is_active: 1, workflow_name: { "IS NULL": 1 } };
+
                     var params = {
                       input: input,
                       page_num: rcpAjaxState.page_i,

--- a/api/v3/examples/MessageTemplate/Get.ex.php
+++ b/api/v3/examples/MessageTemplate/Get.ex.php
@@ -11,7 +11,7 @@ function message_template_get_example() {
     'msg_subject' => 'msg_subject_472',
     'msg_text' => 'msg_text_472',
     'msg_html' => 'msg_html_472',
-    'workflow_id' => 472,
+    'workflow_name' => 'contribution_online_invoice',
     'is_default' => '1',
     'is_reserved' => 1,
   ];

--- a/templates/CRM/Admin/Form/MessageTemplates.tpl
+++ b/templates/CRM/Admin/Form/MessageTemplates.tpl
@@ -118,7 +118,7 @@
         </div><!-- /.crm-accordion-body -->
       </div><!-- /.crm-accordion-wrapper -->
 
-      {if !$workflow_id}
+      {if !$isWorkflow}
         <table class="form-layout-compressed">
           <tr>
             <td class="label-left">{$form.is_active.label}</td>


### PR DESCRIPTION
Overview
----------------------------------------
Remove workflow_id reference

Before
----------------------------------------
Legacy field `workflow_id` referenced

After
----------------------------------------
correct field `workflow_name` referenced

Technical Details
----------------------------------------
This is a null op - we have code to ensure workflow_name is set when workflow_id is set

Comments
----------------------------------------
This reduces confusion