### PR TITLE
Stop enforcing workflow_id

### DIFF
--- a/CRM/Core/BAO/MessageTemplate.php
+++ b/CRM/Core/BAO/MessageTemplate.php
@@ -123,7 +123,8 @@ class CRM_Core_BAO_MessageTemplate extends CRM_Core_DAO_MessageTemplate {
       case 'idname':
         $map = self::getWorkflowNameIdMap();
         if ($map[$params['workflow_name']] != $params['workflow_id']) {
-          throw new CRM_Core_Exception("The workflow_id and workflow_name are mismatched. Note: You only need to submit one or the other.");
+          unset($params['workflow_id']);
+          Civi::log()->info('The workflow_id and workflow_name are mismatched. Note: You only need to submit one or the other.');
         }
         break;
 


### PR DESCRIPTION


Overview
----------------------------------------
Stop enforcing workflow_id

This makes it so it ignores workflow_id rather than fails & treats workflow_name as the master

Before
----------------------------------------
wofkflow_id was deprecated over a year ago but this code was added to help out - however, it means you can't save in message admin extension unless you have created an option group - this should be optional & is possibly slightly required on the old screen but is not in message_template extension

After
----------------------------------------
worrkflow_name prioritised

Technical Details
----------------------------------------
Last round (may 2020) we started phasing out workflow _id but there was a worry some hooks might reference it so we kept it alive - but we don't want it around forever

Comments
----------------------------------------
