### PR TITLE
dev/core#2866 Ignore preferred mail format - send to both

### DIFF
--- a/CRM/Contact/Form/Task/EmailTrait.php
+++ b/CRM/Contact/Form/Task/EmailTrait.php
@@ -859,13 +859,11 @@ trait CRM_Contact_Form_Task_EmailTrait {
       }
 
       $tokenSubject = $subject;
-      $tokenText = in_array($values['preferred_mail_format'], ['Both', 'Text'], TRUE) ? $text : '';
-      $tokenHtml = in_array($values['preferred_mail_format'], ['Both', 'HTML'], TRUE) ? $html : '';
 
       $renderedTemplate = CRM_Core_BAO_MessageTemplate::renderTemplate([
         'messageTemplate' => [
-          'msg_text' => $tokenText,
-          'msg_html' => $tokenHtml,
+          'msg_text' => $text,
+          'msg_html' => $html,
           'msg_subject' => $tokenSubject,
         ],
         'tokenContext' => $tokenContext,


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#2866 Ignore preferred mail format - send to both

This was canvassed in gitlab (thumbs up from @aydun) and on github where @jmcclelland @colemanw and @JoeMurray spoke in support - no counter views.



Before
----------------------------------------
From email task the user's preferred_mail_format is dependent on the user's value for the field

After
----------------------------------------
We live in a world where users have mail clients that receive 'both' and present to them based on their settings. Also civicrm has moved out of cvs through svn to github since it seemed like a good idea

Technical Details
----------------------------------------

 It only affects the email task for now because I think to remove from other places I'd need to remove it from the UI too but in terms of the email task it's adding complexity that I kinda need to remove in order to resolve other issues around loading rows 

Comments
----------------------------------------

Also - I suspect this might be broken :-)