### PR TITLE
Update SelfSvcUpdate.php

### DIFF
--- a/CRM/Event/Form/SelfSvcUpdate.php
+++ b/CRM/Event/Form/SelfSvcUpdate.php
@@ -160,7 +160,7 @@ class CRM_Event_Form_SelfSvcUpdate extends CRM_Core_Form {
    * return @void
    */
   public function buildQuickForm() {
-    $this->add('select', 'action', ts('Transfer or Cancel Registration'), [ts('-select-'), ts('Transfer'), ts('Cancel')], TRUE);
+    $this->add('select', 'action', ts('Transfer or Cancel Registration'), [ts('-select-'), ts('Transfer'), ts('Cancel Registration')], TRUE);
     $this->addButtons([
       [
         'type' => 'submit',


### PR DESCRIPTION
Changing this text is necessary for internationalization, because otherwise we get an ambigous translation in some languages

Overview
----------------------------------------
Simple change of "cancel" to "cancel registration"

Before
----------------------------------------
"cancel" won't give a meaningful translation, at least in german.

After
----------------------------------------
"cancel registration" remains meaningful in english, but works better in other languages.
This string already exists in CRM/Event/Form/Registration/ParticipantConfirm.php, so most probably transifex already has the translation available for most languages.

Technical Details
----------------------------------------
n.a.

Comments
----------------------------------------
n.a.