### PR TITLE
APIv4 - Add Contact.getDuplicates action

### DIFF
--- a/CRM/Dedupe/Finder.php
+++ b/CRM/Dedupe/Finder.php
@@ -93,7 +93,7 @@ class CRM_Dedupe_Finder {
     if (!$params) {
       return [];
     }
-    $checkPermission = CRM_Utils_Array::value('check_permission', $params, TRUE);
+    $checkPermission = $params['check_permission'] ?? TRUE;
     // This may no longer be required - see https://github.com/civicrm/civicrm-core/pull/13176
     $params = array_filter($params);
 

--- a/Civi/Api4/Action/Contact/GetDuplicates.php
+++ b/Civi/Api4/Action/Contact/GetDuplicates.php
@@ -1,0 +1,123 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Action\Contact;
+
+use Civi\Api4\DedupeRuleGroup;
+use Civi\Api4\Generic\BasicGetFieldsAction;
+use Civi\Api4\Generic\Result;
+use Civi\Api4\Utils\FormattingUtil;
+
+/**
+ * Get matching contacts based on a dedupe rule
+ */
+class GetDuplicates extends \Civi\Api4\Generic\DAOCreateAction {
+
+  /**
+   * Name of dedupe rule to use.
+   *
+   * Specifying "Unsupervised" or "Supervised" will use the default rule group
+   * for the contact type, or else the name of a specific rule group can be given.
+   *
+   * @var string
+   * @optionsCallback getRuleGroupNames
+   * @required
+   */
+  protected $dedupeRule;
+
+  /**
+   * Options callback for dedupeRule param
+   * @return string[]
+   */
+  protected function getRuleGroupNames() {
+    $generic = ['Unsupervised', 'Supervised'];
+    $specific = DedupeRuleGroup::get(FALSE)
+      ->addSelect('name')
+      ->execute()->column('name');
+    return array_merge($generic, $specific);
+  }
+
+  /**
+   * @param \Civi\Api4\Generic\Result $result
+   */
+  public function _run(Result $result) {
+    $defaultRule = $ruleId = NULL;
+    $item = $this->values;
+
+    $contactType = $item['contact_type'] ?? NULL;
+    $this->formatWriteValues($item);
+    $this->transformCustomParams($item);
+
+    if (in_array($this->dedupeRule, ['Unsupervised', 'Supervised'], TRUE)) {
+      if (!$contactType) {
+        throw new \API_Exception('Using a default dedupe rule requires contact type.');
+      }
+      $defaultRule = $this->dedupeRule;
+    }
+    else {
+      $ruleGroup = DedupeRuleGroup::get(FALSE)
+        ->addWhere('name', '=', $this->dedupeRule)
+        ->addSelect('id', 'contact_type')
+        ->execute()->single();
+      $contactType = $ruleGroup['contact_type'];
+      $ruleId = $ruleGroup['id'];
+    }
+
+    foreach (\CRM_Contact_BAO_Contact::getDuplicateContacts($item, $contactType, $defaultRule, [], $this->checkPermissions, $ruleId) as $id) {
+      $result[] = ['id' => $id];
+    }
+  }
+
+  /**
+   * @param array $params
+   * @throws \API_Exception
+   */
+  private function transformCustomParams(&$params) {
+    foreach ($params as $name => $value) {
+      $field = $this->getCustomFieldInfo($name);
+      if ($field) {
+        unset($params[$name]);
+
+        if (isset($value)) {
+          if ($field['suffix']) {
+            $options = FormattingUtil::getPseudoconstantList($field, $name, $params, 'create');
+            $value = FormattingUtil::replacePseudoconstant($options, $value, TRUE);
+          }
+          $params["custom_{$field['id']}"] = $value;
+        }
+      }
+    }
+  }
+
+  /**
+   * Combines getfields from Contact + related entities into a flat array
+   *
+   * @return array
+   */
+  public static function fields(BasicGetFieldsAction $action) {
+    $fields = [];
+    $ignore = ['id', 'contact_id', 'is_primary', 'on_hold', 'location_type_id', 'phone_type_id', 'website_type_id'];
+    foreach (['Contact', 'Email', 'Phone', 'Address', 'Website', 'IM', 'OpenID'] as $entity) {
+      $entityFields = (array) civicrm_api4($entity, 'getFields', [
+        'action' => 'create',
+        'loadOptions' => $action->getLoadOptions(),
+        'where' => [['name', 'NOT IN', $ignore], ['type', 'IN', ['Field', 'Custom']]],
+      ]);
+      $fields = array_merge($fields, $entityFields);
+    }
+    foreach ($fields as $index => $field) {
+      $fields[$index]['required'] = $field['name'] === 'contact_type';
+    }
+    return $fields;
+  }
+
+}

--- a/Civi/Api4/Generic/AbstractAction.php
+++ b/Civi/Api4/Generic/AbstractAction.php
@@ -281,8 +281,13 @@ abstract class AbstractAction implements \ArrayAccess {
       foreach ($this->reflect()->getProperties(\ReflectionProperty::IS_PROTECTED) as $property) {
         $name = $property->getName();
         if ($name != 'version' && $name[0] != '_') {
-          $this->_paramInfo[$name] = ReflectionUtils::getCodeDocs($property, 'Property', $vars);
-          $this->_paramInfo[$name]['default'] = $defaults[$name];
+          $docs = ReflectionUtils::getCodeDocs($property, 'Property', $vars);
+          $docs['default'] = $defaults[$name];
+          if (!empty($docs['optionsCallback'])) {
+            $docs['options'] = $this->{$docs['optionsCallback']}();
+            unset($docs['optionsCallback']);
+          }
+          $this->_paramInfo[$name] = $docs;
         }
       }
     }

--- a/Civi/Api4/Generic/BasicGetFieldsAction.php
+++ b/Civi/Api4/Generic/BasicGetFieldsAction.php
@@ -88,7 +88,7 @@ class BasicGetFieldsAction extends BasicGetAction {
     catch (NotImplementedException $e) {
     }
     if (isset($actionClass) && method_exists($actionClass, 'fields')) {
-      $values = $actionClass->fields();
+      $values = $actionClass->fields($this);
     }
     else {
       $values = $this->getRecords();


### PR DESCRIPTION
Overview
----------------------------------------
POC dedupe action for APIv4.

![image](https://user-images.githubusercontent.com/2874912/135637776-59ef53ae-028e-4518-8647-fd7a3ccc551f.png)


Comments
----------------------------------------
Now I remember why we hadn't done this one already. So this "works" and we could write a test for it and call it a day, but there are a few matters which give me pause:

1. It takes all params in a single flat array (note the screenshot - "Email" doesn't belong to the contact entity, yet there it is). You can see how I had to fudge this in getfields, basically looping through all the entities and combining them together.
2. While this flat array is what `CRM_Contact_BAO_Contact::getDuplicateContacts()` expects (this action basically wraps that function) - that function then does a lot of work to *un*flatten it into a nested structure like `[civicrm_contact => [first_name => ... ], civicrm_email => [email => ...]]`.
3. So maybe we should take nested data as API input and skip the flattening and unflattening fudge factory? That would make this action a lot less friendly to the api explorer, but maybe that's worth doing anyway?
4. Even if we do that, there's a shortcoming in the underlying dedupe system, which is that it can only consider a single email, phone, address, etc. even though those records are multi-valued. That sucks for a use-case like Afform where the user can enter e.g. their home and work emails and we want to dedupe before creating a new contact record for them.
5. None of this gets us any closer to having deduping built-in to the Contact.create action. I really like that about APIv3, where you can create a contact and have the api check for duplicates at the same time. Alas, Contact.create in v4 doesn't accept non-contact fields like `email`, `phone`, etc. which means there would be insufficient data for deduping.