### PR TITLE
APIv4 - Give every SQL expression a title

### DIFF
--- a/Civi/Api4/Query/SqlEquation.php
+++ b/Civi/Api4/Query/SqlEquation.php
@@ -116,4 +116,8 @@ class SqlEquation extends SqlExpression {
     return $value;
   }
 
+  public static function getTitle(): string {
+    return ts('Equation');
+  }
+
 }

--- a/Civi/Api4/Query/SqlExpression.php
+++ b/Civi/Api4/Query/SqlExpression.php
@@ -172,6 +172,11 @@ abstract class SqlExpression {
   }
 
   /**
+   * @return string
+   */
+  abstract public static function getTitle(): string;
+
+  /**
    * @return string|NULL
    */
   public static function getDataType():? string {

--- a/Civi/Api4/Query/SqlField.php
+++ b/Civi/Api4/Query/SqlField.php
@@ -41,4 +41,8 @@ class SqlField extends SqlExpression {
     return $fieldList[$this->expr]['sql_name'];
   }
 
+  public static function getTitle(): string {
+    return ts('Field');
+  }
+
 }

--- a/Civi/Api4/Query/SqlFunction.php
+++ b/Civi/Api4/Query/SqlFunction.php
@@ -198,11 +198,6 @@ abstract class SqlFunction extends SqlExpression {
   /**
    * @return string
    */
-  abstract public static function getTitle(): string;
-
-  /**
-   * @return string
-   */
   abstract public static function getDescription(): string;
 
 }

--- a/Civi/Api4/Query/SqlNull.php
+++ b/Civi/Api4/Query/SqlNull.php
@@ -23,4 +23,8 @@ class SqlNull extends SqlExpression {
     return 'NULL';
   }
 
+  public static function getTitle(): string {
+    return ts('Null');
+  }
+
 }

--- a/Civi/Api4/Query/SqlNumber.php
+++ b/Civi/Api4/Query/SqlNumber.php
@@ -26,4 +26,8 @@ class SqlNumber extends SqlExpression {
     return $this->expr;
   }
 
+  public static function getTitle(): string {
+    return ts('Number');
+  }
+
 }

--- a/Civi/Api4/Query/SqlString.php
+++ b/Civi/Api4/Query/SqlString.php
@@ -31,4 +31,8 @@ class SqlString extends SqlExpression {
     return '"' . \CRM_Core_DAO::escapeString($this->expr) . '"';
   }
 
+  public static function getTitle(): string {
+    return ts('Text');
+  }
+
 }

--- a/Civi/Api4/Query/SqlWild.php
+++ b/Civi/Api4/Query/SqlWild.php
@@ -23,4 +23,8 @@ class SqlWild extends SqlExpression {
     return '*';
   }
 
+  public static function getTitle(): string {
+    return ts('Wild');
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a bug in Afform where it would crash trying to get the title of SQL Equations
on search display forms.

Before
----------------------------------------
1. Create a search display that uses an equation in a column.
2. Try to create an afform for it.
3. Crash

After
----------------------------------------
Works.

Technical Details
----------------
Just to avoid confusion about which Sql expressions have a title and which do not, I added one for all of them.