### PR TITLE
Fix unreplaced template vars in civicrm.settings.php when using legacy installer

### DIFF
--- a/install/civicrm.php
+++ b/install/civicrm.php
@@ -205,6 +205,10 @@ function civicrm_config(&$config) {
     'dbPass' => addslashes($config['mysql']['password']),
     'dbHost' => $config['mysql']['server'],
     'dbName' => addslashes($config['mysql']['database']),
+    // These need to be filled manually when using the old installer if an
+    // SSL connection to MySQL is needed.
+    'dbSSL' => '',
+    'CMSdbSSL' => '',
   );
 
   $params['baseURL'] = $config['base_url'] ?? civicrm_cms_base();


### PR DESCRIPTION
Overview
----------------------------------------
When using the legacy installer (e.g. sites/all/modules/civicrm/install/index.php) it leaves behind some unreplaced ssl-related template variables.

Before
----------------------------------------
DSN in civicrm.settings.php looks like `mysql://foo:bar@localhost/cividb?new_link=true%%dbSSL%%` after install.

After
----------------------------------------
`mysql://foo:bar@localhost/cividb?new_link=true`

Technical Details
----------------------------------------
The ssl vars are only replaced when using the newer civicrm-setup.

Comments
----------------------------------------
See also https://github.com/civicrm/civicrm-joomla/pull/63
