### PR TITLE
Add participant tokens to pdf task

### DIFF
--- a/CRM/Activity/Form/Task.php
+++ b/CRM/Activity/Form/Task.php
@@ -127,4 +127,13 @@ WHERE  activity_id IN ( $IDs ) AND
     ]);
   }
 
+  /**
+   * Get the token processor schema required to list any tokens for this task.
+   *
+   * @return array
+   */
+  public function getTokenSchema(): array {
+    return ['activityId'];
+  }
+
 }

--- a/CRM/Activity/Form/Task/PDF.php
+++ b/CRM/Activity/Form/Task/PDF.php
@@ -57,15 +57,6 @@ class CRM_Activity_Form_Task_PDF extends CRM_Activity_Form_Task {
   }
 
   /**
-   * List available tokens for this form.
-   *
-   * @return array
-   */
-  public function listTokens() {
-    return $this->createTokenProcessor()->listTokens();
-  }
-
-  /**
    * Create a token processor
    *
    * @return \Civi\Token\TokenProcessor

--- a/CRM/Case/Form/Task.php
+++ b/CRM/Case/Form/Task.php
@@ -69,6 +69,23 @@ class CRM_Case_Form_Task extends CRM_Core_Form_Task {
   }
 
   /**
+   * Get the rows from the results to be pdf-d.
+   *
+   * @return array
+   */
+  protected function getRows(): array {
+    $rows = [];
+    foreach ($this->_contactIds as $index => $contactID) {
+      $caseID = $this->getVar('_caseId');
+      if (empty($caseID) && !empty($this->_caseIds[$index])) {
+        $caseID = $this->_caseIds[$index];
+      }
+      $rows[] = ['contactId' => $contactID, 'caseId' => $caseID];
+    }
+    return $rows;
+  }
+
+  /**
    * Get the name of the table for the relevant entity.
    *
    * @return string

--- a/CRM/Contact/Form/Task.php
+++ b/CRM/Contact/Form/Task.php
@@ -137,7 +137,7 @@ class CRM_Contact_Form_Task extends CRM_Core_Form_Task {
       // since we don't store all contacts in prevnextcache, when user selects "all" use query to retrieve contacts
       // rather than prevnext cache table for most of the task actions except export where we rebuild query to fetch
       // final result set
-      $allCids[$cacheKey] = self::getContactIds($form);
+      $allCids[$cacheKey] = self::legacyGetContactIds($form);
 
       $form->_contactIds = [];
       if (empty($form->_contactIds)) {
@@ -222,11 +222,16 @@ class CRM_Contact_Form_Task extends CRM_Core_Form_Task {
    *   - custom search (FIXME: does this still apply to custom search?).
    * When we call this function we are not using the prev/next cache
    *
+   * We've started to try to move away from these functions
+   * being static. Probably we need to convert the export forms
+   * to use a trait based approach. For now this is renamed to
+   * permit the use of a non-static function with this name
+   *
    * @param $form CRM_Core_Form
    *
    * @return array $contactIds
    */
-  public static function getContactIds($form) {
+  protected static function legacyGetContactIds($form) {
     // need to perform action on all contacts
     // fire the query again and get the contact id's + display name
     $sortID = NULL;

--- a/CRM/Contact/Form/Task/PDF.php
+++ b/CRM/Contact/Form/Task/PDF.php
@@ -110,4 +110,26 @@ class CRM_Contact_Form_Task_PDF extends CRM_Contact_Form_Task {
     return $tokens;
   }
 
+  /**
+   * Get the rows from the results to be pdf-d.
+   *
+   * @todo the case handling should be in the case pdf task.
+   * It needs fixing to support standalone & some url fixes
+   *
+   * similar to https://github.com/civicrm/civicrm-core/pull/21688
+   *
+   * @return array
+   */
+  protected function getRows(): array {
+    $rows = [];
+    foreach ($this->_contactIds as $index => $contactID) {
+      $caseID = $this->getVar('_caseId');
+      if (empty($caseID) && !empty($this->_caseIds[$index])) {
+        $caseID = $this->_caseIds[$index];
+      }
+      $rows[] = ['contactId' => $contactID, 'caseId' => $caseID];
+    }
+    return $rows;
+  }
+
 }

--- a/CRM/Contact/Form/Task/PDFTrait.php
+++ b/CRM/Contact/Form/Task/PDFTrait.php
@@ -237,16 +237,11 @@ trait CRM_Contact_Form_Task_PDFTrait {
       [$html_message, $zip] = CRM_Utils_PDF_Document::unzipDoc($formValues['document_file_path'], $formValues['document_type']);
     }
 
-    foreach ($this->_contactIds as $item => $contactId) {
-      $caseId = $this->getVar('_caseId');
-      if (empty($caseId) && !empty($this->_caseIds[$item])) {
-        $caseId = $this->_caseIds[$item];
-      }
-
+    foreach ($this->getRows() as $row) {
       $tokenHtml = CRM_Core_BAO_MessageTemplate::renderTemplate([
-        'contactId' => $contactId,
+        'contactId' => $row['contactId'],
         'messageTemplate' => ['msg_html' => $html_message],
-        'tokenContext' => $caseId ? ['caseId' => $caseId] : [],
+        'tokenContext' => array_merge($row, ['schema' => $this->getTokenSchema()]),
         'disableSmarty' => (!defined('CIVICRM_MAIL_SMARTY') || !CIVICRM_MAIL_SMARTY),
       ])['html'];
 

--- a/CRM/Contribute/Form/Task.php
+++ b/CRM/Contribute/Form/Task.php
@@ -104,4 +104,13 @@ class CRM_Contribute_Form_Task extends CRM_Core_Form_Task {
     ]);
   }
 
+  /**
+   * Get the token processor schema required to list any tokens for this task.
+   *
+   * @return array
+   */
+  public function getTokenSchema(): array {
+    return ['contributionId', 'contactId'];
+  }
+
 }

--- a/CRM/Contribute/Form/Task/Email.php
+++ b/CRM/Contribute/Form/Task/Email.php
@@ -32,15 +32,4 @@ class CRM_Contribute_Form_Task_Email extends CRM_Contribute_Form_Task {
     return $this->getIDs();
   }
 
-  /**
-   * List available tokens for this form.
-   *
-   * @return array
-   */
-  public function listTokens() {
-    $tokens = CRM_Core_SelectValues::contactTokens();
-    $tokens = array_merge(CRM_Core_SelectValues::contributionTokens(), $tokens);
-    return $tokens;
-  }
-
 }

--- a/CRM/Contribute/Form/Task/PDFLetter.php
+++ b/CRM/Contribute/Form/Task/PDFLetter.php
@@ -293,15 +293,12 @@ class CRM_Contribute_Form_Task_PDFLetter extends CRM_Contribute_Form_Task {
   }
 
   /**
-   * List available tokens for this form.
+   * Get the token processor schema required to list any tokens for this task.
    *
    * @return array
    */
-  public function listTokens() {
-    $tokens = CRM_Core_SelectValues::contactTokens();
-    $tokens = array_merge(CRM_Core_SelectValues::contributionTokens(), $tokens);
-    $tokens = array_merge(CRM_Core_SelectValues::domainTokens(), $tokens);
-    return $tokens;
+  public function getTokenSchema(): array {
+    return ['contributionId', 'contactId'];
   }
 
   /**

--- a/CRM/Core/Form/Task.php
+++ b/CRM/Core/Form/Task.php
@@ -359,4 +359,26 @@ SELECT contact_id
     return ['contactId'];
   }
 
+  /**
+   * Get the rows from the results.
+   *
+   * @return array
+   */
+  protected function getRows(): array {
+    $rows = [];
+    foreach ($this->getContactIDs() as $contactID) {
+      $rows[] = ['contactId' => $contactID];
+    }
+    return $rows;
+  }
+
+  /**
+   * Get the relevant contact IDs.
+   *
+   * @return array
+   */
+  protected function getContactIDs(): array {
+    return $this->_contactIds ?? [];
+  }
+
 }

--- a/CRM/Core/Form/Task.php
+++ b/CRM/Core/Form/Task.php
@@ -9,6 +9,8 @@
  +--------------------------------------------------------------------+
  */
 
+use Civi\Token\TokenProcessor;
+
 /**
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
@@ -336,6 +338,25 @@ SELECT contact_id
   public function getEntityAliasField() {
     CRM_Core_Error::deprecatedFunctionWarning('function should be overridden');
     return $this::$entityShortname . '_id';
+  }
+
+  /**
+   * List available tokens for this form.
+   *
+   * @return array
+   */
+  public function listTokens() {
+    $tokenProcessor = new TokenProcessor(Civi::dispatcher(), ['schema' => $this->getTokenSchema()]);
+    return $tokenProcessor->listTokens();
+  }
+
+  /**
+   * Get the token processor schema required to list any tokens for this task.
+   *
+   * @return array
+   */
+  protected function getTokenSchema(): array {
+    return ['contactId'];
   }
 
 }

--- a/CRM/Event/Form/Task/PDF.php
+++ b/CRM/Event/Form/Task/PDF.php
@@ -48,21 +48,7 @@ class CRM_Event_Form_Task_PDF extends CRM_Event_Form_Task {
   public function preProcess() {
     $this->preProcessPDF();
     parent::preProcess();
-
-    // we have all the participant ids, so now we get the contact ids
-    parent::setContactIDs();
-
     $this->assign('single', $this->_single);
-  }
-
-  /**
-   * List available tokens for this form.
-   *
-   * @return array
-   */
-  public function listTokens() {
-    $tokens = CRM_Core_SelectValues::contactTokens();
-    return $tokens;
   }
 
 }

--- a/CRM/Event/ParticipantTokens.php
+++ b/CRM/Event/ParticipantTokens.php
@@ -10,6 +10,7 @@
  +--------------------------------------------------------------------+
  */
 
+use Civi\Token\Event\TokenValueEvent;
 use Civi\Token\TokenRow;
 
 /**
@@ -40,6 +41,21 @@ class CRM_Event_ParticipantTokens extends CRM_Core_EntityTokens {
    */
   public function getCurrencyFieldName(): array {
     return ['fee_currency'];
+  }
+
+  /**
+   * To handle variable tokens, override this function and return the active tokens.
+   *
+   * @param \Civi\Token\Event\TokenValueEvent $e
+   *
+   * @return mixed
+   */
+  public function getActiveTokens(TokenValueEvent $e) {
+    $messageTokens = $e->getTokenProcessor()->getMessageTokens();
+    if (!isset($messageTokens[$this->entity])) {
+      return isset($messageTokens['event']) ? ['event_id'] : FALSE;
+    }
+    return parent::getActiveTokens($e);
   }
 
   /**

--- a/CRM/Member/Form/Task.php
+++ b/CRM/Member/Form/Task.php
@@ -95,4 +95,13 @@ class CRM_Member_Form_Task extends CRM_Core_Form_Task {
     );
   }
 
+  /**
+   * Get the token processor schema required to list any tokens for this task.
+   *
+   * @return array
+   */
+  public function getTokenSchema(): array {
+    return ['membershipId', 'contactId'];
+  }
+
 }

--- a/CRM/Member/Form/Task/PDFLetter.php
+++ b/CRM/Member/Form/Task/PDFLetter.php
@@ -137,4 +137,13 @@ class CRM_Member_Form_Task_PDFLetter extends CRM_Member_Form_Task {
     return $html;
   }
 
+  /**
+   * Get the token processor schema required to list any tokens for this task.
+   *
+   * @return array
+   */
+  public function getTokenSchema(): array {
+    return ['membershipId', 'contactId'];
+  }
+
 }

--- a/CRM/Member/Form/Task/PDFLetter.php
+++ b/CRM/Member/Form/Task/PDFLetter.php
@@ -137,15 +137,4 @@ class CRM_Member_Form_Task_PDFLetter extends CRM_Member_Form_Task {
     return $html;
   }
 
-  /**
-   * List available tokens for this form.
-   *
-   * @return array
-   */
-  public function listTokens() {
-    $tokens = CRM_Core_SelectValues::contactTokens();
-    $tokens = array_merge(CRM_Core_SelectValues::membershipTokens(), $tokens);
-    return $tokens;
-  }
-
 }

--- a/Civi/Token/TokenRow.php
+++ b/Civi/Token/TokenRow.php
@@ -174,8 +174,8 @@ class TokenRow {
    * @return TokenRow
    */
   public function customToken($entity, $customFieldID, $entityID) {
-    $customFieldName = "custom_" . $customFieldID;
-    $record = civicrm_api3($entity, "getSingle", [
+    $customFieldName = 'custom_' . $customFieldID;
+    $record = civicrm_api3($entity, 'getSingle', [
       'return' => $customFieldName,
       'id' => $entityID,
     ]);
@@ -183,7 +183,7 @@ class TokenRow {
 
     // format the raw custom field value into proper display value
     if (isset($fieldValue)) {
-      $fieldValue = \CRM_Core_BAO_CustomField::displayValue($fieldValue, $customFieldID);
+      $fieldValue = (string) \CRM_Core_BAO_CustomField::displayValue($fieldValue, $customFieldID);
     }
 
     return $this->format('text/html')->tokens($entity, $customFieldName, $fieldValue);


### PR DESCRIPTION
Overview
----------------------------------------
Add participant tokens to pdf task

Before
----------------------------------------
Only contact tokens available in pdf letter task

After
----------------------------------------
contact, domain, participant tokens available

Technical Details
----------------------------------------
I've got this working - but I'm gonna try to break it down a bit into some more PRs just to convince myself all the parts are correct. 

Comments
----------------------------------------
@demeritcowboy this is on the pdf side - but the email side would wind up similar with the only difference being that I think on the email side we would have to check for enitty -specific tokens & if none then group by the contact id - ie  2 emails for a 2 contributions doesn't make sense if all the fields are identical.