### PR TITLE
Standardise listTokens in email & pdf taskes

### DIFF
--- a/CRM/Activity/Form/Task.php
+++ b/CRM/Activity/Form/Task.php
@@ -127,4 +127,13 @@ WHERE  activity_id IN ( $IDs ) AND
     ]);
   }
 
+  /**
+   * Get the token processor schema required to list any tokens for this task.
+   *
+   * @return array
+   */
+  public function getTokenSchema(): array {
+    return ['activityId'];
+  }
+
 }

--- a/CRM/Activity/Form/Task/PDF.php
+++ b/CRM/Activity/Form/Task/PDF.php
@@ -57,15 +57,6 @@ class CRM_Activity_Form_Task_PDF extends CRM_Activity_Form_Task {
   }
 
   /**
-   * List available tokens for this form.
-   *
-   * @return array
-   */
-  public function listTokens() {
-    return $this->createTokenProcessor()->listTokens();
-  }
-
-  /**
    * Create a token processor
    *
    * @return \Civi\Token\TokenProcessor

--- a/CRM/Contribute/Form/Task.php
+++ b/CRM/Contribute/Form/Task.php
@@ -104,4 +104,13 @@ class CRM_Contribute_Form_Task extends CRM_Core_Form_Task {
     ]);
   }
 
+  /**
+   * Get the token processor schema required to list any tokens for this task.
+   *
+   * @return array
+   */
+  public function getTokenSchema(): array {
+    return ['contributionId', 'contactId'];
+  }
+
 }

--- a/CRM/Contribute/Form/Task/Email.php
+++ b/CRM/Contribute/Form/Task/Email.php
@@ -32,15 +32,4 @@ class CRM_Contribute_Form_Task_Email extends CRM_Contribute_Form_Task {
     return $this->getIDs();
   }
 
-  /**
-   * List available tokens for this form.
-   *
-   * @return array
-   */
-  public function listTokens() {
-    $tokens = CRM_Core_SelectValues::contactTokens();
-    $tokens = array_merge(CRM_Core_SelectValues::contributionTokens(), $tokens);
-    return $tokens;
-  }
-
 }

--- a/CRM/Contribute/Form/Task/PDFLetter.php
+++ b/CRM/Contribute/Form/Task/PDFLetter.php
@@ -293,15 +293,12 @@ class CRM_Contribute_Form_Task_PDFLetter extends CRM_Contribute_Form_Task {
   }
 
   /**
-   * List available tokens for this form.
+   * Get the token processor schema required to list any tokens for this task.
    *
    * @return array
    */
-  public function listTokens() {
-    $tokens = CRM_Core_SelectValues::contactTokens();
-    $tokens = array_merge(CRM_Core_SelectValues::contributionTokens(), $tokens);
-    $tokens = array_merge(CRM_Core_SelectValues::domainTokens(), $tokens);
-    return $tokens;
+  public function getTokenSchema(): array {
+    return ['contributionId', 'contactId'];
   }
 
   /**

--- a/CRM/Core/Form/Task.php
+++ b/CRM/Core/Form/Task.php
@@ -9,6 +9,8 @@
  +--------------------------------------------------------------------+
  */
 
+use Civi\Token\TokenProcessor;
+
 /**
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
@@ -336,6 +338,25 @@ SELECT contact_id
   public function getEntityAliasField() {
     CRM_Core_Error::deprecatedFunctionWarning('function should be overridden');
     return $this::$entityShortname . '_id';
+  }
+
+  /**
+   * List available tokens for this form.
+   *
+   * @return array
+   */
+  public function listTokens() {
+    $tokenProcessor = new TokenProcessor(Civi::dispatcher(), ['schema' => $this->getTokenSchema()]);
+    return $tokenProcessor->listTokens();
+  }
+
+  /**
+   * Get the token processor schema required to list any tokens for this task.
+   *
+   * @return array
+   */
+  protected function getTokenSchema(): array {
+    return ['contactId'];
   }
 
 }

--- a/CRM/Member/Form/Task.php
+++ b/CRM/Member/Form/Task.php
@@ -95,4 +95,13 @@ class CRM_Member_Form_Task extends CRM_Core_Form_Task {
     );
   }
 
+  /**
+   * Get the token processor schema required to list any tokens for this task.
+   *
+   * @return array
+   */
+  public function getTokenSchema(): array {
+    return ['membershipId', 'contactId'];
+  }
+
 }

--- a/CRM/Member/Form/Task/PDFLetter.php
+++ b/CRM/Member/Form/Task/PDFLetter.php
@@ -137,15 +137,4 @@ class CRM_Member_Form_Task_PDFLetter extends CRM_Member_Form_Task {
     return $html;
   }
 
-  /**
-   * List available tokens for this form.
-   *
-   * @return array
-   */
-  public function listTokens() {
-    $tokens = CRM_Core_SelectValues::contactTokens();
-    $tokens = array_merge(CRM_Core_SelectValues::membershipTokens(), $tokens);
-    return $tokens;
-  }
-
 }


### PR DESCRIPTION
Overview
----------------------------------------
This simplifies the code to 'listtokens' across most of the pdf & email classes.

It has the side effect of exposing domain tokens consistently (good)

Before
----------------------------------------
Variety is the spice of life

After
----------------------------------------
Bor-ring - all forms do it the same way .... almost.

Technical Details
----------------------------------------
The case tokens are a bit of a hold out as ideally we would have
one function on CRM_Case_Form_Task which email & pdf would use
but we are still getting to that point - see
https://github.com/civicrm/civicrm-core/pull/21688

Comments
----------------------------------------
