### PR TITLE
CiviCRM APIv3, Improve API Exception error message when trying to subscribe to a non-Public Mailing Group

### DIFF
--- a/api/v3/MailingEventSubscribe.php
+++ b/api/v3/MailingEventSubscribe.php
@@ -38,6 +38,10 @@ function civicrm_api3_mailing_event_subscribe_create($params) {
     throw new API_Exception('Invalid Group id');
   }
 
+  if (substr($group->visibility, 0, 6) != 'Public') {
+    throw new API_Exception('Group is not Public. Contact cannot be subscribed to this Group.');
+  }
+
   $subscribe = CRM_Mailing_Event_BAO_Subscribe::subscribe($group_id, $email, $contact_id);
 
   if ($subscribe !== NULL) {


### PR DESCRIPTION
Overview
----------------------------------------
CiviCRM APIv3, Improve API Exception error message when trying to subscribe to a non-Public Mailing Group

Before
----------------------------------------
If the Mailing Group, has Visibility set to "User and User Admin Only" then the Contact cannot be subscribed to the Mailing Group and the API returns a vague error_message: "Subscription failed"

After
----------------------------------------
If the Mailing Group, has Visibility set to "User and User Admin Only" then the Contact cannot be subscribed to the Mailing Group and the API returns a more descriptive error_message": "Group is not Public. Users cannot be subscribed to this Group."

Technical Details
----------------------------------------
Copies same check which is performed at BAO which may now be redundant.
I tried searching for a similar method in APIv4 but couldn't find it. Happy to update the PR if someone can point out where where the Mailing Event Subscribe action is in APIv4.

Comments
----------------------------------------
Descriptive error messages reduce time to debug and keep developers smiling.

Agileware Ref: CIVICRM-1858
