### PR TITLE
message_admin - Add titles/hints to hyperlinks

### DIFF
--- a/ext/message_admin/ang/crmMsgadm/WorkflowTranslated.html
+++ b/ext/message_admin/ang/crmMsgadm/WorkflowTranslated.html
@@ -24,23 +24,23 @@
       <td>{{record.tx_language_label || ts('Standard')}}</td>
       <td>
         <span ng-if="!record.tx_language || !!record.tx_statuses.active">
-          <a class="text-success" crm-icon="fa-file-text" ng-href="{{$ctrl.editUrl(record)}}">{{ts('Current')}}</a>
+          <a class="text-success" crm-icon="fa-file-text" title="{{ts('Edit current revision, &quot;%1&quot;, &quot;%2&quot;', {1: record.msg_title, 2: record.tx_language_label || ts('Standard')})}}" ng-href="{{$ctrl.editUrl(record)}}">{{ts('Current')}}</a>
         </span>
         <span ng-if="!(!record.tx_language || !!record.tx_statuses.active)">
-          <span class="text-danger" crm-icon="fa-file-text">{{ts('Current')}}</span>
+          <span class="text-danger" crm-icon="fa-file-text" title="{{ts('No current revision, &quot;%1&quot;, &quot;%2&quot;', {1: record.msg_title, 2: record.tx_language_label || ts('Standard')})}}">{{ts('Current')}}</span>
         </span>
       </td>
       <td>
         <span ng-if="!!record.tx_statuses.draft">
-          <a class="text-warning" crm-icon="fa-file-text-o" ng-href="{{$ctrl.editUrl(record, 'draft')}}">{{ts('Draft')}}</a>
+          <a class="text-warning" crm-icon="fa-file-text-o" title="{{ts('Edit draft revision, &quot;%1&quot;, &quot;%2&quot;', {1: record.msg_title, 2: record.tx_language_label || ts('Standard')})}}" ng-href="{{$ctrl.editUrl(record, 'draft')}}">{{ts('Draft')}}</a>
         </span>
         <span ng-if="!record.tx_statuses.draft">
-          <span class="text-muted" crm-icon="fa-file-text-o">{{ts('Draft')}}</span>
+          <span class="text-muted" crm-icon="fa-file-text-o" title="{{ts('No draft revision, &quot;%1&quot;, &quot;%2&quot;', {1: record.msg_title, 2: record.tx_language_label || ts('Standard')})}}">{{ts('Draft')}}</span>
         </span>
       </td>
       <td>
         <span ng-if="!record.tx_language">
-          <a class="" crm-icon="fa-plus" ng-click="$ctrl.addTranslation(record)">{{ts('Translate')}}</a>
+          <a class="" crm-icon="fa-plus" ng-click="$ctrl.addTranslation(record)" title="{{ts('Add translation, &quot;%1&quot;', {1: record.msg_title})}}">{{ts('Translate')}}</a>
         </span>
       </td>
     </tr>


### PR DESCRIPTION
Overview
----------------------------------------

Small usability tweak. When mousing through the long list of buttons, it's hard to be  sure that your pointer is on the right row.

Before
----------------------------------------

Wall of links

After
----------------------------------------

Wall of links, with help:

<img width="1067" alt="Screen Shot 2021-10-01 at 5 06 48 PM" src="https://user-images.githubusercontent.com/1336047/135697344-27879805-e40f-4889-8ac7-dd5275eaf675.png">

