### PR TITLE
CiviCRM, removing an extension from the file system before it is disabled and uninstalled causes infinite session status error messages to be shown to all CiviCRM admins, which cannot be dismissed.

### DIFF
--- a/CRM/Extension/Container/Collection.php
+++ b/CRM/Extension/Container/Collection.php
@@ -106,7 +106,13 @@ class CRM_Extension_Container_Collection implements CRM_Extension_Container_Inte
    * @throws \CRM_Extension_Exception_MissingException
    */
   public function getPath($key) {
-    return $this->getContainer($key)->getPath($key);
+    try {
+      return $this->getContainer($key)->getPath($key);
+    }
+    catch (CRM_Extension_Exception_MissingException $e) {
+      // This could happen if there was a dirty removal (i.e. deleting ext-code before uninstalling).
+      return;
+    }
   }
 
   /**

--- a/CRM/Extension/Mapper.php
+++ b/CRM/Extension/Mapper.php
@@ -362,7 +362,8 @@ class CRM_Extension_Mapper {
           $urls[$module->name] = $this->keyToUrl($module->name);
         }
         catch (CRM_Extension_Exception_MissingException $e) {
-          CRM_Core_Session::setStatus(ts('An enabled extension is missing from the extensions directory') . ':' . $module->name);
+          // This could happen if there was a dirty removal (i.e. deleting ext-code before uninstalling).
+          continue;
         }
       }
     }

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -312,10 +312,7 @@ abstract class CRM_Utils_Hook {
     $civiModules = CRM_Core_PseudoConstant::getModuleExtensions();
     foreach ($civiModules as $civiModule) {
       if (!file_exists($civiModule['filePath'])) {
-        CRM_Core_Session::setStatus(
-          ts('Error loading module file (%1). Please restore the file or disable the module.',
-            [1 => $civiModule['filePath']]),
-          ts('Warning'), 'error');
+        // This could happen if there was a dirty removal (i.e. deleting ext-code before uninstalling).
         continue;
       }
       include_once $civiModule['filePath'];


### PR DESCRIPTION
Overview
----------------------------------------
CiviCRM, removing an extension from the file system before it is disabled and uninstalled causes infinite session status error messages to be shown to all CiviCRM admins, which cannot be dismissed.

Before
----------------------------------------
Remove an extension from the file system before it is disabled and uninstalled. The following screenshots demonstrates what a CiviCRM admin user will experience, where-ever they go in CiviCRM. Clicking the **Dismiss (X)** button on the notification does not stop the notification reappearing. It will just pop-up again on the next screen.

![Screenshot_20211002_104557](https://user-images.githubusercontent.com/58866555/135698528-7c725067-ae29-4787-8bbf-67b4942cfe0a.png)

![Screenshot_20211002_104633](https://user-images.githubusercontent.com/58866555/135698547-0e10bf3c-1737-4822-a33d-ad58b0a4d8e5.png)

![Screenshot_20211002_104700](https://user-images.githubusercontent.com/58866555/135698554-016b7d3b-6317-483c-9175-f1f097385d88.png)

![Screenshot_20211002_104727](https://user-images.githubusercontent.com/58866555/135698564-60e8432b-7a62-4989-80a3-da9432eb75ff.png)

![Screenshot_20211002_104836](https://user-images.githubusercontent.com/58866555/135698598-842e94c1-53a8-4b4f-9b82-2fd84440e699.png)

After
----------------------------------------
Remove an extension from the file system before it is disabled and uninstalled. The Extension Missing status is shown on the Extensions page. **No more** session status alerts on every single page, for each extension which cannot be dismissed. Sanity is restored.

![Screenshot_20211002_105020](https://user-images.githubusercontent.com/58866555/135698692-8594ee47-9a32-457a-8789-4235728e3c92.png)

Technical Details
----------------------------------------

Comments
----------------------------------------
This type of overzealous alerting does not help in anyway. Happy to accept feedback on other ways to reduce alerts to one single, dismissable alert if this is not the correct approach.

Agileware Ref: CIVICRM-1859
