### PR TITLE
message_admin - Fix quirk when using "Create Draft"

### DIFF
--- a/ang/crmMonaco.js
+++ b/ang/crmMonaco.js
@@ -65,6 +65,12 @@
             // FIXME: else: retry?
           };
 
+          if ($attr.ngDisabled) {
+            $scope.$watch($parse($attr.ngDisabled), function(disabled){
+              editor.updateOptions({readOnly: disabled});
+            });
+          }
+
           // FIXME: This makes vertical scrolling much better, but horizontal is still weird.
           var origOverflow;
           function bodyScrollSuspend() {

--- a/ext/message_admin/ang/crmMsgadm/Edit.html
+++ b/ext/message_admin/ang/crmMsgadm/Edit.html
@@ -67,7 +67,7 @@
         </ul>
       </div>
       <div class="panel-body" ng-hide="$ctrl.loading">
-        <crm-msgadm-edit-content options="{record: $ctrl.records[$ctrl.tab], disabled: ($ctrl.tab==='original')}" token-list="$ctrl.tokenList"></crm-msgadm-edit-content>
+        <crm-msgadm-edit-content options="{record: $ctrl.records[$ctrl.tab]}" token-list="$ctrl.tokenList" disabled="$ctrl.tab==='original'"></crm-msgadm-edit-content>
       </div>
     </div>
 

--- a/ext/message_admin/ang/crmMsgadm/Edit.html
+++ b/ext/message_admin/ang/crmMsgadm/Edit.html
@@ -66,9 +66,8 @@
           </li>
         </ul>
       </div>
-      <div class="panel-body">
-        <crm-msgadm-edit-content options="{record: $ctrl.records[$ctrl.tab], tokenList: $ctrl.tokenList, disabled: true}" ng-if="$ctrl.tab==='original'"></crm-msgadm-edit-content>
-        <crm-msgadm-edit-content options="{record: $ctrl.records[$ctrl.tab], tokenList: $ctrl.tokenList}" ng-if="$ctrl.tab!=='original'"></crm-msgadm-edit-content>
+      <div class="panel-body" ng-hide="$ctrl.loading">
+        <crm-msgadm-edit-content options="{record: $ctrl.records[$ctrl.tab], disabled: ($ctrl.tab==='original')}" token-list="$ctrl.tokenList"></crm-msgadm-edit-content>
       </div>
     </div>
 

--- a/ext/message_admin/ang/crmMsgadm/Edit.html
+++ b/ext/message_admin/ang/crmMsgadm/Edit.html
@@ -67,7 +67,7 @@
         </ul>
       </div>
       <div class="panel-body" ng-hide="$ctrl.loading">
-        <crm-msgadm-edit-content options="{record: $ctrl.records[$ctrl.tab]}" token-list="$ctrl.tokenList" disabled="$ctrl.tab==='original'"></crm-msgadm-edit-content>
+        <crm-msgadm-edit-content msgtpl="$ctrl.records[$ctrl.tab]" token-list="$ctrl.tokenList" disabled="$ctrl.tab==='original'"></crm-msgadm-edit-content>
       </div>
     </div>
 

--- a/ext/message_admin/ang/crmMsgadm/EditContent.html
+++ b/ext/message_admin/ang/crmMsgadm/EditContent.html
@@ -15,7 +15,7 @@
       <div class="clearfix"></div>
     </div>
     <div class="panel-body" uib-collapse="!accordions.msg_subject">
-      <div ng-model="$ctrl.options.record.msg_subject"
+      <div ng-model="$ctrl.msgtpl.msg_subject"
            crm-monaco="$ctrl.monacoOptions({language: 'smarty', crmHeightPct: 0.15})"
            crm-monaco-insert-rx="insert:msg_subject"
            ng-disabled="$ctrl.isDisabled()"
@@ -45,7 +45,7 @@
       <div class="clearfix"></div>
     </div>
     <div class="panel-body" uib-collapse="!accordions.msg_html">
-      <div ng-model="$ctrl.options.record.msg_html"
+      <div ng-model="$ctrl.msgtpl.msg_html"
            crm-monaco="$ctrl.monacoOptions({language: 'html', crmHeightPct: 0.5})"
            crm-monaco-insert-rx="insert:msg_html"
            ng-disabled="$ctrl.isDisabled()"
@@ -74,7 +74,7 @@
       <div class="clearfix"></div>
     </div>
     <div class="panel-body" uib-collapse="!accordions.msg_text">
-      <div ng-model="$ctrl.options.record.msg_text"
+      <div ng-model="$ctrl.msgtpl.msg_text"
            crm-monaco="$ctrl.monacoOptions({language: 'smarty', crmHeightPct: 0.5})"
            crm-monaco-insert-rx="insert:msg_text"
            ng-disabled="$ctrl.isDisabled()"

--- a/ext/message_admin/ang/crmMsgadm/EditContent.html
+++ b/ext/message_admin/ang/crmMsgadm/EditContent.html
@@ -8,7 +8,7 @@
       <input class="form-control pull-right crm-action-menu fa-code"
              tabindex="-1"
              style="z-index:1"
-             crm-ui-select="{placeholder: ts('Token'), data: $ctrl.options.tokenList, width: '12em', dropdownAutoWidth: true}"
+             crm-ui-select="{placeholder: ts('Token'), data: $ctrl.tokenList, width: '12em', dropdownAutoWidth: true}"
              on-crm-ui-select="$broadcast('insert:msg_subject', selection)"
              ng-show="accordions.msg_subject && !$ctrl.isDisabled()"
       />
@@ -30,7 +30,7 @@
       <input class="form-control pull-right crm-action-menu fa-code"
              tabindex="-1"
              style="z-index:1"
-             crm-ui-select="{placeholder: ts('Token'), data: $ctrl.options.tokenList, width: '12em', dropdownAutoWidth: true}"
+             crm-ui-select="{placeholder: ts('Token'), data: $ctrl.tokenList, width: '12em', dropdownAutoWidth: true}"
              on-crm-ui-select="$broadcast('insert:msg_html', selection)"
              ng-show="accordions.msg_html && !$ctrl.isDisabled()"
       />
@@ -59,7 +59,7 @@
       <input class="form-control pull-right crm-action-menu fa-code"
              tabindex="-1"
              style="z-index:1"
-             crm-ui-select="{placeholder: ts('Token'), data: $ctrl.options.tokenList, width: '12em', dropdownAutoWidth: true}"
+             crm-ui-select="{placeholder: ts('Token'), data: $ctrl.tokenList, width: '12em', dropdownAutoWidth: true}"
              on-crm-ui-select="$broadcast('insert:msg_text', selection)"
              ng-show="accordions.msg_text && !$ctrl.isDisabled()"
       />

--- a/ext/message_admin/ang/crmMsgadm/EditContent.html
+++ b/ext/message_admin/ang/crmMsgadm/EditContent.html
@@ -18,6 +18,7 @@
       <div ng-model="$ctrl.options.record.msg_subject"
            crm-monaco="$ctrl.monacoOptions({language: 'smarty', crmHeightPct: 0.15})"
            crm-monaco-insert-rx="insert:msg_subject"
+           ng-disabled="$ctrl.isDisabled()"
       ></div>
       <p class="help-block">{{::ts('The email subject is a single line. However, template codes may use multiple lines.')}}</p>
     </div>
@@ -47,6 +48,7 @@
       <div ng-model="$ctrl.options.record.msg_html"
            crm-monaco="$ctrl.monacoOptions({language: 'html', crmHeightPct: 0.5})"
            crm-monaco-insert-rx="insert:msg_html"
+           ng-disabled="$ctrl.isDisabled()"
       ></div>
     </div>
   </div>
@@ -75,6 +77,7 @@
       <div ng-model="$ctrl.options.record.msg_text"
            crm-monaco="$ctrl.monacoOptions({language: 'smarty', crmHeightPct: 0.5})"
            crm-monaco-insert-rx="insert:msg_text"
+           ng-disabled="$ctrl.isDisabled()"
       ></div>
     </div>
   </div>

--- a/ext/message_admin/ang/crmMsgadm/EditContent.js
+++ b/ext/message_admin/ang/crmMsgadm/EditContent.js
@@ -2,6 +2,7 @@
   angular.module('crmMsgadm').component('crmMsgadmEditContent', {
     bindings: {
       onPreview: '&',
+      tokenList: '<',
       options: '='
     },
     templateUrl: '~/crmMsgadm/EditContent.html',
@@ -31,7 +32,7 @@
           },
           record: $ctrl.options.record,
           field: fld,
-          tokenList: $ctrl.options.tokenList
+          tokenList: $ctrl.tokenList
         };
         var options = CRM.utils.adjustDialogDefaults({
           // show: {effect: 'slideDown'},

--- a/ext/message_admin/ang/crmMsgadm/EditContent.js
+++ b/ext/message_admin/ang/crmMsgadm/EditContent.js
@@ -15,7 +15,6 @@
 
       $ctrl.monacoOptions = function (opts) {
         return angular.extend({}, {
-          readOnly: $ctrl.isDisabled(),
           wordWrap: 'wordWrapColumn',
           wordWrapColumn: 100,
           wordWrapMinified: false,

--- a/ext/message_admin/ang/crmMsgadm/EditContent.js
+++ b/ext/message_admin/ang/crmMsgadm/EditContent.js
@@ -3,6 +3,7 @@
     bindings: {
       onPreview: '&',
       tokenList: '<',
+      disabled: '<',
       options: '='
     },
     templateUrl: '~/crmMsgadm/EditContent.html',
@@ -11,7 +12,7 @@
       var $ctrl = this;
 
       $ctrl.isDisabled = function() {
-        return $ctrl.options.disabled;
+        return $ctrl.disabled;
       };
 
       $ctrl.monacoOptions = function (opts) {

--- a/ext/message_admin/ang/crmMsgadm/EditContent.js
+++ b/ext/message_admin/ang/crmMsgadm/EditContent.js
@@ -4,7 +4,7 @@
       onPreview: '&',
       tokenList: '<',
       disabled: '<',
-      options: '='
+      msgtpl: '='
     },
     templateUrl: '~/crmMsgadm/EditContent.html',
     controller: function ($scope, $element, crmStatus, crmUiAlert, dialogService, $rootScope) {
@@ -31,7 +31,7 @@
           openPreview: function(options) {
             return $ctrl.openPreview(options);
           },
-          record: $ctrl.options.record,
+          record: $ctrl.msgtpl,
           field: fld,
           tokenList: $ctrl.tokenList
         };


### PR DESCRIPTION
Overview
----------------------------------------

In `message_admin` extension, there is a quirk when creating a new draft of a translated message.  This fixes it.

Steps to reproduce
----------------------------------------

(*Steps performed in Firefox 92*)

* Enable `message_admin`
* Navigate to "Admin => Comm => Message Templates => System Workflow Messages"
* Pick a template and add a new "Translation"
* In this new translation, click "Create draft"
* Edit the subject line (eg add new text at the end - or double-click a word and delete it)

Before
----------------------------------------

As soon as you start typing (eg ~300ms later), the content resets. Your initial changes are applied off-screen to the "Current" revision, and the screen redraws to show the (previous/unedited) "Draft" revision. 

(After that happens, editing is normal. You can flip back/forth between tabs+fields as expected.)

After
----------------------------------------

Works from the get-go.

Technical Details
----------------------------------------

The problem seems to involve the manner in which changes propagate between the Angular parts (ie `MsgtpluiEdit` <=> `crmMsgadmEditContent` <=> `crmMosaico`). (1) I hacked `copyTranslations()` (`dest[fld] = 'copy: ' + src[fld]`) -- propagating this extra data-change caused things to work intuitively. (2) While hacking around in other ways, I sometimes noticed warnings about non-assignability that touched on the `options` for `crmMsgadmEditContent`.

It seems to involve a quirk around how the bidirectional `bindings:{options:'='}` works. The patch decomposes `options` so that it doesn't lean as heavily on deep+bidir `options`.

Comments
----------------------------------------

The original problem is a bit quirky and doesn't always reproduce. I *think* that it makes a difference that you're working on a draft of a *new* translation. But I haven' strictly determined that. However, it was quite reproducible while I was developing this patch. It may not be worthwhile for a reviewer to reproduce the original problem. The main question would be whether the change seems regressive in any way.