### PR TITLE
[wip]dev/core#2814 Switch last core place from replaceContactTokens to the tokenProcessor

### DIFF
--- a/CRM/Contact/Tokens.php
+++ b/CRM/Contact/Tokens.php
@@ -303,6 +303,9 @@ class CRM_Contact_Tokens extends CRM_Core_EntityTokens {
       if (empty($row->context['contact'])) {
         $row->context['contact'] = $this->getContact($row->context['contactId'], $messageTokens);
       }
+      if (empty($row->context['contactId'])) {
+        $row->context['contactId'] = $row->context['contact']['id'];
+      }
 
       foreach ($messageTokens as $token) {
         if ($token === 'checksum') {
@@ -330,8 +333,7 @@ class CRM_Contact_Tokens extends CRM_Core_EntityTokens {
           $row->format('text/html')->tokens('contact', $token, html_entity_decode($row->context['contact'][$token]));
         }
         else {
-          $row->format('text/html')
-            ->tokens('contact', $token, $this->getFieldValue($row, $token));
+          parent::evaluateToken($row, 'contact', $token, [$row->context['contactId'] => $row->context['contact']]);
         }
       }
     }

--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -9,6 +9,8 @@
  +--------------------------------------------------------------------+
  */
 
+use Civi\Token\TokenProcessor;
+
 /**
  *
  * @package CRM
@@ -592,6 +594,8 @@ class CRM_Utils_Token {
    * @param bool $returnBlankToken
    *   Return unevaluated token if value is null.
    *
+   * @deprecated
+   *
    * @param bool $escapeSmarty
    *
    * @return string
@@ -634,6 +638,13 @@ class CRM_Utils_Token {
   }
 
   /**
+   * Do Not use.
+   *
+   * Only core usage is from a deprecated unused function and
+   * from deprecated BAO_Mailing code (to be replaced by flexmailer).
+   *
+   * @deprecated
+   *
    * @param $token
    * @param $contact
    * @param bool $html
@@ -718,8 +729,12 @@ class CRM_Utils_Token {
   }
 
   /**
+   * Do not use - unused in core.
+   *
    * Replace all the hook tokens in $str with information from
    * $contact.
+   *
+   * @deprecated
    *
    * @param string $str
    *   The string with tokens to be replaced.
@@ -790,6 +805,10 @@ class CRM_Utils_Token {
   }
 
   /**
+   * Do not use, unused in core.
+   *
+   * @deprecated
+   *
    * @param $token
    * @param $contact
    * @param $category
@@ -1303,9 +1322,6 @@ class CRM_Utils_Token {
    *
    * @TODO Remove that inconsistency in usage.
    *
-   * ::replaceContactTokens() may need to be called after this method, to
-   * replace tokens supplied from this method.
-   *
    * @param string $tokenString
    * @param array $contactDetails
    * @param int $contactId
@@ -1317,72 +1333,24 @@ class CRM_Utils_Token {
     if (!$contactDetails && !$contactId) {
       return;
     }
-
     // check if there are any tokens
     $greetingTokens = self::getTokens($tokenString);
-
-    if (!empty($greetingTokens)) {
-      // first use the existing contact object for token replacement
-      if (!empty($contactDetails)) {
-        $tokenString = CRM_Utils_Token::replaceContactTokens($tokenString, $contactDetails, TRUE, $greetingTokens, TRUE, $escapeSmarty);
+    $context = $contactId ? ['contactId' => $contactId] : [];
+    if ($contactDetails) {
+      foreach ($contactDetails[0] as $contact) {
+        // Only 1 - the loop is because we may not know the id.
+        $context['contact'] = $contact;
       }
-
-      self::removeNullContactTokens($tokenString, $contactDetails, $greetingTokens);
-      // check if there are any unevaluated tokens
-      $greetingTokens = self::getTokens($tokenString);
-
-      // $greetingTokens not empty, means there are few tokens which are not
-      // evaluated, like custom data etc
-      // so retrieve it from database
-      if (!empty($greetingTokens) && array_key_exists('contact', $greetingTokens)) {
-        $greetingsReturnProperties = array_flip(CRM_Utils_Array::value('contact', $greetingTokens));
-        $greetingsReturnProperties = array_fill_keys(array_keys($greetingsReturnProperties), 1);
-        $contactParams = ['contact_id' => $contactId];
-
-        $greetingDetails = self::getTokenDetails($contactParams,
-          $greetingsReturnProperties,
-          FALSE, FALSE, NULL,
-          $greetingTokens,
-          $className
-        );
-
-        // again replace tokens
-        $tokenString = CRM_Utils_Token::replaceContactTokens($tokenString,
-          $greetingDetails,
-          TRUE,
-          $greetingTokens,
-          TRUE,
-          $escapeSmarty
-        );
-      }
-
-      // check if there are still any unevaluated tokens
-      $remainingTokens = self::getTokens($tokenString);
-
-      // $greetingTokens not empty, there are customized or hook tokens to replace
-      if (!empty($remainingTokens)) {
-        // Fill the return properties array
-        $greetingTokens = $remainingTokens;
-        reset($greetingTokens);
-        $greetingsReturnProperties = [];
-        foreach ($greetingTokens as $value) {
-          $props = array_flip($value);
-          $props = array_fill_keys(array_keys($props), 1);
-          $greetingsReturnProperties = $greetingsReturnProperties + $props;
-        }
-        $contactParams = ['contact_id' => $contactId];
-        $greetingDetails = self::getTokenDetails($contactParams,
-          $greetingsReturnProperties,
-          FALSE, FALSE, NULL,
-          $greetingTokens,
-          $className
-        );
-        // Prepare variables for calling replaceHookTokens
-        $categories = array_keys($greetingTokens);
-        [$contact] = $greetingDetails;
-        // Replace tokens defined in Hooks.
-        $tokenString = CRM_Utils_Token::replaceHookTokens($tokenString, $contact[$contactId], $categories);
-      }
+    }
+    $tokenProcessor = new TokenProcessor(\Civi::dispatcher(), [
+      'smarty' => FALSE,
+      'class' => $className,
+    ]);
+    $tokenProcessor->addRow($context);
+    $tokenProcessor->addMessage('greeting', $tokenString, 'text/plain');
+    $tokenProcessor->evaluate();
+    foreach ($tokenProcessor->getRows() as $row) {
+      $tokenString = $row->render('greeting');
     }
   }
 
@@ -1390,6 +1358,8 @@ class CRM_Utils_Token {
    * At this point, $contactDetails has loaded the contact from the DAO. Any
    * (non-custom) missing fields are null.  By removing them, we can avoid
    * expensive calls to CRM_Contact_BAO_Query.
+   *
+   * @deprecated unused in core
    *
    * @param string $tokenString
    * @param array $contactDetails
@@ -1862,6 +1832,10 @@ class CRM_Utils_Token {
   }
 
   /**
+   * @deprecated
+   *
+   * Only used from deprecated functions not called by core.
+   *
    * @return array
    *   [legacy_token => new_token]
    */


### PR DESCRIPTION
Overview
----------------------------------------
Switch last core place from replaceContactTokens to the tokenProcessor

Before
----------------------------------------
`CRM_Utils_Token::replaceGreetingTokens` is the last place to use `replaceContactTokens`

After
----------------------------------------
`CRM_Utils_Token::replaceGreetingTokens` calls the token processor

Technical Details
----------------------------------------
I actually intend to deprecate `CRM_Utils_Token::replaceGreetingTokens` and stop calling if from core - however I'm fixing it here first as it bubbles up the outstanding things not covered by the token processor and because it's called from outside of core - so deprecating `CRM_Utils_Token::replaceGreetingTokens` is a follow on rather than part of this PR.

By making this change I caused more tests to go through the token processor and those tests identified 2 regressions in master (obviously getting all tests to do the same thing was part of the reason for consolidating)

1) date fields - empty value being treated as 'now' not empty - spun off into https://github.com/civicrm/civicrm-core/pull/21704
2) prior to the consolidation work we did on the token compatibility layer we were using `replaceGreetingTokens` to do a 'lst pass'. This was doing two extra 'hidden' things

a) removing unresolved tokens (previously fixed)
b) replacing tokens like `{, }` - these are commonly used in greetings (and not used but would be super useful in workflow templates) - I copied the relevant line over https://github.com/civicrm/civicrm-core/compare/master...eileenmcnaughton:token4?expand=1#diff-3f93091ccbe99a7c1ae88473057539b1021099b37852cfea68ff948f9f8d1a86R66

We also had a gap where the `prefix_id:label` tokens etc were not being resolved if `contact` was passed in - the `replaceGreetingTokens` code was unusual in passing in preloaded contact info so I needed to do some fixes to get those tests to work. If this gets merged I have some thoughts about follow up cleanup

Comments
----------------------------------------
I've added upgrade script to switch from the deprecated tokens to the unambigous tokens in the email greeting etc fields. I included 'prefix_id' because that was in a test but I recall @colemanw switching to that in 4.4 only to find that it resolved inconsistenly (for the obvious reason) & switching back


Closes https://lab.civicrm.org/dev/core/-/issues/2814  - except that I want to do the extra steps to deprecate 'replaceGreetingTokens`