### PR TITLE
enotice fix

### DIFF
--- a/CRM/Upgrade/Page/Upgrade.php
+++ b/CRM/Upgrade/Page/Upgrade.php
@@ -74,7 +74,7 @@ class CRM_Upgrade_Page_Upgrade extends CRM_Core_Page {
     $upgrade = new CRM_Upgrade_Form();
     $template = CRM_Core_Smarty::singleton();
     list($currentVer, $latestVer) = $upgrade->getUpgradeVersions();
-
+    CRM_Core_Smarty::singleton()->assign('sid', CRM_Utils_System::getSiteID());
     // Show success msg if db already upgraded
     if (version_compare($currentVer, $latestVer) == 0) {
       $template->assign('upgraded', TRUE);
@@ -188,7 +188,6 @@ class CRM_Upgrade_Page_Upgrade extends CRM_Core_Page {
 
     $template->assign('message', $postUpgradeMessage);
     $template->assign('upgraded', TRUE);
-    $template->assign('sid', CRM_Utils_System::getSiteID());
     $template->assign('newVersion', $latestVer);
 
     // Render page header


### PR DESCRIPTION
Overview
----------------------------------------
enotice fix

Before
----------------------------------------
2 enotices on upgrade page if site already upgraded

After
----------------------------------------
Just 1 - I wasn't sure with this one - to the right of the green tick would be info if `$message` were assigned - in the 'already upgraded there is no message - it didn't look weird until I started focussing on it

![image](https://user-images.githubusercontent.com/336308/135702982-55cdb4c0-0ab2-48a6-be1b-6e00c0dcc80f.png)

Technical Details
----------------------------------------


Comments
----------------------------------------
UPDATE - I just updated a site which DID need an upgrade without this - here is what it looks like without this patch (ie `$sid` wasn't assigned then either) - that's why squishing e-notices can be bad


![image](https://user-images.githubusercontent.com/336308/135703152-151554dc-5ee4-4b0d-b772-932c245dc539.png)

