### PR TITLE
Master only regression - fix empty token date

### DIFF
--- a/CRM/Core/EntityTokens.php
+++ b/CRM/Core/EntityTokens.php
@@ -91,7 +91,7 @@ class CRM_Core_EntityTokens extends AbstractTokenSubscriber {
     if ($this->isDateField($field)) {
       try {
         return $row->format('text/plain')
-          ->tokens($entity, $field, new DateTime($fieldValue));
+          ->tokens($entity, $field, ($fieldValue ? new DateTime($fieldValue) : $fieldValue));
       }
       catch (Exception $e) {
         Civi::log()->info('invalid date token');


### PR DESCRIPTION

Overview
----------------------------------------
Master only regression - fix empty token date

Before
----------------------------------------
Empty date field token rendering as 'now'

After
----------------------------------------
Fixes a bug where an empty date was still getting put into a DateTime object
(defaulting to now)

Technical Details
----------------------------------------

Comments
----------------------------------------
