### PR TITLE
(Alternate) Fix unreplaced template vars in civicrm.settings.php when using legacy installer

### DIFF
--- a/CRM/Upgrade/Incremental/php/FiveFortyThree.php
+++ b/CRM/Upgrade/Incremental/php/FiveFortyThree.php
@@ -44,10 +44,9 @@ class CRM_Upgrade_Incremental_php_FiveFortyThree extends CRM_Upgrade_Incremental
    *   an intermediate version; note that setPostUpgradeMessage is called repeatedly with different $revs.
    */
   public function setPostUpgradeMessage(&$postUpgradeMessage, $rev): void {
-    // Example: Generate a post-upgrade message.
-    // if ($rev == '5.12.34') {
-    //   $postUpgradeMessage .= '<br /><br />' . ts("By default, CiviCRM now disables the ability to import directly from SQL. To use this feature, you must explicitly grant permission 'import SQL datasource'.");
-    // }
+    if ($rev == '5.43.alpha1') {
+      $postUpgradeMessage .= $this->checkIfSettingsFileContainsPercentVariables();
+    }
   }
 
   /**
@@ -167,6 +166,20 @@ class CRM_Upgrade_Incremental_php_FiveFortyThree extends CRM_Upgrade_Incremental
       CRM_Core_BAO_SchemaHandler::migrateUtf8mb4(($characterSet === 'utf8mb4' ? FALSE : TRUE), ['%civicrm_relationship_cache%']);
     }
     return TRUE;
+  }
+
+  /**
+   * Depending on how it was installed the civicrm.settings.php might still
+   * have %%CMSdbSSL%% or %%dbSSL%% left unreplaced in the file.
+   * We may not (shouldn't) have write access to the file so display a message
+   * instead.
+   * @return string
+   */
+  private function checkIfSettingsFileContainsPercentVariables(): string {
+    if (strpos(CIVICRM_UF_DSN, '%%CMSdbSSL%%') === FALSE && strpos(CIVICRM_DSN, '%%dbSSL%%') === FALSE) {
+      return '';
+    }
+    return '<ul><li>' . ts('Your civicrm.settings.php file contains unreplaced variables %1 and %2 in the CIVICRM_UF_DSN and CIVICRM_DSN strings from when it was first installed. You should remove the %1 and %2 from the strings.', [1 => '%%CMSdbSSL%%', 2 => '%%dbSSL%%']) . '</li></ul>';
   }
 
 }

--- a/templates/CRM/common/civicrm.settings.php.template
+++ b/templates/CRM/common/civicrm.settings.php.template
@@ -73,7 +73,13 @@ if (!defined('CIVICRM_UF')) {
  *      define( 'CIVICRM_UF_DSN', 'mysql://cms_db_username:cms_db_password@db_server/cms_database?new_link=true');
  */
 if (!defined('CIVICRM_UF_DSN') && CIVICRM_UF !== 'UnitTests') {
-  define( 'CIVICRM_UF_DSN'           , 'mysql://%%CMSdbUser%%:%%CMSdbPass%%@%%CMSdbHost%%/%%CMSdbName%%?new_link=true%%CMSdbSSL%%');
+  // The SSL variables are only defined when using civicrm-setup, so make sure
+  // this %% variable gets replaced with blank otherwise.
+  if (!defined('_CIVICRM_CMSdbSSL')) {
+    define('_CIVICRM_CMSdbSSL', '%%CMSdbSSL%%');
+  }
+  $CMSdbSSL = (_CIVICRM_CMSdbSSL === '%%' . 'CMSdbSSL' . '%%') ? '' : _CIVICRM_CMSdbSSL;
+  define( 'CIVICRM_UF_DSN'           , 'mysql://%%CMSdbUser%%:%%CMSdbPass%%@%%CMSdbHost%%/%%CMSdbName%%?new_link=true' . $CMSdbSSL);
 }
 
 // %%extraSettings%%
@@ -106,7 +112,13 @@ if (!defined('CIVICRM_DSN')) {
     define('CIVICRM_DSN', $GLOBALS['_CV']['TEST_DB_DSN']);
   }
   else {
-    define('CIVICRM_DSN', 'mysql://%%dbUser%%:%%dbPass%%@%%dbHost%%/%%dbName%%?new_link=true%%dbSSL%%');
+    // The SSL variables are only defined when using civicrm-setup, so make sure
+    // this %% variable gets replaced with blank otherwise.
+    if (!defined('_CIVICRM_dbSSL')) {
+      define('_CIVICRM_dbSSL', '%%dbSSL%%');
+    }
+    $dbSSL = (_CIVICRM_dbSSL === '%%' . 'dbSSL' . '%%') ? '' : _CIVICRM_dbSSL;
+    define('CIVICRM_DSN', 'mysql://%%dbUser%%:%%dbPass%%@%%dbHost%%/%%dbName%%?new_link=true' . $dbSSL);
   }
 }
 


### PR DESCRIPTION
Overview
----------------------------------------
Alternate to https://github.com/civicrm/civicrm-core/pull/21692

When using the legacy installer (e.g. sites/all/modules/civicrm/install/index.php) it leaves behind some unreplaced ssl-related template variables. Also drush. Anything that isn't using civicrm-setup.

Before
----------------------------------------
DSN in civicrm.settings.php looks like `mysql://foo:bar@localhost/cividb?new_link=true%%dbSSL%%` after install.

After
----------------------------------------
Hard to read in civicrm.settings.php, but works with all the variations.

Upgrade message to tell people they can remove it. It's a message since the file might not be writable.

Technical Details
----------------------------------------
The ssl vars are only replaced when using the newer civicrm-setup.

Comments
----------------------------------------
For readability, I think I'd prefer the other one and just try to find all the spots where it's used.
