### PR TITLE
Towards full metadata - fully declare 'bespoke' tokens

### DIFF
--- a/CRM/Activity/Tokens.php
+++ b/CRM/Activity/Tokens.php
@@ -123,20 +123,6 @@ class CRM_Activity_Tokens extends CRM_Core_EntityTokens {
   }
 
   /**
-   * Get all the tokens supported by this processor.
-   *
-   * @return array|string[]
-   * @throws \API_Exception
-   */
-  protected function getAllTokens(): array {
-    $tokens = parent::getAllTokens();
-    if (array_key_exists('CiviCase', CRM_Core_Component::getEnabledComponents())) {
-      $tokens['case_id'] = ts('Activity Case ID');
-    }
-    return $tokens;
-  }
-
-  /**
    * Get the basic tokens provided.
    *
    * @return array token name => token label
@@ -160,6 +146,29 @@ class CRM_Activity_Tokens extends CRM_Core_EntityTokens {
       }
     }
     return $this->basicTokens;
+  }
+
+  /**
+   * Get tokens that are special or calculated for this enitty.
+   *
+   * @return array|array[]
+   */
+  protected function getBespokeTokens(): array {
+    $tokens = [];
+    if (array_key_exists('CiviCase', CRM_Core_Component::getEnabledComponents())) {
+      $tokens['case_id'] = ts('Activity Case ID');
+      return [
+        'case_id' => [
+          'title' => ts('Activity Case ID'),
+          'name' => 'case_id',
+          'type' => 'calculated',
+          'options' => NULL,
+          'data_type' => 'Integer',
+          'audience' => 'user',
+        ],
+      ];
+    }
+    return $tokens;
   }
 
   /**

--- a/CRM/Core/EntityTokens.php
+++ b/CRM/Core/EntityTokens.php
@@ -174,7 +174,10 @@ class CRM_Core_EntityTokens extends AbstractTokenSubscriber {
         unset($basicTokens[$fieldName]);
       }
     }
-    return array_merge($basicTokens, $this->getPseudoTokens(), $this->getBespokeTokens(), CRM_Utils_Token::getCustomFieldTokens($this->getApiEntityName()));
+    foreach ($this->getBespokeTokens() as $token) {
+      $basicTokens[$token['name']] = $token['title'];
+    }
+    return array_merge($basicTokens, $this->getPseudoTokens(), CRM_Utils_Token::getCustomFieldTokens($this->getApiEntityName()));
   }
 
   /**
@@ -275,7 +278,7 @@ class CRM_Core_EntityTokens extends AbstractTokenSubscriber {
   /**
    * Get any tokens with custom calculation.
    */
-  public function getBespokeTokens(): array {
+  protected function getBespokeTokens(): array {
     return [];
   }
 
@@ -431,7 +434,7 @@ class CRM_Core_EntityTokens extends AbstractTokenSubscriber {
    * @return string[]
    *
    */
-  public function getExposedFields(): array {
+  protected function getExposedFields(): array {
     $return = [];
     foreach ($this->getFieldMetadata() as $field) {
       if (!in_array($field['name'], $this->getSkippedFields(), TRUE)) {

--- a/CRM/Event/ParticipantTokens.php
+++ b/CRM/Event/ParticipantTokens.php
@@ -45,8 +45,17 @@ class CRM_Event_ParticipantTokens extends CRM_Core_EntityTokens {
   /**
    * Get any tokens with custom calculation.
    */
-  public function getBespokeTokens(): array {
-    return ['balance' => ts('Event Balance')];
+  protected function getBespokeTokens(): array {
+    return [
+      'balance' => [
+        'title' => ts('Event Balance'),
+        'name' => 'balance',
+        'type' => 'calculated',
+        'options' => NULL,
+        'data_type' => 'Money',
+        'audience' => 'user',
+      ],
+    ];
   }
 
   /**

--- a/CRM/Member/Tokens.php
+++ b/CRM/Member/Tokens.php
@@ -34,23 +34,23 @@ class CRM_Member_Tokens extends CRM_Core_EntityTokens {
   }
 
   /**
-   * Get all tokens.
+   * List out the fields that are exposed.
    *
-   * This function will be removed once the parent class can determine it.
+   * For historical reasons these are the only exposed fields.
+   *
+   * It is also possible to list 'skippedFields'
+   *
+   * @return string[]
    */
-  public function getAllTokens(): array {
-    return array_merge(
-      [
-        'fee' => ts('Membership Fee'),
-        'id' => ts('Membership ID'),
-        'join_date' => ts('Member Since'),
-        'start_date' => ts('Membership Start Date'),
-        'end_date' => ts('Membership Expiration Date'),
-        'status_id:label' => ts('Status'),
-        'membership_type_id:label' => ts('Membership Type'),
-      ],
-      CRM_Utils_Token::getCustomFieldTokens('Membership')
-    );
+  protected function getExposedFields(): array {
+    return [
+      'id',
+      'join_date',
+      'start_date',
+      'end_date',
+      'status_id',
+      'membership_type_id',
+    ];
   }
 
   /**
@@ -74,6 +74,26 @@ class CRM_Member_Tokens extends CRM_Core_EntityTokens {
    */
   public function getDependencies(): array {
     return ['fee' => 'membership_type_id'];
+  }
+
+  /**
+   * Get any tokens with custom calculation.
+   *
+   * In this case 'fee' should be converted to{membership.membership_type_id.fee}
+   * but we don't have the formatting support to do that with no
+   * custom intervention yet.
+   */
+  protected function getBespokeTokens(): array {
+    return [
+      'fee' => [
+        'title' => ts('Membership Fee'),
+        'name' => 'fee',
+        'type' => 'calculated',
+        'options' => NULL,
+        'data_type' => 'integer',
+        'audience' => 'user',
+      ],
+    ];
   }
 
 }

--- a/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
+++ b/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
@@ -215,6 +215,20 @@ case.custom_1 :' . '
   }
 
   /**
+   * Get tokens that are not advertised via listTokens.
+   *
+   * @return string[]
+   */
+  public function getUnadvertisedTokens(): array {
+    return [
+      '{membership.status_id}' => 'Status ID',
+      '{membership.membership_type_id}' => 'Membership Type ID',
+      '{membership.status_id:name}' => 'Machine name: Status',
+      '{membership.membership_type_id:name}' => 'Machine name: Membership Type',
+    ];
+  }
+
+  /**
    * Get the contribution recur tokens keyed by the token.
    *
    * e.g {contribution_recur.id}
@@ -411,6 +425,8 @@ contribution_recur.payment_instrument_id:name :Check
     $tokens = $tokenProcessor->listTokens();
     // Add in custom tokens as token processor supports these.
     $expectedTokens['{membership.custom_1}'] = 'Enter text here :: Group with field text';
+    // Add in unadvertised tokens - for now they are included.
+    $expectedTokens = array_merge($expectedTokens, $this->getUnadvertisedTokens());
     $this->assertEquals(array_merge($expectedTokens, $this->getDomainTokens()), $tokens);
     $tokenProcessor->addMessage('html', $tokenString, 'text/plain');
     $tokenProcessor->addRow(['membershipId' => $this->getMembershipID()]);
@@ -665,7 +681,11 @@ December 21st, 2007
     $this->setupParticipantScheduledReminder();
 
     $tokens = CRM_Core_SelectValues::eventTokens();
-    $this->assertEquals($this->getEventTokens(), $tokens);
+    $unadvertisedTokens = [
+      '{event.event_type_id}' => 'Event Type',
+      '{event.event_type_id:name}' => 'Machine name: Event Type',
+    ];
+    $this->assertEquals(array_merge($this->getEventTokens(), $unadvertisedTokens), $tokens);
     $tokenProcessor = new TokenProcessor(\Civi::dispatcher(), [
       'controller' => __CLASS__,
       'smarty' => FALSE,


### PR DESCRIPTION
Overview
----------------------------------------
Towards full metadata - fully declare 'bespoke' tokens

The goal is to declare all tokens with full metadata and cache that - rather than the convoluted ways we have of looking up metadata  - I'm working towards https://github.com/civicrm/civicrm-core/pull/21706 but working through roadblocks

Before
----------------------------------------

'bespokeTokens' (only in master) declared as a flat array

After
----------------------------------------
declared as a nuanced array

Technical Details
----------------------------------------
This functionality all has really good test cover. One thing it does change is that membership & event tokens start to advertise the 
machine name tokens - the intent is to get to the point where ALL fields are declared as token metadata (which will be cached) but only those with 'audience' = 'user' will be in the widget - see https://github.com/civicrm/civicrm-core/pull/21706 

Comments
----------------------------------------
@demeritcowboy @colemanw if you have a better function name that 'getBespokeFunctions` please speak now

variants on `custom` are too close to custom fields & calculated is not necessarily accurate. 