### PR TITLE
Error about count() on New Email

### DIFF
--- a/CRM/Contact/Form/Task/EmailTrait.php
+++ b/CRM/Contact/Form/Task/EmailTrait.php
@@ -148,6 +148,11 @@ trait CRM_Contact_Form_Task_EmailTrait {
     if ($cid) {
       $this->_contactIds = explode(',', $cid);
     }
+    // The default in CRM_Core_Form_Task is null, but changing it there gives
+    // errors later.
+    if (is_null($this->_contactIds)) {
+      $this->_contactIds = [];
+    }
     if (count($this->_contactIds) > 1) {
       $this->_single = FALSE;
     }

--- a/tests/phpunit/CRM/Core/FormTest.php
+++ b/tests/phpunit/CRM/Core/FormTest.php
@@ -28,6 +28,10 @@ class CRM_Core_FormTest extends CiviUnitTestCase {
       $_REQUEST[$param] = $value;
     }
 
+    require_once 'HTML/QuickForm.php';
+    $form = new HTML_QuickForm();
+    $form->registerRule('maxfilesize', 'callback', '_ruleCheckMaxFileSize', 'HTML_QuickForm_file');
+
     $item = CRM_Core_Invoke::getItem([$_GET['q']]);
     ob_start();
     CRM_Core_Invoke::runItem($item);
@@ -58,6 +62,9 @@ class CRM_Core_FormTest extends CiviUnitTestCase {
       ],
       'Fulltext search' => [
         'civicrm/contact/search/custom?csid=15&reset=1',
+      ],
+      'New Email' => [
+        'civicrm/activity/email/add?atype=3&action=add&reset=1&context=standalone',
       ],
     ];
   }


### PR DESCRIPTION
Overview
----------------------------------------
1. Go to Contacts - New Email.
```
    Warning: count(): Parameter must be an array or an object that implements Countable in CRM_Contact_Form_Task_Email->buildQuickForm() (line 151 of .../CRM/Contact/Form/Task/EmailTrait.php).
    Warning: count(): Parameter must be an array or an object that implements Countable in CRM_Contact_Form_Task_Email->buildQuickForm() (line 154 of .../CRM/Contact/Form/Task/EmailTrait.php).
    Warning: count(): Parameter must be an array or an object that implements Countable in CRM_Contact_Form_Task_Email->buildQuickForm() (line 239 of .../CRM/Contact/Form/Task/EmailTrait.php).
```

Before
----------------------------------------
red boxes

After
----------------------------------------


Technical Details
----------------------------------------
It's from https://github.com/civicrm/civicrm-core/pull/21680 but I'm not sure what the right fix is. The default in CRM_Core_Form_Task is null, but changing it there causes other errors where the form is treating null differently than array. Before that PR it was an array containing the logged in user, which is odd, so I went with an empty array which is somewhere in between that and null.

Comments
----------------------------------------
