### PR TITLE
flexmailer - Update `[CiviMail Draft]` prefix to match BAO behavior

### DIFF
--- a/ext/flexmailer/src/API/MailingPreview.php
+++ b/ext/flexmailer/src/API/MailingPreview.php
@@ -41,11 +41,24 @@ class MailingPreview {
     $contactID = \CRM_Utils_Array::value('contact_id', $params,
       \CRM_Core_Session::singleton()->get('userID'));
 
-    $job = new \CRM_Mailing_BAO_MailingJob();
+    $job = new class extends \CRM_Mailing_BAO_MailingJob {
+
+      public function insert() {
+        throw new \RuntimeException('MailingJob is just a preview. It cannot be saved.');
+      }
+
+      public function update($dataObject = FALSE) {
+        throw new \RuntimeException('MailingJob is just a preview. It cannot be saved.');
+      }
+
+      public function save($hook = TRUE) {
+        throw new \RuntimeException('MailingJob is just a preview. It cannot be saved.');
+      }
+
+    };
     $job->mailing_id = $mailing->id ?: NULL;
     $job->is_test = 1;
     $job->status = 'Complete';
-    // $job->save();
 
     $flexMailer = new FlexMailer(array(
       'is_preview' => TRUE,

--- a/ext/flexmailer/src/API/MailingPreview.php
+++ b/ext/flexmailer/src/API/MailingPreview.php
@@ -57,7 +57,6 @@ class MailingPreview {
 
     };
     $job->mailing_id = $mailing->id ?: NULL;
-    $job->is_test = 1;
     $job->status = 'Complete';
 
     $flexMailer = new FlexMailer(array(

--- a/ext/flexmailer/tests/phpunit/Civi/FlexMailer/MailingPreviewTest.php
+++ b/ext/flexmailer/tests/phpunit/Civi/FlexMailer/MailingPreviewTest.php
@@ -83,7 +83,7 @@ class MailingPreviewTest extends \CiviUnitTestCase {
     $this->assertMaxIds($maxIDs);
 
     $previewResult = $result['values'][$result['id']]['api.Mailing.preview'];
-    $this->assertEquals("[CiviMail Draft] Hello $displayName",
+    $this->assertEquals("Hello $displayName",
       $previewResult['values']['subject']);
 
     $this->assertStringContainsString("This is $displayName", $previewResult['values']['body_text']);
@@ -112,7 +112,7 @@ class MailingPreviewTest extends \CiviUnitTestCase {
     $previewResult = $this->callAPISuccess('mailing', 'preview', $params);
     $this->assertMaxIds($maxIDs);
 
-    $this->assertEquals("[CiviMail Draft] Hello $displayName",
+    $this->assertEquals("Hello $displayName",
       $previewResult['values']['subject']);
 
     $this->assertStringContainsString("This is $displayName", $previewResult['values']['body_text']);


### PR DESCRIPTION
Overview
----------------------------------------

When drafting a mail-blast, one may use in-app previews and/or email test-messages. This refines the way in which the `[CiviMail Draft]` prefix is applied - and updates Flexmailer to more precisely match BAO.

Before
----------------------------------------

| Use Case | Action | BAO Behavior | Flexmailer Behavior |
| -- | -- | -- | -- |
| Send a test mailing over SMTP | send_test | Has prefix | Has prefix |
| Preview a test mailing in browser | preview | Omits prefix | Has prefix |

After
----------------------------------------

| Use Case | Action | BAO Behavior | Flexmailer Behavior |
| -- | -- | -- | -- |
| Send a test mailing over SMTP | send_test | Has prefix | Has prefix |
| Preview a test mailing in browser | preview | Omits prefix | Omits prefix |

Technical Details
----------------------------------------

The behavior of `[CiviMail Draft]` prefix is [keyed off the property `civicrm_mailing_job.is_test`](https://github.com/civicrm/civicrm-core/blob/bdf67e2837be3eec51cf647cb974c05daad453e5/ext/flexmailer/src/Listener/TestPrefix.php#L22). The functional change here comes from twiddling `is_test=1` => `is_test=0` for `preview` action. 

In the case of previewing, there is no *persistent* `civicrm_mailing_job`, but there is a placeholder/mock-job (*allowing the preview to more completely exercise representative code-paths*). It doesn't matter much what data we put in this mock job - as long as it isn't saved. The `is_test=1` was a slight mitigation in case it was accidentally saved. This patch replaces that with a more forthright mitigation to prevent accidental saving of the mock-job.