### PR TITLE
dev/core#2885 Expose Custom Fields on the New Group form of the Add To Group task

### DIFF
--- a/CRM/Contact/Form/Task/AddToGroup.php
+++ b/CRM/Contact/Form/Task/AddToGroup.php
@@ -53,6 +53,8 @@ class CRM_Contact_Form_Task_AddToGroup extends CRM_Contact_Form_Task {
 
     $this->_context = $this->get('context');
     $this->_id = $this->get('amtgID');
+
+    CRM_Custom_Form_CustomData::preProcess($this, NULL, NULL, 1, 'Group', $this->_id);
   }
 
   /**
@@ -119,6 +121,8 @@ class CRM_Contact_Form_Task_AddToGroup extends CRM_Contact_Form_Task {
     }
     else {
       $this->setTitle(ts('Add Contacts to A Group'));
+      //build custom data
+      CRM_Custom_Form_CustomData::buildQuickForm($this);
     }
 
     $this->addDefaultButtons(ts('Add to Group'));
@@ -139,6 +143,7 @@ class CRM_Contact_Form_Task_AddToGroup extends CRM_Contact_Form_Task {
     }
 
     $defaults['group_option'] = 0;
+    $defaults += CRM_Custom_Form_CustomData::setDefaultValues($this);
     return $defaults;
   }
 
@@ -183,6 +188,7 @@ class CRM_Contact_Form_Task_AddToGroup extends CRM_Contact_Form_Task {
       $groupParams['visibility'] = "User and User Admin Only";
       $groupParams['group_type'] = array_keys($params['group_type'] ?? []);
       $groupParams['is_active'] = 1;
+      $groupParams['custom'] = CRM_Core_BAO_CustomField::postProcess($params, $this->_id, 'Group');
 
       $createdGroup = CRM_Contact_BAO_Group::create($groupParams);
       $groupID = $createdGroup->id;

--- a/templates/CRM/Contact/Form/Task/AddToGroup.tpl
+++ b/templates/CRM/Contact/Form/Task/AddToGroup.tpl
@@ -39,6 +39,9 @@
                     <td>{$form.group_type.html}</td>
                 </tr>
                 {/if}
+                <tr>
+                  <td colspan=2>{include file="CRM/Custom/Form/CustomData.tpl"}</td>
+                </tr>
                 </table>
             </td>
         </tr>

--- a/tests/phpunit/CRM/Contact/Form/Task/AddToGroupTest.php
+++ b/tests/phpunit/CRM/Contact/Form/Task/AddToGroupTest.php
@@ -1,0 +1,104 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+ /**
+  * @group headless
+  */
+class CRM_Contact_Form_Task_AddToGroupTest extends CiviUnitTestCase {
+
+  protected function setUp(): void {
+    parent::setUp();
+  }
+
+  protected function getSearchTaskFormObject(array $formValues) {
+    $_POST = $formValues;
+    $_SERVER['REQUEST_METHOD'] = 'GET';
+    /* @var CRM_Core_Form $form */
+    $form = new CRM_Contact_Form_Task_AddToGroup();
+    $form->controller = new CRM_Contact_Controller_Search();
+    $form->controller->setStateMachine(new CRM_Core_StateMachine($form->controller));
+    $_SESSION['_' . $form->controller->_name . '_container']['values']['Advanced'] = $formValues;
+    return $form;
+  }
+
+  /**
+   * Test delete to trash.
+   */
+  public function testAddToGroup() {
+    $contact = $this->callAPISuccess('Contact', 'create', [
+      'contact_type' => 'Individual',
+      'first_name' => 'John',
+      'last_name' => 'Doe',
+    ]);
+    $contactId = $contact['id'];
+    $existingGroupId = $this->groupCreate();
+    $form = $this->getSearchTaskFormObject(['cids' => $contactId, 'group_option' => 0, 'group_id' => $existingGroupId]);
+    $form->preProcess();
+    $form->_contactIds = [$contactId];
+    $form->set('_componentIds', [$contactId]);
+    $form->buildQuickForm();
+    $form->setDefaultValues();
+    $form->postProcess();
+
+    $groupCount = \Civi\Api4\GroupContact::get()
+      ->addWhere('group_id', '=', $existingGroupId)
+      ->addWhere('status', '=', 'Added')
+      ->execute()
+      ->count();
+    $this->assertEquals(1, $groupCount);
+  }
+
+  /**
+   * Test delete to trash.
+   */
+  public function testAddToNewGroupWithCustomField() {
+    $contact = $this->callAPISuccess('Contact', 'create', [
+      'contact_type' => 'Individual',
+      'first_name' => 'Pete',
+      'last_name' => 'Johnson',
+    ]);
+    $contactId = $contact['id'];
+    $customGroup = $this->customGroupCreate(['extends' => 'Group']);
+    $customField = $this->customFieldCreate(['custom_group_id' => $customGroup['id']]);
+    $customFieldId = $customField['id'];
+
+    $form = $this->getSearchTaskFormObject([
+      'cids' => $contactId,
+      'group_option' => 1,
+      'title' => 'Test Group With Custom Field',
+      'description' => '',
+      'custom_' . $customFieldId => 'Custom Value ABC',
+    ]);
+    $form->preProcess();
+    $form->_contactIds = [$contactId];
+    $form->set('_componentIds', [$contactId]);
+    $form->buildQuickForm();
+    $form->setDefaultValues();
+    $form->postProcess();
+
+    $group = \Civi\Api4\Group::get()
+      ->addSelect('custom.*', 'id')
+      ->addWhere('title', '=', 'Test Group With Custom Field')
+      ->execute();
+    $this->assertEquals(1, $group->count());
+    $group = $group->first();
+    $this->assertArrayKeyExists('new_custom_group.Custom_Field', $group);
+    $this->assertEquals('Custom Value ABC', $group['new_custom_group.Custom_Field']);
+
+    $groupCount = \Civi\Api4\GroupContact::get()
+      ->addWhere('group_id', '=', $group['id'])
+      ->addWhere('status', '=', 'Added')
+      ->execute()
+      ->count();
+    $this->assertEquals(1, $groupCount);
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------

Adds custom fields to the screen when creating a new group from the search action Group - Add contacts to group.

Before
----------------------------------------

No custom fields are visible. See screenshot below.

![Screenshot_20211004_120628](https://user-images.githubusercontent.com/4126292/135843176-a28e169c-99fd-49cb-8d47-4702e59fd59c.png)

After
----------------------------------------

Custom fields are visible. See screenshot below.

![Screenshot_20211004_120405](https://user-images.githubusercontent.com/4126292/135843253-356f446b-0d9f-4e46-9633-0a0fef21d17d.png)

Comments
----------------------------------------

See https://lab.civicrm.org/dev/core/-/issues/2885
