### PR TITLE
APIv4 - Add Contact.age_years extra field to make age calculations easy

### DIFF
--- a/Civi/Api4/Service/Spec/Provider/ContactGetSpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/ContactGetSpecProvider.php
@@ -22,6 +22,7 @@ class ContactGetSpecProvider implements Generic\SpecProviderInterface {
    * @param \Civi\Api4\Service\Spec\RequestSpec $spec
    */
   public function modifySpec(RequestSpec $spec) {
+    // Groups field
     $field = new FieldSpec('groups', 'Contact', 'Array');
     $field->setLabel(ts('In Groups'))
       ->setTitle(ts('Groups'))
@@ -33,6 +34,19 @@ class ContactGetSpecProvider implements Generic\SpecProviderInterface {
       ->setSuffixes(['id', 'name', 'label'])
       ->setOptionsCallback([__CLASS__, 'getGroupList']);
     $spec->addFieldSpec($field);
+
+    // Age field
+    if (!$spec->getValue('contact_type') || $spec->getValue('contact_type') === 'Individual') {
+      $field = new FieldSpec('age_years', 'Contact', 'Integer');
+      $field->setLabel(ts('Age (years)'))
+        ->setTitle(ts('Age (years)'))
+        ->setColumnName('birth_date')
+        ->setDescription(ts('Age of individual (in years)'))
+        ->setType('Extra')
+        ->setReadonly(TRUE)
+        ->setSqlRenderer([__CLASS__, 'calculateAge']);
+      $spec->addFieldSpec($field);
+    }
   }
 
   /**
@@ -92,6 +106,15 @@ class ContactGetSpecProvider implements Generic\SpecProviderInterface {
       }
     }
     return $options;
+  }
+
+  /**
+   * Generate SQL for age field
+   * @param array $field
+   * @return string
+   */
+  public static function calculateAge(array $field) {
+    return "TIMESTAMPDIFF(YEAR, {$field['sql_name']}, CURDATE())";
   }
 
 }

--- a/Civi/Api4/Service/Spec/RequestSpec.php
+++ b/Civi/Api4/Service/Spec/RequestSpec.php
@@ -37,15 +37,29 @@ class RequestSpec implements \Iterator {
   protected $fields = [];
 
   /**
+   * @var array
+   */
+  protected $values = [];
+
+  /**
    * @param string $entity
    * @param string $action
+   * @param array $values
    */
-  public function __construct($entity, $action) {
+  public function __construct($entity, $action, $values = []) {
     $this->entity = $entity;
     $this->action = $action;
     $this->entityTableName = CoreUtil::getTableName($entity);
+    // Set contact_type from id if possible
+    if ($entity === 'Contact' && empty($values['contact_type']) && !empty($values['id'])) {
+      $values['contact_type'] = \CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Contact', $values['id'], 'contact_id');
+    }
+    $this->values = $values;
   }
 
+  /**
+   * @param FieldSpec $field
+   */
   public function addFieldSpec(FieldSpec $field) {
     if (!$field->getEntity()) {
       $field->setEntity($this->entity);
@@ -124,6 +138,21 @@ class RequestSpec implements \Iterator {
    */
   public function getEntity() {
     return $this->entity;
+  }
+
+  /**
+   * @return array
+   */
+  public function getValues() {
+    return $this->values;
+  }
+
+  /**
+   * @param string $key
+   * @return mixed
+   */
+  public function getValue(string $key) {
+    return $this->values[$key] ?? NULL;
   }
 
   /**

--- a/tests/phpunit/api/v4/Action/ContactGetTest.php
+++ b/tests/phpunit/api/v4/Action/ContactGetTest.php
@@ -322,4 +322,27 @@ class ContactGetTest extends \api\v4\UnitTestCase {
       ->execute();
   }
 
+  public function testAge(): void {
+    $lastName = uniqid(__FUNCTION__);
+    $sampleData = [
+      ['first_name' => 'abc', 'last_name' => $lastName, 'birth_date' => 'now - 1 year - 1 month'],
+      ['first_name' => 'def', 'last_name' => $lastName, 'birth_date' => 'now - 21 year - 6 month'],
+    ];
+    Contact::save(FALSE)
+      ->setRecords($sampleData)
+      ->execute();
+
+    $result = Contact::get(FALSE)
+      ->addWhere('last_name', '=', $lastName)
+      ->addSelect('first_name', 'age_years')
+      ->execute()->indexBy('first_name');
+    $this->assertEquals(1, $result['abc']['age_years']);
+    $this->assertEquals(21, $result['def']['age_years']);
+
+    Contact::get(FALSE)
+      ->addWhere('age_years', '=', 21)
+      ->addWhere('last_name', '=', $lastName)
+      ->execute()->single();
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Adds a calculated field to APIv4 which makes it simple to return or filter on a contact's age.

![image](https://user-images.githubusercontent.com/2874912/135887328-af591ef1-855a-4a08-8691-e0156d57ed05.png)
