### PR TITLE
SearchKit - Sortable column fixes/improvements

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin.module.js
+++ b/ext/search_kit/ang/crmSearchAdmin.module.js
@@ -277,7 +277,7 @@
       }
       function fieldToColumn(fieldExpr, defaults) {
         var info = parseExpr(fieldExpr),
-          field = _.findWhere(info.args, {type: 'field'}) || {},
+          field = (_.findWhere(info.args, {type: 'field'}) || {}).field || {},
           values = _.merge({
             type: 'field',
             key: info.alias,
@@ -287,7 +287,7 @@
           values.label = getDefaultLabel(fieldExpr);
         }
         if (defaults.sortable) {
-          values.sortable = field.type === 'Field';
+          values.sortable = field.type && field.type !== 'Pseudo';
         }
         return values;
       }

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminDisplay.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminDisplay.component.js
@@ -192,6 +192,13 @@
         return !col.image && !col.rewrite && !col.link && !info.fn && info.args[0] && info.args[0].field && !info.args[0].field.readonly;
       };
 
+      this.canBeSortable = function(col) {
+        var expr = ctrl.getExprFromSelect(col.key),
+          info = searchMeta.parseExpr(expr),
+          arg = (_.findWhere(info.args, {type: 'field'}) || {});
+        return arg.field && arg.field.type !== 'Pseudo';
+      };
+
       // Aggregate functions (COUNT, AVG, MAX) cannot display as links, except for GROUP_CONCAT
       // which gets special treatment in APIv4 to convert it to an array.
       this.canBeLink = function(col) {

--- a/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayTable.html
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayTable.html
@@ -43,6 +43,12 @@
           <option value="text-right">{{:: ts('Right') }}</option>
         </select>
       </div>
+      <div class="form-inline" ng-if=":: $ctrl.parent.canBeSortable(col)">
+        <label title="{{:: ts('Allow user to click on header to sort table by this column') }}">
+          <input type="checkbox" ng-checked="col.sortable !== false" ng-click="col.sortable = col.sortable === false" >
+          {{:: ts('Sortable Header') }}
+        </label>
+      </div>
       <div ng-include="'~/crmSearchAdmin/displays/colType/' + col.type + '.html'"></div>
     </fieldset>
   </div>


### PR DESCRIPTION
Overview
----------------------------------------
Fix sortable column headers on SearchKit admin tables.
Make click-sortable column headers configurable.

Before
----------------------------------------
Sortable column headers broken on SearchKit admin screens.
Not configurable which headers were click-sortable when building a table display.

After
----------------------------------------
Fixed, configurable.