### PR TITLE
Angular UI - Fix crmIcon to only add crm-button class to non-bootstrap buttons

### DIFF
--- a/ang/crmUi.js
+++ b/ang/crmUi.js
@@ -945,7 +945,8 @@
           else {
             $(element).prepend('<span class="icon ui-icon-' + attrs.crmIcon + '"></span> ');
           }
-          if ($(element).is('button')) {
+          // Add crm-* class to non-bootstrap buttons
+          if ($(element).is('button:not(.btn)')) {
             $(element).addClass('crm-button');
           }
         }


### PR DESCRIPTION
Overview
----------------------------------------
This allows the `crmIcon` helper to be used with Bootstrap-style markup.
Addresses https://github.com/civicrm/civicrm-core/pull/21712#issuecomment-933863450

Before
----------------------------------------
Always adds `crm-button` class to buttons, which conflicts with Bootstrap.

After
----------------------------------------
Only does so if the button doesn't have the Bootstrap `btn` class. 
