### PR TITLE
Fixes dev/core#2888 SearchKit download CSV broken

### DIFF
--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
@@ -42,6 +42,14 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
   protected $filters = [];
 
   /**
+   * Integer used as a seed when ordering by RAND().
+   * This keeps the order stable enough to use a pager with random sorting.
+   *
+   * @var int
+   */
+  protected $seed;
+
+  /**
    * Name of Afform, if this display is embedded (used for permissioning)
    * @var string
    */

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/Run.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/Run.php
@@ -23,14 +23,6 @@ class Run extends AbstractRunAction {
   protected $limit;
 
   /**
-   * Integer used as a seed when ordering by RAND().
-   * This keeps the order stable enough to use a pager with random sorting.
-   *
-   * @var int
-   */
-  protected $seed;
-
-  /**
    * @param \Civi\Api4\Generic\Result $result
    * @throws \API_Exception
    */


### PR DESCRIPTION
Overview
----------------------------------------
Fixes bug noted in https://lab.civicrm.org/dev/core/-/issues/2888

Before
--------
Download CSV fails

After
----------
It works

Technical Details
----------
A new param "seed" was added to the Run action but not the Download action. The clientside code is setting that param for both actions and it's not wrong to do so. Moving it to the parent class fixes it.