### PR TITLE
(dev/core#2766) provide way to distinguish the core and custom fields…

### DIFF
--- a/CRM/Dedupe/BAO/DedupeRuleGroup.php
+++ b/CRM/Dedupe/BAO/DedupeRuleGroup.php
@@ -115,7 +115,7 @@ class CRM_Dedupe_BAO_DedupeRuleGroup extends CRM_Dedupe_DAO_DedupeRuleGroup {
             continue;
           }
           foreach ($cg['fields'] as $cf) {
-            $fields[$ctype][$cg['table_name']][$cf['column_name']] = $cf['label'];
+            $fields[$ctype][$cg['table_name']][$cf['column_name']] = $cg['title'] . ' : ' . $cf['label'];
           }
         }
       }


### PR DESCRIPTION
… on _Find and Merge Duplicate Contacts_ page

Overview
----------------------------------------
There is no way to distinguish the core and custom fields on Find and Merge Duplicate Contacts page.
This is particularly confusing as one of the clients had a custom field named email and created the rule using this custom field and every time someone registered an event which was configured with this aforesaid rule it was attributed to a new contact. We should be using _Custom Field: Custom Group_ format to avoid confusion as we do elsewhere in Import mapping screens, etc.


Before
----------------------------------------
![before](https://user-images.githubusercontent.com/3455173/130070980-97e8d013-05a8-4594-95b6-4c7bc7816ccd.png)


After
----------------------------------------
![Screenshot from 2021-10-05 21-55-34](https://user-images.githubusercontent.com/3455173/136063850-bdba286e-8313-4e68-8530-8755aa43fb8d.png)



