### PR TITLE
Call line item pre hook after tax amount is calculated

### DIFF
--- a/CRM/Price/BAO/LineItem.php
+++ b/CRM/Price/BAO/LineItem.php
@@ -33,12 +33,6 @@ class CRM_Price_BAO_LineItem extends CRM_Price_DAO_LineItem {
    */
   public static function create(&$params) {
     $id = $params['id'] ?? NULL;
-    if ($id) {
-      CRM_Utils_Hook::pre('edit', 'LineItem', $id, $params);
-    }
-    else {
-      CRM_Utils_Hook::pre('create', 'LineItem', $id, $params);
-    }
 
     // unset entity table and entity id in $params
     // we never update the entity table and entity id during update mode
@@ -56,6 +50,13 @@ class CRM_Price_BAO_LineItem extends CRM_Price_DAO_LineItem {
       $params['tax_amount'] = self::getTaxAmountForLineItem($params);
     }
 
+    // Call the hooks after tax is set in case hooks wish to alter it.
+    if ($id) {
+      CRM_Utils_Hook::pre('edit', 'LineItem', $id, $params);
+    }
+    else {
+      CRM_Utils_Hook::pre('create', 'LineItem', $id, $params);
+    }
     $lineItemBAO = new CRM_Price_BAO_LineItem();
     $lineItemBAO->copyValues($params);
 


### PR DESCRIPTION
Overview
----------------------------------------
Call line item pre hook after tax amount is set

Before
----------------------------------------
Tax amount calculation is done after hooks are called in line item BAO

After
----------------------------------------
Tax amount calculation is done before hooks are called in line item BAO

Technical Details
----------------------------------------
@KarinG @pradpnayak we never did get to the bottom of https://lab.civicrm.org/dev/core/-/issues/2796 but it occurred to me that moving the hook call might be one easy thing we can do to allow extension writers to intervene

Comments
----------------------------------------
