### PR TITLE
Fix possibly unefined $form variables in smarty templates

### DIFF
--- a/ext/eventcart/templates/CRM/Event/Cart/Form/Checkout/Payment.tpl
+++ b/ext/eventcart/templates/CRM/Event/Cart/Form/Checkout/Payment.tpl
@@ -94,7 +94,7 @@
   </tfoot>
 </table>
 {if $payment_required == true}
-  {if $form.is_pay_later.label}
+  {if !empty($form.is_pay_later.label)}
     <div class="crm-section {$form.is_pay_later.name}-section">
       <div class="label">{$form.is_pay_later.label}</div>
       <div class="content">{$form.is_pay_later.html}
@@ -117,14 +117,14 @@
 {/if}
 
 <script type="text/javascript">
-{if $form.is_pay_later.name}
+{if !empty($form.is_pay_later.name)}
 var pay_later_sel = "input#{$form.is_pay_later.name}";
 {/if}
 {literal}
 CRM.$(function($) {
 
   function refresh() {
-    {/literal}{if $form.is_pay_later.name}{literal}
+    {/literal}{if !empty($form.is_pay_later.name)}{literal}
     var is_pay_later = $(pay_later_sel).prop("checked");
     {/literal}{else}
     var is_pay_later = false;
@@ -133,7 +133,7 @@ CRM.$(function($) {
     $(".pay-later-instructions").toggle(is_pay_later);
     $("div.billingNameInfo-section .description").html(is_pay_later ? "Enter the billing address at which you can be invoiced." : "Enter the name as shown on your credit or debit card, and the billing address for this card.");
   }
-  {/literal}{if $form.is_pay_later.name}{literal}
+  {/literal}{if !empty($form.is_pay_later.name)}{literal}
   $(pay_later_sel).change(function() {
     refresh();
   });

--- a/ext/legacycustomsearches/templates/CRM/Contact/Form/Search/Custom/MultipleValuesCriteria.tpl
+++ b/ext/legacycustomsearches/templates/CRM/Contact/Form/Search/Custom/MultipleValuesCriteria.tpl
@@ -29,7 +29,7 @@
           <div class="clear"></div>
         </div>
 
-        {if $form.contact_type}
+        {if !empty($form.contact_type)}
           <div class="crm-section contact_type-section">
             <div class="label">
               {$form.contact_type.label}
@@ -41,7 +41,7 @@
           </div>
         {/if}
 
-        {if $form.group}
+        {if !empty($form.group)}
         <div class="crm-section group_selection-section">
           <div class="label">
               {$form.group.label}
@@ -53,7 +53,7 @@
         </div>
         {/if}
 
-        {if $form.tag}
+        {if !empty($form.tag)}
             <div class="crm-section tag-section">
               <div class="label">
                 {$form.tag.label}

--- a/templates/CRM/Activity/Form/Search/Common.tpl
+++ b/templates/CRM/Activity/Form/Search/Common.tpl
@@ -14,7 +14,7 @@
   </td>
 </tr>
 <tr>
-  {if $form.activity_type_id}
+  {if !empty($form.activity_type_id)}
     <td><label>{$form.activity_type_id.label}</label>
        <br />
        {$form.activity_type_id.html}
@@ -43,14 +43,14 @@
   <td>
     <table>
       <tr><td>
-        {if $form.parent_id}
+        {if !empty($form.parent_id)}
           <label>{ts}Has a Followup Activity?{/ts}</label>
           <br/>
           {$form.parent_id.html}
         {/if}
       </td></tr>
       <tr><td>
-      {if $form.followup_parent_id}
+      {if !empty($form.followup_parent_id)}
           <label>{ts}Is a Followup Activity?{/ts}</label>
           <br/>
           {$form.followup_parent_id.html}

--- a/templates/CRM/Admin/Form/Navigation.tpl
+++ b/templates/CRM/Admin/Form/Navigation.tpl
@@ -22,7 +22,7 @@
       <td class="label">{$form.icon.label} {help id="id-menu_icon" file="CRM/Admin/Form/Navigation.hlp"}</td>
       <td>{$form.icon.html} </td>
     </tr>
-    {if $form.parent_id.html}
+    {if !empty($form.parent_id.html)}
       <tr class="crm-navigation-form-block-parent_id">
         <td class="label">{$form.parent_id.label} {help id="id-parent" file="CRM/Admin/Form/Navigation.hlp"}</td>
         <td>{$form.parent_id.html}</td>

--- a/templates/CRM/Admin/Form/PaymentProcessor.tpl
+++ b/templates/CRM/Admin/Form/PaymentProcessor.tpl
@@ -58,37 +58,37 @@
         <tr class="crm-paymentProcessor-form-block-user_name">
             <td class="label">{$form.user_name.label}</td><td>{$form.user_name.html} {help id=$ppTypeName|cat:'-live-user-name' title=$form.user_name.label}</td>
         </tr>
-{if $form.password}
+{if !empty($form.password)}
         <tr class="crm-paymentProcessor-form-block-password">
             <td class="label">{$form.password.label}</td><td>{$form.password.html} {help id=$ppTypeName|cat:'-live-password' title=$form.password.label}</td>
         </tr>
 {/if}
-{if $form.signature}
+{if !empty($form.signature)}
         <tr class="crm-paymentProcessor-form-block-signature">
             <td class="label">{$form.signature.label}</td><td>{$form.signature.html} {help id=$ppTypeName|cat:'-live-signature' title=$form.signature.label}</td>
         </tr>
 {/if}
-{if $form.subject}
+{if !empty($form.subject)}
         <tr class="crm-paymentProcessor-form-block-subject">
             <td class="label">{$form.subject.label}</td><td>{$form.subject.html} {help id=$ppTypeName|cat:'-live-subject' title=$form.subject.label}</td>
         </tr>
 {/if}
-{if $form.url_site}
+{if !empty($form.url_site)}
         <tr class="crm-paymentProcessor-form-block-url_site">
             <td class="label">{$form.url_site.label}</td><td>{$form.url_site.html|crmAddClass:huge} {help id=$ppTypeName|cat:'-live-url-site' title=$form.url_site.label}</td>
         </tr>
 {/if}
-{if $form.url_api}
+{if !empty($form.url_api)}
         <tr class="crm-paymentProcessor-form-block-url_api">
             <td class="label">{$form.url_api.label}</td><td>{$form.url_api.html|crmAddClass:huge} {help id=$ppTypeName|cat:'-live-url-api' title=$form.url_api.label}</td>
         </tr>
 {/if}
-{if $form.url_recur}
+{if !empty($form.url_recur)}
         <tr class="crm-paymentProcessor-form-block-url_recur">
             <td class="label">{$form.url_recur.label}</td><td>{$form.url_recur.html|crmAddClass:huge} {help id=$ppTypeName|cat:'-live-url-recur' title=$form.url_recur.label}</td>
         </tr>
 {/if}
-{if $form.url_button}
+{if !empty($form.url_button)}
         <tr class="crm-paymentProcessor-form-block-url_button">
             <td class="label">{$form.url_button.label}</td><td>{$form.url_button.html|crmAddClass:huge} {help id=$ppTypeName|cat:'-live-url-button' title=$form.url_button.label}</td>
         </tr>
@@ -101,37 +101,37 @@
     <table class="form-layout-compressed">
         <tr class="crm-paymentProcessor-form-block-test_user_name">
             <td class="label">{$form.test_user_name.label}</td><td>{$form.test_user_name.html} {help id=$ppTypeName|cat:'-test-user-name' title=$form.test_user_name.label}</td></tr>
-{if $form.test_password}
+{if !empty($form.test_password)}
         <tr class="crm-paymentProcessor-form-block-test_password">
             <td class="label">{$form.test_password.label}</td><td>{$form.test_password.html} {help id=$ppTypeName|cat:'-test-password' title=$form.test_password.label}</td>
         </tr>
 {/if}
-{if $form.test_signature}
+{if !empty($form.test_signature)}
         <tr class="crm-paymentProcessor-form-block-test_signature">
             <td class="label">{$form.test_signature.label}</td><td>{$form.test_signature.html} {help id=$ppTypeName|cat:'-test-signature' title=$form.test_signature.label}</td>
         </tr>
 {/if}
-{if $form.test_subject}
+{if !empty($form.test_subject)}
         <tr class="crm-paymentProcessor-form-block-test_subject">
             <td class="label">{$form.test_subject.label}</td><td>{$form.test_subject.html} {help id=$ppTypeName|cat:'-test-subject' title=$form.test_subject.label}</td>
         </tr>
 {/if}
-{if $form.test_url_site}
+{if !empty($form.test_url_site)}
         <tr class="crm-paymentProcessor-form-block-test_url_site">
             <td class="label">{$form.test_url_site.label}</td><td>{$form.test_url_site.html|crmAddClass:huge} {help id=$ppTypeName|cat:'-test-url-site' title=$form.test_url_site.label}</td>
         </tr>
 {/if}
-{if $form.test_url_api}
+{if !empty($form.test_url_api)}
         <tr class="crm-paymentProcessor-form-block-test_url_api">
             <td class="label">{$form.test_url_api.label}</td><td>{$form.test_url_api.html|crmAddClass:huge} {help id=$ppTypeName|cat:'-test-url-api' title=$form.test_url_api.label}</td>
         </tr>
 {/if}
-{if $form.test_url_recur}
+{if !empty($form.test_url_recur)}
         <tr class="crm-paymentProcessor-form-block-test_url_recur">
             <td class="label">{$form.test_url_recur.label}</td><td>{$form.test_url_recur.html|crmAddClass:huge} {help id=$ppTypeName|cat:'-test-url-recur' title=$form.test_url_recur.label}</td>
         </tr>
 {/if}
-{if $form.test_url_button}
+{if !empty($form.test_url_button)}
         <tr class="crm-paymentProcessor-form-block-test_url_button">
             <td class="label">{$form.test_url_button.label}</td><td>{$form.test_url_button.html|crmAddClass:huge} {help id=$ppTypeName|cat:'-test-url-button' title=$form.test_url_button.label}</td>
         </tr>

--- a/templates/CRM/Admin/Form/Preferences/Display.tpl
+++ b/templates/CRM/Admin/Form/Preferences/Display.tpl
@@ -212,7 +212,7 @@
   </table>
   <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
 </div>
-{if $form.contact_edit_options.html}
+{if !empty($form.contact_edit_options.html)}
   {literal}
     <script type="text/javascript">
       CRM.$(function($) {

--- a/templates/CRM/Admin/Form/PreferencesDate.tpl
+++ b/templates/CRM/Admin/Form/PreferencesDate.tpl
@@ -20,7 +20,7 @@
             <tr class="crm-preferences-date-form-block-date_format">
                 <td class="label">{$form.date_format.label}</td><td>{$form.date_format.html}</td>
             </tr>
-            {if $form.time_format.label}
+            {if !empty($form.time_format.label)}
             <tr class="crm-preferences-date-form-block-time_format">
                 <td class="label">{$form.time_format.label}</td><td>{$form.time_format.html}</td>
             </tr>

--- a/templates/CRM/Admin/Form/Setting/Localization.tpl
+++ b/templates/CRM/Admin/Form/Setting/Localization.tpl
@@ -19,7 +19,7 @@
                 <td class="label">{$form.lcMessages.label}</td>
                 <td>{$form.lcMessages.html}</td>
             </tr>
-           {if $form.languageLimit}
+           {if !empty($form.languageLimit)}
              <tr class="crm-localization-form-block-languageLimit">
                  <td class="label">{$form.languageLimit.label}</td>
                  <td>{$form.languageLimit.html}<br />
@@ -37,7 +37,7 @@
                 <span class="description">{$settings_fields.inheritLocale.description}</span>
               </td>
             </tr>
-          {if !$form.languageLimit}
+          {if empty($form.languageLimit)}
             <tr class="crm-localization-form-block-uiLanguages">
                 <td class="label">{$form.uiLanguages.label}</td>
                 <td>{$form.uiLanguages.html}</td>
@@ -104,7 +104,7 @@
         </table>
     <h3>{ts}Multiple Languages Support{/ts}</h3>
       <table class="form-layout-compressed">
-        {if $form.makeSinglelingual}
+        {if !empty($form.makeSinglelingual)}
           <tr class="crm-localization-form-block-makeSinglelingual_description">
               <td></td>
               <td><span class="description">{ts 1="http://documentation.civicrm.org"}This is a multilingual installation. It contains certain schema differences compared to regular installations of CiviCRM. Please <a href="%1">refer to the documentation</a> for details.{/ts}</span></td>

--- a/templates/CRM/Admin/Form/Setting/UF.tpl
+++ b/templates/CRM/Admin/Form/Setting/UF.tpl
@@ -17,7 +17,7 @@
             <td class="label">{$form.userFrameworkUsersTableName.label}</td>
             <td>{$form.userFrameworkUsersTableName.html}</td>
         </tr>
-        {if $form.wpBasePage}
+        {if !empty($form.wpBasePage)}
          <tr class="crm-uf-form-block-wpBasePage">
             <td class="label">{$form.wpBasePage.label}</td>
             <td>{$config->userFrameworkBaseURL}{$form.wpBasePage.html}

--- a/templates/CRM/Campaign/Form/ResultOptions.tpl
+++ b/templates/CRM/Campaign/Form/ResultOptions.tpl
@@ -15,7 +15,7 @@
 </td>
 </tr>
 
-<tr id="option_group" {if !$form.option_group_id}class="hiddenElement"{/if}>
+<tr id="option_group" {if empty($form.option_group_id)}class="hiddenElement"{/if}>
   <td class="label">{$form.option_group_id.label}</td>
   <td class="html-adjust">{$form.option_group_id.html}</td>
 </tr>

--- a/templates/CRM/Case/Form/Activity.tpl
+++ b/templates/CRM/Case/Form/Activity.tpl
@@ -233,7 +233,7 @@
         </td>
       </tr>
     {/if}
-    {if $form.tag.html}
+    {if !empty($form.tag.html)}
     <tr class="crm-case-activity-form-block-tag">
       <td class="label">{$form.tag.label}</td>
       <td class="view-value">

--- a/templates/CRM/Case/Form/ActivityTab.tpl
+++ b/templates/CRM/Case/Form/ActivityTab.tpl
@@ -45,7 +45,7 @@
             {$form.activity_type_filter_id.html}
           </td>
         </tr>
-        {if $form.activity_deleted}
+        {if !empty($form.activity_deleted)}
           <tr class="crm-case-caseview-form-block-activity_deleted">
             <td>
               {$form.activity_deleted.html}{$form.activity_deleted.label}

--- a/templates/CRM/Case/Form/Case.tpl
+++ b/templates/CRM/Case/Form/Case.tpl
@@ -53,7 +53,7 @@
     </tr>
 {/if}
 
-{if $form.activity_details.html}
+{if !empty($form.activity_details.html)}
     <tr class="crm-case-form-block-activity_details">
         <td class="label">{$form.activity_details.label}{help id="id-details" activityTypeFile=$activityTypeFile file="CRM/Case/Form/Case.hlp"}</td>
         <td class="view-value">{$form.activity_details.html|crmStripAlternatives}</td>
@@ -68,7 +68,7 @@
     </tr>
 {/if}
 
-{if $form.activity_subject.html}
+{if !empty($form.activity_subject.html)}
     <tr class="crm-case-form-block-activity_subject">
        <td class="label">{$form.activity_subject.label}{help id="id-activity_subject" activityTypeFile=$activityTypeFile file="CRM/Case/Form/Case.hlp"}</td>
        <td>{$form.activity_subject.html|crmAddClass:huge}</td>
@@ -80,7 +80,7 @@
     {include file="CRM/Case/Form/Activity/$activityTypeFile.tpl"}
 {/if}
 
-{if $form.duration.html}
+{if !empty($form.duration.html)}
     <tr class="crm-case-form-block-duration">
       <td class="label">{$form.duration.label}</td>
       <td class="view-value">

--- a/templates/CRM/Case/Form/Search/Common.tpl
+++ b/templates/CRM/Case/Form/Search/Common.tpl
@@ -41,7 +41,7 @@
         <br />
         {$form.case_owner.html}
       {/if}
-      {if $form.case_deleted}
+      {if !empty($form.case_deleted)}
         <br />
         {$form.case_deleted.html}
         {$form.case_deleted.label}

--- a/templates/CRM/Contact/Form/Edit/Individual.tpl
+++ b/templates/CRM/Contact/Form/Edit/Individual.tpl
@@ -10,7 +10,7 @@
 {* tpl for building Individual related fields *}
 <table class="form-layout-compressed">
   <tr>
-    {if $form.prefix_id}
+    {if !empty($form.prefix_id)}
     <td>
       {$form.prefix_id.label}<br/>
       {$form.prefix_id.html}
@@ -22,19 +22,19 @@
       {$form.formal_title.html}
     </td>
     {/if}
-    {if $form.first_name}
+    {if !empty($form.first_name)}
     <td>
       {$form.first_name.label}<br />
       {$form.first_name.html}
     </td>
     {/if}
-    {if $form.middle_name}
+    {if !empty($form.middle_name)}
     <td>
       {$form.middle_name.label}<br />
       {$form.middle_name.html}
     </td>
     {/if}
-    {if $form.last_name}
+    {if !empty($form.last_name)}
     <td>
       {$form.last_name.label}<br />
       {$form.last_name.html}

--- a/templates/CRM/Contact/Form/Inline/ContactName.tpl
+++ b/templates/CRM/Contact/Form/Inline/ContactName.tpl
@@ -14,37 +14,37 @@
     {include file="CRM/common/formButtons.tpl"}
   </div>
   {if $contactType eq 'Individual'}
-    {if $form.prefix_id}
+    {if !empty($form.prefix_id)}
       <div class="crm-inline-edit-field">
         {$form.prefix_id.label}<br/>
         {$form.prefix_id.html}
       </div>
     {/if}
-    {if $form.formal_title}
+    {if !empty($form.formal_title)}
       <div class="crm-inline-edit-field">
         {$form.formal_title.label}<br/>
         {$form.formal_title.html}
       </div>
     {/if}
-    {if $form.first_name}
+    {if !empty($form.first_name)}
       <div class="crm-inline-edit-field">
         {$form.first_name.label}<br />
         {$form.first_name.html}
       </div>
     {/if}
-    {if $form.middle_name}
+    {if !empty($form.middle_name)}
       <div class="crm-inline-edit-field">
         {$form.middle_name.label}<br />
         {$form.middle_name.html}
       </div>
     {/if}
-    {if $form.last_name}
+    {if !empty($form.last_name)}
       <div class="crm-inline-edit-field">
         {$form.last_name.label}<br />
         {$form.last_name.html}
       </div>
     {/if}
-    {if $form.suffix_id}
+    {if !empty($form.suffix_id)}
       <div class="crm-inline-edit-field">
         {$form.suffix_id.label}<br/>
         {$form.suffix_id.html}

--- a/templates/CRM/Contact/Form/OnBehalfOf.tpl
+++ b/templates/CRM/Contact/Form/OnBehalfOf.tpl
@@ -182,7 +182,7 @@
 
 </fieldset>
 
-{if $form.is_for_organization}
+{if !empty($form.is_for_organization)}
     {include file="CRM/common/showHideByFieldValue.tpl"
          trigger_field_id    ="is_for_organization"
          trigger_value       ="true"

--- a/templates/CRM/Contact/Form/Search/BasicCriteria.tpl
+++ b/templates/CRM/Contact/Form/Search/BasicCriteria.tpl
@@ -35,7 +35,7 @@
           <div class="clear"></div>
         </div>
 
-        {if $form.contact_type}
+        {if !empty($form.contact_type)}
           <div class="crm-section contact_type-section">
             <div class="label">
               {$form.contact_type.label}
@@ -47,7 +47,7 @@
           </div>
         {/if}
 
-        {if $form.group}
+        {if !empty($form.group)}
         <div class="crm-section group_selection-section">
           <div class="label">
             {if $context EQ 'smog'}
@@ -67,7 +67,7 @@
         </div>
         {/if}
 
-        {if $form.tag}
+        {if !empty($form.tag)}
             <div class="crm-section tag-section">
               <div class="label">
                 {$form.tag.label}

--- a/templates/CRM/Contact/Form/Search/ContactSearchFields.tpl
+++ b/templates/CRM/Contact/Form/Search/ContactSearchFields.tpl
@@ -7,7 +7,7 @@
   <td>{$form.buttons.html}</td>
 </tr>
 <tr>
-  {if $form.contact_tags}
+  {if !empty($form.contact_tags)}
     <td>
       <label>{$form.contact_tags.label}</label>
       <br>
@@ -17,7 +17,7 @@
     <td>&nbsp;</td>
   {/if}
 
-  {if $form.group}
+  {if !empty($form.group)}
     <td>
       <label>{$form.group.label}</label>
       <br>
@@ -34,7 +34,7 @@
     {$form.contact_type.html}
   </td>
   <td>
-    {if $form.deleted_contacts}
+    {if !empty($form.deleted_contacts)}
       {$form.deleted_contacts.html}&nbsp;&nbsp;{$form.deleted_contacts.label}
     {/if}
   </td>

--- a/templates/CRM/Contact/Form/Search/Criteria/DisplaySettings.tpl
+++ b/templates/CRM/Contact/Form/Search/Criteria/DisplaySettings.tpl
@@ -2,11 +2,11 @@
   <table>
     <tr>
       <td>
-        {if $form.component_mode}
+        {if !empty($form.component_mode)}
           {$form.component_mode.label} {help id="id-display-results"}
           <br />
           {$form.component_mode.html}
-          {if $form.display_relationship_type}
+          {if !empty($form.display_relationship_type)}
             <div id="crm-display_relationship_type">{$form.display_relationship_type.html}</div>
           {/if}
         {else}

--- a/templates/CRM/Contact/Form/Search/Criteria/Location.tpl
+++ b/templates/CRM/Contact/Form/Search/Criteria/Location.tpl
@@ -72,13 +72,13 @@
           <div>{$form.location_type.label} {help id="location_type" title=$form.location_type.label}</div>
           {$form.location_type.html}
         </div>
-        {if $form.address_name.html}
+        {if !empty($form.address_name.html)}
           <div class="crm-field-wrapper">
             {$form.address_name.label}<br />
             {$form.address_name.html}
           </div>
         {/if}
-        {if $form.postal_code.html}
+        {if !empty($form.postal_code.html)}
           <div class="crm-field-wrapper">
             {$form.postal_code.label}
             <input type="checkbox" id="postal-code-range-toggle" value="1"/>
@@ -109,7 +109,7 @@
             {/literal}
           </script>
         {/if}
-        {if $form.prox_distance.html}
+        {if !empty($form.prox_distance.html)}
           <div class="crm-field-wrapper">
             {$form.prox_distance.label}<br />
             {$form.prox_distance.html}&nbsp;{$form.prox_distance_unit.html}

--- a/templates/CRM/Contact/Form/Search/Criteria/SearchSettings.tpl
+++ b/templates/CRM/Contact/Form/Search/Criteria/SearchSettings.tpl
@@ -3,7 +3,7 @@
     <tr>
       <td>{$form.operator.label} {help id="id-search-operator"}<br />{$form.operator.html}</td>
       <td>
-        {if $form.deleted_contacts}{$form.deleted_contacts.html} {$form.deleted_contacts.label}{/if}
+        {if !empty($form.deleted_contacts)}{$form.deleted_contacts.html} {$form.deleted_contacts.label}{/if}
       </td>
       <td class="adv-search-top-submit" colspan="2">
         <div class="crm-submit-buttons">

--- a/templates/CRM/Contact/Form/Task/AddToGroup.tpl
+++ b/templates/CRM/Contact/Form/Task/AddToGroup.tpl
@@ -33,7 +33,7 @@
                 <tr class="crm-contact-task-addtogroup-form-block-description">
                    <td class="label">{$form.description.label}</td>
                    <td>{$form.description.html}</td></tr>
-                {if $form.group_type}
+                {if !empty($form.group_type)}
                 <tr class="crm-contact-task-addtogroup-form-block-group_type">
         <td class="label">{$form.group_type.label}</td>
                     <td>{$form.group_type.html}</td>

--- a/templates/CRM/Contact/Form/Task/Email.tpl
+++ b/templates/CRM/Contact/Form/Task/Email.tpl
@@ -26,14 +26,14 @@
          {$form.to.html} {help id="id-to_email" file="CRM/Contact/Form/Task/Email.hlp"}
        </td>
     </tr>
-    <tr class="crm-contactEmail-form-block-cc_id" {if !$form.cc_id.value}style="display:none;"{/if}>
+    <tr class="crm-contactEmail-form-block-cc_id" {if empty($form.cc_id.value)}style="display:none;"{/if}>
       <td class="label">{$form.cc_id.label}</td>
       <td>
         {$form.cc_id.html}
         <a class="crm-hover-button clear-cc-link" rel="cc_id" title="{ts}Clear{/ts}" href="#"><i class="crm-i fa-times" aria-hidden="true"></i></a>
       </td>
     </tr>
-    <tr class="crm-contactEmail-form-block-bcc_id" {if !$form.bcc_id.value}style="display:none;"{/if}>
+    <tr class="crm-contactEmail-form-block-bcc_id" {if empty($form.bcc_id.value)}style="display:none;"{/if}>
       <td class="label">{$form.bcc_id.label}</td>
       <td>
         {$form.bcc_id.html}
@@ -44,8 +44,8 @@
       <td></td>
       <td>
         <div>
-          <a href="#" rel="cc_id" class="add-cc-link crm-hover-button" {if $form.cc_id.value}style="display:none;"{/if}>{ts}Add CC{/ts}</a>&nbsp;&nbsp;
-          <a href="#" rel="bcc_id" class="add-cc-link crm-hover-button" {if $form.bcc_id.value}style="display:none;"{/if}>{ts}Add BCC{/ts}</a>
+          <a href="#" rel="cc_id" class="add-cc-link crm-hover-button" {if !empty($form.cc_id.value)}style="display:none;"{/if}>{ts}Add CC{/ts}</a>&nbsp;&nbsp;
+          <a href="#" rel="bcc_id" class="add-cc-link crm-hover-button" {if !empty($form.bcc_id.value)}style="display:none;"{/if}>{ts}Add BCC{/ts}</a>
         </div>
       </td>
     </tr>

--- a/templates/CRM/Contact/Form/Task/PDFLetterCommon.tpl
+++ b/templates/CRM/Contact/Form/Task/PDFLetterCommon.tpl
@@ -8,7 +8,7 @@
  +--------------------------------------------------------------------+
 *}
 {*common template for compose PDF letters*}
-{if $form.template.html}
+{if !empty($form.template.html)}
 <table class="form-layout-compressed">
     <tr>
       <td class="label-left">
@@ -23,7 +23,7 @@
       <td class="label-left">{$form.subject.label}</td>
       <td>{$form.subject.html}</td>
     </tr>
-    {if $form.campaign_id}
+    {if !empty($form.campaign_id)}
     <tr>
       <td class="label-left">{$form.campaign_id.label}</td>
       <td>{$form.campaign_id.html}</td>

--- a/templates/CRM/Contact/Form/Task/SaveSearch.tpl
+++ b/templates/CRM/Contact/Form/Task/SaveSearch.tpl
@@ -34,7 +34,7 @@
       <td class="label">{$form.description.label}</td>
       <td>{$form.description.html}</td>
     </tr>
-    {if $form.group_type}
+    {if !empty($form.group_type)}
       <tr class="crm-contact-task-createsmartgroup-form-block-group_type">
         <td class="label">{$form.group_type.label}</td>
         <td>{$form.group_type.html}</td>

--- a/templates/CRM/Contact/Import/Form/Preview.tpl
+++ b/templates/CRM/Contact/Import/Form/Preview.tpl
@@ -102,7 +102,7 @@
 
       {* Existing Group *}
 
-<div id="existing-groups" class="crm-accordion-wrapper crm-existing_group-accordion {if $form.groups} {else}collapsed{/if}">
+<div id="existing-groups" class="crm-accordion-wrapper crm-existing_group-accordion {if !empty($form.groups)} {else}collapsed{/if}">
  <div class="crm-accordion-header">
   {$form.groups.label}
  </div><!-- /.crm-accordion-header -->

--- a/templates/CRM/Contribute/Form/Contribution.tpl
+++ b/templates/CRM/Contribute/Form/Contribution.tpl
@@ -228,7 +228,7 @@
           </td>
         </tr>
         {/if}
-        {if $form.payment_processor_id}
+        {if !empty($form.payment_processor_id)}
           <tr class="crm-contribution-form-block-payment_processor_id"><td class="label nowrap">{$form.payment_processor_id.label}<span class="crm-marker"> * </span></td><td>{$form.payment_processor_id.html}</td></tr>
         {/if}
       </table>

--- a/templates/CRM/Contribute/Form/Contribution/Main.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Main.tpl
@@ -135,7 +135,7 @@
       {/if}
       {/crmRegion}
 
-      {if $form.is_recur}
+      {if !empty($form.is_recur)}
         <div class="crm-public-form-item crm-section {$form.is_recur.name}-section">
           <div class="label">&nbsp;</div>
           <div class="content">
@@ -199,7 +199,7 @@
             <div class="crm-public-form-item crm-section honor_block_text-section">
               {$honor_block_text}
             </div>
-          {if $form.soft_credit_type_id.html}
+          {if !empty($form.soft_credit_type_id.html)}
             <div class="crm-public-form-item crm-section {$form.soft_credit_type_id.name}-section">
               <div class="content" >
                 {$form.soft_credit_type_id.html}
@@ -256,7 +256,7 @@
       {* end of ccid loop *}
     {/if}
 
-    {if $form.payment_processor_id.label}
+    {if !empty($form.payment_processor_id.label)}
       {* PP selection only works with JS enabled, so we hide it initially *}
       <fieldset class="crm-public-form-item crm-group payment_options-group" style="display:none;">
         <legend>{ts}Payment Options{/ts}</legend>

--- a/templates/CRM/Contribute/Form/Contribution/OnBehalfOf.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/OnBehalfOf.tpl
@@ -13,7 +13,7 @@
  * FIXME: This is way more complex than it needs to be
  * FIXME: Why are we not just using the dynamic form tpl to display this profile?
  *}
-{if $form.is_for_organization}
+{if !empty($form.is_for_organization)}
   <div class="crm-public-form-item crm-section {$form.is_for_organization.name}-section">
     <div class="label">&nbsp;</div>
     <div class="content">
@@ -28,7 +28,7 @@
   {if $onBehalfOfFields && $onBehalfOfFields|@count}
     <fieldset>
       <legend>{$fieldSetTitle}</legend>
-      {if $form.org_option}
+      {if !empty($form.org_option)}
         <div id='orgOptions' class="section crm-public-form-item crm-section">
           <div class="content">
             {$form.org_option.html}

--- a/templates/CRM/Contribute/Form/ContributionPage/Amount.tpl
+++ b/templates/CRM/Contribute/Form/ContributionPage/Amount.tpl
@@ -420,7 +420,7 @@
 
 </script>
 {/literal}
-{if $form.is_recur}
+{if !empty($form.is_recur)}
 {include file="CRM/common/showHideByFieldValue.tpl"
     trigger_field_id    ="is_recur"
     trigger_value       ="true"
@@ -430,7 +430,7 @@
     invert              = "false"
 }
 {/if}
-{if $form.adjust_recur_start_date}
+{if !empty($form.adjust_recur_start_date)}
 {include file="CRM/common/showHideByFieldValue.tpl"
     trigger_field_id    ="adjust_recur_start_date"
     trigger_value       ="true"

--- a/templates/CRM/Contribute/Page/Widget.tpl
+++ b/templates/CRM/Contribute/Page/Widget.tpl
@@ -136,7 +136,7 @@
     <div class="crm-amount-raised-wrapper">
         <span id="crm_cpid_{$cpageId}_amt_raised" class="crm-amount-raised"> -- placeholder -- </span>
     </div>
-    {if $form.url_logo.value}
+    {if !empty($form.url_logo.value)}
         <div class="crm-logo"><img src="{$form.url_logo.value}" alt={ts}Logo{/ts}></div>
     {/if}
     <div id="crm_cpid_{$cpageId}_donors" class="crm-donors"></div>

--- a/templates/CRM/Custom/Form/Field.tpl
+++ b/templates/CRM/Custom/Form/Field.tpl
@@ -30,7 +30,7 @@
       <td class="label">{$form.serialize.label}</td>
       <td class="html-adjust">{$form.serialize.html}</td>
     </tr>
-    {if $form.in_selector}
+    {if !empty($form.in_selector)}
       <tr class='crm-custom-field-form-block-in_selector'>
         <td class='label'>{$form.in_selector.label}</td>
         <td class='html-adjust'>{$form.in_selector.html} {help id="id-in_selector"}</td>

--- a/templates/CRM/Custom/Form/Optionfields.tpl
+++ b/templates/CRM/Custom/Form/Optionfields.tpl
@@ -15,7 +15,7 @@
 </td>
 </tr>
 
-<tr id="option_group" {if !$form.option_group_id}class="hiddenElement"{/if}>
+<tr id="option_group" {if empty($form.option_group_id)}class="hiddenElement"{/if}>
   <td class="label">{$form.option_group_id.label}</td>
   <td class="html-adjust">{$form.option_group_id.html}</td>
 </tr>
@@ -86,7 +86,7 @@
     {* hide and display the appropriate blocks as directed by the php code *}
     on_load_init_blocks( showRows, hideBlocks, '' );
 
-{if $form.option_group_id}
+{if !empty($form.option_group_id)}
 {literal}
 function showOptionSelect( ) {
    if ( document.getElementsByName("option_type")[0].checked ) {

--- a/templates/CRM/Event/Form/EventFees.tpl
+++ b/templates/CRM/Event/Form/EventFees.tpl
@@ -227,7 +227,7 @@
 
      function fillTotalAmount( totalAmount ) {
           if ( !totalAmount ) {
-        var amountVal = {/literal}{if $form.amount.value}{$form.amount.value}{else}0{/if}{literal};
+        var amountVal = {/literal}{if !empty($form.amount.value)}{$form.amount.value}{else}0{/if}{literal};
         if ( amountVal > 0 ) {
                var eventFeeBlockValues = {/literal}{$eventFeeBlockValues}{literal};
           totalAmount = eval('eventFeeBlockValues.amount_id_'+ amountVal);

--- a/templates/CRM/Event/Form/ManageEvent/EventInfo.tpl
+++ b/templates/CRM/Event/Form/ManageEvent/EventInfo.tpl
@@ -15,13 +15,13 @@
     {include file="CRM/common/formButtons.tpl" location="top"}
   </div>
   <table class="form-layout-compressed">
-    {if $form.template_id}
+    {if !empty($form.template_id)}
       <tr class="crm-event-manage-eventinfo-form-block-template_id">
         <td class="label">{$form.template_id.label} {help id="id-select-template" isTemplate=$isTemplate}</td>
         <td>{$form.template_id.html}</td>
       </tr>
     {/if}
-    {if $form.template_title}
+    {if !empty($form.template_title)}
       <tr class="crm-event-manage-eventinfo-form-block-template_title">
         <td class="label">{$form.template_title.label} {help id="id-template-title"}{if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_event' field='template_title' id=$eventID}{/if}</td>
         <td>{$form.template_title.html}</td>
@@ -90,7 +90,7 @@
       <td>{$form.event_full_text.html}</td>
     </tr>
     <tr id="id-waitlist-text" class="crm-event-manage-eventinfo-form-block-waitlist_text">
-      {if $form.waitlist_text}
+      {if !empty($form.waitlist_text)}
         <td class="label">{$form.waitlist_text.label} {if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_event' field='waitlist_text' id=$eventID}{/if}<br />{help id="id-help-waitlist_text"}</td>
         <td>{$form.waitlist_text.html}</td>
       {/if}

--- a/templates/CRM/Event/Form/ManageEvent/Registration.tpl
+++ b/templates/CRM/Event/Form/ManageEvent/Registration.tpl
@@ -80,13 +80,13 @@
     <td>{$form.dedupe_rule_group_id.html} {help id="id-dedupe_rule_group_id"}</td>
   </tr>
   <tr class="crm-event-manage-registration-form-block-requires_approval">
-    {if $form.requires_approval}
+    {if !empty($form.requires_approval)}
       <td scope="row" class="label" width="20%">{$form.requires_approval.label}</td>
       <td>{$form.requires_approval.html} {help id="id-requires_approval"}</td>
     {/if}
   </tr>
   <tr id="id-approval-text" class="crm-event-manage-registration-form-block-approval_req_text">
-    {if $form.approval_req_text}
+    {if !empty($form.approval_req_text)}
       <td scope="row" class="label"
           width="20%">{$form.approval_req_text.label} {if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_event' field='approval_req_text' id=$eventID}{/if}</td>
       <td>{$form.approval_req_text.html}</td>
@@ -379,7 +379,7 @@ target_element_type ="block"
 field_type          ="radio"
 invert              = 0
 }
-{if $form.requires_approval}
+{if !empty($form.requires_approval)}
 {include file="CRM/common/showHideByFieldValue.tpl"
     trigger_field_id    ="requires_approval"
     trigger_value       =""

--- a/templates/CRM/Event/Form/Registration/Register.tpl
+++ b/templates/CRM/Event/Form/Registration/Register.tpl
@@ -56,7 +56,7 @@
       </div>
     {/if}
 
-    {if $form.additional_participants.html}
+    {if !empty($form.additional_participants.html)}
       <div class="crm-public-form-item crm-section additional_participants-section" id="noOfparticipants">
         <div class="label">{$form.additional_participants.label} <span class="crm-marker" title="{ts}This field is required.{/ts}">*</span></div>
         <div class="content">
@@ -122,7 +122,7 @@
       </fieldset>
     {/if}
 
-    {if $form.payment_processor_id.label}
+    {if !empty($form.payment_processor_id.label)}
       <fieldset class="crm-public-form-item crm-group payment_options-group" style="display:none;">
         <legend>{ts}Payment Options{/ts}</legend>
         <div class="crm-section payment_processor-section">

--- a/templates/CRM/Event/Form/SelfSvcTransfer.tpl
+++ b/templates/CRM/Event/Form/SelfSvcTransfer.tpl
@@ -28,7 +28,7 @@
       <td class="crm-participant-participant_role">{$details.role}</td>
     </tr>
   </table>
-  {if $form.contact_id}
+  {if !empty($form.contact_id)}
     <div class="crm-public-form-item crm-section selfsvctransfer-section">
       <div class="crm-public-form-item crm-section selfsvctransfer-contact_id-section">
         <div class="label">{$form.contact_id.label}</div>

--- a/templates/CRM/Event/Form/Task/AddToGroup.tpl
+++ b/templates/CRM/Event/Form/Task/AddToGroup.tpl
@@ -33,7 +33,7 @@
                 <tr class="crm-contact-task-addtogroup-form-block-description">
                    <td class="label">{$form.description.label}</td>
                    <td>{$form.description.html}</td></tr>
-                {if $form.group_type}
+                {if !empty($form.group_type)}
                 <tr class="crm-contact-task-addtogroup-form-block-group_type">
         <td class="label">{$form.group_type.label}</td>
                     <td>{$form.group_type.html}</td>

--- a/templates/CRM/Export/Form/Select.tpl
+++ b/templates/CRM/Export/Form/Select.tpl
@@ -29,7 +29,7 @@
   </div>
 
   <div id="map" class="crm-section crm-export-mapping-section">
-      {if $form.mapping }
+      {if !empty($form.mapping)}
         <div class="label crm-label-export-mapping">
             {$form.mapping.label}
         </div>

--- a/templates/CRM/Financial/Form/BatchTransaction.tpl
+++ b/templates/CRM/Financial/Form/BatchTransaction.tpl
@@ -25,7 +25,7 @@
             </td>
           </tr>
           <tr>
-          {if $form.contact_tags}
+          {if !empty($form.contact_tags)}
             <td>
               <label>{ts}Contributor Tag(s){/ts}</label><br>
               {$form.contact_tags.html}
@@ -33,7 +33,7 @@
             {else}
             <td>&nbsp;</td>
           {/if}
-          {if $form.group}
+          {if !empty($form.group)}
             <td><label>{ts}Contributor Group(s){/ts}</label><br>
               {$form.group.html}
             </td>
@@ -242,7 +242,7 @@ function buildTransactionSelectorAssign(filterSearch) {
     });
   }
 });
-	
+
 }
 
 function buildTransactionSelectorRemove( ) {

--- a/templates/CRM/Form/attachment.tpl
+++ b/templates/CRM/Form/attachment.tpl
@@ -41,7 +41,7 @@
      {/if}
     <div id="attachments">
       <table class="form-layout-compressed">
-      {if $form.attachFile_1}
+      {if !empty($form.attachFile_1)}
         {if !empty($context) && $context EQ 'pcpCampaign'}
             <div class="description">{ts}You can upload a picture or image to include on your page. Your file should be in .jpg, .gif, or .png format. Recommended image size is 250 x 250 pixels. Images over 360 pixels wide will be automatically resized to fit.{/ts}</div>
         {/if}

--- a/templates/CRM/Form/body.tpl
+++ b/templates/CRM/Form/body.tpl
@@ -7,11 +7,11 @@
  | and copyright information, see https://civicrm.org/licensing       |
  +--------------------------------------------------------------------+
 *}
-{if $form.javascript}
+{if !empty($form.javascript)}
   {$form.javascript}
 {/if}
 
-{if $form.hidden}
+{if !empty($form.hidden)}
   <div>{$form.hidden}</div>
 {/if}
 

--- a/templates/CRM/Group/Form/Edit.tpl
+++ b/templates/CRM/Group/Form/Edit.tpl
@@ -45,7 +45,7 @@
       <td>{$form.frontend_description.html}</td>
     </tr>
 
-    {if $form.group_type}
+    {if !empty($form.group_type)}
       <tr class="crm-group-form-block-group_type">
         <td class="label">{$form.group_type.label}</td>
         <td>{$form.group_type.html} {help id="id-group-type" file="CRM/Group/Page/Group.hlp"}</td>

--- a/templates/CRM/Mailing/Form/Search.tpl
+++ b/templates/CRM/Mailing/Form/Search.tpl
@@ -26,7 +26,7 @@
           {$form.is_archived.html}
         </div>
       </td>
-      {if $form.mailing_status}
+      {if !empty($form.mailing_status)}
          <td width="100%"><label>{if $sms eq 1}{ts}SMS Status{/ts}{else}{ts}Mailing Status{/ts}{/if}</label><br />
            <div class="listing-box" style="height: auto">
              {foreach from=$form.mailing_status item="mailing_status_val"}

--- a/templates/CRM/Member/Form/MembershipBlock.tpl
+++ b/templates/CRM/Member/Form/MembershipBlock.tpl
@@ -12,7 +12,7 @@
 <div class="help">
     {ts}Use this form to enable and configure a Membership Signup and Renewal section for this Online Contribution Page. If you're not using this page for membership signup, leave the <strong>Enabled</strong> box un-checked..{/ts} {docURL page="user/membership/setup"}
 </div>
-  {if $form.membership_type.html}
+  {if !empty($form.membership_type.html)}
   <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
     <table class="form-layout-compressed">
         <tr class="crm-member-membershipblock-form-block-member_is_active">

--- a/templates/CRM/Member/Form/Search/Common.tpl
+++ b/templates/CRM/Member/Form/Search/Common.tpl
@@ -37,7 +37,7 @@
 </tr>
 <tr>
   <td>
-    {if $form.member_auto_renew}
+    {if !empty($form.member_auto_renew)}
       <label>{$form.member_auto_renew.label}</label>
       {help id="id-member_auto_renew" file="CRM/Member/Form/Search.hlp"}
       <br/>

--- a/templates/CRM/PCP/Form/PCP.tpl
+++ b/templates/CRM/PCP/Form/PCP.tpl
@@ -19,7 +19,7 @@
 
 <div id="pcpFields">
 {crmRegion name="pcp-form-pcp-fields"}
-  {if $form.target_entity_type}
+  {if !empty($form.target_entity_type)}
   <table class="form-layout">
     <tr  class="crm-contribution-contributionpage-pcp-form-block-target_entity_type">
         <td class="label">{$form.target_entity_type.label} <span class="crm-marker"> *</span></td>

--- a/templates/CRM/Pledge/Form/Pledge.tpl
+++ b/templates/CRM/Pledge/Form/Pledge.tpl
@@ -81,7 +81,7 @@
           </tr>
 
         {if $email and $outBound_option != 2}
-            {if $form.is_acknowledge }
+            {if !empty($form.is_acknowledge)}
           <tr class="crm-pledge-form-block-is_acknowledge">
             <td class="label">{$form.is_acknowledge.label}</td>
             <td>{$form.is_acknowledge.html}<br />

--- a/templates/CRM/Price/Form/Option.tpl
+++ b/templates/CRM/Price/Form/Option.tpl
@@ -63,14 +63,14 @@
         </td>
       </tr>
       {* fix for CRM-10241 *}
-      {if $form.count.html}
+      {if !empty($form.count.html)}
         <tr class="crm-price-option-form-block-count">
           <td class="label">{$form.count.label}</td>
           <td>{$form.count.html} {help id="id-participant-count" file="CRM/Price/Page/Field.hlp"}</td>
         </tr>
         {* 2 line fix for CRM-10241 *}
       {/if}
-      {if $form.max_value.html}
+      {if !empty($form.max_value.html)}
         <tr class="crm-price-option-form-block-max_value">
           <td class="label">{$form.max_value.label}</td>
           <td>{$form.max_value.html} {help id="id-participant-max" file="CRM/Price/Page/Field.hlp"}</td>

--- a/templates/CRM/Tag/Form/Edit.tpl
+++ b/templates/CRM/Tag/Form/Edit.tpl
@@ -20,13 +20,13 @@
           <td class="label">{$form.description.label}</td>
           <td>{$form.description.html}</td>
        </tr>
-         {if $form.parent_id.html}
+         {if !empty($form.parent_id.html)}
        <tr class="crm-tag-form-block-parent_id">
          <td class="label">{$form.parent_id.label}</td>
          <td>{$form.parent_id.html}</td>
        </tr>
    {/if}
-      {if $form.used_for}
+      {if !empty($form.used_for)}
        <tr class="crm-tag-form-block-used_for">
           <td class="label">{$form.used_for.label}</td>
           <td>{$form.used_for.html} <br />
@@ -39,7 +39,7 @@
           </td>
         </tr>
       {/if}
-      {if $form.color.html}
+      {if !empty($form.color.html)}
         <tr class="crm-tag-form-block-color">
           <td class="label">{$form.color.label}</td>
           <td>{$form.color.html}</td>

--- a/templates/CRM/common/CMSUser.tpl
+++ b/templates/CRM/common/CMSUser.tpl
@@ -11,7 +11,7 @@
    <fieldset class="crm-group crm_user-group">
       <div class="messages help cms_user_help-section">
    {if !$isCMS}
-      {ts}If you would like to create an account on this site, check the box below and enter a Username{/ts}{if $form.cms_pass} {ts}and a password{/ts}.{/if}
+      {ts}If you would like to create an account on this site, check the box below and enter a Username{/ts}{if !empty($form.cms_pass)} {ts}and a password{/ts}.{/if}
    {else}
       {ts}Please enter a Username to create an account.{/ts}
    {/if}
@@ -32,7 +32,7 @@
              </div>
            </div>
 
-           {if $form.cms_pass}
+           {if !empty($form.cms_pass)}
            <div class="crm-section cms_pass-section">
              <div class="label">
                <label for="cms_pass">{$form.cms_pass.label}</label>


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a bunch of e-notices coming from smarty templates using mass regex find & replace.

Technical Details
----------------------------------------
Referencing a property of the $form in smarty is almost always going to be undefined if it hasn't been set on the form, so this fixes a bad pattern of not using `empty()` to guard against e-notices.