### PR TITLE
For latest iteration of case email form, don't fail when there's no To contact

### DIFF
--- a/CRM/Contact/Form/Task/EmailTrait.php
+++ b/CRM/Contact/Form/Task/EmailTrait.php
@@ -201,7 +201,7 @@ trait CRM_Contact_Form_Task_EmailTrait {
     }
 
     // check if we need to setdefaults and check for valid contact emails / communication preferences
-    if (is_array($this->_allContactIds) && $setDefaults) {
+    if (!empty($this->_allContactIds) && $setDefaults) {
       // get the details for all selected contacts ( to, cc and bcc contacts )
       $allContactDetails = civicrm_api3('Contact', 'get', [
         'id' => ['IN' => $this->_allContactIds],


### PR DESCRIPTION
Overview
----------------------------------------
1. Add Email as an activity in the case type definition.
2. Visit manage case and from the activity dropdown choose Email.

Before
----------------------------------------
Crash

After
----------------------------------------
Ok

Technical Details
----------------------------------------
The default in CRM_Core_Form_Task for _contactIds is null. But pretty much everywhere an empty array makes more sense and several places set it to an empty array. I can't see a reason why line 204 here treats null differently than array. When you look at what the if block does, assuming an empty array didn't crash, the whole if block would still do nothing the same as null.

Comments
----------------------------------------
I can add a test just want to test this out a bit more. Possibly could even change the default in CRM_Core_Form_Task as well.