### PR TITLE
#2892 Replace event type token in action schedule changes event.event_type_id to participant.event_type_id:label. But should be event.event_type_id to event.event_type_id:label

### DIFF
--- a/CRM/Upgrade/Incremental/php/FiveFortyThree.php
+++ b/CRM/Upgrade/Incremental/php/FiveFortyThree.php
@@ -78,7 +78,7 @@ class CRM_Upgrade_Incremental_php_FiveFortyThree extends CRM_Upgrade_Incremental
       'updateActionScheduleToken', 'event.fee_amount', 'participant.fee_amount', $rev
     );
     $this->addTask('Replace event type token in action schedule',
-      'updateActionScheduleToken', 'event.event_type_id', 'participant.event_type_id:label', $rev
+      'updateActionScheduleToken', 'event.event_type_id', 'event.event_type_id:label', $rev
     );
     $this->addTask('Replace event balance in action schedule',
       'updateActionScheduleToken', 'event.balance', 'participant.balance', $rev


### PR DESCRIPTION
Replace event type token in action schedule changes event.event_type_id to participant.event_type_id:label. But should be event.event_type_id to event.event_type_id:label

As identified by @magnolia61 here https://github.com/civicrm/civicrm-core/pull/21666/files#r720059285

Related https://lab.civicrm.org/dev/core/-/issues/2892