### PR TITLE
Flush metadata cache on event edit

### DIFF
--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -154,7 +154,10 @@ class CRM_Event_BAO_Event extends CRM_Event_DAO_Event {
     }
 
     $transaction->commit();
-
+    if (!empty($params['id'])) {
+      // Note that this will specifically clear cached event tokens.
+      Civi::cache('metadata')->clear();
+    }
     return $event;
   }
 
@@ -1093,7 +1096,7 @@ WHERE civicrm_event.is_active = 1
                 TRUE,
                 $participantParams
               );
-              list($profileValues) = $profileValues;
+              [$profileValues] = $profileValues;
               $val = [
                 'id' => $gId,
                 'values' => $profileValues,


### PR DESCRIPTION
Overview
----------------------------------------
Flush metadata cache on event edit

Before
----------------------------------------
Per @agileware-justin testing - tokens for events are cached & changes might not be picked up immediately

After
----------------------------------------
metadata cache cleared on event edit. 

Technical Details
----------------------------------------
It might be possible to nuance this - but the metadata cache is generally used for configuration entities like events, price sets, membership types - that generally are not consistently being edited

Comments
----------------------------------------
