### PR TITLE
Email tokens - preparatory sanity imposition

### DIFF
--- a/CRM/Contact/Form/Task/EmailTrait.php
+++ b/CRM/Contact/Form/Task/EmailTrait.php
@@ -823,13 +823,11 @@ trait CRM_Contact_Form_Task_EmailTrait {
       }
 
       $tokenSubject = $subject;
-      $tokenText = in_array($values['preferred_mail_format'], ['Both', 'Text'], TRUE) ? $text : '';
-      $tokenHtml = in_array($values['preferred_mail_format'], ['Both', 'HTML'], TRUE) ? $html : '';
 
       $renderedTemplate = CRM_Core_BAO_MessageTemplate::renderTemplate([
         'messageTemplate' => [
-          'msg_text' => $tokenText,
-          'msg_html' => $tokenHtml,
+          'msg_text' => $text,
+          'msg_html' => $html,
           'msg_subject' => $tokenSubject,
         ],
         'tokenContext' => $tokenContext,


### PR DESCRIPTION
Overview
----------------------------------------
Move crazy submit pre-processing out of buildForm

Before
----------------------------------------
Pre-processing of submitted values begins in `buildForm` making it mind-breakingly hard to figure out what is happening

After
----------------------------------------
Moved to getting the details from the submitted value in the `to` field

Technical Details
----------------------------------------
@demeritcowboy - still working through testing this & trying to build off it - but I think this is the missing piece for taking the email trait out of the twilight zone & into the 'merely laddened with technical debt' zone

I might need to add some filtering to 'submit' to remove 'should not email' types

Comments
----------------------------------------
Depends on https://github.com/civicrm/civicrm-core/pull/21676