### PR TITLE
Support participant & membership tokens in send-email tasks

### DIFF
--- a/CRM/Case/Form/Task.php
+++ b/CRM/Case/Form/Task.php
@@ -76,7 +76,7 @@ class CRM_Case_Form_Task extends CRM_Core_Form_Task {
       if (empty($caseID) && !empty($this->_caseIds[$index])) {
         $caseID = $this->_caseIds[$index];
       }
-      $rows[] = ['contactId' => $contactID, 'caseId' => $caseID];
+      $rows[] = ['contact_id' => $contactID, 'schema' => ['caseId' => $caseID, 'contactId' => $contactID]];
     }
     return $rows;
   }

--- a/CRM/Case/Form/Task/Email.php
+++ b/CRM/Case/Form/Task/Email.php
@@ -53,12 +53,11 @@ class CRM_Case_Form_Task_Email extends CRM_Case_Form_Task {
    *
    * The case handling should possibly be on the case form.....
    *
-   * @param string $subject
-   *
    * @return string
    * @throws \CRM_Core_Exception
    */
-  protected function getSubject(string $subject):string {
+  protected function getSubject():string {
+    $subject = $this->getSubmittedValue('subject');
     // CRM-5916: prepend case id hash to CiviCase-originating emails’ subjects
     if ($this->getCaseID()) {
       $hash = substr(sha1(CIVICRM_SITE_KEY . $this->getCaseID()), 0, 7);

--- a/CRM/Case/Form/Task/Email.php
+++ b/CRM/Case/Form/Task/Email.php
@@ -66,4 +66,18 @@ class CRM_Case_Form_Task_Email extends CRM_Case_Form_Task {
     return $subject;
   }
 
+  /**
+   * Get the result rows to email.
+   *
+   * @return array
+   */
+  protected function getRows(): array {
+    // format contact details array to handle multiple emails from same contact
+    $rows = parent::getRows();
+    foreach ($rows as $index => $row) {
+      $rows[$index]['schema']['caseId'] = $this->getCaseID();
+    }
+    return $rows;
+  }
+
 }

--- a/CRM/Contact/Form/Task/EmailTrait.php
+++ b/CRM/Contact/Form/Task/EmailTrait.php
@@ -409,7 +409,6 @@ trait CRM_Contact_Form_Task_EmailTrait {
     // send the mail
     [$sent, $activityIds] = $this->sendEmail(
       $formattedContactDetails,
-      $this->getSubject($formValues['subject']),
       $formValues['text_message'],
       $formValues['html_message'],
       $from,
@@ -578,15 +577,10 @@ trait CRM_Contact_Form_Task_EmailTrait {
   /**
    * Get the subject for the message.
    *
-   * The case handling should possibly be on the case form.....
-   *
-   * @param string $subject
-   *
    * @return string
-   * @throws \CRM_Core_Exception
    */
-  protected function getSubject(string $subject):string {
-    return $subject;
+  protected function getSubject():string {
+    return (string) $this->getSubmittedValue('subject');
   }
 
   /**
@@ -750,8 +744,6 @@ trait CRM_Contact_Form_Task_EmailTrait {
    *
    * @param array $contactDetails
    *   The array of contact details to send the email.
-   * @param string $subject
-   *   The subject of the message.
    * @param $text
    * @param $html
    * @param string $from
@@ -781,7 +773,6 @@ trait CRM_Contact_Form_Task_EmailTrait {
    */
   public function sendEmail(
     $contactDetails,
-    $subject,
     $text,
     $html,
     $from,
@@ -822,13 +813,11 @@ trait CRM_Contact_Form_Task_EmailTrait {
         $tokenContext['contributionId'] = $contributionDetails[$contactId]['id'];
       }
 
-      $tokenSubject = $subject;
-
       $renderedTemplate = CRM_Core_BAO_MessageTemplate::renderTemplate([
         'messageTemplate' => [
           'msg_text' => $text,
           'msg_html' => $html,
-          'msg_subject' => $tokenSubject,
+          'msg_subject' => $this->getSubject(),
         ],
         'tokenContext' => $tokenContext,
         'contactId' => $contactId,

--- a/CRM/Contact/Form/Task/EmailTrait.php
+++ b/CRM/Contact/Form/Task/EmailTrait.php
@@ -161,7 +161,7 @@ trait CRM_Contact_Form_Task_EmailTrait {
     $emailAttributes = [
       'class' => 'huge',
     ];
-    $to = $this->add('text', 'to', ts('To'), $emailAttributes, TRUE);
+    $this->add('text', 'to', ts('To'), $emailAttributes, TRUE);
 
     $this->addEntityRef('cc_id', ts('CC'), [
       'entity' => 'Email',
@@ -173,26 +173,12 @@ trait CRM_Contact_Form_Task_EmailTrait {
       'multiple' => TRUE,
     ]);
 
-    if ($to->getValue()) {
-      $this->_toContactIds = $this->_contactIds = [];
-    }
     $setDefaults = TRUE;
     if (property_exists($this, '_context') && $this->_context === 'standalone') {
       $setDefaults = FALSE;
     }
 
     $this->_allContactIds = $this->_toContactIds = $this->_contactIds;
-
-    if ($to->getValue()) {
-      foreach ($this->getEmails($to) as $value) {
-        $contactId = $value['contact_id'];
-        if ($contactId) {
-          $this->_contactIds[] = $this->_toContactIds[] = $contactId;
-          $this->_allContactIds[] = $contactId;
-        }
-      }
-      $setDefaults = TRUE;
-    }
 
     //get the group of contacts as per selected by user in case of Find Activities
     if (!empty($this->_activityHolderIds)) {
@@ -374,7 +360,6 @@ trait CRM_Contact_Form_Task_EmailTrait {
    */
   public function submit($formValues): void {
     $this->saveMessageTemplate($formValues);
-
     $from = $formValues['from_email_address'];
     // dev/core#357 User Emails are keyed by their id so that the Signature is able to be added
     // If we have had a contact email used here the value returned from the line above will be the
@@ -391,19 +376,8 @@ trait CRM_Contact_Form_Task_EmailTrait {
 
     // format contact details array to handle multiple emails from same contact
     $formattedContactDetails = [];
-    foreach ($this->_contactIds as $key => $contactId) {
-      // if we dont have details on this contactID, we should ignore
-      // potentially this is due to the contact not wanting to receive email
-      if (!isset($this->_contactDetails[$contactId])) {
-        continue;
-      }
-      $email = $this->getEmail($key);
-      // prevent duplicate emails if same email address is selected CRM-4067
-      // we should allow same emails for different contacts
-      $details = $this->_contactDetails[$contactId];
-      $details['email'] = $email;
-      unset($details['email_id']);
-      $formattedContactDetails["{$contactId}::{$email}"] = $details;
+    foreach ($this->getEmails() as $details) {
+      $formattedContactDetails[$details['contact_id'] . '::' . $details['email']] = $details;
     }
 
     // send the mail
@@ -486,12 +460,10 @@ trait CRM_Contact_Form_Task_EmailTrait {
   /**
    * Get the emails from the added element.
    *
-   * @param HTML_QuickForm_Element $element
-   *
    * @return array
    */
-  protected function getEmails($element): array {
-    $allEmails = explode(',', $element->getValue());
+  protected function getEmails(): array {
+    $allEmails = explode(',', $this->getSubmittedValue('to'));
     $return = [];
     foreach ($allEmails as $value) {
       $values = explode('::', $value);

--- a/CRM/Contact/Form/Task/PDF.php
+++ b/CRM/Contact/Form/Task/PDF.php
@@ -127,7 +127,7 @@ class CRM_Contact_Form_Task_PDF extends CRM_Contact_Form_Task {
       if (empty($caseID) && !empty($this->_caseIds[$index])) {
         $caseID = $this->_caseIds[$index];
       }
-      $rows[] = ['contactId' => $contactID, 'caseId' => $caseID];
+      $rows[] = ['contact_id' => $contactID, 'schema' => ['caseId' => $caseID, 'contactId' => $contactID]];
     }
     return $rows;
   }

--- a/CRM/Contact/Form/Task/PDFTrait.php
+++ b/CRM/Contact/Form/Task/PDFTrait.php
@@ -241,7 +241,7 @@ trait CRM_Contact_Form_Task_PDFTrait {
       $tokenHtml = CRM_Core_BAO_MessageTemplate::renderTemplate([
         'contactId' => $row['contact_id'],
         'messageTemplate' => ['msg_html' => $html_message],
-        'tokenContext' => ['schema' => $row['schema']],
+        'tokenContext' => array_merge(['schema' => $this->getTokenSchema()], ($row['schema'] ?? [])),
         'disableSmarty' => (!defined('CIVICRM_MAIL_SMARTY') || !CIVICRM_MAIL_SMARTY),
       ])['html'];
 

--- a/CRM/Contact/Form/Task/PDFTrait.php
+++ b/CRM/Contact/Form/Task/PDFTrait.php
@@ -239,9 +239,9 @@ trait CRM_Contact_Form_Task_PDFTrait {
 
     foreach ($this->getRows() as $row) {
       $tokenHtml = CRM_Core_BAO_MessageTemplate::renderTemplate([
-        'contactId' => $row['contactId'],
+        'contactId' => $row['contact_id'],
         'messageTemplate' => ['msg_html' => $html_message],
-        'tokenContext' => array_merge($row, ['schema' => $this->getTokenSchema()]),
+        'tokenContext' => ['schema' => $row['schema']],
         'disableSmarty' => (!defined('CIVICRM_MAIL_SMARTY') || !CIVICRM_MAIL_SMARTY),
       ])['html'];
 

--- a/CRM/Contribute/Form/Task/Email.php
+++ b/CRM/Contribute/Form/Task/Email.php
@@ -15,6 +15,8 @@
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
 
+use Civi\Api4\Contribution;
+
 /**
  * This class provides the functionality to email a group of contacts.
  */
@@ -30,6 +32,37 @@ class CRM_Contribute_Form_Task_Email extends CRM_Contribute_Form_Task {
    */
   protected function getContributionIDs(): array {
     return $this->getIDs();
+  }
+
+  /**
+   * Get the result rows to email.
+   *
+   * @return array
+   *
+   * @throws \API_Exception
+   * @throws \CRM_Core_Exception
+   */
+  protected function getRows(): array {
+    $contributionDetails = Contribution::get(FALSE)
+      ->setSelect(['contact_id', 'id'])
+      ->addWhere('id', 'IN', $this->getContributionIDs())
+      ->execute()
+      // Note that this indexing means that only the last
+      // contribution per contact is resolved to tokens.
+      // this is long-standing functionality, albeit possibly
+      // not thought through.
+      ->indexBy('contact_id');
+
+    // format contact details array to handle multiple emails from same contact
+    $formattedContactDetails = [];
+    foreach ($this->getEmails() as $details) {
+      $formattedContactDetails[$details['contact_id'] . '::' . $details['email']] = $details;
+      if (!empty($contributionDetails[$details['contact_id']])) {
+        $formattedContactDetails[$details['contact_id'] . '::' . $details['email']]['schema'] = ['contributionId' => $contributionDetails[$details['contact_id']]['id']];
+      }
+
+    }
+    return $formattedContactDetails;
   }
 
 }

--- a/CRM/Core/Form/Task.php
+++ b/CRM/Core/Form/Task.php
@@ -367,7 +367,7 @@ SELECT contact_id
   protected function getRows(): array {
     $rows = [];
     foreach ($this->getContactIDs() as $contactID) {
-      $rows[] = ['contactId' => $contactID];
+      $rows[] = ['schema' => ['contactId' => $contactID]];
     }
     return $rows;
   }

--- a/CRM/Core/Form/Task.php
+++ b/CRM/Core/Form/Task.php
@@ -75,6 +75,18 @@ abstract class CRM_Core_Form_Task extends CRM_Core_Form {
    */
   public static $entityShortname = NULL;
 
+
+  /**
+   * Rows to act on.
+   *
+   * e.g
+   *  [
+   *    ['contact_id' => 4, 'participant_id' => 6, 'schema' => ['contactId' => 5, 'participantId' => 6],
+   *  ]
+   * @var array
+   */
+  protected $rows = [];
+
   /**
    * Set where the browser should be directed to next.
    *
@@ -367,7 +379,7 @@ SELECT contact_id
   protected function getRows(): array {
     $rows = [];
     foreach ($this->getContactIDs() as $contactID) {
-      $rows[] = ['schema' => ['contactId' => $contactID]];
+      $rows[] = ['contact_id' => $contactID, 'schema' => ['contactId' => $contactID]];
     }
     return $rows;
   }

--- a/CRM/Core/SelectValues.php
+++ b/CRM/Core/SelectValues.php
@@ -610,25 +610,22 @@ class CRM_Core_SelectValues {
    * @return array
    */
   public static function caseTokens($caseTypeId = NULL) {
-    static $tokens = NULL;
-    if (!$tokens) {
-      $tokens = [
-        '{case.id}' => ts('Case ID'),
-        '{case.case_type_id:label}' => ts('Case Type'),
-        '{case.subject}' => ts('Case Subject'),
-        '{case.start_date}' => ts('Case Start Date'),
-        '{case.end_date}' => ts('Case End Date'),
-        '{case.details}' => ts('Details'),
-        '{case.status_id:label}' => ts('Case Status'),
-        '{case.is_deleted:label}' => ts('Case is in the Trash'),
-        '{case.created_date}' => ts('Created Date'),
-        '{case.modified_date}' => ts('Modified Date'),
-      ];
+    $tokens = [
+      '{case.id}' => ts('Case ID'),
+      '{case.case_type_id:label}' => ts('Case Type'),
+      '{case.subject}' => ts('Case Subject'),
+      '{case.start_date}' => ts('Case Start Date'),
+      '{case.end_date}' => ts('Case End Date'),
+      '{case.details}' => ts('Details'),
+      '{case.status_id:label}' => ts('Case Status'),
+      '{case.is_deleted:label}' => ts('Case is in the Trash'),
+      '{case.created_date}' => ts('Created Date'),
+      '{case.modified_date}' => ts('Modified Date'),
+    ];
 
-      $customFields = CRM_Core_BAO_CustomField::getFields('Case', FALSE, FALSE, $caseTypeId);
-      foreach ($customFields as $id => $field) {
-        $tokens["{case.custom_$id}"] = "{$field['label']} :: {$field['groupTitle']}";
-      }
+    $customFields = CRM_Core_BAO_CustomField::getFields('Case', FALSE, FALSE, $caseTypeId);
+    foreach ($customFields as $id => $field) {
+      $tokens["{case.custom_$id}"] = "{$field['label']} :: {$field['groupTitle']}";
     }
     return $tokens;
   }

--- a/CRM/Event/Form/Task.php
+++ b/CRM/Event/Form/Task.php
@@ -122,7 +122,7 @@ class CRM_Event_Form_Task extends CRM_Core_Form_Task {
       return $this->_contactIds;
     }
     foreach ($this->getRows() as $row) {
-      $this->_contactIds[] = $row['contactId'];
+      $this->_contactIds[] = $row['contact_id'];
     }
     return $this->_contactIds;
   }
@@ -158,7 +158,7 @@ class CRM_Event_Form_Task extends CRM_Core_Form_Task {
    *
    * @throws \API_Exception
    */
-  public function getRows(): array {
+  protected function getRows(): array {
     if (empty($this->rows)) {
       // checkPermissions set to false - in case form is bypassing in some way.
       $participants = Participant::get(FALSE)
@@ -166,9 +166,12 @@ class CRM_Event_Form_Task extends CRM_Core_Form_Task {
         ->setSelect(['id', 'contact_id'])->execute();
       foreach ($participants as $participant) {
         $this->rows[] = [
-          // We map to this funky format for the token processor :-(
-          'contactId' => $participant['contact_id'],
-          'participantId' => $participant['id'],
+          'contact_id' => $participant['contact_id'],
+          'participant_id' => $participant['id'],
+          'schema' => [
+            'contactId' => $participant['contact_id'],
+            'participantId' => $participant['id'],
+          ],
         ];
       }
     }

--- a/CRM/Event/Form/Task/Email.php
+++ b/CRM/Event/Form/Task/Email.php
@@ -22,4 +22,17 @@
 class CRM_Event_Form_Task_Email extends CRM_Event_Form_Task {
   use CRM_Contact_Form_Task_EmailTrait;
 
+  /**
+   * Only send one email per contact.
+   *
+   * This has historically been done for contributions & makes sense if
+   * no entity specific tokens are in use.
+   *
+   * @return bool
+   * @throws \CRM_Core_Exception
+   */
+  protected function isGroupByContact(): bool {
+    return !empty($this->getMessageTokens()['participant']) || !empty($this->getMessageTokens()['event']);
+  }
+
 }

--- a/CRM/Member/Form/Task/Email.php
+++ b/CRM/Member/Form/Task/Email.php
@@ -22,4 +22,17 @@
 class CRM_Member_Form_Task_Email extends CRM_Member_Form_Task {
   use CRM_Contact_Form_Task_EmailTrait;
 
+  /**
+   * Only send one email per contact.
+   *
+   * This has historically been done for contributions & makes sense if
+   * no entity specific tokens are in use.
+   *
+   * @return bool
+   * @throws \CRM_Core_Exception
+   */
+  protected function isGroupByContact(): bool {
+    return !empty($this->getMessageTokens()['membership']);
+  }
+
 }

--- a/tests/phpunit/CRM/Activity/BAO/ActivityTest.php
+++ b/tests/phpunit/CRM/Activity/BAO/ActivityTest.php
@@ -1261,11 +1261,14 @@ class CRM_Activity_BAO_ActivityTest extends CiviUnitTestCase {
     $text = __FUNCTION__ . ' text {contact.display_name} {case.case_type_id:label}';
 
     /* @var CRM_Contact_Form_Task_Email $form */
-    $form = $this->getFormObject('CRM_Contact_Form_Task_Email');
+    $form = $this->getFormObject('CRM_Contact_Form_Task_Email', [
+      'subject' => $subject,
+      'html_message' => $html,
+      'text_message' => $text,
+    ]);
     $mut = new CiviMailUtils($this, TRUE);
     [$sent, $activity_ids] = $form->sendEmail(
       $contactDetails,
-      $subject,
       $text,
       $html,
       __FUNCTION__ . '@example.com',
@@ -1374,11 +1377,14 @@ class CRM_Activity_BAO_ActivityTest extends CiviUnitTestCase {
     $html = __FUNCTION__ . ' html';
     $text = __FUNCTION__ . ' text';
     /* @var CRM_Contact_Form_Task_Email $form */
-    $form = $this->getFormObject('CRM_Contact_Form_Task_Email');
+    $form = $this->getFormObject('CRM_Contact_Form_Task_Email', [
+      'subject' => $subject,
+      'html_message' => $html,
+      'text_message' => $text,
+    ]);
     $mut = new CiviMailUtils($this, TRUE);
     [$sent, $activity_ids] = $form->sendEmail(
       $contactDetails,
-      $subject,
       $text,
       $html,
       $from = __FUNCTION__ . '@example.com'
@@ -1434,16 +1440,15 @@ $text
     ]);
     $campaign_id = $result['id'];
 
-    $subject = __FUNCTION__ . ' subject';
     $html = __FUNCTION__ . ' html';
     $text = __FUNCTION__ . ' text';
-    $userID = $loggedInUser;
-    /* @var CRM_Contact_Form_Task_Email $form */
-    $form = $this->getFormObject('CRM_Contact_Form_Task_Email');
+    /* @var CRM_Activity_Form_Task_Email $form */
+    $form = $this->getFormObject('CRM_Activity_Form_Task_Email', [
+      'subject' => __FUNCTION__ . ' subject',
+    ]);
 
     [$sent, $activity_ids] = $email_result = $form->sendEmail(
       $contactDetails,
-      $subject,
       $text,
       $html,
       __FUNCTION__ . '@example.com',
@@ -1698,10 +1703,13 @@ $text
 
     $mut = new CiviMailUtils($this, TRUE);
     /* @var CRM_Contact_Form_Task_Email $form */
-    $form = $this->getFormObject('CRM_Contact_Form_Task_Email');
+    $form = $this->getFormObject('CRM_Contact_Form_Task_Email', [
+      'subject' => $subject,
+      'html_message' => $html,
+      'text_message' => $text,
+    ]);
     [$sent, $activity_ids] = $form->sendEmail(
       $contact['values'],
-      $subject,
       $text,
       $html,
       $from = __FUNCTION__ . '@example.com',
@@ -1745,10 +1753,13 @@ $text
     $text = __FUNCTION__ . ' text' . '{contact.display_name}';
 
     /* @var CRM_Contact_Form_Task_Email $form */
-    $form = $this->getFormObject('CRM_Contact_Form_Task_Email');
+    $form = $this->getFormObject('CRM_Contact_Form_Task_Email', [
+      'subject' => $subject,
+      'html_message' => $html,
+      'text_message' => $text,
+    ]);
     $form->sendEmail(
       $contact['values'],
-      $subject,
       $text,
       $html,
     __FUNCTION__ . '@example.com',

--- a/tests/phpunit/CRM/Activity/BAO/ActivityTest.php
+++ b/tests/phpunit/CRM/Activity/BAO/ActivityTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Civi\Api4\Activity;
+use Civi\Api4\OptionValue;
 
 /**
  * Class CRM_Activity_BAO_ActivityTest
@@ -30,8 +31,7 @@ class CRM_Activity_BAO_ActivityTest extends CiviUnitTestCase {
    * Clean up after tests.
    *
    * @throws \API_Exception
-   * @throws \CRM_Core_Exception
-   * @throws \CiviCRM_API3_Exception
+   * @throws \Civi\API\Exception\UnauthorizedException
    */
   public function tearDown(): void {
     $tablesToTruncate = [
@@ -45,7 +45,7 @@ class CRM_Activity_BAO_ActivityTest extends CiviUnitTestCase {
     ];
     $this->quickCleanup($tablesToTruncate);
     $this->cleanUpAfterACLs();
-    $this->setupForSmsTests(TRUE);
+    OptionValue::delete(FALSE)->addWhere('name', '=', 'CiviTestSMSProvider')->execute();
     parent::tearDown();
   }
 
@@ -93,11 +93,8 @@ class CRM_Activity_BAO_ActivityTest extends CiviUnitTestCase {
    *
    * getContactActivity() method get activities detail for given target contact
    * id.
-   *
-   * @throws \CRM_Core_Exception
-   * @throws \CiviCRM_API3_Exception
    */
-  public function testGetContactActivity() {
+  public function testGetContactActivity(): void {
     $contactId = $this->individualCreate();
     $params = [
       'first_name' => 'liz',
@@ -1221,6 +1218,7 @@ class CRM_Activity_BAO_ActivityTest extends CiviUnitTestCase {
   }
 
   /**
+   * @throws \API_Exception
    * @throws \CRM_Core_Exception
    * @throws \CiviCRM_API3_Exception
    */
@@ -1242,46 +1240,22 @@ class CRM_Activity_BAO_ActivityTest extends CiviUnitTestCase {
     ];
 
     $contact = $this->callAPISuccess('Contact', 'getsingle', ['id' => $contactId, 'return' => array_keys($contactDetailsIntersectKeys)]);
-    $contactDetailsIntersectKeys = [
-      'contact_id' => '',
-      'sort_name' => '',
-      'display_name' => '',
-      'do_not_email' => '',
-      'preferred_mail_format' => '',
-      'is_deceased' => '',
-      'email' => '',
-      'on_hold' => '',
-    ];
-    $contactDetails = [
-      array_intersect_key($contact, $contactDetailsIntersectKeys),
-    ];
 
     $subject = __FUNCTION__ . ' subject';
     $html = __FUNCTION__ . ' html {contact.display_name} {case.case_type_id:label}';
     $text = __FUNCTION__ . ' text {contact.display_name} {case.case_type_id:label}';
-
-    /* @var CRM_Contact_Form_Task_Email $form */
-    $form = $this->getFormObject('CRM_Contact_Form_Task_Email', [
+    $form = $this->getCaseEmailTaskForm($contactId, [
       'subject' => $subject,
       'html_message' => $html,
       'text_message' => $text,
     ]);
     $mut = new CiviMailUtils($this, TRUE);
-    [$sent, $activity_ids] = $form->sendEmail(
-      $contactDetails,
-      $text,
-      $html,
-      __FUNCTION__ . '@example.com',
-      NULL,
-      NULL,
-      NULL,
-      NULL,
-      NULL,
-      NULL,
-      $this->getCaseID()
-    );
+    $form->postProcess();
+    $activity = Activity::get()
+      ->addSelect('activity_type_id:label', 'subject', 'details')
+      ->addWhere('activity_type_id:name', '=', 'Email')
+      ->execute()->first();
 
-    $activity = $this->callAPISuccessGetSingle('Activity', ['id' => $activity_ids[0], 'return' => ['details', 'subject']]);
     $details = '-ALTERNATIVE ITEM 0-
 ' . __FUNCTION__ . ' html ' . $contact['display_name'] . ' Housing Support
 -ALTERNATIVE ITEM 1-
@@ -1338,59 +1312,33 @@ class CRM_Activity_BAO_ActivityTest extends CiviUnitTestCase {
    * This is different from SentEmailBasic to try to help prevent code that
    * assumes an email always has tokens in it.
    *
+   * @throws \API_Exception
    * @throws \CRM_Core_Exception
    * @throws \CiviCRM_API3_Exception
+   * @throws \Civi\API\Exception\UnauthorizedException
    */
   public function testSendEmailBasicWithoutAnyTokens(): void {
     $contactId = $this->individualCreate();
 
     // create a logged in USER since the code references it for sendEmail user.
-    $loggedInUser = $this->createLoggedInUser();
-
-    $contactDetailsIntersectKeys = [
-      'contact_id' => '',
-      'sort_name' => '',
-      'display_name' => '',
-      'do_not_email' => '',
-      'preferred_mail_format' => '',
-      'is_deceased' => '',
-      'email' => '',
-      'on_hold' => '',
-    ];
-
-    $contact = $this->callAPISuccess('Contact', 'getsingle', ['id' => $contactId, 'return' => array_keys($contactDetailsIntersectKeys)]);
-    $contactDetailsIntersectKeys = [
-      'contact_id' => '',
-      'sort_name' => '',
-      'display_name' => '',
-      'do_not_email' => '',
-      'preferred_mail_format' => '',
-      'is_deceased' => '',
-      'email' => '',
-      'on_hold' => '',
-    ];
-    $contactDetails = [
-      array_intersect_key($contact, $contactDetailsIntersectKeys),
-    ];
+    $this->createLoggedInUser();
 
     $subject = __FUNCTION__ . ' subject';
     $html = __FUNCTION__ . ' html';
     $text = __FUNCTION__ . ' text';
-    /* @var CRM_Contact_Form_Task_Email $form */
-    $form = $this->getFormObject('CRM_Contact_Form_Task_Email', [
+    $form = $this->getContactEmailTaskForm($contactId, [
       'subject' => $subject,
       'html_message' => $html,
       'text_message' => $text,
     ]);
     $mut = new CiviMailUtils($this, TRUE);
-    [$sent, $activity_ids] = $form->sendEmail(
-      $contactDetails,
-      $text,
-      $html,
-      $from = __FUNCTION__ . '@example.com'
-    );
+    $form->postProcess();
 
-    $activity = $this->callAPISuccessGetSingle('Activity', ['id' => $activity_ids[0], 'return' => ['details', 'subject']]);
+    $activity = Activity::get()
+      ->addSelect('activity_type_id:label', 'subject', 'details')
+      ->addWhere('activity_type_id:name', '=', 'Email')
+      ->execute()->first();
+
     $details = "-ALTERNATIVE ITEM 0-
 $html
 -ALTERNATIVE ITEM 1-
@@ -1400,8 +1348,8 @@ $text
     $this->assertEquals($activity['details'], $details, 'Activity details does not match.');
     $this->assertEquals($activity['subject'], $subject, 'Activity subject does not match.');
     $mut->checkMailLog([
-      "From: $from",
-      'To: Anthony Anderson <anthony_anderson@civicrm.org>',
+      'From: from@example.com',
+      'To: Anthony Anderson <email@example.com>',
       "Subject: $subject",
       $html,
       $text,
@@ -1409,29 +1357,18 @@ $text
     $mut->stop();
   }
 
-  public function testSendEmailWithCampaign() {
+  /**
+   * @throws \API_Exception
+   * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
+   */
+  public function testSendEmailWithCampaign(): void {
     // Create a contact and contactDetails array.
     $contactId = $this->individualCreate();
 
     // create a logged in USER since the code references it for sendEmail user.
     $this->createLoggedInUser();
-    $session = CRM_Core_Session::singleton();
-    $loggedInUser = $session->get('userID');
-
-    $contact = $this->civicrm_api('contact', 'getsingle', ['id' => $contactId, 'version' => $this->_apiversion]);
-    $contactDetailsIntersectKeys = [
-      'contact_id' => '',
-      'sort_name' => '',
-      'display_name' => '',
-      'do_not_email' => '',
-      'preferred_mail_format' => '',
-      'is_deceased' => '',
-      'email' => '',
-      'on_hold' => '',
-    ];
-    $contactDetails = [
-      array_intersect_key($contact, $contactDetailsIntersectKeys),
-    ];
+    $this->enableCiviCampaign();
 
     // Create a campaign.
     $result = $this->civicrm_api('Campaign', 'create', [
@@ -1443,29 +1380,24 @@ $text
     $html = __FUNCTION__ . ' html';
     $text = __FUNCTION__ . ' text';
     /* @var CRM_Activity_Form_Task_Email $form */
-    $form = $this->getFormObject('CRM_Activity_Form_Task_Email', [
-      'subject' => __FUNCTION__ . ' subject',
+    $form = $this->getCaseEmailTaskForm($contactId, [
+      'subject' => '',
+      'html_message' => $html,
+      'text_message' => $text,
+      'campaign_id' => $campaign_id,
     ]);
+    $form->postProcess();
+    $activity = Activity::get()
+      ->addSelect('activity_type_id:label', 'subject', 'details', 'campaign_id')
+      ->addWhere('activity_type_id:name', '=', 'Email')
+      ->execute()->first();
 
-    [$sent, $activity_ids] = $email_result = $form->sendEmail(
-      $contactDetails,
-      $text,
-      $html,
-      __FUNCTION__ . '@example.com',
-      $attachments = NULL,
-      $cc = NULL,
-      $bcc = NULL,
-      $contactIds = NULL,
-      NULL,
-      $campaign_id
-    );
-    $activity = $this->civicrm_api('activity', 'getsingle', ['id' => $activity_ids[0], 'version' => $this->_apiversion]);
     $this->assertEquals($activity['campaign_id'], $campaign_id, 'Activity campaign_id does not match.');
   }
 
   /**
    */
-  public function testSendSMSWithoutPermission() {
+  public function testSendSMSWithoutPermission(): void {
     $dummy = NULL;
     $session = CRM_Core_Session::singleton();
     CRM_Core_Config::singleton()->userPermissionClass->permissions = ['access CiviCRM'];
@@ -1679,65 +1611,42 @@ $text
     $caseTest->setUp();
     // Create a contact and contactDetails array.
     $contactId = $this->individualCreate();
-    $contact = $this->callAPISuccess('Contact', 'get', ['id' => $contactId]);
 
     // create a logged in USER since the code references it for sendEmail user.
     $this->createLoggedInUser();
     CRM_Core_Config::singleton()->userPermissionClass->permissions = ['view all contacts', 'access CiviCRM', 'access all cases and activities', 'administer CiviCase'];
-    $session = CRM_Core_Session::singleton();
-    $loggedInUser = $session->get('userID');
-
-    // create a case for this user
-    $result = $this->callAPISuccess('Case', 'create', [
-      'contact_id' => $contactId,
-      'case_type_id' => 1,
-      'subject' => "my case",
-      'status_id' => "Open",
-    ]);
-
-    $caseId = $result['id'];
 
     $subject = __FUNCTION__ . ' subject {case.subject}';
     $html = __FUNCTION__ . ' html {case.subject}';
     $text = __FUNCTION__ . ' text';
 
     $mut = new CiviMailUtils($this, TRUE);
-    /* @var CRM_Contact_Form_Task_Email $form */
-    $form = $this->getFormObject('CRM_Contact_Form_Task_Email', [
+    $form = $this->getCaseEmailTaskForm($contactId, [
       'subject' => $subject,
       'html_message' => $html,
       'text_message' => $text,
+      'to' => $contactId . '::' . 'email@example.com',
     ]);
-    [$sent, $activity_ids] = $form->sendEmail(
-      $contact['values'],
-      $text,
-      $html,
-      $from = __FUNCTION__ . '@example.com',
-      NULL,
-      NULL,
-      NULL,
-      NULL,
-      NULL,
-      NULL,
-      $caseId
-    );
-    $activity = $this->callAPISuccess('Activity', 'getsingle', ['id' => $activity_ids[0], 'return' => ['case_id']]);
-    $this->assertEquals($caseId, $activity['case_id'][0], 'Activity case_id does not match.');
-    $mut->checkMailLog(['subject my case']);
+    $form->postProcess();
+    $activity = Activity::get()
+      ->addSelect('id')
+      ->addWhere('activity_type_id:name', '=', 'Email')
+      ->execute()->first();
+    $activity = $this->callAPISuccess('Activity', 'getsingle', ['id' => $activity['id'], 'return' => ['case_id']]);
+    $this->assertEquals($this->getCaseID(), $activity['case_id'][0], 'Activity case_id does not match.');
+    $mut->checkMailLog(['subject Case Subject']);
     $mut->stop();
   }
 
   /**
    * Checks that tokens are uniquely replaced for contacts.
    */
-  public function testSendEmailWillReplaceTokensUniquelyForEachContact() {
+  public function testSendEmailWillReplaceTokensUniquelyForEachContact(): void {
     $contactId1 = $this->individualCreate(['last_name' => 'Red']);
     $contactId2 = $this->individualCreate(['last_name' => 'Pink']);
 
     // create a logged in USER since the code references it for sendEmail user.
     $this->createLoggedInUser();
-    $session = CRM_Core_Session::singleton();
-    $loggedInUser = $session->get('userID');
     $contact = $this->callAPISuccess('Contact', 'get', ['sequential' => 1, 'id' => ['IN' => [$contactId1, $contactId2]]]);
 
     // Create a campaign.
@@ -1757,19 +1666,14 @@ $text
       'subject' => $subject,
       'html_message' => $html,
       'text_message' => $text,
-    ]);
-    $form->sendEmail(
-      $contact['values'],
-      $text,
-      $html,
-    __FUNCTION__ . '@example.com',
-      $attachments = NULL,
-      $cc = NULL,
-      $bcc = NULL,
-      $additionalDetails = NULL,
-      NULL,
-      $campaign_id
-    );
+      'campaign_id' => $campaign_id,
+      'from_email_address' => 'from@example.com',
+      'to' => $contactId1 . '::email@example.com,' . $contactId2 . '::email2@example.com',
+    ], [], []);
+    $form->set('cid', $contactId1 . ',' . $contactId2);
+    $form->buildForm();
+    $form->postProcess();
+
     $result = $this->callAPISuccess('activity', 'get', ['campaign_id' => $campaign_id]);
     // An activity created for each of the two contacts
     $this->assertEquals(2, $result['count']);
@@ -2835,6 +2739,41 @@ $textValue
       ])['id'];
     }
     return $this->ids['Campaign'][0];
+  }
+
+  /**
+   * @param int $contactId
+   * @param array $submittedValues
+   *
+   * @return \CRM_Case_Form_Task_Email
+   */
+  protected function getCaseEmailTaskForm(int $contactId, array $submittedValues): CRM_Case_Form_Task_Email {
+    $_REQUEST['cid'] = $contactId;
+    $_REQUEST['caseid'] = $this->getCaseID();
+    /* @var CRM_Case_Form_Task_Email $form */
+    $form = $this->getFormObject('CRM_Case_Form_Task_Email', array_merge([
+      'to' => $contactId . '::' . 'email@example.com',
+      'from_email_address' => 'from@example.com',
+    ], $submittedValues));
+    $form->buildForm();
+    return $form;
+  }
+
+  /**
+   * @param int $contactId
+   * @param array $submittedValues
+   *
+   * @return \CRM_Contact_Form_Task_Email
+   */
+  protected function getContactEmailTaskForm(int $contactId, array $submittedValues): CRM_Contact_Form_Task_Email {
+    $_REQUEST['cid'] = $contactId;
+    /* @var CRM_Contact_Form_Task_Email $form */
+    $form = $this->getFormObject('CRM_Contact_Form_Task_Email', array_merge([
+      'to' => $contactId . '::' . 'email@example.com',
+      'from_email_address' => 'from@example.com',
+    ], $submittedValues));
+    $form->buildForm();
+    return $form;
   }
 
 }

--- a/tests/phpunit/CRM/Contact/Form/Task/EmailTest.php
+++ b/tests/phpunit/CRM/Contact/Form/Task/EmailTest.php
@@ -98,6 +98,12 @@ class CRM_Contact_Form_Task_EmailTest extends CiviUnitTestCase {
     /* @var CRM_Contact_Form_Task_Email $form*/
     $form = $this->getFormObject('CRM_Contact_Form_Task_Email', [
       'to' => implode(',', $to),
+      'subject' => 'Really interesting stuff',
+      'bcc_id' => $bcc,
+      'cc_id' => '',
+      'from_email_address' => $loggedInEmail['id'],
+      'html_message' => 'blah',
+      'text_message' => 'blah',
     ]);
     $form->_contactIds = $form_contactIds;
     $form->_contactIds[$deceasedContactID] = $deceasedContactID;
@@ -106,18 +112,14 @@ class CRM_Contact_Form_Task_EmailTest extends CiviUnitTestCase {
     $form->_fromEmails = [$loggedInEmail['id'] => 'mickey@mouse.com'];
     $form->isSearchContext = FALSE;
     $form->buildForm();
-    $form->submit(array_merge($form->_defaultValues, [
-      // @todo - it's better to pass these into getForm
-      // and access them on the form using $this->getSubmittedValue().
-      'from_email_address' => $loggedInEmail['id'],
-      'subject' => 'Really interesting stuff',
-      'bcc_id' => $bcc,
-      'cc_id' => '',
-    ]));
-    $mut->checkMailLog([
-      'This is a test Signature',
-    ]);
-    $mut->stop();
+    $this->assertEquals([
+      'html_message' => '<br/><br/>--<p>This is a test Signature</p>',
+      'text_message' => '
+
+--
+This is a test Signature',
+    ], $form->_defaultValues);
+    $form->postProcess();
     $activity = Activity::get(FALSE)->setSelect(['details'])->execute()->first();
     $bccUrl1 = CRM_Utils_System::url('civicrm/contact/view', ['reset' => 1, 'cid' => $bcc1], TRUE);
     $bccUrl2 = CRM_Utils_System::url('civicrm/contact/view', ['reset' => 1, 'cid' => $bcc2], TRUE);


### PR DESCRIPTION
Overview
----------------------------------------
Support participant & membership tokens in send-email tasks

Before
----------------------------------------
Cannot use participant tokens when sending an email to event participants - or member tokens for memberships

After
----------------------------------------
Works 

Technical Details
----------------------------------------

Comments
----------------------------------------
