### PR TITLE
Simplify getSubject

### DIFF
--- a/CRM/Case/Form/Task/Email.php
+++ b/CRM/Case/Form/Task/Email.php
@@ -53,12 +53,11 @@ class CRM_Case_Form_Task_Email extends CRM_Case_Form_Task {
    *
    * The case handling should possibly be on the case form.....
    *
-   * @param string $subject
-   *
    * @return string
    * @throws \CRM_Core_Exception
    */
-  protected function getSubject(string $subject):string {
+  protected function getSubject():string {
+    $subject = $this->getSubmittedValue('subject');
     // CRM-5916: prepend case id hash to CiviCase-originating emails’ subjects
     if ($this->getCaseID()) {
       $hash = substr(sha1(CIVICRM_SITE_KEY . $this->getCaseID()), 0, 7);

--- a/CRM/Contact/Form/Task/EmailTrait.php
+++ b/CRM/Contact/Form/Task/EmailTrait.php
@@ -409,7 +409,6 @@ trait CRM_Contact_Form_Task_EmailTrait {
     // send the mail
     [$sent, $activityIds] = $this->sendEmail(
       $formattedContactDetails,
-      $this->getSubject($formValues['subject']),
       $formValues['text_message'],
       $formValues['html_message'],
       $from,
@@ -578,15 +577,10 @@ trait CRM_Contact_Form_Task_EmailTrait {
   /**
    * Get the subject for the message.
    *
-   * The case handling should possibly be on the case form.....
-   *
-   * @param string $subject
-   *
    * @return string
-   * @throws \CRM_Core_Exception
    */
-  protected function getSubject(string $subject):string {
-    return $subject;
+  protected function getSubject():string {
+    return (string) $this->getSubmittedValue('subject');
   }
 
   /**
@@ -750,8 +744,6 @@ trait CRM_Contact_Form_Task_EmailTrait {
    *
    * @param array $contactDetails
    *   The array of contact details to send the email.
-   * @param string $subject
-   *   The subject of the message.
    * @param $text
    * @param $html
    * @param string $from
@@ -781,7 +773,6 @@ trait CRM_Contact_Form_Task_EmailTrait {
    */
   public function sendEmail(
     $contactDetails,
-    $subject,
     $text,
     $html,
     $from,
@@ -822,13 +813,11 @@ trait CRM_Contact_Form_Task_EmailTrait {
         $tokenContext['contributionId'] = $contributionDetails[$contactId]['id'];
       }
 
-      $tokenSubject = $subject;
-
       $renderedTemplate = CRM_Core_BAO_MessageTemplate::renderTemplate([
         'messageTemplate' => [
           'msg_text' => $text,
           'msg_html' => $html,
-          'msg_subject' => $tokenSubject,
+          'msg_subject' => $this->getSubject(),
         ],
         'tokenContext' => $tokenContext,
         'contactId' => $contactId,

--- a/tests/phpunit/CRM/Activity/BAO/ActivityTest.php
+++ b/tests/phpunit/CRM/Activity/BAO/ActivityTest.php
@@ -1261,11 +1261,14 @@ class CRM_Activity_BAO_ActivityTest extends CiviUnitTestCase {
     $text = __FUNCTION__ . ' text {contact.display_name} {case.case_type_id:label}';
 
     /* @var CRM_Contact_Form_Task_Email $form */
-    $form = $this->getFormObject('CRM_Contact_Form_Task_Email');
+    $form = $this->getFormObject('CRM_Contact_Form_Task_Email', [
+      'subject' => $subject,
+      'html_message' => $html,
+      'text_message' => $text,
+    ]);
     $mut = new CiviMailUtils($this, TRUE);
     [$sent, $activity_ids] = $form->sendEmail(
       $contactDetails,
-      $subject,
       $text,
       $html,
       __FUNCTION__ . '@example.com',
@@ -1374,11 +1377,14 @@ class CRM_Activity_BAO_ActivityTest extends CiviUnitTestCase {
     $html = __FUNCTION__ . ' html';
     $text = __FUNCTION__ . ' text';
     /* @var CRM_Contact_Form_Task_Email $form */
-    $form = $this->getFormObject('CRM_Contact_Form_Task_Email');
+    $form = $this->getFormObject('CRM_Contact_Form_Task_Email', [
+      'subject' => $subject,
+      'html_message' => $html,
+      'text_message' => $text,
+    ]);
     $mut = new CiviMailUtils($this, TRUE);
     [$sent, $activity_ids] = $form->sendEmail(
       $contactDetails,
-      $subject,
       $text,
       $html,
       $from = __FUNCTION__ . '@example.com'
@@ -1434,16 +1440,15 @@ $text
     ]);
     $campaign_id = $result['id'];
 
-    $subject = __FUNCTION__ . ' subject';
     $html = __FUNCTION__ . ' html';
     $text = __FUNCTION__ . ' text';
-    $userID = $loggedInUser;
-    /* @var CRM_Contact_Form_Task_Email $form */
-    $form = $this->getFormObject('CRM_Contact_Form_Task_Email');
+    /* @var CRM_Activity_Form_Task_Email $form */
+    $form = $this->getFormObject('CRM_Activity_Form_Task_Email', [
+      'subject' => __FUNCTION__ . ' subject',
+    ]);
 
     [$sent, $activity_ids] = $email_result = $form->sendEmail(
       $contactDetails,
-      $subject,
       $text,
       $html,
       __FUNCTION__ . '@example.com',
@@ -1698,10 +1703,13 @@ $text
 
     $mut = new CiviMailUtils($this, TRUE);
     /* @var CRM_Contact_Form_Task_Email $form */
-    $form = $this->getFormObject('CRM_Contact_Form_Task_Email');
+    $form = $this->getFormObject('CRM_Contact_Form_Task_Email', [
+      'subject' => $subject,
+      'html_message' => $html,
+      'text_message' => $text,
+    ]);
     [$sent, $activity_ids] = $form->sendEmail(
       $contact['values'],
-      $subject,
       $text,
       $html,
       $from = __FUNCTION__ . '@example.com',
@@ -1745,10 +1753,13 @@ $text
     $text = __FUNCTION__ . ' text' . '{contact.display_name}';
 
     /* @var CRM_Contact_Form_Task_Email $form */
-    $form = $this->getFormObject('CRM_Contact_Form_Task_Email');
+    $form = $this->getFormObject('CRM_Contact_Form_Task_Email', [
+      'subject' => $subject,
+      'html_message' => $html,
+      'text_message' => $text,
+    ]);
     $form->sendEmail(
       $contact['values'],
-      $subject,
       $text,
       $html,
     __FUNCTION__ . '@example.com',


### PR DESCRIPTION
Overview
----------------------------------------
Simplify getSubject

Before
----------------------------------------
subject relies on values being passed around

After
----------------------------------------
uses `getSubject`

Technical Details
----------------------------------------

Comments
----------------------------------------
https://github.com/civicrm/civicrm-core/pull/21746 incorporates this