### PR TITLE
(dev/mail#83) message_admin - Multiple improvements to the "Preview" dialog

### DIFF
--- a/CRM/Contribute/WorkflowMessage/RecurringEdit/AlexCancelled.ex.php
+++ b/CRM/Contribute/WorkflowMessage/RecurringEdit/AlexCancelled.ex.php
@@ -1,12 +1,12 @@
 <?php
 
-class CRM_Contribute_WorkflowMessage_RecurringEdit_BasicEditExample extends \Civi\WorkflowMessage\WorkflowMessageExample {
+class CRM_Contribute_WorkflowMessage_RecurringEdit_AlexCancelled extends \Civi\WorkflowMessage\WorkflowMessageExample {
 
   public function getExamples(): iterable {
     yield [
       'name' => "workflow/{$this->wfName}/{$this->exName}",
       // This title is not very clear. When we have some more examples to compare against, feel free to change/clarify.
-      'title' => ts('Recurring Edit: Basic Example'),
+      'title' => ts('Recurring Edit: Alex, Cancelled'),
       'tags' => ['preview', 'phpunit'],
     ];
   }

--- a/CRM/Contribute/WorkflowMessage/RecurringEdit/BarbPending.ex.php
+++ b/CRM/Contribute/WorkflowMessage/RecurringEdit/BarbPending.ex.php
@@ -1,0 +1,29 @@
+<?php
+
+class CRM_Contribute_WorkflowMessage_RecurringEdit_BarbPending extends \Civi\WorkflowMessage\WorkflowMessageExample {
+
+  public function getExamples(): iterable {
+    yield [
+      'name' => "workflow/{$this->wfName}/{$this->exName}",
+      // This title is not very clear. When we have some more examples to compare against, feel free to change/clarify.
+      'title' => ts('Recurring Edit: Barbara, Pending'),
+      'tags' => ['preview'],
+    ];
+  }
+
+  public function build(array &$example): void {
+    $msg = (new CRM_Contribute_WorkflowMessage_RecurringEdit())
+      ->setReceiptFromEmail('info@example.com')
+      ->setContact(\Civi\Test::example('entity/Contact/Barb'))
+      ->setContributionRecur(\Civi\Test::example('entity/ContributionRecur/Euro5990/pending'));
+    $example['data'] = $this->toArray($msg);
+
+    $example['asserts'] = [
+      'default' => [
+        ['for' => 'subject', 'regex' => '/Recurring Contribution Update.*Barb/'],
+        ['for' => 'text', 'regex' => '/Recurring contribution is for € 5,990.99, every 2 year.s. for 24 installments/'],
+      ],
+    ];
+  }
+
+}

--- a/Civi/Test/ExampleData/Contact/Barb.ex.php
+++ b/Civi/Test/ExampleData/Contact/Barb.ex.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Civi\Test\ExampleData\Contact;
+
+class Barb extends \Civi\Test\EntityExample {
+
+  public function getExamples(): iterable {
+    yield [
+      'name' => "entity/{$this->entityName}/{$this->exName}",
+    ];
+  }
+
+  public function build(array &$example): void {
+    $example['data'] = [
+      'contact_id' => '100',
+      'contact_type' => 'Individual',
+      'contact_sub_type' => NULL,
+      'sort_name' => 'Johnson, Barbara',
+      'display_name' => 'Barbara Johnson',
+      'do_not_email' => '1',
+      'do_not_phone' => '1',
+      'do_not_mail' => '0',
+      'do_not_sms' => '0',
+      'do_not_trade' => '0',
+      'is_opt_out' => '0',
+      'legal_identifier' => NULL,
+      'external_identifier' => NULL,
+      'nick_name' => 'Barb',
+      'legal_name' => NULL,
+      'image_URL' => NULL,
+      'preferred_communication_method' => NULL,
+      'preferred_language' => NULL,
+      'preferred_mail_format' => 'Both',
+      'first_name' => 'Barbara',
+      'middle_name' => '',
+      'last_name' => 'Johnson',
+      'prefix_id' => '4',
+      'suffix_id' => NULL,
+      'formal_title' => NULL,
+      'communication_style_id' => NULL,
+      'job_title' => NULL,
+      'gender_id' => '1',
+      'birth_date' => '1999-05-11',
+      'is_deceased' => '0',
+      'deceased_date' => NULL,
+      'household_name' => NULL,
+      'organization_name' => NULL,
+      'sic_code' => NULL,
+      'contact_is_deleted' => '0',
+      'current_employer' => NULL,
+      'address_id' => NULL,
+      'street_address' => NULL,
+      'supplemental_address_1' => NULL,
+      'supplemental_address_2' => NULL,
+      'supplemental_address_3' => NULL,
+      'city' => NULL,
+      'postal_code_suffix' => NULL,
+      'postal_code' => NULL,
+      'geo_code_1' => NULL,
+      'geo_code_2' => NULL,
+      'state_province_id' => NULL,
+      'country_id' => NULL,
+      'phone_id' => '7',
+      'phone_type_id' => '1',
+      'phone' => '393-7924',
+      'email_id' => '7',
+      'email' => 'barb@testing.net',
+      'on_hold' => '0',
+      'im_id' => NULL,
+      'provider_id' => NULL,
+      'im' => NULL,
+      'worldregion_id' => NULL,
+      'world_region' => NULL,
+      'languages' => NULL,
+      'individual_prefix' => NULL,
+      'individual_suffix' => NULL,
+      'communication_style' => NULL,
+      'gender' => 'Female',
+      'state_province_name' => NULL,
+      'state_province' => NULL,
+      'country' => NULL,
+      'email_greeting_id' => 1,
+      'email_greeting_custom' => NULL,
+      'email_greeting_display' => 'Dear Barb',
+      'postal_greeting_id' => 1,
+      'postal_greeting_custom' => NULL,
+      'postal_greeting_display' => 'Dear Barb',
+    ];
+  }
+
+}

--- a/ext/message_admin/ang/crmMsgadm.ang.php
+++ b/ext/message_admin/ang/crmMsgadm.ang.php
@@ -24,6 +24,7 @@ return [
     'crmDialog',
     'crmMailing',
     'crmMonaco',
+    'jsonFormatter',
     'ngRoute',
     'ngSanitize',
     'api4',

--- a/ext/message_admin/ang/crmMsgadm/InspectExample.html
+++ b/ext/message_admin/ang/crmMsgadm/InspectExample.html
@@ -1,0 +1,24 @@
+<div id="bootstrap-theme" crm-dialog="inspectExampleDlg">
+
+  <nav class="navbar navbar-default">
+    <div class="container-fluid">
+      <div class="navbar-header">
+        <div class="navbar-brand">
+          {{::model.title}}
+        </div>
+      </div>
+      <div class="navbar-form navbar-right">
+        <div class="form-group">
+          <button crm-icon="fa-refresh" type="button" class="btn btn-default" ng-click="model.refresh()"></button>
+          <button crm-icon="fa-times" type="button" class="btn btn-default" ng-click="inspectExampleDlg.close()">
+            {{::ts('Close')}}
+          </button>
+        </div>
+      </div>
+    </div>
+  </nav>
+
+
+  <json-formatter json="model.data" open="1"></json-formatter>
+
+</div>

--- a/ext/message_admin/ang/crmMsgadm/Preview.html
+++ b/ext/message_admin/ang/crmMsgadm/Preview.html
@@ -40,6 +40,7 @@
             <select class="form-control" ng-options="item.id as item.title for item in model.examples" ng-model="$ctrl.exampleId"></select>
             <div class="input-group-btn">
               <!-- <button class="btn btn-default" ng-click="$ctrl.toggleAdhoc()" crm-icon="fa-pencil"></button> -->
+              <button class="btn btn-default" ng-disabled="model.examples.length <= 1" ng-click="$ctrl.inspectExample()" title="{{::ts('Inspect example data')}}"><i class="crm-i fa-file-code-o"></i></button>
               <button class="btn btn-default" ng-disabled="model.examples.length <= 1" ng-click="$ctrl.cycle('exampleId', 'examples', -1)">&#xab;</button>
               <button class="btn btn-default" ng-disabled="model.examples.length <= 1" ng-click="$ctrl.cycle('exampleId', 'examples', +1)">&#xbb;</button>
             </div>

--- a/ext/message_admin/ang/crmMsgadm/Preview.html
+++ b/ext/message_admin/ang/crmMsgadm/Preview.html
@@ -28,8 +28,8 @@
           <div class="input-group col-sm-9">
             <select class="form-control" ng-options="item.id as item.label for item in model.revisions" ng-model="$ctrl.revisionId"></select>
             <div class="input-group-btn">
-              <button class="btn btn-default" ng-disabled="model.revisions.length <= 1" ng-click="$ctrl.cycle('revisionId', 'revisions', -1)">&#xab;</button>
-              <button class="btn btn-default" ng-disabled="model.revisions.length <= 1" ng-click="$ctrl.cycle('revisionId', 'revisions', +1)">&#xbb;</button>
+              <button class="btn btn-default" ng-disabled="model.revisions.length <= 1" ng-click="$ctrl.cycle('revisionId', 'revisions', -1)" title="{{::ts('Previous revision')}}">&#xab;</button>
+              <button class="btn btn-default" ng-disabled="model.revisions.length <= 1" ng-click="$ctrl.cycle('revisionId', 'revisions', +1)" title="{{::ts('Next revision')}}">&#xbb;</button>
             </div>
           </div>
         </div>
@@ -41,8 +41,8 @@
             <div class="input-group-btn">
               <!-- <button class="btn btn-default" ng-click="$ctrl.toggleAdhoc()" crm-icon="fa-pencil"></button> -->
               <button class="btn btn-default" ng-disabled="model.examples.length <= 1" ng-click="$ctrl.inspectExample()" title="{{::ts('Inspect example data')}}"><i class="crm-i fa-file-code-o"></i></button>
-              <button class="btn btn-default" ng-disabled="model.examples.length <= 1" ng-click="$ctrl.cycle('exampleId', 'examples', -1)">&#xab;</button>
-              <button class="btn btn-default" ng-disabled="model.examples.length <= 1" ng-click="$ctrl.cycle('exampleId', 'examples', +1)">&#xbb;</button>
+              <button class="btn btn-default" ng-disabled="model.examples.length <= 1" ng-click="$ctrl.cycle('exampleId', 'examples', -1)" title="{{::ts('Previous example')}}">&#xab;</button>
+              <button class="btn btn-default" ng-disabled="model.examples.length <= 1" ng-click="$ctrl.cycle('exampleId', 'examples', +1)" title="{{::ts('Next example')}}">&#xbb;</button>
             </div>
           </div>
         </div>
@@ -64,8 +64,8 @@
           <div class="input-group col-sm-9">
             <select class="form-control" ng-options="item.id as item.label for item in model.formats" ng-model="$ctrl.formatId"></select>
             <div class="input-group-btn">
-              <button class="btn btn-default" ng-disabled="model.formats.length <= 1" ng-click="$ctrl.cycle('formatId', 'formats', -1)">&#xab;</button>
-              <button class="btn btn-default" ng-disabled="model.formats.length <= 1" ng-click="$ctrl.cycle('formatId', 'formats', +1)">&#xbb;</button>
+              <button class="btn btn-default" ng-disabled="model.formats.length <= 1" ng-click="$ctrl.cycle('formatId', 'formats', -1)" title="{{::ts('Previous format')}}">&#xab;</button>
+              <button class="btn btn-default" ng-disabled="model.formats.length <= 1" ng-click="$ctrl.cycle('formatId', 'formats', +1)" title="{{::ts('Next format')}}">&#xbb;</button>
             </div>
           </div>
         </div>

--- a/ext/message_admin/ang/crmMsgadm/Preview.js
+++ b/ext/message_admin/ang/crmMsgadm/Preview.js
@@ -10,7 +10,7 @@
     $ctrl.revisionId = parseInt(_.findKey(model.revisions, {name: model.revisionName}));
     $ctrl.formatId = parseInt(_.findKey(model.formats, {name: model.formatName}));
     $ctrl.cycle = function(idFld, listFld, delta){
-      $ctrl[idFld] = ($ctrl[idFld] + delta) % model[listFld].length;
+      $ctrl[idFld] = ($ctrl[idFld] + delta + model[listFld].length) % model[listFld].length;
     };
 
     $ctrl.adhocExample = {};


### PR DESCRIPTION
Overview
----------------------------------------

The recently added "Message Administration" extension provides a "Preview" dialog (if there is a suitable data-model/example-data). The primary aim of this PR is to improve the visibility of example data used by the preview, although it also includes a few incidental improvements/fixes.

(Each change is a separate commit, but the order is a bit sensitive since they sometimes touch related sections.)

Before
----------------------------------------

* In the "Preview" dialog, the "Examples" list has *one* example for `contribution_recurring_edit`.
* In the "Preview" dialog, the "Examples" list does not allow you inspect the example (eg to see where it came from or what data it provides). These are left as top secret affairs.
* The "Preview" pane has cycling buttons. They lack explanatory tooltips.
* The "Preview" pane has cycling buttons. When the page first opens, the cycle-backward ("<<", "Previous", "-1") buttons do not work reliably.

After
----------------------------------------

* In the "Preview" dialog, the "Examples" list has *two* examples for `contribution_recurring_edit`.
* In the "Preview" dialog, the "Examples" list offers a drill-down button to inspect the specific example.
* The "Preview" pane still has cycling buttons -- but now with tooltips!
* The "Preview" pane still has cycling buttons -- and they work from the start!

<img width="1375" alt="Screen Shot 2021-10-06 at 1 49 09 AM" src="https://user-images.githubusercontent.com/1336047/136170838-04ff3e61-41e5-4bec-ae4a-e03609e9ddb9.png">
<img width="1376" alt="Screen Shot 2021-10-06 at 1 49 42 AM" src="https://user-images.githubusercontent.com/1336047/136170851-84d5a17d-754f-410d-8749-4b87bf71d527.png">

Technical Details
----------------------------------------

As a developer using the "Preview" dialog, you may edit the example-data at the same time. It shouldn't be necessary to reload the full page. Edits in the `data` section should go live when it runs the next AJAX call (ie when you cycle-through examples or click the inspector's "Refresh" button). However, you may need to flush a cache if you add/remove/rename an example.