### PR TITLE
System status checks only shows 25 messages

### DIFF
--- a/ang/crmStatusPage.js
+++ b/ang/crmStatusPage.js
@@ -9,7 +9,7 @@
 
       resolve: {
         statusData: function(crmApi) {
-          return crmApi('System', 'check', {sequential: 1});
+          return crmApi('System', 'check', {sequential: 1, options: {limit: 0}});
         }
       }
     });

--- a/ang/crmStatusPage/StatusPageCtrl.js
+++ b/ang/crmStatusPage/StatusPageCtrl.js
@@ -10,7 +10,7 @@
       // Refresh the list. Optionally execute api calls first.
       function refresh(apiCalls, title) {
         title = title || 'Untitled operation';
-        apiCalls = (apiCalls || []).concat([['System', 'check', {sequential: 1}]]);
+        apiCalls = (apiCalls || []).concat([['System', 'check', {sequential: 1, options: {limit: 0}}]]);
         $('#crm-status-list').block();
         crmApi(apiCalls, true)
           .then(function(results) {


### PR DESCRIPTION
Overview
----------------------------------------
Because this page uses API3 and doesn't specify limit=0 it's only showing the first 25 status checks. That's particularly bad because they get sorted by severity and it's the lowest severity first meaning you won't see the real problems if you have more than 25 checks.

Before
----------------------------------------
Only first 25 (lowest severity) system status check messages are shown.

After
----------------------------------------
All system status check messages are shown.

Technical Details
----------------------------------------
Add limit=0

Comments
----------------------------------------
@mlutfy I'm surprised if you didn't already see this - I'm using an extension based on your symbiotic one that does lot's of extra system checks.
