### PR TITLE
Afform - Fix chain-select of contry and address to work on SearchKit forms

### DIFF
--- a/ext/afform/admin/Civi/Api4/Action/Afform/LoadAdminData.php
+++ b/ext/afform/admin/Civi/Api4/Action/Afform/LoadAdminData.php
@@ -216,6 +216,7 @@ class LoadAdminData extends \Civi\Api4\Generic\AbstractAction {
    */
   private function loadForm($name) {
     return Afform::get($this->checkPermissions)
+      ->addSelect('*', 'directive_name')
       ->setFormatWhitespace(TRUE)
       ->setLayoutFormat('shallow')
       ->addWhere('name', '=', $name)

--- a/ext/afform/admin/ang/afGuiEditor/afGuiSearch.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiSearch.component.js
@@ -86,7 +86,7 @@
             "#tag": "af-field",
             name: (prefix ? prefix + '.' : '') + field.name
           };
-          if (field.input_type === 'Select') {
+          if (field.input_type === 'Select' || field.input_type === 'ChainSelect') {
             tag.defn = {input_attrs: {multiple: true}};
           } else if (field.input_type === 'Date') {
             tag.defn = {input_type: 'Select', search_range: true};

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
@@ -76,7 +76,7 @@
       this.canBeMultiple = function() {
         return this.isSearch() &&
           !_.includes(['Date', 'Timestamp'], ctrl.getDefn().data_type) &&
-          _.includes(['Select', 'EntityRef'], $scope.getProp('input_type'));
+          _.includes(['Select', 'EntityRef', 'ChainSelect'], $scope.getProp('input_type'));
       };
 
       this.getRangeElements = function(type) {

--- a/ext/afform/core/Civi/Afform/AfformMetadataInjector.php
+++ b/ext/afform/core/Civi/Afform/AfformMetadataInjector.php
@@ -104,7 +104,7 @@ class AfformMetadataInjector {
       $isSearchRange = !empty($fieldDefn['search_range']) && \CRM_Utils_JS::decode($fieldDefn['search_range']);
 
       // Default placeholder for select inputs
-      if ($inputType === 'Select') {
+      if ($inputType === 'Select' || $inputType === 'ChainSelect') {
         $fieldInfo['input_attrs']['placeholder'] = E::ts('Select');
       }
       elseif ($inputType === 'EntityRef') {
@@ -163,7 +163,7 @@ class AfformMetadataInjector {
     $params = [
       'action' => $action,
       'where' => [['name', 'IN', $namesToMatch]],
-      'select' => ['name', 'label', 'input_type', 'input_attrs', 'help_pre', 'help_post', 'options', 'fk_entity'],
+      'select' => ['name', 'label', 'input_type', 'input_attrs', 'help_pre', 'help_post', 'options', 'entity', 'fk_entity'],
       'loadOptions' => ['id', 'label'],
       // If the admin included this field on the form, then it's OK to get metadata about the field regardless of user permissions.
       'checkPermissions' => FALSE,


### PR DESCRIPTION
Overview
----------------------------------------
Multiple fixes to the chainSelect mechanics
- Provides visual feedback when reloading options
- Works with defalut values from url args
- Works with multi-valued fields
- Works with searchKit joins
- Returns to default state/province/county list when de-selecting country

Before
----------------------------------------
ChainSelect fields (State, County) did not work in search display forms

After
----------------------------------------
Tada!

![image](https://user-images.githubusercontent.com/2874912/136239659-7b298e3f-2438-4da8-989e-e95badd49fbb.png)

