### PR TITLE
Afform - ensure dragging classes are removed when not sorting

### DIFF
--- a/ext/afform/admin/ang/afGuiEditor.js
+++ b/ext/afform/admin/ang/afGuiEditor.js
@@ -180,19 +180,24 @@
     CRM.loadScript(CRM.config.resourceBase + 'js/jquery/jquery.crmIconPicker.js').done(function() {
       $('#af-gui-icon-picker').crmIconPicker();
     });
-    // Add css class while dragging
+    // Add css classes while dragging
     $(document)
+      // When dragging an item over a container, add a class to highlight the target
       .on('sortover', function(e) {
         $('.af-gui-container').removeClass('af-gui-dragtarget');
         $(e.target).closest('.af-gui-container').addClass('af-gui-dragtarget');
       })
+      // Un-highlight when dragging out of a container
       .on('sortout', '.af-gui-container', function() {
         $(this).removeClass('af-gui-dragtarget');
       })
+      // Add body class which puts the entire UI into a "dragging" state
       .on('sortstart', '#afGuiEditor', function() {
         $('body').addClass('af-gui-dragging');
       })
-      .on('sortstop', function() {
+      // Ensure dragging classes are removed when not sorting
+      // Listening to multiple event types because sort* events are not 100% reliable
+      .on('sortbeforestop mouseenter', function() {
         $('body').removeClass('af-gui-dragging');
         $('.af-gui-dragtarget').removeClass('af-gui-dragtarget');
       });


### PR DESCRIPTION
Overview
----------------------------------------
Fixes an annoying UI glitch in Afform where the screen can appear "locked" or "frozen" after dragging fields into a fieldset.

Comments
------------
This is hard to reproduce on purpose but very annoying when it happens to you. It's such a simple fix I think we should merge it into the RC. I'm usually able to reproduce it by dragging a field from the palette on the left into a container within a fieldset.

Technical Details
-------------
Most of this PR is just adding code comments. Only functional change it to listen to more events.