### PR TITLE
SearchKit - Fix anonymous access to running search displays

### DIFF
--- a/ext/search_kit/search_kit.php
+++ b/ext/search_kit/search_kit.php
@@ -24,6 +24,21 @@ function search_kit_civicrm_container($container) {
 }
 
 /**
+ * Implements hook_civicrm_alterApiRoutePermissions().
+ *
+ * Allow anonymous users to run a search display. Permissions are checked internally.
+ *
+ * @see CRM_Utils_Hook::alterApiRoutePermissions
+ */
+function search_kit_civicrm_alterApiRoutePermissions(&$permissions, $entity, $action) {
+  if ($entity === 'SearchDisplay') {
+    if ($action === 'run' || $action === 'download' || $action === 'getSearchTasks') {
+      $permissions = CRM_Core_Permission::ALWAYS_ALLOW_PERMISSION;
+    }
+  }
+}
+
+/**
  * Implements hook_civicrm_xmlMenu().
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_xmlMenu


### PR DESCRIPTION
Overview
----------------------------------------
Recently SearchKit added the ability for anonymous users to access search displays. However, due to an oversight the feature doesn't actually work for anonymous users. This fixes the problem.

Technical Details
----------------------------------------
This is the same fix as used by [afform_civicrm_alterApiRoutePermissions()](https://github.com/civicrm/civicrm-core/blob/9d85626b7b9836c554213e54a1a8115ed5fa8d34/ext/afform/core/afform.php#L493) to remove the barrier to entry for anonymous users.

Comments
---------------------
It was decided that opening up apis to anonymous access one-at-a-time via this hook "feels safer" than doing it system-wide for all of APIv4. However there's no known reason why that *can't* be done, as each API action performs its own permission check right after this outer later, so it's pretty much redundant.

But to get this fixed in the RC, this is the lowest-risk solution.