### PR TITLE
5.42.0 release notes final updates

### DIFF
--- a/release-notes.md
+++ b/release-notes.md
@@ -26,6 +26,15 @@ Released October 6, 2021
 - **[Credits](release-notes/5.42.0.md#credits)**
 - **[Feedback](release-notes/5.42.0.md#feedback)**
 
+## CiviCRM 5.41.2
+
+Released September 25, 2021
+
+- **[Synopsis](release-notes/5.41.2.md#synopsis)**
+- **[Bugs resolved](release-notes/5.41.2.md#bugs)**
+- **[Credits](release-notes/5.41.2.md#credits)**
+- **[Feedback](release-notes/5.41.2.md#feedback)**
+
 ## CiviCRM 5.41.1
 
 Released September 17, 2021

--- a/release-notes.md
+++ b/release-notes.md
@@ -26,6 +26,15 @@ Released October 6, 2021
 - **[Credits](release-notes/5.42.0.md#credits)**
 - **[Feedback](release-notes/5.42.0.md#feedback)**
 
+## CiviCRM 5.41.1
+
+Released September 17, 2021
+
+- **[Synopsis](release-notes/5.41.1.md#synopsis)**
+- **[Bugs resolved](release-notes/5.41.1.md#bugs)**
+- **[Credits](release-notes/5.41.1.md#credits)**
+- **[Feedback](release-notes/5.41.1.md#feedback)**
+
 ## CiviCRM 5.41.0
 
 Released September 1, 2021

--- a/release-notes/5.41.1.md
+++ b/release-notes/5.41.1.md
@@ -1,0 +1,40 @@
+# CiviCRM 5.41.1
+
+Released September 17, 2021
+
+- **[Synopsis](#synopsis)**
+- **[Bugs resolved](#bugs)**
+- **[Credits](#credits)**
+- **[Feedback](#feedback)**
+
+## <a name="synopsis"></a>Synopsis
+
+| *Does this version...?*                                         |          |
+| --------------------------------------------------------------- | -------- |
+| Change the database schema?                                     | no       |
+| Alter the API?                                                  | no       |
+| Require attention to configuration options?                     | no       |
+| **Fix problems installing or upgrading to a previous version?** | **yes**  |
+| Introduce features?                                             | no       |
+| **Fix bugs?**                                                   | **yes**  |
+
+## <a name="bugs"></a>Bugs resolved
+
+* **_CiviContribute_: Saving "New Contribution" with premium product fails in back-office UI  ([dev/core#2816](https://lab.civicrm.org/dev/core/-/issues/2816): [#21512](https://github.com/civicrm/civicrm-core/pull/21512))**
+* **_Custom Search_: Mitigate crash when upgrading on sites with `dataprocessor` <=1.41 ([dev/core#2812](https://lab.civicrm.org/dev/core/-/issues/2812): [#21347](https://github.com/civicrm/civicrm-core/pull/21347))**
+* **_Greenwich_: Mitigate crash when upgrading on sites with `scssphp` >=1.7 ([dev/drupal#164](https://lab.civicrm.org/dev/drupal/-/issues/164): [#21502](https://github.com/civicrm/civicrm-core/pull/21502))**
+
+## <a name="credits"></a>Credits
+
+This release was developed by the following authors and reviewers:
+
+Wikimedia Foundation - Eileen McNaughton; Megaphone Technology Consulting - Jon Goldberg;
+MJW Consulting - Matthew Wire; Joseph Lacey; JMA Consulting - Monish Deb, Seamus Lee; Dave
+D; CiviCRM - Tim Otten, Coleman Watts; Christophe Coevoet; Blackfly Solutions - Alan
+Dixon; Agileware - Justin Freeman, Francis Whittle
+
+## <a name="feedback"></a>Feedback
+
+These release notes are edited by Tim Otten and Andie Hunt.  If you'd like to
+provide feedback on them, please login to https://chat.civicrm.org/civicrm and
+contact `@agh1`.

--- a/release-notes/5.41.2.md
+++ b/release-notes/5.41.2.md
@@ -1,0 +1,43 @@
+# CiviCRM 5.41.2
+
+Released September 25, 2021
+
+- **[Synopsis](#synopsis)**
+- **[Bugs resolved](#bugs)**
+- **[Credits](#credits)**
+- **[Feedback](#feedback)**
+
+## <a name="synopsis"></a>Synopsis
+
+| *Does this version...?*                                         |          |
+| --------------------------------------------------------------- | -------- |
+| Change the database schema?                                     | no       |
+| **Alter the API?**                                              | **yes**  |
+| Require attention to configuration options?                     | no       |
+| Fix problems installing or upgrading to a previous version?     | no       |
+| Introduce features?                                             | no       |
+| **Fix bugs?**                                                   | **yes**  |
+
+## <a name="bugs"></a>Bugs resolved
+
+* **_Smart Groups_: Smart groups based on custom-searches are miscomputed. ([dev/core#2861](https://lab.civicrm.org/dev/core/-/issues/2861): [#21601](https://github.com/civicrm/civicrm-core/pull/21601))**
+
+  The smart group may be signficantly over-sized, including contacts who should not be members.
+
+* **_APIv4_: Backport "File" API ([#21158](https://github.com/civicrm/civicrm-core/pull/21158))**
+
+  This fixes a bug in which "Search Kit" displays crash if the target field references a file.
+
+## <a name="credits"></a>Credits
+
+This release was developed by the following authors and reviewers:
+
+Wikimedia Foundation - Eileen McNaughton; Third Sector Design - Kurund Jalmi; Megaphone
+Technology Consulting - Jon Goldberg; JMA Consulting - Seamus Lee; CiviCRM - Tim Otten,
+Coleman Watts
+
+## <a name="feedback"></a>Feedback
+
+These release notes are edited by Tim Otten and Andie Hunt.  If you'd like to
+provide feedback on them, please login to https://chat.civicrm.org/civicrm and
+contact `@agh1`.

--- a/release-notes/5.42.0.md
+++ b/release-notes/5.42.0.md
@@ -71,11 +71,6 @@ Released October 6, 2021
   Makes SearchKit handle large option lists more efficiently, and adds APIv4
   field metadata about available suffixes.
 
-- **APIv4 - Add File entity
-  ([21158](https://github.com/civicrm/civicrm-core/pull/21158))**
-
-  Adds the entity "File" to APIv4.
-
 - **SearchKit - Add placeholder to token select
   ([21172](https://github.com/civicrm/civicrm-core/pull/21172))**
 
@@ -88,7 +83,8 @@ Released October 6, 2021
   Adds support to display SearchKit results in a grid format.
 
 - **SearchKit - Merge admin results table with searchDisplay code
-  ([21069](https://github.com/civicrm/civicrm-core/pull/21069))**
+  ([21069](https://github.com/civicrm/civicrm-core/pull/21069) and
+  [21488](https://github.com/civicrm/civicrm-core/pull/21488))**
 
   Improves and streamlines the SearchKit Angular code to reconcile two
   different ways of fetching, formatting & displaying results. This reduces code
@@ -245,6 +241,10 @@ Released October 6, 2021
   Fixes loading multiple translations within same page-view (OptionValues,
   ContactTypes).
 
+- **Activity export broken - takes you to some other screen instead
+  ([dev/core#2835](https://lab.civicrm.org/dev/core/-/issues/2835):
+  [21456](https://github.com/civicrm/civicrm-core/pull/21456))**
+
 - **APIv4 - entityBatch linkage
   ([dev/core#2682](https://lab.civicrm.org/dev/core/-/issues/2682):
   [21241](https://github.com/civicrm/civicrm-core/pull/21241))**
@@ -266,6 +266,22 @@ Released October 6, 2021
 
   Refactoring work towards making it possible to have a direct export feature in
   SearchKit.
+
+- **SearchKit - Fix deleting search displays
+  ([21444](https://github.com/civicrm/civicrm-core/pull/21444))**
+
+- **SearchKit - Fix anonymous access to running search displays
+  #([21752](https://github.com/civicrm/civicrm-core/pull/21752))**
+
+  Recently SearchKit added the ability for anonymous users to access search
+  displays. However, due to an oversight the feature doesn't actually work for
+  anonymous users. This fixes the problem.
+
+- **Afform - ensure dragging classes are removed when not sorting
+  ([21750](https://github.com/civicrm/civicrm-core/pull/21750))**
+
+  Fixes an annoying UI glitch in Afform where the screen can appear "locked" or
+  "frozen" after dragging fields into a fieldset.
 
 - **Expose Contribution token processor
   ([dev/core#2747](https://lab.civicrm.org/dev/core/-/issues/2747):
@@ -423,6 +439,24 @@ Released October 6, 2021
 - **Simplify ContributionView form. Always display "lineitems"
   ([21285](https://github.com/civicrm/civicrm-core/pull/21285))**
 
+- **Can we re-order the 'recur links'
+  ([dev/core#2843](https://lab.civicrm.org/dev/core/-/issues/2843):
+  [21559](https://github.com/civicrm/civicrm-core/pull/21559))**
+
+  The new link to View Template on a recurring contribution row is now moved to
+  the end, allowing the Edit link to return to the second spot.
+
+- **When a recurring contribution template has no line items, the contact
+  contribution tab crashes
+  ([dev/financial#187](https://lab.civicrm.org/dev/financial/-/issues/187):
+  [21734](https://github.com/civicrm/civicrm-core/pull/21734))**
+
+- **Call line item pre hook after tax amount is calculated
+  ([21731](https://github.com/civicrm/civicrm-core/pull/21731))**
+
+  `hook_civicrm_pre` is now invoked on a line item entity after the tax amount
+  has been calculated for it.
+
 ### CiviMail
 
 - **CiviCRM Mailing, function unsub_from_mailing has spelling error,
@@ -449,6 +483,9 @@ Released October 6, 2021
 
 - **Update MembershipType.duration and MembershipStatus.name to be required
   ([21119](https://github.com/civicrm/civicrm-core/pull/21119))**
+
+- **Fix missing value of End Adjustment column from Membership status page
+  ([21664](https://github.com/civicrm/civicrm-core/pull/21664))**
 
 ### Drupal Integration
 
@@ -560,7 +597,8 @@ Released October 6, 2021
   ([21226](https://github.com/civicrm/civicrm-core/pull/21226))**
 
 - **[REF] CRM_Utils_Recent - Use hook listener to delete items
-  ([21204](https://github.com/civicrm/civicrm-core/pull/21204))**
+  ([21204](https://github.com/civicrm/civicrm-core/pull/21204) and
+  [21492](https://github.com/civicrm/civicrm-core/pull/21492))**
 
 - **[REF] Deprecate unnecessary del() functions
   ([21200](https://github.com/civicrm/civicrm-core/pull/21200))**


### PR DESCRIPTION
I cherry-picked the commits adding the 5.41.1 and 5.41.2 release notes because they were missing.  I had to resolve conflicts on each in the release-notes.md main listing.