### PR TITLE
Fix token regression - re-add support for empty tokens

### DIFF
--- a/Civi/Token/TokenCompatSubscriber.php
+++ b/Civi/Token/TokenCompatSubscriber.php
@@ -60,6 +60,12 @@ class TokenCompatSubscriber implements EventSubscriberInterface {
       return '';
     });
 
+    // This removes the pattern used in greetings of having bits of text that
+    // depend on the tokens around them - ie '{first_name}{ }{last_name}
+    // has an extra construct '{ }' which will resolve as a space if the
+    // tokens on either side are resolved to 'something'
+    $e->string = preg_replace('/\\\\|\{(\s*)?\}/', ' ', $e->string);
+
     if ($useSmarty) {
       $smartyVars = [];
       foreach ($e->context['smartyTokenAlias'] ?? [] as $smartyName => $tokenName) {

--- a/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
+++ b/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
@@ -259,7 +259,6 @@ case.custom_1 :' . '
     ]);
     $contactID = $this->individualCreate(['middle_name' => '']);
     $tokenProcessor->addRow(['contactId' => $contactID]);
-    $tokenProcessor->evaluate();
     foreach ($variants as $index => $variant) {
       $tokenProcessor->addMessage($index, $variant['string'], 'text/plain');
     }
@@ -268,8 +267,8 @@ case.custom_1 :' . '
     foreach ($variants as $index => $variant) {
       $greetingString = $variant['string'];
       CRM_Utils_Token::replaceGreetingTokens($greetingString, $this->callAPISuccessGetSingle('Contact', ['id' => $contactID]), $contactID);
-      $this->assertEquals($variant['expected'], $greetingString);
-      $this->assertEquals($variant['expected'], $result->render($index));
+      $this->assertEquals($variant['expected'], $greetingString, 'replaceGreetingTokens() should render expected output');
+      $this->assertEquals($variant['expected'], $result->render($index), 'TokenProcessor should render expected output');
     }
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Fix token regression - re-add support for empty tokens since this was originally being accessed from `replaceGreetingTokens` which is no longer called by `tokenCompatSubscriber`

Before
----------------------------------------
`{contact.first_name}{ }{contact.last_name}` leaves in `{ }`

After
----------------------------------------
`{contact.first_name}{ }{contact.last_name}`  removes `{ }`

Technical Details
----------------------------------------
I originally thought the behaviour was to remove those tokens when there was a string either side - the tests show that not to be working for `replaceGreetingTokens` - this syncs the behaviour of the 2 rather than trying to improve it.

Comments
----------------------------------------
@totten @colemanw note this test specifically covers the 2 variants of prefix_id - but won't pass without https://github.com/civicrm/civicrm-core/pull/21705 merged