### PR TITLE
Remove now-obsolete getPseudoTokens

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4904,8 +4904,14 @@ LIMIT 1;";
   }
 
   /**
+   * Do not use - still called from CRM_Contribute_Form_Task_PDFLetter
+   *
+   * This needs to be refactored out of use & deprecated out of existence.
+   *
    * Get the contribution fields for $id and display labels where
    * appropriate (if the token is present).
+   *
+   * @deprecated
    *
    * @param int $id
    * @param array $messageToken
@@ -4925,11 +4931,34 @@ LIMIT 1;";
           $result['values'][$id][$fieldName] = CRM_Core_BAO_CustomField::displayValue($result['values'][$id][$fieldName], $fieldName);
         }
       }
-      $processor = new CRM_Contribute_Tokens();
-      $pseudoFields = array_keys($processor->getPseudoTokens());
+
+      $pseudoFields = [
+        'financial_type_id:label',
+        'financial_type_id:name',
+        'contribution_page_id:label',
+        'contribution_page_id:name',
+        'payment_instrument_id:label',
+        'payment_instrument_id:name',
+        'is_test:label',
+        'is_pay_later:label',
+        'contribution_status_id:label',
+        'contribution_status_id:name',
+        'is_template:label',
+        'campaign_id:label',
+        'campaign_id:name',
+      ];
       foreach ($pseudoFields as $pseudoField) {
         $split = explode(':', $pseudoField);
-        $result['values'][$id][$pseudoField] = $processor->getPseudoValue($split[0], $split[1], $result['values'][$id][$split[0]] ?? '');
+        $pseudoKey = $split[1];
+        $realField = $split[0];
+        $fieldValue = $result['values'][$id][$realField] ?? '';
+        if ($pseudoKey === 'name') {
+          $fieldValue = (string) CRM_Core_PseudoConstant::getName('CRM_Contribute_BAO_Contribution', $realField, $fieldValue);
+        }
+        if ($pseudoKey === 'label') {
+          $fieldValue = (string) CRM_Core_PseudoConstant::getLabel('CRM_Contribute_BAO_Contribution', $realField, $fieldValue);
+        }
+        $result['values'][$id][$pseudoField] = $fieldValue;
       }
     }
     return $result;

--- a/CRM/Core/EntityTokens.php
+++ b/CRM/Core/EntityTokens.php
@@ -313,61 +313,10 @@ class CRM_Core_EntityTokens extends AbstractTokenSubscriber {
   }
 
   /**
-   * Get pseudoTokens - it tokens that reflect the name or label of a pseudoconstant.
-   *
-   * @internal - this function will likely be made protected soon.
-   *
-   * @return array
-   */
-  public function getPseudoTokens(): array {
-    $return = [];
-    foreach (array_keys($this->getBasicTokens()) as $fieldName) {
-      if ($this->isAddPseudoTokens($fieldName)) {
-        $fieldLabel = $this->fieldMetadata[$fieldName]['input_attrs']['label'] ?? $this->fieldMetadata[$fieldName]['label'];
-        $return[$fieldName . ':label'] = $fieldLabel;
-        $return[$fieldName . ':name'] = ts('Machine name') . ': ' . $fieldLabel;
-      }
-      if ($this->isBooleanField($fieldName)) {
-        $return[$fieldName . ':label'] = $this->getFieldMetadata()[$fieldName]['title'];
-      }
-    }
-    return $return;
-  }
-
-  /**
    * Get any tokens with custom calculation.
    */
   protected function getBespokeTokens(): array {
     return [];
-  }
-
-  /**
-   * Is this a field we should add pseudo-tokens to?
-   *
-   * Pseudo-tokens allow access to name and label fields - e.g
-   *
-   * {contribution.contribution_status_id:name} might resolve to 'Completed'
-   *
-   * @param string $fieldName
-   */
-  public function isAddPseudoTokens($fieldName): bool {
-    if (in_array($fieldName, $this->getCurrencyFieldName())) {
-      // 'currency' is manually added to the skip list as an anomaly.
-      // name & label aren't that suitable for 'currency' (symbol, which
-      // possibly maps to 'abbr' would be) and we can't gather that
-      // from the metadata as yet.
-      return FALSE;
-    }
-    if ($this->getFieldMetadata()[$fieldName]['type'] === 'Custom') {
-      // If we remove this early return then we get that extra nuanced goodness
-      // and support for the more portable v4 style field names
-      // on custom fields - where labels or names can be returned.
-      // At present the gap is that the metadata for the label is not accessed
-      // and tests failed on the enotice and we don't have a clear plan about
-      // v4 style custom tokens - but medium term this IF will probably go.
-      return FALSE;
-    }
-    return (bool) ($this->getFieldMetadata()[$fieldName]['options'] || !empty($this->getFieldMetadata()[$fieldName]['suffixes']));
   }
 
   /**
@@ -382,7 +331,7 @@ class CRM_Core_EntityTokens extends AbstractTokenSubscriber {
    *
    * @internal function will likely be protected soon.
    */
-  public function getPseudoValue(string $realField, string $pseudoKey, $fieldValue): string {
+  protected function getPseudoValue(string $realField, string $pseudoKey, $fieldValue): string {
     if ($pseudoKey === 'name') {
       $fieldValue = (string) CRM_Core_PseudoConstant::getName($this->getBAOName(), $realField, $fieldValue);
     }

--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -1523,15 +1523,32 @@ class CRM_Utils_Token {
     return $value;
   }
 
+  /**
+   * @deprecated
+   *
+   * Do not use this function - it still needs full removal from active code
+   * in CRM_Contribute_Form_Task_PDFLetter.
+   */
   protected static function _buildContributionTokens() {
     $key = 'contribution';
 
     if (!isset(Civi::$statics[__CLASS__][__FUNCTION__][$key])) {
-      $processor = new CRM_Contribute_Tokens();
       $tokens = array_merge(CRM_Contribute_BAO_Contribution::exportableFields('All'),
         ['campaign' => [], 'financial_type' => [], 'payment_instrument' => []],
         self::getCustomFieldTokens('Contribution'),
-        $processor->getPseudoTokens()
+        [
+          'financial_type_id:label',
+          'financial_type_id:name',
+          'contribution_page_id:label',
+          'contribution_page_id:name',
+          'payment_instrument_id:label',
+          'payment_instrument_id:name',
+          'is_test:label',
+          'is_pay_later:label',
+          'contribution_status_id:label',
+          'contribution_status_id:name',
+          'is_template:label',
+        ]
       );
       foreach ($tokens as $token) {
         if (!empty($token['name'])) {


### PR DESCRIPTION


Overview
----------------------------------------
Remove now-obsolete getPseudoTokens

Before
----------------------------------------
`getPseudoTokens` & the associated functions were used as part of a refactoring process to align legacy code & token processor code but is no longer required as

- all legacy code paths except for the one tested in `CRM_Contribute_Form_Task_PDFLetterCommonTest` are fully migrated to the token processor
- the remaining path is partially migrated but has a tested flow through 2 functions which we haven't yet got rid of.

After
----------------------------------------
Those last legacy functions are marked as deprecated and use a hard-coded rather than dynamic version of the data that was being retrieved from the token processor. Functions removed


Technical Details
----------------------------------------
@totten @colemanw cleanup following the metadata PR merge



This code is no longer used in the Tokens classes and the functions that used it
from outside of there are now 'settled into their final state & waiting to die'
so a hard-coded list will see out their lives. They are marked now as deprecated

Comments
----------------------------------------
