### PR TITLE
Add system status warning to display scheduled job failures

### DIFF
--- a/CRM/Utils/Check/Component/Env.php
+++ b/CRM/Utils/Check/Component/Env.php
@@ -708,23 +708,26 @@ class CRM_Utils_Check_Component_Env extends CRM_Utils_Check_Component {
       ])['values'][0]['description'] ?? NULL;
       if (!empty($lastExecutionMessage) && strpos($lastExecutionMessage, 'Failure') !== FALSE) {
         $viewLogURL = CRM_Utils_System::url('civicrm/admin/joblog', "jid={$job['id']}&reset=1");
-        $html .= "<tr><td>{$job['name']} </td><td>{$lastExecutionMessage}</td><td>{$job['last_run']}</td><td> <a href='{$viewLogURL}'>View Job Log</a></td></tr>";
+        $html .= '<tr>
+          <td>' . $job['name'] . ' </td>
+          <td>' . $lastExecutionMessage . '</td>
+          <td>' . $job['last_run'] . '</td>
+          <td><a href="' . $viewLogURL . '">' . ts('View Job Log') . '</a></td>
+        </tr>';
       }
     }
     if (empty($html)) {
       return [];
     }
 
-    $message = "<p>The following scheduled jobs failed on the last run:</p>
-      <p><table><thead><tr><th>Job</th><th>Message</th><th>Date</th><th></th>
-      </tr></thead><tbody>
-      $html
-      </tbody></table></p>
-     ";
+    $message = '<p>' . ts('The following scheduled jobs failed on the last run:') . '</p>
+      <p><table><thead><tr><th>' . ts('Job') . '</th><th>' . ts('Message') . '</th><th>' . ts('Last Run') . '</th><th></th>
+      </tr></thead><tbody>' . $html . '
+      </tbody></table></p>';
 
     $msg = new CRM_Utils_Check_Message(
       __FUNCTION__,
-      ts($message),
+      $message,
       ts('Scheduled Job Failures'),
       \Psr\Log\LogLevel::WARNING,
       'fa-server'


### PR DESCRIPTION
Overview
----------------------------------------
Add alert to display scheduled job errors

Before
----------------------------------------
Schedule job fails silently. Civi core doesn't provide an inbuilt option to notify admins.

From https://chat.civicrm.org/civicrm/pl/8wbq1y3j4tdeumnf1iuie44a5o

>anyone else wondered about having Sch Reminder errors listed as problems in System Status? Just found a case where 5 months back 'somehow' a membership was given an End Date of 0000:00:00 and guess what. that stops renewal reminders being sent out. sheesh.

After
----------------------------------------
Alert displayed on the system status page. Eg

![image](https://user-images.githubusercontent.com/5929648/136356979-ca6d8080-7987-4676-ac4c-75b8eb26d237.png)



