### PR TITLE
Reference token metadata internally fix custom tokens label bug

### DIFF
--- a/CRM/Event/Tokens.php
+++ b/CRM/Event/Tokens.php
@@ -49,6 +49,7 @@ class CRM_Event_Tokens extends CRM_Core_EntityTokens {
         'type' => 'calculated',
         'options' => NULL,
         'data_type' => 'String',
+        'audience' => 'user',
       ],
       'info_url' => [
         'title' => ts('Event Info URL'),
@@ -56,6 +57,7 @@ class CRM_Event_Tokens extends CRM_Core_EntityTokens {
         'type' => 'calculated',
         'options' => NULL,
         'data_type' => 'String',
+        'audience' => 'user',
       ],
       'registration_url' => [
         'title' => ts('Event Registration URL'),
@@ -63,6 +65,7 @@ class CRM_Event_Tokens extends CRM_Core_EntityTokens {
         'type' => 'calculated',
         'options' => NULL,
         'data_type' => 'String',
+        'audience' => 'user',
       ],
       'contact_email' => [
         'title' => ts('Event Contact Email'),
@@ -70,6 +73,7 @@ class CRM_Event_Tokens extends CRM_Core_EntityTokens {
         'type' => 'calculated',
         'options' => NULL,
         'data_type' => 'String',
+        'audience' => 'user',
       ],
       'contact_phone' => [
         'title' => ts('Event Contact Phone'),
@@ -77,6 +81,7 @@ class CRM_Event_Tokens extends CRM_Core_EntityTokens {
         'type' => 'calculated',
         'options' => NULL,
         'data_type' => '',
+        'audience' => 'user',
       ],
     ];
   }
@@ -92,7 +97,7 @@ class CRM_Event_Tokens extends CRM_Core_EntityTokens {
     }
     if (array_key_exists($field, $this->getEventTokenValues($eventID))) {
       foreach ($this->getEventTokenValues($eventID)[$field] as $format => $value) {
-        $row->format($format)->tokens($entity, $field, $value);
+        $row->format($format)->tokens($entity, $field, $value ?? '');
       }
     }
   }
@@ -143,14 +148,15 @@ class CRM_Event_Tokens extends CRM_Core_EntityTokens {
       $tokens['contact_phone']['text/html'] = $event['loc_block_id.phone_id.phone'];
       $tokens['contact_email']['text/html'] = $event['loc_block_id.email_id.email'];
 
-      foreach (array_keys($this->getTokenMetadata()) as $field) {
-        if (!isset($tokens[$field])) {
-          if ($this->isCustomField($field)) {
+      foreach ($this->getTokenMetadata() as $fieldName => $fieldSpec) {
+        if (!isset($tokens[$fieldName])) {
+          if ($fieldSpec['type'] === 'Custom') {
             $this->prefetch[$eventID] = $event;
-            $tokens[$field]['text/html'] = $this->getCustomFieldValue($eventID, $field);
+            $value = $event[$fieldSpec['name']];
+            $tokens[$fieldName]['text/html'] = CRM_Core_BAO_CustomField::displayValue($value, $fieldSpec['custom_field_id']);
           }
           else {
-            $tokens[$field]['text/html'] = $event[$field];
+            $tokens[$fieldName]['text/html'] = $event[$fieldName];
           }
         }
       }


### PR DESCRIPTION

Overview
----------------------------------------
Reference token metadata internally. This also fixes a metadata issue @magnolia61 identified where the metadata for custom fields was 'falling through' to the metadata for 'all fields' - resulting in :label: variants being incorrectly added

Before
----------------------------------------
Data is stored in token metadata - it may ALSO be stored as field metadata. When we access via field metadata if will use getFields to fetch if not present
 
After
----------------------------------------
Referring to the token metadata array allows us to avoid an extra getfields & is a step towards only using that look up to build the token metadata

Technical Details
----------------------------------------
This references the token metadata rather than the metadata retrieved from the api
call. Since the former is cached it should save a look up -
albeit not when prefetch is happening, at this stage

Comments
----------------------------------------

@colemanw you only just merged it & I changed it :-) If this passes would be good to get it merged as #21761 builds on it