### PR TITLE
SearchKit - Fix in-place edit in 5.42

### DIFF
--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
@@ -339,6 +339,7 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
       // Select value fields for in-place editing
       if (isset($column['editable']['value'])) {
         $additions[] = $column['editable']['value'];
+        $additions[] = $column['editable']['id'];
       }
     }
     // Add fields referenced via token


### PR DESCRIPTION
Overview
----------------------------------------
This is a partial backport of 3a608fe63b15f8eb6b4c38c4183dc5d391ded4cc to fix a regression with in-place edit in SearchKit.

Before
----------------------------------------
Create a search for contacts with emails. Make the email address editable. It's broken.

After
----------------------------------------
It works.

Comments
----------------------------------------
This is already in master & 5.43 so doesn't need forward merging.
