### PR TITLE
(dev/mail#83) message_admin - Cleanup "Preview" dialogs (properly)

### DIFF
--- a/ext/message_admin/ang/crmMsgadm/Edit.js
+++ b/ext/message_admin/ang/crmMsgadm/Edit.js
@@ -308,9 +308,9 @@
       });
 
     }
-    $rootScope.$on('previewMsgTpl', onPreview);
-    $rootScope.$on('$destroy', function (){
-      $rootScope.$off('previewMsgTpl', onPreview);
+    var unreg = $rootScope.$on('previewMsgTpl', onPreview);
+    $scope.$on('$destroy', function (){
+      unreg();
     });
   });
 


### PR DESCRIPTION
Overview
----------------------------------------

Fix a quirk when using the "Preview" dialog repeatedly, with different message-templates.

ping @eileenmcnaughton 

Use-case
----------------------------------------

1. Open the editor for a message template (eg `#/edit?id=17&lang=fr_FR`). This renders the edit screen.
2. Click on the "Preview" icon.
3. Close the "Preview" dialog.
4. Change the URL to navigate internally to another template (eg `#/edit?id=17&lang=de_DE`). This renders the edit screen again.
5. Click on the "Preview" icon.

Before
----------------------------------------

* At step `#5`, it opens two copies of the "Preview" dialog (each with  slightly different options).  Initially, you see one dialog.  When that  closes, you will see the other dialog.
* As you proceed through closing the dialogs, you may get console warnings  because the internal resources of the two dialogs get mixed up. (*They have the same name.*)

After
----------------------------------------

* At step `#5`, it only opens one copy of the "Preview" dialog.

Technical Details
----------------------------------------

* When rendering the setup screen (`#1`/`#4`), it registers a listener which  will handle the "Preview" clicks.  But the listener is not properly  unregistered.  Consequently, old listeners hang around. So the click at  step `#5` calls both the old+new listeners, creating two dialogs.

