### PR TITLE
(dev/mail#83) message_admin - When using "Preview", use the 'locale' from the editing UI

### DIFF
--- a/Civi/WorkflowMessage/GenericWorkflowMessage.php
+++ b/Civi/WorkflowMessage/GenericWorkflowMessage.php
@@ -15,6 +15,7 @@ namespace Civi\WorkflowMessage;
 use Civi\Schema\Traits\MagicGetterSetterTrait;
 use Civi\WorkflowMessage\Traits\AddressingTrait;
 use Civi\WorkflowMessage\Traits\FinalHelperTrait;
+use Civi\WorkflowMessage\Traits\LocalizationTrait;
 use Civi\WorkflowMessage\Traits\ReflectiveWorkflowTrait;
 
 /**
@@ -43,6 +44,9 @@ class GenericWorkflowMessage implements WorkflowMessageInterface {
 
   // Implement setTo(), setReplyTo(), etc
   use AddressingTrait;
+
+  // Implement setLocale(), etc
+  use LocalizationTrait;
 
   /**
    * WorkflowMessage constructor.

--- a/Civi/WorkflowMessage/Traits/LocalizationTrait.php
+++ b/Civi/WorkflowMessage/Traits/LocalizationTrait.php
@@ -1,0 +1,50 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\WorkflowMessage\Traits;
+
+trait LocalizationTrait {
+
+  /**
+   * @var string|null
+   * @scope tokenContext
+   */
+  protected $locale;
+
+  /**
+   * @return string
+   */
+  public function getLocale(): ?string {
+    return $this->locale;
+  }
+
+  /**
+   * @param string|null $locale
+   * @return $this
+   */
+  public function setLocale(?string $locale) {
+    $this->locale = $locale;
+    return $this;
+  }
+
+  protected function validateExtra_localization(&$errors) {
+    $allLangs = \CRM_Core_I18n::languages();
+    if ($this->locale !== NULL && !isset($allLangs[$this->locale])) {
+      $errors[] = [
+        'severity' => 'error',
+        'fields' => ['locale'],
+        'name' => 'badLocale',
+        'message' => ts('The given locale is not valid (%1)', [json_encode($this->locale)]),
+      ];
+    }
+  }
+
+}

--- a/ext/message_admin/ang/crmMsgadm/Edit.js
+++ b/ext/message_admin/ang/crmMsgadm/Edit.js
@@ -245,11 +245,6 @@
     // Ex: $rootScope.$emit('previewMsgTpl', {revisionName: 'txDraft', formatName: 'msg_text'})
     function onPreview(event, args) {
       var defaults = {
-        // exampleName: 'fix-this-example',
-        // examples: [
-        //   {id: 0, name: 'fix-this-example', title: ts('Fix this example')},
-        //   {id: 1, name: 'another-example', title: ts('Another example')}
-        // ],
         formatName: 'msg_html',
         formats: [
           {id: 0, name: 'msg_html', label: ts('HTML')},

--- a/ext/message_admin/ang/crmMsgadm/Edit.js
+++ b/ext/message_admin/ang/crmMsgadm/Edit.js
@@ -257,7 +257,11 @@
           }
           return acc;
         }, []),
-        title: ts('Preview')
+        filterData: function(data) {
+          data.modelProps.locale = $ctrl.lang;
+          return data;
+        },
+        title: $ctrl.lang ? ts('Preview - %1', {1: $ctrl.locales[$ctrl.lang] || $ctrl.lang}) : ts('Preview')
       };
 
       crmApi4({

--- a/ext/message_admin/ang/crmMsgadm/Preview.js
+++ b/ext/message_admin/ang/crmMsgadm/Preview.js
@@ -39,6 +39,9 @@
         }).then(function(response){
           dlgModel.title = ts('Example: %1', {1: response[0].title || response[0].name});
           dlgModel.data = response[0];
+          if (model.filterData && dlgModel.data.data) {
+            dlgModel.data['data(filtered)'] = model.filterData(angular.copy(dlgModel.data.data));
+          }
         });
       };
 
@@ -76,10 +79,11 @@
       //   $ctrl.preview = model.revisions[$ctrl.revisionId].rec;
       $ctrl.preview = {loading: true};
       var rendering = $ctrl.isAdhocExample ? requestAdhocExample() : requestStoredExample();
-      rendering.then(function(exampleData){
+      rendering.then(function(exampleData) {
+        var filteredData = model.filterData ? model.filterData(exampleData) : exampleData;
         return crmApi4('WorkflowMessage', 'render', {
-          workflow: exampleData.workflow,
-          values: exampleData.modelProps,
+          workflow: filteredData.workflow,
+          values: filteredData.modelProps,
           messageTemplate: model.revisions[$ctrl.revisionId].rec
         });
       }).then(function(response) {

--- a/ext/message_admin/ang/crmMsgadm/Preview.js
+++ b/ext/message_admin/ang/crmMsgadm/Preview.js
@@ -50,36 +50,20 @@
     };
 
     function requestAdhocExample() {
-      var adhocExample;
       try {
-        adhocExample = JSON.parse($ctrl.adhocExampleJson);
+        return $q.resolve(JSON.parse($ctrl.adhocExampleJson.data));
       }
       catch (err) {
         return $q.reject(ts('Malformed JSON example'));
       }
-      return crmApi4('WorkflowMessage', 'render', {
-        workflow: adhocExample.data.workflow,
-        values: adhocExample.data.modelProps,
-        messageTemplate: model.revisions[$ctrl.revisionId].rec
-      }).then(function(response) {
-        return response[0];
-      });
     }
 
     function requestStoredExample() {
-      // For a dev working on example, it's easier if the example is always loaded fresh.
       return crmApi4('ExampleData', 'get', {
         where: [["name", "=", model.examples[$ctrl.exampleId].name]],
-        select: ['name', 'file', 'title', 'data'],
-        chain: {
-          "render": ["WorkflowMessage", "render", {
-            "workflow": "$data.workflow",
-            "values": "$data.modelProps",
-            "messageTemplate": model.revisions[$ctrl.revisionId].rec
-          }]
-        }
+        select: ['data']
       }).then(function(response) {
-        return response[0].render[0];
+        return response[0].data;
       });
     }
 
@@ -92,8 +76,14 @@
       //   $ctrl.preview = model.revisions[$ctrl.revisionId].rec;
       $ctrl.preview = {loading: true};
       var rendering = $ctrl.isAdhocExample ? requestAdhocExample() : requestStoredExample();
-      rendering.then(function(response) {
-        $ctrl.preview = response;
+      rendering.then(function(exampleData){
+        return crmApi4('WorkflowMessage', 'render', {
+          workflow: exampleData.workflow,
+          values: exampleData.modelProps,
+          messageTemplate: model.revisions[$ctrl.revisionId].rec
+        });
+      }).then(function(response) {
+        $ctrl.preview = response[0];
       }, function(failure) {
         $ctrl.preview = {};
         crmUiAlert({title: ts('Render failed'), text: failure.error_message, type: 'error'});


### PR DESCRIPTION
Overview
----------------------------------------

Suppose you create a translation for a message template - and then preview the translation. While previewing, it should evaluate any translations (eg `ts('...')`) using the indicated locale.

ping @eileenmcnaughton

Before
----------------------------------------

<img width="1367" alt="Screen Shot 2021-10-08 at 3 13 38 PM" src="https://user-images.githubusercontent.com/1336047/136630418-2122e130-33f6-4915-b308-2829aaf939ce.png">

After
----------------------------------------

<img width="1367" alt="Screen Shot 2021-10-08 at 3 17 26 PM" src="https://user-images.githubusercontent.com/1336047/136630423-f358d13c-81fe-4b41-86e5-8d85b0992864.png">

Comments
----------------------------------------

In the screenshot above, I used a standard message-template which relies on `{ts}...{/ts}`. Consequently, the locale is quite influential - the entire message appears to translate.

If you were using bespoke messages for each locale (without `{ts}`), then the effect would be more subtle - e.g. it might only affect localized tokens and filters (e.g. the names of months/days/currencies).