### PR TITLE
(dev/mail#83) message_admin - Save automatically when adding/removing drafts

### DIFF
--- a/ext/message_admin/ang/crmMsgadm/Edit.html
+++ b/ext/message_admin/ang/crmMsgadm/Edit.html
@@ -50,17 +50,17 @@
             </a>
           </li>
           <li role="presentation" class="navitem pull-right" ng-show="$ctrl.tab.match('txActive|original') && $ctrl.hasDraft() && $ctrl.allowDraft()">
-            <a crm-icon="fa-plus" class="nav-link text-warning" crm-confirm="{title: ts('Create draft?'), message: ts('There is already an existing draft. If you continue, it will be replaced with a clean draft. (Note: Changes will not take full effect until you save.)')}" on-yes="$ctrl.createDraft($ctrl.records[$ctrl.tab])">
+            <a crm-icon="fa-plus" class="nav-link text-warning" crm-confirm="{title: ts('Create draft?'), message: ts('There is already an existing draft. Click &quot;Continue&quot; to overwrite it with a new, clean draft.')}" on-yes="$ctrl.createDraft($ctrl.records[$ctrl.tab])">
               {{:: ts('Create draft') }}
             </a>
           </li>
           <li role="presentation" class="navitem pull-right" ng-show="$ctrl.tab === 'txDraft'">
-            <a crm-icon="fa-trash" class="nav-link text-danger" crm-confirm="{type: 'delete', obj: {}, title: ts('Abandon draft?'), message: ts('Are you sure you want to abandon this draft? (Note: Changes will not take full effect until you save.)')}" on-yes="$ctrl.deleteDraft()">
+            <a crm-icon="fa-trash" class="nav-link text-danger" crm-confirm="{type: 'delete', obj: {}, title: ts('Abandon draft?'), message: ts('Are you sure you want to abandon this draft?')}" on-yes="$ctrl.deleteDraft()">
               {{:: ts('Abandon draft') }}
             </a>
           </li>
           <li role="presentation" class="navitem pull-right" ng-show="$ctrl.tab === 'txDraft'">
-            <a crm-icon="fa-rocket" class="nav-link text-success" crm-confirm="{title: ts('Activate draft?'), message: ts('Are you sure you want to activate this draft? (Note: Changes will not take full effect until you save.)')}" on-yes="$ctrl.activateDraft()">
+            <a crm-icon="fa-rocket" class="nav-link text-success" crm-confirm="{title: ts('Activate draft?'), message: ts('Are you sure you want to activate this draft?')}" on-yes="$ctrl.activateDraft()">
               {{:: ts('Activate draft') }}
             </a>
           </li>

--- a/ext/message_admin/ang/crmMsgadm/Edit.js
+++ b/ext/message_admin/ang/crmMsgadm/Edit.js
@@ -176,6 +176,21 @@
       {name: 'txDraft', label: ts('%1 - Draft translation', {1: $ctrl.locales[$ctrl.lang] || $ctrl.lang})}
     ];
 
+    function doSave() {
+      var requests = {};
+      if ($ctrl.lang) {
+        requests.txActive = reqReplaceTranslations($ctrl.records.main.id, $ctrl.lang, 'active', $ctrl.records.txActive);
+        requests.txDraft = reqReplaceTranslations($ctrl.records.main.id, $ctrl.lang, 'draft', $ctrl.records.txDraft);
+      }
+      else {
+        requests.main = ['MessageTemplate', 'update', {
+          where: [['id', '=', $ctrl.records.main.id]],
+          values: $ctrl.records.main
+        }];
+      }
+      return crmApi4(requests);
+    }
+
     $ctrl.switchTab = function switchTab(tgt) {
       $ctrl.tab = tgt;
       // Experimenting with action buttons in the tab-bar. This makes the scroll unnecessary.
@@ -198,33 +213,21 @@
     $ctrl.createDraft = function createDraft(src) {
       copyTranslations(src, $ctrl.records.txDraft);
       $ctrl.switchTab('txDraft');
-      crmStatus({success: ts('Beginning draft...')}, $q.resolve());
+      crmStatus({start: ts('Saving...'), success: ts('Created draft.')}, doSave());
     };
     $ctrl.deleteDraft = function deleteDraft() {
       copyTranslations({}, $ctrl.records.txDraft);
       $ctrl.switchTab('txActive');
-      crmStatus({error: ts('Abandoned draft.')}, $q.reject()).then(function(){},function(){});
+      crmStatus({start: ts('Saving...'), success: ts('Abandoned draft.')}, doSave());
     };
     $ctrl.activateDraft = function activateDraft() {
       copyTranslations($ctrl.records.txDraft, $ctrl.records.txActive);
       copyTranslations({}, $ctrl.records.txDraft);
       $ctrl.switchTab('txActive');
-      crmStatus({success: ts('Activated draft.')}, $q.resolve());
+      crmStatus({start: ts('Saving...'), success: ts('Activated draft.')}, doSave());
     };
-
     $ctrl.save = function save() {
-      var requests = {};
-      if ($ctrl.lang) {
-        requests.txActive = reqReplaceTranslations($ctrl.records.main.id, $ctrl.lang, 'active', $ctrl.records.txActive);
-        requests.txDraft = reqReplaceTranslations($ctrl.records.main.id, $ctrl.lang, 'draft', $ctrl.records.txDraft);
-      }
-      else {
-        requests.main = ['MessageTemplate', 'update', {
-          where: [['id', '=', $ctrl.records.main.id]],
-          values: $ctrl.records.main
-        }];
-      }
-      return block(crmStatus({start: ts('Saving...'), success: ts('Saved')}, crmApi4(requests)));
+      return block(crmStatus({start: ts('Saving...'), success: ts('Saved')}, doSave()));
     };
     $ctrl.cancel = function() {
       window.location = '#/workflow';


### PR DESCRIPTION
Overview
----------------------------------------

When editing a message template, there are a few actions for creating, activating, and abandoning drafts. When you perform these actions, should they be buffered in the client (*until you click "Save"*) or should they be sent immediately to the server (*auto-saving the page*)?

Before
----------------------------------------

"Draft"-related actions remains local the client until saving.

<img width="1304" alt="Screen Shot 2021-10-08 at 3 55 29 PM" src="https://user-images.githubusercontent.com/1336047/136632717-ecac7bb6-aa85-415d-b04b-a30283067fd6.png">

After
----------------------------------------

"Draft"-related actions cause the page to save.

<img width="1305" alt="Screen Shot 2021-10-08 at 3 54 14 PM" src="https://user-images.githubusercontent.com/1336047/136632716-5356cb3c-31bb-4fb4-8a35-6ef2d99f5270.png">

Comments
----------------------------------------

For comparison, in CiviMail, these lifecycle actions (creating a draft, submitting/activating a draft, deleting a draft) have action-buttons which persist immediately. Of course, with CiviMail, the behavior is almost a necessity - its aligns with how the data is stored. For Message Templates, the data-storage is different - however, this patch should make it "feel" a bit more similar.
