### PR TITLE
Fix contact tokens class to load using apiv4

### DIFF
--- a/CRM/Core/EntityTokens.php
+++ b/CRM/Core/EntityTokens.php
@@ -75,10 +75,7 @@ class CRM_Core_EntityTokens extends AbstractTokenSubscriber {
    */
   protected function getTokenMetadata(): array {
     if (empty($this->tokensMetadata)) {
-      $cacheKey = __CLASS__ . 'token_metadata' . $this->getApiEntityName() . CRM_Core_Config::domainID() . '_' . CRM_Core_I18n::getLocale();
-      if ($this->checkPermissions) {
-        $cacheKey .= '__' . CRM_Core_Session::getLoggedInContactID();
-      }
+      $cacheKey = $this->getCacheKey();
       if (Civi::cache('metadata')->has($cacheKey)) {
         $this->tokensMetadata = Civi::cache('metadata')->get($cacheKey);
       }
@@ -635,6 +632,19 @@ class CRM_Core_EntityTokens extends AbstractTokenSubscriber {
       }
       $this->tokensMetadata[$tokenName] = $field;
     }
+  }
+
+  /**
+   * Get a cache key appropriate to the current usage.
+   *
+   * @return string
+   */
+  protected function getCacheKey(): string {
+    $cacheKey = __CLASS__ . 'token_metadata' . $this->getApiEntityName() . CRM_Core_Config::domainID() . '_' . CRM_Core_I18n::getLocale();
+    if ($this->checkPermissions) {
+      $cacheKey .= '__' . CRM_Core_Session::getLoggedInContactID();
+    }
+    return $cacheKey;
   }
 
 }

--- a/CRM/Core/EntityTokens.php
+++ b/CRM/Core/EntityTokens.php
@@ -541,7 +541,25 @@ class CRM_Core_EntityTokens extends AbstractTokenSubscriber {
     if (isset($this->getTokenMetadata()[$fieldName])) {
       return $this->getTokenMetadata()[$fieldName];
     }
+    if (isset($this->getTokenMappingsForRelatedEntities()[$fieldName])) {
+      return $this->getTokenMetadata()[$this->getTokenMappingsForRelatedEntities()[$fieldName]];
+    }
     return $this->getTokenMetadata()[$this->getDeprecatedTokens()[$fieldName]];
+  }
+
+  /**
+   * Get token mappings for related entities - specifically the contact entity.
+   *
+   * This function exists to help manage the way contact tokens is structured
+   * of an query-object style result set that needs to be mapped to apiv4.
+   *
+   * The end goal is likely to be to advertised tokens that better map to api
+   * v4 and deprecate the existing ones but that is a long-term migration.
+   *
+   * @return array
+   */
+  protected function getTokenMappingsForRelatedEntities(): array {
+    return [];
   }
 
   /**
@@ -616,7 +634,7 @@ class CRM_Core_EntityTokens extends AbstractTokenSubscriber {
         // At the time of writing currency didn't have a label option - this may have changed.
         && !in_array($field['name'], $this->getCurrencyFieldName(), TRUE)
       ) {
-        $this->tokensMetadata[$tokenName . ':label'] = $this->tokensMetadata[$field['name'] . ':name'] = $field;
+        $this->tokensMetadata[$tokenName . ':label'] = $this->tokensMetadata[$tokenName . ':name'] = $field;
         $fieldLabel = $field['input_attrs']['label'] ?? $field['label'];
         $this->tokensMetadata[$tokenName . ':label']['name'] = $field['name'] . ':label';
         $this->tokensMetadata[$tokenName . ':name']['name'] = $field['name'] . ':name';

--- a/CRM/Upgrade/Incremental/php/FiveFortyThree.php
+++ b/CRM/Upgrade/Incremental/php/FiveFortyThree.php
@@ -83,6 +83,9 @@ class CRM_Upgrade_Incremental_php_FiveFortyThree extends CRM_Upgrade_Incremental
     $this->addTask('Replace event fee amount in action schedule',
       'updateActionScheduleToken', 'event.fee_amount', 'participant.fee_amount', $rev
     );
+    $this->addTask('Replace contact.preferred_communication_method in action schedule',
+      'updateActionScheduleToken', 'contact.preferred_communication_method', 'contact.preferred_communication_method:label', $rev
+    );
     $this->addTask('Replace event event_id in action schedule',
       'updateActionScheduleToken', 'event.event_id', 'event.id', $rev
     );
@@ -118,6 +121,9 @@ class CRM_Upgrade_Incremental_php_FiveFortyThree extends CRM_Upgrade_Incremental
     );
     $this->addTask('Update participant registered by id token in event badges',
       'updatePrintLabelToken', 'participant.participant_registered_by_id', 'participant.registered_by_id', $rev
+    );
+    $this->addTask('Update preferred_communication_method token in saved message templates',
+      'updateMessageToken', '', 'contact.preferred_communication_method', 'contact.preferred_communication_method:label', $rev
     );
     $this->addTask('Update contribution status token in saved message templates',
       'updateMessageToken', '', 'contribution.contribution_status', 'contribution.contribution_status_id:label', $rev

--- a/tests/phpunit/CRM/Core/BAO/MessageTemplateTest.php
+++ b/tests/phpunit/CRM/Core/BAO/MessageTemplateTest.php
@@ -391,7 +391,6 @@ emo
       ['old' => '{contact.individual_suffix}', 'new' => '{contact.suffix_id:label}', 'output' => 'II'],
       ['old' => '{contact.gender}', 'new' => '{contact.gender_id:label}', 'output' => 'Female'],
       ['old' => '{contact.communication_style}', 'new' => '{contact.communication_style_id:label}', 'output' => 'Formal'],
-      ['old' => '{contact.preferred_communication_method}', 'new' => '{contact.preferred_communication_method:label}', 'output' => 'Phone'],
       ['old' => '{contact.contact_id}', 'new' => '{contact.id}', 'output' => $contactID],
       ['old' => '{contact.email_greeting}', 'new' => '{contact.email_greeting_display}', 'output' => 'Dear Anthony'],
       ['old' => '{contact.postal_greeting}', 'new' => '{contact.postal_greeting_display}', 'output' => 'Dear Anthony'],
@@ -473,9 +472,8 @@ emo
       $rendered = (string) $row->render('html');
     }
     $expected = $this->getExpectedContactOutput($address['id'], $tokenData, $rendered);
-    // @todo - this works better in token processor than in CRM_Core_Token.
-    // once synced we can fix $this->getExpectedContactOutput to return the right thing.
-    $expected = str_replace("preferred_communication_method:\n", "preferred_communication_method:Phone\n", $expected);
+    // the right thing to use is the (advertised) label now.
+    $expected = str_replace("preferred_communication_method:Phone\n", "preferred_communication_method:1\n", $expected);
     $this->assertEquals($expected, $rendered);
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Fix contact tokens class to load using apiv4. 

2 things of note
- a big weakness for apiv3 was that it wasn't possible to distinguish between 'not retrieved' and empty - the apiv4 only sets retrieved fields. This is important for us to handle the `replaceGreetingTokens` scenario as we need to deal with a mix of retrieved fields and passed in fields since the entity is pre-saved
- although not exposed this 'does the work' for more accurate tokens for location entities ie
`{contact.primary_address.street_address}` which we can add to with `{contact.billing_address.street_address}`  for workflow template use.

However I'm on the fence about stripping the 'primary_' from the above & thinking it's implied

Before
----------------------------------------
BAO query function called to load the contact

After
----------------------------------------
APIv4 called

Technical Details
----------------------------------------
This looks like a lot of code - but it is really only describing the mapping between the two.

Note how in this heavily tested code the only change to tests is here

https://github.com/civicrm/civicrm-core/pull/21780/files#diff-c3c60600f080b49f2a9029b82865098c2a2742fbcedce0ecd731376917d80e1bL476

- the rendering of `{contact.preferred_communication_method}` was already inconsistent and we now advertise the consistent :label: alternative. I think the handling of this field was inconsistent enough that we don't need to worry about it - although I have added to the upgrade notes - see https://lab.civicrm.org/documentation/docs/sysadmin/-/blob/master/docs/upgrade/version-specific.md

Comments
----------------------------------------
