### PR TITLE
dev/core#2901 Fix send email regression

### DIFF
--- a/CRM/Contact/Form/Task/EmailTrait.php
+++ b/CRM/Contact/Form/Task/EmailTrait.php
@@ -182,7 +182,7 @@ trait CRM_Contact_Form_Task_EmailTrait {
     //get the group of contacts as per selected by user in case of Find Activities
     if (!empty($this->_activityHolderIds)) {
       $contact = $this->get('contacts');
-      $this->_allContactIds = $this->_contactIds = $contact;
+      $this->_allContactIds = $this->_toContactIds = $this->_contactIds = $contact;
     }
 
     // check if we need to setdefaults and check for valid contact emails / communication preferences


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#2901 Fix send email regression

Before
----------------------------------------

Even if all the communication prefs are good and the email is valid it still gives the warning message and doesn't let you send.

Find Activities.
Select one that has a valid With Contact who isn't deceased and doesn't have email on hold etc.
From the actions dropdown choose send email
Choose With Contact.
Warning comes up and redirects you back to search. Selected contact(s) do not have a valid email address, or communication preferences specify DO NOT EMAIL, or they are deceased or Primary email address is On Hold.



After
----------------------------------------
Seems to work ok

Technical Details
----------------------------------------
One of those scary & bizarre properties...


Comments
----------------------------------------
@demeritcowboy 