### PR TITLE
Remove extraneous call to legacy token processing in sms task

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -1246,43 +1246,10 @@ WHERE entity_id =%1 AND entity_table = %2";
     $activity = self::create($activityParams);
     $activityID = $activity->id;
 
-    // Process Tokens
-    // token replacement of addressee/email/postal greetings
-    // get the tokens added in subject and message
-    $messageToken = CRM_Utils_Token::getTokens($text);
-    $returnProperties = [];
-    if (isset($messageToken['contact'])) {
-      foreach ($messageToken['contact'] as $key => $value) {
-        $returnProperties[$value] = 1;
-      }
-    }
-    // Call tokens hook
-    $tokens = [];
-    CRM_Utils_Hook::tokens($tokens);
-    $categories = array_keys($tokens);
-    // get token details for contacts, call only if tokens are used
-    $tokenDetails = [];
-    if (!empty($returnProperties) || !empty($tokens)) {
-      [$tokenDetails] = CRM_Utils_Token::getTokenDetails($contactIds,
-        $returnProperties,
-        NULL, NULL, FALSE,
-        $messageToken,
-        'CRM_Activity_BAO_Activity'
-      );
-    }
-
     $success = 0;
     $errMsgs = [];
     foreach ($contactDetails as $contact) {
       $contactId = $contact['contact_id'];
-
-      // Replace tokens
-      if (!empty($tokenDetails) && is_array($tokenDetails["{$contactId}"])) {
-        // unset phone from details since it always returns primary number
-        unset($tokenDetails["{$contactId}"]['phone']);
-        unset($tokenDetails["{$contactId}"]['phone_type_id']);
-        $contact = array_merge($contact, $tokenDetails["{$contactId}"]);
-      }
       $tokenText = CRM_Core_BAO_MessageTemplate::renderTemplate(['messageTemplate' => ['msg_text' => $text], 'contactId' => $contactId, 'disableSmarty' => TRUE])['text'];
 
       // Only send if the phone is of type mobile


### PR DESCRIPTION
Overview
----------------------------------------
Remove extraneous call to legacy token processing in sms task

Before
----------------------------------------
legacy `getTokenDetails` function called but results not actually used as not passd to the token processor

After
----------------------------------------
Extraneous code removed

Technical Details
----------------------------------------

`$contact` holds the result of an apiv3 contact get call. It is replaced by the result of `getTokenDetails` but then only used to access
- phone
- phone type
- do not sms

These 3 variables are covered by unit tests like `testSendSMSMobileInToProviderParamWithDoNotSMS`

The rendering of the tokens isn't but - the saved result is also not stored to the database & this PR doesn't change that. I did step through the code to ensure it is populated

![image](https://user-images.githubusercontent.com/336308/136718388-ae0f3499-08f9-49a7-8bd0-aefe1248845d.png)

Comments
----------------------------------------

@totten I think we can remove this one