### PR TITLE
Remove call to legacy getTokenDetails

### DIFF
--- a/CRM/Contribute/Form/Task/PDF.php
+++ b/CRM/Contribute/Form/Task/PDF.php
@@ -228,6 +228,7 @@ AND    {$this->_componentClause}";
    * @return array
    *   array of common elements
    *
+   * @throws \CiviCRM_API3_Exception
    */
   public static function getElements($contribIds, $params, $contactIds) {
     $pdfElements = [];
@@ -242,21 +243,17 @@ AND    {$this->_componentClause}";
 
     $pdfElements['createPdf'] = FALSE;
     if (!empty($pdfElements['params']['output']) &&
-      ($pdfElements['params']['output'] == "pdf_invoice" || $pdfElements['params']['output'] == "pdf_receipt")
+      ($pdfElements['params']['output'] === 'pdf_invoice' || $pdfElements['params']['output'] === 'pdf_receipt')
     ) {
       $pdfElements['createPdf'] = TRUE;
     }
 
     $excludeContactIds = [];
     if (!$pdfElements['createPdf']) {
-      $returnProperties = [
-        'email' => 1,
-        'do_not_email' => 1,
-        'is_deceased' => 1,
-        'on_hold' => 1,
-      ];
-
-      list($contactDetails) = CRM_Utils_Token::getTokenDetails($contactIds, $returnProperties, FALSE, FALSE);
+      $contactDetails = civicrm_api3('Contact', 'get', [
+        'return' => ['email', 'do_not_email', 'is_deceased', 'on_hold'],
+        'id' => ['IN' => $contactIds],
+      ])['values'];
       $pdfElements['suppressedEmails'] = 0;
       $suppressedEmails = 0;
       foreach ($contactDetails as $id => $values) {

--- a/tests/phpunit/CRM/Contribute/Form/Task/PDFTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/Task/PDFTest.php
@@ -1,0 +1,68 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+use Civi\Api4\Email;
+
+/**
+ *  Test Email task.
+ *
+ * @package CiviCRM_APIv3
+ * @subpackage API_Contribution
+ * @group headless
+ */
+class CRM_Contribute_Form_Task_PDFTest extends CiviUnitTestCase {
+
+  /**
+   * Clean up after test.
+   */
+  protected function tearDown(): void {
+    $this->quickCleanUpFinancialEntities();
+    parent::tearDown();
+  }
+
+  /**
+   * Test the send pdf task filters out contacts who should not receive the
+   * receipt.
+   *
+   * @throws \API_Exception
+   */
+  public function testSendPDF(): void {
+    $variants = [[], ['do_not_email' => TRUE], ['email' => ''], ['is_deceased' => TRUE], ['on_hold' => 1]];
+    $searchValues = [
+      'task' => CRM_Core_Task::PDF_LETTER,
+      'radio_ts' => 'ts_sel',
+    ];
+    foreach ($variants as $variant) {
+      $contactID = $this->individualCreate($variant);
+      $contributionID = $this->contributionCreate(['contact_id' => $contactID]);
+      $searchValues['mark_x_' . $contributionID] = 1;
+      if (!empty($variant['on_hold'])) {
+        Email::update()
+          ->addWhere('contact_id', '=', $contactID)
+          ->setValues(['on_hold' => TRUE])->execute();
+      }
+    }
+
+    $form = $this->getFormObject('CRM_Contribute_Form_Task_PDF', [
+      'receipt_update' => 1,
+    ], NULL, $searchValues);
+    $form->buildForm();
+    $form->postProcess();
+    $status = CRM_Core_Session::singleton()->getStatus(TRUE);
+    $this->assertEquals([
+      'text' => 'Email was NOT sent to 4 contacts (no email address on file, or communication preferences specify DO NOT EMAIL, or contact is deceased).',
+      'title' => 'Email Error',
+      'type' => 'error',
+      'options' => NULL,
+    ], $status[0]);
+  }
+
+}


### PR DESCRIPTION

Overview
----------------------------------------
Remove call to legacy getTokenDetails

Before
----------------------------------------
`getTokenDetails` called to do a basic apiv3 Contact.get

After
----------------------------------------
apiv3 Contact.get called


Technical Details
----------------------------------------
In this case it is just being used as a v3 api call so I switched to that. I didn't want to risk bringing in error so I didn't go to v4 api

Comments
----------------------------------------
