### PR TITLE
Remove case token listing from contact email task

### DIFF
--- a/CRM/Contact/Form/Task/Email.php
+++ b/CRM/Contact/Form/Task/Email.php
@@ -82,22 +82,4 @@ class CRM_Contact_Form_Task_Email extends CRM_Contact_Form_Task {
    */
   public function setContactIDs() {}
 
-  /**
-   * List available tokens for this form.
-   *
-   * @return array
-   * @throws \CRM_Core_Exception
-   */
-  public function listTokens() {
-    $tokens = CRM_Core_SelectValues::contactTokens();
-
-    if (isset($this->_caseId) || isset($this->_caseIds)) {
-      // For a single case, list tokens relevant for only that case type
-      $caseTypeId = isset($this->_caseId) ? CRM_Core_DAO::getFieldValue('CRM_Case_DAO_Case', $this->_caseId, 'case_type_id') : NULL;
-      $tokens += CRM_Core_SelectValues::caseTokens($caseTypeId);
-    }
-
-    return $tokens;
-  }
-
 }


### PR DESCRIPTION
Overview
----------------------------------------
Remove case token listing from contact email task

Before
----------------------------------------
Contact email task calls the legacy function

After
----------------------------------------
Contact email task calls the token processor (exposes domain tokens)

Technical Details
----------------------------------------
The only reason not to call the token processor to get these is if you are trying to filter the tokens by 'case_type_id' - which should now only apply to the case email task

Comments
----------------------------------------
@demeritcowboy this was a side-track on my path to figure out the rows issue