### PR TITLE
Switch replaceGreetingTokens over

### DIFF
--- a/CRM/Contact/Tokens.php
+++ b/CRM/Contact/Tokens.php
@@ -369,37 +369,34 @@ class CRM_Contact_Tokens extends CRM_Core_EntityTokens {
    * @noinspection PhpUnhandledExceptionInspection
    */
   protected function getTokenMetadata(): array {
-    if ($this->tokensMetadata) {
-      return $this->tokensMetadata;
-    }
     if (Civi::cache('metadata')->has($this->getCacheKey())) {
       return Civi::cache('metadata')->get($this->getCacheKey());
     }
     $this->fieldMetadata = (array) civicrm_api4('Contact', 'getfields', ['checkPermissions' => FALSE], 'name');
-    $this->tokensMetadata = $this->getBespokeTokens();
+    $tokensMetadata = $this->getBespokeTokens();
     foreach ($this->fieldMetadata as $field) {
-      $this->addFieldToTokenMetadata($field, $this->getExposedFields());
+      $this->addFieldToTokenMetadata($tokensMetadata, $field, $this->getExposedFields());
     }
 
     foreach ($this->getRelatedEntityTokenMetadata() as $entity => $exposedFields) {
       $apiEntity = ($entity === 'openid') ? 'OpenID' : ucfirst($entity);
       $metadata = (array) civicrm_api4($apiEntity, 'getfields', ['checkPermissions' => FALSE], 'name');
       foreach ($metadata as $field) {
-        $this->addFieldToTokenMetadata($field, $exposedFields, 'primary_' . $entity);
+        $this->addFieldToTokenMetadata($tokensMetadata, $field, $exposedFields, 'primary_' . $entity);
       }
     }
     // Manually add in the abbreviated state province as that maps to
     // what has traditionally been delivered.
-    $this->tokensMetadata['primary_address.state_province_id:abbr'] = $this->tokensMetadata['primary_address.state_province_id:label'];
-    $this->tokensMetadata['primary_address.state_province_id:abbr']['name'] = 'state_province_id:abbr';
-    $this->tokensMetadata['primary_address.state_province_id:abbr']['audience'] = 'user';
+    $tokensMetadata['primary_address.state_province_id:abbr'] = $tokensMetadata['primary_address.state_province_id:label'];
+    $tokensMetadata['primary_address.state_province_id:abbr']['name'] = 'state_province_id:abbr';
+    $tokensMetadata['primary_address.state_province_id:abbr']['audience'] = 'user';
     // Hide the label for now because we are not sure if there are paths
     // where legacy token resolution is in play where this could not be resolved.
-    $this->tokensMetadata['primary_address.state_province_id:label']['audience'] = 'sysadmin';
+    $tokensMetadata['primary_address.state_province_id:label']['audience'] = 'sysadmin';
     // Hide this really obscure one. Just cos it annoys me.
-    $this->tokensMetadata['primary_address.manual_geo_code:label']['audience'] = 'sysadmin';
-    Civi::cache('metadata')->set($this->getCacheKey(), $this->tokensMetadata);
-    return $this->tokensMetadata;
+    $tokensMetadata['primary_address.manual_geo_code:label']['audience'] = 'sysadmin';
+    Civi::cache('metadata')->set($this->getCacheKey(), $tokensMetadata);
+    return $tokensMetadata;
   }
 
   /**

--- a/CRM/Core/EntityTokens.php
+++ b/CRM/Core/EntityTokens.php
@@ -75,23 +75,18 @@ class CRM_Core_EntityTokens extends AbstractTokenSubscriber {
    * @return array
    */
   protected function getTokenMetadata(): array {
-    if (empty($this->tokensMetadata)) {
-      $cacheKey = $this->getCacheKey();
-      if (Civi::cache('metadata')->has($cacheKey)) {
-        $this->tokensMetadata = Civi::cache('metadata')->get($cacheKey);
+    $cacheKey = $this->getCacheKey();
+    if (!Civi::cache('metadata')->has($cacheKey)) {
+      $tokensMetadata = $this->getBespokeTokens();
+      foreach ($this->getFieldMetadata() as $field) {
+        $this->addFieldToTokenMetadata($tokensMetadata, $field, $this->getExposedFields());
       }
-      else {
-        $this->tokensMetadata = $this->getBespokeTokens();
-        foreach ($this->getFieldMetadata() as $field) {
-          $this->addFieldToTokenMetadata($field, $this->getExposedFields());
-        }
-        foreach ($this->getHiddenTokens() as $name) {
-          $this->tokensMetadata[$name]['audience'] = 'hidden';
-        }
-        Civi::cache('metadata')->set($cacheKey, $this->tokensMetadata);
+      foreach ($this->getHiddenTokens() as $name) {
+        $tokensMetadata[$name]['audience'] = 'hidden';
       }
+      Civi::cache('metadata')->set($cacheKey, $tokensMetadata);
     }
-    return $this->tokensMetadata;
+    return Civi::cache('metadata')->get($cacheKey);
   }
 
   /**
@@ -597,11 +592,12 @@ class CRM_Core_EntityTokens extends AbstractTokenSubscriber {
   /**
    * Add the token to the metadata based on the field spec.
    *
+   * @param array $tokensMetadata
    * @param array $field
    * @param array $exposedFields
    * @param string $prefix
    */
-  protected function addFieldToTokenMetadata(array $field, array $exposedFields, string $prefix = ''): void {
+  protected function addFieldToTokenMetadata(array &$tokensMetadata, array $field, array $exposedFields, string $prefix = ''): void {
     if ($field['type'] !== 'Custom' && !in_array($field['name'], $exposedFields, TRUE)) {
       return;
     }
@@ -623,7 +619,7 @@ class CRM_Core_EntityTokens extends AbstractTokenSubscriber {
       $parts = explode(': ', $field['label']);
       $field['title'] = "{$parts[1]} :: {$parts[0]}";
       $tokenName = 'custom_' . $field['custom_field_id'];
-      $this->tokensMetadata[$tokenName] = $field;
+      $tokensMetadata[$tokenName] = $field;
       return;
     }
     $tokenName = $prefix ? ($prefix . '.' . $field['name']) : $field['name'];
@@ -633,21 +629,21 @@ class CRM_Core_EntityTokens extends AbstractTokenSubscriber {
         // At the time of writing currency didn't have a label option - this may have changed.
         && !in_array($field['name'], $this->getCurrencyFieldName(), TRUE)
       ) {
-        $this->tokensMetadata[$tokenName . ':label'] = $this->tokensMetadata[$tokenName . ':name'] = $field;
+        $tokensMetadata[$tokenName . ':label'] = $tokensMetadata[$tokenName . ':name'] = $field;
         $fieldLabel = $field['input_attrs']['label'] ?? $field['label'];
-        $this->tokensMetadata[$tokenName . ':label']['name'] = $field['name'] . ':label';
-        $this->tokensMetadata[$tokenName . ':name']['name'] = $field['name'] . ':name';
-        $this->tokensMetadata[$tokenName . ':name']['audience'] = 'sysadmin';
-        $this->tokensMetadata[$tokenName . ':label']['title'] = $fieldLabel;
-        $this->tokensMetadata[$tokenName . ':name']['title'] = ts('Machine name') . ': ' . $fieldLabel;
+        $tokensMetadata[$tokenName . ':label']['name'] = $field['name'] . ':label';
+        $tokensMetadata[$tokenName . ':name']['name'] = $field['name'] . ':name';
+        $tokensMetadata[$tokenName . ':name']['audience'] = 'sysadmin';
+        $tokensMetadata[$tokenName . ':label']['title'] = $fieldLabel;
+        $tokensMetadata[$tokenName . ':name']['title'] = ts('Machine name') . ': ' . $fieldLabel;
         $field['audience'] = 'sysadmin';
       }
       if ($field['data_type'] === 'Boolean') {
-        $this->tokensMetadata[$tokenName . ':label'] = $field;
-        $this->tokensMetadata[$tokenName . ':label']['name'] = $field['name'] . ':label';
+        $tokensMetadata[$tokenName . ':label'] = $field;
+        $tokensMetadata[$tokenName . ':label']['name'] = $field['name'] . ':label';
         $field['audience'] = 'sysadmin';
       }
-      $this->tokensMetadata[$tokenName] = $field;
+      $tokensMetadata[$tokenName] = $field;
     }
   }
 

--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -1337,10 +1337,7 @@ class CRM_Utils_Token {
     $greetingTokens = self::getTokens($tokenString);
     $context = $contactId ? ['contactId' => $contactId] : [];
     if ($contactDetails) {
-      foreach ($contactDetails[0] as $contact) {
-        // Only 1 - the loop is because we may not know the id.
-        $context['contact'] = $contact;
-      }
+      $context['contact'] = isset($contactDetails[0]) ? reset($contactDetails[0]) : $contactDetails;
     }
     $tokenProcessor = new TokenProcessor(\Civi::dispatcher(), [
       'smarty' => FALSE,

--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -9,6 +9,8 @@
  +--------------------------------------------------------------------+
  */
 
+use Civi\Token\TokenProcessor;
+
 /**
  *
  * @package CRM
@@ -592,6 +594,8 @@ class CRM_Utils_Token {
    * @param bool $returnBlankToken
    *   Return unevaluated token if value is null.
    *
+   * @deprecated
+   *
    * @param bool $escapeSmarty
    *
    * @return string
@@ -634,6 +638,13 @@ class CRM_Utils_Token {
   }
 
   /**
+   * Do Not use.
+   *
+   * Only core usage is from a deprecated unused function and
+   * from deprecated BAO_Mailing code (to be replaced by flexmailer).
+   *
+   * @deprecated
+   *
    * @param $token
    * @param $contact
    * @param bool $html
@@ -718,8 +729,12 @@ class CRM_Utils_Token {
   }
 
   /**
+   * Do not use - unused in core.
+   *
    * Replace all the hook tokens in $str with information from
    * $contact.
+   *
+   * @deprecated
    *
    * @param string $str
    *   The string with tokens to be replaced.
@@ -790,6 +805,10 @@ class CRM_Utils_Token {
   }
 
   /**
+   * Do not use, unused in core.
+   *
+   * @deprecated
+   *
    * @param $token
    * @param $contact
    * @param $category
@@ -1303,9 +1322,6 @@ class CRM_Utils_Token {
    *
    * @TODO Remove that inconsistency in usage.
    *
-   * ::replaceContactTokens() may need to be called after this method, to
-   * replace tokens supplied from this method.
-   *
    * @param string $tokenString
    * @param array $contactDetails
    * @param int $contactId
@@ -1317,72 +1333,24 @@ class CRM_Utils_Token {
     if (!$contactDetails && !$contactId) {
       return;
     }
-
     // check if there are any tokens
     $greetingTokens = self::getTokens($tokenString);
-
-    if (!empty($greetingTokens)) {
-      // first use the existing contact object for token replacement
-      if (!empty($contactDetails)) {
-        $tokenString = CRM_Utils_Token::replaceContactTokens($tokenString, $contactDetails, TRUE, $greetingTokens, TRUE, $escapeSmarty);
+    $context = $contactId ? ['contactId' => $contactId] : [];
+    if ($contactDetails) {
+      foreach ($contactDetails[0] as $contact) {
+        // Only 1 - the loop is because we may not know the id.
+        $context['contact'] = $contact;
       }
-
-      self::removeNullContactTokens($tokenString, $contactDetails, $greetingTokens);
-      // check if there are any unevaluated tokens
-      $greetingTokens = self::getTokens($tokenString);
-
-      // $greetingTokens not empty, means there are few tokens which are not
-      // evaluated, like custom data etc
-      // so retrieve it from database
-      if (!empty($greetingTokens) && array_key_exists('contact', $greetingTokens)) {
-        $greetingsReturnProperties = array_flip(CRM_Utils_Array::value('contact', $greetingTokens));
-        $greetingsReturnProperties = array_fill_keys(array_keys($greetingsReturnProperties), 1);
-        $contactParams = ['contact_id' => $contactId];
-
-        $greetingDetails = self::getTokenDetails($contactParams,
-          $greetingsReturnProperties,
-          FALSE, FALSE, NULL,
-          $greetingTokens,
-          $className
-        );
-
-        // again replace tokens
-        $tokenString = CRM_Utils_Token::replaceContactTokens($tokenString,
-          $greetingDetails,
-          TRUE,
-          $greetingTokens,
-          TRUE,
-          $escapeSmarty
-        );
-      }
-
-      // check if there are still any unevaluated tokens
-      $remainingTokens = self::getTokens($tokenString);
-
-      // $greetingTokens not empty, there are customized or hook tokens to replace
-      if (!empty($remainingTokens)) {
-        // Fill the return properties array
-        $greetingTokens = $remainingTokens;
-        reset($greetingTokens);
-        $greetingsReturnProperties = [];
-        foreach ($greetingTokens as $value) {
-          $props = array_flip($value);
-          $props = array_fill_keys(array_keys($props), 1);
-          $greetingsReturnProperties = $greetingsReturnProperties + $props;
-        }
-        $contactParams = ['contact_id' => $contactId];
-        $greetingDetails = self::getTokenDetails($contactParams,
-          $greetingsReturnProperties,
-          FALSE, FALSE, NULL,
-          $greetingTokens,
-          $className
-        );
-        // Prepare variables for calling replaceHookTokens
-        $categories = array_keys($greetingTokens);
-        [$contact] = $greetingDetails;
-        // Replace tokens defined in Hooks.
-        $tokenString = CRM_Utils_Token::replaceHookTokens($tokenString, $contact[$contactId], $categories);
-      }
+    }
+    $tokenProcessor = new TokenProcessor(\Civi::dispatcher(), [
+      'smarty' => FALSE,
+      'class' => $className,
+    ]);
+    $tokenProcessor->addRow($context);
+    $tokenProcessor->addMessage('greeting', $tokenString, 'text/plain');
+    $tokenProcessor->evaluate();
+    foreach ($tokenProcessor->getRows() as $row) {
+      $tokenString = $row->render('greeting');
     }
   }
 
@@ -1390,6 +1358,8 @@ class CRM_Utils_Token {
    * At this point, $contactDetails has loaded the contact from the DAO. Any
    * (non-custom) missing fields are null.  By removing them, we can avoid
    * expensive calls to CRM_Contact_BAO_Query.
+   *
+   * @deprecated unused in core
    *
    * @param string $tokenString
    * @param array $contactDetails
@@ -1862,6 +1832,10 @@ class CRM_Utils_Token {
   }
 
   /**
+   * @deprecated
+   *
+   * Only used from deprecated functions not called by core.
+   *
    * @return array
    *   [legacy_token => new_token]
    */

--- a/Civi/Api4/Action/Entity/GetLinks.php
+++ b/Civi/Api4/Action/Entity/GetLinks.php
@@ -25,8 +25,7 @@ class GetLinks extends \Civi\Api4\Generic\BasicGetAction {
   public function getRecords() {
     \CRM_Core_Error::deprecatedWarning('APIv4 Entity::getLinks is deprecated.');
     $result = [];
-    /** @var \Civi\Api4\Service\Schema\SchemaMap $schema */
-    $schema = \Civi::container()->get('schema_map');
+    $schema = CoreUtil::getSchemaMap();
     foreach ($schema->getTables() as $table) {
       $entity = CoreUtil::getApiNameFromTableName($table->getName());
       // Since this is an api function, exclude tables that don't have an api

--- a/Civi/Api4/Query/Api4SelectQuery.php
+++ b/Civi/Api4/Query/Api4SelectQuery.php
@@ -13,6 +13,7 @@ namespace Civi\Api4\Query;
 
 use Civi\API\Exception\UnauthorizedException;
 use Civi\Api4\Service\Schema\Joinable\CustomGroupJoinable;
+use Civi\Api4\Service\Schema\Joiner;
 use Civi\Api4\Utils\FormattingUtil;
 use Civi\Api4\Utils\CoreUtil;
 use Civi\Api4\Utils\SelectUtil;
@@ -1004,8 +1005,7 @@ class Api4SelectQuery {
     if (isset($this->apiFieldSpec[$key])) {
       return;
     }
-    /** @var \Civi\Api4\Service\Schema\Joiner $joiner */
-    $joiner = \Civi::container()->get('joiner');
+    $joiner = new Joiner(CoreUtil::getSchemaMap());
 
     $pathArray = explode('.', $key);
     // The last item in the path is the field name. We don't care about that; we'll add all fields from the joined entity.

--- a/Civi/Api4/Utils/CoreUtil.php
+++ b/Civi/Api4/Utils/CoreUtil.php
@@ -230,4 +230,17 @@ class CoreUtil {
     return static::checkAccessRecord($apiRequest, $record, $userID);
   }
 
+  /**
+   * @return \Civi\Api4\Service\Schema\SchemaMap
+   */
+  public static function getSchemaMap() {
+    $cache = \Civi::cache('metadata');
+    $schemaMap = $cache->get('api4.schema.map');
+    if (!$schemaMap) {
+      $schemaMap = \Civi::service('schema_map_builder')->build();
+      $cache->set('api4.schema.map', $schemaMap);
+    }
+    return $schemaMap;
+  }
+
 }

--- a/Civi/Api4/services.xml
+++ b/Civi/Api4/services.xml
@@ -6,16 +6,8 @@
 
         <service id="spec_gatherer" class="Civi\Api4\Service\Spec\SpecGatherer" public="true"/>
 
-        <service id="schema_map_builder" class="Civi\Api4\Service\Schema\SchemaMapBuilder" public="false">
+        <service id="schema_map_builder" class="Civi\Api4\Service\Schema\SchemaMapBuilder" public="true">
             <argument type="service" id="dispatcher" />
-        </service>
-
-        <service id="schema_map" class="Civi\Api4\Service\Schema\SchemaMap" public="true">
-          <factory service="schema_map_builder" method="build"/>
-        </service>
-
-        <service id="joiner" class="Civi\Api4\Service\Schema\Joiner" public="true">
-            <argument type="service" id="schema_map"/>
         </service>
 
         <service id="action_object_provider" class="Civi\Api4\Provider\ActionObjectProvider" public="true">

--- a/tests/phpunit/CiviTest/bootstrap.php
+++ b/tests/phpunit/CiviTest/bootstrap.php
@@ -26,6 +26,11 @@ if (CIVICRM_UF === 'UnitTests') {
 spl_autoload_register(function($class) {
   _phpunit_mockoloader('api\\v4\\', "tests/phpunit/api/v4/", $class);
   _phpunit_mockoloader('Civi\\Api4\\', "tests/phpunit/api/v4/Mock/Api4/", $class);
+  if (substr($class, 0, 13) === 'CRM_Fake_DAO_') {
+    // phpcs:disable
+    eval('namespace { class ' . $class . ' extends \CRM_Core_DAO { public static function &fields() { $r = []; return $r; }}}');
+    // phpcs:enable
+  }
 });
 
 // ------------------------------------------------------------------------------


### PR DESCRIPTION
Overview
----------------------------------------
Another attempt at https://github.com/civicrm/civicrm-core/pull/21701 - note this replaces `replaceGreetingTokens` but if it works I would then stop calling & deprecate  that function & move the love up to processGreetingTemplate & then up one more level 

@colemanw I'm a bit stuck tracking down an apiv4 caching issue

```
    $group = \Civi\Api4\Group::get()
      ->addSelect('custom.*', 'id')
      ->addWhere('title', '=', 'Test Group With Custom Field')
      ->execute();
```

is failing because the apiv4 cache is loaded before the custom field is added

so this test fails
not ok 602 - Failure: CRM_Contact_Form_Task_AddToGroupTest::testAddToNewGroupWithCustomField

  ---
  message: new_custom_group.Custom_Field element exists?
  severity: fail


Before
----------------------------------------
legacy call to the hook replace

After
----------------------------------------
calls the token processor

Technical Details
----------------------------------------

Comments
----------------------------------------
