### PR TITLE
(NFC) Fix quote style for valid HTML - notifications.tpl

### DIFF
--- a/templates/CRM/common/notifications.tpl
+++ b/templates/CRM/common/notifications.tpl
@@ -1,4 +1,4 @@
-<div id="crm-notification-container" role="alert" aria-live="assertive" aria-atomic=”true” style="display:none">
+<div id="crm-notification-container" role="alert" aria-live="assertive" aria-atomic="true" style="display:none">
   <div id="crm-notification-alert" class="#{ldelim}type{rdelim}">
     <div class="icon ui-notify-close" title="{ts}close{/ts}"> </div>
     <a class="ui-notify-cross ui-notify-close" href="#" title="{ts}close{/ts}">x</a>


### PR DESCRIPTION
Replaces aria-atomic=”true” with aria-atomic="true".

Previously the attribute was wrapped in Unicode "Right Double Quotation Mark" (U+201D) symbols,
instead of the standard "Quotation Mark" (U+0022) supported by HTML. 

This meant the HTML was not valid, and may have led browsers to parse the aria-atomic inconsistently.