### PR TITLE
Afform - fix loading custom fields for search displays

### DIFF
--- a/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php
+++ b/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php
@@ -124,7 +124,7 @@ class AfformAdminMeta {
     $fields = (array) civicrm_api4($entityName, 'getFields', $params);
 
     // Add implicit joins to search fields
-    if ($params['action'] === 'search') {
+    if ($params['action'] === 'get') {
       foreach (array_reverse($fields, TRUE) as $index => $field) {
         if (!empty($field['fk_entity']) && !$field['options']) {
           $fkLabelField = CoreUtil::getInfoItem($field['fk_entity'], 'label_field');

--- a/ext/afform/admin/Civi/Api4/Action/Afform/LoadAdminData.php
+++ b/ext/afform/admin/Civi/Api4/Action/Afform/LoadAdminData.php
@@ -162,7 +162,7 @@ class LoadAdminData extends \Civi\Api4\Generic\AbstractAction {
     }
 
     if ($info['definition']['type'] === 'search') {
-      $getFieldsMode = 'search';
+      $getFieldsMode = 'get';
       $displayTags = [];
       if ($newForm) {
         [$searchName, $displayName] = array_pad(explode('.', $this->entity ?? ''), 2, '');


### PR DESCRIPTION
Overview
----------------------------------------
Fixes the ability to create search display forms for searches based on a multi-record custom group.

Before
----------------------------------------
`Uncaught Error: Call to undefined method Civi\\Api4\\CustomValue::search()`

After
----------------------------------------
Works