### PR TITLE
Remove another call to getTokenDetails

### DIFF
--- a/CRM/Contact/Form/Task/SMSCommon.php
+++ b/CRM/Contact/Form/Task/SMSCommon.php
@@ -156,19 +156,10 @@ class CRM_Contact_Form_Task_SMSCommon {
     }
 
     if (is_array($form->_contactIds) && !empty($form->_contactIds) && $toSetDefault) {
-      $returnProperties = [
-        'sort_name' => 1,
-        'phone' => 1,
-        'do_not_sms' => 1,
-        'is_deceased' => 1,
-        'display_name' => 1,
-      ];
-
-      list($form->_contactDetails) = CRM_Utils_Token::getTokenDetails($form->_contactIds,
-        $returnProperties,
-        FALSE,
-        FALSE
-      );
+      $form->_contactDetails = civicrm_api3('Contact', 'get', [
+        'id' => ['IN' => $form->_contactIds],
+        'return' => ['sort_name', 'phone', 'do_not_sms', 'is_deceased', 'display_name'],
+      ])['values'];
 
       // make a copy of all contact details
       $form->_allContactDetails = $form->_contactDetails;


### PR DESCRIPTION

Overview
----------------------------------------
Remove another call to getTokenDetails

Before
----------------------------------------
Calls `getTokenDetails` - only a few fields used which are accessible via apiv3

After
----------------------------------------
Calls apiv3

Technical Details
----------------------------------------
The goal is to make the tokenValues hook uncalled outside the
token processor & hence redundant. We were trying to do that in 5.43
but this call is not using the results anyway so I guess
putting in master is immaterial to that goal

Comments
----------------------------------------
