### PR TITLE
dev/core#2904 ensure skipStatusCal not passed from the order api

### DIFF
--- a/api/v3/Order.php
+++ b/api/v3/Order.php
@@ -304,6 +304,8 @@ function _civicrm_api3_order_delete_spec(array &$params) {
  */
 function _order_create_wrangle_membership_params(array &$membershipParams) {
   $fields = Membership::getFields(FALSE)->execute()->indexBy('name');
+  // Ensure this legacy parameter is not true.
+  $membershipParams['skipStatusCal'] = FALSE;
   foreach ($fields as $fieldName => $field) {
     $customFieldName = 'custom_' . ($field['custom_field_id'] ?? NULL);
     if ($field['type'] === ['Custom'] && isset($membershipParams[$customFieldName])) {


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#2904 ensure skipStatusCal not passed from the order api

Before
----------------------------------------


After
----------------------------------------

Technical Details
----------------------------------------
See https://lab.civicrm.org/dev/core/-/issues/2904 analysis

Comments
----------------------------------------
