### PR TITLE
$sid doesn't get set on upgrade runFinish

### DIFF
--- a/CRM/Upgrade/Page/Upgrade.php
+++ b/CRM/Upgrade/Page/Upgrade.php
@@ -77,6 +77,7 @@ class CRM_Upgrade_Page_Upgrade extends CRM_Core_Page {
     CRM_Core_Smarty::singleton()->assign('sid', CRM_Utils_System::getSiteID());
     // Show success msg if db already upgraded
     if (version_compare($currentVer, $latestVer) == 0) {
+      $template->assign('message', '');
       $template->assign('upgraded', TRUE);
       $template->assign('newVersion', $latestVer);
       CRM_Utils_System::setTitle(ts('Your database has already been upgraded to CiviCRM %1',
@@ -189,6 +190,7 @@ class CRM_Upgrade_Page_Upgrade extends CRM_Core_Page {
     $template->assign('message', $postUpgradeMessage);
     $template->assign('upgraded', TRUE);
     $template->assign('newVersion', $latestVer);
+    $template->assign('sid', CRM_Utils_System::getSiteID());
 
     // Render page header
     if (!defined('CIVICRM_UF_HEAD') && $region = CRM_Core_Region::instance('html-header', FALSE)) {


### PR DESCRIPTION
Overview
----------------------------------------
Similar to https://github.com/civicrm/civicrm-core/pull/21702, but it seems like it does need to get set both at the start and end places.

Before
----------------------------------------
Undefined index: sid in ...\templates_c\en_US\%%4A\4AC\4ACAAD27%%success.tpl.php on line 46

After
----------------------------------------


Technical Details
----------------------------------------


Comments
----------------------------------------

