### PR TITLE
Do not find references for empty values

### DIFF
--- a/CRM/Core/Reference/Basic.php
+++ b/CRM/Core/Reference/Basic.php
@@ -112,21 +112,26 @@ EOS;
    */
   public function getReferenceCount($targetDao) {
     $targetColumn = $this->getTargetKey();
-    $params = [
-      1 => [$targetDao->$targetColumn, 'String'],
-    ];
-    $sql = <<<EOS
+    $count = 0;
+    if ($targetDao->{$targetColumn} !== '' && $targetDao->{$targetColumn} !== NULL) {
+
+      $params = [
+        1 => [$targetDao->{$targetColumn} ?? '', 'String'],
+      ];
+      $sql = <<<EOS
 SELECT count(*)
 FROM {$this->getReferenceTable()}
 WHERE {$this->getReferenceKey()} = %1
 EOS;
+      $count = CRM_Core_DAO::singleValueQuery($sql, $params);
+    }
 
     return [
       'name' => implode(':', ['sql', $this->getReferenceTable(), $this->getReferenceKey()]),
       'type' => get_class($this),
       'table' => $this->getReferenceTable(),
       'key' => $this->getReferenceKey(),
-      'count' => CRM_Core_DAO::singleValueQuery($sql, $params),
+      'count' => $count,
     ];
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Do not find references for empty strings or null values when looking for references to an entity


Before
----------------------------------------
The reference count query throws a fatal error if the target column is NULL and returns matches for an empty string


After
----------------------------------------
A result of 0 is returned when there is no usable value

Technical Details
----------------------------------------
When looking for references to a column we really want references to 'real values' not empty fields. 0 is a bit ambiguous & behaviour is unchanged.

Comments
----------------------------------------
