### PR TITLE
[REF] Paramter simplification

### DIFF
--- a/CRM/Contribute/Form/Task/PDFLetter.php
+++ b/CRM/Contribute/Form/Task/PDFLetter.php
@@ -423,7 +423,7 @@ class CRM_Contribute_Form_Task_PDFLetter extends CRM_Contribute_Form_Task {
    * @return string
    * @throws \CRM_Core_Exception
    */
-  public function generateHtml(&$contact, $contribution, $groupBy, $contributions, $realSeparator, $tableSeparators, $messageToken, $html_message, $separator, $grouped, $groupByID) {
+  public function generateHtml($contact, $contribution, $groupBy, $contributions, $realSeparator, $tableSeparators, $messageToken, $html_message, $separator, $grouped, $groupByID) {
     static $validated = FALSE;
     $html = NULL;
 
@@ -436,7 +436,7 @@ class CRM_Contribute_Form_Task_PDFLetter extends CRM_Contribute_Form_Task {
         CRM_Core_Session::setStatus(ts('You have selected the table cell separator, but one or more token fields are not placed inside a table cell. This would result in invalid HTML, so comma separators have been used instead.'));
       }
       $validated = TRUE;
-      $html = str_replace($separator, $realSeparator, $this->resolveTokens($html_message, $contact, $contribution['id'], $grouped, $separator, $groupedContributions));
+      $html = str_replace($separator, $realSeparator, $this->resolveTokens($html_message, $contact['contact_id'], $contribution['id'], $grouped, $separator, $groupedContributions));
     }
 
     return $html;
@@ -543,7 +543,7 @@ class CRM_Contribute_Form_Task_PDFLetter extends CRM_Contribute_Form_Task {
   /**
    *
    * @param string $html_message
-   * @param array $contact
+   * @param int $contactID
    * @param int $contributionID
    * @param bool $grouped
    *   Does this letter represent more than one contribution.
@@ -553,10 +553,10 @@ class CRM_Contribute_Form_Task_PDFLetter extends CRM_Contribute_Form_Task {
    *
    * @return string
    */
-  protected function resolveTokens(string $html_message, $contact, $contributionID, $grouped, $separator, $contributions): string {
+  protected function resolveTokens(string $html_message, int $contactID, $contributionID, $grouped, $separator, $contributions): string {
     $tokenContext = [
       'smarty' => (defined('CIVICRM_MAIL_SMARTY') && CIVICRM_MAIL_SMARTY),
-      'contactId' => $contact['contact_id'],
+      'contactId' => $contactID,
       'schema' => ['contributionId'],
     ];
     if ($grouped) {


### PR DESCRIPTION
Overview
----------------------------------------
[REF] Paramter simplification

Before
----------------------------------------
`$contact` passed around & hard to see how it is used

After
----------------------------------------
remove pass-by-ref, only pass `$contact['id']` when that is all that is used

Technical Details
----------------------------------------

Comments
----------------------------------------