### PR TITLE
EntityTokens - Normalize data-loading via myEntityId (eg activityId)

### DIFF
--- a/CRM/Core/EntityTokens.php
+++ b/CRM/Core/EntityTokens.php
@@ -349,9 +349,7 @@ class CRM_Core_EntityTokens extends AbstractTokenSubscriber {
     if ($e->mapping->getEntity() !== $this->getExtendableTableName()) {
       return;
     }
-    foreach ($this->getReturnFields() as $token) {
-      $e->query->select('e.' . $token . ' AS ' . $this->getEntityAlias() . $token);
-    }
+    $e->query->select('e.id AS tokenContext_' . $this->getEntityIDField());
   }
 
   /**

--- a/CRM/Core/EntityTokens.php
+++ b/CRM/Core/EntityTokens.php
@@ -307,11 +307,6 @@ class CRM_Core_EntityTokens extends AbstractTokenSubscriber {
       return $row->context[$entityName][$field];
     }
 
-    $actionSearchResult = $row->context['actionSearchResult'];
-    $aliasedField = $this->getEntityAlias() . $field;
-    if (isset($actionSearchResult->{$aliasedField})) {
-      return $actionSearchResult->{$aliasedField};
-    }
     $entityID = $row->context[$this->getEntityIDField()];
     if ($field === 'id') {
       return $entityID;

--- a/Civi/ActionSchedule/Event/MailingQueryEvent.php
+++ b/Civi/ActionSchedule/Event/MailingQueryEvent.php
@@ -32,13 +32,10 @@ use Symfony\Component\EventDispatcher\Event;
  *
  * - Joining to business tables - to help target filter-criteria/temporal criteria on other entites.
  *   (Ex: Join to the `civicrm_participant` table and filter on participant status or registration date.)
- * - Joining business tables - to select/return additional columns. Feed the data downstream for mail-merge/token-handling. As in:
- *     - (Recommended) Return the IDs of business-records. Use the prefix `tokenContext_*`.
- *       Ex query: `$event->query->select('foo.id AS tokenContext_fooId')
- *       Ex output: `$tokenRow->context['fooId']`
- *     - (Deprecated) Return detailed data of business-records. Ex:
- *       Ex query: `$event->query->select('foo.title as foo_title, foo.status_id as foo_status_id')`
- *       Ex output: `$tokenRow->context['actionSearchResult']->foo_title`
+ * - Joining business tables - to select/return additional columns. In particular, return the IDs of business-records that
+ *   may be useful for token-handling. Use the prefix `tokenContext_*`.
+ *     Ex query: `$event->query->select('foo.id AS tokenContext_fooId')
+ *     Ex output: `$tokenRow->context['fooId']`
  *
  * There are several parameters pre-set for use in queries:
  *  - 'casActionScheduleId'


### PR DESCRIPTION
Overview
----------------------------------------

This changes the way in which *Scheduled Reminders*  (`ActionSchedule`s) and *token providers* (`EntityToken`s) interact. Generally, "Scheduled Reminders" identify target records by ID (eg `activityId`); then `EntityToken`s resolve any token-references (e.g. `{activity.subject}` for the given `activityId`). This patch is, broadly, a simplification of the mechanics behind it.

There are some edge-case implications for extensions, which will be examined in greater depth in the "Technical Detials".

Before
----------------------------------------

`EntityToken`s have two protocols for fetching data. Either:

1. For scheduled-reminders, hook into the main query. Add N-ary columns to select   any fields used by tokens.
2. For everything else, expect a parameter `$row->context['activityId']`. Collect
   the `activityId`s and fetch the needful via APIv4.

The use of *two protocols* poses a few challenges. TLDR: it's duplicate functionality. Listeners who consume the `activityId` must check multiple places, and each protocol may return slightly different data (ie based on SQL query vs API data-loader).

After
----------------------------------------

* `EntityToken`s have one protocol for fetching data: it must receive `activityId`s and then  call APIv4 for the batch.
* For scheduled-reminders, EntityTokens uses a small adapter to ensure that `activityId`s  are available.

Technical Details
----------------------------------------

On `r-tech`nical compatiblity - Eileen pointed out that [the dev-docs have this example](https://docs.civicrm.org/dev/en/latest/step-by-step/create-custom-case-token/#implement-symfony-event-civitokeneval) (*appears to be originally from [here](https://lab.civicrm.org/jaapjansma/mycasetokens/-/blob/main/mycasetokens.php#L28-34)*) which uses `actionScheduleResult`:

```php
    $case_id = null;
    if (isset($row->context['actionSearchResult']) && ($row->context['actionSearchResult']->activity_id)) {
      $case_id = mycasetokens_get_case_id_by_activity_id($row->context['actionSearchResult']->activity_id);
    } elseif (isset($row->context['actionSearchResult']) && ('civicrm_activity' == $row->context['actionSearchResult']->entity_table && $row->context['actionSearchResult']->entity_id)) {
      $case_id = mycasetokens_get_case_id_by_activity_id($row->context['actionSearchResult']->entity_id);
    } elseif (isset($row->context['activityId']) && $row->context['activityId']) {
      $case_id = mycasetokens_get_case_id_by_activity_id($row->context['activityId']);
    }
```

Fortunately, the example checks for both notations. That should give it good backward/forward compat, as in:

* It would work with older releases (e.g 5.0 - 5.20) wherein activity-tokens always used `actionSearchResult`.
* It would work with more recent releases (e.g 5.23 - 5.42) wherein activity-tokens are mixed-up (sometimes consuming `actionSearchResult` and sometimes consuming `activityId`).
* It would work with the proposed change here (eg 5.43+) wherein activity-tokens  always use `activityId`.

Grepping `universe`, I found a couple more references:

* `activitytokens` seems to have [an earlier iteration](https://lab.civicrm.org/extensions/activitytokens/-/blob/master/activitytokens.php#L19-23) of that same idiom. Probably it just needs an update/port of the third  `if()` branch. 
* `scheduledcaserecipients` ships with a [core patch](https://lab.civicrm.org/extensions/scheduledcaserecipients/-/blob/master/civicrm-core-case-tokens.patch). The functionality there might doing some useful stuff, but - in this context - I don't think there's an obligation for us to maintain this kind of patch-file-interop. If we're going to support a patch that applies to `civicrm-core.git`, then it needs to be in `civicrm-core.git`...
* `uk.co.compucorp.manualdirectdebit`is tougher. Not sure what we do there.