### PR TITLE
Remove use of spacer.gif img elements in CRM_Utils_Weight

### DIFF
--- a/CRM/Utils/Weight.php
+++ b/CRM/Utils/Weight.php
@@ -400,8 +400,8 @@ class CRM_Utils_Weight {
         $links[] = "<a class=\"crm-weight-arrow\" href=\"{$url}&amp;dst={$prevID}&amp;dir=swap\"><img src=\"{$imageURL}/up.gif\" title=\"$alt\" alt=\"$alt\" class=\"order-icon\"></a>";
       }
       else {
-        $links[] = "<img src=\"{$imageURL}/spacer.gif\" class=\"order-icon\">";
-        $links[] = "<img src=\"{$imageURL}/spacer.gif\" class=\"order-icon\">";
+        $links[] = "<img src=\"{$imageURL}/spacer.gif\" class=\"order-icon\" alt=''>";
+        $links[] = "<img src=\"{$imageURL}/spacer.gif\" class=\"order-icon\" alt=''>";
       }
 
       if ($nextID != 0) {
@@ -412,8 +412,8 @@ class CRM_Utils_Weight {
         $links[] = "<a class=\"crm-weight-arrow\" href=\"{$url}&amp;dst={$lastID}&amp;dir=last\"><img src=\"{$imageURL}/last.gif\" title=\"$alt\" alt=\"$alt\" class=\"order-icon\"></a>";
       }
       else {
-        $links[] = "<img src=\"{$imageURL}/spacer.gif\" class=\"order-icon\">";
-        $links[] = "<img src=\"{$imageURL}/spacer.gif\" class=\"order-icon\">";
+        $links[] = "<img src=\"{$imageURL}/spacer.gif\" class=\"order-icon\" alt=''>";
+        $links[] = "<img src=\"{$imageURL}/spacer.gif\" class=\"order-icon\" alt=''>";
       }
       $rows[$id]['weight'] = implode('&nbsp;', $links);
     }

--- a/CRM/Utils/Weight.php
+++ b/CRM/Utils/Weight.php
@@ -400,8 +400,8 @@ class CRM_Utils_Weight {
         $links[] = "<a class=\"crm-weight-arrow\" href=\"{$url}&amp;dst={$prevID}&amp;dir=swap\"><img src=\"{$imageURL}/up.gif\" title=\"$alt\" alt=\"$alt\" class=\"order-icon\"></a>";
       }
       else {
-        $links[] = "<img src=\"{$imageURL}/spacer.gif\" class=\"order-icon\" alt=''>";
-        $links[] = "<img src=\"{$imageURL}/spacer.gif\" class=\"order-icon\" alt=''>";
+        $links[] = "<span class=\"order-icon\"></span>";
+        $links[] = "<span class=\"order-icon\"></span>";
       }
 
       if ($nextID != 0) {
@@ -412,8 +412,8 @@ class CRM_Utils_Weight {
         $links[] = "<a class=\"crm-weight-arrow\" href=\"{$url}&amp;dst={$lastID}&amp;dir=last\"><img src=\"{$imageURL}/last.gif\" title=\"$alt\" alt=\"$alt\" class=\"order-icon\"></a>";
       }
       else {
-        $links[] = "<img src=\"{$imageURL}/spacer.gif\" class=\"order-icon\" alt=''>";
-        $links[] = "<img src=\"{$imageURL}/spacer.gif\" class=\"order-icon\" alt=''>";
+        $links[] = "<span class=\"order-icon\"></span>";
+        $links[] = "<span class=\"order-icon\"></span>";
       }
       $rows[$id]['weight'] = implode('&nbsp;', $links);
     }

--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -1853,6 +1853,7 @@ input.crm-form-entityref {
   width: 10px;
   padding-top: 4px;
   padding-right: 4px;
+  display: inline-block;
 }
 
 /* crm button style */


### PR DESCRIPTION
Overview
----------------------------------------
The HTML currently produced by `CRM_Utils_Weight::addOrder()` is not ideal:

- The `img` elements do not contain alt attributes, which is an accessibility concern
- The use of `spacer.gif` is not ideal for performance

This change replaces the `img` elements with `span` elements which don't carry any unwanted semantics. 

Before
----------------------------------------
The HTML did not comply with basic accessibility and performance best-practices.

After
----------------------------------------
The HTML complies with accessibility and performance best practices.

Impact on custom themes
----------------------------------------
`display: inline-block;`  has been added to ensure the `span` elements match the current layout produced by the `img` elements. Custom admin themes should insure that they are also adding this style to the `#crm-container .order-icon` selector.

The `civicrm-admin-utilities` WordPress plugin contains an example of an admin theme which was affected. `civicrm-admin-utilities` has already been updated upstream.

If themes do not add the new `display: inline-block;` declaration then the weight icons will be out of alignment. However, the correct buttons and icons will still show, and so this would be a low-impact, purely visual regression. Therefore I consider the risk to custom themes to be low.