### PR TITLE
Add alt attribute to image on PCPInfo template.

### DIFF
--- a/CRM/PCP/Page/PCPInfo.php
+++ b/CRM/PCP/Page/PCPInfo.php
@@ -185,10 +185,11 @@ class CRM_PCP_Page_PCPInfo extends CRM_Core_Page {
     if (!empty($entityFile)) {
       $fileInfo = reset($entityFile);
       $fileId = $fileInfo['fileID'];
+      $altText = htmlspecialchars($fileInfo['description'] ?? '');
       $fileHash = CRM_Core_BAO_File::generateFileHash($this->_id, $fileId);
       $image = '<img src="' . CRM_Utils_System::url('civicrm/file',
           "reset=1&id=$fileId&eid={$this->_id}&fcs={$fileHash}"
-        ) . '" />';
+        ) . '" alt="' . $altText . '"/>';
       $this->assign('image', $image);
     }
 


### PR DESCRIPTION
It is an accessibility best-practice that all images should have alt text.

If a description has been provided, we use that text,
otherwise an empty alt text is used (i.e. the image is treated as decorative)