### PR TITLE
dev/drupal#167 - Deprecated service to be removed in Drupal 10

### DIFF
--- a/setup/src/Setup/DrupalUtil.php
+++ b/setup/src/Setup/DrupalUtil.php
@@ -20,7 +20,7 @@ class DrupalUtil {
       return basename(conf_path());
     }
     elseif (class_exists('Drupal')) {
-      return \Drupal::service('site.path');
+      return \Drupal::getContainer()->getParameter('site.path');
     }
     else {
       throw new \Exception('Cannot detect path under Drupal "sites/".');


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/drupal/-/issues/167

`site.path` service is deprecated and will be removed in drupal 10.

Before
----------------------------------------
For reasons I don't fully understand drupal uses `@trigger_error` which because of the `@` hides the message and only outputs the deprecations when running in drupal's own test environment, so you can't see it doing an install (with `cv core:install`). But it's there.

One way to see it:

1. In a stock drupal9+civi install, apply this patch to vendor\civicrm\civicrm-core:
    ```patch
    diff --git a/setup/src/Setup/DrupalUtil.php b/setup/src/Setup/DrupalUtil.php
    index d16717dc2e..d51ef461bc 100644
    --- a/setup/src/Setup/DrupalUtil.php
    +++ b/setup/src/Setup/DrupalUtil.php
    @@ -20,7 +20,9 @@ class DrupalUtil {
          return basename(conf_path());
         }
         elseif (class_exists('Drupal')) {
    +      set_error_handler(function(int $errno, string $errstr) { throw new \ErrorException($errstr); });
           return \Drupal::service('site.path');
         }
         else {
           throw new \Exception('Cannot detect path under Drupal "sites/".');
    ```
1. Run `cv core:install --debug-model` which is a read-only operation that won't do anything to your install.
1. It should output a red box: `The "site.path" service is deprecated in drupal:9.0.0 and is removed from drupal:10.0.0 blah blah...`

After
----------------------------------------


Technical Details
----------------------------------------
https://www.drupal.org/node/3080612

Note the "how to be cross-compatible" was added by a contributor and it maybe makes sense in some places but I went a different route.

Comments
----------------------------------------

