### PR TITLE
Make hardcoded strings translatable.

### DIFF
--- a/templates/CRM/Activity/Form/Task/PickOption.tpl
+++ b/templates/CRM/Activity/Form/Task/PickOption.tpl
@@ -9,7 +9,7 @@
 *}
 <div class="crm-form crm-form-block crm-pick-option-form-block">
 <div class="help">
-   Select Group of Contacts
+   {ts}Select Group of Contacts{/ts}
 </div>
 <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
    <table class="form-layout-compressed">

--- a/templates/CRM/Admin/Page/JobLog.tpl
+++ b/templates/CRM/Admin/Page/JobLog.tpl
@@ -41,8 +41,8 @@
             <td class="crm-joblog-name">{$row.name}</td>
             <td class="crm-joblog-details">
                 <div class="crm-joblog-command">{$row.command}</div>
-                {if $row.description}<div class="crm-joblog-description"><span class="bold">Summary</span><br/>{$row.description}</div>{/if}
-              {if $row.data}<div class="crm-joblog-data" style="border-top:1px solid #ccc; margin-top: 10px;"><span class="bold">Details</span><br/><pre>{$row.data}</pre></div>{/if}
+                {if $row.description}<div class="crm-joblog-description"><span class="bold">{ts}Summary{/ts}</span><br/>{$row.description}</div>{/if}
+                {if $row.data}<div class="crm-joblog-data" style="border-top:1px solid #ccc; margin-top: 10px;"><span class="bold">{ts}Details{/ts}</span><br/><pre>{$row.data}</pre></div>{/if}
             </td>
         </tr>
         {/foreach}

--- a/templates/CRM/Admin/Page/MessageTemplates.tpl
+++ b/templates/CRM/Admin/Page/MessageTemplates.tpl
@@ -28,7 +28,7 @@
       <textarea name="msg-subject" id="msg_subject" style="height: 6em; width: 45em;">{$form.msg_subject.value}</textarea>
       <div class='spacer'></div>
       <div class="section">
-        <a href='#' onclick='MessageTemplates.msg_subject.select(); return false;' class='button'><span>Select Subject</span></a>
+        <a href='#' onclick='MessageTemplates.msg_subject.select(); return false;' class='button'><span>{ts}Select Subject{/ts}</span></a>
         <div class='spacer'></div>
       </div>
     </div>
@@ -40,7 +40,7 @@
       <textarea class="huge" name='msg_text' id='msg_text'>{$form.msg_text.value|htmlentities}</textarea>
       <div class='spacer'></div>
       <div class="section">
-        <a href='#' onclick='MessageTemplates.msg_text.select(); return false;' class='button'><span>Select Text Message</span></a>
+        <a href='#' onclick='MessageTemplates.msg_text.select(); return false;' class='button'><span>{ts}Select Text Message{/ts}</span></a>
         <div class='spacer'></div>
       </div>
     </div>
@@ -52,7 +52,7 @@
       <textarea class="huge" name='msg_html' id='msg_html'>{$form.msg_html.value|htmlentities}</textarea>
       <div class='spacer'></div>
       <div class="section">
-        <a href='#' onclick='MessageTemplates.msg_html.select(); return false;' class='button'><span>Select HTML Message</span></a>
+        <a href='#' onclick='MessageTemplates.msg_html.select(); return false;' class='button'><span>{ts}Select HTML Message{/ts}</span></a>
         <div class='spacer'></div>
       </div>
     </div>

--- a/templates/CRM/Contact/Form/Task/ProximityCommon.tpl
+++ b/templates/CRM/Contact/Form/Task/ProximityCommon.tpl
@@ -11,7 +11,7 @@
     <legend>{ts}By Distance from a Location{/ts}</legend>
     <table class="form-layout-compressed">
        <tr><td class="label">{$form.prox_distance.label}</td><td>{$form.prox_distance.html|crmAddClass:four} {$form.prox_distance_unit.html}</td></tr>
-       <tr><td class="label">FROM...</td><td></td></tr>
+       <tr><td class="label">{ts}FROM...{/ts}</td><td></td></tr>
        <tr><td class="label">{$form.prox_street_address.label}</td><td>{$form.prox_street_address.html}</td></tr>
        <tr><td class="label">{$form.prox_city.label}</td><td>{$form.prox_city.html}</td></tr>
        <tr><td class="label">{$form.prox_postal_code.label}</td><td>{$form.prox_postal_code.html}</td></tr>

--- a/templates/CRM/Contact/Import/Form/Mapper.tpl
+++ b/templates/CRM/Contact/Import/Form/Mapper.tpl
@@ -9,7 +9,7 @@
 *}
 <div class="crm-block crm-form-block">
 
-<h3>Mapper - 4 Selectors</h3>
+<h3>{ts}Mapper - 4 Selectors{/ts}</h3>
 
 <div class="form-item">
    <dl>

--- a/templates/CRM/Contact/Page/View/Relationship.tpl
+++ b/templates/CRM/Contact/Page/View/Relationship.tpl
@@ -21,7 +21,7 @@
     {* display current relationships *}
     <h3>{ts}Current Relationships{/ts}</h3>
     <div id="permission-legend" class="help">
-      <span class="crm-label">Permissioned Relationships: </span>
+      <span class="crm-label">{ts}Permissioned Relationships: {/ts}</span>
       {include file="CRM/Contact/Page/View/RelationshipPerm.tpl" permType=1 afterText=true}
     </div>
     {include file="CRM/Contact/Page/View/RelationshipSelector.tpl" context="current"}

--- a/templates/CRM/Contribute/Page/ContributionRecur.tpl
+++ b/templates/CRM/Contribute/Page/ContributionRecur.tpl
@@ -25,7 +25,7 @@
       {else}
         <tr><td class="label">{ts}Amount{/ts}</td><td>{$recur.amount|crmMoney:$recur.currency}{if $is_test} ({ts}test{/ts}){/if}</td></tr>
       {/if}
-      <tr><td class="label">{ts}Frequency{/ts}</td><td>every {$recur.frequency_interval} {$recur.frequency_unit}</td></tr>
+      <tr><td class="label">{ts}Frequency{/ts}</td><td>{ts 1=$recur.frequency_interval 2=$recur.frequency_unit}every %1 %2{/ts}</td></tr>
       {if !empty($recur.installments)}<tr><td class="label">{ts}Installments{/ts}</td><td>{$recur.installments}</td></tr>{/if}
       <tr><td class="label">{ts}Status{/ts}</td><td>{$recur.contribution_status}</td></tr>
       <tr><td class="label">{ts}Start Date{/ts}</td><td>{$recur.start_date|crmDate}</td></tr>

--- a/templates/CRM/Event/Form/ParticipantFeeSelection.tpl
+++ b/templates/CRM/Event/Form/ParticipantFeeSelection.tpl
@@ -81,7 +81,7 @@ CRM.$(function($) {
 
 {/literal}
 </script>
-<h3>Change Registration Selections</h3>
+<h3>{ts}Change Registration Selections{/ts}</h3>
 
 <div class="crm-block crm-form-block crm-payment-form-block">
   <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>

--- a/templates/CRM/Group/Form/Edit.tpl
+++ b/templates/CRM/Group/Form/Edit.tpl
@@ -31,7 +31,7 @@
       <td>{$form.description.html}</td>
     </tr>
 
-    <tr><td colspan="2">If either of the following fields are filled out they will be used instead of the title or description field in profiles and Mailing List Subscription/unsubscribe forms</td></tr>
+    <tr><td colspan="2">{ts}If either of the following fields are filled out they will be used instead of the title or description field in profiles and Mailing List Subscription/unsubscribe forms{/ts}</td></tr>
 
     <tr class="crm-group-form-block-frontend-title">
       <td class="label">{$form.frontend_title.label} {if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_group' field='frontend_title' id=$group.id}{/if}</td>

--- a/templates/CRM/Mailing/Form/ForwardMailing.tpl
+++ b/templates/CRM/Mailing/Form/ForwardMailing.tpl
@@ -9,7 +9,7 @@
 *}
 <div class="crm-block crm-mailing-forward-form-block">
 <table class="form-layout">
-<tr class="crm-mailing-forward-form-block-fromEmail"><td class="label">From</td><td>{$fromEmail}</td></tr>
+<tr class="crm-mailing-forward-form-block-fromEmail"><td class="label">{ts}From{/ts}</td><td>{$fromEmail}</td></tr>
 <tr><td colspan="2">{ts}Please enter up to 5 email addresses to receive the mailing.{/ts}</td></tr>
 <tr class="crm-mailing-forward-form-block-email_0"><td class="label" >{$form.email_0.label}</td><td>{$form.email_0.html}</td></tr>
 <tr class="crm-mailing-forward-form-block-email_1"><td class="label" >{$form.email_1.label}</td><td>{$form.email_1.html}</td></tr>

--- a/templates/CRM/Report/Page/InstanceList.tpl
+++ b/templates/CRM/Report/Page/InstanceList.tpl
@@ -33,7 +33,7 @@
                     <td class="crm-report-instanceList-description">{$row.description}</td>
                     <td>
                     <a href="{$row.viewUrl}" class="action-item crm-hover-button">{ts}View Results{/ts}</a>
-                    <span class="btn-slide crm-hover-button">more
+                    <span class="btn-slide crm-hover-button">{ts}more{/ts}
                       <ul class="panel">
                         {foreach from=$row.actions item=action key=action_name}
                           <li><a href="{$action.url}" class="{$action_name} action-item crm-hover-button small-popup"

--- a/templates/CRM/UF/Page/Group.tpl
+++ b/templates/CRM/UF/Page/Group.tpl
@@ -23,7 +23,7 @@
     <div id="standalone-form">
         <textarea rows="20" cols="80" name="profile" id="profile">{$profile}</textarea>
         <div class="spacer"></div>
-        <a href="#" onclick="html_code.profile.select(); return false;" class="button"><span>Select HTML Code</span></a>
+        <a href="#" onclick="html_code.profile.select(); return false;" class="button"><span>{ts}Select HTML Code{/ts}</span></a>
     </div>
     <div class="action-link">
         &nbsp; <a href="{crmURL p='civicrm/admin/uf/group' q="reset=1"}"><i class="crm-i fa-chevron-left" aria-hidden="true"></i>  {ts}Back to Profile Listings{/ts}</a>

--- a/templates/CRM/common/importProgress.tpl
+++ b/templates/CRM/common/importProgress.tpl
@@ -58,7 +58,7 @@ CRM.$(function($) {
 
 {* Import Progress Bar and Info *}
 <div id="id-processing" class="hiddenElement">
-  <h3>Importing records...</h3><br />
+  <h3>{ts}Importing records...{/ts}</h3><br />
        <div id="status" style="margin-left:6px;"></div>
   <div class="progressBar" id="importProgressBar" style="margin-left:6px;display:none;"></div>
   <div id="intermediate"></div>


### PR DESCRIPTION
Overview
----------------------------------------
Wraps previously hardcoded strings in {ts} in Smarty .tpl files.

Before
----------------------------------------
Some strings in .tpl files were hardcoded.

After
----------------------------------------
Strings are translatable.

Technical Details
----------------------------------------
I used a set of regex searches of style `<span[^>]*>(\s*)[a-z]` to find these untranslated strings, having spotted the first few whilst using Civi. I'm sure a few other hardcoded strings are still hanging around after this change.

