### PR TITLE
ensure events with single quotes can be share via social

### DIFF
--- a/templates/CRM/common/SocialNetwork.tpl
+++ b/templates/CRM/common/SocialNetwork.tpl
@@ -13,14 +13,14 @@
     <h2>{ts}Help spread the word{/ts}</h2>
     <p>{ts}Please help us and let your friends, colleagues and followers know about our page{/ts}{if $title}: <strong><a href="{$pageURL}">{$title}</a></strong>{else}.{/if}</p>
     {if $emailMode eq true}
-        <a href="https://twitter.com/share?url={$url|escape:'url'}&amp;text={$title}" class="btn btn-default" role="button" target="_blank">{ts}Tweet{/ts}</a>
+        <a href="https://twitter.com/share?url={$url|escape:'url'}&amp;text={$title|escape:'url'}" class="btn btn-default" role="button" target="_blank">{ts}Tweet{/ts}</a>
         <a href="https://facebook.com/sharer/sharer.php?u={$url|escape:'url'}" target="_blank" class="btn btn-default" role="button">{ts}Share on Facebook{/ts}</a>
-        <a href="https://www.linkedin.com/shareArticle?mini=true&amp;url={$url|escape:'url'}&amp;title={$title}" target="_blank" rel="noopener" class="btn btn-default">{ts}Share on LinkedIn{/ts}</a>
+        <a href="https://www.linkedin.com/shareArticle?mini=true&amp;url={$url|escape:'url'}&amp;title={$title|escape:'url'}" target="_blank" rel="noopener" class="btn btn-default">{ts}Share on LinkedIn{/ts}</a>
     {else}
-        <button onclick="window.open('https://twitter.com/intent/tweet?url={$url|escape:'url'}&amp;text={$title}','_blank')" type="button" class="btn btn-default crm-button" id="crm-tw"><i aria-hidden="true" class="crm-i fa-twitter"></i>&nbsp;&nbsp;{ts}Tweet{/ts}</button>
+        <button onclick="window.open('https://twitter.com/intent/tweet?url={$url|escape:'url'}&amp;text={$title|escape:'url'}','_blank')" type="button" class="btn btn-default crm-button" id="crm-tw"><i aria-hidden="true" class="crm-i fa-twitter"></i>&nbsp;&nbsp;{ts}Tweet{/ts}</button>
         <button onclick="window.open('https://facebook.com/sharer/sharer.php?u={$url|escape:'url'}','_blank')" type="button" class="btn btn-default crm-button" role="button" id="crm-fb"><i aria-hidden="true" class="crm-i fa-facebook"></i>&nbsp;&nbsp;{ts}Share on Facebook{/ts}</button>
-        <button onclick="window.open('https://www.linkedin.com/shareArticle?mini=true&amp;url={$url|escape:'url'}&amp;title={$title}','_blank')" type="button" rel="noopener" class="btn btn-default crm-button" id="crm-li"><i aria-hidden="true" class="crm-i fa-linkedin"></i>&nbsp;&nbsp;{ts}Share on LinkedIn{/ts}</button>
-        <button onclick="window.open('mailto:?subject={$title}&amp;body={$url|escape:'url'}','_self')" type="button" rel="noopener" class="btn btn-default crm-button" id="crm-email"><i aria-hidden="true" class="crm-i fa-envelope"></i>&nbsp;&nbsp;{ts}Email{/ts}</button>
+        <button onclick="window.open('https://www.linkedin.com/shareArticle?mini=true&amp;url={$url|escape:'url'}&amp;title={$title|escape:'url'}','_blank')" type="button" rel="noopener" class="btn btn-default crm-button" id="crm-li"><i aria-hidden="true" class="crm-i fa-linkedin"></i>&nbsp;&nbsp;{ts}Share on LinkedIn{/ts}</button>
+        <button onclick="window.open('mailto:?subject={$title|escape:'quotes'}&amp;body={$url|escape:'url'}','_self')" type="button" rel="noopener" class="btn btn-default crm-button" id="crm-email"><i aria-hidden="true" class="crm-i fa-envelope"></i>&nbsp;&nbsp;{ts}Email{/ts}</button>
     {/if}
     {if $pageURL}
     <p class="clear">


### PR DESCRIPTION
Overview
----------------------------------------
Titles are not properly escaped when social media links are generated.


Before
----------------------------------------
If an event has a single quote in it, the auto generated twitter, linked in, and email buttons failed to do anything.

After
----------------------------------------
After properly escaping the title, the buttons now work.


Technical Details
----------------------------------------
When an event title has a single quote, the auto-generated javascript code has a parse error in the form:

```
<button onclick="window.open('https://www.linkedin.com/shareArticle?mini=true&amp;url=https://server.com/&amp;title=Woop's my event has an apostrophe which is a parse error here')"</botton>
```

Comments
----------------------------------------
Although failure to escape input is usually a security concern, since public users generally are not allowed to generate event titles I don't think this qualifies. But... would be good to get a security team member to review just in case.
