### PR TITLE
dev/core#2907 fix for gdpr clobering contact tokens

### DIFF
--- a/CRM/Core/EntityTokens.php
+++ b/CRM/Core/EntityTokens.php
@@ -547,7 +547,7 @@ class CRM_Core_EntityTokens extends AbstractTokenSubscriber {
     if (isset($this->getTokenMappingsForRelatedEntities()[$fieldName])) {
       return $this->getTokenMetadata()[$this->getTokenMappingsForRelatedEntities()[$fieldName]];
     }
-    return $this->getTokenMetadata()[$this->getDeprecatedTokens()[$fieldName]];
+    return $this->getTokenMetadata()[$this->getDeprecatedTokens()[$fieldName]] ?? [];
   }
 
   /**


### PR DESCRIPTION

Overview
----------------------------------------
This is a fix for contact tokens not rendering when gdpr tokens is installed - https://github.com/veda-consulting-company/uk.co.vedaconsulting.gdpr

Gdpr declares some addtional tokens with the namespace 'contact'. I am inclined to
agree with @magnolia61's suggestion it is  'naughty' and so while I have fixed the clobbering by
not processing contact-metadata tokens I have not fixed the enotices.

If we think it is non-naughty I can kill those - but I've already loosened
some strictness that I think had benefits in order to facilitate this

Before
----------------------------------------
Contact tokens don't render with gdpr extension installed. This extension declares tokens in the 'contact' namespace such as `{contact.comm_pref_supporter_link}`

After
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/137019655-2aa53625-3c60-4714-8b51-92f9b1757778.png)

Technical Details
----------------------------------------

Comments
----------------------------------------
Thanks for the testing / diagnosis @magnolia61 