### PR TITLE
dev/core#2895 - Failing test demonstrating case token not resolved

### DIFF
--- a/CRM/Utils/Mail.php
+++ b/CRM/Utils/Mail.php
@@ -572,7 +572,7 @@ class CRM_Utils_Mail {
    * contact ID in RFC822 format.
    *
    * @param string $from
-   *   contact ID or formatted "From address", eg. 12 or "Fred Bloggs" <fred@example.org>
+   *   civicrm_email.id or formatted "From address", eg. 12 or "Fred Bloggs" <fred@example.org>
    * @return string
    *   The RFC822-formatted email header (display name + address)
    */

--- a/tests/phpunit/CRM/Case/Form/EmailTest.php
+++ b/tests/phpunit/CRM/Case/Form/EmailTest.php
@@ -6,11 +6,10 @@
 class CRM_Case_Form_EmailTest extends CiviCaseTestCase {
 
   public function testOpeningEmailForm() {
-    $loggedInUserId = $this->createLoggedInUser();
     $clientId = $this->individualCreate();
-    $caseObj = $this->createCase($clientId, $loggedInUserId);
+    $caseObj = $this->createCase($clientId, $this->_loggedInUser);
 
-    $url = "civicrm/case/email/add?reset=1&action=add&atype=3&cid={$loggedInUserId}&caseid={$caseObj->id}";
+    $url = "civicrm/case/email/add?reset=1&action=add&atype=3&cid={$this->_loggedInUser}&caseid={$caseObj->id}";
 
     $_SERVER['REQUEST_URI'] = $url;
     $urlParts = explode('?', $url);
@@ -40,6 +39,54 @@ class CRM_Case_Form_EmailTest extends CiviCaseTestCase {
     $this->assertStringContainsString('name="_qf_Email_upload"', $contents);
     $this->assertStringContainsString('anthony_anderson@civicrm.org', $contents);
     $this->assertStringContainsString('CRM_Case_Form_Task_Email', $contents);
+  }
+
+  public function testCaseTokenForRecipientAddedAfterOpeningForm() {
+    $clientId = $this->individualCreate();
+    $caseObj = $this->createCase($clientId, $this->_loggedInUser);
+
+    $anotherPersonId = $this->individualCreate([], 1);
+    $anotherPersonInfo = $this->callAPISuccess('Contact', 'getsingle', ['id' => $anotherPersonId]);
+
+    $senderEmail = $this->callAPISuccess('Email', 'getsingle', ['contact_id' => $this->_loggedInUser]);
+
+    $mut = new CiviMailUtils($this);
+
+    // Note we start by "clicking" on the link to send an email to the client
+    // but the "to" field below is where we've changed the recipient.
+    $_GET['cid'] = $_REQUEST['cid'] = $clientId;
+    $_GET['caseid'] = $_REQUEST['caseid'] = $caseObj->id;
+    $_GET['atype'] = $_REQUEST['atype'] = 3;
+    $_GET['action'] = $_REQUEST['action'] = 'add';
+
+    $form = $this->getFormObject('CRM_Case_Form_Task_Email', [
+      'to' => "{$anotherPersonId}::{$anotherPersonInfo['email']}",
+      'cc_id' => '',
+      'bcc_id' => '',
+      'subject' => 'abc',
+      // Note this is the civicrm_email.id
+      'from_email_address' => $senderEmail['id'],
+      'html_message' => '<p>Hello {contact.display_name}</p> <p>This is case id {case.id}</p>',
+      'text_message' => '',
+      'template' => '',
+      'saveTemplateName' => '',
+      'MAX_FILE_SIZE' => '2097152',
+      'attachDesc_1' => '',
+      'attachDesc_2' => '',
+      'attachDesc_3' => '',
+      'followup_date' => '',
+      'followup_assignee_contact_id' => '',
+      'followup_activity_type_id' => '',
+      'followup_activity_subject' => '',
+    ]);
+    $form->_contactIds = [$clientId];
+    $form->postProcess();
+
+    $mut->checkMailLog([
+      "Hello {$anotherPersonInfo['display_name']}",
+      "This is case id {$caseObj->id}",
+    ]);
+    $mut->stop();
   }
 
 }

--- a/tests/phpunit/CiviTest/CiviCaseTestCase.php
+++ b/tests/phpunit/CiviTest/CiviCaseTestCase.php
@@ -111,8 +111,8 @@ class CiviCaseTestCase extends CiviUnitTestCase {
    * This method is called after a test is executed.
    */
   public function tearDown(): void {
-    $this->quickCleanup($this->tablesToTruncate, TRUE);
     $this->customDirectories(array('template_path' => FALSE));
+    $this->quickCleanup($this->tablesToTruncate, TRUE);
     CRM_Case_XMLRepository::singleton(TRUE);
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/2895

Before
----------------------------------------
Sending a case email to a person added to the receipient list after opening the form fails to render case tokens.

After
----------------------------------------
Sending a case email to a person added to the receipient list after opening the form fails to render case tokens. (See https://github.com/civicrm/civicrm-core/pull/21801)

Technical Details
----------------------------------------
This test is against master so should fail until 5.43 is merged up to include 21801

Comments
----------------------------------------
Has test
