### PR TITLE
SearchKit server-side rendering

### DIFF
--- a/Civi/Api4/Generic/AbstractAction.php
+++ b/Civi/Api4/Generic/AbstractAction.php
@@ -430,9 +430,6 @@ abstract class AbstractAction implements \ArrayAccess {
   public function entityFields() {
     if (!$this->_entityFields) {
       $allowedTypes = ['Field', 'Filter', 'Extra'];
-      if (method_exists($this, 'getCustomGroup')) {
-        $allowedTypes[] = 'Custom';
-      }
       $getFields = \Civi\API\Request::create($this->getEntityName(), 'getFields', [
         'version' => 4,
         'checkPermissions' => FALSE,

--- a/Civi/Api4/Query/SqlFunction.php
+++ b/Civi/Api4/Query/SqlFunction.php
@@ -196,6 +196,16 @@ abstract class SqlFunction extends SqlExpression {
   }
 
   /**
+   * All functions return 'SqlFunction' as their type.
+   *
+   * To get the function name @see SqlFunction::getName()
+   * @return string
+   */
+  public function getType(): string {
+    return 'SqlFunction';
+  }
+
+  /**
    * @return string
    */
   abstract public static function getDescription(): string;

--- a/ext/search_kit/Civi/Search/Admin.php
+++ b/ext/search_kit/Civi/Search/Admin.php
@@ -122,7 +122,6 @@ class Admin {
           $field['fieldName'] = $field['name'];
           // Hack for RelationshipCache to make Relationship fields editable
           if ($entity['name'] === 'RelationshipCache') {
-            $entity['primary_key'] = ['relationship_id'];
             if (in_array($field['name'], ['is_active', 'start_date', 'end_date'])) {
               $field['readonly'] = FALSE;
             }

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminDisplay.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminDisplay.component.js
@@ -156,37 +156,12 @@
       this.toggleEditable = function(col) {
         if (col.editable) {
           delete col.editable;
-          return;
+        } else {
+          col.editable = true;
         }
-
-        var info = searchMeta.parseExpr(col.key),
-          arg = _.findWhere(info.args, {type: 'field'}) || {},
-          value = col.key.split(':')[0];
-        if (!arg.field || info.fn) {
-          delete col.editable;
-          return;
-        }
-        // If field is an implicit join, use the original fk field
-        if (arg.field.name !== arg.field.fieldName) {
-          value = value.substr(0, value.lastIndexOf('.'));
-          info = searchMeta.parseExpr(value);
-          arg = info.args[0];
-        }
-        col.editable = {
-          // Hack to support editing relationships
-          entity: arg.field.entity.replace('RelationshipCache', 'Relationship'),
-          input_type: arg.field.input_type,
-          data_type: arg.field.data_type,
-          options: !!arg.field.options,
-          serialize: !!arg.field.serialize,
-          fk_entity: arg.field.fk_entity,
-          id: arg.prefix + searchMeta.getEntity(arg.field.entity).primary_key[0],
-          name: arg.field.name,
-          value: value
-        };
       };
 
-      this.isEditable = function(col) {
+      this.canBeEditable = function(col) {
         var expr = ctrl.getExprFromSelect(col.key),
           info = searchMeta.parseExpr(expr);
         return !col.image && !col.rewrite && !col.link && !info.fn && info.args[0] && info.args[0].field && !info.args[0].field.readonly;
@@ -213,6 +188,7 @@
         if (column.link) {
           ctrl.onChangeLink(column, column.link.path, '');
         } else {
+          delete column.editable;
           var defaultLink = ctrl.getLinks(column.key)[0];
           column.link = {path: defaultLink ? defaultLink.path : 'civicrm/'};
           ctrl.onChangeLink(column, null, column.link.path);

--- a/ext/search_kit/ang/crmSearchAdmin/displays/colType/field.html
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/colType/field.html
@@ -43,11 +43,11 @@
   <crm-search-admin-token-select ng-if="col.rewrite" model="col" field="rewrite" suffix=":label"></crm-search-admin-token-select>
 </div>
 <div class="form-inline">
-  <label ng-if="$ctrl.parent.isEditable(col)" title="{{:: ts('Users will be able to click to edit this field.') }}">
+  <label ng-if="$ctrl.parent.canBeEditable(col)" title="{{:: ts('Users will be able to click to edit this field.') }}">
     <input type="checkbox" ng-checked="col.editable" ng-click="$ctrl.parent.toggleEditable(col)">
     {{:: ts('In-Place Edit') }}
   </label>
-  <label ng-if="!$ctrl.parent.isEditable(col)" class="disabled" title="{{:: ts('Read-only or rewritten fields cannot be editable.') }}">
+  <label ng-if="!$ctrl.parent.canBeEditable(col)" class="disabled" title="{{:: ts('Read-only or rewritten fields cannot be editable.') }}">
     <input type="checkbox" disabled>
     {{:: ts('In-Place Edit') }}
   </label>

--- a/ext/search_kit/ang/crmSearchAdmin/resultsTable/crmSearchAdminResultsTable.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/resultsTable/crmSearchAdminResultsTable.component.js
@@ -77,6 +77,9 @@
         };
         ctrl.settings = ctrl.display.settings;
         setLabel();
+        ctrl.results = null;
+        ctrl.rowCount = null;
+        ctrl.page = 1;
       }
 
       function setLabel() {
@@ -86,7 +89,6 @@
       this.$onInit = function() {
         buildSettings();
         this.initializeDisplay($scope, $element);
-        $scope.$watch('$ctrl.search.api_entity', buildSettings);
         $scope.$watch('$ctrl.search.api_params', buildSettings, true);
         $scope.$watch('$ctrl.search.label', setLabel);
       };

--- a/ext/search_kit/ang/crmSearchAdmin/searchListing/afforms.html
+++ b/ext/search_kit/ang/crmSearchAdmin/searchListing/afforms.html
@@ -1,22 +1,22 @@
-<div class="btn-group" ng-if=":: row.display_name.raw">
+<div class="btn-group" ng-if=":: row.data.display_name">
   <button type="button" ng-click="$ctrl.loadAfforms(); row.openAfformMenu = true;" class="btn btn-xs dropdown-toggle btn-primary-outline" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
     {{ $ctrl.afforms ? (row.afform_count === 1 ? ts('1 Form') : ts('%1 Forms', {1: row.afform_count})) : ts('Forms...') }}
     <span class="caret"></span>
   </button>
   <ul class="dropdown-menu" ng-if=":: row.openAfformMenu">
-    <li ng-repeat="display_name in row.display_name.raw" ng-if="::$ctrl.afformAdminEnabled">
-      <a target="_blank" href="{{:: $ctrl.afformPath + '#/create/search/' + row.name.raw + '.' + display_name }}">
-        <i class="fa fa-plus"></i> {{:: ts('Create form for %1', {1: row.display_label.raw[$index]}) }}
+    <li ng-repeat="display_name in row.data.display_name" ng-if="::$ctrl.afformAdminEnabled">
+      <a target="_blank" href="{{:: $ctrl.afformPath + '#/create/search/' + row.data.name + '.' + display_name }}">
+        <i class="fa fa-plus"></i> {{:: ts('Create form for %1', {1: row.data.display_label[$index]}) }}
       </a>
     </li>
     <li class="divider" role="separator" ng-if="::$ctrl.afformAdminEnabled"></li>
     <li ng-if="!row.afform_count" class="disabled">
       <a href>
         <i ng-if="!$ctrl.afforms" class="crm-i fa-spinner fa-spin"></i>
-        <em ng-if="$ctrl.afforms && !$ctrl.afforms[row.name.raw]">{{:: ts('None Found') }}</em>
+        <em ng-if="$ctrl.afforms && !$ctrl.afforms[row.data.name]">{{:: ts('None Found') }}</em>
       </a>
     </li>
-    <li ng-if="$ctrl.afforms" ng-repeat="afform in $ctrl.afforms[row.name.raw]" title="{{:: $ctrl.afformAdminEnabled ? ts('Edit form') : '' }}">
+    <li ng-if="$ctrl.afforms" ng-repeat="afform in $ctrl.afforms[row.data.name]" title="{{:: $ctrl.afformAdminEnabled ? ts('Edit form') : '' }}">
       <a target="_blank" ng-href="{{:: afform.link }}">
         <i class="crm-i {{:: $ctrl.afformAdminEnabled ? 'fa-pencil-square-o' : 'fa-list-alt' }}"></i>
         {{:: afform.title }}

--- a/ext/search_kit/ang/crmSearchAdmin/searchListing/buttons.html
+++ b/ext/search_kit/ang/crmSearchAdmin/searchListing/buttons.html
@@ -1,7 +1,7 @@
-<a class="btn btn-xs btn-default" href="#/edit/{{:: row.id.raw }}" ng-if="row.permissionToEdit">
+<a class="btn btn-xs btn-default" href="#/edit/{{:: row.data.id }}" ng-if="row.permissionToEdit">
   {{:: ts('Edit') }}
 </a>
-<a class="btn btn-xs btn-default" href="#/create/{{:: row.api_entity.raw + '?params=' + $ctrl.encode(row.api_params.raw) }}">
+<a class="btn btn-xs btn-default" href="#/create/{{:: row.data.api_entity + '?params=' + $ctrl.encode(row.data.api_params) }}">
   {{:: ts('Clone') }}
 </a>
 <a href class="btn btn-xs btn-danger" ng-click="$ctrl.confirmDelete(row)">

--- a/ext/search_kit/ang/crmSearchAdmin/searchListing/crmSearchAdminSearchListing.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/searchListing/crmSearchAdminSearchListing.component.js
@@ -60,9 +60,9 @@
 
       this.onPostRun.push(function(result) {
         _.each(result, function(row) {
-          row.permissionToEdit = CRM.checkPerm('all CiviCRM permissions and ACLs') || !_.includes(row.display_acl_bypass.raw, true);
+          row.permissionToEdit = CRM.checkPerm('all CiviCRM permissions and ACLs') || !_.includes(row.data.display_acl_bypass, true);
           // Saves rendering cycles to not show an empty menu of search displays
-          if (!row.display_name.raw) {
+          if (!row.data.display_name) {
             row.openDisplayMenu = false;
           }
         });
@@ -77,16 +77,16 @@
         function getConfirmationMsg() {
           var msg = '<h4>' + _.escape(ts('Permanently delete this saved search?')) + '</h4>' +
             '<ul>';
-          if (search.display_label.view && search.display_label.view.length === 1) {
+          if (search.data.display_label && search.data.display_label.length === 1) {
             msg += '<li>' + _.escape(ts('Includes 1 display which will also be deleted.')) + '</li>';
-          } else if (search.display_label.view && search.display_label.view.length > 1) {
-            msg += '<li>' + _.escape(ts('Includes %1 displays which will also be deleted.', {1: search.display_label.view.length})) + '</li>';
+          } else if (search.data.display_label && search.data.display_label.length > 1) {
+            msg += '<li>' + _.escape(ts('Includes %1 displays which will also be deleted.', {1: search.data.display_label.length})) + '</li>';
           }
-          _.each(search.groups.view, function(smartGroup) {
+          _.each(search.data.groups, function(smartGroup) {
             msg += '<li class="crm-error"><i class="crm-i fa-exclamation-triangle"></i> ' + _.escape(ts('Smart group "%1" will also be deleted.', {1: smartGroup})) + '</li>';
           });
           if (search.afform_count) {
-            _.each(ctrl.afforms[search.name.raw], function(afform) {
+            _.each(ctrl.afforms[search.data.name], function(afform) {
               msg += '<li class="crm-error"><i class="crm-i fa-exclamation-triangle"></i> ' + _.escape(ts('Form "%1" will also be deleted because it contains an embedded display from this search.', {1: afform.title})) + '</li>';
             });
           }
@@ -94,7 +94,7 @@
         }
 
         var dialog = CRM.confirm({
-          title: ts('Delete %1', {1: search.label.view}),
+          title: ts('Delete %1', {1: search.data.label}),
           message: getConfirmationMsg(),
         }).on('crmConfirm:yes', function() {
           $scope.$apply(function() {
@@ -109,7 +109,7 @@
 
       this.deleteSearch = function(search) {
         crmStatus({start: ts('Deleting...'), success: ts('Search Deleted')},
-          crmApi4('SavedSearch', 'delete', {where: [['id', '=', search.id.raw]]}).then(function() {
+          crmApi4('SavedSearch', 'delete', {where: [['id', '=', search.data.id]]}).then(function() {
             ctrl.rowCount = null;
             ctrl.runSearch();
           })
@@ -219,7 +219,7 @@
 
       function updateAfformCounts() {
         _.each(ctrl.results, function(row) {
-          row.afform_count = ctrl.afforms && ctrl.afforms[row.name.raw] && ctrl.afforms[row.name.raw].length || 0;
+          row.afform_count = ctrl.afforms && ctrl.afforms[row.data.name] && ctrl.afforms[row.data.name].length || 0;
         });
       }
 

--- a/ext/search_kit/ang/crmSearchAdmin/searchListing/displays.html
+++ b/ext/search_kit/ang/crmSearchAdmin/searchListing/displays.html
@@ -1,15 +1,15 @@
 <div class="btn-group">
-  <button type="button" disabled ng-if="!row.display_name.raw" class="btn btn-xs dropdown-toggle btn-primary-outline">
+  <button type="button" disabled ng-if="!row.data.display_name" class="btn btn-xs dropdown-toggle btn-primary-outline">
     {{:: ts('0 Displays') }}
   </button>
-  <button type="button" ng-if=":: row.display_name.raw" ng-click="row.openDisplayMenu = true" class="btn btn-xs dropdown-toggle btn-primary-outline" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-    {{:: row.display_name.raw.length === 1 ? ts('1 Display') : ts('%1 Displays', {1: row.display_name.raw.length}) }} <span class="caret"></span>
+  <button type="button" ng-if=":: row.data.display_name" ng-click="row.openDisplayMenu = true" class="btn btn-xs dropdown-toggle btn-primary-outline" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+    {{:: row.data.display_name.length === 1 ? ts('1 Display') : ts('%1 Displays', {1: row.data.display_name.length}) }} <span class="caret"></span>
   </button>
   <ul class="dropdown-menu" ng-if=":: row.openDisplayMenu">
-    <li ng-repeat="display_name in row.display_name.raw" ng-class="{disabled: row.display_acl_bypass.raw[$index]}" title="{{:: row.display_acl_bypass.raw[$index] ? ts('Display has permissions disabled') : ts('View display') }}">
-      <a ng-href="{{:: row.display_acl_bypass.raw[$index] ? '' : $ctrl.searchDisplayPath + '#/display/' + row.name.raw + '/' + display_name }}" target="_blank">
+    <li ng-repeat="display_name in row.data.display_name" ng-class="{disabled: row.data.display_acl_bypass[$index]}" title="{{:: row.data.display_acl_bypass[$index] ? ts('Display has permissions disabled') : ts('View display') }}">
+      <a ng-href="{{:: row.data.display_acl_bypass[$index] ? '' : $ctrl.searchDisplayPath + '#/display/' + row.data.name + '/' + display_name }}" target="_blank">
         <i class="fa {{:: row.display_icon.rw[$index] }}"></i>
-        {{:: row.display_label.raw[$index] }}
+        {{:: row.data.display_label[$index] }}
       </a>
     </li>
   </ul>

--- a/ext/search_kit/ang/crmSearchAdmin/searchListing/tags.html
+++ b/ext/search_kit/ang/crmSearchAdmin/searchListing/tags.html
@@ -1,1 +1,1 @@
-<crm-search-admin-tags tag-ids="row.tag_id.raw" saved-search-id="row.id.raw" class="btn-group btn-group-xs"></crm-search-admin-tags>
+<crm-search-admin-tags tag-ids="row.data.tag_id" saved-search-id="row.data.id" class="btn-group btn-group-xs"></crm-search-admin-tags>

--- a/ext/search_kit/ang/crmSearchDisplay/colType/buttons.html
+++ b/ext/search_kit/ang/crmSearchDisplay/colType/buttons.html
@@ -1,6 +1,6 @@
-<span ng-repeat="item in col.links">
-  <a class="btn {{:: col.size }} btn-{{:: item.style }}" target="{{:: item.target }}" href="{{:: $ctrl.getUrl(item.path, row) }}">
-    <i ng-if=":: item.icon" class="crm-i {{:: item.icon }}"></i>
-    {{:: $ctrl.replaceTokens(item.text, row) }}
+<span ng-repeat="link in colData.links">
+  <a class="btn {{:: $ctrl.settings.columns[colIndex].size }} btn-{{:: link.style }}" target="{{:: link.target }}" href="{{:: link.url }}">
+    <i ng-if=":: link.icon" class="crm-i {{:: link.icon }}"></i>
+    {{:: link.text }}
   </a>
 </span>

--- a/ext/search_kit/ang/crmSearchDisplay/colType/field.html
+++ b/ext/search_kit/ang/crmSearchDisplay/colType/field.html
@@ -1,5 +1,5 @@
-<crm-search-display-editable row="row" col="$ctrl.settings.columns[colIndex]" on-success="$ctrl.runSearch(row)" cancel="$ctrl.editing = null;" ng-if="col.editable && $ctrl.editing && $ctrl.editing[0] === rowIndex && $ctrl.editing[1] === col.key"></crm-search-display-editable>
-<span ng-if="::!colData.links && !colData.img" ng-class="{'crm-editable-enabled': colData.edit && !$ctrl.editing}" ng-click="col.edit && !$ctrl.editing && ($ctrl.editing = [rowIndex, col.key])">
+<crm-search-display-editable row="row" col="colData" on-success="$ctrl.runSearch(row)" cancel="$ctrl.editing = null;" ng-if="colData.edit && $ctrl.editing && $ctrl.editing[0] === rowIndex && $ctrl.editing[1] === colIndex"></crm-search-display-editable>
+<span ng-if="::!colData.links && !colData.img" ng-class="{'crm-editable-enabled': colData.edit && !$ctrl.editing}" ng-click="colData.edit && !$ctrl.editing && ($ctrl.editing = [rowIndex, colIndex])">
   {{:: $ctrl.formatFieldValue(colData) }}
 </span>
 <span ng-if="::colData.links">

--- a/ext/search_kit/ang/crmSearchDisplay/colType/field.html
+++ b/ext/search_kit/ang/crmSearchDisplay/colType/field.html
@@ -1,17 +1,17 @@
-<crm-search-display-editable row="row" col="col" on-success="$ctrl.runSearch(row)" cancel="$ctrl.editing = null;" ng-if="col.editable && $ctrl.editing && $ctrl.editing[0] === rowIndex && $ctrl.editing[1] === col.key"></crm-search-display-editable>
-<span ng-if="::!col.link && !col.image" ng-class="{'crm-editable-enabled': col.editable && !$ctrl.editing && row[col.editable.id]}" ng-click="col.editable && !$ctrl.editing && ($ctrl.editing = [rowIndex, col.key])">
-  {{:: $ctrl.formatFieldValue(row, col) }}
+<crm-search-display-editable row="row" col="$ctrl.settings.columns[colIndex]" on-success="$ctrl.runSearch(row)" cancel="$ctrl.editing = null;" ng-if="col.editable && $ctrl.editing && $ctrl.editing[0] === rowIndex && $ctrl.editing[1] === col.key"></crm-search-display-editable>
+<span ng-if="::!colData.links && !colData.img" ng-class="{'crm-editable-enabled': colData.edit && !$ctrl.editing}" ng-click="col.edit && !$ctrl.editing && ($ctrl.editing = [rowIndex, col.key])">
+  {{:: $ctrl.formatFieldValue(colData) }}
 </span>
-<span ng-if="::col.link">
-  <span ng-repeat="link in $ctrl.getLinks(row, col)">
-    <a target="{{:: col.link.target }}" href="{{:: link.url }}">
-      <span ng-if=":: col.image && $ctrl.formatFieldValue(row, col).length">
-        <img ng-src="{{:: $ctrl.formatFieldValue(row, col) }}" alt="{{:: $ctrl.replaceTokens(col.image.alt, row) }}" height="{{:: col.image.height }}" width="{{:: col.image.width }}"/>
+<span ng-if="::colData.links">
+  <span ng-repeat="link in colData.links">
+    <a target="{{:: link.target }}" href="{{:: link.url }}">
+      <span ng-if=":: colData.img">
+        <img ng-src="{{:: colData.img.src }}" alt="{{:: colData.val }}" height="{{:: colData.img.height }}" width="{{:: colData.img.width }}"/>
       </span>
-      {{:: link.value }}</a><span ng-if="!$last">,
+      {{:: link.text }}</a><span ng-if="!$last">,
     </span>
   </span>
 </span>
-<span ng-if=":: !col.link && col.image && $ctrl.formatFieldValue(row, col).length">
-  <img ng-src="{{:: $ctrl.formatFieldValue(row, col) }}" alt="{{:: $ctrl.replaceTokens(col.image.alt, row, $ctrl.settings.columns) }}" height="{{:: col.image.height }}" width="{{:: col.image.width }}"/>
+<span ng-if=":: !colData.links && colData.img">
+  <img ng-src="{{:: colData.img.src }}" alt="{{:: colData.val }}" height="{{:: colData.img.height }}" width="{{:: colData.img.width }}"/>
 </span>

--- a/ext/search_kit/ang/crmSearchDisplay/colType/include.html
+++ b/ext/search_kit/ang/crmSearchDisplay/colType/include.html
@@ -1,1 +1,1 @@
-<div ng-include="col.path"></div>
+<div ng-include="$ctrl.settings.columns[colIndex].path"></div>

--- a/ext/search_kit/ang/crmSearchDisplay/colType/links.html
+++ b/ext/search_kit/ang/crmSearchDisplay/colType/links.html
@@ -1,6 +1,6 @@
-<span ng-repeat="item in col.links">
-  <a class="text-{{:: item.style }}" target="{{:: item.target }}" href="{{:: $ctrl.getUrl(item.path, row) }}">
-    <i ng-if=":: item.icon" class="crm-i {{:: item.icon }}"></i>
-    {{:: $ctrl.replaceTokens(item.text, row) }}
+<span ng-repeat="link in colData.links">
+  <a class="text-{{:: link.style }}" target="{{:: link.target }}" href="{{:: link.url }}">
+    <i ng-if=":: link.icon" class="crm-i {{:: link.icon }}"></i>
+    {{:: link.text }}
   </a>
 </span>

--- a/ext/search_kit/ang/crmSearchDisplay/colType/menu.html
+++ b/ext/search_kit/ang/crmSearchDisplay/colType/menu.html
@@ -1,13 +1,13 @@
 <div class="btn-group">
-  <button type="button" class="dropdown-toggle {{:: col.size }} btn-{{:: col.style }}" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" ng-click="col.open = true">
-    <i ng-if=":: col.icon" class="crm-i {{:: col.icon }}"></i>
-    {{:: $ctrl.replaceTokens(col.text, row) }}
+  <button type="button" class="dropdown-toggle {{:: $ctrl.settings.columns[colIndex].size }} btn-{{:: $ctrl.settings.columns[colIndex].style }}" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" ng-click="colData.open = true">
+    <i ng-if=":: $ctrl.settings.columns[colIndex].icon" class="crm-i {{:: $ctrl.settings.columns[colIndex].icon }}"></i>
+    {{:: colData.text }}
   </button>
-  <ul class="dropdown-menu {{ col.alignment === 'text-right' ? 'dropdown-menu-right' : '' }}" ng-if=":: col.open">
-    <li ng-repeat="item in col.links" class="bg-{{:: item.style }}">
-      <a href="{{:: $ctrl.getUrl(item.path, row) }}" target="{{:: item.target }}">
-        <i ng-if=":: item.icon" class="crm-i {{:: item.icon }}"></i>
-        {{:: $ctrl.replaceTokens(item.text, row) }}
+  <ul class="dropdown-menu {{ $ctrl.settings.columns[colIndex].alignment === 'text-right' ? 'dropdown-menu-right' : '' }}" ng-if=":: colData.open">
+    <li ng-repeat="link in colData.links" class="bg-{{:: link.style }}">
+      <a href="{{:: link.url }}" target="{{:: link.target }}">
+        <i ng-if=":: link.icon" class="crm-i {{:: link.icon }}"></i>
+        {{:: link.text }}
       </a>
     </li>
   </ul>

--- a/ext/search_kit/ang/crmSearchDisplay/crmSearchDisplayEditable.component.js
+++ b/ext/search_kit/ang/crmSearchDisplay/crmSearchDisplayEditable.component.js
@@ -19,16 +19,16 @@
 
       this.$onInit = function() {
         col = this.col;
-        this.value = _.cloneDeep(this.row[col.editable.value].raw);
-        initialValue = _.cloneDeep(this.row[col.editable.value].raw);
+        this.value = _.cloneDeep(col.edit.value);
+        initialValue = _.cloneDeep(col.edit.value);
 
         this.field = {
-          data_type: col.editable.data_type,
-          input_type: col.editable.input_type,
-          name: col.editable.name,
-          options: col.editable.options,
-          fk_entity: col.editable.fk_entity,
-          serialize: col.editable.serialize,
+          data_type: col.edit.data_type,
+          input_type: col.edit.input_type,
+          name: col.edit.value_key,
+          options: col.edit.options,
+          fk_entity: col.edit.fk_entity,
+          serialize: col.edit.serialize,
         };
 
         $(document).on('keydown.crmSearchDisplayEditable', function(e) {
@@ -55,21 +55,21 @@
           ctrl.cancel();
           return;
         }
-        var values = {id: ctrl.row[col.editable.id].raw};
-        values[col.editable.name] = ctrl.value;
+        var record = _.cloneDeep(col.edit.record);
+        record[col.edit.value_key] = ctrl.value;
         $('input', $element).attr('disabled', true);
-        crmStatus({}, crmApi4(col.editable.entity, 'update', {
-          values: values
+        crmStatus({}, crmApi4(col.edit.entity, 'update', {
+          values: record
         })).then(ctrl.onSuccess);
       };
 
       function loadOptions() {
-        var cacheKey = col.editable.entity + ' ' + ctrl.field.name;
+        var cacheKey = col.edit.entity + ' ' + ctrl.field.name;
         if (optionsCache[cacheKey]) {
           ctrl.field.options = optionsCache[cacheKey];
           return;
         }
-        crmApi4(col.editable.entity, 'getFields', {
+        crmApi4(col.edit.entity, 'getFields', {
           action: 'update',
           select: ['options'],
           loadOptions: ['id', 'name', 'label', 'description', 'color', 'icon'],

--- a/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
+++ b/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
@@ -4,54 +4,7 @@
   // Trait provides base methods and properties common to all search display types
   angular.module('crmSearchDisplay').factory('searchDisplayBaseTrait', function(crmApi4) {
     var ts = CRM.ts('org.civicrm.search_kit'),
-      runCount = 0,
-      seed = Date.now();
-
-    // Replace tokens keyed to rowData.
-    // Pass view=true to replace with view value, otherwise raw value is used.
-    function replaceTokens(str, rowData, view, index) {
-      if (!str) {
-        return '';
-      }
-      _.each(rowData, function(value, key) {
-        if (str.indexOf('[' + key + ']') >= 0) {
-          var val = view ? value.view : value.raw,
-            replacement = angular.isArray(val) ? val[index || 0] : val;
-          str = str.replace(new RegExp(_.escapeRegExp('[' + key + ']', 'g')), replacement);
-        }
-      });
-      return str;
-    }
-
-    function getUrl(link, rowData, index) {
-      var url = replaceTokens(link, rowData, false, index);
-      if (url.slice(0, 1) !== '/' && url.slice(0, 4) !== 'http') {
-        url = CRM.url(url);
-      }
-      return url;
-    }
-
-    // Returns display value for a single column in a row
-    function formatDisplayValue(rowData, key, columns) {
-      var column = _.findWhere(columns, {key: key}),
-        displayValue = column.rewrite ? replaceTokens(column.rewrite, rowData, columns) : getValue(rowData[key], 'view');
-      return angular.isArray(displayValue) ? displayValue.join(', ') : displayValue;
-    }
-
-    // Returns value and url for a column formatted as link(s)
-    function formatLinks(rowData, key, columns) {
-      var column = _.findWhere(columns, {key: key}),
-        value = column.image ? '' : getValue(rowData[key], 'view'),
-        values = angular.isArray(value) ? value : [value],
-        links = [];
-      _.each(values, function(value, index) {
-        links.push({
-          value: value,
-          url: getUrl(column.link.path, rowData, index)
-        });
-      });
-      return links;
-    }
+      runCount = 0;
 
     // Get value from column data, specify either 'raw' or 'view'
     function getValue(data, ret) {
@@ -63,7 +16,6 @@
     return {
       page: 1,
       rowCount: null,
-      getUrl: getUrl,
       // Arrays may contain callback functions for various events
       onChangeFilters: [],
       onPreRun: [],
@@ -182,18 +134,8 @@
           });
         });
       },
-      replaceTokens: function(value, row) {
-        return replaceTokens(value, row, this.settings.columns);
-      },
-      getLinks: function(rowData, col) {
-        rowData._links = rowData._links || {};
-        if (!(col.key in rowData._links)) {
-          rowData._links[col.key] = formatLinks(rowData, col.key, this.settings.columns);
-        }
-        return rowData._links[col.key];
-      },
-      formatFieldValue: function(rowData, col) {
-        return formatDisplayValue(rowData, col.key, this.settings.columns);
+      formatFieldValue: function(colData) {
+        return angular.isArray(colData.val) ? colData.val.join(', ') : colData.val;
       }
     };
   });

--- a/ext/search_kit/ang/crmSearchDisplayGrid/crmSearchDisplayGridItems.html
+++ b/ext/search_kit/ang/crmSearchDisplayGrid/crmSearchDisplayGridItems.html
@@ -1,8 +1,8 @@
 <div ng-repeat="(rowIndex, row) in $ctrl.results">
-  <div ng-repeat="col in $ctrl.settings.columns" title="{{:: $ctrl.replaceTokens(col.title, row) }}" class="{{:: col.break ? '' : 'crm-inline-block' }}">
-    <label ng-if=":: col.label && (col.type !== 'field' || col.forceLabel || row[col.key])">
-      {{:: $ctrl.replaceTokens(col.label, row) }}
+  <div ng-repeat="(colIndex, colData) in row.columns" title="{{:: colData.title }}" class="{{:: colData.cssClass }} {{:: $ctrl.settings.columns[colIndex].break ? '' : 'crm-inline-block' }}">
+    <label ng-if=":: colData.label">
+      {{:: colData.label }}
     </label>
-    <span ng-include="'~/crmSearchDisplay/colType/' + col.type + '.html'"></span>
+    <span ng-include="'~/crmSearchDisplay/colType/' + $ctrl.settings.columns[colIndex].type + '.html'"></span>
   </div>
 </div>

--- a/ext/search_kit/ang/crmSearchDisplayList/crmSearchDisplayListItems.html
+++ b/ext/search_kit/ang/crmSearchDisplayList/crmSearchDisplayListItems.html
@@ -1,8 +1,8 @@
 <li ng-repeat="(rowIndex, row) in $ctrl.results">
-  <div ng-repeat="col in $ctrl.settings.columns" title="{{:: $ctrl.replaceTokens(col.title, row) }}" class="{{:: col.break ? '' : 'crm-inline-block' }}">
-    <label ng-if=":: col.label && (col.type !== 'field' || col.forceLabel || row[col.key])">
-      {{:: $ctrl.replaceTokens(col.label, row) }}
+  <div ng-repeat="(colIndex, colData) in row.columns" title="{{:: colData.title }}" class="{{:: colData.cssClass }} {{:: $ctrl.settings.columns[colIndex].break ? '' : 'crm-inline-block' }}">
+    <label ng-if=":: colData.label">
+      {{:: colData.label }}
     </label>
-    <span ng-include="'~/crmSearchDisplay/colType/' + col.type + '.html'"></span>
+    <span ng-include="'~/crmSearchDisplay/colType/' + $ctrl.settings.columns[colIndex].type + '.html'"></span>
   </div>
 </li>

--- a/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTableBody.html
+++ b/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTableBody.html
@@ -2,7 +2,7 @@
   <td ng-if=":: $ctrl.settings.actions">
     <input type="checkbox" ng-checked="$ctrl.isRowSelected(row)" ng-click="$ctrl.selectRow(row)" ng-disabled="!(!$ctrl.loadingAllRows && row.id)">
   </td>
-  <td ng-repeat="col in $ctrl.settings.columns" ng-include="'~/crmSearchDisplay/colType/' + col.type + '.html'" title="{{:: $ctrl.replaceTokens(col.title, row) }}" class="{{:: col.alignment }}">
+  <td ng-repeat="(colIndex, colData) in row.columns" ng-include="'~/crmSearchDisplay/colType/' + $ctrl.settings.columns[colIndex].type + '.html'" title="{{:: colData.title }}" class="{{:: colData.cssClass }}">
   </td>
 </tr>
 <tr ng-if="$ctrl.rowCount === 0">

--- a/ext/search_kit/ang/crmSearchTasks/traits/searchDisplayTasksTrait.service.js
+++ b/ext/search_kit/ang/crmSearchTasks/traits/searchDisplayTasksTrait.service.js
@@ -37,9 +37,9 @@
 
       // Toggle row selection
       selectRow: function(row) {
-        var index = this.selectedRows.indexOf(row.id.raw);
+        var index = this.selectedRows.indexOf(row.data.id);
         if (index < 0) {
-          this.selectedRows.push(row.id.raw);
+          this.selectedRows.push(row.data.id);
           this.allRowsSelected = (this.rowCount === this.selectedRows.length);
         } else {
           this.allRowsSelected = false;
@@ -49,7 +49,7 @@
 
       // @return bool
       isRowSelected: function(row) {
-        return this.allRowsSelected || _.includes(this.selectedRows, row.id.raw);
+        return this.allRowsSelected || _.includes(this.selectedRows, row.data.id);
       },
 
       refreshAfterTask: function() {
@@ -69,8 +69,8 @@
       onPostRun: [function(results, status, editedRow) {
         if (editedRow && status === 'success') {
           // If edited row disappears (because edits cause it to not meet search criteria), deselect it
-          var index = this.selectedRows.indexOf(editedRow.id.raw);
-          if (index > -1 && !_.findWhere(results, {id: editedRow.id.raw})) {
+          var index = this.selectedRows.indexOf(editedRow.data.id);
+          if (index > -1 && !_.findWhere(results, {id: editedRow.data.id})) {
             this.selectedRows.splice(index, 1);
           }
         }

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchDownloadTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchDownloadTest.php
@@ -70,7 +70,7 @@ class SearchDownloadTest extends \PHPUnit\Framework\TestCase implements Headless
     $download = (array) civicrm_api4('SearchDisplay', 'download', $params);
     $header = array_shift($download);
 
-    $this->assertEquals('First Last', $header[0]['label']);
+    $this->assertEquals('First Last', $header[0]);
 
     foreach ($download as $rowNum => $data) {
       $this->assertEquals($sampleData[$rowNum]['first_name'] . ' ' . $lastName, $data[0]);

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
@@ -87,6 +87,12 @@ class SearchRunTest extends \PHPUnit\Framework\TestCase implements HeadlessInter
               'dataType' => 'String',
               'type' => 'field',
             ],
+            [
+              'key' => 'is_deceased',
+              'label' => 'Deceased',
+              'dataType' => 'Boolean',
+              'type' => 'field',
+            ],
           ],
           'sort' => [
             ['id', 'ASC'],
@@ -103,19 +109,19 @@ class SearchRunTest extends \PHPUnit\Framework\TestCase implements HeadlessInter
     $params['filters']['first_name'] = ['One', 'Two'];
     $result = civicrm_api4('SearchDisplay', 'run', $params);
     $this->assertCount(2, $result);
-    $this->assertEquals('One', $result[0]['first_name']['raw']);
-    $this->assertEquals('Two', $result[1]['first_name']['raw']);
+    $this->assertEquals('One', $result[0]['data']['first_name']);
+    $this->assertEquals('Two', $result[1]['data']['first_name']);
 
     // Raw value should be boolean, view value should be string
-    $this->assertEquals(FALSE, $result[0]['is_deceased']['raw']);
-    $this->assertEquals(ts('No'), $result[0]['is_deceased']['view']);
+    $this->assertEquals(FALSE, $result[0]['data']['is_deceased']);
+    $this->assertEquals(ts('No'), $result[0]['columns'][4]['val']);
 
-    $params['filters'] = ['last_name' => $lastName, 'id' => ['>' => $result[0]['id']['raw'], '<=' => $result[1]['id']['raw'] + 1]];
+    $params['filters'] = ['last_name' => $lastName, 'id' => ['>' => $result[0]['data']['id'], '<=' => $result[1]['data']['id'] + 1]];
     $params['sort'] = [['first_name', 'ASC']];
     $result = civicrm_api4('SearchDisplay', 'run', $params);
     $this->assertCount(2, $result);
-    $this->assertEquals('Three', $result[0]['first_name']['raw']);
-    $this->assertEquals('Two', $result[1]['first_name']['raw']);
+    $this->assertEquals('Three', $result[0]['data']['first_name']);
+    $this->assertEquals('Two', $result[1]['data']['first_name']);
 
     $params['filters'] = ['last_name' => $lastName, 'contact_sub_type:label' => ['Tester', 'Bot']];
     $result = civicrm_api4('SearchDisplay', 'run', $params);
@@ -186,9 +192,9 @@ class SearchRunTest extends \PHPUnit\Framework\TestCase implements HeadlessInter
 
     $result = civicrm_api4('SearchDisplay', 'run', $params);
     $this->assertCount(2, $result);
-    $this->assertNotEmpty($result->first()['display_name']['raw']);
+    $this->assertNotEmpty($result->first()['data']['display_name']);
     // Assert that display name was added to the search due to the link token
-    $this->assertNotEmpty($result->first()['sort_name']['raw']);
+    $this->assertNotEmpty($result->first()['data']['sort_name']);
 
     // These items are not part of the search, but will be added via links
     $this->assertArrayNotHasKey('contact_type', $result->first());
@@ -205,9 +211,9 @@ class SearchRunTest extends \PHPUnit\Framework\TestCase implements HeadlessInter
       ],
     ];
     $result = civicrm_api4('SearchDisplay', 'run', $params);
-    $this->assertEquals('Individual', $result->first()['contact_type']['raw']);
-    $this->assertEquals('Unit test', $result->first()['source']['raw']);
-    $this->assertEquals($lastName, $result->first()['last_name']['raw']);
+    $this->assertEquals('Individual', $result->first()['data']['contact_type']);
+    $this->assertEquals('Unit test', $result->first()['data']['source']);
+    $this->assertEquals($lastName, $result->first()['data']['last_name']);
   }
 
   /**
@@ -304,14 +310,14 @@ class SearchRunTest extends \PHPUnit\Framework\TestCase implements HeadlessInter
     $this->cleanupCachedPermissions();
     $result = civicrm_api4('SearchDisplay', 'run', $params);
     $this->assertCount(1, $result);
-    $this->assertEquals($sampleData['Two'], $result[0]['id']['raw']);
+    $this->assertEquals($sampleData['Two'], $result[0]['data']['id']);
 
     $hooks->setHook('civicrm_aclWhereClause', [$this, 'aclWhereGreaterThan']);
     $this->cleanupCachedPermissions();
     $result = civicrm_api4('SearchDisplay', 'run', $params);
     $this->assertCount(2, $result);
-    $this->assertEquals($sampleData['Three'], $result[0]['id']['raw']);
-    $this->assertEquals($sampleData['Four'], $result[1]['id']['raw']);
+    $this->assertEquals($sampleData['Three'], $result[0]['data']['id']);
+    $this->assertEquals($sampleData['Four'], $result[1]['data']['id']);
   }
 
   public function testWithACLBypass() {


### PR DESCRIPTION
Overview
----------------------------------------
Improves SearchKit by doing more of the rendering work server-side. This allows for more nuanced permission checks of actions, better rendering of spreadsheets, and opens the door for advanced token formatting.

Before
---------------
The `SearchDisplay::run()` api was a thin wrapper around `*::get()`, with not much pre or post-processing. Formatting of results (e.g. token replacements, rewrites, adding links, image handling, and in-place edit processing) happens client-side.

After
-----------
The `SearchDisplay::run()` api does basically all the preprocessing and formatting of results.

Technical Details
--------------------
This PR just does the refactoring needed to switch the column formatting from client to server. Advanced stuff like ACL checks of links hasn't been added yet, as this PR is already big and complex enough. But that can be added in a followup PR.

Comments
-----------
While testing this I noticed extremely poor performance when the search display had some editable columns. I fixed that with #21920 