### PR TITLE
(REF) Tokens - Populate "Event"/"Participant" without direct access to actionSearchResult

### DIFF
--- a/CRM/Event/ParticipantTokens.php
+++ b/CRM/Event/ParticipantTokens.php
@@ -10,7 +10,6 @@
  +--------------------------------------------------------------------+
  */
 
-use Civi\Token\Event\TokenValueEvent;
 use Civi\Token\TokenRow;
 
 /**
@@ -19,13 +18,6 @@ use Civi\Token\TokenRow;
  * Generate "participant.*" tokens.
  */
 class CRM_Event_ParticipantTokens extends CRM_Core_EntityTokens {
-
-  public static function getSubscribedEvents() {
-    $events = parent::getSubscribedEvents();
-    // Set the weight so it runs before event tokens.
-    $events['civi.token.eval'] = ['evaluateTokens', 400];
-    return $events;
-  }
 
   /**
    * Get the entity name for api v4 calls.
@@ -41,21 +33,6 @@ class CRM_Event_ParticipantTokens extends CRM_Core_EntityTokens {
    */
   public function getCurrencyFieldName(): array {
     return ['fee_currency'];
-  }
-
-  /**
-   * To handle variable tokens, override this function and return the active tokens.
-   *
-   * @param \Civi\Token\Event\TokenValueEvent $e
-   *
-   * @return mixed
-   */
-  public function getActiveTokens(TokenValueEvent $e) {
-    $messageTokens = $e->getTokenProcessor()->getMessageTokens();
-    if (!isset($messageTokens[$this->entity])) {
-      return isset($messageTokens['event']) ? ['event_id'] : FALSE;
-    }
-    return parent::getActiveTokens($e);
   }
 
   /**

--- a/CRM/Event/ParticipantTokens.php
+++ b/CRM/Event/ParticipantTokens.php
@@ -74,15 +74,20 @@ class CRM_Event_ParticipantTokens extends CRM_Core_EntityTokens {
     ];
   }
 
+  public function alterActionScheduleQuery(\Civi\ActionSchedule\Event\MailingQueryEvent $e): void {
+    // When targeting `civicrm_participant` records, we enable both `{participant.*}` (per usual) and the related `{event.*}`.
+    parent::alterActionScheduleQuery($e);
+    if ($e->mapping->getEntity() === $this->getExtendableTableName()) {
+      $e->query->select('e.event_id AS tokenContext_eventId');
+    }
+  }
+
   /**
    * @inheritDoc
    * @throws \CiviCRM_API3_Exception
    */
   public function evaluateToken(TokenRow $row, $entity, $field, $prefetch = NULL) {
     $this->prefetch = (array) $prefetch;
-    if (empty($row->context['eventId'])) {
-      $row->context['eventId'] = $this->getFieldValue($row, 'event_id');
-    }
     if ($field === 'balance') {
       // @todo - is this really a good idea to call this & potentially get the
       // balance of the contribution attached to 'registered_by_id'

--- a/CRM/Event/Tokens.php
+++ b/CRM/Event/Tokens.php
@@ -92,9 +92,6 @@ class CRM_Event_Tokens extends CRM_Core_EntityTokens {
    */
   public function evaluateToken(TokenRow $row, $entity, $field, $prefetch = NULL) {
     $eventID = $this->getFieldValue($row, 'id');
-    if (!$eventID) {
-      $eventID = $row->context['actionSearchResult']->event_id;
-    }
     if (array_key_exists($field, $this->getEventTokenValues($eventID))) {
       foreach ($this->getEventTokenValues($eventID)[$field] as $format => $value) {
         $row->format($format)->tokens($entity, $field, $value ?? '');


### PR DESCRIPTION
Overview
--------

When sending a scheduled reminder for a `civicrm_participant` record, it supports tokens for both `{participant.*}` (`$context['participantId']`) and `{event.*}` (`$context['eventId']`). This creates a special requirement to load the `eventId`
in addition to the `participantId`.

This patch changes the way in which `eventId` is loaded.

Before
------

In `ParticipantToken`, the token-evaluation-step for `{participant.*}` tokens has a side-effect of setting `$context['eventId']` based on data from `actionSearchResult` (although this appears slightly indirect).

After
-----

The action-search returns `tokenContext_eventId`, which automatically maps to `$context['eventId']`.

This means that the `eventId` will be set before evaluation begins.

