### PR TITLE
Use preferred entity name (Website not website)

### DIFF
--- a/CRM/Contact/Tokens.php
+++ b/CRM/Contact/Tokens.php
@@ -382,7 +382,7 @@ class CRM_Contact_Tokens extends CRM_Core_EntityTokens {
     }
 
     foreach ($this->getRelatedEntityTokenMetadata() as $entity => $exposedFields) {
-      $apiEntity = ($entity === 'openid') ? 'OpenID' : $entity;
+      $apiEntity = ($entity === 'openid') ? 'OpenID' : ucfirst($entity);
       $metadata = (array) civicrm_api4($apiEntity, 'getfields', ['checkPermissions' => FALSE], 'name');
       foreach ($metadata as $field) {
         $this->addFieldToTokenMetadata($field, $exposedFields, 'primary_' . $entity);


### PR DESCRIPTION
Overview
----------------------------------------
Use preferred entity name (Website not website) in getfields call

Before
----------------------------------------
Calls to `civicrm_api4('website', 'getfields', [])` are failing post caching fixes @colemanw worked on yesterday - with Website being required. I think this should be dealt with in the caching layer but it is ALSO best practice to use ucfirst so I think we should make this change in the meantime. I think this change is probably variable but I'm getting an error trying to send emails via the task

![image](https://user-images.githubusercontent.com/336308/137205063-e66a4a8e-1795-415c-b9a2-5e7d60c88f6c.png)



After
----------------------------------------
Working now - 

Technical Details
----------------------------------------

Comments
----------------------------------------

