### PR TITLE
Fix translation regression in recurring edit workflow template

### DIFF
--- a/CRM/Contribute/WorkflowMessage/RecurringEdit.php
+++ b/CRM/Contribute/WorkflowMessage/RecurringEdit.php
@@ -59,7 +59,7 @@ class CRM_Contribute_WorkflowMessage_RecurringEdit extends Civi\WorkflowMessage\
   protected function exportExtraTokenContext(array &$export): void {
     $export['smartyTokenAlias']['installments'] = 'contribution_recur.installments';
     $export['smartyTokenAlias']['amount'] = 'contribution_recur.amount';
-    $export['smartyTokenAlias']['recur_frequency_unit'] = 'contribution_recur.frequency_unit';
+    $export['smartyTokenAlias']['recur_frequency_unit'] = 'contribution_recur.frequency_unit:label';
     $export['smartyTokenAlias']['recur_frequency_interval'] = 'contribution_recur.frequency_interval';
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Fix translation regression in recurring edit workflow template

Before
----------------------------------------
the frequency unit placed in the template is the db value

After
----------------------------------------
the frequency unit placed in the template is the label

Technical Details
----------------------------------------
@totten 

Comments
----------------------------------------
