### PR TITLE
Stop flushing caches on enable civiCampaign

### DIFF
--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -1778,18 +1778,9 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
 
   /**
    * Enable CiviCampaign Component.
-   *
-   * @param bool $reloadConfig
-   *    Force relaod config or not
    */
-  public function enableCiviCampaign($reloadConfig = TRUE) {
+  public function enableCiviCampaign(): void {
     CRM_Core_BAO_ConfigSetting::enableComponent('CiviCampaign');
-    if ($reloadConfig) {
-      // force reload of config object
-      $config = CRM_Core_Config::singleton(TRUE, TRUE);
-    }
-    //flush cache by calling with reset
-    $activityTypes = CRM_Core_PseudoConstant::activityType(TRUE, TRUE, TRUE, 'name', TRUE);
   }
 
   /**


### PR DESCRIPTION

Overview
----------------------------------------
Stop flushing caches on enable civiCampaign

Before
----------------------------------------
Over aggressive cache clearing - blows away hook config

After
----------------------------------------
Hopefully better

Technical Details
----------------------------------------
We should be able to get the 'right' cache clearing via the core function.

Comments
----------------------------------------
