### PR TITLE
Restrict "Oops" to administrative errors

### DIFF
--- a/CRM/Campaign/Form/Gotv.php
+++ b/CRM/Campaign/Form/Gotv.php
@@ -137,7 +137,7 @@ class CRM_Campaign_Form_Gotv extends CRM_Core_Form {
 
     $surveys = CRM_Campaign_BAO_Survey::getSurveys();
     if (empty($surveys)) {
-      $errorMessages[] = ts("Oops. It looks like no surveys have been created. <a href='%1'>Click here to create a new survey.</a>", [1 => CRM_Utils_System::url('civicrm/survey/add', 'reset=1&action=add')]);
+      $errorMessages[] = ts("It looks like no surveys have been created yet. <a %1>Click here to create a new survey.</a>", [1 => 'href="' . CRM_Utils_System::url('civicrm/survey/add', 'reset=1&action=add') . '"']);
     }
 
     if ($this->_force && !$this->_surveyId) {

--- a/CRM/Event/Form/Registration/ParticipantConfirm.php
+++ b/CRM/Event/Form/Registration/ParticipantConfirm.php
@@ -101,7 +101,7 @@ class CRM_Event_Form_Registration_ParticipantConfirm extends CRM_Event_Form_Regi
       $additonalIds = CRM_Event_BAO_Participant::getAdditionalParticipantIds($this->_participantId);
       $requireSpace = 1 + count($additonalIds);
       if ($emptySeats !== NULL && ($requireSpace > $emptySeats)) {
-        $statusMsg = ts("Oops, it looks like there are currently no available spaces for the %1 event.", [1 => $values['title']]);
+        $statusMsg = ts("Unfortunately there are currently no available spaces for the %1 event.", [1 => $values['title']]);
       }
       else {
         if ($this->_cc == 'fail') {
@@ -143,7 +143,7 @@ class CRM_Event_Form_Registration_ParticipantConfirm extends CRM_Event_Form_Regi
       }
     }
     if (!$statusMsg) {
-      $statusMsg = ts("Oops, it looks like your registration for %1 has already been cancelled.",
+      $statusMsg = ts("Your registration for %1 has already been cancelled. No further action is needed.",
         [1 => $values['title']]
       );
     }

--- a/CRM/Event/Form/Registration/Register.php
+++ b/CRM/Event/Form/Registration/Register.php
@@ -840,7 +840,7 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
       is_array($form->_additionalParticipantIds) &&
       $numberAdditionalParticipants > count($form->_additionalParticipantIds)
     ) {
-      $errors['additional_participants'] = ts("Oops. It looks like you are trying to increase the number of additional people you are registering for. You can confirm registration for a maximum of %1 additional people.", [1 => count($form->_additionalParticipantIds)]);
+      $errors['additional_participants'] = ts("It looks like you are trying to increase the number of additional people you are registering for. You can confirm registration for a maximum of %1 additional people.", [1 => count($form->_additionalParticipantIds)]);
     }
 
     //don't allow to register w/ waiting if enough spaces available.
@@ -848,7 +848,7 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
       if (!is_numeric($form->_availableRegistrations) ||
         (empty($fields['priceSetId']) && CRM_Utils_Array::value('additional_participants', $fields) < $form->_availableRegistrations)
       ) {
-        $errors['bypass_payment'] = ts("Oops. There are enough available spaces in this event. You can not add yourself to the waiting list.");
+        $errors['bypass_payment'] = ts("You have not been added to the waiting list because there are spaces available for this event. We recommend registering yourself for an available space instead.");
       }
     }
 
@@ -1227,7 +1227,7 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
               $status = ts("It looks like you are already registered for this event. If you want to change your registration, or you feel that you've received this message in error, please contact the site administrator.");
             }
             $status .= ' ' . ts('You can also <a href="%1">register another participant</a>.', [1 => $registerUrl]);
-            CRM_Core_Session::singleton()->setStatus($status, ts('Oops.'), 'alert');
+            CRM_Core_Session::singleton()->setStatus($status, '', 'alert');
             $url = CRM_Utils_System::url('civicrm/event/info',
               "reset=1&id={$form->_values['event']['id']}&noFullMsg=true"
             );
@@ -1244,7 +1244,7 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
 
           if ($isAdditional) {
             $status = ts("It looks like this participant is already registered for this event. If you want to change your registration, or you feel that you've received this message in error, please contact the site administrator.");
-            CRM_Core_Session::singleton()->setStatus($status, ts('Oops.'), 'alert');
+            CRM_Core_Session::singleton()->setStatus($status, '', 'alert');
             return $participant->id;
           }
         }

--- a/templates/CRM/Campaign/Page/Petition/Confirm.tpl
+++ b/templates/CRM/Campaign/Page/Petition/Confirm.tpl
@@ -12,7 +12,7 @@
     {if $success}
         {ts 1=$display_name 2=$email}<strong>%1 - your email address '%2' has been successfully verified.</strong>{/ts}
     {else}
-        {ts}Oops. We encountered a problem in processing your email verification. Please contact the site administrator.{/ts}
+        {ts}Unfortunately we encountered a problem in processing your email verification. Please contact the site administrator.{/ts}
     {/if}
 </div>
 

--- a/templates/CRM/Case/Page/Tab.tpl
+++ b/templates/CRM/Case/Page/Tab.tpl
@@ -13,7 +13,7 @@
 {elseif $redirectToCaseAdmin}
     <div class="messages status no-popup">
       {icon icon="fa-info-circle"}{/icon}
-         <strong>{ts}Oops, It looks like there are no active case types.{/ts}</strong>
+         <strong>{ts}It looks like there are no active case types yet.{/ts}</strong>
            {if call_user_func(array('CRM_Core_Permission','check'), ' administer CiviCase')}
              {capture assign=adminCaseTypeURL}{crmURL p='civicrm/a/#/caseType'}
        {/capture}

--- a/templates/CRM/Mailing/Page/Confirm.tpl
+++ b/templates/CRM/Mailing/Page/Confirm.tpl
@@ -12,6 +12,6 @@
 {if $success}
       {ts 1=$display_name 2=$email 3=$group}<strong>%1 (%2)</strong> has been successfully subscribed to the <strong>%3</strong> mailing list.{/ts}
 {else}
-      {ts}Oops. We encountered a problem in processing your subscription confirmation. Please contact the site administrator.{/ts}
+      {ts}Unfortunately we encountered a problem in processing your subscription confirmation. Please contact the site administrator.{/ts}
 {/if}
 </div>


### PR DESCRIPTION
Overview
----------------------------------------
Addresses [this issue on Lab](https://lab.civicrm.org/dev/core/-/issues/2917).

Before
----------------------------------------
Inappropriate (in my opinion) usage of "Oops".

After
----------------------------------------
Usage of "Oops" restricted to actual errors. Language elsewhere modified.