### PR TITLE
Load the API kernel service prior to dispatching the `civi.api4.createRequest` event when creating an API4 request

### DIFF
--- a/Civi/API/Request.php
+++ b/Civi/API/Request.php
@@ -45,6 +45,10 @@ class Request {
         ];
 
       case 4:
+        // Load the API kernel service for registering API providers, as
+        // otherwise subscribers to the civi.api4.createRequest event registered
+        // through the EventSubscriberInterface will not be registered.
+        $kernel = \Civi::service('civi_api_kernel');
         $e = new CreateApi4RequestEvent($entity);
         \Civi::dispatcher()->dispatch('civi.api4.createRequest', $e);
         $callable = [$e->className, $action];


### PR DESCRIPTION
Overview
----------------------------------------
Follow-up to #21771 for registering `EventSubscriberInterface` implementations prior to dispatching the `civi.api4.createRequest` event. 

Before
----------------------------------------
When issueing an API4 request without having loaded the API kernel service (e.g. invoking the API4 via an Ajax request using `CRM.api4()`), the `civi.api4.createRequest` event will not be dispatched with all event subscribers, because the ones registering through an `EventSubscriberInterface` implementation are only being called when _executing_ the request, as the API kernel service is not being loaded until then.

After
----------------------------------------
The event is being dispatched with all event subscribers.

Technical Details
----------------------------------------
This problem only occurs when no other API call has been issued before the API4 call, but API4 explorer fails for entities relying on their `EventSubscriberInterface` implementation when issueing API4 requests via Ajax.

Comments
----------------------------------------
This should go into `5.43` along with the original implementation of the `civi.api4.createRequest` event.