### PR TITLE
(dev/core#2903) Remove reference to CiviCRM forum in HTTP error message

### DIFF
--- a/CRM/Extension/Browser.php
+++ b/CRM/Extension/Browser.php
@@ -243,7 +243,7 @@ class CRM_Extension_Browser {
     restore_error_handler();
 
     if ($status !== CRM_Utils_HttpClient::STATUS_OK) {
-      throw new CRM_Extension_Exception(ts('The CiviCRM public extensions directory at %1 could not be contacted - please check your webserver can make external HTTP requests or contact CiviCRM team on <a href="http://forum.civicrm.org/">CiviCRM forum</a>.', array(1 => $this->getRepositoryUrl())), 'connection_error');
+      throw new CRM_Extension_Exception(ts('The CiviCRM public extensions directory at %1 could not be contacted - please check your webserver can make external HTTP requests. Contact your site administrator for assistance.'), 'connection_error');
     }
 
     // Don't call grabCachedJson here, that would risk infinite recursion


### PR DESCRIPTION
Overview
----------------------------------------
Replace with instruction to contact the site administrator for assistance.
https://lab.civicrm.org/dev/core/-/issues/2903

Before
----------------------------------------
The error message referenced the CiviCRM forums, which have been dormant for several years:

> The CiviCRM public extensions directory at %1 could not be contacted - please check your webserver can make external HTTP requests or contact CiviCRM team on [CiviCRM forum](http://forum.civicrm.org/)

After
----------------------------------------
The error message no longer references the CiviCRM forums.

Comments
----------------------------------------
The new wording has been led by suggestions from @jaapjansma on https://lab.civicrm.org/dev/core/-/issues/2903
