### PR TITLE
dev/core#2876 - When installing an extension that has requirements, show the name not the key

### DIFF
--- a/CRM/Extension/Downloader.php
+++ b/CRM/Extension/Downloader.php
@@ -75,9 +75,11 @@ class CRM_Extension_Downloader {
       $requiredExtensions = CRM_Extension_System::singleton()->getManager()->findInstallRequirements([$extensionInfo->key], $extensionInfo);
       foreach ($requiredExtensions as $extension) {
         if (CRM_Extension_System::singleton()->getManager()->getStatus($extension) !== CRM_Extension_Manager::STATUS_INSTALLED && $extension !== $extensionInfo->key) {
+          $requiredExtensionInfo = CRM_Extension_System::singleton()->getBrowser()->getExtension($extension);
+          $requiredExtensionInfoName = empty($requiredExtensionInfo->name) ? $extension : $requiredExtensionInfo->name;
           $errors[] = [
             'title' => ts('Missing Requirement: %1', [1 => $extension]),
-            'message' => ts('You will not be able to install/upgrade %1 until you have installed the %2 extension.', [1 => $extensionInfo->key, 2 => $extension]),
+            'message' => ts('You will not be able to install/upgrade %1 until you have installed the %2 extension.', [1 => $extensionInfo->name, 2 => $requiredExtensionInfoName]),
           ];
         }
       }


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/2876

A few months ago the extension screen was changed to show names and hide the keys, but the error message still shows the key.

Before
----------------------------------------
1. Go to install e.g. Stripe (just using as an example - anything that has required extensions that aren't installed yet)
1. It gives a message:
    <img width="256" alt="before1" src="https://user-images.githubusercontent.com/2967821/137753004-10aed949-2521-4a47-bd9a-76902e941182.png">
1. Ok now try to find `mjwshared`. You can't because in the list it's called Payment Shared.
    <img width="108" alt="before2" src="https://user-images.githubusercontent.com/2967821/137753291-123670fb-e119-47b5-b5e3-af7bb77dfc29.png">

After
----------------------------------------
<img width="258" alt="after1" src="https://user-images.githubusercontent.com/2967821/137753349-2fbac671-bd38-4519-9729-bbc02d2a96bf.png">


Technical Details
----------------------------------------


Comments
----------------------------------------

