### PR TITLE
dev/core#2919 Hidden submit buttons are confussing for keyboard users

### DIFF
--- a/js/crm.ajax.js
+++ b/js/crm.ajax.js
@@ -511,6 +511,7 @@
           var $el = $(this),
             label = $el.is('input') ? $el.attr('value') : $el.text(),
             identifier = $el.attr('name') || $el.attr('href');
+          $el.attr('tabindex', '-1');
           if (!identifier || identifier === '#' || $.inArray(identifier, added) < 0) {
             var $icon = $el.find('.icon, .crm-i'),
               button = {'data-identifier': identifier, text: label, click: function() {
@@ -526,7 +527,7 @@
             added.push(identifier);
           }
           // display:none causes the form to not submit when pressing "enter"
-          $el.parents(buttonContainers).css({height: 0, padding: 0, margin: 0, overflow: 'hidden'});
+          $el.parents(buttonContainers).css({height: 0, padding: 0, margin: 0, overflow: 'hidden'}).attr('aria-hidden', 'true');
         });
         $el.dialog('option', 'buttons', buttons);
       }


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/2919

Adds tabindex="-1" to hidden buttons, as hidden items should not be focussable.

As the elements are not focussable and repeated in the modal footer, aria-hidden is also applied.

Before
----------------------------------------
The experience for keyboard users was confusing, and potentially dangerous if a hidden element was focussed and triggered.

After
----------------------------------------
Hidden elements in modal dialogs cannot be focussed, and are also hidden from asssitive technology. (The visible buttons remain focussable and availble to assistive technology).

