### PR TITLE
APIv4 - Add 'match' param to save action

### DIFF
--- a/Civi/Api4/Generic/AbstractAction.php
+++ b/Civi/Api4/Generic/AbstractAction.php
@@ -281,8 +281,13 @@ abstract class AbstractAction implements \ArrayAccess {
       foreach ($this->reflect()->getProperties(\ReflectionProperty::IS_PROTECTED) as $property) {
         $name = $property->getName();
         if ($name != 'version' && $name[0] != '_') {
-          $this->_paramInfo[$name] = ReflectionUtils::getCodeDocs($property, 'Property', $vars);
-          $this->_paramInfo[$name]['default'] = $defaults[$name];
+          $docs = ReflectionUtils::getCodeDocs($property, 'Property', $vars);
+          $docs['default'] = $defaults[$name];
+          if (!empty($docs['optionsCallback'])) {
+            $docs['options'] = $this->{$docs['optionsCallback']}();
+            unset($docs['optionsCallback']);
+          }
+          $this->_paramInfo[$name] = $docs;
         }
       }
     }

--- a/Civi/Api4/Generic/BasicSaveAction.php
+++ b/Civi/Api4/Generic/BasicSaveAction.php
@@ -56,6 +56,7 @@ class BasicSaveAction extends AbstractSaveAction {
     foreach ($this->records as &$record) {
       $record += $this->defaults;
       $this->formatWriteValues($record);
+      $this->matchExisting($record);
     }
     $this->validateValues();
     foreach ($this->records as $item) {

--- a/Civi/Api4/Generic/DAOSaveAction.php
+++ b/Civi/Api4/Generic/DAOSaveAction.php
@@ -25,6 +25,7 @@ class DAOSaveAction extends AbstractSaveAction {
     foreach ($this->records as &$record) {
       $record += $this->defaults;
       $this->formatWriteValues($record);
+      $this->matchExisting($record);
       if (empty($record['id'])) {
         $this->fillDefaults($record);
       }

--- a/ang/api4Explorer/Explorer.html
+++ b/ang/api4Explorer/Explorer.html
@@ -98,8 +98,11 @@
           </div>
           <div class="api4-input" ng-mouseenter="help(name, param)" ng-mouseleave="help()" ng-repeat="(name, param) in ::getGenericParams(['array', 'mixed'])">
             <label for="api4-param-{{:: name }}">{{:: name }}<span class="crm-marker" ng-if="::param.required"> *</span></label>
-            <textarea class="form-control" type="{{:: param.type[0] === 'int' && param.type.length === 1 ? 'number' : 'text' }}" id="api4-param-{{:: name }}" ng-model="params[name]">
+            <textarea class="form-control" ng-if="::!param.options" id="api4-param-{{:: name }}" ng-model="params[name]">
             </textarea>
+            <select multiple ng-if="::param.options" crm-ui-select class="form-control" id="api4-param-{{:: name }}" ng-model="params[name]">
+              <option ng-repeat="opt in param.options" value="{{ opt }}">{{ opt }}</option>
+            </select>
           </div>
           <fieldset ng-if="::availableParams.where" class="api4-clause-fieldset" ng-mouseenter="help('where', availableParams.where)" ng-mouseleave="help()">
             <crm-api4-clause clauses="params.where" is-required="availableParams.where.required" op="AND" label="Where" fields="fieldsAndJoins" ></crm-api4-clause>

--- a/tests/phpunit/api/v4/Action/SaveTest.php
+++ b/tests/phpunit/api/v4/Action/SaveTest.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+
+namespace api\v4\Action;
+
+use api\v4\UnitTestCase;
+use Civi\Api4\Contact;
+
+/**
+ * @group headless
+ */
+class SaveTest extends UnitTestCase {
+
+  public function testSaveWithMatchingCriteria() {
+    $records = [
+      ['first_name' => 'One', 'last_name' => 'Test', 'external_identifier' => 'abc'],
+      ['first_name' => 'Two', 'last_name' => 'Test', 'external_identifier' => 'def'],
+    ];
+
+    $contacts = Contact::save(FALSE)
+      ->setRecords($records)
+      ->execute();
+
+    $records[0]['last_name'] = $records[1]['last_name'] = 'Changed';
+    $records[0]['external_identifier'] = 'ghi';
+
+    $modified = Contact::save(FALSE)
+      ->setRecords($records)
+      ->setMatch(['first_name', 'external_identifier'])
+      ->execute();
+
+    $this->assertGreaterThan($contacts[0]['id'], $modified[0]['id']);
+    $this->assertEquals($contacts[1]['id'], $modified[1]['id']);
+
+    $ids = [$contacts[0]['id'], $modified[0]['id'], $contacts[1]['id']];
+    $get = Contact::get(FALSE)
+      ->setSelect(['id', 'first_name', 'last_name', 'external_identifier'])
+      ->addWhere('id', 'IN', $ids)
+      ->addOrderBy('id')
+      ->execute();
+    $expected = [
+      // Original insert
+      ['id' => $contacts[0]['id'], 'first_name' => 'One', 'last_name' => 'Test', 'external_identifier' => 'abc'],
+      // Match+update
+      ['id' => $contacts[1]['id'], 'first_name' => 'Two', 'last_name' => 'Changed', 'external_identifier' => 'def'],
+      // Subsequent insert
+      ['id' => $modified[0]['id'], 'first_name' => 'One', 'last_name' => 'Changed', 'external_identifier' => 'ghi'],
+    ];
+    $this->assertEquals($expected, (array) $get);
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Adds a new `'match'` param to APIv4 `save` which works similarly to `'options.match'` in v3 `create`.
It checks for records matching the given fields, and will update instead of create if a matching record is found.

Before
------------
The `save` action decides whether to create or update each record based on the presence of `id` (or whatever the primary key field is for that entity; it's usually "id").

After
------------
In addition to matching by `id`, the `save` action can match by one or more unique fields like `external_identifier` or `name`.

Technical Details
----------------------------------
APIv3 has both `options.match` and `options.match_mandatory`. I don't think that's necessary for APIv4 because the `update` action is already the equivalent of `match_mandatory` (it only updates records that match the `where` criteria).

This fills the use-case where you want to create or update records given some combination of unique fields other than `id`. Some common examples of other unique fields and unique field combos would be: `[name]`, `[entity_table, entity_id]`, `[external_identifier]`, `[option_group_id, name]`.