### PR TITLE
Add <earlier_x.unit> relative date operator

### DIFF
--- a/CRM/Utils/Date.php
+++ b/CRM/Utils/Date.php
@@ -1517,12 +1517,20 @@ class CRM_Utils_Date {
                 break;
 
               case 'earlier':
-                $to['d'] = $now['mday'];
-                $to['M'] = $now['mon'];
-                $to['Y'] = $now['year'];
-                $to['H'] = 00;
-                $to['i'] = $to['s'] = 00;
-                $to = self::intervalAdd($unit, -$relativeTermSuffix, $to);
+                $quarterDifference = ceil($now['mon'] / 3) - $relativeTermSuffix;
+                $subtractYear = 0;
+                if ($quarterDifference <= 0) {
+                  $subtractYear = intdiv(abs($quarterDifference), 4) + 1;
+                  $quarter = ($quarterDifference % 4) + 4;
+                }
+                else {
+                  $quarter = $quarterDifference;
+                }
+                $to['M'] = 3 * $quarter;
+                $to['Y'] = $now['year'] - $subtractYear;
+                $to['d'] = date('t', mktime(0, 0, 0, $to['M'], 1, $to['Y']));
+                $to['H'] = 23;
+                $to['i'] = $to['s'] = 59;
                 unset($from);
                 break;
             }

--- a/CRM/Utils/Date.php
+++ b/CRM/Utils/Date.php
@@ -1258,6 +1258,16 @@ class CRM_Utils_Date {
                   $from['Y'] -= ($relativeTermSuffix - 1);
                 }
                 break;
+
+              case 'earlier':
+                $to['d'] = $now['mday'];
+                $to['M'] = $now['mon'];
+                $to['Y'] = $now['year'];
+                $to['H'] = 00;
+                $to['i'] = $to['s'] = 00;
+                $to = self::intervalAdd($unit, -$relativeTermSuffix, $to);
+                unset($from);
+                break;
             }
             break;
         }
@@ -1495,15 +1505,28 @@ class CRM_Utils_Date {
             break;
 
           default:
-            if ($relativeTermPrefix === 'ending') {
-              $to['d'] = $now['mday'];
-              $to['M'] = $now['mon'];
-              $to['Y'] = $now['year'];
-              $to['H'] = 23;
-              $to['i'] = $to['s'] = 59;
-              $from = self::intervalAdd('month', -($relativeTermSuffix * 3), $to);
-              $from = self::intervalAdd('second', 1, $from);
+            switch ($relativeTermPrefix) {
+              case 'ending':
+                $to['d'] = $now['mday'];
+                $to['M'] = $now['mon'];
+                $to['Y'] = $now['year'];
+                $to['H'] = 23;
+                $to['i'] = $to['s'] = 59;
+                $from = self::intervalAdd('month', -($relativeTermSuffix * 3), $to);
+                $from = self::intervalAdd('second', 1, $from);
+                break;
+
+              case 'earlier':
+                $to['d'] = $now['mday'];
+                $to['M'] = $now['mon'];
+                $to['Y'] = $now['year'];
+                $to['H'] = 00;
+                $to['i'] = $to['s'] = 00;
+                $to = self::intervalAdd($unit, -$relativeTermSuffix, $to);
+                unset($from);
+                break;
             }
+            break;
         }
         break;
 
@@ -1675,15 +1698,28 @@ class CRM_Utils_Date {
             break;
 
           default:
-            if ($relativeTermPrefix === 'ending') {
-              $to['d'] = $now['mday'];
-              $to['M'] = $now['mon'];
-              $to['Y'] = $now['year'];
-              $to['H'] = 23;
-              $to['i'] = $to['s'] = 59;
-              $from = self::intervalAdd($unit, -$relativeTermSuffix, $to);
-              $from = self::intervalAdd('second', 1, $from);
+            switch ($relativeTermPrefix) {
+              case 'ending':
+                $to['d'] = $now['mday'];
+                $to['M'] = $now['mon'];
+                $to['Y'] = $now['year'];
+                $to['H'] = 23;
+                $to['i'] = $to['s'] = 59;
+                $from = self::intervalAdd($unit, -$relativeTermSuffix, $to);
+                $from = self::intervalAdd('second', 1, $from);
+                break;
+
+              case 'earlier':
+                $to['d'] = $now['mday'];
+                $to['M'] = $now['mon'];
+                $to['Y'] = $now['year'];
+                $to['H'] = 00;
+                $to['i'] = $to['s'] = 00;
+                $to = self::intervalAdd($unit, -$relativeTermSuffix, $to);
+                unset($from);
+                break;
             }
+            break;
         }
         break;
 
@@ -1803,15 +1839,28 @@ class CRM_Utils_Date {
             break;
 
           default:
-            if ($relativeTermPrefix === 'ending') {
-              $to['d'] = $now['mday'];
-              $to['M'] = $now['mon'];
-              $to['Y'] = $now['year'];
-              $to['H'] = 23;
-              $to['i'] = $to['s'] = 59;
-              $from = self::intervalAdd($unit, -$relativeTermSuffix, $to);
-              $from = self::intervalAdd('second', 1, $from);
+            switch ($relativeTermPrefix) {
+              case 'ending':
+                $to['d'] = $now['mday'];
+                $to['M'] = $now['mon'];
+                $to['Y'] = $now['year'];
+                $to['H'] = 23;
+                $to['i'] = $to['s'] = 59;
+                $from = self::intervalAdd($unit, -$relativeTermSuffix, $to);
+                $from = self::intervalAdd('second', 1, $from);
+                break;
+
+              case 'earlier':
+                $to['d'] = $now['mday'];
+                $to['M'] = $now['mon'];
+                $to['Y'] = $now['year'];
+                $to['H'] = 00;
+                $to['i'] = $to['s'] = 00;
+                $to = self::intervalAdd($unit, -$relativeTermSuffix, $to);
+                unset($from);
+                break;
             }
+            break;
         }
         break;
 
@@ -1877,15 +1926,28 @@ class CRM_Utils_Date {
             break;
 
           default:
-            if ($relativeTermPrefix === 'ending') {
-              $to['d'] = $now['mday'];
-              $to['M'] = $now['mon'];
-              $to['Y'] = $now['year'];
-              $to['H'] = 23;
-              $to['i'] = $to['s'] = 59;
-              $from = self::intervalAdd($unit, -$relativeTermSuffix, $to);
-              $from = self::intervalAdd('second', 1, $from);
+            switch ($relativeTermPrefix) {
+              case 'ending':
+                $to['d'] = $now['mday'];
+                $to['M'] = $now['mon'];
+                $to['Y'] = $now['year'];
+                $to['H'] = 23;
+                $to['i'] = $to['s'] = 59;
+                $from = self::intervalAdd($unit, -$relativeTermSuffix, $to);
+                $from = self::intervalAdd('second', 1, $from);
+                break;
+
+              case 'earlier':
+                $to['d'] = $now['mday'];
+                $to['M'] = $now['mon'];
+                $to['Y'] = $now['year'];
+                $to['H'] = 00;
+                $to['i'] = $to['s'] = 00;
+                $to = self::intervalAdd($unit, -$relativeTermSuffix, $to);
+                unset($from);
+                break;
             }
+            break;
         }
         break;
     }

--- a/tests/phpunit/CRM/Utils/DateTest.php
+++ b/tests/phpunit/CRM/Utils/DateTest.php
@@ -324,4 +324,33 @@ class CRM_Utils_DateTest extends CiviUnitTestCase {
     }
   }
 
+  /**
+   * Test relativeToAbsolute function for "earlier_x.<unit>" operator
+   *
+   * "from" must be empty
+   * "to" must be today - x units at 00:00:00
+   */
+  public function testRelativeEarlierX() {
+    $relativeDateValues = [
+      'earlier_2.day' => '- 2 days',
+      'earlier_15.day' => '- 15 days',
+      'earlier_1.week' => '- 1 week',
+      'earlier_6.week' => '- 6 week',
+      'earlier_3.month' => '- 3 month',
+      'earlier_6.month' => '- 6 month',
+      'earlier_4.year' => '- 4 year',
+      'earlier_10.year' => '- 10 year',
+    ];
+
+    foreach ($relativeDateValues as $key => $value) {
+      $parts = explode('.', $key);
+      $date = CRM_Utils_Date::relativeToAbsolute($parts[0], $parts[1]);
+      $this->assertEquals([
+        'from' => NULL,
+        'to' => date('Ymd000000', strtotime($value)),
+      ], $date, 'relative term is ' . $key);
+    }
+
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Adds a new (configurable) relative date operator based on `earlier_x.[unit]` notation. Now this operator is not supported and only *1 unit*  fixed operators are available, as `earlier.day`, `earlier.week `, `earlier.month`, `earlier.quarter`, `earlier.year`.

`[unit]` is one of these options:
- day
- week
- month
- year
- quarter

With this PR a new operator can be created as `OptionValue` for `relative_date_filters` group like `earlier_6.month`, `earlier_3.year`, `earlier_5.week` to get everything before that relative date in the past

Before
----------------------------------------
Relative date operator `earlier_x.[unit]` is not processed

After
----------------------------------------
Custom date operators created in Civi as `OptionValues` with the format `earlier_x.[unit]` can be precessed.

Technical Details
----------------------------------------
UnitTest included
