### PR TITLE
SearchKit - add/remove tags action for all taggable entities

### DIFF
--- a/ext/search_kit/ang/crmSearchTasks/crmSearchTaskTag.ctrl.js
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchTaskTag.ctrl.js
@@ -1,0 +1,99 @@
+(function(angular, $, _) {
+  "use strict";
+
+  angular.module('crmSearchTasks').controller('crmSearchTaskTag', function($scope, crmApi4, searchTaskBaseTrait) {
+    var ts = $scope.ts = CRM.ts('org.civicrm.search_kit'),
+      // Combine this controller with model properties (ids, entity, entityInfo) and searchTaskBaseTrait
+      ctrl = angular.extend(this, $scope.model, searchTaskBaseTrait);
+
+    this.entityTitle = this.getEntityTitle();
+    this.action = 'save';
+    this.selection = [];
+    this.selectedTags = [];
+    this.selectedTagsetTags = {};
+
+    crmApi4({
+      tags: ['Tag', 'get', {
+        select: ['id', 'name', 'color', 'description', 'is_selectable', 'parent_id'],
+        where: [
+          ['is_tagset', '=', false],
+          ['used_for:name', 'CONTAINS', this.entity],
+          ['OR', [['parent_id', 'IS NULL'], ['parent_id.is_tagset', '=', false]]]
+        ],
+        orderBy: {name: 'ASC'}
+      }],
+      tagsets: ['Tag', 'get', {
+        select: ['id', 'name'],
+        where: [['is_tagset', '=', true], ['used_for:name', 'CONTAINS', this.entity]]
+      }],
+    }).then(function(result) {
+      ctrl.tagsets = result.tagsets;
+      ctrl.tags = sortTagsForSelect2(result.tags);
+    });
+
+    // Sort non-tagset tags into a nested hierarchy
+    function sortTagsForSelect2(rawTags) {
+      var sorted = _.transform(rawTags, function(sorted, tag) {
+        sorted[tag.id] = {
+          id: tag.id,
+          text: tag.name,
+          description: tag.description,
+          color: tag.color,
+          disabled: !tag.is_selectable,
+          parent_id: tag.parent_id
+        };
+      }, {});
+      // Capitalizing on the fact that javascript objects always copy-by-reference,
+      // this creates a multi-level hierarchy in a single pass by placing child tags under their parents
+      // while keeping a reference to children at the top level (which allows them to receive children of their own).
+      _.each(sorted, function(tag) {
+        if (tag.parent_id && sorted[tag.parent_id]) {
+          sorted[tag.parent_id].children = sorted[tag.parent_id].children || [];
+          sorted[tag.parent_id].children.push(tag);
+        }
+      });
+      // Remove the child tags from the top level, and what remains is a nested hierarchy
+      return _.filter(sorted, {parent_id: null});
+    }
+
+    this.saveTags = function() {
+      var params = {};
+      if (ctrl.action === 'save') {
+        params.defaults = {
+          'entity_table:name': ctrl.entity
+        };
+        params.records = _.transform(ctrl.selection, function(records, tagId) {
+          records.push({tag_id: tagId});
+        });
+      } else {
+        params.where = [
+          ['entity_table:name', '=', ctrl.entity],
+          ['tag_id', 'IN', ctrl.selection]
+        ];
+      }
+      ctrl.start(params);
+    };
+
+    this.onSelectTags = function() {
+      ctrl.selection = _.cloneDeep(ctrl.selectedTags);
+      _.each(ctrl.selectedTagsetTags, function(set) {
+        ctrl.selection = ctrl.selection.concat(set);
+      });
+    };
+
+    this.onSuccess = function() {
+      if (ctrl.action === 'delete') {
+        CRM.alert(ts('Removed tags from %1 %2.', {1: ctrl.ids.length, 2: ctrl.entityTitle}), ts('Saved'), 'success');
+      } else {
+        CRM.alert(ts('Added tags to %1 %2.', {1: ctrl.ids.length, 2: ctrl.entityTitle}), ts('Saved'), 'success');
+      }
+      this.close();
+    };
+
+    this.onError = function() {
+      CRM.alert(ts('An error occurred while updating tags.'), ts('Error'), 'error');
+      this.cancel();
+    };
+
+  });
+})(angular, CRM.$, CRM._);

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchTaskTag.html
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchTaskTag.html
@@ -1,0 +1,57 @@
+<div id="bootstrap-theme">
+  <form ng-controller="crmSearchTaskTag as $ctrl">
+    <div class="form-radios">
+      <label ng-class="{disabled: !!$ctrl.run}">
+        <input type="radio" name="action" ng-model="$ctrl.action" value="save" ng-disabled="$ctrl.run">
+        {{:: ts('Add Tags') }}
+      </label>
+      <label ng-class="{disabled: !!$ctrl.run}">
+        <input type="radio" name="action" ng-model="$ctrl.action" value="delete" ng-disabled="$ctrl.run">
+        {{:: ts('Remove Tags') }}
+      </label>
+    </div>
+    <div ng-if="!$ctrl.tags">
+      <i class="crm-i fa-spinner fa-spin"></i>
+    </div>
+    <hr />
+    <fieldset ng-if="$ctrl.tags">
+      <div class="form-inline">
+        <label for="crm-search-task-tag-tag">{{:: ts('Tags') }}</label>
+        <input
+          id="crm-search-task-tag-tag"
+          ng-model="$ctrl.selectedTags"
+          class="huge"
+          ng-list
+          ng-change="$ctrl.onSelectTags()"
+          ng-disabled="$ctrl.run"
+          crm-ui-select="{multiple: true, placeholder: ts('Select tags'), data: $ctrl.tags}"
+        >
+      </div>
+      <div ng-repeat="tagset in $ctrl.tagsets" class="form-inline">
+        <label>{{:: tagset.name }}</label>
+        <input
+          ng-model="$ctrl.selectedTagsetTags[tagset.name]"
+          ng-list
+          ng-change="$ctrl.onSelectTags()"
+          ng-disabled="$ctrl.run"
+          crm-entityref="{entity: 'Tag', api: {params: {parent_id: tagset.id, is_selectable: 1}}, select: {minimumInputLength: 0, multiple: true, placeholder: ts('Select tags')}}"
+        >
+      </div>
+    </fieldset>
+    <div ng-if="$ctrl.run" class="crm-search-task-progress">
+      <h5>{{:: $ctrl.action === 'save' ? ts('Adding tags...') : ts('Removing tags...') }}</h5>
+      <crm-search-batch-runner entity="'EntityTag'" action="{{ $ctrl.action }}" id-field="entity_id" params="$ctrl.run" ids="model.ids" success="$ctrl.onSuccess()" error="$ctrl.onError()" ></crm-search-batch-runner>
+    </div>
+    <hr />
+    <div class="buttons text-right">
+      <button type="button" ng-click="$ctrl.cancel()" class="btn btn-danger" ng-hide="$ctrl.run">
+        <i class="crm-i fa-times"></i>
+        {{:: ts('Cancel') }}
+      </button>
+      <button ng-click="$ctrl.saveTags()" class="btn btn-primary" ng-disabled="$ctrl.run || !$ctrl.selection.length">
+        <i class="crm-i fa-{{ $ctrl.run ? 'spin fa-spinner' : 'check' }}"></i>
+        {{ $ctrl.action === 'save' ? ts('Add tags') : ts('Remove tags') }}
+      </button>
+    </div>
+  </form>
+</div>


### PR DESCRIPTION
Overview
----------------------------------------
Adds a new angular-based action to SearchKit for bulk adding/removing tags from contacts, cases, activities, etc.

Before
----------------------------------------
Non-angular quickform popup for tagging, only works for contacts.

After
----------------------------------------
New single form handles tags and tagests for any taggable entity.

![image](https://user-images.githubusercontent.com/2874912/137990941-18092348-0a3c-49ec-9cd2-39b7cbd075c9.png)

