### PR TITLE
[REF] Fix PDF Test failure on php versions 7.4 and later

### DIFF
--- a/CRM/Contribute/Form/Task/PDF.php
+++ b/CRM/Contribute/Form/Task/PDF.php
@@ -180,10 +180,10 @@ AND    {$this->_componentClause}";
 
       $mail = CRM_Contribute_BAO_Contribution::sendMail($input, $ids, $contribID, $elements['createPdf']);
 
-      if ($mail['html']) {
+      if (!empty($mail['html'])) {
         $message[] = $mail['html'];
       }
-      else {
+      elseif (!empty($mail['body'])) {
         $message[] = nl2br($mail['body']);
       }
 


### PR DESCRIPTION
Overview
----------------------------------------
This fixes the following test failure that is present in 5.43 and master for php versions 7.4 and later

```
CRM_Contribute_Form_Task_PDFTest::testSendPDF
Trying to access array offset on value of type null

/home/jenkins/bknix-max/build/build-2/web/sites/all/modules/civicrm/CRM/Contribute/Form/Task/PDF.php:183
```

Before
----------------------------------------
Test fails on php7.4 and later 

After
----------------------------------------
Test should pass on php7.4 and later

ping @eileenmcnaughton @colemanw