### PR TITLE
Update event_online_receipt_html.tpl

### DIFF
--- a/xml/templates/message_templates/event_online_receipt_html.tpl
+++ b/xml/templates/message_templates/event_online_receipt_html.tpl
@@ -14,7 +14,6 @@
 {capture assign=participantTotal}style="margin: 0.5em 0 0.5em;padding: 0.5em;background-color: #999999;font-weight: bold;color: #FAFAFA;border-radius: 2px;"{/capture}
 
 
-<center>
   <table id="crm-event_receipt" style="font-family: Arial, Verdana, sans-serif; text-align: left; width:100%; max-width:700px; padding:0; margin:0; border:0px;">
 
   <!-- BEGIN HEADER -->
@@ -487,7 +486,6 @@
      </tr>
     {/if}
  </table>
-</center>
 
 </body>
 </html>


### PR DESCRIPTION
Text and table do not fit well together when everything is centered (in most message templates). The change should be applied for all message templates for consistency reasons.
More information (including screenshots) can you find here: #21850
Important note: I haven't tested this specific template. I don't think it's a major change and it will look and work as well as all other templates. If you think it is needed, me or anyone else (any help is highly appreciated :) can provide screenshots.