### PR TITLE
Update membership_online_receipt_html.tpl

### DIFF
--- a/xml/templates/message_templates/membership_online_receipt_html.tpl
+++ b/xml/templates/message_templates/membership_online_receipt_html.tpl
@@ -10,7 +10,6 @@
 {capture assign=labelStyle }style="padding: 4px; border-bottom: 1px solid #999; background-color: #f7f7f7;"{/capture}
 {capture assign=valueStyle }style="padding: 4px; border-bottom: 1px solid #999;"{/capture}
 
-<center>
   <table id="crm-event_receipt" style="font-family: Arial, Verdana, sans-serif; text-align: left; width:100%; max-width:700px; padding:0; margin:0; border:0px;">
 
   <!-- BEGIN HEADER -->
@@ -547,7 +546,6 @@
      {/if}
 
   </table>
-</center>
 
 </body>
 </html>


### PR DESCRIPTION
Text and table do not fit well together when everything is centered (in most message templates). The change should be applied for all message templates for consistency reasons.
More information (including screenshots) can you find here: #21850
Important note: I haven't tested this specific template. I don't think it's a major change and it will look and work as well as all other templates. If you think it is needed, me or anyone else (any help is highly appreciated :) can provide screenshots.