### PR TITLE
Update pcp_status_change_html.tpl

### DIFF
--- a/xml/templates/message_templates/pcp_status_change_html.tpl
+++ b/xml/templates/message_templates/pcp_status_change_html.tpl
@@ -6,7 +6,6 @@
 </head>
 <body>
 
-<center>
   <table id="crm-event_receipt" style="font-family: Arial, Verdana, sans-serif; text-align: left; width:100%; max-width:700px; padding:0; margin:0; border:0px;">
 
   <!-- BEGIN HEADER -->
@@ -51,7 +50,6 @@
   </tr>
 
  </table>
-</center>
 
 </body>
 </html>


### PR DESCRIPTION
Text and table do not fit well together when everything is centered (in most message templates). The change should be applied for all message templates for consistency reasons.
More information (including screenshots) can you find here: #21850
Important note: I haven't tested this specific template. I don't think it's a major change and it will look and work as well as all other templates. If you think it is needed, me or anyone else (any help is highly appreciated :) can provide screenshots.