### PR TITLE
Update test_preview_html.tpl

### DIFF
--- a/xml/templates/message_templates/test_preview_html.tpl
+++ b/xml/templates/message_templates/test_preview_html.tpl
@@ -1,4 +1,3 @@
-<center>
  <table id="crm-event_receipt_test" style="font-family: Arial, Verdana, sans-serif; text-align: left; width:100%; max-width:700px; padding:0; margin:0; border:0px;">
   <tr>
    <td>
@@ -7,4 +6,3 @@
    </td>
   </tr>
  </table>
-</center>


### PR DESCRIPTION
Text and table do not fit well together when everything is centered (in most message templates). The change should be applied for all message templates for consistency reasons.
More information (including screenshots) can you find here: #21850
Important note: I haven't tested this specific template. I don't think it's a major change and it will look and work as well as all other templates. If you think it is needed, me or anyone else (any help is highly appreciated :) can provide screenshots.