### PR TITLE
Export - Fix undefined tpl var

### DIFF
--- a/templates/CRM/Export/Form/Map.tpl
+++ b/templates/CRM/Export/Form/Map.tpl
@@ -27,5 +27,4 @@
   </crm-angular-js>
 
   <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
-  {$initHideBoxes}
 </div>


### PR DESCRIPTION
Overview
----------------------------------------
Fixes an undefined index warning caused by an unused variable leftover from refactoring.


Technical Details
----------------------------------------
This variable was a string of javascript leftover from the old export UI, no longer used or needed by the new Angular UI.