### PR TITLE
Improve tests around the Order.create API and membership

### DIFF
--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -2655,13 +2655,13 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
   }
 
   /**
-   * Create price set
+   * Create price set that includes one price field with two option values.
    *
    * @param string $component
    * @param int $componentId
    * @param array $priceFieldOptions
    *
-   * @return array
+   * @return array - the result of API3 PriceFieldValue.get for the new PriceField
    */
   protected function createPriceSet($component = 'contribution_page', $componentId = NULL, $priceFieldOptions = []) {
     $paramsSet['title'] = 'Price Set' . substr(sha1(rand()), 0, 7);

--- a/tests/phpunit/api/v3/OrderTest.php
+++ b/tests/phpunit/api/v3/OrderTest.php
@@ -122,13 +122,13 @@ class api_v3_OrderTest extends CiviUnitTestCase {
    */
   public function checkPaymentResult($results, $expectedResult, $lineItems = NULL): void {
     foreach ($expectedResult[$results['id']] as $key => $value) {
-      $this->assertEquals($results['values'][$results['id']][$key], $value);
+      $this->assertEquals($value, $results['values'][$results['id']][$key], "Unexpected value for '$key'");
     }
 
     if ($lineItems) {
       foreach ($lineItems as $key => $items) {
         foreach ($items as $k => $item) {
-          $this->assertEquals($results['values'][$results['id']]['line_items'][$key][$k], $item);
+          $this->assertEquals($item, $results['values'][$results['id']]['line_items'][$key][$k], "Unexpected value for line item $key, $k");
         }
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------

This follows on from:

- https://github.com/civicrm/civicrm-core/pull/21784
- https://lab.civicrm.org/dev/core/-/issues/2791

There are a few commits - the first few are just code clean ups and don't change anything, but sets up a test that can be reused to test various scenarios as we find we need to.

The latter commit adds a wad of tests that seek to document expected behaviour around setting membership dates, statuses, the skipStatusCal param etc.

Before: 2 tests, with code that was identical except for one line.
After: 1 test method + data provide for 9 different tests: the first two are the original tests. The next 6 test various situations - see comments in data provider, and all pass on the current 'master' branch. The last test is there for  [issue/2791](https://lab.civicrm.org/dev/core/-/issues/2791) and is currently failing .

