### PR TITLE
add 'minute' as recurring unit

### DIFF
--- a/CRM/Admin/Form/ScheduleReminders.php
+++ b/CRM/Admin/Form/ScheduleReminders.php
@@ -390,6 +390,7 @@ class CRM_Admin_Form_ScheduleReminders extends CRM_Admin_Form {
       $defaults['is_active'] = 1;
       $defaults['mode'] = 'Email';
       $defaults['record_activity'] = 1;
+      $defaults['start_action_unit'] = 'hour';
     }
     else {
       $defaults = $this->_values;

--- a/CRM/Core/SelectValues.php
+++ b/CRM/Core/SelectValues.php
@@ -900,6 +900,7 @@ class CRM_Core_SelectValues {
     // is for recurring payments and probably not good to re-use for recurring entities.
     // If something other than a hard-coded list is desired, add a new option_group.
     return [
+      'minute' => ts('minute', ['plural' => 'minutes', 'count' => $count]),
       'hour' => ts('hour', ['plural' => 'hours', 'count' => $count]),
       'day' => ts('day', ['plural' => 'days', 'count' => $count]),
       'week' => ts('week', ['plural' => 'weeks', 'count' => $count]),


### PR DESCRIPTION
Overview
----------------------------------------
When selecting recurring units (e.g. for recurring entities or scheduled reminders) there is no "minute" unit.

Before
----------------------------------------
Couldn't send a message 10 minutes after an event ended, or schedule test times to repeat on a 90 minute basis throughout a day.

After
----------------------------------------
Granularity.

Technical Details
----------------------------------------
This was really as simple as adding `minute` to the `getRecurringFrequencyUnits()` array.  I changed the default back to "hour" on scheduled reminders to preserve existing UX, and the rest is just tests.
