### PR TITLE
[Unreleased Regression] SearchKit - Fix console errors when adding non-field columns

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminDisplay.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminDisplay.component.js
@@ -192,10 +192,12 @@
         return !col.image && !col.rewrite && !col.link && !info.fn && info.args[0] && info.args[0].field && !info.args[0].field.readonly;
       };
 
+      // Checks if a column contains a sortable value
+      // Must be a real sql expression (not a pseudo-field like `result_row_num`)
       this.canBeSortable = function(col) {
         var expr = ctrl.getExprFromSelect(col.key),
           info = searchMeta.parseExpr(expr),
-          arg = (_.findWhere(info.args, {type: 'field'}) || {});
+          arg = (info && info.args && _.findWhere(info.args, {type: 'field'})) || {};
         return arg.field && arg.field.type !== 'Pseudo';
       };
 


### PR DESCRIPTION
Overview
----------------------------------------
Fixes javascript errors introduced in 5.43

Before
----------------------------------------
1. Create a search display
2. Add a new non-field column (e.g. links or buttons)
3. You'll immediately see a bunch of js errors in the console (without needing to leave the admin screen or run the display).

After
----------------------------------------
Fixed