### PR TITLE
Added Cancel Recur Subscription test & setter for `supports` on Dummy processor

### DIFF
--- a/tests/phpunit/CRM/Contribute/Form/CancelSubscriptionTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/CancelSubscriptionTest.php
@@ -53,4 +53,29 @@ class CRM_Contribute_Form_CancelSubscriptionTest extends CRM_Contribute_Form_Rec
     ];
   }
 
+  /**
+   * Test if the full fledged form is displayed on cancelling the Recurring Contribution with a payment processor which does not support cancelling a Recurring Contribution
+   *
+   * @throws \CRM_Core_Exception|\API_Exception
+   */
+  public function testCancelSubscriptionForm(): void {
+    $this->addContribution();
+    /* @var CRM_Contribute_Form_CancelSubscription $form */
+    $form = $this->getFormObject('CRM_Contribute_Form_CancelSubscription', ['is_notify' => TRUE]);
+    $form->set('crid', $this->getContributionRecurID());
+    $form->buildForm();
+
+    /* Set the Payment processor to not support 'Cancel Recurring' */
+    $paymentProcessorObj = Civi\Payment\System::singleton()->getById(CRM_Contribute_BAO_ContributionRecur::getPaymentProcessorID($this->getContributionRecurID()));
+    $paymentProcessorObj->setSupports([
+      'CancelRecurring' => FALSE,
+    ]);
+
+    $actions = CRM_Contribute_Page_Tab::recurLinks($this->getContributionRecurID());
+    // Using "crm-enable-disable"
+    $this->assertEquals($actions[CRM_Core_Action::DISABLE]['ref'], 'crm-enable-disable');
+    // Using "Cancel Recurring" form
+    // $this->assertEquals($actions[CRM_Core_Action::DISABLE]['url'], 'civicrm/contribute/unsubscribe');
+  }
+
 }

--- a/tests/phpunit/CRM/Contribute/Form/RecurForms.php
+++ b/tests/phpunit/CRM/Contribute/Form/RecurForms.php
@@ -19,6 +19,15 @@ class CRM_Contribute_Form_RecurForms extends CiviUnitTestCase {
    */
   protected $paymentProcessorId;
 
+  public function tearDown(): void {
+    if ($this->paymentProcessorId) {
+      \Civi\Api4\PaymentProcessor::delete(FALSE)
+        ->addWhere('id', '=', $this->paymentProcessorId)
+        ->execute();
+    }
+    parent::tearDown();
+  }
+
   /**
    * Get contact id.
    *


### PR DESCRIPTION
Overview
----------------------------------------
Added Test in follow up to #18196. Have also added a function in `CRM_Core_Payment_Dummy` to set the return value for support functions. 

This also allows the capabilities supported by the Dummy processor to be set from outside the class. This is done by adding a support array where the capabilities are initially set to `TRUE` but can be altered by using the `setSupports` Function.  This can be highly useful to alter the capabilities of dummy processors from directly outside the class in future tests as well. 

Comments
----------------------------------------
Functions used within the test have been extended from `RecurForms.php` added in #21588 
