### PR TITLE
dev/core#2922 Add ExampleData for our main test contact

### DIFF
--- a/Civi/Api4/ExampleData.php
+++ b/Civi/Api4/ExampleData.php
@@ -90,8 +90,8 @@ class ExampleData extends \Civi\Api4\Generic\AbstractEntity {
   public static function permissions() {
     return [
       // FIXME: Perhaps use 'edit message templates' or similar?
-      "meta" => ["access CiviCRM"],
-      "default" => ["administer CiviCRM"],
+      'meta' => ['access CiviCRM'],
+      'default' => ['administer CiviCRM'],
     ];
   }
 

--- a/Civi/Test/EntityExample.php
+++ b/Civi/Test/EntityExample.php
@@ -20,13 +20,26 @@ abstract class EntityExample implements ExampleDataInterface {
   protected $entityName;
 
   /**
+   * Get the name of the example in use.
+   *
+   * @return string
+   */
+  protected function getExampleName(): string {
+    return $this->exName;
+  }
+
+  /**
+   * ExName - ex is short for 'example'.
+   *
+   * To avoid trying to remember abbreviations `getExampleName` can be used.
+   *
    * @var string
    */
   protected $exName;
 
   public function __construct() {
     if (!preg_match(';^(.*)[_\\\]([a-zA-Z0-9]+)[_\\\]([a-zA-Z0-9]+)$;', static::class, $m)) {
-      throw new \RuntimeException("Failed to parse class: " . static::class);
+      throw new \RuntimeException('Failed to parse class: ' . static::class);
     }
     $this->entityName = $m[2];
     $this->exName = $m[3];

--- a/Civi/Test/ExampleData/Contact/Anthony.ex.php
+++ b/Civi/Test/ExampleData/Contact/Anthony.ex.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Civi\Test\ExampleData\Contact;
+
+use Civi\Test\EntityExample;
+
+class Anthony extends EntityExample {
+
+  /**
+   * Get examples that this class can provide in an iterable format.
+   */
+  public function getExamples(): iterable {
+    yield [
+      'name' => "entity/{$this->entityName}/" . $this->getExampleName(),
+    ];
+  }
+
+  /**
+   * Add available examples to the `$example` input.
+   *
+   * @param array $example
+   */
+  public function build(array &$example): void {
+    $example['data'] = [
+      'contact_type' => 'Individual',
+      'first_name' => 'Anthony',
+      'last_name' => 'Anderson',
+      'middle_name' => 'J.',
+      'prefix_id:label' => 'Dr.',
+      'suffix_id:label' => 'III',
+      'primary_email.email' => 'anthony.anderson@civicrm.org',
+    ];
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#2922 Add ExampleData for our main test contact

Before
----------------------------------------
No ExampleData for our number 1 test contact

After
----------------------------------------
Data added - I still can't manage to figure out how to use it - see https://lab.civicrm.org/dev/core/-/issues/2922

I was hoping that `ExampleData::get()->addWhere('entity', '= ', 'Contact')->addWhere('name', '=' 'Anthony')`
would dish up Anthony's details for me but that's not what it does.

Technical Details
----------------------------------------
@colemanw I note the other ExampleData sets currently look like apiv3 data- which we should change - but I think this issue of 'email' is always going to be nasty. In apiv3 `email` can be used for contact api as a `get` and a `create` parameter.
In api v4 there is no common syntax between `'get` and `create` for it so we can't define data in one way for both.

In the token class it internally (and as a non-advertised token) uses `primary_email.email` and defines the join for that.

The lack of email being passed through to `Contact.create` also has performance impact on `Contact.create` when other details are missing

Comments
----------------------------------------
I was hoping to figure out how to describe a scenario in test data with 2 contacts with 2 recurring contributions & also use that scenario to create them in a dev database. I think that lift is too much for now