### PR TITLE
Update docblock for alterPaymentProcessorParams because rawParams might be a payment propertyBag

### DIFF
--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -1182,7 +1182,7 @@ abstract class CRM_Utils_Hook {
    * @param CRM_Core_Payment $paymentObj
    *   Instance of payment class of the payment processor invoked (e.g., 'CRM_Core_Payment_Dummy')
    *   See discussion in CRM-16224 as to whether $paymentObj should be passed by reference.
-   * @param array &$rawParams
+   * @param array|\Civi\Payment\PropertyBag &$rawParams
    *    array of params as passed to to the processor
    * @param array|\Civi\Payment\PropertyBag &$cookedParams
    *     params after the processor code has translated them into its own key/value pairs


### PR DESCRIPTION
Overview
----------------------------------------
This just updates the docblock to reflect what it is already the case. The `$rawParams` passed to the hook might be an array or a payment propertyBag.

Before
----------------------------------------
docblock indicates it's an array only

After
----------------------------------------
docblock indicates what it actually could be.

Technical Details
----------------------------------------
`$cookedParams` docblock got updated over a year ago. It's extremely unlikely that you get an array and return a propertyBag. More likely is that you'd return in whatever format you got it in!

Comments
----------------------------------------
