### PR TITLE
Prevent Undefined Index PHP notices with Afform entity metadata without an icon

### DIFF
--- a/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php
+++ b/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php
@@ -85,7 +85,7 @@ class AfformAdminMeta {
     $meta = [
       'entity' => $info['name'],
       'label' => $info['title'],
-      'icon' => $info['icon'],
+      'icon' => $info['icon'] ?? NULL,
     ];
     // Custom entities are always type 'join'
     if (in_array('CustomValue', $info['type'], TRUE)) {


### PR DESCRIPTION
Overview
----------------------------------------
The Afform admin interface shows PHP notices about undefined index `icon` for entities without an icon property defined, e.g. `Custom_` entities (i.e. multi-record custom groups).

Before
----------------------------------------
`Notice: Undefined index: icon in Civi\AfformAdmin\AfformAdminMeta::entityToAfformMeta() (Line 89 of /path/to/civicrm/core/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php).`

After
----------------------------------------
No notices.

Technical Details
----------------------------------------
n/a

Comments
----------------------------------------
n/a