### PR TITLE
Dispatch an event for registering Afform entities

### DIFF
--- a/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php
+++ b/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php
@@ -4,6 +4,7 @@ namespace Civi\AfformAdmin;
 
 use Civi\Api4\Entity;
 use Civi\Api4\Utils\CoreUtil;
+use Civi\Core\Event\GenericHookEvent;
 use CRM_AfformAdmin_ExtensionUtil as E;
 
 class AfformAdminMeta {
@@ -203,6 +204,11 @@ class AfformAdminMeta {
         }
       }
     }
+
+    // Let extensions define their entities through an event, e.g. virtual
+    // entities that can not be registered in separate files.
+    $event = GenericHookEvent::create(['entities' => &$data['entities']]);
+    \Civi::dispatcher()->dispatch('civi.afform.entities', $event);
 
     // Todo: add method for extensions to define other elements
     $data['elements'] = [


### PR DESCRIPTION
Overview
----------------------------------------
Currently, Afform forms can only be created for hard-coded entities or entities provided by extensions through a PHP file for each entity. This adds an event which extensions can subscribe to for registering entities, e.g. "virtual" entities which no PHP files can be created for.

Before
----------------------------------------
No support for virtual entities.

After
----------------------------------------
Virtual entities supported by dispatching an event when generating the list of events.

Technical Details
----------------------------------------
Since CiviCRM Core supports virtual entities for API4 with #21771, the Afform builder should support those as well. Maybe this can be more generic in the future, i.e. allowing to build forms for all API4 entities.

Comments
----------------------------------------
With this, a refactoring of https://github.com/civicrm/civicrm-core/blob/82106bdd7d681f7249f66ff02a36918c8b85610d/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php#L162-L168 _might_ be useful.