### PR TITLE
Correct CMS name on profile UF group types

### DIFF
--- a/CRM/Core/SelectValues.php
+++ b/CRM/Core/SelectValues.php
@@ -237,10 +237,7 @@ class CRM_Core_SelectValues {
     ];
 
     if (CRM_Core_Config::singleton()->userSystem->supports_form_extensions) {
-      $ufGroupType += [
-        'User Registration' => ts('Drupal User Registration'),
-        'User Account' => ts('View/Edit Drupal User Account'),
-      ];
+      $ufGroupType += CRM_Core_Config::singleton()->userSystem->getUfGroupTypes();
     }
     return $ufGroupType;
   }

--- a/CRM/Utils/System/Backdrop.php
+++ b/CRM/Utils/System/Backdrop.php
@@ -1068,4 +1068,15 @@ AND    u.status = 1
     return str_replace(parent::getCRMDatabasePrefix(), '`', '');
   }
 
+  /**
+   * Return the CMS-specific UF Group Types for profiles.
+   * @return array
+   */
+  public function getUfGroupTypes() {
+    return [
+      'User Registration' => ts('Backdrop User Registration'),
+      'User Account' => ts('View/Edit Backdrop User Account'),
+    ];
+  }
+
 }

--- a/CRM/Utils/System/Base.php
+++ b/CRM/Utils/System/Base.php
@@ -1082,4 +1082,12 @@ abstract class CRM_Utils_System_Base {
     return TRUE;
   }
 
+  /**
+   * Return the CMS-specific UF Group Types for profiles.
+   * @return array
+   */
+  public function getUfGroupTypes() {
+    return [];
+  }
+
 }

--- a/CRM/Utils/System/DrupalBase.php
+++ b/CRM/Utils/System/DrupalBase.php
@@ -709,4 +709,15 @@ abstract class CRM_Utils_System_DrupalBase extends CRM_Utils_System_Base {
     return ['ufAccessURL' => url('admin/people/permissions')];
   }
 
+  /**
+   * Return the CMS-specific UF Group Types for profiles.
+   * @return array
+   */
+  public function getUfGroupTypes() {
+    return [
+      'User Registration' => ts('Drupal User Registration'),
+      'User Account' => ts('View/Edit Drupal User Account'),
+    ];
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes https://lab.civicrm.org/dev/backdrop/-/issues/2

Before
----------------------------------------
Says "Drupal User Registration" on Profile options.

After
----------------------------------------
Says either "Backdrop User Registration" or "Drupal User Registration" as appropriate.

Technical Details
----------------------------------------
New method on CRM_Utils_System_*
