### PR TITLE
Make error message translatable - remove tag tasks.

### DIFF
--- a/CRM/Activity/Form/Task/RemoveFromTag.php
+++ b/CRM/Activity/Form/Task/RemoveFromTag.php
@@ -68,7 +68,7 @@ class CRM_Activity_Form_Task_RemoveFromTag extends CRM_Activity_Form_Task {
   public static function formRule($form, $rule) {
     $errors = [];
     if (empty($form['tag']) && empty($form['activity_taglist'])) {
-      $errors['_qf_default'] = "Please select atleast one tag.";
+      $errors['_qf_default'] = ts('Please select at least one tag.');
     }
     return $errors;
   }

--- a/CRM/Contact/Form/Task/RemoveFromTag.php
+++ b/CRM/Contact/Form/Task/RemoveFromTag.php
@@ -63,7 +63,7 @@ class CRM_Contact_Form_Task_RemoveFromTag extends CRM_Contact_Form_Task {
   public static function formRule($form, $rule) {
     $errors = [];
     if (empty($form['tag']) && empty($form['contact_taglist'])) {
-      $errors['_qf_default'] = "Please select atleast one tag.";
+      $errors['_qf_default'] = ts('Please select at least one tag.');
     }
     return $errors;
   }


### PR DESCRIPTION
Overview
----------------------------------------
Make error message translatable. Also fix typo (space between 'at least')

Before
----------------------------------------
Error text could not be translated and had typo.

After
----------------------------------------
Wrapped in `ts` and typo fixed.

