### PR TITLE
[REF] Preliminary cleanup in update greeting

### DIFF
--- a/tests/phpunit/api/v3/CustomValueTest.php
+++ b/tests/phpunit/api/v3/CustomValueTest.php
@@ -491,12 +491,12 @@ class api_v3_CustomValueTest extends CiviUnitTestCase {
   /**
    * Test that custom fields in greeting strings are updated.
    */
-  public function testUpdateCustomGreetings() {
+  public function testUpdateCustomGreetings(): void {
     // Create a custom group with one field.
     $customGroupResult = $this->callAPISuccess('CustomGroup', 'create', [
       'sequential' => 1,
-      'title' => "test custom group",
-      'extends' => "Individual",
+      'title' => 'test custom group',
+      'extends' => 'Individual',
     ]);
     $customFieldResult = $this->callAPISuccess('CustomField', 'create', [
       'custom_group_id' => $customGroupResult['id'],
@@ -509,21 +509,20 @@ class api_v3_CustomValueTest extends CiviUnitTestCase {
     // Create a contact with an email greeting format that includes the new custom field.
     $contactResult = $this->callAPISuccess('Contact', 'create', [
       'contact_type' => 'Individual',
-      'email' => substr(sha1(rand()), 0, 7) . '@yahoo.com',
-      'email_greeting_id' => "Customized",
+      'email' => 'her@yahoo.com',
+      'email_greeting_id' => 'Customized',
       'email_greeting_custom' => "Dear {contact.custom_{$customFieldId}}",
     ]);
     $cid = $contactResult['id'];
 
     // Define testing values.
-    $uniq = uniqid();
-    $testGreetingValue = "Dear $uniq";
+    $testGreetingValue = 'Dear custom field';
 
     // Update contact's custom field with CustomValue.create
-    $customValueResult = $this->callAPISuccess('CustomValue', 'create', [
+    $this->callAPISuccess('CustomValue', 'create', [
       'entity_id' => $cid,
-      "custom_{$customFieldId}" => $uniq,
-      'entity_table' => "civicrm_contact",
+      "custom_{$customFieldId}" => 'custom field',
+      'entity_table' => 'civicrm_contact',
     ]);
 
     $contact = $this->callAPISuccessGetSingle('Contact', ['id' => $cid, 'return' => 'email_greeting']);


### PR DESCRIPTION
Overview
----------------------------------------
[REF] Preliminary cleanup in update greeting

Before
----------------------------------------
Code is sooooo confusing

After
----------------------------------------
Code to get the greeting strings extracted

Technical Details
----------------------------------------

We start with

```
if ($contact->email_greeting_custom != 'null' && $contact->email_greeting_custom) {

}
elseif ($contact->email_greeting_id != 'null' && $contact->email_greeting_id) {
}
else {
   if ($contact->email_greeting_custom) {
}

```
Which leaves it very unclear what the last else is for.

My analysis is that this is 

- if email_greeting_custom has a real value then use that as the email greeting template, 
- if not but a real value (which means a number) has been passed for email_greeting_id then  use the template corresponding to the id supplied

So the if clause winds up like

```
 if (!CRM_Utils_System::isNull($contact->email_greeting_custom)) {
}
 elseif (is_numeric($contact->email_greeting_id)) {
elseif ($contact->email_greeting_custom === 'null') {
}
```


Comments
----------------------------------------