### PR TITLE
Fix cleanup on test, also NFC cleanup

### DIFF
--- a/tests/phpunit/api/v3/PledgePaymentTest.php
+++ b/tests/phpunit/api/v3/PledgePaymentTest.php
@@ -37,63 +37,47 @@ class api_v3_PledgePaymentTest extends CiviUnitTestCase {
 
   /**
    * Clean up after function.
-   * @throws \CRM_Core_Exception
    */
   public function tearDown(): void {
-    $tablesToTruncate = [
-      'civicrm_contribution',
-      'civicrm_contact',
-      'civicrm_pledge',
-      'civicrm_pledge_payment',
-      'civicrm_line_item',
-    ];
-
-    $this->quickCleanup($tablesToTruncate);
+    $this->quickCleanUpFinancialEntities();
     parent::tearDown();
   }
 
-  public function testGetPledgePayment() {
+  public function testGetPledgePayment(): void {
     $params = [];
-    $result = $this->callAPIAndDocument('pledge_payment', 'get', $params, __FUNCTION__, __FILE__);
-    $this->assertEquals(5, $result['count'], " in line " . __LINE__);
+    $result = $this->callAPIAndDocument('PledgePayment', 'get', $params, __FUNCTION__, __FILE__);
+    $this->assertEquals(5, $result['count']);
   }
 
   /**
    * Test that passing in a single variable works.
    */
-  public function testGetSinglePledgePayment() {
-    $createparams = [
+  public function testGetSinglePledgePayment(): void {
+    $this->callAPISuccess('PledgePayment', 'create', [
       'contact_id' => $this->_individualId,
       'pledge_id' => $this->_pledgeID,
       'contribution_id' => $this->_contributionID,
       'status_id' => 1,
-    ];
-    $createResult = $this->callAPISuccess('pledge_payment', 'create', $createparams);
-    $params = [
-      'contribution_id' => $this->_contributionID,
-    ];
-    $result = $this->callAPISuccess('pledge_payment', 'get', $params);
-    $this->assertEquals(1, $result['count'], " in line " . __LINE__);
+    ]);
+    $result = $this->callAPISuccess('PledgePayment', 'get', ['contribution_id' => $this->_contributionID]);
+    $this->assertEquals(1, $result['count']);
   }
 
   /**
    * Test process_pledge job log.
    */
-  public function testProcessPledgeJob() {
-    $pledgeStatuses = CRM_Core_OptionGroup::values('pledge_status',
-      FALSE, FALSE, FALSE, NULL, 'name'
-    );
+  public function testProcessPledgeJob(): void {
     //Make first payment.
     $paymentParams = [
       'contact_id' => $this->_individualId,
       'pledge_id' => $this->_pledgeID,
       'contribution_id' => $this->_contributionID,
-      'scheduled_date' => date('Ymd', strtotime("-1 days")),
-      'status_id' => array_search('Pending', $pledgeStatuses),
+      'scheduled_date' => date('Ymd', strtotime('-1 days')),
+      'status_id' => 'Pending',
     ];
-    $firstPayment = $this->callAPISuccess('pledge_payment', 'create', $paymentParams);
+    $this->callAPISuccess('PledgePayment', 'create', $paymentParams);
     //Status should be 'Pending' after first incomplete payment.
-    $checkStatus = $this->callAPISuccess('pledge', 'getsingle', [
+    $checkStatus = $this->callAPISuccess('Pledge', 'getsingle', [
       'id' => $this->_pledgeID,
       'return' => 'pledge_status',
     ]);
@@ -101,10 +85,10 @@ class api_v3_PledgePaymentTest extends CiviUnitTestCase {
 
     //Execute process_pledge job log.
     $result = $this->callAPISuccess('Job', 'process_pledge', []);
-    $this->assertEquals("Checking if status update is needed for Pledge Id: {$this->_pledgeID} (current status is Pending)\n\r- status updated to: Overdue\n\r1 records updated.", $result['values']);
+    $this->assertEquals("Checking if status update is needed for Pledge Id: $this->_pledgeID (current status is Pending)\n\r- status updated to: Overdue\n\r1 records updated.", $result['values']);
 
     //Status should be 'Overdue' after processing.
-    $statusAfterProcessing = $this->callAPISuccess('pledge', 'getsingle', [
+    $statusAfterProcessing = $this->callAPISuccess('Pledge', 'getsingle', [
       'id' => $this->_pledgeID,
       'return' => 'pledge_status',
     ]);
@@ -114,9 +98,9 @@ class api_v3_PledgePaymentTest extends CiviUnitTestCase {
   /**
    * Test status of pledge on payments and cancellation.
    */
-  public function testPledgeStatus() {
+  public function testPledgeStatus(): void {
     //Status should initially be Pending.
-    $checkStatus = $this->callAPISuccess('pledge', 'getsingle', [
+    $checkStatus = $this->callAPISuccess('Pledge', 'getsingle', [
       'id' => $this->_pledgeID,
       'return' => 'pledge_status',
     ]);
@@ -129,10 +113,10 @@ class api_v3_PledgePaymentTest extends CiviUnitTestCase {
       'contribution_id' => $this->_contributionID,
       'status_id' => 1,
     ];
-    $firstPayment = $this->callAPISuccess('pledge_payment', 'create', $paymentParams);
+    $firstPayment = $this->callAPISuccess('PledgePayment', 'create', $paymentParams);
 
     //Status should be 'In Progress' after first payment.
-    $checkStatus = $this->callAPISuccess('pledge', 'getsingle', [
+    $checkStatus = $this->callAPISuccess('Pledge', 'getsingle', [
       'id' => $this->_pledgeID,
       'return' => 'pledge_status',
     ]);
@@ -142,48 +126,47 @@ class api_v3_PledgePaymentTest extends CiviUnitTestCase {
     $paymentStatusTypes = CRM_Contribute_PseudoConstant::contributionStatus(NULL, 'name');
     $updateParams = [
       'id' => $this->_pledgeID,
-      'status_id' => array_search('Cancelled', $paymentStatusTypes),
+      'status_id' => 'Cancelled',
     ];
-    $this->callAPISuccess('pledge', 'create', $updateParams);
+    $this->callAPISuccess('Pledge', 'create', $updateParams);
 
     //Status should be calculated as Cancelled.
     $pledgeStatus = CRM_Pledge_BAO_PledgePayment::calculatePledgeStatus($this->_pledgeID);
     $this->assertEquals('Cancelled', $paymentStatusTypes[$pledgeStatus]);
 
     //Already completed payments should not be cancelled.
-    $checkPaymentStatus = $this->callAPISuccess('pledge_payment', 'getsingle', [
+    $checkPaymentStatus = $this->callAPISuccess('PledgePayment', 'getsingle', [
       'id' => $firstPayment['id'],
       'return' => 'status_id',
     ]);
-    $this->assertEquals(array_search('Completed', $paymentStatusTypes), $checkPaymentStatus['status_id']);
+    $this->assertEquals('Completed', CRM_Core_PseudoConstant::getName('CRM_Pledge_BAO_Pledge', 'status_id', $checkPaymentStatus['status_id']));
   }
 
   /**
    * Test that passing in a single variable works:: status_id
    */
-  public function testGetSinglePledgePaymentByStatusID() {
-    $createparams = [
+  public function testGetSinglePledgePaymentByStatusID(): void {
+    $this->callAPISuccess('PledgePayment', 'create', [
       'contact_id' => $this->_individualId,
       'pledge_id' => $this->_pledgeID,
       'contribution_id' => $this->_contributionID,
       'status_id' => 1,
-    ];
-    $createResult = $this->callAPISuccess('pledge_payment', 'create', $createparams);
+    ]);
     $params = [
       'status_id' => 1,
     ];
 
-    $result = $this->callAPISuccess('pledge_payment', 'get', $params);
-    $this->assertEquals(1, $result['count'], " in line " . __LINE__);
+    $result = $this->callAPISuccess('PledgePayment', 'get', $params);
+    $this->assertEquals(1, $result['count']);
   }
 
   /**
    * Test that creating a payment will add the contribution ID.
    */
-  public function testCreatePledgePayment() {
+  public function testCreatePledgePayment(): void {
     //check that 5 pledge payments exist at the start
-    $beforeAdd = $this->callAPISuccess('pledge_payment', 'get', []);
-    $this->assertEquals(5, $beforeAdd['count'], " in line " . __LINE__);
+    $beforeAdd = $this->callAPISuccess('PledgePayment', 'get', []);
+    $this->assertEquals(5, $beforeAdd['count']);
 
     //test the pledge_payment_create function
     $params = [
@@ -193,17 +176,17 @@ class api_v3_PledgePaymentTest extends CiviUnitTestCase {
       'status_id' => 1,
       'actual_amount' => 20,
     ];
-    $result = $this->callAPIAndDocument('pledge_payment', 'create', $params, __FUNCTION__, __FILE__);
+    $result = $this->callAPIAndDocument('PledgePayment', 'create', $params, __FUNCTION__, __FILE__);
 
     //check existing updated not new one created - 'create' means add contribution_id in this context
-    $afterAdd = $this->callAPISuccess('pledge_payment', 'get', []);
-    $this->assertEquals(5, $afterAdd['count'], " in line " . __LINE__);
+    $afterAdd = $this->callAPISuccess('PledgePayment', 'get', []);
+    $this->assertEquals(5, $afterAdd['count']);
 
     //get the created payment & check it out
     $getParams['id'] = $result['id'];
-    $getIndPayment = $this->callAPISuccess('pledge_payment', 'get', $getParams);
-    $this->assertEquals(1, $getIndPayment['count'], " in line " . __LINE__);
-    $this->assertEquals(20, $getIndPayment['values'][$result['id']]['actual_amount'], " in line " . __LINE__);
+    $getIndPayment = $this->callAPISuccess('PledgePayment', 'get', $getParams);
+    $this->assertEquals(1, $getIndPayment['count']);
+    $this->assertEquals(20, $getIndPayment['values'][$result['id']]['actual_amount']);
 
     //create a second pledge payment - need a contribution first &can't use the CiviUnitTest case function as invoice is hard-coded
     $contributionParams = [
@@ -214,18 +197,18 @@ class api_v3_PledgePaymentTest extends CiviUnitTestCase {
     $contribution = $this->callAPISuccess('contribution', 'create', $contributionParams);
     $params['contribution_id'] = $contribution['id'];
 
-    $resultCont2 = $this->callAPISuccess('pledge_payment', 'create', $params);
+    $resultCont2 = $this->callAPISuccess('PledgePayment', 'create', $params);
     //make sure original is untouched & has not been updated
-    $this->assertGreaterThan($result['id'], $resultCont2['id'], " in line " . __LINE__);
-    $getIndPaymentAgain = $this->callAPISuccess('pledge_payment', 'get', $getParams);
-    $this->assertEquals(1, $getIndPaymentAgain['count'], " in line " . __LINE__);
-    $this->assertEquals($this->_contributionID, $getIndPaymentAgain['values'][$result['id']]['contribution_id'], " in line " . __LINE__);
+    $this->assertGreaterThan($result['id'], $resultCont2['id']);
+    $getIndPaymentAgain = $this->callAPISuccess('PledgePayment', 'get', $getParams);
+    $this->assertEquals(1, $getIndPaymentAgain['count']);
+    $this->assertEquals($this->_contributionID, $getIndPaymentAgain['values'][$result['id']]['contribution_id']);
   }
 
   /**
    * Test checks behaviour when more payments are created than should be possible.
    */
-  public function testCreatePledgePaymentAllCreated() {
+  public function testCreatePledgePaymentAllCreated(): void {
     $params = [
       'pledge_id' => $this->_pledgeID,
       'status_id' => 1,
@@ -241,8 +224,12 @@ class api_v3_PledgePaymentTest extends CiviUnitTestCase {
       $contribution = $this->callAPISuccess('contribution', 'create', $contributionParams);
 
       $params['contribution_id'] = $contribution['id'];
-
-      $resultCont2 = civicrm_api('pledge_payment', 'create', $params + ['version' => $this->_apiversion]);
+      if ($i < 5) {
+        $this->callAPISuccess('PledgePayment', 'create', $params);
+      }
+      else {
+        $this->callAPIFailure('PledgePayment', 'create', $params, "There are no unmatched payment on this pledge. Pass in the pledge_payment id to specify one or 'option.create_new' to create one");
+      }
       $i++;
     }
     // check that only 5 exist & we got an error setting the 6th
@@ -250,13 +237,12 @@ class api_v3_PledgePaymentTest extends CiviUnitTestCase {
       'pledge_id' => $this->_pledgeID,
     ]);
     // the last one above should result in an error
-    $this->assertEquals("There are no unmatched payment on this pledge. Pass in the pledge_payment id to specify one or 'option.create_new' to create one", $resultCont2['error_message']);
     $this->assertEquals(5, $result['count']);
 
     $params['option.create_new'] = 1;
     $params['scheduled_amount'] = 20;
     $params['scheduled_date'] = '20131212';
-    $resultcreatenew = $this->callAPISuccess('pledge_payment', 'create', $params);
+    $this->callAPISuccess('PledgePayment', 'create', $params);
     $result = $this->callAPISuccess('PledgePayment', 'Get', [
       'pledge_id' => $this->_pledgeID,
     ]);
@@ -267,7 +253,7 @@ class api_v3_PledgePaymentTest extends CiviUnitTestCase {
   /**
    * Test that creating a payment adds the contribution ID where only one pledge payment is in schedule.
    */
-  public function testCreatePledgePaymentWhereOnlyOnePayment() {
+  public function testCreatePledgePaymentWhereOnlyOnePayment(): void {
     $pledgeParams = [
       'contact_id' => $this->_individualId,
       'pledge_create_date' => date('Ymd'),
@@ -300,33 +286,36 @@ class api_v3_PledgePaymentTest extends CiviUnitTestCase {
       'status_id' => 1,
       'actual_amount' => 20,
     ];
-    $result = $this->callAPISuccess('pledge_payment', 'create', $params);
+    $this->callAPISuccess('PledgePayment', 'create', $params);
 
     //check existing updated not new one created - 'create' means add contribution_id in this context
-    $afterAdd = $this->callAPISuccess('pledge_payment', 'get', [
+    $afterAdd = $this->callAPISuccess('PledgePayment', 'get', [
       'contribution_id' => $contributionID,
     ]);
-    $this->assertEquals(1, $afterAdd['count'], " in line " . __LINE__);
+    $this->assertEquals(1, $afterAdd['count']);
   }
 
-  public function testUpdatePledgePayment() {
+  /**
+   * @throws \CRM_Core_Exception
+   */
+  public function testUpdatePledgePayment(): void {
     $params = [
       'pledge_id' => $this->_pledgeID,
       'contribution_id' => $this->_contributionID,
       'status_id' => 2,
       'actual_amount' => 20,
     ];
-    $result = $this->callAPISuccess('pledge_payment', 'create', $params);
-    $updateparams = [
+    $result = $this->callAPISuccess('PledgePayment', 'create', $params);
+    $updateParams = [
       'id' => $result['id'],
       'status_id' => 1,
     ];
 
-    $result = $this->callAPIAndDocument('pledge_payment', 'update', $updateparams, __FUNCTION__, __FILE__);
-    $this->getAndCheck(array_merge($params, $updateparams), $result['id'], $this->_entity);
+    $result = $this->callAPIAndDocument('PledgePayment', 'update', $updateParams, __FUNCTION__, __FILE__);
+    $this->getAndCheck(array_merge($params, $updateParams), $result['id'], $this->_entity);
   }
 
-  public function testDeletePledgePayment() {
+  public function testDeletePledgePayment(): void {
     $params = [
       'contact_id' => $this->_individualId,
       'pledge_id' => $this->_pledgeID,
@@ -335,15 +324,15 @@ class api_v3_PledgePaymentTest extends CiviUnitTestCase {
       'sequential' => 1,
       'actual_amount' => 20,
     ];
-    $pledgePayment = $this->callAPISuccess('pledge_payment', 'create', $params);
+    $pledgePayment = $this->callAPISuccess('PledgePayment', 'create', $params);
 
     $deleteParams = [
       'id' => $pledgePayment['id'],
     ];
-    $result = $this->callAPIAndDocument('pledge_payment', 'delete', $deleteParams, __FUNCTION__, __FILE__);
+    $this->callAPIAndDocument('PledgePayment', 'delete', $deleteParams, __FUNCTION__, __FILE__);
   }
 
-  public function testGetFields() {
+  public function testGetFields(): void {
     $result = $this->callAPISuccess('PledgePayment', 'GetFields', []);
     $this->assertIsArray($result);
   }


### PR DESCRIPTION
Overview
----------------------------------------
Fix cleanup on test, also NFC cleanup

![image](https://user-images.githubusercontent.com/336308/138537131-47da67fa-bfd8-4c09-b1eb-621bec6b0320.png)


Before
----------------------------------------
Tests in post-validate for this class have started failing due to the test not doing a good job of cleaning up after itself

After
----------------------------------------
Using the more thorough cleanup function in tearDown

Technical Details
----------------------------------------
The failing test was just expanded & there must have been a merge order issue for why it forgave this test class until it didn't

Comments
----------------------------------------
