### PR TITLE
[REF] Remove unnecessary code to null greeting display values

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -2810,11 +2810,6 @@ LEFT JOIN civicrm_email    ON ( civicrm_contact.id = civicrm_email.contact_id )
       $emailGreetingString = $emailGreeting[$contact->email_greeting_id];
       $updateQueryString[] = " email_greeting_custom = NULL ";
     }
-    else {
-      if ($contact->email_greeting_custom) {
-        $updateQueryString[] = " email_greeting_display = NULL ";
-      }
-    }
 
     if ($emailGreetingString) {
       CRM_Contact_BAO_Contact_Utils::processGreetingTemplate($emailGreetingString,
@@ -2838,11 +2833,6 @@ LEFT JOIN civicrm_email    ON ( civicrm_contact.id = civicrm_email.contact_id )
       $postalGreeting = CRM_Core_PseudoConstant::greeting($filter);
       $postalGreetingString = $postalGreeting[$contact->postal_greeting_id];
       $updateQueryString[] = " postal_greeting_custom = NULL ";
-    }
-    else {
-      if ($contact->postal_greeting_custom) {
-        $updateQueryString[] = " postal_greeting_display = NULL ";
-      }
     }
 
     if ($postalGreetingString) {
@@ -2868,11 +2858,6 @@ LEFT JOIN civicrm_email    ON ( civicrm_contact.id = civicrm_email.contact_id )
       $addressee = CRM_Core_PseudoConstant::greeting($filter);
       $addresseeString = $addressee[$contact->addressee_id];
       $updateQueryString[] = " addressee_custom = NULL ";
-    }
-    else {
-      if ($contact->addressee_custom) {
-        $updateQueryString[] = " addressee_display = NULL ";
-      }
     }
 
     if ($addresseeString) {


### PR DESCRIPTION
Overview
----------------------------------------
`processGreetings` is taking responsibility for NULLing any greeting _display fields (e.g addressee_display) if no relevant greeting exists (ie. addressee_id IS NULL) . 

However, this is not that function's responsibility as it is called post-contact-save but pre-contact-save the `ensureGreetingParamsAreSet` function has already ensured that ... greeting params are set. Notably this includes setting the _display fields if they should be NULL in such a way that they will be nulled out.

Note that even if a 'custom' string is chosen this will still have an 'id' option - ie if `addressee_custom` is set `addressee_id` will be set too

Before
----------------------------------------
Now you see it

After
----------------------------------------
Now you don't 

Technical Details
----------------------------------------
This function is called from 2 places

![image](https://user-images.githubusercontent.com/336308/138541574-988514a5-2dab-42d0-9ed0-4a155cedea6d.png)

```
Contact::create
Contact::updateGreetingsOnTokenFieldChange
```
In both cases the contact has already been saved (to the extent that is relevant
for the operation).

`Contact::updateGreetingsOnTokenFieldChange`  will not change
will only potentially change tokens within a greeting string - ie the nullness or otherwise won't change. 

In `Contact::create` the nulling will already have taken place if needed ie if there
is no id entity for the relevant greeing
ensureGreetingParamsAreSet will already have [set it to 'null' as part of ensuring greeting parameters are set](https://github.com/civicrm/civicrm-core/blob/86f2711afe5571419b7ccb967309a8e742814074/CRM/Contact/BAO/Contact.php#L539)
before the save - leading to it already being updated to NULL


Comments
----------------------------------------
