### PR TITLE
dev/core#2864 fix for rc breakage in pdf-letter-to-word

### DIFF
--- a/CRM/Contact/Form/Task/PDFTrait.php
+++ b/CRM/Contact/Form/Task/PDFTrait.php
@@ -270,7 +270,7 @@ trait CRM_Contact_Form_Task_PDFTrait {
       CRM_Utils_PDF_Document::printDocuments($html, $fileName, $type, $zip);
     }
     else {
-      CRM_Utils_PDF_Document::html2doc($html, $fileName, $formValues);
+      CRM_Utils_PDF_Document::html2doc($html, $fileName . '.' . $this->getSubmittedValue('document_type'), $formValues);
     }
 
     if ($tee) {


### PR DESCRIPTION
Overview
----------------------------------------
Fix for a regression in the 5.43 rc found by @Stoob - the pdf letter task was failing when outputing in word format

Note this bug relates to the work done to cleanup token processing but replicating it does not rely on there being any tokens in the pdf template - the issue is the filename being passed to `html2doc` did not have the file suffix appended.

Before
----------------------------------------
Hard fail when trying to generate pdf letters from a contact search

```
PhpOffice\PhpWord\Exception\Exception: """ is not a valid writer."
#0 /home/centos/domains/stage.site.org/public_html/sites/all/modules/civicrm/CRM/Utils/PDF/Document.php(122): PhpOffice\PhpWord\IOFactory::createWriter(Object(PhpOffice\PhpWord\PhpWord), NULL)
#1 (closed) /home/centos/domains/stage.site.org/public_html/sites/all/modules/civicrm/CRM/Utils/PDF/Document.php(93): CRM_Utils_PDF_Document::printDoc(Object(PhpOffice\PhpWord\PhpWord), "", "Thank_you_letter_created")
#2 (closed) /home/centos/domains/stage.site.org/public_html/sites/all/modules/civicrm/CRM/Contact/Form/Task/PDFTrait.php(273): CRM_Utils_PDF_Document::html2doc((Array:1), "Thank_you_letter_created", (Array:29))
```

After
----------------------------------------
File generates

Technical Details
----------------------------------------

Comments
----------------------------------------
@Stoob thanks for finding this! It looks like the Activity pdf task & Contribute pdf task were not affected but Contact, Membership & participant would have been