### PR TITLE
dev/financial#57 Hide recur trxn_id if it matches recur processor_id

### DIFF
--- a/templates/CRM/Contribute/Page/ContributionRecur.tpl
+++ b/templates/CRM/Contribute/Page/ContributionRecur.tpl
@@ -35,7 +35,7 @@
       {if !empty($recur.cancel_reason)}<tr><td class="label">{ts}Cancel Reason{/ts}</td><td>{$recur.cancel_reason}</td></tr>{/if}
       {if !empty($recur.end_date)}<tr><td class="label">{ts}End Date{/ts}</td><td>{$recur.end_date|crmDate}</td></tr>{/if}
       {if $recur.processor_id}<tr><td class="label">{ts}Processor ID{/ts}</td><td>{$recur.processor_id}</td></tr>{/if}
-      {if !empty($recur.trxn_id)}<tr><td class="label">{ts}Transaction ID{/ts}</td><td>{$recur.trxn_id}</td></tr>{/if}
+      {if !empty($recur.trxn_id) && ($recur.processor_id neq $recur.trxn_id)}<tr><td class="label">{ts}Transaction ID{/ts}</td><td>{$recur.trxn_id}</td></tr>{/if}
       {if $recur.invoice_id}<tr><td class="label">{ts}Invoice ID{/ts}</td><td>{$recur.invoice_id}</td></tr>{/if}
       <tr><td class="label">{ts}Cycle Day{/ts}</td><td>{$recur.cycle_day}</td></tr>
       {if !empty($recur.next_sched_contribution_date) && $recur.contribution_status_id neq 3}<tr><td class="label">{ts}Next Contribution{/ts}</td><td>{$recur.next_sched_contribution_date|crmDate}</td></tr>{/if}


### PR DESCRIPTION
Overview
----------------------------------------
Hide the recur trxn_id if it matches the processor_id.

Per https://lab.civicrm.org/dev/financial/-/issues/57 contribution_recur.trxn_id is deprecated. For legacy reasons we have to set trxn_id = processor_id in case it is still used by some code but it makes no sense to display that in the UI.

Before
----------------------------------------
Both shown.

![image](https://user-images.githubusercontent.com/2052161/138552067-24fcc766-2ad5-469d-aee8-07379dcc87f2.png)


After
----------------------------------------
Only processor_id shown.

![image](https://user-images.githubusercontent.com/2052161/138552023-c0acc959-9497-4892-bf5c-8dbbe6b51b25.png)


Technical Details
----------------------------------------

Comments
----------------------------------------

