### PR TITLE
Make hardcoded labels passed to setTitle translatable

### DIFF
--- a/CRM/ACL/Form/WordPress/Permissions.php
+++ b/CRM/ACL/Form/WordPress/Permissions.php
@@ -30,7 +30,7 @@ class CRM_ACL_Form_WordPress_Permissions extends CRM_Core_Form {
    */
   public function buildQuickForm() {
 
-    $this->setTitle('WordPress Access Control');
+    $this->setTitle(ts('WordPress Access Control'));
 
     // Get the core permissions array
     $permissionsArray = self::getPermissionArray();

--- a/CRM/Activity/Form/Task/PDF.php
+++ b/CRM/Activity/Form/Task/PDF.php
@@ -23,7 +23,7 @@ class CRM_Activity_Form_Task_PDF extends CRM_Activity_Form_Task {
    */
   public function preProcess(): void {
     parent::preProcess();
-    $this->setTitle('Print/Merge Document');
+    $this->setTitle(ts('Print/Merge Document'));
   }
 
   /**

--- a/CRM/Contact/Form/Task/PDFLetterCommon.php
+++ b/CRM/Contact/Form/Task/PDFLetterCommon.php
@@ -55,7 +55,7 @@ class CRM_Contact_Form_Task_PDFLetterCommon extends CRM_Core_Form_Task_PDFLetter
       $defaults['from_email_address'] = current(CRM_Core_BAO_Domain::getNameAndEmail(FALSE, TRUE));
     }
     $form->setDefaults($defaults);
-    $form->setTitle('Print/Merge Document');
+    $form->setTitle(ts('Print/Merge Document'));
   }
 
   /**

--- a/CRM/Contact/Form/Task/PDFTrait.php
+++ b/CRM/Contact/Form/Task/PDFTrait.php
@@ -179,7 +179,7 @@ trait CRM_Contact_Form_Task_PDFTrait {
       $defaults['from_email_address'] = current(CRM_Core_BAO_Domain::getNameAndEmail(FALSE, TRUE));
     }
     $form->setDefaults($defaults);
-    $form->setTitle('Print/Merge Document');
+    $form->setTitle(ts('Print/Merge Document'));
   }
 
   /**

--- a/CRM/Core/Form/Task/PDFLetterCommon.php
+++ b/CRM/Core/Form/Task/PDFLetterCommon.php
@@ -36,7 +36,7 @@ class CRM_Core_Form_Task_PDFLetterCommon {
   public static function preProcess(&$form) {
     CRM_Core_Error::deprecatedFunctionWarning('no alternative');
 
-    $form->setTitle('Print/Merge Document');
+    $form->setTitle(ts('Print/Merge Document'));
   }
 
   /**

--- a/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/ActivitySearch.php
+++ b/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/ActivitySearch.php
@@ -81,7 +81,7 @@ class CRM_Contact_Form_Search_Custom_ActivitySearch extends CRM_Contact_Form_Sea
     /**
      * You can define a custom title for the search form
      */
-    $this->setTitle('Find Latest Activities');
+    $this->setTitle(ts('Find Latest Activities'));
 
     /**
      * Define the search form fields here

--- a/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/ContribSYBNT.php
+++ b/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/ContribSYBNT.php
@@ -95,7 +95,7 @@ class CRM_Contact_Form_Search_Custom_ContribSYBNT extends CRM_Contact_Form_Searc
       );
     }
 
-    $this->setTitle('Contributions made in Year X and not Year Y');
+    $this->setTitle(ts('Contributions made in Year X and not Year Y'));
     // @TODO: Decide on better names for "Exclusion"
     // @TODO: Add rule to ensure that exclusion dates are not in the inclusion range
   }

--- a/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/ContributionAggregate.php
+++ b/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/ContributionAggregate.php
@@ -53,7 +53,7 @@ class CRM_Contact_Form_Search_Custom_ContributionAggregate extends CRM_Contact_F
     /**
      * You can define a custom title for the search form
      */
-    $this->setTitle('Find Contributors by Aggregate Totals');
+    $this->setTitle(ts('Find Contributors by Aggregate Totals'));
 
     /**
      * Define the search form fields here

--- a/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/DateAdded.php
+++ b/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/DateAdded.php
@@ -72,7 +72,7 @@ class CRM_Contact_Form_Search_Custom_DateAdded extends CRM_Contact_Form_Search_C
       $select2style
     );
 
-    $this->setTitle('Search by date added to CiviCRM');
+    $this->setTitle(ts('Search by date added to CiviCRM'));
 
     //redirect if group not available for search criteria
     if (count($groups) == 0) {

--- a/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/EventAggregate.php
+++ b/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/EventAggregate.php
@@ -52,7 +52,7 @@ class CRM_Contact_Form_Search_Custom_EventAggregate extends CRM_Contact_Form_Sea
     /**
      * You can define a custom title for the search form
      */
-    $this->setTitle('Find Totals for Events');
+    $this->setTitle(ts('Find Totals for Events'));
 
     /**
      * Define the search form fields here

--- a/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/MultipleValues.php
+++ b/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/MultipleValues.php
@@ -85,7 +85,7 @@ class CRM_Contact_Form_Search_Custom_MultipleValues extends CRM_Contact_Form_Sea
    */
   public function buildForm(&$form) {
 
-    $this->setTitle('Multiple Value Custom Group Search and Export');
+    $this->setTitle(ts('Multiple Value Custom Group Search and Export'));
 
     $form->add('text', 'sort_name', ts('Contact Name'), TRUE);
 

--- a/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/PriceSet.php
+++ b/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/PriceSet.php
@@ -198,7 +198,7 @@ AND    p.entity_id    = e.id
     /**
      * You can define a custom title for the search form
      */
-    $this->setTitle('Price Set Export');
+    $this->setTitle(ts('Price Set Export'));
 
     /**
      * if you are using the standard template, this array tells the template what elements

--- a/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/Proximity.php
+++ b/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/Proximity.php
@@ -108,7 +108,7 @@ class CRM_Contact_Form_Search_Custom_Proximity extends CRM_Contact_Form_Search_C
     /**
      * You can define a custom title for the search form
      */
-    $this->setTitle('Proximity Search');
+    $this->setTitle(ts('Proximity Search'));
 
     /**
      * if you are using the standard template, this array tells the template what elements

--- a/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/TagContributions.php
+++ b/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/TagContributions.php
@@ -51,7 +51,7 @@ class CRM_Contact_Form_Search_Custom_TagContributions extends CRM_Contact_Form_S
     /**
      * You can define a custom title for the search form
      */
-    $this->setTitle('Find Contribution Amounts by Tag');
+    $this->setTitle(ts('Find Contribution Amounts by Tag'));
 
     /**
      * Define the search form fields here

--- a/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/ZipCodeRange.php
+++ b/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/ZipCodeRange.php
@@ -60,7 +60,7 @@ class CRM_Contact_Form_Search_Custom_ZipCodeRange extends CRM_Contact_Form_Searc
     /**
      * You can define a custom title for the search form
      */
-    $this->setTitle('Zip Code Range Search');
+    $this->setTitle(ts('Zip Code Range Search'));
 
     /**
      * if you are using the standard template, this array tells the template what elements


### PR DESCRIPTION
Overview
----------------------------------------
Make hardcoded labels passed to setTitle translatable

Before
----------------------------------------
Text was hardcoded.

After
----------------------------------------
Titles passed through `ts()`

Comments
----------------------------------------
This includes changes to the `legacycustomsearches` extension. Although this is referred to as "legacy" I think it makes sense to make this change as this is still part of core CiviCRM.
