### PR TITLE
[REF] Remove usage of deprecated jqXHR.error in jQuery code

### DIFF
--- a/templates/CRM/Financial/Form/Search.tpl
+++ b/templates/CRM/Financial/Form/Search.tpl
@@ -233,7 +233,7 @@ CRM.$(function($) {
           CRM.alert({/literal}'{ts escape="js"}An error occurred while processing your request.{/ts}', $("#batch_update option[value=" + op + "]").text() + ' {ts escape="js"}Error{/ts}'{literal}, 'error');
         }
       },
-      'json').error(serverError);
+      'json').fail(serverError);
   }
 
   function validateOp(records, op) {

--- a/templates/CRM/Financial/Page/BatchTransaction.tpl
+++ b/templates/CRM/Financial/Page/BatchTransaction.tpl
@@ -141,7 +141,7 @@ function saveRecord(recordID, op, recordBAO, entityID) {
       CRM.alert(html.status);
     }
   },
-  'json').error(noServerResponse);
+  'json').fail(noServerResponse);
 }
 
 function batchSummary(entityID) {


### PR DESCRIPTION
Overview
----------------------------------------
`jqXHR.error` is deprecated in jQuery 1.8 and removed in jQuery 3.

This update replaces usage of jqXHR.error with the correct `jqXHR.fail`. (`jqXHR` refers to the promise interface returned by calls to `$.ajax()` and `$.post()`)

Before
----------------------------------------
CiviCRM was using deprecated jQuery methods, which have been removed from jQuery 3.

After
----------------------------------------
CiviCRM is no longer using the deprecated `jqXHR.error` method.

Comments
----------------------------------------
See https://api.jquery.com/jQuery.ajax/#jqXHR for details of the deprecation. CiviCRM appears to currently be using jQuery 1.12.4 which will support the `jqXHR.fail` method.

Although CiviCRM does not use the host CMS's version of jQuery by default, extensions like https://civicrm.org/extensions/civi-jquery do allow CiviCRM to work in this way. This change will help avoid problems if sites attempt to run CiviCRM with their host CMS' version of jQuery and the host CMS is using jQuery 3.

Longer-term this will be a step towards making it feasable for CiviCRM to upgrade to jQuery 3. 
