### PR TITLE
APIv4 - Fix performance drag caused by getInfoItem calling the API

### DIFF
--- a/Civi/Api4/Utils/CoreUtil.php
+++ b/Civi/Api4/Utils/CoreUtil.php
@@ -45,17 +45,26 @@ class CoreUtil {
   }
 
   /**
-   * Get item from an entity's getInfo array
+   * Get a piece of metadata about an entity
    *
    * @param string $entityName
    * @param string $keyToReturn
    * @return mixed
    */
   public static function getInfoItem(string $entityName, string $keyToReturn) {
-    $info = Entity::get(FALSE)
-      ->addWhere('name', '=', $entityName)
-      ->addSelect($keyToReturn)
-      ->execute()->first();
+    // Because this function might be called thousands of times per request, read directly
+    // from the cache set by Apiv4 Entity.get to avoid the processing overhead of the API wrapper.
+    $cached = \Civi::cache('metadata')->get('api4.entities.info');
+    if ($cached) {
+      $info = $cached[$entityName] ?? NULL;
+    }
+    // If the cache is empty, calling Entity.get will populate it and we'll use it next time.
+    else {
+      $info = Entity::get(FALSE)
+        ->addWhere('name', '=', $entityName)
+        ->addSelect($keyToReturn)
+        ->execute()->first();
+    }
     return $info ? $info[$keyToReturn] ?? NULL : NULL;
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a performance bottleneck in APIv4 which was in some cases slowing SearchKit to a crawl (in the unreleased master branch).

Before
----------------------------------------
Searches might take 20 seconds to return results.

After
----------------------------------------
Back to under 2 seconds.

Comments
-----------
I noticed this while testing #21820 

Technical Details
----------------------------------------
The `CoreUtil::getInfoItem` function is sometimes called thousands of times per request, e.g. for every cell in a searchKit display table. Going through the API wrapper that many times is a considerable (+10 sec) drag on performance.
Instead of calling Entity.get, we can just read directly from the cache where it stores its data.