### PR TITLE
Issue 2927: create a method for checking if filename is a directory and also checking open_basedir

### DIFF
--- a/CRM/Admin/Page/APIExplorer.php
+++ b/CRM/Admin/Page/APIExplorer.php
@@ -63,7 +63,7 @@ class CRM_Admin_Page_APIExplorer extends CRM_Core_Page {
     $paths = self::uniquePaths();
     foreach ($paths as $path) {
       $dir = \CRM_Utils_File::addTrailingSlash($path) . 'api' . DIRECTORY_SEPARATOR . 'v3' . DIRECTORY_SEPARATOR . 'examples';
-      if (is_dir($dir)) {
+      if (\CRM_Utils_File::isDir($dir)) {
         foreach (scandir($dir) as $item) {
           if ($item && strpos($item, '.') === FALSE && array_search($item, $examples) === FALSE) {
             $examples[] = $item;
@@ -96,7 +96,7 @@ class CRM_Admin_Page_APIExplorer extends CRM_Core_Page {
       $paths = self::uniquePaths();
       foreach ($paths as $path) {
         $dir = \CRM_Utils_File::addTrailingSlash($path) . 'api' . DIRECTORY_SEPARATOR . 'v3' . DIRECTORY_SEPARATOR . 'examples' . DIRECTORY_SEPARATOR . $_GET['entity'];
-        if (is_dir($dir)) {
+        if (\CRM_Utils_File::isDir($dir)) {
           foreach (scandir($dir) as $item) {
             $item = str_replace('.ex.php', '', $item);
             if ($item && strpos($item, '.') === FALSE) {

--- a/CRM/Utils/File.php
+++ b/CRM/Utils/File.php
@@ -1130,7 +1130,7 @@ HTACCESS;
       $baseDirs = explode(PATH_SEPARATOR, $openBasedir);
       $withinBasedir = FALSE;
       foreach ($baseDirs as $baseDir) {
-        if ($compareFunc($filepath, $baseDir, strlen($baseDir)) === 0) {
+        if ($compareFunc($filePath, $baseDir, strlen($baseDir)) === 0) {
           $withinBasedir = TRUE;
         }
       }

--- a/CRM/Utils/File.php
+++ b/CRM/Utils/File.php
@@ -1112,7 +1112,7 @@ HTACCESS;
       $baseDirs = explode(PATH_SEPARATOR, $openBasedir);
       $withinBasedir = FALSE;
       foreach ($baseDirs as $baseDir) {
-        if (strncmp($fileName, $baseDir, strlen($baseDir)) === 0) {
+        if (strncasecmp($fileName, $baseDir, strlen($baseDir)) === 0) {
           $withinBasedir = TRUE;
         }
       }

--- a/CRM/Utils/File.php
+++ b/CRM/Utils/File.php
@@ -1100,4 +1100,27 @@ HTACCESS;
     return pathinfo($path, PATHINFO_EXTENSION);
   }
 
+  /**
+   * Check that filename is a directory and within open_basedir.
+   * @param string $fileName
+   * @return bool
+   */
+  public static function isDir($fileName = '') {
+    // Ensure filename is within open_basedir restrictions.
+    $openBasedir = ini_get('open_basedir');
+    if (!empty($openBasedir)) {
+      $baseDirs = explode(PATH_SEPARATOR, $openBasedir);
+      $withinBasedir = FALSE;
+      foreach ($baseDirs as $baseDir) {
+        if (strncmp($fileName, $baseDir, strlen($baseDir)) === 0) {
+          $withinBasedir = TRUE;
+        }
+      }
+      if (!$withinBasedir) {
+        return FALSE;
+      }
+    }
+    return is_dir($fileName);
+  }
+
 }

--- a/CRM/Utils/File.php
+++ b/CRM/Utils/File.php
@@ -1107,7 +1107,7 @@ HTACCESS;
    */
   public static function isDir($fileName = '') {
     // If not within open_basedir do not consider it a directory.
-    if (!CRM_Utils_File::isFileInOpenbasedir($filename)) {
+    if (!CRM_Utils_File::isFileInOpenbasedir($fileName)) {
       return FALSE;
     }
     return is_dir($fileName);

--- a/CRM/Utils/File.php
+++ b/CRM/Utils/File.php
@@ -1101,18 +1101,36 @@ HTACCESS;
   }
 
   /**
-   * Check that filename is a directory and within open_basedir.
+   * Check that filename is a directory.
    * @param string $fileName
    * @return bool
    */
   public static function isDir($fileName = '') {
-    // Ensure filename is within open_basedir restrictions.
+    // If not within open_basedir do not consider it a directory.
+    if (!CRM_Utils_File::isFileInOpenbasedir($filename)) {
+      return FALSE;
+    }
+    return is_dir($fileName);
+  }
+
+  /**
+   * Check that path is within open_basedir restriction.
+   * @param string $filePath the absolute path
+   * @return bool
+   */
+  private static function isFileInOpenbasedir($filePath = '') {
+    // Use the appropriate comparison function.
+    $compareFunc = 'strncmp';
+    if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
+      $compareFunc = 'strncasecmp';
+    }
+    // Ensure file path is within open_basedir restrictions.
     $openBasedir = ini_get('open_basedir');
     if (!empty($openBasedir)) {
       $baseDirs = explode(PATH_SEPARATOR, $openBasedir);
       $withinBasedir = FALSE;
       foreach ($baseDirs as $baseDir) {
-        if (strncasecmp($fileName, $baseDir, strlen($baseDir)) === 0) {
+        if ($compareFunc($filepath, $baseDir, strlen($baseDir)) === 0) {
           $withinBasedir = TRUE;
         }
       }
@@ -1120,7 +1138,7 @@ HTACCESS;
         return FALSE;
       }
     }
-    return is_dir($fileName);
+    return TRUE;
   }
 
 }

--- a/Civi/API/Provider/MagicFunctionProvider.php
+++ b/Civi/API/Provider/MagicFunctionProvider.php
@@ -103,7 +103,7 @@ class MagicFunctionProvider implements EventSubscriberInterface, ProviderInterfa
     foreach ($include_dirs as $include_dir) {
       $api_dir = implode(DIRECTORY_SEPARATOR,
         [$include_dir, 'api', 'v' . $version]);
-      if (!is_dir($api_dir)) {
+      if (!CRM_Utils_File::isDir($api_dir)) {
         continue;
       }
       $iterator = new \DirectoryIterator($api_dir);
@@ -119,7 +119,7 @@ class MagicFunctionProvider implements EventSubscriberInterface, ProviderInterfa
 
         // Check for entities with standalone action files (eg "api/v3/MyEntity/MyAction.php").
         $action_dir = $api_dir . DIRECTORY_SEPARATOR . $file;
-        if (preg_match('/^[A-Z][A-Za-z0-9]*$/', $file) && is_dir($action_dir)) {
+        if (preg_match('/^[A-Z][A-Za-z0-9]*$/', $file) && CRM_Utils_File::isDir($action_dir)) {
           if (count(glob("$action_dir/[A-Z]*.php")) > 0) {
             $entities[] = $file;
           }
@@ -281,7 +281,7 @@ class MagicFunctionProvider implements EventSubscriberInterface, ProviderInterfa
       foreach ([$camelName, 'Generic'] as $name) {
         $action_dir = implode(DIRECTORY_SEPARATOR,
           [$include_dir, 'api', "v${version}", $name]);
-        if (!is_dir($action_dir)) {
+        if (!CRM_Utils_File::isDir($action_dir)) {
           continue;
         }
 

--- a/Civi/API/Provider/MagicFunctionProvider.php
+++ b/Civi/API/Provider/MagicFunctionProvider.php
@@ -103,7 +103,7 @@ class MagicFunctionProvider implements EventSubscriberInterface, ProviderInterfa
     foreach ($include_dirs as $include_dir) {
       $api_dir = implode(DIRECTORY_SEPARATOR,
         [$include_dir, 'api', 'v' . $version]);
-      if (!CRM_Utils_File::isDir($api_dir)) {
+      if (!\CRM_Utils_File::isDir($api_dir)) {
         continue;
       }
       $iterator = new \DirectoryIterator($api_dir);
@@ -119,7 +119,7 @@ class MagicFunctionProvider implements EventSubscriberInterface, ProviderInterfa
 
         // Check for entities with standalone action files (eg "api/v3/MyEntity/MyAction.php").
         $action_dir = $api_dir . DIRECTORY_SEPARATOR . $file;
-        if (preg_match('/^[A-Z][A-Za-z0-9]*$/', $file) && CRM_Utils_File::isDir($action_dir)) {
+        if (preg_match('/^[A-Z][A-Za-z0-9]*$/', $file) && \CRM_Utils_File::isDir($action_dir)) {
           if (count(glob("$action_dir/[A-Z]*.php")) > 0) {
             $entities[] = $file;
           }
@@ -281,7 +281,7 @@ class MagicFunctionProvider implements EventSubscriberInterface, ProviderInterfa
       foreach ([$camelName, 'Generic'] as $name) {
         $action_dir = implode(DIRECTORY_SEPARATOR,
           [$include_dir, 'api', "v${version}", $name]);
-        if (!CRM_Utils_File::isDir($action_dir)) {
+        if (!\CRM_Utils_File::isDir($action_dir)) {
           continue;
         }
 


### PR DESCRIPTION
Fixes https://lab.civicrm.org/dev/core/-/issues/2927

Overview
----------------------------------------
Create a method for checking if filename is a directory and also checking open_basedir. Use it instead of is_dir() which throws errors if not within the open_basedir restrictions.

Alternative to https://github.com/civicrm/civicrm-core/pull/21591