### PR TITLE
Remove "Connections" from navigation menu

### DIFF
--- a/CRM/Upgrade/Incremental/sql/5.44.alpha1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.44.alpha1.mysql.tpl
@@ -2,3 +2,6 @@
 
 {* Polulate RelationshipCache.case_id column *}
 UPDATE `civicrm_relationship_cache` rc, `civicrm_relationship` r SET rc.case_id = r.case_id WHERE r.case_id IS NOT NULL AND r.id = rc.relationship_id;
+
+{* Remove Connections admin menu item *}
+DELETE FROM `civicrm_navigation` WHERE url = 'civicrm/a/#/cxn';

--- a/xml/templates/civicrm_navigation.tpl
+++ b/xml/templates/civicrm_navigation.tpl
@@ -378,7 +378,6 @@ INSERT INTO civicrm_navigation
 VALUES
 
     ( @domainID, 'civicrm/admin/setting/component?reset=1',             '{ts escape="sql" skip="true"}Components{/ts}', 'Enable Components',                                    'administer CiviCRM', '', @systemSettingslastID, '1', NULL, 1 ),
-    ( @domainID, 'civicrm/a/#/cxn',                                     '{ts escape="sql" skip="true"}Connections{/ts}', 'Connections',                                         'administer CiviCRM', '', @systemSettingslastID, '1', NULL, 2 ),
     ( @domainID, 'civicrm/admin/extensions?reset=1',                    '{ts escape="sql" skip="true"}Extensions{/ts}', 'Manage Extensions',                                    'administer CiviCRM', '', @systemSettingslastID, '1', 1,    3 ),
 
     ( @domainID, 'civicrm/admin/setting/updateConfigBackend?reset=1',   '{ts escape="sql" skip="true"}Cleanup Caches and Update Paths{/ts}', 'Cleanup Caches and Update Paths', 'administer CiviCRM', '', @systemSettingslastID, '1', NULL, 4 ),


### PR DESCRIPTION
Overview
----------------------------------------
This obscure feature is currently unused, so there's no reason to show it in the menu.

Fixes https://lab.civicrm.org/dev/core/-/issues/2910