### PR TITLE
Remove unused variable

### DIFF
--- a/templates/CRM/common/CMSPrint.tpl
+++ b/templates/CRM/common/CMSPrint.tpl
@@ -34,9 +34,6 @@
 {/crmRegion}
 <div class="clear"></div>
 
-{if isset($localTasks) and $localTasks}
-    {include file="CRM/common/localNav.tpl"}
-{/if}
 <div id="crm-main-content-wrapper">
   {include file="CRM/common/status.tpl"}
   {crmRegion name='page-body'}


### PR DESCRIPTION
Overview
----------------------------------------
Remove unused variable

Before
----------------------------------------
`localTasks' handled but never appear to be assigned

After
----------------------------------------
poof

Technical Details
----------------------------------------
I did some digging for this & the only clue as to it's being used
pointed to Joomla! But, it's not assigned from anywhere in the Joomla!
repo.


Comments
----------------------------------------
CMSPrint is pretty safe to remove from I would think - but it is also here https://github.com/civicrm/civicrm-core/blob/e10fac94e0b3b840d1a5af4feab24f6fb14d6c64/templates/CRM/common/joomla.tpl#L49 @vingle any ideas?


Here is what it includes 

https://github.com/civicrm/civicrm-core/blob/1188c7a8512382b1cb588b6a1ea4b13aa9587bc9/templates/CRM/common/localNav.tpl#L10-L18