### PR TITLE
Ensure no_licence is assigned for drop.tpl

### DIFF
--- a/CRM/Core/CodeGen/Schema.php
+++ b/CRM/Core/CodeGen/Schema.php
@@ -65,6 +65,7 @@ class CRM_Core_CodeGen_Schema extends CRM_Core_CodeGen_BaseTask {
     $dropOrder = array_reverse(array_keys($this->tables));
     $template = new CRM_Core_CodeGen_Util_Template('sql');
     $template->assign('dropOrder', $dropOrder);
+    $template->assign('isOutputLicense', TRUE);
     return ['civicrm_drop.mysql' => $template->fetch('drop.tpl')];
   }
 

--- a/xml/templates/drop.tpl
+++ b/xml/templates/drop.tpl
@@ -1,4 +1,4 @@
-{*suppress license if within a file that already has the license*}{if !isset($no_license) or !$no_license}-- +--------------------------------------------------------------------+
+{*suppress license if within a file that already has the license*}{if $isOutputLicense}-- +--------------------------------------------------------------------+
 -- | Copyright CiviCRM LLC. All rights reserved.                        |
 -- |                                                                    |
 -- | This work is published under the GNU AGPLv3 license with some      |
@@ -11,7 +11,7 @@
 --{/if}
 -- /*******************************************************
 -- *
--- * Clean up the existing tables{if isset($no_license) and $no_license} - this section generated from {$smarty.template}
+-- * Clean up the existing tables{if !$isOutputLicense} - this section generated from {$smarty.template}
 {/if}
 -- *
 -- *******************************************************/

--- a/xml/templates/schema.tpl
+++ b/xml/templates/schema.tpl
@@ -10,7 +10,7 @@
 -- {$generated}
 --{if $database.comment} {$database.comment}{/if}
 
-{include file="drop.tpl" no_license=TRUE}
+{include file="drop.tpl" isOutputLicense=false}
 
 -- /*******************************************************
 -- *


### PR DESCRIPTION
Overview
----------------------------------------
Use empty not isset in drop.tpl

Before
----------------------------------------
Is uses isset

After
----------------------------------------
uses simple check since it is always assigned

Technical Details
----------------------------------------
On experimenting a little with smarty escaping it turns out that isset is gonna be
a lot more painful than empty - we should avoid where we can. However, empty will enotice
with escape on output enabled so the best really is to ensure a variable is defined


Comments
----------------------------------------
