### PR TITLE
WIP - optin escape on output for smarty

### DIFF
--- a/templates/CRM/ACL/Header.tpl
+++ b/templates/CRM/ACL/Header.tpl
@@ -16,21 +16,27 @@
 {php}
   $currentStep = $this->get_template_vars('step');
   $wizard = array(
-    'style' => array(),
+    'style' => ['showTitle' => '', 'barClass' => ''],
     'currentStepNumber' => $currentStep,
     'steps' => array(
-      array(
+      [
         'title' => ts('Manage Roles'),
         'link' => CRM_Utils_System::url('civicrm/admin/options/acl_role', 'reset=1'),
-      ),
-      array(
+        'collapsed' => '',
+        'name' => '',
+      ],
+      [
         'title' => ts('Assign Users'),
         'link' => CRM_Utils_System::url('civicrm/acl/entityrole', 'reset=1'),
-      ),
-      array(
+        'collapsed' => '',
+        'name' => '',
+      ],
+      [
         'title' => ts('Manage ACLs'),
         'link' => CRM_Utils_System::url('civicrm/acl', 'reset=1'),
-      ),
+        'collapsed' => '',
+        'name' => '',
+      ],
     ),
   );
   foreach ($wizard['steps'] as $num => &$step) {

--- a/templates/CRM/ACL/Page/ACL.tpl
+++ b/templates/CRM/ACL/Page/ACL.tpl
@@ -42,7 +42,7 @@
                 <td class="crm-acl-object" >{$row.object}</td>
                 <td class="crm-acl-name crm-editable" data-field="name">{$row.name}</td>
                 <td class="crm-acl-is_active" id="row_{$aclID}_status">{if $row.is_active eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
-                <td>{$row.action|replace:'xx':$aclID}</td>
+                <td>{$row.action|smarty:nodefaults|replace:'xx':$aclID}</td>
               </tr>
             {/foreach}
             </tbody>

--- a/templates/CRM/ACL/Page/EntityRole.tpl
+++ b/templates/CRM/ACL/Page/EntityRole.tpl
@@ -35,7 +35,7 @@
             <td class="crm-acl_entity_role-acl_role">{$row.acl_role}</td>
             <td class="crm-acl_entity_role-entity">{$row.entity}</td>
             <td class="crm-acl_entity_role-is_active" id="row_{$row.id}_status">{if $row.is_active eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
-            <td>{$row.action|replace:'xx':$row.id}</td>
+            <td>{$row.action|smarty:nodefaults|replace:'xx':$row.id}</td>
           </tr>
         {/foreach}
         </tbody>

--- a/templates/CRM/Activity/Form/Selector.tpl
+++ b/templates/CRM/Activity/Form/Selector.tpl
@@ -104,7 +104,7 @@
 
     <td>
       {if (!empty($row.id))}
-        {$row.action|replace:'xx':$row.id}
+        {$row.action|smarty:nodefaults|replace:'xx':$row.id}
       {else}
         {$row.action}
       {/if}

--- a/templates/CRM/Activity/Selector/Activity.tpl
+++ b/templates/CRM/Activity/Selector/Activity.tpl
@@ -83,7 +83,7 @@
 
         <td class="crm-activity-date_time">{$row.activity_date_time|crmDate}</td>
         <td class="crm-activity-status crm-activity-status_{$row.status_id}">{$row.status}</td>
-        <td>{$row.action|replace:'xx':$row.id}</td>
+        <td>{$row.action|smarty:nodefaults|replace:'xx':$row.id}</td>
       </tr>
       {/foreach}
 

--- a/templates/CRM/Admin/Page/ContactType.tpl
+++ b/templates/CRM/Admin/Page/ContactType.tpl
@@ -36,7 +36,7 @@
         <td class="crm-contactType-label crm-editable" data-field="label">{ts}{$row.label}{/ts}</td>
         <td class="crm-contactType-parent">{if $row.parent}{ts}{$row.parent_label}{/ts}{else}{ts}(built-in){/ts}{/if}</td>
         <td class="crm-contactType-description crm-editable" data-field="description" data-type="textarea">{$row.description}</td>
-        <td>{$row.action|replace:'xx':$row.id}</td>
+        <td>{$row.action|smarty:nodefaults|replace:'xx':$row.id}</td>
     </tr>
     {/foreach}
     </table>

--- a/templates/CRM/Admin/Page/EventTemplate.tpl
+++ b/templates/CRM/Admin/Page/EventTemplate.tpl
@@ -46,7 +46,7 @@
               <td class="crm-event-is_monetary">{if $row.is_monetary eq 1}{ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
               <td class="crm-event-is_online_registration">{if $row.is_online_registration eq 1}{ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
               <td class="crm-event-is_active">{if $row.is_active eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
-              <td class="crm-event-action">{$row.action|replace:'xx':$row.id}</td>
+              <td class="crm-event-action">{$row.action|smarty:nodefaults|replace:'xx':$row.id}</td>
           </tr>
         {/foreach}
       </table>

--- a/templates/CRM/Admin/Page/Extensions/AddNew.tpl
+++ b/templates/CRM/Admin/Page/Extensions/AddNew.tpl
@@ -26,7 +26,7 @@ Depends: CRM/common/enableDisableApi.tpl and CRM/common/jsortable.tpl
           </td>
           <td class="crm-extensions-version">{$row.version|escape}</td>
           <td class="crm-extensions-description">{$row.type|capitalize}</td>
-          <td>{$row.action|replace:'xx':$row.id}</td>
+          <td>{$row.action|smarty:nodefaults|replace:'xx':$row.id}</td>
         </tr>
         <tr class="hiddenElement" id="crm-extensions-details-addnew-{$row.file}">
             <td>

--- a/templates/CRM/Admin/Page/Extensions/Main.tpl
+++ b/templates/CRM/Admin/Page/Extensions/Main.tpl
@@ -35,7 +35,7 @@ Depends: CRM/common/enableDisableApi.tpl and CRM/common/jsortable.tpl
             {/if}
           </td>
           <td class="crm-extensions-description">{$row.type|escape|capitalize}</td>
-          <td>{$row.action|replace:'xx':$row.id}</td>
+          <td>{$row.action|smarty:nodefaults|replace:'xx':$row.id}</td>
         </tr>
         <tr class="hiddenElement" id="crm-extensions-details-{$row.file|escape}">
             <td>

--- a/templates/CRM/Admin/Page/Job.tpl
+++ b/templates/CRM/Admin/Page/Job.tpl
@@ -48,7 +48,7 @@
             <td class="crm-job-name">{if isset($row.parameters)}{if $row.parameters eq null}<em>{ts}no parameters{/ts}</em>{else}<pre>{$row.parameters}</pre>{/if}{/if}</td>
             <td class="crm-job-name">{if isset($row.last_run)}{if $row.last_run eq null}never{else}{$row.last_run|crmDate:$config->dateformatDatetime}{/if}{/if}</td>
             <td id="row_{$row.id}_status" class="crm-job-is_active">{if $row.is_active eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
-          <td>{$row.action|replace:'xx':$row.id}</td>
+          <td>{$row.action|smarty:nodefaults|replace:'xx':$row.id}</td>
         </tr>
         {/foreach}
         </table>

--- a/templates/CRM/Admin/Page/LabelFormats.tpl
+++ b/templates/CRM/Admin/Page/LabelFormats.tpl
@@ -56,7 +56,7 @@
               <td class="crm-labelFormat-is_default">{icon condition=$row.is_default}{ts}Default{/ts}{/icon}&nbsp;</td>
               <td class="crm-labelFormat-is_reserved">{if $row.is_reserved eq 1}{ts}Yes{/ts}{else}{ts}No{/ts}{/if}
                 &nbsp;</td>
-              <td>{$row.action|replace:'xx':$row.id}</td>
+              <td>{$row.action|smarty:nodefaults|replace:'xx':$row.id}</td>
             </tr>
           {/foreach}
         </table>

--- a/templates/CRM/Admin/Page/LocationType.tpl
+++ b/templates/CRM/Admin/Page/LocationType.tpl
@@ -40,8 +40,8 @@
         <td class="crmf-vcard_name crm-editable">{if !empty($row.vcard_name)}{$row.vcard_name}{/if}</td>
         <td class="crmf-description crm-editable">{$row.description}</td>
         <td id="row_{$row.id}_status" class="crmf-is_active">{if $row.is_active eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
-        <td class="crmf-is_default">{if isset($row.is_default)}{icon condition=$row.is_default}{ts}Default{/ts}{/icon}&nbsp;{/if}</td>
-        <td>{$row.action|replace:'xx':$row.id}</td>
+        <td class="crmf-is_default">{if $row.is_default}{icon condition=$row.is_default}{ts}Default{/ts}{/icon}&nbsp;{/if}</td>
+        <td>{$row.action|smarty:nodefaults|replace:'xx':$row.id}</td>
     </tr>
     {/foreach}
     </table>

--- a/templates/CRM/Admin/Page/MailSettings.tpl
+++ b/templates/CRM/Admin/Page/MailSettings.tpl
@@ -44,7 +44,7 @@
               <!--<td>{if !empty($row.port)}{$row.port}{/if}</td>-->
               <td class="crm-mailSettings-is_ssl">{if isset($row.is_ssl) and $row.is_ssl eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
               <td class="crm-mailSettings-is_default">{if $row.is_default eq 1}{ts}Bounce Processing <strong>(Default)</strong>{/ts}{else}{ts}Email-to-Activity{/ts}{/if}&nbsp;</td>
-              <td>{$row.action|replace:'xx':$row.id}</td>
+              <td>{$row.action|smarty:nodefaults|replace:'xx':$row.id}</td>
           </tr>
         {/foreach}
       </table>

--- a/templates/CRM/Admin/Page/Mapping.tpl
+++ b/templates/CRM/Admin/Page/Mapping.tpl
@@ -31,7 +31,7 @@
                 <td class="crm-mapping-name">{$row.name}</td>
                 <td class="crm-mapping-description">{$row.description}</td>
                 <td class="crm-mapping-mapping_type">{$row.mapping_type}</td>
-                <td>{$row.action|replace:'xx':$row.id}</td>
+                <td>{$row.action|smarty:nodefaults|replace:'xx':$row.id}</td>
             </tr>
             {/foreach}
             </table>

--- a/templates/CRM/Admin/Page/MessageTemplates.tpl
+++ b/templates/CRM/Admin/Page/MessageTemplates.tpl
@@ -131,7 +131,7 @@
                         <td>{$row.msg_subject}</td>
                         <td id="row_{$row.id}_status">{if $row.is_active eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
                       {/if}
-                      <td>{$row.action|replace:'xx':$row.id}</td>
+                      <td>{$row.action|smarty:nodefaults|replace:'xx':$row.id}</td>
                     </tr>
                 {/foreach}
                 </tbody>

--- a/templates/CRM/Admin/Page/Options.tpl
+++ b/templates/CRM/Admin/Page/Options.tpl
@@ -139,7 +139,7 @@
             {/if}
             <td class="crm-admin-options-is_reserved">{if $row.is_reserved eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
             <td class="crm-admin-options-is_active" id="row_{$row.id}_status">{if $row.is_active eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
-            <td>{$row.action|replace:'xx':$row.id}</td>
+            <td>{$row.action|smarty:nodefaults|replace:'xx':$row.id}</td>
           </tr>
         {/foreach}
         </tbody>

--- a/templates/CRM/Admin/Page/ParticipantStatusType.tpl
+++ b/templates/CRM/Admin/Page/ParticipantStatusType.tpl
@@ -38,7 +38,7 @@
           <td class="center crmf-is_counted">{icon condition=$row.is_counted}{ts}Counted{/ts}{/icon}</td>
           <td class="crmf-weight">{$row.weight}</td>
           <td class="crmf-visibility">{$row.visibility}</td>
-          <td>{$row.action|replace:'xx':$row.id}</td>
+          <td>{$row.action|smarty:nodefaults|replace:'xx':$row.id}</td>
         </tr>
       {/foreach}
     </table>

--- a/templates/CRM/Admin/Page/PaymentProcessor.tpl
+++ b/templates/CRM/Admin/Page/PaymentProcessor.tpl
@@ -44,7 +44,7 @@
             <td class="crmf-is_active center">{if $row.is_active eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
             <td class="crmf-is_default center">{icon condition=$row.is_default}{ts}Default{/ts}{/icon}&nbsp;
             </td>
-            <td>{$row.action|replace:'xx':$row.id}</td>
+            <td>{$row.action|smarty:nodefaults|replace:'xx':$row.id}</td>
         </tr>
         {/foreach}
         </table>

--- a/templates/CRM/Admin/Page/PdfFormats.tpl
+++ b/templates/CRM/Admin/Page/PdfFormats.tpl
@@ -52,7 +52,7 @@
             <td class="crm-pdfFormat-description">{$row.description}</td>
             <td class="crm-pdfFormat-is_default">{icon condition=$row.is_default}{ts}Default{/ts}{/icon}&nbsp;</td>
           <td class="crm-pdfFormat-order nowrap">{$row.weight}</td>
-          <td>{$row.action|replace:'xx':$row.id}</td>
+          <td>{$row.action|smarty:nodefaults|replace:'xx':$row.id}</td>
         </tr>
         {/foreach}
         </table>

--- a/templates/CRM/Admin/Page/PreferencesDate.tpl
+++ b/templates/CRM/Admin/Page/PreferencesDate.tpl
@@ -31,7 +31,7 @@
                 <td class="nowrap">{if !$row.date_format}{ts}Default{/ts}{else}{$row.date_format}{/if}</td>
                 <td align="right">{$row.start}</td>
                 <td align="right">{$row.end}</td>
-                <td><span>{$row.action|replace:'xx':$row.id}</span></td>
+                <td><span>{$row.action|smarty:nodefaults|replace:'xx':$row.id}</span></td>
             </tr>
             {/foreach}
         </table>

--- a/templates/CRM/Admin/Page/RelationshipType.tpl
+++ b/templates/CRM/Admin/Page/RelationshipType.tpl
@@ -54,7 +54,7 @@
                 {if $row.contact_type_b_display} {$row.contact_type_b_display}
                 {if !empty($row.contact_sub_type_b)} - {$row.contact_sub_type_b}{/if} {else} {ts}All Contacts{/ts} {/if} </td>
             <td class="crm-relationship-is_active" id="row_{$row.id}_status">{if $row.is_active eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
-            <td>{$row.action|replace:'xx':$row.id}</td>
+            <td>{$row.action|smarty:nodefaults|replace:'xx':$row.id}</td>
         </tr>
         {/foreach}
         </table>

--- a/templates/CRM/Admin/Page/Reminders.tpl
+++ b/templates/CRM/Admin/Page/Reminders.tpl
@@ -35,7 +35,7 @@
           <td class="crm-scheduleReminders-title">{$row.status}</td>
           <td class="crm-scheduleReminders-is_repeat">{if $row.is_repeat eq 1}{ts}Yes{/ts}{else}{ts}No{/ts}{/if}&nbsp;</td>
           <td id="row_{$row.id}_status" class="crm-scheduleReminders-is_active">{if $row.is_active eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
-          <td>{$row.action|replace:'xx':$row.id}</td>
+          <td>{$row.action|smarty:nodefaults|replace:'xx':$row.id}</td>
           <td class="hiddenElement"></td>
         </tr>
       {/foreach}

--- a/templates/CRM/Badge/Page/Layout.tpl
+++ b/templates/CRM/Badge/Page/Layout.tpl
@@ -40,7 +40,7 @@
               </td>
               <td class="crm-badge-layout-is_default">{icon condition=$row.is_default}{ts}Default{/ts}{/icon}&nbsp;
               </td>
-              <td>{$row.action|replace:'xx':$row.id}</td>
+              <td>{$row.action|smarty:nodefaults|replace:'xx':$row.id}</td>
             </tr>
           {/foreach}
         </table>

--- a/templates/CRM/Block/CreateNew.tpl
+++ b/templates/CRM/Block/CreateNew.tpl
@@ -28,12 +28,13 @@
     <div id="crm-create-new-list">
       <div class="crm-create-new-list-inner">
       <ul>
+
         {foreach from=$shortCuts item=short}
-          <li><a href="{$short.url}" class="crm-{$short.ref}">{$short.title}</a>
+          <li><a href="{$short.url}" class="crm-{$short.ref}">{$short.title|smarty:nodefaults}</a>
             {if $short.shortCuts}
               <ul>
                 {foreach from=$short.shortCuts item=shortCut}
-                  <li><a href="{$shortCut.url}" class="crm-{$shortCut.ref}">{$shortCut.title}</a></li>
+                  <li><a href="{$shortCut.url}" class="crm-{$shortCut.ref}">{$shortCut.title|smarty:nodefaults}</a></li>
                 {/foreach}
               </ul>
             {/if}

--- a/templates/CRM/Campaign/Page/SurveyType.tpl
+++ b/templates/CRM/Campaign/Page/SurveyType.tpl
@@ -35,7 +35,7 @@
           <td class="nowrap crm-admin-options-order">{$row.weight}</td>
           <td class="crm-admin-options-is_reserved">{if $row.is_reserved eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
           <td class="crm-admin-options-is_active" id="row_{$row.id}_status">{if $row.is_active eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
-          <td>{$row.action|replace:'xx':$row.id}</td>
+          <td>{$row.action|smarty:nodefaults|replace:'xx':$row.id}</td>
         </tr>
         {/foreach}
         </table>

--- a/templates/CRM/Case/Form/Selector.tpl
+++ b/templates/CRM/Case/Form/Selector.tpl
@@ -55,7 +55,7 @@
   {$row.case_recent_activity_type}<br />{$row.case_recent_activity_date|crmDate}{else}---{/if}</td>
     <td class="crm-case-case_scheduled_activity_type">{if $row.case_scheduled_activity_type}
   {$row.case_scheduled_activity_type}<br />{$row.case_scheduled_activity_date|crmDate}{else}---{/if}</td>
-    <td>{$row.action|replace:'xx':$row.case_id}{$row.moreActions|replace:'xx':$row.case_id}</td>
+    <td>{$row.action|smarty:nodefaults|replace:'xx':$row.case_id}{$row.moreActions|replace:'xx':$row.case_id}</td>
   {/foreach}
 
     {* Dashboard only lists 10 most recent cases. *}

--- a/templates/CRM/Contact/Form/Selector.tpl
+++ b/templates/CRM/Contact/Form/Selector.tpl
@@ -63,7 +63,7 @@
               </td>
                {/if}
             {/foreach}
-            <td>{$row.action|replace:'xx':$row.contact_id}</td>
+            <td>{$row.action|smarty:nodefaults|replace:'xx':$row.contact_id}</td>
         </tr>
      {/foreach}
   {else}
@@ -118,7 +118,7 @@
                 {/if}
               {/foreach}
             {/if}
-            <td style='width:125px;'>{$row.action|replace:'xx':$row.contact_id}</td>
+            <td style='width:125px;'>{$row.action|smarty:nodefaults|replace:'xx':$row.contact_id}</td>
          </tr>
     {/foreach}
   {/if}

--- a/templates/CRM/Contact/Page/DedupeRules.tpl
+++ b/templates/CRM/Contact/Page/DedupeRules.tpl
@@ -38,7 +38,7 @@
               <tr class="{cycle values="odd-row,even-row"}">
                 <td>{$row.title}</td>
                 <td>{$row.used_display}</td>
-                <td>{$row.action|replace:'xx':$row.id}</td>
+                <td>{$row.action|smarty:nodefaults|replace:'xx':$row.id}</td>
               </tr>
             {/foreach}
           </table>

--- a/templates/CRM/Contribute/Form/Selector.tpl
+++ b/templates/CRM/Contribute/Form/Selector.tpl
@@ -88,7 +88,7 @@
           </td>
           <td class="crm-contribution-soft_credit_type">{$row.contribution_soft_credit_type}</td>
         {/if}
-        <td>{$row.action|replace:'xx':$row.contribution_id}</td>
+        <td>{$row.action|smarty:nodefaults|replace:'xx':$row.contribution_id}</td>
       </tr>
     {/foreach}
 

--- a/templates/CRM/Contribute/Page/ContributionPage.tpl
+++ b/templates/CRM/Contribute/Page/ContributionPage.tpl
@@ -72,7 +72,7 @@
         {/if}
 
         <div class="crm-contribution-page-more">
-                    {$row.action|replace:'xx':$row.id}
+                    {$row.action|smarty:nodefaults|replace:'xx':$row.id}
             </div>
 
       </td>

--- a/templates/CRM/Contribute/Page/ContributionRecurSelector.tpl
+++ b/templates/CRM/Contribute/Page/ContributionRecurSelector.tpl
@@ -29,7 +29,7 @@
         <td>{$row.installments}</td>
         <td>{$row.payment_processor}</td>
         <td>{$row.contribution_status}</td>
-        <td>{$row.action|replace:'xx':$row.recurId}</td>
+        <td>{$row.action|smarty:nodefaults|replace:'xx':$row.recurId}</td>
       </tr>
     {/foreach}
   </table>

--- a/templates/CRM/Contribute/Page/ContributionType.tpl
+++ b/templates/CRM/Contribute/Page/ContributionType.tpl
@@ -39,7 +39,7 @@
           <td>{if $row.is_deductible eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
           <td>{if $row.is_reserved eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
           <td id="row_{$row.id}_status">{if $row.is_active eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
-          <td>{$row.action|replace:'xx':$row.id}</td>
+          <td>{$row.action|smarty:nodefaults|replace:'xx':$row.id}</td>
         </tr>
         {/foreach}
          </table>

--- a/templates/CRM/Contribute/Page/ManagePremiums.tpl
+++ b/templates/CRM/Contribute/Page/ManagePremiums.tpl
@@ -51,7 +51,7 @@
           <td class="crm-contribution-form-block-cost">{$row.cost|crmMoney}</td>
           <td class="crm-contribution-form-block-financial_type">{$row.financial_type}</td>
           <td id="row_{$row.id}_status" >{if $row.is_active eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
-          <td id={$row.id}>{$row.action|replace:'xx':$row.id}</td>
+          <td id={$row.id}>{$row.action|smarty:nodefaults|replace:'xx':$row.id}</td>
         </tr>
         {/foreach}
         </table>

--- a/templates/CRM/Contribute/Page/PcpUserDashboard.tpl
+++ b/templates/CRM/Contribute/Page/PcpUserDashboard.tpl
@@ -31,7 +31,7 @@
         <td>{if $row.end_date}{$row.end_date|truncate:10:''|crmDate}{else}({ts}ongoing{/ts}){/if}</td>
         <td>{$row.pcpStatus}</td>
         {if empty($userChecksum)}
-          <td>{$row.action|replace:'xx':$row.pcpId}</td>
+          <td>{$row.action|smarty:nodefaults|replace:'xx':$row.pcpId}</td>
         {/if}
   </tr>
   {/foreach}
@@ -66,7 +66,7 @@
   <tr class="{cycle values="odd-row,even-row"}">
     <td>{if $row.component eq 'contribute'}<a href="{crmURL p='civicrm/contribute/transact' q="id=`$row.pageId`&reset=1"}" title="{ts}View campaign page{/ts}">{else}<a href="{crmURL p='civicrm/event/register' q="id=`$row.pageId`&reset=1"}" title="{ts}View campaign page{/ts}">{/if}{$row.pageTitle}</a></td>
         <td>{if $row.end_date}{$row.end_date|truncate:10:''|crmDate}{else}({ts}ongoing{/ts}){/if}</td>
-    <td>{$row.action|replace:'xx':$row.pageId}</td>
+    <td>{$row.action|smarty:nodefaults|replace:'xx':$row.pageId}</td>
   </tr>
   {/foreach}
 </table>

--- a/templates/CRM/Custom/Page/Field.tpl
+++ b/templates/CRM/Custom/Page/Field.tpl
@@ -45,7 +45,7 @@
             <td class="crm-editable" data-type="boolean" data-field="is_required">{if !empty($row.is_required)} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
             <td class="crm-editable" data-type="boolean" data-field="is_searchable">{if !empty($row.is_searchable)} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
             <td>{if !empty($row.is_active)} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
-            <td>{$row.action|replace:'xx':$row.id}</td>
+            <td>{$row.action|smarty:nodefaults|replace:'xx':$row.id}</td>
         </tr>
         {/foreach}
         </tbody>

--- a/templates/CRM/Custom/Page/Group.tpl
+++ b/templates/CRM/Custom/Page/Group.tpl
@@ -48,7 +48,7 @@
           <td>{if !empty($row.extends_entity_column_value)}{$row.extends_entity_column_value}{/if}</td>
           <td class="nowrap">{$row.weight}</td>
           <td>{$row.style_display}</td>
-          <td>{$row.action|replace:'xx':$row.id}</td>
+          <td>{$row.action|smarty:nodefaults|replace:'xx':$row.id}</td>
         </tr>
         {/foreach}
         </tbody>

--- a/templates/CRM/Event/Form/Selector.tpl
+++ b/templates/CRM/Event/Form/Selector.tpl
@@ -66,7 +66,7 @@
    </td>
     <td class="crm-participant-participant_status crm-participant_status_{$row.participant_status_id}">{$row.participant_status}</td>
     <td class="crm-participant-participant_role">{$row.participant_role_id}</td>
-    <td>{$row.action|replace:'xx':$participant_id}</td>
+    <td>{$row.action|smarty:nodefaults|replace:'xx':$participant_id}</td>
    </tr>
   {/foreach}
 {* Link to "View all participants" for Dashboard and Contact Summary *}

--- a/templates/CRM/Event/Page/ManageEvent.tpl
+++ b/templates/CRM/Event/Page/ManageEvent.tpl
@@ -122,7 +122,7 @@
               {$row.eventlinks|replace:'xx':$row.id}
             </div>
             <div class="crm-event-more">
-              {$row.action|replace:'xx':$row.id}
+              {$row.action|smarty:nodefaults|replace:'xx':$row.id}
             </div>
           </td>
           <td class="crm-event-start_date hiddenElement">{$row.start_date|crmDate}</td>

--- a/templates/CRM/Financial/Page/FinancialAccount.tpl
+++ b/templates/CRM/Financial/Page/FinancialAccount.tpl
@@ -54,7 +54,7 @@
           <td>{if $row.is_reserved eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
           <td>{icon condition=$row.is_default}{ts}Default{/ts}{/icon}</td>
           <td id="row_{$row.id}_status">{if $row.is_active eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
-          <td>{$row.action|replace:'xx':$row.id}</td>
+          <td>{$row.action|smarty:nodefaults|replace:'xx':$row.id}</td>
         </tr>
         {/foreach}
       </table>

--- a/templates/CRM/Financial/Page/FinancialType.tpl
+++ b/templates/CRM/Financial/Page/FinancialType.tpl
@@ -44,7 +44,7 @@
           <td class="crm-editable" data-field="is_deductible" data-type="boolean">{if $row.is_deductible eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
           <td>{if $row.is_reserved eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
           <td id="row_{$row.id}_status">{if $row.is_active eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
-          <td>{$row.action|replace:'xx':$row.id}</td>
+          <td>{$row.action|smarty:nodefaults|replace:'xx':$row.id}</td>
         </tr>
         {/foreach}
          </table>

--- a/templates/CRM/Financial/Page/FinancialTypeAccount.tpl
+++ b/templates/CRM/Financial/Page/FinancialTypeAccount.tpl
@@ -40,7 +40,7 @@
           <td>{$row.financial_account_type}{if $row.account_type_code} ({$row.account_type_code}){/if}</td>
           <td>{$row.owned_by}</td>
           <td id="row_{$row.id}_status">{if $row.is_active eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
-          <td>{$row.action|replace:'xx':$row.id}</td>
+          <td>{$row.action|smarty:nodefaults|replace:'xx':$row.id}</td>
         </tr>
         {/foreach}
       </table>

--- a/templates/CRM/Grant/Form/Selector.tpl
+++ b/templates/CRM/Grant/Form/Selector.tpl
@@ -50,7 +50,7 @@
     <td class="right crm-grant-grant_application_received_date">{$row.grant_application_received_date|truncate:10:''|crmDate}</td>
     <td class="crm-grant-grant_report_received">{if $row.grant_report_received}{ts}Yes{/ts}{else}{ts}No{/ts}{/if}</td>
     <td class="right crm-grant-grant_money_transfer_date">{$row.grant_money_transfer_date|truncate:10:''|crmDate}</td>
-    <td>{$row.action|replace:'xx':$row.grant_id}</td>
+    <td>{$row.action|smarty:nodefaults|replace:'xx':$row.grant_id}</td>
    </tr>
   {/foreach}
 

--- a/templates/CRM/Group/Page/GroupRows.tpl
+++ b/templates/CRM/Group/Page/GroupRows.tpl
@@ -16,6 +16,6 @@
     {$row.description|mb_truncate:80:"...":true}
     </td>
     <td>{$row.visibility}</td>
-    <td>{$row.action|replace:'xx':$row.id}</td>
+    <td>{$row.action|smarty:nodefaults|replace:'xx':$row.id}</td>
     </tr>
 {/foreach}

--- a/templates/CRM/Mailing/Form/Selector.tpl
+++ b/templates/CRM/Mailing/Form/Selector.tpl
@@ -45,7 +45,7 @@
     <td>{$row.mailing_subject}</td>
     <td>{$row.mailing_job_status}</td>
     <td class="crm-mailing-end_date">{$row.mailing_job_end_date|crmDate}</td>
-    <td>{$row.action|replace:'xx':$row.contact_id}</td>
+    <td>{$row.action|smarty:nodefaults|replace:'xx':$row.contact_id}</td>
   </tr>
   {/foreach}
 </table>

--- a/templates/CRM/Mailing/Page/Browse.tpl
+++ b/templates/CRM/Mailing/Page/Browse.tpl
@@ -70,7 +70,7 @@
        {if call_user_func(array('CRM_Campaign_BAO_Campaign','isCampaignEnable'))}
           <td class="crm-mailing-campaign">{$row.campaign}</td>
       {/if}
-        <td>{$row.action|replace:'xx':$row.id}</td>
+        <td>{$row.action|smarty:nodefaults|replace:'xx':$row.id}</td>
       </tr>
       {/foreach}
     </table>

--- a/templates/CRM/Mailing/Page/Component.tpl
+++ b/templates/CRM/Mailing/Page/Component.tpl
@@ -37,7 +37,7 @@
            <td>{$row.body_text|escape}</td>
            <td>{icon condition=$row.is_default}{ts}Default{/ts}{/icon}&nbsp;</td>
      <td id="row_{$row.id}_status">{if $row.is_active eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
-           <td>{$row.action|replace:'xx':$row.id}</td>
+           <td>{$row.action|smarty:nodefaults|replace:'xx':$row.id}</td>
         </tr>
        {/foreach}
        </table>

--- a/templates/CRM/Member/Form/Selector.tpl
+++ b/templates/CRM/Member/Form/Selector.tpl
@@ -59,7 +59,7 @@
       {/if}
     </td>
     <td>
-        {$row.action|replace:'xx':$row.membership_id}
+        {$row.action|smarty:nodefaults|replace:'xx':$row.membership_id}
         {if $row.owner_membership_id}
             <a href="{crmURL p='civicrm/membership/view' q="reset=1&id=`$row.owner_membership_id`&action=view&context=search"}" title="{ts}View Primary member record{/ts}" class="action-item">{ts}View Primary{/ts}</a>
         {/if}

--- a/templates/CRM/Member/Page/MembershipStatus.tpl
+++ b/templates/CRM/Member/Page/MembershipStatus.tpl
@@ -48,7 +48,7 @@
           <td class="crmf-is_admin crm-editable" data-type="boolean">{if $row.is_admin eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
           <td class="nowrap crmf-weight">{$row.weight}</td>
           <td class="crmf-is_reserved">{if $row.is_reserved eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
-          <td>{if !empty($row.action)}{$row.action|replace:'xx':$row.id}{/if}</td>
+          <td>{if !empty($row.action)}{$row.action|smarty:nodefaults|replace:'xx':$row.id}{/if}</td>
         </tr>
         {/foreach}
         </table>

--- a/templates/CRM/Member/Page/MembershipType.tpl
+++ b/templates/CRM/Member/Page/MembershipType.tpl
@@ -49,7 +49,7 @@
           <td class="crmf-visibility crm-editable" data-type="select">{$row.visibility}</td>
           <td class="nowrap crmf-weight">{$row.weight}</td>
           <td class="crmf-is_active">{if $row.is_active eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
-          <td>{$row.action|replace:'xx':$row.id}</td>
+          <td>{$row.action|smarty:nodefaults|replace:'xx':$row.id}</td>
         </tr>
       {/foreach}
     </table>

--- a/templates/CRM/PCP/Page/PCP.tpl
+++ b/templates/CRM/PCP/Page/PCP.tpl
@@ -44,7 +44,7 @@
     <td>{$row.start_date|crmDate}</td>
     <td>{if $row.end_date}{$row.end_date|crmDate}{else}({ts}ongoing{/ts}){/if}</td>
     <td>{$row.status_id}</td>
-    <td id={$row.id}>{$row.action|replace:'xx':$row.id}</td>
+    <td id={$row.id}>{$row.action|smarty:nodefaults|replace:'xx':$row.id}</td>
   </tr>
   {/foreach}
   </tbody>

--- a/templates/CRM/Pledge/Form/Selector.tpl
+++ b/templates/CRM/Pledge/Form/Selector.tpl
@@ -55,7 +55,7 @@
             <td>{$row.pledge_next_pay_date|truncate:10:''|crmDate}</td>
             <td class="right">{$row.pledge_next_pay_amount|crmMoney:$row.pledge_currency}</td>
             <td>{$row.pledge_status}</td>
-            <td>{$row.action|replace:'xx':$row.pledge_id}</td>
+            <td>{$row.action|smarty:nodefaults|replace:'xx':$row.pledge_id}</td>
         </tr>
     {/foreach}
 

--- a/templates/CRM/Price/Page/Field.tpl
+++ b/templates/CRM/Price/Page/Field.tpl
@@ -74,7 +74,7 @@
       </td>
             <td>{if $row.html_type eq "Text / Numeric Quantity" }{$row.tax_amount|crmMoney}{/if}</td>
         {/if}
-        <td class="field-action">{$row.action|replace:'xx':$row.id}</td>
+        <td class="field-action">{$row.action|smarty:nodefaults|replace:'xx':$row.id}</td>
       </tr>
       {/foreach}
     </table>

--- a/templates/CRM/Price/Page/Option.tpl
+++ b/templates/CRM/Price/Page/Option.tpl
@@ -79,7 +79,7 @@
                 <td>{$row.tax_amount|crmMoney}</td>
               {/if}
               <td id="row_{$row.id}_status" class="crm-price-option-is_active">{if $row.is_active eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
-              <td>{$row.action|replace:'xx':$row.id}</td>
+              <td>{$row.action|smarty:nodefaults|replace:'xx':$row.id}</td>
             </tr>
           {/foreach}
           </tbody>

--- a/templates/CRM/Price/Page/Set.tpl
+++ b/templates/CRM/Price/Page/Set.tpl
@@ -52,7 +52,7 @@
           <td class="crmf-title crm-editable">{$row.title}</td>
           <td class="crmf-extends">{$row.extends}</td>
           <td class="crmf-is_active">{if $row.is_active eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
-          <td>{$row.action|replace:'xx':$row.id}</td>
+          <td>{$row.action|smarty:nodefaults|replace:'xx':$row.id}</td>
         </tr>
         {/foreach}
         </table>

--- a/templates/CRM/Profile/Page/View.tpl
+++ b/templates/CRM/Profile/Page/View.tpl
@@ -13,7 +13,7 @@
 {if $overlayProfile }
     {foreach from=$profileGroups item=group}
         <div class="crm-summary-group">
-           {$group.content}
+           {$group.content|smarty:nodefaults}
         </div>
     {/foreach}
 {else}

--- a/templates/CRM/SMS/Page/Provider.tpl
+++ b/templates/CRM/SMS/Page/Provider.tpl
@@ -38,7 +38,7 @@
         </td>
             <td class="crm-api-params">{if $row.api_params eq null}<em>{ts}no parameters{/ts}</em>{else}<pre>{$row.api_params}</pre>{/if}</td>
 
-          <td>{$row.action|replace:'xx':$row.id}</td>
+          <td>{$row.action|smarty:nodefaults|replace:'xx':$row.id}</td>
         </tr>
         {/foreach}
         </table>

--- a/templates/CRM/UF/Page/Field.tpl
+++ b/templates/CRM/UF/Page/Field.tpl
@@ -53,7 +53,7 @@
                 <td class="crm-editable crmf-is_required" data-type="boolean">{if $row.is_required eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
                 <td class="crm-editable crmf-is_view" data-type="boolean">{if $row.is_view eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
                 <td>{if $row.is_reserved     eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
-                <td>{$row.action|replace:'xx':$row.id}</td>
+                <td>{$row.action|smarty:nodefaults|replace:'xx':$row.id}</td>
             </tr>
             {/foreach}
         </table>

--- a/templates/CRM/UF/Page/Group.tpl
+++ b/templates/CRM/UF/Page/Group.tpl
@@ -81,7 +81,7 @@
                 <td>{$row.group_type}</td>
                 <td>{$row.id}</td>
                 <td>{$row.module}</td>
-                <td>{$row.action|replace:'xx':$row.id}</td>
+                <td>{$row.action|smarty:nodefaults|replace:'xx':$row.id}</td>
               </tr>
             {/if}
             {/foreach}
@@ -126,7 +126,7 @@
                 <td>{$row.group_type}</td>
                 <td>{$row.id}</td>
                 <td>{$row.module}</td>
-                <td>{$row.action|replace:'xx':$row.id}</td>
+                <td>{$row.action|smarty:nodefaults|replace:'xx':$row.id}</td>
               </tr>
             {/if}
             {/foreach}

--- a/templates/CRM/common/pager.tpl
+++ b/templates/CRM/common/pager.tpl
@@ -12,18 +12,18 @@
         <div class="crm-pager">
             <span class="element-right">
             {if $location eq 'top'}
-              {$pager->_response.titleTop}
+              {$pager->_response.titleTop|smarty:nodefaults}
             {else}
-              {$pager->_response.titleBottom}
+              {$pager->_response.titleBottom|smarty:nodefaults}
             {/if}
             </span>
           </span>
           <span class="crm-pager-nav">
-          {$pager->_response.first}&nbsp;
-          {$pager->_response.back}&nbsp;
-          {$pager->_response.next}&nbsp;
-          {$pager->_response.last}&nbsp;
-          {$pager->_response.status}
+          {$pager->_response.first|smarty:nodefaults}&nbsp;
+          {$pager->_response.back|smarty:nodefaults}&nbsp;
+          {$pager->_response.next|smarty:nodefaults}&nbsp;
+          {$pager->_response.last|smarty:nodefaults}&nbsp;
+          {$pager->_response.status|smarty:nodefaults}
           </span>
 
         </div>

--- a/tests/phpunit/Civi/Test/ExampleHookTest.php
+++ b/tests/phpunit/Civi/Test/ExampleHookTest.php
@@ -82,6 +82,7 @@ class ExampleHookTest extends \PHPUnit\Framework\TestCase implements HeadlessInt
   }
 
   public function testPageOutput() {
+    \CRM_Core_Smarty::singleton()->assign('urlIsPublic', FALSE);
     ob_start();
     $p = new Main();
     $p->run();

--- a/xml/templates/schema.tpl
+++ b/xml/templates/schema.tpl
@@ -32,7 +32,7 @@ CREATE TABLE `{$table.name}` ({assign var='first' value=true}
 {foreach from=$table.fields item=field}
 {if ! $first},{/if}{assign var='first' value=false}
 
-  `{$field.name}` {$field.sqlType}{if $field.collate} COLLATE {$field.collate}{/if}{if $field.required} {if $field.required == "false"}NULL{else}NOT NULL{/if}{/if}{if isset($field.autoincrement)} AUTO_INCREMENT{/if}{if $field.default|count_characters} DEFAULT {$field.default}{/if}{if $field.comment} COMMENT '{ts escape=sql}{$field.comment}{/ts}'{/if}
+  `{$field.name}` {$field.sqlType}{if $field.collate} COLLATE {$field.collate}{/if}{if $field.required} {if $field.required == "false"}NULL{else}NOT NULL{/if}{/if}{if !empty($field.autoincrement)} AUTO_INCREMENT{/if}{if $field.default|count_characters} DEFAULT {$field.default}{/if}{if $field.comment} COMMENT '{ts escape=sql}{$field.comment}{/ts}'{/if}
 {/foreach}{* table.fields *}{strip}
 
 {/strip}{if $table.primaryKey}{if !$first},
@@ -40,7 +40,7 @@ CREATE TABLE `{$table.name}` ({assign var='first' value=true}
   PRIMARY KEY ({foreach from=$table.primaryKey.field item=fieldName}{if $firstIndexField}{assign var='firstIndexField' value=false}{else},{/if}`{$fieldName}`{/foreach}){/if}{* table.primaryKey *}
 {if !empty($table.index)}{foreach from=$table.index item=index}{if !$first},
 {/if}{assign var='first' value=false}
-  {if isset($index.unique)}UNIQUE {/if}INDEX `{$index.name}`({assign var='firstIndexField' value=true}{foreach from=$index.field item=fieldName}{strip}
+  {if !empty($index.unique)}UNIQUE {/if}INDEX `{$index.name}`({assign var='firstIndexField' value=true}{foreach from=$index.field item=fieldName}{strip}
 {/strip}{if $firstIndexField}{assign var='firstIndexField' value=false}{else}, {/if}{$fieldName}{/foreach}){/foreach}{* table.index *}
 {/if}{* table.index *}
 {if !empty($table.foreignKey)}


### PR DESCRIPTION
Overview
----------------------------------------
WIP - optin escape on output for smarty. 

This adds a 'strict mode' - it is not expected to be used in strict mode on live sites at the moment but allows devs to turn it on

Before
----------------------------------------
Status quo

After
----------------------------------------
No change unless you add
```
define('CIVICRM_SMARTY_DEFAULT_ESCAPE', TRUE);
```
(or use env to set the same)
AND delete templates_c

If you do you get a 'mostly functional' site with escape on output enabled - with a bunch of holes punched through.

Anything actually changed during escaping is logged to the civi log 


Technical Details
----------------------------------------
The key parts to this are 

1) get rid of `isset` in templates - even though we just added it .... Isset is not compatible with variables being escaped. I did a really rough find & replace here but it will need a more careful pass to get merged. We can pick these off
2) the right way to mark that a smarty variable should not be put through escape-on-output is this 

```
{$shortCut.title|smarty:nodefaults}
```

That works in smarty 2 & smarty 3 and says 'do not apply any default modifiers'. We currently don't have any default modifiers but default -escaping is a default modifier

3) override the default escape function with one that does a series of early exits & only reaches the default function if they don't apply. The exits cover non-string values and common html strings. Over time these could be whittled down as we use approach 2 instead -especially in non-quick-form places link links.



Comments
----------------------------------------

