### PR TITLE
dev/core#2912 : Can't save extra custom fields when inline and required

### DIFF
--- a/CRM/Contact/Form/Contact.php
+++ b/CRM/Contact/Form/Contact.php
@@ -333,7 +333,7 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
         if ($groupCount > 1) {
           $this->set('groupID', $groupID);
           //loop the group
-          for ($i = 0; $i <= $groupCount; $i++) {
+          for ($i = 1; $i <= $groupCount; $i++) {
             CRM_Custom_Form_CustomData::preProcess($this, NULL, $contactSubType,
               $i, $this->_contactType, $this->_contactId
             );


### PR DESCRIPTION
Overview
----------------------------------------
Steps to replicate the issues: 
1. Click on **Administer -> Customize Data and Screens > Custom Fields**.
1. Click **Add Set of Custom Fields**
1. Set Name: 'Test fields', Used for: Contacts, Does this Custom Field Set allow multiple records?: ticked, Display Style: Inline
1. Click **Save**
1. Field Label: Test, Data Type: Alphanumeric, Field input type: single-line input, Required: ticked  [NB seems to affect all types, key thing is this is Required]
1. Click **Save**

Before
----------------------------------------
![before](https://user-images.githubusercontent.com/3735621/139410790-4c504ea4-5051-46f8-a8f7-bbcec1cfe205.gif)


After
----------------------------------------
![after](https://user-images.githubusercontent.com/3735621/139410832-9f1f0c7d-fc71-4c99-ab0b-21162cf29a39.gif)




Comments
----------------------------------------
ping @eileenmcnaughton @jaapjansma @aydun 