### PR TITLE
Remove isset from tpl file

### DIFF
--- a/templates/CRM/common/TabHeader.tpl
+++ b/templates/CRM/common/TabHeader.tpl
@@ -9,14 +9,14 @@
 *}
 {* enclose all tabs and its content in a block *}
 <div class="crm-block crm-content-block">
-  {if !empty($tabHeader) and count($tabHeader)}
+  {if !empty($tabHeader|smarty:nodefaults) and count($tabHeader)}
     <div id="mainTabContainer">
     <ul>
        {foreach from=$tabHeader key=tabName item=tabValue}
-          <li id="tab_{$tabName}" class="crm-tab-button ui-corner-all{if !$tabValue.valid} disabled{/if}{if !empty($tabValue.class)} {$tabValue.class}{/if}" {if !empty($tabValue.extra)}{$tabValue.extra}{/if}>
+          <li id="tab_{$tabName}" class="crm-tab-button ui-corner-all{if !$tabValue.valid} disabled{/if}{if !empty($tabValue.class|smarty:nodefaults)} {$tabValue.class}{/if}" {if !empty($tabValue.extra|smarty:nodefaults)}{$tabValue.extra}{/if}>
           {if $tabValue.active}
-             <a href="{if !empty($tabValue.template)}#panel_{$tabName}{else}{$tabValue.link}{/if}" title="{$tabValue.title|escape}{if !$tabValue.valid} ({ts}disabled{/ts}){/if}">
-               {if !empty($tabValue.icon)}<i class="{$tabValue.icon}"></i>{/if}
+             <a href="{if !empty($tabValue.template|smarty:nodefaults)}#panel_{$tabName}{else}{$tabValue.link}{/if}" title="{$tabValue.title|escape}{if !$tabValue.valid} ({ts}disabled{/ts}){/if}">
+               {if !empty($tabValue.icon|smarty:nodefaults)}<i class="{$tabValue.icon}"></i>{/if}
                <span>{$tabValue.title}</span>
                {if isset($tabValue.count|smarty:nodefaults)}<em>{$tabValue.count}</em>{/if}
              </a>
@@ -27,7 +27,7 @@
        {/foreach}
     </ul>
       {foreach from=$tabHeader key=tabName item=tabValue}
-        {if !empty($tabValue.template)}
+        {if !empty($tabValue.template|smarty:nodefaults)}
           <div id="panel_{$tabName}">
             {include file=$tabValue.template}
           </div>

--- a/templates/CRM/common/TabHeader.tpl
+++ b/templates/CRM/common/TabHeader.tpl
@@ -13,12 +13,12 @@
     <div id="mainTabContainer">
     <ul>
        {foreach from=$tabHeader key=tabName item=tabValue}
-          <li id="tab_{$tabName}" class="crm-tab-button ui-corner-all{if !$tabValue.valid} disabled{/if}{if isset($tabValue.class)} {$tabValue.class}{/if}" {if isset($tabValue.extra)}{$tabValue.extra}{/if}>
+          <li id="tab_{$tabName}" class="crm-tab-button ui-corner-all{if !$tabValue.valid} disabled{/if}{if !empty($tabValue.class)} {$tabValue.class}{/if}" {if !empty($tabValue.extra)}{$tabValue.extra}{/if}>
           {if $tabValue.active}
              <a href="{if !empty($tabValue.template)}#panel_{$tabName}{else}{$tabValue.link}{/if}" title="{$tabValue.title|escape}{if !$tabValue.valid} ({ts}disabled{/ts}){/if}">
                {if !empty($tabValue.icon)}<i class="{$tabValue.icon}"></i>{/if}
                <span>{$tabValue.title}</span>
-               {if isset($tabValue.count)}<em>{$tabValue.count}</em>{/if}
+               {if isset($tabValue.count|smarty:nodefaults)}<em>{$tabValue.count}</em>{/if}
              </a>
           {else}
              <span {if !$tabValue.valid} title="{ts}disabled{/ts}"{/if}>{$tabValue.title}</span>


### PR DESCRIPTION


Overview
----------------------------------------
Fixes a file to not use `isset` per #21935. In one case empty does not have the same meaning & I used `|smarty:nodefaults` to tell smarty not to apply default modifiers - which escape on output would be

Before
----------------------------------------
Use of `isset` which is not compatible with escape on output

After
----------------------------------------
`empty` & `|smarty:nodefaults`

Technical Details
----------------------------------------
Per https://github.com/civicrm/civicrm-core/pull/21935 it turns out isset will be
a blocker to ever doing escape on output so switching a couple of places to
empty. In the last case empty doesn't cut it so I added smarty:nodefaults
so that it would not be escaped.

isset doesn't work on the out put from a function

Comments
----------------------------------------
@demeritcowboy this is the mere measured approach....