### PR TITLE
Simplify and improve performance of query to insert updated cache

### DIFF
--- a/CRM/Contact/BAO/GroupContactCache.php
+++ b/CRM/Contact/BAO/GroupContactCache.php
@@ -765,9 +765,13 @@ ORDER BY   gc.contact_id, g.children
   private static function updateCacheFromTempTable(CRM_Utils_SQL_TempTable $groupContactsTempTable, array $groupIDs): void {
     $tempTable = $groupContactsTempTable->getName();
 
+    // @fixme: GROUP BY is here to guard against having duplicate contacts in the temptable.
+    //   That used to happen for an unknown reason and probably doesn't anymore so we *should*
+    //   be able to remove GROUP BY here safely.
     CRM_Core_DAO::executeQuery(
-      "INSERT IGNORE INTO civicrm_group_contact_cache (contact_id, group_id)
-        SELECT DISTINCT contact_id, group_id FROM $tempTable
+      "INSERT INTO civicrm_group_contact_cache (contact_id, group_id)
+        SELECT contact_id, group_id FROM $tempTable
+        GROUP BY contact_id,group_id
       ");
     $groupContactsTempTable->drop();
     foreach ($groupIDs as $groupID) {


### PR DESCRIPTION
Overview
----------------------------------------
Both `INSERT IGNORE` and `SELECT DISTINCT` reduce performance of queries significantly because of the way they work internally (see various articles online).

We originally had `INSERT IGNORE` to guard against a lock not working properly (they used to be unreliable) when updating the `civicrm_group_contact_cache` table but that is not necessary anymore as we've got to a point where the caching code is much more sensible.

`SELECT DISTINCT` was guarding against there being duplicate `contact_id`s in the temporary cache table. That also should not be happening but requires further validation of a more complex function to ensure that is the case. Changing to `GROUP BY` has the same effect and is generally more performant.

Before
----------------------------------------
Use of `INSERT IGNORE` and `SELECT DISTINCT`.

After
----------------------------------------
Use of `INSERT` and `GROUP BY` for reasons described above.

Technical Details
----------------------------------------
Described above.

Comments
----------------------------------------
I have had this deployed on a client site for some time with no obvious issues.
