### PR TITLE
SearchKit - Conditional style rules for rows/cells

### DIFF
--- a/Civi/Api4/Generic/Traits/ArrayQueryActionTrait.php
+++ b/Civi/Api4/Generic/Traits/ArrayQueryActionTrait.php
@@ -87,7 +87,7 @@ trait ArrayQueryActionTrait {
         return $result;
 
       default:
-        return $this->filterCompare($row, $filters);
+        return self::filterCompare($row, $filters);
     }
   }
 
@@ -97,7 +97,7 @@ trait ArrayQueryActionTrait {
    * @return bool
    * @throws \Civi\API\Exception\NotImplementedException
    */
-  private function filterCompare($row, $condition) {
+  public static function filterCompare($row, $condition) {
     if (!is_array($condition)) {
       throw new NotImplementedException('Unexpected where syntax; expecting array.');
     }

--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -862,6 +862,10 @@ input.crm-form-entityref {
   font-weight: bold;
 }
 
+.crm-container .font-bold {
+  font-weight: bold !important;
+}
+
 .crm-container .font-italic {
   font-style: italic;
 }
@@ -3867,7 +3871,7 @@ span.crm-status-icon {
 }
 
 .crm-container .strikethrough {
-  text-decoration: line-through;
+  text-decoration: line-through !important;
 }
 
 .crm-container input.ng-invalid.ng-dirty,

--- a/ext/search_kit/ang/crmSearchAdmin.module.js
+++ b/ext/search_kit/ang/crmSearchAdmin.module.js
@@ -143,8 +143,8 @@
         }
         if (field) {
           field.baseEntity = entityName;
-          return {field: field, join: join};
         }
+        return {field: field, join: join};
       }
       function parseFnArgs(info, expr) {
         var fnName = expr.split('(')[0],
@@ -224,7 +224,7 @@
           };
         } else if (arg) {
           var fieldAndJoin = getFieldAndJoin(arg, searchEntity);
-          if (fieldAndJoin) {
+          if (fieldAndJoin.field) {
             var split = arg.split(':'),
               prefixPos = split[0].lastIndexOf(fieldAndJoin.field.name);
             return {
@@ -294,7 +294,7 @@
       return {
         getEntity: getEntity,
         getField: function(fieldName, entityName) {
-          return getFieldAndJoin(fieldName, entityName).field;
+          return getFieldAndJoin(fieldName, entityName || searchEntity).field;
         },
         getJoin: getJoin,
         parseExpr: parseExpr,

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminLinkSelect.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminLinkSelect.component.js
@@ -14,6 +14,14 @@
       var ts = $scope.ts = CRM.ts('org.civicrm.search_kit'),
         ctrl = this;
 
+      this.$onInit = function() {
+        $element.on('hidden.bs.dropdown', function() {
+          $scope.$apply(function() {
+            ctrl.menuOpen = false;
+          });
+        });
+      };
+
       this.setValue = function(val) {
         if (val.path) {
           $timeout(function () {

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminLinkSelect.html
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminLinkSelect.html
@@ -1,10 +1,10 @@
 <div class="crm-flex-1 input-group" >
   <input type="text" class="form-control" ng-if="!$ctrl.link.action" ng-model="$ctrl.link.path" ng-model-options="{updateOn: 'blur'}" ng-change="$ctrl.onChange({newLink: $ctrl.link})">
   <div class="input-group-btn" style="{{ $ctrl.link.action ? '' : 'width:27px' }}">
-    <button type="button" class="btn btn-sm btn-secondary-outline dropdown-toggle" style="min-width: 200px; text-align: left;" ng-if="$ctrl.link.action" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+    <button type="button" ng-click="$ctrl.menuOpen = true;" class="btn btn-sm btn-secondary-outline dropdown-toggle crm-search-admin-combo-button" ng-if="$ctrl.link.action" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
       {{ $ctrl.getLink().text }}
     </button>
-    <button type="button" class="btn btn-sm btn-secondary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+    <button type="button" ng-click="$ctrl.menuOpen = true;" class="btn btn-sm btn-secondary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
       <span class="caret"></span>
     </button>
     <ul class="dropdown-menu {{ $ctrl.link.action ? '' : 'dropdown-menu-right' }}" style="min-width: 223px;">

--- a/ext/search_kit/ang/crmSearchAdmin/displays/colType/field.html
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/colType/field.html
@@ -52,3 +52,4 @@
     {{:: ts('In-Place Edit') }}
   </label>
 </div>
+<search-admin-css-rules label="{{:: ts('Style') }}" item="col" default="col.key"></search-admin-css-rules>

--- a/ext/search_kit/ang/crmSearchAdmin/displays/common/searchAdminCssRules.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/common/searchAdminCssRules.component.js
@@ -1,0 +1,69 @@
+(function(angular, $, _) {
+  "use strict";
+
+  angular.module('crmSearchAdmin').component('searchAdminCssRules', {
+    bindings: {
+      item: '<',
+      default: '<',
+      label: '@',
+    },
+    require: {
+      crmSearchAdmin: '^crmSearchAdmin'
+    },
+    templateUrl: '~/crmSearchAdmin/displays/common/searchAdminCssRules.html',
+    controller: function($scope, $element, searchMeta) {
+      var ts = $scope.ts = CRM.ts('org.civicrm.search_kit'),
+        ctrl = this;
+
+      this.getField = searchMeta.getField;
+
+      this.styles = _.transform(_.cloneDeep(CRM.crmSearchAdmin.styles), function(styles, style) {
+        if (style.key !== 'default' && style.key !== 'secondary') {
+          styles['bg-' + style.key] = style.value;
+        }
+      }, {});
+      this.styles.disabled = ts('Disabled');
+      this.styles['font-bold'] = ts('Bold');
+      this.styles['font-italic'] = ts('Italic');
+      this.styles.strikethrough = ts('Strikethrough');
+
+      this.fields = function() {
+        return {results: ctrl.crmSearchAdmin.getAllFields(':name', ['Field', 'Custom', 'Extra'])};
+      };
+
+      this.$onInit = function() {
+        $element.on('hidden.bs.dropdown', function() {
+          $scope.$apply(function() {
+            ctrl.menuOpen = false;
+          });
+        });
+      };
+
+      this.onSelectField = function(clause) {
+        if (clause[1]) {
+          clause[2] = '=';
+          clause.length = 3;
+        } else {
+          clause.length = 1;
+        }
+      };
+
+      this.addClause = function(style) {
+        var clause = [style];
+        if (ctrl.default && ctrl.getField(ctrl.default)) {
+          clause.push(ctrl.default, '=');
+        }
+        this.item.cssRules = this.item.cssRules || [];
+        this.item.cssRules.push(clause);
+      };
+
+      this.showMore = function() {
+        return !this.item.cssRules || !this.item.cssRules.length || _.last(this.item.cssRules)[1];
+      };
+
+
+
+    }
+  });
+
+})(angular, CRM.$, CRM._);

--- a/ext/search_kit/ang/crmSearchAdmin/displays/common/searchAdminCssRules.html
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/common/searchAdminCssRules.html
@@ -1,0 +1,48 @@
+<div class="form-inline" ng-repeat="clause in $ctrl.item.cssRules">
+  <label>{{:: $ctrl.label }}</label>
+  <div class="input-group">
+    <input type="text" class="form-control" ng-if="!$ctrl.styles[clause[0]]" placeholder="{{:: ts('CSS class') }}" ng-model="clause[0]" ng-model-options="{updateOn: 'blur'}">
+    <div class="input-group-btn" style="{{ $ctrl.styles[clause[0]] ? '' : 'width:27px' }}">
+      <button type="button" ng-click="$ctrl.menuOpen = true" ng-if="$ctrl.styles[clause[0]]" class="btn btn-sm dropdown-toggle crm-search-admin-combo-button {{ clause[0].replace('bg-', 'btn-') }}" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+        {{ $ctrl.styles[clause[0]] }}
+      </button>
+      <button type="button" ng-click="$ctrl.menuOpen = true" class="btn btn-sm btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+        <span class="sr-only">{{:: $ctrl.label }}</span> <span class="caret"></span>
+      </button>
+      <ul class="dropdown-menu dropdown-menu-right" ng-if="$ctrl.menuOpen">
+        <li ng-repeat="(key, label) in $ctrl.styles">
+          <a href class="{{:: key }}" ng-click="clause[0] = key">{{:: label }}</a>
+        </li>
+        <li class="divider" role="separator"></li>
+        <li>
+          <a href ng-click="clause[0] = ''">{{:: ts('Other') }}</a>
+        </li>
+      </ul>
+    </div>
+  </div>
+  <label>{{:: ts('If') }}</label>
+  <input class="form-control collapsible-optgroups" ng-model="clause[1]" crm-ui-select="::{data: $ctrl.fields, allowClear: true, placeholder: ts('Always')}" ng-change="$ctrl.onSelectField(clause)" />
+  <!-- TODO: Support operators other than '=' as clause[2] -->
+  <label ng-if="clause[1]">{{:: ts('Is') }}</label>
+  <crm-search-input ng-if="clause[1]" ng-model="clause[3]" field="$ctrl.getField(clause[1])" option-key="'name'" op="clause[1]" format="$ctrl.format" class="form-group"></crm-search-input>
+  <button type="button" class="btn-xs btn-danger-outline" ng-click="$ctrl.item.cssRules.splice($index);" title="{{:: ts('Remove style') }}">
+    <i class="crm-i fa-ban"></i>
+  </button>
+</div>
+<div class="form-inline" ng-if="$ctrl.showMore()" title="{{:: ts('Set background color or text style based on a field value') }}">
+  <label>{{:: $ctrl.label }}</label>
+  <div class="btn-group">
+    <button type="button" ng-click="$ctrl.menuOpen = true" class="btn btn-sm btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+      <span>{{ $ctrl.item.cssRules && $ctrl.item.cssRules.length ? ts('Add') : ts('None') }}</span> <span class="caret"></span>
+    </button>
+    <ul class="dropdown-menu" ng-if="$ctrl.menuOpen">
+      <li ng-repeat="(key, label) in $ctrl.styles">
+        <a href class="{{:: key }}" ng-click="$ctrl.addClause(key)">{{:: label }}</a>
+      </li>
+      <li class="divider" role="separator"></li>
+      <li>
+        <a href ng-click="$ctrl.addClause('')">{{:: ts('Other') }}</a>
+      </li>
+    </ul>
+  </div>
+</div>

--- a/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayTable.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayTable.component.js
@@ -21,7 +21,7 @@
         {name: 'table-striped', label: ts('Even/Odd Stripes')}
       ];
 
-      // Check if array conatains item
+      // Check if array contains item
       this.includes = _.includes;
 
       // Add or remove an item from an array

--- a/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayTable.html
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayTable.html
@@ -18,6 +18,7 @@
       </label>
     </div>
   </div>
+  <search-admin-css-rules label="{{:: ts('Row Style') }}" item="$ctrl.display.settings"></search-admin-css-rules>
   <search-admin-pager-config display="$ctrl.display"></search-admin-pager-config>
 </fieldset>
 <fieldset class="crm-search-admin-edit-columns-wrapper">

--- a/ext/search_kit/ang/crmSearchDisplayGrid/crmSearchDisplayGridItems.html
+++ b/ext/search_kit/ang/crmSearchDisplayGrid/crmSearchDisplayGridItems.html
@@ -1,4 +1,4 @@
-<div ng-repeat="(rowIndex, row) in $ctrl.results">
+<div ng-repeat="(rowIndex, row) in $ctrl.results" class="{{:: row.cssClass }}">
   <div ng-repeat="(colIndex, colData) in row.columns" title="{{:: colData.title }}" class="{{:: colData.cssClass }} {{:: $ctrl.settings.columns[colIndex].break ? '' : 'crm-inline-block' }}">
     <label ng-if=":: colData.label">
       {{:: colData.label }}

--- a/ext/search_kit/ang/crmSearchDisplayList/crmSearchDisplayListItems.html
+++ b/ext/search_kit/ang/crmSearchDisplayList/crmSearchDisplayListItems.html
@@ -1,4 +1,4 @@
-<li ng-repeat="(rowIndex, row) in $ctrl.results">
+<li ng-repeat="(rowIndex, row) in $ctrl.results" class="{{:: row.cssClass }}">
   <div ng-repeat="(colIndex, colData) in row.columns" title="{{:: colData.title }}" class="{{:: colData.cssClass }} {{:: $ctrl.settings.columns[colIndex].break ? '' : 'crm-inline-block' }}">
     <label ng-if=":: colData.label">
       {{:: colData.label }}

--- a/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTableBody.html
+++ b/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTableBody.html
@@ -1,8 +1,8 @@
 <tr ng-repeat="(rowIndex, row) in $ctrl.results">
-  <td ng-if=":: $ctrl.settings.actions">
+  <td ng-if=":: $ctrl.settings.actions" class="{{:: row.cssClass }}">
     <input type="checkbox" ng-checked="$ctrl.isRowSelected(row)" ng-click="$ctrl.selectRow(row)" ng-disabled="!!$ctrl.loadingAllRows">
   </td>
-  <td ng-repeat="(colIndex, colData) in row.columns" ng-include="'~/crmSearchDisplay/colType/' + $ctrl.settings.columns[colIndex].type + '.html'" title="{{:: colData.title }}" class="{{:: colData.cssClass }}">
+  <td ng-repeat="(colIndex, colData) in row.columns" ng-include="'~/crmSearchDisplay/colType/' + $ctrl.settings.columns[colIndex].type + '.html'" title="{{:: colData.title }}" class="{{:: row.cssClass }} {{:: colData.cssClass }}">
   </td>
 </tr>
 <tr ng-if="$ctrl.rowCount === 0">

--- a/ext/search_kit/css/crmSearchAdmin.css
+++ b/ext/search_kit/css/crmSearchAdmin.css
@@ -247,3 +247,8 @@
   width: 30px;
   padding: 2px 4px;
 }
+
+#bootstrap-theme button.crm-search-admin-combo-button {
+  min-width: 200px;
+  text-align: left;
+}


### PR DESCRIPTION
Overview
----------------------------------------
Enhances SearchKit with conditional style rules. For example
- Font strikethrough if contact is deceased
- Background red if email on hold
- Text faded out if relationship is not active

