### PR TITLE
Ensure communityMessages is assigned to the template.

### DIFF
--- a/CRM/Contact/Page/DashBoard.php
+++ b/CRM/Contact/Page/DashBoard.php
@@ -36,13 +36,7 @@ class CRM_Contact_Page_DashBoard extends CRM_Core_Page {
       $this->assign('hookContentPlacement', $contentPlacement);
     }
 
-    $communityMessages = CRM_Core_CommunityMessages::create();
-    if ($communityMessages->isEnabled()) {
-      $message = $communityMessages->pick();
-      if ($message) {
-        $this->assign('communityMessages', $communityMessages->evalMarkup($message['markup']));
-      }
-    }
+    $this->assign('communityMessages', $this->getCommunityMessageOutput());
 
     $loader = Civi::service('angularjs.loader');
     $loader->addModules('crmDashboard');
@@ -93,6 +87,22 @@ class CRM_Contact_Page_DashBoard extends CRM_Core_Page {
     return [
       'dashlets' => CRM_Core_BAO_Dashboard::getContactDashlets(),
     ];
+  }
+
+  /**
+   * Get community message output.
+   *
+   * @return string
+   */
+  protected function getCommunityMessageOutput(): string {
+    $communityMessages = CRM_Core_CommunityMessages::create();
+    if ($communityMessages->isEnabled()) {
+      $message = $communityMessages->pick();
+      if ($message) {
+        return $communityMessages->evalMarkup($message['markup']);
+      }
+    }
+    return '';
   }
 
 }

--- a/templates/CRM/Contact/Page/DashBoardDashlet.tpl
+++ b/templates/CRM/Contact/Page/DashBoardDashlet.tpl
@@ -9,7 +9,7 @@
 *}
 {include file="CRM/common/chart.tpl"}
 {* Alerts for critical configuration settings. *}
-{$communityMessages|default:''}
+{$communityMessages}
 <div class="clear"></div>
 <div class="crm-block crm-content-block">
 


### PR DESCRIPTION

Overview
----------------------------------------
This is a minor code simplification & ensures the parameter is set rather than
handling it not being set at the template level


Before
----------------------------------------
variable potentially not assigned

After
----------------------------------------
variable always assigned, even if empty

Technical Details
----------------------------------------

Comments
----------------------------------------
