### PR TITLE
Handling for intermittent Im->getfields error

### DIFF
--- a/CRM/Contact/Tokens.php
+++ b/CRM/Contact/Tokens.php
@@ -380,6 +380,9 @@ class CRM_Contact_Tokens extends CRM_Core_EntityTokens {
 
     foreach ($this->getRelatedEntityTokenMetadata() as $entity => $exposedFields) {
       $apiEntity = ($entity === 'openid') ? 'OpenID' : ucfirst($entity);
+      if ($apiEntity === 'Im') {
+        $apiEntity = 'IM';
+      }
       $metadata = (array) civicrm_api4($apiEntity, 'getfields', ['checkPermissions' => FALSE], 'name');
       foreach ($metadata as $field) {
         $this->addFieldToTokenMetadata($tokensMetadata, $field, $exposedFields, 'primary_' . $entity);


### PR DESCRIPTION

Overview
----------------------------------------
Handling for intermittent Im->getfields error
I'm not quite sure when this started but I've been seeing Im->getfields not found errors of late - this helps


Before
----------------------------------------
I've been seeing a bunch of fatals

After
----------------------------------------
went away

Technical Details
----------------------------------------
@colemanw I think recent changes within apiv4 caching surfaced this - less sympathy around casing. I haven't pinned it down

Comments
----------------------------------------