### PR TITLE
User experience improvement - CiviCRM Manage Events page, expand the Find Events criteria by default

### DIFF
--- a/templates/CRM/Event/Form/SearchEvent.tpl
+++ b/templates/CRM/Event/Form/SearchEvent.tpl
@@ -7,7 +7,7 @@
  | and copyright information, see https://civicrm.org/licensing       |
  +--------------------------------------------------------------------+
 *}
-  <div class="crm-accordion-wrapper crm-block crm-form-block crm-event-searchevent-form-block collapsed">
+  <div class="crm-accordion-wrapper crm-block crm-form-block crm-event-searchevent-form-block">
     <div class="crm-accordion-header">
       {ts}Find Events{/ts}
     </div>


### PR DESCRIPTION
Overview
----------------------------------------
CiviCRM Manage Events page, Find Events criteria is hidden by default because the section is collapsed.
**End users** cannot see any of the search options which **causes confusion and support requests**.

Before
----------------------------------------

How do I change the search criteria? No options are shown.

![Screenshot_20211101_165429](https://user-images.githubusercontent.com/58866555/139627834-d2d1665d-d2ab-455c-82e8-2f49e3a801e7.png)


After
----------------------------------------

How do I change the search criteria? Options **are shown**.

![Screenshot_20211101_165449](https://user-images.githubusercontent.com/58866555/139627820-74a35289-fcd5-4494-8fbe-82b5cce57bfe.png)

Technical Details
----------------------------------------


Comments
----------------------------------------

Agileware Ref: CIVICRM-1881 
