### PR TITLE
APIv4 - Add managed entity functionality

### DIFF
--- a/Civi/Api4/Entity.php
+++ b/Civi/Api4/Entity.php
@@ -58,6 +58,7 @@ class Entity extends Generic\AbstractEntity {
             'DAOEntity' => 'DAOEntity',
             'CustomValue' => 'CustomValue',
             'BasicEntity' => 'BasicEntity',
+            'ManagedEntity' => 'ManagedEntity',
             'EntityBridge' => 'EntityBridge',
             'OptionList' => 'OptionList',
           ],

--- a/Civi/Api4/Generic/Traits/ManagedEntity.php
+++ b/Civi/Api4/Generic/Traits/ManagedEntity.php
@@ -1,0 +1,39 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Generic\Traits;
+
+use Civi\Api4\Generic\BasicBatchAction;
+
+/**
+ * A managed entity includes extra fields and methods to revert from an overridden local to base state.
+ *
+ * Includes the extra fields `has_base` and `base_module`
+ */
+trait ManagedEntity {
+
+  /**
+   * @param bool $checkPermissions
+   * @return \Civi\Api4\Generic\BasicBatchAction
+   */
+  public static function revert($checkPermissions = TRUE) {
+    return (new BasicBatchAction(static::getEntityName(), __FUNCTION__, function($item, BasicBatchAction $action) {
+      $params = ['entity_type' => $action->getEntityName(), 'entity_id' => $item['id']];
+      if (\CRM_Core_ManagedEntities::singleton()->revert($params)) {
+        return $item;
+      }
+      else {
+        throw new \API_Exception('Cannot revert ' . $action->getEntityName() . ' with id ' . $item['id']);
+      }
+    }))->setCheckPermissions($checkPermissions);
+  }
+
+}

--- a/Civi/Api4/SavedSearch.php
+++ b/Civi/Api4/SavedSearch.php
@@ -11,16 +11,19 @@
 namespace Civi\Api4;
 
 /**
- * SavedSearch aka Smart Groups.
+ * SavedSearch entity.
  *
- * Stores search parameters for populating smart groups with live results.
+ * Stores search criteria for smart groups and SearchKit displays.
  *
+ * @see https://docs.civicrm.org/user/en/latest/the-user-interface/search-kit/
  * @see https://docs.civicrm.org/user/en/latest/organising-your-data/smart-groups/
  * @searchable secondary
  * @since 5.24
  * @package Civi\Api4
  */
 class SavedSearch extends Generic\DAOEntity {
+
+  use Generic\Traits\ManagedEntity;
 
   public static function permissions() {
     $permissions = parent::permissions();

--- a/Civi/Api4/Service/Spec/Provider/ManagedEntitySpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/ManagedEntitySpecProvider.php
@@ -1,0 +1,94 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+
+namespace Civi\Api4\Service\Spec\Provider;
+
+use Civi\Api4\Service\Spec\FieldSpec;
+use Civi\Api4\Service\Spec\RequestSpec;
+use Civi\Api4\Utils\CoreUtil;
+use Civi\Api4\Utils\ReflectionUtils;
+
+/**
+ * Provides calculated fields for APIs using the `ManagedEntity` trait
+ */
+class ManagedEntitySpecProvider implements Generic\SpecProviderInterface {
+
+  /**
+   * @param \Civi\Api4\Service\Spec\RequestSpec $spec
+   */
+  public function modifySpec(RequestSpec $spec) {
+    $field = (new FieldSpec('has_base', $spec->getEntity(), 'Boolean'))
+      ->setLabel(ts('Is Packaged'))
+      ->setTitle(ts('Is Packaged'))
+      ->setColumnName('id')
+      ->setDescription(ts('Is provided by an extension'))
+      ->setType('Extra')
+      ->setReadonly(TRUE)
+      ->setSqlRenderer([__CLASS__, 'renderHasBase']);
+    $spec->addFieldSpec($field);
+
+    $field = (new FieldSpec('base_module', $spec->getEntity(), 'String'))
+      ->setLabel(ts('Packaged Extension'))
+      ->setTitle(ts('Packaged Extension'))
+      ->setColumnName('id')
+      ->setDescription(ts('Name of extension which provides this package'))
+      ->setType('Extra')
+      ->setReadonly(TRUE)
+      ->setOptionsCallback(['CRM_Core_PseudoConstant', 'getExtensions'])
+      ->setSqlRenderer([__CLASS__, 'renderBaseModule']);
+    $spec->addFieldSpec($field);
+  }
+
+  /**
+   * @param string $entity
+   * @param string $action
+   *
+   * @return bool
+   */
+  public function applies($entity, $action) {
+    if ($action !== 'get') {
+      return FALSE;
+    }
+    $className = CoreUtil::getApiClass($entity);
+    return in_array('Civi\Api4\Generic\Traits\ManagedEntity', ReflectionUtils::getTraits($className), TRUE);
+  }
+
+  /**
+   * Get sql snippet for has_base
+   * @param array $field
+   * return string
+   */
+  public static function renderHasBase(array $field): string {
+    $id = $field['sql_name'];
+    $entity = $field['entity'];
+    return "IF($id IN (SELECT `entity_id` FROM `civicrm_managed` WHERE `entity_type` = '$entity'), '1', '0')";
+  }
+
+  /**
+   * Get sql snippet for base_module
+   * @param array $field
+   * return string
+   */
+  public static function renderBaseModule(array $field): string {
+    $id = $field['sql_name'];
+    $entity = $field['entity'];
+    return "(SELECT `civicrm_managed`.`module` FROM `civicrm_managed` WHERE `civicrm_managed`.`entity_id` = $id AND `civicrm_managed`.`entity_type` = '$entity' LIMIT 1)";
+  }
+
+}

--- a/ext/search_kit/Civi/Api4/SearchDisplay.php
+++ b/ext/search_kit/Civi/Api4/SearchDisplay.php
@@ -11,6 +11,8 @@ namespace Civi\Api4;
  */
 class SearchDisplay extends Generic\DAOEntity {
 
+  use \Civi\Api4\Generic\Traits\ManagedEntity;
+
   /**
    * @param bool $checkPermissions
    * @return Action\SearchDisplay\Run

--- a/tests/phpunit/api/v4/Entity/ManagedEntityTest.php
+++ b/tests/phpunit/api/v4/Entity/ManagedEntityTest.php
@@ -1,0 +1,122 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+namespace api\v4\Entity;
+
+use api\v4\UnitTestCase;
+use Civi\Api4\SavedSearch;
+use Civi\Test\HookInterface;
+use Civi\Test\TransactionalInterface;
+
+/**
+ * @group headless
+ */
+class ManagedEntityTest extends UnitTestCase implements TransactionalInterface, HookInterface {
+
+  public function hook_civicrm_managed(array &$entities): void {
+    $entities[] = [
+      // Setting module to 'civicrm' works for the test but not sure we should actually support that
+      // as it's probably better to package stuff in a core extension instead of core itself.
+      'module' => 'civicrm',
+      'name' => 'testSavedSearch',
+      'entity' => 'SavedSearch',
+      'cleanup' => 'never',
+      'update' => 'never',
+      'params' => [
+        'version' => 4,
+        'values' => [
+          'name' => 'TestManagedSavedSearch',
+          'label' => 'Test Saved Search',
+          'description' => 'Original state',
+          'api_entity' => 'Contact',
+          'api_params' => [
+            'version' => 4,
+            'select' => ['id'],
+            'orderBy' => ['id', 'ASC'],
+          ],
+        ],
+      ],
+    ];
+  }
+
+  public function testGetFields() {
+    $fields = SavedSearch::getFields(FALSE)
+      ->addWhere('type', '=', 'Extra')
+      ->setLoadOptions(TRUE)
+      ->execute()->indexBy('name');
+
+    $this->assertEquals('Boolean', $fields['has_base']['data_type']);
+    // If this core extension ever goes away or gets renamed, just pick a different one here
+    $this->assertArrayHasKey('org.civicrm.flexmailer', $fields['base_module']['options']);
+  }
+
+  public function testRevertSavedSearch() {
+    \CRM_Core_ManagedEntities::singleton(TRUE)->reconcile();
+
+    $search = SavedSearch::get(FALSE)
+      ->addWhere('name', '=', 'TestManagedSavedSearch')
+      ->execute()->single();
+    $this->assertEquals('Original state', $search['description']);
+
+    SavedSearch::update(FALSE)
+      ->addValue('id', $search['id'])
+      ->addValue('description', 'Altered state')
+      ->execute();
+
+    $search = SavedSearch::get(FALSE)
+      ->addWhere('name', '=', 'TestManagedSavedSearch')
+      ->addSelect('description', 'has_base', 'base_module')
+      ->execute()->single();
+    $this->assertEquals('Altered state', $search['description']);
+    // Check calculated fields
+    $this->assertTrue($search['has_base']);
+    $this->assertEquals('civicrm', $search['base_module']);
+
+    SavedSearch::revert(FALSE)
+      ->addWhere('name', '=', 'TestManagedSavedSearch')
+      ->execute();
+
+    // Entity should be revered to original state
+    $result = SavedSearch::get(FALSE)
+      ->addWhere('name', '=', 'TestManagedSavedSearch')
+      ->addSelect('description', 'has_base', 'base_module')
+      ->setDebug(TRUE)
+      ->execute();
+    $search = $result->single();
+    $this->assertEquals('Original state', $search['description']);
+    // Check calculated fields
+    $this->assertTrue($search['has_base']);
+    $this->assertEquals('civicrm', $search['base_module']);
+
+    // Check calculated fields for a non-managed entity - they should be empty
+    $newName = uniqid(__FUNCTION__);
+    SavedSearch::create(FALSE)
+      ->addValue('name', $newName)
+      ->addValue('label', 'Whatever')
+      ->execute();
+    $search = SavedSearch::get(FALSE)
+      ->addWhere('name', '=', $newName)
+      ->addSelect('label', 'has_base', 'base_module')
+      ->execute()->single();
+    $this->assertEquals('Whatever', $search['label']);
+    // Check calculated fields
+    $this->assertEquals(NULL, $search['base_module']);
+    $this->assertFalse($search['has_base']);
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Provides extra API functionality which will be used by the SearchKit UI to display searches as "packaged" with a "Revert" button.

Technical Details
----------------------------------------
This new "ManagedEntity" trait provides 2 extra fields (`has_base` & `base_module`) and a `Revert` action to facilitate UIs which show the managed state and a revert button, similar to the AfformAdmin UI. Any DAO-based entity can opt-in to this functionality simply by using the trait.

The `base_module` field provides the name of the extension in which an entity is packaged. It will be useful in the Afform UI as well, so I implemented a version of that field in the `Afform::get` API here: #21960.

Comments
----------------------------------------
This PR includes test for the new fields & action, and existing API test coverage is good.
