### PR TITLE
dev/core#1328 Add define to optionally enable escape-on-output

### DIFF
--- a/templates/CRM/common/civicrm.settings.php.template
+++ b/templates/CRM/common/civicrm.settings.php.template
@@ -193,7 +193,19 @@ if (!defined('CIVICRM_TEMPLATE_COMPILEDIR')) {
  *
  */
 //if (!defined('CIVICRM_TEMPLATE_COMPILE_CHECK')) {
-//  define( 'CIVICRM_TEMPLATE_COMPILE_CHECK', FALSE);
+//  define('CIVICRM_TEMPLATE_COMPILE_CHECK', FALSE);
+//}
+
+/**
+ * Smarty escape on output.
+ *
+ * This tells smarty to pass all variables through the escape function
+ * unless they are piped to smarty:nodefaults (eg. {$myScript|smarty:nodefaults}
+ * At this stage it should only be enabled on development sites.
+ * @see https://github.com/civicrm/civicrm-core/pull/21935
+ */
+//if (!defined('CIVICRM_SMARTY_DEFAULT_ESCAPE')) {
+//  define('CIVICRM_SMARTY_DEFAULT_ESCAPE', TRUE);
 //}
 
 /**


### PR DESCRIPTION
Overview
----------------------------------------
Add define to optionally enable escape-on-output

This PR + fixing the use of isset in the template layer are the pre-requisites for
turning escape on output on and off. Keeping this part in an unmerged branch is
tricky as the templates need to be recompiled when you switch to a branch
which does not have this function

I envisage us starting to use this define in our dev environments fairly soon
as it's working well locally for me on
https://github.com/civicrm/civicrm-core/pull/21935


Before
----------------------------------------
Only smarty variables specifically piped to `escape` are escaped

After
----------------------------------------
If you add the following define
```
define('CIVICRM_SMARTY_DEFAULT_ESCAPE', TRUE);
```
Then all variables are escaped.

Technical Details
----------------------------------------
Note that with this PR if you uncomment the above define your site will crash as long as there are calls to `isset` in the smarty templates. All of those calls have been removed in #21935 - but not with adequate care (and with some errors) . Merging this helps the process of working through those and the enotice issues since it makes it easier to switch back & forth between having default esaping on & off

Comments
----------------------------------------
https://github.com/civicrm/civicrm-core/pull/21979 is open as one PR removal of isset in the template & a bunch of those would need to be merged

https://lab.civicrm.org/dev/core/-/issues/1328#note_66924