### PR TITLE
Use null variables rather than isset in Core_Block

### DIFF
--- a/CRM/Core/Block.php
+++ b/CRM/Core/Block.php
@@ -552,6 +552,7 @@ class CRM_Core_Block {
     if ($config->isUpgradeMode()) {
       return NULL;
     }
+    CRM_Core_Smarty::singleton()->ensureVariablesAreAssigned(['langSwitch', 'breadcrumb', 'pageTitle']);
 
     if (!self::getProperty($id, 'active')) {
       return NULL;

--- a/CRM/Core/Smarty.php
+++ b/CRM/Core/Smarty.php
@@ -188,6 +188,19 @@ class CRM_Core_Smarty extends Smarty {
   }
 
   /**
+   * Ensure these variables are set to make it easier to access them without e-notice.
+   *
+   * @param array $variables
+   */
+  public function ensureVariablesAreAssigned(array $variables): void {
+    foreach ($variables as $variable) {
+      if (!isset($this->get_template_vars()[$variable])) {
+        $this->assign($variable);
+      }
+    }
+  }
+
+  /**
    * Fetch a template (while using certain variables)
    *
    * @param string $resource_name

--- a/templates/CRM/Block/LangSwitch.tpl
+++ b/templates/CRM/Block/LangSwitch.tpl
@@ -7,7 +7,7 @@
  | and copyright information, see https://civicrm.org/licensing       |
  +--------------------------------------------------------------------+
 *}
-{if isset($langSwitch) and $langSwitch|@count > 1}
+{if $langSwitch|@count > 1}
   <form action="#">
     <select name="lcMessages" onchange="window.location='{crmURL q="$queryString"}'+this.value">
       {foreach from=$langSwitch item=language key=locale}


### PR DESCRIPTION

Overview
----------------------------------------
Use null variables rather than isset in Core_Block

Before
----------------------------------------
Variables may not be assigned - requiring checking with 'empty' or 'isset'

After
----------------------------------------
Variables always assigned - they might stay NULL or be overwritten later

Technical Details
----------------------------------------
This removes an isset from LangSwitch and some enotices that we see if escape on output is enabled.

'langSwitch' is normally always assigned by the smarty initialize but for some reason not via this path

Comments
----------------------------------------
