### PR TITLE
[REF] Fix pseduoconstant token rendering for contributions via legacy…

### DIFF
--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -1548,11 +1548,16 @@ class CRM_Utils_Token {
           'contribution_status_id:label',
           'contribution_status_id:name',
           'is_template:label',
+          'campaign_id:label',
+          'campaign_id:name',
         ]
       );
       foreach ($tokens as $token) {
         if (!empty($token['name'])) {
           $tokens[$token['name']] = [];
+        }
+        elseif (is_string($token) && strpos($token, ':') !== FALSE) {
+          $tokens[$token] = [];
         }
       }
       Civi::$statics[__CLASS__][__FUNCTION__][$key] = array_keys($tokens);


### PR DESCRIPTION
… way on php8 and include campaign_id pseudoconsntants as well

Overview
----------------------------------------
In php8 something seems to affect the way the array merge is done not sure how but it does which meant that the psuedo fields for contribution tokens weren't ending up in the static tokens['contribution'] array in this class in php8 causing the test failures https://test.civicrm.org/job/CiviCRM-Core-Edge/CIVIVER=5.43,label=test-3/lastCompletedBuild/testReport/(root)/CRM_Contribute_ActionMapping_ByTypeTest/testTokenRendering/ https://test.civicrm.org/job/CiviCRM-Core-Edge/CIVIVER=5.43,label=test-3/lastCompletedBuild/testReport/junit/(root)/CRM_Contribute_BAO_ContributionTest/testReplaceContributionTokens/

Before
----------------------------------------
Tests fail on php8

After
----------------------------------------
Tests pass on php8

ping @eileenmcnaughton @demeritcowboy 