### PR TITLE
Afform - Display the extension in which an Afform is packaged

### DIFF
--- a/CRM/Extension/Mapper.php
+++ b/CRM/Extension/Mapper.php
@@ -480,8 +480,7 @@ class CRM_Extension_Mapper {
   /**
    * Get a list of all installed modules, including enabled and disabled ones
    *
-   * @return array
-   *   CRM_Core_Module
+   * @return CRM_Core_Module[]
    */
   public function getModules() {
     $result = [];

--- a/Civi/Api4/Generic/BasicGetAction.php
+++ b/Civi/Api4/Generic/BasicGetAction.php
@@ -107,6 +107,7 @@ class BasicGetAction extends AbstractGetAction {
     $fields = $this->entityFields();
     foreach ($records as &$values) {
       foreach ($this->entityFields() as $field) {
+        $values += [$field['name'] => NULL];
         if (!empty($field['options'])) {
           foreach (FormattingUtil::$pseudoConstantSuffixes as $suffix) {
             $pseudofield = $field['name'] . ':' . $suffix;

--- a/ext/afform/admin/ang/afAdmin.js
+++ b/ext/afform/admin/ang/afAdmin.js
@@ -11,7 +11,7 @@
           // Load data for lists
           afforms: function(crmApi4) {
             return crmApi4('Afform', 'get', {
-              select: ['name', 'title', 'type', 'server_route', 'is_public', 'has_local', 'has_base', 'is_dashlet', 'contact_summary:label']
+              select: ['name', 'title', 'type', 'server_route', 'is_public', 'has_local', 'has_base', 'base_module', 'base_module:label', 'is_dashlet', 'contact_summary:label']
             });
           }
         }

--- a/ext/afform/admin/ang/afAdmin/afAdminList.controller.js
+++ b/ext/afform/admin/ang/afAdmin/afAdminList.controller.js
@@ -126,7 +126,7 @@
         if (afform.has_base) {
           apiOps.push(['Afform', 'get', {
             where: [['name', '=', afform.name]],
-            select: ['name', 'title', 'type', 'is_public', 'server_route', 'has_local', 'has_base']
+            select: ['name', 'title', 'type', 'is_public', 'server_route', 'has_local', 'has_base', 'base_module', 'base_module:label']
           }, 0]);
         }
         var apiCall = crmStatus(

--- a/ext/afform/admin/ang/afAdmin/afAdminList.html
+++ b/ext/afform/admin/ang/afAdmin/afAdminList.html
@@ -57,6 +57,11 @@
         <i class="crm-i fa-sort-{{ $ctrl.sortDir ? 'asc' : 'desc' }}" ng-if="$ctrl.sortField === 'placement.length'"></i>
         {{:: ts('Placement') }}
       </th>
+      <th title="{{:: ts('Click to sort') }}" ng-click="$ctrl.sortBy('base_module')">
+        <i class="crm-i fa-sort disabled" ng-if="$ctrl.sortField !== 'base_module'"></i>
+        <i class="crm-i fa-sort-{{ $ctrl.sortDir ? 'asc' : 'desc' }}" ng-if="$ctrl.sortField === 'base_module'"></i>
+        {{:: ts('Package') }}
+      </th>
       <th></th>
     </tr>
     </thead>
@@ -73,10 +78,13 @@
         </a>
       </td>
       <td>{{:: afform.placement.join(', ') }}</td>
+      <td>
+        {{:: afform['base_module:label'] }}
+      </td>
       <td class="text-right">
         <a ng-if="afform.type !== 'system'" href="#/edit/{{:: afform.name }}" class="btn btn-xs btn-primary">{{:: ts('Edit') }}</a>
         <a ng-if="afform.type !== 'system'" href="#/clone/{{:: afform.name }}" class="btn btn-xs btn-secondary">{{:: ts('Clone') }}</a>
-        <a href ng-if="afform.has_local" class="btn btn-xs btn-danger" crm-confirm="{type: afform.has_base ? 'revert' : 'delete', obj: afform}" on-yes="$ctrl.revert(afform)">
+        <a href ng-if="afform.has_local" class="btn btn-xs btn-{{ afform.has_base ? 'warning' : 'danger' }}" crm-confirm="{type: afform.has_base ? 'revert' : 'delete', obj: afform}" on-yes="$ctrl.revert(afform)">
           {{ afform.has_base ? ts('Revert') : ts('Delete') }}
         </a>
       </td>

--- a/ext/afform/admin/ang/afAdmin/afAdminList.html
+++ b/ext/afform/admin/ang/afAdmin/afAdminList.html
@@ -3,7 +3,10 @@
 
   <ul class="nav nav-tabs">
     <li role="presentation" ng-repeat="tab in $ctrl.tabs" ng-class="{active: tab.name === $ctrl.tab}">
-      <a href ng-click="$ctrl.tab = tab.name; $ctrl.searchAfformList = ''"><i class="crm-i {{ tab.icon }}"></i> {{:: tab.plural }}</a>
+      <a href ng-click="$ctrl.tab = tab.name; $ctrl.searchAfformList = ''">
+        <i class="crm-i {{ tab.icon }}"></i> {{:: tab.plural }}
+        <span class="badge">{{ $ctrl.afforms[tab.name].length }}</span>
+      </a>
     </li>
   </ul>
 

--- a/ext/afform/core/CRM/Afform/AfformScanner.php
+++ b/ext/afform/core/CRM/Afform/AfformScanner.php
@@ -49,10 +49,9 @@ class CRM_Afform_AfformScanner {
 
     $mapper = CRM_Extension_System::singleton()->getMapper();
     foreach ($mapper->getModules() as $module) {
-      /** @var $module CRM_Core_Module */
       try {
         if ($module->is_active) {
-          $this->appendFilePaths($paths, dirname($mapper->keyToPath($module->name)) . DIRECTORY_SEPARATOR . 'ang', 20);
+          $this->appendFilePaths($paths, dirname($mapper->keyToPath($module->name)) . DIRECTORY_SEPARATOR . 'ang', $module->name);
         }
       }
       catch (CRM_Extension_Exception_MissingException $e) {
@@ -60,7 +59,7 @@ class CRM_Afform_AfformScanner {
       }
     }
 
-    $this->appendFilePaths($paths, $this->getSiteLocalPath(), 10);
+    $this->appendFilePaths($paths, $this->getSiteLocalPath(), '');
 
     $this->cache->set('afformAllPaths', $paths);
     return $paths;
@@ -157,23 +156,19 @@ class CRM_Afform_AfformScanner {
   }
 
   /**
-   * Adds has_local & has_base to an afform metadata record
+   * Adds base_module, has_local & has_base to an afform metadata record
    *
    * @param array $record
    */
   public function addComputedFields(&$record) {
     $name = $record['name'];
-    // Ex: $allPaths['viewIndividual'][0] == '/var/www/foo/afform/view-individual'].
+    // Ex: $allPaths['viewIndividual']['org.civicrm.foo'] == '/var/www/foo/afform/view-individual'].
     $allPaths = $this->findFilePaths()[$name] ?? [];
-    // $activeLayoutPath = $this->findFilePath($name, self::LAYOUT_FILE);
-    // $activeMetaPath = $this->findFilePath($name, self::METADATA_FILE);
-    $localLayoutPath = $this->createSiteLocalPath($name, self::LAYOUT_FILE);
-    $localMetaPath = $this->createSiteLocalPath($name, self::METADATA_FILE);
-
-    $record['has_local'] = file_exists($localLayoutPath) || file_exists($localMetaPath);
+    // Empty string key refers to the site local path
+    $record['has_local'] = isset($allPaths['']);
     if (!isset($record['has_base'])) {
-      $record['has_base'] = ($record['has_local'] && count($allPaths) > 1)
-        || (!$record['has_local'] && count($allPaths) > 0);
+      $record['base_module'] = \CRM_Utils_Array::first(array_filter(array_keys($allPaths)));
+      $record['has_base'] = !empty($record['base_module']);
     }
   }
 
@@ -211,16 +206,17 @@ class CRM_Afform_AfformScanner {
    *   Ex: ['foo' => [0 => '/var/www/org.example.foobar/ang']]
    * @param string $parent
    *   Ex: '/var/www/org.example.foobar/afform/'
-   * @param int $priority
-   *   Lower priority files override higher priority files.
+   * @param string $module
+   *   Name of module or '' empty string for local files.
    */
-  private function appendFilePaths(&$formPaths, $parent, $priority) {
+  private function appendFilePaths(&$formPaths, $parent, $module) {
     $files = preg_grep(self::FILE_REGEXP, (array) glob("$parent/*"));
 
     foreach ($files as $file) {
       $fileBase = preg_replace(self::FILE_REGEXP, '', $file);
       $name = basename($fileBase);
-      $formPaths[$name][$priority] = $fileBase;
+      $formPaths[$name][$module] = $fileBase;
+      // Local files get top priority
       ksort($formPaths[$name]);
     }
   }

--- a/ext/afform/core/Civi/Api4/Action/Afform/Get.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/Get.php
@@ -17,7 +17,7 @@ class Get extends \Civi\Api4\Generic\BasicGetAction {
   public function getRecords() {
     /** @var \CRM_Afform_AfformScanner $scanner */
     $scanner = \Civi::service('afform_scanner');
-    $getComputed = $this->_isFieldSelected('has_local', 'has_base');
+    $getComputed = $this->_isFieldSelected('has_local', 'has_base', 'base_module');
     $getLayout = $this->_isFieldSelected('layout');
     $getSearchDisplays = $this->_isFieldSelected('search_displays');
     $values = [];

--- a/ext/afform/core/Civi/Api4/Afform.php
+++ b/ext/afform/core/Civi/Api4/Afform.php
@@ -3,6 +3,7 @@
 namespace Civi\Api4;
 
 use Civi\Api4\Generic\BasicBatchAction;
+use Civi\Api4\Generic\BasicGetFieldsAction;
 
 /**
  * User-configurable forms.
@@ -138,7 +139,7 @@ class Afform extends Generic\AbstractEntity {
    * @return Generic\BasicGetFieldsAction
    */
   public static function getFields($checkPermissions = TRUE) {
-    return (new Generic\BasicGetFieldsAction('Afform', __FUNCTION__, function($self) {
+    return (new Generic\BasicGetFieldsAction('Afform', __FUNCTION__, function(BasicGetFieldsAction $self) {
       $fields = [
         [
           'name' => 'name',
@@ -222,13 +223,23 @@ class Afform extends Generic\AbstractEntity {
           'name' => 'has_local',
           'type' => 'Extra',
           'data_type' => 'Boolean',
+          'description' => 'Whether a local copy is saved on site',
           'readonly' => TRUE,
         ];
         $fields[] = [
           'name' => 'has_base',
           'type' => 'Extra',
           'data_type' => 'Boolean',
+          'description' => 'Is provided by an extension',
           'readonly' => TRUE,
+        ];
+        $fields[] = [
+          'name' => 'base_module',
+          'type' => 'Extra',
+          'data_type' => 'String',
+          'description' => 'Name of extension which provides this form',
+          'readonly' => TRUE,
+          'options' => $self->getLoadOptions() ? \CRM_Core_PseudoConstant::getExtensions() : TRUE,
         ];
         $fields[] = [
           'name' => 'search_displays',

--- a/ext/afform/core/tests/phpunit/Civi/Afform/AfformGetTest.php
+++ b/ext/afform/core/tests/phpunit/Civi/Afform/AfformGetTest.php
@@ -52,6 +52,7 @@ class AfformGetTest extends \PHPUnit\Framework\TestCase implements HeadlessInter
     $this->assertEquals($this->formName, $result['name']);
     $this->assertFalse($result['has_base']);
     $this->assertArrayNotHasKey('has_local', $result);
+    $this->assertArrayNotHasKey('base_module', $result);
   }
 
   public function testGetSearchDisplays() {

--- a/ext/afform/mock/tests/phpunit/api/v4/AfformTest.php
+++ b/ext/afform/mock/tests/phpunit/api/v4/AfformTest.php
@@ -54,7 +54,7 @@ class api_v4_AfformTest extends api_v4_AfformTestCase {
 
     $message = 'The initial Afform.get should return default data';
     $result = Civi\Api4\Afform::get()
-      ->addSelect('*', 'has_base', 'has_local')
+      ->addSelect('*', 'has_base', 'has_local', 'base_module')
       ->addWhere('name', '=', $formName)->execute();
     $this->assertEquals($formName, $result[0]['name'], $message);
     $this->assertEquals($get($originalMetadata, 'title'), $get($result[0], 'title'), $message);
@@ -65,6 +65,7 @@ class api_v4_AfformTest extends api_v4_AfformTestCase {
     $this->assertTrue(is_array($result[0]['layout']), $message);
     $this->assertEquals(TRUE, $get($result[0], 'has_base'), $message);
     $this->assertEquals(FALSE, $get($result[0], 'has_local'), $message);
+    $this->assertEquals('org.civicrm.afform-mock', $get($result[0], 'base_module'), $message);
 
     $message = 'After updating with Afform.create, the revised data should be returned';
     $result = Civi\Api4\Afform::update()
@@ -78,7 +79,7 @@ class api_v4_AfformTest extends api_v4_AfformTestCase {
 
     $message = 'After updating, the Afform.get API should return blended data';
     $result = Civi\Api4\Afform::get()
-      ->addSelect('*', 'has_base', 'has_local')
+      ->addSelect('*', 'has_base', 'has_local', 'base_module')
       ->addWhere('name', '=', $formName)->execute();
     $this->assertEquals($formName, $result[0]['name'], $message);
     $this->assertEquals($get($originalMetadata, 'title'), $get($result[0], 'title'), $message);
@@ -89,11 +90,12 @@ class api_v4_AfformTest extends api_v4_AfformTestCase {
     $this->assertTrue(is_array($result[0]['layout']), $message);
     $this->assertEquals(TRUE, $get($result[0], 'has_base'), $message);
     $this->assertEquals(TRUE, $get($result[0], 'has_local'), $message);
+    $this->assertEquals('org.civicrm.afform-mock', $get($result[0], 'base_module'), $message);
 
     Civi\Api4\Afform::revert()->addWhere('name', '=', $formName)->execute();
     $message = 'After reverting, the final Afform.get should return default data';
     $result = Civi\Api4\Afform::get()
-      ->addSelect('*', 'has_base', 'has_local')
+      ->addSelect('*', 'has_base', 'has_local', 'base_module')
       ->addWhere('name', '=', $formName)->execute();
     $this->assertEquals($formName, $result[0]['name'], $message);
     $this->assertEquals($get($originalMetadata, 'title'), $get($result[0], 'title'), $message);
@@ -103,6 +105,7 @@ class api_v4_AfformTest extends api_v4_AfformTestCase {
     $this->assertTrue(is_array($result[0]['layout']), $message);
     $this->assertEquals(TRUE, $get($result[0], 'has_base'), $message);
     $this->assertEquals(FALSE, $get($result[0], 'has_local'), $message);
+    $this->assertEquals('org.civicrm.afform-mock', $get($result[0], 'base_module'), $message);
   }
 
   public function getFormatExamples() {

--- a/tests/phpunit/api/v4/Action/BasicActionsTest.php
+++ b/tests/phpunit/api/v4/Action/BasicActionsTest.php
@@ -279,7 +279,7 @@ class BasicActionsTest extends UnitTestCase implements HookInterface {
 
     foreach (MockBasicEntity::get()->addSelect('*')->execute() as $result) {
       ksort($result);
-      $this->assertEquals(['color', 'group', 'identifier', 'shape', 'size', 'weight'], array_keys($result));
+      $this->assertEquals(['color', 'foo', 'fruit', 'group', 'identifier', 'shape', 'size', 'weight'], array_keys($result));
     }
 
     $result = MockBasicEntity::get()

--- a/tests/phpunit/api/v4/Action/GetFromArrayTest.php
+++ b/tests/phpunit/api/v4/Action/GetFromArrayTest.php
@@ -76,6 +76,7 @@ class GetFromArrayTest extends UnitTestCase {
       ],
       [
         'field1' => 3,
+        'field3' => NULL,
       ],
       [
         'field1' => 4,


### PR DESCRIPTION
Overview
----------------------------------------
Displays extension name in the UI for packaged Afforms.

![image](https://user-images.githubusercontent.com/2874912/139936521-8109add1-9020-4b64-8894-fe0f376f694d.png)

This PR complements #21955 which does something similar for SavedSearches, etc.

Technical Details
----------------------------------------
Adds `base_module` field to `APIv4 Afform::get`, which returns the name of the extension in which an Afform is packaged.

This internally rearranges the way afform paths are stored, using the extension name as key instead of a weight integer. Both give the same results in `ksort()`.
