### PR TITLE
Fix missing currency for event registration when configured via "quick config"

### DIFF
--- a/CRM/Price/BAO/PriceField.php
+++ b/CRM/Price/BAO/PriceField.php
@@ -274,6 +274,7 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
     $config = CRM_Core_Config::singleton();
     $currencySymbol = CRM_Core_DAO::getFieldValue('CRM_Financial_DAO_Currency', $config->defaultCurrency, 'symbol', 'name');
     $qf->assign('currencySymbol', $currencySymbol);
+    $qf->assign('currency', $config->defaultCurrency);
     // get currency name for price field and option attributes
     $currencyName = $config->defaultCurrency;
 

--- a/api/v3/utils.php
+++ b/api/v3/utils.php
@@ -2244,7 +2244,7 @@ function _civicrm_api3_validate_string(&$params, &$fieldName, &$fieldInfo, $enti
       if ($fieldName == 'currency') {
         //When using IN operator $fieldValue is a array of currency codes
         if (!CRM_Utils_Rule::currencyCode($value)) {
-          throw new Exception("Currency not a valid code: $currency");
+          throw new Exception("Currency not a valid code: $value");
         }
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------
This fixes a pretty obscure issue that can be triggered under the following conditions:
1. Even registration page configured with multiple payment processors and no default. (Eg. Stripe + pay later where Stripe is not default in CiviCRM).
2. 3 "non priceset" payment options configured under fees.

This triggers an AJAX call like this when you select a payment processor:
```
https://d7.local.mjw.pt/civicrm/payment/form?formName=Register&is_back_office=&pre_profile_id=12&processor_id=9&cid=202&payment_instrument_id=undefined&currency=undefined&snippet=json
```

which causes on the PHP side currency to be set to the string "undefined":
```
$form->getVar('currency') === 'undefined';
```

which means if you subsequently try to use that value as the currency via an API3 call it fails because "currency" is treated as a magic value in API3 and gets validated against the list of currencies in CiviCRM and throws an exception.

Confused yet?

Before
----------------------------------------
When retrieving the currency in some obscure situations it all goes wrong.

After
----------------------------------------
It does not all go wrong anymore.

Technical Details
----------------------------------------
Described above.

Comments
----------------------------------------
This is obviously obscure enough that no-one noticed that the API3 exception was also returning invalid data!
