### PR TITLE
SearchKit - Fix incorrect pager count when using filters

### DIFF
--- a/CRM/Utils/Array.php
+++ b/CRM/Utils/Array.php
@@ -1336,4 +1336,19 @@ class CRM_Utils_Array {
     return NULL;
   }
 
+  /**
+   * Prepend string prefix to every key in an array
+   *
+   * @param array $collection
+   * @param string $prefix
+   * @return array
+   */
+  public static function prefixKeys(array $collection, string $prefix) {
+    $result = [];
+    foreach ($collection as $key => $value) {
+      $result[$prefix . $key] = $value;
+    }
+    return $result;
+  }
+
 }

--- a/Civi/Api4/Generic/BasicGetAction.php
+++ b/Civi/Api4/Generic/BasicGetAction.php
@@ -112,14 +112,13 @@ class BasicGetAction extends AbstractGetAction {
             $pseudofield = $field['name'] . ':' . $suffix;
             if (!isset($values[$pseudofield]) && isset($values[$field['name']]) && $this->_isFieldSelected($pseudofield)) {
               $values[$pseudofield] = $values[$field['name']];
-              $fields[$pseudofield] = $field;
             }
           }
         }
       }
     }
     // Swap raw values with pseudoconstants
-    FormattingUtil::formatOutputValues($records, $fields, $this->getEntityName(), $this->getActionName());
+    FormattingUtil::formatOutputValues($records, $fields, $this->getActionName());
   }
 
 }

--- a/Civi/Api4/Generic/Traits/CustomValueActionTrait.php
+++ b/Civi/Api4/Generic/Traits/CustomValueActionTrait.php
@@ -84,7 +84,7 @@ trait CustomValueActionTrait {
         $items[$idx]['id'] = (int) \CRM_Core_DAO::singleValueQuery('SELECT MAX(id) FROM ' . $tableName);
       }
     }
-    FormattingUtil::formatOutputValues($items, $this->entityFields(), $this->getEntityName(), 'create');
+    FormattingUtil::formatOutputValues($items, $this->entityFields(), 'create');
     return $items;
   }
 

--- a/Civi/Api4/Generic/Traits/DAOActionTrait.php
+++ b/Civi/Api4/Generic/Traits/DAOActionTrait.php
@@ -161,7 +161,7 @@ trait DAOActionTrait {
       }
     }
 
-    FormattingUtil::formatOutputValues($result, $this->entityFields(), $this->getEntityName());
+    FormattingUtil::formatOutputValues($result, $this->entityFields());
     return $result;
   }
 

--- a/Civi/Api4/Query/Api4SelectQuery.php
+++ b/Civi/Api4/Query/Api4SelectQuery.php
@@ -174,7 +174,7 @@ class Api4SelectQuery {
       }
       $results[] = $result;
     }
-    FormattingUtil::formatOutputValues($results, $this->apiFieldSpec, $this->getEntity(), 'get', $this->selectAliases);
+    FormattingUtil::formatOutputValues($results, $this->apiFieldSpec, 'get', $this->selectAliases);
     return $results;
   }
 

--- a/Civi/Api4/Utils/FormattingUtil.php
+++ b/Civi/Api4/Utils/FormattingUtil.php
@@ -185,20 +185,20 @@ class FormattingUtil {
    *
    * @param array $results
    * @param array $fields
-   * @param string $entity
    * @param string $action
    * @param array $selectAliases
    * @throws \API_Exception
    * @throws \CRM_Core_Exception
    */
-  public static function formatOutputValues(&$results, $fields, $entity, $action = 'get', $selectAliases = []) {
+  public static function formatOutputValues(&$results, $fields, $action = 'get', $selectAliases = []) {
     $fieldOptions = [];
     foreach ($results as &$result) {
       $contactTypePaths = [];
       foreach ($result as $key => $value) {
         $fieldExpr = SqlExpression::convert($selectAliases[$key] ?? $key);
         $fieldName = \CRM_Utils_Array::first($fieldExpr->getFields());
-        $field = $fieldName && isset($fields[$fieldName]) ? $fields[$fieldName] : NULL;
+        $baseName = $fieldName ? \CRM_Utils_Array::first(explode(':', $fieldName)) : NULL;
+        $field = $fields[$fieldName] ?? $fields[$baseName] ?? NULL;
         $dataType = $field['data_type'] ?? ($fieldName == 'id' ? 'Integer' : NULL);
         // Allow Sql Functions to do special formatting and/or alter the $dataType
         if (method_exists($fieldExpr, 'formatOutputValue') && is_string($value)) {

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/Download.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/Download.php
@@ -51,7 +51,7 @@ class Download extends AbstractRunAction {
    */
   protected function processResult(\Civi\Api4\Generic\Result $result) {
     $entityName = $this->savedSearch['api_entity'];
-    $apiParams =& $this->savedSearch['api_params'];
+    $apiParams =& $this->_apiParams;
     $settings = $this->display['settings'];
 
     // Displays are only exportable if they have actions enabled

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/Run.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/Run.php
@@ -34,14 +34,14 @@ class Run extends AbstractRunAction {
    */
   protected function processResult(\Civi\Api4\Generic\Result $result) {
     $entityName = $this->savedSearch['api_entity'];
-    $apiParams =& $this->savedSearch['api_params'];
+    $apiParams =& $this->_apiParams;
     $settings = $this->display['settings'];
     $page = $index = NULL;
     $key = $this->return;
 
     switch ($this->return) {
       case 'id':
-        $key = CoreUtil::getIdFieldName($this->savedSearch['api_entity']);
+        $key = CoreUtil::getIdFieldName($entityName);
         $index = [$key];
       case 'row_count':
         if (empty($apiParams['having'])) {

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/SavedSearchInspectorTrait.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/SavedSearchInspectorTrait.php
@@ -23,6 +23,11 @@ trait SavedSearchInspectorTrait {
   protected $savedSearch;
 
   /**
+   * @var array{select: array, where: array, having: array, orderBy: array, limit: int, offset: int, checkPermissions: bool, debug: bool}
+   */
+  protected $_apiParams;
+
+  /**
    * @var \Civi\Api4\Query\Api4SelectQuery
    */
   private $_selectQuery;
@@ -43,6 +48,7 @@ trait SavedSearchInspectorTrait {
         ->addWhere('name', '=', $this->savedSearch)
         ->execute()->single();
     }
+    $this->_apiParams = $this->savedSearch['api_params'] + ['where' => [], 'join' => [], 'having' => []];
   }
 
   /**
@@ -88,7 +94,7 @@ trait SavedSearchInspectorTrait {
   protected function getSelectClause() {
     if (!isset($this->_selectClause)) {
       $this->_selectClause = [];
-      foreach ($this->savedSearch['api_params']['select'] ?? [] as $selectExpr) {
+      foreach ($this->_apiParams['select'] as $selectExpr) {
         $expr = SqlExpression::convert($selectExpr, TRUE);
         $item = [
           'fields' => [],

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/SavedSearchInspectorTrait.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/SavedSearchInspectorTrait.php
@@ -48,7 +48,7 @@ trait SavedSearchInspectorTrait {
         ->addWhere('name', '=', $this->savedSearch)
         ->execute()->single();
     }
-    $this->_apiParams = $this->savedSearch['api_params'] + ['where' => [], 'join' => [], 'having' => []];
+    $this->_apiParams = ($this->savedSearch['api_params'] ?? []) + ['select' => [], 'where' => [], 'join' => [], 'having' => []];
   }
 
   /**

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchDisplayTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchDisplayTest.php
@@ -27,13 +27,27 @@ class SearchDisplayTest extends \PHPUnit\Framework\TestCase implements HeadlessI
     ];
     $display = SearchDisplay::getDefault(FALSE)
       ->setSavedSearch($params)
-      ->addSelect('*', 'saved_search_id.api_entity', 'type:name')
+      ->addSelect('*', 'saved_search_id.api_entity', 'saved_search_id.api_entity:label', 'type:name', 'type:icon')
       ->execute()->single();
 
     $this->assertCount(5, $display['settings']['columns']);
     $this->assertEquals('Contacts', $display['label']);
     $this->assertEquals('crm-search-display-table', $display['type:name']);
+    $this->assertEquals('fa-table', $display['type:icon']);
     $this->assertEquals('Contact', $display['saved_search_id.api_entity']);
+    $this->assertEquals('Contacts', $display['saved_search_id.api_entity:label']);
+  }
+
+  public function testGetDefaultNoEntity() {
+    $display = SearchDisplay::getDefault(FALSE)
+      ->addSelect('*', 'saved_search_id', 'type:name', 'type:icon')
+      ->execute()->single();
+
+    $this->assertCount(1, $display['settings']['columns']);
+    $this->assertEquals('', $display['label']);
+    $this->assertEquals('crm-search-display-table', $display['type:name']);
+    $this->assertEquals('fa-table', $display['type:icon']);
+    $this->assertNull($display['saved_search_id']);
   }
 
 }

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
@@ -111,6 +111,8 @@ class SearchRunTest extends \PHPUnit\Framework\TestCase implements HeadlessInter
     $this->assertCount(2, $result);
     $this->assertEquals('One', $result[0]['data']['first_name']);
     $this->assertEquals('Two', $result[1]['data']['first_name']);
+    $count = civicrm_api4('SearchDisplay', 'run', ['return' => 'row_count'] + $params);
+    $this->assertCount(2, $count);
 
     // Raw value should be boolean, view value should be string
     $this->assertEquals(FALSE, $result[0]['data']['is_deceased']);
@@ -122,20 +124,28 @@ class SearchRunTest extends \PHPUnit\Framework\TestCase implements HeadlessInter
     $this->assertCount(2, $result);
     $this->assertEquals('Three', $result[0]['data']['first_name']);
     $this->assertEquals('Two', $result[1]['data']['first_name']);
+    $count = civicrm_api4('SearchDisplay', 'run', ['return' => 'row_count'] + $params);
+    $this->assertCount(2, $count);
 
     $params['filters'] = ['last_name' => $lastName, 'contact_sub_type:label' => ['Tester', 'Bot']];
     $result = civicrm_api4('SearchDisplay', 'run', $params);
     $this->assertCount(3, $result);
+    $count = civicrm_api4('SearchDisplay', 'run', ['return' => 'row_count'] + $params);
+    $this->assertCount(3, $count);
 
     // Comma indicates first_name OR last_name
     $params['filters'] = ['first_name,last_name' => $lastName, 'contact_sub_type' => ['Tester']];
     $result = civicrm_api4('SearchDisplay', 'run', $params);
     $this->assertCount(2, $result);
+    $count = civicrm_api4('SearchDisplay', 'run', ['return' => 'row_count'] + $params);
+    $this->assertCount(2, $count);
 
     // Comma indicates first_name OR middle_name, matches "One" or "None"
     $params['filters'] = ['first_name,middle_name' => 'one', 'last_name' => $lastName];
     $result = civicrm_api4('SearchDisplay', 'run', $params);
     $this->assertCount(2, $result);
+    $count = civicrm_api4('SearchDisplay', 'run', ['return' => 'row_count'] + $params);
+    $this->assertCount(2, $count);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a bug where filters were not being applied correctly when fetching rowCount, and also improves the output from `SearchDisplay::getDefault`.

Before
----------------------------------------
Pager incorrect (if > 1 page) after applying a filter.
`SearchDisplay::getDefault` doesn't fully support pseudoconstants.

After
----------------------------------------
Fixed, with tests.