### PR TITLE
Remove call to getTokenDetails

### DIFF
--- a/CRM/Event/BAO/Participant.php
+++ b/CRM/Event/BAO/Participant.php
@@ -1236,15 +1236,7 @@ UPDATE  civicrm_participant
 
     //get all required contacts detail.
     if (!empty($contactIds)) {
-      // get the contact details.
-      list($currentContactDetails) = CRM_Utils_Token::getTokenDetails($contactIds, NULL,
-        FALSE, FALSE, NULL,
-        [],
-        'CRM_Event_BAO_Participant'
-      );
-      foreach ($currentContactDetails as $contactId => $contactValues) {
-        $contactDetails[$contactId] = $contactValues;
-      }
+      $contactDetails = civicrm_api3('Contact', 'get', ['id' => ['IN' => $contactIds, 'return' => 'display_name']])['values'];
     }
 
     //get all required events detail.
@@ -1312,7 +1304,7 @@ UPDATE  civicrm_participant
             $mail = self::sendTransitionParticipantMail($additionalId,
               $participantDetails[$additionalId],
               $eventDetails[$participantDetails[$additionalId]['event_id']],
-              $contactDetails[$participantDetails[$additionalId]['contact_id']],
+              NULL,
               $emailType
             );
 
@@ -1331,7 +1323,7 @@ UPDATE  civicrm_participant
         $mail = self::sendTransitionParticipantMail($participantId,
           $participantValues,
           $eventDetails[$participantValues['event_id']],
-          $contactDetails[$participantValues['contact_id']],
+          NULL,
           $emailType
         );
 

--- a/CRM/Event/BAO/Participant.php
+++ b/CRM/Event/BAO/Participant.php
@@ -1236,7 +1236,7 @@ UPDATE  civicrm_participant
 
     //get all required contacts detail.
     if (!empty($contactIds)) {
-      $contactDetails = civicrm_api3('Contact', 'get', ['id' => ['IN' => $contactIds, 'return' => 'display_name']])['values'];
+      $contactDetails += civicrm_api3('Contact', 'get', ['id' => ['IN' => $contactIds, 'return' => 'display_name']])['values'];
     }
 
     //get all required events detail.

--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -1134,6 +1134,8 @@ class CRM_Utils_Token {
   }
 
   /**
+   * Do not use this function.
+   *
    * Gives required details of contacts in an indexed array format so we
    * can iterate in a nice loop and do token evaluation
    *
@@ -1152,6 +1154,8 @@ class CRM_Utils_Token {
    * @param int|null $jobID
    *   The mailing list jobID - this is a legacy param.
    *
+   * @deprecated
+   *
    * @return array - e.g [[1 => ['first_name' => 'bob'...], 34 => ['first_name' => 'fred'...]]]
    */
   public static function getTokenDetails(
@@ -1164,7 +1168,6 @@ class CRM_Utils_Token {
     $className = NULL,
     $jobID = NULL
   ) {
-
     $params = [];
     foreach ($contactIDs as $contactID) {
       $params[] = [


### PR DESCRIPTION

Overview
----------------------------------------
Remove call to getTokenDetails

Before
----------------------------------------
Call to `getTokenDetails` calls the legacy token hook - but the results are not used

After
----------------------------------------
SImple api call to retrieve minimum required details


Technical Details
----------------------------------------
This is tested vi CRM_Event_Form_Task_BatchTest::testSubmitCancel

Comments
----------------------------------------
Note that after this `getTokenDetails` is still called from the Job.update_greetings - which ALSO calls tokenProcessor and from legacy mailings. Hence there is no reason to implement `hookTokenValues` anymore (although flexmailer should be required by extensions that offer tokens)