### PR TITLE
SearchKit - Fix permission to access default display and download spreadsheets

### DIFF
--- a/ext/search_kit/Civi/Api4/SearchDisplay.php
+++ b/ext/search_kit/Civi/Api4/SearchDisplay.php
@@ -52,10 +52,12 @@ class SearchDisplay extends Generic\DAOEntity {
   public static function permissions() {
     $permissions = parent::permissions();
     $permissions['default'] = ['administer CiviCRM data'];
-    $permissions['get'] = ['access CiviCRM'];
+    // Anyone with access to CiviCRM can view search displays (but not necessarily the results)
+    $permissions['get'] = $permissions['getDefault'] = ['access CiviCRM'];
+    // Anyone with access to CiviCRM can do search tasks (but not necessarily all of them)
     $permissions['getSearchTasks'] = ['access CiviCRM'];
-    // Permission for run action is checked internally
-    $permissions['run'] = [];
+    // Permission to run or download search results is checked internally
+    $permissions['run'] = $permissions['download'] = [];
     return $permissions;
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Followup to #21929 to ensure all users who should have access to view search displays will be able to do so.

Before
----------------------------------------
Default display and spreadsheet download were restricted to administrators; this was an oversight.

After
----------------------------------------
Fixed.

Technical Details
----------------------------------------
Intentionally setting these gatekeeper permissions fairly open as all of these actions perform stricter permission checks internally.
