### PR TITLE
ACLCache: Optimise cache build

### DIFF
--- a/CRM/Contact/BAO/GroupContactCache.php
+++ b/CRM/Contact/BAO/GroupContactCache.php
@@ -370,7 +370,7 @@ WHERE  id IN ( $groupIDs )
    *
    * The groups are refreshable if both the following conditions are met:
    * 1) the cache date in the database is null or stale
-   * 2) a mysql lock can be aquired for the group.
+   * 2) a mysql lock can be acquired for the group.
    *
    * @param array $groupIDs
    *


### PR DESCRIPTION
Overview
----------------------------------------
Equivalent of #21943 but for ACL cache.

Both `INSERT IGNORE` and `SELECT DISTINCT` reduce performance of queries significantly because of the way they work internally (see various articles online).

We originally had `INSERT IGNORE` to guard against a lock not working properly (they used to be unreliable) when updating the `civicrm_acl_contact_cache` table but should not be necessary anymore. If the "IGNORE" is still required then it would expose a fundamental failure of the locking mechanism.

`SELECT DISTINCT` was guarding against there being duplicate `contact_id`s in the temporary cache table. That also should not be happening but requires further validation of a more complex function to ensure that is the case. Changing to `GROUP BY` has the same effect and is generally more performant.

Before
----------------------------------------
Use of `INSERT IGNORE` and `SELECT DISTINCT`.

After
----------------------------------------
Use of `INSERT` and `GROUP BY` for reasons described above.

Technical Details
----------------------------------------
Described above.

Comments
----------------------------------------
I have just deployed on a client site.

@seamuslee001 I've also set useTemporaryTable to FALSE - I'm not sure I can see the benefit of a temporary table here at all because, unlike when building the group_contact_cache, we're not running a series of complex queries to prepare the data and instead are doing everything within a single query. Creating a temporary table with that data and then inserting seems like unnecessary extra queries and overhead all within the lock.