### PR TITLE
Fix isForm to be always assigned, remove checks

### DIFF
--- a/CRM/Core/Page.php
+++ b/CRM/Core/Page.php
@@ -98,6 +98,16 @@ class CRM_Core_Page {
   public $useLivePageJS;
 
   /**
+   * Variables smarty expects to have set.
+   *
+   * We ensure these are assigned (value = NULL) when Smarty is instantiated in
+   * order to avoid e-notices / having to use empty or isset in the template layer.
+   *
+   * @var string[]
+   */
+  public $expectedSmartyVariables = ['breadcrumb', 'pageTitle', 'isForm', 'hookContent'];
+
+  /**
    * Class constructor.
    *
    * @param string $title
@@ -116,6 +126,7 @@ class CRM_Core_Page {
     if (!isset(self::$_template)) {
       self::$_template = CRM_Core_Smarty::singleton();
       self::$_session = CRM_Core_Session::singleton();
+      self::$_template->ensureVariablesAreAssigned($this->expectedSmartyVariables);
     }
 
     // FIXME - why are we messing with 'snippet'? Why not just pass it directly into $this->_print?

--- a/templates/CRM/common/CMSPrint.tpl
+++ b/templates/CRM/common/CMSPrint.tpl
@@ -40,7 +40,7 @@
 <div id="crm-main-content-wrapper">
   {include file="CRM/common/status.tpl"}
   {crmRegion name='page-body'}
-    {if isset($isForm) and $isForm and isset($formTpl)}
+    {if $isForm and $formTpl}
       {include file="CRM/Form/$formTpl.tpl"}
     {else}
       {include file=$tplFile}

--- a/templates/CRM/common/joomla.tpl
+++ b/templates/CRM/common/joomla.tpl
@@ -53,7 +53,7 @@
     <div id="crm-main-content-wrapper">
       {include file="CRM/common/status.tpl"}
       {crmRegion name='page-body'}
-        {if isset($isForm) and $isForm and isset($formTpl)}
+        {if $isForm and $formTpl}
           {include file="CRM/Form/$formTpl.tpl"}
         {else}
           {include file=$tplFile}

--- a/templates/CRM/common/print.tpl
+++ b/templates/CRM/common/print.tpl
@@ -29,7 +29,7 @@
 {include file="CRM/common/status.tpl"}
 
 {crmRegion name='page-body' allowCmsOverride=0}
-  {if $isForm and isset($formTpl)}
+  {if $isForm and $formTpl}
     {include file="CRM/Form/$formTpl.tpl"}
   {else}
     {include file=$tplFile}

--- a/templates/CRM/common/printBody.tpl
+++ b/templates/CRM/common/printBody.tpl
@@ -9,7 +9,7 @@
 *}
 {* printBody.tpl: wrapper for Print views without HTML surrounds. *}
 
-{if $isForm and isset($formTpl)}
+{if $isForm and $formTpl}
     {include file="CRM/Form/$formTpl.tpl"}
 {else}
     {include file=$tplFile}


### PR DESCRIPTION


Overview
----------------------------------------
Fix isForm to be always assigned, remove checks

Before
----------------------------------------
Handling in smarty for it not being assigned

After
----------------------------------------
Always assigned

Technical Details
----------------------------------------
Note I'm not seeing any regressions on this locally with enotice turned on - but the
worst case, if tests pass, is we get some enotices back in a scenario where we
are only impacting bleeding edge devs

Comments
----------------------------------------
