### PR TITLE
Handle activity creation for emails directed to organization contacts

### DIFF
--- a/CRM/Utils/Mail/Incoming.php
+++ b/CRM/Utils/Mail/Incoming.php
@@ -452,6 +452,12 @@ class CRM_Utils_Mail_Incoming {
     $contactID = NULL;
     if ($dao) {
       $contactID = $dao->contact_id;
+    } else {
+      $dao = CRM_Contact_BAO_Contact::matchContactOnEmail($email, 'Organization');
+
+      if ($dao) {
+        $contactID = $dao->contact_id;
+      }
     }
 
     $result = NULL;

--- a/tests/phpunit/CRM/Utils/Mail/IncomingTest.php
+++ b/tests/phpunit/CRM/Utils/Mail/IncomingTest.php
@@ -1,0 +1,89 @@
+<?php
+
+/*
++--------------------------------------------------------------------+
+| Copyright CiviCRM LLC. All rights reserved.                        |
+|                                                                    |
+| This work is published under the GNU AGPLv3 license with some      |
+| permitted exceptions and without any warranty. For full license    |
+| and copyright information, see https://civicrm.org/licensing       |
++--------------------------------------------------------------------+
+ */
+
+/**
+ * Class for testing CRM_Utils_Mail_Incoming.
+ *
+ * @group headless
+ */
+class CRM_Utils_Mail_IncomingTest extends CiviUnitTestCase {
+
+  /**
+   * Email that receives the message.
+   *
+   * @var string
+   */
+  protected $email;
+
+  /**
+   * Name of the contact.
+   *
+   * @var string
+   */
+  protected $name;
+
+  public function setUp(): void {
+    parent::setUp();
+
+    $rand = rand(0, 1000);
+    $this->email = "test{$rand}@example.com";
+    $this->name = "Test$rand";
+  }
+
+  /**
+   * Tests that an email to an existent individual contact uses that contact.
+   */
+  public function testEmailUseExistentIndividualContact(): void {
+    $expectedContactId = $this->individualCreate(['email' => $this->email]);
+
+    $receivedContactId = CRM_Utils_Mail_Incoming::getContactID($this->email, $this->name, TRUE, $mail);
+
+    $this->assertEquals($expectedContactId, $receivedContactId);
+  }
+
+  /**
+   * Tests that an email to a non-existent contact creates an individual.
+   */
+  public function testEmailCreateIndividualContact(): void {
+    $contact = CRM_Contact_BAO_Contact::matchContactOnEmail($this->email, 'Individual');
+    $this->assertNull($contact);
+
+    CRM_Utils_Mail_Incoming::getContactID($this->email, $this->name, TRUE, $mail);
+
+    $contact = CRM_Contact_BAO_Contact::matchContactOnEmail($this->email, 'Individual');
+    $this->assertNotNull($contact);
+  }
+
+  /**
+   * Tests that an email to an existent organization contact uses that contact.
+   */
+  public function testEmailUseExistentOrganizationContact(): void {
+    $expectedContactId = $this->organizationCreate(['email' => $this->email]);
+
+    $receivedContactId = CRM_Utils_Mail_Incoming::getContactID($this->email, $this->name, TRUE, $mail);
+
+    $this->assertEquals($expectedContactId, $receivedContactId);
+  }
+
+  /**
+   * Tests that individual contact has precedence over organization contacts.
+   */
+  public function testEmailPrefersExistentIndividualContact(): void {
+    $individualContactId = $this->individualCreate(['email' => $this->email]);
+    $this->organizationCreate(['email' => $this->email]);
+
+    $receivedContactId = CRM_Utils_Mail_Incoming::getContactID($this->email, $this->name, TRUE, $mail);
+
+    $this->assertEquals($individualContactId, $receivedContactId);
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
This PR modifies the email-to-activity conversion process, making that an email address of an organizational contact gets associated with the activity created (instead of creating a new contact of type individual, as it is at the moment).
Gitlab issue: https://lab.civicrm.org/dev/core/-/issues/2872

Before
----------------------------------------
As described on the Gitlab issue, the emails sent to an organizational mail account are associated with a new contact of type individual, instead of the existent contact of type organization.

After
----------------------------------------
As suggested on the issue, the individual contact has priority over organization contact, if they share the email, but if there is only one of type organization, it gets used.
Also, in case there are no contacts for that email, a new one of type individual is created, like before.

Technical Details
----------------------------------------
The change is on the method that gets the contact ID, `CRM_Utils_Mail_Incoming::getContactID`, in particular on the query performed inside it. The new query is basically the one that @eileenmcnaughton propose.
The tests cover the previous and new cases.
**Update**: The query using Email v4 API was replaced by executing twice the method `CRM_Contact_BAO_Contact::matchContactOnEmail`, one looking for contacts of type `Individual` and the other, if none found, for type `Organization`. This is because this method currently performs some necessary logic for preferring `is_primary` email over others, taking care of multi-site cases, and deleted contacts.

