### PR TITLE
dev/core#2550: DB upgrade fails for 5.15->5.36

### DIFF
--- a/CRM/Contact/BAO/SavedSearch.php
+++ b/CRM/Contact/BAO/SavedSearch.php
@@ -360,7 +360,10 @@ LEFT JOIN civicrm_email ON (contact_a.id = civicrm_email.contact_id AND civicrm_
       if (empty($params['id'])) {
         $params['created_id'] = $loggedInContactID;
       }
-      $params['modified_id'] = $loggedInContactID;
+      // dev/core#2550: Prevent 5.x to 5.36+ upgrade failure
+      if (CRM_Core_BAO_SchemaHandler::checkIfFieldExists('civicrm_saved_search', 'modified_id')) {
+        $params['modified_id'] = $loggedInContactID;
+      }
     }
     // Set by mysql
     unset($params['modified_date']);


### PR DESCRIPTION
Overview
----------------------------------------
Upgrading civicrm from version < 5.36 version to 5.37+ fails with a DB Error


Before
----------------------------------------
Upgrade fail with a message
```
DB Error: no such fields
 Unknown column 'modified_id' in 'field list']"
```
After
----------------------------------------
Fixes the issue.

Technical Details
----------------------------------------
The civicrm_saved_search.modified_id is introduced first on 5.36 [here](https://github.com/civicrm/civicrm-core/pull/19709/files#diff-8b70eecd6309144f518b8fce88fcd53133fe1f0b0c127217e0d5817405ccc6f2R74). But then on. previous upgrade version there are upgrade codes that trigger the SavedSearch::Create fn via api3 call. And as a result, there is code that sets the modified_id to logged-in user by default. This code eventually trigger this DB fatal error for reason as modified_id doesn't exist. The upgrade task which leads to this fatal error is [here](https://github.com/civicrm/civicrm-core/blob/master/CRM/Upgrade/Incremental/php/FiveEighteen.php#L70). 

Comments
----------------------------------------
ping @eileenmcnaughton @colemanw @seamuslee001 