### PR TITLE
[Unreleased regression] SearchKit - Fix display of image fields

### DIFF
--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
@@ -463,7 +463,7 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
   private function formatImage($column, $data) {
     $tokenExpr = $column['rewrite'] ?: '[' . $column['key'] . ']';
     return [
-      'url' => $this->replaceTokens($tokenExpr, $data, 'url'),
+      'src' => $this->replaceTokens($tokenExpr, $data, 'url'),
       'height' => $column['image']['height'] ?? NULL,
       'width' => $column['image']['width'] ?? NULL,
     ];


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a regression in 5.44 where SearchKit failed to display image fields (e.g. contact image_url)

Before
----------------------------------------
Select image_url contact field as a search display column. Click the "image" checkbox to display it as an image.
Image fails to display.

After
----------------------------------------
Image displays.