### PR TITLE
SearchKit - tabbed display for custom vs packaged searches

### DIFF
--- a/CRM/Core/ManagedEntities.php
+++ b/CRM/Core/ManagedEntities.php
@@ -143,6 +143,7 @@ class CRM_Core_ManagedEntities {
     $mgd = new \CRM_Core_DAO_Managed();
     $mgd->copyValues($params);
     $mgd->find(TRUE);
+    $this->loadDeclarations();
     $declarations = CRM_Utils_Array::findAll($this->declarations, [
       'module' => $mgd->module,
       'name' => $mgd->name,

--- a/ext/search_kit/Civi/Api4/SearchDisplay.php
+++ b/ext/search_kit/Civi/Api4/SearchDisplay.php
@@ -11,7 +11,7 @@ namespace Civi\Api4;
  */
 class SearchDisplay extends Generic\DAOEntity {
 
-  use \Civi\Api4\Generic\Traits\ManagedEntity;
+  use Generic\Traits\ManagedEntity;
 
   /**
    * @param bool $checkPermissions

--- a/ext/search_kit/Civi/Search/Admin.php
+++ b/ext/search_kit/Civi/Search/Admin.php
@@ -42,6 +42,8 @@ class Admin {
       'defaultDisplay' => SearchDisplay::getDefault(FALSE)->setSavedSearch(['id' => NULL])->execute()->first(),
       'afformEnabled' => $extensions->isActiveModule('afform'),
       'afformAdminEnabled' => $extensions->isActiveModule('afform_admin'),
+      // TODO: Add v4 API for Extensions
+      'modules' => array_column(civicrm_api3('Extension', 'get', ['status' => "installed"])['values'], 'label', 'key'),
       'tags' => Tag::get()
         ->addSelect('id', 'name', 'color', 'is_selectable', 'description')
         ->addWhere('used_for', 'CONTAINS', 'civicrm_saved_search')

--- a/ext/search_kit/ang/crmSearchAdmin/searchListing/buttons.html
+++ b/ext/search_kit/ang/crmSearchAdmin/searchListing/buttons.html
@@ -7,6 +7,6 @@
 <a class="btn btn-xs btn-secondary" href="#/create/{{:: row.data.api_entity + '?params=' + $ctrl.encode(row.data.api_params) }}">
   {{:: ts('Clone') }}
 </a>
-<a href class="btn btn-xs btn-danger" ng-click="$ctrl.confirmDelete(row)">
-  {{:: ts('Delete') }}
+<a href class="btn btn-xs btn-{{ row.data['base_module:label'] ? 'warning' : 'danger' }}" ng-click="$ctrl.deleteOrRevert(row)">
+  {{ row.data['base_module:label'] ? ts('Revert') : ts('Delete') }}
 </a>

--- a/ext/search_kit/ang/crmSearchAdmin/searchListing/crmSearchAdminSearchListing.html
+++ b/ext/search_kit/ang/crmSearchAdmin/searchListing/crmSearchAdminSearchListing.html
@@ -1,8 +1,29 @@
 <div id="bootstrap-theme" class="crm-search">
   <h1 crm-page-title>{{:: ts('Saved Searches') }}</h1>
+
+  <!-- Tabs based on the has_base filter -->
+  <ul class="nav nav-tabs">
+    <li role="presentation" ng-class="{active: !$ctrl.filters.has_base}">
+      <a href ng-click="$ctrl.setHasBaseFilter(false)"><i class="crm-i fa-search-plus"></i>
+        {{:: ts('Custom Searches') }}
+        <span class="badge">{{ $ctrl.totals.no_base }}</span>
+      </a>
+    </li>
+    <li role="presentation" ng-class="{active: $ctrl.filters.has_base}">
+      <a href ng-click="$ctrl.setHasBaseFilter(true)"><i class="crm-i fa-gift"></i>
+        {{:: ts('Packaged Searches') }}
+        <span class="badge">{{ $ctrl.totals.has_base }}</span>
+      </a>
+    </li>
+  </ul>
+
+  <!-- Other filters -->
   <div class="form-inline">
     <input class="form-control" type="search" ng-model="$ctrl.filters.label" placeholder="{{:: ts('Filter by label...') }}">
-    <input class="form-control" type="search" ng-model="$ctrl.filters['created_id.display_name,modified_id.display_name']" placeholder="{{:: ts('Filter by author...') }}">
+    <input class="form-control" type="search" ng-show="!$ctrl.filters.has_base" ng-model="$ctrl.filters['created_id.display_name,modified_id.display_name']" placeholder="{{:: ts('Filter by author...') }}">
+    <span ng-if="$ctrl.filters.has_base">
+      <input class="form-control" ng-model="$ctrl.filters.base_module" ng-list crm-ui-select="{multiple: true, data: $ctrl.modules, placeholder: ts('Filter by package...')}">
+    </span>
     <input class="form-control collapsible-optgroups" ng-model="$ctrl.filters.api_entity" ng-list crm-ui-select="{multiple: true, data: $ctrl.entitySelect, placeholder: ts('Filter by entity...')}">
     <span ng-if="$ctrl.getTags().results.length">
       <input class="form-control" ng-model="$ctrl.filters.tags" ng-list crm-ui-select="{multiple: true, data: $ctrl.getTags, placeholder: ts('Filter by tags...')}">


### PR DESCRIPTION
Overview
----------------------------------------
Splits the SearchKit admin UI in to 2 tabs - one for custom (locally-created) searches, and one for packaged searches (defined in extensions). Adds a "revert" button for packaged searches.

![image](https://user-images.githubusercontent.com/2874912/140570849-e6620f66-cdc7-42ca-822a-88b27bf773f2.png)

Technical Details
----------------------------------------
The revert action builds upon the work done in #21955 

Comments
----------------------------------------
The "Last modified" column needs a bit more conditional formatting, but "logic and conditional formatting in display columns" is not yet implemented. Hopefully someday soon.