### PR TITLE
SearchKit - Add default text/image to displays; support custom file fields

### DIFF
--- a/ext/search_kit/CRM/Search/Upgrader.php
+++ b/ext/search_kit/CRM/Search/Upgrader.php
@@ -156,6 +156,32 @@ class CRM_Search_Upgrader extends CRM_Search_Upgrader_Base {
   }
 
   /**
+   * Upgrade 1006 - add image column type
+   * @return bool
+   */
+  public function upgrade_1006(): bool {
+    $this->ctx->log->info('Applying update 1006 - add image column type.');
+    $displays = \Civi\Api4\SearchDisplay::get(FALSE)
+      ->setSelect(['id', 'settings'])
+      ->execute();
+    foreach ($displays as $display) {
+      $update = FALSE;
+      foreach ($display['settings']['columns'] ?? [] as $c => $column) {
+        if (!empty($column['image'])) {
+          $display['settings']['columns'][$c]['type'] = 'image';
+          $update = TRUE;
+        }
+      }
+      if ($update) {
+        \Civi\Api4\SearchDisplay::update(FALSE)
+          ->setValues($display)
+          ->execute();
+      }
+    }
+    return TRUE;
+  }
+
+  /**
    * Add a column to a table if it doesn't already exist
    *
    * FIXME: Move to a shared class, delegate to CRM_Upgrade_Incremental_Base::addColumn

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminDisplay.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminDisplay.component.js
@@ -42,6 +42,7 @@
 
       this.preview = this.stale = false;
 
+      // Extra (non-field) colum types
       this.colTypes = {
         links: {
           label: ts('Links'),
@@ -126,10 +127,18 @@
       };
 
       this.getColLabel = function(col) {
-        if (col.type === 'field') {
+        if (col.type === 'field' || col.type === 'image') {
           return ctrl.getFieldLabel(col.key);
         }
         return ctrl.colTypes[col.type].label;
+      };
+
+      this.toggleEmptyVal = function(col) {
+        if (col.empty_value) {
+          delete col.empty_value;
+        } else {
+          col.empty_value = ts('None');
+        }
       };
 
       this.toggleRewrite = function(col) {
@@ -142,14 +151,22 @@
       };
 
       this.toggleImage = function(col) {
-        if (col.image) {
+        if (col.type === 'image') {
           delete col.image;
+          col.type = 'field';
         } else {
           col.image = {
             alt: this.getColLabel(col)
           };
           delete col.editable;
+          col.type = 'image';
         }
+      };
+
+      this.canBeImage = function(col) {
+        var expr = ctrl.getExprFromSelect(col.key),
+          info = searchMeta.parseExpr(expr);
+        return info.args[0] && info.args[0].field && info.args[0].field.input_type === 'File';
       };
 
       this.toggleEditable = function(col) {
@@ -163,7 +180,7 @@
       this.canBeEditable = function(col) {
         var expr = ctrl.getExprFromSelect(col.key),
           info = searchMeta.parseExpr(expr);
-        return !col.image && !col.rewrite && !col.link && !info.fn && info.args[0] && info.args[0].field && !info.args[0].field.readonly;
+        return !col.rewrite && !col.link && !info.fn && info.args[0] && info.args[0].field && !info.args[0].field.readonly;
       };
 
       // Checks if a column contains a sortable value

--- a/ext/search_kit/ang/crmSearchAdmin/displays/colType/image.html
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/colType/image.html
@@ -1,8 +1,17 @@
-<div class="form-inline" ng-if=":: $ctrl.parent.canBeImage(col)">
+<div class="form-inline">
   <label>
-    <input type="checkbox" ng-click="$ctrl.parent.toggleImage(col)" >
+    <input type="checkbox" checked="checked" ng-click="$ctrl.parent.toggleImage(col)" >
     {{:: ts('Image') }}
   </label>
+  <div class="crm-search-admin-flex-row">
+    <label>{{:: ts('Width') }}</label>
+    <input type="number" min="1" class="form-control crm-flex-1" placeholder="Auto" ng-model="col.image.width">
+    <label>{{:: ts('Height') }}</label>
+    <input type="number" min="1" class="form-control crm-flex-1" placeholder="Auto" ng-model="col.image.height">
+    <label>{{:: ts('Alt Text') }}</label>
+    <input type="text" class="form-control crm-flex-2" ng-model="col.image.alt">
+    <crm-search-admin-token-select api-entity="$ctrl.apiEntity" api-params="$ctrl.apiParams" model="col.image" field="alt"></crm-search-admin-token-select>
+  </div>
 </div>
 <div class="form-inline crm-search-admin-flex-row" ng-if=":: $ctrl.parent.canBeLink(col)">
   <label title="{{:: ts('Display as clickable link') }}" >
@@ -26,29 +35,19 @@
   <crm-search-admin-token-select ng-if="col.title" model="col" field="title" suffix=":label"></crm-search-admin-token-select>
 </div>
 <div class="form-inline crm-search-admin-flex-row">
-  <label title="{{:: ts('Text to display if the field contents are empty.') }}">
+  <label title="{{:: ts('Image to display if the field contents are empty.') }}">
     <input type="checkbox" ng-checked="col.empty_value" ng-click="$ctrl.parent.toggleEmptyVal(col)" >
-    {{:: ts('Empty placeholder') }}
+    {{:: ts('Alternate image') }}
   </label>
   <input type="text" class="form-control crm-flex-1" ng-if="col.empty_value" ng-model="col.empty_value" ng-model-options="{updateOn: 'blur'}">
   <crm-search-admin-token-select ng-if="col.empty_value" model="col" field="empty_value" suffix=":label"></crm-search-admin-token-select>
 </div>
 <div class="form-inline crm-search-admin-flex-row">
-  <label title="{{:: ts('Change the contents of this field, or combine multiple field values.') }}">
+  <label title="{{:: ts('Specify url path to this image.') }}">
     <input type="checkbox" ng-checked="col.rewrite" ng-click="$ctrl.parent.toggleRewrite(col)" >
-    {{:: ts('Rewrite') }}
+    {{:: ts('Custom image url') }}
   </label>
   <input type="text" class="form-control crm-flex-1" ng-if="col.rewrite" ng-model="col.rewrite" ng-model-options="{updateOn: 'blur'}">
   <crm-search-admin-token-select ng-if="col.rewrite" model="col" field="rewrite" suffix=":label"></crm-search-admin-token-select>
-</div>
-<div class="form-inline">
-  <label ng-if="$ctrl.parent.canBeEditable(col)" title="{{:: ts('Users will be able to click to edit this field.') }}">
-    <input type="checkbox" ng-checked="col.editable" ng-click="$ctrl.parent.toggleEditable(col)">
-    {{:: ts('In-Place Edit') }}
-  </label>
-  <label ng-if="!$ctrl.parent.canBeEditable(col)" class="disabled" title="{{:: ts('Read-only or rewritten fields cannot be editable.') }}">
-    <input type="checkbox" disabled>
-    {{:: ts('In-Place Edit') }}
-  </label>
 </div>
 <search-admin-css-rules label="{{:: ts('Style') }}" item="col" default="col.key"></search-admin-css-rules>

--- a/ext/search_kit/ang/crmSearchDisplay/colType/field.html
+++ b/ext/search_kit/ang/crmSearchDisplay/colType/field.html
@@ -1,17 +1,11 @@
 <crm-search-display-editable row="row" col="colData" on-success="$ctrl.runSearch(row)" cancel="$ctrl.editing = null;" ng-if="colData.edit && $ctrl.editing && $ctrl.editing[0] === rowIndex && $ctrl.editing[1] === colIndex"></crm-search-display-editable>
-<span ng-if="::!colData.links && !colData.img" ng-class="{'crm-editable-enabled': colData.edit && !$ctrl.editing}" ng-click="colData.edit && !$ctrl.editing && ($ctrl.editing = [rowIndex, colIndex])">
+<span ng-if="::!colData.links" ng-class="{'crm-editable-enabled': colData.edit && !$ctrl.editing}" ng-click="colData.edit && !$ctrl.editing && ($ctrl.editing = [rowIndex, colIndex])">
   {{:: $ctrl.formatFieldValue(colData) }}
 </span>
 <span ng-if="::colData.links">
   <span ng-repeat="link in colData.links">
     <a target="{{:: link.target }}" href="{{:: link.url }}">
-      <span ng-if=":: colData.img">
-        <img ng-src="{{:: colData.img.src }}" alt="{{:: colData.val }}" height="{{:: colData.img.height }}" width="{{:: colData.img.width }}"/>
-      </span>
       {{:: link.text }}</a><span ng-if="!$last">,
     </span>
   </span>
-</span>
-<span ng-if=":: !colData.links && colData.img">
-  <img ng-src="{{:: colData.img.src }}" alt="{{:: colData.val }}" height="{{:: colData.img.height }}" width="{{:: colData.img.width }}"/>
 </span>

--- a/ext/search_kit/ang/crmSearchDisplay/colType/image.html
+++ b/ext/search_kit/ang/crmSearchDisplay/colType/image.html
@@ -1,0 +1,10 @@
+<span ng-if="::colData.links && colData.img">
+  <span ng-repeat="link in colData.links">
+    <a target="{{:: link.target }}" href="{{:: link.url }}">
+      <img ng-src="{{:: colData.img.src }}" alt="{{:: colData.val }}" height="{{:: colData.img.height }}" width="{{:: colData.img.width }}"/>
+    </a>
+  </span>
+</span>
+<span ng-if=":: !colData.links && colData.img">
+  <img ng-src="{{:: colData.img.src }}" alt="{{:: colData.val }}" height="{{:: colData.img.height }}" width="{{:: colData.img.width }}"/>
+</span>

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunWithCustomFieldTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunWithCustomFieldTest.php
@@ -1,0 +1,106 @@
+<?php
+namespace api\v4\SearchDisplay;
+
+use Civi\Api4\Contact;
+use Civi\Api4\CustomField;
+use Civi\Api4\CustomGroup;
+use Civi\Api4\File;
+use Civi\Test\HeadlessInterface;
+
+/**
+ * @group headless
+ */
+class SearchRunWithCustomFieldTest extends \PHPUnit\Framework\TestCase implements HeadlessInterface {
+
+  public function setUpHeadless() {
+    return \Civi\Test::headless()
+      ->installMe(__DIR__)
+      ->apply();
+  }
+
+  /**
+   * Delete all created custom groups.
+   *
+   * @throws \API_Exception
+   */
+  public function tearDown(): void {
+    CustomGroup::delete(FALSE)->addWhere('id', '>', 0)->execute();
+    parent::tearDown();
+  }
+
+  /**
+   * Test running a searchDisplay with various filters.
+   */
+  public function testRunWithImageField() {
+    CustomGroup::create(FALSE)
+      ->addValue('name', 'TestSearchFields')
+      ->addValue('extends', 'Individual')
+      ->execute()
+      ->first();
+
+    CustomField::create(FALSE)
+      ->addValue('label', 'MyFile')
+      ->addValue('custom_group_id.name', 'TestSearchFields')
+      ->addValue('html_type', 'File')
+      ->addValue('data_type', 'File')
+      ->execute();
+
+    $lastName = uniqid(__FUNCTION__);
+
+    $file = File::create()
+      ->addValue('mime_type', 'image/png')
+      ->addValue('uri', "tmp/$lastName.png")
+      ->execute()->first();
+
+    $sampleData = [
+      ['first_name' => 'Zero', 'last_name' => $lastName, 'TestSearchFields.MyFile' => $file['id']],
+      ['first_name' => 'One', 'middle_name' => 'None', 'last_name' => $lastName],
+    ];
+    Contact::save(FALSE)->setRecords($sampleData)->execute();
+
+    $params = [
+      'checkPermissions' => FALSE,
+      'return' => 'page:1',
+      'savedSearch' => [
+        'api_entity' => 'Contact',
+        'api_params' => [
+          'version' => 4,
+          'select' => ['id', 'first_name', 'last_name', 'TestSearchFields.MyFile'],
+          'where' => [['last_name', '=', $lastName]],
+        ],
+      ],
+      'display' => [
+        'type' => 'table',
+        'label' => '',
+        'settings' => [
+          'limit' => 20,
+          'pager' => TRUE,
+          'columns' => [
+            [
+              'key' => 'id',
+              'label' => 'Contact ID',
+              'type' => 'field',
+            ],
+            [
+              'key' => 'TestSearchFields.MyFile',
+              'label' => 'Type',
+              'type' => 'image',
+              'empty_value' => 'http://example.com/image',
+            ],
+          ],
+          'sort' => [
+            ['id', 'ASC'],
+          ],
+        ],
+      ],
+    ];
+
+    $result = civicrm_api4('SearchDisplay', 'run', $params);
+    $this->assertStringContainsString('id=' . $file['id'], $result[0]['data']['TestSearchFields.MyFile']);
+    $this->assertStringContainsString('id=' . $file['id'], $result[0]['columns'][1]['img']['src']);
+    $this->assertEmpty($result[1]['data']['TestSearchFields.MyFile']);
+    // Placeholder image
+    $this->assertStringContainsString('example.com', $result[1]['columns'][1]['img']['src']);
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Allows for "placeholder" text in a search display when a column value is empty. Also works for image fields.
Image fields now support custom file fields to display images out-of-the-box.

Technical Details
----------------------------------------
This breaks out image into its own column type, and generates the url to access custom file fields.
A new 'empty_value' property allows for a placeholder text/image to display when a field is blank.
