### PR TITLE
Tidy up title attributes

### DIFF
--- a/templates/CRM/Activity/Form/Selector.tpl
+++ b/templates/CRM/Activity/Form/Selector.tpl
@@ -17,7 +17,7 @@
    <thead class="sticky">
      <tr>
        {if !$single and $context eq 'Search' }
-          <th scope="col" title="Select Rows">{$form.toggleSelect.html}</th>
+          <th scope="col" title="{ts}Select rows{/ts}">{$form.toggleSelect.html}</th>
        {/if}
        {foreach from=$columnHeaders item=header}
           <th scope="col">

--- a/templates/CRM/Activity/Selector/Activity.tpl
+++ b/templates/CRM/Activity/Selector/Activity.tpl
@@ -14,7 +14,7 @@
   <h3 class="crm-table-title">{ts}Activities{/ts}</h3>
   {/if}
 {if $rows}
-  <form title="activity_pager" action="{crmURL}" method="post">
+  <form action="{crmURL}" method="post">
   {include file="CRM/common/pager.tpl" location="top"}
 
   {strip}

--- a/templates/CRM/Campaign/Form/Selector.tpl
+++ b/templates/CRM/Campaign/Form/Selector.tpl
@@ -16,7 +16,7 @@
   <thead class="sticky">
   <tr>
     {if !$single and $context eq 'Search' }
-        <th scope="col" title="Select Rows">{$form.toggleSelect.html}</th>
+        <th scope="col" title="{ts}Select rows{/ts}">{$form.toggleSelect.html}</th>
     {/if}
     <th scope="col"></th>
     {foreach from=$columnHeaders item=header}

--- a/templates/CRM/Case/Form/Selector.tpl
+++ b/templates/CRM/Case/Form/Selector.tpl
@@ -13,7 +13,7 @@
   <tr class="columnheader">
 
   {if ! $single and $context eq 'Search' }
-    <th scope="col" title="Select Rows">{$form.toggleSelect.html}</th>
+    <th scope="col" title="{ts}Select rows{/ts}">{$form.toggleSelect.html}</th>
   {/if}
 
   <th></th>

--- a/templates/CRM/Contact/Form/Selector.tpl
+++ b/templates/CRM/Contact/Form/Selector.tpl
@@ -15,7 +15,7 @@
 <table summary="{ts}Search results listings.{/ts}" class="selector row-highlight">
   <thead class="sticky">
     <tr>
-      <th scope="col" title="Select All Rows">{$form.toggleSelect.html}</th>
+      <th scope="col" title="{ts}Select rows{/ts}">{$form.toggleSelect.html}</th>
       {if $context eq 'smog'}
           <th scope="col">
             {ts}Status{/ts}

--- a/templates/CRM/Contact/Page/Inline/Basic.tpl
+++ b/templates/CRM/Contact/Page/Inline/Basic.tpl
@@ -28,7 +28,7 @@
       <span class="crm-contact-contact_id">{$contactId}</span>
       {if !empty($userRecordUrl)}
         <span class="crm-contact-user_record_id">
-          &nbsp;/&nbsp;<a title="View user record" class="user-record-link"
+          &nbsp;/&nbsp;<a title="{ts}View user record{/ts}" class="user-record-link"
                           href="{$userRecordUrl}">{$userRecordId}</a>
         </span>
       {/if}

--- a/templates/CRM/Contribute/Form/Selector.tpl
+++ b/templates/CRM/Contribute/Form/Selector.tpl
@@ -15,7 +15,7 @@
     <thead class="sticky">
     <tr>
       {if !$single and $context eq 'Search' }
-        <th scope="col" title="Select Rows">{$form.toggleSelect.html}</th>
+        <th scope="col" title="{ts}Select rows{/ts}">{$form.toggleSelect.html}</th>
       {/if}
       {if !$single}
       <th scope="col"></th>

--- a/templates/CRM/Contribute/Page/DashBoard.tpl
+++ b/templates/CRM/Contribute/Page/DashBoard.tpl
@@ -13,24 +13,24 @@
 <tr class="columnheader-dark">
     <th scope="col">{ts}Period{/ts}</th>
     <th scope="col">{ts}Total Amount{/ts}</th>
-    <th scope="col" title="Contribution Count"><strong>#</strong></th><th></th></tr>
+    <th scope="col" title="{ts}Contribution Count{/ts}"><strong>#</strong></th><th></th></tr>
 <tr>
     <td><strong>{ts}Current Month-To-Date{/ts}</strong></td>
     <td class="label">{if NOT $monthToDate.Valid.amount}{ts}(n/a){/ts}{else}{$monthToDate.Valid.amount}{/if}</td>
     <td class="label">{$monthToDate.Valid.count}</td>
-    <td><a href="{$monthToDate.Valid.url}">{ts}view details{/ts}...</a></td>
+    <td><a href="{$monthToDate.Valid.url}">{ts}View details{/ts}...</a></td>
 </tr>
 <tr>
     <td><strong>{ts}Current Fiscal Year-To-Date{/ts}</strong></td>
     <td class="label">{if NOT $yearToDate.Valid.amount}{ts}(n/a){/ts}{else}{$yearToDate.Valid.amount}{/if}</td>
     <td class="label">{$yearToDate.Valid.count}</td>
-    <td><a href="{$yearToDate.Valid.url}">{ts}view details{/ts}...</a></td>
+    <td><a href="{$yearToDate.Valid.url}">{ts}View details{/ts}...</a></td>
 </tr>
 <tr>
     <td><strong>{ts}Cumulative{/ts}</strong><br />{ts}(since inception){/ts}</td>
     <td class="label">{if NOT $startToDate.Valid.amount}{ts}(n/a){/ts}{else}{$startToDate.Valid.amount}{/if}</td>
     <td class="label">{$startToDate.Valid.count}</td>
-    <td><a href="{$startToDate.Valid.url}">{ts}view details{/ts}...</a></td>
+    <td><a href="{$startToDate.Valid.url}">{ts}View details{/ts}...</a></td>
 </tr>
 </table>
 {elseif $buildChart}

--- a/templates/CRM/Custom/Form/Field.tpl
+++ b/templates/CRM/Custom/Form/Field.tpl
@@ -105,12 +105,12 @@
       </td>
     </tr>
     <tr class="crm-custom-field-form-block-default_value" id="hideDefault" {if $action eq 2 && ($form.data_type.value.0.0 < 4 && $form.data_type.value.1.0 NEQ 'Text')}class="hiddenElement"{/if}>
-      <td title="hideDefaultValTxt" class="label">{$form.default_value.label}</td>
-      <td title="hideDefaultValDef" class="html-adjust">{$form.default_value.html}</td>
+      <td class="label">{$form.default_value.label}</td>
+      <td class="html-adjust">{$form.default_value.html}</td>
     </tr>
     <tr class="crm-custom-field-form-block-description"  id="hideDesc" {if $action neq 4 && $action eq 2 && ($form.data_type.value.0.0 < 4 && $form.data_type.value.1.0 NEQ 'Text')}class="hiddenElement"{/if}>
-      <td title="hideDescTxt" class="label">&nbsp;</td>
-      <td title="hideDescDef" class="html-adjust"><span class="description">{ts}If you want to provide a default value for this field, enter it here. For date fields, format is YYYY-MM-DD.{/ts}</span></td>
+      <td class="label">&nbsp;</td>
+      <td class="html-adjust"><span class="description">{ts}If you want to provide a default value for this field, enter it here. For date fields, format is YYYY-MM-DD.{/ts}</span></td>
     </tr>
     <tr class="crm-custom-field-form-block-help_pre">
       <td class="label">{$form.help_pre.label} {if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_custom_field' field='help_pre' id=$id}{/if}</td>

--- a/templates/CRM/Event/Form/Selector.tpl
+++ b/templates/CRM/Event/Form/Selector.tpl
@@ -16,7 +16,7 @@
 <thead class="sticky">
     <tr>
     {if ! $single and $context eq 'Search' }
-      <th scope="col" title="Select Rows">{$form.toggleSelect.html}</th>
+      <th scope="col" title="{ts}Select rows{/ts}">{$form.toggleSelect.html}</th>
     {/if}
     {foreach from=$columnHeaders item=header}
         <th scope="col">

--- a/templates/CRM/Event/Page/ManageEvent.tpl
+++ b/templates/CRM/Event/Page/ManageEvent.tpl
@@ -94,14 +94,14 @@
                 <ul class="panel" id="panel_participants_{$row.id}">
                   {if $findParticipants.statusCounted}
                     <li>
-                      <a title="Counted" class="action-item crm-hover-button" href="{crmURL p='civicrm/event/search'
+                      <a class="action-item crm-hover-button" href="{crmURL p='civicrm/event/search'
                       q="reset=1&force=1&status=true&event=`$row.id`"}">{$findParticipants.statusCounted}
                       </a>
                     </li>
                   {/if}
                   {if $findParticipants.statusNotCounted}
                     <li>
-                      <a title="Not Counted" class="action-item crm-hover-button"
+                      <a class="action-item crm-hover-button"
                            href="{crmURL p='civicrm/event/search'
                            q="reset=1&force=1&status=false&event=`$row.id`"}">{$findParticipants.statusNotCounted}
                       </a>
@@ -109,7 +109,7 @@
                   {/if}
                   {if $row.participant_listing_id}
                     <li>
-                      <a title="Public Participant Listing" class="action-item crm-hover-button"
+                      <a class="action-item crm-hover-button"
                          href="{crmURL p='civicrm/event/participant' q="reset=1&id=`$row.id`"
                          fe='true'}">{ts}Public Participant Listing{/ts}
                       </a>

--- a/templates/CRM/Grant/Form/Selector.tpl
+++ b/templates/CRM/Grant/Form/Selector.tpl
@@ -16,7 +16,7 @@
   <thead class="sticky">
   <tr>
   {if ! $single and $context eq 'Search' }
-     <th scope="col" title="Select Rows">{$form.toggleSelect.html}</th>
+     <th scope="col" title="{ts}Select rows{/ts}">{$form.toggleSelect.html}</th>
   {/if}
   {foreach from=$columnHeaders item=header}
     <th scope="col">

--- a/templates/CRM/Mailing/Form/Count.tpl
+++ b/templates/CRM/Mailing/Form/Count.tpl
@@ -29,7 +29,7 @@
         </tbody>
       </table>
     </div>
-     <a href="#" id="button"title="Contacts selected in the Find Contacts page"> {ts}View Selected Contacts{/ts}</a>
+     <a href="#" id="button" title="{ts}Contacts selected in the Find Contacts page{/ts}"> {ts}View Selected Contacts{/ts}</a>
   </div>
 {literal}
 <script type="text/javascript">

--- a/templates/CRM/Mailing/Form/Selector.tpl
+++ b/templates/CRM/Mailing/Form/Selector.tpl
@@ -16,7 +16,7 @@
   <thead class="sticky">
   <tr>
     {if $context eq 'Search' }
-        <th scope="col" title="Select Rows">{$form.toggleSelect.html}</th>
+        <th scope="col" title="{ts}Select rows{/ts}">{$form.toggleSelect.html}</th>
     {/if}
     {foreach from=$columnHeaders item=header}
         <th scope="col">

--- a/templates/CRM/Member/Form/Selector.tpl
+++ b/templates/CRM/Member/Form/Selector.tpl
@@ -15,7 +15,7 @@
 <table class="selector row-highlight">
 <thead class="sticky">
 {if ! $single and $context eq 'Search' }
-  <th scope="col" title="Select Rows">{$form.toggleSelect.html}</th>
+  <th scope="col" title="{ts}Select rows{/ts}">{$form.toggleSelect.html}</th>
 {/if}
   {foreach from=$columnHeaders item=header}
     <th scope="col">

--- a/templates/CRM/Member/Page/DashBoard.tpl
+++ b/templates/CRM/Member/Page/DashBoard.tpl
@@ -46,21 +46,21 @@
             <td><strong>{$row.month.total.name}</strong></td>
           {if $preMonth}
             <td class="label crm-grid-cell">
-              {if $row.premonth.new.url}<a href="{$row.premonth.new.url}" title="view details">{$row.premonth.new.count}</a>
+              {if $row.premonth.new.url}<a href="{$row.premonth.new.url}" title="{ts}View details{/ts}">{$row.premonth.new.count}</a>
               {else}{$row.premonth.new.count}{/if}
             </td>
             <td class="label crm-grid-cell">
-              {if $row.premonth.renew.url}<a href="{$row.premonth.renew.url}" title="view details">{$row.premonth.renew.count}</a>
+              {if $row.premonth.renew.url}<a href="{$row.premonth.renew.url}" title="{ts}View details{/ts}">{$row.premonth.renew.count}</a>
               {else}{$row.premonth.renew.count}{/if}
             </td>
             <td class="label crm-grid-cell">
               {if $row.premonth.total.url}
-                <a href="{$row.premonth.total.url}" title="view details">{$row.premonth.total.count}</a>
+                <a href="{$row.premonth.total.url}" title="{ts}View details{/ts}">{$row.premonth.total.count}</a>
               {else}
                 {$row.premonth.total.count}
               {/if}&nbsp;[
               {if $row.premonth_owner.premonth_owner.url}
-                <a href="{$row.premonth_owner.premonth_owner.url}" title="view details">{$row.premonth_owner.premonth_owner.count}</a>
+                <a href="{$row.premonth_owner.premonth_owner.url}" title="{ts}View details{/ts}">{$row.premonth_owner.premonth_owner.count}</a>
               {else}
                 {$row.premonth_owner.premonth_owner.count}
               {/if}]
@@ -68,42 +68,42 @@
           {/if}
 
             <td class="label crm-grid-cell">
-              {if $row.month.new.url}<a href="{$row.month.new.url}" title="view details">{$row.month.new.count}</a>
+              {if $row.month.new.url}<a href="{$row.month.new.url}" title="{ts}View details{/ts}">{$row.month.new.count}</a>
               {else}{$row.month.new.count}{/if}
             </td>
             <td class="label crm-grid-cell">
-              {if $row.month.renew.url}<a href="{$row.month.renew.url}" title="view details">{$row.month.renew.count}</a>
+              {if $row.month.renew.url}<a href="{$row.month.renew.url}" title="{ts}View details{/ts}">{$row.month.renew.count}</a>
               {else}{$row.month.renew.count}{/if}
             </td>
             <td class="label crm-grid-cell">
               {if $row.month.total.url}
-                <a href="{$row.month.total.url}" title="view details">{$row.month.total.count}</a>
+                <a href="{$row.month.total.url}" title="{ts}View details{/ts}">{$row.month.total.count}</a>
               {else}
                 {$row.month.total.count}
               {/if}&nbsp;[
               {if $row.month_owner.month_owner.url}
-                <a href="{$row.month_owner.month_owner.url}" title="view details">{$row.month_owner.month_owner.count}</a>
+                <a href="{$row.month_owner.month_owner.url}" title="{ts}View details{/ts}">{$row.month_owner.month_owner.count}</a>
               {else}
                 {$row.month_owner.month_owner.count}
               {/if}]
             </td>
 
             <td class="label crm-grid-cell">
-              {if $row.year.new.url}<a href="{$row.year.new.url}" title="view details">{$row.year.new.count}</a>
+              {if $row.year.new.url}<a href="{$row.year.new.url}" title="{ts}View details{/ts}">{$row.year.new.count}</a>
               {else}{$row.year.new.count}{/if}
             </td>
             <td class="label crm-grid-cell">
-              {if $row.year.renew.url}<a href="{$row.year.renew.url}" title="view details">{$row.year.renew.count}</a>
+              {if $row.year.renew.url}<a href="{$row.year.renew.url}" title="{ts}View details{/ts}">{$row.year.renew.count}</a>
               {else}{$row.year.renew.count}{/if}
             </td>
             <td class="label crm-grid-cell">
               {if $row.year.total.url}
-                <a href="{$row.year.total.url}" title="view details">{$row.year.total.count}</a>
+                <a href="{$row.year.total.url}" title="{ts}View details{/ts}">{$row.year.total.count}</a>
               {else}
                 {$row.year.total.count}
               {/if}&nbsp;[
               {if $row.year_owner.year_owner.url}
-                <a href="{$row.year_owner.year_owner.url}" title="view details">{$row.year_owner.year_owner.count}</a>
+                <a href="{$row.year_owner.year_owner.url}" title="{ts}View details{/ts}">{$row.year_owner.year_owner.count}</a>
               {else}
                 {$row.year_owner.year_owner.count}
               {/if}]
@@ -112,23 +112,23 @@
             <td class="label crm-grid-cell">
               {if $isCurrent}
                 {if $row.current.total.url}
-                  <a href="{$row.current.total.url}" title="view details">{$row.current.total.count}</a>
+                  <a href="{$row.current.total.url}" title="{ts}View details{/ts}">{$row.current.total.count}</a>
                 {else}
                   {$row.current.total.count}
                 {/if}&nbsp;[
                 {if $row.current_owner.current_owner.url}
-                  <a href="{$row.current_owner.current_owner.url}" title="view details">{$row.current_owner.current_owner.count}</a>
+                  <a href="{$row.current_owner.current_owner.url}" title="{ts}View details{/ts}">{$row.current_owner.current_owner.count}</a>
                 {else}
                   {$row.current_owner.current_owner.count}
                 {/if} ]
               {else}
                 {if $row.total.total.url}
-                  <a href="{$row.total.total.url}" title="view details">{$row.total.total.count}</a>
+                  <a href="{$row.total.total.url}" title="{ts}View details{/ts}">{$row.total.total.count}</a>
                 {else}
                   {$row.total.total.count}
                 {/if}&nbsp;[
                 {if $row.total_owner.total_owner.url}
-                  <a href="{$row.total_owner.total_owner.url}" title="view details">{$row.total_owner.total_owner.count}</a>
+                  <a href="{$row.total_owner.total_owner.url}" title="{ts}View details{/ts}">{$row.total_owner.total_owner.count}</a>
                 {else}
                   {$row.total_owner.total_owner.count}
                 {/if} ]
@@ -141,21 +141,21 @@
         <td><strong>{ts}Totals (all types){/ts}</strong></td>
         {if $preMonth}
             <td class="label crm-grid-cell">
-              {if $totalCount.premonth.new.url}<a href="{$totalCount.premonth.new.url}" title="view details">{$totalCount.premonth.new.count}</a>
+              {if $totalCount.premonth.new.url}<a href="{$totalCount.premonth.new.url}" title="{ts}View details{/ts}">{$totalCount.premonth.new.count}</a>
               {else}{$totalCount.premonth.new.count}{/if}
             </td>
             <td class="label crm-grid-cell">
-              {if $totalCount.premonth.renew.url}<a href="{$totalCount.premonth.renew.url}" title="view details">{$totalCount.premonth.renew.count}</a>
+              {if $totalCount.premonth.renew.url}<a href="{$totalCount.premonth.renew.url}" title="{ts}View details{/ts}">{$totalCount.premonth.renew.count}</a>
               {else}{$totalCount.premonth.renew.count}{/if}
             </td>
             <td class="label crm-grid-cell">
               {if $totalCount.premonth.total.url}
-                <a href="{$totalCount.premonth.total.url}" title="view details">{$totalCount.premonth.total.count}</a>
+                <a href="{$totalCount.premonth.total.url}" title="{ts}View details{/ts}">{$totalCount.premonth.total.count}</a>
               {else}
                 {$totalCount.premonth.total.count}
               {/if}&nbsp;[
               {if $totalCount.premonth_owner.premonth_owner.url}
-                <a href="{$totalCount.premonth_owner.premonth_owner.url}" title="view details">{$totalCount.premonth_owner.premonth_owner.count}</a>
+                <a href="{$totalCount.premonth_owner.premonth_owner.url}" title="{ts}View details{/ts}">{$totalCount.premonth_owner.premonth_owner.count}</a>
               {else}
                 {$totalCount.premonth_owner.premonth_owner.count}
               {/if}]
@@ -163,42 +163,42 @@
         {/if}
 
             <td class="label crm-grid-cell">
-              {if $totalCount.month.new.url}<a href="{$totalCount.month.new.url}" title="view details">{$totalCount.month.new.count}</a>
+              {if $totalCount.month.new.url}<a href="{$totalCount.month.new.url}" title="{ts}View details{/ts}">{$totalCount.month.new.count}</a>
               {else}{$totalCount.month.new.count}{/if}
             </td>
             <td class="label crm-grid-cell">
-              {if $totalCount.month.renew.url}<a href="{$totalCount.month.renew.url}" title="view details">{$totalCount.month.renew.count}</a>
+              {if $totalCount.month.renew.url}<a href="{$totalCount.month.renew.url}" title="{ts}View details{/ts}">{$totalCount.month.renew.count}</a>
               {else}{$totalCount.month.renew.count}{/if}
             </td>
             <td class="label crm-grid-cell">
               {if $totalCount.month.total.url}
-                <a href="{$totalCount.month.total.url}" title="view details">{$totalCount.month.total.count}</a>
+                <a href="{$totalCount.month.total.url}" title="{ts}View details{/ts}">{$totalCount.month.total.count}</a>
               {else}
                 {$totalCount.month.total.count}
               {/if}&nbsp;[
               {if $totalCount.month_owner.month_owner.url}
-                <a href="{$totalCount.month_owner.month_owner.url}" title="view details">{$totalCount.month_owner.month_owner.count}</a>
+                <a href="{$totalCount.month_owner.month_owner.url}" title="{ts}View details{/ts}">{$totalCount.month_owner.month_owner.count}</a>
               {else}
                 {$totalCount.month_owner.month_owner.count}
               {/if}]
             </td>
 
             <td class="label crm-grid-cell">
-              {if $totalCount.year.new.url}<a href="{$totalCount.year.new.url}" title="view details">{$totalCount.year.new.count}</a>
+              {if $totalCount.year.new.url}<a href="{$totalCount.year.new.url}" title="{ts}View details{/ts}">{$totalCount.year.new.count}</a>
               {else}{$totalCount.year.new.count}{/if}
             </td>
             <td class="label crm-grid-cell">
-              {if $totalCount.year.renew.url}<a href="{$totalCount.year.renew.url}" title="view details">{$totalCount.year.renew.count}</a>
+              {if $totalCount.year.renew.url}<a href="{$totalCount.year.renew.url}" title="{ts}View details{/ts}">{$totalCount.year.renew.count}</a>
               {else}{$totalCount.year.renew.count}{/if}
             </td>
             <td class="label crm-grid-cell">
               {if $totalCount.year.total.url}
-                <a href="{$totalCount.year.total.url}" title="view details">{$totalCount.year.total.count}</a>
+                <a href="{$totalCount.year.total.url}" title="{ts}View details{/ts}">{$totalCount.year.total.count}</a>
               {else}
                 {$totalCount.year.total.count}
               {/if}&nbsp;[
               {if $totalCount.year_owner.year_owner.url}
-                <a href="{$totalCount.year_owner.year_owner.url}" title="view details">{$totalCount.year_owner.year_owner.count}</a>
+                <a href="{$totalCount.year_owner.year_owner.url}" title="{ts}View details{/ts}">{$totalCount.year_owner.year_owner.count}</a>
               {else}
                 {$totalCount.year_owner.year_owner.count}
               {/if}]
@@ -207,23 +207,23 @@
             <td class="label crm-grid-cell">
               {if $isCurrent}
                 {if $row.total.total.url}
-                  <a href="{$row.total.total.url}" title="view details">{$totalCount.current.total.count}</a>
+                  <a href="{$row.total.total.url}" title="{ts}View details{/ts}">{$totalCount.current.total.count}</a>
                 {else}
                   {$totalCount.current.total.count}
                 {/if}&nbsp;[
                 {if $row.total_owner.total_owner.url}
-                  <a href="{$row.total_owner.total_owner.url}" title="view details">{$totalCount.current_owner.current_owner.count}</a>
+                  <a href="{$row.total_owner.total_owner.url}" title="{ts}View details{/ts}">{$totalCount.current_owner.current_owner.count}</a>
                 {else}
                   {$totalCount.current_owner.current_owner.count}
                 {/if} ]
               {else}
                 {if $totalCount.total.url}
-                  <a href="{$totalCount.total.url}" title="view details">{$totalCount.total.total.count}</a>
+                  <a href="{$totalCount.total.url}" title="{ts}View details{/ts}">{$totalCount.total.total.count}</a>
                 {else}
                   {$totalCount.total.total.count}
                 {/if}&nbsp;[
                 {if $totalCount.total_owner.total_owner.url}
-                  <a href="{$totalCount.total_owner.total_owner.url}" title="view details">{$totalCount.total_owner.total_owner.count}</a>
+                  <a href="{$totalCount.total_owner.total_owner.url}" title="{ts}View details{/ts}">{$totalCount.total_owner.total_owner.count}</a>
                 {else}
                   {$totalCount.total_owner.total_owner.count}
                 {/if} ]

--- a/templates/CRM/PCP/Page/PCPInfo.tpl
+++ b/templates/CRM/PCP/Page/PCPInfo.tpl
@@ -77,7 +77,7 @@
               </marquee>
           </div>
           <div class="description">
-              [<a href="#" onclick="roll_start_stop(); return false;" id="roll" title="Stop scrolling">{ts}Stop{/ts}</a>]
+              [<a href="#" onclick="roll_start_stop(); return false;" id="roll" title="{ts}Stop scrolling{/ts}">{ts}Stop{/ts}</a>]
           </div>
         </div>
      {/if}

--- a/templates/CRM/Pledge/Form/Selector.tpl
+++ b/templates/CRM/Pledge/Form/Selector.tpl
@@ -16,7 +16,7 @@
 <table class="selector row-highlight">
     <thead class="sticky">
         {if ! $single and $context eq 'Search' }
-            <th scope="col" title="Select Rows">{$form.toggleSelect.html}</th>
+            <th scope="col" title="{ts}Select rows{/ts}">{$form.toggleSelect.html}</th>
         {/if}
             <th></th>
         {foreach from=$columnHeaders item=header}


### PR DESCRIPTION
Overview
----------------------------------------
Tidy up title attributes:
Wrap text in {ts} as appropriate (for translation)
Remove poorly worded or superflous title attributes

Before
----------------------------------------
Hardcoded title attributes, some of which were very pooly worded.

After
----------------------------------------
All title attributes can be translated.

Title attributes removed from `templates/CRM/Activity/Selector/Activity.tpl` and `templates/CRM/Custom/Form/Field.tpl` as they were poorly worded and didn't provide value.

Title attributes from `templates/CRM/Event/Page/ManageEvent.tpl` as they didn't provide additional context from the visible text shown, and so to avoid unnecessary translation effort.

