### PR TITLE
Guard against passing empty values to CRM_Core_DAO::getFieldValue()

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -1096,11 +1096,17 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
       case 'Radio':
       case 'CheckBox':
         if ($field['data_type'] == 'ContactReference' && (is_array($value) || is_numeric($value))) {
-          $displayNames = [];
-          foreach ((array) $value as $contactId) {
-            $displayNames[] = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Contact', $contactId, 'display_name');
+          // Issue #2939 - guard against passing empty values to CRM_Core_DAO::getFieldValue(), which would throw an exception
+          if (empty($value)) {
+            $display = '';
           }
-          $display = implode(', ', $displayNames);
+          else {
+            $displayNames = [];
+            foreach ((array) $value as $contactId) {
+              $displayNames[] = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Contact', $contactId, 'display_name');
+            }
+            $display = implode(', ', $displayNames);
+          }
         }
         elseif ($field['data_type'] == 'ContactReference') {
           $display = $value;


### PR DESCRIPTION
Overview
----------------------------------------
This PR fixes a minor regression introduced in https://github.com/civicrm/civicrm-core/pull/18941 whereby empty values could be passed to CRM_Core_DAO::getFieldValue() which would throw an exception.

This change removes a potential "getFieldValue failed" error that can be thrown if an empty scalar value occurs in a multiple-contact reference custom field.

See https://lab.civicrm.org/dev/core/-/issues/2939

Replaces https://github.com/eileenmcnaughton/civicrm-core/pull/13 which was opened against the wrong repo.

Before
----------------------------------------
When submitting a record that includes a custom field of multiple contact reference type, if that field is empty (i.e. no contacts), an error message "getFieldValue failed" sometimes occurs and the screen freezes and needs to be reloaded. This would be due to the specific data present in the field (zero vs null vs empty array etc).

After
----------------------------------------
Defensive coding prevents empty values being passed to CRM_Core_DAO::getFieldValue(), so no exception occurs and record update proceeds as expected without any error.

Comments
----------------------------------------
Demonstrated working on live CiviCRM installation 5.37.0.
