### PR TITLE
Extract getGroupOrganizationUrl & ensure always assigned

### DIFF
--- a/templates/CRM/Contact/Page/View/Summary.tpl
+++ b/templates/CRM/Contact/Page/View/Summary.tpl
@@ -93,7 +93,7 @@
           {/if}
         {/if}
 
-        {if !empty($groupOrganizationUrl)}
+        {if $groupOrganizationUrl}
           <li class="crm-contact-associated-groups">
             {crmButton href=$groupOrganizationUrl class="associated-groups" icon="cubes"}
               {ts}Associated Multi-Org Group{/ts}


### PR DESCRIPTION
Overview
----------------------------------------
Extract getGroupOrganizationUrl & ensure always assigned

Before
----------------------------------------
GroupOrganizationUrl may not be assigned, meaning the template has to do a possibly e-noticey empty check

After
----------------------------------------
Always assigned, extracted to function

Technical Details
----------------------------------------

Comments
----------------------------------------
