### PR TITLE
(dev/core#2944) Make report column groups hookable

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -1321,6 +1321,7 @@ class CRM_Report_Form extends CRM_Core_Form {
       $this->assign('tabs', $this->tabs);
     }
 
+    CRM_Utils_Hook::alterReportVar('colGroups', $colGroups, $this);
     $this->assign('colGroups', $colGroups);
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Provide a way to manipulate column groups in report to change the order of the column checkboxes in the Columns tab

Before
----------------------------------------
No way to manipulate column groups.

After
----------------------------------------
Column groups in report are now exposed

Technical Details
-------------------------
Ideally, there should be some weight mechanism to alter the display of the columns.
