### PR TITLE
Add Colombia missing state

### DIFF
--- a/CRM/Upgrade/Incremental/sql/5.45.alpha1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.45.alpha1.mysql.tpl
@@ -6,3 +6,8 @@ UPDATE civicrm_state_province SET name = 'Davao del Norte' WHERE country_id = @P
 UPDATE civicrm_state_province SET name = 'Davao de Oro' WHERE country_id = @PHILIPPINESID AND abbreviation = "COM" AND name = "Compostela Valley";
 UPDATE civicrm_state_province SET name = 'Kalinga' WHERE country_id = @PHILIPPINESID AND abbreviation = "KAL" AND name = "Kalinga-Apayso";
 UPDATE civicrm_state_province SET name = 'Cotabato' WHERE country_id = @PHILIPPINESID AND abbreviation = "NCO" AND name = "North Cotabato";
+
+-- Add missing state for Colombia
+SELECT @country_id := id from civicrm_country where name = 'Colombia' AND iso_code = 'CO';
+INSERT IGNORE INTO `civicrm_state_province` (`id`, `country_id`, `abbreviation`, `name`) VALUES
+(NULL, @country_id, 'HUI', 'Huila');

--- a/sql/civicrm_generated.mysql
+++ b/sql/civicrm_generated.mysql
@@ -11914,7 +11914,8 @@ INSERT INTO `civicrm_state_province` (`id`, `name`, `abbreviation`, `country_id`
  (10391,'Torfaen','TOF',1226,1),
  (10392,'Wrexham','WRX',1226,1),
  (10393,'Sejong','50',1115,1),
- (10394,'Dinagat Islands','DIN',1170,1);
+ (10394,'Dinagat Islands','DIN',1170,1),
+ (10395,'Huila','HUI',1048,1);
 /*!40000 ALTER TABLE `civicrm_state_province` ENABLE KEYS */;
 UNLOCK TABLES;
 

--- a/xml/templates/civicrm_state_province.tpl
+++ b/xml/templates/civicrm_state_province.tpl
@@ -4144,4 +4144,7 @@ INSERT INTO civicrm_state_province (id, country_id, abbreviation, name) VALUES
 (NULL, 1115, "50", "Sejong"),
 
 -- Add missing province for Philippines
-(NULL, 1170, "DIN", "Dinagat Islands");
+(NULL, 1170, "DIN", "Dinagat Islands"),
+
+-- Add missing state for Colombia
+(NULL, 1048, "HUI", "Huila");


### PR DESCRIPTION
There is a missing state for Colombia added according to: https://www.iso.org/obp/ui/#iso:code:3166:CO