### PR TITLE
Fix unencoded mailing url query param in Mailing report

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -2061,7 +2061,7 @@ ORDER BY   civicrm_email.is_bulkmail DESC
         'clicks' => $mailing->clicks,
         'unique' => $mailing->unique_clicks,
         'rate' => !empty($report['event_totals']['delivered']) ? (100.0 * $mailing->unique_clicks) / $report['event_totals']['delivered'] : 0,
-        'report' => CRM_Report_Utils_Report::getNextUrl('mailing/clicks', "reset=1&mailing_id_value={$mailing_id}&url_value={$mailing->url}", FALSE, TRUE),
+        'report' => CRM_Report_Utils_Report::getNextUrl('mailing/clicks', "reset=1&mailing_id_value={$mailing_id}&url_value=" . rawurlencode($mailing->url), FALSE, TRUE),
       ];
     }
 


### PR DESCRIPTION
Overview
----------------------------------------

The mailing report generated invalid URLs which broke the report that lists all clicks on a certain tracked link.

Before
----------------------------------------

The report constructed URLs containing clicked URLs without encoding them, breaking the original URL.


After
----------------------------------------

Encoding is applied. The report links work.



Comments
----------------------------------------

Found links where the clicked URL contained a fragment identifier `#` completely broke the URL generated.
