### PR TITLE
don't overfill the prevnext cache when reserving for a survey.

### DIFF
--- a/CRM/Campaign/Selector/Search.php
+++ b/CRM/Campaign/Selector/Search.php
@@ -267,7 +267,7 @@ class CRM_Campaign_Selector_Search extends CRM_Core_Selector_Base implements CRM
 
       $selectSQL = "
       SELECT %1, contact_a.id, contact_a.display_name
-{$sql['from']}
+{$sql['from']} {$sql['where']}
 ";
 
       try {


### PR DESCRIPTION
Overview
----------------------------------------
When reserving respondents for a survey, the `civicrm_prevnext_cache` table gets filled with all the contacts in the database rather then just the contacts returned by the search.  This is barely noticeable on a small site or a site backed by a fast database. But on a big site or a slow database site it casuses a lot of churn and slowness.

Before
----------------------------------------
1. Create a Survey
2. Create a regular group with one person in it.
3. Check that the `civicrm_prevnext_cache` table is empty (or empty it)
4. Click to reserve respondents. Select your survey and group and click Search
5. Check the contents of the `civicrm_prevnext_cache` and you see the same number as total contacts in the `civicrm_contact` table instead of just one contact.

After
----------------------------------------

You should only see one record in the `civicrm_nextprev_cache` table.

Technical Details
----------------------------------------
I think this has been broken for a long time and it makes me wonder if the `nextprev_cache` is even used in this context.

