### PR TITLE
[WIP] dev/core#2945 - Use civi::statics for smarty singleton

### DIFF
--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -319,7 +319,9 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
     $this->registerRules();
 
     // let the constructor initialize this, should happen only once
-    if (!isset(self::$_template)) {
+    if (!isset(\Civi::$statics[__CLASS__][__FUNCTION__])) {
+      \Civi::$statics[__CLASS__][__FUNCTION__] = CRM_Core_Smarty::singleton();
+      // We still need this since it's referenced a fair amount and in subclasses.
       self::$_template = CRM_Core_Smarty::singleton();
     }
     // Smarty $_template is a static var which persists between tests, so

--- a/CRM/Core/Page.php
+++ b/CRM/Core/Page.php
@@ -139,7 +139,9 @@ class CRM_Core_Page {
     $this->_mode = $mode;
 
     // let the constructor initialize this, should happen only once
-    if (!isset(self::$_template)) {
+    if (!isset(\Civi::$statics[__CLASS__][__FUNCTION__])) {
+      \Civi::$statics[__CLASS__][__FUNCTION__] = CRM_Core_Smarty::singleton();
+      // We still need this since it's referenced a fair amount and in subclasses.
       self::$_template = CRM_Core_Smarty::singleton();
       self::$_session = CRM_Core_Session::singleton();
     }

--- a/CRM/Core/Smarty.php
+++ b/CRM/Core/Smarty.php
@@ -47,14 +47,6 @@ class CRM_Core_Smarty extends Smarty {
     PRINT_JSON = 'json';
 
   /**
-   * We only need one instance of this object. So we use the singleton
-   * pattern and cache the instance in this variable
-   *
-   * @var object
-   */
-  static private $_singleton = NULL;
-
-  /**
    * Backup frames.
    *
    * A list of variables ot save temporarily in format (string $name => mixed $value).
@@ -162,13 +154,13 @@ class CRM_Core_Smarty extends Smarty {
    * @return \CRM_Core_Smarty
    */
   public static function &singleton() {
-    if (!isset(self::$_singleton)) {
-      self::$_singleton = new CRM_Core_Smarty();
-      self::$_singleton->initialize();
+    if (!isset(\Civi::$statics[__CLASS__][__FUNCTION__])) {
+      \Civi::$statics[__CLASS__][__FUNCTION__] = new CRM_Core_Smarty();
+      \Civi::$statics[__CLASS__][__FUNCTION__]->initialize();
 
       self::registerStringResource();
     }
-    return self::$_singleton;
+    return \Civi::$statics[__CLASS__][__FUNCTION__];
   }
 
   /**

--- a/tests/phpunit/CRM/Activity/Form/ActivityTest.php
+++ b/tests/phpunit/CRM/Activity/Form/ActivityTest.php
@@ -362,6 +362,7 @@ ENDBODY;
     $form->set('atype', $activity['values'][$activity_id]['activity_type_id']);
 
     $form->buildForm();
+    $form->assign('formTpl', NULL);
 
     // Wish there was another way to do this
     $form->controller->handle($form, 'display');

--- a/tests/phpunit/CRM/Case/Form/CustomDataTest.php
+++ b/tests/phpunit/CRM/Case/Form/CustomDataTest.php
@@ -362,6 +362,7 @@ class CRM_Case_Form_CustomDataTest extends CiviCaseTestCase {
     // this is case type
     $form->set('subType', 1);
     $form->set('cid', $individual);
+    $form->assign('formTpl', NULL);
     ob_start();
     $form->controller->_actions['display']->perform($form, 'display');
     ob_end_clean();

--- a/tests/phpunit/CRM/Case/Form/SearchTest.php
+++ b/tests/phpunit/CRM/Case/Form/SearchTest.php
@@ -25,6 +25,7 @@ class CRM_Case_Form_SearchTest extends CiviCaseTestCase {
   public function testOpeningFindCaseForm() {
     $form = new CRM_Case_Form_Search();
     $form->controller = new CRM_Case_Controller_Search('Find Cases');
+    $form->assign('formTpl', NULL);
 
     ob_start();
     $form->controller->_actions['display']->perform($form, 'display');

--- a/tests/phpunit/CRM/Case/Form/TaskTest.php
+++ b/tests/phpunit/CRM/Case/Form/TaskTest.php
@@ -155,6 +155,7 @@ class CRM_Case_Form_TaskTest extends CiviCaseTestCase {
 
     $form = new CRM_Case_Form_ActivityToCase();
     $form->controller = new CRM_Core_Controller_Simple('CRM_Case_Form_ActivityToCase', 'Case Thing');
+    $form->assign('formTpl', NULL);
     $_REQUEST['activityId'] = $activity['id'];
     $_REQUEST['fileOnCaseAction'] = $input['variation_type'];
 

--- a/tests/phpunit/CRM/Contact/Form/IndividualTest.php
+++ b/tests/phpunit/CRM/Contact/Form/IndividualTest.php
@@ -21,6 +21,7 @@ class CRM_Contact_Form_IndividualTest extends CiviUnitTestCase {
 
     $form->set('reset', '1');
     $form->set('ct', 'Individual');
+    $form->assign('formTpl', NULL);
 
     ob_start();
     $form->controller->_actions['display']->perform($form, 'display');
@@ -58,6 +59,7 @@ class CRM_Contact_Form_IndividualTest extends CiviUnitTestCase {
     ]);
     $form = new CRM_Contact_Form_Contact();
     $form->controller = new CRM_Core_Controller_Simple('CRM_Contact_Form_Contact', 'New Individual');
+    $form->assign('formTpl', NULL);
 
     $form->set('reset', '1');
     $form->set('ct', 'Individual');

--- a/tests/phpunit/CRM/Contact/Page/View/UserDashBoardTest.php
+++ b/tests/phpunit/CRM/Contact/Page/View/UserDashBoardTest.php
@@ -50,7 +50,6 @@ class CRM_Contact_Page_View_UserDashBoardTest extends CiviUnitTestCase {
     $this->quickCleanup(['civicrm_uf_match']);
     CRM_Utils_Hook::singleton()->reset();
     CRM_Core_Session::singleton()->reset();
-    CRM_Core_Smarty::singleton()->clearTemplateVars();
     $this->callAPISuccess('Contact', 'delete', ['id' => $this->contactID]);
     parent::tearDown();
   }

--- a/tests/phpunit/CRM/Contribute/Form/AdditionalPaymentTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/AdditionalPaymentTest.php
@@ -222,7 +222,6 @@ class CRM_Contribute_Form_AdditionalPaymentTest extends CiviUnitTestCase {
     // from previous tests causing a fail.
     // The reason this is hard to fix is that we save a billing address per contribution not
     // per payment so it's a problem with the data model
-    CRM_Core_Smarty::singleton()->clearTemplateVars();
 
     // pay additional amount
     $this->submitPayment(50, NULL, TRUE);

--- a/tests/phpunit/CRM/Core/SessionTest.php
+++ b/tests/phpunit/CRM/Core/SessionTest.php
@@ -8,7 +8,6 @@ class CRM_Core_SessionTest extends CiviUnitTestCase {
 
   public function setUp(): void {
     parent::setUp();
-    CRM_Core_Smarty::singleton()->clearTemplateVars();
     // set null defaults
     foreach (['infoOptions', 'infoType', 'infoMessage', 'infoTitle'] as $info) {
       CRM_Core_Smarty::singleton()->assign($info, NULL);


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/2945

Let's see if this breaks anything.

During unit tests, static vars can be problematic because they don't get reset between tests. There's a point within smarty where if a test fails at that point then its secure mode doesn't get reset. It's come up a couple times and then all the tests that use smarty on certain forms fail after it. It's not easy to track down if you haven't seen it before.

Before
----------------------------------------
All similar tests after a certain one fails fail.

After
----------------------------------------
I dunno yet.

Technical Details
----------------------------------------
Static vars

Comments
----------------------------------------
@totten @seamuslee001 @eileenmcnaughton 
