### PR TITLE
dev/report#77 - Unused variable in contribute/history civireport

### DIFF
--- a/CRM/Report/Form/Contribute/History.php
+++ b/CRM/Report/Form/Contribute/History.php
@@ -839,12 +839,10 @@ class CRM_Report_Form_Contribute_History extends CRM_Report_Form {
 
       if (!empty($row['civicrm_financial_trxn_card_type_id'])) {
         $rows[$rowNum]['civicrm_financial_trxn_card_type_id'] = $this->getLabels($row['civicrm_financial_trxn_card_type_id'], 'CRM_Financial_DAO_FinancialTrxn', 'card_type_id');
-        $entryFound = TRUE;
       }
 
-      $entryFound = $this->alterDisplayContactFields($row, $rows, $rowNum, NULL, NULL) ? TRUE : $entryFound;
-      $entryFound = $this->alterDisplayAddressFields($row, $rows, $rowNum, NULL, NULL) ? TRUE : $entryFound;
-
+      $this->alterDisplayContactFields($row, $rows, $rowNum, NULL, NULL);
+      $this->alterDisplayAddressFields($row, $rows, $rowNum, NULL, NULL);
     }
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
E_NOTICE for `$entryFound`.

This is the contribution aggregrate by relationship report (called History.php of course).

There are a lot of smarty notices on this page - this is a regular old E_NOTICE.

Before
----------------------------------------
E_NOTICE

After
----------------------------------------
Unused variable removed

Technical Details
----------------------------------------
This variable is used in other reports to skip looping over all the rows when the first row doesn't contain any of the columns you're altering. That's not desirable here anyway because of the inner loop higher up that potentially could run on every row. In any case this is no change from current since the variable is never checked.

Comments
----------------------------------------

