### PR TITLE
Ensure smarty variable formTpl is set

### DIFF
--- a/CRM/Core/Controller.php
+++ b/CRM/Core/Controller.php
@@ -172,6 +172,7 @@ class CRM_Core_Controller extends HTML_QuickForm_Controller {
     if (!isset(self::$_template)) {
       self::$_template = CRM_Core_Smarty::singleton();
       self::$_session = CRM_Core_Session::singleton();
+      self::$_template->ensureVariablesAreAssigned(['formTpl']);
     }
 
     // lets try to get it from the session and/or the request vars


### PR DESCRIPTION
Overview
----------------------------------------
After https://github.com/civicrm/civicrm-core/pull/21979 some php8 tests started failing because there are some paths that use CMSPrint.tpl but in a way where isForm is set but formTpl doesn't get set. In particular if it goes via CRM_Core_Quickform_Action_Display but without going thru CRM_Core_Invoke.

Before
----------------------------------------
php8 tests failing

After
----------------------------------------
hopefully passing

Technical Details
----------------------------------------
This is the same thing CRM_Core_Page does but for $formTpl - setting it to null.

Comments
----------------------------------------
@seamuslee001 @eileenmcnaughton 
