### PR TITLE
[NFC] Fix test issue about trying to do array offset on NULL in Payme…

### DIFF
--- a/tests/phpunit/CRM/Core/Payment/ProcessorFormTest.php
+++ b/tests/phpunit/CRM/Core/Payment/ProcessorFormTest.php
@@ -217,6 +217,19 @@ class CRM_Core_Payment_ProcessorFormTest extends CiviUnitTestCase {
 class PaymentProcessorWithStandardBillingRequirements extends CRM_Core_Payment {
 
   /**
+   * Constructor.
+   */
+  public function __construct() {
+    $this->_paymentProcessor = [
+      'payment_type' => 0,
+      'billing_mode' => 0,
+      'id' => 0,
+      'url_recur' => '',
+      'is_recur' => 0,
+    ];
+  }
+
+  /**
    * again, `checkConfig` is abstract in CRM_Core_Payment, so we are forced to implement it
    */
   public function checkConfig() {
@@ -225,6 +238,19 @@ class PaymentProcessorWithStandardBillingRequirements extends CRM_Core_Payment {
 }
 
 class PaymentProcessorWithCustomBillingRequirements extends CRM_Core_Payment {
+
+  /**
+   * Constructor.
+   */
+  public function __construct() {
+    $this->_paymentProcessor = [
+      'payment_type' => 0,
+      'billing_mode' => 0,
+      'id' => 0,
+      'url_recur' => '',
+      'is_recur' => 0,
+    ];
+  }
 
   /**
    * again, `checkConfig` is abstract in CRM_Core_Payment, so we are forced to implement it


### PR DESCRIPTION
…nt ProcessorFormTest

Overview
----------------------------------------
Fixes test failure because _paymentProcessor was NULL

```
CRM_Core_Payment_ProcessorFormTest::testPaymentProcessorWithStandardBillingRequirements
Trying to access array offset on value of type null

/home/jenkins/bknix-edge/build/build-0/web/sites/all/modules/civicrm/CRM/Core/Payment.php:983
```

Before
----------------------------------------
Test fails on php7.4 and later 

After
----------------------------------------
Test passes

ping @eileenmcnaughton @demeritcowboy 