### PR TITLE
Fix for dev/core#2948

### DIFF
--- a/CRM/Event/Form/Registration.php
+++ b/CRM/Event/Form/Registration.php
@@ -686,12 +686,6 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
       $this->set('primaryParticipant', $this->_params);
     }
 
-    CRM_Core_BAO_CustomValueTable::postProcess($this->_params,
-      'civicrm_participant',
-      $participant->id,
-      'Participant'
-    );
-
     $createPayment = (CRM_Utils_Array::value('amount', $this->_params, 0) != 0) ? TRUE : FALSE;
 
     // force to create zero amount payment, CRM-5095
@@ -826,6 +820,15 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
 
     if (!$participantParams['discount_id']) {
       $participantParams['discount_id'] = "null";
+    }
+
+    $participantParams['custom'] = [];
+    foreach ($form->_params as $paramName => $paramValue) {
+      if (strpos($paramName, 'custom_') === 0) {
+        list($customFieldID, $customValueID) = CRM_Core_BAO_CustomField::getKeyID($paramName, TRUE);
+        CRM_Core_BAO_CustomField::formatCustomField($customFieldID, $participantParams['custom'], $paramValue, 'Participant', $customValueID);
+
+      }
     }
 
     $participant = CRM_Event_BAO_Participant::create($participantParams);


### PR DESCRIPTION
Before
----------------------------------------

When registering for an event through the public event registration page the custom data of the participant is not available in the `pre_hook` and `post_hook`.

This was caused by the fact that the custom data is stored after the participant record has been created. 

After
----------------------------------------

The custom data is passed to `pre_hook` and the `post_hook`.

Technical Details
----------------------------------------

The custom data is passed to `CRM_Event_BAO_Participant::create` and not stored separately after the participant record has been saved.  

Comments
----------------------------------------

See https://lab.civicrm.org/dev/core/-/issues/2948 for reproduction steps. 
