### PR TITLE
[NFC] php8 - fix test fails for CRM_Contact_Page_View_UserDashBoardTest

### DIFF
--- a/tests/phpunit/CRM/Contact/Page/View/UserDashBoardTest.php
+++ b/tests/phpunit/CRM/Contact/Page/View/UserDashBoardTest.php
@@ -196,6 +196,7 @@ class CRM_Contact_Page_View_UserDashBoardTest extends CiviUnitTestCase {
     $_REQUEST = ['reset' => 1, 'id' => $this->contactID];
     $dashboard = new CRM_Contact_Page_View_UserDashBoard();
     $dashboard->_contactId = $this->contactID;
+    $dashboard->assign('formTpl', NULL);
     $dashboard->run();
     $_REQUEST = [];
   }


### PR DESCRIPTION
Overview
----------------------------------------
Another couple of the `formTpl` ones.

The tests don't involve a controller and call run() directly, so this seems the simplest place to assign it.