### PR TITLE
[NFC] dev/report#77 - Remove useless comment in contribute/history civireport

### DIFF
--- a/CRM/Report/Form/Contribute/History.php
+++ b/CRM/Report/Form/Contribute/History.php
@@ -16,10 +16,6 @@
  */
 class CRM_Report_Form_Contribute_History extends CRM_Report_Form {
   /**
-   * Primary Contacts count limitCONSTROW_COUNT_LIMIT = 10;
-   */
-
-  /**
    * @var array
    */
   protected $_relationshipColumns = [];


### PR DESCRIPTION
Overview
----------------------------------------
 It's been like this since svn: https://github.com/civicrm/civicrm-svn/commit/94474b19dea99d622a5e23f9924c0e735749bc3a