### PR TITLE
dev/report#77 - Smarty warning about relationship in contribute/history civireport

### DIFF
--- a/CRM/Report/Form/Contribute/History.php
+++ b/CRM/Report/Form/Contribute/History.php
@@ -825,6 +825,11 @@ class CRM_Report_Form_Contribute_History extends CRM_Report_Form {
         $rows[$rowNum] = $row;
       }
 
+      // The main rows don't have this set so gives a smarty warning.
+      if (!isset($row['civicrm_relationship_relationship_type_id'])) {
+        $rows[$rowNum]['civicrm_relationship_relationship_type_id'] = '';
+      }
+
       // Convert Display name into link
       if (!empty($row['civicrm_contact_sort_name']) &&
         !empty($row['civicrm_contact_id'])


### PR DESCRIPTION
Overview
----------------------------------------
1. Turn on debugging at administer - system settings - debugging.
2. Run the contribution aggregate by relationship civireport
3. Tons of warnings, one of them is "Undefined index: civicrm_relationship_relationship_type_id"

Before
----------------------------------------
Undefined index: civicrm_relationship_relationship_type_id

After
----------------------------------------
Still lots of warnings but not that one.

Technical Details
----------------------------------------
This report has two sets of rows - the main rows and the rows for related contacts. The field doesn't have a value set for the main rows.

Comments
----------------------------------------

