### PR TITLE
Flip logic for determining if $section variable is set.

### DIFF
--- a/templates/CRM/Report/Form/Layout/Graph.tpl
+++ b/templates/CRM/Report/Form/Layout/Graph.tpl
@@ -20,7 +20,7 @@
 {/if}
 
 {if empty($printOnly)} {* NO print section starts *}
-  {if !empty($section)}
+  {if empty($section)}
     {include file="CRM/common/chart.tpl" divId="chart_$uniqueId"}
   {/if}
   {if !empty($chartData)}


### PR DESCRIPTION
Overview
----------------------------------------
Previously empty() function calls were added in order to provide PHP8 compatiability,
however, the logic commited was back-to-front.

This broke the ability to display pie and bar charts for those reports which support them.

Before
----------------------------------------
Attempting to display a bar or pie chart for a report failed, with the following error message in the browser devconsole:

```
Uncaught ReferenceError: createChart is not defined
```

After
----------------------------------------
Pie and bar charts should work again.

Technical Details
----------------------------------------
This was broken in https://github.com/civicrm/civicrm-core/commit/0c1caf1823fd0a02c79a62d07b148fab30355300. 

TBH I'm not sure what the check on `$section` is doing, or if it's even needed. Maybe someone smarter than me will know? Seemed safest to just leave it be for now though.