### PR TITLE
Remove use of isset for info.tpl

### DIFF
--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -263,6 +263,13 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
    */
   public $expectedSmartyVariables = [
     'beginHookFormElements',
+    // required for footer.tpl
+    'contactId',
+    // required for info.tpl
+    'infoMessage',
+    'infoTitle',
+    'infoType',
+    'infoOptions',
   ];
 
   /**

--- a/CRM/Core/Page.php
+++ b/CRM/Core/Page.php
@@ -113,6 +113,11 @@ class CRM_Core_Page {
     'hookContentPlacement',
     // required for footer.tpl
     'contactId',
+    // required for info.tpl
+    'infoMessage',
+    'infoTitle',
+    'infoType',
+    'infoOptions',
   ];
 
   /**

--- a/CRM/Core/Page.php
+++ b/CRM/Core/Page.php
@@ -105,7 +105,15 @@ class CRM_Core_Page {
    *
    * @var string[]
    */
-  public $expectedSmartyVariables = ['breadcrumb', 'pageTitle', 'isForm', 'hookContent', 'hookContentPlacement'];
+  public $expectedSmartyVariables = [
+    'breadcrumb',
+    'pageTitle',
+    'isForm',
+    'hookContent',
+    'hookContentPlacement',
+    // required for footer.tpl
+    'contactId',
+  ];
 
   /**
    * Class constructor.

--- a/templates/CRM/common/footer.tpl
+++ b/templates/CRM/common/footer.tpl
@@ -9,7 +9,7 @@
 *}
 {if call_user_func(array('CRM_Core_Permission','check'), 'access CiviCRM')}
   {include file="CRM/common/accesskeys.tpl"}
-  {if !empty($contactId)}
+  {if $contactId}
     {include file="CRM/common/contactFooter.tpl"}
   {/if}
 

--- a/templates/CRM/common/info.tpl
+++ b/templates/CRM/common/info.tpl
@@ -8,10 +8,10 @@
  +--------------------------------------------------------------------+
 *}
 {* Handles display of passed $infoMessage. *}
-{if isset($infoMessage) or isset($infoTitle)}
-  <div class="messages status {$infoType|default:''}"{if !empty($infoOptions)} data-options='{$infoOptions}'{/if}>
+{if $infoMessage || $infoTitle}
+  <div class="messages status {$infoType}"{if $infoOptions} data-options='{$infoOptions}'{/if}>
     {icon icon="fa-info-circle"}{/icon}
-    <span class="msg-title">{$infoTitle|default:''}</span>
-    <span class="msg-text">{$infoMessage|default:''}</span>
+    <span class="msg-title">{$infoTitle}</span>
+    <span class="msg-text">{$infoMessage}</span>
   </div>
 {/if}


### PR DESCRIPTION
Overview
----------------------------------------
Remove use of isset for info.tpl

Before
----------------------------------------
variables not reliably assigned, isset used

 'infoMessage',
 'infoTitle',



After
----------------------------------------
Variables assigned in form & page code.

Technical Details
----------------------------------------
I also ensured `contactId` was set - this one is just an enotice one 

Comments
----------------------------------------

