### PR TITLE
Ensure action is set when loading contactFooter

### DIFF
--- a/CRM/Contact/Form/Inline.php
+++ b/CRM/Contact/Form/Inline.php
@@ -162,6 +162,7 @@ abstract class CRM_Contact_Form_Inline extends CRM_Core_Form {
       'contact_view_options', TRUE
     );
     $smarty->assign('changeLog', $viewOptions['log']);
+    $smarty->ensureVariablesAreAssigned(['action']);
     $ret = ['markup' => $smarty->fetch('CRM/common/contactFooter.tpl')];
     if ($includeCount) {
       $ret['count'] = CRM_Contact_BAO_Contact::getCountComponent('log', $cid);

--- a/templates/CRM/common/contactFooter.tpl
+++ b/templates/CRM/common/contactFooter.tpl
@@ -12,7 +12,7 @@
 <div class="crm-footer" id="crm-record-log">
   <span class="col1">
     {if !empty($external_identifier)}{ts}External ID{/ts}:&nbsp;{$external_identifier}{/if}
-    {if !isset($action) || (isset($action) && $action NEQ 2)}&nbsp; &nbsp;{ts}Contact ID{/ts}:&nbsp;{$contactId}{/if}
+    {if $action !== 2}&nbsp; &nbsp;{ts}Contact ID{/ts}:&nbsp;{$contactId}{/if}
   </span>
   {if !empty($lastModified)}
     {ts}Last Change by{/ts}: <a href="{crmURL p='civicrm/contact/view' q="action=view&reset=1&cid=`$lastModified.id`"}">{$lastModified.name}</a> ({$lastModified.date|crmDate}) &nbsp;


### PR DESCRIPTION
Overview
----------------------------------------
Ensure action is set when loading contactFooter

Before
----------------------------------------
use of isset to check if action is assigned

After
----------------------------------------
ensure that it is assigned

Technical Details
----------------------------------------

Comments
----------------------------------------
