### PR TITLE
Fix all the issets that affect ability to load contact summary page

### DIFF
--- a/CRM/Contact/Page/View/Summary.php
+++ b/CRM/Contact/Page/View/Summary.php
@@ -121,7 +121,30 @@ class CRM_Contact_Page_View_Summary extends CRM_Contact_Page_View {
     $this->assignFieldMetadataToTemplate('Contact');
 
     $params = [];
-    $defaults = [];
+    $defaults = [
+      // Set empty default values for these - they will be overwritten when the contact is
+      // loaded in CRM_Contact_BAO_Contact::retrieve if there are real values
+      // but since we are not using apiV4 they will be left unset if empty.
+      // However, the wind up assigned as smarty variables so we ensure they are set to prevent e-notices
+      // used by ContactInfo.tpl
+      'job_title' => '',
+      'current_employer_id' => '',
+      'nick_name' => '',
+      'legal_name' => '',
+      'source' => '',
+      'sic_code' => '',
+      'external_identifier' => '',
+      // for CommunicationPreferences.tpl
+      'postal_greeting_custom' => '',
+      'email_greeting_custom' => '',
+      'addressee_custom' => '',
+      'communication_style_display' => '',
+      // for Demographics.tpl
+      'age' => ['y' => '', 'm' => ''],
+      'birth_date' => '',
+      // for Website.tpl (the others don't seem to enotice for some reason).
+      'website' => '',
+    ];
 
     $params['id'] = $params['contact_id'] = $this->_contactId;
     $params['noRelationships'] = $params['noNotes'] = $params['noGroups'] = TRUE;
@@ -243,7 +266,6 @@ class CRM_Contact_Page_View_Summary extends CRM_Contact_Page_View {
       }
     }
 
-    $defaults['external_identifier'] = $contact->external_identifier;
     $this->assign($defaults);
 
     // FIXME: when we sort out TZ isssues with DATETIME/TIMESTAMP, we can skip next query

--- a/templates/CRM/Contact/Page/Inline/Basic.tpl
+++ b/templates/CRM/Contact/Page/Inline/Basic.tpl
@@ -35,7 +35,7 @@
   <div class="crm-summary-row">
     <div class="crm-label">{ts}External ID{/ts}</div>
     <div class="crm-content crm-contact_external_identifier_label">
-      {if isset($external_identifier)}{$external_identifier}{/if}
+      {$external_identifier}
     </div>
   </div>
 </div>

--- a/templates/CRM/Contact/Page/Inline/Basic.tpl
+++ b/templates/CRM/Contact/Page/Inline/Basic.tpl
@@ -15,7 +15,7 @@
   <div class="crm-summary-row">
     <div class="crm-label">{ts}Contact Type{/ts}</div>
     <div class="crm-content crm-contact_type_label">
-      {if isset($contact_type_label)}{$contact_type_label}{/if}
+      {$contact_type_label}
     </div>
   </div>
   <div class="crm-summary-row">

--- a/templates/CRM/Contact/Page/Inline/CommunicationPreferences.tpl
+++ b/templates/CRM/Contact/Page/Inline/CommunicationPreferences.tpl
@@ -44,7 +44,7 @@
         {$preferred_mail_format}
       </div>
     </div>
-    {if isset($communication_style_display)}
+    {if $communication_style_display}
     <div class="crm-summary-row">
       <div class="crm-label">{ts}Communication Style{/ts}</div>
       <div class="crm-content crm-contact-communication_style_display">

--- a/templates/CRM/Contact/Page/Inline/ContactInfo.tpl
+++ b/templates/CRM/Contact/Page/Inline/ContactInfo.tpl
@@ -27,27 +27,27 @@
       </div>
       <div class="crm-summary-row">
         <div class="crm-label">{ts}Job Title{/ts}</div>
-        <div class="crm-content crm-contact-job_title">{if isset($job_title)}{$job_title}{/if}</div>
+        <div class="crm-content crm-contact-job_title">{$job_title}</div>
       </div>
       {/if}
       <div class="crm-summary-row">
         <div class="crm-label">{ts}Nickname{/ts}</div>
-        <div class="crm-content crm-contact-nick_name">{if isset($nick_name)}{$nick_name}{/if}</div>
+        <div class="crm-content crm-contact-nick_name">{$nick_name}</div>
       </div>
 
       {if $contact_type eq 'Organization'}
       <div class="crm-summary-row">
         <div class="crm-label">{ts}Legal Name{/ts}</div>
-        <div class="crm-content crm-contact-legal_name">{if isset($legal_name)}{$legal_name}{/if}</div>
+        <div class="crm-content crm-contact-legal_name">{$legal_name}</div>
       </div>
       <div class="crm-summary-row">
         <div class="crm-label">{ts}SIC Code{/ts}</div>
-        <div class="crm-content crm-contact-sic_code">{if isset($sic_code)}{$sic_code}{/if}</div>
+        <div class="crm-content crm-contact-sic_code">{$sic_code}</div>
       </div>
       {/if}
       <div class="crm-summary-row">
         <div class="crm-label">{ts}Source{/ts}</div>
-        <div class="crm-content crm-contact_source">{if isset($source)}{$source}{/if}</div>
+        <div class="crm-content crm-contact_source">{$source}</div>
       </div>
 
     </div>

--- a/templates/CRM/Contact/Page/Inline/Demographics.tpl
+++ b/templates/CRM/Contact/Page/Inline/Demographics.tpl
@@ -23,7 +23,7 @@
       <div class="crm-label">{ts}Date of Birth{/ts}</div>
       <div class="crm-content crm-contact-birth_date_display">
         {assign var="date_format" value=$fields.birth_date.smarty_view_format}
-        {if !empty($birth_date)}
+        {if $birth_date}
           {$birth_date|crmDate:$date_format}
         {/if}
       </div>
@@ -35,7 +35,7 @@
             <div class="crm-content crm-contact-deceased_date_display">
               {assign var="date_format" value = $fields.birth_date.smarty_view_format}
               {$deceased_date|crmDate:$date_format}
-              {if !empty($birth_date)}({ts}Age{/ts} {if !empty($age.y)}{ts count=$age.y plural='%count years'}%count year{/ts}{elseif !empty($age.m)}{ts count=$age.m plural='%count months'}%count month{/ts}{/if}){/if}
+              {if $birth_date}({ts}Age{/ts} {if $age.y}{ts count=$age.y plural='%count years'}%count year{/ts}{elseif $age.m}{ts count=$age.m plural='%count months'}%count month{/ts}{/if}){/if}
             </div>
           </div>
         {else}
@@ -47,7 +47,7 @@
       {else}
         <div class="crm-summary-row">
           <div class="crm-label">{ts}Age{/ts}</div>
-          <div class="crm-content crm-contact-age_display">{if !empty($age.y)}{ts count=$age.y plural='%count years'}%count year{/ts}{elseif !empty($age.m)}{ts count=$age.m plural='%count months'}%count month{/ts}{/if}</div>
+          <div class="crm-content crm-contact-age_display">{if $age.y}{ts count=$age.y plural='%count years'}%count year{/ts}{elseif $age.m}{ts count=$age.m plural='%count months'}%count month{/ts}{/if}</div>
         </div>
       {/if}
     </div>


### PR DESCRIPTION
Overview
----------------------------------------
Fix all the issets that affect ability to load contact summary page

Before
----------------------------------------

After
----------------------------------------

This fixes all the places where isset is used in the tpls that get the contact summary loaded & gets that page to load without enotice with escape on output enabled

Technical Details
----------------------------------------
This is a lot to review at once - I put up this PR because I know @demeritcowboy is often happy to work with larger PRs - but I will continue to pull out commits into small PRs until this is merged (2 are currently MOP)

Comments
----------------------------------------
