### PR TITLE
CiviCRM Membership Status can never be deleted when logging is enabled

### DIFF
--- a/CRM/Member/BAO/MembershipStatus.php
+++ b/CRM/Member/BAO/MembershipStatus.php
@@ -52,7 +52,7 @@ class CRM_Member_BAO_MembershipStatus extends CRM_Member_DAO_MembershipStatus {
   }
 
   /**
-   * Takes an associative array and creates a membership Status object.
+   * Takes an associative array and creates a membership status object.
    *
    * @param array $params
    *   Array of name/value pairs.
@@ -73,7 +73,7 @@ class CRM_Member_BAO_MembershipStatus extends CRM_Member_DAO_MembershipStatus {
   }
 
   /**
-   * Add the membership types.
+   * Add the membership status.
    *
    * @param array $params
    *   Reference array contains the values submitted by the form.
@@ -130,7 +130,7 @@ class CRM_Member_BAO_MembershipStatus extends CRM_Member_DAO_MembershipStatus {
   }
 
   /**
-   * Get  membership status.
+   * Get membership status.
    *
    * @param int $membershipStatusId
    *
@@ -147,28 +147,25 @@ class CRM_Member_BAO_MembershipStatus extends CRM_Member_DAO_MembershipStatus {
   }
 
   /**
-   * Delete membership Types.
+   * Delete membership status.
    *
    * @param int $membershipStatusId
    *
    * @throws CRM_Core_Exception
    */
   public static function del($membershipStatusId) {
-    //check dependencies
-    //checking if membership status is present in some other table
-    $check = FALSE;
-
-    $dependency = ['Membership', 'MembershipLog'];
+    // Check if any membership records are assigned this membership status
+    $dependency = ['Membership'];
     foreach ($dependency as $name) {
       $baoString = 'CRM_Member_BAO_' . $name;
       $dao = new $baoString();
       $dao->status_id = $membershipStatusId;
       if ($dao->find(TRUE)) {
-        throw new CRM_Core_Exception(ts('This membership status cannot be deleted as memberships exist with this status'));
+        throw new CRM_Core_Exception(ts('This membership status cannot be deleted. Memberships exist with this status.'));
       }
     }
     CRM_Utils_Weight::delWeight('CRM_Member_DAO_MembershipStatus', $membershipStatusId);
-    //delete from membership Type table
+    // Delete from Membership Status table
     $membershipStatus = new CRM_Member_DAO_MembershipStatus();
     $membershipStatus->id = $membershipStatusId;
     if (!$membershipStatus->find()) {


### PR DESCRIPTION
CiviCRM Membership Status can never be deleted when logging is enabled, if the membership status was used once. Because there is a check in the membership log table for records having this membership status.

Membership Status delete function appears to have been copied from Membership Type.

Note, Membership Type can be deleted with no such check.


Before
----------------------------------------
Cannot delete Membership Status.

After
----------------------------------------
Can delete Membership Status.

Technical Details
----------------------------------------
Fixed incorrect references to Membership Type in code comments.

Comments
----------------------------------------

Agileware Ref: CIVICRM-1885
