### PR TITLE
Do not smarty encode quicksearch html

### DIFF
--- a/templates/CRM/common/l10n.js.tpl
+++ b/templates/CRM/common/l10n.js.tpl
@@ -37,7 +37,7 @@
   $.fn.select2.defaults.formatLoadMore = "{ts escape='js'}Loading...{/ts}";
   $.fn.select2.defaults.formatSearching = "{ts escape='js'}Searching...{/ts}";
   $.fn.select2.defaults.formatInputTooShort = function() {ldelim}
-    return ($(this).data('api-entity') === 'contact' || $(this).data('api-entity') === 'Contact') ? {$contactSearch} : {$otherSearch};
+    return ($(this).data('api-entity') === 'contact' || $(this).data('api-entity') === 'Contact') ? {$contactSearch|smarty:nodefaults} : {$otherSearch|smarty:nodefaults};
   {rdelim};
 
   // Localize jQuery UI


### PR DESCRIPTION
Overview
----------------------------------------
Do not smarty encode quicksearch html

Before
----------------------------------------
Quicksearch fields with quotes escaped when default modifiers are on

After
----------------------------------------

Fields  not escaped when default modifiers are on

Technical Details
----------------------------------------
I don't really get the need for these fields to be json-encoded but it seems 'legit'

Comments
----------------------------------------
