### PR TITLE
Escape-on-output: Cleanup addCampaignToSearch, remove isset

### DIFF
--- a/CRM/Campaign/BAO/Campaign.php
+++ b/CRM/Campaign/BAO/Campaign.php
@@ -599,16 +599,8 @@ INNER JOIN  civicrm_group grp ON ( grp.id = campgrp.entity_id )
         ['id' => 'campaigns', 'multiple' => 'multiple', 'class' => 'crm-select2']
       );
     }
-    $infoFields = [
-      'elementName',
-      'hasAccessCampaign',
-      'isCampaignEnabled',
-      'showCampaignInSearch',
-    ];
-    foreach ($infoFields as $fld) {
-      $campaignInfo[$fld] = $$fld;
-    }
-    $form->assign('campaignInfo', $campaignInfo);
+
+    $form->assign('campaignElementName', $showCampaignInSearch ? $elementName : '');
   }
 
   /**

--- a/templates/CRM/Activity/Form/Search/Common.tpl
+++ b/templates/CRM/Activity/Form/Search/Common.tpl
@@ -114,8 +114,8 @@
 {/if}
 
 {* campaign in activity search *}
-{include file="CRM/Campaign/Form/addCampaignToComponent.tpl"
-campaignContext="componentSearch" campaignTrClass='' campaignTdClass=''}
+{include file="CRM/Campaign/Form/addCampaignToSearch.tpl"
+campaignTrClass='' campaignTdClass=''}
 
 {if !empty($activityGroupTree)}
   <tr id="activityCustom">

--- a/templates/CRM/Campaign/Form/addCampaignToComponent.tpl
+++ b/templates/CRM/Campaign/Form/addCampaignToComponent.tpl
@@ -1,23 +1,11 @@
 {* add campaigns to various components CRM-7362 *}
 
-{if isset($campaignContext) and $campaignContext eq 'componentSearch'}
-
-  {* add campaign in component search *}
-  <tr class="{$campaignTrClass}">
-    {assign var=elementName value=$campaignInfo.elementName}
-    <td class="{$campaignTdClass}">
-      {if isset($form.$elementName)}
-        {$form.$elementName.label} {$form.$elementName.html}
-      {/if}
-    </td>
-  </tr>
-
-{elseif $campaignInfo.showAddCampaign}
+{if $campaignInfo.showAddCampaign}
 
   <tr class="{$campaignTrClass}">
     <td class="label">{$form.campaign_id.label} {help id="id-campaign_id" file="CRM/Campaign/Form/addCampaignToComponent.hlp"}</td>
     <td class="view-value">{$form.campaign_id.html}</td>
   </tr>
 
-{/if}{* add campaign to component search if closed. *}
+{/if}
 

--- a/templates/CRM/Campaign/Form/addCampaignToSearch.tpl
+++ b/templates/CRM/Campaign/Form/addCampaignToSearch.tpl
@@ -1,0 +1,8 @@
+{if $campaignElementName}
+  {* add campaign in component search *}
+  <tr class="{$campaignTrClass}">
+    <td class="{$campaignTdClass}">
+      {$form.$campaignElementName.label} {$form.$campaignElementName.html}
+    </td>
+  </tr>
+{/if}

--- a/templates/CRM/Contribute/Form/Search/Common.tpl
+++ b/templates/CRM/Contribute/Form/Search/Common.tpl
@@ -172,7 +172,7 @@
 </tr>
 
 {* campaign in contribution search *}
-{include file="CRM/Campaign/Form/addCampaignToComponent.tpl" campaignContext="componentSearch"
+{include file="CRM/Campaign/Form/addCampaignToSearch.tpl"
 campaignTrClass='' campaignTdClass=''}
 
 {* contribution recurring search *}

--- a/templates/CRM/Contribute/Form/SearchContribution.tpl
+++ b/templates/CRM/Contribute/Form/SearchContribution.tpl
@@ -30,8 +30,8 @@
     </tr>
 
     {* campaign in contribution page search *}
-    {include file="CRM/Campaign/Form/addCampaignToComponent.tpl"
-    campaignContext="componentSearch" campaignTrClass='' campaignTdClass=''}
+    {include file="CRM/Campaign/Form/addCampaignToSearch.tpl"
+    campaignTrClass='' campaignTdClass=''}
 
  </table>
  <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl"}</div>

--- a/templates/CRM/Event/Form/Search/Common.tpl
+++ b/templates/CRM/Event/Form/Search/Common.tpl
@@ -52,7 +52,7 @@
 </tr>
 
 {* campaign in contribution search *}
-{include file="CRM/Campaign/Form/addCampaignToComponent.tpl" campaignContext="componentSearch"
+{include file="CRM/Campaign/Form/addCampaignToSearch.tpl"
 campaignTrClass='' campaignTdClass='crm-event-form-block-participant_campaign_id'}
 
 {if $participantGroupTree }

--- a/templates/CRM/Event/Form/SearchEvent.tpl
+++ b/templates/CRM/Event/Form/SearchEvent.tpl
@@ -45,7 +45,7 @@
     </td></tr>
 
     {* campaign in event search *}
-    {include file="CRM/Campaign/Form/addCampaignToComponent.tpl" campaignContext="componentSearch"
+    {include file="CRM/Campaign/Form/addCampaignToSearch.tpl"
     campaignTrClass='crm-event-searchevent-form-block-campaign_id' campaignTdClass=''}
     <td class="right">{include file="CRM/common/formButtons.tpl"}</td>
   </table>

--- a/templates/CRM/Mailing/Form/Search.tpl
+++ b/templates/CRM/Mailing/Form/Search.tpl
@@ -52,8 +52,8 @@
     {/if}
 
     {* campaign in mailing search *}
-    {include file="CRM/Campaign/Form/addCampaignToComponent.tpl"
-      campaignContext="componentSearch" campaignTrClass='' campaignTdClass=''}
+    {include file="CRM/Campaign/Form/addCampaignToSearch.tpl"
+      campaignTrClass='' campaignTdClass=''}
 
     <tr>
       <td>{$form.buttons.html}</td><td colspan="2"></td>

--- a/templates/CRM/Mailing/Form/Search/Common.tpl
+++ b/templates/CRM/Mailing/Form/Search/Common.tpl
@@ -66,7 +66,7 @@
 </tr>
 <tr>
   <td>{* campaign in Advance search *}
-      {include file="CRM/Campaign/Form/addCampaignToComponent.tpl" campaignContext="componentSearch"
+      {include file="CRM/Campaign/Form/addCampaignToSearch.tpl"
        campaignTrClass='crmCampaign' campaignTdClass='crmCampaignContainer'}
   </td>
 </tr>

--- a/templates/CRM/Member/Form/Search/Common.tpl
+++ b/templates/CRM/Member/Form/Search/Common.tpl
@@ -57,7 +57,7 @@
 </tr>
 
 {* campaign in membership search *}
-{include file="CRM/Campaign/Form/addCampaignToComponent.tpl" campaignContext="componentSearch"
+{include file="CRM/Campaign/Form/addCampaignToSearch.tpl"
 campaignTrClass='' campaignTdClass=''}
 
 {if !empty($membershipGroupTree)}

--- a/templates/CRM/Pledge/Form/Search/Common.tpl
+++ b/templates/CRM/Pledge/Form/Search/Common.tpl
@@ -77,8 +77,8 @@
 </tr>
 
 {* campaign in pledge search *}
-{include file="CRM/Campaign/Form/addCampaignToComponent.tpl"
-campaignContext="componentSearch" campaignTrClass='' campaignTdClass=''}
+{include file="CRM/Campaign/Form/addCampaignToSearch.tpl"
+campaignTrClass='' campaignTdClass=''}
 
 {if !empty($pledgeGroupTree)}
 <tr>


### PR DESCRIPTION
Overview
----------------------------------------
Cleanup addCampaignToSearch

Before
----------------------------------------
The functionality to add a campaign filter to a search and to add a campaign field to a component form are in the same tpl but the code run is mutually exclusive. Lots of complexity used to maintain this

After
----------------------------------------
Separate tpls, less variable assignments needed as a result and we can ditch the isset that upsets escape-on-output

Technical Details
----------------------------------------

Comments
----------------------------------------
