### PR TITLE
Escape-on-output-proof enotice fixes

### DIFF
--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -262,6 +262,11 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
    * @var string[]
    */
   public $expectedSmartyVariables = [
+    // in CMSPrint.tpl
+    'breadcrumb',
+    'pageTitle',
+    // in 'body.tpl
+    'suppressForm',
     'beginHookFormElements',
     // required for footer.tpl
     'contactId',

--- a/templates/CRM/Form/body.tpl
+++ b/templates/CRM/Form/body.tpl
@@ -15,7 +15,7 @@
   <div>{$form.hidden}</div>
 {/if}
 
-{if ($snippet !== 'json') and empty($suppressForm) and count($form.errors) gt 0}
+{if ($snippet !== 'json') and !$suppressForm and count($form.errors) gt 0}
    <div class="messages crm-error">
        <i class="crm-i fa-exclamation-triangle crm-i-red" aria-hidden="true"></i>
      {ts}Please correct the following errors in the form fields below:{/ts}

--- a/templates/CRM/Form/default.tpl
+++ b/templates/CRM/Form/default.tpl
@@ -7,7 +7,7 @@
  | and copyright information, see https://civicrm.org/licensing       |
  +--------------------------------------------------------------------+
 *}
-{if empty($suppressForm)}
+{if !$suppressForm}
 <form {$form.attributes} >
   {crmRegion name='form-top'}{/crmRegion}
 {/if}
@@ -18,7 +18,7 @@
     {include file=$tplFile}
   {/crmRegion}
 
-{if empty($suppressForm)}
+{if !$suppressForm}
   {crmRegion name='form-bottom'}{/crmRegion}
 </form>
 {/if}

--- a/templates/CRM/common/CMSPrint.tpl
+++ b/templates/CRM/common/CMSPrint.tpl
@@ -13,7 +13,7 @@
 
 <div id="crm-container" class="crm-container{if !empty($urlIsPublic)} crm-public{/if}" lang="{$config->lcMessages|truncate:2:"":true}" xml:lang="{$config->lcMessages|truncate:2:"":true}">
 
-{if !empty($breadcrumb)}
+{if $breadcrumb}
   <div class="breadcrumb">
     {foreach from=$breadcrumb item=crumb key=key}
       {if $key != 0}
@@ -24,7 +24,7 @@
   </div>
 {/if}
 
-{if !empty($pageTitle)}
+{if $pageTitle}
   <div class="crm-title">
     <h1 class="title">{if !empty($isDeleted)}<del>{/if}{$pageTitle}{if !empty($isDeleted)}</del>{/if}</h1>
   </div>

--- a/templates/CRM/common/fatal.tpl
+++ b/templates/CRM/common/fatal.tpl
@@ -13,7 +13,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
 
 <head>
-  <title>{if !empty($pageTitle)}{$pageTitle|escape}{/if}</title>
+  <title>{$pageTitle|escape}</title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   <base href="{$config->resourceBase}" />
   <style type="text/css" media="screen">


### PR DESCRIPTION
Overview
----------------------------------------
Escape-on-output-proof enotice fixes

Before
----------------------------------------
Use of empty checks doesn't work with escape on output

After
----------------------------------------
Ensure variables are assigned

Technical Details
----------------------------------------

Comments
----------------------------------------
