### PR TITLE
[REF] Fix Pledge Test failing on php8 by ensuring all payments have a…

### DIFF
--- a/CRM/Pledge/BAO/Pledge.php
+++ b/CRM/Pledge/BAO/Pledge.php
@@ -534,6 +534,7 @@ GROUP BY  currency
           [
             'amount' => $values['scheduled_amount'] ?? NULL,
             'due_date' => $values['scheduled_date'] ?? NULL,
+            'status' => CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Pending'),
           ]
         );
 
@@ -570,10 +571,10 @@ GROUP BY  currency
     }
 
     // handle custom data.
+    $customGroup = [];
     if (!empty($params['hidden_custom'])) {
       $groupTree = CRM_Core_BAO_CustomGroup::getTree('Pledge', NULL, $params['id']);
       $pledgeParams = [['pledge_id', '=', $params['id'], 0, 0]];
-      $customGroup = [];
       // retrieve custom data
       foreach ($groupTree as $groupID => $group) {
         $customFields = $customValues = [];
@@ -590,8 +591,8 @@ GROUP BY  currency
         $customGroup[$group['title']] = $customValues;
       }
 
-      $form->assign('customGroup', $customGroup);
     }
+    $form->assign('customGroup', $customGroup);
 
     // handle acknowledgment email stuff.
     [$pledgerDisplayName, $pledgerEmail] = CRM_Contact_BAO_Contact_Location::getEmailDetails($params['contact_id']);

--- a/tests/phpunit/CRM/Pledge/Form/PledgeTest.php
+++ b/tests/phpunit/CRM/Pledge/Form/PledgeTest.php
@@ -31,6 +31,13 @@ class CRM_Pledge_Form_PledgeTest extends CiviUnitTestCase {
       'from_email_address' => Email::get()
         ->addWhere('contact_id', '=', $loggedInUser)
         ->addSelect('id')->execute()->first()['id'],
+      'frequency_interval' => 1,
+      'frequency_unit' => 'month',
+      'installments' => 5,
+      'currency' => 'USD',
+      'scheduled_amount' => 10,
+      'frequency_day' => 4,
+      'status' => 'Pending',
     ]);
     $form->buildForm();
     $form->postProcess();


### PR DESCRIPTION
… status assigned and that customGroup is always assigned to the template and updating test to pass in some additional form values

Overview
----------------------------------------
This fixes the currently failing CRM_Pledge_Form_PledgeTest on php8 by ensuring that all payments even pending ones have a status in the array assigned and also by ensuring customGroup variable is always assigned to the template and fixing the form object in the test

Before
----------------------------------------
Test fails on php8

After
----------------------------------------
Test passes on php8

ping @demeritcowboy @eileenmcnaughton 