### PR TITLE
(dev/core#2951) expose contribution custom fields in lybunt report

### DIFF
--- a/CRM/Report/Form/Contribute/Lybunt.php
+++ b/CRM/Report/Form/Contribute/Lybunt.php
@@ -35,6 +35,7 @@ class CRM_Report_Form_Contribute_Lybunt extends CRM_Report_Form {
   protected $lifeTime_from = NULL;
   protected $lifeTime_where = NULL;
   protected $_customGroupExtends = [
+    'Contribution',
     'Contact',
     'Individual',
     'Household',


### PR DESCRIPTION
Overview
----------------------------------------
Expose contribution custom fields in LYBUNT report

Before
----------------------------------------
No _Donor Information_
![lybunt_before](https://user-images.githubusercontent.com/3455173/141242959-e925d1b0-2e65-40da-be1c-5d0e2854a908.png)

After
----------------------------------------
_Donor Information_ is exposed now
![lybunt_after](https://user-images.githubusercontent.com/3455173/141242974-183278e7-bde7-4baf-864e-5e5599017104.png)

