### PR TITLE
Write access to variable that still references the array value previously used in 'foreach'

### DIFF
--- a/CRM/Contact/Page/View/Summary.php
+++ b/CRM/Contact/Page/View/Summary.php
@@ -445,10 +445,10 @@ class CRM_Contact_Page_View_Summary extends CRM_Contact_Page_View {
     // now sort the tabs based on weight
     usort($allTabs, ['CRM_Utils_Sort', 'cmpFunc']);
     $expectedKeys = ['count', 'class', 'template', 'hideCount', 'icon'];
-    foreach ($allTabs as $index => $tab) {
+    foreach ($allTabs as $index => &$tab) {
       foreach ($expectedKeys as $key) {
         if (!array_key_exists($key, $tab)) {
-          $allTabs[$index][$key] = NULL;
+          $tab[$key] = NULL;
         }
       }
     }


### PR DESCRIPTION
This resolves issues with tabs on the contact view page randomly disappearing or duplicating, due to write access to a variable that still references the array value previously used in a `foreach` loop.

Instead of `unset`ing the variable `$tab`, iterating through the array with references seems more readable to me.