### PR TITLE
Ensure userRecordUrl is always set- fixes enotice with escape-on-output

### DIFF
--- a/CRM/Contact/Page/View.php
+++ b/CRM/Contact/Page/View.php
@@ -328,16 +328,16 @@ class CRM_Contact_Page_View extends CRM_Core_Page {
    */
   public static function addUrls(&$obj, $cid) {
     $uid = CRM_Core_BAO_UFMatch::getUFId($cid);
-
+    $obj->assign('userRecordId', $uid);
+    $userRecordUrl = '';
     if ($uid) {
       $userRecordUrl = CRM_Core_Config::singleton()->userSystem->getUserRecordUrl($cid);
-      $obj->assign('userRecordUrl', $userRecordUrl);
-      $obj->assign('userRecordId', $uid);
     }
     elseif (CRM_Core_Config::singleton()->userSystem->checkPermissionAddUser()) {
       $userAddUrl = CRM_Utils_System::url('civicrm/contact/view/useradd', 'reset=1&action=add&cid=' . $cid);
       $obj->assign('userAddUrl', $userAddUrl);
     }
+    $obj->assign('userRecordUrl', $userRecordUrl);
 
     if (CRM_Core_Permission::check('access Contact Dashboard')) {
       $dashboardURL = CRM_Utils_System::url('civicrm/user',

--- a/templates/CRM/Contact/Page/Inline/Basic.tpl
+++ b/templates/CRM/Contact/Page/Inline/Basic.tpl
@@ -22,11 +22,11 @@
   </div>
   <div class="crm-summary-row">
     <div class="crm-label">
-      {ts}Contact ID{/ts}{if !empty($userRecordUrl)} / {ts}User ID{/ts}{/if}
+      {ts}Contact ID{/ts}{if $userRecordUrl} / {ts}User ID{/ts}{/if}
     </div>
     <div class="crm-content">
       <span class="crm-contact-contact_id">{$contactId}</span>
-      {if !empty($userRecordUrl)}
+      {if $userRecordUrl}
         <span class="crm-contact-user_record_id">
           &nbsp;/&nbsp;<a title="{ts}View user record{/ts}" class="user-record-link"
                           href="{$userRecordUrl}">{$userRecordId}</a>


### PR DESCRIPTION
Overview
----------------------------------------
Ensure userRecordUrl is always set- fixes enotice with escape-on-output

Before
----------------------------------------
use of empty in tpls does not prevent enotices when escape on output enabled

After
----------------------------------------
Always assigned

Technical Details
----------------------------------------

Comments
----------------------------------------
