### PR TITLE
(dev/core#2947) Tokens - Auto-enable `{event.*}` if `participantId` is present

### DIFF
--- a/CRM/Core/SelectValues.php
+++ b/CRM/Core/SelectValues.php
@@ -595,7 +595,7 @@ class CRM_Core_SelectValues {
     $tokenProcessor = new TokenProcessor(Civi::dispatcher(), ['schema' => ['participantId']]);
     $allTokens = $tokenProcessor->listTokens();
     foreach (array_keys($allTokens) as $token) {
-      if (strpos($token, '{domain.') === 0) {
+      if (strpos($token, '{domain.') === 0 || strpos($token, '{event.') === 0) {
         unset($allTokens[$token]);
       }
     }

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -338,6 +338,10 @@ class Container {
         []
       ))->addTag('kernel.event_subscriber')->setPublic(TRUE);
     }
+    $container->setDefinition('civi_token_impliedcontext', new Definition(
+      'Civi\Token\ImpliedContextSubscriber',
+      []
+    ))->addTag('kernel.event_subscriber')->setPublic(TRUE);
     $container->setDefinition('crm_participant_tokens', new Definition(
       'CRM_Event_ParticipantTokens',
       []

--- a/Civi/Token/ImpliedContextSubscriber.php
+++ b/Civi/Token/ImpliedContextSubscriber.php
@@ -1,0 +1,114 @@
+<?php
+namespace Civi\Token;
+
+use Civi\Token\Event\TokenRegisterEvent;
+use Civi\Token\Event\TokenValueEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Suppose you have `$context['participantId']`. You can infer a
+ * corresponding `$context['eventId']`. The ImpliedContextSubscriber reads
+ * values like `participantId` and fills-in values like `eventId`.
+ *
+ * @package Civi\Token
+ */
+class ImpliedContextSubscriber implements EventSubscriberInterface {
+
+  public static function getSubscribedEvents() {
+    return [
+      'civi.token.list' => ['onRegisterTokens', 1000],
+      'civi.token.eval' => ['onEvaluateTokens', 1000],
+    ];
+  }
+
+  /**
+   * When listing tokens, ensure that implied data is visible.
+   *
+   * Ex: If `$context['participantId']` is part of the schema, then
+   * `$context['eventId']` will also be part of the schema.
+   *
+   * This fires early during the `civi.token.list` process to ensure that
+   * other listeners see the updated schema.
+   *
+   * @param \Civi\Token\Event\TokenRegisterEvent $e
+   */
+  public function onRegisterTokens(TokenRegisterEvent $e): void {
+    $tokenProc = $e->getTokenProcessor();
+    foreach ($this->findRelevantMappings($tokenProc) as $mapping) {
+      $tokenProc->addSchema($mapping['destEntityId']);
+    }
+  }
+
+  /**
+   * When evaluating tokens, ensure that implied data is loaded.
+   *
+   * Ex: If `$context['participantId']` is supplied, then lookup the
+   * corresponding `$context['eventId']`.
+   *
+   * This fires early during the `civi.token.list` process to ensure that
+   * other listeners see the autoloaded values.
+   *
+   * @param \Civi\Token\Event\TokenValueEvent $e
+   */
+  public function onEvaluateTokens(TokenValueEvent $e): void {
+    $tokenProc = $e->getTokenProcessor();
+    foreach ($this->findRelevantMappings($tokenProc) as $mapping) {
+      $getSrcId = function($row) use ($mapping) {
+        return $row->context[$mapping['srcEntityId']] ?? $row->context[$mapping['srcEntityRec']]['id'] ?? NULL;
+      };
+
+      $ids = [];
+      foreach ($tokenProc->getRows() as $row) {
+        $ids[] = $getSrcId($row);
+      }
+      $ids = \array_diff(\array_unique($ids), [NULL]);
+      if (empty($ids)) {
+        continue;
+      }
+
+      [$srcTable, $fkColumn] = explode('.', $mapping['fk']);
+      $fks = \CRM_Utils_SQL_Select::from($srcTable)
+        ->where('id in (#ids)', ['ids' => $ids])
+        ->select(['id', $fkColumn])
+        ->execute()
+        ->fetchMap('id', $fkColumn);
+
+      $tokenProc->addSchema($mapping['destEntityId']);
+      foreach ($tokenProc->getRows() as $row) {
+        $srcId = $getSrcId($row);
+        if ($srcId && empty($row->context[$mapping['destEntityId']])) {
+          $row->context($mapping['destEntityId'], $fks[$srcId]);
+        }
+      }
+    }
+  }
+
+  /**
+   * Are there any context-fields for which we should do lookups?
+   *
+   * Ex: If the `$tokenProcessor` has the `participantId`s, then we would want
+   * to know any rules that involve `participantId`. But we don't need to know
+   * rules that involve `contributionId`.
+   *
+   * @param \Civi\Token\TokenProcessor $tokenProcessor
+   */
+  private function findRelevantMappings(TokenProcessor $tokenProcessor): iterable {
+    $schema = $tokenProcessor->context['schema'];
+    yield from [];
+    foreach ($this->getMappings() as $mapping) {
+      if (in_array($mapping['srcEntityRec'], $schema) || in_array($mapping['srcEntityId'], $schema)) {
+        yield $mapping;
+      }
+    }
+  }
+
+  private function getMappings(): iterable {
+    yield [
+      'srcEntityId' => 'participantId',
+      'srcEntityRec' => 'participant',
+      'fk' => 'civicrm_participant.event_id',
+      'destEntityId' => 'eventId',
+    ];
+  }
+
+}

--- a/Civi/Token/TokenProcessor.php
+++ b/Civi/Token/TokenProcessor.php
@@ -128,6 +128,17 @@ class TokenProcessor {
   }
 
   /**
+   * Add new elements to the field schema.
+   *
+   * @param string|string[] $fieldNames
+   * @return TokenProcessor
+   */
+  public function addSchema($fieldNames) {
+    $this->context['schema'] = array_unique(array_merge($this->context['schema'], (array) $fieldNames));
+    return $this;
+  }
+
+  /**
    * Register a string for which we'll need to merge in tokens.
    *
    * @param string $name

--- a/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
+++ b/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
@@ -639,7 +639,7 @@ December 21st, 2007
       'smarty' => FALSE,
       'schema' => ['participantId'],
     ]);
-    $this->assertEquals(array_merge($tokens, $this->getDomainTokens()), $tokenProcessor->listTokens());
+    $this->assertEquals(array_merge($tokens, $this->getEventTokens(), $this->getDomainTokens()), $tokenProcessor->listTokens());
 
     $this->callAPISuccess('job', 'send_reminder', []);
     $expected = $this->getExpectedParticipantTokenOutput();

--- a/tests/phpunit/Civi/Token/ImpliedContextSubscriberTest.php
+++ b/tests/phpunit/Civi/Token/ImpliedContextSubscriberTest.php
@@ -1,0 +1,27 @@
+<?php
+namespace Civi\Token;
+
+class ImpliedContextSubscriberTest extends \CiviUnitTestCase {
+
+  public function testParticipant_ImplicitEvent() {
+    $participantId = $this->participantCreate();
+
+    $messages = \CRM_Core_TokenSmarty::render(
+      ['text' => 'Go to {event.title}!'],
+      ['participantId' => $participantId]
+    );
+    $this->assertEquals('Go to Annual CiviCRM meet!', $messages['text']);
+  }
+
+  public function testParticipant_ExplicitEvent() {
+    $participantId = $this->participantCreate();
+    $otherEventId = $this->eventCreate(['title' => 'Alternate Event'])['id'];
+
+    $messages = \CRM_Core_TokenSmarty::render(
+      ['text' => 'You may also like {event.title}!'],
+      ['participantId' => $participantId, 'eventId' => $otherEventId]
+    );
+    $this->assertEquals('You may also like Alternate Event!', $messages['text']);
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------

This patch addresses bug report https://lab.civicrm.org/dev/core/-/issues/2947 by revisiting some elements #21821.

CC @eileenmcnaughton @magnolia61 

Before
----------------------------------------

* When generating a PDF for a participants, the `{event.*}` tokens don't work.
* The `{event.*}` and `{participant.*}` tokens key off of independent inputs (`$context['eventId']` and `$context['participantId']`). Only `participantId` is supplied for the PDF.

After
----------------------------------------

* When generating a PDF for a participants, the `{event.*}` tokens do work.
* The `{event.*}` and `{participant.*}` tokens may key off of independent inputs (`$context['eventId']` and `$context['participantId']`). However, if `eventId` is omitted, it will be filled automatically based on `participantId`.

Technical Details
----------------------------------------

This is roughly similar to how participant PDFs worked in some of the 5.43.alpha1 revisions (ie before #21821), although the implementation is slightly different. To my reading, it's a bit more thorough... e.g. it fills `eventId` during both `civi.token.list` and `civi.token.eval`; e.g. it supplies the `eventId` as part of the `context` so that it's available to any other listeners that consume `eventId`.

Adds test coverage.