### PR TITLE
[NFC] php8 - set smarty null defaults for CRM_Core_SessionTest

### DIFF
--- a/tests/phpunit/CRM/Core/SessionTest.php
+++ b/tests/phpunit/CRM/Core/SessionTest.php
@@ -8,6 +8,10 @@ class CRM_Core_SessionTest extends CiviUnitTestCase {
 
   public function setUp(): void {
     CRM_Core_Smarty::singleton()->clearTemplateVars();
+    // set null defaults
+    foreach (['infoOptions', 'infoType', 'infoMessage', 'infoTitle'] as $info) {
+      CRM_Core_Smarty::singleton()->assign($info, NULL);
+    }
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Sets null defaults so don't need isset/empty and then also php8 is happy.