### PR TITLE
APIv4 - Add backticks around fields in join criteria

### DIFF
--- a/Civi/Api4/Service/Schema/Joinable/Joinable.php
+++ b/Civi/Api4/Service/Schema/Joinable/Joinable.php
@@ -104,7 +104,7 @@ class Joinable {
    */
   public function getConditionsForJoin(string $baseTableAlias, string $tableAlias) {
     $baseCondition = sprintf(
-      '%s.%s =  %s.%s',
+      '`%s`.`%s` =  `%s`.`%s`',
       $baseTableAlias,
       $this->baseColumn,
       $tableAlias,


### PR DESCRIPTION
https://github.com/civicrm/civicrm-core/pull/22049 but on 5.44