### PR TITLE
5.43.1 - Bump version. Add notes.

### DIFF
--- a/ext/afform/admin/info.xml
+++ b/ext/afform/admin/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2020-01-09</releaseDate>
-  <version>5.43.0</version>
+  <version>5.43.1</version>
   <develStage>beta</develStage>
   <compatibility>
     <ver>5.23</ver>

--- a/ext/afform/core/info.xml
+++ b/ext/afform/core/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2020-01-09</releaseDate>
-  <version>5.43.0</version>
+  <version>5.43.1</version>
   <develStage>beta</develStage>
   <compatibility>
     <ver>5.23</ver>

--- a/ext/afform/html/info.xml
+++ b/ext/afform/html/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2020-01-09</releaseDate>
-  <version>5.43.0</version>
+  <version>5.43.1</version>
   <develStage>alpha</develStage>
   <compatibility>
     <ver>5.23</ver>

--- a/ext/afform/mock/info.xml
+++ b/ext/afform/mock/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2020-01-09</releaseDate>
-  <version>5.43.0</version>
+  <version>5.43.1</version>
   <tags>
     <tag>mgmt:hidden</tag>
   </tags>

--- a/ext/authx/info.xml
+++ b/ext/authx/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2021-02-11</releaseDate>
-  <version>5.43.0</version>
+  <version>5.43.1</version>
   <develStage>alpha</develStage>
   <compatibility>
     <ver>5.0</ver>

--- a/ext/ckeditor4/info.xml
+++ b/ext/ckeditor4/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">https://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2021-05-23</releaseDate>
-  <version>5.43.0</version>
+  <version>5.43.1</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>5.39</ver>

--- a/ext/contributioncancelactions/info.xml
+++ b/ext/contributioncancelactions/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2020-10-12</releaseDate>
-  <version>5.43.0</version>
+  <version>5.43.1</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>5.32</ver>

--- a/ext/eventcart/info.xml
+++ b/ext/eventcart/info.xml
@@ -13,7 +13,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2020-08-03</releaseDate>
-  <version>5.43.0</version>
+  <version>5.43.1</version>
   <tags>
     <tag>mgmt:hidden</tag>
   </tags>

--- a/ext/ewaysingle/info.xml
+++ b/ext/ewaysingle/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2020-10-07</releaseDate>
-  <version>5.43.0</version>
+  <version>5.43.1</version>
   <tags>
     <tag>mgmt:hidden</tag>
   </tags>

--- a/ext/financialacls/info.xml
+++ b/ext/financialacls/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2020-08-27</releaseDate>
-  <version>5.43.0</version>
+  <version>5.43.1</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>5.30</ver>

--- a/ext/flexmailer/info.xml
+++ b/ext/flexmailer/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2020-08-05</releaseDate>
-  <version>5.43.0</version>
+  <version>5.43.1</version>
   <develStage>stable</develStage>
   <comments>
     FlexMailer is an email delivery engine which replaces the internal guts

--- a/ext/greenwich/info.xml
+++ b/ext/greenwich/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2020-07-21</releaseDate>
-  <version>5.43.0</version>
+  <version>5.43.1</version>
   <tags>
     <tag>mgmt:hidden</tag>
   </tags>

--- a/ext/legacycustomsearches/info.xml
+++ b/ext/legacycustomsearches/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2021-07-25</releaseDate>
-  <version>5.43.0</version>
+  <version>5.43.1</version>
   <develStage>stable</develStage>
   <tags>
     <tag>mgmt:hidden</tag>

--- a/ext/message_admin/info.xml
+++ b/ext/message_admin/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2021-06-12</releaseDate>
-  <version>5.43.0</version>
+  <version>5.43.1</version>
   <tags>
     <tag>mgmt:hidden</tag>
   </tags>

--- a/ext/oauth-client/info.xml
+++ b/ext/oauth-client/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2020-10-23</releaseDate>
-  <version>5.43.0</version>
+  <version>5.43.1</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>5.38</ver>

--- a/ext/payflowpro/info.xml
+++ b/ext/payflowpro/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2021-04-13</releaseDate>
-  <version>5.43.0</version>
+  <version>5.43.1</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>5.0</ver>

--- a/ext/recaptcha/info.xml
+++ b/ext/recaptcha/info.xml
@@ -13,7 +13,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2021-04-03</releaseDate>
-  <version>5.43.0</version>
+  <version>5.43.1</version>
   <tags>
     <tag>mgmt:hidden</tag>
   </tags>

--- a/ext/search_kit/info.xml
+++ b/ext/search_kit/info.xml
@@ -14,7 +14,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2021-01-06</releaseDate>
-  <version>5.43.0</version>
+  <version>5.43.1</version>
   <develStage>beta</develStage>
   <compatibility>
     <ver>5.38</ver>

--- a/ext/sequentialcreditnotes/info.xml
+++ b/ext/sequentialcreditnotes/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2020-01-28</releaseDate>
-  <version>5.43.0</version>
+  <version>5.43.1</version>
   <tags>
     <tag>mgmt:hidden</tag>
   </tags>

--- a/release-notes.md
+++ b/release-notes.md
@@ -15,6 +15,15 @@ Other resources for identifying changes are:
     * https://github.com/civicrm/civicrm-joomla
     * https://github.com/civicrm/civicrm-wordpress
 
+## CiviCRM 5.43.1
+
+Released November 12, 2021
+
+- **[Synopsis](release-notes/5.43.1.md#synopsis)**
+- **[Bugs resolved](release-notes/5.43.1.md#bugs)**
+- **[Credits](release-notes/5.43.1.md#credits)**
+- **[Feedback](release-notes/5.43.1.md#feedback)**
+
 ## CiviCRM 5.43.0
 
 Released November 3, 2021

--- a/release-notes/5.43.1.md
+++ b/release-notes/5.43.1.md
@@ -1,0 +1,38 @@
+# CiviCRM 5.43.1
+
+Released November 11, 2021
+
+- **[Synopsis](#synopsis)**
+- **[Bugs resolved](#bugs)**
+- **[Credits](#credits)**
+- **[Feedback](#feedback)**
+
+## <a name="synopsis"></a>Synopsis
+
+| *Does this version...?*                                         |          |
+| --------------------------------------------------------------- | -------- |
+| Change the database schema?                                     | no       |
+| Alter the API?                                                  | no       |
+| Require attention to configuration options?                     | no       |
+| **Fix problems installing or upgrading to a previous version?** | **yes**  |
+| Introduce features?                                             | no       |
+| **Fix bugs?**                                                   | **yes**  |
+
+## <a name="bugs"></a>Bugs resolved
+
+* **_Upgrader_: Upgrader crashes when migrating some smart groups ([dev/core#2550](https://lab.civicrm.org/dev/core/-/issues/2550): [#21997](https://github.com/civicrm/civicrm-core/pull/21997))**
+* **_Maps_: Map link displays critical error ([dev/core#2942](https://lab.civicrm.org/dev/core/-/issues/2942): [#21980](https://github.com/civicrm/civicrm-core/pull/21980))**
+* **_CiviEvent_: `{event.*}` tokens do not render in PDFs for participants ([dev/core#2947](https://lab.civicrm.org/dev/core/-/issues/2947): [#22046](https://github.com/civicrm/civicrm-core/pull/22046))**
+
+## <a name="credits"></a>Credits
+
+This release was developed by the following authors and reviewers:
+
+Wikimedia Foundation - Eileen McNaughton; PeaceWorks Technology Solutions - Martin Hansen;
+JMA Consulting - Monish Deb, Seamus Lee; CiviCRM - Coleman Watts, Tim Otten; @treasurer
+
+## <a name="feedback"></a>Feedback
+
+These release notes are edited by Tim Otten and Andie Hunt.  If you'd like to
+provide feedback on them, please login to https://chat.civicrm.org/civicrm and
+contact `@agh1`.

--- a/sql/civicrm_generated.mysql
+++ b/sql/civicrm_generated.mysql
@@ -2869,7 +2869,7 @@ UNLOCK TABLES;
 LOCK TABLES `civicrm_domain` WRITE;
 /*!40000 ALTER TABLE `civicrm_domain` DISABLE KEYS */;
 INSERT INTO `civicrm_domain` (`id`, `name`, `description`, `version`, `contact_id`, `locales`, `locale_custom_strings`) VALUES
- (1,'Default Domain Name',NULL,'5.43.0',1,NULL,'a:1:{s:5:\"en_US\";a:0:{}}');
+ (1,'Default Domain Name',NULL,'5.43.1',1,NULL,'a:1:{s:5:\"en_US\";a:0:{}}');
 /*!40000 ALTER TABLE `civicrm_domain` ENABLE KEYS */;
 UNLOCK TABLES;
 

--- a/sql/test_data_second_domain.mysql
+++ b/sql/test_data_second_domain.mysql
@@ -963,4 +963,4 @@ INSERT INTO civicrm_navigation
 VALUES
     ( @domainID, CONCAT('civicrm/report/instance/', @instanceID,'&reset=1'), 'Mailing Detail Report', 'Mailing Detail Report', 'administer CiviMail', 'OR', @reportlastID, '1', NULL, @instanceID+2 );
 UPDATE civicrm_report_instance SET navigation_id = LAST_INSERT_ID() WHERE id = @instanceID;
-UPDATE civicrm_domain SET version = '5.43.0';
+UPDATE civicrm_domain SET version = '5.43.1';

--- a/xml/version.xml
+++ b/xml/version.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="iso-8859-1" ?>
 <version>
-  <version_no>5.43.0</version_no>
+  <version_no>5.43.1</version_no>
 </version>


### PR DESCRIPTION
NB: This references three fixes. The last one, https://github.com/civicrm/civicrm-core/pull/22050, has not been merged yet. Once that's merged, these notes should be accurate/ready.