### PR TITLE
Ensure contactTag is always set

### DIFF
--- a/CRM/Contact/Page/View/Summary.php
+++ b/CRM/Contact/Page/View/Summary.php
@@ -201,10 +201,8 @@ class CRM_Contact_Page_View_Summary extends CRM_Contact_Page_View {
     $defaults['contact_type_label'] = CRM_Contact_BAO_ContactType::contactTypePairs(TRUE, $contactType, ', ');
 
     // get contact tags
-    $contactTags = CRM_Core_BAO_EntityTag::getContactTags($this->_contactId);
-
-    if (!empty($contactTags)) {
-      $defaults['contactTag'] = $contactTags;
+    $defaults['contactTag'] = CRM_Core_BAO_EntityTag::getContactTags($this->_contactId);
+    if (!empty($defaults['contactTag'])) {
       $defaults['allTags'] = CRM_Core_BAO_Tag::getTagsUsedFor('civicrm_contact', FALSE);
     }
 

--- a/templates/CRM/Contact/Page/Inline/Basic.tpl
+++ b/templates/CRM/Contact/Page/Inline/Basic.tpl
@@ -5,13 +5,11 @@
          title="{ts}Edit Tags{/ts}">{ts}Tags{/ts}</a>
     </div>
     <div class="crm-content" id="tags">
-      {if !empty($contactTag)}
       {foreach from=$contactTag item=tagName key=tagId}
         <span class="crm-tag-item" {if !empty($allTags.$tagId.color)}style="background-color: {$allTags.$tagId.color}; color: {$allTags.$tagId.color|colorContrast};"{/if} title="{$allTags.$tagId.description|escape}">
           {$tagName}
         </span>
       {/foreach}
-      {/if}
     </div>
   </div>
   <div class="crm-summary-row">


### PR DESCRIPTION
Overview
----------------------------------------
Ensure contactTag is always set

Before
----------------------------------------
$contactTag` only assigned when not empty

After
----------------------------------------
$contactTag` always signed as an array

Technical Details
----------------------------------------
The pattern here is a bit interesting - the array `$defaults` is assigned to the template at it turns out the result of that is that each key is assigned to smarty as a variable. This turns out to be standard stock smarty - but I'm never observed this patter in CiviCRM before.

Comments
----------------------------------------