### PR TITLE
php8 - fix for breadcrumb fails during tests

### DIFF
--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -321,8 +321,13 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
     // let the constructor initialize this, should happen only once
     if (!isset(self::$_template)) {
       self::$_template = CRM_Core_Smarty::singleton();
-      self::$_template->ensureVariablesAreAssigned($this->expectedSmartyVariables);
     }
+    // Smarty $_template is a static var which persists between tests, so
+    // if something calls clearTemplateVars(), the static still exists but
+    // our ensured variables get blown away, so we need to set them even if
+    // it's already been initialized.
+    self::$_template->ensureVariablesAreAssigned($this->expectedSmartyVariables);
+
     // Workaround for CRM-15153 - give each form a reasonably unique css class
     $this->addClass(CRM_Utils_System::getClassName($this));
 

--- a/CRM/Core/Page.php
+++ b/CRM/Core/Page.php
@@ -139,8 +139,12 @@ class CRM_Core_Page {
     if (!isset(self::$_template)) {
       self::$_template = CRM_Core_Smarty::singleton();
       self::$_session = CRM_Core_Session::singleton();
-      self::$_template->ensureVariablesAreAssigned($this->expectedSmartyVariables);
     }
+    // Smarty $_template is a static var which persists between tests, so
+    // if something calls clearTemplateVars(), the static still exists but
+    // our ensured variables get blown away, so we need to set them even if
+    // it's already been initialized.
+    self::$_template->ensureVariablesAreAssigned($this->expectedSmartyVariables);
 
     // FIXME - why are we messing with 'snippet'? Why not just pass it directly into $this->_print?
     if (!empty($_REQUEST['snippet'])) {


### PR DESCRIPTION
Overview
----------------------------------------
breadcrumb appears to be unassigned even though it's one of the ensured vars

Before
----------------------------------------
Smarty is a static var that persists between tests. When clearTemplateVars() gets called by something then the next test doesn't reinit smarty, so the ensured vars have disappeared.

After
----------------------------------------
In lieu of fixing the static cling since that seems to cause other problems that aren't figured out yet, we just reassign the ensured vars every time, even if smarty has already been init'd.

Technical Details
----------------------------------------


Comments
----------------------------------------

