### PR TITLE
[NFC] php8 assign formTpl in HookTest test

### DIFF
--- a/tests/phpunit/CRM/Core/Page/HookTest.php
+++ b/tests/phpunit/CRM/Core/Page/HookTest.php
@@ -80,6 +80,7 @@ class CRM_Core_Page_HookTest extends CiviUnitTestCase {
         'preProcess' => [],
       ];
       $page = new $pageName();
+      $page->assign('formTpl', NULL);
       ob_start();
       $page->run();
       ob_end_clean();
@@ -116,6 +117,7 @@ class CRM_Core_Page_HookTest extends CiviUnitTestCase {
       // Reset the counters
       $this->hookCount = ['pageRun' => []];
       $page = new $pageName();
+      $page->assign('formTpl', NULL);
       ob_start();
       $page->run();
       ob_end_clean();


### PR DESCRIPTION
Overview
----------------------------------------
On my local the pagerun test passes fine and the buildform one fails but with a different smarty var, so I'm not sure what's different. Possibly it matters if you run the whole suite vs just the file but then that implies there's another problem somewhere - 🤷 

Let's see what happens here.