### PR TITLE
[NFC] ENsure that formTpl is assigned in CRM_Custom_Form_OptionTest

### DIFF
--- a/tests/phpunit/CRM/Custom/Form/OptionTest.php
+++ b/tests/phpunit/CRM/Custom/Form/OptionTest.php
@@ -22,6 +22,7 @@ class CRM_Custom_Form_OptionTest extends CiviUnitTestCase {
 
     // Run the form
     $form = new CRM_Custom_Form_Option();
+    $form->assign('formTpl', NULL);
     $form->controller = new CRM_Core_Controller_Simple('CRM_Custom_Form_Option', 'Custom Option');
 
     $form->set('id', $optionValue['id']);


### PR DESCRIPTION
Overview
----------------------------------------
Like https://github.com/civicrm/civicrm-core/pull/22061 but for the OptionTest

Before
----------------------------------------
Test fails in php8

After
----------------------------------------
test passes

ping @eileenmcnaughton @colemanw @demeritcowboy 