### PR TITLE
APIv4 - Opt-in more ManagedEntity types

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -2562,7 +2562,7 @@ SELECT contact_id
     foreach ($links as $refSpec) {
       /** @var $refSpec CRM_Core_Reference_Interface */
       $count = $refSpec->getReferenceCount($this);
-      if ($count['count'] != 0) {
+      if (!empty($count['count'])) {
         $counts[] = $count;
       }
     }

--- a/CRM/Core/Reference/Interface.php
+++ b/CRM/Core/Reference/Interface.php
@@ -31,7 +31,7 @@ interface CRM_Core_Reference_Interface {
    *
    * @param CRM_Core_DAO $targetDao
    *   The instance for which we want references.
-   * @return array
+   * @return array{type: string, count: int}|NULL
    *   a record describing the reference; must include the keys:
    *   - 'type': string (not necessarily unique)
    *   - 'count': int

--- a/Civi/Api4/ContactType.php
+++ b/Civi/Api4/ContactType.php
@@ -27,5 +27,6 @@ namespace Civi\Api4;
  */
 class ContactType extends Generic\DAOEntity {
   use Generic\Traits\OptionList;
+  use Generic\Traits\ManagedEntity;
 
 }

--- a/Civi/Api4/CustomField.php
+++ b/Civi/Api4/CustomField.php
@@ -19,5 +19,6 @@ namespace Civi\Api4;
  * @package Civi\Api4
  */
 class CustomField extends Generic\DAOEntity {
+  use Generic\Traits\ManagedEntity;
 
 }

--- a/Civi/Api4/CustomGroup.php
+++ b/Civi/Api4/CustomGroup.php
@@ -19,5 +19,6 @@ namespace Civi\Api4;
  * @package Civi\Api4
  */
 class CustomGroup extends Generic\DAOEntity {
+  use Generic\Traits\ManagedEntity;
 
 }

--- a/Civi/Api4/Membership.php
+++ b/Civi/Api4/Membership.php
@@ -18,6 +18,5 @@ namespace Civi\Api4;
  * @package Civi\Api4
  */
 class Membership extends Generic\DAOEntity {
-  use Generic\Traits\OptionList;
 
 }

--- a/Civi/Api4/MembershipStatus.php
+++ b/Civi/Api4/MembershipStatus.php
@@ -19,5 +19,6 @@ namespace Civi\Api4;
  */
 class MembershipStatus extends Generic\DAOEntity {
   use Generic\Traits\OptionList;
+  use Generic\Traits\ManagedEntity;
 
 }

--- a/Civi/Api4/MembershipType.php
+++ b/Civi/Api4/MembershipType.php
@@ -19,5 +19,6 @@ namespace Civi\Api4;
  */
 class MembershipType extends Generic\DAOEntity {
   use Generic\Traits\OptionList;
+  use Generic\Traits\ManagedEntity;
 
 }

--- a/Civi/Api4/OptionGroup.php
+++ b/Civi/Api4/OptionGroup.php
@@ -20,5 +20,6 @@ namespace Civi\Api4;
  */
 class OptionGroup extends Generic\DAOEntity {
   use Generic\Traits\OptionList;
+  use Generic\Traits\ManagedEntity;
 
 }

--- a/Civi/Api4/OptionValue.php
+++ b/Civi/Api4/OptionValue.php
@@ -20,5 +20,6 @@ namespace Civi\Api4;
  */
 class OptionValue extends Generic\DAOEntity {
   use Generic\Traits\OptionList;
+  use Generic\Traits\ManagedEntity;
 
 }

--- a/Civi/Api4/PaymentProcessorType.php
+++ b/Civi/Api4/PaymentProcessorType.php
@@ -21,5 +21,6 @@ namespace Civi\Api4;
  */
 class PaymentProcessorType extends Generic\DAOEntity {
   use Generic\Traits\OptionList;
+  use Generic\Traits\ManagedEntity;
 
 }

--- a/Civi/Api4/RelationshipType.php
+++ b/Civi/Api4/RelationshipType.php
@@ -21,5 +21,6 @@ namespace Civi\Api4;
  */
 class RelationshipType extends Generic\DAOEntity {
   use Generic\Traits\OptionList;
+  use Generic\Traits\ManagedEntity;
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Adds the `ManagedEntity` trait to a number of entities that are commonly used for configuration, making it possible to work with them as APIv4 managed entities. This builds on the work done in #21955 and #21989.
