### PR TITLE
Do not check is context is set, should always be

### DIFF
--- a/templates/CRM/Contact/Form/Edit/TagsAndGroups.tpl
+++ b/templates/CRM/Contact/Form/Edit/TagsAndGroups.tpl
@@ -12,7 +12,7 @@
   <div class="crm-accordion-header">{$title}</div>
   <div class="crm-accordion-body" id="tagGroup">
 {/if}
-    <table class="form-layout-compressed{if isset($context) && $context EQ 'profile'} crm-profile-tagsandgroups{/if}">
+    <table class="form-layout-compressed{if $context EQ 'profile'} crm-profile-tagsandgroups{/if}">
       <tr>
         {if empty($type) || $type eq 'tag'}
           <td>
@@ -20,7 +20,7 @@
               {if !empty($title)}{$form.tag.label}<br>{/if}
               {$form.tag.html}
             </div>
-            {if !isset($context) || $context NEQ 'profile'}
+            {if $context NEQ 'profile'}
               {include file="CRM/common/Tagset.tpl"}
             {/if}
           </td>

--- a/templates/CRM/Form/attachmentjs.tpl
+++ b/templates/CRM/Form/attachmentjs.tpl
@@ -15,7 +15,7 @@
         request.done(function() {
           $el.trigger('crmPopupFormSuccess');
           $row.remove();
-          {/literal}{if isset($context) and $context EQ 'MessageTemplate'}{literal}
+          {/literal}{if $context EQ 'MessageTemplate'}{literal}
             $('#file_id').show();
           {/literal}{/if}{literal}
         });


### PR DESCRIPTION
Overview
----------------------------------------
Do not check is context is set, should always be

Before
----------------------------------------
We've added `$context` to 'always assigned - but still have isset checks

After
----------------------------------------
no longer checking....

Technical Details
----------------------------------------

Comments
----------------------------------------
