### PR TITLE
dev/drupal#169 - Fix for session_id() change in Drupal 9.2

### DIFF
--- a/CRM/Core/Key.php
+++ b/CRM/Core/Key.php
@@ -67,7 +67,7 @@ class CRM_Core_Key {
       $session = CRM_Core_Session::singleton();
       self::$_sessionID = $session->get('qfSessionID');
       if (!self::$_sessionID) {
-        self::$_sessionID = session_id();
+        self::$_sessionID = CRM_Core_Config::singleton()->userSystem->getSessionId();
         $session->set('qfSessionID', self::$_sessionID);
       }
     }

--- a/CRM/Utils/System/Base.php
+++ b/CRM/Utils/System/Base.php
@@ -1020,6 +1020,15 @@ abstract class CRM_Utils_System_Base {
   }
 
   /**
+   * This exists because of https://www.drupal.org/node/3006306 where
+   * they changed so that they don't start sessions for anonymous, but we
+   * want that.
+   */
+  public function getSessionId() {
+    return session_id();
+  }
+
+  /**
    * Get role names
    *
    * @return array|null

--- a/CRM/Utils/System/Drupal8.php
+++ b/CRM/Utils/System/Drupal8.php
@@ -849,6 +849,20 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
   }
 
   /**
+   * @inheritdoc
+   */
+  public function getSessionId() {
+    if (\Drupal::hasContainer()) {
+      $session = \Drupal::service('session');
+      if (!$session->has('civicrm.tempstore.sessionid')) {
+        $session->set('civicrm.tempstore.sessionid', \Drupal\Component\Utility\Crypt::randomBytesBase64());
+      }
+      return $session->get('civicrm.tempstore.sessionid');
+    }
+    return '';
+  }
+
+  /**
    * Load the user object.
    *
    * @param int $userID


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/drupal/-/issues/169

It's described well in the ticket but briefly Drupal 9.2 now tries to avoid making sessions for anonymous, so using session_id() is unreliable and can return the empty string.

Before
----------------------------------------
Clicking on a link to contribution page as anonymous if you're not already clicking around the site will then fail when you try to submit the form with "Your browser session has expired".

After
----------------------------------------
Ok

Technical Details
----------------------------------------
It's best described in the ticket and https://www.drupal.org/node/3006306, which is also where I stole the session id generation code from.

There are other uses of session_id() in core but I've left them out here, also as described in the ticket. They aren't important.

Comments
----------------------------------------
I haven't tested this on Drupal 8 - it's technically end-of-life but of course there might still be sites using it. However the functions involved all seem to be identical.