### PR TITLE
[NFC] Add missing calls to parent::setUp and tearDown in unit tests

### DIFF
--- a/tests/phpunit/CRM/Activity/Form/ActivityViewTest.php
+++ b/tests/phpunit/CRM/Activity/Form/ActivityViewTest.php
@@ -16,6 +16,7 @@ class CRM_Activity_Form_ActivityViewTest extends CiviUnitTestCase {
       'civicrm_activity_contact',
     ];
     $this->quickCleanup($tablesToTruncate);
+    parent::tearDown();
   }
 
   /**

--- a/tests/phpunit/CRM/Activity/Form/SearchTest.php
+++ b/tests/phpunit/CRM/Activity/Form/SearchTest.php
@@ -21,6 +21,7 @@ class CRM_Activity_Form_SearchTest extends CiviUnitTestCase {
       'civicrm_activity_contact',
     ];
     $this->quickCleanup($tablesToTruncate);
+    parent::tearDown();
   }
 
   /**

--- a/tests/phpunit/CRM/Contact/BAO/ActivitySearchTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/ActivitySearchTest.php
@@ -98,6 +98,7 @@ class CRM_Contact_BAO_ActivitySearchTest extends CiviUnitTestCase {
     if (!empty($type['count'])) {
       $this->callAPISuccess('option_value', 'delete', ['id' => $this->test_activity_type_id]);
     }
+    parent::tearDown();
   }
 
   /**

--- a/tests/phpunit/CRM/Contact/BAO/ContactType/ContactTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/ContactType/ContactTest.php
@@ -56,6 +56,7 @@ class CRM_Contact_BAO_ContactType_ContactTest extends CiviUnitTestCase {
 DELETE FROM civicrm_contact_type
       WHERE name IN ('{$this->student}','{$this->parent}','{$this->sponsor}', '{$this->team}');";
     CRM_Core_DAO::executeQuery($query);
+    parent::tearDown();
   }
 
   /**

--- a/tests/phpunit/CRM/Contact/BAO/ContactType/RelationshipTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/ContactType/RelationshipTest.php
@@ -86,6 +86,7 @@ DELETE FROM civicrm_contact_type
       WHERE name IN ('{$this->student}','{$this->parent}','{$this->sponsor}');
     ";
     CRM_Core_DAO::executeQuery($query);
+    parent::tearDown();
   }
 
   /**

--- a/tests/phpunit/CRM/Contact/BAO/GroupTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/GroupTest.php
@@ -27,6 +27,7 @@ class CRM_Contact_BAO_GroupTest extends CiviUnitTestCase {
    */
   protected function tearDown(): void {
     $this->quickCleanup(['civicrm_mapping_field', 'civicrm_mapping', 'civicrm_group', 'civicrm_saved_search']);
+    parent::tearDown();
   }
 
   /**

--- a/tests/phpunit/CRM/Contact/BAO/SavedSearchTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/SavedSearchTest.php
@@ -40,6 +40,7 @@ class CRM_Contact_BAO_SavedSearchTest extends CiviUnitTestCase {
       'civicrm_custom_field',
       'civicrm_custom_group',
     ]);
+    parent::tearDown();
   }
 
   /**

--- a/tests/phpunit/CRM/Contact/Page/View/UserDashBoardTest.php
+++ b/tests/phpunit/CRM/Contact/Page/View/UserDashBoardTest.php
@@ -52,6 +52,7 @@ class CRM_Contact_Page_View_UserDashBoardTest extends CiviUnitTestCase {
     CRM_Core_Session::singleton()->reset();
     CRM_Core_Smarty::singleton()->clearTemplateVars();
     $this->callAPISuccess('Contact', 'delete', ['id' => $this->contactID]);
+    parent::tearDown();
   }
 
   /**

--- a/tests/phpunit/CRM/Contribute/BAO/ContributionTypeTest.php
+++ b/tests/phpunit/CRM/Contribute/BAO/ContributionTypeTest.php
@@ -22,6 +22,7 @@ class CRM_Contribute_BAO_ContributionTypeTest extends CiviUnitTestCase {
 
   public function tearDown(): void {
     $this->financialAccountDelete('Donations');
+    parent::tearDown();
   }
 
   /**

--- a/tests/phpunit/CRM/Contribute/Form/Contribution/ConfirmTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/Contribution/ConfirmTest.php
@@ -25,6 +25,7 @@ class CRM_Contribute_Form_Contribution_ConfirmTest extends CiviUnitTestCase {
    */
   public function tearDown(): void {
     $this->quickCleanUpFinancialEntities();
+    parent::tearDown();
   }
 
   /**

--- a/tests/phpunit/CRM/Contribute/Form/ContributionPageTranslationTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/ContributionPageTranslationTest.php
@@ -28,6 +28,7 @@ class CRM_Contribute_Form_ContributionPageTranslationTest extends CiviUnitTestCa
     if ($dbLocale) {
       CRM_Core_I18n_Schema::makeSinglelingual('en_US');
     }
+    parent::tearDown();
   }
 
   /**

--- a/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
@@ -126,6 +126,7 @@ class CRM_Contribute_Form_ContributionTest extends CiviUnitTestCase {
   public function tearDown(): void {
     $this->quickCleanUpFinancialEntities();
     $this->quickCleanup(['civicrm_note', 'civicrm_uf_match', 'civicrm_address']);
+    parent::tearDown();
   }
 
   /**

--- a/tests/phpunit/CRM/Contribute/Form/Task/StatusTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/Task/StatusTest.php
@@ -22,6 +22,7 @@ class CRM_Contribute_Form_Task_StatusTest extends CiviUnitTestCase {
   public function tearDown(): void {
     $this->quickCleanUpFinancialEntities();
     CRM_Utils_Hook::singleton()->reset();
+    parent::tearDown();
   }
 
   /**

--- a/tests/phpunit/CRM/Core/BAO/LocationTest.php
+++ b/tests/phpunit/CRM/Core/BAO/LocationTest.php
@@ -45,6 +45,7 @@ class CRM_Core_BAO_LocationTest extends CiviUnitTestCase {
       'civicrm_loc_block',
     ];
     $this->quickCleanup($tablesToTruncate);
+    parent::tearDown();
   }
 
   public function testCreateWithMissingParams() {

--- a/tests/phpunit/CRM/Core/Payment/AuthorizeNetTest.php
+++ b/tests/phpunit/CRM/Core/Payment/AuthorizeNetTest.php
@@ -33,6 +33,7 @@ class CRM_Core_Payment_AuthorizeNetTest extends CiviUnitTestCase {
 
   public function tearDown(): void {
     $this->quickCleanUpFinancialEntities();
+    parent::tearDown();
   }
 
   /**

--- a/tests/phpunit/CRM/Core/Payment/BaseIPNTest.php
+++ b/tests/phpunit/CRM/Core/Payment/BaseIPNTest.php
@@ -100,6 +100,7 @@ class CRM_Core_Payment_BaseIPNTest extends CiviUnitTestCase {
   public function tearDown(): void {
     $this->quickCleanUpFinancialEntities();
     CRM_Member_PseudoConstant::membershipStatus(NULL, NULL, 'name', TRUE);
+    parent::tearDown();
   }
 
   /**

--- a/tests/phpunit/CRM/Core/Payment/PayPalProIPNTest.php
+++ b/tests/phpunit/CRM/Core/Payment/PayPalProIPNTest.php
@@ -49,6 +49,7 @@ class CRM_Core_Payment_PayPalProIPNTest extends CiviUnitTestCase {
    */
   public function tearDown(): void {
     $this->quickCleanUpFinancialEntities();
+    parent::tearDown();
   }
 
   /**

--- a/tests/phpunit/CRM/Core/SessionTest.php
+++ b/tests/phpunit/CRM/Core/SessionTest.php
@@ -7,6 +7,7 @@
 class CRM_Core_SessionTest extends CiviUnitTestCase {
 
   public function setUp(): void {
+    parent::setUp();
     CRM_Core_Smarty::singleton()->clearTemplateVars();
     // set null defaults
     foreach (['infoOptions', 'infoType', 'infoMessage', 'infoTitle'] as $info) {

--- a/tests/phpunit/CRM/Event/BAO/AdditionalPaymentTest.php
+++ b/tests/phpunit/CRM/Event/BAO/AdditionalPaymentTest.php
@@ -43,6 +43,7 @@ class CRM_Event_BAO_AdditionalPaymentTest extends CiviUnitTestCase {
   public function tearDown(): void {
     $this->eventDelete($this->_eventId);
     $this->quickCleanUpFinancialEntities();
+    parent::tearDown();
   }
 
   /**

--- a/tests/phpunit/CRM/Event/BAO/ChangeFeeSelectionTest.php
+++ b/tests/phpunit/CRM/Event/BAO/ChangeFeeSelectionTest.php
@@ -81,6 +81,7 @@ class CRM_Event_BAO_ChangeFeeSelectionTest extends CiviUnitTestCase {
   public function tearDown(): void {
     $this->eventDelete($this->_eventId);
     $this->quickCleanUpFinancialEntities();
+    parent::tearDown();
   }
 
   /**

--- a/tests/phpunit/CRM/Financial/BAO/FinancialTypeTest.php
+++ b/tests/phpunit/CRM/Financial/BAO/FinancialTypeTest.php
@@ -26,6 +26,7 @@ class CRM_Financial_BAO_FinancialTypeTest extends CiviUnitTestCase {
       CRM_Core_I18n_Schema::makeSinglelingual('en_US');
     }
     $this->financialAccountDelete('Donations');
+    parent::tearDown();
   }
 
   /**

--- a/tests/phpunit/CRM/Mailing/BAO/QueryTest.php
+++ b/tests/phpunit/CRM/Mailing/BAO/QueryTest.php
@@ -29,6 +29,7 @@ class CRM_Mailing_BAO_QueryTest extends CiviUnitTestCase {
       'civicrm_contact',
     ];
     $this->quickCleanup($tablesToTruncate);
+    parent::tearDown();
   }
 
   /**

--- a/tests/phpunit/CRM/Member/BAO/MembershipTypeTest.php
+++ b/tests/phpunit/CRM/Member/BAO/MembershipTypeTest.php
@@ -45,6 +45,7 @@ class CRM_Member_BAO_MembershipTypeTest extends CiviUnitTestCase {
     $this->membershipStatusDelete($this->_membershipStatusID);
     $this->contactDelete($this->_orgContactID);
     $this->contactDelete($this->_indiviContactID);
+    parent::tearDown();
   }
 
   /**

--- a/tests/phpunit/CRM/Member/Form/MembershipRenewalTest.php
+++ b/tests/phpunit/CRM/Member/Form/MembershipRenewalTest.php
@@ -130,6 +130,7 @@ class CRM_Member_Form_MembershipRenewalTest extends CiviUnitTestCase {
       $this->callAPISuccess('contact', 'delete', ['id' => $contactID, 'skip_undelete' => TRUE]);
     }
     CRM_Utils_Time::resetTime();
+    parent::tearDown();
   }
 
   /**

--- a/tests/phpunit/CRM/Member/Form/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/Form/MembershipTest.php
@@ -171,6 +171,7 @@ class CRM_Member_Form_MembershipTest extends CiviUnitTestCase {
     );
     $this->callAPISuccess('Contact', 'delete', ['id' => $this->ids['contact']['organization'], 'skip_undelete' => TRUE]);
     $this->callAPISuccess('RelationshipType', 'delete', ['id' => $this->ids['relationship_type']['member']]);
+    parent::tearDown();
   }
 
   /**

--- a/tests/phpunit/CRM/Member/Form/Task/BatchTest.php
+++ b/tests/phpunit/CRM/Member/Form/Task/BatchTest.php
@@ -27,6 +27,7 @@ class CRM_Member_Form_Task_BatchTest extends CiviUnitTestCase {
     $this->validateAllContributions();
     $this->validateAllPayments();
     $this->quickCleanUpFinancialEntities();
+    parent::tearDown();
   }
 
   /**

--- a/tests/phpunit/CRM/Member/Form/Task/PDFLetterTest.php
+++ b/tests/phpunit/CRM/Member/Form/Task/PDFLetterTest.php
@@ -22,6 +22,7 @@ class CRM_Member_Form_Task_PDFLetterTest extends CiviUnitTestCase {
   public function tearDown(): void {
     $this->quickCleanUpFinancialEntities();
     CRM_Utils_Hook::singleton()->reset();
+    parent::tearDown();
   }
 
   /**

--- a/tests/phpunit/CRM/Member/Import/Parser/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/Import/Parser/MembershipTest.php
@@ -108,6 +108,7 @@ class CRM_Member_Import_Parser_MembershipTest extends CiviUnitTestCase {
     $this->membershipTypeDelete(['id' => $this->_membershipTypeID]);
     $this->membershipStatusDelete($this->_mebershipStatusID);
     $this->quickCleanup($tablesToTruncate, TRUE);
+    parent::tearDown();
   }
 
   /**

--- a/tests/phpunit/CRM/Queue/Queue/SqlTest.php
+++ b/tests/phpunit/CRM/Queue/Queue/SqlTest.php
@@ -49,6 +49,7 @@ class CRM_Queue_Queue_SqlTest extends CiviUnitTestCase {
 
     $tablesToTruncate = ['civicrm_queue_item'];
     $this->quickCleanup($tablesToTruncate);
+    parent::tearDown();
   }
 
   /**

--- a/tests/phpunit/CRM/Queue/QueueTest.php
+++ b/tests/phpunit/CRM/Queue/QueueTest.php
@@ -52,6 +52,7 @@ class CRM_Queue_QueueTest extends CiviUnitTestCase {
 
     $tablesToTruncate = ['civicrm_queue_item'];
     $this->quickCleanup($tablesToTruncate);
+    parent::tearDown();
   }
 
   /**

--- a/tests/phpunit/CRM/Queue/RunnerTest.php
+++ b/tests/phpunit/CRM/Queue/RunnerTest.php
@@ -33,6 +33,7 @@ class CRM_Queue_RunnerTest extends CiviUnitTestCase {
 
     $tablesToTruncate = ['civicrm_queue_item'];
     $this->quickCleanup($tablesToTruncate);
+    parent::tearDown();
   }
 
   public function testRunAllNormal() {

--- a/tests/phpunit/CRM/Utils/Migrate/ImportExportTest.php
+++ b/tests/phpunit/CRM/Utils/Migrate/ImportExportTest.php
@@ -12,6 +12,7 @@ class CRM_Utils_Migrate_ImportExportTest extends CiviUnitTestCase {
       'civicrm_custom_field',
     ];
     $this->quickCleanup($tablesToTruncate, TRUE);
+    parent::tearDown();
   }
 
   /**

--- a/tests/phpunit/Civi/Test/ExampleHookTest.php
+++ b/tests/phpunit/Civi/Test/ExampleHookTest.php
@@ -31,6 +31,7 @@ class ExampleHookTest extends \PHPUnit\Framework\TestCase implements HeadlessInt
   }
 
   protected function setUp(): void {
+    parent::setUp();
     $this->contact = \CRM_Core_DAO::createTestObject('CRM_Contact_DAO_Contact', [
       'contact_type' => 'Individual',
     ]);
@@ -41,6 +42,7 @@ class ExampleHookTest extends \PHPUnit\Framework\TestCase implements HeadlessInt
 
   protected function tearDown(): void {
     $this->contact->delete();
+    parent::tearDown();
   }
 
   /**

--- a/tests/phpunit/Civi/Test/ExampleSubscriberTest.php
+++ b/tests/phpunit/Civi/Test/ExampleSubscriberTest.php
@@ -30,6 +30,7 @@ class ExampleSubscriberTest extends \PHPUnit\Framework\TestCase implements Headl
   }
 
   protected function setUp(): void {
+    parent::setUp();
     $this->contact = \CRM_Core_DAO::createTestObject('CRM_Contact_DAO_Contact', [
       'contact_type' => 'Individual',
     ]);
@@ -40,6 +41,7 @@ class ExampleSubscriberTest extends \PHPUnit\Framework\TestCase implements Headl
 
   protected function tearDown(): void {
     $this->contact->delete();
+    parent::tearDown();
   }
 
   public static function getSubscribedEvents() {

--- a/tests/phpunit/Civi/Test/ExampleTransactionalTest.php
+++ b/tests/phpunit/Civi/Test/ExampleTransactionalTest.php
@@ -22,6 +22,7 @@ class ExampleTransactionalTest extends \PHPUnit\Framework\TestCase implements He
   }
 
   protected function setUp(): void {
+    parent::setUp();
     /** @var \CRM_Contact_DAO_Contact $contact */
     $contact = \CRM_Core_DAO::createTestObject('CRM_Contact_DAO_Contact', [
       'contact_type' => 'Individual',

--- a/tests/phpunit/CiviTest/CiviCaseTestCase.php
+++ b/tests/phpunit/CiviTest/CiviCaseTestCase.php
@@ -114,6 +114,7 @@ class CiviCaseTestCase extends CiviUnitTestCase {
     $this->customDirectories(array('template_path' => FALSE));
     $this->quickCleanup($this->tablesToTruncate, TRUE);
     CRM_Case_XMLRepository::singleton(TRUE);
+    parent::tearDown();
   }
 
   /**

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -354,6 +354,7 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
    *  Common setup functions for all unit tests.
    */
   protected function setUp(): void {
+    parent::setUp();
     $session = CRM_Core_Session::singleton();
     $session->set('userID', NULL);
 
@@ -555,6 +556,7 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
     // classes frees memory as they are not otherwise unset until the
     // very end.
     unset($this->mut);
+    parent::tearDown();
   }
 
   /**

--- a/tests/phpunit/E2E/Core/PrevNextTest.php
+++ b/tests/phpunit/E2E/Core/PrevNextTest.php
@@ -41,6 +41,7 @@ class PrevNextTest extends \CiviEndToEndTestCase {
   protected function tearDown(): void {
     \Civi::service('prevnext')->deleteItem(NULL, $this->cacheKey);
     \Civi::service('prevnext')->deleteItem(NULL, $this->cacheKeyB);
+    parent::tearDown();
   }
 
   public function testFillSql() {

--- a/tests/phpunit/E2E/Extern/SoapTest.php
+++ b/tests/phpunit/E2E/Extern/SoapTest.php
@@ -31,6 +31,7 @@ class E2E_Extern_SoapTest extends CiviEndToEndTestCase {
   public $adminPass;
 
   public function setUp(): void {
+    parent::setUp();
     CRM_Core_Config::singleton(1, 1);
 
     global $_CV;

--- a/tests/phpunit/api/v4/Traits/OptionCleanupTrait.php
+++ b/tests/phpunit/api/v4/Traits/OptionCleanupTrait.php
@@ -31,6 +31,7 @@ trait OptionCleanupTrait {
   protected $optionValueMaxId;
 
   public function setUp(): void {
+    parent::setUp();
     $this->optionGroupMaxId = \CRM_Core_DAO::singleValueQuery('SELECT MAX(id) FROM civicrm_option_group');
     $this->optionValueMaxId = \CRM_Core_DAO::singleValueQuery('SELECT MAX(id) FROM civicrm_option_value');
   }
@@ -42,6 +43,7 @@ trait OptionCleanupTrait {
     if ($this->optionGroupMaxId) {
       \CRM_Core_DAO::executeQuery('DELETE FROM civicrm_option_group WHERE id > ' . $this->optionGroupMaxId);
     }
+    parent::tearDown();
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
You'll notice api3 is missing. Adding the missing calls there causes fails. Not sure if I want to follow up on that since it wasn't what I was looking for.

Normally I'd split this up but it's entirely test files.