### PR TITLE
[REF] dev/drupal#169 Replace other usages of session_id with CRM_Core…

### DIFF
--- a/CRM/Core/IDS.php
+++ b/CRM/Core/IDS.php
@@ -237,13 +237,14 @@ class CRM_Core_IDS {
 
     $data = [];
     $session = CRM_Core_Session::singleton();
+    $session_id = CRM_Core_Config::singleton()->userSystem->getSessionId() ? CRM_Core_Config::singleton()->userSystem->getSessionId() : '0';
     foreach ($result as $event) {
       $data[] = [
         'name' => $event->getName(),
         'value' => stripslashes($event->getValue()),
         'page' => $_SERVER['REQUEST_URI'],
         'userid' => $session->get('userID'),
-        'session' => session_id() ? session_id() : '0',
+        'session' => $session_id,
         'ip' => $ip,
         'reaction' => $reaction,
         'impact' => $result->getImpact(),

--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -2478,7 +2478,7 @@ WHERE cg.extends IN ('" . implode("','", $this->_customGroupExtends) . "') AND
       $this->assign('chartEnabled', TRUE);
       $this->_chartId = "{$this->_params['charts']}_" .
         ($this->_id ? $this->_id : substr(get_class($this), 16)) . '_' .
-        session_id();
+        CRM_Core_Config::singleton()->userSystem->getSessionId();
       $this->assign('chartId', $this->_chartId);
     }
 


### PR DESCRIPTION
…_Config::singleton()->userSystem->getSessionId

Overview
----------------------------------------
As per the ticket this replaces other places in the code that call for session_id with the newly added function

Before
----------------------------------------
session_id function used

After
----------------------------------------
UserSystem getSessionId function used

ping @demeritcowboy @MegaphoneJon 