### PR TITLE
Use smarty:nodefaults with smarty.get

### DIFF
--- a/templates/CRM/Form/validate.tpl
+++ b/templates/CRM/Form/validate.tpl
@@ -9,7 +9,7 @@
 *}
 {* Initialize jQuery validate on a form *}
 {* Extra params and functions may be added to the CRM.validate object before this template is loaded *}
-{if empty($crm_form_validate_included) and ((isset($smarty.get.snippet) and $smarty.get.snippet neq 'json') or !isset($smarty.get.snippet)) and !empty($form) and !empty($form.formClass)}
+{if empty($crm_form_validate_included) && ((isset($smarty.get.snippet|smarty:nodefaults) && $smarty.get.snippet neq 'json') || !isset($smarty.get.snippet|smarty:nodefaults)) && !empty($form) && !empty($form.formClass)}
   {assign var=crm_form_validate_included value=1}
   {literal}
   <script type="text/javascript">


### PR DESCRIPTION
smarty.get is a special smary function to access _GET and I think the nodefaults is the only option
(ie we can't ensure it is set)

(I generally fix the &&  when I touch smarty since we normally use the php syntax where we can)