### PR TITLE
dev/core#2894 - Crash when viewing a contact with a website

### DIFF
--- a/CRM/Contact/Page/View/Summary.php
+++ b/CRM/Contact/Page/View/Summary.php
@@ -143,7 +143,7 @@ class CRM_Contact_Page_View_Summary extends CRM_Contact_Page_View {
       'age' => ['y' => '', 'm' => ''],
       'birth_date' => '',
       // for Website.tpl (the others don't seem to enotice for some reason).
-      'website' => '',
+      'website' => [],
     ];
 
     $params['id'] = $params['contact_id'] = $this->_contactId;


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/2894

Before
----------------------------------------
Create or view a contact that has a website -> Crash.

After
----------------------------------------
ok

Technical Details
----------------------------------------
Wrong default set at https://github.com/civicrm/civicrm-core/commit/d38a3b106c8cd3c1e57cece56c8fd789689513a8#diff-4a563c40e41149a946d34093d667fc77d4cdba5b6e2fa5c4676d33a6c9f9243fR146

It tries to access an array element under $defaults['website'] in order to set the value but it's a string.

Comments
----------------------------------------

