### PR TITLE
OptionValue - Fix incorrect update of `is_default`

### DIFF
--- a/CRM/Core/BAO/OptionValue.php
+++ b/CRM/Core/BAO/OptionValue.php
@@ -175,7 +175,9 @@ class CRM_Core_BAO_OptionValue extends CRM_Core_DAO_OptionValue {
     }
 
     // When setting a default option, unset other options in this group as default
-    if (!empty($params['is_default'])) {
+    // FIXME: The extra CRM_Utils_System::isNull is because the API will pass the string 'null'
+    // FIXME: It would help to make this column NOT NULL DEFAULT 0
+    if (!empty($params['is_default']) && !CRM_Utils_System::isNull($params['is_default'])) {
       $query = 'UPDATE civicrm_option_value SET is_default = 0 WHERE  option_group_id = %1';
 
       // tweak default reset, and allow multiple default within group.

--- a/tests/phpunit/api/v4/Entity/OptionValueTest.php
+++ b/tests/phpunit/api/v4/Entity/OptionValueTest.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+namespace api\v4\Entity;
+
+use api\v4\UnitTestCase;
+use Civi\Api4\OptionGroup;
+use Civi\Api4\OptionValue;
+use Civi\Test\TransactionalInterface;
+
+/**
+ * @group headless
+ */
+class OptionValueTest extends UnitTestCase implements TransactionalInterface {
+
+  public function testNullDefault() {
+    OptionGroup::create(FALSE)
+      ->addValue('name', 'myTestGroup')
+      ->addValue('title', 'myTestGroup')
+      ->execute();
+
+    $defaultId = OptionValue::create()
+      ->addValue('option_group_id.name', 'myTestGroup')
+      ->addValue('label', 'One')
+      ->addValue('value', 1)
+      ->addValue('is_default', TRUE)
+      ->execute()->first()['id'];
+
+    $this->assertTrue(OptionValue::get(FALSE)->addWhere('id', '=', $defaultId)->execute()->first()['is_default']);
+
+    // Now create a second option with is_default set to null.
+    // This should not interfere with the default setting in option one
+    OptionValue::create()
+      ->addValue('option_group_id.name', 'myTestGroup')
+      ->addValue('label', 'Two')
+      ->addValue('value', 2)
+      ->addValue('is_default', NULL)
+      ->execute();
+
+    $this->assertTrue(OptionValue::get(FALSE)->addWhere('id', '=', $defaultId)->execute()->first()['is_default']);
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a bug in the `OptionValue::save` API where other options in the group get incorrectly updated.

Technical Details
----------------------------------------
Checking `!empty($params['is_default'])` gave a false-positive for the string 'null'.

IMO we should consider making this column `NOT NULL DEFAULT 0`