### PR TITLE
APIv4 - Fix checkAccess for CiviCase or other entities with nonstandard class names

### DIFF
--- a/Civi/Api4/Generic/AbstractEntity.php
+++ b/Civi/Api4/Generic/AbstractEntity.php
@@ -52,7 +52,7 @@ abstract class AbstractEntity {
    * @return \Civi\Api4\Generic\CheckAccessAction
    */
   public static function checkAccess() {
-    return new CheckAccessAction(self::getEntityName(), __FUNCTION__);
+    return new CheckAccessAction(static::getEntityName(), __FUNCTION__);
   }
 
   /**
@@ -64,7 +64,7 @@ abstract class AbstractEntity {
     $permissions = \CRM_Core_Permission::getEntityActionPermissions();
 
     // For legacy reasons the permissions are keyed by lowercase entity name
-    $lcentity = \CRM_Core_DAO_AllCoreTables::convertEntityNameToLower(self::getEntityName());
+    $lcentity = \CRM_Core_DAO_AllCoreTables::convertEntityNameToLower(static::getEntityName());
     // Merge permissions for this entity with the defaults
     return ($permissions[$lcentity] ?? []) + $permissions['default'];
   }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes https://lab.civicrm.org/dev/core/-/issues/2950

Before
----------------------------------------
APIv4 mistakenly thinks the lowercase entity name is `'civi_case'` before applying permissions.

After
----------------------------------------
Correctly registers as `'case'` and permissions are correctly looked up.

Technical Details
---------------
The use of `self::getEntityName()` instead of `static::getEntityName()` was causing the overridden `Civi\Api4\CiviCase::getEntityName()` to be overlooked.
