### PR TITLE
Contribution amounts configuration page is borked when translation contains apostrophe

### DIFF
--- a/templates/CRM/Contribute/Form/ContributionPage/Amount.tpl
+++ b/templates/CRM/Contribute/Form/ContributionPage/Amount.tpl
@@ -291,7 +291,7 @@
      if ( !priceSetID ) {
        cj('#priceSet').hide();
        if (CRM.memberPriceset) {
-         cj(".crm-contribution-contributionpage-amount-form-block-amount_block_is_active td").html('<span class="description">{/literal}{ts}You cannot enable the Contribution Amounts section when a Membership Price Set is in use. (See the Memberships tab above.) Membership Price Sets may include additional fields for non-membership options that require an additional fee (e.g. magazine subscription) or an additional voluntary contribution.</span>{/ts}{literal}');
+         cj(".crm-contribution-contributionpage-amount-form-block-amount_block_is_active td").html('<span class="description">{/literal}{ts escape="js"}You cannot enable the Contribution Amounts section when a Membership Price Set is in use. (See the Memberships tab above.) Membership Price Sets may include additional fields for non-membership options that require an additional fee (e.g. magazine subscription) or an additional voluntary contribution.{/ts}{literal}</span>');
        }
      }
      cj('#amountFields').hide();


### PR DESCRIPTION
Overview
----------------------------------------
1. Switch the language to Italian.
2. Visit the config pages for a contribution page and go to the amounts tab.
3. The recurring section is all wonky and the datepicker is broken. The javascript console has errors.

Before
----------------------------------------
Can't properly use the contribution configuration page.

Error in javascript console:
```
Uncaught SyntaxError: missing ) after argument list
    jQuery 7
    refresh http://site.org/sites/all/modules/civicrm/js/crm.ajax.js?r2qefy:310
```

<img width="501" alt="Untitled" src="https://user-images.githubusercontent.com/2967821/142270749-a548d8db-6cf7-4a48-a71b-e267c099e20c.png">


After
----------------------------------------
ok

Technical Details
----------------------------------------
The {ts} is within javascript so needs js-escaping.

For the moment I've left the closing `</span>` within the ts so as not to break the translation, but the opening `<span>` is not inside the ts so there's a bit of a mismatch there.

Comments
----------------------------------------
@masetto Have you come across this? I was looking at the fix unit plurals PR and noticed this in Italian.
