### PR TITLE
[REF] Upgrade CKEditor to 4.17

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -172,7 +172,7 @@
         "ignore": [".*", "node_modules", "docs", "Gruntfile.js", "index.html", "package.json", "test"]
       },
       "ckeditor": {
-        "url": "https://github.com/ckeditor/ckeditor-releases/archive/4.16.2.zip"
+        "url": "https://github.com/ckeditor/ckeditor-releases/archive/4.17.1.zip"
       },
       "crossfilter-1.3.x": {
         "url": "https://github.com/crossfilter/crossfilter/archive/1.3.14.zip",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4743047a2c21f4a7299c2b23fef473d6",
+    "content-hash": "e9060ec676613c281267b190d808a479",
     "packages": [
         {
             "name": "adrienrn/php-mimetyper",


### PR DESCRIPTION
Overview
----------------------------------------
This upgrades CKEditor to 4.17

Before
----------------------------------------
4.16.2 used

After
----------------------------------------
4.17.0 is used

Release Notes are here https://ckeditor.com/cke4/release/CKEditor-4.17.0

ping @eileenmcnaughton @demeritcowboy @colemanw 
