### PR TITLE
EventChecker - Fix recent regression

### DIFF
--- a/Civi/Test/EventChecker.php
+++ b/Civi/Test/EventChecker.php
@@ -30,7 +30,7 @@ class EventChecker {
    *
    * @return $this
    */
-  public function start(\PHPUnit\Framework\Test $test) {
+  public function start($test) {
     if ($this->activeChecks === NULL) {
       $this->activeChecks = [];
       foreach ($this->findAll() as $template) {


### PR DESCRIPTION
Overview
--------

`civix` generates unit-tests from various templates. As part of the `civix` update-testing, it runs sundry tests with sundry versions of phpunit. This procedure is reporting a new failure in 5.43.0, which introduced `Civi/Test/EventChecker.php` as part of the execution of all unit-tests.

Before
------

In 5.43.0, when running `civix`'s `tests/make-example.sh`, it fails on one of the tests when using an older version of phpunit.

```
Fatal error: Uncaught TypeError: Argument 1 passed to Civi\Test\EventChecker::start() must implement interface PHPUnit\Framework\Test, instance of CRM_Civiexample_FooTest given, called in /Users/totten/bknix/build/dmaster/web/sites/all/modules/civicrm/Civi/Test/Legacy/CiviTestListener.php on line 60 and defined in /Users/totten/bknix/build/dmaster/web/sites/all/modules/civicrm/Civi/Test/EventChecker.php on line 33
```

After
-----

When running `civix`'s `tests/make-example.sh`, it passes with all tests.

Comment
-------

The type-hint is too strong -- the actual type-name depends on the version of phpunit. It is, of course, good
to have type-hints, and this preserves the softer `@param` hint.

Submitting to 5.44-rc because this is a recent regression. However, this mostly affects development processes, and I wouldn't be too bothered either way about whether to backport to 5.43-stable.