### PR TITLE
(dev/core#2962) get contact id for the mailing along with display nam…

### DIFF
--- a/CRM/Mailing/Event/BAO/Queue.php
+++ b/CRM/Mailing/Event/BAO/Queue.php
@@ -285,9 +285,10 @@ SELECT DISTINCT(civicrm_mailing_event_queue.contact_id) as contact_id,
     if ($dao->fetch()) {
       $displayName = $dao->display_name;
       $email = $dao->email;
+      $contact_id = $dao->contact_id;
     }
 
-    return [$displayName, $email];
+    return [$displayName, $email, $contact_id];
   }
 
   /**


### PR DESCRIPTION
…e and email

Overview
----------------------------------------
One would expect contact id to be returned here as well in _getContactInfo_ method in _CRM/Mailing/Event/BAO/Queue.php_ along with display name and email.

Before
----------------------------------------
no contact id available.

After
----------------------------------------
contact id exposed
