### PR TITLE
Fix two English strings

### DIFF
--- a/settings/Core.setting.php
+++ b/settings/Core.setting.php
@@ -375,7 +375,7 @@ return [
     'pseudoconstant' => [
       'callback' => 'CRM_Contact_BAO_GroupContactCache::getModes',
     ],
-    'description' => ts('Should the acl cache be by cron jobs or user actions'),
+    'description' => ts('Should the acl cache be flushed by cron jobs or user actions'),
     'help_text' => ts('In "Opportunistic Flush" mode, caches are flushed in response to user actions; this mode is broadly compatible but may add latency during form-submissions. In "Cron Flush" mode, you should schedule a cron job to flush caches if your site uses ACLs; this can improve latency on form-submissions but requires more setup.'),
   ],
   'installed' => [

--- a/templates/CRM/Report/Page/InstanceList.tpl
+++ b/templates/CRM/Report/Page/InstanceList.tpl
@@ -68,7 +68,11 @@
         {if !empty($myReports)}
           {ts}You do not have any private reports. To add a report to this section, edit the Report Settings for a report and set 'Add to My Reports' to Yes.{/ts} &nbsp;
         {else}
-          {ts 1=$compName}No %1 reports have been created.{/ts} &nbsp;
+          {if $compName}
+            {ts 1=$compName}No %1 reports have been created.{/ts} &nbsp;
+          {else}
+            {ts}No reports have been created.{/ts} &nbsp;
+          {/if}
           {if !empty($templateUrl)}
             {ts 1=$templateUrl}You can create reports by selecting from the <a href="%1">list of report templates here.</a>{/ts}
           {else}


### PR DESCRIPTION
Overview
----------------------------------------

Two rather trivial changes in English strings.

* Setting string: reported by r4zoli in the translation channel.
* Report string: it's an incorrect use of ts() to concatenate two strings. In French we would say "Aucun rapport « %1 » créé" because we can't assume the gender of %1, but when `compName`  is empty, then it looks silly, i.e. "Aucun rapport « %1 » créé" 