### PR TITLE
Fix dev/core#2959: some PDFs hard-code format to "a3 landscape", overriding default PDF format

### DIFF
--- a/CRM/Core/Page.php
+++ b/CRM/Core/Page.php
@@ -213,9 +213,7 @@ class CRM_Core_Page {
       CRM_Utils_Hook::alterContent($content, 'page', $pageTemplateFile, $this);
 
       if ($this->_print == CRM_Core_Smarty::PRINT_PDF) {
-        CRM_Utils_PDF_Utils::html2pdf($content, "{$this->_name}.pdf", FALSE,
-          ['paper_size' => 'a3', 'orientation' => 'landscape']
-        );
+        CRM_Utils_PDF_Utils::html2pdf($content, "{$this->_name}.pdf", FALSE);
       }
       elseif ($this->_print == CRM_Core_Smarty::PRINT_JSON) {
         $this->ajaxResponse['content'] = $content;


### PR DESCRIPTION
Overview
----------------------------------------
See the original issue at https://lab.civicrm.org/dev/core/-/issues/2959. In short: civicrm normally specifies default pdf format according to whatever is configured in the UI (if any). But in some cases it is hard-coded to use "A3 Landscape" -- e.g. when calling an existing CiviCRM URL with "?snippet=3" in order to generate a pdf. (We're doing this on some sites in order to print Event Participant Listings as PDF file.)

This happens because there's actually code in CiviCRM that says "use A3 Landscape", and this code is invoked in workflows like described above.

Before
----------------------------------------
1. Append "?snippet=3" to any civicrm url and observe that you're prompted to save a pdf file.
2. Open that pdf file and observe it has page size A3 and orientation Landscape. This is regardless of whatever default PDF format may be configured at /civicrm/admin/pdfFormats?reset=1

After
----------------------------------------
1. Append "?snippet=3" to any civicrm url and observe that you're prompted to save a pdf file.
2. Open that pdf file and observe it has page size, orientation, and other properties defined in the default PDF format configured at /civicrm/admin/pdfFormats?reset=1 (and if none is configured, then whatever defaults are hard-coded in CRM_Core_BAO_PdfFormat::$optionValueFields).

Tech details
----------------------------------------
Hard to guess why this code was written in the first place (esp. since it predates SVN-to-git migration, see it in [6a488035](https://github.com/twomice/civicrm-core/blob/6a488035/CRM/Core/Page.php#L183)). It seems fairly uncommon to keep A3 paper in the printer by default.

Comments
----------------------------------------
I've at least got a "sounds good" from @jaapjansma in the issue comments: https://lab.civicrm.org/dev/core/-/issues/2959#note_67495