### PR TITLE
dev/core#2927 - Avoid warnings for is_dir() when open_basedir is in effect

### DIFF
--- a/CRM/Admin/Page/APIExplorer.php
+++ b/CRM/Admin/Page/APIExplorer.php
@@ -63,7 +63,7 @@ class CRM_Admin_Page_APIExplorer extends CRM_Core_Page {
     $paths = self::uniquePaths();
     foreach ($paths as $path) {
       $dir = \CRM_Utils_File::addTrailingSlash($path) . 'api' . DIRECTORY_SEPARATOR . 'v3' . DIRECTORY_SEPARATOR . 'examples';
-      if (is_dir($dir)) {
+      if (\CRM_Utils_File::isDir($dir)) {
         foreach (scandir($dir) as $item) {
           if ($item && strpos($item, '.') === FALSE && array_search($item, $examples) === FALSE) {
             $examples[] = $item;
@@ -96,7 +96,7 @@ class CRM_Admin_Page_APIExplorer extends CRM_Core_Page {
       $paths = self::uniquePaths();
       foreach ($paths as $path) {
         $dir = \CRM_Utils_File::addTrailingSlash($path) . 'api' . DIRECTORY_SEPARATOR . 'v3' . DIRECTORY_SEPARATOR . 'examples' . DIRECTORY_SEPARATOR . $_GET['entity'];
-        if (is_dir($dir)) {
+        if (\CRM_Utils_File::isDir($dir)) {
           foreach (scandir($dir) as $item) {
             $item = str_replace('.ex.php', '', $item);
             if ($item && strpos($item, '.') === FALSE) {

--- a/CRM/Utils/File.php
+++ b/CRM/Utils/File.php
@@ -1103,4 +1103,49 @@ HTACCESS;
     return pathinfo($path, PATHINFO_EXTENSION);
   }
 
+  /**
+   * Wrapper for is_dir() to avoid flooding logs when open_basedir is used.
+   *
+   * Don't use this function as a swap-in replacement for is_dir() for all
+   * situations as this might silence errors that you want to know about
+   * and would help troubleshoot problems. It should only be used when
+   * doing something like iterating over a set of folders where you know some
+   * of them might not legitimately exist or might be outside open_basedir
+   * because you're trying to find the right one. If you expect the path you're
+   * checking to be inside open_basedir, then you should use the regular
+   * is_dir(). (e.g. it might not exist but might be something
+   * like a cache folder in templates_c, which can't be outside open_basedir,
+   * so there you would use regular is_dir).
+   *
+   * **** Security alert ****
+   * If you change this function so that it would be possible to return
+   * TRUE without checking the real value of is_dir() then it opens up a
+   * possible security issue.
+   * It should either return FALSE, or the value returned from is_dir().
+   *
+   * @param string|null $dir
+   * @return bool
+   */
+  public static function isDir(?string $dir): bool {
+    set_error_handler(function($errno, $errstr) {
+      // If this is open_basedir-related, convert it to an exception so we
+      // can catch it.
+      if (strpos($errstr, 'open_basedir restriction in effect') !== FALSE) {
+        throw new \ErrorException($errstr, $errno);
+      }
+      // Continue with normal error handling so other errors still happen.
+      return FALSE;
+    });
+    try {
+      $is_dir = is_dir($dir);
+    }
+    catch (\ErrorException $e) {
+      $is_dir = FALSE;
+    }
+    finally {
+      restore_error_handler();
+    }
+    return $is_dir;
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/2927

Alternate approach to https://github.com/civicrm/civicrm-core/pull/21923 and https://github.com/civicrm/civicrm-core/pull/21592

There are situations where you don't have control over open_basedir, and civi will sometimes iterate over folders trying to find something and will hit ones outside open_basedir. This produces lots of notices. This approach uses a local error-handler to silence only messages about open_basedir while still keeping all the functionality of the real is_dir.

Before
----------------------------------------
1. Set open_basedir to e.g. /var/www (something that contains enough to have all the files civi would normally access). Often include_path will include pear, which is usually outside that, so will suffice for testing purposes.
2. Restart web server.
3. For testing purposes visit /civicrm/api3.
4. Lots of notices on screen, assuming drupal 7 and you have error_reporting and drupal set to display php errors.

After
----------------------------------------
With this PR, you'll still get one notice because for demonstration purposes I've only replaced is_dir() in one file, but you won't see the other notices.

Technical Details
----------------------------------------
I believe this has an advantage over the previous approaches because (a) it only silences open_basedir, and (b) it doesn't require trying to duplicate some of the core php functionality.

Comments
----------------------------------------
Has test, which is largely based on php's own tests for is_dir. This should ensure that if somebody changes the new isDir function it should still conform to the same results as the real is_dir() except of course complaining about open_basedir.

As I've noted in the function comment, there are times when you DO want to know about this error, because you're expecting that the folder either should exist or be usable, and so it suggests something else is wrong and without the error it might be harder to track down or know something is wrong. So this function shouldn't be used everywhere is_dir() is used, just in places where you know it might legitimately be reaching outside open_basedir.