### PR TITLE
SearchKit - Fix default displays in Afforms and multiple displays per page

### DIFF
--- a/ext/search_kit/Civi/Search/AfformSearchMetadataInjector.php
+++ b/ext/search_kit/Civi/Search/AfformSearchMetadataInjector.php
@@ -32,10 +32,20 @@ class AfformSearchMetadataInjector {
           foreach (pq(implode(',', $displayTags), $doc) as $component) {
             $searchName = pq($component)->attr('search-name');
             $displayName = pq($component)->attr('display-name');
-            if ($searchName && $displayName) {
-              $display = \Civi\Api4\SearchDisplay::get(FALSE)
-                ->addWhere('name', '=', $displayName)
-                ->addWhere('saved_search_id.name', '=', $searchName)
+            if ($searchName) {
+              // Fetch search display if name is provided
+              if (is_string($displayName) && strlen($displayName)) {
+                $searchDisplayGet = \Civi\Api4\SearchDisplay::get(FALSE)
+                  ->addWhere('name', '=', $displayName)
+                  ->addWhere('saved_search_id.name', '=', $searchName);
+              }
+              // Fall-back to the default display
+              else {
+                $displayName = NULL;
+                $searchDisplayGet = \Civi\Api4\SearchDisplay::getDefault(FALSE)
+                  ->setSavedSearch($searchName);
+              }
+              $display = $searchDisplayGet
                 ->addSelect('settings', 'saved_search_id.api_entity', 'saved_search_id.api_params')
                 ->execute()->first();
               if ($display) {

--- a/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
+++ b/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
@@ -3,13 +3,6 @@
 
   // Trait provides base methods and properties common to all search display types
   angular.module('crmSearchDisplay').factory('searchDisplayBaseTrait', function(crmApi4) {
-    var ts = CRM.ts('org.civicrm.search_kit'),
-      runCount = 0;
-
-    // Get value from column data, specify either 'raw' or 'view'
-    function getValue(data, ret) {
-      return (data || {})[ret];
-    }
 
     // Return a base trait shared by all search display controllers
     // Gets mixed in using angular.extend()
@@ -20,6 +13,7 @@
       onChangeFilters: [],
       onPreRun: [],
       onPostRun: [],
+      _runCount: 0,
 
       // Called by the controller's $onInit function
       initializeDisplay: function($scope, $element) {
@@ -98,14 +92,14 @@
       // Call SearchDisplay.run and update ctrl.results and ctrl.rowCount
       runSearch: function(editedRow) {
         var ctrl = this,
-          requestId = ++runCount,
+          requestId = ++this._runCount,
           apiParams = this.getApiParams();
         this.loading = true;
         _.each(ctrl.onPreRun, function(callback) {
           callback.call(ctrl, apiParams);
         });
         return crmApi4('SearchDisplay', 'run', apiParams).then(function(results) {
-          if (requestId < runCount) {
+          if (requestId < ctrl._runCount) {
             return; // Another request started after this one
           }
           ctrl.results = results;
@@ -124,7 +118,7 @@
             callback.call(ctrl, results, 'success', editedRow);
           });
         }, function(error) {
-          if (requestId < runCount) {
+          if (requestId < ctrl._runCount) {
             return; // Another request started after this one
           }
           ctrl.results = [];


### PR DESCRIPTION
Overview
----------------------------------------
Fixes 1 unreleased regression and one new bug in SearchKit & Afform, related to work done in #21929

To reproduce
----------------------------------------
1. Try creating multiple afform+search dashlets and adding them all to your dashboard. Only one will load results and the others will appear "stuck" in a loading state indefinitely.
![image](https://user-images.githubusercontent.com/2874912/142772959-749951af-04d7-42fc-bb75-2e12cd3b48e6.png)

2. Try creating an afform based on the default search display. You can save it but it won't render.

After
----------------------------------------
Works.