### PR TITLE
CiviCRM Message Template, HTML Format and Text Format fields are listed in a different order on the Default Message Template

### DIFF
--- a/templates/CRM/Admin/Page/MessageTemplates.tpl
+++ b/templates/CRM/Admin/Page/MessageTemplates.tpl
@@ -34,6 +34,18 @@
     </div>
   </div>
 
+  <div class="crm-section msg_html-section">
+    <h3 class="header-dark">{$form.msg_html.label}</h3>
+    <div class='text'>
+      <textarea class="huge" name='msg_html' id='msg_html'>{$form.msg_html.value|htmlentities}</textarea>
+      <div class='spacer'></div>
+      <div class="section">
+        <a href='#' onclick='MessageTemplates.msg_html.select(); return false;' class='button'><span>{ts}Select HTML Message{/ts}</span></a>
+        <div class='spacer'></div>
+      </div>
+    </div>
+  </div>
+
   <div class="crm-section msg_txt-section">
   <h3 class="header-dark">{$form.msg_text.label}</h3>
     <div class="text">
@@ -41,18 +53,6 @@
       <div class='spacer'></div>
       <div class="section">
         <a href='#' onclick='MessageTemplates.msg_text.select(); return false;' class='button'><span>{ts}Select Text Message{/ts}</span></a>
-        <div class='spacer'></div>
-      </div>
-    </div>
-  </div>
-
-  <div class="crm-section msg_html-section">
-  <h3 class="header-dark">{$form.msg_html.label}</h3>
-    <div class='text'>
-      <textarea class="huge" name='msg_html' id='msg_html'>{$form.msg_html.value|htmlentities}</textarea>
-      <div class='spacer'></div>
-      <div class="section">
-        <a href='#' onclick='MessageTemplates.msg_html.select(); return false;' class='button'><span>{ts}Select HTML Message{/ts}</span></a>
         <div class='spacer'></div>
       </div>
     </div>


### PR DESCRIPTION
Overview
----------------------------------------
CiviCRM Message Template, HTML Format and Text Format fields are listed in a different order and make it harder to directly compare and copy/paste changes from a **Default Message Template** to a **Message Template**.

This one has been annoying me for a long time (and I expect others too), finally extracted the digit and fixed it.

Before
----------------------------------------

![Screenshot_20211122_105126](https://user-images.githubusercontent.com/58866555/142784018-30b8e184-b6ad-4391-9361-9e0e13fbe293.png)


After
----------------------------------------

![Screenshot_20211122_110727](https://user-images.githubusercontent.com/58866555/142784575-298dfe0b-b7cf-4a6e-816e-7484acb85af9.png)


Technical Details
----------------------------------------


Comments
----------------------------------------

Agileware Ref: CIVICRM-1889
