### PR TITLE
Remove broken dynamic title from event template

### DIFF
--- a/templates/CRM/Event/Form/ManageEvent/Tab.tpl
+++ b/templates/CRM/Event/Form/ManageEvent/Tab.tpl
@@ -78,15 +78,6 @@ CRM.$(function($) {
     return false;
   });
 
-  // Update title dynamically
-  $('h1').each(function() {
-    var title = {/literal}{$title|json_encode}{literal};
-    $(this).html($(this).html().replace(title, '<span id="crm-event-name-page-title">' + title + '</span>'));
-  });
-  $('#crm-main-content-wrapper').on('keyup change', 'input#title', function() {
-    $('#crm-event-name-page-title').text($(this).val());
-  });
-
 });
 </script>
 {/literal}


### PR DESCRIPTION
Overview
----------------------------------------
`$title` is never assigned to the template and it looks like it hasn't for at least two years. So this code doesn't actually seem to do anything.

Before
----------------------------------------
Code that doesn't seem to do anything

After
----------------------------------------
Gone.

Technical Details
----------------------------------------


Comments
----------------------------------------

