### PR TITLE
Use getEntityNameForTable() instead of getClassForTable(), as this might yield ambiguous results

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -3080,7 +3080,7 @@ SELECT contact_id
         $relatedEntities = $this->buildOptions('entity_table', 'get');
         foreach ((array) $relatedEntities as $table => $ent) {
           if (!empty($ent)) {
-            $ent = CRM_Core_DAO_AllCoreTables::getBriefName(CRM_Core_DAO_AllCoreTables::getClassForTable($table));
+            $ent = CRM_Core_DAO_AllCoreTables::getEntityNameForTable($table);
             $subquery = CRM_Utils_SQL::mergeSubquery($ent);
             if ($subquery) {
               $relatedClauses[] = "(entity_table = '$table' AND entity_id " . implode(' AND entity_id ', $subquery) . ")";

--- a/CRM/Core/DAO/AllCoreTables.php
+++ b/CRM/Core/DAO/AllCoreTables.php
@@ -364,6 +364,11 @@ class CRM_Core_DAO_AllCoreTables {
    */
   public static function getEntityNameForTable(string $tableName) {
     self::init();
+    // CRM-19677: on multilingual setup, trim locale from $tableName to fetch class name
+    if (CRM_Core_I18n::isMultilingual()) {
+      global $dbLocale;
+      $tableName = str_replace($dbLocale, '', $tableName);
+    }
     $matches = CRM_Utils_Array::findAll(self::$entityTypes, ['table' => $tableName]);
     return $matches ? $matches[0]['name'] : NULL;
   }

--- a/CRM/Core/DynamicFKAccessTrait.php
+++ b/CRM/Core/DynamicFKAccessTrait.php
@@ -38,7 +38,7 @@ trait CRM_Core_DynamicFKAccessTrait {
       $table = CRM_Core_DAO::getFieldValue(__CLASS__, $record['id'], 'entity_table');
     }
     if ($eid && $table) {
-      $targetEntity = CRM_Core_DAO_AllCoreTables::getBriefName(CRM_Core_DAO_AllCoreTables::getClassForTable($table));
+      $targetEntity = CRM_Core_DAO_AllCoreTables::getEntityNameForTable($table);
       if ($targetEntity === NULL) {
         throw new \API_Exception(sprintf('Cannot resolve permissions for dynamic foreign key in "%s". Invalid table reference "%s".',
           static::getTableName(), $table));

--- a/CRM/Core/Form/RecurringEntity.php
+++ b/CRM/Core/Form/RecurringEntity.php
@@ -94,7 +94,7 @@ class CRM_Core_Form_RecurringEntity {
     }
 
     // Assign variables
-    $entityType = CRM_Core_DAO_AllCoreTables::getBriefName(CRM_Core_DAO_AllCoreTables::getClassForTable($entityTable));
+    $entityType = CRM_Core_DAO_AllCoreTables::getEntityNameForTable($entityTable);
     $tpl = CRM_Core_Smarty::singleton();
     $tpl->assign('recurringEntityType', ts($entityType));
     $tpl->assign('currentEntityId', self::$_entityId);

--- a/CRM/Dedupe/BAO/DedupeRule.php
+++ b/CRM/Dedupe/BAO/DedupeRule.php
@@ -237,7 +237,7 @@ class CRM_Dedupe_BAO_DedupeRule extends CRM_Dedupe_DAO_DedupeRule {
    * @throws \CiviCRM_API3_Exception
    */
   public function getFieldType($fieldName) {
-    $entity = CRM_Core_DAO_AllCoreTables::getBriefName(CRM_Core_DAO_AllCoreTables::getClassForTable($this->rule_table));
+    $entity = CRM_Core_DAO_AllCoreTables::getEntityNameForTable($this->rule_table);
     if (!$entity) {
       // This means we have stored a custom field rather than an entity name in rule_table, figure out the entity.
       $entity = civicrm_api3('CustomGroup', 'getvalue', ['table_name' => $this->rule_table, 'return' => 'extends']);

--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -5029,7 +5029,7 @@ LEFT JOIN civicrm_contact {$field['alias']} ON {$field['alias']}.id = {$this->_a
   public function setEntityRefDefaults(&$field, $table) {
     $field['attributes'] = $field['attributes'] ? $field['attributes'] : [];
     $field['attributes'] += [
-      'entity' => CRM_Core_DAO_AllCoreTables::getBriefName(CRM_Core_DAO_AllCoreTables::getClassForTable($table)),
+      'entity' => CRM_Core_DAO_AllCoreTables::getEntityNameForTable($table),
       'multiple' => TRUE,
       'placeholder' => ts('- select -'),
     ];


### PR DESCRIPTION
Overview
----------------------------------------
Use `CRM_Core_DAO_AllCoreTables::getEntityNameForTable()` instead of `CRM_Core_DAO_AllCoreTables::getBriefName(CRM_Core_DAO_AllCoreTables::getClassForTable())` constructs, as this might yield ambiguous results since entities can share a DAO class.

Before
----------------------------------------
The first result returned by `array_search()` lookups in `CRM_Core_DAO_AllCoreTables::getBriefName()` might not be the entity in question, because there can be multiple entities sharing a DAO class.

After
----------------------------------------
The correct entity is being returned.

Technical Details
----------------------------------------
See #21853 for why entities are now being indexed by brief name instead of class name.

Comments
----------------------------------------
This is toward work on virtual entities, followup to #21853