### PR TITLE
Fix message templates screen to work with escape enabled by default

### DIFF
--- a/CRM/Admin/Page/MessageTemplates.php
+++ b/CRM/Admin/Page/MessageTemplates.php
@@ -252,7 +252,7 @@ class CRM_Admin_Page_MessageTemplates extends CRM_Core_Page_Basic {
     // find all objects
     $messageTemplate->find();
     while ($messageTemplate->fetch()) {
-      $values[$messageTemplate->id] = [];
+      $values[$messageTemplate->id] = ['class' => ''];
       CRM_Core_DAO::storeValues($messageTemplate, $values[$messageTemplate->id]);
       // populate action links
       $this->action($messageTemplate, $action, $values[$messageTemplate->id], $links, CRM_Core_Permission::EDIT);

--- a/CRM/Core/Smarty.php
+++ b/CRM/Core/Smarty.php
@@ -410,9 +410,13 @@ class CRM_Core_Smarty extends Smarty {
 
         // The ones below this point are hopefully here short term.
         || strpos($string, '<a') === 0
+        // Message templates screen
+        || strpos($string, '<span><a href') === 0
         // Not sure how big a pattern this is - used in Pledge view tab
         // not sure if it needs escaping
         || strpos($string, ' action="/civicrm/') === 0
+        // eg. Tag edit page, civicrm/admin/financial/financialType/accounts?action=add&reset=1&aid=1
+        || strpos($string, ' action="" method="post"') === 0
         // This seems to be urls...
         || strpos($string, '/civicrm/') === 0
         // Validation error message - eg. <span class="crm-error">Tournament Fees is a required field.</span>

--- a/ext/legacycustomsearches/templates/CRM/Contact/Form/Search/Custom/FullText.tpl
+++ b/ext/legacycustomsearches/templates/CRM/Contact/Form/Search/Custom/FullText.tpl
@@ -35,7 +35,7 @@
 {/if}
 
 {* @TODO: This is confusing - the variable `table` is already set and used above, and now we set it again to something that is technically different but has the same value, except on a blank form where it doesn't exist, but effectively then is the same value that it already has which is ''. So do we need this line even? *}
-{if (isset($form.table.value.0))}{assign var=table value=$form.table.value.0}{/if}
+{if $form.table.value && (array_key_exists(0, $form.table.value))}{assign var=table value=$form.table.value.0}{/if}
 {assign var=text  value=$form.text.value}
 {if !empty($summary.Contact) }
   <div class="section">

--- a/templates/CRM/Admin/Page/MessageTemplates.tpl
+++ b/templates/CRM/Admin/Page/MessageTemplates.tpl
@@ -125,7 +125,7 @@
                 </thead>
                 <tbody>
                 {foreach from=$template_row item=row}
-                    <tr id="message_template-{$row.id}" class="crm-entity {if !empty($row.class)}{$row.class}{/if}{if NOT $row.is_active} disabled{/if}">
+                    <tr id="message_template-{$row.id}" class="crm-entity {$row.class}{if NOT $row.is_active} disabled{/if}">
                       <td>{$row.msg_title}</td>
                       {if $type eq 'userTemplates'}
                         <td>{$row.msg_subject}</td>

--- a/tests/phpunit/CRM/Core/FormTest.php
+++ b/tests/phpunit/CRM/Core/FormTest.php
@@ -15,7 +15,7 @@ class CRM_Core_FormTest extends CiviUnitTestCase {
    *
    * @dataProvider formList
    */
-  public function testOpeningForms(string $url) {
+  public function testOpeningForms(string $url): void {
     $this->createLoggedInUser();
 
     $_SERVER['REQUEST_URI'] = $url;
@@ -61,6 +61,9 @@ class CRM_Core_FormTest extends CiviUnitTestCase {
       ],
       'New Email' => [
         'civicrm/activity/email/add?atype=3&action=add&reset=1&context=standalone',
+      ],
+      'Message Templates' => [
+        'civicrm/admin/messageTemplates?reset=1',
       ],
     ];
   }


### PR DESCRIPTION
Overview
----------------------------------------
Fix message templates screen to work with escape enabled by default

Before
----------------------------------------
Page won't load with escape enabled by default due to issets 

After
----------------------------------------
It does!

Technical Details
----------------------------------------

Comments
----------------------------------------
