### PR TITLE
Bypass any default escaping for blog, getting started

### DIFF
--- a/templates/CRM/Dashlet/Page/Blog.tpl
+++ b/templates/CRM/Dashlet/Page/Blog.tpl
@@ -47,12 +47,12 @@
     {foreach from=$channel.items item=article}
       <div class="crm-accordion-wrapper collapsed">
         <div class="crm-accordion-header">
-          <span class="crm-news-feed-item-title">{$article.title}</span>
-          <span class="crm-news-feed-item-preview"> - {if function_exists('mb_substr')}{$article.description|strip_tags|mb_substr:0:150}{else}{$article.description|strip_tags}{/if}</span>
+          <span class="crm-news-feed-item-title">{$article.title|smarty:nodefaults|purify}</span>
+          <span class="crm-news-feed-item-preview"> - {if function_exists('mb_substr')}{$article.description|smarty:nodefaults|strip_tags|mb_substr:0:150}{else}{$article.description|smarty:nodefaults|strip_tags}{/if}</span>
         </div>
         <div class="crm-accordion-body">
-          <div>{$article.description}</div>
-          <p class="crm-news-feed-item-link"><a target="_blank" href="{$article.link}" title="{$article.title|escape}"><i class="crm-i fa-external-link" aria-hidden="true"></i> {ts}read more{/ts}…</a></p>
+          <div>{$article.description|smarty:nodefaults|purify}</div>
+          <p class="crm-news-feed-item-link"><a target="_blank" href="{$article.link|smarty:nodefaults|purify}" title="{$article.title|escape}"><i class="crm-i fa-external-link" aria-hidden="true"></i> {ts}read more{/ts}…</a></p>
         </div>
       </div>
     {/foreach}

--- a/templates/CRM/Dashlet/Page/GettingStarted.tpl
+++ b/templates/CRM/Dashlet/Page/GettingStarted.tpl
@@ -8,4 +8,4 @@
  +--------------------------------------------------------------------+
 *}
 
-<div id="civicrm-getting-started">{$gettingStarted}</div>
+<div id="civicrm-getting-started">{$gettingStarted|smarty:nodefaults}</div>


### PR DESCRIPTION

Overview
----------------------------------------
Fixes the blog and getting started dashlets to not apply default escaping so they still render with that enabled.


Before
----------------------------------------
munged html with escape by default enabled

After
----------------------------------------
works

Technical Details
----------------------------------------
This specifies that default escaping should not apply to the blog, getting started.

@seamuslee001  - I added 'purify' to the data coming from the blog - this is our blog so should be
safe but it is techically 3rd part data so I think this is more correct.

Comments
----------------------------------------
