### PR TITLE
Do not use default escaping on address display

### DIFF
--- a/templates/CRM/Contact/Page/Inline/Address.tpl
+++ b/templates/CRM/Contact/Page/Inline/Address.tpl
@@ -38,7 +38,7 @@
           {if !empty($sharedAddresses.$locationIndex.shared_address_display.name)}
             <strong>{ts 1=$sharedAddresses.$locationIndex.shared_address_display.name}Address belongs to %1{/ts}</strong><br />
           {/if}
-          {$add.display|nl2br}
+          {$add.display|smarty:nodefaults|purify|nl2br}
         </div>
       </div>
 


### PR DESCRIPTION

Overview
----------------------------------------
Do not use default escaping on address display

This has vcard html in it and so breaks if default escaping is enabled

Before
----------------------------------------
Broken html with escape-on-output enabled

After
----------------------------------------
Output not subject to default escaping, purify added as good practice while doing this on any field that could contain inputted datat

Technical Details
----------------------------------------

Comments
----------------------------------------
