### PR TITLE
SearchKit - enable search by case role

### DIFF
--- a/Civi/Api4/CaseContact.php
+++ b/Civi/Api4/CaseContact.php
@@ -27,4 +27,24 @@ class CaseContact extends Generic\DAOEntity {
     return $plural ? ts('Case Clients') : ts('Case Client');
   }
 
+  /**
+   * @return array
+   */
+  public static function getInfo() {
+    $info = parent::getInfo();
+    $info['bridge_title'] = ts('Clients');
+    $info['bridge'] = [
+      'case_id' => [
+        'to' => 'contact_id',
+        'description' => ts('Cases with this contact as a client'),
+      ],
+      'contact_id' => [
+        'label' => ts('Clients'),
+        'to' => 'case_id',
+        'description' => ts('Clients for this case'),
+      ],
+    ];
+    return $info;
+  }
+
 }

--- a/Civi/Api4/EntityFinancialAccount.php
+++ b/Civi/Api4/EntityFinancialAccount.php
@@ -30,8 +30,8 @@ class EntityFinancialAccount extends Generic\DAOEntity {
   public static function getInfo() {
     $info = parent::getInfo();
     $info['bridge'] = [
-      'entity_id' => [],
-      'financial_account_id' => [],
+      'entity_id' => ['to' => 'financial_account_id'],
+      'financial_account_id' => ['to' => 'entity_id'],
     ];
     return $info;
   }

--- a/Civi/Api4/EntityFinancialTrxn.php
+++ b/Civi/Api4/EntityFinancialTrxn.php
@@ -30,8 +30,8 @@ class EntityFinancialTrxn extends Generic\DAOEntity {
   public static function getInfo() {
     $info = parent::getInfo();
     $info['bridge'] = [
-      'entity_id' => [],
-      'financial_trxn_id' => [],
+      'entity_id' => ['to' => 'financial_trxn_id'],
+      'financial_trxn_id' => ['to' => 'entity_id'],
     ];
     return $info;
   }

--- a/Civi/Api4/Generic/Traits/EntityBridge.php
+++ b/Civi/Api4/Generic/Traits/EntityBridge.php
@@ -15,8 +15,6 @@ namespace Civi\Api4\Generic\Traits;
  * A bridge is a small table that provides an intermediary link between two other tables.
  *
  * The API can automatically incorporate a Bridge into a join expression.
- *
- * Note: at time of writing this trait does nothing except affect the "type" shown in Entity::get() metadata.
  */
 trait EntityBridge {
 
@@ -29,12 +27,19 @@ trait EntityBridge {
    */
   public static function getInfo() {
     $info = parent::getInfo();
+    $bridgeFields = [];
     if (!empty($info['dao'])) {
       foreach (($info['dao'])::fields() as $field) {
         if (!empty($field['FKClassName']) || $field['name'] === 'entity_id') {
-          $info['bridge'][$field['name']] = [];
+          $bridgeFields[] = $field['name'];
         }
       }
+    }
+    if (count($bridgeFields) === 2) {
+      $info['bridge'] = [
+        $bridgeFields[0] => ['to' => $bridgeFields[1]],
+        $bridgeFields[1] => ['to' => $bridgeFields[0]],
+      ];
     }
     return $info;
   }

--- a/Civi/Api4/GroupContact.php
+++ b/Civi/Api4/GroupContact.php
@@ -59,8 +59,14 @@ class GroupContact extends Generic\DAOEntity {
   public static function getInfo() {
     $info = parent::getInfo();
     $info['bridge'] = [
-      'group_id' => ['description' => ts('Static (non-smart) group contacts')],
-      'contact_id' => ['description' => ts('Static (non-smart) group contacts')],
+      'group_id' => [
+        'to' => 'contact_id',
+        'description' => ts('Static (non-smart) group contacts'),
+      ],
+      'contact_id' => [
+        'to' => 'group_id',
+        'description' => ts('Static (non-smart) group contacts'),
+      ],
     ];
     return $info;
   }

--- a/Civi/Api4/RelationshipCache.php
+++ b/Civi/Api4/RelationshipCache.php
@@ -47,9 +47,18 @@ class RelationshipCache extends Generic\AbstractEntity {
     $info = parent::getInfo();
     $info['bridge_title'] = ts('Relationship');
     $info['bridge'] = [
-      'near_contact_id' => ['description' => ts('One or more contacts with a relationship to this contact')],
-      'far_contact_id' => ['description' => ts('One or more contacts with a relationship to this contact')],
+      'near_contact_id' => [
+        'to' => 'far_contact_id',
+        'description' => ts('One or more related contacts'),
+      ],
     ];
+    if (in_array('CiviCase', \Civi::settings()->get('enable_components'), TRUE)) {
+      $info['bridge']['case_id'] = [
+        'to' => 'far_contact_id',
+        'label' => ts('Case Roles'),
+        'description' => ts('Cases in which this contact has a role'),
+      ];
+    }
     return $info;
   }
 

--- a/ext/search_kit/Civi/Search/Admin.php
+++ b/ext/search_kit/Civi/Search/Admin.php
@@ -210,43 +210,32 @@ class Admin {
         /* @var \CRM_Core_DAO $daoClass */
         $daoClass = $entity['dao'];
         $references = $daoClass::getReferenceColumns();
-        // Only the first bridge reference gets processed, so if it's dynamic we want to be sure it's first in the list
-        usort($references, function($first, $second) {
-          foreach ([-1 => $first, 1 => $second] as $weight => $reference) {
-            if (is_a($reference, 'CRM_Core_Reference_Dynamic')) {
-              return $weight;
-            }
-          }
-          return 0;
-        });
         $fields = array_column($entity['fields'], NULL, 'name');
         $bridge = in_array('EntityBridge', $entity['type']) ? $entity['name'] : NULL;
-        $bridgeFields = array_keys($entity['bridge'] ?? []);
-        foreach ($references as $reference) {
-          $keyField = $fields[$reference->getReferenceKey()] ?? NULL;
-          if (
-            // Sanity check - keyField must exist
-            !$keyField ||
-            // Exclude any joins that are better represented by pseudoconstants
-            is_a($reference, 'CRM_Core_Reference_OptionValue') || (!$bridge && !empty($keyField['options'])) ||
-            // Limit bridge joins to just the first
-            ($bridge && array_search($keyField['name'], $bridgeFields) !== 0) ||
-            // Sanity check - table should match
-            $daoClass::getTableName() !== $reference->getReferenceTable()
-          ) {
-            continue;
-          }
-          // Dynamic references use a column like "entity_table" (for normal joins this value will be null)
-          $dynamicCol = $reference->getTypeColumn();
 
-          // For dynamic references getTargetEntities will return multiple targets; for normal joins this loop will only run once
-          foreach ($reference->getTargetEntities() as $targetTable => $targetEntityName) {
-            if (!isset($allowedEntities[$targetEntityName]) || $targetEntityName === $entity['name']) {
+        // Non-bridge joins directly between 2 entities
+        if (!$bridge) {
+          foreach ($references as $reference) {
+            $keyField = $fields[$reference->getReferenceKey()] ?? NULL;
+            if (
+              // Sanity check - keyField must exist
+              !$keyField ||
+              // Exclude any joins that are better represented by pseudoconstants
+              is_a($reference, 'CRM_Core_Reference_OptionValue') || !empty($keyField['options']) ||
+              // Sanity check - table should match
+              $daoClass::getTableName() !== $reference->getReferenceTable()
+            ) {
               continue;
             }
-            $targetEntity = $allowedEntities[$targetEntityName];
-            // Non-bridge joins directly between 2 entities
-            if (!$bridge) {
+            // Dynamic references use a column like "entity_table" (for normal joins this value will be null)
+            $dynamicCol = $reference->getTypeColumn();
+
+            // For dynamic references getTargetEntities will return multiple targets; for normal joins this loop will only run once
+            foreach ($reference->getTargetEntities() as $targetTable => $targetEntityName) {
+              if (!isset($allowedEntities[$targetEntityName]) || $targetEntityName === $entity['name']) {
+                continue;
+              }
+              $targetEntity = $allowedEntities[$targetEntityName];
               // Add the straight 1-1 join
               $alias = $entity['name'] . '_' . $targetEntityName . '_' . $keyField['name'];
               $joins[$entity['name']][] = [
@@ -270,21 +259,27 @@ class Admin {
                 'multi' => TRUE,
               ];
             }
-            // Bridge joins (sanity check - bridge must specify exactly 2 FK fields)
-            elseif (count($entity['bridge']) === 2) {
-              // Get the other entity being linked through this bridge
-              $baseKey = array_search($reference->getReferenceKey(), $bridgeFields) ? $bridgeFields[0] : $bridgeFields[1];
+          }
+        }
+        // Bridge joins go through an intermediary table
+        elseif (!empty($entity['bridge'])) {
+          foreach ($entity['bridge'] as $targetKey => $bridgeInfo) {
+            $baseKey = $bridgeInfo['to'];
+            $reference = self::getReference($targetKey, $references);
+            $dynamicCol = $reference->getTypeColumn();
+            $keyField = $fields[$reference->getReferenceKey()] ?? NULL;
+            foreach ($reference->getTargetEntities() as $targetTable => $targetEntityName) {
+              $targetEntity = $allowedEntities[$targetEntityName] ?? NULL;
               $baseEntity = $allowedEntities[$fields[$baseKey]['fk_entity']] ?? NULL;
-              if (!$baseEntity) {
+              if (!$targetEntity || !$baseEntity) {
                 continue;
               }
               // Add joins for the two entities that connect through this bridge (n-n)
-              $symmetric = $baseEntity['name'] === $targetEntityName;
-              $targetsTitle = $symmetric ? $allowedEntities[$bridge]['title_plural'] : $targetEntity['title_plural'];
+              $targetsTitle = $bridgeInfo['label'] ?? $targetEntity['title_plural'];
               $alias = $baseEntity['name'] . "_{$bridge}_" . $targetEntityName;
               $joins[$baseEntity['name']][] = [
                 'label' => $baseEntity['title'] . ' ' . $targetsTitle,
-                'description' => $entity['bridge'][$baseKey]['description'] ?? E::ts('Multiple %1 per %2', [1 => $targetsTitle, 2 => $baseEntity['title']]),
+                'description' => $bridgeInfo['description'] ?? E::ts('Multiple %1 per %2', [1 => $targetsTitle, 2 => $baseEntity['title']]),
                 'entity' => $targetEntityName,
                 'conditions' => array_merge(
                   [$bridge],
@@ -295,10 +290,11 @@ class Admin {
                 'alias' => $alias,
                 'multi' => TRUE,
               ];
-              if (!$symmetric) {
+              // Back-fill the reverse join if declared
+              if ($dynamicCol && $keyField && !empty($entity['bridge'][$baseKey])) {
                 $alias = $targetEntityName . "_{$bridge}_" . $baseEntity['name'];
                 $joins[$targetEntityName][] = [
-                  'label' => $targetEntity['title'] . ' ' . $baseEntity['title_plural'],
+                  'label' => $targetEntity['title'] . ' ' . ($entity['bridge'][$baseKey]['label'] ?? $baseEntity['title_plural']),
                   'description' => $entity['bridge'][$reference->getReferenceKey()]['description'] ?? E::ts('Multiple %1 per %2', [1 => $baseEntity['title_plural'], 2 => $targetEntity['title']]),
                   'entity' => $baseEntity['name'],
                   'conditions' => array_merge(
@@ -317,6 +313,19 @@ class Admin {
       }
     }
     return $joins;
+  }
+
+  /**
+   * @param string $fieldName
+   * @param \CRM_Core_Reference_Basic[] $references
+   * @return \CRM_Core_Reference_Basic
+   */
+  private static function getReference(string $fieldName, array $references) {
+    foreach ($references as $reference) {
+      if ($reference->getReferenceKey() === $fieldName) {
+        return $reference;
+      }
+    }
   }
 
   /**

--- a/ext/search_kit/Civi/Search/Admin.php
+++ b/ext/search_kit/Civi/Search/Admin.php
@@ -180,21 +180,22 @@ class Admin {
     foreach ($allowedEntities as $entity) {
       // Multi-record custom field groups (to-date only the contact entity supports these)
       if (in_array('CustomValue', $entity['type'])) {
+        // TODO: Lookup target entity from custom group if someday other entities support multi-record custom data
         $targetEntity = $allowedEntities['Contact'];
         // Join from Custom group to Contact (n-1)
-        $alias = $entity['name'] . '_Contact_entity_id';
+        $alias = "{$entity['name']}_{$targetEntity['name']}_entity_id";
         $joins[$entity['name']][] = [
           'label' => $entity['title'] . ' ' . $targetEntity['title'],
           'description' => '',
-          'entity' => 'Contact',
+          'entity' => $targetEntity['name'],
           'conditions' => self::getJoinConditions('entity_id', $alias . '.id'),
           'defaults' => self::getJoinDefaults($alias, $targetEntity),
           'alias' => $alias,
           'multi' => FALSE,
         ];
         // Join from Contact to Custom group (n-n)
-        $alias = 'Contact_' . $entity['name'] . '_entity_id';
-        $joins['Contact'][] = [
+        $alias = "{$targetEntity['name']}_{$entity['name']}_entity_id";
+        $joins[$targetEntity['name']][] = [
           'label' => $entity['title_plural'],
           'description' => '',
           'entity' => $entity['name'],

--- a/ext/search_kit/tests/phpunit/Civi/Search/AdminTest.php
+++ b/ext/search_kit/tests/phpunit/Civi/Search/AdminTest.php
@@ -1,0 +1,101 @@
+<?php
+namespace Civi\Search;
+
+use Civi\Test\HeadlessInterface;
+use Civi\Test\TransactionalInterface;
+
+/**
+ * @group headless
+ */
+class AdminTest extends \PHPUnit\Framework\TestCase implements HeadlessInterface, TransactionalInterface {
+
+  public function setUpHeadless() {
+    return \Civi\Test::headless()->installMe(__DIR__)->apply();
+  }
+
+  /**
+   */
+  public function testGetJoins(): void {
+    \CRM_Core_BAO_ConfigSetting::disableComponent('CiviCase');
+    $allowedEntities = Admin::getSchema();
+    $this->assertArrayNotHasKey('Case', $allowedEntities);
+    $this->assertArrayNotHasKey('CaseContact', $allowedEntities);
+
+    \CRM_Core_BAO_ConfigSetting::enableComponent('CiviCase');
+    $allowedEntities = Admin::getSchema();
+    $this->assertArrayHasKey('Case', $allowedEntities);
+    $this->assertArrayHasKey('CaseContact', $allowedEntities);
+
+    $joins = Admin::getJoins($allowedEntities);
+    $this->assertNotEmpty($joins);
+
+    $groupContactJoins = \CRM_Utils_Array::findAll($joins['Group'], [
+      'entity' => 'Contact',
+      'bridge' => 'GroupContact',
+      'alias' => 'Group_GroupContact_Contact',
+      'multi' => TRUE,
+    ]);
+    $this->assertCount(1, $groupContactJoins);
+    $this->assertEquals(
+      ['GroupContact', ['id', '=', 'Group_GroupContact_Contact.group_id']],
+      $groupContactJoins[0]['conditions']
+    );
+    $this->assertEquals(
+      [['Group_GroupContact_Contact.status:name', '=', '"Added"']],
+      $groupContactJoins[0]['defaults']
+    );
+
+    $relationshipJoins = \CRM_Utils_Array::findAll($joins['Contact'], [
+      'entity' => 'Contact',
+      'bridge' => 'RelationshipCache',
+      'alias' => 'Contact_RelationshipCache_Contact',
+      'multi' => TRUE,
+    ]);
+    $this->assertCount(1, $relationshipJoins);
+    $this->assertEquals(
+      ['RelationshipCache', ['id', '=', 'Contact_RelationshipCache_Contact.far_contact_id']],
+      $relationshipJoins[0]['conditions']
+    );
+    $this->assertEquals(
+      [['Contact_RelationshipCache_Contact.near_relation:name', '=', '"Child of"']],
+      $relationshipJoins[0]['defaults']
+    );
+
+    $eventParticipantJoins = \CRM_Utils_Array::findAll($joins['Event'], [
+      'entity' => 'Participant',
+      'alias' => 'Event_Participant_event_id',
+      'multi' => TRUE,
+    ]);
+    $this->assertCount(1, $eventParticipantJoins);
+    $this->assertNull($eventParticipantJoins[0]['bridge'] ?? NULL);
+    $this->assertEquals(
+      [['id', '=', 'Event_Participant_event_id.event_id']],
+      $eventParticipantJoins[0]['conditions']
+    );
+
+    $tagActivityJoins = \CRM_Utils_Array::findAll($joins['Tag'], [
+      'entity' => 'Activity',
+      'bridge' => 'EntityTag',
+      'alias' => 'Tag_EntityTag_Activity',
+      'multi' => TRUE,
+    ]);
+    $this->assertCount(1, $tagActivityJoins);
+    $this->assertEquals(
+      ['EntityTag', ['id', '=', 'Tag_EntityTag_Activity.tag_id']],
+      $tagActivityJoins[0]['conditions']
+    );
+
+    $activityTagJoins = \CRM_Utils_Array::findAll($joins['Activity'], [
+      'entity' => 'Tag',
+      'bridge' => 'EntityTag',
+      'alias' => 'Activity_EntityTag_Tag',
+      'multi' => TRUE,
+    ]);
+    $this->assertCount(1, $activityTagJoins);
+    $this->assertEquals(
+      ['EntityTag', ['id', '=', 'Activity_EntityTag_Tag.entity_id'], ['Activity_EntityTag_Tag.entity_table', '=', "'civicrm_activity'"]],
+      $activityTagJoins[0]['conditions']
+    );
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Permits searching for contacts by case role in SearchKit.

![image](https://user-images.githubusercontent.com/2874912/143147991-d421c517-fafd-40d4-b729-ceda5772b221.png)


Technical Details
----------------------------------------
Required heavy refactoring of the APIv4 EntityBridge code to permit asymmetric bridges and bridges to multiple entities.

Comments
----------------------------------------
In order to feel safe about this refactor I added a bunch of test coverage.
