### PR TITLE
CiviCRM Event, remove the superfluous "Are you sure you want to delete this Event?" confirmation for the Event delete action

### DIFF
--- a/CRM/Event/Page/ManageEvent.php
+++ b/CRM/Event/Page/ManageEvent.php
@@ -53,7 +53,6 @@ class CRM_Event_Page_ManageEvent extends CRM_Core_Page {
     if (!(self::$_actionLinks)) {
       // helper variable for nicer formatting
       $copyExtra = ts('Are you sure you want to make a copy of this Event?');
-      $deleteExtra = ts('Are you sure you want to delete this Event?');
 
       self::$_actionLinks = [
         CRM_Core_Action::DISABLE => [
@@ -70,7 +69,6 @@ class CRM_Event_Page_ManageEvent extends CRM_Core_Page {
           'name' => ts('Delete'),
           'url' => CRM_Utils_System::currentPath(),
           'qs' => 'action=delete&id=%%id%%',
-          'extra' => 'onclick = "return confirm(\'' . $deleteExtra . '\');"',
           'title' => ts('Delete Event'),
         ],
         CRM_Core_Action::COPY => [


### PR DESCRIPTION
Overview
----------------------------------------
CiviCRM Event, remove the superfluous "Are you sure you want to delete this Event?" confirmation for the Event delete action.
This duplicates a subsequent confirmation screen.

Before
----------------------------------------
User is prompted TWICE to confirm the deletion of an Event.

After
----------------------------------------
User is prompted ONCE to confirm the deletion of an Event.

Technical Details
----------------------------------------

Comments
----------------------------------------

Agileware Ref: CIVICRM-1894
