### PR TITLE
Test fix - use more 'real' rendering function

### DIFF
--- a/tests/phpunit/CRM/Activity/Form/ActivityTest.php
+++ b/tests/phpunit/CRM/Activity/Form/ActivityTest.php
@@ -303,8 +303,11 @@ class CRM_Activity_Form_ActivityTest extends CiviUnitTestCase {
    * Test that inbound email is still treated properly if you change the label.
    * I'm not crazy about the strategy used in this test but I can't see another
    * way to do it.
+   *
+   * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
    */
-  public function testInboundEmailDisplaysWithLinebreaks() {
+  public function testInboundEmailDisplaysWithLineBreaks(): void {
     // Change label
     $inbound_email = $this->callAPISuccess('OptionValue', 'getsingle', [
       'option_group_id' => 'activity_type',
@@ -349,30 +352,16 @@ ENDBODY;
       'source_contact_id' => $this->source,
       'assignee_contact_id' => NULL,
     ]);
-    $activity_id = $activity['id'];
+    $_REQUEST = [
+      'context' => 'standalone',
+      'cid' => $this->source,
+      'action' => 'view',
+      'id' => $activity['id'],
+      'atype' => $activity['values'][$activity['id']]['activity_type_id'],
+    ];
 
     // Simulate viewing it from the form.
-
-    $form = new CRM_Activity_Form_Activity();
-    $form->controller = new CRM_Core_Controller_Simple('CRM_Activity_Form_Activity', 'Activity');
-    $form->set('context', 'standalone');
-    $form->set('cid', $this->source);
-    $form->set('action', 'view');
-    $form->set('id', $activity_id);
-    $form->set('atype', $activity['values'][$activity_id]['activity_type_id']);
-
-    $form->buildForm();
-
-    // Wish there was another way to do this
-    $form->controller->handle($form, 'display');
-
-    // This isn't a faithful representation of the output since there'll
-    // probably be a lot missing, but for now I don't see a simpler way to
-    // do this.
-    // Also this is printing the template code to the console. It doesn't hurt
-    // the test but it's clutter and I don't know where it's coming from
-    // and can't seem to prevent it.
-    $output = $form->getTemplate()->fetch($form->getTemplateFileName());
+    $output = $this->getRenderedFormContents('CRM_Activity_Form_Activity');
 
     // This kind of suffers from the same problem as the old webtests. It's
     // a bit brittle and tied to the UI.

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -2404,6 +2404,21 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
   }
 
   /**
+   * Get the rendered contents from a form.
+   *
+   * @param string $formName
+   *
+   * @return false|string
+   */
+  protected function getRenderedFormContents(string $formName) {
+    $form = $this->getFormObject($formName);
+    $form->buildForm();
+    ob_start();
+    $form->controller->_actions['display']->perform($form, 'display');
+    return ob_get_clean();
+  }
+
+  /**
    * Set up initial recurring payment allowing subsequent IPN payments.
    *
    * @param array $recurParams (Optional)
@@ -3199,6 +3214,10 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
       case 'CRM_Event_Cart_Form_Checkout_Payment':
       case 'CRM_Event_Cart_Form_Checkout_ParticipantsAndPrices':
         $form->controller = new CRM_Event_Cart_Controller_Checkout();
+        break;
+
+      case strpos($class, '_Form_') !== FALSE:
+        $form->controller = new CRM_Core_Controller_Simple($class, $pageName);
         break;
 
       default:


### PR DESCRIPTION
Overview
----------------------------------------
Test fix - use more 'real' rendering function

Before
----------------------------------------
Test doesn't call all the form functions that assign template variables

After
----------------------------------------
Now it does

Technical Details
----------------------------------------

Comments
----------------------------------------
