### PR TITLE
SearchKit - Improve UX for refresh after editing

### DIFF
--- a/ext/search_kit/ang/crmSearchDisplay/colType/field.html
+++ b/ext/search_kit/ang/crmSearchDisplay/colType/field.html
@@ -1,4 +1,4 @@
-<crm-search-display-editable row="row" col="colData" on-success="$ctrl.runSearch(row)" cancel="$ctrl.editing = null;" ng-if="colData.edit && $ctrl.editing && $ctrl.editing[0] === rowIndex && $ctrl.editing[1] === colIndex"></crm-search-display-editable>
+<crm-search-display-editable row="row" col="colData" do-save="$ctrl.runSearch([apiCall], {}, row)" cancel="$ctrl.editing = null;" ng-if="colData.edit && $ctrl.editing && $ctrl.editing[0] === rowIndex && $ctrl.editing[1] === colIndex"></crm-search-display-editable>
 <span ng-if="::!colData.links" ng-class="{'crm-editable-enabled': colData.edit && !$ctrl.editing}" ng-click="colData.edit && !$ctrl.editing && ($ctrl.editing = [rowIndex, colIndex])">
   {{:: $ctrl.formatFieldValue(colData) }}
 </span>

--- a/ext/search_kit/ang/crmSearchDisplay/crmSearchDisplayEditable.component.js
+++ b/ext/search_kit/ang/crmSearchDisplay/crmSearchDisplayEditable.component.js
@@ -9,10 +9,10 @@
       row: '<',
       col: '<',
       cancel: '&',
-      onSuccess: '&'
+      doSave: '&'
     },
     templateUrl: '~/crmSearchDisplay/crmSearchDisplayEditable.html',
-    controller: function($scope, $element, crmApi4, crmStatus) {
+    controller: function($scope, $element, crmApi4) {
       var ctrl = this,
         initialValue,
         col;
@@ -58,9 +58,7 @@
         var record = _.cloneDeep(col.edit.record);
         record[col.edit.value_key] = ctrl.value;
         $('input', $element).attr('disabled', true);
-        crmStatus({}, crmApi4(col.edit.entity, 'update', {
-          values: record
-        })).then(ctrl.onSuccess);
+        ctrl.doSave({apiCall: [col.edit.entity, 'update', {values: record}]});
       };
 
       function loadOptions() {

--- a/ext/search_kit/ang/crmSearchTasks/traits/searchDisplayTasksTrait.service.js
+++ b/ext/search_kit/ang/crmSearchTasks/traits/searchDisplayTasksTrait.service.js
@@ -55,6 +55,7 @@
       refreshAfterTask: function() {
         this.selectedRows.length = 0;
         this.allRowsSelected = false;
+        this.rowCount = undefined;
         this.runSearch();
       },
 
@@ -70,7 +71,7 @@
         if (editedRow && status === 'success') {
           // If edited row disappears (because edits cause it to not meet search criteria), deselect it
           var index = this.selectedRows.indexOf(editedRow.key);
-          if (index > -1 && !_.findWhere(results, {id: editedRow.key})) {
+          if (index > -1 && !_.findWhere(results, {key: editedRow.key})) {
             this.selectedRows.splice(index, 1);
           }
         }


### PR DESCRIPTION
Overview
----------------------------------------
Makes editing records faster and easier, and fixes a bug where the pager count would not be correctly updated.

Before
----------------------------------------
Pager not always correct after editing.
Slow refresh with flashing placeholders.

After
----------------------------------------
After bulk-editing or in-place-editing, ensures the pager count is correctly updated.
Does the update and refresh for in-place-edit in a single ajax request, without the loading placeholders.
