### PR TITLE
SearchKit - Fix selecting HAVING operator

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchClause.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchClause.component.js
@@ -62,17 +62,15 @@
       }
 
       this.getField = function(expr) {
-        if (!meta[expr]) {
-          meta[expr] = searchMeta.parseExpr(expr).args[0];
+        if (!(expr in meta)) {
+          meta[expr] = _.findWhere(searchMeta.parseExpr(expr).args, {type: 'field'});
         }
-        return meta[expr].field;
+        return meta[expr] && meta[expr].field;
       };
 
       this.getOptionKey = function(expr) {
-        if (!meta[expr]) {
-          meta[expr] = _.findWhere(searchMeta.parseExpr(expr).args, {type: 'field'});
-        }
-        return meta[expr].suffix ? meta[expr].suffix.slice(1) : 'id';
+        var field = ctrl.getField(expr) || {};
+        return field.suffix ? field.suffix.slice(1) : 'id';
       };
 
       this.addGroup = function(op) {

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchInput/crmSearchInputVal.component.js
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchInput/crmSearchInputVal.component.js
@@ -14,13 +14,14 @@
         ctrl = this;
 
       this.$onInit = function() {
-        var rendered = false;
+        var rendered = false,
+          field = this.field || {};
         ctrl.dateRanges = CRM.crmSearchTasks.dateRanges;
-        ctrl.entity = ctrl.field.fk_entity || ctrl.field.entity;
+        ctrl.entity = field.fk_entity || field.entity;
 
         this.ngModel.$render = function() {
           ctrl.value = ctrl.ngModel.$viewValue;
-          if (!rendered && ctrl.field.input_type === 'Date') {
+          if (!rendered && field.input_type === 'Date') {
             setDateType();
           }
           rendered = true;


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a regression in the SearchKit UI where the HAVING clause could not handle functions.

See https://lab.civicrm.org/dev/core/-/issues/2954 for details.

Technical Details
----------------------------------------
Fixes dev/core#2954 by gracefully handling field values when no field exists
