### PR TITLE
Ensure tab headers are assigned, fix widget form test

### DIFF
--- a/CRM/Contribute/Form/ContributionPage/TabHeader.php
+++ b/CRM/Contribute/Form/ContributionPage/TabHeader.php
@@ -57,6 +57,11 @@ class CRM_Contribute_Form_ContributionPage_TabHeader {
       'valid' => FALSE,
       'active' => FALSE,
       'current' => FALSE,
+      'class' => FALSE,
+      'extra' => FALSE,
+      'template' => FALSE,
+      'count' => FALSE,
+      'icon' => FALSE,
     ];
 
     $tabs = [

--- a/templates/CRM/common/TabHeader.tpl
+++ b/templates/CRM/common/TabHeader.tpl
@@ -13,12 +13,12 @@
     <div id="mainTabContainer">
     <ul>
        {foreach from=$tabHeader key=tabName item=tabValue}
-          <li id="tab_{$tabName}" class="crm-tab-button ui-corner-all{if !$tabValue.valid} disabled{/if}{if isset($tabValue.class)} {$tabValue.class}{/if}" {if isset($tabValue.extra)}{$tabValue.extra}{/if}>
+          <li id="tab_{$tabName}" class="crm-tab-button ui-corner-all{if !$tabValue.valid} disabled{/if} {$tabValue.class}" {$tabValue.extra}>
           {if $tabValue.active}
              <a href="{if !empty($tabValue.template)}#panel_{$tabName}{else}{$tabValue.link}{/if}" title="{$tabValue.title|escape}{if !$tabValue.valid} ({ts}disabled{/ts}){/if}">
                {if !empty($tabValue.icon)}<i class="{$tabValue.icon}"></i>{/if}
                <span>{$tabValue.title}</span>
-               {if isset($tabValue.count)}<em>{$tabValue.count}</em>{/if}
+               {if is_numeric($tabValue.count)}<em>{$tabValue.count}</em>{/if}
              </a>
           {else}
              <span {if !$tabValue.valid} title="{ts}disabled{/ts}"{/if}>{$tabValue.title}</span>
@@ -27,7 +27,7 @@
        {/foreach}
     </ul>
       {foreach from=$tabHeader key=tabName item=tabValue}
-        {if !empty($tabValue.template)}
+        {if $tabValue.template}
           <div id="panel_{$tabName}">
             {include file=$tabValue.template}
           </div>

--- a/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
@@ -1741,19 +1741,15 @@ Price Field - Price Field 1        1   $ 100.00      $ 100.00
    * Mostly just check there's no errors opening the Widget tab on contribution
    * pages.
    */
-  public function testOpeningWidgetAdminPage() {
+  public function testOpeningWidgetAdminPage(): void {
     $page_id = $this->callAPISuccess('ContributionPage', 'create', [
       'title' => 'my page',
       'financial_type_id' => $this->_financialTypeId,
       'payment_processor' => $this->paymentProcessorID,
     ])['id'];
+    $_REQUEST = ['reset' => 1, 'action' => 'update', 'id' => $page_id];
 
-    $form = new CRM_Contribute_Form_ContributionPage_Widget();
-    $form->controller = new CRM_Core_Controller_Simple('CRM_Contribute_Form_ContributionPage_Widget', 'Widget');
-
-    $form->set('reset', '1');
-    $form->set('action', 'update');
-    $form->set('id', $page_id);
+    $form = $this->getFormObject('CRM_Contribute_Form_ContributionPage_Widget');
 
     ob_start();
     $form->controller->_actions['display']->perform($form, 'display');


### PR DESCRIPTION
This could regress notices elsewhere but I given the difficulty of getting a combo
of fixes that pass tests I think we should only worry if there are actual test fails
since most people won't see smarty notices anyway
