### PR TITLE
CRM/Event/BAO/Event: Fix ts usage on selfservice_preposition

### DIFF
--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -1171,7 +1171,7 @@ WHERE civicrm_event.is_active = 1
           'credit_card_number' => CRM_Utils_System::mungeCreditCard(CRM_Utils_Array::value('credit_card_number', $participantParams)),
           'credit_card_exp_date' => CRM_Utils_Date::mysqlToIso(CRM_Utils_Date::format(CRM_Utils_Array::value('credit_card_exp_date', $participantParams))),
           'selfcancelxfer_time' => abs($values['event']['selfcancelxfer_time']),
-          'selfservice_preposition' => $values['event']['selfcancelxfer_time'] < 0 ? 'after' : 'before',
+          'selfservice_preposition' => $values['event']['selfcancelxfer_time'] < 0 ? ts('after') : ts('before'),
           'currency' => $values['event']['currency'] ?? CRM_Core_Config::singleton()->defaultCurrency,
         ]);
 


### PR DESCRIPTION
Overview
----------------------------------------

Fixes a missing "ts" function call for translation.

Before
----------------------------------------

![image](https://user-images.githubusercontent.com/254741/143500392-46394f77-616c-4bd3-be1d-2da1f0c930d0.png)


After
----------------------------------------

It works.

Comments
----------------------------------------

It's an incorrect use of ts for concatenation, so it will not work for all languages, but since it should work for most languages, I am not motivated enough to fix it (and the before/after strings already exist in the .mo files).