### PR TITLE
[Smarty variables] [custom data form] Template notice cleanup - make sane

### DIFF
--- a/templates/CRM/Contact/Form/Edit/CustomData.tpl
+++ b/templates/CRM/Contact/Form/Edit/CustomData.tpl
@@ -23,7 +23,8 @@
       {$cd_edit.title}
     </div>
     <div id="customData{$group_id}" class="crm-accordion-body">
-      {include file="CRM/Custom/Form/CustomData.tpl" formEdit=true}
+      {include file="CRM/Custom/Form/Edit/CustomData.tpl" customDataEntity=''}
+      {include file="CRM/Form/attachmentjs.tpl"}
     </div>
     <!-- crm-accordion-body-->
   </div>

--- a/templates/CRM/Custom/Form/CustomData.tpl
+++ b/templates/CRM/Custom/Form/CustomData.tpl
@@ -8,10 +8,7 @@
  +--------------------------------------------------------------------+
 *}
 {* Custom Data form*}
-{if !empty($formEdit)}
-  {include file="CRM/Custom/Form/Edit/CustomData.tpl" customDataEntity=''}
-{else}
-  {foreach from=$groupTree item=cd_edit key=group_id name=custom_sets}
+{foreach from=$groupTree item=cd_edit key=group_id name=custom_sets}
     {if $cd_edit.is_multiple and $multiRecordDisplay eq 'single'}
       {assign var="isSingleRecordEdit" value=TRUE}
     {else}
@@ -40,7 +37,5 @@
       <div id="custom_group_{$group_id}"></div>
     {/if}
   {/foreach}
-
-{/if}
 
 {include file="CRM/Form/attachmentjs.tpl"}


### PR DESCRIPTION

Overview
----------------------------------------
Template notice cleanup - make sane 

Before
----------------------------------------
'shared' code has only one shared line + 5 lines of code to make it share

After
----------------------------------------
unshared

Technical Details
----------------------------------------
The CRM/Custom/Form/CustomData.tpl is called with formEdit set from
1 place - CRM/Contact/Form/Edit/CustomData.tpl - when this is the
case only 1 line of code is shared with the code path if
formEdit is not true/ passed in. This is silly & can be avoided


Comments
----------------------------------------
