### PR TITLE
Display higher severity status checks first

### DIFF
--- a/ang/crmStatusPage.js
+++ b/ang/crmStatusPage.js
@@ -9,7 +9,7 @@
 
       resolve: {
         statusData: function(crmApi) {
-          return crmApi('System', 'check', {sequential: 1, options: {limit: 0}});
+          return crmApi('System', 'check', {sequential: 1, options: {limit: 0, sort: 'severity_id DESC'}});
         }
       }
     });

--- a/ang/crmStatusPage/StatusPageCtrl.js
+++ b/ang/crmStatusPage/StatusPageCtrl.js
@@ -10,7 +10,7 @@
       // Refresh the list. Optionally execute api calls first.
       function refresh(apiCalls, title) {
         title = title || 'Untitled operation';
-        apiCalls = (apiCalls || []).concat([['System', 'check', {sequential: 1, options: {limit: 0}}]]);
+        apiCalls = (apiCalls || []).concat([['System', 'check', {sequential: 1, options: {limit: 0, sort: 'severity_id DESC'}}]]);
         $('#crm-status-list').block();
         crmApi(apiCalls, true)
           .then(function(results) {


### PR DESCRIPTION
Overview
----------------------------------------
The "default" sorting for the status page is to display lowest severity first. This means that the most critical issues are hidden at the bottom even though they are usually the most important bit of information on the page.

Before
----------------------------------------
Status checks page sorted by lowest severity first.

After
----------------------------------------
Status checks page sorted by highest severity first.

Technical Details
----------------------------------------
Add sort to api3 call.

Comments
----------------------------------------

