### PR TITLE
Show if contact is deceased when viewing relationship

### DIFF
--- a/CRM/Contact/Page/View/Relationship.php
+++ b/CRM/Contact/Page/View/Relationship.php
@@ -9,6 +9,8 @@
  +--------------------------------------------------------------------+
  */
 
+use Civi\Api4\Contact;
+
 /**
  *
  * @package CRM
@@ -67,6 +69,15 @@ class CRM_Contact_Page_View_Relationship extends CRM_Core_Page {
     //revert the permissionship text in template
     $relationship = new CRM_Contact_DAO_Relationship();
     $relationship->id = $viewRelationship[$this->getEntityId()]['id'];
+
+    $viewRelationship[$this->getEntityId()]['name'] = CRM_Contact_BAO_Relationship::formatContactName([
+      'name' => $viewRelationship[$this->getEntityId()]['name'],
+      'is_deceased' => Contact::get(FALSE)
+        ->addWhere('id', '=', $viewRelationship[$this->getEntityId()]['cid'])
+        ->addSelect('is_deceased')
+        ->execute()
+        ->first()['is_deceased'],
+    ]);
 
     if ($relationship->find(TRUE)) {
       if (($viewRelationship[$this->getEntityId()]['rtype'] == 'a_b') && ($this->getContactId() == $relationship->contact_id_a)) {


### PR DESCRIPTION
Overview
----------------------------------------
The contact name on the contact summary shows if the contact is deceased:
![image](https://user-images.githubusercontent.com/2052161/143661917-4c6aca91-3664-43f9-b9e4-b7302d561557.png)

but viewing a relationship does not. After this PR the relationship also shows "deceased".

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/2052161/143661959-742f3e1c-1536-48ed-b3cc-286f393877ad.png)

![image](https://user-images.githubusercontent.com/2052161/143661950-a2852eae-ae85-4c33-a810-6b5ece7c004d.png)

After
----------------------------------------
![image](https://user-images.githubusercontent.com/2052161/143661879-91fa9e9f-434c-4771-b341-80177cb2c988.png)

![image](https://user-images.githubusercontent.com/2052161/143661889-917cb52a-5572-43f2-9710-caa042e2671f.png)

Technical Details
----------------------------------------
We retrieve the "is_deceased" status from the contact and then format the name appropriately.

Comments
----------------------------------------

