### PR TITLE
dev/core#2968 - Fix invalid assets url paths

### DIFF
--- a/CRM/Utils/System/Base.php
+++ b/CRM/Utils/System/Base.php
@@ -718,7 +718,8 @@ abstract class CRM_Utils_System_Base {
       // the system for a loop on lobo's macosx box
       // or in modules
       $cmsPath = $config->userSystem->cmsRootPath();
-      $userFrameworkResourceURL = $baseURL . str_replace("$cmsPath/", '',
+      $realCmsPath = realpath($cmsPath);
+      $userFrameworkResourceURL = $baseURL . str_replace(["$cmsPath/", "$realCmsPath/"], '',
           str_replace('\\', '/', $civicrm_root)
         );
 


### PR DESCRIPTION
Overview
----------------------------------------
This fixes assets URLs generation on instances that are using symlinks in the configuration.
I've described it all in the gitlab ticket https://lab.civicrm.org/dev/core/-/issues/2968

