### PR TITLE
dev/core#2961 fix upgrade bug on civicrm_note + logging

### DIFF
--- a/CRM/Upgrade/Incremental/Base.php
+++ b/CRM/Upgrade/Incremental/Base.php
@@ -213,7 +213,10 @@ class CRM_Upgrade_Incremental_Base {
       foreach ($queries as $query) {
         CRM_Core_DAO::executeQuery($query, [], TRUE, NULL, FALSE, FALSE);
       }
+      $logging = new CRM_Logging_Schema();
+      $logging->fixSchemaDifferencesFor($table);
     }
+
     if ($locales && $triggerRebuild) {
       CRM_Core_I18n_Schema::rebuildMultilingualSchema($locales, $version, TRUE);
     }


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#2961 fix upgrade bug on civicrm_note + logging

Before
----------------------------------------
Reported issues with upgrade failure on 5.37 upgrade - these appear to be because we create a new field and then attempt to populate  it before taking any action that would cause the corresponding log table field to be created

After
----------------------------------------
Create the new field in the log table straight after the field is created via the script

Technical Details
----------------------------------------
Normally we reconcile logging tables are the end - however in this case we try to populate it straight away ....

I did think we turned off logging before trying to upgrade?


```
ALTER TABLE civicrm_note ADD COLUMN `note_date` timestamp NULL  DEFAULT CURRENT_TIMESTAMP COMMENT 'Date attached to the note';
ALTER TABLE civicrm_note ADD COLUMN `created_date` timestamp NULL  DEFAULT CURRENT_TIMESTAMP COMMENT 'When the note was created';
UPDATE civicrm_note SET note_date = modified_date, created_date = modified_date, modified_date = modified_date;
```
Comments
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/2961