### PR TITLE
APIv4 - Add `is_active` extra field to Domain entity

### DIFF
--- a/CRM/Core/Config.php
+++ b/CRM/Core/Config.php
@@ -222,7 +222,7 @@ class CRM_Core_Config extends CRM_Core_Config_MagicMerge {
    * @param int $domainID
    * @param bool $reset
    *
-   * @return int|null
+   * @return int
    */
   public static function domainID($domainID = NULL, $reset = FALSE) {
     static $domain;

--- a/Civi/Api4/Service/Spec/Provider/DomainGetSpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/DomainGetSpecProvider.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Service\Spec\Provider;
+
+use Civi\Api4\Service\Spec\FieldSpec;
+use Civi\Api4\Service\Spec\RequestSpec;
+
+class DomainGetSpecProvider implements Generic\SpecProviderInterface {
+
+  /**
+   * @inheritDoc
+   */
+  public function modifySpec(RequestSpec $spec) {
+    $field = new FieldSpec('is_active', $spec->getEntity(), 'Boolean');
+    $field->setLabel(ts('Active Domain'))
+      ->setTitle(ts('Active'))
+      ->setColumnName('id')
+      ->setDescription(ts('Is this the current active domain'))
+      ->setType('Extra')
+      ->setSqlRenderer([__CLASS__, 'renderIsActiveDomain']);
+    $spec->addFieldSpec($field);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function applies($entity, $action) {
+    return $entity === 'Domain' && $action === 'get';
+  }
+
+  /**
+   * @param array $field
+   * return string
+   */
+  public static function renderIsActiveDomain(array $field): string {
+    $currentDomain = \CRM_Core_Config::domainID();
+    return "IF({$field['sql_name']} = '$currentDomain', '1', '0')";
+  }
+
+}

--- a/tests/phpunit/api/v4/Entity/DomainTest.php
+++ b/tests/phpunit/api/v4/Entity/DomainTest.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+namespace api\v4\Entity;
+
+use api\v4\UnitTestCase;
+use Civi\Api4\Domain;
+use Civi\Test\TransactionalInterface;
+
+/**
+ * @group headless
+ */
+class DomainTest extends UnitTestCase implements TransactionalInterface {
+
+  public function testActiveDomain() {
+    Domain::create(FALSE)
+      ->addValue('name', 'Not current')
+      ->addValue('version', \CRM_Utils_System::version())
+      ->execute();
+
+    Domain::update(FALSE)
+      ->addValue('name', 'Currently the current domain')
+      ->addWhere('is_active', '=', TRUE)
+      ->execute();
+
+    $getCurrent = Domain::get(FALSE)
+      ->addWhere('is_active', '=', TRUE)
+      ->execute()->single();
+
+    $this->assertEquals('Currently the current domain', $getCurrent['name']);
+
+    $getAll = Domain::get(FALSE)
+      ->addSelect('*', 'is_active')
+      ->execute()->indexBy('name');
+
+    $this->assertTrue($getAll['Currently the current domain']['is_active']);
+    $this->assertFalse($getAll['Not current']['is_active']);
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Adds a new calculated field to APIv4 making it easier to get the current active domain.

Before
----------------------------------------
You could use the magic keyword "current_domain" which is a holdover from APIv3.

After
----------------------------------------
The magic keyword still works but calculated fields are the way of the future for APIv4 so this new field is consistent with the new approach.
