### PR TITLE
Fix note_date is empty when created via contact 'Add note'

### DIFF
--- a/CRM/Note/Form/Note.php
+++ b/CRM/Note/Form/Note.php
@@ -183,12 +183,19 @@ class CRM_Note_Form_Note extends CRM_Core_Form {
     if ($this->_action & CRM_Core_Action::UPDATE) {
       $params['id'] = $this->_id;
     }
+    // If date is left empty it will be set to empty string.
+    // Which will cause it to be set to NULL in the database and it should default to created_date.
+    if (empty($params['id'])) {
+      if (empty($params['note_date'])) {
+        unset($params['note_date']);
+      }
+    }
 
     // add attachments as needed
     CRM_Core_BAO_File::formatAttachment($params, $params, 'civicrm_note', $params['id']);
 
     $ids = [];
-    $note = CRM_Core_BAO_Note::add($params, $ids);
+    CRM_Core_BAO_Note::add($params, $ids);
 
     CRM_Core_Session::setStatus(ts('Your Note has been saved.'), ts('Saved'), 'success');
   }

--- a/CRM/Upgrade/Incremental/sql/5.45.alpha1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.45.alpha1.mysql.tpl
@@ -11,3 +11,6 @@ UPDATE civicrm_state_province SET name = 'Cotabato' WHERE country_id = @PHILIPPI
 SELECT @country_id := id from civicrm_country where name = 'Colombia' AND iso_code = 'CO';
 INSERT IGNORE INTO `civicrm_state_province` (`id`, `country_id`, `abbreviation`, `name`) VALUES
 (NULL, @country_id, 'HUI', 'Huila');
+
+-- Fix empty civicrm_note.note_date
+UPDATE civicrm_note SET note_date = created_date WHERE note_date IS NULL;

--- a/tests/phpunit/CRM/Contact/Page/View/NoteTest.php
+++ b/tests/phpunit/CRM/Contact/Page/View/NoteTest.php
@@ -44,4 +44,39 @@ class CRM_Contact_Page_View_NoteTest extends CiviUnitTestCase {
     }
   }
 
+  /**
+   * Test that note_date is automatically set to created_date if empty
+   *
+   * @throws \API_Exception
+   * @throws \Civi\API\Exception\UnauthorizedException
+   */
+  public function testCreateNoteEmptyNoteDate() {
+    $contactID = $this->individualCreate();
+    $noteForm = new CRM_Note_Form_Note();
+    $noteForm->_action = CRM_Core_Action::ADD;
+    $noteForm->controller = new CRM_Core_Controller_Simple('CRM_Note_Form_Note', ts('Contact Notes'), CRM_Core_Action::ADD);
+    $noteForm->controller->setEmbedded(TRUE);
+    $noteForm->set('entityTable', 'civicrm_contact');
+    $noteForm->set('entityId', $contactID);
+    $noteForm->preProcess();
+    $noteForm->buildQuickForm();
+
+    $submitValues = [
+      'note' => 'testnote',
+      'note_date' => '',
+      'privacy' => '',
+      'parent_id' => '',
+      'subject' => 'testsubject',
+    ];
+    $container =& $noteForm->controller->container();
+    $container['values'][$noteForm->getName()] = $submitValues;
+    $noteForm->postProcess();
+
+    $savedNote = \Civi\Api4\Note::get(FALSE)
+      ->execute()
+      ->first();
+    // If note_date is empty it should have been set to created_date on create
+    $this->assertEquals($savedNote['created_date'], $savedNote['note_date']);
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Since https://github.com/civicrm/civicrm-core/pull/19738 notes are created with a blank `note_date` if the date is not filled in the UI. It was meant to take the created_date if not set but the form passes an empty string and it gets set to NULL.

Before
----------------------------------------
Empty note date since 5.37 if note date left blank in UI.

After
----------------------------------------
note_date = created_date if note date left blank in UI.

Technical Details
----------------------------------------
Described above. Added test for "Add note" form.

Comments
----------------------------------------
![image](https://user-images.githubusercontent.com/2052161/143957841-09b3a2d8-278d-4bbc-b263-7ddd47fb12f2.png)

