### PR TITLE
Smarty variables]  Prevent settings form assigned html from being escaped

### DIFF
--- a/templates/CRM/Admin/Form/Setting/SettingField.tpl
+++ b/templates/CRM/Admin/Form/Setting/SettingField.tpl
@@ -3,7 +3,7 @@
   <td class="label">{$form.$setting_name.label}</td>
   <td>
     {if !empty($fieldSpec.wrapper_element)}
-      {$fieldSpec.wrapper_element.0}{$form.$setting_name.html}{$fieldSpec.wrapper_element.1}
+      {$fieldSpec.wrapper_element.0|smarty:nodefaults}{$form.$setting_name.html}{$fieldSpec.wrapper_element.1|smarty:nodefaults}
     {else}
       {$form.$setting_name.html}
     {/if}


### PR DESCRIPTION
Overview
----------------------------------------
Prevent settings form assigned html from being escaped

Before
----------------------------------------
inappropriate escaping on https://dmaster.localhost:32353/civicrm/admin/setting/component?reset=1

Looks like this with smarty default escaping

![image](https://user-images.githubusercontent.com/336308/143960107-a07c2fc5-b337-493c-9f40-70c2e66d6fbb.png)


After
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/143960172-6d7a4cdb-0de3-40ab-a9a8-acc7a227ee4f.png)

Technical Details
----------------------------------------
This is assigned here

![image](https://user-images.githubusercontent.com/336308/143959977-8f05d54a-858f-4b63-8cce-358f43c62565.png)

Comments
----------------------------------------

