### PR TITLE
[Smarty Variables] Remove isset from location type form

### DIFF
--- a/CRM/Admin/Page/LocationType.php
+++ b/CRM/Admin/Page/LocationType.php
@@ -107,4 +107,24 @@ class CRM_Admin_Page_LocationType extends CRM_Core_Page_Basic {
     return 'civicrm/admin/locationType';
   }
 
+  /**
+   * @param $sort
+   * @param $action
+   * @param array $links
+   *
+   * @return array
+   */
+  protected function getRows($sort, $action, array $links): array {
+    $rows = parent::getRows($sort, $action, $links);
+    foreach ($rows as &$row) {
+      // prevent smarty notices.
+      foreach (['is_default', 'class', 'vcard_name'] as $expectedField) {
+        if (!isset($row['is_default'])) {
+          $row[$expectedField] = NULL;
+        }
+      }
+    }
+    return $rows;
+  }
+
 }

--- a/CRM/Core/Page/Basic.php
+++ b/CRM/Core/Page/Basic.php
@@ -203,67 +203,8 @@ abstract class CRM_Core_Page_Basic extends CRM_Core_Page {
     if ($action & CRM_Core_Action::ENABLE) {
       $action -= CRM_Core_Action::ENABLE;
     }
-    $baoString = $this->getBAOName();
-    $object = new $baoString();
 
-    $values = [];
-
-    // lets make sure we get the stuff sorted by name if it exists
-    $fields = &$object->fields();
-    $key = '';
-    if (!empty($fields['title'])) {
-      $key = 'title';
-    }
-    elseif (!empty($fields['label'])) {
-      $key = 'label';
-    }
-    elseif (!empty($fields['name'])) {
-      $key = 'name';
-    }
-
-    if (trim($sort)) {
-      $object->orderBy($sort);
-    }
-    elseif ($key) {
-      $object->orderBy($key . ' asc');
-    }
-
-    $contactTypes = CRM_Contact_BAO_ContactType::getSelectElements(FALSE, FALSE);
-    // find all objects
-    $object->find();
-    while ($object->fetch()) {
-      if (!isset($object->mapping_type_id) ||
-        // "1 for Search Builder"
-        $object->mapping_type_id != 1
-      ) {
-        $permission = CRM_Core_Permission::EDIT;
-        if ($key) {
-          $permission = $this->checkPermission($object->id, $object->$key);
-        }
-        if ($permission) {
-          $values[$object->id] = [];
-          CRM_Core_DAO::storeValues($object, $values[$object->id]);
-
-          if (is_a($object, 'CRM_Contact_DAO_RelationshipType')) {
-            if (isset($values[$object->id]['contact_type_a'])) {
-              $values[$object->id]['contact_type_a_display'] = $contactTypes[$values[$object->id]['contact_type_a']];
-            }
-            if (isset($values[$object->id]['contact_type_b'])) {
-              $values[$object->id]['contact_type_b_display'] = $contactTypes[$values[$object->id]['contact_type_b']];
-            }
-          }
-
-          // populate action links
-          $this->action($object, $action, $values[$object->id], $links, $permission);
-
-          if (isset($object->mapping_type_id)) {
-            $mappintTypes = CRM_Core_PseudoConstant::get('CRM_Core_DAO_Mapping', 'mapping_type_id');
-            $values[$object->id]['mapping_type'] = $mappintTypes[$object->mapping_type_id];
-          }
-        }
-      }
-    }
-    $this->assign('rows', $values);
+    $this->assign('rows', $this->getRows($sort, $action, $links));
   }
 
   /**
@@ -393,6 +334,77 @@ abstract class CRM_Core_Page_Basic extends CRM_Core_Page {
     $controller->setEmbedded(TRUE);
     $controller->process();
     $controller->run();
+  }
+
+  /**
+   * @param $sort
+   * @param $action
+   * @param array $links
+   *
+   * @return array
+   */
+  protected function getRows($sort, $action, array $links): array {
+    $baoString = $this->getBAOName();
+    $object = new $baoString();
+
+    $values = [];
+
+    // lets make sure we get the stuff sorted by name if it exists
+    $fields = &$object->fields();
+    $key = '';
+    if (!empty($fields['title'])) {
+      $key = 'title';
+    }
+    elseif (!empty($fields['label'])) {
+      $key = 'label';
+    }
+    elseif (!empty($fields['name'])) {
+      $key = 'name';
+    }
+
+    if (trim($sort)) {
+      $object->orderBy($sort);
+    }
+    elseif ($key) {
+      $object->orderBy($key . ' asc');
+    }
+
+    $contactTypes = CRM_Contact_BAO_ContactType::getSelectElements(FALSE, FALSE);
+    // find all objects
+    $object->find();
+    while ($object->fetch()) {
+      if (!isset($object->mapping_type_id) ||
+        // "1 for Search Builder"
+        $object->mapping_type_id != 1
+      ) {
+        $permission = CRM_Core_Permission::EDIT;
+        if ($key) {
+          $permission = $this->checkPermission($object->id, $object->$key);
+        }
+        if ($permission) {
+          $values[$object->id] = [];
+          CRM_Core_DAO::storeValues($object, $values[$object->id]);
+
+          if (is_a($object, 'CRM_Contact_DAO_RelationshipType')) {
+            if (isset($values[$object->id]['contact_type_a'])) {
+              $values[$object->id]['contact_type_a_display'] = $contactTypes[$values[$object->id]['contact_type_a']];
+            }
+            if (isset($values[$object->id]['contact_type_b'])) {
+              $values[$object->id]['contact_type_b_display'] = $contactTypes[$values[$object->id]['contact_type_b']];
+            }
+          }
+
+          // populate action links
+          $this->action($object, $action, $values[$object->id], $links, $permission);
+
+          if (isset($object->mapping_type_id)) {
+            $mappintTypes = CRM_Core_PseudoConstant::get('CRM_Core_DAO_Mapping', 'mapping_type_id');
+            $values[$object->id]['mapping_type'] = $mappintTypes[$object->mapping_type_id];
+          }
+        }
+      }
+    }
+    return $values;
   }
 
 }

--- a/templates/CRM/Admin/Page/LocationType.tpl
+++ b/templates/CRM/Admin/Page/LocationType.tpl
@@ -34,13 +34,13 @@
       </tr>
     </thead>
     {foreach from=$rows item=row}
-    <tr id="location_type-{$row.id}"  data-action="setvalue" class="{cycle values="odd-row,even-row"}{if !empty($row.class)} {$row.class}{/if} crm-entity {if NOT $row.is_active} disabled{/if}">
+    <tr id="location_type-{$row.id}"  data-action="setvalue" class="{cycle values="odd-row,even-row"} {$row.class} crm-entity {if NOT $row.is_active} disabled{/if}">
         <td class="crmf-name">{$row.name}</td>
         <td class="crmf-display_name crm-editable">{$row.display_name}</td>
-        <td class="crmf-vcard_name crm-editable">{if !empty($row.vcard_name)}{$row.vcard_name}{/if}</td>
+        <td class="crmf-vcard_name crm-editable">{$row.vcard_name}</td>
         <td class="crmf-description crm-editable">{$row.description}</td>
         <td id="row_{$row.id}_status" class="crmf-is_active">{if $row.is_active eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
-        <td class="crmf-is_default">{if isset($row.is_default)}{icon condition=$row.is_default}{ts}Default{/ts}{/icon}&nbsp;{/if}</td>
+        <td class="crmf-is_default">{if $row.is_default}{icon condition=$row.is_default}{ts}Default{/ts}{/icon}&nbsp;{/if}</td>
         <td>{$row.action|replace:'xx':$row.id}</td>
     </tr>
     {/foreach}

--- a/tests/phpunit/CRM/Core/FormTest.php
+++ b/tests/phpunit/CRM/Core/FormTest.php
@@ -50,6 +50,9 @@ class CRM_Core_FormTest extends CiviUnitTestCase {
       'Add New Tag' => [
         'civicrm/tag/edit?action=add&parent_id=',
       ],
+      'Location Type' => [
+        'civicrm/admin/locationType?reset=1',
+      ],
       'Assign Account to Financial Type' => [
         'civicrm/admin/financial/financialType/accounts?action=add&reset=1&aid=1',
       ],


### PR DESCRIPTION

Overview
----------------------------------------
[Smarty Variables] Remove isset from location type form

Before
----------------------------------------
/civicrm/admin/locationType?reset=1 has isset checks in smarty which do not work with escaping by default

After
----------------------------------------
always assigned

Technical Details
----------------------------------------
I extracted `getRows` so I could override it

Comments
----------------------------------------
