### PR TITLE
dev/mail#105 - Oauth dropdown missing on mail settings form

### DIFF
--- a/ext/oauth-client/Civi/Api4/OAuthProvider.php
+++ b/ext/oauth-client/Civi/Api4/OAuthProvider.php
@@ -62,6 +62,9 @@ class OAuthProvider extends Generic\AbstractEntity {
         [
           'name' => 'contactTemplate',
         ],
+        [
+          'name' => 'mailSettingsTemplate',
+        ],
       ];
     });
     return $action->setCheckPermissions($checkPermissions);


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/mail/-/issues/105

https://civicrm.stackexchange.com/questions/40773/cant-add-gmail-account-with-oauth

On the mail accounts page, there's supposed to be a dropdown in place of the usual Add button.

Before
----------------------------------------
1. Enable Oauth-client extension.
1. Set up gmail.
1. Go to the mail accounts page.
1. There isn't a dropdown to select gmail.

After
----------------------------------------
Ok

Technical Details
----------------------------------------
Looks like https://github.com/civicrm/civicrm-core/commit/60a6221505ce7914efb615df14ae664a04a7773f

Comments
----------------------------------------

