### PR TITLE
SearchKit - Fix regression for pseudoconstant selection

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchClause.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchClause.component.js
@@ -61,16 +61,21 @@
         }
       }
 
-      this.getField = function(expr) {
+      // Gets the first arg of type "field"
+      function getFirstArgFromExpr(expr) {
         if (!(expr in meta)) {
           meta[expr] = _.findWhere(searchMeta.parseExpr(expr).args, {type: 'field'});
         }
-        return meta[expr] && meta[expr].field;
+        return meta[expr] || {};
+      }
+
+      this.getField = function(expr) {
+        return getFirstArgFromExpr(expr).field;
       };
 
       this.getOptionKey = function(expr) {
-        var field = ctrl.getField(expr) || {};
-        return field.suffix ? field.suffix.slice(1) : 'id';
+        var arg = getFirstArgFromExpr(expr);
+        return arg.suffix ? arg.suffix.slice(1) : 'id';
       };
 
       this.addGroup = function(op) {


### PR DESCRIPTION
Overview
----------------------------------------
Fixes regression described in https://lab.civicrm.org/dev/report/-/issues/83 which was caused by #22130

Before
-------------
Options incorrectly matched, causing no results from search:
![image](https://user-images.githubusercontent.com/2874912/144093913-f6876821-1f20-4a9a-9de7-dbd633a63a78.png)

After
---------
Fixed