### PR TITLE
Avoid default escaping for blog titles

### DIFF
--- a/templates/CRM/Dashlet/Page/Blog.tpl
+++ b/templates/CRM/Dashlet/Page/Blog.tpl
@@ -52,7 +52,7 @@
         </div>
         <div class="crm-accordion-body">
           <div>{$article.description|smarty:nodefaults|purify}</div>
-          <p class="crm-news-feed-item-link"><a target="_blank" href="{$article.link|smarty:nodefaults|purify}" title="{$article.title|escape}"><i class="crm-i fa-external-link" aria-hidden="true"></i> {ts}read more{/ts}…</a></p>
+          <p class="crm-news-feed-item-link"><a target="_blank" href="{$article.link|smarty:nodefaults|purify}" title="{$article.title|smarty:nodefaults|escape}"><i class="crm-i fa-external-link" aria-hidden="true"></i> {ts}read more{/ts}…</a></p>
         </div>
       </div>
     {/foreach}


### PR DESCRIPTION

Overview
----------------------------------------
Avoid default escaping for blog titles

These have escaping - but we dont want the html to be escaped because it messed with Karin's emojis :-)


Before
----------------------------------------
Blog breaks when Karin parties (when smarty escape-by-default is enabled)

After
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/144117573-3aa5cadd-e309-4ec8-a654-60ecb6b3ed5d.png)


Technical Details
----------------------------------------
Yes, - it's a bit fugly - but it works & maybe in time we'll get more elegant but at this stage getting to the 'not broke' is my priority
Comments
----------------------------------------
