### PR TITLE
APIv4 - Add fixes & tests for domain-specific managed entities

### DIFF
--- a/Civi/Api4/Dashboard.php
+++ b/Civi/Api4/Dashboard.php
@@ -25,5 +25,6 @@ namespace Civi\Api4;
  * @package Civi\Api4
  */
 class Dashboard extends Generic\DAOEntity {
+  use Generic\Traits\ManagedEntity;
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Adds the "Dashboard" as a managedEntity in APIv4. Like "Navigation" it is domain specific; this adds tests for correct handling of domains with APIv4 managed entities.