### PR TITLE
Remove isset checks on isForm

### DIFF
--- a/templates/CRM/Case/Form/ActivityTab.tpl
+++ b/templates/CRM/Case/Form/ActivityTab.tpl
@@ -9,7 +9,7 @@
 *}
 {*this template is used for activity accordion*}
 {assign var=caseid value=$caseID}
-{if isset($isForm) and $isForm}
+{if $isForm}
   <div class="crm-accordion-wrapper crm-case_activities-accordion  crm-case-activities-block">
     <div class="crm-accordion-header">
       {ts}Activities{/ts}
@@ -104,7 +104,7 @@
     {/foreach}
   </style>
 
-{if isset($isForm) and $isForm}
+{if $isForm}
     </div><!-- /.crm-accordion-body -->
   </div><!-- /.crm-accordion-wrapper -->
 {/if}


### PR DESCRIPTION

Overview
----------------------------------------
Remove isset checks on isForm

Before
----------------------------------------
Fatal error with smarty escape by default on when creating a new case

After
----------------------------------------
We are now assigning these from Core_Page so they should be set. If we do get
an enotice back from this then as long as it passes tests it will
be the lesser evil & picked up later


Technical Details
----------------------------------------
@demeritcowboy there are a few issets still lurking in the case code - trying to make sense of them - but there are already smarty enotices so if I can get them through tests I'm not gonna stress if there is a notice regression. Just trying to deal to a few more

Comments
----------------------------------------
