### PR TITLE
Smarty variables]  Remove isset from relationship tab

### DIFF
--- a/CRM/Contact/Page/View/Relationship.php
+++ b/CRM/Contact/Page/View/Relationship.php
@@ -197,6 +197,7 @@ class CRM_Contact_Page_View_Relationship extends CRM_Core_Page {
    * @throws \CRM_Core_Exception
    */
   public function run() {
+    $this->assign('entityInClassFormat', 'relationship');
     $this->preProcessQuickEntityPage();
 
     $this->setContext();

--- a/CRM/Contact/Page/View/UserDashBoard.php
+++ b/CRM/Contact/Page/View/UserDashBoard.php
@@ -132,6 +132,7 @@ class CRM_Contact_Page_View_UserDashBoard extends CRM_Core_Page {
       $contactRelationships = $selector = NULL;
       CRM_Utils_Hook::searchColumns('relationship.columns', $columnHeaders, $contactRelationships, $selector);
       $this->assign('columnHeaders', $columnHeaders);
+      $this->assign('entityInClassFormat', 'relationship');
       $dashboardElements[] = [
         'class' => 'crm-dashboard-permissionedOrgs',
         'templatePath' => 'CRM/Contact/Page/View/RelationshipSelector.tpl',

--- a/templates/CRM/Contact/Page/View/RelationshipSelector.tpl
+++ b/templates/CRM/Contact/Page/View/RelationshipSelector.tpl
@@ -8,11 +8,7 @@
  +--------------------------------------------------------------------+
 *}
 {* entity selector *}
-{crmRegion name="crm-contact-relationshipselector-pre"}
-{/crmRegion}
-{if !isset($entityInClassFormat)}
-   {assign var="entityInClassFormat" value="relationship"}
-{/if}
+{crmRegion name="crm-contact-relationshipselector-pre"}{/crmRegion}
 <div class="crm-contact-{$entityInClassFormat}-{$context}">
   <table
     class="crm-contact-{$entityInClassFormat}-selector-{$context} crm-ajax-table"

--- a/tests/phpunit/CRM/Contact/Page/View/UserDashBoardTest.php
+++ b/tests/phpunit/CRM/Contact/Page/View/UserDashBoardTest.php
@@ -74,7 +74,7 @@ class CRM_Contact_Page_View_UserDashBoardTest extends CiviUnitTestCase {
   /**
    * Test the content of the dashboard.
    */
-  public function testDashboardContentContributionsWithInvoicingEnabled() {
+  public function testDashboardContentContributionsWithInvoicingEnabled(): void {
     $this->contributions[] = $this->contributionCreate([
       'contact_id' => $this->contactID,
       'receive_date' => '2018-11-21',
@@ -193,7 +193,7 @@ class CRM_Contact_Page_View_UserDashBoardTest extends CiviUnitTestCase {
   /**
    * Run the user dashboard.
    */
-  protected function runUserDashboard() {
+  protected function runUserDashboard(): void {
     $_REQUEST = ['reset' => 1, 'id' => $this->contactID];
     $dashboard = new CRM_Contact_Page_View_UserDashBoard();
     $dashboard->_contactId = $this->contactID;


### PR DESCRIPTION

Overview
----------------------------------------
Remove isset from relationship tab
civicrm/contact/view?reset=1&cid=2&relatedChild=relationship


Before
----------------------------------------
Seems like this was always assigned in the tpl layer after isset checking

After
----------------------------------------
Assigned early in php layer (possibly a hook might override but assigns are easily overriden in hooks

Technical Details
----------------------------------------

Comments
----------------------------------------
