### PR TITLE
dev/core#2973 - All custom fields broken on edit forms

### DIFF
--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -1827,7 +1827,7 @@ SELECT IF( EXISTS(SELECT name FROM civicrm_contact_type WHERE name like %1), 1, 
       $expectedProperties = ['options_per_line', 'help_pre', 'help_post'];
       // add field information
       foreach ($value['fields'] as $k => $properties) {
-        $properties = array_merge(array_fill_keys($expectedProperties, 'NULL'), $properties);
+        $properties = array_merge(array_fill_keys($expectedProperties, NULL), $properties);
         $properties['element_name'] = "custom_{$k}_-{$groupCount}";
         if (isset($properties['customValue']) &&
           !CRM_Utils_System::isNull($properties['customValue']) &&


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/2973

All custom fields broken on edit forms

Before
----------------------------------------
![Untitled](https://user-images.githubusercontent.com/2967821/144122900-7e1ec786-fd4f-41d5-8884-98dc063c7504.png)


After
----------------------------------------
Normal

Technical Details
----------------------------------------
https://github.com/civicrm/civicrm-core/pull/22139/files#diff-d20bbdac5d9d1d3ec28be6f1972f8cb747ead74dea90c9076daa2de2a627873cR1830

Comments
----------------------------------------
I'm trying to figure out how to write a test for this because it's so clearly the wrong output.
