### PR TITLE
fixes core#2974, overrides break membership update status when removed

### DIFF
--- a/templates/CRM/Member/Form/Membership.tpl
+++ b/templates/CRM/Member/Form/Membership.tpl
@@ -421,6 +421,7 @@
           cj('#memberStatus').hide();
           cj('#memberStatus_show').show();
           cj('#status-override-end-date').hide();
+          cj('#status_id option[selected]').removeAttr('selected');
           break;
         case '1':
           cj('#memberStatus').show();
@@ -436,6 +437,7 @@
           cj('#memberStatus').hide( );
           cj('#memberStatus_show').show( );
           cj('#status-override-end-date').hide();
+          cj('#status_id option[selected]').removeAttr('selected');
           break;
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------
Membership status update breaks if override is removed.  Replication steps at https://lab.civicrm.org/dev/core/-/issues/2974

Before
----------------------------------------
Membership status won't update after override is removed.

After
----------------------------------------
Membership status updates.
