### PR TITLE
[Smarty variables] Remove isset from add new group form

### DIFF
--- a/CRM/Group/Form/Edit.php
+++ b/CRM/Group/Form/Edit.php
@@ -92,6 +92,8 @@ class CRM_Group_Form_Edit extends CRM_Core_Form {
    * Set up variables to build the form.
    */
   public function preProcess() {
+    $this->addOptionalQuickFormElement('parents');
+    $this->addExpectedSmartyVariable('parent_groups');
     $this->_id = $this->get('id');
     if ($this->_id) {
       $breadCrumb = array(

--- a/templates/CRM/Group/Form/GroupsCommon.tpl
+++ b/templates/CRM/Group/Form/GroupsCommon.tpl
@@ -8,9 +8,9 @@
  +--------------------------------------------------------------------+
 *}
 {*CRM-14190*}
-{if (isset($parent_groups) and $parent_groups|@count > 0) or !empty($form.parents.html)}
+{if $parent_groups|@count > 0 || !empty($form.parents.html)}
   <h3>{ts}Parent Groups{/ts} {help id="id-group-parent" file="CRM/Group/Page/Group.hlp"}</h3>
-  {if isset($parent_groups) and $parent_groups|@count > 0}
+  {if $parent_groups|@count > 0}
     <table class="form-layout-compressed">
       <tr>
         <td><label>{ts}Remove Parent?{/ts}</label></td>


### PR DESCRIPTION

Overview
----------------------------------------
Remove isset from add new group form

civicrm/group/add?reset=1


Before
----------------------------------------
fatal error if smarty default escaping enabled

After
----------------------------------------
works

Technical Details
----------------------------------------

Comments
----------------------------------------
