### PR TITLE
ManagedEntities - Fix permission error during uninstallation (regression-fix)

### DIFF
--- a/CRM/Core/ManagedEntities.php
+++ b/CRM/Core/ManagedEntities.php
@@ -464,6 +464,7 @@ class CRM_Core_ManagedEntities {
     // CRM_Core_BAO_Managed::on_hook_civicrm_post()
     if ($doDelete && CRM_Core_BAO_Managed::isApi4ManagedType($dao->entity_type)) {
       civicrm_api4($dao->entity_type, 'delete', [
+        'checkPermissions' => FALSE,
         'where' => [['id', '=', $dao->entity_id]],
       ]);
     }


### PR DESCRIPTION
Overview
--------

Fixes a recent regression that prevents you from uninstalling extensions via CLI.  This specifically affects extensions which use managed entities.

ping @colemanw 

Steps to reproduce
------------------

```
cv en afform
cv dis afform
cv ext:uninstall afform
```

Before
-------

```
[bknix-max:~/bknix/build/dmaster/web/sites/all/modules/civicrm] cv en afform && cv dis afform && cv ext:uninstall afform
Enabling extension "org.civicrm.afform"
Disabling extension "org.civicrm.afform"
Uninstalling extension "org.civicrm.afform"
Error: API Call Failed: Array
(
    [entity] => Extension
    [action] => uninstall
    [params] => Array
        (
            [keys] => Array
                (
                    [0] => org.civicrm.afform
                )

            [debug] => 1
            [version] => 3
        )

    [result] => Array
        (
            [error_code] => unauthorized
            [entity] => Extension
            [action] => uninstall
            [trace] => #0 /home/me/bknix/build/dmaster/web/sites/all/modules/civicrm/Civi/API/Kernel.php(147): Civi\API\Kernel->authorize(Object(Civi\Api4\Provider\ActionObjectProvider), Object(Civi\Api4\Generic\DAODeleteAction))
 #1 /home/me/bknix/build/dmaster/web/sites/all/modules/civicrm/Civi/Api4/Generic/AbstractAction.php(234): Civi\API\Kernel->runRequest(Object(Civi\Api4\Generic\DAODeleteAction))
 #2 /home/me/bknix/build/dmaster/web/sites/all/modules/civicrm/api/api.php(85): Civi\Api4\Generic\AbstractAction->execute()
 #3 /home/me/bknix/build/dmaster/web/sites/all/modules/civicrm/CRM/Core/ManagedEntities.php(467): civicrm_api4('OptionValue', 'delete', Array)
 #4 /home/me/bknix/build/dmaster/web/sites/all/modules/civicrm/CRM/Core/ManagedEntities.php(303): CRM_Core_ManagedEntities->removeStaleEntity(Object(CRM_Core_DAO_Managed))
 #5 /home/me/bknix/build/dmaster/web/sites/all/modules/civicrm/CRM/Core/ManagedEntities.php(134): CRM_Core_ManagedEntities->reconcileUnknownModules()
 #6 /home/me/bknix/build/dmaster/web/sites/all/modules/civicrm/CRM/Core/Invoke.php(409): CRM_Core_ManagedEntities->reconcile()
 #7 /home/me/bknix/build/dmaster/web/sites/all/modules/civicrm/CRM/Extension/Manager.php(483): CRM_Core_Invoke::rebuildMenuAndCaches(true)
 #8 /home/me/bknix/build/dmaster/web/sites/all/modules/civicrm/api/v3/Extension.php(183): CRM_Extension_Manager->uninstall(Array)
 #9 /home/me/bknix/build/dmaster/web/sites/all/modules/civicrm/Civi/API/Provider/MagicFunctionProvider.php(89): civicrm_api3_extension_uninstall(Array)
 #10 /home/me/bknix/build/dmaster/web/sites/all/modules/civicrm/Civi/API/Kernel.php(149): Civi\API\Provider\MagicFunctionProvider->invoke(Array)
 #11 /home/me/bknix/build/dmaster/web/sites/all/modules/civicrm/Civi/API/Kernel.php(81): Civi\API\Kernel->runRequest(Array)
 #12 /home/me/bknix/build/dmaster/web/sites/all/modules/civicrm/api/api.php(22): Civi\API\Kernel->runSafe('Extension', 'uninstall', Array)
 #13 phar:///home/me/bknix/bin/cv/src/Command/BaseCommand.php(49): civicrm_api('Extension', 'uninstall', Array)
 #14 phar:///home/me/bknix/bin/cv/src/Command/ExtensionUninstallCommand.php(63): Civi\Cv\Command\BaseCommand->callApiSuccess(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput), 'Extension', 'uninstall', Array)
 #15 phar:///home/me/bknix/bin/cv/vendor/symfony/console/Command/Command.php(257): Civi\Cv\Command\ExtensionUninstallCommand->execute(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
 #16 phar:///home/me/bknix/bin/cv/vendor/symfony/console/Application.php(850): Symfony\Component\Console\Command\Command->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
 #17 phar:///home/me/bknix/bin/cv/vendor/symfony/console/Application.php(193): Symfony\Component\Console\Application->doRunCommand(Object(Civi\Cv\Command\ExtensionUninstallCommand), Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
 #18 phar:///home/me/bknix/bin/cv/src/Application.php(46): Symfony\Component\Console\Application->doRun(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
 #19 phar:///home/me/bknix/bin/cv/vendor/symfony/console/Application.php(124): Civi\Cv\Application->doRun(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
 #20 phar:///home/me/bknix/bin/cv/src/Application.php(15): Symfony\Component\Console\Application->run()
 #21 phar:///home/me/bknix/bin/cv/bin/cv(27): Civi\Cv\Application::main('phar:///Users/t...')
 #22 /home/me/bknix/bin/cv(14): require('phar:///Users/t...')
 #23 {main}
            [is_error] => 1
            [error_message] => Authorization failed
        )

)
```

After
-----

Works

Comment
-------

* I encountered this while working on E2E test-coverage for other changes. The E2E test coverage had worked on a previous iteration of 5.45.alpha1 but failed when I rebased.

* I bisected and traced back to [Civi\Api4\OptionGroup - use ManagedEntity](https://github.com/civicrm/civicrm-core/commit/052cd54644#diff-959bdee426a61d6193d2c5dee475f060dd374a49ec37ebf3ea9a52c8fea78e5fL21-R23). This change had the effect of switching some of the `ManagedEntities` tasks from APIv3 to APIv4. And thus the APIv4 security model became relevant.

* You can see a prior draft of the E2E test [here](https://github.com/totten/shimmy/blob/master-reorg/shimmy/tests/phpunit/E2E/Shimmy/LifecycleTest.php#L56-L77). However, it's being reworked as a core patch.

* I'd suggest accepting this without a test - because (a) it's a regression and (b) there will be coverage from the pending change.
