### PR TITLE
[Smarty variables] Remove issets from payment processor form

### DIFF
--- a/CRM/Admin/Page/PaymentProcessorType.php
+++ b/CRM/Admin/Page/PaymentProcessorType.php
@@ -105,4 +105,13 @@ class CRM_Admin_Page_PaymentProcessorType extends CRM_Core_Page_Basic {
     return 'civicrm/admin/paymentProcessorType';
   }
 
+  /**
+   * Get any properties that should always be present in each row (null if no value).
+   *
+   * @return array
+   */
+  protected function getExpectedRowProperties(): array {
+    return ['class', 'description'];
+  }
+
 }

--- a/CRM/Core/Page/Basic.php
+++ b/CRM/Core/Page/Basic.php
@@ -404,7 +404,23 @@ abstract class CRM_Core_Page_Basic extends CRM_Core_Page {
         }
       }
     }
+    foreach ($this->getExpectedRowProperties() as $key) {
+      foreach ($values as $index => $value) {
+        if (!array_key_exists($key, $value)) {
+          $values[$index][$key] = NULL;
+        }
+      }
+    }
     return $values;
+  }
+
+  /**
+   * Get any properties that should always be present in each row (null if no value).
+   *
+   * @return array
+   */
+  protected function getExpectedRowProperties(): array {
+    return [];
   }
 
 }

--- a/templates/CRM/Admin/Page/PaymentProcessorType.tpl
+++ b/templates/CRM/Admin/Page/PaymentProcessorType.tpl
@@ -31,10 +31,10 @@
             <th></th>
         </tr>
         {foreach from=$rows item=row}
-        <tr id="paymentProcessorType-{$row.id}" class="{cycle values="odd-row,even-row"}{if !empty($row.class)} {$row.class}{/if} crm-entity {if NOT $row.is_active} disabled{/if}">
+        <tr id="paymentProcessorType-{$row.id}" class="{cycle values="odd-row,even-row"} {$row.class} crm-entity {if NOT $row.is_active} disabled{/if}">
           <td class="crm-paymentProcessorType-name">{$row.name}</td>
           <td class="crm-paymentProcessorType-title crm-editable" data-field="title">{$row.title}</td>
-            <td class="crm-paymentProcessorType-description">{if isset($row.description)}{$row.description}{/if}</td>
+            <td class="crm-paymentProcessorType-description">{$row.description}</td>
           <td id="row_{$row.id}_status" class="crm-paymentProcessorType-is_active">{if $row.is_active eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
             <td class="crm-paymentProcessorType-is_default">{icon condition=$row.is_default}{ts}Default{/ts}{/icon}&nbsp;</td>
           <td>{$row.action}</td>


### PR DESCRIPTION
Overview
----------------------------------------
[Smarty variables] Remove issets from payment processor form

civicrm/admin/paymentProcessorType?reset=1

Before
----------------------------------------
Fatals on payment processor type view with escape by default enabled

After
----------------------------------------
works

Technical Details
----------------------------------------

Comments
----------------------------------------
