### PR TITLE
[Smarty variables] Fix overzealous escaping with smarty default escaping

### DIFF
--- a/templates/CRM/common/formButtons.tpl
+++ b/templates/CRM/common/formButtons.tpl
@@ -24,7 +24,7 @@
       {capture assign=linkname}name="{$linkButton.ref}"{/capture}
     {else}{capture assign=linkname}name="{$linkButton.name}"{/capture}
     {/if}
-    <a class="button" {$linkname} href="{crmURL p=$linkButton.url q=$linkButton.qs}" {$accessKey} {$linkButton.extra}><span>{$icon}{$linkButton.title}</span></a>
+    <a class="button" {$linkname} href="{crmURL p=$linkButton.url q=$linkButton.qs}" {$accessKey} {$linkButton.extra}><span>{$icon|smarty:nodefaults}{$linkButton.title}</span></a>
   {/foreach}
 {/if}
 


### PR DESCRIPTION
Overview
----------------------------------------
Fix overzealous escaping with smarty default escaping

( if you add define('CIVICRM_SMARTY_DEFAULT_ESCAPE', TRUE); to civicrm.settings.php & then clear templates_c it borks )

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/144140344-6b6540a1-d663-4ffd-ad7b-2dc28eba9129.png)


After
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/144140383-412f19a7-62b4-407d-811e-d9a0ff43f117.png)

Technical Details
----------------------------------------


Comments
----------------------------------------
