### PR TITLE
[Smarty variables]  Remove issets relating to auto_renew

### DIFF
--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -549,6 +549,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
    */
   private function buildMembershipBlock($cid, $selectedMembershipTypeID = NULL, $isTest = NULL) {
     $separateMembershipPayment = FALSE;
+    $this->addOptionalQuickFormElement('auto_renew');
     if ($this->_membershipBlock) {
       $this->_currentMemberships = [];
 

--- a/templates/CRM/Contribute/Form/Contribution/MembershipBlock.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/MembershipBlock.tpl
@@ -195,7 +195,7 @@
         </tr>
 
       {/foreach}
-      {if isset($form.auto_renew) }
+      {if $form.auto_renew}
         <tr id="allow_auto_renew">
           <td style="width: auto;">{$form.auto_renew.html}</td>
           <td style="width: auto;">

--- a/templates/CRM/Price/Form/PriceSet.tpl
+++ b/templates/CRM/Price/Form/PriceSet.tpl
@@ -101,7 +101,7 @@
                     <div class='crm-section auto-renew'>
                       <div class='label'></div>
                       <div class='content' id="auto_renew_section">
-                        {if isset($form.auto_renew) }
+                        {if $form.auto_renew}
                           {$form.auto_renew.html}&nbsp;{$form.auto_renew.label}
                         {/if}
                       </div>


### PR DESCRIPTION

Overview
----------------------------------------
[Smarty variables] Remove issets relating to auto_renew

On demo site these are hit at civicrm/contribute/transact?reset=1&id=2

Before
----------------------------------------
Fatals with smarty escape by default enabled

After
----------------------------------------
works

Technical Details
----------------------------------------

Comments
----------------------------------------
