### PR TITLE
DebugSubscriber - Fix test-suite compatibility with XDebug 3

### DIFF
--- a/Civi/API/Subscriber/DebugSubscriber.php
+++ b/Civi/API/Subscriber/DebugSubscriber.php
@@ -25,6 +25,29 @@ class DebugSubscriber implements EventSubscriberInterface {
   private $debugLog;
 
   /**
+   * @var bool
+   */
+  private $enableStats;
+
+  public function __construct() {
+    $version = phpversion('xdebug');
+    switch ($version ? substr($version, 0, 2) : NULL) {
+      case '2.':
+        $this->enableStats = function_exists('xdebug_time_index');
+        break;
+
+      case '3.':
+        $xdebugMode = explode(',', ini_get('xdebug.mode'));
+        $this->enableStats = in_array('develop', $xdebugMode);
+        break;
+
+      default:
+        $this->enableStats = FALSE;
+        break;
+    }
+  }
+
+  /**
    * @return array
    */
   public static function getSubscribedEvents() {
@@ -70,7 +93,7 @@ class DebugSubscriber implements EventSubscriberInterface {
       if (isset($this->debugLog) && $this->debugLog->getMessages()) {
         $debug['log'] = $this->debugLog->getMessages();
       }
-      if (function_exists('xdebug_time_index')) {
+      if ($this->enableStats) {
         $debug['peakMemory'] = xdebug_peak_memory_usage();
         $debug['memory'] = xdebug_memory_usage();
         $debug['timeIndex'] = xdebug_time_index();


### PR DESCRIPTION
Overview
----------------------------------------

The `DebugSubscriber` listens to APIv3 calls and appends extra debug information (memory usage, runtime, etc). Of course, this only works in some environments (eg when XDebug is enabled). The `DebugSubscriber` includes some guards to enable/disable data depending on XDebug v2 presence. This fixes the guard to also work with XDebug v3.

ping @seamuslee001 

Before
----------------------------------------

If you run with XDebug 3 and use `xdebug.mode=debug`, then several tests will fail with errors like this:

```
Failure in api call for Payment get:  Function must be enabled in php.ini by setting 'xdebug.mode' to 'develop'
#0 /Users/totten/bknix/build/dmaster/web/sites/all/modules/civicrm/api/v3/Payment.php(50): civicrm_api3('FinancialTrxn', 'get', Array)
#1 /Users/totten/bknix/build/dmaster/web/sites/all/modules/civicrm/Civi/API/Provider/MagicFunctionProvider.php(89): civicrm_api3_payment_get(Array)
#2 /Users/totten/bknix/build/dmaster/web/sites/all/modules/civicrm/Civi/API/Kernel.php(149): Civi\API\Provider\MagicFunctionProvider->invoke(Array)
```

The problem? In XDebug v3, `xdebug_time_index()` only works if `php.ini` specifies ["xdebug.mode=develop"](https://xdebug.org/docs/all_settings#mode). Otherwise, it will emit warnings and return NULL. The warnings manifest as test-failures.

After
----------------------------------------

Tests pass. `xdebug_time_index` is not called if it's not going work.

Comments
----------------------------------------

* In XDebug v3, the setting `xdebug.mode` is a comma-separated list of values from https://xdebug.org/docs/all_settings#mode
* XDebug v3 has multiple ways to set `xdebug.mode`/`XDEBUG_MODE`. I was a little confused about how to rapidly experiment with different values, so I played with a few formulations. The first in this list (`php -d xdebug.mode...`) appears to be the most consistent/reliable when setting multiple modes.
    ```
    php -d 'xdebug.mode=develop,debug' -r 'print_r([ini_get("xdebug.mode")]);'

    XDEBUG_MODE=develop,debug php -r 'print_r([ini_get("xdebug.mode")]);'
    XDEBUG_MODE="develop debug" php -r 'print_r([ini_get("xdebug.mode")]);'

    XDEBUG_MODE=develop,debug php -d 'xdebug.mode=develop,debug' -r 'print_r([ini_get("xdebug.mode")]);'
    XDEBUG_MODE="develop debug" php -d 'xdebug.mode=develop,debug'  -r 'print_r([ini_get("xdebug.mode")]);'
    ```
* So for example you can run commands like these:
    ```
    php -d 'xdebug.mode=off' ./bin/cv.phar ev 'return civicrm_api3("Contact","get",["debug"=>1])["xdebug"];'
    ## ^^ Does not try to generate stats

    php -d 'xdebug.mode=debug' ./bin/cv.phar ev 'return civicrm_api3("Contact","get",["debug"=>1])["xdebug"];'
    ## ^^ Does not try to generate stats

    php -d 'xdebug.mode=develop' ./bin/cv.phar ev 'return civicrm_api3("Contact","get",["debug"=>1])["xdebug"];'
    ## ^^ Does try to generate stats - and succeeds

    php -d 'xdebug.mode=debug,develop' ./bin/cv.phar ev 'return civicrm_api3("Contact","get",["debug"=>1])["xdebug"];'
    ## ^^ Does try to generate stats - and succeeds
    ```
* Background: https://xdebug.org/docs/upgrade_guide