### PR TITLE
civix#175 - Add support for mixins. Switch core extensions to mixin/setting-php

### DIFF
--- a/CRM/Extension/BootCache.php
+++ b/CRM/Extension/BootCache.php
@@ -1,0 +1,85 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ */
+class CRM_Extension_BootCache {
+
+  protected $locked = FALSE;
+
+  protected $data;
+
+  /**
+   * Define a persistent value in the extension's boot-cache.
+   *
+   * This value is retained as part of the boot-cache. It will be loaded
+   * very quickly (eg via php op-code caching). However, as a trade-off,
+   * you will not be able to change/reset at runtime - it will only
+   * reset in response to a system-wide flush or redeployment.
+   *
+   * Ex: $mix->define('initTime', function() { return time(); });
+   *
+   * @param string $key
+   * @param mixed $callback
+   * @return mixed
+   *   The value of $callback (either cached or fresh)
+   */
+  public function define($key, $callback) {
+    if (!isset($this->data[$key])) {
+      $this->set($key, $callback($this));
+    }
+    return $this->data[$key];
+  }
+
+  /**
+   * Determine if $key has been set.
+   *
+   * @param string $key
+   * @return bool
+   */
+  public function has($key) {
+    return isset($this->data[$key]);
+  }
+
+  /**
+   * Get the value of $key.
+   *
+   * @param string $key
+   * @param mixed $default
+   * @return mixed
+   */
+  public function get($key, $default = NULL) {
+    return $this->data[$key] ?? $default;
+  }
+
+  /**
+   * Set a value in the cache.
+   *
+   * This operation is only valid on the first page-load when a cache is built.
+   *
+   * @param string $key
+   * @param mixed $value
+   * @return static
+   * @throws \Exception
+   */
+  public function set($key, $value) {
+    if ($this->locked) {
+      throw new \Exception("Cannot modify a locked boot-cache.");
+    }
+    $this->data[$key] = $value;
+    return $this;
+  }
+
+  public function lock() {
+    $this->locked = TRUE;
+  }
+
+}

--- a/CRM/Extension/Info.php
+++ b/CRM/Extension/Info.php
@@ -46,6 +46,13 @@ class CRM_Extension_Info {
 
   /**
    * @var array
+   *   List of expected mixins.
+   *   Ex: ['civix@2.0.0']
+   */
+  public $mixins = [];
+
+  /**
+   * @var array
    *   List of strings (tag-names).
    */
   public $tags = [];
@@ -195,6 +202,12 @@ class CRM_Extension_Info {
         $this->tags = [];
         foreach ($val->tag as $tag) {
           $this->tags[] = (string) $tag;
+        }
+      }
+      elseif ($attr === 'mixins') {
+        $this->mixins = [];
+        foreach ($val->mixin as $mixin) {
+          $this->mixins[] = (string) $mixin;
         }
       }
       elseif ($attr === 'requires') {

--- a/CRM/Extension/MixInfo.php
+++ b/CRM/Extension/MixInfo.php
@@ -1,0 +1,73 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * "Mixins" allow extensions to be initialized with small, reusable chunks of code.
+ *
+ * Example: A mixin might scan an extension for YAML files, aggregate them, add that
+ * to the boot-cache, and use the results to register event-listeners during initialization.
+ *
+ * Mixins have the following characteristics:
+ *
+ * - They are defined by standalone PHP files, e.g. `civix@1.0.2.mixin.php`
+ * - They are implicitly versioned via strict SemVer. (`1.1.0` can replace `1.0.0`; `2.0.0` and `1.0.0` are separate/parallel things).
+ * - They are activated via `info.xml` (`<mix>civix@1.0</mix>`).
+ * - They may be copied/reproduced in multiple extensions.
+ * - They are de-duped - such that a major-version (eg `civix@1` or `civix@2`) is only loaded once.
+ *
+ * The "MixInfo" record tracks the mixins needed by an extension. You may consider this an
+ * optimized subset of the 'info.xml'. (The mix-info is loaded on every page-view, so this
+ * record is serialized and stored in the MixinLoader cache.)
+ */
+class CRM_Extension_MixInfo {
+
+  /**
+   * @var string
+   *
+   * Ex: 'org.civicrm.flexmailer'
+   */
+  public $longName;
+
+  /**
+   * @var string
+   *
+   * Ex: 'flexmailer'
+   */
+  public $shortName;
+
+  /**
+   * @var string|null
+   *
+   * Ex: '/var/www/modules/civicrm/ext/flexmailer'.
+   */
+  public $path;
+
+  /**
+   * @var array
+   *   Ex: ['civix@2.0', 'menu@1.0']
+   */
+  public $mixins;
+
+  /**
+   * Get a path relative to the target extension.
+   *
+   * @param string $relPath
+   * @return string
+   */
+  public function getPath($relPath = NULL) {
+    return $relPath === NULL ? $this->path : $this->path . DIRECTORY_SEPARATOR . ltrim($relPath, '/');
+  }
+
+  public function isActive() {
+    return \CRM_Extension_System::singleton()->getMapper()->isActiveModule($this->shortName);
+  }
+
+}

--- a/CRM/Extension/MixinLoader.php
+++ b/CRM/Extension/MixinLoader.php
@@ -1,0 +1,207 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * The MixinLoader tracks a list of extensions and mixins.
+ */
+class CRM_Extension_MixinLoader {
+
+  /**
+   * @var \CRM_Extension_MixInfo[]
+   */
+  protected $mixInfos = [];
+
+  /**
+   * @var array|null
+   *   If we have not scanned for live funcs, then NULL.
+   *   Otherwise, every live version-requirement is mapped to the corresponding file.
+   *   Ex: ['civix@1' => 'path/to/civix@1.0.0.mixin.php']
+   */
+  protected $liveFuncFiles = NULL;
+
+  /**
+   * @var array
+   *   Ex: ['civix' => ['1.0.0' => 'path/to/civix@1.0.0.mixin.php']]
+   */
+  protected $allFuncFiles = [];
+
+  /**
+   * @param CRM_Extension_MixInfo $mix
+   * @return static
+   * @throws \CRM_Extension_Exception_ParseException
+   */
+  public function addMixInfo(CRM_Extension_MixInfo $mix) {
+    $this->mixInfos[$mix->longName] = $mix;
+    return $this;
+  }
+
+  /**
+   * @param array|string $files
+   *   Ex: 'path/to/some/file@1.0.0.mixin.php'
+   * @param bool $deepRead
+   *   If TRUE, then the file will be read to find metadata.
+   * @return $this
+   */
+  public function addFunctionFiles($files, $deepRead = FALSE) {
+    $files = (array) $files;
+    foreach ($files as $file) {
+      if (preg_match(';^([^@]+)@([^@]+)\.mixin\.php$;', basename($file), $m)) {
+        $this->allFuncFiles[$m[1]][$m[2]] = $file;
+        continue;
+      }
+
+      if ($deepRead) {
+        $header = $this->loadFunctionFileHeader($file);
+        if (isset($header['mixinName'], $header['mixinVersion'])) {
+          $this->allFuncFiles[$header['mixinName']][$header['mixinVersion']] = $file;
+          continue;
+        }
+        else {
+          error_log(sprintf('MixinLoader: Invalid mixin header for "%s". @mixinName and @mixinVersion required.', $file));
+          continue;
+        }
+      }
+
+      error_log(sprintf('MixinLoader: File \"%s\" cannot be parsed.', $file));
+    }
+    return $this;
+  }
+
+  private function loadFunctionFileHeader($file) {
+    $php = file_get_contents($file, TRUE);
+    foreach (token_get_all($php) as $token) {
+      if (is_array($token) && in_array($token[0], [T_DOC_COMMENT, T_COMMENT, T_FUNC_C, T_METHOD_C, T_TRAIT_C, T_CLASS_C])) {
+        return \Civi\Api4\Utils\ReflectionUtils::parseDocBlock($token[1]);
+      }
+    }
+    return [];
+  }
+
+  /**
+   * Optimize the metadata, removing information that is not needed at runtime.
+   *
+   * Steps:
+   *
+   * - Remove any unnecessary $mixInfos (ie they have no mixins).
+   * - Given the available versions and expectations, pick the best $liveFuncFiles.
+   * - Drop $allFuncFiles.
+   */
+  public function compile() {
+    $this->liveFuncFiles = [];
+    $allFuncs = $this->allFuncFiles ?? [];
+
+    $sortByVer = function ($a, $b) {
+      return version_compare($a, $b /* ignore third arg */);
+    };
+    foreach (array_keys($allFuncs) as $name) {
+      uksort($allFuncs[$name], $sortByVer);
+    }
+
+    $this->mixInfos = array_filter($this->mixInfos, function(CRM_Extension_MixInfo $mixInfo) {
+      return !empty($mixInfo->mixins);
+    });
+
+    foreach ($this->mixInfos as $ext) {
+      /** @var \CRM_Extension_MixInfo $ext */
+      foreach ($ext->mixins as $verExpr) {
+        list ($name, $expectVer) = explode('@', $verExpr);
+        $matchFile = NULL;
+        // NOTE: allFuncs[$name] is sorted by increasing version number. Choose highest satisfactory match.
+        foreach ($allFuncs[$name] ?? [] as $availVer => $availFile) {
+          if (static::satisfies($expectVer, $availVer)) {
+            $matchFile = $availFile;
+          }
+        }
+        if ($matchFile) {
+          $this->liveFuncFiles[$verExpr] = $matchFile;
+        }
+        else {
+          error_log(sprintf('MixinLoader: Failed to locate match for "%s"', $verExpr));
+        }
+      }
+    }
+
+    $this->allFuncFiles = NULL;
+
+    return $this;
+  }
+
+  /**
+   * Load all extensions and call their respective function-files.
+   *
+   * @return static
+   * @throws \CRM_Core_Exception
+   */
+  public function run(CRM_Extension_BootCache $bootCache) {
+    if ($this->liveFuncFiles === NULL) {
+      throw new CRM_Core_Exception("Premature initialization. MixinLoader has not identified live functions.");
+    }
+
+    // == WIP ==
+    //
+    //Do mixins run strictly once (during boot)? Or could they run twice? Or incrementally? Some edge-cases:
+    // - Mixins should make changes via dispatcher() and container(). If there's a Civi::reset(), then these things go away. We'll need to
+    //   re-register. (Example scenario: unit-testing)
+    // - Mixins register for every active module. If a new module is enabled, then we haven't had a chance to run on the new extension.
+    // - Mixins register for every active module. If an old module is disabled, then there may be old listeners/services lingering.
+    if (!isset(\Civi::$statics[__CLASS__]['done'])) {
+      \Civi::$statics[__CLASS__]['done'] = [];
+    }
+    $done = &\Civi::$statics[__CLASS__]['done'];
+
+    // Read each live func-file once, even if there's some kind of Civi::reset(). This avoids hard-crash where the func-file registers a PHP class/function/interface.
+    // Granted, PHP symbols require care to avoid conflicts between `mymixin@1.0` and `mymixin@2.0` -- but you can deal with that. For minor-versions, you're
+    // safe because we deduplicate.
+    static $funcsByFile = [];
+    foreach ($this->liveFuncFiles as $verExpr => $file) {
+      if (!isset($funcsByFile[$file])) {
+        $func = include_once $file;
+        if (is_callable($func)) {
+          $funcsByFile[$file] = $func;
+        }
+        else {
+          error_log(sprintf('MixinLoader: Received invalid callback from \"%s\"', $file));
+        }
+      }
+    }
+
+    foreach ($this->mixInfos as $ext) {
+      /** @var \CRM_Extension_MixInfo $ext */
+      foreach ($ext->mixins as $verExpr) {
+        $doneId = $ext->longName . '::' . $verExpr;
+        if (isset($done[$doneId])) {
+          continue;
+        }
+        if (isset($funcsByFile[$this->liveFuncFiles[$verExpr]])) {
+          call_user_func($funcsByFile[$this->liveFuncFiles[$verExpr]], $ext, $bootCache);
+          $done[$doneId] = 1;
+        }
+        else {
+          error_log(sprintf('MixinLoader: Failed to load "%s" for extension "%s"', $verExpr, $ext->longName));
+        }
+      }
+    }
+
+    return $this;
+  }
+
+  /**
+   * @param string $expectVer
+   * @param string $actualVer
+   * @return bool
+   */
+  private static function satisfies($expectVer, $actualVer) {
+    [$expectMajor] = explode('.', $expectVer);
+    [$actualMajor] = explode('.', $actualVer);
+    return ($expectMajor == $actualMajor) && version_compare($actualVer, $expectVer, '>=');
+  }
+
+}

--- a/CRM/Extension/MixinScanner.php
+++ b/CRM/Extension/MixinScanner.php
@@ -1,0 +1,148 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * The MixinScanner scans the list of actives extensions and their required mixins.
+ */
+class CRM_Extension_MixinScanner {
+
+  /**
+   * @var CRM_Extension_Mapper
+   */
+  protected $mapper;
+
+  /**
+   * @var CRM_Extension_Manager
+   */
+  protected $manager;
+
+  /**
+   * @var string[]|null
+   *   A list of base-paths which are implicitly supported by 'include' directives.
+   *   Sorted with the longest paths first.
+   */
+  protected $relativeBases;
+
+  /**
+   * CRM_Extension_ClassLoader constructor.
+   * @param \CRM_Extension_Mapper|NULL $mapper
+   * @param \CRM_Extension_Manager|NULL $manager
+   * @param bool $relativize
+   *   Whether to store paths in relative form.
+   *   Enabling this may slow-down scanning a bit, and it has no benefit when for on-demand loaders.
+   *   However, if the loader is cached, then it may make for smaller, more portable cache-file.
+   */
+  public function __construct(?\CRM_Extension_Mapper $mapper = NULL, \CRM_Extension_Manager $manager = NULL, $relativize = TRUE) {
+    $this->mapper = $mapper ?: CRM_Extension_System::singleton()->getMapper();
+    $this->manager = $manager ?: CRM_Extension_System::singleton()->getManager();
+    if ($relativize) {
+      $this->relativeBases = [Civi::paths()->getVariable('civicrm.root', 'path')];
+      // Previous drafts used `relativeBases=explode(include_path)`. However, this produces unstable results
+      // when flip through the phases of the lifecycle - because the include_path changes throughout the lifecycle.
+      usort($this->relativeBases, function($a, $b) {
+        return strlen($b) - strlen($a);
+      });
+    }
+    else {
+      $this->relativeBases = NULL;
+    }
+  }
+
+  /**
+   * @return \CRM_Extension_MixinLoader
+   */
+  public function createLoader() {
+    $l = new CRM_Extension_MixinLoader();
+
+    foreach ($this->getInstalledKeys() as $key) {
+      try {
+        $path = $this->mapper->keyToBasePath($key);
+        $l->addMixInfo($this->createMixInfo($path . DIRECTORY_SEPARATOR . CRM_Extension_Info::FILENAME));
+        $l->addFunctionFiles($this->findFunctionFiles("$path/mixin/*@*.mixin.php"));
+        $l->addFunctionFiles($this->findFunctionFiles("$path/mixin/*@*/mixin.php"), TRUE);
+      }
+      catch (CRM_Extension_Exception_ParseException $e) {
+        error_log(sprintf('MixinScanner: Failed to read extension (%s)', $key));
+      }
+    }
+
+    $l->addFunctionFiles($this->findFunctionFiles(Civi::paths()->getPath('[civicrm.root]/mixin/*@*.mixin.php')));
+    $l->addFunctionFiles($this->findFunctionFiles(Civi::paths()->getPath('[civicrm.root]/mixin/*@*/mixin.php')), TRUE);
+
+    return $l->compile();
+  }
+
+  /**
+   * @return array
+   */
+  private function getInstalledKeys() {
+    $keys = [];
+
+    $statuses = $this->manager->getStatuses();
+    ksort($statuses);
+    foreach ($statuses as $key => $status) {
+      if ($status === CRM_Extension_Manager::STATUS_INSTALLED) {
+        $keys[] = $key;
+      }
+    }
+
+    return $keys;
+  }
+
+  /**
+   * @param string $infoFile
+   *   Path to the 'info.xml' file
+   * @return \CRM_Extension_MixInfo
+   * @throws \CRM_Extension_Exception_ParseException
+   */
+  private function createMixInfo(string $infoFile) {
+    $info = CRM_Extension_Info::loadFromFile($infoFile);
+    $instance = new CRM_Extension_MixInfo();
+    $instance->longName = $info->key;
+    $instance->shortName = $info->file;
+    $instance->path = rtrim(dirname($infoFile), '/' . DIRECTORY_SEPARATOR);
+    $instance->mixins = $info->mixins;
+    return $instance;
+  }
+
+  /**
+   * @param string $globPat
+   * @return array
+   *   Ex: ['mix/xml-menu-autoload@1.0.mixin.php']
+   */
+  private function findFunctionFiles($globPat) {
+    $useRel = $this->relativeBases !== NULL;
+    $result = [];
+    $funcFiles = (array) glob($globPat);
+    sort($funcFiles);
+    foreach ($funcFiles as $shimFile) {
+      $shimFileRel = $useRel ? $this->relativize($shimFile) : $shimFile;
+      $result[] = $shimFileRel;
+    }
+    return $result;
+  }
+
+  /**
+   * Convert the absolute $file to an expression that is supported by 'include'.
+   *
+   * @param string $file
+   * @return string
+   */
+  private function relativize($file) {
+    foreach ($this->relativeBases as $relativeBase) {
+      if (CRM_Utils_File::isChildPath($relativeBase, $file)) {
+        return ltrim(CRM_Utils_File::relativize($file, $relativeBase), '/' . DIRECTORY_SEPARATOR);
+      }
+    }
+    return $file;
+  }
+
+}

--- a/distmaker/dists/common.sh
+++ b/distmaker/dists/common.sh
@@ -77,7 +77,7 @@ function dm_install_core() {
   local repo="$1"
   local to="$2"
 
-  for dir in ang css i js PEAR templates bin CRM api extern Reports install settings Civi partials release-notes xml setup ; do
+  for dir in ang css i js PEAR templates bin CRM api extern Reports install mixin settings Civi partials release-notes xml setup ; do
     [ -d "$repo/$dir" ] && dm_install_dir "$repo/$dir" "$to/$dir"
   done
 
@@ -98,6 +98,7 @@ function dm_install_core() {
 
   set +e
   rm -rf $to/sql/civicrm_*.??_??.mysql
+  rm -rf $to/mixin/*/example
   set -e
 }
 

--- a/ext/afform/admin/afform_admin.civix.php
+++ b/ext/afform/admin/afform_admin.civix.php
@@ -430,18 +430,6 @@ function _afform_admin_civix_fixNavigationMenuItems(&$nodes, &$maxNavID, $parent
 }
 
 /**
- * (Delegated) Implements hook_civicrm_alterSettingsFolders().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_alterSettingsFolders
- */
-function _afform_admin_civix_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
-  $settingsDir = __DIR__ . DIRECTORY_SEPARATOR . 'settings';
-  if (!in_array($settingsDir, $metaDataFolders) && is_dir($settingsDir)) {
-    $metaDataFolders[] = $settingsDir;
-  }
-}
-
-/**
  * (Delegated) Implements hook_civicrm_entityTypes().
  *
  * Find any *.entityType.php files, merge their content, and return.

--- a/ext/afform/admin/afform_admin.php
+++ b/ext/afform/admin/afform_admin.php
@@ -115,15 +115,6 @@ function afform_admin_civicrm_angularModules(&$angularModules) {
 }
 
 /**
- * Implements hook_civicrm_alterSettingsFolders().
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_alterSettingsFolders
- */
-function afform_admin_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
-  _afform_admin_civix_civicrm_alterSettingsFolders($metaDataFolders);
-}
-
-/**
  * Implements hook_civicrm_entityTypes().
  *
  * Declare entity types provided by this module.

--- a/ext/afform/core/afform.civix.php
+++ b/ext/afform/core/afform.civix.php
@@ -430,18 +430,6 @@ function _afform_civix_fixNavigationMenuItems(&$nodes, &$maxNavID, $parentID) {
 }
 
 /**
- * (Delegated) Implements hook_civicrm_alterSettingsFolders().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_alterSettingsFolders
- */
-function _afform_civix_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
-  $settingsDir = __DIR__ . DIRECTORY_SEPARATOR . 'settings';
-  if (!in_array($settingsDir, $metaDataFolders) && is_dir($settingsDir)) {
-    $metaDataFolders[] = $settingsDir;
-  }
-}
-
-/**
  * (Delegated) Implements hook_civicrm_entityTypes().
  *
  * Find any *.entityType.php files, merge their content, and return.

--- a/ext/afform/core/afform.php
+++ b/ext/afform/core/afform.php
@@ -322,15 +322,6 @@ function _afform_get_partials($moduleName, $module) {
 }
 
 /**
- * Implements hook_civicrm_alterSettingsFolders().
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_alterSettingsFolders
- */
-function afform_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
-  _afform_civix_civicrm_alterSettingsFolders($metaDataFolders);
-}
-
-/**
  * Implements hook_civicrm_entityTypes().
  *
  * Declare entity types provided by this module.

--- a/ext/afform/html/afform_html.civix.php
+++ b/ext/afform/html/afform_html.civix.php
@@ -430,18 +430,6 @@ function _afform_html_civix_fixNavigationMenuItems(&$nodes, &$maxNavID, $parentI
 }
 
 /**
- * (Delegated) Implements hook_civicrm_alterSettingsFolders().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_alterSettingsFolders
- */
-function _afform_html_civix_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
-  $settingsDir = __DIR__ . DIRECTORY_SEPARATOR . 'settings';
-  if (!in_array($settingsDir, $metaDataFolders) && is_dir($settingsDir)) {
-    $metaDataFolders[] = $settingsDir;
-  }
-}
-
-/**
  * (Delegated) Implements hook_civicrm_entityTypes().
  *
  * Find any *.entityType.php files, merge their content, and return.

--- a/ext/afform/html/afform_html.php
+++ b/ext/afform/html/afform_html.php
@@ -119,15 +119,6 @@ function afform_html_civicrm_angularModules(&$angularModules) {
 }
 
 /**
- * Implements hook_civicrm_alterSettingsFolders().
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_alterSettingsFolders
- */
-function afform_html_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
-  _afform_html_civix_civicrm_alterSettingsFolders($metaDataFolders);
-}
-
-/**
  * Implements hook_civicrm_entityTypes().
  *
  * Declare entity types provided by this module.

--- a/ext/afform/mock/afform_mock.civix.php
+++ b/ext/afform/mock/afform_mock.civix.php
@@ -430,18 +430,6 @@ function _afform_mock_civix_fixNavigationMenuItems(&$nodes, &$maxNavID, $parentI
 }
 
 /**
- * (Delegated) Implements hook_civicrm_alterSettingsFolders().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_alterSettingsFolders
- */
-function _afform_mock_civix_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
-  $settingsDir = __DIR__ . DIRECTORY_SEPARATOR . 'settings';
-  if (!in_array($settingsDir, $metaDataFolders) && is_dir($settingsDir)) {
-    $metaDataFolders[] = $settingsDir;
-  }
-}
-
-/**
  * (Delegated) Implements hook_civicrm_entityTypes().
  *
  * Find any *.entityType.php files, merge their content, and return.

--- a/ext/afform/mock/afform_mock.php
+++ b/ext/afform/mock/afform_mock.php
@@ -115,15 +115,6 @@ function afform_mock_civicrm_angularModules(&$angularModules) {
 }
 
 /**
- * Implements hook_civicrm_alterSettingsFolders().
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_alterSettingsFolders
- */
-function afform_mock_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
-  _afform_mock_civix_civicrm_alterSettingsFolders($metaDataFolders);
-}
-
-/**
  * Implements hook_civicrm_entityTypes().
  *
  * Declare entity types provided by this module.

--- a/ext/authx/authx.civix.php
+++ b/ext/authx/authx.civix.php
@@ -454,18 +454,6 @@ function _authx_civix_fixNavigationMenuItems(&$nodes, &$maxNavID, $parentID) {
 }
 
 /**
- * (Delegated) Implements hook_civicrm_alterSettingsFolders().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_alterSettingsFolders
- */
-function _authx_civix_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
-  $settingsDir = __DIR__ . DIRECTORY_SEPARATOR . 'settings';
-  if (!in_array($settingsDir, $metaDataFolders) && is_dir($settingsDir)) {
-    $metaDataFolders[] = $settingsDir;
-  }
-}
-
-/**
  * (Delegated) Implements hook_civicrm_entityTypes().
  *
  * Find any *.entityType.php files, merge their content, and return.

--- a/ext/authx/authx.php
+++ b/ext/authx/authx.php
@@ -188,15 +188,6 @@ function authx_civicrm_angularModules(&$angularModules) {
 }
 
 /**
- * Implements hook_civicrm_alterSettingsFolders().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_alterSettingsFolders
- */
-function authx_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
-  _authx_civix_civicrm_alterSettingsFolders($metaDataFolders);
-}
-
-/**
  * Implements hook_civicrm_entityTypes().
  *
  * Declare entity types provided by this module.

--- a/ext/authx/info.xml
+++ b/ext/authx/info.xml
@@ -24,6 +24,9 @@
   <classloader>
     <psr4 prefix="Civi\" path="Civi"/>
   </classloader>
+  <mixins>
+    <mixin>setting-php@1.0.0</mixin>
+  </mixins>
   <civix>
     <namespace>CRM/Authx</namespace>
   </civix>

--- a/ext/ckeditor4/ckeditor4.civix.php
+++ b/ext/ckeditor4/ckeditor4.civix.php
@@ -430,18 +430,6 @@ function _ckeditor4_civix_fixNavigationMenuItems(&$nodes, &$maxNavID, $parentID)
 }
 
 /**
- * (Delegated) Implements hook_civicrm_alterSettingsFolders().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_alterSettingsFolders
- */
-function _ckeditor4_civix_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
-  $settingsDir = __DIR__ . DIRECTORY_SEPARATOR . 'settings';
-  if (!in_array($settingsDir, $metaDataFolders) && is_dir($settingsDir)) {
-    $metaDataFolders[] = $settingsDir;
-  }
-}
-
-/**
  * (Delegated) Implements hook_civicrm_entityTypes().
  *
  * Find any *.entityType.php files, merge their content, and return.

--- a/ext/ckeditor4/ckeditor4.php
+++ b/ext/ckeditor4/ckeditor4.php
@@ -117,15 +117,6 @@ function ckeditor4_civicrm_angularModules(&$angularModules) {
 }
 
 /**
- * Implements hook_civicrm_alterSettingsFolders().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_alterSettingsFolders
- */
-function ckeditor4_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
-  _ckeditor4_civix_civicrm_alterSettingsFolders($metaDataFolders);
-}
-
-/**
  * Implements hook_civicrm_entityTypes().
  *
  * Declare entity types provided by this module.

--- a/ext/contributioncancelactions/contributioncancelactions.civix.php
+++ b/ext/contributioncancelactions/contributioncancelactions.civix.php
@@ -454,18 +454,6 @@ function _contributioncancelactions_civix_fixNavigationMenuItems(&$nodes, &$maxN
 }
 
 /**
- * (Delegated) Implements hook_civicrm_alterSettingsFolders().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_alterSettingsFolders
- */
-function _contributioncancelactions_civix_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
-  $settingsDir = __DIR__ . DIRECTORY_SEPARATOR . 'settings';
-  if (!in_array($settingsDir, $metaDataFolders) && is_dir($settingsDir)) {
-    $metaDataFolders[] = $settingsDir;
-  }
-}
-
-/**
  * (Delegated) Implements hook_civicrm_entityTypes().
  *
  * Find any *.entityType.php files, merge their content, and return.

--- a/ext/eventcart/eventcart.civix.php
+++ b/ext/eventcart/eventcart.civix.php
@@ -454,18 +454,6 @@ function _eventcart_civix_fixNavigationMenuItems(&$nodes, &$maxNavID, $parentID)
 }
 
 /**
- * (Delegated) Implements hook_civicrm_alterSettingsFolders().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_alterSettingsFolders
- */
-function _eventcart_civix_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
-  $settingsDir = __DIR__ . DIRECTORY_SEPARATOR . 'settings';
-  if (!in_array($settingsDir, $metaDataFolders) && is_dir($settingsDir)) {
-    $metaDataFolders[] = $settingsDir;
-  }
-}
-
-/**
  * (Delegated) Implements hook_civicrm_entityTypes().
  *
  * Find any *.entityType.php files, merge their content, and return.

--- a/ext/eventcart/eventcart.php
+++ b/ext/eventcart/eventcart.php
@@ -113,15 +113,6 @@ function eventcart_civicrm_angularModules(&$angularModules) {
 }
 
 /**
- * Implements hook_civicrm_alterSettingsFolders().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_alterSettingsFolders
- */
-function eventcart_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
-  _eventcart_civix_civicrm_alterSettingsFolders($metaDataFolders);
-}
-
-/**
  * Implements hook_civicrm_entityTypes().
  *
  * Declare entity types provided by this module.

--- a/ext/eventcart/info.xml
+++ b/ext/eventcart/info.xml
@@ -24,6 +24,9 @@
   <classloader>
     <psr4 prefix="Civi\" path="Civi"/>
   </classloader>
+  <mixins>
+    <mixin>setting-php@1.0.0</mixin>
+  </mixins>
   <civix>
     <namespace>CRM/Event/Cart</namespace>
   </civix>

--- a/ext/ewaysingle/ewaysingle.civix.php
+++ b/ext/ewaysingle/ewaysingle.civix.php
@@ -454,18 +454,6 @@ function _ewaysingle_civix_fixNavigationMenuItems(&$nodes, &$maxNavID, $parentID
 }
 
 /**
- * (Delegated) Implements hook_civicrm_alterSettingsFolders().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_alterSettingsFolders
- */
-function _ewaysingle_civix_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
-  $settingsDir = __DIR__ . DIRECTORY_SEPARATOR . 'settings';
-  if (!in_array($settingsDir, $metaDataFolders) && is_dir($settingsDir)) {
-    $metaDataFolders[] = $settingsDir;
-  }
-}
-
-/**
  * (Delegated) Implements hook_civicrm_entityTypes().
  *
  * Find any *.entityType.php files, merge their content, and return.

--- a/ext/ewaysingle/ewaysingle.php
+++ b/ext/ewaysingle/ewaysingle.php
@@ -117,15 +117,6 @@ function ewaysingle_civicrm_angularModules(&$angularModules) {
 }
 
 /**
- * Implements hook_civicrm_alterSettingsFolders().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_alterSettingsFolders
- */
-function ewaysingle_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
-  _ewaysingle_civix_civicrm_alterSettingsFolders($metaDataFolders);
-}
-
-/**
  * Implements hook_civicrm_entityTypes().
  *
  * Declare entity types provided by this module.

--- a/ext/financialacls/financialacls.civix.php
+++ b/ext/financialacls/financialacls.civix.php
@@ -454,18 +454,6 @@ function _financialacls_civix_fixNavigationMenuItems(&$nodes, &$maxNavID, $paren
 }
 
 /**
- * (Delegated) Implements hook_civicrm_alterSettingsFolders().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_alterSettingsFolders
- */
-function _financialacls_civix_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
-  $settingsDir = __DIR__ . DIRECTORY_SEPARATOR . 'settings';
-  if (!in_array($settingsDir, $metaDataFolders) && is_dir($settingsDir)) {
-    $metaDataFolders[] = $settingsDir;
-  }
-}
-
-/**
  * (Delegated) Implements hook_civicrm_entityTypes().
  *
  * Find any *.entityType.php files, merge their content, and return.

--- a/ext/financialacls/financialacls.php
+++ b/ext/financialacls/financialacls.php
@@ -126,15 +126,6 @@ function financialacls_civicrm_angularModules(&$angularModules) {
 }
 
 /**
- * Implements hook_civicrm_alterSettingsFolders().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_alterSettingsFolders
- */
-function financialacls_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
-  _financialacls_civix_civicrm_alterSettingsFolders($metaDataFolders);
-}
-
-/**
  * Implements hook_civicrm_entityTypes().
  *
  * Declare entity types provided by this module.

--- a/ext/financialacls/info.xml
+++ b/ext/financialacls/info.xml
@@ -27,6 +27,9 @@
   <classloader>
     <psr4 prefix="Civi\" path="Civi"/>
   </classloader>
+  <mixins>
+    <mixin>setting-php@1.0.0</mixin>
+  </mixins>
   <civix>
     <namespace>CRM/Financialacls</namespace>
   </civix>

--- a/ext/flexmailer/flexmailer.civix.php
+++ b/ext/flexmailer/flexmailer.civix.php
@@ -454,18 +454,6 @@ function _flexmailer_civix_fixNavigationMenuItems(&$nodes, &$maxNavID, $parentID
 }
 
 /**
- * (Delegated) Implements hook_civicrm_alterSettingsFolders().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_alterSettingsFolders
- */
-function _flexmailer_civix_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
-  $settingsDir = __DIR__ . DIRECTORY_SEPARATOR . 'settings';
-  if (!in_array($settingsDir, $metaDataFolders) && is_dir($settingsDir)) {
-    $metaDataFolders[] = $settingsDir;
-  }
-}
-
-/**
  * (Delegated) Implements hook_civicrm_entityTypes().
  *
  * Find any *.entityType.php files, merge their content, and return.

--- a/ext/flexmailer/flexmailer.php
+++ b/ext/flexmailer/flexmailer.php
@@ -113,15 +113,6 @@ function flexmailer_civicrm_angularModules(&$angularModules) {
 }
 
 /**
- * Implements hook_civicrm_alterSettingsFolders().
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_alterSettingsFolders
- */
-function flexmailer_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
-  _flexmailer_civix_civicrm_alterSettingsFolders($metaDataFolders);
-}
-
-/**
  * Implements hook_civicrm_navigationMenu().
  *
  * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_navigationMenu

--- a/ext/flexmailer/info.xml
+++ b/ext/flexmailer/info.xml
@@ -28,6 +28,9 @@
   <classloader>
     <psr4 prefix="Civi\FlexMailer\" path="src"/>
   </classloader>
+  <mixins>
+    <mixin>setting-php@1.0.0</mixin>
+  </mixins>
   <civix>
     <namespace>CRM/Flexmailer</namespace>
   </civix>

--- a/ext/greenwich/greenwich.civix.php
+++ b/ext/greenwich/greenwich.civix.php
@@ -454,18 +454,6 @@ function _greenwich_civix_fixNavigationMenuItems(&$nodes, &$maxNavID, $parentID)
 }
 
 /**
- * (Delegated) Implements hook_civicrm_alterSettingsFolders().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_alterSettingsFolders
- */
-function _greenwich_civix_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
-  $settingsDir = __DIR__ . DIRECTORY_SEPARATOR . 'settings';
-  if (!in_array($settingsDir, $metaDataFolders) && is_dir($settingsDir)) {
-    $metaDataFolders[] = $settingsDir;
-  }
-}
-
-/**
  * (Delegated) Implements hook_civicrm_entityTypes().
  *
  * Find any *.entityType.php files, merge their content, and return.

--- a/ext/greenwich/greenwich.php
+++ b/ext/greenwich/greenwich.php
@@ -24,15 +24,6 @@ function greenwich_civicrm_config(&$config) {
 //}
 
 /**
- * Implements hook_civicrm_alterSettingsFolders().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_alterSettingsFolders
- */
-function greenwich_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
-  _greenwich_civix_civicrm_alterSettingsFolders($metaDataFolders);
-}
-
-/**
  * Implements hook_civicrm_themes().
  */
 function greenwich_civicrm_themes(&$themes) {

--- a/ext/legacycustomsearches/legacycustomsearches.civix.php
+++ b/ext/legacycustomsearches/legacycustomsearches.civix.php
@@ -430,18 +430,6 @@ function _legacycustomsearches_civix_fixNavigationMenuItems(&$nodes, &$maxNavID,
 }
 
 /**
- * (Delegated) Implements hook_civicrm_alterSettingsFolders().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_alterSettingsFolders
- */
-function _legacycustomsearches_civix_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
-  $settingsDir = __DIR__ . DIRECTORY_SEPARATOR . 'settings';
-  if (!in_array($settingsDir, $metaDataFolders) && is_dir($settingsDir)) {
-    $metaDataFolders[] = $settingsDir;
-  }
-}
-
-/**
  * (Delegated) Implements hook_civicrm_entityTypes().
  *
  * Find any *.entityType.php files, merge their content, and return.

--- a/ext/legacycustomsearches/legacycustomsearches.php
+++ b/ext/legacycustomsearches/legacycustomsearches.php
@@ -117,15 +117,6 @@ function legacycustomsearches_civicrm_angularModules(&$angularModules) {
 }
 
 /**
- * Implements hook_civicrm_alterSettingsFolders().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_alterSettingsFolders
- */
-function legacycustomsearches_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
-  _legacycustomsearches_civix_civicrm_alterSettingsFolders($metaDataFolders);
-}
-
-/**
  * Implements hook_civicrm_entityTypes().
  *
  * Declare entity types provided by this module.

--- a/ext/message_admin/message_admin.civix.php
+++ b/ext/message_admin/message_admin.civix.php
@@ -430,18 +430,6 @@ function _message_admin_civix_fixNavigationMenuItems(&$nodes, &$maxNavID, $paren
 }
 
 /**
- * (Delegated) Implements hook_civicrm_alterSettingsFolders().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_alterSettingsFolders
- */
-function _message_admin_civix_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
-  $settingsDir = __DIR__ . DIRECTORY_SEPARATOR . 'settings';
-  if (!in_array($settingsDir, $metaDataFolders) && is_dir($settingsDir)) {
-    $metaDataFolders[] = $settingsDir;
-  }
-}
-
-/**
  * (Delegated) Implements hook_civicrm_entityTypes().
  *
  * Find any *.entityType.php files, merge their content, and return.

--- a/ext/message_admin/message_admin.php
+++ b/ext/message_admin/message_admin.php
@@ -117,15 +117,6 @@ function message_admin_civicrm_angularModules(&$angularModules) {
 }
 
 /**
- * Implements hook_civicrm_alterSettingsFolders().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_alterSettingsFolders
- */
-function message_admin_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
-  _message_admin_civix_civicrm_alterSettingsFolders($metaDataFolders);
-}
-
-/**
  * Implements hook_civicrm_entityTypes().
  *
  * Declare entity types provided by this module.

--- a/ext/oauth-client/info.xml
+++ b/ext/oauth-client/info.xml
@@ -29,6 +29,9 @@
     <psr4 prefix="Civi\" path="Civi"/>
   </classloader>
   <upgrader>CRM_OAuth_Upgrader</upgrader>
+  <mixins>
+    <mixin>setting-php@1.0.0</mixin>
+  </mixins>
   <civix>
     <namespace>CRM/OAuth</namespace>
   </civix>

--- a/ext/oauth-client/oauth_client.civix.php
+++ b/ext/oauth-client/oauth_client.civix.php
@@ -430,18 +430,6 @@ function _oauth_client_civix_fixNavigationMenuItems(&$nodes, &$maxNavID, $parent
 }
 
 /**
- * (Delegated) Implements hook_civicrm_alterSettingsFolders().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_alterSettingsFolders
- */
-function _oauth_client_civix_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
-  $settingsDir = __DIR__ . DIRECTORY_SEPARATOR . 'settings';
-  if (!in_array($settingsDir, $metaDataFolders) && is_dir($settingsDir)) {
-    $metaDataFolders[] = $settingsDir;
-  }
-}
-
-/**
  * (Delegated) Implements hook_civicrm_entityTypes().
  *
  * Find any *.entityType.php files, merge their content, and return.

--- a/ext/oauth-client/oauth_client.php
+++ b/ext/oauth-client/oauth_client.php
@@ -93,15 +93,6 @@ function oauth_client_civicrm_angularModules(&$angularModules) {
 }
 
 /**
- * Implements hook_civicrm_alterSettingsFolders().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_alterSettingsFolders
- */
-function oauth_client_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
-  _oauth_client_civix_civicrm_alterSettingsFolders($metaDataFolders);
-}
-
-/**
  * Implements hook_civicrm_entityTypes().
  *
  * Declare entity types provided by this module.

--- a/ext/payflowpro/payflowpro.civix.php
+++ b/ext/payflowpro/payflowpro.civix.php
@@ -454,18 +454,6 @@ function _payflowpro_civix_fixNavigationMenuItems(&$nodes, &$maxNavID, $parentID
 }
 
 /**
- * (Delegated) Implements hook_civicrm_alterSettingsFolders().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_alterSettingsFolders
- */
-function _payflowpro_civix_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
-  $settingsDir = __DIR__ . DIRECTORY_SEPARATOR . 'settings';
-  if (!in_array($settingsDir, $metaDataFolders) && is_dir($settingsDir)) {
-    $metaDataFolders[] = $settingsDir;
-  }
-}
-
-/**
  * (Delegated) Implements hook_civicrm_entityTypes().
  *
  * Find any *.entityType.php files, merge their content, and return.

--- a/ext/payflowpro/payflowpro.php
+++ b/ext/payflowpro/payflowpro.php
@@ -117,15 +117,6 @@ function payflowpro_civicrm_angularModules(&$angularModules) {
 }
 
 /**
- * Implements hook_civicrm_alterSettingsFolders().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_alterSettingsFolders
- */
-function payflowpro_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
-  _payflowpro_civix_civicrm_alterSettingsFolders($metaDataFolders);
-}
-
-/**
  * Implements hook_civicrm_entityTypes().
  *
  * Declare entity types provided by this module.

--- a/ext/recaptcha/info.xml
+++ b/ext/recaptcha/info.xml
@@ -24,6 +24,9 @@
   <classloader>
     <psr4 prefix="Civi\" path="Civi"/>
   </classloader>
+  <mixins>
+    <mixin>setting-php@1.0.0</mixin>
+  </mixins>
   <civix>
     <namespace>CRM/Recaptcha</namespace>
   </civix>

--- a/ext/recaptcha/recaptcha.civix.php
+++ b/ext/recaptcha/recaptcha.civix.php
@@ -454,18 +454,6 @@ function _recaptcha_civix_fixNavigationMenuItems(&$nodes, &$maxNavID, $parentID)
 }
 
 /**
- * (Delegated) Implements hook_civicrm_alterSettingsFolders().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_alterSettingsFolders
- */
-function _recaptcha_civix_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
-  $settingsDir = __DIR__ . DIRECTORY_SEPARATOR . 'settings';
-  if (!in_array($settingsDir, $metaDataFolders) && is_dir($settingsDir)) {
-    $metaDataFolders[] = $settingsDir;
-  }
-}
-
-/**
  * (Delegated) Implements hook_civicrm_entityTypes().
  *
  * Find any *.entityType.php files, merge their content, and return.

--- a/ext/recaptcha/recaptcha.php
+++ b/ext/recaptcha/recaptcha.php
@@ -104,15 +104,6 @@ function recaptcha_civicrm_angularModules(&$angularModules) {
 }
 
 /**
- * Implements hook_civicrm_alterSettingsFolders().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_alterSettingsFolders
- */
-function recaptcha_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
-  _recaptcha_civix_civicrm_alterSettingsFolders($metaDataFolders);
-}
-
-/**
  * Implements hook_civicrm_entityTypes().
  *
  * Declare entity types provided by this module.

--- a/ext/search_kit/search_kit.civix.php
+++ b/ext/search_kit/search_kit.civix.php
@@ -430,18 +430,6 @@ function _search_kit_civix_fixNavigationMenuItems(&$nodes, &$maxNavID, $parentID
 }
 
 /**
- * (Delegated) Implements hook_civicrm_alterSettingsFolders().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_alterSettingsFolders
- */
-function _search_kit_civix_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
-  $settingsDir = __DIR__ . DIRECTORY_SEPARATOR . 'settings';
-  if (!in_array($settingsDir, $metaDataFolders) && is_dir($settingsDir)) {
-    $metaDataFolders[] = $settingsDir;
-  }
-}
-
-/**
  * (Delegated) Implements hook_civicrm_entityTypes().
  *
  * Find any *.entityType.php files, merge their content, and return.

--- a/ext/search_kit/search_kit.php
+++ b/ext/search_kit/search_kit.php
@@ -91,15 +91,6 @@ function search_kit_civicrm_angularModules(&$angularModules) {
 }
 
 /**
- * Implements hook_civicrm_alterSettingsFolders().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_alterSettingsFolders
- */
-function search_kit_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
-  _search_kit_civix_civicrm_alterSettingsFolders($metaDataFolders);
-}
-
-/**
  * Implements hook_civicrm_entityTypes().
  *
  * Declare entity types provided by this module.

--- a/ext/sequentialcreditnotes/info.xml
+++ b/ext/sequentialcreditnotes/info.xml
@@ -23,6 +23,9 @@
   <compatibility>
     <ver>5.24</ver>
   </compatibility>
+  <mixins>
+    <mixin>setting-php@1.0.0</mixin>
+  </mixins>
   <civix>
     <namespace>CRM/Sequentialcreditnotes</namespace>
   </civix>

--- a/ext/sequentialcreditnotes/sequentialcreditnotes.civix.php
+++ b/ext/sequentialcreditnotes/sequentialcreditnotes.civix.php
@@ -453,18 +453,6 @@ function _sequentialcreditnotes_civix_fixNavigationMenuItems(&$nodes, &$maxNavID
 }
 
 /**
- * (Delegated) Implements hook_civicrm_alterSettingsFolders().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_alterSettingsFolders
- */
-function _sequentialcreditnotes_civix_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
-  $settingsDir = __DIR__ . DIRECTORY_SEPARATOR;
-  if (!in_array($settingsDir, $metaDataFolders) && is_dir($settingsDir)) {
-    $metaDataFolders[] = $settingsDir;
-  }
-}
-
-/**
  * (Delegated) Implements hook_civicrm_entityTypes().
  *
  * Find any *.entityType.php files, merge their content, and return.

--- a/ext/sequentialcreditnotes/sequentialcreditnotes.php
+++ b/ext/sequentialcreditnotes/sequentialcreditnotes.php
@@ -4,15 +4,6 @@ require_once 'sequentialcreditnotes.civix.php';
 use Civi\Api4\Contribution;
 
 /**
- * Implements hook_civicrm_alterSettingsFolders().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_alterSettingsFolders
- */
-function sequentialcreditnotes_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
-  _sequentialcreditnotes_civix_civicrm_alterSettingsFolders($metaDataFolders);
-}
-
-/**
  * Add a creditnote_id if appropriate.
  *
  * If the contribution is created with cancelled or refunded status, add credit note id

--- a/mixin/polyfill.md
+++ b/mixin/polyfill.md
@@ -1,0 +1,46 @@
+# Mixin Polyfill
+
+Mixins will have built-in support in a future version of CiviCRM (vTBD). However,
+for an extension to use a mixin on an older version of CiviCRM, it should
+include the polyfill ([mixin/polyfill.php](../mixin/polyfill.php)).
+
+## Usage
+
+The polyfill will be enabled in `civix` (vTBD).  To activate the polyfill in
+a bespoke extension (`myext`, `org.example.myextension`), copy `mixin/polyfill.php`.
+Load this file during a few key moments:
+
+```php
+function _myext_mixin_polyfill() {
+  if (!class_exists('CRM_Extension_MixInfo')) {
+    $polyfill = __DIR__ . '/mixin/polyfill.php';
+    (require $polyfill)('org.example.myextension', 'myext', __DIR__);
+  }
+}
+
+function myext_civicrm_config() {
+  _myext_mixin_polyfill();
+}
+
+function myext_civicrm_install() {
+  _myext_mixin_polyfill();
+}
+
+function myext_civicrm_enable() {
+  _myext_mixin_polyfill();
+}
+```
+
+## Limitations / Comparison
+
+The polyfill loader is not as sophisticated as the core loader. Here's a comparison to highlight some of the limitations:
+
+| Feature | Core Loader | Polyfill Loader |
+| -- | -- | -- |
+| Load mixins from files (`mixin/*.mixin.php`) | Yes | Yes |
+| Load mixins from subdirectories (`mixin/*/mixin.php`) | Yes | No |
+| Read annotations from mixin files (eg `@mixinVersion`) | Yes | No |
+| Activation - How does it decide to activate a mixin? | Read `info.xml` | Read `mixin/*.mixin.php` |
+| Boot cache - How does it store boot-cache? | All boot-caches combined into one file | Each extension has separate boot-cache file |
+| Deduplication - If two extensions include the same mixin, then only load one copy. | Yes | Partial - for exact version matches. |
+| Upgrade - If two extensions include different-but-compatible versions, always load the newer version. | Yes | No |

--- a/mixin/polyfill.php
+++ b/mixin/polyfill.php
@@ -1,0 +1,101 @@
+<?php
+
+/**
+ * When deploying on systems that lack mixin support, fake it.
+ *
+ * @mixinFile polyfill.php
+ *
+ * This polyfill does some (persnickity) deduplication, but it doesn't allow upgrades or shipping replacements in core.
+ *
+ * Note: The polyfill.php is designed to be copied into extensions for interoperability. Consequently, this file is
+ * not used 'live' by `civicrm-core`. However, the file does need a canonical home, and it's convenient to keep it
+ * adjacent to the actual mixin files.
+ *
+ * @param string $longName
+ * @param string $shortName
+ * @param string $basePath
+ */
+return function ($longName, $shortName, $basePath) {
+  // Construct imitations of the mixin services. These cannot work as well (e.g. with respect to
+  // number of file-reads, deduping, upgrading)... but they should be OK for a few months while
+  // the mixin services become available.
+
+  // List of active mixins; deduped by version
+  $mixinVers = [];
+  foreach ((array) glob($basePath . '/mixin/*.mixin.php') as $f) {
+    [$name, $ver] = explode('@', substr(basename($f), 0, -10));
+    if (!isset($mixinVers[$name]) || version_compare($ver, $mixinVers[$name], '>')) {
+      $mixinVers[$name] = $ver;
+    }
+  }
+  $mixins = [];
+  foreach ($mixinVers as $name => $ver) {
+    $mixins[] = "$name@$ver";
+  }
+
+  // Imitate CRM_Extension_MixInfo.
+  $mixInfo = new class() {
+
+    /**
+     * @var string
+     */
+    public $longName;
+
+    /**
+     * @var string
+     */
+    public $shortName;
+
+    public $_basePath;
+
+    public function getPath($file = NULL) {
+      return $this->_basePath . ($file === NULL ? '' : (DIRECTORY_SEPARATOR . $file));
+    }
+
+    public function isActive() {
+      return \CRM_Extension_System::singleton()->getMapper()->isActiveModule($this->shortName);
+    }
+
+  };
+  $mixInfo->longName = $longName;
+  $mixInfo->shortName = $shortName;
+  $mixInfo->_basePath = $basePath;
+
+  // Imitate CRM_Extension_BootCache.
+  $bootCache = new class() {
+
+    public function define($name, $callback) {
+      $envId = \CRM_Core_Config_Runtime::getId();
+      $oldExtCachePath = \Civi::paths()->getPath("[civicrm.compile]/CachedExtLoader.{$envId}.php");
+      $stat = stat($oldExtCachePath);
+      $file = Civi::paths()->getPath('[civicrm.compile]/CachedMixin.' . md5($name . ($stat['mtime'] ?? 0)) . '.php');
+      if (file_exists($file)) {
+        return include $file;
+      }
+      else {
+        $data = $callback();
+        file_put_contents($file, '<' . "?php\nreturn " . var_export($data, 1) . ';');
+        return $data;
+      }
+    }
+
+  };
+
+  // Imitate CRM_Extension_MixinLoader::run()
+  // Parse all live mixins before trying to scan any classes.
+  global $_CIVIX_MIXIN_POLYFILL;
+  foreach ($mixins as $mixin) {
+    // If the exact same mixin is defined by multiple exts, just use the first one.
+    if (!isset($_CIVIX_MIXIN_POLYFILL[$mixin])) {
+      $_CIVIX_MIXIN_POLYFILL[$mixin] = include_once $basePath . '/mixin/' . $mixin . '.mixin.php';
+    }
+  }
+  foreach ($mixins as $mixin) {
+    // If there's trickery about installs/uninstalls/resets, then we may need to register a second time.
+    if (!isset(\Civi::$statics[__FUNCTION__][$mixin])) {
+      \Civi::$statics[__FUNCTION__][$mixin] = 1;
+      $func = $_CIVIX_MIXIN_POLYFILL[$mixin];
+      $func($mixInfo, $bootCache);
+    }
+  }
+};

--- a/mixin/setting-php@1/example/CRM/Shimmy/Utils.php
+++ b/mixin/setting-php@1/example/CRM/Shimmy/Utils.php
@@ -1,0 +1,17 @@
+<?php
+
+use CRM_Shimmy_ExtensionUtil as E;
+
+class CRM_Shimmy_Utils {
+
+  /**
+   * @return array
+   */
+  public static function getExampleOptions(): array {
+    return [
+      'first' => E::ts('First example'),
+      'second' => E::ts('Second example'),
+    ];
+  }
+
+}

--- a/mixin/setting-php@1/example/settings/Shimmy.setting.php
+++ b/mixin/setting-php@1/example/settings/Shimmy.setting.php
@@ -1,0 +1,26 @@
+<?php
+use CRM_Shimmy_ExtensionUtil as E;
+
+return [
+  'shimmy_example' => [
+    'group_name' => 'Shimmy Preferences',
+    'group' => 'shimmy',
+    'name' => 'shimmy_example',
+    'type' => 'String',
+    'html_type' => 'select',
+    'html_attributes' => [
+      'class' => 'crm-select2',
+    ],
+    'pseudoconstant' => [
+      'callback' => 'CRM_Shimmy_Utils::getExampleOptions',
+    ],
+    'default' => 'first',
+    'add' => '4.7',
+    'title' => E::ts('Shimmy editor layout'),
+    'is_domain' => 1,
+    'is_contact' => 0,
+    'description' => E::ts('What is a shimmy example?'),
+    'help_text' => NULL,
+    'settings_pages' => ['shimmy' => ['weight' => 10]],
+  ],
+];

--- a/mixin/setting-php@1/example/tests/mixin/SettingsTest.php
+++ b/mixin/setting-php@1/example/tests/mixin/SettingsTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Civi\Shimmy\Mixins;
+
+/**
+ * Assert that the `settings/*.setting.php` mixin is working properly.
+ *
+ * This class defines the assertions to run when installing or uninstalling the extension.
+ * It use called as part of E2E_Shimmy_LifecycleTest.
+ *
+ * @see E2E_Shimmy_LifecycleTest
+ */
+class SettingsTest extends \PHPUnit\Framework\Assert {
+
+  public function testPreConditions($cv) {
+    $this->assertFileExists(static::getPath('/settings/Shimmy.setting.php'), 'The shimmy extension must have a Menu XML file.');
+  }
+
+  public function testInstalled($cv) {
+    // The menu item is registered...
+    $items = $cv->api4('Setting', 'getFields', ['where' => [['name', '=', 'shimmy_example']], 'loadOptions' => TRUE]);
+    $this->assertEquals('shimmy_example', $items[0]['name']);
+    $this->assertEquals('select', $items[0]['html_type']);
+    $this->assertEquals('First example', $items[0]['options']['first']);
+    $this->assertEquals('Second example', $items[0]['options']['second']);
+
+    // And it supports reading/writing...
+    $cv->api3('Setting', 'revert', ['name' => 'shimmy_example']);  /* FIXME: Prior installations don't cleanup... */
+    $value = $cv->api3('Setting', 'getvalue', ['name' => 'shimmy_example']);
+    $this->assertEquals('first', $value);
+    $r = $cv->api3('Setting', 'create', ['shimmy_example' => 'second']);
+    $this->assertEquals(0, $r['is_error']);
+    $value = $cv->api3('Setting', 'getvalue', ['name' => 'shimmy_example']);
+    $this->assertEquals('second', $value);
+  }
+
+  public function testDisabled($cv) {
+    $items = $cv->api4('Setting', 'getFields', ['where' => [['name', '=', 'shimmy_example']], 'loadOptions' => TRUE]);
+    $this->assertEmpty($items);
+
+    $value = $cv->api3('Setting', 'getvalue', ['name' => 'shimmy_example']);
+    $this->assertEquals('second', $value);
+  }
+
+  public function testUninstalled($cv) {
+    $items = $cv->api4('Setting', 'getFields', ['where' => [['name', '=', 'shimmy_example']], 'loadOptions' => TRUE]);
+    $this->assertEmpty($items);
+
+    // Uninstall should probably drop old settings, but it hasn't traditionally, so we won't check for the moment.
+    // FIXME // $value = cv('ev \'return Civi::settings()->get("shimmy_example");\'', 'raw');
+    // FIXME // $this->assertEquals('null', trim($value));
+  }
+
+  protected static function getPath($suffix = ''): string {
+    return dirname(__DIR__, 2) . $suffix;
+  }
+
+}

--- a/mixin/setting-php@1/mixin.php
+++ b/mixin/setting-php@1/mixin.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * Auto-register "settings/*.setting.php" files.
+ *
+ * @mixinName setting-php
+ * @mixinVersion 1.0.0
+ *
+ * @param CRM_Extension_MixInfo $mixInfo
+ *   On newer deployments, this will be an instance of MixInfo. On older deployments, Civix may polyfill with a work-a-like.
+ * @param \CRM_Extension_BootCache $bootCache
+ *   On newer deployments, this will be an instance of MixInfo. On older deployments, Civix may polyfill with a work-a-like.
+ */
+return function ($mixInfo, $bootCache) {
+
+  /**
+   * @param \Civi\Core\Event\GenericHookEvent $e
+   * @see CRM_Utils_Hook::alterSettingsFolders()
+   */
+  Civi::dispatcher()->addListener('hook_civicrm_alterSettingsFolders', function ($e) use ($mixInfo) {
+    // When deactivating on a polyfill/pre-mixin system, listeners may not cleanup automatically.
+    if (!$mixInfo->isActive()) {
+      return;
+    }
+
+    $settingsDir = $mixInfo->getPath('settings');
+    if (!in_array($settingsDir, $e->settingsFolders) && is_dir($settingsDir)) {
+      $e->settingsFolders[] = $settingsDir;
+    }
+  });
+
+};

--- a/tests/extensions/shimmy/info.xml.template
+++ b/tests/extensions/shimmy/info.xml.template
@@ -1,0 +1,34 @@
+<?xml version="1.0"?>
+<extension key="shimmy" type="module">
+  <file>shimmy</file>
+  <name>FIXME</name>
+  <description>FIXME</description>
+  <license>AGPL-3.0</license>
+  <maintainer>
+    <author>CiviCRM LLC</author>
+    <email>info@civicrm.org</email>
+  </maintainer>
+  <urls>
+    <url desc="Main Extension Page">http://FIXME</url>
+    <url desc="Documentation">http://FIXME</url>
+    <url desc="Support">http://FIXME</url>
+    <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
+  </urls>
+  <releaseDate>2021-03-21</releaseDate>
+  <version>1.0</version>
+  <develStage>alpha</develStage>
+  <tags>
+    <tag>mgmt:hidden</tag>
+  </tags>
+  <compatibility>
+    <ver>5.0</ver>
+  </compatibility>
+  <comments>This is a new, undeveloped module</comments>
+  <classloader>
+    <psr0 prefix="CRM_" path="."/>
+    <psr4 prefix="Civi\" path="Civi"/>
+  </classloader>
+  <civix>
+    <namespace>CRM/Shimmy</namespace>
+  </civix>
+</extension>

--- a/tests/extensions/shimmy/phpunit.xml.dist
+++ b/tests/extensions/shimmy/phpunit.xml.dist
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<phpunit backupGlobals="false" backupStaticAttributes="false" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" bootstrap="tests/phpunit/bootstrap.php" cacheResult="false">
+  <testsuites>
+    <testsuite name="My Test Suite">
+      <directory>./tests/phpunit</directory>
+    </testsuite>
+  </testsuites>
+  <filter>
+    <whitelist>
+      <directory suffix=".php">./</directory>
+    </whitelist>
+  </filter>
+  <listeners>
+    <listener class="Civi\Test\CiviTestListener">
+      <arguments/>
+    </listener>
+  </listeners>
+</phpunit>

--- a/tests/extensions/shimmy/shimmy.civix.php
+++ b/tests/extensions/shimmy/shimmy.civix.php
@@ -1,0 +1,309 @@
+<?php
+
+// AUTO-GENERATED FILE -- Civix may overwrite any changes made to this file
+
+/**
+ * The ExtensionUtil class provides small stubs for accessing resources of this
+ * extension.
+ */
+class CRM_Shimmy_ExtensionUtil {
+  const SHORT_NAME = 'shimmy';
+  const LONG_NAME = 'shimmy';
+  const CLASS_PREFIX = 'CRM_Shimmy';
+
+  /**
+   * Translate a string using the extension's domain.
+   *
+   * If the extension doesn't have a specific translation
+   * for the string, fallback to the default translations.
+   *
+   * @param string $text
+   *   Canonical message text (generally en_US).
+   * @param array $params
+   * @return string
+   *   Translated text.
+   * @see ts
+   */
+  public static function ts($text, $params = []) {
+    if (!array_key_exists('domain', $params)) {
+      $params['domain'] = [self::LONG_NAME, NULL];
+    }
+    return ts($text, $params);
+  }
+
+  /**
+   * Get the URL of a resource file (in this extension).
+   *
+   * @param string|NULL $file
+   *   Ex: NULL.
+   *   Ex: 'css/foo.css'.
+   * @return string
+   *   Ex: 'http://example.org/sites/default/ext/org.example.foo'.
+   *   Ex: 'http://example.org/sites/default/ext/org.example.foo/css/foo.css'.
+   */
+  public static function url($file = NULL) {
+    if ($file === NULL) {
+      return rtrim(CRM_Core_Resources::singleton()->getUrl(self::LONG_NAME), '/');
+    }
+    return CRM_Core_Resources::singleton()->getUrl(self::LONG_NAME, $file);
+  }
+
+  /**
+   * Get the path of a resource file (in this extension).
+   *
+   * @param string|NULL $file
+   *   Ex: NULL.
+   *   Ex: 'css/foo.css'.
+   * @return string
+   *   Ex: '/var/www/example.org/sites/default/ext/org.example.foo'.
+   *   Ex: '/var/www/example.org/sites/default/ext/org.example.foo/css/foo.css'.
+   */
+  public static function path($file = NULL) {
+    // return CRM_Core_Resources::singleton()->getPath(self::LONG_NAME, $file);
+    return __DIR__ . ($file === NULL ? '' : (DIRECTORY_SEPARATOR . $file));
+  }
+
+  /**
+   * Get the name of a class within this extension.
+   *
+   * @param string $suffix
+   *   Ex: 'Page_HelloWorld' or 'Page\\HelloWorld'.
+   * @return string
+   *   Ex: 'CRM_Foo_Page_HelloWorld'.
+   */
+  public static function findClass($suffix) {
+    return self::CLASS_PREFIX . '_' . str_replace('\\', '_', $suffix);
+  }
+
+}
+
+use CRM_Shimmy_ExtensionUtil as E;
+
+function _shimmy_civix_mixin_polyfill() {
+  if (!class_exists('CRM_Extension_MixInfo')) {
+    $polyfill = __DIR__ . '/mixin/polyfill.php';
+    (require $polyfill)(E::LONG_NAME, E::SHORT_NAME, E::path());
+  }
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_config().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_config
+ */
+function _shimmy_civix_civicrm_config(&$config = NULL) {
+  static $configured = FALSE;
+  if ($configured) {
+    return;
+  }
+  $configured = TRUE;
+
+  $template =& CRM_Core_Smarty::singleton();
+
+  $extRoot = dirname(__FILE__) . DIRECTORY_SEPARATOR;
+  $extDir = $extRoot . 'templates';
+
+  if (is_array($template->template_dir)) {
+    array_unshift($template->template_dir, $extDir);
+  }
+  else {
+    $template->template_dir = [$extDir, $template->template_dir];
+  }
+
+  $include_path = $extRoot . PATH_SEPARATOR . get_include_path();
+  set_include_path($include_path);
+
+  _shimmy_civix_mixin_polyfill();
+}
+
+/**
+ * Implements hook_civicrm_install().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_install
+ */
+function _shimmy_civix_civicrm_install() {
+  _shimmy_civix_civicrm_config();
+  if ($upgrader = _shimmy_civix_upgrader()) {
+    $upgrader->onInstall();
+  }
+  _shimmy_civix_mixin_polyfill();
+}
+
+/**
+ * Implements hook_civicrm_postInstall().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_postInstall
+ */
+function _shimmy_civix_civicrm_postInstall() {
+  _shimmy_civix_civicrm_config();
+  if ($upgrader = _shimmy_civix_upgrader()) {
+    if (is_callable([$upgrader, 'onPostInstall'])) {
+      $upgrader->onPostInstall();
+    }
+  }
+}
+
+/**
+ * Implements hook_civicrm_uninstall().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_uninstall
+ */
+function _shimmy_civix_civicrm_uninstall() {
+  _shimmy_civix_civicrm_config();
+  if ($upgrader = _shimmy_civix_upgrader()) {
+    $upgrader->onUninstall();
+  }
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_enable().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_enable
+ */
+function _shimmy_civix_civicrm_enable() {
+  _shimmy_civix_civicrm_config();
+  if ($upgrader = _shimmy_civix_upgrader()) {
+    if (is_callable([$upgrader, 'onEnable'])) {
+      $upgrader->onEnable();
+    }
+    _shimmy_civix_mixin_polyfill();
+  }
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_disable().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_disable
+ * @return mixed
+ */
+function _shimmy_civix_civicrm_disable() {
+  _shimmy_civix_civicrm_config();
+  if ($upgrader = _shimmy_civix_upgrader()) {
+    if (is_callable([$upgrader, 'onDisable'])) {
+      $upgrader->onDisable();
+    }
+  }
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_upgrade().
+ *
+ * @param $op string, the type of operation being performed; 'check' or 'enqueue'
+ * @param $queue CRM_Queue_Queue, (for 'enqueue') the modifiable list of pending up upgrade tasks
+ *
+ * @return mixed
+ *   based on op. for 'check', returns array(boolean) (TRUE if upgrades are pending)
+ *   for 'enqueue', returns void
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_upgrade
+ */
+function _shimmy_civix_civicrm_upgrade($op, CRM_Queue_Queue $queue = NULL) {
+  if ($upgrader = _shimmy_civix_upgrader()) {
+    return $upgrader->onUpgrade($op, $queue);
+  }
+}
+
+/**
+ * @return CRM_Shimmy_Upgrader
+ */
+function _shimmy_civix_upgrader() {
+  if (!file_exists(__DIR__ . '/CRM/Shimmy/Upgrader.php')) {
+    return NULL;
+  }
+  else {
+    return CRM_Shimmy_Upgrader_Base::instance();
+  }
+}
+
+/**
+ * Inserts a navigation menu item at a given place in the hierarchy.
+ *
+ * @param array $menu - menu hierarchy
+ * @param string $path - path to parent of this item, e.g. 'my_extension/submenu'
+ *    'Mailing', or 'Administer/System Settings'
+ * @param array $item - the item to insert (parent/child attributes will be
+ *    filled for you)
+ *
+ * @return bool
+ */
+function _shimmy_civix_insert_navigation_menu(&$menu, $path, $item) {
+  // If we are done going down the path, insert menu
+  if (empty($path)) {
+    $menu[] = [
+      'attributes' => array_merge([
+        'label'      => CRM_Utils_Array::value('name', $item),
+        'active'     => 1,
+      ], $item),
+    ];
+    return TRUE;
+  }
+  else {
+    // Find an recurse into the next level down
+    $found = FALSE;
+    $path = explode('/', $path);
+    $first = array_shift($path);
+    foreach ($menu as $key => &$entry) {
+      if ($entry['attributes']['name'] == $first) {
+        if (!isset($entry['child'])) {
+          $entry['child'] = [];
+        }
+        $found = _shimmy_civix_insert_navigation_menu($entry['child'], implode('/', $path), $item);
+      }
+    }
+    return $found;
+  }
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_navigationMenu().
+ */
+function _shimmy_civix_navigationMenu(&$nodes) {
+  if (!is_callable(['CRM_Core_BAO_Navigation', 'fixNavigationMenu'])) {
+    _shimmy_civix_fixNavigationMenu($nodes);
+  }
+}
+
+/**
+ * Given a navigation menu, generate navIDs for any items which are
+ * missing them.
+ */
+function _shimmy_civix_fixNavigationMenu(&$nodes) {
+  $maxNavID = 1;
+  array_walk_recursive($nodes, function($item, $key) use (&$maxNavID) {
+    if ($key === 'navID') {
+      $maxNavID = max($maxNavID, $item);
+    }
+  });
+  _shimmy_civix_fixNavigationMenuItems($nodes, $maxNavID, NULL);
+}
+
+function _shimmy_civix_fixNavigationMenuItems(&$nodes, &$maxNavID, $parentID) {
+  $origKeys = array_keys($nodes);
+  foreach ($origKeys as $origKey) {
+    if (!isset($nodes[$origKey]['attributes']['parentID']) && $parentID !== NULL) {
+      $nodes[$origKey]['attributes']['parentID'] = $parentID;
+    }
+    // If no navID, then assign navID and fix key.
+    if (!isset($nodes[$origKey]['attributes']['navID'])) {
+      $newKey = ++$maxNavID;
+      $nodes[$origKey]['attributes']['navID'] = $newKey;
+      $nodes[$newKey] = $nodes[$origKey];
+      unset($nodes[$origKey]);
+      $origKey = $newKey;
+    }
+    if (isset($nodes[$origKey]['child']) && is_array($nodes[$origKey]['child'])) {
+      _shimmy_civix_fixNavigationMenuItems($nodes[$origKey]['child'], $maxNavID, $nodes[$origKey]['attributes']['navID']);
+    }
+  }
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_entityTypes().
+ *
+ * Find any *.entityType.php files, merge their content, and return.
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_entityTypes
+ */
+function _shimmy_civix_civicrm_entityTypes(&$entityTypes) {
+  $entityTypes = array_merge($entityTypes, []);
+}

--- a/tests/extensions/shimmy/shimmy.php
+++ b/tests/extensions/shimmy/shimmy.php
@@ -1,0 +1,108 @@
+<?php
+
+require_once 'shimmy.civix.php';
+// phpcs:disable
+use CRM_Shimmy_ExtensionUtil as E;
+// phpcs:enable
+
+/**
+ * Implements hook_civicrm_config().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_config/
+ */
+function shimmy_civicrm_config(&$config) {
+  _shimmy_civix_civicrm_config($config);
+}
+
+/**
+ * Implements hook_civicrm_install().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_install
+ */
+function shimmy_civicrm_install() {
+  _shimmy_civix_civicrm_install();
+}
+
+/**
+ * Implements hook_civicrm_postInstall().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_postInstall
+ */
+function shimmy_civicrm_postInstall() {
+  _shimmy_civix_civicrm_postInstall();
+}
+
+/**
+ * Implements hook_civicrm_uninstall().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_uninstall
+ */
+function shimmy_civicrm_uninstall() {
+  _shimmy_civix_civicrm_uninstall();
+}
+
+/**
+ * Implements hook_civicrm_enable().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_enable
+ */
+function shimmy_civicrm_enable() {
+  _shimmy_civix_civicrm_enable();
+}
+
+/**
+ * Implements hook_civicrm_disable().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_disable
+ */
+function shimmy_civicrm_disable() {
+  _shimmy_civix_civicrm_disable();
+}
+
+/**
+ * Implements hook_civicrm_upgrade().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_upgrade
+ */
+function shimmy_civicrm_upgrade($op, CRM_Queue_Queue $queue = NULL) {
+  return _shimmy_civix_civicrm_upgrade($op, $queue);
+}
+
+/**
+ * Implements hook_civicrm_entityTypes().
+ *
+ * Declare entity types provided by this module.
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_entityTypes
+ */
+function shimmy_civicrm_entityTypes(&$entityTypes) {
+  _shimmy_civix_civicrm_entityTypes($entityTypes);
+}
+
+// --- Functions below this ship commented out. Uncomment as required. ---
+
+/**
+ * Implements hook_civicrm_preProcess().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_preProcess
+ */
+//function shimmy_civicrm_preProcess($formName, &$form) {
+//
+//}
+
+/**
+ * Implements hook_civicrm_navigationMenu().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_navigationMenu
+ */
+//function shimmy_civicrm_navigationMenu(&$menu) {
+//  _shimmy_civix_insert_navigation_menu($menu, 'Mailings', array(
+//    'label' => E::ts('New subliminal message'),
+//    'name' => 'mailing_subliminal_message',
+//    'url' => 'civicrm/mailing/subliminal',
+//    'permission' => 'access CiviMail',
+//    'operator' => 'OR',
+//    'separator' => 0,
+//  ));
+//  _shimmy_civix_navigationMenu($menu);
+//}

--- a/tests/extensions/shimmy/tests/phpunit/E2E/Shimmy/LifecycleTest.php
+++ b/tests/extensions/shimmy/tests/phpunit/E2E/Shimmy/LifecycleTest.php
@@ -1,0 +1,182 @@
+<?php
+
+/**
+ * Enable, disable, and uninstall an extension. Ensure that various local example is enabled and disabled appropriately.
+ *
+ * The substantive assertions are split across various files in `tests/mixins/*.php`.
+ *
+ * @group e2e
+ * @see cv
+ */
+class E2E_Shimmy_LifecycleTest extends \PHPUnit\Framework\TestCase implements \Civi\Test\EndToEndInterface {
+
+  /**
+   * @var array
+   */
+  protected $mixinTests;
+
+  protected function setUp(): void {
+    $this->assertNotEquals('UnitTests', getenv('CIVICRM_UF'), 'This is an end-to-end test involving CLI and HTTP. CIVICRM_UF should not be set to UnitTests.');
+
+    parent::setUp();
+
+    $this->mixinTests = [];
+    $mixinTestFiles = (array) glob($this->getPath('/tests/mixin/*Test.php'));
+    foreach ($mixinTestFiles as $file) {
+      require_once $file;
+      $class = '\\Civi\Shimmy\\Mixins\\' . preg_replace(';\.php$;', '', basename($file));
+      $this->mixinTests[] = new $class();
+    }
+  }
+
+  /**
+   * Install and uninstall the extension. Ensure that various mixins+artifacts work correctly.
+   *
+   * This interacts with Civi by running many subprocesses (`cv api3` and `cv api4` commands).
+   * This style of interaction is a better representation of how day-to-day sysadmin works.
+   */
+  public function testLifecycleWithSubprocesses(): void {
+    $this->runLifecycle($this->createCvWithSubprocesses());
+  }
+
+  /**
+   * Install and uninstall the extension. Ensure that various mixins+artifacts work correctly.
+   *
+   * This interacts with Civi by calling local PHP functions (`civicrm_api3(` and `civicrm_api4()`).
+   * This style of interaction reveals whether the install/uninstall mechanics have data-leaks that
+   * may cause subtle/buggy interactions during the transitions.
+   */
+  public function testLifecycleWithLocalFunctions(): void {
+    $this->runLifecycle($this->createCvWithLocalFunctions());
+  }
+
+  /**
+   * @param object $cv
+   *   The `$cv` object is (roughly speaking) a wrapper for calling `cv`.
+   *   It has method bindings for `$cv->api3()` and `$cv->api4()`.
+   *   Different variations of `$cv` may be supplied - they will execute
+   *   `$cv->api3()` and `$cv->api4()` in slightly different ways.
+   */
+  private function runLifecycle($cv): void {
+    $this->runMethods('testPreConditions', $cv);
+
+    // Clear out anything from previous runs.
+    $cv->api3('Extension', 'disable', ['key' => 'shimmy']);
+    $cv->api3('Extension', 'uninstall', ['key' => 'shimmy']);
+
+    // The main show.
+    $cv->api3('Extension', 'enable', ['key' => 'shimmy']);
+    $this->runMethods('testInstalled', $cv);
+
+    // This is a duplicate - make sure things still work after an extra run.
+    $cv->api3('Extension', 'enable', ['key' => 'shimmy']);
+    $this->runMethods('testInstalled', $cv);
+
+    // OK, how's the cleanup?
+    $cv->api3('Extension', 'disable', ['key' => 'shimmy']);
+    $this->runMethods('testDisabled', $cv);
+
+    $cv->api3('Extension', 'uninstall', ['key' => 'shimmy']);
+    $this->runMethods('testUninstalled', $cv);
+  }
+
+  protected static function getPath($suffix = ''): string {
+    return dirname(__DIR__, 4) . $suffix;
+  }
+
+  protected function runMethods(string $method, ...$args) {
+    if (empty($this->mixinTests)) {
+      $this->fail('Cannot run methods. No mixin tests found.');
+    }
+    foreach ($this->mixinTests as $test) {
+      $test->$method(...$args);
+    }
+  }
+
+  protected function createCvWithLocalFunctions() {
+    return new class {
+
+      public function api3($entity, $action, $params) {
+        return civicrm_api3($entity, $action, $params);
+      }
+
+      public function api4($entity, $action, $params): array {
+        $params = array_merge(['checkPermissions' => FALSE], $params);
+        return (array) civicrm_api4($entity, $action, $params);
+      }
+
+    };
+  }
+
+  protected function createCvWithSubprocesses() {
+    return new class {
+
+      public function api3($entity, $action, $params) {
+        return $this->cv('api3 --in=json ' . escapeshellarg("$entity.$action"), json_encode($params));
+      }
+
+      public function api4($entity, $action, $params): array {
+        $params = array_merge(['checkPermissions' => FALSE], $params);
+        return $this->cv('api4 --in=json ' . escapeshellarg("$entity.$action"), json_encode($params));
+      }
+
+      /**
+       * Call the "cv" command.
+       *
+       * @param string $cmd
+       *   The rest of the command to send.
+       * @param string|NULL $pipeData
+       *   Optional data to send to `cv` via pipe.
+       * @param string $decode
+       *   Ex: 'json' or 'phpcode'.
+       * @return string|array
+       *   Response output (if the command executed normally).
+       * @throws \RuntimeException
+       *   If the command terminates abnormally.
+       */
+      protected function cv(string $cmd, ?string $pipeData = NULL, string $decode = 'json') {
+        $cmd = 'cv ' . $cmd;
+        $descriptorSpec = array(0 => array('pipe', 'r'), 1 => array('pipe', 'w'), 2 => STDERR);
+        $oldOutput = getenv('CV_OUTPUT');
+        putenv("CV_OUTPUT=json");
+
+        // Execute `cv` in the original folder. This is a work-around for
+        // phpunit/codeception, which seem to manipulate PWD.
+        $cmd = sprintf('cd %s; %s', escapeshellarg(getenv('PWD')), $cmd);
+
+        $process = proc_open($cmd, $descriptorSpec, $pipes, __DIR__);
+        putenv("CV_OUTPUT=$oldOutput");
+
+        if ($pipeData !== NULL) {
+          fwrite($pipes[0], $pipeData);
+        }
+        fclose($pipes[0]);
+        $result = stream_get_contents($pipes[1]);
+        fclose($pipes[1]);
+        if (proc_close($process) !== 0) {
+          throw new RuntimeException("Command failed ($cmd):\n$result");
+        }
+        switch ($decode) {
+          case 'raw':
+            return $result;
+
+          case 'phpcode':
+            // If the last output is /*PHPCODE*/, then we managed to complete execution.
+            if (substr(trim($result), 0, 12) !== "/*BEGINPHP*/" || substr(trim($result), -10) !== "/*ENDPHP*/") {
+              throw new \RuntimeException("Command failed ($cmd):\n$result");
+            }
+            return $result;
+
+          case 'json':
+            return json_decode($result, 1);
+
+          default:
+            throw new RuntimeException("Bad decoder format ($decode)");
+        }
+      }
+
+    };
+
+  }
+
+}

--- a/tests/extensions/shimmy/tests/phpunit/bootstrap.php
+++ b/tests/extensions/shimmy/tests/phpunit/bootstrap.php
@@ -1,0 +1,64 @@
+<?php
+
+ini_set('memory_limit', '2G');
+
+// phpcs:disable
+eval(cv('php:boot --level=classloader', 'phpcode'));
+// phpcs:enable
+// Allow autoloading of PHPUnit helper classes in this extension.
+$loader = new \Composer\Autoload\ClassLoader();
+$loader->add('CRM_', __DIR__);
+$loader->add('Civi\\', __DIR__);
+$loader->add('api_', __DIR__);
+$loader->add('api\\', __DIR__);
+$loader->register();
+
+/**
+ * Call the "cv" command.
+ *
+ * @param string $cmd
+ *   The rest of the command to send.
+ * @param string $decode
+ *   Ex: 'json' or 'phpcode'.
+ * @return mixed
+ *   Response output (if the command executed normally).
+ *   For 'raw' or 'phpcode', this will be a string. For 'json', it could be any JSON value.
+ * @throws \RuntimeException
+ *   If the command terminates abnormally.
+ */
+function cv(string $cmd, string $decode = 'json') {
+  $cmd = 'cv ' . $cmd;
+  $descriptorSpec = [0 => ['pipe', 'r'], 1 => ['pipe', 'w'], 2 => STDERR];
+  $oldOutput = getenv('CV_OUTPUT');
+  putenv('CV_OUTPUT=json');
+
+  // Execute `cv` in the original folder. This is a work-around for
+  // phpunit/codeception, which seem to manipulate PWD.
+  $cmd = sprintf('cd %s; %s', escapeshellarg(getenv('PWD')), $cmd);
+
+  $process = proc_open($cmd, $descriptorSpec, $pipes, __DIR__);
+  putenv("CV_OUTPUT=$oldOutput");
+  fclose($pipes[0]);
+  $result = stream_get_contents($pipes[1]);
+  fclose($pipes[1]);
+  if (proc_close($process) !== 0) {
+    throw new RuntimeException("Command failed ($cmd):\n$result");
+  }
+  switch ($decode) {
+    case 'raw':
+      return $result;
+
+    case 'phpcode':
+      // If the last output is /*PHPCODE*/, then we managed to complete execution.
+      if (substr(trim($result), 0, 12) !== '/*BEGINPHP*/' || substr(trim($result), -10) !== '/*ENDPHP*/') {
+        throw new \RuntimeException("Command failed ($cmd):\n$result");
+      }
+      return $result;
+
+    case 'json':
+      return json_decode($result, 1);
+
+    default:
+      throw new RuntimeException("Bad decoder format ($decode)");
+  }
+}

--- a/tools/mixin/bin/mixer
+++ b/tools/mixin/bin/mixer
@@ -1,0 +1,279 @@
+#!/usr/bin/env php
+<?php
+
+require_once dirname(__DIR__) . '/src/Mixlib.php';
+
+function mixlib(): Mixlib {
+  static $mixlib;
+  if ($mixlib === NULL) {
+    $mixlib = new Mixlib();
+  }
+  return $mixlib;
+}
+
+/**
+ * Generate a test extension which uses the given mixins..
+ *
+ * @param array $options
+ *   Ex: ['force' => TRUE]
+ * @param string $targetDir
+ *   The output directory.
+ * @param mixed ...$mixinNames
+ *   List of mixins to include in the generated extension.
+ * @return string
+ */
+function task_create(array $options, string $targetDir, ...$mixinNames) {
+  if (file_exists($targetDir)) {
+    if (!empty($options['force'])) {
+      fprintf(STDOUT, "Remove %s\n", $targetDir);
+      remove_dir($targetDir);
+    }
+    else {
+      throw new \RuntimeException("Cannot overwrite $targetDir");
+    }
+  }
+
+  $mixinNames = resolve_mixin_names($mixinNames);
+  fprintf(STDOUT, "Create %s for %s\n", $targetDir, implode(',', $mixinNames));
+
+  $srcDirs = [];
+  $srcDirs[] = mixer_shimmy_dir();
+  foreach ($mixinNames as $mixinName) {
+    if (is_dir(mixer_mixlib_dir() . "/$mixinName/example")) {
+      $srcDirs[] = mixer_mixlib_dir() . "/$mixinName/example";
+    }
+  }
+  deep_copy($srcDirs, $targetDir);
+
+  $mixins = [];
+  foreach ($mixinNames as $mixinName) {
+    $mixins[$mixinName] = mixlib()->assertValid(mixlib()->get($mixinName));
+  }
+
+  if (empty($options['bare'])) {
+    mkdir("$targetDir/mixin");
+    file_put_contents("$targetDir/mixin/polyfill.php", mixlib()->get('polyfill')['src']);
+    foreach ($mixins as $mixin) {
+      file_put_contents("$targetDir/mixin/{$mixin['mixinName']}@{$mixin['mixinVersion']}.mixin.php", $mixin['src']);
+    }
+  }
+
+  rename(assert_file("$targetDir/info.xml.template"), "$targetDir/info.xml");
+  update_xml("$targetDir/info.xml", function (SimpleXMLElement $info) use ($mixins) {
+    $mixinsXml = $info->addChild('mixins');
+    foreach ($mixins as $mixinName => $mixin) {
+      $mixinsXml->addChild('mixin', $mixin['mixinName'] . '@' . $mixin['mixinVersion']);
+    }
+    if (!empty($options['bare'])) {
+      // If the example doesn't include mixins, then we must get them from elsewhere.
+      $requiresXml = $info->addChild('requires');
+      $requiresXml->addChild('ext', 'mixinlib');
+    }
+  });
+
+  return $targetDir;
+}
+
+/**
+ * Generate and test an extension that uses the given mixins..
+ *
+ * @param array $options
+ *   Ex: ['force' => TRUE]
+ *   Ex: ['isolate' => TRUE]
+ * @param string $targetDir
+ *   The output directory.
+ * @param mixed ...$mixinNames
+ *   List of mixins to include in the generated extension.
+ */
+function task_test(array $options, string $targetDir, ...$args) {
+  if (($split = array_search('--', $args)) !== FALSE) {
+    $mixinNames = array_slice($args, 0, $split);
+    $phpunitArgs = array_slice($args, $split + 1);
+  }
+  else {
+    $mixinNames = $args;
+    $phpunitArgs = explode(' ', '--group e2e --debug --stop-on-failure');
+  }
+
+  $mixinNames = resolve_mixin_names($mixinNames);
+  $errors = [];
+  if (!empty($options['isolate']) && count($mixinNames) > 1) {
+    foreach ($mixinNames as $mixinName) {
+      try {
+        task_test($options + ['force' => TRUE], $targetDir, $mixinName, '--', ...$phpunitArgs);
+      }
+      catch (\Throwable $t) {
+        fprintf(STDERR, "Error testing $mixinName\n%s\n\n", $t->getTraceAsString());
+        $errors = [$mixinName];
+      }
+    }
+    if ($errors) {
+      fprintf(STDERR, "Error processing mixins: %s\n", implode(' ', $errors));
+      exit(1);
+    }
+    return;
+  }
+
+  if (is_dir($targetDir) || !empty($options['force'])) {
+    $targetDir = task_create($options, $targetDir, ...$mixinNames);
+  }
+  if (empty(glob("$targetDir/tests/mixin/*.php"))) {
+    fprintf(STDERR, "Skip. No tests found for %s\n", implode(',', $mixinNames));
+    return;
+  }
+  fprintf(STDOUT, "Test %s\n", implode(',', $mixinNames));
+  with_dir($targetDir, function () use ($phpunitArgs) {
+    phpunit($phpunitArgs);
+  });
+}
+
+function task_list(array $options, ...$mixinNames) {
+  $mixinNames = resolve_mixin_names($mixinNames);
+  foreach ($mixinNames as $mixinName) {
+    $mixin = mixlib()->get($mixinName);
+    fprintf(STDOUT, "%-20s %-10s %s\n", $mixin['mixinName'], $mixin['mixinVersion'] ?? '', $mixin['description'] ?? '');
+  }
+}
+
+function task_help(array $options) {
+  $cmd = basename($GLOBALS['argv'][0]);
+  fprintf(STDERR, "%s - Test utility for extension mixins\n", $cmd);
+  fprintf(STDERR, "\n");
+  fprintf(STDERR, "Usage:\n");
+  fprintf(STDERR, "  %s create [-f] [--bare] <new-ext-path> [<mixin-name>...]\n", $cmd);
+  fprintf(STDERR, "  %s test [-f] [--bare] [--isolate] <new-ext-path> [<mixin-name>...] -- [<phpunit-args>...]\n", $cmd);
+  fprintf(STDERR, "  %s list [<mixin-name>...]\n", $cmd);
+}
+
+function mixer_mixlib_dir(): string {
+  return dirname(__DIR__, 3) . '/mixin';
+}
+
+function mixer_shimmy_dir(): string {
+  return dirname(__DIR__, 3) . '/tests/extensions/shimmy';
+}
+
+function assert_dir(string $dir): string {
+  if (!file_exists($dir) || !is_dir($dir)) {
+    throw new \RuntimeException("Directory does not exist ($dir)");
+  }
+  return $dir;
+}
+
+function assert_file(string $file): string {
+  if (!file_exists($file)) {
+    throw new \RuntimeException("File does not exist ($file)");
+  }
+  return $file;
+}
+
+function remove_dir(string $dir): void {
+  if (file_exists($dir)) {
+    passthru_ok("rm -rf " . escapeshellarg($dir));
+  }
+}
+
+function deep_copy(array $srcDirs, string $targetDir): void {
+  $srcDirs = (array) $srcDirs;
+  foreach ($srcDirs as $srcDir) {
+    assert_dir($srcDir);
+  }
+
+  if (!file_exists($targetDir)) {
+    mkdir($targetDir);
+  }
+
+  foreach ($srcDirs as $srcDir) {
+    passthru_ok(sprintf('rsync -a %s/./ %s/./', escapeshellarg($srcDir), escapeshellarg($targetDir)));
+  }
+}
+
+function phpunit(array $args = []) {
+  $argString = implode(' ' , array_map('escapeshellarg', $args));
+  passthru_ok('phpunit8 ' . $argString);
+}
+
+function passthru_ok($cmd) {
+  passthru($cmd, $return);
+  if ($return !== 0) {
+    throw new \RuntimeException("Command failed ($cmd)");
+  }
+}
+
+function resolve_mixin_names(array $mixinNames): array {
+  if (empty($mixinNames)) {
+    return mixlib()->getList();
+  }
+  else {
+    return array_map(
+      function (string $mixinName) {
+        return trim($mixinName, '/' . DIRECTORY_SEPARATOR);
+      }, $mixinNames);
+  }
+}
+
+function with_dir(string $dir, callable $callback) {
+  assert_dir($dir);
+  $orig = getcwd();
+  try {
+    chdir($dir);
+    $callback();
+  } finally {
+    chdir($orig);
+  }
+}
+
+function update_xml(string $file, callable $filter): void {
+  $dom = new DomDocument();
+  $dom->load($file);
+  $dom->xinclude();
+  $simpleXml = simplexml_import_dom($dom);
+  $filter($simpleXml);
+  // force pretty printing with encode/decode cycle
+  $outXML = $simpleXml->saveXML();
+  $xml = new DOMDocument();
+  $xml->encoding = 'iso-8859-1';
+  $xml->preserveWhiteSpace = FALSE;
+  $xml->formatOutput = TRUE;
+  $xml->loadXML($outXML);
+  file_put_contents($file, $xml->saveXML());
+}
+
+function main($args) {
+  $cmd = array_shift($args);
+
+  $isParsingOptions = TRUE;
+  $newOptions = $newArgs = [];
+  $task = NULL;
+  foreach ($args as $arg) {
+    if (!$isParsingOptions) {
+      $newArgs[] = $arg;
+    }
+    elseif ($arg === '--') {
+      $isParsingOptions = FALSE;
+      $newArgs[] = $arg;
+    }
+    elseif ($arg === '-f') {
+      $newOptions['force'] = TRUE;
+    }
+    elseif (preg_match(';^--(bare|isolate|force)$;', $arg, $m)) {
+      $newOptions[$m[1]] = TRUE;
+    }
+    elseif ($task === NULL) {
+      $task = 'task_' . preg_replace(';[^\w];', '_', $arg);
+    }
+    else {
+      $newArgs[] = $arg;
+    }
+  }
+
+  if (function_exists($task)) {
+    call_user_func($task, $newOptions, ...$newArgs);
+  }
+  else {
+    task_help([]);
+    exit(1);
+  }
+}
+
+main($argv);

--- a/tools/mixin/bin/test-all
+++ b/tools/mixin/bin/test-all
@@ -1,0 +1,58 @@
+#!/bin/bash
+set -e
+export XDEBUG_PORT= XDEBUG_MODE=off
+
+###############################################################################
+## Bootstrap
+
+## Determine the absolute path of the directory with the file
+## usage: absdirname <file-path>
+function absdirname() {
+  pushd $(dirname $0) >> /dev/null
+    pwd
+  popd >> /dev/null
+}
+
+SCRIPT_DIR=$(absdirname "$0")
+EXT_DIR=$(cv path -c extensionsDir)/example-mixin
+JUNIT_DIR="$1"
+
+## TODO: Once the managed-entity regression is examined/fixed, remove the MY_MIXINS list. Then it will test all mixins.
+# MY_MIXINS='ang-php@1 case-xml@1 menu-xml@1 setting-php@1 theme-php@1'
+MY_MIXINS=''
+
+###############################################################################
+
+## usage: mixer_test <junit-test-file> [--bare] [--isolate] <mixin-names>...
+function mixer_test() {
+  local XML_FILE="$1"
+  shift
+
+  [ -f "$JUNIT_DIR/$XML_FILE" ] && rm -f "$JUNIT_DIR/$XML_FILE"
+
+  civibuild restore
+  cv flush
+
+  ## usage: mixer test [-f] [--bare] [--isolate] <temp-ext-path> [<mixin-names>...] -- [<phpunit-options>...]
+  "$SCRIPT_DIR/mixer" test -f "$EXT_DIR" "$@" -- --group e2e --log-junit "$JUNIT_DIR/$XML_FILE"
+}
+
+###############################################################################
+
+if [ -z "$EXT_DIR" -o ! -e "$EXT_DIR" ]; then
+  echo "Invalid extension dir: $EXT_DIR"
+  exit 1
+fi
+
+if [ -z "$JUNIT_DIR" ]; then
+  echo "Missing argument: <junit-dir>"
+  exit 1
+elif [ ! -d "$JUNIT_DIR" ]; then
+  mkdir -p "$JUNIT_DIR"
+fi
+
+
+set -ex
+mixer_test "mixin-isolate-bare.xml" $MY_MIXINS --isolate --bare
+mixer_test "mixin-combine-bare.xml" $MY_MIXINS --bare
+mixer_test "mixin-combine-copy.xml" $MY_MIXINS

--- a/tools/mixin/src/Mixlib.php
+++ b/tools/mixin/src/Mixlib.php
@@ -1,0 +1,284 @@
+<?php
+
+/**
+ * The Mixlib class is a utility for downloading/listing available mixins.
+ * It is used by some test-infra and by civix.
+ */
+class Mixlib {
+
+  /**
+   * Local path to the mixlib folder.
+   *
+   * @var string|null
+   */
+  private $mixlibDir;
+
+  /**
+   * Public URL of the mixlib folder.
+   *
+   * @var string|null
+   */
+  private $mixlibUrl;
+
+  private $cache = [];
+
+  /**
+   * Mixlib constructor.
+   *
+   * @param string|NULL $mixlibDir
+   *   Ex: Civi::paths()->getPath('[civicrm.root]/mixin')
+   * @param string|NULL $mixlibUrl
+   *   Ex: "https://raw.githubusercontent.com/civicrm/civicrm-core/5.45/mixin"
+   *   Ex: "https://raw.githubusercontent.com/totten/civicrm-core/master-mix-dec/mixin"
+   */
+  public function __construct(?string $mixlibDir = NULL, ?string $mixlibUrl = NULL) {
+    $this->mixlibDir = $mixlibDir ?: dirname(__DIR__, 3) . '/mixin';
+    $this->mixlibUrl = $mixlibUrl;
+  }
+
+  public function getList(): array {
+    if ($this->mixlibDir === NULL || !file_exists($this->mixlibDir)) {
+      throw new \RuntimeException("Cannot get list of available mixins");
+    }
+
+    if (isset($this->cache['getList'])) {
+      return $this->cache['getList'];
+    }
+
+    $dirs = (array) glob($this->mixlibDir . '/*@*');
+    $mixinNames = [];
+    foreach ($dirs as $dir) {
+      if (is_dir($dir)) {
+        $mixinNames[] = basename($dir);
+      }
+    }
+    sort($mixinNames);
+    $this->cache['getList'] = $mixinNames;
+    return $mixinNames;
+  }
+
+  /**
+   * @param string $mixin
+   *
+   * @return array
+   *   Item with keys:
+   *   - mixinName: string, eg 'mgd-php'
+   *   - mixinVersion: string, eg '1.0.2'
+   *   - mixinConstraint: string, eg 'mgd-php@1.0.2'
+   *   - mixinFile: string, eg 'mgd-php@1.0.2.mixin.php'
+   *   - src: string, unevaluated PHP source
+   */
+  public function get(string $mixin) {
+    if (isset($this->cache["parsed:$mixin"])) {
+      return $this->cache["parsed:$mixin"];
+    }
+
+    $phpCode = $this->getSourceCode($mixin);
+    $mixinSpec = $this->parseString($phpCode);
+    $mixinSpec['mixinName'] = $mixinSpec['mixinName'] ?? preg_replace(';@.*$;', '', $mixin);
+
+    $parts = explode('@', $mixin);
+    $effectiveVersion = !empty($mixinSpec['mixinVersion']) ? $mixinSpec['mixinVersion'] : ($parts[1] ?? '');
+    if ($effectiveVersion) {
+      $mixinSpec = array_merge([
+        'mixinConstraint' => $mixinSpec['mixinName'] . '@' . $effectiveVersion,
+        'mixinFile' => $mixinSpec['mixinName'] . '@' . $effectiveVersion . '.mixin.php',
+      ], $mixinSpec);
+    }
+    else {
+      $mixinSpec = array_merge([
+        'mixinFile' => $mixinSpec['mixinName'] . '.mixin.php',
+      ], $mixinSpec);
+    }
+    $mixinSpec['src'] = $phpCode;
+    $this->cache["parsed:$mixin"] = $mixinSpec;
+
+    return $this->cache["parsed:$mixin"];
+  }
+
+  /**
+   * Consolidate and retrieve the listed mixins.
+   *
+   * @param array $mixinConstraints
+   *   Ex: ['foo@1.0', 'bar@1.2', 'bar@1.3']
+   * @return array
+   *   Ex: ['foo@1.0' => array, 'bar@1.3' => array]
+   */
+  public function consolidate(array $mixinConstraints): array {
+    // Find and remove duplicate constraints. Pick tightest constraint.
+    // array(string $mixinName => string $mixinVersion)
+    $preferredVersions = [];
+    foreach ($mixinConstraints as $mixinName) {
+      [$name, $version] = explode('@', $mixinName);
+      if (!isset($preferredVersions[$name])) {
+        $preferredVersions[$name] = $version;
+      }
+      elseif (version_compare($version, $preferredVersions[$name], '>=')) {
+        $preferredVersions[$name] = $version;
+      }
+    }
+
+    // Resolve current versions matching constraint.
+    $result = [];
+    foreach ($preferredVersions as $mixinName => $mixinVersion) {
+      $result[] = $mixinName . '@' . $mixinVersion;
+    }
+    sort($result);
+    return $result;
+  }
+
+  /**
+   * Consolidate and retrieve the listed mixins.
+   *
+   * @param array $mixinConstraints
+   *   Ex: ['foo@1.0', 'bar@1.2', 'bar@1.3']
+   * @return array
+   *   Ex: ['foo@1.0' => array, 'bar@1.3' => array]
+   */
+  public function resolve(array $mixinConstraints): array {
+    $mixinConstraints = $this->consolidate($mixinConstraints);
+
+    $result = [];
+    foreach ($mixinConstraints as $mixinConstraint) {
+      [$expectName, $expectVersion] = explode('@', $mixinConstraint);
+      $mixin = $this->get($mixinConstraint);
+      $this->assertValid($mixin);
+      if (!version_compare($mixin['mixinVersion'], $expectVersion, '>=') || $mixin['mixinName'] !== $expectName) {
+        throw new \RuntimeException(sprintf("Received incompatible version (expected=\"%s@%s\", actual=\"%s@%s\")", $expectName, $expectVersion, $mixin['mixinName'], $mixin['mixinVersion']));
+      }
+      $result[$mixin['mixinConstraint']] = $mixin;
+    }
+    return $result;
+  }
+
+  /**
+   * @param string $mixin
+   *  Ex: 'foo@1.2.3', 'foo-bar@4.5.6', 'polyfill',
+   * @return string
+   */
+  protected function getSourceCode(string $mixin): string {
+    if ($mixin === 'polyfill') {
+      $file = 'polyfill.php';
+    }
+    elseif (preg_match(';^([-\w]+)@(\d+)([\.\d]+)?;', $mixin, $m)) {
+      // Get the last revision within the major series.
+      $file = sprintf('%s@%s/mixin.php', $m[1], $m[2]);
+    }
+    else {
+      throw new \RuntimeException("Failed to parse mixin name ($mixin)");
+    }
+
+    if ($this->mixlibDir && file_exists($this->mixlibDir . '/' . $file)) {
+      return file_get_contents($this->mixlibDir . '/' . $file);
+    }
+
+    if ($this->mixlibUrl) {
+      $url = $this->mixlibUrl . '/' . $file;
+      $download = file_get_contents($url);
+      if (!empty($download)) {
+        $this->cache["src:$mixin"] = $download;
+        return $download;
+      }
+    }
+
+    throw new \RuntimeException("Failed to locate $file (mixlibDir={$this->mixlibDir}, mixlibUrl={$this->mixlibUrl})");
+  }
+
+  public function assertValid(array $mixin): array {
+    if (empty($mixin['mixinVersion'])) {
+      throw new \RuntimeException("Invalid {$mixin["file"]}. There is no @mixinVersion annotation.");
+    }
+    if (empty($mixin['mixinVersion'])) {
+      throw new \RuntimeException("Invalid {$mixin["file"]}. There is no @mixinName annotation.");
+    }
+    return $mixin;
+  }
+
+  /**
+   * @param string $phpCode
+   * @return array
+   */
+  protected function parseString(string $phpCode): array {
+    $commmentTokens = [T_DOC_COMMENT, T_COMMENT, T_FUNC_C, T_METHOD_C, T_TRAIT_C, T_CLASS_C];
+    $mixinSpec = [];
+    foreach (token_get_all($phpCode) as $token) {
+      if (is_array($token) && in_array($token[0], $commmentTokens)) {
+        $mixinSpec = $this->parseComment($token[1]);
+        break;
+      }
+    }
+    return $mixinSpec;
+  }
+
+  protected function parseComment(string $comment): array {
+    $info = [];
+    $param = NULL;
+    foreach (preg_split("/((\r?\n)|(\r\n?))/", $comment) as $num => $line) {
+      if (!$num || strpos($line, '*/') !== FALSE) {
+        continue;
+      }
+      $line = ltrim(trim($line), '*');
+      if (strlen($line) && $line[0] === ' ') {
+        $line = substr($line, 1);
+      }
+      if (strpos(ltrim($line), '@') === 0) {
+        $words = explode(' ', ltrim($line, ' @'));
+        $key = array_shift($words);
+        $param = NULL;
+        if ($key == 'var') {
+          $info['type'] = explode('|', $words[0]);
+        }
+        elseif ($key == 'return') {
+          $info['return'] = explode('|', $words[0]);
+        }
+        elseif ($key == 'options' || $key == 'ui_join_filters') {
+          $val = str_replace(', ', ',', implode(' ', $words));
+          $info[$key] = explode(',', $val);
+        }
+        elseif ($key == 'throws' || $key == 'see') {
+          $info[$key][] = implode(' ', $words);
+        }
+        elseif ($key == 'param' && $words) {
+          $type = $words[0][0] !== '$' ? explode('|', array_shift($words)) : NULL;
+          $param = rtrim(array_shift($words), '-:()/');
+          $info['params'][$param] = [
+            'type' => $type,
+            'description' => $words ? ltrim(implode(' ', $words), '-: ') : '',
+            'comment' => '',
+          ];
+        }
+        else {
+          // Unrecognized annotation, but we'll duly add it to the info array
+          $val = implode(' ', $words);
+          $info[$key] = strlen($val) ? $val : TRUE;
+        }
+      }
+      elseif ($param) {
+        $info['params'][$param]['comment'] .= $line . "\n";
+      }
+      elseif ($num == 1) {
+        $info['description'] = ucfirst($line);
+      }
+      elseif (!$line) {
+        if (isset($info['comment'])) {
+          $info['comment'] .= "\n";
+        }
+        else {
+          $info['comment'] = NULL;
+        }
+      }
+      // For multi-line description.
+      elseif (count($info) === 1 && isset($info['description']) && substr($info['description'], -1) !== '.') {
+        $info['description'] .= ' ' . $line;
+      }
+      else {
+        $info['comment'] = isset($info['comment']) ? "{$info['comment']}\n$line" : $line;
+      }
+    }
+    if (isset($info['comment'])) {
+      $info['comment'] = rtrim($info['comment']);
+    }
+    return $info;
+  }
+
+}


### PR DESCRIPTION
(*This is an update of #17832 and #19865. Broadly, it addresses issues identified in those PRs and goes further - adding automated tests, allowing `civicrm-core` to define mixins, and converting several core extensions to use the first mixin `setting-php`.*)

Overview
--------

`civix` has traditionally use code-templates to generate a large amount of boilerplate. Some of this boilerplate is entirely redundant, and propagating updates for it is difficult. With many extensions, the cumulative weight can become non-trivial.

This PR introduces an alternative, "mixins". A mixin is a small file that enhances an extension. Loosely speaking, a "Civi mixin" enhances a "Civi extension" in the same way that a "PHP trait" enhances a "PHP class" - by mixing-in various methods/hooks/etc.

Mixins are simple, static PHP files that can be edited and debugged. Mixins are named, versioned, and deduplicated. They are not code-templates. They do not use scans/file-loads/hooks unless an extension actually needs the functionality.

Mixins still allow strong backward/forward interoperability. A developer (or dev-tool like `civix`) may copy a mixin to an extension and deploy it on an older version of `civicrm-core` (*even without this PR*). However, core support has several benefits: improved versioning/upgrading, improved caching, and so on. Additionally, it allows *core extensions* to take advantage of mixins.

See also: https://github.com/totten/civix/issues/175

Before
------

The civix templates generate a few files, such as `mymod.php` and `mymod.civix.php`. A typical example looks like this:

```php
// mymod.php - Implement hook_civicrm_xmlMenu
require_once 'mymod.civix.php';
function mymod_civicrm_xmlMenu(&$all, $the, $params) {
  _mymod_civix_civicrm_xmlMenu($all, $the, $params);
}
```

and

```php
// mymod.civix.php - Implement hook_civicrm_xmlMenu
function _mymod_civix_civicrm_xmlMenu(&$all, $the, $params) {
  foreach (_mosaico_civix_glob(__DIR__ . '/xml/Menu/*.xml') as $file) {
    $files[] = $file;
  }
}
```

After
-----

An extension may enable a mixin in `info.xml`, eg:

```xml
<extension key="org.example.mymod" type="module">
  <file>mymod</file>
  <mixins>
    <mixin>menu-xml@1.0.0</mixin>
  </mixins>
</extension>
```

The name `menu-xml@1.0.0` is used to load an eponymous PHP file. This a simple/static PHP file, and it looks like this (*edited for brevity*):

```php
return function(\CRM_Extension_MixInfo $mixInfo, \CRM_Extension_BootCache $bootCache) {
  Civi::dispatcher()->addListener('hook_civicrm_xmlMenu', function ($e) use ($mixInfo) {
    $files = (array) glob($mixInfo->getPath('xml/Menu/*.xml'));
    foreach ($files as $file) {
      $e->files[] = $file;
    }
  });
};
```

One copy of this `menu-xml@1.0.0` file is sufficient for use by multiple extensions.

<a name="faq"></a>

FAQ
------------------

___Q: What mixins are defined in this PR?___

This PR only defines one mixin (`setting-php`) which autoloads `$EXT/setting/*.setting.php` files. It also updates all core extensions to (a) remove the old setting boilerplate and (b) use the `setting-php` mixin if necessary.

The follow-up PR #22199 converts several more functions from boilerplate-notation to mixin-notation.

___Q: What test coverage is there?___

There are generally two forms of coverage:

* By adopting the mixins for core extensions, we gain exposure through any existing test-coverage for those extensions. You can do some `r-run` with the core extension (enabling+disabling them; viewing admin screens) to see that the settings still work.
* The folders like `mixin/setting-php@1/example` (et al) define example files. The script `./tools/mixin/bin/test-all` will generate a test extension, copy in the examples, and assert that the examples work.

___Q: Why must an extension opt-in to using `<mixin>menu-xml@1.0.0</mixin>`? Why not automatically scan `$EXT/xml/Menu/*` in all extensions?___

A: Automatically scanning `$EXT/xml/Menu/*` in all extensions would interfere with pre-existing extensions - because they already have their own scanners and loaders. Consider a site that has an old copy of `org.example.mymod` installed. It defines `function mymod_civicrm_xmlMenu()` to scan for `mymod/xml/Menu/*`. If `civicrm-core` automatically scanned `$EXT/xml/Menu/*` on all extensions, then `mymod/xml/Menu/*` would load twice.

Depending on the happenstance of the specific hook/scanner, this may produce duplicate registrations, integrity errors, etc. Theoretically, one might be able to negotiate this conflict for specific hooks+files. However, using an opt-in is a simple technique that categorically works for many different hooks/scanners/file-conventions, and it lines us up well if we need to make future changes.

___Q: Where are mixin files loaded from?___

Generally:

```
BASEDIR/mixin/NAME@VERSION.mixin.php   (*dot-mixin-php*)
BASEDIR/mixin/NAME@VERSION/mixin.php   (*sub-dir*)
```

For example, on a D7/BD site, one might have:

```
BASEDIR                                   MIXIN FILE
sites/default/files/civicrm/ext/foobar/   mixin/menu-xml@1.1.0.mixin.php
sites/default/files/civicrm/ext/whizbang/ mixin/menu-xml@1.0.3.mixin.php
sites/all/modules/civicrm/                mixin/menu-xml@1/mixin.php (with header `@mixinVersion 1.3.9`)
sites/all/modules/civicrm/                mixin/menu-xml@2/mixin.php (with header `@mixinVersion 2.0.1`)
```

This example includes four versions (1.1.0, 1.0.3, 1.3.9, and 2.0.1). Older versions (1.1.0, 1.0.3) are effectively ignored. Depending on the `<mixin>` declaration, it will load the best compatible version  - either `1.3.9` or `2.0.1`. (*Under SemVer, `MAJOR` increments are not mutually compatible. But `MINOR` and `PATCH` versions have implied forward-compatibility.*)

___Q: How do I backport a mixin for use on an older version of `civicrm-core`?___

A: I don't actually recommend that most developers do this. An upcoming version of `civix` will do it automatically/as-needed.

But the mechanism is fairly simple: Copy the mixin file, and ensure that the full version is included.

```sh
CIVI="sites/all/modules/civicrm"
EXT="sites/default/files/civicrm/ext/org.example.mymod"
cp "$CIVI/mixin/xml-menu@1/mixin.php" "$EXT/mixin/xml-menu@1.0.0.mixin.php"
```

Additionally, if the target version of `civicrm-core` does not have mixin support, then you need to copy/configure `mixin/polyfill.php`.

