### PR TITLE
Change UI_line_item_value index to be non-unique

### DIFF
--- a/CRM/Upgrade/Incremental/sql/5.45.alpha1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.45.alpha1.mysql.tpl
@@ -11,3 +11,6 @@ UPDATE civicrm_state_province SET name = 'Cotabato' WHERE country_id = @PHILIPPI
 SELECT @country_id := id from civicrm_country where name = 'Colombia' AND iso_code = 'CO';
 INSERT IGNORE INTO `civicrm_state_province` (`id`, `country_id`, `abbreviation`, `name`) VALUES
 (NULL, @country_id, 'HUI', 'Huila');
+
+-- Change civicrm_line_item index to be non-unique
+ALTER TABLE `civicrm_line_item` DROP INDEX `UI_line_item_value`, ADD INDEX `UI_line_item_value` (`entity_table`, `entity_id`, `contribution_id`, `price_field_value_id`, `price_field_id`) USING BTREE;

--- a/xml/schema/Price/LineItem.xml
+++ b/xml/schema/Price/LineItem.xml
@@ -148,7 +148,7 @@
     <fieldName>contribution_id</fieldName>
     <fieldName>price_field_value_id</fieldName>
     <fieldName>price_field_id</fieldName>
-    <unique>true</unique>
+    <unique>false</unique>
     <add>3.3</add>
     <change>4.5</change>
     <!-- Add contribution_id to unique index in 4.5  -->


### PR DESCRIPTION
Overview
----------------------------------------
Change UI_line_item_value index to be non-unique. This is to fix a problem preventing Orders from being created using the WooCommerce CiviCRM plugin. See bug report https://github.com/mecachisenros/woocommerce_civicrm/issues/46

Before
----------------------------------------
CiviCRM Order cannot be created by the WooCommerce CiviCRM plugin

After
----------------------------------------
CiviCRM Order can be created by the WooCommerce CiviCRM plugin

Technical Details
----------------------------------------
The uniqueness of this index is preventing a new Order to be created when there is no Priceset associated with the Line Items for the Order.

Comments
----------------------------------------
Probably needs more work, but this is a first attempt.


Agileware Ref: CIVIWOO-14