### PR TITLE
tools/mixin/bin/test-all - Fix guard for EXT_DIR

### DIFF
--- a/tools/mixin/bin/test-all
+++ b/tools/mixin/bin/test-all
@@ -14,7 +14,8 @@ function absdirname() {
 }
 
 SCRIPT_DIR=$(absdirname "$0")
-EXT_DIR=$(cv path -c extensionsDir)/example-mixin
+EXT_DIR=$(cv path -c extensionsDir)
+EX_EXT_DIR="$EXT_DIR/example-mixin"
 JUNIT_DIR="$1"
 
 ## TODO: Once the managed-entity regression is examined/fixed, remove the MY_MIXINS list. Then it will test all mixins.
@@ -34,7 +35,7 @@ function mixer_test() {
   cv flush
 
   ## usage: mixer test [-f] [--bare] [--isolate] <temp-ext-path> [<mixin-names>...] -- [<phpunit-options>...]
-  "$SCRIPT_DIR/mixer" test -f "$EXT_DIR" "$@" -- --group e2e --log-junit "$JUNIT_DIR/$XML_FILE"
+  "$SCRIPT_DIR/mixer" test -f "$EX_EXT_DIR" "$@" -- --group e2e --log-junit "$JUNIT_DIR/$XML_FILE"
 }
 
 ###############################################################################


### PR DESCRIPTION
Overview
----------------------------------------

This patches a test/infra script and does not affect runtime functionality.

Follow-up to #22198. CC @seamuslee001 

Before
----------------------------------------

`tools/mixin/bin/test-all` only runs if there is a pre-existing copy of the example extension (`$extensionsDir/example-mixin`). If you attempt to run on a clean build (where there is no example extension yet), then it complains that the directory does not exist.

After
----------------------------------------

`tools/mixin/bin/test-all` only asserts that the `$extensionsDir` exists. It auto-creates `$extensionsDir/example-mixin` as needed.

