### PR TITLE
APIv4 ConformanceTest - Demonstrate entity APIs which fail to emit `hook_civicrm_post(delete)`

### DIFF
--- a/tests/phpunit/api/v4/Entity/ConformanceTest.php
+++ b/tests/phpunit/api/v4/Entity/ConformanceTest.php
@@ -432,7 +432,16 @@ class ConformanceTest extends UnitTestCase implements HookInterface {
       $deleteAction->setUseTrash(FALSE);
     }
 
+    $log = [];
+    $listen = function($e) use (&$log) {
+      $log[] = $e->entity . '.' . $e->action;
+    };
+    \Civi::dispatcher()->addListener('hook_civicrm_post', $listen);
     $deleteResult = $deleteAction->execute();
+    \Civi::dispatcher()->removeListener('hook_civicrm_post', $listen);
+
+    // We should have emitted an event.
+    $this->assertTrue(in_array("$entity.delete", $log), "$entity should emit hook_civicrm_post() for deletions");
 
     // should get back an array of deleted id
     $this->assertEquals([['id' => $id]], (array) $deleteResult);


### PR DESCRIPTION
Overview
----------------------------------------

Add assertions to APIv4's `ConformanceTest` to determine whether `FooEntity::delete()` emits `hook_civicrm_post('delete', 'FooEntity')`.

ping @colemanw

Before
----------------------------------------

Some entities emit `hook_civicrm_post('delete'...)`, and some don't... and it's hard to be sure which is which.

After
----------------------------------------

Some entities emit `hook_civicrm_post('delete'...)`, and some don't... and the test tells us which is which.

Comments
----------------------------------------

As discussed in https://github.com/civicrm/civicrm-core/pull/22199#issuecomment-984238304, the event `hook_civicrm_post('delete'...)` becomes more important in the current `master` -- if this event is not supported, then the managed-entities cannot be cleaned up.

The list of non-conformant entities is fairly long: `CaseType`, `Contact`, `ContactType`, `FinancialAccount`, `FinancialType`, `LocationType`, `MembershipStatus`, `MembershipType`, `MessageTemplate`, `OptionGroup`, `PaymentProcessor`, `PaymentProcessorType`, `RelationshipType`, `WordReplacement`.

(Note: `Contact` is probably OK, but it fails the test because it uses alternative names like `Individual`.)