### PR TITLE
Standardize deletion mechanics across ~13 BAOs

### DIFF
--- a/CRM/Case/BAO/CaseType.php
+++ b/CRM/Case/BAO/CaseType.php
@@ -18,7 +18,7 @@
 /**
  * This class contains the functions for Case Type management.
  */
-class CRM_Case_BAO_CaseType extends CRM_Case_DAO_CaseType {
+class CRM_Case_BAO_CaseType extends CRM_Case_DAO_CaseType implements \Civi\Test\HookInterface {
 
   /**
    * Static field for all the case information that we can potentially export.
@@ -65,7 +65,6 @@ class CRM_Case_BAO_CaseType extends CRM_Case_DAO_CaseType {
 
     $caseTypeDAO->copyValues($params);
     $result = $caseTypeDAO->save();
-    CRM_Case_XMLRepository::singleton()->flush();
     return $result;
   }
 
@@ -407,12 +406,9 @@ class CRM_Case_BAO_CaseType extends CRM_Case_DAO_CaseType {
       $transaction->rollback();
       return $caseType;
     }
+    $transaction->commit();
 
     CRM_Utils_Hook::post($action, 'CaseType', $caseType->id, $case);
-
-    $transaction->commit();
-    CRM_Case_XMLRepository::singleton(TRUE);
-    CRM_Core_OptionGroup::flushAll();
 
     return $caseType;
   }
@@ -438,20 +434,40 @@ class CRM_Case_BAO_CaseType extends CRM_Case_DAO_CaseType {
   /**
    * @param int $caseTypeId
    *
+   * @deprecated
    * @throws CRM_Core_Exception
-   * @return mixed
+   * @return CRM_Case_DAO_CaseType
    */
   public static function del($caseTypeId) {
-    $caseType = new CRM_Case_DAO_CaseType();
-    $caseType->id = $caseTypeId;
-    $refCounts = $caseType->getReferenceCounts();
-    $total = array_sum(CRM_Utils_Array::collect('count', $refCounts));
-    if ($total) {
-      throw new CRM_Core_Exception(ts("You can not delete this case type -- it is assigned to %1 existing case record(s). If you do not want this case type to be used going forward, consider disabling it instead.", [1 => $total]));
+    return static::deleteRecord(['id' => $caseTypeId]);
+  }
+
+  /**
+   * Callback for hook_civicrm_pre().
+   * @param \Civi\Core\Event\PreEvent $event
+   * @throws CRM_Core_Exception
+   */
+  public static function self_hook_civicrm_pre(\Civi\Core\Event\PreEvent $event) {
+    // Before deleting a caseType, check references
+    if ($event->action === 'delete') {
+      $caseType = new CRM_Case_DAO_CaseType();
+      $caseType->id = $event->id;
+      $refCounts = $caseType->getReferenceCounts();
+      $total = array_sum(CRM_Utils_Array::collect('count', $refCounts));
+      if (array_sum(CRM_Utils_Array::collect('count', $refCounts))) {
+        throw new CRM_Core_Exception(ts("You can not delete this case type -- it is assigned to %1 existing case record(s). If you do not want this case type to be used going forward, consider disabling it instead.", [1 => $total]));
+      }
     }
-    $result = $caseType->delete();
-    CRM_Case_XMLRepository::singleton(TRUE);
-    return $result;
+  }
+
+  /**
+   * Callback for hook_civicrm_post().
+   * @param \Civi\Core\Event\PostEvent $event
+   */
+  public static function self_hook_civicrm_post(\Civi\Core\Event\PostEvent $event) {
+    // When a caseType is saved or deleted, flush xml and optionGroup cache
+    CRM_Case_XMLRepository::singleton()->flush();
+    CRM_Core_OptionGroup::flushAll();
   }
 
   /**

--- a/CRM/Core/BAO/LocationType.php
+++ b/CRM/Core/BAO/LocationType.php
@@ -14,7 +14,7 @@
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
-class CRM_Core_BAO_LocationType extends CRM_Core_DAO_LocationType {
+class CRM_Core_BAO_LocationType extends CRM_Core_DAO_LocationType implements \Civi\Test\HookInterface {
 
   /**
    * Static holder for the default LT.
@@ -126,28 +126,27 @@ class CRM_Core_BAO_LocationType extends CRM_Core_DAO_LocationType {
    * Delete location Types.
    *
    * @param int $locationTypeId
-   *   ID of the location type to be deleted.
-   *
+   * @deprecated
    */
   public static function del($locationTypeId) {
-    $entity = ['address', 'phone', 'email', 'im'];
-    //check dependencies
-    foreach ($entity as $key) {
-      if ($key == 'im') {
-        $name = strtoupper($key);
-      }
-      else {
-        $name = ucfirst($key);
-      }
-      $baoString = 'CRM_Core_BAO_' . $name;
-      $object = new $baoString();
-      $object->location_type_id = $locationTypeId;
-      $object->delete();
-    }
+    static::deleteRecord(['id' => $locationTypeId]);
+  }
 
-    $locationType = new CRM_Core_DAO_LocationType();
-    $locationType->id = $locationTypeId;
-    $locationType->delete();
+  /**
+   * Callback for hook_civicrm_pre().
+   * @param \Civi\Core\Event\PreEvent $event
+   * @throws CRM_Core_Exception
+   */
+  public static function self_hook_civicrm_pre(\Civi\Core\Event\PreEvent $event) {
+    // When deleting a location type, delete related records
+    if ($event->action === 'delete') {
+      foreach (['Address', 'IM', 'Email', 'Phone'] as $entity) {
+        civicrm_api4($entity, 'delete', [
+          'checkPermissions' => FALSE,
+          'where' => [['location_type_id', '=', $event->id]],
+        ]);
+      }
+    }
   }
 
 }

--- a/CRM/Core/BAO/Mapping.php
+++ b/CRM/Core/BAO/Mapping.php
@@ -14,7 +14,7 @@
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
-class CRM_Core_BAO_Mapping extends CRM_Core_DAO_Mapping {
+class CRM_Core_BAO_Mapping extends CRM_Core_DAO_Mapping implements \Civi\Test\HookInterface {
 
   /**
    * Class constructor.
@@ -1209,6 +1209,20 @@ class CRM_Core_BAO_Mapping extends CRM_Core_DAO_Mapping {
     $mappingField = new CRM_Core_DAO_MappingField();
     $mappingField->name = $fieldName;
     $mappingField->delete();
+  }
+
+  /**
+   * Callback for hook_civicrm_pre().
+   * @param \Civi\Core\Event\PreEvent $event
+   * @throws CRM_Core_Exception
+   */
+  public static function on_hook_civicrm_pre(\Civi\Core\Event\PreEvent $event) {
+    if ($event->action === 'delete' && $event->entity === 'RelationshipType') {
+      // CRM-3323 - Delete mappingField records when deleting relationship type
+      \Civi\Api4\MappingField::delete(FALSE)
+        ->addWhere('relationship_type_id', '=', $event->id)
+        ->execute();
+    }
   }
 
 }

--- a/CRM/Core/BAO/WordReplacement.php
+++ b/CRM/Core/BAO/WordReplacement.php
@@ -18,7 +18,7 @@
 /**
  * Class CRM_Core_BAO_WordReplacement.
  */
-class CRM_Core_BAO_WordReplacement extends CRM_Core_DAO_WordReplacement {
+class CRM_Core_BAO_WordReplacement extends CRM_Core_DAO_WordReplacement implements \Civi\Test\HookInterface {
 
   /**
    * Class constructor.
@@ -105,21 +105,37 @@ class CRM_Core_BAO_WordReplacement extends CRM_Core_DAO_WordReplacement {
   }
 
   /**
-   * Delete website.
+   * Deprecated delete function
    *
+   * @deprecated
    * @param int $id
-   *   WordReplacement id.
-   *
-   * @return object
+   * @return CRM_Core_DAO_WordReplacement
    */
   public static function del($id) {
-    $dao = new CRM_Core_DAO_WordReplacement();
-    $dao->id = $id;
-    $dao->delete();
-    if (!isset($params['options']) || CRM_Utils_Array::value('wp-rebuild', $params['options'], TRUE)) {
+    return static::deleteRecord(['id' => $id]);
+  }
+
+  /**
+   * Callback for hook_civicrm_post().
+   * @param \Civi\Core\Event\PostEvent $event
+   */
+  public static function self_hook_civicrm_post(\Civi\Core\Event\PostEvent $event) {
+    if ($event->action === 'delete') {
       self::rebuild();
     }
-    return $dao;
+  }
+
+  /**
+   * Efficient function to write multiple records then rebuild at the end
+   *
+   * @param array[] $records
+   * @return CRM_Core_DAO_WordReplacement[]
+   * @throws CRM_Core_Exception
+   */
+  public static function writeRecords(array $records): array {
+    $records = parent::writeRecords($records);
+    self::rebuild();
+    return $records;
   }
 
   /**

--- a/CRM/Member/BAO/MembershipType.php
+++ b/CRM/Member/BAO/MembershipType.php
@@ -146,63 +146,18 @@ class CRM_Member_BAO_MembershipType extends CRM_Member_DAO_MembershipType implem
    *
    * @param int $membershipTypeId
    *
+   * @deprecated
    * @throws CRM_Core_Exception
-   * @return bool|mixed
+   * @return bool
    */
   public static function del($membershipTypeId) {
-    // Check dependencies.
-    $check = FALSE;
-    $status = [];
-    $dependency = [
-      'Membership' => 'membership_type_id',
-      'MembershipBlock' => 'membership_type_default',
-    ];
-
-    foreach ($dependency as $name => $field) {
-      $baoString = 'CRM_Member_BAO_' . $name;
-      $dao = new $baoString();
-      $dao->$field = $membershipTypeId;
-      /** @noinspection PhpUndefinedMethodInspection */
-      if ($dao->find(TRUE)) {
-        $check = TRUE;
-        $status[] = $name;
-      }
+    try {
+      static::deleteRecord(['id' => $membershipTypeId]);
+      return TRUE;
     }
-    if ($check) {
-      $cnt = 1;
-      $message = ts('This membership type cannot be deleted due to following reason(s):');
-      if (in_array('Membership', $status)) {
-        $findMembersURL = CRM_Utils_System::url('civicrm/member/search', 'reset=1');
-        $deleteURL = CRM_Utils_System::url('civicrm/contact/search/advanced', 'reset=1');
-        $message .= '<br/>' . ts('%3. There are some contacts who have this membership type assigned to them. Search for contacts with this membership type from <a href=\'%1\'>Find Members</a>. If you are still getting this message after deleting these memberships, there may be contacts in the Trash (deleted) with this membership type. Try using <a href="%2">Advanced Search</a> and checking "Search in Trash".', [
-          1 => $findMembersURL,
-          2 => $deleteURL,
-          3 => $cnt,
-        ]);
-        $cnt++;
-      }
-
-      if (in_array('MembershipBlock', $status)) {
-        $deleteURL = CRM_Utils_System::url('civicrm/admin/contribute', 'reset=1');
-        $message .= ts('%2. This Membership Type is used in an <a href=\'%1\'>Online Contribution page</a>. Uncheck this membership type in the Memberships tab.', [
-          1 => $deleteURL,
-          2 => $cnt,
-        ]);
-        throw new CRM_Core_Exception($message);
-      }
+    catch (CRM_Core_Exception $e) {
+      return FALSE;
     }
-    CRM_Utils_Weight::delWeight('CRM_Member_DAO_MembershipType', $membershipTypeId);
-    //delete from membership Type table
-    $membershipType = new CRM_Member_DAO_MembershipType();
-    $membershipType->id = $membershipTypeId;
-
-    //fix for membership type delete api
-    $result = FALSE;
-    if ($membershipType->find(TRUE)) {
-      return $membershipType->delete();
-    }
-
-    return $result;
   }
 
   /**
@@ -226,6 +181,49 @@ class CRM_Member_BAO_MembershipType extends CRM_Member_DAO_MembershipType implem
           civicrm_api3('MembershipType', 'create', $membershipType);
         }
       }
+    }
+    if ($event->action === 'delete' && $event->entity === 'MembershipType') {
+      // Check dependencies.
+      $check = FALSE;
+      $status = [];
+      $dependency = [
+        'Membership' => 'membership_type_id',
+        'MembershipBlock' => 'membership_type_default',
+      ];
+
+      foreach ($dependency as $name => $field) {
+        $baoString = 'CRM_Member_BAO_' . $name;
+        $dao = new $baoString();
+        $dao->$field = $event->id;
+        if ($dao->find(TRUE)) {
+          $check = TRUE;
+          $status[] = $name;
+        }
+      }
+      if ($check) {
+        $cnt = 1;
+        $message = ts('This membership type cannot be deleted due to following reason(s):');
+        if (in_array('Membership', $status)) {
+          $findMembersURL = CRM_Utils_System::url('civicrm/member/search', 'reset=1');
+          $deleteURL = CRM_Utils_System::url('civicrm/contact/search/advanced', 'reset=1');
+          $message .= '<br/>' . ts('%3. There are some contacts who have this membership type assigned to them. Search for contacts with this membership type from <a href=\'%1\'>Find Members</a>. If you are still getting this message after deleting these memberships, there may be contacts in the Trash (deleted) with this membership type. Try using <a href="%2">Advanced Search</a> and checking "Search in Trash".', [
+            1 => $findMembersURL,
+            2 => $deleteURL,
+            3 => $cnt,
+          ]);
+          $cnt++;
+        }
+
+        if (in_array('MembershipBlock', $status)) {
+          $deleteURL = CRM_Utils_System::url('civicrm/admin/contribute', 'reset=1');
+          $message .= ts('%2. This Membership Type is used in an <a href=\'%1\'>Online Contribution page</a>. Uncheck this membership type in the Memberships tab.', [
+            1 => $deleteURL,
+            2 => $cnt,
+          ]);
+          throw new CRM_Core_Exception($message);
+        }
+      }
+      CRM_Utils_Weight::delWeight('CRM_Member_DAO_MembershipType', $event->id);
     }
   }
 

--- a/Civi/Api4/Generic/Traits/DAOActionTrait.php
+++ b/Civi/Api4/Generic/Traits/DAOActionTrait.php
@@ -116,6 +116,7 @@ trait DAOActionTrait {
       'EntityTag' => 'add',
       'GroupContact' => 'add',
       'Navigation' => 'writeRecords',
+      'WordReplacement' => 'writeRecords',
     ];
     $method = $functionNames[$this->getEntityName()] ?? NULL;
     if (!isset($method)) {

--- a/Civi/Api4/Service/Spec/Provider/FieldDomainIdSpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/FieldDomainIdSpecProvider.php
@@ -21,7 +21,8 @@ class FieldDomainIdSpecProvider implements Generic\SpecProviderInterface {
    */
   public function modifySpec(RequestSpec $spec) {
     $domainIdField = $spec->getFieldByName('domain_id');
-    if ($domainIdField && $domainIdField->isRequired()) {
+    // TODO: The WordReplacement entity should have domain_id required so this OR condition can be removed
+    if ($domainIdField && ($domainIdField->isRequired() || $domainIdField->getEntity() === 'WordReplacement')) {
       $domainIdField->setRequired(FALSE)->setDefaultValue('current_domain');;
     }
   }

--- a/tests/phpunit/api/v4/Action/BaseCustomValueTest.php
+++ b/tests/phpunit/api/v4/Action/BaseCustomValueTest.php
@@ -33,7 +33,6 @@ abstract class BaseCustomValueTest extends UnitTestCase {
   public function tearDown(): void {
     $optgroups = CustomField::get(FALSE)->addSelect('option_group_id')->addWhere('option_group_id', 'IS NOT NULL')->execute();
     foreach ($optgroups as $optgroup) {
-      \Civi\Api4\OptionValue::delete(FALSE)->addWhere('option_group_id', '=', $optgroup['option_group_id'])->execute();
       \Civi\Api4\OptionGroup::delete(FALSE)->addWhere('id', '=', $optgroup['option_group_id'])->execute();
     }
     CustomField::delete(FALSE)->addWhere('id', '>', 0)->execute();

--- a/tests/phpunit/api/v4/Entity/WordReplacementTest.php
+++ b/tests/phpunit/api/v4/Entity/WordReplacementTest.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+
+namespace api\v4\Entity;
+
+use api\v4\UnitTestCase;
+
+/**
+ * @group headless
+ */
+class WordReplacementTest extends UnitTestCase {
+
+  public function testDefaults() {
+    $create = \Civi\Api4\WordReplacement::create(FALSE)
+      ->addValue('find_word', 'Foo')
+      ->addValue('replace_word', 'Bar')
+      ->execute()
+      ->first();
+
+    $result = \Civi\Api4\WordReplacement::get(FALSE)
+      ->addWhere('id', '=', $create['id'])
+      ->execute()->first();
+    $this->assertTrue($result['is_active']);
+    $this->assertEquals('wildcardMatch', $result['match_type']);
+    $this->assertEquals(\CRM_Core_Config::domainID(), $result['domain_id']);
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Refactors various BAO code to use new `deleteRecord` function and deprecate ad-hoc `del()` functions. Gets the test in #22205 to pass.

Note: This fixes some intra-alpha regressions with ManagedEntities. Following #21989 and #22068, it becomes mandatory to support the `hook_post` for APIv4-based cleanup of managed-entities. (*This is true regardless of whether downstream's specific record is inserted via APIv4. It only matters if the entity declares support for APIv4 management.*)

Before
----------------------------------------
Less standardization of delete functions and the hooks they call.

After
----------------------------------------
More standardization.

Technical Details
---------------
Annotating a `BAO::del()` function as `@deprecated` tells APIv4 not to use it. It will call `deleteRecord` instead. 

Entities failing the test in #22205:

- [x] `CaseType`
-  ~~`Contact`~~ (false-positive, test needs fixing)
- [x] `ContactType`
- [x] `FinancialAccount`
- [x] `FinancialType`
- [x] `LocationType`
- [x] `MembershipStatus`
- [x] `MembershipType`
- [x] `MessageTemplate`
- [x] `OptionGroup`
- [x] `PaymentProcessor`
- [x] `PaymentProcessorType`
- [x] `RelationshipType`
- [x] `WordReplacement`