### PR TITLE
fixes core#2980, Automated Messages should respect is_default/is_active

### DIFF
--- a/CRM/Mailing/BAO/MailingComponent.php
+++ b/CRM/Mailing/BAO/MailingComponent.php
@@ -26,7 +26,8 @@ class CRM_Mailing_BAO_MailingComponent extends CRM_Mailing_DAO_MailingComponent 
    *
    * @return CRM_Core_BAO_LocationType.
    */
-  public static function retrieve(&$params, &$defaults) {
+  public static function retrieve(array &$params, array &$defaults) {
+    $params = array_merge(['is_active' => 1, 'is_default' => 1], $params);
     $component = new CRM_Mailing_DAO_MailingComponent();
     $component->copyValues($params);
     if ($component->find(TRUE)) {

--- a/CRM/Mailing/Event/BAO/Reply.php
+++ b/CRM/Mailing/Event/BAO/Reply.php
@@ -223,9 +223,12 @@ class CRM_Mailing_Event_BAO_Reply extends CRM_Mailing_Event_DAO_Reply {
 
     $to = empty($replyto) ? $eq->email : $replyto;
 
-    $component = new CRM_Mailing_BAO_MailingComponent();
-    $component->id = $mailing->reply_id;
-    $component->find(TRUE);
+    $params['id'] = $mailing->reply_id;
+    $defaults = [];
+    $component = CRM_Mailing_BAO_MailingComponent::retrieve($params, $defaults);
+    if (!$component) {
+      return;
+    }
 
     $domain = CRM_Core_BAO_Domain::getDomain();
     list($domainEmailName, $domainEmailAddress) = CRM_Core_BAO_Domain::getNameAndEmail();

--- a/CRM/Mailing/Event/BAO/Subscribe.php
+++ b/CRM/Mailing/Event/BAO/Subscribe.php
@@ -198,12 +198,12 @@ SELECT     civicrm_email.id as email_id
     $group->id = $this->group_id;
     $group->find(TRUE);
 
-    $component = new CRM_Mailing_BAO_MailingComponent();
-    $component->is_default = 1;
-    $component->is_active = 1;
-    $component->component_type = 'Subscribe';
-
-    $component->find(TRUE);
+    $params['component_type'] = 'Subscribe';
+    $defaults = [];
+    $component = CRM_Mailing_BAO_MailingComponent::retrieve($params, $defaults);
+    if (!$component) {
+      return;
+    }
 
     $params = [
       'subject' => $component->subject,

--- a/CRM/Mailing/Event/BAO/Unsubscribe.php
+++ b/CRM/Mailing/Event/BAO/Unsubscribe.php
@@ -310,7 +310,6 @@ WHERE  email = %2
    *   The job ID.
    */
   public static function send_unsub_response($queue_id, $groups, $is_domain, $job) {
-    $config = CRM_Core_Config::singleton();
     $domain = CRM_Core_BAO_Domain::getDomain();
     $jobObject = new CRM_Mailing_BAO_MailingJob();
     $jobTable = $jobObject->getTableName();
@@ -333,15 +332,12 @@ WHERE  email = %2
                         WHERE $jobTable.id = $job");
     $dao->fetch();
 
-    $component = new CRM_Mailing_BAO_MailingComponent();
-
-    if ($is_domain) {
-      $component->id = $dao->optout_id;
+    $params['id'] = $is_domain ? $dao->optout_id : $dao->unsubscribe_id;
+    $defaults = [];
+    $component = CRM_Mailing_BAO_MailingComponent::retrieve($params, $defaults);
+    if (!$component) {
+      return;
     }
-    else {
-      $component->id = $dao->unsubscribe_id;
-    }
-    $component->find(TRUE);
 
     $html = $component->body_html;
     if ($component->body_text) {


### PR DESCRIPTION
https://lab.civicrm.org/dev/core/-/issues/2980

Overview
----------------------------------------
Many automated messages (unsubscribe, resubscribe) don't respect the is_default and is_active flags.

Before
----------------------------------------
Unsubscribe/resubscribe/etc. messages go out regardless of whether they're enabled.

After
----------------------------------------
Automated messages respect the flags.

Technical Details
----------------------------------------
The code here was very copy-pasteish, so I refactored into a common (existing and possibly unused) function, which respects the flags (unless overridden).

I also found that `resub_to_mailing()` and `unsub_from_mailing()` could return `NULL`, right into a `count()` function, so I fixed that.

Finally, I disabled sending unsubscribe/resubscribe messages when the person is already unsubscribed/subscribed.

I recommend disabling whitespace changes when reviewing, this is much smaller than it looks.