### PR TITLE
[NFC] Fix test failures for testRelativeDateRanges

### DIFF
--- a/tests/phpunit/api/v4/Action/DateTest.php
+++ b/tests/phpunit/api/v4/Action/DateTest.php
@@ -71,7 +71,7 @@ class DateTest extends UnitTestCase {
 
     // Avoid problems with `strtotime(<date arithmetic expression>)` giving
     // impossible dates like April 31 which roll over and then don't match.
-    $thisMonth = date('m');
+    $thisMonth = (int) date('m');
     $lastMonth = ($thisMonth === 1 ? 12 : $thisMonth - 1);
     $nextMonth = ($thisMonth === 12 ? 1 : $thisMonth + 1);
     $lastMonthsYear = ($thisMonth === 1 ? date('Y') - 1 : date('Y'));


### PR DESCRIPTION
Overview
----------------------------------------
Output from date() is a string so strict equality test fails and it calculates the wrong year for "next year" in december.