### PR TITLE
PHP 8 compat - no optional param before required

### DIFF
--- a/CRM/Mailing/Event/BAO/Resubscribe.php
+++ b/CRM/Mailing/Event/BAO/Resubscribe.php
@@ -172,12 +172,10 @@ class CRM_Mailing_Event_BAO_Resubscribe {
    *   The queue event ID.
    * @param array $groups
    *   List of group IDs.
-   * @param bool $is_domain
-   *   Is this domain-level?.
    * @param int $job
    *   The job ID.
    */
-  public static function send_resub_response($queue_id, $groups, $is_domain = FALSE, $job) {
+  public static function send_resub_response($queue_id, $groups, $job) {
     // param is_domain is not supported as of now.
 
     $config = CRM_Core_Config::singleton();

--- a/CRM/Mailing/Page/Common.php
+++ b/CRM/Mailing/Page/Common.php
@@ -79,7 +79,7 @@ class CRM_Mailing_Page_Common extends CRM_Core_Page {
       elseif ($this->_type == 'resubscribe') {
         $groups = CRM_Mailing_Event_BAO_Resubscribe::resub_to_mailing($job_id, $queue_id, $hash);
         if (count($groups)) {
-          CRM_Mailing_Event_BAO_Resubscribe::send_resub_response($queue_id, $groups, FALSE, $job_id);
+          CRM_Mailing_Event_BAO_Resubscribe::send_resub_response($queue_id, $groups, $job_id);
         }
         else {
           // should we indicate an error, or just ignore?

--- a/api/v3/MailingEventResubscribe.php
+++ b/api/v3/MailingEventResubscribe.php
@@ -35,7 +35,7 @@ function civicrm_api3_mailing_event_resubscribe_create($params) {
   if (count($groups)) {
     CRM_Mailing_Event_BAO_Resubscribe::send_resub_response(
       $params['event_queue_id'],
-      $groups, FALSE,
+      $groups,
       $params['job_id']
     );
     return civicrm_api3_create_success($params);


### PR DESCRIPTION
Overview
----------------------------------------
PHP 8 doesn't allow optional params before required params.  This param is unused so I removed it

Technical Details
----------------------------------------
Jenkins won't allow any commits that modify this file until this is fixed.

Comments
----------------------------------------
I considered simply making it required given that it's only called with `FALSE` but since it's unused and unlikely to get used any time soon (I don't even understand its intent), I'm just removing it.
