### PR TITLE
OptionGroup - Use standard delete function which calls hooks

### DIFF
--- a/tests/phpunit/api/v4/Action/BaseCustomValueTest.php
+++ b/tests/phpunit/api/v4/Action/BaseCustomValueTest.php
@@ -33,7 +33,6 @@ abstract class BaseCustomValueTest extends UnitTestCase {
   public function tearDown(): void {
     $optgroups = CustomField::get(FALSE)->addSelect('option_group_id')->addWhere('option_group_id', 'IS NOT NULL')->execute();
     foreach ($optgroups as $optgroup) {
-      \Civi\Api4\OptionValue::delete(FALSE)->addWhere('option_group_id', '=', $optgroup['option_group_id'])->execute();
       \Civi\Api4\OptionGroup::delete(FALSE)->addWhere('id', '=', $optgroup['option_group_id'])->execute();
     }
     CustomField::delete(FALSE)->addWhere('id', '>', 0)->execute();


### PR DESCRIPTION
Overview
----------------------------------------
This is a single commit cherry-picked from #22207 to answer the questions "is the whole PR making tests fail or are tests failing for some other reason"