### PR TITLE
(dev/core#2979) remove the limit of 15 max values for multiple values…

### DIFF
--- a/CRM/Report/Utils/Get.php
+++ b/CRM/Report/Utils/Get.php
@@ -170,10 +170,12 @@ class CRM_Report_Utils_Get {
         // send the type as string so that multiple values can also be retrieved from url.
         // for e.g url like - "memtype_in=in&memtype_value=1,2,3"
         $value = self::getTypedValue("{$fieldName}_value", CRM_Utils_Type::T_STRING);
-        if (!preg_match('/^(\d+)(,\d+){0,14}$/', $value)) {
-          // extra check. Also put a limit of 15 max values.
+
+        //change the max value to 20, ideally remove condition
+        if (!preg_match('/^(\d+)(,\d+){0,20}$/', $value)) {
           $value = NULL;
         }
+
         if ($value !== NULL) {
           $defaults["{$fieldName}_value"] = explode(",", $value);
           $defaults["{$fieldName}_op"] = $fieldOP;


### PR DESCRIPTION
… can also be retrieved from url in reports

Overview
----------------------------------------
We send the parameters as string so that multiple values can also be retrieved from url in reports
for e.g url like - "memtype_in=in&memtype_value=1,2,3

However, there is a restriction for 15 values esp when you search for activity types which can be numerous. In this this case, if the values exceeds 15 the criteria are not respected.

Proposal to remove the limit of 15 max values.
https://github.com/civicrm/civicrm-core/blob/master/CRM/Report/Utils/Get.php#L173

Before
----------------------------------------
params not respected if values exceed 15

After
----------------------------------------
values till 20 are respected.

Comments
----------------------------------------
Let me know if the max value is agreeable. It's especially for activity types as we already have a number of activity types that CiviCRM ships with.