### PR TITLE
dev/core#2982 - Remove literal `<br/>` tag in header for Repeat Contributions CiviReport

### DIFF
--- a/CRM/Report/Form/Contribute/Repeat.php
+++ b/CRM/Report/Form/Contribute/Repeat.php
@@ -882,8 +882,8 @@ GROUP BY    currency
     $from2 = CRM_Utils_Date::customFormat($from2, NULL, array('d'));
     $to2 = CRM_Utils_Date::customFormat($to2, NULL, array('d'));
 
-    $this->_columnHeaders['contribution1_total_amount_sum']['title'] = "$from1 -<br/> $to1";
-    $this->_columnHeaders['contribution2_total_amount_sum']['title'] = "$from2 -<br/> $to2";
+    $this->_columnHeaders['contribution1_total_amount_sum']['title'] = "$from1 - $to1";
+    $this->_columnHeaders['contribution2_total_amount_sum']['title'] = "$from2 - $to2";
     unset($this->_columnHeaders['contribution1_total_amount_count'],
       $this->_columnHeaders['contribution2_total_amount_count']
     );


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/2982

There's a literal `<br/>` appearing in the header because it gets escaped. I don't think this is the best way to do styling anyway so I'm just proposing to remove it.

Before
----------------------------------------
<img width="427" alt="Untitled" src="https://user-images.githubusercontent.com/2967821/144862550-9daf92be-ee97-4aca-a507-b7a1b18fe323.png">



After
----------------------------------------
<img width="408" alt="Untitled2" src="https://user-images.githubusercontent.com/2967821/144862087-e39c3392-e9b8-4182-82cd-d898f4e28e8e.png">


Technical Details
----------------------------------------


Comments
----------------------------------------
There's also a slew of warnings on this page. Just picking off the easy part here.
