### PR TITLE
SearchKit - Fix undefined variable for searches of Afforms etc.

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
@@ -424,7 +424,7 @@
       // Is a column eligible to use an aggregate function?
       this.canAggregate = function(col) {
         // If the query does not use grouping, never
-        if (!ctrl.savedSearch.api_params.groupBy.length) {
+        if (!ctrl.savedSearch.api_params.groupBy || !ctrl.savedSearch.api_params.groupBy.length) {
           return false;
         }
         var arg = _.findWhere(searchMeta.parseExpr(col).args, {type: 'field'}) || {};


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a console error when using SearchKit with Afforms and other non-DAO entities.

Before
----------------------------------------
1. Create a new Search for Afforms
2. Add a column
3. Notice error in console

After
----------------------------------------
No error