### PR TITLE
[REF] Add in getVersion override for Drupal 8/9 to support cv testing…

### DIFF
--- a/CRM/Utils/System/Drupal8.php
+++ b/CRM/Utils/System/Drupal8.php
@@ -883,4 +883,11 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
     }
   }
 
+  public function getVersion() {
+    if (class_exists('\Drupal')) {
+      return \Drupal::VERSION;
+    }
+    return 'Unknown';
+  }
+
 }


### PR DESCRIPTION
… and also cv vars:show picking up the right CMS version

Overview
----------------------------------------
This adds in an override for the getVersion function from DrupalBase for d8/d9 specific determination of the current Drupal Version

Before
----------------------------------------
doing `CRM_Core_Config::singleton()->userSystem->getVersion()` outputted unkown for d8/d9

After
----------------------------------------
`CRM_Core_Config::singleton()->userSystem->getVersion()` works for d8/d9 as well as for D7

ping @totten @homotechsual @demeritcowboy 