### PR TITLE
[NFC] Update System Uft8mb4 check to handle for the fact that MySQL8 …

### DIFF
--- a/tests/phpunit/api/v3/SystemTest.php
+++ b/tests/phpunit/api/v3/SystemTest.php
@@ -96,7 +96,9 @@ class api_v3_SystemTest extends CiviUnitTestCase {
       $this->callAPISuccess('System', 'utf8conversion', ['is_revert' => 1]);
       $table = CRM_Core_DAO::executeQuery('SHOW CREATE TABLE civicrm_contact');
       $table->fetch();
-      $this->assertStringEndsWith('DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci ROW_FORMAT=DYNAMIC', $table->Create_Table);
+      $version = CRM_Utils_SQL::getDatabaseVersion();
+      $charset = (version_compare($version, '8', '>=') && stripos($version, 'mariadb') === FALSE) ? 'utf8mb3' : 'utf8';
+      $this->assertStringEndsWith('DEFAULT CHARSET=' . $charset . ' COLLATE=utf8_unicode_ci ROW_FORMAT=DYNAMIC', $table->Create_Table);
     }
     else {
       $this->markTestSkipped('MySQL Version does not support ut8mb4 testing');


### PR DESCRIPTION
…outputs utf8mb3 when the charset has been set to utf8 as utf8mb3 is the underlyling charset for utf8

Overview
----------------------------------------
This fixes the following test failure `api_v3_SystemTest::testSystemUTFMB8Conversion
Failed asserting that 'CREATE TABLE `civicrm_contact` (\n....) ENGINE=InnoDB AUTO_INCREMENT=3 DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci ROW_FORMAT=DYNAMIC' ends with "DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci ROW_FORMAT=DYNAMIC".` 

Before
----------------------------------------
api_v3_SystemTest::testSystemUTFMB8Conversion fails on MySQL8

After
----------------------------------------
api_v3_SystemTest::testSystemUTFMB8Conversion passed on MySQL8

Technical Details
----------------------------------------
As per https://dev.mysql.com/doc/refman/8.0/en/charset-unicode-utf8mb3.html mysql 8 onwards is now outputting utf8mb3 when it used to output utf8 as the default charsets for tables

Comments
----------------------------------------
ping @eileenmcnaughton @totten @demeritcowboy 
