### PR TITLE
dev/core#2984 - Clarify API error when component is disabled

### DIFF
--- a/tests/phpunit/api/v4/Entity/EntityTest.php
+++ b/tests/phpunit/api/v4/Entity/EntityTest.php
@@ -19,6 +19,7 @@
 
 namespace api\v4\Entity;
 
+use Civi\API\Exception\NotImplementedException;
 use Civi\Api4\Entity;
 use api\v4\UnitTestCase;
 
@@ -55,6 +56,15 @@ class EntityTest extends UnitTestCase {
       ->indexBy('name');
     $this->assertArrayNotHasKey('Participant', $result,
       "Entity::get should not have Participant when CiviEvent disabled");
+
+    // Trying to use a CiviEvent API will fail when component is disabled
+    try {
+      \Civi\Api4\Participant::get(FALSE)->execute();
+      $this->fail();
+    }
+    catch (NotImplementedException $e) {
+      $this->assertStringContainsString('CiviEvent', $e->getMessage());
+    }
 
     \CRM_Core_BAO_ConfigSetting::enableComponent('CiviEvent');
     $result = Entity::get(FALSE)


### PR DESCRIPTION
Overview
----------------------------------------
Clarifies API failures due to disabled components. Fixes https://lab.civicrm.org/dev/core/-/issues/2984

Before
----------------------------------------
Using an API from a disabled component would fail in unexpected ways with cryptic error messages.

After
----------------------------------------
Using an API from a disabled component will throw a `NotImplementedException` with a message like "Case API is not available because CiviCase component is disabled"
