### PR TITLE
Afform - Set date-range defaults

### DIFF
--- a/Civi/Api4/Service/Spec/SpecFormatter.php
+++ b/Civi/Api4/Service/Spec/SpecFormatter.php
@@ -275,8 +275,8 @@ class SpecFormatter {
     if ($inputType == 'Date' && !empty($data['custom_group_id'])) {
       $inputAttrs['time'] = empty($data['time_format']) ? FALSE : ($data['time_format'] == 1 ? 12 : 24);
       $inputAttrs['date'] = $data['date_format'];
-      $inputAttrs['start_date_years'] = (int) $data['start_date_years'];
-      $inputAttrs['end_date_years'] = (int) $data['end_date_years'];
+      $inputAttrs['start_date_years'] = isset($data['start_date_years']) ? (int) $data['start_date_years'] : NULL;
+      $inputAttrs['end_date_years'] = isset($data['end_date_years']) ? (int) $data['end_date_years'] : NULL;
     }
     if ($inputType == 'Text' && !empty($data['maxlength'])) {
       $inputAttrs['maxlength'] = (int) $data['maxlength'];

--- a/js/crm.datepicker.js
+++ b/js/crm.datepicker.js
@@ -56,10 +56,10 @@
         CRM.utils.copyAttributes($dataField, $dateField, ['style', 'class', 'disabled', 'aria-label']);
         placeholder = settings.placeholder || $dataField.attr('placeholder');
         $dateField.addClass('crm-form-' + type);
-        if (!settings.minDate && !_.isUndefined(settings.start_date_years)) {
+        if (!settings.minDate && isInt(settings.start_date_years)) {
           settings.minDate = '' + (new Date().getFullYear() - settings.start_date_years) + '-01-01';
         }
-        if (!settings.maxDate && !_.isUndefined(settings.end_date_years)) {
+        if (!settings.maxDate && isInt(settings.end_date_years)) {
           settings.maxDate = '' + (new Date().getFullYear() + settings.end_date_years) + '-12-31';
         }
         if (hasDatepicker) {
@@ -105,10 +105,7 @@
        */
       function dateHasDay() {
         var lowerFormat = settings.dateFormat.toLowerCase();
-        if (lowerFormat.indexOf('d') < 0) {
-          return false;
-        }
-        return true;
+        return lowerFormat.indexOf('d') >= 0;
       }
       function updateInputFields(e, context) {
         var val = $dataField.val(),
@@ -159,4 +156,13 @@
       updateInputFields();
     });
   };
+
+  function isInt(value) {
+    if (isNaN(value)) {
+      return false;
+    }
+    var x = parseFloat(value);
+    return (x | 0) === x;
+  }
+
 })(jQuery, CRM, CRM._);


### PR DESCRIPTION
Overview
----------------------------------------
Ensures datepickers can select more than the current year (start and end date years were defaulting to 0)
[Fixes dev/report#84](https://lab.civicrm.org/dev/report/-/issues/84)

Before
----------------------------------------
DatePicker defaults to only the current year

After
----------------------------------------
Datepicker defaults to +-10 years
