### PR TITLE
Resources: set language-specific cacheCode, fixes AngularJS translation with multilingual

### DIFF
--- a/CRM/Core/Resources.php
+++ b/CRM/Core/Resources.php
@@ -336,7 +336,9 @@ class CRM_Core_Resources implements CRM_Core_Resources_CollectionAdderInterface 
    * @return string
    */
   public function getCacheCode() {
-    return $this->cacheCode;
+    // Ex: AngularJS json partials are language-specific because they ship with the strings
+    // for the current language.
+    return $this->cacheCode . CRM_Core_I18n::getLocale();
   }
 
   /**
@@ -563,7 +565,7 @@ class CRM_Core_Resources implements CRM_Core_Resources_CollectionAdderInterface 
     $hasQuery = strpos($url, '?') !== FALSE;
     $operator = $hasQuery ? '&' : '?';
 
-    return $url . $operator . 'r=' . $this->cacheCode;
+    return $url . $operator . 'r=' . $this->getCacheCode();
   }
 
   /**

--- a/tests/phpunit/CRM/Core/ResourcesTest.php
+++ b/tests/phpunit/CRM/Core/ResourcesTest.php
@@ -136,8 +136,8 @@ class CRM_Core_ResourcesTest extends CiviUnitTestCase {
     $actual = $smarty->fetch('string:{crmRegion name=testAddScriptFile}{/crmRegion}');
     // stable ordering: alphabetical by (snippet.weight,snippet.name)
     $expected = ""
-      . "<script type=\"text/javascript\" src=\"http://core-app/foo%20bar.js?r=resTest\">\n</script>\n"
-      . "<script type=\"text/javascript\" src=\"http://ext-dir/com.example.ext/foo%20bar.js?r=resTest\">\n</script>\n";
+      . "<script type=\"text/javascript\" src=\"http://core-app/foo%20bar.js?r=resTesten_US\">\n</script>\n"
+      . "<script type=\"text/javascript\" src=\"http://ext-dir/com.example.ext/foo%20bar.js?r=resTesten_US\">\n</script>\n";
     $this->assertEquals($expected, $actual);
   }
 
@@ -288,7 +288,7 @@ class CRM_Core_ResourcesTest extends CiviUnitTestCase {
     $actual = $smarty->fetch('string:{crmRegion name=testCrmJS}{/crmRegion}');
     // stable ordering: alphabetical by (snippet.weight,snippet.name)
     $expected = ""
-      . "<script type=\"text/javascript\" src=\"http://ext-dir/com.example.ext/foo%20bar.js?r=resTest\">\n</script>\n"
+      . "<script type=\"text/javascript\" src=\"http://ext-dir/com.example.ext/foo%20bar.js?r=resTesten_US\">\n</script>\n"
       . "<script type=\"text/javascript\" src=\"/whiz/foo%20bar.js\">\n</script>\n";
     $this->assertEquals($expected, $actual);
   }
@@ -304,8 +304,8 @@ class CRM_Core_ResourcesTest extends CiviUnitTestCase {
     $actual = $smarty->fetch('string:{crmRegion name=testAddStyleFile}{/crmRegion}');
     // stable ordering: alphabetical by (snippet.weight,snippet.name)
     $expected = ""
-      . "<link href=\"http://core-app/foo%20bar.css?r=resTest\" rel=\"stylesheet\" type=\"text/css\"/>\n"
-      . "<link href=\"http://ext-dir/com.example.ext/foo%20bar.css?r=resTest\" rel=\"stylesheet\" type=\"text/css\"/>\n";
+      . "<link href=\"http://core-app/foo%20bar.css?r=resTesten_US\" rel=\"stylesheet\" type=\"text/css\"/>\n"
+      . "<link href=\"http://ext-dir/com.example.ext/foo%20bar.css?r=resTesten_US\" rel=\"stylesheet\" type=\"text/css\"/>\n";
     $this->assertEquals($expected, $actual);
   }
 
@@ -350,7 +350,7 @@ class CRM_Core_ResourcesTest extends CiviUnitTestCase {
     $actual = $smarty->fetch('string:{crmRegion name=testCrmCSS}{/crmRegion}');
     // stable ordering: alphabetical by (snippet.weight,snippet.name)
     $expected = ""
-      . "<link href=\"http://ext-dir/com.example.ext/foo%20bar.css?r=resTest\" rel=\"stylesheet\" type=\"text/css\"/>\n"
+      . "<link href=\"http://ext-dir/com.example.ext/foo%20bar.css?r=resTesten_US\" rel=\"stylesheet\" type=\"text/css\"/>\n"
       . "<link href=\"/whiz/foo%20bar.css\" rel=\"stylesheet\" type=\"text/css\"/>\n";
     $this->assertEquals($expected, $actual);
   }
@@ -381,7 +381,7 @@ class CRM_Core_ResourcesTest extends CiviUnitTestCase {
     $this->assertEquals('http://ext-dir/com.example.ext/foo%20bar.png', $actual);
 
     $actual = $smarty->fetch('string:{crmResURL ext=com.example.ext file=foo%20bar.png addCacheCode=1}');
-    $this->assertEquals('http://ext-dir/com.example.ext/foo%20bar.png?r=resTest', $actual);
+    $this->assertEquals('http://ext-dir/com.example.ext/foo%20bar.png?r=resTesten_US', $actual);
 
     $actual = $smarty->fetch('string:{crmResURL ext=com.example.ext}');
     $this->assertEquals('http://ext-dir/com.example.ext/', $actual);
@@ -459,18 +459,21 @@ class CRM_Core_ResourcesTest extends CiviUnitTestCase {
    * @return array
    */
   public function urlForCacheCodeProvider() {
+    $cacheBusterString = Civi::resources()
+      ->setCacheCode($this->cacheBusterString)
+      ->getCacheCode();
     return [
       [
         'http://www.civicrm.org',
-        'http://www.civicrm.org?r=' . $this->cacheBusterString,
+        'http://www.civicrm.org?r=' . $cacheBusterString,
       ],
       [
         'www.civicrm.org/custom.css?foo=bar',
-        'www.civicrm.org/custom.css?foo=bar&r=' . $this->cacheBusterString,
+        'www.civicrm.org/custom.css?foo=bar&r=' . $cacheBusterString,
       ],
       [
         'civicrm.org/custom.css?car=blue&foo=bar',
-        'civicrm.org/custom.css?car=blue&foo=bar&r=' . $this->cacheBusterString,
+        'civicrm.org/custom.css?car=blue&foo=bar&r=' . $cacheBusterString,
       ],
     ];
   }


### PR DESCRIPTION
Overview
----------------------------------------

To reproduce:

* Enable another language (does not need to be multi-lingual, just multiple enabled locales)
* Under Admin>Debugging, enable asset caching.
* Go to an AngularJS page (with asset caching enabled) in English, such as the CiviCRM System Status, or the CiviCRM dashboard.
* Then switch languages, reload the AngularJS page

Result: the page will still be in English.

Example URL on dmaster, after adding French, and enabling asset-caching (dmaster does not enable it by default, because debugging is enabled):

* Go here: https://dmaster.demo.civicrm.org/civicrm/a/#/status
* Then change language: https://dmaster.demo.civicrm.org/civicrm/contact/view?reset=1&cid=203&lcMessages=fr_CA
* Then reload here: https://dmaster.demo.civicrm.org/civicrm/a/#/status

(because the core language switcher does not support AngularJS, fortunately the [language-switcher extension]() does.)

Before
----------------------------------------

Pages are randomly translated:

![image](https://user-images.githubusercontent.com/254741/145462682-7632c6ff-5406-4dc3-a7bc-5acde1f78da0.png)


After
----------------------------------------

Pages are always in the correct language.

Technical Details
----------------------------------------

My fix feels duct-tape-y. I don't know if it will cause other problems. Testing it in production for now. Opening the PR for discussion.