### PR TITLE
(REF) CRM/Upgrade - Remove unused entrypoint `verifyPreDBstate()`

### DIFF
--- a/CRM/Upgrade/Form.php
+++ b/CRM/Upgrade/Form.php
@@ -733,22 +733,6 @@ SET    version = '$version'
 
     $versionObject = $upgrade->incrementalPhpObject($rev);
 
-    // pre-db check for major release.
-    if ($upgrade->checkVersionRelease($rev, 'alpha1')) {
-      if (!(is_callable([$versionObject, 'verifyPreDBstate']))) {
-        throw new CRM_Core_Exception("verifyPreDBstate method was not found for $rev");
-      }
-
-      $error = NULL;
-      if (!($versionObject->verifyPreDBstate($error))) {
-        if (!isset($error)) {
-          $error = "post-condition failed for current upgrade for $rev";
-        }
-        throw new CRM_Core_Exception($error);
-      }
-
-    }
-
     $upgrade->setSchemaStructureTables($rev);
 
     if (is_callable([$versionObject, $phpFunctionName])) {

--- a/CRM/Upgrade/Incremental/Base.php
+++ b/CRM/Upgrade/Incremental/Base.php
@@ -69,17 +69,6 @@ class CRM_Upgrade_Incremental_Base {
   }
 
   /**
-   * Verify DB state.
-   *
-   * @param $errors
-   *
-   * @return bool
-   */
-  public function verifyPreDBstate(&$errors) {
-    return TRUE;
-  }
-
-  /**
    * Compute any messages which should be displayed before upgrade.
    *
    * Note: This function is called iteratively for each upcoming


### PR DESCRIPTION
Overview
--------

In olden times, upgraders sometimes implemented the method `verifyPreDBstate()`. However, this appears to be unused.
Additionally, it's not clear (from the documentation) how you would use it (if you wanted to).

So...  simplify the code....

Before
------

Function exists. But it does nothing. Because no subclasses implement it.

After
-----

Function does not exist. It still does nothing.
