### PR TITLE
Add `authx_login()` API for backend script authentication

### DIFF
--- a/CRM/Utils/System/Drupal8.php
+++ b/CRM/Utils/System/Drupal8.php
@@ -356,7 +356,8 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
    * @return int|null
    */
   public function getUfId($username) {
-    if ($id = user_load_by_name($username)->id()) {
+    $user = user_load_by_name($username);
+    if ($user && $id = $user->id()) {
       return $id;
     }
   }

--- a/ext/authx/Civi/Authx/Authenticator.php
+++ b/ext/authx/Civi/Authx/Authenticator.php
@@ -28,6 +28,12 @@ class Authenticator {
   protected $authxUf;
 
   /**
+   * @var string
+   *   Ex: 'send' or 'exception
+   */
+  protected $rejectMode = 'send';
+
+  /**
    * Authenticator constructor.
    */
   public function __construct() {
@@ -223,11 +229,26 @@ class Authenticator {
   }
 
   /**
+   * Specify the rejection mode.
+   *
+   * @param string $mode
+   * @return $this
+   */
+  public function setRejectMode(string $mode) {
+    $this->rejectMode = $mode;
+    return $this;
+  }
+
+  /**
    * Reject a bad authentication attempt.
    *
    * @param string $message
    */
   protected function reject($message = 'Authentication failed') {
+    if ($this->rejectMode === 'exception') {
+      throw new AuthxException($message);
+    }
+
     \CRM_Core_Session::useFakeSession();
     $r = new Response(401, ['Content-Type' => 'text/plain'], "HTTP 401 $message");
     \CRM_Utils_System::sendResponse($r);

--- a/ext/authx/Civi/Authx/AuthxException.php
+++ b/ext/authx/Civi/Authx/AuthxException.php
@@ -1,0 +1,16 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Authx;
+
+class AuthxException extends \CRM_Core_Exception {
+
+}

--- a/ext/authx/authx.php
+++ b/ext/authx/authx.php
@@ -39,6 +39,36 @@ Civi::dispatcher()->addListener('civi.invoke.auth', function($e) {
 });
 
 /**
+ * Perform a system login.
+ *
+ * This is useful for backend scripts that need to switch to a specific user.
+ *
+ * As needed, this will update the Civi session and CMS data.
+ *
+ * @param array{contactId: int, userId: int, user: string} $principal
+ *   One of:
+ *   - int $contactId
+ *   - int $userId
+ *   - string $user
+ * @param bool $useSession
+ *   If TRUE, the user will be attached to the existing session.
+ *   If FALSE, the user will not be attached to a session. A fake session may be configured to track the momentary login.
+ * @return array{contactId: int, userId: ?int, flow: string, credType: string, useSession: bool}
+ *   An array describing the authenticated session.
+ * @throws \Civi\Authx\AuthxException
+ */
+function authx_login(array $principal, bool $useSession): array {
+  $auth = new \Civi\Authx\Authenticator();
+  $auth->setRejectMode('exception');
+  if ($auth->setPrincipal($principal, $useSession)) {
+    return \CRM_Core_Session::singleton()->get("authx");
+  }
+  else {
+    throw new \Civi\Authx\AuthxException("Failed to set principal");
+  }
+}
+
+/**
  * @return \Civi\Authx\AuthxInterface
  */
 function _authx_uf() {


### PR DESCRIPTION
Overview
----------------------------------------

Adds a function to login as a user. It is cross-platform; accepts contact ID, user ID, or username; and it updates relevant services (*eg Civi session; Drupal `$user`; MySQL `@civicrm_user_id`*).

(This is a dependency for https://lab.civicrm.org/dev/core/-/issues/1304.   ping @seamuslee001)

Before
----------------------------------------

Not available

After
----------------------------------------

```php
// Signature
function authx_login(array $principal, bool $useSession): array;

// Examples
authx_login(['contactId' => 202], FALSE);
authx_login(['userId' => 1], FALSE);
authx_login(['user' => 'admin'], FALSE);
```

This shares much of its implementation with the login processes used by authx for JWT+ApiKey+Password authentication.

Like the JWT/key/password implementations, this has cross-platform E2E testing.

Technical Details
----------------------------------------

The use-case is like this: you have some background worker processes. These processes need to execute some tasks *on behalf of* a user. This is similar to `authx`'s existing login functionality in some ways (*eg you want it to be portable; to integrate with login/session mechanics in the CMS; and to work with a range of user-accounts*); but it also differs in an important way (*eg there is no authentication credential presented by a user; the decision is made by a background agent*).

The `authx_login()` method basically uses the same login mechanics as the rest of `authx`, but it doesn't require specific credentials.

A quick way to see it in action is with `cv`, `drush`, or `wp-cli`. In each of these commands, 

```bash
cv ev 'authx_login(["contactId"=>202],0); return civicrm_api3("Contact","get",["id"=>"user_contact_id"]);'

cv ev 'authx_login(["userId"=>1],0); return civicrm_api3("Contact","get",["id"=>"user_contact_id"]);'

cv ev 'authx_login(["user"=>"admin"],0); return civicrm_api3("Contact","get",["id"=>"user_contact_id"]);'

drush ev 'civicrm_initialize(); authx_login(["contactId"=>202],0); print_r(civicrm_api3("Contact","get",["id"=>"user_contact_id"]));'

wp eval 'civicrm_initialize(); authx_login(["contactId"=>202],0); print_r(civicrm_api3("Contact","get",["id"=>"user_contact_id"]));'
```

There are some existing alternatives, but each has issues.

* Use `CRM_Utils_System::loadBootStrap(...)` and pass username/password. However, in this function, the authentication and bootstrap processes are tightly coupled -- and some of its expectations are wonky.
* Use CMS-specific APIs, eg `\Drupal::service('account_switcher')->switchTo(...)` or `wp_set_current_user()`. Obviously not portable.
* Use `cv --user`, `drush --user`, or `wp --user`. However, these require you pick the target principal/user *before* launching the script.
* Use `CRM_Core_Config::singleton()->userSystem->loadUser(...)`. However, this only workswith a username (not contactId/userId); the incantation is very internal; and test coverage is unclear.

