### PR TITLE
Contact/BAO/Query.php: fix searching for whitespace

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -3478,7 +3478,7 @@ WHERE  $smartGroupClause
     // Replace spaces with wildcards for a LIKE operation
     // UNLESS string contains a comma (this exception is a tiny bit questionable)
     // Also need to check if there is space in between sort name.
-    elseif ($op == 'LIKE' && strpos($value, ',') === FALSE && strpos($value, ' ') === TRUE) {
+    elseif ($op == 'LIKE' && strpos($value, ',') === FALSE && strpos($value, ' ') !== FALSE) {
       $value = str_replace(' ', '%', $value);
     }
     $value = CRM_Core_DAO::escapeString(trim($value));

--- a/tests/phpunit/CRM/Contact/BAO/QueryTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/QueryTest.php
@@ -1376,4 +1376,33 @@ civicrm_relationship.is_active = 1 AND
     $this->assertEquals('Smith', $rows[0]['last_name']);
   }
 
+  /**
+   * Tests if a space is replaced by the wildcard on sort_name when operation is 'LIKE' and there is no comma
+   *
+   * CRM-22060 fix if condition
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testReplaceSpaceByWildcardCondition() {
+    //Check for wildcard
+    $params = [
+      0 => [
+        0 => 'sort_name',
+        1 => 'LIKE',
+        2 => 'John Doe',
+        3 => 0,
+        4 => 1,
+      ],
+    ];
+    $query = new CRM_Contact_BAO_Query($params);
+    list($select, $from, $where) = $query->query();
+    $this->assertStringContainsString("contact_a.sort_name LIKE '%John%Doe%'", $where);
+
+    //Check for NO wildcard due to comma
+    $params[0][2] = 'Doe, John';
+    $query = new CRM_Contact_BAO_Query($params);
+    list($select, $from, $where) = $query->query();
+    $this->assertStringContainsString("contact_a.sort_name LIKE '%Doe, John%'", $where);
+  }
+
 }

--- a/tests/phpunit/api/v3/ContactTest.php
+++ b/tests/phpunit/api/v3/ContactTest.php
@@ -2275,7 +2275,8 @@ class api_v3_ContactTest extends CiviUnitTestCase {
     $this->individualCreate($contactParams_2);
 
     $result = $this->callAPISuccess('contact', 'get', ['sort_name' => 'Blackwell F']);
-    $this->assertEquals(1, $result['count']);
+    // Since #22060 we expect both results as space is being replaced with wildcard
+    $this->assertEquals(2, $result['count']);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
When looking for spaces, the condition was never true.

Before
----------------------------------------
The condition always failed.

After
----------------------------------------
The condition is now applied.

Comments
---------------
PR originally submitted as #22060 - rebased here