### PR TITLE
fixes report#85 - Don't crash Contact Logging Detail report when viewing a contribution

### DIFF
--- a/CRM/Logging/ReportDetail.php
+++ b/CRM/Logging/ReportDetail.php
@@ -477,7 +477,7 @@ class CRM_Logging_ReportDetail extends CRM_Report_Form {
    * @return string
    */
   private function convertForeignKeyValuesToLabels(string $fkClassName, string $field, int $keyval): string {
-    if (property_exists($fkClassName, '_labelField')) {
+    if ($fkClassName::$_labelField) {
       $labelValue = CRM_Core_DAO::getFieldValue($fkClassName, $keyval, $fkClassName::$_labelField);
       // Not sure if this should use ts - there's not a lot of context (`%1 (id: %2)`) - and also the similar field labels above don't use ts.
       return "{$labelValue} (id: {$keyval})";

--- a/tests/phpunit/CRM/Report/Form/Contact/LoggingDetailTest.php
+++ b/tests/phpunit/CRM/Report/Form/Contact/LoggingDetailTest.php
@@ -1,0 +1,55 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *  Test Activity report outcome
+ *
+ * @package CiviCRM
+ */
+class CRM_Report_Form_Contact_LoggingDetailTest extends CiviReportTestCase {
+  protected $_tablesToTruncate = [
+    'civicrm_contact',
+    'log_civicrm_contact',
+  ];
+
+  public function setUp(): void {
+    parent::setUp();
+    $this->callAPISuccess('Setting', 'create', ['logging' => TRUE]);
+    $this->quickCleanup($this->_tablesToTruncate);
+  }
+
+  public function tearDown(): void {
+    $this->callAPISuccess('Setting', 'create', ['logging' => FALSE]);
+    parent::tearDown();
+    $log = new CRM_Logging_Schema();
+    $log->dropAllLogTables();
+  }
+
+  /**
+   * Ensure a missing label name on a DAO won't crash the Logging Detail Report.
+   */
+  public function testLabelFieldIsntRequired() {
+    // Create an individual and a contribution in the same database connection (as if a new contact submitted a contribution online).
+    $cid = $this->individualCreate();
+    $this->contributionCreate(['contact_id' => $cid]);
+    $logConnId = CRM_Core_DAO::singleValueQuery('SELECT log_conn_id FROM log_civicrm_contribution ORDER BY log_date DESC LIMIT 1');
+
+    // Logging Details report builds rows in the constructor so we have to pass the log_conn_id before getReportObject does.
+    $tmpGlobals["_REQUEST"]["log_conn_id"] = $logConnId;
+    CRM_Utils_GlobalStack::singleton()->push($tmpGlobals);
+    // Run the report.
+    $input = [
+      'filters' => ['log_conn_id' => $logConnId],
+    ];
+    $obj = $this->getReportObject('CRM_Report_Form_Contact_LoggingDetail', $input);
+  }
+
+}


### PR DESCRIPTION
https://lab.civicrm.org/dev/report/-/issues/85

Attempting to view the details of a contribution on the Change Log tab fails if the contact was updated in the same database connection.

### Steps to replicate
* Turn on advanced logging.
* Record a donation through a contribution page for either a) a new contact, b) an existing contact, but adding/changing their name.
* Go to that contact's change log, and try to view the details of the most recent change (by clicking **Update** next to the change).

### Before
`DB Error: Syntax Error`.

### After
You see the changes.


This regression comes from [PR 19504](https://github.com/civicrm/civicrm-core/pull/19504).  Previously, not every DAO had a `_labelField` property - so `CRM_Logging_ReportDetail::convertForeignKeyValuesToLabels()` checking if the property existed was basically the same as checking if it was defined.  Now it will always exist (in `CRM_Core_DAO`) but not always be defined. So we change the conditional to reflect that.