### PR TITLE
dev/core#2825 - Make source contact required for activities on the form

### DIFF
--- a/CRM/Activity/Form/Activity.php
+++ b/CRM/Activity/Form/Activity.php
@@ -180,7 +180,7 @@ class CRM_Activity_Form_Activity extends CRM_Contact_Form_Task {
       'source_contact_id' => [
         'type' => 'entityRef',
         'label' => ts('Added by'),
-        'required' => FALSE,
+        'required' => TRUE,
       ],
       'target_contact_id' => [
         'type' => 'entityRef',


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/2825

Before
----------------------------------------
It's possible to edit a case activity and remove the source contact. You don't notice it on the regular activity form because postprocess will fill in the current user, but on a case activity it stays blank and then causes problems later such as disappearing from manage case and crashing the Print Report.

After
----------------------------------------
Both types of activities have it required.

Technical Details
----------------------------------------
It's a quickfix because you'll still have case problems if you permanently delete a contact (https://lab.civicrm.org/dev/core/-/issues/1251). That could be considered a bigger issue though because you've lost important data if you do that.

Comments
----------------------------------------

