### PR TITLE
Update Brick/Money to 0.5.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -80,7 +80,7 @@
     "tplaner/when": "~3.0.0",
     "xkerman/restricted-unserialize": "~1.1",
     "typo3/phar-stream-wrapper": "^2 || ^3.0",
-    "brick/money": "~0.4",
+    "brick/money": "~0.5",
     "ext-intl": "*",
     "pear/mail_mime": "~1.10",
     "pear/db": "1.11",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e9060ec676613c281267b190d808a479",
+    "content-hash": "2914da6f6154985863260a510f6eed54",
     "packages": [
         {
             "name": "adrienrn/php-mimetyper",
@@ -101,16 +101,16 @@
         },
         {
             "name": "brick/money",
-            "version": "0.5.1",
+            "version": "0.5.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/brick/money.git",
-                "reference": "c6f2883c8a759bf7f77c79aaa6004af6d6c0afaf"
+                "reference": "49e6597470da74f6a9f1dd7d5286ea3b4756b7e0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/brick/money/zipball/c6f2883c8a759bf7f77c79aaa6004af6d6c0afaf",
-                "reference": "c6f2883c8a759bf7f77c79aaa6004af6d6c0afaf",
+                "url": "https://api.github.com/repos/brick/money/zipball/49e6597470da74f6a9f1dd7d5286ea3b4756b7e0",
+                "reference": "49e6597470da74f6a9f1dd7d5286ea3b4756b7e0",
                 "shasum": ""
             },
             "require": {
@@ -123,7 +123,7 @@
                 "ext-pdo": "*",
                 "php-coveralls/php-coveralls": "^2.2",
                 "phpunit/phpunit": "^7.5.15 || ^8.0 || ^9.0",
-                "vimeo/psalm": "4.3.2"
+                "vimeo/psalm": "4.9.2"
             },
             "suggest": {
                 "ext-intl": "Required to format Money objects"
@@ -144,13 +144,21 @@
                 "currency",
                 "money"
             ],
+            "support": {
+                "issues": "https://github.com/brick/money/issues",
+                "source": "https://github.com/brick/money/tree/0.5.3"
+            },
             "funding": [
+                {
+                    "url": "https://github.com/BenMorel",
+                    "type": "github"
+                },
                 {
                     "url": "https://tidelift.com/funding/github/packagist/brick/money",
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-02-10T14:14:29+00:00"
+            "time": "2021-10-10T11:59:43+00:00"
         },
         {
             "name": "cache/integration-tests",


### PR DESCRIPTION
Overview
----------------------------------------
This updates Brick/Money library from 0.5.1 to 0.5.3

Before
----------------------------------------
0.5.1

After
----------------------------------------
Add support for VED (Venezuelan bolívar) currency. 

New methods

Money::splitWithRemainder()
Money::allocateWithRemainder()


Technical Details
----------------------------------------


Comments
----------------------------------------
