### PR TITLE
Contribution Confirm: fix wording on the recurring

### DIFF
--- a/templates/CRM/Contribute/Form/Contribution/Confirm.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Confirm.tpl
@@ -123,11 +123,11 @@
                 {if $frequency_unit eq 'day'}
                   <p><strong>{ts}I want to contribute this amount every day.{/ts}</strong></p>
                 {elseif $frequency_unit eq 'week'}
-                  <p><strong>{ts}I want to contribute this amount processed every week.{/ts}</strong></p>
+                  <p><strong>{ts}I want to contribute this amount every week.{/ts}</strong></p>
                 {elseif $frequency_unit eq 'month'}
-                  <p><strong>{ts}I want to contribute this amount processed every month.{/ts}</strong></p>
+                  <p><strong>{ts}I want to contribute this amount every month.{/ts}</strong></p>
                 {elseif $frequency_unit eq 'year'}
-                  <p><strong>{ts}I want to contribute this amount processed every year.{/ts}</strong></p>
+                  <p><strong>{ts}I want to contribute this amount every year.{/ts}</strong></p>
                 {/if}
               {/if}
             {/if}


### PR DESCRIPTION
Overview
----------------------------------------

Fixes a grammar error that may have slipped in by mistake.

Before
----------------------------------------

![image](https://user-images.githubusercontent.com/254741/146038377-a88cb237-bb94-463b-a8ef-4952116778b5.png)


After
----------------------------------------

Removed "processed"

![image](https://user-images.githubusercontent.com/254741/146038448-8ac3c5c2-4b9f-4b56-b4d4-b88f09182260.png)


Technical Details
----------------------------------------

Error introduced in #20308 - had many reviews, none of us noticed it :)

I am doing a PR against 5.45 (RC) because this is a tiny fix and can be annoying to users. It also has an impact on the translations, because the broken strings are not on Transifex (and should not be).

@masetto for information
