### PR TITLE
[REF] Minor parameter simplification

### DIFF
--- a/CRM/Contact/BAO/Relationship.php
+++ b/CRM/Contact/BAO/Relationship.php
@@ -979,8 +979,7 @@ WHERE  relationship_type_id = " . CRM_Utils_Type::escape($type, 'Integer');
     $relationship = CRM_Core_DAO::executeQuery($queryString);
     while ($relationship->fetch()) {
       // Check whether the custom field values are identical.
-      $result = self::checkDuplicateCustomFields($params, $relationship->id);
-      if ($result) {
+      if (self::checkDuplicateCustomFields($params['custom'] ?? [], $relationship->id)) {
         return TRUE;
       }
     }
@@ -992,23 +991,27 @@ WHERE  relationship_type_id = " . CRM_Utils_Type::escape($type, 'Integer');
    * the same as the values of the custom fields of the relation with given
    * $relationshipId.
    *
-   * @param array $params (reference) an assoc array of name/value pairs
+   * @param array $params an assoc array of name/value pairs
    * @param int $relationshipId ID of an existing duplicate relation
    *
    * @return boolean true if custom field values are identical
    * @access private
    * @static
    */
-  private static function checkDuplicateCustomFields(&$params, $relationshipId) {
+  private static function checkDuplicateCustomFields($params, $relationshipId) {
     // Get the custom values of the existing relationship.
     $existingValues = CRM_Core_BAO_CustomValueTable::getEntityValues($relationshipId, 'Relationship');
     // Create a similar array for the new relationship.
     $newValues = [];
-    if (isset($params['custom']) && is_array($params['custom'])) {
-      // $params['custom'] seems to be an array. Each value is again an array.
+    if (!is_array($params)) {
+      // No idea when this would happen....
+      CRM_Core_Error::deprecatedWarning('params should be an array');
+    }
+    else {
+      // $params seems to be an array, as it should be. Each value is again an array.
       // This array contains one value (key -1), and this value seems to be
       // an array with the information about the custom value.
-      foreach ($params['custom'] as $value) {
+      foreach ($params as $value) {
         foreach ($value as $customValue) {
           $newValues[$customValue['custom_field_id']] = $customValue['value'];
         }


### PR DESCRIPTION
The only value in this array used in the function is 'custom' which should be an array. I think it woul
d only ever be an array or NULL (which would then be an array with this change) but I left
a deprecation notice in case. Pass-by-ref isn't needed

Overview
----------------------------------------
_A brief description of the pull request. Keep technical jargon to a minimum. Hyperlink relevant discussions._

Before
----------------------------------------
_What is the old user-interface or technical-contract (as appropriate)?_
_For optimal clarity, include a concrete example such as a screenshot, GIF ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)), or code-snippet._

After
----------------------------------------
_What changed? What is new old user-interface or technical-contract?_
_For optimal clarity, include a concrete example such as a screenshot, GIF ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)), or code-snippet._

Technical Details
----------------------------------------
_If the PR involves technical details/changes/considerations which would not be manifest to a casual developer skimming the above sections, please describe the details here._

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
