### PR TITLE
Do not default-escape weight field on order

### DIFF
--- a/templates/CRM/Admin/Page/Options.tpl
+++ b/templates/CRM/Admin/Page/Options.tpl
@@ -133,7 +133,7 @@
               <td class="center crm-admin-options-filter">{icon condition=$row.filter}{ts}Counted{/ts}{/icon}</td>
             {/if}
             <td class="crm-admin-options-description crm-editable" data-field="description" data-type="textarea">{$row.description}</td>
-            <td class="nowrap crm-admin-options-order">{if $row.weight}{$row.weight}{/if}</td>
+            <td class="nowrap crm-admin-options-order">{if $row.weight}{$row.weight|smarty:nodefaults}{/if}</td>
             {if $showIsDefault}
               <td class="crm-admin-options-is_default" align="center">{if $row.is_default}{icon}{ts}Default{/ts}{/icon}{/if}&nbsp;</td>
             {/if}


### PR DESCRIPTION
Overview
----------------------------------------
Fix over-escaping instance when `define('CIVICRM_SMARTY_DEFAULT_ESCAPE', TRUE);`

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/146156814-d89415e6-9d72-47b7-a06e-20d79fd35800.png)


After
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/146156674-53ca053d-f1d1-472f-b64b-ef2819f8276c.png)


Technical Details
----------------------------------------

Comments
----------------------------------------