### PR TITLE
(NFC) APIv4: Add help info for multi-record custom field sets

### DIFF
--- a/Civi/Api4/Generic/DAOGetAction.php
+++ b/Civi/Api4/Generic/DAOGetAction.php
@@ -31,7 +31,9 @@ class DAOGetAction extends AbstractGetAction {
   /**
    * Fields to return. Defaults to all standard (non-custom, non-extra) fields `['*']`.
    *
-   * The keyword `"custom.*"` selects all custom fields. So to select all standard + custom fields, select `['*', 'custom.*']`.
+   * The keyword `"custom.*"` selects all custom fields (except those belonging to multi-record custom field sets). So to select all standard + custom fields, select `['*', 'custom.*']`.
+   *
+   * Multi-record custom field sets are represented as their own entity, so join to that entity to get those custom fields.
    *
    * Use the dot notation to perform joins in the select clause, e.g. selecting `['*', 'contact.*']` from `Email::get()`
    * will select all fields for the email + all fields for the related contact.


### PR DESCRIPTION
Overview
----------------------------------------
Provides brief help for multi-record custom field sets.  This shows in API Explorer 4.  Select `Contact`, then `get` and click in the `select` box to view the help text.

Before
----------------------------------------
Says 'all' custom fields are returned with `custom.*` which is not correct for multi-record.

After
----------------------------------------
Better info


