### PR TITLE
dev/core#2992 Cancelling preApproval payment does not work

### DIFF
--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -114,6 +114,13 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
     if (!empty($this->_values['footer_text'])) {
       $this->assign('footer_text', $this->_values['footer_text']);
     }
+
+    if (!empty($this->_paymentProcessor) &&  $this->_paymentProcessor['object']->supports('preApproval')) {
+      $isCancel = CRM_Utils_Request::retrieve('cancel', 'Boolean');
+      if ($isCancel && $this->get('pre_approval_parameters')) {
+        $this->set('pre_approval_parameters', []);
+      }
+    }
   }
 
   /**

--- a/CRM/Core/Payment.php
+++ b/CRM/Core/Payment.php
@@ -1186,8 +1186,9 @@ abstract class CRM_Core_Payment {
 
     if ($this->_component == 'event') {
       return CRM_Utils_System::url($this->getBaseReturnUrl(), [
-        'reset' => 1,
-        'cc' => 'fail',
+        '_qf_Register_display' => 1,
+        'qfKey' => $qfKey,
+        'cancel' => 1,
         'participantId' => $participantID,
       ],
         TRUE, NULL, FALSE

--- a/CRM/Event/Form/Registration/Register.php
+++ b/CRM/Event/Form/Registration/Register.php
@@ -198,6 +198,13 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
     if ($this->_allowConfirmation) {
       CRM_Event_Form_EventFees::preProcess($this);
     }
+
+    if (!empty($this->_paymentProcessor) &&  $this->_paymentProcessor['object']->supports('preApproval')) {
+      $isCancel = CRM_Utils_Request::retrieve('cancel', 'Boolean');
+      if ($isCancel && $this->get('pre_approval_parameters')) {
+        $this->set('pre_approval_parameters', []);
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
This issue related to preApproval payment. its present on Contribution and Event registartion form.

E.g Paypal Express.

Reproduction steps
----------------------------------------
1. Set up Paypal Pro account (live and test mode).
1. The configure Processor on Contribution page.
1. Visit online page (live or test mode).
1. Select amount and click on Paypal Button
1. It redirct you to login page, there is link to cancel the process,link look like this 
`http://drupal7.test/civicrm/contribute/transact?_qf_Main_display=1&qfKey=CRMContributeControllerContribution67xqxb55jcow0k0gcs8sc8c4cs0c4sc00s4gcwg0skg84ws840_7945&cancel=1&token=EC-1V540554M6477413R` . Click on it. It redirect you to main page.
1. Now this time do the transaction using credit card.
1. Once you reach to CiviCRM confirm page and click to pay amount. You will get the error like this 
`Payment Processor Error message :Express Checkout PayerID is missing.`


In Case of event registration, we were not passing qfkye to cancel url. when we cancel the payment on paypal express login page.. we are getting `Could not find valid value for id` Error.

After correcting the cancel url we need to apply same changes to reset `preApproval` data to continue payment with other method without resetting the page.

Comments
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/2992