### PR TITLE
Fix Fatal Error on contribution tab and user dashboard when recurring payment generated using extension get disabled

### DIFF
--- a/CRM/Contribute/Page/Tab.php
+++ b/CRM/Contribute/Page/Tab.php
@@ -58,6 +58,13 @@ class CRM_Contribute_Page_Tab extends CRM_Core_Page {
       ],
     ];
 
+    // In case there extension which have recurring payment and then
+    // extension is disabled and in that case payment object may be null
+    // To avoid the fatal error, return with VIEW link.
+    if (!is_object($paymentProcessorObj)) {
+      return $links;
+    }
+
     $templateContribution = CRM_Contribute_BAO_ContributionRecur::getTemplateContribution($recurID);
     if (
       (CRM_Core_Permission::check('edit contributions') || $context !== 'contribution') &&
@@ -121,6 +128,12 @@ class CRM_Contribute_Page_Tab extends CRM_Core_Page {
   public static function selfServiceRecurLinks(int $recurID): array {
     $links = [];
     $paymentProcessorObj = Civi\Payment\System::singleton()->getById(CRM_Contribute_BAO_ContributionRecur::getPaymentProcessorID($recurID));
+    // In case there extension which have recurring payment and then
+    // extension is disabled and in that case payment object may be null
+    // To avoid the fatal error, return with VIEW link.
+    if (!is_object($paymentProcessorObj)) {
+      return $links;
+    }
     if ($paymentProcessorObj->supports('cancelRecurring')
       && $paymentProcessorObj->subscriptionURL($recurID, 'recur', 'cancel')
     ) {


### PR DESCRIPTION
Overview
----------------------------------------
Step to reproduce:
1. Install extensions which support recurring payment e.g Stripe.
2. Create Recurring payment using that processor. (maybe use API Explorer to create it)
3. Disable extension.
4. Visit the Contribution tab or user Dashboard screen. you will get a fatal error.

Before
----------------------------------------
Fatal Error were showing

After
----------------------------------------
It shows a recurring record with `VIEW` link.