### PR TITLE
[Ref] Add getter for priceSetID and use full form flow

### DIFF
--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -1519,7 +1519,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
     // reassign submitted form values if the any information is formatted via beginPostProcess
     $submittedValues = $this->_params;
 
-    if (!empty($submittedValues['price_set_id']) && $action & CRM_Core_Action::UPDATE) {
+    if ($this->getPriceSetID() && $action & CRM_Core_Action::UPDATE) {
       $line = CRM_Price_BAO_LineItem::getLineItems($this->_id, 'contribution');
       $lineID = key($line);
       $priceSetId = CRM_Core_DAO::getFieldValue('CRM_Price_DAO_PriceField', CRM_Utils_Array::value('price_field_id', $line[$lineID]), 'price_set_id');
@@ -1534,7 +1534,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
     // Process price set and get total amount and line items.
     $lineItem = [];
     $priceSetId = $submittedValues['price_set_id'] ?? NULL;
-    if (empty($priceSetId) && !$this->_id) {
+    if (!$this->getPriceSetID() && !$this->_id) {
       $this->_priceSetId = $priceSetId = CRM_Core_DAO::getFieldValue('CRM_Price_DAO_PriceSet', 'default_contribution_amount', 'id', 'name');
       $this->_priceSet = current(CRM_Price_BAO_PriceSet::getSetDetail($priceSetId));
       $fieldID = key($this->_priceSet['fields']);
@@ -2119,6 +2119,18 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
     }
 
     return $statuses;
+  }
+
+  /**
+   * Get the price set ID.
+   *
+   * Note that the function currently returns NULL if not submitted
+   * but will over time be fixed to always return an ID.
+   *
+   * @return int|null
+   */
+  protected function getPriceSetID() {
+    return $this->getSubmittedValue('price_set_id');
   }
 
 }

--- a/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
@@ -372,7 +372,6 @@ class CRM_Contribute_Form_ContributionTest extends CiviUnitTestCase {
    * Test the submit function on the contribution page.
    */
   public function testSubmitCreditCardFee(): void {
-    $form = new CRM_Contribute_Form_Contribution();
     $this->paymentProcessor->setDoDirectPaymentResult(['payment_status_id' => 1, 'is_error' => 0, 'trxn_id' => 'tx', 'fee_amount' => .08]);
     $this->submitContributionForm([
       'total_amount' => 50,
@@ -571,9 +570,8 @@ class CRM_Contribute_Form_ContributionTest extends CiviUnitTestCase {
   /**
    * Test the submit function does not create a billing address if no details provided.
    */
-  public function testSubmitCreditCardWithNoBillingAddress() {
-    $form = new CRM_Contribute_Form_Contribution();
-    $form->testSubmit([
+  public function testSubmitCreditCardWithNoBillingAddress(): void {
+    $this->submitContributionForm([
       'total_amount' => 50,
       'financial_type_id' => 1,
       'contact_id' => $this->_individualId,
@@ -581,7 +579,7 @@ class CRM_Contribute_Form_ContributionTest extends CiviUnitTestCase {
       'payment_processor_id' => $this->paymentProcessorID,
       'credit_card_exp_date' => ['M' => 5, 'Y' => 2025],
       'credit_card_number' => '411111111111111',
-    ], CRM_Core_Action::ADD, 'live');
+    ], NULL, 'live');
     $contribution = $this->callAPISuccessGetSingle('Contribution', ['return' => 'address_id']);
     $this->assertEmpty($contribution['address_id']);
     $this->callAPISuccessGetCount('Address', [


### PR DESCRIPTION
Overview
----------------------------------------
[Ref] Add getter for priceSetID and use full form flow

Before
----------------------------------------
No getter, test uses old flow

After
----------------------------------------
Getter

Technical Details
----------------------------------------
Once the tests use the full form flow we can start using `getSubmittedValue` as being done here & can also look to use functions to retrieve values rather than relying on passing variables around

Comments
----------------------------------------
