### PR TITLE
fixes core#3000: Revert #21313, don't crash when updating a shared address w/ custom fields

### DIFF
--- a/CRM/Core/BAO/Address.php
+++ b/CRM/Core/BAO/Address.php
@@ -104,7 +104,7 @@ class CRM_Core_BAO_Address extends CRM_Core_DAO_Address {
       // call the function to sync shared address and create relationships
       // if address is already shared, share master_id with all children and update relationships accordingly
       // (prevent chaining 2) CRM-21214
-      self::processSharedAddress($address->id, $params, $hook);
+      self::processSharedAddress($address->id, $params);
 
       // lets call the post hook only after we've done all the follow on processing
       CRM_Utils_Hook::post($hook, 'Address', $address->id, $address);
@@ -956,9 +956,8 @@ SELECT is_primary,
    *   Address id.
    * @param array $params
    *   Associated array of address params.
-   * @param string $parentOperation Operation being taken on the parent entity.
    */
-  public static function processSharedAddress($addressId, $params, $parentOperation = NULL) {
+  public static function processSharedAddress($addressId, $params) {
     $query = 'SELECT id, contact_id FROM civicrm_address WHERE master_id = %1';
     $dao = CRM_Core_DAO::executeQuery($query, [1 => [$addressId, 'Integer']]);
 
@@ -997,7 +996,7 @@ SELECT is_primary,
       $addressDAO->copyValues($params);
       $addressDAO->id = $dao->id;
       $addressDAO->save();
-      $addressDAO->copyCustomFields($addressId, $addressDAO->id, $parentOperation);
+      $addressDAO->copyCustomFields($addressId, $addressDAO->id);
     }
   }
 

--- a/CRM/Core/BAO/CustomValueTable.php
+++ b/CRM/Core/BAO/CustomValueTable.php
@@ -399,16 +399,15 @@ class CRM_Core_BAO_CustomValueTable {
    * @param $entityTable
    * @param int $entityID
    * @param $customFieldExtends
-   * @param $parentOperation
    */
-  public static function postProcess(&$params, $entityTable, $entityID, $customFieldExtends, $parentOperation = NULL) {
+  public static function postProcess(&$params, $entityTable, $entityID, $customFieldExtends) {
     $customData = CRM_Core_BAO_CustomField::postProcess($params,
       $entityID,
       $customFieldExtends
     );
 
     if (!empty($customData)) {
-      self::store($customData, $entityTable, $entityID, $parentOperation);
+      self::store($customData, $entityTable, $entityID);
     }
   }
 

--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -1979,12 +1979,11 @@ LIKE %1
    *
    * @param int $entityID
    * @param int $newEntityID
-   * @param string $parentOperation
    */
-  public function copyCustomFields($entityID, $newEntityID, $parentOperation = NULL) {
+  public function copyCustomFields($entityID, $newEntityID) {
     $entity = CRM_Core_DAO_AllCoreTables::getBriefName(get_class($this));
     $tableName = CRM_Core_DAO_AllCoreTables::getTableForClass(get_class($this));
-    // Obtain custom values for the old entity.
+    // Obtain custom values for old event
     $customParams = $htmlType = [];
     $customValues = CRM_Core_BAO_CustomValueTable::getEntityValues($entityID, $entity);
 
@@ -2018,8 +2017,8 @@ LIKE %1
         }
       }
 
-      // Save Custom Fields for new Entity.
-      CRM_Core_BAO_CustomValueTable::postProcess($customParams, $tableName, $newEntityID, $entity, $parentOperation ?? 'create');
+      // Save Custom Fields for new Event
+      CRM_Core_BAO_CustomValueTable::postProcess($customParams, $tableName, $newEntityID, $entity);
     }
 
     // copy activity attachments ( if any )

--- a/tests/phpunit/CRM/Contribute/BAO/ContributionRecurTest.php
+++ b/tests/phpunit/CRM/Contribute/BAO/ContributionRecurTest.php
@@ -294,8 +294,6 @@ class CRM_Contribute_BAO_ContributionRecurTest extends CiviUnitTestCase {
     $templateContribution = $templateContribution->first();
     $this->assertNotNull($templateContribution['template.field']);
     $this->assertEquals('Second and most recent Contribution', $templateContribution['template.field']);
-    $this->callAPISuccess('CustomField', 'delete', ['id' => $custom_field['id']]);
-    $this->callAPISuccess('CustomGroup', 'delete', ['id' => $custom_group['id']]);
   }
 
   /**

--- a/tests/phpunit/api/v3/AddressTest.php
+++ b/tests/phpunit/api/v3/AddressTest.php
@@ -393,6 +393,23 @@ class api_v3_AddressTest extends CiviUnitTestCase {
     $this->customGroupDelete($ids['custom_group_id']);
   }
 
+  public function testUpdateSharedAddressWithCustomFields() {
+    $ids = $this->entityCustomGroupWithSingleFieldCreate(__FUNCTION__, __FILE__);
+
+    $params = $this->_params;
+    $params['custom_' . $ids['custom_field_id']] = "custom string";
+
+    $firstAddress = $this->callAPISuccess($this->_entity, 'create', $params);
+
+    $contactIdB = $this->individualCreate();
+
+    $secondAddressParams = array_merge(['contact_id' => $contactIdB, 'master_id' => $firstAddress['id']], $firstAddress);
+    unset($secondAddressParams['id']);
+    $secondAddress = $this->callAPISuccess('Address', 'create', $secondAddressParams);
+    // Ensure an update to the second address doesn't cause a "db error: already exists" when resaving the custom fields.
+    $this->callAPISuccess('Address', 'create', ['id' => $secondAddress['id'], 'contact_id' => $contactIdB, 'master_id' => $firstAddress['id']]);
+  }
+
   /**
    * @param int $version
    * @dataProvider versionThreeAndFour


### PR DESCRIPTION
Overview
----------------------------------------
See https://lab.civicrm.org/dev/core/-/issues/3000 for details and replication steps.

Before
----------------------------------------
`db error: already exists`

After
----------------------------------------
Saves properly.

Technical Details
----------------------------------------
This is a straight reverse-diff of #21313 plus a unit test.

Comments
----------------------------------------
This also reverts the unit tests added on #21313.  Given the regression nature, I'm going to leave this as is and leave it to @seamuslee001 to decide if this makes more sense completely reverted, or if he wants to reapply #21313 and make it pass with the unit test on this PR.
