### PR TITLE
[NFC] - Try to work around failing tests

### DIFF
--- a/tests/phpunit/CRM/Utils/FileTest.php
+++ b/tests/phpunit/CRM/Utils/FileTest.php
@@ -211,6 +211,9 @@ class CRM_Utils_FileTest extends CiviUnitTestCase {
    */
   public function testIsDirMkdir() {
     $a_dir = sys_get_temp_dir() . '/testIsDir';
+    // I think temp is global to the test node, so if any test failed on this
+    // in the past it doesn't get cleaned up and so already exists.
+    system('rm -rf ' . escapeshellarg($a_dir));
     mkdir($a_dir);
     $this->assertTrue(CRM_Utils_File::isDir($a_dir));
     mkdir($a_dir . '/aSubDir');
@@ -226,6 +229,9 @@ class CRM_Utils_FileTest extends CiviUnitTestCase {
    */
   public function testIsDirSlashVariations() {
     $a_dir = sys_get_temp_dir() . '/testIsDir';
+    // I think temp is global to the test node, so if any test failed on this
+    // in the past it doesn't get cleaned up and so already exists.
+    system('rm -rf ' . escapeshellarg($a_dir));
     mkdir($a_dir);
 
     $old_cwd = getcwd();
@@ -265,6 +271,9 @@ class CRM_Utils_FileTest extends CiviUnitTestCase {
     }
 
     $a_dir = sys_get_temp_dir() . '/testIsDir';
+    // I think temp is global to the test node, so if any test failed on this
+    // in the past it doesn't get cleaned up and so already exists.
+    system('rm -rf ' . escapeshellarg($a_dir));
     mkdir($a_dir);
     symlink($a_dir, $a_dir . '_symlink');
     $this->assertTrue(CRM_Utils_File::isDir($a_dir . '_symlink'));


### PR DESCRIPTION
Overview
----------------------------------------
Some tests are failing on these, I think because the system temp dir is global to the test node, so if at some point in the past the test had left this folder around it would exist already when any test run comes along. So try to start from a clean slate.