### PR TITLE
Fix related contacts label in search kit

### DIFF
--- a/Civi/Api4/RelationshipCache.php
+++ b/Civi/Api4/RelationshipCache.php
@@ -49,6 +49,7 @@ class RelationshipCache extends Generic\AbstractEntity {
     $info['bridge'] = [
       'near_contact_id' => [
         'to' => 'far_contact_id',
+        'label' => ts('Related Contacts'),
         'description' => ts('One or more related contacts'),
       ],
     ];


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a 5.45 regression in the "With: Related Contacts" label.

Before
----------------------------------------

![image](https://user-images.githubusercontent.com/2874912/146611094-f97f236f-1728-4f6c-8e8f-94dbdc4bb58d.png)


After
----------------------------------------

![image](https://user-images.githubusercontent.com/2874912/146611067-40f3d761-4525-42b1-994f-c5f816a3285e.png)

