### PR TITLE
Fix tests to use dates consistent with the 'new' status it tests for

### DIFF
--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -3453,8 +3453,11 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
    */
   public function testPendingToCompleteContribution(): void {
     $this->createPriceSetWithPage('membership');
-    $this->setUpPendingContribution($this->_ids['price_field_value'][0]);
-    $this->callAPISuccess('membership', 'getsingle', ['id' => $this->_ids['membership']]);
+    $this->setUpPendingContribution($this->_ids['price_field_value'][0], '', [], [], [
+      'start_date' => 'yesterday',
+      'join_date' => 'yesterday',
+    ]);
+    $this->callAPISuccess('Membership', 'getsingle', ['id' => $this->_ids['membership']]);
     // Case 1: Assert that Membership Signup Activity is created on Pending to Completed Contribution via backoffice
     $activity = $this->callAPISuccess('Activity', 'get', [
       'activity_type_id' => 'Membership Signup',
@@ -3462,7 +3465,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
       'status_id' => 'Scheduled',
     ]);
     $this->assertEquals(1, $activity['count']);
-    $_REQUEST['id'] = $this->getContributionID();
+    $_REQUEST['id'] = $this->getContributionID('');
     $_REQUEST['action'] = 'update';
     // change pending contribution to completed
     /* @var CRM_Contribute_Form_Contribution $form */
@@ -3505,7 +3508,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
     // 2.b Contribution activity created to record successful payment
     $activity = $this->callAPISuccess('Activity', 'get', [
       'activity_type_id' => 'Contribution',
-      'source_record_id' => $this->getContributionID(),
+      'source_record_id' => $this->getContributionID(''),
       'status_id' => 'Completed',
     ]);
     $this->assertEquals(1, $activity['count']);


### PR DESCRIPTION


The test is currently setting dates consistent with a status of
'Grace' - it passes when going through legacy transitionComponents
which sets to 'New' regardless of calculated status - but when we
switch to the preferred code path it will set based on dates
