### PR TITLE
[REF] Duplicate & unshare processFormContribution

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -1013,6 +1013,9 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
   /**
    * Process the contribution.
    *
+   * @todo - this code was previously shared with the backoffice form - some parts of this
+   * function may relate to that form, not this one.
+   *
    * @param CRM_Core_Form $form
    * @param array $params
    * @param array $result
@@ -1043,7 +1046,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
    * @throws \CRM_Core_Exception
    * @throws \CiviCRM_API3_Exception
    */
-  public static function processFormContribution(
+  protected static function processFormContribution(
     &$form,
     $params,
     $result,


### PR DESCRIPTION

Overview
----------------------------------------
[REF] Duplicate & unshare processFormContribution

Before
----------------------------------------
Code shared between front end & back office forms - but not in a way that reduces the total amount of code

After
----------------------------------------
Code duplicated & unshared - allowing further cleanup

Technical Details
----------------------------------------
The only way I've managed to break up these big toxic functions is divide & conquer. While it seems
counter-intuitive to not doing things in more than one place in practice much of the
code is form-relevant and the the code before, during and after these functions
does a whole lot of extra work to share stuff that they don't really have in common.

This dates back pre-api when the only copy of the business logic often was on the forms....

Comments
----------------------------------------
