### PR TITLE
dev/core#2927 - Avoid flooding logs with open_basedir in effect

### DIFF
--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -1756,7 +1756,12 @@ class CRM_Utils_System {
     $inc_dirs = explode(PATH_SEPARATOR, get_include_path());
     foreach ($inc_dirs as $inc_dir) {
       $target_dir = $inc_dir . DIRECTORY_SEPARATOR . $relpath;
-      if (is_dir($target_dir)) {
+      // While it seems pointless to have a folder that's outside open_basedir
+      // listed in include_path and that seems more like a configuration issue,
+      // not everyone has control over the hosting provider's include_path and
+      // this does happen out in the wild, so use our wrapper to avoid flooding
+      // logs.
+      if (CRM_Utils_File::isDir($target_dir)) {
         $cur_list = scandir($target_dir);
         foreach ($cur_list as $fname) {
           if ($fname != '.' && $fname != '..') {

--- a/Civi/API/Provider/MagicFunctionProvider.php
+++ b/Civi/API/Provider/MagicFunctionProvider.php
@@ -99,11 +99,15 @@ class MagicFunctionProvider implements EventSubscriberInterface, ProviderInterfa
   public function getEntityNames($version) {
     $entities = [];
     $include_dirs = array_unique(explode(PATH_SEPARATOR, get_include_path()));
-    #$include_dirs = array(dirname(__FILE__). '/../../');
     foreach ($include_dirs as $include_dir) {
       $api_dir = implode(DIRECTORY_SEPARATOR,
         [$include_dir, 'api', 'v' . $version]);
-      if (!is_dir($api_dir)) {
+      // While it seems pointless to have a folder that's outside open_basedir
+      // listed in include_path and that seems more like a configuration issue,
+      // not everyone has control over the hosting provider's include_path and
+      // this does happen out in the wild, so use our wrapper to avoid flooding
+      // logs.
+      if (!\CRM_Utils_File::isDir($api_dir)) {
         continue;
       }
       $iterator = new \DirectoryIterator($api_dir);
@@ -281,7 +285,8 @@ class MagicFunctionProvider implements EventSubscriberInterface, ProviderInterfa
       foreach ([$camelName, 'Generic'] as $name) {
         $action_dir = implode(DIRECTORY_SEPARATOR,
           [$include_dir, 'api', "v${version}", $name]);
-        if (!is_dir($action_dir)) {
+        // see note above in getEntityNames about open_basedir
+        if (!\CRM_Utils_File::isDir($action_dir)) {
           continue;
         }
 


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/2927

Followup to #22107 and its inspirations

Before
----------------------------------------
Lots of log entries about open_basedir when e.g. visiting api explorer

After
----------------------------------------
Less

Technical Details
----------------------------------------


Comments
----------------------------------------
@agileware-justin @herbdool These are the only ones that seem to try to access directories that would be outside the civi tree or extension folders or places where files are kept. Such places would need to be inside open_basedir for civi to function in the first place, so leaving them at is_dir seems better.
